### PR TITLE
On adjunctions and cocontinuity

### DIFF
--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -32,6 +32,7 @@ rezk_completion.v
 slicecat.v
 colimits/chains.v
 colimits/colimits.v
+EquivalencesExamples.v
 colimits/polynomialfunctors.v
 limits/limits.v
 AdjunctionHomTypesWeq.v
@@ -41,3 +42,4 @@ ProductPrecategory.v
 PointedFunctors.v
 PointedFunctorsComposition.v
 HorizontalComposition.v
+lists.v

--- a/UniMath/CategoryTheory/EquivalencesExamples.v
+++ b/UniMath/CategoryTheory/EquivalencesExamples.v
@@ -1,0 +1,36 @@
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.ProductPrecategory.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.equivalences.
+Require Import UniMath.CategoryTheory.limits.products.
+
+Section delta_functor_adjunction.
+
+Context {C : precategory} (PC : Products C).
+
+Lemma is_left_adjoint_delta_functor : is_left_adjoint (delta_functor C).
+Proof.
+apply (tpair _ (binproduct_functor PC)).
+mkpair.
+- split.
+  + mkpair.
+    * simpl; intro x.
+      apply (ProductArrow _ _ (identity x) (identity x)).
+    * abstract (intros p q f; simpl;
+                now rewrite precompWithProductArrow, id_right, postcompWithProductArrow, id_left).
+  + mkpair.
+    * simpl; intro x; split; [ apply ProductPr1 | apply ProductPr2 ].
+    * abstract (intros p q f; unfold prodcatmor, compose; simpl;
+                now rewrite ProductOfArrowsPr1, ProductOfArrowsPr2).
+- split; simpl; intro x.
+  + unfold prodcatmor, compose; simpl.
+    now rewrite ProductPr1Commutes, ProductPr2Commutes.
+  + rewrite postcompWithProductArrow, !id_left.
+    apply pathsinv0, Product_endo_is_identity; [ apply ProductPr1Commutes | apply ProductPr2Commutes ].
+Defined.
+
+End delta_functor_adjunction.

--- a/UniMath/CategoryTheory/EquivalencesExamples.v
+++ b/UniMath/CategoryTheory/EquivalencesExamples.v
@@ -27,11 +27,12 @@ mkpair.
     * simpl; intro x; split; [ apply ProductPr1 | apply ProductPr2 ].
     * abstract (intros p q f; unfold prodcatmor, compose; simpl;
                 now rewrite ProductOfArrowsPr1, ProductOfArrowsPr2).
-- split; simpl; intro x.
-  + unfold prodcatmor, compose; simpl.
-    now rewrite ProductPr1Commutes, ProductPr2Commutes.
-  + rewrite postcompWithProductArrow, !id_left.
-    apply pathsinv0, Product_endo_is_identity; [ apply ProductPr1Commutes | apply ProductPr2Commutes ].
+- abstract (split; simpl; intro x;
+  [ unfold prodcatmor, compose; simpl;
+    now rewrite ProductPr1Commutes, ProductPr2Commutes
+  | rewrite postcompWithProductArrow, !id_left;
+    apply pathsinv0, Product_endo_is_identity;
+      [ apply ProductPr1Commutes | apply ProductPr2Commutes ]]).
 Defined.
 
 End delta_functor_adjunction.
@@ -55,12 +56,12 @@ mkpair.
     * abstract (intros p q f; simpl;
                 now rewrite precompWithCoproductArrow, postcompWithCoproductArrow,
                             id_right, id_left).
-- split; simpl; intro x.
-  + rewrite precompWithCoproductArrow, !id_right.
+- abstract (split; simpl; intro x;
+  [ rewrite precompWithCoproductArrow, !id_right;
     apply pathsinv0, Coproduct_endo_is_identity;
-      [ apply CoproductIn1Commutes | apply CoproductIn2Commutes ].
-  + unfold prodcatmor, compose; simpl.
-    now rewrite CoproductIn1Commutes, CoproductIn2Commutes.
+      [ apply CoproductIn1Commutes | apply CoproductIn2Commutes ]
+  | unfold prodcatmor, compose; simpl;
+    now rewrite CoproductIn1Commutes, CoproductIn2Commutes ]).
 Defined.
 
 End bincoproduct_functor_adjunction.

--- a/UniMath/CategoryTheory/EquivalencesExamples.v
+++ b/UniMath/CategoryTheory/EquivalencesExamples.v
@@ -7,6 +7,7 @@ Require Import UniMath.CategoryTheory.ProductPrecategory.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.equivalences.
 Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.limits.coproducts.
 
 Section delta_functor_adjunction.
 
@@ -34,3 +35,32 @@ mkpair.
 Defined.
 
 End delta_functor_adjunction.
+
+Section bincoproduct_functor_adjunction.
+
+Context {C : precategory} (PC : Coproducts C).
+
+Lemma is_left_adjoint_bincoproduct_functor : is_left_adjoint (bincoproduct_functor PC).
+Proof.
+apply (tpair _ (delta_functor _)).
+mkpair.
+- split.
+  + mkpair.
+    * simpl; intro p; set (x := pr1 p); set (y := pr2 p).
+      split; [ apply (CoproductIn1 _ (PC x y)) | apply (CoproductIn2 _ (PC x y)) ].
+    * abstract (intros p q f; unfold prodcatmor, compose; simpl;
+                now rewrite CoproductOfArrowsIn1, CoproductOfArrowsIn2).
+  + mkpair.
+    * intro x; apply (CoproductArrow _ _ (identity x) (identity x)).
+    * abstract (intros p q f; simpl;
+                now rewrite precompWithCoproductArrow, postcompWithCoproductArrow,
+                            id_right, id_left).
+- split; simpl; intro x.
+  + rewrite precompWithCoproductArrow, !id_right.
+    apply pathsinv0, Coproduct_endo_is_identity;
+      [ apply CoproductIn1Commutes | apply CoproductIn2Commutes ].
+  + unfold prodcatmor, compose; simpl.
+    now rewrite CoproductIn1Commutes, CoproductIn2Commutes.
+Defined.
+
+End bincoproduct_functor_adjunction.

--- a/UniMath/CategoryTheory/ProductPrecategory.v
+++ b/UniMath/CategoryTheory/ProductPrecategory.v
@@ -155,7 +155,6 @@ Defined.
 
 End nat_trans_fix_snd_arg.
 
-
 End one_product_precategory.
 
 (** Objects and morphisms in the product precategory of two precategories *)
@@ -164,10 +163,81 @@ Proof.
   exists X.
   exact Y.
 Defined.
+
 Local Notation "A ⊗ B" := (prodcatpair A B) (at level 10).
+
 Definition prodcatmor {C D : precategory} {X X' : C} {Z Z' : D} (α : X ⇒ X') (β : Z ⇒ Z')
   : X ⊗ Z ⇒ X' ⊗ Z'.
 Proof.
   exists α.
   exact β.
 Defined.
+
+(* Define pairs of functors and functors from pr1 and pr2 *)
+Section functors.
+
+Definition pair_functor_data {A B C D : precategory}
+  (F : functor A C) (G : functor B D) :
+  functor_data (product_precategory A B) (product_precategory C D).
+Proof.
+mkpair.
+- intro x; apply (prodcatpair (F (pr1 x)) (G (pr2 x))).
+- intros x y f; simpl; apply (prodcatmor (# F (pr1 f)) (# G (pr2 f))).
+Defined.
+
+Definition pair_functor {A B C D : precategory}
+  (F : functor A C) (G : functor B D) :
+  functor (product_precategory A B) (product_precategory C D).
+Proof.
+apply (tpair _ (pair_functor_data F G)).
+abstract (split;
+  [ intro x; simpl; rewrite !functor_id; apply idpath
+  | intros x y z f g; simpl; rewrite !functor_comp; apply idpath]).
+Defined.
+
+Definition pr1_functor_data (A B : precategory) :
+  functor_data (product_precategory A B) A.
+Proof.
+mkpair.
+- intro x; apply (pr1 x).
+- intros x y f; simpl; apply (pr1 f).
+Defined.
+
+Definition pr1_functor (A B : precategory) :
+  functor (product_precategory A B) A.
+Proof.
+apply (tpair _ (pr1_functor_data A B)).
+abstract (split; [ intro x; apply idpath | intros x y z f g; apply idpath ]).
+Defined.
+
+Definition pr2_functor_data (A B : precategory) :
+  functor_data (product_precategory A B) B.
+Proof.
+mkpair.
+- intro x; apply (pr2 x).
+- intros x y f; simpl; apply (pr2 f).
+Defined.
+
+Definition pr2_functor (A B : precategory) :
+  functor (product_precategory A B) B.
+Proof.
+apply (tpair _ (pr2_functor_data A B)).
+abstract (split; [ intro x; apply idpath | intros x y z f g; apply idpath ]).
+Defined.
+
+Definition delta_functor_data (C : precategory) :
+  functor_data C (product_precategory C C).
+Proof.
+mkpair.
+- intro x; apply (prodcatpair x x).
+- intros x y f; simpl; apply (prodcatmor f f).
+Defined.
+
+Definition delta_functor (C : precategory) :
+  functor C (product_precategory C C).
+Proof.
+apply (tpair _ (delta_functor_data C)).
+abstract (split; [ intro x; apply idpath | intros x y z f g; apply idpath ]).
+Defined.
+
+End functors.

--- a/UniMath/CategoryTheory/colimits/chains.v
+++ b/UniMath/CategoryTheory/colimits/chains.v
@@ -34,7 +34,7 @@ Section move_upstream.
 
 Fixpoint iter_functor {C : precategory} (F : functor C C) (n : nat) : functor C C := match n with
   | O => functor_identity C
-  | S n' => functor_composite _ _ _ (iter_functor F n') F
+  | S n' => functor_composite (iter_functor F n') F
   end.
 
 (* TODO : state this for any object and morphism, that is,

--- a/UniMath/CategoryTheory/colimits/colimits.v
+++ b/UniMath/CategoryTheory/colimits/colimits.v
@@ -22,6 +22,8 @@ Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.equivalences.
+Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
 
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
@@ -510,74 +512,36 @@ Definition is_cocont := forall {g : graph} (d : diagram g C) (L : C)
 
 End preserves_colimit.
 
-Require Import UniMath.CategoryTheory.equivalences.
-Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
-
 Lemma left_adjoint_cocont {C D : precategory} (F : functor C D)
   (H : is_left_adjoint F) (hsC : has_homsets C) (hsD : has_homsets D) : is_cocont F.
 Proof.
 intros g d L ccL HccL M ccM.
-set (phi := @φ_adj _ _ _ H).
-set (phi_inv := @φ_adj_inv _ _ _ H).
 set (G := pr1 H).
 apply (@iscontrweqb _ (Σ y : C ⟦ L, G M ⟧,
-    ∀ i, coconeIn ccL i ;; y = phi _ _ (coconeIn ccM i))).
+    ∀ i, coconeIn ccL i ;; y = φ_adj _ _ _ H (coconeIn ccM i))).
 - eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧,
-    ∀ i, # F (coconeIn ccL i) ;; phi_inv _ _ y = coconeIn ccM i)).
-+
-apply (weqbandf (adjunction_hom_weq _ _ _ H L M)).
-simpl.
-unfold phi_inv.
-intros x.
-apply weqiff; try (apply impred; intro; apply hsD).
-now rewrite φ_adj_inv_after_φ_adj.
-+
-eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧,
-    ∀ i, φ_adj_inv _ _ _ _ (coconeIn ccL i ;; y) = coconeIn ccM i)).
-*
-apply (weqbandf (idweq _)); simpl; intro f.
-apply weqimplimpl; try (apply impred; intro; apply hsD).
-{
-intros h i.
-eapply pathscomp0.
-apply (φ_adj_inv_natural_precomp _ _ _ H L M f _ (coconeIn ccL i)).
-apply (h i).
-}
-{
-intros h i.
-eapply pathscomp0.
-eapply pathsinv0.
-apply (φ_adj_inv_natural_precomp _ _ _ H L M f _ (coconeIn ccL i)).
-apply (h i).
-}
-*
-apply (weqbandf (idweq _)); simpl; intro f.
-apply weqimplimpl.
-{
-intros h i.
-rewrite <- (h i).
-now rewrite (φ_adj_after_φ_adj_inv _ _ _ H).
-}
-{
-intros h i.
-rewrite (h i).
-now rewrite (φ_adj_inv_after_φ_adj _ _ _ H).
-}
-{apply impred; intro; apply hsD. }
-{apply impred; intro; apply hsC. }
-
--
-unfold phi; simpl.
-unfold isColimCocone in HccL.
-simple refine (let X : cocone d (G M) := _ in _).
-{ simple refine (mk_cocone _ _).
-+ intro v.
-apply (φ_adj C D F H (coconeIn ccM v)).
-+ intros m n e; simpl.
-rewrite <- (coconeInCommutes ccM m n e); simpl.
-now rewrite φ_adj_natural_precomp.
-}
-apply (HccL (G M) X).
+    ∀ i, # F (coconeIn ccL i) ;; φ_adj_inv _ _ _ H y = coconeIn ccM i)).
+  + apply (weqbandf (adjunction_hom_weq _ _ _ H L M)); simpl; intro f.
+    apply weqiff; try (apply impred; intro; apply hsD).
+    now rewrite φ_adj_inv_after_φ_adj.
+  + eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧,
+      ∀ i, φ_adj_inv _ _ _ _ (coconeIn ccL i ;; y) = coconeIn ccM i)).
+    * apply weqfibtototal; simpl; intro f.
+      apply weqonsecfibers; intro i.
+      rewrite φ_adj_inv_natural_precomp; apply idweq.
+    * apply weqfibtototal; simpl; intro f.
+      apply weqonsecfibers; intro i.
+      apply weqimplimpl; [ | | apply hsD | apply hsC]; intro h.
+        now rewrite <- h, (φ_adj_after_φ_adj_inv _ _ _ H).
+      now rewrite h, (φ_adj_inv_after_φ_adj _ _ _ H).
+- simple refine (let X : cocone d (G M) := _ in _).
+  { simple refine (mk_cocone _ _).
+    + intro v; apply (φ_adj C D F H (coconeIn ccM v)).
+    + abstract (intros m n e; simpl;
+                rewrite <- (coconeInCommutes ccM m n e); simpl;
+                now rewrite φ_adj_natural_precomp).
+  }
+  apply (HccL (G M) X).
 Defined.
 
 Section preserves_colimit_examples.

--- a/UniMath/CategoryTheory/colimits/colimits.v
+++ b/UniMath/CategoryTheory/colimits/colimits.v
@@ -505,6 +505,15 @@ Definition preserves_colimit {g : graph} (d : diagram g C) (L : C)
   (cc : cocone d L) : UU :=
   isColimCocone d L cc -> isColimCocone (mapdiagram d) (F L) (mapcocone d cc).
 
+Definition is_cocont := forall {g : graph} (d : diagram g C) (L : C)
+  (cc : cocone d L), preserves_colimit d L cc.
+
+Require Import UniMath.CategoryTheory.equivalences.
+Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
+
+Lemma left_adjoint_cocont (H : is_left_adjoint F) : is_cocont.
+Admitted.
+
 End preserves_colimit.
 
 Section preserves_colimit_examples.
@@ -526,6 +535,11 @@ simple refine (tpair _ _ _).
 - simpl; intro t; apply subtypeEquality.
   + simpl; intro v; apply impred; intro; apply hsC.
   + apply (colimArrowUnique CC); intro n; apply (pr2 t).
+Defined.
+
+Lemma is_cocont_identity : is_cocont Fid.
+Proof.
+intros g d L cc; apply preserves_colimit_identity.
 Defined.
 
 Variable (x : D).
@@ -554,7 +568,7 @@ Lemma preserves_colimit_comp (F : functor C D) (G : functor D E)
   {g : graph} (d : diagram g C) (L : C) (cc : cocone d L)
   (H1 : preserves_colimit F d L cc)
   (H2 : preserves_colimit G (mapdiagram F d) (F L) (mapcocone F _ cc)) :
-  preserves_colimit (functor_composite _ _ _ F G) d L cc.
+  preserves_colimit (functor_composite F G) d L cc.
 Proof.
 intros HcL y ccy; simpl.
 set (CC := mk_ColimCocone _ _ _ (H2 (H1 HcL))).
@@ -565,6 +579,13 @@ simple refine (tpair _ _ _).
 - simpl; intro t; apply subtypeEquality.
   + intros f; apply impred; intro; apply hsE.
   + simpl; apply (colimArrowUnique CC), (pr2 t).
+Defined.
+
+Lemma is_cocont_comp (F : functor C D) (G : functor D E)
+  (HF : is_cocont F) (HG : is_cocont G) : is_cocont (functor_composite F G).
+Proof.
+intros g d L cc.
+apply preserves_colimit_comp; [ apply HF | apply HG ].
 Defined.
 
 End preserves_colimit_examples.

--- a/UniMath/CategoryTheory/colimits/colimits.v
+++ b/UniMath/CategoryTheory/colimits/colimits.v
@@ -508,13 +508,77 @@ Definition preserves_colimit {g : graph} (d : diagram g C) (L : C)
 Definition is_cocont := forall {g : graph} (d : diagram g C) (L : C)
   (cc : cocone d L), preserves_colimit d L cc.
 
+End preserves_colimit.
+
 Require Import UniMath.CategoryTheory.equivalences.
 Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
 
