### PR TITLE
Removed duplicates and fixed Types to UU

### DIFF
--- a/UniMath/CategoryTheory/Epis.v
+++ b/UniMath/CategoryTheory/Epis.v
@@ -11,7 +11,7 @@ Section def_epi.
   Variable C : precategory.
 
   (** Definition and construction of isEpi. *)
-  Definition isEpi {x y : C} (f : x --> y) :=
+  Definition isEpi {x y : C} (f : x --> y) : UU :=
     forall (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h.
   Definition mk_isEpi {x y : C} (f : x --> y) :
     (forall (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h) -> isEpi f.

--- a/UniMath/CategoryTheory/Monics.v
+++ b/UniMath/CategoryTheory/Monics.v
@@ -11,7 +11,7 @@ Section def_monic.
   Variable C : precategory.
 
   (** Definition and construction of isMonic. *)
-  Definition isMonic {y z : C} (f : y --> z) :=
+  Definition isMonic {y z : C} (f : y --> z) : UU :=
     forall (x : C) (g h : x --> y), g ;; f = h ;; f -> g = h.
   Definition mk_isMonic {y z : C} (f : y --> z) :
     (forall (x : C) (g h : x --> y), g ;; f = h ;; f -> g = h) -> isMonic f.

--- a/UniMath/CategoryTheory/PreAdditive.v
+++ b/UniMath/CategoryTheory/PreAdditive.v
@@ -19,7 +19,7 @@ Section def_preadditive.
   (** In preadditive category precomposition and postcomposition for any
     morphism yields a morphism of abelian groups. Classically one says that
     composition is bilinear with respect to the abelian groups? *)
-  Definition isPreAdditive (PA : PrecategoryWithAbgrops) :=
+  Definition isPreAdditive (PA : PrecategoryWithAbgrops) : UU :=
     (forall (x y z : PA) (f : x --> y),
         ismonoidfun (PrecategoryWithAbgrops_premor PA x y z f))
       × (forall (x y z : PA) (f : y --> z),

--- a/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
+++ b/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
@@ -18,7 +18,7 @@ Section def_precategory_with_abgrops.
 
   (** Definition of precategories such that homsets are abgrops. *)
   Definition isPrecategoryWithAbgrops (PB : PrecategoryWithBinOps)
-             (hs : has_homsets PB) :=
+             (hs : has_homsets PB) : UU :=
     forall (x y : PB), @isabgrop (hSetpair (PB⟦x,y⟧) (hs x y))
                             (PrecategoryWithBinOps_binop PB x y).
 

--- a/UniMath/CategoryTheory/PrecategoriesWithBinOps.v
+++ b/UniMath/CategoryTheory/PrecategoriesWithBinOps.v
@@ -15,7 +15,7 @@ Section def_precategory_with_binops.
 
 
   (** Definition of precategories such that homs are binops. *)
-  Definition PrecategoryWithBinOpsData (C : precategory) :=
+  Definition PrecategoryWithBinOpsData (C : precategory) : UU :=
     forall (x y : C), binop (C⟦x, y⟧).
 
   Definition PrecategoryWithBinOps :

--- a/UniMath/CategoryTheory/limits/BinDirectSums.v
+++ b/UniMath/CategoryTheory/limits/BinDirectSums.v
@@ -29,7 +29,7 @@ Section def_bindirectsums.
 
   (** Definition of isBinDirectSumCone *)
   Definition isBinDirectSumCone (a b co : A) (i1 : a --> co) (i2 : b --> co)
-             (p1 : co --> a) (p2 : co --> b) :=
+             (p1 : co --> a) (p2 : co --> b) : UU :=
     (isBinCoproductCocone A a b co i1 i2)
       × (isBinProductCone A a b co p1 p2)
       × (i1 ;; p1 = identity a) × (i2 ;; p2 = identity b)
@@ -97,8 +97,8 @@ Section def_bindirectsums.
     BinDirectSumCone a b := tpair _ (tpair _ co (i1,,(i2,,(p1,,p2)))) H.
 
   (** BinDirectSum in categories. *)
-  Definition BinDirectSums := forall (a b : A), BinDirectSumCone a b.
-  Definition has_BinDirectSums := ishinh BinDirectSums.
+  Definition BinDirectSums : UU := forall (a b : A), BinDirectSumCone a b.
+  Definition has_BinDirectSums : UU := ishinh BinDirectSums.
 
   (** The direct sum object. *)
   Definition BinDirectSumConeOb {a b : A} (B : BinDirectSumCone a b) :

--- a/UniMath/CategoryTheory/limits/cokernels.v
+++ b/UniMath/CategoryTheory/limits/cokernels.v
@@ -38,8 +38,8 @@ Section def_cokernels.
     use (mk_Coequalizer g (ZeroArrow _ Z x y) f (CokernelEqRw H)).
     apply isE.
   Defined.
-  Definition Cokernels := forall (y z : C) (g : y --> z), Cokernel g.
-  Definition hasCokernels := forall (y z : C) (g : y --> z), ishinh (Cokernel g).
+  Definition Cokernels : UU := forall (y z : C) (g : y --> z), Cokernel g.
+  Definition hasCokernels : UU := forall (y z : C) (g : y --> z), ishinh (Cokernel g).
   Definition CokernelOb {y z : C} {g : y --> z} (CK : Cokernel g) :
     C := CoequalizerObject CK.
   Coercion CokernelOb : Cokernel >-> ob.

--- a/UniMath/CategoryTheory/limits/equalizers.v
+++ b/UniMath/CategoryTheory/limits/equalizers.v
@@ -63,9 +63,9 @@ Section def_equalizers.
   Defined.
 
   (** Equalizers in precategories. *)
-  Definition Equalizers := forall (y z : C) (f g : y --> z), Equalizer f g.
+  Definition Equalizers : UU := forall (y z : C) (f g : y --> z), Equalizer f g.
 
-  Definition hasEqualizers := forall (y z : C) (f g : y --> z),
+  Definition hasEqualizers : UU := forall (y z : C) (f g : y --> z),
       ishinh (Equalizer f g).
 
   (** Returns the equalizer object. *)

--- a/UniMath/CategoryTheory/limits/graphs/zero.v
+++ b/UniMath/CategoryTheory/limits/graphs/zero.v
@@ -19,7 +19,7 @@ Section def_zero.
   Context {C : precategory}.
 
   (** An object c is zero if it initial and terminal. *)
-  Definition isZero (c : C) := (isInitial C c) × (isTerminal C c).
+  Definition isZero (c : C) : UU := (isInitial C c) × (isTerminal C c).
 
   (** Construction of isZero for an object c from the conditions that the space
     of all morphisms from c to any object d is contractible and and the space of

--- a/UniMath/CategoryTheory/limits/initial.v
+++ b/UniMath/CategoryTheory/limits/initial.v
@@ -13,9 +13,9 @@ Section def_initial.
 
 Variable C : precategory.
 
-Definition isInitial (a : C) := forall b : C, iscontr (a --> b).
+Definition isInitial (a : C) : UU := forall b : C, iscontr (a --> b).
 
-Definition Initial := total2 (fun a => isInitial a).
+Definition Initial : UU := total2 (fun a => isInitial a).
 
 Definition InitialObject (O : Initial) : C := pr1 O.
 Coercion InitialObject : Initial >-> ob.
@@ -108,28 +108,6 @@ Section Initial_and_EmptyCoprod.
         (intros i; apply (fromempty i)).
     apply (iscontrpair (CoproductArrow _ _ X H)); intros t.
     apply CoproductArrowUnique; intros i; apply (fromempty i).
-  Defined.
-
-  (** Construct empty arbitrary coproduct from initial *)
-  Definition empty_coproduct_from_initial (C : precategory)
-             (hs : has_homsets C) :
-    Initial C -> CoproductCocone empty C fromempty.
-  Proof.
-    intros I.
-    assert (H : forall i : empty, C⟦fromempty i, I⟧) by
-        (intros i; apply (fromempty i)).
-    refine (mk_CoproductCocone _ _ _ (InitialObject I) H _).
-    refine (mk_isCoproductCocone _ _ hs _ _ _ _).
-    intros c g.
-    set (k := @InitialArrow _ I c).
-    assert (H0 : forall i : empty, H i ;; (InitialArrow I c) = g i) by
-        (intros i; apply (fromempty i)).
-    refine (iscontrpair (tpair _ k H0) _). intros t.
-    apply (total2_paths (InitialArrowEq C I c _ _)).
-    apply proofirrelevance.
-    apply impred_isaprop.
-    intros t0.
-    apply hs.
   Defined.
 End Initial_and_EmptyCoprod.
 

--- a/UniMath/CategoryTheory/limits/kernels.v
+++ b/UniMath/CategoryTheory/limits/kernels.v
@@ -36,15 +36,16 @@ Section def_kernels.
     use (mk_Equalizer g (ZeroArrow _ Z y z) f (KernelEqRw H)).
     apply isE.
   Defined.
-  Definition Kernels := forall (y z : C) (g : y --> z), Kernel g.
-  Definition hasKernels := forall (y z : C) (g : y --> z), ishinh (Kernel g).
+  Definition Kernels : UU := forall (y z : C) (g : y --> z), Kernel g.
+  Definition hasKernels : UU := forall (y z : C) (g : y --> z), ishinh (Kernel g).
   Definition KernelOb {y z : C} {g : y --> z} (K : Kernel g) :
     C := EqualizerObject K.
   Coercion KernelOb : Kernel >-> ob.
   Definition KernelArrow {y z : C} {g : y --> z} (K : Kernel g) :
-    C⟦K, y⟧:= EqualizerArrow K.
-  Definition KernelEqAr {y z : C} {g : y --> z} (K : Kernel g) :=
-    EqualizerEqAr K.
+    C⟦K, y⟧ := EqualizerArrow K.
+  Definition KernelEqAr {y z : C} {g : y --> z} (K : Kernel g)
+    : EqualizerArrow K ;; g = EqualizerArrow K ;; (ZeroArrow _ Z y z)
+    := EqualizerEqAr K.
   Definition KernelIn {y z : C} {g : y --> z} (K : Kernel g)
              (w : C) (h : w --> y) (H : h ;; g = ZeroArrow _ Z w z) :
     C⟦w, K⟧ := EqualizerIn K _ h (KernelEqRw H).

--- a/UniMath/CategoryTheory/limits/terminal.v
+++ b/UniMath/CategoryTheory/limits/terminal.v
@@ -13,9 +13,9 @@ Section def_terminal.
 
 Variable C : precategory.
 
-Definition isTerminal (b : C) := forall a : C, iscontr (a --> b).
+Definition isTerminal (b : C) : UU := forall a : C, iscontr (a --> b).
 
-Definition Terminal := total2 (fun a => isTerminal a).
+Definition Terminal : UU := total2 (fun a => isTerminal a).
 
 Definition TerminalObject (T : Terminal) : C := pr1 T.
 Coercion TerminalObject : Terminal >-> ob.
@@ -110,29 +110,6 @@ Section Terminal_and_EmptyProd.
         (intros i; apply (fromempty i)).
     apply (iscontrpair (ProductArrow _ _ X H)); intros t.
     apply ProductArrowUnique; intros i; apply (fromempty i).
-  Defined.
-
-  (** Construct empty arbitrary product from Terminal *)
-  Definition empty_product_from_terminal (C : precategory)
-    (hs : has_homsets C) :
-    Terminal C ->  ProductCone empty C fromempty.
-  Proof.
-    intros T.
-    assert (H : forall i : empty, C⟦T, fromempty i⟧) by
-        (intros i; apply (fromempty i)).
-    refine (mk_ProductCone _ _ _ T H _).
-    refine (mk_isProductCone _ _ hs _ _ _ _).
-    intros c f.
-    set (k := @TerminalArrow _ T c).
-    assert (H0 : forall i : empty, (TerminalArrow c) ;; H i = f i) by
-        (intros i; apply (fromempty i)).
-
-    refine (iscontrpair (tpair _ k H0) _). intros t.
-    apply (total2_paths (ArrowsToTerminal C T c _ _)).
-    apply proofirrelevance.
-    apply impred_isaprop.
-    intros t0.
-    apply hs.
   Defined.
 End Terminal_and_EmptyProd.
 

--- a/UniMath/CategoryTheory/limits/zero.v
+++ b/UniMath/CategoryTheory/limits/zero.v
@@ -15,10 +15,10 @@ Section def_zero.
 
   Variable C : precategory.
 
-  Definition isZero (b : C) :=
+  Definition isZero (b : C) : UU :=
     (∀ a : C, iscontr (b --> a)) × (∀ a : C, iscontr (a --> b)).
 
-  Definition Zero := total2 (fun a => isZero a).
+  Definition Zero : UU := total2 (fun a => isZero a).
 
   Definition ZeroObject (Z : Zero) : C := pr1 Z.
   Coercion ZeroObject : Zero >-> ob.


### PR DESCRIPTION
Hi,

this pull request removes duplicates for constructing (co)products from terminals
(resp. initials), (the new ones which use stn 0 instead of empty are found in
FinOrd(Co)products.v), and adds UU to places where it is missing. In
particular, the latter is important, because, if one does not write UU, then coq
uses Type. Type is not allowed outside Preamble.v .
