### PR TITLE
Iterated binary (co)products

### DIFF
--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -67,3 +67,5 @@ PrecategoriesWithBinOps.v
 PrecategoriesWithAbgrops.v
 PreAdditive.v
 limits/BinDirectSums.v
+limits/FinOrdProducts.v
+limits/FinOrdCoproducts.v

--- a/UniMath/CategoryTheory/limits/FinOrdCoproducts.v
+++ b/UniMath/CategoryTheory/limits/FinOrdCoproducts.v
@@ -1,0 +1,206 @@
+(** A direct definition of finite ordered coproducts by using coproducts *)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.Foundations.Combinatorics.StandardFiniteSets.
+
+Require Import UniMath.CategoryTheory.total2_paths.
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.ProductPrecategory.
+
+Require Import UniMath.CategoryTheory.limits.coproducts.
+Require Import UniMath.CategoryTheory.limits.bincoproducts.
+Require Import UniMath.CategoryTheory.limits.initial.
+
+
+(** Definition of finite ordered coproducts. *)
+Section def_FinOrdCoproducts.
+
+  Variable C : precategory.
+
+  Definition FinOrdCoproducts : UU :=
+    forall (n : nat) (a : stn n -> C), CoproductCocone (stn n) C a.
+  Definition hasFinOrdCoproducts := ishinh FinOrdCoproducts.
+
+End def_FinOrdCoproducts.
+
+
+(** Construction of FinOrdCoproducts from Initial and BinCoproducts. *)
+Section FinOrdCoproduct_criteria.
+
+  Variable C : precategory.
+  Hypothesis hs : has_homsets C.
+
+  (** Case n = 0 of the theorem. *)
+  Lemma InitialToCoproduct (I : Initial C):
+    ∀ (a : stn 0 -> C), CoproductCocone (stn 0) C a.
+  Proof.
+    intros a.
+    use (mk_CoproductCocone _ _ _ I
+                            (fun i : stn 0 => fromempty (weqstn0toempty i))).
+    use (mk_isCoproductCocone _ _ hs).
+    intros c g. use unique_exists.
+
+    apply (InitialArrow I c).
+    intros i. apply (fromempty (weqstn0toempty i)).
+    intros y. apply impred_isaprop. intros t. apply hs.
+    intros y X. apply InitialArrowUnique.
+  Defined.
+
+  (** Case n = 1 of the theorem. *)
+  Lemma ObjectToCoproduct:
+    forall (a : stn 1 -> C), CoproductCocone (stn 1) C a.
+  Proof.
+    intros a.
+    set (stn1ob := invweq(weqstn1tounit) tt).
+    use (mk_CoproductCocone _ _ _ (a stn1ob)).
+    intros i. exact (idtoiso (! (maponpaths a (isconnectedstn1 stn1ob i)))).
+
+    (* isCoproductcocone *)
+    use (mk_isCoproductCocone _ _ hs).
+    intros c g.
+    use (unique_exists (g stn1ob)).
+
+    (* Commutativity. *)
+    intros i. rewrite <- (isconnectedstn1 stn1ob i). apply id_left.
+
+    (* Equality of equalities of morphisms. *)
+    intros y. apply impred_isaprop. intros t. apply hs.
+
+    (* Uniqueness. *)
+    intros y X. rewrite <- (X stn1ob). apply pathsinv0. apply id_left.
+  Defined.
+
+  (** Finite ordered coproducts from initial and binary coproducts. *)
+  Theorem FinOrdCoproducts_from_Initial_and_BinCoproducts :
+    Initial C -> BinCoproducts C -> FinOrdCoproducts C.
+  Proof.
+    intros I BinCoprods. unfold FinOrdCoproducts. intros n. induction n.
+
+    (* Case n = 0 *)
+    apply (InitialToCoproduct I).
+
+    (* General case. *)
+    intros a.
+    set (a1 := fun (i : stn n) => a (dni_lastelement i)).
+    set (Cone1 := IHn a1).
+    set (a2 := (fun _ : stn 1 => a (lastelement n))).
+    set (Cone2 := ObjectToCoproduct a2). (* Case n = 1 *)
+    set (Cone1In := CoproductIn _ _ Cone1).
+    set (Cone2In := CoproductIn _ _ Cone2).
+    set (BinCone := BinCoprods (CoproductObject (stn n) C Cone1)
+                               (CoproductObject (stn 1) C Cone2)).
+    set (in1 := BinCoproductIn1 _ BinCone).
+    set (in2 := BinCoproductIn2 _ BinCone).
+    set (m1 := fun i1 : stn n => (Cone1In i1) ;; in1).
+    set (m2 := fun i2 : stn 1 => (Cone2In i2) ;; in2).
+
+    use (mk_CoproductCocone (stn (S n)) C a (BinCoproductObject _ BinCone) _).
+
+    (* Construction of the arrows from a i to BinCone *)
+    intros i. induction (natlehchoice4 (pr1 i) _ (pr2 i)).
+    exact (idtoiso (maponpaths a (dni_lastelement_eq n i a0))
+                   ;; m1 (stnpair n (pr1 i) a0)).
+    exact (idtoiso (maponpaths a (lastelement_eq n i b))
+                   ;;  m2 (invweq(weqstn1tounit) tt)).
+
+    (* Construction of isCoproductCocone. *)
+    use (mk_isCoproductCocone _ _ hs).
+
+    intros c g.
+    set (g1 := fun i : stn n => g(dni_lastelement i)).
+    set (ar1 := CoproductArrow _ _ Cone1 g1).
+    set (com1 := BinCoproductIn1Commutes  _ _ _ BinCone c ar1
+                                          (g(lastelement n))).
+    set (com2 := BinCoproductIn2Commutes _ _ _ BinCone c ar1
+                                         (g(lastelement n))).
+    set (com3 := CoproductInCommutes _ _ _ Cone1 _ g1).
+    set (com4 := CoproductInCommutes _ _ _ Cone2 _
+                                     (fun _ : stn 1 => g(lastelement n))).
+
+    use (unique_exists).
+
+    (* Construction of the unique arrow from BinCone to c. *)
+    use (BinCoproductArrow _ BinCone).
+    use (CoproductArrow _ _ Cone1). intros i. exact (g (dni_lastelement i)).
+    use (CoproductArrow _ _ Cone2). intros i. exact (g (lastelement n)).
+
+    (* First commutativity. *)
+    intros i. unfold coprod_rect. induction (natlehchoice4 (pr1 i) n (pr2 i)).
+    rewrite (dni_lastelement_eq n i a0). repeat rewrite <- assoc.
+    apply remove_id_left. apply idpath.
+
+    unfold m1. unfold in1. rewrite <- assoc. fold g1. fold ar1.
+    use (pathscomp0 (maponpaths (fun f : _ => Cone1In (stnpair n (pr1 i) a0) ;; f)
+                                com1)).
+    fold ar1 in com3. rewrite com3. unfold g1. apply idpath.
+
+
+    (* Second commutativity. *)
+    rewrite (lastelement_eq n i b). repeat rewrite <- assoc.
+    apply remove_id_left. apply idpath.
+
+    unfold m2. unfold in2. rewrite <- assoc. fold g1. fold ar1.
+    use (pathscomp0 (maponpaths (fun f : _ => Cone2In (lastelement 0) ;; f) com2)).
+    rewrite com4. apply idpath.
+
+
+    (* Equality on equalities of morphisms. *)
+    intros y. apply impred_isaprop. intros t. apply hs.
+
+    (* Uniqueness *)
+    unfold coprod_rect. intros k X.
+    apply BinCoproductArrowUnique.
+
+
+    (* From stn n *)
+    apply CoproductArrowUnique.
+    intros i. rewrite <- (X (dni_lastelement i)). rewrite assoc.
+    apply cancel_postcomposition.
+    induction (natlehchoice4 (pr1 (dni_lastelement i)) n
+                             (pr2 (dni_lastelement i))).
+    unfold m1. rewrite assoc. unfold in1.
+    apply cancel_postcomposition.
+    unfold Cone1In. apply pathsinv0.
+
+    set (e := dni_lastelement_is_inj (dni_lastelement_eq n (dni_lastelement i)
+                                                         a0)).
+    use (pathscomp0 _ (CoproductIn_idtoiso (stn n) C (a ∘ dni_lastelement) Cone1
+                                           e)).
+    apply cancel_postcomposition.
+    apply maponpaths. apply maponpaths. (* Why we need maponpaths twice? *)
+    rewrite <- (maponpathscomp _ a).
+    apply maponpaths. apply isasetstn.
+
+    (* This is false because of b *)
+    apply fromempty. induction i as [i i'].
+    cbn in b. induction (!b).
+    apply (isirreflnatlth _ i').
+
+
+    (* From stn 1 *)
+    apply CoproductArrowUnique.
+    intros i. rewrite <- (X (lastelement n)). rewrite assoc.
+    apply cancel_postcomposition.
+    induction (natlehchoice4 (pr1 (lastelement n)) n (pr2 (lastelement n))).
+
+    (* This case is false because of a0 *)
+    apply fromempty. cbn in a0. apply (isirreflnatlth _ a0).
+
+    apply pathsinv0. unfold m2. rewrite assoc. unfold in2.
+    apply cancel_postcomposition. unfold Cone2In.
+
+    (* This case makes sense *)
+    set (e := isconnectedstn1 i (invweq(weqstn1tounit) tt)).
+    use (pathscomp0 _ (CoproductIn_idtoiso (stn 1) C
+                                           (fun _ : _ => a(lastelement n))
+                                           Cone2 e)).
+    apply cancel_postcomposition.
+    apply maponpaths. apply maponpaths. (* Why we need maponpaths twice? *)
+    fold (@funcomp (stn 1) _ _ (fun _ : stn 1 => lastelement n) a).
+    rewrite <- (maponpathscomp (fun _ : stn 1 => lastelement n) a).
+    apply maponpaths. apply isasetstn.
+  Defined.
+End FinOrdCoproduct_criteria.

--- a/UniMath/CategoryTheory/limits/FinOrdProducts.v
+++ b/UniMath/CategoryTheory/limits/FinOrdProducts.v
@@ -169,7 +169,8 @@ Section FinOrdProduct_criteria.
     set (e := dni_lastelement_is_inj (dni_lastelement_eq n (dni_lastelement i)
                                                          a0)).
     use (pathscomp0 _ (ProductPr_idtoiso (stn n) C (a ∘ dni_lastelement) Cone1
-                                         e)).
+                                         (!e))).
+    rewrite maponpathsinv0.
     apply cancel_precomposition.
     apply maponpaths. apply maponpaths. (* Why we need maponpaths twice? *)
     apply maponpaths.