-Lemma left_adjoint_cocont (H : is_left_adjoint F) : is_cocont.
-Admitted.
+Lemma left_adjoint_cocont {C D : precategory} (F : functor C D)
+  (H : is_left_adjoint F) (hsC : has_homsets C) (hsD : has_homsets D) : is_cocont F.
+Proof.
+intros g d L ccL HccL M ccM.
+set (phi := @φ_adj _ _ _ H).
+set (phi_inv := @φ_adj_inv _ _ _ H).
+set (G := pr1 H).
+apply (@iscontrweqb _ (Σ y : C ⟦ L, G M ⟧,
+    ∀ i, coconeIn ccL i ;; y = phi _ _ (coconeIn ccM i))).
+- eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧,
+    ∀ i, # F (coconeIn ccL i) ;; phi_inv _ _ y = coconeIn ccM i)).
++
+apply (weqbandf (adjunction_hom_weq _ _ _ H L M)).
+simpl.
+unfold phi_inv.
+intros x.
+apply weqiff; try (apply impred; intro; apply hsD).
+now rewrite φ_adj_inv_after_φ_adj.
++
+eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧,
+    ∀ i, φ_adj_inv _ _ _ _ (coconeIn ccL i ;; y) = coconeIn ccM i)).
+*
+apply (weqbandf (idweq _)); simpl; intro f.
+apply weqimplimpl; try (apply impred; intro; apply hsD).
+{
+intros h i.
+eapply pathscomp0.
+apply (φ_adj_inv_natural_precomp _ _ _ H L M f _ (coconeIn ccL i)).
+apply (h i).
+}
+{
+intros h i.
+eapply pathscomp0.
+eapply pathsinv0.
+apply (φ_adj_inv_natural_precomp _ _ _ H L M f _ (coconeIn ccL i)).
+apply (h i).
+}
+*
+apply (weqbandf (idweq _)); simpl; intro f.
+apply weqimplimpl.
+{
+intros h i.
+rewrite <- (h i).
+now rewrite (φ_adj_after_φ_adj_inv _ _ _ H).
+}
+{
+intros h i.
+rewrite (h i).
+now rewrite (φ_adj_inv_after_φ_adj _ _ _ H).
+}
+{apply impred; intro; apply hsD. }
+{apply impred; intro; apply hsC. }
 
-End preserves_colimit.
+-
+unfold phi; simpl.
+unfold isColimCocone in HccL.
+simple refine (let X : cocone d (G M) := _ in _).
+{ simple refine (mk_cocone _ _).
++ intro v.
+apply (φ_adj C D F H (coconeIn ccM v)).
++ intros m n e; simpl.
+rewrite <- (coconeInCommutes ccM m n e); simpl.
+now rewrite φ_adj_natural_precomp.
+}
+apply (HccL (G M) X).
+Defined.
 
 Section preserves_colimit_examples.
 

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -174,6 +174,7 @@ intros c L ccL M.
 now apply isColimCocone_pr2_functor.
 Defined.
 
+(* TODO: Opacify more *)
 Lemma omega_cocont_pair_functor (HF : omega_cocont F) (HG : omega_cocont G) :
   omega_cocont (pair_functor F G).
 Proof.

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -223,7 +223,7 @@ End binprod_functor.
 (* The delta functor C -> C^2 mapping x to (x,x) is omega_cocont *)
 Section delta_functor.
 
-Variable C : precategory.
+Variables (C : precategory) (PC : Products C) (hsC : has_homsets C).
 
 Definition delta_functor_data : functor_data C (product_precategory C C).
 Proof.
@@ -241,10 +241,9 @@ mkpair.
   + intros x y z f g; apply idpath.
 Defined.
 
-(* Todo: show that delta_functor is left adjoint to product and the use general fact *)
-Lemma cocont_delta_functor (PC : Products C) : is_cocont delta_functor.
+Lemma is_left_adjoint_delta_functor : is_left_adjoint delta_functor.
 Proof.
-apply left_adjoint_cocont, (tpair _ (binproduct_functor _ PC)).
+apply (tpair _ (binproduct_functor _ PC)).
 mkpair.
 - split.
   + mkpair.
@@ -263,10 +262,16 @@ mkpair.
     apply pathsinv0, Product_endo_is_identity; [ apply ProductPr1Commutes | apply ProductPr2Commutes ].
 Defined.
 
-Lemma omega_cocont_delta_functor (PC : Products C) : omega_cocont delta_functor.
+Lemma cocont_delta_functor : is_cocont delta_functor.
+Proof.
+apply (left_adjoint_cocont _ is_left_adjoint_delta_functor hsC).
+apply (has_homsets_product_precategory _ _ hsC hsC).
+Defined.
+
+Lemma omega_cocont_delta_functor : omega_cocont delta_functor.
 Proof.
 intros c L ccL.
-apply (cocont_delta_functor PC).
+apply cocont_delta_functor.
 Defined.
 
 End delta_functor.
@@ -274,8 +279,7 @@ End delta_functor.
 (* The functor "+ : C^2 -> C" is cocont *)
 Section bincoprod_functor.
 
-Variable C : precategory.
-Variables (PC : Coproducts C).
+Variables (C : precategory) (PC : Coproducts C) (hsC : has_homsets C).
 
 Definition bincoproduct_functor_data : functor_data (product_precategory C C) C.
 Proof.
@@ -298,10 +302,9 @@ mkpair.
   + now intros x y z f g; simpl; rewrite CoproductOfArrows_comp.
 Defined.
 
-(* TODO: opacify *)
-Lemma cocont_bincoproducts_functor : is_cocont bincoproduct_functor.
+Lemma is_left_adjoint_bincoproduct_functor : is_left_adjoint bincoproduct_functor.
 Proof.
-apply left_adjoint_cocont, (tpair _ (delta_functor _)).
+apply (tpair _ (delta_functor _)).
 mkpair.
 - split.
   + mkpair.
@@ -320,6 +323,13 @@ mkpair.
       [ apply CoproductIn1Commutes | apply CoproductIn2Commutes ].
   + unfold prodcatmor, compose; simpl.
     now rewrite CoproductIn1Commutes, CoproductIn2Commutes.
+Defined.
+
+Lemma cocont_bincoproducts_functor : is_cocont bincoproduct_functor.
+Proof.
+apply (left_adjoint_cocont _ is_left_adjoint_bincoproduct_functor).
+- apply has_homsets_product_precategory; apply hsC.
+- apply hsC.
 Defined.
 
 Lemma omega_cocont_bincoproduct_functor: omega_cocont bincoproduct_functor.
@@ -811,9 +821,11 @@ Lemma omega_cocont_sum_of_functors (F G : functor C D)
 Proof.
 apply (omega_cocont_functor_composite _ _ _ hsD).
   apply (omega_cocont_delta_functor _ PC).
+  apply hsC.
 apply (omega_cocont_functor_composite _ _ _ hsD).
   apply (omega_cocont_pair_functor _ _ _ _ _ _ hsC hsC hsD hsD HF HG).
 apply omega_cocont_bincoproduct_functor.
+apply hsD.
 Defined.
 
 End temp.
@@ -874,6 +886,7 @@ apply omega_cocont_sum_of_functors.
   apply functor_category_has_homsets.
   apply omega_cocont_delta_functor.
   apply (Products_functor_precat _ _ ProductsHSET).
+  apply functor_category_has_homsets.
   apply omega_cocont_binproduct_functor.
 apply omega_cocont_pre_composition_functor.
 Defined.

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -780,6 +780,17 @@ rewrite foldr_cons. cbn.
 apply idpath.
 Abort.
 
