### PR TITLE
remove unicode arrow '⇒' for morphisms in CT

### DIFF
--- a/UniMath/CategoryTheory/AdjunctionHomTypesWeq.v
+++ b/UniMath/CategoryTheory/AdjunctionHomTypesWeq.v
@@ -45,15 +45,15 @@ Let ε := counit_from_left_adjoint H.
 
 (** * Definition of the maps on hom-types *)
 
-Definition φ_adj {A : C} {B : D} : F A ⇒ B → A ⇒ G B
-  := λ f : F A ⇒ B, η _ ;; #G f.
+Definition φ_adj {A : C} {B : D} : F A --> B → A --> G B
+  := λ f : F A --> B, η _ ;; #G f.
 
-Definition φ_adj_inv {A : C} {B : D} : A ⇒ G B → F A ⇒ B
-  := λ g : A ⇒ G B, #F g ;; ε _ .
+Definition φ_adj_inv {A : C} {B : D} : A --> G B → F A --> B
+  := λ g : A --> G B, #F g ;; ε _ .
 
 (** * Proof that those maps are inverse to each other *)
 
-Lemma φ_adj_after_φ_adj_inv {A : C} {B : D} (g : A ⇒ G B)
+Lemma φ_adj_after_φ_adj_inv {A : C} {B : D} (g : A --> G B)
   : φ_adj (φ_adj_inv g) = g.
 Proof.
   unfold φ_adj.
@@ -70,7 +70,7 @@ Proof.
   - apply id_right.
 Qed.
 
-Lemma φ_adj_inv_after_φ_adj {A : C} {B : D} (f : F A ⇒ B)
+Lemma φ_adj_inv_after_φ_adj {A : C} {B : D} (f : F A --> B)
   : φ_adj_inv (φ_adj f) = f.
 Proof.
   unfold φ_adj, φ_adj_inv.
@@ -85,7 +85,7 @@ Proof.
   - apply id_left.
 Qed.
 
-Definition adjunction_hom_weq (A : C) (B : D) : F A ⇒ B ≃ A ⇒ G B.
+Definition adjunction_hom_weq (A : C) (B : D) : F A --> B ≃ A --> G B.
 Proof.
   exists φ_adj.
   apply (gradth _ φ_adj_inv).
@@ -95,7 +95,7 @@ Defined.
 
 (** * Proof of the equations (naturality squares) of the adjunction *)
 
