### PR TITLE
added Makefile targets to show axioms and admitted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ coqwc:; coqwc $(VFILES)
 lc:; wc -l $(VFILES)
 lcp:; for i in $(PACKAGES) ; do echo ; echo ==== $$i ==== ; for f in $(VFILES) ; do echo "$$f" ; done | grep "UniMath/$$i" | xargs wc -l ; done
 wc:; wc -w $(VFILES)
+admitted: 
+	grep --color=auto Admitted $(VFILES)
+axiom:
+	grep --color=auto "Axiom " $(VFILES)
 describe:; git describe --dirty --long --always --abbrev=40 --all
 .coq_makefile_input: $(PACKAGE_FILES) $(UMAKEFILES)
 	@ echo making $@ ; ( \


### PR DESCRIPTION
poor man's checks for bad stuff in the Coq code:

- `$ make admitted` shows `Admitted`.
- `$ make axiom` shows uses of the word "Axiom".

There is a lot of noise in the output, due to `coq_makefile` being called, and there are false positives since "Axiom" sometimes occurs in comments.

I'd be happy to see something better than this.