### PR TITLE
Update coq 8.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ sub/coq/config/coq_config.ml: sub/coq/configure sub/coq/configure.ml
 	cd sub/coq && ./configure -coqide no -opt -no-native-compiler -with-doc no -annotate -debug -local
 # instead of "coqlight" below, we could use simply "theories/Init/Prelude.vo"
 sub/coq/bin/coq_makefile sub/coq/bin/coqc: sub/coq/config/coq_config.ml
-	make -C sub/coq KEEP_ML4_PREPROCESSED=true VERBOSE=true READABLE_ML4=yes coqlight
+	$(MAKE) -C sub/coq KEEP_ML4_PREPROCESSED=true VERBOSE=true READABLE_ML4=yes coqlight
 build-coq: sub/coq/bin/coqc
 endif
 


### PR DESCRIPTION
Here we update to the latest coq on the 8.5 branch, after a bug we encountered
(involving Print Assumptions) was fixed for us.