-Lemma φ_adj_natural_precomp (A : C) (B : D) (f : F A ⇒ B) (X : C) (h : X ⇒ A)
+Lemma φ_adj_natural_precomp (A : C) (B : D) (f : F A --> B) (X : C) (h : X --> A)
   : φ_adj (#F h ;; f) = h ;; φ_adj f.
 Proof.
   unfold φ_adj.
@@ -106,7 +106,7 @@ Proof.
   apply pathsinv0, assoc.
 Qed.
 
-Lemma φ_adj_natural_postcomp (A : C) (B : D) (f : F A ⇒ B) (Y : D) (k : B ⇒ Y)
+Lemma φ_adj_natural_postcomp (A : C) (B : D) (f : F A --> B) (Y : D) (k : B --> Y)
   : φ_adj (f ;; k) = φ_adj f ;; #G k.
 Proof.
   unfold φ_adj.
@@ -115,7 +115,7 @@ Proof.
   apply (functor_comp G).
 Qed.
 
-Lemma φ_adj_inv_natural_precomp (A : C) (B : D) (g : A ⇒ G B) (X : C) (h : X ⇒ A)
+Lemma φ_adj_inv_natural_precomp (A : C) (B : D) (g : A --> G B) (X : C) (h : X --> A)
   : φ_adj_inv (h ;; g) = #F h ;; φ_adj_inv g.
 Proof.
   unfold φ_adj_inv.
@@ -123,7 +123,7 @@ Proof.
   apply pathsinv0, assoc.
 Qed.
 
-Lemma φ_adj_inv_natural_postcomp (A : C) (B : D) (g : A ⇒ G B) (Y : D) (k : B ⇒ Y)
+Lemma φ_adj_inv_natural_postcomp (A : C) (B : D) (g : A --> G B) (Y : D) (k : B --> Y)
   : φ_adj_inv (g ;; #G k) = φ_adj_inv g ;; k.
 Proof.
   unfold φ_adj_inv.

--- a/UniMath/CategoryTheory/FunctorAlgebras.v
+++ b/UniMath/CategoryTheory/FunctorAlgebras.v
@@ -37,7 +37,7 @@ Section Algebra_Definition.
 
 Context {C : precategory} (F : functor C C).
 
-Definition algebra_ob : UU := Σ X : C, F X ⇒ X.
+Definition algebra_ob : UU := Σ X : C, F X --> X.
 
 (* this coercion causes confusion, and it is not inserted when parsing most of the time
    thus removing coercion globally
@@ -45,15 +45,15 @@ Definition algebra_ob : UU := Σ X : C, F X ⇒ X.
 Definition alg_carrier (X : algebra_ob) : C := pr1 X.
 Local Coercion alg_carrier : algebra_ob >-> ob.
 
-Definition alg_map (X : algebra_ob) : F X ⇒ X := pr2 X.
+Definition alg_map (X : algebra_ob) : F X --> X := pr2 X.
 
-Definition is_algebra_mor (X Y : algebra_ob) (f : alg_carrier X ⇒ alg_carrier Y) : UU
+Definition is_algebra_mor (X Y : algebra_ob) (f : alg_carrier X --> alg_carrier Y) : UU
   := alg_map X ;; f = #F f ;; alg_map Y.
 
 Definition algebra_mor (X Y : algebra_ob) : UU :=
-  Σ f : X ⇒ Y, is_algebra_mor X Y f.
+  Σ f : X --> Y, is_algebra_mor X Y f.
 
-Coercion mor_from_algebra_mor (X Y : algebra_ob) (f : algebra_mor X Y) : X ⇒ Y := pr1 f.
+Coercion mor_from_algebra_mor (X Y : algebra_ob) (f : algebra_mor X Y) : X --> Y := pr1 f.
 
 Definition isaset_algebra_mor (hs : has_homsets C) (X Y : algebra_ob) : isaset (algebra_mor X Y).
 Proof.
@@ -65,7 +65,7 @@ Proof.
 Qed.
 
 Definition algebra_mor_eq (hs : has_homsets C) {X Y : algebra_ob} {f g : algebra_mor X Y}
-  : (f : X ⇒ Y) = g ≃ f = g.
+  : (f : X --> Y) = g ≃ f = g.
 Proof.
   apply invweq.
   apply subtypeInjectivity.
@@ -172,7 +172,7 @@ Proof.
     + apply (pr2 H).
 Defined.
 
-Definition is_iso_from_is_algebra_iso (X Y : FunctorAlg (pr2 H)) (f : X ⇒ Y)
+Definition is_iso_from_is_algebra_iso (X Y : FunctorAlg (pr2 H)) (f : X --> Y)
   : is_iso f → is_iso (pr1 f).
 Proof.
   intro p.
@@ -185,8 +185,8 @@ Proof.
   - apply (maponpaths pr1 H'').
 Defined.
 
-Definition inv_algebra_mor_from_is_iso {X Y : FunctorAlg (pr2 H)} (f : X ⇒ Y)
-  : is_iso (pr1 f) → (Y ⇒ X).
+Definition inv_algebra_mor_from_is_iso {X Y : FunctorAlg (pr2 H)} (f : X --> Y)
+  : is_iso (pr1 f) → (Y --> X).
 Proof.
   intro T.
   set (fiso:=isopair (pr1 f) T).
@@ -204,7 +204,7 @@ Proof.
   apply (pr2 f).
 Defined.
 
-Definition is_algebra_iso_from_is_iso {X Y : FunctorAlg (pr2 H)} (f : X ⇒ Y)
+Definition is_algebra_iso_from_is_iso {X Y : FunctorAlg (pr2 H)} (f : X --> Y)
   : is_iso (pr1 f) → is_iso f.
 Proof.
   intro T.
@@ -221,7 +221,7 @@ Proof.
 Defined.
 
 Definition algebra_iso_first_iso {X Y : FunctorAlg (pr2 H)}
-  : iso X Y ≃ Σ f : X ⇒ Y, is_iso (pr1 f).
+  : iso X Y ≃ Σ f : X --> Y, is_iso (pr1 f).
 Proof.
   apply (weqbandf (idweq _ )).
   intro f.
@@ -248,7 +248,7 @@ Proof.
 Defined.
 
 Definition algebra_iso_rearrange {X Y : FunctorAlg (pr2 H)}
-  : (Σ f : X ⇒ Y, is_iso (pr1 f)) ≃ algebra_eq_type X Y.
+  : (Σ f : X --> Y, is_iso (pr1 f)) ≃ algebra_eq_type X Y.
 Proof.
   eapply weqcomp.
   - apply weqtotal2asstor.

--- a/UniMath/CategoryTheory/HorizontalComposition.v
+++ b/UniMath/CategoryTheory/HorizontalComposition.v
@@ -79,7 +79,7 @@ Proof.
 Qed.
 
 Lemma horcomp_id_postwhisker (A B C : precategory)
-   (hsB : has_homsets B) (hsC : has_homsets C) (X X' : [A, B, hsB]) (α : X ⇒ X')
+   (hsB : has_homsets B) (hsC : has_homsets C) (X X' : [A, B, hsB]) (α : X --> X')
    (Z : [B ,C, hsC])
   : hor_comp α (nat_trans_id _ ) = post_whisker α Z.
 Proof.

--- a/UniMath/CategoryTheory/PointedFunctors.v
+++ b/UniMath/CategoryTheory/PointedFunctors.v
@@ -119,7 +119,7 @@ Proof.
   exact (nat_trans_id _ ).
 Defined.
 
-Lemma eq_ptd_mor_precat {F G : precategory_Ptd} (a b : F ⇒ G)
+Lemma eq_ptd_mor_precat {F G : precategory_Ptd} (a b : F --> G)
   : a = b ≃ (a : ptd_mor F G) = b.
 Proof.
   simple refine (tpair _ _ _).

--- a/UniMath/CategoryTheory/ProductPrecategory.v
+++ b/UniMath/CategoryTheory/ProductPrecategory.v
@@ -42,7 +42,7 @@ Variables C D : precategory.
 Definition product_precategory_ob_mor : precategory_ob_mor.
 Proof.
   exists (C × D).
-  exact (λ cd cd', pr1 cd ⇒ pr1 cd' × pr2 cd ⇒ pr2 cd').
+  exact (λ cd cd', pr1 cd --> pr1 cd' × pr2 cd --> pr2 cd').
 Defined.
 
 Definition product_precategory_data : precategory_data.
@@ -82,7 +82,7 @@ Variable F: functor product_precategory E.
 Variable d: D.
 
 Definition functor_fix_snd_arg_ob (c:C): E := F(tpair _ c d).
-Definition functor_fix_snd_arg_mor (c c':C)(f: c ⇒ c'): functor_fix_snd_arg_ob c ⇒ functor_fix_snd_arg_ob c'.
+Definition functor_fix_snd_arg_mor (c c':C)(f: c --> c'): functor_fix_snd_arg_ob c --> functor_fix_snd_arg_ob c'.
 Proof.
   apply (#F).
   split; simpl.
@@ -135,7 +135,7 @@ Variable F F': functor product_precategory E.
 Variable α: F ⟶ F'.
 Variable d: D.
 
-Definition nat_trans_fix_snd_arg_data (c:C): functor_fix_snd_arg E F d c ⇒ functor_fix_snd_arg E F' d c := α (tpair _ c d).
+Definition nat_trans_fix_snd_arg_data (c:C): functor_fix_snd_arg E F d c --> functor_fix_snd_arg E F' d c := α (tpair _ c d).
 
 Lemma nat_trans_fix_snd_arg_ax: is_nat_trans _ _ nat_trans_fix_snd_arg_data.
 Proof.
@@ -166,8 +166,8 @@ Defined.
 
 Local Notation "A ⊗ B" := (prodcatpair A B) (at level 10).
 
-Definition prodcatmor {C D : precategory} {X X' : C} {Z Z' : D} (α : X ⇒ X') (β : Z ⇒ Z')
-  : X ⊗ Z ⇒ X' ⊗ Z'.
+Definition prodcatmor {C D : precategory} {X X' : C} {Z Z' : D} (α : X --> X') (β : Z --> Z')
+  : X ⊗ Z --> X' ⊗ Z'.
 Proof.
   exists α.
   exact β.

--- a/UniMath/CategoryTheory/UnicodeNotations.v
+++ b/UniMath/CategoryTheory/UnicodeNotations.v
@@ -7,8 +7,7 @@ Notation "x → y" := (x -> y)
   (at level 90, y at level 200, right associativity): type_scope.
 (* written \to in Agda input method *)
 
-Notation "a ⇒ b" := (precategory_morphisms a b)(at level 50).
-  (* \=> in Agda input method *)
+Notation "a --> b" := (precategory_morphisms a b)(at level 50).
 
 Notation "f ;; g" := (compose f g) (at level 50, format "f  ;;  g", left associativity).
 Notation "# F" := (functor_on_morphisms F) (at level 3).

--- a/UniMath/CategoryTheory/colimits/colimits.v
+++ b/UniMath/CategoryTheory/colimits/colimits.v
@@ -249,7 +249,7 @@ now intro u; rewrite assoc, colimArrowCommutes.
 Qed.
 
 Lemma colim_endo_is_identity {g : graph} (D : diagram g C)
-  (CC : ColimCocone D) (k : colim CC ⇒ colim CC)
+  (CC : ColimCocone D) (k : colim CC --> colim CC)
   (H : ∀ u, colimIn CC u ;; k = colimIn CC u) :
   identity _ = k.
 Proof.

--- a/UniMath/CategoryTheory/limits/FunctorsPointwiseCoproduct.v
+++ b/UniMath/CategoryTheory/limits/FunctorsPointwiseCoproduct.v
@@ -52,8 +52,8 @@ Local Notation "c ⊗ d" := (CoproductObject _ (HD c d))(at level 45).
 
 Definition coproduct_functor_ob (c : C) : D := F c ⊗ G c.
 
-Definition coproduct_functor_mor (c c' : C) (f : c ⇒ c')
-  : coproduct_functor_ob c ⇒ coproduct_functor_ob c'
+Definition coproduct_functor_mor (c c' : C) (f : c --> c')
+  : coproduct_functor_ob c --> coproduct_functor_ob c'
   := CoproductOfArrows _ _ _ (#F f) (#G f).
 
 Definition coproduct_functor_data : functor_data C D.
@@ -108,7 +108,7 @@ Qed.
 
 Definition coproduct_functor : functor C D := tpair _ _ is_functor_coproduct_functor_data.
 
-Definition coproduct_nat_trans_in1_data : ∀ c, F c ⇒ coproduct_functor c
+Definition coproduct_nat_trans_in1_data : ∀ c, F c --> coproduct_functor c
   := λ c : C, CoproductIn1 _ (HD (F c) (G c)).
 
 Lemma is_nat_trans_coproduct_nat_trans_in1_data
@@ -129,7 +129,7 @@ Qed.
 Definition coproduct_nat_trans_in1 : nat_trans _ _
   := tpair _ _ is_nat_trans_coproduct_nat_trans_in1_data.
 
-Definition coproduct_nat_trans_in2_data : ∀ c, G c ⇒ coproduct_functor c
+Definition coproduct_nat_trans_in2_data : ∀ c, G c --> coproduct_functor c
   := λ c : C, CoproductIn2 _ (HD (F c) (G c)).
 
 Lemma is_nat_trans_coproduct_nat_trans_in2_data
@@ -159,7 +159,7 @@ Variable A : functor C D.
 Variable f : F ⟶ A.
 Variable g : G ⟶ A.
 
-Definition coproduct_nat_trans_data : ∀ c, coproduct_functor c ⇒ A c.
+Definition coproduct_nat_trans_data : ∀ c, coproduct_functor c --> A c.
 Proof.
   intro c.
   apply CoproductArrow.
@@ -212,18 +212,18 @@ End vertex.
 
 
 Lemma coproduct_nat_trans_univ_prop (A : [C, D, hsD])
-  (f : (F : [C,D,hsD]) ⇒ A) (g : (G : [C,D,hsD]) ⇒ A) :
+  (f : (F : [C,D,hsD]) --> A) (g : (G : [C,D,hsD]) --> A) :
    ∀
-   t : Σ fg : (coproduct_functor:[C,D,hsD]) ⇒ A,
-       (coproduct_nat_trans_in1 : (F:[C,D,hsD]) ⇒ coproduct_functor);; fg = f
+   t : Σ fg : (coproduct_functor:[C,D,hsD]) --> A,
+       (coproduct_nat_trans_in1 : (F:[C,D,hsD]) --> coproduct_functor);; fg = f
       ×
-       (coproduct_nat_trans_in2: (G : [C,D,hsD]) ⇒ coproduct_functor);; fg = g,
+       (coproduct_nat_trans_in2: (G : [C,D,hsD]) --> coproduct_functor);; fg = g,
    t =
    tpair
-     (λ fg : (coproduct_functor:[C,D,hsD]) ⇒ A,
-      (coproduct_nat_trans_in1 : (F:[C,D,hsD]) ⇒ coproduct_functor);; fg = f
+     (λ fg : (coproduct_functor:[C,D,hsD]) --> A,
+      (coproduct_nat_trans_in1 : (F:[C,D,hsD]) --> coproduct_functor);; fg = f
    ×
-      (coproduct_nat_trans_in2 : (G:[C,D,hsD]) ⇒ coproduct_functor) ;; fg = g)
+      (coproduct_nat_trans_in2 : (G:[C,D,hsD]) --> coproduct_functor) ;; fg = g)
      (coproduct_nat_trans A f g)
      (dirprodpair (coproduct_nat_trans_In1Commutes A f g)
         (coproduct_nat_trans_In2Commutes A f g)).

--- a/UniMath/CategoryTheory/limits/FunctorsPointwiseProduct.v
+++ b/UniMath/CategoryTheory/limits/FunctorsPointwiseProduct.v
@@ -53,8 +53,8 @@ Local Notation "c ⊗ d" := (ProductObject _ (HD c d))(at level 45).
 
 Definition product_functor_ob (c : C) : D := F c ⊗ G c.
 
-Definition product_functor_mor (c c' : C) (f : c ⇒ c')
-  : product_functor_ob c ⇒ product_functor_ob c'
+Definition product_functor_mor (c c' : C) (f : c --> c')
+  : product_functor_ob c --> product_functor_ob c'
   := ProductOfArrows _ _ _ (#F f) (#G f).
 
 Definition product_functor_data : functor_data C D.
@@ -86,7 +86,7 @@ Qed.
 
 Definition product_functor : functor C D := tpair _ _ is_functor_product_functor_data.
 
-Definition product_nat_trans_pr1_data : ∀ c, product_functor c ⇒ F c
+Definition product_nat_trans_pr1_data : ∀ c, product_functor c --> F c
   := λ c : C, ProductPr1 _ (HD (F c) (G c)).
 
 Lemma is_nat_trans_product_nat_trans_pr1_data
@@ -104,7 +104,7 @@ Definition product_nat_trans_pr1 : nat_trans _ _
   := tpair _ _ is_nat_trans_product_nat_trans_pr1_data.
 
 
-Definition product_nat_trans_pr2_data : ∀ c, product_functor c ⇒ G c
+Definition product_nat_trans_pr2_data : ∀ c, product_functor c --> G c
   := λ c : C, ProductPr2 _ (HD (F c) (G c)).
 
 Lemma is_nat_trans_product_nat_trans_pr2_data
@@ -130,7 +130,7 @@ Variable A : functor C D.
 Variable f : A ⟶ F.
 Variable g : A ⟶ G.
 
-Definition product_nat_trans_data : ∀ c,  A c ⇒ product_functor c.
+Definition product_nat_trans_data : ∀ c,  A c --> product_functor c.
 Proof.
   intro c.
   apply ProductArrow.
@@ -181,18 +181,18 @@ Qed.
 End vertex.
 
 Lemma product_nat_trans_univ_prop (A : [C, D, hsD])
-  (f : (A ⇒ (F:[C,D,hsD]))) (g : A ⇒ (G:[C,D,hsD])) :
+  (f : (A --> (F:[C,D,hsD]))) (g : A --> (G:[C,D,hsD])) :
    ∀
-   t : Σ fg : A ⇒ (product_functor:[C,D,hsD]),
-       fg ;; (product_nat_trans_pr1 : (product_functor:[C,D,hsD]) ⇒ F) = f
+   t : Σ fg : A --> (product_functor:[C,D,hsD]),
+       fg ;; (product_nat_trans_pr1 : (product_functor:[C,D,hsD]) --> F) = f
       ×
-       fg ;; (product_nat_trans_pr2 : (product_functor:[C,D,hsD]) ⇒ G) = g,
+       fg ;; (product_nat_trans_pr2 : (product_functor:[C,D,hsD]) --> G) = g,
    t =
    tpair
-     (λ fg : A ⇒ (product_functor:[C,D,hsD]),
-      fg ;; (product_nat_trans_pr1 : (product_functor:[C,D,hsD]) ⇒ F) = f
+     (λ fg : A --> (product_functor:[C,D,hsD]),
+      fg ;; (product_nat_trans_pr1 : (product_functor:[C,D,hsD]) --> F) = f
    ×
-      fg ;; (product_nat_trans_pr2 : (product_functor:[C,D,hsD]) ⇒ G) = g)
+      fg ;; (product_nat_trans_pr2 : (product_functor:[C,D,hsD]) --> G) = g)
      (product_nat_trans A f g)
      (dirprodpair (product_nat_trans_Pr1Commutes A f g)
         (product_nat_trans_Pr2Commutes A f g)).

--- a/UniMath/CategoryTheory/limits/coproducts.v
+++ b/UniMath/CategoryTheory/limits/coproducts.v
@@ -17,12 +17,12 @@ Section coproduct_def.
 
 Variable C : precategory.
 
-Definition isCoproductCocone (a b co : C) (ia : a ⇒ co) (ib : b ⇒ co) :=
-  ∀ (c : C) (f : a ⇒ c) (g : b ⇒ c),
-    iscontr (Σ fg : co ⇒ c, (ia ;; fg = f) × (ib ;; fg = g)).
+Definition isCoproductCocone (a b co : C) (ia : a --> co) (ib : b --> co) :=
+  ∀ (c : C) (f : a --> c) (g : b --> c),
+    iscontr (Σ fg : co --> c, (ia ;; fg = f) × (ib ;; fg = g)).
 
 Definition CoproductCocone (a b : C) :=
-   Σ coiaib : (Σ co : C, a ⇒ co × b ⇒ co),
+   Σ coiaib : (Σ co : C, a --> co × b --> co),
           isCoproductCocone a b (pr1 coiaib) (pr1 (pr2 coiaib)) (pr2 (pr2 coiaib)).
 
 
@@ -30,9 +30,9 @@ Definition Coproducts := ∀ (a b : C), CoproductCocone a b.
 Definition hasCoproducts := ishinh Coproducts.
 
 Definition CoproductObject {a b : C} (CC : CoproductCocone a b) : C := pr1 (pr1 CC).
-Definition CoproductIn1 {a b : C} (CC : CoproductCocone a b): a ⇒ CoproductObject CC :=
+Definition CoproductIn1 {a b : C} (CC : CoproductCocone a b): a --> CoproductObject CC :=
   pr1 (pr2 (pr1 CC)).
-Definition CoproductIn2 {a b : C} (CC : CoproductCocone a b) : b ⇒ CoproductObject CC :=
+Definition CoproductIn2 {a b : C} (CC : CoproductCocone a b) : b --> CoproductObject CC :=
    pr2 (pr2 (pr1 CC)).
 
 Definition isCoproductCocone_CoproductCocone {a b : C} (CC : CoproductCocone a b) :
@@ -41,28 +41,28 @@ Proof.
   exact (pr2 CC).
 Defined.
 
-Definition CoproductArrow {a b : C} (CC : CoproductCocone a b) {c : C} (f : a ⇒ c) (g : b ⇒ c) :
-      CoproductObject CC ⇒ c.
+Definition CoproductArrow {a b : C} (CC : CoproductCocone a b) {c : C} (f : a --> c) (g : b --> c) :
+      CoproductObject CC --> c.
 Proof.
   exact (pr1 (pr1 (isCoproductCocone_CoproductCocone CC _ f g))).
 Defined.
 
 Lemma CoproductIn1Commutes (a b : C) (CC : CoproductCocone a b):
-     ∀ (c : C) (f : a ⇒ c) g, CoproductIn1 CC ;; CoproductArrow CC f g  = f.
+     ∀ (c : C) (f : a --> c) g, CoproductIn1 CC ;; CoproductArrow CC f g  = f.
 Proof.
   intros c f g.
   exact (pr1 (pr2 (pr1 (isCoproductCocone_CoproductCocone CC _ f g)))).
 Qed.
 
 Lemma CoproductIn2Commutes (a b : C) (CC : CoproductCocone a b):
-     ∀ (c : C) (f : a ⇒ c) g, CoproductIn2 CC ;; CoproductArrow CC f g = g.
+     ∀ (c : C) (f : a --> c) g, CoproductIn2 CC ;; CoproductArrow CC f g = g.
 Proof.
   intros c f g.
   exact (pr2 (pr2 (pr1 (isCoproductCocone_CoproductCocone CC _ f g)))).
 Qed.
 
 Lemma CoproductArrowUnique (a b : C) (CC : CoproductCocone a b) (x : C)
-    (f : a ⇒ x) (g : b ⇒ x) (k : CoproductObject CC ⇒ x) :
+    (f : a --> x) (g : b --> x) (k : CoproductObject CC --> x) :
     CoproductIn1 CC ;; k = f → CoproductIn2 CC ;; k = g →
       k = CoproductArrow CC f g.
 Proof.
@@ -74,7 +74,7 @@ Qed.
 
 
 Lemma CoproductArrowEta (a b : C) (CC : CoproductCocone a b) (x : C)
-    (f : CoproductObject CC ⇒ x) :
+    (f : CoproductObject CC --> x) :
     f = CoproductArrow CC (CoproductIn1 CC ;; f) (CoproductIn2 CC ;; f).
 Proof.
   apply CoproductArrowUnique;
@@ -83,12 +83,12 @@ Qed.
 
 
 Definition CoproductOfArrows {a b : C} (CCab : CoproductCocone a b) {c d : C}
-    (CCcd : CoproductCocone c d) (f : a ⇒ c) (g : b ⇒ d) :
-          CoproductObject CCab ⇒ CoproductObject CCcd :=
+    (CCcd : CoproductCocone c d) (f : a --> c) (g : b --> d) :
+          CoproductObject CCab --> CoproductObject CCcd :=
     CoproductArrow CCab (f ;; CoproductIn1 CCcd) (g ;; CoproductIn2 CCcd).
 
 Lemma CoproductOfArrowsIn1 {a b : C} (CCab : CoproductCocone a b) {c d : C}
-    (CCcd : CoproductCocone c d) (f : a ⇒ c) (g : b ⇒ d) :
+    (CCcd : CoproductCocone c d) (f : a --> c) (g : b --> d) :
     CoproductIn1 CCab ;; CoproductOfArrows CCab CCcd f g = f ;; CoproductIn1 CCcd.
 Proof.
   unfold CoproductOfArrows.
@@ -96,7 +96,7 @@ Proof.
 Qed.
 
 Lemma CoproductOfArrowsIn2 {a b : C} (CCab : CoproductCocone a b) {c d : C}
-    (CCcd : CoproductCocone c d) (f : a ⇒ c) (g : b ⇒ d) :
+    (CCcd : CoproductCocone c d) (f : a --> c) (g : b --> d) :
     CoproductIn2 CCab ;; CoproductOfArrows CCab CCcd f g = g ;; CoproductIn2 CCcd.
 Proof.
   unfold CoproductOfArrows.
@@ -105,7 +105,7 @@ Qed.
 
 
 Definition mk_CoproductCocone (a b : C) :
-  ∀ (c : C) (f : a ⇒ c) (g : b ⇒ c),
+  ∀ (c : C) (f : a --> c) (g : b --> c),
    isCoproductCocone _ _ _ f g →  CoproductCocone a b.
 Proof.
   intros.
@@ -116,8 +116,8 @@ Proof.
   - apply X.
 Defined.
 
-Definition mk_isCoproductCocone (hsC : has_homsets C)(a b co : C) (ia : a ⇒ co) (ib : b ⇒ co) :
-   (∀ (c : C) (f : a ⇒ c) (g : b ⇒ c),
+Definition mk_isCoproductCocone (hsC : has_homsets C)(a b co : C) (ia : a --> co) (ib : b --> co) :
+   (∀ (c : C) (f : a --> c) (g : b --> c),
     ∃! k : C ⟦co, c⟧,
       ia ;; k = f ×
       ib ;; k = g)
@@ -131,8 +131,8 @@ Defined.
 
 
 Lemma precompWithCoproductArrow {a b : C} (CCab : CoproductCocone a b) {c d : C}
-    (CCcd : CoproductCocone c d) (f : a ⇒ c) (g : b ⇒ d)
-    {x : C} (k : c ⇒ x) (h : d ⇒ x) :
+    (CCcd : CoproductCocone c d) (f : a --> c) (g : b --> d)
+    {x : C} (k : c --> x) (h : d --> x) :
         CoproductOfArrows CCab CCcd f g ;; CoproductArrow CCcd k h =
          CoproductArrow CCab (f ;; k) (g ;; h).
 Proof.
@@ -147,7 +147,7 @@ Qed.
 
 
 Lemma postcompWithCoproductArrow {a b : C} (CCab : CoproductCocone a b) {c : C}
-    (f : a ⇒ c) (g : b ⇒ c) {x : C} (k : c ⇒ x)  :
+    (f : a --> c) (g : b --> c) {x : C} (k : c --> x)  :
        CoproductArrow CCab f g ;; k = CoproductArrow CCab (f ;; k) (g ;; k).
 Proof.
   apply CoproductArrowUnique.
@@ -167,20 +167,20 @@ Hypothesis H : is_category C.
 Variables a b : C.
 
 Definition from_Coproduct_to_Coproduct (CC CC' : CoproductCocone a b)
-  : CoproductObject CC ⇒ CoproductObject CC'.
+  : CoproductObject CC --> CoproductObject CC'.
 Proof.
   apply (CoproductArrow CC  (CoproductIn1 _ ) (CoproductIn2 _ )).
 Defined.
 
 
 Lemma Coproduct_endo_is_identity (CC : CoproductCocone a b)
-  (k : CoproductObject CC ⇒ CoproductObject CC)
+  (k : CoproductObject CC --> CoproductObject CC)
   (H1 : CoproductIn1 CC ;; k = CoproductIn1 CC)
   (H2 : CoproductIn2 CC ;; k = CoproductIn2 CC)
   : identity _ = k.
 Proof.
   set (H' := pr2 CC _ (CoproductIn1 CC) (CoproductIn2 CC) ); simpl in *.
-  set (X := (Σ fg : pr1 (pr1 CC) ⇒ CoproductObject CC,
+  set (X := (Σ fg : pr1 (pr1 CC) --> CoproductObject CC,
           pr1 (pr2 (pr1 CC));; fg = CoproductIn1 CC
           × pr2 (pr2 (pr1 CC));; fg = CoproductIn2 CC)).
   set (t1 := tpair _ k (dirprodpair H1 H2) : X).
@@ -223,8 +223,8 @@ Definition iso_from_Coproduct_to_Coproduct (CC CC' : CoproductCocone a b)
   : iso (CoproductObject CC) (CoproductObject CC')
   := isopair _ (is_iso_from_Coproduct_to_Coproduct CC CC').
 
-Lemma transportf_isotoid' (c d d': C) (p : iso d d') (f : c ⇒ d) :
-  transportf (λ a0 : C, c ⇒ a0) (isotoid C H p) f = f ;; p .
+Lemma transportf_isotoid' (c d d': C) (p : iso d d') (f : c --> d) :
+  transportf (λ a0 : C, c --> a0) (isotoid C H p) f = f ;; p .
 Proof.
   rewrite <- idtoiso_postcompose.
   rewrite idtoiso_isotoid.
@@ -262,7 +262,7 @@ Variable C : precategory.
 Variable CC : Coproducts C.
 Variables a b c d x y : C.
 
-Lemma CoproductArrow_eq (f f' : a ⇒ c) (g g' : b ⇒ c)
+Lemma CoproductArrow_eq (f f' : a --> c) (g g' : b --> c)
   : f = f' → g = g' →
       CoproductArrow _ (CC _ _) f g = CoproductArrow _ _ f' g'.
 Proof.
@@ -271,7 +271,7 @@ Proof.
   apply idpath.
 Qed.
 
-Lemma CoproductArrow_eq_cor (f f' : CoproductObject C (CC a b) ⇒ c)
+Lemma CoproductArrow_eq_cor (f f' : CoproductObject C (CC a b) --> c)
   : CoproductIn1 _ _;; f = CoproductIn1 _ _;; f' → CoproductIn2 _ _;; f = CoproductIn2 _ _;; f' →
       f = f' .
 Proof.
@@ -283,35 +283,35 @@ Qed.
 
 (** specialized versions of beta rules for coproducts *)
 (* all the following lemmas for manipulation of the hypothesis
-Lemma CoproductIn1Commutes_left (f : a ⇒ c)(g : b ⇒ c)(h : a ⇒ c): CoproductIn1 C (CC _ _) ;; CoproductArrow C (CC _ _) f g = h -> f = h.
+Lemma CoproductIn1Commutes_left (f : a --> c)(g : b --> c)(h : a --> c): CoproductIn1 C (CC _ _) ;; CoproductArrow C (CC _ _) f g = h -> f = h.
 Proof.
   intro Hyp.
   rewrite CoproductIn1Commutes in Hyp.
   exact Hyp.
 Qed.
 
-Lemma CoproductIn1Commutes_right (f : a ⇒ c)(g : b ⇒ c)(h : a ⇒ c): h = CoproductIn1 C (CC _ _) ;; CoproductArrow C (CC _ _) f g -> h = f.
+Lemma CoproductIn1Commutes_right (f : a --> c)(g : b --> c)(h : a --> c): h = CoproductIn1 C (CC _ _) ;; CoproductArrow C (CC _ _) f g -> h = f.
 Proof.
   intro Hyp.
   rewrite CoproductIn1Commutes in Hyp.
   exact Hyp.
 Qed.
 
-Lemma CoproductIn2Commutes_left (f : a ⇒ c)(g : b ⇒ c)(h : b ⇒ c): CoproductIn2 C (CC _ _) ;; CoproductArrow C (CC _ _) f g = h -> g = h.
+Lemma CoproductIn2Commutes_left (f : a --> c)(g : b --> c)(h : b --> c): CoproductIn2 C (CC _ _) ;; CoproductArrow C (CC _ _) f g = h -> g = h.
 Proof.
   intro Hyp.
   rewrite CoproductIn2Commutes in Hyp.
   exact Hyp.
 Qed.
 
-Lemma CoproductIn2Commutes_right (f : a ⇒ c)(g : b ⇒ c)(h : b ⇒ c): h = CoproductIn2 C (CC _ _) ;; CoproductArrow C (CC _ _) f g -> h = g.
+Lemma CoproductIn2Commutes_right (f : a --> c)(g : b --> c)(h : b --> c): h = CoproductIn2 C (CC _ _) ;; CoproductArrow C (CC _ _) f g -> h = g.
 Proof.
   intro Hyp.
   rewrite CoproductIn2Commutes in Hyp.
   exact Hyp.
 Qed.
 
-Lemma CoproductIn1Commutes_left_in_ctx (f : a ⇒ c)(g : b ⇒ c)(h : c ⇒ d)(h' : a ⇒ d): CoproductIn1 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h) = h' -> f ;; h = h'.
+Lemma CoproductIn1Commutes_left_in_ctx (f : a --> c)(g : b --> c)(h : c --> d)(h' : a --> d): CoproductIn1 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h) = h' -> f ;; h = h'.
 Proof.
   intro Hyp.
   rewrite assoc in Hyp.
@@ -319,7 +319,7 @@ Proof.
   exact Hyp.
 Qed.
 
-Lemma CoproductIn1Commutes_right_in_ctx (f : a ⇒ c)(g : b ⇒ c)(h : c ⇒ d)(h' : a ⇒ d): h' = CoproductIn1 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h)  -> h' = f ;; h.
+Lemma CoproductIn1Commutes_right_in_ctx (f : a --> c)(g : b --> c)(h : c --> d)(h' : a --> d): h' = CoproductIn1 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h)  -> h' = f ;; h.
 Proof.
   intro Hyp.
   apply pathsinv0 in Hyp.
@@ -327,7 +327,7 @@ Proof.
   exact (CoproductIn1Commutes_left_in_ctx _ _ _ _ Hyp).
 Qed.
 
-Lemma CoproductIn2Commutes_left_in_ctx (f : a ⇒ c)(g : b ⇒ c)(h : c ⇒ d)(h' : b ⇒ d): CoproductIn2 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h) = h' -> g ;; h = h'.
+Lemma CoproductIn2Commutes_left_in_ctx (f : a --> c)(g : b --> c)(h : c --> d)(h' : b --> d): CoproductIn2 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h) = h' -> g ;; h = h'.
 Proof.
   intro Hyp.
   rewrite assoc in Hyp.
@@ -335,7 +335,7 @@ Proof.
   exact Hyp.
 Qed.
 
-Lemma CoproductIn2Commutes_right_in_ctx (f : a ⇒ c)(g : b ⇒ c)(h : c ⇒ d)(h' : b ⇒ d): h' = CoproductIn2 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h)  -> h' = g ;; h.
+Lemma CoproductIn2Commutes_right_in_ctx (f : a --> c)(g : b --> c)(h : c --> d)(h' : b --> d): h' = CoproductIn2 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h)  -> h' = g ;; h.
 Proof.
   intro Hyp.
   apply pathsinv0 in Hyp.
@@ -343,7 +343,7 @@ Proof.
   exact (CoproductIn2Commutes_left_in_ctx _ _ _ _ Hyp).
 Qed.
 
-Lemma CoproductIn2Commutes_right_in_double_ctx (g0 : x ⇒ b)(f : a ⇒ c)(g : b ⇒ c)(h : c ⇒ d)(h' : x ⇒ d): h' = g0 ;; CoproductIn2 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h)  -> h' = g0 ;; g ;; h.
+Lemma CoproductIn2Commutes_right_in_double_ctx (g0 : x --> b)(f : a --> c)(g : b --> c)(h : c --> d)(h' : x --> d): h' = g0 ;; CoproductIn2 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h)  -> h' = g0 ;; g ;; h.
 Proof.
   intro Hyp.
   rewrite Hyp.
@@ -357,7 +357,7 @@ Qed.
 
 
 (* optimized versions in direct style *)
-Lemma CoproductIn1Commutes_right_dir (f : a ⇒ c)(g : b ⇒ c)(h : a ⇒ c): h = f -> h = CoproductIn1 C (CC _ _) ;; CoproductArrow C (CC _ _) f g.
+Lemma CoproductIn1Commutes_right_dir (f : a --> c)(g : b --> c)(h : a --> c): h = f -> h = CoproductIn1 C (CC _ _) ;; CoproductArrow C (CC _ _) f g.
 Proof.
   intro Hyp.
   rewrite Hyp.
@@ -365,7 +365,7 @@ Proof.
   apply CoproductIn1Commutes.
 Qed.
 
-Lemma CoproductIn2Commutes_right_dir (f : a ⇒ c)(g : b ⇒ c)(h : b ⇒ c): h = g -> h = CoproductIn2 C (CC _ _) ;; CoproductArrow C (CC _ _) f g.
+Lemma CoproductIn2Commutes_right_dir (f : a --> c)(g : b --> c)(h : b --> c): h = g -> h = CoproductIn2 C (CC _ _) ;; CoproductArrow C (CC _ _) f g.
 Proof.
   intro Hyp.
   rewrite Hyp.
@@ -373,7 +373,7 @@ Proof.
   apply CoproductIn2Commutes.
 Qed.
 
-Lemma CoproductIn1Commutes_right_in_ctx_dir (f : a ⇒ c)(g : b ⇒ c)(h : c ⇒ d)(h' : a ⇒ d): h' = f ;; h -> h' = CoproductIn1 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h).
+Lemma CoproductIn1Commutes_right_in_ctx_dir (f : a --> c)(g : b --> c)(h : c --> d)(h' : a --> d): h' = f ;; h -> h' = CoproductIn1 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h).
 Proof.
   intro Hyp.
   rewrite Hyp.
@@ -382,7 +382,7 @@ Proof.
   apply idpath.
 Qed.
 
-Lemma CoproductIn2Commutes_right_in_ctx_dir (f : a ⇒ c)(g : b ⇒ c)(h : c ⇒ d)(h' : b ⇒ d): h' = g ;; h -> h' = CoproductIn2 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h).
+Lemma CoproductIn2Commutes_right_in_ctx_dir (f : a --> c)(g : b --> c)(h : c --> d)(h' : b --> d): h' = g ;; h -> h' = CoproductIn2 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h).
 Proof.
   intro Hyp.
   rewrite Hyp.
@@ -391,21 +391,21 @@ Proof.
   apply idpath.
 Qed.
 
-Lemma CoproductIn1Commutes_left_dir (f : a ⇒ c)(g : b ⇒ c)(h : a ⇒ c): f = h -> CoproductIn1 C (CC _ _) ;; CoproductArrow C (CC _ _) f g = h.
+Lemma CoproductIn1Commutes_left_dir (f : a --> c)(g : b --> c)(h : a --> c): f = h -> CoproductIn1 C (CC _ _) ;; CoproductArrow C (CC _ _) f g = h.
 Proof.
   intro Hyp.
   rewrite Hyp.
   apply CoproductIn1Commutes.
 Qed.
 
-Lemma CoproductIn2Commutes_left_dir (f : a ⇒ c)(g : b ⇒ c)(h : b ⇒ c): g = h -> CoproductIn2 C (CC _ _) ;; CoproductArrow C (CC _ _) f g = h.
+Lemma CoproductIn2Commutes_left_dir (f : a --> c)(g : b --> c)(h : b --> c): g = h -> CoproductIn2 C (CC _ _) ;; CoproductArrow C (CC _ _) f g = h.
 Proof.
   intro Hyp.
   rewrite Hyp.
   apply CoproductIn2Commutes.
 Qed.
 
-Lemma CoproductIn1Commutes_left_in_ctx_dir (f : a ⇒ c)(g : b ⇒ c)(h : c ⇒ d)(h' : a ⇒ d): f ;; h = h' -> CoproductIn1 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h) = h'.
+Lemma CoproductIn1Commutes_left_in_ctx_dir (f : a --> c)(g : b --> c)(h : c --> d)(h' : a --> d): f ;; h = h' -> CoproductIn1 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h) = h'.
 Proof.
   intro Hyp.
   rewrite <- Hyp.
@@ -414,7 +414,7 @@ Proof.
   apply idpath.
 Qed.
 
-Lemma CoproductIn2Commutes_left_in_ctx_dir (f : a ⇒ c)(g : b ⇒ c)(h : c ⇒ d)(h' : b ⇒ d): g ;; h = h' -> CoproductIn2 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h) = h'.
+Lemma CoproductIn2Commutes_left_in_ctx_dir (f : a --> c)(g : b --> c)(h : c --> d)(h' : b --> d): g ;; h = h' -> CoproductIn2 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h) = h'.
 Proof.
   intro Hyp.
   rewrite <- Hyp.
@@ -423,7 +423,7 @@ Proof.
   apply idpath.
 Qed.
 
-Lemma CoproductIn1Commutes_right_in_double_ctx_dir (g0 : x ⇒ a)(f : a ⇒ c)(g : b ⇒ c)(h : c ⇒ d)(h' : x ⇒ d): h' = g0 ;; f ;; h -> h' = g0 ;; CoproductIn1 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h).
+Lemma CoproductIn1Commutes_right_in_double_ctx_dir (g0 : x --> a)(f : a --> c)(g : b --> c)(h : c --> d)(h' : x --> d): h' = g0 ;; f ;; h -> h' = g0 ;; CoproductIn1 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h).
 Proof.
   intro Hyp.
   rewrite Hyp.
@@ -434,7 +434,7 @@ Proof.
   apply idpath.
 Qed.
 
-Lemma CoproductIn2Commutes_right_in_double_ctx_dir (g0 : x ⇒ b)(f : a ⇒ c)(g : b ⇒ c)(h : c ⇒ d)(h' : x ⇒ d): h' = g0 ;; g ;; h -> h' = g0 ;; CoproductIn2 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h).
+Lemma CoproductIn2Commutes_right_in_double_ctx_dir (g0 : x --> b)(f : a --> c)(g : b --> c)(h : c --> d)(h' : x --> d): h' = g0 ;; g ;; h -> h' = g0 ;; CoproductIn2 C (CC _ _) ;; (CoproductArrow C (CC _ _) f g ;; h).
 Proof.
   intro Hyp.
   rewrite Hyp.
@@ -481,7 +481,7 @@ Proof.
 Qed.
 *)
 
-Definition CoproductOfArrows_comp (f : a ⇒ c) (f' : b ⇒ d) (g : c ⇒ x) (g' : d ⇒ y)
+Definition CoproductOfArrows_comp (f : a --> c) (f' : b --> d) (g : c --> x) (g' : d --> y)
   : CoproductOfArrows _ (CC a b) (CC c d) f f' ;;
     CoproductOfArrows _ (CC _ _) (CC _ _) g g'
     =
@@ -500,7 +500,7 @@ Proof.
     apply assoc.
 Qed.
 
-Definition CoproductOfArrows_eq (f f' : a ⇒ c) (g g' : b ⇒ d)
+Definition CoproductOfArrows_eq (f f' : a --> c) (g g' : b --> d)
   : f = f' → g = g' →
       CoproductOfArrows _ _ _ f g = CoproductOfArrows _ (CC _ _) (CC _ _) f' g'.
 Proof.
@@ -510,8 +510,8 @@ Proof.
 Qed.
 
 Lemma precompWithCoproductArrow_eq  (CCab : CoproductCocone _ a b)
-    (CCcd : CoproductCocone _ c d) (f : a ⇒ c) (g : b ⇒ d)
-     (k : c ⇒ x) (h : d ⇒ x) (fk : a ⇒ x) (gh : b ⇒ x):
+    (CCcd : CoproductCocone _ c d) (f : a --> c) (g : b --> d)
+     (k : c --> x) (h : d --> x) (fk : a --> x) (gh : b --> x):
       fk = f ;; k → gh = g ;; h →
         CoproductOfArrows _ CCab CCcd f g ;; CoproductArrow _ CCcd k h =
          CoproductArrow _ CCab (fk) (gh).
@@ -542,7 +542,7 @@ Proof.
   induction F.
 Defined.
 
-Definition CoprodCocone {a b c : C} (ac : a ⇒ c) (bc : b ⇒ c) :
+Definition CoprodCocone {a b c : C} (ac : a --> c) (bc : b --> c) :
    cocone (coproduct_diagram a b) c.
 Proof.
 simple refine (tpair _ _ _ ).

--- a/UniMath/CategoryTheory/limits/coproducts_as_colimits.v
+++ b/UniMath/CategoryTheory/limits/coproducts_as_colimits.v
@@ -27,7 +27,7 @@ Proof.
   induction F.
 Defined.
 
-Definition CopCocone {C : precategory} {a b : C} {c : C} (ac : a ⇒ c) (bc : b ⇒ c) :
+Definition CopCocone {C : precategory} {a b : C} {c : C} (ac : a --> c) (bc : b --> c) :
    cocone (coproduct_diagram a b) c.
 simple refine (tpair _ _ _ ).
 + intro v.
@@ -41,11 +41,11 @@ Section coproduct_def.
 
 Variable C : precategory.
 
-Definition isCoproductCocone (a b co : C) (ia : a ⇒ co) (ib : b ⇒ co) :=
+Definition isCoproductCocone (a b co : C) (ia : a --> co) (ib : b --> co) :=
   isColimCocone (coproduct_diagram a b) co (CopCocone ia ib).
 
-Definition mk_isCoproductCocone (hsC : has_homsets C)(a b co : C) (ia : a ⇒ co) (ib : b ⇒ co) :
-   (∀ (c : C) (f : a ⇒ c) (g : b ⇒ c),
+Definition mk_isCoproductCocone (hsC : has_homsets C)(a b co : C) (ia : a --> co) (ib : b --> co) :
+   (∀ (c : C) (f : a --> c) (g : b --> c),
     ∃! k : C ⟦co, c⟧,
       ia ;; k = f ×
       ib ;; k = g)
@@ -69,7 +69,7 @@ Definition CoproductCocone (a b : C) :=
   ColimCocone (coproduct_diagram a b).
 
 Definition mk_CoproductCocone (a b : C) :
-  ∀ (c : C) (f : a ⇒ c) (g : b ⇒ c),
+  ∀ (c : C) (f : a --> c) (g : b --> c),
    isCoproductCocone _ _ _ f g →  CoproductCocone a b.
 Proof.
   intros.
@@ -83,14 +83,14 @@ Definition Coproducts := ∀ (a b : C), CoproductCocone a b.
 Definition hasCoproducts := ishinh Coproducts.
 
 Definition CoproductObject {a b : C} (CC : CoproductCocone a b) : C := colim CC.
-Definition CoproductIn1 {a b : C} (CC : CoproductCocone a b): a ⇒ CoproductObject CC
+Definition CoproductIn1 {a b : C} (CC : CoproductCocone a b): a --> CoproductObject CC
   := colimIn CC true.
 
-Definition CoproductIn2 {a b : C} (CC : CoproductCocone a b) : b ⇒ CoproductObject CC
+Definition CoproductIn2 {a b : C} (CC : CoproductCocone a b) : b --> CoproductObject CC
   := colimIn CC false.
 
-Definition CoproductArrow {a b : C} (CC : CoproductCocone a b) {c : C} (f : a ⇒ c) (g : b ⇒ c) :
-      CoproductObject CC ⇒ c.
+Definition CoproductArrow {a b : C} (CC : CoproductCocone a b) {c : C} (f : a --> c) (g : b --> c) :
+      CoproductObject CC --> c.
 Proof.
   apply (colimArrow CC).
   simple refine (mk_cocone _ _ ).
@@ -101,7 +101,7 @@ Proof.
 Defined.
 
 Lemma CoproductIn1Commutes (a b : C) (CC : CoproductCocone a b):
-     ∀ (c : C) (f : a ⇒ c) g, CoproductIn1 CC ;; CoproductArrow CC f g  = f.
+     ∀ (c : C) (f : a --> c) g, CoproductIn1 CC ;; CoproductArrow CC f g  = f.
 Proof.
   intros c f g.
   unfold CoproductIn1.
@@ -110,7 +110,7 @@ Proof.
 Qed.
 
 Lemma CoproductIn2Commutes (a b : C) (CC : CoproductCocone a b):
-     ∀ (c : C) (f : a ⇒ c) g, CoproductIn2 CC ;; CoproductArrow CC f g = g.
+     ∀ (c : C) (f : a --> c) g, CoproductIn2 CC ;; CoproductArrow CC f g = g.
 Proof.
   intros c f g.
   unfold CoproductIn1.
@@ -119,7 +119,7 @@ Proof.
 Qed.
 
 Lemma CoproductArrowUnique (a b : C) (CC : CoproductCocone a b) (x : C)
-    (f : a ⇒ x) (g : b ⇒ x) (k : CoproductObject CC ⇒ x) :
+    (f : a --> x) (g : b --> x) (k : CoproductObject CC --> x) :
     CoproductIn1 CC ;; k = f → CoproductIn2 CC ;; k = g →
       k = CoproductArrow CC f g.
 Proof.
@@ -132,7 +132,7 @@ Qed.
 
 
 Lemma CoproductArrowEta (a b : C) (CC : CoproductCocone a b) (x : C)
-    (f : CoproductObject CC ⇒ x) :
+    (f : CoproductObject CC --> x) :
     f = CoproductArrow CC (CoproductIn1 CC ;; f) (CoproductIn2 CC ;; f).
 Proof.
   apply CoproductArrowUnique;
@@ -141,12 +141,12 @@ Qed.
 
 
 Definition CoproductOfArrows {a b : C} (CCab : CoproductCocone a b) {c d : C}
-    (CCcd : CoproductCocone c d) (f : a ⇒ c) (g : b ⇒ d) :
-          CoproductObject CCab ⇒ CoproductObject CCcd :=
+    (CCcd : CoproductCocone c d) (f : a --> c) (g : b --> d) :
+          CoproductObject CCab --> CoproductObject CCcd :=
     CoproductArrow CCab (f ;; CoproductIn1 CCcd) (g ;; CoproductIn2 CCcd).
 
 Lemma CoproductOfArrowsIn1 {a b : C} (CCab : CoproductCocone a b) {c d : C}
-    (CCcd : CoproductCocone c d) (f : a ⇒ c) (g : b ⇒ d) :
+    (CCcd : CoproductCocone c d) (f : a --> c) (g : b --> d) :
     CoproductIn1 CCab ;; CoproductOfArrows CCab CCcd f g = f ;; CoproductIn1 CCcd.
 Proof.
   unfold CoproductOfArrows.
@@ -154,7 +154,7 @@ Proof.
 Qed.
 
 Lemma CoproductOfArrowsIn2 {a b : C} (CCab : CoproductCocone a b) {c d : C}
-    (CCcd : CoproductCocone c d) (f : a ⇒ c) (g : b ⇒ d) :
+    (CCcd : CoproductCocone c d) (f : a --> c) (g : b --> d) :
     CoproductIn2 CCab ;; CoproductOfArrows CCab CCcd f g = g ;; CoproductIn2 CCcd.
 Proof.
   unfold CoproductOfArrows.
@@ -163,8 +163,8 @@ Qed.
 
 
 Lemma precompWithCoproductArrow {a b : C} (CCab : CoproductCocone a b) {c d : C}
-    (CCcd : CoproductCocone c d) (f : a ⇒ c) (g : b ⇒ d)
-    {x : C} (k : c ⇒ x) (h : d ⇒ x) :
+    (CCcd : CoproductCocone c d) (f : a --> c) (g : b --> d)
+    {x : C} (k : c --> x) (h : d --> x) :
         CoproductOfArrows CCab CCcd f g ;; CoproductArrow CCcd k h =
          CoproductArrow CCab (f ;; k) (g ;; h).
 Proof.
@@ -179,7 +179,7 @@ Qed.
 
 
 Lemma postcompWithCoproductArrow {a b : C} (CCab : CoproductCocone a b) {c : C}
-    (f : a ⇒ c) (g : b ⇒ c) {x : C} (k : c ⇒ x)  :
+    (f : a --> c) (g : b --> c) {x : C} (k : c --> x)  :
        CoproductArrow CCab f g ;; k = CoproductArrow CCab (f ;; k) (g ;; k).
 Proof.
   apply CoproductArrowUnique.
@@ -199,14 +199,14 @@ Hypothesis H : is_category C.
 Variables a b : C.
 
 Definition from_Coproduct_to_Coproduct (CC CC' : CoproductCocone a b)
-  : CoproductObject CC ⇒ CoproductObject CC'.
+  : CoproductObject CC --> CoproductObject CC'.
 Proof.
   apply (CoproductArrow CC  (CoproductIn1 _ ) (CoproductIn2 _ )).
 Defined.
 
 
 Lemma Coproduct_endo_is_identity (CC : CoproductCocone a b)
-  (k : CoproductObject CC ⇒ CoproductObject CC)
+  (k : CoproductObject CC --> CoproductObject CC)
   (H1 : CoproductIn1 CC ;; k = CoproductIn1 CC)
   (H2 : CoproductIn2 CC ;; k = CoproductIn2 CC)
   : identity _ = k.
@@ -245,8 +245,8 @@ Definition iso_from_Coproduct_to_Coproduct (CC CC' : CoproductCocone a b)
   : iso (CoproductObject CC) (CoproductObject CC')
   := isopair _ (is_iso_from_Coproduct_to_Coproduct CC CC').
 
-Lemma transportf_isotoid' (c d d': C) (p : iso d d') (f : c ⇒ d) :
-  transportf (λ a0 : C, c ⇒ a0) (isotoid C H p) f = f ;; p .
+Lemma transportf_isotoid' (c d d': C) (p : iso d d') (f : c --> d) :
+  transportf (λ a0 : C, c --> a0) (isotoid C H p) f = f ;; p .
 Proof.
   rewrite <- idtoiso_postcompose.
   rewrite idtoiso_isotoid.

--- a/UniMath/CategoryTheory/limits/initial.v
+++ b/UniMath/CategoryTheory/limits/initial.v
@@ -47,7 +47,7 @@ Proof.
   exact H.
 Defined.
 
-Definition mk_isInitial (a : C) (H : ∀ (b : C), iscontr (a ⇒ b)) :
+Definition mk_isInitial (a : C) (H : ∀ (b : C), iscontr (a --> b)) :
   isInitial a.
 Proof.
   exact H.

--- a/UniMath/CategoryTheory/limits/initial_as_colimit.v
+++ b/UniMath/CategoryTheory/limits/initial_as_colimit.v
@@ -32,7 +32,7 @@ Definition isInitial (a : C) :=
   isColimCocone initDiagram a (initCocone a).
  (* forall b : C, iscontr (a --> b). *)
 
-Definition mk_isInitial (a : C) (H : ∀ (b : C), iscontr (a ⇒ b)) :
+Definition mk_isInitial (a : C) (H : ∀ (b : C), iscontr (a --> b)) :
   isInitial a.
 Proof.
 intros b cb.

--- a/UniMath/CategoryTheory/limits/limits.v
+++ b/UniMath/CategoryTheory/limits/limits.v
@@ -201,7 +201,7 @@ now intro u; rewrite <- assoc, limArrowCommutes.
 Qed.
 
 Lemma lim_endo_is_identity {J C : precategory} {F : functor J C}
-  (CC : LimCone F) (k : lim CC ⇒ lim CC)
+  (CC : LimCone F) (k : lim CC --> lim CC)
   (H : ∀ u, k ;; limOut CC u = limOut CC u) :
   identity _ = k.
 Proof.

--- a/UniMath/CategoryTheory/limits/limits_via_colimits.v
+++ b/UniMath/CategoryTheory/limits/limits_via_colimits.v
@@ -216,7 +216,7 @@ Proof.
 Qed.
 
 Lemma lim_endo_is_identity {g : graph} (D : diagram g C^op)
-  (CC : LimCone D) (k : lim CC ⇒ lim CC)
+  (CC : LimCone D) (k : lim CC --> lim CC)
   (H : ∀ u, k ;; limOut CC u = limOut CC u) :
   identity _ = k.
 Proof.

--- a/UniMath/CategoryTheory/limits/products.v
+++ b/UniMath/CategoryTheory/limits/products.v
@@ -165,7 +165,7 @@ Variable C : precategory.
 Variable CC : Products C.
 Variables a b c d x y : C.
 
-Definition ProductOfArrows_comp (f : a ⇒ c) (f' : b ⇒ d) (g : c ⇒ x) (g' : d ⇒ y)
+Definition ProductOfArrows_comp (f : a --> c) (f' : b --> d) (g : c --> x) (g' : d --> y)
   : ProductOfArrows _ (CC c d) (CC a b) f f' ;;
     ProductOfArrows _ (CC _ _) (CC _ _) g g'
     =
@@ -186,7 +186,7 @@ Proof.
     apply assoc.
 Qed.
 
-Definition ProductOfArrows_eq (f f' : a ⇒ c) (g g' : b ⇒ d)
+Definition ProductOfArrows_eq (f f' : a --> c) (g g' : b --> d)
   : f = f' → g = g' →
       ProductOfArrows _ _ _ f g = ProductOfArrows _ (CC _ _) (CC _ _) f' g'.
 Proof.
@@ -204,7 +204,7 @@ Variable CC : Products C.
 Variables a b : C.
 
 Lemma Product_endo_is_identity (P : ProductCone _ a b)
-  (k : ProductObject _ P ⇒ ProductObject _ P)
+  (k : ProductObject _ P --> ProductObject _ P)
   (H1 : k ;; ProductPr1 _ P = ProductPr1 _ P)
   (H2 : k ;; ProductPr2 _ P = ProductPr2 _ P)
   : identity _ = k.

--- a/UniMath/CategoryTheory/limits/terminal_as_colimit.v
+++ b/UniMath/CategoryTheory/limits/terminal_as_colimit.v
@@ -36,7 +36,7 @@ Defined.
 Definition isTerminal (a : C) :=
   isLimCone termDiagram a (termCone a).
 
-Definition mk_isTerminal (b : C) (H : ∀ (a : C), iscontr (a ⇒ b)) :
+Definition mk_isTerminal (b : C) (H : ∀ (a : C), iscontr (a --> b)) :
   isTerminal b.
 Proof.
 intros a ca.

--- a/UniMath/Ktheory/Test.v
+++ b/UniMath/Ktheory/Test.v
@@ -23,11 +23,11 @@ Variable C : Precategories.Precategory.
 
 Set Automatic Introduction.
 
-Definition isCoproductCocone (a b co : C) (ia : a ⇒ co) (ib : b ⇒ co) :=
+Definition isCoproductCocone (a b co : C) (ia : a --> co) (ib : b --> co) :=
   binarySumProperty ia ib.
 
-Definition mk_isCoproductCocone (a b co : C) (ia : a ⇒ co) (ib : b ⇒ co) :
-   (∀ (c : C) (f : a ⇒ c) (g : b ⇒ c),
+Definition mk_isCoproductCocone (a b co : C) (ia : a --> co) (ib : b --> co) :
+   (∀ (c : C) (f : a --> c) (g : b --> c),
     ∃! k : C ⟦co, c⟧,
       ia ;; k = f ×
       ib ;; k = g)
@@ -50,7 +50,7 @@ Defined.
 Definition CoproductCocone (a b : C) := BinarySum a b.
 
 Definition mk_CoproductCocone (a b : C) :
-  ∀ (c : C) (f : a ⇒ c) (g : b ⇒ c),
+  ∀ (c : C) (f : a --> c) (g : b --> c),
     isCoproductCocone _ _ _ f g →  CoproductCocone a b
   := λ c f g i, c,,(f,,g),,i.
 
@@ -60,32 +60,32 @@ Definition hasCoproducts := ishinh Coproducts.
 Definition CoproductObject {a b : C} (CC : CoproductCocone a b) : C :=
   universalObject CC.
 
-Definition CoproductIn1 {a b : C} (CC : CoproductCocone a b): a ⇒ CoproductObject CC
+Definition CoproductIn1 {a b : C} (CC : CoproductCocone a b): a --> CoproductObject CC
   := in_1 CC.
 
-Definition CoproductIn2 {a b : C} (CC : CoproductCocone a b) : b ⇒ CoproductObject CC
+Definition CoproductIn2 {a b : C} (CC : CoproductCocone a b) : b --> CoproductObject CC
   := in_2 CC.
 
-Definition CoproductArrow {a b : C} (CC : CoproductCocone a b) {c : C} (f : a ⇒ c) (g : b ⇒ c) :
-  CoproductObject CC ⇒ c
+Definition CoproductArrow {a b : C} (CC : CoproductCocone a b) {c : C} (f : a --> c) (g : b --> c) :
+  CoproductObject CC --> c
   := binarySumMap CC f g.
 
 Lemma CoproductIn1Commutes (a b : C) (CC : CoproductCocone a b):
-     ∀ (c : C) (f : a ⇒ c) g, CoproductIn1 CC ;; CoproductArrow CC f g  = f.
+     ∀ (c : C) (f : a --> c) g, CoproductIn1 CC ;; CoproductArrow CC f g  = f.
 Proof.
   intros c f g.
   exact (binarySum_in_1_eqn CC f g).
 Qed.
 
 Lemma CoproductIn2Commutes (a b : C) (CC : CoproductCocone a b):
-     ∀ (c : C) (f : a ⇒ c) g, CoproductIn2 CC ;; CoproductArrow CC f g = g.
+     ∀ (c : C) (f : a --> c) g, CoproductIn2 CC ;; CoproductArrow CC f g = g.
 Proof.
   intros c f g.
   exact (binarySum_in_2_eqn CC f g).
 Qed.
 
 Lemma CoproductArrowUnique (a b : C) (CC : CoproductCocone a b) (x : C)
-    (f : a ⇒ x) (g : b ⇒ x) (k : CoproductObject CC ⇒ x) :
+    (f : a --> x) (g : b --> x) (k : CoproductObject CC --> x) :
     CoproductIn1 CC ;; k = f → CoproductIn2 CC ;; k = g →
       k = CoproductArrow CC f g.
 Proof.
@@ -96,7 +96,7 @@ Proof.
 Qed.
 
 Lemma CoproductArrowEta (a b : C) (CC : CoproductCocone a b) (x : C)
-    (f : CoproductObject CC ⇒ x) :
+    (f : CoproductObject CC --> x) :
     f = CoproductArrow CC (CoproductIn1 CC ;; f) (CoproductIn2 CC ;; f).
 Proof.
   apply CoproductArrowUnique;
@@ -104,12 +104,12 @@ Proof.
 Qed.
 
 Definition CoproductOfArrows {a b : C} (CCab : CoproductCocone a b) {c d : C}
-    (CCcd : CoproductCocone c d) (f : a ⇒ c) (g : b ⇒ d) :
-          CoproductObject CCab ⇒ CoproductObject CCcd :=
+    (CCcd : CoproductCocone c d) (f : a --> c) (g : b --> d) :
+          CoproductObject CCab --> CoproductObject CCcd :=
     CoproductArrow CCab (f ;; CoproductIn1 CCcd) (g ;; CoproductIn2 CCcd).
 
 Lemma CoproductOfArrowsIn1 {a b : C} (CCab : CoproductCocone a b) {c d : C}
-    (CCcd : CoproductCocone c d) (f : a ⇒ c) (g : b ⇒ d) :
+    (CCcd : CoproductCocone c d) (f : a --> c) (g : b --> d) :
     CoproductIn1 CCab ;; CoproductOfArrows CCab CCcd f g = f ;; CoproductIn1 CCcd.
 Proof.
   unfold CoproductOfArrows.
@@ -117,7 +117,7 @@ Proof.
 Qed.
 
 Lemma CoproductOfArrowsIn2 {a b : C} (CCab : CoproductCocone a b) {c d : C}
-    (CCcd : CoproductCocone c d) (f : a ⇒ c) (g : b ⇒ d) :
+    (CCcd : CoproductCocone c d) (f : a --> c) (g : b --> d) :
     CoproductIn2 CCab ;; CoproductOfArrows CCab CCcd f g = g ;; CoproductIn2 CCcd.
 Proof.
   unfold CoproductOfArrows.
@@ -126,8 +126,8 @@ Qed.
 
 
 Lemma precompWithCoproductArrow {a b : C} (CCab : CoproductCocone a b) {c d : C}
-    (CCcd : CoproductCocone c d) (f : a ⇒ c) (g : b ⇒ d)
-    {x : C} (k : c ⇒ x) (h : d ⇒ x) :
+    (CCcd : CoproductCocone c d) (f : a --> c) (g : b --> d)
+    {x : C} (k : c --> x) (h : d --> x) :
         CoproductOfArrows CCab CCcd f g ;; CoproductArrow CCcd k h =
          CoproductArrow CCab (f ;; k) (g ;; h).
 Proof.
@@ -142,7 +142,7 @@ Qed.
 
 
 Lemma postcompWithCoproductArrow {a b : C} (CCab : CoproductCocone a b) {c : C}
-    (f : a ⇒ c) (g : b ⇒ c) {x : C} (k : c ⇒ x)  :
+    (f : a --> c) (g : b --> c) {x : C} (k : c --> x)  :
        CoproductArrow CCab f g ;; k = CoproductArrow CCab (f ;; k) (g ;; k).
 Proof.
   apply CoproductArrowUnique.
@@ -160,14 +160,14 @@ Hypothesis H : is_category C.
 Variables a b : C.
 
 Definition from_Coproduct_to_Coproduct (CC CC' : CoproductCocone a b)
-  : CoproductObject CC ⇒ CoproductObject CC'.
+  : CoproductObject CC --> CoproductObject CC'.
 Proof.
   apply (CoproductArrow CC  (CoproductIn1 _ ) (CoproductIn2 _ )).
 Defined.
 
 
 Lemma Coproduct_endo_is_identity (CC : CoproductCocone a b)
-  (k : CoproductObject CC ⇒ CoproductObject CC)
+  (k : CoproductObject CC --> CoproductObject CC)
   (H1 : CoproductIn1 CC ;; k = CoproductIn1 CC)
   (H2 : CoproductIn2 CC ;; k = CoproductIn2 CC)
   : identity _ = k.

--- a/UniMath/SubstitutionSystems/GenMendlerIteration.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration.v
@@ -60,7 +60,7 @@ Variable F : functor C C.
 
 Let AF := FunctorAlg F hsC.
 
-Definition AlgConstr (A : C) (α : F A ⇒ A) : AF.
+Definition AlgConstr (A : C) (α : F A --> A) : AF.
 Proof.
   exists A.
   exact α.
@@ -72,9 +72,9 @@ Notation "⟨ A , α ⟩" := (AlgConstr A α).
 Variable μF_Initial : Initial AF.
 
 Let μF : C := alg_carrier _ (InitialObject μF_Initial).
-Let inF : F μF ⇒ μF := alg_map _ (InitialObject μF_Initial).
+Let inF : F μF --> μF := alg_map _ (InitialObject μF_Initial).
 
-Let iter {A : C} (α : F A ⇒ A) : μF ⇒ A :=
+Let iter {A : C} (α : F A --> A) : μF --> A :=
   ↓(InitialArrow μF_Initial ⟨A,α⟩).
 
 Variable C' : precategory.
@@ -112,10 +112,10 @@ Section general_case.
 
 Variable ψ : ψ_source ⟶ ψ_target.
 
-Definition preIt : L μF ⇒ X := φ_inv (iter (φ (ψ (R X) (ε X)))).
+Definition preIt : L μF --> X := φ_inv (iter (φ (ψ (R X) (ε X)))).
 
 
-Lemma ψ_naturality (A B: C)(h: B ⇒ A)(f: L A ⇒ X): ψ B (#L h;; f) = #L (#F h);; ψ A f.
+Lemma ψ_naturality (A B: C)(h: B --> A)(f: L A --> X): ψ B (#L h;; f) = #L (#F h);; ψ A f.
 Proof.
   assert (ψ_is_nat := nat_trans_ax ψ);
   assert (ψ_is_nat_inst1 := ψ_is_nat _ _ h).
@@ -132,7 +132,7 @@ Proof.
   apply id_left.
 Qed.
 
-Lemma φ_ψ_μF_eq (h: L μF ⇒ X): φ (ψ μF h) = #F (φ h) ;; φ(ψ (R X) (ε X)).
+Lemma φ_ψ_μF_eq (h: L μF --> X): φ (ψ μF h) = #F (φ h) ;; φ(ψ (R X) (ε X)).
 Proof.
   rewrite <- φ_adj_natural_precomp.
   apply maponpaths.
@@ -148,7 +148,7 @@ Focus 2.
   apply φ_adj_inv_after_φ_adj.
 Qed.
 
-Lemma cancel_φ {A: C}{B: C'} (f g : L A ⇒ B): φ f = φ g -> f = g.
+Lemma cancel_φ {A: C}{B: C'} (f g : L A --> B): φ f = φ g -> f = g.
 Proof.
   intro Hyp.
 (* pedestrian way:
@@ -173,8 +173,8 @@ Proof.
     exact iter_eq.
 Qed.
 
-Lemma preIt_uniq (t : Σ h : L μF ⇒ X, # L inF;; h = ψ μF h):
-    t = tpair (λ h : L μF ⇒ X, # L inF;; h = ψ μF h) preIt preIt_ok.
+Lemma preIt_uniq (t : Σ h : L μF --> X, # L inF;; h = ψ μF h):
+    t = tpair (λ h : L μF --> X, # L inF;; h = ψ μF h) preIt preIt_ok.
 Proof.
     destruct t as [h h_rec_eq]; simpl.
     assert (same: h = preIt).
@@ -199,13 +199,13 @@ Focus 2.
       rewrite <- φ_adj_natural_precomp.
       apply maponpaths.
       exact h_rec_eq.
-    + (* set(φh_alg_mor := tpair _ _ φh_is_alg_mor : pr1 μF_Initial ⇒ ⟨ R X, φ (ψ (R X) (ε X)) ⟩). *)
+    + (* set(φh_alg_mor := tpair _ _ φh_is_alg_mor : pr1 μF_Initial --> ⟨ R X, φ (ψ (R X) (ε X)) ⟩). *)
        simple refine (let X : AF ⟦ InitialObject μF_Initial, ⟨ R X, φ (ψ (R X) (ε X)) ⟩ ⟧ := _ in _).
        * apply (tpair _ (φ h)); assumption.
        * apply (maponpaths pr1 (InitialArrowUnique _ _ X0)).
 Qed.
 
-Theorem GenMendlerIteration : iscontr (Σ h : L μF ⇒ X, #L inF ;; h = ψ μF h).
+Theorem GenMendlerIteration : iscontr (Σ h : L μF --> X, #L inF ;; h = ψ μF h).
 Proof.
   simple refine (tpair _ _ _ ).
   - exists preIt.
@@ -213,7 +213,7 @@ Proof.
   - exact preIt_uniq.
 Defined.
 
-Definition It : L μF ⇒ X := pr1 (pr1 GenMendlerIteration).
+Definition It : L μF --> X := pr1 (pr1 GenMendlerIteration).
 Lemma It_is_preIt : It = preIt.
 Proof.
   apply idpath.
@@ -226,7 +226,7 @@ End general_case.
 Section special_case.
 
   Variable G : functor C' C'.
-  Variable ρ : G X ⇒ X.
+  Variable ρ : G X --> X.
   Variable θ : functor_composite F L ⟶ functor_composite L G.
 
 
@@ -260,7 +260,7 @@ Section special_case.
 
   Definition SpecialGenMendlerIteration :
     iscontr
-      (Σ h : L μF ⇒ X, # L inF ;; h = θ μF ;; #G h ;; ρ)
+      (Σ h : L μF --> X, # L inF ;; h = θ μF ;; #G h ;; ρ)
     := GenMendlerIteration ψ_from_comps.
 
 End special_case.

--- a/UniMath/SubstitutionSystems/Lam.v
+++ b/UniMath/SubstitutionSystems/Lam.v
@@ -170,7 +170,7 @@ Defined.
 (** now define bracket operation for a given [Z] and [f] *)
 
 (** preparations for typedness *)
-Local Definition bla': (ptd_from_alg_functor CC LamE_S LamE_algebra_on_Lam) ⇒ (ptd_from_alg_functor CC _ Lam).
+Local Definition bla': (ptd_from_alg_functor CC LamE_S LamE_algebra_on_Lam) --> (ptd_from_alg_functor CC _ Lam).
 Proof.
   simple refine (tpair _ _ _ ).
     + apply (nat_trans_id _ ).
@@ -180,7 +180,7 @@ Proof.
          apply idpath).
 Defined.
 
-Local Definition bla'_inv: (ptd_from_alg_functor CC _ Lam) ⇒ (ptd_from_alg_functor CC LamE_S LamE_algebra_on_Lam).
+Local Definition bla'_inv: (ptd_from_alg_functor CC _ Lam) --> (ptd_from_alg_functor CC LamE_S LamE_algebra_on_Lam).
 Proof.
   simple refine (tpair _ _ _ ).
     + apply (nat_trans_id _ ).

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -94,7 +94,7 @@ Defined.
 Definition Abs_H_ob (X: EndC): functor C C := functor_composite (option_functor _ CC terminal) X.
 
 (* works only with -type-in-type:
-Definition Abs_H_mor_nat_trans_data (X X': EndC)(α: X ⇒ X'): ∀ c, Abs_H_ob X c ⇒ Abs_H_ob X' c.
+Definition Abs_H_mor_nat_trans_data (X X': EndC)(α: X --> X'): ∀ c, Abs_H_ob X c --> Abs_H_ob X' c.
 Proof.
   intro.
   unfold Abs_H_ob.
@@ -102,13 +102,13 @@ Proof.
 Defined.
 *)
 
-Definition Abs_H_mor_nat_trans_data (X X': functor C C)(α: nat_trans X X'): ∀ c, Abs_H_ob X c ⇒ Abs_H_ob X' c.
+Definition Abs_H_mor_nat_trans_data (X X': functor C C)(α: nat_trans X X'): ∀ c, Abs_H_ob X c --> Abs_H_ob X' c.
 Proof.
   intro.
   apply α.
 Defined.
 
-Lemma is_nat_trans_Abs_H_mor_nat_trans_data  (X X': EndC)(α: X ⇒ X'): is_nat_trans _ _ (Abs_H_mor_nat_trans_data X X' α).
+Lemma is_nat_trans_Abs_H_mor_nat_trans_data  (X X': EndC)(α: X --> X'): is_nat_trans _ _ (Abs_H_mor_nat_trans_data X X' α).
 Proof.
   red.
   intros c c' f.
@@ -118,7 +118,7 @@ Proof.
   apply α_nat_trans.
  Qed.
 
-Definition Abs_H_mor (X X': EndC)(α: X ⇒ X'): (Abs_H_ob X: ob EndC) ⇒ Abs_H_ob X'.
+Definition Abs_H_mor (X X': EndC)(α: X --> X'): (Abs_H_ob X: ob EndC) --> Abs_H_ob X'.
 Proof.
   exists (Abs_H_mor_nat_trans_data X X' α).
   exact (is_nat_trans_Abs_H_mor_nat_trans_data X X' α).
@@ -166,7 +166,7 @@ Definition Abs_H : functor [C, C, hs] [C, C, hs] := tpair _ _ is_functor_Abs_H_d
 
 *)
 Definition Flat_H_ob (X: EndC): functor C C := functor_composite X X.
-Definition Flat_H_mor (X X': EndC)(α: X ⇒ X'): (Flat_H_ob X: EndC) ⇒ Flat_H_ob X' := α ∙∙ α.
+Definition Flat_H_mor (X X': EndC)(α: X --> X'): (Flat_H_ob X: EndC) --> Flat_H_ob X' := α ∙∙ α.
 Definition Flat_H_functor_data: functor_data EndC EndC.
 Proof.
   exists Flat_H_ob.
@@ -208,7 +208,7 @@ Definition Flat_H : functor [C, C, hs] [C, C, hs] := tpair _ _ is_functor_Flat_H
 (** here definition of suitable θ's together with their strength laws  *)
 
 
-Definition App_θ_data: ∀ XZ, (θ_source App_H)XZ ⇒ (θ_target App_H)XZ.
+Definition App_θ_data: ∀ XZ, (θ_source App_H)XZ --> (θ_target App_H)XZ.
 Proof.
   intro XZ.
   apply nat_trans_id.
@@ -306,7 +306,7 @@ Proof.
 Qed.
 
 
-Definition Abs_θ_data_data: ∀ XZ A, ((θ_source Abs_H)XZ: functor C C) A ⇒ ((θ_target Abs_H)XZ: functor C C) A.
+Definition Abs_θ_data_data: ∀ XZ A, ((θ_source Abs_H)XZ: functor C C) A --> ((θ_target Abs_H)XZ: functor C C) A.
 Proof.
   intro XZ.
 (*
@@ -414,7 +414,7 @@ Focus 2.
 Qed.
 
 
-Definition Abs_θ_data: ∀ XZ, (θ_source Abs_H)XZ ⇒ (θ_target Abs_H)XZ.
+Definition Abs_θ_data: ∀ XZ, (θ_source Abs_H)XZ --> (θ_target Abs_H)XZ.
 Proof.
   intro XZ.
   exact (tpair _ _ (is_nat_trans_Abs_θ_data_data XZ)).
@@ -539,7 +539,7 @@ Focus 2.
 Qed.
 
 
-Definition Flat_θ_data: ∀ XZ, (θ_source Flat_H)XZ ⇒ (θ_target Flat_H)XZ.
+Definition Flat_θ_data: ∀ XZ, (θ_source Flat_H)XZ --> (θ_target Flat_H)XZ.
 Proof.
   intro XZ.
 (*  destruct XZ as [X [Z e]].

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -531,7 +531,7 @@ Local Definition Ghat : EndEndC := Const_plus_H (pr1 InitAlg).
 Definition constant_nat_trans (C' D : precategory)
    (hsD : has_homsets D)
    (d d' : D)
-   (m : d ⇒ d')
+   (m : d --> d')
     : [C', D, hsD] ⟦constant_functor C' D d, constant_functor C' D d'⟧.
 Proof.
   exists (fun _ => m).
@@ -544,7 +544,7 @@ Proof.
   apply id_right] ).
 Defined.
 
-Definition thetahat_0 (Z : Ptd) (f : Z ⇒ ptd_from_alg  InitAlg):
+Definition thetahat_0 (Z : Ptd) (f : Z --> ptd_from_alg  InitAlg):
 EndEndC
 ⟦ CoproductObject EndEndC
     (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
@@ -618,7 +618,7 @@ Proof.
   - exact (is_nat_trans_iso2' Z).
 Defined.
 
-Definition thetahat (Z : Ptd)  (f : Z ⇒ ptd_from_alg  InitAlg)
+Definition thetahat (Z : Ptd)  (f : Z --> ptd_from_alg  InitAlg)
            : EndEndC ⟦ functor_composite Id_H
                                         (ℓ (U Z)),
                      functor_composite (ℓ (U Z)) (Ghat) ⟧.
@@ -632,7 +632,7 @@ Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
 
 Let Yon (X : EndC) : functor EndC^op HSET := yoneda_objects EndC hsEndC X.
 
-Definition Phi_fusion (Z : Ptd) (X : EndC) (b : pr1 InitAlg ⇒ X) :
+Definition Phi_fusion (Z : Ptd) (X : EndC) (b : pr1 InitAlg --> X) :
   functor_composite (functor_opp (ℓ (U Z))) (Yon (pr1 InitAlg))
    ⟶
   functor_composite (functor_opp (ℓ (U Z))) (Yon X) .
@@ -667,7 +667,7 @@ Proof.
   set (β0 := InitialArrow IA (pr1 T')).
   match goal with | [|- _ ;; ?b = _ ] => set (β := b) end.
   set ( rhohat := CoproductArrow EndC  (CPEndC _ _ )  β (tau_from_alg T')
-                  :  pr1 Ghat T' ⇒ T').
+                  :  pr1 Ghat T' --> T').
   set (X:= SpecializedGMIt Z _ Ghat rhohat (thetahat Z f)).
   pathvia (pr1 (pr1 X)).
   - set (TT:= fusion_law _ _ _ IA _ hsEndC (pr1 InitAlg) T' _ (KanExt Z)).

--- a/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
@@ -98,7 +98,7 @@ Local Notation "f ⊕ g" := (CoproductOfArrows _ (CPEndC _ _ ) (CPEndC _ _ ) f g
 
 Definition μ_0 : functor_identity C ⟶ functor_data_from_functor _ _ `T := η T. (*ptd_pt _ (pr1 (pr1 T)).*)
 
-Definition μ_0_ptd : id_Ptd C hs ⇒ p T.
+Definition μ_0_ptd : id_Ptd C hs --> p T.
 Proof.
   exists μ_0.
   intro c. simpl. apply id_left.
@@ -139,7 +139,7 @@ Proof.
 Qed.
 
 (* The whole secret is that this typechecks
-  Check (μ_1:U T⇒U T).
+  Check (μ_1:U T-->U T).
 *)
 
 (* therefore, it is not just the type itself that makes it necessary to introduce μ_1_alt,
@@ -291,7 +291,7 @@ Proof.
   - apply id_right.
 Qed.
 
-Definition μ_2_ptd : T_squared ⇒ p T.
+Definition μ_2_ptd : T_squared --> p T.
 Proof.
   exists μ_2.
   unfold is_ptd_mor.
@@ -393,12 +393,12 @@ Lemma μ_3_μ_2_T_μ_2 :  (
                  (* (@functor_composite C C C ((functor_ptd_forget C hs) T)
                     ((functor_ptd_forget C hs) T))
                  ((functor_ptd_forget C hs) T) *)
-          ((μ_2 •• `T) (* :  TtimesTthenT' ⇒ _ *)
+          ((μ_2 •• `T) (* :  TtimesTthenT' --> _ *)
                   (*:@functor_compose C C C hs hs
                     (@functor_composite C C C ((functor_ptd_forget C hs) T)
                                               ((functor_ptd_forget C hs) T))
-                    ((functor_ptd_forget C hs) T) ⇒ _*) ) μ_2 :
-            (*TtimesTthenT'*) T•T² ⇒ `T) = μ_3.
+                    ((functor_ptd_forget C hs) T) --> _*) ) μ_2 :
+            (*TtimesTthenT'*) T•T² --> `T) = μ_3.
   unfold μ_3.
   apply (fbracket_unique (*_pointwise*) T μ_2_ptd).
   split.
@@ -411,7 +411,7 @@ Lemma μ_3_μ_2_T_μ_2 :  (
       assert (H1 := Monad_law_1_from_hss (pr1 (`T) c)).
       apply (!H1).
   - set (B:= τ T).
-    match goal with | [|- _ ;; # ?H (?f ;; _ ) ;; _ = _ ] => set (F:=f : (*TtimesTthenT'*) T•T² ⇒ _ ) end.
+    match goal with | [|- _ ;; # ?H (?f ;; _ ) ;; _ = _ ] => set (F:=f : (*TtimesTthenT'*) T•T² --> _ ) end.
     assert (H3:= functor_comp H _ _ _ F μ_2).
     unfold functor_compose in H3.
     eapply pathscomp0. apply cancel_postcomposition. apply maponpaths. apply H3.
@@ -442,12 +442,12 @@ Lemma μ_3_μ_2_T_μ_2 :  (
       eapply pathscomp0. Focus 2. apply assoc.
       eapply pathscomp0. Focus 2. apply maponpaths. apply (!HXX).
       clear HXX.
-      assert (Strength_2 : ∀ α : functor_compose hs hs (functor_composite (`T) (`T))(`T) ⇒ functor_composite (` T) (`T),
+      assert (Strength_2 : ∀ α : functor_compose hs hs (functor_composite (`T) (`T))(`T) --> functor_composite (` T) (`T),
 
                     pr1 (θ (`T ⊗ T_squared)) c ;; pr1 (# H α) c =
                      pr1 (θ ((`T) ⊗ (ptd_from_alg T))) ((pr1 (pr1 (pr1 T))) c);;
                      pr1 (θ (( (`T) • (`T)) ⊗ (ptd_from_alg T))) c;;
-                     pr1 (# H (α : functor_compose hs hs (`T) (functor_composite (`T) (` T))⇒ _)) c       ).
+                     pr1 (# H (α : functor_compose hs hs (`T) (functor_composite (`T) (` T))--> _)) c       ).
       { (intro α;
           assert (HA := θ_Strength2_int_implies_θ_Strength2 _ _ _ _ θ_strength2_int);
           assert (HA':= HA (`T) (ptd_from_alg T) (ptd_from_alg T) _ α); clear HA;
@@ -504,7 +504,7 @@ Section third_monad_law_with_assoc.
 Lemma third_monad_law_from_hss :
   (`T ∘ μ_2 : EndC ⟦ functor_composite (functor_composite `T `T) `T , `T • `T ⟧) ;; μ_2
   =
-  (α_functor _ _ _ _ : functor_compose hs hs _ _  ⇒ _) ;; (μ_2 •• `T) ;; μ_2.
+  (α_functor _ _ _ _ : functor_compose hs hs _ _  --> _) ;; (μ_2 •• `T) ;; μ_2.
 Proof.
   pathvia μ_3; [apply pathsinv0, μ_3_T_μ_2_μ_2 | ].
   apply pathsinv0.

--- a/UniMath/SubstitutionSystems/Signatures.v
+++ b/UniMath/SubstitutionSystems/Signatures.v
@@ -65,8 +65,8 @@ Local Notation "'EndC'":= ([C, C, hs]) .
 (** Source is given by [(X,Z) => H(X)∙U(Z)] *)
 Definition θ_source_ob (FX : EndC XX Ptd) : [C, C, hs] := H (pr1 FX) • U (pr2 FX).
 
-Definition θ_source_mor {FX FX' : EndC XX Ptd} (αβ : FX ⇒ FX')
-  : θ_source_ob FX ⇒ θ_source_ob FX' := hor_comp (#U (pr2 αβ)) (#H (pr1 αβ)).
+Definition θ_source_mor {FX FX' : EndC XX Ptd} (αβ : FX --> FX')
+  : θ_source_ob FX --> θ_source_ob FX' := hor_comp (#U (pr2 αβ)) (#H (pr1 αβ)).
 
 
 Definition θ_source_functor_data : functor_data (EndC XX Ptd) EndC.
@@ -121,8 +121,8 @@ Definition θ_source : functor _ _ := tpair _ _ is_functor_θ_source.
 
 Definition θ_target_ob (FX : EndC XX Ptd) : EndC := H (pr1 FX • U (pr2 FX)).
 
-Definition θ_target_mor (FX FX' : EndC XX Ptd) (αβ : FX ⇒ FX')
-  : θ_target_ob FX ⇒ θ_target_ob FX'
+Definition θ_target_mor (FX FX' : EndC XX Ptd) (αβ : FX --> FX')
+  : θ_target_ob FX --> θ_target_ob FX'
   := #H (pr1 αβ ∙∙ #U(pr2 αβ)).
 
 Definition θ_target_functor_data : functor_data (EndC XX Ptd) EndC.
@@ -235,17 +235,17 @@ Hypothesis θ_strength1 : θ_Strength1.
 *)
 
 Definition θ_Strength2 : UU := ∀ (X : EndC) (Z Z' : Ptd) (Y : EndC)
-           (α : functor_compose hs hs (functor_composite (U Z) (U Z')) X ⇒ Y),
+           (α : functor_compose hs hs (functor_composite (U Z) (U Z')) X --> Y),
     θ (X ⊗ (Z p• Z' : Ptd)) ;; # H α =
     θ (X ⊗ Z') •• (U Z) ;; θ ((functor_compose hs hs (U Z') X) ⊗ Z) ;;
-       # H (α : functor_compose hs hs (U Z) (X • (U Z')) ⇒ Y).
+       # H (α : functor_compose hs hs (U Z) (X • (U Z')) --> Y).
 
 Section Strength_law_2_intensional.
 
 Definition θ_Strength2_int : UU
   := ∀ (X : EndC) (Z Z' : Ptd),
       θ (X ⊗ (Z p• Z'))  ;; #H (α_functor _ (U Z) (U Z') X )  =
-      (α_functor _ (U Z) (U Z') (H X) : functor_compose hs hs _ _  ⇒ _ ) ;;
+      (α_functor _ (U Z) (U Z') (H X) : functor_compose hs hs _ _  --> _ ) ;;
       θ (X ⊗ Z') •• (U Z) ;; θ ((functor_compose hs hs (U Z') X) ⊗ Z) .
 
 Lemma θ_Strength2_int_implies_θ_Strength2 : θ_Strength2_int → θ_Strength2.
@@ -265,7 +265,7 @@ Proof.
   apply maponpaths.
   clear TXZZ'c.
   assert (functor_comp_H := functor_comp H _ _ _ (α_functor C (pr1 Z) (pr1 Z') X)
-           (a : functor_compose hs hs (U Z) (functor_composite (U Z') X) ⇒ Y)).
+           (a : functor_compose hs hs (U Z) (functor_composite (U Z') X) --> Y)).
   assert (functor_comp_H_c := nat_trans_eq_pointwise functor_comp_H c).
   simpl in functor_comp_H_c.
   eapply pathscomp0.
@@ -321,7 +321,7 @@ Hypothesis θ_strength2 : θ_Strength2.
 (** Not having a general theory of binatural transformations, we isolate
     naturality in each component here *)
 
-Lemma θ_nat_1 (X X' : EndC) (α : X ⇒ X') (Z : Ptd)
+Lemma θ_nat_1 (X X' : EndC) (α : X --> X') (Z : Ptd)
   : compose(C:=EndC) (# H α ∙∙ nat_trans_id (pr1 (U Z))) (θ (X' ⊗ Z)) =
         θ (X ⊗ Z);; # H (α ∙∙ nat_trans_id (pr1 (U Z))).
 Proof.
@@ -333,14 +333,14 @@ Proof.
 Qed.
 
 (* the following makes sense but is wrong
-Lemma θ_nat_1' (X X' : EndC) (α : X ⇒ X') (Z : Ptd)
+Lemma θ_nat_1' (X X' : EndC) (α : X --> X') (Z : Ptd)
   : compose(C:=EndC) (# H α øø (U Z)) (θ (X' ⊗ Z)) =
         θ (X ⊗ Z);; # H (α øø (U Z)).
 Proof.
 Abort.
 *)
 
-Lemma θ_nat_1_pointwise (X X' : EndC) (α : X ⇒ X') (Z : Ptd) (c : C)
+Lemma θ_nat_1_pointwise (X X' : EndC) (α : X --> X') (Z : Ptd) (c : C)
   :  pr1 (# H α) ((pr1 Z) c);; pr1 (θ (X' ⊗ Z)) c =
        pr1 (θ (X ⊗ Z)) c;; pr1 (# H (α ∙∙ nat_trans_id (pr1 Z))) c.
 Proof.
@@ -358,7 +358,7 @@ Proof.
   - apply t'.
 Qed.
 
-Lemma θ_nat_2 (X : EndC) (Z Z' : Ptd) (f : Z ⇒ Z')
+Lemma θ_nat_2 (X : EndC) (Z Z' : Ptd) (f : Z --> Z')
   : compose (C:=EndC) (identity (H X) ∙∙ pr1 f) (θ (X ⊗ Z')) =
        θ (X ⊗ Z);; # H (identity X ∙∙ pr1 f).
 Proof.
@@ -374,7 +374,7 @@ Proof.
   exact t'.
 Qed.
 
-Lemma θ_nat_2_pointwise (X : EndC) (Z Z' : Ptd) (f : Z ⇒ Z') (c : C)
+Lemma θ_nat_2_pointwise (X : EndC) (Z Z' : Ptd) (f : Z --> Z') (c : C)
   :  # (pr1 (H X)) ((pr1 f) c);; pr1 (θ (X ⊗ Z')) c =
        pr1 (θ (X ⊗ Z)) c;; pr1 (# H (identity X ∙∙ pr1 f)) c .
 Proof.

--- a/UniMath/SubstitutionSystems/SubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/SubstitutionSystems.v
@@ -104,36 +104,36 @@ Coercion functor_from_algebra_ob (X : algebra_ob _ Id_H) : functor C C  := pr1 X
 Local Notation "f ⊕ g" := (CoproductOfArrows _ (CPEndC _ _ ) (CPEndC _ _ ) f g) (at level 40).
 
 
-Definition bracket_property (T : algebra_ob Id_H) {Z : Ptd} (f : Z ⇒ ptd_from_alg T)
-           (h : `T • (U Z)  ⇒ `T) : UU
+Definition bracket_property (T : algebra_ob Id_H) {Z : Ptd} (f : Z --> ptd_from_alg T)
+           (h : `T • (U Z)  --> `T) : UU
   :=
     alg_map _ T •• (U Z) ;; h =
           identity (U Z) ⊕ θ (`T ⊗ Z) ;;
           identity (U Z) ⊕ #H h ;;
           CoproductArrow _ (CPEndC _ _ ) (#U f) (tau_from_alg T).
 
-Definition bracket_at (T : algebra_ob Id_H) {Z : Ptd} (f : Z ⇒ ptd_from_alg T): UU :=
-  ∃! h : `T • (U Z)  ⇒ `T, bracket_property T f h.
+Definition bracket_at (T : algebra_ob Id_H) {Z : Ptd} (f : Z --> ptd_from_alg T): UU :=
+  ∃! h : `T • (U Z)  --> `T, bracket_property T f h.
 
 Definition bracket (T : algebra_ob Id_H) : UU
-  := ∀ (Z : Ptd) (f : Z ⇒ ptd_from_alg T), bracket_at T f.
+  := ∀ (Z : Ptd) (f : Z --> ptd_from_alg T), bracket_at T f.
 
-Definition bracket_property_parts (T : algebra_ob Id_H) {Z : Ptd} (f : Z ⇒ ptd_from_alg T)
-           (h : `T • (U Z)  ⇒ `T) : UU
+Definition bracket_property_parts (T : algebra_ob Id_H) {Z : Ptd} (f : Z --> ptd_from_alg T)
+           (h : `T • (U Z)  --> `T) : UU
   :=
     (#U f = η T •• (U Z) ;; h) ×
      (θ (`T ⊗ Z) ;; #H h ;; τ T  = τ T •• (U Z) ;;  h).
 
-Definition bracket_parts_at (T : algebra_ob Id_H) {Z : Ptd} (f : Z ⇒ ptd_from_alg T) : UU :=
-   ∃! h : `T • (U Z)  ⇒ `T, bracket_property_parts T f h.
+Definition bracket_parts_at (T : algebra_ob Id_H) {Z : Ptd} (f : Z --> ptd_from_alg T) : UU :=
+   ∃! h : `T • (U Z)  --> `T, bracket_property_parts T f h.
 
 Definition bracket_parts (T : algebra_ob Id_H) : UU
-  := ∀ (Z : Ptd) (f : Z ⇒ ptd_from_alg T), bracket_parts_at T f.
+  := ∀ (Z : Ptd) (f : Z --> ptd_from_alg T), bracket_parts_at T f.
 
 (* show that for any h of suitable type, the following are equivalent *)
 
-Lemma parts_from_whole (T : algebra_ob Id_H) (Z : Ptd) (f : Z ⇒ ptd_from_alg T)
-      (h :  `T • (U Z)  ⇒ `T) :
+Lemma parts_from_whole (T : algebra_ob Id_H) (Z : Ptd) (f : Z --> ptd_from_alg T)
+      (h :  `T • (U Z)  --> `T) :
   bracket_property T f h → bracket_property_parts T f h.
 Proof.
   intro Hyp.
@@ -187,8 +187,8 @@ Proof.
       apply idpath.
 Qed.
 
-Lemma whole_from_parts (T : algebra_ob Id_H) (Z : Ptd) (f : Z ⇒ ptd_from_alg T)
-      (h :  `T • (U Z)  ⇒ `T) :
+Lemma whole_from_parts (T : algebra_ob Id_H) (Z : Ptd) (f : Z --> ptd_from_alg T)
+      (h :  `T • (U Z)  --> `T) :
   bracket_property_parts T f h → bracket_property T f h.
 Proof.
   intros [Hyp1 Hyp2].
@@ -240,15 +240,15 @@ Definition hss : UU := Σ T, bracket T.
 Coercion alg_from_hss (T : hss) : algebra_ob Id_H := pr1 T.
 
 
-Definition fbracket (T : hss) {Z : Ptd} (f : Z ⇒ ptd_from_alg T)
-  : `T • (U Z) ⇒ `T
+Definition fbracket (T : hss) {Z : Ptd} (f : Z --> ptd_from_alg T)
+  : `T • (U Z) --> `T
   := pr1 (pr1 (pr2 T Z f)).
 
 Notation "⦃ f ⦄" := (fbracket _ f)(at level 0).
 
 (** The bracket operation [fbracket] is unique *)
 
-Definition fbracket_unique_pointwise (T : hss) {Z : Ptd} (f : Z ⇒ ptd_from_alg T)
+Definition fbracket_unique_pointwise (T : hss) {Z : Ptd} (f : Z --> ptd_from_alg T)
   : ∀ (α : functor_composite (U Z) `T ⟶ pr1 `T),
      (∀ c : C, pr1 (#U f) c = pr1 (η T) (pr1 (U Z) c) ;; α c) →
      (∀ c : C, pr1 (θ (`T ⊗ Z))  c ;; pr1 (#H α) c ;; pr1 (τ T) c =
@@ -264,8 +264,8 @@ Proof.
   - apply nat_trans_eq; assumption.
 Qed.
 
-Definition fbracket_unique (T : hss) {Z : Ptd} (f : Z ⇒ ptd_from_alg T)
-: ∀ α : (*functor_composite (C:=C)*) `T • (U Z)  ⇒ `T,
+Definition fbracket_unique (T : hss) {Z : Ptd} (f : Z --> ptd_from_alg T)
+: ∀ α : (*functor_composite (C:=C)*) `T • (U Z)  --> `T,
     bracket_property_parts T f α
    →
    α = ⦃f⦄.
@@ -276,8 +276,8 @@ Proof.
   split;  assumption.
 Qed.
 
-Definition fbracket_unique_target_pointwise (T : hss) {Z : Ptd} (f : Z ⇒ ptd_from_alg T)
-  : ∀ α : `T • U Z ⇒ `T,
+Definition fbracket_unique_target_pointwise (T : hss) {Z : Ptd} (f : Z --> ptd_from_alg T)
+  : ∀ α : `T • U Z --> `T,
         bracket_property_parts T f α
    →
    ∀ c, pr1 α c =  pr1 ⦃ f ⦄ c.
@@ -289,7 +289,7 @@ Qed.
 
 (** Properties of [fbracket] by definition: commutative diagrams *)
 
-Lemma fbracket_η (T : hss) : ∀ {Z : Ptd} (f : Z ⇒ ptd_from_alg T),
+Lemma fbracket_η (T : hss) : ∀ {Z : Ptd} (f : Z --> ptd_from_alg T),
    #U f = η T •• U Z ;; ⦃f⦄.
 Proof.
   intros Z f.
@@ -297,7 +297,7 @@ Proof.
   exact (pr1 (parts_from_whole _ _ _ _  (pr2 (pr1 (pr2 T Z f))))).
 Qed.
 
-Lemma fbracket_τ (T : hss) : ∀ {Z : Ptd} (f : Z ⇒ ptd_from_alg T),
+Lemma fbracket_τ (T : hss) : ∀ {Z : Ptd} (f : Z --> ptd_from_alg T),
     θ (`T ⊗ Z) ;; #H ⦃f⦄ ;; τ T
     =
     τ T •• U Z ;; ⦃f⦄.
@@ -308,7 +308,7 @@ Qed.
 
 (** [fbracket] is also natural *)
 
-Lemma fbracket_natural (T : hss) {Z Z' : Ptd} (f : Z ⇒ Z') (g : Z' ⇒ ptd_from_alg T)
+Lemma fbracket_natural (T : hss) {Z Z' : Ptd} (f : Z --> Z') (g : Z' --> ptd_from_alg T)
 :  (` T ∘ # U f : EndC ⟦ `T • U Z , `T • U Z' ⟧) ;; ⦃ g ⦄ = ⦃ f ;; g ⦄.
 Proof.
   apply fbracket_unique_pointwise.
@@ -366,7 +366,7 @@ Qed.
 
 (** As a consequence of naturality, we can compute [fbracket f] from [fbracket identity] *)
 
-Lemma compute_fbracket (T : hss) : ∀ {Z : Ptd} (f : Z ⇒ ptd_from_alg T),
+Lemma compute_fbracket (T : hss) : ∀ {Z : Ptd} (f : Z --> ptd_from_alg T),
     ⦃ f ⦄ = (` T ∘ # U f : EndC ⟦ `T • U Z , `T • U (p T) ⟧) ;; ⦃ identity p T ⦄.
 Proof.
   intros Z f.
@@ -385,10 +385,10 @@ Qed.
 
 (** A morphism [f] of pointed functors is an algebra morphism when... *)
 (*
-Definition isAlgMor {T T' : Alg} (f : T ⇒ T') : UU :=
+Definition isAlgMor {T T' : Alg} (f : T --> T') : UU :=
   #H (# U f) ;; τ T' = compose (C:=EndC) (τ T) (#U f).
 
-Lemma isaprop_isAlgMor (T T' : Alg) (f : T ⇒ T') : isaprop (isAlgMor f).
+Lemma isaprop_isAlgMor (T T' : Alg) (f : T --> T') : isaprop (isAlgMor f).
 Proof.
   apply isaset_nat_trans.
   apply hs.
@@ -446,7 +446,7 @@ Proof.
 Qed.
 
 Definition ptd_from_alg_mor {T T' : algebra_ob Id_H} (β : algebra_mor _ T T')
-: ptd_from_alg T ⇒ ptd_from_alg T'.
+: ptd_from_alg T --> ptd_from_alg T'.
 Proof.
   exists (pr1 β).
   apply is_ptd_mor_alg_mor.
@@ -484,7 +484,7 @@ Definition ptd_from_alg_functor: functor (precategory_FunctorAlg Id_H hsEndC) Pt
 
 
 Definition isbracketMor {T T' : hss} (β : algebra_mor _ T T') : UU :=
-    ∀ (Z : Ptd) (f : Z ⇒ ptd_from_alg T),
+    ∀ (Z : Ptd) (f : Z --> ptd_from_alg T),
       ⦃ f ⦄ ;; β = β •• U Z ;; ⦃ f ;; # ptd_from_alg_functor β ⦄.
 
 

--- a/UniMath/SubstitutionSystems/SumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/SumOfSignatures.v
@@ -79,7 +79,7 @@ Local Definition bla1 (X : [C, C, hs]) (Z : precategory_Ptd C hs) :
    ∀ c : C,
     (functor_composite_data (pr1 Z)
      (coproduct_functor_data C C CC (H1 X) (H2 X))) c
-   ⇒ (coproduct_functor_data C C CC (H1 (functor_composite (pr1 Z) X))
+   --> (coproduct_functor_data C C CC (H1 (functor_composite (pr1 Z) X))
        (H2 (functor_composite (pr1 Z) X))) c.
 Proof.
   intro c.
@@ -116,7 +116,7 @@ Proof.
 Defined.
 
 
-Definition θ_ob : ∀ XF, θ_source H XF ⇒ θ_target H XF.
+Definition θ_ob : ∀ XF, θ_source H XF --> θ_target H XF.
 Proof.
   intro XZ.
   destruct XZ as [X Z].


### PR DESCRIPTION
and remove the notation from the file CT/UnicodeNotations.v

The same notation '⇒' is still used in package Folds, but since this is a leaf package for now, that's less disturbing.