### PR TITLE
Axiom reorganization

### DIFF
--- a/UniMath/CategoryTheory/HLevel_n_is_of_hlevel_Sn.v
+++ b/UniMath/CategoryTheory/HLevel_n_is_of_hlevel_Sn.v
@@ -118,7 +118,7 @@ Lemma isofhlevel0pathspace (X Y : UU) :
     iscontr X -> iscontr Y -> iscontr (X = Y).
 Proof.
   intros pX pY.
-  set (H := isofhlevelweqb 0 (tpair _ _ (univalenceaxiom X Y))).
+  set (H := isofhlevelweqb 0 (tpair _ _ (univalenceAxiom X Y))).
   apply H.
   exists (isofhlevel0weq _ _ pX pY ).
   intro f.
@@ -139,7 +139,7 @@ Lemma isofhlevelSnpathspace : forall n : nat, forall X Y : UU,
       isofhlevel (S n) Y -> isofhlevel (S n) (X = Y).
 Proof.
   intros n X Y pY.
-  set (H:=isofhlevelweqb (S n) (tpair _ _ (univalenceaxiom X Y))).
+  set (H:=isofhlevelweqb (S n) (tpair _ _ (univalenceAxiom X Y))).
   apply H.
   assert (H' : isofhlevel (S n) (X -> Y)).
     apply impred.
@@ -206,7 +206,7 @@ Lemma UA_for_Predicates (P : UU -> hProp) (X X' : UU)
   weq ((tpair _ X pX) = (tpair (fun x => P x) X' pX')) (weq X X').
 Proof.
   set (f := Id_p_weq_Id P X X' pX pX').
-  set (g := tpair _ _ (univalenceaxiom X X')).
+  set (g := tpair _ _ (univalenceAxiom X X')).
   exact (weqcomp f g).
 Defined.
 

--- a/UniMath/CategoryTheory/category_hset.v
+++ b/UniMath/CategoryTheory/category_hset.v
@@ -116,10 +116,10 @@ Lemma hset_equiv_is_iso (A B : hSet)
 Proof.
   apply (is_iso_qinv (C:=HSET) _ (invmap f)).
   split; simpl.
-  - apply funextfunax; intro x; simpl in *.
+  - apply funextfun; intro x; simpl in *.
     unfold compose, identity; simpl.
     apply homotinvweqweq.
-  - apply funextfunax; intro x; simpl in *.
+  - apply funextfun; intro x; simpl in *.
     unfold compose, identity; simpl.
     apply homotweqinvweq.
 Defined.
@@ -172,7 +172,7 @@ Defined.
 (** ** HSET is a category. *)
 
 Definition univalenceweq (X X' : UU) : weq (X = X') (weq X X') :=
-   tpair _ _ (univalenceaxiom X X').
+   tpair _ _ (univalenceAxiom X X').
 
 Definition hset_id_iso_weq (A B : ob HSET) :
   weq (A = B) (iso A B) :=
@@ -190,7 +190,7 @@ Definition hset_id_iso_weq (A B : ob HSET) :
 Lemma hset_id_iso_weq_is (A B : ob HSET):
     @idtoiso _ A B = pr1 (hset_id_iso_weq A B).
 Proof.
-  apply funextfunax.
+  apply funextfun.
   intro p; elim p.
   apply eq_iso; simpl.
   - apply funextfun;

--- a/UniMath/CategoryTheory/precomp_ess_surj.v
+++ b/UniMath/CategoryTheory/precomp_ess_surj.v
@@ -793,6 +793,7 @@ Defined.
 Lemma extphi : pr1 (pr1 (functor_composite H GG)) = pr1 (pr1 F).
 Proof.
   apply funextsec.
+  unfold homot.
   apply phi.
 Defined.
 

--- a/UniMath/CategoryTheory/sub_precategories.v
+++ b/UniMath/CategoryTheory/sub_precategories.v
@@ -438,11 +438,11 @@ Proof.
   apply (total2_paths2 (H)).
   unfold functor_full_img_factorization_ob in H.
   simpl in *.
-  apply dep_funextfunax.
+  apply dep_funextfun.
   intro a.
-  apply dep_funextfunax.
+  apply dep_funextfun.
   intro b.
-  apply funextfunax.
+  apply funextfun.
   intro f.
 
   generalize Fmor.
@@ -548,7 +548,7 @@ Lemma Id_in_sub_to_iso_equal_iso
     Id_in_sub_to_iso a b = funcomp (total2_paths_hProp_equiv C' a b)
                                     (@idtoiso _ (pr1 a) (pr1 b)).
 Proof.
-  apply funextfunax.
+  apply funextfun.
   intro p.
   destruct p.
   apply eq_iso.
@@ -571,7 +571,7 @@ Lemma precat_paths_in_sub_as_3_maps
      @idtoiso _ a b = funcomp (Id_in_sub_to_iso a b)
                                         (iso_in_sub_from_iso a b).
 Proof.
-  apply funextfunax.
+  apply funextfun.
   intro p; destruct p.
   apply eq_iso; simpl.
   unfold precategory_morphisms_in_subcat.

--- a/UniMath/CategoryTheory/sub_precategories.v
+++ b/UniMath/CategoryTheory/sub_precategories.v
@@ -409,15 +409,14 @@ Qed.
 
 (** *** Image factorization C -> Img(F) -> D *)
 
-Lemma functor_full_img_factorization_ob (C D: precategory)
+Local Lemma functor_full_img_factorization_ob (C D: precategory)
    (F : functor C D):
   functor_on_objects F =
   functor_on_objects (functor_composite
        (functor_full_img F)
             (sub_precategory_inclusion D _)).
 Proof.
-  simpl.
-  apply etacorrection.
+  reflexivity.
 Defined.
 
 

--- a/UniMath/Dedekind/NonnegativeReals.v
+++ b/UniMath/Dedekind/NonnegativeReals.v
@@ -439,7 +439,7 @@ Proof.
   - now intro ; apply pr2.
   - apply funextsec.
     intro r.
-    apply uahp.
+    apply hPropUnivalence.
     exact (pr1 (Heq r)).
     exact (pr2 (Heq r)).
 Qed.
@@ -1291,7 +1291,7 @@ Proof.
       apply plusNonnegativeRationals_le_l. }
     assert (Heq : Dcuts_mult_val X Y = (Dcuts_NQmult_val (x + 1%NRat) (Dcuts_mult_val (Dcuts_NQmult_val (/ (x + 1))%NRat X) Y))).
     { apply funextfun ; intro r.
-      apply uahp.
+      apply hPropUnivalence.
       - apply hinhfun ; intros ((rx,ry)) ; simpl ; intros (Hr,(Xr,Yr)).
         exists (r / (x + 1))%NRat ; split.
         + now  rewrite multdivNonnegativeRationals.
@@ -1556,7 +1556,7 @@ Proof.
     exact Xx. }
   assert (Heq : Dcuts_inv_val X = Dcuts_NQmult_val (/x)%NRat (Dcuts_inv_val Y)).
   { apply funextfun ; intro r.
-    apply uahp.
+    apply hPropUnivalence.
     - apply hinhfun ; intros (l,(Hl,(Hl0,Hl1))).
       exists (x * r) ; split.
       now rewrite <- isassoc_multNonnegativeRationals, islinv_NonnegativeRationals, islunit_oneNonnegativeRationals.
@@ -4163,7 +4163,7 @@ Proof.
   intros.
   apply funextfun.
   intros x.
-  apply uahp.
+  apply hPropUnivalence.
   - apply hinhuniv.
     simpl pr1.
     intros (r,(Hr)).

--- a/UniMath/Folds/folds_isomorphism.v
+++ b/UniMath/Folds/folds_isomorphism.v
@@ -237,10 +237,10 @@ Proof.
     + apply funextsec; intro.
       apply subtypeEquality.
       * intro; apply isapropisweq.
-      * apply funextfun. apply ϕ₂_determined.
+      * apply funextfun. unfold homot. apply ϕ₂_determined.
   - apply subtypeEquality.
     intro. apply isapropisweq.
-    apply funextfun. intros.
+    apply funextfun. intro t.
     apply ϕo_determined.
 Qed.
 

--- a/UniMath/Folds/folds_isomorphism.v
+++ b/UniMath/Folds/folds_isomorphism.v
@@ -227,7 +227,7 @@ Proof.
     + apply funextsec; intro.
       apply subtypeEquality.
       * intro. apply isapropisweq.
-      * apply funextfunax; intro f.
+      * apply funextfun; intro f.
         eapply pathscomp0.
         { apply ϕ₁_is_comp. }
         symmetry.
@@ -237,10 +237,10 @@ Proof.
     + apply funextsec; intro.
       apply subtypeEquality.
       * intro; apply isapropisweq.
-      * apply funextfunax. apply ϕ₂_determined.
+      * apply funextfun. apply ϕ₂_determined.
   - apply subtypeEquality.
     intro. apply isapropisweq.
-    apply funextfunax. intros.
+    apply funextfun. intros.
     apply ϕo_determined.
 Qed.
 

--- a/UniMath/Foundations/.package/files
+++ b/UniMath/Foundations/.package/files
@@ -4,6 +4,7 @@ Basics/PartB.v
 Basics/UnivalenceAxiom.v
 Basics/PartC.v
 Basics/PartD.v
+Basics/UnivalenceAxiom2.v
 Basics/Tests.v
 Basics/Propositions.v
 Basics/Sets.v

--- a/UniMath/Foundations/.package/files
+++ b/UniMath/Foundations/.package/files
@@ -1,10 +1,10 @@
 Basics/Preamble.v
 Basics/PartA.v
 Basics/PartB.v
+Basics/UnivalenceAxiom.v
 Basics/PartC.v
 Basics/PartD.v
 Basics/Tests.v
-Basics/UnivalenceAxiom.v
 Basics/Propositions.v
 Basics/Sets.v
 Algebra/BinaryOperations.v

--- a/UniMath/Foundations/Basics/PartA.v
+++ b/UniMath/Foundations/Basics/PartA.v
@@ -954,9 +954,6 @@ Definition weqpair {X Y : UU} (f : X -> Y) (is: isweq f) : X ≃ Y :=
 Definition idweq (X : UU) : X ≃ X :=
   tpair (fun (f : X -> X) => isweq f) (fun (x : X) => x) (idisweq X).
 
-Definition eqweqmap { T1 T2 : UU } : T1 = T2 -> T1 ≃ T2.
-Proof. intros ? ? []. apply idweq. Defined.
-
 Definition isweqtoempty {X : UU} (f : X -> empty) : isweq f.
 Proof.
   intros. intro y. apply (fromempty y).

--- a/UniMath/Foundations/Basics/PartC.v
+++ b/UniMath/Foundations/Basics/PartC.v
@@ -2,7 +2,7 @@
  March 2014. The third part of the original uu0 file, created on Dec. 3, 2014.
 
 One one usniverse is used and never as a type.
-The only axiom we use is [ funextempty ] which is the functional extensionality
+The only axiom we use is [ funextemptyAxiom ] which is the functional extensionality
  axiom for functions with values in the empty type. *)
 
 
@@ -16,24 +16,13 @@ Coq8.2 *)
 (** Imports *)
 
 Require Export UniMath.Foundations.Basics.PartB.
-
-
-
-
-
-
-
-(** *** Functional extensionality for functions to the empty type *)
-
-Axiom funextempty : ∀ (X:UU) (f g : X->empty), f = g.
-
-
+Require Export UniMath.Foundations.Basics.UnivalenceAxiom.
 
 (** *** More results on propositions *)
 
 
 Theorem isapropneg (X:UU): isaprop (neg X).
-Proof. intro.  apply invproofirrelevance . intros x x' .   apply ( funextempty X x x' ) . Defined .
+Proof. intro.  apply invproofirrelevance . intros x x' .   apply ( funextemptyAxiom X x x' ) . Defined .
 
 (** See also [ isapropneg2 ] *)
 
@@ -58,7 +47,7 @@ set (f:= todneg (neg X)). set (g:= negf  (todneg X)). set (is1:= isapropneg X). 
 
 
 Theorem isapropdec (X:UU): isaprop X -> isaprop (X ⨿ ¬X).
-(* uses [funextempty] *)
+(* uses [funextemptyAxiom] *)
 Proof.
   intros ? i. apply isapropcoprod.
   - exact i.
@@ -120,7 +109,7 @@ Definition pr1compl_ne ( X : UU ) ( x : X ) (neq_x : neqPred x) (c:compl_ne X x 
 
 Definition make_negProp {P:UU} : negProp P.
 Proof. intros. exists (¬ P). split.
-  - apply isapropneg.  (* uses [funextempty] *)
+  - apply isapropneg.  (* uses [funextemptyAxiom] *)
   - apply isrefl_logeq.
 Defined.
 
@@ -132,7 +121,7 @@ Proof. intros. apply isinclpr1. intro y. apply negProp_to_isaprop. Defined.
 
 Lemma compl_ne_weq_compl ( X : UU ) ( x : X ) (neq_x : neqPred x) : compl X x ≃ compl_ne X x neq_x.
 Proof.
-  (* uses [funextempty] *)
+  (* uses [funextemptyAxiom] *)
   intros. apply weqfibtototal; intro y. apply weqiff.
   - apply negProp_to_iff.
   - apply isapropneg.
@@ -141,7 +130,7 @@ Defined.
 
 Lemma compl_weq_compl_ne ( X : UU ) ( x : X ) (neq_x : neqPred x) : compl_ne X x neq_x ≃ compl X x.
 Proof.
-  (* uses [funextempty] *)
+  (* uses [funextemptyAxiom] *)
   intros. apply weqfibtototal; intro y. apply weqiff.
   - apply issymm_logeq. apply negProp_to_iff.
   - apply negProp_to_isaprop.
@@ -181,7 +170,7 @@ Defined.
 
 Definition weqoncompl { X Y : UU } (w: X ≃ Y) x : compl X x ≃ compl Y (w x).
 Proof.
-  (* uses [funextempty] *)
+  (* uses [funextemptyAxiom] *)
   intros. intermediate_weq (Σ x', w x != w x').
   - apply weqfibtototal; intro x'. apply weqiff.
     { apply logeqnegs. apply weq_to_iff. apply weqonpaths. }
@@ -352,7 +341,7 @@ Defined.
 
 Theorem isweqrecompl_ne (X:UU) (x:X) (is:isisolated X x) (neq_x:neqPred x): isweq (recompl_ne _ x neq_x).
 Proof.
-  (* does not use [funextempty] *)
+  (* does not use [funextemptyAxiom] *)
   intros. set (f:= recompl_ne X x neq_x). set (g:= invrecompl_ne X x neq_x is).
   refine (gradth f g _ _).
   { intro u. induction (is (f u)) as [ eq | ne ] .
@@ -1134,65 +1123,5 @@ Proof. intros . set ( p := sumofmaps f ( @pr1 _ ( fun y : Y => neg ( hfiber f y 
 
 Theorem isdecinclfromiscoproj { X Y : UU } ( f : X -> Y ) ( is : iscoproj f ) : isdecincl f .
 Proof . intros . set ( g := ( sumofmaps f ( @pr1 _ ( fun y : Y => neg ( hfiber f y ) ) ) ) ) . set ( f' :=  fun x : X => g ( ii1 x ) ) . assert ( is' : isdecincl f' ) . apply ( isdecinclcomp _ _ ( isdecinclii1 _ _ ) ( isdecinclfromisweq _ is ) ) .    assumption .  Defined .
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-(** ** Results using full form of the functional extentionality axioms.
-
-Summary: We consider two axioms which address functional extensionality. The first one is etacorrection  which compensates for the absense of eta-reduction in Coq8.3 Eta-reduction is expected to be included as a  basic property of the language in Coq8.4 which will make this axiom and related lemmas unnecessary. The second axiom [ funcontr ] is the functional extensionality for dependent functions formulated as the condition that the space of section of a family with contractible fibers is contractible.
-
-Note : some of the results above this point in code use a very limitted form of functional extensionality . See [ funextempty ] .
-
-*)
-
-
-(** *** Axioms and their basic corollaries *)
-
-(** etacorrection *)
-
-Definition etacorrection: forall T:UU, forall P:T -> UU, forall f: (forall t:T, P t), paths f (fun t:T => f t).
-Proof. reflexivity. Defined.
-
-Lemma isweqetacorrection { T : UU } (P:T -> UU): isweq (fun f: forall t:T, P t => (fun t:T => f t)).
-Proof. intros. apply idisweq. Defined.
-
-Definition weqeta { T : UU } (P:T -> UU) := weqpair _ ( isweqetacorrection P ) .
-
-Lemma etacorrectiononpaths { T : UU } (P:T->UU)(s1 s2 :forall t:T, P t) : paths (fun t:T => s1 t) (fun t:T => s2 t)-> paths s1 s2.
-Proof. intros T P s1 s2 X. set (ew := weqeta P). apply (invmaponpathsweq ew s1 s2 X). Defined.
-
-Definition etacor { X Y : UU } (f:X -> Y) : paths f (fun x:X => f x) := etacorrection _ (fun T:X => Y) f.
-
-Lemma etacoronpaths { X Y : UU } (f1 f2 : X->Y) : paths (fun x:X => f1 x) (fun x:X => f2 x) -> paths f1 f2.
-Proof. intros X Y f1 f2 X0. set (ec:= weqeta (fun x:X => Y) ). apply (invmaponpathsweq  ec f1 f2 X0). Defined.
-
-
-(** Dependent functions and sections up to homotopy I *)
-
-
-Definition toforallpaths { T : UU }  (P:T -> UU) (f g :forall t:T, P t) : (paths f g) -> (forall t:T, paths (f t) (g t)).
-Proof. intros T P f g X t. induction X. apply (idpath (f t)). Defined.
-
-
-Definition sectohfiber { X : UU } (P:X -> UU): (forall x:X, P x) -> (hfiber (fun f:_ => fun x:_ => pr1  (f x)) (fun x:X => x)) := (fun a : forall x:X, P x => tpair _ (fun x:_ => tpair _ x (a x)) (idpath (fun x:X => x))).
-
-Definition hfibertosec  { X : UU } (P:X -> UU):  (hfiber (fun f:_ => fun x:_ => pr1  (f x)) (fun x:X => x)) -> (forall x:X, P x):= fun se:_  => fun x:X => match se as se' return P x with tpair _ s e => (transportf P (toforallpaths (fun x:X => X)  (fun x:X => pr1 (s x)) (fun x:X => x) e x) (pr2  (s x))) end.
-
-Definition sectohfibertosec { X : UU } (P:X -> UU): forall a: forall x:X, P x, paths (hfibertosec _  (sectohfiber _ a)) a := fun a:_ => (pathsinv0 (etacorrection _ _ a)).
-
 
 (* End of the file uu0c.v *)

--- a/UniMath/Foundations/Basics/PartC.v
+++ b/UniMath/Foundations/Basics/PartC.v
@@ -22,7 +22,7 @@ Require Export UniMath.Foundations.Basics.UnivalenceAxiom.
 
 
 Theorem isapropneg (X:UU): isaprop (neg X).
-Proof. intro.  apply invproofirrelevance . intros x x' .   apply ( funextemptyAxiom X x x' ) . Defined .
+Proof. intro.  apply invproofirrelevance . intros x x' .   apply ( funextempty X x x' ) . Defined .
 
 (** See also [ isapropneg2 ] *)
 

--- a/UniMath/Foundations/Basics/PartD.v
+++ b/UniMath/Foundations/Basics/PartD.v
@@ -218,7 +218,7 @@ Lemma maponsec1l2 { X : UU } (P:X -> UU)(f:X-> X)(h: forall x:X, paths (f x) x)(
 Proof. intros.
 
 set (map:= fun ff: total2 (fun f0:X->X => forall x:X, paths (f0 x) x) => maponsec1l0 P (pr1  ff) (pr2  ff) s x).
-assert (is1: iscontr (total2 (fun f0:X->X => forall x:X, paths (f0 x) x))). apply funextweql1. assert (e: paths (tpair  (fun f0:X->X => forall x:X, paths (f0 x) x) f h) (tpair  (fun f0:X->X => forall x:X, paths (f0 x) x) (fun x0:X => x0) (fun x0:X => idpath x0))). apply proofirrelevancecontr.  assumption.  apply (maponpaths map  e). Defined.
+assert (is1: iscontr (total2 (fun f0:X->X => forall x:X, paths (f0 x) x))). apply funextcontr. assert (e: paths (tpair  (fun f0:X->X => forall x:X, paths (f0 x) x) f h) (tpair  (fun f0:X->X => forall x:X, paths (f0 x) x) (fun x0:X => x0) (fun x0:X => idpath x0))). apply proofirrelevancecontr.  assumption.  apply (maponpaths map  e). Defined.
 
 
 Theorem isweqmaponsec1 { X Y : UU } (P:Y -> UU)(f: weq X Y ) : isweq (maponsec1 P f).

--- a/UniMath/Foundations/Basics/PartD.v
+++ b/UniMath/Foundations/Basics/PartD.v
@@ -39,20 +39,16 @@ Proof.
 Defined.
 
 Lemma lemmaeta1 { X : UU } (P:X->UU) (Q:(forall x:X, P x) -> UU)(s0: forall x:X, P x)(q: Q (fun x:X => (s0 x))): paths (tpair (fun s: (forall x:X, P x) => Q (fun x:X => (s x))) s0 q) (tpair (fun s: (forall x:X, P x) => Q (fun x:X => (s x))) (fun x:X => (s0 x)) q).
-Proof. intros. set (ff:= fun tp:total2 (fun s: (forall x:X, P x) => Q (fun x:X => (s x))) => tpair _ (fun x:X => pr1  tp x) (pr2  tp)). assert (X0 : isweq ff).  apply (isweqfpmap  ( weqeta P ) Q ).
-assert (ee: paths (ff (tpair (fun s : forall x : X, P x => Q (fun x : X => s x)) s0 q)) (ff (tpair (fun s : forall x : X, P x => Q (fun x : X => s x)) (fun x : X => s0 x) q))). apply idpath.
-
-apply (invmaponpathsweq ( weqpair ff X0 ) _ _ ee). Defined.
-
-
+Proof. reflexivity. Defined.
 
 Definition totaltoforalltototal { X : UU } ( P : X -> UU ) ( PP : forall x:X, P x -> UU )( ss : total2 (fun s0: forall x:X, P x => forall x:X, PP x (s0 x)) ): paths (foralltototal _ _ (totaltoforall  _ _ ss)) ss.
 Proof. intros.  induction ss as [ t x ]. unfold foralltototal. unfold totaltoforall.  simpl.  set (et:= fun x:X => t x).
 
-assert (paths (tpair (fun s0 : forall x0 : X, P x0 => forall x0 : X, PP x0 (s0 x0)) t x) (tpair (fun s0 : forall x0 : X, P x0 => forall x0 : X, PP x0 (s0 x0)) et x)). apply (lemmaeta1 P (fun s: forall x:X, P x =>  forall x:X, PP x (s x)) t x).
+       assert (paths (tpair (fun s0 : forall x0 : X, P x0 => forall x0 : X, PP x0 (s0 x0)) t x) (tpair (fun s0 : forall x0 : X, P x0 => forall x0 : X, PP x0 (s0 x0)) et x)).
+       reflexivity.
 
 assert (ee: paths (tpair (fun s0 : forall x0 : X, P x0 => forall x0 : X, PP x0 (s0 x0)) et x) (tpair (fun s0 : forall x0 : X, P x0 => forall x0 : X, PP x0 (s0 x0)) et (fun x0 : X => x x0))).
-assert (eee: paths x (fun x0:X => x x0)). apply etacorrection. induction eee. apply idpath. induction ee. apply pathsinv0. assumption. Defined.
+apply idpath. induction ee. apply pathsinv0. assumption. Defined.
 
 
 
@@ -86,16 +82,12 @@ Definition funtoprodtoprod { X Y Z : UU } ( f : X -> dirprod Y Z ) : dirprod ( X
 Definition prodtofuntoprod { X Y Z : UU } ( fg : dirprod ( X -> Y ) ( X -> Z ) ) : X -> dirprod Y Z := match fg with tpair _ f g => fun x : X => dirprodpair ( f x ) ( g x ) end .
 
 Theorem weqfuntoprodtoprod ( X Y Z : UU ) : weq ( X -> dirprod Y Z ) ( dirprod ( X -> Y ) ( X -> Z ) ) .
-Proof. intros. set ( f := @funtoprodtoprod X Y Z ) . set ( g := @prodtofuntoprod X Y Z ) . split with f .
-assert ( egf : forall a : _ , paths ( g ( f a ) ) a ) . intro a . apply funextfun .  intro x .  simpl . apply pathsinv0 . apply tppr .
-assert ( efg : forall a : _ , paths ( f ( g a ) ) a ) . intro a . induction a as [ fy fz ] . apply pathsdirprod .  simpl . apply pathsinv0 . apply etacorrection . simpl . apply pathsinv0 . apply etacorrection .
-apply ( gradth _ _ egf efg ) . Defined .
-
-
-
-
-
-
+Proof.
+  intros.
+  simple refine (weqpair _ (gradth (@funtoprodtoprod X Y Z) (@prodtofuntoprod X Y Z ) _ _ )).
+  - intro a . apply funextfun .  intro x .  simpl . apply pathsinv0, tppr .
+  - intro a . now induction a as [ fy fz ] .
+Defined.
 
 (** ** Homotopy fibers of the map [forall x:X, P x -> forall x:X, Q x] *)
 
@@ -327,25 +319,14 @@ Definition funfromcoprodtoprod { X Y Z : UU } ( f : coprod X Y -> Z ) : dirprod 
 Definition prodtofunfromcoprod { X Y Z : UU } ( fg : dirprod ( X -> Z ) ( Y -> Z ) ) : coprod X Y -> Z := match fg with tpair _ f g => sumofmaps f g end .
 
 Theorem weqfunfromcoprodtoprod ( X Y Z : UU ) : weq ( coprod X Y -> Z ) ( dirprod ( X -> Z ) ( Y -> Z ) ) .
-Proof. intros . set ( f := @funfromcoprodtoprod X Y Z ) . set ( g := @prodtofunfromcoprod X Y Z ) . split with f .
-assert ( egf : forall a : _ , paths ( g ( f a ) ) a ) .  intro a . apply funextfun .   intro xy .  induction xy as [ x | y ] .  apply idpath . apply idpath .
-assert ( efg : forall a : _ , paths ( f ( g a ) ) a ) . intro a . induction a as [ fx fy ] . simpl . apply pathsdirprod .  simpl . apply pathsinv0 . apply etacorrection . simpl . apply pathsinv0 . apply etacorrection .
-apply ( gradth _ _ egf efg ) . Defined .
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+Proof.
+  intros .
+  simple refine (
+           weqpair _ (gradth (@funfromcoprodtoprod X Y Z )
+                             (@prodtofunfromcoprod X Y Z) _ _)).
+  - intro a. apply funextfun; intro xy. induction xy as [ x | y ]; reflexivity.
+  - intro a. induction a as [fx fy]. reflexivity.
+Defined.
 
 (** ** Sections of families over contractible types and over [ total2 ] (over dependent sums) *)
 

--- a/UniMath/Foundations/Basics/Propositions.v
+++ b/UniMath/Foundations/Basics/Propositions.v
@@ -4,7 +4,7 @@ In this file we introduce the hProp - an analog of Prop defined based on the uni
 
 Resizing Rule RR1 ( U1 U2 : Univ ) ( X : U1 ) ( is : isaprop X ) |- X : U2 .
 
-Further in the file we introduce the univalence axiom for hProp and a proof of the fact that it is equivalent to a simplier and better known axiom [ uahp ]. We prove that this axiom implies that [ hProp ] satisfies [ isaset ] i.e. it is a type of h-level 2 . This requires another resizing rule :
+Further in the file we introduce the univalence axiom [ hPropUnivalence ] for hProp and a proof of the fact that it is equivalent to a simplier and better known axiom [ propositionalUnivalenceAxiom ]. We prove that this axiom implies that [ hProp ] satisfies [ isaset ] i.e. it is a type of h-level 2 . This requires another resizing rule :
 
 Resizing Rule RR2 ( U1 U2 : Univ ) |- @hProp U1 : U2 .
 
@@ -704,27 +704,25 @@ Proof.
     + apply (propproperty (DecidableProposition_to_hProp _)).
 Defined.
 
-(** ** Univalence axiom for hProp
+(** ** Univalence for hProp *)
 
-We introduce here the weakest form of the univalence axiom - the univalence axiom for hProp which is equivalent to the second part of the extensionality axiom in Church simple type theory.  This axiom is easily shown to be equivalent to its version with [P = P'] as a target and to [ weqtopathshProp ] (see below) as well as to the version of [ weqtopathshProp ] with [P = P'] as a target.
-
-The proof of theorem [ univfromtwoaxiomshProp ] is modeled on the proof of [ univfromtwoaxioms ] from univ01.v
-
-
-*)
-
-
-Axiom uahp : ∀ P P':hProp,  (P -> P') -> (P' -> P) -> @paths hProp P P'.
-
-Corollary uahp' : ∀ P Q, isaprop P -> isaprop Q -> (P -> Q) -> (Q -> P) -> P=Q.
-Proof.
-  intros ? ? i j f g. exact (maponpaths hProptoType (uahp (P,,i) (Q,,j) f g)).
-Defined.
+Theorem hPropUnivalence : forall (P Q:hProp), (P -> Q) -> (Q -> P) -> P = Q.
+  (* this theorem replaced a former axiom, with the same statement, called "uahp" *)
+  Proof.
+    intros ? ? f g.
+    apply subtypeEquality.
+    - intro X. apply isapropisaprop.
+    - apply propositionalUnivalenceAxiom.
+      + apply propproperty.
+      + apply propproperty.
+      + assumption.
+      + assumption.
+  Defined.
 
 Definition eqweqmaphProp { P P': hProp }  ( e: @paths hProp P P' ) : weq P P'.
 Proof. intros . destruct e . apply idweq.  Defined.
 
-Definition weqtopathshProp { P P' : hProp } (w: weq P P' ): @paths hProp P P' := uahp P P' w ( invweq w ) .
+Definition weqtopathshProp { P P' : hProp } (w: weq P P' ): P = P' := hPropUnivalence P P' w ( invweq w ) .
 
 Definition weqpathsweqhProp { P P' : hProp } (w : weq P P'): eqweqmaphProp (weqtopathshProp w) = w.
 Proof. intros. apply proofirrelevance . apply (isapropweqtoprop P P' (pr2 P')). Defined.
@@ -765,7 +763,7 @@ Proof. intros. apply isasethProp.
 Defined.
 
 Lemma iscontrtildehProp : iscontr tildehProp .
-Proof . split with ( tpair _ htrue tt )  .   intro tP .  destruct tP as [ P p ] . apply ( invmaponpathsincl _ ( isinclpr1 ( fun P : hProp => P ) ( fun P => pr2 P ) ) ) .   simpl . apply uahp . apply ( fun x => tt ) .  intro t.  apply p . Defined .
+Proof . split with ( tpair _ htrue tt )  .   intro tP .  destruct tP as [ P p ] . apply ( invmaponpathsincl _ ( isinclpr1 ( fun P : hProp => P ) ( fun P => pr2 P ) ) ) .   simpl . apply hPropUnivalence . apply ( fun x => tt ) .  intro t.  apply p . Defined .
 
 Lemma isaproptildehProp : isaprop tildehProp .
 Proof . apply ( isapropifcontr iscontrtildehProp ) .  Defined .

--- a/UniMath/Foundations/Basics/Propositions.v
+++ b/UniMath/Foundations/Basics/Propositions.v
@@ -477,7 +477,7 @@ Definition to_ComplementaryPair {P} (c:P ⨿ neg P) : ComplementaryPair
   (* By using [isTrue _] instead, we're effectively replacing P by a propositional subtype of it: *)
   (* the part connected to the element of [P ⨿ ¬P]. *)
   (* Similarly, by using [isFalse _] instead, we're effectively replacing [¬P] by a propositional subtype of it.  *)
-  (* Both are proved to be propositions without [funextempty] *)
+  (* Both are proved to be propositions without [funextemptyAxiom] *)
   := (P,,neg P,,(λ p n, n p),,c).
 
 (* Relate isolated points to complementary pairs *)
@@ -532,7 +532,7 @@ Proof.
 Defined.
 
 Definition decidable (X:hProp) : hProp :=
-  (* uses [funextempty] *)
+  (* uses [funextemptyAxiom] *)
   hProppair (X ⨿ ¬X) (isapropdec X (propproperty X)).
 
 Definition decidable_dirprod (X Y:hProp) : decidable X -> decidable Y -> decidable (X ∧ Y).

--- a/UniMath/Foundations/Basics/Propositions.v
+++ b/UniMath/Foundations/Basics/Propositions.v
@@ -197,14 +197,14 @@ Lemma isinclpr1image { X Y : UU } (f:X -> Y): isincl (pr1image f).
 Proof. intros. refine (isofhlevelfpr1 _ _ _). intro. apply ( pr2 ( ishinh ( hfiber f x ) ) ) . Defined.
 
 Lemma issurjprtoimage { X Y : UU } ( f : X -> Y) : issurjective (prtoimage f ).
-Proof. intros. intro z.  set (f' := prtoimage f ). set (g:= pr1image f ). set (gf':= fun x:_ => g ( f' x )).
-assert (e: paths f gf'). apply etacorrection .
-assert (ff: hfiber gf' (pr1 z) -> hfiber f' z).  refine ( invweq ( samehfibers _ _ ( isinclpr1image f ) z ) ) .
-assert (is2: ishinh (hfiber gf' (pr1 z))). destruct e.  apply (pr2 z).
-apply (hinhfun ff is2). Defined.
-
-
-
+Proof.
+  intros. intro z.
+  set (f' := prtoimage f ).
+  assert (ff: hfiber (funcomp f' (pr1image f )) (pr1 z) -> hfiber f' z).
+  { refine ( invweq ( samehfibers _ _ ( isinclpr1image f ) z ) ) . }
+  apply (hinhfun ff).
+  exact (pr2 z).
+Defined.
 
 (** *** The two-out-of-three properties of surjections *)
 

--- a/UniMath/Foundations/Basics/Sets.v
+++ b/UniMath/Foundations/Basics/Sets.v
@@ -632,10 +632,10 @@ Definition eqreldirprod { X Y : UU } ( RX : eqrel X ) ( RY : eqrel Y ) : eqrel (
 (** *** Negation of a relation and its properties *)
 
 Definition negrel { X : UU } ( R : hrel X ) : hrel X
-  := λ x x', hProppair (¬ R x x') (isapropneg _) . (* uses [funextempty] *)
+  := λ x x', hProppair (¬ R x x') (isapropneg _) . (* uses [funextemptyAxiom] *)
 
 Lemma istransnegrel { X : UU } ( R : hrel X  ) ( isr : iscotrans R ) : istrans ( negrel R ) .
-(* uses [funextfun] and [funextempty] *)
+(* uses [funextfun] and [funextemptyAxiom] *)
 Proof . intros . intros x1 x2 x3 r12 r23 .  apply ( negf ( isr x1 x2 x3 ) ) .  apply ( toneghdisj ( dirprodpair r12 r23 ) ) . Defined .
 
 Lemma iscotrans_to_istrans_negReln {X} {R:hrel X} (NR : negReln R) :
@@ -655,7 +655,7 @@ Lemma iscoasymmgenrel { X : UU } ( R : hrel X  ) ( isr : isasymm R ) : iscoasymm
 Proof . intros . intros x1 x2 nr12 . apply ( negf ( isr _ _ ) nr12 ) .  Defined .
 
 Lemma isdecnegrel { X : UU } ( R : hrel X  ) ( isr : isdecrel R ) : isdecrel ( negrel R ) .
-(* uses [funextempty] *)
+(* uses [funextemptyAxiom] *)
 Proof . intros . intros x1 x2 . destruct ( isr x1 x2 ) as [ r | nr ] . apply ii2 .   apply ( todneg _ r ) .  apply ( ii1 nr ) . Defined .
 
 Lemma isnegnegrel { X : UU } ( R : hrel X ) : isnegrel ( negrel R ) .
@@ -1467,7 +1467,7 @@ Proof.
   { apply funextfun; intro e. induction e. reflexivity. }
   induction (!comp). apply twooutof3c.
   { apply isweqonpathsincl. apply isinclpr1. exact isapropisaset. }
-  { apply univalenceaxiom. }
+  { apply univalenceAxiom. }
   Unset Printing Coercions.
 Defined.
 

--- a/UniMath/Foundations/Basics/Sets.v
+++ b/UniMath/Foundations/Basics/Sets.v
@@ -888,7 +888,7 @@ Proof.
 intros X R c x.
 apply (invmaponpathsincl _ (isinclpr1setquot R)).
 apply funextsec; intro x0.
-apply uahp; intro r.
+apply hPropUnivalence; intro r.
 + exact (eqax1 (pr2 c) (pr1 x) x0 r (pr2 x)).
 + exact (eqax2 (pr2 c) (pr1 x) x0 (pr2 x) r).
 Defined.
@@ -898,7 +898,7 @@ Proof. intros. unfold issurjective. intro c.   apply ( @hinhuniv ( carrier ( pr1
 Defined .
 
 Lemma iscompsetquotpr { X : UU } ( R : eqrel X ) ( x x' : X ) ( a : R x x' ) : setquotpr R x = setquotpr R x' .
-Proof. intros. apply ( invmaponpathsincl _ ( isinclpr1setquot R ) ) . simpl . apply funextsec . intro x0 . apply uahp .  intro r0 . apply ( eqreltrans R _ _ _ ( eqrelsymm R _ _ a ) r0 ) .  intro x0' . apply ( eqreltrans R _ _ _ a x0' ) . Defined .
+Proof. intros. apply ( invmaponpathsincl _ ( isinclpr1setquot R ) ) . simpl . apply funextsec . intro x0 . apply hPropUnivalence .  intro r0 . apply ( eqreltrans R _ _ _ ( eqrelsymm R _ _ a ) r0 ) .  intro x0' . apply ( eqreltrans R _ _ _ a x0' ) . Defined .
 
 
 
@@ -977,7 +977,7 @@ Proof . intros . assert ( int1 : ∀ c0 c0' c0'' : _ , P c c0 c0' c0'' ) .  appl
 
 
 
-(** Important note : theorems proved above can not be used ( al least at the moment ) to construct terms whose complete normalization ( evaluation ) is important . For example they should not be used * directly * to construct [ isdeceq ] property of [ setquot ] since [ isdeceq ] is in turn used to construct boolean equality [ booleq ] and evaluation of [ booleq x y ] is important for computational purposes . Terms produced using these universality theorems will not fully normalize even in simple cases due to the following steps in the proof of [ setquotunivprop ] . As a part of the proof term of this theorem there appears the composition of an application of [ uahp ] , transfer of the resulting term of the identity type by [ maponpaths ] along [ P ] followed by the reconstruction of a equivalence ( two directional implication ) between the corresponding propositions through [  eqweqmaphProp ] . The resulting implications are " opaque " and the proofs of disjunctions [ P \/ Q ]  produced with the use of such implications can not be evaluated to one of the summands of the disjunction . An example is given by the following theorem [ isdeceqsetquot_non_constr ] which , as simple experiments show, can not be used to compute the value of [ isdeceqsetquot ] . Below we give another proof of [ isdeceq ( setquot R ) ] using the same assumptions which is " constructive " i.e. usable for the evaluation purposes . *)
+(** Important note : theorems proved above can not be used ( al least at the moment ) to construct terms whose complete normalization ( evaluation ) is important . For example they should not be used * directly * to construct [ isdeceq ] property of [ setquot ] since [ isdeceq ] is in turn used to construct boolean equality [ booleq ] and evaluation of [ booleq x y ] is important for computational purposes . Terms produced using these universality theorems will not fully normalize even in simple cases due to the following steps in the proof of [ setquotunivprop ] . As a part of the proof term of this theorem there appears the composition of an application of [ hPropUnivalence ] , transfer of the resulting term of the identity type by [ maponpaths ] along [ P ] followed by the reconstruction of a equivalence ( two directional implication ) between the corresponding propositions through [  eqweqmaphProp ] . The resulting implications are " opaque " and the proofs of disjunctions [ P \/ Q ]  produced with the use of such implications can not be evaluated to one of the summands of the disjunction . An example is given by the following theorem [ isdeceqsetquot_non_constr ] which , as simple experiments show, can not be used to compute the value of [ isdeceqsetquot ] . Below we give another proof of [ isdeceq ( setquot R ) ] using the same assumptions which is " constructive " i.e. usable for the evaluation purposes . *)
 
 
 
@@ -1105,13 +1105,13 @@ Note that all the properties of the quotient relations which we consider other t
 Definition iscomprelrel { X : UU } ( R : hrel X ) ( L : hrel X ) := iscomprelfun2 R L .
 
 Lemma iscomprelrelif { X : UU } { R : hrel X } ( L : hrel X ) ( isr : issymm R ) ( i1 : ∀ x x' y , R x x' -> L x y -> L x' y ) ( i2 : ∀ x y y' , R y y' -> L x y -> L x y' ) : iscomprelrel R L .
-Proof . intros .  intros x x' y y' rx ry .  set ( rx' := isr _ _ rx ) . set ( ry' := isr _ _ ry ) . apply uahp .  intro lxy .  set ( int1 := i1 _ _ _ rx lxy ) . apply ( i2 _ _ _ ry int1 ) .  intro lxy' .  set ( int1 := i1 _ _ _ rx' lxy' ) .  apply ( i2 _ _ _ ry' int1 ) .  Defined .
+Proof . intros .  intros x x' y y' rx ry .  set ( rx' := isr _ _ rx ) . set ( ry' := isr _ _ ry ) . apply hPropUnivalence .  intro lxy .  set ( int1 := i1 _ _ _ rx lxy ) . apply ( i2 _ _ _ ry int1 ) .  intro lxy' .  set ( int1 := i1 _ _ _ rx' lxy' ) .  apply ( i2 _ _ _ ry' int1 ) .  Defined .
 
 Lemma iscomprelrellogeqf1 { X : UU } { R R' : hrel X } ( L : hrel X ) ( lg : hrellogeq R R' ) ( is : iscomprelrel R L ) : iscomprelrel R' L .
 Proof . intros . apply ( iscomprelfun2logeqf lg L is ) .  Defined .
 
 Lemma iscomprelrellogeqf2 { X : UU } ( R : hrel X ) { L L' : hrel X } ( lg : hrellogeq L L' ) ( is : iscomprelrel R L ) : iscomprelrel R L' .
-Proof . intros . intros x x' x0 x0' r r0 . assert ( e : paths ( L x x0 ) ( L' x x0 ) ) . apply uahp . apply ( pr1 ( lg _ _ ) ) .   apply ( pr2 ( lg _ _ ) ) .  assert ( e' : paths ( L x' x0' ) ( L' x' x0' ) ) . apply uahp . apply ( pr1 ( lg _ _ ) ) .   apply ( pr2 ( lg _ _ ) ) . destruct e .  destruct e' .  apply ( is _ _ _ _ r r0 ) . Defined .
+Proof . intros . intros x x' x0 x0' r r0 . assert ( e : paths ( L x x0 ) ( L' x x0 ) ) . apply hPropUnivalence . apply ( pr1 ( lg _ _ ) ) .   apply ( pr2 ( lg _ _ ) ) .  assert ( e' : paths ( L x' x0' ) ( L' x' x0' ) ) . apply hPropUnivalence . apply ( pr1 ( lg _ _ ) ) .   apply ( pr2 ( lg _ _ ) ) . destruct e .  destruct e' .  apply ( is _ _ _ _ r r0 ) . Defined .
 
 Definition quotrel  { X : UU } { R L : hrel X } ( is : iscomprelrel R L ) : hrel ( setquot R ) := setquotuniv2 R hPropset L is .
 
@@ -1428,7 +1428,7 @@ Proof. intros. apply idpath. Defined.
 (** *** Weak equivalence from [ R x x' ] to [ paths ( setquot2pr R x ) ( setquot2pr R x' ) ] *)
 
 Lemma weqpathssetquot2l1 { X : UU } ( R : eqrel X ) ( x : X ) : iscomprelfun R ( fun x' => R x x' ) .
-Proof . intros .  intros x' x'' .  intro r . apply uahp . intro r' .  apply ( eqreltrans R _ _ _ r' r ) . intro r'' .  apply ( eqreltrans R _ _ _ r'' ( eqrelsymm R _ _ r ) ) . Defined .
+Proof . intros .  intros x' x'' .  intro r . apply hPropUnivalence . intro r' .  apply ( eqreltrans R _ _ _ r' r ) . intro r'' .  apply ( eqreltrans R _ _ _ r'' ( eqrelsymm R _ _ r ) ) . Defined .
 
 Theorem weqpathsinsetquot2 { X : UU } ( R : eqrel X ) ( x x' : X ) : weq ( R x x' ) ( setquot2pr R x = setquot2pr R x' ) .
 Proof .  intros . apply weqimplimpl .  apply iscompsetquot2pr . set ( int := setquot2univ  R hPropset ( fun x'' => R x x'' ) ( weqpathssetquot2l1 R x ) ) .  intro e .  change ( pr1 ( int ( setquot2pr R x' ) ) ) . destruct e . change ( R x x ) . apply ( eqrelrefl R ) . apply ( pr2 ( R x x' ) ) . apply ( isasetsetquot2 ) .  Defined .

--- a/UniMath/Foundations/Basics/UnivalenceAxiom.v
+++ b/UniMath/Foundations/Basics/UnivalenceAxiom.v
@@ -4,81 +4,121 @@ This file contains the formulation of the univalence axiom and the proof that it
 
 *)
 
+(** Preliminaries  *)
 
-(** *** Preamble. *)
+Require Export UniMath.Foundations.Basics.PartB.
 
-(** *** Imports. *)
+(* everything related to eta correction is obsolete *)
 
-Unset Automatic Introduction. (** This line has to be removed for the file to compile with Coq8.2 *)
+Definition etacorrection: forall T:UU, forall P:T -> UU, forall f: (forall t:T, P t), paths f (fun t:T => f t).
+Proof. reflexivity. Defined.
 
+Lemma isweqetacorrection { T : UU } (P:T -> UU): isweq (fun f: forall t:T, P t => (fun t:T => f t)).
+Proof. intros. apply idisweq. Defined.
 
-Require Export UniMath.Foundations.Basics.PartD.
+Definition weqeta { T : UU } (P:T -> UU) := weqpair _ ( isweqetacorrection P ) .
 
+Lemma etacorrectiononpaths { T : UU } (P:T->UU)(s1 s2 :forall t:T, P t) : paths (fun t:T => s1 t) (fun t:T => s2 t)-> paths s1 s2.
+Proof. intros X. set (ew := weqeta P). apply (invmaponpathsweq ew s1 s2 X). Defined.
 
-(** ** Univalence axiom. *)
+Definition etacor { X Y : UU } (f:X -> Y) : paths f (fun x:X => f x) := etacorrection _ (fun T:X => Y) f.
 
-Axiom univalenceaxiom :  forall T1 T2 : UU ,  isweq ( @eqweqmap T1 T2 ).
+Lemma etacoronpaths { X Y : UU } (f1 f2 : X->Y) : paths (fun x:X => f1 x) (fun x:X => f2 x) -> paths f1 f2.
+Proof. intros X0. set (ec:= weqeta (fun x:X => Y) ). apply (invmaponpathsweq  ec f1 f2 X0). Defined.
 
-Corollary univalence X Y : (X=Y) ≃ (X≃Y).
-Proof. intros. exact (weqpair _ (univalenceaxiom X Y)). Defined.
+Definition eqweqmap { T1 T2 : UU } : T1 = T2 -> T1 ≃ T2.
+Proof. intro e. induction e. apply idweq. Defined.
 
-Definition weqtopaths { T1 T2 : UU } ( w : weq T1 T2 ) : paths T1 T2  :=  invmap ( weqpair _ ( univalenceaxiom T1 T2 ) ) w.
+Definition toforallpaths { T : UU } (P:T -> UU) (f g :forall t:T, P t) : f = g -> f ~ g.
+Proof. intros h t. induction h.  apply (idpath _). Defined.
 
+Definition sectohfiber { X : UU } (P:X -> UU): (forall x:X, P x) -> (hfiber (fun f:_ => fun x:_ => pr1  (f x)) (fun x:X => x)) := (fun a : forall x:X, P x => tpair _ (fun x:_ => tpair _ x (a x)) (idpath (fun x:X => x))).
 
-Definition weqpathsweq { T1 T2 : UU } ( w : weq T1 T2 ) : paths ( eqweqmap ( weqtopaths w ) ) w  :=  homotweqinvweq ( weqpair _ ( univalenceaxiom T1 T2 ) ) w.
+Definition hfibertosec { X : UU } (P:X -> UU):
+  (hfiber (fun f x => pr1 (f x)) (fun x:X => x)) -> (forall x:X, P x)
+  := fun se:_  => fun x:X => match se as se' return P x with tpair _ s e => (transportf P (toforallpaths _ (fun x:X => pr1 (s x)) (fun x:X => x) e x) (pr2  (s x))) end.
 
-(** We show that [ univalenceaxiom ] is equivalent to the axioms [ weqtopaths0 ] and [ weqpathsweq0 ] stated below . *)
+Definition sectohfibertosec { X : UU } (P:X -> UU): forall a: forall x:X, P x, paths (hfibertosec _  (sectohfiber _ a)) a := fun a:_ => (pathsinv0 (etacorrection _ _ a)).
 
+(** Axiom statements (propositions) *)
 
-Axiom weqtopaths0 : forall ( T1 T2 : UU ) ( w : weq T1 T2 ) , paths T1 T2.
+Definition univalenceStatement := forall X Y:UU, isweq (@eqweqmap X Y).
 
-Axiom weqpathsweq0 : forall ( T1 T2 : UU ) ( w : weq T1 T2 ) ,  paths ( eqweqmap ( weqtopaths0 _ _ w ) ) w.
+Definition funextemptyStatement := forall (X:UU) (f g : X->empty), f = g.
 
-Theorem univfromtwoaxioms ( T1 T2 : UU ) : isweq ( @eqweqmap T1 T2 ).
-Proof. intros. set ( P1 := fun XY : dirprod UU UU => pr1 XY = pr2 XY ) .
-set ( P2 := fun XY :  dirprod UU UU => weq (pr1 XY)  (pr2 XY) ) .
-set ( Z1 := total2 P1 ). set ( Z2 := total2 P2 ).
-set ( f := totalfun _ _ ( fun XY :  dirprod UU UU =>  @eqweqmap (pr1 XY) (pr2 XY)) : Z1 -> Z2 ) .
-set ( g := totalfun _ _ ( fun XY : dirprod UU UU =>  weqtopaths0 (pr1 XY) (pr2 XY) ) : Z2 -> Z1 ) .
+Definition funextsecweqStatement :=
+  forall (T:UU) (P:T -> UU) (f g :forall t:T, P t), isweq (toforallpaths _ f g).
 
+Definition propositionalUnivalenceStatement :=
+  forall P Q, isaprop P -> isaprop Q -> (P -> Q) -> (Q -> P) -> P=Q.
 
-assert ( efg : homot ( funcomp g f ) ( idfun _ ) ) .  intro z2 . induction z2 as [ XY e ] .
-unfold funcomp . unfold idfun . unfold g . unfold f . unfold totalfun . simpl .
-apply ( maponpaths ( fun w : weq ( pr1 XY) (pr2 XY) =>  tpair P2 XY w )
-( weqpathsweq0 ( pr1 XY ) ( pr2 XY ) e )) .
+(** Axiom consequence statements (not propositions) *)
 
+Definition funextsecStatement :=
+  forall (T:UU) (P:T -> UU) (f g :forall t:T, P t), f ~ g -> f = g.
 
+Definition funextfunStatement :=
+  forall (X Y:UU) (f g : X -> Y), f ~ g -> f = g.
 
+Definition weqtopathsStatement := forall ( T1 T2 : UU ), T1 ≃ T2 -> T1 = T2.
 
-set ( h := fun a1 : Z1 =>  pr1 ( pr1 a1 ) ) .
+Definition weqpathsweqStatement (weqtopaths:weqtopathsStatement) :=
+  forall ( T1 T2 : UU ) ( w : T1 ≃ T2 ), eqweqmap (weqtopaths _ _ w) = w.
 
-assert ( egf0 : forall a1 : Z1 ,  paths ( pr1 ( g ( f a1 ) ) ) (  pr1 a1 ) ). intro.
-apply  idpath.
+(** Implications between statements and consequences of them *)
 
-assert ( egf1 : forall a1 a1' : Z1 ,  paths ( pr1 a1' ) (  pr1 a1 ) ->  paths a1' a1 ). intros.
-set ( X' :=  maponpaths ( @pr1 _ _ ) X ).
-assert ( is : isweq h ). simpl in h .  apply isweqpr1pr1 .
-apply ( invmaponpathsweq ( weqpair h is ) _ _ X' ).
-
-set ( egf := fun a1  => ( egf1 _ _ ( egf0 a1 ) ) ).
-
-set ( is2 := gradth _ _ egf efg ).
-apply ( isweqtotaltofib P1 P2  ( fun XY : dirprod UU UU =>
-@eqweqmap (pr1 XY) (pr2 XY)) is2 ( dirprodpair T1 T2 ) ).
+Theorem funextsecImplication : funextsecweqStatement -> funextsecStatement.
+Proof.
+  intros fe ? ? ? ?. exact (invmap (weqpair _ (fe _ _ f g))).
 Defined.
 
+Theorem funextfunImplication : funextsecStatement -> funextfunStatement.
+Proof.
+  intros fe ? ?. apply fe.
+Defined.
 
-(** Conjecture :  the pair [weqtopaths0] and [weatopathsweq0] is well defined up to a canonical equality. **)
+(** We show that [ univalenceAxiom ] is equivalent to the axioms [ weqtopathsStatement ] and [ weqpathsweqStatement ] stated below . *)
 
+Theorem univfromtwoaxioms :
+  (Σ weqtopaths: weqtopathsStatement, weqpathsweqStatement weqtopaths)
+  <-> univalenceStatement.
+Proof.
+  split.
+  { intros [weqtopaths weqpathsweq] T1 T2.
+    set ( P1 := fun XY : UU × UU => pr1 XY = pr2 XY ) .
+    set ( P2 := fun XY :  UU × UU => weq (pr1 XY)  (pr2 XY) ) .
+    set ( Z1 := total2 P1 ). set ( Z2 := total2 P2 ).
+    set ( f := totalfun _ _ ( fun XY : UU × UU =>  @eqweqmap (pr1 XY) (pr2 XY)) : Z1 -> Z2 ) .
+    set ( g := totalfun _ _ ( fun XY : UU × UU =>  weqtopaths (pr1 XY) (pr2 XY) ) : Z2 -> Z1 ) .
+    assert (efg : funcomp g f ~ idfun _) .
+    - intro z2 . induction z2 as [ XY e ] .
+      unfold funcomp . unfold idfun . unfold g . unfold f . unfold totalfun . simpl .
+      apply ( maponpaths ( fun w : weq ( pr1 XY) (pr2 XY) =>  tpair P2 XY w )
+                       ( weqpathsweq ( pr1 XY ) ( pr2 XY ) e )) .
+    - set ( h := fun a1 : Z1 =>  pr1 ( pr1 a1 ) ) .
+      assert ( egf0 : forall a1 : Z1 ,  pr1 ( g ( f a1 ) ) = pr1 a1 ).
+      + intro. apply idpath.
+      + assert ( egf1 : forall a1 a1' : Z1 ,  paths ( pr1 a1' ) (  pr1 a1 ) ->  paths a1' a1 ).
+        * intros.
+          set ( X' :=  maponpaths pr1 X ).
+          assert ( is : isweq h ).
+          { simpl in h .  apply isweqpr1pr1 . }
+          apply ( invmaponpathsweq ( weqpair h is ) _ _ X' ).
+        * set ( egf := fun a1  => egf1 _ _ ( egf0 a1 ) ).
+          set ( is2 := gradth _ _ egf efg ).
+          apply ( isweqtotaltofib _ _ ( fun _ => eqweqmap) is2 ( dirprodpair T1 T2 ) ).
+          }
+  { intros ua.
+    simple refine (_,,_).
+    - intros ? ?. exact (invmap (weqpair _ (ua _ _))).
+    - intros ? ?. exact (homotweqinvweq (weqpair _ (ua _ _))). }
+Defined.
 
-
-
-
+(** Conjecture :  the pair [weqtopaths] and [weqtopathsweq] in the proof above is well defined up to a canonical equality. **)
 
 (** ** Transport theorem.
 
-Theorem saying that any general scheme to "transport" a structure along a weak equivalence which does not change the structure in the case of the identity equivalence is equivalent to the transport along the path which corresponds to a weak equivalence by the univalenceaxiom. As a corollary we conclude that for any such transport scheme the corresponding maps on spaes of structures are weak equivalences. *)
-
+Theorem saying that any general scheme to "transport" a structure along a weak equivalence which does not change the structure in the case of the identity equivalence is equivalent to the transport along the path which corresponds to a weak equivalence by the univalenceAxiom. As a corollary we conclude that for any such transport scheme the corresponding maps on spaes of structures are weak equivalences. *)
 
 Lemma isweqtransportf10 { X : UU } ( P : X -> UU ) { x x' : X } ( e :  paths x x' ) : isweq ( transportf P e ).
 Proof. intros. destruct e.  apply idisweq. Defined.
@@ -88,57 +128,155 @@ Proof. intros. apply ( isweqtransportf10 _ ( pathsinv0 e ) ). Defined.
 
 
 Lemma l1  { X0 X0' : UU } ( ee : paths X0 X0' ) ( P : UU -> UU ) ( pp' : P X0' ) ( R : forall X X' : UU , forall w : weq X X' , P X' -> P X ) ( r : forall X : UU , forall p : P X , paths ( R X X ( idweq X ) p ) p ) : paths ( R X0 X0' ( eqweqmap ee ) pp' ) (  transportb P ee pp' ).
-Proof. intro. intro. intro. intro. intro. destruct ee. simpl. intro. intro. apply r. Defined.
+Proof. destruct ee. simpl. apply r. Defined.
 
+(** the axioms themselves *)
+
+Axiom univalenceAxiom : univalenceStatement.
+Axiom funextemptyAxiom : funextemptyStatement.
+Axiom funextAxiom : funextsecweqStatement.
+
+(** provide some theorems based on the axioms  *)
+
+Theorem univalence (X Y:UU) : (X=Y) ≃ (X≃Y).
+Proof. exact (weqpair _ (univalenceAxiom X Y)). Defined.
+
+Definition weqtopaths : weqtopathsStatement.
+Proof.
+  intros ? ?. exact (invmap (univalence _ _)).
+Defined.
+Arguments weqtopaths {_ _} _.
+
+Definition weqpathsweq : weqpathsweqStatement (@weqtopaths).
+Proof.
+  intros ? ? w. exact (homotweqinvweq (univalence T1 T2) w).
+Defined.
+Arguments weqpathsweq {_ _} _.
+
+(** ** Proof of the functional extensionality for functions from univalence *)
 
 Theorem weqtransportb ( P : UU -> UU ) ( R : forall ( X X' : UU ) ( w :  weq X X' ) , P X' -> P X ) ( r : forall X : UU , forall p : P X , paths ( R X X ( idweq X ) p ) p ) :  forall ( X X' : UU ) ( w :  weq X X' ) ( p' : P X' ) , paths ( R X X' w p' ) (  transportb P ( weqtopaths w ) p' ).
-Proof. intros. set ( uv := weqtopaths w ).   set ( v := eqweqmap uv ).
-
-assert ( e : paths v w ) . unfold weqtopaths in uv.  apply ( homotweqinvweq ( weqpair _ ( univalenceaxiom X X' ) ) w ).
-
-assert ( ee : paths ( R X X' v p' ) ( R X X' w p' ) ) . set ( R' := fun vis : weq X X' => R X X' vis p' ). assert ( ee' : paths ( R' v ) ( R' w ) ). apply (  maponpaths R' e ). assumption.
-
-destruct ee. apply l1. assumption. Defined.
-
-
+Proof.
+  intros. set ( uv := weqtopaths w ).   set ( v := eqweqmap uv ).
+  assert ( e : paths v w ) . unfold weqtopaths in uv.
+  apply ( homotweqinvweq ( weqpair _ ( univalenceAxiom X X' ) ) w ).
+  assert ( ee : paths ( R X X' v p' ) ( R X X' w p' ) ) . set ( R' := fun vis : weq X X' => R X X' vis p' ). assert ( ee' : paths ( R' v ) ( R' w ) ). apply (  maponpaths R' e ). assumption.
+  destruct ee. apply l1. assumption. Defined.
 
 Corollary isweqweqtransportb ( P : UU -> UU ) ( R :  forall ( X X' : UU ) ( w :  weq X X' ) , P X' -> P X ) ( r :  forall X : UU , forall p : P X , paths ( R X X ( idweq X ) p ) p ) :  forall ( X X' : UU ) ( w :  weq X X' ) , isweq ( fun p' :  P X' => R X X' w p' ).
-Proof. intros. assert ( e : forall p' : P X' , paths ( R X X' w p' ) (  transportb P ( weqtopaths w ) p' ) ). apply weqtransportb. assumption. assert ( ee : forall p' : P X' , paths  ( transportb P ( weqtopaths w ) p' ) ( R X X' w p' ) ). intro.  apply ( pathsinv0 ( e p' ) ). clear e.
-
-assert ( is1 : isweq ( transportb P ( weqtopaths w ) ) ). apply isweqtransportb10.
-apply ( isweqhomot ( transportb P ( weqtopaths w ) ) ( fun p'  :  P X' => R X X' w p' ) ee is1 ).  Defined.
-
-
-
-
+Proof.
+  intros.
+  assert ( e : forall p' : P X' , paths ( R X X' w p' ) (  transportb P ( weqtopaths w ) p' ) ).
+  - apply weqtransportb. assumption.
+  - assert ( ee : forall p' : P X' , paths  ( transportb P ( weqtopaths w ) p' ) ( R X X' w p' ) ).
+    + intro. apply ( pathsinv0 ( e p' ) ).
+    + clear e.
+      assert ( is1 : isweq ( transportb P ( weqtopaths w ) ) ).
+      apply isweqtransportb10.
+      apply ( isweqhomot ( transportb P ( weqtopaths w ) ) ( fun p'  :  P X' => R X X' w p' ) ee is1 ).
+Defined.
 
 (** Theorem saying that composition with a weak equivalence is a weak equivalence on function spaces. *)
 
-
-
-
 Theorem isweqcompwithweq { X X' : UU } ( w : weq X X' ) ( Y : UU ) :  isweq ( fun f : X' -> Y => ( fun x : X => f ( w x ) ) ).
-Proof. intros.
-set ( P := fun X0 : UU => ( X0 -> Y ) ).
-set ( R := fun X0 : UU => ( fun X0' : UU => ( fun w1 : X0 -> X0' =>  ( fun  f : P X0'  => ( fun x : X0 => f ( w1 x ) ) ) ) ) ).
-set ( r := fun X0 : UU => ( fun f : X0 -> Y => pathsinv0 ( etacor f ) ) ).
-apply ( isweqweqtransportb P R r X X' w ). Defined.
-
-
-
-
-(** ** Proof of the functional extensionality for functions *)
-
+Proof.
+  set ( P := fun X0 : UU => ( X0 -> Y ) ).
+  set ( R := fun X0 : UU => ( fun X0' : UU => ( fun w1 : X0 -> X0' =>  ( fun  f : P X0'  => ( fun x : X0 => f ( w1 x ) ) ) ) ) ).
+  apply ( isweqweqtransportb P R (fun X0 f => idpath _) X X' w ).
+Defined.
 
 Lemma eqcor0 { X X' : UU } ( w :  weq X X' ) ( Y : UU ) ( f1 f2 : X' -> Y ) : paths ( fun x : X => f1 ( w x ) )  ( fun x : X => f2 ( w x ) ) -> paths f1 f2.
-Proof. intros. apply ( invmaponpathsweq ( weqpair _ ( isweqcompwithweq w Y ) ) f1 f2 ). assumption.  Defined.
-
+Proof. apply ( invmaponpathsweq ( weqpair _ ( isweqcompwithweq w Y ) ) f1 f2 ). Defined.
 
 Lemma apathpr1topr ( T : UU ) : paths ( fun z :  pathsspace T => pr1 z ) ( fun z : pathsspace T => pr1 ( pr2 z ) ).
-Proof. intro. apply ( eqcor0  ( weqpair _ ( isweqdeltap T ) ) _ ( fun z :  pathsspace T => pr1 z ) ( fun z :  pathsspace T => pr1 ( pr2 z ) ) ( idpath ( idfun T ) ) ) . Defined.
+Proof. apply ( eqcor0 ( weqpair _ ( isweqdeltap T ) ) _ ( fun z :  pathsspace T => pr1 z ) ( fun z :  pathsspace T => pr1 ( pr2 z ) ) ( idpath ( idfun T ) ) ) . Defined.
+
+Theorem funextfunPreliminary : funextfunStatement.
+Proof.
+  intros ? ? f1 f2 e.
+  set ( f := fun x : X => pathsspacetriple Y ( e x ) ).
+  set ( g1 := fun z : pathsspace Y => pr1 z ).
+  set ( g2 := fun z : pathsspace Y => pr1 ( pr2 z ) ).
+  change ( (funcomp f g1) = (funcomp f g2) ).
+  apply maponpaths.
+  apply apathpr1topr.
+Defined.
+
+Arguments funextfunPreliminary {_ _} _ _ _.
+
+(** *** Deduction of functional extensionality for dependent functions (sections) from functional extensionality of usual functions *)
+
+Lemma isweqlcompwithweq {X X' : UU} (w: weq X X') (Y:UU) : isweq (fun (a:X'->Y) x => a (w x)).
+Proof.
+  simple refine (gradth _ _ _ _).
+  exact (fun b x' => b (invweq w x')).
+  exact (fun a => funextfunPreliminary _ a (fun x' => maponpaths a (homotweqinvweq w x'))).
+  exact (fun a => funextfunPreliminary _ a (fun x  => maponpaths a (homotinvweqweq w x ))).
+Defined.
+
+Lemma isweqrcompwithweq { Y Y':UU } (w: weq Y Y')(X:UU): isweq (fun a:X->Y => (fun x:X => w (a x))).
+Proof. intros. set (f:= (fun a:X->Y => (fun x:X => w (a x)))). set (g := fun a':X-> Y' => fun x:X => (invweq  w (a' x))).
+set (egf:= (fun a:X->Y => funextfunPreliminary (fun x:X => (g (f a)) x) a (fun x: X => (homotinvweqweq w (a x))))).
+set (efg:= (fun a':X->Y' => funextfunPreliminary (fun x:X => (f (g a')) x) a' (fun x: X =>  (homotweqinvweq w (a' x))))).
+apply (gradth  f g egf efg). Defined.
+
+Theorem funcontr { X : UU } (P:X -> UU) : (forall x:X, iscontr (P x)) -> iscontr (forall x:X, P x).
+Proof. intros X0 . set (T1 := forall x:X, P x). set (T2 := (hfiber (fun f: (X -> total2 P)  => fun x: X => pr1  (f x)) (fun x:X => x))). assert (is1:isweq (@pr1 X P)). apply isweqpr1. assumption.  set (w1:= weqpair  (@pr1 X P) is1).
+assert (X1:iscontr T2).  apply (isweqrcompwithweq  w1 X (fun x:X => x)).
+apply ( iscontrretract  _ _  (sectohfibertosec P ) X1). Defined.
+
+Corollary funcontrtwice { X : UU } (P: X-> X -> UU)(is: forall (x x':X), iscontr (P x x')): iscontr (forall (x x':X), P x x').
+Proof. intros.
+assert (is1: forall x:X, iscontr (forall x':X, P x x')). intro. apply (funcontr _ (is x)). apply (funcontr _ is1). Defined.
 
 
-Theorem funextfun { X Y : UU } ( f1 f2 : X -> Y ) ( e :  forall x : X , paths ( f1 x ) ( f2 x ) ) : paths f1 f2.
-Proof. intros. set ( f := fun x : X => pathsspacetriple Y ( e x ) ) .  set ( g1 := fun z : pathsspace Y => pr1 z ) . set ( g2 := fun z :  pathsspace Y => pr1 ( pr2 z ) ). assert ( e' : paths g1 g2 ). apply ( apathpr1topr Y ). assert ( ee : paths  ( fun x : X => f1 x ) ( fun x : X => f2 x ) ). change ( paths (fun x : X => g1 ( f x ) ) (fun x : X => g2 ( f x ) ) ) . destruct e' .  apply idpath .   apply etacoronpaths. apply ee . Defined.
+(** Proof of the fact that the [ toforallpaths ] from [paths s1 s2] to [forall t:T, paths (s1 t) (s2 t)] is a weak equivalence - a strong form
+of functional extensionality for sections of general families. The proof uses only [funcontr] which is an axiom i.e. its type satisfies [ isaprop ].  *)
 
-(* End of the file funextfun.v *)
+Lemma funextweql1 { T : UU } (P:T -> UU) (g: ∀ t, P t) : ∃! (f:∀ t, P t), ∀ t:T, f t = g t.
+Proof.
+  intros. unshelve refine (iscontrretract (X := ∀ t, Σ p, p = g t) _ _ _ _).
+  - intros x. unshelve refine (_,,_).
+    + intro t. exact (pr1 (x t)).
+    + intro t; simpl. exact (pr2 (x t)).
+  - intros y t. exists (pr1 y t). exact (pr2 y t).
+  - intros u. induction u as [t x]. reflexivity.
+  - apply funcontr. intro t. apply iscontrcoconustot.
+Defined.
+
+Theorem isweqtoforallpaths { T : UU } (P:T -> UU) (f g: ∀ t:T, P t) :
+  isweq (toforallpaths _ f g).
+Proof.
+  intros.
+  refine (isweqtotaltofib _ _ (λ (h:∀ t, P t), toforallpaths _ h g) _ f).
+  refine (isweqcontrcontr (X := Σ (h: ∀ t, P t), h = g)
+            (λ ff, tpair _ (pr1 ff) (toforallpaths P (pr1 ff) g (pr2 ff))) _ _).
+  { exact (iscontrcoconustot _ g). }
+  { apply funextweql1. }
+Qed.
+
+Theorem weqtoforallpaths { T : UU } (P:T -> UU)(f g : forall t:T, P t) :
+  (f = g) ≃ (∀ t:T, f t = g t).
+Proof. intros. exists (toforallpaths P f g). apply isweqtoforallpaths. Defined.
+
+Definition funextsec : funextsecStatement.
+Proof.
+  intros ? ? f g.
+  exact (invmap (weqtoforallpaths _ f g)).
+Defined.
+Arguments funextsec {_} _ _ _ _.
+
+Theorem funextfun : funextfunStatement.
+Proof.
+  exact (funextfunImplication (@funextsec)).
+Defined.
+
+Arguments funextfun {_ _} _ _ _.
+
+Theorem isweqfunextsec { T : UU } (P:T -> UU) (f g : forall t:T, P t) :
+  isweq (funextsec P f g).
+Proof. intros. apply (isweqinvmap (weqtoforallpaths _ f g)). Defined.
+
+Definition weqfunextsec { T : UU } (P:T -> UU)(f g : forall t:T, P t) :
+  weq  (forall t:T, paths (f t) (g t)) (paths f g)
+  := weqpair _ ( isweqfunextsec P f g ) .

--- a/UniMath/Foundations/Basics/UnivalenceAxiom.v
+++ b/UniMath/Foundations/Basics/UnivalenceAxiom.v
@@ -15,7 +15,7 @@ Assumptions" command of Coq.
 An important point is that we introduce as axioms only those whose statements
 are propositions, so that the axiom and any proofs derivable from other
 axioms will be equal.  Proofs that the statements are propositions will be
-provided separately.
+provided in the file UnivalenceAxiom2.
 
 We postpone stating the axioms themselves until after all the implications
 are established; this helps us encourage the use of the axioms for the
@@ -78,7 +78,7 @@ Definition funextsecweqStatement :=
   forall (T:UU) (P:T -> UU) (f g :forall t:T, P t), isweq (toforallpaths _ f g).
 
 Definition propositionalUnivalenceStatement :=
-  forall P Q, isaprop P -> isaprop Q -> (P -> Q) -> (Q -> P) -> P=Q.
+  forall (P Q:UU), isaprop P -> isaprop Q -> (P -> Q) -> (Q -> P) -> P=Q.
 
 Definition funcontrStatement :=
   forall (X : UU) (P:X -> UU),
@@ -174,6 +174,15 @@ Section UnivalenceImplications.
   Defined.
   Arguments weqpathsweqUAH {_ _} _.
 
+  Lemma propositionalUnivalenceUAH: propositionalUnivalenceStatement.
+  Proof.
+    unfold propositionalUnivalenceStatement; intros ? ? i j f g.
+    apply weqtopathsUAH.
+    simple refine (weqpair f (gradth f g _ _)).
+    - intro p. apply proofirrelevance, i.
+    - intro q. apply proofirrelevance, j.
+  Defined.
+
   (** ** Proof of the functional extensionality for functions from univalence *)
 
   (** ** Transport theorem.
@@ -251,6 +260,14 @@ Section UnivalenceImplications.
     apply apathpr1toprUAH.
   Defined.
   Arguments funextfunPreliminaryUAH {_ _} _ _ _.
+
+  Lemma funextemptyUAH : funextemptyStatement.
+  Proof.
+    unfold funextemptyStatement; intros.
+    apply funextfunPreliminaryUAH.
+    intro x.
+    induction (f x).
+  Defined.
 
   (** *** Deduction of functional extensionality for dependent functions (sections) from functional extensionality of usual functions *)
 
@@ -355,10 +372,10 @@ Lemma funextsecweqFromUnivalence: univalenceStatement -> funextsecweqStatement.
 Proof. exact isweqtoforallpathsUAH. Defined.
 
 Lemma funextemptyFromUnivalence: univalenceStatement -> funextemptyStatement.
-  Abort.
+Proof. exact funextemptyUAH. Defined.
 
 Lemma propositionalUnivalenceFromUnivalence: univalenceStatement -> propositionalUnivalenceStatement.
-  Abort.
+Proof. exact propositionalUnivalenceUAH. Defined.
 
 (** the axioms themselves *)
 
@@ -366,7 +383,7 @@ Axiom univalenceAxiom : univalenceStatement.
 Axiom funextemptyAxiom : funextemptyStatement.
 Axiom funextAxiom : funextsecweqStatement.
 Axiom funcontrAxiom : funcontrStatement.
-Axiom propositionalUnivalence : propositionalUnivalenceStatement.
+Axiom propositionalUnivalenceAxiom : propositionalUnivalenceStatement.
 
 (** provide some theorems based on the axioms  *)
 

--- a/UniMath/Foundations/Basics/UnivalenceAxiom.v
+++ b/UniMath/Foundations/Basics/UnivalenceAxiom.v
@@ -1,6 +1,25 @@
-(** * Univalence axiom and functional extensionality.  Vladimir Voevodsky. Feb. 2010 - Sep. 2011
+(** The univalence axiom and its consequences *)
 
-This file contains the formulation of the univalence axiom and the proof that it implies functional extensionality for functions - Theorem funextfun.
+(**
+
+In this file, we formulate univalence and its consequences, including functional
+extensionality (the statement that functions with equal values are equal).
+
+One approach would be to take univalence as the only axiom and to formulate
+theorems proving the consequences, whose proofs would appeal to the
+univalence axiom.  We adopt a different approach here, preferring also to
+introduce axioms for various consequences of univalence.  This allows us to
+measure how subsequent theorems depend on the axioms using the "Print
+Assumptions" command of Coq.
+
+An important point is that we introduce as axioms only those whose statements
+are propositions, so that the axiom and any proofs derivable from other
+axioms will be equal.  Proofs that the statements are propositions will be
+provided separately.
+
+We postpone stating the axioms themselves until after all the implications
+are established; this helps us encourage the use of the axioms for the
+consequences of univalence, rather than the theorems giving the implications.
 
 *)
 
@@ -40,6 +59,15 @@ Definition hfibertosec { X : UU } (P:X -> UU):
 
 Definition sectohfibertosec { X : UU } (P:X -> UU): forall a: forall x:X, P x, paths (hfibertosec _  (sectohfiber _ a)) a := fun a:_ => (pathsinv0 (etacorrection _ _ a)).
 
+Lemma isweqtransportf10 { X : UU } ( P : X -> UU ) { x x' : X } ( e :  paths x x' ) : isweq ( transportf P e ).
+Proof. intros. destruct e.  apply idisweq. Defined.
+
+Lemma isweqtransportb10 { X : UU } ( P : X -> UU ) { x x' : X } ( e :  paths x x' ) : isweq ( transportb P e ).
+Proof. intros. apply ( isweqtransportf10 _ ( pathsinv0 e ) ). Defined.
+
+Lemma l1  { X0 X0' : UU } ( ee : paths X0 X0' ) ( P : UU -> UU ) ( pp' : P X0' ) ( R : forall X X' : UU , forall w : weq X X' , P X' -> P X ) ( r : forall X : UU , forall p : P X , paths ( R X X ( idweq X ) p ) p ) : paths ( R X0 X0' ( eqweqmap ee ) pp' ) (  transportb P ee pp' ).
+Proof. destruct ee. simpl. apply r. Defined.
+
 (** Axiom statements (propositions) *)
 
 Definition univalenceStatement := forall X Y:UU, isweq (@eqweqmap X Y).
@@ -51,6 +79,10 @@ Definition funextsecweqStatement :=
 
 Definition propositionalUnivalenceStatement :=
   forall P Q, isaprop P -> isaprop Q -> (P -> Q) -> (Q -> P) -> P=Q.
+
+Definition funcontrStatement :=
+  forall (X : UU) (P:X -> UU),
+  (forall x:X, iscontr (P x)) -> iscontr (forall x:X, P x).
 
 (** Axiom consequence statements (not propositions) *)
 
@@ -116,167 +148,264 @@ Defined.
 
 (** Conjecture :  the pair [weqtopaths] and [weqtopathsweq] in the proof above is well defined up to a canonical equality. **)
 
-(** ** Transport theorem.
+Section UnivalenceImplications.
 
-Theorem saying that any general scheme to "transport" a structure along a weak equivalence which does not change the structure in the case of the identity equivalence is equivalent to the transport along the path which corresponds to a weak equivalence by the univalenceAxiom. As a corollary we conclude that for any such transport scheme the corresponding maps on spaes of structures are weak equivalences. *)
+  (** In this section we take univalence as a hypothesis, not as an axiom, so
+     we can limit the number of theorems that take univalence an axiom.
 
-Lemma isweqtransportf10 { X : UU } ( P : X -> UU ) { x x' : X } ( e :  paths x x' ) : isweq ( transportf P e ).
-Proof. intros. destruct e.  apply idisweq. Defined.
+     The suffix UAH on the name of a theorem indicates a theorem that will be
+     stated later unconditionally, with a proof that appeals to the future
+     univalence axiom. *)
 
-Lemma isweqtransportb10 { X : UU } ( P : X -> UU ) { x x' : X } ( e :  paths x x' ) : isweq ( transportb P e ).
-Proof. intros. apply ( isweqtransportf10 _ ( pathsinv0 e ) ). Defined.
+  Hypothesis univalenceAxiom : univalenceStatement.
 
+  Theorem univalenceUAH (X Y:UU) : (X=Y) ≃ (X≃Y).
+  Proof. exact (weqpair _ (univalenceAxiom X Y)). Defined.
 
-Lemma l1  { X0 X0' : UU } ( ee : paths X0 X0' ) ( P : UU -> UU ) ( pp' : P X0' ) ( R : forall X X' : UU , forall w : weq X X' , P X' -> P X ) ( r : forall X : UU , forall p : P X , paths ( R X X ( idweq X ) p ) p ) : paths ( R X0 X0' ( eqweqmap ee ) pp' ) (  transportb P ee pp' ).
-Proof. destruct ee. simpl. apply r. Defined.
+  Definition weqtopathsUAH : weqtopathsStatement.
+  Proof.
+    intros ? ?. exact (invmap (univalenceUAH _ _)).
+  Defined.
+  Arguments weqtopathsUAH {_ _} _.
+
+  Definition weqpathsweqUAH : weqpathsweqStatement (@weqtopathsUAH).
+  Proof.
+    intros ? ? w. exact (homotweqinvweq (univalenceUAH T1 T2) w).
+  Defined.
+  Arguments weqpathsweqUAH {_ _} _.
+
+  (** ** Proof of the functional extensionality for functions from univalence *)
+
+  (** ** Transport theorem.
+
+    Theorem saying that any general scheme to "transport" a structure along a
+    weak equivalence which does not change the structure in the case of the
+    identity equivalence is equivalent to the transport along the path which
+    corresponds to a weak equivalence by the univalenceAxiom. As a corollary we
+    conclude that for any such transport scheme the corresponding maps on spaces
+    of structures are weak equivalences. *)
+
+  Theorem weqtransportbUAH ( P : UU -> UU )
+          ( R : forall ( X X' : UU ) ( w :  weq X X' ) , P X' -> P X )
+          ( r : forall X : UU , forall p : P X , R X X ( idweq X ) p = p ) :
+    forall ( X X' : UU ) ( w :  weq X X' ) ( p' : P X' ),
+      R X X' w p' = transportb P ( weqtopathsUAH w ) p'.
+  Proof.
+    intros.
+    set ( uv := weqtopathsUAH w ).
+    set ( v := eqweqmap uv ).
+    assert ( e : v = w ) .
+    - unfold weqtopathsUAH in uv.
+      apply ( homotweqinvweq ( univalenceUAH X X' ) w ).
+    - assert ( ee : R X X' v p' = R X X' w p' ).
+      + set ( R' := fun vis : X ≃ X' => R X X' vis p' ).
+        assert ( ee' : R' v = R' w ).
+        * apply (  maponpaths R' e ).
+        * assumption.
+      + destruct ee. now apply l1.
+  Defined.
+
+  Corollary isweqweqtransportbUAH
+            ( P : UU -> UU )
+            ( R :  forall ( X X' : UU ) ( w : X ≃ X' ) , P X' -> P X )
+            ( r :  forall X : UU , forall p : P X , R X X ( idweq X ) p  = p ) :
+    forall ( X X' : UU ) ( w : X ≃ X' ),
+      isweq ( fun p' :  P X' => R X X' w p' ).
+  Proof.
+    intros.
+    assert ( e : R X X' w ~ transportb P ( weqtopathsUAH w )).
+    - unfold homot. now apply weqtransportbUAH.
+    - assert ( ee : transportb P ( weqtopathsUAH w ) ~ R X X' w).
+      + intro p'. apply ( pathsinv0 ( e p' ) ).
+      + clear e.
+        assert ( is1 : isweq ( transportb P ( weqtopathsUAH w ) ) ).
+        apply isweqtransportb10.
+        apply ( isweqhomot ( transportb P ( weqtopathsUAH w ) ) (R X X' w) ee is1 ).
+  Defined.
+
+  (** Theorem saying that composition with a weak equivalence is a weak equivalence on function spaces. *)
+
+  Theorem isweqcompwithweqUAH { X X' : UU } ( w : weq X X' ) ( Y : UU ) :
+    isweq ( fun f : X' -> Y => ( fun x : X => f ( w x ) ) ).
+  Proof.
+    set ( P := fun X0 : UU => ( X0 -> Y ) ).
+    set ( R := fun X0 : UU => ( fun X0' : UU => ( fun w1 : X0 -> X0' =>  ( fun  f : P X0'  => ( fun x : X0 => f ( w1 x ) ) ) ) ) ).
+    apply ( isweqweqtransportbUAH P R (fun X0 f => idpath _) X X' w ).
+  Defined.
+
+  Lemma eqcor0UAH { X X' : UU } ( w :  weq X X' ) ( Y : UU ) ( f1 f2 : X' -> Y ) :
+    (fun x : X => f1 ( w x )) = (fun x : X => f2 ( w x ) ) -> f1 = f2.
+  Proof. apply ( invmaponpathsweq ( weqpair _ ( isweqcompwithweqUAH w Y ) ) f1 f2 ). Defined.
+
+  Lemma apathpr1toprUAH ( T : UU ) : paths ( fun z :  pathsspace T => pr1 z ) ( fun z : pathsspace T => pr1 ( pr2 z ) ).
+  Proof. apply ( eqcor0UAH ( weqpair _ ( isweqdeltap T ) ) _ ( fun z :  pathsspace T => pr1 z ) ( fun z :  pathsspace T => pr1 ( pr2 z ) ) ( idpath ( idfun T ) ) ) . Defined.
+
+  Theorem funextfunPreliminaryUAH : funextfunStatement.
+  Proof.
+    intros ? ? f1 f2 e.
+    set ( f := fun x : X => pathsspacetriple Y ( e x ) ).
+    set ( g1 := fun z : pathsspace Y => pr1 z ).
+    set ( g2 := fun z : pathsspace Y => pr1 ( pr2 z ) ).
+    change ( (funcomp f g1) = (funcomp f g2) ).
+    apply maponpaths.
+    apply apathpr1toprUAH.
+  Defined.
+  Arguments funextfunPreliminaryUAH {_ _} _ _ _.
+
+  (** *** Deduction of functional extensionality for dependent functions (sections) from functional extensionality of usual functions *)
+
+  Lemma isweqlcompwithweqUAH {X X' : UU} (w: weq X X') (Y:UU) : isweq (fun (a:X'->Y) x => a (w x)).
+  Proof.
+    simple refine (gradth _ _ _ _).
+    exact (fun b x' => b (invweq w x')).
+    exact (fun a => funextfunPreliminaryUAH _ a (fun x' => maponpaths a (homotweqinvweq w x'))).
+    exact (fun a => funextfunPreliminaryUAH _ a (fun x  => maponpaths a (homotinvweqweq w x ))).
+  Defined.
+
+  Lemma isweqrcompwithweqUAH { Y Y':UU } (w: weq Y Y')(X:UU) :
+    isweq (fun a:X->Y => (fun x => w (a x))).
+  Proof.
+    set (f := fun a:X->Y => (fun x:X => w (a x))).
+    set (g := fun a':X-> Y' => fun x:X => (invweq  w (a' x))).
+    set (egf:= fun a:X->Y => funextfunPreliminaryUAH (fun x:X => (g (f a)) x) a (fun x: X => (homotinvweqweq w (a x)))).
+    set (efg:= fun a':X->Y' => funextfunPreliminaryUAH (fun x:X => (f (g a')) x) a' (fun x: X =>  (homotweqinvweq w (a' x)))).
+    apply (gradth f g egf efg).
+  Defined.
+
+  Theorem funcontrUAH : funcontrStatement.
+  Proof.
+    unfold funcontrStatement.
+    intros ? ? X0.
+    set (T1 := forall x:X, P x).
+    set (T2 := (hfiber (fun f: (X -> total2 P)  => fun x: X => pr1  (f x)) (fun x:X => x))).
+    assert (is1:isweq (@pr1 X P)).
+    - apply isweqpr1. assumption.
+    - set (w1:= weqpair  (@pr1 X P) is1).
+      assert (X1:iscontr T2).
+      + apply (isweqrcompwithweqUAH w1 X (fun x:X => x)).
+      + apply ( iscontrretract  _ _  (sectohfibertosec P ) X1).
+  Defined.
+
+  (** Proof of the fact that the [ toforallpaths ] from [paths s1 s2] to
+  [forall t:T, paths (s1 t) (s2 t)] is a weak equivalence - a strong form of
+  functional extensionality for sections of general families. The proof uses
+  only [funcontrUAH] which is an element of a proposition.  *)
+
+  Lemma funextweql1UAH { T : UU } (P:T -> UU) (g: ∀ t, P t) : ∃! (f:∀ t, P t), ∀ t:T, f t = g t.
+  Proof.
+    unshelve refine (iscontrretract (X := ∀ t, Σ p, p = g t) _ _ _ _).
+    - intros x. unshelve refine (_,,_).
+      + intro t. exact (pr1 (x t)).
+      + intro t; simpl. exact (pr2 (x t)).
+    - intros y t. exists (pr1 y t). exact (pr2 y t).
+    - intros u. induction u as [t x]. reflexivity.
+    - apply funcontrUAH. intro t. apply iscontrcoconustot.
+  Defined.
+
+  Theorem isweqtoforallpathsUAH : funextsecweqStatement.
+  Proof.
+    unfold funextsecweqStatement.
+    intros.
+    refine (isweqtotaltofib _ _ (λ (h:∀ t, P t), toforallpaths _ h g) _ f).
+    refine (isweqcontrcontr (X := Σ (h: ∀ t, P t), h = g)
+              (λ ff, tpair _ (pr1 ff) (toforallpaths P (pr1 ff) g (pr2 ff))) _ _).
+    { exact (iscontrcoconustot _ g). }
+    { apply funextweql1UAH. }
+  Qed.
+  Arguments isweqtoforallpathsUAH {_} _ _ _ _.
+
+  Theorem weqtoforallpathsUAH { T : UU } (P:T -> UU)(f g : forall t:T, P t) :
+    (f = g) ≃ (∀ t:T, f t = g t).
+  Proof.
+    exists (toforallpaths P f g). apply isweqtoforallpathsUAH.
+  Defined.
+
+  Definition funextsecUAH : funextsecStatement.
+  Proof.
+    intros ? ? f g.
+    exact (invmap (weqtoforallpathsUAH _ f g)).
+  Defined.
+  Arguments funextsecUAH {_} _ _ _ _.
+
+  Theorem funextfunUAH : funextfunStatement.
+  Proof.
+    exact (funextfunImplication (@funextsecUAH)).
+  Defined.
+  Arguments funextfunUAH {_ _} _ _ _.
+
+  Theorem isweqfunextsecUAH { T : UU } (P:T -> UU) (f g : forall t:T, P t) :
+    isweq (funextsecUAH P f g).
+  Proof.
+    intros.
+    apply isweqinvmap.
+  Defined.
+
+  Definition weqfunextsecUAH { T : UU } (P:T -> UU)(f g : forall t:T, P t) :
+    weq  (forall t:T, paths (f t) (g t)) (paths f g)
+    := weqpair _ ( isweqfunextsecUAH P f g ) .
+
+End UnivalenceImplications.
+
+(** Univalence implies each of the axioms *)
+
+Lemma funcontrFromUnivalence: univalenceStatement -> funcontrStatement.
+Proof. exact funcontrUAH. Defined.
+
+Lemma funextsecweqFromUnivalence: univalenceStatement -> funextsecweqStatement.
+Proof. exact isweqtoforallpathsUAH. Defined.
+
+Lemma funextemptyFromUnivalence: univalenceStatement -> funextemptyStatement.
+  Abort.
+
+Lemma propositionalUnivalenceFromUnivalence: univalenceStatement -> propositionalUnivalenceStatement.
+  Abort.
 
 (** the axioms themselves *)
 
 Axiom univalenceAxiom : univalenceStatement.
 Axiom funextemptyAxiom : funextemptyStatement.
 Axiom funextAxiom : funextsecweqStatement.
+Axiom funcontrAxiom : funcontrStatement.
+Axiom propositionalUnivalence : propositionalUnivalenceStatement.
 
 (** provide some theorems based on the axioms  *)
 
-Theorem univalence (X Y:UU) : (X=Y) ≃ (X≃Y).
-Proof. exact (weqpair _ (univalenceAxiom X Y)). Defined.
+Definition univalence := univalenceUAH univalenceAxiom.
 
-Definition weqtopaths : weqtopathsStatement.
-Proof.
-  intros ? ?. exact (invmap (univalence _ _)).
-Defined.
+Definition weqtopaths := weqtopathsUAH univalenceAxiom.
 Arguments weqtopaths {_ _} _.
 
-Definition weqpathsweq : weqpathsweqStatement (@weqtopaths).
-Proof.
-  intros ? ? w. exact (homotweqinvweq (univalence T1 T2) w).
-Defined.
+Definition weqpathsweq := weqpathsweqUAH univalenceAxiom.
 Arguments weqpathsweq {_ _} _.
 
-(** ** Proof of the functional extensionality for functions from univalence *)
+Definition funcontr := funcontrAxiom.
+Arguments funcontr {_} _ _.
 
-Theorem weqtransportb ( P : UU -> UU ) ( R : forall ( X X' : UU ) ( w :  weq X X' ) , P X' -> P X ) ( r : forall X : UU , forall p : P X , paths ( R X X ( idweq X ) p ) p ) :  forall ( X X' : UU ) ( w :  weq X X' ) ( p' : P X' ) , paths ( R X X' w p' ) (  transportb P ( weqtopaths w ) p' ).
-Proof.
-  intros. set ( uv := weqtopaths w ).   set ( v := eqweqmap uv ).
-  assert ( e : paths v w ) . unfold weqtopaths in uv.
-  apply ( homotweqinvweq ( weqpair _ ( univalenceAxiom X X' ) ) w ).
-  assert ( ee : paths ( R X X' v p' ) ( R X X' w p' ) ) . set ( R' := fun vis : weq X X' => R X X' vis p' ). assert ( ee' : paths ( R' v ) ( R' w ) ). apply (  maponpaths R' e ). assumption.
-  destruct ee. apply l1. assumption. Defined.
+Definition funextweql1 := @funextweql1UAH univalenceAxiom.
+Arguments funextweql1 {_} _ _.
 
-Corollary isweqweqtransportb ( P : UU -> UU ) ( R :  forall ( X X' : UU ) ( w :  weq X X' ) , P X' -> P X ) ( r :  forall X : UU , forall p : P X , paths ( R X X ( idweq X ) p ) p ) :  forall ( X X' : UU ) ( w :  weq X X' ) , isweq ( fun p' :  P X' => R X X' w p' ).
-Proof.
-  intros.
-  assert ( e : forall p' : P X' , paths ( R X X' w p' ) (  transportb P ( weqtopaths w ) p' ) ).
-  - apply weqtransportb. assumption.
-  - assert ( ee : forall p' : P X' , paths  ( transportb P ( weqtopaths w ) p' ) ( R X X' w p' ) ).
-    + intro. apply ( pathsinv0 ( e p' ) ).
-    + clear e.
-      assert ( is1 : isweq ( transportb P ( weqtopaths w ) ) ).
-      apply isweqtransportb10.
-      apply ( isweqhomot ( transportb P ( weqtopaths w ) ) ( fun p'  :  P X' => R X X' w p' ) ee is1 ).
-Defined.
+Definition isweqtoforallpaths := isweqtoforallpathsUAH univalenceAxiom.
+Arguments isweqtoforallpaths {_} _ _ _ _.
 
-(** Theorem saying that composition with a weak equivalence is a weak equivalence on function spaces. *)
+Definition weqtoforallpaths := @weqtoforallpathsUAH univalenceAxiom.
+Arguments weqtoforallpaths {_} _ _ _.
 
-Theorem isweqcompwithweq { X X' : UU } ( w : weq X X' ) ( Y : UU ) :  isweq ( fun f : X' -> Y => ( fun x : X => f ( w x ) ) ).
-Proof.
-  set ( P := fun X0 : UU => ( X0 -> Y ) ).
-  set ( R := fun X0 : UU => ( fun X0' : UU => ( fun w1 : X0 -> X0' =>  ( fun  f : P X0'  => ( fun x : X0 => f ( w1 x ) ) ) ) ) ).
-  apply ( isweqweqtransportb P R (fun X0 f => idpath _) X X' w ).
-Defined.
-
-Lemma eqcor0 { X X' : UU } ( w :  weq X X' ) ( Y : UU ) ( f1 f2 : X' -> Y ) : paths ( fun x : X => f1 ( w x ) )  ( fun x : X => f2 ( w x ) ) -> paths f1 f2.
-Proof. apply ( invmaponpathsweq ( weqpair _ ( isweqcompwithweq w Y ) ) f1 f2 ). Defined.
-
-Lemma apathpr1topr ( T : UU ) : paths ( fun z :  pathsspace T => pr1 z ) ( fun z : pathsspace T => pr1 ( pr2 z ) ).
-Proof. apply ( eqcor0 ( weqpair _ ( isweqdeltap T ) ) _ ( fun z :  pathsspace T => pr1 z ) ( fun z :  pathsspace T => pr1 ( pr2 z ) ) ( idpath ( idfun T ) ) ) . Defined.
-
-Theorem funextfunPreliminary : funextfunStatement.
-Proof.
-  intros ? ? f1 f2 e.
-  set ( f := fun x : X => pathsspacetriple Y ( e x ) ).
-  set ( g1 := fun z : pathsspace Y => pr1 z ).
-  set ( g2 := fun z : pathsspace Y => pr1 ( pr2 z ) ).
-  change ( (funcomp f g1) = (funcomp f g2) ).
-  apply maponpaths.
-  apply apathpr1topr.
-Defined.
-
-Arguments funextfunPreliminary {_ _} _ _ _.
-
-(** *** Deduction of functional extensionality for dependent functions (sections) from functional extensionality of usual functions *)
-
-Lemma isweqlcompwithweq {X X' : UU} (w: weq X X') (Y:UU) : isweq (fun (a:X'->Y) x => a (w x)).
-Proof.
-  simple refine (gradth _ _ _ _).
-  exact (fun b x' => b (invweq w x')).
-  exact (fun a => funextfunPreliminary _ a (fun x' => maponpaths a (homotweqinvweq w x'))).
-  exact (fun a => funextfunPreliminary _ a (fun x  => maponpaths a (homotinvweqweq w x ))).
-Defined.
-
-Lemma isweqrcompwithweq { Y Y':UU } (w: weq Y Y')(X:UU): isweq (fun a:X->Y => (fun x:X => w (a x))).
-Proof. intros. set (f:= (fun a:X->Y => (fun x:X => w (a x)))). set (g := fun a':X-> Y' => fun x:X => (invweq  w (a' x))).
-set (egf:= (fun a:X->Y => funextfunPreliminary (fun x:X => (g (f a)) x) a (fun x: X => (homotinvweqweq w (a x))))).
-set (efg:= (fun a':X->Y' => funextfunPreliminary (fun x:X => (f (g a')) x) a' (fun x: X =>  (homotweqinvweq w (a' x))))).
-apply (gradth  f g egf efg). Defined.
-
-Theorem funcontr { X : UU } (P:X -> UU) : (forall x:X, iscontr (P x)) -> iscontr (forall x:X, P x).
-Proof. intros X0 . set (T1 := forall x:X, P x). set (T2 := (hfiber (fun f: (X -> total2 P)  => fun x: X => pr1  (f x)) (fun x:X => x))). assert (is1:isweq (@pr1 X P)). apply isweqpr1. assumption.  set (w1:= weqpair  (@pr1 X P) is1).
-assert (X1:iscontr T2).  apply (isweqrcompwithweq  w1 X (fun x:X => x)).
-apply ( iscontrretract  _ _  (sectohfibertosec P ) X1). Defined.
-
-Corollary funcontrtwice { X : UU } (P: X-> X -> UU)(is: forall (x x':X), iscontr (P x x')): iscontr (forall (x x':X), P x x').
-Proof. intros.
-assert (is1: forall x:X, iscontr (forall x':X, P x x')). intro. apply (funcontr _ (is x)). apply (funcontr _ is1). Defined.
-
-
-(** Proof of the fact that the [ toforallpaths ] from [paths s1 s2] to [forall t:T, paths (s1 t) (s2 t)] is a weak equivalence - a strong form
-of functional extensionality for sections of general families. The proof uses only [funcontr] which is an axiom i.e. its type satisfies [ isaprop ].  *)
-
-Lemma funextweql1 { T : UU } (P:T -> UU) (g: ∀ t, P t) : ∃! (f:∀ t, P t), ∀ t:T, f t = g t.
-Proof.
-  intros. unshelve refine (iscontrretract (X := ∀ t, Σ p, p = g t) _ _ _ _).
-  - intros x. unshelve refine (_,,_).
-    + intro t. exact (pr1 (x t)).
-    + intro t; simpl. exact (pr2 (x t)).
-  - intros y t. exists (pr1 y t). exact (pr2 y t).
-  - intros u. induction u as [t x]. reflexivity.
-  - apply funcontr. intro t. apply iscontrcoconustot.
-Defined.
-
-Theorem isweqtoforallpaths { T : UU } (P:T -> UU) (f g: ∀ t:T, P t) :
-  isweq (toforallpaths _ f g).
-Proof.
-  intros.
-  refine (isweqtotaltofib _ _ (λ (h:∀ t, P t), toforallpaths _ h g) _ f).
-  refine (isweqcontrcontr (X := Σ (h: ∀ t, P t), h = g)
-            (λ ff, tpair _ (pr1 ff) (toforallpaths P (pr1 ff) g (pr2 ff))) _ _).
-  { exact (iscontrcoconustot _ g). }
-  { apply funextweql1. }
-Qed.
-
-Theorem weqtoforallpaths { T : UU } (P:T -> UU)(f g : forall t:T, P t) :
-  (f = g) ≃ (∀ t:T, f t = g t).
-Proof. intros. exists (toforallpaths P f g). apply isweqtoforallpaths. Defined.
-
-Definition funextsec : funextsecStatement.
-Proof.
-  intros ? ? f g.
-  exact (invmap (weqtoforallpaths _ f g)).
-Defined.
+Definition funextsec := funextsecUAH univalenceAxiom.
 Arguments funextsec {_} _ _ _ _.
 
-Theorem funextfun : funextfunStatement.
-Proof.
-  exact (funextfunImplication (@funextsec)).
-Defined.
-
+Definition funextfun := funextfunUAH univalenceAxiom.
 Arguments funextfun {_ _} _ _ _.
 
-Theorem isweqfunextsec { T : UU } (P:T -> UU) (f g : forall t:T, P t) :
-  isweq (funextsec P f g).
-Proof. intros. apply (isweqinvmap (weqtoforallpaths _ f g)). Defined.
+Definition weqfunextsec := @weqfunextsecUAH univalenceAxiom.
+Arguments weqfunextsec {_} _ _ _.
 
-Definition weqfunextsec { T : UU } (P:T -> UU)(f g : forall t:T, P t) :
-  weq  (forall t:T, paths (f t) (g t)) (paths f g)
-  := weqpair _ ( isweqfunextsec P f g ) .
+(** Provide some corollaries of the theorems based on the axioms  *)
+
+Corollary funcontrtwice { X : UU } (P: X-> X -> UU) (is: forall (x x':X), iscontr (P x x')) :
+  iscontr (forall (x x':X), P x x').
+Proof.
+  intros.
+  assert (is1: forall x:X, iscontr (forall x':X, P x x')).
+  - intro. apply (funcontr _ (is x)).
+  - apply (funcontr _ is1).
+Defined.

--- a/UniMath/Foundations/Basics/UnivalenceAxiom.v
+++ b/UniMath/Foundations/Basics/UnivalenceAxiom.v
@@ -29,22 +29,6 @@ Require Export UniMath.Foundations.Basics.PartB.
 
 (* everything related to eta correction is obsolete *)
 
-Definition etacorrection: forall T:UU, forall P:T -> UU, forall f: (forall t:T, P t), paths f (fun t:T => f t).
-Proof. reflexivity. Defined.
-
-Lemma isweqetacorrection { T : UU } (P:T -> UU): isweq (fun f: forall t:T, P t => (fun t:T => f t)).
-Proof. intros. apply idisweq. Defined.
-
-Definition weqeta { T : UU } (P:T -> UU) := weqpair _ ( isweqetacorrection P ) .
-
-Lemma etacorrectiononpaths { T : UU } (P:T->UU)(s1 s2 :forall t:T, P t) : paths (fun t:T => s1 t) (fun t:T => s2 t)-> paths s1 s2.
-Proof. intros X. set (ew := weqeta P). apply (invmaponpathsweq ew s1 s2 X). Defined.
-
-Definition etacor { X Y : UU } (f:X -> Y) : paths f (fun x:X => f x) := etacorrection _ (fun T:X => Y) f.
-
-Lemma etacoronpaths { X Y : UU } (f1 f2 : X->Y) : paths (fun x:X => f1 x) (fun x:X => f2 x) -> paths f1 f2.
-Proof. intros X0. set (ec:= weqeta (fun x:X => Y) ). apply (invmaponpathsweq  ec f1 f2 X0). Defined.
-
 Definition eqweqmap { T1 T2 : UU } : T1 = T2 -> T1 ≃ T2.
 Proof. intro e. induction e. apply idweq. Defined.
 
@@ -57,7 +41,11 @@ Definition hfibertosec { X : UU } (P:X -> UU):
   (hfiber (fun f x => pr1 (f x)) (fun x:X => x)) -> (forall x:X, P x)
   := fun se:_  => fun x:X => match se as se' return P x with tpair _ s e => (transportf P (toforallpaths _ (fun x:X => pr1 (s x)) (fun x:X => x) e x) (pr2  (s x))) end.
 
-Definition sectohfibertosec { X : UU } (P:X -> UU): forall a: forall x:X, P x, paths (hfibertosec _  (sectohfiber _ a)) a := fun a:_ => (pathsinv0 (etacorrection _ _ a)).
+Definition sectohfibertosec { X : UU } (P:X -> UU):
+  forall a : (forall x:X, P x), hfibertosec _ (sectohfiber _ a) = a.
+Proof.
+  reflexivity.
+Defined.
 
 Lemma isweqtransportf10 { X : UU } ( P : X -> UU ) { x x' : X } ( e :  paths x x' ) : isweq ( transportf P e ).
 Proof. intros. destruct e.  apply idisweq. Defined.
@@ -300,7 +288,7 @@ Section UnivalenceImplications.
     - set (w1:= weqpair  (@pr1 X P) is1).
       assert (X1:iscontr T2).
       + apply (isweqrcompwithweqUAH w1 X (fun x:X => x)).
-      + apply ( iscontrretract  _ _  (sectohfibertosec P ) X1).
+      + apply (iscontrretract _ _ (sectohfibertosec P) X1).
   Defined.
 
   (** Proof of the fact that the [ toforallpaths ] from [paths s1 s2] to

--- a/UniMath/Foundations/Basics/UnivalenceAxiom2.v
+++ b/UniMath/Foundations/Basics/UnivalenceAxiom2.v
@@ -23,9 +23,9 @@ Proof.
   apply isasetempty.
 Defined.
 
-Lemma isaprop_funextsecweqStatement : isaprop funextsecweqStatement.
+Lemma isaprop_isweqtoforallpathsStatement : isaprop isweqtoforallpathsStatement.
 Proof.
-  unfold funextsecweqStatement.
+  unfold isweqtoforallpathsStatement.
   apply impred_isaprop; intro T;
   apply impred_isaprop; intro P;
   apply impred_isaprop; intro f;
@@ -54,6 +54,15 @@ Proof.
   apply impred_isaprop; intro X;
   apply impred_isaprop; intro P;
   apply impred_isaprop; intros _.
+  apply isapropiscontr.
+Defined.
+
+Lemma isaprop_funextcontrStatement : isaprop funextcontrStatement.
+Proof.
+  unfold funextcontrStatement.
+  apply impred_isaprop; intro T;
+  apply impred_isaprop; intro P;
+  apply impred_isaprop; intro g.
   apply isapropiscontr.
 Defined.
 

--- a/UniMath/Foundations/Basics/UnivalenceAxiom2.v
+++ b/UniMath/Foundations/Basics/UnivalenceAxiom2.v
@@ -1,0 +1,60 @@
+(** proofs that the statements of the axioms are propositions *)
+
+Require Import UniMath.Foundations.Basics.PartD.
+
+Lemma isaprop_univalenceStatement : isaprop univalenceStatement.
+Proof.
+  unfold univalenceStatement.
+  apply impred_isaprop; intro X;
+  apply impred_isaprop; intro Y.
+  apply isapropisweq.
+Defined.
+
+Lemma isaprop_funextemptyStatement : isaprop funextemptyStatement.
+Proof.
+  unfold funextemptyStatement.
+  apply impred_isaprop; intro X;
+  apply impred_isaprop; intro f;
+  apply impred_isaprop; intro g.
+  generalize g; clear g.
+  generalize f; clear f.
+  change (isaset (X → ∅)).
+  apply impred_isaset; intro x.
+  apply isasetempty.
+Defined.
+
+Lemma isaprop_funextsecweqStatement : isaprop funextsecweqStatement.
+Proof.
+  unfold funextsecweqStatement.
+  apply impred_isaprop; intro T;
+  apply impred_isaprop; intro P;
+  apply impred_isaprop; intro f;
+  apply impred_isaprop; intro g.
+  apply isapropisweq.
+Defined.
+
+Lemma isaprop_propositionalUnivalenceStatement : isaprop propositionalUnivalenceStatement.
+Proof.
+  unfold propositionalUnivalenceStatement.
+  apply impred_isaprop; intro P;
+  apply impred_isaprop; intro Q;
+  apply impred_isaprop; intro i;
+  apply impred_isaprop; intro j;
+  apply impred_isaprop; intros _;
+  apply impred_isaprop; intros _.
+  apply (isofhlevelweqb 1 (univalence P Q)).
+  fold isaprop.
+  apply isapropweqtoprop.
+  exact j.
+Defined.
+
+Lemma isaprop_funcontrStatement : isaprop funcontrStatement.
+Proof.
+  unfold funcontrStatement.
+  apply impred_isaprop; intro X;
+  apply impred_isaprop; intro P;
+  apply impred_isaprop; intros _.
+  apply isapropiscontr.
+Defined.
+
+(* end *)

--- a/UniMath/Foundations/Combinatorics/OrderedSets.v
+++ b/UniMath/Foundations/Combinatorics/OrderedSets.v
@@ -94,7 +94,7 @@ Proof.
   unfold isaposetmorphism in e; simpl in e.
   induction e as [e e'].
   unfold posetRelation in *. unfold invmap in *; simpl in *.
-  apply uahp. { apply e. } { apply e'. }
+  apply hPropUnivalence. { apply e. } { apply e'. }
 Defined.
 
 Open Scope transport.

--- a/UniMath/Foundations/Combinatorics/Tests.v
+++ b/UniMath/Foundations/Combinatorics/Tests.v
@@ -113,7 +113,7 @@ Module Test_stn.
     Goal homotinvweqweq re (ii2 tt) = idpath _. reflexivity. Defined.
     Goal homotinvweqweq re (ii1 c) = idpath _.
       try reflexivity.
-      (* quickly returns due to the use of funextempty in the proof of isweqrecompl. *)
+      (* quickly returns due to the use of funextemptyAxiom in the proof of isweqrecompl. *)
     Abort.
 
     Goal re' (ii2 tt) = i. reflexivity. Defined.
@@ -281,8 +281,8 @@ Module Test_fin.
 
     (* This module exports nothing. *)
 
-    (* The proofs of isfinite_isdeceq and isfinite_isaset depend on funextfunax
-       and funextempty, so here we do an experiment to see if that impedes
+    (* The proofs of isfinite_isdeceq and isfinite_isaset depend on funextfun
+       and funextemptyAxiom, so here we do an experiment to see if that impedes
        computability of equality using it. *)
 
     Open Scope stn.
@@ -422,7 +422,7 @@ Module Test_ord.
       Unset Printing Notations.
       unfold decidabilityProperty.
       (* Print Assumptions FiniteOrderedSetDecidableEquality. *)
-      (* uses: funextfunax funextempty *)
+      (* uses: funextfun funextemptyAxiom *)
     Abort.
 
     Goal choice (x ≠ y)%foset true false = false.

--- a/UniMath/Ktheory/AbelianMonoid.v
+++ b/UniMath/Ktheory/AbelianMonoid.v
@@ -73,7 +73,7 @@ Proof.
   induction (dec i j) as [ieqj | inej].
   { induction (ne ieqj). }
   { assert ( H : inej = ne ).
-    { apply funextfun. intros. induction (ne x). }
+    { apply funextfun. intro x. induction (ne x). }
     induction H.
     reflexivity. }
 Defined.

--- a/UniMath/Ktheory/Bifunctor.v
+++ b/UniMath/Ktheory/Bifunctor.v
@@ -118,7 +118,7 @@ Defined.
 Lemma transport_along_funextsec {X:UU} {Y:X->UU} {f g:∀ x, Y x}
       (e:f~g) (x:X) : transportf _ (funextsec _ _ _ e) (f x) = g x.
 Proof.
-  unfold funextsec.
+  unfold funextsec, funextsecUAH. fold @weqtoforallpaths.
   induction (invmap (weqtoforallpaths _ f g) e).
   reflexivity.
 Defined.

--- a/UniMath/Ktheory/Bifunctor.v
+++ b/UniMath/Ktheory/Bifunctor.v
@@ -117,11 +117,7 @@ Defined.
 
 Lemma transport_along_funextsec {X:UU} {Y:X->UU} {f g:∀ x, Y x}
       (e:f~g) (x:X) : transportf _ (funextsec _ _ _ e) (f x) = g x.
-Proof.
-  unfold funextsec, funextsecUAH. fold @weqtoforallpaths.
-  induction (invmap (weqtoforallpaths _ f g) e).
-  reflexivity.
-Defined.
+Proof. now induction (funextsec _ _ _ e). Defined.
 
 Definition Functor_eq_map {A B: Precategory} (F G:[A,B]) :
   F = G ->

--- a/UniMath/Ktheory/GroupAction.v
+++ b/UniMath/Ktheory/GroupAction.v
@@ -148,7 +148,7 @@ Definition is_equivariant_identity {G:gr} {X Y:Action G}
            (p:ac_set X = ac_set Y) :
   weq (p # ac_str X = ac_str Y) (is_equivariant (cast (ap pr1hSet p))).
 Proof. intros ? [X [Xm Xu Xa]] [Y [Ym Yu Ya]] ? .
-       (* should just apply uahp at this point, as in Poset_univalence_prelim! *)
+       (* should just apply hPropUnivalence at this point, as in Poset_univalence_prelim! *)
        simpl in p. destruct p; simpl. unfold transportf; simpl. unfold idfun; simpl.
        simple refine (weqpair _ _).
        { intros p g x. simpl in x. simpl.

--- a/UniMath/Ktheory/Utilities.v
+++ b/UniMath/Ktheory/Utilities.v
@@ -6,12 +6,6 @@ Require Export UniMath.Foundations.Basics.Sets.
 Require Import UniMath.Foundations.Basics.UnivalenceAxiom.
 Require Export UniMath.Ktheory.Tactics.
 
-(* axiom for postponing a proof until later *)
-
-Axiom PostponedProof : empty.
-
-Ltac postponeProof := apply fromempty, PostponedProof.
-
 (** ** Null homotopies, an aid for proving things about propositional truncation *)
 
 Open Scope transport.

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -680,7 +680,7 @@ Proof.
     + apply idpath.
     + eapply pathscomp0. Focus 2. apply T5.
       (* hypothesis of fusion law *)
-      apply funextsec. intro.
+      apply funextsec. intro t.
       simpl.
       unfold compose. simpl.
       apply nat_trans_eq. assumption.


### PR DESCRIPTION
This addresses #381.

It also removes the obsolete lemmas on eta-correction for functions.

Another option would be to preserve uahp as an axiom.