### PR TITLE
Update coq

### DIFF
--- a/UniMath/CategoryTheory/category_hset.v
+++ b/UniMath/CategoryTheory/category_hset.v
@@ -373,7 +373,7 @@ End from_colim.
 
 Definition colimCoconeHSET : cocone D colimHSET.
 Proof.
-unshelve refine (mk_cocone _ _).
+simple refine (mk_cocone _ _).
 - now apply injections.
 - abstract (intros u v e;
             apply funextfun; intros Fi; simpl;
@@ -445,9 +445,9 @@ Defined.
 
 Lemma LimConeHSET : LimCone D.
 Proof.
-  unshelve refine (mk_LimCone _ _ _ _ ).
+  simple refine (mk_LimCone _ _ _ _ ).
   - apply limset.
-  - unshelve refine (mk_cone _ _ ).
+  - simple refine (mk_cone _ _ ).
     + intro u. simpl.
       intro f.
       exact (pr1 f u).
@@ -456,12 +456,12 @@ Proof.
       intro f; simpl.
       apply (pr2 f).
   - intros X CC.
-    unshelve refine (tpair _ _ _ ).
-    + unshelve refine (tpair _ _ _ ).
+    simple refine (tpair _ _ _ ).
+    + simple refine (tpair _ _ _ ).
       * simpl.
         intro x.
         {
-          unshelve refine (tpair _ _ _ ).
+          simple refine (tpair _ _ _ ).
           - intro u.
             apply (coconeIn CC u x). (* TODO : hide implementation of limits *)
           - intros u v e. simpl.

--- a/UniMath/CategoryTheory/colimits/chains.v
+++ b/UniMath/CategoryTheory/colimits/chains.v
@@ -85,7 +85,7 @@ Defined.
 Definition shift_cocone {D : diagram nat_graph C}
   {x : C} (cx : cocone D x) : cocone (shift D) x.
 Proof.
-unshelve refine (tpair _ _ _).
+simple refine (tpair _ _ _).
 - now intro n; apply (coconeIn cx).
 - abstract (now intros m n Hmn; destruct Hmn; apply (coconeInCommutes cx)).
 Defined.
@@ -94,7 +94,7 @@ Defined.
 Definition unshift_cocone {D : diagram nat_graph C}
   {x : C} (cx : cocone (shift D) x) : cocone D x.
 Proof.
-unshelve refine (mk_cocone _ _).
+simple refine (mk_cocone _ _).
 - intro n.
   now apply (@dmor _ _ _ n _ (idpath _) ;; coconeIn cx n).
 - abstract (now intros m n Hmn; destruct Hmn; simpl;
@@ -123,7 +123,7 @@ Definition shift_colim (D : diagram nat_graph C) (CC : ColimCocone D) :
 Proof.
 apply (mk_ColimCocone _ (colim CC) (shift_cocone (colimCocone CC))).
 intros x fx.
-unshelve refine (tpair _ _ _).
+simple refine (tpair _ _ _).
 + exists (colimArrow CC x (unshift_cocone fx)).
   abstract (intro n; simpl;
             eapply pathscomp0;
@@ -144,7 +144,7 @@ Definition unshift_colim (D : diagram nat_graph C) (CC : ColimCocone (shift D)) 
 Proof.
 apply (mk_ColimCocone _ (colim CC) (unshift_cocone (colimCocone CC))).
 intros x fx.
-unshelve refine (tpair _ _ _).
+simple refine (tpair _ _ _).
 + exists (colimArrow CC x (shift_cocone fx)).
   abstract (simpl; intro n;
             rewrite <- assoc;
@@ -194,7 +194,7 @@ Defined.
 (* Definition shift_Fdiagram (x : C) : cocone Fdiagram x -> cocone (shift C Fdiagram) (F x). *)
 (* Proof. *)
 (* intro H. *)
-(* unshelve refine (mk_cocone _ _). *)
+(* simple refine (mk_cocone _ _). *)
 (* - simpl. *)
 (*   intro n. *)
 (*   destruct n. *)
@@ -220,7 +220,7 @@ Local Notation LF := (colim (shift_colim C hsC Fdiagram CC)).
 
 Definition Fcocone : cocone Fdiagram (F L).
 Proof.
-unshelve refine (mk_cocone _ _).
+simple refine (mk_cocone _ _).
 - intro n.
   destruct n; simpl.
   + exact (s ;; # F (colimIn CC 0)).
@@ -316,7 +316,7 @@ Qed.
 Local Definition ad : C⟦L,A⟧.
 Proof.
 apply colimArrow.
-unshelve refine (mk_cocone _ _).
+simple refine (mk_cocone _ _).
 - apply cocone_over_alg.
 - apply isCoconeOverAlg.
 Defined.
@@ -358,7 +358,7 @@ End algebra.
 
 Lemma colimAlgIsInitial : isInitial (precategory_FunctorAlg F hsC) colimAlg.
 Proof.
-unshelve refine (mk_isInitial _ _ ).
+simple refine (mk_isInitial _ _ ).
 intros Aa.
 exists (adaggerMor Aa); simpl; intro Fa.
 apply (algebra_mor_eq _ hsC); simpl.
@@ -446,8 +446,8 @@ Proof.
 (* set (X3 := Fcocone _ _ _ _). *)
 (* apply (isColim_is_iso _ X1). *)
 (* intros a ca. *)
-(* unshelve refine (tpair _ _ _). *)
-(* unshelve refine (tpair _ _ _). *)
+(* simple refine (tpair _ _ _). *)
+(* simple refine (tpair _ _ _). *)
 (* apply colimArrow. *)
 (* apply ca. *)
 (* intros v. *)
@@ -515,7 +515,7 @@ Defined.
 Lemma listFunctor_Initial :
   Initial (precategory_FunctorAlg listFunctor has_homsets_HSET).
 Proof.
-unshelve refine (colimAlgInitial _ _ _ _ _ _).
+simple refine (colimAlgInitial _ _ _ _ _ _).
 - apply InitialHSET.
 - apply ColimCoconeHSET.
 - apply listFunctor_chain_cocontinuous.

--- a/UniMath/CategoryTheory/colimits/colimits.v
+++ b/UniMath/CategoryTheory/colimits/colimits.v
@@ -183,7 +183,7 @@ Definition colimOfArrows {g : graph} {d1 d2 : diagram g C}
   (fNat : ∀ u v (e : edge u v), dmor d1 e ;; f v = f u ;; dmor d2 e) :
   C⟦colim CC1,colim CC2⟧.
 Proof.
-apply colimArrow; unshelve refine (mk_cocone _ _).
+apply colimArrow; simple refine (mk_cocone _ _).
 - now intro u; apply (f u ;; colimIn CC2 u).
 - abstract (intros u v e; simpl;
             now rewrite assoc, fNat, <- assoc, colimInCommutes).
@@ -272,7 +272,7 @@ Lemma isColim_weq {g : graph} (D : diagram g C) (c : C) (cc : cocone D c) :
 Proof.
 split.
 - intros H d.
-  unshelve refine (gradth _ _ _ _).
+  simple refine (gradth _ _ _ _).
   + intros k.
     exact (colimArrow (mk_ColimCocone D c cc H) _ k).
   + abstract (intro k; simpl;
@@ -283,7 +283,7 @@ split.
                 | destruct k as [k Hk]; simpl; apply funextsec; intro u;
                   now apply (colimArrowCommutes (mk_ColimCocone D c cc H))]).
 - intros H d cd.
-  unshelve refine (tpair _ _ _).
+  simple refine (tpair _ _ _).
   + exists (invmap (weqpair _ (H d)) cd).
     abstract (intro u; now apply isColim_weq_subproof2).
   + abstract (intro t; apply subtypeEquality;
@@ -302,7 +302,7 @@ Proof.
 intro H.
 apply is_iso_from_is_z_iso.
 set (CD := mk_ColimCocone D d cd H).
-unshelve refine (tpair _ _ _).
+simple refine (tpair _ _ _).
 - apply (colimArrow CD _ (colimCocone CC)).
 - split.
   + apply pathsinv0, colim_endo_is_identity; simpl; intro u.
@@ -341,7 +341,7 @@ Definition ColimFunctor_ob (a : A) : C := colim (HCg a).
 Definition ColimFunctor_mor (a a' : A) (f : A⟦a, a'⟧) :
   C⟦ColimFunctor_ob a,ColimFunctor_ob a'⟧.
 Proof.
-unshelve refine (colimOfArrows _ _ _ _).
+simple refine (colimOfArrows _ _ _ _).
 - now intro u; apply (# (pr1 (dob D u)) f).
 - abstract (now intros u v e; simpl; apply pathsinv0, (nat_trans_ax (dmor D e))).
 Defined.
@@ -368,7 +368,7 @@ Definition ColimFunctor : functor A C := tpair _ _ is_functor_ColimFunctor_data.
 
 Definition colim_nat_trans_in_data v : [A, C, hsC] ⟦ dob D v, ColimFunctor ⟧.
 Proof.
-unshelve refine (tpair _ _ _).
+simple refine (tpair _ _ _).
 - intro a; exact (colimIn (HCg a) v).
 - abstract (intros a a' f;
             now apply pathsinv0, (colimOfArrowsIn _ _ (HCg a) (HCg a'))).
@@ -377,7 +377,7 @@ Defined.
 Definition cocone_pointwise (F : [A,C,hsC]) (cc : cocone D F) a :
   cocone (diagram_pointwise a) (pr1 F a).
 Proof.
-unshelve refine (mk_cocone _ _).
+simple refine (mk_cocone _ _).
 - now intro v; apply (pr1 (coconeIn cc v) a).
 - abstract (intros u v e;
     now apply (nat_trans_eq_pointwise  (coconeInCommutes cc u v e))).
@@ -387,8 +387,8 @@ Lemma ColimFunctor_unique (F : [A, C, hsC]) (cc : cocone D F) :
   iscontr (Σ x : [A, C, hsC] ⟦ ColimFunctor, F ⟧,
             ∀ v : vertex g, colim_nat_trans_in_data v ;; x = coconeIn cc v).
 Proof.
-unshelve refine (tpair _ _ _).
-- unshelve refine (tpair _ _ _).
+simple refine (tpair _ _ _).
+- simple refine (tpair _ _ _).
   + apply (tpair _ (fun a => colimArrow (HCg a) _ (cocone_pointwise F cc a))).
     abstract (intros a a' f; simpl;
               eapply pathscomp0;
@@ -411,9 +411,9 @@ Defined.
 
 Lemma ColimFunctorCocone : ColimCocone D.
 Proof.
-unshelve refine (mk_ColimCocone _ _ _ _).
+simple refine (mk_ColimCocone _ _ _ _).
 - exact ColimFunctor.
-- unshelve refine (mk_cocone _ _).
+- simple refine (mk_cocone _ _).
   + now apply colim_nat_trans_in_data.
   + abstract (now intros u v e; apply (nat_trans_eq hsC);
                   intro a; apply (colimInCommutes (HCg a))).

--- a/UniMath/CategoryTheory/limits/coproducts.v
+++ b/UniMath/CategoryTheory/limits/coproducts.v
@@ -109,7 +109,7 @@ Definition mk_CoproductCocone (a b : C) :
    isCoproductCocone _ _ _ f g →  CoproductCocone a b.
 Proof.
   intros.
-  unshelve refine (tpair _ _ _ ).
+  simple refine (tpair _ _ _ ).
   - exists c.
     exists f.
     exact g.

--- a/UniMath/CategoryTheory/limits/coproducts_as_colimits.v
+++ b/UniMath/CategoryTheory/limits/coproducts_as_colimits.v
@@ -29,7 +29,7 @@ Defined.
 
 Definition CopCocone {C : precategory} {a b : C} {c : C} (ac : a ⇒ c) (bc : b ⇒ c) :
    cocone (coproduct_diagram a b) c.
-unshelve refine (tpair _ _ _ ).
+simple refine (tpair _ _ _ ).
 + intro v.
   induction v; simpl.
   - exact ac.
@@ -73,7 +73,7 @@ Definition mk_CoproductCocone (a b : C) :
    isCoproductCocone _ _ _ f g →  CoproductCocone a b.
 Proof.
   intros.
-  unshelve refine (tpair _ _ _ ).
+  simple refine (tpair _ _ _ ).
   - exists c.
     apply (CopCocone f g).
   - apply X.
@@ -93,7 +93,7 @@ Definition CoproductArrow {a b : C} (CC : CoproductCocone a b) {c : C} (f : a �
       CoproductObject CC ⇒ c.
 Proof.
   apply (colimArrow CC).
-  unshelve refine (mk_cocone _ _ ).
+  simple refine (mk_cocone _ _ ).
   + intro v. induction v.
     - apply f.
     - apply g.

--- a/UniMath/CategoryTheory/limits/initial_as_colimit.v
+++ b/UniMath/CategoryTheory/limits/initial_as_colimit.v
@@ -25,7 +25,7 @@ Defined.
 
 Definition initCocone (c : C) : cocone initDiagram c.
 Proof.
-unshelve refine (mk_cocone _ _); intro v; induction v.
+simple refine (mk_cocone _ _); intro v; induction v.
 Defined.
 
 Definition isInitial (a : C) :=
@@ -36,7 +36,7 @@ Definition mk_isInitial (a : C) (H : ∀ (b : C), iscontr (a ⇒ b)) :
   isInitial a.
 Proof.
 intros b cb.
-unshelve refine (tpair _ _ _).
+simple refine (tpair _ _ _).
 - exists (pr1 (H b)); intro v; induction v.
 - intro t.
   apply subtypeEquality; simpl;
@@ -53,7 +53,7 @@ refine (mk_ColimCocone _ a (initCocone a) _).
 apply mk_isInitial.
 intro b.
 set (x := H b (initCocone b)).
-unshelve refine (tpair _ _ _).
+simple refine (tpair _ _ _).
 - apply (pr1 x).
 - simpl; intro f; apply path_to_ctr; intro v; induction v.
 Defined.

--- a/UniMath/CategoryTheory/limits/limits.v
+++ b/UniMath/CategoryTheory/limits/limits.v
@@ -79,7 +79,7 @@ Definition LimCone {g : graph} (d : diagram g C^op) : UU :=
 Definition mk_LimCone {g : graph} (d : diagram g C^op)
   (c : C) (cc : cone d c) (isCC : isLimCone d c cc) : LimCone d.
 Proof.
-unshelve refine (mk_ColimCocone _ _ _ _  ).
+simple refine (mk_ColimCocone _ _ _ _  ).
 - apply c.
 - apply cc.
 - apply isCC.
@@ -162,7 +162,7 @@ Definition limOfArrows {g : graph} {d1 d2 : diagram g C^op}
                                 (dmor d1 e : C⟦dob d1 v, dob d1 u⟧);; f u) :
   C⟦lim CC1 , lim CC2⟧.
 Proof.
-  unshelve refine (colimOfArrows CC2 CC1 _ _ ).
+  simple refine (colimOfArrows CC2 CC1 _ _ ).
   - apply f.
   - apply fNat.
 Defined.
@@ -296,7 +296,7 @@ Definition get_diagram (A C : precategory) (hsC : has_homsets C)
 Proof.
 apply (tpair _ (fun u => from_opp_to_opp_opp _ _ _ (pr1 D u))).
 intros u v e; simpl.
-unshelve refine (tpair _ _ _); simpl.
+simple refine (tpair _ _ _); simpl.
   + apply (pr2 D _ _ e).
   + abstract (intros a b f; apply pathsinv0, (pr2 (pr2 D u v e) b a f)).
 Defined.
@@ -307,7 +307,7 @@ Definition get_cocone  (A C : precategory) (hsC : has_homsets C)
 Proof.
 destruct ccF. (* If I remove this destruct the Qed for LimsFunctorCategory
                  takes twice as long *)
-unshelve refine (mk_cocone _ _).
+simple refine (mk_cocone _ _).
 - intro u; apply (tpair _ (pr1 (t u))).
   abstract (intros a b f; apply pathsinv0, (pr2 (t u) b a f)).
 - abstract (intros u v e; apply (nat_trans_eq (has_homsets_opp hsC));
@@ -329,10 +329,10 @@ destruct HColim as [pr1x pr2x].
 destruct pr1x as [pr1pr1x pr2pr1x].
 destruct pr2pr1x as [pr1pr2pr1x pr2pr2pr1x].
 simpl in *.
-unshelve refine (mk_ColimCocone _ (from_opp_opp_to_opp _ _ _ pr1pr1x) _ _).
-- unshelve refine (mk_cocone _ _).
+simple refine (mk_ColimCocone _ (from_opp_opp_to_opp _ _ _ pr1pr1x) _ _).
+- simple refine (mk_cocone _ _).
   + simpl; intros.
-    unshelve refine (tpair _ _ _).
+    simple refine (tpair _ _ _).
     * intro a; apply (pr1pr2pr1x v a).
     * abstract (intros a b f; apply pathsinv0, (nat_trans_ax (pr1pr2pr1x v) (*b a f*))).
   + abstract (intros u v e; apply (nat_trans_eq hsC); simpl; intro a;
@@ -342,8 +342,8 @@ unshelve refine (mk_ColimCocone _ (from_opp_opp_to_opp _ _ _ pr1pr1x) _ _).
   destruct H as [H1 H2].
   destruct H1 as [α Hα].
   simpl in *.
-  unshelve refine (tpair _ _ _).
-  + unshelve refine (tpair _ _ _).
+  simple refine (tpair _ _ _).
+  + simple refine (tpair _ _ _).
     * exists α.
       abstract (intros a b f; simpl; now apply pathsinv0, (nat_trans_ax α b a f)).
     * abstract (intro u; apply (nat_trans_eq hsC); intro a;
@@ -352,7 +352,7 @@ unshelve refine (mk_ColimCocone _ (from_opp_opp_to_opp _ _ _ pr1pr1x) _ _).
     * abstract (intro β; repeat (apply impred; intro);
         now apply (has_homsets_opp (functor_category_has_homsets A C hsC))).
     * match goal with |[ H2 : ∀ _ : ?TT ,  _ = _ ,,_   |- _ ] =>
-                       unshelve refine (let T : TT := _ in _ ) end.
+                       simple refine (let T : TT := _ in _ ) end.
       (*
       refine (let T : Σ x : nat_trans pr1pr1x (functor_opp F),
                          ∀ v, nat_trans_comp (functor_opp (pr1 D v)) _ _
@@ -360,7 +360,7 @@ unshelve refine (mk_ColimCocone _ (from_opp_opp_to_opp _ _ _ pr1pr1x) _ _).
                                coconeIn (get_cocone A C hsC g D F ccF) v :=
                   _ in _).
       *)
-      { unshelve refine (tpair _ (tpair _ (pr1 f) _) _); simpl.
+      { simple refine (tpair _ (tpair _ (pr1 f) _) _); simpl.
         - abstract (intros x y fxy; apply pathsinv0, (pr2 f y x fxy)).
         - abstract (intro u; apply (nat_trans_eq (has_homsets_opp hsC)); intro x;
             destruct ccF; apply (toforallpaths _ _ _ (maponpaths pr1 (Hf u)) x)).

--- a/UniMath/CategoryTheory/limits/more_on_pullbacks.v
+++ b/UniMath/CategoryTheory/limits/more_on_pullbacks.v
@@ -43,7 +43,7 @@ Proof.
   set (FxFy := pr1 (pr1 TH)).
   assert (HFxFy := pr2 (pr1 TH)). simpl in HFxFy.
   set (xy := fully_faithful_inv_hom Fff _ _ FxFy).
-  unshelve refine (tpair _ _ _ ).
+  simple refine (tpair _ _ _ ).
   - exists xy.
     destruct HFxFy; split.
     + refine ( invmaponpathsweq (weqpair _ (Fff _ _ )) _ _ _ ).

--- a/UniMath/CategoryTheory/limits/products.v
+++ b/UniMath/CategoryTheory/limits/products.v
@@ -75,7 +75,7 @@ Definition mk_ProductCone (a b : C) :
    isProductCone _ _ _ f g -> ProductCone a b.
 Proof.
   intros.
-  unshelve refine (tpair _ _ _ ).
+  simple refine (tpair _ _ _ ).
   - exists c.
     exists f.
     exact g.

--- a/UniMath/CategoryTheory/limits/products_as_colimit.v
+++ b/UniMath/CategoryTheory/limits/products_as_colimit.v
@@ -31,7 +31,7 @@ Defined.
 Definition ProdCone {a b c : C} (ca : C⟦c,a⟧) (cb : C⟦c,b⟧) :
   cone (product_diagram a b) c.
 Proof.
-unshelve refine (tpair _ _ _); simpl.
+simple refine (tpair _ _ _); simpl.
 - intro v; induction v.
   + exact ca.
   + exact cb.
@@ -66,7 +66,7 @@ Definition mk_ProductCone (a b : C) :
    isProductCone _ _ _ f g -> ProductCone a b.
 Proof.
   intros.
-  unshelve refine (tpair _ _ _ ).
+  simple refine (tpair _ _ _ ).
   - exists c.
     apply (ProdCone f g).
   - apply X.
@@ -91,7 +91,7 @@ Definition ProductArrow {a b : C} (P : ProductCone a b) {c : C}
   (f : C⟦c,a⟧) (g : C⟦c,b⟧) : C⟦c,ProductObject P⟧.
 Proof.
 apply (limArrow P).
-unshelve refine (mk_cone _ _).
+simple refine (mk_cone _ _).
 - intro v; induction v; [ apply f | apply g ].
 - intros ? ? e; induction e. (* <- should not be opaque! otherwise ProductPr1Commutes doesn't work *)
 Defined.

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -103,8 +103,8 @@ Definition mk_Pullback {a b c : C} (f : C⟦b, a⟧)(g : C⟦c, a⟧)
     (ispb : isPullback f g p1 p2 H)
   : Pullback f g.
 Proof.
-  unshelve refine (tpair _ _ _ ).
-  - unshelve refine (tpair _ _ _ ).
+  simple refine (tpair _ _ _ ).
+  - simple refine (tpair _ _ _ ).
     + apply d.
     + exists p1.
       exact p2.

--- a/UniMath/CategoryTheory/limits/pullbacks_as_colimits.v
+++ b/UniMath/CategoryTheory/limits/pullbacks_as_colimits.v
@@ -46,7 +46,7 @@ Definition PullbCone {a b c : C} (f : C ⟦b,a⟧) (g : C⟦c,a⟧)
            (H : f' ;; f = g';; g)
   : cone (pullback_diagram f g) d.
 Proof.
-  unshelve refine (mk_cone _ _  ).
+  simple refine (mk_cone _ _  ).
   - intro v; induction v; simpl; try assumption.
     apply (f' ;; f).
   - intros u v e;
@@ -72,14 +72,14 @@ Definition mk_isPullback {a b c d : C} (f : C ⟦b, a⟧) (g : C ⟦c, a⟧)
 Proof.
   intros H' x cx; simpl in *.
   set (H1 := H' x (coneOut cx One) (coneOut cx Three) ).
-  unshelve refine (let p : coneOut cx One ;; f = coneOut cx Three ;; g := _ in _ ).
+  simple refine (let p : coneOut cx One ;; f = coneOut cx Three ;; g := _ in _ ).
   - set (H2 := coneOutCommutes cx Two One tt).
     eapply pathscomp0. apply H2.
     clear H2.
     apply pathsinv0.
     apply (coneOutCommutes cx Two Three tt).
   - set (H2 := H1 p).
-    unshelve refine (tpair _ _ _ ).
+    simple refine (tpair _ _ _ ).
     + exists (pr1 (pr1 H2)).
       intro v; induction v; simpl.
       * apply (pr1 (pr2 (pr1 H2))).
@@ -123,10 +123,10 @@ Definition mk_Pullback {a b c : C} (f : C⟦b, a⟧)(g : C⟦c, a⟧)
     (ispb : isPullback f g p1 p2 H)
   : Pullback f g.
 Proof.
-  unshelve refine (tpair _ _ _ ).
-  - unshelve refine (tpair _ _ _ ).
+  simple refine (tpair _ _ _ ).
+  - simple refine (tpair _ _ _ ).
     + apply d.
-    + unshelve refine (PullbCone _ _ _ _ _ _ ); assumption.
+    + simple refine (PullbCone _ _ _ _ _ _ ); assumption.
   - apply ispb.
 Defined.
 
@@ -169,8 +169,8 @@ Definition PullbackArrow {a b c : C} {f : C⟦b, a⟧} {g : C⟦c, a⟧}
            (Pb : Pullback f g) e (h : C⟦e, b⟧) (k : C⟦e, c⟧)(H : h ;; f = k ;; g)
   : C⟦e, lim Pb⟧.
 Proof.
-  unshelve refine (limArrow _ _ _ ).
-  unshelve refine (mk_cone _ _ ).
+  simple refine (limArrow _ _ _ ).
+  simple refine (mk_cone _ _ ).
   - intro v; induction v; simpl; try assumption.
     apply (h ;; f).
   - intros u v edg; induction u; induction v; try induction edg; simpl.
@@ -219,8 +219,8 @@ Definition isPullback_Pullback {a b c : C} {f : C⟦b, a⟧}{g : C⟦c, a⟧}
 Proof.
   apply mk_isPullback.
   intros e h k HK.
-  unshelve refine (tpair _ _ _ ).
-  - unshelve refine (tpair _ _ _ ).
+  simple refine (tpair _ _ _ ).
+  - simple refine (tpair _ _ _ ).
     + apply (PullbackArrow P _ h k HK).
     + split.
       * apply PullbackArrow_PullbackPr1.

--- a/UniMath/CategoryTheory/limits/terminal_as_colimit.v
+++ b/UniMath/CategoryTheory/limits/terminal_as_colimit.v
@@ -30,7 +30,7 @@ Defined.
 
 Definition termCone (c : C) : cone termDiagram c.
 Proof.
-unshelve refine (mk_cocone _ _); intro v; induction v.
+simple refine (mk_cocone _ _); intro v; induction v.
 Defined.
 
 Definition isTerminal (a : C) :=
@@ -40,7 +40,7 @@ Definition mk_isTerminal (b : C) (H : ∀ (a : C), iscontr (a ⇒ b)) :
   isTerminal b.
 Proof.
 intros a ca.
-unshelve refine (tpair _ _ _).
+simple refine (tpair _ _ _).
 - exists (pr1 (H a)); intro v; induction v.
 - intro t.
   apply subtypeEquality; simpl;
@@ -57,7 +57,7 @@ refine (mk_LimCone _ b (termCone b) _).
 apply mk_isTerminal.
 intro a.
 set (x := H a (termCone a)).
-unshelve refine (tpair _ _ _).
+simple refine (tpair _ _ _).
 - apply (pr1 x).
 - simpl; intro f; apply path_to_ctr; intro v; induction v.
 Defined.

--- a/UniMath/CategoryTheory/opp_precat.v
+++ b/UniMath/CategoryTheory/opp_precat.v
@@ -123,7 +123,7 @@ Definition from_opp_to_opp_opp (A C : precategory) (hsC : has_homsets C) :
 Proof.
 apply (tpair _ functor_opp).
 simpl; intros F G α.
-unshelve refine (tpair _ _ _).
+simple refine (tpair _ _ _).
 + simpl; intro a; apply α.
 + abstract (intros a b f; simpl in *;
             apply pathsinv0, (nat_trans_ax α)).
@@ -144,9 +144,9 @@ Definition functor_from_opp_to_opp_opp (A C : precategory) (hsC : has_homsets C)
 Definition from_opp_opp_to_opp (A C : precategory) (hsC : has_homsets C) :
   functor_data [A^op, C^op, has_homsets_opp hsC] [A, C, hsC]^op.
 Proof.
-unshelve refine (tpair _ _ _); simpl.
+simple refine (tpair _ _ _); simpl.
 - intro F.
-  unshelve refine (tpair _ _ _).
+  simple refine (tpair _ _ _).
   + exists F.
     apply (fun a b f => # F f).
   + abstract (split; [ intro a; apply (functor_id F)

--- a/UniMath/CategoryTheory/yoneda.v
+++ b/UniMath/CategoryTheory/yoneda.v
@@ -251,7 +251,7 @@ Lemma isweq_yoneda_map_1 (C : precategory) (hs: has_homsets C) (c : C)
      (yoneda_map_1 C hs c F).
 Proof.
   set (T:=yoneda_map_2 C hs c F). simpl in T.
-  unshelve refine (gradth _ _ _ _ ).
+  simple refine (gradth _ _ _ _ ).
   - apply T.
   - apply yoneda_map_1_2.
   - apply yoneda_map_2_1.
@@ -300,7 +300,7 @@ Variable c : C.
 Definition yoneda_functor_precomp' : nat_trans (yoneda_objects C hsC c)
       (functor_composite _ _ _ (functor_opp F) (yoneda_objects D hsD (F c))).
 Proof.
-  unshelve refine (tpair _ _ _ ).
+  simple refine (tpair _ _ _ ).
   - intros d f ; simpl.
     apply (#F f).
   - abstract (intros d d' f ;
@@ -338,7 +338,7 @@ Definition yoneda_functor_precomp_nat_trans :
       (yoneda C hsC)
       (functor_composite _ _ _ A B).
 Proof.
-  unshelve refine (tpair _ _ _ ).
+  simple refine (tpair _ _ _ ).
   - intro c; simpl.
     apply yoneda_functor_precomp.
   - abstract (

--- a/UniMath/Foundations/Basics/PartA.v
+++ b/UniMath/Foundations/Basics/PartA.v
@@ -1778,7 +1778,7 @@ split with f . apply ( gradth _ _ egf  efg ) . Defined .
 Definition weqtotal2dirprodcomm {X Y:UU} (P: X × Y -> UU) : (Σ xy : X×Y, P xy) ≃ (Σ xy : Y×X, P (weqdirprodcomm _ _ xy)).
 Proof.
   intros.
-  unshelve refine (weqgradth _ _ _ _).
+  simple refine (weqgradth _ _ _ _).
   - intros xyp. induction xyp as [xy p]. induction xy as [x y]. exact ((y,,x),,p).
   - intros yxp. induction yxp as [yx p]. induction yx as [y x]. exact ((x,,y),,p).
   - intros xyp. induction xyp as [xy p]. induction xy as [x y]. reflexivity.
@@ -1787,7 +1787,7 @@ Defined.
 
 Definition weqtotal2dirprodassoc  {X Y:UU} (P: X × Y -> UU) : (Σ xy : X×Y, P xy) ≃ (Σ (x:X) (y:Y), P (x,,y)).
   intros.
-  unshelve refine (weqgradth _ _ _ _).
+  simple refine (weqgradth _ _ _ _).
   - intros xyp. induction xyp as [xy p]. induction xy as [x y]. exact (x,,y,,p).
   - intros xyp. induction xyp as [x yp]. induction yp as [y p]. exact ((x,,y),,p).
   - intros xyp. induction xyp as [xy p]. induction xy as [x y]. reflexivity.
@@ -1797,7 +1797,7 @@ Defined.
 Definition weqtotal2dirprodassoc' {X Y:UU} (P: X × Y -> UU) : (Σ xy : X×Y, P xy) ≃ (Σ (y:Y) (x:X), P (x,,y)).
 Proof.
   intros.
-  unshelve refine (weqgradth _ _ _ _).
+  simple refine (weqgradth _ _ _ _).
   - intros xyp. induction xyp as [xy p]. induction xy as [x y]. exact (y,,x,,p).
   - intros yxp. induction yxp as [x yp]. induction yp as [y p]. exact ((y,,x),,p).
   - intros xyp. induction xyp as [xy p]. induction xy as [x y]. reflexivity.
@@ -1808,7 +1808,7 @@ Definition weqtotal2comm12 {X} (P Q : X -> UU) :
   (Σ (w : Σ x, P x), Q (pr1 w)) ≃ (Σ (w : Σ x, Q x), P (pr1 w)).
 Proof.
   intros.
-  unshelve refine (weqgradth _ _ _ _).
+  simple refine (weqgradth _ _ _ _).
   - intros [[x p] q]. exact ((x,,q),,p).
   - intros [[x q] p]. exact ((x,,p),,q).
   - intros [[x p] q]. reflexivity.
@@ -2592,10 +2592,10 @@ Defined.
 
 Definition weqfp {X Y : UU} (w : X ≃ Y) (P:Y->UU) : (Σ x : X, P (w x)) ≃ (Σ y, P y).
 Proof. intros. exists (weqfp_map w P). refine (gradth _ (weqfp_invmap w P) _ _).
-  { intros xp. unshelve refine (total2_paths _ _).
+  { intros xp. simple refine (total2_paths _ _).
     { simpl. apply homotinvweqweq. }
     simpl. rewrite <- weq_transportf_adjointness. rewrite transport_f_f. rewrite pathsinv0l. reflexivity. }
-  { intros yp. unshelve refine (total2_paths _ _).
+  { intros yp. simple refine (total2_paths _ _).
     { simpl. apply homotweqinvweq. }
     simpl. rewrite transport_f_f. rewrite pathsinv0l. reflexivity. }
 Defined.
@@ -2747,7 +2747,7 @@ Defined.
 
 Definition hfp_right {X Y Z:UU} (f:X->Z) (g:Y->Z) : hfp f g ≃ Σ y, hfiber f (g y).
 Proof.
-  intros. unshelve refine (weqgradth _ _ _ _).
+  intros. simple refine (weqgradth _ _ _ _).
   - intros [[x y] e]. exact (y,,x,,!e).
   - intros [x [y e]]. exact ((y,,x),,!e).
   - intros [[x y] e]. apply maponpaths, pathsinv0inv0.
@@ -2756,7 +2756,7 @@ Defined.
 
 Definition hfiber_comm {X Y Z:UU} (f:X->Z) (g:Y->Z) : (Σ x, hfiber g (f x)) ≃ (Σ y, hfiber f (g y)).
 Proof.
-  intros. unshelve refine (weqgradth _ _ _ _).
+  intros. simple refine (weqgradth _ _ _ _).
   - intros [x [y e]]. exact (y,,x,,!e).
   - intros [y [x e]]. exact (x,,y,,!e).
   - intros [x [y e]]. apply maponpaths, maponpaths, pathsinv0inv0.

--- a/UniMath/Foundations/Basics/PartB.v
+++ b/UniMath/Foundations/Basics/PartB.v
@@ -294,10 +294,10 @@ Proof. intros n X is .  apply ( isofhlevelweqf n ( weqhfibertounit X ) ( is tt )
 
 Definition weqhfiberunit {X Z} (i:X->Z) (z:Z) : (Σ x, hfiber (λ _:unit, z) (i x)) ≃ hfiber i z.
 Proof.
-  intros. unshelve refine (weqgradth _ _ _ _).
+  intros. simple refine (weqgradth _ _ _ _).
   + intros [x [t e]]. exact (x,,!e).
   + intros [x e]. exact (x,,tt,,!e).
-  + intros [x [t e]]. apply maponpaths. unshelve refine (total2_paths2 _ _).
+  + intros [x [t e]]. apply maponpaths. simple refine (total2_paths2 _ _).
     * apply isapropunit.
     * simpl. induction e. rewrite pathsinv0inv0. induction t. reflexivity.
   + intros [x e]. apply maponpaths. apply pathsinv0inv0.

--- a/UniMath/Foundations/Basics/PartC.v
+++ b/UniMath/Foundations/Basics/PartC.v
@@ -278,7 +278,7 @@ Definition isisolated_ne_to_isisolated {X x neq_x} :
 Proof.
   intros ? ? ? i y. induction (i y) as [eq|ne].
   - exact (ii1 eq).
-  - apply ii2. now unshelve refine (negProp_to_neg _).
+  - apply ii2. now simple refine (negProp_to_neg _).
 Defined.
 
 Definition isolated ( T : UU ) := Σ t:T, isisolated _ t.
@@ -389,14 +389,14 @@ Proof.
   { induction eq. refine (iscontrweqf (weqii2withneg _ _) _).
     { intros z; induction z as [z e]; induction z as [z neq]; simpl in *.
       contradicts (!e) (negProp_to_neg neq). }
-    { change x with (f (ii2 tt)). unshelve refine ((_,,_),,_).
+    { change x with (f (ii2 tt)). simple refine ((_,,_),,_).
       { exact tt. }
       { reflexivity. }
       { intro w. induction w as [t e]. unfold f in *; simpl in *. induction t.
         apply maponpaths. apply isaproppathsfromisolated. exact is. }}}
   { refine (iscontrweqf (weqii1withneg _ _) _).
     { intros z; induction z as [z e]; simpl in *. contradicts ne e. }
-    { unshelve refine ((_,,_),,_).
+    { simple refine ((_,,_),,_).
       { exists y. now apply neg_to_negProp. }
       { simpl. reflexivity. }
       intros z; induction z as [z e]; induction z as [z neq]; induction e; simpl in *.
@@ -507,7 +507,7 @@ Definition weqtranspos0 { T : UU } ( t1 t2 : T ) :
   isisolated T t1 -> isisolated T t2 -> compl T t1 ≃ compl T t2.
 Proof.
   intros ? ? ? is1 is2.
-  unshelve refine (weqgradth (funtranspos0 t1 t2 is2) (funtranspos0 t2 t1 is1) _ _).
+  simple refine (weqgradth (funtranspos0 t1 t2 is2) (funtranspos0 t2 t1 is1) _ _).
   - intro x. apply ( homottranspos0t2t1t1t2 t1 t2 is1 is2 ) .
   - intro x. apply ( homottranspos0t2t1t1t2 t2 t1 is2 is1 ) .
 Defined .

--- a/UniMath/Foundations/Basics/Tests.v
+++ b/UniMath/Foundations/Basics/Tests.v
@@ -21,7 +21,7 @@ Module Test_gradth.
   Goal homotweqinvweqweq w 3 = idpath _. reflexivity. Defined.
 
   Definition v : bool ≃ bool.
-    unshelve refine (weqgradth negb negb _ _); intro x; induction x; reflexivity. Defined.
+    simple refine (weqgradth negb negb _ _); intro x; induction x; reflexivity. Defined.
   Goal homotinvweqweq v true = idpath _. reflexivity. Defined.
   Goal homotweqinvweq v true = idpath _. reflexivity. Defined.
   Goal homotweqinvweqweq v true = idpath _. reflexivity. Defined.

--- a/UniMath/Foundations/Combinatorics/FiniteSequences.v
+++ b/UniMath/Foundations/Combinatorics/FiniteSequences.v
@@ -297,7 +297,7 @@ Definition concatenate_0 {X} (s:Sequence X) (t:stn 0 -> X) : concatenate s (0,,t
 Proof.
   intros.
   induction s as [n s].
-  unshelve refine (total2_paths2 _ _).
+  simple refine (total2_paths2 _ _).
   { simpl. apply natplusr0. }
   { simpl. generalize (natplusr0 n). intro e. apply funextsec; intro i.
 
@@ -357,13 +357,13 @@ Proof.
   unfold total2_step_b, total2_step_f.
   induction (natlehchoice4 j n J) as [J'|K].
   + simpl.
-    unshelve refine (total2_paths _ _).
+    simple refine (total2_paths _ _).
     * simpl. rewrite replace_dni_last. apply isinjstntonat. reflexivity.
     * rewrite replace_dni_last. unfold dni_lastelement.  simpl.
       change (λ x0 : stn (S n), X x0) with X.
       rewrite transport_f_b. apply (isaset_transportf X).
   + induction (!K). simpl.
-    unshelve refine (total2_paths _ _).
+    simple refine (total2_paths _ _).
     * simpl. now apply isinjstntonat.
     * simpl. assert (d : idpath n = K).
       { apply isasetnat. }
@@ -500,7 +500,7 @@ Definition isassoc_concatenate {X} (x y z:Sequence X) :
   concatenate (concatenate x y) z = concatenate x (concatenate y z).
 Proof.
   intros.
-  unshelve refine (total2_paths _ _).
+  simple refine (total2_paths _ _).
   - simpl. apply natplusassoc.
   - apply sequenceEquality; intros i.
 

--- a/UniMath/Foundations/Combinatorics/OrderedSets.v
+++ b/UniMath/Foundations/Combinatorics/OrderedSets.v
@@ -122,7 +122,7 @@ Defined.
 Local Lemma posetTransport_weq (X Y:Poset) : X≡Y ≃ X≅Y.
 Proof.
   intros.
-  unshelve refine (weqbandf _ _ _ _).
+  simple refine (weqbandf _ _ _ _).
   { apply hSet_univalence. }
   intros e. apply invweq. apply poTransport_weq.
 Defined.
@@ -267,7 +267,7 @@ Definition underlyingPoset_weq (X Y:OrderedSet) :
   X=Y ≃ (underlyingPoset X)=(underlyingPoset Y).
 Proof.
   Set Printing Coercions.
-  intros. unshelve refine (weqpair _ _).
+  intros. simple refine (weqpair _ _).
   { apply maponpaths. }
   apply isweqonpathsincl. apply isincl_underlyingPoset.
   Unset Printing Coercions.
@@ -324,7 +324,7 @@ Definition FiniteOrderedSetDecidableInequality (X:FiniteOrderedSet) : DecidableR
 Defined.
 
 Definition FiniteOrderedSetDecidableLessThan (X:FiniteOrderedSet) : DecidableRelation X.
-  intros ? x y. unshelve refine (decidable_to_DecidableProposition _).
+  intros ? x y. simple refine (decidable_to_DecidableProposition _).
   - exact (x < y).
   - apply isfinite_isdec_lessthan. apply finitenessProperty.
 Defined.
@@ -352,7 +352,7 @@ Defined.
 
 Definition standardFiniteOrderedSet (n:nat) : FiniteOrderedSet.
 Proof.
-  intros. unshelve refine (_,,_).
+  intros. simple refine (_,,_).
   - exists (stnposet n). intros x y; apply istotalnatleh.
   - apply isfinitestn.
 Defined.
@@ -380,11 +380,11 @@ Definition transportFiniteOrdering {n} {X:UU} : X ≃ ⟦ n ⟧ -> FiniteOrdered
 (* The new finite ordered set has X as its underlying set. *)
 Proof.
   intros ? ? w.
-  unshelve refine (_,,_).
-  - unshelve refine (_,,_).
-    * unshelve refine (_,,_).
+  simple refine (_,,_).
+  - simple refine (_,,_).
+    * simple refine (_,,_).
     + exists X. apply (isofhlevelweqb 2 w). apply setproperty.
-      + unfold PartialOrder; simpl. unshelve refine (_,,_).
+      + unfold PartialOrder; simpl. simple refine (_,,_).
         { intros x y. exact (w x ≤ w y). }
         apply inducedPartialOrder_weq.
         exact (pr2 (pr2 (pr1 (pr1 ⟦ n ⟧)))).
@@ -490,12 +490,12 @@ Definition concatenateFiniteOrderedSets
 Proof.
   (* we use lexicographic order *)
   intros.
-  unshelve refine (_,,_).
+  simple refine (_,,_).
   {
-    unshelve refine (_,,_).
-    { unshelve refine (_,,_).
+    simple refine (_,,_).
+    { simple refine (_,,_).
       { exact (Σ x, Y x)%set. }
-      unshelve refine (_,,_).
+      simple refine (_,,_).
       { apply lexicographicOrder. apply posetRelation. intro. apply posetRelation. }
       split.
       { split.
@@ -560,7 +560,7 @@ Abort.
 Theorem enumeration_FiniteOrderedSet (X:FiniteOrderedSet) : iscontr (FiniteStructure X).
 Proof.
   intros.
-  unshelve refine (_,,_).
+  simple refine (_,,_).
   { exists (fincard (finitenessProperty X)).
 
   (* proof in progress... *)

--- a/UniMath/Foundations/Combinatorics/Tests.v
+++ b/UniMath/Foundations/Combinatorics/Tests.v
@@ -66,7 +66,7 @@ Module Test_stn.
 
     (* here's an example that shows complications need not impede that sort of computability: *)
     Local Definition w : unit ≃ stn 1.
-      unshelve refine (weqgradth _ _ _ _).
+      simple refine (weqgradth _ _ _ _).
       { intro. exact (firstelement _). }
       { intro. exact tt. }
       { intro u. simpl. induction u. reflexivity. }

--- a/UniMath/Foundations/NumberSystems/NaturalNumbers.v
+++ b/UniMath/Foundations/NumberSystems/NaturalNumbers.v
@@ -1547,7 +1547,7 @@ Defined.
 Theorem weqdicompl i : nat ≃ nat_compl i.
 Proof.
   intros i.
-  unshelve refine (weqgradth _ _ _ _).
+  simple refine (weqgradth _ _ _ _).
   - intro j. exists (di i j). apply di_neq_i.
   - intro j. exact (si i (pr1 j)).
   - simpl. intro j. unfold di. induction (natlthorgeh j i) as [lt|ge].

--- a/UniMath/Ktheory/AbelianGroup.v
+++ b/UniMath/Ktheory/AbelianGroup.v
@@ -293,13 +293,13 @@ Module Presentation.
   Definition universalMarkedAbelianGroup0 {X I} (R:I->reln X) : abgr.
     intros.
     { exists (univ_setwithbinop R). split.
-      { unshelve refine (_,,_).
+      { simple refine (_,,_).
         { split.
           { exact (isassoc_univ_binop R). }
           { exists (setquotpr _ word_unit). split.
             { exact (is_left_unit_univ_binop R). }
             { exact (is_right_unit_univ_binop R). } } }
-        { unshelve refine (_,,_).
+        { simple refine (_,,_).
           { exact (univ_inverse R). }
           { split.
             { exact (is_left_inverse_univ_binop R). }
@@ -337,10 +337,10 @@ Module Presentation.
          { intermediate_path (unel M). exact (unitproperty f). exact (!unitproperty g). }
          { apply p. }
          (* compare duplication with the proof of MarkedAbelianGroupMap_compat *)
-         { unshelve refine (monoidfuninvtoinv f (setquotpr (smallestAdequateRelation R) w)
+         { simple refine (monoidfuninvtoinv f (setquotpr (smallestAdequateRelation R) w)
              @ _ @ ! monoidfuninvtoinv g (setquotpr (smallestAdequateRelation R) w)).
            apply (ap (grinv M)). apply agreement_on_gens0. assumption. }
-         { unshelve refine (
+         { simple refine (
                Monoid.multproperty f (setquotpr (smallestAdequateRelation R) v)
                    (setquotpr (smallestAdequateRelation R) w)
              @ _ @ !
@@ -431,13 +431,13 @@ Module Sum.                   (* coproducts *)
   Definition make {I} (G:I->abgr) : abgr.
     intros. exact (Presentation.universalMarkedAbelianGroup (R G)). Defined.
   Definition Incl {I} (G:I->abgr) (i:I) : Hom (G i) (make G).
-    intros. unshelve refine (_,,_).
+    intros. simple refine (_,,_).
     { intro g. apply setquotpr. apply word_gen. exact (i,,g). } { split.
       { intros g h. apply iscompsetquotpr. exact (base (adequacy _) (J_sum _ (i,,(g,,h)))). }
       { apply iscompsetquotpr. exact (base (adequacy _) (J_zero _ i)). } } Defined.
   Definition Map0 {I} {G:I->abgr} {T:abgr} (f: ∀ i, Hom (G i) T) :
       MarkedAbelianGroup (R G).
-    intros. unshelve refine (make_MarkedAbelianGroup (R G) T _ _).
+    intros. simple refine (make_MarkedAbelianGroup (R G) T _ _).
     { intros [i g]. exact (f i g). }
     { intros [i|[i [g h]]].
       { simpl. apply unitproperty. }

--- a/UniMath/Ktheory/AbelianMonoid.v
+++ b/UniMath/Ktheory/AbelianMonoid.v
@@ -398,7 +398,7 @@ Module Presentation.
   Defined.
   Lemma adequacy {X I} (R:I->reln X) :
     AdequateRelation R (smallestAdequateRelation0 R).
-  Proof. intros. unshelve refine (make_AdequateRelation R _ _ _ _ _ _ _ _ _ _ _).
+  Proof. intros. simple refine (make_AdequateRelation R _ _ _ _ _ _ _ _ _ _ _).
          { intros ? r ra. apply base. exact ra. }
          { intros ? r ra. apply (reflex R). exact ra. }
          { intros ? ? p r ra. apply (symm R). exact ra. exact (p r ra). }
@@ -428,14 +428,14 @@ Module Presentation.
   (** *** the multiplication on on it *)
 
   Definition univ_binop {X I} (R:I->reln X) : binop (universalMarkedPreAbelianMonoid0 R).
-    intros. unshelve refine (QuotientSet.setquotfun2 word_op _). apply op2_compatibility. Defined.
+    intros. simple refine (QuotientSet.setquotfun2 word_op _). apply op2_compatibility. Defined.
   Definition univ_setwithbinop {X I} (R:I->reln X) : setwithbinop
              := setwithbinoppair (universalMarkedPreAbelianMonoid0 R) (univ_binop R).
 
   (** *** the universal pre-Abelian group *)
 
   Definition universalMarkedPreAbelianMonoid {X I} (R:I->reln X) : MarkedPreAbelianMonoid X.
-    intros. unshelve refine (make_preAbelianMonoid X (universalMarkedPreAbelianMonoid0 R) _ _ _).
+    intros. simple refine (make_preAbelianMonoid X (universalMarkedPreAbelianMonoid0 R) _ _ _).
     { exact (setquotpr _ word_unit). }
     { exact (fun x => setquotpr _ (word_gen x)). }
     { exact (univ_binop _). } Defined.
@@ -507,7 +507,7 @@ Module Presentation.
     fun v w  => eqset (evalwordMM M v) (evalwordMM M w).
   Lemma abelian_group_adequacy {X I} (R:I->reln X) (M:MarkedAbelianMonoid R) :
     AdequateRelation R (MarkedAbelianMonoid_to_hrel M).
-  Proof. intros. unshelve refine (make_AdequateRelation R _ _ _ _ _ _ _ _ _ _ _).
+  Proof. intros. simple refine (make_AdequateRelation R _ _ _ _ _ _ _ _ _ _ _).
          { exact (fun i => m_reln M i). } { reflexivity. }
          { intros ? ?. exact pathsinv0. } { intros ? ? ?. exact pathscomp0. }
          { intros ? ? ? p. simpl in p; simpl.
@@ -587,7 +587,7 @@ Module Presentation.
          { intermediate_path (unel M). exact (Monoid.unitproperty f). exact (!Monoid.unitproperty g). }
          { apply p. }
          (* compare duplication with the proof of MarkedAbelianMonoidMap_compat *)
-         { unshelve refine (
+         { simple refine (
                Monoid.multproperty f (setquotpr (smallestAdequateRelation R) v)
                    (setquotpr (smallestAdequateRelation R) w)
              @ _ @ !
@@ -655,7 +655,7 @@ Module NN_agreement.
   Proof. intro. induction n. { reflexivity. } { exact (ap S IHn). } Qed.
   Lemma mult_fun {X Y:abmonoid} (f:Hom X Y) (n:nat) (x:X) : f(n*x) = n*f x.
   Proof. intros. induction n. { exact (Monoid.unitproperty f). }
-         { unshelve refine (Monoid.multproperty f x (n*x) @ _).
+         { simple refine (Monoid.multproperty f x (n*x) @ _).
            { simpl. simpl in IHn. induction IHn. reflexivity. } } Qed.
   Lemma uniq_fun {X:abmonoid} (f g:Hom nataddabmonoid X) :
     f 1 = g 1 -> homot f g.
@@ -672,7 +672,7 @@ Module NN_agreement.
     set (markednat :=
            make_MarkedAbelianMonoid R nataddabmonoid (fun _ => 1) fromemptysec).
     exists (map_base (thePoint (iscontrMarkedAbelianMonoidMap markednat))).
-    unshelve refine (gradth _ _ _ _).
+    simple refine (gradth _ _ _ _).
     { intros m. { exact (m * one). } }
     { intros w.
       apply (squash_to_prop (lift R w)).

--- a/UniMath/Ktheory/AffineLine.v
+++ b/UniMath/Ktheory/AffineLine.v
@@ -56,11 +56,11 @@ Proof. intros.
               (f (ii1 O) = IH' O (f (ii2 O))) ×
               (∀ n : nat, f (ii1 (S n)) = IH' (S n) (f (ii1 n))))).
        { apply (weqbandf (weqonsecbase _ negpos)). intro f.
-         unshelve refine (weqpair _ (gradth _ _ _ _)).
-         { intros [h0 [hp hn]]. unshelve refine (_,,_,,_,,_).
+         simple refine (weqpair _ (gradth _ _ _ _)).
+         { intros [h0 [hp hn]]. simple refine (_,,_,,_,,_).
            { exact h0. } { exact hp. }
            { exact (hn O). } { intro n. exact (hn (S n)). } }
-         { intros [h0 [hp [h1' hn]]]. unshelve refine (_,,_,,_).
+         { intros [h0 [hp [h1' hn]]]. simple refine (_,,_,,_).
            { exact h0. } { exact hp. }
            { intros [|n']. { exact h1'. } { exact (hn n'). } } }
          { intros [h0 [hp hn]]. simpl. apply paths3.
@@ -132,7 +132,7 @@ Lemma A (P:ℤ->Type) (p0:P zero)
          (fun fh => pr1 fh zero)
          p0).
 Proof. intros.
-       unshelve refine (weqpair _ (gradth _ _ _ _)).
+       simple refine (weqpair _ (gradth _ _ _ _)).
        { intros [f [h0 h]]. exact ((f,,h),,h0). }
        { intros [[f h] h0]. exact (f,,(h0,,h)). }
        { intros [f [h0 h]]. reflexivity. }
@@ -172,18 +172,18 @@ Proof. intros.
        set (l' := fun n => weq_transportf P (k' n)).
        set (ih := fun n => weqcomp (IH (toℤ n)) (l n)).
        set (ih':= fun n => (weqcomp (l' n) (invweq (IH (- toℤ (S n)))))).
-       set (G := ℤRecursion_weq P ih ih'). unshelve refine (weqcomp _ G).
+       set (G := ℤRecursion_weq P ih ih'). simple refine (weqcomp _ G).
        apply weqfibtototal. intro f. unfold ℤRecursionData, ℤBiRecursionData.
-       unshelve refine (weqcomp (weqonsecbase _ negpos) _).
-       unshelve refine (weqcomp (weqsecovercoprodtoprod _) _).
-       unshelve refine (weqcomp (weqdirprodcomm _ _) _). apply weqdirprodf.
-       { apply weqonsecfibers; intro n. unshelve refine (weqonpaths2 _ _ _).
+       simple refine (weqcomp (weqonsecbase _ negpos) _).
+       simple refine (weqcomp (weqsecovercoprodtoprod _) _).
+       simple refine (weqcomp (weqdirprodcomm _ _) _). apply weqdirprodf.
+       { apply weqonsecfibers; intro n. simple refine (weqonpaths2 _ _ _).
          { change (negpos (ii2 n)) with (toℤ n). exact (l n). }
          { unfold l. apply weq_transportf_comp. }
          { reflexivity. } }
        { apply weqonsecfibers; intro n. simpl.
-         unshelve refine (weqcomp (weqpair _ (isweqpathsinv0 _ _)) _).
-         unshelve refine (weqonpaths2 _ _ _).
+         simple refine (weqcomp (weqpair _ (isweqpathsinv0 _ _)) _).
+         simple refine (weqonpaths2 _ _ _).
          { apply invweq. apply IH. }
          { simpl. rewrite homotinvweqweq. reflexivity. }
          { simpl. change (natnattohz 0 (S n)) with (- toℤ (S n)).
@@ -223,10 +223,10 @@ Proof. intros. exists (fun fh => pr1 fh t0). intro q.
        set ( IH' := (fun i => weqcomp (IH (w i)) (l0 i))
                     : ∀ i:ℤ, weq (P (w i)) (P (w(1+i)%hz))).
        set (J := fun f => ∀ i : ℤ, f (1 + i)%hz = (IH' i) (f i)).
-       unshelve refine (iscontrweqb (@weq_over_sections ℤ T w 0 t0 e P q (e#'q) _ H J _) _).
+       simple refine (iscontrweqb (@weq_over_sections ℤ T w 0 t0 e P q (e#'q) _ H J _) _).
        { apply transportfbinv. }
-       { intro. apply invweq. unfold H,J,maponsec1. unshelve refine (weqonsec _ _ w _).
-         intro i. unshelve refine (weqonpaths2 _ _ _).
+       { intro. apply invweq. unfold H,J,maponsec1. simple refine (weqonsec _ _ w _).
+         intro i. simple refine (weqonpaths2 _ _ _).
          { exact (invweq (l0 i)). }
          { unfold l0. rewrite (k0 i). reflexivity. }
          { unfold IH'. unfold weqcomp; simpl.
@@ -360,7 +360,7 @@ Proof. intros.
                                                               (fun t : T => weq_pathscomp0r y (s t)) t0))
                       (iscontrcoconustot Y (f t0)))
                 : @paths (GHomotopy f s (f t0)) _ _).
-       unshelve refine (apevalat t0 (ap pr1 ((idpath _ :
+       simple refine (apevalat t0 (ap pr1 ((idpath _ :
                          (pr2
                             (thePoint
                                (iscontrweqb
@@ -371,7 +371,7 @@ Proof. intros.
                                   (iscontrcoconustot Y (f t0)))))
                            =
                          (path_start a2)) @ a2)) @ _).
-       unshelve refine (apevalat t0
+       simple refine (apevalat t0
                  (ap pr1
                      (compute_pr2_invmap_weqfibtototal
                         (fun y : Y =>
@@ -461,8 +461,8 @@ Definition makeGuidedHomotopy_diagonalPath_comp {T:Torsor ℤ} {Y} (f:T->Y)
   ap pr1 (makeGuidedHomotopy_diagonalPath f s t0) = s t0.
 Proof. intros.
        unfold makeGuidedHomotopy_diagonalPath.
-       unshelve refine (maponpaths_naturality (makeGuidedHomotopy_transPath_comp _ _ _ _) _).
-       unshelve refine (maponpaths_naturality (makeGuidedHomotopy_localPath_comp _ _ _ _ _ _) _).
+       simple refine (maponpaths_naturality (makeGuidedHomotopy_transPath_comp _ _ _ _) _).
+       simple refine (maponpaths_naturality (makeGuidedHomotopy_localPath_comp _ _ _ _ _ _) _).
        exact (makeGuidedHomotopy_verticalPath_comp _ _ _ _ _).
 Defined.
 

--- a/UniMath/Ktheory/Circle.v
+++ b/UniMath/Ktheory/Circle.v
@@ -267,7 +267,7 @@ Lemma circle_map_check_paths'
            (l:circle_loop#y = y) (c:circle), Y c)
       {Y} (f:circle->Y) :
   circle_map (ap f circle_loop) = f .
-Proof. intros. apply funextsec; intro T. generalize T; clear T.
+Proof. intros. apply funextsec.
        unshelve refine (circle_map' _ _ _).
        { reflexivity. }
        { set (y := f (basepoint circle)). set (l := ap f circle_loop).

--- a/UniMath/Ktheory/Circle.v
+++ b/UniMath/Ktheory/Circle.v
@@ -268,7 +268,7 @@ Lemma circle_map_check_paths'
       {Y} (f:circle->Y) :
   circle_map (ap f circle_loop) = f .
 Proof. intros. apply funextsec.
-       unshelve refine (circle_map' _ _ _).
+       simple refine (circle_map' _ _ _).
        { reflexivity. }
        { set (y := f (basepoint circle)). set (l := ap f circle_loop).
          set (P := fun T : underlyingType circle => circle_map _ T = f T).

--- a/UniMath/Ktheory/Equivalences.v
+++ b/UniMath/Ktheory/Equivalences.v
@@ -45,7 +45,7 @@ Proof. intros ? ? w.
        exists f. intro y.
        exists (g y,,p y).
        intros xe.
-       unshelve refine (hfibertriangle2 _ _ _ _ _).
+       simple refine (hfibertriangle2 _ _ _ _ _).
        - exact (! (q (pr1 xe)) @ maponpaths g (pr2 xe)).
        - induction xe as [x e]; simpl. induction e; simpl.
          rewrite pathscomp0rid.
@@ -341,5 +341,5 @@ Proof. intros. apply pathsinv0.
        rewrite pathsinv0l. simpl. rewrite pathsinv0l. reflexivity. Qed.
 
 Definition inverseEquivalence {X Y} : Equivalence X Y -> Equivalence Y X.
-Proof. intros ? ? [f [g [p [q h]]]]. unshelve refine (makeEquivalence Y X g f q p _).
+Proof. intros ? ? [f [g [p [q h]]]]. simple refine (makeEquivalence Y X g f q p _).
        intro y. apply other_adjoint. assumption. Defined.

--- a/UniMath/Ktheory/Group.v
+++ b/UniMath/Ktheory/Group.v
@@ -269,13 +269,13 @@ Module Presentation.
   Definition universalMarkedGroup0 {X I} (R:I->reln X) : gr.
     intros.
     { exists (univ_setwithbinop R).
-      { unshelve refine (_,,_).
+      { simple refine (_,,_).
         { split.
           { exact (isassoc_univ_binop R). }
           { exists (setquotpr _ word_unit). split.
             { exact (is_left_unit_univ_binop R). }
             { exact (is_right_unit_univ_binop R). } } }
-        { unshelve refine (_,,_).
+        { simple refine (_,,_).
           { exact (univ_inverse R). }
           { split.
             { exact (is_left_inverse_univ_binop R). }
@@ -312,10 +312,10 @@ Module Presentation.
          { intermediate_path (unel M). exact (Monoid.unitproperty f). exact (!Monoid.unitproperty g). }
          { apply p. }
          (* compare duplication with the proof of MarkedGroupMap_compat *)
-         { unshelve refine (monoidfuninvtoinv f (setquotpr (smallestAdequateRelation R) w)
+         { simple refine (monoidfuninvtoinv f (setquotpr (smallestAdequateRelation R) w)
              @ _ @ ! monoidfuninvtoinv g (setquotpr (smallestAdequateRelation R) w)).
            apply (ap (grinv M)). apply agreement_on_gens0. assumption. }
-         { unshelve refine (
+         { simple refine (
                Monoid.multproperty f (setquotpr (smallestAdequateRelation R) v)
                    (setquotpr (smallestAdequateRelation R) w)
              @ _ @ !

--- a/UniMath/Ktheory/GroupAction.v
+++ b/UniMath/Ktheory/GroupAction.v
@@ -32,7 +32,7 @@ Proof. intros. apply (invmaponpathsincl _ (isinclpr1weq _ _)).
 
 Definition weqcompweql {X Y Z} (f:X ≃ Y) :
   isweq (fun g:Y ≃ Z => weqcomp f g).
-Proof. intros. unshelve refine (gradth _ _ _ _).
+Proof. intros. simple refine (gradth _ _ _ _).
        { intro h. exact (weqcomp (invweq f) h). }
        { intro g. simpl. rewrite <- weqcompassoc. rewrite weqcompinvl.
          apply weqcompidl. }
@@ -41,7 +41,7 @@ Proof. intros. unshelve refine (gradth _ _ _ _).
 
 Definition weqcompweqr {X Y Z} (g:Y ≃ Z) :
   isweq (fun f:X ≃ Y => weqcomp f g).
-Proof. intros. unshelve refine (gradth _ _ _ _).
+Proof. intros. simple refine (gradth _ _ _ _).
        { intro h. exact (weqcomp h (invweq g)). }
        { intro f. simpl. rewrite weqcompassoc. rewrite weqcompinvr.
          apply weqcompidr. }
@@ -150,10 +150,10 @@ Definition is_equivariant_identity {G:gr} {X Y:Action G}
 Proof. intros ? [X [Xm Xu Xa]] [Y [Ym Yu Ya]] ? .
        (* should just apply uahp at this point, as in Poset_univalence_prelim! *)
        simpl in p. destruct p; simpl. unfold transportf; simpl. unfold idfun; simpl.
-       unshelve refine (weqpair _ _).
+       simple refine (weqpair _ _).
        { intros p g x. simpl in x. simpl.
          exact (apevalat x (apevalat g (ap act_mult p))). }
-       unshelve refine (gradth _ _ _ _).
+       simple refine (gradth _ _ _ _).
        { unfold cast; simpl.
          intro i.
          assert (p:Xm=Ym).
@@ -225,10 +225,10 @@ Proof. intros ? ? ? ? x. exact (path_to_ActionIso e x). Defined.
 Definition Action_univalence_prelim {G:gr} {X Y:Action G} :
   weq (X = Y) (ActionIso X Y).
 Proof. intros.
-       unshelve refine (weqcomp (total2_paths_equiv (ActionStructure G) X Y) _).
-       unshelve refine (weqbandf _ _ _ _).
+       simple refine (weqcomp (total2_paths_equiv (ActionStructure G) X Y) _).
+       simple refine (weqbandf _ _ _ _).
        { apply hSet_univalence. }
-       simpl. intro p. unshelve refine (weqcomp (is_equivariant_identity p) _).
+       simpl. intro p. simple refine (weqcomp (is_equivariant_identity p) _).
        exact (eqweqmap (ap is_equivariant (pr1_eqweqmap (ap set_to_type p)))).
 Defined.
 
@@ -389,7 +389,7 @@ Lemma pr1weq_injectivity {X Y} (f g:X ≃ Y) : weq (f = g) (pr1weq f = pr1weq g)
 Proof. intros. apply weqonpathsincl. apply isinclpr1weq.  Defined.
 
 Definition autos (G:gr) : G ≃ (ActionIso (trivialTorsor G) (trivialTorsor G)).
-Proof. intros. exists (trivialTorsorAuto G). unshelve refine (gradth _ _ _ _).
+Proof. intros. exists (trivialTorsorAuto G). simple refine (gradth _ _ _ _).
        { intro f. exact (f (unel G)). } { intro g; simpl. exact (lunax _ g). }
        { intro f; simpl. apply (invweq (underlyingIso_injectivity _ _)); simpl.
          apply (invweq (pr1weq_injectivity _ _)). apply funextsec; intro g.
@@ -408,9 +408,9 @@ Defined.
 
 Lemma trivialTorsorAuto_unit (G:gr) :
   trivialTorsorAuto G (unel _) = idActionIso _.
-Proof. intros. unshelve refine (subtypeEquality _ _).
+Proof. intros. simple refine (subtypeEquality _ _).
        { intro k. apply is_equivariant_isaprop. }
-       { unshelve refine (subtypeEquality _ _).
+       { simple refine (subtypeEquality _ _).
          { intro; apply isapropisweq. }
          { apply funextsec; intro x; simpl. exact (runax G x). } }
 Defined.
@@ -418,9 +418,9 @@ Defined.
 Lemma trivialTorsorAuto_mult (G:gr) (g h:G) :
   composeActionIso (trivialTorsorAuto G g) (trivialTorsorAuto G h)
   = (trivialTorsorAuto G (op g h)).
-Proof. intros. unshelve refine (subtypeEquality _ _).
+Proof. intros. simple refine (subtypeEquality _ _).
        { intro; apply is_equivariant_isaprop. }
-       { unshelve refine (subtypeEquality _ _).
+       { simple refine (subtypeEquality _ _).
          { intro; apply isapropisweq. }
          { apply funextsec; intro x; simpl. exact (assocax _ x g h). } }
 Defined.
@@ -428,7 +428,7 @@ Defined.
 (** ** Applications of univalence *)
 
 Definition Torsor_univalence {G:gr} {X Y:Torsor G} : weq (X = Y) (ActionIso X Y).
-Proof. intros. unshelve refine (weqcomp underlyingAction_injectivity _).
+Proof. intros. simple refine (weqcomp underlyingAction_injectivity _).
        apply Action_univalence. Defined.
 
 Definition Torsor_univalence_comp {G:gr} {X Y:Torsor G} (p:X = Y) :
@@ -457,8 +457,8 @@ Proof. intros ? [X x]. exists (triviality_isomorphism X x).
 Definition PointedTorsor_univalence {G:gr} {X Y:PointedTorsor G} :
   weq (X = Y) (PointedActionIso X Y).
 Proof. intros.
-       unshelve refine (weqcomp (total2_paths_equiv _ X Y) _).
-       unshelve refine (weqbandf _ _ _ _).
+       simple refine (weqcomp (total2_paths_equiv _ X Y) _).
+       simple refine (weqbandf _ _ _ _).
        { intros.
          exact (weqcomp (weqonpathsincl underlyingAction underlyingAction_incl X Y)
                         Action_univalence). }
@@ -483,7 +483,7 @@ Proof. intros. exists (pointedTrivialTorsor G). intros [X x].
 
 Theorem loopsBG (G:gr) : weq (Ω (B G)) G.
 Proof. intros. apply invweq.
-       unshelve refine (weqcomp _ (invweq Torsor_univalence)).
+       simple refine (weqcomp _ (invweq Torsor_univalence)).
        apply autos. Defined.
 
 Definition loopsBG_comp (G:gr) (g h:G)

--- a/UniMath/Ktheory/Integers.v
+++ b/UniMath/Ktheory/Integers.v
@@ -97,7 +97,7 @@ Defined.
 Definition negpos_weq := weqpair _ negpos' : weq (total2 hz_normal_form) ℤ.
 
 Definition negpos : weq (coprod nat nat) ℤ. (* ℤ = (-inf,-1) + (0,inf) *)
-Proof. unshelve refine (weqpair _ (gradth _ _ _ _)).
+Proof. simple refine (weqpair _ (gradth _ _ _ _)).
        { intros [n'|n].
          { exact (natnattohz 0 (S n')). } { exact (natnattohz n 0). } }
        { intro i. destruct (hz_to_normal_form i) as [[n p]|[m q]].

--- a/UniMath/Ktheory/Monoid.v
+++ b/UniMath/Ktheory/Monoid.v
@@ -76,22 +76,22 @@ Module Presentation'.
   Definition smallestAdequateRelation {X I} (R:I->reln X) : AdequateRelation R.
   Proof.
     intros.
-    unshelve refine (_,,_).
-    { unshelve refine (_,,_).
+    simple refine (_,,_).
+    { simple refine (_,,_).
       { intros v w.
         exists (∀ r, isAdequateRelation R r -> r v w).
         apply impred; intros r; apply impred_prop. }
-      { unshelve refine (_,,_).
-        { unshelve refine (_,,_).
+      { simple refine (_,,_).
+        { simple refine (_,,_).
           { intros u v w uv vw r ad; simpl in uv, vw.
             apply (eqreltrans r u v w).
             { apply uv. exact ad. }
             { apply vw. exact ad. }}
           { intros w r ad. apply eqrelrefl. } }
         { intros v w vw r ad. apply eqrelsymm. apply vw. exact ad. }}}
-    { unshelve refine (_,,_); simpl.
+    { simple refine (_,,_); simpl.
       { intros i r ad. apply (base ad i). }
-      { unshelve refine (_,,_).
+      { simple refine (_,,_).
         { intros u v w min r ad. apply (left_compat  ad). apply min. exact ad. }
         { intros u v w min r ad. apply (right_compat ad). apply min. exact ad. }}}
   Defined.
@@ -103,7 +103,7 @@ Module Presentation'.
   Definition univ_unit {X I} (R:I->reln X) := setquotpr _ word_unit : univ_set R.
 
   Definition univ_binop {X I} (R:I->reln X) : binop (univ_set R).
-    intros. unshelve refine (setquotfun2 _ _ word_op _).
+    intros. simple refine (setquotfun2 _ _ word_op _).
     induction (smallestAdequateRelation R) as [r ad]; simpl.
     intros v v' w w' vv' ww'.
     apply (eqreltrans _ _ (word_op v w') _ (left_compat ad _ _ _ ww') (right_compat ad _ _ _ vv')).
@@ -259,7 +259,7 @@ Module Presentation.
   Defined.
   Lemma adequacy {X I} (R:I->reln X) :
     AdequateRelation R (smallestAdequateRelation0 R).
-  Proof. intros. unshelve refine (make_AdequateRelation R _ _ _ _ _ _ _ _ _ _).
+  Proof. intros. simple refine (make_AdequateRelation R _ _ _ _ _ _ _ _ _ _).
          { intros ? r ra. apply base. exact ra. }
          { intros ? r ra. apply (reflex R). exact ra. }
          { intros ? ? p r ra. apply (symm R). exact ra. exact (p r ra). }
@@ -288,14 +288,14 @@ Module Presentation.
   (** *** the multiplication on on it *)
 
   Definition univ_binop {X I} (R:I->reln X) : binop (universalMarkedPreMonoid0 R).
-    intros. unshelve refine (QuotientSet.setquotfun2 word_op _). apply op2_compatibility. Defined.
+    intros. simple refine (QuotientSet.setquotfun2 word_op _). apply op2_compatibility. Defined.
   Definition univ_setwithbinop {X I} (R:I->reln X) : setwithbinop
              := setwithbinoppair (universalMarkedPreMonoid0 R) (univ_binop R).
 
   (** *** the universal pre-monoid *)
 
   Definition universalMarkedPreMonoid {X I} (R:I->reln X) : MarkedPreMonoid X.
-    intros. unshelve refine (make_preMonoid X (universalMarkedPreMonoid0 R) _ _ _).
+    intros. simple refine (make_preMonoid X (universalMarkedPreMonoid0 R) _ _ _).
     { exact (setquotpr _ word_unit). }
     { exact (fun x => setquotpr _ (word_gen x)). }
     { exact (univ_binop _). } Defined.
@@ -359,7 +359,7 @@ Module Presentation.
     fun v w  => eqset (evalwordMM M v) (evalwordMM M w).
   Lemma abelian_group_adequacy {X I} (R:I->reln X) (M:MarkedMonoid R) :
     AdequateRelation R (MarkedMonoid_to_hrel M).
-  Proof. intros. unshelve refine (make_AdequateRelation R _ _ _ _ _ _ _ _ _ _).
+  Proof. intros. simple refine (make_AdequateRelation R _ _ _ _ _ _ _ _ _ _).
          { exact (fun i => m_reln R M i). } { reflexivity. }
          { intros ? ?. exact pathsinv0. } { intros ? ? ?. exact pathscomp0. }
          { intros ? ? ? p. simpl in p; simpl.
@@ -438,7 +438,7 @@ Defined.
          { intermediate_path (unel M). exact (unitproperty f). exact (!unitproperty g). }
          { apply p. }
          (* compare duplication with the proof of MarkedMonoidMap_compat *)
-         { unshelve refine (
+         { simple refine (
                multproperty f (setquotpr (smallestAdequateRelation R) v)
                    (setquotpr (smallestAdequateRelation R) w)
              @ _ @ !
@@ -522,7 +522,7 @@ Module Product.
       [isdeceq I]. *)
 
   Proof. intros ? ? ? decide_equality xi. apply hinhpr.
-    unshelve refine (_,,_).
+    simple refine (_,,_).
     { intro j. destruct (decide_equality i j) as [p|_].
       { exact (transportf X p xi). }
       { exact (unel (X j)). } }

--- a/UniMath/Ktheory/MoreEquivalences.v
+++ b/UniMath/Ktheory/MoreEquivalences.v
@@ -91,7 +91,7 @@ Definition weqpr1_irr_sec {X} {P:X->Type}
 Proof. intros.
        set (isc := fun x => iscontraprop1 (invproofirrelevance _ (irr x)) (sec x)).
        apply Equivalence_to_weq.
-       unshelve refine (makeEquivalence _ _ _ _ _ _ _).
+       simple refine (makeEquivalence _ _ _ _ _ _ _).
        { exact pr1. } { intro x. exact (x,,sec x). } { intro x. reflexivity. }
        { intros [x p]. simpl. apply pair_path_in2. apply irr. }
        { intros [x p]. simpl. apply pair_path_in2_comp1. } Defined.
@@ -102,7 +102,7 @@ Definition invweqpr1_irr_sec {X} {P:X->Type}
 Proof. intros.
        set (isc := fun x => iscontraprop1 (invproofirrelevance _ (irr x)) (sec x)).
        apply Equivalence_to_weq.
-       unshelve refine (makeEquivalence _ _ _ _ _ _ _).
+       simple refine (makeEquivalence _ _ _ _ _ _ _).
        { intro x. exact (x,,sec x). } { exact pr1. }
        { intros [x p]. simpl. apply pair_path_in2. apply irr. }
        { intro x. reflexivity. }

--- a/UniMath/Ktheory/Nat.v
+++ b/UniMath/Ktheory/Nat.v
@@ -18,14 +18,14 @@ Module Uniqueness.
         (f:∀ n, P n) :
     weq (∀ n, f n = nat_rect P p0 IH n)
         (f 0=p0 × ∀ n, f(S n)=IH n (f n)).
-  Proof. intros. unshelve refine (_,,gradth _ _ _ _).
+  Proof. intros. simple refine (_,,gradth _ _ _ _).
          { intros h. split.
            { exact (h 0). } { intros. exact (h (S n) @ ap (IH n) (! h n)). } }
          { intros [h0 h'] ?. induction n as [|n'].
            { exact h0. } { exact (h' n' @ ap (IH n') IHn'). } }
          { simpl. intros h. apply funextsec; intros n; simpl. induction n.
            { simpl. reflexivity. }
-           { simpl. rewrite <- path_assoc. unshelve refine (_ @ pathscomp0rid _).
+           { simpl. rewrite <- path_assoc. simple refine (_ @ pathscomp0rid _).
              rewrite <- maponpathscomp0. rewrite IHn. rewrite pathsinv0l.
              simpl. reflexivity. } }
          { intros [h0 h']. apply pair_path_in2. apply funextsec; intro n; simpl.
@@ -58,7 +58,7 @@ Module Uniqueness.
            (P 0)
            (fun fh => pr1 fh 0)
            p0).
-  Proof. intros. unshelve refine (weqpair _ (gradth _ _ _ _)).
+  Proof. intros. simple refine (weqpair _ (gradth _ _ _ _)).
          { intros [f [h0 h']]. exact ((f,,h'),,h0). }
          { intros [[f h'] h0]. exact (f,,(h0,,h')). }
          { intros [f [h0 h']]. reflexivity. }
@@ -145,7 +145,7 @@ Module Discern.
   Proof. intros. apply proofirrelevance. apply nat_discern_isaprop. Defined.
 
   Definition helper_D m n : isweq (helper_B m n).
-  Proof. intros. unshelve refine (gradth _ (helper_C _ _) _ _).
+  Proof. intros. simple refine (gradth _ (helper_C _ _) _ _).
          { intro e. assert(p := ! helper_B _ _ e). destruct p.
            apply proofirrelevancecontr. apply nat_discern_iscontr. }
          { intro e. destruct e. induction m.
@@ -343,7 +343,7 @@ Proof. intros ? ? ? i.
        rewrite minusplusnmm.
        { exact i. }
        { change (m ≤ n).
-         unshelve refine (istransnatleh _ i); clear i.
+         simple refine (istransnatleh _ i); clear i.
          apply natlehmplusnm. }
 Defined.
 

--- a/UniMath/Ktheory/QuotientSet.v
+++ b/UniMath/Ktheory/QuotientSet.v
@@ -25,7 +25,7 @@ Definition setquotuniv2 {X Y} (RX:hrel X) (RY:hrel Y)
            {Z:hSet} (f:X->Y->Z) (is:iscomprelfun2 RX RY f) :
   setquot RX -> setquot RY -> Z.
 Proof. intros ? ? ? ? ? ? ? x''.
-       unshelve refine (setquotuniv RX (funset (setquot RY) Z) _ _ _).
+       simple refine (setquotuniv RX (funset (setquot RY) Z) _ _ _).
        { simpl. intro x. apply (setquotuniv RY Z (f x)).
          intros y y' e. unfold iscomprelfun2 in is.
          apply (pr2 is). assumption. }

--- a/UniMath/Ktheory/StandardCategories.v
+++ b/UniMath/Ktheory/StandardCategories.v
@@ -38,7 +38,7 @@ Definition path_pregroupoid (X:UU) : isofhlevel 3 X -> precategory.
      be useful, because in it, each arrow is a path, rather than an
      equivalence class of paths. *)
   intros obj iobj.
-  unshelve refine (Precategories.makePrecategory obj (fun x y => x = y)  _ _ _ _ _).
+  simple refine (Precategories.makePrecategory obj (fun x y => x = y)  _ _ _ _ _).
   { reflexivity. }
   { intros. exact (f @ g). }
   { reflexivity. }

--- a/UniMath/Ktheory/Utilities.v
+++ b/UniMath/Ktheory/Utilities.v
@@ -499,8 +499,8 @@ Definition weq_over_sections {S T} (w:S ≃ T)
            (g:∀ f:Section P, weq (H f) (J (maponsec1 P w f))) :
   weq (hfiber (fun fh:total2 H => pr1 fh t0) p0 )
       (hfiber (fun fh:total2 J => pr1 fh s0) pw0).
-Proof. intros. unshelve refine (weqbandf _ _ _ _).
-       { unshelve refine (weqbandf _ _ _ _).
+Proof. intros. simple refine (weqbandf _ _ _ _).
+       { simple refine (weqbandf _ _ _ _).
          { exact (weqonsecbase P w). }
          { unfold weqonsecbase; simpl. exact g. } }
        { intros [f h]. simpl. unfold maponsec1; simpl.
@@ -509,7 +509,7 @@ Proof. intros. unshelve refine (weqbandf _ _ _ _).
 
 Definition weq_total2_prod {X Y} (Z:Y->Type) : (Σ y, X × Z y) ≃ (X × Σ y, Z y).
 Proof.                          (* move upstream *)
-       intros. unshelve refine (weqpair _ (gradth _ _ _ _)).
+       intros. simple refine (weqpair _ (gradth _ _ _ _)).
        { intros [y [x z]]. exact (x,,y,,z). }
        { intros [x [y z]]. exact (y,,x,,z). }
        { intros [y [x z]]. reflexivity. }
@@ -518,7 +518,7 @@ Proof.                          (* move upstream *)
 (* associativity of Σ *)
 Definition totalAssociativity {X:UU} {Y: ∀ (x:X), UU} (Z: ∀ (x:X) (y:Y x), UU) : (Σ (x:X) (y:Y x), Z x y) ≃ (Σ (p:Σ (x:X), Y x), Z (pr1 p) (pr2 p)).
 Proof.                          (* move upstream *)
-  intros. unshelve refine (_,,gradth _ _ _ _).
+  intros. simple refine (_,,gradth _ _ _ _).
   { intros [x [y z]]. exact ((x,,y),,z). }
   { intros [[x y] z]. exact (x,,(y,,z)). }
   { intros [x [y z]]. reflexivity. }

--- a/UniMath/SubstitutionSystems/FunctorsPointwiseCoproduct.v
+++ b/UniMath/SubstitutionSystems/FunctorsPointwiseCoproduct.v
@@ -254,11 +254,11 @@ Qed.
 Definition functor_precat_coproduct_cocone
   : CoproductCocone [C, D, hsD] F G.
 Proof.
-  unshelve refine (mk_CoproductCocone _ _ _ _ _ _ _ ).
+  simple refine (mk_CoproductCocone _ _ _ _ _ _ _ ).
   - apply coproduct_functor.
   - apply coproduct_nat_trans_in1.
   - apply coproduct_nat_trans_in2.
-  - unshelve refine (mk_isCoproductCocone _ _ _ _ _ _ _ _ ).
+  - simple refine (mk_isCoproductCocone _ _ _ _ _ _ _ _ ).
     + apply functor_category_has_homsets.
     + intros A f g.
      exists (tpair _ (coproduct_nat_trans A f g)

--- a/UniMath/SubstitutionSystems/FunctorsPointwiseProduct.v
+++ b/UniMath/SubstitutionSystems/FunctorsPointwiseProduct.v
@@ -222,11 +222,11 @@ Qed.
 Definition functor_precat_product_cone
   : ProductCone [C, D, hsD] F G.
 Proof.
-unshelve refine (mk_ProductCone _ _ _ _ _ _ _).
+simple refine (mk_ProductCone _ _ _ _ _ _ _).
 - apply product_functor.
 - apply product_nat_trans_pr1.
 - apply product_nat_trans_pr2.
-- unshelve refine (mk_isProductCone _ _ _ _ _ _ _ _).
+- simple refine (mk_isProductCone _ _ _ _ _ _ _ _).
   + apply functor_category_has_homsets.
   + intros A f g.
     exists (tpair _ (product_nat_trans A f g)

--- a/UniMath/SubstitutionSystems/GenMendlerIteration.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration.v
@@ -200,14 +200,14 @@ Focus 2.
       apply maponpaths.
       exact h_rec_eq.
     + (* set(φh_alg_mor := tpair _ _ φh_is_alg_mor : pr1 μF_Initial ⇒ ⟨ R X, φ (ψ (R X) (ε X)) ⟩). *)
-       unshelve refine (let X : AF ⟦ InitialObject μF_Initial, ⟨ R X, φ (ψ (R X) (ε X)) ⟩ ⟧ := _ in _).
+       simple refine (let X : AF ⟦ InitialObject μF_Initial, ⟨ R X, φ (ψ (R X) (ε X)) ⟩ ⟧ := _ in _).
        * apply (tpair _ (φ h)); assumption.
        * apply (maponpaths pr1 (InitialArrowUnique _ _ X0)).
 Qed.
 
 Theorem GenMendlerIteration : iscontr (Σ h : L μF ⇒ X, #L inF ;; h = ψ μF h).
 Proof.
-  unshelve refine (tpair _ _ _ ).
+  simple refine (tpair _ _ _ ).
   - exists preIt.
     exact preIt_ok.
   - exact preIt_uniq.
@@ -250,7 +250,7 @@ Section special_case.
 
   Definition ψ_from_comps : ψ_source ⟶ ψ_target.
   Proof.
-    unshelve refine (tpair _ _ _ ).
+    simple refine (tpair _ _ _ ).
     - intro A. simpl. intro f.
       unfold yoneda_objects_ob in *.
       exact (θ A ;; #G f ;; ρ).

--- a/UniMath/SubstitutionSystems/Lam.v
+++ b/UniMath/SubstitutionSystems/Lam.v
@@ -172,7 +172,7 @@ Defined.
 (** preparations for typedness *)
 Local Definition bla': (ptd_from_alg_functor CC LamE_S LamE_algebra_on_Lam) ⇒ (ptd_from_alg_functor CC _ Lam).
 Proof.
-  unshelve refine (tpair _ _ _ ).
+  simple refine (tpair _ _ _ ).
     + apply (nat_trans_id _ ).
     + abstract
         (intro c; rewrite id_right
@@ -182,7 +182,7 @@ Defined.
 
 Local Definition bla'_inv: (ptd_from_alg_functor CC _ Lam) ⇒ (ptd_from_alg_functor CC LamE_S LamE_algebra_on_Lam).
 Proof.
-  unshelve refine (tpair _ _ _ ).
+  simple refine (tpair _ _ _ ).
     + apply (nat_trans_id _ ).
     + abstract
         (intro c; rewrite id_right ;

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -165,7 +165,7 @@ Definition aux_iso_1 (Z : Ptd)
            (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
               (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_source H) Z))⟧.
 Proof.
-  unshelve refine (tpair _ _ _).
+  simple refine (tpair _ _ _).
   - intro X.
     exact (CoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (ρ_functor _ (U Z))
             (nat_trans_id (θ_source H (X⊗Z):functor C C))).
@@ -209,7 +209,7 @@ Local Definition aux_iso_1_inv (Z: Ptd)
               (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_source H) Z)),
       functor_composite Id_H (ℓ (U Z)) ⟧.
 Proof.
-  unshelve refine (tpair _ _ _).
+  simple refine (tpair _ _ _).
   - intro X.
     exact (CoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (λ_functor _ (U Z))
            (nat_trans_id (θ_source H (X⊗Z):functor C C))).
@@ -264,7 +264,7 @@ Local Definition aux_iso_2_inv (Z : Ptd)
                     (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_target H) Z)),
       functor_composite (ℓ (U Z) )   (Const_plus_H (U Z)) ⟧.
 Proof.
-  unshelve refine (tpair _ _ _).
+  simple refine (tpair _ _ _).
   - intro X.
     exact (nat_trans_id ((@CoproductObject EndC (U Z) (θ_target H (X⊗Z)) (CPEndC _ _) )
              : functor C C)).
@@ -620,7 +620,7 @@ Local Definition iso2' (Z : Ptd) : EndEndC ⟦
              (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_target H) Z)),
   functor_composite (ℓ (U Z)) Ghat ⟧.
 Proof.
-    unshelve refine (tpair _ _ _).
+    simple refine (tpair _ _ _).
   - intro X.
     exact (nat_trans_id ((@CoproductObject EndC _ (θ_target H (X⊗Z)) (CPEndC _ _) )
             : functor C C)).
@@ -646,7 +646,7 @@ Definition Phi_fusion (Z : Ptd) (X : EndC) (b : pr1 InitAlg ⇒ X) :
    ⟶
   functor_composite (functor_opp (ℓ (U Z))) (Yon X) .
 Proof.
-  unshelve refine (tpair _ _ _ ).
+  simple refine (tpair _ _ _ ).
   - intro Y.
     intro a.
     exact (a ;; b).
@@ -890,7 +890,7 @@ Qed.
 
 Lemma isInitial_InitHSS : isInitial (hss_precategory CP H) InitHSS.
 Proof.
-  unshelve refine (mk_isInitial _ _).
+  simple refine (mk_isInitial _ _).
   intro T.
   exists (hss_InitMor T).
   apply hss_InitMor_unique.
@@ -899,7 +899,7 @@ Defined.
 
 Lemma InitialHSS : Initial (hss_precategory CP H).
 Proof.
-  unshelve refine (mk_Initial InitHSS _).
+  simple refine (mk_Initial InitHSS _).
   apply isInitial_InitHSS.
 Defined.
 

--- a/UniMath/SubstitutionSystems/PointedFunctors.v
+++ b/UniMath/SubstitutionSystems/PointedFunctors.v
@@ -122,7 +122,7 @@ Defined.
 Lemma eq_ptd_mor_precat {F G : precategory_Ptd} (a b : F ⇒ G)
   : a = b ≃ (a : ptd_mor F G) = b.
 Proof.
-  unshelve refine (tpair _ _ _).
+  simple refine (tpair _ _ _).
   intro H.
   exact H.
   apply idisweq.


### PR DESCRIPTION
We update Coq to the latest 8.5 version after the announcement of
v8.5 RC 1.

This update implements "simple refine", which is the recommended way to
get the new behavior of the "refine" tactic, so we replace "unshelve
refine" by "simple refine" everywhere except in those cases where it
doesn't work.  (It was just a few days ago that we had to replace almost
all of our uses of "refine" by "unshelve refine".)