### PR TITLE
Work in progress to defining the syntax of the lambda calculus

### DIFF
--- a/UniMath/CategoryTheory/colimits/chains.v
+++ b/UniMath/CategoryTheory/colimits/chains.v
@@ -34,7 +34,7 @@ Section move_upstream.
 
 Fixpoint iter_functor {C : precategory} (F : functor C C) (n : nat) : functor C C := match n with
   | O => functor_identity C
-  | S n' => functor_composite _ _ _ (iter_functor F n') F
+  | S n' => functor_composite (iter_functor F n') F
   end.
 
 (* TODO : state this for any object and morphism, that is,

--- a/UniMath/CategoryTheory/colimits/colimits.v
+++ b/UniMath/CategoryTheory/colimits/colimits.v
@@ -22,6 +22,8 @@ Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.equivalences.
+Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
 
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
@@ -510,74 +512,36 @@ Definition is_cocont := forall {g : graph} (d : diagram g C) (L : C)
 
 End preserves_colimit.
 
-Require Import UniMath.CategoryTheory.equivalences.
-Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
-
 Lemma left_adjoint_cocont {C D : precategory} (F : functor C D)
   (H : is_left_adjoint F) (hsC : has_homsets C) (hsD : has_homsets D) : is_cocont F.
 Proof.
 intros g d L ccL HccL M ccM.
-set (phi := @φ_adj _ _ _ H).
-set (phi_inv := @φ_adj_inv _ _ _ H).
 set (G := pr1 H).
 apply (@iscontrweqb _ (Σ y : C ⟦ L, G M ⟧,
-    ∀ i, coconeIn ccL i ;; y = phi _ _ (coconeIn ccM i))).
+    ∀ i, coconeIn ccL i ;; y = φ_adj _ _ _ H (coconeIn ccM i))).
 - eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧,
-    ∀ i, # F (coconeIn ccL i) ;; phi_inv _ _ y = coconeIn ccM i)).
-+
-apply (weqbandf (adjunction_hom_weq _ _ _ H L M)).
-simpl.
-unfold phi_inv.
-intros x.
-apply weqiff; try (apply impred; intro; apply hsD).
-now rewrite φ_adj_inv_after_φ_adj.
-+
-eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧,
-    ∀ i, φ_adj_inv _ _ _ _ (coconeIn ccL i ;; y) = coconeIn ccM i)).
-*
-apply (weqbandf (idweq _)); simpl; intro f.
-apply weqimplimpl; try (apply impred; intro; apply hsD).
-{
-intros h i.
-eapply pathscomp0.
-apply (φ_adj_inv_natural_precomp _ _ _ H L M f _ (coconeIn ccL i)).
-apply (h i).
-}
-{
-intros h i.
-eapply pathscomp0.
-eapply pathsinv0.
-apply (φ_adj_inv_natural_precomp _ _ _ H L M f _ (coconeIn ccL i)).
-apply (h i).
-}
-*
-apply (weqbandf (idweq _)); simpl; intro f.
-apply weqimplimpl.
-{
-intros h i.
-rewrite <- (h i).
-now rewrite (φ_adj_after_φ_adj_inv _ _ _ H).
-}
-{
-intros h i.
-rewrite (h i).
-now rewrite (φ_adj_inv_after_φ_adj _ _ _ H).
-}
-{apply impred; intro; apply hsD. }
-{apply impred; intro; apply hsC. }
-
--
-unfold phi; simpl.
-unfold isColimCocone in HccL.
-simple refine (let X : cocone d (G M) := _ in _).
-{ simple refine (mk_cocone _ _).
-+ intro v.
-apply (φ_adj C D F H (coconeIn ccM v)).
-+ intros m n e; simpl.
-rewrite <- (coconeInCommutes ccM m n e); simpl.
-now rewrite φ_adj_natural_precomp.
-}
-apply (HccL (G M) X).
+    ∀ i, # F (coconeIn ccL i) ;; φ_adj_inv _ _ _ H y = coconeIn ccM i)).
+  + apply (weqbandf (adjunction_hom_weq _ _ _ H L M)); simpl; intro f.
+    apply weqiff; try (apply impred; intro; apply hsD).
+    now rewrite φ_adj_inv_after_φ_adj.
+  + eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧,
+      ∀ i, φ_adj_inv _ _ _ _ (coconeIn ccL i ;; y) = coconeIn ccM i)).
+    * apply weqfibtototal; simpl; intro f.
+      apply weqonsecfibers; intro i.
+      rewrite φ_adj_inv_natural_precomp; apply idweq.
+    * apply weqfibtototal; simpl; intro f.
+      apply weqonsecfibers; intro i.
+      apply weqimplimpl; [ | | apply hsD | apply hsC]; intro h.
+        now rewrite <- h, (φ_adj_after_φ_adj_inv _ _ _ H).
+      now rewrite h, (φ_adj_inv_after_φ_adj _ _ _ H).
+- simple refine (let X : cocone d (G M) := _ in _).
+  { simple refine (mk_cocone _ _).
+    + intro v; apply (φ_adj C D F H (coconeIn ccM v)).
+    + abstract (intros m n e; simpl;
+                rewrite <- (coconeInCommutes ccM m n e); simpl;
+                now rewrite φ_adj_natural_precomp).
+  }
+  apply (HccL (G M) X).
 Defined.
 
 Section preserves_colimit_examples.

--- a/UniMath/CategoryTheory/colimits/colimits.v
+++ b/UniMath/CategoryTheory/colimits/colimits.v
@@ -505,6 +505,15 @@ Definition preserves_colimit {g : graph} (d : diagram g C) (L : C)
   (cc : cocone d L) : UU :=
   isColimCocone d L cc -> isColimCocone (mapdiagram d) (F L) (mapcocone d cc).
 
+Definition is_cocont := forall {g : graph} (d : diagram g C) (L : C)
+  (cc : cocone d L), preserves_colimit d L cc.
+
+Require Import UniMath.CategoryTheory.equivalences.
+Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
+
+Lemma left_adjoint_cocont (H : is_left_adjoint F) : is_cocont.
+Admitted.
+
 End preserves_colimit.
 
 Section preserves_colimit_examples.
@@ -526,6 +535,11 @@ simple refine (tpair _ _ _).
 - simpl; intro t; apply subtypeEquality.
   + simpl; intro v; apply impred; intro; apply hsC.
   + apply (colimArrowUnique CC); intro n; apply (pr2 t).
+Defined.
+
+Lemma is_cocont_identity : is_cocont Fid.
+Proof.
+intros g d L cc; apply preserves_colimit_identity.
 Defined.
 
 Variable (x : D).
@@ -554,7 +568,7 @@ Lemma preserves_colimit_comp (F : functor C D) (G : functor D E)
   {g : graph} (d : diagram g C) (L : C) (cc : cocone d L)
   (H1 : preserves_colimit F d L cc)
   (H2 : preserves_colimit G (mapdiagram F d) (F L) (mapcocone F _ cc)) :
-  preserves_colimit (functor_composite _ _ _ F G) d L cc.
+  preserves_colimit (functor_composite F G) d L cc.
 Proof.
 intros HcL y ccy; simpl.
 set (CC := mk_ColimCocone _ _ _ (H2 (H1 HcL))).
