### PR TITLE
product precategory only was cartesian power, now more general

### DIFF
--- a/UniMath/CategoryTheory/ProductPrecategory.v
+++ b/UniMath/CategoryTheory/ProductPrecategory.v
@@ -17,15 +17,15 @@ Require Import UniMath.CategoryTheory.UnicodeNotations.
 
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
-Section product_precategory.
+Section dep_product_precategory.
 
 Variable I : UU.
-Variables C : precategory.
+Variables C : I -> precategory.
 
 Definition product_precategory_ob_mor : precategory_ob_mor.
 Proof.
 mkpair.
-- apply (forall (i : I), ob C).
+- apply (forall (i : I), ob (C i)).
 - intros f g.
   apply (forall i, f i --> g i).
 Defined.
@@ -52,19 +52,39 @@ Qed.
 Definition product_precategory : precategory
   := tpair _ _ is_precategory_product_precategory_data.
 
-Definition has_homsets_product_precategory (hsC : has_homsets C) :
+Definition has_homsets_product_precategory (hsC : forall (i:I), has_homsets (C i)) :
   has_homsets product_precategory.
 Proof.
 intros a b; simpl.
 apply impred_isaset; intro i; apply hsC.
 Qed.
 
-End product_precategory.
+End dep_product_precategory.
+
+
+Section power_precategory.
+
+Variable I : UU.
+Variables C : precategory.
+
+
+Definition power_precategory : precategory
+  := product_precategory I (fun _ => C).
+
+Definition has_homsets_power_precategory (hsC : has_homsets C) :
+  has_homsets power_precategory.
+Proof.
+apply has_homsets_product_precategory.
+intro i; assumption.
+Qed.
+
+End power_precategory.
+
 
 Section functors.
 
-Definition pair_functor_data (I : UU) {A B : precategory}
-  (F : forall (i : I), functor A B) :
+Definition pair_functor_data (I : UU) {A B : I -> precategory}
+  (F : forall (i : I), functor (A i) (B i)) :
   functor_data (product_precategory I A)
                (product_precategory I B).
 Proof.
@@ -73,8 +93,8 @@ mkpair.
 - intros a b f i; apply (# (F i) (f i)).
 Defined.
 
-Definition pair_functor (I : UU) {A B : precategory}
-  (F : forall (i : I), functor A B) :
+Definition pair_functor (I : UU) {A B : I -> precategory}
+  (F : forall (i : I), functor (A i) (B i)) :
   functor (product_precategory I A)
           (product_precategory I B).
 Proof.
@@ -84,23 +104,23 @@ abstract
           | intros x y z f g; apply funextsec; intro i; apply functor_comp]).
 Defined.
 
-Definition pr_functor_data (I : UU) (C : precategory) (i : I) :
-  functor_data (product_precategory I C) C.
+Definition pr_functor_data (I : UU) (C : I -> precategory) (i : I) :
+  functor_data (product_precategory I C) (C i).
 Proof.
 mkpair.
 - intro a; apply (a i).
 - intros x y f; simpl; apply (f i).
 Defined.
 
-Definition pr_functor (I : UU) (C : precategory) (i : I) :
-  functor (product_precategory I C) C.
+Definition pr_functor (I : UU) (C : I -> precategory) (i : I) :
+  functor (product_precategory I C) (C i).
 Proof.
 apply (tpair _ (pr_functor_data I C i)).
 abstract (split; intros x *; apply idpath).
 Defined.
 
 Definition delta_functor_data (I : UU) (C : precategory) :
-  functor_data C (product_precategory I C).
+  functor_data C (power_precategory I C).
 Proof.
 mkpair.
 - intros x i; apply x.
@@ -108,7 +128,7 @@ mkpair.
 Defined.
 
 Definition delta_functor (I : UU) (C : precategory) :
-  functor C (product_precategory I C).
+  functor C (power_precategory I C).
 Proof.
 apply (tpair _ (delta_functor_data I C)).
 abstract (split; intros x *; apply idpath).

--- a/UniMath/CategoryTheory/cocontfunctors.v
+++ b/UniMath/CategoryTheory/cocontfunctors.v
@@ -293,10 +293,10 @@ now unfold ifI; destruct (HI i i) as [p|p]; [|destruct (p (idpath _))].
 Defined.
 
 Lemma isColimCocone_pr_functor
-  (c : chain (product_precategory I A))
-  (L : product_precategory I A) (ccL : cocone c L)
+  (c : chain (power_precategory I A))
+  (L : power_precategory I A) (ccL : cocone c L)
   (M : isColimCocone c L ccL) : forall i,
-  isColimCocone _ _ (mapcocone (pr_functor I A i) c ccL).
+  isColimCocone _ _ (mapcocone (pr_functor I (fun _ => A) i) c ccL).
 Proof.
 intros i x ccx; simpl in *.
 simple refine (let HHH : cocone c (fun j => ifI i j x (L j)) := _ in _).
