### PR TITLE
fixed notation for functor precategory

### DIFF
--- a/UniMath/CategoryTheory/colimits/colimits.v
+++ b/UniMath/CategoryTheory/colimits/colimits.v
@@ -23,7 +23,7 @@ Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 
-Local Notation "# F" := (functor_on_morphisms F) (at level 3).
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
 Section move_upstream.
 

--- a/UniMath/CategoryTheory/equivalences_lemmas.v
+++ b/UniMath/CategoryTheory/equivalences_lemmas.v
@@ -10,16 +10,16 @@ january 2013
 (** **********************************************************
 
 Contents :  Definition of adjunction
-	
+
 	    Definition of equivalence of precategories
-	
+
 	    Equivalence of categories yields weak equivalence
             of object types
-            
+
             A fully faithful and ess. surjective functor induces
-            equivalence of precategories, if the source 
-            is a category. 
-           
+            equivalence of precategories, if the source
+            is a category.
+
 ************************************************************)
 
 
@@ -38,7 +38,7 @@ Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 Local Notation "a --> b" := (precategory_morphisms a b)(at level 50).
 (*Local Notation "'hom' C" := (precategory_morphisms (C := C)) (at level 2).*)
 Local Notation "f ;; g" := (compose f g) (at level 50, format "f  ;;  g").
-Notation "[ C , D ]" := (functor_precategory C D).
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
 
@@ -52,10 +52,10 @@ Local Definition G : functor B A := right_adjoint (pr1 H).
 Local Definition eta := eta_pointwise_iso_from_equivalence H.
 Local Definition eps := eps_pointwise_iso_from_equivalence H.
 
-Definition inverse {a b} (g : F a --> F b) : a --> b := 
+Definition inverse {a b} (g : F a --> F b) : a --> b :=
    eta a ;;  #G g ;; inv_from_iso (eta b).
 
