### PR TITLE
Empty product from terminal and vice versa

### DIFF
--- a/UniMath/CategoryTheory/limits/initial.v
+++ b/UniMath/CategoryTheory/limits/initial.v
@@ -93,6 +93,45 @@ Arguments InitialArrowUnique {_} _ _ _ .
 Arguments mk_isInitial {_} _ _ _ .
 Arguments mk_Initial {_} _ _.
 
+Section Initial_and_EmptyCoprod.
+  Require Import UniMath.CategoryTheory.limits.arbitrary_coproducts.
+
+  (** Construct Initial from empty arbitrary coproduct. *)
+  Definition initial_from_empty_coproduct (C : precategory):
+    ArbitraryCoproductCocone empty C fromempty -> Initial C.
+  Proof.
+    intros X.
+    refine (mk_Initial (ArbitraryCoproductObject _ _ X) _).
+    refine (mk_isInitial _ _).
+    intros b.
+    assert (H : forall i : empty, C⟦fromempty i, b⟧) by
+        (intros i; apply (fromempty i)).
+    apply (iscontrpair (ArbitraryCoproductArrow _ _ X H)); intros t.
+    apply ArbitraryCoproductArrowUnique; intros i; apply (fromempty i).
+  Defined.
+
+  (** Construct empty arbitrary coproduct from initial *)
+  Definition empty_coproduct_from_initial (C : category) :
+    Initial C -> ArbitraryCoproductCocone empty C fromempty.
+  Proof.
+    intros I.
+    assert (H : forall i : empty, C⟦fromempty i, I⟧) by
+        (intros i; apply (fromempty i)).
+    refine (mk_ArbitraryCoproductCocone _ _ _ (InitialObject I) H _).
+    refine (mk_isArbitraryCoproductCocone _ _ (pr2 (pr2 C)) _ _ _ _).
+    intros c g.
+    set (k := @InitialArrow _ I c).
+    assert (H0 : forall i : empty, H i ;; (InitialArrow I c) = g i) by
+        (intros i; apply (fromempty i)).
+    refine (iscontrpair (tpair _ k H0) _). intros t.
+    eapply (total2_paths (InitialArrowEq C I c _ _)).
+    apply proofirrelevance.
+    apply impred_isaprop.
+    intros t0.
+    apply (pr2 (pr2 C) _ _).
+  Defined.
+End Initial_and_EmptyCoprod.
+
 (* Section Initial_from_Colims. *)
 
 (* Require Import UniMath.CategoryTheory.limits.graphs.colimits. *)

--- a/UniMath/CategoryTheory/limits/initial.v
+++ b/UniMath/CategoryTheory/limits/initial.v
@@ -111,24 +111,25 @@ Section Initial_and_EmptyCoprod.
   Defined.
 
   (** Construct empty arbitrary coproduct from initial *)
-  Definition empty_coproduct_from_initial (C : category) :
+  Definition empty_coproduct_from_initial (C : precategory)
+             (hs : has_homsets C) :
     Initial C -> ArbitraryCoproductCocone empty C fromempty.
   Proof.
     intros I.
     assert (H : forall i : empty, C⟦fromempty i, I⟧) by
         (intros i; apply (fromempty i)).
     refine (mk_ArbitraryCoproductCocone _ _ _ (InitialObject I) H _).
-    refine (mk_isArbitraryCoproductCocone _ _ (pr2 (pr2 C)) _ _ _ _).
+    refine (mk_isArbitraryCoproductCocone _ _ hs _ _ _ _).
     intros c g.
     set (k := @InitialArrow _ I c).
     assert (H0 : forall i : empty, H i ;; (InitialArrow I c) = g i) by
         (intros i; apply (fromempty i)).
     refine (iscontrpair (tpair _ k H0) _). intros t.
-    eapply (total2_paths (InitialArrowEq C I c _ _)).
+    apply (total2_paths (InitialArrowEq C I c _ _)).
     apply proofirrelevance.
     apply impred_isaprop.
     intros t0.
-    apply (pr2 (pr2 C) _ _).
+    apply hs.
   Defined.
 End Initial_and_EmptyCoprod.
 

--- a/UniMath/CategoryTheory/limits/terminal.v
+++ b/UniMath/CategoryTheory/limits/terminal.v
@@ -5,9 +5,9 @@ Require Import UniMath.Foundations.Basics.Sets.
 
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
 
 Local Notation "a --> b" := (precategory_morphisms a b)(at level 50).
