### PR TITLE
change notation for "forall"

### DIFF
--- a/UniMath/CategoryTheory/Epis.v
+++ b/UniMath/CategoryTheory/Epis.v
@@ -11,16 +11,8 @@ Section def_epi.
   Variable C : precategory.
 
   (** Definition and construction of isEpi. *)
-<<<<<<< HEAD
-  Definition isEpi {x y : C} (f : x --> y) :=
-    Π (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h.
-||||||| merged common ancestors
-  Definition isEpi {x y : C} (f : x --> y) :=
-    forall (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h.
-=======
   Definition isEpi {x y : C} (f : x --> y) : UU :=
-    forall (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h.
->>>>>>> 2c0c40deb560dc855144f924c8a63184d7e0462d
+    Π (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h.
   Definition mk_isEpi {x y : C} (f : x --> y) :
     (Π (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h) -> isEpi f.
   Proof. intros X. unfold isEpi. apply X.  Defined.

--- a/UniMath/CategoryTheory/Epis.v
+++ b/UniMath/CategoryTheory/Epis.v
@@ -12,9 +12,9 @@ Section def_epi.
 
   (** Definition and construction of isEpi. *)
   Definition isEpi {x y : C} (f : x --> y) :=
-    forall (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h.
+    Π (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h.
   Definition mk_isEpi {x y : C} (f : x --> y) :
-    (forall (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h) -> isEpi f.
+    (Π (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h) -> isEpi f.
   Proof. intros X. unfold isEpi. apply X.  Defined.
 
   (** Definition and construction of Epi. *)

--- a/UniMath/CategoryTheory/HLevel_n_is_of_hlevel_Sn.v
+++ b/UniMath/CategoryTheory/HLevel_n_is_of_hlevel_Sn.v
@@ -46,7 +46,7 @@ Defined.
     the hProposition [P] with this fibration.
 *)
 
-Lemma ident_is_prop : forall (P : UU -> hProp) (X X' : UU)
+Lemma ident_is_prop : Π (P : UU -> hProp) (X X' : UU)
       (pX : P X) (pX' : P X') (w : X = X'),
    isaprop (transportf (fun X => P X) w pX = pX').
 Proof.
@@ -135,7 +135,7 @@ Defined.
 
 (** *** The case [n = S n'] *)
 
-Lemma isofhlevelSnpathspace : forall n : nat, forall X Y : UU,
+Lemma isofhlevelSnpathspace : Π n : nat, Π X Y : UU,
       isofhlevel (S n) Y -> isofhlevel (S n) (X = Y).
 Proof.
   intros n X Y pY.
@@ -154,7 +154,7 @@ Defined.
 
 (** ** The lemma itself *)
 
-Lemma isofhlevelpathspace : forall n : nat, forall X Y : UU,
+Lemma isofhlevelpathspace : Π n : nat, Π X Y : UU,
       isofhlevel n X -> isofhlevel n Y -> isofhlevel n (X = Y).
 Proof.
   intros n.
@@ -178,7 +178,7 @@ Definition HLevel n := total2 (fun X : UU => isofhlevel n X).
 
 (** * Main theorem: [HLevel n] is of hlevel [S n] *)
 
-Lemma hlevel_of_hlevels : forall n,
+Lemma hlevel_of_hlevels : Π n,
       isofhlevel (S n) (HLevel n).
 Proof.
   intro n.
@@ -210,7 +210,7 @@ Proof.
   exact (weqcomp f g).
 Defined.
 
-Corollary UA_for_HLevels : forall (n : nat)
+Corollary UA_for_HLevels : Π (n : nat)
       (X X' : HLevel n),
      weq (X = X') (weq (pr1 X) (pr1 X')).
 Proof.

--- a/UniMath/CategoryTheory/HorizontalComposition.v
+++ b/UniMath/CategoryTheory/HorizontalComposition.v
@@ -69,7 +69,7 @@ Lemma horcomp_id_left (C D : precategory) (X : functor C C) (Z Z' : functor C D)
 *)
 Lemma horcomp_id_left (C D : precategory) (X : functor C C) (Z Z' : functor C D)(f : nat_trans Z Z')
   :
-  forall c : C, hor_comp (nat_trans_id X) f c = f (X c).
+  Π c : C, hor_comp (nat_trans_id X) f c = f (X c).
 Proof.
   simpl.
   intro c.

--- a/UniMath/CategoryTheory/Monads.v
+++ b/UniMath/CategoryTheory/Monads.v
@@ -56,11 +56,11 @@ Definition η {C : precategory} (F : Monad_data C)
 Definition Monad_laws {C : precategory} (T : Monad_data C) : UU
   :=
     (
-      (∀ c : C, η T (T c) ;; μ T c = identity (T c))
+      (Π c : C, η T (T c) ;; μ T c = identity (T c))
         ×
-      (∀ c : C, #T (η T c) ;; μ T c = identity (T c)))
+      (Π c : C, #T (η T c) ;; μ T c = identity (T c)))
       ×
-    (∀ c : C, #T (μ T c) ;; μ T c = μ T (T c) ;; μ T c).
+    (Π c : C, #T (μ T c) ;; μ T c = μ T (T c) ;; μ T c).
 
 Lemma isaprop_Monad_laws (C : precategory) (hs : has_homsets C) (T : Monad_data C) :
    isaprop (Monad_laws T).
@@ -76,8 +76,8 @@ Coercion Monad_data_from_Monad (C : precategory) (T : Monad C) : Monad_data C :=
 
 Definition Monad_Mor_laws {C : precategory} {T T' : Monad_data C} (α : T ⟶ T')
   : UU :=
-  (∀ a : C, μ T a ;; α a = α (T a) ;; #T' (α a) ;; μ T' a) ×
-  (∀ a : C, η T a ;; α a = η T' a).
+  (Π a : C, μ T a ;; α a = α (T a) ;; #T' (α a) ;; μ T' a) ×
+  (Π a : C, η T a ;; α a = η T' a).
 
 Lemma isaprop_Monad_Mor_laws (C : precategory) (hs : has_homsets C)
   (T T' : Monad_data C) (α : T ⟶ T')
@@ -94,13 +94,13 @@ Coercion nat_trans_from_monad_mor (C : precategory) (T T' : Monad C) (s : Monad_
   : T ⟶ T' := pr1 s.
 
 Definition Monad_Mor_η {C : precategory} {T T' : Monad C} (α : Monad_Mor T T')
-  : ∀ a : C, η T a ;; α a = η T' a.
+  : Π a : C, η T a ;; α a = η T' a.
 Proof.
   exact (pr2 (pr2 α)).
 Qed.
 
 Definition Monad_Mor_μ {C : precategory} {T T' : Monad C} (α : Monad_Mor T T')
-  : ∀ a : C, μ T a ;; α a = α (T a) ;; #T' (α a) ;; μ T' a.
+  : Π a : C, μ T a ;; α a = α (T a) ;; #T' (α a) ;; μ T' a.
 Proof.
   exact (pr1 (pr2 α)).
 Qed.

--- a/UniMath/CategoryTheory/Monics.v
+++ b/UniMath/CategoryTheory/Monics.v
@@ -12,9 +12,9 @@ Section def_monic.
 
   (** Definition and construction of isMonic. *)
   Definition isMonic {y z : C} (f : y --> z) :=
-    forall (x : C) (g h : x --> y), g ;; f = h ;; f -> g = h.
+    Π (x : C) (g h : x --> y), g ;; f = h ;; f -> g = h.
   Definition mk_isMonic {y z : C} (f : y --> z) :
-    (forall (x : C) (g h : x --> y), g ;; f = h ;; f -> g = h) -> isMonic f.
+    (Π (x : C) (g h : x --> y), g ;; f = h ;; f -> g = h) -> isMonic f.
   Proof. intros X. unfold isMonic. apply X.  Defined.
 
   (** Definition and construction of Monic. *)

--- a/UniMath/CategoryTheory/PointedFunctors.v
+++ b/UniMath/CategoryTheory/PointedFunctors.v
@@ -45,7 +45,7 @@ Coercion functor_from_ptd_obj (F : ptd_obj) : functor C C := pr1 F.
 
 Definition ptd_pt (F : ptd_obj) : functor_identity C ⟶ F := pr2 F.
 
-Definition is_ptd_mor {F G : ptd_obj}(α: F ⟶ G) : UU := ∀ c : C, ptd_pt F c ;; α c = ptd_pt G c.
+Definition is_ptd_mor {F G : ptd_obj}(α: F ⟶ G) : UU := Π c : C, ptd_pt F c ;; α c = ptd_pt G c.
 
 Definition ptd_mor (F G : ptd_obj) : UU :=
   Σ α : F ⟶ G, is_ptd_mor α.
@@ -62,7 +62,7 @@ Proof.
 Defined.
 
 Definition ptd_mor_commutes {F G : ptd_obj} (α : ptd_mor F G)
-  : ∀ c : C, ptd_pt F c ;; α c = ptd_pt G c.
+  : Π c : C, ptd_pt F c ;; α c = ptd_pt G c.
 Proof.
   exact (pr2 α).
 Qed.

--- a/UniMath/CategoryTheory/PreAdditive.v
+++ b/UniMath/CategoryTheory/PreAdditive.v
@@ -20,15 +20,15 @@ Section def_preadditive.
     morphism yields a morphism of abelian groups. Classically one says that
     composition is bilinear with respect to the abelian groups? *)
   Definition isPreAdditive (PA : PrecategoryWithAbgrops) :=
-    (forall (x y z : PA) (f : x --> y),
+    (Π (x y z : PA) (f : x --> y),
         ismonoidfun (PrecategoryWithAbgrops_premor PA x y z f))
-      × (forall (x y z : PA) (f : y --> z),
+      × (Π (x y z : PA) (f : y --> z),
             ismonoidfun (PrecategoryWithAbgrops_postmor PA x y z f)).
 
   Definition mk_isPreAdditive (PA : PrecategoryWithAbgrops)
-             (H1 : forall (x y z : PA) (f : x --> y),
+             (H1 : Π (x y z : PA) (f : x --> y),
                  ismonoidfun (PrecategoryWithAbgrops_premor PA x y z f))
-             (H2 : forall (x y z : PA) (f : y --> z),
+             (H2 : Π (x y z : PA) (f : y --> z),
                    ismonoidfun (PrecategoryWithAbgrops_postmor PA x y z f)) :
     isPreAdditive PA.
   Proof.

--- a/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
+++ b/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
@@ -19,7 +19,7 @@ Section def_precategory_with_abgrops.
   (** Definition of precategories such that homsets are abgrops. *)
   Definition isPrecategoryWithAbgrops (PB : PrecategoryWithBinOps)
              (hs : has_homsets PB) :=
-    forall (x y : PB), @isabgrop (hSetpair (PB⟦x,y⟧) (hs x y))
+    Π (x y : PB), @isabgrop (hSetpair (PB⟦x,y⟧) (hs x y))
                             (PrecategoryWithBinOps_binop PB x y).
 
   Definition PrecategoryWithAbgrops : UU :=

--- a/UniMath/CategoryTheory/PrecategoriesWithBinOps.v
+++ b/UniMath/CategoryTheory/PrecategoriesWithBinOps.v
@@ -16,7 +16,7 @@ Section def_precategory_with_binops.
 
   (** Definition of precategories such that homs are binops. *)
   Definition PrecategoryWithBinOpsData (C : precategory) :=
-    forall (x y : C), binop (C⟦x, y⟧).
+    Π (x y : C), binop (C⟦x, y⟧).
 
   Definition PrecategoryWithBinOps :
     UU := Σ C : precategory, PrecategoryWithBinOpsData C.

--- a/UniMath/CategoryTheory/ProductPrecategory.v
+++ b/UniMath/CategoryTheory/ProductPrecategory.v
@@ -25,9 +25,9 @@ Variables C : I -> precategory.
 Definition product_precategory_ob_mor : precategory_ob_mor.
 Proof.
 mkpair.
-- apply (forall (i : I), ob (C i)).
+- apply (Π (i : I), ob (C i)).
 - intros f g.
-  apply (forall i, f i --> g i).
+  apply (Π i, f i --> g i).
 Defined.
 
 Definition product_precategory_data : precategory_data.
@@ -52,7 +52,7 @@ Qed.
 Definition product_precategory : precategory
   := tpair _ _ is_precategory_product_precategory_data.
 
-Definition has_homsets_product_precategory (hsC : forall (i:I), has_homsets (C i)) :
+Definition has_homsets_product_precategory (hsC : Π (i:I), has_homsets (C i)) :
   has_homsets product_precategory.
 Proof.
 intros a b; simpl.
@@ -84,7 +84,7 @@ End power_precategory.
 Section functors.
 
 Definition pair_functor_data (I : UU) {A B : I -> precategory}
-  (F : forall (i : I), functor (A i) (B i)) :
+  (F : Π (i : I), functor (A i) (B i)) :
   functor_data (product_precategory I A)
                (product_precategory I B).
 Proof.
@@ -94,7 +94,7 @@ mkpair.
 Defined.
 
 Definition pair_functor (I : UU) {A B : I -> precategory}
-  (F : forall (i : I), functor (A i) (B i)) :
+  (F : Π (i : I), functor (A i) (B i)) :
   functor (product_precategory I A)
           (product_precategory I B).
 Proof.

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -49,7 +49,7 @@ Variable A : UU.
 Variable R0 : hrel A.
 
 Lemma isaprop_eqrel_from_hrel a b :
-  isaprop (∀ R : eqrel A, (∀ x y, R0 x y -> R x y) -> R a b).
+  isaprop (Π R : eqrel A, (Π x y, R0 x y -> R x y) -> R a b).
 Proof.
   apply impred; intro R; apply impred_prop.
 Qed.
@@ -73,8 +73,8 @@ now intros H R HR; apply HR.
 Qed.
 
 (* eqrel_from_hrel is the *smallest* relation containing R0 *)
-Lemma minimal_eqrel_from_hrel (R : eqrel A) (H : ∀ a b, R0 a b -> R a b) :
-  ∀ a b, eqrel_from_hrel a b -> R a b.
+Lemma minimal_eqrel_from_hrel (R : eqrel A) (H : Π a b, R0 a b -> R a b) :
+  Π a b, eqrel_from_hrel a b -> R a b.
 Proof.
 now intros a b H'; apply H'.
 Qed.
@@ -196,7 +196,7 @@ simple refine (mk_cocone _ _).
 Defined.
 
 Definition ColimHSETArrow (c : HSET) (cc : cocone D c) :
-  Σ x : HSET ⟦ colimHSET, c ⟧, ∀ v : vertex g, injections v ;; x = coconeIn cc v.
+  Σ x : HSET ⟦ colimHSET, c ⟧, Π v : vertex g, injections v ;; x = coconeIn cc v.
 Proof.
 exists (from_colimHSET _ cc).
 abstract (intro i; simpl; unfold injections, compose, from_colimHSET; simpl;
@@ -301,8 +301,8 @@ Variable g : graph.
 Variable D : diagram g HSET.
 
 Definition limset_UU : UU :=
-  Σ (f : ∀ u : vertex g, pr1hSet (dob D u)),
-    ∀ u v (e : edge u v), dmor D e (f u) = f v.
+  Σ (f : Π u : vertex g, pr1hSet (dob D u)),
+    Π u v (e : edge u v), dmor D e (f u) = f v.
 
 Definition limset : HSET.
 Proof.
@@ -348,8 +348,8 @@ Variable J : precategory.
 Variable D : functor J HSET.
 
 Definition cats_limset_UU : UU :=
-  Σ (f : ∀ u, pr1hSet (D u)),
-    ∀ u v (e : J⟦u,v⟧), # D e (f u) = f v.
+  Σ (f : Π u, pr1hSet (D u)),
+    Π u v (e : J⟦u,v⟧), # D e (f u) = f v.
 
 Definition cats_limset : HSET.
 Proof.
@@ -412,7 +412,7 @@ Lemma Products_HSET (I : UU) : Products I HSET.
 Proof.
 intros A.
 simple refine (mk_ProductCone _ _ _ _ _ _).
-- apply (tpair _ (forall i, pr1 (A i))); apply isaset_forall_hSet.
+- apply (tpair _ (Π i, pr1 (A i))); apply isaset_forall_hSet.
 - simpl; intros i f; apply (f i).
 - apply (mk_isProductCone _ _ has_homsets_HSET).
   intros C f; simpl in *.

--- a/UniMath/CategoryTheory/chains.v
+++ b/UniMath/CategoryTheory/chains.v
@@ -85,7 +85,7 @@ induction m; simpl.
 Defined.
 
 Definition chain_mor {C : precategory} (c : chain C) i :
-  forall j, i < j -> C⟦dob c i, dob c j⟧.
+  Π j, i < j -> C⟦dob c i, dob c j⟧.
 Proof.
 induction j.
 - intros Hi0.
@@ -98,7 +98,7 @@ induction j.
 Defined.
 
 Lemma chain_mor_commutes {C : precategory} (c : chain C) (x : C)
-  (cc : cocone c x) i : forall j (Hij : i < j),
+  (cc : cocone c x) i : Π j (Hij : i < j),
   chain_mor c i j Hij ;; coconeIn cc j = coconeIn cc i.
 Proof.
 induction j.
@@ -149,7 +149,7 @@ End chains.
 Notation "'chain'" := (diagram nat_graph).
 
 Definition is_omega_cocont {C D : precategory} (F : functor C D) : UU :=
-  forall (c : chain C) (L : C) (cc : cocone c L),
+  Π (c : chain C) (L : C) (cc : cocone c L),
   preserves_colimit F c L cc.
 
 Definition omega_cocont_functor (C D : precategory)  : UU :=

--- a/UniMath/CategoryTheory/cocontfunctors.v
+++ b/UniMath/CategoryTheory/cocontfunctors.v
@@ -172,7 +172,7 @@ mkpair.
   abstract (intro n; apply (maponpaths pr1 (p1 n))).
 - intro t.
   simple refine (let X : Σ x0,
-           ∀ v : nat, coconeIn ccab v ;; x0 =
+           Π v : nat, coconeIn ccab v ;; x0 =
                       binprodcatmor (pr1 ccx v) (pr2 (pr1 ccab v)) := _ in _).
   { mkpair.
     - split; [ apply (pr1 t) | apply (identity _) ].
@@ -219,7 +219,7 @@ mkpair.
   abstract (intro n; apply (maponpaths dirprod_pr2 (p1 n))).
 - intro t.
   simple refine (let X : Σ x0,
-           ∀ v : nat, coconeIn ccab v ;; x0 =
+           Π v : nat, coconeIn ccab v ;; x0 =
                       binprodcatmor (pr1 (pr1 ccab v)) (pr1 ccx v) := _ in _).
   { mkpair.
     - split; [ apply (identity _) | apply (pr1 t) ].
@@ -276,7 +276,7 @@ End binproduct_pair_functor.
 Section pair_functor.
 
 Variables (I : UU) (A B : precategory).
-Variables (F : forall (i : I), functor A B).
+Variables (F : Π (i : I), functor A B).
 Variables (hsA : has_homsets A) (hsB : has_homsets B).
 
 (* I needs to have decidable equality for pr_functor to be omega cocont *)
@@ -295,7 +295,7 @@ Defined.
 Lemma isColimCocone_pr_functor
   (c : chain (power_precategory I A))
   (L : power_precategory I A) (ccL : cocone c L)
-  (M : isColimCocone c L ccL) : forall i,
+  (M : isColimCocone c L ccL) : Π i,
   isColimCocone _ _ (mapcocone (pr_functor I (fun _ => A) i) c ccL).
 Proof.
 intros i x ccx; simpl in *.
@@ -326,7 +326,7 @@ mkpair.
     now rewrite hp, idpath_transportf).
 - intro t.
   simple refine (let X : Σ x0,
-           ∀ n, coconeIn ccL n ;; x0 = coconeIn HHH n := _ in _).
+           Π n, coconeIn ccL n ;; x0 = coconeIn HHH n := _ in _).
   { mkpair.
     - simpl; intro j; unfold ifI.
       destruct (HI i j).
@@ -351,7 +351,7 @@ now apply isColimCocone_pr_functor.
 Defined.
 
 Lemma is_omega_cocont_pair_functor
-  (HF : forall (i : I), is_omega_cocont (F i)) :
+  (HF : Π (i : I), is_omega_cocont (F i)) :
   is_omega_cocont (pair_functor I F).
 Proof.
 intros cAB ml ccml Hccml xy ccxy; simpl in *.
@@ -373,7 +373,7 @@ mkpair.
   + destruct t as [f1 f2]; simpl in *.
     apply funextsec; intro i.
     simple refine (let H : Σ x : B ⟦ (F i) (ml i), xy i ⟧,
-                          ∀ n, # (F i) (coconeIn ccml n i) ;; x =
+                          Π n, # (F i) (coconeIn ccml n i) ;; x =
                                coconeIn ccxy n i := _ in _).
     { apply (tpair _ (f1 i)); intro n; apply (toforallpaths _ _ _ (f2 n) i). }
     apply (maponpaths pr1 (pr2 (X i) H)).
@@ -505,8 +505,8 @@ Variables (HD : Coproducts I D).
 Variables (hsC : has_homsets C) (hsD : has_homsets D).
 Variable (HI : isdeceq I).
 
-Lemma is_omega_cocont_coproduct_of_functors_alt (F : forall i, functor C D)
-  (HF : forall i, is_omega_cocont (F i)) :
+Lemma is_omega_cocont_coproduct_of_functors_alt (F : Π i, functor C D)
+  (HF : Π i, is_omega_cocont (F i)) :
   is_omega_cocont (coproduct_of_functors_alt _ HD F).
 Proof.
 apply (is_omega_cocont_functor_composite hsD).
@@ -517,12 +517,12 @@ apply (is_omega_cocont_indexed_coproduct_functor _ _ _ hsD).
 Defined.
 
 Definition omega_cocont_coproduct_of_functors_alt
-  (F : forall i, omega_cocont_functor C D) :
+  (F : Π i, omega_cocont_functor C D) :
   omega_cocont_functor C D :=
     tpair _ _ (is_omega_cocont_coproduct_of_functors_alt _ (fun i => pr2 (F i))).
 
-Lemma is_omega_cocont_coproduct_of_functors (F : forall (i : I), functor C D)
-  (HF : forall i, is_omega_cocont (F i)) :
+Lemma is_omega_cocont_coproduct_of_functors (F : Π (i : I), functor C D)
+  (HF : Π i, is_omega_cocont (F i)) :
   is_omega_cocont (coproduct_of_functors I _ _ HD F).
 Proof.
 exact (transportf _
@@ -531,7 +531,7 @@ exact (transportf _
 Defined.
 
 Definition omega_cocont_coproduct_of_functors
-  (F : forall i, omega_cocont_functor C D) :
+  (F : Π i, omega_cocont_functor C D) :
   omega_cocont_functor C D :=
     tpair _ _ (is_omega_cocont_coproduct_of_functors _ (fun i => pr2 (F i))).
 
@@ -580,7 +580,7 @@ Variables (C : precategory) (PC : BinProducts C) (hsC : has_homsets C).
 Variables (hE : has_exponentials PC).
 
 Definition fun_lt (cAB : chain (binproduct_precategory C C)) :
-  forall i j, i < j ->
+  Π i j, i < j ->
               C ⟦ BinProductObject C (PC (ob1 (dob cAB i)) (ob2 (dob cAB j))),
                   BinProductObject C (PC (ob1 (dob cAB j)) (ob2 (dob cAB j))) ⟧.
 Proof.
@@ -589,7 +589,7 @@ apply (BinProductOfArrows _ _ _ (mor1 (chain_mor cAB _ _ hij)) (identity _)).
 Defined.
 
 Definition fun_gt (cAB : chain (binproduct_precategory C C)) :
-  forall i j, i > j ->
+  Π i j, i > j ->
               C ⟦ BinProductObject C (PC (ob1 (dob cAB i)) (ob2 (dob cAB j))),
                   BinProductObject C (PC (ob1 (dob cAB i)) (ob2 (dob cAB i))) ⟧.
 Proof.
@@ -720,7 +720,7 @@ Proof.
   apply BinProductOfArrows; [apply (dmor cAB (idpath _)) | apply identity ].
 Defined.
 
-Local Lemma fNat : ∀ i u v (e : edge u v),
+Local Lemma fNat : Π i u v (e : edge u v),
    dmor (mapdiagram (constprod_functor1 PC _) cB) e ;; f i v =
    f i u ;; dmor (mapdiagram (constprod_functor1 PC _) cB) e.
 Proof.
@@ -739,7 +739,7 @@ Proof.
     apply (colimOfArrows (CCAiB i) (CCAiB (S i)) (f i) (fNat i)).
 Defined.
 
-Local Lemma AiM_chain_eq : forall i, dmor AiM_chain (idpath (S i)) =
+Local Lemma AiM_chain_eq : Π i, dmor AiM_chain (idpath (S i)) =
                        dmor (mapdiagram (constprod_functor2 PC M) cA) (idpath _).
 Proof.
   intro i; simpl; unfold colimOfArrows, BinProduct_of_functors_mor; simpl.
@@ -753,7 +753,7 @@ Proof.
 Qed.
 
 (* Define a cocone over K from the A_i * M chain *)
-Local Lemma ccAiM_K_subproof : ∀ u v (e : edge u v),
+Local Lemma ccAiM_K_subproof : Π u v (e : edge u v),
    dmor (mapdiagram (constprod_functor2 PC M) cA) e ;;
    colimArrow (CCAiB v) K (ccAiB_K v) = colimArrow (CCAiB u) K (ccAiB_K u).
 Proof.
@@ -808,7 +808,7 @@ Qed.
 Local Definition ccAiM_K := mk_cocone _ ccAiM_K_subproof.
 
 Local Lemma is_cocone_morphism :
- ∀ v : nat,
+ Π v : nat,
    BinProductOfArrows C (PC L M) (PC (pr1 (dob cAB v)) (pr2 (dob cAB v)))
      (pr1 (coconeIn ccLM v)) (pr2 (coconeIn ccLM v)) ;;
    colimArrow HAiM K ccAiM_K = coconeIn ccK v.
@@ -832,9 +832,9 @@ Proof.
   now rewrite id_left, id_right.
 Qed.
 
-Lemma is_unique_cocone_morphism : ∀
+Lemma is_unique_cocone_morphism : Π
    t : Σ x : C ⟦ BinProductObject C (PC L M), K ⟧,
-       ∀ v : nat,
+       Π v : nat,
        BinProductOfArrows C (PC L M) (PC (pr1 (dob cAB v)) (pr2 (dob cAB v)))
          (pr1 (coconeIn ccLM v)) (pr2 (coconeIn ccLM v)) ;; x =
        coconeIn ccK v, t = colimArrow HAiM K ccAiM_K,, is_cocone_morphism.
@@ -874,7 +874,7 @@ Proof.
 Qed.
 
 Definition isColimProductOfColims :  ∃! x : C ⟦ BinProductObject C (PC L M), K ⟧,
-   ∀ v : nat,
+   Π v : nat,
    BinProductOfArrows C (PC L M) (PC (pr1 (dob cAB v)) (pr2 (dob cAB v)))
      (pr1 (coconeIn ccLM v)) (pr2 (coconeIn ccLM v)) ;; x =
    coconeIn ccK v.
@@ -1030,7 +1030,7 @@ use adjunction_from_partial.
 - apply eps.
 - intros T S α; simpl in *.
 
-  transparent assert (cc : (forall c, cone (QT T c) (S c))).
+  transparent assert (cc : (Π c, cone (QT T c) (S c))).
   { intro c.
     use mk_cone.
     + intro mf; apply (# S (pr2 mf) ;; α (pr1 mf)).
@@ -1039,13 +1039,13 @@ use adjunction_from_partial.
                 simpl; rewrite assoc, <- functor_comp; apply cancel_postcomposition, maponpaths, (pr2 h)).
   }
 
-  transparent assert (σ : (forall c, A ⟦ S c, R T c ⟧)).
+  transparent assert (σ : (Π c, A ⟦ S c, R T c ⟧)).
   { intro c; apply (limArrow _ _ (cc c)). }
 
   set (lambda' := fun c' mf' => limOut (LA (c' ↓ K) (QT T c')) mf').
 
   (* this is the conclusion from the big diagram (8) in MacLane's proof *)
-  assert (H : forall c c' (g : C ⟦ c, c' ⟧) (mf' : c' ↓ K),
+  assert (H : Π c c' (g : C ⟦ c, c' ⟧) (mf' : c' ↓ K),
                 # S g ;; σ c' ;; lambda' _ mf' = σ c ;; Rmor T c c' g ;; lambda' _ mf').
   { intros c c' g mf'.
     rewrite <- !assoc.

--- a/UniMath/CategoryTheory/covyoneda.v
+++ b/UniMath/CategoryTheory/covyoneda.v
@@ -82,7 +82,7 @@ Definition covyoneda_objects (C : precategory) (hs: has_homsets C) (c : C^op) :
 (** ** On morphisms *)
 
 Definition covyoneda_morphisms_data (C : precategory) (hs: has_homsets C) (c c' : C^op)
-    (f : C^op⟦c,c'⟧) : forall a : C,
+    (f : C^op⟦c,c'⟧) : Π a : C,
          HSET⟦covyoneda_objects C hs c a,covyoneda_objects C hs c' a⟧.
 Proof.
 simpl in f; intros a g.

--- a/UniMath/CategoryTheory/equivalences.v
+++ b/UniMath/CategoryTheory/equivalences.v
@@ -49,9 +49,9 @@ Definition form_adjunction {A B : precategory}
        (eta : nat_trans (functor_identity A) (functor_composite F G))
        (eps : nat_trans (functor_composite G F) (functor_identity B)) : UU :=
 dirprod
-  (forall a : ob A,
+  (Π a : ob A,
        #F (eta a) ;; eps (F a) = identity (F a))
-  (forall b : ob B,
+  (Π b : ob B,
        eta (G b) ;; #G (eps b) = identity (G b)).
 
 
@@ -86,7 +86,7 @@ Definition counit_from_left_adjoint {A B : precategory}
 
 Definition triangle_id_left_ad (A B : precategory)
   (F : functor A B) (H : is_left_adjoint F) :
-  forall (a : ob A),
+  Π (a : ob A),
        #F (unit_from_left_adjoint H a);;
        counit_from_left_adjoint H (F a)
        =
@@ -95,7 +95,7 @@ Definition triangle_id_left_ad (A B : precategory)
 
 Definition triangle_id_right_ad (A B : precategory)
    (F : functor A B)  (H : is_left_adjoint F) :
-  forall b : ob B,
+  Π b : ob B,
          unit_from_left_adjoint H (right_adjoint H b);;
         #(right_adjoint H) (counit_from_left_adjoint H b) =
         identity (right_adjoint H b)
@@ -106,9 +106,9 @@ Definition triangle_id_right_ad (A B : precategory)
 Definition adj_equivalence_of_precats {A B : precategory}
   (F : functor A B) : UU :=
    total2 (fun H : is_left_adjoint  F =>
-     dirprod (forall a, is_isomorphism
+     dirprod (Π a, is_isomorphism
                     (unit_from_left_adjoint H a))
-             (forall b, is_isomorphism
+             (Π b, is_isomorphism
                     (counit_from_left_adjoint H b))
              ).
 
@@ -120,7 +120,7 @@ Local Notation "HF ^^-1" := (adj_equivalence_inv  HF)(at level 3).
 
 Definition unit_pointwise_iso_from_adj_equivalence {A B : precategory}
    {F : functor A B} (HF : adj_equivalence_of_precats F) :
-    forall a, iso a (HF^^-1 (F a)).
+    Π a, iso a (HF^^-1 (F a)).
   intro a.
   exists (unit_from_left_adjoint (pr1 HF) a).
   exact (pr1 (pr2 HF) a).
@@ -128,7 +128,7 @@ Defined.
 
 Definition counit_pointwise_iso_from_adj_equivalence {A B : precategory}
   {F : functor A B} (HF : adj_equivalence_of_precats F) :
-    forall b, iso (F (HF^^-1 b)) b.
+    Π b, iso (F (HF^^-1 b)) b.
   intro b.
   exists (counit_from_left_adjoint (pr1 HF) b).
   exact (pr2 (pr2 HF) b).
@@ -199,7 +199,7 @@ Defined.
 
 Lemma isaprop_sigma_iso (A B : precategory) (HA : is_category A) (*hsB: has_homsets B*)
      (F : functor A B) (HF : fully_faithful F) :
-      forall b : ob B,
+      Π b : ob B,
   isaprop (total2 (fun a : ob A => iso (pr1 F a) b)).
 Proof.
   intro b.
@@ -248,7 +248,7 @@ Qed.
 
 Lemma isaprop_pi_sigma_iso (A B : precategory) (HA : is_category A) (hsB: has_homsets B)
      (F : ob [A, B, hsB]) (HF : fully_faithful F) :
-  isaprop (forall b : ob B,
+  isaprop (Π b : ob B,
              total2 (fun a : ob A => iso (pr1 F a) b)).
 Proof.
   apply impred.
@@ -474,11 +474,11 @@ Section adjunction_from_partial.
 
 Definition is_universal_arrow_from {D C : precategory}
   (S : functor D C) (c : C) (r : D) (v : C⟦S r, c⟧) : UU :=
-  forall (d : D) (f : C⟦S d,c⟧), ∃! (f' : D⟦d,r⟧), f = # S f' ;; v.
+  Π (d : D) (f : C⟦S d,c⟧), ∃! (f' : D⟦d,r⟧), f = # S f' ;; v.
 
 Variables (X A : precategory) (F : functor X A).
-Variables (G0 : ob A -> ob X) (eps : forall a, A⟦F (G0 a),a⟧).
-Hypothesis (Huniv : forall a, is_universal_arrow_from F a (G0 a) (eps a)).
+Variables (G0 : ob A -> ob X) (eps : Π a, A⟦F (G0 a),a⟧).
+Hypothesis (Huniv : Π a, is_universal_arrow_from F a (G0 a) (eps a)).
 
 Local Definition G_data : functor_data A X.
 Proof.

--- a/UniMath/CategoryTheory/exponentials.v
+++ b/UniMath/CategoryTheory/exponentials.v
@@ -27,7 +27,7 @@ Definition constprod_functor2 (a : C) : functor C C :=
 
 Definition is_exponentiable (a : C) : UU := is_left_adjoint (constprod_functor1 a).
 
-Definition has_exponentials : UU := forall (a : C), is_exponentiable a.
+Definition has_exponentials : UU := Π (a : C), is_exponentiable a.
 
 Definition nat_trans_constprod_functor1 (a : C) :
   nat_trans (constprod_functor1 a) (constprod_functor2 a).

--- a/UniMath/CategoryTheory/functor_categories.v
+++ b/UniMath/CategoryTheory/functor_categories.v
@@ -66,10 +66,10 @@ Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 
 
 Definition functor_data (C C' : precategory_ob_mor) :=
-  total2 ( fun F : ob C -> ob C' =>  forall a b : ob C, a --> b -> F a --> F b).
+  total2 ( fun F : ob C -> ob C' =>  Π a b : ob C, a --> b -> F a --> F b).
 
 Definition functor_data_constr ( C C' : precategory_ob_mor )
-           ( F : ob C -> ob C' ) ( Fm : forall a b : ob C, a --> b -> F a --> F b ) :
+           ( F : ob C -> ob C' ) ( Fm : Π a b : ob C, a --> b -> F a --> F b ) :
   functor_data C C' := tpair _ F Fm .
 
 Definition functor_on_objects {C C' : precategory_ob_mor}
@@ -83,10 +83,10 @@ Definition functor_on_morphisms {C C' : precategory_ob_mor} (F : functor_data C 
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
 Definition functor_idax {C C' : precategory_data} (F : functor_data C C') :=
-  forall a : ob C, #F (identity a) = identity (F a).
+  Π a : ob C, #F (identity a) = identity (F a).
 
 Definition functor_compax {C C' : precategory_data} (F : functor_data C C') :=
-  forall a b c : ob C, forall f : a --> b, forall g : b --> c, #F (f ;; g) = #F f ;; #F g .
+  Π a b c : ob C, Π f : a --> b, Π g : b --> c, #F (f ;; g) = #F f ;; #F g .
 
 Definition is_functor {C C' : precategory_data} (F : functor_data C C') :=
      dirprod ( functor_idax F ) ( functor_compax F ) .
@@ -135,7 +135,7 @@ Proof.
           transportf
             (fun x : ob C -> ob C' =>
             (fun x0 : ob C -> ob C' =>
-            forall a b : ob C, a --> b -> x0 a --> x0 b) x)
+            Π a b : ob C, a --> b -> x0 a --> x0 b) x)
             p (pr2 (pr1 F)) = pr2 (pr1 G)) _
    (fiber_paths (base_paths F G p)) _ (fiber_paths (base_paths F G q))  H).
    apply uip.
@@ -157,12 +157,12 @@ Defined.
 
 
 Definition functor_id {C C' : precategory_data}(F : functor C C'):
-       forall a : ob C, #F (identity a) = identity (F a) := pr1 (pr2 F).
+       Π a : ob C, #F (identity a) = identity (F a) := pr1 (pr2 F).
 
 Definition functor_comp {C C' : precategory_data}
       (F : functor C C'):
-       forall a b c : ob C, forall f : a --> b,
-                 forall g : b --> c,
+       Π a b c : ob C, Π f : a --> b,
+                 Π g : b --> c,
                 #F (f ;; g) = #F f ;; #F g := pr2 (pr2 F).
 
 
@@ -274,7 +274,7 @@ Qed.
 (** ** Fully faithful functors *)
 
 Definition fully_faithful {C D : precategory_data} (F : functor C D) :=
-  forall a b : ob C,
+  Π a b : ob C,
     isweq (functor_on_morphisms F (a:=a) (b:=b)).
 
 Lemma isaprop_fully_faithful (C D : precategory_data) (F : functor C D) :
@@ -514,12 +514,12 @@ Qed.
 (** ** Essentially surjective functors *)
 
 Definition essentially_surjective {C D : precategory_data} (F : functor C D) :=
-  forall b, ishinh (total2 (fun a => iso (F a) b)).
+  Π b, ishinh (total2 (fun a => iso (F a) b)).
 
 (** ** Faithful functors *)
 
 Definition faithful {C D : precategory_data} (F : functor C D) :=
-  forall a b : ob C, isincl (fun f : a --> b => #F f).
+  Π a b : ob C, isincl (fun f : a --> b => #F f).
 
 Lemma isaprop_faithful (C D : precategory_data) (F : functor C D) :
    isaprop (faithful F).
@@ -532,7 +532,7 @@ Qed.
 
 
 Definition full {C D : precategory_data} (F : functor C D) :=
-   forall a b: C, issurjective (fun f : a --> b => #F f).
+   Π a b: C, issurjective (fun f : a --> b => #F f).
 
 
 
@@ -679,13 +679,13 @@ End Constant_Functor.
 
 Definition is_nat_trans {C C' : precategory_data}
   (F F' : functor_data C C')
-  (t : forall x : ob C, F x -->  F' x) :=
-  forall (x x' : ob C)(f : x --> x'),
+  (t : Π x : ob C, F x -->  F' x) :=
+  Π (x x' : ob C)(f : x --> x'),
     #F f ;; t x' = t x ;; #F' f.
 
 
 Lemma isaprop_is_nat_trans (C C' : precategory_data) (hs: has_homsets C')
-  (F F' : functor_data C C') (t : forall x : ob C, F x -->  F' x):
+  (F F' : functor_data C C') (t : Π x : ob C, F x -->  F' x):
   isaprop (is_nat_trans F F' t).
 Proof.
   repeat (apply impred; intro).
@@ -695,7 +695,7 @@ Qed.
 
 Definition nat_trans {C C' : precategory_data}
   (F F' : functor_data C C') := total2 (
-   fun t : forall x : ob C, F x -->  F' x => is_nat_trans F F' t).
+   fun t : Π x : ob C, F x -->  F' x => is_nat_trans F F' t).
 
 Lemma isaset_nat_trans {C C' : precategory_data} (hs: has_homsets C')
   (F F' : functor_data C C') : isaset (nat_trans F F').
@@ -712,19 +712,19 @@ Qed.
 
 Definition nat_trans_data {C C' : precategory_data}
  {F F' : functor_data C C'}(a : nat_trans F F') :
-   forall x : ob C, F x --> F' x := pr1 a.
+   Π x : ob C, F x --> F' x := pr1 a.
 Coercion nat_trans_data : nat_trans >-> Funclass.
 
 Definition nat_trans_ax {C C' : precategory_data}
   {F F' : functor_data C C'} (a : nat_trans F F') :
-  forall (x x' : ob C)(f : x --> x'),
+  Π (x x' : ob C)(f : x --> x'),
     #F f ;; a x' = a x ;; #F' f := pr2 a.
 
 (** Equality between two natural transformations *)
 
 Lemma nat_trans_eq {C C' : precategory_data} (hs: has_homsets C')
   (F F' : functor_data C C')(a a' : nat_trans F F'):
-  (forall x, a x = a' x) -> a = a'.
+  (Π x, a x = a' x) -> a = a'.
 Proof.
   intro H.
   assert (H' : pr1 a = pr1 a').
@@ -738,7 +738,7 @@ Qed.
 
 Definition nat_trans_eq_pointwise {C C' : precategory_data}
    {F F' : functor_data C C'} {a a' : nat_trans F F'}:
-      a = a' -> forall x, a x = a' x.
+      a = a' -> Π x, a x = a' x.
 Proof.
   intro h.
   apply toforallpaths.
@@ -839,7 +839,7 @@ Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 Lemma nat_trans_comp_pointwise (C : precategory_data)(C' : precategory) (hs: has_homsets C')
   (F G H : ob [C, C', hs]) (A : F --> G) (A' : G --> H)
    (B : F --> H) : A ;; A' = B ->
-        forall a, pr1 A a ;; pr1 A' a = pr1 B a.
+        Π a, pr1 A a ;; pr1 A' a = pr1 B a.
 Proof.
   intros H' a.
   pathvia (pr1 (A ;; A') a).
@@ -855,7 +855,7 @@ Variable hsD : has_homsets D.
 Context {F G : functor C D}.
 Variables alpha beta : nat_trans F G.
 
-Definition nat_trans_eq_weq : weq (alpha = beta) (forall c, alpha c = beta c).
+Definition nat_trans_eq_weq : weq (alpha = beta) (Π c, alpha c = beta c).
 Proof.
   eapply weqcomp.
   - apply subtypeInjectivity.
@@ -870,7 +870,7 @@ End nat_trans_eq.
 Lemma is_nat_trans_inv_from_pointwise_inv (C : precategory_data)(D : precategory)
   (hs: has_homsets D)
   (F G : ob [C,D,hs]) (A : F --> G)
-  (H : forall a : ob C, is_isomorphism (pr1 A a)) :
+  (H : Π a : ob C, is_isomorphism (pr1 A a)) :
   is_nat_trans _ _
      (fun a : ob C => inv_from_iso (tpair _ _ (H a))).
 Proof.
@@ -890,13 +890,13 @@ Qed.
 Definition nat_trans_inv_from_pointwise_inv (C : precategory_data)(D : precategory)
   (hs: has_homsets D)
   (F G : ob [C,D,hs]) (A : F --> G)
-  (H : forall a : ob C, is_isomorphism (pr1 A a)) :
+  (H : Π a : ob C, is_isomorphism (pr1 A a)) :
     G --> F := tpair _ _ (is_nat_trans_inv_from_pointwise_inv _ _ _ _ _ _ H).
 
 
 Lemma is_inverse_nat_trans_inv_from_pointwise_inv (C : precategory_data)(C' : precategory) (hs: has_homsets C')
     (F G : [C, C', hs]) (A : F --> G)
-   (H : forall a : C, is_isomorphism (pr1 A a)) :
+   (H : Π a : C, is_isomorphism (pr1 A a)) :
   is_inverse_in_precat A (nat_trans_inv_from_pointwise_inv C C' _ F G A H).
 Proof.
   simpl; split; simpl.
@@ -914,7 +914,7 @@ Qed.
 Lemma functor_iso_if_pointwise_iso (C : precategory_data) (C' : precategory)
   (hs: has_homsets C')
  (F G : ob [C, C', hs]) (A : F --> G) :
-   (forall a : ob C, is_isomorphism (pr1 A a)) ->
+   (Π a : ob C, is_isomorphism (pr1 A a)) ->
            is_isomorphism A .
 Proof.
   intro H.
@@ -925,7 +925,7 @@ Defined.
 Definition functor_iso_from_pointwise_iso (C : precategory_data)(C' : precategory)
   (hs: has_homsets C')
  (F G : ob [C, C', hs]) (A : F --> G)
-   (H : forall a : ob C, is_isomorphism (pr1 A a)) :
+   (H : Π a : ob C, is_isomorphism (pr1 A a)) :
      iso F G :=
  tpair _ _ (functor_iso_if_pointwise_iso _ _ _ _ _ _ H).
 
@@ -934,7 +934,7 @@ Lemma is_functor_iso_pointwise_if_iso (C : precategory_data)(C' : precategory)
   (hs: has_homsets C')
  (F G : ob [C, C', hs]) (A : F --> G) :
   is_isomorphism A ->
-       forall a : ob C, is_isomorphism (pr1 A a).
+       Π a : ob C, is_isomorphism (pr1 A a).
 Proof.
   intros H a.
   set (T:= inv_from_iso (tpair _ A H)).
@@ -952,7 +952,7 @@ Defined.
 Lemma nat_trans_inv_pointwise_inv_before (C : precategory_data) (C' : precategory)
   (hs: has_homsets C')
  (F G : ob [C, C', hs]) (A : F --> G) (Aiso: is_isomorphism A) :
-       forall a : C, pr1 (inv_from_iso (isopair A Aiso)) a ;; pr1 A a = identity _ .
+       Π a : C, pr1 (inv_from_iso (isopair A Aiso)) a ;; pr1 A a = identity _ .
 Proof.
   intro a.
   set (T:= inv_from_iso (isopair A Aiso)).
@@ -964,7 +964,7 @@ Defined.
 Lemma nat_trans_inv_pointwise_inv_after (C : precategory_data) (C' : precategory)
   (hs: has_homsets C')
  (F G : ob [C, C', hs]) (A : F --> G) (Aiso: is_isomorphism A) :
-       forall a : C, pr1 A a ;; pr1 (inv_from_iso (isopair A Aiso)) a = identity _ .
+       Π a : C, pr1 A a ;; pr1 (inv_from_iso (isopair A Aiso)) a = identity _ .
 Proof.
   intro a.
   set (T:= inv_from_iso (isopair A Aiso)).
@@ -978,7 +978,7 @@ Definition functor_iso_pointwise_if_iso (C : precategory_data) (C' : precategory
   (hs: has_homsets C')
  (F G : ob [C, C',hs]) (A : F --> G)
   (H : is_isomorphism A) :
-     forall a : ob C,
+     Π a : ob C,
        iso (pr1 F a) (pr1 G a) :=
   fun a => tpair _ _ (is_functor_iso_pointwise_if_iso C C' _ F G A H a).
 
@@ -1015,11 +1015,11 @@ Defined.
 
 Lemma transport_of_functor_map_is_pointwise (C : precategory_data) (D : precategory)
       (F0 G0 : ob C -> ob D)
-    (F1 : forall a b : ob C, a --> b -> F0 a --> F0 b)
+    (F1 : Π a b : ob C, a --> b -> F0 a --> F0 b)
    (gamma : F0  = G0 )
     (a b : ob C) (f : a --> b) :
 transportf (fun x : ob C -> ob D =>
-            forall a0 b0 : ob  C, a0 --> b0 -> x a0 --> x b0)
+            Π a0 b0 : ob  C, a0 --> b0 -> x a0 --> x b0)
            gamma  F1 a b f =
 transportf (fun TT : ob D => G0 a --> TT)
   (toforallpaths (fun _ : ob C => D) F0 G0 gamma b)
@@ -1030,8 +1030,8 @@ Proof.
   apply idpath.
 Defined.
 
-Lemma toforallpaths_funextsec : forall (T : UU) (P : T -> UU) (f g : forall t : T, P t)
-          (h : forall t : T, f t = g t),
+Lemma toforallpaths_funextsec : Π (T : UU) (P : T -> UU) (f g : Π t : T, P t)
+          (h : Π t : T, f t = g t),
             toforallpaths _  _ _ (funextsec _ _ _ h) = h.
 Proof.
   intros T P f g h.

--- a/UniMath/CategoryTheory/limits/BinDirectSums.v
+++ b/UniMath/CategoryTheory/limits/BinDirectSums.v
@@ -97,7 +97,7 @@ Section def_bindirectsums.
     BinDirectSumCone a b := tpair _ (tpair _ co (i1,,(i2,,(p1,,p2)))) H.
 
   (** BinDirectSum in categories. *)
-  Definition BinDirectSums := forall (a b : A), BinDirectSumCone a b.
+  Definition BinDirectSums := Π (a b : A), BinDirectSumCone a b.
   Definition has_BinDirectSums := ishinh BinDirectSums.
 
   (** The direct sum object. *)
@@ -177,7 +177,7 @@ Section def_bindirectsums.
 
   (** Commutativity of BinDirectSum. *)
   Definition BinDirectSumIn1Commutes {a b : A} (B : BinDirectSumCone a b) :
-    forall (c : A) (f : a --> c) (g : b --> c),
+    Π (c : A) (f : a --> c) (g : b --> c),
       (BinDirectSumIn1 B) ;; (FromBinDirectSum B f g) = f.
   Proof.
     intros c f g.
@@ -185,7 +185,7 @@ Section def_bindirectsums.
   Defined.
 
   Definition BinDirectSumIn2Commutes {a b : A} (B : BinDirectSumCone a b) :
-    forall (c : A) (f : a --> c) (g : b --> c),
+    Π (c : A) (f : a --> c) (g : b --> c),
       (BinDirectSumIn2 B) ;; (FromBinDirectSum B f g) = g.
   Proof.
     intros c f g.
@@ -193,7 +193,7 @@ Section def_bindirectsums.
   Defined.
 
   Definition BinDirectSumPr1Commutes {a b : A} (B : BinDirectSumCone a b) :
-    forall (c : A) (f : c --> a) (g : c --> b),
+    Π (c : A) (f : c --> a) (g : c --> b),
       (ToBinDirectSum B f g) ;; (BinDirectSumPr1 B) = f.
   Proof.
     intros c f g.
@@ -201,7 +201,7 @@ Section def_bindirectsums.
   Defined.
 
   Definition BinDirectSumPr2Commutes {a b : A} (B : BinDirectSumCone a b) :
-    forall (c : A) (f : c --> a) (g : c --> b),
+    Π (c : A) (f : c --> a) (g : c --> b),
       (ToBinDirectSum B f g) ;; (BinDirectSumPr2 B) = g.
   Proof.
     intros c f g.

--- a/UniMath/CategoryTheory/limits/FunctorsPointwiseBinCoproduct.v
+++ b/UniMath/CategoryTheory/limits/FunctorsPointwiseBinCoproduct.v
@@ -114,7 +114,7 @@ Proof.
 now apply (functor_eq _ _ hsD).
 Defined.
 
-Definition coproduct_nat_trans_in1_data : ∀ c, F c --> BinCoproduct_of_functors c
+Definition coproduct_nat_trans_in1_data : Π c, F c --> BinCoproduct_of_functors c
   := λ c : C, BinCoproductIn1 _ (HD (F c) (G c)).
 
 Lemma is_nat_trans_coproduct_nat_trans_in1_data
@@ -135,7 +135,7 @@ Qed.
 Definition coproduct_nat_trans_in1 : nat_trans _ _
   := tpair _ _ is_nat_trans_coproduct_nat_trans_in1_data.
 
-Definition coproduct_nat_trans_in2_data : ∀ c, G c --> BinCoproduct_of_functors c
+Definition coproduct_nat_trans_in2_data : Π c, G c --> BinCoproduct_of_functors c
   := λ c : C, BinCoproductIn2 _ (HD (F c) (G c)).
 
 Lemma is_nat_trans_coproduct_nat_trans_in2_data
@@ -165,7 +165,7 @@ Variable A : functor C D.
 Variable f : F ⟶ A.
 Variable g : G ⟶ A.
 
-Definition coproduct_nat_trans_data : ∀ c, BinCoproduct_of_functors c --> A c.
+Definition coproduct_nat_trans_data : Π c, BinCoproduct_of_functors c --> A c.
 Proof.
   intro c.
   apply BinCoproductArrow.
@@ -219,7 +219,7 @@ End vertex.
 
 Lemma coproduct_nat_trans_univ_prop (A : [C, D, hsD])
   (f : (F : [C,D,hsD]) --> A) (g : (G : [C,D,hsD]) --> A) :
-   ∀
+   Π
    t : Σ fg : (BinCoproduct_of_functors:[C,D,hsD]) --> A,
        (coproduct_nat_trans_in1 : (F:[C,D,hsD]) --> BinCoproduct_of_functors);; fg = f
       ×

--- a/UniMath/CategoryTheory/limits/FunctorsPointwiseBinProduct.v
+++ b/UniMath/CategoryTheory/limits/FunctorsPointwiseBinProduct.v
@@ -94,7 +94,7 @@ Proof.
 now apply (functor_eq _ _ hsD).
 Defined.
 
-Definition binproduct_nat_trans_pr1_data : ∀ c, BinProduct_of_functors c --> F c
+Definition binproduct_nat_trans_pr1_data : Π c, BinProduct_of_functors c --> F c
   := λ c : C, BinProductPr1 _ (HD (F c) (G c)).
 
 Lemma is_nat_trans_binproduct_nat_trans_pr1_data
@@ -112,7 +112,7 @@ Definition binproduct_nat_trans_pr1 : nat_trans _ _
   := tpair _ _ is_nat_trans_binproduct_nat_trans_pr1_data.
 
 
-Definition binproduct_nat_trans_pr2_data : ∀ c, BinProduct_of_functors c --> G c
+Definition binproduct_nat_trans_pr2_data : Π c, BinProduct_of_functors c --> G c
   := λ c : C, BinProductPr2 _ (HD (F c) (G c)).
 
 Lemma is_nat_trans_binproduct_nat_trans_pr2_data
@@ -138,7 +138,7 @@ Variable A : functor C D.
 Variable f : A ⟶ F.
 Variable g : A ⟶ G.
 
-Definition binproduct_nat_trans_data : ∀ c,  A c --> BinProduct_of_functors c.
+Definition binproduct_nat_trans_data : Π c,  A c --> BinProduct_of_functors c.
 Proof.
   intro c.
   apply BinProductArrow.
@@ -190,7 +190,7 @@ End vertex.
 
 Lemma binproduct_nat_trans_univ_prop (A : [C, D, hsD])
   (f : (A --> (F:[C,D,hsD]))) (g : A --> (G:[C,D,hsD])) :
-   ∀
+   Π
    t : Σ fg : A --> (BinProduct_of_functors:[C,D,hsD]),
        fg ;; (binproduct_nat_trans_pr1 : (BinProduct_of_functors:[C,D,hsD]) --> F) = f
       ×

--- a/UniMath/CategoryTheory/limits/FunctorsPointwiseCoproduct.v
+++ b/UniMath/CategoryTheory/limits/FunctorsPointwiseCoproduct.v
@@ -91,7 +91,7 @@ Definition coproduct_nat_trans_in i : nat_trans (F i) coproduct_of_functors :=
 Section vertex.
 
 Variable A : functor C D.
-Variable f : forall i, nat_trans (F i) A.
+Variable f : Π i, nat_trans (F i) A.
 
 Definition coproduct_nat_trans_data c :
   coproduct_of_functors c --> A c :=

--- a/UniMath/CategoryTheory/limits/FunctorsPointwiseProduct.v
+++ b/UniMath/CategoryTheory/limits/FunctorsPointwiseProduct.v
@@ -96,7 +96,7 @@ Section vertex.
 (** The product morphism of a diagram with vertex [A] *)
 
 Variable A : functor C D.
-Variable f : forall i, nat_trans A (F i).
+Variable f : Π i, nat_trans A (F i).
 
 Definition product_nat_trans_data c :
   A c --> product_of_functors c:=

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -20,7 +20,7 @@ Section coproduct_def.
 Variable C : precategory.
 
 Definition isBinCoproductCocone (a b co : C) (ia : a --> co) (ib : b --> co) :=
-  ∀ (c : C) (f : a --> c) (g : b --> c),
+  Π (c : C) (f : a --> c) (g : b --> c),
     iscontr (Σ fg : co --> c, (ia ;; fg = f) × (ib ;; fg = g)).
 
 Definition BinCoproductCocone (a b : C) :=
@@ -28,7 +28,7 @@ Definition BinCoproductCocone (a b : C) :=
       isBinCoproductCocone a b (pr1 coiaib) (pr1 (pr2 coiaib)) (pr2 (pr2 coiaib)).
 
 
-Definition BinCoproducts := ∀ (a b : C), BinCoproductCocone a b.
+Definition BinCoproducts := Π (a b : C), BinCoproductCocone a b.
 Definition hasBinCoproducts := ishinh BinCoproducts.
 
 Definition BinCoproductObject {a b : C} (CC : BinCoproductCocone a b) : C := pr1 (pr1 CC).
@@ -50,14 +50,14 @@ Proof.
 Defined.
 
 Lemma BinCoproductIn1Commutes (a b : C) (CC : BinCoproductCocone a b):
-     ∀ (c : C) (f : a --> c) g, BinCoproductIn1 CC ;; BinCoproductArrow CC f g  = f.
+     Π (c : C) (f : a --> c) g, BinCoproductIn1 CC ;; BinCoproductArrow CC f g  = f.
 Proof.
   intros c f g.
   exact (pr1 (pr2 (pr1 (isBinCoproductCocone_BinCoproductCocone CC _ f g)))).
 Qed.
 
 Lemma BinCoproductIn2Commutes (a b : C) (CC : BinCoproductCocone a b):
-     ∀ (c : C) (f : a --> c) g, BinCoproductIn2 CC ;; BinCoproductArrow CC f g = g.
+     Π (c : C) (f : a --> c) g, BinCoproductIn2 CC ;; BinCoproductArrow CC f g = g.
 Proof.
   intros c f g.
   exact (pr2 (pr2 (pr1 (isBinCoproductCocone_BinCoproductCocone CC _ f g)))).
@@ -107,7 +107,7 @@ Qed.
 
 
 Definition mk_BinCoproductCocone (a b : C) :
-  ∀ (c : C) (f : a --> c) (g : b --> c),
+  Π (c : C) (f : a --> c) (g : b --> c),
    isBinCoproductCocone _ _ _ f g →  BinCoproductCocone a b.
 Proof.
   intros.
@@ -119,7 +119,7 @@ Proof.
 Defined.
 
 Definition mk_isBinCoproductCocone (hsC : has_homsets C)(a b co : C) (ia : a --> co) (ib : b --> co) :
-   (∀ (c : C) (f : a --> c) (g : b --> c),
+   (Π (c : C) (f : a --> c) (g : b --> c),
     ∃! k : C ⟦co, c⟧,
       ia ;; k = f ×
       ib ;; k = g)
@@ -566,7 +566,7 @@ End BinCoproducts.
 (* + apply (tpair _ (pr1 t)); split; [ apply (pr2 t true) | apply (pr2 t false) ]. *)
 (* + intros t0. *)
 (*   apply subtypeEquality; [intros aa; apply isapropdirprod; apply hsC|]; simpl. *)
-(*   simple refine (let X : Σ x : C ⟦ ab, c ⟧, ∀ v, coconeIn cc v ;; x = *)
+(*   simple refine (let X : Σ x : C ⟦ ab, c ⟧, Π v, coconeIn cc v ;; x = *)
 (*             bool_rect (λ v0, C ⟦ if v0 then a else b, c ⟧) f g v := _ in _). *)
 (*   { apply (tpair _ (pr1 t0)); intro x; case x; *)
 (*     [ apply (pr1 (pr2 t0)) | apply (pr2 (pr2 t0)) ]. } *)

--- a/UniMath/CategoryTheory/limits/binproducts.v
+++ b/UniMath/CategoryTheory/limits/binproducts.v
@@ -15,7 +15,7 @@ Section binproduct_def.
 Variable C : precategory.
 
 Definition isBinProductCone (c d p: C) (p1 : p --> c) (p2 : p --> d) :=
-  forall (a : C) (f : a --> c) (g : a --> d),
+  Π (a : C) (f : a --> c) (g : a --> d),
     iscontr (total2 (fun fg : a --> p => dirprod (fg ;; p1 = f)
                                                  (fg ;; p2 = g))).
 
@@ -24,7 +24,7 @@ Definition BinProductCone (c d : C) :=
              isBinProductCone c d (pr1 pp1p2) (pr1 (pr2 pp1p2)) (pr2 (pr2 pp1p2))).
 
 
-Definition BinProducts := forall (c d : C), BinProductCone c d.
+Definition BinProducts := Π (c d : C), BinProductCone c d.
 Definition hasBinProducts := ishinh BinProducts.
 
 Definition BinProductObject {c d : C} (P : BinProductCone c d) : C := pr1 (pr1 P).
@@ -46,14 +46,14 @@ Proof.
 Defined.
 
 Lemma BinProductPr1Commutes (c d : C) (P : BinProductCone c d):
-     forall (a : C) (f : a --> c) g, BinProductArrow P f g ;; BinProductPr1 P = f.
+     Π (a : C) (f : a --> c) g, BinProductArrow P f g ;; BinProductPr1 P = f.
 Proof.
   intros a f g.
   exact (pr1 (pr2 (pr1 (isBinProductCone_BinProductCone P _ f g)))).
 Qed.
 
 Lemma BinProductPr2Commutes (c d : C) (P : BinProductCone c d):
-     forall (a : C) (f : a --> c) g, BinProductArrow P f g ;; BinProductPr2 P = g.
+     Π (a : C) (f : a --> c) g, BinProductArrow P f g ;; BinProductPr2 P = g.
 Proof.
   intros a f g.
   exact (pr2 (pr2 (pr1 (isBinProductCone_BinProductCone P _ f g)))).
@@ -72,7 +72,7 @@ Qed.
 
 
 Definition mk_BinProductCone (a b : C) :
-  ∀ (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧),
+  Π (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧),
    isBinProductCone _ _ _ f g -> BinProductCone a b.
 Proof.
   intros.
@@ -85,7 +85,7 @@ Defined.
 
 Definition mk_isBinProductCone (hsC : has_homsets C) (a b p : C)
   (pa : C⟦p,a⟧) (pb : C⟦p,b⟧) :
-  (∀ (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧),
+  (Π (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧),
     ∃! k : C⟦c,p⟧, k ;; pa = f × k ;; pb = g) ->
   isBinProductCone a b p pa pb.
 Proof.
@@ -259,7 +259,7 @@ End BinProduct_unique.
 (* + apply (tpair _ (pr1 t)); split; [ apply (pr2 t true) | apply (pr2 t false) ]. *)
 (* + intros t0. *)
 (*   apply subtypeEquality; [intros aa; apply isapropdirprod; apply hsC|]; simpl. *)
-(*   simple refine (let X : Σ x : c --> ab, ∀ v, coconeIn cc v ;; x = *)
+(*   simple refine (let X : Σ x : c --> ab, Π v, coconeIn cc v ;; x = *)
 (*             (if v as b0 return (c --> (if b0 then a else b)) then f else g) := _ in _). *)
 (*   { apply (tpair _ (pr1 t0)); intro x; case x; *)
 (*     [ apply (pr1 (pr2 t0)) | apply (pr2 (pr2 t0)) ]. } *)

--- a/UniMath/CategoryTheory/limits/cats/limits.v
+++ b/UniMath/CategoryTheory/limits/cats/limits.v
@@ -43,25 +43,25 @@ End move_upstream.
 Section lim_def.
 
 Definition cone {J C : precategory} (F : functor J C) (c : C) : UU :=
-  Σ (f : ∀ (v : J), C⟦c,F v⟧),
-    ∀ (u v : J) (e : J⟦u,v⟧), f u ;; # F e = f v.
+  Σ (f : Π (v : J), C⟦c,F v⟧),
+    Π (u v : J) (e : J⟦u,v⟧), f u ;; # F e = f v.
 
 Definition mk_cone {J C : precategory} {F : functor J C} {c : C}
-  (f : ∀ v, C⟦c, F v⟧) (Hf : ∀ u v (e : J⟦u,v⟧) , f u ;; # F e  = f v) :
+  (f : Π v, C⟦c, F v⟧) (Hf : Π u v (e : J⟦u,v⟧) , f u ;; # F e  = f v) :
   cone F c := tpair _ f Hf.
 
 Definition coneOut {J C : precategory} {F : functor J C} {c : C} (cc : cone F c) :
-  ∀ v, C⟦c, F v⟧ := pr1 cc.
+  Π v, C⟦c, F v⟧ := pr1 cc.
 
 Lemma coneOutCommutes {J C : precategory} {F : functor J C} {c : C}
-  (cc : cone F c) : ∀ u v (e : J⟦u,v⟧), coneOut cc u ;; # F e = coneOut cc v.
+  (cc : cone F c) : Π u v (e : J⟦u,v⟧), coneOut cc u ;; # F e = coneOut cc v.
 Proof.
 apply (pr2 cc).
 Qed.
 
 Definition isLimCone {J C : precategory} (F : functor J C)
-  (l : C) (cc0 : cone F l) : UU := ∀ (c : C) (cc : cone F c),
-    iscontr (Σ x : C⟦c,l⟧, ∀ v, x ;; coneOut cc0 v = coneOut cc v).
+  (l : C) (cc0 : cone F l) : UU := Π (c : C) (cc : cone F c),
+    iscontr (Σ x : C⟦c,l⟧, Π v, x ;; coneOut cc0 v = coneOut cc v).
 
 Definition LimCone {J C : precategory} (F : functor J C) : UU :=
   Σ (A : (Σ l, cone F l)), isLimCone F (pr1 A) (pr2 A).
@@ -70,9 +70,9 @@ Definition mk_LimCone {J C : precategory} (F : functor J C)
   (c : C) (cc : cone F c) (isCC : isLimCone F c cc) : LimCone F :=
   tpair _ (tpair _ c cc) isCC.
 
-Definition Lims (C : precategory) : UU := ∀ {J : precategory} (F : functor J C), LimCone F.
+Definition Lims (C : precategory) : UU := Π {J : precategory} (F : functor J C), LimCone F.
 Definition hasLims : UU  :=
-  ∀ {J C : precategory} (F : functor J C), ishinh (LimCone F).
+  Π {J C : precategory} (F : functor J C), ishinh (LimCone F).
 
 (* lim is the tip of the lim cone *)
 Definition lim {J C : precategory} {F : functor J C} (CC : LimCone F) : C
@@ -82,18 +82,18 @@ Definition limCone {J C : precategory} {F : functor J C} (CC : LimCone F) :
   cone F (lim CC) := pr2 (pr1 CC).
 
 Definition limOut {J C : precategory} {F : functor J C} (CC : LimCone F) :
-  ∀ v, C⟦lim CC,F v⟧ := coneOut (limCone CC).
+  Π v, C⟦lim CC,F v⟧ := coneOut (limCone CC).
 
 Lemma limOutCommutes {J C : precategory} {F : functor J C}
-  (CC : LimCone F) : ∀ u v (e : J⟦u,v⟧),
+  (CC : LimCone F) : Π u v (e : J⟦u,v⟧),
    limOut CC u ;; # F e = limOut CC v.
 Proof.
 exact (coneOutCommutes (limCone CC)).
 Qed.
 
 Lemma limUnivProp {J C : precategory} {F : functor J C}
-  (CC : LimCone F) : ∀ (c : C) (cc : cone F c),
-  iscontr (Σ x : C⟦c, lim CC⟧, ∀v, x ;; limOut CC v = coneOut cc v).
+  (CC : LimCone F) : Π (c : C) (cc : cone F c),
+  iscontr (Σ x : C⟦c, lim CC⟧, Π v, x ;; limOut CC v = coneOut cc v).
 Proof.
 exact (pr2 CC).
 Qed.
@@ -122,7 +122,7 @@ Qed.
 
 Lemma limArrowUnique {J C : precategory} {F : functor J C} (CC : LimCone F)
   (c : C) (cc : cone F c) (k : C⟦c, lim CC⟧)
-  (Hk : ∀ u, k ;; limOut CC u = coneOut cc u) :
+  (Hk : Π u, k ;; limOut CC u = coneOut cc u) :
   k = limArrow CC c cc.
 Proof.
 now apply path_to_ctr, Hk.
@@ -130,7 +130,7 @@ Qed.
 
 Lemma Cone_precompose {J C : precategory} {F : functor J C}
   {c : C} (cc : cone F c) (x : C) (f : C⟦x,c⟧) :
-    ∀ u v (e : J⟦u,v⟧), (f ;; coneOut cc u) ;; # F e = f ;; coneOut cc v.
+    Π u v (e : J⟦u,v⟧), (f ;; coneOut cc u) ;; # F e = f ;; coneOut cc v.
 Proof.
 now intros u v e; rewrite <- assoc, coneOutCommutes.
 Qed.
@@ -145,8 +145,8 @@ Qed.
 
 Definition limOfArrows {J C : precategory} {F1 F2 : functor J C}
   (CC1 : LimCone F1) (CC2 : LimCone F2)
-  (f : ∀ u, C⟦F1 u,F2 u⟧)
-  (fNat : ∀ u v (e : J⟦u,v⟧), f u ;; # F2 e = # F1 e ;; f v) :
+  (f : Π u, C⟦F1 u,F2 u⟧)
+  (fNat : Π u v (e : J⟦u,v⟧), f u ;; # F2 e = # F1 e ;; f v) :
   C⟦lim CC1 , lim CC2⟧.
 Proof.
 apply limArrow; simple refine (mk_cone _ _).
@@ -157,9 +157,9 @@ Defined.
 
 Lemma limOfArrowsOut {J C : precategory} {F1 F2 : functor J C}
   (CC1 : LimCone F1) (CC2 : LimCone F2)
-  (f : ∀ u, C⟦F1 u,F2 u⟧)
-  (fNat : ∀ u v (e : J⟦u,v⟧), f u ;; # F2 e = # F1 e ;; f v) :
-    ∀ u, limOfArrows CC1 CC2 f fNat ;; limOut CC2 u =
+  (f : Π u, C⟦F1 u,F2 u⟧)
+  (fNat : Π u v (e : J⟦u,v⟧), f u ;; # F2 e = # F1 e ;; f v) :
+    Π u, limOfArrows CC1 CC2 f fNat ;; limOut CC2 u =
           limOut CC1 u ;; f u.
 Proof.
 now unfold limOfArrows; intro u; rewrite limArrowCommutes.
@@ -168,8 +168,8 @@ Qed.
 Lemma postCompWithLimOfArrows_subproof
   {J C : precategory} {F1 F2 : functor J C}
   (CC1 : LimCone F1) (CC2 : LimCone F2)
-  (f : ∀ u, C⟦F1 u,F2 u⟧)
-  (fNat : ∀ u v (e : J⟦u,v⟧), f u ;; # F2 e = # F1 e ;; f v)
+  (f : Π u, C⟦F1 u,F2 u⟧)
+  (fNat : Π u v (e : J⟦u,v⟧), f u ;; # F2 e = # F1 e ;; f v)
   (x : C) (cc : cone F1 x) u v (e : J⟦u,v⟧) :
     (coneOut cc u ;; f u) ;; # F2 e = coneOut cc v ;; f v.
 Proof.
@@ -179,8 +179,8 @@ Defined.
 Lemma postcompWithLimOfArrows
   {J C : precategory} {F1 F2 : functor J C}
   (CC1 : LimCone F1) (CC2 : LimCone F2)
-  (f : ∀ u, C⟦F1 u,F2 u⟧)
-  (fNat : ∀ u v (e : J⟦u,v⟧), f u ;; # F2 e = # F1 e ;; f v)
+  (f : Π u, C⟦F1 u,F2 u⟧)
+  (fNat : Π u v (e : J⟦u,v⟧), f u ;; # F2 e = # F1 e ;; f v)
   (x : C) (cc : cone F1 x) :
      limArrow CC1 x cc ;; limOfArrows CC1 CC2 f fNat =
        limArrow CC2 x (mk_cone (λ u, coneOut cc u ;; f u)
@@ -202,7 +202,7 @@ Qed.
 
 Lemma lim_endo_is_identity {J C : precategory} {F : functor J C}
   (CC : LimCone F) (k : lim CC --> lim CC)
-  (H : ∀ u, k ;; limOut CC u = limOut CC u) :
+  (H : Π u, k ;; limOut CC u = limOut CC u) :
   identity _ = k.
 Proof.
 unshelve refine (uniqueExists _ _ (limUnivProp CC _ _) _ _ _ _).
@@ -220,13 +220,13 @@ Defined.
 
 Lemma isColim_weq_subproof1 {g : graph} (D : diagram g C)
   (c : C) (cc : cocone D c) (d : C) (k : C⟦c,d⟧) :
-  ∀ u, coconeIn cc u ;; k = pr1 (Cocone_by_postcompose D c cc d k) u.
+  Π u, coconeIn cc u ;; k = pr1 (Cocone_by_postcompose D c cc d k) u.
 Proof.
 now intro u.
 Qed.
 
 Lemma isColim_weq_subproof2 (g : graph) (D : diagram g C)
-  (c : C) (cc : cocone D c) (H : ∀ d, isweq (Cocone_by_postcompose D c cc d))
+  (c : C) (cc : cocone D c) (H : Π d, isweq (Cocone_by_postcompose D c cc d))
   (d : C) (cd : cocone D d) (u : vertex g) :
     coconeIn cc u ;; invmap (weqpair _ (H d)) cd = coconeIn cd u.
 Proof.
@@ -236,7 +236,7 @@ now rewrite p.
 Qed.
 
 Lemma isColim_weq {g : graph} (D : diagram g C) (c : C) (cc : cocone D c) :
-  isColimCocone D c cc <-> ∀ d, isweq (Cocone_by_postcompose D c cc d).
+  isColimCocone D c cc <-> Π d, isweq (Cocone_by_postcompose D c cc d).
 Proof.
 split.
 - intros H d.
@@ -288,7 +288,7 @@ mkpair.
       apply (toforallpaths _ _ _ (maponpaths pr1 (functor_comp D x y z f g)) a)]).
 Defined.
 
-Variable (HCg : forall (a : A), LimCone (functor_pointwise a)).
+Variable (HCg : Π (a : A), LimCone (functor_pointwise a)).
 
 Definition LimFunctor_ob (a : A) : C := lim (HCg a).
 
@@ -339,7 +339,7 @@ Defined.
 
 Lemma LimFunctor_unique (F : [A, C, hsC]) (cc : cone D F) :
   iscontr (Σ x : [A, C, hsC] ⟦ F, LimFunctor ⟧,
-            ∀ v, x ;; lim_nat_trans_in_data v = coneOut cc v).
+            Π v, x ;; lim_nat_trans_in_data v = coneOut cc v).
 Proof.
 mkpair.
 - mkpair.

--- a/UniMath/CategoryTheory/limits/coequalizers.v
+++ b/UniMath/CategoryTheory/limits/coequalizers.v
@@ -14,12 +14,12 @@ Section def_coequalizers.
   (** Definition and construction of isCoequalizer. *)
   Definition isCoequalizer {x y z : C} (f g : x --> y) (e : y --> z)
              (H : f ;; e = g ;; e) : UU :=
-    forall (w : C) (h : y --> w) (H : f ;; h = g ;; h),
+    Π (w : C) (h : y --> w) (H : f ;; h = g ;; h),
       iscontr (Σ φ : z --> w, e ;; φ  = h).
 
   Definition mk_isCoequalizer {y z w : C} (f g : y --> z) (e : z --> w)
              (H : f ;; e = g ;; e) :
-    (forall (w0 : C) (h : z --> w0) (H' : f ;; h = g ;; h),
+    (Π (w0 : C) (h : z --> w0) (H' : f ;; h = g ;; h),
         iscontr (Σ ψ : w --> w0, e ;; ψ = h)) -> isCoequalizer f g e H.
   Proof.
     intros X. unfold isCoequalizer. exact X.
@@ -63,10 +63,10 @@ Section def_coequalizers.
   Defined.
 
   (** Coequalizers in precategories. *)
-  Definition Coequalizers := forall (y z : C) (f g : y --> z),
+  Definition Coequalizers := Π (y z : C) (f g : y --> z),
       Coequalizer f g.
 
-  Definition hasCoequalizers := forall (y z : C) (f g : y --> z),
+  Definition hasCoequalizers := Π (y z : C) (f g : y --> z),
       ishinh (Coequalizer f g).
 
   (** Returns the coequalizer object. *)

--- a/UniMath/CategoryTheory/limits/cokernels.v
+++ b/UniMath/CategoryTheory/limits/cokernels.v
@@ -38,8 +38,8 @@ Section def_cokernels.
     use (mk_Coequalizer g (ZeroArrow _ Z x y) f (CokernelEqRw H)).
     apply isE.
   Defined.
-  Definition Cokernels := forall (y z : C) (g : y --> z), Cokernel g.
-  Definition hasCokernels := forall (y z : C) (g : y --> z), ishinh (Cokernel g).
+  Definition Cokernels := Π (y z : C) (g : y --> z), Cokernel g.
+  Definition hasCokernels := Π (y z : C) (g : y --> z), ishinh (Cokernel g).
   Definition CokernelOb {y z : C} {g : y --> z} (CK : Cokernel g) :
     C := CoequalizerObject CK.
   Coercion CokernelOb : Cokernel >-> ob.

--- a/UniMath/CategoryTheory/limits/cones.v
+++ b/UniMath/CategoryTheory/limits/cones.v
@@ -21,7 +21,7 @@ Variable hs: has_homsets C.
 Variable F : functor J C.
 
 Definition ConeData := total2 (
-  fun a : C => forall j : J, a --> F j).
+  fun a : C => Π j : J, a --> F j).
 
 Definition ConeTop (a : ConeData) : C := pr1 a.
 Definition ConeMor (a : ConeData) (j : J) : ConeTop a --> F j := (pr2 a) j.
@@ -37,7 +37,7 @@ Proof.
 Defined.
 
 Definition ConeProp (a : ConeData) :=
-  forall j j' (f : j --> j'), ConeMor a j ;; #F f = ConeMor a j'.
+  Π j j' (f : j --> j'), ConeMor a j ;; #F f = ConeMor a j'.
 
 Lemma isaprop_ConeProp (a : ConeData) : isaprop (ConeProp a).
 Proof.
@@ -72,7 +72,7 @@ Coercion ConeProp_from_Cone : Cone >-> ConeProp.
 
 
 Lemma cone_prop (a : Cone) :
-  forall j j' (f : j --> j'), ConeMor a j ;; #F f = ConeMor a j'.
+  Π j j' (f : j --> j'), ConeMor a j ;; #F f = ConeMor a j'.
 Proof.
   exact (pr2 a).
 Qed.
@@ -87,7 +87,7 @@ Defined.
 
 Definition Cone_Mor (M N : Cone) :=
   total2 (fun f : ConeTop M --> ConeTop N =>
-        forall j : J, f ;; ConeMor N j = ConeMor M j).
+        Π j : J, f ;; ConeMor N j = ConeMor M j).
 
 
 Lemma isaset_Cone_Mor (M N : Cone) : isaset (Cone_Mor M N).
@@ -114,7 +114,7 @@ Proof.
 Qed.
 
 Lemma cone_mor_prop M N (f : Cone_Mor M N) :
-    forall j : J, ConeConnect f ;; ConeMor N j = ConeMor M j.
+    Π j : J, ConeConnect f ;; ConeMor N j = ConeMor M j.
 Proof.
   exact (pr2 f).
 Qed.
@@ -282,7 +282,7 @@ Proof.
 Defined.
 
 
-Lemma isotoid_CONE_idtoiso (M N : CONE) : forall p : M = N, isotoid_CONE (idtoiso p) = p.
+Lemma isotoid_CONE_idtoiso (M N : CONE) : Π p : M = N, isotoid_CONE (idtoiso p) = p.
 Proof.
   intro p.
   induction p.
@@ -299,7 +299,7 @@ Proof.
   apply idpath.
 Qed.
 
-Lemma idtoiso_isotoid_CONE (M N : CONE) : forall f : iso M N, idtoiso (isotoid_CONE f) = f.
+Lemma idtoiso_isotoid_CONE (M N : CONE) : Π f : iso M N, idtoiso (isotoid_CONE f) = f.
 Proof.
   intro f.
   apply eq_iso.

--- a/UniMath/CategoryTheory/limits/coproducts.v
+++ b/UniMath/CategoryTheory/limits/coproducts.v
@@ -20,19 +20,19 @@ Section coproduct_def.
 Variables (I : UU) (C : precategory).
 
 Definition isCoproductCocone (a : I -> C) (co : C)
-  (ia : forall i, a i --> co) :=
-  forall (c : C) (f : forall i, a i --> c),
-    iscontr (total2 (fun (g : co --> c) => forall i, ia i ;; g = f i)).
+  (ia : Π i, a i --> co) :=
+  Π (c : C) (f : Π i, a i --> c),
+    iscontr (total2 (fun (g : co --> c) => Π i, ia i ;; g = f i)).
 
 Definition CoproductCocone (a : I -> C) :=
-   Σ coia : (Σ co : C, forall i, a i --> co),
+   Σ coia : (Σ co : C, Π i, a i --> co),
           isCoproductCocone a (pr1 coia) (pr2 coia).
 
-Definition Coproducts := ∀ (a : I -> C), CoproductCocone a.
+Definition Coproducts := Π (a : I -> C), CoproductCocone a.
 Definition hasCoproducts := ishinh Coproducts.
 
 Definition CoproductObject {a : I -> C} (CC : CoproductCocone a) : C := pr1 (pr1 CC).
-Definition CoproductIn {a : I -> C} (CC : CoproductCocone a): forall i, a i --> CoproductObject CC :=
+Definition CoproductIn {a : I -> C} (CC : CoproductCocone a): Π i, a i --> CoproductObject CC :=
   pr2 (pr1 CC).
 
 Definition isCoproductCocone_CoproductCocone {a : I -> C} (CC : CoproductCocone a) :
@@ -41,22 +41,22 @@ Proof.
   exact (pr2 CC).
 Defined.
 
-Definition CoproductArrow {a : I -> C} (CC : CoproductCocone a) {c : C} (f : forall i, a i --> c) :
+Definition CoproductArrow {a : I -> C} (CC : CoproductCocone a) {c : C} (f : Π i, a i --> c) :
       CoproductObject CC --> c.
 Proof.
   exact (pr1 (pr1 (isCoproductCocone_CoproductCocone CC _ f))).
 Defined.
 
 Lemma CoproductInCommutes (a : I -> C) (CC : CoproductCocone a) :
-     ∀ (c : C) (f : forall i, a i --> c) i, CoproductIn CC i ;; CoproductArrow CC f = f i.
+     Π (c : C) (f : Π i, a i --> c) i, CoproductIn CC i ;; CoproductArrow CC f = f i.
 Proof.
   intros c f i.
   exact (pr2 (pr1 (isCoproductCocone_CoproductCocone CC _ f)) i).
 Qed.
 
 Lemma CoproductArrowUnique (a : I -> C) (CC : CoproductCocone a) (x : C)
-    (f : forall i, a i --> x) (k : CoproductObject CC --> x)
-    (Hk : forall i, CoproductIn CC i ;; k = f i) :
+    (f : Π i, a i --> x) (k : CoproductObject CC --> x)
+    (Hk : Π i, CoproductIn CC i ;; k = f i) :
   k = CoproductArrow CC f.
 Proof.
   set (H' := pr2 (isCoproductCocone_CoproductCocone CC _ f) (k,,Hk)).
@@ -72,19 +72,19 @@ Qed.
 
 
 Definition CoproductOfArrows {a : I -> C} (CCab : CoproductCocone a) {c : I -> C}
-    (CCcd : CoproductCocone c) (f : forall i, a i --> c i) :
+    (CCcd : CoproductCocone c) (f : Π i, a i --> c i) :
           CoproductObject CCab --> CoproductObject CCcd :=
     CoproductArrow CCab (fun i => f i ;; CoproductIn CCcd i).
 
 Lemma CoproductOfArrowsIn {a : I -> C} (CCab : CoproductCocone a) {c : I -> C}
-    (CCcd : CoproductCocone c) (f : forall i, a i --> c i) :
-    forall i, CoproductIn CCab i ;; CoproductOfArrows CCab CCcd f = f i ;; CoproductIn CCcd i.
+    (CCcd : CoproductCocone c) (f : Π i, a i --> c i) :
+    Π i, CoproductIn CCab i ;; CoproductOfArrows CCab CCcd f = f i ;; CoproductIn CCcd i.
 Proof.
   unfold CoproductOfArrows; intro i.
   apply CoproductInCommutes.
 Qed.
 
-Definition mk_CoproductCocone (a : I -> C) (c : C) (f : forall i, a i --> c) :
+Definition mk_CoproductCocone (a : I -> C) (c : C) (f : Π i, a i --> c) :
    isCoproductCocone _ _ f →  CoproductCocone a.
 Proof.
 intro H.
@@ -94,8 +94,8 @@ mkpair.
 Defined.
 
 Definition mk_isCoproductCocone (hsC : has_homsets C) (a : I -> C) (co : C)
-  (f : forall i, a i --> co) : (∀ (c : C) (g : forall i, a i --> c),
-                                  ∃! k : C ⟦co, c⟧, forall i, f i ;; k = g i)
+  (f : Π i, a i --> co) : (Π (c : C) (g : Π i, a i --> c),
+                                  ∃! k : C ⟦co, c⟧, Π i, f i ;; k = g i)
    →    isCoproductCocone a co f.
 Proof.
   intros H c cc.
@@ -103,8 +103,8 @@ Proof.
 Defined.
 
 Lemma precompWithCoproductArrow {a : I -> C} (CCab : CoproductCocone a) {c : I -> C}
-    (CCcd : CoproductCocone c) (f : forall i, a i --> c i)
-    {x : C} (k : forall i, c i --> x) :
+    (CCcd : CoproductCocone c) (f : Π i, a i --> c i)
+    {x : C} (k : Π i, c i --> x) :
         CoproductOfArrows CCab CCcd f ;; CoproductArrow CCcd k =
          CoproductArrow CCab (fun i => f i ;; k i).
 Proof.
@@ -113,7 +113,7 @@ now rewrite assoc, CoproductOfArrowsIn, <- assoc, CoproductInCommutes.
 Qed.
 
 Lemma postcompWithCoproductArrow {a : I -> C} (CCab : CoproductCocone a) {c : C}
-    (f : forall i, a i --> c) {x : C} (k : c --> x)  :
+    (f : Π i, a i --> c) {x : C} (k : c --> x)  :
        CoproductArrow CCab f ;; k = CoproductArrow CCab (fun i => f i ;; k).
 Proof.
 apply CoproductArrowUnique; intro i.
@@ -122,7 +122,7 @@ Qed.
 
 Lemma Coproduct_endo_is_identity (a : I -> C) (CC : CoproductCocone a)
   (k : CoproductObject CC --> CoproductObject CC)
-  (H1 : forall i, CoproductIn CC i ;; k = CoproductIn CC i)
+  (H1 : Π i, CoproductIn CC i ;; k = CoproductIn CC i)
   : identity _ = k.
 Proof.
 apply pathsinv0.
@@ -147,7 +147,7 @@ Variables (I : UU) (C : precategory) (CC : Coproducts I C).
 (* Qed. *)
 
 Definition CoproductOfArrows_comp (a b c : I -> C)
-  (f : forall i, a i --> b i) (g : forall i, b i --> c i) :
+  (f : Π i, a i --> b i) (g : Π i, b i --> c i) :
    CoproductOfArrows _ _ _ _ f ;; CoproductOfArrows _ _ (CC _) (CC _) g
    = CoproductOfArrows _ _ (CC _) (CC _)(fun i => f i ;; g i).
 Proof.
@@ -156,7 +156,7 @@ rewrite assoc, CoproductOfArrowsIn.
 now rewrite <- assoc, CoproductOfArrowsIn, assoc.
 Qed.
 
-Definition CoproductOfArrows_eq (a c : I -> C) (f f' : forall i, a i --> c i) : f = f' ->
+Definition CoproductOfArrows_eq (a c : I -> C) (f f' : Π i, a i --> c i) : f = f' ->
   CoproductOfArrows _ _ _ _ f = CoproductOfArrows _ _ (CC _) (CC _) f'.
 Proof.
 now induction 1.

--- a/UniMath/CategoryTheory/limits/equalizers.v
+++ b/UniMath/CategoryTheory/limits/equalizers.v
@@ -14,12 +14,12 @@ Section def_equalizers.
   (** Definition and construction of isEqualizer. *)
   Definition isEqualizer {x y z : C} (f g : y --> z) (e : x --> y)
              (H : e ;; f = e ;; g) : UU :=
-    forall (w : C) (h : w --> y) (H : h ;; f = h ;; g),
+    Π (w : C) (h : w --> y) (H : h ;; f = h ;; g),
       iscontr (Σ φ : w --> x, φ ;; e = h).
 
   Definition mk_isEqualizer {x y z : C} (f g : y --> z) (e : x --> y)
              (H : e ;; f = e ;; g) :
-    (forall (w : C) (h : w --> y) (H' : h ;; f = h ;; g),
+    (Π (w : C) (h : w --> y) (H' : h ;; f = h ;; g),
         iscontr (Σ ψ : w --> x, ψ ;; e = h)) -> isEqualizer f g e H.
   Proof.
     intros X. unfold isEqualizer. exact X.
@@ -63,9 +63,9 @@ Section def_equalizers.
   Defined.
 
   (** Equalizers in precategories. *)
-  Definition Equalizers := forall (y z : C) (f g : y --> z), Equalizer f g.
+  Definition Equalizers := Π (y z : C) (f g : y --> z), Equalizer f g.
 
-  Definition hasEqualizers := forall (y z : C) (f g : y --> z),
+  Definition hasEqualizers := Π (y z : C) (f g : y --> z),
       ishinh (Equalizer f g).
 
   (** Returns the equalizer object. *)

--- a/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
@@ -47,7 +47,7 @@ Definition isBinCoproductCocone (a b co : C) (ia : a --> co) (ib : b --> co) :=
   isColimCocone (bincoproduct_diagram a b) co (CopCocone ia ib).
 
 Definition mk_isBinCoproductCocone (hsC : has_homsets C)(a b co : C) (ia : a --> co) (ib : b --> co) :
-   (∀ (c : C) (f : a --> c) (g : b --> c),
+   (Π (c : C) (f : a --> c) (g : b --> c),
     ∃! k : C ⟦co, c⟧,
       ia ;; k = f ×
       ib ;; k = g)
@@ -71,7 +71,7 @@ Definition BinCoproductCocone (a b : C) :=
   ColimCocone (bincoproduct_diagram a b).
 
 Definition mk_BinCoproductCocone (a b : C) :
-  ∀ (c : C) (f : a --> c) (g : b --> c),
+  Π (c : C) (f : a --> c) (g : b --> c),
    isBinCoproductCocone _ _ _ f g →  BinCoproductCocone a b.
 Proof.
   intros.
@@ -81,7 +81,7 @@ Proof.
   - apply X.
 Defined.
 
-Definition BinCoproducts := ∀ (a b : C), BinCoproductCocone a b.
+Definition BinCoproducts := Π (a b : C), BinCoproductCocone a b.
 Definition hasBinCoproducts := ishinh BinCoproducts.
 
 Definition BinCoproductObject {a b : C} (CC : BinCoproductCocone a b) : C := colim CC.
@@ -103,7 +103,7 @@ Proof.
 Defined.
 
 Lemma BinCoproductIn1Commutes (a b : C) (CC : BinCoproductCocone a b):
-     ∀ (c : C) (f : a --> c) g, BinCoproductIn1 CC ;; BinCoproductArrow CC f g  = f.
+     Π (c : C) (f : a --> c) g, BinCoproductIn1 CC ;; BinCoproductArrow CC f g  = f.
 Proof.
   intros c f g.
   unfold BinCoproductIn1.
@@ -112,7 +112,7 @@ Proof.
 Qed.
 
 Lemma BinCoproductIn2Commutes (a b : C) (CC : BinCoproductCocone a b):
-     ∀ (c : C) (f : a --> c) g, BinCoproductIn2 CC ;; BinCoproductArrow CC f g = g.
+     Π (c : C) (f : a --> c) g, BinCoproductIn2 CC ;; BinCoproductArrow CC f g = g.
 Proof.
   intros c f g.
   unfold BinCoproductIn1.

--- a/UniMath/CategoryTheory/limits/graphs/binproducts.v
+++ b/UniMath/CategoryTheory/limits/graphs/binproducts.v
@@ -41,7 +41,7 @@ Definition isBinProductCone (c d p : C) (p1 : C⟦p,c⟧) (p2 : C⟦p,d⟧) :=
 
 Definition mk_isBinProductCone (hsC : has_homsets C) (a b p : C)
   (pa : C⟦p,a⟧) (pb : C⟦p,b⟧) :
-  (∀ (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧),
+  (Π (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧),
     ∃! k : C⟦c,p⟧, k ;; pa = f × k ;; pb = g) ->
   isBinProductCone a b p pa pb.
 Proof.
@@ -60,7 +60,7 @@ Defined.
 Definition BinProductCone (a b : C) := LimCone (binproduct_diagram a b).
 
 Definition mk_BinProductCone (a b : C) :
-  ∀ (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧),
+  Π (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧),
    isBinProductCone _ _ _ f g -> BinProductCone a b.
 Proof.
   intros.
@@ -70,7 +70,7 @@ Proof.
   - apply X.
 Defined.
 
-Definition BinProducts := forall (a b : C), BinProductCone a b.
+Definition BinProducts := Π (a b : C), BinProductCone a b.
 
 (* What is the best definition of this? *)
 (* Definition hasBinProducts (C : precategory) := ishinh (BinProducts C). *)
@@ -95,14 +95,14 @@ simple refine (mk_cone _ _).
 Defined.
 
 Lemma BinProductPr1Commutes (a b : C) (P : BinProductCone a b):
-     forall (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧), BinProductArrow P f g ;; BinProductPr1 P = f.
+     Π (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧), BinProductArrow P f g ;; BinProductPr1 P = f.
 Proof.
 intros c f g.
 apply (limArrowCommutes P c (ProdCone f g) true).
 Qed.
 
 Lemma BinProductPr2Commutes (a b : C) (P : BinProductCone a b):
-     forall (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧), BinProductArrow P f g ;; BinProductPr2 P = g.
+     Π (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧), BinProductArrow P f g ;; BinProductPr2 P = g.
 Proof.
 intros c f g.
 apply (limArrowCommutes P c (ProdCone f g) false).

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -54,13 +54,13 @@ Definition vertex : graph -> UU := pr1.
 Definition edge {g : graph} : vertex g -> vertex g -> UU := pr2 g.
 
 Definition diagram (g : graph) (C : precategory) : UU :=
-  Σ (f : vertex g -> C), ∀ (a b : vertex g), edge a b -> C⟦f a, f b⟧.
+  Σ (f : vertex g -> C), Π (a b : vertex g), edge a b -> C⟦f a, f b⟧.
 
 Definition dob {g : graph} {C : precategory} (d : diagram g C) : vertex g -> C :=
   pr1 d.
 
 Definition dmor {g : graph} {C : precategory} (d : diagram g C) :
-  ∀ {a b}, edge a b -> C⟦dob d a,dob d b⟧ := pr2 d.
+  Π {a b}, edge a b -> C⟦dob d a,dob d b⟧ := pr2 d.
 
 Section diagram_from_functor.
 
@@ -83,19 +83,19 @@ Context {C : precategory} (hsC : has_homsets C).
 
 (* A cocone with tip c over a diagram d *)
 Definition cocone {g : graph} (d : diagram g C) (c : C) : UU :=
-  Σ (f : ∀ (v : vertex g), C⟦dob d v,c⟧),
-    ∀ (u v : vertex g) (e : edge u v), dmor d e ;; f v = f u.
+  Σ (f : Π (v : vertex g), C⟦dob d v,c⟧),
+    Π (u v : vertex g) (e : edge u v), dmor d e ;; f v = f u.
 
 Definition mk_cocone {g : graph} {d : diagram g C} {c : C}
-  (f : ∀ v, C⟦dob d v,c⟧) (Hf : ∀ u v e, dmor d e ;; f v = f u) :
+  (f : Π v, C⟦dob d v,c⟧) (Hf : Π u v e, dmor d e ;; f v = f u) :
   cocone d c := tpair _ f Hf.
 
 (* The injections to c in the cocone *)
 Definition coconeIn {g : graph} {d : diagram g C} {c : C} (cc : cocone d c) :
-  ∀ v, C⟦dob d v,c⟧ := pr1 cc.
+  Π v, C⟦dob d v,c⟧ := pr1 cc.
 
 Lemma coconeInCommutes {g : graph} {d : diagram g C} {c : C} (cc : cocone d c) :
-  ∀ u v (e : edge u v), dmor d e ;; coconeIn cc v = coconeIn cc u.
+  Π u v (e : edge u v), dmor d e ;; coconeIn cc v = coconeIn cc u.
 Proof.
 exact (pr2 cc).
 Qed.
@@ -104,8 +104,8 @@ Qed.
    diagram there is a unique morphism from the tip of cc0 to the tip
    of cc *)
 Definition isColimCocone {g : graph} (d : diagram g C) (c0 : C)
-  (cc0 : cocone d c0) : UU := ∀ (c : C) (cc : cocone d c),
-    iscontr (Σ x : C⟦c0,c⟧, ∀ v, coconeIn cc0 v ;; x = coconeIn cc v).
+  (cc0 : cocone d c0) : UU := Π (c : C) (cc : cocone d c),
+    iscontr (Σ x : C⟦c0,c⟧, Π v, coconeIn cc0 v ;; x = coconeIn cc v).
 
 (* Definition isColim {g : graph} (d : diagram g C) (L : C) := *)
 (*   Σ c : cocone d L, isColimCocone d L c. *)
@@ -117,9 +117,9 @@ Definition mk_ColimCocone {g : graph} (d : diagram g C)
   (c : C) (cc : cocone d c) (isCC : isColimCocone d c cc) : ColimCocone d :=
     tpair _ (tpair _ c cc) isCC.
 
-Definition Colims : UU := ∀ {g : graph} (d : diagram g C), ColimCocone d.
+Definition Colims : UU := Π {g : graph} (d : diagram g C), ColimCocone d.
 Definition hasColims : UU  :=
-  ∀ {g : graph} (d : diagram g C), ishinh (ColimCocone d).
+  Π {g : graph} (d : diagram g C), ishinh (ColimCocone d).
 
 (* colim is the tip of the colim cocone *)
 Definition colim {g : graph} {d : diagram g C} (CC : ColimCocone d) : C :=
@@ -132,18 +132,18 @@ Definition isColimCocone_from_ColimCocone {g : graph} {d : diagram g C} (CC : Co
   isColimCocone d (colim CC) _ := pr2 CC.
 
 Definition colimIn {g : graph} {d : diagram g C} (CC : ColimCocone d) :
-  ∀ (v : vertex g), C⟦dob d v,colim CC⟧ := coconeIn (colimCocone CC).
+  Π (v : vertex g), C⟦dob d v,colim CC⟧ := coconeIn (colimCocone CC).
 
 Lemma colimInCommutes {g : graph} {d : diagram g C}
-  (CC : ColimCocone d) : ∀ (u v : vertex g) (e : edge u v),
+  (CC : ColimCocone d) : Π (u v : vertex g) (e : edge u v),
    dmor d e ;; colimIn CC v = colimIn CC u.
 Proof.
 exact (coconeInCommutes (colimCocone CC)).
 Qed.
 
 Lemma colimUnivProp {g : graph} {d : diagram g C}
-  (CC : ColimCocone d) : ∀ (c : C) (cc : cocone d c),
-  iscontr (Σ x : C⟦colim CC,c⟧, ∀ (v : vertex g), colimIn CC v ;; x = coconeIn cc v).
+  (CC : ColimCocone d) : Π (c : C) (cc : cocone d c),
+  iscontr (Σ x : C⟦colim CC,c⟧, Π (v : vertex g), colimIn CC v ;; x = coconeIn cc v).
 Proof.
 exact (pr2 CC).
 Qed.
@@ -171,7 +171,7 @@ Qed.
 
 Lemma colimArrowUnique {g : graph} {d : diagram g C} (CC : ColimCocone d)
   (c : C) (cc : cocone d c) (k : C⟦colim CC,c⟧)
-  (Hk : ∀ (u : vertex g), colimIn CC u ;; k = coconeIn cc u) :
+  (Hk : Π (u : vertex g), colimIn CC u ;; k = coconeIn cc u) :
   k = colimArrow CC c cc.
 Proof.
 now apply path_to_ctr, Hk.
@@ -179,7 +179,7 @@ Qed.
 
 Lemma Cocone_postcompose {g : graph} {d : diagram g C}
   {c : C} (cc : cocone d c) (x : C) (f : C⟦c,x⟧) :
-    ∀ u v (e : edge u v), dmor d e ;; (coconeIn cc v ;; f) = coconeIn cc u ;; f.
+    Π u v (e : edge u v), dmor d e ;; (coconeIn cc v ;; f) = coconeIn cc u ;; f.
 Proof.
 now intros u v e; rewrite assoc, coconeInCommutes.
 Qed.
@@ -195,8 +195,8 @@ Qed.
 
 Definition colimOfArrows {g : graph} {d1 d2 : diagram g C}
   (CC1 : ColimCocone d1) (CC2 : ColimCocone d2)
-  (f : ∀ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : ∀ u v (e : edge u v), dmor d1 e ;; f v = f u ;; dmor d2 e) :
+  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : Π u v (e : edge u v), dmor d1 e ;; f v = f u ;; dmor d2 e) :
   C⟦colim CC1,colim CC2⟧.
 Proof.
 apply colimArrow; simple refine (mk_cocone _ _).
@@ -207,9 +207,9 @@ Defined.
 
 Lemma colimOfArrowsIn {g : graph} (d1 d2 : diagram g C)
   (CC1 : ColimCocone d1) (CC2 : ColimCocone d2)
-  (f : ∀ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : ∀ u v (e : edge u v), dmor d1 e ;; f v = f u ;; dmor d2 e) :
-    ∀ u, colimIn CC1 u ;; colimOfArrows CC1 CC2 f fNat =
+  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : Π u v (e : edge u v), dmor d1 e ;; f v = f u ;; dmor d2 e) :
+    Π u, colimIn CC1 u ;; colimOfArrows CC1 CC2 f fNat =
          f u ;; colimIn CC2 u.
 Proof.
 now unfold colimOfArrows; intro u; rewrite colimArrowCommutes.
@@ -217,8 +217,8 @@ Qed.
 
 Lemma preCompWithColimOfArrows_subproof {g : graph} {d1 d2 : diagram g C}
   (CC1 : ColimCocone d1) (CC2 : ColimCocone d2)
-  (f : ∀ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : ∀ u v (e : edge u v), dmor d1 e ;; f v = f u ;; dmor d2 e)
+  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : Π u v (e : edge u v), dmor d1 e ;; f v = f u ;; dmor d2 e)
   (x : C) (cc : cocone d2 x) u v (e : edge u v) :
      dmor d1 e ;; (f v ;; coconeIn cc v) = f u ;; coconeIn cc u.
 Proof.
@@ -227,8 +227,8 @@ Qed.
 
 Lemma precompWithColimOfArrows {g : graph} (d1 d2 : diagram g C)
   (CC1 : ColimCocone d1) (CC2 : ColimCocone d2)
-  (f : ∀ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : ∀ u v (e : edge u v), dmor d1 e ;; f v = f u ;; dmor d2 e)
+  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : Π u v (e : edge u v), dmor d1 e ;; f v = f u ;; dmor d2 e)
   (x : C) (cc : cocone d2 x) :
   colimOfArrows CC1 CC2 f fNat ;; colimArrow CC2 x cc =
   colimArrow CC1 x (mk_cocone (λ u, f u ;; coconeIn cc u)
@@ -250,7 +250,7 @@ Qed.
 
 Lemma colim_endo_is_identity {g : graph} (D : diagram g C)
   (CC : ColimCocone D) (k : colim CC --> colim CC)
-  (H : ∀ u, colimIn CC u ;; k = colimIn CC u) :
+  (H : Π u, colimIn CC u ;; k = colimIn CC u) :
   identity _ = k.
 Proof.
 unshelve refine (uniqueExists _ _ (colimUnivProp CC _ _) _ _ _ _).
@@ -268,13 +268,13 @@ Defined.
 
 Lemma isColim_weq_subproof1 {g : graph} (D : diagram g C)
   (c : C) (cc : cocone D c) (d : C) (k : C⟦c,d⟧) :
-  ∀ u, coconeIn cc u ;; k = pr1 (Cocone_by_postcompose D c cc d k) u.
+  Π u, coconeIn cc u ;; k = pr1 (Cocone_by_postcompose D c cc d k) u.
 Proof.
 now intro u.
 Qed.
 
 Lemma isColim_weq_subproof2 (g : graph) (D : diagram g C)
-  (c : C) (cc : cocone D c) (H : ∀ d, isweq (Cocone_by_postcompose D c cc d))
+  (c : C) (cc : cocone D c) (H : Π d, isweq (Cocone_by_postcompose D c cc d))
   (d : C) (cd : cocone D d) (u : vertex g) :
     coconeIn cc u ;; invmap (weqpair _ (H d)) cd = coconeIn cd u.
 Proof.
@@ -284,7 +284,7 @@ now rewrite p.
 Qed.
 
 Lemma isColim_weq {g : graph} (D : diagram g C) (c : C) (cc : cocone D c) :
-  isColimCocone D c cc <-> ∀ d, isweq (Cocone_by_postcompose D c cc d).
+  isColimCocone D c cc <-> Π d, isweq (Cocone_by_postcompose D c cc d).
 Proof.
 split.
 - intros H d.
@@ -379,7 +379,7 @@ exists (fun v => pr1 (dob D v) a); intros u v e.
 now apply (pr1 (dmor D e) a).
 Defined.
 
-Variable (HCg : forall (a : A), ColimCocone (diagram_pointwise a)).
+Variable (HCg : Π (a : A), ColimCocone (diagram_pointwise a)).
 
 Definition ColimFunctor_ob (a : A) : C := colim (HCg a).
 
@@ -430,7 +430,7 @@ Defined.
 
 Lemma ColimFunctor_unique (F : [A, C, hsC]) (cc : cocone D F) :
   iscontr (Σ x : [A, C, hsC] ⟦ ColimFunctor, F ⟧,
-            ∀ v : vertex g, colim_nat_trans_in_data v ;; x = coconeIn cc v).
+            Π v : vertex g, colim_nat_trans_in_data v ;; x = coconeIn cc v).
 Proof.
 simple refine (tpair _ _ _).
 - simple refine (tpair _ _ _).
@@ -468,7 +468,7 @@ Defined.
 
 Definition isColimFunctor_is_pointwise_Colim
   (X : [A,C,hsC]) (R : cocone D X) (H : isColimCocone D X R)
-  : ∀ a, isColimCocone (diagram_pointwise a) _ (cocone_pointwise X R a).
+  : Π a, isColimCocone (diagram_pointwise a) _ (cocone_pointwise X R a).
 Proof.
   intro a.
   apply (is_iso_isColim hsC _ (HCg a)).
@@ -519,7 +519,7 @@ Definition preserves_colimit {g : graph} (d : diagram g C) (L : C)
   (cc : cocone d L) : UU :=
   isColimCocone d L cc -> isColimCocone (mapdiagram d) (F L) (mapcocone d cc).
 
-Definition is_cocont := forall {g : graph} (d : diagram g C) (L : C)
+Definition is_cocont := Π {g : graph} (d : diagram g C) (L : C)
   (cc : cocone d L), preserves_colimit d L cc.
 
 End preserves_colimit.
@@ -530,14 +530,14 @@ Proof.
 intros g d L ccL HccL M ccM.
 set (G := pr1 H).
 apply (@iscontrweqb _ (Σ y : C ⟦ L, G M ⟧,
-    ∀ i, coconeIn ccL i ;; y = φ_adj _ _ _ H (coconeIn ccM i))).
+    Π i, coconeIn ccL i ;; y = φ_adj _ _ _ H (coconeIn ccM i))).
 - eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧,
-    ∀ i, # F (coconeIn ccL i) ;; φ_adj_inv _ _ _ H y = coconeIn ccM i)).
+    Π i, # F (coconeIn ccL i) ;; φ_adj_inv _ _ _ H y = coconeIn ccM i)).
   + apply (weqbandf (adjunction_hom_weq _ _ _ H L M)); simpl; intro f.
     abstract (apply weqiff; try (apply impred; intro; apply hsD);
     now rewrite φ_adj_inv_after_φ_adj).
   + eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧,
-      ∀ i, φ_adj_inv _ _ _ _ (coconeIn ccL i ;; y) = coconeIn ccM i)).
+      Π i, φ_adj_inv _ _ _ _ (coconeIn ccL i ;; y) = coconeIn ccM i)).
     * apply weqfibtototal; simpl; intro f.
     abstract (apply weqiff; try (apply impred; intro; apply hsD); split;
       [ intros HH i; rewrite φ_adj_inv_natural_precomp; apply HH
@@ -615,7 +615,7 @@ Let Fx : functor C D := constant_functor C D x.
 
 (* This is is too weak as diagrams are not necessarily categories *)
 Lemma preserves_colimit_constant {g : graph} (v : vertex g)
-  (conn : forall (u : vertex g), edge v u)
+  (conn : Π (u : vertex g), edge v u)
   (d : diagram g C) (L : C) (cc : cocone d L) :
   preserves_colimit Fx d L cc.
 Proof.

--- a/UniMath/CategoryTheory/limits/graphs/initial.v
+++ b/UniMath/CategoryTheory/limits/graphs/initial.v
@@ -31,9 +31,9 @@ Defined.
 
 Definition isInitial (a : C) :=
   isColimCocone initDiagram a (initCocone a).
- (* forall b : C, iscontr (a --> b). *)
+ (* Π b : C, iscontr (a --> b). *)
 
-Definition mk_isInitial (a : C) (H : ∀ (b : C), iscontr (a --> b)) :
+Definition mk_isInitial (a : C) (H : Π (b : C), iscontr (a --> b)) :
   isInitial a.
 Proof.
 intros b cb.

--- a/UniMath/CategoryTheory/limits/graphs/limits.v
+++ b/UniMath/CategoryTheory/limits/graphs/limits.v
@@ -29,27 +29,27 @@ Section lim_def.
 Context {C : precategory} (hsC : has_homsets C).
 
 Definition cone {g : graph} (d : diagram g C) (c : C) : UU :=
-  Σ (f : ∀ (v : vertex g), C⟦c,dob d v⟧),
-    ∀ (u v : vertex g) (e : edge u v), f u ;; dmor d e = f v.
+  Σ (f : Π (v : vertex g), C⟦c,dob d v⟧),
+    Π (u v : vertex g) (e : edge u v), f u ;; dmor d e = f v.
 
 Definition mk_cone {g : graph} {d : diagram g C} {c : C}
-  (f : ∀ v, C⟦c, dob d v⟧) (Hf : ∀ u v (e : edge u v), f u ;; dmor d e = f v) :
+  (f : Π v, C⟦c, dob d v⟧) (Hf : Π u v (e : edge u v), f u ;; dmor d e = f v) :
   cone d c
   := tpair _ f Hf.
 
 (** The injections to c in the cocone *)
 Definition coneOut {g : graph} {d : diagram g C} {c : C} (cc : cone d c) :
-  ∀ v, C⟦c, dob d v⟧ := pr1 cc.
+  Π v, C⟦c, dob d v⟧ := pr1 cc.
 
 Lemma coneOutCommutes {g : graph} {d : diagram g C} {c : C} (cc : cone d c) :
-  ∀ u v (e : edge u v), coneOut cc u ;; dmor d e = coneOut cc v.
+  Π u v (e : edge u v), coneOut cc u ;; dmor d e = coneOut cc v.
 Proof.
 apply (pr2 cc).
 Qed.
 
 Definition isLimCone {g : graph} (d : diagram g C) (c0 : C)
-  (cc0 : cone d c0) : UU := ∀ (c : C) (cc : cone d c),
-    iscontr (Σ x : C⟦c,c0⟧, ∀ v, x ;; coneOut cc0 v = coneOut cc v).
+  (cc0 : cone d c0) : UU := Π (c : C) (cc : cone d c),
+    iscontr (Σ x : C⟦c,c0⟧, Π v, x ;; coneOut cc0 v = coneOut cc v).
 
 Definition LimCone {g : graph} (d : diagram g C) : UU :=
    Σ (A : (Σ l, cone d l)), isLimCone d (pr1 A) (pr2 A).
@@ -58,9 +58,9 @@ Definition mk_LimCone {g : graph} (d : diagram g C)
   (c : C) (cc : cone d c) (isCC : isLimCone d c cc) : LimCone d
   := tpair _ (tpair _ c cc) isCC.
 
-Definition Lims : UU := ∀ {g : graph} (d : diagram g C), LimCone d.
+Definition Lims : UU := Π {g : graph} (d : diagram g C), LimCone d.
 Definition hasLims : UU  :=
-  ∀ {g : graph} (d : diagram g C), ishinh (LimCone d).
+  Π {g : graph} (d : diagram g C), ishinh (LimCone d).
 
 (** [lim] is the tip of the [LimCone] *)
 Definition lim {g : graph} {d : diagram g C} (CC : LimCone d) : C
@@ -70,18 +70,18 @@ Definition limCone {g : graph} {d : diagram g C} (CC : LimCone d) :
   cone d (lim CC) := pr2 (pr1 CC).
 
 Definition limOut {g : graph} {d : diagram g C} (CC : LimCone d) :
-  ∀ (v : vertex g), C⟦lim CC, dob d v⟧ := coneOut (limCone CC).
+  Π (v : vertex g), C⟦lim CC, dob d v⟧ := coneOut (limCone CC).
 
 Lemma limOutCommutes {g : graph} {d : diagram g C}
-  (CC : LimCone d) : ∀ (u v : vertex g) (e : edge u v),
+  (CC : LimCone d) : Π (u v : vertex g) (e : edge u v),
    limOut CC u ;; dmor d e = limOut CC v.
 Proof.
 exact (coneOutCommutes (limCone CC)).
 Qed.
 
 Lemma limUnivProp {g : graph} {d : diagram g C}
-  (CC : LimCone d) : ∀ (c : C) (cc : cone d c),
-  iscontr (Σ x : C⟦c, lim CC⟧, ∀ (v : vertex g), x ;; limOut CC v = coneOut cc v).
+  (CC : LimCone d) : Π (c : C) (cc : cone d c),
+  iscontr (Σ x : C⟦c, lim CC⟧, Π (v : vertex g), x ;; limOut CC v = coneOut cc v).
 Proof.
 apply (pr2 CC).
 Qed.
@@ -111,7 +111,7 @@ Qed.
 
 Lemma limArrowUnique {g : graph} {d : diagram g C} (CC : LimCone d)
   (c : C) (cc : cone d c) (k : C⟦c, lim CC⟧)
-  (Hk : ∀ (u : vertex g), k ;; limOut CC u = coneOut cc u) :
+  (Hk : Π (u : vertex g), k ;; limOut CC u = coneOut cc u) :
   k = limArrow CC c cc.
 Proof.
 now apply path_to_ctr, Hk.
@@ -119,7 +119,7 @@ Qed.
 
 Lemma Cone_precompose {g : graph} {d : diagram g C}
   {c : C} (cc : cone d c) (x : C) (f : C⟦x,c⟧) :
-    ∀ u v (e : edge u v), (f ;; coneOut cc u) ;; dmor d e = f ;; coneOut cc v.
+    Π u v (e : edge u v), (f ;; coneOut cc u) ;; dmor d e = f ;; coneOut cc v.
 Proof.
 now intros u v e; rewrite <- assoc, coneOutCommutes.
 Qed.
@@ -134,8 +134,8 @@ Qed.
 
 Definition limOfArrows {g : graph} {d1 d2 : diagram g C}
   (CC1 : LimCone d1) (CC2 : LimCone d2)
-  (f : ∀ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : ∀ u v (e : edge u v), f u ;; dmor d2 e = dmor d1 e ;; f v) :
+  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : Π u v (e : edge u v), f u ;; dmor d2 e = dmor d1 e ;; f v) :
   C⟦lim CC1 , lim CC2⟧.
 Proof.
 apply limArrow; simple refine (mk_cone _ _).
@@ -146,9 +146,9 @@ Defined.
 
 Lemma limOfArrowsOut {g : graph} (d1 d2 : diagram g C)
   (CC1 : LimCone d1) (CC2 : LimCone d2)
-  (f : ∀ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : ∀ u v (e : edge u v), f u ;; dmor d2 e = dmor d1 e ;; f v) :
-    ∀ u, limOfArrows CC1 CC2 f fNat ;; limOut CC2 u =
+  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : Π u v (e : edge u v), f u ;; dmor d2 e = dmor d1 e ;; f v) :
+    Π u, limOfArrows CC1 CC2 f fNat ;; limOut CC2 u =
           limOut CC1 u ;; f u.
 Proof.
 now unfold limOfArrows; intro u; rewrite limArrowCommutes.
@@ -156,8 +156,8 @@ Qed.
 
 Lemma postCompWithLimOfArrows_subproof {g : graph} {d1 d2 : diagram g C}
   (CC1 : LimCone d1) (CC2 : LimCone d2)
-  (f : ∀ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : ∀ u v (e : edge u v), f u ;; dmor d2 e = dmor d1 e ;; f v)
+  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : Π u v (e : edge u v), f u ;; dmor d2 e = dmor d1 e ;; f v)
   (x : C) (cc : cone d1 x) u v (e : edge u v) :
     (coneOut cc u ;; f u) ;; dmor d2 e = coneOut cc v ;; f v.
 Proof.
@@ -166,8 +166,8 @@ Defined.
 
 Lemma postCompWithLimOfArrows {g : graph} (d1 d2 : diagram g C)
   (CC1 : LimCone d1) (CC2 : LimCone d2)
-  (f : ∀ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : ∀ u v (e : edge u v), f u ;; dmor d2 e = dmor d1 e ;; f v)
+  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : Π u v (e : edge u v), f u ;; dmor d2 e = dmor d1 e ;; f v)
   (x : C) (cc : cone d1 x) :
      limArrow CC1 x cc ;; limOfArrows CC1 CC2 f fNat =
        limArrow CC2 x (mk_cone (λ u, coneOut cc u ;; f u)
@@ -189,7 +189,7 @@ Qed.
 
 Lemma lim_endo_is_identity {g : graph} (D : diagram g C)
   (CC : LimCone D) (k : lim CC --> lim CC)
-  (H : ∀ u, k ;; limOut CC u = limOut CC u) :
+  (H : Π u, k ;; limOut CC u = limOut CC u) :
   identity _ = k.
 Proof.
 unshelve refine (uniqueExists _ _ (limUnivProp CC _ _) _ _ _ _).
@@ -269,13 +269,13 @@ Defined.
 
 Lemma isColim_weq_subproof1 {g : graph} (D : diagram g C)
   (c : C) (cc : cocone D c) (d : C) (k : C⟦c,d⟧) :
-  ∀ u, coconeIn cc u ;; k = pr1 (Cocone_by_postcompose D c cc d k) u.
+  Π u, coconeIn cc u ;; k = pr1 (Cocone_by_postcompose D c cc d k) u.
 Proof.
 now intro u.
 Qed.
 
 Lemma isColim_weq_subproof2 (g : graph) (D : diagram g C)
-  (c : C) (cc : cocone D c) (H : ∀ d, isweq (Cocone_by_postcompose D c cc d))
+  (c : C) (cc : cocone D c) (H : Π d, isweq (Cocone_by_postcompose D c cc d))
   (d : C) (cd : cocone D d) (u : vertex g) :
     coconeIn cc u ;; invmap (weqpair _ (H d)) cd = coconeIn cd u.
 Proof.
@@ -285,7 +285,7 @@ now rewrite p.
 Qed.
 
 Lemma isColim_weq {g : graph} (D : diagram g C) (c : C) (cc : cocone D c) :
-  isColimCocone D c cc <-> ∀ d, isweq (Cocone_by_postcompose D c cc d).
+  isColimCocone D c cc <-> Π d, isweq (Cocone_by_postcompose D c cc d).
 Proof.
 split.
 - intros H d.
@@ -334,7 +334,7 @@ Variable D : diagram g [A, C, hsC].
 (* now apply (pr1 (dmor D e) a). *)
 (* Defined. *)
 
-Variable (HCg : forall (a : A), LimCone (diagram_pointwise A C hsC g D a)).
+Variable (HCg : Π (a : A), LimCone (diagram_pointwise A C hsC g D a)).
 
 Definition LimFunctor_ob (a : A) : C := lim (HCg a).
 
@@ -385,7 +385,7 @@ Defined.
 
 Lemma LimFunctor_unique (F : [A, C, hsC]) (cc : cone D F) :
   iscontr (Σ x : [A, C, hsC] ⟦ F, LimFunctor ⟧,
-            ∀ v, x ;; lim_nat_trans_in_data v = coneOut cc v).
+            Π v, x ;; lim_nat_trans_in_data v = coneOut cc v).
 Proof.
 mkpair.
 - mkpair.
@@ -420,7 +420,7 @@ Defined.
 
 Definition isLimFunctor_is_pointwise_Lim
   (X : [A,C,hsC]) (R : cone D X) (H : isLimCone D X R)
-  : ∀ a, isLimCone (diagram_pointwise _ _ hsC _ D a)
+  : Π a, isLimCone (diagram_pointwise _ _ hsC _ D a)
                    _
                    (cone_pointwise X R a).
 Proof.
@@ -460,8 +460,8 @@ Context {C : precategory} (hsC : has_homsets C).
 (* A cone with tip c over a diagram d *)
 (*
 Definition cocone {g : graph} (d : diagram g C) (c : C) : UU :=
-  Σ (f : ∀ (v : vertex g), C⟦dob d v,c⟧),
-    ∀ (u v : vertex g) (e : edge u v), dmor d e ;; f v = f u.
+  Σ (f : Π (v : vertex g), C⟦dob d v,c⟧),
+    Π (u v : vertex g) (e : edge u v), dmor d e ;; f v = f u.
 *)
 
 Definition opp_diagram g C := diagram g C^op.
@@ -471,21 +471,21 @@ Definition cone {g : graph} (d : diagram g C^op) (c : C) : UU :=
 
 (*
 Definition mk_cocone {g : graph} {d : diagram g C} {c : C}
-  (f : ∀ v, C⟦dob d v,c⟧) (Hf : ∀ u v e, dmor d e ;; f v = f u) :
+  (f : Π v, C⟦dob d v,c⟧) (Hf : Π u v e, dmor d e ;; f v = f u) :
   cocone d c := tpair _ f Hf.
 *)
 
 Definition mk_cone {g : graph} {d : diagram g C^op} {c : C}
-  (f : ∀ v, C⟦c, dob d v⟧) (Hf : ∀ u v (e : edge u v) , f v ;; dmor d e  = f u) :
+  (f : Π v, C⟦c, dob d v⟧) (Hf : Π u v (e : edge u v) , f v ;; dmor d e  = f u) :
   cone d c
   := tpair _ f Hf.
 
 (* The injections to c in the cocone *)
 Definition coneOut {g : graph} {d : diagram g C^op} {c : C} (cc : cone d c) :
-  ∀ v, C⟦c, dob d v⟧ := coconeIn cc.
+  Π v, C⟦c, dob d v⟧ := coconeIn cc.
 
 Lemma coneOutCommutes {g : graph} {d : diagram g C^op} {c : C} (cc : cone d c) :
-  ∀ u v (e : edge u v), coneOut cc v ;; dmor d e = coneOut cc u.
+  Π u v (e : edge u v), coneOut cc v ;; dmor d e = coneOut cc u.
 Proof.
   apply (coconeInCommutes cc).
 Qed.
@@ -497,9 +497,9 @@ Definition isLimCone {g : graph} (d : diagram g C^op) (c0 : C)
   (cc0 : cone d c0) : UU :=
    isColimCocone _ _ cc0.
 (*
-∀ (c : C) (cc : cone d c),
+Π (c : C) (cc : cone d c),
       isColimCocone
-    iscontr (Σ x : C⟦c0,c⟧, ∀ v, coconeIn cc0 v ;; x = coconeIn cc v).
+    iscontr (Σ x : C⟦c0,c⟧, Π v, coconeIn cc0 v ;; x = coconeIn cc v).
 *)
 
 Definition LimCone {g : graph} (d : diagram g C^op) : UU :=
@@ -514,9 +514,9 @@ simple refine (mk_ColimCocone _ _ _ _  ).
 - apply isCC.
 Defined.
 
-Definition Lims : UU := ∀ {g : graph} (d : diagram g C^op), LimCone d.
+Definition Lims : UU := Π {g : graph} (d : diagram g C^op), LimCone d.
 Definition hasLims : UU  :=
-  ∀ {g : graph} (d : diagram g C^op), ishinh (LimCone d).
+  Π {g : graph} (d : diagram g C^op), ishinh (LimCone d).
 
 (* lim is the tip of the lim cone *)
 Definition lim {g : graph} {d : diagram g C^op} (CC : LimCone d) : C
@@ -526,18 +526,18 @@ Definition limCone {g : graph} {d : diagram g C^op} (CC : LimCone d) :
   cone d (lim CC) := colimCocone CC.
 
 Definition limOut {g : graph} {d : diagram g C^op} (CC : LimCone d) :
-  ∀ (v : vertex g), C⟦lim CC, dob d v⟧ := coneOut (limCone CC).
+  Π (v : vertex g), C⟦lim CC, dob d v⟧ := coneOut (limCone CC).
 
 Lemma limOutCommutes {g : graph} {d : diagram g C^op}
-  (CC : LimCone d) : ∀ (u v : vertex g) (e : edge u v),
+  (CC : LimCone d) : Π (u v : vertex g) (e : edge u v),
    limOut CC v ;; dmor d e = limOut CC u.
 Proof.
 exact (coneOutCommutes (limCone CC)).
 Qed.
 
 Lemma limUnivProp {g : graph} {d : diagram g C^op}
-  (CC : LimCone d) : ∀ (c : C) (cc : cone d c),
-  iscontr (Σ x : C⟦c, lim CC⟧, ∀ (v : vertex g), x ;; limOut CC v = coneOut cc v).
+  (CC : LimCone d) : Π (c : C) (cc : cone d c),
+  iscontr (Σ x : C⟦c, lim CC⟧, Π (v : vertex g), x ;; limOut CC v = coneOut cc v).
 Proof.
 apply (colimUnivProp CC).
 Qed.
@@ -562,7 +562,7 @@ Qed.
 
 Lemma limArrowUnique {g : graph} {d : diagram g C^op} (CC : LimCone d)
   (c : C) (cc : cone d c) (k : C⟦c, lim CC⟧)
-  (Hk : ∀ (u : vertex g), k ;; limOut CC u = coneOut cc u) :
+  (Hk : Π (u : vertex g), k ;; limOut CC u = coneOut cc u) :
   k = limArrow CC c cc.
 Proof.
   apply (colimArrowUnique CC c cc k Hk).
@@ -570,7 +570,7 @@ Qed.
 
 Lemma Cone_precompose {g : graph} {d : diagram g C^op}
   {c : C} (cc : cone d c) (x : C) (f : C⟦x,c⟧) :
-    ∀ u v (e : edge u v), (f ;; coneOut cc v) ;; dmor d e = f ;; coneOut cc u.
+    Π u v (e : edge u v), (f ;; coneOut cc v) ;; dmor d e = f ;; coneOut cc u.
 Proof.
   apply (Cocone_postcompose cc x f).
 Qed.
@@ -585,8 +585,8 @@ Qed.
 
 Definition limOfArrows {g : graph} {d1 d2 : diagram g C^op}
   (CC1 : LimCone d1) (CC2 : LimCone d2)
-  (f : ∀ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : ∀ u v (e : edge u v), f v ;; (dmor d2 e : C⟦dob d2 v, dob d2 u⟧)
+  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : Π u v (e : edge u v), f v ;; (dmor d2 e : C⟦dob d2 v, dob d2 u⟧)
                               =
                                 (dmor d1 e : C⟦dob d1 v, dob d1 u⟧);; f u) :
   C⟦lim CC1 , lim CC2⟧.
@@ -598,9 +598,9 @@ Defined.
 
 Lemma limOfArrowsOut {g : graph} (d1 d2 : diagram g C^op)
   (CC1 : LimCone d1) (CC2 : LimCone d2)
-  (f : ∀ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : ∀ u v (e : edge u v), f v ;; dmor d2 e = (dmor d1 e : C ⟦ _ , _ ⟧)  ;; f u) :
-    ∀ u, limOfArrows CC1 CC2 f fNat ;; limOut CC2 u =
+  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : Π u v (e : edge u v), f v ;; dmor d2 e = (dmor d1 e : C ⟦ _ , _ ⟧)  ;; f u) :
+    Π u, limOfArrows CC1 CC2 f fNat ;; limOut CC2 u =
           limOut CC1 u ;; f u.
 Proof.
   apply (colimOfArrowsIn _ _ CC2 CC1 f fNat).
@@ -608,8 +608,8 @@ Qed.
 
 Lemma postCompWithLimOfArrows_subproof {g : graph} {d1 d2 : diagram g C^op}
   (CC1 : LimCone d1) (CC2 : LimCone d2)
-  (f : ∀ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : ∀ u v (e : edge u v), f v ;; dmor d2 e = (dmor d1 e : C ⟦ _ , _ ⟧)  ;; f u)
+  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : Π u v (e : edge u v), f v ;; dmor d2 e = (dmor d1 e : C ⟦ _ , _ ⟧)  ;; f u)
   (x : C) (cc : cone d1 x) u v (e : edge u v) :
     (coneOut cc v ;; f v) ;; dmor d2 e = coneOut cc u ;; f u.
 Proof.
@@ -618,8 +618,8 @@ Defined.
 
 Lemma postcompWithColimOfArrows {g : graph} (d1 d2 : diagram g C^op)
   (CC1 : LimCone d1) (CC2 : LimCone d2)
-  (f : ∀ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : ∀ u v (e : edge u v), f v ;; dmor d2 e = (dmor d1 e : C ⟦ _ , _ ⟧)  ;; f u)
+  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : Π u v (e : edge u v), f v ;; dmor d2 e = (dmor d1 e : C ⟦ _ , _ ⟧)  ;; f u)
   (x : C) (cc : cone d1 x) :
      limArrow CC1 x cc ;; limOfArrows CC1 CC2 f fNat =
        limArrow CC2 x (mk_cone (λ u, coneOut cc u ;; f u)
@@ -646,7 +646,7 @@ Qed.
 
 Lemma lim_endo_is_identity {g : graph} (D : diagram g C^op)
   (CC : LimCone D) (k : lim CC --> lim CC)
-  (H : ∀ u, k ;; limOut CC u = limOut CC u) :
+  (H : Π u, k ;; limOut CC u = limOut CC u) :
   identity _ = k.
 Proof.
 unshelve refine (uniqueExists _ _ (limUnivProp CC _ _) _ _ _ _).
@@ -666,13 +666,13 @@ Defined.
 
 Lemma isColim_weq_subproof1 {g : graph} (D : diagram g C)
   (c : C) (cc : cocone D c) (d : C) (k : C⟦c,d⟧) :
-  ∀ u, coconeIn cc u ;; k = pr1 (Cocone_by_postcompose D c cc d k) u.
+  Π u, coconeIn cc u ;; k = pr1 (Cocone_by_postcompose D c cc d k) u.
 Proof.
 now intro u.
 Qed.
 
 Lemma isColim_weq_subproof2 (g : graph) (D : diagram g C)
-  (c : C) (cc : cocone D c) (H : ∀ d, isweq (Cocone_by_postcompose D c cc d))
+  (c : C) (cc : cocone D c) (H : Π d, isweq (Cocone_by_postcompose D c cc d))
   (d : C) (cd : cocone D d) (u : vertex g) :
     coconeIn cc u ;; invmap (weqpair _ (H d)) cd = coconeIn cd u.
 Proof.
@@ -682,7 +682,7 @@ now rewrite p.
 Qed.
 
 Lemma isColim_weq {g : graph} (D : diagram g C) (c : C) (cc : cocone D c) :
-  isColimCocone D c cc <-> ∀ d, isweq (Cocone_by_postcompose D c cc d).
+  isColimCocone D c cc <-> Π d, isweq (Cocone_by_postcompose D c cc d).
 Proof.
 split.
 - intros H d.
@@ -806,7 +806,7 @@ Defined.
 Lemma LimFunctorCone (A C : precategory) (hsC : has_homsets C)
   (g : graph)
   (D : diagram g [A, C, hsC]^op)
-  (HC : ∀ a : A^op,
+  (HC : Π a : A^op,
             LimCone
               (diagram_pointwise A^op C^op (has_homsets_opp hsC) g
                  (get_diagram A C hsC g D) a))
@@ -840,11 +840,11 @@ use (mk_ColimCocone _ (from_opp_opp_to_opp _ _ _ pr1pr1x)).
   + intro H; destruct H as [f Hf]; apply subtypeEquality.
     * abstract (intro β; repeat (apply impred; intro);
         now apply (has_homsets_opp (functor_category_has_homsets A C hsC))).
-    * match goal with |[ H2 : ∀ _ : ?TT ,  _ = _ ,,_   |- _ ] =>
+    * match goal with |[ H2 : Π _ : ?TT ,  _ = _ ,,_   |- _ ] =>
                        transparent assert (T : TT) end.
       (*
       refine (let T : Σ x : nat_trans pr1pr1x (functor_opp F),
-                         ∀ v, nat_trans_comp (functor_opp (pr1 D v)) _ _
+                         Π v, nat_trans_comp (functor_opp (pr1 D v)) _ _
                                 (pr1pr2pr1x v) x =
                                coconeIn (get_cocone A C hsC g D F ccF) v :=
                   _ in _).
@@ -939,7 +939,7 @@ Defined.
 
 Lemma ColimFunctor_unique (F : [A, C, hsC]) (cc : cocone D F) :
   iscontr (Σ x : [A, C, hsC] ⟦ ColimFunctor, F ⟧,
-            ∀ v : vertex g, colim_nat_trans_in_data v ;; x = coconeIn cc v).
+            Π v : vertex g, colim_nat_trans_in_data v ;; x = coconeIn cc v).
 Proof.
 refine (tpair _ _ _).
 - refine (tpair _ _ _).

--- a/UniMath/CategoryTheory/limits/graphs/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/graphs/pullbacks.v
@@ -57,13 +57,13 @@ Definition isPullback {a b c d : C} (f : C ⟦b, a⟧) (g : C ⟦c, a⟧)
            (p1 : C⟦d,b⟧) (p2 : C⟦d,c⟧) (H : p1 ;; f = p2;; g) : UU :=
     isLimCone (pullback_diagram f g) d (PullbCone f g d p1 p2 H).
 (*
-   forall e (h : e --> b) (k : e --> c)(H : h ;; f = k ;; g ),
+   Π e (h : e --> b) (k : e --> c)(H : h ;; f = k ;; g ),
       iscontr (total2 (fun hk : e --> d => dirprod (hk ;; p1 = h)(hk ;; p2 = k))).
  *)
 
 Definition mk_isPullback {a b c d : C} (f : C ⟦b, a⟧) (g : C ⟦c, a⟧)
            (p1 : C⟦d,b⟧) (p2 : C⟦d,c⟧) (H : p1 ;; f = p2;; g) :
-  (forall e (h : C ⟦e, b⟧) (k : C⟦e,c⟧)(Hk : h ;; f = k ;; g ),
+  (Π e (h : C ⟦e, b⟧) (k : C⟦e,c⟧)(Hk : h ;; f = k ;; g ),
       iscontr (total2 (fun hk : C⟦e,d⟧ => dirprod (hk ;; p1 = h)(hk ;; p2 = k))))
   →
   isPullback f g p1 p2 H.
@@ -136,10 +136,10 @@ Definition Pullback {a b c : C} (f : b --> a)(g : c --> a) :=
         isPullback f g (pr1 (pr2 pfg)) (pr2 (pr2 pfg)) H)).
  *)
 
-Definition Pullbacks := forall (a b c : C)(f : C⟦b, a⟧)(g : C⟦c, a⟧),
+Definition Pullbacks := Π (a b c : C)(f : C⟦b, a⟧)(g : C⟦c, a⟧),
        Pullback f g.
 
-Definition hasPullbacks := forall (a b c : C) (f : C⟦b, a⟧) (g : C⟦c, a⟧),
+Definition hasPullbacks := Π (a b c : C) (f : C⟦b, a⟧) (g : C⟦c, a⟧),
          ishinh (Pullback f g).
 
 

--- a/UniMath/CategoryTheory/limits/graphs/terminal.v
+++ b/UniMath/CategoryTheory/limits/graphs/terminal.v
@@ -34,7 +34,7 @@ Defined.
 Definition isTerminal (a : C) :=
   isLimCone termDiagram a (termCone a).
 
-Definition mk_isTerminal (b : C) (H : ∀ (a : C), iscontr (a --> b)) :
+Definition mk_isTerminal (b : C) (H : Π (a : C), iscontr (a --> b)) :
   isTerminal b.
 Proof.
 intros a ca.

--- a/UniMath/CategoryTheory/limits/graphs/zero.v
+++ b/UniMath/CategoryTheory/limits/graphs/zero.v
@@ -24,8 +24,8 @@ Section def_zero.
   (** Construction of isZero for an object c from the conditions that the space
     of all morphisms from c to any object d is contractible and and the space of
     all morphisms from any object d to c is contractible. *)
-  Definition mk_isZero (c : C) (H : (forall (d : C), iscontr (c --> d))
-                                      × (forall (d : C), iscontr (d --> c))) :
+  Definition mk_isZero (c : C) (H : (Π (d : C), iscontr (c --> d))
+                                      × (Π (d : C), iscontr (d --> c))) :
     isZero c := mk_isInitial c (dirprod_pr1 H),,mk_isTerminal c (dirprod_pr2 H).
 
   (** Definition of Zero. *)

--- a/UniMath/CategoryTheory/limits/initial.v
+++ b/UniMath/CategoryTheory/limits/initial.v
@@ -13,7 +13,7 @@ Section def_initial.
 
 Variable C : precategory.
 
-Definition isInitial (a : C) := forall b : C, iscontr (a --> b).
+Definition isInitial (a : C) := Π b : C, iscontr (a --> b).
 
 Definition Initial := total2 (fun a => isInitial a).
 
@@ -47,7 +47,7 @@ Proof.
   exact H.
 Defined.
 
-Definition mk_isInitial (a : C) (H : ∀ (b : C), iscontr (a --> b)) :
+Definition mk_isInitial (a : C) (H : Π (b : C), iscontr (a --> b)) :
   isInitial a.
 Proof.
   exact H.
@@ -104,7 +104,7 @@ Section Initial_and_EmptyCoprod.
     refine (mk_Initial (CoproductObject _ _ X) _).
     refine (mk_isInitial _ _).
     intros b.
-    assert (H : forall i : empty, C⟦fromempty i, b⟧) by
+    assert (H : Π i : empty, C⟦fromempty i, b⟧) by
         (intros i; apply (fromempty i)).
     apply (iscontrpair (CoproductArrow _ _ X H)); intros t.
     apply CoproductArrowUnique; intros i; apply (fromempty i).
@@ -116,13 +116,13 @@ Section Initial_and_EmptyCoprod.
     Initial C -> CoproductCocone empty C fromempty.
   Proof.
     intros I.
-    assert (H : forall i : empty, C⟦fromempty i, I⟧) by
+    assert (H : Π i : empty, C⟦fromempty i, I⟧) by
         (intros i; apply (fromempty i)).
     refine (mk_CoproductCocone _ _ _ (InitialObject I) H _).
     refine (mk_isCoproductCocone _ _ hs _ _ _ _).
     intros c g.
     set (k := @InitialArrow _ I c).
-    assert (H0 : forall i : empty, H i ;; (InitialArrow I c) = g i) by
+    assert (H0 : Π i : empty, H i ;; (InitialArrow I c) = g i) by
         (intros i; apply (fromempty i)).
     refine (iscontrpair (tpair _ k H0) _). intros t.
     apply (total2_paths (InitialArrowEq C I c _ _)).
@@ -163,7 +163,7 @@ End Initial_and_EmptyCoprod.
 (* apply (mk_Initial c); apply mk_isInitial; intros b. *)
 (* case (iscc _ (initCocone b)); intros f Hf; destruct f as [f fcomm]. *)
 (* apply (tpair _ f); intro g. *)
-(* transparent assert (X : (Σ x : c --> b, ∀ v, *)
+(* transparent assert (X : (Σ x : c --> b, Π v, *)
 (*                        coconeIn cc v ;; x = coconeIn (initCocone b) v)). *)
 (*   { apply (tpair _ g); intro u; induction u. } *)
 (* apply (maponpaths pr1 (Hf X)). *)

--- a/UniMath/CategoryTheory/limits/kernels.v
+++ b/UniMath/CategoryTheory/limits/kernels.v
@@ -36,8 +36,8 @@ Section def_kernels.
     use (mk_Equalizer g (ZeroArrow _ Z y z) f (KernelEqRw H)).
     apply isE.
   Defined.
-  Definition Kernels := forall (y z : C) (g : y --> z), Kernel g.
-  Definition hasKernels := forall (y z : C) (g : y --> z), ishinh (Kernel g).
+  Definition Kernels := Π (y z : C) (g : y --> z), Kernel g.
+  Definition hasKernels := Π (y z : C) (g : y --> z), ishinh (Kernel g).
   Definition KernelOb {y z : C} {g : y --> z} (K : Kernel g) :
     C := EqualizerObject K.
   Coercion KernelOb : Kernel >-> ob.

--- a/UniMath/CategoryTheory/limits/more_on_pullbacks.v
+++ b/UniMath/CategoryTheory/limits/more_on_pullbacks.v
@@ -433,7 +433,7 @@ Definition maps_pb_square_to_pb_square
   isPullback _ _ _ _ H -> isPullback _ _ _ _ (functor_on_square H).
 
 Definition maps_pb_squares_to_pb_squares :=
-   ∀ {a b c d : C}
+   Π {a b c d : C}
      {f : C ⟦b, a⟧} {g : C ⟦c, a⟧} {h : C⟦d, b⟧} {k : C⟦d,c⟧}
      (H : h ;; f = k ;; g),
      maps_pb_square_to_pb_square H.
@@ -466,7 +466,7 @@ Variable Hcomm : c ;; a = d ;; b.
 Arguments mk_Pullback {_ _ _ _ _ _ _ _ _ _ } _ .
 
 Lemma pb_if_pointwise_pb
-  : (∀ x : C, isPullback _ _ _ _ (nat_trans_eq_pointwise Hcomm x)) -> isPullback _ _ _ _ Hcomm.
+  : (Π x : C, isPullback _ _ _ _ (nat_trans_eq_pointwise Hcomm x)) -> isPullback _ _ _ _ Hcomm.
 Proof.
   intro T.
   simple refine (mk_isPullback _ _ _ _ _ _ ).

--- a/UniMath/CategoryTheory/limits/products.v
+++ b/UniMath/CategoryTheory/limits/products.v
@@ -20,87 +20,87 @@ Section product_def.
 
 Variable (I : UU) (C : precategory).
 
-Definition isProductCone (c : forall (i : I), C) (p : C)
-  (pi : forall i, p --> c i) :=
-  forall (a : C) (f : forall i, a --> c i),
-    iscontr (total2 (fun (fap : a --> p) => forall i, fap ;; pi i = f i)).
+Definition isProductCone (c : Π (i : I), C) (p : C)
+  (pi : Π i, p --> c i) :=
+  Π (a : C) (f : Π i, a --> c i),
+    iscontr (total2 (fun (fap : a --> p) => Π i, fap ;; pi i = f i)).
 
-Definition ProductCone (ci : forall i, C) :=
-   total2 (fun pp1p2 : total2 (fun p : C => forall i, p --> ci i) =>
+Definition ProductCone (ci : Π i, C) :=
+   total2 (fun pp1p2 : total2 (fun p : C => Π i, p --> ci i) =>
              isProductCone ci (pr1 pp1p2) (pr2 pp1p2)).
 
-Definition Products := forall (ci : forall i, C), ProductCone ci.
+Definition Products := Π (ci : Π i, C), ProductCone ci.
 Definition hasProducts := ishinh Products.
 
-Definition ProductObject {c : forall i, C} (P : ProductCone c) : C := pr1 (pr1 P).
-Definition ProductPr {c : forall i, C} (P : ProductCone c) : forall i, ProductObject P --> c i :=
+Definition ProductObject {c : Π i, C} (P : ProductCone c) : C := pr1 (pr1 P).
+Definition ProductPr {c : Π i, C} (P : ProductCone c) : Π i, ProductObject P --> c i :=
   pr2 (pr1 P).
 
-Definition isProductCone_ProductCone {c : forall i, C} (P : ProductCone c) :
+Definition isProductCone_ProductCone {c : Π i, C} (P : ProductCone c) :
    isProductCone c (ProductObject P) (ProductPr P).
 Proof.
   exact (pr2 P).
 Defined.
 
-Definition ProductArrow {c : forall i, C} (P : ProductCone c) {a : C} (f : forall i, a --> c i)
+Definition ProductArrow {c : Π i, C} (P : ProductCone c) {a : C} (f : Π i, a --> c i)
   : a --> ProductObject P.
 Proof.
   apply (pr1 (pr1 (isProductCone_ProductCone P _ f))).
 Defined.
 
-Lemma ProductPrCommutes (c : forall i, C) (P : ProductCone c) :
-     forall (a : C) (f : forall i, a --> c i) i, ProductArrow P f ;; ProductPr P i = f i.
+Lemma ProductPrCommutes (c : Π i, C) (P : ProductCone c) :
+     Π (a : C) (f : Π i, a --> c i) i, ProductArrow P f ;; ProductPr P i = f i.
 Proof.
   intros a f i.
   apply (pr2 (pr1 (isProductCone_ProductCone P _ f)) i).
 Qed.
 
-Lemma ProductArrowUnique (c : forall i, C) (P : ProductCone c) (x : C)
-    (f : forall i, x --> c i) (k : x --> ProductObject P)
-    (Hk : forall i, k ;; ProductPr P i = f i) : k = ProductArrow P f.
+Lemma ProductArrowUnique (c : Π i, C) (P : ProductCone c) (x : C)
+    (f : Π i, x --> c i) (k : x --> ProductObject P)
+    (Hk : Π i, k ;; ProductPr P i = f i) : k = ProductArrow P f.
 Proof.
   set (H' := pr2 (isProductCone_ProductCone P _ f) (k,,Hk)).
   apply (base_paths _ _ H').
 Qed.
 
-Definition mk_ProductCone (a : forall i, C) :
-  ∀ (c : C) (f : forall i, C⟦c,a i⟧), isProductCone _ _ f -> ProductCone a.
+Definition mk_ProductCone (a : Π i, C) :
+  Π (c : C) (f : Π i, C⟦c,a i⟧), isProductCone _ _ f -> ProductCone a.
 Proof.
   intros c f X.
   simple refine (tpair _ (c,,f) X).
 Defined.
 
 Definition mk_isProductCone (hsC : has_homsets C) (a : I -> C) (p : C)
-  (pa : forall i, C⟦p,a i⟧) : (∀ (c : C) (f : forall i, C⟦c,a i⟧),
-                                  ∃! k : C⟦c,p⟧, forall i, k ;; pa i = f i) ->
+  (pa : Π i, C⟦p,a i⟧) : (Π (c : C) (f : Π i, C⟦c,a i⟧),
+                                  ∃! k : C⟦c,p⟧, Π i, k ;; pa i = f i) ->
                               isProductCone a p pa.
 Proof.
 intros H c cc; apply H.
 Defined.
 
-Lemma ProductArrowEta (c : forall i, C) (P : ProductCone c) (x : C)
+Lemma ProductArrowEta (c : Π i, C) (P : ProductCone c) (x : C)
     (f : x --> ProductObject P) :
     f = ProductArrow P (fun i => f ;; ProductPr P i).
 Proof.
   now apply ProductArrowUnique.
 Qed.
 
-Definition ProductOfArrows {c : forall i, C} (Pc : ProductCone c) {a : forall i, C}
-    (Pa : ProductCone a) (f : forall i, a i --> c i) :
+Definition ProductOfArrows {c : Π i, C} (Pc : ProductCone c) {a : Π i, C}
+    (Pa : ProductCone a) (f : Π i, a i --> c i) :
       ProductObject Pa --> ProductObject Pc :=
     ProductArrow Pc (fun i => ProductPr Pa i ;; f i).
 
-Lemma ProductOfArrowsPr {c : forall i, C} (Pc : ProductCone c) {a : forall i, C}
-    (Pa : ProductCone a) (f : forall i, a i --> c i) :
-    forall i, ProductOfArrows Pc Pa f ;; ProductPr Pc i = ProductPr Pa i ;; f i.
+Lemma ProductOfArrowsPr {c : Π i, C} (Pc : ProductCone c) {a : Π i, C}
+    (Pa : ProductCone a) (f : Π i, a i --> c i) :
+    Π i, ProductOfArrows Pc Pa f ;; ProductPr Pc i = ProductPr Pa i ;; f i.
 Proof.
   unfold ProductOfArrows; intro i.
   now rewrite (ProductPrCommutes _ _ _ _ i).
 Qed.
 
-Lemma postcompWithProductArrow {c : forall i, C} (Pc : ProductCone c) {a : forall i, C}
-    (Pa : ProductCone a) (f : forall i, a i --> c i)
-    {x : C} (k : forall i, x --> a i) :
+Lemma postcompWithProductArrow {c : Π i, C} (Pc : ProductCone c) {a : Π i, C}
+    (Pa : ProductCone a) (f : Π i, a i --> c i)
+    {x : C} (k : Π i, x --> a i) :
         ProductArrow Pa k ;; ProductOfArrows Pc Pa f =
         ProductArrow Pc (fun i => k i ;; f i).
 Proof.
@@ -108,8 +108,8 @@ apply ProductArrowUnique; intro i.
 now rewrite <- assoc, ProductOfArrowsPr, assoc, ProductPrCommutes.
 Qed.
 
-Lemma precompWithProductArrow {c : forall i, C} (Pc : ProductCone c)
-  {a : C} (f : forall i, a --> c i) {x : C} (k : x --> a)  :
+Lemma precompWithProductArrow {c : Π i, C} (Pc : ProductCone c)
+  {a : C} (f : Π i, a --> c i) {x : C} (k : x --> a)  :
        k ;; ProductArrow Pc f = ProductArrow Pc (fun i => k ;; f i).
 Proof.
 apply ProductArrowUnique; intro i.
@@ -122,8 +122,8 @@ Section Products.
 
 Variables (I : UU) (C : precategory) (CC : Products I C).
 
-Definition ProductOfArrows_comp (a b c : forall (i : I), C)
-  (f : forall i, a i --> b i) (g : forall i, b i --> c i)
+Definition ProductOfArrows_comp (a b c : Π (i : I), C)
+  (f : Π i, a i --> b i) (g : Π i, b i --> c i)
   : ProductOfArrows _ _ _ _ f ;; ProductOfArrows _ _ _ (CC _) g
     = ProductOfArrows _ _ (CC _) (CC _) (fun i => f i ;; g i).
 Proof.
@@ -147,11 +147,11 @@ Section Product_unique.
 
 Variables (I : UU) (C : precategory).
 Variable CC : Products I C.
-Variables a : forall (i : I), C.
+Variables a : Π (i : I), C.
 
 Lemma Product_endo_is_identity (P : ProductCone _ _ a)
   (k : ProductObject _ _ P --> ProductObject _ _ P)
-  (H1 : forall i, k ;; ProductPr _ _ P i = ProductPr _ _ P i)
+  (H1 : Π i, k ;; ProductPr _ _ P i = ProductPr _ _ P i)
   : identity _ = k.
 Proof.
   apply pathsinv0.
@@ -193,6 +193,6 @@ End product_functor.
 (* The product of a family of functors *)
 Definition product_of_functors_alt
   (I : UU) {C D : precategory} (HD : Products I D)
-  (F : forall (i : I), functor C D) : functor C D :=
+  (F : Π (i : I), functor C D) : functor C D :=
    functor_composite (delta_functor I C)
      (functor_composite (pair_functor _ F) (product_functor _ HD)).

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -18,7 +18,7 @@ Variable hs: has_homsets C.
 
 Definition isPullback {a b c d : C} (f : b --> a) (g : c --> a)
         (p1 : d --> b) (p2 : d --> c) (H : p1 ;; f = p2;; g) : UU :=
-   forall e (h : e --> b) (k : e --> c)(H : h ;; f = k ;; g ),
+   Π e (h : e --> b) (k : e --> c)(H : h ;; f = k ;; g ),
       iscontr (total2 (fun hk : e --> d => dirprod (hk ;; p1 = h)(hk ;; p2 = k))).
 
 Lemma isaprop_isPullback {a b c d : C} (f : b --> a) (g : c --> a)
@@ -48,10 +48,10 @@ Definition Pullback {a b c : C} (f : b --> a)(g : c --> a) :=
          total2 (fun H : pr1 (pr2 pfg) ;; f = pr2 (pr2 pfg) ;; g =>
         isPullback f g (pr1 (pr2 pfg)) (pr2 (pr2 pfg)) H)).
 
-Definition Pullbacks := forall (a b c : C)(f : b --> a)(g : c --> a),
+Definition Pullbacks := Π (a b c : C)(f : b --> a)(g : c --> a),
        Pullback f g.
 
-Definition hasPullbacks := forall (a b c : C) (f : b --> a) (g : c --> a),
+Definition hasPullbacks := Π (a b c : C) (f : b --> a) (g : c --> a),
          ishinh (Pullback f g).
 
 
@@ -114,7 +114,7 @@ Defined.
 
 Definition mk_isPullback {a b c d : C} (f : C ⟦b, a⟧) (g : C ⟦c, a⟧)
            (p1 : C⟦d,b⟧) (p2 : C⟦d,c⟧) (H : p1 ;; f = p2;; g) :
-  (forall e (h : C ⟦e, b⟧) (k : C⟦e,c⟧)(Hk : h ;; f = k ;; g ),
+  (Π e (h : C ⟦e, b⟧) (k : C⟦e,c⟧)(Hk : h ;; f = k ;; g ),
       iscontr (total2 (fun hk : C⟦e,d⟧ => dirprod (hk ;; p1 = h)(hk ;; p2 = k))))
   →
   isPullback f g p1 p2 H.

--- a/UniMath/CategoryTheory/limits/pushouts.v
+++ b/UniMath/CategoryTheory/limits/pushouts.v
@@ -18,7 +18,7 @@ Section def_po.
 
   Definition isPushout {a b c d : C} (f : a --> b) (g : a --> c)
              (in1 : b --> d) (in2 : c --> d) (H : f ;; in1 = g ;; in2) : UU :=
-    forall e (h : b --> e) (k : c --> e)(H : f ;; h = g ;; k),
+    Π e (h : b --> e) (k : c --> e)(H : f ;; h = g ;; k),
       iscontr (total2 (fun hk : d --> e => dirprod (in1 ;; hk = h) (in2 ;; hk = k))).
 
   Lemma isaprop_isPushout {a b c d : C} (f : a --> b) (g : a --> c)
@@ -48,10 +48,10 @@ Section def_po.
               total2 (fun H : f ;; pr1 (pr2 pfg) = g ;; pr2 (pr2 pfg) =>
                         isPushout f g (pr1 (pr2 pfg)) (pr2 (pr2 pfg)) H)).
 
-  Definition Pushouts := forall (a b c : C) (f : a --> b) (g : a --> c),
+  Definition Pushouts := Π (a b c : C) (f : a --> b) (g : a --> c),
       Pushout f g.
 
-  Definition hasPushouts := forall (a b c : C) (f : a --> b) (g : a --> c),
+  Definition hasPushouts := Π (a b c : C) (f : a --> b) (g : a --> c),
       ishinh (Pushout f g).
 
 
@@ -117,7 +117,7 @@ Section def_po.
 
   Definition mk_isPushout {a b c d : C} (f : C ⟦a, b⟧) (g : C ⟦a, c⟧)
              (in1 : C⟦b,d⟧) (in2 : C⟦c,d⟧) (H : f ;; in1 = g ;; in2) :
-    (forall e (h : C ⟦b, e⟧) (k : C⟦c,e⟧)(Hk : f ;; h = g ;; k),
+    (Π e (h : C ⟦b, e⟧) (k : C⟦c,e⟧)(Hk : f ;; h = g ;; k),
         iscontr (total2 (fun hk : C⟦d,e⟧ =>
                            dirprod (in1 ;; hk = h)(in2 ;; hk = k))))
     →

--- a/UniMath/CategoryTheory/limits/terminal.v
+++ b/UniMath/CategoryTheory/limits/terminal.v
@@ -13,7 +13,7 @@ Section def_terminal.
 
 Variable C : precategory.
 
-Definition isTerminal (b : C) := forall a : C, iscontr (a --> b).
+Definition isTerminal (b : C) := Π a : C, iscontr (a --> b).
 
 Definition Terminal := total2 (fun a => isTerminal a).
 
@@ -25,7 +25,7 @@ Proof.
   exists b; exact H.
 Defined.
 
-Definition mk_isTerminal (b : C) (H : ∀ (a : C), iscontr (a --> b)) :
+Definition mk_isTerminal (b : C) (H : Π (a : C), iscontr (a --> b)) :
   isTerminal b.
 Proof.
   exact H.
@@ -106,7 +106,7 @@ Section Terminal_and_EmptyProd.
     refine (mk_Terminal (ProductObject _ C X) _).
     refine (mk_isTerminal _ _).
     intros a.
-    assert (H : forall i : empty, C⟦a, fromempty i⟧) by
+    assert (H : Π i : empty, C⟦a, fromempty i⟧) by
         (intros i; apply (fromempty i)).
     apply (iscontrpair (ProductArrow _ _ X H)); intros t.
     apply ProductArrowUnique; intros i; apply (fromempty i).
@@ -118,13 +118,13 @@ Section Terminal_and_EmptyProd.
     Terminal C ->  ProductCone empty C fromempty.
   Proof.
     intros T.
-    assert (H : forall i : empty, C⟦T, fromempty i⟧) by
+    assert (H : Π i : empty, C⟦T, fromempty i⟧) by
         (intros i; apply (fromempty i)).
     refine (mk_ProductCone _ _ _ T H _).
     refine (mk_isProductCone _ _ hs _ _ _ _).
     intros c f.
     set (k := @TerminalArrow _ T c).
-    assert (H0 : forall i : empty, (TerminalArrow c) ;; H i = f i) by
+    assert (H0 : Π i : empty, (TerminalArrow c) ;; H i = f i) by
         (intros i; apply (fromempty i)).
 
     refine (iscontrpair (tpair _ k H0) _). intros t.
@@ -171,7 +171,7 @@ End Terminal_and_EmptyProd.
 (* case (iscc _ (termCone b)); intros f Hf; destruct f as [f fcomm]. *)
 (* apply (tpair _ f); intro g. *)
 (* simple refine (let X : Σ x : b --> c, *)
-(*                        ∀ v, coconeIn cc v ;; x = coconeIn (termCone b) v := _ in _). *)
+(*                        Π v, coconeIn cc v ;; x = coconeIn (termCone b) v := _ in _). *)
 (*   { apply (tpair _ g); intro u; induction u. } *)
 (* apply (maponpaths pr1 (Hf X)). *)
 (* Defined. *)

--- a/UniMath/CategoryTheory/limits/zero.v
+++ b/UniMath/CategoryTheory/limits/zero.v
@@ -16,7 +16,7 @@ Section def_zero.
   Variable C : precategory.
 
   Definition isZero (b : C) :=
-    (∀ a : C, iscontr (b --> a)) × (∀ a : C, iscontr (a --> b)).
+    (Π a : C, iscontr (b --> a)) × (Π a : C, iscontr (a --> b)).
 
   Definition Zero := total2 (fun a => isZero a).
 
@@ -28,8 +28,8 @@ Section def_zero.
     exists b; exact H.
   Defined.
 
-  Definition mk_isZero (b : C) (H : forall (a : C), iscontr (b --> a))
-             (H' : forall (a : C), iscontr (a --> b)) : isZero b.
+  Definition mk_isZero (b : C) (H : Π (a : C), iscontr (b --> a))
+             (H' : Π (a : C), iscontr (a --> b)) : isZero b.
   Proof.
     unfold isZero.  exact ((H,,H')).
   Defined.

--- a/UniMath/CategoryTheory/lists.v
+++ b/UniMath/CategoryTheory/lists.v
@@ -112,9 +112,9 @@ Transparent foldr_map.
 (* This defines the induction principle for lists using foldr *)
 Section list_induction.
 
-Variables (P : pr1 List -> UU) (PhSet : forall l, isaset (P l)).
+Variables (P : pr1 List -> UU) (PhSet : Π l, isaset (P l)).
 Variables (P0 : P nil)
-          (Pc : forall (a : pr1 A) (l : pr1 List), P l -> P (cons (a,,l))).
+          (Pc : Π (a : pr1 A) (l : pr1 List), P l -> P (cons (a,,l))).
 
 Let P' : UU := Σ l, P l.
 Let P0' : P' := (nil,, P0).
@@ -159,8 +159,8 @@ Defined.
 
 End list_induction.
 
-Lemma listIndProp (P : pr1 List -> UU) (HP : forall l, isaprop (P l)) :
-  P nil -> (forall a l, P l → P (cons (a,, l))) -> forall l, P l.
+Lemma listIndProp (P : pr1 List -> UU) (HP : Π l, isaprop (P l)) :
+  P nil -> (Π a l, P l → P (cons (a,, l))) -> Π l, P l.
 Proof.
 intros Pnil Pcons.
 apply listInd; try assumption.
@@ -183,7 +183,7 @@ Definition length : pr1 List -> nat :=
 Definition map (f : pr1 A -> pr1 A) : pr1 List -> pr1 List :=
   foldr _ nil (λ xxs : pr1 A × pr1 List, cons (f (pr1 xxs),, pr2 xxs)).
 
-Lemma length_map (f : pr1 A -> pr1 A) : forall xs, length (map f xs) = length xs.
+Lemma length_map (f : pr1 A -> pr1 A) : Π xs, length (map f xs) = length xs.
 Proof.
 apply listIndProp.
 - intros l; apply isasetnat.
@@ -218,7 +218,7 @@ Definition sum : pr1 (List natHSET) -> nat :=
 (* Eval vm_compute in sum testlist. *)
 (* Eval vm_compute in sum testlistS. *)
 
-Goal (forall l, length _ (2 :: l) = S (length _ l)).
+Goal (Π l, length _ (2 :: l) = S (length _ l)).
 simpl.
 intro l.
 try apply idpath. (* this doesn't work *)
@@ -233,7 +233,7 @@ Abort.
 
 (* Eval compute in const 0 (nil natHSET). *)
 
-(* Axiom const' : forall {A B : UU}, A -> B -> A. *)
+(* Axiom const' : Π {A B : UU}, A -> B -> A. *)
 
 (* Eval compute in const' 0 1. *)
 (* Eval compute in const' 0 (nil natHSET). *)
@@ -263,10 +263,10 @@ Definition nil_list (A : UU) : list A := (0,,tt).
 Definition cons_list (A : UU) (x : A) (xs : list A) : list A :=
   (S (pr1 xs),, (x,, pr2 xs)).
 
-Lemma list_ind : ∀ (A : Type) (P : list A -> UU),
+Lemma list_ind : Π (A : Type) (P : list A -> UU),
     P (nil_list A)
-  -> (∀ (x : A) (xs : list A), P xs -> P (cons_list A x xs))
-  -> ∀ xs, P xs.
+  -> (Π (x : A) (xs : list A), P xs -> P (cons_list A x xs))
+  -> Π xs, P xs.
 Proof.
 intros A P Hnil Hcons xs.
 destruct xs as [n xs].
@@ -332,7 +332,7 @@ apply (foldr A (list (pr1 A),,isaset_list A)).
   apply (tpair _ (S (pr1 (pr2 L))) (pr1 L,,pr2 (pr2 L))).
 Defined.
 
-Lemma to_listK (A : HSET) : ∀ x : list (pr1 A), to_list A (to_List A x) = x.
+Lemma to_listK (A : HSET) : Π x : list (pr1 A), to_list A (to_List A x) = x.
 Proof.
 intro l; destruct l as [n l]; unfold to_list, to_List.
 induction n; simpl.
@@ -344,7 +344,7 @@ induction n; simpl.
   apply idpath.
 Qed.
 
-Lemma to_ListK (A : HSET) : ∀ y : pr1 (List A), to_List A (to_list A y) = y.
+Lemma to_ListK (A : HSET) : Π y : pr1 (List A), to_List A (to_list A y) = y.
 Proof.
 apply listIndProp.
 * intro l; apply setproperty.
@@ -472,7 +472,7 @@ simple refine (tpair _ _ _).
   | destruct t; destruct ccL; unfold BinCoproduct_of_functors_mor in *; destruct t0; simpl;
     apply BinCoproductArrowUnique;
     [ now rewrite <- (p 0), assoc, BinCoproductOfArrowsIn1, id_left
-    | simple refine (let temp : Σ x0 : C ⟦ c, HcL ⟧, ∀ v : nat,
+    | simple refine (let temp : Σ x0 : C ⟦ c, HcL ⟧, Π v : nat,
          coconeIn L v ;; x0 = BinCoproductIn2 C (PC x (dob hF v)) ;; f v := _ in _);
          [ apply (tpair _ (BinCoproductIn2 C (PC x c) ;; t));
           now intro n; rewrite <- (p n), !assoc, BinCoproductOfArrowsIn2|];
@@ -586,9 +586,9 @@ Transparent foldr_map.
 (* This defines the induction principle for lists using foldr *)
 Section list_induction.
 
-Variables (P : pr1 List -> UU) (PhSet : forall l, isaset (P l)).
+Variables (P : pr1 List -> UU) (PhSet : Π l, isaset (P l)).
 Variables (P0 : P nil)
-          (Pc : forall (a : pr1 A) (l : pr1 List), P l -> P (cons (a,,l))).
+          (Pc : Π (a : pr1 A) (l : pr1 List), P l -> P (cons (a,,l))).
 
 Let P' : UU := Σ l, P l.
 Let P0' : P' := (nil,, P0).
@@ -628,8 +628,8 @@ Defined.
 
 End list_induction.
 
-Lemma listIndProp (P : pr1 List -> UU) (HP : forall l, isaprop (P l)) :
-  P nil -> (forall a l, P l → P (cons (a,, l))) -> forall l, P l.
+Lemma listIndProp (P : pr1 List -> UU) (HP : Π l, isaprop (P l)) :
+  P nil -> (Π a l, P l → P (cons (a,, l))) -> Π l, P l.
 Proof.
 intros Pnil Pcons.
 apply listInd; try assumption.
@@ -648,7 +648,7 @@ Definition length : pr1 List -> nat :=
 Definition map (f : pr1 A -> pr1 A) : pr1 List -> pr1 List :=
   foldr _ nil (λ xxs : pr1 A × pr1 List, cons (f (pr1 xxs),, pr2 xxs)).
 
-Lemma length_map (f : pr1 A -> pr1 A) : forall xs, length (map f xs) = length xs.
+Lemma length_map (f : pr1 A -> pr1 A) : Π xs, length (map f xs) = length xs.
 Proof.
 apply listIndProp.
 - intros l; apply isasetnat.
@@ -695,7 +695,7 @@ Definition sum : pr1 (List natHSET) -> nat :=
 (* native_compute. *)
 (* Abort. *)
 
-Goal (forall l, length _ (2 :: l) = S (length _ l)).
+Goal (Π l, length _ (2 :: l) = S (length _ l)).
 simpl.
 intro l.
 try apply idpath. (* this doesn't work *)

--- a/UniMath/CategoryTheory/opp_precat.v
+++ b/UniMath/CategoryTheory/opp_precat.v
@@ -62,7 +62,7 @@ Proof. intros a b; apply hsC. Qed.
 
 Definition functor_opp_data {C D : precategory} (F : functor C D) :
   functor_data C^op D^op :=
-    tpair (fun F : C^op -> D^op => forall a b, C^op ⟦a, b⟧ -> D^op ⟦F a, F b⟧) F
+    tpair (fun F : C^op -> D^op => Π a b, C^op ⟦a, b⟧ -> D^op ⟦F a, F b⟧) F
           (fun (a b : C) (f : C⟦b, a⟧) => functor_on_morphisms F f).
 
 Lemma is_functor_functor_opp {C D : precategory} (F : functor C D) :

--- a/UniMath/CategoryTheory/precategories.v
+++ b/UniMath/CategoryTheory/precategories.v
@@ -70,15 +70,15 @@ Local Notation "a --> b" := (precategory_morphisms a b)(at level 50).
 *)
 
 Definition precategory_id_comp (C : precategory_ob_mor) :=
-     dirprod (forall c : C, c --> c) (* identities *)
-             (forall a b c : C,
+     dirprod (Π c : C, c --> c) (* identities *)
+             (Π a b c : C,
                  a --> b -> b --> c -> a --> c).
 
 Definition precategory_data := total2 precategory_id_comp.
 
 Definition precategory_data_pair (C : precategory_ob_mor)
-    (id : forall c : C, c --> c)
-    (comp: forall a b c : C,
+    (id : Π c : C, c --> c)
+    (comp: Π a b c : C,
          a --> b -> b --> c -> a --> c) : precategory_data :=
    tpair _ C (dirprodpair id comp).
 
@@ -88,7 +88,7 @@ Coercion precategory_ob_mor_from_precategory_data :
   precategory_data >-> precategory_ob_mor.
 
 Definition identity { C : precategory_data } :
-    forall c : C, c --> c :=
+    Π c : C, c --> c :=
          pr1 (pr2 C).
 
 Definition compose { C : precategory_data }
@@ -105,15 +105,15 @@ Local Notation "f ;; g" := (compose f g) (at level 50, format "f  ;;  g").
 *)
 
 Definition is_precategory (C : precategory_data) :=
-   dirprod (dirprod (forall (a b : C) (f : a --> b),
+   dirprod (dirprod (Π (a b : C) (f : a --> b),
                          identity a ;; f = f)
-                     (forall (a b : C) (f : a --> b),
+                     (Π (a b : C) (f : a --> b),
                          f ;; identity b = f))
-            (forall (a b c d : C)
+            (Π (a b c d : C)
                     (f : a --> b)(g : b --> c) (h : c --> d),
                      f ;; (g ;; h) = (f ;; g) ;; h).
 (*
-Definition is_hs_precategory_data (C : precategory_data) := forall (a b : C), isaset (a --> b).
+Definition is_hs_precategory_data (C : precategory_data) := Π (a b : C), isaset (a --> b).
 *)
 (*
 Definition hs_precategory_data := total2 is_hs_precategory_data.
@@ -126,7 +126,7 @@ Coercion precategory_data_from_hs_precategory_data : hs_precategory_data >-> pre
 Definition precategory := total2 is_precategory.
 
 Definition hs_precategory := total2 (fun C : precategory_data =>
-  dirprod (is_precategory C) (forall a b : C, isaset (a --> b))).
+  dirprod (is_precategory C) (Π a b : C, isaset (a --> b))).
 
 Definition precategory_data_from_precategory (C : precategory) :
        precategory_data := pr1 C.
@@ -140,7 +140,7 @@ Definition precategory_from_hs_precategory (C : hs_precategory) : precategory :=
   tpair _ (pr1 C) (pr1 (pr2 C)).
 Coercion precategory_from_hs_precategory : hs_precategory >-> precategory.
 
-Definition has_homsets (C : precategory_ob_mor) := forall a b : C, isaset (a --> b).
+Definition has_homsets (C : precategory_ob_mor) := Π a b : C, isaset (a --> b).
 
 Lemma isaprop_has_homsets (C : precategory_ob_mor) : isaprop (has_homsets C).
 Proof.
@@ -159,15 +159,15 @@ Qed.
 
 
 Definition id_left (C : precategory) :
-   forall (a b : C) (f : a --> b),
+   Π (a b : C) (f : a --> b),
            identity a ;; f = f := pr1 (pr1 (pr2 C)).
 
 Definition id_right (C : precategory) :
-   forall (a b : C) (f : a --> b),
+   Π (a b : C) (f : a --> b),
            f ;; identity b = f := pr2 (pr1 (pr2 C)).
 
 Definition assoc (C : precategory) :
-   forall (a b c d : C)
+   Π (a b c d : C)
           (f : a --> b)(g : b --> c) (h : c --> d),
                      f ;; (g ;; h) = (f ;; g) ;; h := pr2 (pr2 C).
 
@@ -267,7 +267,7 @@ Definition precomp_with {C : precategory_data} {a b : C} (f : a --> b) {c} (g : 
    f ;; g.
 
 Definition is_iso {C : precategory_data} {a b : C} (f : a --> b) :=
-  forall c, isweq (precomp_with f (c:=c)).
+  Π c, isweq (precomp_with f (c:=c)).
 
 Definition is_isomorphism {C: precategory_data}{a b : C} (f : a --> b) := is_iso f.
 
@@ -417,7 +417,7 @@ Qed.
 (** Stability under composition, inverses etc *)
 
 Definition isweqhomot' {X Y} (f g : X -> Y) (H : isweq f)
-      (homot : forall x, f x = g x) : isweq g.
+      (homot : Π x, f x = g x) : isweq g.
 Proof.
   apply (isweqhomot f g homot H).
 Defined.
@@ -911,7 +911,7 @@ Defined.
 
 (* use eta expanded version to force printing of object arguments *)
 Definition is_category (C : precategory) :=
-  dirprod (forall (a b : ob C), isweq (fun p : a = b => idtoiso p))
+  dirprod (Π (a b : ob C), isweq (fun p : a = b => idtoiso p))
           (has_homsets C).
 
 Lemma eq_idtoiso_idtomor {C:precategory} (a b:ob C) (e:a = b) :
@@ -943,7 +943,7 @@ Coercion precat_from_cat : category >-> precategory.
 Lemma category_has_groupoid_ob (C : category): isofhlevel 3 (ob C).
 Proof.
   change (isofhlevel 3 C) with
-        (forall a b : C, isofhlevel 2 (a = b)).
+        (Π a b : C, isofhlevel 2 (a = b)).
   intros a b.
   apply (isofhlevelweqb _ (tpair _ _ (pr1 (pr2 C) a b))).
   apply isaset_iso.
@@ -1115,8 +1115,8 @@ Proof.
 Qed.
 
 Lemma transportf_isotoid_dep (C : precategory)
-   (a a' : C) (p : a = a') (f : forall c, a --> c) :
- transportf (fun x : C => forall c, x --> c) p f = fun c => idtoiso (!p) ;; f c.
+   (a a' : C) (p : a = a') (f : Π c, a --> c) :
+ transportf (fun x : C => Π c, x --> c) p f = fun c => idtoiso (!p) ;; f c.
 Proof.
   destruct p.
   simpl.
@@ -1128,8 +1128,8 @@ Qed.
 
 Lemma transportf_isotoid_dep' (J C : precategory)
   (F : J -> C)
-   (a a' : C) (p : a = a') (f : forall c, a --> F c) :
- transportf (fun x : C => forall c, x --> F c) p f = fun c => idtoiso (!p) ;; f c.
+   (a a' : C) (p : a = a') (f : Π c, a --> F c) :
+ transportf (fun x : C => Π c, x --> F c) p f = fun c => idtoiso (!p) ;; f c.
 Proof.
   destruct p.
   apply funextsec.
@@ -1176,7 +1176,7 @@ Definition precategory_total_id (C : precategory_data) :
       fun c => tpair _ (dirprodpair c c) (identity c).
 
 Definition precategory_total_comp'' (C : precategory_data) :
-      forall f g : total_morphisms C,
+      Π f g : total_morphisms C,
         precategory_target C f = precategory_source C g ->
          total_morphisms C.
 Proof.
@@ -1191,7 +1191,7 @@ Proof.
 Defined.
 
 Definition precategory_total_comp (C : precategory_data) :
-      forall f g : total_morphisms C,
+      Π f g : total_morphisms C,
         precategory_target C f = precategory_source C g ->
          total_morphisms C :=
   fun f g e =>

--- a/UniMath/CategoryTheory/precomp_ess_surj.v
+++ b/UniMath/CategoryTheory/precomp_ess_surj.v
@@ -81,10 +81,10 @@ Section preimage.
 Local Definition X (b : B) := total2 (
  fun ck :
   total2 (fun c : C =>
-                forall a : A,
+                Π a : A,
                      iso (H a) b -> iso (F a) c) =>
-    forall t t' : total2 (fun a : A => iso (H a) b),
-          forall f : pr1 t --> pr1 t',
+    Π t t' : total2 (fun a : A => iso (H a) b),
+          Π f : pr1 t --> pr1 t',
              (#H f ;; pr2 t' = pr2 t ->
                     #F f ;; pr2 ck (pr1 t') (pr2 t') = pr2 ck (pr1 t) (pr2 t))).
 
@@ -93,7 +93,7 @@ Local Definition kX {b : B} (t : X b) := (pr2 (pr1 t)).
 (** The following is the third component of the center of [X b] *)
 
 Lemma X_aux_type_center_of_contr_proof (b : B) (anot : A) (hnot : iso (H anot) b) :
-  forall (t t' : total2 (fun a :  A => iso (H a) b))
+  Π (t t' : total2 (fun a :  A => iso (H a) b))
     (f : pr1 t --> pr1 t'),
   #H f;; pr2 t' = pr2 t ->
   #F f;;
@@ -137,7 +137,7 @@ Defined.
 (** Any inhabitant of [X b] is equal to the center of [X b]. *)
 
 Lemma X_aux_type_contr_eq (b : B) (anot : A) (hnot : iso (H anot) b) :
-   forall t : X b, t = X_aux_type_center_of_contr b anot hnot.
+   Π t : X b, t = X_aux_type_center_of_contr b anot hnot.
 Proof.
   intro t.
   assert (Hpr1 : pr1 (X_aux_type_center_of_contr b anot hnot) = pr1 t).
@@ -186,7 +186,7 @@ Qed.
 
 (** Putting everything together: [X b] is contractible. *)
 
-Definition iscontr_X : forall b : B, iscontr (X b).
+Definition iscontr_X : Π b : B, iscontr (X b).
 Proof.
   intro b.
   assert (HH : isaprop (iscontr (X b))).
@@ -206,7 +206,7 @@ Definition Go : B -> C :=
    fun b : B => pr1 (pr1 (pr1 (iscontr_X b))).
 
 Local Definition k (b : B) :
-     forall a : A, iso (H a) b -> iso (F a) (Go b) :=
+     Π a : A, iso (H a) b -> iso (F a) (Go b) :=
               pr2 (pr1 (pr1 (iscontr_X b))).
 
 Local Definition q (b : B) := pr2 (pr1 (iscontr_X b)).
@@ -224,7 +224,7 @@ Defined.
        modulo transport along [Xphi b t]. *)
 
 Definition Xkphi_transp (b : B) (t : X b) :
-     forall a : A, forall h : iso (H a) b,
+     Π a : A, Π h : iso (H a) b,
   transportf _ (Xphi b t) (kX t) a h =  k b a h.
 Proof.
   unfold k.
@@ -237,7 +237,7 @@ Qed.
     as [k b], modulo postcomposition with an isomorphism. *)
 
 Definition Xkphi_idtoiso (b : B) (t : X b) :
-    forall a : A, forall h : iso (H a) b,
+    Π a : A, Π h : iso (H a) b,
    k b a h ;; idtoiso (!Xphi b t) = kX t a h.
 Proof.
   intros a h.
@@ -251,7 +251,7 @@ Qed.
 (*
 Lemma k_transport (b : ob B) (*t : X b*) (c : ob C)
    (p : pr1 (pr1 t) = c) (a : ob A) (h : iso (pr1 H a) b):
-transportf (fun c' : ob C => forall a : ob A, iso (pr1 H a) b ->
+transportf (fun c' : ob C => Π a : ob A, iso (pr1 H a) b ->
                           iso ((pr1 F) a) c')
    p (k) a h = (k b) b a h ;; idtoiso p .
 *)
@@ -264,16 +264,16 @@ transportf (fun c' : ob C => forall a : ob A, iso (pr1 H a) b ->
 
 Local Definition Y {b b' : B} (f : b --> b') :=
   total2 (fun g : Go b --> Go b' =>
-      forall a : A,
-        forall h : iso (H a) b,
-          forall a' : A,
-            forall h' : iso (H a') b',
-              forall l : a --> a',
+      Π a : A,
+        Π h : iso (H a) b,
+          Π a' : A,
+            Π h' : iso (H a') b',
+              Π l : a --> a',
                 #H l ;; h' = h ;; f -> #F l ;; k b' a' h' = k b a h ;; g).
 
 Lemma Y_inhab_proof (b b' : B) (f : b --> b') (a0 : A) (h0 : iso (H a0) b)
     (a0' : A) (h0' : iso (H a0') b') :
-  forall (a : A) (h : iso (H a) b) (a' : A) (h' : iso (H a') b')
+  Π (a : A) (h : iso (H a) b) (a' : A) (h' : iso (H a') b')
     (l : a --> a'),
   #H l;; h' = h;; f ->
   #F l;; k b' a' h' =
@@ -371,7 +371,7 @@ Defined.
 Lemma Y_contr_eq (b b' : B) (f : b --> b')
      (a0 : A) (h0 : iso (H a0) b)
      (a0' : A) (h0' : iso (H a0') b') :
-  forall t : Y f, t = Y_inhab b b' f a0 h0 a0' h0'.
+  Π t : Y f, t = Y_inhab b b' f a0 h0 a0' h0'.
 Proof.
   intro t.
   apply pathsinv0.
@@ -430,7 +430,7 @@ Proof.
   split. unfold functor_idax. simpl.
   intro b.
 
-  assert (PR2 : forall (a : A) (h : iso (H a) b) (a' : A)
+  assert (PR2 : Π (a : A) (h : iso (H a) b) (a' : A)
           (h' : iso (H a') b)
     (l : a --> a'),
   #H l;; h' = h;; identity b ->
@@ -487,7 +487,7 @@ Proof.
     repeat rewrite assoc; apply idpath.
 
 
-  assert (PR2 : forall (a : A) (h : iso (H a) b)(a' : A)
+  assert (PR2 : Π (a : A) (h : iso (H a) b)(a' : A)
           (h' : iso (H a') b') (l : a --> a'),
            #H l;; h' = h;; f ->
            #F l;; k b' a' h' =
@@ -577,7 +577,7 @@ Proof.
     apply idpath.
 
   clear PR2.
-  assert (PR2 : forall (a : A) (h : iso (H a) b') (a' : A)
+  assert (PR2 : Π (a : A) (h : iso (H a) b') (a' : A)
             (h' : iso (H a') b'') (l : a --> a'),
          #H l;; h' = h;; f' ->
            #F l;; k b'' a' h' =
@@ -654,7 +654,7 @@ Proof.
     apply idpath.
 
   clear PR2.
-  assert (PR2 : forall (a : A) (h : iso (H a) b) (a' : A)
+  assert (PR2 : Π (a : A) (h : iso (H a) b) (a' : A)
              (h' : iso (H a') b'') (l : a --> a'),
           #H l;; h' = h;; (f;; f') ->
           #F l;; k b'' a' h' =
@@ -755,7 +755,7 @@ Definition GG : [B, C, pr2 Ccat] := tpair _ preimage_functor_data
    This allows to prove [G (H a) = F a]. *)
 
 Lemma qF (a0 : A) :
-  forall (t t' : total2 (fun a :  A => iso (H a) (H a0)))
+  Π (t t' : total2 (fun a :  A => iso (H a) (H a0)))
     (f : pr1 t --> pr1 t'),
   #H f;; pr2 t' = pr2 t ->
   #F f;; #F (fH^-1 (pr2 t')) =
@@ -775,7 +775,7 @@ Proof.
 Qed.
 
 
-Definition kFa (a0 : A) : forall a : A,
+Definition kFa (a0 : A) : Π a : A,
   iso (H a) (H a0) -> iso (F a) (F a0) :=
  fun (a : A) (h : iso (H a) (H a0)) =>
    functor_on_iso F
@@ -813,7 +813,7 @@ Proof.
   rewrite <- idtoiso_precompose.
   rewrite idtoiso_inv.
   rewrite <- assoc.
-  assert (PSIf : forall (a : A) (h : iso (H a) (H a0)) (a' : A)
+  assert (PSIf : Π (a : A) (h : iso (H a) (H a0)) (a' : A)
   (h' : iso (H a') (H a0')) (l : a --> a'),
          #H l;; h' = h;; #H f ->
          #F l;; k (H a0') a' h' =

--- a/UniMath/CategoryTheory/precomp_fully_faithful.v
+++ b/UniMath/CategoryTheory/precomp_fully_faithful.v
@@ -113,7 +113,7 @@ Variable gamma : nat_trans
 
 Lemma isaprop_aux_space (b : B) :
     isaprop (total2 (fun g : F b --> G b =>
-      forall a : A, forall f : iso (H a) b,
+      Π a : A, Π f : iso (H a) b,
            gamma a = #F f ;; g ;; #G (inv_from_iso f))).
 Proof.
   apply invproofirrelevance.
@@ -176,18 +176,18 @@ Qed.
 
 Lemma iscontr_aux_space (b : B) :
    iscontr (total2 (fun g : F b --> G b =>
-      forall a : A, forall f : iso (H a) b,
+      Π a : A, Π f : iso (H a) b,
            gamma a = #F f ;; g ;; #G (inv_from_iso f)  )).
 Proof.
   set (X := isapropiscontr (total2
      (fun g : F b --> G b =>
-      forall (a : A) (f : iso (H a) b),
+      Π (a : A) (f : iso (H a) b),
       gamma a = (#F f;; g);; #G (inv_from_iso f)))).
   apply (p b (tpair (fun x => isaprop x) _ X)).
   intros [anot h].
   simpl in *.
   set (g := #F (inv_from_iso h) ;; gamma anot ;; #G h).
-  assert (gp : forall (a : A)
+  assert (gp : Π (a : A)
                      (f : iso (H a) b),
                  gamma a = #F f ;; g ;; #G (inv_from_iso f)).
     clear X.
@@ -221,7 +221,7 @@ Proof.
 Defined.
 
 
-Definition pdelta : forall b : B, F b --> G b :=
+Definition pdelta : Π b : B, F b --> G b :=
          fun b => pr1 (pr1 (iscontr_aux_space b)).
 
 Lemma is_nat_trans_pdelta :

--- a/UniMath/CategoryTheory/rezk_completion.v
+++ b/UniMath/CategoryTheory/rezk_completion.v
@@ -79,7 +79,7 @@ Coercion target_category (C : precategory) (X : functor_from C) : category := pr
 Definition func_functor_from {C : precategory} (X : functor_from C) : functor C X := pr2 X.
 
 Definition is_initial_functor_from (C : precategory) (X : functor_from C) : UU
-  := ∀ X' : functor_from C,
+  := Π X' : functor_from C,
      ∃! H : functor X X',
        functor_composite (func_functor_from X) H = func_functor_from X'.
 
@@ -161,7 +161,7 @@ Defined.
 
 Definition Rezk_completion_endo_is_identity (D : functor_from A)
            (DH : is_initial_functor_from A D)
-  : ∀ X : functor D D, functor_composite (func_functor_from D) X = func_functor_from D
+  : Π X : functor D D, functor_composite (func_functor_from D) X = func_functor_from D
         ->
         X = functor_identity D.
 Proof.

--- a/UniMath/CategoryTheory/slicecat.v
+++ b/UniMath/CategoryTheory/slicecat.v
@@ -233,7 +233,7 @@ Lemma slicecat_functor_subproof (af bg : C / x) (h : af --> bg) :
 Proof. rewrite assoc, (pr2 h); apply idpath. Qed.
 
 Definition slicecat_functor_data : functor_data (C / x) (C / y) :=
-  tpair (fun F => forall a b, a --> b -> F a --> F b)
+  tpair (fun F => Π a b, a --> b -> F a --> F b)
         slicecat_functor_ob
         (fun a b h => tpair _ (pr1 h) (slicecat_functor_subproof _ _ h)).
 
@@ -319,7 +319,7 @@ assert (H1 : transportf (fun x : C / z => pr1 x --> b)
                  (fun p => tpair _ a p = tpair _ a _) (idpath (tpair _ a _))
                  (assoc C a x y z fax f g)) h = h).
   case (assoc C a x y z fax f g); apply idpath.
-assert (H2 : forall h', h' = h ->
+assert (H2 : Π h', h' = h ->
              transportf (fun x : C / z => a --> pr1 x)
                         (Basics.PartA.internal_paths_rew_r _ _ _
                            (fun p => tpair _ b p = tpair _ b _) (idpath _)

--- a/UniMath/CategoryTheory/sub_precategories.v
+++ b/UniMath/CategoryTheory/sub_precategories.v
@@ -58,14 +58,14 @@ Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
 Definition is_sub_precategory {C : precategory}
     (C' : hsubtypes C)
-    (Cmor' : forall a b : C, hsubtypes (a --> b)) :=
- dirprod (forall a : C, C' a ->  Cmor' _ _ (identity a ))
-         (forall (a b c : C) (f: a --> b) (g : b --> c),
+    (Cmor' : Π a b : C, hsubtypes (a --> b)) :=
+ dirprod (Π a : C, C' a ->  Cmor' _ _ (identity a ))
+         (Π (a b c : C) (f: a --> b) (g : b --> c),
                    Cmor' _ _ f -> Cmor' _ _  g -> Cmor' _ _  (f ;; g)).
 
 Definition sub_precategories (C : precategory) := total2 (
    fun C' : dirprod (hsubtypes (ob C))
-                    (forall a b:ob C, hsubtypes (a --> b)) =>
+                    (Π a b:ob C, hsubtypes (a --> b)) =>
         is_sub_precategory (pr1 C') (pr2 C')).
 
 (** A full subcategory has the true predicate on morphisms *)
@@ -110,13 +110,13 @@ Definition sub_precategory_morphisms {C : precategory}(C':sub_precategories C)
 *)
 
 Definition sub_precategory_id (C : precategory)(C':sub_precategories C) :
-   forall a : ob C,
+   Π a : ob C,
        sub_precategory_predicate_objects C' a ->
        sub_precategory_predicate_morphisms  C' _ _ (identity a) :=
          pr1 (pr2 C').
 
 Definition sub_precategory_comp (C : precategory)(C':sub_precategories C) :
-   forall (a b c: ob C) (f: a --> b) (g : b --> c),
+   Π (a b c: ob C) (f: a --> b) (g : b --> c),
           sub_precategory_predicate_morphisms C' _ _ f ->
           sub_precategory_predicate_morphisms C' _ _ g ->
           sub_precategory_predicate_morphisms C' _ _  (f ;; g) :=

--- a/UniMath/CategoryTheory/trees.v
+++ b/UniMath/CategoryTheory/trees.v
@@ -124,9 +124,9 @@ Transparent foldr_map.
 (* This defines the induction principle for trees using foldr *)
 Section tree_induction.
 
-Variables (P : pr1 Tree -> UU) (PhSet : forall l, isaset (P l)).
+Variables (P : pr1 Tree -> UU) (PhSet : Π l, isaset (P l)).
 Variables (P0 : P leaf)
-          (Pc : forall (a : pr1 A) (l1 l2 : pr1 Tree), P l1 -> P l2 -> P (node (a,,l1,,l2))).
+          (Pc : Π (a : pr1 A) (l1 l2 : pr1 Tree), P l1 -> P l2 -> P (node (a,,l1,,l2))).
 
 Let P' : UU := Σ l, P l.
 Let P0' : P' := (leaf,, P0).
@@ -176,8 +176,8 @@ Defined.
 
 End tree_induction.
 
-Lemma treeIndProp (P : pr1 Tree -> UU) (HP : forall l, isaprop (P l)) :
-  P leaf -> (forall a l1 l2, P l1 → P l2 → P (node (a,,l1,,l2))) -> forall l, P l.
+Lemma treeIndProp (P : pr1 Tree -> UU) (HP : Π l, isaprop (P l)) :
+  P leaf -> (Π a l1 l2, P l1 → P l2 → P (node (a,,l1,,l2))) -> Π l, P l.
 Proof.
 intros Pnil Pcons.
 apply treeInd; try assumption.
@@ -211,7 +211,7 @@ Definition map (f : nat -> nat) (l : pr1 (Tree natHSET)) : pr1 (Tree natHSET) :=
   foldr natHSET (Tree natHSET) (leaf natHSET)
       (λ a, node natHSET (f (pr1 a),, pr1 (pr2 a),, pr2 (pr2 a))) l.
 
-Lemma size_map (f : nat -> nat) : forall l, size (map f l) = size l.
+Lemma size_map (f : nat -> nat) : Π l, size (map f l) = size l.
 Proof.
 apply treeIndProp.
 - intros l. apply isasetnat.

--- a/UniMath/CategoryTheory/yoneda.v
+++ b/UniMath/CategoryTheory/yoneda.v
@@ -95,7 +95,7 @@ Definition yoneda_objects (C : precategory) (hs: has_homsets C) (c : C) :
 (** ** On morphisms *)
 
 Definition yoneda_morphisms_data (C : precategory)(hs: has_homsets C) (c c' : C)
-    (f : hom C c c') : forall a : ob C^op,
+    (f : hom C c c') : Π a : ob C^op,
          hom _ (yoneda_objects C hs c a) ( yoneda_objects C hs c' a) :=
             fun a g => g ;; f.
 

--- a/UniMath/Dedekind/Complements.v
+++ b/UniMath/Dedekind/Complements.v
@@ -5,7 +5,7 @@
 Require Export UniMath.Foundations.NumberSystems.NaturalNumbers.
 Require Import UniMath.Ktheory.Utilities.
 
-Lemma max_le_l : ∀ n m : nat, (n ≤ max n m)%nat.
+Lemma max_le_l : Π n m : nat, (n ≤ max n m)%nat.
 Proof.
   induction n ; simpl max.
   - intros ; reflexivity.
@@ -13,7 +13,7 @@ Proof.
     + now apply isreflnatleh.
     + now apply IHn.
 Qed.
-Lemma max_le_r : ∀ n m : nat, (m ≤ max n m)%nat.
+Lemma max_le_r : Π n m : nat, (m ≤ max n m)%nat.
 Proof.
   induction n ; simpl max.
   - intros ; now apply isreflnatleh.
@@ -76,7 +76,7 @@ Proof.
 Qed.
 
 Lemma hqgth_hqneq :
-  forall x y : hq, x > y -> hqneq x y.
+  Π x y : hq, x > y -> hqneq x y.
 Proof.
   intros x y Hlt Heq.
   rewrite Heq in Hlt.
@@ -84,20 +84,20 @@ Proof.
 Qed.
 
 Lemma hqldistr :
-  forall x y z, x * (y + z) = x * y + x * z.
+  Π x y z, x * (y + z) = x * y + x * z.
 Proof.
   intros x y z.
   now apply rngldistr.
 Qed.
 
 Lemma hqmult2r :
-  forall x : hq, x * 2 = x + x.
+  Π x : hq, x * 2 = x + x.
 Proof.
   intros x.
   now rewrite hq2eq1plus1, hqldistr, (hqmultr1 x).
 Qed.
 
-Lemma hqplusdiv2 : forall x : hq, x = (x + x) / 2.
+Lemma hqplusdiv2 : Π x : hq, x = (x + x) / 2.
   intros x.
   apply hqmultrcan with 2.
   now apply hqgth_hqneq, hq2_gt0.
@@ -110,7 +110,7 @@ Lemma hqplusdiv2 : forall x : hq, x = (x + x) / 2.
 Qed.
 
 Lemma hqlth_between :
-  forall x y : hq, x < y -> total2 (fun z => dirprod (x < z) (z < y)).
+  Π x y : hq, x < y -> total2 (fun z => dirprod (x < z) (z < y)).
 Proof.
   assert (H0 : / 2 > 0).
   { apply hqgthandmultlinv with 2.
@@ -137,7 +137,7 @@ Proof.
 Qed.
 
 Lemma hq0lehandplus:
-  forall n m : hq,
+  Π n m : hq,
     0 <= n -> 0 <= m -> 0 <= (n + m).
 Proof.
   intros n m Hn Hm.
@@ -146,14 +146,14 @@ Proof.
 Qed.
 
 Lemma hq0lehandmult:
-  ∀ n m : hq, 0 <= n -> 0 <= m -> 0 <= n * m.
+  Π n m : hq, 0 <= n -> 0 <= m -> 0 <= n * m.
 Proof.
   intros n m.
   exact hqmultgeh0geh0.
 Qed.
 
 Lemma hq0leminus :
-  forall r q : hq, r <= q -> 0 <= q - r.
+  Π r q : hq, r <= q -> 0 <= q - r.
 Proof.
   intros r q Hr.
   apply hqlehandplusrinv with r.
@@ -178,7 +178,7 @@ Qed.
 Lemma isaproptotal2' {X : UU} (P : X -> UU) :
   isaset X ->
   isPredicate P ->
-  (∀ x y : X, P x -> P y -> x = y) ->
+  (Π x y : X, P x -> P y -> x = y) ->
   isaprop (Σ x : X, P x).
 Proof.
   intros X P HX HP Heq x y ; simpl.
@@ -207,7 +207,7 @@ Proof.
 Qed.
 
 Lemma hztohqandleh':
-  ∀ n m : hz, (hztohq n <= hztohq m)%hq -> hzleh n m.
+  Π n m : hz, (hztohq n <= hztohq m)%hq -> hzleh n m.
 Proof.
   intros n m Hle Hlt.
   apply Hle.
@@ -215,7 +215,7 @@ Proof.
   exact Hlt.
 Qed.
 Lemma hztohqandlth':
-  ∀ n m : hz, (hztohq n < hztohq m)%hq -> hzlth n m.
+  Π n m : hz, (hztohq n < hztohq m)%hq -> hzlth n m.
 Proof.
   intros n m Hlt.
   apply neghzgehtolth.
@@ -229,7 +229,7 @@ Qed.
 (** ** hq is archimedean *)
 
 Lemma nattorig_nattohz :
-  ∀ n : nat, nattorig (X := hz) n = nattohz n.
+  Π n : nat, nattorig (X := hz) n = nattohz n.
 Proof.
   induction n.
   - simpl.
@@ -239,7 +239,7 @@ Proof.
 Qed.
 
 Lemma nattorig_nat :
-  ∀ n : nat, nattorig (X := natcommrig) n = n.
+  Π n : nat, nattorig (X := natcommrig) n = n.
 Proof.
   induction n.
   reflexivity.

--- a/UniMath/Dedekind/DecidableDedekindCuts.v
+++ b/UniMath/Dedekind/DecidableDedekindCuts.v
@@ -13,7 +13,7 @@ Open Scope Dcuts_scope.
 (** ** Definition *)
 
 Lemma isboolDcuts_isaprop (x : Dcuts) :
-  isaprop (forall r, (r ∈ x) ∨ (neg (r ∈ x))).
+  isaprop (Π r, (r ∈ x) ∨ (neg (r ∈ x))).
 Proof.
   intros x.
   apply impred_isaprop.
@@ -36,11 +36,11 @@ Proof.
   apply (hSetpair (carrier isboolDcuts)).
   exact isaset_boolDcuts.
 Defined.
-Definition mk_boolDcuts (x : Dcuts) (Hdec : ∀ r : NonnegativeRationals, (r ∈ x) ⨿ ¬ (r ∈ x)) : boolDcuts :=
+Definition mk_boolDcuts (x : Dcuts) (Hdec : Π r : NonnegativeRationals, (r ∈ x) ⨿ ¬ (r ∈ x)) : boolDcuts :=
   x,, (λ r : NonnegativeRationals, hinhpr (Hdec r)).
 
 Lemma is_zero_dec :
-  forall x : Dcuts, isboolDcuts x -> (x = 0) ∨ (¬ (x = 0)).
+  Π x : Dcuts, isboolDcuts x -> (x = 0) ∨ (¬ (x = 0)).
 Proof.
   intros x Hx.
   generalize (Hx 0%NRat) ; apply hinhfun ; intros [Hx0 | Hx0].

--- a/UniMath/Dedekind/Fields.v
+++ b/UniMath/Dedekind/Fields.v
@@ -3,7 +3,7 @@
 Require Export UniMath.Foundations.Algebra.Domains_and_Fields.
 
 Lemma isapropmultinvpair :
-  ∀ (X : rig) (x : X), isaprop (multinvpair X x).
+  Π (X : rig) (x : X), isaprop (multinvpair X x).
 Proof.
   intros X x.
   apply isapropinvpair.

--- a/UniMath/Dedekind/NonnegativeRationals.v
+++ b/UniMath/Dedekind/NonnegativeRationals.v
@@ -339,7 +339,7 @@ Proof.
   reflexivity.
 Qed.
 Lemma plusNonnegativeRationals_correct :
-  ∀ (x y : NonnegativeRationals),
+  Π (x y : NonnegativeRationals),
     x + y = Rationals_to_NonnegativeRationals (pr1 x + pr1 y)%hq (hq0lehandplus _ _ (pr2 x) (pr2 y)).
 Proof.
   intros (x,Hx) (y,Hy).
@@ -347,7 +347,7 @@ Proof.
   reflexivity.
 Qed.
 Lemma minusNonnegativeRationals_correct :
-  ∀ (x y : NonnegativeRationals) (Hminus : y <= x),
+  Π (x y : NonnegativeRationals) (Hminus : y <= x),
     x - y = Rationals_to_NonnegativeRationals (pr1 x - pr1 y)%hq (hq0leminus _ _ Hminus).
 Proof.
   intros (x,Hx) (y,Hy) H.
@@ -360,7 +360,7 @@ Proof.
     reflexivity.
 Qed.
 Lemma multNonnegativeRationals_correct :
-  ∀ (x y : NonnegativeRationals),
+  Π (x y : NonnegativeRationals),
     x * y = Rationals_to_NonnegativeRationals (pr1 x * pr1 y)%hq ( hq0lehandmult _ _ (pr2 x) (pr2 y)).
 Proof.
   intros (x,Hx) (y,Hy).
@@ -368,7 +368,7 @@ Proof.
   reflexivity.
 Qed.
 Lemma invNonnegativeRationals_correct :
-  ∀ (x : NonnegativeRationals) (Hx : 0 < x),
+  Π (x : NonnegativeRationals) (Hx : 0 < x),
     / x = Rationals_to_NonnegativeRationals (/ pr1 x)%hq (hqlthtoleh _ _ (hqinv_gt0 _ Hx)).
 Proof.
   intros (x,Hx) Hx0.
@@ -383,25 +383,25 @@ Proof.
 Qed.
 
 Lemma leNonnegativeRationals_correct :
-  ∀ x y : NonnegativeRationals, (x <= y) = (pr1 x <= pr1 y)%hq.
+  Π x y : NonnegativeRationals, (x <= y) = (pr1 x <= pr1 y)%hq.
 Proof.
   intros x y.
   reflexivity.
 Qed.
 Lemma geNonnegativeRationals_correct :
-  ∀ x y : NonnegativeRationals, (x >= y) = (pr1 x >= pr1 y)%hq.
+  Π x y : NonnegativeRationals, (x >= y) = (pr1 x >= pr1 y)%hq.
 Proof.
   intros x y.
   reflexivity.
 Qed.
 Lemma ltNonnegativeRationals_correct :
-  ∀ x y : NonnegativeRationals, (x < y) = (pr1 x < pr1 y)%hq.
+  Π x y : NonnegativeRationals, (x < y) = (pr1 x < pr1 y)%hq.
 Proof.
   intros x y.
   reflexivity.
 Qed.
 Lemma gtNonnegativeRationals_correct :
-  ∀ x y : NonnegativeRationals, (x > y) = (pr1 x > pr1 y)%hq.
+  Π x y : NonnegativeRationals, (x > y) = (pr1 x > pr1 y)%hq.
 Proof.
   intros x y.
   reflexivity.
@@ -412,7 +412,7 @@ Qed.
 (** *** Decidability *)
 
 Lemma isdeceq_NonnegativeRationals :
-  ∀ x y : NonnegativeRationals, (x = y) ⨿ (x != y).
+  Π x y : NonnegativeRationals, (x = y) ⨿ (x != y).
 Proof.
   intros (x,Hx) (y,Hy).
   destruct (isdeceqhq x y) as [H|H].
@@ -426,20 +426,20 @@ Proof.
     apply base_paths.
 Qed.
 Lemma isdecrel_leNonnegativeRationals :
-  ∀ x y : NonnegativeRationals, (x <= y) ⨿ ¬ (x <= y).
+  Π x y : NonnegativeRationals, (x <= y) ⨿ ¬ (x <= y).
 Proof.
   intros x y.
   apply isdecrelhqleh.
 Qed.
 Lemma isdecrel_ltNonnegativeRationals :
-  ∀ x y : NonnegativeRationals, (x < y) ⨿ ¬ (x < y).
+  Π x y : NonnegativeRationals, (x < y) ⨿ ¬ (x < y).
 Proof.
   intros x y.
   apply isdecrelhqlth.
 Qed.
 
 Lemma le_eqorltNonnegativeRationals :
-  ∀ x y : NonnegativeRationals, x <= y -> (x = y) ⨿ (x < y).
+  Π x y : NonnegativeRationals, x <= y -> (x = y) ⨿ (x < y).
 Proof.
   intros x y Hle.
   destruct (hqlehchoice (pr1 x) (pr1 y)) as [Hlt | Heq].
@@ -449,7 +449,7 @@ Proof.
     now apply subtypeEquality_prop, Heq.
 Qed.
 Lemma noteq_ltorgtNonnegativeRationals :
-  ∀ x y : NonnegativeRationals, x != y -> (x < y) ⨿ (x > y).
+  Π x y : NonnegativeRationals, x != y -> (x < y) ⨿ (x > y).
 Proof.
   intros x y Hneq.
   destruct (isdecrel_leNonnegativeRationals x y) as [Hle|Hlt].
@@ -463,7 +463,7 @@ Proof.
     exact Hlt.
 Qed.
 Lemma eq0orgt0NonnegativeRationals :
-  ∀ x : NonnegativeRationals, (x = 0) ⨿ (0 < x).
+  Π x : NonnegativeRationals, (x = 0) ⨿ (0 < x).
 Proof.
   intros x.
   destruct (le_eqorltNonnegativeRationals 0 x) as [Hx | Hx].
@@ -475,30 +475,30 @@ Qed.
 (** *** Basic theorems about order *)
 
 Definition lt_leNonnegativeRationals :
-  ∀ x y : NonnegativeRationals, x < y -> x <= y
+  Π x y : NonnegativeRationals, x < y -> x <= y
   := EOlt_le (X := NonnegativeRationals_EffectivelyOrderedSet).
 
 Definition isrefl_leNonnegativeRationals:
-  ∀ x : NonnegativeRationals, x <= x :=
+  Π x : NonnegativeRationals, x <= x :=
   isrefl_EOle (X := NonnegativeRationals_EffectivelyOrderedSet).
 Definition istrans_leNonnegativeRationals:
-  ∀ x y z : NonnegativeRationals, x <= y -> y <= z -> x <= z :=
+  Π x y z : NonnegativeRationals, x <= y -> y <= z -> x <= z :=
   istrans_EOle (X := NonnegativeRationals_EffectivelyOrderedSet).
 Definition isirrefl_ltNonnegativeRationals:
-  ∀ x : NonnegativeRationals, ¬ (x < x) :=
+  Π x : NonnegativeRationals, ¬ (x < x) :=
   isirrefl_EOlt (X := NonnegativeRationals_EffectivelyOrderedSet).
 Definition istrans_ltNonnegativeRationals :
-  ∀ x y z : NonnegativeRationals, x < y -> y < z -> x < z
+  Π x y z : NonnegativeRationals, x < y -> y < z -> x < z
   := istrans_EOlt (X := NonnegativeRationals_EffectivelyOrderedSet).
 Definition istrans_lt_le_ltNonnegativeRationals:
-  ∀ x y z : NonnegativeRationals, x < y -> y <= z -> x < z
+  Π x y z : NonnegativeRationals, x < y -> y <= z -> x < z
   := istrans_EOlt_le (X := NonnegativeRationals_EffectivelyOrderedSet).
 Definition istrans_le_lt_ltNonnegativeRationals :
-  ∀ x y z : NonnegativeRationals, x <= y -> y < z -> x < z
+  Π x y z : NonnegativeRationals, x <= y -> y < z -> x < z
   := istrans_EOle_lt (X := NonnegativeRationals_EffectivelyOrderedSet).
 
 Lemma isantisymm_leNonnegativeRationals :
-  ∀ x y : NonnegativeRationals, x <= y -> y <= x -> x = y.
+  Π x y : NonnegativeRationals, x <= y -> y <= x -> x = y.
 Proof.
   intros x y Hle Hge.
   apply subtypeEquality_prop.
@@ -506,16 +506,16 @@ Proof.
 Qed.
 
 Definition ge_leNonnegativeRationals:
-  ∀ x y : NonnegativeRationals, (x >= y) <-> (y <= x)
+  Π x y : NonnegativeRationals, (x >= y) <-> (y <= x)
   := EOge_le (X := NonnegativeRationals_EffectivelyOrderedSet).
 Definition lt_gtNonnegativeRationals:
-  ∀ x y : NonnegativeRationals, (x > y) <-> (y < x)
+  Π x y : NonnegativeRationals, (x > y) <-> (y < x)
   := EOgt_lt (X := NonnegativeRationals_EffectivelyOrderedSet).
 Definition notlt_geNonnegativeRationals:
-  ∀ x y : NonnegativeRationals, (¬ (x < y)) <-> (y <= x)
+  Π x y : NonnegativeRationals, (¬ (x < y)) <-> (y <= x)
   := not_EOlt_le (X := NonnegativeRationals_EffectivelyOrderedSet).
 Lemma notge_ltNonnegativeRationals :
-  ∀ x y : NonnegativeRationals, (¬ (y <= x)) <-> (x < y).
+  Π x y : NonnegativeRationals, (¬ (y <= x)) <-> (x < y).
 Proof.
   intros x y.
   split.
@@ -524,14 +524,14 @@ Proof.
 Qed.
 
 Definition ltNonnegativeRationals_noteq :
-  ∀ x y, x < y -> x != y
+  Π x y, x < y -> x != y
   := EOlt_noteq (X := NonnegativeRationals_EffectivelyOrderedSet).
 Definition gtNonnegativeRationals_noteq :
-  ∀ x y, x > y -> x != y
+  Π x y, x > y -> x != y
   := EOgt_noteq (X := NonnegativeRationals_EffectivelyOrderedSet).
 
 Lemma between_ltNonnegativeRationals :
-  ∀ x y : NonnegativeRationals,
+  Π x y : NonnegativeRationals,
     x < y -> Σ t : NonnegativeRationals, x < t × t < y.
 Proof.
   intros x y H.
@@ -549,20 +549,20 @@ Qed.
 (** *** Order and 0 *)
 
 Lemma isnonnegative_NonnegativeRationals :
-  ∀ x : NonnegativeRationals , 0 <= x.
+  Π x : NonnegativeRationals , 0 <= x.
 Proof.
   intros x.
   apply (pr2 x).
 Qed.
 Lemma isnonnegative_NonnegativeRationals' :
-  ∀ x : NonnegativeRationals , ¬ (x < 0).
+  Π x : NonnegativeRationals , ¬ (x < 0).
 Proof.
   intros x.
   apply (pr2 x).
 Qed.
 
 Lemma NonnegativeRationals_eq0_le0 :
-  ∀ r : NonnegativeRationals, (r <= 0) -> (r = 0).
+  Π r : NonnegativeRationals, (r <= 0) -> (r = 0).
 Proof.
   intros r Hr0.
   apply subtypeEquality_prop.
@@ -571,7 +571,7 @@ Proof.
   apply (pr2 r).
 Qed.
 Lemma NonnegativeRationals_neq0_gt0 :
-  ∀ r : NonnegativeRationals, (r != 0) -> (0 < r).
+  Π r : NonnegativeRationals, (r != 0) -> (0 < r).
 Proof.
   intros r Hr0.
   apply neghqlehtogth.
@@ -600,25 +600,25 @@ Qed.
 (** Rewritings *)
 
 Definition isassoc_plusNonnegativeRationals:
-  ∀ x y z : NonnegativeRationals, x + y + z = x + (y + z) :=
+  Π x y z : NonnegativeRationals, x + y + z = x + (y + z) :=
   CommDivRig_isassoc_plus.
 
 Definition islunit_zeroNonnegativeRationals:
-  ∀ r : NonnegativeRationals, 0 + r = r :=
+  Π r : NonnegativeRationals, 0 + r = r :=
   CommDivRig_islunit_zero.
 
 Definition isrunit_zeroNonnegativeRationals:
-  ∀ r : NonnegativeRationals, r + 0 = r :=
+  Π r : NonnegativeRationals, r + 0 = r :=
   CommDivRig_isrunit_zero.
 
 Definition iscomm_plusNonnegativeRationals:
-  ∀ x y : NonnegativeRationals, x + y = y + x :=
+  Π x y : NonnegativeRationals, x + y = y + x :=
   CommDivRig_iscomm_plus.
 
 (** Order *)
 
 Lemma plusNonnegativeRationals_ltcompat_r :
-  ∀ x y z : NonnegativeRationals, (y < z) <-> (y + x < z + x).
+  Π x y z : NonnegativeRationals, (y < z) <-> (y + x < z + x).
 Proof.
   intros x y z.
   split.
@@ -626,7 +626,7 @@ Proof.
   now apply hqlthandplusrinv.
 Qed.
 Lemma plusNonnegativeRationals_ltcompat_l :
-  ∀ x y z : NonnegativeRationals, (y < z) <-> (x + y < x + z).
+  Π x y z : NonnegativeRationals, (y < z) <-> (x + y < x + z).
 Proof.
   intros x y z.
   rewrite !(iscomm_plusNonnegativeRationals x).
@@ -634,7 +634,7 @@ Proof.
 Qed.
 
 Lemma plusNonnegativeRationals_lecompat_r :
-  ∀ r q n : NonnegativeRationals, (q <= n) <-> (q + r <= n + r).
+  Π r q n : NonnegativeRationals, (q <= n) <-> (q + r <= n + r).
 Proof.
   intros r q n.
   split.
@@ -642,7 +642,7 @@ Proof.
   - now apply hqlehandplusrinv.
 Qed.
 Lemma plusNonnegativeRationals_lecompat_l :
-  ∀ r q n : NonnegativeRationals, (q <= n) <-> (r + q <= r + n).
+  Π r q n : NonnegativeRationals, (q <= n) <-> (r + q <= r + n).
 Proof.
   intros r q n.
   rewrite ! (iscomm_plusNonnegativeRationals r).
@@ -650,7 +650,7 @@ Proof.
 Qed.
 
 Lemma plusNonnegativeRationals_eqcompat_l:
-  ∀ k x y : NonnegativeRationals,
+  Π k x y : NonnegativeRationals,
     (k + x = k + y) -> (x = y).
 Proof.
   intros k x y H.
@@ -660,7 +660,7 @@ Proof.
     apply isrefl_leNonnegativeRationals.
 Qed.
 Lemma plusNonnegativeRationals_eqcompat_r:
-  ∀ k x y : NonnegativeRationals,
+  Π k x y : NonnegativeRationals,
     (x + k = y + k) -> (x = y).
 Proof.
   intros k x y.
@@ -669,7 +669,7 @@ Proof.
 Qed.
 
 Lemma plusNonnegativeRationals_ltcompat :
-  ∀ x x' y y' : NonnegativeRationals,
+  Π x x' y y' : NonnegativeRationals,
     x < x' -> y < y' -> x + y < x' + y'.
 Proof.
   intros x x' y y' Hx Hy.
@@ -678,7 +678,7 @@ Proof.
   now apply hqlthandplusr, Hx.
 Qed.
 Lemma plusNonnegativeRationals_le_lt_ltcompat :
-  ∀ x x' y y' : NonnegativeRationals,
+  Π x x' y y' : NonnegativeRationals,
     x <= x' -> y < y' -> x + y < x' + y'.
 Proof.
   intros x x' y y' Hx Hy.
@@ -687,7 +687,7 @@ Proof.
   now apply hqlehandplusr, Hx.
 Qed.
 Lemma plusNonnegativeRationals_lt_le_ltcompat :
-  ∀ x x' y y' : NonnegativeRationals,
+  Π x x' y y' : NonnegativeRationals,
     x < x' -> y <= y' -> x + y < x' + y'.
 Proof.
   intros x x' y y' Hx Hy.
@@ -697,7 +697,7 @@ Proof.
 Qed.
 
 Lemma plusNonnegativeRationals_le_r :
-  ∀ r q : NonnegativeRationals, r <= r + q.
+  Π r q : NonnegativeRationals, r <= r + q.
 Proof.
   intros r q.
   pattern r at 1.
@@ -706,7 +706,7 @@ Proof.
   apply (pr2 q).
 Qed.
 Lemma plusNonnegativeRationals_le_l :
-  ∀ r q : NonnegativeRationals, r <= q + r.
+  Π r q : NonnegativeRationals, r <= q + r.
 Proof.
   intros r q.
   rewrite iscomm_plusNonnegativeRationals.
@@ -714,7 +714,7 @@ Proof.
 Qed.
 
 Lemma ispositive_plusNonnegativeRationals_l :
-  forall x y : NonnegativeRationals, 0 < x -> 0 < x + y.
+  Π x y : NonnegativeRationals, 0 < x -> 0 < x + y.
 Proof.
   intros x y Hx.
   apply istrans_lt_le_ltNonnegativeRationals with x.
@@ -722,7 +722,7 @@ Proof.
   now apply plusNonnegativeRationals_le_r.
 Qed.
 Lemma ispositive_plusNonnegativeRationals_r :
-  forall x y : NonnegativeRationals, 0 < y -> 0 < x + y.
+  Π x y : NonnegativeRationals, 0 < y -> 0 < x + y.
 Proof.
   intros x y Hy.
   apply istrans_lt_le_ltNonnegativeRationals with y.
@@ -731,7 +731,7 @@ Proof.
 Qed.
 
 Lemma plusNonnegativeRationals_lt_r :
-  ∀ r q : NonnegativeRationals, 0 < q -> r < r + q.
+  Π r q : NonnegativeRationals, 0 < q -> r < r + q.
 Proof.
   intros x y Hy0.
   pattern x at 1.
@@ -740,7 +740,7 @@ Proof.
   exact Hy0.
 Qed.
 Lemma plusNonnegativeRationals_lt_l :
-  ∀ r q : NonnegativeRationals, 0 < r -> q < r + q.
+  Π r q : NonnegativeRationals, 0 < r -> q < r + q.
 Proof.
   intros x y.
   rewrite iscomm_plusNonnegativeRationals.
@@ -751,7 +751,7 @@ Qed.
 (** Rewriting *)
 
 Lemma minusNonnegativeRationals_eq_zero:
-  ∀ x y : NonnegativeRationals, x <= y -> x - y = 0.
+  Π x y : NonnegativeRationals, x <= y -> x - y = 0.
 Proof.
   intros (x,Hx) (y,Hy) Hle.
   unfold minusNonnegativeRationals, hnnq_minus ; simpl pr1.
@@ -760,7 +760,7 @@ Proof.
   - reflexivity.
 Qed.
 Lemma minusNonnegativeRationals_plus_r :
-  ∀ r q : NonnegativeRationals,
+  Π r q : NonnegativeRationals,
     r <= q -> (q - r) + r = q.
 Proof.
   intros (r,Hr) (q,hq) H ; simpl in H.
@@ -775,7 +775,7 @@ Proof.
 Qed.
 
 Lemma plusNonnegativeRationals_minus_r :
-  ∀ q r : NonnegativeRationals, (r + q) - q = r.
+  Π q r : NonnegativeRationals, (r + q) - q = r.
 Proof.
   intros (q,Hq) (r,Hr).
   rewrite (minusNonnegativeRationals_correct _ _ (plusNonnegativeRationals_le_l _ _)).
@@ -785,7 +785,7 @@ Proof.
   now rewrite hqplusassoc, (hqpluscomm q), (hqlminus q), hqplusr0.
 Qed.
 Lemma plusNonnegativeRationals_minus_l :
-  ∀ q r : NonnegativeRationals, (q + r) - q = r.
+  Π q r : NonnegativeRationals, (q + r) - q = r.
 Proof.
   intros q r.
   rewrite iscomm_plusNonnegativeRationals.
@@ -793,27 +793,27 @@ Proof.
 Qed.
 
 Lemma minusNonnegativeRationals_correct_l :
-  forall x y z : NonnegativeRationals, x = y + z -> z = x - y.
+  Π x y z : NonnegativeRationals, x = y + z -> z = x - y.
 Proof.
   intros x y z ->.
   now rewrite plusNonnegativeRationals_minus_l.
 Qed.
 Lemma minusNonnegativeRationals_correct_r :
-  forall x y z : NonnegativeRationals, x = y + z -> y = x - z.
+  Π x y z : NonnegativeRationals, x = y + z -> y = x - z.
 Proof.
   intros x y z ->.
   now rewrite plusNonnegativeRationals_minus_r.
 Qed.
 
 Lemma minusNonnegativeRationals_zero_l :
-  forall x : NonnegativeRationals, 0 - x = 0.
+  Π x : NonnegativeRationals, 0 - x = 0.
 Proof.
   intros x.
   apply minusNonnegativeRationals_eq_zero.
   now apply isnonnegative_NonnegativeRationals.
 Qed.
 Lemma minusNonnegativeRationals_zero_r :
-  forall x : NonnegativeRationals, x - 0 = x.
+  Π x : NonnegativeRationals, x - 0 = x.
 Proof.
   intros x.
   rewrite <- (isrunit_zeroNonnegativeRationals (x - 0)).
@@ -822,7 +822,7 @@ Proof.
 Qed.
 
 Lemma minusNonnegativeRationals_plus_exchange :
-  forall x y z : NonnegativeRationals, y <= x -> x - y + z = (x + z) - y.
+  Π x y z : NonnegativeRationals, y <= x -> x - y + z = (x + z) - y.
 Proof.
   intros x y z Hxy.
   assert (Hxzy : y <= x + z).
@@ -840,7 +840,7 @@ Qed.
 (** Order *)
 
 Lemma ispositive_minusNonnegativeRationals :
-  ∀ x y : NonnegativeRationals, (x < y) <-> (0 < y - x).
+  Π x y : NonnegativeRationals, (x < y) <-> (0 < y - x).
 Proof.
   intros x y.
   split ; intro Hlt.
@@ -856,7 +856,7 @@ Proof.
 Qed.
 
 Lemma minusNonnegativeRationals_le :
-  ∀ x y : NonnegativeRationals, x - y <= x.
+  Π x y : NonnegativeRationals, x - y <= x.
 Proof.
   intros x y.
   apply_pr2 (plusNonnegativeRationals_lecompat_r y).
@@ -872,7 +872,7 @@ Proof.
 Qed.
 
 Lemma minusNonnegativeRationals_lecompat_l :
-  forall k x y : NonnegativeRationals, x <= y -> x - k <= y - k.
+  Π k x y : NonnegativeRationals, x <= y -> x - k <= y - k.
 Proof.
   intros k x y Hxy.
   case (isdecrel_leNonnegativeRationals k x) ; intros Hkx.
@@ -886,7 +886,7 @@ Proof.
     now apply lt_leNonnegativeRationals, notge_ltNonnegativeRationals.
 Qed.
 Lemma minusNonnegativeRationals_lecompat_l' :
-  forall k x y : NonnegativeRationals, k <= y -> x - k <= y - k -> x <= y.
+  Π k x y : NonnegativeRationals, k <= y -> x - k <= y - k -> x <= y.
 Proof.
   intros k x y Hky H.
   case (isdecrel_leNonnegativeRationals k x) ; intros Hkx.
@@ -900,7 +900,7 @@ Proof.
 Qed.
 
 Lemma minusNonnegativeRationals_lecompat_r :
-  forall k x y : NonnegativeRationals, x <= y -> k - y <= k - x.
+  Π k x y : NonnegativeRationals, x <= y -> k - y <= k - x.
 Proof.
   intros k x y Hxy.
   case (isdecrel_leNonnegativeRationals y k) ; intros Hky.
@@ -917,7 +917,7 @@ Proof.
     now apply lt_leNonnegativeRationals, notge_ltNonnegativeRationals.
 Qed.
 Lemma minusNonnegativeRationals_lecompat_r' :
-  forall k x y : NonnegativeRationals, x <= k -> k - y <= k - x -> x <= y.
+  Π k x y : NonnegativeRationals, x <= k -> k - y <= k - x -> x <= y.
 Proof.
   intros k x y Hkx H.
   case (isdecrel_leNonnegativeRationals y k) ; intros Hky.
@@ -934,7 +934,7 @@ Proof.
 Qed.
 
 Lemma minusNonnegativeRationals_ltcompat_l:
-  ∀ x y z : NonnegativeRationals, x < y -> z < y -> x - z < y - z.
+  Π x y z : NonnegativeRationals, x < y -> z < y -> x - z < y - z.
 Proof.
   intros x y z Hxy Hyz.
   case (isdecrel_leNonnegativeRationals x z) ; intros Hxz.
@@ -949,7 +949,7 @@ Proof.
     now apply lt_leNonnegativeRationals, Hxz.
 Qed.
 Lemma minusNonnegativeRationals_ltcompat_l' :
-  forall x y z : NonnegativeRationals, x - z < y - z -> x < y.
+  Π x y z : NonnegativeRationals, x - z < y - z -> x < y.
 Proof.
   intros x y z Hlt.
   assert (Hyz : (z < y)%NRat).
@@ -968,7 +968,7 @@ Proof.
     exact Hlt.
 Qed.
 Lemma minusNonnegativeRationals_ltcompat_r:
-  ∀ x y z : NonnegativeRationals, x < y -> x < z -> z - y < z - x.
+  Π x y z : NonnegativeRationals, x < y -> x < z -> z - y < z - x.
 Proof.
   intros x y z Hxy Hxz.
   case (isdecrel_leNonnegativeRationals y z) ; intros Hky.
@@ -985,7 +985,7 @@ Proof.
     now apply lt_leNonnegativeRationals, notge_ltNonnegativeRationals, Hky.
 Qed.
 Lemma minusNonnegativeRationals_ltcompat_r':
-  ∀ x y z : NonnegativeRationals, z - y < z - x -> x < y.
+  Π x y z : NonnegativeRationals, z - y < z - x -> x < y.
 Proof.
   intros x y z H.
   apply notge_ltNonnegativeRationals.
@@ -999,34 +999,34 @@ Qed.
 (** Rewritings *)
 
 Definition isassoc_multNonnegativeRationals:
-  ∀ x y z : NonnegativeRationals, x * y * z = x * (y * z) :=
+  Π x y z : NonnegativeRationals, x * y * z = x * (y * z) :=
   CommDivRig_isassoc_mult.
 Definition islunit_oneNonnegativeRationals:
-  ∀ x : NonnegativeRationals, 1 * x = x :=
+  Π x : NonnegativeRationals, 1 * x = x :=
   CommDivRig_islunit_one.
 Definition isrunit_oneNonnegativeRationals:
-  ∀ x : NonnegativeRationals, x * 1 = x :=
+  Π x : NonnegativeRationals, x * 1 = x :=
   CommDivRig_isrunit_one.
 Definition iscomm_multNonnegativeRationals:
-  ∀ x y : NonnegativeRationals, x * y = y * x :=
+  Π x y : NonnegativeRationals, x * y = y * x :=
   CommDivRig_iscomm_mult.
 Definition isldistr_mult_plusNonnegativeRationals:
-  ∀ x y z : NonnegativeRationals, z * (x + y) = z * x + z * y :=
+  Π x y z : NonnegativeRationals, z * (x + y) = z * x + z * y :=
   CommDivRig_isldistr.
 Definition isrdistr_mult_plusNonnegativeRationals:
-  ∀ x y z : NonnegativeRationals, (x + y) * z = x * z + y * z :=
+  Π x y z : NonnegativeRationals, (x + y) * z = x * z + y * z :=
   CommDivRig_isrdistr.
 Definition islabsorb_zero_multNonnegativeRationals:
-  ∀ x : NonnegativeRationals, 0 * x = 0 :=
+  Π x : NonnegativeRationals, 0 * x = 0 :=
   rigmult0x _.
 Definition israbsorb_zero_multNonnegativeRationals:
-  ∀ x : NonnegativeRationals, x * 0 = 0 :=
+  Π x : NonnegativeRationals, x * 0 = 0 :=
   rigmultx0 _.
 
 (** Order *)
 
 Lemma multNonnegativeRationals_ltcompat_l :
-  ∀ k x y : NonnegativeRationals, 0 < k -> (x < y) <->  (k * x < k * y).
+  Π k x y : NonnegativeRationals, 0 < k -> (x < y) <->  (k * x < k * y).
 Proof.
   intros k x y Hk.
   split ; intro H.
@@ -1038,7 +1038,7 @@ Proof.
     exact H.
 Qed.
 Lemma multNonnegativeRationals_ltcompat_r :
-  ∀ k x y : NonnegativeRationals, 0 < k -> (x < y) <-> (x * k < y * k).
+  Π k x y : NonnegativeRationals, 0 < k -> (x < y) <-> (x * k < y * k).
 Proof.
   intros k x y Hk.
   rewrite !(iscomm_multNonnegativeRationals _ k).
@@ -1046,7 +1046,7 @@ Proof.
 Qed.
 
 Lemma multNonnegativeRationals_lecompat_l :
-  ∀ k x y : NonnegativeRationals, x <= y -> k * x <= k * y.
+  Π k x y : NonnegativeRationals, x <= y -> k * x <= k * y.
 Proof.
   intros k x y Hle.
   destruct (eq0orgt0NonnegativeRationals k) as [Hk0 | Hk0].
@@ -1057,21 +1057,21 @@ Proof.
     exact Hk0.
 Qed.
 Lemma multNonnegativeRationals_lecompat_l' :
-  ∀ k x y : NonnegativeRationals, 0 < k -> k * x <= k * y -> x <= y.
+  Π k x y : NonnegativeRationals, 0 < k -> k * x <= k * y -> x <= y.
 Proof.
   intros k x y Hk0.
   apply (hqlehandmultlinv (pr1 x) (pr1 y) (pr1 k)).
   exact Hk0.
 Qed.
 Lemma multNonnegativeRationals_lecompat_r :
-  ∀ k x y : NonnegativeRationals, x <= y -> x * k <= y * k.
+  Π k x y : NonnegativeRationals, x <= y -> x * k <= y * k.
 Proof.
   intros k x y Hk.
   rewrite !(iscomm_multNonnegativeRationals _ k).
   now apply multNonnegativeRationals_lecompat_l.
 Qed.
 Lemma multNonnegativeRationals_lecompat_r' :
-  ∀ k x y : NonnegativeRationals, 0 < k -> x * k <= y * k -> x <= y.
+  Π k x y : NonnegativeRationals, 0 < k -> x * k <= y * k -> x <= y.
 Proof.
   intros k x y Hk.
   rewrite !(iscomm_multNonnegativeRationals _ k).
@@ -1079,7 +1079,7 @@ Proof.
 Qed.
 
 Lemma multNonnegativeRationals_eqcompat_l:
-  ∀ k x y : NonnegativeRationals,
+  Π k x y : NonnegativeRationals,
     0 < k -> k * x = k * y -> x = y.
 Proof.
   intros k x y Hk0 H.
@@ -1096,7 +1096,7 @@ Proof.
   now apply islunit_oneNonnegativeRationals.
 Qed.
 Lemma multNonnegativeRationals_eqcompat_r:
-  ∀ k x y : NonnegativeRationals,
+  Π k x y : NonnegativeRationals,
     0 < k -> x * k = y * k -> x = y.
 Proof.
   intros k x y.
@@ -1105,7 +1105,7 @@ Proof.
 Qed.
 
 Lemma ispositive_multNonnegativeRationals:
-  ∀ x y : NonnegativeRationals,
+  Π x y : NonnegativeRationals,
     0 < x -> 0 < y -> 0 < x * y.
 Proof.
   intros x y Hx Hy.
@@ -1115,7 +1115,7 @@ Proof.
   exact Hy.
 Qed.
 Lemma multNonnegativeRationals_ltcompat:
-  ∀ x x' y y' : NonnegativeRationals,
+  Π x x' y y' : NonnegativeRationals,
     x < x' -> y < y' -> x * y < x' * y'.
 Proof.
   intros x x' y y' Hx Hy.
@@ -1134,7 +1134,7 @@ Proof.
     now apply lt_leNonnegativeRationals.
 Qed.
 Lemma multNonnegativeRationals_le_lt:
-  ∀ x x' y y' : NonnegativeRationals,
+  Π x x' y y' : NonnegativeRationals,
     0 < x -> x <= x' -> y < y' -> x * y < x' * y'.
 Proof.
   intros x x' y y' Hx0 Hx Hy.
@@ -1145,7 +1145,7 @@ Proof.
   - now apply multNonnegativeRationals_lecompat_r, Hx.
 Qed.
 Lemma multNonnegativeRationals_lt_le:
-  ∀ x x' y y' : NonnegativeRationals,
+  Π x x' y y' : NonnegativeRationals,
     0 < y -> x < x' -> y <= y' -> x * y < x' * y'.
 Proof.
   intros x x' y y' Hy0 Hx Hy.
@@ -1157,14 +1157,14 @@ Proof.
 Qed.
 
 Lemma multNonnegativeRationals_le1_r :
-  ∀ q r : NonnegativeRationals, q <= 1 -> r * q <= r.
+  Π q r : NonnegativeRationals, q <= 1 -> r * q <= r.
 Proof.
   intros q r Hq.
   pattern r at 2 ; rewrite <- isrunit_oneNonnegativeRationals.
   now apply multNonnegativeRationals_lecompat_l.
 Qed.
 Lemma multNonnegativeRationals_le1_l :
-  ∀ q r : NonnegativeRationals, q <= 1 -> q * r <= r.
+  Π q r : NonnegativeRationals, q <= 1 -> q * r <= r.
 Proof.
   intros q r Hq.
   pattern r at 2 ; rewrite <- islunit_oneNonnegativeRationals.
@@ -1172,7 +1172,7 @@ Proof.
 Qed.
 
 Lemma isldistr_mult_minusNonnegativeRationals:
-  ∀ x y z : NonnegativeRationals, z * (x - y) = z * x - z * y.
+  Π x y z : NonnegativeRationals, z * (x - y) = z * x - z * y.
 Proof.
   intros x y z.
   destruct (isdecrel_leNonnegativeRationals x y) as [Hle | Hlt].
@@ -1190,7 +1190,7 @@ Proof.
     exact Hlt.
 Qed.
 Lemma isrdistr_mult_minusNonnegativeRationals:
-  ∀ x y z : NonnegativeRationals, (x - y) * z = x * z - y * z.
+  Π x y z : NonnegativeRationals, (x - y) * z = x * z - y * z.
 Proof.
   intros x y z.
   rewrite !(iscomm_multNonnegativeRationals _ z).
@@ -1201,7 +1201,7 @@ Qed.
 (** Rewritings *)
 
 Definition islinv_NonnegativeRationals:
-  ∀ x : NonnegativeRationals, 0 < x -> / x * x = 1.
+  Π x : NonnegativeRationals, 0 < x -> / x * x = 1.
 Proof.
   intros x Hx0.
   assert (Hx : x != 0).
@@ -1211,7 +1211,7 @@ Proof.
   apply @CommDivRig_islinv.
 Qed.
 Definition isrinv_NonnegativeRationals:
-  ∀ x : NonnegativeRationals, 0 < x -> x * / x = 1.
+  Π x : NonnegativeRationals, 0 < x -> x * / x = 1.
 Proof.
   intros x.
   rewrite iscomm_multNonnegativeRationals.
@@ -1228,7 +1228,7 @@ Proof.
 Qed.
 
 Lemma ispositive_invNonnegativeRationals :
-  ∀ x, (0 < x) <-> (0 < / x).
+  Π x, (0 < x) <-> (0 < / x).
 Proof.
   intros x.
   split ; intro Hx.
@@ -1255,7 +1255,7 @@ Proof.
 Qed.
 
 Lemma isinvolutive_invNonnegativeRationals :
-  forall x, / / x = x.
+  Π x, / / x = x.
 Proof.
   intros x.
   case (eq0orgt0NonnegativeRationals x) ; intro Hx0.
@@ -1271,7 +1271,7 @@ Qed.
 (** Order *)
 
 Lemma invNonnegativeRationals_lecompat :
-  forall x y : NonnegativeRationals, 0 < x -> x <= y -> / y <= / x.
+  Π x y : NonnegativeRationals, 0 < x -> x <= y -> / y <= / x.
 Proof.
   intros x y Hx0 Hxy.
   assert (Hy0 : 0 < y).
@@ -1289,7 +1289,7 @@ Proof.
   exact Hx0.
 Qed.
 Lemma invNonnegativeRationals_lecompat' :
-  forall x y : NonnegativeRationals, 0 < y -> / y <= / x -> x <= y.
+  Π x y : NonnegativeRationals, 0 < y -> / y <= / x -> x <= y.
 Proof.
   intros x y Hy0 Hxy.
   rewrite <- (isinvolutive_invNonnegativeRationals x), <- (isinvolutive_invNonnegativeRationals y).
@@ -1299,7 +1299,7 @@ Proof.
 Qed.
 
 Lemma invNonnegativeRationals_ltcompat :
-  forall x y : NonnegativeRationals, 0 < x -> x < y -> / y < / x.
+  Π x y : NonnegativeRationals, 0 < x -> x < y -> / y < / x.
 Proof.
   intros x y Hx0 Hxy.
   apply notge_ltNonnegativeRationals.
@@ -1311,7 +1311,7 @@ Proof.
   exact H.
 Qed.
 Lemma invNonnegativeRationals_ltcompat' :
-  forall x y : NonnegativeRationals, 0 < y -> / y < / x -> x < y.
+  Π x y : NonnegativeRationals, 0 < y -> / y < / x -> x < y.
 Proof.
   intros x y Hy0 Hxy.
   rewrite <- (isinvolutive_invNonnegativeRationals x), <- (isinvolutive_invNonnegativeRationals y).
@@ -1322,7 +1322,7 @@ Proof.
 Qed.
 
 Lemma issublinear_invNonnegativeRationals :
-  forall x y : NonnegativeRationals, / (x + y) <= / x + / y.
+  Π x y : NonnegativeRationals, / (x + y) <= / x + / y.
 Proof.
   intros x y.
   destruct (eq0orgt0NonnegativeRationals x) as [Hx0 | Hx0].
@@ -1342,7 +1342,7 @@ Proof.
   now apply ispositive_plusNonnegativeRationals_l, Hx0.
 Qed.
 Lemma issublinear_invNonnegativeRationals_lt :
-  forall x y : NonnegativeRationals, (0 < x)%NRat -> (0 < y)%NRat -> (/ (x + y) < / x + / y)%NRat.
+  Π x y : NonnegativeRationals, (0 < x)%NRat -> (0 < y)%NRat -> (/ (x + y) < / x + / y)%NRat.
 Proof.
   intros x y Hx0 Hy0.
   apply_pr2 (multNonnegativeRationals_ltcompat_l x).
@@ -1365,7 +1365,7 @@ Qed.
 (** Rewritings *)
 
 Lemma multdivNonnegativeRationals :
-  ∀ q r : NonnegativeRationals, 0 < r -> r * (q / r) = q.
+  Π q r : NonnegativeRationals, 0 < r -> r * (q / r) = q.
 Proof.
   intros q r Hr0.
   unfold divNonnegativeRationals.
@@ -1376,7 +1376,7 @@ Proof.
 Qed.
 
 Lemma minus_divNonnegativeRationals :
-  forall x y : NonnegativeRationals, 0 < y -> / x - / y = (y - x) / (x * y).
+  Π x y : NonnegativeRationals, 0 < y -> / x - / y = (y - x) / (x * y).
 Proof.
   intros x y Hy0.
   destruct (eq0orgt0NonnegativeRationals x) as [Hx0 | Hx0].
@@ -1400,7 +1400,7 @@ Qed.
 (** Order *)
 
 Lemma ispositive_divNonnegativeRationals :
-  ∀ x y, 0 < x -> 0 < y -> 0 < x / y.
+  Π x y, 0 < x -> 0 < y -> 0 < x / y.
 Proof.
   intros x y Hx Hy.
   apply ispositive_multNonnegativeRationals.
@@ -1410,7 +1410,7 @@ Proof.
 Qed.
 
 Lemma divNonnegativeRationals_le1 :
-  ∀ q r : NonnegativeRationals, q <= r -> q / r <= 1.
+  Π q r : NonnegativeRationals, q <= r -> q / r <= 1.
 Proof.
   intros q r Hrq.
   destruct (eq0orgt0NonnegativeRationals r) as [Hr0 | Hr0].
@@ -1429,7 +1429,7 @@ Qed.
 
 (** ** NQhalf *)
 
-Lemma NQhalf_double : ∀ x, x = x / 2 + x / 2.
+Lemma NQhalf_double : Π x, x = x / 2 + x / 2.
 Proof.
   intros (x,Hx).
   unfold divNonnegativeRationals, invNonnegativeRationals, hnnq_inv, twoNonnegativeRationals, Rationals_to_NonnegativeRationals ; simpl pr1.
@@ -1442,7 +1442,7 @@ Proof.
   now apply (isirreflhqlth 2%hq).
 Qed.
 
-Lemma ispositive_NQhalf : ∀ x, (0 < x) <-> (0 < x / 2).
+Lemma ispositive_NQhalf : Π x, (0 < x) <-> (0 < x / 2).
 Proof.
   intro x.
   split ; intro Hx.
@@ -1469,7 +1469,7 @@ Definition NQmax : binop NonnegativeRationals :=
   | ii2 _ => x
   end.
 Lemma NQmax_eq_zero :
-  ∀ x y : NonnegativeRationals, NQmax x y = 0 -> (x = 0) × (y = 0).
+  Π x y : NonnegativeRationals, NQmax x y = 0 -> (x = 0) × (y = 0).
 Proof.
   intros x y.
   unfold NQmax.
@@ -1483,16 +1483,16 @@ Proof.
     now apply lt_leNonnegativeRationals, notge_ltNonnegativeRationals.
 Qed.
 Lemma NQmax_case :
-  ∀ (P : NonnegativeRationals -> UU),
-  ∀ x y : NonnegativeRationals, P x -> P y -> P (NQmax x y).
+  Π (P : NonnegativeRationals -> UU),
+  Π x y : NonnegativeRationals, P x -> P y -> P (NQmax x y).
 Proof.
   intros P x y Hx Hy.
   unfold NQmax.
   now destruct isdecrel_leNonnegativeRationals.
 Qed.
 Lemma NQmax_case_strong :
-  ∀ (P : NonnegativeRationals -> UU),
-  ∀ x y : NonnegativeRationals, (y <= x -> P x) -> (x <= y -> P y) -> P (NQmax x y).
+  Π (P : NonnegativeRationals -> UU),
+  Π x y : NonnegativeRationals, (y <= x -> P x) -> (x <= y -> P y) -> P (NQmax x y).
 Proof.
   intros P x y Hx Hy.
   unfold NQmax.
@@ -1502,7 +1502,7 @@ Proof.
     now apply lt_leNonnegativeRationals, notge_ltNonnegativeRationals.
 Qed.
 Lemma iscomm_NQmax :
-  ∀ x y, NQmax x y = NQmax y x.
+  Π x y, NQmax x y = NQmax y x.
 Proof.
   intros x y.
   apply NQmax_case_strong ; intro Hle ;
@@ -1513,7 +1513,7 @@ Proof.
   - now apply isantisymm_leNonnegativeRationals.
 Qed.
 Lemma NQmax_le_l :
-  ∀ x y : NonnegativeRationals, x <= NQmax x y.
+  Π x y : NonnegativeRationals, x <= NQmax x y.
 Proof.
   intros x y.
   apply NQmax_case_strong ; intro Hle.
@@ -1521,7 +1521,7 @@ Proof.
   - exact Hle.
 Qed.
 Lemma NQmax_le_r :
-  ∀ x y : NonnegativeRationals, y <= NQmax x y.
+  Π x y : NonnegativeRationals, y <= NQmax x y.
 Proof.
   intros x y.
   rewrite iscomm_NQmax.
@@ -1537,7 +1537,7 @@ Proof.
   reflexivity.
 Qed.
 Lemma nat_to_NonnegativeRationals_Sn :
-  ∀ n : nat, nat_to_NonnegativeRationals (S n) = nat_to_NonnegativeRationals n + 1.
+  Π n : nat, nat_to_NonnegativeRationals (S n) = nat_to_NonnegativeRationals n + 1.
 Proof.
   intro n.
   apply subtypeEquality_prop.
@@ -1552,7 +1552,7 @@ Proof.
   set (H := isarchhq).
   apply isarchfld_isarchrng in H.
   apply isarchrng_isarchrig in H.
-  assert (∀ n, pr1 (nattorig (X := pr1 (CommDivRig_DivRig NonnegativeRationals)) n) = nattorig (X := pr1fld hq) n).
+  assert (Π n, pr1 (nattorig (X := pr1 (CommDivRig_DivRig NonnegativeRationals)) n) = nattorig (X := pr1fld hq) n).
   { induction n.
     - reflexivity.
     - rewrite !nattorigS, <- IHn.

--- a/UniMath/Dedekind/NonnegativeReals.v
+++ b/UniMath/Dedekind/NonnegativeReals.v
@@ -14,17 +14,17 @@ Local Open Scope tap_scope.
 (** ** Definition of Dedekind cuts *)
 
 Definition Dcuts_def_bot (X : hsubtypes NonnegativeRationals) : UU :=
-  ∀ x : NonnegativeRationals, X x ->
-    ∀ y : NonnegativeRationals, y <= x -> X y.
+  Π x : NonnegativeRationals, X x ->
+    Π y : NonnegativeRationals, y <= x -> X y.
 Definition Dcuts_def_open (X : hsubtypes NonnegativeRationals) : UU :=
-  ∀ x : NonnegativeRationals, X x ->
+  Π x : NonnegativeRationals, X x ->
     hexists (fun y : NonnegativeRationals => (X y) × (x < y)).
 Definition Dcuts_def_finite (X : hsubtypes NonnegativeRationals) : hProp :=
   ∃ ub : NonnegativeRationals, ¬ (X ub).
 Definition Dcuts_def_error (X : hsubtypes NonnegativeRationals) : UU :=
-  ∀ r : NonnegativeRationals, 0 < r -> (¬ (X r)) ∨ Σ q : NonnegativeRationals, (X q) × (¬ (X (q + r))).
+  Π r : NonnegativeRationals, 0 < r -> (¬ (X r)) ∨ Σ q : NonnegativeRationals, (X q) × (¬ (X (q + r))).
 Definition Dcuts_def_error' (X : hsubtypes NonnegativeRationals) (k : NonnegativeRationals) : UU :=
-  ∀ r, 0 < r -> r <= k -> (¬ (X r)) ∨ Σ q : NonnegativeRationals, (0 < q) × (X q) × (¬ (X (q + r))).
+  Π r, 0 < r -> r <= k -> (¬ (X r)) ∨ Σ q : NonnegativeRationals, (0 < q) × (X q) × (¬ (X (q + r))).
 
 Lemma Dcuts_def_error'_correct1 (X : hsubtypes NonnegativeRationals) (k : NonnegativeRationals) :
   Dcuts_def_bot X -> Dcuts_def_open X ->
@@ -85,7 +85,7 @@ Qed.
 
 Lemma Dcuts_def_error_not_empty (X : hsubtypes NonnegativeRationals) :
   X 0 -> Dcuts_def_error X ->
-  ∀ c : NonnegativeRationals,
+  Π c : NonnegativeRationals,
     (0 < c)%NRat -> ∃ x : NonnegativeRationals, X x × ¬ X (x + c).
 Proof.
   intros X X0 Hx c Hc.
@@ -172,8 +172,8 @@ Proof.
 Defined.
 
 Lemma Dcuts_finite :
-  ∀ X : Dcuts_set, ∀ r : NonnegativeRationals,
-    neg (r ∈ X) -> ∀ n : NonnegativeRationals, n ∈ X -> n < r.
+  Π X : Dcuts_set, Π r : NonnegativeRationals,
+    neg (r ∈ X) -> Π n : NonnegativeRationals, n ∈ X -> n < r.
 Proof.
   intros X r Hr n Hn.
   apply notge_ltNonnegativeRationals ; intro Hn'.
@@ -189,7 +189,7 @@ Qed.
 
 Definition Dcuts_le_rel : hrel Dcuts_set :=
   λ X Y : Dcuts_set,
-          hProppair (∀ x : NonnegativeRationals, x ∈ X -> x ∈ Y)
+          hProppair (Π x : NonnegativeRationals, x ∈ X -> x ∈ Y)
                     (impred_isaprop _ (λ _, isapropimpl _ _ (pr2 _))).
 
 Lemma istrans_Dcuts_le_rel : istrans Dcuts_le_rel.
@@ -284,7 +284,7 @@ Qed.
 (** Effectively Ordered Set *)
 
 Lemma Dcuts_lt_le_rel :
-  ∀ x y : Dcuts_set, Dcuts_lt_rel x y -> Dcuts_le_rel x y.
+  Π x y : Dcuts_set, Dcuts_lt_rel x y -> Dcuts_le_rel x y.
 Proof.
   intros x y ; apply hinhuniv ; intros (r,(Xr,Yr)).
   intros n Xn.
@@ -295,7 +295,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_le_ngt_rel :
-  ∀ x y : Dcuts_set, ¬ Dcuts_lt_rel x y <-> Dcuts_le_rel y x.
+  Π x y : Dcuts_set, ¬ Dcuts_lt_rel x y <-> Dcuts_le_rel y x.
 Proof.
   intros X Y.
   split.
@@ -330,7 +330,7 @@ Proof.
 Qed.
 
 Lemma istrans_Dcuts_lt_le_rel :
-  ∀ x y z : Dcuts_set, Dcuts_lt_rel x y -> Dcuts_le_rel y z -> Dcuts_lt_rel x z.
+  Π x y z : Dcuts_set, Dcuts_lt_rel x y -> Dcuts_le_rel y z -> Dcuts_lt_rel x z.
 Proof.
   intros x y z Hlt Hle.
   revert Hlt ; apply hinhfun ; intros (r,(nXr,Yr)).
@@ -339,7 +339,7 @@ Proof.
   - now apply Hle.
 Qed.
 Lemma istrans_Dcuts_le_lt_rel :
-  ∀ x y z : Dcuts_set, Dcuts_le_rel x y -> Dcuts_lt_rel y z -> Dcuts_lt_rel x z.
+  Π x y z : Dcuts_set, Dcuts_le_rel x y -> Dcuts_lt_rel y z -> Dcuts_lt_rel x z.
 Proof.
   intros x y z Hle.
   apply hinhfun ; intros (r,(nYr,Zr)).
@@ -382,8 +382,8 @@ Notation "x > y" := (@EOgt_rel eo_Dcuts x y) : Dcuts_scope.
 (** ** Equivalence on [Dcuts] *)
 
 Definition Dcuts_eq_rel :=
-  λ X Y : Dcuts_set, ∀ r : NonnegativeRationals, (r ∈ X -> r ∈ Y) × (r ∈ Y -> r ∈ X).
-Lemma isaprop_Dcuts_eq_rel : ∀ X Y : Dcuts_set, isaprop (Dcuts_eq_rel X Y).
+  λ X Y : Dcuts_set, Π r : NonnegativeRationals, (r ∈ X -> r ∈ Y) × (r ∈ Y -> r ∈ X).
+Lemma isaprop_Dcuts_eq_rel : Π X Y : Dcuts_set, isaprop (Dcuts_eq_rel X Y).
 Proof.
   intros X Y.
   apply impred_isaprop ; intro r.
@@ -392,7 +392,7 @@ Proof.
   - now apply isapropimpl, pr2.
 Qed.
 Definition Dcuts_eq : hrel Dcuts_set :=
-  λ X Y : Dcuts_set, hProppair (∀ r, dirprod (r ∈ X -> r ∈ Y) (r ∈ Y -> r ∈ X)) (isaprop_Dcuts_eq_rel X Y).
+  λ X Y : Dcuts_set, hProppair (Π r, dirprod (r ∈ X -> r ∈ Y) (r ∈ Y -> r ∈ X)) (isaprop_Dcuts_eq_rel X Y).
 
 Lemma istrans_Dcuts_eq : istrans Dcuts_eq.
 Proof.
@@ -431,7 +431,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_eq_is_eq :
-  ∀ x y : Dcuts_set,
+  Π x y : Dcuts_set,
     Dcuts_eq x y -> x = y.
 Proof.
   intros x y Heq.
@@ -505,7 +505,7 @@ Definition Dcuts : tightapSet :=
     istight_Dcuts_ap_rel.
 
 Lemma not_Dcuts_ap_eq :
-  forall x y : Dcuts, ¬ (x ≠ y) -> (x = y).
+  Π x y : Dcuts, ¬ (x ≠ y) -> (x = y).
 Proof.
   intros x y.
   now apply istight_Dcuts_ap_rel.
@@ -514,31 +514,31 @@ Qed.
 (** *** Various theorems about order *)
 
 Lemma Dcuts_ge_le :
-  ∀ x y : Dcuts, x >= y -> y <= x.
+  Π x y : Dcuts, x >= y -> y <= x.
 Proof.
   easy.
 Qed.
 Lemma Dcuts_le_ge :
-  ∀ x y : Dcuts, x <= y -> y >= x.
+  Π x y : Dcuts, x <= y -> y >= x.
 Proof.
   easy.
 Qed.
 Lemma Dcuts_eq_le :
-  ∀ x y : Dcuts, Dcuts_eq x y -> x <= y.
+  Π x y : Dcuts, Dcuts_eq x y -> x <= y.
 Proof.
   intros x y Heq.
   intro r ;
     now apply (pr1 (Heq _)).
 Qed.
 Lemma Dcuts_eq_ge :
-  ∀ x y : Dcuts, Dcuts_eq x y -> x >= y.
+  Π x y : Dcuts, Dcuts_eq x y -> x >= y.
 Proof.
   intros x y Heq.
   apply Dcuts_eq_le.
   now apply issymm_Dcuts_eq.
 Qed.
 Lemma Dcuts_le_ge_eq :
-  ∀ x y : Dcuts, x <= y -> x >= y -> x = y.
+  Π x y : Dcuts, x <= y -> x >= y -> x = y.
 Proof.
   intros x y le_xy ge_xy.
   apply Dcuts_eq_is_eq.
@@ -548,31 +548,31 @@ Proof.
 Qed.
 
 Lemma Dcuts_gt_lt :
-  ∀ x y : Dcuts, (x > y) <-> (y < x).
+  Π x y : Dcuts, (x > y) <-> (y < x).
 Proof.
   now split.
 Qed.
 Lemma Dcuts_gt_ge :
-  ∀ x y : Dcuts, x > y -> x >= y.
+  Π x y : Dcuts, x > y -> x >= y.
 Proof.
   intros x y.
   now apply Dcuts_lt_le_rel.
 Qed.
 
 Lemma Dcuts_gt_nle :
-  ∀ x y : Dcuts, x > y -> neg (x <= y).
+  Π x y : Dcuts, x > y -> neg (x <= y).
 Proof.
   intros x y Hlt Hle.
   now apply (pr2 (Dcuts_le_ngt_rel _ _)) in Hle.
 Qed.
 Lemma Dcuts_nlt_ge :
-  ∀ x y : Dcuts, neg (x < y) <-> (x >= y).
+  Π x y : Dcuts, neg (x < y) <-> (x >= y).
 Proof.
   intros X Y.
   now apply Dcuts_le_ngt_rel.
 Qed.
 Lemma Dcuts_lt_nge :
-  ∀ x y : Dcuts, x < y -> neg (x >= y).
+  Π x y : Dcuts, x < y -> neg (x >= y).
 Proof.
   intros x y.
   now apply Dcuts_gt_nle.
@@ -629,7 +629,7 @@ Definition NonnegativeRationals_to_Dcuts (q : NonnegativeRationals) : Dcuts :=
 
 
 Lemma isapfun_NonnegativeRationals_to_Dcuts_aux :
-  ∀ q q' : NonnegativeRationals,
+  Π q q' : NonnegativeRationals,
     NonnegativeRationals_to_Dcuts q < NonnegativeRationals_to_Dcuts q'
     <-> (q < q')%NRat.
 Proof.
@@ -648,7 +648,7 @@ Proof.
     exact H.
 Qed.
 Lemma isapfun_NonnegativeRationals_to_Dcuts :
-  ∀ q q' : NonnegativeRationals,
+  Π q q' : NonnegativeRationals,
     NonnegativeRationals_to_Dcuts q ≠ NonnegativeRationals_to_Dcuts q'
     -> q != q'.
 Proof.
@@ -658,7 +658,7 @@ Proof.
   now apply gtNonnegativeRationals_noteq, isapfun_NonnegativeRationals_to_Dcuts_aux.
 Qed.
 Lemma isapfun_NonnegativeRationals_to_Dcuts' :
-  ∀ q q' : NonnegativeRationals,
+  Π q q' : NonnegativeRationals,
     q != q'
     -> NonnegativeRationals_to_Dcuts q ≠ NonnegativeRationals_to_Dcuts q'.
 Proof.
@@ -680,14 +680,14 @@ Notation "2" := Dcuts_two : Dcuts_scope.
 (** Various usefull theorems *)
 
 Lemma Dcuts_zero_empty :
-  forall r : NonnegativeRationals, neg (r ∈ 0).
+  Π r : NonnegativeRationals, neg (r ∈ 0).
 Proof.
   intros r ; simpl.
   change (neg (r < 0)%NRat).
   now apply isnonnegative_NonnegativeRationals'.
 Qed.
 Lemma Dcuts_notempty_notzero :
-  forall (x : Dcuts) (r : NonnegativeRationals), r ∈ x -> x ≠ 0.
+  Π (x : Dcuts) (r : NonnegativeRationals), r ∈ x -> x ≠ 0.
 Proof.
   intros x r Hx.
   right.
@@ -699,7 +699,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_ge_0 :
-  ∀ x : Dcuts, Dcuts_zero <= x.
+  Π x : Dcuts, Dcuts_zero <= x.
 Proof.
   intros x r Hr.
   apply fromempty.
@@ -707,7 +707,7 @@ Proof.
   now apply Dcuts_zero_empty.
 Qed.
 Lemma Dcuts_notlt_0 :
-  ∀ x : Dcuts, ¬ (x < Dcuts_zero).
+  Π x : Dcuts, ¬ (x < Dcuts_zero).
 Proof.
   intros x.
   unfold neg.
@@ -718,7 +718,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_apzero_notempty :
-  forall (x : Dcuts), (0%NRat ∈ x) <-> x ≠ 0.
+  Π (x : Dcuts), (0%NRat ∈ x) <-> x ≠ 0.
 Proof.
   intros x ; split.
   - now apply Dcuts_notempty_notzero.
@@ -731,7 +731,7 @@ Proof.
 Qed.
 
 Lemma NonnegativeRationals_to_Dcuts_notin_le :
-  ∀ (x : Dcuts) (r : NonnegativeRationals),
+  Π (x : Dcuts) (r : NonnegativeRationals),
     ¬ (r ∈ x) -> x <= NonnegativeRationals_to_Dcuts r.
 Proof.
   intros x r Hr q Hq.
@@ -1362,11 +1362,11 @@ Context (X_0 : X 0%NRat).
 
 Definition Dcuts_inv_val : hsubtypes NonnegativeRationals :=
   λ r : NonnegativeRationals,
-        hexists (λ l : NonnegativeRationals, (∀ rx : NonnegativeRationals, X rx -> (r * rx <= l)%NRat)
+        hexists (λ l : NonnegativeRationals, (Π rx : NonnegativeRationals, X rx -> (r * rx <= l)%NRat)
                                                × (0 < l)%NRat × (l < 1)%NRat).
 
 Lemma Dcuts_inv_in :
-  ∀ x, (0 < x)%NRat -> X x -> (Dcuts_inv_val (/ x)%NRat) -> empty.
+  Π x, (0 < x)%NRat -> X x -> (Dcuts_inv_val (/ x)%NRat) -> empty.
 Proof.
   intros x Hx0 Xx.
   unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; intros (l,(H,(Hl0,Hl1))).
@@ -1377,7 +1377,7 @@ Proof.
   exact Hx0.
 Qed.
 Lemma Dcuts_inv_out :
-  ∀ x, ¬ (X x) -> ∀ y, (x < y)%NRat -> Dcuts_inv_val (/ y)%NRat.
+  Π x, ¬ (X x) -> Π y, (x < y)%NRat -> Dcuts_inv_val (/ y)%NRat.
 Proof.
   intros x nXx y Hy.
   apply hinhpr.
@@ -1483,7 +1483,7 @@ Context (X_1 : X 1%NRat).
 
 Lemma Dcuts_inv_error_aux : Dcuts_def_error Dcuts_inv_val.
 Proof.
-  assert (∀ c, (0 < c)%NRat -> hexists (λ q : NonnegativeRationals, X q × ¬ X (q + c))).
+  assert (Π c, (0 < c)%NRat -> hexists (λ q : NonnegativeRationals, X q × ¬ X (q + c))).
   { intros c Hc0.
     generalize (X_error c Hc0) ; apply hinhuniv ; intros [nXc | H].
     - apply hinhpr.
@@ -1616,7 +1616,7 @@ Defined.
 (** ** Algebraic properties *)
 
 Lemma Dcuts_NQmult_mult :
-  ∀ (x : NonnegativeRationals) (y : Dcuts) (Hx0 : (0 < x)%NRat), Dcuts_NQmult x y Hx0 = Dcuts_mult (NonnegativeRationals_to_Dcuts x) y.
+  Π (x : NonnegativeRationals) (y : Dcuts) (Hx0 : (0 < x)%NRat), Dcuts_NQmult x y Hx0 = Dcuts_mult (NonnegativeRationals_to_Dcuts x) y.
 Proof.
   intros x y Hx0.
   apply Dcuts_eq_is_eq.
@@ -1670,7 +1670,7 @@ Qed.
 
 Lemma iscomm_Dcuts_plus : iscomm Dcuts_plus.
 Proof.
-  assert (H : ∀ x y, ∀ x0 : NonnegativeRationals, x0 ∈ Dcuts_plus x y -> x0 ∈ Dcuts_plus y x).
+  assert (H : Π x y, Π x0 : NonnegativeRationals, x0 ∈ Dcuts_plus x y -> x0 ∈ Dcuts_plus y x).
   { intros x y r.
     apply hinhuniv, sumofmaps ; apply hinhuniv ; simpl pr1.
     - apply sumofmaps ; intros Hr.
@@ -1694,7 +1694,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_plus_lt_l :
-  ∀ x x' y : Dcuts, Dcuts_plus x y < Dcuts_plus x' y -> x < x'.
+  Π x x' y : Dcuts, Dcuts_plus x y < Dcuts_plus x' y -> x < x'.
 Proof.
   intros x x' y.
   apply hinhuniv ; intros (r,(Nr,Hr)).
@@ -1749,7 +1749,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_mult_lt_l :
-  ∀ x x' y : Dcuts, Dcuts_mult x y < Dcuts_mult x' y -> x < x'.
+  Π x x' y : Dcuts, Dcuts_mult x y < Dcuts_mult x' y -> x < x'.
 Proof.
   intros x x' y.
   apply hinhuniv ; intros (r,(Nr)).
@@ -1960,7 +1960,7 @@ Proof.
   now apply islunit_Dcuts_mult_one.
 Qed.
 Lemma islabsorb_Dcuts_mult_zero :
-  ∀ x : Dcuts, Dcuts_mult Dcuts_zero x = Dcuts_zero.
+  Π x : Dcuts, Dcuts_mult Dcuts_zero x = Dcuts_zero.
 Proof.
   intros x.
   apply Dcuts_eq_is_eq ; intro r ; split.
@@ -1970,7 +1970,7 @@ Proof.
     now apply Dcuts_zero_empty in Hr.
 Qed.
 Lemma israbsorb_Dcuts_mult_zero :
-  ∀ x : Dcuts, Dcuts_mult x Dcuts_zero = Dcuts_zero.
+  Π x : Dcuts, Dcuts_mult x Dcuts_zero = Dcuts_zero.
 Proof.
   intros x.
   rewrite iscomm_Dcuts_mult.
@@ -2060,7 +2060,7 @@ Proof.
   exact ispositive_oneNonnegativeRationals.
 Qed.
 Definition islinv_Dcuts_inv :
-  ∀ x : Dcuts, ∀ Hx0 : x ≠ 0, Dcuts_mult (Dcuts_inv x Hx0) x = 1.
+  Π x : Dcuts, Π Hx0 : x ≠ 0, Dcuts_mult (Dcuts_inv x Hx0) x = 1.
 Proof.
   intros x Hx0.
   apply Dcuts_eq_is_eq ; intro q ; split.
@@ -2172,7 +2172,7 @@ Proof.
         now apply NQmax_case.
 Qed.
 Lemma isrinv_Dcuts_inv :
-  ∀ x : Dcuts, ∀ Hx0 : x ≠ 0, Dcuts_mult x (Dcuts_inv x Hx0) = 1.
+  Π x : Dcuts, Π Hx0 : x ≠ 0, Dcuts_mult x (Dcuts_inv x Hx0) = 1.
 Proof.
   intros x Hx0.
   rewrite iscomm_Dcuts_mult.
@@ -2180,7 +2180,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_plus_ltcompat_l :
-  ∀ x y z: Dcuts, (y < z) <-> (Dcuts_plus y x < Dcuts_plus z x).
+  Π x y z: Dcuts, (y < z) <-> (Dcuts_plus y x < Dcuts_plus z x).
 Proof.
   intros x y z.
   split.
@@ -2232,7 +2232,7 @@ Proof.
   - now apply Dcuts_plus_lt_l.
 Qed.
 Lemma Dcuts_plus_lecompat_l :
-  ∀ x y z: Dcuts, (y <= z) <-> (Dcuts_plus y x <= Dcuts_plus z x).
+  Π x y z: Dcuts, (y <= z) <-> (Dcuts_plus y x <= Dcuts_plus z x).
 Proof.
   intros x y z.
   split.
@@ -2242,14 +2242,14 @@ Proof.
     now apply Dcuts_plus_ltcompat_l.
 Qed.
 Lemma Dcuts_plus_ltcompat_r :
-  ∀ x y z: Dcuts, (y < z) <-> (Dcuts_plus x y < Dcuts_plus x z).
+  Π x y z: Dcuts, (y < z) <-> (Dcuts_plus x y < Dcuts_plus x z).
 Proof.
   intros x y z.
   rewrite ! (iscomm_Dcuts_plus x).
   now apply Dcuts_plus_ltcompat_l.
 Qed.
 Lemma Dcuts_plus_lecompat_r :
-  ∀ x y z: Dcuts, (y <= z) <-> (Dcuts_plus x y <= Dcuts_plus x z).
+  Π x y z: Dcuts, (y <= z) <-> (Dcuts_plus x y <= Dcuts_plus x z).
 Proof.
   intros x y z.
   rewrite ! (iscomm_Dcuts_plus x).
@@ -2257,14 +2257,14 @@ Proof.
 Qed.
 
 Lemma Dcuts_plus_le_l :
-  ∀ x y, x <= Dcuts_plus x y.
+  Π x y, x <= Dcuts_plus x y.
 Proof.
   intros x y r Xr.
   apply hinhpr ; left.
   now apply hinhpr ; left.
 Qed.
 Lemma Dcuts_plus_le_r :
-  ∀ x y, y <= Dcuts_plus x y.
+  Π x y, y <= Dcuts_plus x y.
 Proof.
   intros x y r Xr.
   apply hinhpr ; left.
@@ -2272,7 +2272,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_mult_ltcompat_l :
-  ∀ x y z: Dcuts, (0 < x) -> (y < z) -> (Dcuts_mult y x < Dcuts_mult z x).
+  Π x y z: Dcuts, (0 < x) -> (y < z) -> (Dcuts_mult y x < Dcuts_mult z x).
 Proof.
   intros X Y Z.
   apply hinhuniv2 ; intros (x,(_,Xx)) (r,(nYr,Zr)).
@@ -2335,20 +2335,20 @@ Proof.
         now apply istrans_ltNonnegativeRationals with r.
 Qed.
 Lemma Dcuts_mult_ltcompat_l' :
-  ∀ x y z: Dcuts, (Dcuts_mult y x < Dcuts_mult z x) -> (y < z).
+  Π x y z: Dcuts, (Dcuts_mult y x < Dcuts_mult z x) -> (y < z).
 Proof.
   intros x y z.
   now apply Dcuts_mult_lt_l.
 Qed.
 Lemma Dcuts_mult_lecompat_l :
-  ∀ x y z: Dcuts, (0 < x) -> (Dcuts_mult y x <= Dcuts_mult z x) -> (y <= z).
+  Π x y z: Dcuts, (0 < x) -> (Dcuts_mult y x <= Dcuts_mult z x) -> (y <= z).
 Proof.
   intros x y z Hx0.
   intros H ; apply Dcuts_nlt_ge ; intro H0 ; apply (pr2 (Dcuts_nlt_ge _ _) H).
   now apply Dcuts_mult_ltcompat_l.
 Qed.
 Lemma Dcuts_mult_lecompat_l' :
-  ∀ x y z: Dcuts, (y <= z) -> (Dcuts_mult y x <= Dcuts_mult z x).
+  Π x y z: Dcuts, (y <= z) -> (Dcuts_mult y x <= Dcuts_mult z x).
 Proof.
   intros x y z.
   intros H ; apply Dcuts_nlt_ge ; intro H0 ; apply (pr2 (Dcuts_nlt_ge _ _) H).
@@ -2356,28 +2356,28 @@ Proof.
 Qed.
 
 Lemma Dcuts_mult_ltcompat_r :
-  ∀ x y z: Dcuts, (0 < x) -> (y < z) -> (Dcuts_mult x y < Dcuts_mult x z).
+  Π x y z: Dcuts, (0 < x) -> (y < z) -> (Dcuts_mult x y < Dcuts_mult x z).
 Proof.
   intros x y z.
   rewrite ! (iscomm_Dcuts_mult x).
   now apply Dcuts_mult_ltcompat_l.
 Qed.
 Lemma Dcuts_mult_ltcompat_r' :
-  ∀ x y z: Dcuts, (Dcuts_mult x y < Dcuts_mult x z) -> (y < z).
+  Π x y z: Dcuts, (Dcuts_mult x y < Dcuts_mult x z) -> (y < z).
 Proof.
   intros x y z.
   rewrite ! (iscomm_Dcuts_mult x).
   now apply Dcuts_mult_ltcompat_l'.
 Qed.
 Lemma Dcuts_mult_lecompat_r :
-  ∀ x y z: Dcuts, (0 < x) -> (Dcuts_mult x y <= Dcuts_mult x z) -> (y <= z).
+  Π x y z: Dcuts, (0 < x) -> (Dcuts_mult x y <= Dcuts_mult x z) -> (y <= z).
 Proof.
   intros x y z.
   rewrite ! (iscomm_Dcuts_mult x).
   now apply Dcuts_mult_lecompat_l.
 Qed.
 Lemma Dcuts_mult_lecompat_r' :
-  ∀ x y z: Dcuts, (y <= z) -> (Dcuts_mult x y <= Dcuts_mult x z).
+  Π x y z: Dcuts, (y <= z) -> (Dcuts_mult x y <= Dcuts_mult x z).
 Proof.
   intros x y z.
   rewrite ! (iscomm_Dcuts_mult x).
@@ -2385,7 +2385,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_plus_double :
-  ∀ x : Dcuts, Dcuts_plus x x = Dcuts_mult Dcuts_two x.
+  Π x : Dcuts, Dcuts_plus x x = Dcuts_mult Dcuts_two x.
 Proof.
   intros x.
   rewrite <- (Dcuts_NQmult_mult _ _ ispositive_twoNonnegativeRationals).
@@ -2515,7 +2515,7 @@ Section Dcuts_minus.
   Context (Y_error : Dcuts_def_error Y).
 
 Definition Dcuts_minus_val : hsubtypes NonnegativeRationals :=
-  fun r => hexists (λ x, X x × ∀ y, (Y y) ⨿ (y = 0%NRat) -> (r < x - y)%NRat).
+  fun r => hexists (λ x, X x × Π y, (Y y) ⨿ (y = 0%NRat) -> (r < x - y)%NRat).
 
 Lemma Dcuts_minus_bot : Dcuts_def_bot Dcuts_minus_val.
 Proof.
@@ -2601,7 +2601,7 @@ Proof.
     now right.
   - destruct Hx as (x,(Xx,nXx)).
     case (isdecrel_leNonnegativeRationals (y + c / 2)%NRat x) ; intro Hxy.
-    + assert (HY : ∀ y', coprod (Y y') (y' = 0%NRat) -> (y' < y + c / 2)%NRat).
+    + assert (HY : Π y', coprod (Y y') (y' = 0%NRat) -> (y' < y + c / 2)%NRat).
       { intros y' [Yy' | Yy'].
         apply notge_ltNonnegativeRationals ; intro H ; apply nYy.
         now apply Y_bot with (1 := Yy').
@@ -2673,7 +2673,7 @@ Definition Dcuts_minus (X Y : Dcuts) : Dcuts :=
                               (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_error Y)).
 
 Lemma Dcuts_minus_correct_l:
-  ∀ x y z : Dcuts, x = Dcuts_plus y z -> z = Dcuts_minus x y.
+  Π x y z : Dcuts, x = Dcuts_plus y z -> z = Dcuts_minus x y.
 Proof.
   intros _ Y Z ->.
   apply Dcuts_eq_is_eq ; intro r ; split.
@@ -2734,7 +2734,7 @@ Proof.
       now left.
 Qed.
 Lemma Dcuts_minus_correct_r:
-  ∀ x y z : Dcuts, x = Dcuts_plus y z -> y = Dcuts_minus x z.
+  Π x y z : Dcuts, x = Dcuts_plus y z -> y = Dcuts_minus x z.
 Proof.
   intros x y z Hx.
   apply Dcuts_minus_correct_l.
@@ -2742,7 +2742,7 @@ Proof.
   now apply iscomm_Dcuts_plus.
 Qed.
 Lemma Dcuts_minus_eq_zero:
-  ∀ x y : Dcuts, x <= y -> Dcuts_minus x y = 0.
+  Π x y : Dcuts, x <= y -> Dcuts_minus x y = 0.
 Proof.
   intros X Y Hxy.
   apply Dcuts_eq_is_eq ; intros r ; split.
@@ -2754,7 +2754,7 @@ Proof.
     now apply fromempty ; apply (Dcuts_zero_empty r).
 Qed.
 Lemma Dcuts_minus_plus_r:
-  ∀ x y z : Dcuts, z <= y -> x = Dcuts_minus y z -> y = Dcuts_plus x z.
+  Π x y z : Dcuts, z <= y -> x = Dcuts_minus y z -> y = Dcuts_plus x z.
 Proof.
   intros _ Y Z Hyz ->.
   apply Dcuts_eq_is_eq ; intro r ; split.
@@ -2844,7 +2844,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_minus_le :
-  ∀ x y, Dcuts_minus x y <= x.
+  Π x y, Dcuts_minus x y <= x.
 Proof.
   intros X Y r.
   apply hinhuniv ; intros (x,(Xx,Hx)).
@@ -2855,7 +2855,7 @@ Proof.
 Qed.
 
 Lemma ispositive_Dcuts_minus :
-  ∀ x y : Dcuts, (y < x) <-> (0 < Dcuts_minus x y).
+  Π x y : Dcuts, (y < x) <-> (0 < Dcuts_minus x y).
 Proof.
   intros X Y.
   split.
@@ -2970,7 +2970,7 @@ Definition Dcuts_max (X Y : Dcuts) : Dcuts :=
                             (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_error Y)).
 
 Lemma iscomm_Dcuts_max :
-  ∀ x y : Dcuts, Dcuts_max x y = Dcuts_max y x.
+  Π x y : Dcuts, Dcuts_max x y = Dcuts_max y x.
 Proof.
   intros x y.
   apply Dcuts_eq_is_eq ; intros r.
@@ -2978,14 +2978,14 @@ Proof.
 Qed.
 
 Lemma Dcuts_max_le_l :
-  ∀ x y : Dcuts, x <= Dcuts_max x y.
+  Π x y : Dcuts, x <= Dcuts_max x y.
 Proof.
   intros x y r Xr.
   apply hinhpr.
   now left.
 Qed.
 Lemma Dcuts_max_le_r :
-  ∀ x y : Dcuts, y <= Dcuts_max x y.
+  Π x y : Dcuts, y <= Dcuts_max x y.
 Proof.
   intros x y r Xr.
   apply hinhpr.
@@ -2993,7 +2993,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_max_carac_l :
-  ∀ x y : Dcuts, y <= x -> Dcuts_max x y = x.
+  Π x y : Dcuts, y <= x -> Dcuts_max x y = x.
 Proof.
   intros x y Hxy.
   apply Dcuts_eq_is_eq ; intros r ; split.
@@ -3004,7 +3004,7 @@ Proof.
     now apply hinhpr ; left.
 Qed.
 Lemma Dcuts_max_carac_r :
-  ∀ x y : Dcuts, x <= y -> Dcuts_max x y = y.
+  Π x y : Dcuts, x <= y -> Dcuts_max x y = y.
 Proof.
   intros x y Hxy.
   rewrite iscomm_Dcuts_max.
@@ -3012,7 +3012,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_minus_plus_max :
-  ∀ x y : Dcuts, Dcuts_plus (Dcuts_minus x y) y = Dcuts_max x y.
+  Π x y : Dcuts, Dcuts_plus (Dcuts_minus x y) y = Dcuts_max x y.
 Proof.
   intros X Y.
   apply Dcuts_eq_is_eq ; intros r ; split.
@@ -3064,7 +3064,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_max_le :
-  ∀ x y z, x <= z -> y <= z -> Dcuts_max x y <= z.
+  Π x y z, x <= z -> y <= z -> Dcuts_max x y <= z.
 Proof.
   intros x y z Hx Hy r.
   apply hinhuniv ; intros [Xr|Yr].
@@ -3072,7 +3072,7 @@ Proof.
   now apply Hy.
 Qed.
 Lemma Dcuts_max_lt :
-  ∀ x y z : Dcuts, x < z -> y < z -> Dcuts_max x y < z.
+  Π x y z : Dcuts, x < z -> y < z -> Dcuts_max x y < z.
 Proof.
   intros x y z.
   apply hinhfun2 ; intros (rx,(Xrx,Zrx)) (ry,(Yry,Zry)).
@@ -3237,7 +3237,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_max_plus :
-  ∀ x y : Dcuts,
+  Π x y : Dcuts,
     (0 < x -> y = 0) ->
     Dcuts_max x y = Dcuts_plus x y.
 Proof.
@@ -3335,7 +3335,7 @@ Definition Dcuts_half (x : Dcuts) : Dcuts :=
            (Dcuts_half_error (pr1 x) (is_Dcuts_bot x) (is_Dcuts_error x)).
 
 Lemma Dcuts_half_le :
-  ∀ x : Dcuts, Dcuts_half x <= x.
+  Π x : Dcuts, Dcuts_half x <= x.
 Proof.
   intros x.
   intros r Hr.
@@ -3344,7 +3344,7 @@ Proof.
 Qed.
 
 Lemma isdistr_Dcuts_half_plus :
-  forall x y : Dcuts, Dcuts_half (Dcuts_plus x y) = Dcuts_plus (Dcuts_half x) (Dcuts_half y).
+  Π x y : Dcuts, Dcuts_half (Dcuts_plus x y) = Dcuts_plus (Dcuts_half x) (Dcuts_half y).
 Proof.
   intros x y.
   apply Dcuts_eq_is_eq.
@@ -3390,7 +3390,7 @@ Proof.
       * exact Yr.
 Qed.
 Lemma Dcuts_half_double :
-  ∀ x : Dcuts, x = Dcuts_plus (Dcuts_half x) (Dcuts_half x).
+  Π x : Dcuts, x = Dcuts_plus (Dcuts_half x) (Dcuts_half x).
 Proof.
   intros x.
   rewrite  <- isdistr_Dcuts_half_plus.
@@ -3413,7 +3413,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_half_correct :
-  ∀ x, Dcuts_half x = Dcuts_mult x (Dcuts_inv Dcuts_two Dcuts_two_ap_zero).
+  Π x, Dcuts_half x = Dcuts_mult x (Dcuts_inv Dcuts_two Dcuts_two_ap_zero).
 Proof.
   intros x.
   pattern x at 2 ; rewrite (Dcuts_half_double x).
@@ -3422,7 +3422,7 @@ Proof.
 Qed.
 
 Lemma ispositive_Dcuts_half:
-  ∀ x : Dcuts, (0 < x) <-> (0 < Dcuts_half x).
+  Π x : Dcuts, (0 < x) <-> (0 < Dcuts_half x).
 Proof.
   intros.
   rewrite Dcuts_half_correct.
@@ -3442,7 +3442,7 @@ Qed.
 (** ** Locatedness *)
 
 Lemma Dcuts_locatedness :
-  ∀ X : Dcuts, ∀ p q : NonnegativeRationals, (p < q)%NRat -> p ∈ X ∨ ¬ (q ∈ X).
+  Π X : Dcuts, Π p q : NonnegativeRationals, (p < q)%NRat -> p ∈ X ∨ ¬ (q ∈ X).
 Proof.
   intros X p q Hlt.
   apply ispositive_minusNonnegativeRationals in Hlt.
@@ -3473,19 +3473,19 @@ Qed.
 Section Dcuts_lim.
 
 Context (U : nat -> hsubtypes NonnegativeRationals)
-        (U_bot : ∀ n : nat, Dcuts_def_bot (U n))
-        (U_open : ∀ n : nat, Dcuts_def_open (U n))
-        (U_error : ∀ n : nat, Dcuts_def_error (U n)).
+        (U_bot : Π n : nat, Dcuts_def_bot (U n))
+        (U_open : Π n : nat, Dcuts_def_open (U n))
+        (U_error : Π n : nat, Dcuts_def_error (U n)).
 
 Context (U_cauchy :
-           ∀ eps : NonnegativeRationals,
+           Π eps : NonnegativeRationals,
                    (0 < eps)%NRat ->
                    hexists
                      (λ N : nat,
-                            ∀ n m : nat, N ≤ n -> N ≤ m -> (forall r, U n r -> Dcuts_plus_val (U m) (λ q, (q < eps)%NRat) r) × (forall r, U m r -> Dcuts_plus_val (U n) (λ q, (q < eps)%NRat) r))).
+                            Π n m : nat, N ≤ n -> N ≤ m -> (Π r, U n r -> Dcuts_plus_val (U m) (λ q, (q < eps)%NRat) r) × (Π r, U m r -> Dcuts_plus_val (U n) (λ q, (q < eps)%NRat) r))).
 
 Definition Dcuts_lim_cauchy_val : hsubtypes NonnegativeRationals :=
-λ r : NonnegativeRationals, hexists (λ c : NonnegativeRationals, (0 < c)%NRat × Σ N : nat, ∀ n : nat, N ≤ n -> U n (r + c)).
+λ r : NonnegativeRationals, hexists (λ c : NonnegativeRationals, (0 < c)%NRat × Σ N : nat, Π n : nat, N ≤ n -> U n (r + c)).
 
 Lemma Dcuts_lim_cauchy_bot : Dcuts_def_bot Dcuts_lim_cauchy_val.
 Proof.
@@ -3703,18 +3703,18 @@ Qed.
 End Dcuts_lim.
 
 Definition Dcuts_Cauchy_seq (u : nat -> Dcuts) : hProp
-  := hProppair (∀ eps : Dcuts,
+  := hProppair (Π eps : Dcuts,
                    0 < eps ->
                    hexists
                      (λ N : nat,
-                            ∀ n m : nat, N ≤ n -> N ≤ m -> u n < Dcuts_plus (u m) eps × u m < Dcuts_plus (u n) eps))
+                            Π n m : nat, N ≤ n -> N ≤ m -> u n < Dcuts_plus (u m) eps × u m < Dcuts_plus (u n) eps))
                (impred_isaprop _ (λ _, isapropimpl _ _ (pr2 _))).
 Definition is_Dcuts_lim_seq (u : nat -> Dcuts) (l : Dcuts) : hProp
-  := hProppair (∀ eps : Dcuts,
+  := hProppair (Π eps : Dcuts,
                    0 < eps ->
                    hexists
                      (λ N : nat,
-                            ∀ n : nat, N ≤ n -> u n < Dcuts_plus l eps × l < Dcuts_plus (u n) eps))
+                            Π n : nat, N ≤ n -> u n < Dcuts_plus l eps × l < Dcuts_plus (u n) eps))
                (impred_isaprop _ (λ _, isapropimpl _ _ (pr2 _))).
 
 Definition Dcuts_lim_cauchy_seq (u : nat -> Dcuts) (Hu : Dcuts_Cauchy_seq u) : Dcuts.
@@ -3864,16 +3864,16 @@ Qed.
 Section Dcuts_of_Dcuts.
 
 Context (E : hsubtypes Dcuts).
-Context (E_bot : ∀ x : Dcuts, E x -> ∀ y : Dcuts, y <= x -> E y).
-Context (E_open : ∀ x : Dcuts, E x -> ∃ y : Dcuts, x < y × E y).
-Context (E_error: ∀ c : Dcuts, 0 < c -> (¬ E c) ∨ (hexists (λ P, E P × ¬ E (Dcuts_plus P c)))).
+Context (E_bot : Π x : Dcuts, E x -> Π y : Dcuts, y <= x -> E y).
+Context (E_open : Π x : Dcuts, E x -> ∃ y : Dcuts, x < y × E y).
+Context (E_error: Π c : Dcuts, 0 < c -> (¬ E c) ∨ (hexists (λ P, E P × ¬ E (Dcuts_plus P c)))).
 
 Definition Dcuts_of_Dcuts_val : NonnegativeRationals -> hProp :=
   λ r : NonnegativeRationals, ∃ X : Dcuts, (E X) × (r ∈ X).
 
 Lemma Dcuts_of_Dcuts_bot :
-  ∀ (x : NonnegativeRationals),
-    Dcuts_of_Dcuts_val x -> ∀ y : NonnegativeRationals, (y <= x)%NRat -> Dcuts_of_Dcuts_val y.
+  Π (x : NonnegativeRationals),
+    Dcuts_of_Dcuts_val x -> Π y : NonnegativeRationals, (y <= x)%NRat -> Dcuts_of_Dcuts_val y.
 Proof.
   intros r Xr n Xn.
   revert Xr ; apply hinhfun ; intros (X,(Ex,Xr)).
@@ -3883,7 +3883,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_of_Dcuts_open :
-  ∀ (x : NonnegativeRationals),
+  Π (x : NonnegativeRationals),
     Dcuts_of_Dcuts_val x ->
     hexists (fun y : NonnegativeRationals => dirprod (Dcuts_of_Dcuts_val y) (x < y)%NRat).
 Proof.
@@ -4015,8 +4015,8 @@ Definition Dcuts_of_Dcuts'_val : hsubtypes Dcuts :=
   λ x : Dcuts, ∃ r : NonnegativeRationals, (¬ (r ∈ x)) × E r.
 
 Lemma Dcuts_of_Dcuts'_bot :
-  ∀ (x : Dcuts),
-    Dcuts_of_Dcuts'_val x -> ∀ y : Dcuts, (y <= x) -> Dcuts_of_Dcuts'_val y.
+  Π (x : Dcuts),
+    Dcuts_of_Dcuts'_val x -> Π y : Dcuts, (y <= x) -> Dcuts_of_Dcuts'_val y.
 Proof.
   intros r Xr n Xn.
   revert Xr.
@@ -4031,7 +4031,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_of_Dcuts'_open :
-  ∀ (x : Dcuts),
+  Π (x : Dcuts),
     Dcuts_of_Dcuts'_val x ->
     hexists (fun y : Dcuts => dirprod (Dcuts_of_Dcuts'_val y) (x < y)).
 Proof.
@@ -4058,7 +4058,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_of_Dcuts'_error:
-  ∀ c : Dcuts, 0 < c -> (¬ Dcuts_of_Dcuts'_val c) ∨ (hexists (λ P, Dcuts_of_Dcuts'_val P × ¬ Dcuts_of_Dcuts'_val (Dcuts_plus P c))).
+  Π c : Dcuts, 0 < c -> (¬ Dcuts_of_Dcuts'_val c) ∨ (hexists (λ P, Dcuts_of_Dcuts'_val P × ¬ Dcuts_of_Dcuts'_val (Dcuts_plus P c))).
 Proof.
   intros C HC.
   assert (∃ c : NonnegativeRationals, c ∈ C × (0 < c)%NRat).
@@ -4125,7 +4125,7 @@ Qed.
 End Dcuts_of_Dcuts'.
 
 Lemma Dcuts_of_Dcuts_bij :
-  ∀ x : Dcuts, Dcuts_of_Dcuts (Dcuts_of_Dcuts'_val (pr1 x)) (Dcuts_of_Dcuts'_bot (pr1 x)) (Dcuts_of_Dcuts'_error (pr1 x) (is_Dcuts_bot x) (is_Dcuts_error x)) = x.
+  Π x : Dcuts, Dcuts_of_Dcuts (Dcuts_of_Dcuts'_val (pr1 x)) (Dcuts_of_Dcuts'_bot (pr1 x)) (Dcuts_of_Dcuts'_error (pr1 x) (is_Dcuts_bot x) (is_Dcuts_error x)) = x.
 Proof.
   intros x.
   apply Dcuts_eq_is_eq.
@@ -4157,7 +4157,7 @@ Proof.
       exact (pr2 (pr2 q)).
 Qed.
 Lemma Dcuts_of_Dcuts_bij' :
-  ∀ E : hsubtypes Dcuts, ∀ (E_bot : ∀ x : Dcuts, E x -> ∀ y : Dcuts, y <= x -> E y) (E_open : ∀ x : Dcuts, E x -> ∃ y : Dcuts, x < y × E y),
+  Π E : hsubtypes Dcuts, Π (E_bot : Π x : Dcuts, E x -> Π y : Dcuts, y <= x -> E y) (E_open : Π x : Dcuts, E x -> ∃ y : Dcuts, x < y × E y),
     Dcuts_of_Dcuts'_val (Dcuts_of_Dcuts_val E) = E.
 Proof.
   intros.
@@ -4293,9 +4293,9 @@ Definition NonnegativeReals_to_hsubtypesNonnegativeRationals :
   NonnegativeReals -> (hsubtypes NonnegativeRationals) := pr1.
 Definition hsubtypesNonnegativeRationals_to_NonnegativeReals
   (X : NonnegativeRationals -> hProp)
-  (Xbot : ∀ x : NonnegativeRationals,
-            X x -> ∀ y : NonnegativeRationals, (y <= x)%NRat -> X y)
-  (Xopen : ∀ x : NonnegativeRationals,
+  (Xbot : Π x : NonnegativeRationals,
+            X x -> Π y : NonnegativeRationals, (y <= x)%NRat -> X y)
+  (Xopen : Π x : NonnegativeRationals,
              X x ->
              hexists (fun y : NonnegativeRationals => dirprod (X y) (x < y)%NRat))
   (Xtop : Dcuts_def_error X) : NonnegativeReals :=
@@ -4313,7 +4313,7 @@ Notation "x / 2" := (halfNonnegativeReals x) (at level 35, no associativity) : N
 (** ** Compatibility with NonnegativeRationals *)
 
 Lemma NonnegativeRationals_to_NonnegativeReals_lt :
-  ∀ x y : NonnegativeRationals,
+  Π x y : NonnegativeRationals,
     (x < y)%NRat <->
     NonnegativeRationals_to_NonnegativeReals x < NonnegativeRationals_to_NonnegativeReals y.
 Proof.
@@ -4331,7 +4331,7 @@ Proof.
 Qed.
 
 Lemma NonnegativeRationals_to_NonnegativeReals_le :
-  ∀ x y : NonnegativeRationals,
+  Π x y : NonnegativeRationals,
     (x <= y)%NRat <->
     NonnegativeRationals_to_NonnegativeReals x <= NonnegativeRationals_to_NonnegativeReals y.
 Proof.
@@ -4363,7 +4363,7 @@ Proof.
   reflexivity.
 Qed.
 Lemma NonnegativeRationals_to_NonnegativeReals_plus :
-  ∀ x y : NonnegativeRationals, NonnegativeRationals_to_NonnegativeReals (x + y)%NRat = NonnegativeRationals_to_NonnegativeReals x + NonnegativeRationals_to_NonnegativeReals y.
+  Π x y : NonnegativeRationals, NonnegativeRationals_to_NonnegativeReals (x + y)%NRat = NonnegativeRationals_to_NonnegativeReals x + NonnegativeRationals_to_NonnegativeReals y.
 Proof.
   intros x y.
   apply Dcuts_eq_is_eq.
@@ -4427,7 +4427,7 @@ Proof.
 Qed.
 
 Lemma NonnegativeRationals_to_NonnegativeReals_minus :
-  ∀ x y : NonnegativeRationals, NonnegativeRationals_to_NonnegativeReals (x - y)%NRat = NonnegativeRationals_to_NonnegativeReals x - NonnegativeRationals_to_NonnegativeReals y.
+  Π x y : NonnegativeRationals, NonnegativeRationals_to_NonnegativeReals (x - y)%NRat = NonnegativeRationals_to_NonnegativeReals x - NonnegativeRationals_to_NonnegativeReals y.
 Proof.
   intros x y.
   destruct (isdecrel_leNonnegativeRationals x y) as [Hxy | Hxy].
@@ -4444,7 +4444,7 @@ Proof.
     exact Hxy.
 Qed.
 Lemma NonnegativeRationals_to_NonnegativeReals_mult :
-  ∀ x y : NonnegativeRationals, NonnegativeRationals_to_NonnegativeReals (x * y)%NRat = NonnegativeRationals_to_NonnegativeReals x * NonnegativeRationals_to_NonnegativeReals y.
+  Π x y : NonnegativeRationals, NonnegativeRationals_to_NonnegativeReals (x * y)%NRat = NonnegativeRationals_to_NonnegativeReals x * NonnegativeRationals_to_NonnegativeReals y.
 Proof.
   intros x y.
   destruct (eq0orgt0NonnegativeRationals x) as [-> | Hx].
@@ -4476,7 +4476,7 @@ Proof.
 Qed.
 
 Lemma NonnegativeRationals_to_NonnegativeReals_nattorig :
-  ∀ n : nat, NonnegativeRationals_to_NonnegativeReals (nattorig n) = nattorig n.
+  Π n : nat, NonnegativeRationals_to_NonnegativeReals (nattorig n) = nattorig n.
 Proof.
   induction n.
   - reflexivity.
@@ -4493,7 +4493,7 @@ Proof.
   reflexivity.
 Qed.
 Lemma nat_to_NonnegativeReals_Sn :
-  ∀ n : nat, nat_to_NonnegativeReals (S n) = nat_to_NonnegativeReals n + 1.
+  Π n : nat, nat_to_NonnegativeReals (S n) = nat_to_NonnegativeReals n + 1.
 Proof.
   intros n.
   unfold nat_to_NonnegativeReals.
@@ -4505,13 +4505,13 @@ Qed.
 (** Order, apartness, and equality *)
 
 Definition istrans_leNonnegativeReals :
-  ∀ x y z : NonnegativeReals, x <= y -> y <= z -> x <= z
+  Π x y z : NonnegativeReals, x <= y -> y <= z -> x <= z
   := istrans_EOle (X := EffectivelyOrdered_NonnegativeReals).
 Definition isrefl_leNonnegativeReals :
-  ∀ x : NonnegativeReals, x <= x
+  Π x : NonnegativeReals, x <= x
   := isrefl_EOle (X := EffectivelyOrdered_NonnegativeReals).
 Lemma isantisymm_leNonnegativeReals :
-  ∀ x y : NonnegativeReals, x <= y × y <= x <-> x = y.
+  Π x y : NonnegativeReals, x <= y × y <= x <-> x = y.
 Proof.
   intros x y ; split.
   - intros (Hle,Hge).
@@ -4523,47 +4523,47 @@ Proof.
 Qed.
 
 Definition istrans_ltNonnegativeReals :
-  ∀ x y z : NonnegativeReals, x < y -> y < z -> x < z
+  Π x y z : NonnegativeReals, x < y -> y < z -> x < z
   := istrans_EOlt (X := EffectivelyOrdered_NonnegativeReals).
 Definition iscotrans_ltNonnegativeReals :
-  ∀ x y z : NonnegativeReals, x < z -> x < y ∨ y < z
+  Π x y z : NonnegativeReals, x < z -> x < y ∨ y < z
   := iscotrans_Dcuts_lt_rel.
 Definition isirrefl_ltNonnegativeReals :
-  ∀ x : NonnegativeReals, ¬ (x < x)
+  Π x : NonnegativeReals, ¬ (x < x)
   := isirrefl_EOlt (X := EffectivelyOrdered_NonnegativeReals).
 
 Definition istrans_lt_le_ltNonnegativeReals :
-  ∀ x y z : NonnegativeReals, x < y -> y <= z -> x < z
+  Π x y z : NonnegativeReals, x < y -> y <= z -> x < z
   := istrans_EOlt_le (X := EffectivelyOrdered_NonnegativeReals).
 Definition istrans_le_lt_ltNonnegativeReals :
-  ∀ x y z : NonnegativeReals, x <= y -> y < z -> x < z
+  Π x y z : NonnegativeReals, x <= y -> y < z -> x < z
   := istrans_EOle_lt (X := EffectivelyOrdered_NonnegativeReals).
 
 Lemma lt_leNonnegativeReals :
-  ∀ x y : NonnegativeReals, x < y -> x <= y.
+  Π x y : NonnegativeReals, x < y -> x <= y.
 Proof.
   exact Dcuts_lt_le_rel.
 Qed.
 Lemma notlt_leNonnegativeReals :
-  ∀ x y : NonnegativeReals, ¬ (x < y) <-> (y <= x).
+  Π x y : NonnegativeReals, ¬ (x < y) <-> (y <= x).
 Proof.
   exact Dcuts_nlt_ge.
 Qed.
 
 Lemma isnonnegative_NonnegativeReals :
-  ∀ x : NonnegativeReals, 0 <= x.
+  Π x : NonnegativeReals, 0 <= x.
 Proof.
   intros x.
   now apply Dcuts_ge_0.
 Qed.
 Lemma isnonnegative_NonnegativeReals' :
-  ∀ x : NonnegativeReals, ¬ (x < 0).
+  Π x : NonnegativeReals, ¬ (x < 0).
 Proof.
   intros x.
   now apply Dcuts_notlt_0.
 Qed.
 Lemma le0_NonnegativeReals :
-  ∀ x : NonnegativeReals, (x <= 0) <-> (x = 0).
+  Π x : NonnegativeReals, (x <= 0) <-> (x = 0).
 Proof.
   intros x ; split ; intros Hx.
   apply isantisymm_leNonnegativeReals.
@@ -4575,21 +4575,21 @@ Proof.
 Qed.
 
 Lemma ap_ltNonnegativeReals :
-  ∀ x y : NonnegativeReals, x ≠ y <-> (x < y) ⨿  (y < x).
+  Π x y : NonnegativeReals, x ≠ y <-> (x < y) ⨿  (y < x).
 Proof.
   now intros x y ; split.
 Qed.
 Definition isirrefl_apNonnegativeReals :
-  ∀ x : NonnegativeReals, ¬ (x ≠ x)
+  Π x : NonnegativeReals, ¬ (x ≠ x)
   := isirrefl_Dcuts_ap_rel.
 Definition issymm_apNonnegativeReals :
-  ∀ x y : NonnegativeReals, x ≠ y -> y ≠ x
+  Π x y : NonnegativeReals, x ≠ y -> y ≠ x
   := issymm_Dcuts_ap_rel.
 Definition iscotrans_apNonnegativeReals :
-  ∀ x y z : NonnegativeReals, x ≠ z -> x ≠ y ∨ y ≠ z
+  Π x y z : NonnegativeReals, x ≠ z -> x ≠ y ∨ y ≠ z
   := iscotrans_Dcuts_ap_rel.
 Lemma istight_apNonnegativeReals:
-  ∀ x y : NonnegativeReals, (¬ (x ≠ y)) <-> (x = y).
+  Π x y : NonnegativeReals, (¬ (x ≠ y)) <-> (x = y).
 Proof.
   intros x y.
   split.
@@ -4599,7 +4599,7 @@ Proof.
 Qed.
 
 Lemma ispositive_apNonnegativeReals :
-  ∀ x : NonnegativeReals, x ≠ 0 <-> 0 < x.
+  Π x : NonnegativeReals, x ≠ 0 <-> 0 < x.
 Proof.
   intros X ; split.
   - intros [ | Hlt ].
@@ -4622,32 +4622,32 @@ Qed.
 (** addition *)
 
 Definition ap_plusNonnegativeReals:
-  ∀ x x' y y' : NonnegativeReals,
+  Π x x' y y' : NonnegativeReals,
     x + y ≠ x' + y' -> x ≠ x' ∨ y ≠ y'
   := apCCDRplus (X := NonnegativeReals).
 
 Definition islunit_zero_plusNonnegativeReals:
-  ∀ x : NonnegativeReals, 0 + x = x
+  Π x : NonnegativeReals, 0 + x = x
   := islunit_CCDRzero_CCDRplus (X := NonnegativeReals).
 Definition isrunit_zero_plusNonnegativeReals:
-  ∀ x : NonnegativeReals, x + 0 = x
+  Π x : NonnegativeReals, x + 0 = x
   := isrunit_CCDRzero_CCDRplus (X := NonnegativeReals).
 Definition isassoc_plusNonnegativeReals:
-  ∀ x y z : NonnegativeReals, x + y + z = x + (y + z)
+  Π x y z : NonnegativeReals, x + y + z = x + (y + z)
   := isassoc_CCDRplus (X := NonnegativeReals).
 Definition iscomm_plusNonnegativeReals:
-  ∀ x y : NonnegativeReals, x + y = y + x
+  Π x y : NonnegativeReals, x + y = y + x
   := iscomm_CCDRplus (X := NonnegativeReals).
 
 Definition plusNonnegativeReals_ltcompat_l :
-  ∀ x y z: NonnegativeReals, (y < z) <-> (y + x < z + x)
+  Π x y z: NonnegativeReals, (y < z) <-> (y + x < z + x)
   := Dcuts_plus_ltcompat_l.
 Definition plusNonnegativeReals_ltcompat_r :
-  ∀ x y z: NonnegativeReals, (y < z) <-> (x + y < x + z)
+  Π x y z: NonnegativeReals, (y < z) <-> (x + y < x + z)
   := Dcuts_plus_ltcompat_r.
 
 Lemma plusNonnegativeReals_ltcompat :
-  ∀ x y z t : NonnegativeReals, x < y -> z < t -> x + z < y + t.
+  Π x y z t : NonnegativeReals, x < y -> z < t -> x + z < y + t.
 Proof.
   intros x y z t Hxy Hzt.
   eapply istrans_ltNonnegativeReals, plusNonnegativeReals_ltcompat_l.
@@ -4655,7 +4655,7 @@ Proof.
   exact Hxy.
 Qed.
 Lemma plusNonnegativeReals_lt_l:
-  ∀ x y : NonnegativeReals, 0 < x <-> y < x + y.
+  Π x y : NonnegativeReals, 0 < x <-> y < x + y.
 Proof.
   intros x y.
   pattern y at 1.
@@ -4663,7 +4663,7 @@ Proof.
   now apply plusNonnegativeReals_ltcompat_l.
 Qed.
 Lemma plusNonnegativeReals_lt_r:
-  ∀ x y : NonnegativeReals, 0 < y <-> x < x + y.
+  Π x y : NonnegativeReals, 0 < y <-> x < x + y.
 Proof.
   intros x y.
   pattern x at 1.
@@ -4672,13 +4672,13 @@ Proof.
 Qed.
 
 Definition plusNonnegativeReals_lecompat_l :
-  ∀ x y z: NonnegativeReals, (y <= z) <-> (y + x <= z + x)
+  Π x y z: NonnegativeReals, (y <= z) <-> (y + x <= z + x)
   := Dcuts_plus_lecompat_l.
 Definition plusNonnegativeReals_lecompat_r :
-  ∀ x y z: NonnegativeReals, (y <= z) <-> (x + y <= x + z)
+  Π x y z: NonnegativeReals, (y <= z) <-> (x + y <= x + z)
   := Dcuts_plus_lecompat_r.
 Lemma plusNonnegativeReals_lecompat :
-  ∀ x y x' y' : NonnegativeReals,
+  Π x y x' y' : NonnegativeReals,
     x <= y -> x' <= y' -> x + x' <= y + y'.
 Proof.
   intros x y x' y' H H'.
@@ -4690,18 +4690,18 @@ Proof.
 Qed.
 
 Lemma plusNonnegativeReals_le_l :
-  ∀ (x y : NonnegativeReals), x <= x + y.
+  Π (x y : NonnegativeReals), x <= x + y.
 Proof.
   exact Dcuts_plus_le_l.
 Qed.
 Lemma plusNonnegativeReals_le_r :
-  ∀ (x y : NonnegativeReals), y <= x + y.
+  Π (x y : NonnegativeReals), y <= x + y.
 Proof.
   exact Dcuts_plus_le_r.
 Qed.
 
 Lemma plusNonnegativeReals_le_ltcompat :
-  ∀ x y z t : NonnegativeReals,
+  Π x y z t : NonnegativeReals,
     x <= y -> z < t -> x + z < y + t.
 Proof.
   intros x y z t Hxy Hzt.
@@ -4710,7 +4710,7 @@ Proof.
 Qed.
 
 Lemma plusNonnegativeReals_eqcompat_l :
-  ∀ x y z: NonnegativeReals, (y + x = z + x) <-> (y = z).
+  Π x y z: NonnegativeReals, (y + x = z + x) <-> (y = z).
 Proof.
   intros x y z ; split.
   - intro H ;
@@ -4722,7 +4722,7 @@ Proof.
   - now intros ->.
 Qed.
 Lemma plusNonnegativeReals_eqcompat_r :
-  ∀ x y z: NonnegativeReals, (x + y = x + z) <-> (y = z).
+  Π x y z: NonnegativeReals, (x + y = x + z) <-> (y = z).
 Proof.
   intros x y z.
   rewrite ! (iscomm_plusNonnegativeReals x).
@@ -4730,7 +4730,7 @@ Proof.
 Qed.
 
 Lemma plusNonnegativeReals_apcompat_l :
-  ∀ x y z: NonnegativeReals, (y ≠ z) <-> (y + x ≠ z + x).
+  Π x y z: NonnegativeReals, (y ≠ z) <-> (y + x ≠ z + x).
 Proof.
   intros a b c.
   split.
@@ -4745,7 +4745,7 @@ Proof.
   - now apply islapbinop_Dcuts_plus.
 Qed.
 Lemma plusNonnegativeReals_apcompat_r :
-  ∀ x y z: NonnegativeReals, (y ≠ z) <-> (x + y ≠ x + z).
+  Π x y z: NonnegativeReals, (y ≠ z) <-> (x + y ≠ x + z).
 Proof.
   intros x y z.
   rewrite ! (iscomm_plusNonnegativeReals x).
@@ -4755,102 +4755,102 @@ Qed.
 (** Subtraction *)
 
 Definition minusNonnegativeReals_plus_r :
-  ∀ x y z : NonnegativeReals, z <= y -> x = y - z -> y = x + z
+  Π x y z : NonnegativeReals, z <= y -> x = y - z -> y = x + z
   := Dcuts_minus_plus_r.
 Definition minusNonnegativeReals_eq_zero :
-  ∀ x y : NonnegativeReals, x <= y -> x - y = 0
+  Π x y : NonnegativeReals, x <= y -> x - y = 0
   := Dcuts_minus_eq_zero.
 Definition minusNonnegativeReals_correct_r :
-  ∀ x y z : NonnegativeReals, x = y + z -> y = x - z
+  Π x y z : NonnegativeReals, x = y + z -> y = x - z
   := Dcuts_minus_correct_r.
 Definition minusNonnegativeReals_correct_l :
-  ∀ x y z : NonnegativeReals, x = y + z -> z = x - y
+  Π x y z : NonnegativeReals, x = y + z -> z = x - y
   := Dcuts_minus_correct_l.
 Definition ispositive_minusNonnegativeReals :
-  ∀ x y : NonnegativeReals, (y < x) <-> (0 < x - y)
+  Π x y : NonnegativeReals, (y < x) <-> (0 < x - y)
   := ispositive_Dcuts_minus.
 Definition minusNonnegativeReals_le :
-  ∀ x y : NonnegativeReals, x - y <= x
+  Π x y : NonnegativeReals, x - y <= x
   := Dcuts_minus_le.
 
 (** Multiplication *)
 
 Definition ap_multNonnegativeReals:
-  ∀ x x' y y' : NonnegativeReals,
+  Π x x' y y' : NonnegativeReals,
     x * y ≠ x' * y' -> x ≠ x' ∨ y ≠ y'
   := apCCDRmult (X := NonnegativeReals).
 
 Definition islunit_one_multNonnegativeReals:
-  ∀ x : NonnegativeReals, 1 * x = x
+  Π x : NonnegativeReals, 1 * x = x
   := islunit_CCDRone_CCDRmult (X := NonnegativeReals).
 Definition isrunit_one_multNonnegativeReals:
-  ∀ x : NonnegativeReals, x * 1 = x
+  Π x : NonnegativeReals, x * 1 = x
   := isrunit_CCDRone_CCDRmult (X := NonnegativeReals).
 Definition isassoc_multNonnegativeReals:
-  ∀ x y z : NonnegativeReals, x * y * z = x * (y * z)
+  Π x y z : NonnegativeReals, x * y * z = x * (y * z)
   := isassoc_CCDRmult (X := NonnegativeReals).
 Definition iscomm_multNonnegativeReals:
-  ∀ x y : NonnegativeReals, x * y = y * x
+  Π x y : NonnegativeReals, x * y = y * x
   := iscomm_CCDRmult (X := NonnegativeReals).
 Definition islabsorb_zero_multNonnegativeReals:
-  ∀ x : NonnegativeReals, 0 * x = 0
+  Π x : NonnegativeReals, 0 * x = 0
   := islabsorb_CCDRzero_CCDRmult (X := NonnegativeReals).
 Definition israbsorb_zero_multNonnegativeReals:
-  ∀ x : NonnegativeReals, x * 0 = 0
+  Π x : NonnegativeReals, x * 0 = 0
   := israbsorb_CCDRzero_CCDRmult (X := NonnegativeReals).
 
 Definition multNonnegativeReals_ltcompat_l :
-  ∀ x y z: NonnegativeReals, (0 < x) -> (y < z) -> (y * x < z * x)
+  Π x y z: NonnegativeReals, (0 < x) -> (y < z) -> (y * x < z * x)
   := Dcuts_mult_ltcompat_l.
 Definition multNonnegativeReals_ltcompat_l' :
-  ∀ x y z: NonnegativeReals, (y * x < z * x) -> (y < z)
+  Π x y z: NonnegativeReals, (y * x < z * x) -> (y < z)
   := Dcuts_mult_ltcompat_l'.
 Definition multNonnegativeReals_lecompat_l :
-  ∀ x y z: NonnegativeReals, (0 < x) -> (y * x <= z * x) -> (y <= z)
+  Π x y z: NonnegativeReals, (0 < x) -> (y * x <= z * x) -> (y <= z)
   := Dcuts_mult_lecompat_l.
 Definition multNonnegativeReals_lecompat_l' :
-  ∀ x y z: NonnegativeReals, (y <= z) -> (y * x <= z * x)
+  Π x y z: NonnegativeReals, (y <= z) -> (y * x <= z * x)
   := Dcuts_mult_lecompat_l'.
 
 Definition multNonnegativeReals_ltcompat_r :
-  ∀ x y z: NonnegativeReals, (0 < x) -> (y < z) -> (x * y < x * z)
+  Π x y z: NonnegativeReals, (0 < x) -> (y < z) -> (x * y < x * z)
   := Dcuts_mult_ltcompat_r.
 Definition multNonnegativeReals_ltcompat_r' :
-  ∀ x y z: NonnegativeReals, (x * y < x *  z) -> (y < z)
+  Π x y z: NonnegativeReals, (x * y < x *  z) -> (y < z)
   := Dcuts_mult_ltcompat_r'.
 Definition multNonnegativeReals_lecompat_r :
-  ∀ x y z: NonnegativeReals, (0 < x) -> (x * y <= x * z) -> (y <= z)
+  Π x y z: NonnegativeReals, (0 < x) -> (x * y <= x * z) -> (y <= z)
   := Dcuts_mult_lecompat_r.
 Definition multNonnegativeReals_lecompat_r' :
-  ∀ x y z: NonnegativeReals, (y <= z) -> (x * y <= x * z)
+  Π x y z: NonnegativeReals, (y <= z) -> (x * y <= x * z)
   := Dcuts_mult_lecompat_r'.
 
 (** Multiplicative Inverse *)
 
 Definition islinv_invNonnegativeReals:
-  ∀ (x : NonnegativeReals) (Hx0 : x ≠ 0), invNonnegativeReals x Hx0 * x = 1
+  Π (x : NonnegativeReals) (Hx0 : x ≠ 0), invNonnegativeReals x Hx0 * x = 1
   := islinv_CCDRinv (X := NonnegativeReals).
 Definition isrinv_invNonnegativeReals:
-  ∀ (x : NonnegativeReals) (Hx0 : x ≠ 0), x * invNonnegativeReals x Hx0 = 1
+  Π (x : NonnegativeReals) (Hx0 : x ≠ 0), x * invNonnegativeReals x Hx0 = 1
   := isrinv_CCDRinv (X := NonnegativeReals).
 
 Definition isldistr_plus_multNonnegativeReals:
-  ∀ x y z : NonnegativeReals, z * (x + y) = z * x + z * y
+  Π x y z : NonnegativeReals, z * (x + y) = z * x + z * y
   := isldistr_CCDRplus_CCDRmult (X := NonnegativeReals).
 Definition isrdistr_plus_multNonnegativeReals:
-  ∀ x y z : NonnegativeReals, (x + y) * z = x * z + y * z
+  Π x y z : NonnegativeReals, (x + y) * z = x * z + y * z
   := isrdistr_CCDRplus_CCDRmult (X := NonnegativeReals).
 
 (** maximum *)
 
 Lemma iscomm_maxNonnegativeReals :
-  ∀ x y : NonnegativeReals,
+  Π x y : NonnegativeReals,
     maxNonnegativeReals x y = maxNonnegativeReals y x.
 Proof.
   exact iscomm_Dcuts_max.
 Qed.
 Lemma isassoc_maxNonnegativeReals :
-  ∀ x y z : NonnegativeReals,
+  Π x y z : NonnegativeReals,
     maxNonnegativeReals (maxNonnegativeReals x y) z =
     maxNonnegativeReals x (maxNonnegativeReals y z).
 Proof.
@@ -4858,13 +4858,13 @@ Proof.
 Qed.
 
 Lemma isldistr_max_plusNonnegativeReals :
-  ∀ x y z : NonnegativeReals,
+  Π x y z : NonnegativeReals,
     z + maxNonnegativeReals x y = maxNonnegativeReals (z + x) (z + y).
 Proof.
   exact isldistr_Dcuts_max_plus.
 Qed.
 Lemma isrdistr_max_plusNonnegativeReals :
-  ∀ x y z : NonnegativeReals,
+  Π x y z : NonnegativeReals,
     maxNonnegativeReals x y + z = maxNonnegativeReals (x + z) (y + z).
 Proof.
   intros x y z.
@@ -4873,13 +4873,13 @@ Proof.
 Qed.
 
 Lemma isldistr_max_multNonnegativeReals :
-  ∀ x y z : NonnegativeReals,
+  Π x y z : NonnegativeReals,
     z * maxNonnegativeReals x y = maxNonnegativeReals (z * x) (z * y).
 Proof.
   exact isldistr_Dcuts_max_mult.
 Qed.
 Lemma isrdistr_max_multNonnegativeReals :
-  ∀ x y z : NonnegativeReals,
+  Π x y z : NonnegativeReals,
     maxNonnegativeReals x y * z = maxNonnegativeReals (x * z) (y * z).
 Proof.
   intros x y z.
@@ -4888,40 +4888,40 @@ Proof.
 Qed.
 
 Lemma maxNonnegativeReals_carac_l :
-  ∀ x y : NonnegativeReals,
+  Π x y : NonnegativeReals,
     y <= x -> maxNonnegativeReals x y = x.
 Proof.
   exact Dcuts_max_carac_l.
 Qed.
 Lemma maxNonnegativeReals_carac_r :
-  ∀ x y : NonnegativeReals,
+  Π x y : NonnegativeReals,
     x <= y -> maxNonnegativeReals x y = y.
 Proof.
   exact Dcuts_max_carac_r.
 Qed.
 
 Lemma maxNonnegativeReals_le_l :
-  ∀ x y : NonnegativeReals,
+  Π x y : NonnegativeReals,
     x <= maxNonnegativeReals x y.
 Proof.
   exact Dcuts_max_le_l.
 Qed.
 Lemma maxNonnegativeReals_le_r :
-  ∀ x y : NonnegativeReals,
+  Π x y : NonnegativeReals,
     y <= maxNonnegativeReals x y.
 Proof.
   exact Dcuts_max_le_r.
 Qed.
 
 Lemma maxNonnegativeReals_lt :
-  ∀ x y z : NonnegativeReals,
+  Π x y z : NonnegativeReals,
     x < z -> y < z
     -> maxNonnegativeReals x y < z.
 Proof.
   exact Dcuts_max_lt.
 Qed.
 Lemma maxNonnegativeReals_le :
-  ∀ x y z : NonnegativeReals,
+  Π x y z : NonnegativeReals,
     x <= z -> y <= z
     -> maxNonnegativeReals x y <= z.
 Proof.
@@ -4929,7 +4929,7 @@ Proof.
 Qed.
 
 Lemma maxNonnegativeReals_minus_plus:
-  ∀ x y : NonnegativeReals,
+  Π x y : NonnegativeReals,
     maxNonnegativeReals x y = (x - y) + y.
 Proof.
   intros x y.
@@ -4938,7 +4938,7 @@ Proof.
 Qed.
 
 Lemma isldistr_minus_multNonnegativeReals :
-  ∀ x y z : NonnegativeReals, z * (x - y) = z * x - z * y.
+  Π x y z : NonnegativeReals, z * (x - y) = z * x - z * y.
 Proof.
   intros x y z.
   apply plusNonnegativeReals_eqcompat_l with (Dcuts_mult z y).
@@ -4946,7 +4946,7 @@ Proof.
   apply isldistr_max_multNonnegativeReals.
 Qed.
 Lemma isrdistr_minus_multNonnegativeReals :
-   ∀ x y z : NonnegativeReals, (x - y) * z = x * z - y * z.
+   Π x y z : NonnegativeReals, (x - y) * z = x * z - y * z.
 Proof.
   intros x y z.
   rewrite !(iscomm_multNonnegativeReals _ z).
@@ -4954,7 +4954,7 @@ Proof.
 Qed.
 
 Lemma isassoc_minusNonnegativeReals :
-  ∀ x y z : NonnegativeReals,
+  Π x y z : NonnegativeReals,
     (x - y) - z = x - (y + z).
 Proof.
   intros x y z.
@@ -4971,7 +4971,7 @@ Proof.
   now apply plusNonnegativeReals_le_r.
 Qed.
 Lemma iscomm_minusNonnegativeReals :
-  ∀ x y z : NonnegativeReals,
+  Π x y z : NonnegativeReals,
     x - y - z = x - z - y.
 Proof.
   intros x y z.
@@ -4981,7 +4981,7 @@ Proof.
 Qed.
 
 Lemma max_plusNonnegativeReals :
-  ∀ x y : NonnegativeReals,
+  Π x y : NonnegativeReals,
     (0 < x -> y = 0) ->
     maxNonnegativeReals x y = x + y.
 Proof.
@@ -4991,18 +4991,18 @@ Qed.
 (** half of a non-negative real numbers *)
 
 Lemma double_halfNonnegativeReals :
-  ∀ x : NonnegativeReals, x = (x / 2) + (x / 2).
+  Π x : NonnegativeReals, x = (x / 2) + (x / 2).
 Proof.
   exact Dcuts_half_double.
 Qed.
 Lemma isdistr_plus_halfNonnegativeReals:
-  ∀ x y : NonnegativeReals,
+  Π x y : NonnegativeReals,
     (x + y) / 2 = (x / 2) + (y / 2).
 Proof.
   exact isdistr_Dcuts_half_plus.
 Qed.
 Lemma ispositive_halfNonnegativeReals:
-  ∀ x : NonnegativeReals,
+  Π x : NonnegativeReals,
     (0 < x) <-> (0 < x / 2).
 Proof.
   exact ispositive_Dcuts_half.
@@ -5011,7 +5011,7 @@ Qed.
 (** ** NonnegativeRationals is dense in NonnegativeReals *)
 
 Lemma NonnegativeReals_dense :
-  ∀ x y : NonnegativeReals, x < y -> ∃ r : NonnegativeRationals, x < NonnegativeRationals_to_NonnegativeReals r × NonnegativeRationals_to_NonnegativeReals r < y.
+  Π x y : NonnegativeReals, x < y -> ∃ r : NonnegativeRationals, x < NonnegativeRationals_to_NonnegativeReals r × NonnegativeRationals_to_NonnegativeReals r < y.
 Proof.
   intros x y.
   apply hinhuniv ; intros q.
@@ -5076,18 +5076,18 @@ Qed.
 (** ** Completeness *)
 
 Definition Cauchy_seq (u : nat -> NonnegativeReals) : hProp
-  := hProppair (∀ eps : NonnegativeReals,
+  := hProppair (Π eps : NonnegativeReals,
                    0 < eps ->
                    hexists
                      (λ N : nat,
-                            ∀ n m : nat, N ≤ n -> N ≤ m -> u n < u m + eps × u m < u n + eps))
+                            Π n m : nat, N ≤ n -> N ≤ m -> u n < u m + eps × u m < u n + eps))
                (impred_isaprop _ (λ _, isapropimpl _ _ (pr2 _))).
 Definition is_lim_seq (u : nat -> NonnegativeReals) (l : NonnegativeReals) : hProp
-  := hProppair (∀ eps : NonnegativeReals,
+  := hProppair (Π eps : NonnegativeReals,
                    0 < eps ->
                    hexists
                      (λ N : nat,
-                            ∀ n : nat, N ≤ n -> u n < l + eps × l < u n + eps))
+                            Π n : nat, N ≤ n -> u n < l + eps × l < u n + eps))
                (impred_isaprop _ (λ _, isapropimpl _ _ (pr2 _))).
 
 Definition Cauchy_lim_seq (u : nat -> NonnegativeReals) (Cu : Cauchy_seq u) : NonnegativeReals
@@ -5134,7 +5134,7 @@ Proof.
   - now apply (is_lim_seq_unique_aux u).
 Qed.
 Lemma isaprop_ex_lim_seq :
-  ∀ u : nat -> NonnegativeReals, isaprop (Σ l : NonnegativeReals, is_lim_seq u l).
+  Π u : nat -> NonnegativeReals, isaprop (Σ l : NonnegativeReals, is_lim_seq u l).
 Proof.
   intros u l l'.
   apply (iscontrweqf (X := (pr1 l = pr1 l'))).

--- a/UniMath/Dedekind/Reals.v
+++ b/UniMath/Dedekind/Reals.v
@@ -23,7 +23,7 @@ Definition nat_to_hr (n : nat) : hr_commrng :=
   NR_to_hr (nat_to_NonnegativeReals n,,0).
 
 Lemma NR_to_hr_inside :
-  ∀ x : NonnegativeReals × NonnegativeReals, pr1 (NR_to_hr x) x.
+  Π x : NonnegativeReals × NonnegativeReals, pr1 (NR_to_hr x) x.
 Proof.
   intros x.
   apply hinhpr ; simpl.
@@ -31,7 +31,7 @@ Proof.
 Qed.
 
 Local Lemma iscomprelfun_NRminus :
-  ∀ x y : NonnegativeReals × NonnegativeReals,
+  Π x y : NonnegativeReals × NonnegativeReals,
     pr1 x + pr2 y = pr1 y + pr2 x
     -> pr1 x - pr2 x = pr1 y - pr2 y.
 Proof.
@@ -71,7 +71,7 @@ Definition hr_to_NRpos (x : hr_commrng) : NonnegativeReals := pr1 (hr_to_NR x).
 Definition hr_to_NRneg (x : hr_commrng) : NonnegativeReals := pr2 (hr_to_NR x).
 
 Lemma hr_to_NR_correct :
-  ∀ (x : hr_commrng), pr1 x (hr_to_NR x).
+  Π (x : hr_commrng), pr1 x (hr_to_NR x).
 Proof.
   intros X.
   generalize (pr1 (pr2 X)).
@@ -93,7 +93,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NRpos_NR_to_hr :
-  ∀ (x : NonnegativeReals × NonnegativeReals),
+  Π (x : NonnegativeReals × NonnegativeReals),
     hr_to_NRpos (NR_to_hr x) = pr1 x - pr2 x.
 Proof.
   intros x.
@@ -101,7 +101,7 @@ Proof.
   now rewrite setquotunivcomm.
 Qed.
 Lemma hr_to_NRneg_NR_to_hr :
-  ∀ (x : NonnegativeReals × NonnegativeReals),
+  Π (x : NonnegativeReals × NonnegativeReals),
     hr_to_NRneg (NR_to_hr x) = pr2 x - pr1 x.
 Proof.
   intros x.
@@ -110,7 +110,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NR_bij :
-  ∀ x : hr_commrng, NR_to_hr (hr_to_NR x) = x.
+  Π x : hr_commrng, NR_to_hr (hr_to_NR x) = x.
 Proof.
   intros x.
   unfold NR_to_hr.
@@ -119,7 +119,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NRposneg_zero :
-  ∀ x : hr_commrng, 0 < hr_to_NRpos x -> hr_to_NRneg x = 0.
+  Π x : hr_commrng, 0 < hr_to_NRpos x -> hr_to_NRneg x = 0.
 Proof.
   intros x.
   rewrite <- (hr_to_NR_bij x).
@@ -132,7 +132,7 @@ Proof.
   exact Hx.
 Qed.
 Lemma hr_to_NRnegpos_zero :
-  ∀ x : hr_commrng, 0 < hr_to_NRneg x -> hr_to_NRpos x = 0.
+  Π x : hr_commrng, 0 < hr_to_NRneg x -> hr_to_NRpos x = 0.
 Proof.
   intros x.
   rewrite <- (hr_to_NR_bij x).
@@ -146,7 +146,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NRpos_NR_to_hr_std :
-  ∀ (x : NonnegativeReals × NonnegativeReals),
+  Π (x : NonnegativeReals × NonnegativeReals),
     (0 < pr1 x -> pr2 x = 0) ->
     hr_to_NRpos (NR_to_hr x) = pr1 x.
 Proof.
@@ -157,7 +157,7 @@ Proof.
   now apply max_plusNonnegativeReals.
 Qed.
 Lemma hr_to_NRneg_NR_to_hr_std :
-  ∀ (x : NonnegativeReals × NonnegativeReals),
+  Π (x : NonnegativeReals × NonnegativeReals),
     (0 < pr1 x -> pr2 x = 0) ->
     hr_to_NRneg (NR_to_hr x) = pr2 x.
 Proof.
@@ -172,7 +172,7 @@ Qed.
 (** Caracterisation of equality *)
 
 Lemma NR_to_hr_eq :
-  ∀ x y : NonnegativeReals × NonnegativeReals,
+  Π x y : NonnegativeReals × NonnegativeReals,
     pr1 x + pr2 y = pr1 y + pr2 x <-> NR_to_hr x = NR_to_hr y.
 Proof.
   intros x y.
@@ -222,7 +222,7 @@ Qed.
 (** plus *)
 
 Lemma NR_to_hr_plus :
-  ∀ x y : NonnegativeReals × NonnegativeReals,
+  Π x y : NonnegativeReals × NonnegativeReals,
     (NR_to_hr x + NR_to_hr y)%rng = NR_to_hr (pr1 x + pr1 y ,, pr2 x + pr2 y).
 Proof.
   intros x y.
@@ -235,7 +235,7 @@ Qed.
 (** opp *)
 
 Lemma NR_to_hr_opp :
-  ∀ x : NonnegativeReals × NonnegativeReals,
+  Π x : NonnegativeReals × NonnegativeReals,
     (- NR_to_hr x)%rng = NR_to_hr (pr2 x ,, pr1 x).
 Proof.
   intros x.
@@ -246,7 +246,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NR_opp :
-  ∀ x : hr_commrng,
+  Π x : hr_commrng,
     hr_to_NR (- x)%rng = (hr_to_NRneg x ,, hr_to_NRpos x).
 Proof.
   intros x.
@@ -258,7 +258,7 @@ Proof.
   reflexivity.
 Qed.
 Lemma hr_to_NRpos_opp :
-  ∀ x : hr_commrng,
+  Π x : hr_commrng,
     hr_to_NRpos (- x)%rng = hr_to_NRneg x.
 Proof.
   intros x.
@@ -266,7 +266,7 @@ Proof.
   now rewrite hr_to_NR_opp.
 Qed.
 Lemma hr_to_NRneg_opp :
-  ∀ x : hr_commrng,
+  Π x : hr_commrng,
     hr_to_NRneg (- x)%rng = hr_to_NRpos x.
 Proof.
   intros x.
@@ -277,7 +277,7 @@ Qed.
 (** minus *)
 
 Lemma NR_to_hr_minus :
-  ∀ x y : NonnegativeReals × NonnegativeReals,
+  Π x y : NonnegativeReals × NonnegativeReals,
     (NR_to_hr x - NR_to_hr y)%rng = NR_to_hr (pr1 x + pr2 y ,, pr2 x + pr1 y).
 Proof.
   intros x y.
@@ -286,7 +286,7 @@ Proof.
 Qed.
 
 Lemma hr_opp_minus :
-  ∀ x y : hr_commrng,
+  Π x y : hr_commrng,
     (x - y = - ((- x) - (- y)))%rng.
 Proof.
   intros x y.
@@ -296,7 +296,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NRpos_minus :
-  ∀ x y : hr_commrng,
+  Π x y : hr_commrng,
     hr_to_NRpos x - hr_to_NRpos y <= hr_to_NRpos (x - y)%rng.
 Proof.
   intros X Y.
@@ -325,7 +325,7 @@ Proof.
   apply maxNonnegativeReals_le_r.
 Qed.
 Lemma hr_to_NRneg_minus :
-  ∀ x y : hr_commrng,
+  Π x y : hr_commrng,
     hr_to_NRneg x - hr_to_NRneg y <= hr_to_NRneg (x - y)%rng.
 Proof.
   intros x y.
@@ -343,7 +343,7 @@ Qed.
 (** mult *)
 
 Lemma NR_to_hr_mult :
-  ∀ x y : NonnegativeReals × NonnegativeReals,
+  Π x y : NonnegativeReals × NonnegativeReals,
     (NR_to_hr x * NR_to_hr y)%rng = NR_to_hr (pr1 x * pr1 y + pr2 x * pr2 y ,, pr1 x * pr2 y + pr2 x * pr1 y).
 Proof.
   intros x y.
@@ -369,7 +369,7 @@ Definition hr_lt_rel : hrel hr_commrng
   := rigtorngrel NonnegativeReals isbinophrel_ltNonnegativeReals.
 
 Lemma NR_to_hr_lt :
-  ∀ x y : NonnegativeReals × NonnegativeReals,
+  Π x y : NonnegativeReals × NonnegativeReals,
     pr1 x + pr2 y < pr1 y + pr2 x
     <-> hr_lt_rel (NR_to_hr x) (NR_to_hr y).
 Proof.
@@ -398,7 +398,7 @@ Definition hr_le_rel : hrel hr_commrng
   := rigtorngrel NonnegativeReals isbinophrel_leNonnegativeReals.
 
 Lemma NR_to_hr_le :
-  ∀ x y : NonnegativeReals × NonnegativeReals,
+  Π x y : NonnegativeReals × NonnegativeReals,
     pr1 x + pr2 y <= pr1 y + pr2 x
     <-> hr_le_rel (NR_to_hr x) (NR_to_hr y).
 Proof.
@@ -415,7 +415,7 @@ Qed.
 (** Theorems about order *)
 
 Lemma hr_notlt_le :
-  ∀ X Y, ¬ hr_lt_rel X Y <-> hr_le_rel Y X.
+  Π X Y, ¬ hr_lt_rel X Y <-> hr_le_rel Y X.
 Proof.
   intros x y.
   rewrite <- (hr_to_NR_bij x), <- (hr_to_NR_bij y).
@@ -434,7 +434,7 @@ Proof.
 Qed.
 
 Lemma hr_lt_le :
-  ∀ X Y, hr_lt_rel X Y -> hr_le_rel X Y.
+  Π X Y, hr_lt_rel X Y -> hr_le_rel X Y.
 Proof.
   intros x y.
   rewrite <- (hr_to_NR_bij x), <- (hr_to_NR_bij y).
@@ -470,7 +470,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NR_nonnegative :
-  ∀ x : hr_commrng,
+  Π x : hr_commrng,
     (hr_to_NRneg x = 0) <-> hr_le_rel 0%rng x.
 Proof.
   intros x.
@@ -493,7 +493,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NR_positive :
-  ∀ x : hr_commrng,
+  Π x : hr_commrng,
     (hr_to_NRpos x ≠ 0 × hr_to_NRneg x = 0) <-> hr_lt_rel 0%rng x.
 Proof.
   intros x.
@@ -516,7 +516,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NR_nonpositive :
-  ∀ x : hr_commrng,
+  Π x : hr_commrng,
     (hr_to_NRpos x = 0) <-> hr_le_rel x 0%rng.
 Proof.
   intros x.
@@ -539,7 +539,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NR_negative :
-  ∀ x : hr_commrng,
+  Π x : hr_commrng,
     (hr_to_NRpos x = 0 × hr_to_NRneg x ≠ 0) <-> hr_lt_rel x 0%rng.
 Proof.
   intros x.
@@ -562,7 +562,7 @@ Proof.
 Qed.
 
 Lemma hr_plus_ltcompat_l :
-  ∀ x y z : hr_commrng, hr_lt_rel y z <-> hr_lt_rel (y+x)%rng (z+x)%rng.
+  Π x y z : hr_commrng, hr_lt_rel y z <-> hr_lt_rel (y+x)%rng (z+x)%rng.
 Proof.
   intros X Y Z.
   rewrite <- (hr_to_NR_bij X), <- (hr_to_NR_bij Y), <- (hr_to_NR_bij Z).
@@ -582,7 +582,7 @@ Proof.
     now apply_pr2_in NR_to_hr_lt Hlt.
 Qed.
 Lemma hr_plus_ltcompat_r :
-  ∀ x y z : hr_commrng, hr_lt_rel y z <-> hr_lt_rel (x + y)%rng (x + z)%rng.
+  Π x y z : hr_commrng, hr_lt_rel y z <-> hr_lt_rel (x + y)%rng (x + z)%rng.
 Proof.
   intros x y z.
   rewrite !(rngcomm1 _ x).
@@ -590,7 +590,7 @@ Proof.
 Qed.
 
 Lemma hr_plus_lecompat_l :
-  ∀ x y z : hr_commrng, hr_le_rel y z <-> hr_le_rel (y + x)%rng (z + x)%rng.
+  Π x y z : hr_commrng, hr_le_rel y z <-> hr_le_rel (y + x)%rng (z + x)%rng.
 Proof.
   intros x y z ; split ; intro Hle.
   - apply hr_notlt_le.
@@ -605,7 +605,7 @@ Proof.
     exact Hlt.
 Qed.
 Lemma hr_plus_lecompat_r :
-  ∀ x y z : hr_commrng, hr_le_rel y z <-> hr_le_rel (x + y)%rng (x + z)%rng.
+  Π x y z : hr_commrng, hr_le_rel y z <-> hr_le_rel (x + y)%rng (x + z)%rng.
 Proof.
   intros x y z.
   rewrite !(rngcomm1 _ x).
@@ -613,7 +613,7 @@ Proof.
 Qed.
 
 Lemma hr_mult_ltcompat_l :
-  ∀ x y z : hr_commrng, hr_lt_rel 0%rng x -> hr_lt_rel y z -> hr_lt_rel (y * x)%rng (z * x)%rng.
+  Π x y z : hr_commrng, hr_lt_rel 0%rng x -> hr_lt_rel y z -> hr_lt_rel (y * x)%rng (z * x)%rng.
 Proof.
   intros X Y Z Hx0 Hlt.
   apply_pr2_in hr_to_NR_positive Hx0.
@@ -631,7 +631,7 @@ Proof.
   now rewrite !hr_to_NR_bij.
 Qed.
 Lemma hr_mult_ltcompat_l' :
-  ∀ x y z : hr_commrng, hr_le_rel 0%rng x -> hr_lt_rel (y * x)%rng (z * x)%rng -> hr_lt_rel y z.
+  Π x y z : hr_commrng, hr_le_rel 0%rng x -> hr_lt_rel (y * x)%rng (z * x)%rng -> hr_lt_rel y z.
 Proof.
   intros X Y Z Hx0.
   apply_pr2_in hr_to_NR_nonnegative Hx0.
@@ -647,7 +647,7 @@ Proof.
   now apply_pr2_in NR_to_hr_lt Hlt.
 Qed.
 Lemma hr_mult_ltcompat_r' :
-  ∀ x y z : hr_commrng, hr_le_rel 0%rng x -> hr_lt_rel (x * y)%rng (x * z)%rng -> hr_lt_rel y z.
+  Π x y z : hr_commrng, hr_le_rel 0%rng x -> hr_lt_rel (x * y)%rng (x * z)%rng -> hr_lt_rel y z.
 Proof.
   intros x y z.
   rewrite !(rngcomm2 _ x).
@@ -655,7 +655,7 @@ Proof.
 Qed.
 
 Lemma hr_mult_lecompat_l :
-  ∀ x y z : hr_commrng, hr_le_rel 0%rng x -> hr_le_rel y z -> hr_le_rel (y * x)%rng (z * x)%rng.
+  Π x y z : hr_commrng, hr_le_rel 0%rng x -> hr_le_rel y z -> hr_le_rel (y * x)%rng (z * x)%rng.
 Proof.
   intros x y z Hx0 Hle.
   apply hr_notlt_le.
@@ -666,7 +666,7 @@ Proof.
   exact Hlt.
 Qed.
 Lemma hr_mult_lecompat_l' :
-  ∀ x y z : hr_commrng, hr_lt_rel 0%rng x -> hr_le_rel (y * x)%rng (z * x)%rng -> hr_le_rel y z.
+  Π x y z : hr_commrng, hr_lt_rel 0%rng x -> hr_le_rel (y * x)%rng (z * x)%rng -> hr_le_rel y z.
 Proof.
   intros x y z Hx0 Hle.
   apply hr_notlt_le.
@@ -677,14 +677,14 @@ Proof.
   exact Hlt.
 Qed.
 Lemma hr_mult_lecompat_r :
-  ∀ x y z : hr_commrng, hr_le_rel 0%rng x -> hr_le_rel y z -> hr_le_rel (x * y)%rng (x * z)%rng.
+  Π x y z : hr_commrng, hr_le_rel 0%rng x -> hr_le_rel y z -> hr_le_rel (x * y)%rng (x * z)%rng.
 Proof.
   intros x y z.
   rewrite !(rngcomm2 _ x).
   apply hr_mult_lecompat_l.
 Qed.
 Lemma hr_mult_lecompat_r' :
-  ∀ x y z : hr_commrng, hr_lt_rel 0%rng x -> hr_le_rel (x * y)%rng (x * z)%rng -> hr_le_rel y z.
+  Π x y z : hr_commrng, hr_lt_rel 0%rng x -> hr_le_rel (x * y)%rng (x * z)%rng -> hr_le_rel y z.
 Proof.
   intros x y z.
   rewrite !(rngcomm2 _ x).
@@ -706,7 +706,7 @@ Definition hr_ap_rel : hrel hr_commrng
   := rigtorngrel NonnegativeReals isbinophrel_apNonnegativeReals.
 
 Lemma NR_to_hr_ap :
-  ∀ x y : NonnegativeReals × NonnegativeReals,
+  Π x y : NonnegativeReals × NonnegativeReals,
     pr1 x + pr2 y ≠ pr1 y + pr2 x
     <-> hr_ap_rel (NR_to_hr x) (NR_to_hr y).
 Proof.
@@ -723,7 +723,7 @@ Qed.
 (** Theorems about apartness *)
 
 Lemma hr_ap_lt :
-  ∀ X Y : hr_commrng, hr_ap_rel X Y <-> (hr_lt_rel X Y) ⨿ (hr_lt_rel Y X).
+  Π X Y : hr_commrng, hr_ap_rel X Y <-> (hr_lt_rel X Y) ⨿ (hr_lt_rel Y X).
 Proof.
   intros X Y.
   rewrite <-  (hr_to_NR_bij X), <- (hr_to_NR_bij Y).
@@ -811,7 +811,7 @@ Proof.
   rewrite <- (hr_to_NR_bij X), <- (hr_to_NR_bij Y), <- (hr_to_NR_bij Z), !NR_to_hr_mult.
   intros Hap.
   apply_pr2_in NR_to_hr_ap Hap ; simpl in Hap.
-  cut (∀ Y Z, (pr1 (hr_to_NR Z) * pr1 (hr_to_NR X) + pr2 (hr_to_NR Z) * pr2 (hr_to_NR X) + (pr1 (hr_to_NR Y) * pr2 (hr_to_NR X) + pr2 (hr_to_NR Y) * pr1 (hr_to_NR X)))
+  cut (Π Y Z, (pr1 (hr_to_NR Z) * pr1 (hr_to_NR X) + pr2 (hr_to_NR Z) * pr2 (hr_to_NR X) + (pr1 (hr_to_NR Y) * pr2 (hr_to_NR X) + pr2 (hr_to_NR Y) * pr1 (hr_to_NR X)))
        = (pr1 (hr_to_NR Z) + pr2 (hr_to_NR Y)) * pr1 (hr_to_NR X) + (pr2 (hr_to_NR Z) + pr1 (hr_to_NR Y)) * pr2 (hr_to_NR X)).
   intro H ; simpl in H,Hap ; rewrite !H in Hap ; clear H.
   apply ap_plusNonnegativeReals in Hap.
@@ -852,7 +852,7 @@ Proof.
 Qed.
 
 Lemma hr_islinv_neg :
-  ∀ (x : hr_commrng) (Hap : hr_lt_rel x 0%rng),
+  Π (x : hr_commrng) (Hap : hr_lt_rel x 0%rng),
    (NR_to_hr (0%NR,, invNonnegativeReals (hr_to_NRneg x) (pr2 (pr2 (hr_to_NR_negative _) Hap))) * x)%rng = 1%rng.
 Proof.
   intros x Hap.
@@ -869,7 +869,7 @@ Proof.
   apply (pr1 (pr2 (hr_to_NR_negative x) Hap)).
 Qed.
 Lemma hr_isrinv_neg :
-  ∀ (x : hr_commrng) (Hap : hr_lt_rel x 0%rng),
+  Π (x : hr_commrng) (Hap : hr_lt_rel x 0%rng),
    (x * NR_to_hr (0%NR,, invNonnegativeReals (hr_to_NRneg x) (pr2 (pr2 (hr_to_NR_negative _) Hap))))%rng = 1%rng.
 Proof.
   intros x Hap.
@@ -878,7 +878,7 @@ Proof.
 Qed.
 
 Lemma hr_islinv_pos :
-  ∀ (x : hr_commrng) (Hap : hr_lt_rel 0%rng x),
+  Π (x : hr_commrng) (Hap : hr_lt_rel 0%rng x),
    (NR_to_hr (invNonnegativeReals (hr_to_NRpos x) (pr1 (pr2 (hr_to_NR_positive _) Hap)) ,, 0%NR) * x)%rng = 1%rng.
 Proof.
   intros x Hap.
@@ -895,7 +895,7 @@ Proof.
   apply (pr2 (pr2 (hr_to_NR_positive x) Hap)).
 Qed.
 Lemma hr_isrinv_pos :
-  ∀ (x : hr_commrng) (Hap : hr_lt_rel 0%rng x),
+  Π (x : hr_commrng) (Hap : hr_lt_rel 0%rng x),
    (x * NR_to_hr (invNonnegativeReals (hr_to_NRpos x) (pr1 (pr2 (hr_to_NR_positive _) Hap)) ,, 0%NR))%rng = 1%rng.
 Proof.
   intros x Hap.
@@ -904,7 +904,7 @@ Proof.
 Qed.
 
 Lemma hr_ex_inv :
-  ∀ x : hr_commrng,
+  Π x : hr_commrng,
     hr_ap_rel x 0%rng -> multinvpair hr_commrng x.
 Proof.
   intros x Hap.
@@ -938,7 +938,7 @@ Definition hr_abs (x : hr_ConstructiveField) : NonnegativeReals :=
   maxNonnegativeReals (hr_to_NRpos x) (hr_to_NRneg x).
 
 Lemma NR_to_hr_abs :
-  ∀ x : NonnegativeReals × NonnegativeReals,
+  Π x : NonnegativeReals × NonnegativeReals,
     hr_abs (NR_to_hr x) <= maxNonnegativeReals (pr1 x) (pr2 x).
 Proof.
   intros x.
@@ -952,7 +952,7 @@ Proof.
 Qed.
 
 Lemma hr_abs_opp :
-  ∀ x : hr_ConstructiveField, hr_abs (- x)%rng = hr_abs x.
+  Π x : hr_ConstructiveField, hr_abs (- x)%rng = hr_abs x.
 Proof.
   intros x.
   unfold hr_abs.
@@ -961,7 +961,7 @@ Proof.
 Qed.
 
 Lemma istriangle_hr_abs :
-  ∀ x y : hr_ConstructiveField,
+  Π x y : hr_ConstructiveField,
     hr_abs (x + y)%rng <= hr_abs x + hr_abs y.
 Proof.
   intros x y.
@@ -978,7 +978,7 @@ Proof.
 Qed.
 
 Lemma istriangle_hr_abs' :
-  ∀ x y : hr_ConstructiveField,
+  Π x y : hr_ConstructiveField,
     hr_abs x - hr_abs y <= hr_abs (x + y)%rng.
 Proof.
   intros x y.
@@ -994,7 +994,7 @@ Proof.
 Qed.
 
 Lemma hr_abs_minus :
-  ∀ x y : hr_ConstructiveField,
+  Π x y : hr_ConstructiveField,
     hr_abs x - hr_abs y <= hr_abs (x - y)%rng.
 Proof.
   intros x y.
@@ -1003,14 +1003,14 @@ Proof.
 Qed.
 
 Lemma multNonnegativeReals_lecompat :
-  ∀ x y z t : NonnegativeReals, x <= y -> z <= t -> x * z <= y * t.
+  Π x y z t : NonnegativeReals, x <= y -> z <= t -> x * z <= y * t.
 Proof.
   intros x y z t H H0.
   eapply istrans_leNonnegativeReals, multNonnegativeReals_lecompat_l', H.
   apply multNonnegativeReals_lecompat_r', H0.
 Qed.
 Lemma ispositive_multNonnegativeReals :
-  ∀ x y : NonnegativeReals, 0 < x ∧ 0 < y <-> 0 < x * y.
+  Π x y : NonnegativeReals, 0 < x ∧ 0 < y <-> 0 < x * y.
 Proof.
   intros x y.
   split.
@@ -1026,7 +1026,7 @@ Proof.
     exact H.
 Qed.
 Lemma maxNonnegativeReals_lt' :
-  ∀ x y z : NonnegativeReals,
+  Π x y z : NonnegativeReals,
     z < maxNonnegativeReals x y -> z < x ∨ z < y.
 Proof.
   intros x y z.
@@ -1046,7 +1046,7 @@ Proof.
 Qed.
 
 Lemma hr_abs_mult :
-  ∀ x y : hr_ConstructiveField, hr_abs (x * y)%rng = hr_abs x * hr_abs y.
+  Π x y : hr_ConstructiveField, hr_abs (x * y)%rng = hr_abs x * hr_abs y.
 Proof.
   intros x y.
   pattern x at 1 ; rewrite <- (hr_to_NR_bij x) ;
@@ -1111,7 +1111,7 @@ Proof.
 Qed.
 
 Lemma nat_to_hr_S :
-  ∀ n : nat, nat_to_hr (S n) = (1 + nat_to_hr n)%rng.
+  Π n : nat, nat_to_hr (S n) = (1 + nat_to_hr n)%rng.
 Proof.
   intros n.
   unfold nat_to_hr.
@@ -1182,7 +1182,7 @@ Qed.
 Definition Cauchy_seq (u : nat -> hr_ConstructiveField) : hProp.
 Proof.
   intro u.
-  apply (hProppair (∀ c : NonnegativeReals, 0 < c -> ∃ N : nat, ∀ n m : nat, N ≤ n -> N ≤ m -> hr_abs (u m - u n)%rng < c)).
+  apply (hProppair (Π c : NonnegativeReals, 0 < c -> ∃ N : nat, Π n m : nat, N ≤ n -> N ≤ m -> hr_abs (u m - u n)%rng < c)).
   apply impred_isaprop ; intro.
   apply isapropimpl.
   apply pr2.
@@ -1194,7 +1194,7 @@ Lemma Cauchy_seq_pr1 (u : nat -> hr_ConstructiveField) :
 Proof.
   intros u x.
   set (y := λ n : nat, hr_to_NRneg (u n)).
-  assert (Hxy : ∀ n, NR_to_hr (x n ,, y n) = u n).
+  assert (Hxy : Π n, NR_to_hr (x n ,, y n) = u n).
   { intros n.
     unfold x, y, hr_to_NRpos, hr_to_NRneg.
     rewrite <- tppr.
@@ -1231,7 +1231,7 @@ Lemma Cauchy_seq_pr2 (u : nat -> hr_ConstructiveField) :
 Proof.
   intros u y.
   set (x := λ n : nat, hr_to_NRpos (u n)).
-  assert (Hxy : ∀ n, NR_to_hr (x n ,, y n) = u n).
+  assert (Hxy : Π n, NR_to_hr (x n ,, y n) = u n).
   { intros n.
     unfold x, y, hr_to_NRpos, hr_to_NRneg.
     rewrite <- tppr.
@@ -1266,7 +1266,7 @@ Qed.
 Definition is_lim_seq (u : nat -> hr_ConstructiveField) (l : hr_ConstructiveField) : hProp.
 Proof.
   intros u l.
-  apply (hProppair (∀ c : NonnegativeReals, 0 < c -> ∃ N : nat, ∀ n : nat, N ≤ n -> hr_abs (u n - l)%rng < c)).
+  apply (hProppair (Π c : NonnegativeReals, 0 < c -> ∃ N : nat, Π n : nat, N ≤ n -> hr_abs (u n - l)%rng < c)).
   apply impred_isaprop ; intro.
   apply isapropimpl.
   apply pr2.
@@ -1279,7 +1279,7 @@ Proof.
   intros u Cu.
   set (x := λ n, hr_to_NRpos (u n)).
   set (y := λ n, hr_to_NRneg (u n)).
-  assert (Hxy : ∀ n, NR_to_hr (x n ,, y n) = u n).
+  assert (Hxy : Π n, NR_to_hr (x n ,, y n) = u n).
   { intros n.
     unfold x, y, hr_to_NRpos, hr_to_NRneg.
     rewrite <- tppr.
@@ -1347,8 +1347,8 @@ Definition Rminus : binop Reals := CFminus.
 
 Definition Rone : Reals := CFone.
 Definition Rmult : binop Reals := CFmult.
-Definition Rinv : ∀ x : Reals, (Rap x Rzero) -> Reals := CFinv.
-Definition Rdiv : Reals -> ∀ y : Reals, (Rap y Rzero) -> Reals := CFdiv.
+Definition Rinv : Π x : Reals, (Rap x Rzero) -> Reals := CFinv.
+Definition Rdiv : Reals -> Π y : Reals, (Rap y Rzero) -> Reals := CFdiv.
 
 Definition Rtwo : Reals := Rplus Rone Rone.
 Definition Rabs : Reals -> NonnegativeReals := hr_abs.
@@ -1378,7 +1378,7 @@ Notation "x / y" := (Rdiv x (pr1 y) (pr2 y)) : R_scope.
 (** ** NRNRtoR and RtoNRNR *)
 
 Lemma NRNRtoR_RtoNRNR :
-  ∀ x : Reals, NRNRtoR (pr1 (RtoNRNR x)) (pr2 (RtoNRNR x)) = x.
+  Π x : Reals, NRNRtoR (pr1 (RtoNRNR x)) (pr2 (RtoNRNR x)) = x.
 Proof.
   intros X.
   unfold NRNRtoR.
@@ -1387,7 +1387,7 @@ Proof.
 Qed.
 
 Lemma RtoNRNR_NRNRtoR :
-  ∀ x y : NonnegativeReals,
+  Π x y : NonnegativeReals,
     (RtoNRNR (NRNRtoR x y)) = ((x - y)%NR ,, (y - x)%NR).
 Proof.
   intros X Y.
@@ -1397,7 +1397,7 @@ Proof.
 Qed.
 
 Lemma NRNRtoR_inside :
-  ∀ x y : NonnegativeReals, pr1 (NRNRtoR x y) (x,,y).
+  Π x y : NonnegativeReals, pr1 (NRNRtoR x y) (x,,y).
 Proof.
   intros x y.
   apply hinhpr.
@@ -1425,7 +1425,7 @@ Proof.
 Qed.
 
 Lemma NRNRtoR_eq :
-  ∀ x x' y y' : NonnegativeReals,
+  Π x x' y y' : NonnegativeReals,
     (x + y' = x' + y)%NR <->
     NRNRtoR x y = NRNRtoR x' y'.
 Proof.
@@ -1433,7 +1433,7 @@ Proof.
   apply (NR_to_hr_eq (x,,y) (x' ,, y')).
 Qed.
 Lemma NRNRtoR_ap :
-  ∀ x x' y y' : NonnegativeReals,
+  Π x x' y y' : NonnegativeReals,
     (x + y' ≠ x' + y)%NR <->
     NRNRtoR x y ≠ NRNRtoR x' y'.
 Proof.
@@ -1441,7 +1441,7 @@ Proof.
   apply (NR_to_hr_ap (x,,y) (x' ,, y')).
 Qed.
 Lemma NRNRtoR_lt :
-  ∀ x x' y y' : NonnegativeReals,
+  Π x x' y y' : NonnegativeReals,
     (x + y' < x' + y)%NR <->
     NRNRtoR x y < NRNRtoR x' y'.
 Proof.
@@ -1449,7 +1449,7 @@ Proof.
   apply (NR_to_hr_lt (x,,y) (x' ,, y')).
 Qed.
 Lemma NRNRtoR_le :
-  ∀ x x' y y' : NonnegativeReals,
+  Π x x' y y' : NonnegativeReals,
     (x + y' <= x' + y)%NR <->
     NRNRtoR x y <= NRNRtoR x' y'.
 Proof.
@@ -1458,31 +1458,31 @@ Proof.
 Qed.
 
 Lemma NRNRtoR_plus :
-  ∀ x x' y y' : NonnegativeReals, NRNRtoR (x + x')%NR (y + y')%NR = NRNRtoR x y + NRNRtoR x' y'.
+  Π x x' y y' : NonnegativeReals, NRNRtoR (x + x')%NR (y + y')%NR = NRNRtoR x y + NRNRtoR x' y'.
 Proof.
   intros x x' y y'.
   apply pathsinv0, NR_to_hr_plus.
 Qed.
 Lemma NRNRtoR_opp :
-  ∀ x y : NonnegativeReals, NRNRtoR y x = - NRNRtoR x y.
+  Π x y : NonnegativeReals, NRNRtoR y x = - NRNRtoR x y.
 Proof.
   intros x y.
   apply pathsinv0, NR_to_hr_opp.
 Qed.
 Lemma NRNRtoR_minus :
-  ∀ x x' y y' : NonnegativeReals, NRNRtoR (x + y')%NR (y + x')%NR = NRNRtoR x y - NRNRtoR x' y'.
+  Π x x' y y' : NonnegativeReals, NRNRtoR (x + y')%NR (y + x')%NR = NRNRtoR x y - NRNRtoR x' y'.
 Proof.
   intros x x' y y'.
   apply pathsinv0, NR_to_hr_minus.
 Qed.
 Lemma NRNRtoR_mult :
-  ∀ x x' y y' : NonnegativeReals, NRNRtoR (x * x' + y * y')%NR (x * y' + y * x')%NR = NRNRtoR x y * NRNRtoR x' y'.
+  Π x x' y y' : NonnegativeReals, NRNRtoR (x * x' + y * y')%NR (x * y' + y * x')%NR = NRNRtoR x y * NRNRtoR x' y'.
 Proof.
   intros x x' y y'.
   apply pathsinv0, NR_to_hr_mult.
 Qed.
 Lemma NRNRtoR_inv_pos :
-  ∀ (x : NonnegativeReals) Hrn Hr,
+  Π (x : NonnegativeReals) Hrn Hr,
     NRNRtoR (invNonnegativeReals x Hrn) 0%NR = Rinv (NRNRtoR x 0%NR) Hr.
 Proof.
   intros x Hrn Hr.
@@ -1499,7 +1499,7 @@ Proof.
   apply NRNRtoR_one.
 Qed.
 Lemma NRNRtoR_inv_neg :
-  ∀ (x : NonnegativeReals) Hrn Hr,
+  Π (x : NonnegativeReals) Hrn Hr,
     NRNRtoR 0%NR (invNonnegativeReals x Hrn) = Rinv (NRNRtoR 0%NR x) Hr.
 Proof.
   intros x Hrn Hr.
@@ -1528,45 +1528,45 @@ Proof.
 Qed.
 
 Lemma isirrefl_Rlt :
-  ∀ x : Reals, ¬ (x < x).
+  Π x : Reals, ¬ (x < x).
 Proof.
   exact (pr2 isStrongOrder_hr_lt).
 Qed.
 Lemma istrans_Rlt :
-  ∀ x y z : Reals, x < y -> y < z -> x < z.
+  Π x y z : Reals, x < y -> y < z -> x < z.
 Proof.
   exact (pr1 isStrongOrder_hr_lt).
 Qed.
 Lemma iscotrans_Rlt :
-  ∀ (x y z : Reals), (x < z) -> (x < y) ∨ (y < z).
+  Π (x y z : Reals), (x < z) -> (x < y) ∨ (y < z).
 Proof.
   exact iscotrans_hr_lt.
 Qed.
 
 Lemma Rplus_ltcompat_l:
-  ∀ x y z : Reals, y < z <-> (y + x) < (z + x).
+  Π x y z : Reals, y < z <-> (y + x) < (z + x).
 Proof.
   exact hr_plus_ltcompat_l.
 Qed.
 Lemma Rplus_ltcompat_r:
-  ∀ x y z : Reals, y < z <-> (x + y) < (x + z).
+  Π x y z : Reals, y < z <-> (x + y) < (x + z).
 Proof.
   exact hr_plus_ltcompat_r.
 Qed.
 Lemma Rmult_ltcompat_l:
-  ∀ x y z : Reals,
+  Π x y z : Reals,
     0 < x -> y < z -> (y * x) < (z * x).
 Proof.
   exact hr_mult_ltcompat_l.
 Qed.
 Lemma Rmult_ltcompat_l':
-  ∀ x y z : Reals,
+  Π x y z : Reals,
     0 <= x -> (y * x) < (z * x) -> y < z.
 Proof.
   exact hr_mult_ltcompat_l'.
 Qed.
 Lemma Rmult_ltcompat_r:
-  ∀ x y z : Reals,
+  Π x y z : Reals,
     0 < x -> y < z -> (x * y) < (x * z).
 Proof.
   intros x y z.
@@ -1574,25 +1574,25 @@ Proof.
   now apply Rmult_ltcompat_l.
 Qed.
 Lemma Rmult_ltcompat_r':
-  ∀ x y z : Reals,
+  Π x y z : Reals,
     0 <= x -> (x * y) < (x * z) -> y < z.
 Proof.
   exact hr_mult_ltcompat_r'.
 Qed.
 
 Lemma Rarchimedean:
-  ∀ x : Reals, ∃ n : nat, x < nattorng n.
+  Π x : Reals, ∃ n : nat, x < nattorng n.
 Proof.
   exact hr_archimedean.
 Qed.
 
 Lemma notRlt_Rle :
-  ∀ x y : Reals, ¬ (x < y) <-> (y <= x).
+  Π x y : Reals, ¬ (x < y) <-> (y <= x).
 Proof.
   exact hr_notlt_le.
 Qed.
 Lemma Rlt_Rle :
-  ∀ x y : Reals, x < y -> x <= y.
+  Π x y : Reals, x < y -> x <= y.
 Proof.
   intros x y H.
   apply notRlt_Rle.
@@ -1603,12 +1603,12 @@ Proof.
   exact H0.
 Qed.
 Lemma isantisymm_Rle :
-  ∀ x y : Reals, x <= y -> y <= x -> x = y.
+  Π x y : Reals, x <= y -> y <= x -> x = y.
 Proof.
   exact isantisymm_hr_le.
 Qed.
 Lemma istrans_Rle :
-  ∀ x y z : Reals, x <= y -> y <= z -> x <= z.
+  Π x y z : Reals, x <= y -> y <= z -> x <= z.
 Proof.
   intros x y z Hxy Hyz.
   apply notRlt_Rle ; intro H.
@@ -1622,7 +1622,7 @@ Proof.
   exact Hxy.
 Qed.
 Lemma istrans_Rle_lt :
-  ∀ x y z : Reals, x <= y -> y < z -> x < z.
+  Π x y z : Reals, x <= y -> y < z -> x < z.
 Proof.
   intros x y z Hxy Hyz.
   generalize (iscotrans_Rlt _ x _ Hyz).
@@ -1635,7 +1635,7 @@ Proof.
   exact H.
 Qed.
 Lemma istrans_Rlt_le :
-  ∀ x y z : Reals, x < y -> y <= z -> x < z.
+  Π x y z : Reals, x < y -> y <= z -> x < z.
 Proof.
   intros x y z Hxy Hyz.
   generalize (iscotrans_Rlt _ z _ Hxy).
@@ -1649,42 +1649,42 @@ Proof.
 Qed.
 
 Lemma Rplus_lecompat_l:
-  ∀ x y z : Reals, y <= z <-> (y + x) <= (z + x).
+  Π x y z : Reals, y <= z <-> (y + x) <= (z + x).
 Proof.
   exact hr_plus_lecompat_l.
 Qed.
 Lemma Rplus_lecompat_r:
-  ∀ x y z : Reals, y <= z <-> (x + y) <= (x + z).
+  Π x y z : Reals, y <= z <-> (x + y) <= (x + z).
 Proof.
   exact hr_plus_lecompat_r.
 Qed.
 Lemma Rmult_lecompat_l:
-  ∀ x y z : Reals,
+  Π x y z : Reals,
     0 <= x -> y <= z -> (y * x) <= (z * x).
 Proof.
   exact hr_mult_lecompat_l.
 Qed.
 Lemma Rmult_lecompat_l':
-  ∀ x y z : Reals,
+  Π x y z : Reals,
     0 < x -> (y * x) <= (z * x) -> y <= z.
 Proof.
   exact hr_mult_lecompat_l'.
 Qed.
 Lemma Rmult_lecompat_r:
-  ∀ x y z : Reals,
+  Π x y z : Reals,
     0 <= x -> y <= z -> (x * y) <= (x * z).
 Proof.
   exact hr_mult_lecompat_r.
 Qed.
 Lemma Rmult_lecompat_r':
-  ∀ x y z : Reals,
+  Π x y z : Reals,
     0 < x -> (x * y) <= (x * z) -> y <= z.
 Proof.
   exact hr_mult_lecompat_r'.
 Qed.
 
 Lemma Rap_Rlt:
-  ∀ x y : Reals, x ≠ y <-> (x < y) ⨿ (y < x).
+  Π x y : Reals, x ≠ y <-> (x < y) ⨿ (y < x).
 Proof.
   exact hr_ap_lt.
 Qed.
@@ -1695,75 +1695,75 @@ Proof.
 Qed.
 
 Lemma isirrefl_Rap :
-  ∀ x : Reals, ¬ (x ≠ x).
+  Π x : Reals, ¬ (x ≠ x).
 Proof.
   exact isirrefl_CFap.
 Qed.
 Lemma issymm_Rap :
-  ∀ (x y : Reals), (x ≠ y) -> (y ≠ x).
+  Π (x y : Reals), (x ≠ y) -> (y ≠ x).
 Proof.
   exact issymm_CFap.
 Qed.
 Lemma iscotrans_Rap :
-  ∀ (x y z : Reals), (x ≠ z) -> (x ≠ y) ∨ (y ≠ z).
+  Π (x y z : Reals), (x ≠ z) -> (x ≠ y) ∨ (y ≠ z).
 Proof.
   exact iscotrans_CFap.
 Qed.
 Lemma istight_Rap :
-  ∀ (x y : Reals), ¬ (x ≠ y) -> x = y.
+  Π (x y : Reals), ¬ (x ≠ y) -> x = y.
 Proof.
   exact istight_CFap.
 Qed.
 
 Lemma apRplus :
-  ∀ (x x' y y' : Reals),
+  Π (x x' y y' : Reals),
     (x + y ≠ x' + y') -> (x ≠ x') ∨ (y ≠ y').
 Proof.
   exact apCFplus.
 Qed.
 Lemma Rplus_apcompat_l :
-  ∀ x y z : Reals,
+  Π x y z : Reals,
     y + x ≠ z + x <-> y ≠ z.
 Proof.
   exact CFplus_apcompat_l.
 Qed.
 Lemma Rplus_apcompat_r :
-  ∀ x y z : Reals,
+  Π x y z : Reals,
     x + y ≠ x + z <-> y ≠ z.
 Proof.
   exact CFplus_apcompat_r.
 Qed.
 
 Lemma apRmult:
-  ∀ (x x' y y' : Reals),
+  Π (x x' y y' : Reals),
   (x * y ≠ x' * y') -> (x ≠ x') ∨ (y ≠ y').
 Proof.
   apply apCFmult.
 Qed.
 Lemma Rmult_apcompat_l:
-  ∀ (x y z : Reals), (y * x ≠ z * x) -> (y ≠ z).
+  Π (x y z : Reals), (y * x ≠ z * x) -> (y ≠ z).
 Proof.
   exact CFmult_apcompat_l.
 Qed.
 Lemma Rmult_apcompat_l':
-  ∀ (x y z : Reals),
+  Π (x y z : Reals),
     (x ≠ 0) -> (y ≠ z) -> (y * x ≠ z * x).
 Proof.
   exact CFmult_apcompat_l'.
 Qed.
 Lemma Rmult_apcompat_r:
-  ∀ (x y z : Reals), (x * y ≠ x * z) -> (y ≠ z).
+  Π (x y z : Reals), (x * y ≠ x * z) -> (y ≠ z).
 Proof.
   exact CFmult_apcompat_r.
 Qed.
 Lemma Rmult_apcompat_r':
-  ∀ (x y z : Reals),
+  Π (x y z : Reals),
     (x ≠ 0) -> (y ≠ z) -> (x * y ≠ x * z).
 Proof.
   exact CFmult_apcompat_r'.
 Qed.
 Lemma RmultapRzero:
-  ∀ (x y : Reals),
+  Π (x y : Reals),
     (x * y ≠ 0) -> (x ≠ 0) ∧ (y ≠ 0).
 Proof.
   exact CFmultapCFzero.
@@ -1772,85 +1772,85 @@ Qed.
 (** ** Algrebra *)
 
 Lemma islunit_Rzero_Rplus :
-  forall x : Reals, 0 + x = x.
+  Π x : Reals, 0 + x = x.
 Proof.
   exact islunit_CFzero_CFplus.
 Qed.
 Lemma isrunit_Rzero_Rplus :
-  ∀ x : Reals, x + 0 = x.
+  Π x : Reals, x + 0 = x.
 Proof.
   exact isrunit_CFzero_CFplus.
 Qed.
 Lemma isassoc_Rplus :
-  ∀ x y z : Reals, x + y + z = x + (y + z).
+  Π x y z : Reals, x + y + z = x + (y + z).
 Proof.
   exact isassoc_CFplus.
 Qed.
 Lemma islinv_Ropp :
-  ∀ x : Reals, - x + x = 0.
+  Π x : Reals, - x + x = 0.
 Proof.
   exact islinv_CFopp.
 Qed.
 Lemma isrinv_Ropp :
-  ∀ x : Reals, x + - x = 0.
+  Π x : Reals, x + - x = 0.
 Proof.
   exact isrinv_CFopp.
 Qed.
 
 Lemma iscomm_Rplus :
-  ∀ x y : Reals, x + y = y + x.
+  Π x y : Reals, x + y = y + x.
 Proof.
   exact iscomm_CFplus.
 Qed.
 Lemma islunit_Rone_Rmult :
-  ∀ x : Reals, 1 * x = x.
+  Π x : Reals, 1 * x = x.
 Proof.
   exact islunit_CFone_CFmult.
 Qed.
 Lemma isrunit_Rone_Rmult :
-  ∀ x : Reals, x * 1 = x.
+  Π x : Reals, x * 1 = x.
 Proof.
   exact isrunit_CFone_CFmult.
 Qed.
 Lemma isassoc_Rmult :
-  ∀ x y z : Reals, x * y * z = x * (y * z).
+  Π x y z : Reals, x * y * z = x * (y * z).
 Proof.
   exact isassoc_CFmult.
 Qed.
 Lemma iscomm_Rmult :
-  ∀ x y : Reals, x * y = y * x.
+  Π x y : Reals, x * y = y * x.
 Proof.
   exact iscomm_CFmult.
 Qed.
 Lemma islinv_Rinv :
-  ∀ (x : Reals) (Hx0 : x ≠ 0),
+  Π (x : Reals) (Hx0 : x ≠ 0),
     (Rinv x Hx0) * x = 1.
 Proof.
   exact islinv_CFinv.
 Qed.
 Lemma isrinv_Rinv :
-  ∀ (x : Reals) (Hx0 : x ≠ 0),
+  Π (x : Reals) (Hx0 : x ≠ 0),
     x * (Rinv x Hx0) = 1.
 Proof.
   exact isrinv_CFinv.
 Qed.
 Lemma islabsorb_Rzero_Rmult :
-  ∀ x : Reals, 0 * x = 0.
+  Π x : Reals, 0 * x = 0.
 Proof.
   exact islabsorb_CFzero_CFmult.
 Qed.
 Lemma israbsorb_Rzero_Rmult :
-  ∀ x : Reals, x * 0 = 0.
+  Π x : Reals, x * 0 = 0.
 Proof.
   exact israbsorb_CFzero_CFmult.
 Qed.
 Lemma isldistr_Rplus_Rmult :
-  ∀ x y z : Reals, z * (x + y) = z * x + z * y.
+  Π x y z : Reals, z * (x + y) = z * x + z * y.
 Proof.
   exact isldistr_CFplus_CFmult.
 Qed.
 Lemma isrdistr_Rplus_Rmult :
-  ∀ x y z : Reals, (x + y) * z = x * z + y * z.
+  Π x y z : Reals, (x + y) * z = x * z + y * z.
 Proof.
   exact isrdistr_CFplus_CFmult.
 Qed.
@@ -1858,18 +1858,18 @@ Qed.
 (** ** Rabs *)
 
 Lemma istriangle_Rabs :
-  ∀ x y : Reals, (Rabs (x + y)%R <= Rabs x + Rabs y)%NR.
+  Π x y : Reals, (Rabs (x + y)%R <= Rabs x + Rabs y)%NR.
 Proof.
   exact istriangle_hr_abs.
 Qed.
 Lemma istriangle_Rabs' :
-  ∀ x y : Reals, (Rabs x - Rabs y <= Rabs (x + y)%R)%NR.
+  Π x y : Reals, (Rabs x - Rabs y <= Rabs (x + y)%R)%NR.
 Proof.
   exact istriangle_hr_abs'.
 Qed.
 
 Lemma Rabs_Rmult :
-  ∀ x y : Reals, (Rabs (x * y)%R = Rabs x * Rabs y)%NR.
+  Π x y : Reals, (Rabs (x * y)%R = Rabs x * Rabs y)%NR.
 Proof.
   exact hr_abs_mult.
 Qed.

--- a/UniMath/Dedekind/Sets.v
+++ b/UniMath/Dedekind/Sets.v
@@ -23,9 +23,9 @@ Definition makeSubset {X : hSet} {Hsub : hsubtypes X} (x : X) (Hx : Hsub x) : su
 Definition unop (X : UU) := X -> X.
 
 Definition islinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtypes X) (inv : subset exinv -> X) :=
-  forall (x : X) (Hx : exinv x), op (inv (x ,, Hx)) x = x1.
+  Π (x : X) (Hx : exinv x), op (inv (x ,, Hx)) x = x1.
 Definition isrinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtypes X) (inv : subset exinv -> X) :=
-  forall (x : X) (Hx : exinv x), op x (inv (x ,, Hx)) = x1.
+  Π (x : X) (Hx : exinv x), op x (inv (x ,, Hx)) = x1.
 Definition isinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtypes X) (inv : subset exinv -> X)  :=
   islinv' x1 op exinv inv × isrinv' x1 op exinv inv.
 
@@ -104,7 +104,7 @@ Qed.
 Definition po_reverse {X : UU} (l : po X) :=
   popair (hrel_reverse l) (ispreorder_reverse l (pr2 l)).
 Lemma po_reverse_correct {X : UU} (l : po X) :
-  forall x y : X, po_reverse l x y = l y x.
+  Π x y : X, po_reverse l x y = l y x.
 Proof.
   intros X l x y.
   now apply paths_refl.
@@ -128,7 +128,7 @@ Qed.
 Definition eqrel_reverse {X : UU} (l : eqrel X) :=
   eqrelpair (hrel_reverse l) (iseqrel_reverse l (pr2 l)).
 Lemma eqrel_reverse_correct {X : UU} (l : eqrel X) :
-  forall x y : X, eqrel_reverse l x y = l y x.
+  Π x y : X, eqrel_reverse l x y = l y x.
 Proof.
   intros X l x y.
   now apply paths_refl.
@@ -152,7 +152,7 @@ Qed.
 Definition StrongOrder_reverse {X : UU} (l : StrongOrder X) :=
   pairStrongOrder (hrel_reverse l) (isStrongOrder_reverse l (pr2 l)).
 Lemma StrongOrder_reverse_correct {X : UU} (l : StrongOrder X) :
-  forall x y : X, StrongOrder_reverse l x y = l y x.
+  Π x y : X, StrongOrder_reverse l x y = l y x.
 Proof.
   intros X l x y.
   now apply paths_refl.
@@ -192,9 +192,9 @@ Qed.
 
 Definition isEffectiveOrder {X : UU} (le lt : hrel X) :=
   dirprod ((ispreorder le) × (isStrongOrder lt))
-          ((∀ x y : X, (¬ lt x y) <-> (le y x))
-          × (∀ x y z : X, lt x y -> le y z -> lt x z)
-          × (∀ x y z : X, le x y -> lt y z -> lt x z)).
+          ((Π x y : X, (¬ lt x y) <-> (le y x))
+          × (Π x y z : X, lt x y -> le y z -> lt x z)
+          × (Π x y z : X, le x y -> lt y z -> lt x z)).
 Definition EffectiveOrder (X : UU) :=
   Σ lelt : hrel X * hrel X, isEffectiveOrder (fst lelt) (snd lelt).
 Definition pairEffectiveOrder {X : UU} (le lt : hrel X) (is : isEffectiveOrder le lt) : EffectiveOrder X :=
@@ -249,37 +249,37 @@ Context {X : EffectivelyOrderedSet}.
 Open Scope eo_scope.
 
 Lemma not_EOlt_le :
-  ∀ x y : X, (¬ (x < y)) <-> (y <= x).
+  Π x y : X, (¬ (x < y)) <-> (y <= x).
 Proof.
   exact (pr1 (pr2 (pr2 (pr2 X)))).
 Qed.
 Lemma EOge_le:
-  ∀ x y : X, (x >= y) <-> (y <= x).
+  Π x y : X, (x >= y) <-> (y <= x).
 Proof.
   now split.
 Qed.
 Lemma EOgt_lt:
-  ∀ x y : X, (x > y) <-> (y < x).
+  Π x y : X, (x > y) <-> (y < x).
 Proof.
   now split.
 Qed.
 
 Definition isrefl_EOle:
-  forall x : X, x <= x
+  Π x : X, x <= x
   := isrefl_po EOle.
 Definition istrans_EOle:
-  ∀ x y z : X, x <= y -> y <= z -> x <= z
+  Π x y z : X, x <= y -> y <= z -> x <= z
   := istrans_po EOle.
 
 Definition isirrefl_EOlt:
-  forall x : X, ¬ (x < x)
+  Π x : X, ¬ (x < x)
   := isirrefl_StrongOrder EOlt.
 Definition istrans_EOlt:
-  ∀ x y z : X, x < y -> y < z -> x < z
+  Π x y z : X, x < y -> y < z -> x < z
   := istrans_StrongOrder EOlt.
 
 Lemma EOlt_le :
-  ∀ x y : X, x < y -> x <= y.
+  Π x y : X, x < y -> x <= y.
 Proof.
   intros x y Hxy.
   apply not_EOlt_le.
@@ -291,25 +291,25 @@ Proof.
 Qed.
 
 Lemma istrans_EOlt_le:
-  ∀ x y z : X, x < y -> y <= z -> x < z.
+  Π x y z : X, x < y -> y <= z -> x < z.
 Proof.
   exact (pr1 (pr2 (pr2 (pr2 (pr2 X))))).
 Qed.
 Lemma istrans_EOle_lt:
-  ∀ x y z : X, x <= y -> y < z -> x < z.
+  Π x y z : X, x <= y -> y < z -> x < z.
 Proof.
   exact (pr2 (pr2 (pr2 (pr2 (pr2 X))))).
 Qed.
 
 Lemma EOlt_noteq :
-  ∀ x y : X, x < y -> x != y.
+  Π x y : X, x < y -> x != y.
 Proof.
   intros x y Hlt Heq.
   rewrite Heq in Hlt.
   now apply isirrefl_EOlt in Hlt.
 Qed.
 Lemma EOgt_noteq :
-  ∀ x y : X, x > y -> x != y.
+  Π x y : X, x > y -> x != y.
 Proof.
   intros x y Hgt Heq.
   rewrite Heq in Hgt.
@@ -328,9 +328,9 @@ Context {X : PreorderedSet}.
 Local Notation "x <= y" := (pr1 (pr2 X) x y).
 
 Definition isUpperBound (E : hsubtypes X) (ub : X) : UU :=
-  forall x : X, E x -> x <= ub.
+  Π x : X, E x -> x <= ub.
 Definition isSmallerThanUpperBounds (E : hsubtypes X) (lub : X) : UU :=
-  forall ub : X, isUpperBound E ub -> lub <= ub.
+  Π ub : X, isUpperBound E ub -> lub <= ub.
 
 Definition isLeastUpperBound (E : hsubtypes X) (lub : X) : UU :=
   dirprod (isUpperBound E lub) (isSmallerThanUpperBounds E lub).
@@ -373,9 +373,9 @@ Context {X : PreorderedSet}.
 Local Notation "x >= y" := (pr1 (pr2 X) y x).
 
 Definition isLowerBound (E : hsubtypes X) (ub : X) : UU :=
-  forall x : X, E x -> x >= ub.
+  Π x : X, E x -> x >= ub.
 Definition isBiggerThanLowerBounds (E : hsubtypes X) (lub : X) : UU :=
-  forall ub : X, isLowerBound E ub -> lub >= ub.
+  Π ub : X, isLowerBound E ub -> lub >= ub.
 
 Definition isGreatestLowerBound (E : hsubtypes X) (lub : X) : UU :=
   dirprod (isLowerBound E lub) (isBiggerThanLowerBounds E lub).
@@ -413,7 +413,7 @@ Qed.
 End GreatestLowerBound.
 
 Definition isCompleteSpace (X : PreorderedSet) :=
-  forall E : hsubtypes X,
+  Π E : hsubtypes X,
     hexists (isUpperBound E) -> hexists E -> LeastUpperBound E.
 Definition CompleteSpace  :=
   total2 (fun X : PreorderedSet => isCompleteSpace X).

--- a/UniMath/Folds/UnicodeNotations.v
+++ b/UniMath/Folds/UnicodeNotations.v
@@ -3,7 +3,7 @@ Require Export UniMath.Foundations.Basics.PartD.
 Require Export UniMath.Foundations.Basics.Propositions.
 
 (*
-Notation "∀  x .. y , P" := (forall x, .. (forall y, P) ..)
+Notation "'Π'  x .. y , P" := (Π x, .. (Π y, P) ..)
   (at level 200, x binder, y binder, right associativity) : type_scope.
 Notation "'Σ'  x .. y , P" := (total2 (fun x => .. (total2 (fun y => P)) ..))
   (at level 200, x binder, y binder, right associativity) : type_scope.

--- a/UniMath/Folds/folds_isomorphism.v
+++ b/UniMath/Folds/folds_isomorphism.v
@@ -7,8 +7,8 @@ Contents of this file:
 
   - Definition of type of isomorphism [folds_iso a b] in a FOLDS precategory
     - consists of two families of isos and an iso, see [folds_iso_data]
-      - [ϕ₁ : ∀ x, x ⇒ a → x ⇒ b]
-      - [ϕ₂ : ∀ z, a ⇒ z → b ⇒ z]
+      - [ϕ₁ : Π x, x ⇒ a → x ⇒ b]
+      - [ϕ₂ : Π z, a ⇒ z → b ⇒ z]
       - [ϕ∙ :      a ⇒ a → b ⇒ b]
     - and a number of logical equivalences, see [folds_iso_prop]
   - Some lemmas expressing naturality of maps [ϕX]
@@ -51,8 +51,8 @@ Local Notation "'id' a" := (identity (C:=C') a) (at level 30).
 
 
 Definition folds_iso_data (a b : C) : UU :=
-  ((∀ {x : C}, (x ⇒ a) ≃ (x ⇒ b))
- × (∀ {z : C}, (a ⇒ z) ≃ (b ⇒ z)))
+  ((Π {x : C}, (x ⇒ a) ≃ (x ⇒ b))
+ × (Π {z : C}, (a ⇒ z) ≃ (b ⇒ z)))
 ×             ((a ⇒ a) ≃ (b ⇒ b)).
 
 Definition ϕ₁ {a b : C} (f : folds_iso_data a b) {x : C} : (x ⇒ a) ≃ (x ⇒ b) :=
@@ -65,14 +65,14 @@ Notation "ϕ∙" := ϕo. (* works as a notation, but not as an identifier *)
 
 
 Definition folds_iso_prop {a b : C} (i : folds_iso_data a b) : UU :=
-  ((((∀ (x y : C) (f : x ⇒ y) (g : y ⇒ a) (h : x ⇒ a), T f g h ≃ T f ((ϕ₁ i) g) ((ϕ₁ i) h))
-   × (∀ (x z : C) (f : x ⇒ a) (g : a ⇒ z) (h : x ⇒ z), T f g h ≃ T ((ϕ₁ i) f) ((ϕ₂ i) g) h))
-   × (∀ (z w : C) (f : a ⇒ z) (g : z ⇒ w) (h : a ⇒ w), T f g h ≃ T ((ϕ₂ i) f) g ((ϕ₂ i) h)))
- × (((∀ (x : C) (f : x ⇒ a) (g : a ⇒ a) (h : x ⇒ a),   T f g h ≃ T ((ϕ₁ i) f) ((ϕo i) g) ((ϕ₁ i) h))
-   × (∀ (x : C) (f : a ⇒ x) (g : x ⇒ a) (h : a ⇒ a),   T f g h ≃ T ((ϕ₂ i) f) ((ϕ₁ i) g) ((ϕ∙ i) h)))
-  × ((∀ (x : C) (f : a ⇒ a) (g h : a ⇒ x),             T f g h ≃ T ((ϕ∙ i) f) ((ϕ₂ i) g) ((ϕ₂ i) h))
-   × (∀ f g h : a ⇒ a,                                 T f g h ≃ T ((ϕ∙ i) f) ((ϕ∙ i) g) ((ϕ∙ i) h)))))
-   × (∀ f : a ⇒ a,                                     I f ≃ I ((ϕ∙ i) f)).
+  ((((Π (x y : C) (f : x ⇒ y) (g : y ⇒ a) (h : x ⇒ a), T f g h ≃ T f ((ϕ₁ i) g) ((ϕ₁ i) h))
+   × (Π (x z : C) (f : x ⇒ a) (g : a ⇒ z) (h : x ⇒ z), T f g h ≃ T ((ϕ₁ i) f) ((ϕ₂ i) g) h))
+   × (Π (z w : C) (f : a ⇒ z) (g : z ⇒ w) (h : a ⇒ w), T f g h ≃ T ((ϕ₂ i) f) g ((ϕ₂ i) h)))
+ × (((Π (x : C) (f : x ⇒ a) (g : a ⇒ a) (h : x ⇒ a),   T f g h ≃ T ((ϕ₁ i) f) ((ϕo i) g) ((ϕ₁ i) h))
+   × (Π (x : C) (f : a ⇒ x) (g : x ⇒ a) (h : a ⇒ a),   T f g h ≃ T ((ϕ₂ i) f) ((ϕ₁ i) g) ((ϕ∙ i) h)))
+  × ((Π (x : C) (f : a ⇒ a) (g h : a ⇒ x),             T f g h ≃ T ((ϕ∙ i) f) ((ϕ₂ i) g) ((ϕ₂ i) h))
+   × (Π f g h : a ⇒ a,                                 T f g h ≃ T ((ϕ∙ i) f) ((ϕ∙ i) g) ((ϕ∙ i) h)))))
+   × (Π f : a ⇒ a,                                     I f ≃ I ((ϕ∙ i) f)).
 
 Definition isaprop_folds_iso_prop (a b : C) (i : folds_iso_data a b) : isaprop (folds_iso_prop i).
 Proof.
@@ -192,7 +192,7 @@ Variables i i' : folds_iso a b.
 
 Hypothesis H : ϕ₁ i (id _ ) = ϕ₁ i' (id _ ).
 
-Lemma ϕ₂_determined : ∀ x (f : a ⇒ x) , ϕ₂ i f = ϕ₂ i' f.
+Lemma ϕ₂_determined : Π x (f : a ⇒ x) , ϕ₂ i f = ϕ₂ i' f.
 Proof.
   intros x f.
   rewrite (ϕ₂_is_comp i).
@@ -209,7 +209,7 @@ Proof.
   apply idpath.
 Qed.
 
-Lemma ϕo_determined : ∀ f, ϕ∙ i f = ϕ∙ i' f.
+Lemma ϕo_determined : Π f, ϕ∙ i f = ϕ∙ i' f.
 Proof.
   intro f.
   do 2 rewrite ϕo_ϕ₁_ϕ₂.

--- a/UniMath/Folds/folds_pre_2_cat.v
+++ b/UniMath/Folds/folds_pre_2_cat.v
@@ -77,45 +77,45 @@ Definition double_transport {C : folds_3_ob_mor} {a a' b b' : ob C}
 (** We do not assume those to be propositions.  *)
 
 Definition folds_3_id_comp_eq := Σ C : folds_3_ob_mor,
- ( (∀ a : C, a ⇒ a → UU)
- × (∀ (a b c : C), (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → UU))
- × ∀ a b : C, a ⇒ b → a ⇒ b → UU.
+ ( (Π a : C, a ⇒ a → UU)
+ × (Π (a b c : C), (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → UU))
+ × Π a b : C, a ⇒ b → a ⇒ b → UU.
 
 
 Definition folds_ob_mor_from_folds_id_comp (C : folds_3_id_comp_eq) : folds_3_ob_mor := pr1 C.
 Coercion folds_ob_mor_from_folds_id_comp : folds_3_id_comp_eq >-> folds_3_ob_mor.
 
-Definition I {C : folds_3_id_comp_eq} : ∀ {a : C}, a ⇒ a → UU := pr1 (pr1 (pr2 C)).
+Definition I {C : folds_3_id_comp_eq} : Π {a : C}, a ⇒ a → UU := pr1 (pr1 (pr2 C)).
 Definition T {C : folds_3_id_comp_eq} :
-      ∀ {a b c : C}, (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → UU := pr2 (pr1 (pr2 C)).
+      Π {a b c : C}, (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → UU := pr2 (pr1 (pr2 C)).
 Definition E {C : folds_3_id_comp_eq} :
-      ∀ {a b : C}, a ⇒ b → a ⇒ b → UU := pr2 (pr2 C).
+      Π {a b : C}, a ⇒ b → a ⇒ b → UU := pr2 (pr2 C).
 
 (** ** E is an "equality", i.e. a congruence and equivalence *)
 
 Definition E_is_good_to_I_and_T (C : folds_3_id_comp_eq) : UU :=
-  (((∀ (a b : C) (f : a ⇒ b), E f f) (* refl *)
- ×  (∀ (a b : C) (f g : a ⇒ b), E f g → E g f)) (* sym *)
-×   (∀ (a b : C) (f g h : a ⇒ b), E f g → E g h → E f h))
-×  ((∀ (a : C) (f g : a ⇒ a), E f g → I f → I g)
-×   (∀ (a b c : C) (f f' : a ⇒ b) (g g' : b ⇒ c) (h h' : a ⇒ c),
+  (((Π (a b : C) (f : a ⇒ b), E f f) (* refl *)
+ ×  (Π (a b : C) (f g : a ⇒ b), E f g → E g f)) (* sym *)
+×   (Π (a b : C) (f g h : a ⇒ b), E f g → E g h → E f h))
+×  ((Π (a : C) (f g : a ⇒ a), E f g → I f → I g)
+×   (Π (a b c : C) (f f' : a ⇒ b) (g g' : b ⇒ c) (h h' : a ⇒ c),
                       E f f' → E g g' → E h h' → T f g h → T f' g' h')).
 
 (** **  The axioms for identity *)
 
 Definition folds_ax_id (C : folds_3_id_comp_eq) :=
-     (∀ a : C, ∥ Σ f : a ⇒ a, I f ∥ )  (* there is a thing satisfying I *)
- ×  ((∀ (a b : C) (f : a ⇒ b)(i : b ⇒ b), I i → T f i f) (* I is post neutral *)
-  ×  (∀ (a b : C) (f : a ⇒ b)(i : a ⇒ a), I i → T i f f)). (* I is pre neutral *)
+     (Π a : C, ∥ Σ f : a ⇒ a, I f ∥ )  (* there is a thing satisfying I *)
+ ×  ((Π (a b : C) (f : a ⇒ b)(i : b ⇒ b), I i → T f i f) (* I is post neutral *)
+  ×  (Π (a b : C) (f : a ⇒ b)(i : a ⇒ a), I i → T i f f)). (* I is pre neutral *)
 
 (** ** The axioms for composition *)
 
 Definition folds_ax_comp (C : folds_3_id_comp_eq) :=
-     (∀ {a b c : C} (f : a ⇒ b) (g : b ⇒ c), ∥ Σ h : a ⇒ c, T f g h ∥ )
+     (Π {a b c : C} (f : a ⇒ b) (g : b ⇒ c), ∥ Σ h : a ⇒ c, T f g h ∥ )
                                                         (* there is a composite *)
- × ( (∀ {a b c : C} {f : a ⇒ b} {g : b ⇒ c} {h k : a ⇒ c}, T f g h → T f g k → E h k )
+ × ( (Π {a b c : C} {f : a ⇒ b} {g : b ⇒ c} {h k : a ⇒ c}, T f g h → T f g k → E h k )
                                                         (* composite is unique mod E *)
-  ×  (∀ {a b c d : C} (f : a ⇒ b) (g : b ⇒ c) (h : c ⇒ d) (fg : a ⇒ c)
+  ×  (Π {a b c d : C} (f : a ⇒ b) (g : b ⇒ c) (h : c ⇒ d) (fg : a ⇒ c)
                       (gh : b ⇒ d) (fg_h : a ⇒ d) (f_gh : a ⇒ d),
        T f g fg → T g h gh → T fg h fg_h → T f gh f_gh → E f_gh fg_h)).
                                                         (* composition is assoc mod E *)
@@ -139,9 +139,9 @@ Coercion folds_id_comp_from_folds_precat : folds_pre_3_cat >-> folds_3_id_comp_e
 (** they are 3-precategories such that T, I and E are hProps *)
 
 Definition is_folds_pre_2_cat (C : folds_pre_3_cat) :=
-   ( (∀ (a : C) (i : a ⇒ a), isaprop (I i))
-  ×  (∀ (a b c : C) (f : a ⇒ b) (g : b ⇒ c) (h : a ⇒ c), isaprop (T f g h)))
- ×   (∀ (a b : C) (f g : a ⇒ b), isaprop (E f g)).
+   ( (Π (a : C) (i : a ⇒ a), isaprop (I i))
+  ×  (Π (a b c : C) (f : a ⇒ b) (g : b ⇒ c) (h : a ⇒ c), isaprop (T f g h)))
+ ×   (Π (a b : C) (f g : a ⇒ b), isaprop (E f g)).
 
 Definition folds_pre_2_cat : UU := Σ C, is_folds_pre_2_cat C.
 
@@ -158,19 +158,19 @@ Coercion folds_3_from_folds_2 : folds_pre_2_cat >-> folds_pre_3_cat.
 (** * FOLDS-2-isomorphisms *)
 
 Definition folds_iso {C: folds_pre_3_cat} {a b : C} (f g : a ⇒ b) : UU :=
-(((∀ (x : C) (u : x ⇒ a) (v : x ⇒ b), T u f v ≃ T u g v)
-  × (∀ (x : C) (u : a ⇒ x) (v : x ⇒ b), T u v f ≃ T u v g))
- × (∀ (x : C) (u : b ⇒ x) (v : a ⇒ x), T f u v ≃ T g u v))
-× ((((∀ (u : a ⇒ b) (p : b = a), T p ## f f u ≃ T p ## g g u)
-     × (∀ (u : b ⇒ b) (p : a = a), T (transportf (λ a, a ⇒ b) p f) u f ≃
+(((Π (x : C) (u : x ⇒ a) (v : x ⇒ b), T u f v ≃ T u g v)
+  × (Π (x : C) (u : a ⇒ x) (v : x ⇒ b), T u v f ≃ T u v g))
+ × (Π (x : C) (u : b ⇒ x) (v : a ⇒ x), T f u v ≃ T g u v))
+× ((((Π (u : a ⇒ b) (p : b = a), T p ## f f u ≃ T p ## g g u)
+     × (Π (u : b ⇒ b) (p : a = a), T (transportf (λ a, a ⇒ b) p f) u f ≃
                                    T (transportf (λ a, a ⇒ b) p g) u g))
-    × ((∀ (u : a ⇒ a) (p : b = b), T u p ## f f ≃ T u p ## g g)
-       × (∀ (p : a = a) (q : b = a) (r : b = b),
+    × ((Π (u : a ⇒ a) (p : b = b), T u p ## f f ≃ T u p ## g g)
+       × (Π (p : a = a) (q : b = a) (r : b = b),
           T (double_transport p q f) r ## f f
           ≃ T (double_transport p q g) r ## g g)))
-   × (((∀ p : b = a, I p ## f ≃ I p ## g) × (∀ u : a ⇒ b, E f u ≃ E g u))
-      × ((∀ u : a ⇒ b, E u f ≃ E u g)
-         × (∀ (p : a = a) (q : b = b),
+   × (((Π p : b = a, I p ## f ≃ I p ## g) × (Π u : a ⇒ b, E f u ≃ E g u))
+      × ((Π u : a ⇒ b, E u f ≃ E u g)
+         × (Π (p : a = a) (q : b = b),
             E (double_transport p q f) f ≃ E (double_transport p q g) g)))).
 
 Lemma isaprop_folds_2_iso (C : folds_pre_2_cat) (a b : C) (f g : a ⇒ b) :
@@ -192,14 +192,14 @@ Defined.
 
 (** * In FOLDS-2-precats, [folds_iso f g <-> E f g] *)
 
-Lemma E_transport_source : ∀ (C : folds_pre_2_cat) (a a' b : C) (f g : a ⇒ b) (p : a = a'),
+Lemma E_transport_source : Π (C : folds_pre_2_cat) (a a' b : C) (f g : a ⇒ b) (p : a = a'),
           E f g → E (transportf (λ c, c ⇒ b) p f) (transportf (λ c, c ⇒ b) p g).
 Proof.
   intros. destruct p.
   assumption.
 Defined.
 
-Lemma E_transport_target : ∀ (C : folds_pre_2_cat) (a b b' : C) (f g : a ⇒ b) (p : b = b'),
+Lemma E_transport_target : Π (C : folds_pre_2_cat) (a b b' : C) (f g : a ⇒ b) (p : b = b'),
           E f g → E (transportf (λ c, a ⇒ c) p f) (transportf (λ c, a ⇒ c) p g).
 Proof.
   intros. destruct p.
@@ -276,7 +276,7 @@ Defined.
 
 
 Definition is_univalent_folds_pre_2_cat (C : folds_pre_2_cat) : UU :=
-   ∀ (a b : C) (f g : a ⇒ b), isweq (@idtoiso2 _ _ _ f g).
+   Π (a b : C) (f g : a ⇒ b), isweq (@idtoiso2 _ _ _ f g).
 
 Lemma isaprop_is_univalent_folds_2_precat (C : folds_pre_2_cat) :
    isaprop (is_univalent_folds_pre_2_cat C).
@@ -296,10 +296,10 @@ Definition isotoid2 (C : folds_pre_2_cat) (H : is_univalent_folds_pre_2_cat C)
  *)
 
 Definition is_folds_precategory (C : folds_pre_2_cat) : UU :=
-     (∀ a b : C, isaset (a ⇒ b))
- ×  ((∀ {a b c : C} {f : a ⇒ b} {g : b ⇒ c} {h k : a ⇒ c},
+     (Π a b : C, isaset (a ⇒ b))
+ ×  ((Π {a b c : C} {f : a ⇒ b} {g : b ⇒ c} {h k : a ⇒ c},
                   T f g h → T f g k → h = k )       (* T is unique mod identity *)
-  ×  (∀ {a b c d : C} (f : a ⇒ b) (g : b ⇒ c) (h : c ⇒ d)
+  ×  (Π {a b c d : C} (f : a ⇒ b) (g : b ⇒ c) (h : c ⇒ d)
                   (fg : a ⇒ c) (gh : b ⇒ d) (fg_h : a ⇒ d) (f_gh : a ⇒ d),
                T f g fg → T g h gh →
                   T fg h fg_h → T f gh f_gh → f_gh = fg_h)). (* T is assoc mod identity *)
@@ -367,7 +367,7 @@ Section folds_precat_implies_univalent.
 Variable C : folds_pre_2_cat.
 
 Hypothesis H : is_folds_precategory C.
-Hypothesis standardness : ∀ (a b : C) (f g : a ⇒ b), E f g → f = g.
+Hypothesis standardness : Π (a b : C) (f g : a ⇒ b), E f g → f = g.
 
 Lemma folds_2_iso_implies_identity (a b : C) (f g : a ⇒ b) : folds_iso f g → f = g.
 Proof.

--- a/UniMath/Folds/folds_precat.v
+++ b/UniMath/Folds/folds_precat.v
@@ -33,28 +33,28 @@ Coercion ob : folds_ob_mor >-> UU.
 Definition folds_morphisms {C : folds_ob_mor} : C → C → UU := pr2 C.
 Local Notation "a ⇒ b" := (folds_morphisms a b)(at level 50).
 
-Definition has_folds_homsets (C : folds_ob_mor) : UU := ∀ a b: C, isaset (a ⇒ b).
+Definition has_folds_homsets (C : folds_ob_mor) : UU := Π a b: C, isaset (a ⇒ b).
 
 (** ** Identity and composition, given through predicates *)
 
 Definition folds_id_T := Σ C : folds_ob_mor,
-    (∀ a : C, a ⇒ a → hProp)
- ×  (∀ (a b c : C), (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → hProp).
+    (Π a : C, a ⇒ a → hProp)
+ ×  (Π (a b c : C), (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → hProp).
 
 Definition folds_ob_mor_from_folds_id_comp (C : folds_id_T) : folds_ob_mor := pr1 C.
 Coercion folds_ob_mor_from_folds_id_comp : folds_id_T >-> folds_ob_mor.
 
-Definition I {C : folds_id_T} : ∀ {a : C}, a ⇒ a → hProp
+Definition I {C : folds_id_T} : Π {a : C}, a ⇒ a → hProp
   := pr1 (pr2 C).
-Definition T {C : folds_id_T} : ∀ {a b c : C}, (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → hProp
+Definition T {C : folds_id_T} : Π {a b c : C}, (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → hProp
   := pr2 (pr2 C).
 
 (** **  The axioms for identity *)
 
 Definition folds_ax_I (C : folds_id_T) :=
-     (∀ a : C, ∥ Σ f : a ⇒ a, I f ∥ )  (* there is an id *)
-  × ((∀ (a b : C) (f : a ⇒ b)(i : b ⇒ b), I i → T f i f) (* id is post neutral *)
-   × (∀ (a b : C) (f : a ⇒ b)(i : a ⇒ a), I i → T i f f)). (* id is pre neutral *)
+     (Π a : C, ∥ Σ f : a ⇒ a, I f ∥ )  (* there is an id *)
+  × ((Π (a b : C) (f : a ⇒ b)(i : b ⇒ b), I i → T f i f) (* id is post neutral *)
+   × (Π (a b : C) (f : a ⇒ b)(i : a ⇒ a), I i → T i f f)). (* id is pre neutral *)
 
 Lemma isaprop_folds_ax_id C : isaprop (folds_ax_I C).
 Proof.
@@ -65,10 +65,10 @@ Proof.
 Qed.
 
 Definition folds_ax_T (C : folds_id_T) :=
-     (∀ {a b c : C} (f : a ⇒ b) (g : b ⇒ c), ∥ Σ h : a ⇒ c, T f g h ∥ ) (* there is a composite *)
- ×  ((∀ {a b c : C} {f : a ⇒ b} {g : b ⇒ c} {h k : a ⇒ c},
+     (Π {a b c : C} (f : a ⇒ b) (g : b ⇒ c), ∥ Σ h : a ⇒ c, T f g h ∥ ) (* there is a composite *)
+ ×  ((Π {a b c : C} {f : a ⇒ b} {g : b ⇒ c} {h k : a ⇒ c},
                   T f g h → T f g k → h = k )       (* composite is unique *)
-  ×  (∀ {a b c d : C} (f : a ⇒ b) (g : b ⇒ c) (h : c ⇒ d)
+  ×  (Π {a b c d : C} (f : a ⇒ b) (g : b ⇒ c) (h : c ⇒ d)
                   (fg : a ⇒ c) (gh : b ⇒ d) (fg_h : a ⇒ d) (f_gh : a ⇒ d),
                T f g fg → T g h gh →
                   T fg h fg_h → T f gh f_gh → f_gh = fg_h)). (* composition is assoc *)
@@ -98,7 +98,7 @@ Section some_lemmas_about_folds_precats.
 
 Variable C : folds_precat.
 
-Lemma I_unique : ∀ (a : C) (i i' : a ⇒ a), I i → I i' → i = i'.
+Lemma I_unique : Π (a : C) (i i' : a ⇒ a), I i → I i' → i = i'.
 Proof.
   intros a i i' Hi Hi'.
   destruct C as [CC [Cid Ccomp]]; simpl in *.
@@ -109,7 +109,7 @@ Proof.
   apply (pr1 (pr2 Ccomp) _ _ _ _ _ _ _ H1 H2).
 Qed.
 
-Lemma I_contr : ∀ a : C, iscontr (Σ f : a ⇒ a, I f).
+Lemma I_contr : Π a : C, iscontr (Σ f : a ⇒ a, I f).
 Proof.
   intro a.
   set (H := pr1 (pr1 (pr2 C)) a).
@@ -131,7 +131,7 @@ Proof.
   apply (pr2 (pr1 (I_contr a))).
 Defined.
 
-Lemma T_contr : ∀ (a b c : C) (f : a ⇒ b) (g : b ⇒ c), iscontr (Σ h, T f g h).
+Lemma T_contr : Π (a b c : C) (f : a ⇒ b) (g : b ⇒ c), iscontr (Σ h, T f g h).
 Proof.
   intros a b c f g.
   set (H' := hProppair (iscontr (Σ h : a ⇒ c, T f g h))

--- a/UniMath/Folds/from_precats_to_folds_and_back.v
+++ b/UniMath/Folds/from_precats_to_folds_and_back.v
@@ -58,8 +58,8 @@ Proof.
 Defined.
 
 Definition folds_id_comp_from_precat_data : folds_id_T :=
-  tpair (λ C : folds_ob_mor, (∀ a : C, a ⇒ a → hProp)
-                           × (∀ (a b c : C), (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → hProp))
+  tpair (λ C : folds_ob_mor, (Π a : C, a ⇒ a → hProp)
+                           × (Π (a b c : C), (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → hProp))
         (pr1 C) (dirprodpair (@id_pred) (@comp_pred)).
 
 End data.

--- a/UniMath/Foundations/Algebra/Apartness.v
+++ b/UniMath/Foundations/Algebra/Apartness.v
@@ -70,21 +70,21 @@ Open Scope ap_scope.
 (** Lemmas about apartness *)
 
 Lemma isirreflapSet {X : apSet} :
-  ∀ x : X, ¬ (x # x).
+  Π x : X, ¬ (x # x).
 Proof.
   intros ?.
   exact (pr1 (pr2 (pr2 X))).
 Qed.
 
 Lemma issymmapSet {X : apSet} :
-  ∀ x y : X, x # y -> y # x.
+  Π x y : X, x # y -> y # x.
 Proof.
   intros ?.
   exact (pr1 (pr2 (pr2 (pr2 X)))).
 Qed.
 
 Lemma iscotransapSet {X : apSet} :
-  ∀ x y z : X, x # z -> x # y ∨ y # z.
+  Π x y z : X, x # z -> x # y ∨ y # z.
 Proof.
   intros ?.
   exact (pr2 (pr2 (pr2 (pr2 X)))).
@@ -94,7 +94,7 @@ Close Scope ap_scope.
 (** ** Tight apartness *)
 
 Definition istight {X : UU} (R : hrel X) :=
-  forall x y : X, ¬ (R x y) -> x = y.
+  Π x y : X, ¬ (R x y) -> x = y.
 Definition istightap {X : UU} (ap : hrel X) :=
   isaprel ap × istight ap.
 
@@ -115,42 +115,42 @@ Open Scope tap_scope.
 (** Some lemmas *)
 
 Lemma isirrefltightapSet {X : tightapSet} :
-  ∀ x : X, ¬ (x ≠ x).
+  Π x : X, ¬ (x ≠ x).
 Proof.
   intros ?.
   exact isirreflapSet.
 Qed.
 
 Lemma issymmtightapSet {X : tightapSet} :
-  ∀ x y : X, x ≠ y -> y ≠ x.
+  Π x y : X, x ≠ y -> y ≠ x.
 Proof.
   intros ?.
   exact issymmapSet.
 Qed.
 
 Lemma iscotranstightapSet {X : tightapSet} :
-  ∀ x y z : X, x ≠ z -> x ≠ y ∨ y ≠ z.
+  Π x y z : X, x ≠ z -> x ≠ y ∨ y ≠ z.
 Proof.
   intros ?.
   exact iscotransapSet.
 Qed.
 
 Lemma istighttightapSet {X : tightapSet} :
-  forall x y : X, ¬ (x ≠ y) -> x = y.
+  Π x y : X, ¬ (x ≠ y) -> x = y.
 Proof.
   intros ?.
   exact (pr2 (pr2 (pr2 X))).
 Qed.
 
 Lemma istighttightapSet_rev {X : tightapSet} :
-  forall x y : X, x = y -> ¬ (x ≠ y).
+  Π x y : X, x = y -> ¬ (x ≠ y).
 Proof.
   intros ? x _ <-.
   now apply isirrefltightapSet.
 Qed.
 
 Lemma tightapSet_dec {X : tightapSet} :
-  LEM -> forall x y : X, (x != y <-> x ≠ y).
+  LEM -> Π x y : X, (x != y <-> x ≠ y).
 Proof.
   intros ? Hdec x y.
   destruct (Hdec (x ≠ y)) as [ Hneq | Heq ].
@@ -171,7 +171,7 @@ Qed.
 (** ** Operations and apartness *)
 
 Definition isapunop {X : tightapSet} (op :unop X) :=
-  forall x y : X, op x ≠ op y -> x ≠ y.
+  Π x y : X, op x ≠ op y -> x ≠ y.
 Lemma isaprop_isapunop {X : tightapSet} (op :unop X) :
   isaprop (isapunop op).
 Proof.
@@ -183,9 +183,9 @@ Proof.
 Qed.
 
 Definition islapbinop {X : tightapSet} (op : binop X) :=
-  forall x, isapunop (λ y, op y x).
+  Π x, isapunop (λ y, op y x).
 Definition israpbinop {X : tightapSet} (op : binop X) :=
-  forall x, isapunop (λ y, op x y).
+  Π x, isapunop (λ y, op x y).
 Definition isapbinop {X : tightapSet} (op : binop X) :=
   (islapbinop op) × (israpbinop op).
 Lemma isaprop_islapbinop {X : tightapSet} (op : binop X) :
@@ -238,21 +238,21 @@ Section apsetwithbinop_pty.
 Context {X : apsetwithbinop}.
 
 Lemma islapbinop_op :
-  ∀ x x' y : X, op x y ≠ op x' y -> x ≠ x'.
+  Π x x' y : X, op x y ≠ op x' y -> x ≠ x'.
 Proof.
   intros x y y'.
   now apply (pr1 (pr2 (pr2 X))).
 Qed.
 
 Lemma israpbinop_op :
-  ∀ x y y' : X, op x y ≠ op x y' -> y ≠ y'.
+  Π x y y' : X, op x y ≠ op x y' -> y ≠ y'.
 Proof.
   intros x y y'.
   now apply (pr2 (pr2 (pr2 X))).
 Qed.
 
 Lemma isapbinop_op :
-  ∀ x x' y y' : X, op x y ≠ op x' y' -> x ≠ x' ∨ y ≠ y'.
+  Π x x' y y' : X, op x y ≠ op x' y' -> x ≠ x' ∨ y ≠ y'.
 Proof.
   intros x x' y y' Hop.
   apply (iscotranstightapSet _ (op x' y)) in Hop.
@@ -275,37 +275,37 @@ Definition apsetwith2binop_apsetwithbinop2 : apsetwithbinop :=
   (pr1 X) ,, (pr2 (pr2 X)).
 
 Lemma islapbinop_op1 :
-  ∀ x x' y : X, op1 x y ≠ op1 x' y -> x ≠ x'.
+  Π x x' y : X, op1 x y ≠ op1 x' y -> x ≠ x'.
 Proof.
   exact (islapbinop_op (X := apsetwith2binop_apsetwithbinop1)).
 Qed.
 
 Lemma israpbinop_op1 :
-  ∀ x y y' : X, op1 x y ≠ op1 x y' -> y ≠ y'.
+  Π x y y' : X, op1 x y ≠ op1 x y' -> y ≠ y'.
 Proof.
   exact (israpbinop_op (X := apsetwith2binop_apsetwithbinop1)).
 Qed.
 
 Lemma isapbinop_op1 :
-  ∀ x x' y y' : X, op1 x y ≠ op1 x' y' -> x ≠ x' ∨ y ≠ y'.
+  Π x x' y y' : X, op1 x y ≠ op1 x' y' -> x ≠ x' ∨ y ≠ y'.
 Proof.
   exact (isapbinop_op (X := apsetwith2binop_apsetwithbinop1)).
 Qed.
 
 Lemma islapbinop_op2 :
-  ∀ x x' y : X, op2 x y ≠ op2 x' y -> x ≠ x'.
+  Π x x' y : X, op2 x y ≠ op2 x' y -> x ≠ x'.
 Proof.
   exact (islapbinop_op (X := apsetwith2binop_apsetwithbinop2)).
 Qed.
 
 Lemma israpbinop_op2 :
-  ∀ x y y' : X, op2 x y ≠ op2 x y' -> y ≠ y'.
+  Π x y y' : X, op2 x y ≠ op2 x y' -> y ≠ y'.
 Proof.
   exact (israpbinop_op (X := apsetwith2binop_apsetwithbinop2)).
 Qed.
 
 Lemma isapbinop_op2 :
-  ∀ x x' y y' : X, op2 x y ≠ op2 x' y' -> x ≠ x' ∨ y ≠ y'.
+  Π x x' y y' : X, op2 x y ≠ op2 x' y' -> x ≠ x' ∨ y ≠ y'.
 Proof.
   exact (isapbinop_op (X := apsetwith2binop_apsetwithbinop2)).
 Qed.

--- a/UniMath/Foundations/Algebra/Archimedean.v
+++ b/UniMath/Foundations/Algebra/Archimedean.v
@@ -31,7 +31,7 @@ Definition nattorng {X : rng} (n : nat) : X :=
   nattorig (X := rngtorig X) n.
 
 Lemma natmultS :
-  ∀ {X : monoid} (n : nat) (x : X),
+  Π {X : monoid} (n : nat) (x : X),
     natmult (S n) x = (x + natmult n x)%addmonoid.
 Proof.
   intros X [ | n] x.
@@ -39,14 +39,14 @@ Proof.
   - reflexivity.
 Qed.
 Lemma nattorigS {X : rig} :
-  ∀ (n : nat), nattorig (X := X) (S n) = (1 + nattorig n)%rig.
+  Π (n : nat), nattorig (X := X) (S n) = (1 + nattorig n)%rig.
 Proof.
   intros.
   now apply (natmultS (X := rigaddabmonoid X)).
 Qed.
 
 Lemma nattorig_natmult :
-  ∀ {X : rig} (n : nat) (x : X),
+  Π {X : rig} (n : nat) (x : X),
     (nattorig n * x)%rig = natmult (X := rigaddabmonoid X) n x.
 Proof.
   intros.
@@ -56,7 +56,7 @@ Proof.
     now rewrite rigrdistr, IHn, riglunax2.
 Qed.
 Lemma natmult_plus :
-  ∀ {X : monoid} (n m : nat) (x : X),
+  Π {X : monoid} (n m : nat) (x : X),
     natmult (n + m) x = (natmult n x + natmult m x)%addmonoid.
 Proof.
   induction n ; intros m x.
@@ -66,7 +66,7 @@ Proof.
     reflexivity.
 Qed.
 Lemma nattorig_plus :
-  ∀ {X : rig} (n m : nat),
+  Π {X : rig} (n m : nat),
     (nattorig (n + m) : X) = (nattorig n + nattorig m)%rig.
 Proof.
   intros X n m.
@@ -74,7 +74,7 @@ Proof.
 Qed.
 
 Lemma natmult_mult :
-  ∀ {X : monoid} (n m : nat) (x : X),
+  Π {X : monoid} (n m : nat) (x : X),
     natmult (n * m) x = (natmult n (natmult m x))%addmonoid.
 Proof.
   induction n ; intros m x.
@@ -88,7 +88,7 @@ Proof.
     reflexivity.
 Qed.
 Lemma nattorig_mult :
-  ∀ {X : rig} (n m : nat),
+  Π {X : rig} (n m : nat),
     (nattorig (n * m) : X) = (nattorig n * nattorig m)%rig.
 Proof.
   intros X n m.
@@ -98,7 +98,7 @@ Proof.
 Qed.
 
 Lemma natmult_op {X : monoid} :
-  ∀ (n : nat) (x y : X),
+  Π (n : nat) (x y : X),
     (x + y = y + x)%addmonoid
     -> natmult n (x + y)%addmonoid = (natmult n x + natmult n y)%addmonoid.
 Proof.
@@ -120,7 +120,7 @@ Qed.
 
 Lemma natmult_binophrel {X : monoid} (R : hrel X) :
   istrans R -> isbinophrel R ->
-  ∀ (n : nat) (x y : X), R x y -> R (natmult (S n) x) (natmult (S n) y).
+  Π (n : nat) (x y : X), R x y -> R (natmult (S n) x) (natmult (S n) y).
 Proof.
   intros X R Hr Hop n x y H.
   induction n.
@@ -177,7 +177,7 @@ Qed.
 
 Lemma isequiv_setquot_aux {X : abmonoid} (R : hrel X) :
   isinvbinophrel R ->
-  ∀ x y : X, (setquot_aux R) x y <-> R x y.
+  Π x y : X, (setquot_aux R) x y <-> R x y.
 Proof.
   intros X R H x y.
   split.
@@ -194,20 +194,20 @@ Qed.
 (** ** Archimedean property in a monoid *)
 
 Definition isarchmonoid {X : abmonoid} (R : hrel X) :=
-  ∀ x y1 y2 : X,
+  Π x y1 y2 : X,
     R y1 y2 ->
     (∃ n : nat, R (natmult n y1 + x)%addmonoid (natmult n y2))
       × (∃ n : nat, R (natmult n y1) (natmult n y2 + x)%addmonoid).
 
 Definition isarchmonoid_1 {X : abmonoid} (R : hrel X) :
   isarchmonoid R ->
-  ∀ x y1 y2 : X,
+  Π x y1 y2 : X,
     R y1 y2 ->
     ∃ n : nat, R (natmult n y1 + x)%addmonoid (natmult n y2) :=
   λ H x y1 y2 Hy, (pr1 (H x y1 y2 Hy)).
 Definition isarchmonoid_2 {X : abmonoid} (R : hrel X) :
   isarchmonoid R ->
-  ∀ x y1 y2 : X,
+  Π x y1 y2 : X,
     R y1 y2 ->
     ∃ n : nat, R (natmult n y1) (natmult n y2 + x)%addmonoid :=
   λ H x y1 y2 Hy, (pr2 (H x y1 y2 Hy)).
@@ -215,13 +215,13 @@ Definition isarchmonoid_2 {X : abmonoid} (R : hrel X) :
 (** ** Archimedean property in a group *)
 
 Definition isarchgr {X : abgr} (R : hrel X) :=
-  ∀ x y1 y2 : X,
+  Π x y1 y2 : X,
     R y1 y2 ->
     ∃ n : nat, R (natmult n y1 + x)%addmonoid (natmult n y2).
 
 Local Lemma isarchgr_isarchmonoid_aux {X : abgr} (R : hrel X) :
   isbinophrel R ->
-  ∀ (n : nat) (x y1 y2 : X),
+  Π (n : nat) (x y1 y2 : X),
     R (natmult n y1 * grinv X x)%multmonoid (natmult n y2) -> R (natmult n y1) (natmult n y2 * x)%multmonoid.
 Proof.
   intros X R Hop.
@@ -272,7 +272,7 @@ Local Lemma isarchabgrfrac_aux {X : abmonoid} (R : hrel X)
               (natmult (X := abgrfrac X) (n1 + n2) (setquotpr (binopeqrelabgrfrac X) y2)).
 Proof.
   intros.
-  assert (H0 : ∀ n y, natmult (X := abgrfrac X) n (setquotpr (binopeqrelabgrfrac X) y) = setquotpr (binopeqrelabgrfrac X) (natmult n (pr1 y) ,, natmult n (pr2 y))).
+  assert (H0 : Π n y, natmult (X := abgrfrac X) n (setquotpr (binopeqrelabgrfrac X) y) = setquotpr (binopeqrelabgrfrac X) (natmult n (pr1 y) ,, natmult n (pr2 y))).
   { intros n y.
     induction n.
     reflexivity.
@@ -346,21 +346,21 @@ Defined.
 (** ** Archimedean property in a rig *)
 
 Definition isarchrig {X : rig} (R : hrel X) :=
-  (∀ y1 y2 : X, R y1 y2 -> ∃ n : nat, R (nattorig n * y1)%rig (1 + nattorig n * y2)%rig)
-    × (∀ x : X, ∃ n : nat, R (nattorig n) x)
-    × (∀ x : X, ∃ n : nat, R (nattorig n + x)%rig 0%rig).
+  (Π y1 y2 : X, R y1 y2 -> ∃ n : nat, R (nattorig n * y1)%rig (1 + nattorig n * y2)%rig)
+    × (Π x : X, ∃ n : nat, R (nattorig n) x)
+    × (Π x : X, ∃ n : nat, R (nattorig n + x)%rig 0%rig).
 
 Definition isarchrig_1 {X : rig} (R : hrel X) :
   isarchrig R ->
-  ∀ y1 y2 : X, R y1 y2 -> ∃ n : nat, R (nattorig n * y1)%rig (1 + nattorig n * y2)%rig :=
+  Π y1 y2 : X, R y1 y2 -> ∃ n : nat, R (nattorig n * y1)%rig (1 + nattorig n * y2)%rig :=
   pr1.
 Definition isarchrig_2 {X : rig} (R : hrel X) :
   isarchrig R ->
-  ∀ x : X, ∃ n : nat, R (nattorig n) x :=
+  Π x : X, ∃ n : nat, R (nattorig n) x :=
   λ H, (pr1 (pr2 H)).
 Definition isarchrig_3 {X : rig} (R : hrel X) :
   isarchrig R ->
-  ∀ x : X, ∃ n : nat, R (nattorig n + x)%rig 0%rig :=
+  Π x : X, ∃ n : nat, R (nattorig n + x)%rig 0%rig :=
 
   λ H, (pr2 (pr2 H)).
 
@@ -507,15 +507,15 @@ Defined.
 (** ** Archimedean property in a ring *)
 
 Definition isarchrng {X : rng} (R : hrel X) :=
-  (∀ x : X, R x 0%rng -> ∃ n : nat, R (nattorng n * x)%rng 1%rng)
-    × (∀ x : X, ∃ n : nat, R (nattorng n) x).
+  (Π x : X, R x 0%rng -> ∃ n : nat, R (nattorng n * x)%rng 1%rng)
+    × (Π x : X, ∃ n : nat, R (nattorng n) x).
 
 Definition isarchrng_1 {X : rng} (R : hrel X) :
   isarchrng R ->
-  ∀ x : X, R x 0%rng -> ∃ n : nat, R (nattorng n * x)%rng 1%rng := pr1.
+  Π x : X, R x 0%rng -> ∃ n : nat, R (nattorng n * x)%rng 1%rng := pr1.
 Definition isarchrng_2 {X : rng} (R : hrel X) :
   isarchrng R ->
-  ∀ x : X, ∃ n : nat, R (nattorng n) x := pr2.
+  Π x : X, ∃ n : nat, R (nattorng n) x := pr2.
 
 Lemma isarchrng_isarchrig {X : rng} (R : hrel X) :
   isbinophrel (X := rigaddabmonoid X) R ->
@@ -598,7 +598,7 @@ Proof.
 Defined.
 
 Theorem isarchrigtorng :
-  ∀ (X : rig) (R : hrel X) (Hr : R 1%rig 0%rig)
+  Π (X : rig) (R : hrel X) (Hr : R 1%rig 0%rig)
     (Hadd : isbinophrel (X := rigaddabmonoid X) R)
     (Htra : istrans R)
     (Harch : isarchrig (setquot_aux (X := rigaddabmonoid X) R)), isarchrng (X := rigtorng X) (rigtorngrel X Hadd).
@@ -702,7 +702,7 @@ Proof.
 Defined.
 
 Lemma natmult_commrngfrac {X : commrng} {S : subabmonoids} :
-  ∀ n (x : X × S), natmult (X := rngaddabgr (commrngfrac X S)) n (setquotpr (eqrelcommrngfrac X S) x) = setquotpr (eqrelcommrngfrac X S) (natmult (X := rngaddabgr X) n (pr1 x) ,, (pr2 x)).
+  Π n (x : X × S), natmult (X := rngaddabgr (commrngfrac X S)) n (setquotpr (eqrelcommrngfrac X S) x) = setquotpr (eqrelcommrngfrac X S) (natmult (X := rngaddabgr X) n (pr1 x) ,, (pr2 x)).
 Proof.
   simpl ; intros X S n x.
   induction n.
@@ -821,10 +821,10 @@ Qed.
 (** ** Archimedean property in a field *)
 
 Definition isarchfld {X : fld} (R : hrel X) :=
-  ∀ x : X, ∃ n : nat, R (nattorng n) x.
+  Π x : X, ∃ n : nat, R (nattorng n) x.
 
 Lemma isarchfld_isarchrng {X : fld} (R : hrel X) :
-  ∀ (Hadd : isbinophrel (X := rigaddabmonoid X) R) ( Hmult : isrngmultgt X R)
+  Π (Hadd : isbinophrel (X := rigaddabmonoid X) R) ( Hmult : isrngmultgt X R)
     (Hirr : isirrefl R),
     isarchfld R -> isarchrng R.
 Proof.
@@ -863,7 +863,7 @@ Proof.
   unfold fldfracgt.
   generalize (isarchcommrngfrac (X := X) (S := rngpossubmonoid X is1 is2) R is0 is1 (λ (c : X) (r : (rngpossubmonoid X is1 is2) c), r) is2 tra X0).
   intros.
-  assert (H_f : ∀ n x, (weqfldfracgt_f X is is0 is1 is2 nc (nattorng n * x)%rng) = (nattorng n * weqfldfracgt_f X is is0 is1 is2 nc x)%rng).
+  assert (H_f : Π n x, (weqfldfracgt_f X is is0 is1 is2 nc (nattorng n * x)%rng) = (nattorng n * weqfldfracgt_f X is is0 is1 is2 nc x)%rng).
   { clear -irr.
     intros n x.
     unfold nattorng.
@@ -902,12 +902,12 @@ Defined.
 (** ** Archimedean property in a constructive field *)
 
 Definition isarchCF {X : ConstructiveField} (R : hrel X) :=
-  ∀ x : X, ∃ n : nat, R (nattorng n) x.
+  Π x : X, ∃ n : nat, R (nattorng n) x.
 
 Lemma isarchCF_isarchrng {X : ConstructiveField} (R : hrel X) :
-  ∀ (Hadd : isbinophrel (X := rigaddabmonoid X) R) ( Hmult : isrngmultgt X R)
+  Π (Hadd : isbinophrel (X := rigaddabmonoid X) R) ( Hmult : isrngmultgt X R)
     (Hirr : isirrefl R),
-    (∀ x : X, R x 0%CF -> (x ≠ 0)%CF) ->
+    (Π x : X, R x 0%CF -> (x ≠ 0)%CF) ->
     isarchCF R -> isarchrng R.
 Proof.
   intros X R Hadd Hmult Hirr H0 H.

--- a/UniMath/Foundations/Algebra/BinaryOperations.v
+++ b/UniMath/Foundations/Algebra/BinaryOperations.v
@@ -50,19 +50,19 @@ Definition isinvertible { X : UU } ( opp : binop X ) ( x : X ) := dirprod ( isli
 
 (** *)
 
-Definition isassoc { X : hSet} ( opp : binop X ) := forall x x' x'' , paths ( opp ( opp x x' ) x'' ) ( opp x ( opp x' x'' ) ) .
+Definition isassoc { X : hSet} ( opp : binop X ) := Π x x' x'' , paths ( opp ( opp x x' ) x'' ) ( opp x ( opp x' x'' ) ) .
 
 Lemma isapropisassoc { X : hSet } ( opp : binop X ) : isaprop ( isassoc opp ) .
 Proof . intros . apply impred . intro x . apply impred . intro x' . apply impred . intro x'' . simpl . apply ( setproperty X ) . Defined .
 
 (** *)
 
-Definition islunit { X : hSet} ( opp : binop X ) ( un0 : X ) := forall x : X , paths ( opp un0 x ) x .
+Definition islunit { X : hSet} ( opp : binop X ) ( un0 : X ) := Π x : X , paths ( opp un0 x ) x .
 
 Lemma isapropislunit { X : hSet} ( opp : binop X ) ( un0 : X ) : isaprop ( islunit opp un0 ) .
 Proof . intros . apply impred . intro x . simpl . apply ( setproperty X ) .  Defined .
 
-Definition isrunit { X : hSet} ( opp : binop X ) ( un0 : X ) := forall x : X , paths ( opp x un0 ) x  .
+Definition isrunit { X : hSet} ( opp : binop X ) ( un0 : X ) := Π x : X , paths ( opp x un0 ) x  .
 
 Lemma isapropisrunit { X : hSet} ( opp : binop X ) ( un0 : X ) : isaprop ( isrunit opp un0 ) .
 Proof . intros . apply impred . intro x . simpl . apply ( setproperty X ) .  Defined .
@@ -92,12 +92,12 @@ Proof . intros . apply ( isofhleveldirprod 1 ) . apply ( isapropisassoc ) .  app
 
 (** *)
 
-Definition islinv { X : hSet } ( opp : binop X ) ( un0 : X ) ( inv0 : X -> X ) := forall x : X , paths ( opp ( inv0 x ) x ) un0 .
+Definition islinv { X : hSet } ( opp : binop X ) ( un0 : X ) ( inv0 : X -> X ) := Π x : X , paths ( opp ( inv0 x ) x ) un0 .
 
 Lemma isapropislinv { X : hSet } ( opp : binop X ) ( un0 : X ) ( inv0 : X -> X ) : isaprop ( islinv opp un0 inv0 ) .
 Proof . intros . apply impred . intro x .  apply ( setproperty X (opp (inv0 x) x) un0 ) . Defined .
 
-Definition isrinv { X : hSet } ( opp : binop X ) ( un0 : X ) ( inv0 : X -> X ) := forall x : X , paths ( opp x ( inv0 x ) ) un0 .
+Definition isrinv { X : hSet } ( opp : binop X ) ( un0 : X ) ( inv0 : X -> X ) := Π x : X , paths ( opp x ( inv0 x ) ) un0 .
 
 Lemma isapropisrinv { X : hSet } ( opp : binop X ) ( un0 : X ) ( inv0 : X -> X ) : isaprop ( isrinv opp un0 inv0 ) .
 Proof . intros . apply impred . intro x .  apply ( setproperty X ) . Defined .
@@ -123,42 +123,42 @@ Definition grrinvax_is { X : hSet } { opp : binop X } ( is : isgrop opp ) := pr2
 
 Lemma isweqrmultingr_is { X : hSet } { opp : binop X } ( is : isgrop opp ) ( x0 : X ) : isrinvertible opp x0 .
 Proof . intros .  destruct is as [ is istr ] . set ( f := fun x : X => opp x x0 ) . set ( g := fun x : X => opp x ( ( pr1 istr ) x0 ) ) .  destruct is as [ assoc isun0 ] . destruct istr as [ inv0 axs ] .   destruct isun0 as [ un0 unaxs ] .  simpl in * |-  .
-assert ( egf : forall x : _ , paths ( g ( f x ) ) x ) . intro x . unfold f . unfold g . destruct ( pathsinv0 ( assoc x x0 ( inv0 x0 ) ) ) .  assert ( e := pr2 axs x0 ) .   simpl in e . rewrite e . apply ( pr2 unaxs x ) .
-assert ( efg : forall x : _ , paths ( f ( g x ) ) x ) . intro x .  unfold f . unfold g . destruct ( pathsinv0 ( assoc x ( inv0 x0 ) x0 ) ) . assert ( e := pr1 axs x0 ) . simpl in e . rewrite e . apply ( pr2 unaxs x ) .
+assert ( egf : Π x : _ , paths ( g ( f x ) ) x ) . intro x . unfold f . unfold g . destruct ( pathsinv0 ( assoc x x0 ( inv0 x0 ) ) ) .  assert ( e := pr2 axs x0 ) .   simpl in e . rewrite e . apply ( pr2 unaxs x ) .
+assert ( efg : Π x : _ , paths ( f ( g x ) ) x ) . intro x .  unfold f . unfold g . destruct ( pathsinv0 ( assoc x ( inv0 x0 ) x0 ) ) . assert ( e := pr1 axs x0 ) . simpl in e . rewrite e . apply ( pr2 unaxs x ) .
 apply ( gradth _ _ egf efg ) . Defined .
 
 Lemma isweqlmultingr_is { X : hSet } { opp : binop X } ( is : isgrop opp )  ( x0 : X ) : islinvertible opp x0 .
 Proof . intros .   destruct is as [ is istr ] .  set ( f := fun x : X => opp x0 x ) . set ( g := fun x : X => opp ( ( pr1 istr ) x0 ) x ) .  destruct is as [ assoc isun0 ] . destruct istr as [ inv0 axs ] .  destruct isun0 as [ un0 unaxs ] .  simpl in * |-  .
-assert ( egf : forall x : _ , paths ( g ( f x ) ) x ) . intro x . unfold f . unfold g . destruct ( assoc ( inv0 x0 ) x0 x  ) . assert ( e := pr1 axs x0 ) . simpl in e . rewrite e . apply ( pr1 unaxs x ) .
-assert ( efg : forall x : _ , paths ( f ( g x ) ) x ) . intro x . unfold f . unfold g . destruct ( assoc x0 ( inv0 x0 ) x  ) . assert ( e := pr2 axs x0 ) . simpl in e . rewrite e . apply ( pr1 unaxs x ) .
+assert ( egf : Π x : _ , paths ( g ( f x ) ) x ) . intro x . unfold f . unfold g . destruct ( assoc ( inv0 x0 ) x0 x  ) . assert ( e := pr1 axs x0 ) . simpl in e . rewrite e . apply ( pr1 unaxs x ) .
+assert ( efg : Π x : _ , paths ( f ( g x ) ) x ) . intro x . unfold f . unfold g . destruct ( assoc x0 ( inv0 x0 ) x  ) . assert ( e := pr2 axs x0 ) . simpl in e . rewrite e . apply ( pr1 unaxs x ) .
 apply ( gradth _ _ egf efg ) . Defined .
 
 
 Lemma isapropinvstruct { X : hSet } { opp : binop X } ( is : ismonoidop opp ) : isaprop ( invstruct opp is ) .
-Proof . intros . apply isofhlevelsn . intro is0 . set ( un0 := pr1 ( pr2 is ) ) . assert ( int : forall i : X -> X , isaprop ( dirprod ( forall x : X , paths ( opp ( i x ) x ) un0 ) ( forall x : X , paths ( opp x ( i x ) ) un0 ) ) ) . intro i . apply ( isofhleveldirprod 1 ) .  apply impred . intro x .  simpl . apply ( setproperty X  ) . apply impred . intro x .   simpl .  apply ( setproperty X ) . apply ( isapropsubtype ( fun i : _ => hProppair _ ( int i ) ) ) .  intros inv1 inv2 .  simpl . intro ax1 .  intro ax2 .  apply funextfun . intro x0 . apply ( invmaponpathsweq ( weqpair _ ( isweqrmultingr_is ( tpair _ is is0 ) x0 ) ) ) .    simpl . rewrite ( pr1 ax1 x0 ) .   rewrite ( pr1 ax2 x0 ) .  apply idpath .  Defined .
+Proof . intros . apply isofhlevelsn . intro is0 . set ( un0 := pr1 ( pr2 is ) ) . assert ( int : Π i : X -> X , isaprop ( dirprod ( Π x : X , paths ( opp ( i x ) x ) un0 ) ( Π x : X , paths ( opp x ( i x ) ) un0 ) ) ) . intro i . apply ( isofhleveldirprod 1 ) .  apply impred . intro x .  simpl . apply ( setproperty X  ) . apply impred . intro x .   simpl .  apply ( setproperty X ) . apply ( isapropsubtype ( fun i : _ => hProppair _ ( int i ) ) ) .  intros inv1 inv2 .  simpl . intro ax1 .  intro ax2 .  apply funextfun . intro x0 . apply ( invmaponpathsweq ( weqpair _ ( isweqrmultingr_is ( tpair _ is is0 ) x0 ) ) ) .    simpl . rewrite ( pr1 ax1 x0 ) .   rewrite ( pr1 ax2 x0 ) .  apply idpath .  Defined .
 
 Lemma isapropisgrop { X : hSet } ( opp : binop X ) : isaprop ( isgrop opp ) .
 Proof . intros . apply ( isofhleveltotal2 1 ) . apply isapropismonoidop . apply isapropinvstruct . Defined .
 
 (* (** Unitary monoid where all elements are invertible is a group *)
 
-Definition allinvvertibleinv { X : hSet } { opp : binop X } ( is : ismonoidop opp ) ( allinv : forall x : X , islinvertible opp x ) : X -> X := fun x : X => invmap ( weqpair _ ( allinv x ) ) ( unel_is is ) .
+Definition allinvvertibleinv { X : hSet } { opp : binop X } ( is : ismonoidop opp ) ( allinv : Π x : X , islinvertible opp x ) : X -> X := fun x : X => invmap ( weqpair _ ( allinv x ) ) ( unel_is is ) .
 
 *)
 
 
 (** The following lemma is an analog of [ Bourbaki , Alg. 1 , ex. 2 , p. 132 ] *)
 
-Lemma isgropif { X : hSet } { opp : binop X } ( is0 : ismonoidop opp ) ( is : forall x : X, hexists ( fun x0 : X => eqset ( opp x x0 ) ( unel_is is0 ) ) ) : isgrop opp .
+Lemma isgropif { X : hSet } { opp : binop X } ( is0 : ismonoidop opp ) ( is : Π x : X, hexists ( fun x0 : X => eqset ( opp x x0 ) ( unel_is is0 ) ) ) : isgrop opp .
 Proof . intros . split with is0 .  destruct is0 as [ assoc isun0 ] . destruct isun0 as [ un0 unaxs0 ] . simpl in is .  simpl in unaxs0 . simpl in un0 . simpl in assoc . simpl in unaxs0 .
 
-assert ( l1 : forall x' : X , isincl ( fun x0 : X => opp x0 x' ) ) . intro x' . apply ( @hinhuniv ( total2 ( fun x0 : X => paths ( opp x' x0 ) un0 ) ) ( hProppair _ ( isapropisincl ( fun x0 : X => opp x0 x' ) ) ) ) .  intro int1 . simpl . apply isinclbetweensets .  apply ( pr2 X ) .  apply ( pr2 X ) .   intros a b .  intro e .  rewrite ( pathsinv0 ( pr2 unaxs0 a ) ) . rewrite ( pathsinv0 ( pr2 unaxs0 b ) ) .  destruct int1 as [ invx' eq ] .  rewrite ( pathsinv0 eq ) . destruct ( assoc a x' invx' ) .  destruct ( assoc b x' invx' ) .  rewrite e . apply idpath .  apply ( is x' ) .
+assert ( l1 : Π x' : X , isincl ( fun x0 : X => opp x0 x' ) ) . intro x' . apply ( @hinhuniv ( total2 ( fun x0 : X => paths ( opp x' x0 ) un0 ) ) ( hProppair _ ( isapropisincl ( fun x0 : X => opp x0 x' ) ) ) ) .  intro int1 . simpl . apply isinclbetweensets .  apply ( pr2 X ) .  apply ( pr2 X ) .   intros a b .  intro e .  rewrite ( pathsinv0 ( pr2 unaxs0 a ) ) . rewrite ( pathsinv0 ( pr2 unaxs0 b ) ) .  destruct int1 as [ invx' eq ] .  rewrite ( pathsinv0 eq ) . destruct ( assoc a x' invx' ) .  destruct ( assoc b x' invx' ) .  rewrite e . apply idpath .  apply ( is x' ) .
 
-assert ( is' :  forall x : X, hexists ( fun x0 : X => eqset ( opp x0 x ) un0 ) ) . intro x . apply ( fun f : _  => hinhuniv f ( is x ) ) .  intro s1 .  destruct s1 as [ x' eq ] .  apply hinhpr . split with x' . simpl . apply ( invmaponpathsincl _ ( l1 x' ) ) .   rewrite ( assoc x' x x' ) . rewrite eq .  rewrite ( pr1 unaxs0 x' ) . unfold unel_is.   simpl . rewrite ( pr2 unaxs0 x' ) .  apply idpath .
+assert ( is' :  Π x : X, hexists ( fun x0 : X => eqset ( opp x0 x ) un0 ) ) . intro x . apply ( fun f : _  => hinhuniv f ( is x ) ) .  intro s1 .  destruct s1 as [ x' eq ] .  apply hinhpr . split with x' . simpl . apply ( invmaponpathsincl _ ( l1 x' ) ) .   rewrite ( assoc x' x x' ) . rewrite eq .  rewrite ( pr1 unaxs0 x' ) . unfold unel_is.   simpl . rewrite ( pr2 unaxs0 x' ) .  apply idpath .
 
-assert ( l1' :  forall x' : X , isincl ( fun x0 : X => opp x' x0 ) ) . intro x' . apply ( @hinhuniv ( total2 ( fun x0 : X => paths ( opp x0 x' ) un0 ) ) ( hProppair _ ( isapropisincl ( fun x0 : X => opp x' x0 ) ) ) ) .  intro int1 . simpl . apply isinclbetweensets .  apply ( pr2 X ) .  apply ( pr2 X ) .   intros a b .  intro e .  rewrite ( pathsinv0 ( pr1 unaxs0 a ) ) . rewrite ( pathsinv0 ( pr1 unaxs0 b ) ) .  destruct int1 as [ invx' eq ] .  rewrite ( pathsinv0 eq ) . destruct ( pathsinv0 ( assoc invx' x' a )  ) .  destruct ( pathsinv0 ( assoc invx' x' b ) ) .  rewrite e . apply idpath .  apply ( is' x' ) .
+assert ( l1' :  Π x' : X , isincl ( fun x0 : X => opp x' x0 ) ) . intro x' . apply ( @hinhuniv ( total2 ( fun x0 : X => paths ( opp x0 x' ) un0 ) ) ( hProppair _ ( isapropisincl ( fun x0 : X => opp x' x0 ) ) ) ) .  intro int1 . simpl . apply isinclbetweensets .  apply ( pr2 X ) .  apply ( pr2 X ) .   intros a b .  intro e .  rewrite ( pathsinv0 ( pr1 unaxs0 a ) ) . rewrite ( pathsinv0 ( pr1 unaxs0 b ) ) .  destruct int1 as [ invx' eq ] .  rewrite ( pathsinv0 eq ) . destruct ( pathsinv0 ( assoc invx' x' a )  ) .  destruct ( pathsinv0 ( assoc invx' x' b ) ) .  rewrite e . apply idpath .  apply ( is' x' ) .
 
-assert ( int : forall x : X , isaprop ( total2 ( fun x0 : X => eqset ( opp x0 x ) un0 ) ) ) . intro x .   apply isapropsubtype .  intros x1 x2 .  intros eq1 eq2 .  apply ( invmaponpathsincl _ ( l1 x ) ) . rewrite eq1 .   rewrite eq2 .  apply idpath .
+assert ( int : Π x : X , isaprop ( total2 ( fun x0 : X => eqset ( opp x0 x ) un0 ) ) ) . intro x .   apply isapropsubtype .  intros x1 x2 .  intros eq1 eq2 .  apply ( invmaponpathsincl _ ( l1 x ) ) . rewrite eq1 .   rewrite eq2 .  apply idpath .
 
 simpl . set ( linv0 := fun x : X => hinhunivcor1 ( hProppair _ ( int x ) ) ( is' x ) ) .  simpl in linv0 .  set ( inv0 := fun x : X => pr1 ( linv0 x ) ) .  split with inv0 . simpl . split with ( fun x : _ => pr2 ( linv0 x ) ) .  intro x .  apply ( invmaponpathsincl _ ( l1 x ) ) . rewrite ( assoc x ( inv0 x ) x ) . change ( inv0 x ) with ( pr1 ( linv0 x ) ) . rewrite ( pr2 ( linv0 x ) ) . unfold unel_is . simpl . rewrite ( pr1 unaxs0 x ) . rewrite ( pr2 unaxs0 x ) . apply idpath .  Defined .
 
@@ -166,7 +166,7 @@ simpl . set ( linv0 := fun x : X => hinhunivcor1 ( hProppair _ ( int x ) ) ( is'
 
 (** *)
 
-Definition iscomm { X : hSet} ( opp : binop X ) := forall x x' : X , paths ( opp x x' ) ( opp x' x ) .
+Definition iscomm { X : hSet} ( opp : binop X ) := Π x x' : X , paths ( opp x x' ) ( opp x' x ) .
 
 Lemma isapropiscomm { X : hSet } ( opp : binop X ) : isaprop ( iscomm opp ) .
 Proof . intros . apply impred . intros x . apply impred . intro x' . simpl . apply ( setproperty X ) . Defined .
@@ -255,12 +255,12 @@ Proof . intros . apply ( isofhleveldirprod 1 ) . apply isapropisgrop . apply isa
 
 (** *)
 
-Definition isldistr { X : hSet} ( opp1 opp2 : binop X ) := forall x x' x'' : X , paths ( opp2 x'' ( opp1 x x' ) ) ( opp1 ( opp2 x'' x ) ( opp2 x'' x' ) ) .
+Definition isldistr { X : hSet} ( opp1 opp2 : binop X ) := Π x x' x'' : X , paths ( opp2 x'' ( opp1 x x' ) ) ( opp1 ( opp2 x'' x ) ( opp2 x'' x' ) ) .
 
 Lemma isapropisldistr { X : hSet} ( opp1 opp2 : binop X ) : isaprop ( isldistr opp1 opp2 ) .
 Proof . intros . apply impred . intro x . apply impred . intro x' . apply impred . intro x'' . simpl . apply ( setproperty X ) . Defined .
 
-Definition isrdistr { X : hSet} ( opp1 opp2 : binop X ) := forall x x' x'' : X , paths ( opp2 ( opp1 x x' ) x'' ) ( opp1 ( opp2 x x'' ) ( opp2 x' x'' ) ) .
+Definition isrdistr { X : hSet} ( opp1 opp2 : binop X ) := Π x x' x'' : X , paths ( opp2 ( opp1 x x' ) x'' ) ( opp1 ( opp2 x x'' ) ( opp2 x' x'' ) ) .
 
 Lemma isapropisrdistr { X : hSet} ( opp1 opp2 : binop X ) : isaprop ( isrdistr opp1 opp2 ) .
 Proof . intros . apply impred . intro x . apply impred . intro x' . apply impred . intro x'' . simpl . apply ( setproperty X ) . Defined .
@@ -284,7 +284,7 @@ split with f . apply ( isweqimplimpl f g ( isapropisldistr opp1 opp2 )  ( isapro
 (** *)
 
 
-Definition isrigops { X : hSet } ( opp1 opp2 : binop X ) :=  dirprod ( total2 ( fun axs : dirprod ( isabmonoidop opp1 ) ( ismonoidop opp2 ) => ( dirprod ( forall x : X , paths ( opp2 ( unel_is ( pr1 axs ) ) x ) ( unel_is ( pr1 axs ) ) ) ) ( forall x : X , paths ( opp2 x ( unel_is ( pr1 axs ) ) ) ( unel_is ( pr1 axs ) ) ) ) ) ( isdistr opp1 opp2 ) .
+Definition isrigops { X : hSet } ( opp1 opp2 : binop X ) :=  dirprod ( total2 ( fun axs : dirprod ( isabmonoidop opp1 ) ( ismonoidop opp2 ) => ( dirprod ( Π x : X , paths ( opp2 ( unel_is ( pr1 axs ) ) x ) ( unel_is ( pr1 axs ) ) ) ) ( Π x : X , paths ( opp2 x ( unel_is ( pr1 axs ) ) ) ( unel_is ( pr1 axs ) ) ) ) ) ( isdistr opp1 opp2 ) .
 
 Definition rigop1axs_is { X : hSet } { opp1 opp2 : binop X } : isrigops opp1 opp2 -> isabmonoidop opp1 := fun is : _ => pr1 ( pr1 ( pr1 is ) ) .
 Definition rigop2axs_is { X : hSet } { opp1 opp2 : binop X } : isrigops opp1 opp2 -> ismonoidop opp2 := fun is : _ => pr2 ( pr1 ( pr1 is ) ) .
@@ -320,12 +320,12 @@ Definition rngunel2_is { X : hSet } { opp1 opp2 : binop X } ( is : isrngops opp1
 Lemma isapropisrngops { X : hSet } ( opp1 opp2 : binop X ) : isaprop ( isrngops opp1 opp2 ) .
 Proof . intros . apply ( isofhleveldirprod 1 ) . apply ( isofhleveldirprod 1 ) . apply isapropisabgrop . apply isapropismonoidop. apply isapropisdistr . Defined .
 
-Lemma multx0_is_l { X : hSet } { opp1 opp2 : binop X } ( is1 : isgrop opp1 ) ( is2 : ismonoidop opp2 ) ( is12 : isdistr opp1 opp2 ) : forall x : X , paths ( opp2 x ( unel_is ( pr1 is1 ) ) ) ( unel_is ( pr1 is1 ) )  .
+Lemma multx0_is_l { X : hSet } { opp1 opp2 : binop X } ( is1 : isgrop opp1 ) ( is2 : ismonoidop opp2 ) ( is12 : isdistr opp1 opp2 ) : Π x : X , paths ( opp2 x ( unel_is ( pr1 is1 ) ) ) ( unel_is ( pr1 is1 ) )  .
 Proof . intros .  destruct is12 as [ ldistr0 rdistr0 ] . destruct is2 as [ assoc2 [ un2 [ lun2 run2 ] ] ] . simpl in * . apply ( invmaponpathsweq ( weqpair _ ( isweqrmultingr_is is1 ( opp2 x un2 ) ) ) ) .  simpl .  destruct is1 as [ [ assoc1 [ un1 [ lun1 run1 ] ] ] [ inv0 [ linv0 rinv0 ] ] ] .  unfold unel_is .  simpl in * . rewrite ( lun1 ( opp2 x un2 ) ) . destruct ( ldistr0 un1 un2 x ) .    rewrite ( run2 x ) .  rewrite ( lun1 un2 ) .  rewrite ( run2 x ) . apply idpath .  Defined .
 
 Opaque multx0_is_l .
 
-Lemma mult0x_is_l { X : hSet } { opp1 opp2 : binop X } ( is1 : isgrop opp1 ) ( is2 : ismonoidop opp2 ) ( is12 : isdistr opp1 opp2 ) : forall x : X , paths ( opp2 ( unel_is ( pr1 is1 ) ) x ) ( unel_is ( pr1 is1 ) ) .
+Lemma mult0x_is_l { X : hSet } { opp1 opp2 : binop X } ( is1 : isgrop opp1 ) ( is2 : ismonoidop opp2 ) ( is12 : isdistr opp1 opp2 ) : Π x : X , paths ( opp2 ( unel_is ( pr1 is1 ) ) x ) ( unel_is ( pr1 is1 ) ) .
 Proof . intros .  destruct is12 as [ ldistr0 rdistr0 ] . destruct is2 as [ assoc2 [ un2 [ lun2 run2 ] ] ] . simpl in * . apply ( invmaponpathsweq ( weqpair _ ( isweqrmultingr_is is1 ( opp2 un2 x ) ) ) ) .  simpl .  destruct is1 as [ [ assoc1 [ un1 [ lun1 run1 ] ] ] [ inv0 [ linv0 rinv0 ] ] ] .  unfold unel_is .  simpl in * . rewrite ( lun1 ( opp2 un2 x ) ) . destruct ( rdistr0 un1 un2 x ) .  rewrite ( lun2 x ) .  rewrite ( lun1 un2 ) .  rewrite ( lun2 x ) . apply idpath .  Defined .
 
 Opaque mult0x_is_l .
@@ -422,7 +422,7 @@ Notation "x * y" := ( op x y ) : multoperation_scope .
 
 (** **** Functions compatible with a binary operation ( homomorphisms ) and their properties *)
 
-Definition isbinopfun { X Y : setwithbinop } ( f : X -> Y ) := forall x x' : X , paths ( f ( op x x' ) ) ( op ( f x ) ( f x' ) ) .
+Definition isbinopfun { X Y : setwithbinop } ( f : X -> Y ) := Π x x' : X , paths ( f ( op x x' ) ) ( op ( f x ) ( f x' ) ) .
 
 Lemma isapropisbinopfun { X Y : setwithbinop } ( f : X -> Y ) : isaprop ( isbinopfun f ) .
 Proof . intros . apply impred . intro x . apply impred . intro x' . apply ( setproperty Y ) . Defined .
@@ -618,7 +618,7 @@ Definition isabgropisob { X Y : setwithbinop } ( f : binopiso X Y ) ( is : isabg
 
 (** **** Subobjects *)
 
-Definition issubsetwithbinop { X : hSet } ( opp : binop X ) ( A : hsubtypes X ) := forall a a' : A , A ( opp ( pr1 a ) ( pr1 a' ) ) .
+Definition issubsetwithbinop { X : hSet } ( opp : binop X ) ( A : hsubtypes X ) := Π a a' : A , A ( opp ( pr1 a ) ( pr1 a' ) ) .
 
 Lemma isapropissubsetwithbinop { X : hSet } ( opp : binop X ) ( A : hsubtypes X ) : isaprop ( issubsetwithbinop opp A ) .
 Proof .  intros .  apply impred .  intro a . apply impred . intros a' . apply ( pr2 ( A ( opp (pr1 a) (pr1 a')) ) ) . Defined .
@@ -646,7 +646,7 @@ Coercion carrierofasubsetwithbinop : subsetswithbinop >-> setwithbinop .
 
 (** **** Relations compatible with a binary operation and quotient objects *)
 
-Definition isbinophrel { X : setwithbinop } ( R : hrel X ) := dirprod ( forall a b c : X , R a b -> R ( op c a ) ( op c b ) ) ( forall a b c : X , R a b -> R ( op a c ) ( op b c ) ) .
+Definition isbinophrel { X : setwithbinop } ( R : hrel X ) := dirprod ( Π a b c : X , R a b -> R ( op c a ) ( op c b ) ) ( Π a b c : X , R a b -> R ( op a c ) ( op b c ) ) .
 
 Definition isbinophrellogeqf { X : setwithbinop } { L R : hrel X } ( lg : hrellogeq L R ) ( isl : isbinophrel L ) : isbinophrel R .
 Proof . intros . split . intros a b c rab . apply ( ( pr1 ( lg _ _ ) ( ( pr1 isl ) _ _ _ ( pr2 ( lg  _ _ ) rab ) ) ) ) . intros a b c rab .  apply ( ( pr1 ( lg _ _ ) ( ( pr2 isl ) _ _ _ ( pr2 ( lg  _ _ ) rab ) ) ) ) . Defined .
@@ -654,7 +654,7 @@ Proof . intros . split . intros a b c rab . apply ( ( pr1 ( lg _ _ ) ( ( pr1 isl
 Lemma isapropisbinophrel { X : setwithbinop } ( R : hrel X ) : isaprop ( isbinophrel R ) .
 Proof . intros . apply isapropdirprod . apply impred . intro a . apply impred . intro b . apply impred . intro c . apply impred . intro r . apply ( pr2 ( R _ _ ) ) .  apply impred . intro a . apply impred . intro b . apply impred . intro c . apply impred . intro r . apply ( pr2 ( R _ _ ) ) .  Defined .
 
-Lemma isbinophrelif { X : setwithbinop } ( R : hrel X ) ( is : iscomm ( @op X ) ) ( isl : forall a b c : X , R a b -> R ( op c a ) ( op c b ) ) : isbinophrel R .
+Lemma isbinophrelif { X : setwithbinop } ( R : hrel X ) ( is : iscomm ( @op X ) ) ( isl : Π a b c : X , R a b -> R ( op c a ) ( op c b ) ) : isbinophrel R .
 Proof . intros . split with isl .  intros a b c rab .  destruct ( is c a ) . destruct ( is c b ) . apply ( isl _ _ _ rab ) . Defined .
 
 Lemma iscompbinoptransrel { X : setwithbinop } ( R : hrel X ) ( ist : istrans R )  ( isb : isbinophrel R ) : iscomprelrelfun2 R R ( @op X ) .
@@ -685,7 +685,7 @@ assert ( iscomp : iscomprelrelfun2 R R op ) . apply ( iscompbinoptransrel R ( eq
 set ( qtmlt := setquotfun2 R R op iscomp ) .   simpl . unfold binop . apply qtmlt . Defined .
 
 
-Definition ispartbinophrel { X : setwithbinop } ( S : hsubtypes X ) ( R : hrel X ) := dirprod ( forall a b c : X , S c -> R a b -> R ( op c a ) ( op c b ) ) ( forall a b c : X , S c -> R a b -> R ( op a c ) ( op b c ) ) .
+Definition ispartbinophrel { X : setwithbinop } ( S : hsubtypes X ) ( R : hrel X ) := dirprod ( Π a b c : X , S c -> R a b -> R ( op c a ) ( op c b ) ) ( Π a b c : X , S c -> R a b -> R ( op a c ) ( op b c ) ) .
 
 Definition isbinoptoispartbinop { X : setwithbinop } ( S : hsubtypes X ) ( L : hrel X ) ( is : isbinophrel L ) : ispartbinophrel S L .
 Proof . intros X S L .  unfold isbinophrel . unfold ispartbinophrel . intro d2 .  split .  intros a b c is .  apply ( pr1 d2 a b c ) . intros a b c is . apply ( pr2 d2 a b c ) . Defined .
@@ -693,14 +693,14 @@ Proof . intros X S L .  unfold isbinophrel . unfold ispartbinophrel . intro d2 .
 Definition ispartbinophrellogeqf { X : setwithbinop } ( S : hsubtypes X ) { L R : hrel X } ( lg : hrellogeq L R ) ( isl : ispartbinophrel S L ) : ispartbinophrel S R .
 Proof . intros . split . intros a b c is rab .  apply ( ( pr1 ( lg _ _ ) ( ( pr1 isl ) _ _ _ is ( pr2 ( lg _ _ ) rab ) ) ) ) . intros a b c is rab .  apply ( ( pr1 ( lg _ _ ) ( ( pr2 isl ) _ _ _ is ( pr2 ( lg  _ _ ) rab ) ) ) ) . Defined .
 
-Lemma ispartbinophrelif { X : setwithbinop } ( S : hsubtypes X ) ( R : hrel X ) ( is : iscomm ( @op X ) ) ( isl : forall a b c : X , S c -> R a b -> R ( op c a ) ( op c b ) ) : ispartbinophrel S R .
+Lemma ispartbinophrelif { X : setwithbinop } ( S : hsubtypes X ) ( R : hrel X ) ( is : iscomm ( @op X ) ) ( isl : Π a b c : X , S c -> R a b -> R ( op c a ) ( op c b ) ) : ispartbinophrel S R .
 Proof . intros .  split with isl .  intros a b c s rab .  destruct ( is c a ) . destruct ( is c b ) . apply ( isl _ _ _ s rab ) . Defined .
 
 
 
 (** **** Relations inversely compatible with a binary operation *)
 
-Definition isinvbinophrel { X : setwithbinop } ( R : hrel X ) := dirprod ( forall a b c : X , R ( op c a ) ( op c b ) ->  R a b ) ( forall a b c : X , R ( op a c ) ( op b c ) -> R a b ) .
+Definition isinvbinophrel { X : setwithbinop } ( R : hrel X ) := dirprod ( Π a b c : X , R ( op c a ) ( op c b ) ->  R a b ) ( Π a b c : X , R ( op a c ) ( op b c ) -> R a b ) .
 
 Definition isinvbinophrellogeqf { X : setwithbinop } { L R : hrel X } ( lg : hrellogeq L R ) ( isl : isinvbinophrel L ) : isinvbinophrel R .
 Proof . intros . split . intros a b c rab . apply ( ( pr1 ( lg _ _ ) ( ( pr1 isl ) _ _ _ ( pr2 ( lg  _ _ ) rab ) ) ) ) . intros a b c rab .  apply ( ( pr1 ( lg _ _ ) ( ( pr2 isl ) _ _ _ ( pr2 ( lg  _ _ ) rab ) ) ) ) . Defined .
@@ -708,14 +708,14 @@ Proof . intros . split . intros a b c rab . apply ( ( pr1 ( lg _ _ ) ( ( pr1 isl
 Lemma isapropisinvbinophrel { X : setwithbinop } ( R : hrel X ) : isaprop ( isinvbinophrel R ) .
 Proof . intros . apply isapropdirprod . apply impred . intro a . apply impred . intro b . apply impred . intro c . apply impred . intro r . apply ( pr2 ( R _ _ ) ) .  apply impred . intro a . apply impred . intro b . apply impred . intro c . apply impred . intro r . apply ( pr2 ( R _ _ ) ) .  Defined .
 
-Lemma isinvbinophrelif { X : setwithbinop } ( R : hrel X ) ( is : iscomm ( @op X ) ) ( isl : forall a b c : X ,  R ( op c a ) ( op c b ) -> R a b ) : isinvbinophrel R .
+Lemma isinvbinophrelif { X : setwithbinop } ( R : hrel X ) ( is : iscomm ( @op X ) ) ( isl : Π a b c : X ,  R ( op c a ) ( op c b ) -> R a b ) : isinvbinophrel R .
 Proof . intros . split with isl .  intros a b c rab .  destruct ( is c a ) . destruct ( is c b ) . apply ( isl _ _ _ rab ) . Defined .
 
 
 
 
 
-Definition ispartinvbinophrel { X : setwithbinop } ( S : hsubtypes X ) ( R : hrel X ) := dirprod ( forall a b c : X , S c -> R ( op c a ) ( op c b ) -> R a b ) ( forall  a b c : X  , S c -> R ( op a c ) ( op b c ) -> R a b ) .
+Definition ispartinvbinophrel { X : setwithbinop } ( S : hsubtypes X ) ( R : hrel X ) := dirprod ( Π a b c : X , S c -> R ( op c a ) ( op c b ) -> R a b ) ( Π a b c : X  , S c -> R ( op a c ) ( op b c ) -> R a b ) .
 
 Definition isinvbinoptoispartinvbinop { X : setwithbinop } ( S : hsubtypes X ) ( L : hrel X ) ( is : isinvbinophrel L ) : ispartinvbinophrel S L .
 Proof . intros X S L .  unfold isinvbinophrel . unfold ispartinvbinophrel . intro d2 .  split .  intros a b c s .  apply ( pr1 d2 a b c ) . intros a b c s . apply ( pr2 d2 a b c ) . Defined .
@@ -723,37 +723,37 @@ Proof . intros X S L .  unfold isinvbinophrel . unfold ispartinvbinophrel . intr
 Definition ispartinvbinophrellogeqf { X : setwithbinop } ( S : hsubtypes X ) { L R : hrel X } ( lg : hrellogeq L R ) ( isl : ispartinvbinophrel S L ) : ispartinvbinophrel S R .
 Proof . intros . split . intros a b c s rab . apply ( ( pr1 ( lg _ _ ) ( ( pr1 isl ) _ _ _ s ( pr2 ( lg  _ _ ) rab ) ) ) ) . intros a b c s rab .  apply ( ( pr1 ( lg _ _ ) ( ( pr2 isl ) _ _ _ s ( pr2 ( lg  _ _ ) rab ) ) ) ) . Defined .
 
-Lemma ispartinvbinophrelif { X : setwithbinop } ( S : hsubtypes X ) ( R : hrel X ) ( is : iscomm ( @op X ) ) ( isl : forall a b c : X , S c -> R ( op c a ) ( op c b ) -> R a b ) : ispartinvbinophrel S R .
+Lemma ispartinvbinophrelif { X : setwithbinop } ( S : hsubtypes X ) ( R : hrel X ) ( is : iscomm ( @op X ) ) ( isl : Π a b c : X , S c -> R ( op c a ) ( op c b ) -> R a b ) : ispartinvbinophrel S R .
 Proof . intros .  split with isl .  intros a b c s rab .  destruct ( is c a ) . destruct ( is c b ) . apply ( isl _ _ _ s rab ) . Defined .
 
 
 (** **** Homomorphisms and relations *)
 
 Lemma binophrelandfun { X Y : setwithbinop } ( f : binopfun X Y ) ( R : hrel Y ) ( is : @isbinophrel Y R ) : @isbinophrel X ( fun x x' => R ( f x ) ( f x' ) ) .
-Proof . intros . set ( ish := ( pr2 f ) : forall a0 b0 , paths ( f ( op a0 b0 ) ) ( op ( f a0 ) ( f b0 ) ) ) . split .
+Proof . intros . set ( ish := ( pr2 f ) : Π a0 b0 , paths ( f ( op a0 b0 ) ) ( op ( f a0 ) ( f b0 ) ) ) . split .
 
 intros a b c r . rewrite ( ish _ _ ) .   rewrite ( ish _ _ ) .  apply ( pr1 is ) . apply r .
 
 intros a b c r . rewrite ( ish _ _ ) .   rewrite ( ish _ _ ) .  apply ( pr2 is ) . apply r . Defined .
 
 
-Lemma ispartbinophrelandfun { X Y : setwithbinop } ( f : binopfun X Y ) ( SX : hsubtypes X ) ( SY : hsubtypes Y ) ( iss : forall x : X , ( SX x ) -> ( SY ( f x ) ) ) ( R : hrel Y ) ( is : @ispartbinophrel Y SY R ) : @ispartbinophrel X SX ( fun x x' => R ( f x ) ( f x' ) ) .
-Proof . intros . set ( ish := ( pr2 f ) : forall a0 b0 , paths ( f ( op a0 b0 ) ) ( op ( f a0 ) ( f b0 ) ) ) . split .
+Lemma ispartbinophrelandfun { X Y : setwithbinop } ( f : binopfun X Y ) ( SX : hsubtypes X ) ( SY : hsubtypes Y ) ( iss : Π x : X , ( SX x ) -> ( SY ( f x ) ) ) ( R : hrel Y ) ( is : @ispartbinophrel Y SY R ) : @ispartbinophrel X SX ( fun x x' => R ( f x ) ( f x' ) ) .
+Proof . intros . set ( ish := ( pr2 f ) : Π a0 b0 , paths ( f ( op a0 b0 ) ) ( op ( f a0 ) ( f b0 ) ) ) . split .
 
 intros a b c s r . rewrite ( ish _ _ ) .   rewrite ( ish _ _ ) .  apply ( ( pr1 is ) _ _ _ ( iss _ s ) r ) .
 
 intros a b c s r . rewrite ( ish _ _ ) .   rewrite ( ish _ _ ) .  apply ( ( pr2 is ) _ _ _ ( iss _ s ) r ) . Defined .
 
 Lemma invbinophrelandfun { X Y : setwithbinop } ( f : binopfun X Y ) ( R : hrel Y ) ( is : @isinvbinophrel Y R ) : @isinvbinophrel X ( fun x x' => R ( f x ) ( f x' ) ) .
-Proof . intros .  set ( ish := ( pr2 f ) : forall a0 b0 , paths ( f ( op a0 b0 ) ) ( op ( f a0 ) ( f b0 ) ) ) . split .
+Proof . intros .  set ( ish := ( pr2 f ) : Π a0 b0 , paths ( f ( op a0 b0 ) ) ( op ( f a0 ) ( f b0 ) ) ) . split .
 
 intros a b c r . rewrite ( ish _ _ ) in r .   rewrite ( ish _ _ ) in r .  apply ( ( pr1 is ) _ _ _ r ) .
 
 intros a b c r . rewrite ( ish _ _ ) in r .   rewrite ( ish _ _ ) in r .  apply ( ( pr2 is ) _ _ _ r ) . Defined .
 
 
-Lemma ispartinvbinophrelandfun { X Y : setwithbinop } ( f : binopfun X Y ) ( SX : hsubtypes X ) ( SY : hsubtypes Y ) ( iss : forall x : X , ( SX x ) -> ( SY ( f x ) ) ) ( R : hrel Y ) ( is : @ispartinvbinophrel Y SY R ) : @ispartinvbinophrel X SX ( fun x x' => R ( f x ) ( f x' ) ) .
-Proof . intros .  set ( ish := ( pr2 f ) : forall a0 b0 , paths ( f ( op a0 b0 ) ) ( op ( f a0 ) ( f b0 ) ) ) . split .
+Lemma ispartinvbinophrelandfun { X Y : setwithbinop } ( f : binopfun X Y ) ( SX : hsubtypes X ) ( SY : hsubtypes Y ) ( iss : Π x : X , ( SX x ) -> ( SY ( f x ) ) ) ( R : hrel Y ) ( is : @ispartinvbinophrel Y SY R ) : @ispartinvbinophrel X SX ( fun x x' => R ( f x ) ( f x' ) ) .
+Proof . intros .  set ( ish := ( pr2 f ) : Π a0 b0 , paths ( f ( op a0 b0 ) ) ( op ( f a0 ) ( f b0 ) ) ) . split .
 
 intros a b c s r . rewrite ( ish _ _ ) in r .   rewrite ( ish _ _ ) in r .  apply ( ( pr1 is ) _ _ _ ( iss _ s ) r ) .
 
@@ -763,8 +763,8 @@ intros a b c s r . rewrite ( ish _ _ ) in r .   rewrite ( ish _ _ ) in r .  appl
 (** **** Quotient relations *)
 
 Lemma isbinopquotrel { X : setwithbinop } ( R : @binopeqrel X ) { L : hrel X } ( is : iscomprelrel R L ) ( isl : isbinophrel L ) : @isbinophrel ( setwithbinopquot R ) ( quotrel is ) .
-Proof .  intros .  unfold isbinophrel .   split . assert ( int : forall a b c :  setwithbinopquot R , isaprop ( quotrel is a b -> quotrel is (op c a ) (op c b ) ) ) . intros a b c .  apply impred . intro .  apply ( pr2 ( quotrel is _ _ ) ) .  apply ( setquotuniv3prop R ( fun a b c => hProppair _ ( int a b c ) ) ) . exact ( pr1 isl )  .
- assert ( int : forall a b c :  setwithbinopquot R , isaprop ( quotrel is a b -> quotrel is (op a c ) (op b c ) ) ) . intros a b c .  apply impred . intro .  apply ( pr2 ( quotrel is _ _ ) ) .  apply ( setquotuniv3prop R ( fun a b c => hProppair _ ( int a b c ) ) ) . exact ( pr2 isl )  . Defined .
+Proof .  intros .  unfold isbinophrel .   split . assert ( int : Π a b c :  setwithbinopquot R , isaprop ( quotrel is a b -> quotrel is (op c a ) (op c b ) ) ) . intros a b c .  apply impred . intro .  apply ( pr2 ( quotrel is _ _ ) ) .  apply ( setquotuniv3prop R ( fun a b c => hProppair _ ( int a b c ) ) ) . exact ( pr1 isl )  .
+ assert ( int : Π a b c :  setwithbinopquot R , isaprop ( quotrel is a b -> quotrel is (op a c ) (op b c ) ) ) . intros a b c .  apply impred . intro .  apply ( pr2 ( quotrel is _ _ ) ) .  apply ( setquotuniv3prop R ( fun a b c => hProppair _ ( int a b c ) ) ) . exact ( pr2 isl )  . Defined .
 
 
 
@@ -804,7 +804,7 @@ Notation "x * y" := ( op2 x y ) : twobinops_scope .
 
 (** **** Functions compatible with a pair of binary operation ( homomorphisms ) and their properties *)
 
-Definition istwobinopfun { X Y : setwith2binop } ( f : X -> Y ) := dirprod ( forall x x' : X , paths ( f ( op1 x x' ) ) ( op1 ( f x ) ( f x' ) ) ) ( forall x x' : X , paths ( f ( op2 x x' ) ) ( op2 ( f x ) ( f x' ) ) )  .
+Definition istwobinopfun { X Y : setwith2binop } ( f : X -> Y ) := dirprod ( Π x x' : X , paths ( f ( op1 x x' ) ) ( op1 ( f x ) ( f x' ) ) ) ( Π x x' : X , paths ( f ( op2 x x' ) ) ( op2 ( f x ) ( f x' ) ) )  .
 
 Lemma isapropistwobinopfun { X Y : setwith2binop } ( f : X -> Y ) : isaprop ( istwobinopfun f ) .
 Proof . intros . apply isofhleveldirprod . apply impred . intro x . apply impred . intro x' . apply ( setproperty Y ) . apply impred . intro x . apply impred . intro x' . apply ( setproperty Y ) . Defined .
@@ -926,7 +926,7 @@ Definition iscommrngopsisob { X Y : setwith2binop } ( f : twobinopiso X Y ) ( is
 
 (** **** Subobjects *)
 
-Definition issubsetwith2binop { X : setwith2binop } ( A : hsubtypes X ) := dirprod ( forall a a' : A , A ( op1 ( pr1 a ) ( pr1 a' ) ) ) ( forall a a' : A , A ( op2 ( pr1 a ) ( pr1 a' ) ) ) .
+Definition issubsetwith2binop { X : setwith2binop } ( A : hsubtypes X ) := dirprod ( Π a a' : A , A ( op1 ( pr1 a ) ( pr1 a' ) ) ) ( Π a a' : A , A ( op2 ( pr1 a ) ( pr1 a' ) ) ) .
 
 Lemma isapropissubsetwith2binop { X : setwith2binop } ( A : hsubtypes X ) : isaprop ( issubsetwith2binop A ) .
 Proof . intros . apply ( isofhleveldirprod 1 ) .

--- a/UniMath/Foundations/Algebra/ConstructiveStructures.v
+++ b/UniMath/Foundations/Algebra/ConstructiveStructures.v
@@ -13,7 +13,7 @@ Require Export UniMath.Foundations.Algebra.Domains_and_Fields.
 
 Definition isnonzeroCR (X : rig) (R : tightap X) := R 1%rig 0%rig.
 Definition isConstrDivRig (X : rig) (R : tightap X) :=
-  isnonzeroCR X R × (∀ x : X, R x 0%rig -> multinvpair X x).
+  isnonzeroCR X R × (Π x : X, R x 0%rig -> multinvpair X x).
 
 (** ** Constructive rig with division *)
 
@@ -61,22 +61,22 @@ Section CDR_pty.
 Context {X : ConstructiveDivisionRig}.
 
 Lemma isirrefl_CDRap :
-  ∀ x : X, ¬ (x ≠ x).
+  Π x : X, ¬ (x ≠ x).
 Proof.
   exact (pr1 (pr1 (pr2 (pr1 (pr2 X))))).
 Qed.
 Lemma issymm_CDRap :
-  ∀ x y : X, x ≠ y -> y ≠ x.
+  Π x y : X, x ≠ y -> y ≠ x.
 Proof.
   exact (pr1 (pr2 (pr1 (pr2 (pr1 (pr2 X)))))).
 Qed.
 Lemma iscotrans_CDRap :
-  ∀ x y z : X, x ≠ z -> x ≠ y ∨ y ≠ z.
+  Π x y z : X, x ≠ z -> x ≠ y ∨ y ≠ z.
 Proof.
   exact (pr2 (pr2 (pr1 (pr2 (pr1 (pr2 X)))))).
 Qed.
 Lemma istight_CDRap :
-  ∀ x y : X, ¬ (x ≠ y) -> x = y.
+  Π x y : X, ¬ (x ≠ y) -> x = y.
 Proof.
   exact (pr2 (pr2 (pr1 (pr2 X)))).
 Qed.
@@ -87,102 +87,102 @@ Proof.
 Qed.
 
 Lemma islunit_CDRzero_CDRplus :
-  forall x : X, 0 + x = x.
+  Π x : X, 0 + x = x.
 Proof.
   now apply riglunax1.
 Qed.
 Lemma isrunit_CDRzero_CDRplus :
-  forall x : X, x + 0 = x.
+  Π x : X, x + 0 = x.
 Proof.
   now apply rigrunax1.
 Qed.
 Lemma isassoc_CDRplus :
-  forall x y z : X, x + y + z = x + (y + z).
+  Π x y z : X, x + y + z = x + (y + z).
 Proof.
   now apply rigassoc1.
 Qed.
 Lemma iscomm_CDRplus :
-  forall x y : X, x + y = y + x.
+  Π x y : X, x + y = y + x.
 Proof.
   now apply rigcomm1.
 Qed.
 Lemma islunit_CDRone_CDRmult :
-  forall x : X, 1 * x = x.
+  Π x : X, 1 * x = x.
 Proof.
   now apply riglunax2.
 Qed.
 Lemma isrunit_CDRone_CDRmult :
-  forall x : X, x * 1 = x.
+  Π x : X, x * 1 = x.
 Proof.
   now apply rigrunax2.
 Qed.
 Lemma isassoc_CDRmult :
-  forall x y z : X, x * y * z = x * (y * z).
+  Π x y z : X, x * y * z = x * (y * z).
 Proof.
   now apply rigassoc2.
 Qed.
 Lemma islinv_CDRinv :
-  ∀ (x : X) (Hx0 : x ≠ (0 : X)),
+  Π (x : X) (Hx0 : x ≠ (0 : X)),
     (CDRinv x Hx0) * x = 1.
 Proof.
   intros x Hx0.
   apply (pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 X)))) x Hx0))).
 Qed.
 Lemma isrinv_CDRinv :
-  ∀ (x : X) (Hx0 : x ≠ (0 : X)),
+  Π (x : X) (Hx0 : x ≠ (0 : X)),
     x * (CDRinv x Hx0) = 1.
 Proof.
   intros x Hx0.
   apply (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 X)))) x Hx0))).
 Qed.
 Lemma islabsorb_CDRzero_CDRmult :
-  ∀ x : X, 0 * x = 0.
+  Π x : X, 0 * x = 0.
 Proof.
   now apply rigmult0x.
 Qed.
 Lemma israbsorb_CDRzero_CDRmult :
-  ∀ x : X, x * 0 = 0.
+  Π x : X, x * 0 = 0.
 Proof.
   now apply rigmultx0.
 Qed.
 Lemma isldistr_CDRplus_CDRmult :
-  ∀ x y z : X, z * (x + y) = z * x + z * y.
+  Π x y z : X, z * (x + y) = z * x + z * y.
 Proof.
   now apply rigdistraxs.
 Qed.
 
 Lemma apCDRplus :
-  ∀ x x' y y' : X,
+  Π x x' y y' : X,
     x + y ≠ x' + y' -> x ≠ x' ∨ y ≠ y'.
 Proof.
   exact (isapbinop_op1 (X := ConstructiveDivisionRig_apsetwith2binop X)).
 Qed.
 Lemma CDRplus_apcompat_l :
-  ∀ x y z : X, y + x ≠ z + x -> y ≠ z.
+  Π x y z : X, y + x ≠ z + x -> y ≠ z.
 Proof.
   intros x y z.
   exact (islapbinop_op1 (X := ConstructiveDivisionRig_apsetwith2binop X) _ _ _).
 Qed.
 Lemma CDRplus_apcompat_r :
-  ∀ x y z : X, x + y ≠ x + z -> y ≠ z.
+  Π x y z : X, x + y ≠ x + z -> y ≠ z.
 Proof.
   exact (israpbinop_op1 (X := ConstructiveDivisionRig_apsetwith2binop X)).
 Qed.
 
 Lemma apCDRmult :
-  forall x x' y y' : X,
+  Π x x' y y' : X,
     x * y ≠ x' * y' -> x ≠ x' ∨ y ≠ y'.
 Proof.
   exact (isapbinop_op2 (X := ConstructiveDivisionRig_apsetwith2binop X)).
 Qed.
 Lemma CDRmult_apcompat_l :
-  ∀ x y z : X, y * x ≠ z * x -> y ≠ z.
+  Π x y z : X, y * x ≠ z * x -> y ≠ z.
 Proof.
   intros x y z.
   exact (islapbinop_op2 (X := ConstructiveDivisionRig_apsetwith2binop X) _ _ _).
 Qed.
 Lemma CDRmult_apcompat_l' :
-  ∀ x y z : X, x ≠ 0 -> y ≠ z -> y * x ≠ z * x.
+  Π x y z : X, x ≠ 0 -> y ≠ z -> y * x ≠ z * x.
 Proof.
   intros x y z Hx Hap.
   refine (CDRmult_apcompat_l (CDRinv x Hx) _ _ _).
@@ -190,12 +190,12 @@ Proof.
   exact Hap.
 Qed.
 Lemma CDRmult_apcompat_r :
-  ∀ x y z : X, x * y ≠ x * z -> y ≠ z.
+  Π x y z : X, x * y ≠ x * z -> y ≠ z.
 Proof.
   exact (israpbinop_op2 (X := ConstructiveDivisionRig_apsetwith2binop X)).
 Qed.
 Lemma CDRmult_apcompat_r' :
-  ∀ x y z : X, x ≠ 0 -> y ≠ z -> x * y ≠ x * z.
+  Π x y z : X, x ≠ 0 -> y ≠ z -> x * y ≠ x * z.
 Proof.
   intros x y z Hx Hap.
   refine (CDRmult_apcompat_r (CDRinv x Hx) _ _ _).
@@ -204,7 +204,7 @@ Proof.
 Qed.
 
 Lemma CDRmultapCDRzero :
-  forall x y : X, x * y ≠ 0 -> x ≠ 0 ∧ y ≠ 0.
+  Π x y : X, x * y ≠ 0 -> x ≠ 0 ∧ y ≠ 0.
 Proof.
   intros x y Hmult.
   split.
@@ -266,22 +266,22 @@ Section CCDR_pty.
 Context {X : ConstructiveCommutativeDivisionRig}.
 
 Lemma isirrefl_CCDRap :
-  ∀ x : X, ¬ (x ≠ x).
+  Π x : X, ¬ (x ≠ x).
 Proof.
   exact (isirrefl_CDRap (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma issymm_CCDRap :
-  ∀ x y : X, x ≠ y -> y ≠ x.
+  Π x y : X, x ≠ y -> y ≠ x.
 Proof.
   exact (issymm_CDRap (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma iscotrans_CCDRap :
-  ∀ x y z : X, x ≠ z -> x ≠ y ∨ y ≠ z.
+  Π x y z : X, x ≠ z -> x ≠ y ∨ y ≠ z.
 Proof.
   exact (iscotrans_CDRap (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma istight_CCDRap :
-  ∀ x y : X, ¬ (x ≠ y) -> x = y.
+  Π x y : X, ¬ (x ≠ y) -> x = y.
 Proof.
   exact (istight_CDRap (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
@@ -292,74 +292,74 @@ Proof.
 Qed.
 
 Lemma islunit_CCDRzero_CCDRplus :
-  forall x : X, 0 + x = x.
+  Π x : X, 0 + x = x.
 Proof.
   now apply riglunax1.
 Qed.
 Lemma isrunit_CCDRzero_CCDRplus :
-  forall x : X, x + 0 = x.
+  Π x : X, x + 0 = x.
 Proof.
   now apply rigrunax1.
 Qed.
 Lemma isassoc_CCDRplus :
-  forall x y z : X, x + y + z = x + (y + z).
+  Π x y z : X, x + y + z = x + (y + z).
 Proof.
   now apply rigassoc1.
 Qed.
 Lemma iscomm_CCDRplus :
-  forall x y : X, x + y = y + x.
+  Π x y : X, x + y = y + x.
 Proof.
   now apply rigcomm1.
 Qed.
 Lemma islunit_CCDRone_CCDRmult :
-  forall x : X, 1 * x = x.
+  Π x : X, 1 * x = x.
 Proof.
   now apply riglunax2.
 Qed.
 Lemma isrunit_CCDRone_CCDRmult :
-  forall x : X, x * 1 = x.
+  Π x : X, x * 1 = x.
 Proof.
   now apply rigrunax2.
 Qed.
 Lemma isassoc_CCDRmult :
-  forall x y z : X, x * y * z = x * (y * z).
+  Π x y z : X, x * y * z = x * (y * z).
 Proof.
   now apply rigassoc2.
 Qed.
 Lemma iscomm_CCDRmult :
-  forall x y : X, x * y = y * x.
+  Π x y : X, x * y = y * x.
 Proof.
   now apply rigcomm2.
 Qed.
 Lemma islinv_CCDRinv :
-  ∀ (x : X) (Hx0 : x ≠ (0 : X)),
+  Π (x : X) (Hx0 : x ≠ (0 : X)),
     (CDRinv (X := X) x Hx0) * x = 1.
 Proof.
   exact (islinv_CDRinv (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma isrinv_CCDRinv :
-  ∀ (x : X) (Hx0 : x ≠ (0 : X)),
+  Π (x : X) (Hx0 : x ≠ (0 : X)),
     x * (CDRinv (X := X) x Hx0) = 1.
 Proof.
   exact (isrinv_CDRinv (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma islabsorb_CCDRzero_CCDRmult :
-  ∀ x : X, 0 * x = 0.
+  Π x : X, 0 * x = 0.
 Proof.
   now apply rigmult0x.
 Qed.
 Lemma israbsorb_CCDRzero_CCDRmult :
-  ∀ x : X, x * 0 = 0.
+  Π x : X, x * 0 = 0.
 Proof.
   now apply rigmultx0.
 Qed.
 Lemma isldistr_CCDRplus_CCDRmult :
-  ∀ x y z : X, z * (x + y) = z * x + z * y.
+  Π x y z : X, z * (x + y) = z * x + z * y.
 Proof.
   now apply rigdistraxs.
 Qed.
 Lemma isrdistr_CCDRplus_CCDRmult :
-  ∀ x y z : X, (x + y) * z = x * z + y * z.
+  Π x y z : X, (x + y) * z = x * z + y * z.
 Proof.
   intros x y z.
   rewrite !(iscomm_CCDRmult _ z).
@@ -367,51 +367,51 @@ Proof.
 Qed.
 
 Lemma apCCDRplus :
-  ∀ x x' y y' : X,
+  Π x x' y y' : X,
     x + y ≠ x' + y' -> x ≠ x' ∨ y ≠ y'.
 Proof.
   exact (apCDRplus (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma CCDRplus_apcompat_l :
-  ∀ x y z : X, y + x ≠ z + x -> y ≠ z.
+  Π x y z : X, y + x ≠ z + x -> y ≠ z.
 Proof.
   exact (CDRplus_apcompat_l (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma CCDRplus_apcompat_r :
-  ∀ x y z : X, x + y ≠ x + z -> y ≠ z.
+  Π x y z : X, x + y ≠ x + z -> y ≠ z.
 Proof.
   exact (CDRplus_apcompat_r (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 
 Lemma apCCDRmult :
-  forall x x' y y' : X,
+  Π x x' y y' : X,
     x * y ≠ x' * y' -> x ≠ x' ∨ y ≠ y'.
 Proof.
   exact (apCDRmult (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma CCDRmult_apcompat_l :
-  ∀ x y z : X, y * x ≠ z * x -> y ≠ z.
+  Π x y z : X, y * x ≠ z * x -> y ≠ z.
 Proof.
   exact (CDRmult_apcompat_l (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma CCDRmult_apcompat_l' :
-  ∀ x y z : X, x ≠ 0 -> y ≠ z -> y * x ≠ z * x.
+  Π x y z : X, x ≠ 0 -> y ≠ z -> y * x ≠ z * x.
 Proof.
   exact (CDRmult_apcompat_l' (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma CCDRmult_apcompat_r :
-  ∀ x y z : X, x * y ≠ x * z -> y ≠ z.
+  Π x y z : X, x * y ≠ x * z -> y ≠ z.
 Proof.
   exact (CDRmult_apcompat_r (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma CCDRmult_apcompat_r' :
-  ∀ x y z : X, x ≠ 0 -> y ≠ z -> x * y ≠ x * z.
+  Π x y z : X, x ≠ 0 -> y ≠ z -> x * y ≠ x * z.
 Proof.
   exact (CDRmult_apcompat_r' (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 
 Lemma CCDRmultapCCDRzero :
-  forall x y : X, x * y ≠ 0 -> x ≠ 0 ∧ y ≠ 0.
+  Π x y : X, x * y ≠ 0 -> x ≠ 0 ∧ y ≠ 0.
 Proof.
   exact (CDRmultapCDRzero (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
@@ -469,22 +469,22 @@ Section CF_pty.
 Context {X : ConstructiveField}.
 
 Lemma isirrefl_CFap :
-  ∀ x : X, ¬ (x ≠ x).
+  Π x : X, ¬ (x ≠ x).
 Proof.
   exact (isirrefl_CCDRap (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma issymm_CFap :
-  ∀ x y : X, x ≠ y -> y ≠ x.
+  Π x y : X, x ≠ y -> y ≠ x.
 Proof.
   exact (issymm_CCDRap (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma iscotrans_CFap :
-  ∀ x y z : X, x ≠ z -> x ≠ y ∨ y ≠ z.
+  Π x y z : X, x ≠ z -> x ≠ y ∨ y ≠ z.
 Proof.
   exact (iscotrans_CCDRap (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma istight_CFap :
-  ∀ x y : X, ¬ (x ≠ y) -> x = y.
+  Π x y : X, ¬ (x ≠ y) -> x = y.
 Proof.
   exact (istight_CCDRap (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
@@ -495,85 +495,85 @@ Proof.
 Qed.
 
 Lemma islunit_CFzero_CFplus :
-  forall x : X, 0 + x = x.
+  Π x : X, 0 + x = x.
 Proof.
   now apply rnglunax1.
 Qed.
 Lemma isrunit_CFzero_CFplus :
-  forall x : X, x + 0 = x.
+  Π x : X, x + 0 = x.
 Proof.
   now apply rngrunax1.
 Qed.
 Lemma isassoc_CFplus :
-  forall x y z : X, x + y + z = x + (y + z).
+  Π x y z : X, x + y + z = x + (y + z).
 Proof.
   now apply rngassoc1.
 Qed.
 Lemma islinv_CFopp :
-  ∀ x : X, - x + x = 0.
+  Π x : X, - x + x = 0.
 Proof.
   now apply rnglinvax1.
 Qed.
 Lemma isrinv_CFopp :
-  ∀ x : X, x + - x = 0.
+  Π x : X, x + - x = 0.
 Proof.
   now apply rngrinvax1.
 Qed.
 
 Lemma iscomm_CFplus :
-  forall x y : X, x + y = y + x.
+  Π x y : X, x + y = y + x.
 Proof.
   now apply rngcomm1.
 Qed.
 Lemma islunit_CFone_CFmult :
-  forall x : X, 1 * x = x.
+  Π x : X, 1 * x = x.
 Proof.
   now apply rnglunax2.
 Qed.
 Lemma isrunit_CFone_CFmult :
-  forall x : X, x * 1 = x.
+  Π x : X, x * 1 = x.
 Proof.
   now apply rngrunax2.
 Qed.
 Lemma isassoc_CFmult :
-  forall x y z : X, x * y * z = x * (y * z).
+  Π x y z : X, x * y * z = x * (y * z).
 Proof.
   now apply rngassoc2.
 Qed.
 Lemma iscomm_CFmult :
-  forall x y : X, x * y = y * x.
+  Π x y : X, x * y = y * x.
 Proof.
   now apply rngcomm2.
 Qed.
 Lemma islinv_CFinv :
-  ∀ (x : X) (Hx0 : x ≠ 0),
+  Π (x : X) (Hx0 : x ≠ 0),
     (CFinv x Hx0) * x = 1.
 Proof.
   exact (islinv_CCDRinv (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma isrinv_CFinv :
-  ∀ (x : X) (Hx0 : x ≠ 0),
+  Π (x : X) (Hx0 : x ≠ 0),
     x * (CFinv x Hx0) = 1.
 Proof.
   exact (isrinv_CCDRinv (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma islabsorb_CFzero_CFmult :
-  ∀ x : X, 0 * x = 0.
+  Π x : X, 0 * x = 0.
 Proof.
   now apply rngmult0x.
 Qed.
 Lemma israbsorb_CFzero_CFmult :
-  ∀ x : X, x * 0 = 0.
+  Π x : X, x * 0 = 0.
 Proof.
   now apply rngmultx0.
 Qed.
 Lemma isldistr_CFplus_CFmult :
-  ∀ x y z : X, z * (x + y) = z * x + z * y.
+  Π x y z : X, z * (x + y) = z * x + z * y.
 Proof.
   now apply rngdistraxs.
 Qed.
 Lemma isrdistr_CFplus_CFmult :
-  ∀ x y z : X, (x + y) * z = x * z + y * z.
+  Π x y z : X, (x + y) * z = x * z + y * z.
 Proof.
   intros.
   rewrite !(iscomm_CFmult _ z).
@@ -581,13 +581,13 @@ Proof.
 Qed.
 
 Lemma apCFplus :
-  ∀ x x' y y' : X,
+  Π x x' y y' : X,
     x + y ≠ x' + y' -> x ≠ x' ∨ y ≠ y'.
 Proof.
   exact (apCCDRplus (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma CFplus_apcompat_l :
-  ∀ x y z : X, y + x ≠ z + x <-> y ≠ z.
+  Π x y z : X, y + x ≠ z + x <-> y ≠ z.
 Proof.
   intros x y z.
   split.
@@ -599,7 +599,7 @@ Proof.
     exact Hap.
 Qed.
 Lemma CFplus_apcompat_r :
-  ∀ x y z : X, x + y ≠ x + z <-> y ≠ z.
+  Π x y z : X, x + y ≠ x + z <-> y ≠ z.
 Proof.
   intros x y z.
   rewrite !(iscomm_CFplus x).
@@ -607,34 +607,34 @@ Proof.
 Qed.
 
 Lemma apCFmult :
-  forall x x' y y' : X,
+  Π x x' y y' : X,
     x * y ≠ x' * y' -> x ≠ x' ∨ y ≠ y'.
 Proof.
   exact (apCCDRmult (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma CFmult_apcompat_l :
-  ∀ x y z : X, y * x ≠ z * x -> y ≠ z.
+  Π x y z : X, y * x ≠ z * x -> y ≠ z.
 Proof.
   exact (CCDRmult_apcompat_l (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma CFmult_apcompat_l' :
-  ∀ x y z : X, x ≠ 0 -> y ≠ z -> y * x ≠ z * x.
+  Π x y z : X, x ≠ 0 -> y ≠ z -> y * x ≠ z * x.
 Proof.
   exact (CCDRmult_apcompat_l' (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma CFmult_apcompat_r :
-  ∀ x y z : X, x * y ≠ x * z -> y ≠ z.
+  Π x y z : X, x * y ≠ x * z -> y ≠ z.
 Proof.
   exact (CCDRmult_apcompat_r (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma CFmult_apcompat_r' :
-  ∀ x y z : X, x ≠ 0 -> y ≠ z -> x * y ≠ x * z.
+  Π x y z : X, x ≠ 0 -> y ≠ z -> x * y ≠ x * z.
 Proof.
   exact (CCDRmult_apcompat_r' (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 
 Lemma CFmultapCFzero :
-  forall x y : X, x * y ≠ 0 -> x ≠ 0 ∧ y ≠ 0.
+  Π x y : X, x * y ≠ 0 -> x ≠ 0 ∧ y ≠ 0.
 Proof.
   exact (CCDRmultapCCDRzero (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.

--- a/UniMath/Foundations/Algebra/DivisionRig.v
+++ b/UniMath/Foundations/Algebra/DivisionRig.v
@@ -20,7 +20,7 @@ Require Export UniMath.Foundations.Algebra.Domains_and_Fields.
 Definition isnonzerorig (X : rig) : UU := (1%rig : X) != 0%rig.
 
 Definition isDivRig (X : rig) : UU :=
-  isnonzerorig X × (∀ x : X, x != 0%rig -> multinvpair X x).
+  isnonzerorig X × (Π x : X, x != 0%rig -> multinvpair X x).
 
 Lemma isaprop_isDivRig (X : rig) : isaprop (isDivRig X).
 Proof.
@@ -56,10 +56,10 @@ Definition isDivRig_isrunit_x1 {X : rig} (is : isDivRig X) : isrunit (isDivRig_m
   := rigrunax2 X.
 
 Definition isDivRig_islinv {X : rig} (is : isDivRig X) :
-  ∀ (x : X) (Hx : x != isDivRig_zero is), isDivRig_mult is (isDivRig_inv is (x,, Hx)) x = isDivRig_one is
+  Π (x : X) (Hx : x != isDivRig_zero is), isDivRig_mult is (isDivRig_inv is (x,, Hx)) x = isDivRig_one is
   := λ (x : X) (Hx : x != isDivRig_zero is), pr1 (pr2 (pr2 is x Hx)).
 Definition isDivRig_isrinv {X : rig} (is : isDivRig X) :
-  ∀ (x : X) (Hx : x != isDivRig_zero is), isDivRig_mult is x (isDivRig_inv is (x,, Hx)) = isDivRig_one is
+  Π (x : X) (Hx : x != isDivRig_zero is), isDivRig_mult is x (isDivRig_inv is (x,, Hx)) = isDivRig_one is
   := λ (x : X) (Hx : x != isDivRig_zero is), pr2 (pr2 (pr2 is x Hx)).
 
 Definition isDivRig_isldistr {X : rig} (is : isDivRig X) : isldistr (isDivRig_plus is) (isDivRig_mult is) := rigldistr X.
@@ -100,40 +100,40 @@ Section DivRig_pty.
 Context {F : DivRig}.
 
 Definition DivRig_isassoc_plus:
-  ∀ x y z : F, x + y + z = x + (y + z) :=
+  Π x y z : F, x + y + z = x + (y + z) :=
   isDivRig_isassoc_plus (DivRig_isDivRig F).
 Definition DivRig_islunit_zero:
-  ∀ x : F, 0 + x = x :=
+  Π x : F, 0 + x = x :=
   isDivRig_islunit_x0 (DivRig_isDivRig F).
 Definition DivRig_isrunit_zero:
-  ∀ x : F, x + 0 = x :=
+  Π x : F, x + 0 = x :=
   isDivRig_isrunit_x0 (DivRig_isDivRig F).
 Definition DivRig_iscomm_plus:
-  ∀ x y : F, x + y = y + x :=
+  Π x y : F, x + y = y + x :=
   isDivRig_iscomm_plus (DivRig_isDivRig F).
 
 Definition DivRig_isassoc_mult:
-  ∀ x y z : F, x * y * z = x * (y * z) :=
+  Π x y z : F, x * y * z = x * (y * z) :=
   isDivRig_isassoc_mult (DivRig_isDivRig F).
 Definition DivRig_islunit_one:
-  ∀ x : F, 1 * x = x :=
+  Π x : F, 1 * x = x :=
   isDivRig_islunit_x1 (DivRig_isDivRig F).
 Definition DivRig_isrunit_one:
-  ∀ x : F, x * 1 = x :=
+  Π x : F, x * 1 = x :=
   isDivRig_isrunit_x1 (DivRig_isDivRig F).
 
 Definition DivRig_islinv:
-  ∀ (x : F) (Hx : x != 0), / (x,, Hx) * x = 1 :=
+  Π (x : F) (Hx : x != 0), / (x,, Hx) * x = 1 :=
   isDivRig_islinv (DivRig_isDivRig F).
 Definition DivRig_isrinv:
-  ∀ (x : F) (Hx : x != 0), x * / (x,, Hx) = 1 :=
+  Π (x : F) (Hx : x != 0), x * / (x,, Hx) = 1 :=
   isDivRig_isrinv (DivRig_isDivRig F).
 
 Definition DivRig_isldistr:
-  ∀ x y z : F, z * (x + y) = z * x + z * y :=
+  Π x y z : F, z * (x + y) = z * x + z * y :=
   isDivRig_isldistr (DivRig_isDivRig F).
 Definition DivRig_isrdistr:
-  ∀ x y z : F, (x + y) * z = x * z + y * z :=
+  Π x y z : F, (x + y) * z = x * z + y * z :=
   isDivRig_isrdistr (DivRig_isDivRig F).
 
 End DivRig_pty.
@@ -152,43 +152,43 @@ Open Scope dr_scope.
 Context {F : CommDivRig}.
 
 Definition CommDivRig_isassoc_plus:
-  ∀ x y z : F, x + y + z = x + (y + z) :=
+  Π x y z : F, x + y + z = x + (y + z) :=
   DivRig_isassoc_plus.
 Definition CommDivRig_islunit_zero:
-  ∀ x : F, 0 + x = x :=
+  Π x : F, 0 + x = x :=
   DivRig_islunit_zero.
 Definition CommDivRig_isrunit_zero:
-  ∀ x : F, x + 0 = x :=
+  Π x : F, x + 0 = x :=
   DivRig_isrunit_zero.
 Definition CommDivRig_iscomm_plus:
-  ∀ x y : F, x + y = y + x :=
+  Π x y : F, x + y = y + x :=
   DivRig_iscomm_plus.
 
 Definition CommDivRig_isassoc_mult:
-  ∀ x y z : F, x * y * z = x * (y * z) :=
+  Π x y z : F, x * y * z = x * (y * z) :=
   DivRig_isassoc_mult.
 Definition CommDivRig_islunit_one:
-  ∀ x : F, 1 * x = x :=
+  Π x : F, 1 * x = x :=
   DivRig_islunit_one.
 Definition CommDivRig_isrunit_one:
-  ∀ x : F, x * 1 = x :=
+  Π x : F, x * 1 = x :=
   DivRig_isrunit_one.
 Definition CommDivRig_iscomm_mult:
-  ∀ x y : F, x * y = y * x :=
+  Π x y : F, x * y = y * x :=
   rigcomm2 (pr1 F).
 
 Definition CommDivRig_islinv:
-  ∀ (x : F) (Hx : x != 0), / (x,, Hx) * x = 1 :=
+  Π (x : F) (Hx : x != 0), / (x,, Hx) * x = 1 :=
   DivRig_islinv.
 Definition CommDivRig_isrinv:
-  ∀ (x : F) (Hx : x != 0), x * / (x,, Hx) = 1 :=
+  Π (x : F) (Hx : x != 0), x * / (x,, Hx) = 1 :=
   DivRig_isrinv.
 
 Definition CommDivRig_isldistr:
-  ∀ x y z : F, z * (x + y) = z * x + z * y :=
+  Π x y z : F, z * (x + y) = z * x + z * y :=
   DivRig_isldistr.
 Definition CommDivRig_isrdistr:
-  ∀ x y z : F, (x + y) * z = x * z + y * z :=
+  Π x y z : F, (x + y) * z = x * z + y * z :=
   DivRig_isrdistr.
 
 Close Scope dr_scope.

--- a/UniMath/Foundations/Algebra/Domains_and_Fields.v
+++ b/UniMath/Foundations/Algebra/Domains_and_Fields.v
@@ -22,13 +22,13 @@ Require Export UniMath.Foundations.Algebra.Rigs_and_Rings .
 
 (** To one binary operation *)
 
-Lemma islcancelableif { X : hSet } ( opp : binop X ) ( x : X ) ( is : forall a b : X , paths ( opp x a ) ( opp x b ) -> paths a b ) : islcancelable opp x .
+Lemma islcancelableif { X : hSet } ( opp : binop X ) ( x : X ) ( is : Π a b : X , paths ( opp x a ) ( opp x b ) -> paths a b ) : islcancelable opp x .
 Proof . intros . apply isinclbetweensets . apply ( setproperty X ) . apply ( setproperty X ) . apply is .  Defined .
 
-Lemma isrcancelableif { X : hSet } ( opp : binop X ) ( x : X ) ( is : forall a b : X , paths ( opp a x ) ( opp b x ) -> paths a b ) : isrcancelable opp x .
+Lemma isrcancelableif { X : hSet } ( opp : binop X ) ( x : X ) ( is : Π a b : X , paths ( opp a x ) ( opp b x ) -> paths a b ) : isrcancelable opp x .
 Proof . intros . apply isinclbetweensets . apply ( setproperty X ) . apply ( setproperty X ) . apply is .  Defined .
 
-Definition iscancelableif { X : hSet } ( opp : binop X ) ( x : X ) ( isl : forall a b : X , paths ( opp x a ) ( opp x b ) -> paths a b ) ( isr : forall a b : X , paths ( opp a x ) ( opp b x ) -> paths a b ) : iscancelable opp x := dirprodpair ( islcancelableif opp x isl ) ( isrcancelableif opp x isr ) .
+Definition iscancelableif { X : hSet } ( opp : binop X ) ( x : X ) ( isl : Π a b : X , paths ( opp x a ) ( opp x b ) -> paths a b ) ( isr : Π a b : X , paths ( opp a x ) ( opp b x ) -> paths a b ) : iscancelable opp x := dirprodpair ( islcancelableif opp x isl ) ( isrcancelableif opp x isr ) .
 
 
 (** To monoids *)
@@ -144,14 +144,14 @@ Proof .  intros .   apply ( negf ( maponpaths ( fun a : X => ( pr1 x' ) * a ) ) 
 Lemma isnonzerofromrinvel ( X : rng ) ( is : isnonzerorng X ) ( x : X ) ( x' : multrinvpair X x ) : neg ( paths x 0 ) .
 Proof .  intros .   apply ( negf ( maponpaths ( fun a : X => a * ( pr1 x' ) ) ) ) .  assert ( e := pr2 x' ) . change ( paths ( x * pr1 x' ) 1 ) in e . change ( neg ( paths ( x * pr1 x' ) ( 0 * ( pr1 x' ) ) ) ) .   rewrite e . rewrite ( rngmult0x X _ ) . apply is . Defined .
 
-Definition isintdom ( X : commrng ) := dirprod ( isnonzerorng X ) ( forall a1 a2 : X , paths ( a1 * a2 ) 0 -> hdisj ( eqset a1 0 ) ( eqset a2 0 ) ) .
+Definition isintdom ( X : commrng ) := dirprod ( isnonzerorng X ) ( Π a1 a2 : X , paths ( a1 * a2 ) 0 -> hdisj ( eqset a1 0 ) ( eqset a2 0 ) ) .
 
 Definition intdom := total2 ( fun X : commrng => isintdom X ) .
 Definition pr1intdom : intdom -> commrng := @pr1 _ _ .
 Coercion pr1intdom : intdom >-> commrng .
 
 Definition nonzeroax ( X : intdom ) : neg ( @paths X 1 0 ) := pr1 ( pr2 X ) .
-Definition intdomax ( X : intdom ) : forall a1 a2 : X , paths ( a1 * a2 ) 0 -> hdisj ( eqset a1 0 ) ( eqset a2 0 )  := pr2 ( pr2 X ) .
+Definition intdomax ( X : intdom ) : Π a1 a2 : X , paths ( a1 * a2 ) 0 -> hdisj ( eqset a1 0 ) ( eqset a2 0 )  := pr2 ( pr2 X ) .
 
 (** **** Computational lemmas for integral domains *)
 
@@ -170,12 +170,12 @@ Proof . intros . intro e . destruct ( ism ( intdomax2l X n m e isn  ) ) .  Defin
 
 
 
-Lemma intdomlcan ( X : intdom ) : forall a b c : X , neg ( paths c 0 ) -> paths ( c * a ) ( c * b ) -> paths a b .
+Lemma intdomlcan ( X : intdom ) : Π a b c : X , neg ( paths c 0 ) -> paths ( c * a ) ( c * b ) -> paths a b .
 Proof . intros X a b c ne e . apply ( @grtopathsxy ( rngaddabgr X ) a b ) . change ( paths ( a - b ) 0 ) . assert ( e' := grfrompathsxy ( rngaddabgr X ) e ) .  change ( paths ( ( c * a ) - ( c * b ) ) 0 ) in e' .  rewrite ( pathsinv0 ( rngrmultminus X _ _ ) ) in e' .  rewrite ( pathsinv0 ( rngldistr X _ _ c ) ) in e' . assert ( int := intdomax X _ _ e' ) .  generalize ne .  assert ( int' : isaprop ( neg (paths c 0) -> paths (a - b) 0 ) ) . apply impred . intro . apply ( setproperty X _ _ ) .  generalize int .  simpl .  apply ( @hinhuniv _ ( hProppair _ int' ) ) .  intro ene . destruct ene as [ e'' | ne' ] .  destruct ( ne e'' ) . intro .  apply ne' .  Defined .
 
 Opaque intdomlcan .
 
-Lemma intdomrcan ( X : intdom ) : forall a b c : X , neg ( paths c 0 ) -> paths ( a * c ) ( b * c ) -> paths a b .
+Lemma intdomrcan ( X : intdom ) : Π a b c : X , neg ( paths c 0 ) -> paths ( a * c ) ( b * c ) -> paths a b .
 Proof . intros X a b c ne e . apply ( @grtopathsxy ( rngaddabgr X ) a b ) . change ( paths ( a - b ) 0 ) . assert ( e' := grfrompathsxy ( rngaddabgr X ) e ) .  change ( paths ( ( a * c ) - ( b * c ) ) 0 ) in e' .  rewrite ( pathsinv0 ( rnglmultminus X _ _ ) ) in e' .  rewrite ( pathsinv0 ( rngrdistr X _ _ c ) ) in e' . assert ( int := intdomax X _ _ e' ) .  generalize ne .  assert ( int' : isaprop ( neg (paths c 0) -> paths (a - b) 0 ) ) . apply impred . intro . apply ( setproperty X _ _ ) .  generalize int .  simpl .  apply ( @hinhuniv _ ( hProppair _ int' ) ) .  intro ene . destruct ene as [ e'' | ne' ] .  intro .  apply e'' .  destruct ( ne ne' ) .  Defined .
 
 Opaque intdomrcan .
@@ -221,7 +221,7 @@ Proof . intros . destruct ( nc ( pr1 x ) 0 ( pr2 x ) ) as [ g | l ] . apply ( tp
 
 (** **** Main definitions *)
 
-Definition isafield ( X : commrng ) := dirprod ( isnonzerorng X ) ( forall x : X , coprod ( multinvpair X x ) ( paths x 0 ) ) .
+Definition isafield ( X : commrng ) := dirprod ( isnonzerorng X ) ( Π x : X , coprod ( multinvpair X x ) ( paths x 0 ) ) .
 
 Definition fld := total2 ( fun X : commrng => isafield X ) .
 Definition fldpair ( X : commrng ) ( is : isafield X ) : fld := tpair _ X is .
@@ -273,7 +273,7 @@ Proof . intros . set ( x := pr1 xa ) . set ( aa := pr2 xa ) .  assert ( e' := ne
 
 Opaque nonzeroincommrngfrac .
 
-Lemma zeroincommrngfrac ( X : intdom ) ( S : @submonoids ( rngmultmonoid X ) ) ( is : forall s : S , neg ( paths ( pr1 s ) 0 ) ) ( x : X ) ( aa : S ) ( e : paths ( setquotpr ( eqrelcommrngfrac X S ) ( dirprodpair x aa ) ) ( setquotpr _ ( dirprodpair 0 ( unel S ) ) ) )  : paths x 0 .
+Lemma zeroincommrngfrac ( X : intdom ) ( S : @submonoids ( rngmultmonoid X ) ) ( is : Π s : S , neg ( paths ( pr1 s ) 0 ) ) ( x : X ) ( aa : S ) ( e : paths ( setquotpr ( eqrelcommrngfrac X S ) ( dirprodpair x aa ) ) ( setquotpr _ ( dirprodpair 0 ( unel S ) ) ) )  : paths x 0 .
 Proof . intros . assert ( e' := invweq ( weqpathsinsetquot _ _ _ ) e ) .  simpl in e' .  generalize e' .  apply ( @hinhuniv _ ( hProppair _ ( setproperty X _ _ ) ) ) . intro t2 . simpl . set ( aa0 := pr1 t2 ) . set ( a0 := pr1 aa0 ) . assert ( e2 := pr2 t2 ) . set ( a := pr1 aa ) .  simpl in e2 . change ( paths ( x * 1 * a0 ) ( 0 * a * a0 ) ) in e2 . rewrite ( rngmult0x X _ ) in e2 .  rewrite ( rngmult0x X _ ) in e2 . rewrite ( rngrunax2 X _ ) in e2 . apply ( intdomax2r X x a0 e2 ( is aa0 ) ) . Defined .
 
 Opaque zeroincommrngfrac .
@@ -283,7 +283,7 @@ Lemma isdeceqfldfrac  ( X : intdom ) ( is : isdeceq X ) : isdeceq ( commrngfrac 
 Proof . intros . apply isdeceqcommrngfrac .  intro a . apply isrcancelableif . intros b0 b1 e . apply ( intdomrcan X _ _ ( pr1 a ) ( pr2 a ) e ) .  apply is . Defined .
 
 Lemma islinvinfldfrac ( X : intdom ) ( is : isdeceq X ) ( x : commrngfrac X ( intdomnonzerosubmonoid X ) ) ( ne : neg ( paths x 0 ) ) : paths ( ( fldfracmultinv0 X is x ) * x ) 1 .
-Proof . intros X is . assert ( int : forall x0 , isaprop ( neg ( paths x0 0 ) ->  paths ( ( fldfracmultinv0 X is x0 ) * x0 ) 1 ) ) . intro x0 . apply impred. intro . apply ( setproperty (commrngfrac X (intdomnonzerosubmonoid X)) (fldfracmultinv0 X is x0 * x0) _ ) . apply ( setquotunivprop _ ( fun x0 => hProppair _ ( int x0 ) ) ) .  simpl . intros xa ne .  change ( paths ( setquotpr (eqrelcommrngfrac X (intdomnonzerosubmonoid X)) ( dirprodpair ( ( pr1 ( fldfracmultinvint X is xa ) ) * ( pr1 xa ) ) ( @op ( intdomnonzerosubmonoid X ) ( pr2 ( fldfracmultinvint X is xa ) ) ( pr2 xa ) ) ) ) ( setquotpr _ ( dirprodpair 1 ( tpair _ 1 ( nonzeroax X ) ) ) ) )  . apply ( weqpathsinsetquot ) .  unfold fldfracmultinvint . simpl . destruct ( is (pr1 xa) 0  ) as [ e0 | ne0' ] .
+Proof . intros X is . assert ( int : Π x0 , isaprop ( neg ( paths x0 0 ) ->  paths ( ( fldfracmultinv0 X is x0 ) * x0 ) 1 ) ) . intro x0 . apply impred. intro . apply ( setproperty (commrngfrac X (intdomnonzerosubmonoid X)) (fldfracmultinv0 X is x0 * x0) _ ) . apply ( setquotunivprop _ ( fun x0 => hProppair _ ( int x0 ) ) ) .  simpl . intros xa ne .  change ( paths ( setquotpr (eqrelcommrngfrac X (intdomnonzerosubmonoid X)) ( dirprodpair ( ( pr1 ( fldfracmultinvint X is xa ) ) * ( pr1 xa ) ) ( @op ( intdomnonzerosubmonoid X ) ( pr2 ( fldfracmultinvint X is xa ) ) ( pr2 xa ) ) ) ) ( setquotpr _ ( dirprodpair 1 ( tpair _ 1 ( nonzeroax X ) ) ) ) )  . apply ( weqpathsinsetquot ) .  unfold fldfracmultinvint . simpl . destruct ( is (pr1 xa) 0  ) as [ e0 | ne0' ] .
 
 destruct ( nonzeroincommrngfrac X ( intdomnonzerosubmonoid X ) xa ne e0 ) .
 
@@ -390,13 +390,13 @@ Definition weqfldfracgt_b ( X : intdom ) ( is : isdeceq X ) { R : hrel X } ( is1
 Definition weqfldfracgt ( X : intdom ) ( is : isdeceq X ) { R : hrel X } ( is0 : @isbinophrel ( rngaddabgr X ) R ) ( is1 : isrngmultgt X R ) ( is2 : R 1 0 ) ( nc : neqchoice R ) ( ir : isirrefl R ) : weq ( fldfrac X is ) ( commrngfrac X ( rngpossubmonoid X is1 is2 ) ) .
 Proof . intros . set ( f := weqfldfracgt_f X is is0 is1 is2 nc ) . set ( g := weqfldfracgt_b X is is1 is2 ir ) .  split with f .
 
-assert ( egf : forall a , paths ( g ( f a ) ) a ) .  unfold fldfrac. simpl . apply ( setquotunivprop _ ( fun a => hProppair _ ( isasetsetquot _ ( g ( f a ) ) a  ) ) ) . intro xa .  simpl . change ( paths ( setquotpr (eqrelcommrngfrac X (intdomnonzerosubmonoid X)) ( weqfldfracgtint_b X is1 is2 ir ( weqfldfracgtint_f X is0 is1 is2 nc xa ) ) ) ( setquotpr (eqrelcommrngfrac X (intdomnonzerosubmonoid X)) xa ) ) . apply ( weqpathsinsetquot ) . simpl . apply hinhpr . split with ( tpair ( fun x => neg ( paths x 0 ) ) 1 ( nonzeroax X ) ) . simpl . unfold weqfldfracgtint_f .  destruct ( nc (pr1 (pr2 xa)) 0 (pr2 (pr2 xa)) ) as [ g' | l' ] .
+assert ( egf : Π a , paths ( g ( f a ) ) a ) .  unfold fldfrac. simpl . apply ( setquotunivprop _ ( fun a => hProppair _ ( isasetsetquot _ ( g ( f a ) ) a  ) ) ) . intro xa .  simpl . change ( paths ( setquotpr (eqrelcommrngfrac X (intdomnonzerosubmonoid X)) ( weqfldfracgtint_b X is1 is2 ir ( weqfldfracgtint_f X is0 is1 is2 nc xa ) ) ) ( setquotpr (eqrelcommrngfrac X (intdomnonzerosubmonoid X)) xa ) ) . apply ( weqpathsinsetquot ) . simpl . apply hinhpr . split with ( tpair ( fun x => neg ( paths x 0 ) ) 1 ( nonzeroax X ) ) . simpl . unfold weqfldfracgtint_f .  destruct ( nc (pr1 (pr2 xa)) 0 (pr2 (pr2 xa)) ) as [ g' | l' ] .
 
 simpl . apply idpath .
 
 simpl .  rewrite (rngrmultminus X _ _ ) . rewrite ( rnglmultminus X _ _ ) . apply idpath .
 
-assert ( efg : forall a , paths ( f ( g a ) ) a ) .  unfold fldfrac. simpl . apply ( setquotunivprop _ ( fun a => hProppair _ ( isasetsetquot _ ( f ( g a ) ) a  ) ) ) . intro xa .  simpl .
+assert ( efg : Π a , paths ( f ( g a ) ) a ) .  unfold fldfrac. simpl . apply ( setquotunivprop _ ( fun a => hProppair _ ( isasetsetquot _ ( f ( g a ) ) a  ) ) ) . intro xa .  simpl .
 change ( paths ( setquotpr _ ( weqfldfracgtint_f X is0 is1 is2 nc ( weqfldfracgtint_b X is1 is2 ir xa ) ) ) ( setquotpr (eqrelcommrngfrac X (rngpossubmonoid X is1 is2)) xa ) ) . apply weqpathsinsetquot . simpl . apply hinhpr .  split with ( tpair ( fun x => R x 0 ) 1 is2 ) .  unfold weqfldfracgtint_f .   unfold weqfldfracgtint_b . simpl . set ( int := nc (pr1 (pr2 xa)) 0 (rtoneq ir (pr2 (pr2 xa)))  ). change ( nc (pr1 (pr2 xa)) 0 (rtoneq ir (pr2 (pr2 xa))) ) with int . destruct int as [ g' | l' ] .
 
 simpl . apply idpath .
@@ -411,7 +411,7 @@ Proof . intros . set ( g :=  weqfldfracgt_b X is is1 is2 ir ) . set ( g0 := weqf
 
 split .
 
-unfold isbinopfun . change ( forall x x' : commrngfrac X ( rngpossubmonoid X is1 is2 )  , paths ( g ( x + x' ) ) ( ( g x ) + ( g x' ) ) ) .  apply ( setquotuniv2prop _ ( fun x x' : commrngfrac X ( rngpossubmonoid X is1 is2 ) => hProppair _ ( setproperty (fldfrac X is) ( g ( x + x' ) ) ( ( g x ) + ( g x' ) ) ) ) ) . intros xa1 xa2 .  change ( paths ( setquotpr (eqrelcommrngfrac X ( intdomnonzerosubmonoid X ) ) ( g0 ( commrngfracop1int X (rngpossubmonoid X is1 is2) xa1 xa2 ) ) ) ( setquotpr (eqrelcommrngfrac X ( intdomnonzerosubmonoid X )) ( commrngfracop1int  X ( intdomnonzerosubmonoid X ) ( g0 xa1 ) ( g0 xa2 ) ) ) )  . apply ( maponpaths ( setquotpr _ ) ) .  unfold g0 .  unfold weqfldfracgtint_b . unfold commrngfracop1int . simpl . apply ( pathsdirprod ) .  apply idpath . destruct xa1 as [ x1 aa1 ] .   destruct xa2 as [ x2 aa2 ] .  simpl . destruct aa1 as [ a1 ia1 ] . destruct aa2 as [ a2 ia2 ] . simpl .  apply ( invmaponpathsincl ( @pr1 _ _ ) ( isinclpr1 _ ( fun a => ( isapropneg ( paths a 0 ) ) ) ) ( tpair _ (a1 * a2) (rtoneq ir (is1 a1 a2 ia1 ia2)) ) (carrierpair
+unfold isbinopfun . change ( Π x x' : commrngfrac X ( rngpossubmonoid X is1 is2 )  , paths ( g ( x + x' ) ) ( ( g x ) + ( g x' ) ) ) .  apply ( setquotuniv2prop _ ( fun x x' : commrngfrac X ( rngpossubmonoid X is1 is2 ) => hProppair _ ( setproperty (fldfrac X is) ( g ( x + x' ) ) ( ( g x ) + ( g x' ) ) ) ) ) . intros xa1 xa2 .  change ( paths ( setquotpr (eqrelcommrngfrac X ( intdomnonzerosubmonoid X ) ) ( g0 ( commrngfracop1int X (rngpossubmonoid X is1 is2) xa1 xa2 ) ) ) ( setquotpr (eqrelcommrngfrac X ( intdomnonzerosubmonoid X )) ( commrngfracop1int  X ( intdomnonzerosubmonoid X ) ( g0 xa1 ) ( g0 xa2 ) ) ) )  . apply ( maponpaths ( setquotpr _ ) ) .  unfold g0 .  unfold weqfldfracgtint_b . unfold commrngfracop1int . simpl . apply ( pathsdirprod ) .  apply idpath . destruct xa1 as [ x1 aa1 ] .   destruct xa2 as [ x2 aa2 ] .  simpl . destruct aa1 as [ a1 ia1 ] . destruct aa2 as [ a2 ia2 ] . simpl .  apply ( invmaponpathsincl ( @pr1 _ _ ) ( isinclpr1 _ ( fun a => ( isapropneg ( paths a 0 ) ) ) ) ( tpair _ (a1 * a2) (rtoneq ir (is1 a1 a2 ia1 ia2)) ) (carrierpair
         (fun x : pr1 X =>
          hProppair (paths x 0 -> empty) (isapropneg (paths x 0)))
         (a1 * a2)
@@ -423,7 +423,7 @@ change ( paths ( setquotpr (eqrelcommrngfrac X ( intdomnonzerosubmonoid X )) ( g
 
 split .
 
-unfold isbinopfun . change ( forall x x' : commrngfrac X ( rngpossubmonoid X is1 is2 )  , paths ( g ( x * x' ) ) ( ( g x ) * ( g x' ) ) ) .  apply ( setquotuniv2prop _ ( fun x x' : commrngfrac X ( rngpossubmonoid X is1 is2 ) => hProppair _ ( setproperty (fldfrac X is) ( g ( x * x' ) ) ( ( g x ) * ( g x' ) ) ) ) ) . intros xa1 xa2 .  change ( paths ( setquotpr (eqrelcommrngfrac X ( intdomnonzerosubmonoid X ) ) ( g0 ( commrngfracop2int X (rngpossubmonoid X is1 is2) xa1 xa2 ) ) ) ( setquotpr (eqrelcommrngfrac X ( intdomnonzerosubmonoid X )) ( commrngfracop2int  X ( intdomnonzerosubmonoid X ) ( g0 xa1 ) ( g0 xa2 ) ) ) )  . apply ( maponpaths ( setquotpr _ ) ) .  unfold g0 .  unfold weqfldfracgtint_b . unfold commrngfracop2int . unfold abmonoidfracopint .  simpl . apply ( pathsdirprod ) .  apply idpath . destruct xa1 as [ x1 aa1 ] .   destruct xa2 as [ x2 aa2 ] .  simpl . destruct aa1 as [ a1 ia1 ] . destruct aa2 as [ a2 ia2 ] . simpl .  apply ( invmaponpathsincl ( @pr1 _ _ ) ( isinclpr1 _ ( fun a => ( isapropneg ( paths a 0 ) ) ) ) ( tpair _ ( a1 * a2 ) ( rtoneq ir (is1 a1 a2 ia1 ia2) ) ) (carrierpair
+unfold isbinopfun . change ( Π x x' : commrngfrac X ( rngpossubmonoid X is1 is2 )  , paths ( g ( x * x' ) ) ( ( g x ) * ( g x' ) ) ) .  apply ( setquotuniv2prop _ ( fun x x' : commrngfrac X ( rngpossubmonoid X is1 is2 ) => hProppair _ ( setproperty (fldfrac X is) ( g ( x * x' ) ) ( ( g x ) * ( g x' ) ) ) ) ) . intros xa1 xa2 .  change ( paths ( setquotpr (eqrelcommrngfrac X ( intdomnonzerosubmonoid X ) ) ( g0 ( commrngfracop2int X (rngpossubmonoid X is1 is2) xa1 xa2 ) ) ) ( setquotpr (eqrelcommrngfrac X ( intdomnonzerosubmonoid X )) ( commrngfracop2int  X ( intdomnonzerosubmonoid X ) ( g0 xa1 ) ( g0 xa2 ) ) ) )  . apply ( maponpaths ( setquotpr _ ) ) .  unfold g0 .  unfold weqfldfracgtint_b . unfold commrngfracop2int . unfold abmonoidfracopint .  simpl . apply ( pathsdirprod ) .  apply idpath . destruct xa1 as [ x1 aa1 ] .   destruct xa2 as [ x2 aa2 ] .  simpl . destruct aa1 as [ a1 ia1 ] . destruct aa2 as [ a2 ia2 ] . simpl .  apply ( invmaponpathsincl ( @pr1 _ _ ) ( isinclpr1 _ ( fun a => ( isapropneg ( paths a 0 ) ) ) ) ( tpair _ ( a1 * a2 ) ( rtoneq ir (is1 a1 a2 ia1 ia2) ) ) (carrierpair
         (fun x : pr1 X =>
          hProppair (paths x 0 -> empty) (isapropneg (paths x 0)))
         (a1 * a2)
@@ -503,7 +503,7 @@ Proof . intros .  unfold fldfracgt . intros a b . apply isdecabmonoidfracrel .  
 
 
 Definition iscomptofldfrac ( X : intdom ) ( is : isdeceq X ) { L : hrel X } ( is0 : @isbinophrel ( rngaddabgr X ) L ) ( is1 : isrngmultgt X L )  ( is2 : L 1 0 ) ( nc : neqchoice L ) ( isa : isasymm L ) : iscomprelrelfun L ( fldfracgt X is is0 is1 is2 nc ) ( tofldfrac X is ) .
-Proof . intros . intros x1 x2 l . assert ( int := iscomptocommrngfrac X ( rngpossubmonoid X is1 is2 ) is0 is1 ( fun c r => r )  ) . simpl in int .  unfold fldfracgt . unfold iscomprelrelfun in int .  assert ( ee : forall x : X , paths (tocommrngfrac X (rngpossubmonoid X is1 is2) x) (weqfldfracgt_f X is is0 is1 is2 nc (tofldfrac X is x)) ) .  intros x .  change (tocommrngfrac X (rngpossubmonoid X is1 is2) x) with (  setquotpr (eqrelcommrngfrac X (rngpossubmonoid X is1 is2)) ( dirprodpair x ( tpair ( fun a => L a 0 ) _ is2 ) ) ) . change (weqfldfracgt_f X is is0 is1 is2 nc (tofldfrac X is x)) with (  setquotpr (eqrelcommrngfrac X (rngpossubmonoid X is1 is2)) ( weqfldfracgtint_f X is0 is1 is2 nc ( dirprodpair x ( tpair ( fun a => neg ( paths a 0 ) ) 1 ( nonzeroax X ) ) ) ) ) . apply ( maponpaths ( setquotpr (eqrelcommrngfrac X (rngpossubmonoid X is1 is2)) ) ) . unfold weqfldfracgtint_f .  simpl . destruct ( nc 1 0 (nonzeroax X)  ) as [ l' | nl ] .
+Proof . intros . intros x1 x2 l . assert ( int := iscomptocommrngfrac X ( rngpossubmonoid X is1 is2 ) is0 is1 ( fun c r => r )  ) . simpl in int .  unfold fldfracgt . unfold iscomprelrelfun in int .  assert ( ee : Π x : X , paths (tocommrngfrac X (rngpossubmonoid X is1 is2) x) (weqfldfracgt_f X is is0 is1 is2 nc (tofldfrac X is x)) ) .  intros x .  change (tocommrngfrac X (rngpossubmonoid X is1 is2) x) with (  setquotpr (eqrelcommrngfrac X (rngpossubmonoid X is1 is2)) ( dirprodpair x ( tpair ( fun a => L a 0 ) _ is2 ) ) ) . change (weqfldfracgt_f X is is0 is1 is2 nc (tofldfrac X is x)) with (  setquotpr (eqrelcommrngfrac X (rngpossubmonoid X is1 is2)) ( weqfldfracgtint_f X is0 is1 is2 nc ( dirprodpair x ( tpair ( fun a => neg ( paths a 0 ) ) 1 ( nonzeroax X ) ) ) ) ) . apply ( maponpaths ( setquotpr (eqrelcommrngfrac X (rngpossubmonoid X is1 is2)) ) ) . unfold weqfldfracgtint_f .  simpl . destruct ( nc 1 0 (nonzeroax X)  ) as [ l' | nl ] .
 
 apply pathsdirprod .  apply idpath .  apply ( invmaponpathsincl _ ( isinclpr1 _ ( fun a => ( pr2 ( L a 0 ) ) ) ) ) . apply idpath .
 

--- a/UniMath/Foundations/Algebra/IteratedBinaryOperations.v
+++ b/UniMath/Foundations/Algebra/IteratedBinaryOperations.v
@@ -88,12 +88,12 @@ Proof.
   intros.
   induction n as [|n IH].
   - reflexivity.
-  - assert (specialcase : ∀ (y:stn _->M) (g : stn _ ≃ stn _), g (lastelement n) = lastelement n ->
+  - assert (specialcase : Π (y:stn _->M) (g : stn _ ≃ stn _), g (lastelement n) = lastelement n ->
         sequenceProduct (S n,, y) = sequenceProduct (S n,, y ∘ g)).
     { intros ? ? a. rewrite 2? sequenceProductStep. change ((_ ∘ _) _) with (y (g (lastelement n))).
       rewrite a. apply (maponpaths (λ m, m * _)). change (_ ∘ _ ∘ _) with (y ∘ (g ∘ dni_lastelement)).
       set (h := eqweqmap (maponpaths stn_compl a)).
-      assert (pr1_h : ∀ i, pr1 (pr1 (h i)) = pr1 (pr1 i)). { intros. induction a. reflexivity. }
+      assert (pr1_h : Π i, pr1 (pr1 (h i)) = pr1 (pr1 i)). { intros. induction a. reflexivity. }
       set (wc := weqdnicompl n (lastelement n)).
       set (g' := (invweq wc ∘ (h ∘ (weqoncompl_ne g (lastelement n) (stnneq _) (stnneq _) ∘ wc))) %weq).
       intermediate_path (sequenceProduct (n,, y ∘ dni_lastelement ∘ g')).

--- a/UniMath/Foundations/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Foundations/Algebra/Monoids_and_Groups.v
@@ -302,12 +302,12 @@ Definition prabmonoidfrac ( X : abmonoid ) ( A : @submonoids X ) : X -> A -> abm
 
 (* ??? could the use of [ issubabmonoid ] in [ binopeqrelabmonoidfrac ] and [ submonoid ] in [ abmonoidfrac ] lead to complications for the unification machinery? See also [ abmonoidfracisbinoprelint ] below . *)
 
-Lemma invertibilityinabmonoidfrac  ( X : abmonoid ) ( A : @submonoids X ) : forall a a' : A , isinvertible ( @op ( abmonoidfrac X A ) ) ( prabmonoidfrac X A ( pr1 a ) a' ) .
+Lemma invertibilityinabmonoidfrac  ( X : abmonoid ) ( A : @submonoids X ) : Π a a' : A , isinvertible ( @op ( abmonoidfrac X A ) ) ( prabmonoidfrac X A ( pr1 a ) a' ) .
 Proof . intros . set ( R := eqrelabmonoidfrac X A ) .   unfold isinvertible .
 
 assert ( isl : islinvertible ( @op ( abmonoidfrac X A ) ) ( prabmonoidfrac X A ( pr1 a ) a' ) ) . unfold islinvertible .  set ( f := fun x0 : abmonoidfrac X A => prabmonoidfrac X A (pr1 a) a' + x0 ) . set ( g := fun x0 : abmonoidfrac X A => prabmonoidfrac X A (pr1 a' ) a + x0 ) .
-assert ( egf : forall x0 : _ , paths ( g ( f x0 ) ) x0 ) . apply ( setquotunivprop R ( fun x0 : abmonoidfrac X A => eqset (g (f x0)) x0 ) ) .  intro xb . simpl . apply ( iscompsetquotpr R ( @dirprodpair X A ( ( pr1 a' ) + ( ( pr1 a ) + ( pr1 xb ) ) ) ( ( @op A ) a ( ( @op A ) a' ( pr2 xb ) ) ) ) ) .   simpl .  apply hinhpr .  split with ( unel A ) .  unfold pr1carrier . simpl . set  ( e := assocax X ( pr1 a ) ( pr1 a' ) ( pr1 ( pr2 xb ) ) ) . simpl in e . destruct e .  set ( e := assocax X ( pr1 xb ) ( pr1 a + pr1 a' ) ( pr1 ( pr2 xb ) ) ) . simpl in e .  destruct e . set ( e := assocax X ( pr1 a' ) ( pr1 a ) ( pr1 xb ) ) . simpl in e .  destruct e . set ( e := commax X ( pr1 a ) ( pr1 a' ) ) . simpl in e . destruct e .  set ( e := commax X ( pr1 a + pr1 a' ) ( pr1 xb ) ) . simpl in e . destruct e . apply idpath .
-assert ( efg : forall x0 : _ , paths ( f ( g x0 ) ) x0 ) .  apply ( setquotunivprop R ( fun x0 : abmonoidfrac X A => eqset (f (g x0)) x0 ) ) .  intro xb . simpl . apply ( iscompsetquotpr R ( @dirprodpair X A ( ( pr1 a ) + ( ( pr1 a' ) + ( pr1 xb ) ) ) ( ( @op A ) a' ( ( @op A ) a ( pr2 xb ) ) ) ) ) .   simpl .  apply hinhpr .  split with ( unel A ) .  unfold pr1carrier . simpl . set  ( e := assocax X ( pr1 a' ) ( pr1 a ) ( pr1 ( pr2 xb ) ) ) . simpl in e . destruct e .  set ( e := assocax X ( pr1 xb ) ( pr1 a' + pr1 a ) ( pr1 ( pr2 xb ) ) ) . simpl in e .  destruct e . set ( e := assocax X ( pr1 a ) ( pr1 a' ) ( pr1 xb ) ) . simpl in e .  destruct e . set ( e := commax X ( pr1 a' ) ( pr1 a ) ) . simpl in e . destruct e .  set ( e := commax X ( pr1 a' + pr1 a ) ( pr1 xb ) ) . simpl in e . destruct e . apply idpath .
+assert ( egf : Π x0 : _ , paths ( g ( f x0 ) ) x0 ) . apply ( setquotunivprop R ( fun x0 : abmonoidfrac X A => eqset (g (f x0)) x0 ) ) .  intro xb . simpl . apply ( iscompsetquotpr R ( @dirprodpair X A ( ( pr1 a' ) + ( ( pr1 a ) + ( pr1 xb ) ) ) ( ( @op A ) a ( ( @op A ) a' ( pr2 xb ) ) ) ) ) .   simpl .  apply hinhpr .  split with ( unel A ) .  unfold pr1carrier . simpl . set  ( e := assocax X ( pr1 a ) ( pr1 a' ) ( pr1 ( pr2 xb ) ) ) . simpl in e . destruct e .  set ( e := assocax X ( pr1 xb ) ( pr1 a + pr1 a' ) ( pr1 ( pr2 xb ) ) ) . simpl in e .  destruct e . set ( e := assocax X ( pr1 a' ) ( pr1 a ) ( pr1 xb ) ) . simpl in e .  destruct e . set ( e := commax X ( pr1 a ) ( pr1 a' ) ) . simpl in e . destruct e .  set ( e := commax X ( pr1 a + pr1 a' ) ( pr1 xb ) ) . simpl in e . destruct e . apply idpath .
+assert ( efg : Π x0 : _ , paths ( f ( g x0 ) ) x0 ) .  apply ( setquotunivprop R ( fun x0 : abmonoidfrac X A => eqset (f (g x0)) x0 ) ) .  intro xb . simpl . apply ( iscompsetquotpr R ( @dirprodpair X A ( ( pr1 a ) + ( ( pr1 a' ) + ( pr1 xb ) ) ) ( ( @op A ) a' ( ( @op A ) a ( pr2 xb ) ) ) ) ) .   simpl .  apply hinhpr .  split with ( unel A ) .  unfold pr1carrier . simpl . set  ( e := assocax X ( pr1 a' ) ( pr1 a ) ( pr1 ( pr2 xb ) ) ) . simpl in e . destruct e .  set ( e := assocax X ( pr1 xb ) ( pr1 a' + pr1 a ) ( pr1 ( pr2 xb ) ) ) . simpl in e .  destruct e . set ( e := assocax X ( pr1 a ) ( pr1 a' ) ( pr1 xb ) ) . simpl in e .  destruct e . set ( e := commax X ( pr1 a' ) ( pr1 a ) ) . simpl in e . destruct e .  set ( e := commax X ( pr1 a' + pr1 a ) ( pr1 xb ) ) . simpl in e . destruct e . apply idpath .
 apply ( gradth _ _ egf efg ) .
 
 apply ( dirprodpair isl ( weqlinvertiblerinvertible ( @op ( abmonoidfrac X A ) ) ( commax ( abmonoidfrac X A ) ) ( prabmonoidfrac X A ( pr1 a ) a' ) isl ) ) .
@@ -331,20 +331,20 @@ Definition ismonoidfuntoabmonoidfrac ( X : abmonoid ) ( A : @submonoids X ) : is
 
 Definition  hrel0abmonoidfrac ( X : abmonoid ) ( A : @submonoids X ) : hrel ( dirprod X A ) :=  fun xa yb : setdirprod X A => eqset ( ( pr1 xa ) + ( pr1 ( pr2 yb ) ) )  ( ( pr1 yb ) + ( pr1 ( pr2 xa ) ) ) .
 
-Lemma weqhrelhrel0abmonoidfrac ( X : abmonoid ) ( A : @submonoids X ) ( iscanc : forall a : A , isrcancelable ( @op X ) ( pr1carrier _ a ) ) ( xa xa' : dirprod X A ) : weq ( eqrelabmonoidfrac X A xa xa' ) ( hrel0abmonoidfrac X A xa xa' ) .
+Lemma weqhrelhrel0abmonoidfrac ( X : abmonoid ) ( A : @submonoids X ) ( iscanc : Π a : A , isrcancelable ( @op X ) ( pr1carrier _ a ) ) ( xa xa' : dirprod X A ) : weq ( eqrelabmonoidfrac X A xa xa' ) ( hrel0abmonoidfrac X A xa xa' ) .
 Proof . intros .  unfold eqrelabmonoidfrac .  unfold hrelabmonoidfrac . simpl .  apply weqimplimpl .
 
 apply ( @hinhuniv _ ( eqset (pr1 xa + pr1 (pr2 xa')) (pr1 xa' + pr1 (pr2 xa)) ) ) .  intro ae .  destruct ae as [ a eq ] .  apply ( invmaponpathsincl _ ( iscanc a ) _ _ eq ) .
 intro eq . apply hinhpr . split with ( unel A ) . rewrite ( runax X )  .  rewrite ( runax X ) .  apply eq . apply ( isapropishinh _ ) .  apply ( setproperty X ) .   Defined .
 
 
-Lemma isinclprabmonoidfrac ( X : abmonoid ) ( A : @submonoids X ) ( iscanc : forall a : A , isrcancelable ( @op X ) ( pr1carrier _ a ) ) : forall a' : A , isincl ( fun x => prabmonoidfrac X A x a' ) .
+Lemma isinclprabmonoidfrac ( X : abmonoid ) ( A : @submonoids X ) ( iscanc : Π a : A , isrcancelable ( @op X ) ( pr1carrier _ a ) ) : Π a' : A , isincl ( fun x => prabmonoidfrac X A x a' ) .
 Proof . intros . apply isinclbetweensets . apply ( setproperty X ) .  apply ( setproperty ( abmonoidfrac X A ) ) .  intros x x' .   intro e .  set ( e' := invweq ( weqpathsinsetquot ( eqrelabmonoidfrac X A ) ( dirprodpair x a' ) ( dirprodpair x' a' ) )  e ) . set ( e'':= weqhrelhrel0abmonoidfrac X A iscanc ( dirprodpair _ _ ) ( dirprodpair _ _ ) e' ) . simpl in e'' . apply ( invmaponpathsincl _ ( iscanc a' ) ) . apply e'' .  Defined .
 
-Definition isincltoabmonoidfrac ( X : abmonoid ) ( A : @submonoids X ) ( iscanc : forall a : A , isrcancelable ( @op X ) ( pr1carrier _ a ) ) : isincl ( toabmonoidfrac X A ) := isinclprabmonoidfrac X A iscanc ( unel A ) .
+Definition isincltoabmonoidfrac ( X : abmonoid ) ( A : @submonoids X ) ( iscanc : Π a : A , isrcancelable ( @op X ) ( pr1carrier _ a ) ) : isincl ( toabmonoidfrac X A ) := isinclprabmonoidfrac X A iscanc ( unel A ) .
 
 
-Lemma isdeceqabmonoidfrac ( X : abmonoid ) ( A : @submonoids X ) ( iscanc : forall a : A , isrcancelable ( @op X ) ( pr1carrier _ a ) ) ( is : isdeceq X ) : isdeceq ( abmonoidfrac X A ) .
+Lemma isdeceqabmonoidfrac ( X : abmonoid ) ( A : @submonoids X ) ( iscanc : Π a : A , isrcancelable ( @op X ) ( pr1carrier _ a ) ) ( is : isdeceq X ) : isdeceq ( abmonoidfrac X A ) .
 Proof . intros . apply ( isdeceqsetquot ( eqrelabmonoidfrac X A ) ) .   intros xa xa' .  apply ( isdecpropweqb ( weqhrelhrel0abmonoidfrac X A iscanc xa xa' ) ) . apply isdecpropif  . unfold isaprop . simpl . set ( int := setproperty X (pr1 xa + pr1 (pr2 xa')) (pr1 xa' + pr1 (pr2 xa))) . simpl in int . apply int . unfold hrel0abmonoidfrac . unfold eqset .   simpl . apply ( is _ _ ) . Defined .
 
 
@@ -462,13 +462,13 @@ Proof . intros .  apply iscotransquotrel . apply iscotransabmonoidfracrelint .  
 
 
 Lemma isantisymmnegabmonoidfracrel ( X : abmonoid ) ( A : @subabmonoids X ) { L : hrel X } ( is : ispartbinophrel A L ) ( isl : isantisymmneg L ) : isantisymmneg ( abmonoidfracrel X A is ) .
-Proof . intros . assert ( int : forall x1 x2  , isaprop ( neg ( abmonoidfracrel X A is x1 x2 )-> neg ( abmonoidfracrel X A is x2 x1 ) -> paths x1 x2 ) ) .  intros x1 x2 . apply impred . intro . apply impred . intro . apply ( isasetsetquot _ x1 x2 ) . unfold isantisymmneg .   apply ( setquotuniv2prop _ ( fun x1 x2 => hProppair _ ( int x1 x2 ) ) ) .  intros xa1 xa2 . intros r r' . apply ( weqpathsinsetquot _  ) . generalize r r' . clear r r' . change ( neg ( abmonoidfracrelint X A L xa1 xa2 ) -> neg ( abmonoidfracrelint X A L xa2 xa1 ) -> ( eqrelabmonoidfrac X A xa1 xa2 ) )  .    intros nr12 nr21 . set ( nr12' := neghexisttoforallneg _ nr12 ( unel A ) ) .  set ( nr21' := neghexisttoforallneg _ nr21 ( unel A ) ) .  set ( int' := isl _ _ nr12' nr21' ) .  simpl .   apply hinhpr . split with ( unel A ) . apply int' . Defined .
+Proof . intros . assert ( int : Π x1 x2  , isaprop ( neg ( abmonoidfracrel X A is x1 x2 )-> neg ( abmonoidfracrel X A is x2 x1 ) -> paths x1 x2 ) ) .  intros x1 x2 . apply impred . intro . apply impred . intro . apply ( isasetsetquot _ x1 x2 ) . unfold isantisymmneg .   apply ( setquotuniv2prop _ ( fun x1 x2 => hProppair _ ( int x1 x2 ) ) ) .  intros xa1 xa2 . intros r r' . apply ( weqpathsinsetquot _  ) . generalize r r' . clear r r' . change ( neg ( abmonoidfracrelint X A L xa1 xa2 ) -> neg ( abmonoidfracrelint X A L xa2 xa1 ) -> ( eqrelabmonoidfrac X A xa1 xa2 ) )  .    intros nr12 nr21 . set ( nr12' := neghexisttoforallneg _ nr12 ( unel A ) ) .  set ( nr21' := neghexisttoforallneg _ nr21 ( unel A ) ) .  set ( int' := isl _ _ nr12' nr21' ) .  simpl .   apply hinhpr . split with ( unel A ) . apply int' . Defined .
 
 Opaque  isantisymmnegabmonoidfracrel .
 
 
 Lemma isantisymmabmonoidfracrel ( X : abmonoid ) ( A : @subabmonoids X ) { L : hrel X } ( is : ispartbinophrel A L ) ( isl : isantisymm L ) : isantisymm ( abmonoidfracrel X A is ) .
-Proof . intros . set ( assoc := ( assocax X ) : isassoc ( @op X ) ) . unfold isassoc in assoc .  set ( comm := commax X ) .  unfold iscomm in comm . unfold isantisymm.  assert ( int : forall x1 x2  , isaprop ( ( abmonoidfracrel X A is x1 x2 )-> ( abmonoidfracrel X A is x2 x1 )-> paths x1 x2 ) ) .  intros x1 x2 . apply impred . intro . apply impred . intro . apply ( isasetsetquot _ x1 x2 ) .  apply ( setquotuniv2prop _ ( fun x1 x2 => hProppair _ ( int x1 x2 ) ) ) .  intros xa1 xa2 . intros r r' . apply ( weqpathsinsetquot _  ) . generalize r r' . clear r r' . change ( ( abmonoidfracrelint X A L xa1 xa2 ) -> ( abmonoidfracrelint X A L xa2 xa1 ) -> ( eqrelabmonoidfrac X A xa1 xa2 ) )  .  unfold abmonoidfracrelint . unfold eqrelabmonoidfrac . simpl .  apply hinhfun2 .  intros t2l1 t2l2 .   set ( c1a := pr1 t2l1 ) . set ( l1 := pr2 t2l1 ) . set ( c2a := pr1 t2l2 ) . set ( l2 := pr2 t2l2 ) .  set ( c1 := pr1 c1a ) . set ( c2 := pr1 c2a ) . split with ( @op A c1a c2a ) .  set ( x1 := pr1 xa1 ) . set ( a1 := pr1 ( pr2 xa1 ) ) .  set ( x2 := pr1 xa2 ) . set ( a2 := pr1 ( pr2 xa2 ) ) . change ( paths ( x1 + a2 + ( @op X c1 c2 ) ) ( x2 + a1 + ( @op X c1 c2 ) ) ) .
+Proof . intros . set ( assoc := ( assocax X ) : isassoc ( @op X ) ) . unfold isassoc in assoc .  set ( comm := commax X ) .  unfold iscomm in comm . unfold isantisymm.  assert ( int : Π x1 x2  , isaprop ( ( abmonoidfracrel X A is x1 x2 )-> ( abmonoidfracrel X A is x2 x1 )-> paths x1 x2 ) ) .  intros x1 x2 . apply impred . intro . apply impred . intro . apply ( isasetsetquot _ x1 x2 ) .  apply ( setquotuniv2prop _ ( fun x1 x2 => hProppair _ ( int x1 x2 ) ) ) .  intros xa1 xa2 . intros r r' . apply ( weqpathsinsetquot _  ) . generalize r r' . clear r r' . change ( ( abmonoidfracrelint X A L xa1 xa2 ) -> ( abmonoidfracrelint X A L xa2 xa1 ) -> ( eqrelabmonoidfrac X A xa1 xa2 ) )  .  unfold abmonoidfracrelint . unfold eqrelabmonoidfrac . simpl .  apply hinhfun2 .  intros t2l1 t2l2 .   set ( c1a := pr1 t2l1 ) . set ( l1 := pr2 t2l1 ) . set ( c2a := pr1 t2l2 ) . set ( l2 := pr2 t2l2 ) .  set ( c1 := pr1 c1a ) . set ( c2 := pr1 c2a ) . split with ( @op A c1a c2a ) .  set ( x1 := pr1 xa1 ) . set ( a1 := pr1 ( pr2 xa1 ) ) .  set ( x2 := pr1 xa2 ) . set ( a2 := pr1 ( pr2 xa2 ) ) . change ( paths ( x1 + a2 + ( @op X c1 c2 ) ) ( x2 + a1 + ( @op X c1 c2 ) ) ) .
 
 assert ( ll1 : L ( ( x1 + a2 ) + ( @op X c1 c2 ) ) ( ( x2 + a1 ) + ( @op X c1 c2 ) ) ) . destruct ( assoc ( x1 + a2 ) c1 c2 ) . destruct ( assoc ( x2 + a1 ) c1 c2 ) . apply ( ( pr2 is ) _ _ _ ( pr2 c2a ) ) . apply l1 .
 
@@ -489,12 +489,12 @@ Opaque ispartbinopabmonoidfracrelint .
 
 (* ??? Coq 8.4-8.5 trunk hangs here on the following line:
 
-Axiom ispartlbinopabmonoidfracrel : forall ( X : abmonoid ) ( A : @subabmonoids X ) { L : hrel X } ( is : ispartbinophrel A L ) ( aa aa' : A ) ( z z' : abmonoidfrac X A ) ( l : abmonoidfracrel X A is z z' ) , abmonoidfracrel X A is ( ( prabmonoidfrac X A ( pr1 aa ) aa' ) + z ) ( ( prabmonoidfrac X A ( pr1 aa ) aa' ) + z' ) .
+Axiom ispartlbinopabmonoidfracrel : Π ( X : abmonoid ) ( A : @subabmonoids X ) { L : hrel X } ( is : ispartbinophrel A L ) ( aa aa' : A ) ( z z' : abmonoidfrac X A ) ( l : abmonoidfracrel X A is z z' ) , abmonoidfracrel X A is ( ( prabmonoidfrac X A ( pr1 aa ) aa' ) + z ) ( ( prabmonoidfrac X A ( pr1 aa ) aa' ) + z' ) .
 
 *)
 
 Lemma ispartlbinopabmonoidfracrel ( X : abmonoid ) ( A : @subabmonoids X ) { L : hrel X } ( is : ispartbinophrel A L ) ( aa aa' : A ) ( z z' : abmonoidfrac X A ) ( l : abmonoidfracrel X A is z z' ) : abmonoidfracrel X A is ( ( prabmonoidfrac X A ( pr1 aa ) aa' ) + z ) ( ( prabmonoidfrac X A ( pr1 aa ) aa' ) + z' ) .
-Proof . intros X A L is aa aa' . set ( assoc := ( assocax X ) : isassoc ( @op X ) ) . unfold isassoc in assoc .  set ( comm := commax X ) .  unfold iscomm in comm . set ( rer := abmonoidrer X ) . assert ( int : forall z z' , isaprop ( abmonoidfracrel X A is z z' -> abmonoidfracrel X A is (prabmonoidfrac X A (pr1 aa) aa' + z) (prabmonoidfrac X A (pr1 aa) aa' + z') ) ) . intros z z' . apply impred . intro . apply ( pr2 ( abmonoidfracrel _ _ _ _ _ ) ) .  apply ( setquotuniv2prop _ ( fun z z' => hProppair _ ( int z z' ) ) ) . intros xa1 xa2 .  change ( abmonoidfracrelint X A L xa1 xa2 -> abmonoidfracrelint X A L ( @op ( abmonoiddirprod X A ) ( dirprodpair ( pr1 aa ) aa' ) xa1 ) (  @op ( abmonoiddirprod X A ) ( dirprodpair ( pr1 aa ) aa' ) xa2 ) ) . unfold abmonoidfracrelint .  simpl . apply hinhfun . intro t2l .  set ( a := pr1 aa ) . set ( a' := pr1 aa' ) . set ( c0a := pr1 t2l ) . set ( l := pr2 t2l ) .  set ( c0 := pr1 c0a ) .  set ( x1 := pr1 xa1 ) . set ( a1 := pr1 ( pr2 xa1 ) ) .  set ( x2 := pr1 xa2 ) . set ( a2 := pr1 ( pr2 xa2 ) ) . split with c0a .
+Proof . intros X A L is aa aa' . set ( assoc := ( assocax X ) : isassoc ( @op X ) ) . unfold isassoc in assoc .  set ( comm := commax X ) .  unfold iscomm in comm . set ( rer := abmonoidrer X ) . assert ( int : Π z z' , isaprop ( abmonoidfracrel X A is z z' -> abmonoidfracrel X A is (prabmonoidfrac X A (pr1 aa) aa' + z) (prabmonoidfrac X A (pr1 aa) aa' + z') ) ) . intros z z' . apply impred . intro . apply ( pr2 ( abmonoidfracrel _ _ _ _ _ ) ) .  apply ( setquotuniv2prop _ ( fun z z' => hProppair _ ( int z z' ) ) ) . intros xa1 xa2 .  change ( abmonoidfracrelint X A L xa1 xa2 -> abmonoidfracrelint X A L ( @op ( abmonoiddirprod X A ) ( dirprodpair ( pr1 aa ) aa' ) xa1 ) (  @op ( abmonoiddirprod X A ) ( dirprodpair ( pr1 aa ) aa' ) xa2 ) ) . unfold abmonoidfracrelint .  simpl . apply hinhfun . intro t2l .  set ( a := pr1 aa ) . set ( a' := pr1 aa' ) . set ( c0a := pr1 t2l ) . set ( l := pr2 t2l ) .  set ( c0 := pr1 c0a ) .  set ( x1 := pr1 xa1 ) . set ( a1 := pr1 ( pr2 xa1 ) ) .  set ( x2 := pr1 xa2 ) . set ( a2 := pr1 ( pr2 xa2 ) ) . split with c0a .
 
 change ( L ( a + x1 + ( a' + a2 ) + c0 ) ( a + x2 + ( a' + a1 ) + c0 ) ) . rewrite ( rer _ x1 a' _ ) . rewrite ( rer _ x2 a' _ ) .  rewrite ( assoc _ ( x1 + a2 ) c0 ) .  rewrite ( assoc _ ( x2 + a1 ) c0 ) . apply ( ( pr1 is ) _ _ _ ( pr2 ( @op A aa aa' ) ) ) . apply l . Defined .
 
@@ -502,21 +502,21 @@ Opaque ispartlbinopabmonoidfracrel .
 
 
 Lemma ispartrbinopabmonoidfracrel ( X : abmonoid ) ( A : @subabmonoids X ) { L : hrel X } ( is : ispartbinophrel A L ) ( aa aa' : A ) ( z z' : abmonoidfrac X A ) ( l : abmonoidfracrel X A is z z' ) : abmonoidfracrel X A is ( z + ( prabmonoidfrac X A ( pr1 aa ) aa' ) ) ( z' + ( prabmonoidfrac X A ( pr1 aa ) aa' ) ) .
-Proof . intros X A L is aa aa' . set ( assoc := ( assocax X ) : isassoc ( @op X ) ) . unfold isassoc in assoc .  set ( comm := commax X ) .  unfold iscomm in comm . set ( rer := abmonoidrer X ) . assert ( int : forall z z' : abmonoidfrac X A , isaprop ( abmonoidfracrel X A is z z' -> abmonoidfracrel X A is ( z + ( prabmonoidfrac X A (pr1 aa) aa') )  ( z' + prabmonoidfrac X A (pr1 aa) aa' ) ) )  . intros z z' . apply impred . intro . apply ( pr2 ( abmonoidfracrel _ _ _ _ _ ) ) .  apply ( setquotuniv2prop _ ( fun z z' => hProppair _ ( int z z' ) ) ) . intros xa1 xa2 .  change ( abmonoidfracrelint X A L xa1 xa2 -> abmonoidfracrelint X A L ( @op ( abmonoiddirprod X A ) xa1 ( dirprodpair ( pr1 aa ) aa' ) ) (  @op ( abmonoiddirprod X A ) xa2 ( dirprodpair ( pr1 aa ) aa' ) ) ) . unfold abmonoidfracrelint .  simpl . apply hinhfun . intro t2l .  set ( a := pr1 aa ) . set ( a' := pr1 aa' ) . set ( c0a := pr1 t2l ) . set ( l := pr2 t2l ) .  set ( c0 := pr1 c0a ) .  set ( x1 := pr1 xa1 ) . set ( a1 := pr1 ( pr2 xa1 ) ) .  set ( x2 := pr1 xa2 ) . set ( a2 := pr1 ( pr2 xa2 ) ) . split with c0a .
+Proof . intros X A L is aa aa' . set ( assoc := ( assocax X ) : isassoc ( @op X ) ) . unfold isassoc in assoc .  set ( comm := commax X ) .  unfold iscomm in comm . set ( rer := abmonoidrer X ) . assert ( int : Π z z' : abmonoidfrac X A , isaprop ( abmonoidfracrel X A is z z' -> abmonoidfracrel X A is ( z + ( prabmonoidfrac X A (pr1 aa) aa') )  ( z' + prabmonoidfrac X A (pr1 aa) aa' ) ) )  . intros z z' . apply impred . intro . apply ( pr2 ( abmonoidfracrel _ _ _ _ _ ) ) .  apply ( setquotuniv2prop _ ( fun z z' => hProppair _ ( int z z' ) ) ) . intros xa1 xa2 .  change ( abmonoidfracrelint X A L xa1 xa2 -> abmonoidfracrelint X A L ( @op ( abmonoiddirprod X A ) xa1 ( dirprodpair ( pr1 aa ) aa' ) ) (  @op ( abmonoiddirprod X A ) xa2 ( dirprodpair ( pr1 aa ) aa' ) ) ) . unfold abmonoidfracrelint .  simpl . apply hinhfun . intro t2l .  set ( a := pr1 aa ) . set ( a' := pr1 aa' ) . set ( c0a := pr1 t2l ) . set ( l := pr2 t2l ) .  set ( c0 := pr1 c0a ) .  set ( x1 := pr1 xa1 ) . set ( a1 := pr1 ( pr2 xa1 ) ) .  set ( x2 := pr1 xa2 ) . set ( a2 := pr1 ( pr2 xa2 ) ) . split with c0a .
 
 change ( L ( x1 + a + ( a2 + a' ) + c0 ) ( x2 + a + ( a1 + a' ) + c0 ) ) . rewrite ( rer _ a a2 _ ) . rewrite ( rer _ a a1 _ ) .  rewrite ( assoc ( x1 + a2 ) _ c0 ) .  rewrite ( assoc ( x2 + a1 ) _ c0 ) .  rewrite ( comm _ c0 ) . destruct ( assoc ( x1 + a2 ) c0 ( a + a' ) ) . destruct ( assoc ( x2 + a1 ) c0 ( a + a' ) ) . apply ( ( pr2 is ) _ _ _ ( pr2 ( @op A aa aa' ) ) ) . apply l . Defined .
 
 Opaque ispartrbinopabmonoidfracrel .
 
 
-Lemma abmonoidfracrelimpl ( X : abmonoid ) ( A : @subabmonoids X ) { L L' : hrel X } ( is : ispartbinophrel A L ) ( is' : ispartbinophrel A L' )  ( impl : forall x x' , L x x' -> L' x x' ) ( x x' : abmonoidfrac X A ) ( ql : abmonoidfracrel X A is x x' ) : abmonoidfracrel X A is' x x'  .
+Lemma abmonoidfracrelimpl ( X : abmonoid ) ( A : @subabmonoids X ) { L L' : hrel X } ( is : ispartbinophrel A L ) ( is' : ispartbinophrel A L' )  ( impl : Π x x' , L x x' -> L' x x' ) ( x x' : abmonoidfrac X A ) ( ql : abmonoidfracrel X A is x x' ) : abmonoidfracrel X A is' x x'  .
 Proof . intros .  generalize ql .  apply quotrelimpl .  intros x0 x0' .  unfold abmonoidfracrelint .  simpl .  apply hinhfun .  intro t2 . split with ( pr1 t2 ) .   apply ( impl _ _ ( pr2 t2 ) ) . Defined .
 
 
 Opaque abmonoidfracrelimpl .
 
 
-Lemma abmonoidfracrellogeq ( X : abmonoid ) ( A : @subabmonoids X ) { L L' : hrel X } ( is : ispartbinophrel A L ) ( is' : ispartbinophrel A L' )  ( lg : forall x x' , L x x' <-> L' x x' ) ( x x' : abmonoidfrac X A ) :  ( abmonoidfracrel X A is x x' ) <-> ( abmonoidfracrel X A is' x x' ) .
+Lemma abmonoidfracrellogeq ( X : abmonoid ) ( A : @subabmonoids X ) { L L' : hrel X } ( is : ispartbinophrel A L ) ( is' : ispartbinophrel A L' )  ( lg : Π x x' , L x x' <-> L' x x' ) ( x x' : abmonoidfrac X A ) :  ( abmonoidfracrel X A is x x' ) <-> ( abmonoidfracrel X A is' x x' ) .
 Proof . intros .   apply quotrellogeq .  intros x0 x0' .  split .
 
 unfold abmonoidfracrelint .  simpl .  apply hinhfun .  intro t2 . split with ( pr1 t2 ) .   apply ( pr1 ( lg _ _ ) ( pr2 t2 ) ) .
@@ -628,7 +628,7 @@ Proof . intros . assert ( r := ( pr1 is ) _ _ x isg ) . rewrite ( grrinvax X x )
 
 (** **** Subobjects *)
 
-Definition issubgr { X : gr } ( A : hsubtypes X ) := dirprod ( issubmonoid A ) ( forall x : X , A x -> A ( grinv X x ) ) .
+Definition issubgr { X : gr } ( A : hsubtypes X ) := dirprod ( issubmonoid A ) ( Π x : X , A x -> A ( grinv X x ) ) .
 
 Lemma isapropissubgr { X : gr } ( A : hsubtypes X ) : isaprop ( issubgr A ) .
 Proof . intros . apply ( isofhleveldirprod 1 ) . apply isapropissubmonoid . apply impred . intro x .   apply impred . intro a . apply ( pr2 (A ( grinv X x)) ) . Defined .
@@ -837,13 +837,13 @@ Definition ismonoidfuntoabgrfrac ( X : abmonoid ) : ismonoidfun ( toabgrfrac X )
 (** **** Abelian group of fractions in the case when all elements are cancelable *)
 
 
-Lemma isinclprabgrfrac ( X : abmonoid ) ( iscanc : forall x : X , isrcancelable ( @op X ) x ) : forall x' : X , isincl ( fun x => prabgrfrac X x x' ) .
+Lemma isinclprabgrfrac ( X : abmonoid ) ( iscanc : Π x : X , isrcancelable ( @op X ) x ) : Π x' : X , isincl ( fun x => prabgrfrac X x x' ) .
 Proof . intros . set ( int := isinclprabmonoidfrac X ( totalsubmonoid X ) ( fun a : totalsubmonoid X => iscanc ( pr1 a ) ) ( carrierpair ( fun x : X => htrue ) x' tt ) ) .
 set ( int1 := isinclcomp ( inclpair _ int ) ( invweq ( weqabgrfrac X ) ) ) . apply int1 .  Defined .
 
-Definition isincltoabgrfrac ( X : abmonoid ) ( iscanc : forall x : X , isrcancelable ( @op X ) x ) : isincl ( toabgrfrac X ) := isinclprabgrfrac X iscanc ( unel X ) .
+Definition isincltoabgrfrac ( X : abmonoid ) ( iscanc : Π x : X , isrcancelable ( @op X ) x ) : isincl ( toabgrfrac X ) := isinclprabgrfrac X iscanc ( unel X ) .
 
-Lemma isdeceqabgrfrac ( X : abmonoid ) ( iscanc : forall x : X , isrcancelable ( @op X ) x ) ( is : isdeceq X ) : isdeceq ( abgrfrac X ) .
+Lemma isdeceqabgrfrac ( X : abmonoid ) ( iscanc : Π x : X , isrcancelable ( @op X ) x ) ( is : isdeceq X ) : isdeceq ( abgrfrac X ) .
 Proof . intros . apply ( isdeceqweqf ( invweq ( weqabgrfrac X ) ) ) .   apply ( isdeceqabmonoidfrac X ( totalsubmonoid X ) ( fun a : totalsubmonoid X => iscanc ( pr1 a ) ) is ) . Defined .
 
 
@@ -873,10 +873,10 @@ Definition abgrfracrel' ( X : abmonoid ) { L : hrel X } ( is : isbinophrel L ) :
 Definition logeqabgrfracrels ( X : abmonoid ) { L : hrel X } ( is : isbinophrel L ) : hrellogeq ( abgrfracrel' X is ) ( abgrfracrel X is ) .
 Proof . intros X L is x1 x2 . split .
 
-assert ( int : forall x x' , isaprop ( abgrfracrel' X is x x' -> abgrfracrel X is x x' ) ) . intros x x' . apply impred . intro . apply ( pr2 _ ) . generalize x1 x2 . clear x1 x2 . apply ( setquotuniv2prop _ ( fun x x' => hProppair _ ( int x x' ) ) ) . intros x x' .  change ( ( abgrfracrelint' X L x x' )  -> ( abgrfracrelint _ L x x' ) ) . apply ( pr1 ( logeqabgrfracrelints X L x x' ) ) .
+assert ( int : Π x x' , isaprop ( abgrfracrel' X is x x' -> abgrfracrel X is x x' ) ) . intros x x' . apply impred . intro . apply ( pr2 _ ) . generalize x1 x2 . clear x1 x2 . apply ( setquotuniv2prop _ ( fun x x' => hProppair _ ( int x x' ) ) ) . intros x x' .  change ( ( abgrfracrelint' X L x x' )  -> ( abgrfracrelint _ L x x' ) ) . apply ( pr1 ( logeqabgrfracrelints X L x x' ) ) .
 
 
-assert ( int : forall x x' , isaprop ( abgrfracrel X is x x' -> abgrfracrel' X is x x' ) ) . intros x x' . apply impred . intro . apply ( pr2 _ ) .   generalize x1 x2 . clear x1 x2 . apply ( setquotuniv2prop _ ( fun x x' => hProppair _ ( int x x' ) ) ) . intros x x' .  change ( ( abgrfracrelint X L x x' )  -> ( abgrfracrelint' _ L x x' ) ) . apply ( pr2 ( logeqabgrfracrelints X L x x' ) ) . Defined .
+assert ( int : Π x x' , isaprop ( abgrfracrel X is x x' -> abgrfracrel' X is x x' ) ) . intros x x' . apply impred . intro . apply ( pr2 _ ) .   generalize x1 x2 . clear x1 x2 . apply ( setquotuniv2prop _ ( fun x x' => hProppair _ ( int x x' ) ) ) . intros x x' .  change ( ( abgrfracrelint X L x x' )  -> ( abgrfracrelint' _ L x x' ) ) . apply ( pr2 ( logeqabgrfracrelints X L x x' ) ) . Defined .
 
 
 Lemma istransabgrfracrelint ( X : abmonoid ) { L : hrel X } ( is : isbinophrel L ) ( isl : istrans L ) : istrans ( abgrfracrelint X L ) .
@@ -953,14 +953,14 @@ Opaque iscotransabgrfracrel .
 
 
 
-Lemma abgrfracrelimpl ( X : abmonoid ) { L L' : hrel X } ( is : isbinophrel L ) ( is' : isbinophrel L' )  ( impl : forall x x' , L x x' -> L' x x' ) ( x x' : abgrfrac X ) ( ql : abgrfracrel X is x x' ) : abgrfracrel X is' x x'  .
+Lemma abgrfracrelimpl ( X : abmonoid ) { L L' : hrel X } ( is : isbinophrel L ) ( is' : isbinophrel L' )  ( impl : Π x x' , L x x' -> L' x x' ) ( x x' : abgrfrac X ) ( ql : abgrfracrel X is x x' ) : abgrfracrel X is' x x'  .
 Proof . intros .   generalize ql .  apply quotrelimpl .  intros x0 x0' .  simpl .  apply hinhfun .  intro t2 . split with ( pr1 t2 ) .   apply ( impl _ _ ( pr2 t2 ) ) . Defined .
 
 
 Opaque abgrfracrelimpl .
 
 
-Lemma abgrfracrellogeq ( X : abmonoid ) { L L' : hrel X } ( is : isbinophrel L ) ( is' : isbinophrel L' )  ( lg : forall x x' , L x x' <-> L' x x' ) ( x x' : abgrfrac X ) :  ( abgrfracrel X is x x' ) <-> ( abgrfracrel X is' x x' ) .
+Lemma abgrfracrellogeq ( X : abmonoid ) { L L' : hrel X } ( is : isbinophrel L ) ( is' : isbinophrel L' )  ( lg : Π x x' , L x x' <-> L' x x' ) ( x x' : abgrfrac X ) :  ( abgrfracrel X is x x' ) <-> ( abgrfracrel X is' x x' ) .
 Proof . intros .   apply quotrellogeq .  intros x0 x0' .  split .
 
 simpl .  apply hinhfun .  intro t2 . split with ( pr1 t2 ) .   apply ( pr1 ( lg _ _ ) ( pr2 t2 ) ) .

--- a/UniMath/Foundations/Algebra/Rigs_and_Rings.v
+++ b/UniMath/Foundations/Algebra/Rigs_and_Rings.v
@@ -41,8 +41,8 @@ Definition rigassoc1 ( X : rig ) : isassoc ( @op1 X ) := assocax_is ( rigop1axs 
 Definition rigunel1 { X : rig } : X := unel_is ( rigop1axs X ) .
 Definition riglunax1 ( X : rig ) : islunit op1 ( @rigunel1 X ) := lunax_is ( rigop1axs X ) .
 Definition rigrunax1 ( X : rig ) : isrunit op1 ( @rigunel1 X ) := runax_is ( rigop1axs X ) .
-Definition rigmult0x ( X : rig ) : forall x : X , paths ( op2 ( @rigunel1 X ) x ) ( @rigunel1 X ) := rigmult0x_is ( pr2 X ) .
-Definition rigmultx0 ( X : rig ) : forall x : X , paths ( op2 x ( @rigunel1 X ) ) ( @rigunel1 X ) := rigmultx0_is ( pr2 X ) .
+Definition rigmult0x ( X : rig ) : Π x : X , paths ( op2 ( @rigunel1 X ) x ) ( @rigunel1 X ) := rigmult0x_is ( pr2 X ) .
+Definition rigmultx0 ( X : rig ) : Π x : X , paths ( op2 x ( @rigunel1 X ) ) ( @rigunel1 X ) := rigmultx0_is ( pr2 X ) .
 Definition rigcomm1 ( X : rig ) : iscomm ( @op1 X ) := commax_is ( rigop1axs X ) .
 
 
@@ -57,7 +57,7 @@ Definition rigdistraxs ( X : rig ) : isdistr ( @op1 X ) ( @op2 X ) := pr2 ( pr2 
 Definition rigldistr ( X : rig ) : isldistr ( @op1 X ) ( @op2 X ) := pr1 ( pr2 ( pr2 X ) ) .
 Definition rigrdistr ( X : rig ) : isrdistr ( @op1 X ) ( @op2 X ) := pr2 ( pr2 ( pr2 X ) ) .
 
-Definition rigconstr { X : hSet } ( opp1 opp2 : binop X ) ( ax11 : ismonoidop opp1 ) ( ax12 : iscomm opp1 ) ( ax2 : ismonoidop opp2 ) ( m0x : forall x : X , paths ( opp2 ( unel_is ax11 ) x ) ( unel_is ax11 ) ) ( mx0 : forall x : X , paths ( opp2 x ( unel_is ax11 ) ) ( unel_is ax11 ) ) ( dax : isdistr opp1 opp2 ) : rig .
+Definition rigconstr { X : hSet } ( opp1 opp2 : binop X ) ( ax11 : ismonoidop opp1 ) ( ax12 : iscomm opp1 ) ( ax2 : ismonoidop opp2 ) ( m0x : Π x : X , paths ( opp2 ( unel_is ax11 ) x ) ( unel_is ax11 ) ) ( mx0 : Π x : X , paths ( opp2 x ( unel_is ax11 ) ) ( unel_is ax11 ) ) ( dax : isdistr opp1 opp2 ) : rig .
 Proof. intros. split with  ( setwith2binoppair X ( dirprodpair opp1 opp2 ) ) . split . split with ( dirprodpair ( dirprodpair ax11 ax12 ) ax2 ) . apply ( dirprodpair m0x mx0 ) . apply dax . Defined .
 
 Definition rigaddabmonoid ( X : rig ) : abmonoid := abmonoidpair ( setwithbinoppair X op1 ) ( rigop1axs X ) .
@@ -102,9 +102,9 @@ Proof . intros . split . apply ( ismonoidfuninvmap ( rigaddiso f ) ) . apply  ( 
 
 (** **** Relations similar to "greater" or "greater or equal" on rigs *)
 
-Definition isrigmultgt ( X : rig ) ( R : hrel X ) :=  forall a b c d : X , R a b -> R c d -> R ( op1 ( op2 a c ) ( op2 b d ) ) ( op1 ( op2 a d ) ( op2 b c ) ) .
+Definition isrigmultgt ( X : rig ) ( R : hrel X ) :=  Π a b c d : X , R a b -> R c d -> R ( op1 ( op2 a c ) ( op2 b d ) ) ( op1 ( op2 a d ) ( op2 b c ) ) .
 
-Definition isinvrigmultgt ( X : rig ) ( R : hrel X ) := dirprod ( forall a b c d : X , R ( op1 ( op2 a c ) ( op2 b d ) ) ( op1 ( op2 a d ) ( op2 b c ) ) -> R a b -> R c d ) ( forall a b c d : X , R ( op1 ( op2 a c ) ( op2 b d ) ) ( op1 ( op2 a d ) ( op2 b c ) ) -> R c d -> R a b ) .
+Definition isinvrigmultgt ( X : rig ) ( R : hrel X ) := dirprod ( Π a b c d : X , R ( op1 ( op2 a c ) ( op2 b d ) ) ( op1 ( op2 a d ) ( op2 b c ) ) -> R a b -> R c d ) ( Π a b c d : X , R ( op1 ( op2 a c ) ( op2 b d ) ) ( op1 ( op2 a d ) ( op2 b c ) ) -> R c d -> R a b ) .
 
 
 (** **** Subobjects *)
@@ -192,7 +192,7 @@ Definition rigdirprod ( X Y : rig ) := @rigpair ( setwith2binopdirprod X Y ) ( i
 Definition commrig := total2 ( fun X : setwith2binop => iscommrigops ( @op1 X ) ( @op2 X ) ) .
 Definition commrigpair ( X : setwith2binop ) ( is : iscommrigops ( @op1 X ) ( @op2 X ) ) : commrig := tpair ( fun X : setwith2binop => iscommrigops ( @op1 X ) ( @op2 X ) ) X is .
 
-Definition commrigconstr { X : hSet } ( opp1 opp2 : binop X ) ( ax11 : ismonoidop opp1 ) ( ax12 : iscomm opp1 ) ( ax2 : ismonoidop opp2 ) ( ax22 : iscomm opp2 ) ( m0x : forall x : X , paths ( opp2 ( unel_is ax11 ) x ) ( unel_is ax11 ) ) ( mx0 : forall x : X , paths ( opp2 x ( unel_is ax11 ) ) ( unel_is ax11 ) ) ( dax : isdistr opp1 opp2 ) : commrig .
+Definition commrigconstr { X : hSet } ( opp1 opp2 : binop X ) ( ax11 : ismonoidop opp1 ) ( ax12 : iscomm opp1 ) ( ax2 : ismonoidop opp2 ) ( ax22 : iscomm opp2 ) ( m0x : Π x : X , paths ( opp2 ( unel_is ax11 ) x ) ( unel_is ax11 ) ) ( mx0 : Π x : X , paths ( opp2 x ( unel_is ax11 ) ) ( unel_is ax11 ) ) ( dax : isdistr opp1 opp2 ) : commrig .
 Proof. intros. split with  ( setwith2binoppair X ( dirprodpair opp1 opp2 ) ) . split . split . split with ( dirprodpair ( dirprodpair ax11 ax12 ) ax2 ) . apply ( dirprodpair m0x mx0 ) . apply dax . apply ax22 . Defined .
 
 Definition commrigtorig : commrig -> rig := fun X : _ => @rigpair ( pr1 X ) ( pr1 ( pr2 X ) ) .
@@ -209,7 +209,7 @@ Definition commrigmultabmonoid ( X : commrig ) : abmonoid := abmonoidpair ( setw
 (** **** Relations similar to "greater" on commutative rigs *)
 
 
-Lemma isinvrigmultgtif ( X : commrig ) ( R : hrel X ) ( is2 : forall a b c d ,  R ( op1 ( op2 a c ) ( op2 b d ) ) ( op1 ( op2 a d ) ( op2 b c ) ) -> R a b -> R c d ) : isinvrigmultgt X R .
+Lemma isinvrigmultgtif ( X : commrig ) ( R : hrel X ) ( is2 : Π a b c d ,  R ( op1 ( op2 a c ) ( op2 b d ) ) ( op1 ( op2 a d ) ( op2 b c ) ) -> R a b -> R c d ) : isinvrigmultgt X R .
 Proof . intros . split .  apply is2 .  intros a b c d r rcd . rewrite ( rigcomm1 X ( op2 a d ) _ ) in r . rewrite ( rigcomm2 X a c ) in r . rewrite ( rigcomm2 X b d ) in r .     rewrite ( rigcomm2 X b c ) in r .  rewrite ( rigcomm2 X a d ) in r .  apply ( is2 _ _ _ _ r rcd ) . Defined .
 
 
@@ -264,8 +264,8 @@ Definition rngunel1 { X : rng } : X := unel_is ( rngop1axs X ) .
 Definition rnglunax1 ( X : rng ) : islunit op1 ( @rngunel1 X ) := lunax_is ( rngop1axs X ) .
 Definition rngrunax1 ( X : rng ) : isrunit op1 ( @rngunel1 X ) := runax_is ( rngop1axs X ) .
 Definition rnginv1 { X : rng } : X -> X := grinv_is ( rngop1axs X ) .
-Definition rnglinvax1 ( X : rng ) : forall x : X , paths ( op1 ( rnginv1 x ) x ) rngunel1 := grlinvax_is ( rngop1axs X ) .
-Definition rngrinvax1 ( X : rng ) : forall x : X , paths ( op1 x ( rnginv1 x ) ) rngunel1 := grrinvax_is ( rngop1axs X ) .
+Definition rnglinvax1 ( X : rng ) : Π x : X , paths ( op1 ( rnginv1 x ) x ) rngunel1 := grlinvax_is ( rngop1axs X ) .
+Definition rngrinvax1 ( X : rng ) : Π x : X , paths ( op1 x ( rnginv1 x ) ) rngunel1 := grrinvax_is ( rngop1axs X ) .
 Definition rngcomm1 ( X : rng ) : iscomm ( @op1 X ) := commax_is ( rngop1axs X ) .
 
 
@@ -282,10 +282,10 @@ Definition rngrdistr ( X : rng ) : isrdistr ( @op1 X ) ( @op2 X ) := pr2 ( pr2 (
 
 Definition rngconstr { X : hSet } ( opp1 opp2 : binop X ) ( ax11 : isgrop opp1 ) ( ax12 : iscomm opp1 ) ( ax2 : ismonoidop opp2 ) ( dax : isdistr opp1 opp2 ) : rng := @rngpair ( setwith2binoppair X ( dirprodpair opp1 opp2 ) ) ( dirprodpair ( dirprodpair ( dirprodpair ax11 ax12 ) ax2 ) dax ) .
 
-Definition rngmultx0 ( X : rng ) : forall x : X , paths ( op2 x rngunel1 ) rngunel1 := rngmultx0_is ( rngaxs X ) .
-Definition rngmult0x ( X : rng ) : forall x : X , paths ( op2 rngunel1 x ) rngunel1 := rngmult0x_is ( rngaxs X ) .
+Definition rngmultx0 ( X : rng ) : Π x : X , paths ( op2 x rngunel1 ) rngunel1 := rngmultx0_is ( rngaxs X ) .
+Definition rngmult0x ( X : rng ) : Π x : X , paths ( op2 rngunel1 x ) rngunel1 := rngmult0x_is ( rngaxs X ) .
 Definition rngminus1 { X : rng } : X := rngminus1_is ( rngaxs X ) .
-Definition rngmultwithminus1 ( X : rng ) : forall x : X , paths ( op2 rngminus1 x ) ( rnginv1 x ) := rngmultwithminus1_is ( rngaxs X ) .
+Definition rngmultwithminus1 ( X : rng ) : Π x : X , paths ( op2 rngminus1 x ) ( rnginv1 x ) := rngmultwithminus1_is ( rngaxs X ) .
 
 
 Definition rngaddabgr ( X : rng ) : abgr := abgrpair ( setwithbinoppair X op1 ) ( rngop1axs X ) .
@@ -334,17 +334,17 @@ Open Scope rng_scope .
 
 Definition rnginvunel1 ( X : rng ) : paths ( - 0 ) 0 := grinvunel ( rngaddabgr X ) .
 
-Lemma rngismultlcancelableif ( X : rng ) ( x : X ) ( isl: forall y , paths ( x * y ) 0 -> paths y 0 ) : islcancelable op2 x .
+Lemma rngismultlcancelableif ( X : rng ) ( x : X ) ( isl: Π y , paths ( x * y ) 0 -> paths y 0 ) : islcancelable op2 x .
 Proof . intros . apply ( @isinclbetweensets X X ) . apply setproperty .  apply setproperty . intros x1 x2 e . assert ( e' := maponpaths ( fun a => a + ( x * ( -x2 ) ) ) e ) .  simpl in e' .  rewrite ( pathsinv0 ( rngldistr X _ _ x ) ) in e' .  rewrite ( pathsinv0 ( rngldistr X _ _ x ) ) in e' . rewrite ( rngrinvax1 X x2 ) in e' . rewrite ( rngmultx0 X _ ) in e' .  assert ( e'' := isl ( x1 - x2 ) e' ) . assert ( e''' := maponpaths ( fun a => a + x2 ) e'' ) .  simpl in e''' .  rewrite ( rngassoc1 X _ _ x2  ) in e''' .  rewrite ( rnglinvax1 X x2 ) in e''' . rewrite ( rnglunax1 X _ ) in e''' .   rewrite ( rngrunax1 X _ ) in e''' . apply e''' . Defined .
 
 Opaque  rngismultlcancelableif .
 
-Lemma rngismultrcancelableif ( X : rng ) ( x : X ) ( isr: forall y , paths ( y * x ) 0 -> paths y 0 ) : isrcancelable op2 x .
+Lemma rngismultrcancelableif ( X : rng ) ( x : X ) ( isr: Π y , paths ( y * x ) 0 -> paths y 0 ) : isrcancelable op2 x .
 Proof . intros . apply ( @isinclbetweensets X X ) . apply setproperty .  apply setproperty . intros x1 x2 e . assert ( e' := maponpaths ( fun a => a + ( ( -x2 ) * x ) ) e ) .  simpl in e' .  rewrite ( pathsinv0 ( rngrdistr X _ _ x ) ) in e' .  rewrite ( pathsinv0 ( rngrdistr X _ _ x ) ) in e' . rewrite ( rngrinvax1 X x2 ) in e' . rewrite ( rngmult0x X _ ) in e' .  assert ( e'' := isr ( x1 - x2 ) e' ) . assert ( e''' := maponpaths ( fun a => a + x2 ) e'' ) .  simpl in e''' .  rewrite ( rngassoc1 X _ _ x2  ) in e''' .  rewrite ( rnglinvax1 X x2 ) in e''' . rewrite ( rnglunax1 X _ ) in e''' .   rewrite ( rngrunax1 X _ ) in e''' . apply e''' . Defined .
 
 Opaque  rngismultrcancelableif .
 
-Lemma rngismultcancelableif ( X : rng ) ( x : X ) ( isl: forall y , paths ( x * y ) 0 -> paths y 0 )  ( isr: forall y , paths ( y * x ) 0 -> paths y 0 ) : iscancelable op2 x .
+Lemma rngismultcancelableif ( X : rng ) ( x : X ) ( isl: Π y , paths ( x * y ) 0 -> paths y 0 )  ( isr: Π y , paths ( y * x ) 0 -> paths y 0 ) : iscancelable op2 x .
 Proof . intros . apply ( dirprodpair ( rngismultlcancelableif X x isl ) ( rngismultrcancelableif X x isr ) ) . Defined .
 
 Lemma rnglmultminus ( X : rng ) ( a b : X ) : paths ( ( - a ) * b ) ( - ( a * b ) ) .
@@ -383,7 +383,7 @@ Definition rngtolt0 ( X : rng ) { R : hrel X } ( is0 : @isbinophrel ( rngaddabgr
 (** **** Relations compatible with the multiplicative structure on rings *)
 
 
-Definition isrngmultgt ( X : rng ) ( R : hrel X ) := forall a b , R a 0 -> R b 0 -> R ( a * b ) 0 .
+Definition isrngmultgt ( X : rng ) ( R : hrel X ) := Π a b , R a 0 -> R b 0 -> R ( a * b ) 0 .
 
 Lemma rngmultgt0lt0 ( X : rng ) { R : hrel X } ( is0 : @isbinophrel ( rngaddabgr X ) R ) ( is : isrngmultgt X R ) { x y : X } ( isx : R x 0 ) ( isy : R 0 y ) : R 0 ( x * y ) .
 Proof . intros . assert ( isy' := grfromltunel ( rngaddabgr X ) is0 isy ) . assert ( r := is _ _ isx isy' ) .  change ( pr1 ( R ( x * ( - y ) ) 0 ) ) in r . rewrite ( rngrmultminus X _ _ ) in r . assert ( r' := grfromgtunel ( rngaddabgr X ) is0 r ) . change ( pr1 ( R 0 ( - - ( x * y ) ) ) ) in r' . rewrite ( rngminusminus X ( x * y ) ) in r' .   apply r' .  Defined .
@@ -400,22 +400,22 @@ Proof . intros . assert ( rx := rngfromlt0 _ is0 isx ) .   assert ( ry := rngfro
 
 Opaque rngmultlt0lt0 .
 
-Lemma isrngmultgttoislrngmultgt ( X : rng ) { R : hrel X } ( is0 : @isbinophrel ( rngaddabgr X ) R ) ( is : isrngmultgt X R ) : forall a b c : X , R c 0 -> R a b -> R ( c * a ) ( c * b ) .
+Lemma isrngmultgttoislrngmultgt ( X : rng ) { R : hrel X } ( is0 : @isbinophrel ( rngaddabgr X ) R ) ( is : isrngmultgt X R ) : Π a b c : X , R c 0 -> R a b -> R ( c * a ) ( c * b ) .
 Proof . intros X R is0 is a b c rc0 rab . set ( rab':= ( pr2 is0 ) _ _ ( - b ) rab ) .  clearbody rab' . change ( pr1 ( R ( a - b ) ( b - b ) ) ) in rab' .  rewrite ( rngrinvax1 X b ) in rab' . set ( r' := is _ _ rc0 rab' ) . clearbody r' . set ( r'' :=  ( pr2 is0 ) _ _ ( c * b ) r' ) .  clearbody r'' .  change ( pr1 ( R ( c * ( a - b ) + c * b ) ( 0 + c * b ) ) ) in r'' . rewrite ( rnglunax1 X _ ) in r'' .  rewrite ( pathsinv0 ( rngldistr X _ _ c ) ) in r'' .  rewrite ( rngassoc1 X a _ _ ) in r'' .  rewrite ( rnglinvax1 X b ) in r'' .   rewrite ( rngrunax1 X _ ) in r'' .  apply r'' .  Defined .
 
 Opaque isrngmultgttoislrngmultgt .
 
-Lemma islrngmultgttoisrngmultgt ( X : rng ) { R : hrel X } ( is : forall a b c : X , R c 0 -> R a b -> R ( c * a ) ( c * b ) ) : isrngmultgt X R .
+Lemma islrngmultgttoisrngmultgt ( X : rng ) { R : hrel X } ( is : Π a b c : X , R c 0 -> R a b -> R ( c * a ) ( c * b ) ) : isrngmultgt X R .
 Proof . intros . intros a b ra rb . set ( int := is b 0 a ra rb ) .  clearbody int .  rewrite ( rngmultx0 X _ ) in int .  apply int . Defined .
 
 Opaque islrngmultgttoisrngmultgt .
 
-Lemma isrngmultgttoisrrngmultgt ( X : rng ) { R : hrel X } ( is0 : @isbinophrel ( rngaddabgr X ) R ) ( is : isrngmultgt X R ) : forall a b c : X , R c 0 -> R a b -> R ( a * c ) ( b * c ) .
+Lemma isrngmultgttoisrrngmultgt ( X : rng ) { R : hrel X } ( is0 : @isbinophrel ( rngaddabgr X ) R ) ( is : isrngmultgt X R ) : Π a b c : X , R c 0 -> R a b -> R ( a * c ) ( b * c ) .
 Proof . intros X R is0 is a b c rc0 rab . set ( rab':= ( pr2 is0 ) _ _ ( - b ) rab ) .  clearbody rab' . change ( pr1 ( R ( a - b ) ( b - b ) ) ) in rab' .  rewrite ( rngrinvax1 X b ) in rab' . set ( r' := is _ _ rab' rc0 ) . clearbody r' . set ( r'' :=  ( pr2 is0 ) _ _ ( b * c ) r' ) .  clearbody r'' .  change ( pr1 ( R ( ( a - b ) * c + b * c ) ( 0 + b * c ) ) ) in r'' . rewrite ( rnglunax1 X _ ) in r'' .  rewrite ( pathsinv0 ( rngrdistr X _ _ c ) ) in r'' .  rewrite ( rngassoc1 X a _ _ ) in r'' .  rewrite ( rnglinvax1 X b ) in r'' .   rewrite ( rngrunax1 X _ ) in r'' .  apply r'' .  Defined .
 
 Opaque isrngmultgttoisrrngmultgt .
 
-Lemma isrrngmultgttoisrngmultgt ( X : rng ) { R : hrel X } ( is1 : forall a b c : X , R c 0 -> R a b -> R ( a * c ) ( b * c ) ) : isrngmultgt X R .
+Lemma isrrngmultgttoisrngmultgt ( X : rng ) { R : hrel X } ( is1 : Π a b c : X , R c 0 -> R a b -> R ( a * c ) ( b * c ) ) : isrngmultgt X R .
 Proof . intros . intros a b ra rb . set ( int := is1 _ _ _ rb ra ) .  clearbody int .  rewrite ( rngmult0x X _ ) in int .  apply int . Defined .
 
 Opaque isrrngmultgttoisrngmultgt .
@@ -441,21 +441,21 @@ Opaque isrigmultgttoisrngmultgt .
 
 
 
-Definition isinvrngmultgt  ( X : rng ) ( R : hrel X ) := dirprod ( forall a b , R ( a * b ) 0 -> R a 0 -> R b 0  ) ( forall a b , R ( a * b ) 0 -> R b 0 -> R a 0  ) .
+Definition isinvrngmultgt  ( X : rng ) ( R : hrel X ) := dirprod ( Π a b , R ( a * b ) 0 -> R a 0 -> R b 0  ) ( Π a b , R ( a * b ) 0 -> R b 0 -> R a 0  ) .
 
 
-Lemma isinvrngmultgttoislinvrngmultgt ( X : rng ) { R : hrel X } ( is0 : @isbinophrel ( rngaddabgr X ) R ) ( is : isinvrngmultgt X R ) : forall a b c : X , R c 0 -> R ( c * a ) ( c * b ) -> R a b .
+Lemma isinvrngmultgttoislinvrngmultgt ( X : rng ) { R : hrel X } ( is0 : @isbinophrel ( rngaddabgr X ) R ) ( is : isinvrngmultgt X R ) : Π a b c : X , R c 0 -> R ( c * a ) ( c * b ) -> R a b .
 Proof . intros X R is0 is a b c rc0 r . set ( rab':= ( pr2 is0 ) _ _ ( c * - b ) r ) .  clearbody rab' . change ( pr1 ( R ( c * a + c * - b ) ( c * b + c * - b ) ) ) in rab' .  rewrite ( pathsinv0 ( rngldistr X _ _ c ) ) in rab' .  rewrite ( pathsinv0 ( rngldistr X _ _ c ) ) in rab' .  rewrite ( rngrinvax1 X b ) in rab' .  rewrite ( rngmultx0 X _ ) in rab' .  set ( r' := ( pr1 is ) _ _ rab' rc0 ) . clearbody r' . set ( r'' :=  ( pr2 is0 ) _ _ b r' ) .  clearbody r'' .  change ( pr1 ( R ( a - b + b ) ( 0 + b ) ) ) in r'' . rewrite ( rnglunax1 X _ ) in r'' .  rewrite ( rngassoc1 X a _ _ ) in r'' .  rewrite ( rnglinvax1 X b ) in r'' .   rewrite ( rngrunax1 X _ ) in r'' .  apply r'' .  Defined .
 
 Opaque isinvrngmultgttoislinvrngmultgt .
 
-Lemma isinvrngmultgttoisrinvrngmultgt ( X : rng ) { R : hrel X } ( is0 : @isbinophrel ( rngaddabgr X ) R ) ( is : isinvrngmultgt X R ) : forall a b c : X , R c 0 -> R ( a * c ) ( b * c ) -> R a b .
+Lemma isinvrngmultgttoisrinvrngmultgt ( X : rng ) { R : hrel X } ( is0 : @isbinophrel ( rngaddabgr X ) R ) ( is : isinvrngmultgt X R ) : Π a b c : X , R c 0 -> R ( a * c ) ( b * c ) -> R a b .
 Proof . intros X R is0 is a b c rc0 r . set ( rab':= ( pr2 is0 ) _ _ ( - b * c ) r ) .  clearbody rab' . change ( pr1 ( R ( a * c + - b * c ) ( b * c + - b * c ) ) ) in rab' .  rewrite ( pathsinv0 ( rngrdistr X _ _ c ) ) in rab' .  rewrite ( pathsinv0 ( rngrdistr X _ _ c ) ) in rab' .  rewrite ( rngrinvax1 X b ) in rab' .  rewrite ( rngmult0x X _ ) in rab' .  set ( r' := ( pr2 is ) _ _ rab' rc0 ) . clearbody r' . set ( r'' :=  ( pr2 is0 ) _ _ b r' ) .  clearbody r'' .  change ( pr1 ( R ( a - b + b ) ( 0 + b ) ) ) in r'' . rewrite ( rnglunax1 X _ ) in r'' .  rewrite ( rngassoc1 X a _ _ ) in r'' .  rewrite ( rnglinvax1 X b ) in r'' .   rewrite ( rngrunax1 X _ ) in r'' .  apply r'' .  Defined .
 
 Opaque isinvrngmultgttoisrinvrngmultgt .
 
 
-Lemma islrinvrngmultgttoisinvrngmultgt ( X : rng ) { R : hrel X } ( isl : forall a b c : X , R c 0 -> R ( c * a ) ( c * b ) -> R a b ) ( isr : forall a b c : X , R c 0 -> R ( a * c ) ( b * c ) -> R a b ) : isinvrngmultgt X R .
+Lemma islrinvrngmultgttoisinvrngmultgt ( X : rng ) { R : hrel X } ( isl : Π a b c : X , R c 0 -> R ( c * a ) ( c * b ) -> R a b ) ( isr : Π a b c : X , R c 0 -> R ( a * c ) ( b * c ) -> R a b ) : isinvrngmultgt X R .
 Proof . intros . split .
 
 intros a b rab ra . rewrite ( pathsinv0 ( rngmultx0 X a ) ) in rab . apply ( isl _ _ _ ra rab ) .
@@ -490,10 +490,10 @@ Lemma rngaddhrelandfun { X Y : rng } ( f : rngfun X Y ) ( R : hrel Y ) ( isr :  
 Proof . intros . apply ( binophrelandfun ( rngaddfun f ) R isr ) .   Defined .
 
 Lemma rngmultgtandfun { X Y : rng } ( f : rngfun X Y ) ( R : hrel Y ) ( isr : isrngmultgt Y R ) : isrngmultgt X ( fun x x' => R ( f x ) ( f x' ) ) .
-Proof . intros . intros a b ra rb . assert ( ax0 := ( pr2 ( pr1 ( pr2 f ) ) ) : paths ( f 0 ) 0 ) .  assert ( ax1 := ( pr1 ( pr2 ( pr2 f ) ) ) : forall a b , paths ( f ( a * b ) ) ( ( f a ) * ( f b ) ) ) . rewrite ax0 in ra . rewrite ax0 in rb . rewrite ax0 . rewrite ( ax1 _ _  ) .  apply ( isr _ _ ra rb ) . Defined .
+Proof . intros . intros a b ra rb . assert ( ax0 := ( pr2 ( pr1 ( pr2 f ) ) ) : paths ( f 0 ) 0 ) .  assert ( ax1 := ( pr1 ( pr2 ( pr2 f ) ) ) : Π a b , paths ( f ( a * b ) ) ( ( f a ) * ( f b ) ) ) . rewrite ax0 in ra . rewrite ax0 in rb . rewrite ax0 . rewrite ( ax1 _ _  ) .  apply ( isr _ _ ra rb ) . Defined .
 
 Lemma rnginvmultgtandfun { X Y : rng } ( f : rngfun X Y ) ( R : hrel Y ) ( isr : isinvrngmultgt Y R ) : isinvrngmultgt X ( fun x x' => R ( f x ) ( f x' ) ) .
-Proof . intros . assert ( ax0 := ( pr2 ( pr1 ( pr2 f ) ) ) : paths ( f 0 ) 0 ) .  assert ( ax1 := ( pr1 ( pr2 ( pr2 f ) ) ) : forall a b , paths ( f ( a * b ) ) ( ( f a ) * ( f b ) ) ) . split .
+Proof . intros . assert ( ax0 := ( pr2 ( pr1 ( pr2 f ) ) ) : paths ( f 0 ) 0 ) .  assert ( ax1 := ( pr1 ( pr2 ( pr2 f ) ) ) : Π a b , paths ( f ( a * b ) ) ( ( f a ) * ( f b ) ) ) . split .
 intros a b rab ra . rewrite ax0 in ra . rewrite ax0 in rab . rewrite ax0 . rewrite ( ax1 _ _  ) in rab .  apply ( ( pr1 isr ) _ _ rab ra ) .
 
 intros a b rab rb . rewrite ax0 in rb . rewrite ax0 in rab . rewrite ax0 . rewrite ( ax1 _ _  ) in rab .  apply ( ( pr2 isr ) _ _ rab rb ) . Defined .
@@ -705,7 +705,7 @@ Definition ismultmonoidfuntorngdiff  ( X : rig ) : @ismonoidfun  ( rigmultmonoid
 
 Definition isrigfuntorngdiff ( X : rig ) : @isrigfun X ( rigtorng X ) ( torngdiff X ) := dirprodpair ( isaddmonoidfuntorngdiff X ) ( ismultmonoidfuntorngdiff X ) .
 
-Definition isincltorngdiff ( X : rig ) ( iscanc : forall x : X , @isrcancelable X ( @op1 X ) x ) : isincl ( torngdiff X ) := isincltoabgrfrac ( rigaddabmonoid X ) iscanc .
+Definition isincltorngdiff ( X : rig ) ( iscanc : Π x : X , @isrcancelable X ( @op1 X ) x ) : isincl ( torngdiff X ) := isincltoabgrfrac ( rigaddabmonoid X ) iscanc .
 
 
 (** **** Relations similar to "greater" or "greater or equal"  on the ring associated with a rig *)
@@ -713,9 +713,9 @@ Definition isincltorngdiff ( X : rig ) ( iscanc : forall x : X , @isrcancelable 
 Definition rigtorngrel ( X : rig ) { R : hrel X } ( is : @isbinophrel ( rigaddabmonoid X ) R ) : hrel ( rigtorng X ) := abgrfracrel ( rigaddabmonoid X ) is .
 
 Lemma isrngrigtorngmultgt  ( X : rig ) { R : hrel X } ( is0 : @isbinophrel ( rigaddabmonoid X ) R ) ( is : isrigmultgt X R ) : isrngmultgt ( rigtorng X ) ( rigtorngrel X is0 ) .
-Proof . intros . set ( assoc := rigassoc1 X ) .  set ( comm := rigcomm1 X ) .   set ( rer := ( abmonoidrer ( rigaddabmonoid X ) ) : forall a b c d : X , paths ( ( a + b ) + ( c + d ) ) ( ( a + c ) + ( b + d ) ) ) . set ( ld := rigldistr X ) . set ( rd := rigrdistr X ) .
+Proof . intros . set ( assoc := rigassoc1 X ) .  set ( comm := rigcomm1 X ) .   set ( rer := ( abmonoidrer ( rigaddabmonoid X ) ) : Π a b c d : X , paths ( ( a + b ) + ( c + d ) ) ( ( a + c ) + ( b + d ) ) ) . set ( ld := rigldistr X ) . set ( rd := rigrdistr X ) .
 
-assert ( int : forall a b , isaprop ( rigtorngrel X is0 a rngunel1 -> rigtorngrel X is0 b rngunel1 ->  rigtorngrel X is0 (a * b) rngunel1 ) ) . intros a b . apply impred . intro . apply impred .  intro . apply ( pr2 _ ) .   unfold isrngmultgt . apply ( setquotuniv2prop _ ( fun a b => hProppair _ ( int a b ) ) ) .
+assert ( int : Π a b , isaprop ( rigtorngrel X is0 a rngunel1 -> rigtorngrel X is0 b rngunel1 ->  rigtorngrel X is0 (a * b) rngunel1 ) ) . intros a b . apply impred . intro . apply impred .  intro . apply ( pr2 _ ) .   unfold isrngmultgt . apply ( setquotuniv2prop _ ( fun a b => hProppair _ ( int a b ) ) ) .
 
 
 intros xa1 xa2 . change ( ( abgrfracrelint ( rigaddabmonoid X ) R ) xa1 ( dirprodpair ( @rigunel1 X ) ( @rigunel1 X ) ) -> ( abgrfracrelint ( rigaddabmonoid X ) R ) xa2 ( dirprodpair ( @rigunel1 X ) ( @rigunel1 X ) ) -> ( abgrfracrelint ( rigaddabmonoid X ) R ( @rigtorngop2int X xa1 xa2 ) ( dirprodpair ( @rigunel1 X ) ( @rigunel1 X ) ) ) ) .  unfold abgrfracrelint . simpl . apply hinhfun2 . intros t22 t21 .   set ( c2 := pr1 t21 ) . set ( c1 := pr1 t22 ) . set ( r1 := pr2 t21 ) . set ( r2 := pr2 t22 ) . set ( x1 := pr1 xa1 ) . set ( a1 := pr2 xa1 ) .  set ( x2 := pr1 xa2 ) . set ( a2 := pr2 xa2 ) . split with ( ( x1 * c2 + a1 * c2 ) + ( ( c1 * x2 + c1 * c2 ) + ( c1 * a2 + c1 * c2 ) ) ) . change ( pr1 ( R ( x1 * x2 + a1 * a2 + 0 + ( ( x1 * c2 + a1 * c2 ) + ( ( c1 * x2 + c1 * c2 ) + ( c1 * a2 + c1 * c2 ) ) ) )  ( 0 + ( x1 * a2 + a1 * x2 ) + ( x1 * c2 + a1 * c2 +  ( ( c1 * x2 + c1 * c2 ) + ( c1 * a2 + c1 * c2 ) ) ) ) ) ) . rewrite ( riglunax1 X _ ) .  rewrite ( rigrunax1 X _ ) .   rewrite ( assoc ( x1 * c2 ) _ _ ) .  rewrite ( rer _ ( a1 * a2 ) _ _ ) .  rewrite ( rer _ ( a1 * x2 ) _ _ ) . rewrite ( pathsinv0 ( assoc ( a1 * a2 ) _ _  ) ) . rewrite ( pathsinv0 ( assoc ( a1 * x2 ) _ _  ) ) . rewrite ( pathsinv0 ( assoc ( x1 * x2 + _ ) _ _ ) ) . rewrite ( pathsinv0 ( assoc ( x1 * a2 + _ ) _ _ ) ) .  rewrite ( rer _ ( a1 * a2 + _ ) _ _ ) .  rewrite ( rer _ ( a1 * x2 + _ ) _ _ ) .  rewrite ( pathsinv0 ( ld _ _ x1 ) ) . rewrite ( pathsinv0 ( ld _ _ x1 ) ) . rewrite ( pathsinv0 ( ld _ _ c1 ) ) . rewrite ( pathsinv0 ( ld _ _ c1 ) ) . rewrite ( pathsinv0 ( ld _ _ a1 ) ) .  rewrite ( pathsinv0 ( ld _ _ a1 ) ) .  rewrite ( pathsinv0 ( rd _ _ ( x2 + c2 ) ) ) .  rewrite ( pathsinv0 ( rd _ _ ( a2 + c2 ) ) ) . rewrite ( comm ( a1 * _ ) _ ) .  rewrite ( rer _ ( c1 * _ ) _ _ ) . rewrite ( pathsinv0 ( rd _ _ ( x2 + c2 ) ) ) .  rewrite ( pathsinv0 ( rd _ _ ( a2 + c2 ) ) ) .  clearbody r1 . clearbody r2 . change ( pr1 ( R ( x2 + 0 + c2 ) ( 0 + a2 + c2 ) ) ) in r1 . change ( pr1 ( R ( x1 + 0 + c1 ) ( 0 + a1 + c1 ) ) ) in r2 .  rewrite ( rigrunax1 X _ ) in r1 .   rewrite ( riglunax1 X _ ) in r1 .   rewrite ( rigrunax1 X _ ) in r2 .   rewrite ( riglunax1 X _ ) in r2 . rewrite ( comm c1 a1 ) . apply ( is _ _ _ _ r2 r1 ) .   Defined .
@@ -729,11 +729,11 @@ Proof . intros . apply ( isdecabgrfracrel ( rigaddabmonoid X ) is is' isd ) . De
 Lemma isinvrngrigtorngmultgt ( X : rig ) { R : hrel X } ( is0 : @isbinophrel ( rigaddabmonoid X ) R ) ( is1 : @isinvbinophrel ( rigaddabmonoid X ) R ) ( is : isinvrigmultgt X R ) : isinvrngmultgt ( rigtorng X ) ( rigtorngrel X is0 ) .
 Proof . intros .  split .
 
-assert ( int : forall a b , isaprop ( rigtorngrel X is0 (a * b) rngunel1 -> rigtorngrel X is0 a rngunel1 -> rigtorngrel X is0 b rngunel1 ) ) . intros . apply impred . intro . apply impred . intro . apply ( pr2 _ ) .  apply (  setquotuniv2prop _ ( fun a b => hProppair _ ( int a b ) ) ) .
+assert ( int : Π a b , isaprop ( rigtorngrel X is0 (a * b) rngunel1 -> rigtorngrel X is0 a rngunel1 -> rigtorngrel X is0 b rngunel1 ) ) . intros . apply impred . intro . apply impred . intro . apply ( pr2 _ ) .  apply (  setquotuniv2prop _ ( fun a b => hProppair _ ( int a b ) ) ) .
 
 intros xa1 xa2 . change ( ( abgrfracrelint ( rigaddabmonoid X ) R ( @rigtorngop2int X xa1 xa2 ) ( dirprodpair ( @rigunel1 X ) ( @rigunel1 X ) ) ) -> ( abgrfracrelint ( rigaddabmonoid X ) R ) xa1 ( dirprodpair ( @rigunel1 X ) ( @rigunel1 X ) ) -> ( abgrfracrelint ( rigaddabmonoid X ) R ) xa2 ( dirprodpair ( @rigunel1 X ) ( @rigunel1 X ) ) ) .   unfold abgrfracrelint . simpl . apply hinhfun2 . intros t22 t21 .   set ( c2 := pr1 t22 ) . set ( c1 := pr1 t21 ) . set ( r1 := pr2 t21 ) . set ( r2 := pr2 t22 ) . set ( x1 := pr1 xa1 ) . set ( a1 := pr2 xa1 ) .  set ( x2 := pr1 xa2 ) . set ( a2 := pr2 xa2 ) . simpl in r2 . clearbody r2 .  change ( pr1 ( R ( x1 * x2 + a1 * a2 + 0 + c2 ) ( 0 + ( x1 * a2 + a1 * x2 ) + c2 ) ) ) in r2 . rewrite ( riglunax1 X _ ) in r2 .  rewrite ( rigrunax1 X _ ) in r2 . rewrite ( rigrunax1 X _ ) . rewrite ( riglunax1 X _ ) . set ( r2' := ( pr2 is1 ) _ _ c2 r2 ) .  clearbody r1 . change ( pr1 ( R ( x1 + 0 + c1 ) ( 0 + a1 + c1 ) ) ) in r1 . rewrite ( riglunax1 X _ ) in r1 .  rewrite ( rigrunax1 X _ ) in r1  .   set ( r1' := ( pr2 is1 ) _ _ c1 r1 ) . split with 0 .  rewrite ( rigrunax1 X _ ) .  rewrite ( rigrunax1 X _ ) .  apply ( ( pr1 is ) _ _ _ _ r2' r1' ) .
 
-assert ( int : forall a b , isaprop ( rigtorngrel X is0 (a * b) rngunel1 -> rigtorngrel X is0 b rngunel1  -> rigtorngrel X is0 a rngunel1 ) ) . intros . apply impred . intro . apply impred . intro . apply ( pr2 _ ) .  apply (  setquotuniv2prop _ ( fun a b => hProppair _ ( int a b ) ) ) .
+assert ( int : Π a b , isaprop ( rigtorngrel X is0 (a * b) rngunel1 -> rigtorngrel X is0 b rngunel1  -> rigtorngrel X is0 a rngunel1 ) ) . intros . apply impred . intro . apply impred . intro . apply ( pr2 _ ) .  apply (  setquotuniv2prop _ ( fun a b => hProppair _ ( int a b ) ) ) .
 
 intros xa1 xa2 . change ( ( abgrfracrelint ( rigaddabmonoid X ) R ( @rigtorngop2int X xa1 xa2 ) ( dirprodpair ( @rigunel1 X ) ( @rigunel1 X ) ) ) -> ( abgrfracrelint ( rigaddabmonoid X ) R ) xa2 ( dirprodpair ( @rigunel1 X ) ( @rigunel1 X ) ) -> ( abgrfracrelint ( rigaddabmonoid X ) R ) xa1 ( dirprodpair ( @rigunel1 X ) ( @rigunel1 X ) ) ) .   unfold abgrfracrelint . simpl . apply hinhfun2 . intros t22 t21 .   set ( c2 := pr1 t22 ) . set ( c1 := pr1 t21 ) . set ( r1 := pr2 t21 ) . set ( r2 := pr2 t22 ) . set ( x1 := pr1 xa1 ) . set ( a1 := pr2 xa1 ) .  set ( x2 := pr1 xa2 ) . set ( a2 := pr2 xa2 ) . simpl in r2 . clearbody r2 .  change ( pr1 ( R ( x1 * x2 + a1 * a2 + 0 + c2 ) ( 0 + ( x1 * a2 + a1 * x2 ) + c2 ) ) ) in r2 . rewrite ( riglunax1 X _ ) in r2 .  rewrite ( rigrunax1 X _ ) in r2 . rewrite ( rigrunax1 X _ ) . rewrite ( riglunax1 X _ ) . set ( r2' := ( pr2 is1 ) _ _ c2 r2 ) .  clearbody r1 . change ( pr1 ( R ( x2 + 0 + c1 ) ( 0 + a2 + c1 ) ) ) in r1 . rewrite ( riglunax1 X _ ) in r1 .  rewrite ( rigrunax1 X _ ) in r1  .   set ( r1' := ( pr2 is1 ) _ _ c1 r1 ) . split with 0 .  rewrite ( rigrunax1 X _ ) .  rewrite ( rigrunax1 X _ ) .  apply ( ( pr2 is ) _ _ _ _ r2' r1' ) . Defined .
 
@@ -779,8 +779,8 @@ Coercion commrngtocommrig : commrng >-> commrig .
 
 Open Scope rng_scope.
 
-Lemma commrngismultcancelableif ( X : commrng ) ( x : X ) ( isl : forall y , paths ( x * y ) 0 -> paths y 0 ) : iscancelable op2 x .
-Proof . intros . split . apply ( rngismultlcancelableif X x isl ) .  assert ( isr : forall y , paths ( y * x ) 0 -> paths y 0 ) . intros y e . rewrite ( rngcomm2 X _ _ ) in e . apply ( isl y e ) . apply ( rngismultrcancelableif X x isr ) . Defined .
+Lemma commrngismultcancelableif ( X : commrng ) ( x : X ) ( isl : Π y , paths ( x * y ) 0 -> paths y 0 ) : iscancelable op2 x .
+Proof . intros . split . apply ( rngismultlcancelableif X x isl ) .  assert ( isr : Π y , paths ( y * x ) 0 -> paths y 0 ) . intros y e . rewrite ( rngcomm2 X _ _ ) in e . apply ( isl y e ) . apply ( rngismultrcancelableif X x isr ) . Defined .
 
 Opaque commrngismultcancelableif .
 
@@ -880,7 +880,7 @@ Opaque commrngfracl2 .
 
 Lemma commrngfracassoc1 ( X : commrng ) ( S : @subabmonoids ( rngmultabmonoid X ) ) : isassoc ( commrngfracop1 X S ) .
 Proof . intros . set ( R := eqrelcommrngfrac X S ) . set ( add1int := commrngfracop1int X S ) . set ( add1 := commrngfracop1 X S ) .  unfold isassoc .
-assert ( int : forall xs xs' xs'' : dirprod X S , paths ( setquotpr R ( add1int ( add1int xs xs' ) xs'' ) ) ( setquotpr R ( add1int xs ( add1int xs' xs'' ) ) ) ) . unfold add1int . unfold commrngfracop1int . intros xs xs' xs'' .  apply ( @maponpaths _ _ ( setquotpr R ) ) .   simpl .  apply pathsdirprod . unfold pr1carrier . apply ( commrngfracl2 X  ( pr1 xs ) ( pr1 xs' ) ( pr1 xs'' ) ( pr1 ( pr2 xs ) )  ( pr1 ( pr2 xs' ) ) ( pr1 ( pr2 xs'' ) ) ) . apply ( invmaponpathsincl _ ( isinclpr1carrier ( pr1 S ) ) ) .  unfold pr1carrier . simpl .  set ( assoc2 := rngassoc2 X ) .  apply ( assoc2 (pr1 (pr2 xs)) (pr1 (pr2 xs')) (pr1 (pr2 xs'')) ) .
+assert ( int : Π xs xs' xs'' : dirprod X S , paths ( setquotpr R ( add1int ( add1int xs xs' ) xs'' ) ) ( setquotpr R ( add1int xs ( add1int xs' xs'' ) ) ) ) . unfold add1int . unfold commrngfracop1int . intros xs xs' xs'' .  apply ( @maponpaths _ _ ( setquotpr R ) ) .   simpl .  apply pathsdirprod . unfold pr1carrier . apply ( commrngfracl2 X  ( pr1 xs ) ( pr1 xs' ) ( pr1 xs'' ) ( pr1 ( pr2 xs ) )  ( pr1 ( pr2 xs' ) ) ( pr1 ( pr2 xs'' ) ) ) . apply ( invmaponpathsincl _ ( isinclpr1carrier ( pr1 S ) ) ) .  unfold pr1carrier . simpl .  set ( assoc2 := rngassoc2 X ) .  apply ( assoc2 (pr1 (pr2 xs)) (pr1 (pr2 xs')) (pr1 (pr2 xs'')) ) .
 
 apply ( setquotuniv3prop R ( fun x x' x'' : setquotinset R => @eqset ( setquotinset R ) ( add1 ( add1 x x' ) x'') ( add1 x ( add1 x' x'') ) ) int ) . Defined .
 
@@ -977,7 +977,7 @@ split with ( commrngfracunit1 X S ) .  split with ( commrngfracinv1 X S ) .  app
 
 Definition prcommrngfrac ( X : commrng ) ( S : @subabmonoids ( rngmultabmonoid X ) ) : X -> S -> commrngfrac X S := fun x s => setquotpr _ ( dirprodpair x s ) .
 
-Lemma invertibilityincommrngfrac  ( X : commrng ) ( S : @subabmonoids ( rngmultabmonoid X ) ) : forall a a' : S , isinvertible ( @op2 ( commrngfrac X S ) ) ( prcommrngfrac X S ( pr1 a ) a' ) .
+Lemma invertibilityincommrngfrac  ( X : commrng ) ( S : @subabmonoids ( rngmultabmonoid X ) ) : Π a a' : S , isinvertible ( @op2 ( commrngfrac X S ) ) ( prcommrngfrac X S ( pr1 a ) a' ) .
 Proof . intros . apply ( invertibilityinabmonoidfrac ( rngmultabmonoid X ) S ) . Defined .
 
 
@@ -1029,7 +1029,7 @@ Definition isrngfuntocommrngfrac ( X : commrng ) ( S : @subabmonoids ( rngmultab
 
 Definition  hrelcommrngfrac0 ( X : commrng ) ( S : @submonoids ( rngmultabmonoid X ) ) : hrel ( dirprod X S ) :=  fun xa yb : setdirprod X S => eqset ( ( pr1 xa ) * ( pr1 ( pr2 yb ) ) )  ( ( pr1 yb ) * ( pr1 ( pr2 xa ) ) ) .
 
-Lemma weqhrelhrel0commrngfrac ( X : commrng ) ( S : @submonoids ( rngmultabmonoid X ) ) ( iscanc : forall a : S , isrcancelable ( @op2 X ) ( pr1carrier _ a ) ) ( xa xa' : dirprod X S ) : weq ( eqrelcommrngfrac X S xa xa' ) ( hrelcommrngfrac0 X S xa xa' ) .
+Lemma weqhrelhrel0commrngfrac ( X : commrng ) ( S : @submonoids ( rngmultabmonoid X ) ) ( iscanc : Π a : S , isrcancelable ( @op2 X ) ( pr1carrier _ a ) ) ( xa xa' : dirprod X S ) : weq ( eqrelcommrngfrac X S xa xa' ) ( hrelcommrngfrac0 X S xa xa' ) .
 Proof . intros .  unfold eqrelabmonoidfrac .  unfold hrelabmonoidfrac . simpl .  apply weqimplimpl .
 
 apply ( @hinhuniv _ ( eqset (pr1 xa * pr1 (pr2 xa')) (pr1 xa' * pr1 (pr2 xa)) ) ) .  intro ae .  destruct ae as [ a eq ] .  apply ( invmaponpathsincl _ ( iscanc a ) _ _ eq ) .
@@ -1038,12 +1038,12 @@ intro eq . apply hinhpr . split with ( unel S ) . rewrite ( rngrunax2 X )  .  re
 Opaque weqhrelhrel0abmonoidfrac .
 
 
-Lemma isinclprcommrngfrac ( X : commrng ) ( S : @submonoids ( rngmultabmonoid X ) ) ( iscanc : forall a : S , isrcancelable ( @op2 X ) ( pr1carrier _ a ) ) : forall a' : S , isincl ( fun x => prcommrngfrac X S x a' ) .
+Lemma isinclprcommrngfrac ( X : commrng ) ( S : @submonoids ( rngmultabmonoid X ) ) ( iscanc : Π a : S , isrcancelable ( @op2 X ) ( pr1carrier _ a ) ) : Π a' : S , isincl ( fun x => prcommrngfrac X S x a' ) .
 Proof . intros . apply isinclbetweensets . apply ( setproperty X ) .  apply ( setproperty ( commrngfrac X S ) ) .  intros x x' .   intro e .  set ( e' := invweq ( weqpathsinsetquot ( eqrelcommrngfrac X S ) ( dirprodpair x a' ) ( dirprodpair x' a' ) )  e ) . set ( e'' := weqhrelhrel0commrngfrac X S iscanc ( dirprodpair _ _ ) ( dirprodpair _ _ ) e' )  . simpl in e'' . apply ( invmaponpathsincl _ ( iscanc a' ) ) . apply e'' .  Defined .
 
-Definition isincltocommrngfrac ( X : commrng ) ( S : @submonoids ( rngmultabmonoid X ) ) ( iscanc : forall a : S , isrcancelable ( @op2 X ) ( pr1carrier _ a ) ) : isincl ( tocommrngfrac X S ) := isinclprcommrngfrac X S iscanc ( unel S ) .
+Definition isincltocommrngfrac ( X : commrng ) ( S : @submonoids ( rngmultabmonoid X ) ) ( iscanc : Π a : S , isrcancelable ( @op2 X ) ( pr1carrier _ a ) ) : isincl ( tocommrngfrac X S ) := isinclprcommrngfrac X S iscanc ( unel S ) .
 
-Lemma isdeceqcommrngfrac ( X : commrng ) ( S : @submonoids ( rngmultabmonoid  X ) ) ( iscanc : forall a : S , isrcancelable ( @op2 X ) ( pr1carrier _ a ) ) ( is : isdeceq X ) : isdeceq ( commrngfrac X S ) .
+Lemma isdeceqcommrngfrac ( X : commrng ) ( S : @submonoids ( rngmultabmonoid  X ) ) ( iscanc : Π a : S , isrcancelable ( @op2 X ) ( pr1carrier _ a ) ) ( is : isdeceq X ) : isdeceq ( commrngfrac X S ) .
 Proof . intros . apply ( isdeceqsetquot ( eqrelcommrngfrac X S ) ) .   intros xa xa' .   apply ( isdecpropweqb ( weqhrelhrel0commrngfrac X S iscanc xa xa' ) ) . apply isdecpropif  . unfold isaprop . simpl . set ( int := setproperty X (pr1 xa * pr1 (pr2 xa')) (pr1 xa' * pr1 (pr2 xa))) . simpl in int . apply int . unfold hrelcommrngfrac0 . unfold eqset .   simpl . apply ( is _ _ ) . Defined .
 
 
@@ -1052,32 +1052,32 @@ Proof . intros . apply ( isdeceqsetquot ( eqrelcommrngfrac X S ) ) .   intros xa
 
 
 
-Lemma ispartbinopcommrngfracgt ( X : commrng ) ( S : @submonoids ( rngmultabmonoid X ) ) { R : hrel X } ( is0 : @isbinophrel ( rigaddabmonoid X ) R ) ( is1 : isrngmultgt X R ) ( is2 : forall c : X , S c -> R c 0 ) : @ispartbinophrel ( rngmultabmonoid X ) S R .
+Lemma ispartbinopcommrngfracgt ( X : commrng ) ( S : @submonoids ( rngmultabmonoid X ) ) { R : hrel X } ( is0 : @isbinophrel ( rigaddabmonoid X ) R ) ( is1 : isrngmultgt X R ) ( is2 : Π c : X , S c -> R c 0 ) : @ispartbinophrel ( rngmultabmonoid X ) S R .
 Proof . intros . split .
 
 intros a b c s rab . apply ( isrngmultgttoislrngmultgt X is0 is1 _ _ _ ( is2 c s ) rab ) .
 intros a b c s rab . apply ( isrngmultgttoisrrngmultgt X is0 is1 _ _ _ ( is2 c s ) rab ) .  Defined .
 
-Definition commrngfracgt ( X : commrng ) ( S : @submonoids ( rngmultabmonoid X ) ) { R : hrel X } ( is0 : @isbinophrel ( rigaddabmonoid X ) R ) ( is1 : isrngmultgt X R ) ( is2 : forall c : X , S c -> R c 0 )  : hrel ( commrngfrac X S ) := abmonoidfracrel ( rngmultabmonoid X ) S ( ispartbinopcommrngfracgt X S is0 is1 is2 ) .
+Definition commrngfracgt ( X : commrng ) ( S : @submonoids ( rngmultabmonoid X ) ) { R : hrel X } ( is0 : @isbinophrel ( rigaddabmonoid X ) R ) ( is1 : isrngmultgt X R ) ( is2 : Π c : X , S c -> R c 0 )  : hrel ( commrngfrac X S ) := abmonoidfracrel ( rngmultabmonoid X ) S ( ispartbinopcommrngfracgt X S is0 is1 is2 ) .
 
-Lemma isrngmultcommrngfracgt ( X : commrng ) ( S : @submonoids ( rngmultabmonoid X ) ) { R : hrel X } ( is0 : @isbinophrel ( rigaddabmonoid X ) R ) ( is1 : isrngmultgt X R ) ( is2 : forall c : X , S c -> R c 0 ) : isrngmultgt ( commrngfrac X S ) ( commrngfracgt X S is0 is1 is2 ) .
-Proof . intros . set ( rer2 := ( abmonoidrer ( rngmultabmonoid X )) : forall a b c d : X , paths ( ( a * b ) * ( c * d ) ) ( ( a * c ) * ( b * d ) ) ) . apply islrngmultgttoisrngmultgt .
+Lemma isrngmultcommrngfracgt ( X : commrng ) ( S : @submonoids ( rngmultabmonoid X ) ) { R : hrel X } ( is0 : @isbinophrel ( rigaddabmonoid X ) R ) ( is1 : isrngmultgt X R ) ( is2 : Π c : X , S c -> R c 0 ) : isrngmultgt ( commrngfrac X S ) ( commrngfracgt X S is0 is1 is2 ) .
+Proof . intros . set ( rer2 := ( abmonoidrer ( rngmultabmonoid X )) : Π a b c d : X , paths ( ( a * b ) * ( c * d ) ) ( ( a * c ) * ( b * d ) ) ) . apply islrngmultgttoisrngmultgt .
 
-assert ( int : forall a b c :  (commrngfrac X S) , isaprop ( commrngfracgt X S is0 is1 is2 c 0 -> commrngfracgt X S is0 is1 is2 a b -> commrngfracgt X S is0 is1 is2 (c * a) (c * b) ) ) . intros a b c . apply impred . intro . apply impred . intro . apply ( pr2 _ ) . apply ( setquotuniv3prop _ ( fun a b c => hProppair _ ( int a b c ) ) ) . intros xa1 xa2 xa3 . change ( abmonoidfracrelint ( rngmultabmonoid X ) S R xa3 ( dirprodpair 0 ( unel S ) )  -> abmonoidfracrelint ( rngmultabmonoid X ) S R xa1 xa2 -> abmonoidfracrelint ( rngmultabmonoid X ) S R ( commrngfracop2int X S xa3 xa1 ) ( commrngfracop2int X S xa3 xa2 ) ) .  simpl . apply hinhfun2 . intros t21 t22 .  set ( c1s := pr1 t21 ) . set ( c1 := pr1 c1s ) . set ( r1 := pr2 t21 ) .   set ( c2s := pr1 t22 ) . set ( c2 := pr1 c2s ) . set ( r2 := pr2 t22 ) . set ( x1 := pr1 xa1 ) . set ( a1 := pr1 ( pr2 xa1 ) ) .  set ( x2 := pr1 xa2 ) . set ( a2 := pr1 ( pr2 xa2 ) ) .  set ( x3 := pr1 xa3 ) . set ( a3 := pr1 ( pr2 xa3 ) ) . split with ( @op S c1s c2s ) . change ( pr1 ( R ( x3 * x1 * ( a3 * a2 ) * ( c1 * c2 ) ) ( x3 * x2 * ( a3 * a1 ) * ( c1 * c2 ) ) ) ) . rewrite ( rngcomm2 X a3 a2 ) .  rewrite ( rngcomm2 X a3 a1 ) . rewrite ( rngassoc2 X _ _ ( c1 * c2 ) ) .  rewrite ( rngassoc2 X ( x3 * x2 ) _ ( c1 * c2 ) ) . rewrite ( rer2 _ a3 c1 _ ) . rewrite ( rer2 _ a3 c1 _ ) . rewrite ( rngcomm2 X a2 c1 ) . rewrite ( rngcomm2 X a1 c1 ) . rewrite ( pathsinv0 ( rngassoc2 X ( x3 * x1 ) _ _ ) ) . rewrite ( pathsinv0 ( rngassoc2 X ( x3 * x2 ) _ _ ) ) . rewrite ( rer2 _ x1 c1 _ ) .  rewrite ( rer2 _ x2 c1 _ ) . rewrite ( rngcomm2 X a3 c2 ) . rewrite ( pathsinv0 ( rngassoc2 X _ c2 a3 ) ) .  rewrite ( pathsinv0 ( rngassoc2 X _ c2 _ ) ) . apply ( ( isrngmultgttoisrrngmultgt X is0 is1 ) _ _ _ ( is2 _ ( pr2 ( pr2 xa3 ) ) ) ) .  rewrite ( rngassoc2 X _ _ c2 ) . rewrite ( rngassoc2 X _ ( x2 * a1 ) c2 ) .
+assert ( int : Π a b c :  (commrngfrac X S) , isaprop ( commrngfracgt X S is0 is1 is2 c 0 -> commrngfracgt X S is0 is1 is2 a b -> commrngfracgt X S is0 is1 is2 (c * a) (c * b) ) ) . intros a b c . apply impred . intro . apply impred . intro . apply ( pr2 _ ) . apply ( setquotuniv3prop _ ( fun a b c => hProppair _ ( int a b c ) ) ) . intros xa1 xa2 xa3 . change ( abmonoidfracrelint ( rngmultabmonoid X ) S R xa3 ( dirprodpair 0 ( unel S ) )  -> abmonoidfracrelint ( rngmultabmonoid X ) S R xa1 xa2 -> abmonoidfracrelint ( rngmultabmonoid X ) S R ( commrngfracop2int X S xa3 xa1 ) ( commrngfracop2int X S xa3 xa2 ) ) .  simpl . apply hinhfun2 . intros t21 t22 .  set ( c1s := pr1 t21 ) . set ( c1 := pr1 c1s ) . set ( r1 := pr2 t21 ) .   set ( c2s := pr1 t22 ) . set ( c2 := pr1 c2s ) . set ( r2 := pr2 t22 ) . set ( x1 := pr1 xa1 ) . set ( a1 := pr1 ( pr2 xa1 ) ) .  set ( x2 := pr1 xa2 ) . set ( a2 := pr1 ( pr2 xa2 ) ) .  set ( x3 := pr1 xa3 ) . set ( a3 := pr1 ( pr2 xa3 ) ) . split with ( @op S c1s c2s ) . change ( pr1 ( R ( x3 * x1 * ( a3 * a2 ) * ( c1 * c2 ) ) ( x3 * x2 * ( a3 * a1 ) * ( c1 * c2 ) ) ) ) . rewrite ( rngcomm2 X a3 a2 ) .  rewrite ( rngcomm2 X a3 a1 ) . rewrite ( rngassoc2 X _ _ ( c1 * c2 ) ) .  rewrite ( rngassoc2 X ( x3 * x2 ) _ ( c1 * c2 ) ) . rewrite ( rer2 _ a3 c1 _ ) . rewrite ( rer2 _ a3 c1 _ ) . rewrite ( rngcomm2 X a2 c1 ) . rewrite ( rngcomm2 X a1 c1 ) . rewrite ( pathsinv0 ( rngassoc2 X ( x3 * x1 ) _ _ ) ) . rewrite ( pathsinv0 ( rngassoc2 X ( x3 * x2 ) _ _ ) ) . rewrite ( rer2 _ x1 c1 _ ) .  rewrite ( rer2 _ x2 c1 _ ) . rewrite ( rngcomm2 X a3 c2 ) . rewrite ( pathsinv0 ( rngassoc2 X _ c2 a3 ) ) .  rewrite ( pathsinv0 ( rngassoc2 X _ c2 _ ) ) . apply ( ( isrngmultgttoisrrngmultgt X is0 is1 ) _ _ _ ( is2 _ ( pr2 ( pr2 xa3 ) ) ) ) .  rewrite ( rngassoc2 X _ _ c2 ) . rewrite ( rngassoc2 X _ ( x2 * a1 ) c2 ) .
 
 simpl in r1 . clearbody r1 . simpl in r2 . clearbody r2 . change ( pr1 ( R ( x3 * 1 * c1 ) ( 0 * a3 * c1 ) ) ) in r1 .  rewrite ( rngrunax2 _ _ ) in r1 . rewrite ( rngmult0x X _ ) in r1 . rewrite ( rngmult0x X _ ) in r1 . apply ( ( isrngmultgttoislrngmultgt X is0 is1 ) _ _ _ r1 r2 ) . Defined .
 
 Opaque isrngmultcommrngfracgt .
 
-Lemma isrngaddcommrngfracgt ( X : commrng ) ( S : @submonoids ( rngmultabmonoid X ) ) { R : hrel X } ( is0 : @isbinophrel ( rigaddabmonoid X ) R ) ( is1 : isrngmultgt X R ) ( is2 : forall c : X , S c -> R c 0 ) : @isbinophrel ( rngaddabgr ( commrngfrac X S ) ) ( commrngfracgt X S is0 is1 is2 ) .
-Proof .  intros . set ( rer2 := ( abmonoidrer ( rngmultabmonoid X )) : forall a b c d : X , paths ( ( a * b ) * ( c * d ) ) ( ( a * c ) * ( b * d ) ) ) .  apply isbinophrelif . intros a b . apply ( rngcomm1 ( commrngfrac X S )  a b ) .
+Lemma isrngaddcommrngfracgt ( X : commrng ) ( S : @submonoids ( rngmultabmonoid X ) ) { R : hrel X } ( is0 : @isbinophrel ( rigaddabmonoid X ) R ) ( is1 : isrngmultgt X R ) ( is2 : Π c : X , S c -> R c 0 ) : @isbinophrel ( rngaddabgr ( commrngfrac X S ) ) ( commrngfracgt X S is0 is1 is2 ) .
+Proof .  intros . set ( rer2 := ( abmonoidrer ( rngmultabmonoid X )) : Π a b c d : X , paths ( ( a * b ) * ( c * d ) ) ( ( a * c ) * ( b * d ) ) ) .  apply isbinophrelif . intros a b . apply ( rngcomm1 ( commrngfrac X S )  a b ) .
 
-assert ( int : forall a b c : rngaddabgr (commrngfrac X S) , isaprop ( commrngfracgt X S is0 is1 is2 a b -> commrngfracgt X S is0 is1 is2 (op c a) (op c b) ) ) . intros a b c . apply impred . intro . apply ( pr2 _ ) . apply ( setquotuniv3prop _ ( fun a b c => hProppair _ ( int a b c ) ) ) . intros xa1 xa2 xa3 . change ( abmonoidfracrelint ( rngmultabmonoid X ) S R xa1 xa2 -> abmonoidfracrelint ( rngmultabmonoid X ) S R ( commrngfracop1int X S xa3 xa1 ) ( commrngfracop1int X S xa3 xa2 ) ) . simpl . apply hinhfun .  intro t2 . set ( c0s := pr1 t2 ) . set ( c0 := pr1 c0s ) . set ( r := pr2 t2 ) . split with c0s .   set ( x1 := pr1 xa1 ) . set ( a1 := pr1 ( pr2 xa1 ) ) .  set ( x2 := pr1 xa2 ) . set ( a2 := pr1 ( pr2 xa2 ) ) .  set ( x3 := pr1 xa3 ) . set ( a3 := pr1 ( pr2 xa3 ) ) . change ( pr1 ( R ( ( a1 * x3 + a3 * x1 ) * ( a3 * a2 ) * c0 ) ( ( a2 * x3 + a3 * x2 ) * ( a3 * a1 ) * c0 ) ) ) . rewrite ( rngassoc2 X _ _ c0 ) .  rewrite ( rngassoc2 X _ ( a3 * _ ) c0 ) . rewrite ( rngrdistr X _ _ _ ) .   rewrite ( rngrdistr X _ _ _ ) . rewrite ( rer2 _ x3 _ _ ) .  rewrite ( rer2 _ x3 _ _ ) . rewrite ( rngcomm2 X a3 a2 ) . rewrite ( rngcomm2 X a3 a1 ) .  rewrite ( pathsinv0 ( rngassoc2 X a1 a2 a3 ) ) .   rewrite ( pathsinv0 ( rngassoc2 X a2 a1 a3 ) ) . rewrite ( rngcomm2 X a1 a2 ) .  apply ( ( pr1 is0 ) _ _ _ ) .  rewrite ( rngcomm2 X  a2 a3 ) .  rewrite ( rngcomm2 X  a1 a3 ) . rewrite ( rngassoc2 X a3 a2 c0 ) . rewrite ( rngassoc2 X a3 a1 c0 ) . rewrite ( rer2 _ x1 a3 _ ) . rewrite ( rer2 _ x2 a3 _ ) . rewrite ( pathsinv0 ( rngassoc2 X x1 _ _ ) ) . rewrite ( pathsinv0 ( rngassoc2 X x2 _ _ ) ) . apply ( ( isrngmultgttoislrngmultgt X is0 is1 ) _ _ _ ( is2 _ ( pr2 ( @op S ( pr2 xa3 ) ( pr2 xa3 ) ) ) ) r )  . Defined .
+assert ( int : Π a b c : rngaddabgr (commrngfrac X S) , isaprop ( commrngfracgt X S is0 is1 is2 a b -> commrngfracgt X S is0 is1 is2 (op c a) (op c b) ) ) . intros a b c . apply impred . intro . apply ( pr2 _ ) . apply ( setquotuniv3prop _ ( fun a b c => hProppair _ ( int a b c ) ) ) . intros xa1 xa2 xa3 . change ( abmonoidfracrelint ( rngmultabmonoid X ) S R xa1 xa2 -> abmonoidfracrelint ( rngmultabmonoid X ) S R ( commrngfracop1int X S xa3 xa1 ) ( commrngfracop1int X S xa3 xa2 ) ) . simpl . apply hinhfun .  intro t2 . set ( c0s := pr1 t2 ) . set ( c0 := pr1 c0s ) . set ( r := pr2 t2 ) . split with c0s .   set ( x1 := pr1 xa1 ) . set ( a1 := pr1 ( pr2 xa1 ) ) .  set ( x2 := pr1 xa2 ) . set ( a2 := pr1 ( pr2 xa2 ) ) .  set ( x3 := pr1 xa3 ) . set ( a3 := pr1 ( pr2 xa3 ) ) . change ( pr1 ( R ( ( a1 * x3 + a3 * x1 ) * ( a3 * a2 ) * c0 ) ( ( a2 * x3 + a3 * x2 ) * ( a3 * a1 ) * c0 ) ) ) . rewrite ( rngassoc2 X _ _ c0 ) .  rewrite ( rngassoc2 X _ ( a3 * _ ) c0 ) . rewrite ( rngrdistr X _ _ _ ) .   rewrite ( rngrdistr X _ _ _ ) . rewrite ( rer2 _ x3 _ _ ) .  rewrite ( rer2 _ x3 _ _ ) . rewrite ( rngcomm2 X a3 a2 ) . rewrite ( rngcomm2 X a3 a1 ) .  rewrite ( pathsinv0 ( rngassoc2 X a1 a2 a3 ) ) .   rewrite ( pathsinv0 ( rngassoc2 X a2 a1 a3 ) ) . rewrite ( rngcomm2 X a1 a2 ) .  apply ( ( pr1 is0 ) _ _ _ ) .  rewrite ( rngcomm2 X  a2 a3 ) .  rewrite ( rngcomm2 X  a1 a3 ) . rewrite ( rngassoc2 X a3 a2 c0 ) . rewrite ( rngassoc2 X a3 a1 c0 ) . rewrite ( rer2 _ x1 a3 _ ) . rewrite ( rer2 _ x2 a3 _ ) . rewrite ( pathsinv0 ( rngassoc2 X x1 _ _ ) ) . rewrite ( pathsinv0 ( rngassoc2 X x2 _ _ ) ) . apply ( ( isrngmultgttoislrngmultgt X is0 is1 ) _ _ _ ( is2 _ ( pr2 ( @op S ( pr2 xa3 ) ( pr2 xa3 ) ) ) ) r )  . Defined .
 
 Opaque isrngaddcommrngfracgt .
 
 
-Definition isdeccommrngfracgt ( X : commrng ) ( S : @submonoids ( rngmultabmonoid X ) ) { R : hrel X } ( is0 : @isbinophrel ( rigaddabmonoid X ) R ) ( is1 : isrngmultgt  X R ) ( is2 : forall c : X , S c -> R c 0 ) ( is' : @ispartinvbinophrel ( rngmultabmonoid X ) S R )  ( isd : isdecrel R ) : isdecrel ( commrngfracgt X S is0 is1 is2 ) .
+Definition isdeccommrngfracgt ( X : commrng ) ( S : @submonoids ( rngmultabmonoid X ) ) { R : hrel X } ( is0 : @isbinophrel ( rigaddabmonoid X ) R ) ( is1 : isrngmultgt  X R ) ( is2 : Π c : X , S c -> R c 0 ) ( is' : @ispartinvbinophrel ( rngmultabmonoid X ) S R )  ( isd : isdecrel R ) : isdecrel ( commrngfracgt X S is0 is1 is2 ) .
 Proof . intros . apply ( isdecabmonoidfracrel ( rngmultabmonoid X ) S ( ispartbinopcommrngfracgt X S is0 is1 is2 ) is' isd ) . Defined .
 
 
@@ -1085,7 +1085,7 @@ Proof . intros . apply ( isdecabmonoidfracrel ( rngmultabmonoid X ) S ( ispartbi
 (** **** Realations and the canonical homomorphism to the ring of fractions *)
 
 
-Definition iscomptocommrngfrac ( X : commrng ) ( S : @submonoids ( rngmultabmonoid X ) ) { L : hrel X } ( is0 : @isbinophrel ( rigaddabmonoid X ) L ) ( is1 : isrngmultgt X L ) ( is2 : forall c : X , S c -> L c 0 ) : iscomprelrelfun L ( commrngfracgt X S is0 is1 is2 ) ( tocommrngfrac X S ) := iscomptoabmonoidfrac ( rngmultabmonoid X ) S ( ispartbinopcommrngfracgt X S is0 is1 is2 ) .
+Definition iscomptocommrngfrac ( X : commrng ) ( S : @submonoids ( rngmultabmonoid X ) ) { L : hrel X } ( is0 : @isbinophrel ( rigaddabmonoid X ) L ) ( is1 : isrngmultgt X L ) ( is2 : Π c : X , S c -> L c 0 ) : iscomprelrelfun L ( commrngfracgt X S is0 is1 is2 ) ( tocommrngfrac X S ) := iscomptoabmonoidfrac ( rngmultabmonoid X ) S ( ispartbinopcommrngfracgt X S is0 is1 is2 ) .
 
 Opaque iscomptocommrngfrac .
 

--- a/UniMath/Foundations/Algebra/Tests.v
+++ b/UniMath/Foundations/Algebra/Tests.v
@@ -11,11 +11,11 @@ Module Test_assoc.
 
   Open Scope multmonoid.
 
-  Goal ∀ (M:monoid) (f:stn 3 -> M),
+  Goal Π (M:monoid) (f:stn 3 -> M),
          sequenceProduct(3,,f) = 1 * f(●O) * f(●1%nat) * f(●2).
   Proof. reflexivity. Defined.
 
-  Goal ∀ (M:monoid) (f:stn 3 -> Sequence M),
+  Goal Π (M:monoid) (f:stn 3 -> Sequence M),
          doubleProduct(3,,f) =
             1 * sequenceProduct (f(●0))
               * sequenceProduct (f(●1%nat))

--- a/UniMath/Foundations/Basics/PartA.v
+++ b/UniMath/Foundations/Basics/PartA.v
@@ -30,7 +30,7 @@ Require Export UniMath.Foundations.Basics.Preamble.
 
 (** *** Canonical functions from [ empty ] and to [ unit ] *)
 
-Definition fromempty  : ∀ X : UU , empty -> X.
+Definition fromempty  : Π X : UU , empty -> X.
 Proof.
   intro X.
   intro H.
@@ -60,18 +60,18 @@ Definition funcomp_assoc {X Y Z W : UU} (f : X -> Y) (g : Y -> Z) (h : Z -> W)
 
 (** back and forth between functions of pairs and functions returning functions *)
 
-Definition curry {X} {Y:X->UU} {Z} (f: (Σ x:X, Y x) -> Z) : ∀ x, Y x -> Z.
+Definition curry {X} {Y:X->UU} {Z} (f: (Σ x:X, Y x) -> Z) : Π x, Y x -> Z.
 Proof. intros ? ? ? ? ? y. exact (f(x,,y)). Defined.
 
-Definition uncurry {X} {Y:X->UU} {Z} (g:∀ x (y:Y x), Z) : (Σ x, Y x) -> Z.
+Definition uncurry {X} {Y:X->UU} {Z} (g:Π x (y:Y x), Z) : (Σ x, Y x) -> Z.
 Proof. intros ? ? ? ? xy. exact (g (pr1 xy) (pr2 xy)). Defined.
 
 Lemma uncurry_curry {X} {Y:X->UU} {Z} (f:(Σ x:X, Y x) -> Z):
-  ∀ p, uncurry (curry f) p = f p.
+  Π p, uncurry (curry f) p = f p.
 Proof. intros. induction p as [x y]. reflexivity. Defined.
 
-Lemma curry_uncurry {X} {Y:X->UU} {Z} (g:∀ x (y:Y x), Z) :
-  ∀ x y, curry (uncurry g) x y = g x y.
+Lemma curry_uncurry {X} {Y:X->UU} {Z} (g:Π x (y:Y x), Z) :
+  Π x y, curry (uncurry g) x y = g x y.
 Proof. reflexivity. Defined.
 
 (** *** Iteration of an endomorphism *)
@@ -361,10 +361,10 @@ Proof. intros. destruct r, s, p, q. reflexivity. Defined.
     equivalence. *)
 
 Definition maponpathshomidinv {X : UU} (f : X -> X)
-  (h : ∀ x : X, f x = x) (x x' : X) (e : f x = f x') : x = x' :=
+  (h : Π x : X, f x = x) (x x' : X) (e : f x = f x') : x = x' :=
     ! (h x) @ e @ (h x').
 
-Lemma maponpathshomid1 {X : UU} (f : X -> X) (h: ∀ x : X, f x = x)
+Lemma maponpathshomid1 {X : UU} (f : X -> X) (h: Π x : X, f x = x)
   {x x' : X} (e : x = x') : maponpaths f e = (h x) @ e @ (! h x').
 Proof.
   intros. induction e. simpl.
@@ -372,7 +372,7 @@ Proof.
   apply pathsinv0r.
 Defined.
 
-Lemma maponpathshomid2 {X : UU} (f : X -> X) (h: ∀ x : X, f x = x)
+Lemma maponpathshomid2 {X : UU} (f : X -> X) (h: Π x : X, f x = x)
   (x x' : X) (e: f x = f x') : maponpaths f (maponpathshomidinv f h _ _ e) = e.
 Proof.
   intros.
@@ -380,8 +380,8 @@ Proof.
   apply (pathscomp0 (maponpathshomid1 f h (! h x @ e @ h x'))).
 
   (* We prove a little lemma first. *)
-  assert (l : ∀ X : UU, ∀ a b c d : X,
-            ∀ p : a = b, ∀ q : a = c, ∀ r : c = d,
+  assert (l : Π X : UU, Π a b c d : X,
+            Π p : a = b, Π q : a = c, Π r : c = d,
                p @ (!p @ q @ r) @ !r = q).
   { intros. induction p. induction q. induction r. apply idpath. }
 
@@ -392,7 +392,7 @@ Defined.
     projection [ p ] with a section [ s ]. *)
 
 Definition pathssec1 {X Y : UU} (s : X -> Y) (p : Y -> X)
-  (eps : ∀ (x : X) , p (s x) = x)
+  (eps : Π (x : X) , p (s x) = x)
     (x : X) (y : Y) (e : s x = y) : x = p y.
 Proof.
   intros.
@@ -401,7 +401,7 @@ Proof.
 Defined.
 
 Definition pathssec2 {X Y : UU} (s : X -> Y) (p : Y -> X)
-  (eps : ∀ (x : X), p (s x) = x)
+  (eps : Π (x : X), p (s x) = x)
     (x x' : X) (e : s x = s x') : x = x'.
 Proof.
   intros.
@@ -410,19 +410,19 @@ Proof.
 Defined.
 
 Definition pathssec2id {X Y : UU} (s : X -> Y) (p : Y -> X)
-  (eps : ∀ x : X, p (s x) = x)
+  (eps : Π x : X, p (s x) = x)
     (x : X) : pathssec2 s p eps _ _ (idpath (s x)) = idpath x.
 Proof.
   intros.
   unfold pathssec2. unfold pathssec1. simpl.
-  assert (e : ∀ X : UU, ∀ a b : X,
-    ∀ p : a = b, (! p @ idpath _) @ p = idpath _).
+  assert (e : Π X : UU, Π a b : X,
+    Π p : a = b, (! p @ idpath _) @ p = idpath _).
   { intros. induction p0. simpl. apply idpath. }
   apply e.
 Defined.
 
 Definition pathssec3 {X Y : UU} (s : X -> Y) (p : Y -> X)
-  (eps : ∀ x : X, p (s x) = x) {x x' : X} (e : x = x') :
+  (eps : Π x : X, p (s x) = x) {x x' : X} (e : x = x') :
     pathssec2 s p eps  _ _ (maponpaths s e) = e.
 Proof.
   intros. induction e. simpl.
@@ -449,8 +449,8 @@ Defined.
 
 Definition constr1 {X : UU} (P : X -> UU) {x x' : X} (e : x = x') :
   Σ (f : P x -> P x'),
-  Σ (ee : ∀ p : P x, tpair _ x p = tpair _ x' (f p)),
-  ∀ (pp : P x),
+  Σ (ee : Π p : P x, tpair _ x p = tpair _ x' (f p)),
+  Π (pp : P x),
     maponpaths pr1 (ee pp) = e.
 Proof.
   intros. induction e.
@@ -504,11 +504,11 @@ Definition transport_b_b {X : UU} (P : X ->UU) {x y z : X} (e : x = y) (e' : y =
            (p : P z) : transportb P e (transportb P e' p) = transportb P (e @ e') p.
 Proof. intros. induction e'. induction e. reflexivity. Defined.
 
-Definition transport_map {X} {P Q:X -> UU} (f : ∀x, P x -> Q x) {x:X} {y:X} (e:x=y) (p:P x) :
+Definition transport_map {X} {P Q:X -> UU} (f : Π x, P x -> Q x) {x:X} {y:X} (e:x=y) (p:P x) :
   transportf Q e (f x p) = f y (transportf P e p).
 Proof. intros. induction e. reflexivity. Defined.
 
-Definition transport_section {X} {P:X -> UU} (f:∀ x, P x) {x:X} {y:X} (e:x=y) :
+Definition transport_section {X} {P:X -> UU} (f:Π x, P x) {x:X} {y:X} (e:x=y) :
   transportf P e (f x) = f y.
 Proof. intros. exact (transport_map (P:= λ _,unit) (λ x _,f x) e tt). Defined.
 
@@ -605,7 +605,7 @@ Defined.
     Adapted from the HoTT library and the HoTT book
 *)
 
-Definition transportD {A : UU} (B : A -> UU) (C : ∀ a : A, B a -> UU)
+Definition transportD {A : UU} (B : A -> UU) (C : Π a : A, B a -> UU)
   {x1 x2 : A} (p : x1 = x2) (y : B x1) (z : C x1 y) : C x2 (transportf _ p y).
 Proof.
   intros.
@@ -614,7 +614,7 @@ Proof.
 Defined.
 
 
-Definition transportf_total2 {A : UU} {B : A -> UU} {C : ∀ a:A, B a -> UU}
+Definition transportf_total2 {A : UU} {B : A -> UU} {C : Π a:A, B a -> UU}
   {x1 x2 : A} (p : x1 = x2) (yz : Σ y : B x1, C x1 y) :
     transportf (fun x => Σ y : B x, C x y) p yz =
      tpair (fun y => C x2 y) (transportf _ p  (pr1 yz))
@@ -661,8 +661,8 @@ Defined.
 
 (** *** Homotopy between functions *)
 
-Definition homot {X : UU} {P : X -> UU} (f g : ∀ x : X, P x) :=
-  ∀ x : X , f x = g x.
+Definition homot {X : UU} {P : X -> UU} (f g : Π x : X, P x) :=
+  Π x : X , f x = g x.
 
 Notation "f ~ g" := (homot f g) (at level 70, no associativity).
 
@@ -683,17 +683,17 @@ Definition homotfun {X Y Z : UU} {f f' : X -> Y} (h : f ~ f')
 
 (** Contractible types. *)
 
-Definition iscontr (T:UU) : UU := Σ cntr:T, ∀ t:T, t=cntr.
+Definition iscontr (T:UU) : UU := Σ cntr:T, Π t:T, t=cntr.
 
 Notation "'∃!'  x .. y , P" := (iscontr (Σ x , .. (Σ y , P) .. )) (at level 200, x binder, y binder, right associativity) : type_scope.
   (* type this in emacs in agda-input method with \ex ! *)
 
-Definition iscontrpair {T : UU} : ∀ x : T, (∀ t : T, t = x) -> iscontr T := tpair _.
+Definition iscontrpair {T : UU} : Π x : T, (Π t : T, t = x) -> iscontr T := tpair _.
 
 Definition iscontrpr1 {T : UU} : iscontr T -> T := pr1.
 
 Lemma iscontrretract {X Y : UU} (p : X -> Y) (s : Y -> X)
-  (eps : ∀ y : Y, p (s y) = y) (is : iscontr X) : iscontr Y.
+  (eps : Π y : Y, p (s y) = y) (is : iscontr X) : iscontr Y.
 Proof.
   intros.
   induction is as [x fe].
@@ -862,7 +862,7 @@ Definition tococonusf {X Y : UU} (f : X -> Y) : X -> coconusf f :=
   fun (x : _) => tpair _ (f x) (hfiberpair f x (idpath _ )).
 
 Lemma homottofromcoconusf {X Y : UU} (f : X -> Y) :
-  ∀ yxe : coconusf f, tococonusf f (fromcoconusf f yxe) = yxe.
+  Π yxe : coconusf f, tococonusf f (fromcoconusf f yxe) = yxe.
 Proof.
   intros.
   induction yxe as [y xe].
@@ -875,7 +875,7 @@ Proof.
 Defined.
 
 Lemma homotfromtococonusf {X Y : UU} (f : X -> Y) :
-  ∀ x : X, fromcoconusf f (tococonusf f x) = x.
+  Π x : X, fromcoconusf f (tococonusf f x) = x.
 Proof.
   intros.
   unfold fromcoconusf.
@@ -914,7 +914,7 @@ Defined.
 (** *** Basics *)
 
 Definition isweq {X Y : UU} (f : X -> Y) : UU :=
-  ∀ y : Y, iscontr (hfiber f y).
+  Π y : Y, iscontr (hfiber f y).
 
 Lemma idisweq (T : UU) : isweq (idfun T).
 Proof.
@@ -943,7 +943,7 @@ Proof.
 Defined.
 
 Definition weqccontrhfiber2 {X Y : UU} (w : X ≃ Y) (y : Y) :
-  ∀ x : hfiber w y, x = weqccontrhfiber w y.
+  Π x : hfiber w y, x = weqccontrhfiber w y.
 Proof.
   intros. unfold weqccontrhfiber. apply (pr2 (pr2 w y)).
 Defined.
@@ -983,7 +983,7 @@ Definition invmap {X Y : UU} (w : X ≃ Y) : Y -> X :=
     corrected in order for lemma [ homotweqinvweqweq ] to hold. *)
 
 Definition homotweqinvweq {X Y : UU} (w : X ≃ Y) :
-  ∀ y : Y, w (invmap w y) = y.
+  Π y : Y, w (invmap w y) = y.
 Proof.
   intros.
   unfold invmap.
@@ -991,7 +991,7 @@ Proof.
 Defined.
 
 Definition homotinvweqweq0 {X Y : UU} (w : X ≃ Y) :
- ∀ x : X, x = invmap w (w x).
+ Π x : X, x = invmap w (w x).
 Proof.
   intros.
   unfold invmap.
@@ -1002,7 +1002,7 @@ Proof.
 Defined.
 
 Definition homotinvweqweq {X Y : UU} (w : X ≃ Y) :
-  ∀ x : X, invmap w (w x) = x :=
+  Π x : X, invmap w (w x) = x :=
     fun (x : X) => ! (homotinvweqweq0 w x).
 
 Lemma diaglemma2 {X Y : UU} (f : X -> Y) {x x' : X}
@@ -1137,7 +1137,7 @@ Defined.
 (** [ unit ] is contractible (recall that [ tt ] is the name of the
     canonical term of the type [ unit ]). *)
 
-Lemma isconnectedunit : ∀ x x' : unit, x = x'.
+Lemma isconnectedunit : Π x x' : unit, x = x'.
 Proof.
   intros. induction x. induction x'. apply idpath.
 Defined.
@@ -1152,12 +1152,12 @@ Proof.
   intro cp. induction cp as [x t]. induction x. apply t.
 Defined.
 
-Lemma unitl2: ∀ e : tt = tt, unitl1 (unitl0 e) = e.
+Lemma unitl2: Π e : tt = tt, unitl1 (unitl0 e) = e.
 Proof.
   intros. unfold unitl0. simpl. apply idpath.
 Defined.
 
-Lemma unitl3: ∀ e : tt = tt, e = idpath tt.
+Lemma unitl3: Π e : tt = tt, e = idpath tt.
 Proof.
   intros.
 
@@ -1228,7 +1228,7 @@ Definition hfibersgftog {X Y Z : UU} (f : X -> Y) (g : Y -> Z) (z : Z)
     hfiberpair g (f (pr1 xe)) (pr2 xe).
 
 Lemma constr2 {X Y : UU} (f : X -> Y) (g : Y -> X)
-  (efg: ∀ y : Y, f (g y) = y) (x0 : X) (xe : hfiber g x0) :
+  (efg: Π y : Y, f (g y) = y) (x0 : X) (xe : hfiber g x0) :
     Σ xe' : hfiber (g ∘ f) x0, xe = hfibersgftog f g x0 xe'.
 Proof.
   intros.
@@ -1245,7 +1245,7 @@ Proof.
 Defined.
 
 Lemma iscontrhfiberl1 {X Y : UU} (f : X -> Y) (g : Y -> X)
-  (efg: ∀ y : Y, f (g y) = y) (x0 : X)
+  (efg: Π y : Y, f (g y) = y) (x0 : X)
     (is : iscontr (hfiber (g ∘ f) x0)) : iscontr (hfiber g x0).
 Proof.
   intros.
@@ -1284,7 +1284,7 @@ Proof.
   simpl.
 
   (* Now, a little lemma: *)
-  assert (ee : ∀ a b c : Y, ∀ p : a = b, ∀ q : b = c,
+  assert (ee : Π a b c : Y, Π p : a = b, Π q : b = c,
     !p @ (p @ q) = q).
   { intros. induction p. induction q. apply idpath. }
 
@@ -1328,14 +1328,14 @@ Proof.
 Defined.
 
 Theorem gradth {X Y : UU} (f : X -> Y) (g : Y -> X)
-  (egf: ∀ x : X, g (f x) = x)
-  (efg: ∀ y : Y, f (g y) = y) : isweq f.
+  (egf: Π x : X, g (f x) = x)
+  (efg: Π y : Y, f (g y) = y) : isweq f.
 Proof.
   intros.
   unfold isweq.
   intro y.
   assert (iscontr (hfiber (f ∘ g) y)).
-  assert (efg' : ∀ y : Y, y = f (g y)).
+  assert (efg' : Π y : Y, y = f (g y)).
   { intro y0.
     apply pathsinv0.
     apply (efg y0). }
@@ -1345,12 +1345,12 @@ Proof.
 Defined.
 
 Definition weqgradth {X Y : UU} (f : X -> Y) (g : Y -> X)
-  (egf: ∀ x : X, g (f x) = x)
-  (efg: ∀ y : Y, f (g y) = y) : X ≃ Y :=
+  (egf: Π x : X, g (f x) = x)
+  (efg: Π y : Y, f (g y) = y) : X ≃ Y :=
     weqpair _ (gradth _ _ egf efg).
 
 Definition bijective {X Y:UU} (f:X->Y) :=
-  (∀ y, Σ x, f x = y) × (∀ x x', f x = f x' -> x = x').
+  (Π y, Σ x, f x = y) × (Π x x', f x = f x' -> x = x').
 
 Corollary bijection_to_weq {X Y:UU} (f:X->Y) : bijective f -> isweq f.
 Proof.
@@ -1366,9 +1366,9 @@ Defined.
 Corollary isweqinvmap {X Y : UU} (w : weq X Y) : isweq (invmap w).
 Proof.
   intros.
-  assert (efg : ∀ (y : Y), w (invmap w y) = y).
+  assert (efg : Π (y : Y), w (invmap w y) = y).
   apply homotweqinvweq.
-  assert (egf : ∀ (x : X), invmap w (w x) = x).
+  assert (egf : Π (x : X), invmap w (w x) = x).
   apply homotinvweqweq.
   apply (gradth _ _ efg egf).
 Defined.
@@ -1424,9 +1424,9 @@ Proof.
   set (f := fun (t : unit) => pr1 is).
   set (g := fun (x : X) => tt).
   split with f.
-  assert (egf : ∀ t : unit, g (f t) = t).
+  assert (egf : Π t : unit, g (f t) = t).
   { intro. induction t. apply idpath. }
-  assert (efg : ∀ x : X, f (g x) = x).
+  assert (efg : Π x : X, f (g x) = x).
   { intro. apply (! (pr2 is x)). }
   apply (gradth _ _ egf efg).
 Defined.
@@ -1465,9 +1465,9 @@ Proof.
   intros.
   set (f := fun (e : x = x') => e @ e').
   set (g := fun (e'' : x = x'') => e'' @ (! e')).
-  assert (egf : ∀ e : _, g (f e) = e).
+  assert (egf : Π e : _, g (f e) = e).
   { intro e. induction e. induction e'. apply idpath. }
-  assert (efg : ∀ e : _, f (g e) = e).
+  assert (efg : Π e : _, f (g e) = e).
   { intro e. induction e. induction e'. apply idpath. }
   apply (gradth f g egf efg).
 Defined.
@@ -1494,9 +1494,9 @@ Corollary isweqdeltap (T : UU) : isweq (deltap T).
 Proof.
   intros.
   set (ff := deltap T). set (gg := fun (z : pathsspace T) => pr1 z).
-  assert (egf : ∀ t : T, gg (ff t) = t).
+  assert (egf : Π t : T, gg (ff t) = t).
   { intro. apply idpath. }
-  assert (efg : ∀ (tte : _), ff (gg tte) = tte).
+  assert (efg : Π (tte : _), ff (gg tte) = tte).
   { intro tte. induction tte as [t c].
     induction c as [x e]. induction e.
     apply idpath.
@@ -1513,9 +1513,9 @@ Proof.
   set (f := fun (a : pathsspace' T) => pr1 (pr1 a)).
   set (g := fun (t : T) =>
               tpair _ (dirprodpair t t) (idpath t) : pathsspace' T).
-  assert (efg : ∀ t : T, f (g t) = t).
+  assert (efg : Π t : T, f (g t) = t).
   { intros t. unfold f. unfold g. simpl. apply idpath. }
-  assert (egf : ∀ a : _, g (f a) = a).
+  assert (egf : Π a : _, g (f a) = a).
   { intros a. induction a as [xy e].
     induction xy as [x y]. simpl in e.
     induction e. unfold f. unfold g.
@@ -1551,7 +1551,7 @@ Proof.
 
   split with ff.
 
-  assert (effgg : ∀ xe : _, ff (gg xe) = xe).
+  assert (effgg : Π xe : _, ff (gg xe) = xe).
   {
     intro xe.
     induction xe as [x e].
@@ -1563,7 +1563,7 @@ Proof.
     apply (hfibertriangle2 g xe1 xe2 (idpath x) eee).
   }
 
-  assert (eggff : ∀ xe : _, gg (ff xe) = xe).
+  assert (eggff : Π xe : _, gg (ff xe) = xe).
   {
     intro xe.
     induction xe as [x e].
@@ -1595,7 +1595,7 @@ Proof.
 
   set (invf := invgf ∘ g).
 
-  assert (efinvf : ∀ y : Y, f (invf y) = y).
+  assert (efinvf : Π y : Y, f (invf y) = y).
   {
     intro y.
     assert (int1 : g (f (invf y)) = g y).
@@ -1603,7 +1603,7 @@ Proof.
     apply (invmaponpathsweq gw _ _  int1).
   }
 
-  assert (einvff: ∀ x : X, invf (f x) = x).
+  assert (einvff: Π x : X, invf (f x) = x).
   { intro. unfold invf. apply (homotinvweqweq gfw x). }
 
   apply (gradth f invf einvff efinvf).
@@ -1631,10 +1631,10 @@ Proof.
 
   set (invg := f ∘ invgf).
 
-  assert (eginvg : ∀ z : Z, g (invg z) = z).
+  assert (eginvg : Π z : Z, g (invg z) = z).
   { intro. unfold invg. apply (homotweqinvweq wgf z). }
 
-  assert (einvgg : ∀ y : Y, invg (g y) = y).
+  assert (einvgg : Π y : Y, invg (g y) = y).
   { intro. unfold invg.
 
     assert (isinvf: isweq invf).
@@ -1671,7 +1671,7 @@ Proof.
 Defined.
 
 Lemma isweql3 {X Y : UU} (f : X -> Y) (g : Y -> X)
-  (egf: ∀ x : X, g (f x) = x): isweq f -> isweq g.
+  (egf: Π x : X, g (f x) = x): isweq f -> isweq g.
 Proof.
   intros X Y f g egf w.
   assert (int1 : isweq (g ∘ f)).
@@ -1694,7 +1694,7 @@ Proof.
   set (gf := g ∘ f).
   set (invgf := invf ∘ invg).
 
-  assert (egfinvgf : ∀ x : X, invgf (gf x) = x).
+  assert (egfinvgf : Π x : X, invgf (gf x) = x).
   {
     intros x.
     assert (int1 : invf (invg (g (f x))) = invf (f x)).
@@ -1705,7 +1705,7 @@ Proof.
     apply int2.
   }
 
-  assert (einvgfgf : ∀ z : Z, gf (invgf z) = z).
+  assert (einvgfgf : Π z : Z, gf (invgf z) = z).
   {
     intros z.
     assert (int1 : g (f (invgf z)) = g (invg z)).
@@ -1843,8 +1843,8 @@ Defined .
 
 Theorem weqtotal2asstor { X : UU } ( P : X -> UU ) ( Q : total2 P -> UU ) : weq ( total2 Q ) ( Σ x : X, Σ p : P x, Q ( tpair P x p ) ).
 Proof. intros . set ( f := total2asstor P Q ) . set ( g:= total2asstol P Q ) .  split with f .
-assert ( egf : ∀ xpq : _ , ( g ( f xpq ) ) = xpq ) . intro . induction xpq as [ xp q ] . induction xp as [ x p ] . apply idpath .
-assert ( efg : ∀ xpq : _ , ( f ( g xpq ) ) = xpq ) . intro . induction xpq as [ x pq ] . induction pq as [ p q ] . apply idpath .
+assert ( egf : Π xpq : _ , ( g ( f xpq ) ) = xpq ) . intro . induction xpq as [ xp q ] . induction xp as [ x p ] . apply idpath .
+assert ( efg : Π xpq : _ , ( f ( g xpq ) ) = xpq ) . intro . induction xpq as [ x pq ] . induction pq as [ p q ] . apply idpath .
 apply ( gradth _ _ egf efg ) . Defined.
 
 Definition weqtotal2asstol { X : UU } ( P : X -> UU ) ( Q : total2 P -> UU ) : weq ( Σ x : X, Σ p : P x, Q ( tpair P x p ) ) ( total2 Q ) := invweq ( weqtotal2asstor P Q ) .
@@ -1858,8 +1858,8 @@ Definition weqdirprodasstol ( X Y Z : UU ) : weq  ( dirprod X ( dirprod Y Z ) ) 
 
 Definition weqdirprodcomm ( X Y : UU ) : weq ( dirprod X Y ) ( dirprod Y X ) .
 Proof. intros . set ( f := fun xy : dirprod X Y => dirprodpair ( pr2 xy ) ( pr1 xy ) ) . set ( g := fun yx : dirprod Y X => dirprodpair ( pr2 yx ) ( pr1 yx ) ) .
-assert ( egf : ∀ xy : _ , ( g ( f xy ) ) = xy ) . intro . induction xy . apply idpath .
-assert ( efg : ∀ yx : _ , ( f ( g yx ) ) = yx ) . intro . induction yx . apply idpath .
+assert ( egf : Π xy : _ , ( g ( f xy ) ) = xy ) . intro . induction xy . apply idpath .
+assert ( efg : Π yx : _ , ( f ( g yx ) ) = yx ) . intro . induction yx . apply idpath .
 split with f . apply ( gradth _ _ egf  efg ) . Defined .
 
 Definition weqtotal2dirprodcomm {X Y:UU} (P: X × Y -> UU) : (Σ xy : X×Y, P xy) ≃ (Σ xy : Y×X, P (weqdirprodcomm _ _ xy)).
@@ -1915,8 +1915,8 @@ Proof. intros X Y Z X0. induction X0 as [ d | d ].  induction d as [ t x ]. appl
 
 Theorem isweqrdistrtoprod (X Y Z:UU): isweq (rdistrtoprod X Y Z).
 Proof. intros. set (f:= rdistrtoprod X Y Z). set (g:= rdistrtocoprod X Y Z).
-assert (egf: ∀ a:_, (g (f a)) = a).  intro. induction a as [ d | d ] . induction d. apply idpath. induction d. apply idpath.
-assert (efg: ∀ a:_, (f (g a)) = a). intro. induction a as [ t x ]. induction x.  apply idpath. apply idpath.
+assert (egf: Π a:_, (g (f a)) = a).  intro. induction a as [ d | d ] . induction d. apply idpath. induction d. apply idpath.
+assert (efg: Π a:_, (f (g a)) = a). intro. induction a as [ t x ]. induction x.  apply idpath. apply idpath.
 apply (gradth  f g egf efg). Defined.
 
 Definition weqrdistrtoprod (X Y Z: UU):= weqpair  _ (isweqrdistrtoprod X Y Z).
@@ -1942,7 +1942,7 @@ Theorem weqtotal2overcoprod {X Y : UU} (P : X ⨿ Y -> UU) :
 Proof.
   intros. set (f := fromtotal2overcoprod P). set (g := tototal2overcoprod P).
   split with f.
-  assert (egf : ∀ a : _ , (g (f a)) = a).
+  assert (egf : Π a : _ , (g (f a)) = a).
   { intro a.
     induction a as [ xy p ].
     induction xy as [ x | y ].
@@ -1950,7 +1950,7 @@ Proof.
     apply idpath.
     simpl.
     apply idpath. }
-  assert (efg : ∀ a : _ , (f (g a)) = a).
+  assert (efg : Π a : _ , (f (g a)) = a).
   { intro a.
     induction a as [ xp | yp ].
     induction xp as [ x p ].
@@ -1966,16 +1966,16 @@ Defined.
 
 Theorem isweqdirprodf { X Y X' Y' : UU } ( w : X ≃ Y )( w' : weq X' Y' ) : isweq (dirprodf w w' ).
 Proof. intros. set ( f := dirprodf w w' ) . set ( g := dirprodf ( invweq w ) ( invweq w' ) ) .
-assert ( egf : ∀ a : _ , ( g ( f a ) ) = a ) . intro a . induction a as [ x x' ] .  simpl .   apply pathsdirprod . apply ( homotinvweqweq w x ) .  apply ( homotinvweqweq w' x' ) .
-assert ( efg : ∀ a : _ , ( f ( g a ) ) = a ) . intro a . induction a as [ x x' ] .  simpl .   apply pathsdirprod . apply ( homotweqinvweq w x ) .  apply ( homotweqinvweq w' x' ) .
+assert ( egf : Π a : _ , ( g ( f a ) ) = a ) . intro a . induction a as [ x x' ] .  simpl .   apply pathsdirprod . apply ( homotinvweqweq w x ) .  apply ( homotinvweqweq w' x' ) .
+assert ( efg : Π a : _ , ( f ( g a ) ) = a ) . intro a . induction a as [ x x' ] .  simpl .   apply pathsdirprod . apply ( homotweqinvweq w x ) .  apply ( homotweqinvweq w' x' ) .
 apply ( gradth _ _ egf efg ) . Defined .
 
 Definition weqdirprodf { X Y X' Y' : UU } ( w : X ≃ Y ) ( w' : weq X' Y' ) := weqpair _ ( isweqdirprodf w w' ) .
 
 Definition weqtodirprodwithunit (X:UU): weq X (dirprod X unit).
 Proof. intros. set (f:=fun x:X => dirprodpair x tt). split with f.  set (g:= fun xu:dirprod X unit => pr1  xu).
-assert (egf: ∀ x:X, (g (f x)) = x). intro. apply idpath.
-assert (efg: ∀ xu:_, (f (g xu)) = xu). intro. induction xu as  [ t x ]. induction x. apply idpath.
+assert (egf: Π x:X, (g (f x)) = x). intro. apply idpath.
+assert (efg: Π xu:_, (f (g xu)) = xu). intro. induction xu as  [ t x ]. induction x. apply idpath.
 apply (gradth  f g egf efg). Defined.
 
 
@@ -1995,8 +1995,8 @@ Definition sumofmaps {X Y Z:UU}(fx: X -> Z)(fy: Y -> Z): (X ⨿ Y) -> Z := fun x
 Definition boolascoprod: unit ⨿ unit ≃ bool.
 Proof. set (f:= fun xx: coprod unit unit => match xx with ii1 t => true | ii2 t => false end). split with f.
 set (g:= fun t:bool => match t with true => ii1  tt | false => ii2  tt end).
-assert (egf: ∀ xx:_, (g (f xx)) = xx). intro xx .  induction xx as [ u | u ] . induction u. apply idpath. induction u. apply idpath.
-assert (efg: ∀ t:_, (f (g t)) = t). induction t. apply idpath. apply idpath.
+assert (egf: Π xx:_, (g (f xx)) = xx). intro xx .  induction xx as [ u | u ] . induction u. apply idpath. induction u. apply idpath.
+assert (efg: Π t:_, (f (g t)) = t). induction t. apply idpath. apply idpath.
 apply (gradth  f g egf efg). Defined.
 
 
@@ -2016,8 +2016,8 @@ Proof. intros. intros [[x|y]|z]; reflexivity. Defined.
 
 Theorem isweqcoprodasstor (X Y Z:UU): isweq (coprodasstor X Y Z).
 Proof. intros. set (f:= coprodasstor X Y Z). set (g:= coprodasstol X Y Z).
-assert (egf: ∀ xyz:_, (g (f xyz)) = xyz). intro xyz. induction xyz as [ c | z ] .  induction c. apply idpath. apply idpath. apply idpath.
-assert (efg: ∀ xyz:_, (f (g xyz)) = xyz). intro xyz.  induction xyz as [ x | c ] .  apply idpath.  induction c. apply idpath. apply idpath.
+assert (egf: Π xyz:_, (g (f xyz)) = xyz). intro xyz. induction xyz as [ c | z ] .  induction c. apply idpath. apply idpath. apply idpath.
+assert (efg: Π xyz:_, (f (g xyz)) = xyz). intro xyz.  induction xyz as [ x | c ] .  apply idpath.  induction c. apply idpath. apply idpath.
 apply (gradth  f g egf efg). Defined.
 
 Definition weqcoprodasstor ( X Y Z : UU ) := weqpair _ ( isweqcoprodasstor X Y Z ) .
@@ -2031,24 +2031,24 @@ Definition coprodcomm (X Y:UU): X ⨿ Y -> Y ⨿ X := fun xy:_ => match xy with 
 
 Theorem isweqcoprodcomm (X Y:UU): isweq (coprodcomm X Y).
 Proof. intros. set (f:= coprodcomm X Y). set (g:= coprodcomm Y X).
-assert (egf: ∀ xy:_, (g (f xy)) = xy). intro. induction xy. apply idpath. apply idpath.
-assert (efg: ∀ yx:_, (f (g yx)) = yx). intro. induction yx. apply idpath. apply idpath.
+assert (egf: Π xy:_, (g (f xy)) = xy). intro. induction xy. apply idpath. apply idpath.
+assert (efg: Π yx:_, (f (g yx)) = yx). intro. induction yx. apply idpath. apply idpath.
 apply (gradth  f g egf efg). Defined.
 
 Definition weqcoprodcomm (X Y:UU):= weqpair  _ (isweqcoprodcomm X Y).
 
 Theorem isweqii1withneg  (X : UU) { Y : UU } (nf:Y -> empty): isweq (@ii1 X Y).
 Proof. intros. set (f:= @ii1 X Y). set (g:= fun xy:X ⨿ Y => match xy with ii1 x => x | ii2 y => fromempty (nf y) end).
-assert (egf: ∀ x:X, (g (f x)) = x). intro. apply idpath.
-assert (efg: ∀ xy: X ⨿ Y, (f (g xy)) = xy). intro. induction xy as [ x | y ] . apply idpath. apply (fromempty (nf y)).
+assert (egf: Π x:X, (g (f x)) = x). intro. apply idpath.
+assert (efg: Π xy: X ⨿ Y, (f (g xy)) = xy). intro. induction xy as [ x | y ] . apply idpath. apply (fromempty (nf y)).
 apply (gradth  f g egf efg). Defined.
 
 Definition weqii1withneg ( X : UU ) { Y : UU } ( nf : ¬ Y ) := weqpair _ ( isweqii1withneg X nf ) .
 
 Theorem isweqii2withneg  { X  : UU } ( Y : UU ) (nf : X -> empty): isweq (@ii2 X Y).
 Proof. intros. set (f:= @ii2 X Y). set (g:= fun xy:X ⨿ Y => match xy with ii1 x => fromempty (nf x) | ii2 y => y end).
-assert (egf: ∀ y : Y, (g (f y)) = y). intro. apply idpath.
-assert (efg: ∀ xy: X ⨿ Y, (f (g xy)) = xy). intro. induction xy as [ x | y ] . apply (fromempty (nf x)).  apply idpath.
+assert (egf: Π y : Y, (g (f y)) = y). intro. apply idpath.
+assert (efg: Π xy: X ⨿ Y, (f (g xy)) = xy). intro. induction xy as [ x | y ] . apply (fromempty (nf x)).  apply idpath.
 apply (gradth  f g egf efg). Defined.
 
 Definition weqii2withneg { X : UU } ( Y : UU ) ( nf : ¬ X ) := weqpair _ ( isweqii2withneg Y nf ) .
@@ -2071,8 +2071,8 @@ Definition homotcoprodfhomot { X X' Y Y' } ( f g : X -> Y ) ( f' g' : X' -> Y' )
 
 Theorem isweqcoprodf { X Y X' Y' : UU } ( w : weq X X' )( w' : weq Y Y' ) : isweq (coprodf w w' ).
 Proof. intros. set (finv:= invmap w ). set (ginv:= invmap w' ). set (ff:=coprodf w w' ). set (gg:=coprodf   finv ginv).
-assert (egf: ∀ xy: X ⨿ Y, (gg (ff xy)) = xy). intro. induction xy as [ x | y ] . simpl. apply (maponpaths (@ii1 X Y)  (homotinvweqweq w x)).     apply (maponpaths (@ii2 X Y)  (homotinvweqweq w' y)).
-assert (efg: ∀ xy': coprod X' Y', (ff (gg xy')) = xy'). intro. induction xy' as [ x | y ] . simpl.  apply (maponpaths (@ii1 X' Y')  (homotweqinvweq w x)).     apply (maponpaths (@ii2 X' Y')  (homotweqinvweq w' y)).
+assert (egf: Π xy: X ⨿ Y, (gg (ff xy)) = xy). intro. induction xy as [ x | y ] . simpl. apply (maponpaths (@ii1 X Y)  (homotinvweqweq w x)).     apply (maponpaths (@ii2 X Y)  (homotinvweqweq w' y)).
+assert (efg: Π xy': coprod X' Y', (ff (gg xy')) = xy'). intro. induction xy' as [ x | y ] . simpl.  apply (maponpaths (@ii1 X' Y')  (homotweqinvweq w x)).     apply (maponpaths (@ii2 X' Y')  (homotweqinvweq w' y)).
 apply (gradth  ff gg egf efg). Defined.
 
 Definition weqcoprodf { X Y X' Y' : UU } : X≃X' -> Y≃Y' -> X ⨿ Y ≃ X' ⨿ Y'.
@@ -2135,13 +2135,13 @@ Theorem saying that if a fibration has only one non-empty fiber then the total s
 
 
 
-Theorem onefiber { X : UU } (P:X -> UU) (x:X) (c: ∀ x':X, (x = x') ⨿ ¬ P x') : isweq (λ p, tpair P x p).
+Theorem onefiber { X : UU } (P:X -> UU) (x:X) (c: Π x':X, (x = x') ⨿ ¬ P x') : isweq (λ p, tpair P x p).
 Proof. intros.
 
 set (f:= fun p: P x => tpair _ x p).
 
 set (cx := c x).
-transparent assert (cnew : (∀ x' : X, (x = x') ⨿ ¬ P x')).
+transparent assert (cnew : (Π x' : X, (x = x') ⨿ ¬ P x')).
   { intro x'. refine (coprod_rect (fun _ => _) _ _ (cx)).
   - intro x0. refine (coprod_rect (fun _ => _) _ _ (c x')).
     + intro ee. apply ii1; exact (pathscomp0 (pathsinv0 x0) ee).
@@ -2155,7 +2155,7 @@ ii2 phi =>  fromempty (phi (pr2  pp))
 end).
 
 
-assert (efg: ∀ pp: total2 P, (f (g pp)) = pp).  intro. induction pp as [ t x0 ]. set (cnewt:= cnew t).  unfold g. unfold f. simpl. change (cnew t) with cnewt. induction cnewt as [ x1 | y ].  apply (pathsinv0 (pr1  (pr2  (constr1 P (pathsinv0 x1))) x0)). induction (y x0).
+assert (efg: Π pp: total2 P, (f (g pp)) = pp).  intro. induction pp as [ t x0 ]. set (cnewt:= cnew t).  unfold g. unfold f. simpl. change (cnew t) with cnewt. induction cnewt as [ x1 | y ].  apply (pathsinv0 (pr1  (pr2  (constr1 P (pathsinv0 x1))) x0)). induction (y x0).
 
 set (cnewx:= cnew x).
 assert (e1: (cnew x) = cnewx). apply idpath.
@@ -2163,7 +2163,7 @@ unfold cnew in cnewx. change (c x) with cx in cnewx.
 induction cx as [ x0 | e0 ].
 assert (e: (cnewx) = (ii1  (idpath x))).  apply (maponpaths (@ii1 (x = x) (P x -> empty))  (pathsinv0l x0)).
 
-assert (egf: ∀ p: P x, (g (f p)) = p).  intro. simpl in g. unfold g.  unfold f.   simpl.
+assert (egf: Π p: P x, (g (f p)) = p).  intro. simpl in g. unfold g.  unfold f.   simpl.
 
 set (ff:= fun cc:coprod (x = x) (P x -> empty) =>
 match cc with
@@ -2213,8 +2213,8 @@ end).
 
 Theorem isweqcoprodtoboolsum (X Y:UU): isweq (coprodtoboolsum X Y).
 Proof. intros. set (f:= coprodtoboolsum X Y). set (g:= boolsumtocoprod X Y).
-assert (egf: ∀ xy: X ⨿ Y , (g (f xy)) = xy). induction xy. apply idpath. apply idpath.
-assert (efg: ∀ xy: total2 (boolsumfun X Y), (f (g xy)) = xy). intro. induction xy as [ t x ]. induction t.  apply idpath. apply idpath. apply (gradth  f g egf efg). Defined.
+assert (egf: Π xy: X ⨿ Y , (g (f xy)) = xy). induction xy. apply idpath. apply idpath.
+assert (efg: Π xy: total2 (boolsumfun X Y), (f (g xy)) = xy). intro. induction xy as [ t x ]. induction t.  apply idpath. apply idpath. apply (gradth  f g egf efg). Defined.
 
 Definition weqcoprodtoboolsum ( X Y : UU ) := weqpair _ ( isweqcoprodtoboolsum X Y ) .
 
@@ -2281,7 +2281,7 @@ Proof. intros x ne . induction (boolchoice x) as [t | f].  apply t . induction (
 
 The group of constructions related to fibration sequences forms one of the most important computational toolboxes of homotopy theory .
 
-Given a pair of functions [ ( f : X -> Y ) ( g : Y -> Z ) ] and a point [ z : Z ] , a structure of the complex on such a triple is a homotopy from the composition [ funcomp f g ] to the constant function [ X -> Z ] corresponding to [ z ] i.e. a term [ ez : ∀ x:X, ( g ( f x ) ) = z ]. Specifing such a structure is essentially equivalent to specifing a structure of the form [ ezmap : X -> hfiber g z ]. The mapping in one direction is given in the definition of [ ezmap ] below. The mapping in another is given by [ f := fun x : X => pr1 ( ezmap x ) ] and [ ez := fun x : X => pr2 ( ezmap x ) ].
+Given a pair of functions [ ( f : X -> Y ) ( g : Y -> Z ) ] and a point [ z : Z ] , a structure of the complex on such a triple is a homotopy from the composition [ funcomp f g ] to the constant function [ X -> Z ] corresponding to [ z ] i.e. a term [ ez : Π x:X, ( g ( f x ) ) = z ]. Specifing such a structure is essentially equivalent to specifing a structure of the form [ ezmap : X -> hfiber g z ]. The mapping in one direction is given in the definition of [ ezmap ] below. The mapping in another is given by [ f := fun x : X => pr1 ( ezmap x ) ] and [ ez := fun x : X => pr2 ( ezmap x ) ].
 
 A complex is called a fibration sequence if [ ezmap ] is a weak equivalence. Correspondingly, the structure of a fibration sequence on [ f g z ] is a pair [ ( ez , is ) ] where [ is : isweq ( ezmap f g z ez ) ]. For a fibration sequence [ f g z fs ]  where [ fs : fibseqstr f g z ] and any [ y : Y ] there is defined a function [ diff1 : ( g y ) = z -> X ] and a structure of the fibration sequence [ fibseqdiff1 ] on the triple [ diff1 g y ]. This new fibration sequence is called the derived fibration sequence of the original one.
 
@@ -2301,7 +2301,7 @@ There are three important special cases in which fibration sequences arise:
 
 (** The structure of a complex structure on a composable pair of functions [ ( f : X -> Y ) ( g : Y -> Z ) ] relative to a term [ z : Z ]. *)
 
-Definition complxstr  { X Y Z : UU } (f:X -> Y) (g:Y->Z) ( z : Z ) := ∀ x:X, (g (f x)) = z .
+Definition complxstr  { X Y Z : UU } (f:X -> Y) (g:Y->Z) ( z : Z ) := Π x:X, (g (f x)) = z .
 
 
 
@@ -2336,8 +2336,8 @@ end.
 
 Theorem isweqezmap1 { X Y Z : UU } ( f : X -> Y ) ( g : Y -> Z ) ( z : Z ) ( fs : fibseqstr f g z ) ( y : Y ) : isweq ( ezmap1 f g z fs y ) .
 Proof . intros . set ( ff := ezmap1 f g z fs y ) . set ( gg := invezmap1 f g z ( pr1 fs ) y ) .
-assert ( egf : ∀ e : _ , ( gg ( ff e ) ) = e ) . intro .  simpl . apply ( hfibertriangle1inv0 g (homotweqinvweq (ezweq f g z fs) (hfiberpair g y e)) ) .
-assert ( efg : ∀ xe : _ , ( ff ( gg xe ) ) = xe ) . intro .  induction xe as [ x e ] .  induction e .  simpl . unfold ff . unfold ezmap1 . unfold d1 .   change (hfiberpair g (f x) ( pr1 fs x) ) with ( ezmap f g z fs x ) .  apply ( hfibertriangle2 f ( hfiberpair f ( invmap (ezweq f g z fs) (ezmap f g z fs x) ) _ ) ( hfiberpair f x ( idpath _ ) ) ( homotinvweqweq ( ezweq f g z fs ) x ) ) . simpl .  set ( e1 := pathsinv0 ( pathscomp0rid (maponpaths f (homotinvweqweq (ezweq f g z fs) x) ) ) ) . assert ( e2 : (maponpaths (hfiberpr1 g z) (homotweqinvweq (ezweq f g z fs) ( ( ezmap f g z fs ) x))) = (maponpaths f (homotinvweqweq (ezweq f g z fs) x)) ) . set ( e3 := maponpaths ( fun e : _ => maponpaths ( hfiberpr1 g z ) e ) ( pathsinv0  ( homotweqinvweqweq ( ezweq f g z fs ) x ) ) ) .  simpl in e3 .  set ( e4 := maponpathscomp (ezmap f g z (pr1 fs)) (hfiberpr1 g z) (homotinvweqweq (ezweq f g z fs) x) ) .   simpl in e4 . apply ( pathscomp0 e3 e4 ) . apply ( pathscomp0 e2 e1 ) .
+assert ( egf : Π e : _ , ( gg ( ff e ) ) = e ) . intro .  simpl . apply ( hfibertriangle1inv0 g (homotweqinvweq (ezweq f g z fs) (hfiberpair g y e)) ) .
+assert ( efg : Π xe : _ , ( ff ( gg xe ) ) = xe ) . intro .  induction xe as [ x e ] .  induction e .  simpl . unfold ff . unfold ezmap1 . unfold d1 .   change (hfiberpair g (f x) ( pr1 fs x) ) with ( ezmap f g z fs x ) .  apply ( hfibertriangle2 f ( hfiberpair f ( invmap (ezweq f g z fs) (ezmap f g z fs x) ) _ ) ( hfiberpair f x ( idpath _ ) ) ( homotinvweqweq ( ezweq f g z fs ) x ) ) . simpl .  set ( e1 := pathsinv0 ( pathscomp0rid (maponpaths f (homotinvweqweq (ezweq f g z fs) x) ) ) ) . assert ( e2 : (maponpaths (hfiberpr1 g z) (homotweqinvweq (ezweq f g z fs) ( ( ezmap f g z fs ) x))) = (maponpaths f (homotinvweqweq (ezweq f g z fs) x)) ) . set ( e3 := maponpaths ( fun e : _ => maponpaths ( hfiberpr1 g z ) e ) ( pathsinv0  ( homotweqinvweqweq ( ezweq f g z fs ) x ) ) ) .  simpl in e3 .  set ( e4 := maponpathscomp (ezmap f g z (pr1 fs)) (hfiberpr1 g z) (homotinvweqweq (ezweq f g z fs) x) ) .   simpl in e4 . apply ( pathscomp0 e3 e4 ) . apply ( pathscomp0 e2 e1 ) .
 apply ( gradth _ _ egf efg ) . Defined .
 
 Definition ezweq1 { X Y Z : UU } ( f : X -> Y ) ( g : Y -> Z ) ( z : Z ) ( fs : fibseqstr f g z ) ( y : Y ) := weqpair _ ( isweqezmap1 f g z fs y ) .
@@ -2370,8 +2370,8 @@ end.
 
 Definition isweqezmappr1 { Z : UU } ( P : Z -> UU ) ( z : Z ) : isweq ( ezmappr1 P z ).
 Proof. intros.
-assert ( egf : ∀ x: P z , (invezmappr1 _ z ((ezmappr1 P z ) x)) = x). intro. unfold ezmappr1. unfold invezmappr1. simpl. apply idpath.
-assert ( efg : ∀ x: hfiber  (@pr1 Z P) z , (ezmappr1 _ z (invezmappr1 P z x)) = x). intros.  induction x as [ x t0 ]. induction t0. simpl in x.  simpl. induction x. simpl. unfold transportf. unfold ezmappr1. apply idpath.
+assert ( egf : Π x: P z , (invezmappr1 _ z ((ezmappr1 P z ) x)) = x). intro. unfold ezmappr1. unfold invezmappr1. simpl. apply idpath.
+assert ( efg : Π x: hfiber  (@pr1 Z P) z , (ezmappr1 _ z (invezmappr1 P z x)) = x). intros.  induction x as [ x t0 ]. induction t0. simpl in x.  simpl. induction x. simpl. unfold transportf. unfold ezmappr1. apply idpath.
 apply (gradth _ _ egf efg ). Defined.
 
 Definition ezweqpr1 { Z : UU } ( P : Z -> UU ) ( z : Z ) := weqpair _ ( isweqezmappr1 P z ) .
@@ -2396,7 +2396,7 @@ Definition ezweq1pr1 { Z : UU } ( P : Z -> UU ) ( z : Z ) ( zp : total2 P ) : we
 
 
 Theorem isfibseqg { Y Z : UU } (g:Y -> Z) (z:Z) : isfibseq  (hfiberpr1  g z) g z (fun ye: _ => pr2  ye).
-Proof. intros. assert (Y0:∀ ye': hfiber  g z, ye' = (ezmap (hfiberpr1  g z) g z (fun ye: _ => pr2  ye) ye')). intro. apply tppr. apply (isweqhomot  _ _ Y0 (idisweq _ )).  Defined.
+Proof. intros. assert (Y0:Π ye': hfiber  g z, ye' = (ezmap (hfiberpr1  g z) g z (fun ye: _ => pr2  ye) ye')). intro. apply tppr. apply (isweqhomot  _ _ Y0 (idisweq _ )).  Defined.
 
 Definition ezweqg { Y Z : UU } (g:Y -> Z) (z:Z) := weqpair _ ( isfibseqg g z ) .
 Definition fibseqg { Y Z : UU } (g:Y -> Z) (z:Z) : fibseqstr (hfiberpr1  g z) g z := fibseqstrpair _ _ _ _ ( isfibseqg g z ) .
@@ -2462,8 +2462,8 @@ Proof . intros .  induction ye as [ y e ] . induction e .  induction xee' as [ x
 
 Theorem isweqezmaphf { X Y Z : UU } ( f : X -> Y ) ( g : Y -> Z ) ( z : Z ) ( ye : hfiber g z ) : isweq ( ezmaphf f g z ye ) .
 Proof . intros . set ( ff := ezmaphf f g z ye ) . set ( gg := invezmaphf f g z ye ) .
-assert ( egf : ∀ xe : _ , ( gg ( ff xe ) ) = xe ) . induction ye as [ y e ] . induction e .  intro xe .   apply ( hfibertriangle2 f ( gg ( ff xe ) ) xe ( idpath ( pr1 xe ) ) ) . induction xe as [ x ex ] . simpl in ex . induction ( ex ) .  simpl .   apply idpath .
-assert ( efg : ∀ xee' : _ , ( ff ( gg xee' ) ) = xee' ) . induction ye as [ y e ] . induction e .  intro xee' .
+assert ( egf : Π xe : _ , ( gg ( ff xe ) ) = xe ) . induction ye as [ y e ] . induction e .  intro xe .   apply ( hfibertriangle2 f ( gg ( ff xe ) ) xe ( idpath ( pr1 xe ) ) ) . induction xe as [ x ex ] . simpl in ex . induction ( ex ) .  simpl .   apply idpath .
+assert ( efg : Π xee' : _ , ( ff ( gg xee' ) ) = xee' ) . induction ye as [ y e ] . induction e .  intro xee' .
 assert ( hint : ( ff ( gg xee' ) ) = ( ffgg f g ( g y ) ( hfiberpair g y ( idpath _ ) ) xee'  ) ) .  induction xee' as [ xe e' ] .   induction xe as [ x e ] .  apply idpath .
 apply ( pathscomp0 hint ( homotffggid _ _ _ _ xee' ) ) .
 apply ( gradth _ _ egf efg ) . Defined .
@@ -2507,11 +2507,11 @@ Proof. intros . split with ( hfibersgftog w g z ) .  intro ye . apply ( iscontrw
 Theorems saying that a fiber-wise morphism between total spaces is a weak equivalence if and only if all the morphisms between the fibers are weak equivalences. *)
 
 
-Definition totalfun { X : UU } ( P Q : X -> UU ) (f: ∀ x:X, P x -> Q x) := (fun z: total2 P => tpair Q (pr1  z) (f (pr1  z) (pr2  z))).
+Definition totalfun { X : UU } ( P Q : X -> UU ) (f: Π x:X, P x -> Q x) := (fun z: total2 P => tpair Q (pr1  z) (f (pr1  z) (pr2  z))).
 
 
-Theorem isweqtotaltofib { X : UU } ( P Q : X -> UU) (f: ∀ x:X, P x -> Q x):
-isweq (totalfun _ _ f) -> ∀ x:X, isweq (f x).
+Theorem isweqtotaltofib { X : UU } ( P Q : X -> UU) (f: Π x:X, P x -> Q x):
+isweq (totalfun _ _ f) -> Π x:X, isweq (f x).
 Proof. intros X P Q f X0 x. set (totp:= total2 P). set (totq := total2 Q).  set (totf:= (totalfun _ _ f)). set (pip:= fun z: totp => pr1  z). set (piq:= fun z: totq => pr1  z).
 
 set (hfx:= hfibersgftog totf piq x).  simpl in hfx.
@@ -2521,16 +2521,16 @@ assert (X1:isweq int). apply (isweqinvezmaphf totf piq x y). induction y as [ t 
 assert (is1: iscontr (hfiber  totf t)). apply (X0 t). apply (iscontrweqb  ( weqpair int X1 ) is1).
 set (ip:= ezmappr1 P x). set (iq:= ezmappr1 Q x). set (h:= fun p: P x => hfx (ip p)).
 assert (is2: isweq h). apply (twooutof3c ip hfx (isweqezmappr1 P x) H). set (h':= fun p: P x => iq ((f x) p)).
-assert (ee: ∀ p:P x, (h p) = (h' p)). intro. apply idpath.
+assert (ee: Π p:P x, (h p) = (h' p)). intro. apply idpath.
 assert (X2:isweq h'). apply (isweqhomot   h h' ee is2).
 apply (twooutof3a (f x) iq X2).
 apply (isweqezmappr1 Q x). Defined.
 
 
-Definition weqtotaltofib { X : UU } ( P Q : X -> UU ) ( f : ∀ x : X , P x -> Q x ) ( is : isweq ( totalfun _ _ f ) ) ( x : X ) : weq ( P x ) ( Q x ) := weqpair _ ( isweqtotaltofib P Q f is x ) .
+Definition weqtotaltofib { X : UU } ( P Q : X -> UU ) ( f : Π x : X , P x -> Q x ) ( is : isweq ( totalfun _ _ f ) ) ( x : X ) : weq ( P x ) ( Q x ) := weqpair _ ( isweqtotaltofib P Q f is x ) .
 
 
-Theorem isweqfibtototal { X : UU } ( P Q : X -> UU) (f: ∀ x:X, weq ( P x ) ( Q x ) ) : isweq (totalfun _ _ f).
+Theorem isweqfibtototal { X : UU } ( P Q : X -> UU) (f: Π x:X, weq ( P x ) ( Q x ) ) : isweq (totalfun _ _ f).
 Proof. intros X P Q f . set (fpq:= totalfun P Q f). set (pr1p:= fun z: total2 P => pr1  z). set (pr1q:= fun z: total2 Q => pr1  z). unfold isweq. intro xq.   set (x:= pr1q xq). set (xqe:= hfiberpair  pr1q  xq (idpath _)). set (hfpqx:= hfibersgftog fpq pr1q x).
 
 assert (isint: iscontr (hfiber  hfpqx xqe)).
@@ -2539,7 +2539,7 @@ assert (is2: isweq diag).  apply (twooutof3c (f x) iqx (pr2 ( f x) ) (isweqezmap
 set (intmap:= invezmaphf  fpq pr1q x xqe). apply (iscontrweqf  ( weqpair intmap (isweqinvezmaphf fpq pr1q x xqe) ) isint).
 Defined.
 
-Definition weqfibtototal {X : UU} (P Q : X -> UU) (f: ∀ x, P x ≃ Q x) : (Σ x, P x) ≃ (Σ x, Q x)
+Definition weqfibtototal {X : UU} (P Q : X -> UU) (f: Π x, P x ≃ Q x) : (Σ x, P x) ≃ (Σ x, Q x)
   := weqpair _ ( isweqfibtototal P Q f ).
 
 (** ** Homotopy fibers of the function [fpmap: total2 X (P f) -> total2 Y P].
@@ -2563,19 +2563,19 @@ Proof. intros X Y f P yp X0. set (int1:= hfibersgftog (hffpmap2  f P) (fun u: (�
 Lemma centralfiber { X : UU } (P:X -> UU)(x:X): isweq (fun p: P x => tpair (fun u: coconusfromt X x => P ( pr1  u)) (coconusfromtpair X (idpath x)) p).
 Proof. intros. set (f:= fun p: P x => tpair (fun u: coconusfromt X x => P(pr1  u)) (coconusfromtpair X (idpath x)) p). set (g:= fun z: total2 (fun u: coconusfromt X x => P ( pr1  u)) => transportf P (pathsinv0 (pr2  (pr1  z))) (pr2  z)).
 
-assert (efg: ∀  z: total2 (fun u: coconusfromt X x => P ( pr1  u)), (f (g z)) = z). intro. induction z as [ t x0 ]. induction t as [t x1 ].   simpl. induction x1. simpl. apply idpath.
+assert (efg: Π  z: total2 (fun u: coconusfromt X x => P ( pr1  u)), (f (g z)) = z). intro. induction z as [ t x0 ]. induction t as [t x1 ].   simpl. induction x1. simpl. apply idpath.
 
-assert (egf: ∀ p: P x , (g (f p)) = p).  intro. apply idpath.
+assert (egf: Π p: P x , (g (f p)) = p).  intro. apply idpath.
 
 apply (gradth f g egf efg). Defined.
 
 
 Lemma isweqhff { X Y : UU } (f: X -> Y)(P:Y-> UU): isweq (hffpmap2  f P).
-Proof. intros. set (int:= total2 (fun x:X => total2 (fun u: coconusfromt Y (f x) => P (pr1  u)))). set (intpair:= tpair (fun x:X => total2 (fun u: coconusfromt Y (f x) => P (pr1  u)))).  set (toint:= fun z: (total2 (fun u : total2 P => hfiber  f (pr1  u))) => intpair (pr1  (pr2  z)) (tpair  (fun u: coconusfromt Y (f (pr1  (pr2  z))) => P (pr1  u)) (coconusfromtpair _ (pr2  (pr2  z))) (pr2  (pr1  z)))). set (fromint:= fun z: int => tpair (fun u:total2 P => hfiber  f (pr1  u)) (tpair P (pr1  (pr1  (pr2  z))) (pr2  (pr2  z))) (hfiberpair  f  (pr1  z) (pr2  (pr1  (pr2  z))))). assert (fromto: ∀ u:(total2 (fun u : total2 P => hfiber  f (pr1  u))), (fromint (toint u)) = u). simpl in toint. simpl in fromint. simpl. intro u. induction u as [ t x ]. induction x. induction t as [ p0 p1 ] . simpl. unfold toint. unfold fromint. simpl. apply idpath. assert (tofrom: ∀ u:int, (toint (fromint u)) = u). intro. induction u as [ t x ]. induction x as [ t0 x ]. induction t0. simpl in x. simpl. unfold fromint. unfold toint. simpl. apply idpath. assert (is: isweq toint). apply (gradth  toint fromint fromto tofrom).  clear tofrom. clear fromto.  clear fromint.
+Proof. intros. set (int:= total2 (fun x:X => total2 (fun u: coconusfromt Y (f x) => P (pr1  u)))). set (intpair:= tpair (fun x:X => total2 (fun u: coconusfromt Y (f x) => P (pr1  u)))).  set (toint:= fun z: (total2 (fun u : total2 P => hfiber  f (pr1  u))) => intpair (pr1  (pr2  z)) (tpair  (fun u: coconusfromt Y (f (pr1  (pr2  z))) => P (pr1  u)) (coconusfromtpair _ (pr2  (pr2  z))) (pr2  (pr1  z)))). set (fromint:= fun z: int => tpair (fun u:total2 P => hfiber  f (pr1  u)) (tpair P (pr1  (pr1  (pr2  z))) (pr2  (pr2  z))) (hfiberpair  f  (pr1  z) (pr2  (pr1  (pr2  z))))). assert (fromto: Π u:(total2 (fun u : total2 P => hfiber  f (pr1  u))), (fromint (toint u)) = u). simpl in toint. simpl in fromint. simpl. intro u. induction u as [ t x ]. induction x. induction t as [ p0 p1 ] . simpl. unfold toint. unfold fromint. simpl. apply idpath. assert (tofrom: Π u:int, (toint (fromint u)) = u). intro. induction u as [ t x ]. induction x as [ t0 x ]. induction t0. simpl in x. simpl. unfold fromint. unfold toint. simpl. apply idpath. assert (is: isweq toint). apply (gradth  toint fromint fromto tofrom).  clear tofrom. clear fromto.  clear fromint.
 
 set (h:= fun u: total2 (fun x:X => P (f x)) => toint ((hffpmap2  f P) u)). simpl in h.
 
-assert (l1: ∀ x:X, isweq (fun p: P (f x) => tpair  (fun u: coconusfromt _ (f x) => P (pr1  u)) (coconusfromtpair _ (idpath  (f x))) p)). intro. apply (centralfiber P (f x)).
+assert (l1: Π x:X, isweq (fun p: P (f x) => tpair  (fun u: coconusfromt _ (f x) => P (pr1  u)) (coconusfromtpair _ (idpath  (f x))) p)). intro. apply (centralfiber P (f x)).
 
 assert (X0:isweq h). apply (isweqfibtototal  (fun x:X => P (f x))  (fun x:X => total2 (fun u: coconusfromt _ (f x) => P (pr1  u))) (fun x:X =>  weqpair _  ( l1 x ) ) ).
 
@@ -2628,23 +2628,23 @@ Definition tototal2overunit   ( P : unit -> UU ) ( p : P tt ) : total2 P  := tpa
 
 Theorem weqtotal2overunit ( P : unit -> UU ) : (Σ u, P u) ≃ P tt .
 Proof. intro . set ( f := fromtotal2overunit P ) . set ( g := tototal2overunit P ) . split with f .
-assert ( egf : ∀ a : _ , ( g ( f a ) ) = a ) . intro a . induction a as [ t p ] . induction t . apply idpath .
-assert ( efg : ∀ a : _ , ( f ( g a ) ) = a ) . intro a . apply idpath .
+assert ( egf : Π a : _ , ( g ( f a ) ) = a ) . intro a . induction a as [ t p ] . induction t . apply idpath .
+assert ( efg : Π a : _ , ( f ( g a ) ) = a ) . intro a . apply idpath .
 apply ( gradth _ _ egf efg ) . Defined .
 
 (** ** The maps between total spaces of families given by a map between the bases of the families and maps between the corresponding members of the families *)
 
 
 Definition bandfmap { X Y : UU } (f: X -> Y) ( P : X -> UU) (Q: Y -> UU)
-           (fm: ∀ x:X, P x -> (Q (f x))) :
+           (fm: Π x:X, P x -> (Q (f x))) :
   (Σ x, P x) -> (Σ x, Q x)
   := λ xp, f (pr1 xp) ,, fm (pr1 xp) (pr2 xp).
 
-Theorem isweqbandfmap { X Y : UU } (w : X ≃ Y ) (P:X -> UU)(Q: Y -> UU)( fw : ∀ x:X, weq ( P x) (Q (w x))) : isweq (bandfmap  _ P Q fw).
+Theorem isweqbandfmap { X Y : UU } (w : X ≃ Y ) (P:X -> UU)(Q: Y -> UU)( fw : Π x:X, weq ( P x) (Q (w x))) : isweq (bandfmap  _ P Q fw).
 Proof. intros. set (f1:= totalfun P _ fw). set (is1:= isweqfibtototal P (fun x:X => Q (w x)) fw ).  set (f2:= fpmap w Q).  set (is2:= isweqfpmap w Q ).
-assert (h: ∀ xp: total2 P, (f2 (f1 xp)) = (bandfmap  w P Q fw xp)). intro. induction xp. apply idpath.  apply (isweqhomot  _ _ h (twooutof3c f1 f2 is1 is2)). Defined.
+assert (h: Π xp: total2 P, (f2 (f1 xp)) = (bandfmap  w P Q fw xp)). intro. induction xp. apply idpath.  apply (isweqhomot  _ _ h (twooutof3c f1 f2 is1 is2)). Defined.
 
-Definition weqbandf { X Y : UU } (w : X ≃ Y ) (P:X -> UU)(Q: Y -> UU)( fw : ∀ x:X, weq ( P x) (Q (w x))) := weqpair _ ( isweqbandfmap w P Q fw ) .
+Definition weqbandf { X Y : UU } (w : X ≃ Y ) (P:X -> UU)(Q: Y -> UU)( fw : Π x:X, weq ( P x) (Q (w x))) := weqpair _ ( isweqbandfmap w P Q fw ) .
 
 
 
@@ -2683,7 +2683,7 @@ Definition weqbandf { X Y : UU } (w : X ≃ Y ) (P:X -> UU)(Q: Y -> UU)( fw : �
 (** *** Homotopy commutative squares *)
 
 
-Definition commsqstr { X X' Y Z : UU } ( g' : Z -> X' ) ( f' : X' -> Y ) ( g : Z -> X ) ( f : X -> Y ) := ∀ ( z : Z ) , ( f' ( g' z ) ) = ( f ( g z ) ) .
+Definition commsqstr { X X' Y Z : UU } ( g' : Z -> X' ) ( f' : X' -> Y ) ( g : Z -> X ) ( f : X -> Y ) := Π ( z : Z ) , ( f' ( g' z ) ) = ( f ( g z ) ) .
 
 
 Definition hfibersgtof'  { X X' Y Z : UU } ( f : X -> Y ) ( f' : X' -> Y ) ( g : Z -> X ) ( g' : Z -> X' ) ( h : commsqstr g' f' g f ) ( x : X ) ( ze : hfiber g x ) : hfiber f' ( f x )  .
@@ -2716,9 +2716,9 @@ Definition hfpg' {X X' Y:UU} (f:X -> Y) (f':X' -> Y) : hfp f f' -> X' := fun xx'
 
 Definition commsqZtohfp { X X' Y Z : UU } ( f : X -> Y ) ( f' : X' -> Y ) ( g : Z -> X ) ( g' : Z -> X' ) ( h : commsqstr g' f' g f ) : Z -> hfp f f' := fun z : _ => tpair _ ( dirprodpair ( g z ) ( g' z ) ) ( h z ) .
 
-Definition commsqZtohfphomot  { X X' Y Z : UU } ( f : X -> Y ) ( f' : X' -> Y ) ( g : Z -> X ) ( g' : Z -> X' ) ( h : commsqstr g' f' g f  ) : ∀ z : Z , ( hfpg _ _ ( commsqZtohfp _ _ _ _ h z ) ) = ( g z ) := fun z : _ => idpath _ .
+Definition commsqZtohfphomot  { X X' Y Z : UU } ( f : X -> Y ) ( f' : X' -> Y ) ( g : Z -> X ) ( g' : Z -> X' ) ( h : commsqstr g' f' g f  ) : Π z : Z , ( hfpg _ _ ( commsqZtohfp _ _ _ _ h z ) ) = ( g z ) := fun z : _ => idpath _ .
 
-Definition commsqZtohfphomot'  { X X' Y Z : UU } ( f : X -> Y ) ( f' : X' -> Y ) ( g : Z -> X ) ( g' : Z -> X' ) ( h : commsqstr g' f' g f  ) : ∀ z : Z , ( hfpg' _ _ ( commsqZtohfp _ _ _ _ h z ) ) = ( g' z ) := fun z : _ => idpath _ .
+Definition commsqZtohfphomot'  { X X' Y Z : UU } ( f : X -> Y ) ( f' : X' -> Y ) ( g : Z -> X ) ( g' : Z -> X' ) ( h : commsqstr g' f' g f  ) : Π z : Z , ( hfpg' _ _ ( commsqZtohfp _ _ _ _ h z ) ) = ( g' z ) := fun z : _ => idpath _ .
 
 
 Definition hfpoverX {X X' Y:UU} (f:X -> Y) (f':X' -> Y) := total2 (fun x : X => hfiber  f' ( f x ) ) .
@@ -2749,8 +2749,8 @@ Definition hfptohfiber { X Y : UU } ( f : X -> Y ) ( y : Y ) ( hf : hfp ( fun t 
 
 Lemma weqhfibertohfp  { X Y : UU } ( f : X -> Y ) ( y : Y ) : weq ( hfiber f y )  ( hfp ( fun t : unit => y ) f ) .
 Proof . intros . set ( ff := hfibertohfp f y ) . set ( gg := hfptohfiber f y ) . split with ff .
-assert ( egf : ∀ xe : _ , ( gg ( ff xe ) ) = xe ) . intro . induction xe . apply idpath .
-assert ( efg : ∀ hf : _ , ( ff ( gg hf ) ) = hf ) . intro . induction hf as [ tx e ] . induction tx as [ t x ] . induction t .   apply idpath .
+assert ( egf : Π xe : _ , ( gg ( ff xe ) ) = xe ) . intro . induction xe . apply idpath .
+assert ( efg : Π hf : _ , ( ff ( gg hf ) ) = hf ) . intro . induction hf as [ tx e ] . induction tx as [ t x ] . induction t .   apply idpath .
 apply ( gradth _ _ egf efg ) . Defined .
 
 Lemma hfp_left  {X Y Z:UU} (f:X->Z) (g:Y->Z) : hfp f g ≃ Σ x, hfiber g (f x).
@@ -2791,16 +2791,16 @@ Definition weqZtohfp  { X X' Y Z : UU } ( f : X -> Y ) ( f' : X' -> Y ) ( g : Z 
 Lemma isweqhfibersgtof' { X X' Y Z : UU } ( f : X -> Y ) ( f' : X' -> Y ) ( g : Z -> X ) ( g' : Z -> X' ) ( hf : hfsqstr f f' g g' ) ( x : X ) : isweq ( hfibersgtof' f f' g g' hf x ) .
 Proof. intros . set ( is := pr2 hf ) . set ( h := pr1 hf ) .
 set ( a := weqtococonusf g ) . set ( c := weqpair _ is ) .  set ( d := weqhfptohfpoverX f f' ) .  set ( b0 := totalfun _ _ ( hfibersgtof' f f' g g' h ) ) .
-assert ( h1 : ∀ z : Z , ( d ( c z ) ) = ( b0 ( a z ) ) ) . intro . simpl .  unfold b0 . unfold a .   unfold weqtococonusf . unfold tococonusf .   simpl .  unfold totalfun, total2asstor, hfibersgtof'; simpl. assert ( e : ( h  z ) = ( pathscomp0 (h z) (idpath (f (g z))) ) ) . apply ( pathsinv0 ( pathscomp0rid _ ) ) . induction e .  apply idpath .
+assert ( h1 : Π z : Z , ( d ( c z ) ) = ( b0 ( a z ) ) ) . intro . simpl .  unfold b0 . unfold a .   unfold weqtococonusf . unfold tococonusf .   simpl .  unfold totalfun, total2asstor, hfibersgtof'; simpl. assert ( e : ( h  z ) = ( pathscomp0 (h z) (idpath (f (g z))) ) ) . apply ( pathsinv0 ( pathscomp0rid _ ) ) . induction e .  apply idpath .
 assert ( is1 : isweq ( fun z : _ => b0 ( a z ) ) ) . apply ( isweqhomot _ _ h1 ) .   apply ( twooutof3c _ _ ( pr2 c ) ( pr2 d ) ) .
 assert ( is2 : isweq b0 ) . apply ( twooutof3b _ _ ( pr2 a ) is1 ) .  apply ( isweqtotaltofib _ _ _ is2 x ) .   Defined .
 
 Definition weqhfibersgtof' { X X' Y Z : UU } ( f : X -> Y ) ( f' : X' -> Y ) ( g : Z -> X ) ( g' : Z -> X' ) ( hf : hfsqstr f f' g g' ) ( x : X ) := weqpair _ ( isweqhfibersgtof' _ _ _ _ hf x ) .
 
-Lemma ishfsqweqhfibersgtof' { X X' Y Z : UU } ( f : X -> Y ) ( f' : X' -> Y ) ( g : Z -> X ) ( g' : Z -> X' ) ( h : commsqstr g' f' g f  ) ( is : ∀ x : X , isweq ( hfibersgtof' f f' g g' h x ) ) :  hfsqstr f f' g g' .
+Lemma ishfsqweqhfibersgtof' { X X' Y Z : UU } ( f : X -> Y ) ( f' : X' -> Y ) ( g : Z -> X ) ( g' : Z -> X' ) ( h : commsqstr g' f' g f  ) ( is : Π x : X , isweq ( hfibersgtof' f f' g g' h x ) ) :  hfsqstr f f' g g' .
 Proof .  intros . split with h .
 set ( a := weqtococonusf g ) . set ( c0 := commsqZtohfp f f' g g' h ) .  set ( d := weqhfptohfpoverX f f' ) .  set ( b := weqfibtototal _ _ ( fun x : X => weqpair _ ( is x ) ) ) .
-assert ( h1 : ∀ z : Z , ( d ( c0 z ) ) = ( b ( a z ) ) ) . intro . simpl .  unfold b . unfold a .   unfold weqtococonusf . unfold tococonusf .   simpl .  unfold totalfun, total2asstor, hfibersgtof'; simpl . assert ( e : ( h z ) = ( pathscomp0 (h z) (idpath (f (g z))) ) ) . apply ( pathsinv0 ( pathscomp0rid _ ) ) .  induction e .  apply idpath .
+assert ( h1 : Π z : Z , ( d ( c0 z ) ) = ( b ( a z ) ) ) . intro . simpl .  unfold b . unfold a .   unfold weqtococonusf . unfold tococonusf .   simpl .  unfold totalfun, total2asstor, hfibersgtof'; simpl . assert ( e : ( h z ) = ( pathscomp0 (h z) (idpath (f (g z))) ) ) . apply ( pathsinv0 ( pathscomp0rid _ ) ) .  induction e .  apply idpath .
 assert ( is1 : isweq ( fun z : _ => d ( c0 z ) ) ) . apply ( isweqhomot _ _ ( fun z : Z => ( pathsinv0 ( h1 z ) ) ) ) .   apply ( twooutof3c _ _ ( pr2 a ) ( pr2 b ) ) .
  apply ( twooutof3a _ _ is1 ( pr2 d ) ) .    Defined .
 
@@ -2808,22 +2808,22 @@ assert ( is1 : isweq ( fun z : _ => d ( c0 z ) ) ) . apply ( isweqhomot _ _ ( fu
 Lemma isweqhfibersg'tof { X X' Y Z : UU } ( f : X -> Y ) ( f' : X' -> Y ) ( g : Z -> X ) ( g' : Z -> X' ) ( hf : hfsqstr f f' g g' ) ( x' : X' ) : isweq (  hfibersg'tof f f' g g' hf x' ) .
 Proof. intros . set ( is := pr2 hf ) . set ( h := pr1 hf ) .
 set ( a' := weqtococonusf g' ) . set ( c' := weqpair _ is ) .  set ( d' := weqhfptohfpoverX' f f' ) .  set ( b0' := totalfun _ _ ( hfibersg'tof f f' g g' h ) ) .
-assert ( h1 : ∀ z : Z , ( d' ( c' z ) ) = ( b0' ( a' z ) ) ) . intro .  unfold b0' . unfold a' .   unfold weqtococonusf . unfold tococonusf .   unfold totalfun, hfibersg'tof; simpl .  assert ( e : ( pathsinv0 ( h  z ) ) = ( pathscomp0 ( pathsinv0 (h z) ) (idpath (f' (g' z))) ) ) . apply (  pathsinv0 ( pathscomp0rid _ ) ) .  induction e .  apply idpath .
+assert ( h1 : Π z : Z , ( d' ( c' z ) ) = ( b0' ( a' z ) ) ) . intro .  unfold b0' . unfold a' .   unfold weqtococonusf . unfold tococonusf .   unfold totalfun, hfibersg'tof; simpl .  assert ( e : ( pathsinv0 ( h  z ) ) = ( pathscomp0 ( pathsinv0 (h z) ) (idpath (f' (g' z))) ) ) . apply (  pathsinv0 ( pathscomp0rid _ ) ) .  induction e .  apply idpath .
 assert ( is1 : isweq ( fun z : _ => b0' ( a' z ) ) ) . apply ( isweqhomot _ _ h1 ) .   apply ( twooutof3c _ _ ( pr2 c' ) ( pr2 d' ) ) .
 assert ( is2 : isweq b0' ) . apply ( twooutof3b _ _ ( pr2 a' ) is1 ) .  apply ( isweqtotaltofib _ _ _ is2 x' ) .   Defined .
 
 Definition weqhfibersg'tof { X X' Y Z : UU } ( f : X -> Y ) ( f' : X' -> Y ) ( g : Z -> X ) ( g' : Z -> X' ) ( hf : hfsqstr f f' g g' ) ( x' : X' ) := weqpair _ ( isweqhfibersg'tof _ _ _ _ hf x' ) .
 
-Lemma ishfsqweqhfibersg'tof { X X' Y Z : UU } ( f : X -> Y ) ( f' : X' -> Y ) ( g : Z -> X ) ( g' : Z -> X' ) ( h : commsqstr g' f' g f ) ( is : ∀ x' : X' , isweq ( hfibersg'tof f f' g g' h x' ) ) :  hfsqstr f f' g g' .
+Lemma ishfsqweqhfibersg'tof { X X' Y Z : UU } ( f : X -> Y ) ( f' : X' -> Y ) ( g : Z -> X ) ( g' : Z -> X' ) ( h : commsqstr g' f' g f ) ( is : Π x' : X' , isweq ( hfibersg'tof f f' g g' h x' ) ) :  hfsqstr f f' g g' .
 Proof .  intros . split with h .
 set ( a' := weqtococonusf g' ) . set ( c0' := commsqZtohfp f f' g g' h ) .  set ( d' := weqhfptohfpoverX' f f' ) .  set ( b' := weqfibtototal _ _ ( fun x' : X' => weqpair _ ( is x' ) ) ) .
-assert ( h1 : ∀ z : Z , ( d' ( c0' z ) ) = ( b' ( a' z ) ) ) . intro . simpl .  unfold b' . unfold a' .   unfold weqtococonusf . unfold tococonusf .   unfold totalfun, total2asstor, hfibersg'tof; simpl . assert ( e : ( pathsinv0 ( h z ) ) = ( pathscomp0 ( pathsinv0 (h z) ) (idpath (f' (g' z))) ) ) . apply ( pathsinv0 ( pathscomp0rid _ ) ) .  induction e .  apply idpath .
+assert ( h1 : Π z : Z , ( d' ( c0' z ) ) = ( b' ( a' z ) ) ) . intro . simpl .  unfold b' . unfold a' .   unfold weqtococonusf . unfold tococonusf .   unfold totalfun, total2asstor, hfibersg'tof; simpl . assert ( e : ( pathsinv0 ( h z ) ) = ( pathscomp0 ( pathsinv0 (h z) ) (idpath (f' (g' z))) ) ) . apply ( pathsinv0 ( pathscomp0rid _ ) ) .  induction e .  apply idpath .
 assert ( is1 : isweq ( fun z : _ => d' ( c0' z ) ) ) . apply ( isweqhomot _ _ ( fun z : Z => ( pathsinv0 ( h1 z ) ) ) ) .   apply ( twooutof3c _ _ ( pr2 a' ) ( pr2 b' ) ) .
  apply ( twooutof3a _ _ is1 ( pr2 d' ) ) .    Defined .
 
 Theorem transposhfpsqstr { X X' Y Z : UU } ( f : X -> Y ) ( f' : X' -> Y ) ( g : Z -> X ) ( g' : Z -> X' ) ( hf : hfsqstr f f' g g' ) : hfsqstr f' f g' g .
 Proof . intros . set ( is := pr2 hf ) . set ( h := pr1 hf ) . set ( th := transposcommsqstr f f' g g' h ) . split with th .
-set ( w1 := weqhfpcomm f f' ) . assert ( h1 : ∀ z : Z , (  w1 ( commsqZtohfp f f' g g' h z ) ) = (  commsqZtohfp f' f g' g th z ) ) . intro . unfold commsqZtohfp .  simpl . unfold fpmap . unfold totalfun .   simpl .  apply idpath .  apply ( isweqhomot _ _ h1 ) .  apply ( twooutof3c _ _ is ( pr2 w1 ) ) . Defined .
+set ( w1 := weqhfpcomm f f' ) . assert ( h1 : Π z : Z , (  w1 ( commsqZtohfp f f' g g' h z ) ) = (  commsqZtohfp f' f g' g th z ) ) . intro . unfold commsqZtohfp .  simpl . unfold fpmap . unfold totalfun .   simpl .  apply idpath .  apply ( isweqhomot _ _ h1 ) .  apply ( twooutof3c _ _ is ( pr2 w1 ) ) . Defined .
 
 
 (** *** Fiber sequences and homotopy fiber squares *)

--- a/UniMath/Foundations/Basics/PartB.v
+++ b/UniMath/Foundations/Basics/PartB.v
@@ -29,12 +29,12 @@ Require Export UniMath.Foundations.Basics.PartA.
 Fixpoint isofhlevel (n:nat) (X:UU): UU:=
 match n with
 O => iscontr X |
-S m => forall x:X, forall x':X, (isofhlevel m (paths x x'))
+S m => Π x:X, Π x':X, (isofhlevel m (paths x x'))
 end.
 
 (* induction induction *)
 
-Theorem hlevelretract (n:nat) { X Y : UU } ( p : X -> Y ) ( s : Y -> X ) ( eps : forall y : Y , paths ( p ( s y ) ) y ) : isofhlevel n X -> isofhlevel n Y .
+Theorem hlevelretract (n:nat) { X Y : UU } ( p : X -> Y ) ( s : Y -> X ) ( eps : Π y : Y , paths ( p ( s y ) ) y ) : isofhlevel n X -> isofhlevel n Y .
 Proof. intro. induction n as [ | n IHn ].  intros X Y p s eps X0. unfold isofhlevel.  apply ( iscontrretract p s eps X0).
  unfold isofhlevel. intros X Y p s eps X0 x x'. unfold isofhlevel in X0. assert (is: isofhlevel n (paths (s x) (s x'))).  apply X0. set (s':= @maponpaths _ _ s x x'). set (p':= pathssec2  s p eps x x').  set (eps':= @pathssec3 _ _  s p eps x x' ). simpl. apply (IHn  _ _ p' s' eps' is). Defined.
 
@@ -47,8 +47,8 @@ Proof. intros n X Y f X0 .  apply (hlevelretract n  (invmap  f ) f (homotinvweqw
 Lemma isofhlevelsn ( n : nat ) { X : UU } ( f : X -> isofhlevel ( S n ) X ) : isofhlevel ( S n ) X.
 Proof. intros . simpl . intros x x' . apply ( f x x x'). Defined.
 
-Lemma isofhlevelssn (n:nat) { X : UU } ( is : forall x:X, isofhlevel (S n) (paths x x)) : isofhlevel (S (S n)) X.
-Proof. intros . simpl.  intros x x'.  change ( forall ( x0 x'0 : paths x x' ), isofhlevel n ( paths x0 x'0 ) ) with ( isofhlevel (S n) (paths x x') ).
+Lemma isofhlevelssn (n:nat) { X : UU } ( is : Π x:X, isofhlevel (S n) (paths x x)) : isofhlevel (S (S n)) X.
+Proof. intros . simpl.  intros x x'.  change ( Π ( x0 x'0 : paths x x' ), isofhlevel n ( paths x0 x'0 ) ) with ( isofhlevel (S n) (paths x x') ).
 assert ( X1 : paths x x' -> isofhlevel (S n) (paths x x') ) . intro X2. induction X2. apply ( is x ). apply  ( isofhlevelsn n X1 ). Defined.
 
 
@@ -60,10 +60,10 @@ assert ( X1 : paths x x' -> isofhlevel (S n) (paths x x') ) . intro X2. inductio
 (** *** h-levels of functions *)
 
 
-Definition isofhlevelf ( n : nat ) { X Y : UU } ( f : X -> Y ) : UU := forall y:Y, isofhlevel n (hfiber  f y).
+Definition isofhlevelf ( n : nat ) { X Y : UU } ( f : X -> Y ) : UU := Π y:Y, isofhlevel n (hfiber  f y).
 
 
-Theorem isofhlevelfhomot ( n : nat ) { X Y : UU }(f f':X -> Y)(h: forall x:X, paths (f x) (f' x)): isofhlevelf n f -> isofhlevelf n  f'.
+Theorem isofhlevelfhomot ( n : nat ) { X Y : UU }(f f':X -> Y)(h: Π x:X, paths (f x) (f' x)): isofhlevelf n f -> isofhlevelf n  f'.
 Proof. intros n X Y f f' h X0. unfold isofhlevelf. intro y . apply ( isofhlevelweqf n ( weqhfibershomot f f' h y ) ( X0 y )) .   Defined .
 
 
@@ -86,10 +86,10 @@ assert (is1: isofhlevel O Y). split with ( f ( pr1 X0 ) ) . intro t .  unfold is
 apply (isweqcontrcontr  f X0 is1).
 
 intros X Y f X0 X1.  unfold isofhlevelf. simpl.
-assert  (is1: forall x' x:X, isofhlevel n (paths x' x)). simpl in X0.  assumption.
-assert (is2: forall y' y:Y, isofhlevel (S n) (paths y' y)). simpl in X1.  simpl. assumption.
-assert (is3: forall (y:Y)(x:X)(xe': hfiber  f y), isofhlevelf n  (d2g  f x xe')).  intros. apply (IHn  _ _ (d2g  f x xe') (is1 (pr1  xe') x) (is2 (f x) y)).
-assert (is4: forall (y:Y)(x:X)(xe': hfiber  f y)(e: paths (f x) y), isofhlevel n (paths (hfiberpair  f x e) xe')). intros.
+assert  (is1: Π x' x:X, isofhlevel n (paths x' x)). simpl in X0.  assumption.
+assert (is2: Π y' y:Y, isofhlevel (S n) (paths y' y)). simpl in X1.  simpl. assumption.
+assert (is3: Π (y:Y)(x:X)(xe': hfiber  f y), isofhlevelf n  (d2g  f x xe')).  intros. apply (IHn  _ _ (d2g  f x xe') (is1 (pr1  xe') x) (is2 (f x) y)).
+assert (is4: Π (y:Y)(x:X)(xe': hfiber  f y)(e: paths (f x) y), isofhlevel n (paths (hfiberpair  f x e) xe')). intros.
 apply (isofhlevelweqb n  ( ezweq3g f x xe' e)  (is3 y x xe' e)).
 intros y xe xe' .  induction xe as [ t x ]. apply (is4 y t xe' x). Defined.
 
@@ -97,10 +97,10 @@ intros y xe xe' .  induction xe as [ t x ]. apply (is4 y t xe' x). Defined.
 
 Theorem isofhlevelXfromfY ( n : nat ) { X Y : UU } ( f : X -> Y ) : isofhlevelf n f -> isofhlevel n Y -> isofhlevel n X.
 Proof. intro. induction n as [ | n IHn ] .  intros X Y f X0 X1.  apply (iscontrweqb ( weqpair f X0 ) X1). intros X Y f X0 X1. simpl.
-assert (is1: forall (y:Y)(xe xe': hfiber  f y), isofhlevel n (paths xe xe')). intros. apply (X0 y).
-assert (is2: forall (y:Y)(x:X)(xe': hfiber  f y), isofhlevelf n  (d2g  f x xe')). intros. unfold isofhlevel. intro y0.
+assert (is1: Π (y:Y)(xe xe': hfiber  f y), isofhlevel n (paths xe xe')). intros. apply (X0 y).
+assert (is2: Π (y:Y)(x:X)(xe': hfiber  f y), isofhlevelf n  (d2g  f x xe')). intros. unfold isofhlevel. intro y0.
 apply (isofhlevelweqf n ( ezweq3g  f x xe' y0 ) (is1 y (hfiberpair  f x y0) xe')).
-assert (is3: forall (y' y : Y), isofhlevel n (paths y' y)). simpl in X1. assumption.
+assert (is3: Π (y' y : Y), isofhlevel n (paths y' y)). simpl in X1. assumption.
 intros x' x .
 set (y:= f x').  set (e':= idpath y). set (xe':= hfiberpair  f x' e').
 apply (IHn  _ _ (d2g  f x xe') (is2 y x xe') (is3 (f x) y)). Defined.
@@ -110,12 +110,12 @@ apply (IHn  _ _ (d2g  f x xe') (is2 y x xe') (is3 (f x) y)). Defined.
 
 
 
-Theorem  isofhlevelffib ( n : nat ) { X : UU } ( P : X -> UU ) ( x : X ) ( is : forall x':X, isofhlevel n (paths x' x) ) : isofhlevelf n ( tpair P x ) .
+Theorem  isofhlevelffib ( n : nat ) { X : UU } ( P : X -> UU ) ( x : X ) ( is : Π x':X, isofhlevel n (paths x' x) ) : isofhlevelf n ( tpair P x ) .
 Proof . intros . unfold isofhlevelf . intro xp .   apply (isofhlevelweqf n ( ezweq1pr1 P x xp) ( is ( pr1 xp ) ) ) . Defined .
 
 
 
-Theorem isofhlevelfhfiberpr1y ( n : nat ) { X Y : UU } ( f : X -> Y ) ( y : Y ) ( is : forall y':Y, isofhlevel n (paths  y' y) ) : isofhlevelf n ( hfiberpr1 f y).
+Theorem isofhlevelfhfiberpr1y ( n : nat ) { X Y : UU } ( f : X -> Y ) ( y : Y ) ( is : Π y':Y, isofhlevel n (paths  y' y) ) : isofhlevelf n ( hfiberpr1 f y).
 Proof.  intros .  unfold isofhlevelf. intro x.  apply (isofhlevelweqf n ( ezweq1g f y x ) ( is ( f x ) ) ) . Defined.
 
 
@@ -167,7 +167,7 @@ Proof. intros . intro z . assert ( is' : isweq ( hfibersgftog w g z ) ) .  intro
 
 
 
-Corollary isofhlevelfhomot2 (n:nat) { X X' Y : UU } (f:X -> Y)(f':X' -> Y)(w : weq X X' )(h:forall x:X, paths (f x) (f' (w x))) : isofhlevelf n  f -> isofhlevelf n  f'.
+Corollary isofhlevelfhomot2 (n:nat) { X X' Y : UU } (f:X -> Y)(f':X' -> Y)(w : weq X X' )(h:Π x:X, paths (f x) (f' (w x))) : isofhlevelf n  f -> isofhlevelf n  f'.
 Proof. intros n X X' Y f f' w h X0.  assert (X1: isofhlevelf n  (fun x:X => f' (w x))). apply (isofhlevelfhomot n _ _ h X0).
 apply (isofhlevelfgwtog n  w f' X1). Defined.
 
@@ -178,25 +178,25 @@ Theorem isofhlevelfonpaths (n:nat) { X Y : UU }(f:X -> Y)(x x':X): isofhlevelf (
 Proof. intros n X Y f x x' X0.
 set (y:= f x'). set (xe':= hfiberpair  f x' (idpath _ )).
 assert (is1: isofhlevelf n  (d2g  f x xe')). unfold isofhlevelf. intro y0 .  apply (isofhlevelweqf n  ( ezweq3g  f x xe' y0  ) (X0 y (hfiberpair  f x y0) xe')).
-assert (h: forall ee:paths x' x, paths (d2g  f x xe' ee) (maponpaths f  (pathsinv0  ee))). intro.
+assert (h: Π ee:paths x' x, paths (d2g  f x xe' ee) (maponpaths f  (pathsinv0  ee))). intro.
 assert (e0: paths (pathscomp0   (maponpaths f  (pathsinv0 ee)) (idpath _ ))  (maponpaths f  (pathsinv0  ee)) ). induction ee.  simpl.  apply idpath. apply (e0). apply (isofhlevelfhomot2 n _ _  ( weqpair (@pathsinv0 _ x' x ) (isweqpathsinv0 _ _ ) ) h is1) . Defined.
 
 
 
-Theorem isofhlevelfsn (n:nat) { X Y : UU } (f:X -> Y): (forall x x':X, isofhlevelf n  (@maponpaths _ _ f x x')) -> isofhlevelf (S n)  f.
+Theorem isofhlevelfsn (n:nat) { X Y : UU } (f:X -> Y): (Π x x':X, isofhlevelf n  (@maponpaths _ _ f x x')) -> isofhlevelf (S n)  f.
 Proof. intros n X Y f X0.  unfold isofhlevelf. intro y .  simpl.  intros x x' . induction x as [ x e ]. induction x' as [ x' e' ].  induction e' . set (xe':= hfiberpair  f x' ( idpath _ ) ).  set (xe:= hfiberpair  f x e). set (d3:= d2g  f x xe'). simpl in d3.
 assert (is1: isofhlevelf n  (d2g  f x xe')).
-assert (h: forall ee: paths x' x, paths (maponpaths f  (pathsinv0  ee)) (d2g  f x xe' ee)). intro. unfold d2g. simpl .  apply ( pathsinv0 ( pathscomp0rid _ ) ) .
+assert (h: Π ee: paths x' x, paths (maponpaths f  (pathsinv0  ee)) (d2g  f x xe' ee)). intro. unfold d2g. simpl .  apply ( pathsinv0 ( pathscomp0rid _ ) ) .
 assert (is2: isofhlevelf n  (fun ee: paths x' x => maponpaths f  (pathsinv0  ee))).  apply (isofhlevelfgtogw n  ( weqpair _ (isweqpathsinv0  _ _  ) ) (@maponpaths _ _ f x x') (X0 x x')).
 apply (isofhlevelfhomot n  _ _  h is2).
 apply (isofhlevelweqb n  (  ezweq3g f x xe' e )  (is1 e)).  Defined.
 
 
-Theorem isofhlevelfssn (n:nat) { X Y : UU } (f:X -> Y): (forall x:X, isofhlevelf (S n)  (@maponpaths _ _ f x x)) -> isofhlevelf (S (S n))  f.
+Theorem isofhlevelfssn (n:nat) { X Y : UU } (f:X -> Y): (Π x:X, isofhlevelf (S n)  (@maponpaths _ _ f x x)) -> isofhlevelf (S (S n))  f.
 Proof.  intros n X Y f X0.  unfold isofhlevelf. intro y .
-assert (forall xe0: hfiber  f y, isofhlevel (S n) (paths xe0 xe0)). intro. induction xe0 as [ x e ].  induction e . set (e':= idpath ( f x ) ).  set (xe':= hfiberpair  f x e').  set (xe:= hfiberpair  f x e' ). set (d3:= d2g  f x xe'). simpl in d3.
+assert (Π xe0: hfiber  f y, isofhlevel (S n) (paths xe0 xe0)). intro. induction xe0 as [ x e ].  induction e . set (e':= idpath ( f x ) ).  set (xe':= hfiberpair  f x e').  set (xe:= hfiberpair  f x e' ). set (d3:= d2g  f x xe'). simpl in d3.
 assert (is1: isofhlevelf (S n)  (d2g  f x xe')).
-assert (h: forall ee: paths x x, paths (maponpaths f  (pathsinv0  ee))  (d2g  f x xe' ee)). intro. unfold d2g . simpl . apply ( pathsinv0 ( pathscomp0rid _ ) ) .
+assert (h: Π ee: paths x x, paths (maponpaths f  (pathsinv0  ee))  (d2g  f x xe' ee)). intro. unfold d2g . simpl . apply ( pathsinv0 ( pathscomp0rid _ ) ) .
 assert (is2: isofhlevelf (S n)  (fun ee: paths x x => maponpaths f  (pathsinv0  ee))).  apply (isofhlevelfgtogw ( S n )  ( weqpair _ (isweqpathsinv0  _ _  ) ) (@maponpaths _ _ f x x) ( X0 x )) .
 apply (isofhlevelfhomot (S n) _ _  h is2).
 apply (isofhlevelweqb (S n)  ( ezweq3g  f x xe' e' )  (is1 e')).
@@ -210,20 +210,20 @@ apply (isofhlevelssn).  assumption. Defined.
 (** *** h-levelf of [ pr1 ] *)
 
 
-Theorem isofhlevelfpr1 (n:nat) { X : UU } (P:X -> UU)(is: forall x:X, isofhlevel n (P x)) : isofhlevelf n  (@pr1 X P).
+Theorem isofhlevelfpr1 (n:nat) { X : UU } (P:X -> UU)(is: Π x:X, isofhlevel n (P x)) : isofhlevelf n  (@pr1 X P).
 Proof. intros. unfold isofhlevelf. intro x .  apply (isofhlevelweqf n  ( ezweqpr1  _ x)    (is x)). Defined.
 
-Lemma isweqpr1 { Z : UU } ( P : Z -> UU ) ( is1 : forall z : Z, iscontr ( P z ) ) : isweq ( @pr1 Z P ) .
+Lemma isweqpr1 { Z : UU } ( P : Z -> UU ) ( is1 : Π z : Z, iscontr ( P z ) ) : isweq ( @pr1 Z P ) .
 Proof. intros. unfold isweq.  intro y. set (isy:= is1 y). apply (iscontrweqf ( ezweqpr1 P y)) . assumption. Defined.
 
-Definition weqpr1 { Z : UU } ( P : Z -> UU ) ( is : forall z : Z , iscontr ( P z ) ) : weq ( total2 P ) Z := weqpair _ ( isweqpr1 P is ) .
+Definition weqpr1 { Z : UU } ( P : Z -> UU ) ( is : Π z : Z , iscontr ( P z ) ) : weq ( total2 P ) Z := weqpair _ ( isweqpr1 P is ) .
 
 
 
 
 (** *** h-level of the total space [ total2 ] *)
 
-Theorem isofhleveltotal2 ( n : nat ) { X : UU } ( P : X -> UU ) ( is1 : isofhlevel n X )( is2 : forall x:X, isofhlevel n (P x) ) : isofhlevel n (total2 P).
+Theorem isofhleveltotal2 ( n : nat ) { X : UU } ( P : X -> UU ) ( is1 : isofhlevel n X )( is2 : Π x:X, isofhlevel n (P x) ) : isofhlevel n (total2 P).
 Proof. intros. apply (isofhlevelXfromfY n  (@pr1 _ _ )). apply isofhlevelfpr1. assumption. assumption. Defined.
 
 Corollary isofhleveldirprod ( n : nat ) ( X Y : UU ) ( is1 : isofhlevel n X ) ( is2 : isofhlevel n Y ) : isofhlevel n (dirprod X Y).
@@ -257,7 +257,7 @@ Proof. intros. apply isofhleveltotal2. assumption. intro. assumption. Defined.
 
 Definition isaprop  := isofhlevel 1 .
 
-Definition isPredicate {X} (Y : X->UU) := ∀ x, isaprop (Y x).
+Definition isPredicate {X} (Y : X->UU) := Π x, isaprop (Y x).
 
 Definition isapropunit : isaprop unit := iscontrpathsinunit .
 
@@ -268,7 +268,7 @@ Proof. intros . set (f:= fun x:X => tt). assert (isw : isweq f). apply isweqcont
 Coercion isapropifcontr : iscontr >-> isaprop  .
 
 Theorem hlevelntosn ( n : nat ) ( T : UU )  ( is : isofhlevel n T ) : isofhlevel (S n) T.
-Proof. intro.   induction n as [ | n IHn ] . intro. apply isapropifcontr. intro.  intro X. change (forall t1 t2:T, isofhlevel (S n) (paths t1 t2)). intros t1 t2 . change (forall t1 t2 : T, isofhlevel n (paths t1 t2)) in X. set (XX := X t1 t2). apply (IHn _ XX).  Defined.
+Proof. intro.   induction n as [ | n IHn ] . intro. apply isapropifcontr. intro.  intro X. change (Π t1 t2:T, isofhlevel (S n) (paths t1 t2)). intros t1 t2 . change (Π t1 t2 : T, isofhlevel n (paths t1 t2)) in X. set (XX := X t1 t2). apply (IHn _ XX).  Defined.
 
 Corollary isofhlevelcontr (n:nat) { X : UU } ( is : iscontr X ) : isofhlevel n X.
 Proof. intro. induction n as [ | n IHn ] . intros X X0 . assumption.
@@ -313,10 +313,10 @@ Defined.
 Lemma iscontraprop1inv { X : UU } ( f : X -> iscontr X ) : isaprop X .
 Proof. intros X X0. assert ( H : X -> isofhlevel (S O) X). intro X1.  apply (hlevelntosn O _ ( X0 X1 ) ) . apply ( isofhlevelsn O H ) . Defined.
 
-Lemma proofirrelevance ( X : UU ) ( is : isaprop X ) : forall x x' : X , paths x x' .
+Lemma proofirrelevance ( X : UU ) ( is : isaprop X ) : Π x x' : X , paths x x' .
 Proof. intros . unfold isaprop in is . unfold isofhlevel in is .   apply ( pr1 ( is x x' ) ). Defined.
 
-Lemma invproofirrelevance ( X : UU ) ( ee : forall x x' : X , paths x x' ) : isaprop X.
+Lemma invproofirrelevance ( X : UU ) ( ee : Π x x' : X , paths x x' ) : isaprop X.
 Proof. intros . unfold isaprop. unfold isofhlevel .  intro x .
 assert ( is1 : iscontr X ).  split with x. intro t .  apply ( ee t x). assert ( is2 : isaprop X).  apply isapropifcontr. assumption.
 unfold isaprop in is2. unfold isofhlevel in is2.  apply (is2 x). Defined.
@@ -335,8 +335,8 @@ Defined.
 
 Lemma isweqimplimpl { X Y : UU } ( f : X -> Y ) ( g : Y -> X ) ( isx : isaprop X ) ( isy : isaprop Y ) : isweq f.
 Proof. intros.
-assert (isx0: forall x:X, paths (g (f x)) x). intro. apply proofirrelevance . apply isx .
-assert (isy0 : forall y : Y, paths (f (g y)) y). intro. apply proofirrelevance . apply isy .
+assert (isx0: Π x:X, paths (g (f x)) x). intro. apply proofirrelevance . apply isx .
+assert (isy0 : Π y : Y, paths (f (g y)) y). intro. apply proofirrelevance . apply isy .
 apply (gradth  f g isx0 isy0).  Defined.
 
 Definition weqimplimpl { X Y : UU } ( f : X -> Y ) ( g : Y -> X ) ( isx : isaprop X ) ( isy : isaprop Y ) := weqpair _ ( isweqimplimpl f g isx isy ) .
@@ -428,14 +428,14 @@ Definition isofhlevelsninclb (n:nat) { X Y : UU } (f:X -> Y)(is: isincl  f) : is
 Definition  isapropinclb { X Y : UU } ( f : X -> Y ) ( isf : isincl f ) : isaprop Y ->  isaprop X := isofhlevelXfromfY 1 _ isf .
 
 
-Lemma iscontrhfiberofincl { X Y : UU } (f:X -> Y): isincl  f -> (forall x:X, iscontr (hfiber  f (f x))).
+Lemma iscontrhfiberofincl { X Y : UU } (f:X -> Y): isincl  f -> (Π x:X, iscontr (hfiber  f (f x))).
 Proof. intros X Y f X0 x. unfold isofhlevelf in X0. set (isy:= X0 (f x)).  apply (iscontraprop1 isy (hfiberpair  f _ (idpath (f x)))). Defined.
 
 (* see incl_injectivity for the equivalence between isincl and isInjective *)
-Definition isInjective { X Y : UU } (f:X -> Y) := ∀ (x x':X), isweq (maponpaths f : x = x' -> f x = f x').
+Definition isInjective { X Y : UU } (f:X -> Y) := Π (x x':X), isweq (maponpaths f : x = x' -> f x = f x').
 
 Definition Injectivity { X Y : UU } (f:X -> Y) :
-  isInjective f -> ∀ (x x':X), x = x'  ≃  f x = f x'.
+  isInjective f -> Π (x x':X), x = x'  ≃  f x = f x'.
 Proof. intros ? ? ? i ? ?. exact (weqpair _ (i x x')). Defined.
 
 Lemma isweqonpathsincl { X Y : UU } (f:X -> Y) : isincl f -> isInjective f.
@@ -443,7 +443,7 @@ Proof. intros ? ? ? is x x'. apply (isofhlevelfonpaths O  f x x' is). Defined.
 
 Definition weqonpathsincl  { X Y : UU } (f:X -> Y) (is: isincl  f)(x x':X) := weqpair _ ( isweqonpathsincl f is x x' ) .
 
-Definition invmaponpathsincl { X Y : UU } (f:X -> Y) : isincl f -> ∀ x x', f x = f x' -> x = x'.
+Definition invmaponpathsincl { X Y : UU } (f:X -> Y) : isincl f -> Π x x', f x = f x' -> x = x'.
 Proof.
   intros ? ? ? is x x'.
   exact (invmap (weqonpathsincl  f is x x')).
@@ -452,10 +452,10 @@ Defined.
 Lemma isinclweqonpaths { X Y : UU } (f:X -> Y): isInjective f -> isincl  f.
 Proof. intros X Y f X0.  apply (isofhlevelfsn O f X0). Defined.
 
-Definition isinclpr1 { X : UU } (P:X -> UU)(is: forall x:X, isaprop (P x)): isincl  (@pr1 X P):= isofhlevelfpr1 (S O) P is.
+Definition isinclpr1 { X : UU } (P:X -> UU)(is: Π x:X, isaprop (P x)): isincl  (@pr1 X P):= isofhlevelfpr1 (S O) P is.
 
 Theorem subtypeInjectivity {A : UU} (B : A -> UU) :
-  isPredicate B -> ∀ (x y : total2 B), (x = y) ≃ (pr1 x = pr1 y).
+  isPredicate B -> Π (x y : total2 B), (x = y) ≃ (pr1 x = pr1 y).
 Proof. intros. apply Injectivity. apply isweqonpathsincl. now apply isinclpr1.
 Defined.
 
@@ -493,7 +493,7 @@ Defined.
 
 (** *** Basics about types of h-level 2 - "sets" *)
 
-Definition isaset ( X : UU ) : UU := ∀ x x' : X , isaprop ( x = x' ) .
+Definition isaset ( X : UU ) : UU := Π x x' : X , isaprop ( x = x' ) .
 
 (* Definition isaset := isofhlevel 2 . *)
 
@@ -511,7 +511,7 @@ Proof . intros . apply ( isofhlevelcontr 2 is ) . Defined .
 Lemma isasetaprop { X : UU } ( is : isaprop X ) : isaset X .
 Proof . intros . apply ( isofhlevelsnprop 1 is ) . Defined .
 
-Corollary isaset_total2 {X:UU} (P:X->UU) : isaset X -> (∀ x, isaset (P x)) -> isaset (Σ x, P x).
+Corollary isaset_total2 {X:UU} (P:X->UU) : isaset X -> (Π x, isaset (P x)) -> isaset (Σ x, P x).
 Proof. intros. apply (isofhleveltotal2 2); assumption. Defined.
 
 Corollary isaset_dirprod {X Y:UU} : isaset X -> isaset Y -> isaset (X × Y).
@@ -528,11 +528,11 @@ Proof. intros . apply ( proofirrelevance _ ( is x x' ) e e' ) . Defined .
 Lemma isofhlevelssnset (n:nat) ( X : UU ) ( is : isaset X ) : isofhlevel ( S (S n) ) X.
 Proof. intros n X X0. simpl. unfold isaset in X0.   intros x x' . apply isofhlevelsnprop. set ( int := X0 x x'). assumption . Defined.
 
-Lemma isasetifiscontrloops (X:UU): (forall x:X, iscontr (paths x x)) -> isaset X.
+Lemma isasetifiscontrloops (X:UU): (Π x:X, iscontr (paths x x)) -> isaset X.
 Proof. intros X X0. unfold isaset. unfold isofhlevel. intros x x' x0 x0' .   induction x0. set (is:= X0 x). apply isapropifcontr. assumption.  Defined.
 
-Lemma iscontrloopsifisaset (X:UU): (isaset X) -> (forall x:X, iscontr (paths x x)).
-Proof. intros X X0 x. unfold isaset in X0. unfold isofhlevel in X0.  change (forall (x x' : X) (x0 x'0 : paths x x'), iscontr (paths x0 x'0))  with (forall (x x':X),  isaprop (paths x x')) in X0.  apply (iscontraprop1 (X0 x x) (idpath x)). Defined.
+Lemma iscontrloopsifisaset (X:UU): (isaset X) -> (Π x:X, iscontr (paths x x)).
+Proof. intros X X0 x. unfold isaset in X0. unfold isofhlevel in X0.  change (Π (x x' : X) (x0 x'0 : paths x x'), iscontr (paths x0 x'0))  with (Π (x x':X),  isaprop (paths x x')) in X0.  apply (iscontraprop1 (X0 x x) (idpath x)). Defined.
 
 
 
@@ -552,7 +552,7 @@ Proof. intros. refine (isofhlevelfhfiberpr1 _ _ _ _). assumption. Defined.
 (** Criterion for a function between sets being an inclusion.  *)
 
 
-Theorem isinclbetweensets { X Y : UU } ( f : X -> Y ) ( isx : isaset X ) ( isy : isaset Y ) ( inj : forall x x' : X , ( paths ( f x ) ( f x' ) -> paths x x' ) ) : isincl f .
+Theorem isinclbetweensets { X Y : UU } ( f : X -> Y ) ( isx : isaset X ) ( isy : isaset Y ) ( inj : Π x x' : X , ( paths ( f x ) ( f x' ) -> paths x x' ) ) : isincl f .
 Proof. intros .  apply isinclweqonpaths .  intros x x' .  apply ( isweqimplimpl ( @maponpaths _ _ f x x' ) (  inj x x' ) ( isx x x' ) ( isy ( f x ) ( f x' ) ) ) . Defined .
 
 (** A map from [ unit ] to a set is an inclusion. *)

--- a/UniMath/Foundations/Basics/PartC.v
+++ b/UniMath/Foundations/Basics/PartC.v
@@ -25,7 +25,7 @@ Require Export UniMath.Foundations.Basics.PartB.
 
 (** *** Functional extensionality for functions to the empty type *)
 
-Axiom funextempty : ∀ (X:UU) (f g : X->empty), f = g.
+Axiom funextempty : Π (X:UU) (f g : X->empty), f = g.
 
 
 
@@ -100,15 +100,15 @@ Coercion negProp_to_neg : negProp >-> Funclass.
 Definition neg_to_negProp {P} {nP : negProp P} : ¬P -> nP.
 Proof. intros ? ? np. exact (pr1 (negProp_to_iff nP) np). Defined.
 
-Definition negPred {X:UU} (x  :X) (P:∀ y:X, UU)      := ∀ y  , negProp (P y).
+Definition negPred {X:UU} (x  :X) (P:Π y:X, UU)      := Π y  , negProp (P y).
 
-Definition negReln {X:UU}         (P:∀ (x y:X), UU)  := ∀ x y, negProp (P x y).
+Definition negReln {X:UU}         (P:Π (x y:X), UU)  := Π x y, negProp (P x y).
 
 Definition neqProp {X:UU} (x y:X) :=            negProp (x=y).
 
-Definition neqPred {X:UU} (x  :X) := ∀ y,       negProp (x=y).
+Definition neqPred {X:UU} (x  :X) := Π y,       negProp (x=y).
 
-Definition neqReln (X:UU)         := ∀ (x y:X), negProp (x=y).
+Definition neqReln (X:UU)         := Π (x y:X), negProp (x=y).
 
 Definition compl_ne (X:UU) (x:X) (neq_x : neqPred x) := Σ y, neq_x y.
 
@@ -206,7 +206,7 @@ Proof.
   - refine (weqfp _ _).
 Defined.
 
-Definition weqoncompl_compute { X Y : UU } (w: weq X Y) ( x : X ) : ∀ x', pr1 (weqoncompl w x x') = w (pr1 x').
+Definition weqoncompl_compute { X Y : UU } (w: weq X Y) ( x : X ) : Π x', pr1 (weqoncompl w x x') = w (pr1 x').
 Proof. intros. induction x' as [x' b]. reflexivity. Defined.
 
 Definition weqoncompl_ne_compute { X Y : UU }
@@ -262,8 +262,8 @@ Proof.
     - exact c.
 Defined.
 
-Definition isisolated (X:UU) (x:X) := ∀ x':X, (x = x') ⨿ (x != x').
-Definition isisolated_ne (X:UU) (x:X) (neq_x:neqPred x) := ∀ y:X, (x=y) ⨿ neq_x y.
+Definition isisolated (X:UU) (x:X) := Π x':X, (x = x') ⨿ (x != x').
+Definition isisolated_ne (X:UU) (x:X) (neq_x:neqPred x) := Π y:X, (x=y) ⨿ neq_x y.
 
 Definition isisolated_to_isisolated_ne {X x neq_x} :
   isisolated X x -> isisolated_ne X x neq_x.
@@ -292,7 +292,7 @@ Definition isolatedpair_ne ( T : UU ) (t:T) (neq:neqReln T) (i:isisolated_ne _ t
 Definition pr1isolated ( T : UU ) (x:isolated T) : T := pr1 x.
 Definition pr1isolated_ne ( T : UU ) (neq:neqReln T) (x:isolated_ne T neq) : T := pr1 x.
 
-Theorem isaproppathsfromisolated ( X : UU ) ( x : X ) ( is : isisolated X x ) : ∀ x', isaprop(x = x') .
+Theorem isaproppathsfromisolated ( X : UU ) ( x : X ) ( is : isisolated X x ) : Π x', isaprop(x = x') .
 Proof. intros . apply iscontraprop1inv .  intro e .  induction e .
 set (f:= fun e: paths x x => coconusfromtpair _ e).
 assert (is' : isweq f). apply (onefiber (fun x':X => paths x x' ) x (fun x':X => is x' )).
@@ -316,7 +316,7 @@ Proof.
   - contradicts (neq_x x k) (idpath x).
 Defined.
 
-Theorem isaproppathstoisolated  ( X : UU ) ( x : X ) ( is : isisolated X x ) : ∀ x' : X, isaprop ( x' = x ) .
+Theorem isaproppathstoisolated  ( X : UU ) ( x : X ) ( is : isisolated X x ) : Π x' : X, isaprop ( x' = x ) .
 Proof . intros . apply ( isofhlevelweqf 1 ( weqpathsinv0 x x' ) ( isaproppathsfromisolated X x is x' ) ) . Defined .
 
 Lemma isisolatedweqf { X Y : UU } (f : X ≃ Y) (x:X) : isisolated X x -> isisolated Y (f x).
@@ -409,9 +409,9 @@ Definition weqrecompl_ne (X:UU) (x:X) (is:isisolated X x) (neq_x:neqPred x): com
 Theorem isweqrecompl (X:UU)(x:X)(is:isisolated X x): isweq (recompl _ x).
 Proof. intros. set (f:= recompl _ x). set (g:= invrecompl X x is). unfold invrecompl in g. simpl in g.
 
-assert (efg: forall x':X, paths (f (g x')) x'). intro.   induction (is x') as [ x0 | e ].   induction x0. unfold f. unfold g. simpl. unfold recompl. simpl.  induction (is x) as [ x0 | e ] .  simpl. apply idpath. induction (e (idpath x)).  unfold f. unfold g. simpl. unfold recompl. simpl.  induction  (is x') as [ x0 | e0 ].  induction (e x0). simpl. apply idpath.
+assert (efg: Π x':X, paths (f (g x')) x'). intro.   induction (is x') as [ x0 | e ].   induction x0. unfold f. unfold g. simpl. unfold recompl. simpl.  induction (is x) as [ x0 | e ] .  simpl. apply idpath. induction (e (idpath x)).  unfold f. unfold g. simpl. unfold recompl. simpl.  induction  (is x') as [ x0 | e0 ].  induction (e x0). simpl. apply idpath.
 
-assert (egf: forall u: coprod  (compl X x) unit, paths (g (f u)) u). unfold isisolated in is. intro. induction (is (f u)) as [ p | e ] . induction u as [ c | u].    simpl. induction c as [ t x0 ]. simpl in p. induction (x0 p).
+assert (egf: Π u: coprod  (compl X x) unit, paths (g (f u)) u). unfold isisolated in is. intro. induction (is (f u)) as [ p | e ] . induction u as [ c | u].    simpl. induction c as [ t x0 ]. simpl in p. induction (x0 p).
 
 induction u.
 assert (e1: paths  (g (f (ii2 tt))) (g x)). apply (maponpaths g  p).
@@ -523,8 +523,8 @@ Proof. intros. intro t . unfold funtranspos .  rewrite ( homotrecomplfcomp t1 t2
 
 Theorem weqtranspos { T : UU } ( t1 t2 : T ) ( is1 : isisolated T t1 ) ( is2 : isisolated T t2 ) : weq T T .
 Proof . intros . set ( f := funtranspos ( tpair _ t1 is1) ( tpair _ t2 is2 ) ) . set ( g := funtranspos ( tpair _ t2 is2 ) ( tpair _ t1 is1 ) ) . split with f .
-assert ( egf : forall t : T , paths ( g ( f t ) ) t ) . intro . apply homottranspost2t1t1t2 .
-assert ( efg : forall t : T , paths ( f ( g t ) ) t ) . intro .  apply homottranspost2t1t1t2 .
+assert ( egf : Π t : T , paths ( g ( f t ) ) t ) . intro . apply homottranspost2t1t1t2 .
+assert ( efg : Π t : T , paths ( f ( g t ) ) t ) . intro .  apply homottranspost2t1t1t2 .
 apply ( gradth _ _ egf efg ) . Defined .
 
 
@@ -550,7 +550,7 @@ rewrite ( pathsfuntransposofnet1t2 _ _ _ _ _ net1t net2t ) . rewrite ( pathsfunt
 (** *** Types with decidable equality *)
 
 
-Definition isdeceq (X:UU) : UU := ∀ (x x':X), (x=x') ⨿ (x!=x').
+Definition isdeceq (X:UU) : UU := Π (x x':X), (x=x') ⨿ (x!=x').
 
 Lemma isdeceqweqf { X Y : UU } ( w : weq X Y ) ( is : isdeceq X ) : isdeceq Y .
 Proof. intros . intros y y' . set ( w' := weqonpaths ( invweq w ) y y' ) .  set ( int := is ( ( invweq w ) y ) ( ( invweq w ) y' ) ) . induction int as [ i | ni ] .    apply ( ii1 ( ( invweq w' ) i ) ) . apply ( ii2 ( ( negf w' ) ni ) ) .  Defined .
@@ -624,8 +624,8 @@ Definition subsetsplitinv { X : UU } ( f : X -> bool ) ( ab : coprod (hfiber f t
 
 Theorem weqsubsetsplit { X : UU } ( f : X -> bool ) : weq X (coprod ( hfiber f true) ( hfiber f false) ) .
 Proof . intros . set ( ff := subsetsplit f ) . set ( gg := subsetsplitinv f ) . split with ff .
-assert ( egf : forall a : _ , paths ( gg ( ff a ) ) a ) . intros .   unfold ff .  unfold subsetsplit . induction ( boolchoice ( f a ) ) as [ et | ef ] . simpl .  apply idpath .  simpl .  apply idpath .
-assert ( efg : forall a : _ , paths ( ff ( gg a ) ) a ) . intros . induction a as [ et | ef ] .  induction et as [ x et' ] .  simpl . unfold ff . unfold subsetsplit . induction ( boolchoice ( f x ) ) as [ e1 | e2 ] .   apply ( maponpaths ( @ii1 _ _  ) ) .  apply ( maponpaths ( hfiberpair f x ) ) .  apply uip . apply isasetbool . induction ( nopathstruetofalse ( pathscomp0 ( pathsinv0 et' ) e2 ) ) .    induction ef as [ x et' ] .  simpl . unfold ff . unfold subsetsplit . induction ( boolchoice ( f x ) ) as [ e1 | e2 ] . induction ( nopathsfalsetotrue ( pathscomp0 ( pathsinv0 et' ) e1 ) ) .     apply ( maponpaths ( @ii2 _ _  ) ) .  apply ( maponpaths ( hfiberpair f x ) ) .  apply uip . apply isasetbool .
+assert ( egf : Π a : _ , paths ( gg ( ff a ) ) a ) . intros .   unfold ff .  unfold subsetsplit . induction ( boolchoice ( f a ) ) as [ et | ef ] . simpl .  apply idpath .  simpl .  apply idpath .
+assert ( efg : Π a : _ , paths ( ff ( gg a ) ) a ) . intros . induction a as [ et | ef ] .  induction et as [ x et' ] .  simpl . unfold ff . unfold subsetsplit . induction ( boolchoice ( f x ) ) as [ e1 | e2 ] .   apply ( maponpaths ( @ii1 _ _  ) ) .  apply ( maponpaths ( hfiberpair f x ) ) .  apply uip . apply isasetbool . induction ( nopathstruetofalse ( pathscomp0 ( pathsinv0 et' ) e2 ) ) .    induction ef as [ x et' ] .  simpl . unfold ff . unfold subsetsplit . induction ( boolchoice ( f x ) ) as [ e1 | e2 ] . induction ( nopathsfalsetotrue ( pathscomp0 ( pathsinv0 et' ) e1 ) ) .     apply ( maponpaths ( @ii2 _ _  ) ) .  apply ( maponpaths ( hfiberpair f x ) ) .  apply uip . apply isasetbool .
 apply ( gradth _ _ egf efg ) . Defined .
 
 
@@ -665,7 +665,7 @@ Proof . intros . set ( g := eqbx Y y is ) . set ( ye := pr1 ( iscontrhfibereqbx 
 
 Theorem isinclii1 (X Y:UU): isincl  (@ii1 X Y).
 Proof. intros. set (f:= @ii1 X Y). set (g:= coprodtoboolsum X Y). set (gf:= fun x:X => (g (f x))). set (gf':= fun x:X => tpair (boolsumfun X Y) true x).
-assert (h: forall x:X , paths (gf' x) (gf x)). intro. apply idpath.
+assert (h: Π x:X , paths (gf' x) (gf x)). intro. apply idpath.
 assert (is1: isofhlevelf (S O)  gf'). apply (isofhlevelfsnfib O (boolsumfun X Y) true (isasetbool true true)).
 assert (is2: isofhlevelf (S O)  gf). apply (isofhlevelfhomot (S O)  gf' gf h is1).
 apply (isofhlevelff (S O) _ _ is2  (isofhlevelfweq (S (S O) )  (weqcoprodtoboolsum X Y))). Defined.
@@ -683,7 +683,7 @@ Proof. intros . intro xe . induction xe as [ x e ] . apply ( negpathsii1ii2 _ _ 
 
 Theorem isinclii2 (X Y:UU): isincl  (@ii2 X Y).
 Proof. intros. set (f:= @ii2 X Y). set (g:= coprodtoboolsum X Y). set (gf:= fun y:Y => (g (f y))). set (gf':= fun y:Y => tpair (boolsumfun X Y) false y).
-assert (h: forall y:Y , paths (gf' y) (gf y)). intro. apply idpath.
+assert (h: Π y:Y , paths (gf' y) (gf y)). intro. apply idpath.
 assert (is1: isofhlevelf (S O)  gf'). apply (isofhlevelfsnfib O (boolsumfun X Y) false (isasetbool false false)).
 assert (is2: isofhlevelf (S O)  gf). apply (isofhlevelfhomot (S O)  gf' gf h is1).
 apply (isofhlevelff (S O)  _ _ is2 (isofhlevelfweq (S (S O)) ( weqcoprodtoboolsum X Y))). Defined.
@@ -813,8 +813,8 @@ Proof. intros X Y Z f g z hsfg . induction hsfg as [ xy e ] .  induction xy as [
 
 Theorem weqhfibersofsumofmaps { X Y Z : UU } ( f : X -> Z ) ( g : Y -> Z ) ( z : Z ) : weq ( coprod ( hfiber f z ) ( hfiber g z ) ) ( hfiber ( sumofmaps f g ) z ) .
 Proof. intros . set ( ff := coprodofhfiberstohfiber f g z ) . set ( gg := hfibertocoprodofhfibers f g z ) . split with ff .
-assert ( effgg : forall hsfg : _ , paths ( ff ( gg hsfg ) ) hsfg ) . intro .  induction hsfg as [ xy e ] . induction xy as [ x | y ] . simpl .  apply idpath .  simpl . apply idpath .
-assert ( eggff : forall hfg : _ , paths ( gg ( ff hfg ) ) hfg ) . intro . induction hfg as [ hf | hg ] . induction hf as [ x fe ] . simpl .  apply idpath .  induction hg as [ y ge ] . simpl . apply idpath .
+assert ( effgg : Π hsfg : _ , paths ( ff ( gg hsfg ) ) hsfg ) . intro .  induction hsfg as [ xy e ] . induction xy as [ x | y ] . simpl .  apply idpath .  simpl . apply idpath .
+assert ( eggff : Π hfg : _ , paths ( gg ( ff hfg ) ) hfg ) . intro . induction hfg as [ hf | hg ] . induction hf as [ x fe ] . simpl .  apply idpath .  induction hg as [ y ge ] . simpl . apply idpath .
 apply ( gradth _ _ eggff effgg ) . Defined .
 
 
@@ -831,19 +831,19 @@ Proof . intros . intro z .  set ( w := weqhfibersofsumofmaps f g z ) .  set ( is
 (** *** Theorem saying that the sum of two functions of h-level n with non-intersecting images is of h-level n *)
 
 
-Lemma noil1 { X Y Z : UU } ( f : X -> Z ) ( g : Y -> Z ) ( noi : forall ( x : X ) ( y : Y ) , neg ( paths ( f x ) ( g y ) ) ) ( z : Z ) : hfiber f z -> hfiber g z -> empty .
+Lemma noil1 { X Y Z : UU } ( f : X -> Z ) ( g : Y -> Z ) ( noi : Π ( x : X ) ( y : Y ) , neg ( paths ( f x ) ( g y ) ) ) ( z : Z ) : hfiber f z -> hfiber g z -> empty .
 Proof. intros X Y Z f g noi z hfz hgz . induction hfz as [ x fe ] . induction hgz as [ y ge ] . apply ( noi x y ( pathscomp0 fe ( pathsinv0 ge ) ) ) .   Defined .
 
 
-Lemma weqhfibernoi1  { X Y Z : UU } ( f : X -> Z ) ( g : Y -> Z ) ( noi : forall ( x : X ) ( y : Y ) , neg ( paths ( f x ) ( g y ) ) ) ( z : Z ) ( xe : hfiber f z ) : weq ( hfiber ( sumofmaps f g ) z ) ( hfiber f z ) .
+Lemma weqhfibernoi1  { X Y Z : UU } ( f : X -> Z ) ( g : Y -> Z ) ( noi : Π ( x : X ) ( y : Y ) , neg ( paths ( f x ) ( g y ) ) ) ( z : Z ) ( xe : hfiber f z ) : weq ( hfiber ( sumofmaps f g ) z ) ( hfiber f z ) .
 Proof. intros . set ( w1 := invweq ( weqhfibersofsumofmaps f g z ) ) .  assert ( a : neg ( hfiber g z ) ) . intro ye . apply ( noil1 f g noi z xe ye ) .    set ( w2 := invweq ( weqii1withneg ( hfiber f z ) a ) ) .  apply ( weqcomp w1 w2 ) . Defined .
 
-Lemma weqhfibernoi2  { X Y Z : UU } ( f : X -> Z ) ( g : Y -> Z ) ( noi : forall ( x : X ) ( y : Y ) , neg ( paths ( f x ) ( g y ) ) ) ( z : Z ) ( ye : hfiber g z ) : weq ( hfiber ( sumofmaps f g ) z ) ( hfiber g z ) .
+Lemma weqhfibernoi2  { X Y Z : UU } ( f : X -> Z ) ( g : Y -> Z ) ( noi : Π ( x : X ) ( y : Y ) , neg ( paths ( f x ) ( g y ) ) ) ( z : Z ) ( ye : hfiber g z ) : weq ( hfiber ( sumofmaps f g ) z ) ( hfiber g z ) .
 Proof. intros . set ( w1 := invweq ( weqhfibersofsumofmaps f g z ) ) .  assert ( a : neg ( hfiber f z ) ) . intro xe . apply ( noil1 f g noi z xe ye ) .    set ( w2 := invweq ( weqii2withneg ( hfiber g z ) a ) ) .  apply ( weqcomp w1 w2 ) . Defined .
 
 
 
-Theorem isofhlevelfsumofmapsnoi ( n : nat ) { X Y Z : UU } ( f : X -> Z ) ( g : Y -> Z ) ( isf : isofhlevelf n f ) ( isg : isofhlevelf n g ) ( noi : forall ( x : X ) ( y : Y ) , neg ( paths ( f x ) ( g y ) ) ) : isofhlevelf n ( sumofmaps f g ) .
+Theorem isofhlevelfsumofmapsnoi ( n : nat ) { X Y Z : UU } ( f : X -> Z ) ( g : Y -> Z ) ( isf : isofhlevelf n f ) ( isg : isofhlevelf n g ) ( noi : Π ( x : X ) ( y : Y ) , neg ( paths ( f x ) ( g y ) ) ) : isofhlevelf n ( sumofmaps f g ) .
 Proof. intros .  intro z .  induction n as [ | n ] .   set ( zinx := invweq ( weqpair _ isf ) z ) . set ( ziny := invweq ( weqpair _ isg ) z ) . assert ( ex : paths ( f zinx ) z ) .  apply ( homotweqinvweq ( weqpair _ isf ) z ) . assert ( ey : paths ( g ziny ) z ) . apply ( homotweqinvweq ( weqpair _ isg ) z ) .   induction ( ( noi zinx ziny ) ( pathscomp0 ex ( pathsinv0 ey ) ) ) .
 apply isofhlevelsn . intro hfgz .  induction ( ( invweq ( weqhfibersofsumofmaps f g z ) hfgz ) ) as [ xe | ye ] .   apply ( isofhlevelweqb _ ( weqhfibernoi1 f g noi z xe ) ( isf z ) ) .   apply ( isofhlevelweqb _ ( weqhfibernoi2 f g noi z ye ) ( isg z ) ) . Defined .
 
@@ -869,11 +869,11 @@ assert (ne: neg (paths x x1 )). apply (negf  (maponpaths ( @ii1 _ _ ) ) x0). app
 
 Theorem isweqtocompltoii1x (X Y:UU)(x:X): isweq (tocompltoii1x X Y x).
 Proof. intros. set (f:= tocompltoii1x X Y x). set (g:= fromcompltoii1x X Y x).
-assert (egf:forall nexy:_ , paths (g (f nexy)) nexy). intro. induction nexy as [ c | y ]. induction c as [ t x0 ]. simpl.
+assert (egf:Π nexy:_ , paths (g (f nexy)) nexy). intro. induction nexy as [ c | y ]. induction c as [ t x0 ]. simpl.
 assert (e: paths (negf (maponpaths (@ii1 X Y)) (negf (invmaponpathsincl  (@ii1 X Y) (isinclii1 X Y) x t) x0)) x0). apply (isapropneg (paths x t) ).
 apply (maponpaths (fun ee: neg (paths x t ) => ii1  (complpair X x t ee))  e). apply idpath.
 
-assert (efg: forall neii1x:_, paths (f (g neii1x)) neii1x). intro.  induction neii1x as [ t x0 ]. induction t as [ x1 | y ].  simpl.
+assert (efg: Π neii1x:_, paths (f (g neii1x)) neii1x). intro.  induction neii1x as [ t x0 ]. induction t as [ x1 | y ].  simpl.
 assert (e: paths  (negf (invmaponpathsincl (@ii1 X Y) (isinclii1 X Y) x x1 ) (negf (maponpaths (@ii1 X Y) ) x0)) x0). apply (isapropneg (paths _ _ )  ).
 apply (maponpaths (fun ee: (neg (paths (ii1 x) (ii1 x1))) => (complpair _ _ (ii1 x1) ee))  e). simpl.
 assert (e: paths (negf pathsinv0 (negpathsii2ii1 x y)) x0). apply (isapropneg (paths _ _ ) ).
@@ -895,12 +895,12 @@ assert (ne: neg (paths y y0 )). apply (negf  (maponpaths ( @ii2 _ _ ) ) x). appl
 
 Theorem isweqtocompltoii2y (X Y:UU)(y:Y): isweq (tocompltoii2y X Y y).
 Proof. intros. set (f:= tocompltoii2y X Y y). set (g:= fromcompltoii2y X Y y).
-assert (egf:forall nexy:_ , paths (g (f nexy)) nexy). intro. induction nexy as [ x | c ].
+assert (egf:Π nexy:_ , paths (g (f nexy)) nexy). intro. induction nexy as [ x | c ].
 apply idpath. induction c as [ t x ]. simpl.
 assert (e: paths (negf (maponpaths (@ii2 X Y) ) (negf (invmaponpathsincl (@ii2 X Y) (isinclii2 X Y) y t) x)) x). apply (isapropneg (paths y t ) ).
 apply (maponpaths (fun ee: neg ( paths y t ) => ii2  (complpair _ y t ee))  e).
 
-assert (efg: forall neii2x:_, paths (f (g neii2x)) neii2x). intro.  induction neii2x as [ t x ]. induction t as [ x0 | y0 ].  simpl.
+assert (efg: Π neii2x:_, paths (f (g neii2x)) neii2x). intro.  induction neii2x as [ t x ]. induction t as [ x0 | y0 ].  simpl.
 assert (e: paths (negpathsii2ii1 x0 y) x). apply (isapropneg (paths _ _ ) ).
 apply (maponpaths   (fun ee: (neg (paths (ii2 y) (ii1 x0)  )) => (complpair _ _ (ii1 x0) ee))  e). simpl.
 assert (e: paths  (negf (invmaponpathsincl _ (isinclii2 X Y) y y0 ) (negf (maponpaths (@ii2 X Y) ) x)) x). apply (isapropneg (paths _ _ )  ).
@@ -921,8 +921,8 @@ Proof. intros X X0. induction X0 as [ t x ].  induction t as [ x0 | u ] . assump
 
 Lemma isweqtocompltodisjoint (X:UU): isweq (tocompltodisjoint X).
 Proof. intros. set (ff:= tocompltodisjoint X). set (gg:= fromcompltodisjoint X).
-assert (egf: forall x:X, paths (gg (ff x)) x).  intro.  apply idpath.
-assert (efg: forall xx:_, paths (ff (gg xx)) xx). intro. induction xx as [ t x ].  induction t as [ x0 | u ] .   simpl.  unfold ff. unfold tocompltodisjoint. simpl. assert (ee: paths  (negpathsii2ii1 x0 tt) x).  apply (proofirrelevance _ (isapropneg _) ). induction ee. apply idpath. induction u.  simpl. apply (fromempty (x (idpath _))). apply (gradth  ff gg egf efg).  Defined.
+assert (egf: Π x:X, paths (gg (ff x)) x).  intro.  apply idpath.
+assert (efg: Π xx:_, paths (ff (gg xx)) xx). intro. induction xx as [ t x ].  induction t as [ x0 | u ] .   simpl.  unfold ff. unfold tocompltodisjoint. simpl. assert (ee: paths  (negpathsii2ii1 x0 tt) x).  apply (proofirrelevance _ (isapropneg _) ). induction ee. apply idpath. induction u.  simpl. apply (fromempty (x (idpath _))). apply (gradth  ff gg egf efg).  Defined.
 
 
 Definition weqtocompltodisjoint ( X : UU ) := weqpair _ ( isweqtocompltodisjoint X ) .
@@ -1012,7 +1012,7 @@ Defined .
 Lemma isdecproppaths { X : UU } ( is : isdeceq X ) ( x x' : X ) : isdecprop ( paths x x' ) .
 Proof. intros . apply ( isdecpropif _ ( isasetifdeceq _ is x x' ) ( is x x' ) ) .  Defined .
 
-Lemma isdeceqif { X : UU } ( is : forall x x' : X , isdecprop ( paths x x' ) ) : isdeceq X .
+Lemma isdeceqif { X : UU } ( is : Π x x' : X , isdecprop ( paths x x' ) ) : isdeceq X .
 Proof . intros . intros x x' . apply ( pr1 ( is x x' ) ) . Defined .
 
 Lemma isaninv1 (X:UU): isdecprop X  -> isaninvprop X.
@@ -1060,7 +1060,7 @@ Proof . intros . apply ( isdecpropweqf ( weqpathsinv0 x x' ) ( isdecproppathsfro
 
 
 
-Definition isdecincl {X Y:UU} (f :X -> Y) := ∀ y:Y, isdecprop ( hfiber f y ).
+Definition isdecincl {X Y:UU} (f :X -> Y) := Π y:Y, isdecprop ( hfiber f y ).
 Lemma isdecincltoisincl { X Y : UU } ( f : X -> Y ) : isdecincl f -> isincl f .
 Proof. intros X Y f is . intro y . apply ( isdecproptoisaprop _ ( is y ) ) . Defined.
 Coercion isdecincltoisincl : isdecincl >-> isincl .
@@ -1082,17 +1082,17 @@ Proof. intros. intro y . induction y as [ x | y ] .  apply ( isdecpropif _ ( isi
 apply ( isdecpropif _ ( isinclii2 X Y ( ii2 y ) ) ( ii1 (hfiberpair  (@ii2 _ _ )  y (idpath _ )) ) ) .   Defined.
 
 
-Lemma isdecinclpr1 { X : UU } ( P : X -> UU ) ( is : forall x : X , isdecprop ( P x ) ) : isdecincl ( @pr1 _ P ) .
+Lemma isdecinclpr1 { X : UU } ( P : X -> UU ) ( is : Π x : X , isdecprop ( P x ) ) : isdecincl ( @pr1 _ P ) .
 Proof . intros . intro x . assert ( w : weq ( P x ) ( hfiber (@pr1 _ P )  x ) ) . apply ezweqpr1 .  apply ( isdecpropweqf w ( is x ) ) . Defined .
 
 
-Theorem isdecinclhomot { X Y : UU } ( f g : X -> Y ) ( h : forall x : X , paths ( f x ) ( g x ) ) ( is : isdecincl f ) : isdecincl g .
+Theorem isdecinclhomot { X Y : UU } ( f g : X -> Y ) ( h : Π x : X , paths ( f x ) ( g x ) ) ( is : isdecincl f ) : isdecincl g .
 Proof. intros . intro y . apply ( isdecpropweqf ( weqhfibershomot f g h y ) ( is y ) ) . Defined .
 
 
 Theorem isdecinclcomp { X Y Z : UU } ( f : X -> Y ) ( g : Y -> Z ) ( isf : isdecincl f ) ( isg : isdecincl g ) : isdecincl ( fun x : X => g ( f x ) ) .
-Proof. intros. intro z .  set ( gf := fun x : X => g ( f x ) ) . assert ( wy : forall ye : hfiber g z , weq ( hfiber f ( pr1 ye ) ) ( hfiber ( hfibersgftog f g z ) ye ) ) . apply  ezweqhf .
-assert ( ww : forall y : Y , weq ( hfiber f y ) ( hfiber gf ( g y ) ) ) . intro .  apply ( samehfibers f g ) . apply ( isdecincltoisincl _ isg ) .
+Proof. intros. intro z .  set ( gf := fun x : X => g ( f x ) ) . assert ( wy : Π ye : hfiber g z , weq ( hfiber f ( pr1 ye ) ) ( hfiber ( hfibersgftog f g z ) ye ) ) . apply  ezweqhf .
+assert ( ww : Π y : Y , weq ( hfiber f y ) ( hfiber gf ( g y ) ) ) . intro .  apply ( samehfibers f g ) . apply ( isdecincltoisincl _ isg ) .
   induction ( pr1 ( isg z ) ) as [ ye | nye ] . induction ye as [ y e ] .  induction e . apply ( isdecpropweqf ( ww y ) ( isf y ) ) .   assert ( wz : weq ( hfiber gf z ) ( hfiber g z ) ) . split with ( hfibersgftog f g z ) . intro ye .   induction ( nye ye ) .  apply ( isdecpropweqb wz ( isg z ) ) .  Defined .
 
 (** The conditions of the following theorem can be weakened by assuming only that the h-fibers of g satisfy [ isdeceq ] i.e. are "sets with decidable equality". *)
@@ -1111,7 +1111,7 @@ Proof. intros . intro z . set ( gf := fun x : X => g ( f x ) ) . assert ( w : we
 (** *** Decidable inclusions and isolated points *)
 
 Theorem isisolateddecinclf { X Y : UU } ( f : X -> Y ) ( x : X ) : isdecincl f -> isisolated X x -> isisolated Y ( f x ) .
-Proof .  intros X Y f x isf isx .   assert ( is' : forall y : Y , isdecincl ( d1g  f y x ) ) . intro y .  intro xe .  set ( w := ezweq2g f x xe ) . apply ( isdecpropweqf w ( isdecproppathstoisolated X x isx _ ) ) .  assert ( is'' : forall y : Y , isdecprop ( paths ( f x ) y ) ) . intro .  apply ( isdecpropfromdecincl _ ( is' y ) ( isf y ) ) . intro y' .   apply ( pr1 ( is'' y' ) ) .  Defined .
+Proof .  intros X Y f x isf isx .   assert ( is' : Π y : Y , isdecincl ( d1g  f y x ) ) . intro y .  intro xe .  set ( w := ezweq2g f x xe ) . apply ( isdecpropweqf w ( isdecproppathstoisolated X x isx _ ) ) .  assert ( is'' : Π y : Y , isdecprop ( paths ( f x ) y ) ) . intro .  apply ( isdecpropfromdecincl _ ( is' y ) ( isf y ) ) . intro y' .   apply ( pr1 ( is'' y' ) ) .  Defined .
 
 
 
@@ -1122,7 +1122,7 @@ Definition negimage { X Y : UU } ( f : X -> Y ) := total2 ( fun y : Y => neg ( h
 Definition negimagepair { X Y : UU } ( f : X -> Y ) := tpair ( fun y : Y => neg ( hfiber f y ) ) .
 
 Lemma isinclfromcoprodwithnegimage { X Y : UU } ( f : X -> Y ) ( is : isincl f ) : isincl ( sumofmaps f ( @pr1 _ ( fun y : Y => neg ( hfiber f y ) ) ) ) .
-Proof .  intros . assert ( noi : forall ( x : X ) ( nx : negimage f ) , neg ( paths ( f x ) ( pr1 nx ) ) ) .  intros x nx e .  induction nx as [ y nhf ] .  simpl in e .  apply ( nhf ( hfiberpair _ x e ) ) . assert ( is' : isincl ( @pr1 _ ( fun y : Y => neg ( hfiber f y ) ) ) ) .  apply isinclpr1 .   intro y .  apply isapropneg .  apply ( isofhlevelfsumofmapsnoi 1 f _ is is' noi ) .   Defined .
+Proof .  intros . assert ( noi : Π ( x : X ) ( nx : negimage f ) , neg ( paths ( f x ) ( pr1 nx ) ) ) .  intros x nx e .  induction nx as [ y nhf ] .  simpl in e .  apply ( nhf ( hfiberpair _ x e ) ) . assert ( is' : isincl ( @pr1 _ ( fun y : Y => neg ( hfiber f y ) ) ) ) .  apply isinclpr1 .   intro y .  apply isapropneg .  apply ( isofhlevelfsumofmapsnoi 1 f _ is is' noi ) .   Defined .
 
 
 Definition iscoproj { X Y : UU } ( f : X -> Y ) := isweq ( sumofmaps f ( @pr1 _ ( fun y : Y => neg ( hfiber f y ) ) ) ) .
@@ -1164,15 +1164,15 @@ Note : some of the results above this point in code use a very limitted form of 
 
 (** etacorrection *)
 
-Definition etacorrection: forall T:UU, forall P:T -> UU, forall f: (forall t:T, P t), paths f (fun t:T => f t).
+Definition etacorrection: Π T:UU, Π P:T -> UU, Π f: (Π t:T, P t), paths f (fun t:T => f t).
 Proof. reflexivity. Defined.
 
-Lemma isweqetacorrection { T : UU } (P:T -> UU): isweq (fun f: forall t:T, P t => (fun t:T => f t)).
+Lemma isweqetacorrection { T : UU } (P:T -> UU): isweq (fun f: Π t:T, P t => (fun t:T => f t)).
 Proof. intros. apply idisweq. Defined.
 
 Definition weqeta { T : UU } (P:T -> UU) := weqpair _ ( isweqetacorrection P ) .
 
-Lemma etacorrectiononpaths { T : UU } (P:T->UU)(s1 s2 :forall t:T, P t) : paths (fun t:T => s1 t) (fun t:T => s2 t)-> paths s1 s2.
+Lemma etacorrectiononpaths { T : UU } (P:T->UU)(s1 s2 :Π t:T, P t) : paths (fun t:T => s1 t) (fun t:T => s2 t)-> paths s1 s2.
 Proof. intros T P s1 s2 X. set (ew := weqeta P). apply (invmaponpathsweq ew s1 s2 X). Defined.
 
 Definition etacor { X Y : UU } (f:X -> Y) : paths f (fun x:X => f x) := etacorrection _ (fun T:X => Y) f.
@@ -1184,15 +1184,15 @@ Proof. intros X Y f1 f2 X0. set (ec:= weqeta (fun x:X => Y) ). apply (invmaponpa
 (** Dependent functions and sections up to homotopy I *)
 
 
-Definition toforallpaths { T : UU }  (P:T -> UU) (f g :forall t:T, P t) : (paths f g) -> (forall t:T, paths (f t) (g t)).
+Definition toforallpaths { T : UU }  (P:T -> UU) (f g :Π t:T, P t) : (paths f g) -> (Π t:T, paths (f t) (g t)).
 Proof. intros T P f g X t. induction X. apply (idpath (f t)). Defined.
 
 
-Definition sectohfiber { X : UU } (P:X -> UU): (forall x:X, P x) -> (hfiber (fun f:_ => fun x:_ => pr1  (f x)) (fun x:X => x)) := (fun a : forall x:X, P x => tpair _ (fun x:_ => tpair _ x (a x)) (idpath (fun x:X => x))).
+Definition sectohfiber { X : UU } (P:X -> UU): (Π x:X, P x) -> (hfiber (fun f:_ => fun x:_ => pr1  (f x)) (fun x:X => x)) := (fun a : Π x:X, P x => tpair _ (fun x:_ => tpair _ x (a x)) (idpath (fun x:X => x))).
 
-Definition hfibertosec  { X : UU } (P:X -> UU):  (hfiber (fun f:_ => fun x:_ => pr1  (f x)) (fun x:X => x)) -> (forall x:X, P x):= fun se:_  => fun x:X => match se as se' return P x with tpair _ s e => (transportf P (toforallpaths (fun x:X => X)  (fun x:X => pr1 (s x)) (fun x:X => x) e x) (pr2  (s x))) end.
+Definition hfibertosec  { X : UU } (P:X -> UU):  (hfiber (fun f:_ => fun x:_ => pr1  (f x)) (fun x:X => x)) -> (Π x:X, P x):= fun se:_  => fun x:X => match se as se' return P x with tpair _ s e => (transportf P (toforallpaths (fun x:X => X)  (fun x:X => pr1 (s x)) (fun x:X => x) e x) (pr2  (s x))) end.
 
-Definition sectohfibertosec { X : UU } (P:X -> UU): forall a: forall x:X, P x, paths (hfibertosec _  (sectohfiber _ a)) a := fun a:_ => (pathsinv0 (etacorrection _ _ a)).
+Definition sectohfibertosec { X : UU } (P:X -> UU): Π a: Π x:X, P x, paths (hfibertosec _  (sectohfiber _ a)) a := fun a:_ => (pathsinv0 (etacorrection _ _ a)).
 
 
 (* End of the file uu0c.v *)

--- a/UniMath/Foundations/Basics/PartD.v
+++ b/UniMath/Foundations/Basics/PartD.v
@@ -20,7 +20,7 @@ Require Export UniMath.Foundations.Basics.PartC.
 
 (** *** Deduction of functional extnsionality for dependent functions (sections) from functional extensionality of usual functions *)
 
-Axiom funextfunax : forall (X Y:UU)(f g:X->Y),  (forall x:X, paths (f x) (g x)) -> (paths f g).
+Axiom funextfunax : Π (X Y:UU)(f g:X->Y),  (Π x:X, paths (f x) (g x)) -> (paths f g).
 
 
 Lemma isweqlcompwithweq { X X' : UU} (w: weq X X') (Y:UU) : isweq (fun a:X'->Y => (fun x:X => a (w x))).
@@ -39,22 +39,22 @@ apply (gradth  f g egf efg). Defined.
 
 
 
-Theorem funcontr { X : UU } (P:X -> UU) : (forall x:X, iscontr (P x)) -> iscontr (forall x:X, P x).
-Proof. intros X P X0 . set (T1 := forall x:X, P x). set (T2 := (hfiber (fun f: (X -> total2 P)  => fun x: X => pr1  (f x)) (fun x:X => x))). assert (is1:isweq (@pr1 X P)). apply isweqpr1. assumption.  set (w1:= weqpair  (@pr1 X P) is1).
+Theorem funcontr { X : UU } (P:X -> UU) : (Π x:X, iscontr (P x)) -> iscontr (Π x:X, P x).
+Proof. intros X P X0 . set (T1 := Π x:X, P x). set (T2 := (hfiber (fun f: (X -> total2 P)  => fun x: X => pr1  (f x)) (fun x:X => x))). assert (is1:isweq (@pr1 X P)). apply isweqpr1. assumption.  set (w1:= weqpair  (@pr1 X P) is1).
 assert (X1:iscontr T2).  apply (isweqrcompwithweq  w1 X (fun x:X => x)).
 apply ( iscontrretract  _ _  (sectohfibertosec P ) X1). Defined.
 
-Corollary funcontrtwice { X : UU } (P: X-> X -> UU)(is: forall (x x':X), iscontr (P x x')): iscontr (forall (x x':X), P x x').
+Corollary funcontrtwice { X : UU } (P: X-> X -> UU)(is: Π (x x':X), iscontr (P x x')): iscontr (Π (x x':X), P x x').
 Proof. intros.
-assert (is1: forall x:X, iscontr (forall x':X, P x x')). intro. apply (funcontr _ (is x)). apply (funcontr _ is1). Defined.
+assert (is1: Π x:X, iscontr (Π x':X, P x x')). intro. apply (funcontr _ (is x)). apply (funcontr _ is1). Defined.
 
 
-(** Proof of the fact that the [ toforallpaths ] from [paths s1 s2] to [forall t:T, paths (s1 t) (s2 t)] is a weak equivalence - a strong form
+(** Proof of the fact that the [ toforallpaths ] from [paths s1 s2] to [Π t:T, paths (s1 t) (s2 t)] is a weak equivalence - a strong form
 of functional extensionality for sections of general families. The proof uses only [funcontr] which is an axiom i.e. its type satisfies [ isaprop ].  *)
 
-Lemma funextweql1 { T : UU } (P:T -> UU) (g: ∀ t, P t) : ∃! (f:∀ t, P t), ∀ t:T, f t = g t.
+Lemma funextweql1 { T : UU } (P:T -> UU) (g: Π t, P t) : ∃! (f:Π t, P t), Π t:T, f t = g t.
 Proof.
-  intros. unshelve refine (iscontrretract (X := ∀ t, Σ p, p = g t) _ _ _ _).
+  intros. unshelve refine (iscontrretract (X := Π t, Σ p, p = g t) _ _ _ _).
   - intros x. unshelve refine (_,,_).
     + intro t. exact (pr1 (x t)).
     + intro t; simpl. exact (pr2 (x t)).
@@ -63,46 +63,46 @@ Proof.
   - apply funcontr. intro t. apply iscontrcoconustot.
 Defined.
 
-Theorem isweqtoforallpaths { T : UU } (P:T -> UU) (f g: ∀ t:T, P t) :
+Theorem isweqtoforallpaths { T : UU } (P:T -> UU) (f g: Π t:T, P t) :
   isweq (toforallpaths P f g).
 Proof.
   intros.
-  refine (isweqtotaltofib _ _ (λ (h:∀ t, P t), toforallpaths P h g) _ f).
-  refine (isweqcontrcontr (X := Σ (h: ∀ t, P t), h = g)
+  refine (isweqtotaltofib _ _ (λ (h:Π t, P t), toforallpaths P h g) _ f).
+  refine (isweqcontrcontr (X := Σ (h: Π t, P t), h = g)
             (λ ff, tpair _ (pr1 ff) (toforallpaths P (pr1 ff) g (pr2 ff))) _ _).
   { exact (iscontrcoconustot _ g). }
   { apply funextweql1. }
 Qed.
 
-Theorem weqtoforallpaths { T : UU } (P:T -> UU)(f g : forall t:T, P t) :
-  (f = g) ≃ (∀ t:T, f t = g t).
+Theorem weqtoforallpaths { T : UU } (P:T -> UU)(f g : Π t:T, P t) :
+  (f = g) ≃ (Π t:T, f t = g t).
 Proof. intros. exists (toforallpaths P f g). apply isweqtoforallpaths. Defined.
 
-Definition funextsec {T:UU} (P: T-> UU) (f g : ∀ t:T, P t) : (∀ t, f t = g t) -> f = g
+Definition funextsec {T:UU} (P: T-> UU) (f g : Π t:T, P t) : (Π t, f t = g t) -> f = g
   := invmap (weqtoforallpaths _ f g) .
 
-Definition funextfun { X Y:UU } (f g:X->Y) : (∀ x:X, f x = g x) -> f = g
+Definition funextfun { X Y:UU } (f g:X->Y) : (Π x:X, f x = g x) -> f = g
   := funextsec _ _ _.
 
 (** I do not know at the moment whether [funextfun] is equal (homotopic) to [funextfunax]. It is advisable in all cases to use [funextfun] or, equivalently, [funextsec], since it can be produced from [funcontr] and therefore is well defined up to a canonical equivalence.  In addition it is a homotopy inverse of [toforallpaths] which may be true or not for [funextsecax]. *)
 
-Theorem isweqfunextsec { T : UU } (P:T -> UU)(f g : forall t:T, P t) : isweq (funextsec P f g).
+Theorem isweqfunextsec { T : UU } (P:T -> UU)(f g : Π t:T, P t) : isweq (funextsec P f g).
 Proof. intros. apply (isweqinvmap ( weqtoforallpaths _  f g ) ). Defined.
 
-Definition weqfunextsec { T : UU } (P:T -> UU)(f g : forall t:T, P t) : weq  (forall t:T, paths (f t) (g t)) (paths f g) := weqpair _ ( isweqfunextsec P f g ) .
+Definition weqfunextsec { T : UU } (P:T -> UU)(f g : Π t:T, P t) : weq  (Π t:T, paths (f t) (g t)) (paths f g) := weqpair _ ( isweqfunextsec P f g ) .
 
 
 
 
 
 
-(** ** Sections of "double fibration" [(P: T -> UU)(PP: forall t:T, P t -> UU)] and pairs of sections *)
+(** ** Sections of "double fibration" [(P: T -> UU)(PP: Π t:T, P t -> UU)] and pairs of sections *)
 
 
 
 (** *** General case *)
 
-Definition totaltoforall { X : UU } (P : X -> UU ) ( PP : forall x:X, P x -> UU ) : total2 (fun s0: forall x:X, P x => forall x:X, PP x (s0 x)) -> forall x:X, total2 (PP x).
+Definition totaltoforall { X : UU } (P : X -> UU ) ( PP : Π x:X, P x -> UU ) : total2 (fun s0: Π x:X, P x => Π x:X, PP x (s0 x)) -> Π x:X, total2 (PP x).
 Proof.
   intros X P PP X0 x.
   exists (pr1 X0 x).
@@ -110,49 +110,49 @@ Proof.
 Defined.
 
 
-Definition foralltototal  { X : UU } ( P : X -> UU ) ( PP : forall x:X, P x -> UU ):  (forall x:X, total2 (PP x)) -> total2 (fun s0: forall x:X, P x => forall x:X, PP x (s0 x)).
+Definition foralltototal  { X : UU } ( P : X -> UU ) ( PP : Π x:X, P x -> UU ):  (Π x:X, total2 (PP x)) -> total2 (fun s0: Π x:X, P x => Π x:X, PP x (s0 x)).
 Proof.
   intros X P PP X0.
   exists (fun x:X => pr1  (X0 x)).
   apply (fun x:X => pr2  (X0 x)).
 Defined.
 
-Lemma lemmaeta1 { X : UU } (P:X->UU) (Q:(forall x:X, P x) -> UU)(s0: forall x:X, P x)(q: Q (fun x:X => (s0 x))): paths (tpair (fun s: (forall x:X, P x) => Q (fun x:X => (s x))) s0 q) (tpair (fun s: (forall x:X, P x) => Q (fun x:X => (s x))) (fun x:X => (s0 x)) q).
-Proof. intros. set (ff:= fun tp:total2 (fun s: (forall x:X, P x) => Q (fun x:X => (s x))) => tpair _ (fun x:X => pr1  tp x) (pr2  tp)). assert (X0 : isweq ff).  apply (isweqfpmap  ( weqeta P ) Q ).
-assert (ee: paths (ff (tpair (fun s : forall x : X, P x => Q (fun x : X => s x)) s0 q)) (ff (tpair (fun s : forall x : X, P x => Q (fun x : X => s x)) (fun x : X => s0 x) q))). apply idpath.
+Lemma lemmaeta1 { X : UU } (P:X->UU) (Q:(Π x:X, P x) -> UU)(s0: Π x:X, P x)(q: Q (fun x:X => (s0 x))): paths (tpair (fun s: (Π x:X, P x) => Q (fun x:X => (s x))) s0 q) (tpair (fun s: (Π x:X, P x) => Q (fun x:X => (s x))) (fun x:X => (s0 x)) q).
+Proof. intros. set (ff:= fun tp:total2 (fun s: (Π x:X, P x) => Q (fun x:X => (s x))) => tpair _ (fun x:X => pr1  tp x) (pr2  tp)). assert (X0 : isweq ff).  apply (isweqfpmap  ( weqeta P ) Q ).
+assert (ee: paths (ff (tpair (fun s : Π x : X, P x => Q (fun x : X => s x)) s0 q)) (ff (tpair (fun s : Π x : X, P x => Q (fun x : X => s x)) (fun x : X => s0 x) q))). apply idpath.
 
 apply (invmaponpathsweq ( weqpair ff X0 ) _ _ ee). Defined.
 
 
 
-Definition totaltoforalltototal { X : UU } ( P : X -> UU ) ( PP : forall x:X, P x -> UU )( ss : total2 (fun s0: forall x:X, P x => forall x:X, PP x (s0 x)) ): paths (foralltototal _ _ (totaltoforall  _ _ ss)) ss.
+Definition totaltoforalltototal { X : UU } ( P : X -> UU ) ( PP : Π x:X, P x -> UU )( ss : total2 (fun s0: Π x:X, P x => Π x:X, PP x (s0 x)) ): paths (foralltototal _ _ (totaltoforall  _ _ ss)) ss.
 Proof. intros.  induction ss as [ t x ]. unfold foralltototal. unfold totaltoforall.  simpl.  set (et:= fun x:X => t x).
 
-assert (paths (tpair (fun s0 : forall x0 : X, P x0 => forall x0 : X, PP x0 (s0 x0)) t x) (tpair (fun s0 : forall x0 : X, P x0 => forall x0 : X, PP x0 (s0 x0)) et x)). apply (lemmaeta1 P (fun s: forall x:X, P x =>  forall x:X, PP x (s x)) t x).
+assert (paths (tpair (fun s0 : Π x0 : X, P x0 => Π x0 : X, PP x0 (s0 x0)) t x) (tpair (fun s0 : Π x0 : X, P x0 => Π x0 : X, PP x0 (s0 x0)) et x)). apply (lemmaeta1 P (fun s: Π x:X, P x =>  Π x:X, PP x (s x)) t x).
 
-assert (ee: paths (tpair (fun s0 : forall x0 : X, P x0 => forall x0 : X, PP x0 (s0 x0)) et x) (tpair (fun s0 : forall x0 : X, P x0 => forall x0 : X, PP x0 (s0 x0)) et (fun x0 : X => x x0))).
+assert (ee: paths (tpair (fun s0 : Π x0 : X, P x0 => Π x0 : X, PP x0 (s0 x0)) et x) (tpair (fun s0 : Π x0 : X, P x0 => Π x0 : X, PP x0 (s0 x0)) et (fun x0 : X => x x0))).
 assert (eee: paths x (fun x0:X => x x0)). apply etacorrection. induction eee. apply idpath. induction ee. apply pathsinv0. assumption. Defined.
 
 
 
-Definition foralltototaltoforall { X : UU } ( P : X -> UU ) ( PP : forall x:X, P x -> UU ) ( ss : forall x:X, total2 (PP x)): paths (totaltoforall _ _ (foralltototal _ _ ss)) ss.
-Proof. intros. unfold foralltototal. unfold totaltoforall.  simpl. assert (ee: forall x:X, paths (tpair (PP x) (pr1 (ss x)) (pr2 (ss x))) (ss x)).  intro. apply (pathsinv0   (tppr  (ss x))).  apply (funextsec). assumption. Defined.
+Definition foralltototaltoforall { X : UU } ( P : X -> UU ) ( PP : Π x:X, P x -> UU ) ( ss : Π x:X, total2 (PP x)): paths (totaltoforall _ _ (foralltototal _ _ ss)) ss.
+Proof. intros. unfold foralltototal. unfold totaltoforall.  simpl. assert (ee: Π x:X, paths (tpair (PP x) (pr1 (ss x)) (pr2 (ss x))) (ss x)).  intro. apply (pathsinv0   (tppr  (ss x))).  apply (funextsec). assumption. Defined.
 
-Theorem isweqforalltototal { X : UU } ( P : X -> UU ) ( PP : forall x:X, P x -> UU ) : isweq (foralltototal P PP).
+Theorem isweqforalltototal { X : UU } ( P : X -> UU ) ( PP : Π x:X, P x -> UU ) : isweq (foralltototal P PP).
 Proof. intros.  apply (gradth  (foralltototal P PP) (totaltoforall P PP) (foralltototaltoforall P PP) (totaltoforalltototal P PP)). Defined.
 
-Theorem isweqtotaltoforall { X : UU } (P:X->UU)(PP:forall x:X, P x -> UU): isweq (totaltoforall P PP).
+Theorem isweqtotaltoforall { X : UU } (P:X->UU)(PP:Π x:X, P x -> UU): isweq (totaltoforall P PP).
 Proof. intros.  apply (gradth   (totaltoforall P PP) (foralltototal P PP)  (totaltoforalltototal P PP) (foralltototaltoforall P PP)). Defined.
 
-Definition weqforalltototal { X : UU } ( P : X -> UU ) ( PP : forall x:X, P x -> UU ) := weqpair _ ( isweqforalltototal P PP ) .
+Definition weqforalltototal { X : UU } ( P : X -> UU ) ( PP : Π x:X, P x -> UU ) := weqpair _ ( isweqforalltototal P PP ) .
 
-Definition weqtotaltoforall { X : UU } ( P : X -> UU ) ( PP : forall x:X, P x -> UU ) := invweq ( weqforalltototal P PP ) .
+Definition weqtotaltoforall { X : UU } ( P : X -> UU ) ( PP : Π x:X, P x -> UU ) := invweq ( weqforalltototal P PP ) .
 
 
 
 (** *** Functions to a dependent sum (to a [ total2 ]) *)
 
-Definition weqfuntototaltototal ( X : UU ) { Y : UU } ( Q : Y -> UU ) : weq ( X -> total2 Q ) ( total2 ( fun f : X -> Y => forall x : X , Q ( f x ) ) ) := weqforalltototal ( fun x : X => Y ) ( fun x : X => Q ) .
+Definition weqfuntototaltototal ( X : UU ) { Y : UU } ( Q : Y -> UU ) : weq ( X -> total2 Q ) ( total2 ( fun f : X -> Y => Π x : X , Q ( f x ) ) ) := weqforalltototal ( fun x : X => Y ) ( fun x : X => Q ) .
 
 
 (** *** Functions to direct product *)
@@ -166,8 +166,8 @@ Definition prodtofuntoprod { X Y Z : UU } ( fg : dirprod ( X -> Y ) ( X -> Z ) )
 
 Theorem weqfuntoprodtoprod ( X Y Z : UU ) : weq ( X -> dirprod Y Z ) ( dirprod ( X -> Y ) ( X -> Z ) ) .
 Proof. intros. set ( f := @funtoprodtoprod X Y Z ) . set ( g := @prodtofuntoprod X Y Z ) . split with f .
-assert ( egf : forall a : _ , paths ( g ( f a ) ) a ) . intro a . apply funextfun .  intro x .  simpl . apply pathsinv0 . apply tppr .
-assert ( efg : forall a : _ , paths ( f ( g a ) ) a ) . intro a . induction a as [ fy fz ] . apply pathsdirprod .  simpl . apply pathsinv0 . apply etacorrection . simpl . apply pathsinv0 . apply etacorrection .
+assert ( egf : Π a : _ , paths ( g ( f a ) ) a ) . intro a . apply funextfun .  intro x .  simpl . apply pathsinv0 . apply tppr .
+assert ( efg : Π a : _ , paths ( f ( g a ) ) a ) . intro a . induction a as [ fy fz ] . apply pathsdirprod .  simpl . apply pathsinv0 . apply etacorrection . simpl . apply pathsinv0 . apply etacorrection .
 apply ( gradth _ _ egf efg ) . Defined .
 
 
@@ -176,23 +176,23 @@ apply ( gradth _ _ egf efg ) . Defined .
 
 
 
-(** ** Homotopy fibers of the map [forall x:X, P x -> forall x:X, Q x] *)
+(** ** Homotopy fibers of the map [Π x:X, P x -> Π x:X, Q x] *)
 
 (** *** General case *)
 
-Definition maponsec { X:UU }  (P Q : X -> UU) (f: forall x:X, P x -> Q x): (forall x:X, P x) -> (forall x:X, Q x) :=
-fun s: forall x:X, P x => (fun x:X => (f x) (s x)).
+Definition maponsec { X:UU }  (P Q : X -> UU) (f: Π x:X, P x -> Q x): (Π x:X, P x) -> (Π x:X, Q x) :=
+fun s: Π x:X, P x => (fun x:X => (f x) (s x)).
 
-Definition maponsec1 { X Y : UU } (P:Y -> UU)(f:X-> Y): (forall y:Y, P y) -> (forall x:X, P (f x)) := fun sy: forall y:Y, P y => (fun x:X => sy (f x)).
+Definition maponsec1 { X Y : UU } (P:Y -> UU)(f:X-> Y): (Π y:Y, P y) -> (Π x:X, P (f x)) := fun sy: Π y:Y, P y => (fun x:X => sy (f x)).
 
 
 
-Definition hfibertoforall { X : UU } (P Q : X -> UU) (f: forall x:X, P x -> Q x)(s: forall x:X, Q x): hfiber  (@maponsec _ _ _ f) s -> forall x:X, hfiber  (f x) (s x).
+Definition hfibertoforall { X : UU } (P Q : X -> UU) (f: Π x:X, P x -> Q x)(s: Π x:X, Q x): hfiber  (@maponsec _ _ _ f) s -> Π x:X, hfiber  (f x) (s x).
 Proof. intro. intro. intro. intro. intro.  unfold hfiber.
 
-set (map1:= totalfun (fun pointover : forall x : X, P x =>
-      paths (fun x : X => f x (pointover x)) s) (fun pointover : forall x : X, P x =>
-      forall x:X, paths  ((f x) (pointover x)) (s x))  (fun pointover: forall x:X, P x => toforallpaths _ (fun x : X => f x (pointover x)) s )).
+set (map1:= totalfun (fun pointover : Π x : X, P x =>
+      paths (fun x : X => f x (pointover x)) s) (fun pointover : Π x : X, P x =>
+      Π x:X, paths  ((f x) (pointover x)) (s x))  (fun pointover: Π x:X, P x => toforallpaths _ (fun x : X => f x (pointover x)) s )).
 
 set (map2 := totaltoforall P (fun x:X => (fun pointover : P x => paths (f x pointover) (s x)))).
 
@@ -200,68 +200,68 @@ set (themap := fun a:_ => map2 (map1 a)). assumption. Defined.
 
 
 
-Definition foralltohfiber  { X : UU } ( P Q : X -> UU) (f: forall x:X, P x -> Q x)(s: forall x:X, Q x): (forall x:X, hfiber  (f x) (s x)) -> hfiber  (maponsec _ _ f) s.
+Definition foralltohfiber  { X : UU } ( P Q : X -> UU) (f: Π x:X, P x -> Q x)(s: Π x:X, Q x): (Π x:X, hfiber  (f x) (s x)) -> hfiber  (maponsec _ _ f) s.
 Proof.  intro. intro. intro. intro.   intro. unfold hfiber.
 
 set (map2inv := foralltototal P (fun x:X => (fun pointover : P x => paths (f x pointover) (s x)))).
-set (map1inv :=  totalfun (fun pointover : forall x : X, P x =>
-      forall x:X, paths  ((f x) (pointover x)) (s x)) (fun pointover : forall x : X, P x =>
-      paths (fun x : X => f x (pointover x)) s) (fun pointover: forall x:X, P x => funextsec _ (fun x : X => f x (pointover x)) s)).
+set (map1inv :=  totalfun (fun pointover : Π x : X, P x =>
+      Π x:X, paths  ((f x) (pointover x)) (s x)) (fun pointover : Π x : X, P x =>
+      paths (fun x : X => f x (pointover x)) s) (fun pointover: Π x:X, P x => funextsec _ (fun x : X => f x (pointover x)) s)).
 set (themap := fun a:_=> map1inv (map2inv a)). assumption. Defined.
 
 
-Theorem isweqhfibertoforall  { X : UU } (P Q :X -> UU) (f: forall x:X, P x -> Q x)(s: forall x:X, Q x): isweq (hfibertoforall _ _ f s).
+Theorem isweqhfibertoforall  { X : UU } (P Q :X -> UU) (f: Π x:X, P x -> Q x)(s: Π x:X, Q x): isweq (hfibertoforall _ _ f s).
 Proof. intro. intro. intro. intro. intro.
 
-set (map1:= totalfun (fun pointover : forall x : X, P x =>
-      paths  (fun x : X => f x (pointover x)) s) (fun pointover : forall x : X, P x =>
-      forall x:X, paths  ((f x) (pointover x)) (s x))  (fun pointover: forall x:X, P x => toforallpaths _ (fun x : X => f x (pointover x)) s)).
+set (map1:= totalfun (fun pointover : Π x : X, P x =>
+      paths  (fun x : X => f x (pointover x)) s) (fun pointover : Π x : X, P x =>
+      Π x:X, paths  ((f x) (pointover x)) (s x))  (fun pointover: Π x:X, P x => toforallpaths _ (fun x : X => f x (pointover x)) s)).
 
 set (map2 := totaltoforall P (fun x:X => (fun pointover : P x => paths (f x pointover) (s x)))).
 
-assert (is1: isweq map1). apply (isweqfibtototal _ _ (fun pointover: forall x:X, P x => weqtoforallpaths _ (fun x : X => f x (pointover x)) s )).
+assert (is1: isweq map1). apply (isweqfibtototal _ _ (fun pointover: Π x:X, P x => weqtoforallpaths _ (fun x : X => f x (pointover x)) s )).
 
 assert (is2: isweq map2). apply isweqtotaltoforall.
 
 apply (twooutof3c map1 map2 is1 is2). Defined.
 
 
-Definition weqhfibertoforall  { X : UU } (P Q :X -> UU) (f: forall x:X, P x -> Q x)(s: forall x:X, Q x) := weqpair _ ( isweqhfibertoforall P Q f s ) .
+Definition weqhfibertoforall  { X : UU } (P Q :X -> UU) (f: Π x:X, P x -> Q x)(s: Π x:X, Q x) := weqpair _ ( isweqhfibertoforall P Q f s ) .
 
 
 
-Theorem isweqforalltohfiber  { X : UU } (P Q : X -> UU) (f: forall x:X, P x -> Q x)(s: forall x:X, Q x): isweq (foralltohfiber  _ _ f s).
+Theorem isweqforalltohfiber  { X : UU } (P Q : X -> UU) (f: Π x:X, P x -> Q x)(s: Π x:X, Q x): isweq (foralltohfiber  _ _ f s).
 Proof. intro. intro. intro. intro. intro.
 
 set (map2inv := foralltototal P (fun x:X => (fun pointover : P x => paths (f x pointover) (s x)))).
 
 assert (is2: isweq map2inv). apply (isweqforalltototal P (fun x:X => (fun pointover : P x => paths (f x pointover) (s x)))).
 
-set (map1inv :=  totalfun (fun pointover : forall x : X, P x =>
-      forall x:X, paths  ((f x) (pointover x)) (s x)) (fun pointover : forall x : X, P x =>
-      paths (fun x : X => f x (pointover x)) s) (fun pointover: forall x:X, P x => funextsec _  (fun x : X => f x (pointover x)) s)).
+set (map1inv :=  totalfun (fun pointover : Π x : X, P x =>
+      Π x:X, paths  ((f x) (pointover x)) (s x)) (fun pointover : Π x : X, P x =>
+      paths (fun x : X => f x (pointover x)) s) (fun pointover: Π x:X, P x => funextsec _  (fun x : X => f x (pointover x)) s)).
 
 assert (is1: isweq map1inv).
 
 (* ??? in this place 8.4 (actually trunk to 8.5) hangs if the next command is
 
-apply (isweqfibtototal _ _ (fun pointover: forall x:X, P x => weqfunextsec _ (fun x : X => f x (pointover x)) s ) ).
+apply (isweqfibtototal _ _ (fun pointover: Π x:X, P x => weqfunextsec _ (fun x : X => f x (pointover x)) s ) ).
 
 and no -no-sharing option is turned on. It also hangs on
 
-exact (isweqfibtototal (fun pointover : forall x : X, P x =>
-                forall x : X, paths (f x (pointover x)) (s x)) (fun pointover : forall x : X, P x =>
-                paths (fun x : X => f x (pointover x)) s) (fun pointover: forall x:X, P x => weqfunextsec Q (fun x : X => f x (pointover x)) s ) ).
+exact (isweqfibtototal (fun pointover : Π x : X, P x =>
+                Π x : X, paths (f x (pointover x)) (s x)) (fun pointover : Π x : X, P x =>
+                paths (fun x : X => f x (pointover x)) s) (fun pointover: Π x:X, P x => weqfunextsec Q (fun x : X => f x (pointover x)) s ) ).
 
 for at least 2hrs. After adding "Opaque funextsec ." the "exact" commend goes through in <1sec and so does the "apply". If "Transparent funextsec." added after the "apply" the compilation hangs on "Define".
 
 Resoved (2014.10.23). *)
 
-apply (isweqfibtototal _ _ (fun pointover: forall x:X, P x => weqfunextsec _ (fun x : X => f x (pointover x)) s ) ).
+apply (isweqfibtototal _ _ (fun pointover: Π x:X, P x => weqfunextsec _ (fun x : X => f x (pointover x)) s ) ).
 apply (twooutof3c map2inv map1inv is2 is1). Defined.
 
 
-Definition weqforalltohfiber  { X : UU } (P Q : X -> UU) (f: forall x:X, P x -> Q x)(s: forall x:X, Q x) := weqpair _ ( isweqforalltohfiber P Q f s ) .
+Definition weqforalltohfiber  { X : UU } (P Q : X -> UU) (f: Π x:X, P x -> Q x)(s: Π x:X, Q x) := weqpair _ ( isweqforalltohfiber P Q f s ) .
 
 
 
@@ -270,12 +270,12 @@ Definition weqforalltohfiber  { X : UU } (P Q : X -> UU) (f: forall x:X, P x -> 
 
 
 
-Corollary isweqmaponsec { X : UU } (P Q : X-> UU) (f: forall x:X, weq ( P x ) ( Q x) ) : isweq (maponsec _ _ f).
+Corollary isweqmaponsec { X : UU } (P Q : X-> UU) (f: Π x:X, weq ( P x ) ( Q x) ) : isweq (maponsec _ _ f).
 Proof. intros. unfold isweq.  intro y.
-assert (is1: iscontr (forall x:X, hfiber  (f x) (y x))). assert (is2: forall x:X, iscontr (hfiber  (f x) (y x))). intro x. apply ( ( pr2 ( f x ) )  (y x)). apply funcontr. assumption.
+assert (is1: iscontr (Π x:X, hfiber  (f x) (y x))). assert (is2: Π x:X, iscontr (hfiber  (f x) (y x))). intro x. apply ( ( pr2 ( f x ) )  (y x)). apply funcontr. assumption.
 apply (iscontrweqb  (weqhfibertoforall P Q f y) is1 ). Defined.
 
-Definition weqonsecfibers { X : UU } (P Q : X-> UU) (f: forall x:X, weq ( P x ) ( Q x )) := weqpair _ ( isweqmaponsec P Q f ) .
+Definition weqonsecfibers { X : UU } (P Q : X-> UU) (f: Π x:X, weq ( P x ) ( Q x )) := weqpair _ ( isweqmaponsec P Q f ) .
 
 
 (** *** Composition of functions with a weak equivalence on the right *)
@@ -295,17 +295,17 @@ Definition  weqffun ( X : UU ) { Y Z : UU } ( w : weq Y Z ) : weq ( X -> Y ) ( X
 (** *** General case *)
 
 
-Definition maponsec1l0 { X : UU } (P:X -> UU)(f:X-> X)(h: forall x:X, paths (f x) x)(s: forall x:X, P x): (forall x:X, P x) := (fun x:X => transportf P  (h x) (s (f x))).
+Definition maponsec1l0 { X : UU } (P:X -> UU)(f:X-> X)(h: Π x:X, paths (f x) x)(s: Π x:X, P x): (Π x:X, P x) := (fun x:X => transportf P  (h x) (s (f x))).
 
-Lemma maponsec1l1  { X : UU } (P:X -> UU)(x:X)(s:forall x:X, P x): paths (maponsec1l0 P (fun x:X => x) (fun x:X => idpath x) s x) (s x).
+Lemma maponsec1l1  { X : UU } (P:X -> UU)(x:X)(s:Π x:X, P x): paths (maponsec1l0 P (fun x:X => x) (fun x:X => idpath x) s x) (s x).
 Proof. intros. unfold maponsec1l0.   apply idpath. Defined.
 
 
-Lemma maponsec1l2 { X : UU } (P:X -> UU)(f:X-> X)(h: forall x:X, paths (f x) x)(s: forall x:X, P x)(x:X): paths (maponsec1l0 P f h s x) (s x).
+Lemma maponsec1l2 { X : UU } (P:X -> UU)(f:X-> X)(h: Π x:X, paths (f x) x)(s: Π x:X, P x)(x:X): paths (maponsec1l0 P f h s x) (s x).
 Proof. intros.
 
-set (map:= fun ff: total2 (fun f0:X->X => forall x:X, paths (f0 x) x) => maponsec1l0 P (pr1  ff) (pr2  ff) s x).
-assert (is1: iscontr (total2 (fun f0:X->X => forall x:X, paths (f0 x) x))). apply funextweql1. assert (e: paths (tpair  (fun f0:X->X => forall x:X, paths (f0 x) x) f h) (tpair  (fun f0:X->X => forall x:X, paths (f0 x) x) (fun x0:X => x0) (fun x0:X => idpath x0))). apply proofirrelevancecontr.  assumption.  apply (maponpaths map  e). Defined.
+set (map:= fun ff: total2 (fun f0:X->X => Π x:X, paths (f0 x) x) => maponsec1l0 P (pr1  ff) (pr2  ff) s x).
+assert (is1: iscontr (total2 (fun f0:X->X => Π x:X, paths (f0 x) x))). apply funextweql1. assert (e: paths (tpair  (fun f0:X->X => Π x:X, paths (f0 x) x) f h) (tpair  (fun f0:X->X => Π x:X, paths (f0 x) x) (fun x0:X => x0) (fun x0:X => idpath x0))). apply proofirrelevancecontr.  assumption.  apply (maponpaths map  e). Defined.
 
 
 Theorem isweqmaponsec1 { X Y : UU } (P:Y -> UU)(f: weq X Y ) : isweq (maponsec1 P f).
@@ -313,11 +313,11 @@ Proof. intros.
 
 set (map:= maponsec1  P f).
 set (invf:= invmap f). set (e1:= homotweqinvweq f). set (e2:= homotinvweqweq f ).
-set (im1:= fun sx: forall x:X, P (f x) => (fun y:Y => sx (invf y))).
-set (im2:= fun sy': forall y:Y, P (f (invf y)) => (fun y:Y => transportf _ (homotweqinvweq f y) (sy' y))).
-set (invmapp := (fun sx: forall x:X, P (f x) => im2 (im1 sx))).
+set (im1:= fun sx: Π x:X, P (f x) => (fun y:Y => sx (invf y))).
+set (im2:= fun sy': Π y:Y, P (f (invf y)) => (fun y:Y => transportf _ (homotweqinvweq f y) (sy' y))).
+set (invmapp := (fun sx: Π x:X, P (f x) => im2 (im1 sx))).
 
-assert (efg0: forall sx: (forall x:X, P (f x)), forall x:X, paths ((map (invmapp sx)) x) (sx x)).  intro. intro. unfold map. unfold invmapp. unfold im1. unfold im2. unfold maponsec1.  simpl. fold invf.  set (ee:=e2 x).  fold invf in ee.
+assert (efg0: Π sx: (Π x:X, P (f x)), Π x:X, paths ((map (invmapp sx)) x) (sx x)).  intro. intro. unfold map. unfold invmapp. unfold im1. unfold im2. unfold maponsec1.  simpl. fold invf.  set (ee:=e2 x).  fold invf in ee.
 
 set (e3x:= fun x0:X => invmaponpathsweq f (invf (f x0)) x0 (homotweqinvweq f (f x0))). set (e3:=e3x x). assert (e4: paths (homotweqinvweq f (f x)) (maponpaths f  e3)). apply (pathsinv0  (pathsweq4  f (invf (f x)) x _)).
 
@@ -328,17 +328,17 @@ assert (e6: paths (transportf P (maponpaths f e3) (sx (invf (f x)))) (transportf
 set (ff:= fun x:X => invf (f x)).
 assert (e7: paths (transportf (fun x : X => P (f x)) e3 (sx (invf (f x)))) (sx x)). apply (maponsec1l2 (fun x:X => P (f x)) ff e3x sx x).  apply (pathscomp0   (pathscomp0   e5 e6) e7).
 
-assert (efg: forall sx: (forall x:X, P (f x)), paths  (map (invmapp sx)) sx). intro. apply (funextsec _ _ _ (efg0 sx)).
+assert (efg: Π sx: (Π x:X, P (f x)), paths  (map (invmapp sx)) sx). intro. apply (funextsec _ _ _ (efg0 sx)).
 
-assert (egf0: forall sy: (forall y:Y, P y), forall y:Y, paths ((invmapp (map sy)) y) (sy y)). intros. unfold invmapp. unfold map.  unfold im1. unfold im2. unfold maponsec1.
+assert (egf0: Π sy: (Π y:Y, P y), Π y:Y, paths ((invmapp (map sy)) y) (sy y)). intros. unfold invmapp. unfold map.  unfold im1. unfold im2. unfold maponsec1.
 
 set (ff:= fun y:Y => f (invf y)). fold invf. apply (maponsec1l2 P ff ( homotweqinvweq f ) sy y).
-assert (egf: forall sy: (forall y:Y, P y), paths  (invmapp (map sy)) sy). intro. apply (funextsec _ _ _ (egf0 sy)).
+assert (egf: Π sy: (Π y:Y, P y), paths  (invmapp (map sy)) sy). intro. apply (funextsec _ _ _ (egf0 sy)).
 
 apply (gradth  map invmapp egf efg). Defined.
 
 Definition weqonsecbase { X Y : UU } ( P : Y -> UU ) ( f : weq X Y )
-  : weq (forall y : Y, P y) (forall x : X, P (f x))
+  : weq (Π y : Y, P y) (Π x : X, P (f x))
   := weqpair _ ( isweqmaponsec1 P f ) .
 
 
@@ -369,22 +369,22 @@ Definition  weqbfun  { X Y : UU } ( Z : UU ) ( w : weq X Y ) : weq ( Y -> Z ) ( 
 
 (** *** General case *)
 
-Definition iscontrsecoverempty ( P : empty -> UU ) : iscontr ( forall x : empty , P x ) .
+Definition iscontrsecoverempty ( P : empty -> UU ) : iscontr ( Π x : empty , P x ) .
 Proof . intro . split with ( fun x : empty => fromempty x )  .  intro t .  apply funextsec .  intro t0 . induction t0 . Defined .
 
-Definition iscontrsecoverempty2 { X : UU } ( P : X -> UU ) ( is : neg X ) : iscontr ( forall x : X , P x ) .
+Definition iscontrsecoverempty2 { X : UU } ( P : X -> UU ) ( is : neg X ) : iscontr ( Π x : X , P x ) .
 Proof . intros .  set ( w := weqtoempty is ) . set ( w' := weqonsecbase P ( invweq w ) ) .   apply ( iscontrweqb w' ( iscontrsecoverempty _ ) ) . Defined .
 
-Definition secovercoprodtoprod { X Y : UU } ( P : coprod X Y -> UU ) ( a: forall xy : coprod X Y , P xy ) : dirprod ( forall x : X , P ( ii1 x ) ) ( forall y : Y , P ( ii2 y ) ) := dirprodpair ( fun x : X => a ( ii1 x ) ) ( fun y : Y => a ( ii2 y ) )  .
+Definition secovercoprodtoprod { X Y : UU } ( P : coprod X Y -> UU ) ( a: Π xy : coprod X Y , P xy ) : dirprod ( Π x : X , P ( ii1 x ) ) ( Π y : Y , P ( ii2 y ) ) := dirprodpair ( fun x : X => a ( ii1 x ) ) ( fun y : Y => a ( ii2 y ) )  .
 
-Definition prodtosecovercoprod { X Y : UU } ( P : coprod X Y -> UU ) ( a : dirprod ( forall x : X , P ( ii1 x ) ) ( forall y : Y , P ( ii2 y ) ) ) :  forall xy : coprod X Y , P xy .
+Definition prodtosecovercoprod { X Y : UU } ( P : coprod X Y -> UU ) ( a : dirprod ( Π x : X , P ( ii1 x ) ) ( Π y : Y , P ( ii2 y ) ) ) :  Π xy : coprod X Y , P xy .
 Proof . intros . induction xy as [ x | y ] . apply ( pr1 a x ) .    apply ( pr2 a y ) . Defined .
 
 
-Definition weqsecovercoprodtoprod { X Y : UU } ( P : coprod X Y -> UU ) : weq ( forall xy : coprod X Y , P xy ) ( dirprod ( forall x : X , P ( ii1 x ) ) ( forall y : Y , P ( ii2 y ) ) ) .
+Definition weqsecovercoprodtoprod { X Y : UU } ( P : coprod X Y -> UU ) : weq ( Π xy : coprod X Y , P xy ) ( dirprod ( Π x : X , P ( ii1 x ) ) ( Π y : Y , P ( ii2 y ) ) ) .
 Proof . intros . set ( f := secovercoprodtoprod P ) .  set ( g := prodtosecovercoprod P ) . split with f .
-assert ( egf : forall a : _ , paths ( g ( f a ) ) a ) . intro . apply funextsec .  intro t .  induction t as [ x | y ] .  apply idpath . apply idpath .
-assert ( efg : forall a : _ , paths ( f ( g a ) ) a ) . intro .  induction a as [ ax ay ] . apply ( pathsdirprod ) .  apply funextsec . intro x . apply idpath .  apply funextsec . intro y . apply idpath .
+assert ( egf : Π a : _ , paths ( g ( f a ) ) a ) . intro . apply funextsec .  intro t .  induction t as [ x | y ] .  apply idpath . apply idpath .
+assert ( efg : Π a : _ , paths ( f ( g a ) ) a ) . intro .  induction a as [ ax ay ] . apply ( pathsdirprod ) .  apply funextsec . intro x . apply idpath .  apply funextsec . intro y . apply idpath .
 apply ( gradth _ _ egf efg ) . Defined .
 
 
@@ -407,8 +407,8 @@ Definition prodtofunfromcoprod { X Y Z : UU } ( fg : dirprod ( X -> Z ) ( Y -> Z
 
 Theorem weqfunfromcoprodtoprod ( X Y Z : UU ) : weq ( coprod X Y -> Z ) ( dirprod ( X -> Z ) ( Y -> Z ) ) .
 Proof. intros . set ( f := @funfromcoprodtoprod X Y Z ) . set ( g := @prodtofunfromcoprod X Y Z ) . split with f .
-assert ( egf : forall a : _ , paths ( g ( f a ) ) a ) .  intro a . apply funextfun .   intro xy .  induction xy as [ x | y ] .  apply idpath . apply idpath .
-assert ( efg : forall a : _ , paths ( f ( g a ) ) a ) . intro a . induction a as [ fx fy ] . simpl . apply pathsdirprod .  simpl . apply pathsinv0 . apply etacorrection . simpl . apply pathsinv0 . apply etacorrection .
+assert ( egf : Π a : _ , paths ( g ( f a ) ) a ) .  intro a . apply funextfun .   intro xy .  induction xy as [ x | y ] .  apply idpath . apply idpath .
+assert ( efg : Π a : _ , paths ( f ( g a ) ) a ) . intro a . induction a as [ fx fy ] . simpl . apply pathsdirprod .  simpl . apply pathsinv0 . apply etacorrection . simpl . apply pathsinv0 . apply etacorrection .
 apply ( gradth _ _ egf efg ) . Defined .
 
 
@@ -433,27 +433,27 @@ apply ( gradth _ _ egf efg ) . Defined .
 (** *** General case *)
 
 
-Definition tosecoverunit ( P : unit -> UU ) ( p : P tt ) : forall t : unit , P t .
+Definition tosecoverunit ( P : unit -> UU ) ( p : P tt ) : Π t : unit , P t .
 Proof . intros . induction t . apply p . Defined .
 
-Definition weqsecoverunit ( P : unit -> UU ) : weq ( forall t : unit , P t ) ( P tt ) .
-Proof . intro. set ( f := fun a : forall t : unit , P t => a tt ) . set ( g := tosecoverunit P ) . split with f .
-assert ( egf : forall a : _ , paths ( g ( f a ) ) a ) . intro . apply funextsec .  intro t . induction t . apply idpath .
-assert ( efg : forall a : _ , paths ( f ( g a ) ) a ) . intros . apply idpath .
+Definition weqsecoverunit ( P : unit -> UU ) : weq ( Π t : unit , P t ) ( P tt ) .
+Proof . intro. set ( f := fun a : Π t : unit , P t => a tt ) . set ( g := tosecoverunit P ) . split with f .
+assert ( egf : Π a : _ , paths ( g ( f a ) ) a ) . intro . apply funextsec .  intro t . induction t . apply idpath .
+assert ( efg : Π a : _ , paths ( f ( g a ) ) a ) . intros . apply idpath .
 apply ( gradth _ _ egf efg ) . Defined .
 
 
-Definition weqsecovercontr { X : UU } ( P : X -> UU ) ( is : iscontr X ) : weq ( forall x : X , P x ) ( P ( pr1 is ) ) .
+Definition weqsecovercontr { X : UU } ( P : X -> UU ) ( is : iscontr X ) : weq ( Π x : X , P x ) ( P ( pr1 is ) ) .
 Proof . intros . set ( w1 := weqonsecbase P ( wequnittocontr is ) ) . apply ( weqcomp w1 ( weqsecoverunit _ ) ) .  Defined .
 
-Definition tosecovertotal2 { X : UU } ( P : X -> UU ) ( Q : total2 P -> UU ) ( a : forall x : X , forall p : P x , Q ( tpair _ x p ) ) : forall xp : total2 P , Q xp .
+Definition tosecovertotal2 { X : UU } ( P : X -> UU ) ( Q : total2 P -> UU ) ( a : Π x : X , Π p : P x , Q ( tpair _ x p ) ) : Π xp : total2 P , Q xp .
 Proof . intros . induction xp as [ x p ] . apply ( a x p ) . Defined .
 
 
-Definition weqsecovertotal2 { X : UU } ( P : X -> UU ) ( Q : total2 P -> UU ) : weq ( forall xp : total2 P , Q xp ) ( forall x : X , forall p : P x , Q ( tpair _ x p ) ) .
-Proof . intros . set  ( f := fun a : forall xp : total2 P , Q xp => fun x : X => fun p : P x => a ( tpair _ x p ) ) . set ( g := tosecovertotal2 P Q ) . split with f .
-assert ( egf : forall a : _ , paths ( g ( f a ) ) a ) . intro . apply funextsec .  intro xp . induction xp as [ x p ] . apply idpath .
-assert ( efg : forall a : _ , paths ( f ( g a ) ) a ) . intro . apply funextsec . intro x . apply funextsec . intro p . apply idpath .
+Definition weqsecovertotal2 { X : UU } ( P : X -> UU ) ( Q : total2 P -> UU ) : weq ( Π xp : total2 P , Q xp ) ( Π x : X , Π p : P x , Q ( tpair _ x p ) ) .
+Proof . intros . set  ( f := fun a : Π xp : total2 P , Q xp => fun x : X => fun p : P x => a ( tpair _ x p ) ) . set ( g := tosecovertotal2 P Q ) . split with f .
+assert ( egf : Π a : _ , paths ( g ( f a ) ) a ) . intro . apply funextsec .  intro xp . induction xp as [ x p ] . apply idpath .
+assert ( efg : Π a : _ , paths ( f ( g a ) ) a ) . intro . apply funextsec . intro x . apply funextsec . intro p . apply idpath .
 apply ( gradth _ _ egf efg ) . Defined .
 
 
@@ -467,11 +467,11 @@ Definition  weqfunfromcontr { X : UU } ( Y : UU ) ( is : iscontr X ) : weq ( X -
 
 (** *** Functions from [ total2 ] *)
 
-Definition weqfunfromtotal2 { X : UU } ( P : X -> UU ) ( Y : UU ) : weq ( total2 P -> Y ) ( forall x : X , P x -> Y ) := weqsecovertotal2 P _ .
+Definition weqfunfromtotal2 { X : UU } ( P : X -> UU ) ( Y : UU ) : weq ( total2 P -> Y ) ( Π x : X , P x -> Y ) := weqsecovertotal2 P _ .
 
 (** *** Functions from direct product *)
 
-Definition weqfunfromdirprod ( X X' Y : UU ) : weq ( dirprod X X' -> Y ) ( forall x : X , X' -> Y ) := weqsecovertotal2 _ _ .
+Definition weqfunfromdirprod ( X X' Y : UU ) : weq ( dirprod X X' -> Y ) ( Π x : X , X' -> Y ) := weqsecovertotal2 _ _ .
 
 
 
@@ -492,24 +492,24 @@ Definition weqfunfromdirprod ( X X' Y : UU ) : weq ( dirprod X X' -> Y ) ( foral
 
 (** *** General case *)
 
-Theorem impred (n:nat) { T : UU } (P:T -> UU): (forall t:T, isofhlevel n (P t)) -> (isofhlevel n (forall t:T, P t)).
+Theorem impred (n:nat) { T : UU } (P:T -> UU): (Π t:T, isofhlevel n (P t)) -> (isofhlevel n (Π t:T, P t)).
 Proof. intro. induction n as [ | n IHn ] . intros T P X.  apply (funcontr P X). intros T P X. unfold isofhlevel in X.  unfold isofhlevel. intros x x' .
 
-assert (is: forall t:T, isofhlevel n (paths (x t) (x' t))).  intro. apply (X t (x t) (x' t)).
-assert (is2: isofhlevel n (forall t:T, paths (x t) (x' t))). apply (IHn _ (fun t0:T => paths (x t0) (x' t0)) is).
+assert (is: Π t:T, isofhlevel n (paths (x t) (x' t))).  intro. apply (X t (x t) (x' t)).
+assert (is2: isofhlevel n (Π t:T, paths (x t) (x' t))). apply (IHn _ (fun t0:T => paths (x t0) (x' t0)) is).
 set (u:=toforallpaths P x x').  assert (is3:isweq u). apply isweqtoforallpaths.  set (v:= invmap ( weqpair u is3) ). assert (is4: isweq v). apply isweqinvmap. apply (isofhlevelweqf n  ( weqpair v is4 )). assumption. Defined.
 
-Corollary impred_iscontr { T : UU } (P:T -> UU): (forall t:T, iscontr (P t)) -> (iscontr (forall t:T, P t)).
+Corollary impred_iscontr { T : UU } (P:T -> UU): (Π t:T, iscontr (P t)) -> (iscontr (Π t:T, P t)).
 Proof. intros. apply (impred 0). assumption. Defined.
 
-Corollary impred_isaprop { T : UU } (P:T -> UU): (forall t:T, isaprop (P t)) -> (isaprop (forall t:T, P t)).
+Corollary impred_isaprop { T : UU } (P:T -> UU): (Π t:T, isaprop (P t)) -> (isaprop (Π t:T, P t)).
 Proof. apply impred. Defined.
 
-Corollary impred_isaset { T : UU } (P:T -> UU): (forall t:T, isaset (P t)) -> (isaset (forall t:T, P t)).
+Corollary impred_isaset { T : UU } (P:T -> UU): (Π t:T, isaset (P t)) -> (isaset (Π t:T, P t)).
 Proof. intros. apply (impred 2). assumption. Defined.
 
-Corollary impredtwice  (n:nat) { T T' : UU } (P:T -> T' -> UU): (forall (t:T)(t':T'), isofhlevel n (P t t')) -> (isofhlevel n (forall (t:T)(t':T'), P t t')).
-Proof.  intros n T T' P X. assert (is1: forall t:T, isofhlevel n (forall t':T', P t t')). intro. apply (impred n _ (X t)). apply (impred n _ is1). Defined.
+Corollary impredtwice  (n:nat) { T T' : UU } (P:T -> T' -> UU): (Π (t:T)(t':T'), isofhlevel n (P t t')) -> (isofhlevel n (Π (t:T)(t':T'), P t t')).
+Proof.  intros n T T' P X. assert (is1: Π t:T, isofhlevel n (Π t':T', P t t')). intro. apply (impred n _ (X t)). apply (impred n _ is1). Defined.
 
 
 Corollary impredfun (n:nat)(X Y:UU)(is: isofhlevel n Y) : isofhlevel n (X -> Y).
@@ -518,12 +518,12 @@ Proof. intros. apply (impred n (fun x:_ => Y) (fun x:X => is)). Defined.
 
 Theorem impredtech1 (n:nat)(X Y: UU) : (X -> isofhlevel n Y) -> isofhlevel n (X -> Y).
 Proof. intro. induction n as [ | n IHn ] . intros X Y X0. simpl. split with (fun x:X => pr1  (X0 x)).  intro t .
-assert (s1: forall x:X, paths (t x) (pr1  (X0 x))). intro. apply proofirrelevancecontr. apply (X0 x).
+assert (s1: Π x:X, paths (t x) (pr1  (X0 x))). intro. apply proofirrelevancecontr. apply (X0 x).
 apply funextsec. assumption.
 
 intros X Y X0. simpl. assert (X1: X -> isofhlevel (S n) (X -> Y)). intro X1 . apply impred. assumption. intros x x' .
-assert (s1: isofhlevel n (forall xx:X, paths (x xx) (x' xx))). apply impred. intro t . apply (X0 t).
-assert (w: weq (forall xx:X, paths (x xx) (x' xx)) (paths x x')). apply (weqfunextsec  _ x x' ). apply (isofhlevelweqf n w s1). Defined.
+assert (s1: isofhlevel n (Π xx:X, paths (x xx) (x' xx))). apply impred. intro t . apply (X0 t).
+assert (w: weq (Π xx:X, paths (x xx) (x' xx)) (paths x x')). apply (weqfunextsec  _ x x' ). apply (isofhlevelweqf n w s1). Defined.
 
 
 
@@ -560,16 +560,16 @@ Proof . intros .  apply impred . intro . apply ( isapropifnegtrue  is ) . Define
 Theorem iscontriscontr { X : UU } ( is : iscontr X ) : iscontr ( iscontr X ).
 Proof. intros X X0 .
 
-assert (is0: forall (x x':X), paths x x'). apply proofirrelevancecontr. assumption.
+assert (is0: Π (x x':X), paths x x'). apply proofirrelevancecontr. assumption.
 
-assert (is1: forall cntr:X, iscontr (forall x:X, paths x cntr)). intro.
-assert (is2: forall x:X, iscontr (paths x cntr)).
+assert (is1: Π cntr:X, iscontr (Π x:X, paths x cntr)). intro.
+assert (is2: Π x:X, iscontr (paths x cntr)).
 assert (is2: isaprop X). apply isapropifcontr. assumption.
 unfold isaprop in is2. unfold isofhlevel in is2. intro x . apply (is2 x cntr).
 apply funcontr. assumption.
 
-set (f:= @pr1 X (fun cntr:X => forall x:X, paths x cntr)).
-assert (X1:isweq f).  apply isweqpr1. assumption. change (total2 (fun cntr : X => forall x : X, paths x cntr)) with (iscontr X) in X1.  apply (iscontrweqb ( weqpair f X1 ) ) . assumption.  Defined.
+set (f:= @pr1 X (fun cntr:X => Π x:X, paths x cntr)).
+assert (X1:isweq f).  apply isweqpr1. assumption. change (total2 (fun cntr : X => Π x : X, paths x cntr)) with (iscontr X) in X1.  apply (iscontrweqb ( weqpair f X1 ) ) . assumption.  Defined.
 
 
 
@@ -589,17 +589,17 @@ Proof. intro. apply ( isofhlevelsn 0 ) .  intro is . unfold isdeceq. apply impre
 
 Theorem isapropisofhlevel (n:nat)(X:UU): isaprop (isofhlevel n X).
 Proof. intro.  unfold isofhlevel.    induction n as [ | n IHn ] . apply isapropiscontr.  intro X .
-assert (X0: forall (x x':X), isaprop  ((fix isofhlevel (n0 : nat) (X0 : UU) {struct n0} : UU :=
+assert (X0: Π (x x':X), isaprop  ((fix isofhlevel (n0 : nat) (X0 : UU) {struct n0} : UU :=
          match n0 with
          | O => iscontr X0
-         | S m => forall x0 x'0 : X0, isofhlevel m (paths x0 x'0)
+         | S m => Π x0 x'0 : X0, isofhlevel m (paths x0 x'0)
          end) n (paths x x'))). intros. apply (IHn (paths x x')).
 assert (is1:
-     (forall x:X, isaprop (forall  x' : X,
+     (Π x:X, isaprop (Π x' : X,
       (fix isofhlevel (n0 : nat) (X1 : UU) {struct n0} : UU :=
          match n0 with
          | O => iscontr X1
-         | S m => forall x0 x'0 : X1, isofhlevel m (paths x0 x'0)
+         | S m => Π x0 x'0 : X1, isofhlevel m (paths x0 x'0)
          end) n (paths x x')))). intro.  apply (impred ( S O ) _  (X0 x)). apply (impred (S O) _ is1). Defined.
 
 Corollary isapropisaprop (X:UU) : isaprop (isaprop X).
@@ -667,14 +667,14 @@ Defined.
 
 Theorem weqfweq ( X : UU ) { Y Z : UU } ( w : weq Y Z ) : weq ( weq X Y ) ( weq X Z ) .
 Proof. intros . set ( f := fun a : weq X Y => weqcomp a w ) . set ( g := fun b : weq X Z  => weqcomp b ( invweq w ) ) . split with f .
-assert ( egf : forall a : _ , paths ( g ( f a ) ) a ) . intro a . apply ( invmaponpathsincl _ ( isinclpr1weq _ _ ) ) . apply funextfun .  intro x .  apply ( homotinvweqweq w ( a x ) ) .
-assert ( efg : forall b : _ , paths ( f ( g b ) ) b ) . intro b .  apply ( invmaponpathsincl _ ( isinclpr1weq _ _ ) ) . apply funextfun . intro x . apply ( homotweqinvweq w ( b x ) ) .
+assert ( egf : Π a : _ , paths ( g ( f a ) ) a ) . intro a . apply ( invmaponpathsincl _ ( isinclpr1weq _ _ ) ) . apply funextfun .  intro x .  apply ( homotinvweqweq w ( a x ) ) .
+assert ( efg : Π b : _ , paths ( f ( g b ) ) b ) . intro b .  apply ( invmaponpathsincl _ ( isinclpr1weq _ _ ) ) . apply funextfun . intro x . apply ( homotweqinvweq w ( b x ) ) .
 apply ( gradth _ _ egf efg ) . Defined .
 
 Theorem weqbweq  { X Y : UU } ( Z : UU ) ( w : weq X Y ) : weq ( weq Y Z ) ( weq X Z ) .
 Proof. intros . set ( f := fun a : weq Y Z =>  weqcomp w a ) . set ( g := fun b : weq X Z  => weqcomp ( invweq w ) b ) . split with f .
-assert ( egf : forall a : _ , paths ( g ( f a ) ) a ) . intro a .  apply ( invmaponpathsincl _ ( isinclpr1weq _ _ ) ) . apply funextfun .  intro y .  apply ( maponpaths a ( homotweqinvweq w y ) ) .
-assert ( efg : forall b : _ , paths ( f ( g b ) ) b ) . intro b .  apply ( invmaponpathsincl _ ( isinclpr1weq _ _ ) ) . apply funextfun . intro x . apply ( maponpaths b ( homotinvweqweq w x ) ) .
+assert ( egf : Π a : _ , paths ( g ( f a ) ) a ) . intro a .  apply ( invmaponpathsincl _ ( isinclpr1weq _ _ ) ) . apply funextfun .  intro y .  apply ( maponpaths a ( homotweqinvweq w y ) ) .
+assert ( efg : Π b : _ , paths ( f ( g b ) ) b ) . intro b .  apply ( invmaponpathsincl _ ( isinclpr1weq _ _ ) ) . apply funextfun . intro x . apply ( maponpaths b ( homotinvweqweq w x ) ) .
 apply ( gradth _ _ egf efg ) . Defined .
 
 Theorem weqweq {X Y:UU} (w:X≃Y) : (X≃X) ≃ (Y≃Y).
@@ -690,8 +690,8 @@ Defined.
 
 Theorem weqinvweq ( X Y : UU ) : weq ( weq X Y ) ( weq Y X ) .
 Proof . intros . set ( f := fun w : weq X Y => invweq w ) . set ( g := fun w : weq Y X => invweq w ) . split with f .
-assert ( egf : forall w : _ , paths ( g ( f w ) ) w ) . intro . apply ( invmaponpathsincl _ ( isinclpr1weq _ _ ) ) . apply funextfun . intro x .   unfold f.  unfold g . unfold invweq . simpl . unfold invmap . simpl . apply idpath .
-assert ( efg : forall w : _ , paths ( f ( g w ) ) w ) . intro . apply ( invmaponpathsincl _ ( isinclpr1weq _ _ ) ) . apply funextfun . intro x .   unfold f.  unfold g . unfold invweq . simpl . unfold invmap . simpl . apply idpath .
+assert ( egf : Π w : _ , paths ( g ( f w ) ) w ) . intro . apply ( invmaponpathsincl _ ( isinclpr1weq _ _ ) ) . apply funextfun . intro x .   unfold f.  unfold g . unfold invweq . simpl . unfold invmap . simpl . apply idpath .
+assert ( efg : Π w : _ , paths ( f ( g w ) ) w ) . intro . apply ( invmaponpathsincl _ ( isinclpr1weq _ _ ) ) . apply funextfun . intro x .   unfold f.  unfold g . unfold invweq . simpl . unfold invmap . simpl . apply idpath .
 apply ( gradth _ _ egf efg ) . Defined .
 
 
@@ -861,7 +861,7 @@ Defined.
 (* Coprojections i.e. functions which are weakly equivalent to functions of the form ii1: X -> coprod X Y
 
 
-Definition locsplit (X:UU)(Y:UU)(f:X -> Y):= forall y:Y, coprod (hfiber  f y) (hfiber  f y -> empty).
+Definition locsplit (X:UU)(Y:UU)(f:X -> Y):= Π y:Y, coprod (hfiber  f y) (hfiber  f y -> empty).
 
 Definition dnegimage (X:UU)(Y:UU)(f:X -> Y):= total2 Y (fun y:Y => dneg(hfiber  f y)).
 Definition dnegimageincl (X Y:UU)(f:X -> Y):= pr1 Y (fun y:Y => dneg(hfiber  f y)).

--- a/UniMath/Foundations/Basics/Preamble.v
+++ b/UniMath/Foundations/Basics/Preamble.v
@@ -79,12 +79,12 @@ Implicit Arguments ii2 [ A B ] .
 
 Notation coprod_rect := sum_rect.
 
-Notation "X ⨿ Y" := (coprod X Y) (at level 50, left associativity) : type_scope.
+Notation "X ⨿ Y" := (coprod X Y) (at level 50, left associativity).
   (* type this in emacs with C-X 8 RET AMALGAMATION OR COPRODUCT *)
 
-Notation "∀  x .. y , P" := (forall x, .. (forall y, P) ..)
+Notation "'Π'  x .. y , P" := (forall x, .. (forall y, P) ..)
   (at level 200, x binder, y binder, right associativity) : type_scope.
-  (* type this in emacs in agda-input method with \forall *)
+  (* type this in emacs in agda-input method with \Pi *)
 
 Notation "'λ' x .. y , t" := (fun x => .. (fun y => t) ..)
   (at level 200, x binder, y binder, right associativity).
@@ -92,15 +92,15 @@ Notation "'λ' x .. y , t" := (fun x => .. (fun y => t) ..)
 
 Definition coprod_rect_compute_1
            (A B : UU) (P : A ⨿ B -> UU)
-           (f : ∀ a : A, P (ii1 a))
-           (g : ∀ b : B, P (ii2 b)) (a:A) :
+           (f : Π (a : A), P (ii1 a))
+           (g : Π (b : B), P (ii2 b)) (a:A) :
   coprod_rect P f g (ii1 a) = f a.
 Proof. reflexivity. Defined.
 
 Definition coprod_rect_compute_2
            (A B : UU) (P : A ⨿ B -> UU)
-           (f : ∀ a : A, P (ii1 a))
-           (g : ∀ b : B, P (ii2 b)) (b:B) :
+           (f : Π a : A, P (ii1 a))
+           (g : Π b : B, P (ii2 b)) (b:B) :
   coprod_rect P f g (ii2 b) = g b.
 Proof. reflexivity. Defined.
 
@@ -134,7 +134,7 @@ if we used "Record", has a known interpretation in the framework of the univalen
 
 (* or total2 as an inductive type:  *)
 
-    Inductive total2 { T: Type } ( P: T -> Type ) := tpair : forall ( t : T ) ( p : P t ) , total2 P .
+    Inductive total2 { T: Type } ( P: T -> Type ) := tpair : Π ( t : T ) ( p : P t ) , total2 P .
 
     Definition pr1 { T : Type } { P : T -> Type } ( t : total2 P ) : T .
     Proof . intros .  induction t as [ t p ] . exact t . Defined.
@@ -156,7 +156,7 @@ Notation "x ,, y" := (tpair _ x y) (at level 60, right associativity). (* looser
 
 Ltac mkpair := (simple refine (tpair _ _ _ ) ; [| cbn]).
 
-Goal ∀ X (Y : X -> UU) (x : X) (y : Y x), Σ x, Y x.
+Goal Π X (Y : X -> UU) (x : X) (y : Y x), Σ x, Y x.
   intros X Y x y.
   mkpair.
   - apply x.
@@ -164,7 +164,7 @@ Goal ∀ X (Y : X -> UU) (x : X) (y : Y x), Σ x, Y x.
 Defined.
 
 (* print out this theorem to see whether "induction" compiles to "match" *)
-Goal ∀ X (Y:X->UU) (w:Σ x, Y x), X.
+Goal Π X (Y:X->UU) (w:Σ x, Y x), X.
   intros.
   induction w as [x y].
   exact x.
@@ -172,7 +172,7 @@ Defined.
 
 (* Step through this proof to demonstrate eta expansion for pairs, if primitive
    projections are on: *)
-Goal ∀ X (Y:X->UU) (w:Σ x, Y x), w = (pr1 w,, pr2 w).
+Goal Π X (Y:X->UU) (w:Σ x, Y x), w = (pr1 w,, pr2 w).
 Proof. try reflexivity. Abort.
 
 Definition rewrite_pr1_tpair {X} {P:X->UU} x p : pr1 (tpair P x p) = x.

--- a/UniMath/Foundations/Basics/Propositions.v
+++ b/UniMath/Foundations/Basics/Propositions.v
@@ -60,14 +60,14 @@ Coercion negProp_to_hProp : negProp >-> hProp.
 (* convenient corollaries of some theorems that take separate isaprop arguments: *)
 
 Corollary subtypeInjectivity_prop {A : UU} (B : A -> hProp) :
-  ∀ (x y : total2 B), (x = y) ≃ (pr1 x = pr1 y).
+  Π (x y : total2 B), (x = y) ≃ (pr1 x = pr1 y).
 Proof. intros. apply subtypeInjectivity. intro. apply propproperty. Defined.
 
 Corollary subtypeEquality_prop {A : UU} {B : A -> hProp}
    {s s' : total2 (fun x => B x)} : pr1 s = pr1 s' -> s = s'.
 Proof. intros A B s s'. apply invmap. apply subtypeInjectivity_prop. Defined.
 
-Corollary impred_prop {T:UU} (P:T -> hProp) : isaprop (∀ t:T, P t).
+Corollary impred_prop {T:UU} (P:T -> hProp) : isaprop (Π t:T, P t).
 Proof. intros. apply impred; intro. apply propproperty. Defined.
 
 Corollary isaprop_total2 (X:hProp) (Y:X->hProp) : isaprop (Σ x, Y x).
@@ -78,16 +78,14 @@ Proof.
   - intro x. apply propproperty.
 Defined.
 
-Lemma isaprop_forall_hProp (X:UU) (Y:X->hProp) : isaprop (∀ x, Y x).
+Lemma isaprop_forall_hProp (X:UU) (Y:X->hProp) : isaprop (Π x, Y x).
 Proof. intros. apply impred_isaprop. intro x. apply propproperty. Defined.
 
-Definition forall_hProp {X:UU} (Y:X->hProp) : hProp := hProppair (∀ x, Y x) (isaprop_forall_hProp X Y).
+Definition forall_hProp {X:UU} (Y:X->hProp) : hProp := hProppair (Π x, Y x) (isaprop_forall_hProp X Y).
 
 Notation "∀  x .. y , P" := (forall_hProp (fun x => .. (forall_hProp (fun y => P)) ..))
-  (at level 200, x binder, y binder, right associativity) : prop.
-  (* type this in emacs in agda-input method with \Sigma *)
-
-Delimit Scope prop with prop.
+  (at level 200, x binder, y binder, right associativity) : type_scope.
+  (* type this in emacs in agda-input method with \Pi *)
 
 (** The following re-definitions should make proofs easier in the future when the unification algorithms in Coq are improved . At the moment they create more complications than they eliminate ( e.g. try to prove [ isapropishinh ] with [ isaprop ] in [ hProp ] ) so for the time being they are commented out .
 
@@ -119,7 +117,7 @@ Definition isdecEq ( X : UU ) : hProp := hProppair _ ( isapropisdeceq X ) .
 
 
 
-Definition ishinh_UU ( X : UU ) := ∀ P: hProp, ( ( X -> P ) -> P ).
+Definition ishinh_UU ( X : UU ) := Π P: hProp, ( ( X -> P ) -> P ).
 
 Lemma isapropishinh ( X : UU ) : isaprop ( ishinh_UU X ).
 Proof. intro. apply impred . intro P . apply impred.  intro. apply ( pr2 P ) .  Defined .
@@ -188,7 +186,7 @@ Definition pr1image { X Y : UU } ( f : X -> Y ) := @pr1 _  ( fun y : Y => ishinh
 Definition prtoimage { X Y : UU } (f : X -> Y) : X -> image f.
 Proof. intros X Y f X0. apply (imagepair _ (f X0) (hinhpr (hfiberpair f X0 (idpath _ )))). Defined.
 
-Definition issurjective { X Y : UU } (f : X -> Y ) := ∀ y:Y, ishinh (hfiber f y).
+Definition issurjective { X Y : UU } (f : X -> Y ) := Π y:Y, ishinh (hfiber f y).
 
 Lemma isapropissurjective { X Y : UU } ( f : X -> Y) : isaprop (issurjective f).
 Proof. intros.  apply impred. intro t. apply  (pr2 (ishinh (hfiber f t))). Defined.
@@ -322,18 +320,18 @@ apply ( hinhuniv s2 ). apply X1 .   unfold himpl. simpl . apply s1 .  Defined.
 
 (** *** Negation and quantification.
 
-There are four standard implications in classical logic which can be summarized as ( neg ( ∀ P ) ) <-> ( exists ( neg P ) ) and ( neg ( exists P ) ) <-> ( ∀ ( neg P ) ) . Of these four implications three are provable in the intuitionistic logic.  The remaining implication ( neg ( ∀ P ) ) -> ( exists ( neg P ) ) is not provable in general . For a proof in the case of bounded quantification of decidable predicates on natural numbers see hnat.v . For some other cases when these implications hold see ??? . *)
+There are four standard implications in classical logic which can be summarized as ( neg ( Π P ) ) <-> ( exists ( neg P ) ) and ( neg ( exists P ) ) <-> ( Π ( neg P ) ) . Of these four implications three are provable in the intuitionistic logic.  The remaining implication ( neg ( Π P ) ) -> ( exists ( neg P ) ) is not provable in general . For a proof in the case of bounded quantification of decidable predicates on natural numbers see hnat.v . For some other cases when these implications hold see ??? . *)
 
-Lemma hexistsnegtonegforall { X : UU } ( F : X -> UU ) : (∃ x : X, neg (F x)) -> neg ( ∀ x : X , F x ) .
-Proof . intros X F . simpl . apply ( @hinhuniv _ ( hProppair _ ( isapropneg (∀ x : X , F x ) ) ) ) .  simpl . intros t2 f2 . destruct t2 as [ x d2 ] .  apply ( d2 ( f2 x ) ) . Defined .
+Lemma hexistsnegtonegforall { X : UU } ( F : X -> UU ) : (∃ x : X, neg (F x)) -> neg ( Π x : X , F x ) .
+Proof . intros X F . simpl . apply ( @hinhuniv _ ( hProppair _ ( isapropneg (Π x : X , F x ) ) ) ) .  simpl . intros t2 f2 . destruct t2 as [ x d2 ] .  apply ( d2 ( f2 x ) ) . Defined .
 
-Lemma forallnegtoneghexists { X : UU } ( F : X -> UU ) : ( ∀ x : X , neg ( F x ) ) -> neg ( ∃ x, F x ) .
+Lemma forallnegtoneghexists { X : UU } ( F : X -> UU ) : ( Π x : X , neg ( F x ) ) -> neg ( ∃ x, F x ) .
 Proof. intros X F nf . change ( ( ishinh_UU ( total2 F ) ) -> hfalse ) . apply hinhuniv .   intro t2 . destruct t2 as [ x f ] .  apply ( nf x f ) . Defined .
 
-Lemma neghexisttoforallneg { X : UU } ( F : X -> UU ) : ¬ ( ∃ x, F x ) -> ∀ x : X , ¬ ( F x ) .
+Lemma neghexisttoforallneg { X : UU } ( F : X -> UU ) : ¬ ( ∃ x, F x ) -> Π x : X , ¬ ( F x ) .
 Proof . intros X F nhe x . intro fx .  apply ( nhe ( hinhpr ( tpair F x fx ) ) ) . Defined .
 
-Definition weqforallnegtonegexists { X : UU } ( F : X -> UU ) : weq (∀ x : X, ¬ F x) (¬ ∃ x, F x).
+Definition weqforallnegtonegexists { X : UU } ( F : X -> UU ) : weq (Π x : X, ¬ F x) (¬ ∃ x, F x).
 Proof . intros . apply ( weqimplimpl ( forallnegtoneghexists F ) ( neghexisttoforallneg F ) ) . apply impred .   intro x . apply isapropneg . apply isapropneg . Defined .
 
 
@@ -550,7 +548,7 @@ Defined.
    We don't state LEM as an axiom, because we want to force it
    to be a hypothesis of any corollaries of any theorems that
    appeal to it. *)
-Definition LEM := ∀ P:hProp, decidable P.
+Definition LEM := Π P:hProp, decidable P.
 
 Lemma LEM_for_sets X : LEM -> isaset X -> isdeceq X.
 Proof. intros X lem is x y. exact (lem (hProppair (x = y) (is x y))). Defined.
@@ -714,9 +712,9 @@ The proof of theorem [ univfromtwoaxiomshProp ] is modeled on the proof of [ uni
 *)
 
 
-Axiom uahp : ∀ P P':hProp,  (P -> P') -> (P' -> P) -> @paths hProp P P'.
+Axiom uahp : Π P P':hProp,  (P -> P') -> (P' -> P) -> @paths hProp P P'.
 
-Corollary uahp' : ∀ P Q, isaprop P -> isaprop Q -> (P -> Q) -> (Q -> P) -> P=Q.
+Corollary uahp' : Π P Q, isaprop P -> isaprop Q -> (P -> Q) -> (Q -> P) -> P=Q.
 Proof.
   intros ? ? i j f g. exact (maponpaths hProptoType (uahp (P,,i) (Q,,j) f g)).
 Defined.
@@ -741,12 +739,12 @@ set (f:= ( totalfun _ _ (fun XY: hProp × hProp =>
                            @eqweqmaphProp ( pr1 XY ) ( pr2 XY )): Z1 -> Z2)).
 set (g:= ( totalfun _ _ (fun XY: hProp × hProp =>
                            @weqtopathshProp ( pr1 XY ) ( pr2 XY )): Z2 -> Z1)).
-assert (efg : ∀ z2 : Z2 , paths ( f ( g z2 ) ) z2 ). intros. induction z2 as [ XY w] .
+assert (efg : Π z2 : Z2 , paths ( f ( g z2 ) ) z2 ). intros. induction z2 as [ XY w] .
 exact ( maponpaths (fun w: weq (pr1 XY) (pr2 XY) => tpair P2 XY w) (@weqpathsweqhProp (pr1 XY) (pr2 XY) w)).
 
 set (h:= fun a1:Z1 => (pr1 ( pr1 a1))).
-assert (egf0: ∀ a1:Z1,  paths ( pr1 (g (f a1))) ( pr1 a1)). intro. apply  idpath.
-assert (egf1: ∀ a1 a1':Z1,  paths ( pr1 a1') ( pr1 a1) -> paths a1' a1). intros ? ? X .
+assert (egf0: Π a1:Z1,  paths ( pr1 (g (f a1))) ( pr1 a1)). intro. apply  idpath.
+assert (egf1: Π a1 a1':Z1,  paths ( pr1 a1') ( pr1 a1) -> paths a1' a1). intros ? ? X .
 set (X':=  maponpaths ( @pr1 _ _ )  X).
 assert (is:  isweq h). apply ( isweqpr1pr1 hProp ). apply ( invmaponpathsweq ( weqpair h is ) _ _ X').
 set (egf:= fun a1:_ => (egf1 _ _ (egf0 a1))).

--- a/UniMath/Foundations/Basics/Sets.v
+++ b/UniMath/Foundations/Basics/Sets.v
@@ -60,12 +60,12 @@ Notation "'Σ'  x .. y , P" := (total2_hSet (fun x => .. (total2_hSet (fun y => 
   (at level 200, x binder, y binder, right associativity) : set.
   (* type this in emacs in agda-input method with \Sigma *)
 
-Lemma isaset_forall_hSet (X:UU) (Y:X->hSet) : isaset (∀ x, Y x).
+Lemma isaset_forall_hSet (X:UU) (Y:X->hSet) : isaset (Π x, Y x).
 Proof. intros. apply impred_isaset. intro x. apply setproperty. Defined.
 
-Definition forall_hSet {X:UU} (Y:X->hSet) : hSet := hSetpair (∀ x, Y x) (isaset_forall_hSet X Y).
+Definition forall_hSet {X:UU} (Y:X->hSet) : hSet := hSetpair (Π x, Y x) (isaset_forall_hSet X Y).
 
-Notation "∀  x .. y , P" := (forall_hSet (fun x => .. (forall_hSet (fun y => P)) ..))
+Notation "'Π'  x .. y , P" := (forall_hSet (fun x => .. (forall_hSet (fun y => P)) ..))
   (at level 200, x binder, y binder, right associativity) : set.
   (* type this in emacs in agda-input method with \Sigma *)
 
@@ -112,7 +112,7 @@ Definition boolset : hSet := hSetpair bool isasetbool .
 (* properties of functions between sets *)
 
 Definition isInjectiveFunction { X Y : hSet } (f:X -> Y) : hProp.
-Proof. intros. exists ( ∀ (x x':X), f x = f x' -> x = x' ).
+Proof. intros. exists ( Π (x x':X), f x = f x' -> x = x' ).
        abstract (
            intros; apply impred; intro x; apply impred; intro y;
            apply impred; intro e; apply setproperty) using isaprop_isInjectiveFunction.
@@ -127,7 +127,7 @@ Intuition based on standard univalent models suggests that any type satisfying w
 
 *)
 
-Definition ischoicebase_uu1 ( X : UU ) := ∀ P : X -> UU , ( ∀ x : X , ishinh ( P x ) ) -> ishinh ( ∀ x : X , P x ) .
+Definition ischoicebase_uu1 ( X : UU ) := Π P : X -> UU , ( Π x : X , ishinh ( P x ) ) -> ishinh ( Π x : X , P x ) .
 
 Lemma isapropischoicebase ( X : UU ) : isaprop ( ischoicebase_uu1 X ) .  (** Uses RR1 *)
 Proof .  intro . apply impred . intro P .  apply impred . intro fs . apply ( pr2 ( ishinh _ ) ) .  Defined .
@@ -192,7 +192,7 @@ Definition weqtotalsubtype ( X : UU ) : totalsubtype X ≃ X .
 Proof . intro . apply weqpr1 .   intro . apply iscontrunit .  Defined .
 
 Definition weq_subtypes {X Y} (w : X≃Y) (S: hsubtypes X) (T: hsubtypes Y) :
-           (∀ x, S x <-> T (w x)) -> carrier S ≃ carrier T.
+           (Π x, S x <-> T (w x)) -> carrier S ≃ carrier T.
 Proof.
   intros ? ? ? ? ? eq. apply (weqbandf w). intro x. apply weqiff.
   - apply eq.
@@ -216,8 +216,8 @@ Proof . intros . set ( xis := pr1 xisyis ) . set ( yis := pr2 xisyis ) . set ( x
 
 Lemma weqsubtypesdirprod { X Y : UU } ( A : hsubtypes X ) ( B : hsubtypes Y ) : subtypesdirprod A B ≃ A × B .
 Proof . intros .  set ( f := fromdsubtypesdirprodcarrier A B ) . set ( g :=  tosubtypesdirprodcarrier A B ) . split with f .
-assert ( egf : ∀ a : _ , paths ( g ( f a ) ) a ) . intro a . destruct a as [ xy is ] . destruct xy as [ x y ] . destruct is as [ isx isy ] . apply idpath .
-assert ( efg : ∀ a : _ , paths ( f ( g a ) ) a ) . intro a . destruct a as [ xis yis ] . destruct xis as [ x isx ] . destruct yis as [ y isy ] . apply idpath .
+assert ( egf : Π a : _ , paths ( g ( f a ) ) a ) . intro a . destruct a as [ xy is ] . destruct xy as [ x y ] . destruct is as [ isx isy ] . apply idpath .
+assert ( efg : Π a : _ , paths ( f ( g a ) ) a ) . intro a . destruct a as [ xis yis ] . destruct xis as [ x isx ] . destruct yis as [ y isy ] . apply idpath .
 apply ( gradth _ _ egf efg ) . Defined .
 
 Lemma ishinhsubtypesdirprod  { X Y : UU } ( A : hsubtypes X ) ( B : hsubtypes Y ) ( isa : ishinh A ) ( isb : ishinh B ) : ishinh ( subtypesdirprod A B ) .
@@ -228,13 +228,13 @@ Proof . intros . apply ( hinhfun ( invweq ( weqsubtypesdirprod A B ) ) ) .  appl
 (** *** A a subtype of with a paths between any every two elements is an h-prop. *)
 
 
-Lemma isapropsubtype { X : UU } ( A : hsubtypes X ) ( is : ∀ ( x1 x2 : X ) , A x1 -> A x2 -> x1 = x2 ) : isaprop ( carrier A ) .
+Lemma isapropsubtype { X : UU } ( A : hsubtypes X ) ( is : Π ( x1 x2 : X ) , A x1 -> A x2 -> x1 = x2 ) : isaprop ( carrier A ) .
 Proof. intros.  apply invproofirrelevance. intros x x' .
 assert ( isincl ( @pr1 _ A )).  apply isinclpr1. intro x0. apply ( pr2 ( A x0 )).
 apply ( invmaponpathsincl ( @pr1 _ A ) X0 ). destruct x as [ x0 is0 ]. destruct x' as [ x0' is0' ] . simpl. apply is. assumption. assumption. Defined.
 
 Definition squash_pairs_to_set {Y} (F:Y->UU) :
-  (isaset Y) -> (∀ y y', F y -> F y' -> y=y') ->
+  (isaset Y) -> (Π y y', F y -> F y' -> y=y') ->
   (∃ y, F y) -> Y.
 Proof.
   intros ? ? is e.
@@ -253,7 +253,7 @@ Proof.
 Defined.
 
 Definition squash_to_set {X Y} (is:isaset Y) (f:X->Y) :
-          (∀ x x', f x = f x') -> ∥ X ∥ -> Y.
+          (Π x x', f x = f x') -> ∥ X ∥ -> Y.
 Proof.
   intros ? ? ? ? e w.
   set (P := Σ y, ∃ x, f x = y).
@@ -299,51 +299,51 @@ Coercion DecidableRelation_to_hrel : DecidableRelation >-> hrel.
 
 
 
-Definition istrans { X : UU } ( R : hrel X ) := ∀ ( x1 x2 x3 : X ), R x1 x2 -> R x2 x3 -> R x1 x3.
+Definition istrans { X : UU } ( R : hrel X ) := Π ( x1 x2 x3 : X ), R x1 x2 -> R x2 x3 -> R x1 x3.
 
-Definition isrefl { X : UU } ( R : hrel X ) := ∀ x : X , R x x.
+Definition isrefl { X : UU } ( R : hrel X ) := Π x : X , R x x.
 
-Definition issymm { X : UU } ( R : hrel X ) := ∀ ( x1 x2 : X ), R x1 x2 -> R x2 x1 .
+Definition issymm { X : UU } ( R : hrel X ) := Π ( x1 x2 : X ), R x1 x2 -> R x2 x1 .
 
 Definition ispreorder { X : UU } ( R : hrel X ) := istrans R × isrefl R .
 
 Definition iseqrel { X : UU } ( R : hrel X ) := ispreorder R × issymm R .
 Definition iseqrelconstr { X : UU } { R : hrel X } ( trans0 : istrans R ) ( refl0 : isrefl R ) ( symm0 : issymm R ) : iseqrel R := dirprodpair ( dirprodpair trans0 refl0 ) symm0 .
 
-Definition isirrefl { X : UU } ( R : hrel X ) := ∀ x : X , ¬ R x x .
+Definition isirrefl { X : UU } ( R : hrel X ) := Π x : X , ¬ R x x .
 
-Definition isasymm { X : UU } ( R : hrel X ) := ∀ ( x1 x2 : X ), R x1 x2 -> R x2 x1 -> empty .
+Definition isasymm { X : UU } ( R : hrel X ) := Π ( x1 x2 : X ), R x1 x2 -> R x2 x1 -> empty .
 
-Definition iscoasymm { X : UU } ( R : hrel X ) := ∀ x1 x2 , ¬ R x1 x2 -> R x2 x1 .
+Definition iscoasymm { X : UU } ( R : hrel X ) := Π x1 x2 , ¬ R x1 x2 -> R x2 x1 .
 
-Definition istotal { X : UU } ( R : hrel X ) := ∀ x1 x2 , R x1 x2 ∨ R x2 x1 .
+Definition istotal { X : UU } ( R : hrel X ) := Π x1 x2 , R x1 x2 ∨ R x2 x1 .
 
-Definition isdectotal { X : UU } ( R : hrel X ) := ∀ x1 x2 , R x1 x2 ⨿ R x2 x1 .
+Definition isdectotal { X : UU } ( R : hrel X ) := Π x1 x2 , R x1 x2 ⨿ R x2 x1 .
 
-Definition iscotrans { X : UU } ( R : hrel X ) := ∀ x1 x2 x3 , R x1 x3 -> R x1 x2 ∨ R x2 x3 .
+Definition iscotrans { X : UU } ( R : hrel X ) := Π x1 x2 x3 , R x1 x3 -> R x1 x2 ∨ R x2 x3 .
 
-Definition isdeccotrans { X : UU } ( R : hrel X ) := ∀ x1 x2 x3 , R x1 x3 -> R x1 x2 ⨿ R x2 x3 .
+Definition isdeccotrans { X : UU } ( R : hrel X ) := Π x1 x2 x3 , R x1 x3 -> R x1 x2 ⨿ R x2 x3 .
 
-Definition isdecrel { X : UU } ( R : hrel X ) := ∀ x1 x2 , R x1 x2 ⨿ ¬ R x1 x2 .
+Definition isdecrel { X : UU } ( R : hrel X ) := Π x1 x2 , R x1 x2 ⨿ ¬ R x1 x2 .
 
-Definition isnegrel { X : UU } ( R : hrel X ) := ∀ x1 x2 , ¬ ¬ R x1 x2 -> R x1 x2 .
+Definition isnegrel { X : UU } ( R : hrel X ) := Π x1 x2 , ¬ ¬ R x1 x2 -> R x1 x2 .
 
 (** Note that the property of being (co-)antisymmetric is different from other properties of relations which we consider due to the presence of [ paths ] in its formulation . As a consequence it behaves differently relative to the quotients of types - the quotient relation can be (co-)antisymmetric while the original relation was not . *)
 
-Definition isantisymm { X : UU } ( R : hrel X ) := ∀ ( x1 x2 : X ), R x1 x2 -> R x2 x1 -> x1 = x2 .
+Definition isantisymm { X : UU } ( R : hrel X ) := Π ( x1 x2 : X ), R x1 x2 -> R x2 x1 -> x1 = x2 .
 
 Definition isPartialOrder { X : UU } ( R : hrel X ) := ispreorder R × isantisymm R.
 
 Ltac unwrap_isPartialOrder i :=
   induction i as [transrefl antisymm]; induction transrefl as [trans refl].
 
-Definition isantisymmneg { X : UU } ( R : hrel X ) := ∀ ( x1 x2 : X ), ¬ R x1 x2 -> ¬ R x2 x1 -> x1 = x2 .
+Definition isantisymmneg { X : UU } ( R : hrel X ) := Π ( x1 x2 : X ), ¬ R x1 x2 -> ¬ R x2 x1 -> x1 = x2 .
 
-Definition iscoantisymm { X : UU } ( R : hrel X ) := ∀ x1 x2 , ¬ R x1 x2 -> R x2 x1 ⨿ (x1 = x2) .
+Definition iscoantisymm { X : UU } ( R : hrel X ) := Π x1 x2 , ¬ R x1 x2 -> R x2 x1 ⨿ (x1 = x2) .
 
 (** Note that the following condition on a relation is different from all the other which we have considered since it is not a property but a structure, i.e. it is in general unclear whether [ isaprop ( neqchoice R ) ] is provable. *)
 
-Definition neqchoice { X : UU } ( R : hrel X ) := ∀ x1 x2 , x1 != x2 -> R x1 x2 ⨿ R x2 x1 .
+Definition neqchoice { X : UU } ( R : hrel X ) := Π x1 x2 , x1 != x2 -> R x1 x2 ⨿ R x2 x1 .
 
 (** proofs that the properties are propositions  *)
 
@@ -413,54 +413,54 @@ Proof . intros . intro e . rewrite e in r . apply ( is b r ) . Defined .
 
 (** *** Standard properties of relations and logical equivalences *)
 
-Definition hrellogeq { X : UU } ( L R : hrel X ) := ∀ x1 x2 , ( L x1 x2 <-> R x1 x2 ) .
+Definition hrellogeq { X : UU } ( L R : hrel X ) := Π x1 x2 , ( L x1 x2 <-> R x1 x2 ) .
 
-Definition istranslogeqf { X : UU } { L R : hrel X } ( lg : ∀ x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : istrans L ) : istrans R .
+Definition istranslogeqf { X : UU } { L R : hrel X } ( lg : Π x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : istrans L ) : istrans R .
 Proof . intros . intros x1 x2 x3 r12 r23 .   apply ( ( pr1 ( lg _ _ ) ) ( isl _ _ _ ( ( pr2 ( lg _ _ ) ) r12 ) ( ( pr2 ( lg _ _ ) ) r23 ) ) ) . Defined .
 
-Definition isrefllogeqf { X : UU } { L R : hrel X } ( lg : ∀ x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : isrefl L ) : isrefl R .
+Definition isrefllogeqf { X : UU } { L R : hrel X } ( lg : Π x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : isrefl L ) : isrefl R .
 Proof . intros . intro x . apply ( pr1 ( lg _ _ ) ( isl x ) ) .  Defined .
 
-Definition issymmlogeqf { X : UU } { L R : hrel X } ( lg : ∀ x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : issymm L ) : issymm R .
+Definition issymmlogeqf { X : UU } { L R : hrel X } ( lg : Π x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : issymm L ) : issymm R .
 Proof . intros . intros x1 x2 r12 . apply ( pr1 ( lg _ _ ) ( isl _ _ ( pr2 ( lg _ _ ) r12 ) ) ) . Defined .
 
-Definition ispologeqf { X : UU } { L R : hrel X } ( lg : ∀ x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : ispreorder L ) : ispreorder R .
+Definition ispologeqf { X : UU } { L R : hrel X } ( lg : Π x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : ispreorder L ) : ispreorder R .
 Proof . intros . apply ( dirprodpair ( istranslogeqf lg ( pr1 isl ) ) ( isrefllogeqf lg ( pr2 isl ) ) ) . Defined .
 
-Definition iseqrellogeqf { X : UU } { L R : hrel X } ( lg : ∀ x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : iseqrel L ) : iseqrel R .
+Definition iseqrellogeqf { X : UU } { L R : hrel X } ( lg : Π x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : iseqrel L ) : iseqrel R .
 Proof . intros . apply ( dirprodpair ( ispologeqf lg ( pr1 isl ) ) ( issymmlogeqf lg ( pr2 isl ) ) ) . Defined .
 
-Definition isirrefllogeqf { X : UU } { L R : hrel X } ( lg : ∀ x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : isirrefl L ) : isirrefl R .
+Definition isirrefllogeqf { X : UU } { L R : hrel X } ( lg : Π x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : isirrefl L ) : isirrefl R .
 Proof . intros . intros x r . apply ( isl _ ( pr2 ( lg x x ) r ) ) . Defined .
 
-Definition isasymmlogeqf { X : UU } { L R : hrel X } ( lg : ∀ x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : isasymm L ) : isasymm R .
+Definition isasymmlogeqf { X : UU } { L R : hrel X } ( lg : Π x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : isasymm L ) : isasymm R .
 Proof . intros . intros x1 x2 r12 r21 . apply ( isl _ _ ( pr2 ( lg _ _ ) r12 ) ( pr2 ( lg _ _ ) r21 ) )   . Defined .
 
-Definition iscoasymmlogeqf { X : UU } { L R : hrel X } ( lg : ∀ x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : iscoasymm L ) : iscoasymm R .
+Definition iscoasymmlogeqf { X : UU } { L R : hrel X } ( lg : Π x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : iscoasymm L ) : iscoasymm R .
 Proof . intros . intros x1 x2 r12 . apply ( ( pr1 ( lg _ _ ) ) ( isl _ _ ( negf ( pr1 ( lg _ _ ) ) r12 ) ) ) . Defined .
 
-Definition istotallogeqf { X : UU } { L R : hrel X } ( lg : ∀ x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : istotal L ) : istotal R .
+Definition istotallogeqf { X : UU } { L R : hrel X } ( lg : Π x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : istotal L ) : istotal R .
 Proof . intros . intros x1 x2 . set ( int := isl x1 x2 ) .  generalize int . clear int . simpl .  apply hinhfun .  apply ( coprodf ( pr1 ( lg x1 x2 ) ) ( pr1 ( lg x2 x1 ) ) ) .  Defined .
 
-Definition iscotranslogeqf { X : UU } { L R : hrel X } ( lg : ∀ x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : iscotrans L ) : iscotrans R .
+Definition iscotranslogeqf { X : UU } { L R : hrel X } ( lg : Π x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : iscotrans L ) : iscotrans R .
 Proof . intros . intros x1 x2 x3 r13 . set ( int := isl x1 x2 x3 ( pr2 ( lg _ _ ) r13 ) ) .  generalize int . clear int . simpl .  apply hinhfun .  apply ( coprodf ( pr1 ( lg x1 x2 ) ) ( pr1 ( lg x2 x3 ) ) ) .  Defined .
 
-Definition isdecrellogeqf { X : UU } { L R : hrel X } ( lg : ∀ x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : isdecrel L ) : isdecrel R .
+Definition isdecrellogeqf { X : UU } { L R : hrel X } ( lg : Π x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : isdecrel L ) : isdecrel R .
 Proof . intros . intros x1 x2 . destruct ( isl x1 x2 ) as [ l | nl ] . apply ( ii1 ( pr1 ( lg _ _ ) l ) ) . apply ( ii2 ( negf ( pr2 ( lg _ _ ) ) nl ) ) . Defined .
 
-Definition isnegrellogeqf { X : UU } { L R : hrel X } ( lg : ∀ x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : isnegrel L ) : isnegrel R .
+Definition isnegrellogeqf { X : UU } { L R : hrel X } ( lg : Π x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : isnegrel L ) : isnegrel R .
 Proof . intros . intros x1 x2 nnr . apply ( ( pr1 ( lg _ _ ) ) ( isl _ _ ( negf ( negf ( pr2 ( lg _ _ ) ) ) nnr ) ) ) . Defined .
 
-Definition isantisymmlogeqf { X : UU } { L R : hrel X } ( lg : ∀ x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : isantisymm L ) : isantisymm R .
+Definition isantisymmlogeqf { X : UU } { L R : hrel X } ( lg : Π x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : isantisymm L ) : isantisymm R .
 Proof . intros . intros x1 x2 r12 r21 . apply ( isl _ _ ( pr2 ( lg _ _ ) r12 ) ( pr2 ( lg _ _ ) r21 ) )   . Defined .
 
-Definition isantisymmneglogeqf { X : UU } { L R : hrel X } ( lg : ∀ x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : isantisymmneg L ) : isantisymmneg R .
+Definition isantisymmneglogeqf { X : UU } { L R : hrel X } ( lg : Π x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : isantisymmneg L ) : isantisymmneg R .
 Proof . intros . intros x1 x2 nr12 nr21 . apply ( isl _ _ ( negf ( pr1 ( lg _ _ ) ) nr12 ) ( negf ( pr1 ( lg _ _ ) ) nr21 ) )   . Defined .
 
-Definition iscoantisymmlogeqf { X : UU } { L R : hrel X } ( lg : ∀ x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : iscoantisymm L ) : iscoantisymm R .
+Definition iscoantisymmlogeqf { X : UU } { L R : hrel X } ( lg : Π x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : iscoantisymm L ) : iscoantisymm R .
 Proof . intros . intros x1 x2 r12 . set ( int := isl _ _ ( negf ( pr1 ( lg _ _ ) ) r12 ) ) . generalize int .  clear int .  simpl . apply ( coprodf ( pr1 ( lg _ _ ) ) ( idfun _ ) ) . Defined .
 
-Definition neqchoicelogeqf { X : UU } { L R : hrel X } ( lg : ∀ x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : neqchoice L ) : neqchoice R .
+Definition neqchoicelogeqf { X : UU } { L R : hrel X } ( lg : Π x1 x2 , L x1 x2 <-> R x1 x2 ) ( isl : neqchoice L ) : neqchoice R .
 Proof . intros . intros x1 x2  ne .  apply ( coprodf ( pr1 ( lg x1 x2 ) ) ( pr1 ( lg x2 x1 ) ) ( isl _ _ ne ) ) . Defined .
 
 
@@ -506,13 +506,13 @@ Proof. intros ? x y l m. exact (pr2 (pr2 (pr2 X)) x y l m). Defined.
 
 Delimit Scope poset with poset.
 Notation "m ≤ n" := (posetRelation _ m n) (no associativity, at level 70) : poset.
-Definition isaposetmorphism { X Y : Poset } ( f : X -> Y ) := (∀ x x' : X, x ≤ x' -> f x ≤ f x')%poset .
+Definition isaposetmorphism { X Y : Poset } ( f : X -> Y ) := (Π x x' : X, x ≤ x' -> f x ≤ f x')%poset .
 Definition posetmorphism ( X Y : Poset ) := total2 ( fun f : X -> Y => isaposetmorphism f ) .
 Definition posetmorphismpair ( X Y : Poset ) := tpair ( fun f : X -> Y => isaposetmorphism f ) .
 Definition carrierofposetmorphism ( X Y : Poset ) : posetmorphism X Y -> ( X -> Y ) := @pr1 _ _ .
 Coercion  carrierofposetmorphism : posetmorphism >-> Funclass .
 
-Definition isdec_ordering (X:Poset) := ∀ (x y:X), decidable (x≤y)%poset.
+Definition isdec_ordering (X:Poset) := Π (x y:X), decidable (x≤y)%poset.
 
 Lemma isaprop_isaposetmorphism {X Y:Poset} (f:X->Y) : isaprop (isaposetmorphism f).
 Proof.
@@ -581,9 +581,9 @@ Defined.
 (** poset concepts *)
 
 Notation "m < n" := (m ≤ n × m != n)%poset (only parsing) :poset.
-Definition isMinimal {X:Poset} (x:X) := ∀ y, x≤y.
-Definition isMaximal {X:Poset} (x:X) := ∀ y, y≤x.
-Definition consecutive {X:Poset} (x y:X) := x<y × ∀ z, ¬ (x<z × z<y).
+Definition isMinimal {X:Poset} (x:X) := Π y, x≤y.
+Definition isMaximal {X:Poset} (x:X) := Π y, y≤x.
+Definition consecutive {X:Poset} (x y:X) := x<y × Π z, ¬ (x<z × z<y).
 
 Lemma isaprop_isMinimal {X:Poset} (x:X) : isaprop (isMaximal x).
 Proof.
@@ -786,12 +786,12 @@ Proof . intros . intros x1 x2 ne .  set ( int := negf ( invmaponpathsincl _ ( is
 
 
 
-Definition iseqclass { X : UU } ( R : hrel X ) ( A : hsubtypes X ) := dirprod ( ishinh ( carrier A ) ) ( dirprod ( ∀ x1 x2 : X , R x1 x2 -> A x1 -> A x2 ) ( ∀ x1 x2 : X, A x1 ->  A x2 -> R x1 x2 ) ).
-Definition iseqclassconstr { X : UU } ( R : hrel X ) { A : hsubtypes X } ( ax0 : ishinh ( carrier A ) ) ( ax1 : ∀ x1 x2 : X , R x1 x2 -> A x1 -> A x2 ) ( ax2 : ∀ x1 x2 : X, A x1 ->  A x2 -> R x1 x2 ) : iseqclass R A := dirprodpair ax0 ( dirprodpair ax1 ax2 ) .
+Definition iseqclass { X : UU } ( R : hrel X ) ( A : hsubtypes X ) := dirprod ( ishinh ( carrier A ) ) ( dirprod ( Π x1 x2 : X , R x1 x2 -> A x1 -> A x2 ) ( Π x1 x2 : X, A x1 ->  A x2 -> R x1 x2 ) ).
+Definition iseqclassconstr { X : UU } ( R : hrel X ) { A : hsubtypes X } ( ax0 : ishinh ( carrier A ) ) ( ax1 : Π x1 x2 : X , R x1 x2 -> A x1 -> A x2 ) ( ax2 : Π x1 x2 : X, A x1 ->  A x2 -> R x1 x2 ) : iseqclass R A := dirprodpair ax0 ( dirprodpair ax1 ax2 ) .
 
 Definition eqax0 { X : UU } { R : hrel X } { A : hsubtypes X }  : iseqclass R A -> ishinh ( carrier A ) := fun is : iseqclass R A =>  pr1 is .
-Definition eqax1 { X : UU } { R : hrel X } { A : hsubtypes X } : iseqclass R A ->  ∀ x1 x2 : X,  R x1 x2 -> A x1 -> A x2 := fun is: iseqclass R A => pr1 ( pr2 is) .
-Definition eqax2 { X : UU } { R : hrel X } { A : hsubtypes X } : iseqclass R A ->  ∀ x1 x2 : X,  A x1 -> A x2 -> R x1 x2 := fun is: iseqclass R A => pr2 ( pr2 is) .
+Definition eqax1 { X : UU } { R : hrel X } { A : hsubtypes X } : iseqclass R A ->  Π x1 x2 : X,  R x1 x2 -> A x1 -> A x2 := fun is: iseqclass R A => pr1 ( pr2 is) .
+Definition eqax2 { X : UU } { R : hrel X } { A : hsubtypes X } : iseqclass R A ->  Π x1 x2 : X,  A x1 -> A x2 -> R x1 x2 := fun is: iseqclass R A => pr2 ( pr2 is) .
 
 Lemma isapropiseqclass {X : UU} (R : hrel X) (A : hsubtypes X) :
   isaprop (iseqclass R A) .
@@ -812,15 +812,15 @@ Defined.
 Lemma iseqclassdirprod { X Y : UU } { R : hrel X } { Q : hrel Y } { A : hsubtypes X } { B : hsubtypes Y } ( isa : iseqclass R A ) ( isb : iseqclass Q B ) : iseqclass ( hreldirprod R Q ) ( subtypesdirprod A B ) .
 Proof . intros . set ( XY := dirprod X Y ) . set ( AB := subtypesdirprod A B ) . set ( RQ := hreldirprod R Q ) .
 set ( ax0 := ishinhsubtypesdirprod  A B ( eqax0 isa ) ( eqax0 isb ) ) .
-assert ( ax1 : ∀ xy1 xy2 : XY , RQ xy1 xy2 -> AB xy1 -> AB xy2 ) . intros xy1 xy2 rq ab1 . apply ( dirprodpair ( eqax1 isa _ _ ( pr1 rq ) ( pr1 ab1 ) ) ( eqax1 isb _ _ ( pr2 rq ) ( pr2 ab1 ) ) ) .
-assert ( ax2 : ∀ xy1 xy2 : XY ,  AB xy1 -> AB xy2 -> RQ xy1 xy2 ) . intros xy1 xy2 ab1 ab2 . apply ( dirprodpair ( eqax2 isa _ _ ( pr1 ab1 ) ( pr1 ab2 ) ) ( eqax2 isb _ _ ( pr2 ab1 ) ( pr2 ab2 ) ) ) .
+assert ( ax1 : Π xy1 xy2 : XY , RQ xy1 xy2 -> AB xy1 -> AB xy2 ) . intros xy1 xy2 rq ab1 . apply ( dirprodpair ( eqax1 isa _ _ ( pr1 rq ) ( pr1 ab1 ) ) ( eqax1 isb _ _ ( pr2 rq ) ( pr2 ab1 ) ) ) .
+assert ( ax2 : Π xy1 xy2 : XY ,  AB xy1 -> AB xy2 -> RQ xy1 xy2 ) . intros xy1 xy2 ab1 ab2 . apply ( dirprodpair ( eqax2 isa _ _ ( pr1 ab1 ) ( pr1 ab2 ) ) ( eqax2 isb _ _ ( pr2 ab1 ) ( pr2 ab2 ) ) ) .
 apply ( iseqclassconstr _ ax0 ax1 ax2 ) . Defined .
 
 
 
 (** ** Surjections to sets are epimorphisms  *)
 
-Theorem surjectionisepitosets { X Y Z : UU } ( f : X -> Y ) ( g1 g2 : Y -> Z ) ( is1 : issurjective f ) ( is2 : isaset Z ) ( isf : ∀ x : X , g1 (f x) = g2 (f x)  ) : ∀ y : Y , g1 y = g2 y .
+Theorem surjectionisepitosets { X Y Z : UU } ( f : X -> Y ) ( g1 g2 : Y -> Z ) ( is1 : issurjective f ) ( is2 : isaset Z ) ( isf : Π x : X , g1 (f x) = g2 (f x)  ) : Π y : Y , g1 y = g2 y .
 Proof. intros . set (P1:= hProppair (paths (g1 y) (g2 y)) (is2 (g1 y) (g2 y))). unfold issurjective in is1.
 assert (s1: (hfiber f y)-> paths (g1 y) (g2 y)). intro X1. destruct X1 as [t x ]. induction x. apply (isf t).
 assert (s2: ishinh (paths (g1 y) (g2 y))). apply (hinhfun s1 (is1 y)).
@@ -907,7 +907,7 @@ Proof. intros. apply ( invmaponpathsincl _ ( isinclpr1setquot R ) ) . simpl . ap
 (** *** Universal property of [ seqtquot R ] for functions to sets satisfying compatibility condition [ iscomprelfun ] *)
 
 
-Definition iscomprelfun { X Y : UU } ( R : hrel X ) ( f : X -> Y ) := ∀ x x' : X , R x x' -> f x = f x' .
+Definition iscomprelfun { X Y : UU } ( R : hrel X ) ( f : X -> Y ) := Π x x' : X , R x x' -> f x = f x' .
 
 Lemma iscomprelfunlogeqf { X Y : UU } { R L : hrel X } ( lg : hrellogeq L R ) ( f : X -> Y ) ( is : iscomprelfun L f ) : iscomprelfun R f .
 Proof . intros . intros x x' r . apply ( is _ _ ( pr2 ( lg  _ _ ) r ) ) . Defined .
@@ -923,7 +923,7 @@ Proof. intros.   apply ( pr1image ( fun x : c => f ( pr1 x ) ) ) . apply ( @hinh
 (** Note: the axioms rax, sax and trans are not used in the proof of setquotuniv. If we consider a relation which is not an equivalence relation then setquot will still be the set of subsets which are equivalence classes. Now however such subsets need not to cover all of the type. In fact their set can be empty. Nevertheless setquotuniv will apply. *)
 
 
-Theorem setquotunivcomm  { X : UU } ( R : eqrel X ) ( Y : hSet ) ( f : X -> Y ) ( is : iscomprelfun R f ) : ∀ x : X , setquotuniv R Y f is ( setquotpr R x ) =f x .
+Theorem setquotunivcomm  { X : UU } ( R : eqrel X ) ( Y : hSet ) ( f : X -> Y ) ( is : iscomprelfun R f ) : Π x : X , setquotuniv R Y f is ( setquotpr R x ) =f x .
 Proof. intros. unfold setquotuniv . unfold setquotpr .  simpl .  apply idpath .  Defined.
 
 
@@ -935,7 +935,7 @@ Proof .  intros . split with ( iscompsetquotpr R x x' ) .  apply isweqimplimpl .
 (** *** Functoriality of [ setquot ] for functions mapping one relation to another *)
 
 
-Definition iscomprelrelfun { X Y : UU } ( RX : hrel X ) ( RY : hrel Y ) ( f : X -> Y ) := ∀ x x' : X , RX x x' -> RY ( f x ) ( f x' ) .
+Definition iscomprelrelfun { X Y : UU } ( RX : hrel X ) ( RY : hrel Y ) ( f : X -> Y ) := Π x x' : X , RX x x' -> RY ( f x ) ( f x' ) .
 
 Lemma iscomprelfunlogeqf1 { X Y : UU }  { LX RX : hrel X } ( RY : hrel Y ) ( lg : hrellogeq LX RX ) ( f : X -> Y ) ( is : iscomprelrelfun LX RY f ) : iscomprelrelfun RX RY f .
 Proof . intros . intros x x' r . apply ( is _ _ ( pr2 ( lg  _ _ ) r ) ) . Defined .
@@ -946,7 +946,7 @@ Proof . intros . intros x x' r . apply ( ( pr1 ( lg _ _ ) ) ( is _ _ r ) ) . Def
 Definition  setquotfun  { X Y : UU } ( RX : hrel X ) ( RY : eqrel Y ) ( f : X -> Y ) ( is : iscomprelrelfun RX RY f ) ( cx : setquot RX ) : setquot RY .
 Proof . intros . set ( ff := funcomp f ( setquotpr RY ) ) . assert ( isff : iscomprelfun RX ff ) .  intros x x' .  intro r .  apply ( weqpathsinsetquot RY ( f x ) ( f x' ) ) .  apply is . apply r . apply ( setquotuniv RX ( setquotinset RY ) ff isff cx) .  Defined .
 
-Definition setquotfuncomm  { X Y : UU } ( RX : eqrel X ) ( RY : eqrel Y ) ( f : X -> Y ) ( is : iscomprelrelfun RX RY f ) : ∀ x : X , setquotfun RX RY f is ( setquotpr RX x ) = setquotpr RY ( f x ) .
+Definition setquotfuncomm  { X Y : UU } ( RX : eqrel X ) ( RY : eqrel Y ) ( f : X -> Y ) ( is : iscomprelrelfun RX RY f ) : Π x : X , setquotfun RX RY f is ( setquotpr RX x ) = setquotpr RY ( f x ) .
 Proof . intros . simpl . apply idpath .  Defined .
 
 
@@ -954,7 +954,7 @@ Proof . intros . simpl . apply idpath .  Defined .
 (** *** Universal property of [ setquot ] for predicates of one and several variables *)
 
 Theorem setquotunivprop {X : UU} (R : eqrel X) (P : setquot (pr1 R) -> hProp)
-  (ps : ∀ x : X, pr1 (P (setquotpr R x))) : ∀ c : setquot (pr1 R), pr1 (P c).
+  (ps : Π x : X, pr1 (P (setquotpr R x))) : Π c : setquot (pr1 R), pr1 (P c).
 Proof.
 intros X R P ps c.
 apply (@hinhuniv (carrier (pr1 c)) (P c)).
@@ -965,14 +965,14 @@ apply (@hinhuniv (carrier (pr1 c)) (P c)).
 - exact (eqax0 (pr2 c)).
 Defined.
 
-Theorem setquotuniv2prop { X : UU } ( R : eqrel X ) ( P : setquot R -> setquot R -> hProp ) ( is : ∀ x x' : X ,  P ( setquotpr R x ) ( setquotpr R x' ) ) : ∀ c c' : setquot R ,  P c c' .
-Proof . intros . assert ( int1 : ∀ c0' : _ , P c c0' ) .  apply ( setquotunivprop R ( fun c0' => P c c0' ) ) .  intro x . apply ( setquotunivprop R ( fun c0 : _ => P c0 ( setquotpr R x ) ) ) .  intro x0 . apply ( is x0 x ) . apply ( int1 c' ) .  Defined .
+Theorem setquotuniv2prop { X : UU } ( R : eqrel X ) ( P : setquot R -> setquot R -> hProp ) ( is : Π x x' : X ,  P ( setquotpr R x ) ( setquotpr R x' ) ) : Π c c' : setquot R ,  P c c' .
+Proof . intros . assert ( int1 : Π c0' : _ , P c c0' ) .  apply ( setquotunivprop R ( fun c0' => P c c0' ) ) .  intro x . apply ( setquotunivprop R ( fun c0 : _ => P c0 ( setquotpr R x ) ) ) .  intro x0 . apply ( is x0 x ) . apply ( int1 c' ) .  Defined .
 
-Theorem setquotuniv3prop { X : UU } ( R : eqrel X ) ( P : setquot R -> setquot R -> setquot R -> hProp ) ( is : ∀ x x' x'' : X ,  P  ( setquotpr R x ) ( setquotpr R x' ) ( setquotpr R x'' ) ) : ∀ c c' c'' : setquot R , P c c' c''  .
-Proof . intros . assert ( int1 : ∀ c0' c0'' : _ , P c c0' c0'' ) .  apply ( setquotuniv2prop R ( fun c0' c0'' => P c c0' c0'' ) ) .  intros x x' . apply ( setquotunivprop R ( fun c0 : _ => P c0 ( setquotpr R x ) ( setquotpr R x' ) ) ) .  intro x0 . apply ( is x0 x x' ) . apply ( int1 c' c'' ) .  Defined .
+Theorem setquotuniv3prop { X : UU } ( R : eqrel X ) ( P : setquot R -> setquot R -> setquot R -> hProp ) ( is : Π x x' x'' : X ,  P  ( setquotpr R x ) ( setquotpr R x' ) ( setquotpr R x'' ) ) : Π c c' c'' : setquot R , P c c' c''  .
+Proof . intros . assert ( int1 : Π c0' c0'' : _ , P c c0' c0'' ) .  apply ( setquotuniv2prop R ( fun c0' c0'' => P c c0' c0'' ) ) .  intros x x' . apply ( setquotunivprop R ( fun c0 : _ => P c0 ( setquotpr R x ) ( setquotpr R x' ) ) ) .  intro x0 . apply ( is x0 x x' ) . apply ( int1 c' c'' ) .  Defined .
 
-Theorem setquotuniv4prop { X : UU } ( R : eqrel X ) ( P : setquot R -> setquot R ->  setquot R -> setquot R -> hProp ) ( is : ∀ x x' x'' x''' : X ,  P  ( setquotpr R x ) ( setquotpr R x' ) ( setquotpr R x'' ) ( setquotpr R x''' ) ) : ∀ c c' c'' c''' : setquot R , P c c' c'' c''' .
-Proof . intros . assert ( int1 : ∀ c0 c0' c0'' : _ , P c c0 c0' c0'' ) .  apply ( setquotuniv3prop R ( fun c0 c0' c0'' => P c c0 c0' c0'' ) ) .  intros x x' x'' . apply ( setquotunivprop R ( fun c0 : _ => P c0 ( setquotpr R x ) ( setquotpr R x' ) ( setquotpr R x'' ) ) ) .  intro x0 . apply ( is x0 x x' x'' ) . apply ( int1 c' c'' c''' ) .  Defined .
+Theorem setquotuniv4prop { X : UU } ( R : eqrel X ) ( P : setquot R -> setquot R ->  setquot R -> setquot R -> hProp ) ( is : Π x x' x'' x''' : X ,  P  ( setquotpr R x ) ( setquotpr R x' ) ( setquotpr R x'' ) ( setquotpr R x''' ) ) : Π c c' c'' c''' : setquot R , P c c' c'' c''' .
+Proof . intros . assert ( int1 : Π c0 c0' c0'' : _ , P c c0 c0' c0'' ) .  apply ( setquotuniv3prop R ( fun c0 c0' c0'' => P c c0 c0' c0'' ) ) .  intros x x' x'' . apply ( setquotunivprop R ( fun c0 : _ => P c0 ( setquotpr R x ) ( setquotpr R x' ) ( setquotpr R x'' ) ) ) .  intro x0 . apply ( is x0 x x' x'' ) . apply ( int1 c' c'' c''' ) .  Defined .
 
 
 
@@ -988,24 +988,24 @@ Lemma issurjsetquotfun { X Y : UU } ( RX : eqrel X ) ( RY : eqrel Y ) ( f : X ->
 Proof . intros . apply ( issurjtwooutof3b ( setquotpr RX ) ) . apply ( issurjcomp f ( setquotpr RY ) is ( issurjsetquotpr RY ) ) .   Defined .
 
 
-Lemma isinclsetquotfun { X Y : UU } ( RX : eqrel X ) ( RY : eqrel Y ) ( f : X -> Y ) ( is1 : iscomprelrelfun RX RY f  )  ( is2 : ∀ x x' : X , RY ( f x ) ( f x' ) -> RX x x' ) : isincl ( setquotfun RX RY f is1 ) .
+Lemma isinclsetquotfun { X Y : UU } ( RX : eqrel X ) ( RY : eqrel Y ) ( f : X -> Y ) ( is1 : iscomprelrelfun RX RY f  )  ( is2 : Π x x' : X , RY ( f x ) ( f x' ) -> RX x x' ) : isincl ( setquotfun RX RY f is1 ) .
 Proof . intros . apply isinclbetweensets . apply isasetsetquot .   apply isasetsetquot .
-assert ( is : ∀ x x' : setquot RX , isaprop ( paths (setquotfun RX RY f is1 x) (setquotfun RX RY f is1 x') -> paths x x' ) ) . intros . apply impred .  intro . apply isasetsetquot .
+assert ( is : Π x x' : setquot RX , isaprop ( paths (setquotfun RX RY f is1 x) (setquotfun RX RY f is1 x') -> paths x x' ) ) . intros . apply impred .  intro . apply isasetsetquot .
 apply ( setquotuniv2prop RX ( fun x x' => hProppair _ ( is x x' ) ) ) .  simpl . intros x x' .  intro e .  set ( e' := invweq ( weqpathsinsetquot RY ( f x ) ( f x' ) ) e ) .  apply ( weqpathsinsetquot RX _ _ ( is2 x x' e' ) ) .  Defined .
 
-Definition setquotincl { X Y : UU } ( RX : eqrel X ) ( RY : eqrel Y ) ( f : X -> Y ) ( is1 : iscomprelrelfun RX RY f  )  ( is2 : ∀ x x' : X , RY ( f x ) ( f x' ) -> RX x x' ) := inclpair ( setquotfun RX RY f is1 ) ( isinclsetquotfun RX RY f is1 is2 ) .
+Definition setquotincl { X Y : UU } ( RX : eqrel X ) ( RY : eqrel Y ) ( f : X -> Y ) ( is1 : iscomprelrelfun RX RY f  )  ( is2 : Π x x' : X , RY ( f x ) ( f x' ) -> RX x x' ) := inclpair ( setquotfun RX RY f is1 ) ( isinclsetquotfun RX RY f is1 is2 ) .
 
-Definition  weqsetquotweq { X Y : UU } ( RX : eqrel X ) ( RY : eqrel Y ) ( f : weq X Y ) ( is1 : iscomprelrelfun RX RY f  )  ( is2 : ∀ x x' : X , RY ( f x ) ( f x' ) -> RX x x' ) : weq ( setquot RX ) ( setquot RY )  .
+Definition  weqsetquotweq { X Y : UU } ( RX : eqrel X ) ( RY : eqrel Y ) ( f : weq X Y ) ( is1 : iscomprelrelfun RX RY f  )  ( is2 : Π x x' : X , RY ( f x ) ( f x' ) -> RX x x' ) : weq ( setquot RX ) ( setquot RY )  .
 Proof . intros . set ( ff := setquotfun RX RY f is1 ) . split with ff .
-assert ( is2' : ∀ y y' : Y , RY y y' -> RX ( invmap f y ) ( invmap f y' ) ) . intros y y' .  rewrite ( pathsinv0 ( homotweqinvweq f y ) ) .  rewrite ( pathsinv0 ( homotweqinvweq f y' ) ) .  rewrite ( homotinvweqweq f ( invmap f y ) ) . rewrite ( homotinvweqweq f ( invmap f y' ) ) .  apply ( is2 _ _ ) .  set ( gg := setquotfun RY RX ( invmap f ) is2' ) .
+assert ( is2' : Π y y' : Y , RY y y' -> RX ( invmap f y ) ( invmap f y' ) ) . intros y y' .  rewrite ( pathsinv0 ( homotweqinvweq f y ) ) .  rewrite ( pathsinv0 ( homotweqinvweq f y' ) ) .  rewrite ( homotinvweqweq f ( invmap f y ) ) . rewrite ( homotinvweqweq f ( invmap f y' ) ) .  apply ( is2 _ _ ) .  set ( gg := setquotfun RY RX ( invmap f ) is2' ) .
 
-assert ( egf : ∀ a , paths ( gg ( ff a ) ) a ) . apply ( setquotunivprop RX ( fun a0 => hProppair _ ( isasetsetquot RX ( gg ( ff a0 ) ) a0 ) ) ) .    simpl .  intro x .  unfold ff . unfold gg .  apply ( maponpaths ( setquotpr RX ) ( homotinvweqweq f x ) ) .
+assert ( egf : Π a , paths ( gg ( ff a ) ) a ) . apply ( setquotunivprop RX ( fun a0 => hProppair _ ( isasetsetquot RX ( gg ( ff a0 ) ) a0 ) ) ) .    simpl .  intro x .  unfold ff . unfold gg .  apply ( maponpaths ( setquotpr RX ) ( homotinvweqweq f x ) ) .
 
-assert ( efg : ∀ a , paths ( ff ( gg a ) ) a ) . apply ( setquotunivprop RY ( fun a0 => hProppair _ ( isasetsetquot RY ( ff ( gg a0 ) ) a0 ) ) ) .    simpl .  intro x .  unfold ff . unfold gg .  apply ( maponpaths ( setquotpr RY ) ( homotweqinvweq f x ) ) .
+assert ( efg : Π a , paths ( ff ( gg a ) ) a ) . apply ( setquotunivprop RY ( fun a0 => hProppair _ ( isasetsetquot RY ( ff ( gg a0 ) ) a0 ) ) ) .    simpl .  intro x .  unfold ff . unfold gg .  apply ( maponpaths ( setquotpr RY ) ( homotweqinvweq f x ) ) .
 
 apply ( gradth _ _ egf efg ) . Defined .
 
-Definition weqsetquotsurj  { X Y : UU } ( RX : eqrel X ) ( RY : eqrel Y ) ( f : X -> Y ) ( is : issurjective f ) ( is1 : iscomprelrelfun RX RY f  )  ( is2 : ∀ x x' : X , RY ( f x ) ( f x' ) -> RX x x' ) : weq ( setquot RX ) ( setquot RY )  .
+Definition weqsetquotsurj  { X Y : UU } ( RX : eqrel X ) ( RY : eqrel Y ) ( f : X -> Y ) ( is : issurjective f ) ( is1 : iscomprelrelfun RX RY f  )  ( is2 : Π x x' : X , RY ( f x ) ( f x' ) -> RX x x' ) : weq ( setquot RX ) ( setquot RY )  .
 Proof . intros . set ( ff := setquotfun RX RY f is1 ) . split with ff .  apply ( @isweqinclandsurj ( setquotinset RX ) ( setquotinset RY ) ff ) .  apply ( isinclsetquotfun RX RY f is1 is2 ) .  apply ( issurjsetquotfun RX RY f is is1 ) .  Defined .
 
 
@@ -1023,9 +1023,9 @@ Definition dirprodtosetquot { X Y : UU } ( RX : hrel X ) ( RY : hrel Y ) (cd : d
 Theorem weqsetquottodirprod { X Y : UU } ( RX : eqrel X ) ( RY : eqrel Y ) : weq ( setquot ( eqreldirprod RX RY ) ) ( dirprod ( setquot RX ) ( setquot RY ) ) .
 Proof . intros . set ( f := setquottodirprod  RX RY ) . set ( g := dirprodtosetquot RX RY ) . split with f .
 
-assert ( egf : ∀ a : _ , paths ( g ( f a ) ) a ) . apply ( setquotunivprop _ ( fun a : _ => ( hProppair _ ( isasetsetquot _ ( g ( f a ) ) a ) ) ) ) . intro xy . destruct xy as [ x y ] . simpl . apply ( invmaponpathsincl _ ( isinclpr1setquot _ ) ) . simpl . apply funextsec .  intro xy' .  destruct xy' as [ x' y' ] . apply idpath .
+assert ( egf : Π a : _ , paths ( g ( f a ) ) a ) . apply ( setquotunivprop _ ( fun a : _ => ( hProppair _ ( isasetsetquot _ ( g ( f a ) ) a ) ) ) ) . intro xy . destruct xy as [ x y ] . simpl . apply ( invmaponpathsincl _ ( isinclpr1setquot _ ) ) . simpl . apply funextsec .  intro xy' .  destruct xy' as [ x' y' ] . apply idpath .
 
-assert ( efg : ∀ a : _ , paths ( f ( g a ) ) a ) . intro a . destruct a as [ ax ay ] . apply pathsdirprod . generalize ax .  clear ax . apply ( setquotunivprop RX ( fun ax : _ => ( hProppair _ ( isasetsetquot _ _ _ ) ) ) ) . intro x . simpl .  generalize ay .  clear ay . apply ( setquotunivprop RY ( fun ay : _ => ( hProppair _ ( isasetsetquot _ _ _ ) ) ) ) . intro y . simpl .   apply ( invmaponpathsincl _ ( isinclpr1setquot _ ) ) . apply funextsec .  intro x0 . simpl . apply idpath . generalize ax .  clear ax . apply ( setquotunivprop RX ( fun ax : _ => ( hProppair _ ( isasetsetquot _ _ _ ) ) ) ) . intro x . simpl .  generalize ay .  clear ay . apply ( setquotunivprop RY ( fun ay : _ => ( hProppair _ ( isasetsetquot _ _ _ ) ) ) ) . intro y . simpl .   apply ( invmaponpathsincl _ ( isinclpr1setquot _ ) ) . apply funextsec .  intro x0 . simpl . apply idpath .
+assert ( efg : Π a : _ , paths ( f ( g a ) ) a ) . intro a . destruct a as [ ax ay ] . apply pathsdirprod . generalize ax .  clear ax . apply ( setquotunivprop RX ( fun ax : _ => ( hProppair _ ( isasetsetquot _ _ _ ) ) ) ) . intro x . simpl .  generalize ay .  clear ay . apply ( setquotunivprop RY ( fun ay : _ => ( hProppair _ ( isasetsetquot _ _ _ ) ) ) ) . intro y . simpl .   apply ( invmaponpathsincl _ ( isinclpr1setquot _ ) ) . apply funextsec .  intro x0 . simpl . apply idpath . generalize ax .  clear ax . apply ( setquotunivprop RX ( fun ax : _ => ( hProppair _ ( isasetsetquot _ _ _ ) ) ) ) . intro x . simpl .  generalize ay .  clear ay . apply ( setquotunivprop RY ( fun ay : _ => ( hProppair _ ( isasetsetquot _ _ _ ) ) ) ) . intro y . simpl .   apply ( invmaponpathsincl _ ( isinclpr1setquot _ ) ) . apply funextsec .  intro x0 . simpl . apply idpath .
 
 apply ( gradth _ _ egf efg ) . Defined .
 
@@ -1033,9 +1033,9 @@ apply ( gradth _ _ egf efg ) . Defined .
 
 (** *** Universal property of [ setquot ] for functions of two variables *)
 
-Definition iscomprelfun2 { X Y : UU } ( R : hrel X ) ( f : X -> X -> Y ) := ∀ x x' x0 x0' : X , R x x' ->  R x0 x0' -> f x x0 = f x' x0' .
+Definition iscomprelfun2 { X Y : UU } ( R : hrel X ) ( f : X -> X -> Y ) := Π x x' x0 x0' : X , R x x' ->  R x0 x0' -> f x x0 = f x' x0' .
 
-Lemma iscomprelfun2if { X Y : UU } ( R : hrel X ) ( f : X -> X -> Y ) ( is1 : ∀ x x' x0 : X , R x x' -> f x x0 = f x' x0 ) ( is2 : ∀ x x0 x0' : X , R x0 x0' -> f x x0 = f x x0' ) : iscomprelfun2 R f .
+Lemma iscomprelfun2if { X Y : UU } ( R : hrel X ) ( f : X -> X -> Y ) ( is1 : Π x x' x0 : X , R x x' -> f x x0 = f x' x0 ) ( is2 : Π x x0 x0' : X , R x0 x0' -> f x x0 = f x x0' ) : iscomprelfun2 R f .
 Proof . intros . intros x x' x0 x0' .  intros r r' .  set ( e := is1 x x' x0 r ) . set ( e' := is2 x' x0 x0' r' ) . apply ( pathscomp0 e e' ) . Defined .
 
 Lemma iscomprelfun2logeqf { X Y : UU } { L R : hrel X } ( lg : hrellogeq L R ) ( f : X -> X -> Y ) ( is : iscomprelfun2 L f ) : iscomprelfun2 R f .
@@ -1045,7 +1045,7 @@ Definition setquotuniv2  { X : UU } ( R : hrel X ) ( Y : hSet ) ( f : X -> X -> 
 Proof. intros .  set ( ff := fun xy : dirprod X X => f ( pr1 xy ) ( pr2 xy ) ) . set ( RR := hreldirprod R R ) .
 assert ( isff : iscomprelfun RR ff ) . intros xy x'y' . simpl . intro dp .  destruct dp as [ r r'] .  apply ( is _ _ _ _ r r' ) . apply ( setquotuniv RR Y ff isff ( dirprodtosetquot R R ( dirprodpair c c0 ) ) ) . Defined .
 
-Theorem setquotuniv2comm  { X : UU } ( R : eqrel X ) ( Y : hSet ) ( f : X -> X -> Y ) ( is : iscomprelfun2 R f ) : ∀ x x' : X , setquotuniv2 R Y f is ( setquotpr R x ) ( setquotpr R x' ) = f x x' .
+Theorem setquotuniv2comm  { X : UU } ( R : eqrel X ) ( Y : hSet ) ( f : X -> X -> Y ) ( is : iscomprelfun2 R f ) : Π x x' : X , setquotuniv2 R Y f is ( setquotpr R x ) ( setquotpr R x' ) = f x x' .
 Proof. intros.   apply idpath .  Defined.
 
 
@@ -1053,9 +1053,9 @@ Proof. intros.   apply idpath .  Defined.
 (** *** Functoriality of [ setquot ] for functions of two variables mapping one relation to another *)
 
 
-Definition iscomprelrelfun2 { X Y : UU } ( RX : hrel X ) ( RY : hrel Y ) ( f : X -> X -> Y ) := ∀ x x' x0 x0' : X , RX x x' -> RX x0 x0' ->  RY ( f x x0 ) ( f x' x0' ) .
+Definition iscomprelrelfun2 { X Y : UU } ( RX : hrel X ) ( RY : hrel Y ) ( f : X -> X -> Y ) := Π x x' x0 x0' : X , RX x x' -> RX x0 x0' ->  RY ( f x x0 ) ( f x' x0' ) .
 
-Lemma iscomprelrelfun2if { X Y : UU } ( RX : hrel X ) ( RY : eqrel Y ) ( f : X -> X -> Y ) ( is1 : ∀ x x' x0 : X , RX x x' -> RY ( f x x0 ) ( f x' x0 ) ) ( is2 : ∀ x x0 x0' : X , RX x0 x0' -> RY ( f x x0 ) ( f x x0' ) ) : iscomprelrelfun2 RX RY f .
+Lemma iscomprelrelfun2if { X Y : UU } ( RX : hrel X ) ( RY : eqrel Y ) ( f : X -> X -> Y ) ( is1 : Π x x' x0 : X , RX x x' -> RY ( f x x0 ) ( f x' x0 ) ) ( is2 : Π x x0 x0' : X , RX x0 x0' -> RY ( f x x0 ) ( f x x0' ) ) : iscomprelrelfun2 RX RY f .
 Proof . intros . intros x x' x0 x0' .  intros r r' .  set ( e := is1 x x' x0 r ) . set ( e' := is2 x' x0 x0' r' ) . apply ( eqreltrans RY _ _ _ e e' ) . Defined .
 
 Lemma iscomprelrelfun2logeqf1 { X Y : UU } { LX RX : hrel X } ( RY : hrel Y ) ( lg : hrellogeq LX RX ) ( f : X -> X -> Y ) ( is : iscomprelrelfun2 LX RY f ) : iscomprelrelfun2 RX RY f .
@@ -1067,7 +1067,7 @@ Proof . intros . intros x x' x0 x0' r r0 . apply ( ( pr1 ( lg _ _ ) ) ( is _ _ _
 Definition  setquotfun2  { X Y : UU } ( RX : hrel X ) ( RY : eqrel Y ) ( f : X -> X -> Y ) ( is : iscomprelrelfun2 RX RY f ) ( cx cx0 : setquot RX ) : setquot RY .
 Proof . intros . set ( ff := fun x x0 : X => setquotpr RY ( f x x0 ) ) . assert ( isff : iscomprelfun2 RX ff ) .  intros x x' x0 x0' .  intros r r0  .  apply ( weqpathsinsetquot RY ( f x x0 ) ( f x' x0' ) ) .  apply is . apply r . apply r0 . apply ( setquotuniv2 RX ( setquotinset RY ) ff isff cx cx0 ) .  Defined .
 
-Theorem setquotfun2comm  { X Y : UU } ( RX : eqrel X ) ( RY : eqrel Y ) ( f : X -> X -> Y ) ( is : iscomprelrelfun2 RX RY f ) : ∀ x x' : X , setquotfun2 RX RY f is ( setquotpr RX x ) ( setquotpr RX x' ) =  setquotpr RY ( f x x' ) .
+Theorem setquotfun2comm  { X Y : UU } ( RX : eqrel X ) ( RY : eqrel Y ) ( f : X -> X -> Y ) ( is : iscomprelrelfun2 RX RY f ) : Π x x' : X , setquotfun2 RX RY f is ( setquotpr RX x ) ( setquotpr RX x' ) =  setquotpr RY ( f x x' ) .
 Proof. intros.   apply idpath .  Defined.
 
 
@@ -1075,25 +1075,25 @@ Proof. intros.   apply idpath .  Defined.
 (** *** Set quotients with respect to decidable equivalence relations have decidable equality *)
 
 
-Theorem isdeceqsetquot_non_constr { X : UU } ( R : eqrel X ) ( is : ∀ x x' : X , isdecprop ( R x x' ) ) : isdeceq ( setquot R ) .
+Theorem isdeceqsetquot_non_constr { X : UU } ( R : eqrel X ) ( is : Π x x' : X , isdecprop ( R x x' ) ) : isdeceq ( setquot R ) .
 Proof . intros .  apply isdeceqif . intros x x' .  apply ( setquotuniv2prop R ( fun x0 x0' => hProppair _ ( isapropisdecprop ( paths x0 x0' ) ) ) ) .  intros x0 x0' .  simpl .  apply ( isdecpropweqf ( weqpathsinsetquot R x0 x0' ) ( is x0 x0' ) ) .  Defined .
 
-Definition setquotbooleqint { X : UU } ( R : eqrel X ) ( is : ∀ x x' : X , isdecprop ( R x x' ) ) ( x x' : X ) : bool .
+Definition setquotbooleqint { X : UU } ( R : eqrel X ) ( is : Π x x' : X , isdecprop ( R x x' ) ) ( x x' : X ) : bool .
 Proof . intros . destruct ( pr1 ( is x x' ) ) . apply true . apply false . Defined .
 
-Lemma  setquotbooleqintcomp { X : UU } ( R : eqrel X ) ( is : ∀ x x' : X , isdecprop ( R x x' ) ) : iscomprelfun2 R ( setquotbooleqint R is ) .
+Lemma  setquotbooleqintcomp { X : UU } ( R : eqrel X ) ( is : Π x x' : X , isdecprop ( R x x' ) ) : iscomprelfun2 R ( setquotbooleqint R is ) .
 Proof . intros . unfold iscomprelfun2 .    intros x x' x0 x0' r r0 .  unfold setquotbooleqint . destruct ( pr1 ( is x x0 ) ) as [ r1 | nr1 ]  .   destruct ( pr1 ( is x' x0' ) ) as [ r1' | nr1' ] . apply idpath . destruct ( nr1' ( eqreltrans R _ _ _ ( eqreltrans R _ _ _ ( eqrelsymm R _ _ r ) r1 ) r0 ) )  .   destruct ( pr1 ( is x' x0' ) ) as [ r1' | nr1' ] . destruct ( nr1 ( eqreltrans R _ _ _ r ( eqreltrans R _ _ _ r1' ( eqrelsymm R _ _ r0 ) ) ) ) . apply idpath .   Defined .
 
 
-Definition setquotbooleq { X : UU } ( R : eqrel X ) ( is : ∀ x x' : X , isdecprop ( R x x' ) ) : setquot R -> setquot R -> bool := setquotuniv2 R ( hSetpair _ ( isasetbool ) ) ( setquotbooleqint R is ) ( setquotbooleqintcomp R is ) .
+Definition setquotbooleq { X : UU } ( R : eqrel X ) ( is : Π x x' : X , isdecprop ( R x x' ) ) : setquot R -> setquot R -> bool := setquotuniv2 R ( hSetpair _ ( isasetbool ) ) ( setquotbooleqint R is ) ( setquotbooleqintcomp R is ) .
 
-Lemma setquotbooleqtopaths  { X : UU } ( R : eqrel X ) ( is : ∀ x x' : X , isdecprop ( R x x' ) ) ( x x' : setquot R ) : setquotbooleq R is x x' = true  -> x = x' .
-Proof . intros X R is . assert ( isp : ∀ x x' : setquot R , isaprop ( paths ( setquotbooleq R is x x' ) true  -> paths x x' ) ) . intros x x' . apply impred . intro . apply ( isasetsetquot R x x' ) .     apply ( setquotuniv2prop R ( fun x x' => hProppair _ ( isp x x' ) ) ) . simpl .    intros x x' .  change ( paths (setquotbooleqint R is x x' ) true -> paths (setquotpr R x) (setquotpr R x') ) . unfold setquotbooleqint .  destruct ( pr1 ( is x x' ) ) as [ i1 | i2 ] . intro .  apply ( weqpathsinsetquot R _ _ i1 ) .  intro H . destruct ( nopathsfalsetotrue H ) .  Defined .
+Lemma setquotbooleqtopaths  { X : UU } ( R : eqrel X ) ( is : Π x x' : X , isdecprop ( R x x' ) ) ( x x' : setquot R ) : setquotbooleq R is x x' = true  -> x = x' .
+Proof . intros X R is . assert ( isp : Π x x' : setquot R , isaprop ( paths ( setquotbooleq R is x x' ) true  -> paths x x' ) ) . intros x x' . apply impred . intro . apply ( isasetsetquot R x x' ) .     apply ( setquotuniv2prop R ( fun x x' => hProppair _ ( isp x x' ) ) ) . simpl .    intros x x' .  change ( paths (setquotbooleqint R is x x' ) true -> paths (setquotpr R x) (setquotpr R x') ) . unfold setquotbooleqint .  destruct ( pr1 ( is x x' ) ) as [ i1 | i2 ] . intro .  apply ( weqpathsinsetquot R _ _ i1 ) .  intro H . destruct ( nopathsfalsetotrue H ) .  Defined .
 
-Lemma setquotpathstobooleq  { X : UU } ( R : eqrel X ) ( is : ∀ x x' : X , isdecprop ( R x x' ) ) ( x x' : setquot R ) : x = x' -> setquotbooleq R is x x' = true .
+Lemma setquotpathstobooleq  { X : UU } ( R : eqrel X ) ( is : Π x x' : X , isdecprop ( R x x' ) ) ( x x' : setquot R ) : x = x' -> setquotbooleq R is x x' = true .
 Proof . intros X R is x x' e . destruct e . generalize x .  apply ( setquotunivprop R ( fun x => hProppair _ ( isasetbool (setquotbooleq R is x x) true ) ) ) .  simpl .  intro x0 .  change ( paths ( setquotbooleqint R is x0 x0 ) true ) .  unfold setquotbooleqint .  destruct ( pr1 ( is x0 x0 ) ) as [ i1 | i2 ] .  apply idpath .  destruct ( i2 ( eqrelrefl R x0 ) ) .  Defined .
 
-Definition  isdeceqsetquot { X : UU } ( R : eqrel X ) ( is : ∀ x x' : X , isdecprop ( R x x' ) ) : isdeceq ( setquot R ) .
+Definition  isdeceqsetquot { X : UU } ( R : eqrel X ) ( is : Π x x' : X , isdecprop ( R x x' ) ) : isdeceq ( setquot R ) .
 Proof . intros . intros x x' .  destruct ( boolchoice ( setquotbooleq R is x x' ) ) as [ i | ni ] .  apply ( ii1 ( setquotbooleqtopaths R is x x' i ) ) . apply ii2 .   intro e .  destruct ( falsetonegtrue _ ni ( setquotpathstobooleq R is x x' e ) ) . Defined .
 
 
@@ -1104,7 +1104,7 @@ Note that all the properties of the quotient relations which we consider other t
 
 Definition iscomprelrel { X : UU } ( R : hrel X ) ( L : hrel X ) := iscomprelfun2 R L .
 
-Lemma iscomprelrelif { X : UU } { R : hrel X } ( L : hrel X ) ( isr : issymm R ) ( i1 : ∀ x x' y , R x x' -> L x y -> L x' y ) ( i2 : ∀ x y y' , R y y' -> L x y -> L x y' ) : iscomprelrel R L .
+Lemma iscomprelrelif { X : UU } { R : hrel X } ( L : hrel X ) ( isr : issymm R ) ( i1 : Π x x' y , R x x' -> L x y -> L x' y ) ( i2 : Π x y y' , R y y' -> L x y -> L x y' ) : iscomprelrel R L .
 Proof . intros .  intros x x' y y' rx ry .  set ( rx' := isr _ _ rx ) . set ( ry' := isr _ _ ry ) . apply uahp .  intro lxy .  set ( int1 := i1 _ _ _ rx lxy ) . apply ( i2 _ _ _ ry int1 ) .  intro lxy' .  set ( int1 := i1 _ _ _ rx' lxy' ) .  apply ( i2 _ _ _ ry' int1 ) .  Defined .
 
 Lemma iscomprelrellogeqf1 { X : UU } { R R' : hrel X } ( L : hrel X ) ( lg : hrellogeq R R' ) ( is : iscomprelrel R L ) : iscomprelrel R' L .
@@ -1116,10 +1116,10 @@ Proof . intros . intros x x' x0 x0' r r0 . assert ( e : paths ( L x x0 ) ( L' x 
 Definition quotrel  { X : UU } { R L : hrel X } ( is : iscomprelrel R L ) : hrel ( setquot R ) := setquotuniv2 R hPropset L is .
 
 Lemma istransquotrel { X : UU } { R : eqrel X } { L : hrel X } ( is : iscomprelrel R L ) ( isl : istrans L ) : istrans ( quotrel is ) .
-Proof . intros . unfold istrans.  assert ( int : ∀ x1 x2 x3 : setquot R , isaprop ( quotrel is x1 x2 -> quotrel is x2 x3 -> quotrel is x1 x3 ) ) .  intros x1 x2 x3 . apply impred . intro . apply impred . intro . apply ( pr2 ( quotrel is x1 x3 ) ) .  apply ( setquotuniv3prop R ( fun x1 x2 x3 => hProppair _ ( int x1 x2 x3 ) ) ) .  intros x x' x'' . intros r r' . apply ( isl x x' x'' r r' ) . Defined .
+Proof . intros . unfold istrans.  assert ( int : Π x1 x2 x3 : setquot R , isaprop ( quotrel is x1 x2 -> quotrel is x2 x3 -> quotrel is x1 x3 ) ) .  intros x1 x2 x3 . apply impred . intro . apply impred . intro . apply ( pr2 ( quotrel is x1 x3 ) ) .  apply ( setquotuniv3prop R ( fun x1 x2 x3 => hProppair _ ( int x1 x2 x3 ) ) ) .  intros x x' x'' . intros r r' . apply ( isl x x' x'' r r' ) . Defined .
 
 Lemma issymmquotrel  { X : UU } { R : eqrel X } { L : hrel X } ( is : iscomprelrel R L ) ( isl : issymm L ) : issymm ( quotrel is ) .
-Proof . intros . unfold issymm.  assert ( int : ∀ x1 x2 : setquot R , isaprop ( quotrel is x1 x2 -> quotrel is x2 x1 ) ) .  intros x1 x2 . apply impred . intro . apply ( pr2 ( quotrel is x2 x1 ) ) .  apply ( setquotuniv2prop R ( fun x1 x2 => hProppair _ ( int x1 x2 ) ) ) .  intros x x' . intros r . apply ( isl x x' r ) . Defined .
+Proof . intros . unfold issymm.  assert ( int : Π x1 x2 : setquot R , isaprop ( quotrel is x1 x2 -> quotrel is x2 x1 ) ) .  intros x1 x2 . apply impred . intro . apply ( pr2 ( quotrel is x2 x1 ) ) .  apply ( setquotuniv2prop R ( fun x1 x2 => hProppair _ ( int x1 x2 ) ) ) .  intros x x' . intros r . apply ( isl x x' r ) . Defined .
 
 Lemma isreflquotrel { X : UU } { R : eqrel X } { L : hrel X } ( is : iscomprelrel R L ) ( isl : isrefl L ) : isrefl ( quotrel is ) .
 Proof . intros . unfold isrefl .  apply ( setquotunivprop R ) .   intro x .  apply ( isl x ) . Defined .
@@ -1134,30 +1134,30 @@ Lemma isirreflquotrel { X : UU } { R : eqrel X } { L : hrel X } ( is : iscomprel
 Proof . intros . unfold isirrefl .  apply ( setquotunivprop R ( fun x => hProppair _ ( isapropneg (quotrel is x x) ) ) ) .   intro x .  apply ( isl x ) . Defined .
 
 Lemma isasymmquotrel { X : UU } { R : eqrel X } { L : hrel X } ( is : iscomprelrel R L ) ( isl : isasymm L ) : isasymm ( quotrel is ) .
-Proof . intros . unfold isasymm.  assert ( int : ∀ x1 x2 : setquot R , isaprop ( quotrel is x1 x2 -> quotrel is x2 x1 -> empty ) ) .  intros x1 x2 . apply impred . intro . apply impred . intro . apply isapropempty .  apply ( setquotuniv2prop R ( fun x1 x2 => hProppair _ ( int x1 x2 ) ) ) .  intros x x' . intros r r' . apply ( isl x x' r r' ) . Defined .
+Proof . intros . unfold isasymm.  assert ( int : Π x1 x2 : setquot R , isaprop ( quotrel is x1 x2 -> quotrel is x2 x1 -> empty ) ) .  intros x1 x2 . apply impred . intro . apply impred . intro . apply isapropempty .  apply ( setquotuniv2prop R ( fun x1 x2 => hProppair _ ( int x1 x2 ) ) ) .  intros x x' . intros r r' . apply ( isl x x' r r' ) . Defined .
 
 Lemma iscoasymmquotrel { X : UU } { R : eqrel X } { L : hrel X } ( is : iscomprelrel R L ) ( isl : iscoasymm L ) : iscoasymm ( quotrel is ) .
-Proof . intros . unfold iscoasymm.  assert ( int : ∀ x1 x2 : setquot R , isaprop ( neg ( quotrel is x1 x2 ) -> quotrel is x2 x1 ) ) .  intros x1 x2 . apply impred . intro . apply ( pr2 _ ) .  apply ( setquotuniv2prop R ( fun x1 x2 => hProppair _ ( int x1 x2 ) ) ) .  intros x x' . intros r . apply ( isl x x' r ) . Defined .
+Proof . intros . unfold iscoasymm.  assert ( int : Π x1 x2 : setquot R , isaprop ( neg ( quotrel is x1 x2 ) -> quotrel is x2 x1 ) ) .  intros x1 x2 . apply impred . intro . apply ( pr2 _ ) .  apply ( setquotuniv2prop R ( fun x1 x2 => hProppair _ ( int x1 x2 ) ) ) .  intros x x' . intros r . apply ( isl x x' r ) . Defined .
 
 Lemma istotalquotrel { X : UU } { R : eqrel X } { L : hrel X } ( is : iscomprelrel R L ) ( isl : istotal L ) : istotal ( quotrel is ) .
 Proof . intros .  unfold istotal . apply ( setquotuniv2prop R ( fun x1 x2 => hdisj _ _ ) ) .  intros x x' . intros r r' . apply ( isl x x' r r' ) . Defined .
 
 Lemma iscotransquotrel { X : UU } { R : eqrel X } { L : hrel X } ( is : iscomprelrel R L ) ( isl : iscotrans L ) : iscotrans ( quotrel is ) .
-Proof . intros .  unfold iscotrans . assert ( int : ∀ x1 x2 x3 : setquot R , isaprop ( quotrel is x1 x3 -> hdisj (quotrel is x1 x2) (quotrel is x2 x3) ) ) . intros . apply impred . intro . apply ( pr2 _ ) . apply ( setquotuniv3prop R ( fun x1 x2 x3 => hProppair  _ ( int x1 x2 x3 ) ) ) .  intros x x' x'' . intros r . apply ( isl x x' x'' r  ) . Defined .
+Proof . intros .  unfold iscotrans . assert ( int : Π x1 x2 x3 : setquot R , isaprop ( quotrel is x1 x3 -> hdisj (quotrel is x1 x2) (quotrel is x2 x3) ) ) . intros . apply impred . intro . apply ( pr2 _ ) . apply ( setquotuniv3prop R ( fun x1 x2 x3 => hProppair  _ ( int x1 x2 x3 ) ) ) .  intros x x' x'' . intros r . apply ( isl x x' x'' r  ) . Defined .
 
 Lemma isantisymmquotrel { X : UU } { R : eqrel X } { L : hrel X } ( is : iscomprelrel R L ) ( isl : isantisymm L ) : isantisymm ( quotrel is ) .
-Proof . intros . unfold isantisymm.  assert ( int : ∀ x1 x2 : setquot R , isaprop ( quotrel is x1 x2 -> quotrel is x2 x1 -> paths x1 x2 ) ) .  intros x1 x2 . apply impred . intro . apply impred . intro . apply ( isasetsetquot R x1 x2 ) .  apply ( setquotuniv2prop R ( fun x1 x2 => hProppair _ ( int x1 x2 ) ) ) .  intros x x' . intros r r' . apply ( maponpaths ( setquotpr R ) ( isl x x' r r' ) ) . Defined .
+Proof . intros . unfold isantisymm.  assert ( int : Π x1 x2 : setquot R , isaprop ( quotrel is x1 x2 -> quotrel is x2 x1 -> paths x1 x2 ) ) .  intros x1 x2 . apply impred . intro . apply impred . intro . apply ( isasetsetquot R x1 x2 ) .  apply ( setquotuniv2prop R ( fun x1 x2 => hProppair _ ( int x1 x2 ) ) ) .  intros x x' . intros r r' . apply ( maponpaths ( setquotpr R ) ( isl x x' r r' ) ) . Defined .
 
 Lemma isantisymmnegquotrel { X : UU } { R : eqrel X } { L : hrel X } ( is : iscomprelrel R L ) ( isl : isantisymmneg L ) : isantisymmneg ( quotrel is ) .
-Proof . intros . unfold isantisymmneg.  assert ( int : ∀ x1 x2 : setquot R , isaprop ( neg ( quotrel is x1 x2 ) -> neg ( quotrel is x2 x1 ) -> paths x1 x2 ) ) .  intros x1 x2 . apply impred . intro . apply impred . intro . apply ( isasetsetquot R x1 x2 ) .  apply ( setquotuniv2prop R ( fun x1 x2 => hProppair _ ( int x1 x2 ) ) ) .  intros x x' . intros r r' . apply ( maponpaths ( setquotpr R ) ( isl x x' r r' ) ) . Defined .
+Proof . intros . unfold isantisymmneg.  assert ( int : Π x1 x2 : setquot R , isaprop ( neg ( quotrel is x1 x2 ) -> neg ( quotrel is x2 x1 ) -> paths x1 x2 ) ) .  intros x1 x2 . apply impred . intro . apply impred . intro . apply ( isasetsetquot R x1 x2 ) .  apply ( setquotuniv2prop R ( fun x1 x2 => hProppair _ ( int x1 x2 ) ) ) .  intros x x' . intros r r' . apply ( maponpaths ( setquotpr R ) ( isl x x' r r' ) ) . Defined .
 
 (** We do not have a lemma for [ neqchoicequotrel ] since [ neqchoice ] is not a property and since even when it is a property such as under the additional condition [ isasymm ] on the relation it still carrier computational content (similarly to [ isdec ]) which would be lost under our current approach of taking quotients. How to best define [neqchoicequotrel] remains at the moment an open question.*)
 
 
-Lemma quotrelimpl { X : UU } { R : eqrel X } { L L' : hrel X } ( is : iscomprelrel R L ) ( is' : iscomprelrel R L' ) ( impl : ∀ x x' , L x x' -> L' x x' ) ( x x' : setquot R ) ( ql : quotrel is x x' ) : quotrel is' x x'  .
-Proof . intros .  generalize x x' ql . assert ( int : ∀ x0 x0' , isaprop ( quotrel is x0 x0' -> quotrel is' x0 x0' ) ) . intros x0 x0' . apply impred . intro . apply ( pr2 _ ) . apply ( setquotuniv2prop _ ( fun x0 x0' => hProppair _ ( int x0 x0' ) ) ) . intros x0 x0' .  change ( L x0 x0' -> L' x0 x0' ) .  apply ( impl x0 x0' ) . Defined .
+Lemma quotrelimpl { X : UU } { R : eqrel X } { L L' : hrel X } ( is : iscomprelrel R L ) ( is' : iscomprelrel R L' ) ( impl : Π x x' , L x x' -> L' x x' ) ( x x' : setquot R ) ( ql : quotrel is x x' ) : quotrel is' x x'  .
+Proof . intros .  generalize x x' ql . assert ( int : Π x0 x0' , isaprop ( quotrel is x0 x0' -> quotrel is' x0 x0' ) ) . intros x0 x0' . apply impred . intro . apply ( pr2 _ ) . apply ( setquotuniv2prop _ ( fun x0 x0' => hProppair _ ( int x0 x0' ) ) ) . intros x0 x0' .  change ( L x0 x0' -> L' x0 x0' ) .  apply ( impl x0 x0' ) . Defined .
 
-Lemma quotrellogeq { X : UU } { R : eqrel X } { L L' : hrel X } ( is : iscomprelrel R L ) ( is' : iscomprelrel R L' ) ( lg : ∀ x x' , L x x' <-> L' x x' ) ( x x' : setquot R ) : ( quotrel is x x' ) <-> ( quotrel is' x x' ) .
+Lemma quotrellogeq { X : UU } { R : eqrel X } { L L' : hrel X } ( is : iscomprelrel R L ) ( is' : iscomprelrel R L' ) ( lg : Π x x' , L x x' <-> L' x x' ) ( x x' : setquot R ) : ( quotrel is x x' ) <-> ( quotrel is' x x' ) .
 Proof . intros . split . apply ( quotrelimpl is is' ( fun x0 x0' => pr1 ( lg x0 x0' ) ) x x' ) .  apply ( quotrelimpl is' is ( fun x0 x0' => pr2 ( lg x0 x0' ) ) x x' ) . Defined .
 
 
@@ -1168,7 +1168,7 @@ Definition quotdecrelint { X : UU } { R : hrel X } ( L : decrel X ) ( is : iscom
 Proof .    intros .  set ( f := decreltobrel L ) .  unfold brel . apply ( setquotuniv2 R boolset f ) . intros x x' x0 x0' r r0. unfold f . unfold decreltobrel in * .  destruct ( pr2 L x x0' ) as [ l | nl ] . destruct ( pr2 L x' x0' ) as [ l' | nl' ] .  destruct ( pr2 L x x0 ) as [ l'' | nl'' ] . apply idpath .  set ( e := is x x' x0 x0' r r0 ) . destruct e . destruct ( nl'' l' ) .   destruct ( pr2 L x x0 ) as [ l'' | nl'' ] .  set ( e := is x x' x0 x0' r r0 ) . destruct e . destruct ( nl' l'' ) .  apply idpath . destruct ( pr2 L x x0 ) as [ l' | nl' ] . destruct ( pr2 L x' x0' ) as [ l'' | nl'' ] .  apply idpath .  set ( e := is x x' x0 x0' r r0 ) . destruct e . destruct ( nl'' l' ) . destruct ( pr2 L x' x0' ) as [ l'' | nl'' ] .  set ( e := is x x' x0 x0' r r0 ) . destruct e . destruct ( nl' l'' ) .    apply idpath . Defined .
 
 Definition quotdecrelintlogeq { X : UU } { R : eqrel X } ( L : decrel X ) ( is : iscomprelrel R ( pr1 L ) ) ( x x' : setquot R ) : breltodecrel ( quotdecrelint L is ) x x' <-> quotrel is x x' .
-Proof . intros X R L is . assert ( int : ∀ x x' , isaprop ( paths ( quotdecrelint L is x x' ) true  <-> ( quotrel is x x' ) ) ) .  intros x x' . apply isapropdirprod .    apply impred . intro . apply ( pr2 ( quotrel _ _ _ ) ) . apply impred . intro . apply isasetbool .  apply ( setquotuniv2prop R ( fun x x' => hProppair _ ( int x x' ) ) ) . intros x x' .   simpl . split .  apply ( pathstor L x x' ) . apply ( rtopaths L x x' ) . Defined .
+Proof . intros X R L is . assert ( int : Π x x' , isaprop ( paths ( quotdecrelint L is x x' ) true  <-> ( quotrel is x x' ) ) ) .  intros x x' . apply isapropdirprod .    apply impred . intro . apply ( pr2 ( quotrel _ _ _ ) ) . apply impred . intro . apply isasetbool .  apply ( setquotuniv2prop R ( fun x x' => hProppair _ ( int x x' ) ) ) . intros x x' .   simpl . split .  apply ( pathstor L x x' ) . apply ( rtopaths L x x' ) . Defined .
 
 Lemma isdecquotrel { X : UU } { R : eqrel X } { L : hrel X } ( is : iscomprelrel R L ) ( isl : isdecrel L ) : isdecrel ( quotrel is ) .
 Proof . intros . apply ( isdecrellogeqf ( quotdecrelintlogeq ( decrelpair isl ) is ) ( pr2 ( breltodecrel ( quotdecrelint ( decrelpair isl ) is ) ) ) ) .  Defined .
@@ -1182,7 +1182,7 @@ Definition decquotrel  { X : UU } { R : eqrel X } ( L : decrel X ) ( is : iscomp
 
 Definition reseqrel { X : UU } ( R : eqrel X ) ( P : hsubtypes X ) : eqrel P := eqrelpair _ ( iseqrelresrel R P ( pr2 R ) ) .
 
-Lemma iseqclassresrel { X : UU } ( R : hrel X ) ( P Q : hsubtypes X ) ( is : iseqclass R Q ) ( is' : ∀ x , Q x -> P x ) : iseqclass ( resrel R P ) ( fun x : P => Q ( pr1 x ) ) .
+Lemma iseqclassresrel { X : UU } ( R : hrel X ) ( P Q : hsubtypes X ) ( is : iseqclass R Q ) ( is' : Π x , Q x -> P x ) : iseqclass ( resrel R P ) ( fun x : P => Q ( pr1 x ) ) .
 Proof . intros . split .
 
 set ( l1 := pr1 is ) . generalize l1 . clear l1 . simpl . apply hinhfun . intro q . split with ( carrierpair P ( pr1 q ) ( is' ( pr1 q ) ( pr2 q ) ) ) . apply ( pr2 q ) .  split .
@@ -1200,9 +1200,9 @@ Proof . intros X R P . assert ( int : isaset P ) . apply ( isasetsubset ( @pr1 _
 Definition weqsubquot { X : UU } ( R : eqrel X ) ( P : hsubtypes ( setquot R ) ) : weq P ( setquot ( resrel R ( funcomp ( setquotpr R ) P ) ) ) .
 Proof . intros . set ( f := fromsubquot R P ) . set ( g := tosubquot R P ) .  split with f .  assert ( int0 : isaset P ) . apply ( isasetsubset ( @pr1 _ P ) ) . apply ( setproperty ( setquotinset R ) ) . refine (isinclpr1carrier _) .
 
-assert ( egf : ∀ a , paths ( g ( f a ) ) a ) .  intros a .  destruct a as [ p isp ] . generalize isp . generalize p . clear isp . clear p .  assert ( int : ∀ p , isaprop ( ∀ isp : P p , paths (g (f ( tpair _ p isp ))) ( tpair _ p isp )  ) ) .  intro p . apply impred . intro . apply ( int0 _ _ ) . apply ( setquotunivprop _ ( fun a =>  hProppair _ ( int a ) ) ) .  simpl . intros x isp .  apply ( invmaponpathsincl _ ( isinclpr1carrier P ) _ _ ) .  apply idpath .
+assert ( egf : Π a , paths ( g ( f a ) ) a ) .  intros a .  destruct a as [ p isp ] . generalize isp . generalize p . clear isp . clear p .  assert ( int : Π p , isaprop ( Π isp : P p , paths (g (f ( tpair _ p isp ))) ( tpair _ p isp )  ) ) .  intro p . apply impred . intro . apply ( int0 _ _ ) . apply ( setquotunivprop _ ( fun a =>  hProppair _ ( int a ) ) ) .  simpl . intros x isp .  apply ( invmaponpathsincl _ ( isinclpr1carrier P ) _ _ ) .  apply idpath .
 
-assert ( efg : ∀ a , paths ( f ( g a ) ) a ) . assert ( int : ∀ a , isaprop ( paths ( f ( g a ) ) a ) ) . intro a . apply ( setproperty ( setquotinset (resrel R (funcomp (setquotpr R) P)) )  ) . set ( Q := reseqrel R (funcomp (setquotpr R) P) ) . apply ( setquotunivprop Q ( fun a : setquot (resrel R (funcomp (setquotpr R) P)) =>  hProppair _ ( int a ) ) ) .   intro a . simpl .  unfold f . unfold g . unfold fromsubquot . unfold tosubquot .
+assert ( efg : Π a , paths ( f ( g a ) ) a ) . assert ( int : Π a , isaprop ( paths ( f ( g a ) ) a ) ) . intro a . apply ( setproperty ( setquotinset (resrel R (funcomp (setquotpr R) P)) )  ) . set ( Q := reseqrel R (funcomp (setquotpr R) P) ) . apply ( setquotunivprop Q ( fun a : setquot (resrel R (funcomp (setquotpr R) P)) =>  hProppair _ ( int a ) ) ) .   intro a . simpl .  unfold f . unfold g . unfold fromsubquot . unfold tosubquot .
 
 (* Compilations hangs here if the next command is "simpl." in 8.4-8.5-trunk *)
 
@@ -1217,11 +1217,11 @@ Proof . intros . apply idpath . Defined . ]
 
 As one of the consequences we are forced to use a "hack" in the definition of multiplicative inverses for rationals in [ hqmultinv ] .
 
-The issue which arises here is the same one which arises in several other places in the work with quotients. It can be traced back first to the failure of [ invmaponpathsincl ] to map [ idpath ] to [ idpath ] and then to the fact that for [ ( X : UU ) ( is : isaprop X ) ] the term [ t := proofirrelevance is : ∀ x1 x2 : X , paths x1 x2 ] does not satisfy (definitionally) the condition [ t x x == idpath x ].
+The issue which arises here is the same one which arises in several other places in the work with quotients. It can be traced back first to the failure of [ invmaponpathsincl ] to map [ idpath ] to [ idpath ] and then to the fact that for [ ( X : UU ) ( is : isaprop X ) ] the term [ t := proofirrelevance is : Π x1 x2 : X , paths x1 x2 ] does not satisfy (definitionally) the condition [ t x x == idpath x ].
 
 It can and probably should be fixed by the addition of a new componenet to CIC in the form of a term constructor:
 
-tfc ( X : UU ) ( E : X -> UU ) ( is : ∀ x , iscontr ( E x ) ) ( x0 : X ) ( e0 : E x0 ) : ∀ x : X , E x .
+tfc ( X : UU ) ( E : X -> UU ) ( is : Π x , iscontr ( E x ) ) ( x0 : X ) ( e0 : E x0 ) : Π x : X , E x .
 
 and a computation rule
 
@@ -1229,9 +1229,9 @@ tfc_comp ( tfc X E is x0 e0 x0 ) == e0
 
 (with both tfc and tfc_comp definable in an arbitrary context)
 
-Such an extension will be compatible with the univalent models and should not, as far as I can see, provide any problems for normalization or for the decidability of typing. Using tfc one can give a construction of [ proofirrelevance ] as follows ( recall that [ isaprop := ∀ x1 x2 , iscontr ( paths x1 x2 ) ] ) :
+Such an extension will be compatible with the univalent models and should not, as far as I can see, provide any problems for normalization or for the decidability of typing. Using tfc one can give a construction of [ proofirrelevance ] as follows ( recall that [ isaprop := Π x1 x2 , iscontr ( paths x1 x2 ) ] ) :
 
-Lemma proofirrelevance { X : UU } ( is : isaprop X ) : ∀ x1 x2 , paths x1 x2 .
+Lemma proofirrelevance { X : UU } ( is : isaprop X ) : Π x1 x2 , paths x1 x2 .
 Proof . intros X is x1 . apply ( tfc X ( fun x2 => paths x1 x2 ) is x1 ( idpath x1 ) ) . Defined .
 
 Defined in this way [ proofirrelevance ] will have the required property and will enable to define [ invmaponpathsincl ] in such a way that the existing proofs of [ setquotl0 ] and [ fromsubquot ] and [ weqsubquot ] will provide the desired behavior of [ fromsubquot ] on terms of the form [ ( tpair _ ( setquotpr R x ) is ) ]. *)
@@ -1285,7 +1285,7 @@ Definition compfunpair { X : UU }  ( R : hrel X ) { S : UU } ( f : X -> S ) ( is
 Definition pr1compfun ( X : UU )  ( R : hrel X ) ( S : UU ) : @compfun X R S -> ( X -> S ) := @pr1 _ _ .
 Coercion pr1compfun : compfun >-> Funclass .
 
-Definition compevmapset { X : UU } ( R : hrel X ) : X -> ∀ S : hSet, ( compfun R S ) -> S := fun x : X => fun S : _ => fun f : compfun R S => pr1 f x.
+Definition compevmapset { X : UU } ( R : hrel X ) : X -> Π S : hSet, ( compfun R S ) -> S := fun x : X => fun S : _ => fun f : compfun R S => pr1 f x.
 
 Definition compfuncomp { X : UU }  ( R : hrel X ) { S S' : UU } ( f : compfun R S ) ( g : S -> S' ) : compfun R S' .
 Proof . intros . split with ( funcomp f g ) . intros x x' r .  apply ( maponpaths g ( pr2 f x x' r ) ) . Defined .
@@ -1302,9 +1302,9 @@ Proof . intros . intros x x' r . unfold Fi . apply funextfun .  intro f . apply 
 
 Definition Fv { X Y : UU } ( R : hrel X ) ( f : compfun R Y ) ( phi : F X Y R ) : Y := phi f .
 
-Definition qeq { X Y : UU } ( R : hrel X ) := total2 ( fun phi : F X Y R => ∀ psi : F X Y R -> Y  , paths ( psi phi ) ( Fv R ( compfuncomp R ( compfunpair R _ ( iscompFi R ) ) psi ) phi ) ) .
+Definition qeq { X Y : UU } ( R : hrel X ) := total2 ( fun phi : F X Y R => Π psi : F X Y R -> Y  , paths ( psi phi ) ( Fv R ( compfuncomp R ( compfunpair R _ ( iscompFi R ) ) psi ) phi ) ) .
 
-Lemma isinclpr1qeq { X : UU } ( R : hrel X ) ( Y : hSet ) : isincl ( @pr1 _ ( fun phi : F X Y R => ∀ psi : F X Y R -> Y  , paths ( psi phi ) ( Fv R ( compfuncomp R ( compfunpair R _ ( iscompFi R ) ) psi ) phi ) ) ) .
+Lemma isinclpr1qeq { X : UU } ( R : hrel X ) ( Y : hSet ) : isincl ( @pr1 _ ( fun phi : F X Y R => Π psi : F X Y R -> Y  , paths ( psi phi ) ( Fv R ( compfuncomp R ( compfunpair R _ ( iscompFi R ) ) psi ) phi ) ) ) .
 Proof . intros . apply isinclpr1 .  intro phi .  apply impred . intro psi .  apply ( pr2 Y ) . Defined.
 
 Definition toqeq { X Y : UU } ( R : hrel X ) ( x : X ) : @qeq X Y R .
@@ -1367,7 +1367,7 @@ Proof . intros . apply idpath . Defined .
 Lemma test ( X Y : UU ) ( phi : F X Y ) ( f : X -> Y ) : paths ( Fd1 phi ( Fi ( X -> Y ) Y f ) ) ( Fd2 phi ( Fi ( X -> Y ) Y f ) ) .
 Proof . intros . unfold Fd1 . unfold Fd2. unfold Fi . unfold Ffunct . unfold funcomp .    simpl .  apply ( maponpaths phi ) .  apply etacorrection . Defined .
 
-Inductive try0 ( T : UU ) ( t : T ) : ∀ ( t1 t2 : T ) ( e1 : paths t t1 ) ( e2 : paths t t2 ) , UU := idconstr : ∀ ( t' : T ) ( e' : paths t t' ) , try0 T t t' t' e' e' .
+Inductive try0 ( T : UU ) ( t : T ) : Π ( t1 t2 : T ) ( e1 : paths t t1 ) ( e2 : paths t t2 ) , UU := idconstr : Π ( t' : T ) ( e' : paths t t' ) , try0 T t t' t' e' e' .
 
 Definition try0map1 ( T : UU ) ( t : T ) ( t1 t2 : T ) ( e1 : paths t t1 ) ( e2 : paths t t2 ) ( X : try0 T t t1 t2 e1 e2 ) : paths t1 t2 .
 Proof . intros . destruct  X . apply idpath . Defined .
@@ -1400,7 +1400,7 @@ Definition setquot2 { X : UU } ( R : hrel X ) : UU := image  ( compevmapset R ) 
 
 Theorem isasetsetquot2 { X : UU } ( R : hrel X ) : isaset ( setquot2 R ) .
 Proof. intros.
-assert (is1: isofhlevel 2 ( ∀ S: hSet, (compfun R S) -> S )).  apply impred.  intro.  apply impred.  intro X0.  apply (pr2 t).
+assert (is1: isofhlevel 2 ( Π S: hSet, (compfun R S) -> S )).  apply impred.  intro.  apply impred.  intro X0.  apply (pr2 t).
 apply (isasetsubset _ is1 (isinclpr1image _ )).  Defined.
 
 Definition setquot2inset { X : UU } ( R : hrel X ) : hSet := hSetpair _ ( isasetsetquot2 R ) .

--- a/UniMath/Foundations/Basics/Tests.v
+++ b/UniMath/Foundations/Basics/Tests.v
@@ -2,16 +2,16 @@ Unset Automatic Introduction.
 Require Export UniMath.Foundations.Basics.PartD.
 
 Goal Σ (_:nat) (_:nat) (_:nat) (_:nat), nat. exact (2,,3,,4,,5,,6). Defined.
-Goal ∀ i j k, i+j+k = (i+j)+k. reflexivity. Defined.
-Goal ∀ n, 1+n = S n. reflexivity. Defined.
-Goal ∀ i j k, i*j*k = (i*j)*k. reflexivity. Defined.
-Goal ∀ n, 0*n = 0. reflexivity. Defined.
-Goal ∀ n, 0+n = n. reflexivity. Defined.
-Goal ∀ n, 0*n = 0. reflexivity. Defined.
-Goal ∀ n m, S n * m = n*m + m. reflexivity. Defined.
-Goal ∀ n, 1*n = n. reflexivity. Defined.
-Goal ∀ n, 4*n = n+n+n+n. reflexivity. Defined.
-Goal ∀ X x, idweq X x = x. reflexivity. Defined.
+Goal Π i j k, i+j+k = (i+j)+k. reflexivity. Defined.
+Goal Π n, 1+n = S n. reflexivity. Defined.
+Goal Π i j k, i*j*k = (i*j)*k. reflexivity. Defined.
+Goal Π n, 0*n = 0. reflexivity. Defined.
+Goal Π n, 0+n = n. reflexivity. Defined.
+Goal Π n, 0*n = 0. reflexivity. Defined.
+Goal Π n m, S n * m = n*m + m. reflexivity. Defined.
+Goal Π n, 1*n = n. reflexivity. Defined.
+Goal Π n, 4*n = n+n+n+n. reflexivity. Defined.
+Goal Π X x, idweq X x = x. reflexivity. Defined.
 
 Module Test_gradth.
   Let f := idfun nat.
@@ -27,7 +27,7 @@ Module Test_gradth.
   Goal homotweqinvweqweq v true = idpath _. reflexivity. Defined.
 End Test_gradth.
 
-Goal ∀ X x, invweq (idweq X) x = x. reflexivity. Defined.
+Goal Π X x, invweq (idweq X) x = x. reflexivity. Defined.
 
 Module Test_weqtotal2overcoprod.
   Let P (t : bool ⨿ bool) := nat.
@@ -69,11 +69,11 @@ Module Test_sets.
 
   Require Import UniMath.Foundations.Basics.Sets.
 
-  Goal ∀ Y (is:isaset Y) (F:Y->UU) (e :∀ y y', F y -> F y' -> y=y')
+  Goal Π Y (is:isaset Y) (F:Y->UU) (e :Π y y', F y -> F y' -> y=y')
          y (f:F y), squash_pairs_to_set F is e (hinhpr (y,,f)) = y.
   Proof. reflexivity. Qed.
 
-  Goal ∀ X Y (is:isaset Y) (f:X->Y) (e:∀ x x', f x = f x'),
+  Goal Π X Y (is:isaset Y) (f:X->Y) (e:Π x x', f x = f x'),
          f = funcomp hinhpr (squash_to_set is f e).
   Proof. reflexivity. Qed.
 

--- a/UniMath/Foundations/Basics/UnivalenceAxiom.v
+++ b/UniMath/Foundations/Basics/UnivalenceAxiom.v
@@ -17,7 +17,7 @@ Require Export UniMath.Foundations.Basics.PartD.
 
 (** ** Univalence axiom. *)
 
-Axiom univalenceaxiom :  forall T1 T2 : UU ,  isweq ( @eqweqmap T1 T2 ).
+Axiom univalenceaxiom :  Π T1 T2 : UU ,  isweq ( @eqweqmap T1 T2 ).
 
 Corollary univalence X Y : (X=Y) ≃ (X≃Y).
 Proof. intros. exact (weqpair _ (univalenceaxiom X Y)). Defined.
@@ -30,9 +30,9 @@ Definition weqpathsweq { T1 T2 : UU } ( w : weq T1 T2 ) : paths ( eqweqmap ( weq
 (** We show that [ univalenceaxiom ] is equivalent to the axioms [ weqtopaths0 ] and [ weqpathsweq0 ] stated below . *)
 
 
-Axiom weqtopaths0 : forall ( T1 T2 : UU ) ( w : weq T1 T2 ) , paths T1 T2.
+Axiom weqtopaths0 : Π ( T1 T2 : UU ) ( w : weq T1 T2 ) , paths T1 T2.
 
-Axiom weqpathsweq0 : forall ( T1 T2 : UU ) ( w : weq T1 T2 ) ,  paths ( eqweqmap ( weqtopaths0 _ _ w ) ) w.
+Axiom weqpathsweq0 : Π ( T1 T2 : UU ) ( w : weq T1 T2 ) ,  paths ( eqweqmap ( weqtopaths0 _ _ w ) ) w.
 
 Theorem univfromtwoaxioms ( T1 T2 : UU ) : isweq ( @eqweqmap T1 T2 ).
 Proof. intros. set ( P1 := fun XY : dirprod UU UU => pr1 XY = pr2 XY ) .
@@ -52,10 +52,10 @@ apply ( maponpaths ( fun w : weq ( pr1 XY) (pr2 XY) =>  tpair P2 XY w )
 
 set ( h := fun a1 : Z1 =>  pr1 ( pr1 a1 ) ) .
 
-assert ( egf0 : forall a1 : Z1 ,  paths ( pr1 ( g ( f a1 ) ) ) (  pr1 a1 ) ). intro.
+assert ( egf0 : Π a1 : Z1 ,  paths ( pr1 ( g ( f a1 ) ) ) (  pr1 a1 ) ). intro.
 apply  idpath.
 
-assert ( egf1 : forall a1 a1' : Z1 ,  paths ( pr1 a1' ) (  pr1 a1 ) ->  paths a1' a1 ). intros.
+assert ( egf1 : Π a1 a1' : Z1 ,  paths ( pr1 a1' ) (  pr1 a1 ) ->  paths a1' a1 ). intros.
 set ( X' :=  maponpaths ( @pr1 _ _ ) X ).
 assert ( is : isweq h ). simpl in h .  apply isweqpr1pr1 .
 apply ( invmaponpathsweq ( weqpair h is ) _ _ X' ).
@@ -87,11 +87,11 @@ Lemma isweqtransportb10 { X : UU } ( P : X -> UU ) { x x' : X } ( e :  paths x x
 Proof. intros. apply ( isweqtransportf10 _ ( pathsinv0 e ) ). Defined.
 
 
-Lemma l1  { X0 X0' : UU } ( ee : paths X0 X0' ) ( P : UU -> UU ) ( pp' : P X0' ) ( R : forall X X' : UU , forall w : weq X X' , P X' -> P X ) ( r : forall X : UU , forall p : P X , paths ( R X X ( idweq X ) p ) p ) : paths ( R X0 X0' ( eqweqmap ee ) pp' ) (  transportb P ee pp' ).
+Lemma l1  { X0 X0' : UU } ( ee : paths X0 X0' ) ( P : UU -> UU ) ( pp' : P X0' ) ( R : Π X X' : UU , Π w : weq X X' , P X' -> P X ) ( r : Π X : UU , Π p : P X , paths ( R X X ( idweq X ) p ) p ) : paths ( R X0 X0' ( eqweqmap ee ) pp' ) (  transportb P ee pp' ).
 Proof. intro. intro. intro. intro. intro. destruct ee. simpl. intro. intro. apply r. Defined.
 
 
-Theorem weqtransportb ( P : UU -> UU ) ( R : forall ( X X' : UU ) ( w :  weq X X' ) , P X' -> P X ) ( r : forall X : UU , forall p : P X , paths ( R X X ( idweq X ) p ) p ) :  forall ( X X' : UU ) ( w :  weq X X' ) ( p' : P X' ) , paths ( R X X' w p' ) (  transportb P ( weqtopaths w ) p' ).
+Theorem weqtransportb ( P : UU -> UU ) ( R : Π ( X X' : UU ) ( w :  weq X X' ) , P X' -> P X ) ( r : Π X : UU , Π p : P X , paths ( R X X ( idweq X ) p ) p ) :  Π ( X X' : UU ) ( w :  weq X X' ) ( p' : P X' ) , paths ( R X X' w p' ) (  transportb P ( weqtopaths w ) p' ).
 Proof. intros. set ( uv := weqtopaths w ).   set ( v := eqweqmap uv ).
 
 assert ( e : paths v w ) . unfold weqtopaths in uv.  apply ( homotweqinvweq ( weqpair _ ( univalenceaxiom X X' ) ) w ).
@@ -102,8 +102,8 @@ destruct ee. apply l1. assumption. Defined.
 
 
 
-Corollary isweqweqtransportb ( P : UU -> UU ) ( R :  forall ( X X' : UU ) ( w :  weq X X' ) , P X' -> P X ) ( r :  forall X : UU , forall p : P X , paths ( R X X ( idweq X ) p ) p ) :  forall ( X X' : UU ) ( w :  weq X X' ) , isweq ( fun p' :  P X' => R X X' w p' ).
-Proof. intros. assert ( e : forall p' : P X' , paths ( R X X' w p' ) (  transportb P ( weqtopaths w ) p' ) ). apply weqtransportb. assumption. assert ( ee : forall p' : P X' , paths  ( transportb P ( weqtopaths w ) p' ) ( R X X' w p' ) ). intro.  apply ( pathsinv0 ( e p' ) ). clear e.
+Corollary isweqweqtransportb ( P : UU -> UU ) ( R :  Π ( X X' : UU ) ( w :  weq X X' ) , P X' -> P X ) ( r :  Π X : UU , Π p : P X , paths ( R X X ( idweq X ) p ) p ) :  Π ( X X' : UU ) ( w :  weq X X' ) , isweq ( fun p' :  P X' => R X X' w p' ).
+Proof. intros. assert ( e : Π p' : P X' , paths ( R X X' w p' ) (  transportb P ( weqtopaths w ) p' ) ). apply weqtransportb. assumption. assert ( ee : Π p' : P X' , paths  ( transportb P ( weqtopaths w ) p' ) ( R X X' w p' ) ). intro.  apply ( pathsinv0 ( e p' ) ). clear e.
 
 assert ( is1 : isweq ( transportb P ( weqtopaths w ) ) ). apply isweqtransportb10.
 apply ( isweqhomot ( transportb P ( weqtopaths w ) ) ( fun p'  :  P X' => R X X' w p' ) ee is1 ).  Defined.
@@ -138,7 +138,7 @@ Lemma apathpr1topr ( T : UU ) : paths ( fun z :  pathsspace T => pr1 z ) ( fun z
 Proof. intro. apply ( eqcor0  ( weqpair _ ( isweqdeltap T ) ) _ ( fun z :  pathsspace T => pr1 z ) ( fun z :  pathsspace T => pr1 ( pr2 z ) ) ( idpath ( idfun T ) ) ) . Defined.
 
 
-Theorem funextfun { X Y : UU } ( f1 f2 : X -> Y ) ( e :  forall x : X , paths ( f1 x ) ( f2 x ) ) : paths f1 f2.
+Theorem funextfun { X Y : UU } ( f1 f2 : X -> Y ) ( e :  Π x : X , paths ( f1 x ) ( f2 x ) ) : paths f1 f2.
 Proof. intros. set ( f := fun x : X => pathsspacetriple Y ( e x ) ) .  set ( g1 := fun z : pathsspace Y => pr1 z ) . set ( g2 := fun z :  pathsspace Y => pr1 ( pr2 z ) ). assert ( e' : paths g1 g2 ). apply ( apathpr1topr Y ). assert ( ee : paths  ( fun x : X => f1 x ) ( fun x : X => f2 x ) ). change ( paths (fun x : X => g1 ( f x ) ) (fun x : X => g2 ( f x ) ) ) . destruct e' .  apply idpath .   apply etacoronpaths. apply ee . Defined.
 
 (* End of the file funextfun.v *)

--- a/UniMath/Foundations/Combinatorics/FiniteSequences.v
+++ b/UniMath/Foundations/Combinatorics/FiniteSequences.v
@@ -19,7 +19,7 @@ Definition transport_stn m n i (b:i<m) (p:m=n) :
 Proof. intros. induction p. reflexivity. Defined.
 
 Definition sequenceEquality {X m n} (f:stn m->X) (g:stn n->X) (p:m=n) :
-  (∀ i, f i = g (transportf stn p i))
+  (Π i, f i = g (transportf stn p i))
   -> transportf (λ m, stn m->X) p f = g.
 Proof. intros ? ? ? ? ? ? e. induction p. apply funextfun. exact e. Defined.
 
@@ -97,7 +97,7 @@ Defined.
 
 (* Three ways.  Use induction: *)
 
-Definition iscontr_rect' X (i : iscontr X) (x0 : X) (P : X ->UU) (p0 : P x0) : ∀ x:X, P x.
+Definition iscontr_rect' X (i : iscontr X) (x0 : X) (P : X ->UU) (p0 : P x0) : Π x:X, P x.
 Proof. intros. induction (pr1 (isapropifcontr i x0 x)). exact p0. Defined.
 
 Definition iscontr_rect_compute' X (i : iscontr X) (x : X) (P : X ->UU) (p : P x) :
@@ -112,7 +112,7 @@ Defined.
 
 (* ... or use weqsecovercontr, but specializing x to pr1 i: *)
 
-Definition iscontr_rect'' X (i : iscontr X) (P : X ->UU) (p0 : P (pr1 i)) : ∀ x:X, P x.
+Definition iscontr_rect'' X (i : iscontr X) (P : X ->UU) (p0 : P (pr1 i)) : Π x:X, P x.
 Proof. intros. exact (invmap (weqsecovercontr P i) p0 x). Defined.
 
 Definition iscontr_rect_compute'' X (i : iscontr X) (P : X ->UU) (p : P(pr1 i)) :
@@ -127,7 +127,7 @@ Definition iscontr_adjointness X (is:iscontr X) (x:X) : pr1 (isapropifcontr is x
    the weq [unit ≃ X] would give it to us, in the case where x is [pr1 is] *)
 Proof. intros. now apply isasetifcontr. Defined.
 
-Definition iscontr_rect X (is : iscontr X) (x0 : X) (P : X ->UU) (p0 : P x0) : ∀ x:X, P x.
+Definition iscontr_rect X (is : iscontr X) (x0 : X) (P : X ->UU) (p0 : P x0) : Π x:X, P x.
 Proof. intros. exact (transportf P (pr1 (isapropifcontr is x0 x)) p0). Defined.
 
 Definition iscontr_rect_compute X (is : iscontr X) (x : X) (P : X ->UU) (p : P x) :
@@ -135,11 +135,11 @@ Definition iscontr_rect_compute X (is : iscontr X) (x : X) (P : X ->UU) (p : P x
 Proof. intros. unfold iscontr_rect. now rewrite iscontr_adjointness. Defined.
 
 Corollary weqsecovercontr':     (* reprove weqsecovercontr, move upstream *)
-  ∀ (X:UU) (P:X->UU) (is:iscontr X), (∀ x:X, P x) ≃ P (pr1 is).
+  Π (X:UU) (P:X->UU) (is:iscontr X), (Π x:X, P x) ≃ P (pr1 is).
 Proof.
   intros.
   set (x0 := pr1 is).
-  set (secs := ∀ x : X, P x).
+  set (secs := Π x : X, P x).
   set (fib  := P x0).
   set (destr := (λ f, f x0) : secs->fib).
   set (constr:= iscontr_rect X is x0 P : fib->secs).
@@ -243,7 +243,7 @@ Defined.
 
 Definition Sequence_rect {X} {P : Sequence X ->UU}
            (p0 : P nil)
-           (ind : ∀ (x : Sequence X) (y : X), P x -> P (append x y))
+           (ind : Π (x : Sequence X) (y : X), P x -> P (append x y))
            (x : Sequence X) : P x.
 Proof. intros. induction x as [n x]. induction n as [|n IH].
   - exact (transportf P (nil_unique x) p0).
@@ -254,7 +254,7 @@ Proof. intros. induction x as [n x]. induction n as [|n IH].
 Defined.
 
 Lemma Sequence_rect_compute_nil {X} {P : Sequence X ->UU} (p0 : P nil)
-      (ind : ∀ (s : Sequence X) (x : X), P s -> P (append s x)) :
+      (ind : Π (s : Sequence X) (x : X), P s -> P (append s x)) :
   Sequence_rect p0 ind nil = p0.
 Proof.
   intros.
@@ -267,7 +267,7 @@ Defined.
 
 Lemma Sequence_rect_compute_cons
       {X} {P : Sequence X ->UU} (p0 : P nil)
-      (ind : ∀ (s : Sequence X) (x : X), P s -> P (append s x))
+      (ind : Π (s : Sequence X) (x : X), P s -> P (append s x))
       (x:X) (l:Sequence X) :
   Sequence_rect p0 ind (append l x) = ind l x (Sequence_rect p0 ind l).
 Proof.

--- a/UniMath/Foundations/Combinatorics/FiniteSets.v
+++ b/UniMath/Foundations/Combinatorics/FiniteSets.v
@@ -56,7 +56,7 @@ Defined.
 
 Definition nelstructoncoprod { X  Y : UU } { n m : nat } ( sx : nelstruct n X ) ( sy : nelstruct m Y ) : nelstruct ( n + m ) ( coprod X Y ) := weqcomp ( invweq ( weqfromcoprodofstn n m ) ) ( weqcoprodf sx sy ) .
 
-Definition nelstructontotal2 { X : UU } ( P : X -> UU ) ( f : X -> nat ) { n : nat } ( sx : nelstruct n X ) ( fs : forall x : X , nelstruct ( f x ) ( P x ) ) : nelstruct ( stnsum ( funcomp ( pr1 sx ) f ) ) ( total2 P )  := weqcomp ( invweq ( weqstnsum ( funcomp ( pr1 sx ) P ) ( funcomp ( pr1 sx ) f ) ( fun i : stn n => fs ( ( pr1 sx ) i ) ) ) )  ( weqfp sx P )  .
+Definition nelstructontotal2 { X : UU } ( P : X -> UU ) ( f : X -> nat ) { n : nat } ( sx : nelstruct n X ) ( fs : Π x : X , nelstruct ( f x ) ( P x ) ) : nelstruct ( stnsum ( funcomp ( pr1 sx ) f ) ) ( total2 P )  := weqcomp ( invweq ( weqstnsum ( funcomp ( pr1 sx ) P ) ( funcomp ( pr1 sx ) f ) ( fun i : stn n => fs ( ( pr1 sx ) i ) ) ) )  ( weqfp sx P )  .
 
 Definition nelstructondirprod { X Y : UU } { n m : nat } ( sx : nelstruct n X ) ( sy : nelstruct m Y ) : nelstruct ( n * m ) ( dirprod X Y ) := weqcomp ( invweq ( weqfromprodofstn n m ) ) ( weqdirprodf sx sy ) .
 
@@ -64,7 +64,7 @@ Definition nelstructondirprod { X Y : UU } { n m : nat } ( sx : nelstruct n X ) 
 
 Definition nelstructonfun { X Y : UU } { n m : nat } ( sx : nelstruct n X ) ( sy : nelstruct m Y ) : nelstruct ( natpower m n ) ( X -> Y ) := weqcomp ( invweq ( weqfromfunstntostn n m ) ) ( weqcomp ( weqbfun _ ( invweq sx ) ) ( weqffun _ sy ) )  .
 
-Definition nelstructonforall { X : UU } ( P : X -> UU ) ( f : X -> nat ) { n : nat } ( sx : nelstruct n X ) ( fs : forall x : X , nelstruct ( f x ) ( P x ) ) : nelstruct ( stnprod ( funcomp ( pr1 sx ) f ) ) ( forall x : X , P x )  := invweq ( weqcomp ( weqonsecbase P sx ) ( weqstnprod ( funcomp ( pr1 sx ) P ) ( funcomp ( pr1 sx ) f ) ( fun i : stn n => fs ( ( pr1 sx ) i ) ) ) )  .
+Definition nelstructonforall { X : UU } ( P : X -> UU ) ( f : X -> nat ) { n : nat } ( sx : nelstruct n X ) ( fs : Π x : X , nelstruct ( f x ) ( P x ) ) : nelstruct ( stnprod ( funcomp ( pr1 sx ) f ) ) ( Π x : X , P x )  := invweq ( weqcomp ( weqonsecbase P sx ) ( weqstnprod ( funcomp ( pr1 sx ) P ) ( funcomp ( pr1 sx ) f ) ( fun i : stn n => fs ( ( pr1 sx ) i ) ) ) )  .
 
 Definition nelstructonweq { X : UU } { n : nat } ( sx : nelstruct n X ) : nelstruct ( factorial n ) ( weq X X ) := weqcomp ( invweq ( weqfromweqstntostn n ) ) ( weqcomp ( weqbweq _ ( invweq sx ) ) ( weqfweq _ sx ) ) .
 
@@ -145,7 +145,7 @@ Proof . intros . unfold finstruct .  unfold finstruct in sx . destruct sx as [ n
 
 Definition finstructoncoprod { X  Y : UU } ( sx : finstruct X ) ( sy : finstruct Y ) : finstruct ( coprod X Y ) := tpair _ ( ( pr1 sx ) + ( pr1 sy ) ) ( nelstructoncoprod ( pr2 sx ) ( pr2 sy ) ) .
 
-Definition finstructontotal2 { X : UU } ( P : X -> UU )   ( sx : finstruct X ) ( fs : forall x : X , finstruct ( P x ) ) : finstruct ( total2 P ) := tpair _ ( stnsum ( funcomp ( pr1 ( pr2 sx ) ) ( fun x : X =>  pr1 ( fs x ) ) ) ) ( nelstructontotal2 P ( fun x : X => pr1 ( fs x ) ) ( pr2 sx ) ( fun x : X => pr2 ( fs x ) ) ) .
+Definition finstructontotal2 { X : UU } ( P : X -> UU )   ( sx : finstruct X ) ( fs : Π x : X , finstruct ( P x ) ) : finstruct ( total2 P ) := tpair _ ( stnsum ( funcomp ( pr1 ( pr2 sx ) ) ( fun x : X =>  pr1 ( fs x ) ) ) ) ( nelstructontotal2 P ( fun x : X => pr1 ( fs x ) ) ( pr2 sx ) ( fun x : X => pr2 ( fs x ) ) ) .
 
 Definition finstructondirprod { X Y : UU } ( sx : finstruct X ) ( sy : finstruct Y ) : finstruct ( dirprod X Y ) := tpair _ ( ( pr1 sx ) * ( pr1 sy ) ) ( nelstructondirprod ( pr2 sx ) ( pr2 sy ) ) .
 
@@ -154,7 +154,7 @@ Definition finstructondecsubset { X : UU }  ( f : X -> bool ) ( sx : finstruct X
 
 Definition finstructonfun { X Y : UU } ( sx : finstruct X ) ( sy : finstruct Y ) : finstruct ( X -> Y ) := tpair _ ( natpower ( pr1 sy ) ( pr1 sx ) ) ( nelstructonfun ( pr2 sx ) ( pr2 sy ) ) .
 
-Definition finstructonforall { X : UU } ( P : X -> UU )  ( sx : finstruct X ) ( fs : forall x : X , finstruct ( P x ) ) : finstruct ( forall x : X , P x )  := tpair _ ( stnprod ( funcomp ( pr1 ( pr2 sx ) ) ( fun x : X =>  pr1 ( fs x ) ) ) ) ( nelstructonforall P ( fun x : X => pr1 ( fs x ) ) ( pr2 sx ) ( fun x : X => pr2 ( fs x ) ) ) .
+Definition finstructonforall { X : UU } ( P : X -> UU )  ( sx : finstruct X ) ( fs : Π x : X , finstruct ( P x ) ) : finstruct ( Π x : X , P x )  := tpair _ ( stnprod ( funcomp ( pr1 ( pr2 sx ) ) ( fun x : X =>  pr1 ( fs x ) ) ) ) ( nelstructonforall P ( fun x : X => pr1 ( fs x ) ) ( pr2 sx ) ( fun x : X => pr2 ( fs x ) ) ) .
 
 Definition finstructonweq { X : UU }  ( sx : finstruct X ) : finstruct ( weq X X ) := tpair _ ( factorial ( pr1 sx ) ) ( nelstructonweq ( pr2 sx ) ) .
 
@@ -223,8 +223,8 @@ Definition isfinitecompl { X : UU } ( x : X ) ( sx : isfinite X ) : isfinite ( c
 
 Definition isfinitecoprod { X  Y : UU } ( sx : isfinite X ) ( sy : isfinite Y ) : isfinite ( coprod X Y ) := hinhfun2 ( fun sx0 : _ => fun sy0 : _ => finstructoncoprod sx0 sy0 ) sx sy .
 
-Definition isfinitetotal2 { X : UU } ( P : X -> UU ) ( sx : isfinite X ) ( fs : forall x : X , isfinite ( P x ) ) : isfinite ( total2 P ) .
-Proof . intros . set ( fs' := ischoicebasefiniteset sx _ fs ) .  apply ( hinhfun2 ( fun fx0 : forall x : X , finstruct ( P x )  => fun sx0 : _ => finstructontotal2 P sx0 fx0 ) fs' sx ) .  Defined .
+Definition isfinitetotal2 { X : UU } ( P : X -> UU ) ( sx : isfinite X ) ( fs : Π x : X , isfinite ( P x ) ) : isfinite ( total2 P ) .
+Proof . intros . set ( fs' := ischoicebasefiniteset sx _ fs ) .  apply ( hinhfun2 ( fun fx0 : Π x : X , finstruct ( P x )  => fun sx0 : _ => finstructontotal2 P sx0 fx0 ) fs' sx ) .  Defined .
 
 Definition isfinitedirprod { X Y : UU } ( sx : isfinite X ) ( sy : isfinite Y ) : isfinite ( dirprod X Y ) := hinhfun2 ( fun sx0 : _ => fun sy0 : _ => finstructondirprod sx0 sy0 ) sx sy .
 
@@ -232,8 +232,8 @@ Definition isfinitedecsubset { X : UU } ( f : X -> bool ) ( sx : isfinite X ) : 
 
 Definition isfinitefun { X Y : UU } ( sx : isfinite X ) ( sy : isfinite Y ) : isfinite ( X -> Y ) := hinhfun2 ( fun sx0 : _ => fun sy0 : _ => finstructonfun sx0 sy0 ) sx sy .
 
-Definition isfiniteforall { X : UU } ( P : X -> UU ) ( sx : isfinite X ) ( fs : forall x : X , isfinite ( P x ) ) : isfinite ( forall x : X , P x ) .
-Proof . intros . set ( fs' := ischoicebasefiniteset sx _ fs ) .  apply ( hinhfun2 ( fun fx0 : forall x : X , finstruct ( P x )  => fun sx0 : _ => finstructonforall P sx0 fx0 ) fs' sx ) .  Defined .
+Definition isfiniteforall { X : UU } ( P : X -> UU ) ( sx : isfinite X ) ( fs : Π x : X , isfinite ( P x ) ) : isfinite ( Π x : X , P x ) .
+Proof . intros . set ( fs' := ischoicebasefiniteset sx _ fs ) .  apply ( hinhfun2 ( fun fx0 : Π x : X , finstruct ( P x )  => fun sx0 : _ => finstructonforall P sx0 fx0 ) fs' sx ) .  Defined .
 
 Definition isfiniteweq { X : UU } ( sx : isfinite X ) : isfinite ( weq X X ) := hinhfun ( fun sx0 : _ =>  finstructonweq sx0 ) sx .
 

--- a/UniMath/Foundations/Combinatorics/OrderedSets.v
+++ b/UniMath/Foundations/Combinatorics/OrderedSets.v
@@ -33,7 +33,7 @@ Definition tallyStandardSubset {n} (P: DecidableSubtype (stn n)) : stn (S n).
 Proof. intros. exists (stnsum (λ x, choice (P x) 1 0)). apply natlehtolthsn.
        apply (istransnatleh (m := stnsum(λ _ : stn n, 1))).
        { apply stnsum_le; intro i. apply bound01. }
-       assert ( p : ∀ r s, r = s -> (r ≤ s)%nat). { intros ? ? e. destruct e. apply isreflnatleh. }
+       assert ( p : Π r s, r = s -> (r ≤ s)%nat). { intros ? ? e. destruct e. apply isreflnatleh. }
        apply p. apply stnsum_1.
 Defined.
 
@@ -51,7 +51,7 @@ Defined.
 (* types and univalence *)
 
 Theorem UU_rect (X Y : UU) (P : X ≃ Y -> UU) :
-  (∀ e : X=Y, P (univalence _ _ e)) -> ∀ f, P f.
+  (Π e : X=Y, P (univalence _ _ e)) -> Π f, P f.
 Proof.
   intros ? ? ? ih ?.
   set (p := ih (invmap (univalence _ _) f)).
@@ -62,7 +62,7 @@ Defined.
 Ltac type_induction f e := generalize f; apply UU_rect; intro e; clear f.
 
 Theorem hSet_rect (X Y : hSet) (P : X ≃ Y -> UU) :
-  (∀ e : X=Y, P (hSet_univalence _ _ e)) -> ∀ f, P f.
+  (Π e : X=Y, P (hSet_univalence _ _ e)) -> Π f, P f.
 Proof.
   intros ? ? ? ih ?.
   Set Printing Coercions.
@@ -152,14 +152,14 @@ Proof. reflexivity. Defined.
                   pathToEq : (X=Y) -> PosetEquivalence X Y.
 
     PosetEquivalence_rect
-         : ∀ (X Y : Poset) (P : PosetEquivalence X Y -> Type),
-           (∀ e : X = Y, P (pathToEq X Y e)) ->
-           ∀ p : PosetEquivalence X Y, P p
+         : Π (X Y : Poset) (P : PosetEquivalence X Y -> Type),
+           (Π e : X = Y, P (pathToEq X Y e)) ->
+           Π p : PosetEquivalence X Y, P p
 
 *)
 
 Theorem PosetEquivalence_rect (X Y : Poset) (P : X ≅ Y -> UU) :
-  (∀ e : X = Y, P (Poset_univalence_map e)) -> ∀ f, P f.
+  (Π e : X = Y, P (Poset_univalence_map e)) -> Π f, P f.
 Proof.
   intros ? ? ? ih ?.
   set (p := ih (invmap (Poset_univalence _ _) f)).
@@ -246,7 +246,7 @@ Proof. intros ? i ? ?. apply isdeceq_isdec_ordering. now apply isfinite_isdeceq.
 Defined.
 
 Corollary isdeceq_isdec_lessthan (X:OrderedSet) :
-  isdeceq X -> ∀ (x y:X), decidable (x < y).
+  isdeceq X -> Π (x y:X), decidable (x < y).
 Proof.
   intros ? i ? ?. apply decidable_dirprod.
   - now apply isdeceq_isdec_ordering.
@@ -256,7 +256,7 @@ Proof.
     * apply i.
 Defined.
 
-Corollary isfinite_isdec_lessthan (X:OrderedSet) : isfinite X -> ∀ (x y:X), decidable (x < y).
+Corollary isfinite_isdec_lessthan (X:OrderedSet) : isfinite X -> Π (x y:X), decidable (x < y).
 Proof. intros ? i ? ?. apply isdeceq_isdec_lessthan. now apply isfinite_isdeceq.
 Defined.
 
@@ -278,7 +278,7 @@ Proof. intros. exact ((Poset_univalence _ _) ∘ (underlyingPoset_weq _ _))%weq.
 Defined.
 
 Theorem OrderedSetEquivalence_rect (X Y : OrderedSet) (P : X ≅ Y -> UU) :
-  (∀ e : X = Y, P (OrderedSet_univalence _ _ e)) -> ∀ f, P f.
+  (Π e : X = Y, P (OrderedSet_univalence _ _ e)) -> Π f, P f.
 Proof.
   intros ? ? ? ih ?.
   set (p := ih (invmap (OrderedSet_univalence _ _) f)).
@@ -399,21 +399,21 @@ Close Scope foset.
 
 Definition lexicographicOrder
            (X:hSet) (Y:X->hSet)
-           (R:hrel X) (S : ∀ x, hrel (Y x)) : hrel (Σ x, Y x)%set.
+           (R:hrel X) (S : Π x, hrel (Y x)) : hrel (Σ x, Y x)%set.
   intros ? ? ? ? u u'.
   set (x := pr1 u). set (y := pr2 u). set (x' := pr1 u'). set (y' := pr2 u').
   exact ((x != x' ∧ R x x') ∨ (∃ e : x = x', S x' (transportf Y e y) y'))%set.
 Defined.
 
-Lemma lex_isrefl (X:hSet) (Y:X->hSet) (R:hrel X) (S : ∀ x, hrel (Y x)) :
-  (∀ x, isrefl(S x)) -> isrefl (lexicographicOrder X Y R S).
+Lemma lex_isrefl (X:hSet) (Y:X->hSet) (R:hrel X) (S : Π x, hrel (Y x)) :
+  (Π x, isrefl(S x)) -> isrefl (lexicographicOrder X Y R S).
 Proof.
   intros ? ? ? ? Srefl u. induction u as [x y]. apply hdisj_in2; simpl.
   apply hinhpr. exists (idpath x). apply Srefl.
 Defined.
 
-Lemma lex_istrans (X:hSet) (Y:X->hSet) (R:hrel X) (S : ∀ x, hrel (Y x)) :
-  isantisymm R -> istrans R -> (∀ x, istrans(S x)) -> istrans (lexicographicOrder X Y R S).
+Lemma lex_istrans (X:hSet) (Y:X->hSet) (R:hrel X) (S : Π x, hrel (Y x)) :
+  isantisymm R -> istrans R -> (Π x, istrans(S x)) -> istrans (lexicographicOrder X Y R S).
 Proof.
   intros ? ? ? ? Ranti Rtrans Strans u u' u'' p q.
   induction u as [x y]. induction u' as [x' y']. induction u'' as [x'' y''].
@@ -450,8 +450,8 @@ Defined.
 Local Ltac unwrap a := apply (squash_to_prop a);
     [ apply isaset_total2_hSet | simpl; clear a; intro a; simpl in a ].
 
-Lemma lex_isantisymm (X:hSet) (Y:X->hSet) (R:hrel X) (S : ∀ x, hrel (Y x)) :
-  isantisymm R -> (∀ x, isantisymm(S x)) -> isantisymm (lexicographicOrder X Y R S).
+Lemma lex_isantisymm (X:hSet) (Y:X->hSet) (R:hrel X) (S : Π x, hrel (Y x)) :
+  isantisymm R -> (Π x, isantisymm(S x)) -> isantisymm (lexicographicOrder X Y R S).
 Proof.
   intros ? ? ? ? Ranti Santi u u' a b.
   induction u as [x y]; induction u' as [x' y'].
@@ -467,8 +467,8 @@ Proof.
     { apply (Santi x' y y' s s'). }
     induction t. reflexivity. Defined.
 
-Lemma lex_istotal (X:hSet) (Y:X->hSet) (R:hrel X) (S : ∀ x, hrel (Y x)) :
-  isdeceq X -> istotal R -> (∀ x, istotal(S x)) -> istotal (lexicographicOrder X Y R S).
+Lemma lex_istotal (X:hSet) (Y:X->hSet) (R:hrel X) (S : Π x, hrel (Y x)) :
+  isdeceq X -> istotal R -> (Π x, istotal(S x)) -> istotal (lexicographicOrder X Y R S).
 Proof.
   intros ? ? ? ? Xdec Rtot Stot u u'. induction u as [x y]. induction u' as [x' y'].
   induction (Xdec x x') as [eq|ne].
@@ -571,16 +571,16 @@ Open Scope logic.
 
 Definition isLattice {X:hSet} (le:hrel X) (min max:binop X) :=
   Σ po : isPartialOrder le,
-  Σ lub : ∀ x y z, le x z ∧ le y z <-> le (max x y) z,
-  Σ glb : ∀ x y t, le t x ∧ le t y <-> le t (min x y),
+  Σ lub : Π x y z, le x z ∧ le y z <-> le (max x y) z,
+  Σ glb : Π x y t, le t x ∧ le t y <-> le t (min x y),
   unit.
 
 Definition istrans2 {X:hSet} (le lt:hrel X) :=
-  Σ transltle: ∀ x y z, lt x y -> le y z -> lt x z,
-  Σ translelt: ∀ x y z, le x y -> lt y z -> lt x z,
+  Σ transltle: Π x y z, lt x y -> le y z -> lt x z,
+  Σ translelt: Π x y z, le x y -> lt y z -> lt x z,
   unit.
 
-Definition iswklin {X} (lt:hrel X) := ∀ x y z, lt x y -> lt x z ∨ lt z y.
+Definition iswklin {X} (lt:hrel X) := Π x y z, lt x y -> lt x z ∨ lt z y.
 
 Definition isComputablyOrdered {X:hSet}
            (lt:hrel X) (min max:binop X) :=

--- a/UniMath/Foundations/Combinatorics/StandardFiniteSets.v
+++ b/UniMath/Foundations/Combinatorics/StandardFiniteSets.v
@@ -251,7 +251,7 @@ Definition weqdnicompl n (i:stn(S n)): stn n ≃ stn_compl i.
 Proof.
   intros.
   set (w := weqdicompl (stntonat _ i)).
-  assert (eq : ∀ j, j < n <-> pr1 (w j) < S n).
+  assert (eq : Π j, j < n <-> pr1 (w j) < S n).
   { simpl in w. intros j. unfold w.
     change (pr1 ((weqdicompl i) j)) with (di (stntonat _ i) j).
     unfold di.
@@ -386,8 +386,8 @@ Proof. intros . apply ( isinclbetweensets f ( isasetstn 1 ) is ) . intros x x' e
 
 Definition weqstn2tobool : weq ( stn 2 ) bool .
 Proof. set ( f := fun j : stn 2 => match ( isdeceqnat j 0 ) with ii1 _ => false | ii2 _ => true end ) . set ( g := fun b : bool => match b with false => stnpair 2 0 ( idpath true ) | true => stnpair 2 1 ( idpath true ) end ) .  split with f .
-assert ( egf : forall j : _ , paths ( g ( f j ) ) j ) . intro j . unfold f .  destruct ( isdeceqnat j 0 ) as [ e | ne ] .  apply ( invmaponpathsincl _ ( isinclstntonat 2 ) ) . rewrite e .   apply idpath .  apply ( invmaponpathsincl _ ( isinclstntonat 2 ) ) . destruct j as [ j l ] . simpl . set ( l' := natlthtolehsn _ _ l ) .  destruct ( natlehchoice _ _ l' ) as [ l'' | e ] . simpl in ne . destruct  ( ne ( natlth1tois0 _ l'' ) ) .  apply ( pathsinv0 ( invmaponpathsS _ _ e ) ) .
-assert ( efg : forall b : _ , paths ( f ( g b ) ) b ) . intro b .  unfold g .  destruct b . apply idpath . apply idpath.
+assert ( egf : Π j : _ , paths ( g ( f j ) ) j ) . intro j . unfold f .  destruct ( isdeceqnat j 0 ) as [ e | ne ] .  apply ( invmaponpathsincl _ ( isinclstntonat 2 ) ) . rewrite e .   apply idpath .  apply ( invmaponpathsincl _ ( isinclstntonat 2 ) ) . destruct j as [ j l ] . simpl . set ( l' := natlthtolehsn _ _ l ) .  destruct ( natlehchoice _ _ l' ) as [ l'' | e ] . simpl in ne . destruct  ( ne ( natlth1tois0 _ l'' ) ) .  apply ( pathsinv0 ( invmaponpathsS _ _ e ) ) .
+assert ( efg : Π b : _ , paths ( f ( g b ) ) b ) . intro b .  unfold g .  destruct b . apply idpath . apply idpath.
 apply ( gradth _ _ egf efg ) . Defined .
 
 
@@ -400,8 +400,8 @@ apply ( gradth _ _ egf efg ) . Defined .
 Theorem weqfromcoprodofstn ( n m : nat ) : weq ( coprod ( stn n ) ( stn m ) ) ( stn ( n + m ) ) .
 Proof. intros .
 
-assert ( i1 : forall i : nat , natlth i n -> natlth i ( n + m ) ) . intros i1 l . apply ( natlthlehtrans _ _ _ l ( natlehnplusnm n m ) ) .
-assert ( i2 : forall i : nat , natlth i m -> natlth ( n + i ) ( n + m ) ) .  intros i2 l .  apply natgthandplusl . assumption .
+assert ( i1 : Π i : nat , natlth i n -> natlth i ( n + m ) ) . intros i1 l . apply ( natlthlehtrans _ _ _ l ( natlehnplusnm n m ) ) .
+assert ( i2 : Π i : nat , natlth i m -> natlth ( n + i ) ( n + m ) ) .  intros i2 l .  apply natgthandplusl . assumption .
 set ( f := fun ab : coprod ( stn n ) ( stn m ) => match ab with ii1 a =>  stnpair ( n + m ) a ( i1 a ( pr2 a ) ) | ii2 b => stnpair ( n + m ) ( n + b ) ( i2 b ( pr2 b ) ) end ) .
 split with f .
 
@@ -465,7 +465,7 @@ Lemma transport_stnsum {m n} (e:m=n) (g:stn n->nat) :
   stnsum g = stnsum (λ i, g(transportf stn e i)).
 Proof. intros. induction e. reflexivity. Defined.
 
-Lemma stnsum_le {n} (f g:stn n->nat) : (∀ i, f i ≤ g i) -> stnsum f ≤ stnsum g.
+Lemma stnsum_le {n} (f g:stn n->nat) : (Π i, f i ≤ g i) -> stnsum f ≤ stnsum g.
 Proof.
   intros ? ? ? le. induction n as [|n IH]. { simpl. reflexivity. }
   apply natlehandplus. { apply IH. intro i. apply le. } apply le.
@@ -633,7 +633,7 @@ Proof.
 Defined.
 
 Theorem weqstnsum { n : nat } (P : stn n -> UU) (f : stn n -> nat) :
-  (∀ i, stn (f i) ≃ P i) -> total2 P ≃ stn (stnsum f).
+  (Π i, stn (f i) ≃ P i) -> total2 P ≃ stn (stnsum f).
 Proof.
   intros ? ? ? w.
   intermediate_weq (Σ i, stn (f i)).
@@ -641,7 +641,7 @@ Proof.
   - apply weqstnsum1.
 Defined.
 
-Corollary weqstnsum2 { X : UU } ( n : nat ) ( f : stn n -> nat ) ( g : X -> stn n ) ( ww : forall i : stn n , weq ( stn ( f i ) ) ( hfiber g i ) ) : weq X ( stn ( stnsum f ) ) .
+Corollary weqstnsum2 { X : UU } ( n : nat ) ( f : stn n -> nat ) ( g : X -> stn n ) ( ww : Π i : stn n , weq ( stn ( f i ) ) ( hfiber g i ) ) : weq X ( stn ( stnsum f ) ) .
 Proof. intros . assert ( w : weq X ( total2 ( fun i : stn n => hfiber g i ) ) ) . apply weqtococonusf . apply ( weqcomp w ( weqstnsum ( fun i : stn n => hfiber g i ) f ww ) ) .   Defined .
 
 (** lexical enumeration of pairs of natural numbers *)
@@ -649,9 +649,9 @@ Proof. intros . assert ( w : weq X ( total2 ( fun i : stn n => hfiber g i ) ) ) 
 Definition lexicalEnumeration {n} (m:stn n->nat) := invweq (weqstnsum1 m) : stn (stnsum m) ≃ (Σ i : stn n, stn (m i)).
 Definition inverse_lexicalEnumeration {n} (m:stn n->nat) := weqstnsum1 m : (Σ i : stn n, stn (m i)) ≃ stn (stnsum m).
 
-Definition lex_curry {X n} (m:stn n->nat) : (stn (stnsum m) -> X) -> (∀ (i:stn n), stn (m i) -> X).
+Definition lex_curry {X n} (m:stn n->nat) : (stn (stnsum m) -> X) -> (Π (i:stn n), stn (m i) -> X).
 Proof. intros ? ? ? f ? j. exact (f (inverse_lexicalEnumeration m (i,,j))). Defined.
-Definition lex_uncurry {X n} (m:stn n->nat) : (∀ (i:stn n), stn (m i) -> X) -> (stn (stnsum m) -> X).
+Definition lex_uncurry {X n} (m:stn n->nat) : (Π (i:stn n), stn (m i) -> X) -> (stn (stnsum m) -> X).
 Proof. intros ? ? ? g ij. exact (uncurry g (lexicalEnumeration m ij)). Defined.
 
 (** two generalizations of stnsum, potentially useful *)
@@ -678,7 +678,7 @@ Theorem weqfromprodofstn ( n m : nat ) : stn n × stn m ≃ stn (n * m).
 Proof.
   intros.
   induction ( natgthorleh m 0 ) as [ is | i ] .
-  - assert ( i1 : ∀ i j : nat, i < n -> j < m -> j + i * m < n * m).
+  - assert ( i1 : Π i j : nat, i < n -> j < m -> j + i * m < n * m).
     + intros i j li lj.
       apply (natlthlehtrans ( j + i * m ) ( ( S i ) * m ) ( n * m )).
       * change (S i * m) with (i*m + m).
@@ -726,7 +726,7 @@ Defined.
 Theorem weqfromdecsubsetofstn { n : nat } ( f : stn n -> bool ) : total2 ( fun x : nat => weq ( hfiber f true ) ( stn x ) ) .
 Proof . intro . induction n as [ | n IHn ] . intros .    split with 0 .  assert ( g : ( hfiber f true ) -> ( stn 0 ) ) . intro hf . destruct hf as [ i e ] .  destruct ( weqstn0toempty i ) .  apply ( weqtoempty2 g weqstn0toempty ) . intro . set ( g := weqfromcoprodofstn 1 n ) .   change ( 1 + n ) with ( S n ) in g .
 
-set ( fl := fun i : stn 1 => f ( g ( ii1 i ) ) ) .   set ( fh := fun i : stn n => f ( g ( ii2 i ) ) ) . assert ( w : weq ( hfiber f true ) ( hfiber ( sumofmaps fl fh ) true ) ) .  set ( int := invweq ( weqhfibersgwtog g f true  ) ) .  assert ( h : forall x : _ , paths ( f ( g x ) ) ( sumofmaps fl fh x ) ) . intro . destruct x as [ x1 | xn ] . apply idpath . apply idpath .   apply ( weqcomp int ( weqhfibershomot _ _ h true ) ) .  set ( w' := weqcomp w ( invweq ( weqhfibersofsumofmaps fl fh true ) ) ) .
+set ( fl := fun i : stn 1 => f ( g ( ii1 i ) ) ) .   set ( fh := fun i : stn n => f ( g ( ii2 i ) ) ) . assert ( w : weq ( hfiber f true ) ( hfiber ( sumofmaps fl fh ) true ) ) .  set ( int := invweq ( weqhfibersgwtog g f true  ) ) .  assert ( h : Π x : _ , paths ( f ( g x ) ) ( sumofmaps fl fh x ) ) . intro . destruct x as [ x1 | xn ] . apply idpath . apply idpath .   apply ( weqcomp int ( weqhfibershomot _ _ h true ) ) .  set ( w' := weqcomp w ( invweq ( weqhfibersofsumofmaps fl fh true ) ) ) .
 
 set ( x0 := pr1 ( IHn fh ) ) . set ( w0 := pr2 ( IHn fh ) ) . simpl in w0 . destruct ( boolchoice ( fl ( lastelement 0 ) ) ) as [ i | ni ] .
 
@@ -772,7 +772,7 @@ Proof.
   apply (maponpaths (λ i, i * f (lastelement _))). apply IH. intro x. apply h.
 Defined.
 
-Theorem weqstnprod { n : nat } ( P : stn n -> UU ) ( f : stn n -> nat ) ( ww : forall i : stn n , weq ( stn ( f i ) )  ( P i ) ) : weq ( forall x : stn n , P x  ) ( stn ( stnprod f ) ) .
+Theorem weqstnprod { n : nat } ( P : stn n -> UU ) ( f : stn n -> nat ) ( ww : Π i : stn n , weq ( stn ( f i ) )  ( P i ) ) : weq ( Π x : stn n , P x  ) ( stn ( stnprod f ) ) .
 Proof .
   intro n .
   induction n as [ | n IHn ] .
@@ -867,11 +867,11 @@ Proof. intros n n' X. apply (eqfromdnegeq nat isdeceqnat _ _  (dnegf (@weqtoeqst
 (** ** Some results on bounded quantification *)
 
 
-Lemma weqforallnatlehn0 ( F : nat -> hProp ) : weq ( forall n : nat , natleh n 0 -> F n ) ( F 0 ) .
-Proof . intros .  assert ( lg : ( forall n : nat , natleh n 0 -> F n ) <-> ( F 0 ) ) . split . intro f .  apply ( f 0 ( isreflnatleh 0 ) ) .  intros f0 n l .  set ( e := natleh0tois0 l ) .  rewrite e .  apply f0 . assert ( is1 : isaprop ( forall n : nat , natleh n 0 -> F n ) ) . apply impred . intro n . apply impred .   intro l .  apply ( pr2 ( F n ) ) .  apply ( weqimplimpl ( pr1 lg ) ( pr2 lg ) is1 ( pr2 ( F 0 ) ) ) . Defined .
+Lemma weqforallnatlehn0 ( F : nat -> hProp ) : weq ( Π n : nat , natleh n 0 -> F n ) ( F 0 ) .
+Proof . intros .  assert ( lg : ( Π n : nat , natleh n 0 -> F n ) <-> ( F 0 ) ) . split . intro f .  apply ( f 0 ( isreflnatleh 0 ) ) .  intros f0 n l .  set ( e := natleh0tois0 l ) .  rewrite e .  apply f0 . assert ( is1 : isaprop ( Π n : nat , natleh n 0 -> F n ) ) . apply impred . intro n . apply impred .   intro l .  apply ( pr2 ( F n ) ) .  apply ( weqimplimpl ( pr1 lg ) ( pr2 lg ) is1 ( pr2 ( F 0 ) ) ) . Defined .
 
-Lemma weqforallnatlehnsn' ( n' : nat ) ( F : nat -> hProp ) : weq ( forall n : nat , natleh n ( S n' ) -> F n ) ( dirprod ( forall n : nat , natleh n n' -> F n ) ( F ( S n' ) ) ) .
-Proof . intros . assert ( lg : ( forall n : nat , natleh n ( S n' ) -> F n ) <-> dirprod ( forall n : nat , natleh n n' -> F n ) ( F ( S n' ) ) ) .  split . intro f.  apply ( dirprodpair ( fun n => fun l => ( f n ( natlehtolehs _ _ l ) ) ) ( f ( S n' ) ( isreflnatleh _ ) ) ) .  intro d2 . intro n .  intro l .  destruct ( natlehchoice2 _ _ l ) as [ h | e ] . simpl in h .  apply ( pr1 d2 n h ) . destruct d2 as [ f2 d2 ] .  rewrite e .  apply d2 . assert ( is1 : isaprop ( forall n : nat , natleh n ( S n' ) -> F n ) ) . apply impred . intro n . apply impred . intro l . apply ( pr2 ( F n ) ) . assert ( is2 : isaprop ( dirprod ( forall n : nat , natleh n n' -> F n ) ( F ( S n' ) ) ) ) . apply isapropdirprod . apply impred . intro n . apply impred . intro l . apply ( pr2 ( F n ) ) .   apply ( pr2 ( F ( S n' ) ) ) .  apply ( weqimplimpl ( pr1 lg ) ( pr2 lg ) is1 is2 ) . Defined .
+Lemma weqforallnatlehnsn' ( n' : nat ) ( F : nat -> hProp ) : weq ( Π n : nat , natleh n ( S n' ) -> F n ) ( dirprod ( Π n : nat , natleh n n' -> F n ) ( F ( S n' ) ) ) .
+Proof . intros . assert ( lg : ( Π n : nat , natleh n ( S n' ) -> F n ) <-> dirprod ( Π n : nat , natleh n n' -> F n ) ( F ( S n' ) ) ) .  split . intro f.  apply ( dirprodpair ( fun n => fun l => ( f n ( natlehtolehs _ _ l ) ) ) ( f ( S n' ) ( isreflnatleh _ ) ) ) .  intro d2 . intro n .  intro l .  destruct ( natlehchoice2 _ _ l ) as [ h | e ] . simpl in h .  apply ( pr1 d2 n h ) . destruct d2 as [ f2 d2 ] .  rewrite e .  apply d2 . assert ( is1 : isaprop ( Π n : nat , natleh n ( S n' ) -> F n ) ) . apply impred . intro n . apply impred . intro l . apply ( pr2 ( F n ) ) . assert ( is2 : isaprop ( dirprod ( Π n : nat , natleh n n' -> F n ) ( F ( S n' ) ) ) ) . apply isapropdirprod . apply impred . intro n . apply impred . intro l . apply ( pr2 ( F n ) ) .   apply ( pr2 ( F ( S n' ) ) ) .  apply ( weqimplimpl ( pr1 lg ) ( pr2 lg ) is1 is2 ) . Defined .
 
 Lemma weqexistsnatlehn0 ( P : nat -> hProp  ) : weq ( hexists ( fun n : nat => dirprod ( natleh n 0 ) ( P n ) ) ) ( P 0 ) .
 Proof . intro . assert ( lg : hexists ( fun n : nat => dirprod ( natleh n 0 ) ( P n ) ) <-> P 0  ) . split .  simpl . apply ( @hinhuniv _ ( P 0 ) ) .  intro t2 .  destruct t2 as [ n d2 ] . destruct d2 as [ l p ] . set ( e := natleh0tois0 l ) . clearbody e .  destruct e . apply p . intro p . apply hinhpr . split with 0 .  split with ( isreflnatleh 0 ) .  apply p . apply ( weqimplimpl ( pr1 lg ) ( pr2 lg ) ( pr2 _ ) ( pr2 _ ) ) .  Defined .
@@ -880,31 +880,31 @@ Lemma weqexistsnatlehnsn' ( n' : nat ) ( P : nat -> hProp  ) : weq ( hexists ( f
 Proof . intros . assert ( lg : hexists ( fun n : nat => dirprod ( natleh n ( S n' ) ) ( P n ) )  <-> hdisj ( hexists ( fun n : nat => dirprod ( natleh n n' ) ( P n ) ) )  ( P ( S n' ) )  ) . split . apply hinhfun .   intro t2 .  destruct t2 as [ n d2 ] . destruct d2 as [ l p ] . destruct ( natlehchoice2 _ _ l ) as [ h | nh ] . simpl in h . apply ii1 .  apply hinhpr . split with n .  apply ( dirprodpair h p ) . destruct nh .  apply ( ii2 p ) . simpl . apply ( @hinhuniv _ ( ishinh _ ) ) . intro c .  destruct c as [ t | p ] .  generalize t . simpl . apply hinhfun .  clear t . intro t . destruct t as [ n d2 ] . destruct d2 as [ l p ] . split with n .  split with ( natlehtolehs _ _ l ) .  apply p .  apply hinhpr . split with ( S n' ) .  split with ( isreflnatleh _ ) . apply p .  apply ( weqimplimpl ( pr1 lg ) ( pr2 lg ) ( pr2 _ ) ( pr2 _ ) ) .  Defined .
 
 
-Lemma isdecbexists ( n : nat ) ( P : nat -> UU ) ( is : forall n' , isdecprop ( P n' ) ) : isdecprop ( hexists ( fun n' => dirprod ( natleh n' n ) ( P n' ) ) ) .
+Lemma isdecbexists ( n : nat ) ( P : nat -> UU ) ( is : Π n' , isdecprop ( P n' ) ) : isdecprop ( hexists ( fun n' => dirprod ( natleh n' n ) ( P n' ) ) ) .
 Proof . intros .  set ( P' := fun n' : nat => hProppair _ ( is n' ) ) . induction n as [ | n IHn ] . apply ( isdecpropweqb ( weqexistsnatlehn0 P' ) ) . apply ( is 0 ) .   apply ( isdecpropweqb ( weqexistsnatlehnsn' _ P' ) ) . apply isdecprophdisj . apply IHn . apply ( is ( S n ) ) . Defined .
 
-Lemma isdecbforall ( n : nat ) ( P : nat -> UU ) ( is : forall n' , isdecprop ( P n' ) ) : isdecprop ( forall n' , natleh n' n -> P n' )  .
+Lemma isdecbforall ( n : nat ) ( P : nat -> UU ) ( is : Π n' , isdecprop ( P n' ) ) : isdecprop ( Π n' , natleh n' n -> P n' )  .
 Proof . intros .  set ( P' := fun n' : nat => hProppair _ ( is n' ) ) . induction n as [ | n IHn ] . apply ( isdecpropweqb ( weqforallnatlehn0 P' ) ) . apply ( is 0 ) .   apply ( isdecpropweqb ( weqforallnatlehnsn' _ P' ) ) . apply isdecpropdirprod . apply IHn . apply ( is ( S n ) ) . Defined .
 
 
 
-(** The following lemma finds the largest [ n' ] such that [ neg ( P n' ) ] . It is a stronger form of ( neg forall ) -> ( exists neg ) in the case of bounded quantification of decidable propositions. *)
+(** The following lemma finds the largest [ n' ] such that [ neg ( P n' ) ] . It is a stronger form of ( neg Π ) -> ( exists neg ) in the case of bounded quantification of decidable propositions. *)
 
-Lemma negbforalldectototal2neg ( n : nat ) ( P : nat -> UU ) ( is : forall n' : nat , isdecprop ( P n' ) ) : neg ( forall n' : nat , natleh n' n -> P n' ) -> total2 ( fun n' => dirprod ( natleh n' n ) ( neg ( P n' ) ) ) .
+Lemma negbforalldectototal2neg ( n : nat ) ( P : nat -> UU ) ( is : Π n' : nat , isdecprop ( P n' ) ) : neg ( Π n' : nat , natleh n' n -> P n' ) -> total2 ( fun n' => dirprod ( natleh n' n ) ( neg ( P n' ) ) ) .
 Proof . intros n P is . set ( P' := fun n' : nat => hProppair _ ( is n' ) ) . induction n as [ | n IHn ] . intro nf . set ( nf0 := negf ( invweq ( weqforallnatlehn0 P' ) ) nf ) . split with 0 . apply ( dirprodpair ( isreflnatleh 0 ) nf0 ) .   intro nf . set ( nf2 := negf ( invweq ( weqforallnatlehnsn' n P' ) ) nf ) . set ( nf3 := fromneganddecy ( is ( S n ) ) nf2 ) . destruct nf3 as [ f1 | f2 ] . set ( int := IHn f1 ) .  destruct int as [ n' d2 ] . destruct d2 as [ l np ] . split with n' .  split with ( natlehtolehs _ _ l ) .  apply np . split with ( S n ) . split with ( isreflnatleh _ ) . apply f2 .  Defined .
 
 
 (** ** Accessibility - the least element of an inhabited decidable subset of [nat] *)
 
-Definition natdecleast ( F : nat -> UU ) ( is : forall n , isdecprop ( F n ) ) := total2 ( fun  n : nat => dirprod ( F n ) ( forall n' : nat , F n' -> natleh n n' ) ) .
+Definition natdecleast ( F : nat -> UU ) ( is : Π n , isdecprop ( F n ) ) := total2 ( fun  n : nat => dirprod ( F n ) ( Π n' : nat , F n' -> natleh n n' ) ) .
 
-Lemma isapropnatdecleast ( F : nat -> UU ) ( is : forall n , isdecprop ( F n ) ) : isaprop ( natdecleast F is ) .
-Proof . intros . set ( P := fun n' : nat => hProppair _ ( is n' ) ) . assert ( int1 : forall n : nat, isaprop ( dirprod ( F n ) ( forall n' : nat , F n' -> natleh n n' ) ) ) .  intro n . apply isapropdirprod . apply ( pr2 ( P n ) ) .  apply impred . intro t .  apply impred .  intro .  apply ( pr2 ( natleh n t ) ) . set ( int2 := ( fun n : nat => hProppair _ ( int1 n ) ) : nat -> hProp ) .   change ( isaprop ( total2 int2 ) ) . apply isapropsubtype . intros x1 x2 .  intros c1 c2 . simpl in * . destruct c1 as [ e1 c1 ] . destruct c2 as [ e2 c2 ] . set ( l1 := c1 x2 e2 ) .  set ( l2 := c2 x1 e1 ) . apply ( isantisymmnatleh _ _ l1 l2 ) .  Defined .
+Lemma isapropnatdecleast ( F : nat -> UU ) ( is : Π n , isdecprop ( F n ) ) : isaprop ( natdecleast F is ) .
+Proof . intros . set ( P := fun n' : nat => hProppair _ ( is n' ) ) . assert ( int1 : Π n : nat, isaprop ( dirprod ( F n ) ( Π n' : nat , F n' -> natleh n n' ) ) ) .  intro n . apply isapropdirprod . apply ( pr2 ( P n ) ) .  apply impred . intro t .  apply impred .  intro .  apply ( pr2 ( natleh n t ) ) . set ( int2 := ( fun n : nat => hProppair _ ( int1 n ) ) : nat -> hProp ) .   change ( isaprop ( total2 int2 ) ) . apply isapropsubtype . intros x1 x2 .  intros c1 c2 . simpl in * . destruct c1 as [ e1 c1 ] . destruct c2 as [ e2 c2 ] . set ( l1 := c1 x2 e2 ) .  set ( l2 := c2 x1 e1 ) . apply ( isantisymmnatleh _ _ l1 l2 ) .  Defined .
 
-Theorem accth ( F : nat -> UU ) ( is : forall n , isdecprop ( F n ) )  ( is' : hexists F ) : natdecleast F is .
+Theorem accth ( F : nat -> UU ) ( is : Π n , isdecprop ( F n ) )  ( is' : hexists F ) : natdecleast F is .
 Proof . intros F is . simpl . apply (@hinhuniv _ ( hProppair _ ( isapropnatdecleast F is ) ) ) . intro t2. destruct t2 as [ n l ] . simpl .
 
-set ( F' := fun n' : nat => hexists ( fun n'' => dirprod ( natleh n'' n' ) ( F n'' ) ) ) .  assert ( X : forall n' , F' n' -> natdecleast F is ) .  intro n' .  simpl .    induction n' as [ | n' IHn' ] . apply ( @hinhuniv _  ( hProppair _ ( isapropnatdecleast F is ) ) ) . simpl .   intro t2 . destruct t2 as [ n'' is'' ] . destruct is'' as [ l'' d'' ] .  split with 0 .  split . set ( e := natleh0tois0 l'' ) . clearbody e . destruct e . apply d'' .  apply ( fun n' => fun f : _ => natleh0n n' ) .  apply ( @hinhuniv _  ( hProppair _ ( isapropnatdecleast F is ) ) ) . intro t2 .  destruct t2 as [ n'' is'' ] . set ( j := natlehchoice2 _ _ ( pr1 is'' ) ) .  destruct j as [ jl | je ] .  simpl .  apply ( IHn' ( hinhpr ( tpair _ n'' ( dirprodpair jl ( pr2 is'' ) ) ) ) ) .  simpl . rewrite je in is''  .  destruct is'' as [ nn is'' ] .  clear nn. clear je . clear n'' .
+set ( F' := fun n' : nat => hexists ( fun n'' => dirprod ( natleh n'' n' ) ( F n'' ) ) ) .  assert ( X : Π n' , F' n' -> natdecleast F is ) .  intro n' .  simpl .    induction n' as [ | n' IHn' ] . apply ( @hinhuniv _  ( hProppair _ ( isapropnatdecleast F is ) ) ) . simpl .   intro t2 . destruct t2 as [ n'' is'' ] . destruct is'' as [ l'' d'' ] .  split with 0 .  split . set ( e := natleh0tois0 l'' ) . clearbody e . destruct e . apply d'' .  apply ( fun n' => fun f : _ => natleh0n n' ) .  apply ( @hinhuniv _  ( hProppair _ ( isapropnatdecleast F is ) ) ) . intro t2 .  destruct t2 as [ n'' is'' ] . set ( j := natlehchoice2 _ _ ( pr1 is'' ) ) .  destruct j as [ jl | je ] .  simpl .  apply ( IHn' ( hinhpr ( tpair _ n'' ( dirprodpair jl ( pr2 is'' ) ) ) ) ) .  simpl . rewrite je in is''  .  destruct is'' as [ nn is'' ] .  clear nn. clear je . clear n'' .
 
 assert ( is' : isdecprop ( F' n' ) ) . apply ( isdecbexists n' F is ) .   destruct ( pr1 is' ) as [ f | nf ] .  apply ( IHn'  f ) .  split with ( S n' ) .  split with is'' . intros n0 fn0 . destruct ( natlthorgeh n0 ( S n' ) )  as [ l' | g' ] .  set ( i' := natlthtolehsn _ _ l' ) .  destruct ( nf ( hinhpr ( tpair _ n0 ( dirprodpair i' fn0 ) ) ) ) .   apply g' .
 
@@ -923,7 +923,7 @@ Ltac inductive_reflexivity i b :=
 
 (** general associativity for addition in nat *)
 
-Theorem nat_plus_associativity {n} {m:stn n->nat} (k:∀ (ij : Σ i, stn (m i)), nat) :
+Theorem nat_plus_associativity {n} {m:stn n->nat} (k:Π (ij : Σ i, stn (m i)), nat) :
   stnsum (λ i, stnsum (curry k i)) = stnsum (k ∘ lexicalEnumeration m).
 Proof.
   intros. apply weqtoeqstn.
@@ -939,7 +939,7 @@ Proof.
   { apply inverse_lexicalEnumeration. }
 Defined.
 
-Corollary nat_plus_associativity' n (m:stn n->nat) (k:∀ i, stn (m i) -> nat) :
+Corollary nat_plus_associativity' n (m:stn n->nat) (k:Π i, stn (m i) -> nat) :
   stnsum (λ i, stnsum (k i)) = stnsum (uncurry k ∘ lexicalEnumeration m).
 Proof. intros. exact (nat_plus_associativity (uncurry k)). Defined.
 

--- a/UniMath/Foundations/Combinatorics/Tests.v
+++ b/UniMath/Foundations/Combinatorics/Tests.v
@@ -13,7 +13,7 @@ Module Test_stn.
   Goal (stnel(6,3) ≠ stnel(6,4)). easy. Defined.
   Goal ¬(stnel(6,3) ≠ stnel(6,3)). easy. Defined.
 
-  Goal ∀ m n (i:m≤n) (j:stn m), pr1 (stnmtostnn m n i j) = pr1 j.
+  Goal Π m n (i:m≤n) (j:stn m), pr1 (stnmtostnn m n i j) = pr1 j.
     intros. induction j as [j J]. reflexivity.
   Defined.
 
@@ -138,8 +138,8 @@ Module Test_stn.
   End Test2.
 
   (* confirm that [stnsum] is associative in the same way as the parser, which is left associative *)
-  Goal ∀ (f : stn 3 -> nat), stnsum f =  f(●0) + f(●1)  +  f(●2). reflexivity. Defined.
-  Goal ∀ (f : stn 3 -> nat), stnsum f = (f(●0) + f(●1)) +  f(●2). reflexivity. Defined.
+  Goal Π (f : stn 3 -> nat), stnsum f =  f(●0) + f(●1)  +  f(●2). reflexivity. Defined.
+  Goal Π (f : stn 3 -> nat), stnsum f = (f(●0) + f(●1)) +  f(●2). reflexivity. Defined.
 
   Module Test_weqstnsum.
     (* this module exports nothing *)
@@ -206,7 +206,7 @@ Module Test_stn.
   End Test_weqfromprodofstn.
 
   (* confirm that [stnprod] is associative in the same way as the parser *)
-  Goal ∀ (f : stn 3 -> nat), stnprod f = f(●0) * f(●1) * f(●2).
+  Goal Π (f : stn 3 -> nat), stnprod f = f(●0) * f(●1) * f(●2).
   Proof. reflexivity. Defined.
 
 
@@ -223,7 +223,7 @@ Module Test_stn.
           * contradicts (negnatlthn0 n) b.
     Defined.
 
-  Goal ∀ n, testfun n < 5.
+  Goal Π n, testfun n < 5.
     Proof.
       intros.
       induction n as [i c].
@@ -265,7 +265,7 @@ Module Test_fin.
   (* Eval compute in (carddneg _  (isfinitedirprod _ _ (isfinitestn (S (S (S (S O)))))  (isfinitestn (S (S (S O)))))). *)
   (* Eval lazy in   (pr1 (finitestructcomplement _ (dirprodpair _ _ tt tt) (finitestructdirprod _ _ (finitestructunit) (finitestructunit)))). *)
 
-  Goal ∀ X (fin : finstruct X) (f : X -> nat),
+  Goal Π X (fin : finstruct X) (f : X -> nat),
     finsum (hinhpr fin) f = stnsum (f ∘ pr1weq (pr2 fin)).
   Proof. reflexivity. Qed.
 
@@ -334,7 +334,7 @@ Module Test_fin.
     Defined.
 
     (* test isfiniteforall *)
-    Let T := ∀ x, Y' x.
+    Let T := Π x, Y' x.
     Let eqT : DecidableRelation T :=
       isfinite_to_DecidableEquality (isfiniteforall Y' finX (λ _, finY)).
     Goal decide (eqT (λ _, y) (λ _, y)) = true.
@@ -435,7 +435,7 @@ Module Test_ord.
 
   End TestLex2.
 
-  Goal ∀ X (lt:hrel X), iscotrans lt <-> iswklin lt.
+  Goal Π X (lt:hrel X), iscotrans lt <-> iswklin lt.
   Proof.
     intros. unfold iscotrans, iswklin. split.
     { intros i x1 x3 x2. apply i. }
@@ -450,13 +450,13 @@ Module Test_ord.
   Open Scope multmonoid.
 
   (* demonstrate that the Coq parser is left-associative with "*" *)
-  Goal ∀ (M:monoid) (x y z:M), x*y*z = (x*y)*z. Proof. reflexivity. Defined.
-  Goal ∀ (M:monoid) (x y z:M), x*y*z = x*(y*z). Proof. apply assocax. Defined.
+  Goal Π (M:monoid) (x y z:M), x*y*z = (x*y)*z. Proof. reflexivity. Defined.
+  Goal Π (M:monoid) (x y z:M), x*y*z = x*(y*z). Proof. apply assocax. Defined.
 
   (* demonstrate that the Coq parser is left-associative with "+" *)
   Open Scope addmonoid.
-  Goal ∀ (M:monoid) (x y z:M), x+y+z = (x+y)+z. Proof. reflexivity. Defined.
-  Goal ∀ (M:monoid) (x y z:M), x+y+z = x+(y+z). Proof. apply assocax. Defined.
+  Goal Π (M:monoid) (x y z:M), x+y+z = (x+y)+z. Proof. reflexivity. Defined.
+  Goal Π (M:monoid) (x y z:M), x+y+z = x+(y+z). Proof. apply assocax. Defined.
   Close Scope addmonoid.
 
 End Test_ord.

--- a/UniMath/Foundations/NumberSystems/Integers.v
+++ b/UniMath/Foundations/NumberSystems/Integers.v
@@ -684,7 +684,7 @@ Definition hzgehtogehs ( n m : hz ) : hzgeh n m -> hzgeh ( n + 1 ) m := hzlehtol
 (** *** Two comparisons and [ n -> n + 1 ] *)
 
 Lemma hzgthtogehsn ( n m : hz ) : hzgth n m -> hzgeh n ( m + 1 ) .
-Proof. assert ( int : forall n m , isaprop ( hzgth n m -> hzgeh n ( m + 1 )  ) ) .
+Proof. assert ( int : Π n m , isaprop ( hzgth n m -> hzgeh n ( m + 1 )  ) ) .
        { intros . apply impred . intro . apply ( pr2 _ ) . }
        unfold hzgth in * .  apply ( setquotuniv2prop _ ( fun n m => hProppair _ ( int n m ) ) ) . set ( R := abgrfracrelint nataddabmonoid natgth ) .
        intros x x' .  change ( R x x' -> ( neg ( R ( @op ( abmonoiddirprod (rigaddabmonoid natcommrig) (rigaddabmonoid natcommrig) ) x' ( dirprodpair 1%nat 0%nat ) ) x ) ) ) .
@@ -818,7 +818,7 @@ Lemma hzabsval0 : paths ( hzabsval 0 ) 0%nat .
 Proof .  apply idpath .  Defined .
 
 Lemma hzabsvalgth0 { x : hz } ( is : hzgth x 0 ) : paths ( nattohz ( hzabsval x ) ) x .
-Proof . assert ( int : forall x : hz , isaprop ( hzgth x 0 ->  paths ( nattohz ( hzabsval x ) ) x ) ) . intro . apply impred . intro . apply ( setproperty hz ) .  apply ( setquotunivprop _ ( fun x => hProppair _ ( int x ) ) ) . intros xa g . simpl in xa . assert ( g' := natnattohzandgth _ _ g ) . simpl in g' .  simpl .  change ( paths ( setquotpr (eqrelabgrfrac (rigaddabmonoid natcommrig)) ( dirprodpair ( hzabsvalint xa ) 0%nat ) ) ( setquotpr (eqrelabgrfrac (rigaddabmonoid natcommrig)) xa ) ) . apply weqpathsinsetquot . simpl . apply hinhpr . split with 0%nat .  change ( pr1 ( natgth ( pr1 xa + 0%nat ) ( pr2 xa ) ) ) in g' . rewrite ( natplusr0 _ ) in g' .  change ( paths  (hzabsvalint xa + pr2 xa + 0)%nat (pr1 xa + 0 + 0)%nat ) . rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) . unfold hzabsvalint .   destruct ( natgthorleh (pr1 xa) (pr2 xa)  ) as [ g'' | l ] .
+Proof . assert ( int : Π x : hz , isaprop ( hzgth x 0 ->  paths ( nattohz ( hzabsval x ) ) x ) ) . intro . apply impred . intro . apply ( setproperty hz ) .  apply ( setquotunivprop _ ( fun x => hProppair _ ( int x ) ) ) . intros xa g . simpl in xa . assert ( g' := natnattohzandgth _ _ g ) . simpl in g' .  simpl .  change ( paths ( setquotpr (eqrelabgrfrac (rigaddabmonoid natcommrig)) ( dirprodpair ( hzabsvalint xa ) 0%nat ) ) ( setquotpr (eqrelabgrfrac (rigaddabmonoid natcommrig)) xa ) ) . apply weqpathsinsetquot . simpl . apply hinhpr . split with 0%nat .  change ( pr1 ( natgth ( pr1 xa + 0%nat ) ( pr2 xa ) ) ) in g' . rewrite ( natplusr0 _ ) in g' .  change ( paths  (hzabsvalint xa + pr2 xa + 0)%nat (pr1 xa + 0 + 0)%nat ) . rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) . unfold hzabsvalint .   destruct ( natgthorleh (pr1 xa) (pr2 xa)  ) as [ g'' | l ] .
 
 rewrite ( minusplusnmm _ _ ( natlthtoleh _ _ g'' ) ) . apply idpath .
 
@@ -831,7 +831,7 @@ Lemma hzabsvalgeh0 { x : hz } ( is : hzgeh x 0 ) : paths ( nattohz ( hzabsval x 
 Proof .  intros . destruct ( hzgehchoice _ _ is ) as [ g | e ] .  apply ( hzabsvalgth0 g ) . rewrite e .  apply idpath .  Defined .
 
 Lemma hzabsvallth0 { x : hz } ( is : hzlth x 0 ) : paths ( nattohz ( hzabsval x ) ) ( - x ) .
-Proof . assert ( int : forall x : hz , isaprop ( hzlth x 0 ->  paths ( nattohz ( hzabsval x ) ) ( - x ) ) ) . intro . apply impred . intro . apply ( setproperty hz ) .  apply ( setquotunivprop _ ( fun x => hProppair _ ( int x ) ) ) . intros xa l . simpl in xa . assert ( l' := natnattohzandlth _ _ l ) . simpl in l' .  simpl .  change ( paths ( setquotpr (eqrelabgrfrac (rigaddabmonoid natcommrig)) ( dirprodpair ( hzabsvalint xa ) 0%nat ) ) ( setquotpr (eqrelabgrfrac (rigaddabmonoid natcommrig)) ( dirprodpair ( pr2 xa ) ( pr1 xa ) ) ) ) . apply weqpathsinsetquot . simpl . apply hinhpr . split with 0%nat .  change ( pr1 ( natlth ( pr1 xa + 0%nat ) ( pr2 xa ) ) ) in l' . rewrite ( natplusr0 _ ) in l' .  change ( paths  (hzabsvalint xa + pr1 xa + 0)%nat (pr2 xa + 0 + 0)%nat ) . rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) . unfold hzabsvalint .   destruct ( natgthorleh (pr1 xa) (pr2 xa)  ) as [ g | l'' ] .
+Proof . assert ( int : Π x : hz , isaprop ( hzlth x 0 ->  paths ( nattohz ( hzabsval x ) ) ( - x ) ) ) . intro . apply impred . intro . apply ( setproperty hz ) .  apply ( setquotunivprop _ ( fun x => hProppair _ ( int x ) ) ) . intros xa l . simpl in xa . assert ( l' := natnattohzandlth _ _ l ) . simpl in l' .  simpl .  change ( paths ( setquotpr (eqrelabgrfrac (rigaddabmonoid natcommrig)) ( dirprodpair ( hzabsvalint xa ) 0%nat ) ) ( setquotpr (eqrelabgrfrac (rigaddabmonoid natcommrig)) ( dirprodpair ( pr2 xa ) ( pr1 xa ) ) ) ) . apply weqpathsinsetquot . simpl . apply hinhpr . split with 0%nat .  change ( pr1 ( natlth ( pr1 xa + 0%nat ) ( pr2 xa ) ) ) in l' . rewrite ( natplusr0 _ ) in l' .  change ( paths  (hzabsvalint xa + pr1 xa + 0)%nat (pr2 xa + 0 + 0)%nat ) . rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) . unfold hzabsvalint .   destruct ( natgthorleh (pr1 xa) (pr2 xa)  ) as [ g | l'' ] .
 
 destruct ( isasymmnatgth _ _ g l' ) .
 

--- a/UniMath/Foundations/NumberSystems/NaturalNumbers.v
+++ b/UniMath/Foundations/NumberSystems/NaturalNumbers.v
@@ -1591,7 +1591,7 @@ This part is included for illustration purposes only . In practice it is easier 
 
 (** *** A generalization of [ le ] and its properties . *)
 
-Inductive leF { T : UU } ( F : T -> T ) ( t : T ) : T -> UU := leF_O : leF F t t | leF_S : forall t' : T , leF F t t' -> leF F t ( F t' ) .
+Inductive leF { T : UU } ( F : T -> T ) ( t : T ) : T -> UU := leF_O : leF F t t | leF_S : Π t' : T , leF F t t' -> leF F t ( F t' ) .
 
 Lemma leFiter { T : UU } ( F : T -> T ) ( t : T ) ( n : nat ) : leF F t ( iteration F n t ) .
 Proof. intros .   induction n as [ | n IHn ] . apply leF_O . simpl . unfold funcomp . apply leF_S .  assumption .  Defined .
@@ -1609,8 +1609,8 @@ set ( h := fun ne :  total2 ( fun n0 : nat => paths ( iteration F n0 t ) ( itera
 
 Lemma isweqleFtototal2withnat { T : UU } ( F : T -> T ) ( t t' : T ) : isweq ( leFtototal2withnat F t t' ) .
 Proof . intros .  set ( f := leFtototal2withnat F t t' ) . set ( g :=  total2withnattoleF  F t t' ) .
-assert ( egf : forall x : _ , paths ( g ( f x ) ) x ) . intro x .  induction x as [ | y H0 IHH0 ] . apply idpath . simpl . simpl in IHH0 .  destruct (leFtototal2withnat F t y H0 ) as [ m e ] .   destruct e .  simpl .   simpl in IHH0.  apply (  @maponpaths _ _ ( leF_S F t (iteration F m t) ) _ _ IHH0 ) .
-assert ( efg : forall x : _ , paths ( f ( g x ) ) x ) . intro x .  destruct x as [ n e ] .  destruct e . simpl .  apply  leFtototal2withnat_l0 .
+assert ( egf : Π x : _ , paths ( g ( f x ) ) x ) . intro x .  induction x as [ | y H0 IHH0 ] . apply idpath . simpl . simpl in IHH0 .  destruct (leFtototal2withnat F t y H0 ) as [ m e ] .   destruct e .  simpl .   simpl in IHH0.  apply (  @maponpaths _ _ ( leF_S F t (iteration F m t) ) _ _ IHH0 ) .
+assert ( efg : Π x : _ , paths ( f ( g x ) ) x ) . intro x .  destruct x as [ n e ] .  destruct e . simpl .  apply  leFtototal2withnat_l0 .
 apply ( gradth _ _ egf efg ) . Defined.
 
 Definition weqleFtototalwithnat { T : UU } ( F : T -> T ) ( t t' : T ) : weq ( leF F t t' ) (  total2 ( fun n : nat => paths ( iteration F n t ) t' ) ) := weqpair _ ( isweqleFtototal2withnat F t t' ) .

--- a/UniMath/Ktheory/AbelianGroup.v
+++ b/UniMath/Ktheory/AbelianGroup.v
@@ -87,19 +87,19 @@ Module Presentation.
 
   Record AdequateRelation {X I} (R:I->reln X) (r : hrel (word X)) :=
     make_AdequateRelation {
-        base: ∀ i, r (lhs (R i)) (rhs (R i));
-        reflex : ∀ w, r w w;
-        symm : ∀ v w, r v w -> r w v;
-        trans : ∀ u v w, r u v -> r v w -> r u w;
-        left_compat : ∀ u v w, r v w -> r (word_op u v) (word_op u w);
-        right_compat: ∀ u v w, r u v -> r (word_op u w) (word_op v w);
-        left_unit : ∀ w, r (word_op word_unit w) w;
-        right_unit : ∀ w, r (word_op w word_unit) w;
-        assoc : ∀ u v w, r (word_op (word_op u v) w) (word_op u (word_op v w));
-        inverse_compat : ∀ v w, r v w -> r (word_inv v) (word_inv w);
-        left_inverse : ∀ w, r (word_op (word_inv w) w) word_unit;
-        right_inverse: ∀ w, r (word_op w (word_inv w)) word_unit;
-        comm : ∀ v w, r (word_op v w) (word_op w v)
+        base: Π i, r (lhs (R i)) (rhs (R i));
+        reflex : Π w, r w w;
+        symm : Π v w, r v w -> r w v;
+        trans : Π u v w, r u v -> r v w -> r u w;
+        left_compat : Π u v w, r v w -> r (word_op u v) (word_op u w);
+        right_compat: Π u v w, r u v -> r (word_op u w) (word_op v w);
+        left_unit : Π w, r (word_op word_unit w) w;
+        right_unit : Π w, r (word_op w word_unit) w;
+        assoc : Π u v w, r (word_op (word_op u v) w) (word_op u (word_op v w));
+        inverse_compat : Π v w, r v w -> r (word_inv v) (word_inv w);
+        left_inverse : Π w, r (word_op (word_inv w) w) word_unit;
+        right_inverse: Π w, r (word_op w (word_inv w)) word_unit;
+        comm : Π v w, r (word_op v w) (word_op w v)
       }.
   Arguments make_AdequateRelation {X I} R r _ _ _ _ _ _ _ _ _ _ _ _ _.
   Arguments base {X I R r} _ _.
@@ -116,7 +116,7 @@ Module Presentation.
 
   Definition smallestAdequateRelation0 {X I} (R:I->reln X) : hrel (word X).
     intros ? ? ? v w.
-    exists (∀ r: hrel (word X), AdequateRelation R r -> r v w).
+    exists (Π r: hrel (word X), AdequateRelation R r -> r v w).
     abstract (apply impred; intro r; apply impred_prop).
   Defined.
   Lemma adequacy {X I} (R:I->reln X) :
@@ -197,7 +197,7 @@ Module Presentation.
          apply (squash_to_prop (lift R w') ig); intros [w []].
          exact (iscompsetquotpr e _ _ (fun r ra => assoc R r ra u v w)). Qed.
   Lemma is_left_inverse_univ_binop {X I} (R:I->reln X) :
-    ∀ w:setquot (smallestAdequateRelation0 R),
+    Π w:setquot (smallestAdequateRelation0 R),
       univ_binop R (univ_inverse R w) w =
       setquotpr (smallestAdequateRelation R) word_unit.
   Proof. intros. isaprop_goal ig. { apply setproperty. }
@@ -205,7 +205,7 @@ Module Presentation.
     exact (iscompsetquotpr (smallestAdequateRelation R) _ _
                            (fun r ra => left_inverse R r ra v)). Qed.
   Lemma is_right_inverse_univ_binop {X I} (R:I->reln X) :
-    ∀ w:setquot (smallestAdequateRelation0 R),
+    Π w:setquot (smallestAdequateRelation0 R),
       univ_binop R w (univ_inverse R w) =
       setquotpr (smallestAdequateRelation R) word_unit.
   Proof. intros. isaprop_goal ig. { apply setproperty. }
@@ -244,7 +244,7 @@ Module Presentation.
     make_MarkedAbelianGroup {
         m_base :> abgr;
         m_mark : X -> m_base;
-        m_reln : ∀ i, evalword (toMarkedPreAbelianGroup R m_base m_mark) (lhs (R i)) =
+        m_reln : Π i, evalword (toMarkedPreAbelianGroup R m_base m_mark) (lhs (R i)) =
                            evalword (toMarkedPreAbelianGroup R m_base m_mark) (rhs (R i)) }.
   Arguments make_MarkedAbelianGroup {X I} R _ _ _.
   Arguments m_base {X I R} _.
@@ -272,7 +272,7 @@ Module Presentation.
   Record MarkedAbelianGroupMap {X I} {R:I->reln X} (M N:MarkedAbelianGroup R) :=
     make_MarkedAbelianGroupMap {
         map_base :> Hom_abgr M N;
-        map_mark : ∀ x, map_base (m_mark M x) = m_mark N x }.
+        map_mark : Π x, map_base (m_mark M x) = m_mark N x }.
   Arguments map_base {X I R M N} m.
   Arguments map_mark {X I R M N} m x.
   Lemma MarkedAbelianGroupMapEquality {X I} {R:I->reln X} {M N:MarkedAbelianGroup R}
@@ -339,7 +339,7 @@ Module Presentation.
                 (universalMarkedAbelianGroup3 R).
   Fixpoint agreement_on_gens0 {X I} {R:I->reln X} {M:abgr}
         (f g:Hom_abgr (universalMarkedAbelianGroup R) M)
-        (p:∀ i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
+        (p:Π i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
                    g (setquotpr (smallestAdequateRelation R) (word_gen i)))
         (w:word X) :
           pr1 f (setquotpr (smallestAdequateRelation R) w) =
@@ -362,7 +362,7 @@ Module Presentation.
            { apply agreement_on_gens0. assumption. } } Qed.
   Lemma agreement_on_gens {X I} {R:I->reln X} {M:abgr}
         (f g:Hom_abgr (universalMarkedAbelianGroup R) M) :
-        (∀ i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
+        (Π i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
                    g (setquotpr (smallestAdequateRelation R) (word_gen i)))
           -> f = g.
     intros ? ? ? ? ? ? p. apply Monoid.funEquality.
@@ -416,14 +416,14 @@ Module Product.
     intros a b. apply funextsec; intro i. apply commax. Defined.
   Definition Proj {I} (G:I->abgr) (i:I) : Hom_abgr (make G) (G i).
     exact @Group.Product.Proj. Defined.
-  Definition Map {I} (G:I->abgr) (T:abgr) (g: ∀ i, Hom_abgr T (G i)) :
+  Definition Map {I} (G:I->abgr) (T:abgr) (g: Π i, Hom_abgr T (G i)) :
     Hom_abgr T (make G).
     exact @Group.Product.Fun. Defined.
-  Lemma Eqn {I} (G:I->abgr) (T:abgr) (g: ∀ i, Hom_abgr T (G i))
-           : ∀ i, Proj G i ∘ Map G T g = g i.
+  Lemma Eqn {I} (G:I->abgr) (T:abgr) (g: Π i, Hom_abgr T (G i))
+           : Π i, Proj G i ∘ Map G T g = g i.
     exact @Group.Product.Eqn. Qed.
   Definition UniqueMap {I} (G:I->abgr) (T:abgr) (h h' : Hom_abgr T (make G)) :
-       (∀ i, Proj G i ∘ h = Proj G i ∘ h') -> h = h'.
+       (Π i, Proj G i ∘ h = Proj G i ∘ h') -> h = h'.
     intros ? ? ? ? ? e. apply Monoid.funEquality.
     apply funextsec; intro t. apply funextsec; intro i.
     exact (apevalat t (ap pr1 (e i))). Qed.
@@ -446,21 +446,21 @@ Module Sum.                   (* coproducts *)
     { intro g. apply setquotpr. apply word_gen. exact (i,,g). } { split.
       { intros g h. apply iscompsetquotpr. exact (base (adequacy _) (J_sum _ (i,,(g,,h)))). }
       { apply iscompsetquotpr. exact (base (adequacy _) (J_zero _ i)). } } Defined.
-  Definition Map0 {I} {G:I->abgr} {T:abgr} (f: ∀ i, Hom_abgr (G i) T) :
+  Definition Map0 {I} {G:I->abgr} {T:abgr} (f: Π i, Hom_abgr (G i) T) :
       MarkedAbelianGroup (R G).
     intros. simple refine (make_MarkedAbelianGroup (R G) T _ _).
     { intros [i g]. exact (f i g). }
     { intros [i|[i [g h]]].
       { simpl. apply unitproperty. }
       { simpl. apply addproperty. } } Defined.
-  Definition Map {I} (G:I->abgr) (T:abgr) (f: ∀ i, Hom_abgr (G i) T) :
+  Definition Map {I} (G:I->abgr) (T:abgr) (f: Π i, Hom_abgr (G i) T) :
       Hom_abgr (make G) T.
     intros. exact (thePoint (iscontrMarkedAbelianGroupMap (Map0 f))). Defined.
-  Lemma Eqn {I} (G:I->abgr) (T:abgr) (f: ∀ i, Hom_abgr (G i) T)
-           : ∀ i, Map G T f ∘ Incl G i = f i.
+  Lemma Eqn {I} (G:I->abgr) (T:abgr) (f: Π i, Hom_abgr (G i) T)
+           : Π i, Map G T f ∘ Incl G i = f i.
     intros. apply Monoid.funEquality. reflexivity. Qed.
   Definition UniqueMap {I} (G:I->abgr) (T:abgr) (h h' : Hom_abgr (make G) T) :
-       (∀ i, h ∘ Incl G i = h' ∘ Incl G i) -> h = h'.
+       (Π i, h ∘ Incl G i = h' ∘ Incl G i) -> h = h'.
     intros ? ? ? ? ? e. apply (agreement_on_gens h h').
     { intros [i g]. exact (ap (evalat g) (ap pr1 (e i))). }
   Qed.

--- a/UniMath/Ktheory/AbelianMonoid.v
+++ b/UniMath/Ktheory/AbelianMonoid.v
@@ -13,7 +13,7 @@ Definition finiteOperation0 (X:abmonoid) n (x:stn n->X) : X.
 Proof. (* return (...((x0*x1)*x2)*...)  *)
   intros. induction n as [|n x'].
   { exact (unel _). } { exact ((x' (funcomp (dni_last n) x)) + x (lastelement n)). } Defined.
-Goal ∀ (X:abmonoid) n (x:stn (S n)->X),
+Goal Π (X:abmonoid) n (x:stn (S n)->X),
      finiteOperation0 X (S n) x
   = finiteOperation0 X n (funcomp (dni_last n) x) + x (lastelement n).
 Proof. reflexivity. Qed.
@@ -283,7 +283,7 @@ Abort.
 
 Definition decidable_type (X:UU) := X ⨿ ¬X.
 
-Lemma uniqueness0 (X:abmonoid) n : ∀ I (f g:nelstruct n I) (x:I->X),
+Lemma uniqueness0 (X:abmonoid) n : Π I (f g:nelstruct n I) (x:I->X),
      finiteOperation0 X n (funcomp (pr1 f) x)
   = finiteOperation0 X n (funcomp (pr1 g) x).
 Proof.
@@ -367,16 +367,16 @@ Module Presentation.
 
   Record AdequateRelation {X I} (R:I->reln X) (r : hrel (word X)) :=
     make_AdequateRelation {
-        base: ∀ i, r (lhs (R i)) (rhs (R i));
-        reflex : ∀ w, r w w;
-        symm : ∀ v w, r v w -> r w v;
-        trans : ∀ u v w, r u v -> r v w -> r u w;
-        left_compat : ∀ u v w, r v w -> r (word_op u v) (word_op u w);
-        right_compat: ∀ u v w, r u v -> r (word_op u w) (word_op v w);
-        left_unit : ∀ w, r (word_op word_unit w) w;
-        right_unit : ∀ w, r (word_op w word_unit) w;
-        assoc : ∀ u v w, r (word_op (word_op u v) w) (word_op u (word_op v w));
-        comm : ∀ v w, r (word_op v w) (word_op w v)
+        base: Π i, r (lhs (R i)) (rhs (R i));
+        reflex : Π w, r w w;
+        symm : Π v w, r v w -> r w v;
+        trans : Π u v w, r u v -> r v w -> r u w;
+        left_compat : Π u v w, r v w -> r (word_op u v) (word_op u w);
+        right_compat: Π u v w, r u v -> r (word_op u w) (word_op v w);
+        left_unit : Π w, r (word_op word_unit w) w;
+        right_unit : Π w, r (word_op w word_unit) w;
+        assoc : Π u v w, r (word_op (word_op u v) w) (word_op u (word_op v w));
+        comm : Π v w, r (word_op v w) (word_op w v)
       }.
   Arguments make_AdequateRelation {X I} R r _ _ _ _ _ _ _ _ _ _.
   Arguments base {X I R r} _ _.
@@ -393,7 +393,7 @@ Module Presentation.
 
   Definition smallestAdequateRelation0 {X I} (R:I->reln X) : hrel (word X).
     intros ? ? ? v w.
-    exists (∀ r: hrel (word X), AdequateRelation R r -> r v w).
+    exists (Π r: hrel (word X), AdequateRelation R r -> r v w).
     abstract (apply impred; intro r; apply impred_prop).
   Defined.
   Lemma adequacy {X I} (R:I->reln X) :
@@ -492,7 +492,7 @@ Module Presentation.
     make_MarkedAbelianMonoid {
         m_base :> abmonoid;
         m_mark : X -> m_base;
-        m_reln : ∀ i, evalword (toMarkedPreAbelianMonoid R m_base m_mark) (lhs (R i)) =
+        m_reln : Π i, evalword (toMarkedPreAbelianMonoid R m_base m_mark) (lhs (R i)) =
                            evalword (toMarkedPreAbelianMonoid R m_base m_mark) (rhs (R i)) }.
   Arguments make_MarkedAbelianMonoid {X I} R _ _ _.
   Arguments m_base {X I R} _.
@@ -520,7 +520,7 @@ Module Presentation.
   Record MarkedAbelianMonoidMap {X I} {R:I->reln X} (M N:MarkedAbelianMonoid R) :=
     make_MarkedAbelianMonoidMap {
         map_base :> Hom M N;
-        map_mark : ∀ x, map_base (m_mark M x) = m_mark N x }.
+        map_mark : Π x, map_base (m_mark M x) = m_mark N x }.
   Arguments map_base {X I R M N} m.
   Arguments map_mark {X I R M N} m x.
   Lemma MarkedAbelianMonoidMapEquality {X I} {R:I->reln X} {M N:MarkedAbelianMonoid R}
@@ -578,7 +578,7 @@ Module Presentation.
                 (universalMarkedAbelianMonoid3 R).
   Fixpoint agreement_on_gens0 {X I} {R:I->reln X} {M:abmonoid}
         (f g:Hom (universalMarkedAbelianMonoid R) M)
-        (p:∀ i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
+        (p:Π i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
                    g (setquotpr (smallestAdequateRelation R) (word_gen i)))
         (w:word X) :
           pr1 f (setquotpr (smallestAdequateRelation R) w) =
@@ -598,7 +598,7 @@ Module Presentation.
            { apply agreement_on_gens0. assumption. } } Qed.
   Lemma agreement_on_gens {X I} {R:I->reln X} {M:abmonoid}
         (f g:Hom (universalMarkedAbelianMonoid R) M) :
-        (∀ i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
+        (Π i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
                    g (setquotpr (smallestAdequateRelation R) (word_gen i)))
           -> f = g.
     intros ? ? ? ? ? ? p. apply Monoid.funEquality.

--- a/UniMath/Ktheory/AffineLine.v
+++ b/UniMath/Ktheory/AffineLine.v
@@ -28,33 +28,33 @@ Open Scope hz_scope.
 (** ** Recursion for ℤ *)
 
 Definition ℤRecursionData0 (P:ℤ->Type) (p0:P zero)
-      (IH :∀ n, P(  toℤ n) -> P(  toℤ (S n)))
-      (IH':∀ n, P(- toℤ n) -> P(- toℤ (S n))) := fun
-          f:∀ i, P i =>
+      (IH :Π n, P(  toℤ n) -> P(  toℤ (S n)))
+      (IH':Π n, P(- toℤ n) -> P(- toℤ (S n))) := fun
+          f:Π i, P i =>
             (f zero = p0) ×
-            (∀ n, f(  toℤ (S n)) = IH  n (f (  toℤ n))) ×
-            (∀ n, f(- toℤ (S n)) = IH' n (f (- toℤ n))).
+            (Π n, f(  toℤ (S n)) = IH  n (f (  toℤ n))) ×
+            (Π n, f(- toℤ (S n)) = IH' n (f (- toℤ n))).
 
 Definition ℤRecursionData (P:ℤ->Type)
-      (IH :∀ n, P(  toℤ n) -> P(  toℤ (S n)))
-      (IH':∀ n, P(- toℤ n) -> P(- toℤ (S n))) := fun
-             f:∀ i, P i =>
-               (∀ n, f(  toℤ (S n)) = IH  n (f (  toℤ n))) ×
-               (∀ n, f(- toℤ (S n)) = IH' n (f (- toℤ n))).
+      (IH :Π n, P(  toℤ n) -> P(  toℤ (S n)))
+      (IH':Π n, P(- toℤ n) -> P(- toℤ (S n))) := fun
+             f:Π i, P i =>
+               (Π n, f(  toℤ (S n)) = IH  n (f (  toℤ n))) ×
+               (Π n, f(- toℤ (S n)) = IH' n (f (- toℤ n))).
 
 Lemma ℤRecursionUniq (P:ℤ->Type) (p0:P zero)
-      (IH :∀ n, P(  toℤ n) -> P(  toℤ (S n)))
-      (IH':∀ n, P(- toℤ n) -> P(- toℤ (S n))) :
+      (IH :Π n, P(  toℤ n) -> P(  toℤ (S n)))
+      (IH':Π n, P(- toℤ n) -> P(- toℤ (S n))) :
   iscontr (total2 (ℤRecursionData0 P p0 IH IH')).
 Proof. intros.
        unfold ℤRecursionData0.
        (* use hNatRecursion_weq *)
        apply (iscontrweqb (Y :=
-            Σ f:∀ w, P (negpos w),
+            Σ f:Π w, P (negpos w),
               (f (ii2 O) = p0) ×
-              (∀ n : nat, f (ii2 (S n)) = IH n (f (ii2 n))) ×
+              (Π n : nat, f (ii2 (S n)) = IH n (f (ii2 n))) ×
               (f (ii1 O) = IH' O (f (ii2 O))) ×
-              (∀ n : nat, f (ii1 (S n)) = IH' (S n) (f (ii1 n))))).
+              (Π n : nat, f (ii1 (S n)) = IH' (S n) (f (ii1 n))))).
        { apply (weqbandf (weqonsecbase _ negpos)). intro f.
          simple refine (weqpair _ (gradth _ _ _ _)).
          { intros [h0 [hp hn]]. simple refine (_,,_,,_,,_).
@@ -68,51 +68,51 @@ Proof. intros.
            { apply funextsec; intros [|n']; reflexivity; reflexivity. } }
          { intros [h0 [h1' [hp hn]]]. reflexivity. } }
        intermediate_iscontr (
-             Σ f : (∀ n, P (negpos (ii1 n))) ×
-                 (∀ n, P (negpos (ii2 n))),
+             Σ f : (Π n, P (negpos (ii1 n))) ×
+                 (Π n, P (negpos (ii2 n))),
                 (pr2 f O = p0) ×
-                (∀ n : nat, pr2 f (S n) = IH n (pr2 f n)) ×
+                (Π n : nat, pr2 f (S n) = IH n (pr2 f n)) ×
                 (pr1 f O = IH' O (pr2 f O)) ×
-                (∀ n : nat, pr1 f (S n) = IH' (S n) (pr1 f n))).
+                (Π n : nat, pr1 f (S n) = IH' (S n) (pr1 f n))).
        { apply (weqbandf (weqsecovercoprodtoprod (fun w => P (negpos w)))).
          intro f. apply idweq. }
        intermediate_iscontr (
-              Σ f : (∀ n, P (negpos (ii2 n))) ×
-                    (∀ n, P (negpos (ii1 n))),
+              Σ f : (Π n, P (negpos (ii2 n))) ×
+                    (Π n, P (negpos (ii1 n))),
                 (pr1 f O = p0) ×
-                (∀ n : nat, pr1 f (S n) = IH n (pr1 f n)) ×
+                (Π n : nat, pr1 f (S n) = IH n (pr1 f n)) ×
                 (pr2 f O = IH' O (pr1 f O)) ×
-                (∀ n : nat, pr2 f (S n) = IH' (S n) (pr2 f n))).
+                (Π n : nat, pr2 f (S n) = IH' (S n) (pr2 f n))).
        { apply (weqbandf (weqdirprodcomm _ _)). intro f. apply idweq. }
        intermediate_iscontr (
-                Σ (f2 : ∀ n : nat, P (negpos (ii2 n)))
-                  (f1 : ∀ n : nat, P (negpos (ii1 n))),
+                Σ (f2 : Π n : nat, P (negpos (ii2 n)))
+                  (f1 : Π n : nat, P (negpos (ii1 n))),
                      (f2 O = p0) ×
-                     (∀ n : nat, f2 (S n) = IH n (f2 n)) ×
+                     (Π n : nat, f2 (S n) = IH n (f2 n)) ×
                      (f1 O = IH' O (f2 O)) ×
-                     (∀ n : nat, f1 (S n) = IH' (S n) (f1 n))).
+                     (Π n : nat, f1 (S n) = IH' (S n) (f1 n))).
        { apply weqtotal2asstor. }
        intermediate_iscontr (
-            Σ f2 : ∀ n : nat, P (negpos (ii2 n)),
+            Σ f2 : Π n : nat, P (negpos (ii2 n)),
                  (f2 O = p0) ×
-            Σ f1 : ∀ n : nat, P (negpos (ii1 n)),
-                 (∀ n : nat, f2 (S n) = IH n (f2 n)) ×
+            Σ f1 : Π n : nat, P (negpos (ii1 n)),
+                 (Π n : nat, f2 (S n) = IH n (f2 n)) ×
                  (f1 O = IH' O (f2 O)) ×
-                 (∀ n : nat, f1 (S n) = IH' (S n) (f1 n))).
+                 (Π n : nat, f1 (S n) = IH' (S n) (f1 n))).
        { apply weqfibtototal; intro f2. apply weq_total2_prod. }
        intermediate_iscontr (
-            Σ f2 : ∀ n : nat, P (negpos (ii2 n)),
+            Σ f2 : Π n : nat, P (negpos (ii2 n)),
                  (f2 O = p0) ×
-                 (∀ n : nat, f2 (S n) = IH n (f2 n)) ×
-            Σ f1 : ∀ n : nat, P (negpos (ii1 n)),
+                 (Π n : nat, f2 (S n) = IH n (f2 n)) ×
+            Σ f1 : Π n : nat, P (negpos (ii1 n)),
                  (f1 O = IH' O (f2 O)) ×
-                 (∀ n : nat, f1 (S n) = IH' (S n) (f1 n))).
+                 (Π n : nat, f1 (S n) = IH' (S n) (f1 n))).
        { apply weqfibtototal; intro f2. apply weqfibtototal; intro.
          apply weq_total2_prod. }
        intermediate_iscontr (
-            Σ f2 : ∀ n : nat, P (negpos (ii2 n)),
+            Σ f2 : Π n : nat, P (negpos (ii2 n)),
                  (f2 O = p0) ×
-                 (∀ n : nat, f2 (S n) = IH n (f2 n))).
+                 (Π n : nat, f2 (S n) = IH n (f2 n))).
        { apply weqfibtototal; intro f2. apply weqfibtototal; intro h0.
          apply weqpr1; intro ih2.
          exact (Nat.Uniqueness.hNatRecursionUniq
@@ -123,8 +123,8 @@ Proof. intros.
 Defined.
 
 Lemma A (P:ℤ->Type) (p0:P zero)
-      (IH :∀ n, P(  toℤ n) -> P(  toℤ (S n)))
-      (IH':∀ n, P(- toℤ n) -> P(- toℤ (S n))) :
+      (IH :Π n, P(  toℤ n) -> P(  toℤ (S n)))
+      (IH':Π n, P(- toℤ n) -> P(- toℤ (S n))) :
   weq (total2 (ℤRecursionData0 P p0 IH IH'))
       (@hfiber
          (total2 (ℤRecursionData P IH IH'))
@@ -139,15 +139,15 @@ Proof. intros.
        { intros [[f h] h0]. reflexivity. } Defined.
 
 Lemma ℤRecursion_weq (P:ℤ->Type)
-      (IH :∀ n, P(  toℤ n) -> P(  toℤ (S n)))
-      (IH':∀ n, P(- toℤ n) -> P(- toℤ (S n))) :
+      (IH :Π n, P(  toℤ n) -> P(  toℤ (S n)))
+      (IH':Π n, P(- toℤ n) -> P(- toℤ (S n))) :
   weq (total2 (ℤRecursionData P IH IH')) (P 0).
 Proof. intros. exists (fun f => pr1 f zero). intro p0.
        apply (iscontrweqf (A _ _ _ _)). apply ℤRecursionUniq. Defined.
 
 Lemma ℤRecursion_weq_compute (P:ℤ->Type)
-      (IH :∀ n, P(  toℤ n) -> P(  toℤ (S n)))
-      (IH':∀ n, P(- toℤ n) -> P(- toℤ (S n)))
+      (IH :Π n, P(  toℤ n) -> P(  toℤ (S n)))
+      (IH':Π n, P(- toℤ n) -> P(- toℤ (S n)))
       (fh : total2 (ℤRecursionData P IH IH')) :
   ℤRecursion_weq P IH IH' fh = pr1 fh zero.
 Proof. reflexivity.             (* don't change the proof *)
@@ -155,16 +155,16 @@ Defined.
 
 (** ** Bidirectional recursion for ℤ *)
 
-Definition ℤBiRecursionData (P:ℤ->Type) (IH :∀ i, P(i) -> P(1+i)) :=
-  fun f:∀ i, P i => ∀ i, f(1+i)=IH i (f i).
+Definition ℤBiRecursionData (P:ℤ->Type) (IH :Π i, P(i) -> P(1+i)) :=
+  fun f:Π i, P i => Π i, f(1+i)=IH i (f i).
 
-Definition ℤBiRecursion_weq (P:ℤ->Type) (IH :∀ i, weq (P i) (P(1+i))) :
+Definition ℤBiRecursion_weq (P:ℤ->Type) (IH :Π i, weq (P i) (P(1+i))) :
   weq (total2 (ℤBiRecursionData P IH)) (P 0).
 Proof. intros.
-       assert (k : ∀ n, one + toℤ n = toℤ (S n)).
+       assert (k : Π n, one + toℤ n = toℤ (S n)).
        { intro. rewrite nattohzandS. reflexivity. }
        set (l := fun n : nat => weq_transportf P (k n)).
-       assert (k' : ∀ n, - toℤ n = one + (- toℤ (S n))).
+       assert (k' : Π n, - toℤ n = one + (- toℤ (S n))).
        { intros. unfold one, toℤ. rewrite nattohzand1.
          rewrite nattohzandS. rewrite hzminusplus. rewrite <- (hzplusassoc one).
          rewrite (hzpluscomm one). rewrite hzlminus. rewrite hzplusl0.
@@ -191,7 +191,7 @@ Proof. intros.
            reflexivity. } } Defined.
 
 Definition ℤBiRecursion_weq_compute (P:ℤ->Type)
-           (IH :∀ i, weq (P i) (P(1+i)))
+           (IH :Π i, weq (P i) (P(1+i)))
       (fh : total2 (ℤBiRecursionData P IH)) :
   ℤBiRecursion_weq P IH fh = pr1 fh 0.
 Proof. reflexivity.             (* don't change the proof *)
@@ -204,25 +204,25 @@ Open Scope action_scope.
 (** ** Bidirectional recursion for ℤ-torsors *)
 
 Definition GuidedSection {T:Torsor ℤ}
-           (P:T->Type) (IH:∀ t, weq (P t) (P (one + t))) := fun
+           (P:T->Type) (IH:Π t, weq (P t) (P (one + t))) := fun
      f:Section P =>
-       ∀ t, f (one + t) = IH t (f t).
+       Π t, f (one + t) = IH t (f t).
 
 Definition ℤTorsorRecursion_weq {T:Torsor ℤ} (P:T->Type)
-      (IH:∀ t, weq (P t) (P (one + t))) (t0:T) :
+      (IH:Π t, weq (P t) (P (one + t))) (t0:T) :
   weq (total2 (GuidedSection P IH)) (P t0).
 Proof. intros. exists (fun fh => pr1 fh t0). intro q.
        set (w := triviality_isomorphism T t0).
-       assert (k0 : ∀ i, one + w i = w (1+i)%hz).
+       assert (k0 : Π i, one + w i = w (1+i)%hz).
        { intros. simpl. unfold right_mult, ac_mult. rewrite act_assoc.
          reflexivity. }
        set (l0 := (fun i => eqweqmap (ap P (k0 i)))
-               : ∀ i, weq (P(one + w i)) (P(w(1+i)%hz))).
+               : Π i, weq (P(one + w i)) (P(w(1+i)%hz))).
        assert( e : right_mult t0 zero = t0 ). { apply act_unit. }
-       set (H := fun f => ∀ t : T, f (one + t) = (IH t) (f t)).
+       set (H := fun f => Π t : T, f (one + t) = (IH t) (f t)).
        set ( IH' := (fun i => weqcomp (IH (w i)) (l0 i))
-                    : ∀ i:ℤ, weq (P (w i)) (P (w(1+i)%hz))).
-       set (J := fun f => ∀ i : ℤ, f (1 + i)%hz = (IH' i) (f i)).
+                    : Π i:ℤ, weq (P (w i)) (P (w(1+i)%hz))).
+       set (J := fun f => Π i : ℤ, f (1 + i)%hz = (IH' i) (f i)).
        simple refine (iscontrweqb (@weq_over_sections ℤ T w 0 t0 e P q (e#'q) _ H J _) _).
        { apply transportfbinv. }
        { intro. apply invweq. unfold H,J,maponsec1. simple refine (weqonsec _ _ w _).
@@ -235,13 +235,13 @@ Proof. intros. exists (fun fh => pr1 fh t0). intro q.
 Defined.
 
 Definition ℤTorsorRecursion_compute {T:Torsor ℤ} (P:T->Type)
-      (IH:∀ t, weq (P t) (P (one + t))) t h :
+      (IH:Π t, weq (P t) (P (one + t))) t h :
   ℤTorsorRecursion_weq P IH t h = pr1 h t.
 Proof. reflexivity.             (* don't change the proof *)
 Defined.
 
 Definition ℤTorsorRecursion_inv_compute {T:Torsor ℤ} (P:T->Type)
-      (IH:∀ t, weq (P t) (P (one + t)))
+      (IH:Π t, weq (P t) (P (one + t)))
       (t0:T) (h0:P t0) :
   pr1 (invmap (ℤTorsorRecursion_weq P IH t0) h0) t0 = h0.
 Proof. intros.
@@ -251,7 +251,7 @@ Proof. intros.
                 homotweqinvweq (ℤTorsorRecursion_weq P IH t0) h0). Defined.
 
 Definition ℤTorsorRecursion_transition {T:Torsor ℤ} (P:T->Type)
-      (IH:∀ t, weq (P t) (P (one + t)))
+      (IH:Π t, weq (P t) (P (one + t)))
       (t:T)
       (h:total2 (GuidedSection P IH)) :
   ℤTorsorRecursion_weq P IH (one+t) h
@@ -260,9 +260,9 @@ Definition ℤTorsorRecursion_transition {T:Torsor ℤ} (P:T->Type)
 Proof. intros. rewrite 2!ℤTorsorRecursion_compute. exact (pr2 h t). Defined.
 
 Definition ℤTorsorRecursion_transition_inv {T:Torsor ℤ} (P:T->Type)
-      (IH:∀ t, weq (P t) (P (one + t)))
+      (IH:Π t, weq (P t) (P (one + t)))
       (t:T) :
-  ∀ h0,
+  Π h0,
   invmap (ℤTorsorRecursion_weq P IH t) h0
   =
   invmap (ℤTorsorRecursion_weq P IH (one+t)) (IH t h0).
@@ -273,7 +273,7 @@ Proof. intros.
        rewrite homotinvweqweq. reflexivity. Defined.
 
 Definition ℤTorsorRecursion {T:Torsor ℤ} (P:T->Type)
-      (IH:∀ t, weq (P t) (P (one + t)))
+      (IH:Π t, weq (P t) (P (one + t)))
       (t t':T) :
   weq (P t) (P t').
 Proof. intros.
@@ -294,10 +294,10 @@ Proof. intros.
 
  *)
 
-Definition target_paths {Y} {T:Torsor ℤ} (f:T->Y) := ∀ t, f t=f(one + t).
+Definition target_paths {Y} {T:Torsor ℤ} (f:T->Y) := Π t, f t=f(one + t).
 
 Definition GHomotopy {Y} {T:Torsor ℤ} (f:T->Y) (s:target_paths f) := fun
-        y:Y => Σ h:nullHomotopyFrom f y, ∀ n, h(one + n) = h n @ s n.
+        y:Y => Σ h:nullHomotopyFrom f y, Π n, h(one + n) = h n @ s n.
 
 Definition GuidedHomotopy {Y} {T:Torsor ℤ} (f:T->Y) (s:target_paths f) :=
   total2 (GHomotopy f s).
@@ -319,7 +319,7 @@ Definition GH_equations {Y} {T:Torsor ℤ} (f:T->Y) (s:target_paths f)
            (yhp : GuidedHomotopy f s)
      := pr2 (pr2 yhp)
      : let h := GH_homotopy yhp in
-       ∀ n, h(one + n) = h n @ s n.
+       Π n, h(one + n) = h n @ s n.
 
 Theorem iscontrGuidedHomotopy {Y} (T:Torsor ℤ) (f:T->Y) (s:target_paths f) :
   iscontr (GuidedHomotopy f s).
@@ -334,14 +334,14 @@ Proof. intros. apply (squash_to_prop (torsor_nonempty T)).
        apply iscontrcoconustot. Defined.
 
 Corollary proofirrGuidedHomotopy {Y} (T:Torsor ℤ) (f:T->Y) (s:target_paths f) :
-  ∀ v w : GuidedHomotopy f s, v=w.
+  Π v w : GuidedHomotopy f s, v=w.
 Proof. (* later give a more direct proof *)
        intros. apply proofirrelevancecontr. apply iscontrGuidedHomotopy. Defined.
 
 Definition iscontrGuidedHomotopy_comp_1 {Y} :
   let T := trivialTorsor ℤ in
   let t0 := 0 : T in
-    ∀ (f:T->Y) (s:target_paths f),
+    Π (f:T->Y) (s:target_paths f),
       GH_point (thePoint (iscontrGuidedHomotopy T f s)) = f t0.
 Proof. reflexivity.             (* don't change the proof *)
 Defined.
@@ -349,7 +349,7 @@ Defined.
 Definition iscontrGuidedHomotopy_comp_2 {Y} :
   let T := trivialTorsor ℤ in
   let t0 := 0 : T in
-    ∀ (f:T->Y) (s:target_paths f),
+    Π (f:T->Y) (s:target_paths f),
         (GH_homotopy (thePoint (iscontrGuidedHomotopy T f s)) t0) =
         (idpath (f t0)).
 Proof. intros.
@@ -385,7 +385,7 @@ Defined.
 (* Definition iscontrGuidedHomotopy_comp_3 {Y} : *)
 (*   let T := trivialTorsor ℤ in  *)
 (*   let t0 := 0 : T in *)
-(*     ∀ (f:T->Y) (s:target_paths f), *)
+(*     Π (f:T->Y) (s:target_paths f), *)
 (*       GH_to_cone t0 (thePoint (iscontrGuidedHomotopy T f s)) = f t0,, idpath (f t0). *)
 (* Proof. intros. *)
 
@@ -476,11 +476,11 @@ Proof. intros ? ? ? ? t'.
        exact (makeGuidedHomotopy1 f s t). Defined.
 
 Definition map_path {T:Torsor ℤ} {Y} (f:T->Y) (s:target_paths f) :
-  ∀ t, map f s (squash_element t) = map f s (squash_element (one + t)).
+  Π t, map f s (squash_element t) = map f s (squash_element (one + t)).
 Proof. intros. exact (makeGuidedHomotopy_diagonalPath f s t). Defined.
 
 Definition map_path_check {T:Torsor ℤ} {Y} (f:T->Y) (s:target_paths f) :
-  ∀ t, ∀ p : map f s (squash_element t) =
+  Π t, Π p : map f s (squash_element t) =
                        map f s (squash_element (one + t)),
     ap pr1 p = s t.
 Proof. intros. set (q := map_path f s t). assert (k : q=p).

--- a/UniMath/Ktheory/Bifunctor.v
+++ b/UniMath/Ktheory/Bifunctor.v
@@ -23,7 +23,7 @@ Definition comm_functor_data {I A B:Precategory} :
   := λ D a, functor_data_constr I B (λ i, D ◾ i ◾ a) (λ i j e, D ▭ e ◽ a).
 
 Lemma isfunctor_comm_functor_data {I A B:Precategory} :
-  ∀ (D:[I,[A,B]]) (a:A), is_functor (comm_functor_data D a).
+  Π (D:[I,[A,B]]) (a:A), is_functor (comm_functor_data D a).
 Proof.
   split.
   { unfold functor_idax. intro i; simpl. unfold functor_mor_application.
@@ -115,7 +115,7 @@ Proof.
                 | intro b; simpl; now rewrite id_right, id_left]]) using N. }
 Defined.
 
-Lemma transport_along_funextsec {X:UU} {Y:X->UU} {f g:∀ x, Y x}
+Lemma transport_along_funextsec {X:UU} {Y:X->UU} {f g:Π x, Y x}
       (e:f~g) (x:X) : transportf _ (funextsec _ _ _ e) (f x) = g x.
 Proof.
   unfold funextsec.
@@ -125,8 +125,8 @@ Defined.
 
 Definition Functor_eq_map {A B: Precategory} (F G:[A,B]) :
   F = G ->
-  Σ (ob : ∀ a, F ◾ a = G ◾ a),
-  ∀ a a' f, transportf (λ k, k --> G ◾ a')
+  Σ (ob : Π a, F ◾ a = G ◾ a),
+  Π a a' f, transportf (λ k, k --> G ◾ a')
                        (ob a)
                        (transportf (λ k, F ◾ a --> k)
                                    (ob a')
@@ -145,8 +145,8 @@ Admitted.
 
 Lemma Functor_eq_weq {A B: Precategory} (F G:[A,B]) :
   F = G ≃
-  Σ (ob : ∀ a, F ◾ a = G ◾ a),
-  ∀ a a' f, transportf (λ k, k --> G ◾ a')
+  Σ (ob : Π a, F ◾ a = G ◾ a),
+  Π a a' f, transportf (λ k, k --> G ◾ a')
                        (ob a)
                        (transportf (λ k, F ◾ a --> k)
                                    (ob a')
@@ -156,8 +156,8 @@ Proof.
 Defined.
 
 Lemma Functor_eq {A B: Precategory} {F G:[A,B]}
-      (ob : ∀ a, F ◾ a = G ◾ a)
-      (mor : ∀ a a' f, transportf (λ k, k --> G ◾ a')
+      (ob : Π a, F ◾ a = G ◾ a)
+      (mor : Π a a' f, transportf (λ k, k --> G ◾ a')
                                   (ob a)
                                   (transportf (λ k, F ◾ a --> k)
                                               (ob a')
@@ -184,11 +184,11 @@ Abort.
 (** bifunctors related to representable functors  *)
 
 Definition θ_1 {B C:Precategory} (F : [B, C]) (X : [B, [C^op, SET]]) : hSet
-  := (∀ b, F ◾ b ⇒ X ◾ b) % set.
+  := (Π b, F ◾ b ⇒ X ◾ b) % set.
 
 Definition θ_2 {B C:Precategory} (F : [B, C]) (X : [B, [C^op, SET]])
            (x : θ_1 F X) : hSet
-  := (∀ (b' b:B) (f:b'-->b), x b ⟲ F ▭ f = X ▭ f ⟳ x b' ) % set.
+  := (Π (b' b:B) (f:b'-->b), x b ⟲ F ▭ f = X ▭ f ⟳ x b' ) % set.
 
 Definition θ {B C:Precategory} (F : [B, C]) (X : [B, [C^op, SET]]) : hSet
   := ( Σ x : θ_1 F X, θ_2 F X x ) % set.

--- a/UniMath/Ktheory/Circle.v
+++ b/UniMath/Ktheory/Circle.v
@@ -254,7 +254,7 @@ Proof. intros. assert (p := pr1_GH_weq_compute l).
 
 
 Definition circle_map' {Y:circle->Type} {y:Y(basepoint circle)}
-           (l:circle_loop#y = y) : ∀ c:circle, Y c.
+           (l:circle_loop#y = y) : Π c:circle, Y c.
 Proof. (** (not proved yet) *)
 Abort.
 
@@ -263,7 +263,7 @@ Abort.
  http://arxiv.org/abs/1402.0761 *)
 
 Lemma circle_map_check_paths'
-      (circle_map': ∀ (Y:circle->UU) (y:Y(basepoint circle))
+      (circle_map': Π (Y:circle->UU) (y:Y(basepoint circle))
            (l:circle_loop#y = y) (c:circle), Y c)
       {Y} (f:circle->Y) :
   circle_map (ap f circle_loop) = f .

--- a/UniMath/Ktheory/DirectSum.v
+++ b/UniMath/Ktheory/DirectSum.v
@@ -15,7 +15,7 @@ Require UniMath.Ktheory.RawMatrix.
 Local Open Scope cat.
 
 Definition identity_matrix {C:Precategory} (h:hasZeroMaps C)
-           {I} (d:I -> ob C) (dec : isdeceq I) : ∀ i j, Hom C (d j) (d i).
+           {I} (d:I -> ob C) (dec : isdeceq I) : Π i j, Hom C (d j) (d i).
 Proof. intros. induction (dec i j) as [ eq | ne ].
        { induction eq. apply identity. }
        { apply h. }
@@ -31,11 +31,11 @@ Proof. intros. apply RawMatrix.from_matrix. apply identity_matrix.
 Record DirectSum {C:Precategory} (h:hasZeroMaps C) I (dec : isdeceq I) (c : I -> ob C) :=
   make_DirectSum {
       ds : C;
-      ds_pr : ∀ i, Hom C ds (c i);
-      ds_in : ∀ i, Hom C (c i) ds;
-      ds_id : ∀ i j, ds_pr i ∘ ds_in j = identity_matrix h c dec i j;
-      ds_isprod : ∀ c, isweq (λ f : Hom C c ds, λ i, ds_pr i ∘ f);
-      ds_issum  : ∀ c, isweq (λ f : Hom C ds c, λ i, f ∘ ds_in i) }.
+      ds_pr : Π i, Hom C ds (c i);
+      ds_in : Π i, Hom C (c i) ds;
+      ds_id : Π i j, ds_pr i ∘ ds_in j = identity_matrix h c dec i j;
+      ds_isprod : Π c, isweq (λ f : Hom C c ds, λ i, ds_pr i ∘ f);
+      ds_issum  : Π c, isweq (λ f : Hom C ds c, λ i, f ∘ ds_in i) }.
 Definition toDirectSum {C:Precategory} (h:hasZeroMaps C) {I} (dec : isdeceq I) (d:I -> ob C)
            (B:Sum d) (D:Product d)
            (is: is_isomorphism (identity_map h dec B D)) : DirectSum h I dec d.
@@ -57,6 +57,6 @@ Proof. intros. set (id := identity_map h dec B D).
 Defined.
 Definition FiniteDirectSums (C:Precategory) :=
              Σ h : hasZeroMaps C,
-             ∀ I : FiniteSet,
-             ∀ d : I -> ob C,
+             Π I : FiniteSet,
+             Π d : I -> ob C,
                DirectSum h I (isfinite_isdeceq I (pr2 I)) d.

--- a/UniMath/Ktheory/Equivalences.v
+++ b/UniMath/Ktheory/Equivalences.v
@@ -7,8 +7,8 @@ Require Import UniMath.Foundations.Basics.UnivalenceAxiom.
 Require Import UniMath.Ktheory.Tactics.
 
 Definition Equivalence X Y :=
-  Σ (f:X->Y) (g:Y->X) (p:∀ y, f(g y) = y) (q:∀ x, g(f x) = x),
-      ∀ x, ap f (q x) = p(f x).
+  Σ (f:X->Y) (g:Y->X) (p:Π y, f(g y) = y) (q:Π x, g(f x) = x),
+      Π x, ap f (q x) = p(f x).
 
 Notation "X ≅ Y" := (Equivalence X Y) (at level 60, no associativity) : type_scope.
 
@@ -21,14 +21,14 @@ Coercion Equivalence_toFunction : Equivalence >-> Funclass.
 Definition Equivalence_toInverseFunction {X Y} : X≅Y -> Y->X.
 Proof. intros ? ? f. exact (pr1 (pr2 f)). Defined.
 
-Definition Equivalence_toTargetHomotopy {X Y} (f:Equivalence X Y) : ∀ y, f (Equivalence_toInverseFunction f y) = y
+Definition Equivalence_toTargetHomotopy {X Y} (f:Equivalence X Y) : Π y, f (Equivalence_toInverseFunction f y) = y
   := pr1 (pr2 (pr2 f)).
 
-Definition Equivalence_toSourceHomotopy {X Y} (f:Equivalence X Y) : ∀ x, Equivalence_toInverseFunction f (f x) = x
+Definition Equivalence_toSourceHomotopy {X Y} (f:Equivalence X Y) : Π x, Equivalence_toInverseFunction f (f x) = x
   := pr1 (pr2 (pr2 (pr2 f))).
 
 Definition Equivalence_toAdjointness {X Y} (f:Equivalence X Y)
-  : ∀ x, ap f (Equivalence_toSourceHomotopy f x) = Equivalence_toTargetHomotopy f (f x)
+  : Π x, ap f (Equivalence_toSourceHomotopy f x) = Equivalence_toTargetHomotopy f (f x)
   := pr2 (pr2 (pr2 (pr2 f))).
 
 Lemma transportf_fun_idpath {X Y} {f:X->Y} x x' (w:x = x') (t:f x = f x) :
@@ -145,10 +145,10 @@ Local Notation "p @' q" := (pathscomp0 p q) (only parsing, at level 61, left ass
 Local Arguments idpath {_ _}.
 
 Lemma other_adjoint {X Y} (f : X -> Y) (g : Y -> X)
-      (p : ∀ y : Y, f (g y) = y)
-      (q : ∀ x : X, g (f x) = x)
-      (h : ∀ x : X, ap f (q x) = p (f x)) :
- ∀ y : Y, ap g (p y) = q (g y).
+      (p : Π y : Y, f (g y) = y)
+      (q : Π x : X, g (f x) = x)
+      (h : Π x : X, ap f (q x) = p (f x)) :
+ Π y : Y, ap g (p y) = q (g y).
 Proof. intros. apply pathsinv0.
        intermediate_path (
             !(ap g (p (f (g y))))

--- a/UniMath/Ktheory/Group.v
+++ b/UniMath/Ktheory/Group.v
@@ -60,18 +60,18 @@ Module Presentation.
 
   Record AdequateRelation {X I} (R:I->reln X) (r : hrel (word X)) :=
     make_AdequateRelation {
-        base: ∀ i, r (lhs (R i)) (rhs (R i));
-        reflex : ∀ w, r w w;
-        symm : ∀ v w, r v w -> r w v;
-        trans : ∀ u v w, r u v -> r v w -> r u w;
-        left_compat : ∀ u v w, r v w -> r (word_op u v) (word_op u w);
-        right_compat: ∀ u v w, r u v -> r (word_op u w) (word_op v w);
-        left_unit : ∀ w, r (word_op word_unit w) w;
-        right_unit : ∀ w, r (word_op w word_unit) w;
-        assoc : ∀ u v w, r (word_op (word_op u v) w) (word_op u (word_op v w));
-        inverse_compat : ∀ v w, r v w -> r (word_inv v) (word_inv w);
-        left_inverse : ∀ w, r (word_op (word_inv w) w) word_unit;
-        right_inverse: ∀ w, r (word_op w (word_inv w)) word_unit
+        base: Π i, r (lhs (R i)) (rhs (R i));
+        reflex : Π w, r w w;
+        symm : Π v w, r v w -> r w v;
+        trans : Π u v w, r u v -> r v w -> r u w;
+        left_compat : Π u v w, r v w -> r (word_op u v) (word_op u w);
+        right_compat: Π u v w, r u v -> r (word_op u w) (word_op v w);
+        left_unit : Π w, r (word_op word_unit w) w;
+        right_unit : Π w, r (word_op w word_unit) w;
+        assoc : Π u v w, r (word_op (word_op u v) w) (word_op u (word_op v w));
+        inverse_compat : Π v w, r v w -> r (word_inv v) (word_inv w);
+        left_inverse : Π w, r (word_op (word_inv w) w) word_unit;
+        right_inverse: Π w, r (word_op w (word_inv w)) word_unit
       }.
   Arguments make_AdequateRelation {X I} R r _ _ _ _ _ _ _ _ _ _ _ _.
   Arguments base {X I R r} _ _.
@@ -88,7 +88,7 @@ Module Presentation.
 
   Definition smallestAdequateRelation0 {X I} (R:I->reln X) : hrel (word X).
     intros ? ? ? v w.
-    exists (∀ r: hrel (word X), AdequateRelation R r -> r v w).
+    exists (Π r: hrel (word X), AdequateRelation R r -> r v w).
     abstract (apply impred; intro r; apply impred_prop).
   Defined.
   Lemma adequacy {X I} (R:I->reln X) :
@@ -168,7 +168,7 @@ Module Presentation.
          apply (squash_to_prop (lift R w') ig); intros [w []].
          exact (iscompsetquotpr e _ _ (fun r ra => assoc R r ra u v w)). Qed.
   Lemma is_left_inverse_univ_binop {X I} (R:I->reln X) :
-    ∀ w:setquot (smallestAdequateRelation0 R),
+    Π w:setquot (smallestAdequateRelation0 R),
       univ_binop R (univ_inverse R w) w =
       setquotpr (smallestAdequateRelation R) word_unit.
   Proof. intros. isaprop_goal ig. { apply setproperty. }
@@ -176,7 +176,7 @@ Module Presentation.
     exact (iscompsetquotpr (smallestAdequateRelation R) _ _
                            (fun r ra => left_inverse R r ra v)). Qed.
   Lemma is_right_inverse_univ_binop {X I} (R:I->reln X) :
-    ∀ w:setquot (smallestAdequateRelation0 R),
+    Π w:setquot (smallestAdequateRelation0 R),
       univ_binop R w (univ_inverse R w) =
       setquotpr (smallestAdequateRelation R) word_unit.
   Proof. intros. isaprop_goal ig. { apply setproperty. }
@@ -209,7 +209,7 @@ Module Presentation.
     make_MarkedGroup {
         m_base :> gr;
         m_mark : X -> m_base;
-        m_reln : ∀ i, evalword (toMarkedPreGroup R m_base m_mark) (lhs (R i)) =
+        m_reln : Π i, evalword (toMarkedPreGroup R m_base m_mark) (lhs (R i)) =
                            evalword (toMarkedPreGroup R m_base m_mark) (rhs (R i)) }.
   Arguments make_MarkedGroup {X I} R _ _ _.
   Arguments m_base {X I R} _.
@@ -237,7 +237,7 @@ Module Presentation.
   Record MarkedGroupMap {X I} {R:I->reln X} (M N:MarkedGroup R) :=
     make_MarkedGroupMap {
         map_base :> Hom M N;
-        map_mark : ∀ x, map_base (m_mark M x) = m_mark N x }.
+        map_mark : Π x, map_base (m_mark M x) = m_mark N x }.
   Arguments map_base {X I R M N} m.
   Arguments map_mark {X I R M N} m x.
   Lemma MarkedGroupMapEquality {X I} {R:I->reln X} {M N:MarkedGroup R}
@@ -303,7 +303,7 @@ Module Presentation.
                 (universalMarkedGroup3 R).
   Fixpoint agreement_on_gens0 {X I} {R:I->reln X} {M:gr}
         (f g:Hom (universalMarkedGroup R) M)
-        (p:∀ i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
+        (p:Π i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
                    g (setquotpr (smallestAdequateRelation R) (word_gen i)))
         (w:word X) :
           pr1 f (setquotpr (smallestAdequateRelation R) w) =
@@ -326,7 +326,7 @@ Module Presentation.
            { apply agreement_on_gens0. assumption. } } Qed.
   Lemma agreement_on_gens {X I} {R:I->reln X} {M:gr}
         (f g:Hom (universalMarkedGroup R) M) :
-        (∀ i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
+        (Π i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
                    g (setquotpr (smallestAdequateRelation R) (word_gen i)))
           -> f = g.
     intros ? ? ? ? ? ? p. apply Monoid.funEquality.
@@ -376,10 +376,10 @@ Module Product.
     - intro y. apply funextsec; intro i. apply grrinvax. Defined.
   Definition Proj {I} (X:I->gr) (i:I) : Hom (make X) (X i).
     intros. exact (Monoid.Product.Proj X i). Defined.
-  Definition Fun {I} (X:I->gr) (T:gr) (g: ∀ i, Hom T (X i)) : Hom T (make X).
+  Definition Fun {I} (X:I->gr) (T:gr) (g: Π i, Hom T (X i)) : Hom T (make X).
     intros. exact (Monoid.Product.Fun X T g). Defined.
-  Definition Eqn {I} (X:I->gr) (T:gr) (g: ∀ i, Hom T (X i))
-             : ∀ i, Proj X i ∘ Fun X T g = g i.
+  Definition Eqn {I} (X:I->gr) (T:gr) (g: Π i, Hom T (X i))
+             : Π i, Proj X i ∘ Fun X T g = g i.
     intros. apply Monoid.funEquality. reflexivity. Qed.
 End Product.
 Module Free.

--- a/UniMath/Ktheory/GroupAction.v
+++ b/UniMath/Ktheory/GroupAction.v
@@ -78,16 +78,16 @@ Definition action_op G X := G -> X -> X.
 Record ActionStructure (G:gr) (X:hSet) :=
   make {
       act_mult : action_op G X;
-      act_unit : ∀ x, act_mult (unel _) x = x;
-      act_assoc : ∀ g h x, act_mult (op g h) x = act_mult g (act_mult h x)
+      act_unit : Π x, act_mult (unel _) x = x;
+      act_assoc : Π g h x, act_mult (op g h) x = act_mult g (act_mult h x)
     }.
 Arguments act_mult {G _} _ g x.
 
 Module Pack.
   Definition ActionStructure' (G:gr) (X:hSet) :=
          Σ act_mult : action_op G X,
-         Σ act_unit : ∀ x, act_mult (unel _) x = x,
-      (* act_assoc : *) ∀ g h x, act_mult (op g h) x = act_mult g (act_mult h x).
+         Σ act_unit : Π x, act_mult (unel _) x = x,
+      (* act_assoc : *) Π g h x, act_mult (op g h) x = act_mult g (act_mult h x).
   Definition pack {G:gr} {X:hSet} : ActionStructure' G X -> ActionStructure G X
     := fun ac => make G X (pr1 ac) (pr1 (pr2 ac)) (pr2 (pr2 ac)).
   Definition unpack {G:gr} {X:hSet} : ActionStructure G X -> ActionStructure' G X
@@ -124,13 +124,13 @@ Definition ac_mult {G:gr} (X:Action G) := act_mult (pr2 X).
 Delimit Scope action_scope with action.
 Local Notation "g * x" := (ac_mult _ g x) : action_scope.
 Open Scope action_scope.
-Definition ac_assoc {G:gr} (X:Action G) := act_assoc _ _ (pr2 X) : ∀ g h x, (op g h)*x = g*(h*x).
+Definition ac_assoc {G:gr} (X:Action G) := act_assoc _ _ (pr2 X) : Π g h x, (op g h)*x = g*(h*x).
 
 Definition right_mult {G:gr} {X:Action G} (x:X) := fun g => g*x.
 Definition left_mult {G:gr} {X:Action G} (g:G) := fun x:X => g*x.
 
 Definition is_equivariant {G:gr} {X Y:Action G} (f:X->Y) :=
-  ∀ g x, f (g*x) = g*(f x).
+  Π g x, f (g*x) = g*(f x).
 
 Definition is_equivariant_isaprop {G:gr} {X Y:Action G} (f:X->Y) :
   isaprop (is_equivariant f).
@@ -270,7 +270,7 @@ Proof. intros. exact (apevalat x (ap pr1weq
 (** ** Torsors *)
 
 Definition is_torsor {G:gr} (X:Action G) :=
-  nonempty X × ∀ x:X, isweq (right_mult x).
+  nonempty X × Π x:X, isweq (right_mult x).
 
 Lemma is_torsor_isaprop {G:gr} (X:Action G) : isaprop (is_torsor X).
 Proof. intros. apply isapropdirprod. { apply propproperty. }

--- a/UniMath/Ktheory/Halfline.v
+++ b/UniMath/Ktheory/Halfline.v
@@ -6,10 +6,10 @@ Require UniMath.CategoryTheory.precategories.
 Require UniMath.Ktheory.Nat.
 Notation ℕ := nat.
 
-Definition target_paths {Y} (f:ℕ->Y) := ∀ n, f n=f(S n).
+Definition target_paths {Y} (f:ℕ->Y) := Π n, f n=f(S n).
 
 Definition gHomotopy {Y} (f:ℕ->Y) (s:target_paths f) := fun
-     y:Y => Σ (h:nullHomotopyFrom f y), ∀ n, h(S n) = h n @ s n.
+     y:Y => Σ (h:nullHomotopyFrom f y), Π n, h(S n) = h n @ s n.
 
 Definition GuidedHomotopy {Y} (f:ℕ->Y) (s:target_paths f) :=
   total2 (gHomotopy f s).
@@ -38,12 +38,12 @@ Proof. intros ? ? ? r. apply (squash_to_prop r).
          { exact (transportf (gHomotopy f s) (s n) IHn). } } Defined.
 
 Definition map_path {Y} {f:ℕ->Y} (s:target_paths f) :
-  ∀ n, map s (squash_element n) = map s (squash_element (S n)).
+  Π n, map s (squash_element n) = map s (squash_element (S n)).
 Proof. intros. apply (total2_paths2 (s n)).
        simpl. reflexivity. Defined.
 
 Definition map_path_check {Y} {f:ℕ->Y} (s:target_paths f) (n:ℕ) :
-  ∀ p : map s (squash_element n) = map s (squash_element (S n)),
+  Π p : map s (squash_element n) = map s (squash_element (S n)),
     ap pr1 p = s n.
 Proof. intros. set (q := map_path s n).
        assert (path_inverse_to_right : q=p).

--- a/UniMath/Ktheory/Interval.v
+++ b/UniMath/Ktheory/Interval.v
@@ -16,8 +16,8 @@ Proof. intros ? ? ? e. set (f := fun t:bool => if t then y else y').
        truncation, but notice that propositional truncation uses functional
        extensionality for functions, already. *)
 
-Definition funextsec2 X (Y:X->Type) (f g:∀ x,Y x) :
-           (∀ x, f x = g x) -> f = g.
+Definition funextsec2 X (Y:X->Type) (f g:Π x,Y x) :
+           (Π x, f x = g x) -> f = g.
 Proof. intros ? ? ? ? e.
        exact (maponpaths (fun h x => interval_map (e x) h) interval_path).
 Defined.

--- a/UniMath/Ktheory/Magma.v
+++ b/UniMath/Ktheory/Magma.v
@@ -25,15 +25,15 @@ Module Product.
     intros.
     exists (Section X,,i1 X). exact (fun v w i => v i * w i). Defined.
   (** the projection maps *)
-  Definition Proj {I} (X:I->setwithbinop) : ∀ i:I, Hom (make X) (X i).
+  Definition Proj {I} (X:I->setwithbinop) : Π i:I, Hom (make X) (X i).
     intros. exists (fun y => y i). intros a b. reflexivity. Defined.
   (** the universal map *)
   Definition Fun {I} (X:I->setwithbinop) (T:setwithbinop)
-             (g: ∀ i, Hom T (X i))
+             (g: Π i, Hom T (X i))
              : Hom T (make X).
     intros. exists (fun t i => g i t).
     intros t u. apply funextsec; intro i. apply (pr2 (g i)). Defined.
-  Definition Eqn {I} (X:I->setwithbinop) (T:setwithbinop) (g: ∀ i, Hom T (X i))
-             : ∀ i, Proj X i ∘ Fun X T g = g i.
+  Definition Eqn {I} (X:I->setwithbinop) (T:setwithbinop) (g: Π i, Hom T (X i))
+             : Π i, Proj X i ∘ Fun X T g = g i.
     intros. apply funEquality. reflexivity. Qed.
 End Product.

--- a/UniMath/Ktheory/MetricTree.v
+++ b/UniMath/Ktheory/MetricTree.v
@@ -14,11 +14,11 @@ Record Tree :=
   make {
       mt_set:> Type;
       mt_dist: mt_set -> mt_set -> nat;
-      mt_refl: ∀ x, mt_dist x x = 0;
-      mt_anti: ∀ x y, mt_dist x y = 0 -> x = y;
-      mt_symm: ∀ x y, mt_dist x y = mt_dist y x;
-      mt_trans: ∀ x y z, mt_dist x z <= mt_dist x y + mt_dist y z;
-      mt_step: ∀ x z, x != z ->
+      mt_refl: Π x, mt_dist x x = 0;
+      mt_anti: Π x y, mt_dist x y = 0 -> x = y;
+      mt_symm: Π x y, mt_dist x y = mt_dist y x;
+      mt_trans: Π x y z, mt_dist x z <= mt_dist x y + mt_dist y z;
+      mt_step: Π x z, x != z ->
                       Σ y, (S (mt_dist x y) = mt_dist x z) × (mt_dist y z = 1)
     }.
 
@@ -37,10 +37,10 @@ Definition step (T:Tree) {x z:T} (ne:x != z) : T := pr1 (mt_step _ x z ne).
 
 Definition tree_induction (T:Tree) (x:T) (P:T->Type)
            (p0 : P x)
-           (pn : ∀ z (ne:x != z), P (step T ne) -> P z) :
-  ∀ z, P z.
+           (pn : Π z (ne:x != z), P (step T ne) -> P z) :
+  Π z, P z.
 Proof. intros ? ? ? ? ?.
-       assert(d_ind : ∀ n z, mt_dist _ x z = n -> P z).
+       assert(d_ind : Π n z, mt_dist _ x z = n -> P z).
        { intros ?.
          induction n as [|n IH].
          { intros. assert (k:x=z).

--- a/UniMath/Ktheory/Monoid.v
+++ b/UniMath/Ktheory/Monoid.v
@@ -62,9 +62,9 @@ Module Presentation'.
   Definition make_reln {X} : word X -> word X -> reln X := fun v w => v,,w.
 
   Definition isAdequateRelation {X I} (R:I->reln X) (r : eqrel (word X)) :=
-        (* base         *) (∀ i, r (lhs (R i)) (rhs (R i))) ×
-        (* left_compat  *) (∀ u v w, r v w -> r (word_op u v) (word_op u w)) ×
-        (* right_compat *) (∀ u v w, r u v -> r (word_op u w) (word_op v w)).
+        (* base         *) (Π i, r (lhs (R i)) (rhs (R i))) ×
+        (* left_compat  *) (Π u v w, r v w -> r (word_op u v) (word_op u w)) ×
+        (* right_compat *) (Π u v w, r u v -> r (word_op u w) (word_op v w)).
   Definition base         {X I} {R:I->reln X} {r} (ad : isAdequateRelation R r) := pr1 ad.
   Definition left_compat  {X I} {R:I->reln X} {r} (ad : isAdequateRelation R r) := pr1(pr2 ad).
   Definition right_compat {X I} {R:I->reln X} {r} (ad : isAdequateRelation R r) := pr2(pr2 ad).
@@ -79,7 +79,7 @@ Module Presentation'.
     simple refine (_,,_).
     { simple refine (_,,_).
       { intros v w.
-        exists (∀ r, isAdequateRelation R r -> r v w).
+        exists (Π r, isAdequateRelation R r -> r v w).
         apply impred; intros r; apply impred_prop. }
       { simple refine (_,,_).
         { simple refine (_,,_).
@@ -229,15 +229,15 @@ Module Presentation.
 
   Record AdequateRelation {X I} (R:I->reln X) (r : hrel (word X)) :=
     make_AdequateRelation {
-        base: ∀ i, r (lhs (R i)) (rhs (R i));
-        reflex : ∀ w, r w w;
-        symm : ∀ v w, r v w -> r w v;
-        trans : ∀ u v w, r u v -> r v w -> r u w;
-        left_compat : ∀ u v w, r v w -> r (word_op u v) (word_op u w);
-        right_compat: ∀ u v w, r u v -> r (word_op u w) (word_op v w);
-        left_unit : ∀ w, r (word_op word_unit w) w;
-        right_unit : ∀ w, r (word_op w word_unit) w;
-        assoc : ∀ u v w, r (word_op (word_op u v) w) (word_op u (word_op v w))
+        base: Π i, r (lhs (R i)) (rhs (R i));
+        reflex : Π w, r w w;
+        symm : Π v w, r v w -> r w v;
+        trans : Π u v w, r u v -> r v w -> r u w;
+        left_compat : Π u v w, r v w -> r (word_op u v) (word_op u w);
+        right_compat: Π u v w, r u v -> r (word_op u w) (word_op v w);
+        left_unit : Π w, r (word_op word_unit w) w;
+        right_unit : Π w, r (word_op w word_unit) w;
+        assoc : Π u v w, r (word_op (word_op u v) w) (word_op u (word_op v w))
       }.
   Arguments make_AdequateRelation {X I} R r _ _ _ _ _ _ _ _ _.
   Arguments base {X I R r} _ _.
@@ -254,7 +254,7 @@ Module Presentation.
 
   Definition smallestAdequateRelation0 {X I} (R:I->reln X) : hrel (word X).
     intros ? ? ? v w.
-    exists (∀ r: hrel (word X), AdequateRelation R r -> r v w).
+    exists (Π r: hrel (word X), AdequateRelation R r -> r v w).
     abstract (apply impred; intro r; apply impred_prop).
   Defined.
   Lemma adequacy {X I} (R:I->reln X) :
@@ -346,7 +346,7 @@ Module Presentation.
     make_MarkedMonoid {
         m_base :> monoid;
         m_mark : X -> m_base;
-        m_reln : ∀ i, evalword (toMarkedPreMonoid R m_base m_mark) (lhs (R i)) =
+        m_reln : Π i, evalword (toMarkedPreMonoid R m_base m_mark) (lhs (R i)) =
                            evalword (toMarkedPreMonoid R m_base m_mark) (rhs (R i)) }.
   Arguments make_MarkedMonoid {X I} R _ _ _.
   Arguments m_base {X I R} _.
@@ -371,7 +371,7 @@ Module Presentation.
   Record MarkedMonoidMap {X I} {R:I->reln X} (M N:MarkedMonoid R) :=
     make_MarkedMonoidMap {
         map_base :> Hom M N;
-        map_mark : ∀ x, map_base (m_mark M x) = m_mark N x }.
+        map_mark : Π x, map_base (m_mark M x) = m_mark N x }.
   Arguments map_base {X I R M N} m.
   Arguments map_mark {X I R M N} m x.
   Lemma MarkedMonoidMapEquality {X I} {R:I->reln X} {M N:MarkedMonoid R}
@@ -429,7 +429,7 @@ Defined.
                 (universalMarkedMonoid3 R).
   Fixpoint agreement_on_gens0 {X I} {R:I->reln X} {M:monoid}
         (f g:Hom (universalMarkedMonoid R) M)
-        (p:∀ i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
+        (p:Π i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
                    g (setquotpr (smallestAdequateRelation R) (word_gen i)))
         (w:word X) :
           pr1 f (setquotpr (smallestAdequateRelation R) w) =
@@ -449,7 +449,7 @@ Defined.
            { apply agreement_on_gens0. assumption. } } Qed.
   Lemma agreement_on_gens {X I} {R:I->reln X} {M:monoid}
         (f g:Hom (universalMarkedMonoid R) M) :
-        (∀ i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
+        (Π i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
                    g (setquotpr (smallestAdequateRelation R) (word_gen i)))
           -> f = g.
     intros ? ? ? ? ? ? p. apply funEquality.
@@ -506,13 +506,13 @@ Module Product.
   Definition Proj {I} (X:I->monoid) (i:I) : Hom (make X) (X i).
     intros. exists (pr1 (Magma.Product.Proj X i)). split.
     exact (pr2 (Magma.Product.Proj X i)). simpl. reflexivity. Defined.
-  Definition Fun {I} (X:I->monoid) (T:monoid) (g: ∀ i, Hom T (X i))
+  Definition Fun {I} (X:I->monoid) (T:monoid) (g: Π i, Hom T (X i))
              : Hom T (make X).
     intros.  exists (pr1 (Magma.Product.Fun X T g)).
     exists (pr2 (Magma.Product.Fun X T g)). apply funextsec; intro i.
     exact (pr2 (pr2 (g i))). Defined.
-  Definition Eqn {I} (X:I->monoid) (T:monoid) (g: ∀ i, Hom T (X i))
-             : ∀ i, Proj X i ∘ Fun X T g = g i.
+  Definition Eqn {I} (X:I->monoid) (T:monoid) (g: Π i, Hom T (X i))
+             : Π i, Proj X i ∘ Fun X T g = g i.
     intros. apply funEquality. reflexivity. Qed.
   Lemma issurjective_projection {I} (X:I->monoid) (i:I) :
     isdeceq I -> issurjective (Proj X i).

--- a/UniMath/Ktheory/MoreEquivalences.v
+++ b/UniMath/Ktheory/MoreEquivalences.v
@@ -29,7 +29,7 @@ Definition weq_pathscomp0r {X} x {y z:X} (p:y = z) : weq (x = y) (x = z).
 Proof. intros. exact (weqpair _ (isweqpathscomp0r _ p)). Defined.
 
 Definition iscontrretract_compute {X Y} (p:X->Y) (s:Y->X)
-           (eps:∀ y : Y, p (s y) = y) (is:iscontr X) :
+           (eps:Π y : Y, p (s y) = y) (is:iscontr X) :
   thePoint (iscontrretract p s eps is) = p (thePoint is).
 Proof. intros. unfold iscontrretract. destruct is as [ctr uni].
        simpl. reflexivity. Defined.
@@ -40,25 +40,25 @@ Proof. intros. unfold iscontrweqb. rewrite iscontrretract_compute.
        reflexivity. Defined.
 
 Definition compute_iscontrweqb_weqfibtototal_1 {T} {P Q:T->Type}
-           (f:∀ t, weq (P t) (Q t))
+           (f:Π t, weq (P t) (Q t))
            (is:iscontr (total2 Q)) :
   pr1 (thePoint (iscontrweqb (weqfibtototal P Q f) is)) = pr1 (thePoint is).
 Proof. intros. destruct is as [ctr uni]. reflexivity. Defined.
 
 Definition compute_pr1_invmap_weqfibtototal {T} {P Q:T->Type}
-           (f:∀ t, weq (P t) (Q t))
+           (f:Π t, weq (P t) (Q t))
            (w:total2 Q) :
   pr1 (invmap (weqfibtototal P Q f) w) = pr1 w.
 Proof. intros. reflexivity. Defined.
 
 Definition compute_pr2_invmap_weqfibtototal {T} {P Q:T->Type}
-           (f:∀ t, weq (P t) (Q t))
+           (f:Π t, weq (P t) (Q t))
            (w:total2 Q) :
   pr2 (invmap (weqfibtototal P Q f) w) = invmap (f (pr1 w)) (pr2 w).
 Proof. intros. reflexivity. Defined.
 
 Definition compute_iscontrweqb_weqfibtototal_3 {T} {P Q:T->Type}
-           (f:∀ t, weq (P t) (Q t))
+           (f:Π t, weq (P t) (Q t))
            (is:iscontr (total2 Q)) :
   ap pr1 (iscontrweqb_compute (weqfibtototal P Q f) is)
   =
@@ -69,11 +69,11 @@ Definition iscontrcoconustot_comp {X} {x:X} :
   thePoint (iscontrcoconustot X x) = x,,idpath x.
 Proof. reflexivity. Defined.
 
-Definition funfibtototal {X} (P Q:X->Type) (f:∀ x:X, P x -> Q x) :
+Definition funfibtototal {X} (P Q:X->Type) (f:Π x:X, P x -> Q x) :
   total2 P -> total2 Q.
 Proof. intros ? ? ? ? [x p]. exact (x,,f x p). Defined.
 
-Definition weqfibtototal_comp {X} (P Q:X->Type) (f:∀ x:X, weq (P x) (Q x)) :
+Definition weqfibtototal_comp {X} (P Q:X->Type) (f:Π x:X, weq (P x) (Q x)) :
   invmap (weqfibtototal P Q f) = funfibtototal Q P (fun x => invmap (f x)).
 Proof. intros. apply funextsec; intros [x q]. reflexivity. Defined.
 
@@ -86,7 +86,7 @@ Definition eqweqmapap_inv' {T} (P:T->Type) {t u:T} (e:t = u) (p:P t) :
 Proof. intros. destruct e. reflexivity. Defined.
 
 Definition weqpr1_irr_sec {X} {P:X->Type}
-           (irr:∀ x (p q:P x), p = q) (sec:Section P) : weq (total2 P) X.
+           (irr:Π x (p q:P x), p = q) (sec:Section P) : weq (total2 P) X.
 (* compare with weqpr1 *)
 Proof. intros.
        set (isc := fun x => iscontraprop1 (invproofirrelevance _ (irr x)) (sec x)).
@@ -97,7 +97,7 @@ Proof. intros.
        { intros [x p]. simpl. apply pair_path_in2_comp1. } Defined.
 
 Definition invweqpr1_irr_sec {X} {P:X->Type}
-           (irr:∀ x (p q:P x), p = q) (sec:Section P) : X ≃ (total2 P).
+           (irr:Π x (p q:P x), p = q) (sec:Section P) : X ≃ (total2 P).
 (* compare with weqpr1 *)
 Proof. intros.
        set (isc := fun x => iscontraprop1 (invproofirrelevance _ (irr x)) (sec x)).
@@ -110,12 +110,12 @@ Proof. intros.
          reflexivity. } Defined.
 
 Definition homotinvweqweq' {X} {P:X->Type}
-           (irr:∀ x (p q:P x), p = q) (s:Section P) (w:total2 P) :
+           (irr:Π x (p q:P x), p = q) (s:Section P) (w:total2 P) :
   invmap (weqpr1_irr_sec irr s) (weqpr1_irr_sec irr s w) = w.
 Proof. intros ? ? ? ? [x p]. apply pair_path_in2. apply irr. Defined.
 
 Definition homotinvweqweq'_comp {X} {P:X->Type}
-           (irr:∀ x (p q:P x), p = q) (sec:Section P)
+           (irr:Π x (p q:P x), p = q) (sec:Section P)
            (x:X) (p:P x) :
   let f := weqpr1_irr_sec irr sec in
   let w := x,,p in
@@ -127,7 +127,7 @@ Proof. reflexivity.             (* don't change the proof *)
 Defined.
 
 Definition homotinvweqweq_comp {X} {P:X->Type}
-           (irr:∀ x (p q:P x), p = q) (sec:Section P)
+           (irr:Π x (p q:P x), p = q) (sec:Section P)
            (x:X) (p:P x) :
   let f := weqpr1_irr_sec irr sec in
   let w := x,,p in
@@ -140,7 +140,7 @@ Proof.
 Abort.
 
 Definition homotinvweqweq_comp_3 {X} {P:X->Type}
-           (irr:∀ x (p q:P x), p = q) (sec:Section P)
+           (irr:Π x (p q:P x), p = q) (sec:Section P)
            (x:X) (p:P x) :
   let f := weqpr1_irr_sec irr sec in
   let g := invweqpr1_irr_sec irr sec in
@@ -162,7 +162,7 @@ Proof. intros. destruct ni, mi, l. simpl. rewrite pathscomp0rid. reflexivity.
 Defined.
 
 Definition loop_correspondence' {X Y} {P:X->Type}
-           (irr:∀ x (p q:P x), p = q) (sec:Section P)
+           (irr:Π x (p q:P x), p = q) (sec:Section P)
            (g:total2 P->Y)
            {w w':total2 P} {l:w = w'}
            {m:weqpr1_irr_sec irr sec w = weqpr1_irr_sec irr sec w'} (mi:ap (weqpr1_irr_sec irr sec) l = m)

--- a/UniMath/Ktheory/Nat.v
+++ b/UniMath/Ktheory/Nat.v
@@ -14,10 +14,10 @@ Definition ℕ := nat.
 
 Module Uniqueness.
 
-  Lemma helper_A (P:nat->Type) (p0:P 0) (IH:∀ n, P n->P(S n))
-        (f:∀ n, P n) :
-    weq (∀ n, f n = nat_rect P p0 IH n)
-        (f 0=p0 × ∀ n, f(S n)=IH n (f n)).
+  Lemma helper_A (P:nat->Type) (p0:P 0) (IH:Π n, P n->P(S n))
+        (f:Π n, P n) :
+    weq (Π n, f n = nat_rect P p0 IH n)
+        (f 0=p0 × Π n, f(S n)=IH n (f n)).
   Proof. intros. simple refine (_,,gradth _ _ _ _).
          { intros h. split.
            { exact (h 0). } { intros. exact (h (S n) @ ap (IH n) (! h n)). } }
@@ -32,29 +32,29 @@ Module Uniqueness.
            rewrite <- path_assoc. rewrite <- maponpathscomp0. rewrite pathsinv0r.
            apply pathscomp0rid. } Defined.
 
-  Lemma helper_B (P:nat->Type) (p0:P 0) (IH:∀ n, P n->P(S n))
-        (f:∀ n, P n) :
+  Lemma helper_B (P:nat->Type) (p0:P 0) (IH:Π n, P n->P(S n))
+        (f:Π n, P n) :
     weq (f = nat_rect P p0 IH)
-        ((f 0=p0) × (∀ n, f(S n)=IH n (f n))).
+        ((f 0=p0) × (Π n, f(S n)=IH n (f n))).
   Proof. intros.
          exact (weqcomp (weqtoforallpaths _ _ _) (helper_A _ _ _ _)). Defined.
 
-  Lemma helper_C (P:nat->Type) (p0:P 0) (IH:∀ n, P n->P(S n)) :
-    (Σ f:∀ n, P n, f = nat_rect P p0 IH)
+  Lemma helper_C (P:nat->Type) (p0:P 0) (IH:Π n, P n->P(S n)) :
+    (Σ f:Π n, P n, f = nat_rect P p0 IH)
       ≃
-    (Σ f:∀ n, P n, f 0=p0 × ∀ n, f(S n)=IH n (f n)).
+    (Σ f:Π n, P n, f 0=p0 × Π n, f(S n)=IH n (f n)).
   Proof. intros. apply weqfibtototal. intros f. apply helper_B. Defined.
 
-  Lemma hNatRecursionUniq (P:nat->Type) (p0:P 0) (IH:∀ n, P n->P(S n)) :
-    ∃! (f:∀ n, P n), f 0=p0 × ∀ n, f(S n) = IH n (f n).
+  Lemma hNatRecursionUniq (P:nat->Type) (p0:P 0) (IH:Π n, P n->P(S n)) :
+    ∃! (f:Π n, P n), f 0=p0 × Π n, f(S n) = IH n (f n).
   Proof. intros. exact (iscontrweqf (helper_C _ _ _) (iscontrcoconustot _ _)).
   Defined.
 
-  Lemma helper_D (P:nat->Type) (p0:P 0) (IH:∀ n, P n->P(S n)) :
-     (Σ f:∀ n, P n, (f 0=p0) × (∀ n, f(S n)=IH n (f n)))
+  Lemma helper_D (P:nat->Type) (p0:P 0) (IH:Π n, P n->P(S n)) :
+     (Σ f:Π n, P n, (f 0=p0) × (Π n, f(S n)=IH n (f n)))
        ≃
         (@hfiber
-           (Σ (f:∀ n, P n), ∀ n, f(S n)=IH n (f n))
+           (Σ (f:Π n, P n), Π n, f(S n)=IH n (f n))
            (P 0)
            (fun fh => pr1 fh 0)
            p0).
@@ -65,8 +65,8 @@ Module Uniqueness.
          { intros [[f h'] h0]. reflexivity. }
   Defined.
 
-  Lemma hNatRecursion_weq (P:nat->Type) (IH:∀ n, P n->P(S n)) :
-    weq (total2 (fun f:∀ n, P n => ∀ n, f(S n)=IH n (f n))) (P 0).
+  Lemma hNatRecursion_weq (P:nat->Type) (IH:Π n, P n->P(S n)) :
+    weq (total2 (fun f:Π n, P n => Π n, f(S n)=IH n (f n))) (P 0).
   Proof. intros. exists (fun f => pr1 f 0). intro p0.
          apply (iscontrweqf (helper_D _ _ _)). apply hNatRecursionUniq.
   Defined.
@@ -88,7 +88,7 @@ Module Discern.
       | S m, 0 => empty
       | 0, 0 => unit end.
 
-  Goal ∀ m n, nat_discern m n -> nat_discern (S m) (S n).
+  Goal Π m n, nat_discern m n -> nat_discern (S m) (S n).
   Proof. intros ? ? e. exact e. Defined.
 
   Lemma nat_discern_inj m n : nat_discern (S m) (S n) -> nat_discern m n.
@@ -130,7 +130,7 @@ Module Discern.
            { simpl. intro i. assert(b := helper_B _ _ i); clear i.
              destruct b. reflexivity. } } Defined.
 
-  Goal ∀ m n (e:nat_discern m n), ap S (helper_B m n e) = helper_B (S m) (S n) e.
+  Goal Π m n (e:nat_discern m n), ap S (helper_B m n e) = helper_B (S m) (S n) e.
   Proof. reflexivity. Defined.
 
   Fixpoint helper_C m n : m = n -> nat_discern m n.

--- a/UniMath/Ktheory/Precategories.v
+++ b/UniMath/Ktheory/Precategories.v
@@ -129,7 +129,7 @@ Definition category_pair (C:precategory) (i:is_category C) : category := C,,i.
 Definition theUnivalenceProperty (C:category) := pr2 _ : is_category C.
 
 Definition reflects_isos {C D} (X:C==>D) :=
-  ∀ c c' (f : c --> c'), is_isomorphism (#X f) -> is_isomorphism f.
+  Π c c' (f : c --> c'), is_isomorphism (#X f) -> is_isomorphism f.
 
 Lemma isaprop_reflects_isos {C D} (X:C==>D) : isaprop (reflects_isos X).
 Proof.
@@ -179,20 +179,20 @@ Definition makePrecategory_ob_mor
 Definition makePrecategory_data
     (obj : UU)
     (mor : obj -> obj -> UU)
-    (identity : ∀ i, mor i i)
-    (compose : ∀ i j k (f:mor i j) (g:mor j k), mor i k)
+    (identity : Π i, mor i i)
+    (compose : Π i j k (f:mor i j) (g:mor j k), mor i k)
     : precategory_data
   := precategory_data_pair (makePrecategory_ob_mor obj mor) identity compose.
 
 Definition makePrecategory
     (obj : UU)
     (mor : obj -> obj -> UU)
-    (homsets : ∀ a b, isaset (mor a b))
-    (identity : ∀ i, mor i i)
-    (compose : ∀ i j k (f:mor i j) (g:mor j k), mor i k)
-    (right : ∀ i j (f:mor i j), compose _ _ _ (identity i) f = f)
-    (left  : ∀ i j (f:mor i j), compose _ _ _ f (identity j) = f)
-    (associativity : ∀ a b c d (f:mor a b) (g:mor b c) (h:mor c d),
+    (homsets : Π a b, isaset (mor a b))
+    (identity : Π i, mor i i)
+    (compose : Π i j k (f:mor i j) (g:mor j k), mor i k)
+    (right : Π i j (f:mor i j), compose _ _ _ (identity i) f = f)
+    (left  : Π i j (f:mor i j), compose _ _ _ f (identity j) = f)
+    (associativity : Π a b c d (f:mor a b) (g:mor b c) (h:mor c d),
         compose _ _ _ f (compose _ _ _ g h) = compose _ _ _ (compose _ _ _ f g) h)
   : Precategory
   := (precategory_pair
@@ -205,9 +205,9 @@ Definition makePrecategory
 
 Definition makeFunctor {C D:Precategory}
            (obj : C -> D)
-           (mor : ∀ c c' : C, c --> c' -> obj c --> obj c')
-           (identity : ∀ c, mor c c (identity c) = identity (obj c))
-           (compax : ∀ (a b c : C) (f : a --> b) (g : b --> c),
+           (mor : Π c c' : C, c --> c' -> obj c --> obj c')
+           (identity : Π c, mor c c (identity c) = identity (obj c))
+           (compax : Π (a b c : C) (f : a --> b) (g : b --> c),
                        mor a c (g ∘ f) = mor b c g ∘ mor a b f) :
   C ==> D
   := (obj,, mor),, identity,, compax.
@@ -304,28 +304,28 @@ Proof. exact (functor_comp F _ _ _ f g). Defined.
 Definition nat_iso {B C:Precategory} (F G:[B,C]) := iso F G.
 
 Definition makeNattrans {C D:Precategory} {F G:[C,D]}
-           (mor : ∀ x : C, F ◾ x --> G ◾ x)
-           (eqn : ∀ c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
+           (mor : Π x : C, F ◾ x --> G ◾ x)
+           (eqn : Π c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
   F --> G
   := (mor,,eqn).
 
 Definition makeNattrans_op {C D:Precategory} {F G:[C^op,D]}
-           (mor : ∀ x : C, F ◾ x --> G ◾ x)
-           (eqn : ∀ c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
+           (mor : Π x : C, F ◾ x --> G ◾ x)
+           (eqn : Π c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
   F --> G
   := (mor,,eqn).
 
 Definition makeNatiso {C D:Precategory} {F G:[C,D]}
-           (mor : ∀ x : C, iso (F ◾ x) (G ◾ x))
-           (eqn : ∀ c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
+           (mor : Π x : C, iso (F ◾ x) (G ◾ x))
+           (eqn : Π c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
   nat_iso F G.
 Proof.
   refine (makeNattrans mor eqn,,_). apply functor_iso_if_pointwise_iso; intro c. apply pr2.
 Defined.
 
 Definition makeNatiso_op {C D:Precategory} {F G:[C^op,D]}
-           (mor : ∀ x : C, iso (F ◾ x) (G ◾ x))
-           (eqn : ∀ c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
+           (mor : Π x : C, iso (F ◾ x) (G ◾ x))
+           (eqn : Π c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
   nat_iso F G.
 Proof.
   refine (makeNattrans_op mor eqn,,_). apply functor_iso_if_pointwise_iso; intro c. apply pr2.
@@ -367,9 +367,9 @@ Definition functor_to_opp_opp {C:Precategory} : C ==> C^op^op
 
 Definition makeFunctor_op {C D:Precategory}
            (obj : ob C -> ob D)
-           (mor : ∀ a b : C, b --> a -> obj a --> obj b)
-           (identity : ∀ c, mor c c (identity c) = identity (obj c))
-           (compax : ∀ (a b c : C) (f : b --> a) (g : c --> b),
+           (mor : Π a b : C, b --> a -> obj a --> obj b)
+           (identity : Π c, mor c c (identity c) = identity (obj c))
+           (compax : Π (a b c : C) (f : b --> a) (g : c --> b),
                        mor a c (f ∘ g) = mor b c g ∘ mor a b f) :
   C^op ==> D
   := (obj,, mor),, identity,, compax.
@@ -499,10 +499,10 @@ Lemma total2_paths1 {A : UU} {B : A -> UU} (a:A) {b b':B a} :
   b=b' -> tpair B a b = tpair B a b'.
 Proof. intro e. induction e. reflexivity. Defined.
 
-Goal ∀ A : UU, ∀ B : A -> UU, ∀ p : (Σ a, B a), p = tpair B (pr1 p) (pr2 p).
+Goal Π A : UU, Π B : A -> UU, Π p : (Σ a, B a), p = tpair B (pr1 p) (pr2 p).
   induction p as [a b]. reflexivity. Defined.
 
-Goal ∀ X Y (f:X->Y), f = λ x, f x.
+Goal Π X Y (f:X->Y), f = λ x, f x.
   reflexivity. Defined.
 
 (* new categories from old *)
@@ -524,7 +524,7 @@ Proof.
 Defined.
 
 Definition functorWithStructures {C:Precategory} {P Q:ob C -> UU}
-           (F : ∀ c, P c -> Q c) : categoryWithStructure C P ==> categoryWithStructure C Q.
+           (F : Π c, P c -> Q c) : categoryWithStructure C P ==> categoryWithStructure C Q.
 Proof.
   unshelve refine (makeFunctor _ _ _ _).
   (* transport the structure: *)
@@ -536,7 +536,7 @@ Proof.
 Defined.
 
 Definition addStructure {B C:Precategory} {P:ob C -> UU}
-           (F:B==>C) (h : ∀ b, P(F b)) : B ==> categoryWithStructure C P.
+           (F:B==>C) (h : Π b, P(F b)) : B ==> categoryWithStructure C P.
 Proof.
   unshelve refine (makeFunctor _ _ _ _).
   - intros b. exact (F b,,h b).
@@ -545,10 +545,10 @@ Proof.
   - abstract (intros b b' b'' f g; simpl; apply functor_comp) using L.
 Defined.
 
-Lemma identityFunction : ∀ (T:SET) (f:T-->T) (t:T:hSet), f = identity T -> f t = t.
+Lemma identityFunction : Π (T:SET) (f:T-->T) (t:T:hSet), f = identity T -> f t = t.
 Proof. intros ? ? ?. exact (apevalat t). Defined.
 
-Lemma identityFunction' : ∀ (T:SET) (t:T:hSet), identity T t = t.
+Lemma identityFunction' : Π (T:SET) (t:T:hSet), identity T t = t.
 Proof. reflexivity. Defined.
 
 (*  *)
@@ -589,10 +589,10 @@ Defined.
 (* zero maps, definition: *)
 
 Definition hasZeroMaps (C:Precategory) :=
-  Σ (zero : ∀ a b:C, a --> b),
-  (∀ a b c, ∀ f:b --> c, f ∘ zero a b = zero a c)
+  Σ (zero : Π a b:C, a --> b),
+  (Π a b c, Π f:b --> c, f ∘ zero a b = zero a c)
     ×
-    (∀ a b c, ∀ f:c --> b, zero b a ∘ f = zero c a).
+    (Π a b c, Π f:c --> b, zero b a ∘ f = zero c a).
 
 Definition is {C:Precategory} (zero: hasZeroMaps C) {a b:C} (f:a-->b)
   := f = pr1 zero _ _.

--- a/UniMath/Ktheory/QuotientSet.v
+++ b/UniMath/Ktheory/QuotientSet.v
@@ -5,12 +5,12 @@ Require Import
         UniMath.Ktheory.Utilities.
 Definition iscomprelfun2 {X Y Z} (RX:hrel X) (RY:hrel Y)
            (f:X->Y->Z) : Type
-  := (∀ x x', RX x x' -> ∀ y, f x y = f x' y) ×
-     (∀ y y', RY y y' -> ∀ x, f x y = f x y').
+  := (Π x x', RX x x' -> Π y, f x y = f x' y) ×
+     (Π y y', RY y y' -> Π x, f x y = f x y').
 Definition iscomprelrelfun2 {X Y Z} (RX:hrel X) (RY:hrel Y) (RZ:eqrel Z)
            (f:X->Y->Z) : Type
-  := (∀ x x' y, RX x x' -> RZ (f x y) (f x' y)) ×
-     (∀ x y y', RY y y' -> RZ (f x y) (f x y')).
+  := (Π x x' y, RX x x' -> RZ (f x y) (f x' y)) ×
+     (Π x y y', RY y y' -> RZ (f x y) (f x y')).
 Lemma setquotuniv_equal { X : UU } ( R : hrel X ) ( Y : hSet )
       ( f f' : X -> Y ) (p : f = f')
       ( is : iscomprelfun R f ) ( is' : iscomprelfun R f' )

--- a/UniMath/Ktheory/RawMatrix.v
+++ b/UniMath/Ktheory/RawMatrix.v
@@ -16,31 +16,31 @@ Local Open Scope cat.
 
 Definition to_row {C:Precategory} {I} {b:I -> ob C}
            (B:Sum b) {d:ob C} :
-  weq (Hom C (universalObject B) d) (∀ j, Hom C (b j) d).
+  weq (Hom C (universalObject B) d) (Π j, Hom C (b j) d).
 Proof. intros. exact (universalProperty B d). Defined.
 
 Definition from_row {C:Precategory}  {I} {b:I -> ob C}
            (B:Sum b) {d:ob C} :
-  weq (∀ j, Hom C (b j) d) (Hom C (universalObject B) d).
+  weq (Π j, Hom C (b j) d) (Hom C (universalObject B) d).
 Proof. intros. apply invweq. apply to_row. Defined.
 
 Lemma from_row_entry {C:Precategory} {I} {b:I -> ob C}
-           (B:Sum b) {d:ob C} (f : ∀ j, Hom C (b j) d) :
-  ∀ j, from_row B f ∘ opp_mor (universalElement B j) = f j.
+           (B:Sum b) {d:ob C} (f : Π j, Hom C (b j) d) :
+  Π j, from_row B f ∘ opp_mor (universalElement B j) = f j.
 Proof. intros. exact (apevalat j (homotweqinvweq (to_row B) f)). Qed.
 
 Definition to_col {C:Precategory} {I} {d:I -> ob C} (D:Product d) {b:ob C} :
-  (Hom C b (universalObject D)) ≃ (∀ i, Hom C b (d i)).
+  (Hom C b (universalObject D)) ≃ (Π i, Hom C b (d i)).
 Proof. intros. exact (universalProperty D b). Defined.
 
 Definition from_col {C:Precategory} {I} {d:I -> ob C}
            (D:Product d) {b:ob C} :
- (∀ i, Hom C b (d i)) ≃ (Hom C b (universalObject D)).
+ (Π i, Hom C b (d i)) ≃ (Hom C b (universalObject D)).
 Proof. intros. apply invweq. apply to_col. Defined.
 
 Lemma from_col_entry {C:Precategory} {I} {b:I -> ob C}
-           (D:Product b) {d:ob C} (f : ∀ i, Hom C d (b i)) :
-  ∀ i, universalElement D i ∘ from_col D f = f i.
+           (D:Product b) {d:ob C} (f : Π i, Hom C d (b i)) :
+  Π i, universalElement D i ∘ from_col D f = f i.
 Proof. intros.
   apply (apevalat i (homotweqinvweq (to_col D) f )). Qed.
 
@@ -49,9 +49,9 @@ Definition to_matrix {C:Precategory}
            {J} {b:J -> ob C} (B:Sum b) :
   (Hom C (universalObject B) (universalObject D))
     ≃
-    (∀ i j, Hom C (b j) (d i)).
+    (Π i j, Hom C (b j) (d i)).
 Proof.
-  intros. apply @weqcomp with (Y := ∀ i, Hom C (universalObject B) (d i)).
+  intros. apply @weqcomp with (Y := Π i, Hom C (universalObject B) (d i)).
   { apply to_col. }
   { apply weqonsecfibers; intro i. apply to_row. }
 Defined.
@@ -59,19 +59,19 @@ Defined.
 Definition from_matrix {C:Precategory}
            {I} {d:I -> ob C} (D:Product d)
            {J} {b:J -> ob C} (B:Sum b) :
-           weq (∀ i j, Hom C (b j) (d i)) (Hom C (universalObject B) (universalObject D)).
+           weq (Π i j, Hom C (b j) (d i)) (Hom C (universalObject B) (universalObject D)).
 Proof. intros. apply invweq. apply to_matrix. Defined.
 
 Lemma from_matrix_entry {C:Precategory}
            {I} {d:I -> ob C} (D:Product d)
            {J} {b:J -> ob C} (B:Sum b)
-           (f : ∀ i j, Hom C (b j) (d i)) :
-  ∀ i j, (universalElement D i ∘ from_matrix D B f) ∘ opp_mor (universalElement B j) = f i j.
+           (f : Π i j, Hom C (b j) (d i)) :
+  Π i j, (universalElement D i ∘ from_matrix D B f) ∘ opp_mor (universalElement B j) = f i j.
 Proof. intros. exact (apevalat j (apevalat i (homotweqinvweq (to_matrix D B) f))). Qed.
 
 Lemma from_matrix_entry_assoc {C:Precategory}
            {I} {d:I -> ob C} (D:Product d)
            {J} {b:J -> ob C} (B:Sum b)
-           (f : ∀ i j, Hom C (b j) (d i)) :
-  ∀ i j, universalElement D i ∘ (from_matrix D B f ∘ opp_mor(universalElement B j)) = f i j.
+           (f : Π i j, Hom C (b j) (d i)) :
+  Π i j, universalElement D i ∘ (from_matrix D B f ∘ opp_mor(universalElement B j)) = f i j.
 Proof. intros. rewrite <- assoc. exact (from_matrix_entry D B f i j). Qed.

--- a/UniMath/Ktheory/Representation.v
+++ b/UniMath/Ktheory/Representation.v
@@ -12,7 +12,7 @@ Set Automatic Introduction.
 Local Open Scope cat.
 
 Definition isUniversal {C:Precategory} {X:[C^op,SET]} {c:C} (x:c ⇒ X)
-  := ∀ (c':C), isweq (λ f : c' --> c, x ⟲ f).
+  := Π (c':C), isweq (λ f : c' --> c, x ⟲ f).
 
 Definition Universal {C:Precategory} (X:[C^op,SET]) (c:C)
   := Σ (x:c ⇒ X), isUniversal x.
@@ -71,7 +71,7 @@ Definition toRepresentableFunctor {C:Precategory} :
 (* make a representation of a functor *)
 
 Definition makeRepresentation {C:Precategory} {c:C} {X:[C^op,SET]} (x:c ⇒ X) :
-  (∀ (c':C), bijective (λ f : c' --> c, x ⟲ f)) -> Representation X.
+  (Π (c':C), bijective (λ f : c' --> c, x ⟲ f)) -> Representation X.
 Proof.
   intros bij. exists c. exists x. intros c'. apply set_bijection_to_weq.
   - exact (bij c').
@@ -359,7 +359,7 @@ Definition HomPair_2 {C:Precategory} (a b c:C) :
 Definition BinaryProduct {C:Precategory} (a b:C) :=
   Representation (HomPair a b).
 
-Definition hasBinaryProducts (C:Precategory) := ∀ (a b:C), BinaryProduct a b.
+Definition hasBinaryProducts (C:Precategory) := Π (a b:C), BinaryProduct a b.
 
 Definition pr_1 {C:Precategory} {a b:C} (prod : BinaryProduct a b) :
   universalObject prod --> a
@@ -406,7 +406,7 @@ Defined.
 Definition BinarySum {C:Precategory} (a b:C) :=
   BinaryProduct (opp_ob a) (opp_ob b).
 
-Definition hasBinarySums (C:Precategory) := ∀ (a b:C), BinarySum a b.
+Definition hasBinarySums (C:Precategory) := Π (a b:C), BinarySum a b.
 
 Lemma binarySumsToProducts {C:Precategory} :
   hasBinarySums C -> hasBinaryProducts C^op.
@@ -465,7 +465,7 @@ Definition HomFamily (C:Precategory) {I} (c:I -> ob C) : C^op ==> SET.
 Proof.
   unshelve refine (_,,_).
   - unshelve refine (_,,_).
-    + intros x. exact (∀ i, Hom C x (c i)) % set.
+    + intros x. exact (Π i, Hom C x (c i)) % set.
     + intros x y f p i; simpl; simpl in p.
       exact (compose (C:=C) f (p i)).
   - abstract (split;
@@ -485,12 +485,12 @@ Definition pr_ {C:Precategory} {I} {c:I -> ob C} (prod : Product c) (i:I) :
 
 Definition productMapExistence {C:Precategory} {I} {c:I -> ob C} (prod : Product c)
       {a:C} :
-  (∀ i, Hom C a (c i)) -> Hom C a (universalObject prod)
+  (Π i, Hom C a (c i)) -> Hom C a (universalObject prod)
   := λ f, prod \\ f.
 
 Lemma productMapUniqueness {C:Precategory} {I} {c:I -> ob C} (prod : Product c)
       {a:C} (f g : Hom C a (universalObject prod)) :
-  (∀ i, pr_ prod i ∘ f = pr_ prod i ∘ g) -> f = g.
+  (Π i, pr_ prod i ∘ f = pr_ prod i ∘ g) -> f = g.
 Proof.
   intro e. apply mapUniqueness. apply funextsec; intro i. apply e.
 Defined.
@@ -504,12 +504,12 @@ Definition in_ {C:Precategory} {I} {c:I -> ob C} (sum : Sum c) (i:I) :
 
 Definition sumMapExistence {C:Precategory} {I} {c:I -> ob C} (sum : Sum c)
       {a:C} :
-  (∀ i, Hom C (c i) a) -> Hom C (universalObject sum) a
+  (Π i, Hom C (c i) a) -> Hom C (universalObject sum) a
   := λ f, f // sum.
 
 Lemma sumMapUniqueness {C:Precategory} {I} {c:I -> ob C} (sum : Sum c)
       {a:C} (f g : Hom C (universalObject sum) a) :
-  (∀ i, f ∘ in_ sum i = g ∘ in_ sum i) -> f = g.
+  (Π i, f ∘ in_ sum i = g ∘ in_ sum i) -> f = g.
 Proof.
   intro e. apply opp_mor_eq, mapUniqueness. apply funextsec; intro i. apply e.
 Defined.
@@ -704,16 +704,16 @@ Defined.
    Grothendieck.  See EGA Chapter 0. *)
 
 Definition Representation_Map {C:Precategory} {X Y:[C^op,SET]} (p : X --> Y) :=
-  ∀ (c : C) (y : c ⇒ Y), Representation (fiber p y).
+  Π (c : C) (y : c ⇒ Y), Representation (fiber p y).
 
 Definition isRepresentable_Map {C:Precategory} {X Y:[C^op,SET]} (p : X --> Y) :=
-  ∀ (c : C) (y : c ⇒ Y), isRepresentable (fiber p y).
+  Π (c : C) (y : c ⇒ Y), isRepresentable (fiber p y).
 
 (** limits and colimits  *)
 
 Definition cone {I C:Precategory} (c:C) (D: [I,C]) : UU
-  := Σ (φ : ∀ i, Hom C c (D ◾ i)),
-     ∀ i j (e : i --> j), D ▭ e ∘ φ i = φ j.
+  := Σ (φ : Π i, Hom C c (D ◾ i)),
+     Π i j (e : i --> j), D ▭ e ∘ φ i = φ j.
 
 Lemma cone_eq {C I:Precategory} (c:C^op) (D: I==>C) (p q:cone (C:=C) c D) :
   pr1 p ~ pr1 q -> p = q.
@@ -802,9 +802,9 @@ Definition inj_comm {C I:Precategory} {D: I==>C} (colim:Colimit D) {i j:I} (f:i-
   inj_ colim j ∘ # D f = inj_ colim i.
 Proof. intros. exact (pr2 (universalElement colim) _ _ f). Defined.
 
-Definition hasLimits (C:Precategory) := ∀ (I:Precategory) (D: I==>C), Limit D.
+Definition hasLimits (C:Precategory) := Π (I:Precategory) (D: I==>C), Limit D.
 
-Definition hasColimits (C:Precategory) := ∀ (I:Precategory) (D: I==>C), Colimit D.
+Definition hasColimits (C:Precategory) := Π (I:Precategory) (D: I==>C), Colimit D.
 
 Definition lim_functor (C:Precategory) (lim:hasLimits C) (I:Precategory) :
   [I,C] ==> C
@@ -816,7 +816,7 @@ Definition colim_functor (C:Precategory) (colim:hasColimits C) (I:Precategory) :
          universalObjectFunctor C^op □ addStructure cocone_functor (colim I)).
 
 Lemma bifunctor_assoc_repn {B C:Precategory} (X : [B, [C^op,SET]]) :
-  (∀ b, Representation (X ◾ b)) -> Representation (bifunctor_assoc X).
+  (Π b, Representation (X ◾ b)) -> Representation (bifunctor_assoc X).
 Proof.
   intro r. set (X' := addStructure X r).
   change (categoryWithStructure [C ^op, SET] Representation) with (RepresentedFunctor C) in X'.
@@ -879,7 +879,7 @@ Proof.
   { apply bifunctor_assoc_repn; intro b. exact t. }
 Defined.
 
-Goal ∀ B C t b,
+Goal Π B C t b,
        universalObject(functorPrecategoryTerminalObject B C t) ◾ b = universalObject t.
   reflexivity.
 Defined.

--- a/UniMath/Ktheory/StandardCategories.v
+++ b/UniMath/Ktheory/StandardCategories.v
@@ -12,7 +12,7 @@ Proof. intros. exact (compose f g). Defined.
 (** *** the path groupoid *)
 
 Definition is_groupoid (C : Precategory) :=
-  ∀ a b : ob C, isweq (fun p : a = b => idtomor a b p).
+  Π a b : ob C, isweq (fun p : a = b => idtomor a b p).
 
 Lemma isaprop_is_groupoid (C : Precategory) : isaprop (is_groupoid C).
 Proof. intro. apply impred.

--- a/UniMath/Ktheory/Test.v
+++ b/UniMath/Ktheory/Test.v
@@ -27,7 +27,7 @@ Definition isCoproductCocone (a b co : C) (ia : a --> co) (ib : b --> co) :=
   binarySumProperty ia ib.
 
 Definition mk_isCoproductCocone (a b co : C) (ia : a --> co) (ib : b --> co) :
-   (∀ (c : C) (f : a --> c) (g : b --> c),
+   (Π (c : C) (f : a --> c) (g : b --> c),
     ∃! k : C ⟦co, c⟧,
       ia ;; k = f ×
       ib ;; k = g)
@@ -50,7 +50,7 @@ Defined.
 Definition CoproductCocone (a b : C) := BinarySum a b.
 
 Definition mk_CoproductCocone (a b : C) :
-  ∀ (c : C) (f : a --> c) (g : b --> c),
+  Π (c : C) (f : a --> c) (g : b --> c),
     isCoproductCocone _ _ _ f g -> CoproductCocone a b
   := λ c f g i, c,,(f,,g),,i.
 
@@ -71,14 +71,14 @@ Definition CoproductArrow {a b : C} (CC : CoproductCocone a b) {c : C} (f : a --
   := binarySumMap CC f g.
 
 Lemma CoproductIn1Commutes (a b : C) (CC : CoproductCocone a b):
-     ∀ (c : C) (f : a --> c) g, CoproductIn1 CC ;; CoproductArrow CC f g  = f.
+     Π (c : C) (f : a --> c) g, CoproductIn1 CC ;; CoproductArrow CC f g  = f.
 Proof.
   intros c f g.
   exact (binarySum_in_1_eqn CC f g).
 Qed.
 
 Lemma CoproductIn2Commutes (a b : C) (CC : CoproductCocone a b):
-     ∀ (c : C) (f : a --> c) g, CoproductIn2 CC ;; CoproductArrow CC f g = g.
+     Π (c : C) (f : a --> c) g, CoproductIn2 CC ;; CoproductArrow CC f g = g.
 Proof.
   intros c f g.
   exact (binarySum_in_2_eqn CC f g).

--- a/UniMath/Ktheory/Utilities.v
+++ b/UniMath/Ktheory/Utilities.v
@@ -16,12 +16,12 @@ Ltac postponeProof := apply fromempty, PostponedProof.
 
 Open Scope transport.
 
-Definition nullHomotopyTo {X Y} (f:X->Y) (y:Y) := ∀ x:X, f x = y.
+Definition nullHomotopyTo {X Y} (f:X->Y) (y:Y) := Π x:X, f x = y.
 Definition NullHomotopyTo {X Y} (f:X->Y) := total2 (nullHomotopyTo f).
 Definition NullHomotopyTo_center {X Y} (f:X->Y) : NullHomotopyTo f -> Y := pr1.
 Definition NullHomotopyTo_path {X Y} {f:X->Y} (r:NullHomotopyTo f) := pr2 r.
 
-Definition nullHomotopyFrom {X Y} (f:X->Y) (y:Y) := ∀ x:X, y = f x.
+Definition nullHomotopyFrom {X Y} (f:X->Y) (y:Y) := Π x:X, y = f x.
 Definition NullHomotopyFrom {X Y} (f:X->Y) := total2 (nullHomotopyFrom f).
 Definition NullHomotopyFrom_center {X Y} (f:X->Y) : NullHomotopyFrom f -> Y := pr1.
 Definition NullHomotopyFrom_path {X Y} {f:X->Y} (r:NullHomotopyFrom f) := pr2 r.
@@ -92,7 +92,7 @@ Definition cone_squash_map {X Y} (f:X->Y) (y:Y) :
 Proof. intros ? ? ? ? e h.
        exact (point_from (h (paths_to_prop y) (fun x => f x,,e x))). Defined.
 
-Goal ∀ X Y (y:Y) (f:X->Y) (e:∀ m:X, f m = y),
+Goal Π X Y (y:Y) (f:X->Y) (e:Π m:X, f m = y),
        f = funcomp squash_element (cone_squash_map f y e).
 Proof. reflexivity. Qed.
 
@@ -101,20 +101,20 @@ Proof. reflexivity. Qed.
 Lemma squash_uniqueness {X} (x:X) (h:∥ X ∥) : squash_element x = h.
 Proof. intros. apply propproperty. Qed.
 
-Goal ∀ X Q (i:isaprop Q) (f:X -> Q) (x:X),
+Goal Π X Q (i:isaprop Q) (f:X -> Q) (x:X),
    factor_through_squash i f (squash_element x) = f x.
 Proof. reflexivity. Defined.
 
 Lemma factor_dep_through_squash {X} {Q:∥ X ∥->UU} :
-  (∀ h, isaprop (Q h)) ->
-  (∀ x, Q(squash_element x)) ->
-  (∀ h, Q h).
+  (Π h, isaprop (Q h)) ->
+  (Π x, Q(squash_element x)) ->
+  (Π h, Q h).
 Proof.
   intros ? ? i f ?.  apply (h (hProppair (Q h) (i h))).
   intro x. simpl. destruct (squash_uniqueness x h). exact (f x).
 Defined.
 
-Lemma factor_through_squash_hProp {X} : ∀ hQ:hProp, (X -> hQ) -> ∥ X ∥ -> hQ.
+Lemma factor_through_squash_hProp {X} : Π hQ:hProp, (X -> hQ) -> ∥ X ∥ -> hQ.
 Proof. intros ? [Q i] f h. refine (h _ _). assumption. Defined.
 
 Lemma funspace_isaset {X Y} : isaset Y -> isaset (X -> Y).
@@ -149,10 +149,10 @@ Definition funcomp' { X Y Z : UU } ( g : Y -> Z ) ( f : X -> Y ) := fun x : X =>
 Open Scope transport.
 
 (* some jargon reminders: *)
-Goal forall X (i:isaprop X) (x x':X), x = x'.
+Goal Π X (i:isaprop X) (x x':X), x = x'.
 Proof. apply proofirrelevance. Defined.
 
-Goal forall X (i:iscontr X) (x x':X), x = x'.
+Goal Π X (i:iscontr X) (x x':X), x = x'.
 Proof. intros. apply proofirrelevancecontr. assumption. Defined.
 
 (* *)
@@ -214,9 +214,9 @@ Definition pathscomp0_rinj {X} {x y z:X} {p p':x = y} {q:y = z} (r:p@q = p'@q) :
 Proof. intros. destruct q. exact (! pathscomp0rid p @ r @ pathscomp0rid p').
 Defined.
 
-Lemma irrel_paths {X} (irr:∀ x y:X, x = y) {x y:X} (p q:x = y) : p = q.
+Lemma irrel_paths {X} (irr:Π x y:X, x = y) {x y:X} (p q:x = y) : p = q.
 Proof. intros.
-       assert (k : ∀ z:X, ∀ r:x = z, r @ irr z z = irr x z).
+       assert (k : Π z:X, Π r:x = z, r @ irr z z = irr x z).
        { intros. destruct r. reflexivity. }
        exact (pathscomp0_rinj (k y p @ !k y q)). Defined.
 
@@ -241,7 +241,7 @@ Proof. reflexivity. Defined.
 
 (* replace all uses of this by uses of subtypePairEquality *)
 Definition pair_path_props {X} {P:X->Type} {x y:X} {p:P x} {q:P y} :
-  x = y -> (∀ z, isaprop (P z)) -> x,,p = y,,q.
+  x = y -> (Π z, isaprop (P z)) -> x,,p = y,,q.
 Proof. intros ? ? ? ? ? ? e is. now apply subtypePairEquality. Abort.
 
 Definition pair_path2 {A} {B:A->UU} {a a1 a2} {b1:B a1} {b2:B a2}
@@ -269,14 +269,14 @@ Proof. intros. destruct p, q. reflexivity. Defined.
 
 (** ** Maps from pair types *)
 
-Definition from_total2 {X} {P:X->Type} {Y} : (∀ x, P x->Y) -> total2 P -> Y.
+Definition from_total2 {X} {P:X->Type} {Y} : (Π x, P x->Y) -> total2 P -> Y.
 Proof. intros ? ? ? f [x p]. exact (f x p). Defined.
 
 (** ** Sections and functions *)
 
-Definition Section {T} (P:T->UU) := ∀ t:T, P t.
+Definition Section {T} (P:T->UU) := Π t:T, P t.
 
-Definition homotsec {T} {P:T->UU} (f g:Section P) := ∀ t, f t = g t.
+Definition homotsec {T} {P:T->UU} (f g:Section P) := Π t, f t = g t.
 
 (* compare with [adjev] *)
 Definition evalat {T} {P:T->UU} (t:T) (f:Section P) := f t.
@@ -330,39 +330,39 @@ Lemma transport_idfun {X} (P:X->UU) {x y:X} (p:x = y) (u:P x) :
 (* same as HoTT.PathGroupoids.transport_idmap_ap *)
 Proof. intros. destruct p. reflexivity. Defined.
 
-Lemma transport_functions {X} {Y:X->Type} {Z:∀ x (y:Y x), Type}
-      {f f':Section Y} (p:f = f') (z:∀ x, Z x (f x)) x :
-    transportf (fun f => ∀ x, Z x (f x)) p z x =
+Lemma transport_functions {X} {Y:X->Type} {Z:Π x (y:Y x), Type}
+      {f f':Section Y} (p:f = f') (z:Π x, Z x (f x)) x :
+    transportf (fun f => Π x, Z x (f x)) p z x =
     transportf (Z x) (toforallpaths _ _ _ p x) (z x).
 Proof. intros. destruct p. reflexivity. Defined.
 
 Definition transport_funapp {T} {X Y:T->Type}
-           (f:∀ t, X t -> Y t) (x:∀ t, X t)
+           (f:Π t, X t -> Y t) (x:Π t, X t)
            {t t':T} (p:t = t') :
   transportf _ p ((f t)(x t))
   = (transportf (fun t => X t -> Y t) p (f t)) (transportf _ p (x t)).
 Proof. intros. destruct p. reflexivity. Defined.
 
-Definition helper_A {T} {Y} (P:T->Y->Type) {y y':Y} (k:∀ t, P t y) (e:y = y') t :
+Definition helper_A {T} {Y} (P:T->Y->Type) {y y':Y} (k:Π t, P t y) (e:y = y') t :
   transportf (fun y => P t y) e (k t)
   =
-  (transportf (fun y => ∀ t, P t y) e k) t.
+  (transportf (fun y => Π t, P t y) e k) t.
 Proof. intros. destruct e. reflexivity. Defined.
 
-Definition helper_B {T} {Y} (f:T->Y) {y y':Y} (k:∀ t, y = f t) (e:y = y') t :
+Definition helper_B {T} {Y} (f:T->Y) {y y':Y} (k:Π t, y = f t) (e:y = y') t :
   transportf (fun y => y = f t) e (k t)
   =
-  (transportf (fun y => ∀ t, y = f t) e k) t.
+  (transportf (fun y => Π t, y = f t) e k) t.
 Proof. intros. exact (helper_A _ k e t). Defined.
 
-Definition transport_invweq {T} {X Y:T->Type} (f:∀ t, weq (X t) (Y t))
+Definition transport_invweq {T} {X Y:T->Type} (f:Π t, weq (X t) (Y t))
            {t t':T} (p:t = t') :
   transportf (fun t => weq (Y t) (X t)) p (invweq (f t))
   =
   invweq (transportf (fun t => weq (X t) (Y t)) p (f t)).
 Proof. intros. destruct p. reflexivity. Defined.
 
-Definition transport_invmap {T} {X Y:T->Type} (f:∀ t, weq (X t) (Y t))
+Definition transport_invmap {T} {X Y:T->Type} (f:Π t, weq (X t) (Y t))
            {t t':T} (p:t=t') :
   transportf (fun t => Y t -> X t) p (invmap (f t))
   =
@@ -371,17 +371,17 @@ Proof. intros. destruct p. reflexivity. Defined.
 
   (** *** Double transport *)
 
-  Definition transportf2 {X} {Y:X->Type} (Z:∀ x, Y x->Type)
+  Definition transportf2 {X} {Y:X->Type} (Z:Π x, Y x->Type)
              {x x'} (p:x = x')
              (y:Y x) (z:Z x y) : Z x' (p#y).
   Proof. intros. destruct p. exact z. Defined.
 
-  Definition transportb2 {X} {Y:X->Type} (Z:∀ x, Y x->Type)
+  Definition transportb2 {X} {Y:X->Type} (Z:Π x, Y x->Type)
              {x x'} (p:x=x')
              (y':Y x') (z':Z x' y') : Z x (p#'y').
   Proof. intros. destruct p. exact z'. Defined.
 
-  Definition maponpaths_pr1_pr2 {X} {P:X->UU} {Q:∀ x, P x->Type}
+  Definition maponpaths_pr1_pr2 {X} {P:X->UU} {Q:Π x, P x->Type}
              {w w': Σ x p, Q x p}
              (p : w = w') :
     transportf P (ap pr1 p) (pr1 (pr2 w)) = pr1 (pr2 w').
@@ -390,14 +390,14 @@ Proof. intros. destruct p. reflexivity. Defined.
   (** *** Transport a pair *)
 
   (* replace this with transportf_total2 (?) : *)
-  Definition transportf_pair X (Y:X->Type) (Z:∀ x, Y x->Type)
+  Definition transportf_pair X (Y:X->Type) (Z:Π x, Y x->Type)
              x x' (p:x = x') (y:Y x) (z:Z x y) :
     transportf (fun x => total2 (Z x)) p (tpair (Z x) y z)
     =
     tpair (Z x') (transportf Y p y) (transportf2 _ p y z).
   Proof. intros. destruct p. reflexivity. Defined.
 
-  Definition transportb_pair X (Y:X->Type) (Z:∀ x, Y x->Type)
+  Definition transportb_pair X (Y:X->Type) (Z:Π x, Y x->Type)
              x x' (p:x = x')
              (y':Y x') (z':Z x' y')
              (z' : (Z x' y')) :
@@ -415,10 +415,10 @@ Lemma isaprop_wma_inhab' X : (X -> iscontr X) -> isaprop X.
 Proof. intros ? f. apply isaprop_wma_inhab. intro x. apply isapropifcontr.
        apply (f x). Qed.
 
-Goal ∀ (X:hSet) (x y:X) (p q:x = y), p = q.
+Goal Π (X:hSet) (x y:X) (p q:x = y), p = q.
 Proof. intros. apply setproperty. Defined.
 
-Goal ∀ (X:Type) (x y:X) (p q:x = y), isaset X -> p = q.
+Goal Π (X:Type) (x y:X) (p q:x = y), isaset X -> p = q.
 Proof. intros ? ? ? ? ? is. apply is. Defined.
 
 Definition funset X (Y:hSet) : hSet
@@ -426,9 +426,9 @@ Definition funset X (Y:hSet) : hSet
 
 (** ** Connected types *)
 
-Definition isconnected X := ∀ (x y:X), nonempty (x = y).
+Definition isconnected X := Π (x y:X), nonempty (x = y).
 
-Lemma base_connected {X} (t:X) : (∀ y:X, nonempty (t = y)) -> isconnected X.
+Lemma base_connected {X} (t:X) : (Π y:X, nonempty (t = y)) -> isconnected X.
 Proof. intros ? ? p x y. assert (a := p x). assert (b := p y). clear p.
        apply (squash_to_prop a). apply propproperty. clear a. intros a.
        apply (squash_to_prop b). apply propproperty. clear b. intros b.
@@ -448,7 +448,7 @@ Definition pr1_eqweqmap2 { X Y } ( e: X = Y ) :
 Proof. intros. destruct e. reflexivity. Defined.
 
 Definition weqonsec {X Y} (P:X->Type) (Q:Y->Type)
-           (f:X ≃ Y) (g:∀ x, weq (P x) (Q (f x))) :
+           (f:X ≃ Y) (g:Π x, weq (P x) (Q (f x))) :
   weq (Section P) (Section Q).
 Proof. intros.
        exact (weqcomp (weqonsecfibers P (fun x => Q(f x)) g)
@@ -489,7 +489,7 @@ Proof. intros ? ? ? ? ? p. exact (! homotweqinvweq f y @ ap f p). Defined.
 Definition weqbandfrel {X Y T}
            (e:Y->T) (t:T) (f : X ≃ Y)
            (P:X -> Type) (Q: Y -> Type)
-           (g:∀ x:X, weq (P x) (Q (f x))) :
+           (g:Π x:X, weq (P x) (Q (f x))) :
   weq (hfiber (fun xp:total2 P => e(f(pr1 xp))) t)
       (hfiber (fun yq:total2 Q => e(  pr1 yq )) t).
 Proof. intros. refine (weqbandf (weqbandf f _ _ g) _ _ _).
@@ -501,7 +501,7 @@ Definition weq_over_sections {S T} (w:S ≃ T)
            (p0:P t0) (pw0:P(w s0)) (l:k#pw0 = p0)
            (H:Section P -> Type)
            (J:Section (funcomp w P) -> Type)
-           (g:∀ f:Section P, weq (H f) (J (maponsec1 P w f))) :
+           (g:Π f:Section P, weq (H f) (J (maponsec1 P w f))) :
   weq (hfiber (fun fh:total2 H => pr1 fh t0) p0 )
       (hfiber (fun fh:total2 J => pr1 fh s0) pw0).
 Proof. intros. simple refine (weqbandf _ _ _ _).
@@ -521,7 +521,7 @@ Proof.                          (* move upstream *)
        { intros [x [y z]]. reflexivity. } Defined.
 
 (* associativity of Σ *)
-Definition totalAssociativity {X:UU} {Y: ∀ (x:X), UU} (Z: ∀ (x:X) (y:Y x), UU) : (Σ (x:X) (y:Y x), Z x y) ≃ (Σ (p:Σ (x:X), Y x), Z (pr1 p) (pr2 p)).
+Definition totalAssociativity {X:UU} {Y: Π (x:X), UU} (Z: Π (x:X) (y:Y x), UU) : (Σ (x:X) (y:Y x), Z x y) ≃ (Σ (p:Σ (x:X), Y x), Z (pr1 p) (pr2 p)).
 Proof.                          (* move upstream *)
   intros. simple refine (_,,gradth _ _ _ _).
   { intros [x [y z]]. exact ((x,,y),,z). }

--- a/UniMath/SubstitutionSystems/BinProductOfSignatures.v
+++ b/UniMath/SubstitutionSystems/BinProductOfSignatures.v
@@ -65,7 +65,7 @@ Definition H : functor [C, C, hsC] [C, C, hsC] :=
   BinProduct_of_functors _ _ CCC H1 H2.
 
 Local Definition bla1 (X : [C, C, hsC]) (Z : precategory_Ptd C hsC) :
-   ∀ c : C,
+   Π c : C,
     (functor_composite_data (pr1 Z)
      (BinProduct_of_functors_data C C PC (H1 X) (H2 X))) c
    --> (BinProduct_of_functors_data C C PC (H1 (functor_composite (pr1 Z) X))
@@ -105,7 +105,7 @@ Proof.
 Defined.
 
 
-Definition θ_ob : ∀ XF, θ_source H XF --> θ_target H XF.
+Definition θ_ob : Π XF, θ_source H XF --> θ_target H XF.
 Proof.
   intro XZ.
   destruct XZ as [X Z].

--- a/UniMath/SubstitutionSystems/BinSumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/BinSumOfSignatures.v
@@ -80,7 +80,7 @@ Definition H : functor [C, C, hs] [C, C, hs] := BinCoproduct_of_functors _ _ CCC
 (* Definition H : functor [C, C, hs] [C, C, hs] := BinCoproduct_of_functors_alt CCC H1 H2. *)
 
 Local Definition bla1 (X : [C, C, hs]) (Z : precategory_Ptd C hs) :
-   ∀ c : C,
+   Π c : C,
     (functor_composite_data (pr1 Z)
      (BinCoproduct_of_functors_data C C CC (H1 X) (H2 X))) c
    --> (BinCoproduct_of_functors_data C C CC (H1 (functor_composite (pr1 Z) X))
@@ -120,7 +120,7 @@ Proof.
 Defined.
 
 
-Definition θ_ob : ∀ XF, θ_source H XF --> θ_target H XF.
+Definition θ_ob : Π XF, θ_source H XF --> θ_target H XF.
 Proof.
   intro XZ.
   destruct XZ as [X Z].

--- a/UniMath/SubstitutionSystems/Lam.v
+++ b/UniMath/SubstitutionSystems/Lam.v
@@ -79,7 +79,7 @@ Let CPEndEndC:= BinCoproducts_functor_precat _ _ CPEndC hsEndC: BinCoproducts En
 
 Let one : C :=  @TerminalObject C terminal.
 
-Variable KanExt : ∀ Z : precategory_Ptd C hs,
+Variable KanExt : Π Z : precategory_Ptd C hs,
    RightKanExtension.GlobalRightKanExtensionExists C C
      (U Z) C hs hs.
 
@@ -417,7 +417,7 @@ Qed.
 Lemma bracket_for_LamE_algebra_on_Lam_unique (Z : Ptd)
   (f : Ptd ⟦ Z, ptd_from_alg LamE_algebra_on_Lam ⟧)
  :
-   ∀
+   Π
    t : Σ
        h : [C, C, hs]
            ⟦ functor_composite (U Z)

--- a/UniMath/SubstitutionSystems/LamHSET.v
+++ b/UniMath/SubstitutionSystems/LamHSET.v
@@ -64,7 +64,7 @@ use colimAlgInitial.
 - apply ColimsFunctorCategory; apply ColimsHSET.
 Defined.
 
-Lemma KanExt_HSET : ∀ Z : precategory_Ptd HSET has_homsets_HSET,
+Lemma KanExt_HSET : Π Z : precategory_Ptd HSET has_homsets_HSET,
    RightKanExtension.GlobalRightKanExtensionExists HSET HSET
      (U Z) HSET has_homsets_HSET has_homsets_HSET.
 Proof.

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -105,7 +105,7 @@ Defined.
 (* Definition Abs_H_ob (X: EndC): functor C C := functor_composite (option_functor _ CC terminal) X. *)
 
 (* (* works only with -type-in-type: *)
-(* Definition Abs_H_mor_nat_trans_data (X X': EndC)(α: X --> X'): ∀ c, Abs_H_ob X c --> Abs_H_ob X' c. *)
+(* Definition Abs_H_mor_nat_trans_data (X X': EndC)(α: X --> X'): Π c, Abs_H_ob X c --> Abs_H_ob X' c. *)
 (* Proof. *)
 (*   intro. *)
 (*   unfold Abs_H_ob. *)
@@ -113,7 +113,7 @@ Defined.
 (* Defined. *)
 (* *) *)
 
-(* Definition Abs_H_mor_nat_trans_data (X X': functor C C)(α: nat_trans X X'): ∀ c, Abs_H_ob X c --> Abs_H_ob X' c. *)
+(* Definition Abs_H_mor_nat_trans_data (X X': functor C C)(α: nat_trans X X'): Π c, Abs_H_ob X c --> Abs_H_ob X' c. *)
 (* Proof. *)
 (*   intro. *)
 (*   apply α. *)
@@ -230,7 +230,7 @@ Definition Flat_H : functor [C, C, hs] [C, C, hs] := tpair _ _ is_functor_Flat_H
 (** here definition of suitable θ's together with their strength laws  *)
 
 
-Definition App_θ_data: ∀ XZ, (θ_source App_H)XZ --> (θ_target App_H)XZ.
+Definition App_θ_data: Π XZ, (θ_source App_H)XZ --> (θ_target App_H)XZ.
 Proof.
   intro XZ.
   apply nat_trans_id.
@@ -328,7 +328,7 @@ Proof.
 Qed.
 
 
-Definition Abs_θ_data_data: ∀ XZ A, ((θ_source Abs_H)XZ: functor C C) A --> ((θ_target Abs_H)XZ: functor C C) A.
+Definition Abs_θ_data_data: Π XZ A, ((θ_source Abs_H)XZ: functor C C) A --> ((θ_target Abs_H)XZ: functor C C) A.
 Proof.
   intro XZ.
 (*
@@ -350,7 +350,7 @@ Proof.
   + exact (# (pr1 (pr2 XZ)) (BinCoproductIn2 _ (CC (TerminalObject terminal) A))).
 Defined.
 
-Lemma is_nat_trans_Abs_θ_data_data: ∀ XZ, is_nat_trans _ _ (Abs_θ_data_data XZ).
+Lemma is_nat_trans_Abs_θ_data_data: Π XZ, is_nat_trans _ _ (Abs_θ_data_data XZ).
 Proof.
 
   intro XZ.
@@ -436,7 +436,7 @@ Focus 2.
 Qed.
 
 
-Definition Abs_θ_data: ∀ XZ, (θ_source Abs_H)XZ --> (θ_target Abs_H)XZ.
+Definition Abs_θ_data: Π XZ, (θ_source Abs_H)XZ --> (θ_target Abs_H)XZ.
 Proof.
   intro XZ.
   exact (tpair _ _ (is_nat_trans_Abs_θ_data_data XZ)).
@@ -561,7 +561,7 @@ Focus 2.
 Qed.
 
 
-Definition Flat_θ_data: ∀ XZ, (θ_source Flat_H)XZ --> (θ_target Flat_H)XZ.
+Definition Flat_θ_data: Π XZ, (θ_source Flat_H)XZ --> (θ_target Flat_H)XZ.
 Proof.
   intro XZ.
 (*  destruct XZ as [X [Z e]].

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -79,7 +79,7 @@ Let EndEndC := [EndC, EndC, hsEndC].
 Let CPEndEndC:= BinCoproducts_functor_precat _ _ CPEndC hsEndC: BinCoproducts EndEndC.
 
 
-Variable KanExt : ∀ Z : Ptd, GlobalRightKanExtensionExists _ _ (U Z) _ hs hs.
+Variable KanExt : Π Z : Ptd, GlobalRightKanExtensionExists _ _ (U Z) _ hs hs.
 
 Variable H : Signature C hs.
 Let θ := theta H.
@@ -96,7 +96,7 @@ Let Alg : precategory := FunctorAlg Id_H hsEndC.
 
 Variable IA : Initial Alg.
 Definition SpecializedGMIt (Z : Ptd) (X : EndC)
-  :  ∀ (G : functor [C, C, hs] [C, C, hs])
+  :  Π (G : functor [C, C, hs] [C, C, hs])
        (ρ : [C, C, hs] ⟦ G X, X ⟧)
        (θ : functor_composite Id_H (ℓ (U Z)) ⟶ functor_composite (ℓ (U Z)) G),
      ∃! h : [C, C, hs] ⟦ ℓ (U Z) (` (InitialObject IA)), X ⟧,
@@ -429,7 +429,7 @@ Proof.
 Qed.
 
 Local Lemma foo' (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
- ∀ t : Σ h : [C, C, hs] ⟦ functor_composite (U Z) (pr1  InitAlg),
+ Π t : Σ h : [C, C, hs] ⟦ functor_composite (U Z) (pr1  InitAlg),
                          pr1 InitAlg ⟧,
        bracket_property f h,
    t
@@ -860,7 +860,7 @@ Proof.
       apply (nat_trans_eq_pointwise Hyp c).
 Qed.
 
-Definition hss_InitMor : ∀ T' : hss CP H, hssMor InitHSS T'.
+Definition hss_InitMor : Π T' : hss CP H, hssMor InitHSS T'.
 Proof.
   intro T'.
   exists (InitialArrow IA (pr1 T')).
@@ -868,7 +868,7 @@ Proof.
 Defined.
 
 Lemma hss_InitMor_unique (T' : hss_precategory CP H):
-  ∀ t : hss_precategory CP H ⟦ InitHSS, T' ⟧, t = hss_InitMor T'.
+  Π t : hss_precategory CP H ⟦ InitHSS, T' ⟧, t = hss_InitMor T'.
 Proof.
   intro t.
   apply (invmap (hssMor_eq1 _ _ _ _ _ _ _ _ )).

--- a/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
@@ -131,7 +131,7 @@ Proof.
 Qed.
 
 
-Lemma μ_1_identity' : ∀ c : C, μ_1 c = identity _.
+Lemma μ_1_identity' : Π c : C, μ_1 c = identity _.
 Proof.
   intros c.
   assert (HA:= nat_trans_eq_pointwise μ_1_identity).
@@ -176,7 +176,7 @@ Defined.
 (** *** Proof of the first monad law *)
 
 Lemma Monad_law_1_from_hss :
-  ∀ c : C, μ_0 (pr1 (`T) c);; μ_2 c = identity ((pr1 (`T)) c).
+  Π c : C, μ_0 (pr1 (`T) c);; μ_2 c = identity ((pr1 (`T)) c).
 Proof.
   intro c.
   unfold μ_2. simpl.
@@ -191,7 +191,7 @@ Qed.
 (** *** Proof of the second monad law *)
 
 Lemma Monad_law_2_from_hss:
-  ∀ c : C, # (pr1 (`T)) (μ_0 c);; μ_2 c = identity ((pr1 (`T)) c).
+  Π c : C, # (pr1 (`T)) (μ_0 c);; μ_2 c = identity ((pr1 (`T)) c).
 Proof.
   intro c.
   pathvia (μ_1 c).
@@ -275,7 +275,7 @@ Defined.
     the pointed structure given by [η] *)
 
 Lemma μ_2_is_ptd_mor :
-  ∀ c : C, (ptd_pt C T_squared) c;; μ_2 c = pr1 (η T) c.
+  Π c : C, (ptd_pt C T_squared) c;; μ_2 c = pr1 (η T) c.
 Proof.
   intro c.
   unfold μ_2.
@@ -442,7 +442,7 @@ Lemma μ_3_μ_2_T_μ_2 :  (
       eapply pathscomp0. Focus 2. apply assoc.
       eapply pathscomp0. Focus 2. apply maponpaths. apply (!HXX).
       clear HXX.
-      assert (Strength_2 : ∀ α : functor_compose hs hs (functor_composite (`T) (`T))(`T) --> functor_composite (` T) (`T),
+      assert (Strength_2 : Π α : functor_compose hs hs (functor_composite (`T) (`T))(`T) --> functor_composite (` T) (`T),
 
                     pr1 (θ (`T ⊗ T_squared)) c ;; pr1 (# H α) c =
                      pr1 (θ ((`T) ⊗ (ptd_from_alg T))) ((pr1 (pr1 (pr1 T))) c);;

--- a/UniMath/SubstitutionSystems/SignatureExamples.v
+++ b/UniMath/SubstitutionSystems/SignatureExamples.v
@@ -143,7 +143,7 @@ Let D' Ze Ze' :=
  (nat_trans_comp (post_whisker (δ Ze) (pr1 Ze'))
                  (α_functor _ G (pr1 Ze) (pr1 Ze'))))).
 
-Definition δ_law2 : UU := forall Ze Ze', δ (Ze p• Ze') = D' Ze Ze'.
+Definition δ_law2 : UU := Π Ze Ze', δ (Ze p• Ze') = D' Ze Ze'.
 Hypothesis H2 : δ_law2.
 
 Lemma θ_Strength2_int_from_δ : θ_Strength2_int θ_from_δ.

--- a/UniMath/SubstitutionSystems/Signatures.v
+++ b/UniMath/SubstitutionSystems/Signatures.v
@@ -186,14 +186,14 @@ Hypothesis θ : θ_source ⟶ θ_target.
 
 (** [θ] is supposed to satisfy two strength laws *)
 
-Definition θ_Strength1 : UU := ∀ X : EndC,
+Definition θ_Strength1 : UU := Π X : EndC,
   (θ (X ⊗ (id_Ptd C hs))) ;; # H (identity X : functor_composite (functor_identity C) X ⟶ pr1 X)
           = nat_trans_id _ .
 
 Section Strength_law_1_intensional.
 
 Definition θ_Strength1_int : UU
-  := ∀ X : EndC,
+  := Π X : EndC,
      θ (X ⊗ (id_Ptd C hs)) ;; # H (λ_functor _ _ ) = λ_functor _ _ .
 
 Lemma θ_Strength1_int_implies_θ_Strength1 : θ_Strength1_int → θ_Strength1.
@@ -234,7 +234,7 @@ End Strength_law_1_intensional.
 Hypothesis θ_strength1 : θ_Strength1.
 *)
 
-Definition θ_Strength2 : UU := ∀ (X : EndC) (Z Z' : Ptd) (Y : EndC)
+Definition θ_Strength2 : UU := Π (X : EndC) (Z Z' : Ptd) (Y : EndC)
            (α : functor_compose hs hs (functor_composite (U Z) (U Z')) X --> Y),
     θ (X ⊗ (Z p• Z' : Ptd)) ;; # H α =
     θ (X ⊗ Z') •• (U Z) ;; θ ((functor_compose hs hs (U Z') X) ⊗ Z) ;;
@@ -243,7 +243,7 @@ Definition θ_Strength2 : UU := ∀ (X : EndC) (Z Z' : Ptd) (Y : EndC)
 Section Strength_law_2_intensional.
 
 Definition θ_Strength2_int : UU
-  := ∀ (X : EndC) (Z Z' : Ptd),
+  := Π (X : EndC) (Z Z' : Ptd),
       θ (X ⊗ (Z p• Z'))  ;; #H (α_functor _ (U Z) (U Z') X )  =
       (α_functor _ (U Z) (U Z') (H X) : functor_compose hs hs _ _  --> _ ) ;;
       θ (X ⊗ Z') •• (U Z) ;; θ ((functor_compose hs hs (U Z') X) ⊗ Z) .

--- a/UniMath/SubstitutionSystems/SubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/SubstitutionSystems.v
@@ -116,7 +116,7 @@ Definition bracket_at (T : algebra_ob Id_H) {Z : Ptd} (f : Z --> ptd_from_alg T)
   ∃! h : `T • (U Z)  --> `T, bracket_property T f h.
 
 Definition bracket (T : algebra_ob Id_H) : UU
-  := ∀ (Z : Ptd) (f : Z --> ptd_from_alg T), bracket_at T f.
+  := Π (Z : Ptd) (f : Z --> ptd_from_alg T), bracket_at T f.
 
 Definition bracket_property_parts (T : algebra_ob Id_H) {Z : Ptd} (f : Z --> ptd_from_alg T)
            (h : `T • (U Z)  --> `T) : UU
@@ -128,7 +128,7 @@ Definition bracket_parts_at (T : algebra_ob Id_H) {Z : Ptd} (f : Z --> ptd_from_
    ∃! h : `T • (U Z)  --> `T, bracket_property_parts T f h.
 
 Definition bracket_parts (T : algebra_ob Id_H) : UU
-  := ∀ (Z : Ptd) (f : Z --> ptd_from_alg T), bracket_parts_at T f.
+  := Π (Z : Ptd) (f : Z --> ptd_from_alg T), bracket_parts_at T f.
 
 (* show that for any h of suitable type, the following are equivalent *)
 
@@ -231,8 +231,8 @@ Qed.
 
 (* show bracket_parts_point is logically equivalent to bracket_point, then
    use it to show that bracket_parts is equivalent to bracket using [weqonsecfibers:
-  ∀ (X : UU) (P Q : X → UU),
-  (∀ x : X, P x ≃ Q x) → (∀ x : X, P x) ≃ (∀ x : X, Q x)] *)
+  Π (X : UU) (P Q : X → UU),
+  (Π x : X, P x ≃ Q x) → (Π x : X, P x) ≃ (Π x : X, Q x)] *)
 
 
 Definition hss : UU := Σ T, bracket T.
@@ -249,9 +249,9 @@ Notation "⦃ f ⦄" := (fbracket _ f)(at level 0).
 (** The bracket operation [fbracket] is unique *)
 
 Definition fbracket_unique_pointwise (T : hss) {Z : Ptd} (f : Z --> ptd_from_alg T)
-  : ∀ (α : functor_composite (U Z) `T ⟶ pr1 `T),
-     (∀ c : C, pr1 (#U f) c = pr1 (η T) (pr1 (U Z) c) ;; α c) →
-     (∀ c : C, pr1 (θ (`T ⊗ Z))  c ;; pr1 (#H α) c ;; pr1 (τ T) c =
+  : Π (α : functor_composite (U Z) `T ⟶ pr1 `T),
+     (Π c : C, pr1 (#U f) c = pr1 (η T) (pr1 (U Z) c) ;; α c) →
+     (Π c : C, pr1 (θ (`T ⊗ Z))  c ;; pr1 (#H α) c ;; pr1 (τ T) c =
         pr1 (τ T) (pr1 (U Z) c) ;; α c)
      →
      α = ⦃f⦄.
@@ -265,7 +265,7 @@ Proof.
 Qed.
 
 Definition fbracket_unique (T : hss) {Z : Ptd} (f : Z --> ptd_from_alg T)
-: ∀ α : (*functor_composite (C:=C)*) `T • (U Z)  --> `T,
+: Π α : (*functor_composite (C:=C)*) `T • (U Z)  --> `T,
     bracket_property_parts T f α
    →
    α = ⦃f⦄.
@@ -277,10 +277,10 @@ Proof.
 Qed.
 
 Definition fbracket_unique_target_pointwise (T : hss) {Z : Ptd} (f : Z --> ptd_from_alg T)
-  : ∀ α : `T • U Z --> `T,
+  : Π α : `T • U Z --> `T,
         bracket_property_parts T f α
    →
-   ∀ c, pr1 α c =  pr1 ⦃ f ⦄ c.
+   Π c, pr1 α c =  pr1 ⦃ f ⦄ c.
 Proof.
   intros α H12.
   set (t:= fbracket_unique _ _ α H12).
@@ -289,7 +289,7 @@ Qed.
 
 (** Properties of [fbracket] by definition: commutative diagrams *)
 
-Lemma fbracket_η (T : hss) : ∀ {Z : Ptd} (f : Z --> ptd_from_alg T),
+Lemma fbracket_η (T : hss) : Π {Z : Ptd} (f : Z --> ptd_from_alg T),
    #U f = η T •• U Z ;; ⦃f⦄.
 Proof.
   intros Z f.
@@ -297,7 +297,7 @@ Proof.
   exact (pr1 (parts_from_whole _ _ _ _  (pr2 (pr1 (pr2 T Z f))))).
 Qed.
 
-Lemma fbracket_τ (T : hss) : ∀ {Z : Ptd} (f : Z --> ptd_from_alg T),
+Lemma fbracket_τ (T : hss) : Π {Z : Ptd} (f : Z --> ptd_from_alg T),
     θ (`T ⊗ Z) ;; #H ⦃f⦄ ;; τ T
     =
     τ T •• U Z ;; ⦃f⦄.
@@ -366,7 +366,7 @@ Qed.
 
 (** As a consequence of naturality, we can compute [fbracket f] from [fbracket identity] *)
 
-Lemma compute_fbracket (T : hss) : ∀ {Z : Ptd} (f : Z --> ptd_from_alg T),
+Lemma compute_fbracket (T : hss) : Π {Z : Ptd} (f : Z --> ptd_from_alg T),
     ⦃ f ⦄ = (` T ∘ # U f : EndC ⟦ `T • U Z , `T • U (p T) ⟧) ;; ⦃ identity p T ⦄.
 Proof.
   intros Z f.
@@ -484,7 +484,7 @@ Definition ptd_from_alg_functor: functor (precategory_FunctorAlg Id_H hsEndC) Pt
 
 
 Definition isbracketMor {T T' : hss} (β : algebra_mor _ T T') : UU :=
-    ∀ (Z : Ptd) (f : Z --> ptd_from_alg T),
+    Π (Z : Ptd) (f : Z --> ptd_from_alg T),
       ⦃ f ⦄ ;; β = β •• U Z ;; ⦃ f ;; # ptd_from_alg_functor β ⦄.
 
 

--- a/UniMath/SubstitutionSystems/SubstitutionSystems_Summary.v
+++ b/UniMath/SubstitutionSystems/SubstitutionSystems_Summary.v
@@ -55,11 +55,11 @@ Notation "G • F" := (functor_composite F G).
 (** Lemma 8 *)
 
 Definition GenMendlerIteration :
-   ∀ (C : precategory) (hsC : has_homsets C) (F : functor C C)
+   Π (C : precategory) (hsC : has_homsets C) (F : functor C C)
    (μF_Initial : Initial (FunctorAlg F hsC)) (C' : precategory)
    (hsC' : has_homsets C') (X : C') (L : functor C C'),
    equivalences.is_left_adjoint L
-   → ∀ ψ : ψ_source C C' hsC' X L ⟶ ψ_target C F C' hsC' X L,
+   → Π ψ : ψ_source C C' hsC' X L ⟶ ψ_target C F C' hsC' X L,
      ∃! h : C' ⟦ L ` (InitialObject μF_Initial), X ⟧,
      # L (alg_map F (InitialObject μF_Initial)) ;; h =
      ψ ` (InitialObject μF_Initial) h.
@@ -73,7 +73,7 @@ Arguments It {_ _ _} _ {_} _ _ _ _ _ .
 (** Lemma 9 *)
 
 Theorem fusion_law
-     : ∀ (C : precategory) (hsC : has_homsets C)
+     : Π (C : precategory) (hsC : has_homsets C)
        (F : functor C C)
        (μF_Initial : Initial (precategory_FunctorAlg F hsC))
        (C' : precategory) (hsC' : has_homsets C')
@@ -101,7 +101,7 @@ Qed.
 (** Lemma 15 *)
 
 Lemma fbracket_natural
-     : ∀ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
+     : Π (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
        (H : Signature C hs) (T : hss CP H) (Z Z' : precategory_Ptd C hs)
        (f : precategory_Ptd C hs ⟦ Z, Z' ⟧)
        (g : precategory_Ptd C hs ⟦ Z', ptd_from_alg T ⟧),
@@ -111,7 +111,7 @@ Proof.
 Qed.
 
 Lemma compute_fbracket
-     : ∀ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
+     : Π (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
        (H : Signature C hs) (T : hss CP H) (Z : precategory_Ptd C hs)
        (f : precategory_Ptd C hs ⟦ Z, ptd_from_alg T ⟧),
        ⦃ f ⦄ = (`T ∘ # U f : [C,C,hs] ⟦ `T • U Z , `T • U _ ⟧) ;; ⦃ identity (ptd_from_alg T) ⦄.
@@ -125,7 +125,7 @@ Qed.
 (** Theorem 24 *)
 
 Definition Monad_from_hss
-     : ∀ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
+     : Π (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
        (H : Signature C hs), hss CP H → Monad C.
 Proof.
   apply Monad_from_hss.
@@ -134,7 +134,7 @@ Defined.
 (** Theorem 25 *)
 
 Definition hss_to_monad_functor
-     : ∀ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
+     : Π (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
        (H : Signature C hs),
        functor (hss_precategory CP H) (precategory_Monad C hs).
 Proof.
@@ -144,7 +144,7 @@ Defined.
 (** Lemma 26 *)
 
 Lemma faithful_hss_to_monad
-     : ∀ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
+     : Π (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
        (H : Signature C hs), faithful (hss_to_monad_functor C hs CP H).
 Proof.
   apply faithful_hss_to_monad.
@@ -160,9 +160,9 @@ Defined.
 *)
 
 Definition bracket_for_initial_algebra
- : ∀ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C),
-     (∀ Z : precategory_Ptd C hs, GlobalRightKanExtensionExists C C (U Z) C hs hs)
-       → ∀ (H : Signature C hs)
+ : Π (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C),
+     (Π Z : precategory_Ptd C hs, GlobalRightKanExtensionExists C C (U Z) C hs hs)
+       → Π (H : Signature C hs)
            (IA : Initial (FunctorAlg (Id_H C hs CP H) (functor_category_has_homsets C C hs)))
            (Z : precategory_Ptd C hs),
            precategory_Ptd C hs ⟦ Z, ptd_from_alg (InitAlg C hs CP H IA) ⟧
@@ -173,8 +173,8 @@ Proof.
 Defined.
 
 Lemma bracket_Thm15_ok_η
-     : ∀ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
-       (KanExt : ∀ Z : precategory_Ptd C hs,
+     : Π (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
+       (KanExt : Π Z : precategory_Ptd C hs,
                  GlobalRightKanExtensionExists C C (U Z) C hs hs)
        (H : Signature C hs)
        (IA : Initial (FunctorAlg (Id_H C hs CP H) (functor_category_has_homsets C C hs)))
@@ -188,8 +188,8 @@ Proof.
 Qed.
 
 Lemma bracket_Thm15_ok_τ
-  : ∀ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
-      (KanExt : ∀ Z : precategory_Ptd C hs, GlobalRightKanExtensionExists C C (U Z) C hs hs)
+  : Π (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
+      (KanExt : Π Z : precategory_Ptd C hs, GlobalRightKanExtensionExists C C (U Z) C hs hs)
       (H : Signature C hs)
       (IA : Initial (FunctorAlg (Id_H C hs CP H) (functor_category_has_homsets C C hs)))
       (Z : precategory_Ptd C hs)
@@ -207,10 +207,10 @@ Qed.
 (** Theorem 29 *)
 
 Definition Initial_HSS :
-   ∀ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C),
-     (∀ Z : precategory_Ptd C hs,
+   Π (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C),
+     (Π Z : precategory_Ptd C hs,
          GlobalRightKanExtensionExists C C (U Z) C hs hs)
-     → ∀ H : Signature C hs,
+     → Π H : Signature C hs,
        Initial (FunctorAlg (Id_H C hs CP H) (functor_category_has_homsets C C hs))
        → Initial (hss_precategory CP H).
 Proof.
@@ -223,7 +223,7 @@ Defined.
 (** Lemma 30 *)
 
 Definition Sum_of_Signatures
-  : ∀ (C : precategory) (hs : has_homsets C),
+  : Π (C : precategory) (hs : has_homsets C),
        BinCoproducts C → Signature C hs → Signature C hs → Signature C hs.
 Proof.
   apply BinSum_of_Signatures.
@@ -235,7 +235,7 @@ Defined.
 (** Definition 31 *)
 
 Definition App_Sig
-  : ∀ (C : precategory) (hs : has_homsets C), BinProducts C → Signature C hs.
+  : Π (C : precategory) (hs : has_homsets C), BinProducts C → Signature C hs.
 Proof.
   apply App_Sig.
 Defined.
@@ -243,7 +243,7 @@ Defined.
 (** Definition 32 *)
 
 Definition Lam_Sig
-  : ∀ (C : precategory) (hs : has_homsets C),
+  : Π (C : precategory) (hs : has_homsets C),
     Terminal C → BinCoproducts C → BinProducts C → Signature C hs.
 Proof.
   apply Lam_Sig.
@@ -252,7 +252,7 @@ Defined.
 (** Definition 33 *)
 
 Definition Flat_Sig
-  : ∀ (C : precategory) (hs : has_homsets C), Signature C hs.
+  : Π (C : precategory) (hs : has_homsets C), Signature C hs.
 Proof.
   apply Flat_Sig.
 Defined.
@@ -262,12 +262,12 @@ Defined.
 (** Definition 36 *)
 
 Definition Lam_Flatten
-  :  ∀ (C : precategory) (hs : has_homsets C)
+  :  Π (C : precategory) (hs : has_homsets C)
        (terminal : Terminal C)
        (CC : BinCoproducts C) (CP : BinProducts C),
-    (∀ Z : precategory_Ptd C hs,
+    (Π Z : precategory_Ptd C hs,
         GlobalRightKanExtensionExists C C (U Z) C hs hs)
-    → ∀ Lam_Initial : Initial (FunctorAlg (Id_H C hs CC (Lam_Sig C hs terminal CC CP))
+    → Π Lam_Initial : Initial (FunctorAlg (Id_H C hs CC (Lam_Sig C hs terminal CC CP))
                                           (functor_category_has_homsets C C hs)),
   [C, C, hs] ⟦ (Flat_H C hs) ` (InitialObject Lam_Initial), ` (InitialObject Lam_Initial) ⟧.
 Proof.
@@ -277,9 +277,9 @@ Defined.
 (** Lemma 37, construction of the bracket *)
 
 Definition fbracket_for_LamE_algebra_on_Lam
-  : ∀ (C : precategory) (hs : has_homsets C) (terminal : Terminal C)
+  : Π (C : precategory) (hs : has_homsets C) (terminal : Terminal C)
       (CC : BinCoproducts C) (CP : BinProducts C)
-      (KanExt : ∀ Z : precategory_Ptd C hs, GlobalRightKanExtensionExists C C (U Z) C hs hs)
+      (KanExt : Π Z : precategory_Ptd C hs, GlobalRightKanExtensionExists C C (U Z) C hs hs)
       (Lam_Initial : Initial (FunctorAlg (Id_H C hs CC (Lam_Sig C hs terminal CC CP))
                                          (functor_category_has_homsets C C hs)))
       (Z : precategory_Ptd C hs),
@@ -297,9 +297,9 @@ Defined.
 (** Morphism from initial hss to construed hss, consequence of Lemma 37 *)
 
 Definition EVAL
-  : ∀ (C : precategory) (hs : has_homsets C) (terminal : Terminal C)
+  : Π (C : precategory) (hs : has_homsets C) (terminal : Terminal C)
       (CC : BinCoproducts C) (CP : BinProducts C)
-      (KanExt : ∀ Z : precategory_Ptd C hs, GlobalRightKanExtensionExists C C (U Z) C hs hs)
+      (KanExt : Π Z : precategory_Ptd C hs, GlobalRightKanExtensionExists C C (U Z) C hs hs)
        (Lam_Initial : Initial
                         (FunctorAlg
                            (Id_H C hs CC

--- a/UniMath/SubstitutionSystems/SumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/SumOfSignatures.v
@@ -54,10 +54,10 @@ Local Notation "'CCC'" := (Coproducts_functor_precat I C C CC hsC : Coproducts I
 
 Variables H1 : I -> functor [C, C, hsC] [C, C, hsC].
 
-Variable θ1 : forall i, θ_source (H1 i) ⟶ θ_target (H1 i).
+Variable θ1 : Π i, θ_source (H1 i) ⟶ θ_target (H1 i).
 
-(* Variable S11 : forall i, θ_Strength1 (θ1 i). *)
-(* Variable S12 : forall i, θ_Strength2 (θ1 i). *)
+(* Variable S11 : Π i, θ_Strength1 (θ1 i). *)
+(* Variable S12 : Π i, θ_Strength2 (θ1 i). *)
 
 (** * Definition of the data of the sum of two signatures *)
 
@@ -93,7 +93,7 @@ Proof.
 exists (bla1 X Z); apply bar.
 Defined.
 
-Definition θ_ob : ∀ XF, θ_source H XF --> θ_target H XF.
+Definition θ_ob : Π XF, θ_source H XF --> θ_target H XF.
 Proof.
 intros [X Z]; apply bla.
 Defined.
@@ -114,8 +114,8 @@ Local Definition θ : θ_source H ⟶ θ_target H := tpair _ _ is_nat_trans_θ_o
 
 (** * Proof of the laws of the sum of two signatures *)
 
-Variable S11' : forall i, θ_Strength1_int (θ1 i).
-Variable S12' : forall i, θ_Strength2_int (θ1 i).
+Variable S11' : Π i, θ_Strength1_int (θ1 i).
+Variable S12' : Π i, θ_Strength2_int (θ1 i).
 
 Lemma SumStrength1' : θ_Strength1_int θ.
 Proof.
@@ -156,7 +156,7 @@ mkpair.
 Defined.
 
 Lemma is_omega_cocont_Sum_of_Signatures (S : I -> Signature C hsC)
-  (h : forall i, is_omega_cocont (S i)) (PC : Products I C) :
+  (h : Π i, is_omega_cocont (S i)) (PC : Products I C) :
   is_omega_cocont (Sum_of_Signatures S).
 Proof.
 apply is_omega_cocont_coproduct_of_functors; try assumption.

--- a/UniMath/Tactics/Abmonoids_Tactics.v
+++ b/UniMath/Tactics/Abmonoids_Tactics.v
@@ -17,8 +17,8 @@ Definition abmonoid_to_absemigr (M : abmonoid) : isabsemigrop (@op M) :=
   dirprodpair (@assocax M) (@commax M).
 
 Definition absemigr_perm021 :
-  forall X : hSet, forall opp : binop X, forall is : isabsemigrop opp,
-  forall n0 n1 n2,
+  Π X : hSet, Π opp : binop X, Π is : isabsemigrop opp,
+  Π n0 n1 n2,
     opp (opp n0 n1) n2 = opp (opp n0 n2) n1 :=
   fun X opp is n0 n1 n2 =>
     pathscomp0
@@ -31,8 +31,8 @@ Definition abmonoid_perm021 :=
   fun M : abmonoid => absemigr_perm021 M (@op M) (abmonoid_to_absemigr M).
 
 Definition absemigr_perm102 :
-  forall X : hSet, forall opp : binop X, forall is : isabsemigrop opp,
-  forall n0 n1 n2,
+  Π X : hSet, Π opp : binop X, Π is : isabsemigrop opp,
+  Π n0 n1 n2,
     opp (opp n0 n1) n2 = opp (opp n1 n0) n2 :=
   fun X opp is n0 n1 n2 => maponpaths (fun z => opp z n2) ((pr2 is) n0 n1).
 
@@ -40,8 +40,8 @@ Definition abmonoid_perm102 :=
   fun M : abmonoid => absemigr_perm102 M (@op M) (abmonoid_to_absemigr M).
 
 Definition absemigr_perm120 :
-  forall X : hSet, forall opp : binop X, forall is : isabsemigrop opp,
-  forall n0 n1 n2,
+  Π X : hSet, Π opp : binop X, Π is : isabsemigrop opp,
+  Π n0 n1 n2,
     opp (opp n0 n1) n2 = opp (opp n2 n0) n1 :=
   fun X opp is n0 n1 n2 =>
     pathscomp0 ((pr2 is) (opp n0 n1) n2) (pathsinv0 ((pr1 is) n2 n0 n1)).
@@ -50,8 +50,8 @@ Definition abmonoid_perm120 :=
   fun M : abmonoid => absemigr_perm120 M (@op M) (abmonoid_to_absemigr M).
 
 Definition absemigr_perm201 :
-  forall X : hSet, forall opp : binop X, forall is : isabsemigrop opp,
-  forall n0 n1 n2,
+  Π X : hSet, Π opp : binop X, Π is : isabsemigrop opp,
+  Π n0 n1 n2,
     opp (opp n0 n1) n2 = opp (opp n1 n2) n0 :=
   fun X opp is n0 n1 n2 =>
     pathscomp0 ((pr1 is) n0 n1 n2) ((pr2 is) n0 (opp n1 n2)).
@@ -60,8 +60,8 @@ Definition abmonoid_perm201 :=
   fun M : abmonoid => absemigr_perm201 M (@op M) (abmonoid_to_absemigr M).
 
 Definition absemigr_perm210 :
-  forall X : hSet, forall opp : binop X, forall is : isabsemigrop opp,
-  forall n0 n1 n2,
+  Π X : hSet, Π opp : binop X, Π is : isabsemigrop opp,
+  Π n0 n1 n2,
     opp (opp n0 n1) n2 = opp (opp n2 n1) n0 :=
   fun X opp is n0 n1 n2 =>
     pathscomp0 (absemigr_perm102 X opp is n0 n1 n2)

--- a/UniMath/Tactics/Nat_Tactics.v
+++ b/UniMath/Tactics/Nat_Tactics.v
@@ -22,7 +22,7 @@ Definition natneqtwist n (p : ¬ (0 = n)) : ¬ (n = 0) :=
   fun f => p (pathsinv0 f).
 
 Definition nat_plus_perm021 :
-  forall n0 n1 n2,
+  Π n0 n1 n2,
     n0 + n1 + n2 = n0 + n2 + n1 :=
   fun n0 n1 n2 =>
     pathscomp0
@@ -32,30 +32,30 @@ Definition nat_plus_perm021 :
       (pathsinv0 (natplusassoc n0 n2 n1)).
 
 Definition nat_plus_perm102 :
-  forall n0 n1 n2,
+  Π n0 n1 n2,
     n0 + n1 + n2 = n1 + n0 + n2 :=
   fun n0 n1 n2 => maponpaths (fun z => z + n2) (natpluscomm n0 n1).
 
 Definition nat_plus_perm120 :
-  forall n0 n1 n2,
+  Π n0 n1 n2,
     n0 + n1 + n2 = n2 + n0 + n1 :=
   fun n0 n1 n2 =>
     pathscomp0 (natpluscomm (n0 + n1) n2) (pathsinv0 (natplusassoc n2 n0 n1)).
 
 Definition nat_plus_perm201 :
-  forall n0 n1 n2,
+  Π n0 n1 n2,
     n0 + n1 + n2 = n1 + n2 + n0 :=
   fun n0 n1 n2 =>
     pathscomp0 (natplusassoc n0 n1 n2) (natpluscomm n0 (n1 + n2)).
 
 Definition nat_plus_perm210 :
-  forall n0 n1 n2,
+  Π n0 n1 n2,
     n0 + n1 + n2 = n2 + n1 + n0 :=
   fun n0 n1 n2 =>
     pathscomp0 (nat_plus_perm102 n0 n1 n2) (nat_plus_perm120 n1 n0 n2).
 
 Definition nat_mult_perm021 :
-  forall n0 n1 n2,
+  Π n0 n1 n2,
     n0 * n1 * n2 = n0 * n2 * n1 :=
   fun n0 n1 n2 =>
     pathscomp0
@@ -65,29 +65,29 @@ Definition nat_mult_perm021 :
       (pathsinv0 (natmultassoc n0 n2 n1)).
 
 Definition nat_mult_perm102 :
-  forall n0 n1 n2,
+  Π n0 n1 n2,
     n0 * n1 * n2 = n1 * n0 * n2 :=
   fun n0 n1 n2 => maponpaths (fun z => z * n2) (natmultcomm n0 n1).
 
 Definition nat_mult_perm120 :
-  forall n0 n1 n2,
+  Π n0 n1 n2,
     n0 * n1 * n2 = n2 * n0 * n1 :=
   fun n0 n1 n2 =>
     pathscomp0 (natmultcomm (n0 * n1) n2) (pathsinv0 (natmultassoc n2 n0 n1)).
 
 Definition nat_mult_perm201 :
-  forall n0 n1 n2,
+  Π n0 n1 n2,
     n0 * n1 * n2 = n1 * n2 * n0 :=
   fun n0 n1 n2 =>
     pathscomp0 (natmultassoc n0 n1 n2) (natmultcomm n0 (n1 * n2)).
 
 Definition nat_mult_perm210 :
-  forall n0 n1 n2,
+  Π n0 n1 n2,
     n0 * n1 * n2 = n2 * n1 * n0 :=
   fun n0 n1 n2 =>
     pathscomp0 (nat_mult_perm102 n0 n1 n2) (nat_mult_perm120 n1 n0 n2).
 
-Definition minus0r : forall n, n - 0 = n :=
+Definition minus0r : Π n, n - 0 = n :=
   fun n => match n with
              | 0 => (idpath _)
              | S _ => (idpath _)
@@ -911,7 +911,7 @@ Ltac nat_simple :=
 Ltac nat_intros :=
   repeat match goal with
            | |- ?x -> ?y => intro
-           | |- forall _, _ => intro
+           | |- Π _, _ => intro
          end.
 
 Ltac nat_try :=


### PR DESCRIPTION
We rename our notation for ∀ to Π.

We make a global definition for ∀ that applies just to families of
propositions and yields a proposition (hProp).

We change all existing uses of "forall" and ∀ to Π.  Later on, those
that applied to hProps could be switched back to ∀.

The reason we change all uses of "forall" is that ∀ is normally read as
"for all".

Here is the definition of ∀ from Propositions.v:
```
    Lemma isaprop_forall_hProp (X:UU) (Y:X->hProp) : isaprop (Π x, Y x).
    Proof. intros. apply impred_isaprop. intro x. apply propproperty. Defined.

    Definition forall_hProp {X:UU} (Y:X->hProp) : hProp := hProppair (Π x, Y x) (isaprop_forall_hProp X Y).

    Notation "∀  x .. y , P" := (forall_hProp (fun x => .. (forall_hProp (fun y => P)) ..))
      (at level 200, x binder, y binder, right associativity) : type_scope.
```

This resolves #369 .