@@ -565,6 +579,13 @@ simple refine (tpair _ _ _).
 - simpl; intro t; apply subtypeEquality.
   + intros f; apply impred; intro; apply hsE.
   + simpl; apply (colimArrowUnique CC), (pr2 t).
+Defined.
+
+Lemma is_cocont_comp (F : functor C D) (G : functor D E)
+  (HF : is_cocont F) (HG : is_cocont G) : is_cocont (functor_composite F G).
+Proof.
+intros g d L cc.
+apply preserves_colimit_comp; [ apply HF | apply HG ].
 Defined.
 
 End preserves_colimit_examples.

--- a/UniMath/CategoryTheory/colimits/colimits.v
+++ b/UniMath/CategoryTheory/colimits/colimits.v
@@ -508,13 +508,77 @@ Definition preserves_colimit {g : graph} (d : diagram g C) (L : C)
 Definition is_cocont := forall {g : graph} (d : diagram g C) (L : C)
   (cc : cocone d L), preserves_colimit d L cc.
 
+End preserves_colimit.
+
 Require Import UniMath.CategoryTheory.equivalences.
 Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
 
-Lemma left_adjoint_cocont (H : is_left_adjoint F) : is_cocont.
-Admitted.
+Lemma left_adjoint_cocont {C D : precategory} (F : functor C D)
+  (H : is_left_adjoint F) (hsC : has_homsets C) (hsD : has_homsets D) : is_cocont F.
+Proof.
+intros g d L ccL HccL M ccM.
+set (phi := @φ_adj _ _ _ H).
+set (phi_inv := @φ_adj_inv _ _ _ H).
+set (G := pr1 H).
+apply (@iscontrweqb _ (Σ y : C ⟦ L, G M ⟧,
+    ∀ i, coconeIn ccL i ;; y = phi _ _ (coconeIn ccM i))).
+- eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧,
+    ∀ i, # F (coconeIn ccL i) ;; phi_inv _ _ y = coconeIn ccM i)).
++
+apply (weqbandf (adjunction_hom_weq _ _ _ H L M)).
+simpl.
+unfold phi_inv.
+intros x.
+apply weqiff; try (apply impred; intro; apply hsD).
+now rewrite φ_adj_inv_after_φ_adj.
++
+eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧,
+    ∀ i, φ_adj_inv _ _ _ _ (coconeIn ccL i ;; y) = coconeIn ccM i)).
+*
+apply (weqbandf (idweq _)); simpl; intro f.
+apply weqimplimpl; try (apply impred; intro; apply hsD).
+{
+intros h i.
+eapply pathscomp0.
+apply (φ_adj_inv_natural_precomp _ _ _ H L M f _ (coconeIn ccL i)).
+apply (h i).
+}
+{
+intros h i.
+eapply pathscomp0.
+eapply pathsinv0.
+apply (φ_adj_inv_natural_precomp _ _ _ H L M f _ (coconeIn ccL i)).
+apply (h i).
+}
+*
+apply (weqbandf (idweq _)); simpl; intro f.
+apply weqimplimpl.
+{
+intros h i.
+rewrite <- (h i).
+now rewrite (φ_adj_after_φ_adj_inv _ _ _ H).
+}
+{
+intros h i.
+rewrite (h i).
+now rewrite (φ_adj_inv_after_φ_adj _ _ _ H).
+}
+{apply impred; intro; apply hsD. }
+{apply impred; intro; apply hsC. }
 
-End preserves_colimit.
+-
+unfold phi; simpl.
+unfold isColimCocone in HccL.
+simple refine (let X : cocone d (G M) := _ in _).
+{ simple refine (mk_cocone _ _).
++ intro v.
+apply (φ_adj C D F H (coconeIn ccM v)).
++ intros m n e; simpl.
+rewrite <- (coconeInCommutes ccM m n e); simpl.
+now rewrite φ_adj_natural_precomp.
+}
+apply (HccL (G M) X).
+Defined.
 
 Section preserves_colimit_examples.
 

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -223,7 +223,7 @@ End binprod_functor.
 (* The delta functor C -> C^2 mapping x to (x,x) is omega_cocont *)
 Section delta_functor.
 
-Variable C : precategory.
+Variables (C : precategory) (PC : Products C) (hsC : has_homsets C).
 
 Definition delta_functor_data : functor_data C (product_precategory C C).
 Proof.
@@ -241,10 +241,9 @@ mkpair.
   + intros x y z f g; apply idpath.
 Defined.
 
-(* Todo: show that delta_functor is left adjoint to product and the use general fact *)
-Lemma cocont_delta_functor (PC : Products C) : is_cocont delta_functor.
+Lemma is_left_adjoint_delta_functor : is_left_adjoint delta_functor.
 Proof.
-apply left_adjoint_cocont, (tpair _ (binproduct_functor _ PC)).
+apply (tpair _ (binproduct_functor _ PC)).
 mkpair.
 - split.
   + mkpair.
@@ -263,10 +262,16 @@ mkpair.
     apply pathsinv0, Product_endo_is_identity; [ apply ProductPr1Commutes | apply ProductPr2Commutes ].
 Defined.
 
-Lemma omega_cocont_delta_functor (PC : Products C) : omega_cocont delta_functor.
+Lemma cocont_delta_functor : is_cocont delta_functor.
+Proof.
+apply (left_adjoint_cocont _ is_left_adjoint_delta_functor hsC).
+apply (has_homsets_product_precategory _ _ hsC hsC).
+Defined.
+
+Lemma omega_cocont_delta_functor : omega_cocont delta_functor.
 Proof.
 intros c L ccL.
-apply (cocont_delta_functor PC).
+apply cocont_delta_functor.
 Defined.
 
 End delta_functor.
@@ -274,8 +279,7 @@ End delta_functor.
 (* The functor "+ : C^2 -> C" is cocont *)
 Section bincoprod_functor.
 
-Variable C : precategory.
-Variables (PC : Coproducts C).
+Variables (C : precategory) (PC : Coproducts C) (hsC : has_homsets C).
 
 Definition bincoproduct_functor_data : functor_data (product_precategory C C) C.
 Proof.
@@ -298,10 +302,9 @@ mkpair.
   + now intros x y z f g; simpl; rewrite CoproductOfArrows_comp.
 Defined.
 
-(* TODO: opacify *)
-Lemma cocont_bincoproducts_functor : is_cocont bincoproduct_functor.
+Lemma is_left_adjoint_bincoproduct_functor : is_left_adjoint bincoproduct_functor.
 Proof.
-apply left_adjoint_cocont, (tpair _ (delta_functor _)).
+apply (tpair _ (delta_functor _)).
 mkpair.
 - split.
   + mkpair.
@@ -320,6 +323,13 @@ mkpair.
       [ apply CoproductIn1Commutes | apply CoproductIn2Commutes ].
   + unfold prodcatmor, compose; simpl.
     now rewrite CoproductIn1Commutes, CoproductIn2Commutes.
+Defined.
+
+Lemma cocont_bincoproducts_functor : is_cocont bincoproduct_functor.
+Proof.
+apply (left_adjoint_cocont _ is_left_adjoint_bincoproduct_functor).
+- apply has_homsets_product_precategory; apply hsC.
+- apply hsC.
 Defined.
 
 Lemma omega_cocont_bincoproduct_functor: omega_cocont bincoproduct_functor.
