### PR TITLE
Finish the linking of SubstSys and Cocont

### DIFF
--- a/UniMath/CategoryTheory/cocontfunctors.v
+++ b/UniMath/CategoryTheory/cocontfunctors.v
@@ -6,6 +6,7 @@ This file contains proofs that the following functors are
 - Constant functor: F_x : C -> D, c |-> x
 - Identity functor
 - Composition of omega-cocontinuous functors
+- Iteration of omega-cocontinuous functors: F^n : C -> C
 - Pairing of omega-cocont functors (F,G) : A * B -> C * D, (x,y) |-> (F x,G y)
 - Delta functor: C -> C^2, x |-> (x,x)
 - Binary coproduct functor: C^2 -> C, (x,y) |-> x + y
@@ -105,6 +106,19 @@ Defined.
 Definition omega_cocont_functor_composite {C D E : precategory}
   (hsE : has_homsets E) (F : omega_cocont_functor C D) (G : omega_cocont_functor D E) :
   omega_cocont_functor C E := tpair _ _ (is_omega_cocont_functor_composite hsE _ _ (pr2 F) (pr2 G)).
+
+(* Functor iteration preserves omega cocontinuity *)
+Lemma is_omega_cocont_iter_functor {C : precategory} (hsC : has_homsets C)
+  (F : functor C C) (hF : is_omega_cocont F) n : is_omega_cocont (iter_functor F n).
+Proof.
+induction n as [|n IH]; simpl.
+- apply (is_omega_cocont_functor_identity _ hsC).
+- apply (is_omega_cocont_functor_composite hsC _ _ IH hF).
+Defined.
+
+Definition omega_cocont_iter_functor {C : precategory} (hsC : has_homsets C)
+  (F : omega_cocont_functor C C) n : omega_cocont_functor C C :=
+  tpair _ _ (is_omega_cocont_iter_functor hsC _ (pr2 F) n).
 
 (* A pair of functors (F,G) : A * B -> C * D is omega_cocont if F and G are *)
 Section pair_functor.

--- a/UniMath/CategoryTheory/cocontfunctors.v
+++ b/UniMath/CategoryTheory/cocontfunctors.v
@@ -930,8 +930,9 @@ Notation "F + G" :=
   (omega_cocont_coproduct_of_functors _ _ ProductsHSET CoproductsHSET
      has_homsets_HSET has_homsets_HSET F G) : cocont_functor_hset_scope.
 
-(* omega_cocont_coproduct_functor has worse computational behavior and
-   breaks isalghom_pr1foldr in lists *)
+(* omega_cocont_coproduct_functor has worse computational behavior
+   than omega_cocont_coproduct_of_functors and breaks
+   isalghom_pr1foldr in lists *)
 (* Notation "F + G" := *)
 (*   (omega_cocont_coproduct_functor _ _ ProductsHSET CoproductsHSET *)
 (*      has_homsets_HSET has_homsets_HSET _ _ (pr2 F) (pr2 G)) : *)

--- a/UniMath/CategoryTheory/cocontfunctors.v
+++ b/UniMath/CategoryTheory/cocontfunctors.v
@@ -9,7 +9,8 @@ This file contains proofs that the following functors are
 - Pairing of omega-cocont functors (F,G) : A * B -> C * D, (x,y) |-> (F x,G y)
 - Delta functor: C -> C^2, x |-> (x,x)
 - Binary coproduct functor: C^2 -> C, (x,y) |-> x + y
-- Sum of functors: F + G : C -> D, x |-> (x,x) |-> (F x,G x) |-> F x + G x
+- Coproduct of functors: F + G : C -> D, x |-> (x,x) |-> (F x,G x) |-> F x + G x
+- Coproduct functor: F + G : C -> D, x |-> F x + G x
 - Constant product functors: C -> C, x |-> a * x  and  x |-> x * a
 - Binary product functor: C^2 -> C, (x,y) |-> x * y
 - Product of functors: F * G : C -> D, x |-> (x,x) |-> (F x,G x) |-> F x * G x
@@ -281,15 +282,14 @@ Defined.
 
 End bincoprod_functor.
 
-(* Definition sum_of_functors {C D : precategory}  (HD : Coproducts D) (F G : functor C D) := coproduct_functor _ _ HD F G. *)
-Section sum_of_functors.
+Section coproduct_of_functors.
 
 Variables (C D : precategory) (PC : Products C) (HD : Coproducts D).
 Variables (hsC : has_homsets C) (hsD : has_homsets D).
 
-Lemma is_omega_cocont_sum_of_functors (F G : functor C D)
+Lemma is_omega_cocont_coproduct_of_functors (F G : functor C D)
   (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
-  is_omega_cocont (sum_of_functors HD F G).
+  is_omega_cocont (coproduct_of_functors HD F G).
 Proof.
 apply (is_omega_cocont_functor_composite hsD).
   apply (is_omega_cocont_delta_functor _ PC hsC).
@@ -298,11 +298,23 @@ apply (is_omega_cocont_functor_composite hsD).
 apply (is_omega_cocont_bincoproduct_functor _ _ hsD).
 Defined.
 
-Definition omega_cocont_sum_of_functors (F G : functor C D)
+Definition omega_cocont_coproduct_of_functors (F G : functor C D)
   (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
-  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_sum_of_functors F G HF HG).
+  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_coproduct_of_functors F G HF HG).
 
-End sum_of_functors.
+Lemma is_omega_cocont_coproduct_functor (F G : functor C D)
+  (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
+  is_omega_cocont (coproduct_functor _ _ HD F G).
+Proof.
+exact (transportf _ (coproduct_of_functors_eq_coproduct_functor C D HD hsD F G)
+                  (is_omega_cocont_coproduct_of_functors _ _ HF HG)).
+Defined.
+
+Definition omega_cocont_coproduct_functor (F G : functor C D)
+  (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
+  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_coproduct_functor F G HF HG).
+
+End coproduct_of_functors.
 
 Section constprod_functors.
 
@@ -892,9 +904,16 @@ Notation "F * G" :=
     cocont_functor_hset_scope.
 
 Notation "F + G" :=
-  (omega_cocont_sum_of_functors _ _ ProductsHSET CoproductsHSET
+  (omega_cocont_coproduct_of_functors _ _ ProductsHSET CoproductsHSET
      has_homsets_HSET has_homsets_HSET _ _ (pr2 F) (pr2 G)) :
     cocont_functor_hset_scope.
+
+(* omega_cocont_coproduct_functor has worse computational behavior and
+   breaks isalghom_pr1foldr in lists *)
+(* Notation "F + G" := *)
+(*   (omega_cocont_coproduct_functor _ _ ProductsHSET CoproductsHSET *)
+(*      has_homsets_HSET has_homsets_HSET _ _ (pr2 F) (pr2 G)) : *)
+(*     cocont_functor_hset_scope. *)
 
 Notation "1" := (unitHSET) : cocont_functor_hset_scope.
 Notation "0" := (emptyHSET) : cocont_functor_hset_scope.

--- a/UniMath/CategoryTheory/cocontfunctors.v
+++ b/UniMath/CategoryTheory/cocontfunctors.v
@@ -14,6 +14,7 @@ This file contains proofs that the following functors are
 - Constant product functors: C -> C, x |-> a * x  and  x |-> x * a
 - Binary product functor: C^2 -> C, (x,y) |-> x * y
 - Product of functors: F * G : C -> D, x |-> (x,x) |-> (F x,G x) |-> F x * G x
+- Product functor: F * G : C -> D, x |-> F x * G x
 - Precomposition functor: _ o K : [C,A] -> [M,A] for K : M -> C
 
 
@@ -695,6 +696,18 @@ Defined.
 Definition omega_cocont_product_of_functors (F G : functor C D)
   (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
   omega_cocont_functor C D := tpair _ _ (is_omega_cocont_product_of_functors F G HF HG).
+
+Lemma is_omega_cocont_product_functor (F G : functor C D)
+  (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
+  is_omega_cocont (product_functor _ _ PD F G).
+Proof.
+exact (transportf _ (product_of_functors_eq_product_functor C D PD hsD F G)
+                  (is_omega_cocont_product_of_functors _ _ HF HG)).
+Defined.
+
+Definition omega_cocont_product_functor (F G : functor C D)
+  (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
+  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_product_functor F G HF HG).
 
 End product_of_functors.
 

--- a/UniMath/CategoryTheory/cocontfunctors.v
+++ b/UniMath/CategoryTheory/cocontfunctors.v
@@ -299,9 +299,8 @@ apply (is_omega_cocont_functor_composite hsD).
 apply (is_omega_cocont_bincoproduct_functor _ _ hsD).
 Defined.
 
-Definition omega_cocont_coproduct_of_functors (F G : functor C D)
-  (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
-  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_coproduct_of_functors F G HF HG).
+Definition omega_cocont_coproduct_of_functors (F G : omega_cocont_functor C D) :
+  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_coproduct_of_functors _ _ (pr2 F) (pr2 G)).
 
 Lemma is_omega_cocont_coproduct_functor (F G : functor C D)
   (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
@@ -311,9 +310,8 @@ exact (transportf _ (coproduct_of_functors_eq_coproduct_functor C D HD hsD F G)
                   (is_omega_cocont_coproduct_of_functors _ _ HF HG)).
 Defined.
 
-Definition omega_cocont_coproduct_functor (F G : functor C D)
-  (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
-  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_coproduct_functor F G HF HG).
+Definition omega_cocont_coproduct_functor (F G : omega_cocont_functor C D) :
+  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_coproduct_functor _ _ (pr2 F) (pr2 G)).
 
 End coproduct_of_functors.
 
@@ -693,9 +691,8 @@ apply (is_omega_cocont_functor_composite hsD).
 apply (is_omega_cocont_binproduct_functor _ _ hsD hED).
 Defined.
 
-Definition omega_cocont_product_of_functors (F G : functor C D)
-  (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
-  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_product_of_functors F G HF HG).
+Definition omega_cocont_product_of_functors (F G : omega_cocont_functor C D) :
+  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_product_of_functors _ _ (pr2 F) (pr2 G)).
 
 Lemma is_omega_cocont_product_functor (F G : functor C D)
   (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
@@ -705,9 +702,8 @@ exact (transportf _ (product_of_functors_eq_product_functor C D PD hsD F G)
                   (is_omega_cocont_product_of_functors _ _ HF HG)).
 Defined.
 
-Definition omega_cocont_product_functor (F G : functor C D)
-  (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
-  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_product_functor F G HF HG).
+Definition omega_cocont_product_functor (F G : omega_cocont_functor C D) :
+  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_product_functor _ _ (pr2 F) (pr2 G)).
 
 End product_of_functors.
 
@@ -913,13 +909,12 @@ Notation "'Id'" := (omega_cocont_functor_identity _ has_homsets_HSET) :
 
 Notation "F * G" :=
   (omega_cocont_product_of_functors _ _ ProductsHSET _
-     has_exponentials_HSET has_homsets_HSET has_homsets_HSET _ _ (pr2 F) (pr2 G)) :
+     has_exponentials_HSET has_homsets_HSET has_homsets_HSET F G) :
     cocont_functor_hset_scope.
 
 Notation "F + G" :=
   (omega_cocont_coproduct_of_functors _ _ ProductsHSET CoproductsHSET
-     has_homsets_HSET has_homsets_HSET _ _ (pr2 F) (pr2 G)) :
-    cocont_functor_hset_scope.
+     has_homsets_HSET has_homsets_HSET F G) : cocont_functor_hset_scope.
 
 (* omega_cocont_coproduct_functor has worse computational behavior and
    breaks isalghom_pr1foldr in lists *)

--- a/UniMath/CategoryTheory/lambdacalculus.v
+++ b/UniMath/CategoryTheory/lambdacalculus.v
@@ -43,10 +43,10 @@ Defined.
 (* TODO: package omega cocont functors *)
 Definition LambdaFunctor : functor [HSET,HSET,has_homsets_HSET] [HSET,HSET,has_homsets_HSET].
 Proof.
-eapply sum_of_functors.
+eapply coproduct_of_functors.
   apply (Coproducts_functor_precat _ _ CoproductsHSET).
   apply (constant_functor [HSET, HSET, has_homsets_HSET] [HSET, HSET, has_homsets_HSET] (functor_identity HSET)).
-eapply sum_of_functors.
+eapply coproduct_of_functors.
   apply (Coproducts_functor_precat _ _ CoproductsHSET).
   (* app *)
   eapply functor_composite.
@@ -74,13 +74,13 @@ Defined.
 
 Lemma omega_cocont_LambdaFunctor : is_omega_cocont LambdaFunctor.
 Proof.
-apply is_omega_cocont_sum_of_functors.
+apply is_omega_cocont_coproduct_of_functors.
   apply (Products_functor_precat _ _ ProductsHSET).
   apply functor_category_has_homsets.
   apply functor_category_has_homsets.
   apply is_omega_cocont_constant_functor.
   apply functor_category_has_homsets.
-apply is_omega_cocont_sum_of_functors.
+apply is_omega_cocont_coproduct_of_functors.
   apply (Products_functor_precat _ _ ProductsHSET).
   apply functor_category_has_homsets.
   apply functor_category_has_homsets.

--- a/UniMath/CategoryTheory/lambdacalculus.v
+++ b/UniMath/CategoryTheory/lambdacalculus.v
@@ -75,7 +75,7 @@ Local Notation "F + G" :=
 Local Notation "'_' 'o' 'option'" :=
   (omega_cocont_pre_composition_functor _ _ _
       (option_functor HSET CoproductsHSET TerminalHSET)
-      has_homsets_HSET has_homsets_HSET cats_LimsHSET) (at level 0).
+      has_homsets_HSET has_homsets_HSET cats_LimsHSET) (at level 10).
 
 Definition lambdaOmegaFunctor : omega_cocont_functor HSET2 HSET2 :=
   '(functor_identity HSET) + (Id * Id + _ o option).
@@ -151,52 +151,59 @@ Proof.
 assert (F := maponpaths (fun x => CoproductIn1 _ _ ;; x)
                         (algebra_mor_commutes _ _ _ (foldr_map X fvar fapp flam))).
 rewrite assoc in F.
-eapply pathscomp0.
-apply F.
+eapply pathscomp0; [apply F|].
 rewrite assoc.
-eapply pathscomp0.
-eapply cancel_postcomposition.
-apply CoproductOfArrowsIn1.
+eapply pathscomp0; [eapply cancel_postcomposition, CoproductOfArrowsIn1|].
 rewrite <- assoc.
-eapply pathscomp0.
-eapply maponpaths.
-apply CoproductIn1Commutes.
+eapply pathscomp0; [eapply maponpaths, CoproductIn1Commutes|].
 apply id_left.
 Defined.
 
 Lemma foldr_app (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧)
   (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) :
