### PR TITLE
Added some results on arbitrary (co)products

### DIFF
--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -25,6 +25,8 @@ limits/FunctorsPointwiseCoproduct.v
 limits/FunctorsPointwiseArbitraryCoproduct.v
 limits/FunctorsPointwiseProduct.v
 limits/FunctorsPointwiseArbitraryProduct.v
+limits/finite_products.v
+limits/finite_coproducts.v
 limits/graphs/colimits.v
 HLevel_n_is_of_hlevel_Sn.v
 category_hset_structures.v

--- a/UniMath/CategoryTheory/limits/coproducts.v
+++ b/UniMath/CategoryTheory/limits/coproducts.v
@@ -13,6 +13,8 @@ Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.ProductPrecategory.
+Require Import UniMath.CategoryTheory.limits.arbitrary_coproducts.
+Require Import UniMath.Foundations.Combinatorics.StandardFiniteSets.
 
 (** * Definition of binary coproduct of objects in a precategory *)
 Section coproduct_def.
@@ -525,6 +527,237 @@ Proof.
 Qed.
 
 End Coproducts.
+
+(** In this section we construct a coproduct from an arbitrary coproduct and an
+  arbitrary coproduct from a coproduct. *)
+Section Coproducts_ArbitraryCoproducts.
+  (** Variables and definitions we are going to use in the proofs. *)
+  Variable C : precategory.
+  Hypothesis hs : has_homsets C.
+  Definition stn0 : stn 2 := stnpair 2 0 (natlthtolths _ _ (natlthnsn 0)).
+  Definition stn1 : stn 2 := stnpair 2 1 (natlthnsn 1).
+
+  (** We will use the following two definitions to do induction. *)
+  Definition tworec (n : nat) (H' : n < 2) : (n = 0) ⨿ (n = 1).
+  Proof.
+    destruct n.
+    exact (ii1 (idpath 0)).
+    destruct n.
+    exact (ii2 (idpath 1)).
+    exact (fromempty (nopathsfalsetotrue H')).
+  Defined.
+  Definition stn2ind (i : stn 2) : (i = stn0) ⨿ (i = stn1).
+  Proof.
+    induction (tworec (pr1 i)).
+    apply ii1. apply isinjstntonat, a.
+    apply ii2. apply isinjstntonat, b.
+    exact (pr2 i).
+  Defined.
+
+  (** Construct a family of 2 objects from a pair of objects. *)
+  Definition pair_to_stn2 (c1 c2 : C) : (stn 2) -> C.
+  Proof.
+    intros X.
+    induction (stn2ind X).
+    exact c1.
+    exact c2.
+  Defined.
+
+  (** The following lemmas check that the above definition is correct.*)
+  Lemma pair_to_stn2_1 (c1 c2 : C) : pair_to_stn2 c1 c2 stn0 = c1.
+  Proof. apply idpath. Defined.
+  Lemma pair_to_stn2_2 (c1 c2 : C) : pair_to_stn2 c1 c2 stn1 = c2.
+  Proof. apply idpath. Defined.
+
+  (** Construct a family of 2 morphisms with the same target from 2 morphisms
+    with the same target. *)
+  Definition pair_to_stn2_mors (c : C) (a : stn 2 -> C) (f : C⟦a stn0, c⟧)
+             (g : C⟦a stn1, c⟧) : forall i : stn 2, C⟦a i, c⟧.
+  Proof.
+    intros i. induction (stn2ind i).
+    rewrite <- a0 in f. apply f.
+    rewrite <- b in g. apply g.
+  Defined.
+
+  (** The following lemmas check that the above definition is correct. *)
+  Lemma pair_to_stn2_mors_1 (c : C) (a : stn 2 -> C) (f : C⟦a stn0, c⟧)
+        (g : C⟦a stn1, c⟧) :
+    pair_to_stn2_mors c a f g stn0 = f.
+  Proof. apply idpath. Defined.
+  Lemma pair_to_stn2_mors_2 (c : C) (a : stn 2 -> C) (f : C⟦a stn0, c⟧)
+        (g : C⟦a stn1, c⟧) :
+    pair_to_stn2_mors c a f g stn1 = g.
+  Proof. apply idpath. Defined.
+
+  (** Construction of a coproduct from an arbitrary coproduct of 2 objects. *)
+  Definition coproduct_from_arbitrary_coproduct
+             (a : stn 2 -> C) (Cone : ArbitraryCoproductCocone (stn 2) C a) :
+    CoproductCocone C (a stn0) (a stn1).
+  Proof.
+    set (in1 := ArbitraryCoproductIn _ _ Cone stn0).
+    set (in2 := ArbitraryCoproductIn _ _ Cone stn1).
+    set (Coneob := (ArbitraryCoproductObject _ _ Cone)).
+    refine (mk_CoproductCocone _ (a stn0) (a stn1) Coneob in1 in2 _).
+    refine (mk_isCoproductCocone _ hs _ _ _ _ _ _).
+    intros c f g.
+    set (mors := pair_to_stn2_mors c a f g).
+    set (com1 := ArbitraryCoproductInCommutes _ _ a Cone c mors stn0).
+    set (com2 := ArbitraryCoproductInCommutes _ _ a Cone c mors stn1).
+    set (ar := (ArbitraryCoproductArrow _ _ Cone mors)).
+    refine (tpair _ (tpair _ ar _)  _).
+    intros t; eapply total2_paths.
+    apply proofirrelevance, isapropdirprod; apply hs.
+
+    Unshelve.
+
+    (* Commutativity *)
+    split.
+    rewrite <- (pair_to_stn2_mors_1 c a f g). apply com1.
+    rewrite <- (pair_to_stn2_mors_2 c a f g). apply com2.
+
+    (* Uniqueness *)
+    eapply ArbitraryCoproductArrowUnique. intros i. induction (stn2ind i).
+    rewrite a0. fold in1. rewrite <- (pair_to_stn2_mors_1 c a f g).
+    apply (dirprod_pr1 (pr2 t)).
+    rewrite b. fold in2. rewrite <- (pair_to_stn2_mors_2 c a f g).
+    apply (dirprod_pr2 (pr2 t)).
+  Defined.
+
+  (** Construction of an arbitrary coproduct from a coproduct. *)
+  Definition arbitrary_coproduct_from_coproduct (c1 c2 : C)
+             (Cone : CoproductCocone C c1 c2) :
+    ArbitraryCoproductCocone (stn 2) C (pair_to_stn2 c1 c2).
+  Proof.
+    set (a := pair_to_stn2 c1 c2).
+    set (in1 := CoproductIn1 _ Cone).
+    set (in2 := CoproductIn2 _ Cone).
+    set (ConeOb := CoproductObject _ Cone).
+    set (f := pair_to_stn2_mors ConeOb a in1 in2).
+    refine (mk_ArbitraryCoproductCocone _ _ a ConeOb f _ ).
+    refine (mk_isArbitraryCoproductCocone _ _ hs _ _ _ _).
+    intros c g.
+    set (f1 := g stn0).
+    set (f2 := g stn1).
+    set (ar := CoproductArrow _ Cone f1 f2).
+    set (com1 := CoproductIn1Commutes _ _ _ Cone _ f1 f2).
+    set (com2 := CoproductIn2Commutes _ _ _ Cone _ f1 f2).
+    refine (tpair _ (tpair _ ar _ ) _).
+    intros t. eapply total2_paths. apply proofirrelevance.
+    apply impred_isaprop. intros t0. apply hs.
+
+    Unshelve.
+    (* Commutativity *)
+    intros i. induction (stn2ind i).
+    rewrite a0. unfold f. rewrite (pair_to_stn2_mors_1 ConeOb a in1 in2).
+    apply com1.
+    rewrite b. unfold f. rewrite (pair_to_stn2_mors_2 ConeOb a in1 in2).
+    apply com2.
+
+    (* Uniqueness *)
+    apply CoproductArrowUnique.
+    fold in1. rewrite <- (pair_to_stn2_mors_1 ConeOb a in1 in2). fold f.
+    apply (pr2 t stn0).
+    fold in2. rewrite <- (pair_to_stn2_mors_2 ConeOb a in1 in2). fold f.
+    apply (pr2 t stn1).
+  Defined.
+End Coproducts_ArbitraryCoproducts.
+
+(** In this section we construct an arbitrary coproduct from two arbitrary
+  coproducts by taking the disjoint union of the objects. We need to assume that
+  the coproduct of the given two arbitrary coproducts exists. *)
+Section coproduct_from_coproducts.
+  Variable C : precategory.
+  Hypothesis hs : has_homsets C.
+
+  (** Disjoint union of the objects a1 and a2. *)
+  Definition coprod_families {I1 I2 : UU} (a1 : I1 -> C) (a2 : I2 -> C):
+    I1 ⨿ I2 -> C.
+  Proof.
+    intros X.
+    induction X.
+    apply (a1 a).
+    apply (a2 b).
+  Defined.
+
+  (** Verify that we have the same objects. *)
+  Lemma coprod_families_1 {I1 I2 : UU} (a1 : I1 -> C) (a2 : I2 -> C) (i : I1):
+    coprod_families a1 a2 (ii1 i) = a1 i.
+  Proof. apply idpath. Defined.
+  Lemma coprod_families_2 {I1 I2 : UU} (a1 : I1 -> C) (a2 : I2 -> C) (i : I2):
+    coprod_families a1 a2 (ii2 i) = a2 i.
+  Proof. apply idpath. Defined.
+
+  (** Construction of an arbitrary coproduct from two arbitrary coproducts and a
+    coproduct of the two arbitrary coproducts. *)
+  Theorem arbitrary_coproduct_from_arbitrary_coproducts :
+    forall (I1 I2 : UU) (a1 : I1 -> C) (a2 : I2 -> C)
+      (A1 : ArbitraryCoproductCocone _ C a1)
+      (A2 : ArbitraryCoproductCocone _ C a2)
+      (Cone : CoproductCocone C (ArbitraryCoproductObject _ _ A1)
+                              (ArbitraryCoproductObject _ _ A2)),
+      ArbitraryCoproductCocone _ C (coprod_families a1 a2).
+  Proof.
+    intros I1 I2 a1 a2 A1 A2 Cone.
+
+    (* Set names from useful terms *)
+    set (A1in := ArbitraryCoproductIn _ _ A1).
+    set (A2in := ArbitraryCoproductIn _ _ A2).
+    set (in1 := CoproductIn1 _ Cone).
+    set (in2 := CoproductIn2 _ Cone).
+
+    eapply (mk_ArbitraryCoproductCocone _ _ _ (CoproductObject _ Cone)).
+    eapply mk_isArbitraryCoproductCocone.
+    apply hs.
+    intros c g.
+
+    (* Set names for useful terms *)
+    set (g1 := fun i : I1 => g (ii1 i)).
+    set (g2 := fun i : I2 => g (ii2 i)).
+    set (ar1 := ArbitraryCoproductArrow _ _ A1 g1).
+    set (ar2 := ArbitraryCoproductArrow _ _ A2 g2).
+    set (ar := CoproductArrow _ Cone ar1 ar2).
+    set (com1 := CoproductIn1Commutes _ _ _ Cone c ar1 ar2).
+    set (com2 := CoproductIn2Commutes _ _ _ Cone c ar1 ar2).
+
+    refine (tpair _ _ _).
+    intros t.
+    eapply total2_paths. apply proofirrelevance.
+    apply impred_isaprop. intros t0. apply hs.
+
+    Unshelve.
+
+    (* Morphisms from objects to the cone *)
+    intros i. unfold coprod_families, coprod_rect. induction i.
+    apply (A1in a ;; in1).
+    apply (A2in b ;; in2).
+
+    (* The unique arrow from the cone to c *)
+    refine (tpair _ ar _ ).
+
+    (* Commutativity of morphisms *)
+    intros i. unfold coprod_rect. induction i.
+
+    set (com'1 := ArbitraryCoproductInCommutes _ _ _ A1 c g1 a).
+    unfold A1in. unfold in1. unfold ar. rewrite <- assoc. rewrite com1.
+    unfold ar1. rewrite -> com'1. apply idpath.
+
+
+    set (com'2 := ArbitraryCoproductInCommutes _ _ _ A2 c g2 b).
+    unfold A2in, in2, ar. rewrite <- assoc. rewrite com2.
+    unfold ar2. rewrite com'2. apply idpath.
+
+    simpl.
+    (* Uniqueness of the morphism from the cone *)
+    eapply CoproductArrowUnique.
+    eapply ArbitraryCoproductArrowUnique.
+    intros i. simpl in t. set (t2 := pr2 t (ii1 i)). simpl in t2.
+    fold A1in. rewrite assoc. apply t2.
+
+    eapply ArbitraryCoproductArrowUnique.
+    intros i. simpl in t. set (t2 := pr2 t (ii2 i)). simpl in t2.
+    fold A2in. rewrite assoc. apply t2.
+  Defined.
+End coproduct_from_coproducts.
 
 (* Section Coproducts_from_Colims. *)
 

--- a/UniMath/CategoryTheory/limits/coproducts.v
+++ b/UniMath/CategoryTheory/limits/coproducts.v
@@ -563,12 +563,6 @@ Section Coproducts_ArbitraryCoproducts.
     exact c2.
   Defined.
 
-  (** The following lemmas check that the above definition is correct.*)
-  Lemma pair_to_stn2_1 (c1 c2 : C) : pair_to_stn2 c1 c2 stn0 = c1.
-  Proof. apply idpath. Defined.
-  Lemma pair_to_stn2_2 (c1 c2 : C) : pair_to_stn2 c1 c2 stn1 = c2.
-  Proof. apply idpath. Defined.
-
   (** Construct a family of 2 morphisms with the same target from 2 morphisms
     with the same target. *)
   Definition pair_to_stn2_mors (c : C) (a : stn 2 -> C) (f : C⟦a stn0, c⟧)
@@ -579,16 +573,6 @@ Section Coproducts_ArbitraryCoproducts.
     rewrite <- b in g. apply g.
   Defined.
 
-  (** The following lemmas check that the above definition is correct. *)
-  Lemma pair_to_stn2_mors_1 (c : C) (a : stn 2 -> C) (f : C⟦a stn0, c⟧)
-        (g : C⟦a stn1, c⟧) :
-    pair_to_stn2_mors c a f g stn0 = f.
-  Proof. apply idpath. Defined.
-  Lemma pair_to_stn2_mors_2 (c : C) (a : stn 2 -> C) (f : C⟦a stn0, c⟧)
-        (g : C⟦a stn1, c⟧) :
-    pair_to_stn2_mors c a f g stn1 = g.
-  Proof. apply idpath. Defined.
-
   (** Construction of a coproduct from an arbitrary coproduct of 2 objects. *)
   Definition coproduct_from_arbitrary_coproduct
              (a : stn 2 -> C) (Cone : ArbitraryCoproductCocone (stn 2) C a) :
@@ -597,30 +581,31 @@ Section Coproducts_ArbitraryCoproducts.
     set (in1 := ArbitraryCoproductIn _ _ Cone stn0).
     set (in2 := ArbitraryCoproductIn _ _ Cone stn1).
     set (Coneob := (ArbitraryCoproductObject _ _ Cone)).
+
     refine (mk_CoproductCocone _ (a stn0) (a stn1) Coneob in1 in2 _).
     refine (mk_isCoproductCocone _ hs _ _ _ _ _ _).
     intros c f g.
+
     set (mors := pair_to_stn2_mors c a f g).
     set (com1 := ArbitraryCoproductInCommutes _ _ a Cone c mors stn0).
     set (com2 := ArbitraryCoproductInCommutes _ _ a Cone c mors stn1).
     set (ar := (ArbitraryCoproductArrow _ _ Cone mors)).
-    refine (tpair _ (tpair _ ar _)  _).
-    intros t; eapply total2_paths.
-    apply proofirrelevance, isapropdirprod; apply hs.
 
-    Unshelve.
+    use (subtypeEquality'' ar); simpl.
 
     (* Commutativity *)
     split.
-    rewrite <- (pair_to_stn2_mors_1 c a f g). apply com1.
-    rewrite <- (pair_to_stn2_mors_2 c a f g). apply com2.
+    apply com1.
+    apply com2.
+
+    (* Equality on equalities of morphisms *)
+    intros y. apply isapropdirprod; apply hs.
 
     (* Uniqueness *)
-    eapply ArbitraryCoproductArrowUnique. intros i. induction (stn2ind i).
-    rewrite a0. fold in1. rewrite <- (pair_to_stn2_mors_1 c a f g).
-    apply (dirprod_pr1 (pr2 t)).
-    rewrite b. fold in2. rewrite <- (pair_to_stn2_mors_2 c a f g).
-    apply (dirprod_pr2 (pr2 t)).
+    intros y X. apply ArbitraryCoproductArrowUnique.
+    intros i. induction (stn2ind i).
+    rewrite a0. apply (dirprod_pr1 X).
+    rewrite b. apply (dirprod_pr2 X).
   Defined.
 
   (** Construction of an arbitrary coproduct from a coproduct. *)
@@ -633,32 +618,30 @@ Section Coproducts_ArbitraryCoproducts.
     set (in2 := CoproductIn2 _ Cone).
     set (ConeOb := CoproductObject _ Cone).
     set (f := pair_to_stn2_mors ConeOb a in1 in2).
+
     refine (mk_ArbitraryCoproductCocone _ _ a ConeOb f _ ).
     refine (mk_isArbitraryCoproductCocone _ _ hs _ _ _ _).
     intros c g.
+
     set (f1 := g stn0).
     set (f2 := g stn1).
     set (ar := CoproductArrow _ Cone f1 f2).
     set (com1 := CoproductIn1Commutes _ _ _ Cone _ f1 f2).
     set (com2 := CoproductIn2Commutes _ _ _ Cone _ f1 f2).
-    refine (tpair _ (tpair _ ar _ ) _).
-    intros t. eapply total2_paths. apply proofirrelevance.
-    apply impred_isaprop. intros t0. apply hs.
 
-    Unshelve.
+    use (subtypeEquality'' ar); simpl.
+
     (* Commutativity *)
     intros i. induction (stn2ind i).
-    rewrite a0. unfold f. rewrite (pair_to_stn2_mors_1 ConeOb a in1 in2).
-    apply com1.
-    rewrite b. unfold f. rewrite (pair_to_stn2_mors_2 ConeOb a in1 in2).
-    apply com2.
+    rewrite a0. apply com1.
+    rewrite b. apply com2.
+
+    (* Equality on equalities of morphisms *)
+    intros y. apply impred_isaprop. intros t. apply hs.
 
     (* Uniqueness *)
-    apply CoproductArrowUnique.
-    fold in1. rewrite <- (pair_to_stn2_mors_1 ConeOb a in1 in2). fold f.
-    apply (pr2 t stn0).
-    fold in2. rewrite <- (pair_to_stn2_mors_2 ConeOb a in1 in2). fold f.
-    apply (pr2 t stn1).
+    intros y X. apply CoproductArrowUnique.
+    apply (X stn0). apply (X stn1).
   Defined.
 End Coproducts_ArbitraryCoproducts.
 
@@ -669,23 +652,17 @@ Section coproduct_from_coproducts.
   Variable C : precategory.
   Hypothesis hs : has_homsets C.
 
-  (** Disjoint union of the objects a1 and a2. *)
-  Definition coprod_families {I1 I2 : UU} (a1 : I1 -> C) (a2 : I2 -> C):
-    I1 ⨿ I2 -> C.
+  (** Sum of two families of morphisms a1 and a2 with a common target. *)
+  Definition sumofmorsfrom :
+    forall (c : C) (I1 I2 : UU) (a1 : I1 -> C) (a2 : I2 -> C)
+      (m1 : forall i1 : I1, C⟦a1 i1, c⟧) (m2 : forall i2 : I2, C⟦a2 i2, c⟧),
+    forall i : I1 ⨿ I2, C⟦(sumofmaps a1 a2) i, c⟧.
   Proof.
-    intros X.
-    induction X.
-    apply (a1 a).
-    apply (a2 b).
+    intros c I1 I2 a1 a2 m1 m2 i. unfold sumofmaps.
+    induction i.
+    exact (m1 a).
+    exact (m2 b).
   Defined.
-
-  (** Verify that we have the same objects. *)
-  Lemma coprod_families_1 {I1 I2 : UU} (a1 : I1 -> C) (a2 : I2 -> C) (i : I1):
-    coprod_families a1 a2 (ii1 i) = a1 i.
-  Proof. apply idpath. Defined.
-  Lemma coprod_families_2 {I1 I2 : UU} (a1 : I1 -> C) (a2 : I2 -> C) (i : I2):
-    coprod_families a1 a2 (ii2 i) = a2 i.
-  Proof. apply idpath. Defined.
 
   (** Construction of an arbitrary coproduct from two arbitrary coproducts and a
     coproduct of the two arbitrary coproducts. *)
@@ -695,7 +672,7 @@ Section coproduct_from_coproducts.
       (A2 : ArbitraryCoproductCocone _ C a2)
       (Cone : CoproductCocone C (ArbitraryCoproductObject _ _ A1)
                               (ArbitraryCoproductObject _ _ A2)),
-      ArbitraryCoproductCocone _ C (coprod_families a1 a2).
+      ArbitraryCoproductCocone _ C (sumofmaps a1 a2).
   Proof.
     intros I1 I2 a1 a2 A1 A2 Cone.
 
@@ -704,10 +681,13 @@ Section coproduct_from_coproducts.
     set (A2in := ArbitraryCoproductIn _ _ A2).
     set (in1 := CoproductIn1 _ Cone).
     set (in2 := CoproductIn2 _ Cone).
+    set (m1 := fun i1 : I1 => (A1in i1) ;; in1).
+    set (m2 := fun i2 : I2 => (A2in i2) ;; in2).
+    set (ConeOb := CoproductObject _ Cone).
 
-    eapply (mk_ArbitraryCoproductCocone _ _ _ (CoproductObject _ Cone)).
-    eapply mk_isArbitraryCoproductCocone.
-    apply hs.
+    refine (mk_ArbitraryCoproductCocone
+              _ _ _ ConeOb (sumofmorsfrom ConeOb _ _ _ _ m1 m2) _).
+    refine (mk_isArbitraryCoproductCocone _ _ hs _ _ _ _).
     intros c g.
 
     (* Set names for useful terms *)
@@ -719,42 +699,32 @@ Section coproduct_from_coproducts.
     set (com1 := CoproductIn1Commutes _ _ _ Cone c ar1 ar2).
     set (com2 := CoproductIn2Commutes _ _ _ Cone c ar1 ar2).
 
-    refine (tpair _ _ _).
-    intros t.
-    eapply total2_paths. apply proofirrelevance.
-    apply impred_isaprop. intros t0. apply hs.
+    use (subtypeEquality'' ar); simpl.
 
-    Unshelve.
-
-    (* Morphisms from objects to the cone *)
-    intros i. unfold coprod_families, coprod_rect. induction i.
-    apply (A1in a ;; in1).
-    apply (A2in b ;; in2).
-
-    (* The unique arrow from the cone to c *)
-    refine (tpair _ ar _ ).
-
-    (* Commutativity of morphisms *)
-    intros i. unfold coprod_rect. induction i.
+    (* Commutativity *)
+    intros i. unfold sumofmorsfrom, coprod_rect. induction i.
 
     set (com'1 := ArbitraryCoproductInCommutes _ _ _ A1 c g1 a).
-    unfold A1in. unfold in1. unfold ar. rewrite <- assoc. rewrite com1.
-    unfold ar1. rewrite -> com'1. apply idpath.
-
+    unfold m1, ar, A1in, in1. rewrite <- assoc. rewrite com1.
+    unfold ar1. rewrite com'1. apply idpath.
 
     set (com'2 := ArbitraryCoproductInCommutes _ _ _ A2 c g2 b).
-    unfold A2in, in2, ar. rewrite <- assoc. rewrite com2.
+    unfold m2, ar, A2in, in2. rewrite <- assoc. rewrite com2.
     unfold ar2. rewrite com'2. apply idpath.
 
-    simpl.
+    (* Equality on equalities of morphisms. *)
+    intros y. apply impred_isaprop. intros t0. apply hs.
+
     (* Uniqueness of the morphism from the cone *)
-    eapply CoproductArrowUnique.
-    eapply ArbitraryCoproductArrowUnique.
-    intros i. simpl in t. set (t2 := pr2 t (ii1 i)). simpl in t2.
+    intros y X. apply CoproductArrowUnique.
+    apply ArbitraryCoproductArrowUnique.
+    intros i. unfold sumofmorsfrom, coprod_rect in X.
+    set (t2 := X (ii1 i)). simpl in t2.
     fold A1in. rewrite assoc. apply t2.
 
-    eapply ArbitraryCoproductArrowUnique.
-    intros i. simpl in t. set (t2 := pr2 t (ii2 i)). simpl in t2.
+    apply ArbitraryCoproductArrowUnique.
+    intros i. unfold sumofmorsfrom, coprod_rect in X.
+    set (t2 := X (ii2 i)). simpl in t2.
     fold A2in. rewrite assoc. apply t2.
   Defined.
 End coproduct_from_coproducts.

--- a/UniMath/CategoryTheory/limits/finite_coproducts.v
+++ b/UniMath/CategoryTheory/limits/finite_coproducts.v
@@ -1,0 +1,103 @@
+(** A direct definition of finite coproducts by using arbitrary coproducts *)
+
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.Foundations.Combinatorics.StandardFiniteSets.
+
+Require Import UniMath.CategoryTheory.total2_paths.
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.ProductPrecategory.
+Require Import UniMath.CategoryTheory.limits.arbitrary_coproducts.
+Require Import UniMath.CategoryTheory.limits.coproducts.
+Require Import UniMath.CategoryTheory.limits.initial.
+
+(** Definition of finite coproduct. *)
+Section finite_coproduct_def.
+
+  Variable C : precategory.
+
+  Definition FinCoproducts :=
+    forall (n : nat) (a : stn n -> C), ArbitraryCoproductCocone (stn n) C a.
+  Definition hasFinCoproducts := ishinh FinCoproducts.
+
+End finite_coproduct_def.
+
+(** In the following section we prove that initial object and coproducts imply
+  finite coproducts. *)
+Section finite_coproduct_criteria.
+  Variable C : precategory.
+  Hypothesis hs : has_homsets C.
+
+  (* Couldn't find the following elsewhere. *)
+  Definition unit_to_ob (c : C) : unit -> C := fun tt : unit => c.
+
+  (** This results is used in the induction step of the proof of the criteria.
+    It says that for any object of C we can construct an arbitrary coproduct of
+    1 object from it. *)
+  Lemma identity_to_arbitrary_coproduct (c : C) :
+    ArbitraryCoproductCocone unit C (unit_to_ob c).
+  Proof.
+    refine (mk_ArbitraryCoproductCocone _ _ _ c (fun tt : unit => identity _) _).
+    refine (mk_isArbitraryCoproductCocone _ _ hs _ _ _ _).
+    intros c0 g.
+
+    use (subtypeEquality'' (g tt)); simpl.
+    intros i. apply remove_id_left. apply idpath.
+    apply maponpaths, isconnectedunit.
+
+    (* Equality of equalities of morphisms *)
+    intros y. apply impred_isaprop. intros t. apply hs.
+
+    (* Uniqueness *)
+    intros y X. rewrite <- (X tt). apply pathsinv0.
+    apply remove_id_left; apply idpath.
+  Defined.
+
+  (** In this Theorem we prove that finite coproducts can be constructed from
+    initial and coproducts. The result is proved by induction on the number of
+    objects in the finite coproduct. *)
+  Theorem fin_coproduct_from_initial_and_coproducts :
+    Initial C -> Coproducts C -> FinCoproducts C.
+  Proof.
+    intros I Coprods. unfold FinCoproducts. intros n. induction n.
+
+    (* Case n = 0 follows from the fact that empty coproduct can be
+       constructed from initial. *)
+    rewrite (UnivalenceAxiom.weqtopaths (weqstn0toempty)).
+    set (e := iscontrfunfromempty C).
+    intros a; assert (H : a = fromempty).
+    apply (@pathscomp0  _ _ (pr1 e) _).
+    apply ((pr2 e) a). apply pathsinv0. apply ((pr2 e) fromempty).
+    rewrite H.
+    apply (empty_coproduct_from_initial _ hs I).
+
+    (* The general case uses the result that from two arbitrary coproducts,
+       such that the coproduct of these exists, we can construct a new
+       arbitrary coproduct. *)
+    rewrite <- (UnivalenceAxiom.weqtopaths (weqdnicoprod _ (lastelement n))).
+    intros a.
+
+    (* Some useful terms *)
+    set (A1Cocone := IHn (a ∘ (@ii1 (stn n) unit))).
+    set (A2Cocone := identity_to_arbitrary_coproduct (a(ii2 tt))).
+    set (CoprodCocone := Coprods (ArbitraryCoproductObject (stn n) C A1Cocone)
+                       (ArbitraryCoproductObject unit C A2Cocone)).
+    set (ACocone := arbitrary_coproduct_from_arbitrary_coproducts
+                    _ hs (stn n) unit _ _ A1Cocone A2Cocone CoprodCocone).
+
+    (* We show that the goal follows from ACocone by showing that the associated
+       families of objects are homotopic, hence equal by Univalence. *)
+    assert (H : homot a (sumofmaps (a ∘ ii1 (B:=unit))
+                                   (unit_to_ob (a (ii2 tt))))).
+    intros i. induction i. apply idpath.
+    unfold sumofmaps, unit_to_ob, coprod_rect.
+    apply maponpaths, maponpaths. apply isconnectedunit.
+    unfold homot in H. apply UnivalenceAxiom.funextfun in H.
+    rewrite <- H in ACocone.
+    exact ACocone.
+  Defined.
+
+End finite_coproduct_criteria.

--- a/UniMath/CategoryTheory/limits/finite_products.v
+++ b/UniMath/CategoryTheory/limits/finite_products.v
@@ -1,0 +1,103 @@
+(** A direct definition of finite products by using arbitrary products *)
+
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.Foundations.Combinatorics.StandardFiniteSets.
+
+Require Import UniMath.CategoryTheory.total2_paths.
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.ProductPrecategory.
+Require Import UniMath.CategoryTheory.limits.arbitrary_products.
+Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.limits.terminal.
+
+(** Definition of finite coproduct. *)
+Section finite_product_def.
+
+  Variable C : precategory.
+
+  Definition FinProducts :=
+    forall (n : nat) (a : stn n -> C), ArbitraryProductCone (stn n) C a.
+  Definition hasFinProducts := ishinh FinProducts.
+
+End finite_product_def.
+
+(** In the following section we prove that initial object and products imply
+  finite products. *)
+Section finite_product_criteria.
+  Variable C : precategory.
+  Hypothesis hs : has_homsets C.
+
+  (* Couldn't find the following elsewhere. *)
+  Definition unit_to_ob (c : C) : unit -> C := fun tt : unit => c.
+
+  (** This result is used in the induction step of the proof of the criteria. It
+    says that for any object of C we can construct an arbitrary product of
+    1 object from it. *)
+  Lemma identity_to_arbitrary_product (c : C) :
+    ArbitraryProductCone unit C (unit_to_ob c).
+  Proof.
+    refine (mk_ArbitraryProductCone _ _ _ c (fun tt : unit => identity _) _).
+    refine (mk_isArbitraryProductCone _ _ hs _ _ _ _).
+    intros c0 g.
+
+    use (subtypeEquality'' (g tt)); simpl.
+    intros i. apply remove_id_right. apply idpath.
+    apply maponpaths, isconnectedunit.
+
+    (* Equality on equalities of morphisms *)
+    intros y. apply impred_isaprop. intros t. apply hs.
+
+    (* Uniqueness *)
+    intros y X. rewrite <- (X tt). apply pathsinv0.
+    apply remove_id_right; apply idpath.
+  Defined.
+
+  (** In this Theorem we prove that finite products can be constructed from
+    initial and products. The result is proved by induction on the number of
+    objects in the finite product. *)
+  Theorem fin_product_from_terminal_and_products :
+    Terminal C -> Products C -> FinProducts C.
+  Proof.
+    intros I Prods. unfold FinProducts. intros n. induction n.
+
+    (* Case n = 0 follows from the fact that empty product can be
+       constructed from terminal. *)
+    rewrite (UnivalenceAxiom.weqtopaths (weqstn0toempty)).
+    set (e := iscontrfunfromempty C).
+    intros a; assert (H : a = fromempty).
+    apply (@pathscomp0  _ _ (pr1 e) _).
+    apply ((pr2 e) a). apply pathsinv0. apply ((pr2 e) fromempty).
+    rewrite H.
+    apply (empty_product_from_terminal _ hs I).
+
+    (* The general case uses the result that from two arbitrary products,
+       such that the product of these exists, we can construct a new
+       arbitrary product. *)
+    rewrite <- (UnivalenceAxiom.weqtopaths (weqdnicoprod _ (lastelement n))).
+    intros a.
+
+    (* Some useful terms *)
+    set (A1Cone := IHn (a ∘ (@ii1 (stn n) unit))).
+    set (A2Cone := identity_to_arbitrary_product (a(ii2 tt))).
+    set (ProdCone := Prods (ArbitraryProductObject (stn n) C A1Cone)
+                       (ArbitraryProductObject unit C A2Cone)).
+    set (ACone := arbitrary_product_from_arbitrary_products
+                    _ hs (stn n) unit _ _ A1Cone A2Cone ProdCone).
+
+    (* We show that the goal follows from ACone by showing that the associated
+       families of objects are homotopic, hence equal by Univalence. *)
+    assert (H : homot a (sumofmaps (a ∘ ii1 (B:=unit))
+                                   (unit_to_ob (a (ii2 tt))))).
+    intros i. induction i. apply idpath.
+    unfold sumofmaps, unit_to_ob, coprod_rect.
+    apply maponpaths, maponpaths. apply isconnectedunit.
+    unfold homot in H. apply UnivalenceAxiom.funextfun in H.
+    rewrite <- H in ACone.
+    exact ACone.
+  Defined.
+
+End finite_product_criteria.

--- a/UniMath/CategoryTheory/limits/products.v
+++ b/UniMath/CategoryTheory/limits/products.v
@@ -234,12 +234,6 @@ Section Products_ArbitraryProducts.
     exact c2.
   Defined.
 
-  (** The following lemmas verify that the above definition is correct.*)
-  Lemma pair_to_stn2_1 (c1 c2 : C) : pair_to_stn2 c1 c2 stn0 = c1.
-  Proof. apply idpath. Defined.
-  Lemma pair_to_stn2_2 (c1 c2 : C) : pair_to_stn2 c1 c2 stn1 = c2.
-  Proof. apply idpath. Defined.
-
   (** Construct a family of two morphisms with the same domain from
     two morphisms with the same domain. *)
   Definition pair_to_stn2_mors (c : C) (a : stn 2 -> C) (f : C⟦c, a stn0⟧)
@@ -250,16 +244,6 @@ Section Products_ArbitraryProducts.
     rewrite <- b in g. apply g.
   Defined.
 
-  (** The following lemmas verify that the above definition is correct. *)
-  Lemma pair_to_stn2_mors_1 (c : C) (a : stn 2 -> C) (f : C⟦c, a stn0⟧)
-        (g : C⟦c, a stn1⟧) :
-    pair_to_stn2_mors c a f g stn0 = f.
-  Proof. apply idpath. Defined.
-  Lemma pair_to_stn2_mors_2 (c : C) (a : stn 2 -> C) (f : C⟦c, a stn0⟧)
-        (g : C⟦c, a stn1⟧) :
-    pair_to_stn2_mors c a f g stn1 = g.
-  Proof. apply idpath. Defined.
-
   (** Construction of a product from an arbitrary product. *)
   Definition product_from_arbitrary_product (a : stn 2 -> C)
              (Cone : ArbitraryProductCone (stn 2) C a) :
@@ -268,30 +252,31 @@ Section Products_ArbitraryProducts.
     set (p1 := ArbitraryProductPr _ _ Cone stn0).
     set (p2 := ArbitraryProductPr _ _ Cone stn1).
     set (Coneob := (ArbitraryProductObject _ _ Cone)).
+
     refine (mk_ProductCone _ (a stn0) (a stn1) Coneob p1 p2 _).
     refine (mk_isProductCone _ hs _ _ _ _ _ _).
+
     intros c f g.
     set (mors := pair_to_stn2_mors c a f g).
     set (com1 := ArbitraryProductPrCommutes _ _ a Cone c mors stn0).
     set (com2 := ArbitraryProductPrCommutes _ _ a Cone c mors stn1).
     set (ar := (ArbitraryProductArrow _ _ Cone mors)).
-    refine (tpair _ (tpair _ ar _)  _).
-    intros t; eapply total2_paths.
-    apply proofirrelevance, isapropdirprod; apply hs.
 
-    Unshelve.
+    use (subtypeEquality'' ar); simpl.
 
     (* Commutativity *)
     split.
-    rewrite <- (pair_to_stn2_mors_1 c a f g). apply com1.
-    rewrite <- (pair_to_stn2_mors_2 c a f g). apply com2.
+    apply com1.
+    apply com2.
+
+    (* Equality on equality of morphisms *)
+    intros y. apply isapropdirprod; apply hs.
 
     (* Uniqueness *)
-    eapply ArbitraryProductArrowUnique. intros i. induction (stn2ind i).
-    rewrite a0. fold p1. rewrite <- (pair_to_stn2_mors_1 c a f g).
-    apply (dirprod_pr1 (pr2 t)).
-    rewrite b. fold p2. rewrite <- (pair_to_stn2_mors_2 c a f g).
-    apply (dirprod_pr2 (pr2 t)).
+    intros y X. apply ArbitraryProductArrowUnique.
+    intros i. induction (stn2ind i).
+    rewrite a0. apply (dirprod_pr1 X).
+    rewrite b. apply (dirprod_pr2 X).
   Defined.
 
   (** Construction of an arbitrary product from a product. *)
@@ -304,32 +289,31 @@ Section Products_ArbitraryProducts.
     set (p2 := ProductPr2 _ Cone).
     set (ConeOb := ProductObject _ Cone).
     set (f := pair_to_stn2_mors ConeOb a p1 p2).
+
     refine (mk_ArbitraryProductCone _ _ a ConeOb f _ ).
     refine (mk_isArbitraryProductCone _ _ hs _ _ _ _).
     intros c g.
+
     set (f1 := g stn0).
     set (f2 := g stn1).
     set (ar := ProductArrow _ Cone f1 f2).
     set (com1 := ProductPr1Commutes _ _ _ Cone _ f1 f2).
     set (com2 := ProductPr2Commutes _ _ _ Cone _ f1 f2).
-    refine (tpair _ (tpair _ ar _ ) _).
-    intros t. eapply total2_paths. apply proofirrelevance.
-    apply impred_isaprop. intros t0. apply hs.
 
-    Unshelve.
+    use (subtypeEquality'' ar); simpl.
+
     (* Commutativity *)
     intros i. induction (stn2ind i).
-    rewrite a0. unfold f. rewrite (pair_to_stn2_mors_1 ConeOb a p1 p2).
-    apply com1.
-    rewrite b. unfold f. rewrite (pair_to_stn2_mors_2 ConeOb a p1 p2).
-    apply com2.
+    rewrite a0. apply com1.
+    rewrite b. apply com2.
+
+    (* Equality on morphism equalities *)
+    intros y. apply impred_isaprop. intros t0. apply hs.
 
     (* Uniqueness *)
-    apply ProductArrowUnique.
-    fold p1. rewrite <- (pair_to_stn2_mors_1 ConeOb a p1 p2). fold f.
-    apply (pr2 t stn0).
-    fold p2. rewrite <- (pair_to_stn2_mors_2 ConeOb a p1 p2). fold f.
-    apply (pr2 t stn1).
+    intros y X. apply ProductArrowUnique.
+    apply (X stn0).
+    apply (X stn1).
   Defined.
 End Products_ArbitraryProducts.
 
@@ -340,23 +324,17 @@ Section product_from_products.
   Variable C : precategory.
   Hypothesis hs : has_homsets C.
 
-  (** Disjoint union of the objects a1 and a2. *)
-  Definition coprod_families {I1 I2 : UU} (a1 : I1 -> C) (a2 : I2 -> C):
-    I1 ⨿ I2 -> C.
+  (** Sum of two families of morphisms a1 and a2 with a common domain. *)
+  Definition sumofmorsto :
+    forall (c : C) (I1 I2 : UU) (a1 : I1 -> C) (a2 : I2 -> C)
+      (m1 : forall i1 : I1, C⟦c, a1 i1⟧) (m2 : forall i2 : I2, C⟦c, a2 i2⟧),
+    forall i : I1 ⨿ I2, C⟦c, (sumofmaps a1 a2) i⟧.
   Proof.
-    intros X.
-    induction X.
-    apply (a1 a).
-    apply (a2 b).
+    intros c I1 I2 a1 a2 m1 m2 i. unfold sumofmaps.
+    induction i.
+    exact (m1 a).
+    exact (m2 b).
   Defined.
-
-  (** Verify that we have the same objects. *)
-  Lemma coprod_families_1 {I1 I2 : UU} (a1 : I1 -> C) (a2 : I2 -> C) (i : I1):
-    coprod_families a1 a2 (ii1 i) = a1 i.
-  Proof. apply idpath. Defined.
-  Lemma coprod_families_2 {I1 I2 : UU} (a1 : I1 -> C) (a2 : I2 -> C) (i : I2):
-    coprod_families a1 a2 (ii2 i) = a2 i.
-  Proof. apply idpath. Defined.
 
 
   (** Construction of an arbitrary coproduct from two arbitrary coproducts and a
@@ -367,7 +345,7 @@ Section product_from_products.
       (A2 : ArbitraryProductCone _ C a2)
       (Cone : ProductCone C (ArbitraryProductObject _ _ A1)
                           (ArbitraryProductObject _ _ A2)),
-      ArbitraryProductCone _ C (coprod_families a1 a2).
+      ArbitraryProductCone _ C (sumofmaps a1 a2).
   Proof.
     intros I1 I2 a1 a2 A1 A2 Cone.
 
@@ -376,10 +354,13 @@ Section product_from_products.
     set (A2pr := ArbitraryProductPr _ _ A2).
     set (p1 := ProductPr1 _ Cone).
     set (p2 := ProductPr2 _ Cone).
+    set (m1 := fun i1 : I1 => p1 ;; (A1pr i1)).
+    set (m2 := fun i2 : I2 => p2 ;; (A2pr i2)).
+    set (ConeOb := ProductObject _ Cone).
 
-    eapply (mk_ArbitraryProductCone _ _ _ (ProductObject _ Cone)).
-    eapply mk_isArbitraryProductCone.
-    apply hs.
+    refine (mk_ArbitraryProductCone
+              _ _ _ ConeOb (sumofmorsto ConeOb _ _ _ _ m1 m2) _).
+    refine (mk_isArbitraryProductCone _ _ hs _ _ _ _).
     intros c g.
 
     (* Set names for useful terms *)
@@ -391,42 +372,32 @@ Section product_from_products.
     set (com1 := ProductPr1Commutes _ _ _ Cone c ar1 ar2).
     set (com2 := ProductPr2Commutes _ _ _ Cone c ar1 ar2).
 
-    refine (tpair _ _ _).
-    intros t.
-    eapply total2_paths. apply proofirrelevance.
-    apply impred_isaprop. intros t0. apply hs.
-
-    Unshelve.
-
-    (* Morphisms to objects from the cone *)
-    intros i. unfold coprod_families, coprod_rect. induction i.
-    apply (p1 ;; A1pr a).
-    apply (p2 ;; A2pr b).
-
-    (* The unique arrow to the cone from c *)
-    refine (tpair _ ar _ ).
+    use (subtypeEquality'' ar); simpl.
 
     (* Commutativity of morphisms *)
-    intros i. unfold coprod_rect. induction i.
+    intros i. unfold sumofmorsto, coprod_rect. induction i.
 
     set (com'1 := ArbitraryProductPrCommutes _ _ _ A1 c g1 a).
-    unfold A1pr. unfold p1. unfold ar. rewrite assoc. rewrite com1.
+    unfold ar, m1. rewrite assoc. unfold p1, A1pr. rewrite com1.
     unfold ar1. rewrite -> com'1. apply idpath.
 
-
     set (com'2 := ArbitraryProductPrCommutes _ _ _ A2 c g2 b).
-    unfold A2pr, p2, ar. rewrite assoc. rewrite com2.
+    unfold ar, m2. rewrite assoc. unfold p2, A2pr. rewrite com2.
     unfold ar2. rewrite com'2. apply idpath.
 
-    simpl.
+    (* Equality of equality of morphisms *)
+    intros y. apply impred_isaprop. intros t0. apply hs.
+
     (* Uniqueness of the morphism to the cone *)
-    eapply ProductArrowUnique.
-    eapply ArbitraryProductArrowUnique.
-    intros i. simpl in t. set (t2 := pr2 t (ii1 i)). simpl in t2.
+    intros y X. apply ProductArrowUnique.
+    apply ArbitraryProductArrowUnique.
+    intros i. unfold sumofmorsto, coprod_rect in X.
+    set (t2 := X (ii1 i)). simpl in t2.
     fold A1pr. rewrite <- assoc. apply t2.
 
-    eapply ArbitraryProductArrowUnique.
-    intros i. simpl in t. set (t2 := pr2 t (ii2 i)). simpl in t2.
+    apply ArbitraryProductArrowUnique.
+    intros i. unfold sumofmorsto, coprod_rect in X.
+    set (t2 := X (ii2 i)). simpl in t2.
     fold A2pr. rewrite <- assoc. apply t2.
   Defined.
 End product_from_products.

--- a/UniMath/Foundations/Basics/PartB.v
+++ b/UniMath/Foundations/Basics/PartB.v
@@ -469,6 +469,20 @@ Corollary subtypeEquality' {A : UU} {B : A -> UU}
 (* This variant of subtypeEquality is not often needed. *)
 Proof. intros ? ? ? ? e is. apply (total2_paths e). apply is. Defined.
 
+(* This variant is used for categories. *)
+Corollary subtypeEquality'' {A : UU} {B : A -> UU} (x : A) (b : B x)
+          (h : forall y, isaprop (B y)) (H : forall y, B y -> y = x) :
+  iscontr (total2 (fun t : A => B t)).
+Proof.
+  intros A B x b h H.
+  use iscontrpair.
+  exact (x,,b).
+  intros t.
+  apply subtypeEquality'.
+  simpl. apply (H (pr1 t)). apply (pr2 t).
+  apply (h (pr1 (x,,b))).
+Defined.
+
 Definition subtypePairEquality {X} {P:X -> UU} (is: isPredicate P)
            {x y:X} {p:P x} {q:P y} :
   x = y -> (x,,p) = (y,,q).


### PR DESCRIPTION
Hi Benedikt and others.

I managed to formalize the following results about arbitrary (co)products:
- Construction of an arbitrary (co)product from two arbitrary (co)products and
  the assumption that we have a (co)product of the two arbitrary (co)products.
- Construction of a (co)product from an arbitrary (co)product of two elements
  and vice versa.
  
* In the proofs I have used eapply and Unshelve. Should I try to remove
  these?
* Are there other things I should do to the proofs?

To prove these, I needed some general results which should probably be moved
into some other files.
- The lemmas and definitions with name "coprod_families*" are both in the
  files coproduct.v and product.v. Are these kind of definitions and lemmas
  already done somewhere? If not, where one should move these? Should these
  be renamed?
- In product.v and coproduct.c I have the "tworec", "stn2ind", and
  "pair_to_stn2*". Where one should move these? Should these be renamed?
