### PR TITLE
remove checks and abouts

### DIFF
--- a/Packages/RezkCompletion/limits/products.v
+++ b/Packages/RezkCompletion/limits/products.v
@@ -144,14 +144,11 @@ Section test.
 
 Variable C : precategory.
 Variable H : Products C.
-
-About ProductObject.
 Arguments ProductObject [C] c d {_}.
-About ProductObject.
 Local Notation "c 'x' d" := (ProductObject  c d )(at level 5).
-
+(*
 Check (fun c d : C => c x d).
-
+*)
 End test.
 
 

--- a/Packages/RezkCompletion/limits/terminal.v
+++ b/Packages/RezkCompletion/limits/terminal.v
@@ -72,25 +72,16 @@ End Terminal_Unique.
 End def_terminal.
 
 
+(*
 Section test.
 Variable C : precategory.
 Variable T : Terminal C.
 
-About TerminalObject.
-
 Arguments TerminalObject [C]{_}.
-
-About TerminalObject.
-
-Check (fun a => a --> T).
-
-About TerminalArrow.
-
 Arguments TerminalArrow [C]{T} b.
 
-Check (fun a : C => TerminalArrow a).
-
 End test.
+*)
 
 Arguments TerminalObject [C]{_}.
 Arguments TerminalArrow [C]{T} b.


### PR DESCRIPTION
removing Check and About vernaculars to make compilation silent
leaving the stuff in a comment to memorize how to set arguments 
