### PR TITLE
Towards linking omega-cocontinuous functors and substitution systems

### DIFF
--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -45,6 +45,7 @@ PointedFunctorsComposition.v
 HorizontalComposition.v
 CommaCategories.v
 lists.v
+trees.v
 exponentials.v
 covyoneda.v
 lambdacalculus.v

--- a/UniMath/CategoryTheory/chains.v
+++ b/UniMath/CategoryTheory/chains.v
@@ -148,9 +148,13 @@ End chains.
 
 Notation "'chain'" := (diagram nat_graph).
 
-Definition omega_cocont {C D : precategory} (F : functor C D) : UU :=
+Definition is_omega_cocont {C D : precategory} (F : functor C D) : UU :=
   forall (c : chain C) (L : C) (cc : cocone c L),
   preserves_colimit F c L cc.
+
+Definition omega_cocont_functor (C D : precategory)  : UU :=
+  total2 (fun F : functor C D => is_omega_cocont F).
+
 
 (* This section proves that (L,α : F L -> L) is the initial algebra
    where L is the colimit of the inital chain:
@@ -162,9 +166,10 @@ Definition omega_cocont {C D : precategory} (F : functor C D) : UU :=
 Section colim_initial_algebra.
 
 Variables (C : precategory) (hsC : has_homsets C).
-Variables (F : functor C C) (HF : omega_cocont F).
-Variables (InitC : Initial C).
+Variables (FHF : omega_cocont_functor C C) (InitC : Initial C).
 
+Let F := pr1 FHF.
+Let HF : is_omega_cocont F := pr2 FHF.
 Let Fchain : chain C := initChain InitC F.
 
 Variable (CC : ColimCocone Fchain).

--- a/UniMath/CategoryTheory/chains.v
+++ b/UniMath/CategoryTheory/chains.v
@@ -166,10 +166,14 @@ Definition omega_cocont_functor (C D : precategory)  : UU :=
 Section colim_initial_algebra.
 
 Variables (C : precategory) (hsC : has_homsets C).
-Variables (FHF : omega_cocont_functor C C) (InitC : Initial C).
 
-Let F := pr1 FHF.
-Let HF : is_omega_cocont F := pr2 FHF.
+(* It is important that these are not packaged together as it is
+   sometimes necessary to control how opaque HF is. See
+   isalghom_pr1foldr in lists.v *)
+Variables (F : functor C C) (HF : is_omega_cocont F).
+
+Variables (InitC : Initial C).
+
 Let Fchain : chain C := initChain InitC F.
 
 Variable (CC : ColimCocone Fchain).

--- a/UniMath/CategoryTheory/lambdacalculus.v
+++ b/UniMath/CategoryTheory/lambdacalculus.v
@@ -72,28 +72,28 @@ Defined.
 (*     eapply product_of_functors. *)
 (*       apply delta_functor. *)
 
-Lemma omega_cocont_LambdaFunctor : omega_cocont LambdaFunctor.
+Lemma omega_cocont_LambdaFunctor : is_omega_cocont LambdaFunctor.
 Proof.
-apply omega_cocont_sum_of_functors.
+apply is_omega_cocont_sum_of_functors.
   apply (Products_functor_precat _ _ ProductsHSET).
   apply functor_category_has_homsets.
   apply functor_category_has_homsets.
-  apply omega_cocont_constant_functor.
+  apply is_omega_cocont_constant_functor.
   apply functor_category_has_homsets.
-apply omega_cocont_sum_of_functors.
+apply is_omega_cocont_sum_of_functors.
   apply (Products_functor_precat _ _ ProductsHSET).
   apply functor_category_has_homsets.
   apply functor_category_has_homsets.
-  apply omega_cocont_functor_composite.
+  apply is_omega_cocont_functor_composite.
   apply functor_category_has_homsets.
-  apply omega_cocont_delta_functor.
+  apply is_omega_cocont_delta_functor.
   apply (Products_functor_precat _ _ ProductsHSET).
   apply functor_category_has_homsets.
-  apply omega_cocont_binproduct_functor.
+  apply is_omega_cocont_binproduct_functor.
   apply functor_category_has_homsets.
   apply has_exponentials_functor_HSET.
   apply has_homsets_HSET.
-apply omega_cocont_pre_composition_functor.
+apply is_omega_cocont_pre_composition_functor.
 apply cats_LimsHSET.
 Defined.
 

--- a/UniMath/CategoryTheory/limits/initial.v
+++ b/UniMath/CategoryTheory/limits/initial.v
@@ -130,3 +130,34 @@ Arguments mk_Initial {_} _ _.
 (* Defined. *)
 
 (* End Initial_from_Colims. *)
+
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
+
+Section InitialFunctorCat.
+
+Variable C D : precategory.
+Variable ID : Initial D.
+Variable hsD : has_homsets D.
+
+Definition Initial_functor_precat : Initial [C, D, hsD].
+Proof.
+use mk_Initial.
+- mkpair.
+  + mkpair.
+    * intros c; apply (InitialObject ID).
+    * simpl; intros a b f; apply (InitialArrow ID).
+  + abstract (split;
+               [ intro a; apply pathsinv0, InitialEndo_is_identity
+               | intros a b c f g; apply pathsinv0, InitialArrowUnique]).
+- intros F.
+  mkpair.
+  + simpl.
+    mkpair.
+    * intro a; apply InitialArrow.
+    * abstract (intros a b f; simpl;
+                rewrite <- (InitialEndo_is_identity _ ID (InitialArrow ID ID)), id_left;
+                apply pathsinv0, InitialArrowUnique).
+  + abstract (intros α; apply (nat_trans_eq hsD); intro a; apply InitialArrowUnique).
+Defined.
+
+End InitialFunctorCat.

--- a/UniMath/CategoryTheory/limits/products.v
+++ b/UniMath/CategoryTheory/limits/products.v
@@ -306,3 +306,11 @@ abstract (split;
 Defined.
 
 End binproduct_functor.
+
+(* Defines the product of two functors by:
+    x -> (x,x) -> (F x,G x) -> F x * G x
+*)
+Definition product_of_functors {C D : precategory} (HD : Products D)
+  (F G : functor C D) : functor C D :=
+  functor_composite (delta_functor C)
+     (functor_composite (pair_functor F G) (binproduct_functor HD)).

--- a/UniMath/CategoryTheory/lists.v
+++ b/UniMath/CategoryTheory/lists.v
@@ -28,30 +28,24 @@ Section lists.
 
 Variable A : HSET.
 
-(* F(X) = 1 + (A * X) *)
-Definition listFunctor : functor HSET HSET :=
-  sum_of_functors CoproductsHSET (constant_functor _ _ unitHSET)
-                  (constprod_functor1 ProductsHSET A).
+Local Open Scope polynomial_functor_hset_scope.
 
-Lemma omega_cocont_listFunctor : omega_cocont listFunctor.
-Proof.
-apply omega_cocont_sum_of_functors; try apply has_homsets_HSET.
-- apply ProductsHSET.
-- apply is_omega_cocont_constant_functor, has_homsets_HSET.
-- apply (omega_cocont_constprod_functor1 _ _ has_homsets_HSET has_exponentials_HSET).
-Defined.
+(* F(X) = 1 + (A * X) *)
+Definition listOmegaFunctor : omega_cocont_functor HSET HSET := '1 + 'A * Id.
+
+Let listFunctor : functor HSET HSET := pr1 listOmegaFunctor.
+Let is_omega_cocont_listFunctor : is_omega_cocont listFunctor := pr2 listOmegaFunctor.
 
 Lemma listFunctor_Initial :
   Initial (precategory_FunctorAlg listFunctor has_homsets_HSET).
 Proof.
-apply (colimAlgInitial _ _ _ omega_cocont_listFunctor
-                       InitialHSET (ColimCoconeHSET _ _)).
+apply (colimAlgInitial _ _ _ is_omega_cocont_listFunctor InitialHSET (ColimCoconeHSET _ _)).
 Defined.
 
 Definition List : HSET :=
   alg_carrier _ (InitialObject listFunctor_Initial).
 
-Let List_mor : HSET⟦listFunctor List,List⟧ :=
+Let List_mor : HSET⟦pr1 listFunctor List,List⟧ :=
   alg_map _ (InitialObject listFunctor_Initial).
 
 Let List_alg : algebra_ob listFunctor :=
@@ -141,7 +135,7 @@ abstract (apply (isofhleveltotal2 2); [ apply setproperty | intro x; apply PhSet
 Defined.
 
 (* This line is crucial for isalghom_pr1foldr to typecheck *)
-Opaque omega_cocont_listFunctor.
+Opaque is_omega_cocont_listFunctor.
 
 Lemma isalghom_pr1foldr :
   is_algebra_mor _ List_alg List_alg (fun l => pr1 (foldr P'HSET P0' Pc' l)).
@@ -152,7 +146,7 @@ apply CoproductArrow_eq_cor.
   apply (maponpaths pr1 (foldr_cons P'HSET P0' Pc' a l)).
 Qed.
 
-Transparent omega_cocont_listFunctor.
+Transparent is_omega_cocont_listFunctor.
 
 Definition pr1foldr_algmor : algebra_mor _ List_alg List_alg :=
   tpair _ _ isalghom_pr1foldr.
@@ -181,6 +175,8 @@ intro l; apply isasetaprop, HP.
 Defined.
 
 Require Import UniMath.Foundations.NumberSystems.NaturalNumbers.
+
+Local Open Scope nat_scope.
 
 Definition natHSET : HSET.
 Proof.
@@ -348,7 +344,8 @@ mkpair.
 Defined.
 
 (* This doesn't compute: *)
-(* Eval compute in (to_list' _ testlist). *)
+(* Eval compute in (to_list' _ testlist).b
+ *)
 
 End list'.
 
@@ -370,7 +367,7 @@ Definition constprod_functor : functor HSET HSET :=
 
 Definition flip {A B C : UU} (f : A -> B -> C) : B -> A -> C := fun x y => f y x.
 
-Lemma omega_cocontConstProdFunctor : omega_cocont constprod_functor.
+Lemma omega_cocontConstProdFunctor : is_omega_cocont constprod_functor.
 Proof.
 intros hF c L ccL HcL cc.
 simple refine (tpair _ _ _).
@@ -419,7 +416,7 @@ Variables (C : precategory) (hsC : has_homsets C) (x : C) (PC : Coproducts C).
 Definition constcoprod_functor : functor C C :=
   coproduct_functor C C PC (constant_functor C C x) (functor_identity C).
 
-Lemma omega_cocontConstCoprodFunctor : omega_cocont constcoprod_functor.
+Lemma omega_cocontConstCoprodFunctor : is_omega_cocont constcoprod_functor.
 Proof.
 intros hF c L ccL HcL cc.
 simple refine (tpair _ _ _).
@@ -472,7 +469,7 @@ Definition stream : functor HSET HSET := constprod_functor1 ProductsHSET A.
 Definition listFunctor : functor HSET HSET :=
   functor_composite stream (constcoprod_functor _ unitHSET CoproductsHSET).
 
-Lemma omega_cocont_listFunctor : omega_cocont listFunctor.
+Lemma omega_cocont_listFunctor : is_omega_cocont listFunctor.
 Proof.
 apply (is_omega_cocont_functor_composite has_homsets_HSET).
 - apply omega_cocontConstProdFunctor.

--- a/UniMath/CategoryTheory/lists.v
+++ b/UniMath/CategoryTheory/lists.v
@@ -45,7 +45,7 @@ Defined.
 Definition List : HSET :=
   alg_carrier _ (InitialObject listFunctor_Initial).
 
-Let List_mor : HSET⟦pr1 listFunctor List,List⟧ :=
+Let List_mor : HSET⟦listFunctor List,List⟧ :=
   alg_map _ (InitialObject listFunctor_Initial).
 
 Let List_alg : algebra_ob listFunctor :=

--- a/UniMath/CategoryTheory/lists.v
+++ b/UniMath/CategoryTheory/lists.v
@@ -23,6 +23,341 @@ Require Import UniMath.CategoryTheory.limits.coproducts.
 Local Notation "# F" := (functor_on_morphisms F) (at level 3).
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
+(* Lists as the colimit of a chain given by the list functor: F(X) = 1 + A * X *)
+Section lists.
+
+Variable A : HSET.
+
+(* F(X) = 1 + (A * X) *)
+Definition listFunctor : functor HSET HSET :=
+  sum_of_functors CoproductsHSET (constant_functor _ _ unitHSET)
+                  (constprod_functor1 ProductsHSET A).
+
+Lemma omega_cocont_listFunctor : omega_cocont listFunctor.
+Proof.
+apply omega_cocont_sum_of_functors; try apply has_homsets_HSET.
+- apply ProductsHSET.
+- apply is_omega_cocont_constant_functor, has_homsets_HSET.
+- apply (omega_cocont_constprod_functor1 _ _ has_homsets_HSET has_exponentials_HSET).
+Defined.
+
+Lemma listFunctor_Initial :
+  Initial (precategory_FunctorAlg listFunctor has_homsets_HSET).
+Proof.
+apply (colimAlgInitial _ _ _ omega_cocont_listFunctor
+                       InitialHSET (ColimCoconeHSET _ _)).
+Defined.
+
+Definition List : HSET :=
+  alg_carrier _ (InitialObject listFunctor_Initial).
+
+Let List_mor : HSET⟦listFunctor List,List⟧ :=
+  alg_map _ (InitialObject listFunctor_Initial).
+
+Let List_alg : algebra_ob listFunctor :=
+  InitialObject listFunctor_Initial.
+
+Definition nil_map : HSET⟦unitHSET,List⟧.
+Proof.
+simpl; intro x.
+apply List_mor, inl, x.
+Defined.
+
+Definition nil : pr1 List := nil_map tt.
+
+Definition cons_map : HSET⟦(A × List)%set,List⟧.
+Proof.
+intros xs.
+apply List_mor, (inr xs).
+Defined.
+
+Definition cons : pr1 A × pr1 List -> pr1 List := cons_map.
+
+(* Get recursion/iteration scheme: *)
+
+(*    x : X           f : A × X -> X *)
+(* ------------------------------------ *)
+(*       foldr x f : List A -> X *)
+
+Definition mk_listAlgebra (X : HSET) (x : pr1 X)
+  (f : HSET⟦(A × X)%set,X⟧) : algebra_ob listFunctor.
+Proof.
+set (x' := λ (_ : unit), x).
+apply (tpair _ X (sumofmaps x' f) : algebra_ob listFunctor).
+Defined.
+
+Definition foldr_map (X : HSET) (x : pr1 X) (f : HSET⟦(A × X)%set,X⟧) :
+  algebra_mor _ List_alg (mk_listAlgebra X x f).
+Proof.
+apply (InitialArrow listFunctor_Initial (mk_listAlgebra X x f)).
+Defined.
+
+Definition foldr (X : HSET) (x : pr1 X)
+  (f : pr1 A × pr1 X -> pr1 X) : pr1 List -> pr1 X.
+Proof.
+apply (foldr_map _ x f).
+Defined.
+
+(* Maybe quantify over "λ _ : unit, x" instead of nil? *)
+Lemma foldr_nil (X : hSet) (x : X) (f : pr1 A × X -> X) : foldr X x f nil = x.
+Proof.
+assert (F := maponpaths (fun x => CoproductIn1 _ _ ;; x)
+                        (algebra_mor_commutes _ _ _ (foldr_map X x f))).
+apply (toforallpaths _ _ _ F tt).
+Qed.
+
+Lemma foldr_cons (X : hSet) (x : X) (f : pr1 A × X -> X)
+                 (a : pr1 A) (l : pr1 List) :
+  foldr X x f (cons (a,,l)) = f (a,,foldr X x f l).
+Proof.
+assert (F := maponpaths (fun x => CoproductIn2 _ _ ;; x)
+                        (algebra_mor_commutes _ _ _ (foldr_map X x f))).
+assert (Fal := toforallpaths _ _ _ F (a,,l)).
+clear F.
+(* apply Fal. *) (* This doesn't work here. why? *)
+unfold compose in Fal.
+simpl in Fal.
+apply Fal.
+Opaque foldr_map.
+Qed. (* This Qed is slow unless foldr_map is Opaque *)
+Transparent foldr_map.
+
+(* This defines the induction principle for lists using foldr *)
+Section list_induction.
+
+Variables (P : pr1 List -> UU) (PhSet : forall l, isaset (P l)).
+Variables (P0 : P nil)
+          (Pc : forall (a : pr1 A) (l : pr1 List), P l -> P (cons (a,,l))).
+
+Let P' : UU := Σ l, P l.
+Let P0' : P' := (nil,, P0).
+Let Pc' : pr1 A × P' -> P' :=
+  λ ap : pr1 A × P', cons (pr1 ap,, pr1 (pr2 ap)),,Pc (pr1 ap) (pr1 (pr2 ap)) (pr2 (pr2 ap)).
+
+Definition P'HSET : HSET.
+Proof.
+apply (tpair _ P').
+abstract (apply (isofhleveltotal2 2); [ apply setproperty | intro x; apply PhSet ]).
+Defined.
+
+(* This line is crucial for isalghom_pr1foldr to typecheck *)
+Opaque omega_cocont_listFunctor.
+
+Lemma isalghom_pr1foldr :
+  is_algebra_mor _ List_alg List_alg (fun l => pr1 (foldr P'HSET P0' Pc' l)).
+Proof.
+apply CoproductArrow_eq_cor.
+- apply funextfun; intro x; destruct x; apply idpath.
+- apply funextfun; intro x; destruct x as [a l].
+  apply (maponpaths pr1 (foldr_cons P'HSET P0' Pc' a l)).
+Qed.
+
+Transparent omega_cocont_listFunctor.
+
+Definition pr1foldr_algmor : algebra_mor _ List_alg List_alg :=
+  tpair _ _ isalghom_pr1foldr.
+
+Lemma pr1foldr_algmor_identity : identity _ = pr1foldr_algmor.
+Proof.
+now rewrite <- (InitialEndo_is_identity _ listFunctor_Initial pr1foldr_algmor).
+Qed.
+
+Lemma listInd l : P l.
+Proof.
+assert (H : pr1 (foldr P'HSET P0' Pc' l) = l).
+  apply (toforallpaths _ _ _ (!pr1foldr_algmor_identity) l).
+rewrite <- H.
+apply (pr2 (foldr P'HSET P0' Pc' l)).
+Defined.
+
+End list_induction.
+
+Lemma listIndProp (P : pr1 List -> UU) (HP : forall l, isaprop (P l)) :
+  P nil -> (forall a l, P l → P (cons (a,, l))) -> forall l, P l.
+Proof.
+intros Pnil Pcons.
+apply listInd; try assumption.
+intro l; apply isasetaprop, HP.
+Defined.
+
+Require Import UniMath.Foundations.NumberSystems.NaturalNumbers.
+
+Definition natHSET : HSET.
+Proof.
+exists nat.
+abstract (apply isasetnat).
+Defined.
+
+Definition length : pr1 List -> nat :=
+  foldr natHSET 0 (fun x => S (pr2 x)).
+
+Definition map (f : pr1 A -> pr1 A) : pr1 List -> pr1 List :=
+  foldr _ nil (λ xxs : pr1 A × pr1 List, cons (f (pr1 xxs),, pr2 xxs)).
+
+Lemma length_map (f : pr1 A -> pr1 A) : forall xs, length (map f xs) = length xs.
+Proof.
+apply listIndProp.
+- intros l; apply isasetnat.
+- apply idpath.
+- simpl; unfold map, length; simpl; intros a l Hl.
+  simpl.
+  now rewrite !foldr_cons, <- Hl.
+Qed.
+
+End lists.
+
+(* Some examples of computations with lists over nat *)
+Section nat_examples.
+
+Definition cons_nat a l : pr1 (List natHSET) := cons natHSET (a,,l).
+
+Infix "::" := cons_nat.
+Notation "[]" := (nil natHSET) (at level 0, format "[]").
+
+Definition testlist : pr1 (List natHSET) := 5 :: 2 :: [].
+
+Definition testlistS : pr1 (List natHSET) :=
+  map natHSET S testlist.
+
+Definition sum : pr1 (List natHSET) -> nat :=
+  foldr natHSET natHSET 0 (fun xy => pr1 xy + pr2 xy).
+
+(* None of these compute *)
+(* Eval cbn in length _ (nil natHSET). *)
+(* Eval vm_compute in length _ testlist. *)
+(* Eval vm_compute in length _ testlistS. *)
+(* Eval vm_compute in sum testlist. *)
+(* Eval vm_compute in sum testlistS. *)
+
+Goal (forall l, length _ (2 :: l) = S (length _ l)).
+simpl.
+intro l.
+try apply idpath. (* this doesn't work *)
+unfold length, cons_nat.
+rewrite foldr_cons. cbn.
+apply idpath.
+Abort.
+
+(* some experiments: *)
+
+(* Definition const {A B : UU} : A -> B -> A := fun x _ => x. *)
+
+(* Eval compute in const 0 (nil natHSET). *)
+
+(* Axiom const' : forall {A B : UU}, A -> B -> A. *)
+
+(* Eval compute in const' 0 1. *)
+(* Eval compute in const' 0 (nil natHSET). *)
+
+(* Time Eval vm_compute in nil natHSET.  (* This crashes my computer by using up all memory *) *)
+
+End nat_examples.
+
+(* Alternative and more general definition of lists (inspired by a
+   remark of Voevodsky) *)
+Section list'.
+
+(* Remark: I think if you really need lists you should prove a theorem
+that establishes a weq between the lists that you have defined and
+lists defined as total2 ( fun n : nat => iterprod n A ) where iterprod
+n A is defined by induction such that iterprod 0 A = unit, iterprod 1
+A = A and iterprod ( S n ) A = dirprod (iterprod n A) A for n=S n’. *)
+
+Fixpoint iterprod (n : nat) (A : UU) : UU := match n with
+  | O => unit
+  | S n' => dirprod A (iterprod n' A)
+  end.
+
+Definition list' (A : UU) := total2 (fun n => iterprod n A).
+
+Definition nil_list' (A : UU) : list' A := (0,,tt).
+Definition cons_list' (A : UU) (x : A) (xs : list' A) : list' A :=
+  (S (pr1 xs),, (x,, pr2 xs)).
+
+Lemma list'_ind : ∀ (A : Type) (P : list' A -> UU),
+    P (nil_list' A)
+  -> (∀ (x : A) (xs : list' A), P xs -> P (cons_list' A x xs))
+  -> ∀ xs, P xs.
+Proof.
+intros A P Hnil Hcons xs.
+destruct xs as [n xs].
+induction n.
+- destruct xs.
+  apply Hnil.
+- destruct xs as [x xs].
+  apply (Hcons x (n,,xs) (IHn xs)).
+Qed.
+
+Lemma isaset_list' (A : HSET) : isaset (list' (pr1 A)).
+Proof.
+apply isaset_total2; [apply isasetnat|].
+intro n; induction n; simpl; [apply isasetunit|].
+apply isaset_dirprod; [ apply setproperty | apply IHn ].
+Qed.
+
+Definition to_List (A : HSET) : list' (pr1 A) -> pr1 (List A).
+Proof.
+intros l.
+destruct l as [n l].
+induction n.
++ exact (nil A).
++ apply (cons _ (pr1 l,,IHn (pr2 l))).
+Defined.
+
+Definition to_list' (A : HSET) : pr1 (List A) -> list' (pr1 A).
+Proof.
+apply (foldr A (list' (pr1 A),,isaset_list' A)).
+* apply (0,,tt).
+* intros L.
+  apply (tpair _ (S (pr1 (pr2 L))) (pr1 L,,pr2 (pr2 L))).
+Defined.
+
+Lemma to_list'K (A : HSET) : ∀ x : list' (pr1 A), to_list' A (to_List A x) = x.
+Proof.
+intro l; destruct l as [n l]; unfold to_list', to_List.
+induction n; simpl.
+- rewrite foldr_nil.
+  destruct l.
+  apply idpath.
+- rewrite foldr_cons; simpl.
+  rewrite IHn; simpl; rewrite <- (paireta l).
+  apply idpath.
+Qed.
+
+Lemma to_ListK (A : HSET) : ∀ y : pr1 (List A), to_List A (to_list' A y) = y.
+Proof.
+apply listIndProp.
+* intro l; apply setproperty.
+* unfold to_list'; rewrite foldr_nil.
+  apply idpath.
+* unfold to_list', to_List; intros a l IH.
+  rewrite foldr_cons; simpl.
+  apply maponpaths, maponpaths, pathsinv0.
+  eapply pathscomp0; [eapply pathsinv0, IH|]; simpl.
+  now destruct foldr.
+Qed.
+
+Lemma weq_list' (A : HSET) : list' (pr1 A) ≃ pr1 (List A).
+Proof.
+mkpair.
+- apply to_List.
+- simple refine (gradth _ _ _ _).
+  + apply to_list'.
+  + apply to_list'K.
+  + apply to_ListK.
+Defined.
+
+(* This doesn't compute: *)
+(* Eval compute in (to_list' _ testlist). *)
+
+End list'.
+
+
+
+(** Alternative version of lists using a more direct proof of
+    omega-cocontinuity *)
+Module AltList.
+
 (* The functor "x * F" is omega_cocont. This is only proved for set at the
    moment as it needs that the category is cartesian closed *)
 Section constprod_functor.
@@ -135,21 +470,15 @@ Definition stream : functor HSET HSET := constprod_functor1 ProductsHSET A.
 
 (* F(X) = 1 + (A * X) *)
 Definition listFunctor : functor HSET HSET :=
-  sum_of_functors CoproductsHSET (constant_functor _ _ unitHSET) (constprod_functor1 ProductsHSET A).
-  (* functor_composite stream (constcoprod_functor _ unitHSET CoproductsHSET). *)
+  functor_composite stream (constcoprod_functor _ unitHSET CoproductsHSET).
 
 Lemma omega_cocont_listFunctor : omega_cocont listFunctor.
 Proof.
-apply omega_cocont_sum_of_functors; try apply has_homsets_HSET.
-- apply ProductsHSET.
-- apply is_omega_cocont_constant_functor, has_homsets_HSET.
-- apply (omega_cocont_constprod_functor1 _ _ has_homsets_HSET has_exponentials_HSET).
-
-(* apply (omega_cocont_functor_composite has_homsets_HSET). *)
-(* (* - apply omega_cocontConstProdFunctor. *) *)
-(* (* If I use this length doesn't compute with vm_compute... *) *)
+apply (is_omega_cocont_functor_composite has_homsets_HSET).
+- apply omega_cocontConstProdFunctor.
+(* If I use this length doesn't compute with vm_compute... *)
 (* - apply (omega_cocont_constprod_functor1 _ _ has_homsets_HSET has_exponentials_HSET). *)
-(* - apply (omega_cocontConstCoprodFunctor _ has_homsets_HSET). *)
+- apply (omega_cocontConstCoprodFunctor _ has_homsets_HSET).
 Defined.
 
 Lemma listFunctor_Initial :
@@ -160,15 +489,13 @@ apply (colimAlgInitial _ _ _ omega_cocont_listFunctor
 Defined.
 
 Definition List : HSET :=
-  (* colim (ColimCoconeHSET nat_graph (initChain InitialHSET listFunctor)). *)
   alg_carrier _ (InitialObject listFunctor_Initial).
-(* Opaque List. *)
+
 Let List_mor : HSET⟦listFunctor List,List⟧ :=
   alg_map _ (InitialObject listFunctor_Initial).
-(* Opaque List_mor. *)
+
 Let List_alg : algebra_ob listFunctor :=
   InitialObject listFunctor_Initial.
-(* Opaque List_alg. *)
 
 Definition nil_map : HSET⟦unitHSET,List⟧.
 Proof.
@@ -204,17 +531,12 @@ Definition foldr_map (X : HSET) (x : pr1 X) (f : HSET⟦(A × X)%set,X⟧) :
 Proof.
 apply (InitialArrow listFunctor_Initial (mk_listAlgebra X x f)).
 Defined.
-(* Opaque foldr_map. *)
 
 Definition foldr (X : HSET) (x : pr1 X)
   (f : pr1 A × pr1 X -> pr1 X) : pr1 List -> pr1 X.
 Proof.
 apply (foldr_map _ x f).
 Defined.
-(* Opaque foldr. *)
-
-
-Opaque foldr_map.
 
 (* Maybe quantify over "λ _ : unit, x" instead of nil? *)
 Lemma foldr_nil (X : hSet) (x : X) (f : pr1 A × X -> X) : foldr X x f nil = x.
@@ -223,8 +545,6 @@ assert (F := maponpaths (fun x => CoproductIn1 _ _ ;; x)
                         (algebra_mor_commutes _ _ _ (foldr_map X x f))).
 apply (toforallpaths _ _ _ F tt).
 Qed.
-
-(* Opaque cons_map. *)
 
 Lemma foldr_cons (X : hSet) (x : X) (f : pr1 A × X -> X)
                  (a : pr1 A) (l : pr1 List) :
@@ -238,7 +558,9 @@ clear F.
 unfold compose in Fal.
 simpl in Fal.
 apply Fal.
-Qed. (* This Qed is slow! *)
+Opaque foldr_map.
+Qed. (* This Qed is slow unless one has the Opaque command above *)
+Transparent foldr_map.
 
 (* This defines the induction principle for lists using foldr *)
 Section list_induction.
@@ -258,20 +580,14 @@ apply (tpair _ P').
 abstract (apply (isofhleveltotal2 2); [ apply setproperty | intro x; apply PhSet ]).
 Defined.
 
-Transparent foldr_map.
-Opaque omega_cocont_listFunctor.
-
 Lemma isalghom_pr1foldr :
   is_algebra_mor _ List_alg List_alg (fun l => pr1 (foldr P'HSET P0' Pc' l)).
 Proof.
 apply CoproductArrow_eq_cor.
-- apply funextfun; intro x; destruct x.
-apply idpath.
+- apply funextfun; intro x; destruct x; apply idpath.
 - apply funextfun; intro x; destruct x as [a l].
   apply (maponpaths pr1 (foldr_cons P'HSET P0' Pc' a l)).
 Qed.
-
-Transparent omega_cocont_listFunctor.
 
 Definition pr1foldr_algmor : algebra_mor _ List_alg List_alg :=
   tpair _ _ isalghom_pr1foldr.
@@ -299,8 +615,6 @@ apply listInd; try assumption.
 intro l; apply isasetaprop, HP.
 Defined.
 
-Require Import UniMath.Foundations.NumberSystems.NaturalNumbers.
-
 Definition natHSET : HSET.
 Proof.
 exists nat.
@@ -325,9 +639,6 @@ Qed.
 
 End lists.
 
-(* Opaque List. *)
-(* Opaque foldr. *) (* makes "cbn" and "compute" in the computation below fail *)
-
 (* Some examples of computations with lists over nat *)
 Section nat_examples.
 
@@ -344,6 +655,7 @@ Definition testlistS : pr1 (List natHSET) :=
 Definition sum : pr1 (List natHSET) -> nat :=
   foldr natHSET natHSET 0 (fun xy => pr1 xy + pr2 xy).
 
+(* All of these work *)
 (* Eval cbn in length _ (nil natHSET). *)
 (* Eval vm_compute in length _ testlist. *)
 (* Eval vm_compute in length _ testlistS. *)
@@ -371,129 +683,5 @@ rewrite foldr_cons. cbn.
 apply idpath.
 Abort.
 
-(* some experiments: *)
-
-(* Definition const {A B : UU} : A -> B -> A := fun x _ => x. *)
-
-(* Eval compute in const 0 (nil natHSET). *)
-
-(* Axiom const' : forall {A B : UU}, A -> B -> A. *)
-
-(* Eval compute in const' 0 1. *)
-(* Eval compute in const' 0 (nil natHSET). *)
-
-(* Time Eval vm_compute in nil natHSET.  (* This crashes my computer by using up all memory *) *)
-
 End nat_examples.
-
-(* Inductive list A : UU := *)
-(*   | nilA : list A *)
-(*   | consA : A -> list A -> list A. *)
-
-(* Fixpoint lengthA (A : UU) (xs : list A) : nat := match xs with *)
-(*   | nilA _ => 0 *)
-(*   | consA _ _ xs' => S (lengthA _ xs') *)
-(*   end. *)
-
-(* Goal (forall l, lengthA nat (consA _ 2 l) = S (lengthA nat l)). *)
-(* intro l. *)
-(* apply idpath. *)
-(* Abort. *)
-
-(* Alternative and more general definition of lists (inspired by a remark of VV) *)
-Section list'.
-
-(* I think if you really need lists you should prove a theorem that
-establishes a weq between the lists that you have defined and lists
-defined as total2 ( fun n : nat => iterprod n A ) where iterprod n A
-is defined by induction such that iterprod 0 A = unit, iterprod 1 A =
-A and iterprod ( S n ) A = dirprod (iterprod n A) A for n=S n’. *)
-
-Fixpoint iterprod (n : nat) (A : UU) : UU := match n with
-  | O => unit
-  | S n' => dirprod A (iterprod n' A)
-  end.
-
-Definition list' (A : UU) := total2 (fun n => iterprod n A).
-
-Definition nil_list' (A : UU) : list' A := (0,,tt).
-Definition cons_list' (A : UU) (x : A) (xs : list' A) : list' A :=
-  (S (pr1 xs),, (x,, pr2 xs)).
-
-Lemma list'_ind : ∀ (A : Type) (P : list' A -> UU),
-    P (nil_list' A)
-  -> (∀ (x : A) (xs : list' A), P xs -> P (cons_list' A x xs))
-  -> ∀ xs, P xs.
-Proof.
-intros A P Hnil Hcons xs.
-destruct xs as [n xs].
-induction n.
-- destruct xs.
-  apply Hnil.
-- destruct xs as [x xs].
-  apply (Hcons x (n,,xs) (IHn xs)).
-Qed.
-
-Lemma isaset_list' (A : HSET) : isaset (list' (pr1 A)).
-Proof.
-apply isaset_total2; [apply isasetnat|].
-intro n; induction n; simpl; [apply isasetunit|].
-apply isaset_dirprod; [ apply setproperty | apply IHn ].
-Qed.
-
-Definition to_List (A : HSET) : list' (pr1 A) -> pr1 (List A).
-Proof.
-intros l.
-destruct l as [n l].
-induction n.
-+ exact (nil A).
-+ apply (cons _ (pr1 l,,IHn (pr2 l))).
-Defined.
-
-Definition to_list' (A : HSET) : pr1 (List A) -> list' (pr1 A).
-Proof.
-apply (foldr A (list' (pr1 A),,isaset_list' A)).
-* apply (0,,tt).
-* intros L.
-  apply (tpair _ (S (pr1 (pr2 L))) (pr1 L,,pr2 (pr2 L))).
-Defined.
-
-Lemma to_list'K (A : HSET) : ∀ x : list' (pr1 A), to_list' A (to_List A x) = x.
-Proof.
-intro l; destruct l as [n l]; unfold to_list', to_List.
-induction n; simpl.
-- rewrite foldr_nil.
-  destruct l.
-  apply idpath.
-- rewrite foldr_cons; simpl.
-  rewrite IHn; simpl; rewrite <- (paireta l).
-  apply idpath.
-Qed.
-
-Lemma to_ListK (A : HSET) : ∀ y : pr1 (List A), to_List A (to_list' A y) = y.
-Proof.
-apply listIndProp.
-* intro l; apply setproperty.
-* unfold to_list'; rewrite foldr_nil.
-  apply idpath.
-* unfold to_list', to_List; intros a l IH.
-  rewrite foldr_cons; simpl.
-  apply maponpaths, maponpaths, pathsinv0.
-  eapply pathscomp0; [eapply pathsinv0, IH|]; simpl.
-  now destruct foldr.
-Qed.
-
-Lemma weq_list' (A : HSET) : list' (pr1 A) ≃ pr1 (List A).
-Proof.
-mkpair.
-- apply to_List.
-- simple refine (gradth _ _ _ _).
-  + apply to_list'.
-  + apply to_list'K.
-  + apply to_ListK.
-Defined.
-
-(* This works: *)
-(* Eval compute in (to_list' _ testlist). *)
-
-End list'.
+End AltList.

--- a/UniMath/CategoryTheory/lists.v
+++ b/UniMath/CategoryTheory/lists.v
@@ -135,21 +135,21 @@ Definition stream : functor HSET HSET := constprod_functor1 ProductsHSET A.
 
 (* F(X) = 1 + (A * X) *)
 Definition listFunctor : functor HSET HSET :=
-  (* sum_of_functors CoproductsHSET (constant_functor _ _ unitHSET) (constprod_functor1 ProductsHSET A). *)
-  functor_composite stream (constcoprod_functor _ unitHSET CoproductsHSET).
+  sum_of_functors CoproductsHSET (constant_functor _ _ unitHSET) (constprod_functor1 ProductsHSET A).
+  (* functor_composite stream (constcoprod_functor _ unitHSET CoproductsHSET). *)
 
 Lemma omega_cocont_listFunctor : omega_cocont listFunctor.
 Proof.
-(* apply omega_cocont_sum_of_functors; try apply has_homsets_HSET. *)
-(* - apply ProductsHSET. *)
-(* - apply omega_cocont_constant_functor, has_homsets_HSET. *)
-(* - apply (omega_cocont_constprod_functor1 _ _ has_homsets_HSET has_exponentials_HSET). *)
-
-apply (omega_cocont_functor_composite has_homsets_HSET).
-(* - apply omega_cocontConstProdFunctor. *)
-(* If I use this length doesn't compute with vm_compute... *)
+apply omega_cocont_sum_of_functors; try apply has_homsets_HSET.
+- apply ProductsHSET.
+- apply is_omega_cocont_constant_functor, has_homsets_HSET.
 - apply (omega_cocont_constprod_functor1 _ _ has_homsets_HSET has_exponentials_HSET).
-- apply (omega_cocontConstCoprodFunctor _ has_homsets_HSET).
+
+(* apply (omega_cocont_functor_composite has_homsets_HSET). *)
+(* (* - apply omega_cocontConstProdFunctor. *) *)
+(* (* If I use this length doesn't compute with vm_compute... *) *)
+(* - apply (omega_cocont_constprod_functor1 _ _ has_homsets_HSET has_exponentials_HSET). *)
+(* - apply (omega_cocontConstCoprodFunctor _ has_homsets_HSET). *)
 Defined.
 
 Lemma listFunctor_Initial :
@@ -162,13 +162,13 @@ Defined.
 Definition List : HSET :=
   (* colim (ColimCoconeHSET nat_graph (initChain InitialHSET listFunctor)). *)
   alg_carrier _ (InitialObject listFunctor_Initial).
-Opaque List.
+(* Opaque List. *)
 Let List_mor : HSET⟦listFunctor List,List⟧ :=
   alg_map _ (InitialObject listFunctor_Initial).
-Opaque List_mor.
+(* Opaque List_mor. *)
 Let List_alg : algebra_ob listFunctor :=
   InitialObject listFunctor_Initial.
-Opaque List_alg.
+(* Opaque List_alg. *)
 
 Definition nil_map : HSET⟦unitHSET,List⟧.
 Proof.
@@ -204,14 +204,17 @@ Definition foldr_map (X : HSET) (x : pr1 X) (f : HSET⟦(A × X)%set,X⟧) :
 Proof.
 apply (InitialArrow listFunctor_Initial (mk_listAlgebra X x f)).
 Defined.
-Opaque foldr_map.
+(* Opaque foldr_map. *)
 
 Definition foldr (X : HSET) (x : pr1 X)
   (f : pr1 A × pr1 X -> pr1 X) : pr1 List -> pr1 X.
 Proof.
 apply (foldr_map _ x f).
 Defined.
-Opaque foldr.
+(* Opaque foldr. *)
+
+
+Opaque foldr_map.
 
 (* Maybe quantify over "λ _ : unit, x" instead of nil? *)
 Lemma foldr_nil (X : hSet) (x : X) (f : pr1 A × X -> X) : foldr X x f nil = x.
@@ -220,6 +223,8 @@ assert (F := maponpaths (fun x => CoproductIn1 _ _ ;; x)
                         (algebra_mor_commutes _ _ _ (foldr_map X x f))).
 apply (toforallpaths _ _ _ F tt).
 Qed.
+
+(* Opaque cons_map. *)
 
 Lemma foldr_cons (X : hSet) (x : X) (f : pr1 A × X -> X)
                  (a : pr1 A) (l : pr1 List) :
@@ -253,14 +258,20 @@ apply (tpair _ P').
 abstract (apply (isofhleveltotal2 2); [ apply setproperty | intro x; apply PhSet ]).
 Defined.
 
+Transparent foldr_map.
+Opaque omega_cocont_listFunctor.
+
 Lemma isalghom_pr1foldr :
   is_algebra_mor _ List_alg List_alg (fun l => pr1 (foldr P'HSET P0' Pc' l)).
 Proof.
 apply CoproductArrow_eq_cor.
-- apply funextfun; intro x; destruct x; apply idpath.
+- apply funextfun; intro x; destruct x.
+apply idpath.
 - apply funextfun; intro x; destruct x as [a l].
   apply (maponpaths pr1 (foldr_cons P'HSET P0' Pc' a l)).
 Qed.
+
+Transparent omega_cocont_listFunctor.
 
 Definition pr1foldr_algmor : algebra_mor _ List_alg List_alg :=
   tpair _ _ isalghom_pr1foldr.
@@ -314,7 +325,7 @@ Qed.
 
 End lists.
 
-Opaque List.
+(* Opaque List. *)
 (* Opaque foldr. *) (* makes "cbn" and "compute" in the computation below fail *)
 
 (* Some examples of computations with lists over nat *)

--- a/UniMath/CategoryTheory/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/polynomialfunctors.v
@@ -1,5 +1,14 @@
 (**
 
+This file contains proofs that the following functors are
+(omega-)cocontinuous:
+
+- Constant functor: F : C -> D, _ |-> x
+- Identity functor
+- Composition of omega-cocontinuous functors
+- The pair of functors (F,G) : A * B -> C * D if F and G are
+
+
      Anders Mörtberg, 2015-2016
 
 *)
@@ -44,12 +53,9 @@ End move_upstream.
 
 Section polynomial_functors.
 
-Definition omega_cocont_functor {C D : precategory}  : UU :=
-  total2 (fun F : functor C D => omega_cocont F).
-
 (* The constant functor is omega cocontinuous *)
 Lemma is_omega_cocont_constant_functor (C D : precategory) (hsD : has_homsets D)
-  (x : D) : omega_cocont (constant_functor C D x).
+  (x : D) : is_omega_cocont (constant_functor C D x).
 Proof.
 intros c L ccL HcL y ccy; simpl.
 simple refine (tpair _ _ _).
@@ -65,31 +71,31 @@ simple refine (tpair _ _ _).
 Defined.
 
 Definition omega_cocont_constant_functor (C D : precategory) (hsD : has_homsets D)
-  (x : D) : omega_cocont_functor := tpair _ _ (is_omega_cocont_constant_functor C D hsD x).
+  (x : D) : omega_cocont_functor C D := tpair _ _ (is_omega_cocont_constant_functor C D hsD x).
 
 (* The identity functor is omega cocontinuous *)
 Lemma is_omega_cocont_functor_identity (C : precategory) (hsC : has_homsets C) :
-  omega_cocont (functor_identity C).
+  is_omega_cocont (functor_identity C).
 Proof.
 intros c L ccL HcL.
 apply (preserves_colimit_identity hsC _ _ _ HcL).
 Defined.
 
 Definition omega_cocont_functor_identity (C : precategory) (hsC : has_homsets C) :
-  omega_cocont_functor := tpair _ _ (is_omega_cocont_functor_identity C hsC).
+  omega_cocont_functor C C := tpair _ _ (is_omega_cocont_functor_identity C hsC).
 
 (* Functor composition preserves omega cocontinuity *)
 Lemma is_omega_cocont_functor_composite {C D E : precategory}
   (hsE : has_homsets E) (F : functor C D) (G : functor D E) :
-  omega_cocont F -> omega_cocont G -> omega_cocont (functor_composite F G).
+  is_omega_cocont F -> is_omega_cocont G -> is_omega_cocont (functor_composite F G).
 Proof.
 intros hF hG c L cc.
 apply (preserves_colimit_comp hsE); [ apply hF | apply hG ].
 Defined.
 
 Definition omega_cocont_functor_composite {C D E : precategory}
-  (hsE : has_homsets E) (F : @omega_cocont_functor C D) (G : omega_cocont_functor) :
-  omega_cocont_functor := tpair _ _ (is_omega_cocont_functor_composite hsE _ _ (pr2 F) (pr2 G)).
+  (hsE : has_homsets E) (F : omega_cocont_functor C D) (G : omega_cocont_functor D E) :
+  omega_cocont_functor C E := tpair _ _ (is_omega_cocont_functor_composite hsE _ _ (pr2 F) (pr2 G)).
 
 (* A pair of functors (F,G) : A * B -> C * D is omega_cocont if F and G are *)
 Section pair_functor.
@@ -142,7 +148,7 @@ mkpair.
             | apply (maponpaths (fun x => pr1 (pr1 x)) (p2 X))]).
 Defined.
 
-Lemma omega_cocont_pr1_functor : omega_cocont (pr1_functor A B).
+Lemma is_omega_cocont_pr1_functor : is_omega_cocont (pr1_functor A B).
 Proof.
 intros c L ccL M.
 now apply isColimCocone_pr1_functor.
@@ -189,15 +195,14 @@ mkpair.
               | apply (maponpaths (fun x => dirprod_pr2 (pr1 x)) (p2 X)) ]).
 Defined.
 
-Lemma omega_cocont_pr2_functor : omega_cocont (pr2_functor A B).
+Lemma is_omega_cocont_pr2_functor : is_omega_cocont (pr2_functor A B).
 Proof.
 intros c L ccL M.
 now apply isColimCocone_pr2_functor.
 Defined.
 
-(* TODO: Opacify more *)
-Lemma omega_cocont_pair_functor (HF : omega_cocont F) (HG : omega_cocont G) :
-  omega_cocont (pair_functor F G).
+Lemma is_omega_cocont_pair_functor (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
+  is_omega_cocont (pair_functor F G).
 Proof.
 intros cAB ml ccml Hccml xy ccxy; simpl in *.
 simple refine (let cFAX : cocone (mapdiagram F (mapchain (pr1_functor A B) cAB))
@@ -242,7 +247,7 @@ apply (left_adjoint_cocont _ (is_left_adjoint_delta_functor PC) hsC).
 abstract (apply (has_homsets_product_precategory _ _ hsC hsC)).
 Defined.
 
-Lemma omega_cocont_delta_functor : omega_cocont (delta_functor C).
+Lemma is_omega_cocont_delta_functor : is_omega_cocont (delta_functor C).
 Proof.
 intros c L ccL.
 apply cocont_delta_functor.
@@ -262,7 +267,7 @@ apply (left_adjoint_cocont _ (is_left_adjoint_bincoproduct_functor PC)).
 - abstract (apply hsC).
 Defined.
 
-Lemma omega_cocont_bincoproduct_functor: omega_cocont (bincoproduct_functor PC).
+Lemma is_omega_cocont_bincoproduct_functor: is_omega_cocont (bincoproduct_functor PC).
 Proof.
 intros c L ccL; apply cocont_bincoproducts_functor.
 Defined.
@@ -275,16 +280,20 @@ Section sum_of_functors.
 Variables (C D : precategory) (PC : Products C) (HD : Coproducts D).
 Variables (hsC : has_homsets C) (hsD : has_homsets D).
 
-Lemma omega_cocont_sum_of_functors (F G : functor C D)
-  (HF : omega_cocont F) (HG : omega_cocont G) :
-  omega_cocont (sum_of_functors HD F G).
+Lemma is_omega_cocont_sum_of_functors (F G : functor C D)
+  (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
+  is_omega_cocont (sum_of_functors HD F G).
 Proof.
 apply (is_omega_cocont_functor_composite hsD).
-  apply (omega_cocont_delta_functor _ PC hsC).
+  apply (is_omega_cocont_delta_functor _ PC hsC).
 apply (is_omega_cocont_functor_composite hsD).
-  apply (omega_cocont_pair_functor _ _ _ _ _ _ hsC hsC hsD hsD HF HG).
-apply (omega_cocont_bincoproduct_functor _ _ hsD).
+  apply (is_omega_cocont_pair_functor _ _ _ _ _ _ hsC hsC hsD hsD HF HG).
+apply (is_omega_cocont_bincoproduct_functor _ _ hsD).
 Defined.
+
+Definition omega_cocont_sum_of_functors (F G : functor C D)
+  (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
+  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_sum_of_functors F G HF HG).
 
 End sum_of_functors.
 
@@ -298,11 +307,14 @@ Proof.
 apply (left_adjoint_cocont _ (hE _) hsC hsC).
 Defined.
 
-Lemma omega_cocont_constprod_functor1 (x : C) : omega_cocont (constprod_functor1 PC x).
+Lemma is_omega_cocont_constprod_functor1 (x : C) : is_omega_cocont (constprod_functor1 PC x).
 Proof.
 intros c L ccL.
 apply cocont_constprod_functor1.
 Defined.
+
+Definition omega_cocont_constprod_functor1 (x : C) :
+  omega_cocont_functor C C := tpair _ _ (is_omega_cocont_constprod_functor1 x).
 
 Lemma cocont_constprod_functor2 (x : C) : is_cocont (constprod_functor2 PC x).
 Proof.
@@ -310,11 +322,14 @@ apply left_adjoint_cocont; try apply hsC.
 apply (is_left_adjoint_constprod_functor2 PC hsC), hE.
 Defined.
 
-Lemma omega_cocont_constprod_functor2 (x : C) : omega_cocont (constprod_functor2 PC x).
+Lemma is_omega_cocont_constprod_functor2 (x : C) : is_omega_cocont (constprod_functor2 PC x).
 Proof.
 intros c L ccL.
 apply cocont_constprod_functor2.
 Defined.
+
+Definition omega_cocont_constprod_functor2 (x : C) :
+  omega_cocont_functor C C := tpair _ _ (is_omega_cocont_constprod_functor2 x).
 
 End constprod_functors.
 
@@ -425,7 +440,6 @@ simple refine (mk_cocone _ _).
 + simpl; intros j k e; apply map_to_K_commutes.
 Defined.
 
-
 Section omega_cocont_binproduct.
 
 Variable cAB : chain (product_precategory C C).
@@ -445,14 +459,14 @@ Let HB := isColimCocone_pr2_functor _ _ hsC _ _ _ HccLM
 
 (* Form the colimiting cocones of "A_i * B_0 -> A_i * B_1 -> ..." *)
 Let HAiB :=
-  fun i => omega_cocont_constprod_functor1 _ PC hsC hE (pr1 (pr1 cAB i)) _ _ _ HB.
+  fun i => is_omega_cocont_constprod_functor1 _ PC hsC hE (pr1 (pr1 cAB i)) _ _ _ HB.
 
 (* Turn HAiB into a ColimCocone: *)
 Let CCAiB := fun i => mk_ColimCocone _ _ _ (HAiB i).
 
 (* Define the HAiM ColimCocone: *)
 Let HAiM :=
-  mk_ColimCocone _ _ _ (omega_cocont_constprod_functor2 _ PC hsC hE M _ _ _ HA).
+  mk_ColimCocone _ _ _ (is_omega_cocont_constprod_functor2 _ PC hsC hE M _ _ _ HA).
 
 Let ccAiB_K := fun i => ccAiB_K _ _ ccK i.
 
@@ -634,7 +648,7 @@ Defined.
 
 End omega_cocont_binproduct.
 
-Lemma omega_cocont_binproduct_functor : omega_cocont (binproduct_functor PC).
+Lemma is_omega_cocont_binproduct_functor : is_omega_cocont (binproduct_functor PC).
 Proof.
 intros cAB LM ccLM HccLM K ccK; simpl in *.
 apply isColimProductOfColims.
@@ -642,6 +656,28 @@ apply HccLM.
 Defined.
 
 End binprod_functor.
+
+Section product_of_functors.
+
+Variables (C D : precategory) (PC : Products C) (PD : Products D) (hED : has_exponentials PD).
+Variables (hsC : has_homsets C) (hsD : has_homsets D).
+
+Lemma is_omega_cocont_product_of_functors (F G : functor C D)
+  (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
+  is_omega_cocont (product_of_functors PD F G).
+Proof.
+apply (is_omega_cocont_functor_composite hsD).
+  apply (is_omega_cocont_delta_functor _ PC hsC).
+apply (is_omega_cocont_functor_composite hsD).
+  apply (is_omega_cocont_pair_functor _ _ _ _ _ _ hsC hsC hsD hsD HF HG).
+apply (is_omega_cocont_binproduct_functor _ _ hsD hED).
+Defined.
+
+Definition omega_cocont_product_of_functors (F G : functor C D)
+  (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
+  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_product_of_functors F G HF HG).
+
+End product_of_functors.
 
 (* Precomposition functor is cocontinuous *)
 Section pre_composition_functor.
@@ -819,13 +855,25 @@ apply left_adjoint_cocont.
 - apply functor_category_has_homsets.
 Qed.
 
-Lemma omega_cocont_pre_composition_functor :
-  omega_cocont (pre_composition_functor _ _ _ hsC hsA K).
+Lemma is_omega_cocont_pre_composition_functor :
+  is_omega_cocont (pre_composition_functor _ _ _ hsC hsA K).
 Proof.
 intros c L ccL.
 apply cocont_pre_composition_functor.
 Defined.
 
+Definition omega_cocont_pre_composition_functor :
+  omega_cocont_functor [C, A, hsA] [M, A, hsA] :=
+  tpair _ _ is_omega_cocont_pre_composition_functor.
+
 End pre_composition_functor.
 
 End polynomial_functors.
+
+
+(* Specialized notation for HSET *)
+Section notations_hset.
+
+(* TODO: add notations for constant, identity, +, *, *: *)
+
+End notations_hset.

--- a/UniMath/CategoryTheory/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/polynomialfunctors.v
@@ -3,13 +3,13 @@
 This file contains proofs that the following functors are
 (omega-)cocontinuous:
 
-- Constant functor: F : C -> D, _ |-> x
+- Constant functor: F_x : C -> D, c |-> x
 - Identity functor
 - Composition of omega-cocontinuous functors
-- The pair of functors (F,G) : A * B -> C * D if F and G are
+- The pair of functors (F,G) : A * B -> C * D if F and G are. (x,y) |-> (F x,G y)
+...
 
-
-     Anders Mörtberg, 2015-2016
+Written by: Anders Mörtberg, 2015-2016
 
 *)
 
@@ -870,10 +870,24 @@ End pre_composition_functor.
 
 End polynomial_functors.
 
+(* Specialized notations for HSET *)
+Delimit Scope polynomial_functor_hset_scope with PS.
 
-(* Specialized notation for HSET *)
-Section notations_hset.
+Notation "' x" := (omega_cocont_constant_functor _ _ has_homsets_HSET x)
+                    (at level 10) : polynomial_functor_hset_scope.
 
-(* TODO: add notations for constant, identity, +, *, *: *)
+Notation "'Id'" := (omega_cocont_functor_identity _ has_homsets_HSET) :
+                     polynomial_functor_hset_scope.
 
-End notations_hset.
+Notation "F * G" :=
+  (omega_cocont_product_of_functors _ _ ProductsHSET _
+     has_exponentials_HSET has_homsets_HSET has_homsets_HSET _ _ (pr2 F) (pr2 G)) :
+    polynomial_functor_hset_scope.
+
+Notation "F + G" :=
+  (omega_cocont_sum_of_functors _ _ ProductsHSET CoproductsHSET
+     has_homsets_HSET has_homsets_HSET _ _ (pr2 F) (pr2 G)) :
+    polynomial_functor_hset_scope.
+
+Notation "1" := (unitHSET) : polynomial_functor_hset_scope.
+Notation "0" := (emptyHSET) : polynomial_functor_hset_scope.

--- a/UniMath/CategoryTheory/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/polynomialfunctors.v
@@ -44,8 +44,11 @@ End move_upstream.
 
 Section polynomial_functors.
 
+Definition omega_cocont_functor {C D : precategory}  : UU :=
+  total2 (fun F : functor C D => omega_cocont F).
+
 (* The constant functor is omega cocontinuous *)
-Lemma omega_cocont_constant_functor (C D : precategory) (hsD : has_homsets D)
+Lemma is_omega_cocont_constant_functor (C D : precategory) (hsD : has_homsets D)
   (x : D) : omega_cocont (constant_functor C D x).
 Proof.
 intros c L ccL HcL y ccy; simpl.
@@ -61,22 +64,32 @@ simple refine (tpair _ _ _).
               | now simpl; destruct p as [p H]; rewrite <- (H 0), id_left]).
 Defined.
 
+Definition omega_cocont_constant_functor (C D : precategory) (hsD : has_homsets D)
+  (x : D) : omega_cocont_functor := tpair _ _ (is_omega_cocont_constant_functor C D hsD x).
+
 (* The identity functor is omega cocontinuous *)
-Lemma omega_cocont_functor_identity (C : precategory) (hsC : has_homsets C) :
+Lemma is_omega_cocont_functor_identity (C : precategory) (hsC : has_homsets C) :
   omega_cocont (functor_identity C).
 Proof.
 intros c L ccL HcL.
 apply (preserves_colimit_identity hsC _ _ _ HcL).
 Defined.
 
+Definition omega_cocont_functor_identity (C : precategory) (hsC : has_homsets C) :
+  omega_cocont_functor := tpair _ _ (is_omega_cocont_functor_identity C hsC).
+
 (* Functor composition preserves omega cocontinuity *)
-Lemma omega_cocont_functor_composite {C D E : precategory}
+Lemma is_omega_cocont_functor_composite {C D E : precategory}
   (hsE : has_homsets E) (F : functor C D) (G : functor D E) :
   omega_cocont F -> omega_cocont G -> omega_cocont (functor_composite F G).
 Proof.
 intros hF hG c L cc.
 apply (preserves_colimit_comp hsE); [ apply hF | apply hG ].
 Defined.
+
+Definition omega_cocont_functor_composite {C D E : precategory}
+  (hsE : has_homsets E) (F : @omega_cocont_functor C D) (G : omega_cocont_functor) :
+  omega_cocont_functor := tpair _ _ (is_omega_cocont_functor_composite hsE _ _ (pr2 F) (pr2 G)).
 
 (* A pair of functors (F,G) : A * B -> C * D is omega_cocont if F and G are *)
 Section pair_functor.

--- a/UniMath/CategoryTheory/polynomialfunctors.v
+++ b/UniMath/CategoryTheory/polynomialfunctors.v
@@ -239,7 +239,7 @@ Variables (C : precategory) (PC : Products C) (hsC : has_homsets C).
 Lemma cocont_delta_functor : is_cocont (delta_functor C).
 Proof.
 apply (left_adjoint_cocont _ (is_left_adjoint_delta_functor PC) hsC).
-apply (has_homsets_product_precategory _ _ hsC hsC).
+abstract (apply (has_homsets_product_precategory _ _ hsC hsC)).
 Defined.
 
 Lemma omega_cocont_delta_functor : omega_cocont (delta_functor C).
@@ -258,8 +258,8 @@ Variables (C : precategory) (PC : Coproducts C) (hsC : has_homsets C).
 Lemma cocont_bincoproducts_functor : is_cocont (bincoproduct_functor PC).
 Proof.
 apply (left_adjoint_cocont _ (is_left_adjoint_bincoproduct_functor PC)).
-- apply has_homsets_product_precategory; apply hsC.
-- apply hsC.
+- abstract (apply has_homsets_product_precategory; apply hsC).
+- abstract (apply hsC).
 Defined.
 
 Lemma omega_cocont_bincoproduct_functor: omega_cocont (bincoproduct_functor PC).
@@ -279,9 +279,9 @@ Lemma omega_cocont_sum_of_functors (F G : functor C D)
   (HF : omega_cocont F) (HG : omega_cocont G) :
   omega_cocont (sum_of_functors HD F G).
 Proof.
-apply (omega_cocont_functor_composite hsD).
+apply (is_omega_cocont_functor_composite hsD).
   apply (omega_cocont_delta_functor _ PC hsC).
-apply (omega_cocont_functor_composite hsD).
+apply (is_omega_cocont_functor_composite hsD).
   apply (omega_cocont_pair_functor _ _ _ _ _ _ hsC hsC hsD hsD HF HG).
 apply (omega_cocont_bincoproduct_functor _ _ hsD).
 Defined.

--- a/UniMath/CategoryTheory/trees.v
+++ b/UniMath/CategoryTheory/trees.v
@@ -1,0 +1,185 @@
+(* Definition of binary trees done analoguously to lists.
+
+Written by: Anders Mörtberg (2016)
+
+*)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.total2_paths.
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.category_hset.
+Require Import UniMath.CategoryTheory.category_hset_structures.
+Require Import UniMath.CategoryTheory.limits.initial.
+Require Import UniMath.CategoryTheory.FunctorAlgebras.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseProduct.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseCoproduct.
+Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.limits.terminal.
+Require Import UniMath.CategoryTheory.chains.
+Require Import UniMath.CategoryTheory.polynomialfunctors.
+Require Import UniMath.CategoryTheory.exponentials.
+Require Import UniMath.CategoryTheory.limits.coproducts.
+
+Local Notation "# F" := (functor_on_morphisms F) (at level 3).
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
+
+(* Binary trees *)
+Section bintrees.
+
+Variable A : HSET.
+
+Local Open Scope polynomial_functor_hset_scope.
+
+(* F(X) = 1 + A * X * X *)
+Definition treeOmegaFunctor : omega_cocont_functor HSET HSET := '1 + 'A * (Id * Id).
+
+Let treeFunctor : functor HSET HSET := pr1 treeOmegaFunctor.
+Let is_omega_cocont_treeFunctor : is_omega_cocont treeFunctor := pr2 treeOmegaFunctor.
+
+Lemma treeFunctor_Initial :
+  Initial (precategory_FunctorAlg treeFunctor has_homsets_HSET).
+Proof.
+apply (colimAlgInitial _ _ _ is_omega_cocont_treeFunctor InitialHSET (ColimCoconeHSET _ _)).
+Defined.
+
+Definition Tree : HSET :=
+  alg_carrier _ (InitialObject treeFunctor_Initial).
+
+Let Tree_mor : HSET⟦treeFunctor Tree,Tree⟧ :=
+  alg_map _ (InitialObject treeFunctor_Initial).
+
+Let Tree_alg : algebra_ob treeFunctor :=
+  InitialObject treeFunctor_Initial.
+
+Definition leaf_map : HSET⟦unitHSET,Tree⟧.
+Proof.
+simpl; intro x.
+apply Tree_mor, inl, x.
+Defined.
+
+Definition leaf : pr1 Tree := leaf_map tt.
+
+Definition node_map : HSET⟦(A × (Tree × Tree))%set,Tree⟧.
+Proof.
+intros xs.
+apply Tree_mor, (inr xs).
+Defined.
+
+Definition node : pr1 A × (pr1 Tree × pr1 Tree) -> pr1 Tree := node_map.
+
+(* Get recursion/iteration scheme: *)
+
+(*    x : X           f : A × X × X -> X *)
+(* ------------------------------------ *)
+(*       foldr x f : Tree A -> X *)
+
+Definition mk_treeAlgebra (X : HSET) (x : pr1 X)
+  (f : HSET⟦(A × X × X)%set,X⟧) : algebra_ob treeFunctor.
+Proof.
+set (x' := λ (_ : unit), x).
+apply (tpair _ X (sumofmaps x' f) : algebra_ob treeFunctor).
+Defined.
+
+Definition foldr_map (X : HSET) (x : pr1 X) (f : HSET⟦(A × X × X)%set,X⟧) :
+  algebra_mor _ Tree_alg (mk_treeAlgebra X x f).
+Proof.
+apply (InitialArrow treeFunctor_Initial (mk_treeAlgebra X x f)).
+Defined.
+
+Definition foldr (X : HSET) (x : pr1 X)
+  (f : pr1 A × pr1 X × pr1 X -> pr1 X) : pr1 Tree -> pr1 X.
+Proof.
+apply (foldr_map _ x f).
+Defined.
+
+(* Maybe quantify over "λ _ : unit, x" instead of nil? *)
+Lemma foldr_leaf (X : hSet) (x : X) (f : pr1 A × X × X -> X) : foldr X x f leaf = x.
+Proof.
+assert (F := maponpaths (fun x => CoproductIn1 _ _ ;; x)
+                        (algebra_mor_commutes _ _ _ (foldr_map X x f))).
+apply (toforallpaths _ _ _ F tt).
+Qed.
+
+Lemma foldr_node (X : hSet) (x : X) (f : pr1 A × X × X -> X)
+                 (a : pr1 A) (l1 l2 : pr1 Tree) :
+  foldr X x f (node (a,,l1,,l2)) = f (a,,foldr X x f l1,,foldr X x f l2).
+Proof.
+assert (F := maponpaths (fun x => CoproductIn2 _ _ ;; x)
+                        (algebra_mor_commutes _ _ _ (foldr_map X x f))).
+assert (Fal := toforallpaths _ _ _ F (a,,l1,,l2)).
+clear F.
+(* apply Fal. *) (* This doesn't work here. why? *)
+unfold compose in Fal.
+simpl in Fal.
+apply Fal.
+Opaque foldr_map.
+Qed. (* This Qed is slow unless foldr_map is Opaque *)
+Transparent foldr_map.
+
+(* This defines the induction principle for trees using foldr *)
+Section tree_induction.
+
+Variables (P : pr1 Tree -> UU) (PhSet : forall l, isaset (P l)).
+Variables (P0 : P leaf)
+          (Pc : forall (a : pr1 A) (l1 l2 : pr1 Tree), P l1 -> P l2 -> P (node (a,,l1,,l2))).
+
+Let P' : UU := Σ l, P l.
+Let P0' : P' := (leaf,, P0).
+Let Pc' : pr1 A × P' × P' -> P'.
+Proof.
+intros ap.
+apply (tpair _ (node (pr1 ap,,pr1 (pr1 (pr2 ap)),,pr1 (pr2 (pr2 ap))))).
+apply (Pc _ _ _ (pr2 (pr1 (pr2 ap))) (pr2 (pr2 (pr2 ap)))).
+  (* λ ap : pr1 A × P' × P', node (pr1 ap,, pr1 (pr2 ap)),,Pc (pr1 ap) (pr1 (pr2 ap)) (pr2 (pr2 ap)). *)
+Defined.
+
+Definition P'HSET : HSET.
+Proof.
+apply (tpair _ P').
+abstract (apply (isofhleveltotal2 2); [ apply setproperty | intro x; apply PhSet ]).
+Defined.
+
+(* This line is crucial for isalghom_pr1foldr to typecheck *)
+Opaque is_omega_cocont_treeFunctor.
+
+Lemma isalghom_pr1foldr :
+  is_algebra_mor _ Tree_alg Tree_alg (fun l => pr1 (foldr P'HSET P0' Pc' l)).
+Proof.
+apply CoproductArrow_eq_cor.
+- apply funextfun; intro x; destruct x; apply idpath.
+- apply funextfun; intro x; destruct x as [a [l1 l2]].
+  apply (maponpaths pr1 (foldr_node P'HSET P0' Pc' a l1 l2)).
+Qed.
+
+Transparent is_omega_cocont_treeFunctor.
+
+Definition pr1foldr_algmor : algebra_mor _ Tree_alg Tree_alg :=
+  tpair _ _ isalghom_pr1foldr.
+
+Lemma pr1foldr_algmor_identity : identity _ = pr1foldr_algmor.
+Proof.
+now rewrite <- (InitialEndo_is_identity _ treeFunctor_Initial pr1foldr_algmor).
+Qed.
+
+Lemma treeInd l : P l.
+Proof.
+assert (H : pr1 (foldr P'HSET P0' Pc' l) = l).
+  apply (toforallpaths _ _ _ (!pr1foldr_algmor_identity) l).
+rewrite <- H.
+apply (pr2 (foldr P'HSET P0' Pc' l)).
+Defined.
+
+End tree_induction.
+
+Lemma treeIndProp (P : pr1 Tree -> UU) (HP : forall l, isaprop (P l)) :
+  P leaf -> (forall a l1 l2, P l1 → P l2 → P (node (a,,l1,,l2))) -> forall l, P l.
+Proof.
+intros Pnil Pcons.
+apply treeInd; try assumption.
+intro l; apply isasetaprop, HP.
+Defined.

--- a/UniMath/CategoryTheory/trees.v
+++ b/UniMath/CategoryTheory/trees.v
@@ -183,3 +183,45 @@ intros Pnil Pcons.
 apply treeInd; try assumption.
 intro l; apply isasetaprop, HP.
 Defined.
+
+End bintrees.
+
+Section nat_examples.
+
+Require Import UniMath.Foundations.NumberSystems.NaturalNumbers.
+
+Local Open Scope nat_scope.
+
+Definition natHSET : HSET.
+Proof.
+exists nat.
+abstract (apply isasetnat).
+Defined.
+
+Definition size : pr1 (Tree natHSET) -> nat :=
+  foldr natHSET natHSET 0 (fun x => S (pr1 (pr2 x) + pr2 (pr2 x))).
+
+Lemma size_node a l1 l2 : size (node natHSET (a,,l1,,l2)) = 1 + size l1 + size l2.
+Proof.
+unfold size.
+now rewrite foldr_node.
+Qed.
+
+Definition map (f : nat -> nat) (l : pr1 (Tree natHSET)) : pr1 (Tree natHSET) :=
+  foldr natHSET (Tree natHSET) (leaf natHSET)
+      (λ a, node natHSET (f (pr1 a),, pr1 (pr2 a),, pr2 (pr2 a))) l.
+
+Lemma size_map (f : nat -> nat) : forall l, size (map f l) = size l.
+Proof.
+apply treeIndProp.
+- intros l. apply isasetnat.
+- apply idpath.
+- intros a l1 l2 ih1 ih2.
+  unfold map.
+  now rewrite foldr_node, !size_node, <- ih1, <- ih2.
+Qed.
+
+Definition sum : pr1 (Tree natHSET) -> nat :=
+  foldr natHSET natHSET 0 (fun x => pr1 x + pr1 (pr2 x) + pr2 (pr2 x)).
+
+End nat_examples.

--- a/UniMath/SubstitutionSystems/Lam.v
+++ b/UniMath/SubstitutionSystems/Lam.v
@@ -53,7 +53,54 @@ Arguments θ_target {_ _} _ .
 Arguments θ_Strength1 {_ _ _} _ .
 Arguments θ_Strength2 {_ _ _} _ .
 
+Section set_instances.
 
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.exponentials.
+Require Import UniMath.CategoryTheory.category_hset.
+Require Import UniMath.CategoryTheory.category_hset_structures.
+Require Import UniMath.CategoryTheory.chains.
+Require Import UniMath.CategoryTheory.polynomialfunctors.
+
+Let Lam_S : Signature _ _ := Lam_Sig HSET has_homsets_HSET TerminalHSET CoproductsHSET ProductsHSET.
+
+Local Notation "'EndHSET'":= ([HSET, HSET, has_homsets_HSET]) .
+
+Let hsEndC : has_homsets EndHSET := functor_category_has_homsets _ _ has_homsets_HSET.
+
+Lemma Lam_Initial_HSET : Initial (precategory_FunctorAlg (Id_H _ _ CoproductsHSET Lam_S) hsEndC).
+Proof.
+use colimAlgInitial.
+- unfold Id_H, Const_plus_H.
+  apply is_omega_cocont_sum_of_functors.
+  + apply (Products_functor_precat _ _ ProductsHSET).
+  + apply functor_category_has_homsets.
+  + apply functor_category_has_homsets.
+  + apply is_omega_cocont_constant_functor; apply functor_category_has_homsets.
+  + apply is_omega_cocont_Lam.
+    * apply (has_exponentials_functor_HSET _ has_homsets_HSET).
+    * apply cats_LimsHSET.
+- admit.
+- apply ColimsFunctorCategory; apply ColimsHSET.
+Admitted.
+
+Lemma KanExt_HSET : ∀ Z : precategory_Ptd HSET has_homsets_HSET,
+   RightKanExtension.GlobalRightKanExtensionExists HSET HSET
+     (U Z) HSET has_homsets_HSET has_homsets_HSET.
+Proof.
+intro Z.
+apply RightKanExtension_from_limits.
+apply cats_LimsHSET.
+Defined.
+
+Definition LamHSS_Initial_HSET : Initial (hss_precategory CoproductsHSET Lam_S).
+Proof.
+  apply InitialHSS.
+  - apply KanExt_HSET.
+  - apply Lam_Initial_HSET.
+Defined.
+
+End set_instances.
 
 Section Lambda.
 

--- a/UniMath/SubstitutionSystems/Lam.v
+++ b/UniMath/SubstitutionSystems/Lam.v
@@ -80,9 +80,9 @@ use colimAlgInitial.
   + apply is_omega_cocont_Lam.
     * apply (has_exponentials_functor_HSET _ has_homsets_HSET).
     * apply cats_LimsHSET.
-- admit.
+- apply (Initial_functor_precat _ _ InitialHSET).
 - apply ColimsFunctorCategory; apply ColimsHSET.
-Admitted.
+Defined.
 
 Lemma KanExt_HSET : ∀ Z : precategory_Ptd HSET has_homsets_HSET,
    RightKanExtension.GlobalRightKanExtensionExists HSET HSET

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -55,7 +55,8 @@ Variable CC : Coproducts C.
 Variable terminal : Terminal C.
 Let one : C :=  @TerminalObject C terminal.
 
-Definition square_functor := product_functor C C CP (functor_identity C) (functor_identity C).
+(* Definition square_functor := product_functor C C CP (functor_identity C) (functor_identity C). *)
+Definition square_functor := product_of_functors CP (functor_identity C) (functor_identity C).
 
 Definition option_functor: functor C C := coproduct_functor _ _ CC (constant_functor _ _  one) (functor_identity C).
 
@@ -87,72 +88,100 @@ Proof.
   exact CP.
 Defined.
 
+Require Import UniMath.CategoryTheory.chains.
+Require Import UniMath.CategoryTheory.polynomialfunctors.
+Require Import UniMath.CategoryTheory.exponentials.
+
+Lemma is_omega_cocont_App_H (hE : has_exponentials (Products_functor_precat C C CP hs)) :
+  is_omega_cocont App_H.
+Proof.
+unfold App_H, square_functor.
+apply is_omega_cocont_product_of_functors.
+- apply (Products_functor_precat _ _ CP).
+- apply hE.
+- apply functor_category_has_homsets.
+- apply functor_category_has_homsets.
+- apply (is_omega_cocont_functor_identity _ (functor_category_has_homsets _ _ hs)).
+- apply (is_omega_cocont_functor_identity _ (functor_category_has_homsets _ _ hs)).
+Defined.
+
 (**
    [Abs_H (X) := X o option]
 *)
 
-Definition Abs_H_ob (X: EndC): functor C C := functor_composite (option_functor _ CC terminal) X.
+(* Definition Abs_H_ob (X: EndC): functor C C := functor_composite (option_functor _ CC terminal) X. *)
 
-(* works only with -type-in-type:
-Definition Abs_H_mor_nat_trans_data (X X': EndC)(α: X --> X'): ∀ c, Abs_H_ob X c --> Abs_H_ob X' c.
+(* (* works only with -type-in-type: *)
+(* Definition Abs_H_mor_nat_trans_data (X X': EndC)(α: X --> X'): ∀ c, Abs_H_ob X c --> Abs_H_ob X' c. *)
+(* Proof. *)
+(*   intro. *)
+(*   unfold Abs_H_ob. *)
+(*   red. simpl. apply α. *)
+(* Defined. *)
+(* *) *)
+
+(* Definition Abs_H_mor_nat_trans_data (X X': functor C C)(α: nat_trans X X'): ∀ c, Abs_H_ob X c --> Abs_H_ob X' c. *)
+(* Proof. *)
+(*   intro. *)
+(*   apply α. *)
+(* Defined. *)
+
+(* Lemma is_nat_trans_Abs_H_mor_nat_trans_data  (X X': EndC)(α: X --> X'): is_nat_trans _ _ (Abs_H_mor_nat_trans_data X X' α). *)
+(* Proof. *)
+(*   red. *)
+(*   intros c c' f. *)
+(*   destruct α as [α α_nat_trans]. *)
+(*   unfold Abs_H_mor_nat_trans_data, Abs_H_ob. *)
+(*   simpl. *)
+(*   apply α_nat_trans. *)
+(*  Qed. *)
+
+(* Definition Abs_H_mor (X X': EndC)(α: X --> X'): (Abs_H_ob X: ob EndC) --> Abs_H_ob X'. *)
+(* Proof. *)
+(*   exists (Abs_H_mor_nat_trans_data X X' α). *)
+(*   exact (is_nat_trans_Abs_H_mor_nat_trans_data X X' α). *)
+(* Defined. *)
+
+(* Definition Abs_H_functor_data: functor_data EndC EndC. *)
+(* Proof. *)
+(*   exists Abs_H_ob. *)
+(*   exact Abs_H_mor. *)
+(* Defined. *)
+
+(* Lemma is_functor_Abs_H_data: is_functor Abs_H_functor_data. *)
+(* Proof. *)
+(*   red. *)
+(*   split; red. *)
+(*   + intros X. *)
+(*     unfold Abs_H_functor_data. *)
+(*     simpl. *)
+(*     apply nat_trans_eq; try assumption. *)
+(*     intro c. *)
+(*     unfold Abs_H_mor. *)
+(*     simpl. *)
+(*     apply idpath. *)
+(*   + intros X X' X'' α β. *)
+(*     unfold Abs_H_functor_data. *)
+(*     simpl. *)
+(*     apply nat_trans_eq; try assumption. *)
+(*     intro c. *)
+(*     unfold Abs_H_mor. *)
+(*     simpl. *)
+(*     apply idpath. *)
+(* Qed. *)
+
+Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.limits.cats.limits.
+
+Definition Abs_H : functor [C, C, hs] [C, C, hs] :=
+ (* tpair _ _ is_functor_Abs_H_data. *)
+  pre_composition_functor _ _ _ hs _ (option_functor C CC terminal).
+
+Lemma is_omega_cocont_Abs_H (LC : Lims C) : is_omega_cocont Abs_H.
 Proof.
-  intro.
-  unfold Abs_H_ob.
-  red. simpl. apply α.
+unfold Abs_H.
+apply (is_omega_cocont_pre_composition_functor _ _ _ _ _ _ LC).
 Defined.
-*)
-
-Definition Abs_H_mor_nat_trans_data (X X': functor C C)(α: nat_trans X X'): ∀ c, Abs_H_ob X c --> Abs_H_ob X' c.
-Proof.
-  intro.
-  apply α.
-Defined.
-
-Lemma is_nat_trans_Abs_H_mor_nat_trans_data  (X X': EndC)(α: X --> X'): is_nat_trans _ _ (Abs_H_mor_nat_trans_data X X' α).
-Proof.
-  red.
-  intros c c' f.
-  destruct α as [α α_nat_trans].
-  unfold Abs_H_mor_nat_trans_data, Abs_H_ob.
-  simpl.
-  apply α_nat_trans.
- Qed.
-
-Definition Abs_H_mor (X X': EndC)(α: X --> X'): (Abs_H_ob X: ob EndC) --> Abs_H_ob X'.
-Proof.
-  exists (Abs_H_mor_nat_trans_data X X' α).
-  exact (is_nat_trans_Abs_H_mor_nat_trans_data X X' α).
-Defined.
-
-Definition Abs_H_functor_data: functor_data EndC EndC.
-Proof.
-  exists Abs_H_ob.
-  exact Abs_H_mor.
-Defined.
-
-Lemma is_functor_Abs_H_data: is_functor Abs_H_functor_data.
-Proof.
-  red.
-  split; red.
-  + intros X.
-    unfold Abs_H_functor_data.
-    simpl.
-    apply nat_trans_eq; try assumption.
-    intro c.
-    unfold Abs_H_mor.
-    simpl.
-    apply idpath.
-  + intros X X' X'' α β.
-    unfold Abs_H_functor_data.
-    simpl.
-    apply nat_trans_eq; try assumption.
-    intro c.
-    unfold Abs_H_mor.
-    simpl.
-    apply idpath.
-Qed.
-
-Definition Abs_H : functor [C, C, hs] [C, C, hs] := tpair _ _ is_functor_Abs_H_data.
 
 
 (**
@@ -647,12 +676,21 @@ Proof.
   + exact Flat_θ_strength2_int.
 Defined.
 
-
 Definition Lam_Sig: Signature C hs :=
   Sum_of_Signatures C hs CC App_Sig Abs_Sig.
 
+Lemma is_omega_cocont_Lam (hE : has_exponentials (Products_functor_precat C C CP hs)) (LC : Lims C) :
+  is_omega_cocont (Signature_Functor _ _ Lam_Sig).
+Proof.
+apply is_omega_cocont_sum_of_functors.
+- apply (Products_functor_precat _ _ CP).
+- apply functor_category_has_homsets.
+- apply functor_category_has_homsets.
+- apply (is_omega_cocont_App_H hE).
+- apply (is_omega_cocont_Abs_H LC).
+Defined.
+
 Definition LamE_Sig: Signature C hs :=
   Sum_of_Signatures C hs CC Lam_Sig Flat_Sig.
-
 
 End Lambda.

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -85,14 +85,14 @@ Variable H : Signature C hs.
 Let θ := theta H.
 
 Definition Const_plus_H (X : EndC) : functor EndC EndC
-  := coproduct_functor _ _ CPEndC
-                       (constant_functor _ _ X)
-                       H.
-
+  (* := coproduct_functor _ _ CPEndC (constant_functor _ _ X) H. *)
+  := sum_of_functors CPEndC (constant_functor _ _ X) H.
 
 Definition Id_H :  functor [C, C, hs] [C, C, hs]
  := Const_plus_H (functor_identity _ : EndC).
 
+(* Opaque Const_plus_H. *)
+(* Opaque Id_H. *)
 
 Let Alg : precategory := FunctorAlg Id_H hsEndC.
 
@@ -147,7 +147,8 @@ Proof.
   - rewrite functor_id.
     do 2 rewrite id_right.
     apply pathsinv0, id_left.
-Qed.
+Admitted.
+(* Qed. *)
 
 Definition aux_iso_1 (Z : Ptd)
   : EndEndC
@@ -191,7 +192,8 @@ Proof.
     do 2 rewrite id_right.
     apply pathsinv0.
     apply id_left.
-Qed.
+Admitted.
+(* Qed. *)
 
 Local Definition aux_iso_1_inv (Z: Ptd)
   : EndEndC
@@ -302,52 +304,53 @@ Lemma bracket_Thm15_ok_part1 (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg  InitAlg ⟧):
  # U f
  =
  # (pr1 (ℓ (U Z))) (η InitAlg) ;; ⦃f⦄.
-Proof.
-  apply nat_trans_eq; try (exact hs).
-  intro c.
-  assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))).
-  assert (h_eq' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
-               (((aux_iso_1_inv Z):(_⟶_)) _);; m) h_eq);
-  clear h_eq.
-  simpl in h_eq'.
-  assert (h_eq1' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
-               (CoproductIn1 EndC (CPEndC _ _));; m) h_eq');
-  clear h_eq'.
-  assert (h_eq1'_inst := nat_trans_eq_pointwise h_eq1' c);
-  clear h_eq1'.
-(* match goal right in the beginning in contrast with earlier approach - suggestion by Benedikt *)
-  match goal with |[ H1 : _  = ?f |- _ = _   ] =>
-         pathvia f end.
+Admitted.
+(* Proof. *)
+(*   apply nat_trans_eq; try (exact hs). *)
+(*   intro c. *)
+(*   assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))). *)
+(*   assert (h_eq' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ => *)
+(*                (((aux_iso_1_inv Z):(_⟶_)) _);; m) h_eq); *)
+(*   clear h_eq. *)
+(*   simpl in h_eq'. *)
+(*   assert (h_eq1' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ => *)
+(*                (CoproductIn1 EndC (CPEndC _ _));; m) h_eq'); *)
+(*   clear h_eq'. *)
+(*   assert (h_eq1'_inst := nat_trans_eq_pointwise h_eq1' c); *)
+(*   clear h_eq1'. *)
+(* (* match goal right in the beginning in contrast with earlier approach - suggestion by Benedikt *) *)
+(*   match goal with |[ H1 : _  = ?f |- _ = _   ] => *)
+(*          pathvia f end. *)
 
-  - clear h_eq1'_inst.
-    unfold coproduct_nat_trans_data; simpl.
-    unfold coproduct_nat_trans_in1_data ; simpl.
-    repeat rewrite <- assoc .
-    apply CoproductIn1Commutes_right_in_ctx_dir.
-    unfold λ_functor; simpl.
-    rewrite id_left.
-    apply CoproductIn1Commutes_right_in_ctx_dir.
-    unfold ρ_functor; simpl.
-    rewrite id_left.
-    apply CoproductIn1Commutes_right_in_ctx_dir.
-    rewrite (id_left EndC).
-    rewrite id_left.
-    apply CoproductIn1Commutes_right_in_ctx_dir.
-    rewrite (id_left EndC).
-    apply CoproductIn1Commutes_right_dir.
-    apply idpath.
-  - rewrite <- h_eq1'_inst.
-    clear h_eq1'_inst.
-    apply CoproductIn1Commutes_left_in_ctx_dir.
-    unfold λ_functor, nat_trans_id; simpl.
-    rewrite id_left.
-    repeat rewrite (id_left EndEndC).
-    repeat rewrite (id_left EndC).
-    unfold functor_fix_snd_arg_ob.
-    repeat rewrite assoc.
-(*    apply maponpaths. *)
-    apply idpath.
-Qed.
+(*   - clear h_eq1'_inst. *)
+(*     unfold coproduct_nat_trans_data; simpl. *)
+(*     unfold coproduct_nat_trans_in1_data ; simpl. *)
+(*     repeat rewrite <- assoc . *)
+(*     apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*     unfold λ_functor; simpl. *)
+(*     rewrite id_left. *)
+(*     apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*     unfold ρ_functor; simpl. *)
+(*     rewrite id_left. *)
+(*     apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*     rewrite (id_left EndC). *)
+(*     rewrite id_left. *)
+(*     apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*     rewrite (id_left EndC). *)
+(*     apply CoproductIn1Commutes_right_dir. *)
+(*     apply idpath. *)
+(*   - rewrite <- h_eq1'_inst. *)
+(*     clear h_eq1'_inst. *)
+(*     apply CoproductIn1Commutes_left_in_ctx_dir. *)
+(*     unfold λ_functor, nat_trans_id; simpl. *)
+(*     rewrite id_left. *)
+(*     repeat rewrite (id_left EndEndC). *)
+(*     repeat rewrite (id_left EndC). *)
+(*     unfold functor_fix_snd_arg_ob. *)
+(*     repeat rewrite assoc. *)
+(* (*    apply maponpaths. *) *)
+(*     apply idpath. *)
+(* Qed. *)
 
 (* produce some output to keep TRAVIS running *)
 Check bracket_Thm15_ok_part1.
@@ -356,61 +359,62 @@ Lemma bracket_Thm15_ok_part2 (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg  InitAlg ⟧):
  (theta H) ((alg_carrier _  InitAlg) ⊗ Z) ;;  # H ⦃f⦄ ;; τ InitAlg
   =
    # (pr1 (ℓ (U Z))) (τ InitAlg) ;; ⦃f⦄.
-Proof.
-  apply nat_trans_eq; try (exact hs).
-  intro c.
-  assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))).
-  assert (h_eq' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
-                  (((aux_iso_1_inv Z):(_⟶_)) _);; m) h_eq);
-  clear h_eq.
- (*        simpl in h_eq'. (* until here same as in previous lemma *) *)
+Admitted.
+(* Proof. *)
+(*   apply nat_trans_eq; try (exact hs). *)
+(*   intro c. *)
+(*   assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))). *)
+(*   assert (h_eq' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ => *)
+(*                   (((aux_iso_1_inv Z):(_⟶_)) _);; m) h_eq); *)
+(*   clear h_eq. *)
+(*  (*        simpl in h_eq'. (* until here same as in previous lemma *) *) *)
 
-  assert (h_eq2' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
-                (CoproductIn2 EndC (CPEndC _ _));; m) h_eq').
-  clear h_eq'.
-  assert (h_eq2'_inst := nat_trans_eq_pointwise h_eq2' c).
-  clear h_eq2'.
-  match goal with |[ H1 : _  = ?f |- _ = _   ] =>
-                   pathvia (f) end.
-  - clear h_eq2'_inst.
-    apply CoproductIn2Commutes_right_in_ctx_dir.
-    unfold aux_iso_1; simpl.
-    rewrite id_right.
-    rewrite id_left.
-    do 3 rewrite <- assoc.
-    apply CoproductIn2Commutes_right_in_ctx_dir.
-    unfold nat_trans_id; simpl. rewrite id_left.
-    apply CoproductIn2Commutes_right_in_ctx_dir.
-    unfold nat_trans_fix_snd_arg_data.
-    apply CoproductIn2Commutes_right_in_double_ctx_dir.
-    rewrite <- assoc.
-    apply maponpaths.
-    eapply pathscomp0. Focus 2. apply assoc.
-    apply maponpaths.
-    apply pathsinv0.
-    apply CoproductIn2Commutes.
+(*   assert (h_eq2' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ => *)
+(*                 (CoproductIn2 EndC (CPEndC _ _));; m) h_eq'). *)
+(*   clear h_eq'. *)
+(*   assert (h_eq2'_inst := nat_trans_eq_pointwise h_eq2' c). *)
+(*   clear h_eq2'. *)
+(*   match goal with |[ H1 : _  = ?f |- _ = _   ] => *)
+(*                    pathvia (f) end. *)
+(*   - clear h_eq2'_inst. *)
+(*     apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*     unfold aux_iso_1; simpl. *)
+(*     rewrite id_right. *)
+(*     rewrite id_left. *)
+(*     do 3 rewrite <- assoc. *)
+(*     apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*     unfold nat_trans_id; simpl. rewrite id_left. *)
+(*     apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*     unfold nat_trans_fix_snd_arg_data. *)
+(*     apply CoproductIn2Commutes_right_in_double_ctx_dir. *)
+(*     rewrite <- assoc. *)
+(*     apply maponpaths. *)
+(*     eapply pathscomp0. Focus 2. apply assoc. *)
+(*     apply maponpaths. *)
+(*     apply pathsinv0. *)
+(*     apply CoproductIn2Commutes. *)
 
-(* alternative with slightly less precise control:
-           do 4 rewrite <- assoc.
-           apply CoproductIn2Commutes_right_in_ctx_dir.
-           rewrite id_left.
-           apply CoproductIn2Commutes_right_in_ctx_dir.
-           apply CoproductIn2Commutes_right_in_ctx_dir.
-           unfold nat_trans_fix_snd_arg_data.
-           rewrite id_left.
-           apply CoproductIn2Commutes_right_in_double_ctx_dir.
-           do 2 rewrite <- assoc.
-           apply maponpaths.
-           apply maponpaths.
-           apply pathsinv0.
-           apply CoproductIn2Commutes.
-*)
+(* (* alternative with slightly less precise control: *)
+(*            do 4 rewrite <- assoc. *)
+(*            apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*            rewrite id_left. *)
+(*            apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*            apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*            unfold nat_trans_fix_snd_arg_data. *)
+(*            rewrite id_left. *)
+(*            apply CoproductIn2Commutes_right_in_double_ctx_dir. *)
+(*            do 2 rewrite <- assoc. *)
+(*            apply maponpaths. *)
+(*            apply maponpaths. *)
+(*            apply pathsinv0. *)
+(*            apply CoproductIn2Commutes. *)
+(* *) *)
 
-  - rewrite <- h_eq2'_inst. clear h_eq2'_inst.
-    apply CoproductIn2Commutes_left_in_ctx_dir.
-    repeat rewrite id_left.
-    apply assoc.
-Qed.
+(*   - rewrite <- h_eq2'_inst. clear h_eq2'_inst. *)
+(*     apply CoproductIn2Commutes_left_in_ctx_dir. *)
+(*     repeat rewrite id_left. *)
+(*     apply assoc. *)
+(* Qed. *)
 
 (* produce some output to keep TRAVIS running *)
 Check bracket_Thm15_ok_part2.
@@ -422,15 +426,16 @@ Proof.
   split.
   + exact (bracket_Thm15_ok_part1 Z f).
   + exact (bracket_Thm15_ok_part2 Z f).
-Qed.
+Admitted.
+(* Qed. *)
 
 Lemma bracket_Thm15_ok_cor (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧):
  bracket_property f (bracket_Thm15 Z f).
 Proof.
   apply whole_from_parts.
   apply bracket_Thm15_ok.
-Qed.
-
+Admitted.
+(* Qed. *)
 
 Local Lemma foo' (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
  ∀ t : Σ h : [C, C, hs] ⟦ functor_composite (U Z) (pr1  InitAlg),
@@ -444,59 +449,60 @@ Local Lemma foo' (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
               pr1 InitAlg ⟧,
        bracket_property f h)
       ⦃f⦄ (bracket_Thm15_ok_cor Z f).
-Proof.
-  intros [h' h'_eq].
-  apply subtypeEquality.
-  - intro.
-    unfold bracket_property.
-    apply isaset_nat_trans. exact hs.
-  - simpl.
-    apply parts_from_whole in h'_eq.
-(*    destruct h'_eq as [h'_eq1 h'_eq2]. *)
-    unfold bracket_Thm15.
-    apply path_to_ctr.
-    apply nat_trans_eq; try (exact hs).
-    intro c; simpl.
-    unfold coproduct_nat_trans_data.
-    repeat rewrite (id_left EndC).
-    rewrite id_right.
-    repeat rewrite <- assoc.
-    eapply pathscomp0. Focus 2. eapply pathsinv0. apply postcompWithCoproductArrow.
-    apply CoproductArrowUnique.
-    + destruct h'_eq as [h'_eq1 _ ]. (*clear h'_eq2.*)
-      simpl.
-      rewrite (id_left C).
-      assert (h'_eq1_inst := nat_trans_eq_pointwise h'_eq1 c);
-        clear h'_eq1.
-      simpl in h'_eq1_inst.
-      unfold coproduct_nat_trans_in1_data in h'_eq1_inst; simpl in h'_eq1_inst.
-      rewrite <- assoc in h'_eq1_inst.
-      eapply pathscomp0.
-      eapply pathsinv0.
-      exact h'_eq1_inst.
-      clear h'_eq1_inst.
-      apply CoproductIn1Commutes_right_in_ctx_dir.
-      apply CoproductIn1Commutes_right_in_ctx_dir.
-      apply CoproductIn1Commutes_right_dir.
-        apply idpath.
-    + destruct h'_eq as [_ h'_eq2]. (*clear h'_eq2.*)
-      assert (h'_eq2_inst := nat_trans_eq_pointwise h'_eq2 c);
-        clear h'_eq2.
-      simpl in h'_eq2_inst.
-      unfold coproduct_nat_trans_in2_data in h'_eq2_inst; simpl in h'_eq2_inst.
-      apply pathsinv0 in h'_eq2_inst.
-      rewrite <- assoc in h'_eq2_inst.
-      eapply pathscomp0. exact h'_eq2_inst. clear h'_eq2_inst.
-      apply CoproductIn2Commutes_right_in_ctx_dir.
-      apply CoproductIn2Commutes_right_in_double_ctx_dir.
-      unfold nat_trans_fix_snd_arg_data; simpl.
-      do 2 rewrite <- assoc.
-      apply maponpaths.
-      rewrite <- assoc.
-      apply maponpaths.
-      apply pathsinv0.
-      apply CoproductIn2Commutes.
-Qed.
+Admitted.
+(* Proof. *)
+(*   intros [h' h'_eq]. *)
+(*   apply subtypeEquality. *)
+(*   - intro. *)
+(*     unfold bracket_property. *)
+(*     apply isaset_nat_trans. exact hs. *)
+(*   - simpl. *)
+(*     apply parts_from_whole in h'_eq. *)
+(* (*    destruct h'_eq as [h'_eq1 h'_eq2]. *) *)
+(*     unfold bracket_Thm15. *)
+(*     apply path_to_ctr. *)
+(*     apply nat_trans_eq; try (exact hs). *)
+(*     intro c; simpl. *)
+(*     unfold coproduct_nat_trans_data. *)
+(*     repeat rewrite (id_left EndC). *)
+(*     rewrite id_right. *)
+(*     repeat rewrite <- assoc. *)
+(*     eapply pathscomp0. Focus 2. eapply pathsinv0. apply postcompWithCoproductArrow. *)
+(*     apply CoproductArrowUnique. *)
+(*     + destruct h'_eq as [h'_eq1 _ ]. (*clear h'_eq2.*) *)
+(*       simpl. *)
+(*       rewrite (id_left C). *)
+(*       assert (h'_eq1_inst := nat_trans_eq_pointwise h'_eq1 c); *)
+(*         clear h'_eq1. *)
+(*       simpl in h'_eq1_inst. *)
+(*       unfold coproduct_nat_trans_in1_data in h'_eq1_inst; simpl in h'_eq1_inst. *)
+(*       rewrite <- assoc in h'_eq1_inst. *)
+(*       eapply pathscomp0. *)
+(*       eapply pathsinv0. *)
+(*       exact h'_eq1_inst. *)
+(*       clear h'_eq1_inst. *)
+(*       apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*       apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*       apply CoproductIn1Commutes_right_dir. *)
+(*         apply idpath. *)
+(*     + destruct h'_eq as [_ h'_eq2]. (*clear h'_eq2.*) *)
+(*       assert (h'_eq2_inst := nat_trans_eq_pointwise h'_eq2 c); *)
+(*         clear h'_eq2. *)
+(*       simpl in h'_eq2_inst. *)
+(*       unfold coproduct_nat_trans_in2_data in h'_eq2_inst; simpl in h'_eq2_inst. *)
+(*       apply pathsinv0 in h'_eq2_inst. *)
+(*       rewrite <- assoc in h'_eq2_inst. *)
+(*       eapply pathscomp0. exact h'_eq2_inst. clear h'_eq2_inst. *)
+(*       apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*       apply CoproductIn2Commutes_right_in_double_ctx_dir. *)
+(*       unfold nat_trans_fix_snd_arg_data; simpl. *)
+(*       do 2 rewrite <- assoc. *)
+(*       apply maponpaths. *)
+(*       rewrite <- assoc. *)
+(*       apply maponpaths. *)
+(*       apply pathsinv0. *)
+(*       apply CoproductIn2Commutes. *)
+(* Qed. *)
 
 Definition bracket_for_InitAlg : bracket InitAlg.
 Proof.
@@ -603,7 +609,8 @@ Proof.
     rewrite <- (nat_trans_ax α).
     rewrite functor_id.
     apply id_left.
-Qed.
+Admitted.
+(* Qed. *)
 
 Local Definition iso2' (Z : Ptd) : EndEndC ⟦
   CoproductObject EndEndC
@@ -660,209 +667,210 @@ Lemma ishssMor_InitAlg (T' : hss CP H) :
   @ishssMor C hs CP H
         InitHSS T'
            (InitialArrow IA (pr1 T') : @algebra_mor EndC Id_H InitAlg T' ).
-Proof.
-  unfold ishssMor.
-  unfold isbracketMor.
-  intros Z f.
-  set (β0 := InitialArrow IA (pr1 T')).
-  match goal with | [|- _ ;; ?b = _ ] => set (β := b) end.
-  set ( rhohat := CoproductArrow EndC  (CPEndC _ _ )  β (tau_from_alg T')
-                  :  pr1 Ghat T' --> T').
-  set (X:= SpecializedGMIt Z _ Ghat rhohat (thetahat Z f)).
-  pathvia (pr1 (pr1 X)).
-  - set (TT:= fusion_law _ _ _ IA _ hsEndC (pr1 InitAlg) T' _ (KanExt Z)).
-    set (Psi := ψ_from_comps _ (Id_H) _ hsEndC _ (ℓ (U Z)) (Const_plus_H (U Z)) (ρ_Thm15 Z f)
-                             (aux_iso_1 Z ;; θ'_Thm15 Z ;; aux_iso_2_inv Z) ).
-    set (T2 := TT Psi).
-    set (T3 := T2 (ℓ (U Z)) (KanExt Z)).
-    set (Psi' := ψ_from_comps _ (Id_H) _ hsEndC _ (ℓ (U Z)) (Ghat) (rhohat)
-                             (iso1' Z ;; thetahat_0 Z f ;; iso2' Z) ).
-    set (T4 := T3 Psi').
-    set (Φ := (Phi_fusion Z T' β)).
-    set (T5 := T4 Φ).
-    pathvia (Φ _ (fbracket InitHSS f)).
-    + apply idpath.
-    + eapply pathscomp0. Focus 2. apply T5.
-      (* hypothesis of fusion law *)
-      apply funextsec. intro.
-      simpl.
-      unfold compose. simpl.
-      apply nat_trans_eq. assumption.
-      simpl.
-      intro c.
-      rewrite id_right.
-      rewrite id_right.
-      (* should be decomposed into two diagrams *)
-      apply CoproductArrow_eq_cor.
-      * (* first diagram *)
-        clear TT T2 T3 T4 T5.
-        do 5 rewrite <- assoc.
-        apply CoproductIn1Commutes_left_in_ctx_dir.
-        apply CoproductIn1Commutes_right_in_ctx_dir.
-        simpl.
-        rewrite id_left.
-        apply CoproductIn1Commutes_left_in_ctx_dir.
-        apply CoproductIn1Commutes_right_in_ctx_dir.
-        simpl.
-        rewrite id_left.
-        apply CoproductIn1Commutes_left_in_ctx_dir.
-        simpl.
-        rewrite id_left.
-        apply CoproductIn1Commutes_left_in_ctx_dir.
-        rewrite <- assoc.
-        apply maponpaths.
-        apply CoproductIn1Commutes_right_in_ctx_dir.
-        simpl.
-        rewrite id_left.
-        apply CoproductIn1Commutes_right_dir.
-        apply idpath.
-      * (* a bit out of order what follows *)
-        apply cancel_postcomposition.
-        apply idpath.
-      * (* second diagram *)
-        clear TT T2 T3 T4 T5.
-        do 5 rewrite <- assoc.
-        apply CoproductIn2Commutes_left_in_ctx_dir.
-        apply CoproductIn2Commutes_right_in_ctx_dir.
-        rewrite (id_left EndC).
-        apply CoproductIn2Commutes_left_in_ctx_dir.
-        apply CoproductIn2Commutes_right_in_ctx_dir.
-        simpl.
-        unfold nat_trans_fix_snd_arg_data.
-        repeat rewrite <- assoc.
-        apply maponpaths.
-        apply CoproductIn2Commutes_left_in_ctx_dir.
-        apply CoproductIn2Commutes_right_in_ctx_dir.
-        simpl.
-        assert (H_nat_inst := functor_comp H _ _ _ t β).
-        assert (H_nat_inst_c := nat_trans_eq_pointwise H_nat_inst c); clear H_nat_inst.
-        {
-          match goal with |[ H1 : _  = ?f |- _ = _;; ?g ;; ?h  ] =>
-             pathvia (f;;g;;h) end.
-          + clear H_nat_inst_c.
-            simpl.
-            repeat rewrite <- assoc.
-            apply maponpaths.
-            apply CoproductIn2Commutes_left_in_ctx_dir.
-            simpl.
-            unfold coproduct_nat_trans_in2_data, coproduct_nat_trans_data.
-            assert (Hyp := τ_part_of_alg_mor _ hs CP _ _ _ (InitialArrow IA (pr1 T'))).
-            assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp.
-            simpl in Hyp_c.
-            eapply pathscomp0. eapply pathsinv0. exact Hyp_c.
-            clear Hyp_c.
-            apply maponpaths.
-            apply pathsinv0.
-            apply CoproductIn2Commutes.
-          + rewrite <- H_nat_inst_c.
-            apply idpath.
-        }
-  - apply pathsinv0.
-    apply path_to_ctr.
-    (* now a lot of serious verification work to be done *)
-    apply nat_trans_eq; try (exact hs).
-    intro c.
-    simpl.
-    rewrite id_right.
-    (* look at type:
-       match goal with | [ |- ?l = _ ] => let ty:= (type of l) in idtac ty end. *)
-    apply CoproductArrow_eq_cor.
-    + repeat rewrite <- assoc.
-      apply CoproductIn1Commutes_right_in_ctx_dir.
-      simpl.
-      unfold coproduct_nat_trans_in1_data,
-             coproduct_nat_trans_in2_data,
-             coproduct_nat_trans_data.
-      rewrite id_left.
-      apply CoproductIn1Commutes_right_in_ctx_dir.
-      simpl.
-      repeat rewrite <- assoc.
-      eapply pathscomp0. Focus 2. apply maponpaths. apply CoproductIn1Commutes_right_in_ctx_dir.
-        rewrite id_left. apply CoproductIn1Commutes_right_dir. apply idpath.
-      do 2 rewrite assoc.
-      eapply pathscomp0.
-        apply cancel_postcomposition.
-        assert (ptd_mor_commutes_inst := ptd_mor_commutes _ (ptd_from_alg_mor _ hs CP H β0) ((pr1 Z) c)).
-        apply ptd_mor_commutes_inst.
-      assert (fbracket_η_inst := fbracket_η T' (f;; ptd_from_alg_mor _ hs CP H β0)).
-      assert (fbracket_η_inst_c := nat_trans_eq_pointwise fbracket_η_inst c); clear fbracket_η_inst.
-      apply (!fbracket_η_inst_c).
-    + (* now the difficult case *)
-      repeat rewrite <- assoc.
-      apply CoproductIn2Commutes_right_in_ctx_dir.
-      simpl.
-      unfold coproduct_nat_trans_in1_data, coproduct_nat_trans_in2_data, coproduct_nat_trans_data.
-      rewrite id_left.
-      apply CoproductIn2Commutes_right_in_ctx_dir.
-      unfold nat_trans_fix_snd_arg_data.
-      simpl.
-      unfold coproduct_nat_trans_in2_data.
-      repeat rewrite <- assoc.
-      eapply pathscomp0. Focus 2.
-        apply maponpaths.
-        apply CoproductIn2Commutes_right_in_ctx_dir.
-        rewrite <- assoc.
-        apply maponpaths.
-        apply CoproductIn2Commutes_right_dir.
-        apply idpath.
-      do 2 rewrite assoc.
-      eapply pathscomp0.
-        apply cancel_postcomposition.
-        eapply pathsinv0.
-        assert (τ_part_of_alg_mor_inst := τ_part_of_alg_mor _ hs CP H _ _ β0).
-        assert (τ_part_of_alg_mor_inst_Zc :=
-                  nat_trans_eq_pointwise τ_part_of_alg_mor_inst ((pr1 Z) c));
-          clear τ_part_of_alg_mor_inst.
-        apply τ_part_of_alg_mor_inst_Zc.
-      simpl.
-      unfold coproduct_nat_trans_in2_data.
-      repeat rewrite <- assoc.
-      eapply pathscomp0.
-        apply maponpaths.
-        rewrite assoc.
-        eapply pathsinv0.
-        assert (fbracket_τ_inst := fbracket_τ T' (f;; ptd_from_alg_mor _ hs CP H β0)).
-        assert (fbracket_τ_inst_c := nat_trans_eq_pointwise fbracket_τ_inst c); clear fbracket_τ_inst.
-        apply fbracket_τ_inst_c.
-      simpl.
-      unfold coproduct_nat_trans_in2_data.
-      repeat rewrite assoc.
-      apply cancel_postcomposition.
-      apply cancel_postcomposition.
-      assert (Hyp:
-                 ((# (pr1 (ℓ(U Z))) (# H β));;
-                 (theta H) ((alg_carrier _  T') ⊗ Z);;
-                 # H (fbracket T' (f;; ptd_from_alg_mor C hs CP H β0))
-                 =
-                 θ (tpair (λ _ : functor C C, ptd_obj C) (alg_carrier _ (InitialObject IA)) Z) ;;
-                 # H (# (pr1 (ℓ(U Z))) β ;;
-                 fbracket T' (f;; ptd_from_alg_mor C hs CP H β0)))).
+Admitted.
+(* Proof. *)
+(*   unfold ishssMor. *)
+(*   unfold isbracketMor. *)
+(*   intros Z f. *)
+(*   set (β0 := InitialArrow IA (pr1 T')). *)
+(*   match goal with | [|- _ ;; ?b = _ ] => set (β := b) end. *)
+(*   set ( rhohat := CoproductArrow EndC  (CPEndC _ _ )  β (tau_from_alg T') *)
+(*                   :  pr1 Ghat T' --> T'). *)
+(*   set (X:= SpecializedGMIt Z _ Ghat rhohat (thetahat Z f)). *)
+(*   pathvia (pr1 (pr1 X)). *)
+(*   - set (TT:= fusion_law _ _ _ IA _ hsEndC (pr1 InitAlg) T' _ (KanExt Z)). *)
+(*     set (Psi := ψ_from_comps _ (Id_H) _ hsEndC _ (ℓ (U Z)) (Const_plus_H (U Z)) (ρ_Thm15 Z f) *)
+(*                              (aux_iso_1 Z ;; θ'_Thm15 Z ;; aux_iso_2_inv Z) ). *)
+(*     set (T2 := TT Psi). *)
+(*     set (T3 := T2 (ℓ (U Z)) (KanExt Z)). *)
+(*     set (Psi' := ψ_from_comps _ (Id_H) _ hsEndC _ (ℓ (U Z)) (Ghat) (rhohat) *)
+(*                              (iso1' Z ;; thetahat_0 Z f ;; iso2' Z) ). *)
+(*     set (T4 := T3 Psi'). *)
+(*     set (Φ := (Phi_fusion Z T' β)). *)
+(*     set (T5 := T4 Φ). *)
+(*     pathvia (Φ _ (fbracket InitHSS f)). *)
+(*     + apply idpath. *)
+(*     + eapply pathscomp0. Focus 2. apply T5. *)
+(*       (* hypothesis of fusion law *) *)
+(*       apply funextsec. intro. *)
+(*       simpl. *)
+(*       unfold compose. simpl. *)
+(*       apply nat_trans_eq. assumption. *)
+(*       simpl. *)
+(*       intro c. *)
+(*       rewrite id_right. *)
+(*       rewrite id_right. *)
+(*       (* should be decomposed into two diagrams *) *)
+(*       apply CoproductArrow_eq_cor. *)
+(*       * (* first diagram *) *)
+(*         clear TT T2 T3 T4 T5. *)
+(*         do 5 rewrite <- assoc. *)
+(*         apply CoproductIn1Commutes_left_in_ctx_dir. *)
+(*         apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*         simpl. *)
+(*         rewrite id_left. *)
+(*         apply CoproductIn1Commutes_left_in_ctx_dir. *)
+(*         apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*         simpl. *)
+(*         rewrite id_left. *)
+(*         apply CoproductIn1Commutes_left_in_ctx_dir. *)
+(*         simpl. *)
+(*         rewrite id_left. *)
+(*         apply CoproductIn1Commutes_left_in_ctx_dir. *)
+(*         rewrite <- assoc. *)
+(*         apply maponpaths. *)
+(*         apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*         simpl. *)
+(*         rewrite id_left. *)
+(*         apply CoproductIn1Commutes_right_dir. *)
+(*         apply idpath. *)
+(*       * (* a bit out of order what follows *) *)
+(*         apply cancel_postcomposition. *)
+(*         apply idpath. *)
+(*       * (* second diagram *) *)
+(*         clear TT T2 T3 T4 T5. *)
+(*         do 5 rewrite <- assoc. *)
+(*         apply CoproductIn2Commutes_left_in_ctx_dir. *)
+(*         apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*         rewrite (id_left EndC). *)
+(*         apply CoproductIn2Commutes_left_in_ctx_dir. *)
+(*         apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*         simpl. *)
+(*         unfold nat_trans_fix_snd_arg_data. *)
+(*         repeat rewrite <- assoc. *)
+(*         apply maponpaths. *)
+(*         apply CoproductIn2Commutes_left_in_ctx_dir. *)
+(*         apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*         simpl. *)
+(*         assert (H_nat_inst := functor_comp H _ _ _ t β). *)
+(*         assert (H_nat_inst_c := nat_trans_eq_pointwise H_nat_inst c); clear H_nat_inst. *)
+(*         { *)
+(*           match goal with |[ H1 : _  = ?f |- _ = _;; ?g ;; ?h  ] => *)
+(*              pathvia (f;;g;;h) end. *)
+(*           + clear H_nat_inst_c. *)
+(*             simpl. *)
+(*             repeat rewrite <- assoc. *)
+(*             apply maponpaths. *)
+(*             apply CoproductIn2Commutes_left_in_ctx_dir. *)
+(*             simpl. *)
+(*             unfold coproduct_nat_trans_in2_data, coproduct_nat_trans_data. *)
+(*             assert (Hyp := τ_part_of_alg_mor _ hs CP _ _ _ (InitialArrow IA (pr1 T'))). *)
+(*             assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp. *)
+(*             simpl in Hyp_c. *)
+(*             eapply pathscomp0. eapply pathsinv0. exact Hyp_c. *)
+(*             clear Hyp_c. *)
+(*             apply maponpaths. *)
+(*             apply pathsinv0. *)
+(*             apply CoproductIn2Commutes. *)
+(*           + rewrite <- H_nat_inst_c. *)
+(*             apply idpath. *)
+(*         } *)
+(*   - apply pathsinv0. *)
+(*     apply path_to_ctr. *)
+(*     (* now a lot of serious verification work to be done *) *)
+(*     apply nat_trans_eq; try (exact hs). *)
+(*     intro c. *)
+(*     simpl. *)
+(*     rewrite id_right. *)
+(*     (* look at type: *)
+(*        match goal with | [ |- ?l = _ ] => let ty:= (type of l) in idtac ty end. *) *)
+(*     apply CoproductArrow_eq_cor. *)
+(*     + repeat rewrite <- assoc. *)
+(*       apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*       simpl. *)
+(*       unfold coproduct_nat_trans_in1_data, *)
+(*              coproduct_nat_trans_in2_data, *)
+(*              coproduct_nat_trans_data. *)
+(*       rewrite id_left. *)
+(*       apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*       simpl. *)
+(*       repeat rewrite <- assoc. *)
+(*       eapply pathscomp0. Focus 2. apply maponpaths. apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*         rewrite id_left. apply CoproductIn1Commutes_right_dir. apply idpath. *)
+(*       do 2 rewrite assoc. *)
+(*       eapply pathscomp0. *)
+(*         apply cancel_postcomposition. *)
+(*         assert (ptd_mor_commutes_inst := ptd_mor_commutes _ (ptd_from_alg_mor _ hs CP H β0) ((pr1 Z) c)). *)
+(*         apply ptd_mor_commutes_inst. *)
+(*       assert (fbracket_η_inst := fbracket_η T' (f;; ptd_from_alg_mor _ hs CP H β0)). *)
+(*       assert (fbracket_η_inst_c := nat_trans_eq_pointwise fbracket_η_inst c); clear fbracket_η_inst. *)
+(*       apply (!fbracket_η_inst_c). *)
+(*     + (* now the difficult case *) *)
+(*       repeat rewrite <- assoc. *)
+(*       apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*       simpl. *)
+(*       unfold coproduct_nat_trans_in1_data, coproduct_nat_trans_in2_data, coproduct_nat_trans_data. *)
+(*       rewrite id_left. *)
+(*       apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*       unfold nat_trans_fix_snd_arg_data. *)
+(*       simpl. *)
+(*       unfold coproduct_nat_trans_in2_data. *)
+(*       repeat rewrite <- assoc. *)
+(*       eapply pathscomp0. Focus 2. *)
+(*         apply maponpaths. *)
+(*         apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*         rewrite <- assoc. *)
+(*         apply maponpaths. *)
+(*         apply CoproductIn2Commutes_right_dir. *)
+(*         apply idpath. *)
+(*       do 2 rewrite assoc. *)
+(*       eapply pathscomp0. *)
+(*         apply cancel_postcomposition. *)
+(*         eapply pathsinv0. *)
+(*         assert (τ_part_of_alg_mor_inst := τ_part_of_alg_mor _ hs CP H _ _ β0). *)
+(*         assert (τ_part_of_alg_mor_inst_Zc := *)
+(*                   nat_trans_eq_pointwise τ_part_of_alg_mor_inst ((pr1 Z) c)); *)
+(*           clear τ_part_of_alg_mor_inst. *)
+(*         apply τ_part_of_alg_mor_inst_Zc. *)
+(*       simpl. *)
+(*       unfold coproduct_nat_trans_in2_data. *)
+(*       repeat rewrite <- assoc. *)
+(*       eapply pathscomp0. *)
+(*         apply maponpaths. *)
+(*         rewrite assoc. *)
+(*         eapply pathsinv0. *)
+(*         assert (fbracket_τ_inst := fbracket_τ T' (f;; ptd_from_alg_mor _ hs CP H β0)). *)
+(*         assert (fbracket_τ_inst_c := nat_trans_eq_pointwise fbracket_τ_inst c); clear fbracket_τ_inst. *)
+(*         apply fbracket_τ_inst_c. *)
+(*       simpl. *)
+(*       unfold coproduct_nat_trans_in2_data. *)
+(*       repeat rewrite assoc. *)
+(*       apply cancel_postcomposition. *)
+(*       apply cancel_postcomposition. *)
+(*       assert (Hyp: *)
+(*                  ((# (pr1 (ℓ(U Z))) (# H β));; *)
+(*                  (theta H) ((alg_carrier _  T') ⊗ Z);; *)
+(*                  # H (fbracket T' (f;; ptd_from_alg_mor C hs CP H β0)) *)
+(*                  = *)
+(*                  θ (tpair (λ _ : functor C C, ptd_obj C) (alg_carrier _ (InitialObject IA)) Z) ;; *)
+(*                  # H (# (pr1 (ℓ(U Z))) β ;; *)
+(*                  fbracket T' (f;; ptd_from_alg_mor C hs CP H β0)))). *)
 
-      Focus 2.
-      assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp.
-      exact Hyp_c.
+(*       Focus 2. *)
+(*       assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp. *)
+(*       exact Hyp_c. *)
 
-      clear c. clear X. clear rhohat.
-      rewrite (functor_comp H).
-      rewrite assoc.
-      apply cancel_postcomposition.
-      fold θ.
-      apply nat_trans_eq; try (exact hs).
-      intro c.
-      assert (θ_nat_1_pointwise_inst := θ_nat_1_pointwise _ hs H θ _ _ β Z c).
-      eapply pathscomp0 ; [exact θ_nat_1_pointwise_inst | ].
-      clear θ_nat_1_pointwise_inst.
-      simpl.
-      apply maponpaths.
-      assert (Hyp: # H (β ∙∙ nat_trans_id (pr1 Z)) = # H (# (pr1 (ℓ(U Z))) β)).
-      { apply maponpaths.
-        apply nat_trans_eq; try (exact hs).
-        intro c'.
-        simpl.
-        rewrite functor_id.
-        apply id_right. }
-      apply (nat_trans_eq_pointwise Hyp c).
-Qed.
+(*       clear c. clear X. clear rhohat. *)
+(*       rewrite (functor_comp H). *)
+(*       rewrite assoc. *)
+(*       apply cancel_postcomposition. *)
+(*       fold θ. *)
+(*       apply nat_trans_eq; try (exact hs). *)
+(*       intro c. *)
+(*       assert (θ_nat_1_pointwise_inst := θ_nat_1_pointwise _ hs H θ _ _ β Z c). *)
+(*       eapply pathscomp0 ; [exact θ_nat_1_pointwise_inst | ]. *)
+(*       clear θ_nat_1_pointwise_inst. *)
+(*       simpl. *)
+(*       apply maponpaths. *)
+(*       assert (Hyp: # H (β ∙∙ nat_trans_id (pr1 Z)) = # H (# (pr1 (ℓ(U Z))) β)). *)
+(*       { apply maponpaths. *)
+(*         apply nat_trans_eq; try (exact hs). *)
+(*         intro c'. *)
+(*         simpl. *)
+(*         rewrite functor_id. *)
+(*         apply id_right. } *)
+(*       apply (nat_trans_eq_pointwise Hyp c). *)
+(* Qed. *)
 
 Definition hss_InitMor : ∀ T' : hss CP H, hssMor InitHSS T'.
 Proof.
@@ -877,7 +885,8 @@ Proof.
   intro t.
   apply (invmap (hssMor_eq1 _ _ _ _ _ _ _ _ )).
   apply (@InitialArrowUnique _ IA (pr1 T') (pr1 t)).
-Qed.
+Admitted.
+(* Qed. *)
 
 Lemma isInitial_InitHSS : isInitial (hss_precategory CP H) InitHSS.
 Proof.

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -91,9 +91,6 @@ Definition Const_plus_H (X : EndC) : functor EndC EndC
 Definition Id_H :  functor [C, C, hs] [C, C, hs]
  := Const_plus_H (functor_identity _ : EndC).
 
-(* Opaque Const_plus_H. *)
-(* Opaque Id_H. *)
-
 Let Alg : precategory := FunctorAlg Id_H hsEndC.
 
 
@@ -147,8 +144,7 @@ Proof.
   - rewrite functor_id.
     do 2 rewrite id_right.
     apply pathsinv0, id_left.
-Admitted.
-(* Qed. *)
+Qed.
 
 Definition aux_iso_1 (Z : Ptd)
   : EndEndC
@@ -192,8 +188,7 @@ Proof.
     do 2 rewrite id_right.
     apply pathsinv0.
     apply id_left.
-Admitted.
-(* Qed. *)
+Qed.
 
 Local Definition aux_iso_1_inv (Z: Ptd)
   : EndEndC
@@ -304,53 +299,52 @@ Lemma bracket_Thm15_ok_part1 (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg  InitAlg ⟧):
  # U f
  =
  # (pr1 (ℓ (U Z))) (η InitAlg) ;; ⦃f⦄.
-Admitted.
-(* Proof. *)
-(*   apply nat_trans_eq; try (exact hs). *)
-(*   intro c. *)
-(*   assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))). *)
-(*   assert (h_eq' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ => *)
-(*                (((aux_iso_1_inv Z):(_⟶_)) _);; m) h_eq); *)
-(*   clear h_eq. *)
-(*   simpl in h_eq'. *)
-(*   assert (h_eq1' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ => *)
-(*                (CoproductIn1 EndC (CPEndC _ _));; m) h_eq'); *)
-(*   clear h_eq'. *)
-(*   assert (h_eq1'_inst := nat_trans_eq_pointwise h_eq1' c); *)
-(*   clear h_eq1'. *)
-(* (* match goal right in the beginning in contrast with earlier approach - suggestion by Benedikt *) *)
-(*   match goal with |[ H1 : _  = ?f |- _ = _   ] => *)
-(*          pathvia f end. *)
+Proof.
+  apply nat_trans_eq; try (exact hs).
+  intro c.
+  assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))).
+  assert (h_eq' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
+               (((aux_iso_1_inv Z):(_⟶_)) _);; m) h_eq);
+  clear h_eq.
+  simpl in h_eq'.
+  assert (h_eq1' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
+               (CoproductIn1 EndC (CPEndC _ _));; m) h_eq');
+  clear h_eq'.
+  assert (h_eq1'_inst := nat_trans_eq_pointwise h_eq1' c);
+  clear h_eq1'.
+(* match goal right in the beginning in contrast with earlier approach - suggestion by Benedikt *)
+  match goal with |[ H1 : _  = ?f |- _ = _   ] =>
+         pathvia f end.
 
-(*   - clear h_eq1'_inst. *)
-(*     unfold coproduct_nat_trans_data; simpl. *)
-(*     unfold coproduct_nat_trans_in1_data ; simpl. *)
-(*     repeat rewrite <- assoc . *)
-(*     apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*     unfold λ_functor; simpl. *)
-(*     rewrite id_left. *)
-(*     apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*     unfold ρ_functor; simpl. *)
-(*     rewrite id_left. *)
-(*     apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*     rewrite (id_left EndC). *)
-(*     rewrite id_left. *)
-(*     apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*     rewrite (id_left EndC). *)
-(*     apply CoproductIn1Commutes_right_dir. *)
-(*     apply idpath. *)
-(*   - rewrite <- h_eq1'_inst. *)
-(*     clear h_eq1'_inst. *)
-(*     apply CoproductIn1Commutes_left_in_ctx_dir. *)
-(*     unfold λ_functor, nat_trans_id; simpl. *)
-(*     rewrite id_left. *)
-(*     repeat rewrite (id_left EndEndC). *)
-(*     repeat rewrite (id_left EndC). *)
-(*     unfold functor_fix_snd_arg_ob. *)
-(*     repeat rewrite assoc. *)
-(* (*    apply maponpaths. *) *)
-(*     apply idpath. *)
-(* Qed. *)
+  - clear h_eq1'_inst.
+    unfold coproduct_nat_trans_data; simpl.
+    unfold coproduct_nat_trans_in1_data ; simpl.
+    repeat rewrite <- assoc .
+    apply CoproductIn1Commutes_right_in_ctx_dir.
+    unfold λ_functor; simpl.
+    rewrite id_left.
+    apply CoproductIn1Commutes_right_in_ctx_dir.
+    unfold ρ_functor; simpl.
+    rewrite id_left.
+    apply CoproductIn1Commutes_right_in_ctx_dir.
+    rewrite (id_left EndC).
+    rewrite id_left.
+    apply CoproductIn1Commutes_right_in_ctx_dir.
+    rewrite (id_left EndC).
+    apply CoproductIn1Commutes_right_dir.
+    apply idpath.
+  - rewrite <- h_eq1'_inst.
+    clear h_eq1'_inst.
+    apply CoproductIn1Commutes_left_in_ctx_dir.
+    unfold λ_functor, nat_trans_id; simpl.
+    rewrite id_left.
+    repeat rewrite (id_left EndEndC).
+    repeat rewrite (id_left EndC).
+    unfold functor_fix_snd_arg_ob.
+    repeat rewrite assoc.
+(*    apply maponpaths. *)
+    apply idpath.
+Qed.
 
 (* produce some output to keep TRAVIS running *)
 Check bracket_Thm15_ok_part1.
@@ -359,42 +353,41 @@ Lemma bracket_Thm15_ok_part2 (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg  InitAlg ⟧):
  (theta H) ((alg_carrier _  InitAlg) ⊗ Z) ;;  # H ⦃f⦄ ;; τ InitAlg
   =
    # (pr1 (ℓ (U Z))) (τ InitAlg) ;; ⦃f⦄.
-Admitted.
-(* Proof. *)
-(*   apply nat_trans_eq; try (exact hs). *)
-(*   intro c. *)
-(*   assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))). *)
-(*   assert (h_eq' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ => *)
-(*                   (((aux_iso_1_inv Z):(_⟶_)) _);; m) h_eq); *)
-(*   clear h_eq. *)
-(*  (*        simpl in h_eq'. (* until here same as in previous lemma *) *) *)
+Proof.
+  apply nat_trans_eq; try (exact hs).
+  intro c.
+  assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))).
+  assert (h_eq' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
+                  (((aux_iso_1_inv Z):(_⟶_)) _);; m) h_eq);
+  clear h_eq.
+ (*        simpl in h_eq'. (* until here same as in previous lemma *) *)
 
-(*   assert (h_eq2' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ => *)
-(*                 (CoproductIn2 EndC (CPEndC _ _));; m) h_eq'). *)
-(*   clear h_eq'. *)
-(*   assert (h_eq2'_inst := nat_trans_eq_pointwise h_eq2' c). *)
-(*   clear h_eq2'. *)
-(*   match goal with |[ H1 : _  = ?f |- _ = _   ] => *)
-(*                    pathvia (f) end. *)
-(*   - clear h_eq2'_inst. *)
-(*     apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*     unfold aux_iso_1; simpl. *)
-(*     rewrite id_right. *)
-(*     rewrite id_left. *)
-(*     do 3 rewrite <- assoc. *)
-(*     apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*     unfold nat_trans_id; simpl. rewrite id_left. *)
-(*     apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*     unfold nat_trans_fix_snd_arg_data. *)
-(*     apply CoproductIn2Commutes_right_in_double_ctx_dir. *)
-(*     rewrite <- assoc. *)
-(*     apply maponpaths. *)
-(*     eapply pathscomp0. Focus 2. apply assoc. *)
-(*     apply maponpaths. *)
-(*     apply pathsinv0. *)
-(*     apply CoproductIn2Commutes. *)
+  assert (h_eq2' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
+                (CoproductIn2 EndC (CPEndC _ _));; m) h_eq').
+  clear h_eq'.
+  assert (h_eq2'_inst := nat_trans_eq_pointwise h_eq2' c).
+  clear h_eq2'.
+  match goal with |[ H1 : _  = ?f |- _ = _   ] =>
+                   pathvia (f) end.
+  - clear h_eq2'_inst.
+    apply CoproductIn2Commutes_right_in_ctx_dir.
+    unfold aux_iso_1; simpl.
+    rewrite id_right.
+    rewrite id_left.
+    do 3 rewrite <- assoc.
+    apply CoproductIn2Commutes_right_in_ctx_dir.
+    unfold nat_trans_id; simpl. rewrite id_left.
+    apply CoproductIn2Commutes_right_in_ctx_dir.
+    unfold nat_trans_fix_snd_arg_data.
+    apply CoproductIn2Commutes_right_in_double_ctx_dir.
+    rewrite <- assoc.
+    apply maponpaths.
+    eapply pathscomp0. Focus 2. apply assoc.
+    apply maponpaths.
+    apply pathsinv0.
+    apply CoproductIn2Commutes.
 
-(* (* alternative with slightly less precise control: *)
+(* alternative with slightly less precise control: *)
 (*            do 4 rewrite <- assoc. *)
 (*            apply CoproductIn2Commutes_right_in_ctx_dir. *)
 (*            rewrite id_left. *)
@@ -408,13 +401,13 @@ Admitted.
 (*            apply maponpaths. *)
 (*            apply pathsinv0. *)
 (*            apply CoproductIn2Commutes. *)
-(* *) *)
+(* *)
 
-(*   - rewrite <- h_eq2'_inst. clear h_eq2'_inst. *)
-(*     apply CoproductIn2Commutes_left_in_ctx_dir. *)
-(*     repeat rewrite id_left. *)
-(*     apply assoc. *)
-(* Qed. *)
+  - rewrite <- h_eq2'_inst. clear h_eq2'_inst.
+    apply CoproductIn2Commutes_left_in_ctx_dir.
+    repeat rewrite id_left.
+    apply assoc.
+Qed.
 
 (* produce some output to keep TRAVIS running *)
 Check bracket_Thm15_ok_part2.
@@ -426,16 +419,14 @@ Proof.
   split.
   + exact (bracket_Thm15_ok_part1 Z f).
   + exact (bracket_Thm15_ok_part2 Z f).
-Admitted.
-(* Qed. *)
+Qed.
 
 Lemma bracket_Thm15_ok_cor (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧):
  bracket_property f (bracket_Thm15 Z f).
 Proof.
   apply whole_from_parts.
   apply bracket_Thm15_ok.
-Admitted.
-(* Qed. *)
+Qed.
 
 Local Lemma foo' (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
  ∀ t : Σ h : [C, C, hs] ⟦ functor_composite (U Z) (pr1  InitAlg),
@@ -449,60 +440,59 @@ Local Lemma foo' (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
               pr1 InitAlg ⟧,
        bracket_property f h)
       ⦃f⦄ (bracket_Thm15_ok_cor Z f).
-Admitted.
-(* Proof. *)
-(*   intros [h' h'_eq]. *)
-(*   apply subtypeEquality. *)
-(*   - intro. *)
-(*     unfold bracket_property. *)
-(*     apply isaset_nat_trans. exact hs. *)
-(*   - simpl. *)
-(*     apply parts_from_whole in h'_eq. *)
-(* (*    destruct h'_eq as [h'_eq1 h'_eq2]. *) *)
-(*     unfold bracket_Thm15. *)
-(*     apply path_to_ctr. *)
-(*     apply nat_trans_eq; try (exact hs). *)
-(*     intro c; simpl. *)
-(*     unfold coproduct_nat_trans_data. *)
-(*     repeat rewrite (id_left EndC). *)
-(*     rewrite id_right. *)
-(*     repeat rewrite <- assoc. *)
-(*     eapply pathscomp0. Focus 2. eapply pathsinv0. apply postcompWithCoproductArrow. *)
-(*     apply CoproductArrowUnique. *)
-(*     + destruct h'_eq as [h'_eq1 _ ]. (*clear h'_eq2.*) *)
-(*       simpl. *)
-(*       rewrite (id_left C). *)
-(*       assert (h'_eq1_inst := nat_trans_eq_pointwise h'_eq1 c); *)
-(*         clear h'_eq1. *)
-(*       simpl in h'_eq1_inst. *)
-(*       unfold coproduct_nat_trans_in1_data in h'_eq1_inst; simpl in h'_eq1_inst. *)
-(*       rewrite <- assoc in h'_eq1_inst. *)
-(*       eapply pathscomp0. *)
-(*       eapply pathsinv0. *)
-(*       exact h'_eq1_inst. *)
-(*       clear h'_eq1_inst. *)
-(*       apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*       apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*       apply CoproductIn1Commutes_right_dir. *)
-(*         apply idpath. *)
-(*     + destruct h'_eq as [_ h'_eq2]. (*clear h'_eq2.*) *)
-(*       assert (h'_eq2_inst := nat_trans_eq_pointwise h'_eq2 c); *)
-(*         clear h'_eq2. *)
-(*       simpl in h'_eq2_inst. *)
-(*       unfold coproduct_nat_trans_in2_data in h'_eq2_inst; simpl in h'_eq2_inst. *)
-(*       apply pathsinv0 in h'_eq2_inst. *)
-(*       rewrite <- assoc in h'_eq2_inst. *)
-(*       eapply pathscomp0. exact h'_eq2_inst. clear h'_eq2_inst. *)
-(*       apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*       apply CoproductIn2Commutes_right_in_double_ctx_dir. *)
-(*       unfold nat_trans_fix_snd_arg_data; simpl. *)
-(*       do 2 rewrite <- assoc. *)
-(*       apply maponpaths. *)
-(*       rewrite <- assoc. *)
-(*       apply maponpaths. *)
-(*       apply pathsinv0. *)
-(*       apply CoproductIn2Commutes. *)
-(* Qed. *)
+Proof.
+  intros [h' h'_eq].
+  apply subtypeEquality.
+  - intro.
+    unfold bracket_property.
+    apply isaset_nat_trans. exact hs.
+  - simpl.
+    apply parts_from_whole in h'_eq.
+(*    destruct h'_eq as [h'_eq1 h'_eq2]. *)
+    unfold bracket_Thm15.
+    apply path_to_ctr.
+    apply nat_trans_eq; try (exact hs).
+    intro c; simpl.
+    unfold coproduct_nat_trans_data.
+    repeat rewrite (id_left EndC).
+    rewrite id_right.
+    repeat rewrite <- assoc.
+    eapply pathscomp0. Focus 2. eapply pathsinv0. apply postcompWithCoproductArrow.
+    apply CoproductArrowUnique.
+    + destruct h'_eq as [h'_eq1 _ ]. (*clear h'_eq2.*)
+      simpl.
+      rewrite (id_left C).
+      assert (h'_eq1_inst := nat_trans_eq_pointwise h'_eq1 c);
+        clear h'_eq1.
+      simpl in h'_eq1_inst.
+      unfold coproduct_nat_trans_in1_data in h'_eq1_inst; simpl in h'_eq1_inst.
+      rewrite <- assoc in h'_eq1_inst.
+      eapply pathscomp0.
+      eapply pathsinv0.
+      exact h'_eq1_inst.
+      clear h'_eq1_inst.
+      apply CoproductIn1Commutes_right_in_ctx_dir.
+      apply CoproductIn1Commutes_right_in_ctx_dir.
+      apply CoproductIn1Commutes_right_dir.
+        apply idpath.
+    + destruct h'_eq as [_ h'_eq2]. (*clear h'_eq2.*)
+      assert (h'_eq2_inst := nat_trans_eq_pointwise h'_eq2 c);
+        clear h'_eq2.
+      simpl in h'_eq2_inst.
+      unfold coproduct_nat_trans_in2_data in h'_eq2_inst; simpl in h'_eq2_inst.
+      apply pathsinv0 in h'_eq2_inst.
+      rewrite <- assoc in h'_eq2_inst.
+      eapply pathscomp0. exact h'_eq2_inst. clear h'_eq2_inst.
+      apply CoproductIn2Commutes_right_in_ctx_dir.
+      apply CoproductIn2Commutes_right_in_double_ctx_dir.
+      unfold nat_trans_fix_snd_arg_data; simpl.
+      do 2 rewrite <- assoc.
+      apply maponpaths.
+      rewrite <- assoc.
+      apply maponpaths.
+      apply pathsinv0.
+      apply CoproductIn2Commutes.
+Qed.
 
 Definition bracket_for_InitAlg : bracket InitAlg.
 Proof.
@@ -609,8 +599,7 @@ Proof.
     rewrite <- (nat_trans_ax α).
     rewrite functor_id.
     apply id_left.
-Admitted.
-(* Qed. *)
+Qed.
 
 Local Definition iso2' (Z : Ptd) : EndEndC ⟦
   CoproductObject EndEndC
@@ -667,210 +656,209 @@ Lemma ishssMor_InitAlg (T' : hss CP H) :
   @ishssMor C hs CP H
         InitHSS T'
            (InitialArrow IA (pr1 T') : @algebra_mor EndC Id_H InitAlg T' ).
-Admitted.
-(* Proof. *)
-(*   unfold ishssMor. *)
-(*   unfold isbracketMor. *)
-(*   intros Z f. *)
-(*   set (β0 := InitialArrow IA (pr1 T')). *)
-(*   match goal with | [|- _ ;; ?b = _ ] => set (β := b) end. *)
-(*   set ( rhohat := CoproductArrow EndC  (CPEndC _ _ )  β (tau_from_alg T') *)
-(*                   :  pr1 Ghat T' --> T'). *)
-(*   set (X:= SpecializedGMIt Z _ Ghat rhohat (thetahat Z f)). *)
-(*   pathvia (pr1 (pr1 X)). *)
-(*   - set (TT:= fusion_law _ _ _ IA _ hsEndC (pr1 InitAlg) T' _ (KanExt Z)). *)
-(*     set (Psi := ψ_from_comps _ (Id_H) _ hsEndC _ (ℓ (U Z)) (Const_plus_H (U Z)) (ρ_Thm15 Z f) *)
-(*                              (aux_iso_1 Z ;; θ'_Thm15 Z ;; aux_iso_2_inv Z) ). *)
-(*     set (T2 := TT Psi). *)
-(*     set (T3 := T2 (ℓ (U Z)) (KanExt Z)). *)
-(*     set (Psi' := ψ_from_comps _ (Id_H) _ hsEndC _ (ℓ (U Z)) (Ghat) (rhohat) *)
-(*                              (iso1' Z ;; thetahat_0 Z f ;; iso2' Z) ). *)
-(*     set (T4 := T3 Psi'). *)
-(*     set (Φ := (Phi_fusion Z T' β)). *)
-(*     set (T5 := T4 Φ). *)
-(*     pathvia (Φ _ (fbracket InitHSS f)). *)
-(*     + apply idpath. *)
-(*     + eapply pathscomp0. Focus 2. apply T5. *)
-(*       (* hypothesis of fusion law *) *)
-(*       apply funextsec. intro. *)
-(*       simpl. *)
-(*       unfold compose. simpl. *)
-(*       apply nat_trans_eq. assumption. *)
-(*       simpl. *)
-(*       intro c. *)
-(*       rewrite id_right. *)
-(*       rewrite id_right. *)
-(*       (* should be decomposed into two diagrams *) *)
-(*       apply CoproductArrow_eq_cor. *)
-(*       * (* first diagram *) *)
-(*         clear TT T2 T3 T4 T5. *)
-(*         do 5 rewrite <- assoc. *)
-(*         apply CoproductIn1Commutes_left_in_ctx_dir. *)
-(*         apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*         simpl. *)
-(*         rewrite id_left. *)
-(*         apply CoproductIn1Commutes_left_in_ctx_dir. *)
-(*         apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*         simpl. *)
-(*         rewrite id_left. *)
-(*         apply CoproductIn1Commutes_left_in_ctx_dir. *)
-(*         simpl. *)
-(*         rewrite id_left. *)
-(*         apply CoproductIn1Commutes_left_in_ctx_dir. *)
-(*         rewrite <- assoc. *)
-(*         apply maponpaths. *)
-(*         apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*         simpl. *)
-(*         rewrite id_left. *)
-(*         apply CoproductIn1Commutes_right_dir. *)
-(*         apply idpath. *)
-(*       * (* a bit out of order what follows *) *)
-(*         apply cancel_postcomposition. *)
-(*         apply idpath. *)
-(*       * (* second diagram *) *)
-(*         clear TT T2 T3 T4 T5. *)
-(*         do 5 rewrite <- assoc. *)
-(*         apply CoproductIn2Commutes_left_in_ctx_dir. *)
-(*         apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*         rewrite (id_left EndC). *)
-(*         apply CoproductIn2Commutes_left_in_ctx_dir. *)
-(*         apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*         simpl. *)
-(*         unfold nat_trans_fix_snd_arg_data. *)
-(*         repeat rewrite <- assoc. *)
-(*         apply maponpaths. *)
-(*         apply CoproductIn2Commutes_left_in_ctx_dir. *)
-(*         apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*         simpl. *)
-(*         assert (H_nat_inst := functor_comp H _ _ _ t β). *)
-(*         assert (H_nat_inst_c := nat_trans_eq_pointwise H_nat_inst c); clear H_nat_inst. *)
-(*         { *)
-(*           match goal with |[ H1 : _  = ?f |- _ = _;; ?g ;; ?h  ] => *)
-(*              pathvia (f;;g;;h) end. *)
-(*           + clear H_nat_inst_c. *)
-(*             simpl. *)
-(*             repeat rewrite <- assoc. *)
-(*             apply maponpaths. *)
-(*             apply CoproductIn2Commutes_left_in_ctx_dir. *)
-(*             simpl. *)
-(*             unfold coproduct_nat_trans_in2_data, coproduct_nat_trans_data. *)
-(*             assert (Hyp := τ_part_of_alg_mor _ hs CP _ _ _ (InitialArrow IA (pr1 T'))). *)
-(*             assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp. *)
-(*             simpl in Hyp_c. *)
-(*             eapply pathscomp0. eapply pathsinv0. exact Hyp_c. *)
-(*             clear Hyp_c. *)
-(*             apply maponpaths. *)
-(*             apply pathsinv0. *)
-(*             apply CoproductIn2Commutes. *)
-(*           + rewrite <- H_nat_inst_c. *)
-(*             apply idpath. *)
-(*         } *)
-(*   - apply pathsinv0. *)
-(*     apply path_to_ctr. *)
-(*     (* now a lot of serious verification work to be done *) *)
-(*     apply nat_trans_eq; try (exact hs). *)
-(*     intro c. *)
-(*     simpl. *)
-(*     rewrite id_right. *)
-(*     (* look at type: *)
-(*        match goal with | [ |- ?l = _ ] => let ty:= (type of l) in idtac ty end. *) *)
-(*     apply CoproductArrow_eq_cor. *)
-(*     + repeat rewrite <- assoc. *)
-(*       apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*       simpl. *)
-(*       unfold coproduct_nat_trans_in1_data, *)
-(*              coproduct_nat_trans_in2_data, *)
-(*              coproduct_nat_trans_data. *)
-(*       rewrite id_left. *)
-(*       apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*       simpl. *)
-(*       repeat rewrite <- assoc. *)
-(*       eapply pathscomp0. Focus 2. apply maponpaths. apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*         rewrite id_left. apply CoproductIn1Commutes_right_dir. apply idpath. *)
-(*       do 2 rewrite assoc. *)
-(*       eapply pathscomp0. *)
-(*         apply cancel_postcomposition. *)
-(*         assert (ptd_mor_commutes_inst := ptd_mor_commutes _ (ptd_from_alg_mor _ hs CP H β0) ((pr1 Z) c)). *)
-(*         apply ptd_mor_commutes_inst. *)
-(*       assert (fbracket_η_inst := fbracket_η T' (f;; ptd_from_alg_mor _ hs CP H β0)). *)
-(*       assert (fbracket_η_inst_c := nat_trans_eq_pointwise fbracket_η_inst c); clear fbracket_η_inst. *)
-(*       apply (!fbracket_η_inst_c). *)
-(*     + (* now the difficult case *) *)
-(*       repeat rewrite <- assoc. *)
-(*       apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*       simpl. *)
-(*       unfold coproduct_nat_trans_in1_data, coproduct_nat_trans_in2_data, coproduct_nat_trans_data. *)
-(*       rewrite id_left. *)
-(*       apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*       unfold nat_trans_fix_snd_arg_data. *)
-(*       simpl. *)
-(*       unfold coproduct_nat_trans_in2_data. *)
-(*       repeat rewrite <- assoc. *)
-(*       eapply pathscomp0. Focus 2. *)
-(*         apply maponpaths. *)
-(*         apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*         rewrite <- assoc. *)
-(*         apply maponpaths. *)
-(*         apply CoproductIn2Commutes_right_dir. *)
-(*         apply idpath. *)
-(*       do 2 rewrite assoc. *)
-(*       eapply pathscomp0. *)
-(*         apply cancel_postcomposition. *)
-(*         eapply pathsinv0. *)
-(*         assert (τ_part_of_alg_mor_inst := τ_part_of_alg_mor _ hs CP H _ _ β0). *)
-(*         assert (τ_part_of_alg_mor_inst_Zc := *)
-(*                   nat_trans_eq_pointwise τ_part_of_alg_mor_inst ((pr1 Z) c)); *)
-(*           clear τ_part_of_alg_mor_inst. *)
-(*         apply τ_part_of_alg_mor_inst_Zc. *)
-(*       simpl. *)
-(*       unfold coproduct_nat_trans_in2_data. *)
-(*       repeat rewrite <- assoc. *)
-(*       eapply pathscomp0. *)
-(*         apply maponpaths. *)
-(*         rewrite assoc. *)
-(*         eapply pathsinv0. *)
-(*         assert (fbracket_τ_inst := fbracket_τ T' (f;; ptd_from_alg_mor _ hs CP H β0)). *)
-(*         assert (fbracket_τ_inst_c := nat_trans_eq_pointwise fbracket_τ_inst c); clear fbracket_τ_inst. *)
-(*         apply fbracket_τ_inst_c. *)
-(*       simpl. *)
-(*       unfold coproduct_nat_trans_in2_data. *)
-(*       repeat rewrite assoc. *)
-(*       apply cancel_postcomposition. *)
-(*       apply cancel_postcomposition. *)
-(*       assert (Hyp: *)
-(*                  ((# (pr1 (ℓ(U Z))) (# H β));; *)
-(*                  (theta H) ((alg_carrier _  T') ⊗ Z);; *)
-(*                  # H (fbracket T' (f;; ptd_from_alg_mor C hs CP H β0)) *)
-(*                  = *)
-(*                  θ (tpair (λ _ : functor C C, ptd_obj C) (alg_carrier _ (InitialObject IA)) Z) ;; *)
-(*                  # H (# (pr1 (ℓ(U Z))) β ;; *)
-(*                  fbracket T' (f;; ptd_from_alg_mor C hs CP H β0)))). *)
+Proof.
+  unfold ishssMor.
+  unfold isbracketMor.
+  intros Z f.
+  set (β0 := InitialArrow IA (pr1 T')).
+  match goal with | [|- _ ;; ?b = _ ] => set (β := b) end.
+  set ( rhohat := CoproductArrow EndC  (CPEndC _ _ )  β (tau_from_alg T')
+                  :  pr1 Ghat T' --> T').
+  set (X:= SpecializedGMIt Z _ Ghat rhohat (thetahat Z f)).
+  pathvia (pr1 (pr1 X)).
+  - set (TT:= fusion_law _ _ _ IA _ hsEndC (pr1 InitAlg) T' _ (KanExt Z)).
+    set (Psi := ψ_from_comps _ (Id_H) _ hsEndC _ (ℓ (U Z)) (Const_plus_H (U Z)) (ρ_Thm15 Z f)
+                             (aux_iso_1 Z ;; θ'_Thm15 Z ;; aux_iso_2_inv Z) ).
+    set (T2 := TT Psi).
+    set (T3 := T2 (ℓ (U Z)) (KanExt Z)).
+    set (Psi' := ψ_from_comps _ (Id_H) _ hsEndC _ (ℓ (U Z)) (Ghat) (rhohat)
+                             (iso1' Z ;; thetahat_0 Z f ;; iso2' Z) ).
+    set (T4 := T3 Psi').
+    set (Φ := (Phi_fusion Z T' β)).
+    set (T5 := T4 Φ).
+    pathvia (Φ _ (fbracket InitHSS f)).
+    + apply idpath.
+    + eapply pathscomp0. Focus 2. apply T5.
+      (* hypothesis of fusion law *)
+      apply funextsec. intro.
+      simpl.
+      unfold compose. simpl.
+      apply nat_trans_eq. assumption.
+      simpl.
+      intro c.
+      rewrite id_right.
+      rewrite id_right.
+      (* should be decomposed into two diagrams *)
+      apply CoproductArrow_eq_cor.
+      * (* first diagram *)
+        clear TT T2 T3 T4 T5.
+        do 5 rewrite <- assoc.
+        apply CoproductIn1Commutes_left_in_ctx_dir.
+        apply CoproductIn1Commutes_right_in_ctx_dir.
+        simpl.
+        rewrite id_left.
+        apply CoproductIn1Commutes_left_in_ctx_dir.
+        apply CoproductIn1Commutes_right_in_ctx_dir.
+        simpl.
+        rewrite id_left.
+        apply CoproductIn1Commutes_left_in_ctx_dir.
+        simpl.
+        rewrite id_left.
+        apply CoproductIn1Commutes_left_in_ctx_dir.
+        rewrite <- assoc.
+        apply maponpaths.
+        apply CoproductIn1Commutes_right_in_ctx_dir.
+        simpl.
+        rewrite id_left.
+        apply CoproductIn1Commutes_right_dir.
+        apply idpath.
+      * (* a bit out of order what follows *)
+        apply cancel_postcomposition.
+        apply idpath.
+      * (* second diagram *)
+        clear TT T2 T3 T4 T5.
+        do 5 rewrite <- assoc.
+        apply CoproductIn2Commutes_left_in_ctx_dir.
+        apply CoproductIn2Commutes_right_in_ctx_dir.
+        rewrite (id_left EndC).
+        apply CoproductIn2Commutes_left_in_ctx_dir.
+        apply CoproductIn2Commutes_right_in_ctx_dir.
+        simpl.
+        unfold nat_trans_fix_snd_arg_data.
+        repeat rewrite <- assoc.
+        apply maponpaths.
+        apply CoproductIn2Commutes_left_in_ctx_dir.
+        apply CoproductIn2Commutes_right_in_ctx_dir.
+        simpl.
+        assert (H_nat_inst := functor_comp H _ _ _ t β).
+        assert (H_nat_inst_c := nat_trans_eq_pointwise H_nat_inst c); clear H_nat_inst.
+        {
+          match goal with |[ H1 : _  = ?f |- _ = _;; ?g ;; ?h  ] =>
+             pathvia (f;;g;;h) end.
+          + clear H_nat_inst_c.
+            simpl.
+            repeat rewrite <- assoc.
+            apply maponpaths.
+            apply CoproductIn2Commutes_left_in_ctx_dir.
+            simpl.
+            unfold coproduct_nat_trans_in2_data, coproduct_nat_trans_data.
+            assert (Hyp := τ_part_of_alg_mor _ hs CP _ _ _ (InitialArrow IA (pr1 T'))).
+            assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp.
+            simpl in Hyp_c.
+            eapply pathscomp0. eapply pathsinv0. exact Hyp_c.
+            clear Hyp_c.
+            apply maponpaths.
+            apply pathsinv0.
+            apply CoproductIn2Commutes.
+          + rewrite <- H_nat_inst_c.
+            apply idpath.
+        }
+  - apply pathsinv0.
+    apply path_to_ctr.
+    (* now a lot of serious verification work to be done *)
+    apply nat_trans_eq; try (exact hs).
+    intro c.
+    simpl.
+    rewrite id_right.
+    (* look at type: *)
+(*        match goal with | [ |- ?l = _ ] => let ty:= (type of l) in idtac ty end. *)
+    apply CoproductArrow_eq_cor.
+    + repeat rewrite <- assoc.
+      apply CoproductIn1Commutes_right_in_ctx_dir.
+      simpl.
+      unfold coproduct_nat_trans_in1_data,
+             coproduct_nat_trans_in2_data,
+             coproduct_nat_trans_data.
+      rewrite id_left.
+      apply CoproductIn1Commutes_right_in_ctx_dir.
+      simpl.
+      repeat rewrite <- assoc.
+      eapply pathscomp0. Focus 2. apply maponpaths. apply CoproductIn1Commutes_right_in_ctx_dir.
+        rewrite id_left. apply CoproductIn1Commutes_right_dir. apply idpath.
+      do 2 rewrite assoc.
+      eapply pathscomp0.
+        apply cancel_postcomposition.
+        assert (ptd_mor_commutes_inst := ptd_mor_commutes _ (ptd_from_alg_mor _ hs CP H β0) ((pr1 Z) c)).
+        apply ptd_mor_commutes_inst.
+      assert (fbracket_η_inst := fbracket_η T' (f;; ptd_from_alg_mor _ hs CP H β0)).
+      assert (fbracket_η_inst_c := nat_trans_eq_pointwise fbracket_η_inst c); clear fbracket_η_inst.
+      apply (!fbracket_η_inst_c).
+    + (* now the difficult case *)
+      repeat rewrite <- assoc.
+      apply CoproductIn2Commutes_right_in_ctx_dir.
+      simpl.
+      unfold coproduct_nat_trans_in1_data, coproduct_nat_trans_in2_data, coproduct_nat_trans_data.
+      rewrite id_left.
+      apply CoproductIn2Commutes_right_in_ctx_dir.
+      unfold nat_trans_fix_snd_arg_data.
+      simpl.
+      unfold coproduct_nat_trans_in2_data.
+      repeat rewrite <- assoc.
+      eapply pathscomp0. Focus 2.
+        apply maponpaths.
+        apply CoproductIn2Commutes_right_in_ctx_dir.
+        rewrite <- assoc.
+        apply maponpaths.
+        apply CoproductIn2Commutes_right_dir.
+        apply idpath.
+      do 2 rewrite assoc.
+      eapply pathscomp0.
+        apply cancel_postcomposition.
+        eapply pathsinv0.
+        assert (τ_part_of_alg_mor_inst := τ_part_of_alg_mor _ hs CP H _ _ β0).
+        assert (τ_part_of_alg_mor_inst_Zc :=
+                  nat_trans_eq_pointwise τ_part_of_alg_mor_inst ((pr1 Z) c));
+          clear τ_part_of_alg_mor_inst.
+        apply τ_part_of_alg_mor_inst_Zc.
+      simpl.
+      unfold coproduct_nat_trans_in2_data.
+      repeat rewrite <- assoc.
+      eapply pathscomp0.
+        apply maponpaths.
+        rewrite assoc.
+        eapply pathsinv0.
+        assert (fbracket_τ_inst := fbracket_τ T' (f;; ptd_from_alg_mor _ hs CP H β0)).
+        assert (fbracket_τ_inst_c := nat_trans_eq_pointwise fbracket_τ_inst c); clear fbracket_τ_inst.
+        apply fbracket_τ_inst_c.
+      simpl.
+      unfold coproduct_nat_trans_in2_data.
+      repeat rewrite assoc.
+      apply cancel_postcomposition.
+      apply cancel_postcomposition.
+      assert (Hyp:
+                 ((# (pr1 (ℓ(U Z))) (# H β));;
+                 (theta H) ((alg_carrier _  T') ⊗ Z);;
+                 # H (fbracket T' (f;; ptd_from_alg_mor C hs CP H β0))
+                 =
+                 θ (tpair (λ _ : functor C C, ptd_obj C) (alg_carrier _ (InitialObject IA)) Z) ;;
+                 # H (# (pr1 (ℓ(U Z))) β ;;
+                 fbracket T' (f;; ptd_from_alg_mor C hs CP H β0)))).
 
-(*       Focus 2. *)
-(*       assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp. *)
-(*       exact Hyp_c. *)
+      Focus 2.
+      assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp.
+      exact Hyp_c.
 
-(*       clear c. clear X. clear rhohat. *)
-(*       rewrite (functor_comp H). *)
-(*       rewrite assoc. *)
-(*       apply cancel_postcomposition. *)
-(*       fold θ. *)
-(*       apply nat_trans_eq; try (exact hs). *)
-(*       intro c. *)
-(*       assert (θ_nat_1_pointwise_inst := θ_nat_1_pointwise _ hs H θ _ _ β Z c). *)
-(*       eapply pathscomp0 ; [exact θ_nat_1_pointwise_inst | ]. *)
-(*       clear θ_nat_1_pointwise_inst. *)
-(*       simpl. *)
-(*       apply maponpaths. *)
-(*       assert (Hyp: # H (β ∙∙ nat_trans_id (pr1 Z)) = # H (# (pr1 (ℓ(U Z))) β)). *)
-(*       { apply maponpaths. *)
-(*         apply nat_trans_eq; try (exact hs). *)
-(*         intro c'. *)
-(*         simpl. *)
-(*         rewrite functor_id. *)
-(*         apply id_right. } *)
-(*       apply (nat_trans_eq_pointwise Hyp c). *)
-(* Qed. *)
+      clear c. clear X. clear rhohat.
+      rewrite (functor_comp H).
+      rewrite assoc.
+      apply cancel_postcomposition.
+      fold θ.
+      apply nat_trans_eq; try (exact hs).
+      intro c.
+      assert (θ_nat_1_pointwise_inst := θ_nat_1_pointwise _ hs H θ _ _ β Z c).
+      eapply pathscomp0 ; [exact θ_nat_1_pointwise_inst | ].
+      clear θ_nat_1_pointwise_inst.
+      simpl.
+      apply maponpaths.
+      assert (Hyp: # H (β ∙∙ nat_trans_id (pr1 Z)) = # H (# (pr1 (ℓ(U Z))) β)).
+      { apply maponpaths.
+        apply nat_trans_eq; try (exact hs).
+        intro c'.
+        simpl.
+        rewrite functor_id.
+        apply id_right. }
+      apply (nat_trans_eq_pointwise Hyp c).
+Qed.
 
 Definition hss_InitMor : ∀ T' : hss CP H, hssMor InitHSS T'.
 Proof.
@@ -885,8 +873,7 @@ Proof.
   intro t.
   apply (invmap (hssMor_eq1 _ _ _ _ _ _ _ _ )).
   apply (@InitialArrowUnique _ IA (pr1 T') (pr1 t)).
-Admitted.
-(* Qed. *)
+Qed.
 
 Lemma isInitial_InitHSS : isInitial (hss_precategory CP H) InitHSS.
 Proof.

--- a/UniMath/SubstitutionSystems/SumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/SumOfSignatures.v
@@ -72,8 +72,8 @@ Variable S22 : θ_Strength2 θ2.
 
 (** * Definition of the data of the sum of two signatures *)
 
-Definition H : functor [C, C, hs] [C, C, hs] := coproduct_functor _ _ CCC H1 H2.
-
+(* Definition H : functor [C, C, hs] [C, C, hs] := coproduct_functor _ _ CCC H1 H2. *)
+Definition H : functor [C, C, hs] [C, C, hs] := sum_of_functors CCC H1 H2.
 
 Local Definition bla1 (X : [C, C, hs]) (Z : precategory_Ptd C hs) :
    ∀ c : C,


### PR DESCRIPTION
This pull request contains various results towards linking Benedikt's and my work on omega-cocontinuous functors to the work on substitution systems. In particular it contains:

- Packaging and notations for omega-cocontinuous functors and a cleanup of the lists example.
- Another example implementing binary trees as the initial algebra of F(X) = 1 + A * X * X
- Lifting of initial objects to functor categories
- Instantiation of the necessary hypotheses in substitution systems using the results from the work on omega-cocontinuous functors. 

There are some issues that needs to be resolved related to compilation times of substitution systems. I had to change product_functor to product_of_functors and coproduct_functor to sum_of_functors in substitution systems in order to make it possible to use the results on omega-cocontinuous functors, however this seems to lead to very increased compilation times. 