-  app_map ;; foldr_map X fvar fapp flam = pr1
-     (# (pair_functor (pr1 (Id * Id)) (pr1 _ o option))
-        (# (delta_functor HSET2)
-           (pr2 (# (delta_functor HSET2) (foldr_map X fvar fapp flam))))) ;; fapp.
+  app_map ;; foldr_map X fvar fapp flam =
+  # (pr1 (Id * Id)) (foldr_map X fvar fapp flam) ;; fapp.
 Proof.
 assert (F := maponpaths (fun x => CoproductIn1 _ _ ;; CoproductIn2 _ _ ;; x)
                         (algebra_mor_commutes _ _ _ (foldr_map X fvar fapp flam))).
 rewrite assoc in F.
-eapply pathscomp0.
-apply F.
+eapply pathscomp0; [apply F|].
 rewrite assoc.
 eapply pathscomp0.
-eapply cancel_postcomposition.
-rewrite <- assoc.
-eapply maponpaths.
-apply CoproductOfArrowsIn2.
+  eapply cancel_postcomposition.
+  rewrite <- assoc.
+  eapply maponpaths, CoproductOfArrowsIn2.
 rewrite assoc.
 eapply pathscomp0.
-eapply cancel_postcomposition.
-eapply cancel_postcomposition.
-apply CoproductOfArrowsIn1.
-rewrite <-assoc.
-eapply pathscomp0.
-eapply maponpaths.
-apply CoproductIn2Commutes.
-eapply pathscomp0.
+  eapply cancel_postcomposition, cancel_postcomposition, CoproductOfArrowsIn1.
 rewrite <- assoc.
-eapply maponpaths.
-apply CoproductIn1Commutes.
-Check (ProductOfArrows _ _ _ (foldr_map X fvar fapp flam) (foldr_map X fvar fapp flam) ).
-apply idpath.
+eapply pathscomp0; [eapply maponpaths, CoproductIn2Commutes|].
+rewrite <- assoc.
+now eapply pathscomp0; [eapply maponpaths, CoproductIn1Commutes|].
+Defined.
+
+Lemma foldr_lam (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧)
+  (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) :
+  lam_map ;; foldr_map X fvar fapp flam =
+  # (pr1 (_ o option)) (foldr_map X fvar fapp flam) ;; flam.
+Proof.
+assert (F := maponpaths (fun x => CoproductIn2 _ _ ;; CoproductIn2 _ _ ;; x)
+                        (algebra_mor_commutes _ _ _ (foldr_map X fvar fapp flam))).
+rewrite assoc in F.
+eapply pathscomp0; [apply F|].
+rewrite assoc.
+eapply pathscomp0.
+  eapply cancel_postcomposition.
+  rewrite <- assoc.
+  eapply maponpaths, CoproductOfArrowsIn2.
+rewrite assoc.
+eapply pathscomp0.
+  eapply cancel_postcomposition, cancel_postcomposition, CoproductOfArrowsIn2.
+rewrite <- assoc.
+eapply pathscomp0.
+  eapply maponpaths, CoproductIn2Commutes.
+rewrite <- assoc.
+now eapply pathscomp0; [eapply maponpaths, CoproductIn2Commutes|].
 Defined.
 
 End lambdacalculus.

--- a/UniMath/CategoryTheory/lambdacalculus.v
+++ b/UniMath/CategoryTheory/lambdacalculus.v
@@ -146,8 +146,7 @@ Defined.
 
 Lemma foldr_var (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧)
   (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) :
-  CoproductIn1 _ _ ;; alg_map lambdaFunctor LC_alg ;; foldr_map X fvar fapp flam =
-  fvar.
+  var_map ;; foldr_map X fvar fapp flam = fvar.
 Proof.
 assert (F := maponpaths (fun x => CoproductIn1 _ _ ;; x)
                         (algebra_mor_commutes _ _ _ (foldr_map X fvar fapp flam))).
@@ -163,6 +162,40 @@ eapply pathscomp0.
 eapply maponpaths.
 apply CoproductIn1Commutes.
 apply id_left.
+Defined.
+
+Lemma foldr_app (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧)
+  (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) :
+  app_map ;; foldr_map X fvar fapp flam = pr1
+     (# (pair_functor (pr1 (Id * Id)) (pr1 _ o option))
+        (# (delta_functor HSET2)
+           (pr2 (# (delta_functor HSET2) (foldr_map X fvar fapp flam))))) ;; fapp.
+Proof.
+assert (F := maponpaths (fun x => CoproductIn1 _ _ ;; CoproductIn2 _ _ ;; x)
+                        (algebra_mor_commutes _ _ _ (foldr_map X fvar fapp flam))).
+rewrite assoc in F.
+eapply pathscomp0.
+apply F.
+rewrite assoc.
+eapply pathscomp0.
+eapply cancel_postcomposition.
+rewrite <- assoc.
+eapply maponpaths.
+apply CoproductOfArrowsIn2.
+rewrite assoc.
+eapply pathscomp0.
+eapply cancel_postcomposition.
+eapply cancel_postcomposition.
+apply CoproductOfArrowsIn1.
+rewrite <-assoc.
+eapply pathscomp0.
+eapply maponpaths.
+apply CoproductIn2Commutes.
+eapply pathscomp0.
+rewrite <- assoc.
+eapply maponpaths.
+apply CoproductIn1Commutes.
+apply idpath.
 Defined.
 
 End lambdacalculus.

--- a/UniMath/CategoryTheory/lambdacalculus.v
+++ b/UniMath/CategoryTheory/lambdacalculus.v
@@ -158,11 +158,12 @@ rewrite assoc.
 eapply pathscomp0.
 eapply cancel_postcomposition.
 apply CoproductOfArrowsIn1.
-(* Opaque foldr_map. *)
-(* simpl. *)
-admit.
-(* rewrite id_left *)
-Admitted.
+rewrite <- assoc.
+eapply pathscomp0.
+eapply maponpaths.
+apply CoproductIn1Commutes.
+apply id_left.
+Defined.
 
 End lambdacalculus.
 

--- a/UniMath/CategoryTheory/lambdacalculus.v
+++ b/UniMath/CategoryTheory/lambdacalculus.v
@@ -32,23 +32,75 @@ Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
 Section lambdacalculus.
 
-(* TODO: package omega cocont functors *)
-Definition LambdaFunctor : functor [HSET,HSET,has_homsets_HSET] [HSET,HSET,has_homsets_HSET].
+Local Notation "'HSET2'":= [HSET, HSET, has_homsets_HSET].
+
+Local Definition has_homsets_HSET2 : has_homsets HSET2.
 Proof.
-eapply coproduct_of_functors.
-  apply (Coproducts_functor_precat _ _ CoproductsHSET).
-  apply (constant_functor [HSET, HSET, has_homsets_HSET] [HSET, HSET, has_homsets_HSET] (functor_identity HSET)).
-eapply coproduct_of_functors.
-  apply (Coproducts_functor_precat _ _ CoproductsHSET).
-  (* app *)
-  eapply functor_composite.
-    apply delta_functor.
-    apply binproduct_functor.
-    apply (Products_functor_precat _ _ ProductsHSET).
-(* lam *)
-apply (pre_composition_functor _ _ _ has_homsets_HSET _
-         (option_functor _ CoproductsHSET TerminalHSET)).
+apply functor_category_has_homsets.
 Defined.
+
+Local Definition ProductsHSET2 : Products HSET2.
+Proof.
+apply (Products_functor_precat _ _ ProductsHSET).
+Defined.
+
+Local Definition CoproductsHSET2 : Coproducts HSET2.
+Proof.
+apply (Coproducts_functor_precat _ _ CoproductsHSET).
+Defined.
+
+Local Lemma has_exponentials_HSET2 : has_exponentials ProductsHSET2.
+Proof.
+apply has_exponentials_functor_HSET, has_homsets_HSET.
+Defined.
+
+Local Lemma InitialHSET2 : Initial HSET2.
+Proof.
+apply (Initial_functor_precat _ _ InitialHSET).
+Defined.
+
+Local Notation "' x" := (omega_cocont_constant_functor _ _ has_homsets_HSET2 x)
+                          (at level 10).
+
+Local Notation "'Id'" := (omega_cocont_functor_identity _ has_homsets_HSET2).
+
+Local Notation "F * G" :=
+  (omega_cocont_product_of_functors _ _ ProductsHSET2 _
+     has_exponentials_HSET2 has_homsets_HSET2 has_homsets_HSET2 F G).
+
+Local Notation "F + G" :=
+  (omega_cocont_coproduct_of_functors _ _ ProductsHSET2 CoproductsHSET2
+     has_homsets_HSET2 has_homsets_HSET2 F G).
+
+Local Notation "'_' 'o' 'option'" :=
+  (omega_cocont_pre_composition_functor _ _ _
+      (option_functor HSET CoproductsHSET TerminalHSET)
+      has_homsets_HSET has_homsets_HSET cats_LimsHSET) (at level 0).
+
+Definition lambdaOmegaFunctor : omega_cocont_functor HSET2 HSET2 :=
+  Id + (Id * Id + _ o option).
+
+Let lambdaFunctor : functor HSET2 HSET2 := pr1 lambdaOmegaFunctor.
+Let is_omega_cocont_lambdaFunctor : is_omega_cocont lambdaFunctor :=
+  pr2 lambdaOmegaFunctor.
+
+(* Old version *)
+(* Definition Lambda : functor HSET2 HSET2. *)
+(* Proof. *)
+(* eapply coproduct_of_functors. *)
+(*   apply CoproductsHSET2. *)
+(*   apply (constant_functor HSET2 HSET2 (functor_identity HSET)). *)
+(* eapply coproduct_of_functors. *)
+(*   apply CoproductsHSET2. *)
+(*   (* app *) *)
+(*   eapply functor_composite. *)
+(*     apply delta_functor. *)
+(*     apply binproduct_functor. *)
+(*     apply ProductsHSET2. *)
+(* (* lam *) *)
+(* apply (pre_composition_functor _ _ _ has_homsets_HSET _ *)
+(*          (option_functor _ CoproductsHSET TerminalHSET)). *)
+(* Defined. *)
 
 (* Bad approach *)
 (* Definition Lambda : functor [HSET,HSET,has_homsets_HSET] [HSET,HSET,has_homsets_HSET]. *)
@@ -65,29 +117,102 @@ Defined.
 (*     eapply product_of_functors. *)
 (*       apply delta_functor. *)
 
-Lemma omega_cocont_LambdaFunctor : is_omega_cocont LambdaFunctor.
+(* Lemma omega_cocont_LambdaFunctor : is_omega_cocont LambdaFunctor. *)
+(* Proof. *)
+(* apply is_omega_cocont_coproduct_of_functors. *)
+(*   apply (Products_functor_precat _ _ ProductsHSET). *)
+(*   apply functor_category_has_homsets. *)
+(*   apply functor_category_has_homsets. *)
+(* simpl. *)
+(* apply is_omega_cocont_functor_identity. *)
+(*   apply has_homsets_HSET2. *)
+(* apply is_omega_cocont_coproduct_of_functors. *)
+(*   apply (Products_functor_precat _ _ ProductsHSET). *)
+(*   apply functor_category_has_homsets. *)
+(*   apply functor_category_has_homsets. *)
+(*   apply is_omega_cocont_functor_composite. *)
+(*   apply functor_category_has_homsets. *)
+(*   apply is_omega_cocont_delta_functor. *)
+(*   apply (Products_functor_precat _ _ ProductsHSET). *)
+(*   apply functor_category_has_homsets. *)
+(*   apply is_omega_cocont_binproduct_functor. *)
+(*   apply functor_category_has_homsets. *)
+(*   apply has_exponentials_functor_HSET. *)
+(*   apply has_homsets_HSET. *)
+(* apply is_omega_cocont_pre_composition_functor. *)
+(* apply cats_LimsHSET. *)
+(* Defined. *)
+
+Lemma lambdaFunctor_Initial :
+  Initial (precategory_FunctorAlg lambdaFunctor has_homsets_HSET2).
 Proof.
-apply is_omega_cocont_coproduct_of_functors.
-  apply (Products_functor_precat _ _ ProductsHSET).
-  apply functor_category_has_homsets.
-  apply functor_category_has_homsets.
-  apply is_omega_cocont_constant_functor.
-  apply functor_category_has_homsets.
-apply is_omega_cocont_coproduct_of_functors.
-  apply (Products_functor_precat _ _ ProductsHSET).
-  apply functor_category_has_homsets.
-  apply functor_category_has_homsets.
-  apply is_omega_cocont_functor_composite.
-  apply functor_category_has_homsets.
-  apply is_omega_cocont_delta_functor.
-  apply (Products_functor_precat _ _ ProductsHSET).
-  apply functor_category_has_homsets.
-  apply is_omega_cocont_binproduct_functor.
-  apply functor_category_has_homsets.
-  apply has_exponentials_functor_HSET.
-  apply has_homsets_HSET.
-apply is_omega_cocont_pre_composition_functor.
-apply cats_LimsHSET.
+apply (colimAlgInitial _ _ _ is_omega_cocont_lambdaFunctor InitialHSET2).
+apply ColimsFunctorCategory; apply ColimsHSET.
 Defined.
+
+Definition LambdaCalculus : HSET2 :=
+  alg_carrier _ (InitialObject lambdaFunctor_Initial).
+
+Let LambdaCalculus_mor : HSET2⟦lambdaFunctor LambdaCalculus,LambdaCalculus⟧ :=
+  alg_map _ (InitialObject lambdaFunctor_Initial).
+
+Let LambdaCalculus_alg : algebra_ob lambdaFunctor :=
+  InitialObject lambdaFunctor_Initial.
+
+(* This is needed to not make things too slow below *)
+Opaque LambdaCalculus_mor.
+
+Definition var_map : HSET2⟦LambdaCalculus,LambdaCalculus⟧.
+Proof.
+simple refine (tpair _ _ _).
+- intro x.
+  simple refine (_ ;; pr1 LambdaCalculus_mor x).
+  intro z; apply (inl z).
+- intros x y f; rewrite <- assoc.
+  apply pathsinv0.
+  eapply pathscomp0.
+  eapply maponpaths, pathsinv0.
+  apply (nat_trans_ax LambdaCalculus_mor x y f).
+  now apply funextsec; intro z; unfold compose; simpl.
+Defined.
+
+(* How to do this nicer? *)
+Definition prod2 (x y : HSET2) : HSET2.
+Proof.
+apply ProductsHSET2; [apply x | apply y].
+Defined.
+
+Definition app_map : HSET2⟦prod2 LambdaCalculus LambdaCalculus,LambdaCalculus⟧.
+Proof.
+simple refine (tpair _ _ _).
+- intros x.
+  simple refine (_ ;; pr1 LambdaCalculus_mor x).
+  intro z.
+  apply inr.
+  apply (inl z).
+- intros x y f; rewrite <- assoc.
+  apply pathsinv0.
+  eapply pathscomp0.
+  eapply maponpaths, pathsinv0.
+  apply (nat_trans_ax LambdaCalculus_mor x y f).
+  now apply funextsec; intro z; unfold compose; simpl.
+Defined.
+
+(* What is the target type? *)
+(* Definition lam_map : HSET2⟦LambdaCalculus,???⟧. *)
+(* Proof. *)
+(* simple refine (tpair _ _ _). *)
+(* - intros x. *)
+(*   simple refine (_ ;; pr1 LambdaCalculus_mor x). *)
+(*   intro z. *)
+(*   apply inr. *)
+(*   apply (inr z). *)
+(* - intros x y f; rewrite <- assoc. *)
+(*   apply pathsinv0. *)
+(*   eapply pathscomp0. *)
+(*   eapply maponpaths, pathsinv0. *)
+(*   apply (nat_trans_ax LambdaCalculus_mor x y f). *)
+(*   now apply funextsec; intro z; unfold compose; simpl. *)
+(* Defined. *)
 
 End lambdacalculus.

--- a/UniMath/CategoryTheory/lambdacalculus.v
+++ b/UniMath/CategoryTheory/lambdacalculus.v
@@ -78,7 +78,7 @@ Local Notation "'_' 'o' 'option'" :=
       has_homsets_HSET has_homsets_HSET cats_LimsHSET) (at level 0).
 
 Definition lambdaOmegaFunctor : omega_cocont_functor HSET2 HSET2 :=
-  Id + (Id * Id + _ o option).
+  ' (functor_identity HSET) + (Id * Id + _ o option).
 
 Let lambdaFunctor : functor HSET2 HSET2 := pr1 lambdaOmegaFunctor.
 Let is_omega_cocont_lambdaFunctor : is_omega_cocont lambdaFunctor :=
@@ -150,30 +150,31 @@ apply (colimAlgInitial _ _ _ is_omega_cocont_lambdaFunctor InitialHSET2).
 apply ColimsFunctorCategory; apply ColimsHSET.
 Defined.
 
-Definition LambdaCalculus : HSET2 :=
+Definition LC : HSET2 :=
   alg_carrier _ (InitialObject lambdaFunctor_Initial).
 
-Let LambdaCalculus_mor : HSET2⟦lambdaFunctor LambdaCalculus,LambdaCalculus⟧ :=
+Let LC_mor : HSET2⟦lambdaFunctor LC,LC⟧ :=
   alg_map _ (InitialObject lambdaFunctor_Initial).
 
-Let LambdaCalculus_alg : algebra_ob lambdaFunctor :=
+Let LC_alg : algebra_ob lambdaFunctor :=
   InitialObject lambdaFunctor_Initial.
 
 (* This is needed to not make things too slow below *)
-Opaque LambdaCalculus_mor.
+(* Opaque LC_mor. *)
 
-Definition var_map : HSET2⟦LambdaCalculus,LambdaCalculus⟧.
+Definition var_map : HSET2⟦functor_identity HSET,LC⟧.
 Proof.
-simple refine (tpair _ _ _).
-- intro x.
-  simple refine (_ ;; pr1 LambdaCalculus_mor x).
-  intro z; apply (inl z).
-- intros x y f; rewrite <- assoc.
-  apply pathsinv0.
-  eapply pathscomp0.
-  eapply maponpaths, pathsinv0.
-  apply (nat_trans_ax LambdaCalculus_mor x y f).
-  now apply funextsec; intro z; unfold compose; simpl.
+apply (CoproductIn1 HSET2 _ ;; LC_mor).
+(* simple refine (tpair _ _ _). *)
+(* - intro x. *)
+(*   simple refine (_ ;; pr1 LC_mor x). *)
+(*   intro z; apply (inl z). *)
+(* - intros x y f; rewrite <- assoc. *)
+(*   apply pathsinv0. *)
+(*   eapply pathscomp0. *)
+(*   eapply maponpaths, pathsinv0. *)
+(*   apply (nat_trans_ax LC_mor x y f). *)
+(*   now apply funextsec; intro z; unfold compose; simpl. *)
 Defined.
 
 (* How to do this nicer? *)
@@ -182,28 +183,38 @@ Proof.
 apply ProductsHSET2; [apply x | apply y].
 Defined.
 
-Definition app_map : HSET2⟦prod2 LambdaCalculus LambdaCalculus,LambdaCalculus⟧.
+Definition app_map : HSET2⟦prod2 LC LC,LC⟧.
 Proof.
-simple refine (tpair _ _ _).
-- intros x.
-  simple refine (_ ;; pr1 LambdaCalculus_mor x).
-  intro z.
-  apply inr.
-  apply (inl z).
-- intros x y f; rewrite <- assoc.
-  apply pathsinv0.
-  eapply pathscomp0.
-  eapply maponpaths, pathsinv0.
-  apply (nat_trans_ax LambdaCalculus_mor x y f).
-  now apply funextsec; intro z; unfold compose; simpl.
-Defined.
-
-(* What is the target type? *)
-(* Definition lam_map : HSET2⟦LambdaCalculus,???⟧. *)
-(* Proof. *)
+apply (CoproductIn1 HSET2 _ ;; CoproductIn2 HSET2 _ ;; LC_mor).
 (* simple refine (tpair _ _ _). *)
 (* - intros x. *)
-(*   simple refine (_ ;; pr1 LambdaCalculus_mor x). *)
+(*   simple refine (_ ;; pr1 LC_mor x). *)
+(*   intro z. *)
+(*   apply inr. *)
+(*   apply (inl z). *)
+(* - intros x y f; rewrite <- assoc. *)
+(*   apply pathsinv0. *)
+(*   eapply pathscomp0. *)
+(*   eapply maponpaths, pathsinv0. *)
+(*   apply (nat_trans_ax LC_mor x y f). *)
+(*   now apply funextsec; intro z; unfold compose; simpl. *)
+Defined.
+
+Definition app_map' (x : HSET) :
+  HSET⟦(pr1 LC x × pr1 LC x)%set,pr1 LC x⟧.
+Proof.
+apply app_map.
+Defined.
+
+Let optionLC := (pre_composition_functor _ _ _ has_homsets_HSET _
+                  (option_functor HSET CoproductsHSET TerminalHSET) LC).
+
+Definition lam_map : HSET2⟦optionLC,LC⟧.
+Proof.
+apply (CoproductIn2 HSET2 _ ;; CoproductIn2 HSET2 _ ;; LC_mor).
+(* simple refine (tpair _ _ _). *)
+(* - intros x. *)
+(*   simple refine (_ ;; pr1 LC_mor x). *)
 (*   intro z. *)
 (*   apply inr. *)
 (*   apply (inr z). *)
@@ -211,8 +222,8 @@ Defined.
 (*   apply pathsinv0. *)
 (*   eapply pathscomp0. *)
 (*   eapply maponpaths, pathsinv0. *)
-(*   apply (nat_trans_ax LambdaCalculus_mor x y f). *)
+(*   apply (nat_trans_ax LC_mor x y f). *)
 (*   now apply funextsec; intro z; unfold compose; simpl. *)
-(* Defined. *)
+Defined.
 
 End lambdacalculus.

--- a/UniMath/CategoryTheory/lambdacalculus.v
+++ b/UniMath/CategoryTheory/lambdacalculus.v
@@ -195,11 +195,11 @@ eapply pathscomp0.
 rewrite <- assoc.
 eapply maponpaths.
 apply CoproductIn1Commutes.
+Check (ProductOfArrows _ _ _ (foldr_map X fvar fapp flam) (foldr_map X fvar fapp flam) ).
 apply idpath.
 Defined.
 
 End lambdacalculus.
-
 
 
 (* Old version *)

--- a/UniMath/CategoryTheory/lambdacalculus.v
+++ b/UniMath/CategoryTheory/lambdacalculus.v
@@ -132,10 +132,37 @@ Defined.
 
 Definition foldr_map (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧)
   (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) :
-  algebra_mor _ LC_alg (mk_lambdaAlgebra X fvar fapp flam).
+  algebra_mor lambdaFunctor LC_alg (mk_lambdaAlgebra X fvar fapp flam).
 Proof.
 apply (InitialArrow lambdaFunctor_Initial (mk_lambdaAlgebra X fvar fapp flam)).
 Defined.
+
+Definition foldr_map' (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧)
+  (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) :
+   HSET2 ⟦ pr1 LC_alg, pr1 (mk_lambdaAlgebra X fvar fapp flam) ⟧.
+Proof.
+apply (foldr_map X fvar fapp flam).
+Defined.
+
+Lemma foldr_var (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧)
+  (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) :
+  CoproductIn1 _ _ ;; alg_map lambdaFunctor LC_alg ;; foldr_map X fvar fapp flam =
+  fvar.
+Proof.
+assert (F := maponpaths (fun x => CoproductIn1 _ _ ;; x)
+                        (algebra_mor_commutes _ _ _ (foldr_map X fvar fapp flam))).
+rewrite assoc in F.
+eapply pathscomp0.
+apply F.
+rewrite assoc.
+eapply pathscomp0.
+eapply cancel_postcomposition.
+apply CoproductOfArrowsIn1.
+(* Opaque foldr_map. *)
+(* simpl. *)
+admit.
+(* rewrite id_left *)
+Admitted.
 
 End lambdacalculus.
 

--- a/UniMath/CategoryTheory/lambdacalculus.v
+++ b/UniMath/CategoryTheory/lambdacalculus.v
@@ -32,14 +32,6 @@ Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
 Section lambdacalculus.
 
-Definition option_functor : [HSET,HSET,has_homsets_HSET].
-Proof.
-apply coproduct_functor.
-apply CoproductsHSET.
-apply (constant_functor _ _ unitHSET).
-apply functor_identity.
-Defined.
-
 (* TODO: package omega cocont functors *)
 Definition LambdaFunctor : functor [HSET,HSET,has_homsets_HSET] [HSET,HSET,has_homsets_HSET].
 Proof.
@@ -54,7 +46,8 @@ eapply coproduct_of_functors.
     apply binproduct_functor.
     apply (Products_functor_precat _ _ ProductsHSET).
 (* lam *)
-apply (pre_composition_functor _ _ _ _ _ option_functor).
+apply (pre_composition_functor _ _ _ has_homsets_HSET _
+         (option_functor _ CoproductsHSET TerminalHSET)).
 Defined.
 
 (* Bad approach *)

--- a/UniMath/CategoryTheory/limits/FunctorsPointwiseCoproduct.v
+++ b/UniMath/CategoryTheory/limits/FunctorsPointwiseCoproduct.v
@@ -105,9 +105,11 @@ Proof.
 *)
 Qed.
 
-Definition coproduct_functor : functor C D := tpair _ _ is_functor_coproduct_functor_data.
+Definition coproduct_functor : functor C D :=
+  tpair _ _ is_functor_coproduct_functor_data.
 
-Lemma coproduct_of_functors_eq_coproduct_functor : coproduct_of_functors HD F G = coproduct_functor.
+Lemma coproduct_of_functors_eq_coproduct_functor :
+  coproduct_of_functors HD F G = coproduct_functor.
 Proof.
 now apply (functor_eq _ _ hsD).
 Defined.

--- a/UniMath/CategoryTheory/limits/FunctorsPointwiseCoproduct.v
+++ b/UniMath/CategoryTheory/limits/FunctorsPointwiseCoproduct.v
@@ -276,7 +276,6 @@ Defined.
 
 End coproduct_functor.
 
-
 Definition Coproducts_functor_precat : Coproducts [C, D, hsD].
 Proof.
   intros F G.
@@ -284,3 +283,17 @@ Proof.
 Defined.
 
 End def_functor_pointwise_coprod.
+
+Section option_functor.
+
+Require Import UniMath.CategoryTheory.limits.terminal.
+
+Variables (C : precategory) (hsC : has_homsets C) (CC : Coproducts C).
+
+Variable terminal : Terminal C.
+Let one : C :=  @TerminalObject C terminal.
+
+Definition option_functor : functor C C :=
+  coproduct_functor C C CC (constant_functor _ _ one) (functor_identity C).
+
+End option_functor.

--- a/UniMath/CategoryTheory/limits/FunctorsPointwiseCoproduct.v
+++ b/UniMath/CategoryTheory/limits/FunctorsPointwiseCoproduct.v
@@ -62,7 +62,6 @@ Proof.
   exact coproduct_functor_mor.
 Defined.
 
-
 Lemma is_functor_coproduct_functor_data : is_functor coproduct_functor_data.
 Proof.
   split; simpl; intros.
@@ -107,6 +106,11 @@ Proof.
 Qed.
 
 Definition coproduct_functor : functor C D := tpair _ _ is_functor_coproduct_functor_data.
+
+Lemma coproduct_of_functors_eq_coproduct_functor : coproduct_of_functors HD F G = coproduct_functor.
+Proof.
+now apply (functor_eq _ _ hsD).
+Defined.
 
 Definition coproduct_nat_trans_in1_data : ∀ c, F c --> coproduct_functor c
   := λ c : C, CoproductIn1 _ (HD (F c) (G c)).

--- a/UniMath/CategoryTheory/limits/FunctorsPointwiseProduct.v
+++ b/UniMath/CategoryTheory/limits/FunctorsPointwiseProduct.v
@@ -84,7 +84,14 @@ Proof.
     apply ProductOfArrows_comp.
 Qed.
 
-Definition product_functor : functor C D := tpair _ _ is_functor_product_functor_data.
+Definition product_functor : functor C D :=
+  tpair _ _ is_functor_product_functor_data.
+
+Lemma product_of_functors_eq_product_functor :
+  product_of_functors HD F G = product_functor.
+Proof.
+now apply (functor_eq _ _ hsD).
+Defined.
 
 Definition product_nat_trans_pr1_data : ∀ c, product_functor c --> F c
   := λ c : C, ProductPr1 _ (HD (F c) (G c)).

--- a/UniMath/CategoryTheory/limits/coproducts.v
+++ b/UniMath/CategoryTheory/limits/coproducts.v
@@ -600,10 +600,13 @@ abstract (split;
   | now intros x y z f g; simpl; rewrite CoproductOfArrows_comp ]).
 Defined.
 
-(* Defines the sum of two functors by:
+(* Defines the copropuct of two functors by:
     x -> (x,x) -> (F x,G x) -> F x + G x
+
+  For a direct and equal definition see FunctorsPointwiseCoproduct.v
+
 *)
-Definition sum_of_functors {C D : precategory} (HD : Coproducts D)
+Definition coproduct_of_functors {C D : precategory} (HD : Coproducts D)
   (F G : functor C D) : functor C D :=
   functor_composite (delta_functor C)
      (functor_composite (pair_functor F G) (bincoproduct_functor HD)).

--- a/UniMath/CategoryTheory/limits/products.v
+++ b/UniMath/CategoryTheory/limits/products.v
@@ -309,6 +309,9 @@ End binproduct_functor.
 
 (* Defines the product of two functors by:
     x -> (x,x) -> (F x,G x) -> F x * G x
+
+  For a direct definition see FunctorsPointwiseProduct.v
+
 *)
 Definition product_of_functors {C D : precategory} (HD : Products D)
   (F G : functor C D) : functor C D :=

--- a/UniMath/CategoryTheory/lists.v
+++ b/UniMath/CategoryTheory/lists.v
@@ -51,19 +51,13 @@ Let List_mor : HSET⟦listFunctor List,List⟧ :=
 Let List_alg : algebra_ob listFunctor :=
   InitialObject listFunctor_Initial.
 
-Definition nil_map : HSET⟦unitHSET,List⟧.
-Proof.
-simpl; intro x.
-apply List_mor, inl, x.
-Defined.
+Definition nil_map : HSET⟦unitHSET,List⟧ :=
+  CoproductIn1 HSET _ ;; List_mor.
 
 Definition nil : pr1 List := nil_map tt.
 
-Definition cons_map : HSET⟦(A × List)%set,List⟧.
-Proof.
-intros xs.
-apply List_mor, (inr xs).
-Defined.
+Definition cons_map : HSET⟦(A × List)%set,List⟧ :=
+  CoproductIn2 HSET _ ;; List_mor.
 
 Definition cons : pr1 A × pr1 List -> pr1 List := cons_map.
 

--- a/UniMath/CategoryTheory/lists.v
+++ b/UniMath/CategoryTheory/lists.v
@@ -108,7 +108,6 @@ assert (F := maponpaths (fun x => CoproductIn2 _ _ ;; x)
                         (algebra_mor_commutes _ _ _ (foldr_map X x f))).
 assert (Fal := toforallpaths _ _ _ F (a,,l)).
 clear F.
-(* apply Fal. *) (* This doesn't work here. why? *)
 unfold compose in Fal.
 simpl in Fal.
 apply Fal.

--- a/UniMath/SubstitutionSystems/.package/files
+++ b/UniMath/SubstitutionSystems/.package/files
@@ -10,3 +10,4 @@ GenMendlerIteration.v
 Notation.v
 SubstitutionSystems_Summary.v
 LamHSET.v
+SigToMonad.v

--- a/UniMath/SubstitutionSystems/.package/files
+++ b/UniMath/SubstitutionSystems/.package/files
@@ -8,3 +8,4 @@ LamSignature.v
 GenMendlerIteration.v
 Notation.v
 SubstitutionSystems_Summary.v
+LamHSET.v

--- a/UniMath/SubstitutionSystems/.package/files
+++ b/UniMath/SubstitutionSystems/.package/files
@@ -1,4 +1,5 @@
 SumOfSignatures.v
+ProductOfSignatures.v
 SubstitutionSystems.v
 Signatures.v
 MonadsFromSubstitutionSystems.v

--- a/UniMath/SubstitutionSystems/.package/files
+++ b/UniMath/SubstitutionSystems/.package/files
@@ -11,3 +11,4 @@ Notation.v
 SubstitutionSystems_Summary.v
 LamHSET.v
 SigToMonad.v
+LamFromSig.v

--- a/UniMath/SubstitutionSystems/Lam.v
+++ b/UniMath/SubstitutionSystems/Lam.v
@@ -53,7 +53,54 @@ Arguments θ_target {_ _} _ .
 Arguments θ_Strength1 {_ _ _} _ .
 Arguments θ_Strength2 {_ _ _} _ .
 
+Section set_instances.
 
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.exponentials.
+Require Import UniMath.CategoryTheory.category_hset.
+Require Import UniMath.CategoryTheory.category_hset_structures.
+Require Import UniMath.CategoryTheory.chains.
+Require Import UniMath.CategoryTheory.polynomialfunctors.
+
+Let Lam_S : Signature _ _ := Lam_Sig HSET has_homsets_HSET TerminalHSET CoproductsHSET ProductsHSET.
+
+Local Notation "'EndHSET'":= ([HSET, HSET, has_homsets_HSET]) .
+
+Let hsEndC : has_homsets EndHSET := functor_category_has_homsets _ _ has_homsets_HSET.
+
+Lemma Lam_Initial_HSET : Initial (precategory_FunctorAlg (Id_H _ _ CoproductsHSET Lam_S) hsEndC).
+Proof.
+use colimAlgInitial.
+- unfold Id_H, Const_plus_H.
+  apply is_omega_cocont_sum_of_functors.
+  + apply (Products_functor_precat _ _ ProductsHSET).
+  + apply functor_category_has_homsets.
+  + apply functor_category_has_homsets.
+  + apply is_omega_cocont_constant_functor; apply functor_category_has_homsets.
+  + apply is_omega_cocont_Lam.
+    * apply (has_exponentials_functor_HSET _ has_homsets_HSET).
+    * apply cats_LimsHSET.
+- admit.
+- apply ColimsFunctorCategory; apply ColimsHSET.
+Admitted.
+
+Lemma KanExt_HSET : ∀ Z : precategory_Ptd HSET has_homsets_HSET,
+   RightKanExtension.GlobalRightKanExtensionExists HSET HSET
+     (U Z) HSET has_homsets_HSET has_homsets_HSET.
+Proof.
+intro Z.
+apply RightKanExtension_from_limits.
+apply cats_LimsHSET.
+Defined.
+
+Definition LamHSS_Initial_HSET : Initial (hss_precategory CoproductsHSET Lam_S).
+Proof.
+  apply InitialHSS.
+  - apply KanExt_HSET.
+  - apply Lam_Initial_HSET.
+Defined.
+
+End set_instances.
 
 Section Lambda.
 

--- a/UniMath/SubstitutionSystems/Lam.v
+++ b/UniMath/SubstitutionSystems/Lam.v
@@ -53,55 +53,6 @@ Arguments θ_target {_ _} _ .
 Arguments θ_Strength1 {_ _ _} _ .
 Arguments θ_Strength2 {_ _ _} _ .
 
-Section set_instances.
-
-Require Import UniMath.CategoryTheory.limits.graphs.colimits.
-Require Import UniMath.CategoryTheory.exponentials.
-Require Import UniMath.CategoryTheory.category_hset.
-Require Import UniMath.CategoryTheory.category_hset_structures.
-Require Import UniMath.CategoryTheory.chains.
-Require Import UniMath.CategoryTheory.polynomialfunctors.
-
-Let Lam_S : Signature _ _ := Lam_Sig HSET has_homsets_HSET TerminalHSET CoproductsHSET ProductsHSET.
-
-Local Notation "'EndHSET'":= ([HSET, HSET, has_homsets_HSET]) .
-
-Let hsEndC : has_homsets EndHSET := functor_category_has_homsets _ _ has_homsets_HSET.
-
-Lemma Lam_Initial_HSET : Initial (precategory_FunctorAlg (Id_H _ _ CoproductsHSET Lam_S) hsEndC).
-Proof.
-use colimAlgInitial.
-- unfold Id_H, Const_plus_H.
-  apply is_omega_cocont_sum_of_functors.
-  + apply (Products_functor_precat _ _ ProductsHSET).
-  + apply functor_category_has_homsets.
-  + apply functor_category_has_homsets.
-  + apply is_omega_cocont_constant_functor; apply functor_category_has_homsets.
-  + apply is_omega_cocont_Lam.
-    * apply (has_exponentials_functor_HSET _ has_homsets_HSET).
-    * apply cats_LimsHSET.
-- apply (Initial_functor_precat _ _ InitialHSET).
-- apply ColimsFunctorCategory; apply ColimsHSET.
-Defined.
-
-Lemma KanExt_HSET : ∀ Z : precategory_Ptd HSET has_homsets_HSET,
-   RightKanExtension.GlobalRightKanExtensionExists HSET HSET
-     (U Z) HSET has_homsets_HSET has_homsets_HSET.
-Proof.
-intro Z.
-apply RightKanExtension_from_limits.
-apply cats_LimsHSET.
-Defined.
-
-Definition LamHSS_Initial_HSET : Initial (hss_precategory CoproductsHSET Lam_S).
-Proof.
-  apply InitialHSS.
-  - apply KanExt_HSET.
-  - apply Lam_Initial_HSET.
-Defined.
-
-End set_instances.
-
 Section Lambda.
 
 Variable C : precategory.

--- a/UniMath/SubstitutionSystems/Lam.v
+++ b/UniMath/SubstitutionSystems/Lam.v
@@ -80,9 +80,9 @@ use colimAlgInitial.
   + apply is_omega_cocont_Lam.
     * apply (has_exponentials_functor_HSET _ has_homsets_HSET).
     * apply cats_LimsHSET.
-- admit.
+- apply (Initial_functor_precat _ _ InitialHSET).
 - apply ColimsFunctorCategory; apply ColimsHSET.
-Admitted.
+Defined.
 
 Lemma KanExt_HSET : ∀ Z : precategory_Ptd HSET has_homsets_HSET,
    RightKanExtension.GlobalRightKanExtensionExists HSET HSET

--- a/UniMath/SubstitutionSystems/LamFromSig.v
+++ b/UniMath/SubstitutionSystems/LamFromSig.v
@@ -1,0 +1,62 @@
+(**
+
+Obtain the lambda calculus from the signature [[0,0],[1]]
+
+Written by: Anders Mörtberg, 2016
+
+*)
+
+Require Import UniMath.Foundations.Basics.PartD.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.SubstitutionSystems.Signatures.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseCoproduct.
+Require Import UniMath.CategoryTheory.Monads.
+Require Import UniMath.SubstitutionSystems.SumOfSignatures.
+Require Import UniMath.SubstitutionSystems.ProductOfSignatures.
+Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
+Require Import UniMath.SubstitutionSystems.LamSignature.
+Require Import UniMath.SubstitutionSystems.Lam.
+Require Import UniMath.SubstitutionSystems.Notation.
+Require Import UniMath.SubstitutionSystems.SigToMonad.
+
+Require Import UniMath.CategoryTheory.category_hset.
+Require Import UniMath.CategoryTheory.category_hset_structures.
+Require Import UniMath.CategoryTheory.chains.
+Require Import UniMath.CategoryTheory.cocontfunctors.
+Require Import UniMath.CategoryTheory.lists.
+
+Section Lam.
+
+Infix "::" := (cons_list nat).
+Notation "[]" := (nil_list nat) (at level 0, format "[]").
+
+(* The signature of the lambda calculus: [[0,0],[1]] *)
+Definition LamSig : Sig := cons_list (list nat) (0 :: 0 :: []) (cons_list (list nat) (1 :: []) (nil_list (list nat))).
+
+Local Notation "'Id'" := (functor_identity _).
+
+Local Notation "F * G" := (H HSET has_homsets_HSET ProductsHSET F G).
+
+Local Notation "F + G" := (SumOfSignatures.H _ _ CoproductsHSET F G).
+Local Notation "'_' 'o' 'option'" :=
+  (ℓ (option_functor HSET CoproductsHSET TerminalHSET)) (at level 0).
+
+Eval cbn in pr1 (SigToSignature LamSig).
+(* = Id * Id + _ o option *)
+(*      : functor [HSET, HSET, has_homsets_HSET] *)
+(*          [HSET, HSET, has_homsets_HSET] *)
+
+Require Import UniMath.SubstitutionSystems.LamHSET.
+
+Let Lam_S : Signature HSET has_homsets_HSET :=
+  Lam_Sig HSET has_homsets_HSET TerminalHSET CoproductsHSET ProductsHSET.
+
+Goal (pr1 Lam_S = pr1 (SigToSignature LamSig)).
+now apply idpath.
+Abort.
+
+Definition LamMonad : Monad HSET := SigToMonad LamSig.
+
+End Lam.

--- a/UniMath/SubstitutionSystems/LamFromSig.v
+++ b/UniMath/SubstitutionSystems/LamFromSig.v
@@ -7,12 +7,28 @@ Written by: Anders Mörtberg, 2016
 *)
 
 Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Sets.
 
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
-Require Import UniMath.SubstitutionSystems.Signatures.
+Require Import UniMath.CategoryTheory.category_hset.
+Require Import UniMath.CategoryTheory.category_hset_structures.
+Require Import UniMath.CategoryTheory.chains.
+Require Import UniMath.CategoryTheory.cocontfunctors.
+Require Import UniMath.CategoryTheory.lists.
+Require Import UniMath.CategoryTheory.limits.initial.
+Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.limits.coproducts.
+Require Import UniMath.CategoryTheory.limits.terminal.
+Require Import UniMath.CategoryTheory.limits.cats.limits.
+Require Import UniMath.CategoryTheory.FunctorAlgebras.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseProduct.
 Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseCoproduct.
+Require Import UniMath.CategoryTheory.exponentials.
+Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.Monads.
+
+Require Import UniMath.SubstitutionSystems.Signatures.
 Require Import UniMath.SubstitutionSystems.SumOfSignatures.
 Require Import UniMath.SubstitutionSystems.ProductOfSignatures.
 Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
@@ -20,17 +36,39 @@ Require Import UniMath.SubstitutionSystems.LamSignature.
 Require Import UniMath.SubstitutionSystems.Lam.
 Require Import UniMath.SubstitutionSystems.Notation.
 Require Import UniMath.SubstitutionSystems.SigToMonad.
-
-Require Import UniMath.CategoryTheory.category_hset.
-Require Import UniMath.CategoryTheory.category_hset_structures.
-Require Import UniMath.CategoryTheory.chains.
-Require Import UniMath.CategoryTheory.cocontfunctors.
-Require Import UniMath.CategoryTheory.lists.
+Require Import UniMath.SubstitutionSystems.LiftingInitial.
 
 Section Lam.
 
 Infix "::" := (cons_list nat).
 Notation "[]" := (nil_list nat) (at level 0, format "[]").
+
+Local Notation "'HSET2'":= [HSET, HSET, has_homsets_HSET].
+
+Local Definition has_homsets_HSET2 : has_homsets HSET2.
+Proof.
+apply functor_category_has_homsets.
+Defined.
+
+Local Definition ProductsHSET2 : Products HSET2.
+Proof.
+apply (Products_functor_precat _ _ ProductsHSET).
+Defined.
+
+Local Definition CoproductsHSET2 : Coproducts HSET2.
+Proof.
+apply (Coproducts_functor_precat _ _ CoproductsHSET).
+Defined.
+
+Local Lemma has_exponentials_HSET2 : has_exponentials ProductsHSET2.
+Proof.
+apply has_exponentials_functor_HSET, has_homsets_HSET.
+Defined.
+
+Local Lemma InitialHSET2 : Initial HSET2.
+Proof.
+apply (Initial_functor_precat _ _ InitialHSET).
+Defined.
 
 (* The signature of the lambda calculus: [[0,0],[1]] *)
 Definition LamSig : Sig :=
@@ -59,6 +97,68 @@ Goal (pr1 Lam_S = pr1 (SigToSignature LamSig)).
 now apply idpath.
 Abort.
 
+Definition LamSignature : Signature HSET has_homsets_HSET := SigToSignature LamSig.
+Definition LamFunctor : functor HSET2 HSET2 := Id_H _ _ CoproductsHSET LamSignature.
+
 Definition LamMonad : Monad HSET := SigToMonad LamSig.
+
+(* Definition lambdaOmegaFunctor : omega_cocont_functor HSET2 HSET2 := *)
+(*   '(functor_identity HSET) + (Id * Id + _ o option). *)
+
+(* Let lambdaFunctor : functor HSET2 HSET2 := pr1 LamSignature. *)
+(* Let is_omega_cocont_lambdaFunctor : is_omega_cocont lambdaFunctor := *)
+(*   pr2 lambdaOmegaFunctor. *)
+
+Lemma lambdaFunctor_Initial :
+   Initial (FunctorAlg LamFunctor has_homsets_HSET2).
+Proof.
+apply (SigInitial LamSig).
+Defined.
+
+Definition LC : HSET2 :=
+  alg_carrier _ (InitialObject lambdaFunctor_Initial).
+
+Let LC_mor : HSET2⟦LamFunctor LC,LC⟧ :=
+  alg_map _ (InitialObject lambdaFunctor_Initial).
+
+Let LC_alg : algebra_ob LamFunctor :=
+  InitialObject lambdaFunctor_Initial.
+
+Definition var_map : HSET2⟦functor_identity HSET,LC⟧ :=
+  CoproductIn1 HSET2 _ ;; LC_mor.
+
+(* How to do this nicer? *)
+Definition prod2 (x y : HSET2) : HSET2.
+Proof.
+apply ProductsHSET2; [apply x | apply y].
+Defined.
+
+Definition app_map : HSET2⟦prod2 LC LC,LC⟧ :=
+  CoproductIn1 HSET2 _ ;; CoproductIn2 HSET2 _ ;; LC_mor.
+
+Definition app_map' (x : HSET) : HSET⟦(pr1 LC x × pr1 LC x)%set,pr1 LC x⟧.
+Proof.
+apply app_map.
+Defined.
+
+Let precomp_option X := (pre_composition_functor _ _ HSET has_homsets_HSET has_homsets_HSET
+                  (option_functor HSET CoproductsHSET TerminalHSET) X).
+
+Definition lam_map : HSET2⟦precomp_option LC,LC⟧ :=
+  CoproductIn2 HSET2 _ ;; CoproductIn2 HSET2 _ ;; LC_mor.
+
+Definition mk_lambdaAlgebra (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧)
+  (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) : algebra_ob LamFunctor.
+Proof.
+apply (tpair _ X).
+simple refine (CoproductArrow _ _ fvar (CoproductArrow _ _ fapp flam)).
+Defined.
+
+Definition foldr_map (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧)
+  (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) :
+  algebra_mor _ LC_alg (mk_lambdaAlgebra X fvar fapp flam).
+Proof.
+apply (InitialArrow lambdaFunctor_Initial (mk_lambdaAlgebra X fvar fapp flam)).
+Defined.
 
 End Lam.

--- a/UniMath/SubstitutionSystems/LamFromSig.v
+++ b/UniMath/SubstitutionSystems/LamFromSig.v
@@ -33,7 +33,9 @@ Infix "::" := (cons_list nat).
 Notation "[]" := (nil_list nat) (at level 0, format "[]").
 
 (* The signature of the lambda calculus: [[0,0],[1]] *)
-Definition LamSig : Sig := cons_list (list nat) (0 :: 0 :: []) (cons_list (list nat) (1 :: []) (nil_list (list nat))).
+Definition LamSig : Sig :=
+  cons_list (list nat) (0 :: 0 :: [])
+   (cons_list (list nat) (1 :: []) (nil_list (list nat))).
 
 Local Notation "'Id'" := (functor_identity _).
 

--- a/UniMath/SubstitutionSystems/LamHSET.v
+++ b/UniMath/SubstitutionSystems/LamHSET.v
@@ -1,0 +1,49 @@
+
+Section set_instances.
+
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.exponentials.
+Require Import UniMath.CategoryTheory.category_hset.
+Require Import UniMath.CategoryTheory.category_hset_structures.
+Require Import UniMath.CategoryTheory.chains.
+Require Import UniMath.CategoryTheory.polynomialfunctors.
+
+Let Lam_S : Signature _ _ := Lam_Sig HSET has_homsets_HSET TerminalHSET CoproductsHSET ProductsHSET.
+
+Local Notation "'EndHSET'":= ([HSET, HSET, has_homsets_HSET]) .
+
+Let hsEndC : has_homsets EndHSET := functor_category_has_homsets _ _ has_homsets_HSET.
+
+Lemma Lam_Initial_HSET : Initial (precategory_FunctorAlg (Id_H _ _ CoproductsHSET Lam_S) hsEndC).
+Proof.
+use colimAlgInitial.
+- unfold Id_H, Const_plus_H.
+  apply is_omega_cocont_sum_of_functors.
+  + apply (Products_functor_precat _ _ ProductsHSET).
+  + apply functor_category_has_homsets.
+  + apply functor_category_has_homsets.
+  + apply is_omega_cocont_constant_functor; apply functor_category_has_homsets.
+  + apply is_omega_cocont_Lam.
+    * apply (has_exponentials_functor_HSET _ has_homsets_HSET).
+    * apply cats_LimsHSET.
+- apply (Initial_functor_precat _ _ InitialHSET).
+- apply ColimsFunctorCategory; apply ColimsHSET.
+Defined.
+
+Lemma KanExt_HSET : ∀ Z : precategory_Ptd HSET has_homsets_HSET,
+   RightKanExtension.GlobalRightKanExtensionExists HSET HSET
+     (U Z) HSET has_homsets_HSET has_homsets_HSET.
+Proof.
+intro Z.
+apply RightKanExtension_from_limits.
+apply cats_LimsHSET.
+Defined.
+
+Definition LamHSS_Initial_HSET : Initial (hss_precategory CoproductsHSET Lam_S).
+Proof.
+  apply InitialHSS.
+  - apply KanExt_HSET.
+  - apply Lam_Initial_HSET.
+Defined.
+
+End set_instances.

--- a/UniMath/SubstitutionSystems/LamHSET.v
+++ b/UniMath/SubstitutionSystems/LamHSET.v
@@ -41,7 +41,8 @@ Require Import UniMath.CategoryTheory.cocontfunctors.
 
 Section LamHSET.
 
-Let Lam_S : Signature _ _ := Lam_Sig HSET has_homsets_HSET TerminalHSET CoproductsHSET ProductsHSET.
+Let Lam_S : Signature HSET has_homsets_HSET :=
+  Lam_Sig HSET has_homsets_HSET TerminalHSET CoproductsHSET ProductsHSET.
 
 Local Notation "'EndHSET'":= ([HSET, HSET, has_homsets_HSET]) .
 

--- a/UniMath/SubstitutionSystems/LamHSET.v
+++ b/UniMath/SubstitutionSystems/LamHSET.v
@@ -1,12 +1,44 @@
+(**
 
-Section set_instances.
+Instantiate the hypotheses of InitialHSS with Lam for HSET.
+
+Written by: Anders Mörtberg, 2016
+
+*)
+
+Require Import UniMath.Foundations.Basics.PartD.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.limits.coproducts.
+Require Import UniMath.CategoryTheory.limits.terminal.
+Require Import UniMath.CategoryTheory.limits.initial.
+Require Import UniMath.CategoryTheory.FunctorAlgebras.
+Require Import UniMath.CategoryTheory.PointedFunctors.
+Require Import UniMath.CategoryTheory.ProductPrecategory.
+Require Import UniMath.SubstitutionSystems.Signatures.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseCoproduct.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseProduct.
+Require Import UniMath.CategoryTheory.EndofunctorsMonoidal.
+Require Import UniMath.SubstitutionSystems.SumOfSignatures.
+Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
+Require Import UniMath.SubstitutionSystems.LamSignature.
+Require Import UniMath.SubstitutionSystems.Lam.
+Require Import UniMath.SubstitutionSystems.LiftingInitial.
+Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
+Require Import UniMath.SubstitutionSystems.Notation.
 
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.category_hset.
 Require Import UniMath.CategoryTheory.category_hset_structures.
 Require Import UniMath.CategoryTheory.chains.
-Require Import UniMath.CategoryTheory.polynomialfunctors.
+Require Import UniMath.CategoryTheory.cocontfunctors.
+
+Section set_instances.
 
 Let Lam_S : Signature _ _ := Lam_Sig HSET has_homsets_HSET TerminalHSET CoproductsHSET ProductsHSET.
 
@@ -18,7 +50,7 @@ Lemma Lam_Initial_HSET : Initial (precategory_FunctorAlg (Id_H _ _ CoproductsHSE
 Proof.
 use colimAlgInitial.
 - unfold Id_H, Const_plus_H.
-  apply is_omega_cocont_sum_of_functors.
+  apply is_omega_cocont_coproduct_functor.
   + apply (Products_functor_precat _ _ ProductsHSET).
   + apply functor_category_has_homsets.
   + apply functor_category_has_homsets.
@@ -41,9 +73,9 @@ Defined.
 
 Definition LamHSS_Initial_HSET : Initial (hss_precategory CoproductsHSET Lam_S).
 Proof.
-  apply InitialHSS.
-  - apply KanExt_HSET.
-  - apply Lam_Initial_HSET.
+apply InitialHSS.
+- apply KanExt_HSET.
+- apply Lam_Initial_HSET.
 Defined.
 
 End set_instances.

--- a/UniMath/SubstitutionSystems/LamHSET.v
+++ b/UniMath/SubstitutionSystems/LamHSET.v
@@ -23,6 +23,7 @@ Require Import UniMath.SubstitutionSystems.Signatures.
 Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseCoproduct.
 Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseProduct.
 Require Import UniMath.CategoryTheory.EndofunctorsMonoidal.
+Require Import UniMath.CategoryTheory.Monads.
 Require Import UniMath.SubstitutionSystems.SumOfSignatures.
 Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.LamSignature.
@@ -38,7 +39,7 @@ Require Import UniMath.CategoryTheory.category_hset_structures.
 Require Import UniMath.CategoryTheory.chains.
 Require Import UniMath.CategoryTheory.cocontfunctors.
 
-Section set_instances.
+Section LamHSET.
 
 Let Lam_S : Signature _ _ := Lam_Sig HSET has_homsets_HSET TerminalHSET CoproductsHSET ProductsHSET.
 
@@ -78,4 +79,13 @@ apply InitialHSS.
 - apply Lam_Initial_HSET.
 Defined.
 
-End set_instances.
+Definition LamMonad : Monad HSET.
+Proof.
+use Monad_from_hss.
+- apply has_homsets_HSET.
+- apply CoproductsHSET.
+- apply Lam_S.
+- apply LamHSS_Initial_HSET.
+Defined.
+
+End LamHSET.

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -55,7 +55,8 @@ Variable CC : Coproducts C.
 Variable terminal : Terminal C.
 Let one : C :=  @TerminalObject C terminal.
 
-Definition square_functor := product_functor C C CP (functor_identity C) (functor_identity C).
+(* Definition square_functor := product_functor C C CP (functor_identity C) (functor_identity C). *)
+Definition square_functor := product_of_functors CP (functor_identity C) (functor_identity C).
 
 Definition option_functor: functor C C := coproduct_functor _ _ CC (constant_functor _ _  one) (functor_identity C).
 
@@ -87,72 +88,100 @@ Proof.
   exact CP.
 Defined.
 
+Require Import UniMath.CategoryTheory.chains.
+Require Import UniMath.CategoryTheory.polynomialfunctors.
+Require Import UniMath.CategoryTheory.exponentials.
+
+Lemma is_omega_cocont_App_H (hE : has_exponentials (Products_functor_precat C C CP hs)) :
+  is_omega_cocont App_H.
+Proof.
+unfold App_H, square_functor.
+apply is_omega_cocont_product_of_functors.
+- apply (Products_functor_precat _ _ CP).
+- apply hE.
+- apply functor_category_has_homsets.
+- apply functor_category_has_homsets.
+- apply (is_omega_cocont_functor_identity _ (functor_category_has_homsets _ _ hs)).
+- apply (is_omega_cocont_functor_identity _ (functor_category_has_homsets _ _ hs)).
+Defined.
+
 (**
    [Abs_H (X) := X o option]
 *)
 
-Definition Abs_H_ob (X: EndC): functor C C := functor_composite (option_functor _ CC terminal) X.
+(* Definition Abs_H_ob (X: EndC): functor C C := functor_composite (option_functor _ CC terminal) X. *)
 
-(* works only with -type-in-type:
-Definition Abs_H_mor_nat_trans_data (X X': EndC)(α: X --> X'): ∀ c, Abs_H_ob X c --> Abs_H_ob X' c.
+(* (* works only with -type-in-type: *)
+(* Definition Abs_H_mor_nat_trans_data (X X': EndC)(α: X --> X'): ∀ c, Abs_H_ob X c --> Abs_H_ob X' c. *)
+(* Proof. *)
+(*   intro. *)
+(*   unfold Abs_H_ob. *)
+(*   red. simpl. apply α. *)
+(* Defined. *)
+(* *) *)
+
+(* Definition Abs_H_mor_nat_trans_data (X X': functor C C)(α: nat_trans X X'): ∀ c, Abs_H_ob X c --> Abs_H_ob X' c. *)
+(* Proof. *)
+(*   intro. *)
+(*   apply α. *)
+(* Defined. *)
+
+(* Lemma is_nat_trans_Abs_H_mor_nat_trans_data  (X X': EndC)(α: X --> X'): is_nat_trans _ _ (Abs_H_mor_nat_trans_data X X' α). *)
+(* Proof. *)
+(*   red. *)
+(*   intros c c' f. *)
+(*   destruct α as [α α_nat_trans]. *)
+(*   unfold Abs_H_mor_nat_trans_data, Abs_H_ob. *)
+(*   simpl. *)
+(*   apply α_nat_trans. *)
+(*  Qed. *)
+
+(* Definition Abs_H_mor (X X': EndC)(α: X --> X'): (Abs_H_ob X: ob EndC) --> Abs_H_ob X'. *)
+(* Proof. *)
+(*   exists (Abs_H_mor_nat_trans_data X X' α). *)
+(*   exact (is_nat_trans_Abs_H_mor_nat_trans_data X X' α). *)
+(* Defined. *)
+
+(* Definition Abs_H_functor_data: functor_data EndC EndC. *)
+(* Proof. *)
+(*   exists Abs_H_ob. *)
+(*   exact Abs_H_mor. *)
+(* Defined. *)
+
+(* Lemma is_functor_Abs_H_data: is_functor Abs_H_functor_data. *)
+(* Proof. *)
+(*   red. *)
+(*   split; red. *)
+(*   + intros X. *)
+(*     unfold Abs_H_functor_data. *)
+(*     simpl. *)
+(*     apply nat_trans_eq; try assumption. *)
+(*     intro c. *)
+(*     unfold Abs_H_mor. *)
+(*     simpl. *)
+(*     apply idpath. *)
+(*   + intros X X' X'' α β. *)
+(*     unfold Abs_H_functor_data. *)
+(*     simpl. *)
+(*     apply nat_trans_eq; try assumption. *)
+(*     intro c. *)
+(*     unfold Abs_H_mor. *)
+(*     simpl. *)
+(*     apply idpath. *)
+(* Qed. *)
+
+Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.limits.cats.limits.
+
+Definition Abs_H : functor [C, C, hs] [C, C, hs] :=
+ (* tpair _ _ is_functor_Abs_H_data. *)
+  pre_composition_functor _ _ _ hs _ (option_functor C CC terminal).
+
+Lemma is_omega_cocont_Abs_H (LC : Lims C) : is_omega_cocont Abs_H.
 Proof.
-  intro.
-  unfold Abs_H_ob.
-  red. simpl. apply α.
+unfold Abs_H.
+apply (is_omega_cocont_pre_composition_functor _ _ _ _ _ _ LC).
 Defined.
-*)
-
-Definition Abs_H_mor_nat_trans_data (X X': functor C C)(α: nat_trans X X'): ∀ c, Abs_H_ob X c --> Abs_H_ob X' c.
-Proof.
-  intro.
-  apply α.
-Defined.
-
-Lemma is_nat_trans_Abs_H_mor_nat_trans_data  (X X': EndC)(α: X --> X'): is_nat_trans _ _ (Abs_H_mor_nat_trans_data X X' α).
-Proof.
-  red.
-  intros c c' f.
-  destruct α as [α α_nat_trans].
-  unfold Abs_H_mor_nat_trans_data, Abs_H_ob.
-  simpl.
-  apply α_nat_trans.
- Qed.
-
-Definition Abs_H_mor (X X': EndC)(α: X --> X'): (Abs_H_ob X: ob EndC) --> Abs_H_ob X'.
-Proof.
-  exists (Abs_H_mor_nat_trans_data X X' α).
-  exact (is_nat_trans_Abs_H_mor_nat_trans_data X X' α).
-Defined.
-
-Definition Abs_H_functor_data: functor_data EndC EndC.
-Proof.
-  exists Abs_H_ob.
-  exact Abs_H_mor.
-Defined.
-
-Lemma is_functor_Abs_H_data: is_functor Abs_H_functor_data.
-Proof.
-  red.
-  split; red.
-  + intros X.
-    unfold Abs_H_functor_data.
-    simpl.
-    apply nat_trans_eq; try assumption.
-    intro c.
-    unfold Abs_H_mor.
-    simpl.
-    apply idpath.
-  + intros X X' X'' α β.
-    unfold Abs_H_functor_data.
-    simpl.
-    apply nat_trans_eq; try assumption.
-    intro c.
-    unfold Abs_H_mor.
-    simpl.
-    apply idpath.
-Qed.
-
-Definition Abs_H : functor [C, C, hs] [C, C, hs] := tpair _ _ is_functor_Abs_H_data.
 
 
 (**
@@ -647,12 +676,21 @@ Proof.
   + exact Flat_θ_strength2_int.
 Defined.
 
-
 Definition Lam_Sig: Signature C hs :=
   Sum_of_Signatures C hs CC App_Sig Abs_Sig.
 
+Lemma is_omega_cocont_Lam (hE : has_exponentials (Products_functor_precat C C CP hs)) (LC : Lims C) :
+  is_omega_cocont (Signature_Functor _ _ Lam_Sig).
+Proof.
+apply is_omega_cocont_sum_of_functors.
+- apply (Products_functor_precat _ _ CP).
+- apply functor_category_has_homsets.
+- apply functor_category_has_homsets.
+- apply (is_omega_cocont_App_H hE).
+- apply (is_omega_cocont_Abs_H LC).
+Defined.
+
 Definition LamE_Sig: Signature C hs :=
   Sum_of_Signatures C hs CC Lam_Sig Flat_Sig.
-
 
 End Lambda.

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -40,7 +40,6 @@ Require Import UniMath.CategoryTheory.EndofunctorsMonoidal.
 Require Import UniMath.SubstitutionSystems.SumOfSignatures.
 Require Import UniMath.SubstitutionSystems.Notation.
 
-
 Arguments θ_source {_ _} _ .
 Arguments θ_target {_ _} _ .
 Arguments θ_Strength1 {_ _ _} _ .
@@ -56,8 +55,6 @@ Variable terminal : Terminal C.
 Let one : C :=  @TerminalObject C terminal.
 
 Definition square_functor := product_functor C C CP (functor_identity C) (functor_identity C).
-(* Definition square_functor := product_of_functors CP (functor_identity C) (functor_identity C). *)
-
 Definition option_functor: functor C C := coproduct_functor _ _ CC (constant_functor _ _  one) (functor_identity C).
 
 End Preparations.
@@ -88,22 +85,22 @@ Proof.
   exact CP.
 Defined.
 
-(* Require Import UniMath.CategoryTheory.chains. *)
-(* Require Import UniMath.CategoryTheory.polynomialfunctors. *)
-(* Require Import UniMath.CategoryTheory.exponentials. *)
+Require Import UniMath.CategoryTheory.chains.
+Require Import UniMath.CategoryTheory.cocontfunctors.
+Require Import UniMath.CategoryTheory.exponentials.
 
-(* Lemma is_omega_cocont_App_H (hE : has_exponentials (Products_functor_precat C C CP hs)) : *)
-(*   is_omega_cocont App_H. *)
-(* Proof. *)
-(* unfold App_H, square_functor. *)
-(* apply is_omega_cocont_product_of_functors. *)
-(* - apply (Products_functor_precat _ _ CP). *)
-(* - apply hE. *)
-(* - apply functor_category_has_homsets. *)
-(* - apply functor_category_has_homsets. *)
-(* - apply (is_omega_cocont_functor_identity _ (functor_category_has_homsets _ _ hs)). *)
-(* - apply (is_omega_cocont_functor_identity _ (functor_category_has_homsets _ _ hs)). *)
-(* Defined. *)
+Lemma is_omega_cocont_App_H (hE : has_exponentials (Products_functor_precat C C CP hs)) :
+  is_omega_cocont App_H.
+Proof.
+unfold App_H, square_functor.
+apply is_omega_cocont_product_functor.
+- apply (Products_functor_precat _ _ CP).
+- apply hE.
+- apply functor_category_has_homsets.
+- apply functor_category_has_homsets.
+- apply (is_omega_cocont_functor_identity _ (functor_category_has_homsets _ _ hs)).
+- apply (is_omega_cocont_functor_identity _ (functor_category_has_homsets _ _ hs)).
+Defined.
 
 (**
    [Abs_H (X) := X o option]
@@ -177,11 +174,11 @@ Definition Abs_H : functor [C, C, hs] [C, C, hs] :=
  (* tpair _ _ is_functor_Abs_H_data. *)
   pre_composition_functor _ _ _ hs _ (option_functor C CC terminal).
 
-(* Lemma is_omega_cocont_Abs_H (LC : Lims C) : is_omega_cocont Abs_H. *)
-(* Proof. *)
-(* unfold Abs_H. *)
-(* apply (is_omega_cocont_pre_composition_functor _ _ _ _ _ _ LC). *)
-(* Defined. *)
+Lemma is_omega_cocont_Abs_H (LC : Lims C) : is_omega_cocont Abs_H.
+Proof.
+unfold Abs_H.
+apply (is_omega_cocont_pre_composition_functor _ _ _ _ _ _ LC).
+Defined.
 
 
 (**
@@ -679,16 +676,16 @@ Defined.
 Definition Lam_Sig: Signature C hs :=
   Sum_of_Signatures C hs CC App_Sig Abs_Sig.
 
-(* Lemma is_omega_cocont_Lam (hE : has_exponentials (Products_functor_precat C C CP hs)) (LC : Lims C) : *)
-(*   is_omega_cocont (Signature_Functor _ _ Lam_Sig). *)
-(* Proof. *)
-(* apply is_omega_cocont_sum_of_functors. *)
-(* - apply (Products_functor_precat _ _ CP). *)
-(* - apply functor_category_has_homsets. *)
-(* - apply functor_category_has_homsets. *)
-(* - apply (is_omega_cocont_App_H hE). *)
-(* - apply (is_omega_cocont_Abs_H LC). *)
-(* Defined. *)
+Lemma is_omega_cocont_Lam (hE : has_exponentials (Products_functor_precat C C CP hs)) (LC : Lims C) :
+  is_omega_cocont (Signature_Functor _ _ Lam_Sig).
+Proof.
+apply is_omega_cocont_coproduct_functor.
+- apply (Products_functor_precat _ _ CP).
+- apply functor_category_has_homsets.
+- apply functor_category_has_homsets.
+- apply (is_omega_cocont_App_H hE).
+- apply (is_omega_cocont_Abs_H LC).
+Defined.
 
 Definition LamE_Sig: Signature C hs :=
   Sum_of_Signatures C hs CC Lam_Sig Flat_Sig.

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -246,10 +246,10 @@ Proof.
   unfold App_θ_data.
   intros XZ XZ' αβ.
 (* the following only for better readability: *)
-  destruct XZ as [X Z];
-  destruct XZ' as [X' Z'];
-  destruct αβ as [α β];
-  simpl in *.
+  (* destruct XZ as [X Z]; *)
+  (* destruct XZ' as [X' Z']; *)
+  (* destruct αβ as [α β]; *)
+  (* simpl in *. *)
   apply nat_trans_eq; try assumption.
   intro c.
   simpl.

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -51,14 +51,10 @@ Variable C : precategory.
 Variable hs : has_homsets C.
 Variable CP : Products C.
 Variable CC : Coproducts C.
-Variable terminal : Terminal C.
-Let one : C :=  @TerminalObject C terminal.
 
 Definition square_functor := product_functor C C CP (functor_identity C) (functor_identity C).
-Definition option_functor: functor C C := coproduct_functor _ _ CC (constant_functor _ _  one) (functor_identity C).
 
 End Preparations.
-
 
 Section Lambda.
 

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -55,8 +55,8 @@ Variable CC : Coproducts C.
 Variable terminal : Terminal C.
 Let one : C :=  @TerminalObject C terminal.
 
-(* Definition square_functor := product_functor C C CP (functor_identity C) (functor_identity C). *)
-Definition square_functor := product_of_functors CP (functor_identity C) (functor_identity C).
+Definition square_functor := product_functor C C CP (functor_identity C) (functor_identity C).
+(* Definition square_functor := product_of_functors CP (functor_identity C) (functor_identity C). *)
 
 Definition option_functor: functor C C := coproduct_functor _ _ CC (constant_functor _ _  one) (functor_identity C).
 
@@ -88,22 +88,22 @@ Proof.
   exact CP.
 Defined.
 
-Require Import UniMath.CategoryTheory.chains.
-Require Import UniMath.CategoryTheory.polynomialfunctors.
-Require Import UniMath.CategoryTheory.exponentials.
+(* Require Import UniMath.CategoryTheory.chains. *)
+(* Require Import UniMath.CategoryTheory.polynomialfunctors. *)
+(* Require Import UniMath.CategoryTheory.exponentials. *)
 
-Lemma is_omega_cocont_App_H (hE : has_exponentials (Products_functor_precat C C CP hs)) :
-  is_omega_cocont App_H.
-Proof.
-unfold App_H, square_functor.
-apply is_omega_cocont_product_of_functors.
-- apply (Products_functor_precat _ _ CP).
-- apply hE.
-- apply functor_category_has_homsets.
-- apply functor_category_has_homsets.
-- apply (is_omega_cocont_functor_identity _ (functor_category_has_homsets _ _ hs)).
-- apply (is_omega_cocont_functor_identity _ (functor_category_has_homsets _ _ hs)).
-Defined.
+(* Lemma is_omega_cocont_App_H (hE : has_exponentials (Products_functor_precat C C CP hs)) : *)
+(*   is_omega_cocont App_H. *)
+(* Proof. *)
+(* unfold App_H, square_functor. *)
+(* apply is_omega_cocont_product_of_functors. *)
+(* - apply (Products_functor_precat _ _ CP). *)
+(* - apply hE. *)
+(* - apply functor_category_has_homsets. *)
+(* - apply functor_category_has_homsets. *)
+(* - apply (is_omega_cocont_functor_identity _ (functor_category_has_homsets _ _ hs)). *)
+(* - apply (is_omega_cocont_functor_identity _ (functor_category_has_homsets _ _ hs)). *)
+(* Defined. *)
 
 (**
    [Abs_H (X) := X o option]
@@ -177,11 +177,11 @@ Definition Abs_H : functor [C, C, hs] [C, C, hs] :=
  (* tpair _ _ is_functor_Abs_H_data. *)
   pre_composition_functor _ _ _ hs _ (option_functor C CC terminal).
 
-Lemma is_omega_cocont_Abs_H (LC : Lims C) : is_omega_cocont Abs_H.
-Proof.
-unfold Abs_H.
-apply (is_omega_cocont_pre_composition_functor _ _ _ _ _ _ LC).
-Defined.
+(* Lemma is_omega_cocont_Abs_H (LC : Lims C) : is_omega_cocont Abs_H. *)
+(* Proof. *)
+(* unfold Abs_H. *)
+(* apply (is_omega_cocont_pre_composition_functor _ _ _ _ _ _ LC). *)
+(* Defined. *)
 
 
 (**
@@ -679,16 +679,16 @@ Defined.
 Definition Lam_Sig: Signature C hs :=
   Sum_of_Signatures C hs CC App_Sig Abs_Sig.
 
-Lemma is_omega_cocont_Lam (hE : has_exponentials (Products_functor_precat C C CP hs)) (LC : Lims C) :
-  is_omega_cocont (Signature_Functor _ _ Lam_Sig).
-Proof.
-apply is_omega_cocont_sum_of_functors.
-- apply (Products_functor_precat _ _ CP).
-- apply functor_category_has_homsets.
-- apply functor_category_has_homsets.
-- apply (is_omega_cocont_App_H hE).
-- apply (is_omega_cocont_Abs_H LC).
-Defined.
+(* Lemma is_omega_cocont_Lam (hE : has_exponentials (Products_functor_precat C C CP hs)) (LC : Lims C) : *)
+(*   is_omega_cocont (Signature_Functor _ _ Lam_Sig). *)
+(* Proof. *)
+(* apply is_omega_cocont_sum_of_functors. *)
+(* - apply (Products_functor_precat _ _ CP). *)
+(* - apply functor_category_has_homsets. *)
+(* - apply functor_category_has_homsets. *)
+(* - apply (is_omega_cocont_App_H hE). *)
+(* - apply (is_omega_cocont_Abs_H LC). *)
+(* Defined. *)
 
 Definition LamE_Sig: Signature C hs :=
   Sum_of_Signatures C hs CC Lam_Sig Flat_Sig.

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -85,8 +85,8 @@ Variable H : Signature C hs.
 Let θ := theta H.
 
 Definition Const_plus_H (X : EndC) : functor EndC EndC
-  (* := coproduct_functor _ _ CPEndC (constant_functor _ _ X) H. *)
-  := sum_of_functors CPEndC (constant_functor _ _ X) H.
+  := coproduct_functor _ _ CPEndC (constant_functor _ _ X) H.
+  (* := sum_of_functors CPEndC (constant_functor _ _ X) H. *)
 
 Definition Id_H :  functor [C, C, hs] [C, C, hs]
  := Const_plus_H (functor_identity _ : EndC).

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -85,14 +85,14 @@ Variable H : Signature C hs.
 Let θ := theta H.
 
 Definition Const_plus_H (X : EndC) : functor EndC EndC
-  := coproduct_functor _ _ CPEndC
-                       (constant_functor _ _ X)
-                       H.
-
+  (* := coproduct_functor _ _ CPEndC (constant_functor _ _ X) H. *)
+  := sum_of_functors CPEndC (constant_functor _ _ X) H.
 
 Definition Id_H :  functor [C, C, hs] [C, C, hs]
  := Const_plus_H (functor_identity _ : EndC).
 
+(* Opaque Const_plus_H. *)
+(* Opaque Id_H. *)
 
 Let Alg : precategory := FunctorAlg Id_H hsEndC.
 
@@ -147,7 +147,8 @@ Proof.
   - rewrite functor_id.
     do 2 rewrite id_right.
     apply pathsinv0, id_left.
-Qed.
+Admitted.
+(* Qed. *)
 
 Definition aux_iso_1 (Z : Ptd)
   : EndEndC
@@ -191,7 +192,8 @@ Proof.
     do 2 rewrite id_right.
     apply pathsinv0.
     apply id_left.
-Qed.
+Admitted.
+(* Qed. *)
 
 Local Definition aux_iso_1_inv (Z: Ptd)
   : EndEndC
@@ -302,52 +304,53 @@ Lemma bracket_Thm15_ok_part1 (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg  InitAlg ⟧):
  # U f
  =
  # (pr1 (ℓ (U Z))) (η InitAlg) ;; ⦃f⦄.
-Proof.
-  apply nat_trans_eq; try (exact hs).
-  intro c.
-  assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))).
-  assert (h_eq' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
-               (((aux_iso_1_inv Z):(_⟶_)) _);; m) h_eq);
-  clear h_eq.
-  simpl in h_eq'.
-  assert (h_eq1' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
-               (CoproductIn1 EndC (CPEndC _ _));; m) h_eq');
-  clear h_eq'.
-  assert (h_eq1'_inst := nat_trans_eq_pointwise h_eq1' c);
-  clear h_eq1'.
-(* match goal right in the beginning in contrast with earlier approach - suggestion by Benedikt *)
-  match goal with |[ H1 : _  = ?f |- _ = _   ] =>
-         pathvia f end.
+Admitted.
+(* Proof. *)
+(*   apply nat_trans_eq; try (exact hs). *)
+(*   intro c. *)
+(*   assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))). *)
+(*   assert (h_eq' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ => *)
+(*                (((aux_iso_1_inv Z):(_⟶_)) _);; m) h_eq); *)
+(*   clear h_eq. *)
+(*   simpl in h_eq'. *)
+(*   assert (h_eq1' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ => *)
+(*                (CoproductIn1 EndC (CPEndC _ _));; m) h_eq'); *)
+(*   clear h_eq'. *)
+(*   assert (h_eq1'_inst := nat_trans_eq_pointwise h_eq1' c); *)
+(*   clear h_eq1'. *)
+(* (* match goal right in the beginning in contrast with earlier approach - suggestion by Benedikt *) *)
+(*   match goal with |[ H1 : _  = ?f |- _ = _   ] => *)
+(*          pathvia f end. *)
 
-  - clear h_eq1'_inst.
-    unfold coproduct_nat_trans_data; simpl.
-    unfold coproduct_nat_trans_in1_data ; simpl.
-    repeat rewrite <- assoc .
-    apply CoproductIn1Commutes_right_in_ctx_dir.
-    unfold λ_functor; simpl.
-    rewrite id_left.
-    apply CoproductIn1Commutes_right_in_ctx_dir.
-    unfold ρ_functor; simpl.
-    rewrite id_left.
-    apply CoproductIn1Commutes_right_in_ctx_dir.
-    rewrite (id_left EndC).
-    rewrite id_left.
-    apply CoproductIn1Commutes_right_in_ctx_dir.
-    rewrite (id_left EndC).
-    apply CoproductIn1Commutes_right_dir.
-    apply idpath.
-  - rewrite <- h_eq1'_inst.
-    clear h_eq1'_inst.
-    apply CoproductIn1Commutes_left_in_ctx_dir.
-    unfold λ_functor, nat_trans_id; simpl.
-    rewrite id_left.
-    repeat rewrite (id_left EndEndC).
-    repeat rewrite (id_left EndC).
-    unfold functor_fix_snd_arg_ob.
-    repeat rewrite assoc.
-(*    apply maponpaths. *)
-    apply idpath.
-Qed.
+(*   - clear h_eq1'_inst. *)
+(*     unfold coproduct_nat_trans_data; simpl. *)
+(*     unfold coproduct_nat_trans_in1_data ; simpl. *)
+(*     repeat rewrite <- assoc . *)
+(*     apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*     unfold λ_functor; simpl. *)
+(*     rewrite id_left. *)
+(*     apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*     unfold ρ_functor; simpl. *)
+(*     rewrite id_left. *)
+(*     apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*     rewrite (id_left EndC). *)
+(*     rewrite id_left. *)
+(*     apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*     rewrite (id_left EndC). *)
+(*     apply CoproductIn1Commutes_right_dir. *)
+(*     apply idpath. *)
+(*   - rewrite <- h_eq1'_inst. *)
+(*     clear h_eq1'_inst. *)
+(*     apply CoproductIn1Commutes_left_in_ctx_dir. *)
+(*     unfold λ_functor, nat_trans_id; simpl. *)
+(*     rewrite id_left. *)
+(*     repeat rewrite (id_left EndEndC). *)
+(*     repeat rewrite (id_left EndC). *)
+(*     unfold functor_fix_snd_arg_ob. *)
+(*     repeat rewrite assoc. *)
+(* (*    apply maponpaths. *) *)
+(*     apply idpath. *)
+(* Qed. *)
 
 (* produce some output to keep TRAVIS running *)
 Check bracket_Thm15_ok_part1.
@@ -356,61 +359,62 @@ Lemma bracket_Thm15_ok_part2 (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg  InitAlg ⟧):
  (theta H) ((alg_carrier _  InitAlg) ⊗ Z) ;;  # H ⦃f⦄ ;; τ InitAlg
   =
    # (pr1 (ℓ (U Z))) (τ InitAlg) ;; ⦃f⦄.
-Proof.
-  apply nat_trans_eq; try (exact hs).
-  intro c.
-  assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))).
-  assert (h_eq' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
-                  (((aux_iso_1_inv Z):(_⟶_)) _);; m) h_eq);
-  clear h_eq.
- (*        simpl in h_eq'. (* until here same as in previous lemma *) *)
+Admitted.
+(* Proof. *)
+(*   apply nat_trans_eq; try (exact hs). *)
+(*   intro c. *)
+(*   assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))). *)
+(*   assert (h_eq' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ => *)
+(*                   (((aux_iso_1_inv Z):(_⟶_)) _);; m) h_eq); *)
+(*   clear h_eq. *)
+(*  (*        simpl in h_eq'. (* until here same as in previous lemma *) *) *)
 
-  assert (h_eq2' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
-                (CoproductIn2 EndC (CPEndC _ _));; m) h_eq').
-  clear h_eq'.
-  assert (h_eq2'_inst := nat_trans_eq_pointwise h_eq2' c).
-  clear h_eq2'.
-  match goal with |[ H1 : _  = ?f |- _ = _   ] =>
-                   pathvia (f) end.
-  - clear h_eq2'_inst.
-    apply CoproductIn2Commutes_right_in_ctx_dir.
-    unfold aux_iso_1; simpl.
-    rewrite id_right.
-    rewrite id_left.
-    do 3 rewrite <- assoc.
-    apply CoproductIn2Commutes_right_in_ctx_dir.
-    unfold nat_trans_id; simpl. rewrite id_left.
-    apply CoproductIn2Commutes_right_in_ctx_dir.
-    unfold nat_trans_fix_snd_arg_data.
-    apply CoproductIn2Commutes_right_in_double_ctx_dir.
-    rewrite <- assoc.
-    apply maponpaths.
-    eapply pathscomp0. Focus 2. apply assoc.
-    apply maponpaths.
-    apply pathsinv0.
-    apply CoproductIn2Commutes.
+(*   assert (h_eq2' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ => *)
+(*                 (CoproductIn2 EndC (CPEndC _ _));; m) h_eq'). *)
+(*   clear h_eq'. *)
+(*   assert (h_eq2'_inst := nat_trans_eq_pointwise h_eq2' c). *)
+(*   clear h_eq2'. *)
+(*   match goal with |[ H1 : _  = ?f |- _ = _   ] => *)
+(*                    pathvia (f) end. *)
+(*   - clear h_eq2'_inst. *)
+(*     apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*     unfold aux_iso_1; simpl. *)
+(*     rewrite id_right. *)
+(*     rewrite id_left. *)
+(*     do 3 rewrite <- assoc. *)
+(*     apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*     unfold nat_trans_id; simpl. rewrite id_left. *)
+(*     apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*     unfold nat_trans_fix_snd_arg_data. *)
+(*     apply CoproductIn2Commutes_right_in_double_ctx_dir. *)
+(*     rewrite <- assoc. *)
+(*     apply maponpaths. *)
+(*     eapply pathscomp0. Focus 2. apply assoc. *)
+(*     apply maponpaths. *)
+(*     apply pathsinv0. *)
+(*     apply CoproductIn2Commutes. *)
 
-(* alternative with slightly less precise control:
-           do 4 rewrite <- assoc.
-           apply CoproductIn2Commutes_right_in_ctx_dir.
-           rewrite id_left.
-           apply CoproductIn2Commutes_right_in_ctx_dir.
-           apply CoproductIn2Commutes_right_in_ctx_dir.
-           unfold nat_trans_fix_snd_arg_data.
-           rewrite id_left.
-           apply CoproductIn2Commutes_right_in_double_ctx_dir.
-           do 2 rewrite <- assoc.
-           apply maponpaths.
-           apply maponpaths.
-           apply pathsinv0.
-           apply CoproductIn2Commutes.
-*)
+(* (* alternative with slightly less precise control: *)
+(*            do 4 rewrite <- assoc. *)
+(*            apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*            rewrite id_left. *)
+(*            apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*            apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*            unfold nat_trans_fix_snd_arg_data. *)
+(*            rewrite id_left. *)
+(*            apply CoproductIn2Commutes_right_in_double_ctx_dir. *)
+(*            do 2 rewrite <- assoc. *)
+(*            apply maponpaths. *)
+(*            apply maponpaths. *)
+(*            apply pathsinv0. *)
+(*            apply CoproductIn2Commutes. *)
+(* *) *)
 
-  - rewrite <- h_eq2'_inst. clear h_eq2'_inst.
-    apply CoproductIn2Commutes_left_in_ctx_dir.
-    repeat rewrite id_left.
-    apply assoc.
-Qed.
+(*   - rewrite <- h_eq2'_inst. clear h_eq2'_inst. *)
+(*     apply CoproductIn2Commutes_left_in_ctx_dir. *)
+(*     repeat rewrite id_left. *)
+(*     apply assoc. *)
+(* Qed. *)
 
 (* produce some output to keep TRAVIS running *)
 Check bracket_Thm15_ok_part2.
@@ -422,15 +426,16 @@ Proof.
   split.
   + exact (bracket_Thm15_ok_part1 Z f).
   + exact (bracket_Thm15_ok_part2 Z f).
-Qed.
+Admitted.
+(* Qed. *)
 
 Lemma bracket_Thm15_ok_cor (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧):
  bracket_property f (bracket_Thm15 Z f).
 Proof.
   apply whole_from_parts.
   apply bracket_Thm15_ok.
-Qed.
-
+Admitted.
+(* Qed. *)
 
 Local Lemma foo' (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
  ∀ t : Σ h : [C, C, hs] ⟦ functor_composite (U Z) (pr1  InitAlg),
@@ -444,59 +449,60 @@ Local Lemma foo' (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
               pr1 InitAlg ⟧,
        bracket_property f h)
       ⦃f⦄ (bracket_Thm15_ok_cor Z f).
-Proof.
-  intros [h' h'_eq].
-  apply subtypeEquality.
-  - intro.
-    unfold bracket_property.
-    apply isaset_nat_trans. exact hs.
-  - simpl.
-    apply parts_from_whole in h'_eq.
-(*    destruct h'_eq as [h'_eq1 h'_eq2]. *)
-    unfold bracket_Thm15.
-    apply path_to_ctr.
-    apply nat_trans_eq; try (exact hs).
-    intro c; simpl.
-    unfold coproduct_nat_trans_data.
-    repeat rewrite (id_left EndC).
-    rewrite id_right.
-    repeat rewrite <- assoc.
-    eapply pathscomp0. Focus 2. eapply pathsinv0. apply postcompWithCoproductArrow.
-    apply CoproductArrowUnique.
-    + destruct h'_eq as [h'_eq1 _ ]. (*clear h'_eq2.*)
-      simpl.
-      rewrite (id_left C).
-      assert (h'_eq1_inst := nat_trans_eq_pointwise h'_eq1 c);
-        clear h'_eq1.
-      simpl in h'_eq1_inst.
-      unfold coproduct_nat_trans_in1_data in h'_eq1_inst; simpl in h'_eq1_inst.
-      rewrite <- assoc in h'_eq1_inst.
-      eapply pathscomp0.
-      eapply pathsinv0.
-      exact h'_eq1_inst.
-      clear h'_eq1_inst.
-      apply CoproductIn1Commutes_right_in_ctx_dir.
-      apply CoproductIn1Commutes_right_in_ctx_dir.
-      apply CoproductIn1Commutes_right_dir.
-        apply idpath.
-    + destruct h'_eq as [_ h'_eq2]. (*clear h'_eq2.*)
-      assert (h'_eq2_inst := nat_trans_eq_pointwise h'_eq2 c);
-        clear h'_eq2.
-      simpl in h'_eq2_inst.
-      unfold coproduct_nat_trans_in2_data in h'_eq2_inst; simpl in h'_eq2_inst.
-      apply pathsinv0 in h'_eq2_inst.
-      rewrite <- assoc in h'_eq2_inst.
-      eapply pathscomp0. exact h'_eq2_inst. clear h'_eq2_inst.
-      apply CoproductIn2Commutes_right_in_ctx_dir.
-      apply CoproductIn2Commutes_right_in_double_ctx_dir.
-      unfold nat_trans_fix_snd_arg_data; simpl.
-      do 2 rewrite <- assoc.
-      apply maponpaths.
-      rewrite <- assoc.
-      apply maponpaths.
-      apply pathsinv0.
-      apply CoproductIn2Commutes.
-Qed.
+Admitted.
+(* Proof. *)
+(*   intros [h' h'_eq]. *)
+(*   apply subtypeEquality. *)
+(*   - intro. *)
+(*     unfold bracket_property. *)
+(*     apply isaset_nat_trans. exact hs. *)
+(*   - simpl. *)
+(*     apply parts_from_whole in h'_eq. *)
+(* (*    destruct h'_eq as [h'_eq1 h'_eq2]. *) *)
+(*     unfold bracket_Thm15. *)
+(*     apply path_to_ctr. *)
+(*     apply nat_trans_eq; try (exact hs). *)
+(*     intro c; simpl. *)
+(*     unfold coproduct_nat_trans_data. *)
+(*     repeat rewrite (id_left EndC). *)
+(*     rewrite id_right. *)
+(*     repeat rewrite <- assoc. *)
+(*     eapply pathscomp0. Focus 2. eapply pathsinv0. apply postcompWithCoproductArrow. *)
+(*     apply CoproductArrowUnique. *)
+(*     + destruct h'_eq as [h'_eq1 _ ]. (*clear h'_eq2.*) *)
+(*       simpl. *)
+(*       rewrite (id_left C). *)
+(*       assert (h'_eq1_inst := nat_trans_eq_pointwise h'_eq1 c); *)
+(*         clear h'_eq1. *)
+(*       simpl in h'_eq1_inst. *)
+(*       unfold coproduct_nat_trans_in1_data in h'_eq1_inst; simpl in h'_eq1_inst. *)
+(*       rewrite <- assoc in h'_eq1_inst. *)
+(*       eapply pathscomp0. *)
+(*       eapply pathsinv0. *)
+(*       exact h'_eq1_inst. *)
+(*       clear h'_eq1_inst. *)
+(*       apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*       apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*       apply CoproductIn1Commutes_right_dir. *)
+(*         apply idpath. *)
+(*     + destruct h'_eq as [_ h'_eq2]. (*clear h'_eq2.*) *)
+(*       assert (h'_eq2_inst := nat_trans_eq_pointwise h'_eq2 c); *)
+(*         clear h'_eq2. *)
+(*       simpl in h'_eq2_inst. *)
+(*       unfold coproduct_nat_trans_in2_data in h'_eq2_inst; simpl in h'_eq2_inst. *)
+(*       apply pathsinv0 in h'_eq2_inst. *)
+(*       rewrite <- assoc in h'_eq2_inst. *)
+(*       eapply pathscomp0. exact h'_eq2_inst. clear h'_eq2_inst. *)
+(*       apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*       apply CoproductIn2Commutes_right_in_double_ctx_dir. *)
+(*       unfold nat_trans_fix_snd_arg_data; simpl. *)
+(*       do 2 rewrite <- assoc. *)
+(*       apply maponpaths. *)
+(*       rewrite <- assoc. *)
+(*       apply maponpaths. *)
+(*       apply pathsinv0. *)
+(*       apply CoproductIn2Commutes. *)
+(* Qed. *)
 
 Definition bracket_for_InitAlg : bracket InitAlg.
 Proof.
@@ -603,7 +609,8 @@ Proof.
     rewrite <- (nat_trans_ax α).
     rewrite functor_id.
     apply id_left.
-Qed.
+Admitted.
+(* Qed. *)
 
 Local Definition iso2' (Z : Ptd) : EndEndC ⟦
   CoproductObject EndEndC
@@ -660,209 +667,210 @@ Lemma ishssMor_InitAlg (T' : hss CP H) :
   @ishssMor C hs CP H
         InitHSS T'
            (InitialArrow IA (pr1 T') : @algebra_mor EndC Id_H InitAlg T' ).
-Proof.
-  unfold ishssMor.
-  unfold isbracketMor.
-  intros Z f.
-  set (β0 := InitialArrow IA (pr1 T')).
-  match goal with | [|- _ ;; ?b = _ ] => set (β := b) end.
-  set ( rhohat := CoproductArrow EndC  (CPEndC _ _ )  β (tau_from_alg T')
-                  :  pr1 Ghat T' --> T').
-  set (X:= SpecializedGMIt Z _ Ghat rhohat (thetahat Z f)).
-  pathvia (pr1 (pr1 X)).
-  - set (TT:= fusion_law _ _ _ IA _ hsEndC (pr1 InitAlg) T' _ (KanExt Z)).
-    set (Psi := ψ_from_comps _ (Id_H) _ hsEndC _ (ℓ (U Z)) (Const_plus_H (U Z)) (ρ_Thm15 Z f)
-                             (aux_iso_1 Z ;; θ'_Thm15 Z ;; aux_iso_2_inv Z) ).
-    set (T2 := TT Psi).
-    set (T3 := T2 (ℓ (U Z)) (KanExt Z)).
-    set (Psi' := ψ_from_comps _ (Id_H) _ hsEndC _ (ℓ (U Z)) (Ghat) (rhohat)
-                             (iso1' Z ;; thetahat_0 Z f ;; iso2' Z) ).
-    set (T4 := T3 Psi').
-    set (Φ := (Phi_fusion Z T' β)).
-    set (T5 := T4 Φ).
-    pathvia (Φ _ (fbracket InitHSS f)).
-    + apply idpath.
-    + eapply pathscomp0. Focus 2. apply T5.
-      (* hypothesis of fusion law *)
-      apply funextsec. intro.
-      simpl.
-      unfold compose. simpl.
-      apply nat_trans_eq. assumption.
-      simpl.
-      intro c.
-      rewrite id_right.
-      rewrite id_right.
-      (* should be decomposed into two diagrams *)
-      apply CoproductArrow_eq_cor.
-      * (* first diagram *)
-        clear TT T2 T3 T4 T5.
-        do 5 rewrite <- assoc.
-        apply CoproductIn1Commutes_left_in_ctx_dir.
-        apply CoproductIn1Commutes_right_in_ctx_dir.
-        simpl.
-        rewrite id_left.
-        apply CoproductIn1Commutes_left_in_ctx_dir.
-        apply CoproductIn1Commutes_right_in_ctx_dir.
-        simpl.
-        rewrite id_left.
-        apply CoproductIn1Commutes_left_in_ctx_dir.
-        simpl.
-        rewrite id_left.
-        apply CoproductIn1Commutes_left_in_ctx_dir.
-        rewrite <- assoc.
-        apply maponpaths.
-        apply CoproductIn1Commutes_right_in_ctx_dir.
-        simpl.
-        rewrite id_left.
-        apply CoproductIn1Commutes_right_dir.
-        apply idpath.
-      * (* a bit out of order what follows *)
-        apply cancel_postcomposition.
-        apply idpath.
-      * (* second diagram *)
-        clear TT T2 T3 T4 T5.
-        do 5 rewrite <- assoc.
-        apply CoproductIn2Commutes_left_in_ctx_dir.
-        apply CoproductIn2Commutes_right_in_ctx_dir.
-        rewrite (id_left EndC).
-        apply CoproductIn2Commutes_left_in_ctx_dir.
-        apply CoproductIn2Commutes_right_in_ctx_dir.
-        simpl.
-        unfold nat_trans_fix_snd_arg_data.
-        repeat rewrite <- assoc.
-        apply maponpaths.
-        apply CoproductIn2Commutes_left_in_ctx_dir.
-        apply CoproductIn2Commutes_right_in_ctx_dir.
-        simpl.
-        assert (H_nat_inst := functor_comp H _ _ _ t β).
-        assert (H_nat_inst_c := nat_trans_eq_pointwise H_nat_inst c); clear H_nat_inst.
-        {
-          match goal with |[ H1 : _  = ?f |- _ = _;; ?g ;; ?h  ] =>
-             pathvia (f;;g;;h) end.
-          + clear H_nat_inst_c.
-            simpl.
-            repeat rewrite <- assoc.
-            apply maponpaths.
-            apply CoproductIn2Commutes_left_in_ctx_dir.
-            simpl.
-            unfold coproduct_nat_trans_in2_data, coproduct_nat_trans_data.
-            assert (Hyp := τ_part_of_alg_mor _ hs CP _ _ _ (InitialArrow IA (pr1 T'))).
-            assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp.
-            simpl in Hyp_c.
-            eapply pathscomp0. eapply pathsinv0. exact Hyp_c.
-            clear Hyp_c.
-            apply maponpaths.
-            apply pathsinv0.
-            apply CoproductIn2Commutes.
-          + rewrite <- H_nat_inst_c.
-            apply idpath.
-        }
-  - apply pathsinv0.
-    apply path_to_ctr.
-    (* now a lot of serious verification work to be done *)
-    apply nat_trans_eq; try (exact hs).
-    intro c.
-    simpl.
-    rewrite id_right.
-    (* look at type:
-       match goal with | [ |- ?l = _ ] => let ty:= (type of l) in idtac ty end. *)
-    apply CoproductArrow_eq_cor.
-    + repeat rewrite <- assoc.
-      apply CoproductIn1Commutes_right_in_ctx_dir.
-      simpl.
-      unfold coproduct_nat_trans_in1_data,
-             coproduct_nat_trans_in2_data,
-             coproduct_nat_trans_data.
-      rewrite id_left.
-      apply CoproductIn1Commutes_right_in_ctx_dir.
-      simpl.
-      repeat rewrite <- assoc.
-      eapply pathscomp0. Focus 2. apply maponpaths. apply CoproductIn1Commutes_right_in_ctx_dir.
-        rewrite id_left. apply CoproductIn1Commutes_right_dir. apply idpath.
-      do 2 rewrite assoc.
-      eapply pathscomp0.
-        apply cancel_postcomposition.
-        assert (ptd_mor_commutes_inst := ptd_mor_commutes _ (ptd_from_alg_mor _ hs CP H β0) ((pr1 Z) c)).
-        apply ptd_mor_commutes_inst.
-      assert (fbracket_η_inst := fbracket_η T' (f;; ptd_from_alg_mor _ hs CP H β0)).
-      assert (fbracket_η_inst_c := nat_trans_eq_pointwise fbracket_η_inst c); clear fbracket_η_inst.
-      apply (!fbracket_η_inst_c).
-    + (* now the difficult case *)
-      repeat rewrite <- assoc.
-      apply CoproductIn2Commutes_right_in_ctx_dir.
-      simpl.
-      unfold coproduct_nat_trans_in1_data, coproduct_nat_trans_in2_data, coproduct_nat_trans_data.
-      rewrite id_left.
-      apply CoproductIn2Commutes_right_in_ctx_dir.
-      unfold nat_trans_fix_snd_arg_data.
-      simpl.
-      unfold coproduct_nat_trans_in2_data.
-      repeat rewrite <- assoc.
-      eapply pathscomp0. Focus 2.
-        apply maponpaths.
-        apply CoproductIn2Commutes_right_in_ctx_dir.
-        rewrite <- assoc.
-        apply maponpaths.
-        apply CoproductIn2Commutes_right_dir.
-        apply idpath.
-      do 2 rewrite assoc.
-      eapply pathscomp0.
-        apply cancel_postcomposition.
-        eapply pathsinv0.
-        assert (τ_part_of_alg_mor_inst := τ_part_of_alg_mor _ hs CP H _ _ β0).
-        assert (τ_part_of_alg_mor_inst_Zc :=
-                  nat_trans_eq_pointwise τ_part_of_alg_mor_inst ((pr1 Z) c));
-          clear τ_part_of_alg_mor_inst.
-        apply τ_part_of_alg_mor_inst_Zc.
-      simpl.
-      unfold coproduct_nat_trans_in2_data.
-      repeat rewrite <- assoc.
-      eapply pathscomp0.
-        apply maponpaths.
-        rewrite assoc.
-        eapply pathsinv0.
-        assert (fbracket_τ_inst := fbracket_τ T' (f;; ptd_from_alg_mor _ hs CP H β0)).
-        assert (fbracket_τ_inst_c := nat_trans_eq_pointwise fbracket_τ_inst c); clear fbracket_τ_inst.
-        apply fbracket_τ_inst_c.
-      simpl.
-      unfold coproduct_nat_trans_in2_data.
-      repeat rewrite assoc.
-      apply cancel_postcomposition.
-      apply cancel_postcomposition.
-      assert (Hyp:
-                 ((# (pr1 (ℓ(U Z))) (# H β));;
-                 (theta H) ((alg_carrier _  T') ⊗ Z);;
-                 # H (fbracket T' (f;; ptd_from_alg_mor C hs CP H β0))
-                 =
-                 θ (tpair (λ _ : functor C C, ptd_obj C) (alg_carrier _ (InitialObject IA)) Z) ;;
-                 # H (# (pr1 (ℓ(U Z))) β ;;
-                 fbracket T' (f;; ptd_from_alg_mor C hs CP H β0)))).
+Admitted.
+(* Proof. *)
+(*   unfold ishssMor. *)
+(*   unfold isbracketMor. *)
+(*   intros Z f. *)
+(*   set (β0 := InitialArrow IA (pr1 T')). *)
+(*   match goal with | [|- _ ;; ?b = _ ] => set (β := b) end. *)
+(*   set ( rhohat := CoproductArrow EndC  (CPEndC _ _ )  β (tau_from_alg T') *)
+(*                   :  pr1 Ghat T' --> T'). *)
+(*   set (X:= SpecializedGMIt Z _ Ghat rhohat (thetahat Z f)). *)
+(*   pathvia (pr1 (pr1 X)). *)
+(*   - set (TT:= fusion_law _ _ _ IA _ hsEndC (pr1 InitAlg) T' _ (KanExt Z)). *)
+(*     set (Psi := ψ_from_comps _ (Id_H) _ hsEndC _ (ℓ (U Z)) (Const_plus_H (U Z)) (ρ_Thm15 Z f) *)
+(*                              (aux_iso_1 Z ;; θ'_Thm15 Z ;; aux_iso_2_inv Z) ). *)
+(*     set (T2 := TT Psi). *)
+(*     set (T3 := T2 (ℓ (U Z)) (KanExt Z)). *)
+(*     set (Psi' := ψ_from_comps _ (Id_H) _ hsEndC _ (ℓ (U Z)) (Ghat) (rhohat) *)
+(*                              (iso1' Z ;; thetahat_0 Z f ;; iso2' Z) ). *)
+(*     set (T4 := T3 Psi'). *)
+(*     set (Φ := (Phi_fusion Z T' β)). *)
+(*     set (T5 := T4 Φ). *)
+(*     pathvia (Φ _ (fbracket InitHSS f)). *)
+(*     + apply idpath. *)
+(*     + eapply pathscomp0. Focus 2. apply T5. *)
+(*       (* hypothesis of fusion law *) *)
+(*       apply funextsec. intro. *)
+(*       simpl. *)
+(*       unfold compose. simpl. *)
+(*       apply nat_trans_eq. assumption. *)
+(*       simpl. *)
+(*       intro c. *)
+(*       rewrite id_right. *)
+(*       rewrite id_right. *)
+(*       (* should be decomposed into two diagrams *) *)
+(*       apply CoproductArrow_eq_cor. *)
+(*       * (* first diagram *) *)
+(*         clear TT T2 T3 T4 T5. *)
+(*         do 5 rewrite <- assoc. *)
+(*         apply CoproductIn1Commutes_left_in_ctx_dir. *)
+(*         apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*         simpl. *)
+(*         rewrite id_left. *)
+(*         apply CoproductIn1Commutes_left_in_ctx_dir. *)
+(*         apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*         simpl. *)
+(*         rewrite id_left. *)
+(*         apply CoproductIn1Commutes_left_in_ctx_dir. *)
+(*         simpl. *)
+(*         rewrite id_left. *)
+(*         apply CoproductIn1Commutes_left_in_ctx_dir. *)
+(*         rewrite <- assoc. *)
+(*         apply maponpaths. *)
+(*         apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*         simpl. *)
+(*         rewrite id_left. *)
+(*         apply CoproductIn1Commutes_right_dir. *)
+(*         apply idpath. *)
+(*       * (* a bit out of order what follows *) *)
+(*         apply cancel_postcomposition. *)
+(*         apply idpath. *)
+(*       * (* second diagram *) *)
+(*         clear TT T2 T3 T4 T5. *)
+(*         do 5 rewrite <- assoc. *)
+(*         apply CoproductIn2Commutes_left_in_ctx_dir. *)
+(*         apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*         rewrite (id_left EndC). *)
+(*         apply CoproductIn2Commutes_left_in_ctx_dir. *)
+(*         apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*         simpl. *)
+(*         unfold nat_trans_fix_snd_arg_data. *)
+(*         repeat rewrite <- assoc. *)
+(*         apply maponpaths. *)
+(*         apply CoproductIn2Commutes_left_in_ctx_dir. *)
+(*         apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*         simpl. *)
+(*         assert (H_nat_inst := functor_comp H _ _ _ t β). *)
+(*         assert (H_nat_inst_c := nat_trans_eq_pointwise H_nat_inst c); clear H_nat_inst. *)
+(*         { *)
+(*           match goal with |[ H1 : _  = ?f |- _ = _;; ?g ;; ?h  ] => *)
+(*              pathvia (f;;g;;h) end. *)
+(*           + clear H_nat_inst_c. *)
+(*             simpl. *)
+(*             repeat rewrite <- assoc. *)
+(*             apply maponpaths. *)
+(*             apply CoproductIn2Commutes_left_in_ctx_dir. *)
+(*             simpl. *)
+(*             unfold coproduct_nat_trans_in2_data, coproduct_nat_trans_data. *)
+(*             assert (Hyp := τ_part_of_alg_mor _ hs CP _ _ _ (InitialArrow IA (pr1 T'))). *)
+(*             assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp. *)
+(*             simpl in Hyp_c. *)
+(*             eapply pathscomp0. eapply pathsinv0. exact Hyp_c. *)
+(*             clear Hyp_c. *)
+(*             apply maponpaths. *)
+(*             apply pathsinv0. *)
+(*             apply CoproductIn2Commutes. *)
+(*           + rewrite <- H_nat_inst_c. *)
+(*             apply idpath. *)
+(*         } *)
+(*   - apply pathsinv0. *)
+(*     apply path_to_ctr. *)
+(*     (* now a lot of serious verification work to be done *) *)
+(*     apply nat_trans_eq; try (exact hs). *)
+(*     intro c. *)
+(*     simpl. *)
+(*     rewrite id_right. *)
+(*     (* look at type: *)
+(*        match goal with | [ |- ?l = _ ] => let ty:= (type of l) in idtac ty end. *) *)
+(*     apply CoproductArrow_eq_cor. *)
+(*     + repeat rewrite <- assoc. *)
+(*       apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*       simpl. *)
+(*       unfold coproduct_nat_trans_in1_data, *)
+(*              coproduct_nat_trans_in2_data, *)
+(*              coproduct_nat_trans_data. *)
+(*       rewrite id_left. *)
+(*       apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*       simpl. *)
+(*       repeat rewrite <- assoc. *)
+(*       eapply pathscomp0. Focus 2. apply maponpaths. apply CoproductIn1Commutes_right_in_ctx_dir. *)
+(*         rewrite id_left. apply CoproductIn1Commutes_right_dir. apply idpath. *)
+(*       do 2 rewrite assoc. *)
+(*       eapply pathscomp0. *)
+(*         apply cancel_postcomposition. *)
+(*         assert (ptd_mor_commutes_inst := ptd_mor_commutes _ (ptd_from_alg_mor _ hs CP H β0) ((pr1 Z) c)). *)
+(*         apply ptd_mor_commutes_inst. *)
+(*       assert (fbracket_η_inst := fbracket_η T' (f;; ptd_from_alg_mor _ hs CP H β0)). *)
+(*       assert (fbracket_η_inst_c := nat_trans_eq_pointwise fbracket_η_inst c); clear fbracket_η_inst. *)
+(*       apply (!fbracket_η_inst_c). *)
+(*     + (* now the difficult case *) *)
+(*       repeat rewrite <- assoc. *)
+(*       apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*       simpl. *)
+(*       unfold coproduct_nat_trans_in1_data, coproduct_nat_trans_in2_data, coproduct_nat_trans_data. *)
+(*       rewrite id_left. *)
+(*       apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*       unfold nat_trans_fix_snd_arg_data. *)
+(*       simpl. *)
+(*       unfold coproduct_nat_trans_in2_data. *)
+(*       repeat rewrite <- assoc. *)
+(*       eapply pathscomp0. Focus 2. *)
+(*         apply maponpaths. *)
+(*         apply CoproductIn2Commutes_right_in_ctx_dir. *)
+(*         rewrite <- assoc. *)
+(*         apply maponpaths. *)
+(*         apply CoproductIn2Commutes_right_dir. *)
+(*         apply idpath. *)
+(*       do 2 rewrite assoc. *)
+(*       eapply pathscomp0. *)
+(*         apply cancel_postcomposition. *)
+(*         eapply pathsinv0. *)
+(*         assert (τ_part_of_alg_mor_inst := τ_part_of_alg_mor _ hs CP H _ _ β0). *)
+(*         assert (τ_part_of_alg_mor_inst_Zc := *)
+(*                   nat_trans_eq_pointwise τ_part_of_alg_mor_inst ((pr1 Z) c)); *)
+(*           clear τ_part_of_alg_mor_inst. *)
+(*         apply τ_part_of_alg_mor_inst_Zc. *)
+(*       simpl. *)
+(*       unfold coproduct_nat_trans_in2_data. *)
+(*       repeat rewrite <- assoc. *)
+(*       eapply pathscomp0. *)
+(*         apply maponpaths. *)
+(*         rewrite assoc. *)
+(*         eapply pathsinv0. *)
+(*         assert (fbracket_τ_inst := fbracket_τ T' (f;; ptd_from_alg_mor _ hs CP H β0)). *)
+(*         assert (fbracket_τ_inst_c := nat_trans_eq_pointwise fbracket_τ_inst c); clear fbracket_τ_inst. *)
+(*         apply fbracket_τ_inst_c. *)
+(*       simpl. *)
+(*       unfold coproduct_nat_trans_in2_data. *)
+(*       repeat rewrite assoc. *)
+(*       apply cancel_postcomposition. *)
+(*       apply cancel_postcomposition. *)
+(*       assert (Hyp: *)
+(*                  ((# (pr1 (ℓ(U Z))) (# H β));; *)
+(*                  (theta H) ((alg_carrier _  T') ⊗ Z);; *)
+(*                  # H (fbracket T' (f;; ptd_from_alg_mor C hs CP H β0)) *)
+(*                  = *)
+(*                  θ (tpair (λ _ : functor C C, ptd_obj C) (alg_carrier _ (InitialObject IA)) Z) ;; *)
+(*                  # H (# (pr1 (ℓ(U Z))) β ;; *)
+(*                  fbracket T' (f;; ptd_from_alg_mor C hs CP H β0)))). *)
 
-      Focus 2.
-      assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp.
-      exact Hyp_c.
+(*       Focus 2. *)
+(*       assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp. *)
+(*       exact Hyp_c. *)
 
-      clear c. clear X. clear rhohat.
-      rewrite (functor_comp H).
-      rewrite assoc.
-      apply cancel_postcomposition.
-      fold θ.
-      apply nat_trans_eq; try (exact hs).
-      intro c.
-      assert (θ_nat_1_pointwise_inst := θ_nat_1_pointwise _ hs H θ _ _ β Z c).
-      eapply pathscomp0 ; [exact θ_nat_1_pointwise_inst | ].
-      clear θ_nat_1_pointwise_inst.
-      simpl.
-      apply maponpaths.
-      assert (Hyp: # H (β ∙∙ nat_trans_id (pr1 Z)) = # H (# (pr1 (ℓ(U Z))) β)).
-      { apply maponpaths.
-        apply nat_trans_eq; try (exact hs).
-        intro c'.
-        simpl.
-        rewrite functor_id.
-        apply id_right. }
-      apply (nat_trans_eq_pointwise Hyp c).
-Qed.
+(*       clear c. clear X. clear rhohat. *)
+(*       rewrite (functor_comp H). *)
+(*       rewrite assoc. *)
+(*       apply cancel_postcomposition. *)
+(*       fold θ. *)
+(*       apply nat_trans_eq; try (exact hs). *)
+(*       intro c. *)
+(*       assert (θ_nat_1_pointwise_inst := θ_nat_1_pointwise _ hs H θ _ _ β Z c). *)
+(*       eapply pathscomp0 ; [exact θ_nat_1_pointwise_inst | ]. *)
+(*       clear θ_nat_1_pointwise_inst. *)
+(*       simpl. *)
+(*       apply maponpaths. *)
+(*       assert (Hyp: # H (β ∙∙ nat_trans_id (pr1 Z)) = # H (# (pr1 (ℓ(U Z))) β)). *)
+(*       { apply maponpaths. *)
+(*         apply nat_trans_eq; try (exact hs). *)
+(*         intro c'. *)
+(*         simpl. *)
+(*         rewrite functor_id. *)
+(*         apply id_right. } *)
+(*       apply (nat_trans_eq_pointwise Hyp c). *)
+(* Qed. *)
 
 Definition hss_InitMor : ∀ T' : hss CP H, hssMor InitHSS T'.
 Proof.
@@ -877,7 +885,8 @@ Proof.
   intro t.
   apply (invmap (hssMor_eq1 _ _ _ _ _ _ _ _ )).
   apply (@InitialArrowUnique _ IA (pr1 T') (pr1 t)).
-Qed.
+Admitted.
+(* Qed. *)
 
 Lemma isInitial_InitHSS : isInitial (hss_precategory CP H) InitHSS.
 Proof.

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -91,9 +91,6 @@ Definition Const_plus_H (X : EndC) : functor EndC EndC
 Definition Id_H :  functor [C, C, hs] [C, C, hs]
  := Const_plus_H (functor_identity _ : EndC).
 
-(* Opaque Const_plus_H. *)
-(* Opaque Id_H. *)
-
 Let Alg : precategory := FunctorAlg Id_H hsEndC.
 
 
@@ -147,8 +144,7 @@ Proof.
   - rewrite functor_id.
     do 2 rewrite id_right.
     apply pathsinv0, id_left.
-Admitted.
-(* Qed. *)
+Qed.
 
 Definition aux_iso_1 (Z : Ptd)
   : EndEndC
@@ -192,8 +188,7 @@ Proof.
     do 2 rewrite id_right.
     apply pathsinv0.
     apply id_left.
-Admitted.
-(* Qed. *)
+Qed.
 
 Local Definition aux_iso_1_inv (Z: Ptd)
   : EndEndC
@@ -304,53 +299,52 @@ Lemma bracket_Thm15_ok_part1 (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg  InitAlg ⟧):
  # U f
  =
  # (pr1 (ℓ (U Z))) (η InitAlg) ;; ⦃f⦄.
-Admitted.
-(* Proof. *)
-(*   apply nat_trans_eq; try (exact hs). *)
-(*   intro c. *)
-(*   assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))). *)
-(*   assert (h_eq' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ => *)
-(*                (((aux_iso_1_inv Z):(_⟶_)) _);; m) h_eq); *)
-(*   clear h_eq. *)
-(*   simpl in h_eq'. *)
-(*   assert (h_eq1' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ => *)
-(*                (CoproductIn1 EndC (CPEndC _ _));; m) h_eq'); *)
-(*   clear h_eq'. *)
-(*   assert (h_eq1'_inst := nat_trans_eq_pointwise h_eq1' c); *)
-(*   clear h_eq1'. *)
-(* (* match goal right in the beginning in contrast with earlier approach - suggestion by Benedikt *) *)
-(*   match goal with |[ H1 : _  = ?f |- _ = _   ] => *)
-(*          pathvia f end. *)
+Proof.
+  apply nat_trans_eq; try (exact hs).
+  intro c.
+  assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))).
+  assert (h_eq' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
+               (((aux_iso_1_inv Z):(_⟶_)) _);; m) h_eq);
+  clear h_eq.
+  simpl in h_eq'.
+  assert (h_eq1' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
+               (CoproductIn1 EndC (CPEndC _ _));; m) h_eq');
+  clear h_eq'.
+  assert (h_eq1'_inst := nat_trans_eq_pointwise h_eq1' c);
+  clear h_eq1'.
+(* match goal right in the beginning in contrast with earlier approach - suggestion by Benedikt *)
+  match goal with |[ H1 : _  = ?f |- _ = _   ] =>
+         pathvia f end.
 
-(*   - clear h_eq1'_inst. *)
-(*     unfold coproduct_nat_trans_data; simpl. *)
-(*     unfold coproduct_nat_trans_in1_data ; simpl. *)
-(*     repeat rewrite <- assoc . *)
-(*     apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*     unfold λ_functor; simpl. *)
-(*     rewrite id_left. *)
-(*     apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*     unfold ρ_functor; simpl. *)
-(*     rewrite id_left. *)
-(*     apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*     rewrite (id_left EndC). *)
-(*     rewrite id_left. *)
-(*     apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*     rewrite (id_left EndC). *)
-(*     apply CoproductIn1Commutes_right_dir. *)
-(*     apply idpath. *)
-(*   - rewrite <- h_eq1'_inst. *)
-(*     clear h_eq1'_inst. *)
-(*     apply CoproductIn1Commutes_left_in_ctx_dir. *)
-(*     unfold λ_functor, nat_trans_id; simpl. *)
-(*     rewrite id_left. *)
-(*     repeat rewrite (id_left EndEndC). *)
-(*     repeat rewrite (id_left EndC). *)
-(*     unfold functor_fix_snd_arg_ob. *)
-(*     repeat rewrite assoc. *)
-(* (*    apply maponpaths. *) *)
-(*     apply idpath. *)
-(* Qed. *)
+  - clear h_eq1'_inst.
+    unfold coproduct_nat_trans_data; simpl.
+    unfold coproduct_nat_trans_in1_data ; simpl.
+    repeat rewrite <- assoc .
+    apply CoproductIn1Commutes_right_in_ctx_dir.
+    unfold λ_functor; simpl.
+    rewrite id_left.
+    apply CoproductIn1Commutes_right_in_ctx_dir.
+    unfold ρ_functor; simpl.
+    rewrite id_left.
+    apply CoproductIn1Commutes_right_in_ctx_dir.
+    rewrite (id_left EndC).
+    rewrite id_left.
+    apply CoproductIn1Commutes_right_in_ctx_dir.
+    rewrite (id_left EndC).
+    apply CoproductIn1Commutes_right_dir.
+    apply idpath.
+  - rewrite <- h_eq1'_inst.
+    clear h_eq1'_inst.
+    apply CoproductIn1Commutes_left_in_ctx_dir.
+    unfold λ_functor, nat_trans_id; simpl.
+    rewrite id_left.
+    repeat rewrite (id_left EndEndC).
+    repeat rewrite (id_left EndC).
+    unfold functor_fix_snd_arg_ob.
+    repeat rewrite assoc.
+(*    apply maponpaths. *)
+    apply idpath.
+Qed.
 
 (* produce some output to keep TRAVIS running *)
 Check bracket_Thm15_ok_part1.
@@ -359,42 +353,41 @@ Lemma bracket_Thm15_ok_part2 (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg  InitAlg ⟧):
  (theta H) ((alg_carrier _  InitAlg) ⊗ Z) ;;  # H ⦃f⦄ ;; τ InitAlg
   =
    # (pr1 (ℓ (U Z))) (τ InitAlg) ;; ⦃f⦄.
-Admitted.
-(* Proof. *)
-(*   apply nat_trans_eq; try (exact hs). *)
-(*   intro c. *)
-(*   assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))). *)
-(*   assert (h_eq' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ => *)
-(*                   (((aux_iso_1_inv Z):(_⟶_)) _);; m) h_eq); *)
-(*   clear h_eq. *)
-(*  (*        simpl in h_eq'. (* until here same as in previous lemma *) *) *)
+Proof.
+  apply nat_trans_eq; try (exact hs).
+  intro c.
+  assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))).
+  assert (h_eq' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
+                  (((aux_iso_1_inv Z):(_⟶_)) _);; m) h_eq);
+  clear h_eq.
+ (*        simpl in h_eq'. (* until here same as in previous lemma *) *)
 
-(*   assert (h_eq2' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ => *)
-(*                 (CoproductIn2 EndC (CPEndC _ _));; m) h_eq'). *)
-(*   clear h_eq'. *)
-(*   assert (h_eq2'_inst := nat_trans_eq_pointwise h_eq2' c). *)
-(*   clear h_eq2'. *)
-(*   match goal with |[ H1 : _  = ?f |- _ = _   ] => *)
-(*                    pathvia (f) end. *)
-(*   - clear h_eq2'_inst. *)
-(*     apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*     unfold aux_iso_1; simpl. *)
-(*     rewrite id_right. *)
-(*     rewrite id_left. *)
-(*     do 3 rewrite <- assoc. *)
-(*     apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*     unfold nat_trans_id; simpl. rewrite id_left. *)
-(*     apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*     unfold nat_trans_fix_snd_arg_data. *)
-(*     apply CoproductIn2Commutes_right_in_double_ctx_dir. *)
-(*     rewrite <- assoc. *)
-(*     apply maponpaths. *)
-(*     eapply pathscomp0. Focus 2. apply assoc. *)
-(*     apply maponpaths. *)
-(*     apply pathsinv0. *)
-(*     apply CoproductIn2Commutes. *)
+  assert (h_eq2' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
+                (CoproductIn2 EndC (CPEndC _ _));; m) h_eq').
+  clear h_eq'.
+  assert (h_eq2'_inst := nat_trans_eq_pointwise h_eq2' c).
+  clear h_eq2'.
+  match goal with |[ H1 : _  = ?f |- _ = _   ] =>
+                   pathvia (f) end.
+  - clear h_eq2'_inst.
+    apply CoproductIn2Commutes_right_in_ctx_dir.
+    unfold aux_iso_1; simpl.
+    rewrite id_right.
+    rewrite id_left.
+    do 3 rewrite <- assoc.
+    apply CoproductIn2Commutes_right_in_ctx_dir.
+    unfold nat_trans_id; simpl. rewrite id_left.
+    apply CoproductIn2Commutes_right_in_ctx_dir.
+    unfold nat_trans_fix_snd_arg_data.
+    apply CoproductIn2Commutes_right_in_double_ctx_dir.
+    rewrite <- assoc.
+    apply maponpaths.
+    eapply pathscomp0. Focus 2. apply assoc.
+    apply maponpaths.
+    apply pathsinv0.
+    apply CoproductIn2Commutes.
 
-(* (* alternative with slightly less precise control: *)
+(* alternative with slightly less precise control: *)
 (*            do 4 rewrite <- assoc. *)
 (*            apply CoproductIn2Commutes_right_in_ctx_dir. *)
 (*            rewrite id_left. *)
@@ -408,13 +401,13 @@ Admitted.
 (*            apply maponpaths. *)
 (*            apply pathsinv0. *)
 (*            apply CoproductIn2Commutes. *)
-(* *) *)
+(* *)
 
-(*   - rewrite <- h_eq2'_inst. clear h_eq2'_inst. *)
-(*     apply CoproductIn2Commutes_left_in_ctx_dir. *)
-(*     repeat rewrite id_left. *)
-(*     apply assoc. *)
-(* Qed. *)
+  - rewrite <- h_eq2'_inst. clear h_eq2'_inst.
+    apply CoproductIn2Commutes_left_in_ctx_dir.
+    repeat rewrite id_left.
+    apply assoc.
+Qed.
 
 (* produce some output to keep TRAVIS running *)
 Check bracket_Thm15_ok_part2.
@@ -426,16 +419,14 @@ Proof.
   split.
   + exact (bracket_Thm15_ok_part1 Z f).
   + exact (bracket_Thm15_ok_part2 Z f).
-Admitted.
-(* Qed. *)
+Qed.
 
 Lemma bracket_Thm15_ok_cor (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧):
  bracket_property f (bracket_Thm15 Z f).
 Proof.
   apply whole_from_parts.
   apply bracket_Thm15_ok.
-Admitted.
-(* Qed. *)
+Qed.
 
 Local Lemma foo' (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
  ∀ t : Σ h : [C, C, hs] ⟦ functor_composite (U Z) (pr1  InitAlg),
@@ -449,60 +440,59 @@ Local Lemma foo' (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
               pr1 InitAlg ⟧,
        bracket_property f h)
       ⦃f⦄ (bracket_Thm15_ok_cor Z f).
-Admitted.
-(* Proof. *)
-(*   intros [h' h'_eq]. *)
-(*   apply subtypeEquality. *)
-(*   - intro. *)
-(*     unfold bracket_property. *)
-(*     apply isaset_nat_trans. exact hs. *)
-(*   - simpl. *)
-(*     apply parts_from_whole in h'_eq. *)
-(* (*    destruct h'_eq as [h'_eq1 h'_eq2]. *) *)
-(*     unfold bracket_Thm15. *)
-(*     apply path_to_ctr. *)
-(*     apply nat_trans_eq; try (exact hs). *)
-(*     intro c; simpl. *)
-(*     unfold coproduct_nat_trans_data. *)
-(*     repeat rewrite (id_left EndC). *)
-(*     rewrite id_right. *)
-(*     repeat rewrite <- assoc. *)
-(*     eapply pathscomp0. Focus 2. eapply pathsinv0. apply postcompWithCoproductArrow. *)
-(*     apply CoproductArrowUnique. *)
-(*     + destruct h'_eq as [h'_eq1 _ ]. (*clear h'_eq2.*) *)
-(*       simpl. *)
-(*       rewrite (id_left C). *)
-(*       assert (h'_eq1_inst := nat_trans_eq_pointwise h'_eq1 c); *)
-(*         clear h'_eq1. *)
-(*       simpl in h'_eq1_inst. *)
-(*       unfold coproduct_nat_trans_in1_data in h'_eq1_inst; simpl in h'_eq1_inst. *)
-(*       rewrite <- assoc in h'_eq1_inst. *)
-(*       eapply pathscomp0. *)
-(*       eapply pathsinv0. *)
-(*       exact h'_eq1_inst. *)
-(*       clear h'_eq1_inst. *)
-(*       apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*       apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*       apply CoproductIn1Commutes_right_dir. *)
-(*         apply idpath. *)
-(*     + destruct h'_eq as [_ h'_eq2]. (*clear h'_eq2.*) *)
-(*       assert (h'_eq2_inst := nat_trans_eq_pointwise h'_eq2 c); *)
-(*         clear h'_eq2. *)
-(*       simpl in h'_eq2_inst. *)
-(*       unfold coproduct_nat_trans_in2_data in h'_eq2_inst; simpl in h'_eq2_inst. *)
-(*       apply pathsinv0 in h'_eq2_inst. *)
-(*       rewrite <- assoc in h'_eq2_inst. *)
-(*       eapply pathscomp0. exact h'_eq2_inst. clear h'_eq2_inst. *)
-(*       apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*       apply CoproductIn2Commutes_right_in_double_ctx_dir. *)
-(*       unfold nat_trans_fix_snd_arg_data; simpl. *)
-(*       do 2 rewrite <- assoc. *)
-(*       apply maponpaths. *)
-(*       rewrite <- assoc. *)
-(*       apply maponpaths. *)
-(*       apply pathsinv0. *)
-(*       apply CoproductIn2Commutes. *)
-(* Qed. *)
+Proof.
+  intros [h' h'_eq].
+  apply subtypeEquality.
+  - intro.
+    unfold bracket_property.
+    apply isaset_nat_trans. exact hs.
+  - simpl.
+    apply parts_from_whole in h'_eq.
+(*    destruct h'_eq as [h'_eq1 h'_eq2]. *)
+    unfold bracket_Thm15.
+    apply path_to_ctr.
+    apply nat_trans_eq; try (exact hs).
+    intro c; simpl.
+    unfold coproduct_nat_trans_data.
+    repeat rewrite (id_left EndC).
+    rewrite id_right.
+    repeat rewrite <- assoc.
+    eapply pathscomp0. Focus 2. eapply pathsinv0. apply postcompWithCoproductArrow.
+    apply CoproductArrowUnique.
+    + destruct h'_eq as [h'_eq1 _ ]. (*clear h'_eq2.*)
+      simpl.
+      rewrite (id_left C).
+      assert (h'_eq1_inst := nat_trans_eq_pointwise h'_eq1 c);
+        clear h'_eq1.
+      simpl in h'_eq1_inst.
+      unfold coproduct_nat_trans_in1_data in h'_eq1_inst; simpl in h'_eq1_inst.
+      rewrite <- assoc in h'_eq1_inst.
+      eapply pathscomp0.
+      eapply pathsinv0.
+      exact h'_eq1_inst.
+      clear h'_eq1_inst.
+      apply CoproductIn1Commutes_right_in_ctx_dir.
+      apply CoproductIn1Commutes_right_in_ctx_dir.
+      apply CoproductIn1Commutes_right_dir.
+        apply idpath.
+    + destruct h'_eq as [_ h'_eq2]. (*clear h'_eq2.*)
+      assert (h'_eq2_inst := nat_trans_eq_pointwise h'_eq2 c);
+        clear h'_eq2.
+      simpl in h'_eq2_inst.
+      unfold coproduct_nat_trans_in2_data in h'_eq2_inst; simpl in h'_eq2_inst.
+      apply pathsinv0 in h'_eq2_inst.
+      rewrite <- assoc in h'_eq2_inst.
+      eapply pathscomp0. exact h'_eq2_inst. clear h'_eq2_inst.
+      apply CoproductIn2Commutes_right_in_ctx_dir.
+      apply CoproductIn2Commutes_right_in_double_ctx_dir.
+      unfold nat_trans_fix_snd_arg_data; simpl.
+      do 2 rewrite <- assoc.
+      apply maponpaths.
+      rewrite <- assoc.
+      apply maponpaths.
+      apply pathsinv0.
+      apply CoproductIn2Commutes.
+Qed.
 
 Definition bracket_for_InitAlg : bracket InitAlg.
 Proof.
@@ -609,8 +599,7 @@ Proof.
     rewrite <- (nat_trans_ax α).
     rewrite functor_id.
     apply id_left.
-Admitted.
-(* Qed. *)
+Qed.
 
 Local Definition iso2' (Z : Ptd) : EndEndC ⟦
   CoproductObject EndEndC
@@ -667,210 +656,209 @@ Lemma ishssMor_InitAlg (T' : hss CP H) :
   @ishssMor C hs CP H
         InitHSS T'
            (InitialArrow IA (pr1 T') : @algebra_mor EndC Id_H InitAlg T' ).
-Admitted.
-(* Proof. *)
-(*   unfold ishssMor. *)
-(*   unfold isbracketMor. *)
-(*   intros Z f. *)
-(*   set (β0 := InitialArrow IA (pr1 T')). *)
-(*   match goal with | [|- _ ;; ?b = _ ] => set (β := b) end. *)
-(*   set ( rhohat := CoproductArrow EndC  (CPEndC _ _ )  β (tau_from_alg T') *)
-(*                   :  pr1 Ghat T' --> T'). *)
-(*   set (X:= SpecializedGMIt Z _ Ghat rhohat (thetahat Z f)). *)
-(*   pathvia (pr1 (pr1 X)). *)
-(*   - set (TT:= fusion_law _ _ _ IA _ hsEndC (pr1 InitAlg) T' _ (KanExt Z)). *)
-(*     set (Psi := ψ_from_comps _ (Id_H) _ hsEndC _ (ℓ (U Z)) (Const_plus_H (U Z)) (ρ_Thm15 Z f) *)
-(*                              (aux_iso_1 Z ;; θ'_Thm15 Z ;; aux_iso_2_inv Z) ). *)
-(*     set (T2 := TT Psi). *)
-(*     set (T3 := T2 (ℓ (U Z)) (KanExt Z)). *)
-(*     set (Psi' := ψ_from_comps _ (Id_H) _ hsEndC _ (ℓ (U Z)) (Ghat) (rhohat) *)
-(*                              (iso1' Z ;; thetahat_0 Z f ;; iso2' Z) ). *)
-(*     set (T4 := T3 Psi'). *)
-(*     set (Φ := (Phi_fusion Z T' β)). *)
-(*     set (T5 := T4 Φ). *)
-(*     pathvia (Φ _ (fbracket InitHSS f)). *)
-(*     + apply idpath. *)
-(*     + eapply pathscomp0. Focus 2. apply T5. *)
-(*       (* hypothesis of fusion law *) *)
-(*       apply funextsec. intro. *)
-(*       simpl. *)
-(*       unfold compose. simpl. *)
-(*       apply nat_trans_eq. assumption. *)
-(*       simpl. *)
-(*       intro c. *)
-(*       rewrite id_right. *)
-(*       rewrite id_right. *)
-(*       (* should be decomposed into two diagrams *) *)
-(*       apply CoproductArrow_eq_cor. *)
-(*       * (* first diagram *) *)
-(*         clear TT T2 T3 T4 T5. *)
-(*         do 5 rewrite <- assoc. *)
-(*         apply CoproductIn1Commutes_left_in_ctx_dir. *)
-(*         apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*         simpl. *)
-(*         rewrite id_left. *)
-(*         apply CoproductIn1Commutes_left_in_ctx_dir. *)
-(*         apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*         simpl. *)
-(*         rewrite id_left. *)
-(*         apply CoproductIn1Commutes_left_in_ctx_dir. *)
-(*         simpl. *)
-(*         rewrite id_left. *)
-(*         apply CoproductIn1Commutes_left_in_ctx_dir. *)
-(*         rewrite <- assoc. *)
-(*         apply maponpaths. *)
-(*         apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*         simpl. *)
-(*         rewrite id_left. *)
-(*         apply CoproductIn1Commutes_right_dir. *)
-(*         apply idpath. *)
-(*       * (* a bit out of order what follows *) *)
-(*         apply cancel_postcomposition. *)
-(*         apply idpath. *)
-(*       * (* second diagram *) *)
-(*         clear TT T2 T3 T4 T5. *)
-(*         do 5 rewrite <- assoc. *)
-(*         apply CoproductIn2Commutes_left_in_ctx_dir. *)
-(*         apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*         rewrite (id_left EndC). *)
-(*         apply CoproductIn2Commutes_left_in_ctx_dir. *)
-(*         apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*         simpl. *)
-(*         unfold nat_trans_fix_snd_arg_data. *)
-(*         repeat rewrite <- assoc. *)
-(*         apply maponpaths. *)
-(*         apply CoproductIn2Commutes_left_in_ctx_dir. *)
-(*         apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*         simpl. *)
-(*         assert (H_nat_inst := functor_comp H _ _ _ t β). *)
-(*         assert (H_nat_inst_c := nat_trans_eq_pointwise H_nat_inst c); clear H_nat_inst. *)
-(*         { *)
-(*           match goal with |[ H1 : _  = ?f |- _ = _;; ?g ;; ?h  ] => *)
-(*              pathvia (f;;g;;h) end. *)
-(*           + clear H_nat_inst_c. *)
-(*             simpl. *)
-(*             repeat rewrite <- assoc. *)
-(*             apply maponpaths. *)
-(*             apply CoproductIn2Commutes_left_in_ctx_dir. *)
-(*             simpl. *)
-(*             unfold coproduct_nat_trans_in2_data, coproduct_nat_trans_data. *)
-(*             assert (Hyp := τ_part_of_alg_mor _ hs CP _ _ _ (InitialArrow IA (pr1 T'))). *)
-(*             assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp. *)
-(*             simpl in Hyp_c. *)
-(*             eapply pathscomp0. eapply pathsinv0. exact Hyp_c. *)
-(*             clear Hyp_c. *)
-(*             apply maponpaths. *)
-(*             apply pathsinv0. *)
-(*             apply CoproductIn2Commutes. *)
-(*           + rewrite <- H_nat_inst_c. *)
-(*             apply idpath. *)
-(*         } *)
-(*   - apply pathsinv0. *)
-(*     apply path_to_ctr. *)
-(*     (* now a lot of serious verification work to be done *) *)
-(*     apply nat_trans_eq; try (exact hs). *)
-(*     intro c. *)
-(*     simpl. *)
-(*     rewrite id_right. *)
-(*     (* look at type: *)
-(*        match goal with | [ |- ?l = _ ] => let ty:= (type of l) in idtac ty end. *) *)
-(*     apply CoproductArrow_eq_cor. *)
-(*     + repeat rewrite <- assoc. *)
-(*       apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*       simpl. *)
-(*       unfold coproduct_nat_trans_in1_data, *)
-(*              coproduct_nat_trans_in2_data, *)
-(*              coproduct_nat_trans_data. *)
-(*       rewrite id_left. *)
-(*       apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*       simpl. *)
-(*       repeat rewrite <- assoc. *)
-(*       eapply pathscomp0. Focus 2. apply maponpaths. apply CoproductIn1Commutes_right_in_ctx_dir. *)
-(*         rewrite id_left. apply CoproductIn1Commutes_right_dir. apply idpath. *)
-(*       do 2 rewrite assoc. *)
-(*       eapply pathscomp0. *)
-(*         apply cancel_postcomposition. *)
-(*         assert (ptd_mor_commutes_inst := ptd_mor_commutes _ (ptd_from_alg_mor _ hs CP H β0) ((pr1 Z) c)). *)
-(*         apply ptd_mor_commutes_inst. *)
-(*       assert (fbracket_η_inst := fbracket_η T' (f;; ptd_from_alg_mor _ hs CP H β0)). *)
-(*       assert (fbracket_η_inst_c := nat_trans_eq_pointwise fbracket_η_inst c); clear fbracket_η_inst. *)
-(*       apply (!fbracket_η_inst_c). *)
-(*     + (* now the difficult case *) *)
-(*       repeat rewrite <- assoc. *)
-(*       apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*       simpl. *)
-(*       unfold coproduct_nat_trans_in1_data, coproduct_nat_trans_in2_data, coproduct_nat_trans_data. *)
-(*       rewrite id_left. *)
-(*       apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*       unfold nat_trans_fix_snd_arg_data. *)
-(*       simpl. *)
-(*       unfold coproduct_nat_trans_in2_data. *)
-(*       repeat rewrite <- assoc. *)
-(*       eapply pathscomp0. Focus 2. *)
-(*         apply maponpaths. *)
-(*         apply CoproductIn2Commutes_right_in_ctx_dir. *)
-(*         rewrite <- assoc. *)
-(*         apply maponpaths. *)
-(*         apply CoproductIn2Commutes_right_dir. *)
-(*         apply idpath. *)
-(*       do 2 rewrite assoc. *)
-(*       eapply pathscomp0. *)
-(*         apply cancel_postcomposition. *)
-(*         eapply pathsinv0. *)
-(*         assert (τ_part_of_alg_mor_inst := τ_part_of_alg_mor _ hs CP H _ _ β0). *)
-(*         assert (τ_part_of_alg_mor_inst_Zc := *)
-(*                   nat_trans_eq_pointwise τ_part_of_alg_mor_inst ((pr1 Z) c)); *)
-(*           clear τ_part_of_alg_mor_inst. *)
-(*         apply τ_part_of_alg_mor_inst_Zc. *)
-(*       simpl. *)
-(*       unfold coproduct_nat_trans_in2_data. *)
-(*       repeat rewrite <- assoc. *)
-(*       eapply pathscomp0. *)
-(*         apply maponpaths. *)
-(*         rewrite assoc. *)
-(*         eapply pathsinv0. *)
-(*         assert (fbracket_τ_inst := fbracket_τ T' (f;; ptd_from_alg_mor _ hs CP H β0)). *)
-(*         assert (fbracket_τ_inst_c := nat_trans_eq_pointwise fbracket_τ_inst c); clear fbracket_τ_inst. *)
-(*         apply fbracket_τ_inst_c. *)
-(*       simpl. *)
-(*       unfold coproduct_nat_trans_in2_data. *)
-(*       repeat rewrite assoc. *)
-(*       apply cancel_postcomposition. *)
-(*       apply cancel_postcomposition. *)
-(*       assert (Hyp: *)
-(*                  ((# (pr1 (ℓ(U Z))) (# H β));; *)
-(*                  (theta H) ((alg_carrier _  T') ⊗ Z);; *)
-(*                  # H (fbracket T' (f;; ptd_from_alg_mor C hs CP H β0)) *)
-(*                  = *)
-(*                  θ (tpair (λ _ : functor C C, ptd_obj C) (alg_carrier _ (InitialObject IA)) Z) ;; *)
-(*                  # H (# (pr1 (ℓ(U Z))) β ;; *)
-(*                  fbracket T' (f;; ptd_from_alg_mor C hs CP H β0)))). *)
+Proof.
+  unfold ishssMor.
+  unfold isbracketMor.
+  intros Z f.
+  set (β0 := InitialArrow IA (pr1 T')).
+  match goal with | [|- _ ;; ?b = _ ] => set (β := b) end.
+  set ( rhohat := CoproductArrow EndC  (CPEndC _ _ )  β (tau_from_alg T')
+                  :  pr1 Ghat T' --> T').
+  set (X:= SpecializedGMIt Z _ Ghat rhohat (thetahat Z f)).
+  pathvia (pr1 (pr1 X)).
+  - set (TT:= fusion_law _ _ _ IA _ hsEndC (pr1 InitAlg) T' _ (KanExt Z)).
+    set (Psi := ψ_from_comps _ (Id_H) _ hsEndC _ (ℓ (U Z)) (Const_plus_H (U Z)) (ρ_Thm15 Z f)
+                             (aux_iso_1 Z ;; θ'_Thm15 Z ;; aux_iso_2_inv Z) ).
+    set (T2 := TT Psi).
+    set (T3 := T2 (ℓ (U Z)) (KanExt Z)).
+    set (Psi' := ψ_from_comps _ (Id_H) _ hsEndC _ (ℓ (U Z)) (Ghat) (rhohat)
+                             (iso1' Z ;; thetahat_0 Z f ;; iso2' Z) ).
+    set (T4 := T3 Psi').
+    set (Φ := (Phi_fusion Z T' β)).
+    set (T5 := T4 Φ).
+    pathvia (Φ _ (fbracket InitHSS f)).
+    + apply idpath.
+    + eapply pathscomp0. Focus 2. apply T5.
+      (* hypothesis of fusion law *)
+      apply funextsec. intro.
+      simpl.
+      unfold compose. simpl.
+      apply nat_trans_eq. assumption.
+      simpl.
+      intro c.
+      rewrite id_right.
+      rewrite id_right.
+      (* should be decomposed into two diagrams *)
+      apply CoproductArrow_eq_cor.
+      * (* first diagram *)
+        clear TT T2 T3 T4 T5.
+        do 5 rewrite <- assoc.
+        apply CoproductIn1Commutes_left_in_ctx_dir.
+        apply CoproductIn1Commutes_right_in_ctx_dir.
+        simpl.
+        rewrite id_left.
+        apply CoproductIn1Commutes_left_in_ctx_dir.
+        apply CoproductIn1Commutes_right_in_ctx_dir.
+        simpl.
+        rewrite id_left.
+        apply CoproductIn1Commutes_left_in_ctx_dir.
+        simpl.
+        rewrite id_left.
+        apply CoproductIn1Commutes_left_in_ctx_dir.
+        rewrite <- assoc.
+        apply maponpaths.
+        apply CoproductIn1Commutes_right_in_ctx_dir.
+        simpl.
+        rewrite id_left.
+        apply CoproductIn1Commutes_right_dir.
+        apply idpath.
+      * (* a bit out of order what follows *)
+        apply cancel_postcomposition.
+        apply idpath.
+      * (* second diagram *)
+        clear TT T2 T3 T4 T5.
+        do 5 rewrite <- assoc.
+        apply CoproductIn2Commutes_left_in_ctx_dir.
+        apply CoproductIn2Commutes_right_in_ctx_dir.
+        rewrite (id_left EndC).
+        apply CoproductIn2Commutes_left_in_ctx_dir.
+        apply CoproductIn2Commutes_right_in_ctx_dir.
+        simpl.
+        unfold nat_trans_fix_snd_arg_data.
+        repeat rewrite <- assoc.
+        apply maponpaths.
+        apply CoproductIn2Commutes_left_in_ctx_dir.
+        apply CoproductIn2Commutes_right_in_ctx_dir.
+        simpl.
+        assert (H_nat_inst := functor_comp H _ _ _ t β).
+        assert (H_nat_inst_c := nat_trans_eq_pointwise H_nat_inst c); clear H_nat_inst.
+        {
+          match goal with |[ H1 : _  = ?f |- _ = _;; ?g ;; ?h  ] =>
+             pathvia (f;;g;;h) end.
+          + clear H_nat_inst_c.
+            simpl.
+            repeat rewrite <- assoc.
+            apply maponpaths.
+            apply CoproductIn2Commutes_left_in_ctx_dir.
+            simpl.
+            unfold coproduct_nat_trans_in2_data, coproduct_nat_trans_data.
+            assert (Hyp := τ_part_of_alg_mor _ hs CP _ _ _ (InitialArrow IA (pr1 T'))).
+            assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp.
+            simpl in Hyp_c.
+            eapply pathscomp0. eapply pathsinv0. exact Hyp_c.
+            clear Hyp_c.
+            apply maponpaths.
+            apply pathsinv0.
+            apply CoproductIn2Commutes.
+          + rewrite <- H_nat_inst_c.
+            apply idpath.
+        }
+  - apply pathsinv0.
+    apply path_to_ctr.
+    (* now a lot of serious verification work to be done *)
+    apply nat_trans_eq; try (exact hs).
+    intro c.
+    simpl.
+    rewrite id_right.
+    (* look at type: *)
+(*        match goal with | [ |- ?l = _ ] => let ty:= (type of l) in idtac ty end. *)
+    apply CoproductArrow_eq_cor.
+    + repeat rewrite <- assoc.
+      apply CoproductIn1Commutes_right_in_ctx_dir.
+      simpl.
+      unfold coproduct_nat_trans_in1_data,
+             coproduct_nat_trans_in2_data,
+             coproduct_nat_trans_data.
+      rewrite id_left.
+      apply CoproductIn1Commutes_right_in_ctx_dir.
+      simpl.
+      repeat rewrite <- assoc.
+      eapply pathscomp0. Focus 2. apply maponpaths. apply CoproductIn1Commutes_right_in_ctx_dir.
+        rewrite id_left. apply CoproductIn1Commutes_right_dir. apply idpath.
+      do 2 rewrite assoc.
+      eapply pathscomp0.
+        apply cancel_postcomposition.
+        assert (ptd_mor_commutes_inst := ptd_mor_commutes _ (ptd_from_alg_mor _ hs CP H β0) ((pr1 Z) c)).
+        apply ptd_mor_commutes_inst.
+      assert (fbracket_η_inst := fbracket_η T' (f;; ptd_from_alg_mor _ hs CP H β0)).
+      assert (fbracket_η_inst_c := nat_trans_eq_pointwise fbracket_η_inst c); clear fbracket_η_inst.
+      apply (!fbracket_η_inst_c).
+    + (* now the difficult case *)
+      repeat rewrite <- assoc.
+      apply CoproductIn2Commutes_right_in_ctx_dir.
+      simpl.
+      unfold coproduct_nat_trans_in1_data, coproduct_nat_trans_in2_data, coproduct_nat_trans_data.
+      rewrite id_left.
+      apply CoproductIn2Commutes_right_in_ctx_dir.
+      unfold nat_trans_fix_snd_arg_data.
+      simpl.
+      unfold coproduct_nat_trans_in2_data.
+      repeat rewrite <- assoc.
+      eapply pathscomp0. Focus 2.
+        apply maponpaths.
+        apply CoproductIn2Commutes_right_in_ctx_dir.
+        rewrite <- assoc.
+        apply maponpaths.
+        apply CoproductIn2Commutes_right_dir.
+        apply idpath.
+      do 2 rewrite assoc.
+      eapply pathscomp0.
+        apply cancel_postcomposition.
+        eapply pathsinv0.
+        assert (τ_part_of_alg_mor_inst := τ_part_of_alg_mor _ hs CP H _ _ β0).
+        assert (τ_part_of_alg_mor_inst_Zc :=
+                  nat_trans_eq_pointwise τ_part_of_alg_mor_inst ((pr1 Z) c));
+          clear τ_part_of_alg_mor_inst.
+        apply τ_part_of_alg_mor_inst_Zc.
+      simpl.
+      unfold coproduct_nat_trans_in2_data.
+      repeat rewrite <- assoc.
+      eapply pathscomp0.
+        apply maponpaths.
+        rewrite assoc.
+        eapply pathsinv0.
+        assert (fbracket_τ_inst := fbracket_τ T' (f;; ptd_from_alg_mor _ hs CP H β0)).
+        assert (fbracket_τ_inst_c := nat_trans_eq_pointwise fbracket_τ_inst c); clear fbracket_τ_inst.
+        apply fbracket_τ_inst_c.
+      simpl.
+      unfold coproduct_nat_trans_in2_data.
+      repeat rewrite assoc.
+      apply cancel_postcomposition.
+      apply cancel_postcomposition.
+      assert (Hyp:
+                 ((# (pr1 (ℓ(U Z))) (# H β));;
+                 (theta H) ((alg_carrier _  T') ⊗ Z);;
+                 # H (fbracket T' (f;; ptd_from_alg_mor C hs CP H β0))
+                 =
+                 θ (tpair (λ _ : functor C C, ptd_obj C) (alg_carrier _ (InitialObject IA)) Z) ;;
+                 # H (# (pr1 (ℓ(U Z))) β ;;
+                 fbracket T' (f;; ptd_from_alg_mor C hs CP H β0)))).
 
-(*       Focus 2. *)
-(*       assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp. *)
-(*       exact Hyp_c. *)
+      Focus 2.
+      assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp.
+      exact Hyp_c.
 
-(*       clear c. clear X. clear rhohat. *)
-(*       rewrite (functor_comp H). *)
-(*       rewrite assoc. *)
-(*       apply cancel_postcomposition. *)
-(*       fold θ. *)
-(*       apply nat_trans_eq; try (exact hs). *)
-(*       intro c. *)
-(*       assert (θ_nat_1_pointwise_inst := θ_nat_1_pointwise _ hs H θ _ _ β Z c). *)
-(*       eapply pathscomp0 ; [exact θ_nat_1_pointwise_inst | ]. *)
-(*       clear θ_nat_1_pointwise_inst. *)
-(*       simpl. *)
-(*       apply maponpaths. *)
-(*       assert (Hyp: # H (β ∙∙ nat_trans_id (pr1 Z)) = # H (# (pr1 (ℓ(U Z))) β)). *)
-(*       { apply maponpaths. *)
-(*         apply nat_trans_eq; try (exact hs). *)
-(*         intro c'. *)
-(*         simpl. *)
-(*         rewrite functor_id. *)
-(*         apply id_right. } *)
-(*       apply (nat_trans_eq_pointwise Hyp c). *)
-(* Qed. *)
+      clear c. clear X. clear rhohat.
+      rewrite (functor_comp H).
+      rewrite assoc.
+      apply cancel_postcomposition.
+      fold θ.
+      apply nat_trans_eq; try (exact hs).
+      intro c.
+      assert (θ_nat_1_pointwise_inst := θ_nat_1_pointwise _ hs H θ _ _ β Z c).
+      eapply pathscomp0 ; [exact θ_nat_1_pointwise_inst | ].
+      clear θ_nat_1_pointwise_inst.
+      simpl.
+      apply maponpaths.
+      assert (Hyp: # H (β ∙∙ nat_trans_id (pr1 Z)) = # H (# (pr1 (ℓ(U Z))) β)).
+      { apply maponpaths.
+        apply nat_trans_eq; try (exact hs).
+        intro c'.
+        simpl.
+        rewrite functor_id.
+        apply id_right. }
+      apply (nat_trans_eq_pointwise Hyp c).
+Qed.
 
 Definition hss_InitMor : ∀ T' : hss CP H, hssMor InitHSS T'.
 Proof.
@@ -885,8 +873,7 @@ Proof.
   intro t.
   apply (invmap (hssMor_eq1 _ _ _ _ _ _ _ _ )).
   apply (@InitialArrowUnique _ IA (pr1 T') (pr1 t)).
-Admitted.
-(* Qed. *)
+Qed.
 
 Lemma isInitial_InitHSS : isInitial (hss_precategory CP H) InitHSS.
 Proof.

--- a/UniMath/SubstitutionSystems/ProductOfSignatures.v
+++ b/UniMath/SubstitutionSystems/ProductOfSignatures.v
@@ -6,8 +6,7 @@ Contents :
      strength laws for the product
 
 
-Written by Anders Mörtberg, 2016 (adapted from SumOfSignatures
-
+Written by Anders Mörtberg, 2016 (adapted from SumOfSignatures.v)
 
 
 ************************************************************)
@@ -25,6 +24,9 @@ Require Import UniMath.CategoryTheory.PointedFunctorsComposition.
 Require Import UniMath.SubstitutionSystems.Signatures.
 Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseProduct.
 Require Import UniMath.SubstitutionSystems.Notation.
+Require Import UniMath.CategoryTheory.chains.
+Require Import UniMath.CategoryTheory.cocontfunctors.
+Require Import UniMath.CategoryTheory.exponentials.
 
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 Local Notation "F ⟶ G" := (nat_trans F G) (at level 39).
@@ -272,5 +274,18 @@ Proof.
   + apply ProductStrength2'; assumption.
 Defined.
 
+Lemma is_omega_cocont_Product_of_Signatures (S1 S2 : Signature C hsC)
+  (h1 : is_omega_cocont S1) (h2 : is_omega_cocont S2)
+  (hE : has_exponentials (Products_functor_precat C C PC hsC)) :
+  is_omega_cocont (Product_of_Signatures S1 S2).
+Proof.
+destruct S1 as [F1 [F2 [F3 F4]]]; simpl in *.
+destruct S2 as [G1 [G2 [G3 G4]]]; simpl in *.
+unfold H.
+apply is_omega_cocont_product_functor; try assumption.
+- apply (Products_functor_precat _ _ PC).
+- apply functor_category_has_homsets.
+- apply functor_category_has_homsets.
+Defined.
 
 End product_of_signatures.

--- a/UniMath/SubstitutionSystems/ProductOfSignatures.v
+++ b/UniMath/SubstitutionSystems/ProductOfSignatures.v
@@ -1,0 +1,276 @@
+(** **********************************************************
+
+Contents :
+
+- Definition of the product of two signatures, in particular proof of
+     strength laws for the product
+
+
+Written by Anders Mörtberg, 2016 (adapted from SumOfSignatures
+
+
+
+************************************************************)
+
+Require Import UniMath.Foundations.Basics.PartD.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.ProductPrecategory.
+Require Import UniMath.CategoryTheory.PointedFunctors.
+Require Import UniMath.CategoryTheory.PointedFunctorsComposition.
+Require Import UniMath.SubstitutionSystems.Signatures.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseProduct.
+Require Import UniMath.SubstitutionSystems.Notation.
+
+Local Notation "# F" := (functor_on_morphisms F)(at level 3).
+Local Notation "F ⟶ G" := (nat_trans F G) (at level 39).
+Local Notation "G □ F" := (functor_composite _ _ _ F G) (at level 35).
+
+Arguments θ_source {_ _} _ .
+Arguments θ_target {_ _} _ .
+Arguments θ_Strength1 {_ _ _} _ .
+Arguments θ_Strength2 {_ _ _} _ .
+Arguments θ_Strength1_int {_ _ _} _ .
+Arguments θ_Strength2_int {_ _ _} _ .
+
+Section product_of_signatures.
+
+Variable C : precategory.
+Variable hsC : has_homsets C.
+Variable PC : Products C.
+
+Section construction.
+
+Local Notation "'CCC'" := (Products_functor_precat C C PC hsC : Products [C, C, hsC]).
+
+Variables H1 H2 : functor [C, C, hsC] [C, C, hsC].
+
+Variable θ1 : θ_source H1 ⟶ θ_target H1.
+Variable θ2 : θ_source H2 ⟶ θ_target H2.
+
+Variable S11 : θ_Strength1 θ1.
+Variable S12 : θ_Strength2 θ1.
+Variable S21 : θ_Strength1 θ2.
+Variable S22 : θ_Strength2 θ2.
+
+(** * Definition of the data of the product of two signatures *)
+
+Definition H : functor [C, C, hsC] [C, C, hsC] := product_functor _ _ CCC H1 H2.
+
+Local Definition bla1 (X : [C, C, hsC]) (Z : precategory_Ptd C hsC) :
+   ∀ c : C,
+    (functor_composite_data (pr1 Z)
+     (product_functor_data C C PC (H1 X) (H2 X))) c
+   --> (product_functor_data C C PC (H1 (functor_composite (pr1 Z) X))
+       (H2 (functor_composite (pr1 Z) X))) c.
+Proof.
+  intro c.
+  apply ProductOfArrows.
+  - exact (pr1 (θ1 (X ⊗ Z)) c).
+  - exact (pr1 (θ2 (X ⊗ Z)) c).
+Defined.
+
+Local Lemma bar (X : [C, C, hsC]) (Z : precategory_Ptd C hsC):
+   is_nat_trans
+     (functor_composite_data (pr1 Z)
+        (product_functor_data C C PC (H1 X) (H2 X)))
+     (product_functor_data C C PC (H1 (functor_composite (pr1 Z) X))
+        (H2 (functor_composite (pr1 Z) X))) (bla1 X Z).
+Proof.
+  intros x x' f; simpl.
+  unfold bla1; simpl.
+  unfold product_functor_mor.
+  eapply pathscomp0; [ apply ProductOfArrows_comp | ].
+  eapply pathscomp0; [ | eapply pathsinv0; apply ProductOfArrows_comp].
+  apply ProductOfArrows_eq.
+  * apply (nat_trans_ax (θ1 (X ⊗ Z))).
+  * apply (nat_trans_ax (θ2 (X ⊗ Z))).
+Qed.
+
+Local Definition bla (X : [C, C, hsC]) (Z : precategory_Ptd C hsC) :
+   functor_composite_data (pr1 Z)
+     (product_functor_data C C PC (H1 X) (H2 X))
+   ⟶ product_functor_data C C PC (H1 (functor_composite (pr1 Z) X))
+       (H2 (functor_composite (pr1 Z) X)).
+Proof.
+  exists (bla1 X Z).
+  apply bar.
+Defined.
+
+
+Definition θ_ob : ∀ XF, θ_source H XF --> θ_target H XF.
+Proof.
+  intro XZ.
+  destruct XZ as [X Z].
+  apply bla.
+Defined.
+
+
+Local Lemma is_nat_trans_θ_ob :
+ is_nat_trans (θ_source_functor_data C hsC H) (θ_target_functor_data C hsC H)
+     θ_ob.
+Proof.
+  intros XZ X'Z' αβ.
+  assert (Hyp1:= nat_trans_ax θ1 _ _ αβ).
+  assert (Hyp2:= nat_trans_ax θ2 _ _ αβ).
+  apply nat_trans_eq.
+  - exact hsC.
+  - intro c; simpl.
+    destruct XZ as [X Z].
+    destruct X'Z' as [X' Z'].
+    destruct αβ as [α β]. simpl in *.
+    unfold product_nat_trans_data;
+    unfold bla1; simpl.
+    unfold product_functor_mor.
+    unfold product_nat_trans_pr2_data.
+    unfold product_nat_trans_pr1_data.
+    eapply pathscomp0; [ | eapply pathsinv0; apply ProductOfArrows_comp].
+    eapply pathscomp0. apply cancel_postcomposition. apply ProductOfArrows_comp.
+    eapply pathscomp0. apply ProductOfArrows_comp.
+    apply ProductOfArrows_eq.
+    + apply (nat_trans_eq_pointwise Hyp1 c).
+    + apply (nat_trans_eq_pointwise Hyp2 c).
+Qed.
+
+Local Definition θ : θ_source H ⟶ θ_target H.
+Proof.
+  exists θ_ob.
+  apply is_nat_trans_θ_ob.
+Defined.
+
+(** * Proof of the laws of the product of two signatures *)
+
+Lemma ProductStrength1 : θ_Strength1 θ.
+Proof.
+  unfold θ_Strength1.
+  intro X.
+  apply nat_trans_eq.
+  - apply hsC.
+  - intro x.
+    simpl.
+    unfold bla1.
+    unfold product_nat_trans_data.
+
+    eapply pathscomp0. apply ProductOfArrows_comp.
+     apply pathsinv0.
+     apply Product_endo_is_identity.
+     + rewrite ProductOfArrowsPr1.
+       unfold θ_Strength1 in S11.
+       assert (Ha := nat_trans_eq_pointwise (S11 X) x).
+       eapply pathscomp0; [ | apply id_right].
+       apply maponpaths.
+       apply Ha.
+     + rewrite ProductOfArrowsPr2.
+       unfold θ_Strength1 in S21.
+       assert (Ha := nat_trans_eq_pointwise (S21 X) x).
+       eapply pathscomp0; [ | apply id_right].
+       apply maponpaths.
+       apply Ha.
+Qed.
+
+Lemma ProductStrength2 : θ_Strength2 θ.
+Proof.
+  intros X Z Z' Y α.
+  apply (nat_trans_eq hsC).
+    intro x.
+    eapply pathscomp0. apply ProductOfArrows_comp.
+    apply pathsinv0.
+    eapply pathscomp0. apply cancel_postcomposition. simpl. apply ProductOfArrows_comp.
+    eapply pathscomp0. apply ProductOfArrows_comp.
+    apply pathsinv0.
+    apply ProductOfArrows_eq.
+       - assert (Ha:=S12 X Z Z' Y α).
+         simpl in Ha.
+         assert (Ha_x := nat_trans_eq_pointwise Ha x).
+         apply Ha_x.
+       - assert (Ha:=S22 X Z Z' Y α).
+         simpl in Ha.
+         assert (Ha_x := nat_trans_eq_pointwise Ha x).
+         apply Ha_x.
+Qed.
+
+Variable S11' : θ_Strength1_int θ1.
+Variable S12' : θ_Strength2_int θ1.
+Variable S21' : θ_Strength1_int θ2.
+Variable S22' : θ_Strength2_int θ2.
+
+Lemma ProductStrength1' : θ_Strength1_int θ.
+Proof.
+  clear S11 S12 S21 S22 S12' S22'.
+  unfold θ_Strength1_int.
+  intro X.
+  apply nat_trans_eq.
+  - apply hsC.
+  - intro x.
+    simpl.
+    unfold bla1.
+    unfold product_nat_trans_data.
+
+    eapply pathscomp0. apply ProductOfArrows_comp.
+     apply pathsinv0.
+     apply Product_endo_is_identity.
+     + rewrite ProductOfArrowsPr1.
+       red in S11'.
+       assert (Ha := nat_trans_eq_pointwise (S11' X) x).
+       simpl in Ha.
+       eapply pathscomp0; [ | apply id_right].
+       apply maponpaths.
+       apply Ha.
+     + rewrite ProductOfArrowsPr2.
+       red in S21'.
+       assert (Ha := nat_trans_eq_pointwise (S21' X) x).
+       simpl in Ha.
+       eapply pathscomp0; [ | apply id_right].
+       apply maponpaths.
+       apply Ha.
+Qed.
+
+
+Lemma ProductStrength2' : θ_Strength2_int θ.
+Proof.
+  clear S11 S12 S21 S22 S11' S21'.
+  unfold θ_Strength2_int.
+  intros X Z Z'.
+  apply nat_trans_eq; try assumption.
+    intro x.
+    simpl.
+    rewrite id_left.
+    eapply pathscomp0. apply ProductOfArrows_comp.
+    apply pathsinv0.
+    eapply pathscomp0. apply ProductOfArrows_comp.
+    apply pathsinv0.
+    apply ProductOfArrows_eq.
+       - assert (Ha:=S12' X Z Z').
+         simpl in Ha.
+         assert (Ha_x := nat_trans_eq_pointwise Ha x).
+         simpl in Ha_x.
+         rewrite id_left in Ha_x.
+         apply Ha_x.
+       - assert (Ha:=S22' X Z Z').
+         simpl in Ha.
+         assert (Ha_x := nat_trans_eq_pointwise Ha x).
+         simpl in Ha_x.
+         rewrite id_left in Ha_x.
+         apply Ha_x.
+Qed.
+
+End construction.
+
+
+Definition Product_of_Signatures (S1 S2: Signature C hsC): Signature C hsC.
+Proof.
+  destruct S1 as [H1 [θ1 [S11' S12']]].
+  destruct S2 as [H2 [θ2 [S21' S22']]].
+  exists (H H1 H2).
+  exists (θ H1 H2 θ1 θ2).
+  split.
+  + apply ProductStrength1'; assumption.
+  + apply ProductStrength2'; assumption.
+Defined.
+
+
+End product_of_signatures.

--- a/UniMath/SubstitutionSystems/SigToMonad.v
+++ b/UniMath/SubstitutionSystems/SigToMonad.v
@@ -200,7 +200,7 @@ Variable δ2 : δ_source C hsC G2 ⟶ δ_target C hsC G2.
 Hypothesis (δ1_law1 : δ_law1 C hsC G1 δ1) (δ1_law2 : δ_law2 C hsC G1 δ1).
 Hypothesis (δ2_law1 : δ_law1 C hsC G2 δ2) (δ2_law2 : δ_law2 C hsC G2 δ2).
 
-Definition δ_comp : δ_source C hsC (G2• G1 : [C,C,hsC]) ⟶ δ_target C hsC (G2 • G1 : [C,C,hsC]).
+Definition δ_comp : δ_source C hsC (G2 • G1 : [C,C,hsC]) ⟶ δ_target C hsC (G2 • G1 : [C,C,hsC]).
 Proof.
 mkpair.
 - intros Ze.
@@ -219,17 +219,68 @@ rewrite assoc.
 eapply cancel_postcomposition.
 eapply pathsinv0.
 apply functor_comp.
-unfold is_ptd_mor in X.
 simpl in *.
+eapply pathscomp0.
+eapply cancel_postcomposition.
+eapply maponpaths.
+generalize (nat_trans_eq_pointwise (nat_trans_ax δ1 (Z,,e) (Z',, e') (α,,X)) c).
+simpl; rewrite id_left, functor_id, id_right; intro H1.
+apply H1.
+rewrite functor_comp, <- assoc.
+eapply pathscomp0.
+eapply maponpaths.
+generalize (nat_trans_eq_pointwise (nat_trans_ax δ2 (Z,,e) (Z',, e') (α,,X)) (G1 c)).
+simpl; rewrite id_left, functor_id, id_right; intro H2.
+apply H2.
+now rewrite assoc.
+Defined.
 
-assert (lol : # G1 (α c) ;; pr1 (δ1 (Z',, e')) c = pr1 (δ1 (Z,, e)) c ;; α (G1 c)).
-generalize (nat_trans_ax (δ1 (Z',, e'))).
+Lemma δ_comp_law1 : δ_law1 C hsC (G2 • G1 : [C,C,hsC]) δ_comp.
+Proof.
+apply (nat_trans_eq hsC); intro c; simpl.
+rewrite !id_left, id_right.
+unfold δ_law1 in *.
+eapply pathscomp0.
+eapply maponpaths.
+apply (nat_trans_eq_pointwise δ2_law1 (G1 c)).
+eapply pathscomp0.
+eapply cancel_postcomposition.
+eapply maponpaths.
+apply (nat_trans_eq_pointwise δ1_law1 c).
+now rewrite id_right; apply functor_id.
+Qed.
+
+Lemma δ_comp_law2 : δ_law2 C hsC (G2 • G1 : [C,C,hsC]) δ_comp.
+Proof.
+intros Ze Ze'.
+apply (nat_trans_eq hsC); intro c; simpl.
+rewrite !id_left, !id_right.
+eapply pathscomp0.
+eapply cancel_postcomposition.
+eapply maponpaths.
+apply (nat_trans_eq_pointwise (δ1_law2 Ze Ze') c).
+eapply pathscomp0.
+eapply maponpaths.
+apply (nat_trans_eq_pointwise (δ2_law2 Ze Ze') (G1 c)).
 simpl.
-generalize (nat_trans_ax α).
+rewrite !id_left, !id_right.
+eapply pathscomp0.
+eapply cancel_postcomposition.
+apply functor_comp.
+rewrite <- !assoc.
+apply maponpaths.
+destruct Ze as [Z e]; simpl in *.
+destruct Ze' as [Z' e']; simpl in *.
+rewrite assoc.
+eapply pathscomp0.
+eapply cancel_postcomposition.
+apply (nat_trans_ax (δ2 (Z',,e')) _ _ (pr1 (δ1 (Z,, e)) c)).
 simpl.
-admit.
-admit.
-Admitted.
+rewrite <- !assoc.
+apply maponpaths.
+apply pathsinv0.
+now apply functor_comp.
+Qed.
 
 End δ_mul.
 

--- a/UniMath/SubstitutionSystems/SigToMonad.v
+++ b/UniMath/SubstitutionSystems/SigToMonad.v
@@ -94,119 +94,230 @@ Definition Sig : UU := list (list nat).
 Let precomp_option := omega_cocont_pre_composition_functor _ _ _
                         (option_functor HSET CoproductsHSET TerminalHSET) has_homsets_HSET has_homsets_HSET cats_LimsHSET.
 
+Let optionHSET := (option_functor HSET CoproductsHSET TerminalHSET).
+
 (* This would have been nice, but it adds an extra Id in the end *)
 (* Local Definition SigToFunctor_helper2 (n : nat) : omega_cocont_functor HSET2 HSET2 := *)
 (*   omega_cocont_iter_functor has_homsets_HSET2 (precomp_option) n. *)
 
-Local Fixpoint SigToFunctor_helper2 (n : nat) : omega_cocont_functor HSET2 HSET2 := match n with
-  | O => Id
-  | S O => precomp_option
-  | S n' => let G := omega_cocont_pre_composition_functor _ _ _
-                       (option_functor HSET CoproductsHSET TerminalHSET) has_homsets_HSET has_homsets_HSET cats_LimsHSET
-               (* is this order correct???? *)
-            in omega_cocont_functor_composite has_homsets_HSET2 G (SigToFunctor_helper2 n')
+Fixpoint iter_functor1 {C : precategory} (F : functor C C) (n : nat) : functor C C := match n with
+  | O => F
+  | S n' => functor_composite (iter_functor F n') F
   end.
+
+(* This constructs: _ o option^n *)
+(* Local Definition precomp_option_iter (n : nat) : omega_cocont_functor HSET2 HSET2 := match n with *)
+(*   | O => Id *)
+(*   | S n => omega_cocont_pre_composition_functor _ _ _ *)
+(*              (iter_functor1 optionHSET n) has_homsets_HSET has_homsets_HSET cats_LimsHSET *)
+(*   end. *)
+
+(* (* Old version: *) *)
+(* (* Local Fixpoint precomp_option_iter (n : nat) : omega_cocont_functor HSET2 HSET2 := match n with *) *)
+(* (*   | O => Id *) *)
+(* (*   | S O => precomp_option *) *)
+(* (*   | S n' => let G := omega_cocont_pre_composition_functor _ _ _ *) *)
+(* (*                        (option_functor HSET CoproductsHSET TerminalHSET) has_homsets_HSET has_homsets_HSET cats_LimsHSET *) *)
+(* (*                (* is this order correct???? *) *) *)
+(* (*             in omega_cocont_functor_composite has_homsets_HSET2 G (iter_precomp_option n') *) *)
+(* (*   end. *) *)
+
+(* (* Definition SigToFunctor_helper2_Signature (n : nat) : Signature HSET has_homsets_HSET. *) *)
+(* (* Proof. *) *)
+(* (* mkpair. *) *)
+(* (* - apply (precom n). *) *)
+(* (* - mkpair; simpl. *) *)
+(* (* + *) *)
+
+(* Local Definition arity_to_functor : list nat -> omega_cocont_functor HSET2 HSET2. *)
 (* Proof. *)
-(* intro n. *)
-(* induction n as [|_ F]. *)
+(* intro l. *)
+(* generalize (map_list precomp_option_iter l). *)
+(* apply foldr1_list. *)
+(* - intros F G. *)
+(*   apply (F * G). *)
 (* - apply Id. *)
-(* - *)
-(* set (G := (omega_cocont_pre_composition_functor _ _ _ *)
-(*             (option_functor HSET CoproductsHSET TerminalHSET) has_homsets_HSET has_homsets_HSET cats_LimsHSET)). *)
-(* (* is this order correct???? *) *)
-(* apply (omega_cocont_functor_composite has_homsets_HSET2 G F). *)
 (* Defined. *)
 
-Local Definition SigToFunctor_helper : list nat -> omega_cocont_functor HSET2 HSET2.
+(* Arguments arity_to_functor : simpl never. *)
+
+(* Definition SigToFunctor : Sig -> omega_cocont_functor HSET2 HSET2. *)
+(* Proof. *)
+(* use foldr_list. *)
+(* - intros l F. *)
+(*   apply (arity_to_functor l + F). *)
+(* - apply Id. *)
+(* Defined. *)
+
+
+(* New version *)
+Eval cbn in (pr1 Id).
+
+Definition precomp_option_iter (n : nat) : functor HSET2 HSET2 := match n with
+  | O => functor_identity HSET2
+  | S n => pre_composition_functor _ _ _ has_homsets_HSET _ (iter_functor1 optionHSET n)
+  end.
+
+Arguments iter_functor1 : simpl never.
+
+Lemma is_omega_cocont_precomp_option_iter (n : nat) : is_omega_cocont (precomp_option_iter n).
 Proof.
-intro l.
-generalize (map_list SigToFunctor_helper2 l).
-apply foldr1_list.
-- intros F G.
-  apply (F * G).
-- apply Id.
+destruct n; simpl.
+- apply (is_omega_cocont_functor_identity _ has_homsets_HSET2).
+- apply (is_omega_cocont_pre_composition_functor _ _ _ (iter_functor1 optionHSET n) _ _ cats_LimsHSET).
+Qed.
+
+Definition apa (n : nat) : Σ
+   θ : θ_source_functor_data _ _ (precomp_option_iter n)
+       ⟶ θ_target_functor_data _ _ (precomp_option_iter n),
+       θ_Strength1_int θ × θ_Strength2_int θ.
+Admitted.
+
+Definition precomp_option_iter_Signature (n : nat) : Signature HSET has_homsets_HSET.
+Proof.
+mkpair.
+- apply (precomp_option_iter n).
+- apply apa.
 Defined.
 
-Definition SigToFunctor : Sig -> omega_cocont_functor HSET2 HSET2.
+Lemma is_omega_cocont_precomp_iter_Signature (n : nat) : is_omega_cocont (precomp_option_iter_Signature n).
+Proof.
+apply is_omega_cocont_precomp_option_iter.
+Qed.
+
+(* Local Definition arity_to_functor : list nat -> omega_cocont_functor HSET2 HSET2. *)
+(* Proof. *)
+(* intro l. *)
+(* generalize (map_list precomp_option_iter l). *)
+(* apply foldr1_list. *)
+(* - intros F G. *)
+(*   apply (F * G). *)
+(* - apply Id. *)
+(* Defined. *)
+
+(* Arguments arity_to_functor : simpl never. *)
+
+Definition bepa  (S1 S2 : Signature HSET has_homsets_HSET) : Σ
+   θ : θ_source_functor_data _ _ (product_functor _ _ ProductsHSET2 S1 S2)
+    ⟶ θ_target_functor_data _ _ (product_functor _ _ ProductsHSET2 S1 S2),
+       θ_Strength1_int θ × θ_Strength2_int θ.
+Admitted.
+
+Definition Product_of_Signatures (S1 S2 : Signature HSET has_homsets_HSET) : Signature HSET has_homsets_HSET.
+Proof.
+mkpair.
+- apply (product_functor _ _ ProductsHSET2 S1 S2).
+- apply bepa.
+Defined.
+
+Lemma is_omega_cocont_Product_of_Signatures (S1 S2 : Signature HSET has_homsets_HSET)
+  (h1 : is_omega_cocont S1) (h2 : is_omega_cocont S2) :
+  is_omega_cocont (Product_of_Signatures S1 S2).
+Proof.
+apply is_omega_cocont_product_functor; try assumption.
+- apply ProductsHSET2.
+- apply has_exponentials_HSET2.
+- apply has_homsets_HSET2.
+- apply has_homsets_HSET2.
+Qed.
+
+(* Signature for the Id functor *)
+Definition IdSignature : Signature HSET has_homsets_HSET.
+Proof.
+mkpair.
+- apply Id.
+- mkpair; simpl.
+  + mkpair; simpl.
+    * intro x.
+      { mkpair.
+        - intro y; simpl; apply idfun.
+        - abstract (intros y y' f; apply idpath).
+      }
+    * abstract (intros y y' f; apply (nat_trans_eq has_homsets_HSET); intro z; apply idpath).
+  + abstract (split;
+               [ intros x; apply (nat_trans_eq has_homsets_HSET); intro z; apply idpath
+               | intros x y z; apply (nat_trans_eq has_homsets_HSET); intro w; apply idpath]).
+Defined.
+
+Definition Arity_to_Signature : list nat -> Signature HSET has_homsets_HSET.
+Proof.
+intros xs.
+generalize (map_list precomp_option_iter_Signature xs).
+apply foldr1_list.
+- apply Product_of_Signatures.
+- apply IdSignature.
+Defined.
+
+
+(* Definition foldr1_list {A : UU} (f : A -> A -> A) (a : A) (l : list A) : A. *)
+(* Proof. *)
+(* destruct l as [n xs]. *)
+(* destruct n. *)
+(* - apply a. *)
+(* - induction n as [|n F]. *)
+(*   + apply (pr1 xs). *)
+(*   + apply (f (pr1 xs) (F (pr2 xs))). *)
+(* Defined. *)
+
+
+Lemma is_omega_cocont_Arity_to_Signature (xs : list nat) : is_omega_cocont (Arity_to_Signature xs).
+Proof.
+destruct xs as [n xs].
+destruct n.
+- destruct xs; simpl; apply (is_omega_cocont_functor_identity _ has_homsets_HSET2).
+- induction n.
++
+destruct xs as [m xs].
+destruct xs; simpl.
+apply is_omega_cocont_precomp_option_iter.
++
+unfold Arity_to_Signature.
+simpl in *.
+destruct xs as [m xs].
+generalize (IHn xs).
+destruct xs.
+apply is_omega_cocont_Product_of_Signatures.
+apply is_omega_cocont_precomp_option_iter.
+Defined.
+
+Definition SigToSignature : Sig -> Signature HSET has_homsets_HSET.
 Proof.
 use foldr_list.
 - intros l F.
-  apply (SigToFunctor_helper l + F).
-- apply Id.
+  apply (Sum_of_Signatures _ _ CoproductsHSET (Arity_to_Signature l) F).
+- apply IdSignature.
 Defined.
 
-(* Test lambda calculus *)
-Section test_lam.
-
-Infix "::" := (cons_list nat).
-Notation "[]" := (nil_list nat) (at level 0, format "[]").
-
-(* The signature of the lambda calculus: [[0,0],[1]] *)
-Definition LamSig : Sig := cons_list (list nat) (0 :: 0 :: []) (cons_list (list nat) (1 :: []) (nil_list (list nat))).
-
-Eval cbn in SigToFunctor LamSig.
-
-Require Import UniMath.SubstitutionSystems.LamHSET.
-
-Let Lam_S : Signature HSET has_homsets_HSET :=
-  Lam_Sig HSET has_homsets_HSET TerminalHSET CoproductsHSET ProductsHSET.
-
-Check (pr1 Lam_S).
-Goal (pr1 Lam_S = pr1 (SigToFunctor LamSig)).
-simpl.
-apply subtypeEquality.
-intros x.
-apply isaprop_is_functor.
-apply (functor_category_has_homsets HSET HSET has_homsets_HSET).
-simpl.
-unfold App_H, square_functor.
-unfold Abs_H.
-apply maponpaths.
-admit.
-Abort. (* equal if we add Id *)
-
-End test_lam.
-
-Variable (sig : Sig).
-
-Definition SigToSignature : Signature HSET has_homsets_HSET.
+Lemma is_omega_cocont_Sum_of_Signatures (S1 S2 : Signature HSET has_homsets_HSET)
+  (h1 : is_omega_cocont S1) (h2 : is_omega_cocont S2) :
+  is_omega_cocont (Sum_of_Signatures _ _ CoproductsHSET S1 S2).
 Proof.
-mkpair.
-- apply (SigToFunctor sig).
-- mkpair.
-+ destruct sig as [n xs].
-  induction n.
-  { - destruct xs; simpl.
-      mkpair.
-      + simpl; intro x; destruct x as [F x]; simpl.
-        mkpair.
-      * simpl.
-        intro y.
-        apply idfun.
-      *
-        intros y y' f.
-        simpl.
-        apply idpath.
-      + intros y y' f.
-        apply (nat_trans_eq has_homsets_HSET).
-        intro x; simpl.
-        destruct y.
-        destruct y'.
-        simpl.
-        apply idpath.
-  }
-  { mkpair.
-    - simpl; intro y.
-      mkpair.
-      + admit.
-      + admit.
-    - admit.
-  }
-+ admit.
-Admitted.
+destruct S1 as [F1 [F2 [F3 F4]]]; simpl in *.
+destruct S2 as [G1 [G2 [G3 G4]]]; simpl in *.
+unfold H.
+apply is_omega_cocont_coproduct_functor; try assumption.
+- apply ProductsHSET2.
+- apply has_homsets_HSET2.
+- apply has_homsets_HSET2.
+Qed.
 
-Definition SigInitial : Initial (FunctorAlg (Id_H HSET has_homsets_HSET CoproductsHSET SigToSignature)
-                                (functor_category_has_homsets HSET HSET has_homsets_HSET)).
+Lemma is_omega_cocont_SigToSignature (s : Sig) : is_omega_cocont (SigToSignature s).
+Proof.
+destruct s as [n xs].
+induction n.
+destruct xs.
+simpl.
+apply (is_omega_cocont_functor_identity _ has_homsets_HSET2).
+simpl.
+destruct xs.
+apply is_omega_cocont_Sum_of_Signatures.
+apply is_omega_cocont_Arity_to_Signature.
+apply IHn.
+Qed.
+
+Definition SigInitial (sig : Sig) :
+  Initial (FunctorAlg (Id_H HSET has_homsets_HSET CoproductsHSET (SigToSignature sig))
+                            (functor_category_has_homsets HSET HSET has_homsets_HSET)).
 Proof.
 use colimAlgInitial.
 - unfold Id_H, Const_plus_H.
@@ -215,25 +326,58 @@ use colimAlgInitial.
   + apply functor_category_has_homsets.
   + apply functor_category_has_homsets.
   + apply is_omega_cocont_constant_functor; apply functor_category_has_homsets.
-  + admit.
+  + apply is_omega_cocont_SigToSignature.
 - apply (Initial_functor_precat _ _ InitialHSET).
 - apply ColimsFunctorCategory; apply ColimsHSET.
-Admitted.
+Defined.
 
-Definition SigInitialHSS : Initial (hss_precategory CoproductsHSET SigToSignature).
+Definition SigInitialHSS (sig : Sig) : Initial (hss_precategory CoproductsHSET (SigToSignature sig)).
 Proof.
 apply InitialHSS.
 - intro Z; apply RightKanExtension_from_limits, cats_LimsHSET.
 - apply SigInitial.
 Defined.
 
-Definition SigToMonad : Monad HSET.
+Definition SigToMonad (sig : Sig) : Monad HSET.
 Proof.
 use Monad_from_hss.
 - apply has_homsets_HSET.
 - apply CoproductsHSET.
-- apply SigToSignature.
+- apply (SigToSignature sig).
 - apply SigInitialHSS.
 Defined.
 
 End SigToMonad.
+
+
+(* (* Test lambda calculus *) *)
+(* Section test_lam. *)
+
+(* Infix "::" := (cons_list nat). *)
+(* Notation "[]" := (nil_list nat) (at level 0, format "[]"). *)
+
+(* (* The signature of the lambda calculus: [[0,0],[1]] *) *)
+(* Definition LamSig : Sig := cons_list (list nat) (0 :: 0 :: []) (cons_list (list nat) (1 :: []) (nil_list (list nat))). *)
+
+(* Eval cbn in pr1 (SigToSignature LamSig). *)
+
+(* Require Import UniMath.SubstitutionSystems.LamHSET. *)
+
+(* Let Lam_S : Signature HSET has_homsets_HSET := *)
+(*   Lam_Sig HSET has_homsets_HSET TerminalHSET CoproductsHSET ProductsHSET. *)
+
+(* Check (pr1 Lam_S). *)
+(* Goal (pr1 Lam_S = pr1 (SigToFunctor LamSig)). *)
+(* simpl. *)
+(* apply subtypeEquality. *)
+(* intros x. *)
+(* apply isaprop_is_functor. *)
+(* apply (functor_category_has_homsets HSET HSET has_homsets_HSET). *)
+(* simpl. *)
+(* unfold App_H, square_functor. *)
+(* unfold Abs_H. *)
+(* apply maponpaths. *)
+(* admit. *)
+(* Abort. (* equal if we add Id *) *)
+
+(* End test_lam. *)

--- a/UniMath/SubstitutionSystems/SigToMonad.v
+++ b/UniMath/SubstitutionSystems/SigToMonad.v
@@ -3,6 +3,7 @@
 From signatures to monads
 
 Written by: Anders Mörtberg, 2016
+Based on a note by Ralph Matthes
 
 *)
 
@@ -43,8 +44,6 @@ Require Import UniMath.CategoryTheory.lists.
 Require Import UniMath.CategoryTheory.HorizontalComposition.
 
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
-Local Notation "'HSET2'":= ([HSET, HSET, has_homsets_HSET]) .
-
 
 (* Construct θ in a Signature in the case when the functor is
    precomposition with a functor G by constructing a family of simpler
@@ -465,6 +464,8 @@ End id_signature.
 (* M := Monad_from_HSS(I)    # *)
 Section SigToMonad.
 
+Local Notation "'HSET2'":= ([HSET, HSET, has_homsets_HSET]) .
+
 Local Definition has_homsets_HSET2 : has_homsets HSET2.
 Proof.
 apply functor_category_has_homsets.
@@ -480,7 +481,7 @@ Proof.
 apply (Coproducts_functor_precat _ _ CoproductsHSET).
 Defined.
 
-Local Lemma has_exponentials_HSET2 : has_exponentials  ProductsHSET2.
+Local Lemma has_exponentials_HSET2 : has_exponentials ProductsHSET2.
 Proof.
 apply has_exponentials_functor_HSET, has_homsets_HSET.
 Defined.

--- a/UniMath/SubstitutionSystems/SigToMonad.v
+++ b/UniMath/SubstitutionSystems/SigToMonad.v
@@ -138,6 +138,24 @@ Definition LamSig : Sig := cons_list (list nat) (0 :: 0 :: []) (cons_list (list 
 
 Eval cbn in SigToFunctor LamSig.
 
+Require Import UniMath.SubstitutionSystems.LamHSET.
+
+Let Lam_S : Signature HSET has_homsets_HSET :=
+  Lam_Sig HSET has_homsets_HSET TerminalHSET CoproductsHSET ProductsHSET.
+
+Check (pr1 Lam_S).
+Goal (pr1 Lam_S = pr1 (SigToFunctor LamSig)).
+simpl.
+apply subtypeEquality.
+intros x.
+apply isaprop_is_functor.
+apply (functor_category_has_homsets HSET HSET has_homsets_HSET).
+simpl.
+unfold App_H, square_functor.
+unfold Abs_H.
+admit.
+Abort. (* Hmm... *)
+
 End test_lam.
 
 Variable (sig : Sig).

--- a/UniMath/SubstitutionSystems/SigToMonad.v
+++ b/UniMath/SubstitutionSystems/SigToMonad.v
@@ -91,8 +91,16 @@ Local Notation "F + G" :=
 
 Definition Sig : UU := list (list nat).
 
+Let precomp_option := omega_cocont_pre_composition_functor _ _ _
+                        (option_functor HSET CoproductsHSET TerminalHSET) has_homsets_HSET has_homsets_HSET cats_LimsHSET.
+
+(* This would have been nice, but it adds an extra Id in the end *)
+(* Local Definition SigToFunctor_helper2 (n : nat) : omega_cocont_functor HSET2 HSET2 := *)
+(*   omega_cocont_iter_functor has_homsets_HSET2 (precomp_option) n. *)
+
 Local Fixpoint SigToFunctor_helper2 (n : nat) : omega_cocont_functor HSET2 HSET2 := match n with
   | O => Id
+  | S O => precomp_option
   | S n' => let G := omega_cocont_pre_composition_functor _ _ _
                        (option_functor HSET CoproductsHSET TerminalHSET) has_homsets_HSET has_homsets_HSET cats_LimsHSET
                (* is this order correct???? *)
@@ -153,17 +161,51 @@ apply (functor_category_has_homsets HSET HSET has_homsets_HSET).
 simpl.
 unfold App_H, square_functor.
 unfold Abs_H.
+apply maponpaths.
 admit.
-Abort. (* Hmm... *)
+Abort. (* equal if we add Id *)
 
 End test_lam.
 
 Variable (sig : Sig).
 
-Definition SigToSignature : Sig -> Signature HSET has_homsets_HSET.
+Definition SigToSignature : Signature HSET has_homsets_HSET.
+Proof.
+mkpair.
+- apply (SigToFunctor sig).
+- mkpair.
++ destruct sig as [n xs].
+  induction n.
+  { - destruct xs; simpl.
+      mkpair.
+      + simpl; intro x; destruct x as [F x]; simpl.
+        mkpair.
+      * simpl.
+        intro y.
+        apply idfun.
+      *
+        intros y y' f.
+        simpl.
+        apply idpath.
+      + intros y y' f.
+        apply (nat_trans_eq has_homsets_HSET).
+        intro x; simpl.
+        destruct y.
+        destruct y'.
+        simpl.
+        apply idpath.
+  }
+  { mkpair.
+    - simpl; intro y.
+      mkpair.
+      + admit.
+      + admit.
+    - admit.
+  }
++ admit.
 Admitted.
 
-Definition SigInitial : Initial (FunctorAlg (Id_H HSET has_homsets_HSET CoproductsHSET (SigToSignature sig))
+Definition SigInitial : Initial (FunctorAlg (Id_H HSET has_homsets_HSET CoproductsHSET SigToSignature)
                                 (functor_category_has_homsets HSET HSET has_homsets_HSET)).
 Proof.
 use colimAlgInitial.
@@ -178,7 +220,7 @@ use colimAlgInitial.
 - apply ColimsFunctorCategory; apply ColimsHSET.
 Admitted.
 
-Definition SigInitialHSS : Initial (hss_precategory CoproductsHSET (SigToSignature sig)).
+Definition SigInitialHSS : Initial (hss_precategory CoproductsHSET SigToSignature).
 Proof.
 apply InitialHSS.
 - intro Z; apply RightKanExtension_from_limits, cats_LimsHSET.
@@ -190,7 +232,7 @@ Proof.
 use Monad_from_hss.
 - apply has_homsets_HSET.
 - apply CoproductsHSET.
-- apply (SigToSignature sig).
+- apply SigToSignature.
 - apply SigInitialHSS.
 Defined.
 

--- a/UniMath/SubstitutionSystems/SigToMonad.v
+++ b/UniMath/SubstitutionSystems/SigToMonad.v
@@ -1,0 +1,179 @@
+(**
+
+From signatures to monads
+
+Written by: Anders Mörtberg, 2016
+
+*)
+
+Require Import UniMath.Foundations.Basics.PartD.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.limits.coproducts.
+Require Import UniMath.CategoryTheory.limits.terminal.
+Require Import UniMath.CategoryTheory.limits.initial.
+Require Import UniMath.CategoryTheory.FunctorAlgebras.
+Require Import UniMath.CategoryTheory.PointedFunctors.
+Require Import UniMath.CategoryTheory.ProductPrecategory.
+Require Import UniMath.SubstitutionSystems.Signatures.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseCoproduct.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseProduct.
+Require Import UniMath.CategoryTheory.EndofunctorsMonoidal.
+Require Import UniMath.CategoryTheory.Monads.
+Require Import UniMath.SubstitutionSystems.SumOfSignatures.
+Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
+Require Import UniMath.SubstitutionSystems.LamSignature.
+Require Import UniMath.SubstitutionSystems.Lam.
+Require Import UniMath.SubstitutionSystems.LiftingInitial.
+Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
+Require Import UniMath.SubstitutionSystems.Notation.
+
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.exponentials.
+Require Import UniMath.CategoryTheory.category_hset.
+Require Import UniMath.CategoryTheory.category_hset_structures.
+Require Import UniMath.CategoryTheory.chains.
+Require Import UniMath.CategoryTheory.cocontfunctors.
+Require Import UniMath.CategoryTheory.lists.
+
+(* S : SIG *)
+(* |->  # some hacking needed *)
+(* functor(S) : functor [Set,Set] [Set,Set] *)
+(* |->  # exists because func(S) is omega-cocont *)
+(* Initial (Id + functor(S)) *)
+(* |->  # see LiftingInitial.v *)
+(* I:= Initial (HSS(func(S), \theta) *)
+(* |->  # see MonadsFromSubstitutionSystems.v *)
+(* M := Monad_from_HSS(I)    # *)
+Section SigToMonad.
+
+Local Notation "'HSET2'":= ([HSET, HSET, has_homsets_HSET]) .
+
+Local Definition has_homsets_HSET2 : has_homsets HSET2.
+Proof.
+apply functor_category_has_homsets.
+Defined.
+
+Local Definition ProductsHSET2 : Products HSET2.
+Proof.
+apply (Products_functor_precat _ _ ProductsHSET).
+Defined.
+
+Local Definition CoproductsHSET2 : Coproducts HSET2.
+Proof.
+apply (Coproducts_functor_precat _ _ CoproductsHSET).
+Defined.
+
+Local Lemma has_exponentials_HSET2 : has_exponentials  ProductsHSET2.
+Proof.
+apply has_exponentials_functor_HSET, has_homsets_HSET.
+Defined.
+
+(* Specialized notations for HSET2 *)
+
+(* Notation "' x" := (omega_cocont_constant_functor _ _ has_homsets_HSET2 x) *)
+(*                     (at level 10) : cocont_functor_hset_scope. *)
+
+Local Notation "'Id'" := (omega_cocont_functor_identity _ has_homsets_HSET2).
+
+Local Notation "F * G" :=
+  (omega_cocont_product_functor _ _ ProductsHSET2 _
+     has_exponentials_HSET2 has_homsets_HSET2 has_homsets_HSET2 F G).
+
+Local Notation "F + G" :=
+  (omega_cocont_coproduct_functor _ _ ProductsHSET2 CoproductsHSET2
+     has_homsets_HSET2 has_homsets_HSET2 F G).
+
+
+Definition Sig : UU := list (list nat).
+
+Local Fixpoint SigToFunctor_helper2 (n : nat) : omega_cocont_functor HSET2 HSET2 := match n with
+  | O => Id
+  | S n' => let G := omega_cocont_pre_composition_functor _ _ _
+                       (option_functor HSET CoproductsHSET TerminalHSET) has_homsets_HSET has_homsets_HSET cats_LimsHSET
+               (* is this order correct???? *)
+            in omega_cocont_functor_composite has_homsets_HSET2 G (SigToFunctor_helper2 n')
+  end.
+(* Proof. *)
+(* intro n. *)
+(* induction n as [|_ F]. *)
+(* - apply Id. *)
+(* - *)
+(* set (G := (omega_cocont_pre_composition_functor _ _ _ *)
+(*             (option_functor HSET CoproductsHSET TerminalHSET) has_homsets_HSET has_homsets_HSET cats_LimsHSET)). *)
+(* (* is this order correct???? *) *)
+(* apply (omega_cocont_functor_composite has_homsets_HSET2 G F). *)
+(* Defined. *)
+
+Local Definition SigToFunctor_helper : list nat -> omega_cocont_functor HSET2 HSET2.
+Proof.
+intro l.
+generalize (map_list SigToFunctor_helper2 l).
+apply foldr1_list.
+- intros F G.
+  apply (F * G).
+- apply Id.
+Defined.
+
+Definition SigToFunctor : Sig -> omega_cocont_functor HSET2 HSET2.
+Proof.
+use foldr_list.
+- intros l F.
+  apply (SigToFunctor_helper l + F).
+- apply Id.
+Defined.
+
+(* Test lambda calculus *)
+Section test_lam.
+
+Infix "::" := (cons_list nat).
+Notation "[]" := (nil_list nat) (at level 0, format "[]").
+
+(* The signature of the lambda calculus: [[0,0],[1]] *)
+Definition LamSig : Sig := cons_list (list nat) (0 :: 0 :: []) (cons_list (list nat) (1 :: []) (nil_list (list nat))).
+
+Eval cbn in SigToFunctor LamSig.
+
+End test_lam.
+
+Variable (sig : Sig).
+
+Definition SigToSignature : Sig -> Signature HSET has_homsets_HSET.
+Admitted.
+
+Definition SigInitial : Initial (FunctorAlg (Id_H HSET has_homsets_HSET CoproductsHSET (SigToSignature sig))
+                                (functor_category_has_homsets HSET HSET has_homsets_HSET)).
+Proof.
+use colimAlgInitial.
+- unfold Id_H, Const_plus_H.
+  apply is_omega_cocont_coproduct_functor.
+  + apply (Products_functor_precat _ _ ProductsHSET).
+  + apply functor_category_has_homsets.
+  + apply functor_category_has_homsets.
+  + apply is_omega_cocont_constant_functor; apply functor_category_has_homsets.
+  + admit.
+- apply (Initial_functor_precat _ _ InitialHSET).
+- apply ColimsFunctorCategory; apply ColimsHSET.
+Admitted.
+
+Definition SigInitialHSS : Initial (hss_precategory CoproductsHSET (SigToSignature sig)).
+Proof.
+apply InitialHSS.
+- intro Z; apply RightKanExtension_from_limits, cats_LimsHSET.
+- apply SigInitial.
+Defined.
+
+Definition SigToMonad : Monad HSET.
+Proof.
+use Monad_from_hss.
+- apply has_homsets_HSET.
+- apply CoproductsHSET.
+- apply (SigToSignature sig).
+- apply SigInitialHSS.
+Defined.
+
+End SigToMonad.

--- a/UniMath/SubstitutionSystems/SigToMonad.v
+++ b/UniMath/SubstitutionSystems/SigToMonad.v
@@ -152,7 +152,6 @@ Fixpoint iter_functor1 {C : precategory} (F : functor C C) (n : nat) : functor C
 
 
 (* New version *)
-Eval cbn in (pr1 Id).
 
 Definition precomp_option_iter (n : nat) : functor HSET2 HSET2 := match n with
   | O => functor_identity HSET2

--- a/UniMath/SubstitutionSystems/SigToMonad.v
+++ b/UniMath/SubstitutionSystems/SigToMonad.v
@@ -25,6 +25,7 @@ Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseProduct.
 Require Import UniMath.CategoryTheory.EndofunctorsMonoidal.
 Require Import UniMath.CategoryTheory.Monads.
 Require Import UniMath.SubstitutionSystems.SumOfSignatures.
+Require Import UniMath.SubstitutionSystems.ProductOfSignatures.
 Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.LamSignature.
 Require Import UniMath.SubstitutionSystems.Lam.
@@ -197,23 +198,13 @@ Qed.
 
 (* Arguments arity_to_functor : simpl never. *)
 
-Definition bepa  (S1 S2 : Signature HSET has_homsets_HSET) : Σ
-   θ : θ_source_functor_data _ _ (product_functor _ _ ProductsHSET2 S1 S2)
-    ⟶ θ_target_functor_data _ _ (product_functor _ _ ProductsHSET2 S1 S2),
-       θ_Strength1_int θ × θ_Strength2_int θ.
-Admitted.
-
-Definition Product_of_Signatures (S1 S2 : Signature HSET has_homsets_HSET) : Signature HSET has_homsets_HSET.
-Proof.
-mkpair.
-- apply (product_functor _ _ ProductsHSET2 S1 S2).
-- apply bepa.
-Defined.
-
 Lemma is_omega_cocont_Product_of_Signatures (S1 S2 : Signature HSET has_homsets_HSET)
   (h1 : is_omega_cocont S1) (h2 : is_omega_cocont S2) :
-  is_omega_cocont (Product_of_Signatures S1 S2).
+  is_omega_cocont (Product_of_Signatures _ _ ProductsHSET S1 S2).
 Proof.
+destruct S1 as [F1 [F2 [F3 F4]]]; simpl in *.
+destruct S2 as [G1 [G2 [G3 G4]]]; simpl in *.
+unfold H.
 apply is_omega_cocont_product_functor; try assumption.
 - apply ProductsHSET2.
 - apply has_exponentials_HSET2.
@@ -244,7 +235,7 @@ Proof.
 intros xs.
 generalize (map_list precomp_option_iter_Signature xs).
 apply foldr1_list.
-- apply Product_of_Signatures.
+- apply (Product_of_Signatures _ _ ProductsHSET).
 - apply IdSignature.
 Defined.
 

--- a/UniMath/SubstitutionSystems/SigToMonad.v
+++ b/UniMath/SubstitutionSystems/SigToMonad.v
@@ -605,37 +605,3 @@ use Monad_from_hss.
 Defined.
 
 End SigToMonad.
-
-
-(* Test lambda calculus *)
-Section test_lam.
-
-Infix "::" := (cons_list nat).
-Notation "[]" := (nil_list nat) (at level 0, format "[]").
-
-(* The signature of the lambda calculus: [[0,0],[1]] *)
-Definition LamSig : Sig := cons_list (list nat) (0 :: 0 :: []) (cons_list (list nat) (1 :: []) (nil_list (list nat))).
-
-Local Notation "'Id'" := (functor_identity _).
-
-Local Notation "F * G" := (H HSET has_homsets_HSET ProductsHSET F G).
-
-Local Notation "F + G" := (SumOfSignatures.H _ _ CoproductsHSET F G).
-Local Notation "'_' 'o' 'option'" :=
-  (ℓ (option_functor HSET CoproductsHSET TerminalHSET)) (at level 0).
-
-Eval cbn in pr1 (SigToSignature LamSig).
-(* = Id * Id + _ o option *)
-(*      : functor [HSET, HSET, has_homsets_HSET] *)
-(*          [HSET, HSET, has_homsets_HSET] *)
-
-Require Import UniMath.SubstitutionSystems.LamHSET.
-
-Let Lam_S : Signature HSET has_homsets_HSET :=
-  Lam_Sig HSET has_homsets_HSET TerminalHSET CoproductsHSET ProductsHSET.
-
-Goal (pr1 Lam_S = pr1 (SigToSignature LamSig)).
-now apply idpath.
-Abort.
-
-End test_lam.

--- a/UniMath/SubstitutionSystems/SubstitutionSystems_Summary.v
+++ b/UniMath/SubstitutionSystems/SubstitutionSystems_Summary.v
@@ -244,7 +244,7 @@ Defined.
 
 Definition Lam_Sig
   : ∀ (C : precategory) (hs : has_homsets C),
-    terminal.Terminal C → Coproducts C → Products C → Signature C hs.
+    Terminal C → Coproducts C → Products C → Signature C hs.
 Proof.
   apply Lam_Sig.
 Defined.

--- a/UniMath/SubstitutionSystems/SumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/SumOfSignatures.v
@@ -72,8 +72,8 @@ Variable S22 : θ_Strength2 θ2.
 
 (** * Definition of the data of the sum of two signatures *)
 
-Definition H : functor [C, C, hs] [C, C, hs] := coproduct_functor _ _ CCC H1 H2.
-
+(* Definition H : functor [C, C, hs] [C, C, hs] := coproduct_functor _ _ CCC H1 H2. *)
+Definition H : functor [C, C, hs] [C, C, hs] := sum_of_functors CCC H1 H2.
 
 Local Definition bla1 (X : [C, C, hs]) (Z : precategory_Ptd C hs) :
    ∀ c : C,

--- a/UniMath/SubstitutionSystems/SumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/SumOfSignatures.v
@@ -72,8 +72,8 @@ Variable S22 : θ_Strength2 θ2.
 
 (** * Definition of the data of the sum of two signatures *)
 
-(* Definition H : functor [C, C, hs] [C, C, hs] := coproduct_functor _ _ CCC H1 H2. *)
-Definition H : functor [C, C, hs] [C, C, hs] := sum_of_functors CCC H1 H2.
+Definition H : functor [C, C, hs] [C, C, hs] := coproduct_functor _ _ CCC H1 H2.
+(* Definition H : functor [C, C, hs] [C, C, hs] := sum_of_functors CCC H1 H2. *)
 
 Local Definition bla1 (X : [C, C, hs]) (Z : precategory_Ptd C hs) :
    ∀ c : C,

--- a/UniMath/SubstitutionSystems/SumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/SumOfSignatures.v
@@ -194,20 +194,12 @@ Qed.
 
 Lemma SumStrength2 : θ_Strength2 θ.
 Proof.
-  unfold θ_Strength2.
   intros X Z Z' Y α.
-  apply nat_trans_eq; try assumption.
+  apply (nat_trans_eq hs).
     intro x.
-    simpl.
-    unfold bla1.
-    simpl.
-    unfold coproduct_nat_trans_data.
-    simpl.
     eapply pathscomp0. apply CoproductOfArrows_comp.
     apply pathsinv0.
-    eapply pathscomp0. apply cancel_postcomposition. apply CoproductOfArrows_comp.
-    unfold coproduct_nat_trans_in2_data.
-    unfold coproduct_nat_trans_in1_data.
+    eapply pathscomp0. apply cancel_postcomposition. simpl. apply CoproductOfArrows_comp.
     eapply pathscomp0. apply CoproductOfArrows_comp.
     apply pathsinv0.
     apply CoproductOfArrows_eq.
@@ -267,10 +259,6 @@ Proof.
     intro x.
     simpl.
     rewrite id_left.
-    unfold bla1.
-    simpl.
-    unfold coproduct_nat_trans_data.
-    simpl.
     eapply pathscomp0. apply CoproductOfArrows_comp.
     apply pathsinv0.
     eapply pathscomp0. apply CoproductOfArrows_comp.

--- a/UniMath/SubstitutionSystems/SumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/SumOfSignatures.v
@@ -36,6 +36,11 @@ Require Import UniMath.CategoryTheory.PointedFunctorsComposition.
 Require Import UniMath.SubstitutionSystems.Signatures.
 Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseCoproduct.
 Require Import UniMath.SubstitutionSystems.Notation.
+Require Import UniMath.CategoryTheory.chains.
+Require Import UniMath.CategoryTheory.cocontfunctors.
+Require Import UniMath.CategoryTheory.exponentials.
+Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseProduct.
 
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 Local Notation "F ⟶ G" := (nat_trans F G) (at level 39).
@@ -292,5 +297,17 @@ Proof.
   + apply SumStrength2'; assumption.
 Defined.
 
+Lemma is_omega_cocont_Sum_of_Signatures (S1 S2 : Signature C hs)
+  (h1 : is_omega_cocont S1) (h2 : is_omega_cocont S2) (PC : Products C) :
+  is_omega_cocont (Sum_of_Signatures S1 S2).
+Proof.
+destruct S1 as [F1 [F2 [F3 F4]]]; simpl in *.
+destruct S2 as [G1 [G2 [G3 G4]]]; simpl in *.
+unfold H.
+apply is_omega_cocont_coproduct_functor; try assumption.
+- apply (Products_functor_precat _ _ PC).
+- apply functor_category_has_homsets.
+- apply functor_category_has_homsets.
+Defined.
 
 End sum_of_signatures.

--- a/UniMath/SubstitutionSystems/SumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/SumOfSignatures.v
@@ -73,7 +73,9 @@ Variable S22 : θ_Strength2 θ2.
 (** * Definition of the data of the sum of two signatures *)
 
 Definition H : functor [C, C, hs] [C, C, hs] := coproduct_functor _ _ CCC H1 H2.
-(* Definition H : functor [C, C, hs] [C, C, hs] := sum_of_functors CCC H1 H2. *)
+
+(* This becomes too slow: *)
+(* Definition H : functor [C, C, hs] [C, C, hs] := coproduct_of_functors CCC H1 H2. *)
 
 Local Definition bla1 (X : [C, C, hs]) (Z : precategory_Ptd C hs) :
    ∀ c : C,


### PR DESCRIPTION
This PR provides the connection between SubstSys and Cocont, in particular it contains:

- Proofs that more functors are omega cocont, in particular (co)product_functor

- Instantiation of the hypotheses of InitialHSS with Lam for HSET (LamHSET.v)

- Definition of the product of two Signatures, in particular proof of strength laws for the product (ProductOfSignatures.v)

- Construction of a Signature in the case when the functor is precomposition with a functor G. This is done by constructing a family of simpler distributive laws called delta (i.e. we construct something simpler than the theta in Signature for this special case). (currently at the top of SigToMonad.v, where should this be put?)

- Instantiations of the delta family when G = option and G = F^n

- Finally, by combining all of this, we get a function from lists of lists of natural numbers to a monad on Set obtained from the initial heterogeneous substitution system. See the end of SigToMonad.v for an example where this function is applied to the signature for the lambda calculus (i.e. [[0,0],[1]). 