### PR TITLE
added some comments about the two definitions of iso in a precategory

### DIFF
--- a/UniMath/RezkCompletion/precategories.v
+++ b/UniMath/RezkCompletion/precategories.v
@@ -15,12 +15,21 @@ Contents :  Definition of
 	        Categories (aka saturated precategories)         	
                 Setcategories
                 
-                Isomorphisms
+                Isomorphisms I: [iso]
+                  Definition: [isiso f := isweq (precomp_with f)]
                   various lemmas:
                     uniqueness of inverse, composition etc.
                     stability under composition
+                  Analogue to [gradth]: [is_iso_qinv]
+
+                Isomorphisms II: [z_iso]
+                  Definition: [is_z_iso f := Σ g, ...]
+                  Relationship between [z_iso] and [iso]
                 
                 Categories have groupoid as objects
+
+                Many lemmas about [idtoiso], [isotoid],
+                   interplay with composition, transport etc.
                 	
            
 ************************************************************)


### PR DESCRIPTION
Mention both "iso" and the more intuitive "z_iso" in header of precategories.v

Changes only concern comments, not actual code