-Local Notation "f ;; g" := (compose f g)(at level 50).
 
 Section def_terminal.
 
@@ -93,6 +93,47 @@ Arguments TerminalObject [C] _.
 Arguments TerminalArrow [C]{T} b.
 Arguments mk_isTerminal {_} _ _ _ .
 Arguments mk_Terminal {_} _ _.
+
+
+Section Terminal_and_EmptyProd.
+  Require Import UniMath.CategoryTheory.limits.arbitrary_products.
+
+  (** Construct Terminal from empty arbitrary product. *)
+  Definition terminal_from_empty_product (C : precategory) :
+    ArbitraryProductCone empty C fromempty -> Terminal C.
+  Proof.
+    intros X.
+    refine (mk_Terminal (ArbitraryProductObject _ C X) _).
+    refine (mk_isTerminal _ _).
+    intros a.
+    assert (H : forall i : empty, C⟦a, fromempty i⟧) by
+        (intros i; apply (fromempty i)).
+    apply (iscontrpair (ArbitraryProductArrow _ _ X H)); intros t.
+    apply ArbitraryProductArrowUnique; intros i; apply (fromempty i).
+  Defined.
+
+  (** Construct empty arbitrary product from Terminal *)
+  Definition empty_product_from_terminal (C : category) :
+    Terminal C ->  ArbitraryProductCone empty C fromempty.
+  Proof.
+    intros T.
+    assert (H : forall i : empty, C⟦T, fromempty i⟧) by
+        (intros i; apply (fromempty i)).
+    refine (mk_ArbitraryProductCone _ _ _ T H _).
+    refine (mk_isArbitraryProductCone _ _ (pr2 (pr2 C)) _ _ _ _).
+    intros c f.
+    set (k := @TerminalArrow _ T c).
+    assert (H0 : forall i : empty, (TerminalArrow c) ;; H i = f i) by
+        (intros i; apply (fromempty i)).
+
+    refine (iscontrpair (tpair _ k H0) _). intros t.
+    eapply (total2_paths (ArrowsToTerminal C T c _ _)).
+    apply proofirrelevance.
+    apply impred_isaprop.
+    intros t0.
+    apply (pr2 (pr2 C) _ _).
+  Defined.
+End Terminal_and_EmptyProd.
 
 (* Section Terminal_from_Lims. *)
 

--- a/UniMath/CategoryTheory/limits/terminal.v
+++ b/UniMath/CategoryTheory/limits/terminal.v
@@ -113,25 +113,26 @@ Section Terminal_and_EmptyProd.
   Defined.
 
   (** Construct empty arbitrary product from Terminal *)
-  Definition empty_product_from_terminal (C : category) :
+  Definition empty_product_from_terminal (C : precategory)
+    (hs : has_homsets C) :
     Terminal C ->  ArbitraryProductCone empty C fromempty.
   Proof.
     intros T.
     assert (H : forall i : empty, C⟦T, fromempty i⟧) by
         (intros i; apply (fromempty i)).
     refine (mk_ArbitraryProductCone _ _ _ T H _).
-    refine (mk_isArbitraryProductCone _ _ (pr2 (pr2 C)) _ _ _ _).
+    refine (mk_isArbitraryProductCone _ _ hs _ _ _ _).
     intros c f.
     set (k := @TerminalArrow _ T c).
     assert (H0 : forall i : empty, (TerminalArrow c) ;; H i = f i) by
         (intros i; apply (fromempty i)).
 
     refine (iscontrpair (tpair _ k H0) _). intros t.
-    eapply (total2_paths (ArrowsToTerminal C T c _ _)).
+    apply (total2_paths (ArrowsToTerminal C T c _ _)).
     apply proofirrelevance.
     apply impred_isaprop.
     intros t0.
-    apply (pr2 (pr2 C) _ _).
+    apply hs.
   Defined.
 End Terminal_and_EmptyProd.
 


### PR DESCRIPTION
Hi.
	
I tried to formalize finite (co)products and prove that initial and coproducts
(resp. terminal and products) imply finite coproducts (resp. finite products).
I was not able to prove this, so I decided to formalize the case about
empty coproducts and initials (resp. empty products and terminals). This
special case is at least intended to be used as the base case when one proves
existence of finite (co)products by induction on the number of elements of the
(co)product.

All comments are welcome.