### PR TITLE
Monics, epis, (co)equalizers, and (co)kernels

### DIFF
--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -56,3 +56,9 @@ trees.v
 exponentials.v
 covyoneda.v
 lambdacalculus.v
+Monics.v
+Epis.v
+limits/equalizers.v
+limits/coequalizers.v
+limits/kernels.v
+limits/cokernels.v

--- a/UniMath/CategoryTheory/Epis.v
+++ b/UniMath/CategoryTheory/Epis.v
@@ -1,0 +1,84 @@
+(* Definition of epi *)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+
+Section def_epi.
+
+  Variable C : precategory.
+
+  (** Definition and construction of isEpi. *)
+  Definition isEpi {x y : C} (f : x --> y) :=
+    forall (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h.
+  Definition mk_isEpi {x y : C} (f : x --> y) :
+    (forall (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h) -> isEpi f.
+  Proof. intros X. unfold isEpi. apply X.  Defined.
+
+  (** Definition and construction of Epi. *)
+  Definition Epi (x y : C) := Σ f : x --> y, isEpi f.
+  Definition mk_Epi {x y : C} (f : x --> y) (H : isEpi f) : Epi x y.
+  Proof. apply (tpair _ f H). Defined.
+
+  (** Gets the arrow out of Epi. *)
+  Definition EpiArrow {x y : C} (M : Epi x y) := pr1 M.
+
+  (** Identity to isEpi and Epi. *)
+  Lemma id_isEpi {x : C} : isEpi (identity x).
+  Proof.
+    apply mk_isEpi.
+    intros z g h H.
+    rewrite <- id_left; apply pathsinv0; rewrite <- id_left; apply pathsinv0.
+    exact H.
+  Defined.
+
+  Lemma id_Epi {x : C} : Epi x x.
+  Proof. exact (tpair _ (identity x) (id_isEpi)). Defined.
+
+  (** Isomorphism to isEpi and Epi. *)
+  Lemma iso_isEpi {x y : C} (f : x --> y) (H : is_iso f) : isEpi f.
+  Proof.
+    apply mk_isEpi.
+    intros z g h X.
+    apply (pre_comp_with_iso_is_inj _ x _ _ f H).
+    exact X.
+  Defined.
+
+  Lemma iso_Epi {x y : C} (f : x --> y) (H : is_iso f) : Epi x y.
+  Proof. apply (mk_Epi f (iso_isEpi f H)). Defined.
+
+  (** Composition of isEpis and Epis. *)
+  Definition isEpi_comp {x y z : C} (f : x --> y) (g : y --> z) :
+    isEpi f -> isEpi g -> isEpi (f ;; g).
+  Proof.
+    intros X X0. unfold isEpi. intros z0 g0 h X1.
+    repeat rewrite <- assoc in X1. apply X in X1. apply X0 in X1. apply X1.
+  Defined.
+
+  Definition Epi_comp {x y z : C} (M1 : Epi x y) (M2 : Epi y z) :
+    Epi x z := tpair _ (EpiArrow M1 ;; EpiArrow M2)
+                       (isEpi_comp (EpiArrow M1) (EpiArrow M2)
+                                     (pr2 M1) (pr2 M2)).
+
+  (* This general result should be moved somewhere? *)
+  Lemma precomp_with_eq {x y z : C} {f g : y --> z} (h : x --> y) :
+    f = g -> h ;; f = h ;; g.
+  Proof.
+    intros X.
+    rewrite X.
+    apply idpath.
+  Defined.
+
+  (** If precomposition of g with f is an epi, then g is an epi. *)
+  Definition isEpi_precomp {x y z : C} (f : x --> y) (g : y --> z) :
+    isEpi (f ;; g) -> isEpi g.
+  Proof.
+    intros X. intros w φ ψ H.
+    apply (precomp_with_eq f) in H.
+    repeat rewrite assoc in H.
+    apply (X w _ _ H).
+  Defined.
+
+End def_epi.

--- a/UniMath/CategoryTheory/Epis.v
+++ b/UniMath/CategoryTheory/Epis.v
@@ -43,7 +43,7 @@ Section def_epi.
   Proof. apply (iso_isEpi (identity x) (identity_is_iso _ x)). Defined.
 
   Lemma identity_Epi {x : C} : Epi x x.
-  Proof. exact (tpair _ (identity x) (id_isEpi)). Defined.
+  Proof. exact (tpair _ (identity x) (identity_isEpi)). Defined.
 
   (** Composition of isEpis and Epis. *)
   Definition isEpi_comp {x y z : C} (f : x --> y) (g : y --> z) :

--- a/UniMath/CategoryTheory/Monics.v
+++ b/UniMath/CategoryTheory/Monics.v
@@ -1,0 +1,84 @@
+(* Definition of monic *)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+
+Section def_monic.
+
+  Variable C : precategory.
+
+  (** Definition and construction of isMonic. *)
+  Definition isMonic {y z : C} (f : y --> z) :=
+    forall (x : C) (g h : x --> y), g ;; f = h ;; f -> g = h.
+  Definition mk_isMonic {y z : C} (f : y --> z) :
+    (forall (x : C) (g h : x --> y), g ;; f = h ;; f -> g = h) -> isMonic f.
+  Proof. intros X. unfold isMonic. apply X.  Defined.
+
+  (** Definition and construction of Monic. *)
+  Definition Monic (y z : C) := Σ f : y --> z, isMonic f.
+  Definition mk_Monic {y z : C} (f : y --> z) (H : isMonic f) : Monic y z.
+  Proof. apply (tpair _ f H). Defined.
+
+  (** Gets the arrow out of Monic. *)
+  Definition MonicArrow {y z : C} (M : Monic y z) := pr1 M.
+
+  (** Identity to isMonic and Monic. *)
+  Lemma identity_isMonic {x : C} : isMonic (identity x).
+  Proof.
+    apply mk_isMonic.
+    intros z g h H.
+    rewrite <- id_right; apply pathsinv0; rewrite <- id_right; apply pathsinv0.
+    exact H.
+  Defined.
+
+  Lemma identity_Monic {x : C} : Monic x x.
+  Proof. exact (tpair _ (identity x) (identity_isMonic)). Defined.
+
+  (** Isomorphism to isMonic and Monic. *)
+  Lemma iso_isMonic {y x : C} (f : y --> x) (H : is_iso f) : isMonic f.
+  Proof.
+    apply mk_isMonic.
+    intros z g h X.
+    apply (post_comp_with_iso_is_inj _ y _ f H).
+    exact X.
+  Defined.
+
+  Lemma iso_Monic {y x : C} (f : y --> x) (H : is_iso f) : Monic y x.
+  Proof. apply (mk_Monic f (iso_isMonic f H)). Defined.
+
+  (** Composition of isMonics and Monics. *)
+  Definition isMonic_comp {x y z : C} (f : x --> y) (g : y --> z) :
+    isMonic f -> isMonic g -> isMonic (f ;; g).
+  Proof.
+    intros X X0. apply mk_isMonic. intros x0 g0 h X1.
+    repeat rewrite assoc in X1. apply X0 in X1. apply X in X1. apply X1.
+  Defined.
+
+  Definition Monic_comp {x y z : C} (M1 : Monic x y) (M2 : Monic y z) :
+    Monic x z := tpair _ (MonicArrow M1 ;; MonicArrow M2)
+                       (isMonic_comp (MonicArrow M1) (MonicArrow M2)
+                                     (pr2 M1) (pr2 M2)).
+
+  (* This general result should be moved somewhere? *)
+  Lemma postcomp_with_eq {x y z : C} {f g : x --> y} (h : y --> z) :
+    f = g -> f ;; h = g ;; h.
+  Proof.
+    intros X.
+    rewrite X.
+    apply idpath.
+  Defined.
+
+  (** If precomposition of g with f is a monic, then f is a monic. *)
+  Definition isMonic_postcomp {x y z : C} (f : x --> y) (g : y --> z) :
+    isMonic (f ;; g) -> isMonic f.
+  Proof.
+    intros X. intros w φ ψ H.
+    apply (postcomp_with_eq g) in H.
+    repeat rewrite <- assoc in H.
+    apply (X w _ _ H).
+  Defined.
+
+End def_monic.

--- a/UniMath/CategoryTheory/limits/coequalizers.v
+++ b/UniMath/CategoryTheory/limits/coequalizers.v
@@ -1,0 +1,194 @@
+(* Direct implementation of coequalizers. *)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.Epis.
+
+Section def_coequalizers.
+
+  Context {C : precategory}.
+
+  (** Definition and construction of isCoequalizer. *)
+  Definition isCoequalizer {x y z : C} (f g : x --> y) (e : y --> z)
+             (H : f ;; e = g ;; e) : UU :=
+    forall (w : C) (h : y --> w) (H : f ;; h = g ;; h),
+      iscontr (Σ φ : z --> w, e ;; φ  = h).
+
+  Definition mk_isCoequalizer {y z w : C} (f g : y --> z) (e : z --> w)
+             (H : f ;; e = g ;; e) :
+    (forall (w0 : C) (h : z --> w0) (H' : f ;; h = g ;; h),
+        iscontr (Σ ψ : w --> w0, e ;; ψ = h)) -> isCoequalizer f g e H.
+  Proof.
+    intros X. unfold isCoequalizer. exact X.
+  Defined.
+
+  Lemma isaprop_isCoequalizer {y z w : C} (f g : y --> z) (e : z --> w)
+        (H : f ;; e = g ;; e) :
+    isaprop (isCoequalizer f g e H).
+  Proof.
+    repeat (apply impred; intro).
+    apply isapropiscontr.
+  Defined.
+
+  (** Proves that the arrow from the coequalizer object with the right
+    commutativity property is unique. *)
+  Lemma isCoequalizerOutUnique {y z w: C} (f g : y --> z) (e : z --> w)
+        (H : f ;; e = g ;; e) (E : isCoequalizer f g e H)
+        (w0 : C) (h : z --> w0) (H' : f ;; h = g ;; h)
+        (φ : w --> w0) (H'' : e ;; φ = h) :
+    φ = (pr1 (pr1 (E w0 h H'))).
+  Proof.
+    set (T := tpair (fun ψ : w --> w0 => e ;; ψ = h) φ H'').
+    set (T' := pr2 (E w0 h H') T).
+    apply (base_paths _ _ T').
+  Defined.
+
+  (** Definition and construction of coequalizers. *)
+  Definition Coequalizer {y z : C} (f g : y --> z) :=
+    Σ e : (Σ w : C, z --> w),
+          (Σ H : f ;; (pr2 e) = g ;; (pr2 e), isCoequalizer f g (pr2 e) H).
+
+  Definition mk_Coequalizer {y z w : C} (f g : y --> z) (e : z --> w)
+             (H : f ;; e = g ;; e) (isE : isCoequalizer f g e H) :
+    Coequalizer f g.
+  Proof.
+    simple refine (tpair _ _ _).
+    - simple refine (tpair _ _ _).
+      + apply w.
+      + apply e.
+    - simpl. refine (tpair _ H isE).
+  Defined.
+
+  (** Coequalizers in precategories. *)
+  Definition Coequalizers := forall (y z : C) (f g : y --> z),
+      Coequalizer f g.
+
+  Definition hasCoequalizers := forall (y z : C) (f g : y --> z),
+      ishinh (Coequalizer f g).
+
+  (** Returns the coequalizer object. *)
+  Definition CoequalizerObject {y z : C} {f g : y --> z} (E : Coequalizer f g) : C
+    := pr1 (pr1 E).
+  Coercion CoequalizerObject : Coequalizer >-> ob.
+
+  (** Returns the coequalizer arrow. *)
+  Definition CoequalizerArrow {y z : C} {f g : y --> z} (E : Coequalizer f g) :
+    C⟦z, E⟧ := pr2 (pr1 E).
+
+  (** The equality on morphisms that coequalizers must satisfy. *)
+  Definition CoequalizerEqAr {y z : C} {f g : y --> z} (E : Coequalizer f g) :
+    f ;; CoequalizerArrow E = g ;; CoequalizerArrow E := pr1 (pr2 E).
+
+  (** Returns the property isCoequalizer from Coequalizer. *)
+  Definition isCoequalizer_Coequalizer {y z : C} {f g : y --> z}
+             (E : Coequalizer f g) :
+    isCoequalizer f g (CoequalizerArrow E) (CoequalizerEqAr E) := pr2 (pr2 E).
+
+  (** Every morphism which satisfy the coequalizer equality on morphism factors
+    uniquely through the CoequalizerArrow. *)
+  Definition CoequalizerOut {y z : C} {f g : y --> z} (E : Coequalizer f g)
+             (w : C) (h : z --> w) (H : f ;; h = g ;; h) :
+    C⟦E, w⟧ := pr1 (pr1 (isCoequalizer_Coequalizer E w h H)).
+
+  Lemma CoequalizerCommutes {y z : C} {f g : y --> z} (E : Coequalizer f g)
+        (w : C) (h : z --> w) (H : f ;; h = g ;; h) :
+    (CoequalizerArrow E) ;; (CoequalizerOut E w h H) = h.
+  Proof.
+    exact (pr2 (pr1 ((isCoequalizer_Coequalizer E) w h H))).
+  Defined.
+
+  Lemma isCoequalizerOutsEq {y z w: C} {f g : y --> z} {e : z --> w}
+        {H : f ;; e = g ;; e} (E : isCoequalizer f g e H)
+        {w0 : C} (φ1 φ2: w --> w0) (H' : e ;; φ1 = e ;; φ2) : φ1 = φ2.
+  Proof.
+    assert (H'1 : f ;; e ;; φ1 = g ;; e ;; φ1).
+    rewrite H. apply idpath.
+    set (E' := mk_Coequalizer _ _ _ _ E).
+    repeat rewrite <- assoc in H'1.
+    set (E'ar := CoequalizerOut E' w0 (e ;; φ1) H'1).
+    pathvia E'ar.
+    apply isCoequalizerOutUnique. apply idpath.
+    apply pathsinv0. apply isCoequalizerOutUnique. apply pathsinv0. apply H'.
+  Defined.
+
+  Lemma CoequalizerOutsEq {y z: C} {f g : y --> z} (E : Coequalizer f g)
+        {w : C} (φ1 φ2: C⟦E, w⟧)
+        (H' : (CoequalizerArrow E) ;; φ1 = (CoequalizerArrow E) ;; φ2) : φ1 = φ2.
+  Proof.
+    apply (isCoequalizerOutsEq (isCoequalizer_Coequalizer E) _ _ H').
+  Defined.
+
+  (** Morphisms between coequalizer objects with the right commutativity
+    equalities. *)
+  Definition identity_is_CoequalizerOut {y z : C} {f g : y --> z}
+             (E : Coequalizer f g) :
+    Σ φ : C⟦E, E⟧, (CoequalizerArrow E) ;; φ = (CoequalizerArrow E).
+  Proof.
+    exists (identity E).
+    apply id_right.
+  Defined.
+
+  Lemma CoequalizerEndo_is_identity {y z : C} {f g : y --> z}
+        {E : Coequalizer f g} (φ : C⟦E, E⟧)
+        (H : (CoequalizerArrow E) ;; φ = CoequalizerArrow E) :
+    identity E = φ.
+  Proof.
+    set (H1 := tpair ((fun φ' : C⟦E, E⟧ => _ ;; φ' = _)) φ H).
+    assert (H2 : identity_is_CoequalizerOut E = H1).
+    - apply proofirrelevance.
+      apply isapropifcontr.
+      apply (isCoequalizer_Coequalizer E).
+      apply CoequalizerEqAr.
+    - apply (base_paths _ _ H2).
+  Defined.
+
+  Definition from_Coequalizer_to_Coequalizer {y z : C} {f g : y --> z}
+             (E E': Coequalizer f g) : C⟦E, E'⟧.
+  Proof.
+    apply (CoequalizerOut E E' (CoequalizerArrow E')).
+    apply CoequalizerEqAr.
+  Defined.
+
+  Lemma are_inverses_from_Coequalizer_to_Coequalizer {y z : C} {f g : y --> z}
+        {E E': Coequalizer f g} :
+    is_inverse_in_precat (from_Coequalizer_to_Coequalizer E E')
+                         (from_Coequalizer_to_Coequalizer E' E).
+  Proof.
+    split; apply pathsinv0; use CoequalizerEndo_is_identity;
+    rewrite assoc; unfold from_Coequalizer_to_Coequalizer;
+      repeat rewrite CoequalizerCommutes; apply idpath.
+  Defined.
+
+  Lemma isiso_from_Coequalizer_to_Coequalizer {y z : C} {f g : y --> z}
+        (E E' : Coequalizer f g) :
+    is_isomorphism (from_Coequalizer_to_Coequalizer E E').
+  Proof.
+    apply (is_iso_qinv _ (from_Coequalizer_to_Coequalizer E' E)).
+    apply are_inverses_from_Coequalizer_to_Coequalizer.
+  Defined.
+
+  Definition iso_from_Coequalizer_to_Coequalizer {y z : C} {f g : y --> z}
+             (E E' : Coequalizer f g) : iso E E' :=
+    tpair _ _ (isiso_from_Coequalizer_to_Coequalizer E E').
+
+
+  (** We prove that CoequalizerArrow is an epi. *)
+  Lemma CoequalizerArrowisEpi {y z : C} {f g : y --> z} (E : Coequalizer f g ) :
+    isEpi _ (CoequalizerArrow E).
+  Proof.
+    apply mk_isEpi.
+    intros z0 g0 h X.
+    apply (CoequalizerOutsEq E).
+    apply X.
+  Defined.
+
+  Lemma CoequalizerArrowEpi {y z : C} {f g : y --> z} (E : Coequalizer f g ) :
+    Epi _ z E.
+  Proof.
+    apply (mk_Epi _ (CoequalizerArrow E)).
+    apply (CoequalizerArrowisEpi E).
+  Defined.
+End def_coequalizers.

--- a/UniMath/CategoryTheory/limits/coequalizers.v
+++ b/UniMath/CategoryTheory/limits/coequalizers.v
@@ -47,7 +47,7 @@ Section def_coequalizers.
   Defined.
 
   (** Definition and construction of coequalizers. *)
-  Definition Coequalizer {y z : C} (f g : y --> z) :=
+  Definition Coequalizer {y z : C} (f g : y --> z) : UU :=
     Σ e : (Σ w : C, z --> w),
           (Σ H : f ;; (pr2 e) = g ;; (pr2 e), isCoequalizer f g (pr2 e) H).
 
@@ -70,8 +70,8 @@ Section def_coequalizers.
       ishinh (Coequalizer f g).
 
   (** Returns the coequalizer object. *)
-  Definition CoequalizerObject {y z : C} {f g : y --> z} (E : Coequalizer f g) : C
-    := pr1 (pr1 E).
+  Definition CoequalizerObject {y z : C} {f g : y --> z} (E : Coequalizer f g) :
+    C := pr1 (pr1 E).
   Coercion CoequalizerObject : Coequalizer >-> ob.
 
   (** Returns the coequalizer arrow. *)

--- a/UniMath/CategoryTheory/limits/cokernels.v
+++ b/UniMath/CategoryTheory/limits/cokernels.v
@@ -23,13 +23,13 @@ Section def_cokernels.
         (H : g ;; f = ZeroArrow _ Z x z) :
     g ;; f = ZeroArrow _ Z x y ;; f.
   Proof.
-    rewrite <- (ZeroArrow_comp_left _ Z x y z f) in H.
-    exact H.
+    pathvia (ZeroArrow _ Z x z).
+    apply H. apply pathsinv0. apply ZeroArrow_comp_left.
   Defined.
 
   (** Definition and construction of Cokernels *)
-  Definition Cokernel {y z : C} (g : y --> z) :=
-    Coequalizer g (ZeroArrow _ Z y z).
+  Definition Cokernel {y z : C} (g : y --> z) :
+    UU := Coequalizer g (ZeroArrow _ Z y z).
   Definition mk_Cokernel {x y z : C} (f : y --> z) (g : x --> y)
              (H : g ;; f = (ZeroArrow _ Z x z))
              (isE : isCoequalizer g (ZeroArrow _ Z x y) f (CokernelEqRw H))
@@ -40,25 +40,23 @@ Section def_cokernels.
   Defined.
   Definition Cokernels := forall (y z : C) (g : y --> z), Cokernel g.
   Definition hasCokernels := forall (y z : C) (g : y --> z), ishinh (Cokernel g).
-  Definition CokernelOb {y z : C} {g : y --> z} (CK : Cokernel g)
-    := CoequalizerObject CK.
+  Definition CokernelOb {y z : C} {g : y --> z} (CK : Cokernel g) :
+    C := CoequalizerObject CK.
   Coercion CokernelOb : Cokernel >-> ob.
-  Definition CokernelArrow {y z : C} {g : y --> z} (CK : Cokernel g) :=
-    CoequalizerArrow CK.
+  Definition CokernelArrow {y z : C} {g : y --> z} (CK : Cokernel g) :
+    C⟦z, CK⟧ := CoequalizerArrow CK.
   Definition CokernelEqAr {y z : C} {g : y --> z} (CK : Cokernel g) :=
     CoequalizerEqAr CK.
   Definition CokernelOut {y z : C} {g : y --> z} (CK : Cokernel g)
-             (w : C) (h : z --> w) (H : g ;; h = ZeroArrow _ Z y w) : C⟦CK, w⟧.
-  Proof.
-    exact (pr1 (pr1 (isCoequalizer_Coequalizer CK w h (CokernelEqRw H)))).
-  Defined.
+             (w : C) (h : z --> w) (H : g ;; h = ZeroArrow _ Z y w) :
+    C⟦CK, w⟧ := CoequalizerOut CK _ h (CokernelEqRw H).
 
   (** Commutativity of Cokernels. *)
   Lemma CokernelCommutes {y z : C} {g : y --> z} (CK : Cokernel g)
         (w : C) (h : z --> w) (H : g ;; h = ZeroArrow _ Z y w) :
     (CokernelArrow CK) ;; (CokernelOut CK w h H) = h.
   Proof.
-    exact (pr2 (pr1 ((isCoequalizer_Coequalizer CK) w h (CokernelEqRw H)))).
+    apply (CoequalizerCommutes CK).
   Defined.
 
   (** Two arrows from Cokernel, such that the compositions with CokernelArrow
@@ -96,8 +94,9 @@ Section def_cokernels.
              (CK CK': Cokernel g) : C⟦CK, CK'⟧.
   Proof.
     apply (CokernelOut CK CK' (CokernelArrow CK')).
-    rewrite <- (ZeroArrow_comp_left _ Z y z CK' (CokernelArrow CK')).
+    pathvia (ZeroArrow _ Z y z ;; CokernelArrow CK').
     apply CokernelEqAr.
+    apply ZeroArrow_comp_left.
   Defined.
 
   Lemma are_inverses_from_Cokernel_to_Cokernel {y z : C} {g : y --> z}

--- a/UniMath/CategoryTheory/limits/cokernels.v
+++ b/UniMath/CategoryTheory/limits/cokernels.v
@@ -1,0 +1,137 @@
+(* direct implementation of cokernels *)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.Epis.
+Require Import UniMath.CategoryTheory.limits.coequalizers.
+Require Import UniMath.CategoryTheory.limits.zero.
+
+(** In this section we define cokernels and show that cokernel arrow is an
+  epi. *)
+Section def_cokernels.
+
+  Context {C : precategory}.
+  Hypothesis Z : Zero C.
+
+  (** This rewrite is used to rewrite an equality f ;; g = ZeroArrow to
+     f ;; g = ZeroArrow ;; g. This is because Coequalizers need the latter
+     equality. *)
+  Lemma CokernelEqRw {x y z : C} {g : x --> y} {f : y --> z}
+        (H : g ;; f = ZeroArrow _ Z x z) :
+    g ;; f = ZeroArrow _ Z x y ;; f.
+  Proof.
+    rewrite <- (ZeroArrow_comp_left _ Z x y z f) in H.
+    exact H.
+  Defined.
+
+  (** Definition and construction of Cokernels *)
+  Definition Cokernel {y z : C} (g : y --> z) :=
+    Coequalizer g (ZeroArrow _ Z y z).
+  Definition mk_Cokernel {x y z : C} (f : y --> z) (g : x --> y)
+             (H : g ;; f = (ZeroArrow _ Z x z))
+             (isE : isCoequalizer g (ZeroArrow _ Z x y) f (CokernelEqRw H))
+    : Cokernel g.
+  Proof.
+    use (mk_Coequalizer g (ZeroArrow _ Z x y) f (CokernelEqRw H)).
+    apply isE.
+  Defined.
+  Definition Cokernels := forall (y z : C) (g : y --> z), Cokernel g.
+  Definition hasCokernels := forall (y z : C) (g : y --> z), ishinh (Cokernel g).
+  Definition CokernelOb {y z : C} {g : y --> z} (CK : Cokernel g)
+    := CoequalizerObject CK.
+  Coercion CokernelOb : Cokernel >-> ob.
+  Definition CokernelArrow {y z : C} {g : y --> z} (CK : Cokernel g) :=
+    CoequalizerArrow CK.
+  Definition CokernelEqAr {y z : C} {g : y --> z} (CK : Cokernel g) :=
+    CoequalizerEqAr CK.
+  Definition CokernelOut {y z : C} {g : y --> z} (CK : Cokernel g)
+             (w : C) (h : z --> w) (H : g ;; h = ZeroArrow _ Z y w) : C⟦CK, w⟧.
+  Proof.
+    exact (pr1 (pr1 (isCoequalizer_Coequalizer CK w h (CokernelEqRw H)))).
+  Defined.
+
+  (** Commutativity of Cokernels. *)
+  Lemma CokernelCommutes {y z : C} {g : y --> z} (CK : Cokernel g)
+        (w : C) (h : z --> w) (H : g ;; h = ZeroArrow _ Z y w) :
+    (CokernelArrow CK) ;; (CokernelOut CK w h H) = h.
+  Proof.
+    exact (pr2 (pr1 ((isCoequalizer_Coequalizer CK) w h (CokernelEqRw H)))).
+  Defined.
+
+  (** Two arrows from Cokernel, such that the compositions with CokernelArrow
+    are equal, are equal. *)
+  Lemma CokernelOutsEq {y z: C} {g : y --> z} (CK : Cokernel g)
+        {w : C} (φ1 φ2: C⟦CK, w⟧)
+        (H' : (CokernelArrow CK) ;; φ1 = (CokernelArrow CK) ;; φ2) : φ1 = φ2.
+  Proof.
+    apply (isCoequalizerOutsEq (isCoequalizer_Coequalizer CK) _ _ H').
+  Defined.
+
+  (** Results on morphisms between Cokernels. *)
+  Definition identity_is_CokernelOut {y z : C} {g : y --> z}
+             (CK : Cokernel g) :
+    Σ φ : C⟦CK, CK⟧, (CokernelArrow CK) ;; φ = (CokernelArrow CK).
+  Proof.
+    exists (identity CK).
+    apply id_right.
+  Defined.
+
+  Lemma CokernelEndo_is_identity {y z : C} {g : y --> z} {CK : Cokernel g}
+        (φ : C⟦CK, CK⟧) (H : (CokernelArrow CK) ;; φ = CokernelArrow CK) :
+    identity CK = φ.
+  Proof.
+    set (H1 := tpair ((fun φ' : C⟦CK, CK⟧ => _ ;; φ' = _)) φ H).
+    assert (H2 : identity_is_CokernelOut CK = H1).
+    - apply proofirrelevance.
+      apply isapropifcontr.
+      apply (isCoequalizer_Coequalizer CK).
+      apply CokernelEqAr.
+    - apply (base_paths _ _ H2).
+  Defined.
+
+  Definition from_Cokernel_to_Cokernel {y z : C} {g : y --> z}
+             (CK CK': Cokernel g) : C⟦CK, CK'⟧.
+  Proof.
+    apply (CokernelOut CK CK' (CokernelArrow CK')).
+    rewrite <- (ZeroArrow_comp_left _ Z y z CK' (CokernelArrow CK')).
+    apply CokernelEqAr.
+  Defined.
+
+  Lemma are_inverses_from_Cokernel_to_Cokernel {y z : C} {g : y --> z}
+        {CK CK': Cokernel g} :
+    is_inverse_in_precat (from_Cokernel_to_Cokernel CK CK')
+                         (from_Cokernel_to_Cokernel CK' CK).
+  Proof.
+    split; apply pathsinv0; use CokernelEndo_is_identity;
+    unfold from_Cokernel_to_Cokernel; rewrite assoc.
+    rewrite (CokernelCommutes CK CK').
+    rewrite (CokernelCommutes CK' CK).
+    apply idpath.
+
+    rewrite (CokernelCommutes CK' CK).
+    rewrite (CokernelCommutes CK CK').
+    apply idpath.
+  Defined.
+
+  Lemma isiso_from_Cokernel_to_Cokernel {y z : C} {g : y --> z}
+        (CK CK' : Cokernel g) :
+    is_isomorphism (from_Cokernel_to_Cokernel CK CK').
+  Proof.
+    apply (is_iso_qinv _ (from_Cokernel_to_Cokernel CK' CK)).
+    apply are_inverses_from_Cokernel_to_Cokernel.
+  Defined.
+
+  Definition iso_from_Cokernel_to_Cokernel {y z : C} {g : y --> z}
+             (CK CK' : Cokernel g) : iso CK CK' :=
+    tpair _ _ (isiso_from_Cokernel_to_Cokernel CK CK').
+
+  (** It follows that CokernelArrow is an epi. *)
+  Lemma CokernelArrowisEpi {y z : C} {g : y --> z} (CK : Cokernel g ) :
+    isEpi _ (CokernelArrow CK).
+  Proof.
+    apply CoequalizerArrowisEpi.
+  Defined.
+End def_cokernels.

--- a/UniMath/CategoryTheory/limits/equalizers.v
+++ b/UniMath/CategoryTheory/limits/equalizers.v
@@ -47,7 +47,7 @@ Section def_equalizers.
   Defined.
 
   (** Definition and construction of equalizers. *)
-  Definition Equalizer {y z : C} (f g : y --> z) :=
+  Definition Equalizer {y z : C} (f g : y --> z) : UU :=
     Σ e : (Σ w : C, w --> y),
           (Σ H : (pr2 e) ;; f = (pr2 e) ;; g, isEqualizer f g (pr2 e) H).
 
@@ -63,15 +63,14 @@ Section def_equalizers.
   Defined.
 
   (** Equalizers in precategories. *)
-  Definition Equalizers := forall (y z : C) (f g : y --> z),
-      Equalizer f g.
+  Definition Equalizers := forall (y z : C) (f g : y --> z), Equalizer f g.
 
   Definition hasEqualizers := forall (y z : C) (f g : y --> z),
       ishinh (Equalizer f g).
 
   (** Returns the equalizer object. *)
-  Definition EqualizerObject {y z : C} {f g : y --> z} (E : Equalizer f g) : C
-    := pr1 (pr1 E).
+  Definition EqualizerObject {y z : C} {f g : y --> z} (E : Equalizer f g) :
+    C := pr1 (pr1 E).
   Coercion EqualizerObject : Equalizer >-> ob.
 
   (** Returns the equalizer arrow. *)

--- a/UniMath/CategoryTheory/limits/equalizers.v
+++ b/UniMath/CategoryTheory/limits/equalizers.v
@@ -1,0 +1,191 @@
+(* Direct implementation of equalizers. *)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.Monics.
+
+Section def_equalizers.
+
+  Context {C : precategory}.
+
+  (** Definition and construction of isEqualizer. *)
+  Definition isEqualizer {x y z : C} (f g : y --> z) (e : x --> y)
+             (H : e ;; f = e ;; g) : UU :=
+    forall (w : C) (h : w --> y) (H : h ;; f = h ;; g),
+      iscontr (Σ φ : w --> x, φ ;; e = h).
+
+  Definition mk_isEqualizer {x y z : C} (f g : y --> z) (e : x --> y)
+             (H : e ;; f = e ;; g) :
+    (forall (w : C) (h : w --> y) (H' : h ;; f = h ;; g),
+        iscontr (Σ ψ : w --> x, ψ ;; e = h)) -> isEqualizer f g e H.
+  Proof.
+    intros X. unfold isEqualizer. exact X.
+  Defined.
+
+  Lemma isaprop_isEqualizer {x y z : C} (f g : y --> z) (e : x --> y)
+        (H : e ;; f = e ;; g) :
+    isaprop (isEqualizer f g e H).
+  Proof.
+    repeat (apply impred; intro).
+    apply isapropiscontr.
+  Defined.
+
+  (** Proves that the arrow to the equalizer object with the right
+    commutativity property is unique. *)
+  Lemma isEqualizerInUnique {x y z : C} (f g : y --> z) (e : x --> y)
+        (H : e ;; f = e ;; g) (E : isEqualizer f g e H)
+        (w : C) (h : w --> y) (H' : h ;; f = h ;; g)
+        (φ : w --> x) (H'' : φ ;; e = h) :
+    φ = (pr1 (pr1 (E w h H'))).
+  Proof.
+    set (T := tpair (fun ψ : w --> x => ψ ;; e = h) φ H'').
+    set (T' := pr2 (E w h H') T).
+    apply (base_paths _ _ T').
+  Defined.
+
+  (** Definition and construction of equalizers. *)
+  Definition Equalizer {y z : C} (f g : y --> z) :=
+    Σ e : (Σ w : C, w --> y),
+          (Σ H : (pr2 e) ;; f = (pr2 e) ;; g, isEqualizer f g (pr2 e) H).
+
+  Definition mk_Equalizer {x y z : C} (f g : y --> z) (e : x --> y)
+             (H : e ;; f = e ;; g) (isE : isEqualizer f g e H) :
+    Equalizer f g.
+  Proof.
+    simple refine (tpair _ _ _).
+    - simple refine (tpair _ _ _).
+      + apply x.
+      + apply e.
+    - simpl. refine (tpair _ H isE).
+  Defined.
+
+  (** Equalizers in precategories. *)
+  Definition Equalizers := forall (y z : C) (f g : y --> z),
+      Equalizer f g.
+
+  Definition hasEqualizers := forall (y z : C) (f g : y --> z),
+      ishinh (Equalizer f g).
+
+  (** Returns the equalizer object. *)
+  Definition EqualizerObject {y z : C} {f g : y --> z} (E : Equalizer f g) : C
+    := pr1 (pr1 E).
+  Coercion EqualizerObject : Equalizer >-> ob.
+
+  (** Returns the equalizer arrow. *)
+  Definition EqualizerArrow {y z : C} {f g : y --> z} (E : Equalizer f g) :
+    C⟦E, y⟧ := pr2 (pr1 E).
+
+  (** The equality on morphisms that equalizers must satisfy. *)
+  Definition EqualizerEqAr {y z : C} {f g : y --> z} (E : Equalizer f g) :
+    EqualizerArrow E ;; f = EqualizerArrow E ;; g := pr1 (pr2 E).
+
+  (** Returns the property isEqualizer from Equalizer. *)
+  Definition isEqualizer_Equalizer {y z : C} {f g : y --> z} (E : Equalizer f g) :
+    isEqualizer f g (EqualizerArrow E) (EqualizerEqAr E) := pr2 (pr2 E).
+
+  (** Every morphism which satisfy the equalizer equality on morphism factors
+    uniquely through the EqualizerArrow. *)
+  Definition EqualizerIn {y z : C} {f g : y --> z} (E : Equalizer f g)
+             (w : C) (h : w --> y) (H : h ;; f = h ;; g) :
+    C⟦w, E⟧ := pr1 (pr1 (isEqualizer_Equalizer E w h H)).
+
+  Lemma EqualizerCommutes {y z : C} {f g : y --> z} (E : Equalizer f g)
+        (w : C) (h : w --> y) (H : h ;; f = h ;; g) :
+    (EqualizerIn E w h H) ;; (EqualizerArrow E) = h.
+  Proof.
+    exact (pr2 (pr1 ((isEqualizer_Equalizer E) w h H))).
+  Defined.
+
+  Lemma isEqualizerInsEq {x y z: C} {f g : y --> z} {e : x --> y}
+        {H : e ;; f = e ;; g} (E : isEqualizer f g e H)
+        {w : C} (φ1 φ2: w --> x) (H' : φ1 ;; e = φ2 ;; e) : φ1 = φ2.
+  Proof.
+    assert (H'1 : φ1 ;; e ;; f = φ1 ;; e ;; g).
+    rewrite <- assoc. rewrite H. rewrite assoc. apply idpath.
+    set (E' := mk_Equalizer _ _ _ _ E).
+    set (E'ar := EqualizerIn E' w (φ1 ;; e) H'1).
+    pathvia E'ar.
+    apply isEqualizerInUnique. apply idpath.
+    apply pathsinv0. apply isEqualizerInUnique. apply pathsinv0. apply H'.
+  Defined.
+
+  Lemma EqualizerInsEq {y z: C} {f g : y --> z} (E : Equalizer f g)
+        {w : C} (φ1 φ2: C⟦w, E⟧)
+        (H' : φ1 ;; (EqualizerArrow E) = φ2 ;; (EqualizerArrow E)) : φ1 = φ2.
+  Proof.
+    apply (isEqualizerInsEq (isEqualizer_Equalizer E) _ _ H').
+  Defined.
+
+  (** Morphisms between equalizer objects with the right commutativity
+    equalities. *)
+  Definition identity_is_EqualizerIn {y z : C} {f g : y --> z}
+             (E : Equalizer f g) :
+    Σ φ : C⟦E, E⟧, φ ;; (EqualizerArrow E) = (EqualizerArrow E).
+  Proof.
+    exists (identity E).
+    apply id_left.
+  Defined.
+
+  Lemma EqualizerEndo_is_identity {y z : C} {f g : y --> z} {E : Equalizer f g}
+        (φ : C⟦E, E⟧) (H : φ ;; (EqualizerArrow E) = EqualizerArrow E) :
+    identity E = φ.
+  Proof.
+    set (H1 := tpair ((fun φ' : C⟦E, E⟧ => φ' ;; _ = _)) φ H).
+    assert (H2 : identity_is_EqualizerIn E = H1).
+    - apply proofirrelevance.
+      apply isapropifcontr.
+      apply (isEqualizer_Equalizer E).
+      apply EqualizerEqAr.
+    - apply (base_paths _ _ H2).
+  Defined.
+
+  Definition from_Equalizer_to_Equalizer {y z : C} {f g : y --> z}
+             (E E': Equalizer f g) : C⟦E, E'⟧.
+  Proof.
+    apply (EqualizerIn E' E (EqualizerArrow E)).
+    apply EqualizerEqAr.
+  Defined.
+
+  Lemma are_inverses_from_Equalizer_to_Equalizer {y z : C} {f g : y --> z}
+        {E E': Equalizer f g} :
+    is_inverse_in_precat (from_Equalizer_to_Equalizer E E')
+                         (from_Equalizer_to_Equalizer E' E).
+  Proof.
+    split; apply pathsinv0; use EqualizerEndo_is_identity;
+    rewrite <- assoc; unfold from_Equalizer_to_Equalizer;
+      repeat rewrite EqualizerCommutes; apply idpath.
+  Defined.
+
+  Lemma isiso_from_Equalizer_to_Equalizer {y z : C} {f g : y --> z}
+        (E E' : Equalizer f g) :
+    is_isomorphism (from_Equalizer_to_Equalizer E E').
+  Proof.
+    apply (is_iso_qinv _ (from_Equalizer_to_Equalizer E' E)).
+    apply are_inverses_from_Equalizer_to_Equalizer.
+  Defined.
+
+  Definition iso_from_Equalizer_to_Equalizer {y z : C} {f g : y --> z}
+             (E E' : Equalizer f g) : iso E E' :=
+    tpair _ _ (isiso_from_Equalizer_to_Equalizer E E').
+
+
+  (** We prove that EqualizerArrow is a monic. *)
+  Lemma EqualizerArrowisMonic {y z : C} {f g : y --> z} (E : Equalizer f g ) :
+    isMonic _ (EqualizerArrow E).
+  Proof.
+    apply mk_isMonic.
+    intros z0 g0 h X.
+    apply (EqualizerInsEq E).
+    apply X.
+  Defined.
+
+  Lemma EqualizerArrowMonic {y z : C} {f g : y --> z} (E : Equalizer f g ) :
+    Monic _ E y.
+  Proof.
+    apply (mk_Monic _ (EqualizerArrow E)).
+    apply (EqualizerArrowisMonic E).
+  Defined.
+End def_equalizers.

--- a/UniMath/CategoryTheory/limits/kernels.v
+++ b/UniMath/CategoryTheory/limits/kernels.v
@@ -1,0 +1,129 @@
+(* direct implementation of kernels *)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.Monics.
+Require Import UniMath.CategoryTheory.limits.equalizers.
+Require Import UniMath.CategoryTheory.limits.zero.
+
+Section def_kernels.
+
+  Context {C : precategory}.
+  Hypothesis Z : Zero C.
+
+  (** This rewrite is used to rewrite an equality f ;; g = ZeroArrow to
+     f ;; g = f ;; ZeroArrow. This is because Equalizers need the latter
+     equality. *)
+  Lemma KernelEqRw {x y z : C} {g : y --> z} {f : x --> y}
+        (H : f ;; g = ZeroArrow _ Z x z) :
+    f ;; g = f ;; ZeroArrow _ Z y z.
+  Proof.
+    rewrite <- (ZeroArrow_comp_right _ Z x y z f) in H.
+    exact H.
+  Defined.
+
+  (** Definition and construction of Kernels *)
+  Definition Kernel {y z : C} (g : y --> z) :=
+    Equalizer g (ZeroArrow _ Z y z).
+  Definition mk_Kernel {x y z : C} (f : x --> y) (g : y --> z)
+             (H : f ;; g = (ZeroArrow _ Z x z))
+             (isE : isEqualizer g (ZeroArrow _ Z y z) f (KernelEqRw H))
+    : Kernel g.
+  Proof.
+    use (mk_Equalizer g (ZeroArrow _ Z y z) f (KernelEqRw H)).
+    apply isE.
+  Defined.
+  Definition Kernels := forall (y z : C) (g : y --> z), Kernel g.
+  Definition hasKernels := forall (y z : C) (g : y --> z), ishinh (Kernel g).
+  Definition KernelOb {y z : C} {g : y --> z} (K : Kernel g)
+    := EqualizerObject K.
+  Coercion KernelOb : Kernel >-> ob.
+  Definition KernelArrow {y z : C} {g : y --> z} (K : Kernel g) :=
+    EqualizerArrow K.
+  Definition KernelEqAr {y z : C} {g : y --> z} (K : Kernel g) :=
+    EqualizerEqAr K.
+  Definition KernelIn {y z : C} {g : y --> z} (K : Kernel g)
+             (w : C) (h : w --> y) (H : h ;; g = ZeroArrow _ Z w z) : C⟦w, K⟧.
+  Proof.
+    exact (pr1 (pr1 (isEqualizer_Equalizer K w h (KernelEqRw H)))).
+  Defined.
+
+  (** Commutativity of Kernels. *)
+  Lemma KernelCommutes {y z : C} {g : y --> z} (K : Kernel g)
+        (w : C) (h : w --> y) (H : h ;; g = ZeroArrow _ Z w z) :
+    (KernelIn K w h H) ;; (KernelArrow K) = h.
+  Proof.
+    exact (pr2 (pr1 ((isEqualizer_Equalizer K) w h (KernelEqRw H)))).
+  Defined.
+
+  (** Two arrows to Kernel, such that the compositions with KernelArrow
+    are equal, are equal. *)
+  Lemma KernelInsEq {y z: C} {g : y --> z} (K : Kernel g)
+        {w : C} (φ1 φ2: C⟦w, K⟧)
+        (H' : φ1 ;; (KernelArrow K) = φ2 ;; (KernelArrow K)) : φ1 = φ2.
+  Proof.
+    apply (isEqualizerInsEq (isEqualizer_Equalizer K) _ _ H').
+  Defined.
+
+  (** Results on morphisms between Kernels. *)
+  Definition identity_is_KernelIn {y z : C} {g : y --> z}
+             (K : Kernel g) :
+    Σ φ : C⟦K, K⟧, φ ;; (KernelArrow K) = (KernelArrow K).
+  Proof.
+    exists (identity K).
+    apply id_left.
+  Defined.
+
+  Lemma KernelEndo_is_identity {y z : C} {g : y --> z} {K : Kernel g}
+        (φ : C⟦K, K⟧) (H : φ ;; (KernelArrow K) = KernelArrow K) :
+    identity K = φ.
+  Proof.
+    set (H1 := tpair ((fun φ' : C⟦K, K⟧ => φ' ;; _ = _)) φ H).
+    assert (H2 : identity_is_KernelIn K = H1).
+    - apply proofirrelevance.
+      apply isapropifcontr.
+      apply (isEqualizer_Equalizer K).
+      apply KernelEqAr.
+    - apply (base_paths _ _ H2).
+  Defined.
+
+  Definition from_Kernel_to_Kernel {y z : C} {g : y --> z}
+             (K K': Kernel g) : C⟦K, K'⟧.
+  Proof.
+    apply (KernelIn K' K (KernelArrow K)).
+    rewrite <- (ZeroArrow_comp_right _ Z K y z (KernelArrow K)).
+    apply KernelEqAr.
+  Defined.
+
+  Lemma are_inverses_from_Kernel_to_Kernel {y z : C} {g : y --> z}
+        {K K': Kernel g} :
+    is_inverse_in_precat (from_Kernel_to_Kernel K K')
+                         (from_Kernel_to_Kernel K' K).
+  Proof.
+    split; apply pathsinv0; use KernelEndo_is_identity;
+    rewrite <- assoc; unfold from_Kernel_to_Kernel;
+      repeat rewrite KernelCommutes; apply idpath.
+  Defined.
+
+  Lemma isiso_from_Kernel_to_Kernel {y z : C} {g : y --> z}
+        (K K' : Kernel g) :
+    is_isomorphism (from_Kernel_to_Kernel K K').
+  Proof.
+    apply (is_iso_qinv _ (from_Kernel_to_Kernel K' K)).
+    apply are_inverses_from_Kernel_to_Kernel.
+  Defined.
+
+  Definition iso_from_Kernel_to_Kernel {y z : C} {g : y --> z}
+             (K K' : Kernel g) : iso K K' :=
+    tpair _ _ (isiso_from_Kernel_to_Kernel K K').
+
+  (** It follows that KernelArrow is monic. *)
+  Lemma KernelArrowisMonic {y z : C} {g : y --> z} (K : Kernel g ) :
+    isMonic _ (KernelArrow K).
+  Proof.
+    apply EqualizerArrowisMonic.
+  Defined.
+End def_kernels.

--- a/UniMath/CategoryTheory/limits/kernels.v
+++ b/UniMath/CategoryTheory/limits/kernels.v
@@ -21,13 +21,13 @@ Section def_kernels.
         (H : f ;; g = ZeroArrow _ Z x z) :
     f ;; g = f ;; ZeroArrow _ Z y z.
   Proof.
-    rewrite <- (ZeroArrow_comp_right _ Z x y z f) in H.
-    exact H.
+    pathvia (ZeroArrow _ Z x z).
+    apply H. apply pathsinv0. apply ZeroArrow_comp_right.
   Defined.
 
   (** Definition and construction of Kernels *)
-  Definition Kernel {y z : C} (g : y --> z) :=
-    Equalizer g (ZeroArrow _ Z y z).
+  Definition Kernel {y z : C} (g : y --> z) :
+    UU := Equalizer g (ZeroArrow _ Z y z).
   Definition mk_Kernel {x y z : C} (f : x --> y) (g : y --> z)
              (H : f ;; g = (ZeroArrow _ Z x z))
              (isE : isEqualizer g (ZeroArrow _ Z y z) f (KernelEqRw H))
@@ -38,25 +38,23 @@ Section def_kernels.
   Defined.
   Definition Kernels := forall (y z : C) (g : y --> z), Kernel g.
   Definition hasKernels := forall (y z : C) (g : y --> z), ishinh (Kernel g).
-  Definition KernelOb {y z : C} {g : y --> z} (K : Kernel g)
-    := EqualizerObject K.
+  Definition KernelOb {y z : C} {g : y --> z} (K : Kernel g) :
+    C := EqualizerObject K.
   Coercion KernelOb : Kernel >-> ob.
-  Definition KernelArrow {y z : C} {g : y --> z} (K : Kernel g) :=
-    EqualizerArrow K.
+  Definition KernelArrow {y z : C} {g : y --> z} (K : Kernel g) :
+    C⟦K, y⟧:= EqualizerArrow K.
   Definition KernelEqAr {y z : C} {g : y --> z} (K : Kernel g) :=
     EqualizerEqAr K.
   Definition KernelIn {y z : C} {g : y --> z} (K : Kernel g)
-             (w : C) (h : w --> y) (H : h ;; g = ZeroArrow _ Z w z) : C⟦w, K⟧.
-  Proof.
-    exact (pr1 (pr1 (isEqualizer_Equalizer K w h (KernelEqRw H)))).
-  Defined.
+             (w : C) (h : w --> y) (H : h ;; g = ZeroArrow _ Z w z) :
+    C⟦w, K⟧ := EqualizerIn K _ h (KernelEqRw H).
 
   (** Commutativity of Kernels. *)
   Lemma KernelCommutes {y z : C} {g : y --> z} (K : Kernel g)
         (w : C) (h : w --> y) (H : h ;; g = ZeroArrow _ Z w z) :
     (KernelIn K w h H) ;; (KernelArrow K) = h.
   Proof.
-    exact (pr2 (pr1 ((isEqualizer_Equalizer K) w h (KernelEqRw H)))).
+    apply (EqualizerCommutes K).
   Defined.
 
   (** Two arrows to Kernel, such that the compositions with KernelArrow
@@ -94,8 +92,9 @@ Section def_kernels.
              (K K': Kernel g) : C⟦K, K'⟧.
   Proof.
     apply (KernelIn K' K (KernelArrow K)).
-    rewrite <- (ZeroArrow_comp_right _ Z K y z (KernelArrow K)).
+    pathvia (KernelArrow K ;; ZeroArrow _ Z y z).
     apply KernelEqAr.
+    apply ZeroArrow_comp_right.
   Defined.
 
   Lemma are_inverses_from_Kernel_to_Kernel {y z : C} {g : y --> z}

--- a/UniMath/CategoryTheory/limits/zero.v
+++ b/UniMath/CategoryTheory/limits/zero.v
@@ -5,11 +5,11 @@ Require Import UniMath.Foundations.Basics.Sets.
 
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.limits.initial.
 Require Import UniMath.CategoryTheory.limits.terminal.
 
 Local Notation "a --> b" := (precategory_morphisms a b)(at level 50).
-Local Notation "f ;; g" := (compose f g)(at level 50).
 
 Section def_zero.
 
@@ -44,11 +44,38 @@ Section def_zero.
     apply (pr2 (pr2 Z) _).
   Defined.
 
-  Lemma ArrowFromZero (Z : Zero) (b : C) (f g : Z --> b) : f = g.
+  Lemma ArrowsFromZero (Z : Zero) (b : C) (f g : Z --> b) : f = g.
   Proof.
     apply proofirrelevance.
     apply isapropifcontr.
     apply (pr1 (pr2 Z) _).
+  Defined.
+
+  (** For any pair of objects, there exists a unique arrow which factors
+    through the zero object *)
+  Definition ZeroArrow (Z : Zero) (a b : C) : C⟦a, b⟧
+    := (ZeroArrowTo Z a) ;; (ZeroArrowFrom Z b).
+
+  Lemma ZeroArrowEq (Z : Zero) (a b : C) (f1 : C⟦a, Z⟧) (g1 : C⟦Z, b⟧) :
+    f1 ;; g1 = ZeroArrow Z a b.
+  Proof.
+    rewrite (ArrowsToZero Z a f1 (ZeroArrowTo Z a)).
+    rewrite (ArrowsFromZero Z b g1 (ZeroArrowFrom Z b)).
+    apply idpath.
+  Defined.
+
+  Lemma ZeroArrow_comp_left (Z : Zero) (a b c : C) (f : C⟦b, c⟧) :
+    ZeroArrow Z a b ;; f = ZeroArrow Z a c.
+  Proof.
+    unfold ZeroArrow at 1. rewrite <- assoc.
+    apply ZeroArrowEq.
+  Defined.
+
+  Lemma ZeroArrow_comp_right (Z : Zero) (a b c : C) (f : C⟦a, b⟧) :
+    f ;; ZeroArrow Z b c = ZeroArrow Z a c.
+  Proof.
+    unfold ZeroArrow at 1. rewrite assoc.
+    apply ZeroArrowEq.
   Defined.
 
   Lemma ZeroEndo_is_identity (Z : Zero) (f : Z --> Z) : identity Z = f.


### PR DESCRIPTION
Hi,

due to renaming of (co)products, I did not try to fix my other pull request
today, but tried to do something which would not conflict with renaming. This
pull request contains the following:

- Direct implementation of equalizers and coequalizers, the files equalizers.v
  and coequalizers.v
- Direct implementation of kernels and cokernels, the files kernels.v and
  cokernels.v
- Definition of monics and epis, the files Monics.v and Epis.v
- Some changes to zero.v. These I used for cokernels and kernels.

The files I have added should prove the following:

- Equalizer arrows are monics and Coequalizer arrows are epis.
- Kernel arrows are monics and Cokernel arrows are epis.
- Composition of monics and epis is monic and epi, respectively.
- If composition of morphisms is a monic, then the first morphism is a monic.
  If composition of morphisms is an epi, then the second morphism is an epi.

When writing these files, I tried to mimic the file Pullbacks.v.
All comments are welcome.