### PR TITLE
setup travis for parallel builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language:       ocaml
 before_install: sudo apt-get update -qq
 install:        sudo apt-get install -y ocaml ocaml-nox ocaml-native-compilers camlp4-extra time libgtk2.0 libgtksourceview2.0
+env:
+  - PACKAGE=Foundations
+  - PACKAGE=CategoryTheory
+  - PACKAGE=Ktheory
+  - PACKAGE=Dedekind
+  - PACKAGE=SubstitutionSystems
+  - PACKAGE=Tactics
 script:
   - time make BUILD_COQIDE=yes build-coq
-  - time make TIMECMD=time all
-  - time make install
-after_script:
-  - test -f UniMath/Ktheory/Circle.vo
-  - test -f sub/coq/user-contrib/UniMath/Ktheory/Circle.vo
+  - time make TIMECMD=time $PACKAGE
+


### PR DESCRIPTION
Every UniMath package (plus dependencies) built by Travis in a separate machine.

Pro: 
* faster build time
* less likely to run over the allowed 50 min

Con:
* cannot check "install" target any more