### PR TITLE
transparent assert

### DIFF
--- a/UniMath/CategoryTheory/limits/initial.v
+++ b/UniMath/CategoryTheory/limits/initial.v
@@ -121,8 +121,8 @@ case (H _ initDiagram); intros cc iscc; destruct cc as [c cc].
 apply (mk_Initial c); apply mk_isInitial; intros b.
 case (iscc _ (initCocone b)); intros f Hf; destruct f as [f fcomm].
 apply (tpair _ f); intro g.
-simple refine (let X : Σ x : c --> b, ∀ v,
-                       coconeIn cc v ;; x = coconeIn (initCocone b) v := _ in _).
+transparent assert (X : (Σ x : c --> b, ∀ v,
+                       coconeIn cc v ;; x = coconeIn (initCocone b) v)).
   { apply (tpair _ g); intro u; induction u. }
 apply (maponpaths pr1 (Hf X)).
 Defined.

--- a/UniMath/CategoryTheory/limits/limits.v
+++ b/UniMath/CategoryTheory/limits/limits.v
@@ -352,7 +352,7 @@ use (mk_ColimCocone _ (from_opp_opp_to_opp _ _ _ pr1pr1x)).
     * abstract (intro β; repeat (apply impred; intro);
         now apply (has_homsets_opp (functor_category_has_homsets A C hsC))).
     * match goal with |[ H2 : ∀ _ : ?TT ,  _ = _ ,,_   |- _ ] =>
-                       simple refine (let T : TT := _ in _ ) end.
+                       transparent assert (T : TT) end.
       (*
       refine (let T : Σ x : nat_trans pr1pr1x (functor_opp F),
                          ∀ v, nat_trans_comp (functor_opp (pr1 D v)) _ _

--- a/UniMath/Foundations/Basics/Preamble.v
+++ b/UniMath/Foundations/Basics/Preamble.v
@@ -235,3 +235,6 @@ Ltac simple_rapply p :=
   simple refine (p _ _ _ _ _ _ _ _ _ _ _ _ _ _ _).
 
 Tactic Notation "use" uconstr(p) := simple_rapply p.
+
+Tactic Notation "transparent" "assert" "(" ident(name) ":" constr(type) ")" :=
+  simple refine (let name := (_ : type) in _).


### PR DESCRIPTION
Introduce tactic "transparent assert", as in

transparent assert (t : T).

Note that type T sometimes needs parentheses as in

transparent assert (t : (T)).

See the patch for such an example.
I am not sure if this is due to T containing a colon or to something else.