### PR TITLE
fix notations

### DIFF
--- a/UniMath/CategoryTheory/UnicodeNotations.v
+++ b/UniMath/CategoryTheory/UnicodeNotations.v
@@ -3,11 +3,6 @@ Require Export UniMath.Foundations.Basics.PartD
                UniMath.CategoryTheory.precategories
                UniMath.CategoryTheory.functor_categories.
 
-Notation "x → y" := (x -> y)
-  (at level 99, y at level 200, right associativity): type_scope.
-(* written \to in Agda input method *)
-(* the level comes from sub/coq/theories/Unicode/Utf8_core.v *)
-
 Notation "a --> b" := (precategory_morphisms a b)(at level 50).
 
 Notation "f ;; g" := (compose f g) (at level 50, format "f  ;;  g", left associativity).

--- a/UniMath/CategoryTheory/UnicodeNotations.v
+++ b/UniMath/CategoryTheory/UnicodeNotations.v
@@ -4,8 +4,9 @@ Require Export UniMath.Foundations.Basics.PartD
                UniMath.CategoryTheory.functor_categories.
 
 Notation "x → y" := (x -> y)
-  (at level 90, y at level 200, right associativity): type_scope.
+  (at level 99, y at level 200, right associativity): type_scope.
 (* written \to in Agda input method *)
+(* the level comes from sub/coq/theories/Unicode/Utf8_core.v *)
 
 Notation "a --> b" := (precategory_morphisms a b)(at level 50).
 

--- a/UniMath/Folds/UnicodeNotations.v
+++ b/UniMath/Folds/UnicodeNotations.v
@@ -10,8 +10,10 @@ Notation "'Σ'  x .. y , P" := (total2 (fun x => .. (total2 (fun y => P)) ..))
 Notation "A × B" := (dirprod A B) (at level 80, no associativity) : type_scope.
 Notation "X ≃ Y" := (weq X Y) (at level 80, no associativity) : type_scope.
 *)
+
 Notation "x → y" := (x -> y)
-  (at level 90, y at level 200, right associativity): type_scope.
+  (at level 99, y at level 200, right associativity): type_scope.
+  (* the level comes from sub/coq/theories/Unicode/Utf8_core.v *)
 
 (*
 Notation "'λ' x .. y , t" := (fun x => .. (fun y => t) ..)

--- a/UniMath/Folds/UnicodeNotations.v
+++ b/UniMath/Folds/UnicodeNotations.v
@@ -11,10 +11,6 @@ Notation "A × B" := (dirprod A B) (at level 80, no associativity) : type_scope.
 Notation "X ≃ Y" := (weq X Y) (at level 80, no associativity) : type_scope.
 *)
 