-Lemma inverse_is_inverse_1 a b (f : a --> b) : 
+Lemma inverse_is_inverse_1 a b (f : a --> b) :
     inverse (#F f) = f.
 Proof.
   unfold inverse.
@@ -70,7 +70,7 @@ Proof.
   apply idpath.
 Qed.
 
-Lemma triangle_id_inverse (a : A): 
+Lemma triangle_id_inverse (a : A):
    iso_inv_from_iso (functor_on_iso _ _ F _ _ (eta a)) = eps (F a).
 Proof.
   apply eq_iso. simpl.
@@ -82,14 +82,14 @@ Proof.
   apply H'.
 Qed.
 
-Lemma triangle_id_inverse' (a : A): 
+Lemma triangle_id_inverse' (a : A):
    inv_from_iso (functor_on_iso _ _ F _ _ (eta a)) = eps (F a).
 Proof.
   apply (base_paths _ _ (triangle_id_inverse a)).
 Qed.
 
 
-Lemma inverse_is_inverse_2 a b (g : F a --> F b) : 
+Lemma inverse_is_inverse_2 a b (g : F a --> F b) :
     #F (inverse g) = g.
 Proof.
   unfold inverse.
@@ -100,17 +100,17 @@ Proof.
   rewrite <- assoc.
   set (H':=nat_trans_ax  (eps_from_left_adjoint (pr1 H))).
   simpl in H'; rewrite H'; clear H'.
-  rewrite assoc.  
+  rewrite assoc.
   set (H' := pathsinv0 (triangle_id_left_ad _ _ _ (pr1 H) a)).
-  match goal with | [ |- ?f ;; ?g = ?h ] => 
+  match goal with | [ |- ?f ;; ?g = ?h ] =>
         assert (H'' : identity _ = f) end.
   - simpl in *; apply H'.
   - rewrite <- H''. rewrite id_left. apply idpath.
-Qed. 
+Qed.
 
 
 Lemma fully_faithful_from_equivalence : fully_faithful F.
-Proof. 
+Proof.
   unfold fully_faithful.
   intros a b.
   apply (gradth _ (@inverse a b)).
@@ -119,24 +119,3 @@ Proof.
 Qed.
 
 End from_equiv_to_fully_faithful.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/UniMath/CategoryTheory/functor_categories.v
+++ b/UniMath/CategoryTheory/functor_categories.v
@@ -682,7 +682,7 @@ Definition functor_precategory (C : precategory_data) (C' : precategory)
         (functor_precategory_data C C')
         (is_precategory_functor_precategory_data C C' hs).
 
-Notation "[ C , D , hs ]" := (functor_precategory C D hs).
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
 Lemma nat_trans_comp_pointwise (C : precategory_data)(C' : precategory) (hs: has_homsets C')
   (F G H : ob [C, C', hs]) (A : F --> G) (A' : G --> H)

--- a/UniMath/CategoryTheory/limits/limits.v
+++ b/UniMath/CategoryTheory/limits/limits.v
@@ -21,8 +21,8 @@ Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.opp_precat.
 Require Import UniMath.CategoryTheory.colimits.colimits.
 
-Local Notation "# F" := (functor_on_morphisms F) (at level 3).
 Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
 Section lim_def.
 

--- a/UniMath/CategoryTheory/opp_precat.v
+++ b/UniMath/CategoryTheory/opp_precat.v
@@ -22,6 +22,7 @@ Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
 (** * The opposite precategory of a precategory *)
 

--- a/UniMath/CategoryTheory/precomp_ess_surj.v
+++ b/UniMath/CategoryTheory/precomp_ess_surj.v
@@ -11,7 +11,7 @@ january 2013
 
 (** **********************************************************
 
-Contents : Precomposition with a fully faithful and  
+Contents : Precomposition with a fully faithful and
            essentially surjective functor yields
            an essentially surjective functor
 
@@ -31,7 +31,7 @@ Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 Local Notation "a --> b" := (precategory_morphisms a b)(at level 50).
 (*Local Notation "'hom' C" := (precategory_morphisms (C := C)) (at level 2).*)
 Local Notation "f ;; g" := (compose f g) (at level 50, format "f  ;;  g").
-Notation "[ C , D ]" := (functor_precategory C D).
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 Local Notation "FF ^-1" := (fully_faithful_inv_hom FF _ _ ) (at level 20).
 Local Notation "F '^-i'" := (iso_from_fully_faithful_reflection F _ _) (at level 20).
@@ -42,7 +42,7 @@ Ltac simp_rew lem := let H:=fresh in
 Ltac simp_rerew lem := let H:=fresh in
      assert (H:= lem); simpl in *; rewrite <- H; clear H.
 Ltac inv_functor HF x y :=
-   let H:=fresh in 
+   let H:=fresh in
    set (H:= homotweqinvweq (weq_from_fully_faithful HF x y));
      simpl in H;
      unfold fully_faithful_inv_hom; simpl;
@@ -75,17 +75,17 @@ Variable F : functor A C.
 
 Section preimage.
 
-(** The type [X b] will be contractible, and [G] is defined as 
+(** The type [X b] will be contractible, and [G] is defined as
      the first component of its center. *)
 
 Local Definition X (b : B) := total2 (
- fun ck : 
+ fun ck :
   total2 (fun c : C =>
                 forall a : A,
                      iso (H a) b -> iso (F a) c) =>
     forall t t' : total2 (fun a : A => iso (H a) b),
           forall f : pr1 t --> pr1 t',
-             (#H f ;; pr2 t' = pr2 t -> 
+             (#H f ;; pr2 t' = pr2 t ->
                     #F f ;; pr2 ck (pr1 t') (pr2 t') = pr2 ck (pr1 t) (pr2 t))).
 
 Local Definition kX {b : B} (t : X b) := (pr2 (pr1 t)).
@@ -120,7 +120,7 @@ Qed.
 
 (** The center of [X b] *)
 
-Definition X_aux_type_center_of_contr (b : B) 
+Definition X_aux_type_center_of_contr (b : B)
     (anot : A)(hnot : iso (H anot) b) : X b.
 Proof.
   set (cnot := F anot).
@@ -136,12 +136,12 @@ Defined.
 
 (** Any inhabitant of [X b] is equal to the center of [X b]. *)
 
-Lemma X_aux_type_contr_eq (b : B) (anot : A) (hnot : iso (H anot) b) : 
+Lemma X_aux_type_contr_eq (b : B) (anot : A) (hnot : iso (H anot) b) :
    forall t : X b, t = X_aux_type_center_of_contr b anot hnot.
 Proof.
   intro t.
   assert (Hpr1 : pr1 (X_aux_type_center_of_contr b anot hnot) = pr1 t).
-  set (w := isotoid _ Ccat ((pr2 (pr1 t)) anot hnot) : 
+  set (w := isotoid _ Ccat ((pr2 (pr1 t)) anot hnot) :
           pr1 (pr1 (X_aux_type_center_of_contr b anot hnot)) = pr1 (pr1 t)).
   apply (total2_paths w).
   simpl.
@@ -153,7 +153,7 @@ Proof.
   set (qhelp := q1 (tpair _ a h)(tpair _ anot hnot) gah).
   simpl in *.
 
-  assert (feedtoqhelp : 
+  assert (feedtoqhelp :
         #H (fH^-1 (h;; inv_from_iso hnot));; hnot = h).
     inv_functor fH a anot.
     rewrite <- assoc.
@@ -165,20 +165,20 @@ Proof.
        (fH^-i (iso_comp h (iso_inv_from_iso hnot)))) (idtoiso w) ).
   generalize w; intro w0.
   induction w0.
-  simpl. apply eq_iso. simpl. 
+  simpl. apply eq_iso. simpl.
   simpl. rewrite id_right.
   apply idpath.
 
-  apply eq_iso. 
+  apply eq_iso.
   simpl.
   unfold w.
   rewrite idtoiso_isotoid.
   apply quack.
-  
+
   apply pathsinv0.
   apply (total2_paths Hpr1).
   apply proofirrelevance.
-  
+
   repeat (apply impred; intro).
   apply (pr2 Ccat).
 Qed.
@@ -197,7 +197,7 @@ Proof.
   apply (X_aux_type_contr_eq b (pr1 t) (pr2 t)).
 Defined.
 
-(** The object part of [G], [Go b], is defined as the first component of 
+(** The object part of [G], [Go b], is defined as the first component of
     the center of [X b]. *)
 
 (** *** [G] on objects *)
@@ -205,12 +205,12 @@ Defined.
 Definition Go : B -> C :=
    fun b : B => pr1 (pr1 (pr1 (iscontr_X b))).
 
-Local Definition k (b : B) : 
-     forall a : A, iso (H a) b -> iso (F a) (Go b) := 
+Local Definition k (b : B) :
+     forall a : A, iso (H a) b -> iso (F a) (Go b) :=
               pr2 (pr1 (pr1 (iscontr_X b))).
 
 Local Definition q (b : B) := pr2 (pr1 (iscontr_X b)).
- 
+
 
 (** Given any inhabitant of [X b], its first component is equal to [Go b]. *)
 
@@ -223,8 +223,8 @@ Defined.
 (** Given any inhabitant [t : X b], its second component is equal to [k b],
        modulo transport along [Xphi b t]. *)
 
-Definition Xkphi_transp (b : B) (t : X b) : 
-     forall a : A, forall h : iso (H a) b, 
+Definition Xkphi_transp (b : B) (t : X b) :
+     forall a : A, forall h : iso (H a) b,
   transportf _ (Xphi b t) (kX t) a h =  k b a h.
 Proof.
   unfold k.
@@ -233,7 +233,7 @@ Proof.
   apply maponpaths, idpath.
 Qed.
 
-(** Similarly to the lemma before, the second component of [t] is the same 
+(** Similarly to the lemma before, the second component of [t] is the same
     as [k b], modulo postcomposition with an isomorphism. *)
 
 Definition Xkphi_idtoiso (b : B) (t : X b) :
@@ -246,12 +246,12 @@ Proof.
   intro i; destruct i.
   apply id_right.
 Qed.
-   
+
 
 (*
-Lemma k_transport (b : ob B) (*t : X b*) (c : ob C) 
+Lemma k_transport (b : ob B) (*t : X b*) (c : ob C)
    (p : pr1 (pr1 t) = c) (a : ob A) (h : iso (pr1 H a) b):
-transportf (fun c' : ob C => forall a : ob A, iso (pr1 H a) b -> 
+transportf (fun c' : ob C => forall a : ob A, iso (pr1 H a) b ->
                           iso ((pr1 F) a) c')
    p (k) a h = (k b) b a h ;; idtoiso p .
 *)
@@ -283,35 +283,35 @@ Proof.
   intros a h a' h' l alpha.
   set (m := fH^-i (iso_comp h0 (iso_inv_from_iso h))).
   set (m' := fH^-i (iso_comp h0' (iso_inv_from_iso h'))).
-  assert (sss : iso_comp (functor_on_iso _ _ F _ _  m) (k b a h) = 
+  assert (sss : iso_comp (functor_on_iso _ _ F _ _  m) (k b a h) =
                    k b a0 h0).
-    apply eq_iso. 
+    apply eq_iso.
     apply (q b (tpair _ a0 h0) (tpair _ a h) m).
     simpl.
     inv_functor fH a0 a.
     rewrite <- assoc.
     rewrite iso_after_iso_inv.
     apply id_right.
-  assert (ssss : iso_comp (functor_on_iso _ _ F _ _  m') (k b' a' h') = 
+  assert (ssss : iso_comp (functor_on_iso _ _ F _ _  m') (k b' a' h') =
                    k b' a0' h0').
-    apply eq_iso. 
+    apply eq_iso.
     apply (q b' (tpair _ a0' h0') (tpair _ a' h') m').
     simpl;
     inv_functor fH a0' a'.
     rewrite <- assoc.
     rewrite iso_after_iso_inv.
     apply id_right.
-  
+
   set (hfh := h0 ;; f ;; inv_from_iso h0').
   set (l0 := fH^-1 hfh).
   set (g0 := inv_from_iso (k b a0 h0) ;; #F l0  ;; k b' a0' h0').
-  
+
   assert (sssss : #H (l0 ;; m') = #H (m ;; l)).
     rewrite functor_comp .
     unfold m'. simpl.
     inv_functor fH a0' a'.
     unfold l0.
-    inv_functor fH a0 a0'.  
+    inv_functor fH a0 a0'.
     unfold hfh.
     pathvia (h0 ;; f ;; (inv_from_iso h0' ;; h0') ;; inv_from_iso h').
       repeat rewrite assoc; apply idpath.
@@ -331,20 +331,20 @@ Proof.
           sssss.
   clear sssss.
   unfold g0.
-  assert (sss'' : k b a h ;; inv_from_iso (k b a0 h0) = 
+  assert (sss'' : k b a h ;; inv_from_iso (k b a0 h0) =
              inv_from_iso (functor_on_iso _ _ F _ _  m)).
     apply pathsinv0, iso_inv_on_left, pathsinv0.
     apply iso_inv_on_right.
     unfold m; simpl.
-    apply pathsinv0, (base_paths _ _ sss). 
+    apply pathsinv0, (base_paths _ _ sss).
   repeat rewrite assoc.
   rewrite sss''. clear sss'' sss.
-  
+
   rewrite <- functor_on_inv_from_iso.
   rewrite <- functor_comp.
   rewrite star5; clear star5 .
   rewrite functor_comp, functor_on_inv_from_iso.
-  assert (star4 : 
+  assert (star4 :
         inv_from_iso (functor_on_iso A C F a0' a' m');; k b' a0' h0'
            = k b' a' h' ).
     apply iso_inv_on_right.
@@ -396,7 +396,7 @@ Qed.
 
 (** The type [Y b b' f] is contractible. *)
 
-Definition Y_iscontr  (b b' : B) (f : b --> b') : 
+Definition Y_iscontr  (b b' : B) (f : b --> b') :
    iscontr (Y f).
 Proof.
   assert (HH : isaprop (iscontr (Y f))).
@@ -421,7 +421,7 @@ Proof.
 Defined.
 
 
-Notation "'G' f" := (pr1 (pr1 (Y_iscontr _ _ f))) (at level 3).
+Local Notation "'G' f" := (pr1 (pr1 (Y_iscontr _ _ f))) (at level 3).
 
 (** The above data is indeed functorial. *)
 
@@ -429,8 +429,8 @@ Lemma is_functor_preimage_functor_data : is_functor preimage_functor_data.
 Proof.
   split. unfold functor_idax. simpl.
   intro b.
-  
-  assert (PR2 : forall (a : A) (h : iso (H a) b) (a' : A) 
+
+  assert (PR2 : forall (a : A) (h : iso (H a) b) (a' : A)
           (h' : iso (H a') b)
     (l : a --> a'),
   #H l;; h' = h;; identity b ->
@@ -442,21 +442,21 @@ Proof.
     apply LL.
     set (Gbrtilde :=
            tpair _ (identity (Go b)) PR2 : Y (identity b)).
- 
+
     set (H' := pr2 (Y_iscontr b b (identity b)) Gbrtilde).
     set (H'' := base_paths _ _ H').
     simpl in H'.
     rewrite <- H'.
     apply idpath.
-  
-  
+
+
   (** composition *)
 
   intros b b' b'' f f'.
 
   assert (HHHH : isaprop (pr1 (pr1 (Y_iscontr b b'' (f;; f'))) =
                         pr1 (pr1 (Y_iscontr b b' f));; pr1 (pr1 (Y_iscontr b' b'' f')))).
-    apply (pr2 Ccat). 
+    apply (pr2 Ccat).
   apply (p b (tpair (fun x => isaprop x) (pr1 (pr1 (Y_iscontr b b'' (f;; f'))) =
            pr1 (pr1 (Y_iscontr b b' f));; pr1 (pr1 (Y_iscontr b' b'' f'))) HHHH)).
   intros [a0 h0]; simpl.
@@ -471,7 +471,7 @@ Proof.
   set (l0 := fH^-1 (h0 ;; f ;; inv_from_iso h0')).
   set (l0' := fH^-1 (h0' ;; f' ;; inv_from_iso h0'')).
   set (l0'' := fH^-1 (h0 ;; (f;; f') ;; inv_from_iso h0'')).
-  
+
   assert (L : l0 ;; l0' = l0'').
     apply (invmaponpathsweq (weq_from_fully_faithful fH a0 a0'')).
     simpl; rewrite functor_comp.
@@ -485,8 +485,8 @@ Proof.
     unfold l0''.
     inv_functor fH a0 a0''.
     repeat rewrite assoc; apply idpath.
-  
-  
+
+
   assert (PR2 : forall (a : A) (h : iso (H a) b)(a' : A)
           (h' : iso (H a') b') (l : a --> a'),
            #H l;; h' = h;; f ->
@@ -496,18 +496,18 @@ Proof.
     intro alpha.
     set (m := fH^-i (iso_comp h0 (iso_inv_from_iso h))).
     set (m' := fH^-i (iso_comp h0' (iso_inv_from_iso h'))).
-    assert (sss : iso_comp (functor_on_iso _ _ F _ _  m) (k b a h) = 
+    assert (sss : iso_comp (functor_on_iso _ _ F _ _  m) (k b a h) =
                    k b a0 h0).
-      apply eq_iso; simpl. 
+      apply eq_iso; simpl.
       apply (q b (tpair _ a0 h0) (tpair _ a h) m).
       simpl.
       inv_functor fH a0 a.
       rewrite <- assoc.
       rewrite iso_after_iso_inv.
       apply id_right.
-    assert (ssss : iso_comp (functor_on_iso _ _ F _ _  m') (k b' a' h') = 
+    assert (ssss : iso_comp (functor_on_iso _ _ F _ _  m') (k b' a' h') =
                    k b' a0' h0').
-      apply eq_iso; simpl. 
+      apply eq_iso; simpl.
       apply (q b' (tpair _ a0' h0') (tpair _ a' h') m'); simpl.
       inv_functor fH a0' a'.
       rewrite <- assoc.
@@ -540,7 +540,7 @@ Proof.
       apply sssss.
     clear sssss.
     set (sss':= base_paths _ _ sss); simpl in sss'.
-    assert (sss'' : k b a h ;; inv_from_iso (k b a0 h0) = 
+    assert (sss'' : k b a h ;; inv_from_iso (k b a0 h0) =
              inv_from_iso (functor_on_iso _ _ F _ _  m)).
       apply pathsinv0.
       apply iso_inv_on_left.
@@ -548,14 +548,14 @@ Proof.
       apply iso_inv_on_right.
       unfold m; simpl.
       apply pathsinv0.
-      apply sss'.  
+      apply sss'.
     repeat rewrite assoc.
     rewrite sss''. clear sss'' sss' sss.
     rewrite <- functor_on_inv_from_iso.
     rewrite <- functor_comp.
     rewrite star5, functor_comp, functor_on_inv_from_iso.
     clear star5.
-    assert (star4 : 
+    assert (star4 :
         inv_from_iso (functor_on_iso A C F a0' a' m');; k b' a0' h0'
            = k b' a' h' ).
       apply iso_inv_on_right.
@@ -566,8 +566,8 @@ Proof.
     rewrite <- assoc.
     rewrite star4.
     apply idpath.
-  
-  assert (HGf : G f = inv_from_iso (k b a0 h0) ;; #F l0 ;; k b' a0' h0'). 
+
+  assert (HGf : G f = inv_from_iso (k b a0 h0) ;; #F l0 ;; k b' a0' h0').
     set (Gbrtilde :=
            tpair _ (inv_from_iso (k b a0 h0) ;; #F l0 ;; k b' a0' h0') PR2 : Y f).
     set (H' := pr2 (Y_iscontr b b' f) Gbrtilde).
@@ -575,9 +575,9 @@ Proof.
     simpl in H'.
     rewrite <- H'.
     apply idpath.
-  
+
   clear PR2.
-  assert (PR2 : forall (a : A) (h : iso (H a) b') (a' : A) 
+  assert (PR2 : forall (a : A) (h : iso (H a) b') (a' : A)
             (h' : iso (H a') b'') (l : a --> a'),
          #H l;; h' = h;; f' ->
            #F l;; k b'' a' h' =
@@ -586,17 +586,17 @@ Proof.
     intro alpha.
     set (m := fH^-i (iso_comp h0' (iso_inv_from_iso h'))).
     set (m' := fH^-i (iso_comp h0'' (iso_inv_from_iso h''))).
-    assert (sss : iso_comp (functor_on_iso _ _ F _ _  m) (k b' a' h') = 
+    assert (sss : iso_comp (functor_on_iso _ _ F _ _  m) (k b' a' h') =
                    k b' a0' h0').
-      apply eq_iso; simpl. 
+      apply eq_iso; simpl.
       apply (q b' (tpair _ a0' h0') (tpair _ a' h') m); simpl.
       inv_functor fH a0' a'.
       rewrite <- assoc.
       rewrite iso_after_iso_inv.
       apply id_right.
-    assert (ssss : iso_comp (functor_on_iso _ _ F _ _  m') (k b'' a'' h'') = 
+    assert (ssss : iso_comp (functor_on_iso _ _ F _ _  m') (k b'' a'' h'') =
                    k b'' a0'' h0'').
-      apply eq_iso; simpl. 
+      apply eq_iso; simpl.
       apply (q b'' (tpair _ a0'' h0'') (tpair _ a'' h'') m'); simpl.
       inv_functor fH a0'' a''.
       rewrite <- assoc.
@@ -624,7 +624,7 @@ Proof.
         pathsinv0,
         sssss.
     set (sss':= base_paths _ _ sss); simpl in sss'.
-    assert (sss'' : k b' a' h' ;; inv_from_iso (k b' a0' h0') = 
+    assert (sss'' : k b' a' h' ;; inv_from_iso (k b' a0' h0') =
              inv_from_iso (functor_on_iso _ _ F _ _  m)).
       apply pathsinv0, iso_inv_on_left, pathsinv0, iso_inv_on_right.
       unfold m; simpl;
@@ -635,7 +635,7 @@ Proof.
     rewrite <- functor_comp.
     rewrite star5. clear star5 sssss.
     rewrite functor_comp, functor_on_inv_from_iso.
-    assert (star4 : 
+    assert (star4 :
         inv_from_iso (functor_on_iso A C F a0'' a'' m');; k b'' a0'' h0''
            = k b'' a'' h'' ).
       apply iso_inv_on_right.
@@ -645,16 +645,16 @@ Proof.
     rewrite <- assoc.
     rewrite star4.
     apply idpath.
-  assert (HGf' : G f' = inv_from_iso (k b' a0' h0') ;; #F l0' ;; k b'' a0'' h0''). 
+  assert (HGf' : G f' = inv_from_iso (k b' a0' h0') ;; #F l0' ;; k b'' a0'' h0'').
     set (Gbrtilde :=
-       tpair _ (inv_from_iso (k b' a0' h0') ;; #F l0' ;; k b'' a0'' h0'') PR2 : 
+       tpair _ (inv_from_iso (k b' a0' h0') ;; #F l0' ;; k b'' a0'' h0'') PR2 :
                       Y f').
     set (H' := pr2 (Y_iscontr b' b'' f') Gbrtilde).
     rewrite <-(base_paths _ _ H').
     apply idpath.
-  
+
   clear PR2.
-  assert (PR2 : forall (a : A) (h : iso (H a) b) (a' : A) 
+  assert (PR2 : forall (a : A) (h : iso (H a) b) (a' : A)
              (h' : iso (H a') b'') (l : a --> a'),
           #H l;; h' = h;; (f;; f') ->
           #F l;; k b'' a' h' =
@@ -670,9 +670,9 @@ Proof.
       rewrite <- assoc.
       rewrite iso_after_iso_inv.
       apply id_right.
-    assert (ssss : iso_comp (functor_on_iso _ _ F _ _  m') (k b'' a'' h'') = 
+    assert (ssss : iso_comp (functor_on_iso _ _ F _ _  m') (k b'' a'' h'') =
                    k b'' a0'' h0'').
-      apply eq_iso. 
+      apply eq_iso.
       apply (q b'' (tpair _ a0'' h0'') (tpair _ a'' h'') m').
       simpl; inv_functor fH a0'' a''.
       rewrite <- assoc.
@@ -683,7 +683,7 @@ Proof.
       unfold m'. simpl.
       inv_functor fH a0'' a''.
       unfold l0''.
-      inv_functor fH a0 a0''. 
+      inv_functor fH a0 a0''.
       pathvia (h0 ;; (f ;; f') ;; (inv_from_iso h0'' ;; h0'') ;; inv_from_iso h'').
         repeat rewrite assoc; apply idpath.
       rewrite iso_after_iso_inv, id_right, functor_comp.
@@ -701,7 +701,7 @@ Proof.
       apply (invmaponpathsweq (weq_from_fully_faithful fH a0 a'' )).
       apply pathsinv0, sssss.
     set (sss':= base_paths _ _ sss); simpl in sss'.
-    assert (sss'' : k b a h ;; inv_from_iso (k b a0 h0) = 
+    assert (sss'' : k b a h ;; inv_from_iso (k b a0 h0) =
              inv_from_iso (functor_on_iso _ _ F _ _  m)).
       apply pathsinv0, iso_inv_on_left, pathsinv0, iso_inv_on_right.
       unfold m; simpl.
@@ -712,17 +712,17 @@ Proof.
     rewrite <- functor_comp.
     rewrite star5. clear star5 sssss.
     rewrite functor_comp, functor_on_inv_from_iso.
-    assert (star4 : 
+    assert (star4 :
         inv_from_iso (functor_on_iso A C F a0'' a'' m');; k b'' a0'' h0''
            = k b'' a'' h'' ).
       apply iso_inv_on_right, pathsinv0, (base_paths _ _ ssss).
     rewrite <- assoc.
     rewrite star4.
     apply idpath.
-  assert (HGff' : G (f ;; f') = 
-       inv_from_iso (k b a0 h0) ;; #F l0'' ;; k b'' a0'' h0''). 
+  assert (HGff' : G (f ;; f') =
+       inv_from_iso (k b a0 h0) ;; #F l0'' ;; k b'' a0'' h0'').
     set (Gbrtilde :=
-           tpair _ (inv_from_iso (k b a0 h0) ;; #F l0'' ;; k b'' a0'' h0'') PR2 : 
+           tpair _ (inv_from_iso (k b a0 h0) ;; #F l0'' ;; k b'' a0'' h0'') PR2 :
                Y (f ;; f')).
     rewrite <- (pr2 (Y_iscontr b b'' (f ;; f')) Gbrtilde).
     apply idpath.
@@ -731,7 +731,7 @@ Proof.
   pathvia (inv_from_iso (k b a0 h0);; #F l0;; (k b' a0' h0';;
               inv_from_iso (k b' a0' h0'));; #F l0';; k b'' a0'' h0'').
     rewrite iso_inv_after_iso, id_right.
-    rewrite HGff'. 
+    rewrite HGff'.
     repeat rewrite <- assoc.
     apply maponpaths.
     rewrite <- L.
@@ -745,13 +745,13 @@ Qed.
 
 (** We call the functor [GG] ... *)
 
-Definition GG : [B, C, pr2 Ccat] := tpair _ preimage_functor_data 
+Definition GG : [B, C, pr2 Ccat] := tpair _ preimage_functor_data
                     is_functor_preimage_functor_data.
 
 (** ** [G] is the preimage of [F] under [ _ O H] *)
 
 (** Given any [a : A], we produce an element in [X (H a)], whose
-     first component is [F a]. 
+     first component is [F a].
    This allows to prove [G (H a) = F a]. *)
 
 Lemma qF (a0 : A) :
@@ -775,8 +775,8 @@ Proof.
 Qed.
 
 
-Definition kFa (a0 : A) : forall a : A, 
-  iso (H a) (H a0) -> iso (F a) (F a0) := 
+Definition kFa (a0 : A) : forall a : A,
+  iso (H a) (H a0) -> iso (F a) (F a0) :=
  fun (a : A) (h : iso (H a) (H a0)) =>
        functor_on_iso A C F a a0
          (iso_from_fully_faithful_reflection fH a a0 h).
@@ -796,11 +796,11 @@ Proof.
   apply phi.
 Defined.
 
-(** Now for the functor as a whole. It remains to prove 
+(** Now for the functor as a whole. It remains to prove
     equality on morphisms, modulo transport. *)
 
 Lemma is_preimage_for_pre_composition : functor_composite _ _ _ H GG = F.
-Proof. 
+Proof.
   apply (functor_eq _ _  (pr2 Ccat) (functor_composite _ _ _ H GG) F).
   apply (total2_paths extphi).
   apply funextsec; intro a0;
@@ -844,7 +844,7 @@ Proof.
                     PSIf : Y (#H f)).
   set (Ycontr := pr2 (Y_iscontr _ _ (#(pr1 H) f)) Ybla).
   set (Ycontr2 := base_paths _ _ Ycontr); simpl in *.
-  change (G (#H f)) with (G (#(pr1 H) f)). 
+  change (G (#H f)) with (G (#(pr1 H) f)).
   rewrite <- Ycontr2.
   repeat rewrite assoc.
   rewrite iso_after_iso_inv, id_left.
@@ -852,10 +852,10 @@ Proof.
   rewrite iso_after_iso_inv, id_right.
   apply idpath.
 Qed.
-  
 
 
-  
+
+
 End preimage.
 
 End essentially_surjective.
@@ -865,7 +865,7 @@ End essentially_surjective.
 (** Abstracting from [F] by closing the previous section,
     we can prove essential surjectivity of [_ O H]. *)
 
-Lemma pre_composition_essentially_surjective (hsB: has_homsets B) : 
+Lemma pre_composition_essentially_surjective (hsB: has_homsets B) :
        essentially_surjective (pre_composition_functor A B C hsB (pr2 Ccat) H).
 Proof.
   intros F p' f.
@@ -876,8 +876,3 @@ Proof.
 Qed.
 
 End precomp_w_ess_surj_ff_is_ess_surj.
-
-
-
-
-

--- a/UniMath/CategoryTheory/precomp_fully_faithful.v
+++ b/UniMath/CategoryTheory/precomp_fully_faithful.v
@@ -45,7 +45,7 @@ Ltac inv_functor HF x y :=
 Local Notation "a --> b" := (precategory_morphisms a b)(at level 50).
 (*Local Notation "'hom' C" := (precategory_morphisms (C := C)) (at level 2).*)
 Local Notation "f ;; g" := (compose f g) (at level 50, format "f  ;;  g").
-Notation "[ C , D ]" := (functor_precategory C D).
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 Local Notation "G 'O' F" := (functor_compose _ _ _ F G : functor _ _ ) (at level 25).
 Local Notation "FF ^-1" := (fully_faithful_inv_hom FF _ _ ) (at level 20).

--- a/UniMath/CategoryTheory/rezk_completion.v
+++ b/UniMath/CategoryTheory/rezk_completion.v
@@ -36,6 +36,7 @@ Require Import UniMath.CategoryTheory.precomp_fully_faithful.
 Require Import UniMath.CategoryTheory.precomp_ess_surj.
 
 Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
 (** * Construction of the Rezk completion via Yoneda *)
 
@@ -131,7 +132,7 @@ Proof.
   apply T.
 Defined.
 
-Definition Rezk_weq : [Rezk_completion A hsA, C] (pr2 Ccat) ≃ [A, C] (pr2 Ccat)
+Definition Rezk_weq : [Rezk_completion A hsA, C, pr2 Ccat] ≃ [A, C, pr2 Ccat ]
   := weqpair _ Rezk_eta_Universal_Property.
 
 End fix_a_category.
@@ -232,7 +233,7 @@ Proof.
   apply T.
 Defined.
 
-Definition Rezk_opp_weq : [(Rezk_completion A hsA)^op, C, (pr2 Ccat)] ≃ [A^op, C, (pr2 Ccat)]
+Definition Rezk_opp_weq : [(Rezk_completion A hsA)^op, C, pr2 Ccat] ≃ [A^op, C, pr2 Ccat]
   := weqpair _ Rezk_eta_opp_Universal_Property.
 
 End fix_a_category.

--- a/UniMath/CategoryTheory/whiskering.v
+++ b/UniMath/CategoryTheory/whiskering.v
@@ -35,7 +35,7 @@ Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 Local Notation "a --> b" := (precategory_morphisms a b)(at level 50).
 (*Local Notation "'hom' C" := (precategory_morphisms (C := C)) (at level 2).*)
 Local Notation "f ;; g" := (compose f g) (at level 50, format "f  ;;  g").
-Notation "[ C , D ]" := (functor_precategory C D).
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
 

--- a/UniMath/CategoryTheory/yoneda.v
+++ b/UniMath/CategoryTheory/yoneda.v
@@ -36,7 +36,7 @@ Require Import UniMath.CategoryTheory.whiskering.
 (*Local Notation "a --> b" := (precategory_morphisms a b)(at level 50).*)
 Local Notation "'hom' C" := (precategory_morphisms (C := C)) (at level 2).
 (* Local Notation "f ;; g" := (compose f g) (at level 50, format "f  ;;  g").*)
-Local Notation "[ C , D ]" := (functor_precategory C D).
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 Local Notation "# F" := (functor_on_morphisms F) (at level 3).
 Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
 
@@ -259,7 +259,7 @@ Defined.
 
 Definition yoneda_weq (C : precategory) (hs: has_homsets C) (c : C)
    (F : functor C^op HSET)
-  :  hom ([C^op, HSET] (pr2 is_category_HSET)) ((yoneda C hs) c) F ≃ pr1hSet (F c)
+  :  hom [C^op, HSET, pr2 is_category_HSET] ((yoneda C hs) c) F ≃ pr1hSet (F c)
   := weqpair _ (isweq_yoneda_map_1 C hs c F).
 
 

--- a/UniMath/SubstitutionSystems/FunctorsPointwiseCoproduct.v
+++ b/UniMath/SubstitutionSystems/FunctorsPointwiseCoproduct.v
@@ -32,6 +32,7 @@ Require Import UniMath.CategoryTheory.limits.coproducts.
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 Local Notation "F ⟶ G" := (nat_trans F G) (at level 39).
 Local Notation "G □ F" := (functor_composite _ _ _ F G) (at level 35).
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
 Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 

--- a/UniMath/SubstitutionSystems/FunctorsPointwiseProduct.v
+++ b/UniMath/SubstitutionSystems/FunctorsPointwiseProduct.v
@@ -32,6 +32,7 @@ Require Import UniMath.CategoryTheory.limits.products.
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 Local Notation "F ⟶ G" := (nat_trans F G) (at level 39).
 Local Notation "G □ F" := (functor_composite _ _ _ F G) (at level 35).
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
 Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 

--- a/UniMath/SubstitutionSystems/GenMendlerIteration.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration.v
@@ -37,14 +37,14 @@ Require Import UniMath.CategoryTheory.yoneda.
 Require Import UniMath.CategoryTheory.equivalences. (* for adjunctions *)
 Require Import UniMath.SubstitutionSystems.AdjunctionHomTypesWeq. (* for alternative reading of adj *)
 
-Local Notation "# F" := (functor_on_morphisms F)(at level 3).
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 Local Notation "F ⟶ G" := (nat_trans F G) (at level 39).
 Arguments functor_composite {_ _ _} _ _ .
 Arguments nat_trans_comp {_ _ _ _ _} _ _ .
 Local Notation "G ∙ F" := (functor_composite F G : [ _ , _ , _ ]) (at level 35).
 Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
-Notation "↓ f" := (mor_from_algebra_mor _ _ _ f) (at level 3, format "↓ f").
+Local Notation "↓ f" := (mor_from_algebra_mor _ _ _ f) (at level 3, format "↓ f").
 (* in Agda mode \downarrow *)
 
 (** Goal: derive Generalized Iteration in Mendler-style and a fusion law *)

--- a/UniMath/SubstitutionSystems/HorizontalComposition.v
+++ b/UniMath/SubstitutionSystems/HorizontalComposition.v
@@ -29,9 +29,9 @@ Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 
-Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 Local Notation "F ⟶ G" := (nat_trans F G) (at level 39).
 Local Notation "G □ F" := (functor_composite _ _ _ F G) (at level 35).
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
 Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 

--- a/UniMath/SubstitutionSystems/Lam.v
+++ b/UniMath/SubstitutionSystems/Lam.v
@@ -92,7 +92,7 @@ Let LamE_S : Signature _ _ := LamE_Sig C hs terminal CC CP.
 (* assume initial algebra for signature Lam *)
 
 Variable Lam_Initial : Initial
-     (@precategory_FunctorAlg ([C, C] hs)
+     (@precategory_FunctorAlg [C, C, hs]
                              (Id_H C hs CC Lam_S) hsEndC).
 
 Let Lam := InitialObject Lam_Initial.
@@ -120,18 +120,18 @@ Defined.
 
 (* we later prefer leaving App and Abs bundled in the definition of LamE_algebra_on_Lam *)
 
-Definition Lam_App : [C, C] hs ⟦ (App_H C hs CP) `Lam , `Lam ⟧.
+Definition Lam_App : [C, C, hs] ⟦ (App_H C hs CP) `Lam , `Lam ⟧.
 Proof.
   exact (CoproductIn1 _ _ ;; (CoproductIn2 _ _ ;; alg_map _ Lam)).
 Defined.
 
-Definition Lam_Abs : [C, C] hs ⟦ (Abs_H C hs terminal CC) `Lam, `Lam ⟧.
+Definition Lam_Abs : [C, C, hs] ⟦ (Abs_H C hs terminal CC) `Lam, `Lam ⟧.
 Proof.
   exact (CoproductIn2 _ _ ;; (CoproductIn2 _ _ ;; alg_map _ Lam)).
 Defined.
 
 
-Definition Lam_App_Abs :  [C, C] hs
+Definition Lam_App_Abs :  [C, C, hs]
    ⟦ (H C hs CC (App_H C hs CP) (Abs_H C hs terminal CC)) `Lam , `Lam ⟧.
 Proof.
   exact (CoproductIn2 _ _ ;; alg_map _ Lam).
@@ -142,7 +142,7 @@ Defined.
 (** we need a flattening in order to get a model for LamE *)
 
 Definition Lam_Flatten :
-  [C, C] hs ⟦ (Flat_H C hs) `Lam , `Lam ⟧.
+  [C, C, hs] ⟦ (Flat_H C hs) `Lam , `Lam ⟧.
 Proof.
   exact (fbracket LamHSS (identity _ )).
 Defined.
@@ -217,7 +217,7 @@ Defined.
 
 Definition fbracket_for_LamE_algebra_on_Lam (Z : Ptd)
    (f : Ptd ⟦ Z, ptd_from_alg_functor CC LamE_S LamE_algebra_on_Lam ⟧ ) :
-   [C, C] hs
+   [C, C, hs]
    ⟦ functor_composite (U Z) `LamE_algebra_on_Lam, `LamE_algebra_on_Lam ⟧ .
 Proof.
   exact (fbracket LamHSS (f ;; bla)).
@@ -421,14 +421,14 @@ Lemma bracket_for_LamE_algebra_on_Lam_unique (Z : Ptd)
  :
    ∀
    t : Σ
-       h : [C, C] hs
+       h : [C, C, hs]
            ⟦ functor_composite (U Z)
                (` LamE_algebra_on_Lam),
            `LamE_algebra_on_Lam ⟧,
        bracket_property f h,
    t =
    tpair
-     (λ h : [C, C] hs
+     (λ h : [C, C, hs]
             ⟦ functor_composite (U Z)
                 (` LamE_algebra_on_Lam),
             `LamE_algebra_on_Lam ⟧,
@@ -515,7 +515,7 @@ Defined.
 (* assume initial algebra for signature LamE *)
 
 Variable  LamE_Initial : Initial
-     (@precategory_FunctorAlg ([C, C] hs)
+     (@precategory_FunctorAlg [C, C, hs]
         (Id_H C hs CC LamE_S) hsEndC).
 
 

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -90,7 +90,7 @@ Definition Const_plus_H (X : EndC) : functor EndC EndC
                        H.
 
 
-Definition Id_H :  functor ([C, C] hs) ([C, C] hs)
+Definition Id_H :  functor [C, C, hs] [C, C, hs]
  := Const_plus_H (functor_identity _ : EndC).
 
 
@@ -99,10 +99,10 @@ Let Alg : precategory := FunctorAlg Id_H hsEndC.
 
 Variable IA : Initial Alg.
 Definition SpecializedGMIt (Z : Ptd) (X : EndC)
-  :  ∀ (G : functor ([C, C] hs) ([C, C] hs))
-       (ρ : [C, C] hs ⟦ G X, X ⟧)
+  :  ∀ (G : functor [C, C, hs] [C, C, hs])
+       (ρ : [C, C, hs] ⟦ G X, X ⟧)
        (θ : functor_composite Id_H (ℓ (U Z)) ⟶ functor_composite (ℓ (U Z)) G),
-     ∃! h : [C, C] hs ⟦ ℓ (U Z) (` (InitialObject IA)), X ⟧,
+     ∃! h : [C, C, hs] ⟦ ℓ (U Z) (` (InitialObject IA)), X ⟧,
             # (ℓ (U Z)) (alg_map Id_H (InitialObject IA)) ;; h
             =
             θ (` (InitialObject IA)) ;; # G h ;; ρ
@@ -111,9 +111,9 @@ Definition SpecializedGMIt (Z : Ptd) (X : EndC)
 
 
 Definition θ_in_first_arg (Z: Ptd)
-  : functor_fix_snd_arg ([C, C] hs) Ptd ([C, C] hs) (θ_source H) Z
+  : functor_fix_snd_arg [C, C,hs] Ptd [C, C, hs] (θ_source H) Z
     ⟶
-    functor_fix_snd_arg ([C, C] hs) Ptd ([C, C] hs) (θ_target H) Z
+    functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_target H) Z
   := nat_trans_fix_snd_arg _ _ _ _ _ θ Z.
 
 Definition InitAlg : Alg := InitialObject IA.
@@ -132,10 +132,10 @@ Local Lemma aux_iso_1_is_nat_trans (Z : Ptd) :
    is_nat_trans
      (functor_composite Id_H (ℓ (U Z)))
      (pr1 (CoproductObject EndEndC
-        (CPEndEndC (constant_functor ([C, C] hs) ([C, C] hs) (U Z))
-           (functor_fix_snd_arg ([C, C] hs) Ptd ([C, C] hs) (θ_source H) Z))))
-     (λ X : [C, C] hs,
-      CoproductOfArrows ([C, C] hs)
+        (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+           (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_source H) Z))))
+     (λ X : [C, C, hs],
+      CoproductOfArrows [C, C, hs]
         (CPEndC (functor_composite (U Z) (functor_identity C))
            ((θ_source H) (X ⊗ Z))) (CPEndC (U Z) ((θ_source H) (X ⊗ Z)))
         (ρ_functor C (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
@@ -162,8 +162,8 @@ Definition aux_iso_1 (Z : Ptd)
   : EndEndC
     ⟦ functor_composite Id_H (ℓ (U Z)),
       CoproductObject EndEndC
-           (CPEndEndC (constant_functor ([C, C] hs) ([C, C] hs) (U Z))
-              (functor_fix_snd_arg ([C, C] hs) Ptd ([C, C] hs) (θ_source H) Z))⟧.
+           (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+              (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_source H) Z))⟧.
 Proof.
   unshelve refine (tpair _ _ _).
   - intro X.
@@ -175,11 +175,11 @@ Defined.
 Local Lemma aux_iso_1_inv_is_nat_trans (Z : Ptd) :
    is_nat_trans
      (pr1 (CoproductObject EndEndC
-        (CPEndEndC (constant_functor ([C, C] hs) ([C, C] hs) (U Z))
-           (functor_fix_snd_arg ([C, C] hs) Ptd ([C, C] hs) (θ_source H) Z))) )
+        (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+           (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_source H) Z))) )
      (functor_composite Id_H (ℓ (U Z)))
-     (λ X : [C, C] hs,
-      CoproductOfArrows ([C, C] hs)
+     (λ X : [C, C, hs],
+      CoproductOfArrows [C, C, hs]
         (CPEndC (functor_composite (functor_identity C) (U Z))
            ((θ_source H) (X ⊗ Z))) (CPEndC (U Z) ((θ_source H) (X ⊗ Z)))
         (λ_functor C (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
@@ -205,8 +205,8 @@ Qed.
 Local Definition aux_iso_1_inv (Z: Ptd)
   : EndEndC
     ⟦ CoproductObject EndEndC
-           (CPEndEndC (constant_functor ([C, C] hs) ([C, C] hs) (U Z))
-              (functor_fix_snd_arg ([C, C] hs) Ptd ([C, C] hs) (θ_source H) Z)),
+           (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+              (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_source H) Z)),
       functor_composite Id_H (ℓ (U Z)) ⟧.
 Proof.
   unshelve refine (tpair _ _ _).
@@ -225,13 +225,13 @@ Definition G_Thm15 (X : EndC) := coproduct_functor _ _ CPEndC
 Local Lemma aux_iso_2_inv_is_nat_trans (Z : Ptd) :
    is_nat_trans
      (pr1 (CoproductObject EndEndC
-        (CPEndEndC (constant_functor ([C, C] hs) ([C, C] hs) (U Z))
-           (functor_fix_snd_arg ([C, C] hs) Ptd ([C, C] hs) (θ_target H) Z))) )
+        (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+           (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs](θ_target H) Z))) )
      (functor_composite (ℓ (U Z))
         (Const_plus_H (U Z)))
-     (λ X : [C, C] hs,
+     (λ X : [C, C, hs],
       nat_trans_id
-        (CoproductObject ([C, C] hs) (CPEndC (U Z) ((θ_target H) (X ⊗ Z)))
+        (CoproductObject [C, C, hs] (CPEndC (U Z) ((θ_target H) (X ⊗ Z)))
          :functor C C)).
 Proof.
   unfold is_nat_trans; simpl.
@@ -260,8 +260,8 @@ Qed.
 Local Definition aux_iso_2_inv (Z : Ptd)
   : EndEndC
     ⟦ CoproductObject EndEndC
-         (CPEndEndC (constant_functor ([C, C] hs) ([C, C] hs) (U Z))
-                    (functor_fix_snd_arg ([C, C] hs) Ptd ([C, C] hs) (θ_target H) Z)),
+         (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+                    (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_target H) Z)),
       functor_composite (ℓ (U Z) )   (Const_plus_H (U Z)) ⟧.
 Proof.
   unshelve refine (tpair _ _ _).
@@ -274,25 +274,25 @@ Defined.
 Definition θ'_Thm15 (Z: Ptd)
   : EndEndC
     ⟦ CoproductObject EndEndC
-        (CPEndEndC (constant_functor ([C, C] hs) ([C, C] hs) (U Z))
-           (functor_fix_snd_arg ([C, C] hs) Ptd ([C, C] hs) (θ_source H) Z)),
+        (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+           (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_source H) Z)),
       CoproductObject EndEndC
-        (CPEndEndC (constant_functor ([C, C] hs) ([C, C] hs) (U Z))
-            (functor_fix_snd_arg ([C, C] hs) Ptd ([C, C] hs) (θ_target H) Z)) ⟧
+        (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+            (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_target H) Z)) ⟧
   := CoproductOfArrows
    EndEndC (CPEndEndC _ _) (CPEndEndC _ _)
    (identity (constant_functor EndC _ (U Z): functor_precategory EndC EndC hsEndC))
    (θ_in_first_arg Z).
 
 Definition ρ_Thm15 (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧)
-  : [C, C] hs ⟦ CoproductObject ([C, C] hs) (CPEndC (U Z) (H `InitAlg)), `InitAlg ⟧
+  : [C, C, hs] ⟦ CoproductObject [C, C, hs] (CPEndC (U Z) (H `InitAlg)), `InitAlg ⟧
   := @CoproductArrow
    EndC _ _  (CPEndC (U Z)
    (H (alg_carrier _ InitAlg))) (alg_carrier _ InitAlg) (#U f)
    (CoproductIn2 _ _ ;; (alg_map _ InitAlg)).
 
 Definition SpecializedGMIt_Thm15 (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧)
-  : ∃! h : [C, C] hs ⟦ ℓ (U Z) (` (InitialObject IA)), pr1 InitAlg ⟧,
+  : ∃! h : [C, C, hs] ⟦ ℓ (U Z) (` (InitialObject IA)), pr1 InitAlg ⟧,
            # (ℓ (U Z)) (alg_map Id_H (InitialObject IA)) ;; h
            =
            pr1 ((aux_iso_1 Z ;; θ'_Thm15 Z ;; aux_iso_2_inv Z)) (` (InitialObject IA)) ;;
@@ -301,7 +301,7 @@ Definition SpecializedGMIt_Thm15 (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg InitAlg �
      (ρ_Thm15 Z f) (aux_iso_1 Z ;; θ'_Thm15 Z ;; aux_iso_2_inv Z).
 
 Definition bracket_Thm15 (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧)
-  : [C, C] hs ⟦ ℓ (U Z) (` (InitialObject IA)), `InitAlg ⟧
+  : [C, C, hs] ⟦ ℓ (U Z) (` (InitialObject IA)), `InitAlg ⟧
   := pr1 (pr1 (SpecializedGMIt_Thm15 Z f)).
 
 Notation "⦃ f ⦄" := (bracket_Thm15 _ f) (at level 0).
@@ -442,13 +442,13 @@ Qed.
 
 
 Local Lemma foo' (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
- ∀ t : Σ h : [C, C] hs ⟦ functor_composite (U Z) (pr1  InitAlg),
+ ∀ t : Σ h : [C, C, hs] ⟦ functor_composite (U Z) (pr1  InitAlg),
                          pr1 InitAlg ⟧,
        bracket_property f h,
    t
    =
    tpair
-     (λ h : [C, C] hs
+     (λ h : [C, C, hs]
             ⟦ functor_composite (U Z) (pr1 InitAlg),
               pr1 InitAlg ⟧,
        bracket_property f h)
@@ -556,11 +556,11 @@ Defined.
 Definition thetahat_0 (Z : Ptd) (f : Z ⇒ ptd_from_alg  InitAlg):
 EndEndC
 ⟦ CoproductObject EndEndC
-    (CPEndEndC (constant_functor ([C, C] hs) ([C, C] hs) (U Z))
-       (functor_fix_snd_arg ([C, C] hs) Ptd ([C, C] hs) (θ_source H) Z)),
+    (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+       (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_source H) Z)),
 CoproductObject EndEndC
-  (CPEndEndC (constant_functor ([C, C] hs) ([C, C] hs) (pr1 InitAlg))
-             (functor_fix_snd_arg ([C, C] hs) Ptd ([C, C] hs) (θ_target H) Z)) ⟧ .
+  (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (pr1 InitAlg))
+             (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_target H) Z)) ⟧ .
 Proof.
   exact (CoproductOfArrows EndEndC (CPEndEndC _ _) (CPEndEndC _ _)
                            (constant_nat_trans _ _ hsEndC _ _ (#U f))
@@ -570,8 +570,8 @@ Defined.
 Local Definition iso1' (Z : Ptd) :  EndEndC ⟦ functor_composite Id_H
                                         (ℓ (U Z)),
  CoproductObject EndEndC
-    (CPEndEndC (constant_functor ([C, C] hs) ([C, C] hs) (U Z))
-               (functor_fix_snd_arg ([C, C] hs) Ptd ([C, C] hs) (θ_source H) Z)) ⟧.
+    (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+               (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_source H) Z)) ⟧.
 Proof.
   exact (aux_iso_1 Z).
 Defined.
@@ -580,14 +580,14 @@ Defined.
 Local Lemma is_nat_trans_iso2' (Z : Ptd) :
    is_nat_trans
      (pr1 (CoproductObject EndEndC
-        (CPEndEndC (constant_functor ([C, C] hs) ([C, C] hs) (pr1 InitAlg))
-           (functor_fix_snd_arg ([C, C] hs) Ptd ([C, C] hs) (θ_target H) Z))))
+        (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (pr1 InitAlg))
+           (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_target H) Z))))
      (functor_composite (ℓ (U Z)) Ghat)
-     (λ X : [C, C] hs,
+     (λ X : [C, C, hs],
       nat_trans_id
-        (CoproductObject ([C, C] hs)
+        (CoproductObject [C, C, hs]
            (CPEndC
-              ((constant_functor ([C, C] hs) ([C, C] hs) (pr1 InitAlg)) X)
+              ((constant_functor [C, C, hs] [C, C, hs] (pr1 InitAlg)) X)
               ((θ_target H) (X ⊗ Z)))
          :functor C C)).
 Proof.
@@ -616,8 +616,8 @@ Qed.
 
 Local Definition iso2' (Z : Ptd) : EndEndC ⟦
   CoproductObject EndEndC
-  (CPEndEndC (constant_functor ([C, C] hs) ([C, C] hs) (pr1 InitAlg))
-             (functor_fix_snd_arg ([C, C] hs) Ptd ([C, C] hs) (θ_target H) Z)),
+  (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (pr1 InitAlg))
+             (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_target H) Z)),
   functor_composite (ℓ (U Z)) Ghat ⟧.
 Proof.
     unshelve refine (tpair _ _ _).

--- a/UniMath/SubstitutionSystems/Notation.v
+++ b/UniMath/SubstitutionSystems/Notation.v
@@ -41,6 +41,7 @@ Notation "# F" := (functor_on_morphisms F)(at level 3).
 Notation "F ⟶ G" := (nat_trans F G) (at level 39).
 Arguments functor_composite {_ _ _} _ _ .
 Arguments nat_trans_comp {_ _ _ _ _} _ _ .
+Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 Notation "G • F" := (functor_composite F G : [ _ , _ , _ ]) (at level 35).
 Notation "α ∙∙ β" := (hor_comp β α) (at level 20).
 Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).

--- a/UniMath/SubstitutionSystems/PointedFunctors.v
+++ b/UniMath/SubstitutionSystems/PointedFunctors.v
@@ -28,9 +28,9 @@ Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 
-Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 Local Notation "F ⟶ G" := (nat_trans F G) (at level 39).
 Local Notation "G □ F" := (functor_composite _ _ _ F G) (at level 35).
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
 Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 

--- a/UniMath/SubstitutionSystems/SubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/SubstitutionSystems.v
@@ -396,8 +396,8 @@ Qed.
 *)
 
 (** a little preparation for much later *)
-Lemma τ_part_of_alg_mor  (T T' : @algebra_ob ([C, C] hs) Id_H)
-  (β : @algebra_mor ([C, C] hs) Id_H T T'): #H β ;; τ T' = compose (C:=EndC) (τ T) β.
+Lemma τ_part_of_alg_mor  (T T' : @algebra_ob [C, C, hs] Id_H)
+  (β : @algebra_mor [C, C, hs] Id_H T T'): #H β ;; τ T' = compose (C:=EndC) (τ T) β.
 Proof.
   assert (β_is_alg_mor := pr2 β).
   simpl in β_is_alg_mor.
@@ -422,8 +422,8 @@ Qed.
 
 (** A morphism [β] of pointed functors is a bracket morphism when... *)
 
-Lemma is_ptd_mor_alg_mor (T T' : @algebra_ob ([C, C] hs) Id_H)
-  (β : @algebra_mor ([C, C] hs) Id_H T T') :
+Lemma is_ptd_mor_alg_mor (T T' : @algebra_ob [C, C, hs] Id_H)
+  (β : @algebra_mor [C, C, hs] Id_H T T') :
   @is_ptd_mor C (ptd_from_alg T) (ptd_from_alg T') (pr1 β).
 Proof.
   simpl.

--- a/UniMath/SubstitutionSystems/SubstitutionSystems_Summary.v
+++ b/UniMath/SubstitutionSystems/SubstitutionSystems_Summary.v
@@ -167,7 +167,7 @@ Definition bracket_for_initial_algebra
            (Z : precategory_Ptd C hs),
            precategory_Ptd C hs ⟦ Z, ptd_from_alg (InitAlg C hs CP H IA) ⟧
            →
-           [C, C] hs ⟦ ℓ (U Z) ` (InitialObject IA), ` (InitAlg C hs CP H IA) ⟧.
+           [C, C, hs] ⟦ ℓ (U Z) ` (InitialObject IA), ` (InitAlg C hs CP H IA) ⟧.
 Proof.
   apply bracket_Thm15.
 Defined.
@@ -269,7 +269,7 @@ Definition Lam_Flatten
         GlobalRightKanExtensionExists C C (U Z) C hs hs)
     → ∀ Lam_Initial : Initial (FunctorAlg (Id_H C hs CC (Lam_Sig C hs terminal CC CP))
                                           (functor_category_has_homsets C C hs)),
-  [C, C] hs ⟦ (Flat_H C hs) ` (InitialObject Lam_Initial), ` (InitialObject Lam_Initial) ⟧.
+  [C, C, hs] ⟦ (Flat_H C hs) ` (InitialObject Lam_Initial), ` (InitialObject Lam_Initial) ⟧.
 Proof.
   apply Lam_Flatten.
 Defined.
@@ -286,7 +286,7 @@ Definition fbracket_for_LamE_algebra_on_Lam
     precategory_Ptd C hs ⟦ Z ,
                            (ptd_from_alg_functor CC (LamE_Sig C hs terminal CC CP))
                              (LamE_algebra_on_Lam C hs terminal CC CP KanExt Lam_Initial) ⟧
-    → [C, C] hs
+    → [C, C, hs]
              ⟦ functor_composite (U Z)
                                  ` (LamE_algebra_on_Lam C hs terminal CC CP KanExt Lam_Initial),
                ` (LamE_algebra_on_Lam C hs terminal CC CP KanExt Lam_Initial) ⟧.

--- a/UniMath/SubstitutionSystems/SumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/SumOfSignatures.v
@@ -75,7 +75,7 @@ Variable S22 : θ_Strength2 θ2.
 Definition H : functor [C, C, hs] [C, C, hs] := coproduct_functor _ _ CCC H1 H2.
 
 
-Local Definition bla1 (X : [C, C] hs) (Z : precategory_Ptd C hs) :
+Local Definition bla1 (X : [C, C, hs]) (Z : precategory_Ptd C hs) :
    ∀ c : C,
     (functor_composite_data (pr1 Z)
      (coproduct_functor_data C C CC (H1 X) (H2 X))) c
@@ -88,7 +88,7 @@ Proof.
   - exact (pr1 (θ2 (X ⊗ Z)) c).
 Defined.
 
-Local Lemma bar (X : [C, C] hs) (Z : precategory_Ptd C hs):
+Local Lemma bar (X : [C, C, hs]) (Z : precategory_Ptd C hs):
    is_nat_trans
      (functor_composite_data (pr1 Z)
         (coproduct_functor_data C C CC (H1 X) (H2 X)))
@@ -105,7 +105,7 @@ Proof.
   * apply (nat_trans_ax (θ2 (X ⊗ Z))).
 Qed.
 
-Local Definition bla (X : [C, C] hs) (Z : precategory_Ptd C hs) :
+Local Definition bla (X : [C, C, hs]) (Z : precategory_Ptd C hs) :
    functor_composite_data (pr1 Z)
      (coproduct_functor_data C C CC (H1 X) (H2 X))
    ⟶ coproduct_functor_data C C CC (H1 (functor_composite (pr1 Z) X))


### PR DESCRIPTION
by removing obsolete [C,D], replacing it with [C,D,hsD] everywhere.
Also made notation local to ease use of [] notation in other contexts.