@@ -811,9 +821,11 @@ Lemma omega_cocont_sum_of_functors (F G : functor C D)
 Proof.
 apply (omega_cocont_functor_composite _ _ _ hsD).
   apply (omega_cocont_delta_functor _ PC).
+  apply hsC.
 apply (omega_cocont_functor_composite _ _ _ hsD).
   apply (omega_cocont_pair_functor _ _ _ _ _ _ hsC hsC hsD hsD HF HG).
 apply omega_cocont_bincoproduct_functor.
+apply hsD.
 Defined.
 
 End temp.
@@ -874,6 +886,7 @@ apply omega_cocont_sum_of_functors.
   apply functor_category_has_homsets.
   apply omega_cocont_delta_functor.
   apply (Products_functor_precat _ _ ProductsHSET).
+  apply functor_category_has_homsets.
   apply omega_cocont_binproduct_functor.
 apply omega_cocont_pre_composition_functor.
 Defined.

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -780,6 +780,17 @@ rewrite foldr_cons. cbn.
 apply idpath.
 Abort.
 
+(* some experiments: *)
+
+(* Definition const {A B : UU} : A -> B -> A := fun x _ => x. *)
+
+(* Eval compute in const 0 (nil natHSET). *)
+
+(* Axiom const' : forall {A B : UU}, A -> B -> A. *)
+
+(* Eval compute in const' 0 1. *)
+(* Eval compute in const' 0 (nil natHSET). *)
+
 (* Time Eval vm_compute in nil natHSET.  (* This crashes my computer by using up all memory *) *)
 
 End nat_examples.

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -33,7 +33,7 @@ Section constant_functor.
 
 Variable (x : D).
 
-Lemma omega_cocontConstantFunctor : omega_cocont (constant_functor C D x).
+Lemma omega_cocont_constant_functor : omega_cocont (constant_functor C D x).
 Proof.
 intros c L ccL HcL y ccy; simpl.
 simple refine (tpair _ _ _).
@@ -53,7 +53,7 @@ End constant_functor.
 (* The identity functor is omega cocontinuous *)
 Section identity_functor.
 
-Lemma omega_cocontFunctorIdentity : omega_cocont (functor_identity C).
+Lemma omega_cocont_functor_identity : omega_cocont (functor_identity C).
 Proof.
 intros c L ccL HcL.
 apply (preserves_colimit_identity hsC _ _ _ HcL).
@@ -64,7 +64,7 @@ End identity_functor.
 (* Functor composition preserves omega cocontinuity *)
 Section functor_comp.
 
-Lemma omega_cocontFunctorComposite (F : functor C D) (G : functor D E) :
+Lemma omega_cocont_functor_composite (F : functor C D) (G : functor D E) :
   omega_cocont F -> omega_cocont G -> omega_cocont (functor_composite F G).
 Proof.
 intros hF hG c L cc.
@@ -183,10 +183,26 @@ End constcoprod_functor.
 
 End polynomial_functors.
 
+Require Import UniMath.CategoryTheory.ProductPrecategory.
+Require Import UniMath.CategoryTheory.equivalences.
+Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
+
+(* The functor "* : C^2 -> C" is omega cocont *)
+Section binprod_functor.
+
+Variable C : precategory.
+Variables (PC : Products C).
+
+Definition binproduct_functor : functor (product_precategory C C) C.
+Admitted.
+
+Lemma omega_cocont_binproduct_functor : omega_cocont binproduct_functor.
+Admitted.
+
+End binprod_functor.
+
 (* The delta functor C -> C^2 mapping x to (x,x) is omega_cocont *)
 Section delta_functor.
-
-Require Import UniMath.CategoryTheory.ProductPrecategory.
 
 Variable C : precategory.
 
@@ -207,38 +223,21 @@ mkpair.
 Defined.
 
 (* Todo: show that delta_functor is left adjoint to product and the use general fact *)
-Lemma cocont_delta_functor : is_cocont delta_functor.
+Lemma cocont_delta_functor (PC : Products C) : is_cocont delta_functor.
+Proof.
+apply left_adjoint_cocont.
+mkpair.
+- apply (binproduct_functor _ PC).
+- admit.
 Admitted.
+
+Lemma omega_cocont_delta_functor (PC : Products C) : omega_cocont delta_functor.
+Proof.
+intros c L ccL.
+apply (cocont_delta_functor PC).
+Defined.
 
 End delta_functor.
-
-(* A pair of functors (F,G) : C^2 -> D^2 is omega_cocont if F and G are *)
-Section pair_functor.
-
-Variables C D : precategory.
-Variables F G : functor C D.
-
-Definition pair_functor_data : functor_data (product_precategory C C) (product_precategory D D).
-Proof.
-mkpair.
-- intro x; apply (prodcatpair (F (pr1 x)) (G (pr2 x))).
-- intros x y f; simpl; apply (prodcatmor (# F (pr1 f)) (# G (pr2 f))).
-Defined.
-
-Definition pair_functor : functor (product_precategory C C) (product_precategory D D).
-Proof.
-mkpair.
-- exact pair_functor_data.
-- split.
-  + intro x; simpl; rewrite !functor_id; apply idpath.
-  + intros x y z f g; simpl; rewrite !functor_comp; apply idpath.
-Defined.
-
-Lemma cocont_pair_functor (HF : is_cocont F) (HG : is_cocont G) :
-  is_cocont pair_functor.
-Admitted.
-
-End pair_functor.
 
 (* The functor "+ : C^2 -> C" is cocont *)
 Section bincoprod_functor.
@@ -249,30 +248,64 @@ Variables (PC : Coproducts C).
 Definition bincoproduct_functor : functor (product_precategory C C) C.
 Admitted.
 
-End bincoprod_functor.
-
-(* The functor "* : C^2 -> C" is cocont *)
-Section binprod_functor.
-
-Variable C : precategory.
-Variables (PC : Products C).
-
-Definition binproduct_functor : functor (product_precategory C C) C.
+Lemma cocont_bincoproducts_functor: is_cocont bincoproduct_functor.
+Proof.
+apply left_adjoint_cocont.
+mkpair.
+- apply delta_functor.
+- admit.
 Admitted.
 
-End binprod_functor.
+Lemma omega_cocont_bincoproduct_functor: omega_cocont bincoproduct_functor.
+Proof.
+intros c L ccL; apply cocont_bincoproducts_functor.
+Defined.
+
+End bincoprod_functor.
+
+(* A pair of functors (F,G) : A * B -> C * D is omega_cocont if F and G are *)
+Section pair_functor.
+
+Variables A B C D : precategory.
+Variables (F : functor A C) (G : functor B D).
+
+Definition pair_functor_data : functor_data (product_precategory A B) (product_precategory C D).
+Proof.
+mkpair.
+- intro x; apply (prodcatpair (F (pr1 x)) (G (pr2 x))).
+- intros x y f; simpl; apply (prodcatmor (# F (pr1 f)) (# G (pr2 f))).
+Defined.
+
+Definition pair_functor : functor (product_precategory A B) (product_precategory C D).
+Proof.
+mkpair.
+- exact pair_functor_data.
+- split.
+  + intro x; simpl; rewrite !functor_id; apply idpath.
+  + intros x y z f g; simpl; rewrite !functor_comp; apply idpath.
+Defined.
+
+(* Lemma cocont_pair_functor (HF : is_cocont F) (HG : is_cocont G) : *)
+(*   is_cocont pair_functor. *)
+(* Admitted. *)
+
+Lemma omega_cocont_pair_functor (HF : omega_cocont F) (HG : omega_cocont G) :
+  omega_cocont pair_functor.
+Admitted.
+
+End pair_functor.
 
 (* Should go to ProductPrecategory.v *)
 (* The functor "F * G : A * B -> C * D" is cocont *)
-Section product_of_functors.
+(* Section product_of_functors. *)
 
-Variable A B C D : precategory.
-Variables (F : functor A C) (G : functor B D).
+(* Variable A B C D : precategory. *)
+(* Variables (F : functor A C) (G : functor B D). *)
 
-Definition product_of_functors : functor (product_precategory A B) (product_precategory C D).
-Admitted.
+(* Definition product_of_functors : functor (product_precategory A B) (product_precategory C D). *)
+(* Admitted. *)
 
-End product_of_functors.
+(* End product_of_functors. *)
 
 Section rightkanextension.
 
@@ -285,13 +318,18 @@ Variables (K : functor C D).
 (* Lemma foo : has_limits D -> GlobalRightKanExtensionExists K. *)
 
 (* has_limits D *)
-Lemma bar (hsD : has_homsets D) (hsE : has_homsets E) : is_cocont (pre_composition_functor _ _ E hsD hsE K).
+Lemma cocont_pre_composition_functor (hsD : has_homsets D) (hsE : has_homsets E) :
+  is_cocont (pre_composition_functor _ _ E hsD hsE K).
 Admitted. (* will be a simple consequence of foo *)
 
+Lemma omega_cocont_pre_composition_functor (hsD : has_homsets D) (hsE : has_homsets E) :
+  omega_cocont (pre_composition_functor _ _ E hsD hsE K).
+Proof.
+intros c L ccL.
+apply cocont_pre_composition_functor.
+Defined.
+
 End rightkanextension.
-
-(* whiskering.v, pre_composition_functor *)
-
 
 (* Lists as the colimit of a chain given by the list functor: F(X) = 1 + A * X *)
 Section lists.
@@ -307,7 +345,7 @@ Definition listFunctor : functor HSET HSET :=
 
 Lemma omega_cocont_listFunctor : omega_cocont listFunctor.
 Proof.
-apply (omega_cocontFunctorComposite _ _ _ has_homsets_HSET).
+apply (omega_cocont_functor_composite _ _ _ has_homsets_HSET).
 - apply omega_cocontConstProdFunctor.
 - apply (omega_cocontConstCoprodFunctor _ has_homsets_HSET).
 Defined.
@@ -524,7 +562,6 @@ Abort.
 
 End nat_examples.
 
-
 (* Inductive list A : UU := *)
 (*   | nilA : list A *)
 (*   | consA : A -> list A -> list A. *)
@@ -542,33 +579,56 @@ End nat_examples.
 Section lambdacalculus.
 
 Section temp.
-Variables (C D : precategory) (HD : Coproducts D).
+Variables (C D : precategory) (PC : Products C) (HD : Coproducts D).
 
 Definition sum_of_functors (F G : functor C D) : functor C D.
 eapply functor_composite.
   eapply delta_functor.
 eapply functor_composite.
-  eapply product_of_functors.
+  eapply pair_functor.
+  (* eapply product_of_functors. *)
     apply F.
     apply G.
 apply bincoproduct_functor.
 apply HD.
 Defined.
+
+Lemma omega_cocont_sum_of_functors (F G : functor C D) (hsD : has_homsets D)
+  (HF : omega_cocont F) (HG : omega_cocont G) : omega_cocont (sum_of_functors F G).
+Proof.
+apply (omega_cocont_functor_composite _ _ _ hsD).
+  apply (omega_cocont_delta_functor _ PC).
+apply (omega_cocont_functor_composite _ _ _ hsD).
+  apply (omega_cocont_pair_functor _ _ _ _ _ _ HF HG).
+apply omega_cocont_bincoproduct_functor.
+Defined.
+
 End temp.
 
-(* TODO: Define the parts individually and then take the sum_of_functors *)
-Definition Lambda : functor [HSET,HSET,has_homsets_HSET] [HSET,HSET,has_homsets_HSET].
+Definition option_functor : [HSET,HSET,has_homsets_HSET].
+Proof.
+apply coproduct_functor.
+apply CoproductsHSET.
+apply (constant_functor _ _ unitHSET).
+apply functor_identity.
+Defined.
+
+(* TODO: define sum of omega cocont functors *)
+Definition LambdaFunctor : functor [HSET,HSET,has_homsets_HSET] [HSET,HSET,has_homsets_HSET].
 Proof.
 eapply sum_of_functors.
-  admit.
+  apply (Coproducts_functor_precat _ _ CoproductsHSET).
   apply (constant_functor [HSET, HSET, has_homsets_HSET] [HSET, HSET, has_homsets_HSET] (functor_identity HSET)).
 eapply sum_of_functors.
-  admit.
+  apply (Coproducts_functor_precat _ _ CoproductsHSET).
   (* app *)
-  admit.
+  eapply functor_composite.
+    apply delta_functor.
+    apply binproduct_functor.
+    apply (Products_functor_precat _ _ ProductsHSET).
 (* lam *)
-admit.
-Admitted.
+apply (pre_composition_functor _ _ _ _ _ option_functor).
+Defined.
 
 (* Bad approach *)
 (* Definition Lambda : functor [HSET,HSET,has_homsets_HSET] [HSET,HSET,has_homsets_HSET]. *)
@@ -584,5 +644,23 @@ Admitted.
 (*     apply (constant_functor [HSET, HSET, has_homsets_HSET] [HSET, HSET, has_homsets_HSET] (functor_identity HSET)). *)
 (*     eapply product_of_functors. *)
 (*       apply delta_functor. *)
+
+Lemma omega_cocont_LambdaFunctor : omega_cocont LambdaFunctor.
+Proof.
+apply omega_cocont_sum_of_functors.
+  apply (Products_functor_precat _ _ ProductsHSET).
+  apply functor_category_has_homsets.
+  apply omega_cocont_constant_functor.
+  apply functor_category_has_homsets.
+apply omega_cocont_sum_of_functors.
+  apply (Products_functor_precat _ _ ProductsHSET).
+  apply functor_category_has_homsets.
+  apply omega_cocont_functor_composite.
+  apply functor_category_has_homsets.
+  apply omega_cocont_delta_functor.
+  apply (Products_functor_precat _ _ ProductsHSET).
+  apply omega_cocont_binproduct_functor.
+apply omega_cocont_pre_composition_functor.
+Defined.
 
 End lambdacalculus.

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -389,6 +389,7 @@ Defined.
 (*   is_cocont pair_functor. *)
 (* Admitted. *)
 
+(* Maybe generalize these to arbitrary diagrams *)
 Lemma cocone_pr1_functor (cAB : chain (product_precategory A B))
   (ab : A × B) (ccab : cocone cAB ab) :
   cocone (mapchain pr1_functor cAB) (pr1 ab).
@@ -418,7 +419,6 @@ mkpair.
 - apply (tpair _ x1).
   abstract (intro n; apply (maponpaths pr1 (p1 n))).
 - intro t.
-
   simple refine (let X : Σ x0,
            ∀ v : nat, coconeIn ccab v ;; x0 =
                       prodcatmor (pr1 ccx v) (pr2 (pr1 ccab v)) := _ in _).
@@ -481,12 +481,12 @@ intros cAB ml ccml Hccml xy ccxy; simpl in *.
 simple refine (let cFAX : cocone (mapdiagram F (mapchain pr1_functor cAB)) (pr1 xy) := _ in _).
 { simple refine (mk_cocone _ _).
   - intro n; apply (pr1 (pr1 ccxy n)).
-  - abstract (intros m n e; apply (maponpaths pr1 ((pr2 ccxy) m n e))).
+  - abstract (intros m n e; apply (maponpaths pr1 (pr2 ccxy m n e))).
 }
 simple refine (let cGBY : cocone (mapdiagram G (mapchain pr2_functor cAB)) (pr2 xy) := _ in _).
 { simple refine (mk_cocone _ _).
   - intro n; apply (pr2 (pr1 ccxy n)).
-  - abstract (intros m n e; apply (maponpaths dirprod_pr2 ((pr2 ccxy) m n e))).
+  - abstract (intros m n e; apply (maponpaths dirprod_pr2 (pr2 ccxy m n e))).
 }
 destruct (HF _ _ _ (isColimCocone_pr1_functor cAB ml ccml Hccml) _ cFAX) as [[f hf1] hf2].
 destruct (HG _ _ _ (isColimCocone_pr2_functor cAB ml ccml Hccml) _ cGBY) as [[g hg1] hg2].

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -334,7 +334,8 @@ Section pair_functor.
 
 Variables A B C D : precategory.
 Variables (F : functor A C) (G : functor B D).
-Variables (hsA : has_homsets A).
+Variables (hsA : has_homsets A) (hsB : has_homsets B).
+Variables (hsC : has_homsets C) (hsD : has_homsets D).
 
 Definition pair_functor_data : functor_data (product_precategory A B) (product_precategory C D).
 Proof.
@@ -417,6 +418,7 @@ mkpair.
 - apply (tpair _ x1).
   abstract (intro n; apply (maponpaths pr1 (p1 n))).
 - intro t.
+
   simple refine (let X : Σ x0,
            ∀ v : nat, coconeIn ccab v ;; x0 =
                       prodcatmor (pr1 ccx v) (pr2 (pr1 ccab v)) := _ in _).
@@ -429,7 +431,6 @@ mkpair.
             [ intro f; apply impred; intro; apply hsA
             | apply (maponpaths (fun x => pr1 (pr1 x)) (p2 X))]).
 Defined.
-
 
 Lemma cocone_pr2_functor (cAB : chain (product_precategory A B))
   (ab : A × B) (ccab : cocone cAB ab) :
@@ -448,67 +449,61 @@ Proof.
 intros x ccx.
 simple refine (let HHH : cocone cAB (pr1 ab,, x) := _ in _).
 { simple refine (mk_cocone _ _).
-  - simpl; intro n; split.
-apply (# pr1_functor (pr1 ccab n)).
-
-apply (pr1 ccx n).
-  -
-    simpl; intros m n e; rewrite (paireta (dmor cAB e));
-    apply pathsdirprod.
-simpl.
-admit.
-(* apply (maponpaths dirprod_pr2 ((pr2 ccab) m n e)). *)
-apply (pr2 ccx m n e).
+  - simpl; intro n; split;
+      [ apply (# pr1_functor (pr1 ccab n)) | apply (pr1 ccx n) ].
+  - abstract(
+    simpl; intros m n e; rewrite (paireta (dmor cAB e)); apply pathsdirprod;
+      [ apply (maponpaths pr1 (pr2 ccab m n e)) | apply (pr2 ccx m n e) ]).
  }
 destruct (Hccab _ HHH) as [[[x1 x2] p1] p2]; simpl in *.
 mkpair.
 - apply (tpair _ x2).
-  intro n; apply (maponpaths dirprod_pr2 (p1 n)).
+  abstract (intro n; apply (maponpaths dirprod_pr2 (p1 n))).
 - intro t.
-admit.
-(*   simple refine (let X : Σ x0, *)
-(*            ∀ v : nat, coconeIn ccab v ;; x0 = *)
-(*                       prodcatmor (pr1 ccx v) (pr2 (pr1 ccab v)) := _ in _). *)
-(*   { mkpair. *)
-(*     - split; [ apply (pr1 t) | apply (identity _) ]. *)
-(*     - abstract (intro n; rewrite id_right; apply pathsdirprod; *)
-(*                  [ apply (pr2 t) | apply idpath ]). *)
-(*   } *)
-(*   abstract (apply subtypeEquality; simpl; *)
-(*             [ intro f; apply impred; intro; apply hsA *)
-(*             | apply (maponpaths (fun x => pr1 (pr1 x)) (p2 X))]). *)
-(* Defined. *)
-Admitted.
-
+  simple refine (let X : Σ x0,
+           ∀ v : nat, coconeIn ccab v ;; x0 =
+                      prodcatmor (pr1 (pr1 ccab v)) (pr1 ccx v) := _ in _).
+  { mkpair.
+    - split; [ apply (identity _) | apply (pr1 t) ].
+    - abstract (intro n; rewrite id_right; apply pathsdirprod;
+                 [ apply idpath | apply (pr2 t) ]).
+  }
+  abstract (apply subtypeEquality; simpl;
+              [ intro f; apply impred; intro; apply hsB
+              | apply (maponpaths (fun x => dirprod_pr2 (pr1 x)) (p2 X)) ]).
+Defined.
 
 Lemma omega_cocont_pair_functor (HF : omega_cocont F) (HG : omega_cocont G) :
   omega_cocont pair_functor.
 Proof.
-intros cAB ml ccml Hccml xy ccxy.
-(* destruct ml as [m l]. *)
-(* simpl in *. *)
-(* destruct xy as [x y]. *)
+intros cAB ml ccml Hccml xy ccxy; simpl in *.
+(* set (CC := ((ml,, ccml),, Hccml) : ColimCocone cAB). *)
+simple refine (let cFAX : cocone (mapdiagram F (mapchain pr1_functor cAB)) (pr1 xy) := _ in _).
+{ simple refine (mk_cocone _ _).
+  - intro n; apply (pr1 (pr1 ccxy n)).
+  - abstract (intros m n e; apply (maponpaths pr1 ((pr2 ccxy) m n e))).
+}
+simple refine (let cGBY : cocone (mapdiagram G (mapchain pr2_functor cAB)) (pr2 xy) := _ in _).
+{ simple refine (mk_cocone _ _).
+  - intro n; apply (pr2 (pr1 ccxy n)).
+  - abstract (intros m n e; apply (maponpaths dirprod_pr2 ((pr2 ccxy) m n e))).
+}
+destruct (HF _ _ _ (isColimCocone_pr1_functor cAB ml ccml Hccml) _ cFAX) as [[f hf1] hf2].
+destruct (HG _ _ _ (isColimCocone_pr2_functor cAB ml ccml Hccml) _ cGBY) as [[g hg1] hg2].
 simpl in *.
-
-simple refine (let X : ColimCocone cAB := _ in _).
 mkpair.
-apply (tpair _ _ ccml).
-simpl.
-apply Hccml.
-
-simple refine (let YY : cocone (mapdiagram F (mapchain pr1_functor cAB)) (pr1 xy) := _ in _).
-simple refine (mk_cocone _ _); simpl.
-intro n.
-apply (pr1 (pr1 ccxy n)).
-intros m n e.
-apply (maponpaths pr1 ((pr2 ccxy) m n e)).
-destruct (HF _ _ _ (isColimCocone_pr1_functor cAB ml ccml Hccml) (pr1 xy) YY).
-mkpair.
-mkpair.
-admit.
-admit.
-admit.
-Admitted.
+- apply (tpair _ (f,,g)).
+  abstract (intro n; unfold prodcatmor, compose; simpl;
+            now rewrite hf1, hg1, (paireta (coconeIn ccxy n))).
+- intro t.
+  apply subtypeEquality; simpl.
+  + intro x; apply impred; intro.
+    apply isaset_dirprod; [ apply hsC | apply hsD ].
+  + destruct t as [[f1 f2] ?]; simpl in *.
+    apply pathsdirprod.
+    * apply (maponpaths pr1 (hf2 (f1,, (λ n, maponpaths pr1 (p n))))).
+    * apply (maponpaths pr1 (hg2 (f2,, (λ n, maponpaths dirprod_pr2 (p n))))).
+Defined.
 
 End pair_functor.
 
@@ -797,7 +792,7 @@ Section lambdacalculus.
 
 Section temp.
 Variables (C D : precategory) (PC : Products C) (HD : Coproducts D).
-Variables (hsC : has_homsets C).
+Variables (hsC : has_homsets C) (hsD : has_homsets D).
 
 Definition sum_of_functors (F G : functor C D) : functor C D.
 eapply functor_composite.
@@ -811,13 +806,13 @@ apply bincoproduct_functor.
 apply HD.
 Defined.
 
-Lemma omega_cocont_sum_of_functors (F G : functor C D) (hsD : has_homsets D)
+Lemma omega_cocont_sum_of_functors (F G : functor C D)
   (HF : omega_cocont F) (HG : omega_cocont G) : omega_cocont (sum_of_functors F G).
 Proof.
 apply (omega_cocont_functor_composite _ _ _ hsD).
   apply (omega_cocont_delta_functor _ PC).
 apply (omega_cocont_functor_composite _ _ _ hsD).
-  apply (omega_cocont_pair_functor _ _ _ _ _ _ hsC HF HG).
+  apply (omega_cocont_pair_functor _ _ _ _ _ _ hsC hsC hsD hsD HF HG).
 apply omega_cocont_bincoproduct_functor.
 Defined.
 

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -351,12 +351,112 @@ mkpair.
   + intros x y z f g; simpl; rewrite !functor_comp; apply idpath.
 Defined.
 
+Definition pr1_functor_data : functor_data (product_precategory A B) A.
+Proof.
+mkpair.
+- intro x; apply (pr1 x).
+- intros x y f; simpl; apply (pr1 f).
+Defined.
+
+Definition pr1_functor : functor (product_precategory A B) A.
+Proof.
+mkpair.
+- exact pr1_functor_data.
+- split.
+  + intro x; apply idpath.
+  + intros x y z f g; apply idpath.
+Defined.
+
+Definition pr2_functor_data : functor_data (product_precategory A B) B.
+Proof.
+mkpair.
+- intro x; apply (pr2 x).
+- intros x y f; simpl; apply (pr2 f).
+Defined.
+
+Definition pr2_functor : functor (product_precategory A B) B.
+Proof.
+mkpair.
+- exact pr2_functor_data.
+- split.
+  + intro x; apply idpath.
+  + intros x y z f g; apply idpath.
+Defined.
+
 (* Lemma cocont_pair_functor (HF : is_cocont F) (HG : is_cocont G) : *)
 (*   is_cocont pair_functor. *)
 (* Admitted. *)
 
 Lemma omega_cocont_pair_functor (HF : omega_cocont F) (HG : omega_cocont G) :
   omega_cocont pair_functor.
+Proof.
+intros cAB ml ccml Hccml xy ccxy.
+(* destruct ml as [m l]. *)
+(* simpl in *. *)
+(* destruct xy as [x y]. *)
+simpl in *.
+simple refine (let X : ColimCocone cAB := _ in _).
+mkpair.
+apply (tpair _ _ ccml).
+simpl.
+apply Hccml.
+Check (colimArrow X ).
+
+simple refine (let ccA : cocone (mapchain pr1_functor cAB) (pr1 ml) := _ in _).
+  {
+  simple refine (mk_cocone _ _).
+  - simpl; intro n.
+    apply (pr1 (coconeIn ccml n)).
+  - abstract (simpl; intros m n e; now rewrite <- (coconeInCommutes ccml m n e)). }
+assert (H1 : isColimCocone _ _ ccA).
+  {
+intros a cca.
+unfold isColimCocone in Hccml.
+simpl in *.
+simple refine (let HHH : cocone cAB (a,, pr2 ml) := _ in _).
+destruct cca as [f g].
+simpl in *.
+simple refine (mk_cocone _ _).
+simpl; intro n.
+split.
+apply (f n).
+apply (# pr2_functor (pr1 ccml n)).
+simpl.
+intros m n e.
+rewrite (paireta (dmor cAB e)).
+unfold compose.
+simpl.
+apply pathsdirprod.
+apply (g m n e).
+apply (maponpaths dirprod_pr2 ((pr2 ccml) m n e)).
+destruct (Hccml _ HHH) as [[[x1 x2] p1] p2].
+simpl in *.
+mkpair.
+mkpair.
+apply x1.
+simpl; intro n.
+generalize (maponpaths pr1 (p1 n)).
+intros HH.
+unfold compose in HH; simpl in *.
+rewrite HH.
+destruct cca.
+simpl.
+apply idpath.
+simpl.
+admit.
+}
+simple refine (let YY : cocone (mapdiagram F (mapchain pr1_functor cAB)) (pr1 xy) := _ in _).
+simple refine (mk_cocone _ _); simpl.
+intro n.
+apply (pr1 (pr1 ccxy n)).
+intros m n e.
+apply (maponpaths pr1 ((pr2 ccxy) m n e)).
+destruct (HF _ _ ccA H1 (pr1 xy) YY).
+mkpair.
+mkpair.
+admit.
+admit.
+admit.
 Admitted.
 
 End pair_functor.

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -388,11 +388,11 @@ Definition constprod_functor1 (x : C) : functor C C :=
 Definition constprod_functor2 (x : C) : functor C C :=
   product_functor C C PC (functor_identity C) (constant_functor C C x).
 
-Lemma omega_cocont_constprod_functor1 (x : C) : omega_cocont (constprod_functor1 x).
-Admitted.
+(* Lemma omega_cocont_constprod_functor1 (x : C) : omega_cocont (constprod_functor1 x). *)
+(* Admitted. *)
 
-Lemma omega_cocont_constprod_functor2 (x : C) : omega_cocont (constprod_functor2 x).
-Admitted.
+(* Lemma omega_cocont_constprod_functor2 (x : C) : omega_cocont (constprod_functor2 x). *)
+(* Admitted. *)
 
 Definition binproduct_functor_data : functor_data (product_precategory C C) C.
 Proof.
@@ -416,44 +416,44 @@ mkpair.
 Defined.
 
 Lemma omega_cocont_binproduct_functor : omega_cocont binproduct_functor.
-Proof.
-intros c LM ccLM HccLM K ccK; simpl in *.
-generalize (isColimCocone_pr2_functor _ _ hsC _ _ _ HccLM).
-generalize (isColimCocone_pr1_functor _ _ hsC _ _ _ HccLM).
-set (L := pr1 LM); set (M := pr2 LM).
-intros HA HB.
-(* Form the colimiting cocones of "A_i * B_0 -> A_i * B_1 -> ..." *)
-assert (HAiB : forall i, isColimCocone
-     (mapdiagram (constprod_functor1 (pr1 (pr1 c i)))
-        (mapchain (pr2_functor C C) c))
-     ((constprod_functor1 (pr1 (pr1 c i))) M)
-     (mapcocone (constprod_functor1 (pr1 (pr1 c i)))
-        (mapchain (pr2_functor C C) c) (cocone_pr2_functor C C c LM ccLM))).
-  intro i.
-  apply (omega_cocont_constprod_functor1 (pr1 (pr1 c i)) _ _ _ HB).
-generalize (omega_cocont_constprod_functor2 M _ _ _ HA); intro HAiM.
-simple refine (let X : ColimCocone
-       (mapdiagram (constprod_functor2 M) (mapchain (pr1_functor C C) c)) := _ in _).
-mkpair.
-mkpair.
-apply (ProductObject _ (PC L M)).
-apply (mapcocone (constprod_functor2 M) (mapchain (pr1_functor C C) c)
-              (cocone_pr1_functor C C c LM ccLM)).
-apply HAiM.
-simple refine (let Y : cocone (mapdiagram (constprod_functor2 M) (mapchain (pr1_functor C C) c)) K := _ in _).
-  admit.
-mkpair.
-mkpair.
-apply (colimArrow X K Y).
-intro n.
-generalize (colimArrowCommutes X K Y n).
-simpl.
-unfold colimIn.
-simpl.
-unfold product_functor_mor.
-unfold ProductOfArrows.
-admit.
-admit.
+(* Proof. *)
+(* intros c LM ccLM HccLM K ccK; simpl in *. *)
+(* generalize (isColimCocone_pr2_functor _ _ hsC _ _ _ HccLM). *)
+(* generalize (isColimCocone_pr1_functor _ _ hsC _ _ _ HccLM). *)
+(* set (L := pr1 LM); set (M := pr2 LM). *)
+(* intros HA HB. *)
+(* (* Form the colimiting cocones of "A_i * B_0 -> A_i * B_1 -> ..." *) *)
+(* assert (HAiB : forall i, isColimCocone *)
+(*      (mapdiagram (constprod_functor1 (pr1 (pr1 c i))) *)
+(*         (mapchain (pr2_functor C C) c)) *)
+(*      ((constprod_functor1 (pr1 (pr1 c i))) M) *)
+(*      (mapcocone (constprod_functor1 (pr1 (pr1 c i))) *)
+(*         (mapchain (pr2_functor C C) c) (cocone_pr2_functor C C c LM ccLM))). *)
+(*   intro i. *)
+(*   apply (omega_cocont_constprod_functor1 (pr1 (pr1 c i)) _ _ _ HB). *)
+(* generalize (omega_cocont_constprod_functor2 M _ _ _ HA); intro HAiM. *)
+(* simple refine (let X : ColimCocone *)
+(*        (mapdiagram (constprod_functor2 M) (mapchain (pr1_functor C C) c)) := _ in _). *)
+(* mkpair. *)
+(* mkpair. *)
+(* apply (ProductObject _ (PC L M)). *)
+(* apply (mapcocone (constprod_functor2 M) (mapchain (pr1_functor C C) c) *)
+(*               (cocone_pr1_functor C C c LM ccLM)). *)
+(* apply HAiM. *)
+(* simple refine (let Y : cocone (mapdiagram (constprod_functor2 M) (mapchain (pr1_functor C C) c)) K := _ in _). *)
+(*   admit. *)
+(* mkpair. *)
+(* mkpair. *)
+(* apply (colimArrow X K Y). *)
+(* intro n. *)
+(* generalize (colimArrowCommutes X K Y n). *)
+(* simpl. *)
+(* unfold colimIn. *)
+(* simpl. *)
+(* unfold product_functor_mor. *)
+(* unfold ProductOfArrows. *)
+(* admit. *)
+(* admit. *)
 Admitted.
 
 End binprod_functor.
@@ -1007,7 +1007,7 @@ apply (constant_functor _ _ unitHSET).
 apply functor_identity.
 Defined.
 
-(* TODO: define sum of omega cocont functors *)
+(* TODO: package omega cocont functors *)
 Definition LambdaFunctor : functor [HSET,HSET,has_homsets_HSET] [HSET,HSET,has_homsets_HSET].
 Proof.
 eapply sum_of_functors.

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -798,6 +798,104 @@ End nat_examples.
 (* apply idpath. *)
 (* Abort. *)
 
+(* Alternative and more general definition of lists (inspired by a remark of VV) *)
+Section list'.
+
+(* I think if you really need lists you should prove a theorem that
+establishes a weq between the lists that you have defined and lists
+defined as total2 ( fun n : nat => iterprod n A ) where iterprod n A
+is defined by induction such that iterprod 0 A = unit, iterprod 1 A =
+A and iterprod ( S n ) A = dirprod (iterprod n A) A for n=S n’. *)
+
+Fixpoint iterprod (n : nat) (A : UU) : UU := match n with
+  | O => unit
+  | S n' => dirprod A (iterprod n' A)
+  end.
+
+Definition list' (A : UU) := total2 (fun n => iterprod n A).
+
+Definition nil_list' (A : UU) : list' A := (0,,tt).
+Definition cons_list' (A : UU) (x : A) (xs : list' A) : list' A :=
+  (S (pr1 xs),, (x,, pr2 xs)).
+
+Lemma list'_ind : ∀ (A : Type) (P : list' A -> UU),
+    P (nil_list' A)
+  -> (∀ (x : A) (xs : list' A), P xs -> P (cons_list' A x xs))
+  -> ∀ xs, P xs.
+Proof.
+intros A P Hnil Hcons xs.
+destruct xs as [n xs].
+induction n.
+- destruct xs.
+  apply Hnil.
+- destruct xs as [x xs].
+  apply (Hcons x (n,,xs) (IHn xs)).
+Qed.
+
+Lemma isaset_list' (A : HSET) : isaset (list' (pr1 A)).
+Proof.
+apply isaset_total2; [apply isasetnat|].
+intro n; induction n; simpl; [apply isasetunit|].
+apply isaset_dirprod; [ apply setproperty | apply IHn ].
+Qed.
+
+Definition to_List (A : HSET) : list' (pr1 A) -> pr1 (List A).
+Proof.
+intros l.
+destruct l as [n l].
+induction n.
++ exact (nil A).
++ apply (cons _ (pr1 l,,IHn (pr2 l))).
+Defined.
+
+Definition to_list' (A : HSET) : pr1 (List A) -> list' (pr1 A).
+Proof.
+apply (foldr A (list' (pr1 A),,isaset_list' A)).
+* apply (0,,tt).
+* intros L.
+  apply (tpair _ (S (pr1 (pr2 L))) (pr1 L,,pr2 (pr2 L))).
+Defined.
+
+Lemma to_list'K (A : HSET) : ∀ x : list' (pr1 A), to_list' A (to_List A x) = x.
+Proof.
+intro l; destruct l as [n l]; unfold to_list', to_List.
+induction n; simpl.
+- rewrite foldr_nil.
+  destruct l.
+  apply idpath.
+- rewrite foldr_cons; simpl.
+  rewrite IHn; simpl; rewrite <- (paireta l).
+  apply idpath.
+Qed.
+
+Lemma to_ListK (A : HSET) : ∀ y : pr1 (List A), to_List A (to_list' A y) = y.
+Proof.
+apply listIndProp.
+* intro l; apply setproperty.
+* unfold to_list'; rewrite foldr_nil.
+  apply idpath.
+* unfold to_list', to_List; intros a l IH.
+  rewrite foldr_cons; simpl.
+  apply maponpaths, maponpaths, pathsinv0.
+  eapply pathscomp0; [eapply pathsinv0, IH|]; simpl.
+  now destruct foldr.
+Qed.
+
+Lemma weq_list' (A : HSET) : list' (pr1 A) ≃ pr1 (List A).
+Proof.
+mkpair.
+- apply to_List.
+- simple refine (gradth _ _ _ _).
+  + apply to_list'.
+  + apply to_list'K.
+  + apply to_ListK.
+Defined.
+
+(* This works: *)
+Eval compute in (to_list' _ testlist).
+
+End list'.
+
 Section lambdacalculus.
 
 Section temp.

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -193,9 +193,28 @@ Section binprod_functor.
 Variable C : precategory.
 Variables (PC : Products C).
 
-Definition binproduct_functor : functor (product_precategory C C) C.
-Admitted.
+Definition binproduct_functor_data : functor_data (product_precategory C C) C.
+Proof.
+mkpair.
+- intros p.
+  apply (ProductObject _ (PC (pr1 p) (pr2 p))).
+- simpl; intros p q f.
+  apply (ProductOfArrows _ (PC (pr1 q) (pr2 q)) (PC (pr1 p) (pr2 p)) (pr1 f) (pr2 f)).
+Defined.
 
+Definition binproduct_functor : functor (product_precategory C C) C.
+Proof.
+mkpair.
+- apply binproduct_functor_data.
+- split.
+  + intro x; simpl.
+    apply pathsinv0, Product_endo_is_identity.
+    * now rewrite ProductOfArrowsPr1, id_right.
+    * now rewrite ProductOfArrowsPr2, id_right.
+  + now intros x y z f g; simpl; rewrite ProductOfArrows_comp.
+Defined.
+
+(* This is difficult to prove *)
 Lemma omega_cocont_binproduct_functor : omega_cocont binproduct_functor.
 Admitted.
 
@@ -225,11 +244,24 @@ Defined.
 (* Todo: show that delta_functor is left adjoint to product and the use general fact *)
 Lemma cocont_delta_functor (PC : Products C) : is_cocont delta_functor.
 Proof.
-apply left_adjoint_cocont.
+apply left_adjoint_cocont, (tpair _ (binproduct_functor _ PC)).
 mkpair.
-- apply (binproduct_functor _ PC).
-- admit.
-Admitted.
+- split.
+  + mkpair.
+    * simpl; intro x.
+      apply (ProductArrow _ _ (identity x) (identity x)).
+    * abstract (intros p q f; simpl;
+                now rewrite precompWithProductArrow, id_right, postcompWithProductArrow, id_left).
+  + mkpair.
+    * simpl; intro x; split; [ apply ProductPr1 | apply ProductPr2 ].
+    * abstract (intros p q f; unfold prodcatmor, compose; simpl;
+                now rewrite ProductOfArrowsPr1, ProductOfArrowsPr2).
+- split; simpl; intro x.
+  + unfold prodcatmor, compose; simpl.
+    now rewrite ProductPr1Commutes, ProductPr2Commutes.
+  + rewrite postcompWithProductArrow, !id_left.
+    apply pathsinv0, Product_endo_is_identity; [ apply ProductPr1Commutes | apply ProductPr2Commutes ].
+Defined.
 
 Lemma omega_cocont_delta_functor (PC : Products C) : omega_cocont delta_functor.
 Proof.
@@ -245,16 +277,50 @@ Section bincoprod_functor.
 Variable C : precategory.
 Variables (PC : Coproducts C).
 
-Definition bincoproduct_functor : functor (product_precategory C C) C.
-Admitted.
-
-Lemma cocont_bincoproducts_functor: is_cocont bincoproduct_functor.
+Definition bincoproduct_functor_data : functor_data (product_precategory C C) C.
 Proof.
-apply left_adjoint_cocont.
 mkpair.
-- apply delta_functor.
-- admit.
-Admitted.
+- intros p.
+  apply (CoproductObject _ (PC (pr1 p) (pr2 p))).
+- simpl; intros p q f.
+  apply (CoproductOfArrows _ (PC (pr1 p) (pr2 p)) (PC (pr1 q) (pr2 q)) (pr1 f) (pr2 f)).
+Defined.
+
+Definition bincoproduct_functor : functor (product_precategory C C) C.
+Proof.
+mkpair.
+- apply bincoproduct_functor_data.
+- split.
+  + intro x; simpl.
+    apply pathsinv0, Coproduct_endo_is_identity.
+    * now rewrite CoproductOfArrowsIn1, id_left.
+    * now rewrite CoproductOfArrowsIn2, id_left.
+  + now intros x y z f g; simpl; rewrite CoproductOfArrows_comp.
+Defined.
+
+(* TODO: opacify *)
+Lemma cocont_bincoproducts_functor : is_cocont bincoproduct_functor.
+Proof.
+apply left_adjoint_cocont, (tpair _ (delta_functor _)).
+mkpair.
+- split.
+  + mkpair.
+    * simpl; intro p; set (x := pr1 p); set (y := pr2 p).
+      split; [ apply (CoproductIn1 _ (PC x y)) | apply (CoproductIn2 _ (PC x y)) ].
+    * abstract (intros p q f; unfold prodcatmor, compose; simpl;
+                now rewrite CoproductOfArrowsIn1, CoproductOfArrowsIn2).
+  + mkpair.
+    * intro x; apply (CoproductArrow _ _ (identity x) (identity x)).
+    * abstract (intros p q f; simpl;
+                now rewrite precompWithCoproductArrow, postcompWithCoproductArrow,
+                            id_right, id_left).
+- split; simpl; intro x.
+  + rewrite precompWithCoproductArrow, !id_right.
+    apply pathsinv0, Coproduct_endo_is_identity;
+      [ apply CoproductIn1Commutes | apply CoproductIn2Commutes ].
+  + unfold prodcatmor, compose; simpl.
+    now rewrite CoproductIn1Commutes, CoproductIn2Commutes.
+Defined.
 
 Lemma omega_cocont_bincoproduct_functor: omega_cocont bincoproduct_functor.
 Proof.


### PR DESCRIPTION
Proofs that some more functors are (omega) cocontinuous.
Proof that left adjoints preserve colimits.
Definition of the lambda calculus functor.
The equivalence with Voevodsky's definition of lists (as iterated products) and our lists over sets (as the initial algebra of the list functor).

The formalization of the lambda calculus is not finished yet as there are two admitted lemmas (omega_cocont_binproduct_functor and cocont_pre_composition_functor). One should also remove the destructs, opacify properly, package omega cocontinuous functors and move definitions to the appropriate files.