### PR TITLE
Generalize the notion of signatures

### DIFF
--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -5,6 +5,7 @@ opp_precat.v
 limits/terminal.v
 limits/graphs/terminal.v
 limits/products.v
+limits/arbitrary_products.v
 limits/graphs/products.v
 functor_categories.v
 FunctorAlgebras.v

--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -20,6 +20,7 @@ limits/coproducts.v
 limits/arbitrary_coproducts.v
 limits/graphs/coproducts.v
 limits/FunctorsPointwiseCoproduct.v
+limits/FunctorsPointwiseArbitraryCoproduct.v
 limits/FunctorsPointwiseProduct.v
 limits/graphs/colimits.v
 HLevel_n_is_of_hlevel_Sn.v

--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -17,6 +17,7 @@ limits/more_on_pullbacks.v
 limits/initial.v
 limits/graphs/initial.v
 limits/coproducts.v
+limits/arbitrary_coproducts.v
 limits/graphs/coproducts.v
 limits/FunctorsPointwiseCoproduct.v
 limits/FunctorsPointwiseProduct.v

--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -40,6 +40,7 @@ AdjunctionHomTypesWeq.v
 EndofunctorsMonoidal.v
 RightKanExtension.v
 ProductPrecategory.v
+ArbitraryProductPrecategory.v
 PointedFunctors.v
 PointedFunctorsComposition.v
 HorizontalComposition.v

--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -22,6 +22,7 @@ limits/graphs/coproducts.v
 limits/FunctorsPointwiseCoproduct.v
 limits/FunctorsPointwiseArbitraryCoproduct.v
 limits/FunctorsPointwiseProduct.v
+limits/FunctorsPointwiseArbitraryProduct.v
 limits/graphs/colimits.v
 HLevel_n_is_of_hlevel_Sn.v
 category_hset_structures.v

--- a/UniMath/CategoryTheory/ArbitraryProductPrecategory.v
+++ b/UniMath/CategoryTheory/ArbitraryProductPrecategory.v
@@ -5,6 +5,7 @@ Anders Mörtberg
 
 2016
 
+Definition of the general product category
 
 ************************************************************)
 
@@ -60,23 +61,6 @@ Qed.
 
 End arbitrary_product_precategory.
 
-(** Objects and morphisms in the product precategory of two precategories *)
-(* Definition prodcatpair {C D : precategory} (X : C) (Y : D) : product_precategory C D. *)
-(* Proof. *)
-(*   exists X. *)
-(*   exact Y. *)
-(* Defined. *)
-
-(* Local Notation "A ⊗ B" := (prodcatpair A B) (at level 10). *)
-
-(* Definition prodcatmor {C D : precategory} {X X' : C} {Z Z' : D} (α : X --> X') (β : Z --> Z') *)
-(*   : X ⊗ Z --> X' ⊗ Z'. *)
-(* Proof. *)
-(*   exists α. *)
-(*   exact β. *)
-(* Defined. *)
-
-(* Define pairs of functors and functors from pr1 and pr2 *)
 Section functors.
 
 Definition arbitrary_pair_functor_data (I : UU) {A B : precategory}