@@ -197,7 +198,8 @@ Section FinOrdProduct_criteria.
 
     set (e := isconnectedstn1 i (invweq(weqstn1tounit) tt)).
     use (pathscomp0 _ (ProductPr_idtoiso (stn 1) C (fun _ : _ => a(lastelement n))
-                                         Cone2 e)).
+                                         Cone2 (!e))).
+    rewrite maponpathsinv0.
     apply cancel_precomposition.
     apply maponpaths. apply maponpaths. (* Why we need maponpaths twice? *)
     apply maponpaths.

--- a/UniMath/CategoryTheory/limits/FinOrdProducts.v
+++ b/UniMath/CategoryTheory/limits/FinOrdProducts.v
@@ -1,0 +1,208 @@
+(** A direct definition of finite ordered products by using products *)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.Foundations.Combinatorics.StandardFiniteSets.
+
+Require Import UniMath.CategoryTheory.total2_paths.
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.ProductPrecategory.
+
+Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.limits.binproducts.
+Require Import UniMath.CategoryTheory.limits.terminal.
+
+
+(** Definition of finite ordered products. *)
+Section def_FinOrdProducts.
+
+  Variable C : precategory.
+
+  Definition FinOrdProducts : UU :=
+    forall (n : nat) (a : stn n -> C), ProductCone (stn n) C a.
+  Definition hasFinOrdProducts := ishinh FinOrdProducts.
+
+End def_FinOrdProducts.
+
+
+(** Construction of FinOrdProducts from Terminal and BinProducts. *)
+Section FinOrdProduct_criteria.
+
+  Variable C : precategory.
+  Hypothesis hs : has_homsets C.
+
+  (** Case n = 0 of the theorem. *)
+  Lemma TerminalToProduct (T : Terminal C):
+    ∀ (a : stn 0 -> C), ProductCone (stn 0) C a.
+  Proof.
+    intros a.
+    use (mk_ProductCone _ _ _ T
+                        (fun i : stn 0 => fromempty (weqstn0toempty i))).
+    use (mk_isProductCone _ _ hs).
+    intros c g. use unique_exists.
+
+    apply (TerminalArrow c).
+    intros i. apply (fromempty (weqstn0toempty i)).
+    intros y. apply impred_isaprop. intros t. apply hs.
+    intros y X. apply ArrowsToTerminal.
+  Defined.
+
+  (** Case n = 1 of the theorem. *)
+  Lemma identity_to_product:
+    forall (a : stn 1 -> C), ProductCone (stn 1) C a.
+  Proof.
+    intros a.
+    set (stn1ob := invweq(weqstn1tounit) tt).
+
+    use (mk_ProductCone _ _ _ (a stn1ob)).
+    intros i. exact (idtoiso ((maponpaths a (isconnectedstn1 stn1ob i)))).
+
+    use (mk_isProductCone _ _ hs).
+    intros c g.
+    use (unique_exists).
+    exact (g stn1ob).
+
+    (* Commutativity. *)
+    intros i. rewrite <- (isconnectedstn1 stn1ob i). apply id_right.
+
+    (* Equality of equalities of morphisms. *)
+    intros y. apply impred_isaprop. intros t. apply hs.
+
+    (* Uniqueness. *)
+    intros y X. rewrite <- (X stn1ob). apply pathsinv0. apply id_right.
+  Defined.
+
+  (** Finite ordered products from terminal and binary products *)
+  Theorem FinOrdProducts_from_Terminal_and_BinProducts :
+    Terminal C -> BinProducts C -> FinOrdProducts C.
+  Proof.
+    intros T BinProds. unfold FinOrdProducts. intros n. induction n.
+
+    (* Case n = 0 *)
+    apply (TerminalToProduct T).
+
+    (* General case. *)
+    intros a.
+    set (a1 := fun (i : stn n) => a (dni_lastelement i)).
+    set (Cone1 := IHn a1).
+    set (a2 := (fun _ : stn 1 => a (lastelement n))).
+    set (Cone2 := identity_to_product a2). (* Case n = 1 *)
+    set (Cone1Pr := ProductPr _ _ Cone1).
+    set (Cone2Pr := ProductPr _ _ Cone2).
+    set (BinCone := BinProds (ProductObject (stn n) C Cone1)
+                             (ProductObject (stn 1) C Cone2)).
+    set (p1 := BinProductPr1 _ BinCone).
+    set (p2 := BinProductPr2 _ BinCone).
+    set (m1 := fun i1 : stn n => p1 ;; (Cone1Pr i1)).
+    set (m2 := fun i2 : stn 1 => p2 ;; (Cone2Pr i2)).
+    set (BinConeOb := BinProductObject _ BinCone).
+    fold BinConeOb in p1, p2, m1, m2.
+
+    use (mk_ProductCone (stn (S n)) C a BinConeOb _).
+
+    (* Construction of the arrows from a i to BinConeOb *)
+    intros i. induction (natlehchoice4 (pr1 i) _ (pr2 i)).
+    exact (m1 (stnpair n (pr1 i) a0) ;;
+              idtoiso (! maponpaths a (dni_lastelement_eq n i a0))).
+    exact (m2 (invweq(weqstn1tounit) tt) ;;
+              idtoiso (! maponpaths a (lastelement_eq n i b))).
+
+    (* Construction of isProductCone. *)
+    use (mk_isProductCone _ _ hs).
+    intros c g.
+
+    set (g1 := fun i : stn n => g(dni_lastelement i)).
+    set (ar1 := ProductArrow _ _ Cone1 g1). fold ar1.
+    set (com1 := BinProductPr1Commutes  _ _ _ BinCone c ar1 (g(lastelement n))).
+    set (com2 := BinProductPr2Commutes _ _ _ BinCone c ar1 (g(lastelement n))).
+    set (com3 := ProductPrCommutes _ _ _ Cone1 _ g1).
+    set (com4 := ProductPrCommutes _ _ _ Cone2 _
+                                   (fun _ : stn 1 => g(lastelement n))).
+
+    use (unique_exists).
+
+    (* Construction of the unique arrow from ConeOb to c. *)
+    use (BinProductArrow _ BinCone).
+    use (ProductArrow _ _ Cone1). intros i. exact (g (dni_lastelement i)).
+    use (ProductArrow _ _ Cone2). intros i. exact (g (lastelement n)).
+
+    (* First commutativity. *)
+    intros i. unfold coprod_rect. induction (natlehchoice4 (pr1 i) n (pr2 i)).
+    rewrite (dni_lastelement_eq n i a0). repeat rewrite assoc.
+    apply remove_id_right. apply idpath.
+
+    unfold m1. unfold p1. rewrite assoc. fold g1. fold ar1.
+    use (pathscomp0 (maponpaths (fun f : _ => f ;; Cone1Pr (stnpair n (pr1 i) a0))
+                                com1)).
+    fold ar1 in com3. rewrite com3. unfold g1. apply idpath.
+
+
+    (* Second commutativity. *)
+    rewrite (lastelement_eq n i b). repeat rewrite assoc.
+    apply remove_id_right. apply idpath.
+
+    unfold m2. unfold p2. rewrite assoc. fold g1. fold ar1.
+    use (pathscomp0 (maponpaths (fun f : _ => f ;; Cone2Pr (lastelement 0)) com2)).
+    rewrite com4. apply idpath.
+
+
+    (* Equality on equalities of morphisms. *)
+    intros y. apply impred_isaprop. intros t. apply hs.
+
+    (* Uniqueness *)
+    unfold coprod_rect. intros k X.
+    apply BinProductArrowUnique.
+
+
+    (* From stn n *)
+    apply ProductArrowUnique.
+    intros i. rewrite <- (X (dni_lastelement i)). rewrite <- assoc.
+    apply cancel_precomposition.
+    induction (natlehchoice4 (pr1 (dni_lastelement i)) n
+                             (pr2 (dni_lastelement i))).
+    unfold m1. rewrite <- assoc. unfold p1.
+    apply cancel_precomposition.
+    unfold Cone1Pr. apply pathsinv0.
+
+    set (e := dni_lastelement_is_inj (dni_lastelement_eq n (dni_lastelement i)
+                                                         a0)).
+    use (pathscomp0 _ (ProductPr_idtoiso (stn n) C (a ∘ dni_lastelement) Cone1
+                                         e)).
+    apply cancel_precomposition.
+    apply maponpaths. apply maponpaths. (* Why we need maponpaths twice? *)
+    apply maponpaths.
+    rewrite <- (maponpathscomp _ a).
+    apply maponpaths. apply isasetstn.
+
+    (* This is false because of b *)
+    apply fromempty. induction i as [i i'].
+    cbn in b. induction (!b).
+    apply (isirreflnatlth _ i').
+
+
+    (* From stn 1 *)
+    apply ProductArrowUnique.
+    intros i. rewrite <- (X (lastelement n)).  rewrite <- assoc.
+    apply cancel_precomposition.
+    induction (natlehchoice4 (pr1 (lastelement n)) n (pr2 (lastelement n))).
+
+    (* This case is false because of a0 *)
+    apply fromempty. cbn in a0. apply (isirreflnatlth _ a0).
+
+    (* This case makes sense *)
+    apply pathsinv0. unfold m2. rewrite <- assoc. unfold p2.
+    apply cancel_precomposition. unfold Cone2Pr.
+
+    set (e := isconnectedstn1 i (invweq(weqstn1tounit) tt)).
+    use (pathscomp0 _ (ProductPr_idtoiso (stn 1) C (fun _ : _ => a(lastelement n))
+                                         Cone2 e)).
+    apply cancel_precomposition.
+    apply maponpaths. apply maponpaths. (* Why we need maponpaths twice? *)
+    apply maponpaths.
+    fold (@funcomp (stn 1) _ _ (fun _ : stn 1 => lastelement n) a).
+    rewrite <- (maponpathscomp (fun _ : stn 1 => lastelement n) a).
+    apply maponpaths. apply isasetstn.
+  Defined.
+End FinOrdProduct_criteria.

--- a/UniMath/CategoryTheory/limits/coproducts.v
+++ b/UniMath/CategoryTheory/limits/coproducts.v
@@ -54,6 +54,14 @@ Proof.
   exact (pr2 (pr1 (isCoproductCocone_CoproductCocone CC _ f)) i).
 Qed.
 
+Lemma CoproductIn_idtoiso {i1 i2 : I} (a : I -> C) (CC : CoproductCocone a)
+      (e : i1 = i2) :
+  idtoiso (maponpaths a e) ;; CoproductIn CC i2 = CoproductIn CC i1.
+Proof.
+  induction e.
+  apply id_left.
+Qed.
+
 Lemma CoproductArrowUnique (a : I -> C) (CC : CoproductCocone a) (x : C)
     (f : forall i, a i --> x) (k : CoproductObject CC --> x)
     (Hk : forall i, CoproductIn CC i ;; k = f i) :

--- a/UniMath/CategoryTheory/limits/products.v
+++ b/UniMath/CategoryTheory/limits/products.v
@@ -57,7 +57,7 @@ Qed.
 
 Lemma ProductPr_idtoiso {i1 i2 : I} (a : I -> C) (P : ProductCone a)
       (e : i1 = i2) :
-  ProductPr P i2 ;; idtoiso (! maponpaths a e) = ProductPr P i1.
+  ProductPr P i1 ;; idtoiso (maponpaths a e) = ProductPr P i2.
 Proof.
   induction e.
   apply id_right.

--- a/UniMath/CategoryTheory/limits/products.v
+++ b/UniMath/CategoryTheory/limits/products.v
@@ -55,6 +55,14 @@ Proof.
   apply (pr2 (pr1 (isProductCone_ProductCone P _ f)) i).
 Qed.
 
+Lemma ProductPr_idtoiso {i1 i2 : I} (a : I -> C) (P : ProductCone a)
+      (e : i1 = i2) :
+  ProductPr P i2 ;; idtoiso (! maponpaths a e) = ProductPr P i1.
+Proof.
+  induction e.
+  apply id_right.
+Qed.
+
 Lemma ProductArrowUnique (c : forall i, C) (P : ProductCone c) (x : C)
     (f : forall i, x --> c i) (k : x --> ProductObject P)
     (Hk : forall i, k ;; ProductPr P i = f i) : k = ProductArrow P f.

--- a/UniMath/CategoryTheory/precategories.v
+++ b/UniMath/CategoryTheory/precategories.v
@@ -226,6 +226,13 @@ Proof.
   apply idpath.
 Defined.
 
+Lemma cancel_precomposition (C : precategory_data) (a b c: C)
+   (f f' : b --> c) (g : a --> b) : f = f' -> g ;; f = g ;; f'.
+Proof.
+  intro H.
+  induction H.
+  apply idpath.
+Defined.
 
 (** * Setcategories: Precategories whose objects and morphisms are sets *)
 

--- a/UniMath/Foundations/Basics/PartB.v
+++ b/UniMath/Foundations/Basics/PartB.v
@@ -469,6 +469,20 @@ Corollary subtypeEquality' {A : UU} {B : A -> UU}
 (* This variant of subtypeEquality is not often needed. *)
 Proof. intros ? ? ? ? e is. apply (total2_paths e). apply is. Defined.
 
+(* This corollary of subtypeEquality is used for categories. *)
+Corollary unique_exists {A : UU} {B : A -> UU} (x : A) (b : B x)
+          (h : forall y, isaprop (B y)) (H : forall y, B y -> y = x) :
+  iscontr (total2 (fun t : A => B t)).
+Proof.
+  intros A B x b h H.
+  use iscontrpair.
+  exact (x,,b).
+  intros t.
+  apply subtypeEquality'.
+  apply (H (pr1 t)). apply (pr2 t).
+  apply (h (pr1 (x,,b))).
+Defined.
+
 Definition subtypePairEquality {X} {P:X -> UU} (is: isPredicate P)
            {x y:X} {p:P x} {q:P y} :
   x = y -> (x,,p) = (y,,q).

--- a/UniMath/Foundations/Combinatorics/StandardFiniteSets.v
+++ b/UniMath/Foundations/Combinatorics/StandardFiniteSets.v
@@ -381,6 +381,13 @@ Proof. set ( f := fun x : stn 1 => tt ) . apply weqcontrcontr .  split with ( la
 Corollary iscontrstn1 : iscontr ( stn 1 ) .
 Proof. apply iscontrifweqtounit . apply weqstn1tounit . Defined .
 
+Corollary isconnectedstn1 : forall i1 i2 : stn 1, i1 = i2.
+Proof.
+  intros i1 i2.
+  apply (invmaponpathsweq weqstn1tounit).
+  apply isconnectedunit.
+Defined.
+
 Lemma isinclfromstn1 { X : UU } ( f : stn 1 -> X ) ( is : isaset X ) : isincl f .
 Proof. intros . apply ( isinclbetweensets f ( isasetstn 1 ) is ) . intros x x' e . apply ( invmaponpathsweq weqstn1tounit x x' ( idpath tt ) )  .  Defined .
 
@@ -912,6 +919,34 @@ apply ( X n ( hinhpr ( tpair _ n ( dirprodpair ( isreflnatleh n ) l ) ) ) ) .  D
 
 Lemma isinjstntonat n : isInjectiveFunction (pr1 : stnset n -> natset).
 Proof. intros ? i j. apply (invmaponpathsincl pr1). apply isinclstntonat. Defined.
+
+Corollary dni_lastelement_is_inj {n : nat} {i j : stn n}
+      (e : dni_lastelement i = dni_lastelement j) :
+  i = j.
+Proof.
+  intros n i j e.
+  apply isinjstntonat.
+  unfold dni_lastelement in e.
+  apply (maponpaths pr1) in e.
+  exact e.
+Defined.
+
+Corollary dni_lastelement_eq : forall (n : nat) (i : stn (S n)) (ie : pr1 i < n),
+    i = dni_lastelement (stnpair n (pr1 i) ie).
+Proof.
+  intros n i ie.
+  apply isinjstntonat.
+  apply idpath.
+Defined.
+
+Corollary lastelement_eq : forall (n : nat) (i : stn (S n)) (e : pr1 i = n),
+    i = lastelement n.
+Proof.
+  intros n i e.
+  unfold lastelement.
+  apply isinjstntonat.
+  apply e.
+Defined.
 
 (* a tactic for proving things by induction over a finite number of cases *)
 Ltac inductive_reflexivity i b :=


### PR DESCRIPTION
Hi,

this pull request replaces my older pull request on the subject. This pull
request contains:
- Construction of binary (co)products from (co)products and vice versa.
- Direct definition of iterated binary (co)products.
- Construction of iterated binary coproduct (resp. iterated binary product)
  from initial and binary coproducts (resp. terminal and binary products).

What has changed
- Proofs no longer use Univalence. (I use funextfun, and this is defined in
  PartD.v)
- The proofs use the definition stn_alt. This approach was suggested by
  Benedikt. For some reason I called this iter. See Iter.v . I don't know if
  this is a good name. Suggestions for a better one?
- What I mistakenly called finite (co)products last time are now called
  iterated binary (co)products. This was suggested by Dan.
- Renamed subtypeEquality'' to exists_unique. Suggested by Benedikt.
- Use termfun instead of unit_to_ob. Suggested by Benedikt.

The last two definitions and lemma in Iter.v do not really seem to belong
there. Where one should put these?

All comments are welcome.