+(* some experiments: *)
+
+(* Definition const {A B : UU} : A -> B -> A := fun x _ => x. *)
+
+(* Eval compute in const 0 (nil natHSET). *)
+
+(* Axiom const' : forall {A B : UU}, A -> B -> A. *)
+
+(* Eval compute in const' 0 1. *)
+(* Eval compute in const' 0 (nil natHSET). *)
+
 (* Time Eval vm_compute in nil natHSET.  (* This crashes my computer by using up all memory *) *)
 
 End nat_examples.

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -33,7 +33,7 @@ Section constant_functor.
 
 Variable (x : D).
 
-Lemma omega_cocontConstantFunctor : omega_cocont (constant_functor C D x).
+Lemma omega_cocont_constant_functor : omega_cocont (constant_functor C D x).
 Proof.
 intros c L ccL HcL y ccy; simpl.
 simple refine (tpair _ _ _).
@@ -53,7 +53,7 @@ End constant_functor.
 (* The identity functor is omega cocontinuous *)
 Section identity_functor.
 
-Lemma omega_cocontFunctorIdentity : omega_cocont (functor_identity C).
+Lemma omega_cocont_functor_identity : omega_cocont (functor_identity C).
 Proof.
 intros c L ccL HcL.
 apply (preserves_colimit_identity hsC _ _ _ HcL).
@@ -64,7 +64,7 @@ End identity_functor.
 (* Functor composition preserves omega cocontinuity *)
 Section functor_comp.
 
-Lemma omega_cocontFunctorComposite (F : functor C D) (G : functor D E) :
+Lemma omega_cocont_functor_composite (F : functor C D) (G : functor D E) :
   omega_cocont F -> omega_cocont G -> omega_cocont (functor_composite F G).
 Proof.
 intros hF hG c L cc.
@@ -183,10 +183,26 @@ End constcoprod_functor.
 
 End polynomial_functors.
 
+Require Import UniMath.CategoryTheory.ProductPrecategory.
+Require Import UniMath.CategoryTheory.equivalences.
+Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
+
+(* The functor "* : C^2 -> C" is omega cocont *)
+Section binprod_functor.
+
+Variable C : precategory.
+Variables (PC : Products C).
+
+Definition binproduct_functor : functor (product_precategory C C) C.
+Admitted.
+
+Lemma omega_cocont_binproduct_functor : omega_cocont binproduct_functor.
+Admitted.
+
+End binprod_functor.
+
 (* The delta functor C -> C^2 mapping x to (x,x) is omega_cocont *)
 Section delta_functor.
-
-Require Import UniMath.CategoryTheory.ProductPrecategory.
 
 Variable C : precategory.
 
@@ -207,38 +223,21 @@ mkpair.
 Defined.
 
 (* Todo: show that delta_functor is left adjoint to product and the use general fact *)
-Lemma cocont_delta_functor : is_cocont delta_functor.
+Lemma cocont_delta_functor (PC : Products C) : is_cocont delta_functor.
+Proof.
+apply left_adjoint_cocont.
+mkpair.
+- apply (binproduct_functor _ PC).
+- admit.
 Admitted.
+
+Lemma omega_cocont_delta_functor (PC : Products C) : omega_cocont delta_functor.
+Proof.
+intros c L ccL.
+apply (cocont_delta_functor PC).
+Defined.
 
 End delta_functor.
-
-(* A pair of functors (F,G) : C^2 -> D^2 is omega_cocont if F and G are *)
-Section pair_functor.
-
-Variables C D : precategory.
-Variables F G : functor C D.
-
-Definition pair_functor_data : functor_data (product_precategory C C) (product_precategory D D).
-Proof.
-mkpair.
-- intro x; apply (prodcatpair (F (pr1 x)) (G (pr2 x))).
-- intros x y f; simpl; apply (prodcatmor (# F (pr1 f)) (# G (pr2 f))).
-Defined.
-
-Definition pair_functor : functor (product_precategory C C) (product_precategory D D).
-Proof.
-mkpair.
-- exact pair_functor_data.
-- split.
-  + intro x; simpl; rewrite !functor_id; apply idpath.
-  + intros x y z f g; simpl; rewrite !functor_comp; apply idpath.
-Defined.
-
-Lemma cocont_pair_functor (HF : is_cocont F) (HG : is_cocont G) :
-  is_cocont pair_functor.
-Admitted.
-
-End pair_functor.
 
 (* The functor "+ : C^2 -> C" is cocont *)
 Section bincoprod_functor.
@@ -249,30 +248,64 @@ Variables (PC : Coproducts C).
 Definition bincoproduct_functor : functor (product_precategory C C) C.
 Admitted.
 
-End bincoprod_functor.
-
-(* The functor "* : C^2 -> C" is cocont *)
-Section binprod_functor.
-
-Variable C : precategory.
-Variables (PC : Products C).
-
-Definition binproduct_functor : functor (product_precategory C C) C.
+Lemma cocont_bincoproducts_functor: is_cocont bincoproduct_functor.
+Proof.
+apply left_adjoint_cocont.
+mkpair.
+- apply delta_functor.
+- admit.
 Admitted.
 
-End binprod_functor.
+Lemma omega_cocont_bincoproduct_functor: omega_cocont bincoproduct_functor.
+Proof.
+intros c L ccL; apply cocont_bincoproducts_functor.
+Defined.
+
+End bincoprod_functor.
+
+(* A pair of functors (F,G) : A * B -> C * D is omega_cocont if F and G are *)
+Section pair_functor.
+
+Variables A B C D : precategory.
+Variables (F : functor A C) (G : functor B D).
+
+Definition pair_functor_data : functor_data (product_precategory A B) (product_precategory C D).
+Proof.
+mkpair.
+- intro x; apply (prodcatpair (F (pr1 x)) (G (pr2 x))).
+- intros x y f; simpl; apply (prodcatmor (# F (pr1 f)) (# G (pr2 f))).
+Defined.
+
+Definition pair_functor : functor (product_precategory A B) (product_precategory C D).
+Proof.
+mkpair.
+- exact pair_functor_data.
+- split.
+  + intro x; simpl; rewrite !functor_id; apply idpath.
+  + intros x y z f g; simpl; rewrite !functor_comp; apply idpath.
+Defined.
+
+(* Lemma cocont_pair_functor (HF : is_cocont F) (HG : is_cocont G) : *)
+(*   is_cocont pair_functor. *)
+(* Admitted. *)
+
+Lemma omega_cocont_pair_functor (HF : omega_cocont F) (HG : omega_cocont G) :
+  omega_cocont pair_functor.
+Admitted.
+
+End pair_functor.
 
 (* Should go to ProductPrecategory.v *)
 (* The functor "F * G : A * B -> C * D" is cocont *)
-Section product_of_functors.
+(* Section product_of_functors. *)
 
-Variable A B C D : precategory.
-Variables (F : functor A C) (G : functor B D).
+(* Variable A B C D : precategory. *)
+(* Variables (F : functor A C) (G : functor B D). *)
 
-Definition product_of_functors : functor (product_precategory A B) (product_precategory C D).
-Admitted.
+(* Definition product_of_functors : functor (product_precategory A B) (product_precategory C D). *)
+(* Admitted. *)
 
-End product_of_functors.
+(* End product_of_functors. *)
 
 Section rightkanextension.
 
@@ -285,13 +318,18 @@ Variables (K : functor C D).
 (* Lemma foo : has_limits D -> GlobalRightKanExtensionExists K. *)
 
 (* has_limits D *)
-Lemma bar (hsD : has_homsets D) (hsE : has_homsets E) : is_cocont (pre_composition_functor _ _ E hsD hsE K).
+Lemma cocont_pre_composition_functor (hsD : has_homsets D) (hsE : has_homsets E) :
+  is_cocont (pre_composition_functor _ _ E hsD hsE K).
 Admitted. (* will be a simple consequence of foo *)
 
+Lemma omega_cocont_pre_composition_functor (hsD : has_homsets D) (hsE : has_homsets E) :
+  omega_cocont (pre_composition_functor _ _ E hsD hsE K).
+Proof.
+intros c L ccL.
+apply cocont_pre_composition_functor.
+Defined.
+
 End rightkanextension.
-
-(* whiskering.v, pre_composition_functor *)
-
 
 (* Lists as the colimit of a chain given by the list functor: F(X) = 1 + A * X *)
 Section lists.
@@ -307,7 +345,7 @@ Definition listFunctor : functor HSET HSET :=
 
 Lemma omega_cocont_listFunctor : omega_cocont listFunctor.
 Proof.
-apply (omega_cocontFunctorComposite _ _ _ has_homsets_HSET).
+apply (omega_cocont_functor_composite _ _ _ has_homsets_HSET).
 - apply omega_cocontConstProdFunctor.
 - apply (omega_cocontConstCoprodFunctor _ has_homsets_HSET).
 Defined.
@@ -524,7 +562,6 @@ Abort.
 
 End nat_examples.
 
-
 (* Inductive list A : UU := *)
 (*   | nilA : list A *)
 (*   | consA : A -> list A -> list A. *)
@@ -542,33 +579,56 @@ End nat_examples.
 Section lambdacalculus.
 
 Section temp.
-Variables (C D : precategory) (HD : Coproducts D).
+Variables (C D : precategory) (PC : Products C) (HD : Coproducts D).
 
 Definition sum_of_functors (F G : functor C D) : functor C D.
 eapply functor_composite.
   eapply delta_functor.
 eapply functor_composite.
-  eapply product_of_functors.
+  eapply pair_functor.
+  (* eapply product_of_functors. *)
     apply F.
     apply G.
 apply bincoproduct_functor.
 apply HD.
 Defined.
+
+Lemma omega_cocont_sum_of_functors (F G : functor C D) (hsD : has_homsets D)
+  (HF : omega_cocont F) (HG : omega_cocont G) : omega_cocont (sum_of_functors F G).
+Proof.
+apply (omega_cocont_functor_composite _ _ _ hsD).
+  apply (omega_cocont_delta_functor _ PC).
+apply (omega_cocont_functor_composite _ _ _ hsD).
+  apply (omega_cocont_pair_functor _ _ _ _ _ _ HF HG).
+apply omega_cocont_bincoproduct_functor.
+Defined.
+
 End temp.
 
-(* TODO: Define the parts individually and then take the sum_of_functors *)
-Definition Lambda : functor [HSET,HSET,has_homsets_HSET] [HSET,HSET,has_homsets_HSET].
+Definition option_functor : [HSET,HSET,has_homsets_HSET].
+Proof.
+apply coproduct_functor.
+apply CoproductsHSET.
+apply (constant_functor _ _ unitHSET).
+apply functor_identity.
+Defined.
+
+(* TODO: define sum of omega cocont functors *)
+Definition LambdaFunctor : functor [HSET,HSET,has_homsets_HSET] [HSET,HSET,has_homsets_HSET].
 Proof.
 eapply sum_of_functors.
-  admit.
+  apply (Coproducts_functor_precat _ _ CoproductsHSET).
   apply (constant_functor [HSET, HSET, has_homsets_HSET] [HSET, HSET, has_homsets_HSET] (functor_identity HSET)).
 eapply sum_of_functors.
-  admit.
+  apply (Coproducts_functor_precat _ _ CoproductsHSET).
   (* app *)
-  admit.
+  eapply functor_composite.
+    apply delta_functor.
+    apply binproduct_functor.
+    apply (Products_functor_precat _ _ ProductsHSET).
 (* lam *)
-admit.
-Admitted.
+apply (pre_composition_functor _ _ _ _ _ option_functor).
+Defined.
 
 (* Bad approach *)
 (* Definition Lambda : functor [HSET,HSET,has_homsets_HSET] [HSET,HSET,has_homsets_HSET]. *)
@@ -584,5 +644,23 @@ Admitted.
 (*     apply (constant_functor [HSET, HSET, has_homsets_HSET] [HSET, HSET, has_homsets_HSET] (functor_identity HSET)). *)
 (*     eapply product_of_functors. *)
 (*       apply delta_functor. *)
+
+Lemma omega_cocont_LambdaFunctor : omega_cocont LambdaFunctor.
+Proof.
+apply omega_cocont_sum_of_functors.
+  apply (Products_functor_precat _ _ ProductsHSET).
+  apply functor_category_has_homsets.
+  apply omega_cocont_constant_functor.
+  apply functor_category_has_homsets.
+apply omega_cocont_sum_of_functors.
+  apply (Products_functor_precat _ _ ProductsHSET).
+  apply functor_category_has_homsets.
+  apply omega_cocont_functor_composite.
+  apply functor_category_has_homsets.
+  apply omega_cocont_delta_functor.
+  apply (Products_functor_precat _ _ ProductsHSET).
+  apply omega_cocont_binproduct_functor.
+apply omega_cocont_pre_composition_functor.
+Defined.
 
 End lambdacalculus.

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -389,6 +389,7 @@ Defined.
 (*   is_cocont pair_functor. *)
 (* Admitted. *)
 
+(* Maybe generalize these to arbitrary diagrams *)
 Lemma cocone_pr1_functor (cAB : chain (product_precategory A B))
   (ab : A × B) (ccab : cocone cAB ab) :
   cocone (mapchain pr1_functor cAB) (pr1 ab).
@@ -418,7 +419,6 @@ mkpair.
 - apply (tpair _ x1).
   abstract (intro n; apply (maponpaths pr1 (p1 n))).
 - intro t.
-
   simple refine (let X : Σ x0,
            ∀ v : nat, coconeIn ccab v ;; x0 =
                       prodcatmor (pr1 ccx v) (pr2 (pr1 ccab v)) := _ in _).
@@ -481,12 +481,12 @@ intros cAB ml ccml Hccml xy ccxy; simpl in *.
 simple refine (let cFAX : cocone (mapdiagram F (mapchain pr1_functor cAB)) (pr1 xy) := _ in _).
 { simple refine (mk_cocone _ _).
   - intro n; apply (pr1 (pr1 ccxy n)).
-  - abstract (intros m n e; apply (maponpaths pr1 ((pr2 ccxy) m n e))).
+  - abstract (intros m n e; apply (maponpaths pr1 (pr2 ccxy m n e))).
 }
 simple refine (let cGBY : cocone (mapdiagram G (mapchain pr2_functor cAB)) (pr2 xy) := _ in _).
 { simple refine (mk_cocone _ _).
   - intro n; apply (pr2 (pr1 ccxy n)).
-  - abstract (intros m n e; apply (maponpaths dirprod_pr2 ((pr2 ccxy) m n e))).
+  - abstract (intros m n e; apply (maponpaths dirprod_pr2 (pr2 ccxy m n e))).
 }
 destruct (HF _ _ _ (isColimCocone_pr1_functor cAB ml ccml Hccml) _ cFAX) as [[f hf1] hf2].
 destruct (HG _ _ _ (isColimCocone_pr2_functor cAB ml ccml Hccml) _ cGBY) as [[g hg1] hg2].

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -334,7 +334,8 @@ Section pair_functor.
 
 Variables A B C D : precategory.
 Variables (F : functor A C) (G : functor B D).
-Variables (hsA : has_homsets A).
+Variables (hsA : has_homsets A) (hsB : has_homsets B).
+Variables (hsC : has_homsets C) (hsD : has_homsets D).
 
 Definition pair_functor_data : functor_data (product_precategory A B) (product_precategory C D).
 Proof.
@@ -417,6 +418,7 @@ mkpair.
 - apply (tpair _ x1).
   abstract (intro n; apply (maponpaths pr1 (p1 n))).
 - intro t.
+
   simple refine (let X : Σ x0,
            ∀ v : nat, coconeIn ccab v ;; x0 =
                       prodcatmor (pr1 ccx v) (pr2 (pr1 ccab v)) := _ in _).
@@ -429,7 +431,6 @@ mkpair.
             [ intro f; apply impred; intro; apply hsA
             | apply (maponpaths (fun x => pr1 (pr1 x)) (p2 X))]).
 Defined.
-
 
 Lemma cocone_pr2_functor (cAB : chain (product_precategory A B))
   (ab : A × B) (ccab : cocone cAB ab) :
@@ -448,67 +449,61 @@ Proof.
 intros x ccx.
 simple refine (let HHH : cocone cAB (pr1 ab,, x) := _ in _).
 { simple refine (mk_cocone _ _).
-  - simpl; intro n; split.
-apply (# pr1_functor (pr1 ccab n)).
-
-apply (pr1 ccx n).
-  -
-    simpl; intros m n e; rewrite (paireta (dmor cAB e));
-    apply pathsdirprod.
-simpl.
-admit.
-(* apply (maponpaths dirprod_pr2 ((pr2 ccab) m n e)). *)
-apply (pr2 ccx m n e).
+  - simpl; intro n; split;
+      [ apply (# pr1_functor (pr1 ccab n)) | apply (pr1 ccx n) ].
+  - abstract(
+    simpl; intros m n e; rewrite (paireta (dmor cAB e)); apply pathsdirprod;
+      [ apply (maponpaths pr1 (pr2 ccab m n e)) | apply (pr2 ccx m n e) ]).
  }
 destruct (Hccab _ HHH) as [[[x1 x2] p1] p2]; simpl in *.
 mkpair.
 - apply (tpair _ x2).
-  intro n; apply (maponpaths dirprod_pr2 (p1 n)).
+  abstract (intro n; apply (maponpaths dirprod_pr2 (p1 n))).
 - intro t.
-admit.
-(*   simple refine (let X : Σ x0, *)
-(*            ∀ v : nat, coconeIn ccab v ;; x0 = *)
-(*                       prodcatmor (pr1 ccx v) (pr2 (pr1 ccab v)) := _ in _). *)
-(*   { mkpair. *)
-(*     - split; [ apply (pr1 t) | apply (identity _) ]. *)
-(*     - abstract (intro n; rewrite id_right; apply pathsdirprod; *)
-(*                  [ apply (pr2 t) | apply idpath ]). *)
-(*   } *)
-(*   abstract (apply subtypeEquality; simpl; *)
-(*             [ intro f; apply impred; intro; apply hsA *)
-(*             | apply (maponpaths (fun x => pr1 (pr1 x)) (p2 X))]). *)
-(* Defined. *)
-Admitted.
-
+  simple refine (let X : Σ x0,
+           ∀ v : nat, coconeIn ccab v ;; x0 =
+                      prodcatmor (pr1 (pr1 ccab v)) (pr1 ccx v) := _ in _).
+  { mkpair.
+    - split; [ apply (identity _) | apply (pr1 t) ].
+    - abstract (intro n; rewrite id_right; apply pathsdirprod;
+                 [ apply idpath | apply (pr2 t) ]).
+  }
+  abstract (apply subtypeEquality; simpl;
+              [ intro f; apply impred; intro; apply hsB
+              | apply (maponpaths (fun x => dirprod_pr2 (pr1 x)) (p2 X)) ]).
+Defined.
 
 Lemma omega_cocont_pair_functor (HF : omega_cocont F) (HG : omega_cocont G) :
   omega_cocont pair_functor.
 Proof.
-intros cAB ml ccml Hccml xy ccxy.
-(* destruct ml as [m l]. *)
-(* simpl in *. *)
-(* destruct xy as [x y]. *)
+intros cAB ml ccml Hccml xy ccxy; simpl in *.
+(* set (CC := ((ml,, ccml),, Hccml) : ColimCocone cAB). *)
+simple refine (let cFAX : cocone (mapdiagram F (mapchain pr1_functor cAB)) (pr1 xy) := _ in _).
+{ simple refine (mk_cocone _ _).
+  - intro n; apply (pr1 (pr1 ccxy n)).
+  - abstract (intros m n e; apply (maponpaths pr1 ((pr2 ccxy) m n e))).
+}
+simple refine (let cGBY : cocone (mapdiagram G (mapchain pr2_functor cAB)) (pr2 xy) := _ in _).
+{ simple refine (mk_cocone _ _).
+  - intro n; apply (pr2 (pr1 ccxy n)).
+  - abstract (intros m n e; apply (maponpaths dirprod_pr2 ((pr2 ccxy) m n e))).
+}
+destruct (HF _ _ _ (isColimCocone_pr1_functor cAB ml ccml Hccml) _ cFAX) as [[f hf1] hf2].
+destruct (HG _ _ _ (isColimCocone_pr2_functor cAB ml ccml Hccml) _ cGBY) as [[g hg1] hg2].
 simpl in *.
-
-simple refine (let X : ColimCocone cAB := _ in _).
 mkpair.
-apply (tpair _ _ ccml).
-simpl.
-apply Hccml.
-
-simple refine (let YY : cocone (mapdiagram F (mapchain pr1_functor cAB)) (pr1 xy) := _ in _).
-simple refine (mk_cocone _ _); simpl.
-intro n.
-apply (pr1 (pr1 ccxy n)).
-intros m n e.
-apply (maponpaths pr1 ((pr2 ccxy) m n e)).
-destruct (HF _ _ _ (isColimCocone_pr1_functor cAB ml ccml Hccml) (pr1 xy) YY).
-mkpair.
-mkpair.
-admit.
-admit.
-admit.
-Admitted.
+- apply (tpair _ (f,,g)).
+  abstract (intro n; unfold prodcatmor, compose; simpl;
+            now rewrite hf1, hg1, (paireta (coconeIn ccxy n))).
+- intro t.
+  apply subtypeEquality; simpl.
+  + intro x; apply impred; intro.
+    apply isaset_dirprod; [ apply hsC | apply hsD ].
+  + destruct t as [[f1 f2] ?]; simpl in *.
+    apply pathsdirprod.
+    * apply (maponpaths pr1 (hf2 (f1,, (λ n, maponpaths pr1 (p n))))).
+    * apply (maponpaths pr1 (hg2 (f2,, (λ n, maponpaths dirprod_pr2 (p n))))).
+Defined.
 
 End pair_functor.
 
@@ -797,7 +792,7 @@ Section lambdacalculus.
 
 Section temp.
 Variables (C D : precategory) (PC : Products C) (HD : Coproducts D).
-Variables (hsC : has_homsets C).
+Variables (hsC : has_homsets C) (hsD : has_homsets D).
 
 Definition sum_of_functors (F G : functor C D) : functor C D.
 eapply functor_composite.
@@ -811,13 +806,13 @@ apply bincoproduct_functor.
 apply HD.
 Defined.
 
-Lemma omega_cocont_sum_of_functors (F G : functor C D) (hsD : has_homsets D)
+Lemma omega_cocont_sum_of_functors (F G : functor C D)
   (HF : omega_cocont F) (HG : omega_cocont G) : omega_cocont (sum_of_functors F G).
 Proof.
 apply (omega_cocont_functor_composite _ _ _ hsD).
   apply (omega_cocont_delta_functor _ PC).
 apply (omega_cocont_functor_composite _ _ _ hsD).
-  apply (omega_cocont_pair_functor _ _ _ _ _ _ hsC HF HG).
+  apply (omega_cocont_pair_functor _ _ _ _ _ _ hsC hsC hsD hsD HF HG).
 apply omega_cocont_bincoproduct_functor.
 Defined.
 

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -351,12 +351,112 @@ mkpair.
   + intros x y z f g; simpl; rewrite !functor_comp; apply idpath.
 Defined.
 
+Definition pr1_functor_data : functor_data (product_precategory A B) A.
+Proof.
+mkpair.
+- intro x; apply (pr1 x).
+- intros x y f; simpl; apply (pr1 f).
+Defined.
+
+Definition pr1_functor : functor (product_precategory A B) A.
+Proof.
+mkpair.
+- exact pr1_functor_data.
+- split.
+  + intro x; apply idpath.
+  + intros x y z f g; apply idpath.
+Defined.
+
+Definition pr2_functor_data : functor_data (product_precategory A B) B.
+Proof.
+mkpair.
+- intro x; apply (pr2 x).
+- intros x y f; simpl; apply (pr2 f).
+Defined.
+
+Definition pr2_functor : functor (product_precategory A B) B.
+Proof.
+mkpair.
+- exact pr2_functor_data.
+- split.
+  + intro x; apply idpath.
+  + intros x y z f g; apply idpath.
+Defined.
+
 (* Lemma cocont_pair_functor (HF : is_cocont F) (HG : is_cocont G) : *)
 (*   is_cocont pair_functor. *)
 (* Admitted. *)
 
 Lemma omega_cocont_pair_functor (HF : omega_cocont F) (HG : omega_cocont G) :
   omega_cocont pair_functor.
+Proof.
+intros cAB ml ccml Hccml xy ccxy.
+(* destruct ml as [m l]. *)
+(* simpl in *. *)
+(* destruct xy as [x y]. *)
+simpl in *.
+simple refine (let X : ColimCocone cAB := _ in _).
+mkpair.
+apply (tpair _ _ ccml).
+simpl.
+apply Hccml.
+Check (colimArrow X ).
+
+simple refine (let ccA : cocone (mapchain pr1_functor cAB) (pr1 ml) := _ in _).
+  {
+  simple refine (mk_cocone _ _).
+  - simpl; intro n.
+    apply (pr1 (coconeIn ccml n)).
+  - abstract (simpl; intros m n e; now rewrite <- (coconeInCommutes ccml m n e)). }
+assert (H1 : isColimCocone _ _ ccA).
+  {
+intros a cca.
+unfold isColimCocone in Hccml.
+simpl in *.
+simple refine (let HHH : cocone cAB (a,, pr2 ml) := _ in _).
+destruct cca as [f g].
+simpl in *.
+simple refine (mk_cocone _ _).
+simpl; intro n.
+split.
+apply (f n).
+apply (# pr2_functor (pr1 ccml n)).
+simpl.
+intros m n e.
+rewrite (paireta (dmor cAB e)).
+unfold compose.
+simpl.
+apply pathsdirprod.
+apply (g m n e).
+apply (maponpaths dirprod_pr2 ((pr2 ccml) m n e)).
+destruct (Hccml _ HHH) as [[[x1 x2] p1] p2].
+simpl in *.
+mkpair.
+mkpair.
+apply x1.
+simpl; intro n.
+generalize (maponpaths pr1 (p1 n)).
+intros HH.
+unfold compose in HH; simpl in *.
+rewrite HH.
+destruct cca.
+simpl.
+apply idpath.
+simpl.
+admit.
+}
+simple refine (let YY : cocone (mapdiagram F (mapchain pr1_functor cAB)) (pr1 xy) := _ in _).
+simple refine (mk_cocone _ _); simpl.
+intro n.
+apply (pr1 (pr1 ccxy n)).
+intros m n e.
+apply (maponpaths pr1 ((pr2 ccxy) m n e)).
+destruct (HF _ _ ccA H1 (pr1 xy) YY).
+mkpair.
+mkpair.
+admit.
+admit.
+admit.
 Admitted.
 
 End pair_functor.

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -19,24 +19,26 @@ Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.colimits.chains.
 Require Import UniMath.CategoryTheory.ProductPrecategory.
 Require Import UniMath.CategoryTheory.equivalences.
+Require Import UniMath.CategoryTheory.EquivalencesExamples.
 Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
 
 Local Notation "# F" := (functor_on_morphisms F) (at level 3).
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
-(* Proofs that various polynomial functors are omega cocontinuous *)
+Section move_upstream.
+
+Lemma paireta {A B : UU} (p : A × B) : p = (pr1 p,, pr2 p).
+Proof.
+destruct p; apply idpath.
+Defined.
+
+End move_upstream.
+
 Section polynomial_functors.
 
-Variables (C : precategory) (hsC : has_homsets C).
-Variables (D : precategory) (hsD : has_homsets D).
-Variables (E : precategory) (hsE : has_homsets E).
-
 (* The constant functor is omega cocontinuous *)
-Section constant_functor.
-
-Variable (x : D).
-
-Lemma omega_cocont_constant_functor : omega_cocont (constant_functor C D x).
+Lemma omega_cocont_constant_functor (C D : precategory) (hsD : has_homsets D)
+  (x : D) : omega_cocont (constant_functor C D x).
 Proof.
 intros c L ccL HcL y ccy; simpl.
 simple refine (tpair _ _ _).
@@ -51,140 +53,22 @@ simple refine (tpair _ _ _).
               | now simpl; destruct p as [p H]; rewrite <- (H 0), id_left]).
 Defined.
 
-End constant_functor.
-
 (* The identity functor is omega cocontinuous *)
-Section identity_functor.
-
-Lemma omega_cocont_functor_identity : omega_cocont (functor_identity C).
+Lemma omega_cocont_functor_identity (C : precategory) (hsC : has_homsets C) :
+  omega_cocont (functor_identity C).
 Proof.
 intros c L ccL HcL.
 apply (preserves_colimit_identity hsC _ _ _ HcL).
 Defined.
 
-End identity_functor.
-
 (* Functor composition preserves omega cocontinuity *)
-Section functor_comp.
-
-Lemma omega_cocont_functor_composite (F : functor C D) (G : functor D E) :
+Lemma omega_cocont_functor_composite {C D E : precategory}
+  (hsE : has_homsets E) (F : functor C D) (G : functor D E) :
   omega_cocont F -> omega_cocont G -> omega_cocont (functor_composite F G).
 Proof.
 intros hF hG c L cc.
 apply (preserves_colimit_comp hsE); [apply hF|apply hG].
 Defined.
-
-End functor_comp.
-
-(* The functor "x * F" is omega_cocont. This is only proved for set at the
-   moment as it needs that the category is cartesian closed *)
-Section constprod_functor.
-
-Variables (x : HSET).
-
-Definition constprod_functor : functor HSET HSET :=
-  product_functor HSET HSET ProductsHSET (constant_functor HSET HSET x)
-                                         (functor_identity HSET).
-
-Definition flip {A B C : UU} (f : A -> B -> C) : B -> A -> C := fun x y => f y x.
-
-Lemma paireta {A B : UU} (p : A × B) : p = (pr1 p,, pr2 p).
-Proof.
-destruct p; apply idpath.
-Defined.
-
-(* TODO: Opacification *)
-Lemma omega_cocontConstProdFunctor : omega_cocont constprod_functor.
-Proof.
-intros hF c L ccL HcL cc.
-simple refine (tpair _ _ _).
-- simple refine (tpair _ _ _).
-  + simpl; apply uncurry, flip.
-    apply (colimArrow (mk_ColimCocone _ _ _ ccL) (hset_fun_space x HcL)).
-    simple refine (mk_cocone _ _).
-    * simpl; intro n; apply flip, curry, (pr1 cc).
-    * abstract (destruct cc as [f hf]; simpl; intros m n e;
-                rewrite <- (hf m n e); destruct e; simpl;
-                repeat (apply funextfun; intro); apply idpath).
-  + cbn.
-    abstract (
-    destruct cc as [f hf]; simpl; intro n;
-    apply funextfun; intro p; rewrite (paireta p);
-    generalize (colimArrowCommutes (mk_ColimCocone hF c L ccL) _
-                 (mk_cocone _ (omega_cocontConstProdFunctor_subproof
-                               hF c L ccL HcL (f,,hf))) n);
-    unfold flip, curry, colimIn; simpl; intro H;
-    now rewrite <- (toforallpaths _ _ _ (toforallpaths _ _ _ H (pr2 p)) (pr1 p))).
-- abstract (
-  intro p; unfold uncurry; simpl; apply subtypeEquality; simpl;
-  [ intro g; apply impred; intro t;
-    simple refine (let ff : HSET ⟦(x × dob hF t)%set,HcL⟧ := _ in _);
-    [ simpl; apply (pr1 cc)
-    | apply (@has_homsets_HSET _ HcL _ ff) ]
-  | destruct p as [t p]; simpl;
-    apply funextfun; intro xc; destruct xc as [x' c']; simpl;
-    simple refine (let g : HSET⟦colim (mk_ColimCocone hF c L ccL),
-                                hset_fun_space x HcL⟧ := _ in _);
-    [ simpl; apply flip, curry, t
-    | rewrite <- (colimArrowUnique _ _ _ g); [apply idpath | ];
-      destruct cc as [f hf]; simpl in *;
-      now intro n; simpl; rewrite <- (p n) ]
-  ]).
-Defined.
-
-End constprod_functor.
-
-(* The functor "x + F" is omega_cocont.
-   Assumes that the category has coproducts *)
-Section constcoprod_functor.
-
-Variables (x : C) (PC : Coproducts C).
-
-Definition constcoprod_functor : functor C C :=
-  coproduct_functor C C PC (constant_functor C C x) (functor_identity C).
-
-Lemma omega_cocontConstCoprodFunctor : omega_cocont constcoprod_functor.
-Proof.
-intros hF c L ccL HcL cc.
-simple refine (tpair _ _ _).
-- simple refine (tpair _ _ _).
-  + eapply CoproductArrow.
-    * exact (CoproductIn1 _ (PC x (dob hF 0)) ;; pr1 cc 0).
-    * simple refine (let ccHcL : cocone hF HcL := _ in _).
-      { simple refine (mk_cocone _ _).
-        - intros n; exact (CoproductIn2 _ (PC x (dob hF n)) ;; pr1 cc n).
-        - abstract (
-            intros m n e; destruct e; simpl;
-            destruct cc as [f hf]; simpl in *; unfold coproduct_functor_ob in *;
-            rewrite <- (hf m _ (idpath _)), !assoc; apply cancel_postcomposition;
-            now unfold coproduct_functor_mor; rewrite CoproductOfArrowsIn2). }
-      apply (pr1 (pr1 (ccL HcL ccHcL))).
-  + abstract (
-    destruct cc as [f hf]; simpl in *; unfold coproduct_functor_ob in *;
-    simpl; intro n; unfold coproduct_functor_mor in *;
-    rewrite precompWithCoproductArrow; apply pathsinv0, CoproductArrowUnique;
-    [ rewrite id_left; induction n; [apply idpath|];
-      now rewrite <- IHn, <- (hf n _ (idpath _)), assoc,
-                  CoproductOfArrowsIn1, id_left
-    | rewrite <- (hf n _ (idpath _)); destruct ccL; destruct t; simpl in *;
-      rewrite p0; apply maponpaths, hf]).
-- abstract (
-  destruct cc as [f hf]; simpl in *; unfold coproduct_functor_ob in *;
-  intro t; apply subtypeEquality; simpl;
-  [ intro g; apply impred; intro; apply hsC
-  | destruct t; destruct ccL; unfold coproduct_functor_mor in *; destruct t0; simpl;
-    apply CoproductArrowUnique;
-    [ now rewrite <- (p 0), assoc, CoproductOfArrowsIn1, id_left
-    | simple refine (let temp : Σ x0 : C ⟦ c, HcL ⟧, ∀ v : nat,
-         coconeIn L v ;; x0 = CoproductIn2 C (PC x (dob hF v)) ;; f v := _ in _);
-         [ apply (tpair _ (CoproductIn2 C (PC x c) ;; t));
-          now intro n; rewrite <- (p n), !assoc, CoproductOfArrowsIn2|];
-      apply (maponpaths pr1 (p0 temp))]]).
-Defined.
-
-End constcoprod_functor.
-
-End polynomial_functors.
 
 (* A pair of functors (F,G) : A * B -> C * D is omega_cocont if F and G are *)
 Section pair_functor.
@@ -194,62 +78,10 @@ Variables (F : functor A C) (G : functor B D).
 Variables (hsA : has_homsets A) (hsB : has_homsets B).
 Variables (hsC : has_homsets C) (hsD : has_homsets D).
 
-Definition pair_functor_data : functor_data (product_precategory A B) (product_precategory C D).
-Proof.
-mkpair.
-- intro x; apply (prodcatpair (F (pr1 x)) (G (pr2 x))).
-- intros x y f; simpl; apply (prodcatmor (# F (pr1 f)) (# G (pr2 f))).
-Defined.
-
-Definition pair_functor : functor (product_precategory A B) (product_precategory C D).
-Proof.
-mkpair.
-- exact pair_functor_data.
-- split.
-  + intro x; simpl; rewrite !functor_id; apply idpath.
-  + intros x y z f g; simpl; rewrite !functor_comp; apply idpath.
-Defined.
-
-Definition pr1_functor_data : functor_data (product_precategory A B) A.
-Proof.
-mkpair.
-- intro x; apply (pr1 x).
-- intros x y f; simpl; apply (pr1 f).
-Defined.
-
-Definition pr1_functor : functor (product_precategory A B) A.
-Proof.
-mkpair.
-- exact pr1_functor_data.
-- split.
-  + intro x; apply idpath.
-  + intros x y z f g; apply idpath.
-Defined.
-
-Definition pr2_functor_data : functor_data (product_precategory A B) B.
-Proof.
-mkpair.
-- intro x; apply (pr2 x).
-- intros x y f; simpl; apply (pr2 f).
-Defined.
-
-Definition pr2_functor : functor (product_precategory A B) B.
-Proof.
-mkpair.
-- exact pr2_functor_data.
-- split.
-  + intro x; apply idpath.
-  + intros x y z f g; apply idpath.
-Defined.
-
-(* Lemma cocont_pair_functor (HF : is_cocont F) (HG : is_cocont G) : *)
-(*   is_cocont pair_functor. *)
-(* Admitted. *)
-
-(* Maybe generalize these to arbitrary diagrams *)
+(* Maybe generalize these to arbitrary diagrams? *)
 Lemma cocone_pr1_functor (cAB : chain (product_precategory A B))
   (ab : A × B) (ccab : cocone cAB ab) :
-  cocone (mapchain pr1_functor cAB) (pr1 ab).
+  cocone (mapchain (pr1_functor A B)cAB) (pr1 ab).
 Proof.
 simple refine (mk_cocone _ _).
 - simpl; intro n; apply (pr1 (coconeIn ccab n)).
@@ -258,14 +90,14 @@ Defined.
 
 Lemma isColimCocone_pr1_functor (cAB : chain (product_precategory A B))
   (ab : A × B) (ccab : cocone cAB ab) (Hccab : isColimCocone cAB ab ccab) :
-   isColimCocone (mapchain pr1_functor cAB) (pr1 ab)
+   isColimCocone (mapchain (pr1_functor A B) cAB) (pr1 ab)
      (cocone_pr1_functor cAB ab ccab).
 Proof.
 intros x ccx.
 simple refine (let HHH : cocone cAB (x,, pr2 ab) := _ in _).
 { simple refine (mk_cocone _ _).
   - simpl; intro n; split;
-      [ apply (pr1 ccx n) | apply (# pr2_functor (pr1 ccab n)) ].
+      [ apply (pr1 ccx n) | apply (# (pr2_functor A B) (pr1 ccab n)) ].
   - abstract(
     simpl; intros m n e; rewrite (paireta (dmor cAB e));
     apply pathsdirprod; [ apply (pr2 ccx m n e)
@@ -289,7 +121,7 @@ mkpair.
             | apply (maponpaths (fun x => pr1 (pr1 x)) (p2 X))]).
 Defined.
 
-Lemma omega_cocont_pr1_functor : omega_cocont pr1_functor.
+Lemma omega_cocont_pr1_functor : omega_cocont (pr1_functor A B).
 Proof.
 intros c L ccL M.
 now apply isColimCocone_pr1_functor.
@@ -297,7 +129,7 @@ Defined.
 
 Lemma cocone_pr2_functor (cAB : chain (product_precategory A B))
   (ab : A × B) (ccab : cocone cAB ab) :
-  cocone (mapchain pr2_functor cAB) (pr2 ab).
+  cocone (mapchain (pr2_functor A B) cAB) (pr2 ab).
 Proof.
 simple refine (mk_cocone _ _).
 - simpl; intro n; apply (pr2 (coconeIn ccab n)).
@@ -306,14 +138,14 @@ Defined.
 
 Lemma isColimCocone_pr2_functor (cAB : chain (product_precategory A B))
   (ab : A × B) (ccab : cocone cAB ab) (Hccab : isColimCocone cAB ab ccab) :
-   isColimCocone (mapchain pr2_functor cAB) (pr2 ab)
+   isColimCocone (mapchain (pr2_functor A B) cAB) (pr2 ab)
      (cocone_pr2_functor cAB ab ccab).
 Proof.
 intros x ccx.
 simple refine (let HHH : cocone cAB (pr1 ab,, x) := _ in _).
 { simple refine (mk_cocone _ _).
   - simpl; intro n; split;
-      [ apply (# pr1_functor (pr1 ccab n)) | apply (pr1 ccx n) ].
+      [ apply (# (pr1_functor A B) (pr1 ccab n)) | apply (pr1 ccx n) ].
   - abstract(
     simpl; intros m n e; rewrite (paireta (dmor cAB e)); apply pathsdirprod;
       [ apply (maponpaths pr1 (pr2 ccab m n e)) | apply (pr2 ccx m n e) ]).
@@ -336,23 +168,24 @@ mkpair.
               | apply (maponpaths (fun x => dirprod_pr2 (pr1 x)) (p2 X)) ]).
 Defined.
 
-Lemma omega_cocont_pr2_functor : omega_cocont pr2_functor.
+Lemma omega_cocont_pr2_functor : omega_cocont (pr2_functor A B).
 Proof.
 intros c L ccL M.
 now apply isColimCocone_pr2_functor.
 Defined.
 
 Lemma omega_cocont_pair_functor (HF : omega_cocont F) (HG : omega_cocont G) :
-  omega_cocont pair_functor.
+  omega_cocont (pair_functor F G).
 Proof.
 intros cAB ml ccml Hccml xy ccxy; simpl in *.
-(* set (CC := ((ml,, ccml),, Hccml) : ColimCocone cAB). *)
-simple refine (let cFAX : cocone (mapdiagram F (mapchain pr1_functor cAB)) (pr1 xy) := _ in _).
+simple refine (let cFAX : cocone (mapdiagram F (mapchain (pr1_functor A B) cAB))
+                                 (pr1 xy) := _ in _).
 { simple refine (mk_cocone _ _).
   - intro n; apply (pr1 (pr1 ccxy n)).
   - abstract (intros m n e; apply (maponpaths pr1 (pr2 ccxy m n e))).
 }
-simple refine (let cGBY : cocone (mapdiagram G (mapchain pr2_functor cAB)) (pr2 xy) := _ in _).
+simple refine (let cGBY : cocone (mapdiagram G (mapchain (pr2_functor A B)cAB))
+                                 (pr2 xy) := _ in _).
 { simple refine (mk_cocone _ _).
   - intro n; apply (pr2 (pr1 ccxy n)).
   - abstract (intros m n e; apply (maponpaths dirprod_pr2 (pr2 ccxy m n e))).
@@ -382,11 +215,11 @@ Section binprod_functor.
 Variables (C : precategory) (PC : Products C) (hsC : has_homsets C).
 
 (* The functor "x * _" and "_ * x" *)
-Definition constprod_functor1 (x : C) : functor C C :=
-  product_functor C C PC (constant_functor C C x) (functor_identity C).
+(* Definition constprod_functor1 (x : C) : functor C C := *)
+(*   product_functor C C PC (constant_functor C C x) (functor_identity C). *)
 
-Definition constprod_functor2 (x : C) : functor C C :=
-  product_functor C C PC (functor_identity C) (constant_functor C C x).
+(* Definition constprod_functor2 (x : C) : functor C C := *)
+(*   product_functor C C PC (functor_identity C) (constant_functor C C x). *)
 
 (* Lemma omega_cocont_constprod_functor1 (x : C) : omega_cocont (constprod_functor1 x). *)
 (* Admitted. *)
@@ -394,28 +227,7 @@ Definition constprod_functor2 (x : C) : functor C C :=
 (* Lemma omega_cocont_constprod_functor2 (x : C) : omega_cocont (constprod_functor2 x). *)
 (* Admitted. *)
 
-Definition binproduct_functor_data : functor_data (product_precategory C C) C.
-Proof.
-mkpair.
-- intros p.
-  apply (ProductObject _ (PC (pr1 p) (pr2 p))).
-- simpl; intros p q f.
-  apply (ProductOfArrows _ (PC (pr1 q) (pr2 q)) (PC (pr1 p) (pr2 p)) (pr1 f) (pr2 f)).
-Defined.
-
-Definition binproduct_functor : functor (product_precategory C C) C.
-Proof.
-mkpair.
-- apply binproduct_functor_data.
-- split.
-  + intro x; simpl.
-    apply pathsinv0, Product_endo_is_identity.
-    * now rewrite ProductOfArrowsPr1, id_right.
-    * now rewrite ProductOfArrowsPr2, id_right.
-  + now intros x y z f g; simpl; rewrite ProductOfArrows_comp.
-Defined.
-
-Lemma omega_cocont_binproduct_functor : omega_cocont binproduct_functor.
+Lemma omega_cocont_binproduct_functor : omega_cocont (binproduct_functor PC).
 (* Proof. *)
 (* intros c LM ccLM HccLM K ccK; simpl in *. *)
 (* generalize (isColimCocone_pr2_functor _ _ hsC _ _ _ HccLM). *)
@@ -463,50 +275,13 @@ Section delta_functor.
 
 Variables (C : precategory) (PC : Products C) (hsC : has_homsets C).
 
-Definition delta_functor_data : functor_data C (product_precategory C C).
+Lemma cocont_delta_functor : is_cocont (delta_functor C).
 Proof.
-mkpair.
-- intro x; apply (prodcatpair x x).
-- intros x y f; simpl; apply (prodcatmor f f).
-Defined.
-
-Definition delta_functor : functor C (product_precategory C C).
-Proof.
-mkpair.
-- exact delta_functor_data.
-- split.
-  + intro x; apply idpath.
-  + intros x y z f g; apply idpath.
-Defined.
-
-Lemma is_left_adjoint_delta_functor : is_left_adjoint delta_functor.
-Proof.
-apply (tpair _ (binproduct_functor _ PC)).
-mkpair.
-- split.
-  + mkpair.
-    * simpl; intro x.
-      apply (ProductArrow _ _ (identity x) (identity x)).
-    * abstract (intros p q f; simpl;
-                now rewrite precompWithProductArrow, id_right, postcompWithProductArrow, id_left).
-  + mkpair.
-    * simpl; intro x; split; [ apply ProductPr1 | apply ProductPr2 ].
-    * abstract (intros p q f; unfold prodcatmor, compose; simpl;
-                now rewrite ProductOfArrowsPr1, ProductOfArrowsPr2).
-- split; simpl; intro x.
-  + unfold prodcatmor, compose; simpl.
-    now rewrite ProductPr1Commutes, ProductPr2Commutes.
-  + rewrite postcompWithProductArrow, !id_left.
-    apply pathsinv0, Product_endo_is_identity; [ apply ProductPr1Commutes | apply ProductPr2Commutes ].
-Defined.
-
-Lemma cocont_delta_functor : is_cocont delta_functor.
-Proof.
-apply (left_adjoint_cocont _ is_left_adjoint_delta_functor hsC).
+apply (left_adjoint_cocont _ (is_left_adjoint_delta_functor PC) hsC).
 apply (has_homsets_product_precategory _ _ hsC hsC).
 Defined.
 
-Lemma omega_cocont_delta_functor : omega_cocont delta_functor.
+Lemma omega_cocont_delta_functor : omega_cocont (delta_functor C).
 Proof.
 intros c L ccL.
 apply cocont_delta_functor.
@@ -613,362 +388,6 @@ Defined.
 
 End rightkanextension.
 
-(* Lists as the colimit of a chain given by the list functor: F(X) = 1 + A * X *)
-Section lists.
-
-Variable A : HSET.
-
-(* F(X) = A * X *)
-Definition stream : functor HSET HSET := constprod_functor A.
-
-(* F(X) = 1 + (A * X) *)
-Definition listFunctor : functor HSET HSET :=
-  functor_composite stream (constcoprod_functor _ unitHSET CoproductsHSET).
-
-Lemma omega_cocont_listFunctor : omega_cocont listFunctor.
-Proof.
-apply (omega_cocont_functor_composite _ _ _ has_homsets_HSET).
-- apply omega_cocontConstProdFunctor.
-- apply (omega_cocontConstCoprodFunctor _ has_homsets_HSET).
-Defined.
-
-Lemma listFunctor_Initial :
-  Initial (precategory_FunctorAlg listFunctor has_homsets_HSET).
-Proof.
-apply (colimAlgInitial _ _ _ omega_cocont_listFunctor
-                       InitialHSET (ColimCoconeHSET _ _)).
-Defined.
-
-Definition List : HSET :=
-  (* colim (ColimCoconeHSET nat_graph (initChain InitialHSET listFunctor)). *)
-  alg_carrier _ (InitialObject listFunctor_Initial).
-Opaque List.
-Let List_mor : HSET⟦listFunctor List,List⟧ :=
-  alg_map _ (InitialObject listFunctor_Initial).
-Opaque List_mor.
-Let List_alg : algebra_ob listFunctor :=
-  InitialObject listFunctor_Initial.
-Opaque List_alg.
-
-Definition nil_map : HSET⟦unitHSET,List⟧.
-Proof.
-simpl; intro x.
-apply List_mor, inl, x.
-Defined.
-
-Definition nil : pr1 List := nil_map tt.
-
-Definition cons_map : HSET⟦(A × List)%set,List⟧.
-Proof.
-intros xs.
-apply List_mor, (inr xs).
-Defined.
-
-Definition cons : pr1 A × pr1 List -> pr1 List := cons_map.
-
-(* Get recursion/iteration scheme: *)
-
-(*    x : X           f : A × X -> X *)
-(* ------------------------------------ *)
-(*       foldr x f : List A -> X *)
-
-Definition mk_listAlgebra (X : HSET) (x : pr1 X)
-  (f : HSET⟦(A × X)%set,X⟧) : algebra_ob listFunctor.
-Proof.
-set (x' := λ (_ : unit), x).
-apply (tpair _ X (sumofmaps x' f) : algebra_ob listFunctor).
-Defined.
-
-Definition foldr_map (X : HSET) (x : pr1 X) (f : HSET⟦(A × X)%set,X⟧) :
-  algebra_mor _ List_alg (mk_listAlgebra X x f).
-Proof.
-apply (InitialArrow listFunctor_Initial (mk_listAlgebra X x f)).
-Defined.
-Opaque foldr_map.
-
-Definition foldr (X : HSET) (x : pr1 X)
-  (f : pr1 A × pr1 X -> pr1 X) : pr1 List -> pr1 X.
-Proof.
-apply (foldr_map _ x f).
-Defined.
-Opaque foldr.
-
-(* Maybe quantify over "λ _ : unit, x" instead of nil? *)
-Lemma foldr_nil (X : hSet) (x : X) (f : pr1 A × X -> X) : foldr X x f nil = x.
-Proof.
-assert (F := maponpaths (fun x => CoproductIn1 _ _ ;; x)
-                        (algebra_mor_commutes _ _ _ (foldr_map X x f))).
-apply (toforallpaths _ _ _ F tt).
-Qed.
-
-Lemma foldr_cons (X : hSet) (x : X) (f : pr1 A × X -> X)
-                 (a : pr1 A) (l : pr1 List) :
-  foldr X x f (cons (a,,l)) = f (a,,foldr X x f l).
-Proof.
-assert (F := maponpaths (fun x => CoproductIn2 _ _ ;; x)
-                        (algebra_mor_commutes _ _ _ (foldr_map X x f))).
-assert (Fal := toforallpaths _ _ _ F (a,,l)).
-clear F.
-(* apply Fal. *) (* This doesn't work here. why? *)
-unfold compose in Fal.
-simpl in Fal.
-apply Fal.
-Qed. (* This Qed is slow! *)
-
-(* This defines the induction principle for lists using foldr *)
-Section list_induction.
-
-Variables (P : pr1 List -> UU) (PhSet : forall l, isaset (P l)).
-Variables (P0 : P nil)
-          (Pc : forall (a : pr1 A) (l : pr1 List), P l -> P (cons (a,,l))).
-
-Let P' : UU := Σ l, P l.
-Let P0' : P' := (nil,, P0).
-Let Pc' : pr1 A × P' -> P' :=
-  λ ap : pr1 A × P', cons (pr1 ap,, pr1 (pr2 ap)),,Pc (pr1 ap) (pr1 (pr2 ap)) (pr2 (pr2 ap)).
-
-Definition P'HSET : HSET.
-Proof.
-apply (tpair _ P').
-abstract (apply (isofhleveltotal2 2); [ apply setproperty | intro x; apply PhSet ]).
-Defined.
-
-Lemma isalghom_pr1foldr :
-  is_algebra_mor _ List_alg List_alg (fun l => pr1 (foldr P'HSET P0' Pc' l)).
-Proof.
-apply CoproductArrow_eq_cor.
-- apply funextfun; intro x; destruct x; apply idpath.
-- apply funextfun; intro x; destruct x as [a l].
-  apply (maponpaths pr1 (foldr_cons P'HSET P0' Pc' a l)).
-Qed.
-
-Definition pr1foldr_algmor : algebra_mor _ List_alg List_alg :=
-  tpair _ _ isalghom_pr1foldr.
-
-Lemma pr1foldr_algmor_identity : identity _ = pr1foldr_algmor.
-Proof.
-now rewrite <- (InitialEndo_is_identity _ listFunctor_Initial pr1foldr_algmor).
-Qed.
-
-Lemma listInd l : P l.
-Proof.
-assert (H : pr1 (foldr P'HSET P0' Pc' l) = l).
-  apply (toforallpaths _ _ _ (!pr1foldr_algmor_identity) l).
-rewrite <- H.
-apply (pr2 (foldr P'HSET P0' Pc' l)).
-Defined.
-
-End list_induction.
-
-Lemma listIndProp (P : pr1 List -> UU) (HP : forall l, isaprop (P l)) :
-  P nil -> (forall a l, P l → P (cons (a,, l))) -> forall l, P l.
-Proof.
-intros Pnil Pcons.
-apply listInd; try assumption.
-intro l; apply isasetaprop, HP.
-Defined.
-
-Require Import UniMath.Foundations.NumberSystems.NaturalNumbers.
-
-Definition natHSET : HSET.
-Proof.
-exists nat.
-abstract (apply isasetnat).
-Defined.
-
-Definition length : pr1 List -> nat :=
-  foldr natHSET 0 (fun x => S (pr2 x)).
-
-Definition map (f : pr1 A -> pr1 A) : pr1 List -> pr1 List :=
-  foldr _ nil (λ xxs : pr1 A × pr1 List, cons (f (pr1 xxs),, pr2 xxs)).
-
-Lemma length_map (f : pr1 A -> pr1 A) : forall xs, length (map f xs) = length xs.
-Proof.
-apply listIndProp.
-- intros l; apply isasetnat.
-- apply idpath.
-- simpl; unfold map, length; simpl; intros a l Hl.
-  simpl.
-  now rewrite !foldr_cons, <- Hl.
-Qed.
-
-End lists.
-
-Opaque List.
-(* Opaque foldr. *) (* makes "cbn" and "compute" in the computation below fail *)
-
-(* Some examples of computations with lists over nat *)
-Section nat_examples.
-
-Definition cons_nat a l : pr1 (List natHSET) := cons natHSET (a,,l).
-
-Infix "::" := cons_nat.
-Notation "[]" := (nil natHSET) (at level 0, format "[]").
-
-Definition testlist : pr1 (List natHSET) := 5 :: 2 :: [].
-
-Definition testlistS : pr1 (List natHSET) :=
-  map natHSET S testlist.
-
-Definition sum : pr1 (List natHSET) -> nat :=
-  foldr natHSET natHSET 0 (fun xy => pr1 xy + pr2 xy).
-
-Eval vm_compute in length _ (nil natHSET).
-Eval vm_compute in length _ testlist.
-Eval vm_compute in length _ testlistS.
-Eval vm_compute in sum testlist.
-Eval vm_compute in sum testlistS.
-
-Goal length _ testlist = 2.
-vm_compute.
-Restart.
-cbn.
-Restart.
-compute.  (* does not work when foldr is opaque with "Opaque foldr." *)
-Restart.
-cbv.   (* does not work when foldr is opaque with "Opaque foldr." *)
-Restart.
-native_compute.
-Abort.
-
-Goal (forall l, length _ (2 :: l) = S (length _ l)).
-simpl.
-intro l.
-try apply idpath. (* this doesn't work *)
-unfold length, cons_nat.
-rewrite foldr_cons. cbn.
-apply idpath.
-Abort.
-
-(* some experiments: *)
-
-(* Definition const {A B : UU} : A -> B -> A := fun x _ => x. *)
-
-(* Eval compute in const 0 (nil natHSET). *)
-
-(* Axiom const' : forall {A B : UU}, A -> B -> A. *)
-
-(* Eval compute in const' 0 1. *)
-(* Eval compute in const' 0 (nil natHSET). *)
-
-(* Time Eval vm_compute in nil natHSET.  (* This crashes my computer by using up all memory *) *)
-
-End nat_examples.
-
-(* Inductive list A : UU := *)
-(*   | nilA : list A *)
-(*   | consA : A -> list A -> list A. *)
-
-(* Fixpoint lengthA (A : UU) (xs : list A) : nat := match xs with *)
-(*   | nilA _ => 0 *)
-(*   | consA _ _ xs' => S (lengthA _ xs') *)
-(*   end. *)
-
-(* Goal (forall l, lengthA nat (consA _ 2 l) = S (lengthA nat l)). *)
-(* intro l. *)
-(* apply idpath. *)
-(* Abort. *)
-
-(* Alternative and more general definition of lists (inspired by a remark of VV) *)
-Section list'.
-
-(* I think if you really need lists you should prove a theorem that
-establishes a weq between the lists that you have defined and lists
-defined as total2 ( fun n : nat => iterprod n A ) where iterprod n A
-is defined by induction such that iterprod 0 A = unit, iterprod 1 A =
-A and iterprod ( S n ) A = dirprod (iterprod n A) A for n=S n’. *)
-
-Fixpoint iterprod (n : nat) (A : UU) : UU := match n with
-  | O => unit
-  | S n' => dirprod A (iterprod n' A)
-  end.
-
-Definition list' (A : UU) := total2 (fun n => iterprod n A).
-
-Definition nil_list' (A : UU) : list' A := (0,,tt).
-Definition cons_list' (A : UU) (x : A) (xs : list' A) : list' A :=
-  (S (pr1 xs),, (x,, pr2 xs)).
-
-Lemma list'_ind : ∀ (A : Type) (P : list' A -> UU),
-    P (nil_list' A)
-  -> (∀ (x : A) (xs : list' A), P xs -> P (cons_list' A x xs))
-  -> ∀ xs, P xs.
-Proof.
-intros A P Hnil Hcons xs.
-destruct xs as [n xs].
-induction n.
-- destruct xs.
-  apply Hnil.
-- destruct xs as [x xs].
-  apply (Hcons x (n,,xs) (IHn xs)).
-Qed.
-
-Lemma isaset_list' (A : HSET) : isaset (list' (pr1 A)).
-Proof.
-apply isaset_total2; [apply isasetnat|].
-intro n; induction n; simpl; [apply isasetunit|].
-apply isaset_dirprod; [ apply setproperty | apply IHn ].
-Qed.
-
-Definition to_List (A : HSET) : list' (pr1 A) -> pr1 (List A).
-Proof.
-intros l.
-destruct l as [n l].
-induction n.
-+ exact (nil A).
-+ apply (cons _ (pr1 l,,IHn (pr2 l))).
-Defined.
-
-Definition to_list' (A : HSET) : pr1 (List A) -> list' (pr1 A).
-Proof.
-apply (foldr A (list' (pr1 A),,isaset_list' A)).
-* apply (0,,tt).
-* intros L.
-  apply (tpair _ (S (pr1 (pr2 L))) (pr1 L,,pr2 (pr2 L))).
-Defined.
-
-Lemma to_list'K (A : HSET) : ∀ x : list' (pr1 A), to_list' A (to_List A x) = x.
-Proof.
-intro l; destruct l as [n l]; unfold to_list', to_List.
-induction n; simpl.
-- rewrite foldr_nil.
-  destruct l.
-  apply idpath.
-- rewrite foldr_cons; simpl.
-  rewrite IHn; simpl; rewrite <- (paireta l).
-  apply idpath.
-Qed.
-
-Lemma to_ListK (A : HSET) : ∀ y : pr1 (List A), to_List A (to_list' A y) = y.
-Proof.
-apply listIndProp.
-* intro l; apply setproperty.
-* unfold to_list'; rewrite foldr_nil.
-  apply idpath.
-* unfold to_list', to_List; intros a l IH.
-  rewrite foldr_cons; simpl.
-  apply maponpaths, maponpaths, pathsinv0.
-  eapply pathscomp0; [eapply pathsinv0, IH|]; simpl.
-  now destruct foldr.
-Qed.
-
-Lemma weq_list' (A : HSET) : list' (pr1 A) ≃ pr1 (List A).
-Proof.
-mkpair.
-- apply to_List.
-- simple refine (gradth _ _ _ _).
-  + apply to_list'.
-  + apply to_list'K.
-  + apply to_ListK.
-Defined.
-
-(* This works: *)
-Eval compute in (to_list' _ testlist).
-
-End list'.
-
-Section lambdacalculus.
-
 Section temp.
 Variables (C D : precategory) (PC : Products C) (HD : Coproducts D).
 Variables (hsC : has_homsets C) (hsD : has_homsets D).
@@ -988,16 +407,21 @@ Defined.
 Lemma omega_cocont_sum_of_functors (F G : functor C D)
   (HF : omega_cocont F) (HG : omega_cocont G) : omega_cocont (sum_of_functors F G).
 Proof.
-apply (omega_cocont_functor_composite _ _ _ hsD).
+apply (omega_cocont_functor_composite hsD).
   apply (omega_cocont_delta_functor _ PC).
   apply hsC.
-apply (omega_cocont_functor_composite _ _ _ hsD).
+apply (omega_cocont_functor_composite hsD).
   apply (omega_cocont_pair_functor _ _ _ _ _ _ hsC hsC hsD hsD HF HG).
 apply omega_cocont_bincoproduct_functor.
 apply hsD.
 Defined.
 
 End temp.
+
+End polynomial_functors.
+
+Section lambdacalculus.
+
 
 Definition option_functor : [HSET,HSET,has_homsets_HSET].
 Proof.

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -388,11 +388,11 @@ Definition constprod_functor1 (x : C) : functor C C :=
 Definition constprod_functor2 (x : C) : functor C C :=
   product_functor C C PC (functor_identity C) (constant_functor C C x).
 
-Lemma omega_cocont_constprod_functor1 (x : C) : omega_cocont (constprod_functor1 x).
-Admitted.
+(* Lemma omega_cocont_constprod_functor1 (x : C) : omega_cocont (constprod_functor1 x). *)
+(* Admitted. *)
 
-Lemma omega_cocont_constprod_functor2 (x : C) : omega_cocont (constprod_functor2 x).
-Admitted.
+(* Lemma omega_cocont_constprod_functor2 (x : C) : omega_cocont (constprod_functor2 x). *)
+(* Admitted. *)
 
 Definition binproduct_functor_data : functor_data (product_precategory C C) C.
 Proof.
@@ -416,44 +416,44 @@ mkpair.
 Defined.
 
 Lemma omega_cocont_binproduct_functor : omega_cocont binproduct_functor.
-Proof.
-intros c LM ccLM HccLM K ccK; simpl in *.
-generalize (isColimCocone_pr2_functor _ _ hsC _ _ _ HccLM).
-generalize (isColimCocone_pr1_functor _ _ hsC _ _ _ HccLM).
-set (L := pr1 LM); set (M := pr2 LM).
-intros HA HB.
-(* Form the colimiting cocones of "A_i * B_0 -> A_i * B_1 -> ..." *)
-assert (HAiB : forall i, isColimCocone
-     (mapdiagram (constprod_functor1 (pr1 (pr1 c i)))
-        (mapchain (pr2_functor C C) c))
-     ((constprod_functor1 (pr1 (pr1 c i))) M)
-     (mapcocone (constprod_functor1 (pr1 (pr1 c i)))
-        (mapchain (pr2_functor C C) c) (cocone_pr2_functor C C c LM ccLM))).
-  intro i.
-  apply (omega_cocont_constprod_functor1 (pr1 (pr1 c i)) _ _ _ HB).
-generalize (omega_cocont_constprod_functor2 M _ _ _ HA); intro HAiM.
-simple refine (let X : ColimCocone
-       (mapdiagram (constprod_functor2 M) (mapchain (pr1_functor C C) c)) := _ in _).
-mkpair.
-mkpair.
-apply (ProductObject _ (PC L M)).
-apply (mapcocone (constprod_functor2 M) (mapchain (pr1_functor C C) c)
-              (cocone_pr1_functor C C c LM ccLM)).
-apply HAiM.
-simple refine (let Y : cocone (mapdiagram (constprod_functor2 M) (mapchain (pr1_functor C C) c)) K := _ in _).
-  admit.
-mkpair.
-mkpair.
-apply (colimArrow X K Y).
-intro n.
-generalize (colimArrowCommutes X K Y n).
-simpl.
-unfold colimIn.
-simpl.
-unfold product_functor_mor.
-unfold ProductOfArrows.
-admit.
-admit.
+(* Proof. *)
+(* intros c LM ccLM HccLM K ccK; simpl in *. *)
+(* generalize (isColimCocone_pr2_functor _ _ hsC _ _ _ HccLM). *)
+(* generalize (isColimCocone_pr1_functor _ _ hsC _ _ _ HccLM). *)
+(* set (L := pr1 LM); set (M := pr2 LM). *)
+(* intros HA HB. *)
+(* (* Form the colimiting cocones of "A_i * B_0 -> A_i * B_1 -> ..." *) *)
+(* assert (HAiB : forall i, isColimCocone *)
+(*      (mapdiagram (constprod_functor1 (pr1 (pr1 c i))) *)
+(*         (mapchain (pr2_functor C C) c)) *)
+(*      ((constprod_functor1 (pr1 (pr1 c i))) M) *)
+(*      (mapcocone (constprod_functor1 (pr1 (pr1 c i))) *)
+(*         (mapchain (pr2_functor C C) c) (cocone_pr2_functor C C c LM ccLM))). *)
+(*   intro i. *)
+(*   apply (omega_cocont_constprod_functor1 (pr1 (pr1 c i)) _ _ _ HB). *)
+(* generalize (omega_cocont_constprod_functor2 M _ _ _ HA); intro HAiM. *)
+(* simple refine (let X : ColimCocone *)
+(*        (mapdiagram (constprod_functor2 M) (mapchain (pr1_functor C C) c)) := _ in _). *)
+(* mkpair. *)
+(* mkpair. *)
+(* apply (ProductObject _ (PC L M)). *)
+(* apply (mapcocone (constprod_functor2 M) (mapchain (pr1_functor C C) c) *)
+(*               (cocone_pr1_functor C C c LM ccLM)). *)
+(* apply HAiM. *)
+(* simple refine (let Y : cocone (mapdiagram (constprod_functor2 M) (mapchain (pr1_functor C C) c)) K := _ in _). *)
+(*   admit. *)
+(* mkpair. *)
+(* mkpair. *)
+(* apply (colimArrow X K Y). *)
+(* intro n. *)
+(* generalize (colimArrowCommutes X K Y n). *)
+(* simpl. *)
+(* unfold colimIn. *)
+(* simpl. *)
+(* unfold product_functor_mor. *)
+(* unfold ProductOfArrows. *)
+(* admit. *)
+(* admit. *)
 Admitted.
 
 End binprod_functor.
@@ -1007,7 +1007,7 @@ apply (constant_functor _ _ unitHSET).
 apply functor_identity.
 Defined.
 
-(* TODO: define sum of omega cocont functors *)
+(* TODO: package omega cocont functors *)
 Definition LambdaFunctor : functor [HSET,HSET,has_homsets_HSET] [HSET,HSET,has_homsets_HSET].
 Proof.
 eapply sum_of_functors.

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -67,7 +67,7 @@ Lemma omega_cocont_functor_composite {C D E : precategory}
   omega_cocont F -> omega_cocont G -> omega_cocont (functor_composite F G).
 Proof.
 intros hF hG c L cc.
-apply (preserves_colimit_comp hsE); [apply hF|apply hG].
+apply (preserves_colimit_comp hsE); [ apply hF | apply hG ].
 Defined.
 
 (* A pair of functors (F,G) : A * B -> C * D is omega_cocont if F and G are *)
@@ -209,67 +209,6 @@ Defined.
 
 End pair_functor.
 
-(* The functor "* : C^2 -> C" is omega cocont *)
-Section binprod_functor.
-
-Variables (C : precategory) (PC : Products C) (hsC : has_homsets C).
-
-(* The functor "x * _" and "_ * x" *)
-(* Definition constprod_functor1 (x : C) : functor C C := *)
-(*   product_functor C C PC (constant_functor C C x) (functor_identity C). *)
-
-(* Definition constprod_functor2 (x : C) : functor C C := *)
-(*   product_functor C C PC (functor_identity C) (constant_functor C C x). *)
-
-(* Lemma omega_cocont_constprod_functor1 (x : C) : omega_cocont (constprod_functor1 x). *)
-(* Admitted. *)
-
-(* Lemma omega_cocont_constprod_functor2 (x : C) : omega_cocont (constprod_functor2 x). *)
-(* Admitted. *)
-
-Lemma omega_cocont_binproduct_functor : omega_cocont (binproduct_functor PC).
-(* Proof. *)
-(* intros c LM ccLM HccLM K ccK; simpl in *. *)
-(* generalize (isColimCocone_pr2_functor _ _ hsC _ _ _ HccLM). *)
-(* generalize (isColimCocone_pr1_functor _ _ hsC _ _ _ HccLM). *)
-(* set (L := pr1 LM); set (M := pr2 LM). *)
-(* intros HA HB. *)
-(* (* Form the colimiting cocones of "A_i * B_0 -> A_i * B_1 -> ..." *) *)
-(* assert (HAiB : forall i, isColimCocone *)
-(*      (mapdiagram (constprod_functor1 (pr1 (pr1 c i))) *)
-(*         (mapchain (pr2_functor C C) c)) *)
-(*      ((constprod_functor1 (pr1 (pr1 c i))) M) *)
-(*      (mapcocone (constprod_functor1 (pr1 (pr1 c i))) *)
-(*         (mapchain (pr2_functor C C) c) (cocone_pr2_functor C C c LM ccLM))). *)
-(*   intro i. *)
-(*   apply (omega_cocont_constprod_functor1 (pr1 (pr1 c i)) _ _ _ HB). *)
-(* generalize (omega_cocont_constprod_functor2 M _ _ _ HA); intro HAiM. *)
-(* simple refine (let X : ColimCocone *)
-(*        (mapdiagram (constprod_functor2 M) (mapchain (pr1_functor C C) c)) := _ in _). *)
-(* mkpair. *)
-(* mkpair. *)
-(* apply (ProductObject _ (PC L M)). *)
-(* apply (mapcocone (constprod_functor2 M) (mapchain (pr1_functor C C) c) *)
-(*               (cocone_pr1_functor C C c LM ccLM)). *)
-(* apply HAiM. *)
-(* simple refine (let Y : cocone (mapdiagram (constprod_functor2 M) (mapchain (pr1_functor C C) c)) K := _ in _). *)
-(*   admit. *)
-(* mkpair. *)
-(* mkpair. *)
-(* apply (colimArrow X K Y). *)
-(* intro n. *)
-(* generalize (colimArrowCommutes X K Y n). *)
-(* simpl. *)
-(* unfold colimIn. *)
-(* simpl. *)
-(* unfold product_functor_mor. *)
-(* unfold ProductOfArrows. *)
-(* admit. *)
-(* admit. *)
-Admitted.
-
-End binprod_functor.
-
 (* The delta functor C -> C^2 mapping x to (x,x) is omega_cocont *)
 Section delta_functor.
 
@@ -294,195 +233,36 @@ Section bincoprod_functor.
 
 Variables (C : precategory) (PC : Coproducts C) (hsC : has_homsets C).
 
-Definition bincoproduct_functor_data : functor_data (product_precategory C C) C.
+Lemma cocont_bincoproducts_functor : is_cocont (bincoproduct_functor PC).
 Proof.
-mkpair.
-- intros p.
-  apply (CoproductObject _ (PC (pr1 p) (pr2 p))).
-- simpl; intros p q f.
-  apply (CoproductOfArrows _ (PC (pr1 p) (pr2 p)) (PC (pr1 q) (pr2 q)) (pr1 f) (pr2 f)).
-Defined.
-
-Definition bincoproduct_functor : functor (product_precategory C C) C.
-Proof.
-mkpair.
-- apply bincoproduct_functor_data.
-- split.
-  + intro x; simpl.
-    apply pathsinv0, Coproduct_endo_is_identity.
-    * now rewrite CoproductOfArrowsIn1, id_left.
-    * now rewrite CoproductOfArrowsIn2, id_left.
-  + now intros x y z f g; simpl; rewrite CoproductOfArrows_comp.
-Defined.
-
-Lemma is_left_adjoint_bincoproduct_functor : is_left_adjoint bincoproduct_functor.
-Proof.
-apply (tpair _ (delta_functor _)).
-mkpair.
-- split.
-  + mkpair.
-    * simpl; intro p; set (x := pr1 p); set (y := pr2 p).
-      split; [ apply (CoproductIn1 _ (PC x y)) | apply (CoproductIn2 _ (PC x y)) ].
-    * abstract (intros p q f; unfold prodcatmor, compose; simpl;
-                now rewrite CoproductOfArrowsIn1, CoproductOfArrowsIn2).
-  + mkpair.
-    * intro x; apply (CoproductArrow _ _ (identity x) (identity x)).
-    * abstract (intros p q f; simpl;
-                now rewrite precompWithCoproductArrow, postcompWithCoproductArrow,
-                            id_right, id_left).
-- split; simpl; intro x.
-  + rewrite precompWithCoproductArrow, !id_right.
-    apply pathsinv0, Coproduct_endo_is_identity;
-      [ apply CoproductIn1Commutes | apply CoproductIn2Commutes ].
-  + unfold prodcatmor, compose; simpl.
-    now rewrite CoproductIn1Commutes, CoproductIn2Commutes.
-Defined.
-
-Lemma cocont_bincoproducts_functor : is_cocont bincoproduct_functor.
-Proof.
-apply (left_adjoint_cocont _ is_left_adjoint_bincoproduct_functor).
+apply (left_adjoint_cocont _ (is_left_adjoint_bincoproduct_functor PC)).
 - apply has_homsets_product_precategory; apply hsC.
 - apply hsC.
 Defined.
 
-Lemma omega_cocont_bincoproduct_functor: omega_cocont bincoproduct_functor.
+Lemma omega_cocont_bincoproduct_functor: omega_cocont (bincoproduct_functor PC).
 Proof.
 intros c L ccL; apply cocont_bincoproducts_functor.
 Defined.
 
 End bincoprod_functor.
 
-(* Should go to ProductPrecategory.v *)
-(* The functor "F * G : A * B -> C * D" is cocont *)
-(* Section product_of_functors. *)
+Section sum_of_functors.
 
-(* Variable A B C D : precategory. *)
-(* Variables (F : functor A C) (G : functor B D). *)
-
-(* Definition product_of_functors : functor (product_precategory A B) (product_precategory C D). *)
-(* Admitted. *)
-
-(* End product_of_functors. *)
-
-Section rightkanextension.
-
-Require Import UniMath.CategoryTheory.whiskering.
-Require Import UniMath.CategoryTheory.RightKanExtension.
-
-Variables C D E : precategory.
-Variables (K : functor C D).
-
-(* Lemma foo : has_limits D -> GlobalRightKanExtensionExists K. *)
-
-(* has_limits D *)
-Lemma cocont_pre_composition_functor (hsD : has_homsets D) (hsE : has_homsets E) :
-  is_cocont (pre_composition_functor _ _ E hsD hsE K).
-Admitted. (* will be a simple consequence of foo *)
-
-Lemma omega_cocont_pre_composition_functor (hsD : has_homsets D) (hsE : has_homsets E) :
-  omega_cocont (pre_composition_functor _ _ E hsD hsE K).
-Proof.
-intros c L ccL.
-apply cocont_pre_composition_functor.
-Defined.
-
-End rightkanextension.
-
-Section temp.
 Variables (C D : precategory) (PC : Products C) (HD : Coproducts D).
 Variables (hsC : has_homsets C) (hsD : has_homsets D).
 
-Definition sum_of_functors (F G : functor C D) : functor C D.
-eapply functor_composite.
-  eapply delta_functor.
-eapply functor_composite.
-  eapply pair_functor.
-  (* eapply product_of_functors. *)
-    apply F.
-    apply G.
-apply bincoproduct_functor.
-apply HD.
-Defined.
-
 Lemma omega_cocont_sum_of_functors (F G : functor C D)
-  (HF : omega_cocont F) (HG : omega_cocont G) : omega_cocont (sum_of_functors F G).
+  (HF : omega_cocont F) (HG : omega_cocont G) :
+  omega_cocont (sum_of_functors HD F G).
 Proof.
 apply (omega_cocont_functor_composite hsD).
-  apply (omega_cocont_delta_functor _ PC).
-  apply hsC.
+  apply (omega_cocont_delta_functor _ PC hsC).
 apply (omega_cocont_functor_composite hsD).
   apply (omega_cocont_pair_functor _ _ _ _ _ _ hsC hsC hsD hsD HF HG).
-apply omega_cocont_bincoproduct_functor.
-apply hsD.
+apply (omega_cocont_bincoproduct_functor _ _ hsD).
 Defined.
 
-End temp.
+End sum_of_functors.
 
 End polynomial_functors.
-
-Section lambdacalculus.
-
-
-Definition option_functor : [HSET,HSET,has_homsets_HSET].
-Proof.
-apply coproduct_functor.
-apply CoproductsHSET.
-apply (constant_functor _ _ unitHSET).
-apply functor_identity.
-Defined.
-
-(* TODO: package omega cocont functors *)
-Definition LambdaFunctor : functor [HSET,HSET,has_homsets_HSET] [HSET,HSET,has_homsets_HSET].
-Proof.
-eapply sum_of_functors.
-  apply (Coproducts_functor_precat _ _ CoproductsHSET).
-  apply (constant_functor [HSET, HSET, has_homsets_HSET] [HSET, HSET, has_homsets_HSET] (functor_identity HSET)).
-eapply sum_of_functors.
-  apply (Coproducts_functor_precat _ _ CoproductsHSET).
-  (* app *)
-  eapply functor_composite.
-    apply delta_functor.
-    apply binproduct_functor.
-    apply (Products_functor_precat _ _ ProductsHSET).
-(* lam *)
-apply (pre_composition_functor _ _ _ _ _ option_functor).
-Defined.
-
-(* Bad approach *)
-(* Definition Lambda : functor [HSET,HSET,has_homsets_HSET] [HSET,HSET,has_homsets_HSET]. *)
-(* Proof. *)
-(* eapply functor_composite. *)
-(*   apply delta_functor. *)
-(* eapply functor_composite. *)
-(*   eapply product_of_functors. *)
-(*     apply functor_identity. *)
-(*     apply delta_functor. *)
-(* eapply functor_composite. *)
-(*   eapply product_of_functors. *)
-(*     apply (constant_functor [HSET, HSET, has_homsets_HSET] [HSET, HSET, has_homsets_HSET] (functor_identity HSET)). *)
-(*     eapply product_of_functors. *)
-(*       apply delta_functor. *)
-
-Lemma omega_cocont_LambdaFunctor : omega_cocont LambdaFunctor.
-Proof.
-apply omega_cocont_sum_of_functors.
-  apply (Products_functor_precat _ _ ProductsHSET).
-  apply functor_category_has_homsets.
-  apply functor_category_has_homsets.
-  apply omega_cocont_constant_functor.
-  apply functor_category_has_homsets.
-apply omega_cocont_sum_of_functors.
-  apply (Products_functor_precat _ _ ProductsHSET).
-  apply functor_category_has_homsets.
-  apply functor_category_has_homsets.
-  apply omega_cocont_functor_composite.
-  apply functor_category_has_homsets.
-  apply omega_cocont_delta_functor.
-  apply (Products_functor_precat _ _ ProductsHSET).
-  apply functor_category_has_homsets.
-  apply omega_cocont_binproduct_functor.
-  apply functor_category_has_homsets.
-apply omega_cocont_pre_composition_functor.
-Defined.
-
-End lambdacalculus.

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -798,6 +798,104 @@ End nat_examples.
 (* apply idpath. *)
 (* Abort. *)
 
+(* Alternative and more general definition of lists (inspired by a remark of VV) *)
+Section list'.
+
+(* I think if you really need lists you should prove a theorem that
+establishes a weq between the lists that you have defined and lists
+defined as total2 ( fun n : nat => iterprod n A ) where iterprod n A
+is defined by induction such that iterprod 0 A = unit, iterprod 1 A =
+A and iterprod ( S n ) A = dirprod (iterprod n A) A for n=S n’. *)
+
+Fixpoint iterprod (n : nat) (A : UU) : UU := match n with
+  | O => unit
+  | S n' => dirprod A (iterprod n' A)
+  end.
+
+Definition list' (A : UU) := total2 (fun n => iterprod n A).
+
+Definition nil_list' (A : UU) : list' A := (0,,tt).
+Definition cons_list' (A : UU) (x : A) (xs : list' A) : list' A :=
+  (S (pr1 xs),, (x,, pr2 xs)).
+
+Lemma list'_ind : ∀ (A : Type) (P : list' A -> UU),
+    P (nil_list' A)
+  -> (∀ (x : A) (xs : list' A), P xs -> P (cons_list' A x xs))
+  -> ∀ xs, P xs.
+Proof.
+intros A P Hnil Hcons xs.
+destruct xs as [n xs].
+induction n.
+- destruct xs.
+  apply Hnil.
+- destruct xs as [x xs].
+  apply (Hcons x (n,,xs) (IHn xs)).
+Qed.
+
+Lemma isaset_list' (A : HSET) : isaset (list' (pr1 A)).
+Proof.
+apply isaset_total2; [apply isasetnat|].
+intro n; induction n; simpl; [apply isasetunit|].
+apply isaset_dirprod; [ apply setproperty | apply IHn ].
+Qed.
+
+Definition to_List (A : HSET) : list' (pr1 A) -> pr1 (List A).
+Proof.
+intros l.
+destruct l as [n l].
+induction n.
++ exact (nil A).
++ apply (cons _ (pr1 l,,IHn (pr2 l))).
+Defined.
+
+Definition to_list' (A : HSET) : pr1 (List A) -> list' (pr1 A).
+Proof.
+apply (foldr A (list' (pr1 A),,isaset_list' A)).
+* apply (0,,tt).
+* intros L.
+  apply (tpair _ (S (pr1 (pr2 L))) (pr1 L,,pr2 (pr2 L))).
+Defined.
+
+Lemma to_list'K (A : HSET) : ∀ x : list' (pr1 A), to_list' A (to_List A x) = x.
+Proof.
+intro l; destruct l as [n l]; unfold to_list', to_List.
+induction n; simpl.
+- rewrite foldr_nil.
+  destruct l.
+  apply idpath.
+- rewrite foldr_cons; simpl.
+  rewrite IHn; simpl; rewrite <- (paireta l).
+  apply idpath.
+Qed.
+
+Lemma to_ListK (A : HSET) : ∀ y : pr1 (List A), to_List A (to_list' A y) = y.
+Proof.
+apply listIndProp.
+* intro l; apply setproperty.
+* unfold to_list'; rewrite foldr_nil.
+  apply idpath.
+* unfold to_list', to_List; intros a l IH.
+  rewrite foldr_cons; simpl.
+  apply maponpaths, maponpaths, pathsinv0.
+  eapply pathscomp0; [eapply pathsinv0, IH|]; simpl.
+  now destruct foldr.
+Qed.
+
+Lemma weq_list' (A : HSET) : list' (pr1 A) ≃ pr1 (List A).
+Proof.
+mkpair.
+- apply to_List.
+- simple refine (gradth _ _ _ _).
+  + apply to_list'.
+  + apply to_list'K.
+  + apply to_ListK.
+Defined.
+
+(* This works: *)
+Eval compute in (to_list' _ testlist).
+
+End list'.
+
 Section lambdacalculus.
 
 Section temp.

--- a/UniMath/CategoryTheory/colimits/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/colimits/polynomialfunctors.v
@@ -193,9 +193,28 @@ Section binprod_functor.
 Variable C : precategory.
 Variables (PC : Products C).
 
-Definition binproduct_functor : functor (product_precategory C C) C.
-Admitted.
+Definition binproduct_functor_data : functor_data (product_precategory C C) C.
+Proof.
+mkpair.
+- intros p.
+  apply (ProductObject _ (PC (pr1 p) (pr2 p))).
+- simpl; intros p q f.
+  apply (ProductOfArrows _ (PC (pr1 q) (pr2 q)) (PC (pr1 p) (pr2 p)) (pr1 f) (pr2 f)).
+Defined.
 
+Definition binproduct_functor : functor (product_precategory C C) C.
+Proof.
+mkpair.
+- apply binproduct_functor_data.
+- split.
+  + intro x; simpl.
+    apply pathsinv0, Product_endo_is_identity.
+    * now rewrite ProductOfArrowsPr1, id_right.
+    * now rewrite ProductOfArrowsPr2, id_right.
+  + now intros x y z f g; simpl; rewrite ProductOfArrows_comp.
+Defined.
+
+(* This is difficult to prove *)
 Lemma omega_cocont_binproduct_functor : omega_cocont binproduct_functor.
 Admitted.
 
@@ -225,11 +244,24 @@ Defined.
 (* Todo: show that delta_functor is left adjoint to product and the use general fact *)
 Lemma cocont_delta_functor (PC : Products C) : is_cocont delta_functor.
 Proof.
-apply left_adjoint_cocont.
+apply left_adjoint_cocont, (tpair _ (binproduct_functor _ PC)).
 mkpair.
-- apply (binproduct_functor _ PC).
-- admit.
-Admitted.
+- split.
+  + mkpair.
+    * simpl; intro x.
+      apply (ProductArrow _ _ (identity x) (identity x)).
+    * abstract (intros p q f; simpl;
+                now rewrite precompWithProductArrow, id_right, postcompWithProductArrow, id_left).
+  + mkpair.
+    * simpl; intro x; split; [ apply ProductPr1 | apply ProductPr2 ].
+    * abstract (intros p q f; unfold prodcatmor, compose; simpl;
+                now rewrite ProductOfArrowsPr1, ProductOfArrowsPr2).
+- split; simpl; intro x.
+  + unfold prodcatmor, compose; simpl.
+    now rewrite ProductPr1Commutes, ProductPr2Commutes.
+  + rewrite postcompWithProductArrow, !id_left.
+    apply pathsinv0, Product_endo_is_identity; [ apply ProductPr1Commutes | apply ProductPr2Commutes ].
+Defined.
 
 Lemma omega_cocont_delta_functor (PC : Products C) : omega_cocont delta_functor.
 Proof.
@@ -245,16 +277,50 @@ Section bincoprod_functor.
 Variable C : precategory.
 Variables (PC : Coproducts C).
 
-Definition bincoproduct_functor : functor (product_precategory C C) C.
-Admitted.
-
-Lemma cocont_bincoproducts_functor: is_cocont bincoproduct_functor.
+Definition bincoproduct_functor_data : functor_data (product_precategory C C) C.
 Proof.
-apply left_adjoint_cocont.
 mkpair.
-- apply delta_functor.
-- admit.
-Admitted.
+- intros p.
+  apply (CoproductObject _ (PC (pr1 p) (pr2 p))).
+- simpl; intros p q f.
+  apply (CoproductOfArrows _ (PC (pr1 p) (pr2 p)) (PC (pr1 q) (pr2 q)) (pr1 f) (pr2 f)).
+Defined.
+
+Definition bincoproduct_functor : functor (product_precategory C C) C.
+Proof.
+mkpair.
+- apply bincoproduct_functor_data.
+- split.
+  + intro x; simpl.
+    apply pathsinv0, Coproduct_endo_is_identity.
+    * now rewrite CoproductOfArrowsIn1, id_left.
+    * now rewrite CoproductOfArrowsIn2, id_left.
+  + now intros x y z f g; simpl; rewrite CoproductOfArrows_comp.
+Defined.
+
+(* TODO: opacify *)
+Lemma cocont_bincoproducts_functor : is_cocont bincoproduct_functor.
+Proof.
+apply left_adjoint_cocont, (tpair _ (delta_functor _)).
+mkpair.
+- split.
+  + mkpair.
+    * simpl; intro p; set (x := pr1 p); set (y := pr2 p).
+      split; [ apply (CoproductIn1 _ (PC x y)) | apply (CoproductIn2 _ (PC x y)) ].
+    * abstract (intros p q f; unfold prodcatmor, compose; simpl;
+                now rewrite CoproductOfArrowsIn1, CoproductOfArrowsIn2).
+  + mkpair.
+    * intro x; apply (CoproductArrow _ _ (identity x) (identity x)).
+    * abstract (intros p q f; simpl;
+                now rewrite precompWithCoproductArrow, postcompWithCoproductArrow,
+                            id_right, id_left).
+- split; simpl; intro x.
+  + rewrite precompWithCoproductArrow, !id_right.
+    apply pathsinv0, Coproduct_endo_is_identity;
+      [ apply CoproductIn1Commutes | apply CoproductIn2Commutes ].
+  + unfold prodcatmor, compose; simpl.
+    now rewrite CoproductIn1Commutes, CoproductIn2Commutes.
+Defined.
 
 Lemma omega_cocont_bincoproduct_functor: omega_cocont bincoproduct_functor.
 Proof.

--- a/UniMath/CategoryTheory/limits/coproducts.v
+++ b/UniMath/CategoryTheory/limits/coproducts.v
@@ -10,6 +10,7 @@ Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.colimits.colimits.
+Require Import UniMath.CategoryTheory.ProductPrecategory.
 
 (** * Definition of binary coproduct of objects in a precategory *)
 Section coproduct_def.
@@ -569,3 +570,38 @@ apply (maponpaths pr1 (Ht X)).
 Defined.
 
 End Coproducts_from_Colims.
+
+Section functors.
+
+Definition bincoproduct_functor_data {C : precategory} (PC : Coproducts C) :
+  functor_data (product_precategory C C) C.
+Proof.
+mkpair.
+- intros p.
+  apply (CoproductObject _ (PC (pr1 p) (pr2 p))).
+- simpl; intros p q f.
+  apply (CoproductOfArrows _ (PC (pr1 p) (pr2 p))
+                             (PC (pr1 q) (pr2 q)) (pr1 f) (pr2 f)).
+Defined.
+
+(* The binary coproduct functor: C * C -> C *)
+Definition bincoproduct_functor {C : precategory} (PC : Coproducts C) :
+  functor (product_precategory C C) C.
+Proof.
+apply (tpair _ (bincoproduct_functor_data PC)).
+abstract (split;
+  [ intro x; simpl; apply pathsinv0, Coproduct_endo_is_identity;
+    [ now rewrite CoproductOfArrowsIn1, id_left
+    | now rewrite CoproductOfArrowsIn2, id_left ]
+  | now intros x y z f g; simpl; rewrite CoproductOfArrows_comp ]).
+Defined.
+
+(* Defines the sum of two functors by:
+    x -> (x,x) -> (F x,G x) -> F x + G x
+*)
+Definition sum_of_functors {C D : precategory} (HD : Coproducts D)
+  (F G : functor C D) : functor C D :=
+  functor_composite (delta_functor C)
+     (functor_composite (pair_functor F G) (bincoproduct_functor HD)).
+
+End functors.

--- a/UniMath/CategoryTheory/limits/products.v
+++ b/UniMath/CategoryTheory/limits/products.v
@@ -8,6 +8,7 @@ Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.colimits.colimits.
 Require Import UniMath.CategoryTheory.limits.limits.
 Require Import UniMath.CategoryTheory.opp_precat.
+Require Import UniMath.CategoryTheory.ProductPrecategory.
 
 Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
 Local Notation "a --> b" := (precategory_morphisms a b)(at level 50).
@@ -275,3 +276,31 @@ Local Notation "c 'x' d" := (ProductObject  c d )(at level 5).
 Check (fun c d : C => c x d).
 *)
 End test.
+
+(* The binary product functor: C * C -> C *)
+Section binproduct_functor.
+
+Context {C : precategory} (PC : Products C).
+
+Definition binproduct_functor_data :
+  functor_data (product_precategory C C) C.
+Proof.
+mkpair.
+- intros p.
+  apply (ProductObject _ (PC (pr1 p) (pr2 p))).
+- simpl; intros p q f.
+  apply (ProductOfArrows _ (PC (pr1 q) (pr2 q))
+                           (PC (pr1 p) (pr2 p)) (pr1 f) (pr2 f)).
+Defined.
+
+Definition binproduct_functor : functor (product_precategory C C) C.
+Proof.
+apply (tpair _ binproduct_functor_data).
+abstract (split;
+  [ intro x; simpl; apply pathsinv0, Product_endo_is_identity;
+    [ now rewrite ProductOfArrowsPr1, id_right
+    | now rewrite ProductOfArrowsPr2, id_right ]
+  | now intros x y z f g; simpl; rewrite ProductOfArrows_comp]).
+Defined.
+
+End binproduct_functor.

--- a/UniMath/CategoryTheory/lists.v
+++ b/UniMath/CategoryTheory/lists.v
@@ -325,11 +325,11 @@ Definition testlistS : pr1 (List natHSET) :=
 Definition sum : pr1 (List natHSET) -> nat :=
   foldr natHSET natHSET 0 (fun xy => pr1 xy + pr2 xy).
 
-Eval vm_compute in length _ (nil natHSET).
-Eval vm_compute in length _ testlist.
-Eval vm_compute in length _ testlistS.
-Eval vm_compute in sum testlist.
-Eval vm_compute in sum testlistS.
+(* Eval vm_compute in length _ (nil natHSET). *)
+(* Eval vm_compute in length _ testlist. *)
+(* Eval vm_compute in length _ testlistS. *)
+(* Eval vm_compute in sum testlist. *)
+(* Eval vm_compute in sum testlistS. *)
 
 Goal length _ testlist = 2.
 vm_compute.
@@ -475,6 +475,6 @@ mkpair.
 Defined.
 
 (* This works: *)
-Eval compute in (to_list' _ testlist).
+(* Eval compute in (to_list' _ testlist). *)
 
 End list'.

--- a/UniMath/CategoryTheory/lists.v
+++ b/UniMath/CategoryTheory/lists.v
@@ -1,0 +1,480 @@
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.total2_paths.
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.colimits.colimits.
+Require Import UniMath.CategoryTheory.category_hset.
+Require Import UniMath.CategoryTheory.category_hset_structures.
+Require Import UniMath.CategoryTheory.limits.initial.
+Require Import UniMath.CategoryTheory.FunctorAlgebras.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseProduct.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseCoproduct.
+Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.limits.coproducts.
+Require Import UniMath.CategoryTheory.limits.terminal.
+Require Import UniMath.CategoryTheory.colimits.chains.
+Require Import UniMath.CategoryTheory.colimits.polynomialfunctors.
+
+Local Notation "# F" := (functor_on_morphisms F) (at level 3).
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
+
+(* The functor "x * F" is omega_cocont. This is only proved for set at the
+   moment as it needs that the category is cartesian closed *)
+Section constprod_functor.
+
+Variables (x : HSET).
+
+Definition constprod_functor : functor HSET HSET :=
+  product_functor HSET HSET ProductsHSET (constant_functor HSET HSET x)
+                                         (functor_identity HSET).
+
+Definition flip {A B C : UU} (f : A -> B -> C) : B -> A -> C := fun x y => f y x.
+
+Lemma omega_cocontConstProdFunctor : omega_cocont constprod_functor.
+Proof.
+intros hF c L ccL HcL cc.
+simple refine (tpair _ _ _).
+- simple refine (tpair _ _ _).
+  + simpl; apply uncurry, flip.
+    apply (colimArrow (mk_ColimCocone _ _ _ ccL) (hset_fun_space x HcL)).
+    simple refine (mk_cocone _ _).
+    * simpl; intro n; apply flip, curry, (pr1 cc).
+    * abstract (destruct cc as [f hf]; simpl; intros m n e;
+                rewrite <- (hf m n e); destruct e; simpl;
+                repeat (apply funextfun; intro); apply idpath).
+  + cbn.
+    abstract (
+    destruct cc as [f hf]; simpl; intro n;
+    apply funextfun; intro p; rewrite (paireta p);
+    generalize (colimArrowCommutes (mk_ColimCocone hF c L ccL) _
+                 (mk_cocone _ (omega_cocontConstProdFunctor_subproof
+                               hF c L ccL HcL (f,,hf))) n);
+    unfold flip, curry, colimIn; simpl; intro H;
+    now rewrite <- (toforallpaths _ _ _ (toforallpaths _ _ _ H (pr2 p)) (pr1 p))).
+- abstract (
+  intro p; unfold uncurry; simpl; apply subtypeEquality; simpl;
+  [ intro g; apply impred; intro t;
+    simple refine (let ff : HSET ⟦(x × dob hF t)%set,HcL⟧ := _ in _);
+    [ simpl; apply (pr1 cc)
+    | apply (@has_homsets_HSET _ HcL _ ff) ]
+  | destruct p as [t p]; simpl;
+    apply funextfun; intro xc; destruct xc as [x' c']; simpl;
+    simple refine (let g : HSET⟦colim (mk_ColimCocone hF c L ccL),
+                                hset_fun_space x HcL⟧ := _ in _);
+    [ simpl; apply flip, curry, t
+    | rewrite <- (colimArrowUnique _ _ _ g); [apply idpath | ];
+      destruct cc as [f hf]; simpl in *;
+      now intro n; simpl; rewrite <- (p n) ]
+  ]).
+Defined.
+
+End constprod_functor.
+
+(* The functor "x + F" is omega_cocont.
+   Assumes that the category has coproducts *)
+Section constcoprod_functor.
+
+Variables (C : precategory) (hsC : has_homsets C) (x : C) (PC : Coproducts C).
+
+Definition constcoprod_functor : functor C C :=
+  coproduct_functor C C PC (constant_functor C C x) (functor_identity C).
+
+Lemma omega_cocontConstCoprodFunctor : omega_cocont constcoprod_functor.
+Proof.
+intros hF c L ccL HcL cc.
+simple refine (tpair _ _ _).
+- simple refine (tpair _ _ _).
+  + eapply CoproductArrow.
+    * exact (CoproductIn1 _ (PC x (dob hF 0)) ;; pr1 cc 0).
+    * simple refine (let ccHcL : cocone hF HcL := _ in _).
+      { simple refine (mk_cocone _ _).
+        - intros n; exact (CoproductIn2 _ (PC x (dob hF n)) ;; pr1 cc n).
+        - abstract (
+            intros m n e; destruct e; simpl;
+            destruct cc as [f hf]; simpl in *; unfold coproduct_functor_ob in *;
+            rewrite <- (hf m _ (idpath _)), !assoc; apply cancel_postcomposition;
+            now unfold coproduct_functor_mor; rewrite CoproductOfArrowsIn2). }
+      apply (pr1 (pr1 (ccL HcL ccHcL))).
+  + abstract (
+    destruct cc as [f hf]; simpl in *; unfold coproduct_functor_ob in *;
+    simpl; intro n; unfold coproduct_functor_mor in *;
+    rewrite precompWithCoproductArrow; apply pathsinv0, CoproductArrowUnique;
+    [ rewrite id_left; induction n; [apply idpath|];
+      now rewrite <- IHn, <- (hf n _ (idpath _)), assoc,
+                  CoproductOfArrowsIn1, id_left
+    | rewrite <- (hf n _ (idpath _)); destruct ccL; destruct t; simpl in *;
+      rewrite p0; apply maponpaths, hf]).
+- abstract (
+  destruct cc as [f hf]; simpl in *; unfold coproduct_functor_ob in *;
+  intro t; apply subtypeEquality; simpl;
+  [ intro g; apply impred; intro; apply hsC
+  | destruct t; destruct ccL; unfold coproduct_functor_mor in *; destruct t0; simpl;
+    apply CoproductArrowUnique;
+    [ now rewrite <- (p 0), assoc, CoproductOfArrowsIn1, id_left
+    | simple refine (let temp : Σ x0 : C ⟦ c, HcL ⟧, ∀ v : nat,
+         coconeIn L v ;; x0 = CoproductIn2 C (PC x (dob hF v)) ;; f v := _ in _);
+         [ apply (tpair _ (CoproductIn2 C (PC x c) ;; t));
+          now intro n; rewrite <- (p n), !assoc, CoproductOfArrowsIn2|];
+      apply (maponpaths pr1 (p0 temp))]]).
+Defined.
+
+End constcoprod_functor.
+
+
+(* Lists as the colimit of a chain given by the list functor: F(X) = 1 + A * X *)
+Section lists.
+
+Variable A : HSET.
+
+(* F(X) = A * X *)
+Definition stream : functor HSET HSET := constprod_functor A.
+
+(* F(X) = 1 + (A * X) *)
+Definition listFunctor : functor HSET HSET :=
+  functor_composite stream (constcoprod_functor _ unitHSET CoproductsHSET).
+
+Lemma omega_cocont_listFunctor : omega_cocont listFunctor.
+Proof.
+apply (omega_cocont_functor_composite has_homsets_HSET).
+- apply omega_cocontConstProdFunctor.
+- apply (omega_cocontConstCoprodFunctor _ has_homsets_HSET).
+Defined.
+
+Lemma listFunctor_Initial :
+  Initial (precategory_FunctorAlg listFunctor has_homsets_HSET).
+Proof.
+apply (colimAlgInitial _ _ _ omega_cocont_listFunctor
+                       InitialHSET (ColimCoconeHSET _ _)).
+Defined.
+
+Definition List : HSET :=
+  (* colim (ColimCoconeHSET nat_graph (initChain InitialHSET listFunctor)). *)
+  alg_carrier _ (InitialObject listFunctor_Initial).
+Opaque List.
+Let List_mor : HSET⟦listFunctor List,List⟧ :=
+  alg_map _ (InitialObject listFunctor_Initial).
+Opaque List_mor.
+Let List_alg : algebra_ob listFunctor :=
+  InitialObject listFunctor_Initial.
+Opaque List_alg.
+
+Definition nil_map : HSET⟦unitHSET,List⟧.
+Proof.
+simpl; intro x.
+apply List_mor, inl, x.
+Defined.
+
+Definition nil : pr1 List := nil_map tt.
+
+Definition cons_map : HSET⟦(A × List)%set,List⟧.
+Proof.
+intros xs.
+apply List_mor, (inr xs).
+Defined.
+
+Definition cons : pr1 A × pr1 List -> pr1 List := cons_map.
+
+(* Get recursion/iteration scheme: *)
+
+(*    x : X           f : A × X -> X *)
+(* ------------------------------------ *)
+(*       foldr x f : List A -> X *)
+
+Definition mk_listAlgebra (X : HSET) (x : pr1 X)
+  (f : HSET⟦(A × X)%set,X⟧) : algebra_ob listFunctor.
+Proof.
+set (x' := λ (_ : unit), x).
+apply (tpair _ X (sumofmaps x' f) : algebra_ob listFunctor).
+Defined.
+
+Definition foldr_map (X : HSET) (x : pr1 X) (f : HSET⟦(A × X)%set,X⟧) :
+  algebra_mor _ List_alg (mk_listAlgebra X x f).
+Proof.
+apply (InitialArrow listFunctor_Initial (mk_listAlgebra X x f)).
+Defined.
+Opaque foldr_map.
+
+Definition foldr (X : HSET) (x : pr1 X)
+  (f : pr1 A × pr1 X -> pr1 X) : pr1 List -> pr1 X.
+Proof.
+apply (foldr_map _ x f).
+Defined.
+Opaque foldr.
+
+(* Maybe quantify over "λ _ : unit, x" instead of nil? *)
+Lemma foldr_nil (X : hSet) (x : X) (f : pr1 A × X -> X) : foldr X x f nil = x.
+Proof.
+assert (F := maponpaths (fun x => CoproductIn1 _ _ ;; x)
+                        (algebra_mor_commutes _ _ _ (foldr_map X x f))).
+apply (toforallpaths _ _ _ F tt).
+Qed.
+
+Lemma foldr_cons (X : hSet) (x : X) (f : pr1 A × X -> X)
+                 (a : pr1 A) (l : pr1 List) :
+  foldr X x f (cons (a,,l)) = f (a,,foldr X x f l).
+Proof.
+assert (F := maponpaths (fun x => CoproductIn2 _ _ ;; x)
+                        (algebra_mor_commutes _ _ _ (foldr_map X x f))).
+assert (Fal := toforallpaths _ _ _ F (a,,l)).
+clear F.
+(* apply Fal. *) (* This doesn't work here. why? *)
+unfold compose in Fal.
+simpl in Fal.
+apply Fal.
+Qed. (* This Qed is slow! *)
+
+(* This defines the induction principle for lists using foldr *)
+Section list_induction.
+
+Variables (P : pr1 List -> UU) (PhSet : forall l, isaset (P l)).
+Variables (P0 : P nil)
+          (Pc : forall (a : pr1 A) (l : pr1 List), P l -> P (cons (a,,l))).
+
+Let P' : UU := Σ l, P l.
+Let P0' : P' := (nil,, P0).
+Let Pc' : pr1 A × P' -> P' :=
+  λ ap : pr1 A × P', cons (pr1 ap,, pr1 (pr2 ap)),,Pc (pr1 ap) (pr1 (pr2 ap)) (pr2 (pr2 ap)).
+
+Definition P'HSET : HSET.
+Proof.
+apply (tpair _ P').
+abstract (apply (isofhleveltotal2 2); [ apply setproperty | intro x; apply PhSet ]).
+Defined.
+
+Lemma isalghom_pr1foldr :
+  is_algebra_mor _ List_alg List_alg (fun l => pr1 (foldr P'HSET P0' Pc' l)).
+Proof.
+apply CoproductArrow_eq_cor.
+- apply funextfun; intro x; destruct x; apply idpath.
+- apply funextfun; intro x; destruct x as [a l].
+  apply (maponpaths pr1 (foldr_cons P'HSET P0' Pc' a l)).
+Qed.
+
+Definition pr1foldr_algmor : algebra_mor _ List_alg List_alg :=
+  tpair _ _ isalghom_pr1foldr.
+
+Lemma pr1foldr_algmor_identity : identity _ = pr1foldr_algmor.
+Proof.
+now rewrite <- (InitialEndo_is_identity _ listFunctor_Initial pr1foldr_algmor).
+Qed.
+
+Lemma listInd l : P l.
+Proof.
+assert (H : pr1 (foldr P'HSET P0' Pc' l) = l).
+  apply (toforallpaths _ _ _ (!pr1foldr_algmor_identity) l).
+rewrite <- H.
+apply (pr2 (foldr P'HSET P0' Pc' l)).
+Defined.
+
+End list_induction.
+
+Lemma listIndProp (P : pr1 List -> UU) (HP : forall l, isaprop (P l)) :
+  P nil -> (forall a l, P l → P (cons (a,, l))) -> forall l, P l.
+Proof.
+intros Pnil Pcons.
+apply listInd; try assumption.
+intro l; apply isasetaprop, HP.
+Defined.
+
+Require Import UniMath.Foundations.NumberSystems.NaturalNumbers.
+
+Definition natHSET : HSET.
+Proof.
+exists nat.
+abstract (apply isasetnat).
+Defined.
+
+Definition length : pr1 List -> nat :=
+  foldr natHSET 0 (fun x => S (pr2 x)).
+
+Definition map (f : pr1 A -> pr1 A) : pr1 List -> pr1 List :=
+  foldr _ nil (λ xxs : pr1 A × pr1 List, cons (f (pr1 xxs),, pr2 xxs)).
+
+Lemma length_map (f : pr1 A -> pr1 A) : forall xs, length (map f xs) = length xs.
+Proof.
+apply listIndProp.
+- intros l; apply isasetnat.
+- apply idpath.
+- simpl; unfold map, length; simpl; intros a l Hl.
+  simpl.
+  now rewrite !foldr_cons, <- Hl.
+Qed.
+
+End lists.
+
+Opaque List.
+(* Opaque foldr. *) (* makes "cbn" and "compute" in the computation below fail *)
+
+(* Some examples of computations with lists over nat *)
+Section nat_examples.
+
+Definition cons_nat a l : pr1 (List natHSET) := cons natHSET (a,,l).
+
+Infix "::" := cons_nat.
+Notation "[]" := (nil natHSET) (at level 0, format "[]").
+
+Definition testlist : pr1 (List natHSET) := 5 :: 2 :: [].
+
+Definition testlistS : pr1 (List natHSET) :=
+  map natHSET S testlist.
+
+Definition sum : pr1 (List natHSET) -> nat :=
+  foldr natHSET natHSET 0 (fun xy => pr1 xy + pr2 xy).
+
+Eval vm_compute in length _ (nil natHSET).
+Eval vm_compute in length _ testlist.
+Eval vm_compute in length _ testlistS.
+Eval vm_compute in sum testlist.
+Eval vm_compute in sum testlistS.
+
+Goal length _ testlist = 2.
+vm_compute.
+Restart.
+cbn.
+Restart.
+compute.  (* does not work when foldr is opaque with "Opaque foldr." *)
+Restart.
+cbv.   (* does not work when foldr is opaque with "Opaque foldr." *)
+Restart.
+native_compute.
+Abort.
+
+Goal (forall l, length _ (2 :: l) = S (length _ l)).
+simpl.
+intro l.
+try apply idpath. (* this doesn't work *)
+unfold length, cons_nat.
+rewrite foldr_cons. cbn.
+apply idpath.
+Abort.
+
+(* some experiments: *)
+
+(* Definition const {A B : UU} : A -> B -> A := fun x _ => x. *)
+
+(* Eval compute in const 0 (nil natHSET). *)
+
+(* Axiom const' : forall {A B : UU}, A -> B -> A. *)
+
+(* Eval compute in const' 0 1. *)
+(* Eval compute in const' 0 (nil natHSET). *)
+
+(* Time Eval vm_compute in nil natHSET.  (* This crashes my computer by using up all memory *) *)
+
+End nat_examples.
+
+(* Inductive list A : UU := *)
+(*   | nilA : list A *)
+(*   | consA : A -> list A -> list A. *)
+
+(* Fixpoint lengthA (A : UU) (xs : list A) : nat := match xs with *)
+(*   | nilA _ => 0 *)
+(*   | consA _ _ xs' => S (lengthA _ xs') *)
+(*   end. *)
+
+(* Goal (forall l, lengthA nat (consA _ 2 l) = S (lengthA nat l)). *)
+(* intro l. *)
+(* apply idpath. *)
+(* Abort. *)
+
+(* Alternative and more general definition of lists (inspired by a remark of VV) *)
+Section list'.
+
+(* I think if you really need lists you should prove a theorem that
+establishes a weq between the lists that you have defined and lists
+defined as total2 ( fun n : nat => iterprod n A ) where iterprod n A
+is defined by induction such that iterprod 0 A = unit, iterprod 1 A =
+A and iterprod ( S n ) A = dirprod (iterprod n A) A for n=S n’. *)
+
+Fixpoint iterprod (n : nat) (A : UU) : UU := match n with
+  | O => unit
+  | S n' => dirprod A (iterprod n' A)
+  end.
+
+Definition list' (A : UU) := total2 (fun n => iterprod n A).
+
+Definition nil_list' (A : UU) : list' A := (0,,tt).
+Definition cons_list' (A : UU) (x : A) (xs : list' A) : list' A :=
+  (S (pr1 xs),, (x,, pr2 xs)).
+
+Lemma list'_ind : ∀ (A : Type) (P : list' A -> UU),
+    P (nil_list' A)
+  -> (∀ (x : A) (xs : list' A), P xs -> P (cons_list' A x xs))
+  -> ∀ xs, P xs.
+Proof.
+intros A P Hnil Hcons xs.
+destruct xs as [n xs].
+induction n.
+- destruct xs.
+  apply Hnil.
+- destruct xs as [x xs].
+  apply (Hcons x (n,,xs) (IHn xs)).
+Qed.
+
+Lemma isaset_list' (A : HSET) : isaset (list' (pr1 A)).
+Proof.
+apply isaset_total2; [apply isasetnat|].
+intro n; induction n; simpl; [apply isasetunit|].
+apply isaset_dirprod; [ apply setproperty | apply IHn ].
+Qed.
+
+Definition to_List (A : HSET) : list' (pr1 A) -> pr1 (List A).
+Proof.
+intros l.
+destruct l as [n l].
+induction n.
++ exact (nil A).
++ apply (cons _ (pr1 l,,IHn (pr2 l))).
+Defined.
+
+Definition to_list' (A : HSET) : pr1 (List A) -> list' (pr1 A).
+Proof.
+apply (foldr A (list' (pr1 A),,isaset_list' A)).
+* apply (0,,tt).
+* intros L.
+  apply (tpair _ (S (pr1 (pr2 L))) (pr1 L,,pr2 (pr2 L))).
+Defined.
+
+Lemma to_list'K (A : HSET) : ∀ x : list' (pr1 A), to_list' A (to_List A x) = x.
+Proof.
+intro l; destruct l as [n l]; unfold to_list', to_List.
+induction n; simpl.
+- rewrite foldr_nil.
+  destruct l.
+  apply idpath.
+- rewrite foldr_cons; simpl.
+  rewrite IHn; simpl; rewrite <- (paireta l).
+  apply idpath.
+Qed.
+
+Lemma to_ListK (A : HSET) : ∀ y : pr1 (List A), to_List A (to_list' A y) = y.
+Proof.
+apply listIndProp.
+* intro l; apply setproperty.
+* unfold to_list'; rewrite foldr_nil.
+  apply idpath.
+* unfold to_list', to_List; intros a l IH.
+  rewrite foldr_cons; simpl.
+  apply maponpaths, maponpaths, pathsinv0.
+  eapply pathscomp0; [eapply pathsinv0, IH|]; simpl.
+  now destruct foldr.
+Qed.
+
+Lemma weq_list' (A : HSET) : list' (pr1 A) ≃ pr1 (List A).
+Proof.
+mkpair.
+- apply to_List.
+- simple refine (gradth _ _ _ _).
+  + apply to_list'.
+  + apply to_list'K.
+  + apply to_ListK.
+Defined.
+
+(* This works: *)
+Eval compute in (to_list' _ testlist).
+
+End list'.


### PR DESCRIPTION
Proofs that some more functors are (omega) cocontinuous.

Proof that left adjoints preserve colimits.

The equivalence between Voevodsky's definition of lists (as iterated products) and our lists over sets (as the initial algebra of the list functor).

