### PR TITLE
Update coq v8.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = sub/lablgtk
 	url = http://forge.ocamlcore.org/anonscm/git/lablgtk/lablgtk.git
 	branch = master
+[submodule "sub/coq-tools"]
+	path = sub/coq-tools
+	url = https://github.com/JasonGross/coq-tools

--- a/Makefile
+++ b/Makefile
@@ -135,12 +135,10 @@ doc: $(GLOBFILES) $(VFILES)
 	sed -i'.bk' -f $(ENHANCEDDOCSOURCE)/proofs-toggle.sed $(ENHANCEDDOCTARGET)/*html
 
 # Jason Gross' coq-tools bug isolator:
-# Override this on the command line; this is just an example:
-BUGGY_FILE := Foundations/Basics/PartA.v
 # The isolated bug will appear in this file, in the UniMath directory:
 ISOLATED_BUG_FILE := isolated-bug.v
-# To use it, run this command:
-#     make isolate-bug
+# To use it, run something like this command:
+#     make isolate-bug BUGGY_FILE=Foundations/Basics/PartB.v
 sub/coq-tools/find-bug.py:
 	git submodule update --init sub/coq-tools
 help-find-bug:

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,28 @@ doc: $(GLOBFILES) $(VFILES)
 	--with-header $(ENHANCEDDOCSOURCE)/header.html $(VFILES)
 	sed -i'.bk' -f $(ENHANCEDDOCSOURCE)/proofs-toggle.sed $(ENHANCEDDOCTARGET)/*html
 
+# Jason Gross' coq-tools bug isolator:
+# Override this on the command line; this is just an example:
+BUGGY_FILE := Foundations/Basics/PartA.v
+# The isolated bug will appear in this file, in the UniMath directory:
+ISOLATED_BUG_FILE := isolated-bug.v
+# To use it, run this command:
+#     make isolate-bug
+sub/coq-tools/find-bug.py:
+	git submodule update --init sub/coq-tools
+help-find-bug:
+	sub/coq-tools/find-bug.py --help
+isolate-bug: sub/coq-tools/find-bug.py
+	cd UniMath && \
+	rm -f $(ISOLATED_BUG_FILE) && \
+	yes | ../sub/coq-tools/find-bug.py --coqbin ../sub/coq/bin -R . UniMath \
+		--arg " -indices-matter" \
+		--arg " -type-in-type" \
+		$(BUGGY_FILE) $(ISOLATED_BUG_FILE)
+	@ echo "==="
+	@ echo "=== the isolated bug has been deposited in the file UniMath/$(ISOLATED_BUG_FILE)"
+	@ echo "==="
+
 world: all html doc pdffiles
 
 texfiles : $(VFILES:%.v=$(LATEXTARGET)/%.tex)

--- a/UniMath/CategoryTheory/category_hset.v
+++ b/UniMath/CategoryTheory/category_hset.v
@@ -373,7 +373,7 @@ End from_colim.
 
 Definition colimCoconeHSET : cocone D colimHSET.
 Proof.
-refine (mk_cocone _ _).
+unshelve refine (mk_cocone _ _).
 - now apply injections.
 - abstract (intros u v e;
             apply funextfun; intros Fi; simpl;
@@ -445,9 +445,9 @@ Defined.
 
 Lemma LimConeHSET : LimCone D.
 Proof.
-  refine (mk_LimCone _ _ _ _ ).
+  unshelve refine (mk_LimCone _ _ _ _ ).
   - apply limset.
-  - refine (mk_cone _ _ ).
+  - unshelve refine (mk_cone _ _ ).
     + intro u. simpl.
       intro f.
       exact (pr1 f u).
@@ -456,12 +456,12 @@ Proof.
       intro f; simpl.
       apply (pr2 f).
   - intros X CC.
-    refine (tpair _ _ _ ).
-    + refine (tpair _ _ _ ).
+    unshelve refine (tpair _ _ _ ).
+    + unshelve refine (tpair _ _ _ ).
       * simpl.
         intro x.
         {
-          refine (tpair _ _ _ ).
+          unshelve refine (tpair _ _ _ ).
           - intro u.
             apply (coconeIn CC u x). (* TODO : hide implementation of limits *)
           - intros u v e. simpl.

--- a/UniMath/CategoryTheory/colimits/chains.v
+++ b/UniMath/CategoryTheory/colimits/chains.v
@@ -85,7 +85,7 @@ Defined.
 Definition shift_cocone {D : diagram nat_graph C}
   {x : C} (cx : cocone D x) : cocone (shift D) x.
 Proof.
-refine (tpair _ _ _).
+unshelve refine (tpair _ _ _).
 - now intro n; apply (coconeIn cx).
 - abstract (now intros m n Hmn; destruct Hmn; apply (coconeInCommutes cx)).
 Defined.
@@ -94,7 +94,7 @@ Defined.
 Definition unshift_cocone {D : diagram nat_graph C}
   {x : C} (cx : cocone (shift D) x) : cocone D x.
 Proof.
-refine (mk_cocone _ _).
+unshelve refine (mk_cocone _ _).
 - intro n.
   now apply (@dmor _ _ _ n _ (idpath _) ;; coconeIn cx n).
 - abstract (now intros m n Hmn; destruct Hmn; simpl;
@@ -123,7 +123,7 @@ Definition shift_colim (D : diagram nat_graph C) (CC : ColimCocone D) :
 Proof.
 apply (mk_ColimCocone _ (colim CC) (shift_cocone (colimCocone CC))).
 intros x fx.
-refine (tpair _ _ _).
+unshelve refine (tpair _ _ _).
 + exists (colimArrow CC x (unshift_cocone fx)).
   abstract (intro n; simpl;
             eapply pathscomp0;
@@ -144,7 +144,7 @@ Definition unshift_colim (D : diagram nat_graph C) (CC : ColimCocone (shift D)) 
 Proof.
 apply (mk_ColimCocone _ (colim CC) (unshift_cocone (colimCocone CC))).
 intros x fx.
-refine (tpair _ _ _).
+unshelve refine (tpair _ _ _).
 + exists (colimArrow CC x (shift_cocone fx)).
   abstract (simpl; intro n;
             rewrite <- assoc;
@@ -194,7 +194,7 @@ Defined.
 (* Definition shift_Fdiagram (x : C) : cocone Fdiagram x -> cocone (shift C Fdiagram) (F x). *)
 (* Proof. *)
 (* intro H. *)
-(* refine (mk_cocone _ _). *)
+(* unshelve refine (mk_cocone _ _). *)
 (* - simpl. *)
 (*   intro n. *)
 (*   destruct n. *)
@@ -220,7 +220,7 @@ Local Notation LF := (colim (shift_colim C hsC Fdiagram CC)).
 
 Definition Fcocone : cocone Fdiagram (F L).
 Proof.
-refine (mk_cocone _ _).
+unshelve refine (mk_cocone _ _).
 - intro n.
   destruct n; simpl.
   + exact (s ;; # F (colimIn CC 0)).
@@ -316,7 +316,7 @@ Qed.
 Local Definition ad : C⟦L,A⟧.
 Proof.
 apply colimArrow.
-refine (mk_cocone _ _).
+unshelve refine (mk_cocone _ _).
 - apply cocone_over_alg.
 - apply isCoconeOverAlg.
 Defined.
@@ -358,7 +358,7 @@ End algebra.
 
 Lemma colimAlgIsInitial : isInitial (precategory_FunctorAlg F hsC) colimAlg.
 Proof.
-refine (mk_isInitial _ _ ).
+unshelve refine (mk_isInitial _ _ ).
 intros Aa.
 exists (adaggerMor Aa); simpl; intro Fa.
 apply (algebra_mor_eq _ hsC); simpl.
@@ -446,8 +446,8 @@ Proof.
 (* set (X3 := Fcocone _ _ _ _). *)
 (* apply (isColim_is_iso _ X1). *)
 (* intros a ca. *)
-(* refine (tpair _ _ _). *)
-(* refine (tpair _ _ _). *)
+(* unshelve refine (tpair _ _ _). *)
+(* unshelve refine (tpair _ _ _). *)
 (* apply colimArrow. *)
 (* apply ca. *)
 (* intros v. *)
@@ -515,7 +515,7 @@ Defined.
 Lemma listFunctor_Initial :
   Initial (precategory_FunctorAlg listFunctor has_homsets_HSET).
 Proof.
-refine (colimAlgInitial _ _ _ _ _ _).
+unshelve refine (colimAlgInitial _ _ _ _ _ _).
 - apply InitialHSET.
 - apply ColimCoconeHSET.
 - apply listFunctor_chain_cocontinuous.

--- a/UniMath/CategoryTheory/colimits/colimits.v
+++ b/UniMath/CategoryTheory/colimits/colimits.v
@@ -183,7 +183,7 @@ Definition colimOfArrows {g : graph} {d1 d2 : diagram g C}
   (fNat : ∀ u v (e : edge u v), dmor d1 e ;; f v = f u ;; dmor d2 e) :
   C⟦colim CC1,colim CC2⟧.
 Proof.
-apply colimArrow; refine (mk_cocone _ _).
+apply colimArrow; unshelve refine (mk_cocone _ _).
 - now intro u; apply (f u ;; colimIn CC2 u).
 - abstract (intros u v e; simpl;
             now rewrite assoc, fNat, <- assoc, colimInCommutes).
@@ -237,7 +237,7 @@ Lemma colim_endo_is_identity {g : graph} (D : diagram g C)
   (H : ∀ u, colimIn CC u ;; k = colimIn CC u) :
   identity _ = k.
 Proof.
-refine (uniqueExists _ _ (colimUnivProp CC _ _) _ _ _ _).
+unshelve refine (uniqueExists _ _ (colimUnivProp CC _ _) _ _ _ _).
 - now apply (colimCocone CC).
 - intros v; simpl.
   now apply id_right.
@@ -272,7 +272,7 @@ Lemma isColim_weq {g : graph} (D : diagram g C) (c : C) (cc : cocone D c) :
 Proof.
 split.
 - intros H d.
-  refine (gradth _ _ _ _).
+  unshelve refine (gradth _ _ _ _).
   + intros k.
     exact (colimArrow (mk_ColimCocone D c cc H) _ k).
   + abstract (intro k; simpl;
@@ -283,7 +283,7 @@ split.
                 | destruct k as [k Hk]; simpl; apply funextsec; intro u;
                   now apply (colimArrowCommutes (mk_ColimCocone D c cc H))]).
 - intros H d cd.
-  refine (tpair _ _ _).
+  unshelve refine (tpair _ _ _).
   + exists (invmap (weqpair _ (H d)) cd).
     abstract (intro u; now apply isColim_weq_subproof2).
   + abstract (intro t; apply subtypeEquality;
@@ -302,7 +302,7 @@ Proof.
 intro H.
 apply is_iso_from_is_z_iso.
 set (CD := mk_ColimCocone D d cd H).
-refine (tpair _ _ _).
+unshelve refine (tpair _ _ _).
 - apply (colimArrow CD _ (colimCocone CC)).
 - split.
   + apply pathsinv0, colim_endo_is_identity; simpl; intro u.
@@ -341,7 +341,7 @@ Definition ColimFunctor_ob (a : A) : C := colim (HCg a).
 Definition ColimFunctor_mor (a a' : A) (f : A⟦a, a'⟧) :
   C⟦ColimFunctor_ob a,ColimFunctor_ob a'⟧.
 Proof.
-refine (colimOfArrows _ _ _ _).
+unshelve refine (colimOfArrows _ _ _ _).
 - now intro u; apply (# (pr1 (dob D u)) f).
 - abstract (now intros u v e; simpl; apply pathsinv0, (nat_trans_ax (dmor D e))).
 Defined.
@@ -368,7 +368,7 @@ Definition ColimFunctor : functor A C := tpair _ _ is_functor_ColimFunctor_data.
 
 Definition colim_nat_trans_in_data v : [A, C, hsC] ⟦ dob D v, ColimFunctor ⟧.
 Proof.
-refine (tpair _ _ _).
+unshelve refine (tpair _ _ _).
 - intro a; exact (colimIn (HCg a) v).
 - abstract (intros a a' f;
             now apply pathsinv0, (colimOfArrowsIn _ _ (HCg a) (HCg a'))).
@@ -377,7 +377,7 @@ Defined.
 Definition cocone_pointwise (F : [A,C,hsC]) (cc : cocone D F) a :
   cocone (diagram_pointwise a) (pr1 F a).
 Proof.
-refine (mk_cocone _ _).
+unshelve refine (mk_cocone _ _).
 - now intro v; apply (pr1 (coconeIn cc v) a).
 - abstract (intros u v e;
     now apply (nat_trans_eq_pointwise  (coconeInCommutes cc u v e))).
@@ -387,8 +387,8 @@ Lemma ColimFunctor_unique (F : [A, C, hsC]) (cc : cocone D F) :
   iscontr (Σ x : [A, C, hsC] ⟦ ColimFunctor, F ⟧,
             ∀ v : vertex g, colim_nat_trans_in_data v ;; x = coconeIn cc v).
 Proof.
-refine (tpair _ _ _).
-- refine (tpair _ _ _).
+unshelve refine (tpair _ _ _).
+- unshelve refine (tpair _ _ _).
   + apply (tpair _ (fun a => colimArrow (HCg a) _ (cocone_pointwise F cc a))).
     abstract (intros a a' f; simpl;
               eapply pathscomp0;
@@ -411,9 +411,9 @@ Defined.
 
 Lemma ColimFunctorCocone : ColimCocone D.
 Proof.
-refine (mk_ColimCocone _ _ _ _).
+unshelve refine (mk_ColimCocone _ _ _ _).
 - exact ColimFunctor.
-- refine (mk_cocone _ _).
+- unshelve refine (mk_cocone _ _).
   + now apply colim_nat_trans_in_data.
   + abstract (now intros u v e; apply (nat_trans_eq hsC);
                   intro a; apply (colimInCommutes (HCg a))).

--- a/UniMath/CategoryTheory/limits/coproducts.v
+++ b/UniMath/CategoryTheory/limits/coproducts.v
@@ -109,7 +109,7 @@ Definition mk_CoproductCocone (a b : C) :
    isCoproductCocone _ _ _ f g →  CoproductCocone a b.
 Proof.
   intros.
-  refine (tpair _ _ _ ).
+  unshelve refine (tpair _ _ _ ).
   - exists c.
     exists f.
     exact g.

--- a/UniMath/CategoryTheory/limits/coproducts_as_colimits.v
+++ b/UniMath/CategoryTheory/limits/coproducts_as_colimits.v
@@ -29,7 +29,7 @@ Defined.
 
 Definition CopCocone {C : precategory} {a b : C} {c : C} (ac : a ⇒ c) (bc : b ⇒ c) :
    cocone (coproduct_diagram a b) c.
-refine (tpair _ _ _ ).
+unshelve refine (tpair _ _ _ ).
 + intro v.
   induction v; simpl.
   - exact ac.
@@ -54,7 +54,7 @@ Definition mk_isCoproductCocone (hsC : has_homsets C)(a b co : C) (ia : a ⇒ co
 Proof.
   intros H c cc.
   set (H':= H c (coconeIn cc true) (coconeIn cc false)).
-  refine (tpair _ _ _ ).
+  unshelve refine (tpair _ _ _ ).
   - exists (pr1 (pr1 H')).
     set (T := pr2 (pr1 H')). simpl in T.
     abstract (intro u; induction u;
@@ -73,7 +73,7 @@ Definition mk_CoproductCocone (a b : C) :
    isCoproductCocone _ _ _ f g →  CoproductCocone a b.
 Proof.
   intros.
-  refine (tpair _ _ _ ).
+  unshelve refine (tpair _ _ _ ).
   - exists c.
     apply (CopCocone f g).
   - apply X.
@@ -93,7 +93,7 @@ Definition CoproductArrow {a b : C} (CC : CoproductCocone a b) {c : C} (f : a �
       CoproductObject CC ⇒ c.
 Proof.
   apply (colimArrow CC).
-  refine (mk_cocone _ _ ).
+  unshelve refine (mk_cocone _ _ ).
   + intro v. induction v.
     - apply f.
     - apply g.

--- a/UniMath/CategoryTheory/limits/initial_as_colimit.v
+++ b/UniMath/CategoryTheory/limits/initial_as_colimit.v
@@ -25,7 +25,7 @@ Defined.
 
 Definition initCocone (c : C) : cocone initDiagram c.
 Proof.
-refine (mk_cocone _ _); intro v; induction v.
+unshelve refine (mk_cocone _ _); intro v; induction v.
 Defined.
 
 Definition isInitial (a : C) :=
@@ -36,7 +36,7 @@ Definition mk_isInitial (a : C) (H : ∀ (b : C), iscontr (a ⇒ b)) :
   isInitial a.
 Proof.
 intros b cb.
-refine (tpair _ _ _).
+unshelve refine (tpair _ _ _).
 - exists (pr1 (H b)); intro v; induction v.
 - intro t.
   apply subtypeEquality; simpl;
@@ -53,7 +53,7 @@ refine (mk_ColimCocone _ a (initCocone a) _).
 apply mk_isInitial.
 intro b.
 set (x := H b (initCocone b)).
-refine (tpair _ _ _).
+unshelve refine (tpair _ _ _).
 - apply (pr1 x).
 - simpl; intro f; apply path_to_ctr; intro v; induction v.
 Defined.

--- a/UniMath/CategoryTheory/limits/limits.v
+++ b/UniMath/CategoryTheory/limits/limits.v
@@ -79,7 +79,7 @@ Definition LimCone {g : graph} (d : diagram g C^op) : UU :=
 Definition mk_LimCone {g : graph} (d : diagram g C^op)
   (c : C) (cc : cone d c) (isCC : isLimCone d c cc) : LimCone d.
 Proof.
-refine (mk_ColimCocone _ _ _ _  ).
+unshelve refine (mk_ColimCocone _ _ _ _  ).
 - apply c.
 - apply cc.
 - apply isCC.
@@ -162,7 +162,7 @@ Definition limOfArrows {g : graph} {d1 d2 : diagram g C^op}
                                 (dmor d1 e : C⟦dob d1 v, dob d1 u⟧);; f u) :
   C⟦lim CC1 , lim CC2⟧.
 Proof.
-  refine (colimOfArrows CC2 CC1 _ _ ).
+  unshelve refine (colimOfArrows CC2 CC1 _ _ ).
   - apply f.
   - apply fNat.
 Defined.
@@ -220,7 +220,7 @@ Lemma lim_endo_is_identity {g : graph} (D : diagram g C^op)
   (H : ∀ u, k ;; limOut CC u = limOut CC u) :
   identity _ = k.
 Proof.
-refine (uniqueExists _ _ (limUnivProp CC _ _) _ _ _ _).
+unshelve refine (uniqueExists _ _ (limUnivProp CC _ _) _ _ _ _).
 - now apply (limCone CC).
 - intros v; simpl.
   unfold compose. simpl.
@@ -296,7 +296,7 @@ Definition get_diagram (A C : precategory) (hsC : has_homsets C)
 Proof.
 apply (tpair _ (fun u => from_opp_to_opp_opp _ _ _ (pr1 D u))).
 intros u v e; simpl.
-refine (tpair _ _ _); simpl.
+unshelve refine (tpair _ _ _); simpl.
   + apply (pr2 D _ _ e).
   + abstract (intros a b f; apply pathsinv0, (pr2 (pr2 D u v e) b a f)).
 Defined.
@@ -307,7 +307,7 @@ Definition get_cocone  (A C : precategory) (hsC : has_homsets C)
 Proof.
 destruct ccF. (* If I remove this destruct the Qed for LimsFunctorCategory
                  takes twice as long *)
-refine (mk_cocone _ _).
+unshelve refine (mk_cocone _ _).
 - intro u; apply (tpair _ (pr1 (t u))).
   abstract (intros a b f; apply pathsinv0, (pr2 (t u) b a f)).
 - abstract (intros u v e; apply (nat_trans_eq (has_homsets_opp hsC));
@@ -329,10 +329,10 @@ destruct HColim as [pr1x pr2x].
 destruct pr1x as [pr1pr1x pr2pr1x].
 destruct pr2pr1x as [pr1pr2pr1x pr2pr2pr1x].
 simpl in *.
-refine (mk_ColimCocone _ (from_opp_opp_to_opp _ _ _ pr1pr1x) _ _).
-- refine (mk_cocone _ _).
+unshelve refine (mk_ColimCocone _ (from_opp_opp_to_opp _ _ _ pr1pr1x) _ _).
+- unshelve refine (mk_cocone _ _).
   + simpl; intros.
-    refine (tpair _ _ _).
+    unshelve refine (tpair _ _ _).
     * intro a; apply (pr1pr2pr1x v a).
     * abstract (intros a b f; apply pathsinv0, (nat_trans_ax (pr1pr2pr1x v) (*b a f*))).
   + abstract (intros u v e; apply (nat_trans_eq hsC); simpl; intro a;
@@ -342,8 +342,8 @@ refine (mk_ColimCocone _ (from_opp_opp_to_opp _ _ _ pr1pr1x) _ _).
   destruct H as [H1 H2].
   destruct H1 as [α Hα].
   simpl in *.
-  refine (tpair _ _ _).
-  + refine (tpair _ _ _).
+  unshelve refine (tpair _ _ _).
+  + unshelve refine (tpair _ _ _).
     * exists α.
       abstract (intros a b f; simpl; now apply pathsinv0, (nat_trans_ax α b a f)).
     * abstract (intro u; apply (nat_trans_eq hsC); intro a;
@@ -352,7 +352,7 @@ refine (mk_ColimCocone _ (from_opp_opp_to_opp _ _ _ pr1pr1x) _ _).
     * abstract (intro β; repeat (apply impred; intro);
         now apply (has_homsets_opp (functor_category_has_homsets A C hsC))).
     * match goal with |[ H2 : ∀ _ : ?TT ,  _ = _ ,,_   |- _ ] =>
-                       refine (let T : TT := _ in _ ) end.
+                       unshelve refine (let T : TT := _ in _ ) end.
       (*
       refine (let T : Σ x : nat_trans pr1pr1x (functor_opp F),
                          ∀ v, nat_trans_comp (functor_opp (pr1 D v)) _ _
@@ -360,7 +360,7 @@ refine (mk_ColimCocone _ (from_opp_opp_to_opp _ _ _ pr1pr1x) _ _).
                                coconeIn (get_cocone A C hsC g D F ccF) v :=
                   _ in _).
       *)
-      { refine (tpair _ (tpair _ (pr1 f) _) _); simpl.
+      { unshelve refine (tpair _ (tpair _ (pr1 f) _) _); simpl.
         - abstract (intros x y fxy; apply pathsinv0, (pr2 f y x fxy)).
         - abstract (intro u; apply (nat_trans_eq (has_homsets_opp hsC)); intro x;
             destruct ccF; apply (toforallpaths _ _ _ (maponpaths pr1 (Hf u)) x)).

--- a/UniMath/CategoryTheory/limits/products.v
+++ b/UniMath/CategoryTheory/limits/products.v
@@ -75,11 +75,11 @@ Definition mk_ProductCone (a b : C) :
    isProductCone _ _ _ f g -> ProductCone a b.
 Proof.
   intros.
-  refine (tpair _ _ _ ).
+  unshelve refine (tpair _ _ _ ).
   - exists c.
     exists f.
     exact g.
-  - apply X.
+  - exact X.
 Defined.
 
 Definition mk_isProductCone (hsC : has_homsets C) (a b p : C)

--- a/UniMath/CategoryTheory/limits/products_as_colimit.v
+++ b/UniMath/CategoryTheory/limits/products_as_colimit.v
@@ -31,7 +31,7 @@ Defined.
 Definition ProdCone {a b c : C} (ca : C⟦c,a⟧) (cb : C⟦c,b⟧) :
   cone (product_diagram a b) c.
 Proof.
-refine (tpair _ _ _); simpl.
+unshelve refine (tpair _ _ _); simpl.
 - intro v; induction v.
   + exact ca.
   + exact cb.
@@ -50,7 +50,7 @@ Proof.
 intros H c cc.
 simpl in *.
 set (H' := H c (coneOut cc true) (coneOut cc false)).
-refine (tpair _ _ _).
+unshelve refine (tpair _ _ _).
 - exists (pr1 (pr1 H')).
   set (T := pr2 (pr1 H')); simpl in T.
   abstract (intro u; induction u; simpl; [exact (pr1 T)|exact (pr2 T)]).
@@ -66,7 +66,7 @@ Definition mk_ProductCone (a b : C) :
    isProductCone _ _ _ f g -> ProductCone a b.
 Proof.
   intros.
-  refine (tpair _ _ _ ).
+  unshelve refine (tpair _ _ _ ).
   - exists c.
     apply (ProdCone f g).
   - apply X.
@@ -91,7 +91,7 @@ Definition ProductArrow {a b : C} (P : ProductCone a b) {c : C}
   (f : C⟦c,a⟧) (g : C⟦c,b⟧) : C⟦c,ProductObject P⟧.
 Proof.
 apply (limArrow P).
-refine (mk_cone _ _).
+unshelve refine (mk_cone _ _).
 - intro v; induction v; [ apply f | apply g ].
 - intros ? ? e; induction e. (* <- should not be opaque! otherwise ProductPr1Commutes doesn't work *)
 Defined.

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -103,8 +103,8 @@ Definition mk_Pullback {a b c : C} (f : C⟦b, a⟧)(g : C⟦c, a⟧)
     (ispb : isPullback f g p1 p2 H)
   : Pullback f g.
 Proof.
-  refine (tpair _ _ _ ).
-  - refine (tpair _ _ _ ).
+  unshelve refine (tpair _ _ _ ).
+  - unshelve refine (tpair _ _ _ ).
     + apply d.
     + exists p1.
       exact p2.

--- a/UniMath/CategoryTheory/limits/pullbacks_as_colimits.v
+++ b/UniMath/CategoryTheory/limits/pullbacks_as_colimits.v
@@ -46,7 +46,7 @@ Definition PullbCone {a b c : C} (f : C ⟦b,a⟧) (g : C⟦c,a⟧)
            (H : f' ;; f = g';; g)
   : cone (pullback_diagram f g) d.
 Proof.
-  refine (mk_cone _ _  ).
+  unshelve refine (mk_cone _ _  ).
   - intro v; induction v; simpl; try assumption.
     apply (f' ;; f).
   - intros u v e;
@@ -72,14 +72,14 @@ Definition mk_isPullback {a b c d : C} (f : C ⟦b, a⟧) (g : C ⟦c, a⟧)
 Proof.
   intros H' x cx; simpl in *.
   set (H1 := H' x (coneOut cx One) (coneOut cx Three) ).
-  refine (let p : coneOut cx One ;; f = coneOut cx Three ;; g := _ in _ ).
+  unshelve refine (let p : coneOut cx One ;; f = coneOut cx Three ;; g := _ in _ ).
   - set (H2 := coneOutCommutes cx Two One tt).
     eapply pathscomp0. apply H2.
     clear H2.
     apply pathsinv0.
     apply (coneOutCommutes cx Two Three tt).
   - set (H2 := H1 p).
-    refine (tpair _ _ _ ).
+    unshelve refine (tpair _ _ _ ).
     + exists (pr1 (pr1 H2)).
       intro v; induction v; simpl.
       * apply (pr1 (pr2 (pr1 H2))).
@@ -123,10 +123,10 @@ Definition mk_Pullback {a b c : C} (f : C⟦b, a⟧)(g : C⟦c, a⟧)
     (ispb : isPullback f g p1 p2 H)
   : Pullback f g.
 Proof.
-  refine (tpair _ _ _ ).
-  - refine (tpair _ _ _ ).
+  unshelve refine (tpair _ _ _ ).
+  - unshelve refine (tpair _ _ _ ).
     + apply d.
-    + refine (PullbCone _ _ _ _ _ _ ); assumption.
+    + unshelve refine (PullbCone _ _ _ _ _ _ ); assumption.
   - apply ispb.
 Defined.
 
@@ -169,8 +169,8 @@ Definition PullbackArrow {a b c : C} {f : C⟦b, a⟧} {g : C⟦c, a⟧}
            (Pb : Pullback f g) e (h : C⟦e, b⟧) (k : C⟦e, c⟧)(H : h ;; f = k ;; g)
   : C⟦e, lim Pb⟧.
 Proof.
-  refine (limArrow _ _ _ ).
-  refine (mk_cone _ _ ).
+  unshelve refine (limArrow _ _ _ ).
+  unshelve refine (mk_cone _ _ ).
   - intro v; induction v; simpl; try assumption.
     apply (h ;; f).
   - intros u v edg; induction u; induction v; try induction edg; simpl.
@@ -219,8 +219,8 @@ Definition isPullback_Pullback {a b c : C} {f : C⟦b, a⟧}{g : C⟦c, a⟧}
 Proof.
   apply mk_isPullback.
   intros e h k HK.
-  refine (tpair _ _ _ ).
-  - refine (tpair _ _ _ ).
+  unshelve refine (tpair _ _ _ ).
+  - unshelve refine (tpair _ _ _ ).
     + apply (PullbackArrow P _ h k HK).
     + split.
       * apply PullbackArrow_PullbackPr1.

--- a/UniMath/CategoryTheory/limits/terminal_as_colimit.v
+++ b/UniMath/CategoryTheory/limits/terminal_as_colimit.v
@@ -30,7 +30,7 @@ Defined.
 
 Definition termCone (c : C) : cone termDiagram c.
 Proof.
-refine (mk_cocone _ _); intro v; induction v.
+unshelve refine (mk_cocone _ _); intro v; induction v.
 Defined.
 
 Definition isTerminal (a : C) :=
@@ -40,7 +40,7 @@ Definition mk_isTerminal (b : C) (H : ∀ (a : C), iscontr (a ⇒ b)) :
   isTerminal b.
 Proof.
 intros a ca.
-refine (tpair _ _ _).
+unshelve refine (tpair _ _ _).
 - exists (pr1 (H a)); intro v; induction v.
 - intro t.
   apply subtypeEquality; simpl;
@@ -57,7 +57,7 @@ refine (mk_LimCone _ b (termCone b) _).
 apply mk_isTerminal.
 intro a.
 set (x := H a (termCone a)).
-refine (tpair _ _ _).
+unshelve refine (tpair _ _ _).
 - apply (pr1 x).
 - simpl; intro f; apply path_to_ctr; intro v; induction v.
 Defined.

--- a/UniMath/CategoryTheory/opp_precat.v
+++ b/UniMath/CategoryTheory/opp_precat.v
@@ -90,7 +90,7 @@ Definition from_opp_to_opp_opp (A C : precategory) (hsC : has_homsets C) :
 Proof.
 apply (tpair _ functor_opp).
 simpl; intros F G α.
-refine (tpair _ _ _).
+unshelve refine (tpair _ _ _).
 + simpl; intro a; apply α.
 + abstract (intros a b f; simpl in *;
             apply pathsinv0, (nat_trans_ax α)).
@@ -111,9 +111,9 @@ Definition functor_from_opp_to_opp_opp (A C : precategory) (hsC : has_homsets C)
 Definition from_opp_opp_to_opp (A C : precategory) (hsC : has_homsets C) :
   functor_data [A^op, C^op, has_homsets_opp hsC] [A, C, hsC]^op.
 Proof.
-refine (tpair _ _ _); simpl.
+unshelve refine (tpair _ _ _); simpl.
 - intro F.
-  refine (tpair _ _ _).
+  unshelve refine (tpair _ _ _).
   + exists F.
     apply (fun a b f => # F f).
   + abstract (split; [ intro a; apply (functor_id F)

--- a/UniMath/CategoryTheory/yoneda.v
+++ b/UniMath/CategoryTheory/yoneda.v
@@ -251,7 +251,7 @@ Lemma isweq_yoneda_map_1 (C : precategory) (hs: has_homsets C) (c : C)
      (yoneda_map_1 C hs c F).
 Proof.
   set (T:=yoneda_map_2 C hs c F). simpl in T.
-  refine (gradth _ _ _ _ ).
+  unshelve refine (gradth _ _ _ _ ).
   - apply T.
   - apply yoneda_map_1_2.
   - apply yoneda_map_2_1.
@@ -300,7 +300,7 @@ Variable c : C.
 Definition yoneda_functor_precomp' : nat_trans (yoneda_objects C hsC c)
       (functor_composite _ _ _ (functor_opp F) (yoneda_objects D hsD (F c))).
 Proof.
-  refine (tpair _ _ _ ).
+  unshelve refine (tpair _ _ _ ).
   - intros d f ; simpl.
     apply (#F f).
   - abstract (intros d d' f ;
@@ -338,7 +338,7 @@ Definition yoneda_functor_precomp_nat_trans :
       (yoneda C hsC)
       (functor_composite _ _ _ A B).
 Proof.
-  refine (tpair _ _ _ ).
+  unshelve refine (tpair _ _ _ ).
   - intro c; simpl.
     apply yoneda_functor_precomp.
   - abstract (

--- a/UniMath/Foundations/Basics/PartA.v
+++ b/UniMath/Foundations/Basics/PartA.v
@@ -1778,7 +1778,7 @@ split with f . apply ( gradth _ _ egf  efg ) . Defined .
 Definition weqtotal2dirprodcomm {X Y:UU} (P: X × Y -> UU) : (Σ xy : X×Y, P xy) ≃ (Σ xy : Y×X, P (weqdirprodcomm _ _ xy)).
 Proof.
   intros.
-  refine (weqgradth _ _ _ _).
+  unshelve refine (weqgradth _ _ _ _).
   - intros xyp. induction xyp as [xy p]. induction xy as [x y]. exact ((y,,x),,p).
   - intros yxp. induction yxp as [yx p]. induction yx as [y x]. exact ((x,,y),,p).
   - intros xyp. induction xyp as [xy p]. induction xy as [x y]. reflexivity.
@@ -1787,7 +1787,7 @@ Defined.
 
 Definition weqtotal2dirprodassoc  {X Y:UU} (P: X × Y -> UU) : (Σ xy : X×Y, P xy) ≃ (Σ (x:X) (y:Y), P (x,,y)).
   intros.
-  refine (weqgradth _ _ _ _).
+  unshelve refine (weqgradth _ _ _ _).
   - intros xyp. induction xyp as [xy p]. induction xy as [x y]. exact (x,,y,,p).
   - intros xyp. induction xyp as [x yp]. induction yp as [y p]. exact ((x,,y),,p).
   - intros xyp. induction xyp as [xy p]. induction xy as [x y]. reflexivity.
@@ -1797,7 +1797,7 @@ Defined.
 Definition weqtotal2dirprodassoc' {X Y:UU} (P: X × Y -> UU) : (Σ xy : X×Y, P xy) ≃ (Σ (y:Y) (x:X), P (x,,y)).
 Proof.
   intros.
-  refine (weqgradth _ _ _ _).
+  unshelve refine (weqgradth _ _ _ _).
   - intros xyp. induction xyp as [xy p]. induction xy as [x y]. exact (y,,x,,p).
   - intros yxp. induction yxp as [x yp]. induction yp as [y p]. exact ((y,,x),,p).
   - intros xyp. induction xyp as [xy p]. induction xy as [x y]. reflexivity.
@@ -1808,7 +1808,7 @@ Definition weqtotal2comm12 {X} (P Q : X -> UU) :
   (Σ (w : Σ x, P x), Q (pr1 w)) ≃ (Σ (w : Σ x, Q x), P (pr1 w)).
 Proof.
   intros.
-  refine (weqgradth _ _ _ _).
+  unshelve refine (weqgradth _ _ _ _).
   - intros [[x p] q]. exact ((x,,q),,p).
   - intros [[x q] p]. exact ((x,,p),,q).
   - intros [[x p] q]. reflexivity.
@@ -2592,10 +2592,10 @@ Defined.
 
 Definition weqfp {X Y : UU} (w : X ≃ Y) (P:Y->UU) : (Σ x : X, P (w x)) ≃ (Σ y, P y).
 Proof. intros. exists (weqfp_map w P). refine (gradth _ (weqfp_invmap w P) _ _).
-  { intros xp. refine (total2_paths _ _).
+  { intros xp. unshelve refine (total2_paths _ _).
     { simpl. apply homotinvweqweq. }
     simpl. rewrite <- weq_transportf_adjointness. rewrite transport_f_f. rewrite pathsinv0l. reflexivity. }
-  { intros yp. refine (total2_paths _ _).
+  { intros yp. unshelve refine (total2_paths _ _).
     { simpl. apply homotweqinvweq. }
     simpl. rewrite transport_f_f. rewrite pathsinv0l. reflexivity. }
 Defined.
@@ -2747,7 +2747,7 @@ Defined.
 
 Definition hfp_right {X Y Z:UU} (f:X->Z) (g:Y->Z) : hfp f g ≃ Σ y, hfiber f (g y).
 Proof.
-  intros. refine (weqgradth _ _ _ _).
+  intros. unshelve refine (weqgradth _ _ _ _).
   - intros [[x y] e]. exact (y,,x,,!e).
   - intros [x [y e]]. exact ((y,,x),,!e).
   - intros [[x y] e]. apply maponpaths, pathsinv0inv0.
@@ -2756,7 +2756,7 @@ Defined.
 
 Definition hfiber_comm {X Y Z:UU} (f:X->Z) (g:Y->Z) : (Σ x, hfiber g (f x)) ≃ (Σ y, hfiber f (g y)).
 Proof.
-  intros. refine (weqgradth _ _ _ _).
+  intros. unshelve refine (weqgradth _ _ _ _).
   - intros [x [y e]]. exact (y,,x,,!e).
   - intros [y [x e]]. exact (x,,y,,!e).
   - intros [x [y e]]. apply maponpaths, maponpaths, pathsinv0inv0.

--- a/UniMath/Foundations/Basics/PartB.v
+++ b/UniMath/Foundations/Basics/PartB.v
@@ -294,10 +294,10 @@ Proof. intros n X is .  apply ( isofhlevelweqf n ( weqhfibertounit X ) ( is tt )
 
 Definition weqhfiberunit {X Z} (i:X->Z) (z:Z) : (Σ x, hfiber (λ _:unit, z) (i x)) ≃ hfiber i z.
 Proof.
-  intros. refine (weqgradth _ _ _ _).
+  intros. unshelve refine (weqgradth _ _ _ _).
   + intros [x [t e]]. exact (x,,!e).
   + intros [x e]. exact (x,,tt,,!e).
-  + intros [x [t e]]. apply maponpaths. refine (total2_paths2 _ _).
+  + intros [x [t e]]. apply maponpaths. unshelve refine (total2_paths2 _ _).
     * apply isapropunit.
     * simpl. induction e. rewrite pathsinv0inv0. induction t. reflexivity.
   + intros [x e]. apply maponpaths. apply pathsinv0inv0.

--- a/UniMath/Foundations/Basics/PartC.v
+++ b/UniMath/Foundations/Basics/PartC.v
@@ -64,7 +64,7 @@ Proof.
   - exact i.
   - apply isapropneg.
   - exact (λ x n, n x).
-Defined.       
+Defined.
 
 (** ** Isolated points and types with decidable equality. *)
 
@@ -278,7 +278,7 @@ Definition isisolated_ne_to_isisolated {X x neq_x} :
 Proof.
   intros ? ? ? i y. induction (i y) as [eq|ne].
   - exact (ii1 eq).
-  - apply ii2. now refine (negProp_to_neg _).
+  - apply ii2. now unshelve refine (negProp_to_neg _).
 Defined.
 
 Definition isolated ( T : UU ) := Σ t:T, isisolated _ t.
@@ -389,14 +389,14 @@ Proof.
   { induction eq. refine (iscontrweqf (weqii2withneg _ _) _).
     { intros z; induction z as [z e]; induction z as [z neq]; simpl in *.
       contradicts (!e) (negProp_to_neg neq). }
-    { change x with (f (ii2 tt)). refine ((_,,_),,_).
+    { change x with (f (ii2 tt)). unshelve refine ((_,,_),,_).
       { exact tt. }
       { reflexivity. }
       { intro w. induction w as [t e]. unfold f in *; simpl in *. induction t.
         apply maponpaths. apply isaproppathsfromisolated. exact is. }}}
   { refine (iscontrweqf (weqii1withneg _ _) _).
     { intros z; induction z as [z e]; simpl in *. contradicts ne e. }
-    { refine ((_,,_),,_).
+    { unshelve refine ((_,,_),,_).
       { exists y. now apply neg_to_negProp. }
       { simpl. reflexivity. }
       intros z; induction z as [z e]; induction z as [z neq]; induction e; simpl in *.
@@ -507,7 +507,7 @@ Definition weqtranspos0 { T : UU } ( t1 t2 : T ) :
   isisolated T t1 -> isisolated T t2 -> compl T t1 ≃ compl T t2.
 Proof.
   intros ? ? ? is1 is2.
-  refine (weqgradth (funtranspos0 t1 t2 is2) (funtranspos0 t2 t1 is1) _ _).
+  unshelve refine (weqgradth (funtranspos0 t1 t2 is2) (funtranspos0 t2 t1 is1) _ _).
   - intro x. apply ( homottranspos0t2t1t1t2 t1 t2 is1 is2 ) .
   - intro x. apply ( homottranspos0t2t1t1t2 t2 t1 is2 is1 ) .
 Defined .

--- a/UniMath/Foundations/Basics/Tests.v
+++ b/UniMath/Foundations/Basics/Tests.v
@@ -21,7 +21,7 @@ Module Test_gradth.
   Goal homotweqinvweqweq w 3 = idpath _. reflexivity. Defined.
 
   Definition v : bool ≃ bool.
-    refine (weqgradth negb negb _ _); intro x; induction x; reflexivity. Defined.
+    unshelve refine (weqgradth negb negb _ _); intro x; induction x; reflexivity. Defined.
   Goal homotinvweqweq v true = idpath _. reflexivity. Defined.
   Goal homotweqinvweq v true = idpath _. reflexivity. Defined.
   Goal homotweqinvweqweq v true = idpath _. reflexivity. Defined.

--- a/UniMath/Foundations/Combinatorics/FiniteSequences.v
+++ b/UniMath/Foundations/Combinatorics/FiniteSequences.v
@@ -78,7 +78,7 @@ Proof.
   intros. apply (@iscontrweqb _ (empty -> X)).
   - apply invweq. apply weqbfun. apply weqstn0toempty.
   - apply iscontrfunfromempty.
-Defined.  
+Defined.
 
 Definition nil_unique {X} (x : stn 0 -> X) : nil = (0,,x).
 Proof.
@@ -114,7 +114,7 @@ Defined.
 
 Definition iscontr_rect'' X (i : iscontr X) (P : X ->UU) (p0 : P (pr1 i)) : ∀ x:X, P x.
 Proof. intros. exact (invmap (weqsecovercontr P i) p0 x). Defined.
-       
+
 Definition iscontr_rect_compute'' X (i : iscontr X) (P : X ->UU) (p : P(pr1 i)) :
   iscontr_rect'' X i P p (pr1 i) = p.
 Proof. try reflexivity. intros. exact (homotweqinvweq (weqsecovercontr _ i) _).
@@ -185,7 +185,7 @@ Proof.
     induction (natlehchoice4 i n b) as [q|q].
     + simpl. apply maponpaths. apply isinjstntonat; simpl. reflexivity.
     + induction q. contradicts p (isirreflnatlth i).
-  - induction p. 
+  - induction p.
     unfold append_fun; simpl.
     induction (natlehchoice4 i i b) as [r|r].
     * simpl. unfold funcomp; simpl. apply maponpaths.
@@ -267,7 +267,7 @@ Lemma Sequence_rect_compute_cons
       {X} {P : Sequence X ->UU} (p0 : P nil)
       (ind : ∀ (s : Sequence X) (x : X), P s -> P (append s x))
       (x:X) (l:Sequence X) :
-  Sequence_rect p0 ind (append l x) = ind l x (Sequence_rect p0 ind l). 
+  Sequence_rect p0 ind (append l x) = ind l x (Sequence_rect p0 ind l).
 Proof.
   intros.
 
@@ -297,7 +297,7 @@ Definition concatenate_0 {X} (s:Sequence X) (t:stn 0 -> X) : concatenate s (0,,t
 Proof.
   intros.
   induction s as [n s].
-  refine (total2_paths2 _ _).
+  unshelve refine (total2_paths2 _ _).
   { simpl. apply natplusr0. }
   { simpl. generalize (natplusr0 n). intro e. apply funextsec; intro i.
 
@@ -357,13 +357,13 @@ Proof.
   unfold total2_step_b, total2_step_f.
   induction (natlehchoice4 j n J) as [J'|K].
   + simpl.
-    refine (total2_paths _ _).
+    unshelve refine (total2_paths _ _).
     * simpl. rewrite replace_dni_last. apply isinjstntonat. reflexivity.
     * rewrite replace_dni_last. unfold dni_lastelement.  simpl.
       change (λ x0 : stn (S n), X x0) with X.
       rewrite transport_f_b. apply (isaset_transportf X).
   + induction (!K). simpl.
-    refine (total2_paths _ _).
+    unshelve refine (total2_paths _ _).
     * simpl. now apply isinjstntonat.
     * simpl. assert (d : idpath n = K).
       { apply isasetnat. }
@@ -435,7 +435,7 @@ Proof. intros.
   intermediate_weq (stn (stnsum (f ∘ dni n (lastelement n))) ⨿ stn (f (lastelement n))).
   { apply weqcoprodf. { apply weqstnsum1. } apply idweq. }
   apply weqfromcoprodofstn.
-Defined.  
+Defined.
 
 Definition invmap_over_weqcomp {X Y Z} (g:Y≃Z) (f:X≃Y) :
   invmap (g∘f)%weq = invmap f ∘ invmap g.
@@ -459,7 +459,7 @@ Proof.
   apply isinjpr1weq.
   apply funextfun; intros [k p].
   unfold weqstnsum1'.
-  unfold total2_step', total2_step. 
+  unfold total2_step', total2_step.
   rewrite 4? weqcomp_to_funcomp.
   unfold funcomp.
   change (((invweq
@@ -500,7 +500,7 @@ Definition isassoc_concatenate {X} (x y z:Sequence X) :
   concatenate (concatenate x y) z = concatenate x (concatenate y z).
 Proof.
   intros.
-  refine (total2_paths _ _).
+  unshelve refine (total2_paths _ _).
   - simpl. apply natplusassoc.
   - apply sequenceEquality; intros i.
 
@@ -512,5 +512,3 @@ Local Variables:
 compile-command: "make -C ../.. UniMath/Foundations/Sequences.vo"
 End:
 *)
-
-

--- a/UniMath/Foundations/Combinatorics/OrderedSets.v
+++ b/UniMath/Foundations/Combinatorics/OrderedSets.v
@@ -122,7 +122,7 @@ Defined.
 Local Lemma posetTransport_weq (X Y:Poset) : X≡Y ≃ X≅Y.
 Proof.
   intros.
-  refine (weqbandf _ _ _ _).
+  unshelve refine (weqbandf _ _ _ _).
   { apply hSet_univalence. }
   intros e. apply invweq. apply poTransport_weq.
 Defined.
@@ -267,7 +267,7 @@ Definition underlyingPoset_weq (X Y:OrderedSet) :
   X=Y ≃ (underlyingPoset X)=(underlyingPoset Y).
 Proof.
   Set Printing Coercions.
-  intros. refine (weqpair _ _).
+  intros. unshelve refine (weqpair _ _).
   { apply maponpaths. }
   apply isweqonpathsincl. apply isincl_underlyingPoset.
   Unset Printing Coercions.
@@ -324,7 +324,7 @@ Definition FiniteOrderedSetDecidableInequality (X:FiniteOrderedSet) : DecidableR
 Defined.
 
 Definition FiniteOrderedSetDecidableLessThan (X:FiniteOrderedSet) : DecidableRelation X.
-  intros ? x y. refine (decidable_to_DecidableProposition _).
+  intros ? x y. unshelve refine (decidable_to_DecidableProposition _).
   - exact (x < y).
   - apply isfinite_isdec_lessthan. apply finitenessProperty.
 Defined.
@@ -352,7 +352,7 @@ Defined.
 
 Definition standardFiniteOrderedSet (n:nat) : FiniteOrderedSet.
 Proof.
-  intros. refine (_,,_).
+  intros. unshelve refine (_,,_).
   - exists (stnposet n). intros x y; apply istotalnatleh.
   - apply isfinitestn.
 Defined.
@@ -380,11 +380,11 @@ Definition transportFiniteOrdering {n} {X:UU} : X ≃ ⟦ n ⟧ -> FiniteOrdered
 (* The new finite ordered set has X as its underlying set. *)
 Proof.
   intros ? ? w.
-  refine (_,,_).
-  - refine (_,,_).
-    * refine (_,,_).
+  unshelve refine (_,,_).
+  - unshelve refine (_,,_).
+    * unshelve refine (_,,_).
     + exists X. apply (isofhlevelweqb 2 w). apply setproperty.
-      + unfold PartialOrder; simpl. refine (_,,_).
+      + unfold PartialOrder; simpl. unshelve refine (_,,_).
         { intros x y. exact (w x ≤ w y). }
         apply inducedPartialOrder_weq.
         exact (pr2 (pr2 (pr1 (pr1 ⟦ n ⟧)))).
@@ -490,12 +490,12 @@ Definition concatenateFiniteOrderedSets
 Proof.
   (* we use lexicographic order *)
   intros.
-  refine (_,,_).
+  unshelve refine (_,,_).
   {
-    refine (_,,_).
-    { refine (_,,_).
+    unshelve refine (_,,_).
+    { unshelve refine (_,,_).
       { exact (Σ x, Y x)%set. }
-      refine (_,,_).
+      unshelve refine (_,,_).
       { apply lexicographicOrder. apply posetRelation. intro. apply posetRelation. }
       split.
       { split.
@@ -560,7 +560,7 @@ Abort.
 Theorem enumeration_FiniteOrderedSet (X:FiniteOrderedSet) : iscontr (FiniteStructure X).
 Proof.
   intros.
-  refine (_,,_).
+  unshelve refine (_,,_).
   { exists (fincard (finitenessProperty X)).
 
   (* proof in progress... *)

--- a/UniMath/Foundations/Combinatorics/Tests.v
+++ b/UniMath/Foundations/Combinatorics/Tests.v
@@ -66,7 +66,7 @@ Module Test_stn.
 
     (* here's an example that shows complications need not impede that sort of computability: *)
     Local Definition w : unit ≃ stn 1.
-      refine (weqgradth _ _ _ _).
+      unshelve refine (weqgradth _ _ _ _).
       { intro. exact (firstelement _). }
       { intro. exact tt. }
       { intro u. simpl. induction u. reflexivity. }

--- a/UniMath/Foundations/NumberSystems/NaturalNumbers.v
+++ b/UniMath/Foundations/NumberSystems/NaturalNumbers.v
@@ -1547,7 +1547,7 @@ Defined.
 Theorem weqdicompl i : nat ≃ nat_compl i.
 Proof.
   intros i.
-  refine (weqgradth _ _ _ _).
+  unshelve refine (weqgradth _ _ _ _).
   - intro j. exists (di i j). apply di_neq_i.
   - intro j. exact (si i (pr1 j)).
   - simpl. intro j. unfold di. induction (natlthorgeh j i) as [lt|ge].

--- a/UniMath/Ktheory/AbelianGroup.v
+++ b/UniMath/Ktheory/AbelianGroup.v
@@ -293,13 +293,13 @@ Module Presentation.
   Definition universalMarkedAbelianGroup0 {X I} (R:I->reln X) : abgr.
     intros.
     { exists (univ_setwithbinop R). split.
-      { refine (_,,_).
+      { unshelve refine (_,,_).
         { split.
           { exact (isassoc_univ_binop R). }
           { exists (setquotpr _ word_unit). split.
             { exact (is_left_unit_univ_binop R). }
             { exact (is_right_unit_univ_binop R). } } }
-        { refine (_,,_).
+        { unshelve refine (_,,_).
           { exact (univ_inverse R). }
           { split.
             { exact (is_left_inverse_univ_binop R). }
@@ -337,10 +337,10 @@ Module Presentation.
          { intermediate_path (unel M). exact (unitproperty f). exact (!unitproperty g). }
          { apply p. }
          (* compare duplication with the proof of MarkedAbelianGroupMap_compat *)
-         { refine (monoidfuninvtoinv f (setquotpr (smallestAdequateRelation R) w)
+         { unshelve refine (monoidfuninvtoinv f (setquotpr (smallestAdequateRelation R) w)
              @ _ @ ! monoidfuninvtoinv g (setquotpr (smallestAdequateRelation R) w)).
            apply (ap (grinv M)). apply agreement_on_gens0. assumption. }
-         { refine (
+         { unshelve refine (
                Monoid.multproperty f (setquotpr (smallestAdequateRelation R) v)
                    (setquotpr (smallestAdequateRelation R) w)
              @ _ @ !
@@ -431,13 +431,13 @@ Module Sum.                   (* coproducts *)
   Definition make {I} (G:I->abgr) : abgr.
     intros. exact (Presentation.universalMarkedAbelianGroup (R G)). Defined.
   Definition Incl {I} (G:I->abgr) (i:I) : Hom (G i) (make G).
-    intros. refine (_,,_).
+    intros. unshelve refine (_,,_).
     { intro g. apply setquotpr. apply word_gen. exact (i,,g). } { split.
       { intros g h. apply iscompsetquotpr. exact (base (adequacy _) (J_sum _ (i,,(g,,h)))). }
       { apply iscompsetquotpr. exact (base (adequacy _) (J_zero _ i)). } } Defined.
   Definition Map0 {I} {G:I->abgr} {T:abgr} (f: ∀ i, Hom (G i) T) :
       MarkedAbelianGroup (R G).
-    intros. refine (make_MarkedAbelianGroup (R G) T _ _).
+    intros. unshelve refine (make_MarkedAbelianGroup (R G) T _ _).
     { intros [i g]. exact (f i g). }
     { intros [i|[i [g h]]].
       { simpl. apply unitproperty. }

--- a/UniMath/Ktheory/AbelianMonoid.v
+++ b/UniMath/Ktheory/AbelianMonoid.v
@@ -316,9 +316,9 @@ Definition finiteOperation1 (X:abmonoid) I : finstruct I -> (I->X) -> X.
 Defined.
 Definition finiteOperation {I} (is:isfinite I) (X:abmonoid) (x:I->X) : X.
   intros. generalize is; clear is.
-  refine (squash_to_set _ _ _).
-  { apply setproperty. }
+  unshelve refine (squash_to_set _ _ _).
   { intros fs. apply (finiteOperation1 X I fs x). }
+  { apply setproperty. }
   { intros [m f] [n g]. assert (e := same_n f g). induction e.
     try apply uniqueness0.      (* not proved yet *)
     admit.
@@ -398,7 +398,7 @@ Module Presentation.
   Defined.
   Lemma adequacy {X I} (R:I->reln X) :
     AdequateRelation R (smallestAdequateRelation0 R).
-  Proof. intros. refine (make_AdequateRelation R _ _ _ _ _ _ _ _ _ _ _).
+  Proof. intros. unshelve refine (make_AdequateRelation R _ _ _ _ _ _ _ _ _ _ _).
          { intros ? r ra. apply base. exact ra. }
          { intros ? r ra. apply (reflex R). exact ra. }
          { intros ? ? p r ra. apply (symm R). exact ra. exact (p r ra). }
@@ -428,14 +428,14 @@ Module Presentation.
   (** *** the multiplication on on it *)
 
   Definition univ_binop {X I} (R:I->reln X) : binop (universalMarkedPreAbelianMonoid0 R).
-    intros. refine (QuotientSet.setquotfun2 word_op _). apply op2_compatibility. Defined.
+    intros. unshelve refine (QuotientSet.setquotfun2 word_op _). apply op2_compatibility. Defined.
   Definition univ_setwithbinop {X I} (R:I->reln X) : setwithbinop
              := setwithbinoppair (universalMarkedPreAbelianMonoid0 R) (univ_binop R).
 
   (** *** the universal pre-Abelian group *)
 
   Definition universalMarkedPreAbelianMonoid {X I} (R:I->reln X) : MarkedPreAbelianMonoid X.
-    intros. refine (make_preAbelianMonoid X (universalMarkedPreAbelianMonoid0 R) _ _ _).
+    intros. unshelve refine (make_preAbelianMonoid X (universalMarkedPreAbelianMonoid0 R) _ _ _).
     { exact (setquotpr _ word_unit). }
     { exact (fun x => setquotpr _ (word_gen x)). }
     { exact (univ_binop _). } Defined.
@@ -507,7 +507,7 @@ Module Presentation.
     fun v w  => eqset (evalwordMM M v) (evalwordMM M w).
   Lemma abelian_group_adequacy {X I} (R:I->reln X) (M:MarkedAbelianMonoid R) :
     AdequateRelation R (MarkedAbelianMonoid_to_hrel M).
-  Proof. intros. refine (make_AdequateRelation R _ _ _ _ _ _ _ _ _ _ _).
+  Proof. intros. unshelve refine (make_AdequateRelation R _ _ _ _ _ _ _ _ _ _ _).
          { exact (fun i => m_reln M i). } { reflexivity. }
          { intros ? ?. exact pathsinv0. } { intros ? ? ?. exact pathscomp0. }
          { intros ? ? ? p. simpl in p; simpl.
@@ -587,7 +587,7 @@ Module Presentation.
          { intermediate_path (unel M). exact (Monoid.unitproperty f). exact (!Monoid.unitproperty g). }
          { apply p. }
          (* compare duplication with the proof of MarkedAbelianMonoidMap_compat *)
-         { refine (
+         { unshelve refine (
                Monoid.multproperty f (setquotpr (smallestAdequateRelation R) v)
                    (setquotpr (smallestAdequateRelation R) w)
              @ _ @ !
@@ -655,7 +655,7 @@ Module NN_agreement.
   Proof. intro. induction n. { reflexivity. } { exact (ap S IHn). } Qed.
   Lemma mult_fun {X Y:abmonoid} (f:Hom X Y) (n:nat) (x:X) : f(n*x) = n*f x.
   Proof. intros. induction n. { exact (Monoid.unitproperty f). }
-         { refine (Monoid.multproperty f x (n*x) @ _).
+         { unshelve refine (Monoid.multproperty f x (n*x) @ _).
            { simpl. simpl in IHn. induction IHn. reflexivity. } } Qed.
   Lemma uniq_fun {X:abmonoid} (f g:Hom nataddabmonoid X) :
     f 1 = g 1 -> homot f g.
@@ -672,7 +672,7 @@ Module NN_agreement.
     set (markednat :=
            make_MarkedAbelianMonoid R nataddabmonoid (fun _ => 1) fromemptysec).
     exists (map_base (thePoint (iscontrMarkedAbelianMonoidMap markednat))).
-    refine (gradth _ _ _ _).
+    unshelve refine (gradth _ _ _ _).
     { intros m. { exact (m * one). } }
     { intros w.
       apply (squash_to_prop (lift R w)).

--- a/UniMath/Ktheory/AffineLine.v
+++ b/UniMath/Ktheory/AffineLine.v
@@ -1,7 +1,7 @@
 
 Unset Kernel Term Sharing.
 
-(** * Construction of affine lines 
+(** * Construction of affine lines
 
  We show that the propositional truncation of a ℤ-torsor, where ℤ
  is the additive group of the integers, behaves like an affine line.
@@ -27,43 +27,43 @@ Open Scope hz_scope.
 
 (** ** Recursion for ℤ *)
 
-Definition ℤRecursionData0 (P:ℤ->Type) (p0:P zero) 
+Definition ℤRecursionData0 (P:ℤ->Type) (p0:P zero)
       (IH :∀ n, P(  toℤ n) -> P(  toℤ (S n)))
-      (IH':∀ n, P(- toℤ n) -> P(- toℤ (S n))) := fun 
-          f:∀ i, P i => 
+      (IH':∀ n, P(- toℤ n) -> P(- toℤ (S n))) := fun
+          f:∀ i, P i =>
             (f zero = p0) ×
             (∀ n, f(  toℤ (S n)) = IH  n (f (  toℤ n))) ×
             (∀ n, f(- toℤ (S n)) = IH' n (f (- toℤ n))).
 
 Definition ℤRecursionData (P:ℤ->Type)
       (IH :∀ n, P(  toℤ n) -> P(  toℤ (S n)))
-      (IH':∀ n, P(- toℤ n) -> P(- toℤ (S n))) := fun 
-             f:∀ i, P i => 
+      (IH':∀ n, P(- toℤ n) -> P(- toℤ (S n))) := fun
+             f:∀ i, P i =>
                (∀ n, f(  toℤ (S n)) = IH  n (f (  toℤ n))) ×
                (∀ n, f(- toℤ (S n)) = IH' n (f (- toℤ n))).
 
-Lemma ℤRecursionUniq (P:ℤ->Type) (p0:P zero) 
+Lemma ℤRecursionUniq (P:ℤ->Type) (p0:P zero)
       (IH :∀ n, P(  toℤ n) -> P(  toℤ (S n)))
       (IH':∀ n, P(- toℤ n) -> P(- toℤ (S n))) :
   iscontr (total2 (ℤRecursionData0 P p0 IH IH')).
 Proof. intros.
        unfold ℤRecursionData0.
        (* use hNatRecursion_weq *)
-       apply (iscontrweqb (Y :=  
+       apply (iscontrweqb (Y :=
             Σ f:∀ w, P (negpos w),
               (f (ii2 O) = p0) ×
               (∀ n : nat, f (ii2 (S n)) = IH n (f (ii2 n))) ×
               (f (ii1 O) = IH' O (f (ii2 O))) ×
               (∀ n : nat, f (ii1 (S n)) = IH' (S n) (f (ii1 n))))).
        { apply (weqbandf (weqonsecbase _ negpos)). intro f.
-         refine (weqpair _ (gradth _ _ _ _)).
-         { intros [h0 [hp hn]]. refine (_,,_,,_,,_). 
-           { exact h0. } { exact hp. } 
+         unshelve refine (weqpair _ (gradth _ _ _ _)).
+         { intros [h0 [hp hn]]. unshelve refine (_,,_,,_,,_).
+           { exact h0. } { exact hp. }
            { exact (hn O). } { intro n. exact (hn (S n)). } }
-         { intros [h0 [hp [h1' hn]]]. refine (_,,_,,_).
+         { intros [h0 [hp [h1' hn]]]. unshelve refine (_,,_,,_).
            { exact h0. } { exact hp. }
            { intros [|n']. { exact h1'. } { exact (hn n'). } } }
-         { intros [h0 [hp hn]]. simpl. apply paths3. 
+         { intros [h0 [hp hn]]. simpl. apply paths3.
            { reflexivity. } { reflexivity. }
            { apply funextsec; intros [|n']; reflexivity; reflexivity. } }
          { intros [h0 [h1' [hp hn]]]. reflexivity. } }
@@ -74,7 +74,7 @@ Proof. intros.
                 (∀ n : nat, pr2 f (S n) = IH n (pr2 f n)) ×
                 (pr1 f O = IH' O (pr2 f O)) ×
                 (∀ n : nat, pr1 f (S n) = IH' (S n) (pr1 f n))).
-       { apply (weqbandf (weqsecovercoprodtoprod (fun w => P (negpos w)))). 
+       { apply (weqbandf (weqsecovercoprodtoprod (fun w => P (negpos w)))).
          intro f. apply idweq. }
        intermediate_iscontr (
               Σ f : (∀ n, P (negpos (ii2 n))) ×
@@ -94,7 +94,7 @@ Proof. intros.
        { apply weqtotal2asstor. }
        intermediate_iscontr (
             Σ f2 : ∀ n : nat, P (negpos (ii2 n)),
-                 (f2 O = p0) × 
+                 (f2 O = p0) ×
             Σ f1 : ∀ n : nat, P (negpos (ii1 n)),
                  (∀ n : nat, f2 (S n) = IH n (f2 n)) ×
                  (f1 O = IH' O (f2 O)) ×
@@ -103,7 +103,7 @@ Proof. intros.
        intermediate_iscontr (
             Σ f2 : ∀ n : nat, P (negpos (ii2 n)),
                  (f2 O = p0) ×
-                 (∀ n : nat, f2 (S n) = IH n (f2 n)) × 
+                 (∀ n : nat, f2 (S n) = IH n (f2 n)) ×
             Σ f1 : ∀ n : nat, P (negpos (ii1 n)),
                  (f1 O = IH' O (f2 O)) ×
                  (∀ n : nat, f1 (S n) = IH' (S n) (f1 n))).
@@ -114,15 +114,15 @@ Proof. intros.
                  (f2 O = p0) ×
                  (∀ n : nat, f2 (S n) = IH n (f2 n))).
        { apply weqfibtototal; intro f2. apply weqfibtototal; intro h0.
-         apply weqpr1; intro ih2. 
+         apply weqpr1; intro ih2.
          exact (Nat.Uniqueness.hNatRecursionUniq
-                   (fun n => P (negpos (ii1 n))) 
+                   (fun n => P (negpos (ii1 n)))
                    (IH' O (f2 O))
                    (fun n => IH' (S n))). }
        apply Nat.Uniqueness.hNatRecursionUniq.
 Defined.
 
-Lemma A (P:ℤ->Type) (p0:P zero) 
+Lemma A (P:ℤ->Type) (p0:P zero)
       (IH :∀ n, P(  toℤ n) -> P(  toℤ (S n)))
       (IH':∀ n, P(- toℤ n) -> P(- toℤ (S n))) :
   weq (total2 (ℤRecursionData0 P p0 IH IH'))
@@ -132,22 +132,22 @@ Lemma A (P:ℤ->Type) (p0:P zero)
          (fun fh => pr1 fh zero)
          p0).
 Proof. intros.
-       refine (weqpair _ (gradth _ _ _ _)).
+       unshelve refine (weqpair _ (gradth _ _ _ _)).
        { intros [f [h0 h]]. exact ((f,,h),,h0). }
        { intros [[f h] h0]. exact (f,,(h0,,h)). }
        { intros [f [h0 h]]. reflexivity. }
        { intros [[f h] h0]. reflexivity. } Defined.
 
-Lemma ℤRecursion_weq (P:ℤ->Type) 
+Lemma ℤRecursion_weq (P:ℤ->Type)
       (IH :∀ n, P(  toℤ n) -> P(  toℤ (S n)))
       (IH':∀ n, P(- toℤ n) -> P(- toℤ (S n))) :
   weq (total2 (ℤRecursionData P IH IH')) (P 0).
 Proof. intros. exists (fun f => pr1 f zero). intro p0.
        apply (iscontrweqf (A _ _ _ _)). apply ℤRecursionUniq. Defined.
 
-Lemma ℤRecursion_weq_compute (P:ℤ->Type) 
+Lemma ℤRecursion_weq_compute (P:ℤ->Type)
       (IH :∀ n, P(  toℤ n) -> P(  toℤ (S n)))
-      (IH':∀ n, P(- toℤ n) -> P(- toℤ (S n))) 
+      (IH':∀ n, P(- toℤ n) -> P(- toℤ (S n)))
       (fh : total2 (ℤRecursionData P IH IH')) :
   ℤRecursion_weq P IH IH' fh = pr1 fh zero.
 Proof. reflexivity.             (* don't change the proof *)
@@ -155,7 +155,7 @@ Defined.
 
 (** ** Bidirectional recursion for ℤ *)
 
-Definition ℤBiRecursionData (P:ℤ->Type) (IH :∀ i, P(i) -> P(1+i)) := 
+Definition ℤBiRecursionData (P:ℤ->Type) (IH :∀ i, P(i) -> P(1+i)) :=
   fun f:∀ i, P i => ∀ i, f(1+i)=IH i (f i).
 
 Definition ℤBiRecursion_weq (P:ℤ->Type) (IH :∀ i, weq (P i) (P(1+i))) :
@@ -172,18 +172,18 @@ Proof. intros.
        set (l' := fun n => weq_transportf P (k' n)).
        set (ih := fun n => weqcomp (IH (toℤ n)) (l n)).
        set (ih':= fun n => (weqcomp (l' n) (invweq (IH (- toℤ (S n)))))).
-       set (G := ℤRecursion_weq P ih ih'). refine (weqcomp _ G).
+       set (G := ℤRecursion_weq P ih ih'). unshelve refine (weqcomp _ G).
        apply weqfibtototal. intro f. unfold ℤRecursionData, ℤBiRecursionData.
-       refine (weqcomp (weqonsecbase _ negpos) _).
-       refine (weqcomp (weqsecovercoprodtoprod _) _).
-       refine (weqcomp (weqdirprodcomm _ _) _). apply weqdirprodf.
-       { apply weqonsecfibers; intro n. refine (weqonpaths2 _ _ _).
+       unshelve refine (weqcomp (weqonsecbase _ negpos) _).
+       unshelve refine (weqcomp (weqsecovercoprodtoprod _) _).
+       unshelve refine (weqcomp (weqdirprodcomm _ _) _). apply weqdirprodf.
+       { apply weqonsecfibers; intro n. unshelve refine (weqonpaths2 _ _ _).
          { change (negpos (ii2 n)) with (toℤ n). exact (l n). }
          { unfold l. apply weq_transportf_comp. }
          { reflexivity. } }
        { apply weqonsecfibers; intro n. simpl.
-         refine (weqcomp (weqpair _ (isweqpathsinv0 _ _)) _).
-         refine (weqonpaths2 _ _ _).
+         unshelve refine (weqcomp (weqpair _ (isweqpathsinv0 _ _)) _).
+         unshelve refine (weqonpaths2 _ _ _).
          { apply invweq. apply IH. }
          { simpl. rewrite homotinvweqweq. reflexivity. }
          { simpl. change (natnattohz 0 (S n)) with (- toℤ (S n)).
@@ -191,7 +191,7 @@ Proof. intros.
            reflexivity. } } Defined.
 
 Definition ℤBiRecursion_weq_compute (P:ℤ->Type)
-           (IH :∀ i, weq (P i) (P(1+i))) 
+           (IH :∀ i, weq (P i) (P(1+i)))
       (fh : total2 (ℤBiRecursionData P IH)) :
   ℤBiRecursion_weq P IH fh = pr1 fh 0.
 Proof. reflexivity.             (* don't change the proof *)
@@ -203,12 +203,12 @@ Open Scope action_scope.
 
 (** ** Bidirectional recursion for ℤ-torsors *)
 
-Definition GuidedSection {T:Torsor ℤ} 
-           (P:T->Type) (IH:∀ t, weq (P t) (P (one + t))) := fun 
-     f:Section P => 
+Definition GuidedSection {T:Torsor ℤ}
+           (P:T->Type) (IH:∀ t, weq (P t) (P (one + t))) := fun
+     f:Section P =>
        ∀ t, f (one + t) = IH t (f t).
 
-Definition ℤTorsorRecursion_weq {T:Torsor ℤ} (P:T->Type) 
+Definition ℤTorsorRecursion_weq {T:Torsor ℤ} (P:T->Type)
       (IH:∀ t, weq (P t) (P (one + t))) (t0:T) :
   weq (total2 (GuidedSection P IH)) (P t0).
 Proof. intros. exists (fun fh => pr1 fh t0). intro q.
@@ -216,17 +216,17 @@ Proof. intros. exists (fun fh => pr1 fh t0). intro q.
        assert (k0 : ∀ i, one + w i = w (1+i)%hz).
        { intros. simpl. unfold right_mult, ac_mult. rewrite act_assoc.
          reflexivity. }
-       set (l0 := (fun i => eqweqmap (ap P (k0 i))) 
+       set (l0 := (fun i => eqweqmap (ap P (k0 i)))
                : ∀ i, weq (P(one + w i)) (P(w(1+i)%hz))).
        assert( e : right_mult t0 zero = t0 ). { apply act_unit. }
        set (H := fun f => ∀ t : T, f (one + t) = (IH t) (f t)).
        set ( IH' := (fun i => weqcomp (IH (w i)) (l0 i))
                     : ∀ i:ℤ, weq (P (w i)) (P (w(1+i)%hz))).
        set (J := fun f => ∀ i : ℤ, f (1 + i)%hz = (IH' i) (f i)).
-       refine (iscontrweqb (@weq_over_sections ℤ T w 0 t0 e P q (e#'q) _ H J _) _).
+       unshelve refine (iscontrweqb (@weq_over_sections ℤ T w 0 t0 e P q (e#'q) _ H J _) _).
        { apply transportfbinv. }
-       { intro. apply invweq. unfold H,J,maponsec1. refine (weqonsec _ _ w _).
-         intro i. refine (weqonpaths2 _ _ _).
+       { intro. apply invweq. unfold H,J,maponsec1. unshelve refine (weqonsec _ _ w _).
+         intro i. unshelve refine (weqonpaths2 _ _ _).
          { exact (invweq (l0 i)). }
          { unfold l0. rewrite (k0 i). reflexivity. }
          { unfold IH'. unfold weqcomp; simpl.
@@ -234,37 +234,37 @@ Proof. intros. exists (fun fh => pr1 fh t0). intro q.
        exact (pr2 (ℤBiRecursion_weq (fun i => P(w i)) IH') (e #' q)).
 Defined.
 
-Definition ℤTorsorRecursion_compute {T:Torsor ℤ} (P:T->Type) 
+Definition ℤTorsorRecursion_compute {T:Torsor ℤ} (P:T->Type)
       (IH:∀ t, weq (P t) (P (one + t))) t h :
   ℤTorsorRecursion_weq P IH t h = pr1 h t.
 Proof. reflexivity.             (* don't change the proof *)
 Defined.
 
-Definition ℤTorsorRecursion_inv_compute {T:Torsor ℤ} (P:T->Type) 
+Definition ℤTorsorRecursion_inv_compute {T:Torsor ℤ} (P:T->Type)
       (IH:∀ t, weq (P t) (P (one + t)))
       (t0:T) (h0:P t0) :
   pr1 (invmap (ℤTorsorRecursion_weq P IH t0) h0) t0 = h0.
 Proof. intros.
-       exact (! ℤTorsorRecursion_compute P IH t0 
-                (invmap (ℤTorsorRecursion_weq P IH t0) h0) 
-                @ 
+       exact (! ℤTorsorRecursion_compute P IH t0
+                (invmap (ℤTorsorRecursion_weq P IH t0) h0)
+                @
                 homotweqinvweq (ℤTorsorRecursion_weq P IH t0) h0). Defined.
 
-Definition ℤTorsorRecursion_transition {T:Torsor ℤ} (P:T->Type) 
+Definition ℤTorsorRecursion_transition {T:Torsor ℤ} (P:T->Type)
       (IH:∀ t, weq (P t) (P (one + t)))
       (t:T)
       (h:total2 (GuidedSection P IH)) :
   ℤTorsorRecursion_weq P IH (one+t) h
-  = 
+  =
   IH t (ℤTorsorRecursion_weq P IH t h).
 Proof. intros. rewrite 2!ℤTorsorRecursion_compute. exact (pr2 h t). Defined.
 
-Definition ℤTorsorRecursion_transition_inv {T:Torsor ℤ} (P:T->Type) 
+Definition ℤTorsorRecursion_transition_inv {T:Torsor ℤ} (P:T->Type)
       (IH:∀ t, weq (P t) (P (one + t)))
       (t:T) :
   ∀ h0,
   invmap (ℤTorsorRecursion_weq P IH t) h0
-  = 
+  =
   invmap (ℤTorsorRecursion_weq P IH (one+t)) (IH t h0).
 Proof. intros.
        assert (a := ℤTorsorRecursion_transition P IH t
@@ -272,19 +272,19 @@ Proof. intros.
        rewrite homotweqinvweq in a. rewrite <- a.
        rewrite homotinvweqweq. reflexivity. Defined.
 
-Definition ℤTorsorRecursion {T:Torsor ℤ} (P:T->Type) 
+Definition ℤTorsorRecursion {T:Torsor ℤ} (P:T->Type)
       (IH:∀ t, weq (P t) (P (one + t)))
       (t t':T) :
   weq (P t) (P t').
 Proof. intros.
        exact (weqcomp (invweq (ℤTorsorRecursion_weq P IH t))
-                      (ℤTorsorRecursion_weq P IH t')). Defined.  
+                      (ℤTorsorRecursion_weq P IH t')). Defined.
 
-(** ** Guided null-homotopies from ℤ-torsors 
+(** ** Guided null-homotopies from ℤ-torsors
 
  Let f be a map from a ℤ-torsor T to a type Y, and let s be a collection
  of target paths, connecting the images under f of consecutive points of T.
- 
+
  A null-homotopy for f is a point y of Y, together with paths from
  y to each point in the image of f.  We say that it is "guided" by s
  if all the consecutive triangles commute.
@@ -296,10 +296,10 @@ Proof. intros.
 
 Definition target_paths {Y} {T:Torsor ℤ} (f:T->Y) := ∀ t, f t=f(one + t).
 
-Definition GHomotopy {Y} {T:Torsor ℤ} (f:T->Y) (s:target_paths f) := fun 
+Definition GHomotopy {Y} {T:Torsor ℤ} (f:T->Y) (s:target_paths f) := fun
         y:Y => Σ h:nullHomotopyFrom f y, ∀ n, h(one + n) = h n @ s n.
 
-Definition GuidedHomotopy {Y} {T:Torsor ℤ} (f:T->Y) (s:target_paths f) := 
+Definition GuidedHomotopy {Y} {T:Torsor ℤ} (f:T->Y) (s:target_paths f) :=
   total2 (GHomotopy f s).
 
 Definition GH_to_cone {Y} {T:Torsor ℤ}
@@ -307,24 +307,24 @@ Definition GH_to_cone {Y} {T:Torsor ℤ}
   GuidedHomotopy f s -> coconustot Y (f t).
 Proof. intros ? ? ? ? ? [y hp]. exact (y,,pr1 hp t). Defined.
 
-Definition GH_point {Y} {T:Torsor ℤ} {f:T->Y} {s:target_paths f} 
+Definition GH_point {Y} {T:Torsor ℤ} {f:T->Y} {s:target_paths f}
            (yhp : GuidedHomotopy f s) := pr1 yhp : Y.
 
 Definition GH_homotopy {Y} {T:Torsor ℤ} {f:T->Y} {s:target_paths f}
-           (yhp : GuidedHomotopy f s) 
-     := pr1 (pr2 yhp) 
+           (yhp : GuidedHomotopy f s)
+     := pr1 (pr2 yhp)
      : nullHomotopyFrom f (GH_point yhp).
 
-Definition GH_equations {Y} {T:Torsor ℤ} (f:T->Y) (s:target_paths f) 
-           (yhp : GuidedHomotopy f s) 
-     := pr2 (pr2 yhp) 
+Definition GH_equations {Y} {T:Torsor ℤ} (f:T->Y) (s:target_paths f)
+           (yhp : GuidedHomotopy f s)
+     := pr2 (pr2 yhp)
      : let h := GH_homotopy yhp in
        ∀ n, h(one + n) = h n @ s n.
 
 Theorem iscontrGuidedHomotopy {Y} (T:Torsor ℤ) (f:T->Y) (s:target_paths f) :
   iscontr (GuidedHomotopy f s).
 Proof. intros. apply (squash_to_prop (torsor_nonempty T)).
-       { apply isapropiscontr. } intro t0. 
+       { apply isapropiscontr. } intro t0.
        (* A better proof would construct the center explicitly now
           using [makeGuidedHomotopy] below.  Or we could replace this theorem
           by a corollary of it, with the new center. *)
@@ -339,7 +339,7 @@ Proof. (* later give a more direct proof *)
        intros. apply proofirrelevancecontr. apply iscontrGuidedHomotopy. Defined.
 
 Definition iscontrGuidedHomotopy_comp_1 {Y} :
-  let T := trivialTorsor ℤ in 
+  let T := trivialTorsor ℤ in
   let t0 := 0 : T in
     ∀ (f:T->Y) (s:target_paths f),
       GH_point (thePoint (iscontrGuidedHomotopy T f s)) = f t0.
@@ -347,20 +347,20 @@ Proof. reflexivity.             (* don't change the proof *)
 Defined.
 
 Definition iscontrGuidedHomotopy_comp_2 {Y} :
-  let T := trivialTorsor ℤ in 
+  let T := trivialTorsor ℤ in
   let t0 := 0 : T in
     ∀ (f:T->Y) (s:target_paths f),
         (GH_homotopy (thePoint (iscontrGuidedHomotopy T f s)) t0) =
         (idpath (f t0)).
 Proof. intros.
-       assert (a2 := fiber_paths (iscontrweqb_compute 
+       assert (a2 := fiber_paths (iscontrweqb_compute
                       (weqfibtototal (GHomotopy f s) (fun y : Y => y = f t0)
                                      (fun y : Y =>
                                         ℤTorsorRecursion_weq (fun t : T => y = f t)
                                                               (fun t : T => weq_pathscomp0r y (s t)) t0))
-                      (iscontrcoconustot Y (f t0))) 
+                      (iscontrcoconustot Y (f t0)))
                 : @paths (GHomotopy f s (f t0)) _ _).
-       refine (apevalat t0 (ap pr1 ((idpath _ :
+       unshelve refine (apevalat t0 (ap pr1 ((idpath _ :
                          (pr2
                             (thePoint
                                (iscontrweqb
@@ -371,7 +371,7 @@ Proof. intros.
                                   (iscontrcoconustot Y (f t0)))))
                            =
                          (path_start a2)) @ a2)) @ _).
-       refine (apevalat t0
+       unshelve refine (apevalat t0
                  (ap pr1
                      (compute_pr2_invmap_weqfibtototal
                         (fun y : Y =>
@@ -388,15 +388,15 @@ Defined.
 (*     ∀ (f:T->Y) (s:target_paths f), *)
 (*       GH_to_cone t0 (thePoint (iscontrGuidedHomotopy T f s)) = f t0,, idpath (f t0). *)
 (* Proof. intros. *)
-       
+
 
 (*        admit. *)
 (* Defined.        *)
 
 Definition makeGuidedHomotopy {T:Torsor ℤ} {Y} (f:T->Y)
-           (s:target_paths f) {y:Y} t0 (h0:y=f t0) : 
+           (s:target_paths f) {y:Y} t0 (h0:y=f t0) :
   GuidedHomotopy f s.
-Proof. intros. exact (y ,, invweq (ℤTorsorRecursion_weq 
+Proof. intros. exact (y ,, invweq (ℤTorsorRecursion_weq
                (fun t : T => y = f t)
                (fun t => weq_pathscomp0r y (s t))
                t0) h0). Defined.
@@ -431,16 +431,16 @@ Definition makeGuidedHomotopy_transPath {T:Torsor ℤ} {Y} (f:T->Y)
            (s:target_paths f) {y:Y} t0 (h0:y=f t0) :
   makeGuidedHomotopy f s t0 h0 = makeGuidedHomotopy f s (one+t0) (h0 @ s t0).
 Proof. intros. apply pair_path_in2.
-       exact (ℤTorsorRecursion_transition_inv 
+       exact (ℤTorsorRecursion_transition_inv
                 _ (fun t => weq_pathscomp0r y (s t)) _ _). Defined.
 
 Definition makeGuidedHomotopy_transPath_comp {T:Torsor ℤ} {Y} (f:T->Y)
            (s:target_paths f) {y:Y} t0 (h0:y=f t0) :
   ap pr1 (makeGuidedHomotopy_transPath f s t0 h0) = idpath y.
-Proof. intros. 
+Proof. intros.
        unfold makeGuidedHomotopy_transPath.
        exact (pair_path_in2_comp1 _
-                (ℤTorsorRecursion_transition_inv 
+                (ℤTorsorRecursion_transition_inv
                    _ (fun t => weq_pathscomp0r y (s t)) _ _)). Defined.
 
 Definition makeGuidedHomotopy_diagonalPath {T:Torsor ℤ} {Y} (f:T->Y)
@@ -448,7 +448,7 @@ Definition makeGuidedHomotopy_diagonalPath {T:Torsor ℤ} {Y} (f:T->Y)
   makeGuidedHomotopy1 f s t0 = makeGuidedHomotopy1 f s (one + t0).
 Proof. intros.
   assert (b := makeGuidedHomotopy_transPath f s t0 (idpath(f t0))); simpl in b.
-  assert (c := makeGuidedHomotopy_localPath f s (one + t0) 
+  assert (c := makeGuidedHomotopy_localPath f s (one + t0)
                  (s t0)
                  (s t0 @ idpath (f (one + t0)))
                  (! pathscomp0rid (s t0))).
@@ -457,25 +457,25 @@ Proof. intros.
 Defined.
 
 Definition makeGuidedHomotopy_diagonalPath_comp {T:Torsor ℤ} {Y} (f:T->Y)
-           (s:target_paths f) (t0:T) : 
+           (s:target_paths f) (t0:T) :
   ap pr1 (makeGuidedHomotopy_diagonalPath f s t0) = s t0.
 Proof. intros.
        unfold makeGuidedHomotopy_diagonalPath.
-       refine (maponpaths_naturality (makeGuidedHomotopy_transPath_comp _ _ _ _) _).
-       refine (maponpaths_naturality (makeGuidedHomotopy_localPath_comp _ _ _ _ _ _) _).
+       unshelve refine (maponpaths_naturality (makeGuidedHomotopy_transPath_comp _ _ _ _) _).
+       unshelve refine (maponpaths_naturality (makeGuidedHomotopy_localPath_comp _ _ _ _ _ _) _).
        exact (makeGuidedHomotopy_verticalPath_comp _ _ _ _ _).
 Defined.
 
-Definition map {T:Torsor ℤ} {Y} (f:T->Y) (s:target_paths f) : 
+Definition map {T:Torsor ℤ} {Y} (f:T->Y) (s:target_paths f) :
   ∥ T ∥ -> GuidedHomotopy f s.
-Proof. intros ? ? ? ? t'. 
+Proof. intros ? ? ? ? t'.
        (* try to use transport as in Halfline.map *)
        apply (squash_to_prop t').
        { apply isapropifcontr. apply iscontrGuidedHomotopy. }
        intro t; clear t'.
        exact (makeGuidedHomotopy1 f s t). Defined.
 
-Definition map_path {T:Torsor ℤ} {Y} (f:T->Y) (s:target_paths f) : 
+Definition map_path {T:Torsor ℤ} {Y} (f:T->Y) (s:target_paths f) :
   ∀ t, map f s (squash_element t) = map f s (squash_element (one + t)).
 Proof. intros. exact (makeGuidedHomotopy_diagonalPath f s t). Defined.
 
@@ -483,14 +483,14 @@ Definition map_path_check {T:Torsor ℤ} {Y} (f:T->Y) (s:target_paths f) :
   ∀ t, ∀ p : map f s (squash_element t) =
                        map f s (squash_element (one + t)),
     ap pr1 p = s t.
-Proof. intros. set (q := map_path f s t). assert (k : q=p). 
-       { apply (hlevelntosn 1). apply (hlevelntosn 0). 
+Proof. intros. set (q := map_path f s t). assert (k : q=p).
+       { apply (hlevelntosn 1). apply (hlevelntosn 0).
          apply iscontrGuidedHomotopy. }
        destruct k. exact (makeGuidedHomotopy_diagonalPath_comp f s t). Defined.
 
 (** ** From each torsor we get a guided homotopy *)
 
-Definition makeGuidedHomotopy2 (T:Torsor ℤ) {Y} (f:T->Y) (s:target_paths f) : 
+Definition makeGuidedHomotopy2 (T:Torsor ℤ) {Y} (f:T->Y) (s:target_paths f) :
   GuidedHomotopy f s.
 Proof. intros. exact (map f s (torsor_nonempty T)). Defined.
 
@@ -508,7 +508,7 @@ Proof. intros. apply iscontraprop1. { apply propproperty. }
 Lemma affine_line_path {T:Torsor ℤ} (t u:affine_line T) : t = u.
 Proof. intros. apply proofirrelevance. exact (iscontr_affine_line _). Defined.
 
-Definition affine_line_map {T:Torsor ℤ} {Y} (f:T->Y) (s:target_paths f) : 
+Definition affine_line_map {T:Torsor ℤ} {Y} (f:T->Y) (s:target_paths f) :
   affine_line T -> Y.
 Proof. intros ? ? ? ? t'. exact (pr1 (map f s t')). Defined.
 
@@ -519,8 +519,9 @@ Defined.
 
 Definition check_paths {T:Torsor ℤ} {Y} (f:T->Y) (s:target_paths f) (t:T) :
   ap (affine_line_map f s) (squash_path t (one + t)) = s t.
-Proof. intros. refine (_ @ map_path_check f s t _).
-       apply pathsinv0. apply maponpathscomp. Defined.
+Proof. intros. unshelve refine (_ @ map_path_check f s t _).
+       - apply maponpaths. apply squash_path.
+       - apply pathsinv0. apply maponpathscomp. Defined.
 
 Definition check_paths_any {T:Torsor ℤ} {Y} (f:T->Y) (s:target_paths f) (t:T)
            (p : squash_element t = squash_element (one + t)) :
@@ -532,7 +533,7 @@ Proof. intros. set (p' := squash_path t (one + t)).
 Definition add_one {T:Torsor ℤ} : affine_line T -> affine_line T.
 Proof. intros ?. exact (squash_fun (fun t => one + t)). Defined.
 
-(** ** The image of the mere point in an affine line 
+(** ** The image of the mere point in an affine line
 
  A torsor is nonempty, so it merely has a point, as does the
  corresponding affine line.  Here we name its image in Y. *)

--- a/UniMath/Ktheory/Circle.v
+++ b/UniMath/Ktheory/Circle.v
@@ -32,7 +32,7 @@ Proof. intros. unfold circle_loop. rewrite pathsinv0inv0.
 
 (** ** The total space of guided homotopies over BZ *)
 
-Definition ZGuidedHomotopy {Y} {y:Y} (l:y = y) (T:Torsor ℤ) := 
+Definition ZGuidedHomotopy {Y} {y:Y} (l:y = y) (T:Torsor ℤ) :=
   GuidedHomotopy (confun T y) (confun T l).
 
 Definition GH {Y} {y:Y} (l:y = y) := Σ T:Torsor ℤ, ZGuidedHomotopy l T.
@@ -42,7 +42,7 @@ Definition GHpair {Y} {y:Y} (l:y = y) (T:Torsor ℤ) (g:ZGuidedHomotopy l T) :=
 
 Definition pr1_GH {Y} {y:Y} {l:y = y} := pr1 : GH l -> Torsor ℤ.
 
-Definition pr2_GH {Y} {y:Y} (l:y = y) (u:GH l) 
+Definition pr2_GH {Y} {y:Y} (l:y = y) (u:GH l)
   := pr2 u : ZGuidedHomotopy l (pr1_GH u).
 
 Definition GH_path3 {Y} {y:Y} (l:y = y) {T:Torsor ℤ} {y':Y}
@@ -53,7 +53,7 @@ Proof. intros. destruct u. reflexivity. Defined.
 Definition pr12_GH {Y} {y:Y} {l:y = y} (u:GH l) := pr1 (pr2_GH l u) : Y.
 
 Definition pr22_GH {Y} {y:Y} {l:y = y} (u:GH l)
-     := pr2 (pr2_GH l u) 
+     := pr2 (pr2_GH l u)
      : GHomotopy (confun (pr1_GH u) y) (confun (pr1_GH u) l) (pr12_GH u).
 
 Definition GH_path3_comp1 {Y} {y:Y} (l:y = y) {T:Torsor ℤ} {y':Y}
@@ -73,12 +73,12 @@ Local Definition sec {Y} {y:Y} (l:y = y) (T:Torsor ℤ) := makeGuidedHomotopy2 T
 Definition pr1_GH_weq {Y} {y:Y} {l:y = y} : weq (GH l) (Torsor ℤ) := weqpr1_irr_sec (irr l) (sec l).
 
 Definition homotinvweqweq_GH_comp {Y} {y:Y} {l:y = y}
-           (T:Torsor ℤ) (gh:ZGuidedHomotopy l T) : 
+           (T:Torsor ℤ) (gh:ZGuidedHomotopy l T) :
   @paths (@paths (GH l)
              (invweq (@pr1_GH_weq _ _ l) T) (T,,gh))
             (homotinvweqweq' (irr l) (sec l) (T,,gh))
-            (@pair_path_in2 _ (ZGuidedHomotopy l) 
-                            _ (sec l T) gh 
+            (@pair_path_in2 _ (ZGuidedHomotopy l)
+                            _ (sec l T) gh
                             (irr l T (sec l T) gh)).
 Proof. reflexivity.             (* don't change the proof *)
 Defined.
@@ -95,21 +95,21 @@ Definition pr12_pair_path_in2 {Y} {y:Y} (l:y = y) (T:Torsor ℤ)
 Proof. intros. destruct w. reflexivity. Defined.
 
 Definition pr1_GH_weq_compute {Y} {y:Y} (l:y = y) :
-  let T0 := trivialTorsor ℤ in 
-  let t0 := 0 : T0 in 
+  let T0 := trivialTorsor ℤ in
+  let t0 := 0 : T0 in
     @paths (y = y)
               (ap pr12_GH (homotinvweqweq' (irr l) (sec l) (makeGH1 l T0 t0)))
               (idpath y).
 Proof. intros.
        unfold makeGH1,makeGH,GHpair.
        refine (ap (ap pr12_GH)
-                  (homotinvweqweq_GH_comp 
+                  (homotinvweqweq_GH_comp
                      T0
                      (makeGuidedHomotopy (fun _ : T0 => y)
                                          (confun T0 l) t0 (idpath y)))
                   @ _).
-       refine (pr12_pair_path_in2 
-                 l T0 
+       refine (pr12_pair_path_in2
+                 l T0
                  (irr l T0 (sec l T0)
                       (makeGuidedHomotopy (fun _ : T0 => y) (confun T0 l) t0 (idpath y)))
                  @ _).
@@ -124,19 +124,19 @@ Proof. intros.
 (** ** Various paths in GH *)
 
 Definition makeGH_localPath {Y} {y:Y} (l:y=y) (T:Torsor ℤ) {t t':T} (r:t = t')
-           {y'} {h h':y' = y} (q:h = h') 
+           {y'} {h h':y' = y} (q:h = h')
   : makeGH l T t h = makeGH l T t' h'.
-Proof. intros. destruct q, r. reflexivity. 
+Proof. intros. destruct q, r. reflexivity.
 (* compare with [makeGuidedHomotopy_localPath] *)
 Defined.
 
 Definition makeGH_localPath_comp1 {Y} {y:Y} (l:y = y) (T:Torsor ℤ) {t t':T} (r:t = t')
-           {y'} {h h':y' = y} (q:h = h') : 
+           {y'} {h h':y' = y} (q:h = h') :
   ap pr1_GH (makeGH_localPath l T r q) = idpath T.
 Proof. intros. destruct q,r. reflexivity. Defined.
 
 Definition makeGH_localPath_comp2 {Y} {y:Y} (l:y = y) (T:Torsor ℤ) {t t':T} (r:t = t')
-           {y'} {h h':y' = y} (q:h = h') : 
+           {y'} {h h':y' = y} (q:h = h') :
   ap pr12_GH (makeGH_localPath l T r q) = idpath y'.
 Proof. intros. destruct q,r. reflexivity. Defined.
 
@@ -159,7 +159,7 @@ Proof. intros. destruct p. reflexivity. Defined.
 Definition makeGH_horizontalPath {Y} {y:Y} (l:y = y) {T T':Torsor ℤ} (q:T = T')
            (t:T) {y'} (h:y' = y)
   : makeGH l T t h = makeGH l T' (castTorsor q t) h.
-Proof. intros. destruct q. reflexivity. 
+Proof. intros. destruct q. reflexivity.
 (* compare with [makeGuidedHomotopy_horizontalPath] *)
 Defined.
 
@@ -177,7 +177,7 @@ Definition makeGH_transPath {Y} {y:Y} (l:y = y) {T:Torsor ℤ} (t:T) {y'} (h:y' 
   : makeGH l T t h = makeGH l T (one+t) (h@l).
 Proof. intros. apply GH_path3.
        (* copied from the proof of [makeGuidedHomotopy_transPath] *)
-       exact (ℤTorsorRecursion_transition_inv 
+       exact (ℤTorsorRecursion_transition_inv
                 _ (fun t => weq_pathscomp0r y' l) _ _). Defined.
 
 Definition makeGH_transPath_comp1 {Y} {y:Y} (l:y = y) {T:Torsor ℤ} (t:T) {y'} (h:y' = y)
@@ -188,8 +188,8 @@ Definition makeGH_transPath_comp2 {Y} {y:Y} (l:y = y) {T:Torsor ℤ} (t:T) {y'} 
   : ap pr12_GH (makeGH_transPath l t h) = idpath y'.
 Proof. intros. exact (GH_path3_comp2 l _). Defined.
 
-Definition makeGH_diagonalLoop {Y} {y:Y} (l:y = y) {T:Torsor ℤ} (t:T) 
-           (q:T = T) (r:castTorsor q t = one + t) : 
+Definition makeGH_diagonalLoop {Y} {y:Y} (l:y = y) {T:Torsor ℤ} (t:T)
+           (q:T = T) (r:castTorsor q t = one + t) :
   makeGH1 l T t = makeGH1 l T t.
 Proof. intros.
        assert (p2 := makeGH_transPath l t (idpath y)).
@@ -200,8 +200,8 @@ Proof. intros.
        assert (p := p2 @ p0 @ !ph @ p1 @ pv); clear p2 p0 ph p1 pv.
        exact p. Defined.
 
-Definition makeGH_diagonalLoop_comp1 {Y} {y:Y} (l:y = y) {T:Torsor ℤ} (t:T) 
-           (q:T = T) (r:castTorsor q t = one + t) : 
+Definition makeGH_diagonalLoop_comp1 {Y} {y:Y} (l:y = y) {T:Torsor ℤ} (t:T)
+           (q:T = T) (r:castTorsor q t = one + t) :
   ap pr1_GH (makeGH_diagonalLoop l t q r) = !q.
 Proof. intros. unfold makeGH_diagonalLoop.
        refine (maponpaths_naturality (makeGH_transPath_comp1 _ _ _) _).
@@ -213,8 +213,8 @@ Proof. intros. unfold makeGH_diagonalLoop.
        exact (makeGH_verticalPath_comp1 _ _ _ _).
 Defined.
 
-Definition makeGH_diagonalLoop_comp2 {Y} {y:Y} (l:y = y) {T:Torsor ℤ} (t:T) 
-           (q:T = T) (r:castTorsor q t = one + t) : 
+Definition makeGH_diagonalLoop_comp2 {Y} {y:Y} (l:y = y) {T:Torsor ℤ} (t:T)
+           (q:T = T) (r:castTorsor q t = one + t) :
   ap pr12_GH (makeGH_diagonalLoop l t q r) = l.
 Proof. intros. unfold makeGH_diagonalLoop.
        refine (maponpaths_naturality (makeGH_transPath_comp2 _ _ _) _).
@@ -231,29 +231,29 @@ Defined.
 Definition circle_map {Y} {y:Y} (l:y = y) : circle -> Y.
 Proof. intros ? ? ?. exact (funcomp (invmap (@pr1_GH_weq _ _ l)) pr12_GH). Defined.
 
-Definition circle_map_check_values {Y} {y:Y} (l:y = y) : 
+Definition circle_map_check_values {Y} {y:Y} (l:y = y) :
   circle_map l (basepoint circle) = y.
 Proof. reflexivity.              (* don't change the proof *)
 (** This proof works because the trivial torsor has an
     actual point that provides the accompanying proof of nonemptiness. *)
 Defined.
 
-Definition circle_map_check_paths {Y} {y:Y} (l:y = y) : 
+Definition circle_map_check_paths {Y} {y:Y} (l:y = y) :
   ap (circle_map l) circle_loop = l.
 Proof. intros. assert (p := pr1_GH_weq_compute l).
-       refine (_ @ loop_correspondence' (irr l) (sec l) pr12_GH 
+       refine (_ @ loop_correspondence' (irr l) (sec l) pr12_GH
                       (makeGH_diagonalLoop_comp1 l _ _ (loop_compute 0))
                       (makeGH_diagonalLoop_comp2 l _ _ (loop_compute 0)) @ _).
        { intermediate_path (ap (circle_map l) circle_loop @ idpath y).
          { apply pathsinv0. apply pathscomp0rid. }
          { apply pathsinv0. rewrite pathsinv0inv0.
            exact (ap (fun r => ap (circle_map l) circle_loop @ r) p). } }
-       { exact (ap (fun r => r @ l) p). } Defined. 
+       { exact (ap (fun r => r @ l) p). } Defined.
 
 (** *** The induction principle (dependent functions) *)
 
 
-Definition circle_map' {Y:circle->Type} {y:Y(basepoint circle)} 
+Definition circle_map' {Y:circle->Type} {y:Y(basepoint circle)}
            (l:circle_loop#y = y) : ∀ c:circle, Y c.
 Proof. (** (not proved yet) *)
 Abort.
@@ -268,17 +268,16 @@ Lemma circle_map_check_paths'
       {Y} (f:circle->Y) :
   circle_map (ap f circle_loop) = f .
 Proof. intros. apply funextsec; intro T. generalize T; clear T.
-       refine (circle_map' _ _ _).
+       unshelve refine (circle_map' _ _ _).
        { reflexivity. }
        { set (y := f (basepoint circle)). set (l := ap f circle_loop).
          set (P := fun T : underlyingType circle => circle_map _ T = f T).
          apply transport_fun_path. rewrite pathscomp0rid.
          change (idpath y @ ap f circle_loop) with (ap f circle_loop).
-         exact (! circle_map_check_paths l). } Defined.         
+         exact (! circle_map_check_paths l). } Defined.
 
 (*
 Local Variables:
 compile-command: "make -C ../.. UniMath/Ktheory/Circle.vo"
 End:
 *)
-

--- a/UniMath/Ktheory/Equivalences.v
+++ b/UniMath/Ktheory/Equivalences.v
@@ -45,7 +45,7 @@ Proof. intros ? ? w.
        exists f. intro y.
        exists (g y,,p y).
        intros xe.
-       refine (hfibertriangle2 _ _ _ _ _).
+       unshelve refine (hfibertriangle2 _ _ _ _ _).
        - exact (! (q (pr1 xe)) @ maponpaths g (pr2 xe)).
        - induction xe as [x e]; simpl. induction e; simpl.
          rewrite pathscomp0rid.
@@ -82,7 +82,7 @@ Proof.
   apply funextsec; intros x.
   try reflexivity.
 Abort.
-                         
+
 
 (* another proof *)
 Definition weq_to_Equivalence' X Y : X ≃ Y -> Equivalence X Y.
@@ -93,21 +93,21 @@ Definition weq_to_Equivalence' X Y : X ≃ Y -> Equivalence X Y.
   simpl in p.
   set (L := fun x => pr2 (r (f x)) (hfiberpair f x (idpath (f x)))).
   set (q := fun x => ap pr1 (L x)).
-  set (q' := fun x => !q x).  
-  exact (makeEquivalence X Y f g p q' 
-             (fun x => 
+  set (q' := fun x => !q x).
+  exact (makeEquivalence X Y f g p q'
+             (fun x =>
                  ! transportf_fun_idpath x (pr1 (pr1 (r (f x)))) (q x) (idpath (f x))
                  @ (fiber_paths (L x)))).
 Defined.
 
 Definition path_inv_rotate_lr {X} {a b c:X} (r:a = b) (p:b = c) (q:a = c) :
   q = r @ p -> q @ !p = r.
-Proof. intros ? ? ? ? ? ? ? e. destruct p. destruct q. rewrite pathscomp0rid in e. 
+Proof. intros ? ? ? ? ? ? ? e. destruct p. destruct q. rewrite pathscomp0rid in e.
        exact e. Defined.
 
 Definition path_inv_rotate_rr {X} {a b c:X} (r:a = b) (p:b = c) (q:a = c) :
   r @ p = q -> r = q @ !p.
-Proof. intros ? ? ? ? ? ? ? e. destruct p. destruct q. rewrite pathscomp0rid in e. 
+Proof. intros ? ? ? ? ? ? ? e. destruct p. destruct q. rewrite pathscomp0rid in e.
        exact e. Defined.
 
 Definition path_inv_rotate_ll {X} {a b c:X} (p:a = b) (r:b = c) (q:a = c) :
@@ -126,7 +126,7 @@ Proof. intros ? ? ? ? ? e. destruct q.
        intermediate_path (p @ idpath x).
        { apply pathsinv0. apply pathscomp0rid. } exact e. Defined.
 
-Definition maponpaths_fun_fun_natl {X Y Z} {g g':X->Y} {f f':Y->Z} 
+Definition maponpaths_fun_fun_natl {X Y Z} {g g':X->Y} {f f':Y->Z}
            (q:homot g g') (p:homot f f') x :
   ap f (q x) @ p (g' x) = p (g x) @ ap f' (q x).
 Proof. intros. destruct (q x). simpl. rewrite pathscomp0rid. reflexivity. Defined.
@@ -149,7 +149,7 @@ Lemma other_adjoint {X Y} (f : X -> Y) (g : Y -> X)
       (q : ∀ x : X, g (f x) = x)
       (h : ∀ x : X, ap f (q x) = p (f x)) :
  ∀ y : Y, ap g (p y) = q (g y).
-Proof. intros. apply pathsinv0. 
+Proof. intros. apply pathsinv0.
        intermediate_path (
             !(ap g (p (f (g y))))
             @' ap g (p (f (g y)))
@@ -188,7 +188,7 @@ Proof. intros. apply pathsinv0.
             @' !(ap g (p (f (g y))))
             @' q (g (f (g y)))
             @' q (g y)).
-       { maponpaths_pre_post_cat. 
+       { maponpaths_pre_post_cat.
          apply path_inv_rotate_lr. rewrite <- path_assoc.
          apply path_inv_rotate_rl. apply pathsinv0.
          rewrite <- (maponpathscomp f g). set (y' := f (g y)).
@@ -232,7 +232,7 @@ Proof. intros. apply pathsinv0.
             @' !(ap g (p (f (g y))))
             @' q (g (f (g y)))
             @' q (g y)).
-       { maponpaths_pre_post_cat. rewrite <- (maponpathscomp g f). 
+       { maponpaths_pre_post_cat. rewrite <- (maponpathscomp g f).
          apply (ap (ap g)). generalize (f (g y)); clear y; intro y.
          assert (r := maponpaths_fun_fun_natl p p y); simpl in r.
          assert (s := maponpathsidfun (p y)); unfold idfun in s.
@@ -254,7 +254,7 @@ Proof. intros. apply pathsinv0.
             @' ap g (p (f (g (f (g y)))))
             @' q (g (f (g y)))
             @' q (g y)).
-       { maponpaths_pre_post_cat. repeat rewrite <- path_assoc. 
+       { maponpaths_pre_post_cat. repeat rewrite <- path_assoc.
          rewrite pathsinv0r. rewrite pathscomp0rid. reflexivity. }
        intermediate_path (
             ap g ((!p y) @' ap f (!q (g y)))
@@ -279,7 +279,7 @@ Proof. intros. apply pathsinv0.
          unfold funcomp in r; simpl in r. repeat rewrite path_assoc.
          rewrite r. maponpaths_pre_post_cat. clear r.
          assert (r := ! maponpaths_fun_fun_fun_natl p g q y); simpl in r.
-         rewrite maponpathsidfun in r. rewrite (maponpathscomp f). 
+         rewrite maponpathsidfun in r. rewrite (maponpathscomp f).
          rewrite (maponpathscomp g). rewrite (maponpathscomp g) in r.
          exact r. }
        intermediate_path (
@@ -296,7 +296,7 @@ Proof. intros. apply pathsinv0.
                   @' p (f (g (f (g y)))))
             @' q (g (f (g y)))
             @' q (g y)).
-       { maponpaths_pre_post_cat. rewrite <- maponpathscomp0. apply (ap (ap g)). 
+       { maponpaths_pre_post_cat. rewrite <- maponpathscomp0. apply (ap (ap g)).
          reflexivity. }
        intermediate_path (
             !(q (g y))
@@ -329,17 +329,17 @@ Proof. intros. apply pathsinv0.
             @' ap (funcomp f g) (!q (g y))
             @' q (g (f (g y)))
             @' q (g y)).
-       { maponpaths_pre_post_cat. rewrite <- (maponpathscomp f g). 
+       { maponpaths_pre_post_cat. rewrite <- (maponpathscomp f g).
          reflexivity. }
        intermediate_path ((!q (g y)) @' q (g y) @' (!q (g y)) @' q (g y)).
-       { maponpaths_pre_post_cat. rewrite <- (maponpathscomp f g). 
+       { maponpaths_pre_post_cat. rewrite <- (maponpathscomp f g).
          apply path_inv_rotate_ll. repeat rewrite path_assoc.
-         apply path_inv_rotate_rr. 
+         apply path_inv_rotate_rr.
          assert (r := ! maponpaths_fun_fun_natl q q (g y)); simpl in r.
          rewrite maponpathsidfun in r. rewrite (maponpathscomp f g).
          exact r. }
        rewrite pathsinv0l. simpl. rewrite pathsinv0l. reflexivity. Qed.
 
 Definition inverseEquivalence {X Y} : Equivalence X Y -> Equivalence Y X.
-Proof. intros ? ? [f [g [p [q h]]]]. refine (makeEquivalence Y X g f q p _).
+Proof. intros ? ? [f [g [p [q h]]]]. unshelve refine (makeEquivalence Y X g f q p _).
        intro y. apply other_adjoint. assumption. Defined.

--- a/UniMath/Ktheory/Group.v
+++ b/UniMath/Ktheory/Group.v
@@ -269,13 +269,13 @@ Module Presentation.
   Definition universalMarkedGroup0 {X I} (R:I->reln X) : gr.
     intros.
     { exists (univ_setwithbinop R).
-      { refine (_,,_).
+      { unshelve refine (_,,_).
         { split.
           { exact (isassoc_univ_binop R). }
           { exists (setquotpr _ word_unit). split.
             { exact (is_left_unit_univ_binop R). }
             { exact (is_right_unit_univ_binop R). } } }
-        { refine (_,,_).
+        { unshelve refine (_,,_).
           { exact (univ_inverse R). }
           { split.
             { exact (is_left_inverse_univ_binop R). }
@@ -312,10 +312,10 @@ Module Presentation.
          { intermediate_path (unel M). exact (Monoid.unitproperty f). exact (!Monoid.unitproperty g). }
          { apply p. }
          (* compare duplication with the proof of MarkedGroupMap_compat *)
-         { refine (monoidfuninvtoinv f (setquotpr (smallestAdequateRelation R) w)
+         { unshelve refine (monoidfuninvtoinv f (setquotpr (smallestAdequateRelation R) w)
              @ _ @ ! monoidfuninvtoinv g (setquotpr (smallestAdequateRelation R) w)).
            apply (ap (grinv M)). apply agreement_on_gens0. assumption. }
-         { refine (
+         { unshelve refine (
                Monoid.multproperty f (setquotpr (smallestAdequateRelation R) v)
                    (setquotpr (smallestAdequateRelation R) w)
              @ _ @ !

--- a/UniMath/Ktheory/GroupAction.v
+++ b/UniMath/Ktheory/GroupAction.v
@@ -32,7 +32,7 @@ Proof. intros. apply (invmaponpathsincl _ (isinclpr1weq _ _)).
 
 Definition weqcompweql {X Y Z} (f:X ≃ Y) :
   isweq (fun g:Y ≃ Z => weqcomp f g).
-Proof. intros. refine (gradth _ _ _ _).
+Proof. intros. unshelve refine (gradth _ _ _ _).
        { intro h. exact (weqcomp (invweq f) h). }
        { intro g. simpl. rewrite <- weqcompassoc. rewrite weqcompinvl.
          apply weqcompidl. }
@@ -41,7 +41,7 @@ Proof. intros. refine (gradth _ _ _ _).
 
 Definition weqcompweqr {X Y Z} (g:Y ≃ Z) :
   isweq (fun f:X ≃ Y => weqcomp f g).
-Proof. intros. refine (gradth _ _ _ _).
+Proof. intros. unshelve refine (gradth _ _ _ _).
        { intro h. exact (weqcomp h (invweq g)). }
        { intro f. simpl. rewrite weqcompassoc. rewrite weqcompinvr.
          apply weqcompidr. }
@@ -150,10 +150,10 @@ Definition is_equivariant_identity {G:gr} {X Y:Action G}
 Proof. intros ? [X [Xm Xu Xa]] [Y [Ym Yu Ya]] ? .
        (* should just apply uahp at this point, as in Poset_univalence_prelim! *)
        simpl in p. destruct p; simpl. unfold transportf; simpl. unfold idfun; simpl.
-       refine (weqpair _ _).
+       unshelve refine (weqpair _ _).
        { intros p g x. simpl in x. simpl.
          exact (apevalat x (apevalat g (ap act_mult p))). }
-       refine (gradth _ _ _ _).
+       unshelve refine (gradth _ _ _ _).
        { unfold cast; simpl.
          intro i.
          assert (p:Xm=Ym).
@@ -225,10 +225,10 @@ Proof. intros ? ? ? ? x. exact (path_to_ActionIso e x). Defined.
 Definition Action_univalence_prelim {G:gr} {X Y:Action G} :
   weq (X = Y) (ActionIso X Y).
 Proof. intros.
-       refine (weqcomp (total2_paths_equiv (ActionStructure G) X Y) _).
-       refine (weqbandf _ _ _ _).
+       unshelve refine (weqcomp (total2_paths_equiv (ActionStructure G) X Y) _).
+       unshelve refine (weqbandf _ _ _ _).
        { apply hSet_univalence. }
-       simpl. intro p. refine (weqcomp (is_equivariant_identity p) _).
+       simpl. intro p. unshelve refine (weqcomp (is_equivariant_identity p) _).
        exact (eqweqmap (ap is_equivariant (pr1_eqweqmap (ap set_to_type p)))).
 Defined.
 
@@ -389,7 +389,7 @@ Lemma pr1weq_injectivity {X Y} (f g:X ≃ Y) : weq (f = g) (pr1weq f = pr1weq g)
 Proof. intros. apply weqonpathsincl. apply isinclpr1weq.  Defined.
 
 Definition autos (G:gr) : G ≃ (ActionIso (trivialTorsor G) (trivialTorsor G)).
-Proof. intros. exists (trivialTorsorAuto G). refine (gradth _ _ _ _).
+Proof. intros. exists (trivialTorsorAuto G). unshelve refine (gradth _ _ _ _).
        { intro f. exact (f (unel G)). } { intro g; simpl. exact (lunax _ g). }
        { intro f; simpl. apply (invweq (underlyingIso_injectivity _ _)); simpl.
          apply (invweq (pr1weq_injectivity _ _)). apply funextsec; intro g.
@@ -408,9 +408,9 @@ Defined.
 
 Lemma trivialTorsorAuto_unit (G:gr) :
   trivialTorsorAuto G (unel _) = idActionIso _.
-Proof. intros. refine (subtypeEquality _ _).
+Proof. intros. unshelve refine (subtypeEquality _ _).
        { intro k. apply is_equivariant_isaprop. }
-       { refine (subtypeEquality _ _).
+       { unshelve refine (subtypeEquality _ _).
          { intro; apply isapropisweq. }
          { apply funextsec; intro x; simpl. exact (runax G x). } }
 Defined.
@@ -418,9 +418,9 @@ Defined.
 Lemma trivialTorsorAuto_mult (G:gr) (g h:G) :
   composeActionIso (trivialTorsorAuto G g) (trivialTorsorAuto G h)
   = (trivialTorsorAuto G (op g h)).
-Proof. intros. refine (subtypeEquality _ _).
+Proof. intros. unshelve refine (subtypeEquality _ _).
        { intro; apply is_equivariant_isaprop. }
-       { refine (subtypeEquality _ _).
+       { unshelve refine (subtypeEquality _ _).
          { intro; apply isapropisweq. }
          { apply funextsec; intro x; simpl. exact (assocax _ x g h). } }
 Defined.
@@ -428,7 +428,7 @@ Defined.
 (** ** Applications of univalence *)
 
 Definition Torsor_univalence {G:gr} {X Y:Torsor G} : weq (X = Y) (ActionIso X Y).
-Proof. intros. refine (weqcomp underlyingAction_injectivity _).
+Proof. intros. unshelve refine (weqcomp underlyingAction_injectivity _).
        apply Action_univalence. Defined.
 
 Definition Torsor_univalence_comp {G:gr} {X Y:Torsor G} (p:X = Y) :
@@ -457,8 +457,8 @@ Proof. intros ? [X x]. exists (triviality_isomorphism X x).
 Definition PointedTorsor_univalence {G:gr} {X Y:PointedTorsor G} :
   weq (X = Y) (PointedActionIso X Y).
 Proof. intros.
-       refine (weqcomp (total2_paths_equiv _ X Y) _).
-       refine (weqbandf _ _ _ _).
+       unshelve refine (weqcomp (total2_paths_equiv _ X Y) _).
+       unshelve refine (weqbandf _ _ _ _).
        { intros.
          exact (weqcomp (weqonpathsincl underlyingAction underlyingAction_incl X Y)
                         Action_univalence). }
@@ -483,7 +483,7 @@ Proof. intros. exists (pointedTrivialTorsor G). intros [X x].
 
 Theorem loopsBG (G:gr) : weq (Ω (B G)) G.
 Proof. intros. apply invweq.
-       refine (weqcomp _ (invweq Torsor_univalence)).
+       unshelve refine (weqcomp _ (invweq Torsor_univalence)).
        apply autos. Defined.
 
 Definition loopsBG_comp (G:gr) (g h:G)

--- a/UniMath/Ktheory/Integers.v
+++ b/UniMath/Ktheory/Integers.v
@@ -97,7 +97,7 @@ Defined.
 Definition negpos_weq := weqpair _ negpos' : weq (total2 hz_normal_form) ℤ.
 
 Definition negpos : weq (coprod nat nat) ℤ. (* ℤ = (-inf,-1) + (0,inf) *)
-Proof. refine (weqpair _ (gradth _ _ _ _)).
+Proof. unshelve refine (weqpair _ (gradth _ _ _ _)).
        { intros [n'|n].
          { exact (natnattohz 0 (S n')). } { exact (natnattohz n 0). } }
        { intro i. destruct (hz_to_normal_form i) as [[n p]|[m q]].

--- a/UniMath/Ktheory/Monoid.v
+++ b/UniMath/Ktheory/Monoid.v
@@ -76,22 +76,22 @@ Module Presentation'.
   Definition smallestAdequateRelation {X I} (R:I->reln X) : AdequateRelation R.
   Proof.
     intros.
-    refine (_,,_).
-    { refine (_,,_).
+    unshelve refine (_,,_).
+    { unshelve refine (_,,_).
       { intros v w.
         exists (∀ r, isAdequateRelation R r -> r v w).
         apply impred; intros r; apply impred_prop. }
-      { refine (_,,_).
-        { refine (_,,_).
+      { unshelve refine (_,,_).
+        { unshelve refine (_,,_).
           { intros u v w uv vw r ad; simpl in uv, vw.
             apply (eqreltrans r u v w).
             { apply uv. exact ad. }
             { apply vw. exact ad. }}
           { intros w r ad. apply eqrelrefl. } }
         { intros v w vw r ad. apply eqrelsymm. apply vw. exact ad. }}}
-    { refine (_,,_); simpl.
+    { unshelve refine (_,,_); simpl.
       { intros i r ad. apply (base ad i). }
-      { refine (_,,_).
+      { unshelve refine (_,,_).
         { intros u v w min r ad. apply (left_compat  ad). apply min. exact ad. }
         { intros u v w min r ad. apply (right_compat ad). apply min. exact ad. }}}
   Defined.
@@ -103,7 +103,7 @@ Module Presentation'.
   Definition univ_unit {X I} (R:I->reln X) := setquotpr _ word_unit : univ_set R.
 
   Definition univ_binop {X I} (R:I->reln X) : binop (univ_set R).
-    intros. refine (setquotfun2 _ _ word_op _).
+    intros. unshelve refine (setquotfun2 _ _ word_op _).
     induction (smallestAdequateRelation R) as [r ad]; simpl.
     intros v v' w w' vv' ww'.
     apply (eqreltrans _ _ (word_op v w') _ (left_compat ad _ _ _ ww') (right_compat ad _ _ _ vv')).
@@ -259,7 +259,7 @@ Module Presentation.
   Defined.
   Lemma adequacy {X I} (R:I->reln X) :
     AdequateRelation R (smallestAdequateRelation0 R).
-  Proof. intros. refine (make_AdequateRelation R _ _ _ _ _ _ _ _ _ _).
+  Proof. intros. unshelve refine (make_AdequateRelation R _ _ _ _ _ _ _ _ _ _).
          { intros ? r ra. apply base. exact ra. }
          { intros ? r ra. apply (reflex R). exact ra. }
          { intros ? ? p r ra. apply (symm R). exact ra. exact (p r ra). }
@@ -288,14 +288,14 @@ Module Presentation.
   (** *** the multiplication on on it *)
 
   Definition univ_binop {X I} (R:I->reln X) : binop (universalMarkedPreMonoid0 R).
-    intros. refine (QuotientSet.setquotfun2 word_op _). apply op2_compatibility. Defined.
+    intros. unshelve refine (QuotientSet.setquotfun2 word_op _). apply op2_compatibility. Defined.
   Definition univ_setwithbinop {X I} (R:I->reln X) : setwithbinop
              := setwithbinoppair (universalMarkedPreMonoid0 R) (univ_binop R).
 
   (** *** the universal pre-monoid *)
 
   Definition universalMarkedPreMonoid {X I} (R:I->reln X) : MarkedPreMonoid X.
-    intros. refine (make_preMonoid X (universalMarkedPreMonoid0 R) _ _ _).
+    intros. unshelve refine (make_preMonoid X (universalMarkedPreMonoid0 R) _ _ _).
     { exact (setquotpr _ word_unit). }
     { exact (fun x => setquotpr _ (word_gen x)). }
     { exact (univ_binop _). } Defined.
@@ -359,7 +359,7 @@ Module Presentation.
     fun v w  => eqset (evalwordMM M v) (evalwordMM M w).
   Lemma abelian_group_adequacy {X I} (R:I->reln X) (M:MarkedMonoid R) :
     AdequateRelation R (MarkedMonoid_to_hrel M).
-  Proof. intros. refine (make_AdequateRelation R _ _ _ _ _ _ _ _ _ _).
+  Proof. intros. unshelve refine (make_AdequateRelation R _ _ _ _ _ _ _ _ _ _).
          { exact (fun i => m_reln R M i). } { reflexivity. }
          { intros ? ?. exact pathsinv0. } { intros ? ? ?. exact pathscomp0. }
          { intros ? ? ? p. simpl in p; simpl.
@@ -438,7 +438,7 @@ Defined.
          { intermediate_path (unel M). exact (unitproperty f). exact (!unitproperty g). }
          { apply p. }
          (* compare duplication with the proof of MarkedMonoidMap_compat *)
-         { refine (
+         { unshelve refine (
                multproperty f (setquotpr (smallestAdequateRelation R) v)
                    (setquotpr (smallestAdequateRelation R) w)
              @ _ @ !
@@ -522,7 +522,7 @@ Module Product.
       [isdeceq I]. *)
 
   Proof. intros ? ? ? decide_equality xi. apply hinhpr.
-    refine (_,,_).
+    unshelve refine (_,,_).
     { intro j. destruct (decide_equality i j) as [p|_].
       { exact (transportf X p xi). }
       { exact (unel (X j)). } }

--- a/UniMath/Ktheory/MoreEquivalences.v
+++ b/UniMath/Ktheory/MoreEquivalences.v
@@ -91,7 +91,7 @@ Definition weqpr1_irr_sec {X} {P:X->Type}
 Proof. intros.
        set (isc := fun x => iscontraprop1 (invproofirrelevance _ (irr x)) (sec x)).
        apply Equivalence_to_weq.
-       refine (makeEquivalence _ _ _ _ _ _ _).
+       unshelve refine (makeEquivalence _ _ _ _ _ _ _).
        { exact pr1. } { intro x. exact (x,,sec x). } { intro x. reflexivity. }
        { intros [x p]. simpl. apply pair_path_in2. apply irr. }
        { intros [x p]. simpl. apply pair_path_in2_comp1. } Defined.
@@ -102,7 +102,7 @@ Definition invweqpr1_irr_sec {X} {P:X->Type}
 Proof. intros.
        set (isc := fun x => iscontraprop1 (invproofirrelevance _ (irr x)) (sec x)).
        apply Equivalence_to_weq.
-       refine (makeEquivalence _ _ _ _ _ _ _).
+       unshelve refine (makeEquivalence _ _ _ _ _ _ _).
        { intro x. exact (x,,sec x). } { exact pr1. }
        { intros [x p]. simpl. apply pair_path_in2. apply irr. }
        { intro x. reflexivity. }

--- a/UniMath/Ktheory/Nat.v
+++ b/UniMath/Ktheory/Nat.v
@@ -18,14 +18,14 @@ Module Uniqueness.
         (f:∀ n, P n) :
     weq (∀ n, f n = nat_rect P p0 IH n)
         (f 0=p0 × ∀ n, f(S n)=IH n (f n)).
-  Proof. intros. refine (_,,gradth _ _ _ _).
+  Proof. intros. unshelve refine (_,,gradth _ _ _ _).
          { intros h. split.
            { exact (h 0). } { intros. exact (h (S n) @ ap (IH n) (! h n)). } }
          { intros [h0 h'] ?. induction n as [|n'].
            { exact h0. } { exact (h' n' @ ap (IH n') IHn'). } }
          { simpl. intros h. apply funextsec; intros n; simpl. induction n.
            { simpl. reflexivity. }
-           { simpl. rewrite <- path_assoc. refine (_ @ pathscomp0rid _).
+           { simpl. rewrite <- path_assoc. unshelve refine (_ @ pathscomp0rid _).
              rewrite <- maponpathscomp0. rewrite IHn. rewrite pathsinv0l.
              simpl. reflexivity. } }
          { intros [h0 h']. apply pair_path_in2. apply funextsec; intro n; simpl.
@@ -58,7 +58,7 @@ Module Uniqueness.
            (P 0)
            (fun fh => pr1 fh 0)
            p0).
-  Proof. intros. refine (weqpair _ (gradth _ _ _ _)).
+  Proof. intros. unshelve refine (weqpair _ (gradth _ _ _ _)).
          { intros [f [h0 h']]. exact ((f,,h'),,h0). }
          { intros [[f h'] h0]. exact (f,,(h0,,h')). }
          { intros [f [h0 h']]. reflexivity. }
@@ -145,7 +145,7 @@ Module Discern.
   Proof. intros. apply proofirrelevance. apply nat_discern_isaprop. Defined.
 
   Definition helper_D m n : isweq (helper_B m n).
-  Proof. intros. refine (gradth _ (helper_C _ _) _ _).
+  Proof. intros. unshelve refine (gradth _ (helper_C _ _) _ _).
          { intro e. assert(p := ! helper_B _ _ e). destruct p.
            apply proofirrelevancecontr. apply nat_discern_iscontr. }
          { intro e. destruct e. induction m.
@@ -343,7 +343,7 @@ Proof. intros ? ? ? i.
        rewrite minusplusnmm.
        { exact i. }
        { change (m ≤ n).
-         refine (istransnatleh _ i); clear i.
+         unshelve refine (istransnatleh _ i); clear i.
          apply natlehmplusnm. }
 Defined.
 

--- a/UniMath/Ktheory/QuotientSet.v
+++ b/UniMath/Ktheory/QuotientSet.v
@@ -25,7 +25,7 @@ Definition setquotuniv2 {X Y} (RX:hrel X) (RY:hrel Y)
            {Z:hSet} (f:X->Y->Z) (is:iscomprelfun2 RX RY f) :
   setquot RX -> setquot RY -> Z.
 Proof. intros ? ? ? ? ? ? ? x''.
-       refine (setquotuniv RX (funset (setquot RY) Z) _ _ _).
+       unshelve refine (setquotuniv RX (funset (setquot RY) Z) _ _ _).
        { simpl. intro x. apply (setquotuniv RY Z (f x)).
          intros y y' e. unfold iscomprelfun2 in is.
          apply (pr2 is). assumption. }

--- a/UniMath/Ktheory/StandardCategories.v
+++ b/UniMath/Ktheory/StandardCategories.v
@@ -38,7 +38,7 @@ Definition path_pregroupoid (X:UU) : isofhlevel 3 X -> precategory.
      be useful, because in it, each arrow is a path, rather than an
      equivalence class of paths. *)
   intros obj iobj.
-  refine (Precategories.makePrecategory obj (fun x y => x = y)  _ _ _ _ _).
+  unshelve refine (Precategories.makePrecategory obj (fun x y => x = y)  _ _ _ _ _).
   { reflexivity. }
   { intros. exact (f @ g). }
   { reflexivity. }

--- a/UniMath/Ktheory/TerminalObject.v
+++ b/UniMath/Ktheory/TerminalObject.v
@@ -10,7 +10,7 @@ Require UniMath.Ktheory.Sets UniMath.Ktheory.Representation.
 
 Definition unitFunctor_data (C:precategory)
      : functor_data (Precategories.Precategory_obmor C) (Precategories.Precategory_obmor SET).
-  intros. refine (tpair _ _ _).
+  intros. unshelve refine (tpair _ _ _).
   intros. exact Sets.unit. intros. exact (idfun _). Defined.
 Definition unitFunctor (C:precategory) : C ==> SET.
   intros. exists (unitFunctor_data C).

--- a/UniMath/Ktheory/Utilities.v
+++ b/UniMath/Ktheory/Utilities.v
@@ -33,7 +33,7 @@ Lemma isaprop_nullHomotopyTo {X Y} (is:isaset Y) (f:X->Y) (y:Y) :
   isaprop (nullHomotopyTo f y).
 Proof. intros ? ? ? ? ?. apply impred; intros x. apply is. Defined.
 
-Lemma isaprop_NullHomotopyTo_0 {X} {Y} (is:isaset Y) (f:X->Y) : 
+Lemma isaprop_NullHomotopyTo_0 {X} {Y} (is:isaset Y) (f:X->Y) :
   X -> isaprop (NullHomotopyTo f).
 (** The point of X is needed, for when X is empty, then NullHomotopyTo f is
     equivalent to Y. *)
@@ -58,9 +58,9 @@ Lemma iscontr_paths_to {X} (x:X) : iscontr (paths_to x).
 Proof. apply iscontrcoconustot. Defined.
 Lemma iscontr_paths_from {X} (x:X) : iscontr (paths_from x).
 Proof. apply iscontrcoconusfromt. Defined.
-Definition paths_to_prop {X} (x:X) := 
+Definition paths_to_prop {X} (x:X) :=
   hProppair (paths_to x) (isapropifcontr (iscontr_paths_to x)).
-Definition paths_from_prop {X} (x:X) := 
+Definition paths_from_prop {X} (x:X) :=
   hProppair (paths_from x) (isapropifcontr (iscontr_paths_from x)).
 
 (** ** Squashing *)
@@ -76,15 +76,15 @@ Lemma isaprop_NullHomotopyTo {X} {Y} (is:isaset Y) (f:X->Y) :
   ∥ X ∥ -> isaprop (NullHomotopyTo f).
 Proof. intros ? ? ? ?.
        apply factor_through_squash.
-       apply isapropisaprop. 
+       apply isapropisaprop.
        apply isaprop_NullHomotopyTo_0. exact is. Defined.
 
 (** We can get a map from '∥ X ∥' to any type 'Y' provided paths
     are given that allow us to map first into a cone in 'Y'.  *)
 
-Definition cone_squash_map {X Y} (f:X->Y) (y:Y) : 
+Definition cone_squash_map {X Y} (f:X->Y) (y:Y) :
   nullHomotopyTo f y -> ∥ X ∥ -> Y.
-Proof. intros ? ? ? ? e h. 
+Proof. intros ? ? ? ? e h.
        exact (point_from (h (paths_to_prop y) (fun x => f x,,e x))). Defined.
 
 Goal ∀ X Y (y:Y) (f:X->Y) (e:∀ m:X, f m = y),
@@ -92,7 +92,7 @@ Goal ∀ X Y (y:Y) (f:X->Y) (e:∀ m:X, f m = y),
 Proof. reflexivity. Qed.
 
 (** ** Factoring maps through squash *)
- 
+
 Lemma squash_uniqueness {X} (x:X) (h:∥ X ∥) : squash_element x = h.
 Proof. intros. apply propproperty. Qed.
 
@@ -100,12 +100,12 @@ Goal ∀ X Q (i:isaprop Q) (f:X -> Q) (x:X),
    factor_through_squash i f (squash_element x) = f x.
 Proof. reflexivity. Defined.
 
-Lemma factor_dep_through_squash {X} {Q:∥ X ∥->UU} : 
-  (∀ h, isaprop (Q h)) -> 
-  (∀ x, Q(squash_element x)) -> 
+Lemma factor_dep_through_squash {X} {Q:∥ X ∥->UU} :
+  (∀ h, isaprop (Q h)) ->
+  (∀ x, Q(squash_element x)) ->
   (∀ h, Q h).
 Proof.
-  intros ? ? i f ?.  apply (h (hProppair (Q h) (i h))). 
+  intros ? ? i f ?.  apply (h (hProppair (Q h) (i h))).
   intro x. simpl. destruct (squash_uniqueness x h). exact (f x).
 Defined.
 
@@ -113,12 +113,12 @@ Lemma factor_through_squash_hProp {X} : ∀ hQ:hProp, (X -> hQ) -> ∥ X ∥ -> 
 Proof. intros ? [Q i] f h. apply h. assumption. Defined.
 
 Lemma funspace_isaset {X Y} : isaset Y -> isaset (X -> Y).
-Proof. intros ? ? is. apply (impredfun 2). assumption. Defined.    
+Proof. intros ? ? is. apply (impredfun 2). assumption. Defined.
 
 Lemma iscontr_if_inhab_prop {P} : isaprop P -> P -> iscontr P.
 Proof. intros ? i p. exists p. intros p'. apply i. Defined.
 
-Lemma squash_map_uniqueness {X S} (ip : isaset S) (g g' : ∥ X ∥ -> S) : 
+Lemma squash_map_uniqueness {X S} (ip : isaset S) (g g' : ∥ X ∥ -> S) :
   g ∘ squash_element ~ g' ∘ squash_element -> g ~ g'.
 Proof.
   intros ? ? ? ? ? h.
@@ -128,7 +128,7 @@ Proof.
   intro x. apply h.
 Qed.
 
-Lemma squash_map_epi {X S} (ip : isaset S) (g g' : ∥ X ∥ -> S) : 
+Lemma squash_map_epi {X S} (ip : isaset S) (g g' : ∥ X ∥ -> S) :
   g ∘ squash_element = g'∘ squash_element -> g = g'.
 Proof.
   intros ? ? ? ? ? e.
@@ -142,7 +142,7 @@ Notation ap := maponpaths.
 (* see table 3.1 in the coq manual for parsing levels *)
 Notation "f ;; g" := (funcomp f g) (at level 50).
 (* funcomp' is like funcomp, but with the arguments in the other order *)
-Definition funcomp' { X Y Z : UU } ( g : Y -> Z ) ( f : X -> Y ) := fun x : X => g ( f x ) . 
+Definition funcomp' { X Y Z : UU } ( g : Y -> Z ) ( f : X -> Y ) := fun x : X => g ( f x ) .
 Open Scope transport.
 
 (* some jargon reminders: *)
@@ -181,7 +181,7 @@ Proof. intros ? ? ? ? ? e. destruct e. destruct p. reflexivity. Defined.
 Definition cast {T U:Type} : T = U -> T -> U.
 Proof. intros ? ? p t. destruct p. exact t. Defined.
 
-Definition app {X} {P:X->Type} {x x':X} {e e':x = x'} (q:e = e') (p:P x) : 
+Definition app {X} {P:X->Type} {x x':X} {e e':x = x'} (q:e = e') (p:P x) :
    e#p = e'#p.
 Proof. intros. destruct q. reflexivity. Defined.
 
@@ -201,7 +201,7 @@ Proof. intros ? ? ? e. apply pathsinv0_to_right'. rewrite pathscomp0rid.
        exact e. Defined.
 
 Definition loop_power_nat {Y} {y:Y} (l:y = y) (n:nat) : y = y.
-Proof. intros. induction n as [|n p]. 
+Proof. intros. induction n as [|n p].
        { exact (idpath _). } { exact (p@l). } Defined.
 
 Definition pathscomp0_linj {X} {x y z:X} {p:x = y} {q q':y = z} (r:p@q = p@q') : q = q'.
@@ -209,11 +209,11 @@ Proof. intros. destruct p. exact r. Defined.
 
 Definition pathscomp0_rinj {X} {x y z:X} {p p':x = y} {q:y = z} (r:p@q = p'@q) : p = p'.
 Proof. intros. destruct q. exact (! pathscomp0rid p @ r @ pathscomp0rid p').
-Defined.                           
+Defined.
 
 Lemma irrel_paths {X} (irr:∀ x y:X, x = y) {x y:X} (p q:x = y) : p = q.
-Proof. intros. 
-       assert (k : ∀ z:X, ∀ r:x = z, r @ irr z z = irr x z). 
+Proof. intros.
+       assert (k : ∀ z:X, ∀ r:x = z, r @ irr z z = irr x z).
        { intros. destruct r. reflexivity. }
        exact (pathscomp0_rinj (k y p @ !k y q)). Defined.
 
@@ -251,7 +251,7 @@ Proof. intros. destruct p. destruct q. apply idpath. Defined.
 
 (** ** Projections from pair types *)
 
-Definition pair_path_in2_comp1 {X} (P:X->Type) {x:X} {p q:P x} (e:p = q) : 
+Definition pair_path_in2_comp1 {X} (P:X->Type) {x:X} {p q:P x} (e:p = q) :
   ap pr1 (pair_path_in2 P e) = idpath x.
 Proof. intros. destruct e. reflexivity. Defined.
 
@@ -289,14 +289,14 @@ Definition aptwice {X Y Z} (f:X->Y->Z) {a a' b b'} (p:a = a') (q:b = b') : f a b
 
 Definition fromemptysec { X : empty -> UU } (nothing:empty) : X nothing.
 (* compare with [fromempty] in u00 *)
-Proof. intros X H.  destruct H. Defined. 
+Proof. intros X H.  destruct H. Defined.
 
 Definition maponpaths_idpath {X Y} {f:X->Y} {x:X} : ap f (idpath x) = idpath (f x).
 Proof. intros. reflexivity. Defined.
 
 (** ** Transport *)
 
-Definition transport_type_path {X Y:Type} (p:X = Y) (x:X) : 
+Definition transport_type_path {X Y:Type} (p:X = Y) (x:X) :
   transportf (fun T:Type => T) p x = cast p x.
 Proof. intros. destruct p. reflexivity. Defined.
 
@@ -307,7 +307,7 @@ Definition transportfbinv {T} (P:T->Type) {t u:T} (e:t = u) (p:P u) : e#e#'p = p
 Proof. intros. destruct e. reflexivity. Defined.
 
 Definition transport_fun_path {X Y} {f g:X->Y} {x x':X} {p:x = x'} {e:f x = g x} {e':f x' = g x'} :
-  e @ ap g p = ap f p @ e' -> 
+  e @ ap g p = ap f p @ e' ->
   transportf (fun x => f x = g x) p e = e'.
 Proof. intros ? ? ? ? ? ? ? ? ? k. destruct p. rewrite maponpaths_idpath in k. rewrite maponpaths_idpath in k.
        rewrite pathscomp0rid in k. exact k. Defined.
@@ -320,7 +320,7 @@ Definition transportf_pathsinv0' {X} (P:X->UU) {x y:X} (p:x = y) (u:P x) (v:P y)
   p # u = v -> !p # v = u.
 Proof. intros ? ? ? ? ? ? ? e. destruct p, e. reflexivity. Defined.
 
-Lemma transport_idfun {X} (P:X->UU) {x y:X} (p:x = y) (u:P x) : 
+Lemma transport_idfun {X} (P:X->UU) {x y:X} (p:x = y) (u:P x) :
   transportf P p u = transportf (idfun _) (ap P p) u.
 (* same as HoTT.PathGroupoids.transport_idmap_ap *)
 Proof. intros. destruct p. reflexivity. Defined.
@@ -331,36 +331,36 @@ Lemma transport_functions {X} {Y:X->Type} {Z:∀ x (y:Y x), Type}
     transportf (Z x) (toforallpaths _ _ _ p x) (z x).
 Proof. intros. destruct p. reflexivity. Defined.
 
-Definition transport_funapp {T} {X Y:T->Type} 
+Definition transport_funapp {T} {X Y:T->Type}
            (f:∀ t, X t -> Y t) (x:∀ t, X t)
-           {t t':T} (p:t = t') : 
-  transportf _ p ((f t)(x t)) 
+           {t t':T} (p:t = t') :
+  transportf _ p ((f t)(x t))
   = (transportf (fun t => X t -> Y t) p (f t)) (transportf _ p (x t)).
 Proof. intros. destruct p. reflexivity. Defined.
 
 Definition helper_A {T} {Y} (P:T->Y->Type) {y y':Y} (k:∀ t, P t y) (e:y = y') t :
   transportf (fun y => P t y) e (k t)
-  = 
+  =
   (transportf (fun y => ∀ t, P t y) e k) t.
 Proof. intros. destruct e. reflexivity. Defined.
 
 Definition helper_B {T} {Y} (f:T->Y) {y y':Y} (k:∀ t, y = f t) (e:y = y') t :
   transportf (fun y => y = f t) e (k t)
-  = 
+  =
   (transportf (fun y => ∀ t, y = f t) e k) t.
 Proof. intros. exact (helper_A _ k e t). Defined.
 
 Definition transport_invweq {T} {X Y:T->Type} (f:∀ t, weq (X t) (Y t))
-           {t t':T} (p:t = t') : 
+           {t t':T} (p:t = t') :
   transportf (fun t => weq (Y t) (X t)) p (invweq (f t))
-  = 
+  =
   invweq (transportf (fun t => weq (X t) (Y t)) p (f t)).
 Proof. intros. destruct p. reflexivity. Defined.
 
 Definition transport_invmap {T} {X Y:T->Type} (f:∀ t, weq (X t) (Y t))
-           {t t':T} (p:t=t') : 
+           {t t':T} (p:t=t') :
   transportf (fun t => Y t -> X t) p (invmap (f t))
-  = 
+  =
   invmap (transportf (fun t => weq (X t) (Y t)) p (f t)).
 Proof. intros. destruct p. reflexivity. Defined.
 
@@ -394,7 +394,7 @@ Proof. intros. destruct p. reflexivity. Defined.
 
   Definition transportb_pair X (Y:X->Type) (Z:∀ x, Y x->Type)
              x x' (p:x = x')
-             (y':Y x') (z':Z x' y') 
+             (y':Y x') (z':Z x' y')
              (z' : (Z x' y')) :
     transportb (fun x => total2 (Z x)) p (tpair (Z x') y' z')
     =
@@ -407,7 +407,7 @@ Lemma isaprop_wma_inhab X : (X -> isaprop X) -> isaprop X.
 Proof. intros ? f. apply invproofirrelevance. intros x y. apply (f x). Qed.
 
 Lemma isaprop_wma_inhab' X : (X -> iscontr X) -> isaprop X.
-Proof. intros ? f. apply isaprop_wma_inhab. intro x. apply isapropifcontr. 
+Proof. intros ? f. apply isaprop_wma_inhab. intro x. apply isapropifcontr.
        apply (f x). Qed.
 
 Goal ∀ (X:hSet) (x y:X) (p q:x = y), p = q.
@@ -438,7 +438,7 @@ Require Import UniMath.Foundations.Basics.UnivalenceAxiom.
 Definition pr1_eqweqmap { X Y } ( e: X = Y ) : cast e = pr1 (eqweqmap e).
 Proof. intros. destruct e. reflexivity. Defined.
 
-Definition pr1_eqweqmap2 { X Y } ( e: X = Y ) : 
+Definition pr1_eqweqmap2 { X Y } ( e: X = Y ) :
   pr1 (eqweqmap e) = transportf (fun T:Type => T) e.
 Proof. intros. destruct e. reflexivity. Defined.
 
@@ -481,8 +481,8 @@ Proof. intros ? ? ? ? ? p. exact (ap (invweq f) p @ homotinvweqweq f x). Defined
 Definition switch_weq' {X Y} (f:X ≃ Y) {x y} : invweq f y = x -> y = f x.
 Proof. intros ? ? ? ? ? p. exact (! homotweqinvweq f y @ ap f p). Defined.
 
-Definition weqbandfrel {X Y T} 
-           (e:Y->T) (t:T) (f : X ≃ Y) 
+Definition weqbandfrel {X Y T}
+           (e:Y->T) (t:T) (f : X ≃ Y)
            (P:X -> Type) (Q: Y -> Type)
            (g:∀ x:X, weq (P x) (Q (f x))) :
   weq (hfiber (fun xp:total2 P => e(f(pr1 xp))) t)
@@ -490,17 +490,17 @@ Definition weqbandfrel {X Y T}
 Proof. intros. refine (weqbandf (weqbandf f _ _ g) _ _ _).
        intros [x p]. simpl. apply idweq. Defined.
 
-Definition weq_over_sections {S T} (w:S ≃ T) 
+Definition weq_over_sections {S T} (w:S ≃ T)
            {s0:S} {t0:T} (k:w s0 = t0)
-           {P:T->Type} 
+           {P:T->Type}
            (p0:P t0) (pw0:P(w s0)) (l:k#pw0 = p0)
-           (H:Section P -> Type) 
+           (H:Section P -> Type)
            (J:Section (funcomp w P) -> Type)
            (g:∀ f:Section P, weq (H f) (J (maponsec1 P w f))) :
   weq (hfiber (fun fh:total2 H => pr1 fh t0) p0 )
       (hfiber (fun fh:total2 J => pr1 fh s0) pw0).
-Proof. intros. refine (weqbandf _ _ _ _).
-       { refine (weqbandf _ _ _ _).
+Proof. intros. unshelve refine (weqbandf _ _ _ _).
+       { unshelve refine (weqbandf _ _ _ _).
          { exact (weqonsecbase P w). }
          { unfold weqonsecbase; simpl. exact g. } }
        { intros [f h]. simpl. unfold maponsec1; simpl.
@@ -509,7 +509,7 @@ Proof. intros. refine (weqbandf _ _ _ _).
 
 Definition weq_total2_prod {X Y} (Z:Y->Type) : (Σ y, X × Z y) ≃ (X × Σ y, Z y).
 Proof.                          (* move upstream *)
-       intros. refine (weqpair _ (gradth _ _ _ _)).
+       intros. unshelve refine (weqpair _ (gradth _ _ _ _)).
        { intros [y [x z]]. exact (x,,y,,z). }
        { intros [x [y z]]. exact (y,,x,,z). }
        { intros [y [x z]]. reflexivity. }
@@ -518,7 +518,7 @@ Proof.                          (* move upstream *)
 (* associativity of Σ *)
 Definition totalAssociativity {X:UU} {Y: ∀ (x:X), UU} (Z: ∀ (x:X) (y:Y x), UU) : (Σ (x:X) (y:Y x), Z x y) ≃ (Σ (p:Σ (x:X), Y x), Z (pr1 p) (pr2 p)).
 Proof.                          (* move upstream *)
-  intros. refine (_,,gradth _ _ _ _).
+  intros. unshelve refine (_,,gradth _ _ _ _).
   { intros [x [y z]]. exact ((x,,y),,z). }
   { intros [[x y] z]. exact (x,,(y,,z)). }
   { intros [x [y z]]. reflexivity. }
@@ -536,7 +536,7 @@ Coercion underlyingType : PointedType >-> Sortclass.
 
 Definition basepoint (X:PointedType) := pr2 X.
 
-Definition loopSpace (X:PointedType) := 
+Definition loopSpace (X:PointedType) :=
   pointedType (basepoint X = basepoint X) (idpath _).
 
 Definition underlyingLoop {X:PointedType} (l:loopSpace X) : basepoint X = basepoint X.
@@ -549,7 +549,7 @@ Definition Ω := loopSpace.
 Definition paths3 {X Y Z} {x x':X} {y y':Y} {z z':Z} :
   x = x' -> y = y' -> z = z' -> @paths (_×_×_) (x,,y,,z) (x',,y',,z').
 Proof. intros ? ? ? ? ? ? ? ? ? p q r. destruct p, q, r. reflexivity.
-Defined.       
+Defined.
 
 Definition paths4 {W X Y Z} {w w':W} {x x':X} {y y':Y} {z z':Z} :
   w = w' -> x = x' -> y = y' -> z = z' -> @paths (_×_×_×_) (w,,x,,y,,z) (w',,x',,y',,z').

--- a/UniMath/Ktheory/ZeroObject.v
+++ b/UniMath/Ktheory/ZeroObject.v
@@ -41,9 +41,9 @@ Proof. intros. set (i := thePoint (map_to x a)).
   { apply path_left_composition. apply uniqueness. } Qed.
 Lemma zeroMap {C:precategory} (hsC: has_homsets C) (a b:ob C): hasZeroObject C  ->  a → b.
 Proof. intros ? ? ? ?.
-       refine (squash_to_set _ _ _).
-       { apply hsC. }
+       unshelve refine (squash_to_set _ _ _).
        { apply zeroMap'. }
+       { apply hsC. }
        { intros. apply zeroMapUniqueness. } Defined.
 Lemma zeroMap'_left_composition {C:precategory}
       (z:ZeroObject C) (a b c:ob C) (f:b→c) :

--- a/UniMath/SubstitutionSystems/FunctorsPointwiseCoproduct.v
+++ b/UniMath/SubstitutionSystems/FunctorsPointwiseCoproduct.v
@@ -253,11 +253,11 @@ Qed.
 Definition functor_precat_coproduct_cocone
   : CoproductCocone [C, D, hsD] F G.
 Proof.
-  refine (mk_CoproductCocone _ _ _ _ _ _ _ ).
+  unshelve refine (mk_CoproductCocone _ _ _ _ _ _ _ ).
   - apply coproduct_functor.
   - apply coproduct_nat_trans_in1.
   - apply coproduct_nat_trans_in2.
-  - refine (mk_isCoproductCocone _ _ _ _ _ _ _ _ ).
+  - unshelve refine (mk_isCoproductCocone _ _ _ _ _ _ _ _ ).
     + apply functor_category_has_homsets.
     + intros A f g.
      exists (tpair _ (coproduct_nat_trans A f g)

--- a/UniMath/SubstitutionSystems/FunctorsPointwiseProduct.v
+++ b/UniMath/SubstitutionSystems/FunctorsPointwiseProduct.v
@@ -221,11 +221,11 @@ Qed.
 Definition functor_precat_product_cone
   : ProductCone [C, D, hsD] F G.
 Proof.
-refine (mk_ProductCone _ _ _ _ _ _ _).
+unshelve refine (mk_ProductCone _ _ _ _ _ _ _).
 - apply product_functor.
 - apply product_nat_trans_pr1.
 - apply product_nat_trans_pr2.
-- refine (mk_isProductCone _ _ _ _ _ _ _ _).
+- unshelve refine (mk_isProductCone _ _ _ _ _ _ _ _).
   + apply functor_category_has_homsets.
   + intros A f g.
     exists (tpair _ (product_nat_trans A f g)

--- a/UniMath/SubstitutionSystems/GenMendlerIteration.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration.v
@@ -200,14 +200,14 @@ Focus 2.
       apply maponpaths.
       exact h_rec_eq.
     + (* set(φh_alg_mor := tpair _ _ φh_is_alg_mor : pr1 μF_Initial ⇒ ⟨ R X, φ (ψ (R X) (ε X)) ⟩). *)
-       refine (let X : AF ⟦ InitialObject μF_Initial, ⟨ R X, φ (ψ (R X) (ε X)) ⟩ ⟧ := _ in _).
+       unshelve refine (let X : AF ⟦ InitialObject μF_Initial, ⟨ R X, φ (ψ (R X) (ε X)) ⟩ ⟧ := _ in _).
        * apply (tpair _ (φ h)); assumption.
        * apply (maponpaths pr1 (InitialArrowUnique _ _ X0)).
 Qed.
 
 Theorem GenMendlerIteration : iscontr (Σ h : L μF ⇒ X, #L inF ;; h = ψ μF h).
 Proof.
-  refine (tpair _ _ _ ).
+  unshelve refine (tpair _ _ _ ).
   - exists preIt.
     exact preIt_ok.
   - exact preIt_uniq.
@@ -250,7 +250,7 @@ Section special_case.
 
   Definition ψ_from_comps : ψ_source ⟶ ψ_target.
   Proof.
-    refine (tpair _ _ _ ).
+    unshelve refine (tpair _ _ _ ).
     - intro A. simpl. intro f.
       unfold yoneda_objects_ob in *.
       exact (θ A ;; #G f ;; ρ).

--- a/UniMath/SubstitutionSystems/Lam.v
+++ b/UniMath/SubstitutionSystems/Lam.v
@@ -172,7 +172,7 @@ Defined.
 (** preparations for typedness *)
 Local Definition bla': (ptd_from_alg_functor CC LamE_S LamE_algebra_on_Lam) ⇒ (ptd_from_alg_functor CC _ Lam).
 Proof.
-  refine (tpair _ _ _ ).
+  unshelve refine (tpair _ _ _ ).
     + apply (nat_trans_id _ ).
     + abstract
         (intro c; rewrite id_right
@@ -182,7 +182,7 @@ Defined.
 
 Local Definition bla'_inv: (ptd_from_alg_functor CC _ Lam) ⇒ (ptd_from_alg_functor CC LamE_S LamE_algebra_on_Lam).
 Proof.
-  refine (tpair _ _ _ ).
+  unshelve refine (tpair _ _ _ ).
     + apply (nat_trans_id _ ).
     + abstract
         (intro c; rewrite id_right ;
@@ -493,7 +493,7 @@ Definition bracket_for_LamE_algebra_on_Lam_at (Z : Ptd)
   :
     bracket_at C hs CC LamE_S LamE_algebra_on_Lam f.
 Proof.
-  refine (tpair _ _ _ ).
+  unshelve refine (tpair _ _ _ ).
   - exists (fbracket_for_LamE_algebra_on_Lam Z f).
     apply (bracket_property_for_LamE_algebra_on_Lam Z f).
   - apply bracket_for_LamE_algebra_on_Lam_unique.

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -165,7 +165,7 @@ Definition aux_iso_1 (Z : Ptd)
            (CPEndEndC (constant_functor ([C, C] hs) ([C, C] hs) (U Z))
               (functor_fix_snd_arg ([C, C] hs) Ptd ([C, C] hs) (θ_source H) Z))⟧.
 Proof.
-  refine (tpair _ _ _).
+  unshelve refine (tpair _ _ _).
   - intro X.
     exact (CoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (ρ_functor _ (U Z))
             (nat_trans_id (θ_source H (X⊗Z):functor C C))).
@@ -209,7 +209,7 @@ Local Definition aux_iso_1_inv (Z: Ptd)
               (functor_fix_snd_arg ([C, C] hs) Ptd ([C, C] hs) (θ_source H) Z)),
       functor_composite Id_H (ℓ (U Z)) ⟧.
 Proof.
-  refine (tpair _ _ _).
+  unshelve refine (tpair _ _ _).
   - intro X.
     exact (CoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (λ_functor _ (U Z))
            (nat_trans_id (θ_source H (X⊗Z):functor C C))).
@@ -264,7 +264,7 @@ Local Definition aux_iso_2_inv (Z : Ptd)
                     (functor_fix_snd_arg ([C, C] hs) Ptd ([C, C] hs) (θ_target H) Z)),
       functor_composite (ℓ (U Z) )   (Const_plus_H (U Z)) ⟧.
 Proof.
-  refine (tpair _ _ _).
+  unshelve refine (tpair _ _ _).
   - intro X.
     exact (nat_trans_id ((@CoproductObject EndC (U Z) (θ_target H (X⊗Z)) (CPEndC _ _) )
              : functor C C)).
@@ -510,8 +510,8 @@ Qed.
 Definition bracket_for_InitAlg : bracket InitAlg.
 Proof.
   intros Z f.
-  refine (tpair _ _ _ ).
-  - refine (tpair _ _ _ ).
+  unshelve refine (tpair _ _ _ ).
+  - unshelve refine (tpair _ _ _ ).
     + exact (bracket_Thm15 Z f).
     + exact (bracket_Thm15_ok_cor Z f).
        (* B: better to prove the whole outside, and apply it here *)
@@ -620,7 +620,7 @@ Local Definition iso2' (Z : Ptd) : EndEndC ⟦
              (functor_fix_snd_arg ([C, C] hs) Ptd ([C, C] hs) (θ_target H) Z)),
   functor_composite (ℓ (U Z)) Ghat ⟧.
 Proof.
-    refine (tpair _ _ _).
+    unshelve refine (tpair _ _ _).
   - intro X.
     exact (nat_trans_id ((@CoproductObject EndC _ (θ_target H (X⊗Z)) (CPEndC _ _) )
             : functor C C)).
@@ -646,7 +646,7 @@ Definition Phi_fusion (Z : Ptd) (X : EndC) (b : pr1 InitAlg ⇒ X) :
    ⟶
   functor_composite (functor_opp (ℓ (U Z))) (Yon X) .
 Proof.
-  refine (tpair _ _ _ ).
+  unshelve refine (tpair _ _ _ ).
   - intro Y.
     intro a.
     exact (a ;; b).
@@ -890,7 +890,7 @@ Qed.
 
 Lemma isInitial_InitHSS : isInitial (hss_precategory CP H) InitHSS.
 Proof.
-  refine (mk_isInitial _ _).
+  unshelve refine (mk_isInitial _ _).
   intro T.
   exists (hss_InitMor T).
   apply hss_InitMor_unique.
@@ -899,7 +899,7 @@ Defined.
 
 Lemma InitialHSS : Initial (hss_precategory CP H).
 Proof.
-  refine (mk_Initial InitHSS _).
+  unshelve refine (mk_Initial InitHSS _).
   apply isInitial_InitHSS.
 Defined.
 

--- a/UniMath/SubstitutionSystems/PointedFunctors.v
+++ b/UniMath/SubstitutionSystems/PointedFunctors.v
@@ -122,7 +122,7 @@ Defined.
 Lemma eq_ptd_mor_precat {F G : precategory_Ptd} (a b : F ⇒ G)
   : a = b ≃ (a : ptd_mor F G) = b.
 Proof.
-  refine (tpair _ _ _).
+  unshelve refine (tpair _ _ _).
   intro H.
   exact H.
   apply idisweq.


### PR DESCRIPTION
    update to use latest coq v8.5 release
    
    This involves changing many uses of "refine" to "unshelve refine".
    See issue #265 for details.