--- a/UniMath/CategoryTheory/ArbitraryProductPrecategory.v
+++ b/UniMath/CategoryTheory/ArbitraryProductPrecategory.v
@@ -1,0 +1,131 @@
+
+(** **********************************************************
+
+Anders Mörtberg
+
+2016
+
+
+************************************************************)
+
+Require Import UniMath.Foundations.Basics.PartD.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+
+Local Notation "# F" := (functor_on_morphisms F)(at level 3).
+
+Section arbitrary_product_precategory.
+
+Variable I : UU.
+Variables C : precategory.
+
+Definition arbitrary_product_precategory_ob_mor : precategory_ob_mor.
+Proof.
+mkpair.
+- apply (forall (i : I), ob C).
+- intros f g.
+  apply (forall i, f i --> g i).
+Defined.
+
+Definition arbitrary_product_precategory_data : precategory_data.
+Proof.
+  exists arbitrary_product_precategory_ob_mor.
+  split.
+  - intros f i; simpl in *.
+    apply (identity (f i)).
+  - intros a b c f g i; simpl in *.
+    exact (f i ;; g i).
+Defined.
+
+Lemma is_precategory_arbitrary_product_precategory_data :
+  is_precategory arbitrary_product_precategory_data.
+Proof.
+repeat split; intros; apply funextsec; intro i.
+- apply id_left.
+- apply id_right.
+- apply assoc.
+Qed.
+
+Definition arbitrary_product_precategory : precategory
+  := tpair _ _ is_precategory_arbitrary_product_precategory_data.
+
+Definition has_homsets_arbitrary_product_precategory (hsC : has_homsets C) :
+  has_homsets arbitrary_product_precategory.
+Proof.
+intros a b; simpl.
+apply impred_isaset; intro i; apply hsC.
+Qed.
+
+End arbitrary_product_precategory.
+
+(** Objects and morphisms in the product precategory of two precategories *)
+(* Definition prodcatpair {C D : precategory} (X : C) (Y : D) : product_precategory C D. *)
+(* Proof. *)
+(*   exists X. *)
+(*   exact Y. *)
+(* Defined. *)
+
+(* Local Notation "A ⊗ B" := (prodcatpair A B) (at level 10). *)
+
+(* Definition prodcatmor {C D : precategory} {X X' : C} {Z Z' : D} (α : X --> X') (β : Z --> Z') *)
+(*   : X ⊗ Z --> X' ⊗ Z'. *)
+(* Proof. *)
+(*   exists α. *)
+(*   exact β. *)
+(* Defined. *)
+
+(* Define pairs of functors and functors from pr1 and pr2 *)
+Section functors.
+
+(* Definition pair_functor_data {A B C D : precategory} *)
+(*   (F : functor A C) (G : functor B D) : *)
+(*   functor_data (product_precategory A B) (product_precategory C D). *)
+(* Proof. *)
+(* mkpair. *)
+(* - intro x; apply (prodcatpair (F (pr1 x)) (G (pr2 x))). *)
+(* - intros x y f; simpl; apply (prodcatmor (# F (pr1 f)) (# G (pr2 f))). *)
+(* Defined. *)
+
+(* Definition pair_functor {A B C D : precategory} *)
+(*   (F : functor A C) (G : functor B D) : *)
+(*   functor (product_precategory A B) (product_precategory C D). *)
+(* Proof. *)
+(* apply (tpair _ (pair_functor_data F G)). *)
+(* abstract (split; *)
+(*   [ intro x; simpl; rewrite !functor_id; apply idpath *)
+(*   | intros x y z f g; simpl; rewrite !functor_comp; apply idpath]). *)
+(* Defined. *)
+
+Definition pr_functor_data (I : UU) (C : precategory) (i : I) :
+  functor_data (arbitrary_product_precategory I C) C.
+Proof.
+mkpair.
+- intro a; apply (a i).
+- intros x y f; simpl; apply (f i).
+Defined.
+
+Definition pr_functor (I : UU) (C : precategory) (i : I) :
+  functor (arbitrary_product_precategory I C) C.
+Proof.
+apply (tpair _ (pr_functor_data I C i)).
+abstract (split; [ intro x; apply idpath | intros x y z f g; apply idpath ]).
+Defined.
+
+Definition arbitrary_delta_functor_data (I : UU) (C : precategory) :
+  functor_data C (arbitrary_product_precategory I C).
+Proof.
+mkpair.
+- intros x i; apply x.
+- intros x y f i; simpl; apply f.
+Defined.
+
+Definition arbitrary_delta_functor (I : UU) (C : precategory) :
+  functor C (arbitrary_product_precategory I C).
+Proof.
+apply (tpair _ (arbitrary_delta_functor_data I C)).
+abstract (split; [ intro x; apply idpath | intros x y z f g; apply idpath ]).
+Defined.
+
+End functors.

--- a/UniMath/CategoryTheory/ArbitraryProductPrecategory.v
+++ b/UniMath/CategoryTheory/ArbitraryProductPrecategory.v
@@ -79,24 +79,26 @@ End arbitrary_product_precategory.
 (* Define pairs of functors and functors from pr1 and pr2 *)
 Section functors.
 
-(* Definition pair_functor_data {A B C D : precategory} *)
-(*   (F : functor A C) (G : functor B D) : *)
-(*   functor_data (product_precategory A B) (product_precategory C D). *)
-(* Proof. *)
-(* mkpair. *)
-(* - intro x; apply (prodcatpair (F (pr1 x)) (G (pr2 x))). *)
-(* - intros x y f; simpl; apply (prodcatmor (# F (pr1 f)) (# G (pr2 f))). *)
-(* Defined. *)
+Definition arbitrary_pair_functor_data (I : UU) {A B : precategory}
+  (F : forall (i : I), functor A B) :
+  functor_data (arbitrary_product_precategory I A)
+               (arbitrary_product_precategory I B).
+Proof.
+mkpair.
+- intros a i; apply (F i (a i)).
+- intros a b f i; apply (# (F i) (f i)).
+Defined.
 
-(* Definition pair_functor {A B C D : precategory} *)
-(*   (F : functor A C) (G : functor B D) : *)
-(*   functor (product_precategory A B) (product_precategory C D). *)
-(* Proof. *)
-(* apply (tpair _ (pair_functor_data F G)). *)
-(* abstract (split; *)
-(*   [ intro x; simpl; rewrite !functor_id; apply idpath *)
-(*   | intros x y z f g; simpl; rewrite !functor_comp; apply idpath]). *)
-(* Defined. *)
+Definition arbitrary_pair_functor (I : UU) {A B : precategory}
+  (F : forall (i : I), functor A B) :
+  functor (arbitrary_product_precategory I A)
+          (arbitrary_product_precategory I B).
+Proof.
+apply (tpair _ (arbitrary_pair_functor_data I F)).
+abstract
+  (split; [ intro x; apply funextsec; intro i; simpl; apply functor_id
+          | intros x y z f g; apply funextsec; intro i; apply functor_comp]).
+Defined.
 
 Definition pr_functor_data (I : UU) (C : precategory) (i : I) :
   functor_data (arbitrary_product_precategory I C) C.
@@ -110,7 +112,7 @@ Definition pr_functor (I : UU) (C : precategory) (i : I) :
   functor (arbitrary_product_precategory I C) C.
 Proof.
 apply (tpair _ (pr_functor_data I C i)).
-abstract (split; [ intro x; apply idpath | intros x y z f g; apply idpath ]).
+abstract (split; intros x *; apply idpath).
 Defined.
 
 Definition arbitrary_delta_functor_data (I : UU) (C : precategory) :
@@ -125,7 +127,7 @@ Definition arbitrary_delta_functor (I : UU) (C : precategory) :
   functor C (arbitrary_product_precategory I C).
 Proof.
 apply (tpair _ (arbitrary_delta_functor_data I C)).
-abstract (split; [ intro x; apply idpath | intros x y z f g; apply idpath ]).
+abstract (split; intros x *; apply idpath).
 Defined.
 
 End functors.

--- a/UniMath/CategoryTheory/EquivalencesExamples.v
+++ b/UniMath/CategoryTheory/EquivalencesExamples.v
@@ -1,9 +1,20 @@
+(**
+
+This file contains some adjunctions:
+
+- The delta_functor is left adjoint to binproduct_functor
+- The bincoproduct_functor left adjoint to delta_functor
+
+Written by: Anders Mörtberg, 2016
+
+*)
 Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.Foundations.Basics.Propositions.
 Require Import UniMath.Foundations.Basics.Sets.
 
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.ProductPrecategory.
+Require Import UniMath.CategoryTheory.ArbitraryProductPrecategory.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.equivalences.
 Require Import UniMath.CategoryTheory.limits.products.
@@ -38,6 +49,17 @@ Defined.
 
 End delta_functor_adjunction.
 
+Section arbitrary_delta_functor_adjunction.
+
+Context (I : UU) {C : precategory} (PC : Products C).
+
+(* Need arbitray products *)
+Lemma is_left_adjoint_arbitrary_delta_functor :
+  is_left_adjoint (arbitrary_delta_functor I C).
+Admitted.
+
+End arbitrary_delta_functor_adjunction.
+
 Section bincoproduct_functor_adjunction.
 
 Context {C : precategory} (PC : Coproducts C).
@@ -67,3 +89,12 @@ mkpair.
 Defined.
 
 End bincoproduct_functor_adjunction.
+
+Section arbitrary_coproduct_functor_adjunction.
+
+Context {C : precategory} (PC : Coproducts C).
+
+(* Lemma is_left_adjoint_arbitrary_coproduct_functor : *)
+(*   is_left_adjoint (arbitrary_coproduct_functor PC). *)
+
+End arbitrary_coproduct_functor_adjunction.

--- a/UniMath/CategoryTheory/EquivalencesExamples.v
+++ b/UniMath/CategoryTheory/EquivalencesExamples.v
@@ -13,6 +13,7 @@ Section delta_functor_adjunction.
 
 Context {C : precategory} (PC : Products C).
 
+(* The delta_functor is left adjoint to binproduct_functor *)
 Lemma is_left_adjoint_delta_functor : is_left_adjoint (delta_functor C).
 Proof.
 apply (tpair _ (binproduct_functor PC)).
@@ -41,6 +42,7 @@ Section bincoproduct_functor_adjunction.
 
 Context {C : precategory} (PC : Coproducts C).
 
+(* The bincoproduct_functor left adjoint to delta_functor *)
 Lemma is_left_adjoint_bincoproduct_functor : is_left_adjoint (bincoproduct_functor PC).
 Proof.
 apply (tpair _ (delta_functor _)).

--- a/UniMath/CategoryTheory/EquivalencesExamples.v
+++ b/UniMath/CategoryTheory/EquivalencesExamples.v
@@ -115,8 +115,8 @@ Section arbitrary_coproduct_functor_adjunction.
 
 Context (I : UU) {C : precategory} (PC : ArbitraryCoproducts I C).
 
-Lemma is_left_adjoint_arbitrary_coproduct_functor :
-  is_left_adjoint (arbitrary_coproduct_functor I PC).
+Lemma is_left_adjoint_arbitrary_indexed_coproduct_functor :
+  is_left_adjoint (arbitrary_indexed_coproduct_functor I PC).
 Proof.
 apply (tpair _ (arbitrary_delta_functor _ _)).
 mkpair.

--- a/UniMath/CategoryTheory/EquivalencesExamples.v
+++ b/UniMath/CategoryTheory/EquivalencesExamples.v
@@ -2,8 +2,15 @@
 
 This file contains some adjunctions:
 
-- The delta_functor is left adjoint to binproduct_functor
-- The bincoproduct_functor left adjoint to delta_functor
+- The binary delta_functor is left adjoint to binproduct_functor
+
+- The general delta functor is left adjoint to the general product
+  functor
+
+- The bincoproduct_functor is left adjoint to the binary delta functor
+
+- The general coproduct functor is left adjoint to the general delta
+  functor
 
 Written by: Anders Mörtberg, 2016
 
@@ -26,7 +33,7 @@ Section delta_functor_adjunction.
 
 Context {C : precategory} (PC : Products C).
 
-(* The delta_functor is left adjoint to binproduct_functor *)
+(** The binary delta_functor is left adjoint to binproduct_functor *)
 Lemma is_left_adjoint_delta_functor : is_left_adjoint (delta_functor C).
 Proof.
 apply (tpair _ (binproduct_functor PC)).
@@ -55,6 +62,7 @@ Section arbitrary_delta_functor_adjunction.
 
 Context (I : UU) {C : precategory} (PC : ArbitraryProducts I C).
 
+(** The general delta functor is left adjoint to the general product functor *)
 Lemma is_left_adjoint_arbitrary_delta_functor :
   is_left_adjoint (arbitrary_delta_functor I C).
 Proof.
@@ -85,7 +93,7 @@ Section bincoproduct_functor_adjunction.
 
 Context {C : precategory} (PC : Coproducts C).
 
-(* The bincoproduct_functor left adjoint to delta_functor *)
+(** The bincoproduct_functor left adjoint to delta_functor *)
 Lemma is_left_adjoint_bincoproduct_functor : is_left_adjoint (bincoproduct_functor PC).
 Proof.
 apply (tpair _ (delta_functor _)).
@@ -115,6 +123,7 @@ Section arbitrary_coproduct_functor_adjunction.
 
 Context (I : UU) {C : precategory} (PC : ArbitraryCoproducts I C).
 
+(** The general coproduct functor left adjoint to the general delta functor *)
 Lemma is_left_adjoint_arbitrary_indexed_coproduct_functor :
   is_left_adjoint (arbitrary_indexed_coproduct_functor I PC).
 Proof.

--- a/UniMath/CategoryTheory/EquivalencesExamples.v
+++ b/UniMath/CategoryTheory/EquivalencesExamples.v
@@ -20,6 +20,7 @@ Require Import UniMath.CategoryTheory.equivalences.
 Require Import UniMath.CategoryTheory.limits.products.
 Require Import UniMath.CategoryTheory.limits.arbitrary_products.
 Require Import UniMath.CategoryTheory.limits.coproducts.
+Require Import UniMath.CategoryTheory.limits.arbitrary_coproducts.
 
 Section delta_functor_adjunction.
 
@@ -112,9 +113,30 @@ End bincoproduct_functor_adjunction.
 
 Section arbitrary_coproduct_functor_adjunction.
 
-Context {C : precategory} (PC : Coproducts C).
+Context (I : UU) {C : precategory} (PC : ArbitraryCoproducts I C).
 
-(* Lemma is_left_adjoint_arbitrary_coproduct_functor : *)
-(*   is_left_adjoint (arbitrary_coproduct_functor PC). *)
+Lemma is_left_adjoint_arbitrary_coproduct_functor :
+  is_left_adjoint (arbitrary_coproduct_functor I PC).
+Proof.
+apply (tpair _ (arbitrary_delta_functor _ _)).
+mkpair.
+- split.
+  + mkpair.
+    * intros p i; apply ArbitraryCoproductIn.
+    * abstract (intros p q f; apply funextsec; intro i; unfold compose; simpl;
+                now rewrite ArbitraryCoproductOfArrowsIn).
+  + mkpair.
+    * intro x; apply (ArbitraryCoproductArrow _ _ _ (fun _ => identity x)).
+    * abstract (intros p q f; simpl;
+                now rewrite precompWithArbitraryCoproductArrow,
+                            postcompWithArbitraryCoproductArrow,
+                            id_right, id_left).
+- abstract (split; simpl; intro x;
+    [ rewrite precompWithArbitraryCoproductArrow;
+      apply pathsinv0, ArbitraryCoproduct_endo_is_identity; intro i;
+      eapply pathscomp0; [|apply ArbitraryCoproductInCommutes];
+      apply maponpaths, maponpaths, funextsec; intro j; apply id_right
+    | apply funextsec; intro i; apply (ArbitraryCoproductInCommutes _ _ (fun _ => x))]).
+Defined.
 
 End arbitrary_coproduct_functor_adjunction.

--- a/UniMath/CategoryTheory/EquivalencesExamples.v
+++ b/UniMath/CategoryTheory/EquivalencesExamples.v
@@ -18,6 +18,7 @@ Require Import UniMath.CategoryTheory.ArbitraryProductPrecategory.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.equivalences.
 Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.limits.arbitrary_products.
 Require Import UniMath.CategoryTheory.limits.coproducts.
 
 Section delta_functor_adjunction.
@@ -51,12 +52,31 @@ End delta_functor_adjunction.
 
 Section arbitrary_delta_functor_adjunction.
 
-Context (I : UU) {C : precategory} (PC : Products C).
+Context (I : UU) {C : precategory} (PC : ArbitraryProducts I C).
 
-(* Need arbitray products *)
 Lemma is_left_adjoint_arbitrary_delta_functor :
   is_left_adjoint (arbitrary_delta_functor I C).
-Admitted.
+Proof.
+apply (tpair _ (arbitrary_product_functor _ PC)).
+mkpair.
+- split.
+  + mkpair.
+    * simpl; intro x.
+      apply (ArbitraryProductArrow _ _ _ (fun _ => identity x)).
+    * abstract (intros p q f; simpl;
+                now rewrite precompWithArbitraryProductArrow, id_right,
+                            postcompWithArbitraryProductArrow, id_left).
+  + mkpair.
+    * intros x i; apply ArbitraryProductPr.
+    * abstract (intros p q f; apply funextsec; intro i; unfold compose; simpl;
+                now rewrite ArbitraryProductOfArrowsPr).
+- abstract (split; simpl; intro x;
+    [ apply funextsec; intro i; apply (ArbitraryProductPrCommutes _ _ (fun _ => x))
+    | rewrite postcompWithArbitraryProductArrow;
+      apply pathsinv0, ArbitraryProduct_endo_is_identity; intro i;
+      eapply pathscomp0; [|apply (ArbitraryProductPrCommutes I C _ (PC x))];
+      apply cancel_postcomposition, maponpaths, funextsec; intro j; apply id_left]).
+Defined.
 
 End arbitrary_delta_functor_adjunction.
 

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -313,36 +313,23 @@ Proof.
               apply isasetaprop, setproperty ].
 Defined.
 
-(* TODO: clean *)
 Lemma LimConeHSET : LimCone D.
 Proof.
-  simple refine (mk_LimCone _ _ _ _ ).
-  - apply limset.
-  - simple refine (mk_cone _ _ ).
-    + intro u. simpl.
-      intro f.
-      exact (pr1 f u).
-    + abstract (intros u v e; simpl; apply funextfun; intro f; simpl; apply (pr2 f)).
-  - intros X CC.
-    simple refine (tpair _ _ _ ).
-    + simple refine (tpair _ _ _ ).
-      * simpl.
-        intro x.
-        {
-          simple refine (tpair _ _ _ ).
-          - intro u.
-            apply (coneOut CC u x).
-          - abstract (intros u v e; simpl; set (T := coneOutCommutes CC _ _ e);
-                      apply (toforallpaths _ _ _ T)).
-        }
-      * abstract (intro v; apply idpath).
-   + abstract (intro t; apply subtypeEquality;
-     [ intro; apply impred; intro; apply isaset_set_fun_space
-     | simpl; destruct t as [t p]; simpl; apply funextfun; intro x; simpl;
-       unfold compose; simpl; apply subtypeEquality];
-       [intro; repeat (apply impred; intro); apply setproperty
-       |simpl; apply funextsec; intro u; simpl in p;
-       set (p' := toforallpaths _ _ _ (p u)); apply p']).
+simple refine (mk_LimCone _ _ _ _ ).
+- apply limset.
+- apply (tpair _ (fun u f => pr1 f u)).
+  abstract (intros u v e; simpl; apply funextfun; intro f; simpl; apply (pr2 f)).
+- intros X CC.
+  mkpair.
+  + mkpair.
+    * intro x; apply (tpair _ (fun u => coneOut CC u x)).
+      abstract (intros u v e; apply (toforallpaths _ _ _ (coneOutCommutes CC _ _ e))).
+    * abstract (intro v; apply idpath).
+  + abstract (intros [t p]; apply subtypeEquality;
+              [ intro; apply impred; intro; apply isaset_set_fun_space
+              | apply funextfun; intro; apply subtypeEquality];
+                [ intro; repeat (apply impred; intro); apply setproperty
+                | apply funextsec; intro u; apply (toforallpaths _ _ _ (p u))]).
 Defined.
 
 End limits.
@@ -351,7 +338,6 @@ Lemma LimsHSET : Lims HSET.
 Proof.
 now intros g d; apply LimConeHSET.
 Defined.
-
 
 (** Alternative definition of limits using cats/limits *)
 Section cats_limits.
@@ -374,36 +360,23 @@ Proof.
               apply isasetaprop, setproperty ].
 Defined.
 
-(* TODO: clean *)
 Lemma cats_LimConeHSET : cats.limits.LimCone D.
 Proof.
-  simple refine (mk_LimCone _ _ _ _ ).
-  - apply cats_limset.
-  - simple refine (mk_cone _ _ ).
-    + intro u. simpl.
-      intro f.
-      exact (pr1 f u).
-    + abstract (intros u v e; simpl; apply funextfun; intro f; simpl; apply (pr2 f)).
-  - intros X CC.
-    simple refine (tpair _ _ _ ).
-    + simple refine (tpair _ _ _ ).
-      * simpl.
-        intro x.
-        {
-          simple refine (tpair _ _ _ ).
-          - intro u.
-            apply (coneOut CC u x).
-          - abstract (intros u v e; simpl; set (T := coneOutCommutes CC _ _ e);
-                      apply (toforallpaths _ _ _ T)).
-        }
-      * abstract (intro v; apply idpath).
-   + abstract (intro t; apply subtypeEquality;
+simple refine (mk_LimCone _ _ _ _ ).
+- apply cats_limset.
+- apply (tpair _ (fun u f => pr1 f u)).
+  abstract (intros u v e; apply funextfun; intro f; apply (pr2 f)).
+- intros X CC.
+  mkpair.
+  + mkpair.
+    * intro x; apply (tpair _ (fun u => coneOut CC u x)).
+      abstract (intros u v e; apply (toforallpaths _ _ _ (coneOutCommutes CC _ _ e))).
+    * abstract (intro v; apply idpath).
+  + abstract (intros [t p]; apply subtypeEquality;
      [ intro; apply impred; intro; apply isaset_set_fun_space
-     | simpl; destruct t as [t p]; simpl; apply funextfun; intro x; simpl;
-       unfold compose; simpl; apply subtypeEquality];
-       [intro; repeat (apply impred; intro); apply setproperty
-       |simpl; apply funextsec; intro u; simpl in p;
-       set (p' := toforallpaths _ _ _ (p u)); apply p']).
+     | apply funextfun; intro x; apply subtypeEquality];
+       [ intro; repeat (apply impred; intro); apply setproperty
+       | simpl; apply funextsec; intro u; apply (toforallpaths _ _ _ (p u))]).
 Defined.
 
 End cats_limits.
@@ -544,7 +517,7 @@ Defined.
 
 End exponentials.
 
-(* This section defines exponential in [C,HSET] following a slight
+(** This section defines exponential in [C,HSET] following a slight
 variation of Moerdijk-MacLane (p. 46, Prop. 1).
 
 The formula for [C,Set] is G^F(f)=Hom(Hom(f,−)×id(F),G) taken from:

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -25,10 +25,12 @@ Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.category_hset.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.limits.coproducts.
+Require Import UniMath.CategoryTheory.limits.arbitrary_coproducts.
 Require Import UniMath.CategoryTheory.limits.initial.
 Require Import UniMath.CategoryTheory.opp_precat.
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
 Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.limits.arbitrary_products.
 Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import UniMath.CategoryTheory.equivalences.
@@ -244,6 +246,24 @@ simple refine (mk_CoproductCocone _ _ _ _ _ _ _).
                case x; intros; apply idpath]).
 Defined.
 
+Lemma ArbitraryCoproducts_HSET (I : UU) (HI : isaset I) : ArbitraryCoproducts I HSET.
+Proof.
+intros A.
+simple refine (mk_ArbitraryCoproductCocone _ _ _ _ _ _).
+- mkpair.
+  + apply (Σ i, pr1 (A i)).
+  + eapply (isaset_total2 _ HI); intro i; apply setproperty.
+- simpl; apply tpair.
+- apply (mk_isArbitraryCoproductCocone _ _ has_homsets_HSET).
+  intros C f; simpl in *.
+  mkpair.
+  * apply (tpair _ (fun X => f (pr1 X) (pr2 X))); abstract (intro i; apply idpath).
+  * abstract (intros h; apply subtypeEquality; simpl;
+      [ intro; apply impred; intro; apply has_homsets_HSET
+      | destruct h as [t ht]; simpl; apply funextfun;
+        intro x; rewrite <- ht; destruct x; apply idpath]).
+Defined.
+
 Section CoproductsHSET_from_Colims.
 
 Require UniMath.CategoryTheory.limits.graphs.coproducts.
@@ -413,6 +433,22 @@ simple refine (mk_ProductCone _ _ _ _ _ _ _).
     | destruct h as [t [ht1 ht2]]; simpl; apply funextfun; intro x;
                rewrite <- ht2, <- ht1; unfold compose; simpl;
                case (t x); intros; apply idpath]).
+Defined.
+
+Lemma ArbitraryProducts_HSET (I : UU) : ArbitraryProducts I HSET.
+Proof.
+intros A.
+simple refine (mk_ArbitraryProductCone _ _ _ _ _ _).
+- apply (tpair _ (forall i, pr1 (A i))); apply isaset_forall_hSet.
+- simpl; intros i f; apply (f i).
+- apply (mk_isArbitraryProductCone _ _ has_homsets_HSET).
+  intros C f; simpl in *.
+  mkpair.
+  * apply (tpair _ (fun c i => f i c)); intro i; apply idpath.
+   * abstract (intros h; apply subtypeEquality; simpl;
+       [ intro; apply impred; intro; apply has_homsets_HSET
+       | destruct h as [t ht]; simpl; apply funextfun; intro x;
+         apply funextsec; intro i; rewrite <- ht; apply idpath ]).
 Defined.
 
 Section ProductsHSET_from_Lims.

--- a/UniMath/CategoryTheory/cocontfunctors.v
+++ b/UniMath/CategoryTheory/cocontfunctors.v
@@ -370,45 +370,44 @@ Lemma is_omega_cocont_arbitrary_pair_functor
   (HF : forall (i : I), is_omega_cocont (F i)) :
   is_omega_cocont (arbitrary_pair_functor I F).
 Proof.
-admit.
-(* intros cAB ml ccml Hccml xy ccxy; simpl in *. *)
-(* simple refine (let cc i : cocone (mapdiagram (F i) (mapdiagram (pr_functor I A i) cAB)) (xy i) := _ in _). *)
-(* { simple refine (mk_cocone _ _). *)
-(*   - intro n; apply (pr1 ccxy n). *)
-(*   - abstract (intros m n e; *)
-(*               apply (toforallpaths _ _ _ (pr2 ccxy m n e) i)). *)
-(* } *)
-(* set (X i := HF i _ _ _ (isColimCocone_pr_functor i cAB ml ccml Hccml) *)
-(*              (xy i) (cc i)). *)
-(* mkpair. *)
-(* - mkpair. *)
-(* + *)
-(* intro i. *)
-(* apply (pr1 (pr1 (X i))). *)
-(* + *)
-(* intro n. *)
-(* apply funextsec; intro j. *)
-(* simpl. *)
-(* apply (pr2 (pr1 (X j)) n). *)
-(* - intro t. *)
-(*   apply subtypeEquality; simpl. *)
-(*   + intro x; apply impred; intro. *)
-(* apply impred_isaset; intro i; apply hsB. *)
-(*   + destruct t as [f1 f2]; simpl in *. *)
-(* apply funextsec; intro i. *)
+intros cAB ml ccml Hccml xy ccxy; simpl in *.
+simple refine (let cc i : cocone (mapdiagram (F i) (mapdiagram (pr_functor I A i) cAB)) (xy i) := _ in _).
+{ simple refine (mk_cocone _ _).
+  - intro n; apply (pr1 ccxy n).
+  - abstract (intros m n e;
+              apply (toforallpaths _ _ _ (pr2 ccxy m n e) i)).
+}
+set (X i := HF i _ _ _ (isColimCocone_pr_functor cAB ml ccml Hccml i)
+             (xy i) (cc i)).
+mkpair.
+- mkpair.
++
+intro i.
+apply (pr1 (pr1 (X i))).
++
+intro n.
+apply funextsec; intro j.
+simpl.
+apply (pr2 (pr1 (X j)) n).
+- intro t.
+  apply subtypeEquality; simpl.
+  + intro x; apply impred; intro.
+apply impred_isaset; intro i; apply hsB.
+  + destruct t as [f1 f2]; simpl in *.
+apply funextsec; intro i.
 
 
-(* simple refine (let XX : Σ x : B ⟦ (F i) (ml i), xy i ⟧, *)
-(*   ∀ x0 : nat, # (F i) (coconeIn ccml x0 i) ;; x = coconeIn ccxy x0 i := _ in _). *)
-(* mkpair. *)
-(*   apply (f1 i). *)
-(*   intro n. *)
-(*   apply ( toforallpaths _ _ _ (f2 n) i). *)
-(* simpl in *. *)
-(* set (XXX := (pr2 (X i)) XX). *)
-(* simpl in *. *)
-(* apply (maponpaths pr1 XXX). *)
-Admitted.
+simple refine (let XX : Σ x : B ⟦ (F i) (ml i), xy i ⟧,
+  ∀ x0 : nat, # (F i) (coconeIn ccml x0 i) ;; x = coconeIn ccxy x0 i := _ in _).
+mkpair.
+  apply (f1 i).
+  intro n.
+  apply ( toforallpaths _ _ _ (f2 n) i).
+simpl in *.
+set (XXX := (pr2 (X i)) XX).
+simpl in *.
+apply (maponpaths pr1 XXX).
+Defined.
 
 End arbitrary_pair_functor.
 

--- a/UniMath/CategoryTheory/cocontfunctors.v
+++ b/UniMath/CategoryTheory/cocontfunctors.v
@@ -42,6 +42,7 @@ Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseCoproduct.
 Require Import UniMath.CategoryTheory.limits.products.
 Require Import UniMath.CategoryTheory.limits.arbitrary_products.
 Require Import UniMath.CategoryTheory.limits.coproducts.
+Require Import UniMath.CategoryTheory.limits.arbitrary_coproducts.
 Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.chains.
 Require Import UniMath.CategoryTheory.ProductPrecategory.
@@ -454,19 +455,41 @@ Section bincoprod_functor.
 
 Variables (C : precategory) (PC : Coproducts C) (hsC : has_homsets C).
 
-Lemma cocont_bincoproducts_functor : is_cocont (bincoproduct_functor PC).
+Lemma cocont_bincoproduct_functor : is_cocont (bincoproduct_functor PC).
 Proof.
 apply (left_adjoint_cocont _ (is_left_adjoint_bincoproduct_functor PC)).
 - abstract (apply has_homsets_product_precategory; apply hsC).
 - abstract (apply hsC).
 Defined.
 
-Lemma is_omega_cocont_bincoproduct_functor: is_omega_cocont (bincoproduct_functor PC).
+Lemma is_omega_cocont_bincoproduct_functor :
+  is_omega_cocont (bincoproduct_functor PC).
 Proof.
-intros c L ccL; apply cocont_bincoproducts_functor.
+intros c L ccL; apply cocont_bincoproduct_functor.
 Defined.
 
 End bincoprod_functor.
+
+(* The functor "+ : C^I -> C" is cocont *)
+Section arbitrary_coprod_functor.
+
+Variables (I : UU) (C : precategory) (PC : ArbitraryCoproducts I C).
+Variable (hsC : has_homsets C).
+
+Lemma cocont_arbitrary_coproduct_functor : is_cocont (arbitrary_coproduct_functor _ PC).
+Proof.
+apply (left_adjoint_cocont _ (is_left_adjoint_arbitrary_coproduct_functor _ PC)).
+- abstract (apply has_homsets_arbitrary_product_precategory; apply hsC).
+- abstract (apply hsC).
+Defined.
+
+Lemma is_omega_cocont_arbitrary_coproduct_functor :
+  is_omega_cocont (arbitrary_coproduct_functor _ PC).
+Proof.
+intros c L ccL; apply cocont_arbitrary_coproduct_functor.
+Defined.
+
+End arbitrary_coprod_functor.
 
 Section coproduct_of_functors.
 
@@ -499,6 +522,41 @@ Definition omega_cocont_coproduct_functor (F G : omega_cocont_functor C D) :
   omega_cocont_functor C D := tpair _ _ (is_omega_cocont_coproduct_functor _ _ (pr2 F) (pr2 G)).
 
 End coproduct_of_functors.
+
+Section arbitrary_coproduct_of_functors.
+
+Variables (I : UU) (C D : precategory) (PC : ArbitraryProducts I C).
+Variables (HD : ArbitraryCoproducts I D).
+Variables (hsC : has_homsets C) (hsD : has_homsets D).
+
+Lemma is_omega_cocont_arbitrary_coproduct_of_functors (F : forall i, functor C D)
+  (HF : forall i, is_omega_cocont (F i)) :
+  is_omega_cocont (arbitrary_coproduct_of_functors _ HD F).
+Proof.
+apply (is_omega_cocont_functor_composite hsD).
+  apply (is_omega_cocont_arbitrary_delta_functor _ _ PC hsC).
+apply (is_omega_cocont_functor_composite hsD).
+  apply (is_omega_cocont_arbitrary_pair_functor _ _ _ _ hsC hsD HF).
+apply (is_omega_cocont_arbitrary_coproduct_functor _ _ _ hsD).
+Defined.
+
+Definition omega_cocont_arbitrary_coproduct_of_functors
+  (F : forall i, omega_cocont_functor C D) :
+  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_arbitrary_coproduct_of_functors _ (fun i => pr2 (F i))).
+
+(* TODO: port *)
+(* Lemma is_omega_cocont_arbitrary_coproduct_functor (F : forall (i : I), functor C D) *)
+(*   (HF : forall i, is_omega_cocont (F i)) : *)
+(*   is_omega_cocont (arbitrary_coproduct_functor I HD). *)
+(* Proof. *)
+(* exact (transportf _ (coproduct_of_functors_eq_coproduct_functor C D HD hsD F G) *)
+(*                   (is_omega_cocont_coproduct_of_functors _ _ HF HG)). *)
+(* Defined. *)
+
+(* Definition omega_cocont_coproduct_functor (F G : omega_cocont_functor C D) : *)
+(*   omega_cocont_functor C D := tpair _ _ (is_omega_cocont_coproduct_functor _ _ (pr2 F) (pr2 G)). *)
+
+End arbitrary_coproduct_of_functors.
 
 Section constprod_functors.
 

--- a/UniMath/CategoryTheory/cocontfunctors.v
+++ b/UniMath/CategoryTheory/cocontfunctors.v
@@ -40,6 +40,7 @@ Require Import UniMath.CategoryTheory.FunctorAlgebras.
 Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseProduct.
 Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseCoproduct.
 Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.limits.arbitrary_products.
 Require Import UniMath.CategoryTheory.limits.coproducts.
 Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.chains.
@@ -321,9 +322,9 @@ simple refine (let HHH : cocone c (fun _ => x) := _ in _).
   - simpl; intros n j.
     set (X := pr1 ccx n).
 simpl in *.
-Check (pr1 ccL n).
-Check (dob c n i).
-Check dmor.
+(* Check (pr1 ccL n). *)
+(* Check (dob c n i). *)
+(* Check dmor. *)
 set (Y:= (# (pr_functor I A j) (pr1 ccL n))).
 simpl in *.
 
@@ -367,44 +368,45 @@ Lemma is_omega_cocont_arbitrary_pair_functor
   (HF : forall (i : I), is_omega_cocont (F i)) :
   is_omega_cocont (arbitrary_pair_functor I F).
 Proof.
-intros cAB ml ccml Hccml xy ccxy; simpl in *.
-simple refine (let cc i : cocone (mapdiagram (F i) (mapdiagram (pr_functor I A i) cAB)) (xy i) := _ in _).
-{ simple refine (mk_cocone _ _).
-  - intro n; apply (pr1 ccxy n).
-  - abstract (intros m n e;
-              apply (toforallpaths _ _ _ (pr2 ccxy m n e) i)).
-}
-set (X i := HF i _ _ _ (isColimCocone_pr_functor i cAB ml ccml Hccml)
-             (xy i) (cc i)).
-mkpair.
-- mkpair.
-+
-intro i.
-apply (pr1 (pr1 (X i))).
-+
-intro n.
-apply funextsec; intro j.
-simpl.
-apply (pr2 (pr1 (X j)) n).
-- intro t.
-  apply subtypeEquality; simpl.
-  + intro x; apply impred; intro.
-apply impred_isaset; intro i; apply hsB.
-  + destruct t as [f1 f2]; simpl in *.
-apply funextsec; intro i.
+admit.
+(* intros cAB ml ccml Hccml xy ccxy; simpl in *. *)
+(* simple refine (let cc i : cocone (mapdiagram (F i) (mapdiagram (pr_functor I A i) cAB)) (xy i) := _ in _). *)
+(* { simple refine (mk_cocone _ _). *)
+(*   - intro n; apply (pr1 ccxy n). *)
+(*   - abstract (intros m n e; *)
+(*               apply (toforallpaths _ _ _ (pr2 ccxy m n e) i)). *)
+(* } *)
+(* set (X i := HF i _ _ _ (isColimCocone_pr_functor i cAB ml ccml Hccml) *)
+(*              (xy i) (cc i)). *)
+(* mkpair. *)
+(* - mkpair. *)
+(* + *)
+(* intro i. *)
+(* apply (pr1 (pr1 (X i))). *)
+(* + *)
+(* intro n. *)
+(* apply funextsec; intro j. *)
+(* simpl. *)
+(* apply (pr2 (pr1 (X j)) n). *)
+(* - intro t. *)
+(*   apply subtypeEquality; simpl. *)
+(*   + intro x; apply impred; intro. *)
+(* apply impred_isaset; intro i; apply hsB. *)
+(*   + destruct t as [f1 f2]; simpl in *. *)
+(* apply funextsec; intro i. *)
 
 
-simple refine (let XX : Σ x : B ⟦ (F i) (ml i), xy i ⟧,
-  ∀ x0 : nat, # (F i) (coconeIn ccml x0 i) ;; x = coconeIn ccxy x0 i := _ in _).
-mkpair.
-  apply (f1 i).
-  intro n.
-  apply ( toforallpaths _ _ _ (f2 n) i).
-simpl in *.
-set (XXX := (pr2 (X i)) XX).
-simpl in *.
-apply (maponpaths pr1 XXX).
-Defined.
+(* simple refine (let XX : Σ x : B ⟦ (F i) (ml i), xy i ⟧, *)
+(*   ∀ x0 : nat, # (F i) (coconeIn ccml x0 i) ;; x = coconeIn ccxy x0 i := _ in _). *)
+(* mkpair. *)
+(*   apply (f1 i). *)
+(*   intro n. *)
+(*   apply ( toforallpaths _ _ _ (f2 n) i). *)
+(* simpl in *. *)
+(* set (XXX := (pr2 (X i)) XX). *)
+(* simpl in *. *)
+(* apply (maponpaths pr1 XXX). *)
+Admitted.
 
 End arbitrary_pair_functor.
 
@@ -430,11 +432,11 @@ End delta_functor.
 (* The generalized delta functor C -> C^I is omega_cocont *)
 Section arbitrary_delta_functor.
 
-Variables (I : UU) (C : precategory) (PC : Products C) (hsC : has_homsets C).
+Variables (I : UU) (C : precategory) (PC : ArbitraryProducts I C) (hsC : has_homsets C).
 
 Lemma cocont_arbitrary_delta_functor : is_cocont (arbitrary_delta_functor I C).
 Proof.
-apply (left_adjoint_cocont _ (is_left_adjoint_arbitrary_delta_functor PC) hsC).
+apply (left_adjoint_cocont _ (is_left_adjoint_arbitrary_delta_functor _ PC) hsC).
 abstract (apply (has_homsets_arbitrary_product_precategory _ _ hsC)).
 Defined.
 

--- a/UniMath/CategoryTheory/cocontfunctors.v
+++ b/UniMath/CategoryTheory/cocontfunctors.v
@@ -39,6 +39,7 @@ Require Import UniMath.CategoryTheory.limits.initial.
 Require Import UniMath.CategoryTheory.FunctorAlgebras.
 Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseProduct.
 Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseCoproduct.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseArbitraryCoproduct.
 Require Import UniMath.CategoryTheory.limits.products.
 Require Import UniMath.CategoryTheory.limits.arbitrary_products.
 Require Import UniMath.CategoryTheory.limits.coproducts.
@@ -476,17 +477,18 @@ Section arbitrary_coprod_functor.
 Variables (I : UU) (C : precategory) (PC : ArbitraryCoproducts I C).
 Variable (hsC : has_homsets C).
 
-Lemma cocont_arbitrary_coproduct_functor : is_cocont (arbitrary_coproduct_functor _ PC).
+Lemma cocont_arbitrary_indexed_coproduct_functor :
+  is_cocont (arbitrary_indexed_coproduct_functor _ PC).
 Proof.
-apply (left_adjoint_cocont _ (is_left_adjoint_arbitrary_coproduct_functor _ PC)).
+apply (left_adjoint_cocont _ (is_left_adjoint_arbitrary_indexed_coproduct_functor _ PC)).
 - abstract (apply has_homsets_arbitrary_product_precategory; apply hsC).
 - abstract (apply hsC).
 Defined.
 
-Lemma is_omega_cocont_arbitrary_coproduct_functor :
-  is_omega_cocont (arbitrary_coproduct_functor _ PC).
+Lemma is_omega_cocont_arbitrary_indexed_coproduct_functor :
+  is_omega_cocont (arbitrary_indexed_coproduct_functor _ PC).
 Proof.
-intros c L ccL; apply cocont_arbitrary_coproduct_functor.
+intros c L ccL; apply cocont_arbitrary_indexed_coproduct_functor.
 Defined.
 
 End arbitrary_coprod_functor.
@@ -537,24 +539,24 @@ apply (is_omega_cocont_functor_composite hsD).
   apply (is_omega_cocont_arbitrary_delta_functor _ _ PC hsC).
 apply (is_omega_cocont_functor_composite hsD).
   apply (is_omega_cocont_arbitrary_pair_functor _ _ _ _ hsC hsD HF).
-apply (is_omega_cocont_arbitrary_coproduct_functor _ _ _ hsD).
+apply (is_omega_cocont_arbitrary_indexed_coproduct_functor _ _ _ hsD).
 Defined.
 
 Definition omega_cocont_arbitrary_coproduct_of_functors
   (F : forall i, omega_cocont_functor C D) :
   omega_cocont_functor C D := tpair _ _ (is_omega_cocont_arbitrary_coproduct_of_functors _ (fun i => pr2 (F i))).
 
-(* TODO: port *)
-(* Lemma is_omega_cocont_arbitrary_coproduct_functor (F : forall (i : I), functor C D) *)
-(*   (HF : forall i, is_omega_cocont (F i)) : *)
-(*   is_omega_cocont (arbitrary_coproduct_functor I HD). *)
-(* Proof. *)
-(* exact (transportf _ (coproduct_of_functors_eq_coproduct_functor C D HD hsD F G) *)
-(*                   (is_omega_cocont_coproduct_of_functors _ _ HF HG)). *)
-(* Defined. *)
+Lemma is_omega_cocont_arbitrary_coproduct_functor (F : forall (i : I), functor C D)
+  (HF : forall i, is_omega_cocont (F i)) :
+  is_omega_cocont (arbitrary_coproduct_functor I _ _ HD F).
+Proof.
+exact (transportf _ (arbitrary_coproduct_of_functors_eq_arbitrary_coproduct_functor I C D HD hsD F)
+                  (is_omega_cocont_arbitrary_coproduct_of_functors _ HF)).
+Defined.
 
-(* Definition omega_cocont_coproduct_functor (F G : omega_cocont_functor C D) : *)
-(*   omega_cocont_functor C D := tpair _ _ (is_omega_cocont_coproduct_functor _ _ (pr2 F) (pr2 G)). *)
+Definition omega_cocont_arbitrary_coproduct_functor
+  (F : forall i, omega_cocont_functor C D) :
+  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_arbitrary_coproduct_functor _ (fun i => pr2 (F i))).
 
 End arbitrary_coproduct_of_functors.
 

--- a/UniMath/CategoryTheory/cocontfunctors.v
+++ b/UniMath/CategoryTheory/cocontfunctors.v
@@ -50,6 +50,7 @@ Require Import UniMath.CategoryTheory.limits.arbitrary_products.
 Require Import UniMath.CategoryTheory.limits.coproducts.
 Require Import UniMath.CategoryTheory.limits.arbitrary_coproducts.
 Require Import UniMath.CategoryTheory.limits.terminal.
+Require Import UniMath.CategoryTheory.limits.cats.limits.
 Require Import UniMath.CategoryTheory.chains.
 Require Import UniMath.CategoryTheory.ProductPrecategory.
 Require Import UniMath.CategoryTheory.ArbitraryProductPrecategory.
@@ -57,6 +58,9 @@ Require Import UniMath.CategoryTheory.equivalences.
 Require Import UniMath.CategoryTheory.EquivalencesExamples.
 Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
 Require Import UniMath.CategoryTheory.exponentials.
+Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.RightKanExtension.
+Require Import UniMath.CategoryTheory.CommaCategories.
 
 Local Notation "# F" := (functor_on_morphisms F) (at level 3).
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
@@ -72,7 +76,7 @@ End move_upstream.
 
 Section cocont_functors.
 
-(* The constant functor is omega cocontinuous *)
+(** The constant functor is omega cocontinuous *)
 Lemma is_omega_cocont_constant_functor (C D : precategory) (hsD : has_homsets D)
   (x : D) : is_omega_cocont (constant_functor C D x).
 Proof.
@@ -92,7 +96,7 @@ Defined.
 Definition omega_cocont_constant_functor (C D : precategory) (hsD : has_homsets D)
   (x : D) : omega_cocont_functor C D := tpair _ _ (is_omega_cocont_constant_functor C D hsD x).
 
-(* The identity functor is omega cocontinuous *)
+(** The identity functor is omega cocontinuous *)
 Lemma is_omega_cocont_functor_identity (C : precategory) (hsC : has_homsets C) :
   is_omega_cocont (functor_identity C).
 Proof.
@@ -103,7 +107,7 @@ Defined.
 Definition omega_cocont_functor_identity (C : precategory) (hsC : has_homsets C) :
   omega_cocont_functor C C := tpair _ _ (is_omega_cocont_functor_identity C hsC).
 
-(* Functor composition preserves omega cocontinuity *)
+(** Functor composition preserves omega cocontinuity *)
 Lemma is_omega_cocont_functor_composite {C D E : precategory}
   (hsE : has_homsets E) (F : functor C D) (G : functor D E) :
   is_omega_cocont F -> is_omega_cocont G -> is_omega_cocont (functor_composite F G).
@@ -116,7 +120,7 @@ Definition omega_cocont_functor_composite {C D E : precategory}
   (hsE : has_homsets E) (F : omega_cocont_functor C D) (G : omega_cocont_functor D E) :
   omega_cocont_functor C E := tpair _ _ (is_omega_cocont_functor_composite hsE _ _ (pr2 F) (pr2 G)).
 
-(* Functor iteration preserves omega cocontinuity *)
+(** Functor iteration preserves omega cocontinuity *)
 Lemma is_omega_cocont_iter_functor {C : precategory} (hsC : has_homsets C)
   (F : functor C C) (hF : is_omega_cocont F) n : is_omega_cocont (iter_functor F n).
 Proof.
@@ -129,7 +133,7 @@ Definition omega_cocont_iter_functor {C : precategory} (hsC : has_homsets C)
   (F : omega_cocont_functor C C) n : omega_cocont_functor C C :=
   tpair _ _ (is_omega_cocont_iter_functor hsC _ (pr2 F) n).
 
-(* A pair of functors (F,G) : A * B -> C * D is omega_cocont if F and G are *)
+(** A pair of functors (F,G) : A * B -> C * D is omega_cocont if F and G are *)
 Section pair_functor.
 
 Variables A B C D : precategory.
@@ -268,7 +272,7 @@ Defined.
 
 End pair_functor.
 
-(* A family of functor F^I : A^I -> B^I is omega_cocont if each F_i is *)
+(** A family of functor F^I : A^I -> B^I is omega_cocont if each F_i is *)
 Section arbitrary_pair_functor.
 
 Variables (I : UU) (A B : precategory).
@@ -377,7 +381,7 @@ Defined.
 
 End arbitrary_pair_functor.
 
-(* The delta functor C -> C^2 mapping x to (x,x) is omega_cocont *)
+(** The delta functor C -> C^2 mapping x to (x,x) is omega_cocont *)
 Section delta_functor.
 
 Variables (C : precategory) (PC : Products C) (hsC : has_homsets C).
@@ -396,7 +400,7 @@ Defined.
 
 End delta_functor.
 
-(* The generalized delta functor C -> C^I is omega_cocont *)
+(** The generalized delta functor C -> C^I is omega_cocont *)
 Section arbitrary_delta_functor.
 
 Variables (I : UU) (C : precategory) (PC : ArbitraryProducts I C) (hsC : has_homsets C).
@@ -416,7 +420,7 @@ Defined.
 
 End arbitrary_delta_functor.
 
-(* The functor "+ : C^2 -> C" is cocont *)
+(** The functor "+ : C^2 -> C" is cocont *)
 Section bincoprod_functor.
 
 Variables (C : precategory) (PC : Coproducts C) (hsC : has_homsets C).
@@ -436,7 +440,7 @@ Defined.
 
 End bincoprod_functor.
 
-(* The functor "+ : C^I -> C" is cocont *)
+(** The functor "+ : C^I -> C" is cocont *)
 Section arbitrary_coprod_functor.
 
 Variables (I : UU) (C : precategory) (PC : ArbitraryCoproducts I C).
@@ -566,7 +570,7 @@ Definition omega_cocont_constprod_functor2 (x : C) :
 
 End constprod_functors.
 
-(* The functor "* : C^2 -> C" is omega cocont *)
+(** The functor "* : C^2 -> C" is omega cocont *)
 Section binprod_functor.
 
 Variables (C : precategory) (PC : Products C) (hsC : has_homsets C).
@@ -922,13 +926,8 @@ Definition omega_cocont_product_functor (F G : omega_cocont_functor C D) :
 
 End product_of_functors.
 
-(* Precomposition functor is cocontinuous *)
+(** Precomposition functor is cocontinuous *)
 Section pre_composition_functor.
-
-Require Import UniMath.CategoryTheory.whiskering.
-Require Import UniMath.CategoryTheory.RightKanExtension.
-Require Import UniMath.CategoryTheory.CommaCategories.
-Require Import UniMath.CategoryTheory.limits.cats.limits.
 
 Variables M C A : precategory.
 Variables (K : functor M C).
@@ -992,7 +991,6 @@ Local Definition R_functor : functor C A := tpair _ R_data R_is_functor.
 Local Definition eps_n (n : M) : A⟦R_functor (K n),T n⟧ :=
   coneOut (lambda (K n)) (n,,identity (K n)).
 
-(* TODO: Move to comma category file? *)
 Local Definition Kid n : K n ↓ K := (n,, identity (K n)).
 
 Local Lemma eps_is_nat_trans : is_nat_trans (functor_composite_data K R_data) T eps_n.
@@ -1017,7 +1015,7 @@ Local Definition eps : [M,A,hsA]⟦functor_composite K R_functor,T⟧ :=
 
 End fix_T.
 
-(* Construction of right Kan extensions based on MacLane, CWM, X.3 (p. 233) *)
+(** Construction of right Kan extensions based on MacLane, CWM, X.3 (p. 233) *)
 Lemma RightKanExtension_from_limits : GlobalRightKanExtensionExists _ _ K _ hsC hsA.
 Proof.
 unfold GlobalRightKanExtensionExists.
@@ -1113,7 +1111,7 @@ End pre_composition_functor.
 
 End cocont_functors.
 
-(* Specialized notations for HSET *)
+(** Specialized notations for HSET *)
 Delimit Scope cocont_functor_hset_scope with CS.
 
 Notation "' x" := (omega_cocont_constant_functor _ _ has_homsets_HSET x)

--- a/UniMath/CategoryTheory/cocontfunctors.v
+++ b/UniMath/CategoryTheory/cocontfunctors.v
@@ -44,6 +44,7 @@ Require Import UniMath.CategoryTheory.limits.coproducts.
 Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.chains.
 Require Import UniMath.CategoryTheory.ProductPrecategory.
+Require Import UniMath.CategoryTheory.ArbitraryProductPrecategory.
 Require Import UniMath.CategoryTheory.equivalences.
 Require Import UniMath.CategoryTheory.EquivalencesExamples.
 Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
@@ -259,6 +260,154 @@ Defined.
 
 End pair_functor.
 
+(* A family of functor F^I : A^I -> B^I is omega_cocont if each F_i is *)
+Section arbitrary_pair_functor.
+
+Variables (I : UU) (A B : precategory).
+Variables (F : forall (i : I), functor A B).
+Variables (hsA : has_homsets A) (hsB : has_homsets B).
+
+(* Lemma cocone_pr_functor (cAi : chain (arbitrary_product_precategory I A)) *)
+(*   (ai : forall (i : I), A) (ccab : cocone cAi ai) : *)
+(*   cocone (mapchain (pr_functor I A B) cAi) (ai). *)
+(* Proof. *)
+(* simple refine (mk_cocone _ _). *)
+(* - simpl; intro n; apply (mor1 (coconeIn ccab n)). *)
+(* - abstract (simpl; intros m n e; now rewrite <- (coconeInCommutes ccab m n e)). *)
+(* Defined. *)
+
+(* Lemma isColimCocone_pr1_functor (cAB : chain (product_precategory A B)) *)
+(*   (ab : A × B) (ccab : cocone cAB ab) (Hccab : isColimCocone cAB ab ccab) : *)
+(*    isColimCocone (mapchain (pr1_functor A B) cAB) (ob1 ab) *)
+(*      (cocone_pr1_functor cAB ab ccab). *)
+(* Proof. *)
+(* intros x ccx. *)
+(* simple refine (let HHH : cocone cAB (x,, ob2 ab) := _ in _). *)
+(* { simple refine (mk_cocone _ _). *)
+(*   - simpl; intro n; split; *)
+(*       [ apply (pr1 ccx n) | apply (# (pr2_functor A B) (pr1 ccab n)) ]. *)
+(*   - abstract( *)
+(*     simpl; intros m n e; rewrite (paireta (dmor cAB e)); *)
+(*     apply pathsdirprod; [ apply (pr2 ccx m n e) *)
+(*                         | apply (maponpaths dirprod_pr2 ((pr2 ccab) m n e)) ]). *)
+(* } *)
+(* destruct (Hccab _ HHH) as [[[x1 x2] p1] p2]; simpl in *. *)
+(* mkpair. *)
+(* - apply (tpair _ x1). *)
+(*   abstract (intro n; apply (maponpaths pr1 (p1 n))). *)
+(* - intro t. *)
+(*   simple refine (let X : Σ x0, *)
+(*            ∀ v : nat, coconeIn ccab v ;; x0 = *)
+(*                       prodcatmor (pr1 ccx v) (pr2 (pr1 ccab v)) := _ in _). *)
+(*   { mkpair. *)
+(*     - split; [ apply (pr1 t) | apply (identity _) ]. *)
+(*     - abstract (intro n; rewrite id_right; apply pathsdirprod; *)
+(*                  [ apply (pr2 t) | apply idpath ]). *)
+(*   } *)
+(*   abstract (apply subtypeEquality; simpl; *)
+(*             [ intro f; apply impred; intro; apply hsA *)
+(*             | apply (maponpaths (fun x => pr1 (pr1 x)) (p2 X))]). *)
+(* Defined. *)
+
+Lemma isColimCocone_pr_functor
+  (c : chain (arbitrary_product_precategory I A))
+  (L : arbitrary_product_precategory I A) (ccL : cocone c L)
+  (M : isColimCocone c L ccL) : forall i,
+  isColimCocone _ _ (mapcocone (pr_functor I A i) c ccL).
+Proof.
+intros i x ccx; simpl in *.
+simple refine (let HHH : cocone c (fun _ => x) := _ in _).
+{ simple refine (mk_cocone _ _).
+  - simpl; intros n j.
+    set (X := pr1 ccx n).
+simpl in *.
+Check (pr1 ccL n).
+Check (dob c n i).
+Check dmor.
+set (Y:= (# (pr_functor I A j) (pr1 ccL n))).
+simpl in *.
+
+  (*     [ apply (pr1 ccx n) | apply (# (pr2_functor A B) (pr1 ccab n)) ]. *)
+  (* - abstract( *)
+  (*   simpl; intros m n e; rewrite (paireta (dmor cAB e)); *)
+  (*   apply pathsdirprod; [ apply (pr2 ccx m n e) *)
+  (*                       | apply (maponpaths dirprod_pr2 ((pr2 ccab) m n e)) ]). *)
+admit.
+-
+admit.
+}
+unfold isColimCocone in *.
+simpl in *.
+
+destruct (M _ HHH) as [[x1 p1] p2]; simpl in *.
+mkpair.
+- apply (tpair _ (x1 i)).
+  intro n. admit. (* ; apply (maponpaths pr1 (p1 n)). *)
+- intro t.
+  (* simple refine (let X : Σ x0, *)
+  (*          ∀ v : nat, coconeIn ccab v ;; x0 = *)
+  (*                     prodcatmor (pr1 ccx v) (pr2 (pr1 ccab v)) := _ in _). *)
+  (* { mkpair. *)
+  (*   - split; [ apply (pr1 t) | apply (identity _) ]. *)
+  (*   - abstract (intro n; rewrite id_right; apply pathsdirprod; *)
+  (*                [ apply (pr2 t) | apply idpath ]). *)
+  (* } *)
+  (* abstract (apply subtypeEquality; simpl; *)
+  (*           [ intro f; apply impred; intro; apply hsA *)
+  (*           | apply (maponpaths (fun x => pr1 (pr1 x)) (p2 X))]). *)
+Admitted.
+
+Lemma is_omega_cocont_pr_functor (i : I) : is_omega_cocont (pr_functor I A i).
+Proof.
+intros c L ccL M.
+now apply isColimCocone_pr_functor.
+Defined.
+
+Lemma is_omega_cocont_arbitrary_pair_functor
+  (HF : forall (i : I), is_omega_cocont (F i)) :
+  is_omega_cocont (arbitrary_pair_functor I F).
+Proof.
+intros cAB ml ccml Hccml xy ccxy; simpl in *.
+simple refine (let cc i : cocone (mapdiagram (F i) (mapdiagram (pr_functor I A i) cAB)) (xy i) := _ in _).
+{ simple refine (mk_cocone _ _).
+  - intro n; apply (pr1 ccxy n).
+  - abstract (intros m n e;
+              apply (toforallpaths _ _ _ (pr2 ccxy m n e) i)).
+}
+set (X i := HF i _ _ _ (isColimCocone_pr_functor i cAB ml ccml Hccml)
+             (xy i) (cc i)).
+mkpair.
+- mkpair.
++
+intro i.
+apply (pr1 (pr1 (X i))).
++
+intro n.
+apply funextsec; intro j.
+simpl.
+apply (pr2 (pr1 (X j)) n).
+- intro t.
+  apply subtypeEquality; simpl.
+  + intro x; apply impred; intro.
+apply impred_isaset; intro i; apply hsB.
+  + destruct t as [f1 f2]; simpl in *.
+apply funextsec; intro i.
+
+
+simple refine (let XX : Σ x : B ⟦ (F i) (ml i), xy i ⟧,
+  ∀ x0 : nat, # (F i) (coconeIn ccml x0 i) ;; x = coconeIn ccxy x0 i := _ in _).
+mkpair.
+  apply (f1 i).
+  intro n.
+  apply ( toforallpaths _ _ _ (f2 n) i).
+simpl in *.
+set (XXX := (pr2 (X i)) XX).
+simpl in *.
+apply (maponpaths pr1 XXX).
+Defined.
+
+End arbitrary_pair_functor.
+
 (* The delta functor C -> C^2 mapping x to (x,x) is omega_cocont *)
 Section delta_functor.
 
@@ -277,6 +426,26 @@ apply cocont_delta_functor.
 Defined.
 
 End delta_functor.
+
+(* The generalized delta functor C -> C^I is omega_cocont *)
+Section arbitrary_delta_functor.
+
+Variables (I : UU) (C : precategory) (PC : Products C) (hsC : has_homsets C).
+
+Lemma cocont_arbitrary_delta_functor : is_cocont (arbitrary_delta_functor I C).
+Proof.
+apply (left_adjoint_cocont _ (is_left_adjoint_arbitrary_delta_functor PC) hsC).
+abstract (apply (has_homsets_arbitrary_product_precategory _ _ hsC)).
+Defined.
+
+Lemma is_omega_cocont_arbitrary_delta_functor :
+  is_omega_cocont (arbitrary_delta_functor I C).
+Proof.
+intros c L ccL.
+apply cocont_arbitrary_delta_functor.
+Defined.
+
+End arbitrary_delta_functor.
 
 (* The functor "+ : C^2 -> C" is cocont *)
 Section bincoprod_functor.

--- a/UniMath/CategoryTheory/cocontfunctors.v
+++ b/UniMath/CategoryTheory/cocontfunctors.v
@@ -283,6 +283,15 @@ Definition ifI (i j : I) (a b : A) : A := match HI i j with
 (* apply b. *)
 (* Defined. *)
 
+Lemma test i x y : ifI i i x y = x.
+Proof.
+unfold ifI.
+destruct (HI i i) as [p|p].
+Search coprod_rect.
+apply idpath.
+destruct (p (idpath _)).
+Defined.
+
 
 Lemma isColimCocone_pr_functor
   (c : chain (arbitrary_product_precategory I A))
@@ -291,34 +300,78 @@ Lemma isColimCocone_pr_functor
   isColimCocone _ _ (mapcocone (pr_functor I A i) c ccL).
 Proof.
 intros i x ccx; simpl in *.
+
 simple refine (let HHH : cocone c (fun j => ifI i j x (L j)) := _ in _).
 { unfold ifI.
   simple refine (mk_cocone _ _).
   - simpl; intros n j.
-    induction (HI i j) as [p|p].
-    + induction p; apply (pr1 ccx n).
-    + apply (# (pr_functor I A j) (pr1 ccL n)).
+    destruct (HI i j) as [p|p].
+    + apply (transportf (fun i => A ⟦ dob c n i, x ⟧) p (coconeIn ccx n)).
+    + apply (# (pr_functor I A j) (coconeIn ccL n)).
   - abstract (simpl; intros m n e;
       apply funextsec; intro j; unfold compose; simpl;
       destruct (HI i j);
         [ destruct p; apply (pr2 ccx m n e)
         | apply (toforallpaths _ _ _ (pr2 ccL m n e) j)]).
 }
+
 (* simple refine (let lol : x = ifI i i x (L i) := _ in _). *)
 (*   unfold ifI; destruct (HI i i) as [p|p]; [apply idpath|destruct (p (idpath _))]. *)
 destruct (M _ HHH) as [[x1 p1] p2].
+(* destruct (HI i i). *)
+
 simple refine (let X : A⟦L i,x⟧ := _ in _).
-{ unfold ifI in x1.
-  simpl in *.
-  generalize (x1 i).
-  induction (HI i i) as [p|p]; [intro xx; apply xx|induction (p (idpath i))].
+{
+  apply (transportf _ (test _ _ _) (x1 i)).
+
+  (* destruct (HI i i) as [p'|p']; [intro xx; apply xx|induction (p' (idpath i))]. *)
 }
 mkpair.
-- apply (tpair _ X).
+-
+apply (tpair _ X).
   intro n.
-  generalize (toforallpaths _ _ _ (p1 n) i).
-  (* unfold X, HHH; clear X p2 p1 HHH. *)
-  (* destruct (HI i i). *)
+unfold X; clear X.
+rewrite <- idtoiso_postcompose, assoc.
+
+assert (apa : coconeIn ccL n i ;; x1 i = coconeIn HHH n i).
+  apply (toforallpaths _ _ _ (p1 n) i).
+rewrite apa.
+rewrite idtoiso_postcompose.
+simpl.
+unfold test.
+simpl.
+unfold transportf.
+unfold coconeIn.
+clear apa p1 p2 HHH.
+simpl.
+destruct (HI i i).
+apply idpath.
+rewrite <- (idtoiso_precompose _ _ _ _ (test i x (L i)) (coconeIn HHH n i)).
+unfold test.
+destruct (HI i i).
+
+assert (transportf _ (!(test _ _ _)) (coconeIn ccL n i ;; X) = transportf _ (!(test i _ (L i))) (coconeIn ccx n)).
+unfold X; clear X.
+(* generalize ((test i x (L i))). *)
+(* intro p. *)
+
+rewrite <- idtoiso_postcompose.
+rewrite <- idtoiso_postcompose.
+rewrite assoc.
+assert (apa : coconeIn ccL n i ;; x1 i = coconeIn HHH n i).
+  apply (toforallpaths _ _ _ (p1 n) i).
+rewrite apa.
+Check (coconeIn HHH n i).
+Check (coconeIn ccx n).
+assert (asdf :  coconeIn HHH n i = transportf _ (! (test _ _ _)) (coconeIn ccx n)).
+simpl.
+clear apa p2 p1 HHH x1.
+generalize (test i x (L i)).
+intro p.
+
+
+  destruct (HI i i).
+
   admit.
 - intro t.
   (* simple refine (let X : Σ x0, *)

--- a/UniMath/CategoryTheory/cocontfunctors.v
+++ b/UniMath/CategoryTheory/cocontfunctors.v
@@ -8,10 +8,15 @@ This file contains proofs that the following functors are
 - Composition of omega-cocontinuous functors
 - Iteration of omega-cocontinuous functors: F^n : C -> C
 - Pairing of omega-cocont functors (F,G) : A * B -> C * D, (x,y) |-> (F x,G y)
-- Delta functor: C -> C^2, x |-> (x,x)
+- Indexed families of omega-cocont functors F^I : A^I -> B^I
+- Binary delta functor: C -> C^2, x |-> (x,x)
+- General delta functor: C -> C^I
 - Binary coproduct functor: C^2 -> C, (x,y) |-> x + y
-- Coproduct of functors: F + G : C -> D, x |-> (x,x) |-> (F x,G x) |-> F x + G x
-- Coproduct functor: F + G : C -> D, x |-> F x + G x
+- General coproduct functor: C^I -> C
+- Binary coproduct of functors: F + G : C -> D, x |-> (x,x) |-> (F x,G x) |-> F x + G x
+- Coproduct of families of functors: + F_i : C -> D  (generalization of coproduct of functors)
+- Binary coproduct functor: F + G : C -> D, x |-> F x + G x
+- General coproduct functor: + F_i : C -> D
 - Constant product functors: C -> C, x |-> a * x  and  x |-> x * a
 - Binary product functor: C^2 -> C, (x,y) |-> x * y
 - Product of functors: F * G : C -> D, x |-> (x,x) |-> (F x,G x) |-> F x * G x
@@ -346,7 +351,8 @@ Lemma is_omega_cocont_arbitrary_pair_functor
   is_omega_cocont (arbitrary_pair_functor I F).
 Proof.
 intros cAB ml ccml Hccml xy ccxy; simpl in *.
-simple refine (let cc i : cocone (mapdiagram (F i) (mapdiagram (pr_functor I A i) cAB)) (xy i) := _ in _).
+simple refine (let cc i : cocone (mapdiagram (F i)
+                            (mapdiagram (pr_functor I A i) cAB)) (xy i) := _ in _).
 { simple refine (mk_cocone _ _).
   - intro n; apply (pr1 ccxy n).
   - abstract (intros m n e;
@@ -356,9 +362,7 @@ set (X i := HF i _ _ _ (isColimCocone_pr_functor _ _ _ Hccml i) (xy i) (cc i)).
 mkpair.
 - mkpair.
   + intro i; apply (pr1 (pr1 (X i))).
-  + intro n.
-    apply funextsec; intro j.
-    apply (pr2 (pr1 (X j)) n).
+  + abstract (intro n; apply funextsec; intro j; apply (pr2 (pr1 (X j)) n)).
 - intro t.
   apply subtypeEquality; simpl.
   + intro x; apply impred; intro; apply impred_isaset; intro i; apply hsB.
@@ -367,8 +371,7 @@ mkpair.
     simple refine (let H : Σ x : B ⟦ (F i) (ml i), xy i ⟧,
                           ∀ n, # (F i) (coconeIn ccml n i) ;; x =
                                coconeIn ccxy n i := _ in _).
-    apply (tpair _ (f1 i)); intro n.
-    apply (toforallpaths _ _ _ (f2 n) i).
+    { apply (tpair _ (f1 i)); intro n; apply (toforallpaths _ _ _ (f2 n) i). }
     apply (maponpaths pr1 (pr2 (X i) H)).
 Defined.
 
@@ -472,7 +475,8 @@ apply (is_omega_cocont_bincoproduct_functor _ _ hsD).
 Defined.
 
 Definition omega_cocont_coproduct_of_functors (F G : omega_cocont_functor C D) :
-  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_coproduct_of_functors _ _ (pr2 F) (pr2 G)).
+  omega_cocont_functor C D :=
+    tpair _ _ (is_omega_cocont_coproduct_of_functors _ _ (pr2 F) (pr2 G)).
 
 Lemma is_omega_cocont_coproduct_functor (F G : functor C D)
   (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
@@ -483,7 +487,8 @@ exact (transportf _ (coproduct_of_functors_eq_coproduct_functor C D HD hsD F G)
 Defined.
 
 Definition omega_cocont_coproduct_functor (F G : omega_cocont_functor C D) :
-  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_coproduct_functor _ _ (pr2 F) (pr2 G)).
+  omega_cocont_functor C D :=
+    tpair _ _ (is_omega_cocont_coproduct_functor _ _ (pr2 F) (pr2 G)).
 
 End coproduct_of_functors.
 
@@ -507,7 +512,8 @@ Defined.
 
 Definition omega_cocont_arbitrary_coproduct_of_functors
   (F : forall i, omega_cocont_functor C D) :
-  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_arbitrary_coproduct_of_functors _ (fun i => pr2 (F i))).
+  omega_cocont_functor C D :=
+    tpair _ _ (is_omega_cocont_arbitrary_coproduct_of_functors _ (fun i => pr2 (F i))).
 
 Lemma is_omega_cocont_arbitrary_coproduct_functor (F : forall (i : I), functor C D)
   (HF : forall i, is_omega_cocont (F i)) :
@@ -519,7 +525,8 @@ Defined.
 
 Definition omega_cocont_arbitrary_coproduct_functor
   (F : forall i, omega_cocont_functor C D) :
-  omega_cocont_functor C D := tpair _ _ (is_omega_cocont_arbitrary_coproduct_functor _ (fun i => pr2 (F i))).
+  omega_cocont_functor C D :=
+    tpair _ _ (is_omega_cocont_arbitrary_coproduct_functor _ (fun i => pr2 (F i))).
 
 End arbitrary_coproduct_of_functors.
 

--- a/UniMath/CategoryTheory/limits/FunctorsPointwiseArbitraryCoproduct.v
+++ b/UniMath/CategoryTheory/limits/FunctorsPointwiseArbitraryCoproduct.v
@@ -1,0 +1,67 @@
+(** **********************************************************
+
+Anders Mörtberg, 2016
+
+************************************************************)
+
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.limits.arbitrary_coproducts.
+
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
+
+Section def_functor_pointwise_arbitrary_coprod.
+
+Variables (I : UU) (C D : precategory).
+Variable HD : ArbitraryCoproducts I D.
+Variable hsD : has_homsets D.
+
+Section arbitrary_coproduct_functor.
+
+Variables (F : forall (i : I), functor C D).
+
+Definition arbitrary_coproduct_functor_ob (c : C) : D
+  := ArbitraryCoproductObject _ _ (HD (fun i => F i c)).
+
+Definition arbitrary_coproduct_functor_mor (c c' : C) (f : c --> c')
+  : arbitrary_coproduct_functor_ob c --> arbitrary_coproduct_functor_ob c' :=
+  ArbitraryCoproductOfArrows _ _ _ _ (fun i => # (F i) f).
+
+Definition arbitrary_coproduct_functor_data : functor_data C D.
+Proof.
+  exists arbitrary_coproduct_functor_ob.
+  exact arbitrary_coproduct_functor_mor.
+Defined.
+
+Lemma is_functor_arbitrary_coproduct_functor_data :
+  is_functor arbitrary_coproduct_functor_data.
+Proof.
+split; simpl; intros.
+- unfold functor_idax; intros; simpl in *.
+    apply pathsinv0.
+    apply ArbitraryCoproduct_endo_is_identity; intro i.
+    unfold arbitrary_coproduct_functor_mor.
+    eapply pathscomp0; [apply (ArbitraryCoproductOfArrowsIn _ _ (HD (λ i, (F i) a)))|].
+    now simpl; rewrite functor_id, id_left.
+- unfold functor_compax; simpl; unfold arbitrary_coproduct_functor_mor.
+  intros; simpl in *.
+  apply pathsinv0.
+  eapply pathscomp0.
+  apply ArbitraryCoproductOfArrows_comp.
+  apply maponpaths, funextsec; intro i.
+  now rewrite functor_comp.
+Qed.
+
+Definition arbitrary_coproduct_functor : functor C D :=
+  tpair _ _ is_functor_arbitrary_coproduct_functor_data.
+
+Lemma arbitrary_coproduct_of_functors_eq_arbitrary_coproduct_functor :
+  arbitrary_coproduct_of_functors _ HD F = arbitrary_coproduct_functor.
+Proof.
+now apply (functor_eq _ _ hsD).
+Defined.
+
+End arbitrary_coproduct_functor.
+End def_functor_pointwise_arbitrary_coprod.

--- a/UniMath/CategoryTheory/limits/FunctorsPointwiseArbitraryCoproduct.v
+++ b/UniMath/CategoryTheory/limits/FunctorsPointwiseArbitraryCoproduct.v
@@ -126,7 +126,7 @@ Defined.
 
 End arbitrary_coproduct_functor.
 
-Definition Coproducts_functor_precat : ArbitraryCoproducts I [C, D, hsD].
+Definition ArbitraryCoproducts_functor_precat : ArbitraryCoproducts I [C, D, hsD].
 Proof.
   intros F.
   apply functor_precat_arbitrary_coproduct_cocone.

--- a/UniMath/CategoryTheory/limits/FunctorsPointwiseArbitraryCoproduct.v
+++ b/UniMath/CategoryTheory/limits/FunctorsPointwiseArbitraryCoproduct.v
@@ -63,5 +63,73 @@ Proof.
 now apply (functor_eq _ _ hsD).
 Defined.
 
+Definition arbitrary_coproduct_nat_trans_in_data i (c : C) :
+  D ⟦ (F i) c, arbitrary_coproduct_functor c ⟧ :=
+  ArbitraryCoproductIn _ _ (HD (fun j => (F j) c)) i.
+
+Lemma is_nat_trans_arbitrary_coproduct_nat_trans_in_data i :
+  is_nat_trans _ _ (arbitrary_coproduct_nat_trans_in_data i).
+Proof.
+intros c c' f; apply pathsinv0.
+now eapply pathscomp0;[apply (ArbitraryCoproductOfArrowsIn I _ (HD (λ i, (F i) c)))|].
+Qed.
+
+Definition arbitrary_coproduct_nat_trans_in i : nat_trans (F i) arbitrary_coproduct_functor :=
+  tpair _ _ (is_nat_trans_arbitrary_coproduct_nat_trans_in_data i).
+
+Section vertex.
+
+Variable A : functor C D.
+Variable f : forall i, nat_trans (F i) A.
+
+Definition arbitrary_coproduct_nat_trans_data c :
+  arbitrary_coproduct_functor c --> A c :=
+    ArbitraryCoproductArrow _ _ _ (fun i => f i c).
+
+Lemma is_nat_trans_arbitrary_coproduct_nat_trans_data :
+  is_nat_trans _ _ arbitrary_coproduct_nat_trans_data.
+Proof.
+intros a b k; simpl.
+eapply pathscomp0.
+apply (precompWithArbitraryCoproductArrow I D (HD (λ i : I, (F i) a)) (HD (λ i : I, (F i) b))).
+apply pathsinv0.
+eapply pathscomp0; [apply postcompWithArbitraryCoproductArrow|].
+apply maponpaths, funextsec; intro i.
+now rewrite (nat_trans_ax (f i)).
+Qed.
+
+Definition arbitrary_coproduct_nat_trans : nat_trans arbitrary_coproduct_functor A
+  := tpair _ _ is_nat_trans_arbitrary_coproduct_nat_trans_data.
+
+End vertex.
+
+Definition functor_precat_arbitrary_coproduct_cocone
+  : ArbitraryCoproductCocone I [C, D, hsD] F.
+Proof.
+simple refine (mk_ArbitraryCoproductCocone _ _ _ _ _ _).
+- apply arbitrary_coproduct_functor.
+- apply arbitrary_coproduct_nat_trans_in.
+- simple refine (mk_isArbitraryCoproductCocone _ _ _ _ _ _ _).
+  + apply functor_category_has_homsets.
+  + intros A f.
+    mkpair.
+    * apply (tpair _ (arbitrary_coproduct_nat_trans A f)).
+      abstract (intro i; apply (nat_trans_eq hsD); intro c;
+                apply (ArbitraryCoproductInCommutes I D _ (HD (λ j, (F j) c)))).
+    * abstract (
+        intro t; apply subtypeEquality; simpl;
+          [intro; apply impred; intro; apply (isaset_nat_trans hsD)|];
+        apply (nat_trans_eq hsD); intro c;
+        apply ArbitraryCoproductArrowUnique; intro i;
+        apply (nat_trans_eq_pointwise (pr2 t i))).
+Defined.
+
 End arbitrary_coproduct_functor.
+
+Definition Coproducts_functor_precat : ArbitraryCoproducts I [C, D, hsD].
+Proof.
+  intros F.
+  apply functor_precat_arbitrary_coproduct_cocone.
+Defined.
+
 End def_functor_pointwise_arbitrary_coprod.

--- a/UniMath/CategoryTheory/limits/FunctorsPointwiseArbitraryCoproduct.v
+++ b/UniMath/CategoryTheory/limits/FunctorsPointwiseArbitraryCoproduct.v
@@ -4,6 +4,17 @@ Anders Mörtberg, 2016
 
 ************************************************************)
 
+(** **********************************************************
+
+Contents :
+
+- Definition of a coproduct structure on a functor category
+  by taking pointwise coproducts in the target category
+
+Adapted from the binary version
+
+************************************************************)
+
 Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
@@ -20,7 +31,7 @@ Variable hsD : has_homsets D.
 
 Section arbitrary_coproduct_functor.
 
-Variables (F : forall (i : I), functor C D).
+Variables (F : I -> functor C D).
 
 Definition arbitrary_coproduct_functor_ob (c : C) : D
   := ArbitraryCoproductObject _ _ (HD (fun i => F i c)).

--- a/UniMath/CategoryTheory/limits/FunctorsPointwiseArbitraryProduct.v
+++ b/UniMath/CategoryTheory/limits/FunctorsPointwiseArbitraryProduct.v
@@ -1,0 +1,149 @@
+(** **********************************************************
+
+Anders Mörtberg, 2016
+
+************************************************************)
+
+
+(** **********************************************************
+
+Contents :
+
+- Definition of a product structure on a functor category
+  by taking pointwise products in the target category
+
+Adapted from the binary version
+
+************************************************************)
+
+Require Import UniMath.Foundations.Basics.PartD.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.limits.arbitrary_products.
+
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
+
+Section def_functor_pointwise_arbitrary_prod.
+
+Variables (I : UU) (C D : precategory).
+Variable HD : ArbitraryProducts I D.
+Variable hsD : has_homsets D.
+
+Section arbitrary_product_functor.
+
+Variables F : I -> functor C D.
+
+(* Local Notation "c ⊗ d" := (ProductObject _ (HD c d))(at level 45). *)
+
+Definition arbitrary_product_functor_ob (c : C) : D :=
+  ArbitraryProductObject _ _ (HD (fun i => F i c)).
+
+Definition arbitrary_product_functor_mor (c c' : C) (f : c --> c') :
+  arbitrary_product_functor_ob c --> arbitrary_product_functor_ob c' :=
+    ArbitraryProductOfArrows _ _ _ _ (fun i => # (F i) f).
+
+Definition arbitrary_product_functor_data : functor_data C D.
+Proof.
+  exists arbitrary_product_functor_ob.
+  exact arbitrary_product_functor_mor.
+Defined.
+
+Lemma is_functor_arbitrary_product_functor_data : is_functor arbitrary_product_functor_data.
+Proof.
+split; simpl; intros.
+- unfold functor_idax; intros; simpl in *.
+    apply pathsinv0.
+    apply ArbitraryProduct_endo_is_identity; intro i.
+    unfold arbitrary_product_functor_mor.
+    eapply pathscomp0; [apply (ArbitraryProductOfArrowsPr _ _ (HD (λ i, (F i) a)))|].
+    now simpl; rewrite functor_id, id_right.
+- unfold functor_compax; simpl; unfold arbitrary_product_functor_mor.
+  intros; simpl in *.
+  apply pathsinv0.
+  eapply pathscomp0.
+  apply ArbitraryProductOfArrows_comp.
+  apply maponpaths, funextsec; intro i.
+  now rewrite functor_comp.
+Qed.
+
+Definition arbitrary_product_functor : functor C D :=
+  tpair _ _ is_functor_arbitrary_product_functor_data.
+
+Lemma arbitrary_product_of_functors_eq_arbitrary_product_functor :
+  arbitrary_product_of_functors _ HD F = arbitrary_product_functor.
+Proof.
+now apply (functor_eq _ _ hsD).
+Defined.
+
+Definition arbitrary_product_nat_trans_pr_data i (c : C) :
+  D ⟦ arbitrary_product_functor c, (F i) c ⟧ :=
+  ArbitraryProductPr _ _ (HD (fun j => (F j) c)) i.
+
+Lemma is_nat_trans_arbitrary_product_nat_trans_pr_data i :
+  is_nat_trans _ _ (arbitrary_product_nat_trans_pr_data i).
+Proof.
+intros c c' f.
+apply (ArbitraryProductOfArrowsPr I _ (HD (λ i, F i c')) (HD (λ i, F i c))).
+Qed.
+
+Definition arbitrary_product_nat_trans_pr i : nat_trans arbitrary_product_functor (F i) :=
+  tpair _ _ (is_nat_trans_arbitrary_product_nat_trans_pr_data i).
+
+Section vertex.
+
+(** The product morphism of a diagram with vertex [A] *)
+
+Variable A : functor C D.
+Variable f : forall i, nat_trans A (F i).
+
+Definition arbitrary_product_nat_trans_data c :
+  A c --> arbitrary_product_functor c:=
+    ArbitraryProductArrow _ _ _ (fun i => f i c).
+
+Lemma is_nat_trans_arbitrary_product_nat_trans_data :
+  is_nat_trans _ _ arbitrary_product_nat_trans_data.
+Proof.
+intros a b k; simpl.
+eapply pathscomp0; [apply precompWithArbitraryProductArrow|].
+apply pathsinv0.
+eapply pathscomp0; [apply postcompWithArbitraryProductArrow|].
+apply maponpaths, funextsec; intro i.
+now rewrite (nat_trans_ax (f i)).
+Qed.
+
+Definition arbitrary_product_nat_trans : nat_trans A arbitrary_product_functor
+  := tpair _ _ is_nat_trans_arbitrary_product_nat_trans_data.
+
+End vertex.
+
+Definition functor_precat_arbitrary_product_cone
+  : ArbitraryProductCone I [C, D, hsD] F.
+Proof.
+simple refine (mk_ArbitraryProductCone _ _ _ _ _ _).
+- apply arbitrary_product_functor.
+- apply arbitrary_product_nat_trans_pr.
+- simple refine (mk_isArbitraryProductCone _ _ _ _ _ _ _).
+  + apply functor_category_has_homsets.
+  + intros A f.
+    mkpair.
+    * apply (tpair _ (arbitrary_product_nat_trans A f)).
+      abstract (intro i; apply (nat_trans_eq hsD); intro c;
+                apply (ArbitraryProductPrCommutes I D _ (HD (λ j, (F j) c)))).
+    * abstract (
+        intro t; apply subtypeEquality; simpl;
+          [intro; apply impred; intro; apply (isaset_nat_trans hsD)|];
+        apply (nat_trans_eq hsD); intro c;
+        apply ArbitraryProductArrowUnique; intro i;
+        apply (nat_trans_eq_pointwise (pr2 t i))).
+Defined.
+
+End arbitrary_product_functor.
+
+Definition ArbitraryProducts_functor_precat : ArbitraryProducts I [C, D, hsD].
+Proof.
+intros F; apply functor_precat_arbitrary_product_cone.
+Defined.
+
+End def_functor_pointwise_arbitrary_prod.

--- a/UniMath/CategoryTheory/limits/arbitrary_coproducts.v
+++ b/UniMath/CategoryTheory/limits/arbitrary_coproducts.v
@@ -156,14 +156,11 @@ rewrite assoc, ArbitraryCoproductOfArrowsIn.
 now rewrite <- assoc, ArbitraryCoproductOfArrowsIn, assoc.
 Qed.
 
-(* Definition ArbitraryCoproductOfArrows_eq (f f' : a --> c) (g g' : b --> d) *)
-(*   : f = f' → g = g' → *)
-(*       ArbitraryCoproductOfArrows _ _ _ f g = ArbitraryCoproductOfArrows _ (CC _ _) (CC _ _) f' g'. *)
-(* Proof. *)
-(*   induction 1. *)
-(*   induction 1. *)
-(*   apply idpath. *)
-(* Qed. *)
+Definition ArbitraryCoproductOfArrows_eq (a c : I -> C) (f f' : forall i, a i --> c i) : f = f' ->
+  ArbitraryCoproductOfArrows _ _ _ _ f = ArbitraryCoproductOfArrows _ _ (CC _) (CC _) f'.
+Proof.
+now induction 1.
+Qed.
 
 End Coproducts.
 

--- a/UniMath/CategoryTheory/limits/arbitrary_coproducts.v
+++ b/UniMath/CategoryTheory/limits/arbitrary_coproducts.v
@@ -175,7 +175,7 @@ End Coproducts.
 
 Section functors.
 
-Definition arbitrary_coproduct_functor_data (I : UU) {C : precategory}
+Definition arbitrary_indexed_coproduct_functor_data (I : UU) {C : precategory}
   (PC : ArbitraryCoproducts I C) : functor_data (arbitrary_product_precategory I C) C.
 Proof.
 mkpair.
@@ -186,10 +186,10 @@ mkpair.
 Defined.
 
 (* The arbitrary coproduct functor: C^I -> C *)
-Definition arbitrary_coproduct_functor (I : UU) {C : precategory}
+Definition arbitrary_indexed_coproduct_functor (I : UU) {C : precategory}
   (PC : ArbitraryCoproducts I C) : functor (arbitrary_product_precategory I C) C.
 Proof.
-apply (tpair _ (arbitrary_coproduct_functor_data _ PC)).
+apply (tpair _ (arbitrary_indexed_coproduct_functor_data _ PC)).
 split.
   - intro x; simpl; apply pathsinv0, ArbitraryCoproduct_endo_is_identity.
     now intro i; rewrite ArbitraryCoproductOfArrowsIn, id_left.
@@ -202,4 +202,5 @@ End functors.
 Definition arbitrary_coproduct_of_functors (I : UU) {C D : precategory}
   (HD : ArbitraryCoproducts I D) (F : forall i, functor C D) : functor C D :=
   functor_composite (arbitrary_delta_functor I C)
-     (functor_composite (arbitrary_pair_functor _ F) (arbitrary_coproduct_functor _ HD)).
+     (functor_composite (arbitrary_pair_functor _ F)
+                        (arbitrary_indexed_coproduct_functor _ HD)).

--- a/UniMath/CategoryTheory/limits/arbitrary_coproducts.v
+++ b/UniMath/CategoryTheory/limits/arbitrary_coproducts.v
@@ -19,42 +19,42 @@ Section coproduct_def.
 
 Variables (I : UU) (C : precategory).
 
-Definition isArbitraryCoproductCocone (a : forall (i : I), C) (co : C)
+Definition isArbitraryCoproductCocone (a : I -> C) (co : C)
   (ia : forall i, a i --> co) :=
   forall (c : C) (f : forall i, a i --> c),
     iscontr (total2 (fun (g : co --> c) => forall i, ia i ;; g = f i)).
 
-Definition ArbitraryCoproductCocone (a : forall i, C) :=
+Definition ArbitraryCoproductCocone (a : I -> C) :=
    Σ coia : (Σ co : C, forall i, a i --> co),
           isArbitraryCoproductCocone a (pr1 coia) (pr2 coia).
 
-Definition ArbitraryCoproducts := ∀ (a : forall i, C), ArbitraryCoproductCocone a.
+Definition ArbitraryCoproducts := ∀ (a : I -> C), ArbitraryCoproductCocone a.
 Definition hasArbitraryCoproducts := ishinh ArbitraryCoproducts.
 
-Definition ArbitraryCoproductObject {a : forall i, C} (CC : ArbitraryCoproductCocone a) : C := pr1 (pr1 CC).
-Definition ArbitraryCoproductIn {a : forall i, C} (CC : ArbitraryCoproductCocone a): forall i, a i--> ArbitraryCoproductObject CC :=
+Definition ArbitraryCoproductObject {a : I -> C} (CC : ArbitraryCoproductCocone a) : C := pr1 (pr1 CC).
+Definition ArbitraryCoproductIn {a : I -> C} (CC : ArbitraryCoproductCocone a): forall i, a i --> ArbitraryCoproductObject CC :=
   pr2 (pr1 CC).
 
-Definition isArbitraryCoproductCocone_ArbitraryCoproductCocone {a : forall i, C} (CC : ArbitraryCoproductCocone a) :
+Definition isArbitraryCoproductCocone_ArbitraryCoproductCocone {a : I -> C} (CC : ArbitraryCoproductCocone a) :
    isArbitraryCoproductCocone a (ArbitraryCoproductObject CC) (ArbitraryCoproductIn CC).
 Proof.
   exact (pr2 CC).
 Defined.
 
-Definition ArbitraryCoproductArrow {a : forall i, C} (CC : ArbitraryCoproductCocone a) {c : C} (f : forall i, a i --> c) :
+Definition ArbitraryCoproductArrow {a : I -> C} (CC : ArbitraryCoproductCocone a) {c : C} (f : forall i, a i --> c) :
       ArbitraryCoproductObject CC --> c.
 Proof.
   exact (pr1 (pr1 (isArbitraryCoproductCocone_ArbitraryCoproductCocone CC _ f))).
 Defined.
 
-Lemma ArbitraryCoproductInCommutes (a : forall i, C) (CC : ArbitraryCoproductCocone a) :
+Lemma ArbitraryCoproductInCommutes (a : I -> C) (CC : ArbitraryCoproductCocone a) :
      ∀ (c : C) (f : forall i, a i --> c) i, ArbitraryCoproductIn CC i ;; ArbitraryCoproductArrow CC f = f i.
 Proof.
   intros c f i.
   exact (pr2 (pr1 (isArbitraryCoproductCocone_ArbitraryCoproductCocone CC _ f)) i).
 Qed.
 
-Lemma ArbitraryCoproductArrowUnique (a : forall i, C) (CC : ArbitraryCoproductCocone a) (x : C)
+Lemma ArbitraryCoproductArrowUnique (a : I -> C) (CC : ArbitraryCoproductCocone a) (x : C)
     (f : forall i, a i --> x) (k : ArbitraryCoproductObject CC --> x)
     (Hk : forall i, ArbitraryCoproductIn CC i ;; k = f i) :
   k = ArbitraryCoproductArrow CC f.
@@ -63,7 +63,7 @@ Proof.
   apply (base_paths _ _ H').
 Qed.
 
-Lemma ArbitraryCoproductArrowEta (a : forall i, C) (CC : ArbitraryCoproductCocone a) (x : C)
+Lemma ArbitraryCoproductArrowEta (a : I -> C) (CC : ArbitraryCoproductCocone a) (x : C)
     (f : ArbitraryCoproductObject CC --> x) :
     f = ArbitraryCoproductArrow CC (fun i => ArbitraryCoproductIn CC i ;; f).
 Proof.
@@ -71,12 +71,12 @@ Proof.
 Qed.
 
 
-Definition ArbitraryCoproductOfArrows {a : forall i, C} (CCab : ArbitraryCoproductCocone a) {c : forall i, C}
+Definition ArbitraryCoproductOfArrows {a : I -> C} (CCab : ArbitraryCoproductCocone a) {c : I -> C}
     (CCcd : ArbitraryCoproductCocone c) (f : forall i, a i --> c i) :
           ArbitraryCoproductObject CCab --> ArbitraryCoproductObject CCcd :=
     ArbitraryCoproductArrow CCab (fun i => f i ;; ArbitraryCoproductIn CCcd i).
 
-Lemma ArbitraryCoproductOfArrowsIn {a : forall i, C} (CCab : ArbitraryCoproductCocone a) {c : forall i, C}
+Lemma ArbitraryCoproductOfArrowsIn {a : I -> C} (CCab : ArbitraryCoproductCocone a) {c : I -> C}
     (CCcd : ArbitraryCoproductCocone c) (f : forall i, a i --> c i) :
     forall i, ArbitraryCoproductIn CCab i ;; ArbitraryCoproductOfArrows CCab CCcd f = f i ;; ArbitraryCoproductIn CCcd i.
 Proof.
@@ -84,33 +84,27 @@ Proof.
   apply ArbitraryCoproductInCommutes.
 Qed.
 
-(* Definition mk_ArbitraryCoproductCocone (a b : C) : *)
-(*   ∀ (c : C) (f : a --> c) (g : b --> c), *)
-(*    isArbitraryCoproductCocone _ _ _ f g →  ArbitraryCoproductCocone a b. *)
-(* Proof. *)
-(*   intros. *)
-(*   simple refine (tpair _ _ _ ). *)
-(*   - exists c. *)
-(*     exists f. *)
-(*     exact g. *)
-(*   - apply X. *)
-(* Defined. *)
+Definition mk_ArbitraryCoproductCocone (a : I -> C) (c : C) (f : forall i, a i --> c) :
+   isArbitraryCoproductCocone _ _ f →  ArbitraryCoproductCocone a.
+Proof.
+intro H.
+mkpair.
+- apply (tpair _ c f).
+- apply H.
+Defined.
 
-(* Definition mk_isArbitraryCoproductCocone (hsC : has_homsets C)(a b co : C) (ia : a --> co) (ib : b --> co) : *)
-(*    (∀ (c : C) (f : a --> c) (g : b --> c), *)
-(*     ∃! k : C ⟦co, c⟧, *)
-(*       ia ;; k = f × *)
-(*       ib ;; k = g) *)
-(*    → *)
-(*    isArbitraryCoproductCocone a b co ia ib. *)
-(* Proof. *)
-(*   intros H c cc. *)
-(*   apply H. *)
-(* Defined. *)
+Definition mk_isArbitraryCoproductCocone (hsC : has_homsets C) (a : I -> C) (co : C)
+  (f : forall i, a i --> co) : (∀ (c : C) (g : forall i, a i --> c),
+                                  ∃! k : C ⟦co, c⟧, forall i, f i ;; k = g i)
+   →    isArbitraryCoproductCocone a co f.
+Proof.
+  intros H c cc.
+  apply H.
+Defined.
 
-Lemma precompWithArbitraryCoproductArrow {a : forall i, C} (CCab : ArbitraryCoproductCocone a) {c : forall i, C}
+Lemma precompWithArbitraryCoproductArrow {a : I -> C} (CCab : ArbitraryCoproductCocone a) {c : I -> C}
     (CCcd : ArbitraryCoproductCocone c) (f : forall i, a i --> c i)
-    {x : C} (k : forall i, c i--> x) :
+    {x : C} (k : forall i, c i --> x) :
         ArbitraryCoproductOfArrows CCab CCcd f ;; ArbitraryCoproductArrow CCcd k =
          ArbitraryCoproductArrow CCab (fun i => f i ;; k i).
 Proof.
@@ -118,7 +112,7 @@ apply ArbitraryCoproductArrowUnique; intro i.
 now rewrite assoc, ArbitraryCoproductOfArrowsIn, <- assoc, ArbitraryCoproductInCommutes.
 Qed.
 
-Lemma postcompWithArbitraryCoproductArrow {a : forall i, C} (CCab : ArbitraryCoproductCocone a) {c : C}
+Lemma postcompWithArbitraryCoproductArrow {a : I -> C} (CCab : ArbitraryCoproductCocone a) {c : C}
     (f : forall i, a i --> c) {x : C} (k : c --> x)  :
        ArbitraryCoproductArrow CCab f ;; k = ArbitraryCoproductArrow CCab (fun i => f i ;; k).
 Proof.
@@ -126,7 +120,7 @@ apply ArbitraryCoproductArrowUnique; intro i.
 now rewrite assoc, ArbitraryCoproductInCommutes.
 Qed.
 
-Lemma ArbitraryCoproduct_endo_is_identity (a : forall i, C) (CC : ArbitraryCoproductCocone a)
+Lemma ArbitraryCoproduct_endo_is_identity (a : I -> C) (CC : ArbitraryCoproductCocone a)
   (k : ArbitraryCoproductObject CC --> ArbitraryCoproductObject CC)
   (H1 : forall i, ArbitraryCoproductIn CC i ;; k = ArbitraryCoproductIn CC i)
   : identity _ = k.
@@ -152,7 +146,7 @@ Variables (I : UU) (C : precategory) (CC : ArbitraryCoproducts I C).
 (*   apply idpath. *)
 (* Qed. *)
 
-Definition ArbitraryCoproductOfArrows_comp (a b c : forall i, C)
+Definition ArbitraryCoproductOfArrows_comp (a b c : I -> C)
   (f : forall i, a i --> b i) (g : forall i, b i --> c i) :
    ArbitraryCoproductOfArrows _ _ _ _ f ;; ArbitraryCoproductOfArrows _ _ (CC _) (CC _) g
    = ArbitraryCoproductOfArrows _ _ (CC _) (CC _)(fun i => f i ;; g i).
@@ -200,7 +194,7 @@ End functors.
 
 (* Defines the arbitrary copropuct of a family of functors *)
 Definition arbitrary_coproduct_of_functors (I : UU) {C D : precategory}
-  (HD : ArbitraryCoproducts I D) (F : forall i, functor C D) : functor C D :=
+  (HD : ArbitraryCoproducts I D) (F : I -> functor C D) : functor C D :=
   functor_composite (arbitrary_delta_functor I C)
      (functor_composite (arbitrary_pair_functor _ F)
                         (arbitrary_indexed_coproduct_functor _ HD)).

--- a/UniMath/CategoryTheory/limits/arbitrary_coproducts.v
+++ b/UniMath/CategoryTheory/limits/arbitrary_coproducts.v
@@ -1,0 +1,205 @@
+(*
+
+Direct implementation of arbitrary coproducts.
+
+Written by: Anders Mörtberg 2016
+
+*)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.total2_paths.
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.ArbitraryProductPrecategory.
+
+(** * Definition of arbitrary coproducts of objects in a precategory *)
+Section coproduct_def.
+
+Variables (I : UU) (C : precategory).
+
+Definition isArbitraryCoproductCocone (a : forall (i : I), C) (co : C)
+  (ia : forall i, a i --> co) :=
+  forall (c : C) (f : forall i, a i --> c),
+    iscontr (total2 (fun (g : co --> c) => forall i, ia i ;; g = f i)).
+
+Definition ArbitraryCoproductCocone (a : forall i, C) :=
+   Σ coia : (Σ co : C, forall i, a i --> co),
+          isArbitraryCoproductCocone a (pr1 coia) (pr2 coia).
+
+Definition ArbitraryCoproducts := ∀ (a : forall i, C), ArbitraryCoproductCocone a.
+Definition hasArbitraryCoproducts := ishinh ArbitraryCoproducts.
+
+Definition ArbitraryCoproductObject {a : forall i, C} (CC : ArbitraryCoproductCocone a) : C := pr1 (pr1 CC).
+Definition ArbitraryCoproductIn {a : forall i, C} (CC : ArbitraryCoproductCocone a): forall i, a i--> ArbitraryCoproductObject CC :=
+  pr2 (pr1 CC).
+
+Definition isArbitraryCoproductCocone_ArbitraryCoproductCocone {a : forall i, C} (CC : ArbitraryCoproductCocone a) :
+   isArbitraryCoproductCocone a (ArbitraryCoproductObject CC) (ArbitraryCoproductIn CC).
+Proof.
+  exact (pr2 CC).
+Defined.
+
+Definition ArbitraryCoproductArrow {a : forall i, C} (CC : ArbitraryCoproductCocone a) {c : C} (f : forall i, a i --> c) :
+      ArbitraryCoproductObject CC --> c.
+Proof.
+  exact (pr1 (pr1 (isArbitraryCoproductCocone_ArbitraryCoproductCocone CC _ f))).
+Defined.
+
+Lemma ArbitraryCoproductInCommutes (a : forall i, C) (CC : ArbitraryCoproductCocone a) :
+     ∀ (c : C) (f : forall i, a i --> c) i, ArbitraryCoproductIn CC i ;; ArbitraryCoproductArrow CC f = f i.
+Proof.
+  intros c f i.
+  exact (pr2 (pr1 (isArbitraryCoproductCocone_ArbitraryCoproductCocone CC _ f)) i).
+Qed.
+
+Lemma ArbitraryCoproductArrowUnique (a : forall i, C) (CC : ArbitraryCoproductCocone a) (x : C)
+    (f : forall i, a i --> x) (k : ArbitraryCoproductObject CC --> x)
+    (Hk : forall i, ArbitraryCoproductIn CC i ;; k = f i) :
+  k = ArbitraryCoproductArrow CC f.
+Proof.
+  set (H' := pr2 (isArbitraryCoproductCocone_ArbitraryCoproductCocone CC _ f) (k,,Hk)).
+  apply (base_paths _ _ H').
+Qed.
+
+Lemma ArbitraryCoproductArrowEta (a : forall i, C) (CC : ArbitraryCoproductCocone a) (x : C)
+    (f : ArbitraryCoproductObject CC --> x) :
+    f = ArbitraryCoproductArrow CC (fun i => ArbitraryCoproductIn CC i ;; f).
+Proof.
+  now apply ArbitraryCoproductArrowUnique.
+Qed.
+
+
+Definition ArbitraryCoproductOfArrows {a : forall i, C} (CCab : ArbitraryCoproductCocone a) {c : forall i, C}
+    (CCcd : ArbitraryCoproductCocone c) (f : forall i, a i --> c i) :
+          ArbitraryCoproductObject CCab --> ArbitraryCoproductObject CCcd :=
+    ArbitraryCoproductArrow CCab (fun i => f i ;; ArbitraryCoproductIn CCcd i).
+
+Lemma ArbitraryCoproductOfArrowsIn {a : forall i, C} (CCab : ArbitraryCoproductCocone a) {c : forall i, C}
+    (CCcd : ArbitraryCoproductCocone c) (f : forall i, a i --> c i) :
+    forall i, ArbitraryCoproductIn CCab i ;; ArbitraryCoproductOfArrows CCab CCcd f = f i ;; ArbitraryCoproductIn CCcd i.
+Proof.
+  unfold ArbitraryCoproductOfArrows; intro i.
+  apply ArbitraryCoproductInCommutes.
+Qed.
+
+(* Definition mk_ArbitraryCoproductCocone (a b : C) : *)
+(*   ∀ (c : C) (f : a --> c) (g : b --> c), *)
+(*    isArbitraryCoproductCocone _ _ _ f g →  ArbitraryCoproductCocone a b. *)
+(* Proof. *)
+(*   intros. *)
+(*   simple refine (tpair _ _ _ ). *)
+(*   - exists c. *)
+(*     exists f. *)
+(*     exact g. *)
+(*   - apply X. *)
+(* Defined. *)
+
+(* Definition mk_isArbitraryCoproductCocone (hsC : has_homsets C)(a b co : C) (ia : a --> co) (ib : b --> co) : *)
+(*    (∀ (c : C) (f : a --> c) (g : b --> c), *)
+(*     ∃! k : C ⟦co, c⟧, *)
+(*       ia ;; k = f × *)
+(*       ib ;; k = g) *)
+(*    → *)
+(*    isArbitraryCoproductCocone a b co ia ib. *)
+(* Proof. *)
+(*   intros H c cc. *)
+(*   apply H. *)
+(* Defined. *)
+
+Lemma precompWithArbitraryCoproductArrow {a : forall i, C} (CCab : ArbitraryCoproductCocone a) {c : forall i, C}
+    (CCcd : ArbitraryCoproductCocone c) (f : forall i, a i --> c i)
+    {x : C} (k : forall i, c i--> x) :
+        ArbitraryCoproductOfArrows CCab CCcd f ;; ArbitraryCoproductArrow CCcd k =
+         ArbitraryCoproductArrow CCab (fun i => f i ;; k i).
+Proof.
+apply ArbitraryCoproductArrowUnique; intro i.
+now rewrite assoc, ArbitraryCoproductOfArrowsIn, <- assoc, ArbitraryCoproductInCommutes.
+Qed.
+
+Lemma postcompWithArbitraryCoproductArrow {a : forall i, C} (CCab : ArbitraryCoproductCocone a) {c : C}
+    (f : forall i, a i --> c) {x : C} (k : c --> x)  :
+       ArbitraryCoproductArrow CCab f ;; k = ArbitraryCoproductArrow CCab (fun i => f i ;; k).
+Proof.
+apply ArbitraryCoproductArrowUnique; intro i.
+now rewrite assoc, ArbitraryCoproductInCommutes.
+Qed.
+
+Lemma ArbitraryCoproduct_endo_is_identity (a : forall i, C) (CC : ArbitraryCoproductCocone a)
+  (k : ArbitraryCoproductObject CC --> ArbitraryCoproductObject CC)
+  (H1 : forall i, ArbitraryCoproductIn CC i ;; k = ArbitraryCoproductIn CC i)
+  : identity _ = k.
+Proof.
+apply pathsinv0.
+eapply pathscomp0; [apply ArbitraryCoproductArrowEta|].
+apply pathsinv0, ArbitraryCoproductArrowUnique; intro i; apply pathsinv0.
+now rewrite id_right, H1.
+Defined.
+
+End coproduct_def.
+
+Section Coproducts.
+
+Variables (I : UU) (C : precategory) (CC : ArbitraryCoproducts I C).
+
+(* Lemma ArbitraryCoproductArrow_eq (f f' : a --> c) (g g' : b --> c) *)
+(*   : f = f' → g = g' → *)
+(*       ArbitraryCoproductArrow _ (CC _ _) f g = ArbitraryCoproductArrow _ _ f' g'. *)
+(* Proof. *)
+(*   induction 1. *)
+(*   induction 1. *)
+(*   apply idpath. *)
+(* Qed. *)
+
+Definition ArbitraryCoproductOfArrows_comp (a b c : forall i, C)
+  (f : forall i, a i --> b i) (g : forall i, b i --> c i) :
+   ArbitraryCoproductOfArrows _ _ _ _ f ;; ArbitraryCoproductOfArrows _ _ (CC _) (CC _) g
+   = ArbitraryCoproductOfArrows _ _ (CC _) (CC _)(fun i => f i ;; g i).
+Proof.
+apply ArbitraryCoproductArrowUnique; intro i.
+rewrite assoc, ArbitraryCoproductOfArrowsIn.
+now rewrite <- assoc, ArbitraryCoproductOfArrowsIn, assoc.
+Qed.
+
+(* Definition ArbitraryCoproductOfArrows_eq (f f' : a --> c) (g g' : b --> d) *)
+(*   : f = f' → g = g' → *)
+(*       ArbitraryCoproductOfArrows _ _ _ f g = ArbitraryCoproductOfArrows _ (CC _ _) (CC _ _) f' g'. *)
+(* Proof. *)
+(*   induction 1. *)
+(*   induction 1. *)
+(*   apply idpath. *)
+(* Qed. *)
+
+End Coproducts.
+
+Section functors.
+
+Definition arbitrary_coproduct_functor_data (I : UU) {C : precategory}
+  (PC : ArbitraryCoproducts I C) : functor_data (arbitrary_product_precategory I C) C.
+Proof.
+mkpair.
+- intros p.
+  apply (ArbitraryCoproductObject _ _ (PC p)).
+- simpl; intros p q f.
+  apply (ArbitraryCoproductOfArrows _ _ _ _ f).
+Defined.
+
+(* The arbitrary coproduct functor: C^I -> C *)
+Definition arbitrary_coproduct_functor (I : UU) {C : precategory}
+  (PC : ArbitraryCoproducts I C) : functor (arbitrary_product_precategory I C) C.
+Proof.
+apply (tpair _ (arbitrary_coproduct_functor_data _ PC)).
+split.
+  - intro x; simpl; apply pathsinv0, ArbitraryCoproduct_endo_is_identity.
+    now intro i; rewrite ArbitraryCoproductOfArrowsIn, id_left.
+  - now intros x y z f g; simpl; rewrite ArbitraryCoproductOfArrows_comp .
+Defined.
+
+End functors.
+
+(* Defines the arbitrary copropuct of a family of functors *)
+Definition arbitrary_coproduct_of_functors (I : UU) {C D : precategory}
+  (HD : ArbitraryCoproducts I D) (F : forall i, functor C D) : functor C D :=
+  functor_composite (arbitrary_delta_functor I C)
+     (functor_composite (arbitrary_pair_functor _ F) (arbitrary_coproduct_functor _ HD)).

--- a/UniMath/CategoryTheory/limits/arbitrary_products.v
+++ b/UniMath/CategoryTheory/limits/arbitrary_products.v
@@ -17,8 +17,8 @@ Variable (I : UU) (C : precategory).
 
 Definition isArbitraryProductCone (c : forall (i : I), C) (p : C)
   (pi : forall i, p --> c i) :=
-  forall (a : forall i, C) (f : forall i, a i --> c i),
-    iscontr (total2 (fun (faip : forall i, a i --> p) => forall i, faip i ;; pi i = f i)).
+  forall (a : C) (f : forall i, a --> c i),
+    iscontr (total2 (fun (faip : a --> p) => forall i, faip ;; pi i = f i)).
 
 Definition ArbitraryProductCone (ci : forall i, C) :=
    total2 (fun pp1p2 : total2 (fun p : C => forall i, p --> ci i) =>
@@ -39,14 +39,14 @@ Proof.
   exact (pr2 P).
 Defined.
 
-Definition ArbitraryProductArrow {c : forall i, C} (P : ArbitraryProductCone c) {a : forall i, C} (f : forall i, a i --> c i)
-  : forall i, a i --> ArbitraryProductObject P.
+Definition ArbitraryProductArrow {c : forall i, C} (P : ArbitraryProductCone c) {a : C} (f : forall i, a --> c i)
+  : a --> ArbitraryProductObject P.
 Proof.
-  exact (pr1 (pr1 (isArbitraryProductCone_ArbitraryProductCone P _ f))).
+  apply (pr1 (pr1 (isArbitraryProductCone_ArbitraryProductCone P _ f))).
 Defined.
 
 Lemma ArbitraryProductPrCommutes (c : forall i, C) (P : ArbitraryProductCone c) :
-     forall (a : forall i, C) (f : forall i, a i --> c i), forall i, ArbitraryProductArrow P f i ;; ArbitraryProductPr P i = f i.
+     forall (a : C) (f : forall i, a --> c i), forall i, ArbitraryProductArrow P f ;; ArbitraryProductPr P i = f i.
 Proof.
   intros a f i.
   apply (pr2 (pr1 (isArbitraryProductCone_ArbitraryProductCone P _ f)) i).
@@ -59,9 +59,9 @@ Qed.
 (*   exact (pr2 (pr2 (pr1 (isProductCone_ProductCone P _ f g)))). *)
 (* Qed. *)
 
-Lemma ArbitraryProductArrowUnique (c : forall i, C) (P : ArbitraryProductCone c) (x : forall i, C)
-    (f : forall i, x i --> c i) (k : forall i, x i --> ArbitraryProductObject P)
-    (Hk : forall i, k i ;; ArbitraryProductPr P i = f i) : k = ArbitraryProductArrow P f.
+Lemma ArbitraryProductArrowUnique (c : forall i, C) (P : ArbitraryProductCone c) (x : C)
+    (f : forall i, x --> c i) (k : x --> ArbitraryProductObject P)
+    (Hk : forall i, k ;; ArbitraryProductPr P i = f i) : k = ArbitraryProductArrow P f.
 Proof.
   set (H' := pr2 (isArbitraryProductCone_ArbitraryProductCone P _ f) (k,,Hk)).
   apply (base_paths _ _ H').
@@ -84,22 +84,21 @@ Defined.
 (*   apply H. *)
 (* Defined. *)
 
-Lemma ArbitraryProductArrowEta (c : forall i, C) (P : ArbitraryProductCone c) (x : forall i, C)
-    (f : forall i, x i --> ArbitraryProductObject P) :
-    f = ArbitraryProductArrow P (fun i => f i ;; ArbitraryProductPr P i).
+Lemma ArbitraryProductArrowEta (c : forall i, C) (P : ArbitraryProductCone c) (x : C)
+    (f : x --> ArbitraryProductObject P) :
+    f = ArbitraryProductArrow P (fun i => f ;; ArbitraryProductPr P i).
 Proof.
   now apply ArbitraryProductArrowUnique; intro i.
 Qed.
 
-
 Definition ArbitraryProductOfArrows {c : forall i, C} (Pcd : ArbitraryProductCone c) {a : forall i, C}
     (Pab : ArbitraryProductCone a) (f : forall i, a i --> c i) :
-      forall (i : I), ArbitraryProductObject Pab --> ArbitraryProductObject Pcd :=
+      ArbitraryProductObject Pab --> ArbitraryProductObject Pcd :=
     ArbitraryProductArrow Pcd (fun i => ArbitraryProductPr Pab i ;; f i).
 
 Lemma ArbitraryProductOfArrowsPr {c : forall i, C} (Pcd : ArbitraryProductCone c) {a : forall i, C}
     (Pab : ArbitraryProductCone a) (f : forall i, a i --> c i) :
-    forall i, ArbitraryProductOfArrows Pcd Pab f i ;; ArbitraryProductPr Pcd i = ArbitraryProductPr Pab i ;; f i.
+    forall i, ArbitraryProductOfArrows Pcd Pab f ;; ArbitraryProductPr Pcd i = ArbitraryProductPr Pab i ;; f i.
 Proof.
   unfold ArbitraryProductOfArrows; intro i.
   now rewrite (ArbitraryProductPrCommutes _ _ _ _ i).
@@ -133,32 +132,19 @@ Qed.
 
 End product_def.
 
-(* Section Products. *)
+Section Products.
 
-(* Variable C : precategory. *)
-(* Variable CC : Products C. *)
-(* Variables a b c d x y : C. *)
+Variables (I : UU) (C : precategory) (CC : ArbitraryProducts I C).
 
-(* Definition ProductOfArrows_comp (f : a --> c) (f' : b --> d) (g : c --> x) (g' : d --> y) *)
-(*   : ProductOfArrows _ (CC c d) (CC a b) f f' ;; *)
-(*     ProductOfArrows _ (CC _ _) (CC _ _) g g' *)
-(*     = *)
-(*     ProductOfArrows _ (CC _ _) (CC _ _)(f ;; g) (f' ;; g'). *)
-(* Proof. *)
-(*   apply ProductArrowUnique. *)
-(*   - rewrite <- assoc. *)
-(*     rewrite ProductOfArrowsPr1. *)
-(*     rewrite assoc. *)
-(*     rewrite ProductOfArrowsPr1. *)
-(*     apply pathsinv0. *)
-(*     apply assoc. *)
-(*   - rewrite <- assoc. *)
-(*     rewrite ProductOfArrowsPr2. *)
-(*     rewrite assoc. *)
-(*     rewrite ProductOfArrowsPr2. *)
-(*     apply pathsinv0. *)
-(*     apply assoc. *)
-(* Qed. *)
+Definition ProductOfArrows_comp (a b c : forall (i : I), C)
+  (f : forall i, a i --> b i) (g : forall i, b i --> c i)
+  : ArbitraryProductOfArrows _ _ _ _ f ;; ArbitraryProductOfArrows _ _ _ (CC _) g
+    = ArbitraryProductOfArrows _ _ (CC _) (CC _) (fun i => f i ;; g i).
+Proof.
+apply ArbitraryProductArrowUnique; intro i.
+rewrite <- assoc, ArbitraryProductOfArrowsPr.
+now rewrite assoc, ArbitraryProductOfArrowsPr, assoc.
+Qed.
 
 (* Definition ProductOfArrows_eq (f f' : a --> c) (g g' : b --> d) *)
 (*   : f = f' → g = g' → *)
@@ -169,69 +155,57 @@ End product_def.
 (*   apply idpath. *)
 (* Qed. *)
 
-(* End Products. *)
+End Products.
 
-(* Section Product_unique. *)
+Section Product_unique.
 
-(* Variables (I : UU) (C : precategory). *)
-(* Variable CC : ArbitraryProducts I C. *)
-(* Variables a : forall (i : I), C. *)
+Variables (I : UU) (C : precategory).
+Variable CC : ArbitraryProducts I C.
+Variables a : forall (i : I), C.
 
-(* Lemma ArbitraryProduct_endo_is_identity (P : ArbitraryProductCone _ _ a) *)
-(*   (k : ArbitraryProductObject _ _ P --> ArbitraryProductObject _ _ P) *)
-(*   (H1 : forall i, k ;; ArbitraryProductPr _ _ P i = ArbitraryProductPr _ _ P i) *)
-(*   : identity _ = k. *)
-(* Proof. *)
-(*   apply pathsinv0. *)
-(*   eapply pathscomp0. *)
-(*   apply ArbitraryProductArrowEta. *)
-(*   apply pathsinv0. *)
-(*   apply ProductArrowUnique; apply pathsinv0. *)
-(*   + rewrite id_left. exact H1. *)
-(*   + rewrite id_left. exact H2. *)
-(* Qed. *)
+Lemma ArbitraryProduct_endo_is_identity (P : ArbitraryProductCone _ _ a)
+  (k : ArbitraryProductObject _ _ P --> ArbitraryProductObject _ _ P)
+  (H1 : forall i, k ;; ArbitraryProductPr _ _ P i = ArbitraryProductPr _ _ P i)
+  : identity _ = k.
+Proof.
+  apply pathsinv0.
+  eapply pathscomp0.
+  apply ArbitraryProductArrowEta.
+  apply pathsinv0.
+  apply ArbitraryProductArrowUnique; intro i; apply pathsinv0.
+  now rewrite id_left, H1.
+Qed.
 
-(* End Product_unique. *)
+End Product_unique.
 
 (* The arbitrary product functor: C^I -> C *)
-Section abitrary_product_functor.
+Section arbitrary_product_functor.
 
 Context (I : UU) {C : precategory} (PC : ArbitraryProducts I C).
 
-Definition arbitrary_product_functor_data (i : I) :
+Definition arbitrary_product_functor_data :
   functor_data (arbitrary_product_precategory I C) C.
 Proof.
 mkpair.
 - intros p.
   apply (ArbitraryProductObject _ _ (PC p)).
 - simpl; intros p q f.
-  simple refine (ArbitraryProductOfArrows _ _ _ _ _ _).
-  apply f.
-  apply i.
-  (* apply (ArbitraryProductOfArrows _ (PC (pr1 q) (pr2 q)) *)
-  (*                          (PC (pr1 p) (pr2 p)) (pr1 f) (pr2 f)). *)
+  exact (ArbitraryProductOfArrows _ _ _ _ f).
 Defined.
 
-Definition arbitrary_product_functor (i : I) : functor (arbitrary_product_precategory I C) C.
+Definition arbitrary_product_functor : functor (arbitrary_product_precategory I C) C.
 Proof.
-apply (tpair _ (arbitrary_product_functor_data i)).
-split.
-intro x; simpl.
-  [ intro x; simpl; apply pathsinv0, Product_endo_is_identity;
-    [ now rewrite ProductOfArrowsPr1, id_right
-    | now rewrite ProductOfArrowsPr2, id_right ]
+apply (tpair _ arbitrary_product_functor_data).
+abstract (split;
+  [ now intro x; simpl; apply pathsinv0, ArbitraryProduct_endo_is_identity;
+        intro i; rewrite ArbitraryProductOfArrowsPr, id_right
   | now intros x y z f g; simpl; rewrite ProductOfArrows_comp]).
 Defined.
 
-End binproduct_functor.
+End arbitrary_product_functor.
 
-(* Defines the product of two functors by:
-    x -> (x,x) -> (F x,G x) -> F x * G x
-
-  For a direct definition see FunctorsPointwiseProduct.v
-
-*)
-Definition product_of_functors {C D : precategory} (HD : Products D)
-  (F G : functor C D) : functor C D :=
-  functor_composite (delta_functor C)
-     (functor_composite (pair_functor F G) (binproduct_functor HD)).
+(* The product of a family of functors *)
+Definition arbitrary_product_of_functors (I : UU) {C D : precategory} (HD : ArbitraryProducts I D)
+  (F : forall (i : I), functor C D) : functor C D :=
+   functor_composite (arbitrary_delta_functor I C)
+     (functor_composite (arbitrary_pair_functor _ F) (arbitrary_product_functor _ HD)).

--- a/UniMath/CategoryTheory/limits/arbitrary_products.v
+++ b/UniMath/CategoryTheory/limits/arbitrary_products.v
@@ -70,15 +70,13 @@ Proof.
   simple refine (tpair _ (c,,f) X).
 Defined.
 
-(* Definition mk_isProductCone (hsC : has_homsets C) (a b p : C) *)
-(*   (pa : C⟦p,a⟧) (pb : C⟦p,b⟧) : *)
-(*   (∀ (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧), *)
-(*     ∃! k : C⟦c,p⟧, k ;; pa = f × k ;; pb = g) -> *)
-(*   isProductCone a b p pa pb. *)
-(* Proof. *)
-(*   intros H c cc g. *)
-(*   apply H. *)
-(* Defined. *)
+Definition mk_isArbitraryProductCone (hsC : has_homsets C) (a : I -> C) (p : C)
+  (pa : forall i, C⟦p,a i⟧) : (∀ (c : C) (f : forall i, C⟦c,a i⟧),
+                                  ∃! k : C⟦c,p⟧, forall i, k ;; pa i = f i) ->
+                              isArbitraryProductCone a p pa.
+Proof.
+intros H c cc; apply H.
+Defined.
 
 Lemma ArbitraryProductArrowEta (c : forall i, C) (P : ArbitraryProductCone c) (x : C)
     (f : x --> ArbitraryProductObject P) :

--- a/UniMath/CategoryTheory/limits/arbitrary_products.v
+++ b/UniMath/CategoryTheory/limits/arbitrary_products.v
@@ -84,13 +84,12 @@ Defined.
 (*   apply H. *)
 (* Defined. *)
 
-(* Lemma ProductArrowEta (c d : C) (P : ProductCone c d) (x : C) *)
-(*     (f : x --> ProductObject P) : *)
-(*     f = ProductArrow P (f ;; ProductPr1 P) (f ;; ProductPr2 P). *)
-(* Proof. *)
-(*   apply ProductArrowUnique; *)
-(*   apply idpath. *)
-(* Qed. *)
+Lemma ArbitraryProductArrowEta (c : forall i, C) (P : ArbitraryProductCone c) (x : forall i, C)
+    (f : forall i, x i --> ArbitraryProductObject P) :
+    f = ArbitraryProductArrow P (fun i => f i ;; ArbitraryProductPr P i).
+Proof.
+  now apply ArbitraryProductArrowUnique; intro i.
+Qed.
 
 
 Definition ArbitraryProductOfArrows {c : forall i, C} (Pcd : ArbitraryProductCone c) {a : forall i, C}
@@ -174,19 +173,18 @@ End product_def.
 
 (* Section Product_unique. *)
 
-(* Variable C : precategory. *)
-(* Variable CC : Products C. *)
-(* Variables a b : C. *)
+(* Variables (I : UU) (C : precategory). *)
+(* Variable CC : ArbitraryProducts I C. *)
+(* Variables a : forall (i : I), C. *)
 
-(* Lemma Product_endo_is_identity (P : ProductCone _ a b) *)
-(*   (k : ProductObject _ P --> ProductObject _ P) *)
-(*   (H1 : k ;; ProductPr1 _ P = ProductPr1 _ P) *)
-(*   (H2 : k ;; ProductPr2 _ P = ProductPr2 _ P) *)
+(* Lemma ArbitraryProduct_endo_is_identity (P : ArbitraryProductCone _ _ a) *)
+(*   (k : ArbitraryProductObject _ _ P --> ArbitraryProductObject _ _ P) *)
+(*   (H1 : forall i, k ;; ArbitraryProductPr _ _ P i = ArbitraryProductPr _ _ P i) *)
 (*   : identity _ = k. *)
 (* Proof. *)
 (*   apply pathsinv0. *)
 (*   eapply pathscomp0. *)
-(*   apply ProductArrowEta. *)
+(*   apply ArbitraryProductArrowEta. *)
 (*   apply pathsinv0. *)
 (*   apply ProductArrowUnique; apply pathsinv0. *)
 (*   + rewrite id_left. exact H1. *)

--- a/UniMath/CategoryTheory/limits/arbitrary_products.v
+++ b/UniMath/CategoryTheory/limits/arbitrary_products.v
@@ -1,4 +1,10 @@
-(* Direct implementation of products *)
+(*
+
+Direct implementation of arbitrary products.
+
+Written by: Anders Mörtberg 2016
+
+*)
 Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.Foundations.Basics.Propositions.
 Require Import UniMath.Foundations.Basics.Sets.
@@ -17,7 +23,7 @@ Variable (I : UU) (C : precategory).
 Definition isArbitraryProductCone (c : forall (i : I), C) (p : C)
   (pi : forall i, p --> c i) :=
   forall (a : C) (f : forall i, a --> c i),
-    iscontr (total2 (fun (faip : a --> p) => forall i, faip ;; pi i = f i)).
+    iscontr (total2 (fun (fap : a --> p) => forall i, fap ;; pi i = f i)).
 
 Definition ArbitraryProductCone (ci : forall i, C) :=
    total2 (fun pp1p2 : total2 (fun p : C => forall i, p --> ci i) =>
@@ -43,7 +49,7 @@ Proof.
 Defined.
 
 Lemma ArbitraryProductPrCommutes (c : forall i, C) (P : ArbitraryProductCone c) :
-     forall (a : C) (f : forall i, a --> c i), forall i, ArbitraryProductArrow P f ;; ArbitraryProductPr P i = f i.
+     forall (a : C) (f : forall i, a --> c i) i, ArbitraryProductArrow P f ;; ArbitraryProductPr P i = f i.
 Proof.
   intros a f i.
   apply (pr2 (pr1 (isArbitraryProductCone_ArbitraryProductCone P _ f)) i).
@@ -78,7 +84,7 @@ Lemma ArbitraryProductArrowEta (c : forall i, C) (P : ArbitraryProductCone c) (x
     (f : x --> ArbitraryProductObject P) :
     f = ArbitraryProductArrow P (fun i => f ;; ArbitraryProductPr P i).
 Proof.
-  now apply ArbitraryProductArrowUnique; intro i.
+  now apply ArbitraryProductArrowUnique.
 Qed.
 
 Definition ArbitraryProductOfArrows {c : forall i, C} (Pc : ArbitraryProductCone c) {a : forall i, C}

--- a/UniMath/CategoryTheory/limits/arbitrary_products.v
+++ b/UniMath/CategoryTheory/limits/arbitrary_products.v
@@ -7,7 +7,6 @@ Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.ArbitraryProductPrecategory.
-(* Require Import UniMath.CategoryTheory.ProductPrecategory. *)
 
 Local Notation "a --> b" := (precategory_morphisms a b)(at level 50).
 
@@ -30,8 +29,6 @@ Definition hasArbitraryProducts := ishinh ArbitraryProducts.
 Definition ArbitraryProductObject {c : forall i, C} (P : ArbitraryProductCone c) : C := pr1 (pr1 P).
 Definition ArbitraryProductPr {c : forall i, C} (P : ArbitraryProductCone c) : forall i, ArbitraryProductObject P --> c i :=
   pr2 (pr1 P).
-(* Definition ProductPr2 {c d : C} (P : ProductCone c d) : ProductObject P --> d := *)
-(*    pr2 (pr2 (pr1 P)). *)
 
 Definition isArbitraryProductCone_ArbitraryProductCone {c : forall i, C} (P : ArbitraryProductCone c) :
    isArbitraryProductCone c (ArbitraryProductObject P) (ArbitraryProductPr P).
@@ -51,13 +48,6 @@ Proof.
   intros a f i.
   apply (pr2 (pr1 (isArbitraryProductCone_ArbitraryProductCone P _ f)) i).
 Qed.
-
-(* Lemma ProductPr2Commutes (c d : C) (P : ProductCone c d): *)
-(*      forall (a : C) (f : a --> c) g, ProductArrow P f g ;; ProductPr2 P = g. *)
-(* Proof. *)
-(*   intros a f g. *)
-(*   exact (pr2 (pr2 (pr1 (isProductCone_ProductCone P _ f g)))). *)
-(* Qed. *)
 
 Lemma ArbitraryProductArrowUnique (c : forall i, C) (P : ArbitraryProductCone c) (x : C)
     (f : forall i, x --> c i) (k : x --> ArbitraryProductObject P)
@@ -91,44 +81,36 @@ Proof.
   now apply ArbitraryProductArrowUnique; intro i.
 Qed.
 
-Definition ArbitraryProductOfArrows {c : forall i, C} (Pcd : ArbitraryProductCone c) {a : forall i, C}
-    (Pab : ArbitraryProductCone a) (f : forall i, a i --> c i) :
-      ArbitraryProductObject Pab --> ArbitraryProductObject Pcd :=
-    ArbitraryProductArrow Pcd (fun i => ArbitraryProductPr Pab i ;; f i).
+Definition ArbitraryProductOfArrows {c : forall i, C} (Pc : ArbitraryProductCone c) {a : forall i, C}
+    (Pa : ArbitraryProductCone a) (f : forall i, a i --> c i) :
+      ArbitraryProductObject Pa --> ArbitraryProductObject Pc :=
+    ArbitraryProductArrow Pc (fun i => ArbitraryProductPr Pa i ;; f i).
 
-Lemma ArbitraryProductOfArrowsPr {c : forall i, C} (Pcd : ArbitraryProductCone c) {a : forall i, C}
-    (Pab : ArbitraryProductCone a) (f : forall i, a i --> c i) :
-    forall i, ArbitraryProductOfArrows Pcd Pab f ;; ArbitraryProductPr Pcd i = ArbitraryProductPr Pab i ;; f i.
+Lemma ArbitraryProductOfArrowsPr {c : forall i, C} (Pc : ArbitraryProductCone c) {a : forall i, C}
+    (Pa : ArbitraryProductCone a) (f : forall i, a i --> c i) :
+    forall i, ArbitraryProductOfArrows Pc Pa f ;; ArbitraryProductPr Pc i = ArbitraryProductPr Pa i ;; f i.
 Proof.
   unfold ArbitraryProductOfArrows; intro i.
   now rewrite (ArbitraryProductPrCommutes _ _ _ _ i).
 Qed.
 
-(* Lemma postcompWithProductArrow {c d : C} (Pcd : ProductCone c d) {a b : C} *)
-(*     (Pab : ProductCone a b) (f : a --> c) (g : b --> d) *)
-(*     {x : C} (k : x --> a) (h : x --> b) : *)
-(*         ProductArrow Pab k h ;; ProductOfArrows Pcd Pab f g = *)
-(*          ProductArrow Pcd (k ;; f) (h ;; g). *)
-(* Proof. *)
-(*   apply ProductArrowUnique. *)
-(*   - rewrite <- assoc, ProductOfArrowsPr1. *)
-(*     rewrite assoc, ProductPr1Commutes. *)
-(*     apply idpath. *)
-(*   - rewrite <- assoc, ProductOfArrowsPr2. *)
-(*     rewrite assoc, ProductPr2Commutes. *)
-(*     apply idpath. *)
-(* Qed. *)
+Lemma postcompWithArbitraryProductArrow {c : forall i, C} (Pc : ArbitraryProductCone c) {a : forall i, C}
+    (Pa : ArbitraryProductCone a) (f : forall i, a i --> c i)
+    {x : C} (k : forall i, x --> a i) :
+        ArbitraryProductArrow Pa k ;; ArbitraryProductOfArrows Pc Pa f =
+        ArbitraryProductArrow Pc (fun i => k i ;; f i).
+Proof.
+apply ArbitraryProductArrowUnique; intro i.
+now rewrite <- assoc, ArbitraryProductOfArrowsPr, assoc, ArbitraryProductPrCommutes.
+Qed.
 
-(* Lemma precompWithProductArrow {c d : C} (Pcd : ProductCone c d) {a : C} *)
-(*     (f : a --> c) (g : a --> d) {x : C} (k : x --> a)  : *)
-(*        k ;; ProductArrow Pcd f g  = ProductArrow Pcd (k ;; f) (k ;; g). *)
-(* Proof. *)
-(*   apply ProductArrowUnique. *)
-(*   -  rewrite <- assoc, ProductPr1Commutes; *)
-(*      apply idpath. *)
-(*   -  rewrite <- assoc, ProductPr2Commutes; *)
-(*      apply idpath. *)
-(* Qed. *)
+Lemma precompWithArbitraryProductArrow {c : forall i, C} (Pc : ArbitraryProductCone c)
+  {a : C} (f : forall i, a --> c i) {x : C} (k : x --> a)  :
+       k ;; ArbitraryProductArrow Pc f = ArbitraryProductArrow Pc (fun i => k ;; f i).
+Proof.
+apply ArbitraryProductArrowUnique; intro i.
+now rewrite <- assoc, ArbitraryProductPrCommutes.
+Qed.
 
 End product_def.
 
@@ -136,7 +118,7 @@ Section Products.
 
 Variables (I : UU) (C : precategory) (CC : ArbitraryProducts I C).
 
-Definition ProductOfArrows_comp (a b c : forall (i : I), C)
+Definition ArbitraryProductOfArrows_comp (a b c : forall (i : I), C)
   (f : forall i, a i --> b i) (g : forall i, b i --> c i)
   : ArbitraryProductOfArrows _ _ _ _ f ;; ArbitraryProductOfArrows _ _ _ (CC _) g
     = ArbitraryProductOfArrows _ _ (CC _) (CC _) (fun i => f i ;; g i).
@@ -199,7 +181,7 @@ apply (tpair _ arbitrary_product_functor_data).
 abstract (split;
   [ now intro x; simpl; apply pathsinv0, ArbitraryProduct_endo_is_identity;
         intro i; rewrite ArbitraryProductOfArrowsPr, id_right
-  | now intros x y z f g; simpl; rewrite ProductOfArrows_comp]).
+  | now intros x y z f g; simpl; rewrite ArbitraryProductOfArrows_comp]).
 Defined.
 
 End arbitrary_product_functor.

--- a/UniMath/CategoryTheory/limits/arbitrary_products.v
+++ b/UniMath/CategoryTheory/limits/arbitrary_products.v
@@ -1,0 +1,239 @@
+(* Direct implementation of products *)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.total2_paths.
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.ArbitraryProductPrecategory.
+(* Require Import UniMath.CategoryTheory.ProductPrecategory. *)
+
+Local Notation "a --> b" := (precategory_morphisms a b)(at level 50).
+
+Section product_def.
+
+Variable (I : UU) (C : precategory).
+
+Definition isArbitraryProductCone (c : forall (i : I), C) (p : C)
+  (pi : forall i, p --> c i) :=
+  forall (a : forall i, C) (f : forall i, a i --> c i),
+    iscontr (total2 (fun (faip : forall i, a i --> p) => forall i, faip i ;; pi i = f i)).
+
+Definition ArbitraryProductCone (ci : forall i, C) :=
+   total2 (fun pp1p2 : total2 (fun p : C => forall i, p --> ci i) =>
+             isArbitraryProductCone ci (pr1 pp1p2) (pr2 pp1p2)).
+
+Definition ArbitraryProducts := forall (ci : forall i, C), ArbitraryProductCone ci.
+Definition hasArbitraryProducts := ishinh ArbitraryProducts.
+
+Definition ArbitraryProductObject {c : forall i, C} (P : ArbitraryProductCone c) : C := pr1 (pr1 P).
+Definition ArbitraryProductPr {c : forall i, C} (P : ArbitraryProductCone c) : forall i, ArbitraryProductObject P --> c i :=
+  pr2 (pr1 P).
+(* Definition ProductPr2 {c d : C} (P : ProductCone c d) : ProductObject P --> d := *)
+(*    pr2 (pr2 (pr1 P)). *)
+
+Definition isArbitraryProductCone_ArbitraryProductCone {c : forall i, C} (P : ArbitraryProductCone c) :
+   isArbitraryProductCone c (ArbitraryProductObject P) (ArbitraryProductPr P).
+Proof.
+  exact (pr2 P).
+Defined.
+
+Definition ArbitraryProductArrow {c : forall i, C} (P : ArbitraryProductCone c) {a : forall i, C} (f : forall i, a i --> c i)
+  : forall i, a i --> ArbitraryProductObject P.
+Proof.
+  exact (pr1 (pr1 (isArbitraryProductCone_ArbitraryProductCone P _ f))).
+Defined.
+
+Lemma ArbitraryProductPrCommutes (c : forall i, C) (P : ArbitraryProductCone c) :
+     forall (a : forall i, C) (f : forall i, a i --> c i), forall i, ArbitraryProductArrow P f i ;; ArbitraryProductPr P i = f i.
+Proof.
+  intros a f i.
+  apply (pr2 (pr1 (isArbitraryProductCone_ArbitraryProductCone P _ f)) i).
+Qed.
+
+(* Lemma ProductPr2Commutes (c d : C) (P : ProductCone c d): *)
+(*      forall (a : C) (f : a --> c) g, ProductArrow P f g ;; ProductPr2 P = g. *)
+(* Proof. *)
+(*   intros a f g. *)
+(*   exact (pr2 (pr2 (pr1 (isProductCone_ProductCone P _ f g)))). *)
+(* Qed. *)
+
+Lemma ArbitraryProductArrowUnique (c : forall i, C) (P : ArbitraryProductCone c) (x : forall i, C)
+    (f : forall i, x i --> c i) (k : forall i, x i --> ArbitraryProductObject P)
+    (Hk : forall i, k i ;; ArbitraryProductPr P i = f i) : k = ArbitraryProductArrow P f.
+Proof.
+  set (H' := pr2 (isArbitraryProductCone_ArbitraryProductCone P _ f) (k,,Hk)).
+  apply (base_paths _ _ H').
+Qed.
+
+Definition mk_ArbitraryProductCone (a : forall i, C) :
+  ∀ (c : C) (f : forall i, C⟦c,a i⟧), isArbitraryProductCone _ _ f -> ArbitraryProductCone a.
+Proof.
+  intros c f X.
+  simple refine (tpair _ (c,,f) X).
+Defined.
+
+(* Definition mk_isProductCone (hsC : has_homsets C) (a b p : C) *)
+(*   (pa : C⟦p,a⟧) (pb : C⟦p,b⟧) : *)
+(*   (∀ (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧), *)
+(*     ∃! k : C⟦c,p⟧, k ;; pa = f × k ;; pb = g) -> *)
+(*   isProductCone a b p pa pb. *)
+(* Proof. *)
+(*   intros H c cc g. *)
+(*   apply H. *)
+(* Defined. *)
+
+(* Lemma ProductArrowEta (c d : C) (P : ProductCone c d) (x : C) *)
+(*     (f : x --> ProductObject P) : *)
+(*     f = ProductArrow P (f ;; ProductPr1 P) (f ;; ProductPr2 P). *)
+(* Proof. *)
+(*   apply ProductArrowUnique; *)
+(*   apply idpath. *)
+(* Qed. *)
+
+
+Definition ArbitraryProductOfArrows {c : forall i, C} (Pcd : ArbitraryProductCone c) {a : forall i, C}
+    (Pab : ArbitraryProductCone a) (f : forall i, a i --> c i) :
+      forall (i : I), ArbitraryProductObject Pab --> ArbitraryProductObject Pcd :=
+    ArbitraryProductArrow Pcd (fun i => ArbitraryProductPr Pab i ;; f i).
+
+Lemma ArbitraryProductOfArrowsPr {c : forall i, C} (Pcd : ArbitraryProductCone c) {a : forall i, C}
+    (Pab : ArbitraryProductCone a) (f : forall i, a i --> c i) :
+    forall i, ArbitraryProductOfArrows Pcd Pab f i ;; ArbitraryProductPr Pcd i = ArbitraryProductPr Pab i ;; f i.
+Proof.
+  unfold ArbitraryProductOfArrows; intro i.
+  now rewrite (ArbitraryProductPrCommutes _ _ _ _ i).
+Qed.
+
+(* Lemma postcompWithProductArrow {c d : C} (Pcd : ProductCone c d) {a b : C} *)
+(*     (Pab : ProductCone a b) (f : a --> c) (g : b --> d) *)
+(*     {x : C} (k : x --> a) (h : x --> b) : *)
+(*         ProductArrow Pab k h ;; ProductOfArrows Pcd Pab f g = *)
+(*          ProductArrow Pcd (k ;; f) (h ;; g). *)
+(* Proof. *)
+(*   apply ProductArrowUnique. *)
+(*   - rewrite <- assoc, ProductOfArrowsPr1. *)
+(*     rewrite assoc, ProductPr1Commutes. *)
+(*     apply idpath. *)
+(*   - rewrite <- assoc, ProductOfArrowsPr2. *)
+(*     rewrite assoc, ProductPr2Commutes. *)
+(*     apply idpath. *)
+(* Qed. *)
+
+(* Lemma precompWithProductArrow {c d : C} (Pcd : ProductCone c d) {a : C} *)
+(*     (f : a --> c) (g : a --> d) {x : C} (k : x --> a)  : *)
+(*        k ;; ProductArrow Pcd f g  = ProductArrow Pcd (k ;; f) (k ;; g). *)
+(* Proof. *)
+(*   apply ProductArrowUnique. *)
+(*   -  rewrite <- assoc, ProductPr1Commutes; *)
+(*      apply idpath. *)
+(*   -  rewrite <- assoc, ProductPr2Commutes; *)
+(*      apply idpath. *)
+(* Qed. *)
+
+End product_def.
+
+(* Section Products. *)
+
+(* Variable C : precategory. *)
+(* Variable CC : Products C. *)
+(* Variables a b c d x y : C. *)
+
+(* Definition ProductOfArrows_comp (f : a --> c) (f' : b --> d) (g : c --> x) (g' : d --> y) *)
+(*   : ProductOfArrows _ (CC c d) (CC a b) f f' ;; *)
+(*     ProductOfArrows _ (CC _ _) (CC _ _) g g' *)
+(*     = *)
+(*     ProductOfArrows _ (CC _ _) (CC _ _)(f ;; g) (f' ;; g'). *)
+(* Proof. *)
+(*   apply ProductArrowUnique. *)
+(*   - rewrite <- assoc. *)
+(*     rewrite ProductOfArrowsPr1. *)
+(*     rewrite assoc. *)
+(*     rewrite ProductOfArrowsPr1. *)
+(*     apply pathsinv0. *)
+(*     apply assoc. *)
+(*   - rewrite <- assoc. *)
+(*     rewrite ProductOfArrowsPr2. *)
+(*     rewrite assoc. *)
+(*     rewrite ProductOfArrowsPr2. *)
+(*     apply pathsinv0. *)
+(*     apply assoc. *)
+(* Qed. *)
+
+(* Definition ProductOfArrows_eq (f f' : a --> c) (g g' : b --> d) *)
+(*   : f = f' → g = g' → *)
+(*       ProductOfArrows _ _ _ f g = ProductOfArrows _ (CC _ _) (CC _ _) f' g'. *)
+(* Proof. *)
+(*   induction 1. *)
+(*   induction 1. *)
+(*   apply idpath. *)
+(* Qed. *)
+
+(* End Products. *)
+
+(* Section Product_unique. *)
+
+(* Variable C : precategory. *)
+(* Variable CC : Products C. *)
+(* Variables a b : C. *)
+
+(* Lemma Product_endo_is_identity (P : ProductCone _ a b) *)
+(*   (k : ProductObject _ P --> ProductObject _ P) *)
+(*   (H1 : k ;; ProductPr1 _ P = ProductPr1 _ P) *)
+(*   (H2 : k ;; ProductPr2 _ P = ProductPr2 _ P) *)
+(*   : identity _ = k. *)
+(* Proof. *)
+(*   apply pathsinv0. *)
+(*   eapply pathscomp0. *)
+(*   apply ProductArrowEta. *)
+(*   apply pathsinv0. *)
+(*   apply ProductArrowUnique; apply pathsinv0. *)
+(*   + rewrite id_left. exact H1. *)
+(*   + rewrite id_left. exact H2. *)
+(* Qed. *)
+
+(* End Product_unique. *)
+
+(* The arbitrary product functor: C^I -> C *)
+Section abitrary_product_functor.
+
+Context (I : UU) {C : precategory} (PC : ArbitraryProducts I C).
+
+Definition arbitrary_product_functor_data (i : I) :
+  functor_data (arbitrary_product_precategory I C) C.
+Proof.
+mkpair.
+- intros p.
+  apply (ArbitraryProductObject _ _ (PC p)).
+- simpl; intros p q f.
+  simple refine (ArbitraryProductOfArrows _ _ _ _ _ _).
+  apply f.
+  apply i.
+  (* apply (ArbitraryProductOfArrows _ (PC (pr1 q) (pr2 q)) *)
+  (*                          (PC (pr1 p) (pr2 p)) (pr1 f) (pr2 f)). *)
+Defined.
+
+Definition arbitrary_product_functor (i : I) : functor (arbitrary_product_precategory I C) C.
+Proof.
+apply (tpair _ (arbitrary_product_functor_data i)).
+split.
+intro x; simpl.
+  [ intro x; simpl; apply pathsinv0, Product_endo_is_identity;
+    [ now rewrite ProductOfArrowsPr1, id_right
+    | now rewrite ProductOfArrowsPr2, id_right ]
+  | now intros x y z f g; simpl; rewrite ProductOfArrows_comp]).
+Defined.
+
+End binproduct_functor.
+
+(* Defines the product of two functors by:
+    x -> (x,x) -> (F x,G x) -> F x * G x
+
+  For a direct definition see FunctorsPointwiseProduct.v
+
+*)
+Definition product_of_functors {C D : precategory} (HD : Products D)
+  (F G : functor C D) : functor C D :=
+  functor_composite (delta_functor C)
+     (functor_composite (pair_functor F G) (binproduct_functor HD)).

--- a/UniMath/SubstitutionSystems/.package/files
+++ b/UniMath/SubstitutionSystems/.package/files
@@ -2,6 +2,7 @@ SumOfSignatures.v
 ProductOfSignatures.v
 SubstitutionSystems.v
 Signatures.v
+SignatureExamples.v
 MonadsFromSubstitutionSystems.v
 LiftingInitial.v
 Lam.v

--- a/UniMath/SubstitutionSystems/.package/files
+++ b/UniMath/SubstitutionSystems/.package/files
@@ -15,3 +15,4 @@ LamHSET.v
 SigToMonad.v
 GenSigToMonad.v
 LamFromSig.v
+LamFromGenSig.v

--- a/UniMath/SubstitutionSystems/.package/files
+++ b/UniMath/SubstitutionSystems/.package/files
@@ -1,4 +1,5 @@
 SumOfSignatures.v
+ArbitrarySumOfSignatures.v
 ProductOfSignatures.v
 SubstitutionSystems.v
 Signatures.v
@@ -12,4 +13,5 @@ Notation.v
 SubstitutionSystems_Summary.v
 LamHSET.v
 SigToMonad.v
+GenSigToMonad.v
 LamFromSig.v

--- a/UniMath/SubstitutionSystems/ArbitrarySumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/ArbitrarySumOfSignatures.v
@@ -50,8 +50,6 @@ Variables (CC : ArbitraryCoproducts I C).
 
 Section construction.
 
-Check (ArbitraryCoproducts_functor_precat I C C CC hsC).
-
 Local Notation "'CCC'" := (ArbitraryCoproducts_functor_precat I C C CC hsC : ArbitraryCoproducts I [C, C, hsC]).
 
 Variables H1 : I -> functor [C, C, hsC] [C, C, hsC].

--- a/UniMath/SubstitutionSystems/ArbitrarySumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/ArbitrarySumOfSignatures.v
@@ -20,17 +20,17 @@ Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.whiskering.
-Require Import UniMath.CategoryTheory.limits.arbitrary_coproducts.
 Require Import UniMath.CategoryTheory.ProductPrecategory.
 Require Import UniMath.CategoryTheory.PointedFunctors.
 Require Import UniMath.CategoryTheory.PointedFunctorsComposition.
 Require Import UniMath.SubstitutionSystems.Signatures.
+Require Import UniMath.CategoryTheory.limits.arbitrary_coproducts.
 Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseArbitraryCoproduct.
 Require Import UniMath.SubstitutionSystems.Notation.
 Require Import UniMath.CategoryTheory.chains.
 Require Import UniMath.CategoryTheory.cocontfunctors.
 Require Import UniMath.CategoryTheory.limits.arbitrary_products.
-Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseProduct.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseArbitraryProduct.
 
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 Local Notation "F ⟶ G" := (nat_trans F G) (at level 39).
@@ -162,9 +162,9 @@ Lemma is_omega_cocont_ArbitrarySum_of_Signatures (S : I -> Signature C hsC)
   is_omega_cocont (ArbitrarySum_of_Signatures S).
 Proof.
 apply is_omega_cocont_arbitrary_coproduct_functor; try assumption.
-- admit.
+- apply (ArbitraryProducts_functor_precat _ _ _ PC).
 - apply functor_category_has_homsets.
 - apply functor_category_has_homsets.
-Admitted.
+Defined.
 
 End arbitrary_sum_of_signatures.

--- a/UniMath/SubstitutionSystems/ArbitrarySumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/ArbitrarySumOfSignatures.v
@@ -1,0 +1,170 @@
+(** **********************************************************
+
+Anders Mörtberg, 2016
+
+************************************************************)
+
+(** **********************************************************
+
+Contents :
+
+-  Definition of the sum of a family of signatures
+
+Adapted from the binary case
+
+************************************************************)
+
+Require Import UniMath.Foundations.Basics.PartD.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.limits.arbitrary_coproducts.
+Require Import UniMath.CategoryTheory.ProductPrecategory.
+Require Import UniMath.CategoryTheory.PointedFunctors.
+Require Import UniMath.CategoryTheory.PointedFunctorsComposition.
+Require Import UniMath.SubstitutionSystems.Signatures.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseArbitraryCoproduct.
+Require Import UniMath.SubstitutionSystems.Notation.
+Require Import UniMath.CategoryTheory.chains.
+Require Import UniMath.CategoryTheory.cocontfunctors.
+Require Import UniMath.CategoryTheory.limits.arbitrary_products.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseProduct.
+
+Local Notation "# F" := (functor_on_morphisms F)(at level 3).
+Local Notation "F ⟶ G" := (nat_trans F G) (at level 39).
+Local Notation "G □ F" := (functor_composite _ _ _ F G) (at level 35).
+
+Arguments θ_source {_ _} _ .
+Arguments θ_target {_ _} _ .
+Arguments θ_Strength1 {_ _ _} _ .
+Arguments θ_Strength2 {_ _ _} _ .
+Arguments θ_Strength1_int {_ _ _} _ .
+Arguments θ_Strength2_int {_ _ _} _ .
+
+Section arbitrary_sum_of_signatures.
+
+Variables (I : UU) (HI : isdeceq I) (C : precategory) (hsC : has_homsets C).
+Variables (CC : ArbitraryCoproducts I C).
+
+Section construction.
+
+Check (ArbitraryCoproducts_functor_precat I C C CC hsC).
+
+Local Notation "'CCC'" := (ArbitraryCoproducts_functor_precat I C C CC hsC : ArbitraryCoproducts I [C, C, hsC]).
+
+Variables H1 : I -> functor [C, C, hsC] [C, C, hsC].
+
+Variable θ1 : forall i, θ_source (H1 i) ⟶ θ_target (H1 i).
+
+(* Variable S11 : forall i, θ_Strength1 (θ1 i). *)
+(* Variable S12 : forall i, θ_Strength2 (θ1 i). *)
+
+(** * Definition of the data of the sum of two signatures *)
+
+Definition H : functor [C, C, hsC] [C, C, hsC] := arbitrary_coproduct_functor _ _ _ CCC H1.
+
+Local Definition bla1 (X : [C, C, hsC]) (Z : precategory_Ptd C hsC) (x : C) :
+   C ⟦ arbitrary_coproduct_functor_ob _ _ _ CC (λ i, H1 i X) (pr1 Z x),
+       arbitrary_coproduct_functor_ob _ _ _ CC (λ i, H1 i (functor_composite (pr1 Z) X)) x ⟧.
+Proof.
+apply ArbitraryCoproductOfArrows; intro i.
+exact (pr1 (θ1 i (X ⊗ Z)) x).
+Defined.
+
+Local Lemma bar (X : [C, C, hsC]) (Z : precategory_Ptd C hsC) :
+  is_nat_trans (functor_composite_data (pr1 Z)
+                 (arbitrary_coproduct_functor_data _ _ _  CC (λ i, H1 i X)))
+                 (arbitrary_coproduct_functor_data _ _ _ CC (λ i, H1 i (functor_composite (pr1 Z) X)))
+               (bla1 X Z).
+Proof.
+intros x x' f; simpl.
+unfold bla1; simpl.
+unfold arbitrary_coproduct_functor_mor.
+eapply pathscomp0; [ apply ArbitraryCoproductOfArrows_comp | ].
+eapply pathscomp0; [ | eapply pathsinv0; apply ArbitraryCoproductOfArrows_comp].
+apply ArbitraryCoproductOfArrows_eq.
+apply funextsec; intro i.
+apply (nat_trans_ax (θ1 i (X ⊗ Z))).
+Qed.
+
+Local Definition bla (X : [C, C, hsC]) (Z : precategory_Ptd C hsC) :
+   [C, C, hsC] ⟦ (θ_source H) (X,, Z), (θ_target H) (X,, Z) ⟧.
+Proof.
+exists (bla1 X Z); apply bar.
+Defined.
+
+Definition θ_ob : ∀ XF, θ_source H XF --> θ_target H XF.
+Proof.
+intros [X Z]; apply bla.
+Defined.
+
+Local Lemma is_nat_trans_θ_ob :
+  is_nat_trans (θ_source_functor_data C hsC H) (θ_target_functor_data C hsC H)  θ_ob.
+Proof.
+intros [X Z] [X' Z'] αβ.
+apply (nat_trans_eq hsC); intro c; simpl in *.
+eapply pathscomp0; [ | eapply pathsinv0, ArbitraryCoproductOfArrows_comp].
+eapply pathscomp0; [ apply cancel_postcomposition, ArbitraryCoproductOfArrows_comp |].
+eapply pathscomp0; [ apply ArbitraryCoproductOfArrows_comp |].
+apply ArbitraryCoproductOfArrows_eq; apply funextsec; intro i.
+apply (nat_trans_eq_pointwise (nat_trans_ax (θ1 i) (X,,Z) (X',,Z') αβ) c).
+Qed.
+
+Local Definition θ : θ_source H ⟶ θ_target H := tpair _ _ is_nat_trans_θ_ob.
+
+(** * Proof of the laws of the sum of two signatures *)
+
+Variable S11' : forall i, θ_Strength1_int (θ1 i).
+Variable S12' : forall i, θ_Strength2_int (θ1 i).
+
+Lemma SumStrength1' : θ_Strength1_int θ.
+Proof.
+intro X.
+apply (nat_trans_eq hsC); intro x; simpl.
+eapply pathscomp0; [apply ArbitraryCoproductOfArrows_comp|].
+apply pathsinv0, ArbitraryCoproduct_endo_is_identity; intro i.
+eapply pathscomp0.
+  apply (ArbitraryCoproductOfArrowsIn _ _ (CC (λ i, pr1 (pr1 (H1 i) X) x))).
+eapply pathscomp0; [ | apply id_left].
+apply cancel_postcomposition, (nat_trans_eq_pointwise (S11' i X) x).
+Qed.
+
+Lemma SumStrength2' : θ_Strength2_int θ.
+Proof.
+intros X Z Z'.
+apply (nat_trans_eq hsC); intro x; simpl.
+rewrite id_left.
+eapply pathscomp0; [apply ArbitraryCoproductOfArrows_comp|].
+apply pathsinv0.
+eapply pathscomp0; [apply ArbitraryCoproductOfArrows_comp|].
+apply pathsinv0, ArbitraryCoproductOfArrows_eq, funextsec; intro i.
+assert (Ha_x := nat_trans_eq_pointwise (S12' i X Z Z') x); simpl in Ha_x.
+rewrite id_left in Ha_x; apply Ha_x.
+Qed.
+
+End construction.
+
+Definition ArbitrarySum_of_Signatures (S : I -> Signature C hsC) : Signature C hsC.
+Proof.
+mkpair.
+- apply H; intro i.
+  apply (S i).
+- exists (θ (fun i => S i) (fun i => theta (S i))).
+  split.
+  + apply SumStrength1'; intro i; apply (Sig_strength_law1 _ _ (S i)).
+  + apply SumStrength2'; intro i; apply (Sig_strength_law2 _ _ (S i)).
+Defined.
+
+Lemma is_omega_cocont_ArbitrarySum_of_Signatures (S : I -> Signature C hsC)
+  (h : forall i, is_omega_cocont (S i)) (PC : ArbitraryProducts I C) :
+  is_omega_cocont (ArbitrarySum_of_Signatures S).
+Proof.
+apply is_omega_cocont_arbitrary_coproduct_functor; try assumption.
+- admit.
+- apply functor_category_has_homsets.
+- apply functor_category_has_homsets.
+Admitted.
+
+End arbitrary_sum_of_signatures.

--- a/UniMath/SubstitutionSystems/GenSigToMonad.v
+++ b/UniMath/SubstitutionSystems/GenSigToMonad.v
@@ -1,6 +1,11 @@
 (**
 
-From general signatures to monads
+From general signatures to monads. A general signature is a collection
+of lists of natural numbers indexed by a type I with decidable
+equality:
+
+Definition GenSig : UU := I -> list nat.
+
 
 Written by: Anders Mörtberg, 2016
 
@@ -61,7 +66,7 @@ Section GenSigToMonad.
 
 Variables (I : UU) (HI : isdeceq I).
 
-Definition GenSig : UU := forall (i : I), list nat.
+Definition GenSig : UU := I -> list nat.
 
 (* [[nat]] to Signature *)
 Definition GenSigToSignature : GenSig -> Signature HSET has_homsets_HSET.

--- a/UniMath/SubstitutionSystems/GenSigToMonad.v
+++ b/UniMath/SubstitutionSystems/GenSigToMonad.v
@@ -63,18 +63,12 @@ Variables (I : UU) (HI : isdeceq I).
 
 Definition GenSig : UU := forall (i : I), list nat.
 
-Local Lemma ArbitraryCoproducts_HSET : ArbitraryCoproducts I HSET.
-Admitted.
-
-Local Lemma ArbitraryProducts_HSET : ArbitraryProducts I HSET.
-Admitted.
-
 (* [[nat]] to Signature *)
 Definition GenSigToSignature : GenSig -> Signature HSET has_homsets_HSET.
 Proof.
 intro sig.
 eapply (ArbitrarySum_of_Signatures I).
-- apply ArbitraryCoproducts_HSET.
+- apply ArbitraryCoproducts_HSET, (isasetifdeceq _ HI).
 - intro i; apply (Arity_to_Signature (sig i)).
 Defined.
 

--- a/UniMath/SubstitutionSystems/GenSigToMonad.v
+++ b/UniMath/SubstitutionSystems/GenSigToMonad.v
@@ -1,0 +1,120 @@
+(**
+
+From general signatures to monads
+
+Written by: Anders Mörtberg, 2016
+
+*)
+
+Require Import UniMath.Foundations.Basics.PartD.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.limits.arbitrary_products.
+Require Import UniMath.CategoryTheory.limits.arbitrary_coproducts.
+Require Import UniMath.CategoryTheory.limits.terminal.
+Require Import UniMath.CategoryTheory.limits.initial.
+Require Import UniMath.CategoryTheory.FunctorAlgebras.
+Require Import UniMath.CategoryTheory.PointedFunctors.
+Require Import UniMath.CategoryTheory.ProductPrecategory.
+Require Import UniMath.SubstitutionSystems.Signatures.
+Require Import UniMath.SubstitutionSystems.SignatureExamples.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseCoproduct.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseProduct.
+Require Import UniMath.CategoryTheory.EndofunctorsMonoidal.
+Require Import UniMath.CategoryTheory.Monads.
+Require Import UniMath.SubstitutionSystems.ArbitrarySumOfSignatures.
+Require Import UniMath.SubstitutionSystems.ProductOfSignatures.
+Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
+Require Import UniMath.SubstitutionSystems.LamSignature.
+Require Import UniMath.SubstitutionSystems.Lam.
+Require Import UniMath.SubstitutionSystems.LiftingInitial.
+Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
+Require Import UniMath.SubstitutionSystems.Notation.
+Require Import UniMath.SubstitutionSystems.SigToMonad.
+
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.exponentials.
+Require Import UniMath.CategoryTheory.category_hset.
+Require Import UniMath.CategoryTheory.category_hset_structures.
+Require Import UniMath.CategoryTheory.chains.
+Require Import UniMath.CategoryTheory.cocontfunctors.
+Require Import UniMath.CategoryTheory.lists.
+Require Import UniMath.CategoryTheory.HorizontalComposition.
+
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
+Local Notation "'HSET2'":= ([HSET, HSET, has_homsets_HSET]) .
+
+(* Translation from a Sig to a monad by: *)
+(* S : SIG *)
+(* |-> *)
+(* functor(S) : functor [Set,Set] [Set,Set] *)
+(* |-> *)
+(* Initial (Id + functor(S)) *)
+(* |-> *)
+(* I:= Initial (HSS(func(S), \theta) *)
+(* |-> *)
+(* M := Monad_from_HSS(I)    # *)
+Section GenSigToMonad.
+
+Variables (I : UU) (HI : isdeceq I).
+
+Definition GenSig : UU := forall (i : I), list nat.
+
+Local Lemma ArbitraryCoproducts_HSET : ArbitraryCoproducts I HSET.
+Admitted.
+
+Local Lemma ArbitraryProducts_HSET : ArbitraryProducts I HSET.
+Admitted.
+
+(* [[nat]] to Signature *)
+Definition GenSigToSignature : GenSig -> Signature HSET has_homsets_HSET.
+Proof.
+intro sig.
+eapply (ArbitrarySum_of_Signatures I).
+- apply ArbitraryCoproducts_HSET.
+- intro i; apply (Arity_to_Signature (sig i)).
+Defined.
+
+Lemma is_omega_cocont_GenSigToSignature (s : GenSig) : is_omega_cocont (GenSigToSignature s).
+Proof.
+apply (is_omega_cocont_ArbitrarySum_of_Signatures _ HI).
+- intro i; apply is_omega_cocont_Arity_to_Signature.
+- apply ArbitraryProducts_HSET.
+Defined.
+
+Definition GenSigInitial (sig : GenSig) :
+  Initial (FunctorAlg (Id_H HSET has_homsets_HSET CoproductsHSET (GenSigToSignature sig)) has_homsets_HSET2).
+Proof.
+use colimAlgInitial.
+- unfold Id_H, Const_plus_H.
+  apply is_omega_cocont_coproduct_functor.
+  + apply (Products_functor_precat _ _ ProductsHSET).
+  + apply functor_category_has_homsets.
+  + apply functor_category_has_homsets.
+  + apply is_omega_cocont_constant_functor, functor_category_has_homsets.
+  + apply is_omega_cocont_GenSigToSignature.
+- apply (Initial_functor_precat _ _ InitialHSET).
+- apply ColimsFunctorCategory; apply ColimsHSET.
+Defined.
+
+Definition GenSigInitialHSS (sig : GenSig) :
+  Initial (hss_precategory CoproductsHSET (GenSigToSignature sig)).
+Proof.
+apply InitialHSS.
+- intro Z; apply RightKanExtension_from_limits, cats_LimsHSET.
+- apply GenSigInitial.
+Defined.
+
+Definition GenSigToMonad (sig : GenSig) : Monad HSET.
+Proof.
+use Monad_from_hss.
+- apply has_homsets_HSET.
+- apply CoproductsHSET.
+- apply (GenSigToSignature sig).
+- apply GenSigInitialHSS.
+Defined.
+
+End GenSigToMonad.

--- a/UniMath/SubstitutionSystems/LamFromGenSig.v
+++ b/UniMath/SubstitutionSystems/LamFromGenSig.v
@@ -18,26 +18,31 @@ Require Import UniMath.CategoryTheory.cocontfunctors.
 Require Import UniMath.CategoryTheory.lists.
 Require Import UniMath.CategoryTheory.limits.initial.
 Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.limits.arbitrary_products.
 Require Import UniMath.CategoryTheory.limits.coproducts.
+Require Import UniMath.CategoryTheory.limits.arbitrary_coproducts.
 Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.limits.cats.limits.
 Require Import UniMath.CategoryTheory.FunctorAlgebras.
 Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseProduct.
 Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseCoproduct.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseArbitraryProduct.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseArbitraryCoproduct.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.Monads.
 
 Require Import UniMath.SubstitutionSystems.Signatures.
-Require Import UniMath.SubstitutionSystems.SumOfSignatures.
+Require Import UniMath.SubstitutionSystems.ArbitrarySumOfSignatures.
 Require Import UniMath.SubstitutionSystems.ProductOfSignatures.
 Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.LamSignature.
 Require Import UniMath.SubstitutionSystems.Notation.
+Require Import UniMath.SubstitutionSystems.SigToMonad.
 Require Import UniMath.SubstitutionSystems.GenSigToMonad.
 Require Import UniMath.SubstitutionSystems.LiftingInitial.
 
-Section Lam.
+Section GenLam.
 
 Infix "::" := (cons_list nat).
 Notation "[]" := (nil_list nat) (at level 0, format "[]").
@@ -52,6 +57,11 @@ Defined.
 Local Definition ProductsHSET2 : Products HSET2.
 Proof.
 apply (Products_functor_precat _ _ ProductsHSET).
+Defined.
+
+Local Definition ArbitraryProductsHSET2 : ArbitraryProducts bool HSET2.
+Proof.
+apply (ArbitraryProducts_functor_precat _ _ _ (ArbitraryProducts_HSET bool)).
 Defined.
 
 Local Definition CoproductsHSET2 : Coproducts HSET2.
@@ -70,28 +80,36 @@ apply (Initial_functor_precat _ _ InitialHSET).
 Defined.
 
 (* The signature of the lambda calculus: { [0,0], [1] } *)
-Definition LamSig : GenSig bool := fun b =>
+Definition GenLamSig : GenSig bool := fun b =>
   if b then 0 :: 0 :: [] else 1 :: [].
 
-Definition LamSignature : Signature HSET has_homsets_HSET := GenSigToSignature _ isdeceqbool LamSig.
-Definition LamFunctor : functor HSET2 HSET2 := Id_H _ _ CoproductsHSET LamSignature.
+Local Notation "'Id'" := (functor_identity _).
 
-Definition LamMonad : Monad HSET := GenSigToMonad _ isdeceqbool LamSig.
+Local Notation "F * G" := (H HSET has_homsets_HSET ProductsHSET F G).
+
+Local Notation "F + G" := (SumOfSignatures.H _ _ CoproductsHSET F G).
+Local Notation "'_' 'o' 'option'" :=
+  (ℓ (option_functor HSET CoproductsHSET TerminalHSET)) (at level 10).
+
+Definition GenLamSignature : Signature HSET has_homsets_HSET := GenSigToSignature _ isdeceqbool GenLamSig.
+Definition GenLamFunctor : functor HSET2 HSET2 := Id_H _ _ CoproductsHSET GenLamSignature.
+
+Definition GenLamMonad : Monad HSET := GenSigToMonad _ isdeceqbool GenLamSig.
 
 (* From here on it is exactly the same as in CT/lambdacalculus.v *)
 Lemma lambdaFunctor_Initial :
-   Initial (FunctorAlg LamFunctor has_homsets_HSET2).
+   Initial (FunctorAlg GenLamFunctor has_homsets_HSET2).
 Proof.
-apply (GenSigInitial _ isdeceqbool LamSig).
+apply (GenSigInitial _ isdeceqbool GenLamSig).
 Defined.
 
 Definition LC : HSET2 :=
   alg_carrier _ (InitialObject lambdaFunctor_Initial).
 
-Let LC_mor : HSET2⟦LamFunctor LC,LC⟧ :=
+Let LC_mor : HSET2⟦GenLamFunctor LC,LC⟧ :=
   alg_map _ (InitialObject lambdaFunctor_Initial).
 
-Let LC_alg : algebra_ob LamFunctor :=
+Let LC_alg : algebra_ob GenLamFunctor :=
   InitialObject lambdaFunctor_Initial.
 
 Definition var_map : HSET2⟦functor_identity HSET,LC⟧ :=
@@ -103,101 +121,115 @@ Proof.
 apply ProductsHSET2; [apply x | apply y].
 Defined.
 
-(* Definition app_map : HSET2⟦prod2 LC LC,LC⟧ :=  *)
-(*   CoproductIn1 HSET2 _ ;; CoproductIn2 HSET2 _ ;; LC_mor. *)
+Definition app_map : HSET2⟦prod2 LC LC,LC⟧ :=
+  ArbitraryCoproductIn bool HSET2 _ true ;; CoproductIn2 HSET2 _ ;; LC_mor.
 
-(* Definition app_map' (x : HSET) : HSET⟦(pr1 LC x × pr1 LC x)%set,pr1 LC x⟧. *)
-(* Proof. *)
-(* apply app_map. *)
-(* Defined. *)
+Definition app_map' (x : HSET) : HSET⟦(pr1 LC x × pr1 LC x)%set,pr1 LC x⟧.
+Proof.
+apply app_map.
+Defined.
 
 Let precomp_option X := (pre_composition_functor _ _ HSET has_homsets_HSET has_homsets_HSET
                   (option_functor HSET CoproductsHSET TerminalHSET) X).
 
-(* Definition lam_map : HSET2⟦precomp_option LC,LC⟧ := *)
-(*   CoproductIn2 HSET2 _ ;; CoproductIn2 HSET2 _ ;; LC_mor. *)
+Definition lam_map : HSET2⟦precomp_option LC,LC⟧ :=
+  ArbitraryCoproductIn bool HSET2 _ false ;; CoproductIn2 HSET2 _ ;; LC_mor.
 
-(* Definition mk_lambdaAlgebra (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧) *)
-(*   (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) : algebra_ob LamFunctor. *)
-(* Proof. *)
-(* apply (tpair _ X). *)
-(* simple refine (CoproductArrow _ _ fvar (CoproductArrow _ _ fapp flam)). *)
-(* Defined. *)
+Definition mk_lambdaAlgebra (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧)
+  (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) : algebra_ob GenLamFunctor.
+Proof.
+apply (tpair _ X).
+simple refine (CoproductArrow _ _ fvar _).
+simple refine (ArbitraryCoproductArrow _ _ _ _).
+intro b; destruct b.
+- apply fapp.
+- apply flam.
+Defined.
 
-(* Definition foldr_map (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧) *)
-(*   (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) : *)
-(*   algebra_mor LamFunctor LC_alg (mk_lambdaAlgebra X fvar fapp flam). *)
-(* Proof. *)
-(* apply (InitialArrow lambdaFunctor_Initial (mk_lambdaAlgebra X fvar fapp flam)). *)
-(* Defined. *)
+Definition foldr_map (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧)
+  (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) :
+  algebra_mor GenLamFunctor LC_alg (mk_lambdaAlgebra X fvar fapp flam).
+Proof.
+apply (InitialArrow lambdaFunctor_Initial (mk_lambdaAlgebra X fvar fapp flam)).
+Defined.
 
-(* Definition foldr_map' (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧) *)
-(*   (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) : *)
-(*    HSET2 ⟦ pr1 LC_alg, pr1 (mk_lambdaAlgebra X fvar fapp flam) ⟧. *)
-(* Proof. *)
-(* apply (foldr_map X fvar fapp flam). *)
-(* Defined. *)
+Definition foldr_map' (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧)
+  (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) :
+   HSET2 ⟦ pr1 LC_alg, pr1 (mk_lambdaAlgebra X fvar fapp flam) ⟧.
+Proof.
+apply (foldr_map X fvar fapp flam).
+Defined.
 
-(* Lemma foldr_var (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧) *)
-(*   (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) : *)
-(*   var_map ;; foldr_map X fvar fapp flam = fvar. *)
-(* Proof. *)
-(* assert (F := maponpaths (fun x => CoproductIn1 _ _ ;; x) *)
-(*                         (algebra_mor_commutes _ _ _ (foldr_map X fvar fapp flam))). *)
-(* rewrite assoc in F. *)
-(* eapply pathscomp0; [apply F|]. *)
-(* rewrite assoc. *)
-(* eapply pathscomp0; [eapply cancel_postcomposition, CoproductOfArrowsIn1|]. *)
-(* rewrite <- assoc. *)
-(* eapply pathscomp0; [eapply maponpaths, CoproductIn1Commutes|]. *)
-(* apply id_left. *)
-(* Defined. *)
+Lemma foldr_var (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧)
+  (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) :
+  var_map ;; foldr_map X fvar fapp flam = fvar.
+Proof.
+assert (F := maponpaths (fun x => CoproductIn1 _ _ ;; x)
+                        (algebra_mor_commutes _ _ _ (foldr_map X fvar fapp flam))).
+rewrite assoc in F.
+eapply pathscomp0; [apply F|].
+rewrite assoc.
+eapply pathscomp0; [eapply cancel_postcomposition, CoproductOfArrowsIn1|].
+rewrite <- assoc.
+eapply pathscomp0; [eapply maponpaths, CoproductIn1Commutes|].
+apply id_left.
+Defined.
 
-(* Lemma foldr_app (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧) *)
-(*   (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) : *)
-(*   app_map ;; foldr_map X fvar fapp flam = *)
-(*   # (pr1 (Id * Id)) (foldr_map X fvar fapp flam) ;; fapp. *)
-(* Proof. *)
-(* assert (F := maponpaths (fun x => CoproductIn1 _ _ ;; CoproductIn2 _ _ ;; x) *)
-(*                         (algebra_mor_commutes _ _ _ (foldr_map X fvar fapp flam))). *)
-(* rewrite assoc in F. *)
-(* eapply pathscomp0; [apply F|]. *)
-(* rewrite assoc. *)
-(* eapply pathscomp0. *)
-(*   eapply cancel_postcomposition. *)
-(*   rewrite <- assoc. *)
-(*   eapply maponpaths, CoproductOfArrowsIn2. *)
-(* rewrite assoc. *)
-(* eapply pathscomp0. *)
-(*   eapply cancel_postcomposition, cancel_postcomposition, CoproductOfArrowsIn1. *)
-(* rewrite <- assoc. *)
-(* eapply pathscomp0; [eapply maponpaths, CoproductIn2Commutes|]. *)
-(* rewrite <- assoc. *)
-(* now eapply pathscomp0; [eapply maponpaths, CoproductIn1Commutes|]. *)
-(* Defined. *)
+Lemma foldr_app (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧)
+  (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) :
+  app_map ;; foldr_map X fvar fapp flam =
+  # (pr1 (Id * Id)) (foldr_map X fvar fapp flam) ;; fapp.
+Proof.
+assert (F := maponpaths (fun x => ArbitraryCoproductIn _ _ _ true ;; CoproductIn2 _ _ ;; x)
+                        (algebra_mor_commutes _ _ _ (foldr_map X fvar fapp flam))).
+rewrite assoc in F.
+eapply pathscomp0; [apply F|].
+rewrite assoc.
+eapply pathscomp0.
+  eapply cancel_postcomposition.
+  rewrite <- assoc.
+  eapply maponpaths, CoproductOfArrowsIn2.
+rewrite assoc.
+eapply pathscomp0.
+  eapply cancel_postcomposition, cancel_postcomposition.
+  apply (ArbitraryCoproductOfArrowsIn _ _ (ArbitraryCoproducts_functor_precat _ _ _
+          (ArbitraryCoproducts_HSET _ (isasetifdeceq _ isdeceqbool))
+          _ (λ i, pr1 (Arity_to_Signature (GenLamSig i)) `LC_alg))).
+rewrite <- assoc.
+eapply pathscomp0; [eapply maponpaths, CoproductIn2Commutes|].
+rewrite <- assoc.
+eapply pathscomp0; eapply maponpaths.
+  refine (ArbitraryCoproductInCommutes _ _ _ _ _ _ true).
+apply idpath.
+Defined.
 
-(* Lemma foldr_lam (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧) *)
-(*   (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) : *)
-(*   lam_map ;; foldr_map X fvar fapp flam = *)
-(*   # (pr1 (_ o option)) (foldr_map X fvar fapp flam) ;; flam. *)
-(* Proof. *)
-(* assert (F := maponpaths (fun x => CoproductIn2 _ _ ;; CoproductIn2 _ _ ;; x) *)
-(*                         (algebra_mor_commutes _ _ _ (foldr_map X fvar fapp flam))). *)
-(* rewrite assoc in F. *)
-(* eapply pathscomp0; [apply F|]. *)
-(* rewrite assoc. *)
-(* eapply pathscomp0. *)
-(*   eapply cancel_postcomposition. *)
-(*   rewrite <- assoc. *)
-(*   eapply maponpaths, CoproductOfArrowsIn2. *)
-(* rewrite assoc. *)
-(* eapply pathscomp0. *)
-(*   eapply cancel_postcomposition, cancel_postcomposition, CoproductOfArrowsIn2. *)
-(* rewrite <- assoc. *)
-(* eapply pathscomp0. *)
-(*   eapply maponpaths, CoproductIn2Commutes. *)
-(* rewrite <- assoc. *)
-(* now eapply pathscomp0; [eapply maponpaths, CoproductIn2Commutes|]. *)
-(* Defined. *)
+Lemma foldr_lam (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧)
+  (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) :
+  lam_map ;; foldr_map X fvar fapp flam =
+  # (pr1 (_ o option)) (foldr_map X fvar fapp flam) ;; flam.
+Proof.
+assert (F := maponpaths (fun x => ArbitraryCoproductIn _ _ _ false ;; CoproductIn2 _ _ ;; x)
+                        (algebra_mor_commutes _ _ _ (foldr_map X fvar fapp flam))).
+rewrite assoc in F.
+eapply pathscomp0; [apply F|].
+rewrite assoc.
+eapply pathscomp0.
+  eapply cancel_postcomposition.
+  rewrite <- assoc.
+  eapply maponpaths, CoproductOfArrowsIn2.
+rewrite assoc.
+eapply pathscomp0.
+  eapply cancel_postcomposition, cancel_postcomposition.
+  apply (ArbitraryCoproductOfArrowsIn _ _ (ArbitraryCoproducts_functor_precat _ _ _
+          (ArbitraryCoproducts_HSET _ (isasetifdeceq _ isdeceqbool))
+          _ (λ i, pr1 (Arity_to_Signature (GenLamSig i)) `LC_alg))).
+rewrite <- assoc.
+eapply pathscomp0.
+  eapply maponpaths, CoproductIn2Commutes.
+rewrite <- assoc.
+eapply pathscomp0; eapply maponpaths.
+  refine (ArbitraryCoproductInCommutes _ _ _ _ _ _ false).
+apply idpath.
+Defined.
 
-End Lam.
+End GenLam.

--- a/UniMath/SubstitutionSystems/LamFromGenSig.v
+++ b/UniMath/SubstitutionSystems/LamFromGenSig.v
@@ -1,0 +1,203 @@
+(**
+
+Obtain the lambda calculus from the signature { [0,0], [1] }
+
+Written by: Anders Mörtberg, 2016
+
+*)
+
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.category_hset.
+Require Import UniMath.CategoryTheory.category_hset_structures.
+Require Import UniMath.CategoryTheory.chains.
+Require Import UniMath.CategoryTheory.cocontfunctors.
+Require Import UniMath.CategoryTheory.lists.
+Require Import UniMath.CategoryTheory.limits.initial.
+Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.limits.coproducts.
+Require Import UniMath.CategoryTheory.limits.terminal.
+Require Import UniMath.CategoryTheory.limits.cats.limits.
+Require Import UniMath.CategoryTheory.FunctorAlgebras.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseProduct.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseCoproduct.
+Require Import UniMath.CategoryTheory.exponentials.
+Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.Monads.
+
+Require Import UniMath.SubstitutionSystems.Signatures.
+Require Import UniMath.SubstitutionSystems.SumOfSignatures.
+Require Import UniMath.SubstitutionSystems.ProductOfSignatures.
+Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
+Require Import UniMath.SubstitutionSystems.LamSignature.
+Require Import UniMath.SubstitutionSystems.Notation.
+Require Import UniMath.SubstitutionSystems.GenSigToMonad.
+Require Import UniMath.SubstitutionSystems.LiftingInitial.
+
+Section Lam.
+
+Infix "::" := (cons_list nat).
+Notation "[]" := (nil_list nat) (at level 0, format "[]").
+
+Local Notation "'HSET2'":= [HSET, HSET, has_homsets_HSET].
+
+Local Definition has_homsets_HSET2 : has_homsets HSET2.
+Proof.
+apply functor_category_has_homsets.
+Defined.
+
+Local Definition ProductsHSET2 : Products HSET2.
+Proof.
+apply (Products_functor_precat _ _ ProductsHSET).
+Defined.
+
+Local Definition CoproductsHSET2 : Coproducts HSET2.
+Proof.
+apply (Coproducts_functor_precat _ _ CoproductsHSET).
+Defined.
+
+Local Lemma has_exponentials_HSET2 : has_exponentials ProductsHSET2.
+Proof.
+apply has_exponentials_functor_HSET, has_homsets_HSET.
+Defined.
+
+Local Lemma InitialHSET2 : Initial HSET2.
+Proof.
+apply (Initial_functor_precat _ _ InitialHSET).
+Defined.
+
+(* The signature of the lambda calculus: { [0,0], [1] } *)
+Definition LamSig : GenSig bool := fun b =>
+  if b then 0 :: 0 :: [] else 1 :: [].
+
+Definition LamSignature : Signature HSET has_homsets_HSET := GenSigToSignature _ isdeceqbool LamSig.
+Definition LamFunctor : functor HSET2 HSET2 := Id_H _ _ CoproductsHSET LamSignature.
+
+Definition LamMonad : Monad HSET := GenSigToMonad _ isdeceqbool LamSig.
+
+(* From here on it is exactly the same as in CT/lambdacalculus.v *)
+Lemma lambdaFunctor_Initial :
+   Initial (FunctorAlg LamFunctor has_homsets_HSET2).
+Proof.
+apply (GenSigInitial _ isdeceqbool LamSig).
+Defined.
+
+Definition LC : HSET2 :=
+  alg_carrier _ (InitialObject lambdaFunctor_Initial).
+
+Let LC_mor : HSET2⟦LamFunctor LC,LC⟧ :=
+  alg_map _ (InitialObject lambdaFunctor_Initial).
+
+Let LC_alg : algebra_ob LamFunctor :=
+  InitialObject lambdaFunctor_Initial.
+
+Definition var_map : HSET2⟦functor_identity HSET,LC⟧ :=
+  CoproductIn1 HSET2 _ ;; LC_mor.
+
+(* How to do this nicer? *)
+Definition prod2 (x y : HSET2) : HSET2.
+Proof.
+apply ProductsHSET2; [apply x | apply y].
+Defined.
+
+(* Definition app_map : HSET2⟦prod2 LC LC,LC⟧ :=  *)
+(*   CoproductIn1 HSET2 _ ;; CoproductIn2 HSET2 _ ;; LC_mor. *)
+
+(* Definition app_map' (x : HSET) : HSET⟦(pr1 LC x × pr1 LC x)%set,pr1 LC x⟧. *)
+(* Proof. *)
+(* apply app_map. *)
+(* Defined. *)
+
+Let precomp_option X := (pre_composition_functor _ _ HSET has_homsets_HSET has_homsets_HSET
+                  (option_functor HSET CoproductsHSET TerminalHSET) X).
+
+(* Definition lam_map : HSET2⟦precomp_option LC,LC⟧ := *)
+(*   CoproductIn2 HSET2 _ ;; CoproductIn2 HSET2 _ ;; LC_mor. *)
+
+(* Definition mk_lambdaAlgebra (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧) *)
+(*   (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) : algebra_ob LamFunctor. *)
+(* Proof. *)
+(* apply (tpair _ X). *)
+(* simple refine (CoproductArrow _ _ fvar (CoproductArrow _ _ fapp flam)). *)
+(* Defined. *)
+
+(* Definition foldr_map (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧) *)
+(*   (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) : *)
+(*   algebra_mor LamFunctor LC_alg (mk_lambdaAlgebra X fvar fapp flam). *)
+(* Proof. *)
+(* apply (InitialArrow lambdaFunctor_Initial (mk_lambdaAlgebra X fvar fapp flam)). *)
+(* Defined. *)
+
+(* Definition foldr_map' (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧) *)
+(*   (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) : *)
+(*    HSET2 ⟦ pr1 LC_alg, pr1 (mk_lambdaAlgebra X fvar fapp flam) ⟧. *)
+(* Proof. *)
+(* apply (foldr_map X fvar fapp flam). *)
+(* Defined. *)
+
+(* Lemma foldr_var (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧) *)
+(*   (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) : *)
+(*   var_map ;; foldr_map X fvar fapp flam = fvar. *)
+(* Proof. *)
+(* assert (F := maponpaths (fun x => CoproductIn1 _ _ ;; x) *)
+(*                         (algebra_mor_commutes _ _ _ (foldr_map X fvar fapp flam))). *)
+(* rewrite assoc in F. *)
+(* eapply pathscomp0; [apply F|]. *)
+(* rewrite assoc. *)
+(* eapply pathscomp0; [eapply cancel_postcomposition, CoproductOfArrowsIn1|]. *)
+(* rewrite <- assoc. *)
+(* eapply pathscomp0; [eapply maponpaths, CoproductIn1Commutes|]. *)
+(* apply id_left. *)
+(* Defined. *)
+
+(* Lemma foldr_app (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧) *)
+(*   (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) : *)
+(*   app_map ;; foldr_map X fvar fapp flam = *)
+(*   # (pr1 (Id * Id)) (foldr_map X fvar fapp flam) ;; fapp. *)
+(* Proof. *)
+(* assert (F := maponpaths (fun x => CoproductIn1 _ _ ;; CoproductIn2 _ _ ;; x) *)
+(*                         (algebra_mor_commutes _ _ _ (foldr_map X fvar fapp flam))). *)
+(* rewrite assoc in F. *)
+(* eapply pathscomp0; [apply F|]. *)
+(* rewrite assoc. *)
+(* eapply pathscomp0. *)
+(*   eapply cancel_postcomposition. *)
+(*   rewrite <- assoc. *)
+(*   eapply maponpaths, CoproductOfArrowsIn2. *)
+(* rewrite assoc. *)
+(* eapply pathscomp0. *)
+(*   eapply cancel_postcomposition, cancel_postcomposition, CoproductOfArrowsIn1. *)
+(* rewrite <- assoc. *)
+(* eapply pathscomp0; [eapply maponpaths, CoproductIn2Commutes|]. *)
+(* rewrite <- assoc. *)
+(* now eapply pathscomp0; [eapply maponpaths, CoproductIn1Commutes|]. *)
+(* Defined. *)
+
+(* Lemma foldr_lam (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧) *)
+(*   (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) : *)
+(*   lam_map ;; foldr_map X fvar fapp flam = *)
+(*   # (pr1 (_ o option)) (foldr_map X fvar fapp flam) ;; flam. *)
+(* Proof. *)
+(* assert (F := maponpaths (fun x => CoproductIn2 _ _ ;; CoproductIn2 _ _ ;; x) *)
+(*                         (algebra_mor_commutes _ _ _ (foldr_map X fvar fapp flam))). *)
+(* rewrite assoc in F. *)
+(* eapply pathscomp0; [apply F|]. *)
+(* rewrite assoc. *)
+(* eapply pathscomp0. *)
+(*   eapply cancel_postcomposition. *)
+(*   rewrite <- assoc. *)
+(*   eapply maponpaths, CoproductOfArrowsIn2. *)
+(* rewrite assoc. *)
+(* eapply pathscomp0. *)
+(*   eapply cancel_postcomposition, cancel_postcomposition, CoproductOfArrowsIn2. *)
+(* rewrite <- assoc. *)
+(* eapply pathscomp0. *)
+(*   eapply maponpaths, CoproductIn2Commutes. *)
+(* rewrite <- assoc. *)
+(* now eapply pathscomp0; [eapply maponpaths, CoproductIn2Commutes|]. *)
+(* Defined. *)
+
+End Lam.

--- a/UniMath/SubstitutionSystems/SigToMonad.v
+++ b/UniMath/SubstitutionSystems/SigToMonad.v
@@ -3,7 +3,6 @@
 From signatures to monads
 
 Written by: Anders Mörtberg, 2016
-Based on a note by Ralph Matthes
 
 *)
 
@@ -21,6 +20,7 @@ Require Import UniMath.CategoryTheory.FunctorAlgebras.
 Require Import UniMath.CategoryTheory.PointedFunctors.
 Require Import UniMath.CategoryTheory.ProductPrecategory.
 Require Import UniMath.SubstitutionSystems.Signatures.
+Require Import UniMath.SubstitutionSystems.SignatureExamples.
 Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseCoproduct.
 Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseProduct.
 Require Import UniMath.CategoryTheory.EndofunctorsMonoidal.
@@ -44,413 +44,7 @@ Require Import UniMath.CategoryTheory.lists.
 Require Import UniMath.CategoryTheory.HorizontalComposition.
 
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
-
-(* Construct θ in a Signature in the case when the functor is
-   precomposition with a functor G by constructing a family of simpler
-   distributive laws δ *)
-Section θ_from_δ.
-
-Variable C : precategory.
-Variable hsC : has_homsets C.
-Variable G : functor C C.
-
-(** The precategory of pointed endofunctors on [C] *)
-Local Notation "'Ptd'" := (precategory_Ptd C hsC).
-(** The category of endofunctors on [C] *)
-Local Notation "'EndC'":= ([C, C, hsC]) .
-
-Definition δ_source_ob (Ze : Ptd) : EndC := G • pr1 Ze.
-Definition δ_source_mor {Ze Ze' : Ptd} (α : Ze --> Ze') :
-  δ_source_ob Ze --> δ_source_ob Ze' := hor_comp (pr1 α) (nat_trans_id G).
-
-Definition δ_source_functor_data : functor_data Ptd EndC.
-Proof.
-exists δ_source_ob.
-exact (@δ_source_mor).
-Defined.
-
-Lemma is_functor_δ_source : is_functor δ_source_functor_data.
-Proof.
-split; simpl.
-- intro Ze.
-  apply (nat_trans_eq hsC).
-  now intro c; simpl; rewrite functor_id, id_right.
-- intros [Z e] [Z' e'] [Z'' e''] [α a] [β b].
-  apply (nat_trans_eq hsC); intro c; simpl in *.
-  now rewrite !id_left, functor_comp.
-Qed.
-
-Definition δ_source : functor Ptd EndC := tpair _ _ is_functor_δ_source.
-
-Definition δ_target_ob (Ze : Ptd) : EndC := pr1 Ze • G.
-Definition δ_target_mor {Ze Ze' : Ptd} (α : Ze --> Ze') :
-  δ_target_ob Ze --> δ_target_ob Ze' := hor_comp (nat_trans_id G) (pr1 α).
-
-Definition δ_target_functor_data : functor_data Ptd EndC.
-Proof.
-exists δ_target_ob.
-exact (@δ_target_mor).
-Defined.
-
-Lemma is_functor_δ_target : is_functor δ_target_functor_data.
-Proof.
-split; simpl.
-- intro Ze.
-  apply (nat_trans_eq hsC).
-  now intro c; simpl; rewrite functor_id, id_right.
-- intros [Z e] [Z' e'] [Z'' e''] [α a] [β b].
-  apply (nat_trans_eq hsC); intro c; simpl in *.
-  now rewrite !functor_id, !id_right.
-Qed.
-
-Definition δ_target : functor Ptd EndC := tpair _ _ is_functor_δ_target.
-
-Hypothesis δ : δ_source ⟶ δ_target.
-
-Let precompG := (pre_composition_functor _ _ _ hsC hsC G).
-
-Definition θ_from_δ_mor (XZe : [C, C, hsC] XX Ptd) :
-  [C, C, hsC] ⟦ θ_source precompG XZe, θ_target precompG XZe ⟧.
-Proof.
-set (X := pr1 XZe); set (Z := pr1 (pr2 XZe)).
-set (F1 := α_functor _ G Z X).
-set (F2 := post_whisker (δ (pr2 XZe)) X).
-set (F3 := α_functor_inv _ Z G X).
-apply (nat_trans_comp F3 (nat_trans_comp F2 F1)).
-Defined.
-
-Lemma is_nat_trans_θ_from_δ_mor :
-   is_nat_trans (θ_source precompG) (θ_target precompG) θ_from_δ_mor.
-Proof.
-intros [F1 X1] [F2 X2] [α X]; simpl in *.
-apply (nat_trans_eq hsC); intro c; simpl; rewrite !id_right, !id_left.
-generalize (nat_trans_eq_pointwise (nat_trans_ax δ X1 X2 X) c); simpl.
-rewrite id_left, functor_id, id_right.
-intros H.
-rewrite <- assoc.
-eapply pathscomp0.
-  eapply maponpaths, pathsinv0, functor_comp.
-eapply pathscomp0.
-  eapply maponpaths, maponpaths, H.
-rewrite assoc; apply pathsinv0.
-eapply pathscomp0.
-  eapply cancel_postcomposition, nat_trans_ax.
-now rewrite <- assoc, <- functor_comp.
-Qed.
-
-Definition θ_from_δ : θ_source precompG ⟶ θ_target precompG :=
-  tpair _ _ is_nat_trans_θ_from_δ_mor.
-
-(* Should be ρ_G^-1 ∘ λ_G ? *)
-Definition δ_law1 : UU := δ (id_Ptd C hsC) = nat_trans_id G.
-Hypothesis (H1 : δ_law1).
-
-Lemma θ_Strength1_int_from_δ : θ_Strength1_int θ_from_δ.
-Proof.
-intro F.
-apply (nat_trans_eq hsC); intro c; simpl.
-rewrite id_left, !id_right.
-eapply pathscomp0;
-  [eapply maponpaths, (nat_trans_eq_pointwise H1 c)|].
-apply functor_id.
-Qed.
-
-Require Import UniMath.CategoryTheory.PointedFunctorsComposition.
-
-Let D' Ze Ze' :=
-  nat_trans_comp (α_functor _ (pr1 Ze) (pr1 Ze') G)
- (nat_trans_comp (pre_whisker (pr1 Ze) (δ Ze'))
- (nat_trans_comp (α_functor_inv _ (pr1 Ze) G (pr1 Ze'))
- (nat_trans_comp (post_whisker (δ Ze) (pr1 Ze'))
-                 (α_functor _ G (pr1 Ze) (pr1 Ze'))))).
-
-Definition δ_law2 : UU := forall Ze Ze', δ (Ze p• Ze') = D' Ze Ze'.
-Hypothesis H2 : δ_law2.
-
-Lemma θ_Strength2_int_from_δ : θ_Strength2_int θ_from_δ.
-Proof.
-intros F Ze Ze'; simpl.
-set (Z := pr1 Ze); set (Z' := pr1 Ze').
-apply (nat_trans_eq hsC); intro c; simpl.
-generalize (nat_trans_eq_pointwise (H2 Ze Ze') c); simpl.
-rewrite !id_left, !id_right; intro H.
-eapply pathscomp0;
-  [eapply maponpaths, H|].
-apply functor_comp.
-Qed.
-
-Definition θ_precompG : Σ θ : θ_source precompG ⟶ θ_target precompG,
-                              θ_Strength1_int θ × θ_Strength2_int θ :=
-  tpair _ θ_from_δ (θ_Strength1_int_from_δ,,θ_Strength2_int_from_δ).
-
-Definition θ_from_δ_Signature : Signature C hsC :=
-  tpair _ precompG θ_precompG.
-
-End θ_from_δ.
-
-(* Composition of δ's *)
-Section δ_mul.
-
-Variable C : precategory.
-Variable hsC : has_homsets C.
-Variable G1 G2 : functor C C.
-
-Variable δ1 : δ_source C hsC G1 ⟶ δ_target C hsC G1.
-Variable δ2 : δ_source C hsC G2 ⟶ δ_target C hsC G2.
-Hypothesis (δ1_law1 : δ_law1 C hsC G1 δ1) (δ1_law2 : δ_law2 C hsC G1 δ1).
-Hypothesis (δ2_law1 : δ_law1 C hsC G2 δ2) (δ2_law2 : δ_law2 C hsC G2 δ2).
-
-Definition δ_comp_mor (Ze : ptd_obj C) :
-       functor_composite_data (pr1 Ze) (functor_composite_data G1 G2)
-   ⟶ functor_composite_data (functor_composite_data G1 G2) (pr1 Ze).
-Proof.
-set (Z := pr1 Ze).
-set (F1 := α_functor_inv _ Z G1 G2).
-set (F2 := post_whisker (δ1 Ze) G2).
-set (F3 := α_functor _ G1 Z G2).
-set (F4 := pre_whisker G1 (δ2 Ze)).
-set (F5 := α_functor_inv _ G1 G2 Z).
-exact (nat_trans_comp F1 (nat_trans_comp F2 (nat_trans_comp F3 (nat_trans_comp F4 F5)))).
-Defined.
-
-Lemma is_nat_trans_δ_comp_mor : is_nat_trans (δ_source _ _ (G2 • G1 : [C,C,hsC]))
-                                             (δ_target _ hsC (G2 • G1 : [C,C,hsC])) δ_comp_mor.
-Proof.
-intros [Z e] [Z' e'] [α X]; simpl in *.
-apply (nat_trans_eq hsC); intro c; simpl; rewrite functor_id, !id_right, !id_left.
-eapply pathscomp0.
-  rewrite assoc.
-  eapply cancel_postcomposition, pathsinv0, functor_comp.
-eapply pathscomp0.
-  eapply cancel_postcomposition, maponpaths.
-  generalize (nat_trans_eq_pointwise (nat_trans_ax δ1 (Z,,e) (Z',, e') (α,,X)) c).
-  simpl; rewrite id_left, functor_id, id_right; intro H1.
-  apply H1.
-rewrite functor_comp, <- assoc.
-eapply pathscomp0.
-  eapply maponpaths.
-  generalize (nat_trans_eq_pointwise (nat_trans_ax δ2 (Z,,e) (Z',, e') (α,,X)) (G1 c)).
-  simpl; rewrite id_left, functor_id, id_right; intro H2.
-  apply H2.
-now rewrite assoc.
-Qed.
-
-Definition δ_comp : δ_source C hsC (G2 • G1 : [C,C,hsC]) ⟶ δ_target C hsC (G2 • G1 : [C,C,hsC]) :=
-  tpair _ δ_comp_mor is_nat_trans_δ_comp_mor.
-
-Lemma δ_comp_law1 : δ_law1 C hsC (G2 • G1 : [C,C,hsC]) δ_comp.
-Proof.
-apply (nat_trans_eq hsC); intro c; simpl; rewrite !id_left, id_right.
-eapply pathscomp0.
-  eapply maponpaths, (nat_trans_eq_pointwise δ2_law1 (G1 c)).
-eapply pathscomp0.
-  eapply cancel_postcomposition, maponpaths, (nat_trans_eq_pointwise δ1_law1 c).
-now rewrite id_right; apply functor_id.
-Qed.
-
-Lemma δ_comp_law2 : δ_law2 C hsC (G2 • G1 : [C,C,hsC]) δ_comp.
-Proof.
-intros Ze Ze'.
-apply (nat_trans_eq hsC); intro c; simpl; rewrite !id_left, !id_right.
-eapply pathscomp0.
-  eapply cancel_postcomposition, maponpaths, (nat_trans_eq_pointwise (δ1_law2 Ze Ze') c).
-eapply pathscomp0.
-  eapply maponpaths, (nat_trans_eq_pointwise (δ2_law2 Ze Ze') (G1 c)).
-simpl; rewrite !id_left, !id_right.
-eapply pathscomp0.
-  eapply cancel_postcomposition, functor_comp.
-rewrite <- !assoc.
-apply maponpaths.
-rewrite assoc.
-eapply pathscomp0.
-  eapply cancel_postcomposition, (nat_trans_ax (δ2 Ze') _ _ (pr1 (δ1 Ze) c)).
-simpl; rewrite <- !assoc.
-now apply maponpaths, pathsinv0, functor_comp.
-Qed.
-
-End δ_mul.
-
-(* Construct the δ when G = option *)
-Section option_sig.
-
-Variables (C : precategory) (hsC : has_homsets C) (TC : Terminal C) (CC : Coproducts C).
-
-Local Notation "'Ptd'" := (precategory_Ptd C hsC).
-
-Let opt := option_functor C CC TC.
-
-Definition δ_option_mor (Ze : Ptd) (c : C) :  C ⟦ CoproductObject C (CC TC (pr1 Ze c)),
-                                                  pr1 Ze (CoproductObject C (CC TC c)) ⟧.
-Proof.
-apply (@CoproductArrow _ _ _ (CC TC (pr1 Ze c)) (pr1 Ze (CoproductObject C (CC TC c)))).
-- apply (CoproductIn1 _ (CC TC c) ;; pr2 Ze (CoproductObject _ (CC TC c))).
-- apply (# (pr1 Ze) (CoproductIn2 _ (CC TC c))).
-Defined.
-
-Lemma is_nat_trans_δ_option_mor (Ze : Ptd) :
-  is_nat_trans (δ_source C hsC opt Ze : functor C C) (δ_target C hsC opt Ze : functor C C)
-     (δ_option_mor Ze).
-Proof.
-intros a b f; simpl.
-destruct Ze as [Z e].
-unfold coproduct_functor_mor; simpl.
-eapply pathscomp0.
-  apply precompWithCoproductArrow.
-rewrite id_left.
-apply pathsinv0, CoproductArrowUnique.
-- eapply pathscomp0.
-    rewrite assoc.
-    eapply cancel_postcomposition, CoproductIn1Commutes.
-  rewrite <- assoc.
-  eapply pathscomp0.
-    eapply maponpaths, pathsinv0, (nat_trans_ax e).
-  simpl; rewrite assoc.
-  apply cancel_postcomposition.
-  eapply pathscomp0.
-    apply CoproductOfArrowsIn1.
-  now rewrite id_left.
-- rewrite assoc.
-  eapply pathscomp0.
-    eapply cancel_postcomposition, CoproductIn2Commutes.
-  rewrite <- !functor_comp.
-  now apply maponpaths, CoproductOfArrowsIn2.
-Qed.
-
-Lemma is_nat_trans_δ_option_mor_nat_trans : is_nat_trans (δ_source_functor_data C hsC opt)
-     (δ_target_functor_data C hsC opt)
-     (λ Ze : Ptd, δ_option_mor Ze,, is_nat_trans_δ_option_mor Ze).
-Proof.
-intros [Z e] [Z' e'] [α X]; simpl in *.
-apply (nat_trans_eq hsC); intro c; simpl.
-rewrite id_left, functor_id, id_right.
-unfold coproduct_functor_mor, coproduct_functor_ob, δ_option_mor; simpl.
-rewrite precompWithCoproductArrow.
-apply pathsinv0, CoproductArrowUnique.
-- rewrite id_left, assoc.
-  eapply pathscomp0.
-    eapply cancel_postcomposition, CoproductIn1Commutes.
-  rewrite <- assoc.
-  now apply maponpaths, X.
-- rewrite assoc.
-  eapply pathscomp0.
-    eapply cancel_postcomposition, CoproductIn2Commutes.
-  now apply nat_trans_ax.
-Qed.
-
-Definition δ_option : δ_source C hsC opt ⟶ δ_target C hsC opt.
-Proof.
-mkpair.
-- intro Ze.
-  apply (tpair _ (δ_option_mor Ze) (is_nat_trans_δ_option_mor Ze)).
-- apply is_nat_trans_δ_option_mor_nat_trans.
-Defined.
-
-Lemma δ_law1_option : δ_law1 C hsC opt δ_option.
-Proof.
-apply (nat_trans_eq hsC); intro c; simpl.
-unfold δ_option_mor, coproduct_functor_ob; simpl.
-rewrite id_right.
-apply pathsinv0, Coproduct_endo_is_identity.
-- apply CoproductIn1Commutes.
-- apply CoproductIn2Commutes.
-Qed.
-
-Lemma δ_law2_option : δ_law2 C hsC opt δ_option.
-Proof.
-intros [Z e] [Z' e'].
-apply (nat_trans_eq hsC); intro c; simpl.
-unfold δ_option_mor, coproduct_functor_ob; simpl.
-rewrite !id_left, id_right.
-apply pathsinv0, CoproductArrowUnique.
-- rewrite assoc.
-  eapply pathscomp0.
-    eapply cancel_postcomposition, CoproductIn1Commutes.
-  rewrite <- assoc.
-  eapply pathscomp0.
-    eapply maponpaths, pathsinv0, (nat_trans_ax e').
-  simpl; rewrite assoc.
-  eapply pathscomp0.
-    eapply cancel_postcomposition, CoproductIn1Commutes.
-  rewrite <- !assoc.
-  now apply maponpaths, (nat_trans_ax e').
-- rewrite assoc.
-  eapply pathscomp0.
-    eapply cancel_postcomposition, CoproductIn2Commutes.
-  eapply pathscomp0.
-    eapply pathsinv0, functor_comp.
-  now apply maponpaths, CoproductIn2Commutes.
-Qed.
-
-Definition precomp_option_Signature : Signature C hsC :=
-  θ_from_δ_Signature _ hsC opt δ_option δ_law1_option δ_law2_option.
-
-End option_sig.
-
-(* Define δ for G = F^n *)
-Section iter1_sig.
-
-Variable C : precategory.
-Variable hsC : has_homsets C.
-Variable F : functor C C.
-
-Variable δ : δ_source C hsC F ⟶ δ_target C hsC F.
-Hypothesis (H1 : δ_law1 C hsC F δ) (H2 : δ_law2 C hsC F δ).
-
-Local Notation "'Ptd'" := (precategory_Ptd C hsC).
-
-(* G^n+1 *)
-Fixpoint iter_functor1 (n : nat) : functor C C := match n with
-  | O => F
-  | S n' => functor_composite (iter_functor1 n') F
-  end.
-
-Definition δ_iter_functor1 n : δ_source C hsC (iter_functor1 n) ⟶ δ_target C hsC (iter_functor1 n).
-Proof.
-induction n.
-- apply δ.
-- apply δ_comp.
-  + apply IHn.
-  + apply δ.
-Defined.
-
-Lemma δ_law1_iter_functor1 n : δ_law1 C hsC (iter_functor1 n) (δ_iter_functor1 n).
-Proof.
-induction n; [|apply δ_comp_law1]; assumption.
-Qed.
-
-Lemma δ_law2_iter_functor1 n : δ_law2 C hsC (iter_functor1 n) (δ_iter_functor1 n).
-Proof.
-induction n; [|apply δ_comp_law2]; assumption.
-Qed.
-
-End iter1_sig.
-
-Section id_signature.
-
-Variable (C : precategory) (hsC : has_homsets C).
-
-Definition θ_functor_identity : Σ
-  θ : θ_source (functor_identity [C,C,hsC]) ⟶ θ_target (functor_identity [C,C,hsC]),
-  θ_Strength1_int θ × θ_Strength2_int θ.
-Proof.
-mkpair; simpl.
-+ mkpair; simpl.
-  * intro x.
-    { mkpair.
-      - intro y; simpl; apply identity.
-      - abstract (now intros y y' f; rewrite id_left, id_right).
-    }
-  * abstract (now intros y y' f; apply (nat_trans_eq hsC); intro z;
-                  simpl; rewrite id_left, id_right).
-(* If this part is abstract the eval cbn for the LC doesn't reduce properly *)
-+ now split; intros x; intros; apply (nat_trans_eq hsC); intro c; simpl; rewrite !id_left.
-Defined.
-
-(* Signature for the Id functor *)
-Definition IdSignature : Signature C hsC :=
-  tpair _ (functor_identity _) θ_functor_identity.
-
-End id_signature.
+Local Notation "'HSET2'":= ([HSET, HSET, has_homsets_HSET]) .
 
 (* Translation from a Sig to a monad by: *)
 (* S : SIG *)
@@ -464,24 +58,22 @@ End id_signature.
 (* M := Monad_from_HSS(I)    # *)
 Section SigToMonad.
 
-Local Notation "'HSET2'":= ([HSET, HSET, has_homsets_HSET]) .
-
-Local Definition has_homsets_HSET2 : has_homsets HSET2.
+Definition has_homsets_HSET2 : has_homsets HSET2.
 Proof.
 apply functor_category_has_homsets.
 Defined.
 
-Local Definition ProductsHSET2 : Products HSET2.
+Definition ProductsHSET2 : Products HSET2.
 Proof.
 apply (Products_functor_precat _ _ ProductsHSET).
 Defined.
 
-Local Definition CoproductsHSET2 : Coproducts HSET2.
+Definition CoproductsHSET2 : Coproducts HSET2.
 Proof.
 apply (Coproducts_functor_precat _ _ CoproductsHSET).
 Defined.
 
-Local Lemma has_exponentials_HSET2 : has_exponentials ProductsHSET2.
+Lemma has_exponentials_HSET2 : has_exponentials ProductsHSET2.
 Proof.
 apply has_exponentials_functor_HSET, has_homsets_HSET.
 Defined.

--- a/UniMath/SubstitutionSystems/SignatureExamples.v
+++ b/UniMath/SubstitutionSystems/SignatureExamples.v
@@ -1,0 +1,432 @@
+(**
+
+Definitions of various signatures
+
+Written by: Anders Mörtberg, 2016
+Based on a note by Ralph Matthes
+
+*)
+
+Require Import UniMath.Foundations.Basics.PartD.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.limits.coproducts.
+Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseCoproduct.
+Require Import UniMath.CategoryTheory.limits.terminal.
+Require Import UniMath.CategoryTheory.FunctorAlgebras.
+Require Import UniMath.CategoryTheory.PointedFunctors.
+Require Import UniMath.SubstitutionSystems.Signatures.
+Require Import UniMath.CategoryTheory.EndofunctorsMonoidal.
+Require Import UniMath.SubstitutionSystems.Lam.
+Require Import UniMath.SubstitutionSystems.Notation.
+Require Import UniMath.CategoryTheory.HorizontalComposition.
+
+(* Construct θ in a Signature in the case when the functor is
+   precomposition with a functor G by constructing a family of simpler
+   distributive laws δ *)
+Section θ_from_δ.
+
+Variable C : precategory.
+Variable hsC : has_homsets C.
+Variable G : functor C C.
+
+(** The precategory of pointed endofunctors on [C] *)
+Local Notation "'Ptd'" := (precategory_Ptd C hsC).
+(** The category of endofunctors on [C] *)
+Local Notation "'EndC'":= ([C, C, hsC]) .
+
+Definition δ_source_ob (Ze : Ptd) : EndC := G • pr1 Ze.
+Definition δ_source_mor {Ze Ze' : Ptd} (α : Ze --> Ze') :
+  δ_source_ob Ze --> δ_source_ob Ze' := hor_comp (pr1 α) (nat_trans_id G).
+
+Definition δ_source_functor_data : functor_data Ptd EndC.
+Proof.
+exists δ_source_ob.
+exact (@δ_source_mor).
+Defined.
+
+Lemma is_functor_δ_source : is_functor δ_source_functor_data.
+Proof.
+split; simpl.
+- intro Ze.
+  apply (nat_trans_eq hsC).
+  now intro c; simpl; rewrite functor_id, id_right.
+- intros [Z e] [Z' e'] [Z'' e''] [α a] [β b].
+  apply (nat_trans_eq hsC); intro c; simpl in *.
+  now rewrite !id_left, functor_comp.
+Qed.
+
+Definition δ_source : functor Ptd EndC := tpair _ _ is_functor_δ_source.
+
+Definition δ_target_ob (Ze : Ptd) : EndC := pr1 Ze • G.
+Definition δ_target_mor {Ze Ze' : Ptd} (α : Ze --> Ze') :
+  δ_target_ob Ze --> δ_target_ob Ze' := hor_comp (nat_trans_id G) (pr1 α).
+
+Definition δ_target_functor_data : functor_data Ptd EndC.
+Proof.
+exists δ_target_ob.
+exact (@δ_target_mor).
+Defined.
+
+Lemma is_functor_δ_target : is_functor δ_target_functor_data.
+Proof.
+split; simpl.
+- intro Ze.
+  apply (nat_trans_eq hsC).
+  now intro c; simpl; rewrite functor_id, id_right.
+- intros [Z e] [Z' e'] [Z'' e''] [α a] [β b].
+  apply (nat_trans_eq hsC); intro c; simpl in *.
+  now rewrite !functor_id, !id_right.
+Qed.
+
+Definition δ_target : functor Ptd EndC := tpair _ _ is_functor_δ_target.
+
+Hypothesis δ : δ_source ⟶ δ_target.
+
+Let precompG := (pre_composition_functor _ _ _ hsC hsC G).
+
+Definition θ_from_δ_mor (XZe : [C, C, hsC] XX Ptd) :
+  [C, C, hsC] ⟦ θ_source precompG XZe, θ_target precompG XZe ⟧.
+Proof.
+set (X := pr1 XZe); set (Z := pr1 (pr2 XZe)).
+set (F1 := α_functor _ G Z X).
+set (F2 := post_whisker (δ (pr2 XZe)) X).
+set (F3 := α_functor_inv _ Z G X).
+apply (nat_trans_comp F3 (nat_trans_comp F2 F1)).
+Defined.
+
+Lemma is_nat_trans_θ_from_δ_mor :
+   is_nat_trans (θ_source precompG) (θ_target precompG) θ_from_δ_mor.
+Proof.
+intros [F1 X1] [F2 X2] [α X]; simpl in *.
+apply (nat_trans_eq hsC); intro c; simpl; rewrite !id_right, !id_left.
+generalize (nat_trans_eq_pointwise (nat_trans_ax δ X1 X2 X) c); simpl.
+rewrite id_left, functor_id, id_right.
+intros H.
+rewrite <- assoc.
+eapply pathscomp0.
+  eapply maponpaths, pathsinv0, functor_comp.
+eapply pathscomp0.
+  eapply maponpaths, maponpaths, H.
+rewrite assoc; apply pathsinv0.
+eapply pathscomp0.
+  eapply cancel_postcomposition, nat_trans_ax.
+now rewrite <- assoc, <- functor_comp.
+Qed.
+
+Definition θ_from_δ : θ_source precompG ⟶ θ_target precompG :=
+  tpair _ _ is_nat_trans_θ_from_δ_mor.
+
+(* Should be ρ_G^-1 ∘ λ_G ? *)
+Definition δ_law1 : UU := δ (id_Ptd C hsC) = nat_trans_id G.
+Hypothesis (H1 : δ_law1).
+
+Lemma θ_Strength1_int_from_δ : θ_Strength1_int θ_from_δ.
+Proof.
+intro F.
+apply (nat_trans_eq hsC); intro c; simpl.
+rewrite id_left, !id_right.
+eapply pathscomp0;
+  [eapply maponpaths, (nat_trans_eq_pointwise H1 c)|].
+apply functor_id.
+Qed.
+
+Require Import UniMath.CategoryTheory.PointedFunctorsComposition.
+
+Let D' Ze Ze' :=
+  nat_trans_comp (α_functor _ (pr1 Ze) (pr1 Ze') G)
+ (nat_trans_comp (pre_whisker (pr1 Ze) (δ Ze'))
+ (nat_trans_comp (α_functor_inv _ (pr1 Ze) G (pr1 Ze'))
+ (nat_trans_comp (post_whisker (δ Ze) (pr1 Ze'))
+                 (α_functor _ G (pr1 Ze) (pr1 Ze'))))).
+
+Definition δ_law2 : UU := forall Ze Ze', δ (Ze p• Ze') = D' Ze Ze'.
+Hypothesis H2 : δ_law2.
+
+Lemma θ_Strength2_int_from_δ : θ_Strength2_int θ_from_δ.
+Proof.
+intros F Ze Ze'; simpl.
+set (Z := pr1 Ze); set (Z' := pr1 Ze').
+apply (nat_trans_eq hsC); intro c; simpl.
+generalize (nat_trans_eq_pointwise (H2 Ze Ze') c); simpl.
+rewrite !id_left, !id_right; intro H.
+eapply pathscomp0;
+  [eapply maponpaths, H|].
+apply functor_comp.
+Qed.
+
+Definition θ_precompG : Σ θ : θ_source precompG ⟶ θ_target precompG,
+                              θ_Strength1_int θ × θ_Strength2_int θ :=
+  tpair _ θ_from_δ (θ_Strength1_int_from_δ,,θ_Strength2_int_from_δ).
+
+Definition θ_from_δ_Signature : Signature C hsC :=
+  tpair _ precompG θ_precompG.
+
+End θ_from_δ.
+
+(* Composition of δ's *)
+Section δ_mul.
+
+Variable C : precategory.
+Variable hsC : has_homsets C.
+Variable G1 G2 : functor C C.
+
+Variable δ1 : δ_source C hsC G1 ⟶ δ_target C hsC G1.
+Variable δ2 : δ_source C hsC G2 ⟶ δ_target C hsC G2.
+Hypothesis (δ1_law1 : δ_law1 C hsC G1 δ1) (δ1_law2 : δ_law2 C hsC G1 δ1).
+Hypothesis (δ2_law1 : δ_law1 C hsC G2 δ2) (δ2_law2 : δ_law2 C hsC G2 δ2).
+
+Definition δ_comp_mor (Ze : ptd_obj C) :
+       functor_composite_data (pr1 Ze) (functor_composite_data G1 G2)
+   ⟶ functor_composite_data (functor_composite_data G1 G2) (pr1 Ze).
+Proof.
+set (Z := pr1 Ze).
+set (F1 := α_functor_inv _ Z G1 G2).
+set (F2 := post_whisker (δ1 Ze) G2).
+set (F3 := α_functor _ G1 Z G2).
+set (F4 := pre_whisker G1 (δ2 Ze)).
+set (F5 := α_functor_inv _ G1 G2 Z).
+exact (nat_trans_comp F1 (nat_trans_comp F2 (nat_trans_comp F3 (nat_trans_comp F4 F5)))).
+Defined.
+
+Lemma is_nat_trans_δ_comp_mor : is_nat_trans (δ_source _ _ (G2 • G1 : [C,C,hsC]))
+                                             (δ_target _ hsC (G2 • G1 : [C,C,hsC])) δ_comp_mor.
+Proof.
+intros [Z e] [Z' e'] [α X]; simpl in *.
+apply (nat_trans_eq hsC); intro c; simpl; rewrite functor_id, !id_right, !id_left.
+eapply pathscomp0.
+  rewrite assoc.
+  eapply cancel_postcomposition, pathsinv0, functor_comp.
+eapply pathscomp0.
+  eapply cancel_postcomposition, maponpaths.
+  generalize (nat_trans_eq_pointwise (nat_trans_ax δ1 (Z,,e) (Z',, e') (α,,X)) c).
+  simpl; rewrite id_left, functor_id, id_right; intro H1.
+  apply H1.
+rewrite functor_comp, <- assoc.
+eapply pathscomp0.
+  eapply maponpaths.
+  generalize (nat_trans_eq_pointwise (nat_trans_ax δ2 (Z,,e) (Z',, e') (α,,X)) (G1 c)).
+  simpl; rewrite id_left, functor_id, id_right; intro H2.
+  apply H2.
+now rewrite assoc.
+Qed.
+
+Definition δ_comp : δ_source C hsC (G2 • G1 : [C,C,hsC]) ⟶ δ_target C hsC (G2 • G1 : [C,C,hsC]) :=
+  tpair _ δ_comp_mor is_nat_trans_δ_comp_mor.
+
+Lemma δ_comp_law1 : δ_law1 C hsC (G2 • G1 : [C,C,hsC]) δ_comp.
+Proof.
+apply (nat_trans_eq hsC); intro c; simpl; rewrite !id_left, id_right.
+eapply pathscomp0.
+  eapply maponpaths, (nat_trans_eq_pointwise δ2_law1 (G1 c)).
+eapply pathscomp0.
+  eapply cancel_postcomposition, maponpaths, (nat_trans_eq_pointwise δ1_law1 c).
+now rewrite id_right; apply functor_id.
+Qed.
+
+Lemma δ_comp_law2 : δ_law2 C hsC (G2 • G1 : [C,C,hsC]) δ_comp.
+Proof.
+intros Ze Ze'.
+apply (nat_trans_eq hsC); intro c; simpl; rewrite !id_left, !id_right.
+eapply pathscomp0.
+  eapply cancel_postcomposition, maponpaths, (nat_trans_eq_pointwise (δ1_law2 Ze Ze') c).
+eapply pathscomp0.
+  eapply maponpaths, (nat_trans_eq_pointwise (δ2_law2 Ze Ze') (G1 c)).
+simpl; rewrite !id_left, !id_right.
+eapply pathscomp0.
+  eapply cancel_postcomposition, functor_comp.
+rewrite <- !assoc.
+apply maponpaths.
+rewrite assoc.
+eapply pathscomp0.
+  eapply cancel_postcomposition, (nat_trans_ax (δ2 Ze') _ _ (pr1 (δ1 Ze) c)).
+simpl; rewrite <- !assoc.
+now apply maponpaths, pathsinv0, functor_comp.
+Qed.
+
+End δ_mul.
+
+(* Construct the δ when G = option *)
+Section option_sig.
+
+Variables (C : precategory) (hsC : has_homsets C) (TC : Terminal C) (CC : Coproducts C).
+
+Local Notation "'Ptd'" := (precategory_Ptd C hsC).
+
+Let opt := option_functor C CC TC.
+
+Definition δ_option_mor (Ze : Ptd) (c : C) :  C ⟦ CoproductObject C (CC TC (pr1 Ze c)),
+                                                  pr1 Ze (CoproductObject C (CC TC c)) ⟧.
+Proof.
+apply (@CoproductArrow _ _ _ (CC TC (pr1 Ze c)) (pr1 Ze (CoproductObject C (CC TC c)))).
+- apply (CoproductIn1 _ (CC TC c) ;; pr2 Ze (CoproductObject _ (CC TC c))).
+- apply (# (pr1 Ze) (CoproductIn2 _ (CC TC c))).
+Defined.
+
+Lemma is_nat_trans_δ_option_mor (Ze : Ptd) :
+  is_nat_trans (δ_source C hsC opt Ze : functor C C) (δ_target C hsC opt Ze : functor C C)
+     (δ_option_mor Ze).
+Proof.
+intros a b f; simpl.
+destruct Ze as [Z e].
+unfold coproduct_functor_mor; simpl.
+eapply pathscomp0.
+  apply precompWithCoproductArrow.
+rewrite id_left.
+apply pathsinv0, CoproductArrowUnique.
+- eapply pathscomp0.
+    rewrite assoc.
+    eapply cancel_postcomposition, CoproductIn1Commutes.
+  rewrite <- assoc.
+  eapply pathscomp0.
+    eapply maponpaths, pathsinv0, (nat_trans_ax e).
+  simpl; rewrite assoc.
+  apply cancel_postcomposition.
+  eapply pathscomp0.
+    apply CoproductOfArrowsIn1.
+  now rewrite id_left.
+- rewrite assoc.
+  eapply pathscomp0.
+    eapply cancel_postcomposition, CoproductIn2Commutes.
+  rewrite <- !functor_comp.
+  now apply maponpaths, CoproductOfArrowsIn2.
+Qed.
+
+Lemma is_nat_trans_δ_option_mor_nat_trans : is_nat_trans (δ_source_functor_data C hsC opt)
+     (δ_target_functor_data C hsC opt)
+     (λ Ze : Ptd, δ_option_mor Ze,, is_nat_trans_δ_option_mor Ze).
+Proof.
+intros [Z e] [Z' e'] [α X]; simpl in *.
+apply (nat_trans_eq hsC); intro c; simpl.
+rewrite id_left, functor_id, id_right.
+unfold coproduct_functor_mor, coproduct_functor_ob, δ_option_mor; simpl.
+rewrite precompWithCoproductArrow.
+apply pathsinv0, CoproductArrowUnique.
+- rewrite id_left, assoc.
+  eapply pathscomp0.
+    eapply cancel_postcomposition, CoproductIn1Commutes.
+  rewrite <- assoc.
+  now apply maponpaths, X.
+- rewrite assoc.
+  eapply pathscomp0.
+    eapply cancel_postcomposition, CoproductIn2Commutes.
+  now apply nat_trans_ax.
+Qed.
+
+Definition δ_option : δ_source C hsC opt ⟶ δ_target C hsC opt.
+Proof.
+mkpair.
+- intro Ze.
+  apply (tpair _ (δ_option_mor Ze) (is_nat_trans_δ_option_mor Ze)).
+- apply is_nat_trans_δ_option_mor_nat_trans.
+Defined.
+
+Lemma δ_law1_option : δ_law1 C hsC opt δ_option.
+Proof.
+apply (nat_trans_eq hsC); intro c; simpl.
+unfold δ_option_mor, coproduct_functor_ob; simpl.
+rewrite id_right.
+apply pathsinv0, Coproduct_endo_is_identity.
+- apply CoproductIn1Commutes.
+- apply CoproductIn2Commutes.
+Qed.
+
+Lemma δ_law2_option : δ_law2 C hsC opt δ_option.
+Proof.
+intros [Z e] [Z' e'].
+apply (nat_trans_eq hsC); intro c; simpl.
+unfold δ_option_mor, coproduct_functor_ob; simpl.
+rewrite !id_left, id_right.
+apply pathsinv0, CoproductArrowUnique.
+- rewrite assoc.
+  eapply pathscomp0.
+    eapply cancel_postcomposition, CoproductIn1Commutes.
+  rewrite <- assoc.
+  eapply pathscomp0.
+    eapply maponpaths, pathsinv0, (nat_trans_ax e').
+  simpl; rewrite assoc.
+  eapply pathscomp0.
+    eapply cancel_postcomposition, CoproductIn1Commutes.
+  rewrite <- !assoc.
+  now apply maponpaths, (nat_trans_ax e').
+- rewrite assoc.
+  eapply pathscomp0.
+    eapply cancel_postcomposition, CoproductIn2Commutes.
+  eapply pathscomp0.
+    eapply pathsinv0, functor_comp.
+  now apply maponpaths, CoproductIn2Commutes.
+Qed.
+
+Definition precomp_option_Signature : Signature C hsC :=
+  θ_from_δ_Signature _ hsC opt δ_option δ_law1_option δ_law2_option.
+
+End option_sig.
+
+(* Define δ for G = F^n *)
+Section iter1_sig.
+
+Variable C : precategory.
+Variable hsC : has_homsets C.
+Variable F : functor C C.
+
+Variable δ : δ_source C hsC F ⟶ δ_target C hsC F.
+Hypothesis (H1 : δ_law1 C hsC F δ) (H2 : δ_law2 C hsC F δ).
+
+Local Notation "'Ptd'" := (precategory_Ptd C hsC).
+
+(* G^n+1 *)
+Fixpoint iter_functor1 (n : nat) : functor C C := match n with
+  | O => F
+  | S n' => functor_composite (iter_functor1 n') F
+  end.
+
+Definition δ_iter_functor1 n : δ_source C hsC (iter_functor1 n) ⟶ δ_target C hsC (iter_functor1 n).
+Proof.
+induction n.
+- apply δ.
+- apply δ_comp.
+  + apply IHn.
+  + apply δ.
+Defined.
+
+Lemma δ_law1_iter_functor1 n : δ_law1 C hsC (iter_functor1 n) (δ_iter_functor1 n).
+Proof.
+induction n; [|apply δ_comp_law1]; assumption.
+Qed.
+
+Lemma δ_law2_iter_functor1 n : δ_law2 C hsC (iter_functor1 n) (δ_iter_functor1 n).
+Proof.
+induction n; [|apply δ_comp_law2]; assumption.
+Qed.
+
+End iter1_sig.
+
+Section id_signature.
+
+Variable (C : precategory) (hsC : has_homsets C).
+
+Definition θ_functor_identity : Σ
+  θ : θ_source (functor_identity [C,C,hsC]) ⟶ θ_target (functor_identity [C,C,hsC]),
+  θ_Strength1_int θ × θ_Strength2_int θ.
+Proof.
+mkpair; simpl.
++ mkpair; simpl.
+  * intro x.
+    { mkpair.
+      - intro y; simpl; apply identity.
+      - abstract (now intros y y' f; rewrite id_left, id_right).
+    }
+  * abstract (now intros y y' f; apply (nat_trans_eq hsC); intro z;
+                  simpl; rewrite id_left, id_right).
+(* If this part is abstract the eval cbn for the LC doesn't reduce properly *)
++ now split; intros x; intros; apply (nat_trans_eq hsC); intro c; simpl; rewrite !id_left.
+Defined.
+
+(* Signature for the Id functor *)
+Definition IdSignature : Signature C hsC :=
+  tpair _ (functor_identity _) θ_functor_identity.
+
+End id_signature.

--- a/UniMath/SubstitutionSystems/SumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/SumOfSignatures.v
@@ -282,7 +282,6 @@ Qed.
 
 End construction.
 
-
 Definition Sum_of_Signatures (S1 S2: Signature C hs) : Signature C hs.
 Proof.
   destruct S1 as [H1 [θ1 [S11' S12']]].

--- a/UniMath/SubstitutionSystems/SumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/SumOfSignatures.v
@@ -38,11 +38,10 @@ Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseCoproduct.
 Require Import UniMath.SubstitutionSystems.Notation.
 Require Import UniMath.CategoryTheory.chains.
 Require Import UniMath.CategoryTheory.cocontfunctors.
-Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.limits.products.
 Require Import UniMath.CategoryTheory.limits.FunctorsPointwiseProduct.
 
-Local Notation "# F" := (functor_on_morphisms F)(at level 3).
+Local Notation "# F" := (functor_on_morphisms F) (at level 3).
 Local Notation "F ⟶ G" := (nat_trans F G) (at level 39).
 Local Notation "G □ F" := (functor_composite _ _ _ F G) (at level 35).
 
@@ -57,13 +56,11 @@ Section sum_of_signatures.
 
 Variable C : precategory.
 Variable hs : has_homsets C.
-(* Variable PP : Products C. *)
 Variable CC : Coproducts C.
 
 Section construction.
 
 Local Notation "'CCC'" := (Coproducts_functor_precat C C CC hs : Coproducts [C, C, hs]).
-
 
 Variables H1 H2 : functor [C, C, hs] [C, C, hs].
 
@@ -286,7 +283,7 @@ Qed.
 End construction.
 
 
-Definition Sum_of_Signatures (S1 S2: Signature C hs): Signature C hs.
+Definition Sum_of_Signatures (S1 S2: Signature C hs) : Signature C hs.
 Proof.
   destruct S1 as [H1 [θ1 [S11' S12']]].
   destruct S2 as [H2 [θ2 [S21' S22']]].


### PR DESCRIPTION
This PR generalizes the signatures from lists of lists to sets of lists. In particular it contains:

- Generalization of binary (co)products to (co)products indexed by an arbitrary type. 
- Proofs that these (co)products lifts to functor categories
- Proof that generalized versions of some functors (delta, (co)product, pair_functor) are omega cocontinuous
- Generalization of sum of signatures
- Generalization of the notion of signature (GenSig) and the construction of a monad from a GenSig