@@ -305,7 +305,7 @@ simple refine (let HHH : cocone c (fun j => ifI i j x (L j)) := _ in _).
   - simpl; intros n j.
     destruct (HI i j) as [p|p].
     + apply (transportf (fun i => A ⟦ dob c n i, x ⟧) p (coconeIn ccx n)).
-    + apply (# (pr_functor I A j) (coconeIn ccL n)).
+    + apply (# (pr_functor I (fun _ => A) j) (coconeIn ccL n)).
   - abstract (simpl; intros m n e;
       apply funextsec; intro j; unfold compose; simpl;
       destruct (HI i j);
@@ -344,7 +344,7 @@ mkpair.
   now rewrite hp, idpath_transportf.
 Defined.
 
-Lemma is_omega_cocont_pr_functor (i : I) : is_omega_cocont (pr_functor I A i).
+Lemma is_omega_cocont_pr_functor (i : I) : is_omega_cocont (pr_functor I (fun _ => A) i).
 Proof.
 intros c L ccL M.
 now apply isColimCocone_pr_functor.
@@ -356,7 +356,7 @@ Lemma is_omega_cocont_pair_functor
 Proof.
 intros cAB ml ccml Hccml xy ccxy; simpl in *.
 simple refine (let cc i : cocone (mapdiagram (F i)
-                            (mapdiagram (pr_functor I A i) cAB)) (xy i) := _ in _).
+                            (mapdiagram (pr_functor I (fun _ => A) i) cAB)) (xy i) := _ in _).
 { simple refine (mk_cocone _ _).
   - intro n; apply (pr1 ccxy n).
   - abstract (intros m n e;
@@ -408,7 +408,7 @@ Variables (I : UU) (C : precategory) (PC : Products I C) (hsC : has_homsets C).
 Lemma cocont_delta_functor : is_cocont (delta_functor I C).
 Proof.
 apply (left_adjoint_cocont _ (is_left_adjoint_delta_functor _ PC) hsC).
-abstract (apply (has_homsets_product_precategory _ _ hsC)).
+abstract (apply (has_homsets_power_precategory _ _ hsC)).
 Defined.
 
 Lemma is_omega_cocont_delta_functor :
@@ -450,7 +450,7 @@ Lemma cocont_indexed_coproduct_functor :
   is_cocont (indexed_coproduct_functor _ PC).
 Proof.
 apply (left_adjoint_cocont _ (is_left_adjoint_indexed_coproduct_functor _ PC)).
-- abstract (apply has_homsets_product_precategory; apply hsC).
+- abstract (apply has_homsets_power_precategory; apply hsC).
 - abstract (apply hsC).
 Defined.
 

--- a/UniMath/CategoryTheory/limits/coproducts.v
+++ b/UniMath/CategoryTheory/limits/coproducts.v
@@ -167,7 +167,7 @@ End Coproducts.
 Section functors.
 
 Definition indexed_coproduct_functor_data (I : UU) {C : precategory}
-  (PC : Coproducts I C) : functor_data (product_precategory I C) C.
+  (PC : Coproducts I C) : functor_data (power_precategory I C) C.
 Proof.
 mkpair.
 - intros p.
@@ -178,7 +178,7 @@ Defined.
 
 (* The arbitrary coproduct functor: C^I -> C *)
 Definition indexed_coproduct_functor (I : UU) {C : precategory}
-  (PC : Coproducts I C) : functor (product_precategory I C) C.
+  (PC : Coproducts I C) : functor (power_precategory I C) C.
 Proof.
 apply (tpair _ (indexed_coproduct_functor_data _ PC)).
 split.

--- a/UniMath/CategoryTheory/limits/products.v
+++ b/UniMath/CategoryTheory/limits/products.v
@@ -170,7 +170,7 @@ Section product_functor.
 Context (I : UU) {C : precategory} (PC : Products I C).
 
 Definition product_functor_data :
-  functor_data (product_precategory I C) C.
+  functor_data (power_precategory I C) C.
 Proof.
 mkpair.
 - intros p.
@@ -179,7 +179,7 @@ mkpair.
   exact (ProductOfArrows _ _ _ _ f).
 Defined.
 
-Definition product_functor : functor (product_precategory I C) C.
+Definition product_functor : functor (power_precategory I C) C.
 Proof.
 apply (tpair _ product_functor_data).
 abstract (split;


### PR DESCRIPTION
ProductPrecategory.v now with precategory indexed over I
power_precategory corresponds to the previous definitions
pr_functor not instantiated for this special situation
other three files only minimally changed so that they compile again

Remark: "Definition of the general product category" in the header information of UniMath/CategoryTheory/ProductPrecategory.v
seemed to me too generally-sounding. However, the current generalization was not dictated by a need for the generality elsewhere but rather by the fact that the proofs did not even have to be changed.
If in doubt, consider this as my test of the infrastructure set up for contributing to UniMath. 