-Notation "x → y" := (x -> y)
-  (at level 99, y at level 200, right associativity): type_scope.
-  (* the level comes from sub/coq/theories/Unicode/Utf8_core.v *)
-
 (*
 Notation "'λ' x .. y , t" := (fun x => .. (fun y => t) ..)
   (at level 200, x binder, y binder, right associativity).

--- a/UniMath/Foundations/Basics/Preamble.v
+++ b/UniMath/Foundations/Basics/Preamble.v
@@ -200,6 +200,10 @@ Check (O = O) .
 
 Notation "X <- Y" := (Y -> X) (at level 90, only parsing, left associativity) : type_scope.
 
+Notation "x → y" := (x -> y)
+  (at level 99, y at level 200, right associativity): type_scope.
+(* written \to or \r- in Agda input method *)
+(* the level comes from sub/coq/theories/Unicode/Utf8_core.v *)
 
 (* so we do it the other way around: *)
 Definition mul : nat -> nat -> nat.

--- a/UniMath/Ktheory/AbelianGroup.v
+++ b/UniMath/Ktheory/AbelianGroup.v
@@ -538,3 +538,9 @@ Module Category.
   End DirectSum.
 
 End Category.
+
+(*
+Local Variables:
+compile-command: "make -C ../.. TAGS UniMath/Ktheory/AbelianGroup.vo"
+End:
+*)

--- a/UniMath/Ktheory/AbelianMonoid.v
+++ b/UniMath/Ktheory/AbelianMonoid.v
@@ -24,26 +24,26 @@ Lemma fun_assoc {W X Y Z} (f:W->X) (g:X->Y) (h:Y->Z) :
 Proof. reflexivity. Defined.
 Lemma nelstructoncomplmap  {X:UU} {n}
       (x:X) (sx:nelstruct (S n) X) :
-    pr1 (nelstructoncompl x sx) ;; pr1compl X x
-  = dni n (invmap sx x) ;; pr1weq sx.
+    pr1compl X x ∘ pr1 (nelstructoncompl x sx)
+  = pr1weq sx ∘ dni n (invmap sx x).
 Proof. intros.
        try reflexivity.
        try reflexivity.
 Abort.
 Lemma nelstructoncomplmap'  {I:UU} {n}
       (i:stn(S n)) (sx:nelstruct (S n) I) :
-    pr1 (nelstructoncompl (pr1weq sx i) sx) ;; pr1compl I (pr1weq sx i)
-  = dni n (invmap sx (pr1weq sx i)) ;; pr1weq sx.
+    pr1compl I (pr1weq sx i) ∘ pr1 (nelstructoncompl (pr1weq sx i) sx)
+  = pr1weq sx ∘ dni n (invmap sx (pr1weq sx i)).
 Proof.
   try reflexivity.
   try reflexivity.
 Abort.
 Lemma nelstructoncomplmap''  {I:UU} {n}
       (i:stn(S n)) (sx:nelstruct (S n) I) :
-    pr1 (nelstructoncompl (pr1weq sx i) sx) ;; pr1compl I (pr1weq sx i)
-  = dni n i ;; pr1weq sx.
+    pr1compl I (pr1weq sx i) ∘ pr1 (nelstructoncompl (pr1weq sx i) sx)
+  = pr1weq sx ∘ dni n i.
 Proof. intros.
-       intermediate_path (dni n (invmap sx (pr1weq sx i));; pr1weq sx).
+       intermediate_path (pr1weq sx ∘ dni n (invmap sx (pr1weq sx i))).
        { try reflexivity.
          try reflexivity.
 (*        } *)
@@ -51,8 +51,8 @@ Proof. intros.
 (* Defined. *)
 Abort.
 Lemma nelstructoncomplmap'''  {I:UU} {n} (sx:nelstruct (S n) I) :
-    pr1 (nelstructoncompl (pr1weq sx (lastelement n)) sx) ;; pr1compl I (pr1weq sx (lastelement n))
-  = dni_last n ;; pr1weq sx.
+    pr1compl I (pr1weq sx (lastelement n)) ∘ pr1 (nelstructoncompl (pr1weq sx (lastelement n)) sx)
+  = pr1weq sx ∘ dni_last n.
 Proof. intros.
 (*        apply nelstructoncomplmap''. *)
 (* Defined. *)
@@ -121,7 +121,7 @@ Proof.
     * reflexivity.
 Defined.
 
-Lemma transposition_squared {X} (dec: isdeceq X) (i j:X) : transposition0 dec i j ;; transposition0 dec i j ~ idfun X.
+Lemma transposition_squared {X} (dec: isdeceq X) (i j:X) : transposition0 dec i j ∘ transposition0 dec i j ~ idfun X.
 Proof.
   intros.
   unfold homot.
@@ -271,7 +271,7 @@ Proof.
 Defined.
 
 Lemma rotate_left_stn_2 n i j :
-  rotate_left_stn_0 n (i+j) ~ rotate_left_stn_0 n j ;; rotate_left_stn_0 n i.
+  rotate_left_stn_0 n (i+j) ~ rotate_left_stn_0 n i ∘ rotate_left_stn_0 n j.
 Proof.
   intros ? ? ? k.
   destruct n.
@@ -302,7 +302,7 @@ Proof.
     (*     unfold pr1weq in p', q'. *)
     (*     induction p', q', e. *)
     (*     apply (IH (compl I (pr1 f (lastelement n))) *)
-    (*               f' g' (pr1compl I (pr1 f (lastelement n)) ;; x)). } *)
+    (*               f' g' (x ∘ pr1compl I (pr1 f (lastelement n)))). } *)
     (*   { exact (ap x e). } } *)
     (* { *)
 

--- a/UniMath/Ktheory/Bifunctor.v
+++ b/UniMath/Ktheory/Bifunctor.v
@@ -126,9 +126,9 @@ Defined.
 Definition Functor_eq_map {A B: Precategory} (F G:[A,B]) :
   F = G ->
   Σ (ob : ∀ a, F ◾ a = G ◾ a),
-  ∀ a a' f, transportf (λ k, k → G ◾ a')
+  ∀ a a' f, transportf (λ k, k --> G ◾ a')
                        (ob a)
-                       (transportf (λ k, F ◾ a → k)
+                       (transportf (λ k, F ◾ a --> k)
                                    (ob a')
                                    (F ▭ f)) = G ▭ f.
 Proof.
@@ -146,9 +146,9 @@ Admitted.
 Lemma Functor_eq_weq {A B: Precategory} (F G:[A,B]) :
   F = G ≃
   Σ (ob : ∀ a, F ◾ a = G ◾ a),
-  ∀ a a' f, transportf (λ k, k → G ◾ a')
+  ∀ a a' f, transportf (λ k, k --> G ◾ a')
                        (ob a)
-                       (transportf (λ k, F ◾ a → k)
+                       (transportf (λ k, F ◾ a --> k)
                                    (ob a')
                                    (F ▭ f)) = G ▭ f.
 Proof.
@@ -157,9 +157,9 @@ Defined.
 
 Lemma Functor_eq {A B: Precategory} {F G:[A,B]}
       (ob : ∀ a, F ◾ a = G ◾ a)
-      (mor : ∀ a a' f, transportf (λ k, k → G ◾ a')
+      (mor : ∀ a a' f, transportf (λ k, k --> G ◾ a')
                                   (ob a)
-                                  (transportf (λ k, F ◾ a → k)
+                                  (transportf (λ k, F ◾ a --> k)
                                               (ob a')
                                               (F ▭ f)) = G ▭ f) :
   F = G.
@@ -188,7 +188,7 @@ Definition θ_1 {B C:Precategory} (F : [B, C]) (X : [B, [C^op, SET]]) : hSet
 
 Definition θ_2 {B C:Precategory} (F : [B, C]) (X : [B, [C^op, SET]])
            (x : θ_1 F X) : hSet
-  := (∀ (b' b:B) (f:b'→b), x b ⟲ F ▭ f = X ▭ f ⟳ x b' ) % set.
+  := (∀ (b' b:B) (f:b'-->b), x b ⟲ F ▭ f = X ▭ f ⟳ x b' ) % set.
 
 Definition θ {B C:Precategory} (F : [B, C]) (X : [B, [C^op, SET]]) : hSet
   := ( Σ x : θ_1 F X, θ_2 F X x ) % set.
@@ -205,11 +205,11 @@ Proof.
 Defined.
 
 Definition θ_map_1 {B C:Precategory} {F' F:[B, C]} {X : [B, [C^op, SET]]} :
-  F' → F -> F ⟹ X -> θ_1 F' X
+  F' --> F -> F ⟹ X -> θ_1 F' X
   := λ p xe b, pr1 xe b ⟲ p ◽ b.
 
 Definition θ_map_2 {B C:Precategory} {F' F:[B, C]} {X : [B, [C^op, SET]]}
-  (p : F' → F) (xe : F ⟹ X) : θ_2 F' X (θ_map_1 p xe).
+  (p : F' --> F) (xe : F ⟹ X) : θ_2 F' X (θ_map_1 p xe).
 Proof.
   induction xe as [x e]. unfold θ_map_1; unfold θ_1 in x; unfold θ_2 in e.
   intros b' b f; simpl.
@@ -222,17 +222,17 @@ Proof.
 Qed.
 
 Definition θ_map {B C:Precategory} {F' F:[B, C]} {X : [B, [C^op, SET]]} :
-  F' → F -> F ⟹ X -> F' ⟹ X
+  F' --> F -> F ⟹ X -> F' ⟹ X
   := λ p xe, θ_map_1 p xe ,, θ_map_2 p xe.
 
 Notation "xe ⟲⟲ p" := (θ_map p xe) (at level 50) : cat.
 
 Definition φ_map_1 {B C:Precategory} {F:[B, C]} {X' X: [B, [C^op, SET]]} :
-  F ⟹ X -> X → X' -> θ_1 F X'
+  F ⟹ X -> X --> X' -> θ_1 F X'
   := λ x p b, p ◽ b ⟳ pr1 x b.
 
 Definition φ_map_2 {B C:Precategory} {F:[B, C]} {X' X: [B, [C^op, SET]]}
-  (x : F ⟹ X) (p : X → X') : θ_2 F X' (φ_map_1 x p).
+  (x : F ⟹ X) (p : X --> X') : θ_2 F X' (φ_map_1 x p).
 Proof.
   induction x as [x e]. unfold φ_map_1; unfold θ_1 in x; unfold θ_2 in e; unfold θ_2.
   intros b b' f; simpl.
@@ -243,7 +243,7 @@ Proof.
 Qed.
 
 Definition φ_map {B C:Precategory} {F:[B, C]} {X' X: [B, [C^op, SET]]} :
-  F ⟹ X -> X → X' -> F ⟹ X'
+  F ⟹ X -> X --> X' -> F ⟹ X'
   := λ x p, φ_map_1 x p,, φ_map_2 x p.
 
 Definition bifunctor_assoc {B C:Precategory} : [B, [C^op,SET]] ==> [[B,C]^op,SET].

--- a/UniMath/Ktheory/Elements.v
+++ b/UniMath/Ktheory/Elements.v
@@ -11,7 +11,7 @@ Local Open Scope cat.
 Definition cat_ob_mor {C} (X:C==>SET) : precategory_ob_mor.
   intros. exists (Σ c:ob C, X c : hSet).
   intros a b.
-  exact (Σ f : pr1 a → pr1 b, #X f (pr2 a) = (pr2 b)).
+  exact (Σ f : pr1 a --> pr1 b, #X f (pr2 a) = (pr2 b)).
 Defined.
 
 
@@ -32,9 +32,9 @@ Proof.
   - intro f. apply isasetaprop, setproperty.
 Qed.
 
-Definition get_mor {C} {X:C==>SET} {x y:ob (cat_data X)} (f:x → y) := pr1 f.
+Definition get_mor {C} {X:C==>SET} {x y:ob (cat_data X)} (f:x --> y) := pr1 f.
 
-Lemma mor_equality {C} (X:C==>SET) (x y:ob (cat_data X)) (f g:x → y) :
+Lemma mor_equality {C} (X:C==>SET) (x y:ob (cat_data X)) (f g:x --> y) :
       get_mor f = get_mor g -> f = g.
 Proof. intros ? ? ? ? ? ? p. apply subtypeEquality.
        - intro r. apply setproperty.
@@ -55,7 +55,7 @@ Definition get_ob {C:Precategory} {X:C==>SET} (x:ob (cat X)) := pr1 x.
 
 Definition get_el {C:Precategory} {X:C==>SET} (x:ob (cat X)) := pr2 x.
 
-Definition get_eqn {C} {X:C==>SET} {x y:ob (cat_data X)} (f:x → y) := pr2 f.
+Definition get_eqn {C} {X:C==>SET} {x y:ob (cat_data X)} (f:x --> y) := pr2 f.
 
 Definition make_ob {C:Precategory} (X:C==>SET) (c:ob C) (x:X c:hSet) : ob (cat X)
   := (c,,x).

--- a/UniMath/Ktheory/Nat.v
+++ b/UniMath/Ktheory/Nat.v
@@ -367,6 +367,6 @@ Proof. intros ? ? ? i p.
 
 (*
 Local Variables:
-compile-command: "make -helper_C ../.. TAGS UniMath/Ktheory/Nat.vo"
+compile-command: "make -C ../.. TAGS UniMath/Ktheory/Nat.vo"
 End:
 *)

--- a/UniMath/Ktheory/Precategories.v
+++ b/UniMath/Ktheory/Precategories.v
@@ -19,14 +19,14 @@ Arguments id_left [C a b] f.
 Arguments id_right [C a b] f.
 Arguments assoc [C a b c d] f g h.
 
-Notation "a → b" := (@precategory_morphisms _ a b) (at level 50) : cat.
+Notation "a --> b" := (@precategory_morphisms _ a b) (at level 50) : cat.
 (* agda input \r- *)
 
-Notation "a ← b" := (@precategory_morphisms (opp_precat _) a b) (at level 50) : cat.
+Notation "a <-- b" := (@precategory_morphisms (opp_precat _) a b) (at level 50) : cat.
 (* agda input \l- *)
 
-Definition src {C:precategory} {a b:C} (f:a→b) : C := a.
-Definition tar {C:precategory} {a b:C} (f:a→b) : C := b.
+Definition src {C:precategory} {a b:C} (f:a-->b) : C := a.
+Definition tar {C:precategory} {a b:C} (f:a-->b) : C := b.
 
 Definition Precategory := Σ C:precategory, has_homsets C.
 Definition Precategory_pair C h : Precategory := C,,h.
@@ -35,10 +35,10 @@ Coercion Precategory_to_precategory : Precategory >-> precategory.
 Definition homset_property (C:Precategory) : has_homsets C := pr2 C.
 
 Definition hom (C:precategory_data) : ob C -> ob C -> UU :=
-  λ c c', c → c'.
+  λ c c', c --> c'.
 
 Definition Hom (C:Precategory) : ob C -> ob C -> hSet :=
-  λ c c', hSetpair (c → c') (homset_property C _ _ ).
+  λ c c', hSetpair (c --> c') (homset_property C _ _ ).
 
 Ltac eqn_logic :=
   abstract (
@@ -129,7 +129,7 @@ Definition category_pair (C:precategory) (i:is_category C) : category := C,,i.
 Definition theUnivalenceProperty (C:category) := pr2 _ : is_category C.
 
 Definition reflects_isos {C D} (X:C==>D) :=
-  ∀ c c' (f : c → c'), is_isomorphism (#X f) -> is_isomorphism f.
+  ∀ c c' (f : c --> c'), is_isomorphism (#X f) -> is_isomorphism f.
 
 Lemma isaprop_reflects_isos {C D} (X:C==>D) : isaprop (reflects_isos X).
 Proof.
@@ -205,9 +205,9 @@ Definition makePrecategory
 
 Definition makeFunctor {C D:Precategory}
            (obj : C -> D)
-           (mor : ∀ c c' : C, c → c' -> obj c → obj c')
+           (mor : ∀ c c' : C, c --> c' -> obj c --> obj c')
            (identity : ∀ c, mor c c (identity c) = identity (obj c))
-           (compax : ∀ (a b c : C) (f : a → b) (g : b → c),
+           (compax : ∀ (a b c : C) (f : a --> b) (g : b --> c),
                        mor a c (g ∘ f) = mor b c g ∘ mor a b f) :
   C ==> D
   := (obj,, mor),, identity,, compax.
@@ -220,7 +220,7 @@ Notation "F ◾ b" := (functor_object_application F b) (at level 40, left associ
 (* \sqb3 *)
 
 Definition functor_mor_application {B C:Precategory} {b b':B} (F:[B,C]) :
-  b → b'  ->  F ◾ b → F ◾ b'
+  b --> b'  ->  F ◾ b --> F ◾ b'
   := λ f, # (F:_==>_) f.
 Notation "F ▭ f" := (functor_mor_application F f) (at level 40, left associativity) : cat. (* \rew1 *)
 
@@ -231,7 +231,7 @@ Definition arrow' {C:Precategory} (c : C) (X : [C^op^op,SET]) : hSet := X ◾ c.
 Notation "X ⇐ c" := (arrow' c X)  (at level 50) : cat. (* \l= *)
 
 Definition arrow_morphism_composition {C:Precategory} {c' c:C} {X:[C^op,SET]} :
-  c'→c -> c⇒X -> c'⇒X
+  c'-->c -> c⇒X -> c'⇒X
   := λ f x, # (X:_==>_) f x.
 Notation "x ⟲ f" := (arrow_morphism_composition f x) (at level 50, left associativity) : cat.
 (* ⟲ agda-input \l C-N C-N C-N 2 the first time, \l the second time *)
@@ -239,7 +239,7 @@ Notation "x ⟲ f" := (arrow_morphism_composition f x) (at level 50, left associ
    the morphisms of C act on the right of the elements of X *)
 
 Definition nattrans_arrow_composition {C:Precategory} {X X':[C^op,SET]} {c:C} :
-  c⇒X -> X→X' -> c⇒X'
+  c⇒X -> X-->X' -> c⇒X'
   := λ x q, (q:_⟶_) c (x:(X:_==>_) c:hSet).
 Notation "q ⟳ x" := (nattrans_arrow_composition x q) (at level 50, left associativity) : cat.
 (* ⟳ agda-input \r C-N C-N C-N 3 the first time, \r the second time *)
@@ -248,7 +248,7 @@ Notation "q ⟳ x" := (nattrans_arrow_composition x q) (at level 50, left associ
    left of the elements of the functors *)
 
 Definition nattrans_object_application {B C:Precategory} {F F' : [B,C]} (b:B) :
-  F → F'  ->  F ◾ b → F' ◾ b
+  F --> F'  ->  F ◾ b --> F' ◾ b
   := λ p, (p:_⟶_) b.
 Notation "p ◽ b" := (nattrans_object_application b p) (at level 40) : cat.
 (* agda input : \sqw3 *)
@@ -258,21 +258,21 @@ Definition arrow_mor_id {C:Precategory} {c:C} {X:[C^op,SET]} (x:c⇒X) :
   := apevalat x (functor_id X c).
 
 Definition arrow_mor_mor_assoc {C:Precategory} {c c' c'':C} {X:[C^op,SET]}
-           (g:c''→c') (f:c'→c) (x:c⇒X) :
+           (g:c''-->c') (f:c'-->c) (x:c⇒X) :
   x ⟲ (f ∘ g) = (x ⟲ f) ⟲ g
   := apevalat x (functor_comp X c c' c'' f g).
 
 Definition nattrans_naturality {B C:Precategory} {F F':[B, C]} {b b':B}
-           (p : F → F') (f : b → b') :
+           (p : F --> F') (f : b --> b') :
   p ◽ b'  ∘  F ▭ f  =  F' ▭ f  ∘  p ◽ b
   := nat_trans_ax p _ _ f.
 
-Definition comp_func_on_mor {A B C:Precategory} (F:[A,B]) (G:[B,C]) {a a':A} (f:a→a') :
+Definition comp_func_on_mor {A B C:Precategory} (F:[A,B]) (G:[B,C]) {a a':A} (f:a-->a') :
   G □ F ▭ f = G ▭ (F ▭ f).
 Proof. reflexivity. Defined.
 
 Definition nattrans_arrow_mor_assoc {C:Precategory} {c' c:C} {X X':[C^op,SET]}
-           (g:c'→c) (x:c⇒X) (p:X→X') :
+           (g:c'-->c) (x:c⇒X) (p:X-->X') :
   p ⟳ (x ⟲ g) = (p ⟳ x) ⟲ g
   := apevalat x (nat_trans_ax p _ _ g).
 
@@ -281,19 +281,19 @@ Definition nattrans_arrow_id {C:Precategory} {c:C} {X:[C^op,SET]} (x:c⇒X) :
   := idpath _.
 
 Definition nattrans_nattrans_arrow_assoc {C:Precategory} {c:C} {X X' X'':[C^op,SET]}
-           (x:c⇒X) (p:X→X') (q:X'→X'') :
+           (x:c⇒X) (p:X-->X') (q:X'-->X'') :
   q ⟳ (p ⟳ x) = (q ∘ p) ⟳ x
   := idpath _.
 
 Definition nattrans_nattrans_object_assoc {A B C:Precategory}
-           (F:[A,B]) (G:[B, C]) {a a' : A} (f : a → a') :
+           (F:[A,B]) (G:[B, C]) {a a' : A} (f : a --> a') :
   G □ F ▭ f = G ▭ (F ▭ f)
   := idpath _.
 
 Lemma functor_on_id {B C:Precategory} (F:[B,C]) (b:B) : F ▭ identity b = identity (F ◾ b).
 Proof. exact (functor_id F b). Defined.
 
-Lemma functor_on_comp {B C:Precategory} (F:[B,C]) {b b' b'':B} (g:b'→b'') (f:b→b') :
+Lemma functor_on_comp {B C:Precategory} (F:[B,C]) {b b' b'':B} (g:b'-->b'') (f:b-->b') :
   F ▭ (g ∘ f) = F ▭ g ∘ F ▭ f.
 Proof. exact (functor_comp F _ _ _ f g). Defined.
 
@@ -304,15 +304,15 @@ Proof. exact (functor_comp F _ _ _ f g). Defined.
 Definition nat_iso {B C:Precategory} (F G:[B,C]) := iso F G.
 
 Definition makeNattrans {C D:Precategory} {F G:[C,D]}
-           (mor : ∀ x : C, F ◾ x → G ◾ x)
+           (mor : ∀ x : C, F ◾ x --> G ◾ x)
            (eqn : ∀ c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
-  F → G
+  F --> G
   := (mor,,eqn).
 
 Definition makeNattrans_op {C D:Precategory} {F G:[C^op,D]}
-           (mor : ∀ x : C, F ◾ x → G ◾ x)
+           (mor : ∀ x : C, F ◾ x --> G ◾ x)
            (eqn : ∀ c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
-  F → G
+  F --> G
   := (mor,,eqn).
 
 Definition makeNatiso {C D:Precategory} {F G:[C,D]}
@@ -331,8 +331,8 @@ Proof.
   refine (makeNattrans_op mor eqn,,_). apply functor_iso_if_pointwise_iso; intro c. apply pr2.
 Defined.
 
-Lemma move_inv {C:Precategory} {a a' b' b:C} {f : a → b} {f' : a' → b'}
-      {i : a → a'} {i' : a' → a} {j : b → b'} {j' : b' → b} :
+Lemma move_inv {C:Precategory} {a a' b' b:C} {f : a --> b} {f' : a' --> b'}
+      {i : a --> a'} {i' : a' --> a} {j : b --> b'} {j' : b' --> b} :
   is_inverse_in_precat i i' -> is_inverse_in_precat j j' ->
   j ∘ f = f' ∘ i -> j' ∘ f' = f ∘ i'.
 Proof.
@@ -341,7 +341,7 @@ Proof.
   rewrite assoc. rewrite (pr2 I). rewrite id_left. reflexivity.
 Defined.
 
-Lemma weq_iff_iso_SET {X Y:SET} (f:X→Y) : is_iso f <-> isweq f.
+Lemma weq_iff_iso_SET {X Y:SET} (f:X-->Y) : is_iso f <-> isweq f.
 Proof.
   split.
   - intro i. set (F := isopair f i).
@@ -367,9 +367,9 @@ Definition functor_to_opp_opp {C:Precategory} : C ==> C^op^op
 
 Definition makeFunctor_op {C D:Precategory}
            (obj : ob C -> ob D)
-           (mor : ∀ a b : C, b → a -> obj a → obj b)
+           (mor : ∀ a b : C, b --> a -> obj a --> obj b)
            (identity : ∀ c, mor c c (identity c) = identity (obj c))
-           (compax : ∀ (a b c : C) (f : b → a) (g : c → b),
+           (compax : ∀ (a b c : C) (f : b --> a) (g : c --> b),
                        mor a c (f ∘ g) = mor b c g ∘ mor a b f) :
   C^op ==> D
   := (obj,, mor),, identity,, compax.
@@ -386,7 +386,7 @@ Definition opp_mor {C:Precategory} {b c:C} : Hom C b c -> Hom C^op c b
 Definition rm_opp_mor {C:Precategory} {b c:C} : Hom C^op b c -> Hom C c b
   := λ f, f.
 
-Definition opp_mor_eq {C:Precategory} {a b:C} (f g:a → b) :
+Definition opp_mor_eq {C:Precategory} {a b:C} (f g:a --> b) :
   opp_mor f = opp_mor g -> f = g
   := idfun _.
 
@@ -513,7 +513,7 @@ Proof.
   (* add a new component to each object: *)
   - exact (Σ c:C, P c).
   (* the homsets ignore the extra structure: *)
-  - intros x y. exact (pr1 x → pr1 y).
+  - intros x y. exact (pr1 x --> pr1 y).
   (* the rest is the same: *)
   - intros x. apply identity.
   - intros x y z f g. exact (g ∘ f).
@@ -545,7 +545,7 @@ Proof.
   - abstract (intros b b' b'' f g; simpl; apply functor_comp) using L.
 Defined.
 
-Lemma identityFunction : ∀ (T:SET) (f:T→T) (t:T:hSet), f = identity T -> f t = t.
+Lemma identityFunction : ∀ (T:SET) (f:T-->T) (t:T:hSet), f = identity T -> f t = t.
 Proof. intros ? ? ?. exact (apevalat t). Defined.
 
 Lemma identityFunction' : ∀ (T:SET) (t:T:hSet), identity T t = t.
@@ -556,7 +556,7 @@ Proof. reflexivity. Defined.
 Lemma functor_identity_object {C:Precategory} (c:C) : functor_identity C ◾ c = c.
 Proof. reflexivity. Defined.
 
-Lemma functor_identity_arrow {C:Precategory} {c c':C} (f:c→c') : functor_identity C ▭ f = f.
+Lemma functor_identity_arrow {C:Precategory} {c c':C} (f:c-->c') : functor_identity C ▭ f = f.
 Proof. reflexivity. Defined.
 
 Definition constantFunctor (C:Precategory) {D:Precategory} (d:D) : [C,D].
@@ -589,12 +589,12 @@ Defined.
 (* zero maps, definition: *)
 
 Definition hasZeroMaps (C:Precategory) :=
-  Σ (zero : ∀ a b:C, a → b),
-  (∀ a b c, ∀ f:b → c, f ∘ zero a b = zero a c)
+  Σ (zero : ∀ a b:C, a --> b),
+  (∀ a b c, ∀ f:b --> c, f ∘ zero a b = zero a c)
     ×
-    (∀ a b c, ∀ f:c → b, zero b a ∘ f = zero c a).
+    (∀ a b c, ∀ f:c --> b, zero b a ∘ f = zero c a).
 
-Definition is {C:Precategory} (zero: hasZeroMaps C) {a b:C} (f:a→b)
+Definition is {C:Precategory} (zero: hasZeroMaps C) {a b:C} (f:a-->b)
   := f = pr1 zero _ _.
 
 Definition hasZeroMaps_opp (C:Precategory) : hasZeroMaps C -> hasZeroMaps C^op

--- a/UniMath/Ktheory/Representation.v
+++ b/UniMath/Ktheory/Representation.v
@@ -12,7 +12,7 @@ Set Automatic Introduction.
 Local Open Scope cat.
 
 Definition isUniversal {C:Precategory} {X:[C^op,SET]} {c:C} (x:c ⇒ X)
-  := ∀ (c':C), isweq (λ f : c' → c, x ⟲ f).
+  := ∀ (c':C), isweq (λ f : c' --> c, x ⟲ f).
 
 Definition Universal {C:Precategory} (X:[C^op,SET]) (c:C)
   := Σ (x:c ⇒ X), isUniversal x.
@@ -71,7 +71,7 @@ Definition toRepresentableFunctor {C:Precategory} :
 (* make a representation of a functor *)
 
 Definition makeRepresentation {C:Precategory} {c:C} {X:[C^op,SET]} (x:c ⇒ X) :
-  (∀ (c':C), bijective (λ f : c' → c, x ⟲ f)) -> Representation X.
+  (∀ (c':C), bijective (λ f : c' --> c, x ⟲ f)) -> Representation X.
 Proof.
   intros bij. exists c. exists x. intros c'. apply set_bijection_to_weq.
   - exact (bij c').
@@ -90,18 +90,18 @@ Definition universalElement {C:Precategory} {X:[C^op,SET]} (r:Representation X) 
 Coercion universalElement : Representation >-> pr1hSet.
 
 Definition universalProperty {C:Precategory} {X:[C^op,SET]} (r:Representation X) (c:C) :
-  c → universalObject r ≃ c ⇒ X
-  := weqpair (λ f : c → universalObject r, r ⟲ f)
+  c --> universalObject r ≃ c ⇒ X
+  := weqpair (λ f : c --> universalObject r, r ⟲ f)
              (pr2 (pr2 r) c).
 
 Definition universalMap {C:Precategory} {X:[C^op,SET]} (r:Representation X) {c:C} :
-  c ⇒ X -> c → universalObject r
+  c ⇒ X -> c --> universalObject r
   := invmap (universalProperty _ _).
 
 Notation "r \\ x" := (universalMap r x) (at level 50, left associativity) : cat.
 
 Definition universalMap' {C:Precategory} {X:[C^op^op,SET]} (r:Representation X) {c:C} :
-  X ⇐ c -> c ← universalObject r
+  X ⇐ c -> c <-- universalObject r
   := invmap (universalProperty _ _).
 
 Notation "x // r" := (universalMap' r x) (at level 50, left associativity) : cat.
@@ -112,12 +112,12 @@ Definition universalMapProperty {C:Precategory} {X:[C^op,SET]} (r:Representation
   := homotweqinvweq (universalProperty r c) x.
 
 Definition mapUniqueness {C:Precategory} (X:[C^op,SET]) (r : Representation X) (c:C)
-           (f g: c → universalObject r) :
+           (f g: c --> universalObject r) :
   r ⟲ f = r ⟲ g -> f = g
   := invmaponpathsweq (universalProperty _ _) _ _.
 
 Definition universalMapUniqueness {C:Precategory} {X:[C^op,SET]} {r:Representation X}
-      {c:C} (x : c ⇒ X) (f : c → universalObject r) :
+      {c:C} (x : c ⇒ X) (f : c --> universalObject r) :
   r ⟲ f = x -> f = r \\ x
   := pathsweq1 (universalProperty r c) f x.
 
@@ -126,12 +126,12 @@ Definition universalMapIdentity {C:Precategory} {X:[C^op,SET]} (r:Representation
 Proof. apply pathsinv0. apply universalMapUniqueness. apply arrow_mor_id. Qed.
 
 Definition universalMapUniqueness' {C:Precategory} {X:[C^op,SET]} {r:Representation X}
-      {c:C} (x : c ⇒ X) (f : c → universalObject r) :
+      {c:C} (x : c ⇒ X) (f : c --> universalObject r) :
   f = r \\ x -> r ⟲ f = x
   := pathsweq1' (universalProperty r c) f x.
 
 Lemma univ_arrow_mor_assoc {C:Precategory} {a b:C} {Z:[C^op,SET]}
-      (f : a → b) (z : b ⇒ Z) (t : Representation Z) :
+      (f : a --> b) (z : b ⇒ Z) (t : Representation Z) :
   (t \\ z) ∘ f = t \\ (z ⟲ f).
 Proof.
   apply universalMapUniqueness.
@@ -154,7 +154,7 @@ Lemma uOF_comp {C:Precategory} {X Y Z:[C^op,SET]}
       (r:Representation X)
       (s:Representation Y)
       (t:Representation Z)
-      (p:X→Y) (q:Y→Z) :
+      (p:X-->Y) (q:Y-->Z) :
     t \\ ((q ∘ p) ⟳ r) = (t \\ (q ⟳ s)) ∘ (s \\ (p ⟳ r)).
 Proof.
   unshelve refine (transportf (λ k, _ \\ k = _) (nattrans_nattrans_arrow_assoc _ _ _) _).
@@ -175,11 +175,11 @@ Proof.
   - intros X Y Z p q; simpl. apply uOF_comp.
 Defined.
 
-Definition universalObjectFunctor_on_map (C:Precategory) {X Y:RepresentedFunctor C} (p:X→Y) :
+Definition universalObjectFunctor_on_map (C:Precategory) {X Y:RepresentedFunctor C} (p:X-->Y) :
   universalObjectFunctor C ▭ p = pr2 Y \\ (p ⟳ pr2 X).
 Proof. reflexivity. Defined.
 
-Lemma universalObjectFunctor_comm (C:Precategory) {X Y:RepresentedFunctor C} (p:X→Y) :
+Lemma universalObjectFunctor_comm (C:Precategory) {X Y:RepresentedFunctor C} (p:X-->Y) :
   p ⟳ universalElement (pr2 X) = universalElement (pr2 Y) ⟲ universalObjectFunctor C ▭ p.
 Proof.
   change (universalObjectFunctor C ▭ p) with (pr2 Y \\ (p ⟳ pr2 X)).
@@ -245,11 +245,11 @@ Defined.
 
 (** maps from Hom1 to functors *)
 
-Lemma compose_SET {X Y Z:SET} (f:X→Y) (g:Y→Z) : g∘f = λ x, g(f x).
+Lemma compose_SET {X Y Z:SET} (f:X-->Y) (g:Y-->Z) : g∘f = λ x, g(f x).
 Proof. reflexivity. Defined.
 
 Definition element_to_nattrans {C:Precategory} (X:[C^op,SET]) (c:C) :
-  c ⇒ X -> Hom1 c → X.
+  c ⇒ X -> Hom1 c --> X.
 Proof.
   intros x. unshelve refine (makeNattrans_op _ _).
   - unfold Hom1; simpl; intros b f. exact (x ⟲ f).
@@ -362,24 +362,24 @@ Definition BinaryProduct {C:Precategory} (a b:C) :=
 Definition hasBinaryProducts (C:Precategory) := ∀ (a b:C), BinaryProduct a b.
 
 Definition pr_1 {C:Precategory} {a b:C} (prod : BinaryProduct a b) :
-  universalObject prod → a
+  universalObject prod --> a
   := pr1 (universalElement prod).
 
 Definition pr_2 {C:Precategory} {a b:C} (prod : BinaryProduct a b) :
-  universalObject prod → b
+  universalObject prod --> b
   := pr2 (universalElement prod).
 
 Definition binaryProductMap {C:Precategory} {a b:C} (prod : BinaryProduct a b)
-           {c:C} : c → a -> c → b -> c → universalObject prod
+           {c:C} : c --> a -> c --> b -> c --> universalObject prod
   := λ f g, prod \\ (f,,g).
 
 Definition binaryProduct_pr_1_eqn {C:Precategory} {a b:C} (prod : BinaryProduct a b)
-      {c:C} (f : c → a) (g : c → b) :
+      {c:C} (f : c --> a) (g : c --> b) :
   pr_1 prod ∘ binaryProductMap prod f g = f
   := maponpaths (HomPair_1 a b (opp_ob c)) (pr2 (pr1 (pr2 (pr2 prod) c (f,,g)))).
 
 Definition binaryProduct_pr_2_eqn {C:Precategory} {a b:C} (prod : BinaryProduct a b)
-      {c:C} (f : c → a) (g : c → b) :
+      {c:C} (f : c --> a) (g : c --> b) :
   pr_2 prod ∘ binaryProductMap prod f g = g
   := maponpaths (HomPair_2 a b (opp_ob c)) (pr2 (pr1 (pr2 (pr2 prod) c (f,,g)))).
 
@@ -394,9 +394,9 @@ Defined.
 Definition binaryProductMap_2 {C:Precategory} {a b a' b':C}
            (prod : BinaryProduct a b)
            (prod' : BinaryProduct a' b')
-           (f : a → a')
-           (g : b → b')
-           : rm_opp_ob (universalObject prod) → rm_opp_ob (universalObject prod').
+           (f : a --> a')
+           (g : b --> b')
+           : rm_opp_ob (universalObject prod) --> rm_opp_ob (universalObject prod').
 Proof.
   unshelve refine (binaryProductMap _ _ _).
   { exact (f ∘ pr_1 prod). }
@@ -424,20 +424,20 @@ Definition in_2 {C:Precategory} {a b:C} (sum : BinarySum a b) :
   Hom C b (universalObject sum)
   := pr_2 sum.
 
-Definition binarySumProperty {C:Precategory} {a b c:C} (f:a→c) (g:b→c) :=
+Definition binarySumProperty {C:Precategory} {a b c:C} (f:a-->c) (g:b-->c) :=
   isUniversal ((f ,, g) : HomPair (opp_ob a) (opp_ob b) ◾ c : hSet).
 
 Definition binarySumMap {C:Precategory} {a b:C} (sum : BinarySum a b)
-           {c:C} : a → c -> b → c -> rm_opp_ob (universalObject sum) → c
+           {c:C} : a --> c -> b --> c -> rm_opp_ob (universalObject sum) --> c
   := λ f g, rm_opp_mor (sum \\ (opp_mor f,,opp_mor g)).
 
 Definition binarySum_in_1_eqn {C:Precategory} {a b:C} (sum : BinarySum a b)
-      {c:C} (f : a → c) (g : b → c) :
+      {c:C} (f : a --> c) (g : b --> c) :
   binarySumMap sum f g ∘ in_1 sum = f
   := maponpaths (HomPair_1 (opp_ob a) (opp_ob b) c) ((pr2 (pr1 (pr2 (pr2 sum) c (f,,g))))).
 
 Definition binarySum_in_2_eqn {C:Precategory} {a b:C} (sum : BinarySum a b)
-      {c:C} (f : a → c) (g : b → c) :
+      {c:C} (f : a --> c) (g : b --> c) :
   binarySumMap sum f g ∘ in_2 sum = g
   := maponpaths (HomPair_2 (opp_ob a) (opp_ob b) c) ((pr2 (pr1 (pr2 (pr2 sum) c (f,,g))))).
 
@@ -450,9 +450,9 @@ Proof. intros r s. apply opp_mor_eq, mapUniqueness, dirprodeq; assumption. Defin
 Definition binarySumMap_2 {C:Precategory} {a b a' b':C}
            (sum : BinarySum a b)
            (sum' : BinarySum a' b')
-           (f : a → a')
-           (g : b → b')
-           : rm_opp_ob (universalObject sum) → rm_opp_ob (universalObject sum').
+           (f : a --> a')
+           (g : b --> b')
+           : rm_opp_ob (universalObject sum) --> rm_opp_ob (universalObject sum').
 Proof.
   unshelve refine (binarySumMap _ _ _).
   { exact (in_1 sum' ∘ f). }
@@ -480,7 +480,7 @@ Definition Product {C:Precategory} {I} (c:I -> ob C)
   := Representation (HomFamily C c).
 
 Definition pr_ {C:Precategory} {I} {c:I -> ob C} (prod : Product c) (i:I) :
-  universalObject prod → c i
+  universalObject prod --> c i
   := universalElement prod i.
 
 Definition productMapExistence {C:Precategory} {I} {c:I -> ob C} (prod : Product c)
@@ -499,7 +499,7 @@ Definition Sum {C:Precategory} {I} (c:I -> ob C)
   := Representation (HomFamily C^op c).
 
 Definition in_ {C:Precategory} {I} {c:I -> ob C} (sum : Sum c) (i:I) :
-  c i → universalObject sum
+  c i --> universalObject sum
   := rm_opp_mor (universalElement sum i).
 
 Definition sumMapExistence {C:Precategory} {I} {c:I -> ob C} (sum : Sum c)
@@ -518,12 +518,12 @@ Defined.
 
 Local Open Scope cat'.
 
-Definition Equalization {C:Precategory} {c d:C} (f g:c→d) :
+Definition Equalization {C:Precategory} {c d:C} (f g:c-->d) :
   C^op ==> SET.
 Proof.
   unshelve refine (makeFunctor_op _ _ _ _).
   - intro b. unshelve refine (_,,_).
-    + exact (Σ p:b → c, f∘p = g∘p).
+    + exact (Σ p:b --> c, f∘p = g∘p).
     + abstract (apply isaset_total2;
       [ apply homset_property
       | intro; apply isasetaprop; apply homset_property]) using L.
@@ -540,37 +540,37 @@ Proof.
         | apply pathsinv0, assoc ]) using O.
 Defined.
 
-Definition Equalizer {C:Precategory} {c d:C} (f g:c→d) :=
+Definition Equalizer {C:Precategory} {c d:C} (f g:c-->d) :=
   Representation (Equalization f g).
 
-Definition equalizerMap {C:Precategory} {c d:C} {f g:c→d} (eq : Equalizer f g) :
-  universalObject eq → c
+Definition equalizerMap {C:Precategory} {c d:C} {f g:c-->d} (eq : Equalizer f g) :
+  universalObject eq --> c
   := pr1 (universalElement eq).
 
-Definition equalizerEquation {C:Precategory} {c d:C} {f g:c→d} (eq : Equalizer f g) :
+Definition equalizerEquation {C:Precategory} {c d:C} {f g:c-->d} (eq : Equalizer f g) :
   f ∘ equalizerMap eq = g ∘ equalizerMap eq
   := pr2 (universalElement eq).
 
-Definition Coequalizer {C:Precategory} {c d:C} (f g:c→d) :=
+Definition Coequalizer {C:Precategory} {c d:C} (f g:c-->d) :=
   Representation (Equalization (opp_mor f) (opp_mor g)).
 
-Definition coequalizerMap {C:Precategory} {c d:C} {f g:c→d} (coeq : Coequalizer f g) :
-  d → universalObject coeq
+Definition coequalizerMap {C:Precategory} {c d:C} {f g:c-->d} (coeq : Coequalizer f g) :
+  d --> universalObject coeq
   := pr1 (universalElement coeq).
 
-Definition coequalizerEquation {C:Precategory} {c d:C} {f g:c→d} (coeq : Coequalizer f g) :
+Definition coequalizerEquation {C:Precategory} {c d:C} {f g:c-->d} (coeq : Coequalizer f g) :
   coequalizerMap coeq ∘ f = coequalizerMap coeq ∘ g
   := pr2 (universalElement coeq).
 
 (** pullbacks and pushouts  *)
 
-Definition PullbackCone {C:Precategory} {a b c:C} (f:a→c) (g:b→c) :
+Definition PullbackCone {C:Precategory} {a b c:C} (f:a-->c) (g:b-->c) :
   C^op ==> SET.
 Proof.
   intros.
   unshelve refine (makeFunctor_op _ _ _ _).
   - intros t. unshelve refine (_,,_).
-    + exact (Σ (p: t → a × t → b), f ∘ pr1 p = g ∘ pr2 p).
+    + exact (Σ (p: t --> a × t --> b), f ∘ pr1 p = g ∘ pr2 p).
     + abstract (apply isaset_total2;
       [ apply isasetdirprod; apply homset_property
       | intro; apply isasetaprop; apply homset_property]) using L.
@@ -590,33 +590,33 @@ Proof.
         | apply proofirrelevance; apply homset_property]) using P.
 Defined.
 
-Definition Pullback {C:Precategory} {a b c:C} (f:a→c) (g:b→c) :=
+Definition Pullback {C:Precategory} {a b c:C} (f:a-->c) (g:b-->c) :=
   Representation (PullbackCone f g).
 
-Definition pb_1 {C:Precategory} {a b c:C} {f:a→c} {g:b→c} (pb : Pullback f g) :
-  universalObject pb → a
+Definition pb_1 {C:Precategory} {a b c:C} {f:a-->c} {g:b-->c} (pb : Pullback f g) :
+  universalObject pb --> a
   := pr1 (pr1 (universalElement pb)).
 
-Definition pb_2 {C:Precategory} {a b c:C} {f:a→c} {g:b→c} (pb : Pullback f g) :
-  universalObject pb → b
+Definition pb_2 {C:Precategory} {a b c:C} {f:a-->c} {g:b-->c} (pb : Pullback f g) :
+  universalObject pb --> b
   := pr2 (pr1 (universalElement pb)).
 
-Definition pb_eqn {C:Precategory} {a b c:C} {f:a→c} {g:b→c} (pb : Pullback f g) :
+Definition pb_eqn {C:Precategory} {a b c:C} {f:a-->c} {g:b-->c} (pb : Pullback f g) :
   f ∘ pb_1 pb = g ∘ pb_2 pb
   := pr2 (universalElement pb).
 
-Definition Pushout {C:Precategory} {a b c:C} (f:a→b) (g:a→c) :=
+Definition Pushout {C:Precategory} {a b c:C} (f:a-->b) (g:a-->c) :=
   Representation (PullbackCone (opp_mor f) (opp_mor g)).
 
-Definition po_1 {C:Precategory} {a b c:C} {f:a→b} {g:a→c} (po : Pushout f g) :
-  b → universalObject po
+Definition po_1 {C:Precategory} {a b c:C} {f:a-->b} {g:a-->c} (po : Pushout f g) :
+  b --> universalObject po
   := pr1 (pr1 (universalElement po)).
 
-Definition po_2 {C:Precategory} {a b c:C} {f:a→b} {g:a→c} (po : Pushout f g) :
-  c → universalObject po
+Definition po_2 {C:Precategory} {a b c:C} {f:a-->b} {g:a-->c} (po : Pushout f g) :
+  c --> universalObject po
   := pr2 (pr1 (universalElement po)).
 
-Definition po_eqn {C:Precategory} {a b c:C} {f:a→c} {g:a→c} (po : Pushout f g) :
+Definition po_eqn {C:Precategory} {a b c:C} {f:a-->c} {g:a-->c} (po : Pushout f g) :
   po_1 po ∘ f = po_2 po ∘ g
   := pr2 (universalElement po).
 
@@ -624,7 +624,7 @@ Definition po_eqn {C:Precategory} {a b c:C} {f:a→c} {g:a→c} (po : Pushout f 
 
 Local Open Scope cat'.
 
-Definition Annihilator (C:Precategory) (zero:hasZeroMaps C) {c d:C} (f:c → d) :
+Definition Annihilator (C:Precategory) (zero:hasZeroMaps C) {c d:C} (f:c --> d) :
   C^op ==> SET.
 Proof.
   unshelve refine (_,,_).
@@ -648,38 +648,38 @@ Proof.
       | simpl; unfold opp_mor; apply pathsinv0, assoc ] ]) using N. }
 Defined.
 
-Definition Kernel {C:Precategory} (zero:hasZeroMaps C) {c d:ob C} (f:c → d) :=
+Definition Kernel {C:Precategory} (zero:hasZeroMaps C) {c d:ob C} (f:c --> d) :=
   Representation (Annihilator C zero f).
 
-Definition Cokernel {C:Precategory} (zero:hasZeroMaps C) {c d:ob C} (f:c → d) :=
+Definition Cokernel {C:Precategory} (zero:hasZeroMaps C) {c d:ob C} (f:c --> d) :=
   Representation (Annihilator C^op (hasZeroMaps_opp C zero) f).
 
-Definition kernelMap {C:Precategory} {zero:hasZeroMaps C} {c d:ob C} {f:c → d}
-           (r : Kernel zero f) : universalObject r → c
+Definition kernelMap {C:Precategory} {zero:hasZeroMaps C} {c d:ob C} {f:c --> d}
+           (r : Kernel zero f) : universalObject r --> c
   := pr1 (universalElement r).
 
-Definition kernelEquation {C:Precategory} {zero:hasZeroMaps C} {c d:ob C} {f:c → d}
+Definition kernelEquation {C:Precategory} {zero:hasZeroMaps C} {c d:ob C} {f:c --> d}
            (ker : Kernel zero f) :
   f ∘ kernelMap ker = pr1 zero _ _
   := pr2 (universalElement ker).
 
-Definition cokernelMap {C:Precategory} {zero:hasZeroMaps C} {c d:ob C} {f:c → d}
-           (r : Cokernel zero f) : d → universalObject r
+Definition cokernelMap {C:Precategory} {zero:hasZeroMaps C} {c d:ob C} {f:c --> d}
+           (r : Cokernel zero f) : d --> universalObject r
   := pr1 (universalElement r).
 
-Definition cokernelEquation {C:Precategory} {zero:hasZeroMaps C} {c d:ob C} {f:c → d}
+Definition cokernelEquation {C:Precategory} {zero:hasZeroMaps C} {c d:ob C} {f:c --> d}
            (coker : Cokernel zero f) :
   cokernelMap coker ∘ f = pr1 zero _ _
   := pr2 (universalElement coker).
 
 (** fibers of maps between functors *)
 
-Definition fiber {C:Precategory} {X Y:[C^op,SET]} (p : X → Y) {c:C} (y : c ⇒ Y) :
+Definition fiber {C:Precategory} {X Y:[C^op,SET]} (p : X --> Y) {c:C} (y : c ⇒ Y) :
   C^op ==> SET.
 Proof.
   unshelve refine (makeFunctor_op _ _ _ _).
   - intro b.
-    exists (Σ fx : (b → c) × (b ⇒ X), p ⟳ pr2 fx = y ⟲ pr1 fx).
+    exists (Σ fx : (b --> c) × (b ⇒ X), p ⟳ pr2 fx = y ⟲ pr1 fx).
     abstract (apply isaset_total2;
         [ apply isaset_dirprod, setproperty; apply homset_property
         | intros [f x]; apply isasetaprop; apply setproperty ]) using K.
@@ -703,17 +703,17 @@ Defined.
 (* this is representability of a map between two functors, in the sense of
    Grothendieck.  See EGA Chapter 0. *)
 
-Definition Representation_Map {C:Precategory} {X Y:[C^op,SET]} (p : X → Y) :=
+Definition Representation_Map {C:Precategory} {X Y:[C^op,SET]} (p : X --> Y) :=
   ∀ (c : C) (y : c ⇒ Y), Representation (fiber p y).
 
-Definition isRepresentable_Map {C:Precategory} {X Y:[C^op,SET]} (p : X → Y) :=
+Definition isRepresentable_Map {C:Precategory} {X Y:[C^op,SET]} (p : X --> Y) :=
   ∀ (c : C) (y : c ⇒ Y), isRepresentable (fiber p y).
 
 (** limits and colimits  *)
 
 Definition cone {I C:Precategory} (c:C) (D: [I,C]) : UU
   := Σ (φ : ∀ i, Hom C c (D ◾ i)),
-     ∀ i j (e : i → j), D ▭ e ∘ φ i = φ j.
+     ∀ i j (e : i --> j), D ▭ e ∘ φ i = φ j.
 
 Lemma cone_eq {C I:Precategory} (c:C^op) (D: I==>C) (p q:cone (C:=C) c D) :
   pr1 p ~ pr1 q -> p = q.
@@ -788,17 +788,17 @@ Definition Limit {C I:Precategory} (D: I==>C) := Representation (cone_functor D)
 
 Definition Colimit {C I:Precategory} (D: I==>C) := Representation (cocone_functor D).
 
-Definition proj_ {C I:Precategory} {D: I==>C} (lim:Limit D) (i:I) : universalObject lim → D i.
+Definition proj_ {C I:Precategory} {D: I==>C} (lim:Limit D) (i:I) : universalObject lim --> D i.
 Proof. intros. exact ((pr1 (universalElement lim) i)). Defined.
 
-Definition inj_ {C I:Precategory} {D: I==>C} (colim:Colimit D) (i:I) : D i → universalObject colim.
+Definition inj_ {C I:Precategory} {D: I==>C} (colim:Colimit D) (i:I) : D i --> universalObject colim.
 Proof. intros. exact ((pr1 (universalElement colim) i)). Defined.
 
-Definition proj_comm {C I:Precategory} {D: I==>C} (lim:Limit D) {i j:I} (f:i→j) :
+Definition proj_comm {C I:Precategory} {D: I==>C} (lim:Limit D) {i j:I} (f:i-->j) :
   # D f ∘ proj_ lim i = proj_ lim j.
 Proof. intros. exact (pr2 (universalElement lim) _ _ f). Defined.
 
-Definition inj_comm {C I:Precategory} {D: I==>C} (colim:Colimit D) {i j:I} (f:i→j) :
+Definition inj_comm {C I:Precategory} {D: I==>C} (colim:Colimit D) {i j:I} (f:i-->j) :
   inj_ colim j ∘ # D f = inj_ colim i.
 Proof. intros. exact (pr2 (universalElement colim) _ _ f). Defined.
 
@@ -961,7 +961,7 @@ Lemma functorBinaryProduct_eqn {B C:Precategory} (prod : hasBinaryProducts C)
 Proof. reflexivity. Defined.
 
 Lemma functorBinaryProduct_map_eqn {B C:Precategory} (prod : hasBinaryProducts C)
-      (F G F' G' : [B,C]) (p:F→F') (q:G→G') (b:B) :
+      (F G F' G' : [B,C]) (p:F-->F') (q:G-->G') (b:B) :
   binaryProductMap_2 (functorBinaryProduct prod F G) (functorBinaryProduct prod F' G') p q ◽ b
   =
   binaryProductMap_2 (prod (F ◾ b) (G ◾ b)) (prod (F' ◾ b) (G' ◾ b)) (p ◽ b) (q ◽ b).
@@ -1002,7 +1002,7 @@ Lemma functorBinarySum_eqn {B C:Precategory} (sum : hasBinarySums C)
 Proof. reflexivity. Defined.
 
 Lemma functorBinarySum_map_eqn {B C:Precategory} (sum : hasBinarySums C)
-      (F G F' G' : [B,C]) (p:F→F') (q:G→G') (b:B) :
+      (F G F' G' : [B,C]) (p:F-->F') (q:G-->G') (b:B) :
   binarySumMap_2 (functorBinarySum sum F G) (functorBinarySum sum F' G') p q ◽ b
   =
   binarySumMap_2 (sum (F ◾ b) (G ◾ b)) (sum (F' ◾ b) (G' ◾ b)) (p ◽ b) (q ◽ b).

--- a/UniMath/Ktheory/StandardCategories.v
+++ b/UniMath/Ktheory/StandardCategories.v
@@ -6,7 +6,7 @@ Require Import UniMath.Ktheory.Utilities UniMath.Ktheory.Precategories.
 Local Open Scope cat.
 
 Definition compose' { C:precategory_data } { a b c:ob C }
-  (g:b → c) (f:a → b) : a → c.
+  (g:b --> c) (f:a --> b) : a --> c.
 Proof. intros. exact (compose f g). Defined.
 
 (** *** the path groupoid *)

--- a/UniMath/Ktheory/Test.v
+++ b/UniMath/Ktheory/Test.v
@@ -31,7 +31,7 @@ Definition mk_isCoproductCocone (a b co : C) (ia : a --> co) (ib : b --> co) :
     ∃! k : C ⟦co, c⟧,
       ia ;; k = f ×
       ib ;; k = g)
-   →
+   ->
    isCoproductCocone a b co ia ib.
 Proof.
   intros u c fg. refine (iscontrweqf _ (u c (pr1 fg) (pr2 fg))).
@@ -51,7 +51,7 @@ Definition CoproductCocone (a b : C) := BinarySum a b.
 
 Definition mk_CoproductCocone (a b : C) :
   ∀ (c : C) (f : a --> c) (g : b --> c),
-    isCoproductCocone _ _ _ f g →  CoproductCocone a b
+    isCoproductCocone _ _ _ f g -> CoproductCocone a b
   := λ c f g i, c,,(f,,g),,i.
 
 Definition Coproducts := hasBinarySums C.
@@ -86,7 +86,7 @@ Qed.
 
 Lemma CoproductArrowUnique (a b : C) (CC : CoproductCocone a b) (x : C)
     (f : a --> x) (g : b --> x) (k : CoproductObject CC --> x) :
-    CoproductIn1 CC ;; k = f → CoproductIn2 CC ;; k = g →
+    CoproductIn1 CC ;; k = f -> CoproductIn2 CC ;; k = g ->
       k = CoproductArrow CC f g.
 Proof.
   intros u v.

--- a/UniMath/Ktheory/Utilities.v
+++ b/UniMath/Ktheory/Utilities.v
@@ -144,7 +144,6 @@ Qed.
 
 Notation ap := maponpaths.
 (* see table 3.1 in the coq manual for parsing levels *)
-Notation "f ;; g" := (funcomp f g) (at level 50).
 (* funcomp' is like funcomp, but with the arguments in the other order *)
 Definition funcomp' { X Y Z : UU } ( g : Y -> Z ) ( f : X -> Y ) := fun x : X => g ( f x ) .
 Open Scope transport.


### PR DESCRIPTION
Resolves issue https://github.com/UniMath/UniMath/issues/322 .

We changed the level of Notation "x → y" from 90 to 99 to match the core
of Coq, and we removed the Notation "f ;; g" from the Ktheory package.

I don't understand exactly what provokes this incomptability -- there
are certainly some bugs in the way Coq takes care of such things.  In
particular, we aren't reserving any notations yet -- it's a good
suggestion, especially if notation reservation within a given scope
would work.