### PR TITLE
Additive and Abelian categories

### DIFF
--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -73,3 +73,4 @@ Additive.v
 Abelian.v
 category_binops.v
 category_abgr.v
+AbelianisAdditive.v

--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -69,3 +69,7 @@ PreAdditive.v
 limits/BinDirectSums.v
 limits/FinOrdProducts.v
 limits/FinOrdCoproducts.v
+Additive.v
+Abelian.v
+category_binops.v
+category_abgr.v

--- a/UniMath/CategoryTheory/Abelian.v
+++ b/UniMath/CategoryTheory/Abelian.v
@@ -20,6 +20,8 @@ Require Import UniMath.CategoryTheory.limits.equalizers.
 Require Import UniMath.CategoryTheory.limits.coequalizers.
 Require Import UniMath.CategoryTheory.limits.kernels.
 Require Import UniMath.CategoryTheory.limits.cokernels.
+Require Import UniMath.CategoryTheory.limits.pushouts.
+Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import UniMath.CategoryTheory.Monics.
 Require Import UniMath.CategoryTheory.Epis.
 
@@ -27,97 +29,385 @@ Section def_abelian.
 
   (** An abelian category has a zero object, binary (co)products, (co)kernels
     and every monic (resp. epi) is a kernel (resp. cokernel). *)
-  Definition AbelianData (C : precategory) : UU := Zero C.
+  Definition AbelianData1 (C : precategory) : UU :=
+    Zero C × (BinProducts C) × (BinCoproducts C).
+
+  Definition AbelianData2 (C : precategory) (AD1 : AbelianData1 C) : UU :=
+    (Kernels (pr1 AD1)) × (Cokernels (pr1 AD1)).
 
   Definition isAbelianMonicKernels (C : precategory)
-             (AD : AbelianData C) : UU :=
-    ∀ (x y : C) (M : Monic C x y),
-      (∃ (z : C) (f : y --> z) (H : M ;; f = M ;; (ZeroArrow C AD y z)),
-          isEqualizer f (ZeroArrow C AD y z) M H).
+             (AD : AbelianData1 C) : UU :=
+    Π (x y : C) (M : Monic C x y),
+      (∃ (z : C) (f : y --> z) (H : M ;; f = M ;; (ZeroArrow C (pr1 AD) y z)),
+          isEqualizer f (ZeroArrow C (pr1 AD) y z) M H).
+
+  Definition isapropisAbelianMonicKernels (C : precategory)
+             (AD1 : AbelianData1 C) :
+    isaprop (isAbelianMonicKernels C AD1).
+  Proof.
+    apply impred_isaprop; intros x.
+    apply impred_isaprop; intros y.
+    apply impred_isaprop; intros M.
+    apply isapropishinh.
+  Qed.
 
   Definition isAbelianEpiCokernels (C : precategory)
-             (AD : AbelianData C) : UU :=
-    (∀ (y z : C) (E : Epi C y z),
-        (∃ (x : C) (f : x --> y) (H : f ;; E = (ZeroArrow C AD x y) ;; E),
-            isCoequalizer f (ZeroArrow C AD x y) E H)).
+             (AD : AbelianData1 C) : UU :=
+    (Π (y z : C) (E : Epi C y z),
+        (∃ (x : C) (f : x --> y) (H : f ;; E = (ZeroArrow C (pr1 AD) x y) ;; E),
+            isCoequalizer f (ZeroArrow C (pr1 AD) x y) E H)).
 
+  Definition isapropisAbelianEpiCokernels (C : precategory)
+             (AD1 : AbelianData1 C) :
+    isaprop (isAbelianEpiCokernels C AD1).
+  Proof.
+    apply impred_isaprop; intros x.
+    apply impred_isaprop; intros y.
+    apply impred_isaprop; intros M.
+    apply isapropishinh.
+  Qed.
 
   Definition isAbelian (C : precategory)
-              (AD : AbelianData C) : UU :=
-     (BinProducts C) × (BinCoproducts C)
-                     × (Kernels AD) × (Cokernels AD)
-                     × (isAbelianMonicKernels C AD)
-                     × (isAbelianEpiCokernels C AD).
+              (AD1 : AbelianData1 C) : UU :=
+    (isAbelianMonicKernels C AD1) × (isAbelianEpiCokernels C AD1).
 
-  Definition mk_isAbelian (C : precategory) (AD : AbelianData C)
-              (BPr : BinProducts C) (BCPr : BinCoproducts C)
-              (K : Kernels AD) (Ck : Cokernels AD)
-              (MK : isAbelianMonicKernels C AD)
-              (EC : isAbelianEpiCokernels C AD) :
-    isAbelian C AD.
+  Definition isapropisAbelian (C : precategory) (AD1 : AbelianData1 C) :
+    isaprop (isAbelian C AD1).
   Proof.
-    exact (BPr,,(BCPr,,(K,,(Ck,,(MK,,EC))))).
-  Defined.
+    apply isapropdirprod.
+    apply (isapropisAbelianMonicKernels C AD1).
+    apply (isapropisAbelianEpiCokernels C AD1).
+  Qed.
+
+  Definition mk_isAbelian (C : precategory) (AD1 : AbelianData1 C)
+              (MK : isAbelianMonicKernels C AD1)
+              (EC : isAbelianEpiCokernels C AD1) :
+    isAbelian C AD1 := (MK,,EC).
 
   (** Definition of abelian categories *)
   Definition Abelian : UU :=
-    Σ A : (Σ C : precategory, AbelianData C),
-          isAbelian (pr1 A) (pr2 A).
+    Σ A : (Σ C' : (Σ C : precategory, AbelianData1 C),
+                  AbelianData2 (pr1 C') (pr2 C')),
+          isAbelian (pr1 (pr1 A)) (pr2 (pr1 A)).
   Definition Abelian_precategory (A : Abelian) :
-    precategory := pr1 (pr1 A).
+    precategory := pr1 (pr1 (pr1 A)).
   Coercion Abelian_precategory :
     Abelian >-> precategory.
 
   Definition mk_Abelian (C : precategory)
-             (AD : AbelianData C) (H : isAbelian C AD) : Abelian.
-  Proof.
-    exact (tpair _ (tpair _ C AD) H).
-  Defined.
+             (AD1 : AbelianData1 C) (AD2 : AbelianData2 C AD1)
+             (H : isAbelian C AD1) :
+    Abelian := tpair _ (tpair _ (tpair _ C AD1) AD2) H.
 
   Variable A : Abelian.
   Hypothesis hs : has_homsets A.
 
   (** Accessor functions. *)
   Definition Abelian_Zero :
-    Zero A := (pr2 (pr1 A)).
-  Definition Abelian_Products :
-    BinProducts A := pr1 (pr2 A).
+    Zero A := pr1(pr2 (pr1 (pr1 A))).
+  Definition Abelian_BinProducts :
+    BinProducts A := pr1 (pr2 (pr2 (pr1 (pr1 A)))).
   Definition Abelian_BinCoproducts :
-    BinCoproducts A := pr1 (pr2 (pr2 A)).
+    BinCoproducts A := pr2 (pr2 (pr2 (pr1 (pr1 A)))).
   Definition Abelian_Kernels :
-    Kernels Abelian_Zero := pr1 (pr2 (pr2 (pr2 A))).
+    Kernels Abelian_Zero := pr1 (pr2 (pr1 A)).
   Definition Abelian_Cokernels :
-    Cokernels Abelian_Zero := pr1 (pr2 (pr2 (pr2 (pr2 A)))).
+    Cokernels Abelian_Zero := pr2 (pr2 (pr1 A)).
   Definition Abelian_isAbelianMonicKernels
-    : isAbelianMonicKernels A (pr2 (pr1 A))
-    := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 A))))).
+    : isAbelianMonicKernels A (pr2 (pr1 (pr1 A)))
+    := pr1 (pr2 A).
   Definition Abelian_isAbelianEpiCokernels
-    : isAbelianEpiCokernels A (pr2 (pr1 A))
-    := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 A))))).
+    : isAbelianEpiCokernels A (pr2 (pr1 (pr1 A)))
+    := pr2 (pr2 A).
+
+
+  (** The following definitions construct a kernel from a monic and a cokernel
+    from an epi. *)
+  Definition Abelian_monic_kernel {x y : A} (M : Monic A x y) :
+    ∃ (z : A) (f : y --> z), Kernel Abelian_Zero f.
+  Proof.
+    set (AMK := Abelian_isAbelianMonicKernels x y M).
+    apply AMK. intros X. induction X. induction p. induction p.
+    intros P Y. apply Y.
+    refine (tpair _ t _). refine (tpair _ t0 _).
+
+    use (mk_Kernel Abelian_Zero M). (* use the monic as the kernel. *)
+    rewrite <- (ZeroArrow_comp_right A Abelian_Zero _ _ _ M).
+    apply t1. apply p.
+  Defined.
+
+  Definition Abelian_epi_cokernel {y z : A} (E : Epi A y z) :
+    ∃ (x : A) (f : x --> y), Cokernel Abelian_Zero f.
+  Proof.
+    set (AEC := Abelian_isAbelianEpiCokernels y z E).
+    apply AEC. intros X. induction X. induction p. induction p.
+    intros P Y. apply Y.
+    refine (tpair _ t _). refine (tpair _ t0 _).
+
+    use (mk_Cokernel Abelian_Zero E). (* use the epi as the cokernel. *)
+    rewrite <- (ZeroArrow_comp_left A Abelian_Zero _ _ _ E).
+    apply t1. apply p.
+  Defined.
+End def_abelian.
+
+(** In abelian categories morphisms which are both monic and epi are
+  isomorphisms. *)
+Section abelian_monic_epi_iso.
+
+  Variable A : Abelian.
+  Hypothesis hs : has_homsets A.
+
+  (** If a morphism if a monic and epi, then it is also iso *)
+  Lemma Abelian_monic_epi_is_iso {x y : A} {f : x --> y} :
+    isMonic A f -> isEpi A f -> is_iso f.
+  Proof.
+    intros M E.
+    set (M1 := mk_Monic A f M).
+    set (E1 := mk_Epi A f E).
+    set (AMK := Abelian_isAbelianMonicKernels A x y M1).
+    set (AEC := Abelian_isAbelianEpiCokernels A x y E1).
+    cbn in *. unfold ishinh_UU in *.
+
+    use (squash_to_prop AMK). apply isaprop_is_iso.
+    intros X. induction X. induction p. induction p.
+    use (squash_to_prop AEC). apply isaprop_is_iso.
+    intros Y. induction Y. induction p0. induction p0.
+
+    unfold isEqualizer in p. unfold isCoequalizer in p0.
+
+    (* Here we construct the inverse of f *)
+    apply (pr2 E1) in t1.
+    set (p' := p y (identity _)).
+    set (t'1 := maponpaths (fun h : A⟦y, t⟧ => identity _ ;; h) t1).
+    cbn in t'1.
+    set (p'' := p' t'1).
+    induction p''. induction t5.
+
+    use is_iso_qinv.
+
+    (* The inverse of f. *)
+    exact t5.
+
+    (* It remains to show that this is the inverse of f *)
+    split.
+    apply (pr2 M1). cbn. rewrite <- assoc. rewrite p2.
+    rewrite (remove_id_right A _ _ _ (identity x ;; f)).
+    apply idpath. apply idpath. apply pathsinv0.
+    apply id_left.
+
+    apply p2.
+  Defined.
+
+  (** Construction of the iso. *)
+  Lemma Abelian_monic_epi_iso {x y : A} {f : x --> y} :
+    isMonic A f -> isEpi A f -> iso x y.
+  Proof.
+    intros iM iE.
+    use isopair.
+    apply f.
+    apply (Abelian_monic_epi_is_iso iM iE).
+  Defined.
+
+End abelian_monic_epi_iso.
+
+
+(** In the following section we prove that an abelian category has pullbacks of
+    subobjects. *)
+Section abelian_subobject_pullbacks.
+
+  Variable A : Abelian.
+  Hypothesis hs : has_homsets A.
+
+  Lemma Abelian_subobjects_isPullback {x y z: A}
+        (M1 : Monic A x z) (M2 : Monic A y z) :
+    ∃ (a : A) (p1 : a --> x) (p2 : a --> y) (H : p1 ;; M1 = p2 ;; M2),
+      isPullback M1 M2 p1 p2 H.
+  Proof.
+    set (ker1 := Abelian_monic_kernel A M1).
+    set (ker2 := Abelian_monic_kernel A M2).
+    (* These kernels are constructed in Abelian_monic_kernel in a way that M1
+       and M2 are the kernel arrows. But the construction of the kernels is
+       forgotten when I apply these. I need coq to remember this construction.
+       How do I do it? *)
+    unfold Abelian_monic_kernel in ker1. (* Here M1 is shown in the
+                                            construction *)
+    apply ker1. (* Here the reference to M1 is lost. *)
+  Abort.
+
+  Lemma Abelian_quotobject_pushout {x y z: A}
+        (E1 : Epi A x y) (E2 : Epi A x z) :
+    ∃ (a : A) (i1 : y --> a) (i2 : z --> a) (H : E1 ;; i1 = E2 ;; i2),
+      isPushout E1 E2 i1 i2 H.
+  Proof.
+    (* TODO *)
+  Abort.
+
+End abelian_subobject_pullbacks.
+
+(** In the following section we show that equalizers and coequalizers exist in
+  abelian categories.  *)
+Section abelian_equalizers.
+
+  Variable A : Abelian.
+  Hypothesis hs : has_homsets A.
+
+  Lemma Abelian_equalizers {x y : A} (f1 f2 : x --> y) :
+    Equalizer f1 f2.
+  Proof.
+    (* TODO *) (* Needs pullbacks *)
+  Abort.
+
+  Lemma Abelian_coequalizer {x y : A} (f1 f2 : x --> y) :
+    Coequalizer f1 f2.
+  Proof.
+    (* TODO *) (* Needs pushouts *)
+  Abort.
+
+End abelian_equalizers.
+
+(** In this section we prove that every morphism factors as epi ;; monic *)
+Section abelian_factorization.
+
+  Variable A : Abelian.
+  Hypothesis hs : has_homsets A.
+
+  (* TODO: Needs some results on pullbacks, equalizers, and strong
+     epimorphisms. *)
+  Lemma Abelian_factorization {x y z : A} (f : x --> y) :
+    ∃ (E : Epi A x z) (M : Monic A z y), f = E ;; M.
+  Proof.
+    (* TODO *)
+  Abort.
+End abelian_factorization.
+
+(** In this section we prove that kernels of monomorphisms are given by the
+  arrows from zero and cokernels of epimorphisms are given by the arrows to
+  zero. *)
+Section abelian_monic_kernels.
+
+  Variable A : Abelian.
+  Hypothesis hs : has_homsets A.
+
+  (* A kernel of a monic is the arrow from zero. *)
+  Definition Abelian_MonicKernelZero {x y : A} (M : Monic A x y) :
+    Kernel (Abelian_Zero A) M.
+  Proof.
+    use mk_Kernel.
+    exact (Abelian_Zero A).
+    exact (ZeroArrowFrom _).
+    apply (ArrowsFromZero).
+    use (mk_isEqualizer).
+    intros w h X.
+
+    (* Transform X into an equality we need *)
+    rewrite ZeroArrow_comp_right in X.
+    rewrite <- (ZeroArrow_comp_left _ _ _ x y M) in X.
+    apply (pr2 M) in X.
+
+    use unique_exists.
+    apply ZeroArrowTo.
+    cbn. rewrite X. unfold ZeroArrow. apply idpath.
+
+    intros y0. apply hs.
+
+    intros y0 Y. cbn in Y. apply ArrowsToZero.
+  Defined.
+
+
+  (* A cokernel of an epi is the arrow to zero. *)
+  Definition Abelian_EpiCokernelZero {y z : A} (E : Epi A y z) :
+    Cokernel (Abelian_Zero A) E.
+  Proof.
+    use mk_Cokernel.
+    exact (Abelian_Zero A).
+    exact (ZeroArrowTo _).
+    apply (ArrowsToZero).
+    use (mk_isCoequalizer).
+    intros w h X.
+
+    (* Transform X into an equality we need *)
+    rewrite ZeroArrow_comp_left in X.
+    rewrite <- (ZeroArrow_comp_right A (Abelian_Zero A) y z w E) in X.
+    apply (pr2 E) in X.
+
+    use unique_exists.
+    apply ZeroArrowFrom.
+    cbn. rewrite X. unfold ZeroArrow. apply idpath.
+
+    intros y0. apply hs.
+
+    intros y0 Y. cbn in Y. apply ArrowsFromZero.
+  Defined.
+End abelian_monic_kernels.
+
+
+(** In this section we prove that every monic is the kernel of its cokernel and
+  every epi is the cokernel of its kernel. *)
+Section abelian_kernel_cokernel.
+
+  Variable A : Abelian.
+  Hypothesis hs : has_homsets A.
 
 
   (** The following definition constructs kernels from monics. *)
-  Definition Abelian_MonicToKernel {x y : A} (M : Monic A x y) :
-    Kernel Abelian_Zero (CokernelArrow _ (Abelian_Cokernels _ _ M)).
+  Definition Abelian_MonicToKerneEq {x y : A} (M : Monic A x y) :
+    M ;; CokernelArrow (Abelian_Zero A) (Abelian_Cokernels A x y M) =
+    ZeroArrow A (Abelian_Zero A) x (Abelian_Cokernels A x y M).
   Proof.
-    set (AMK := Abelian_isAbelianMonicKernels x y M).
+    set (AMK := Abelian_isAbelianMonicKernels A x y M).
+    unfold ishinh in AMK. cbn in *. unfold ishinh_UU in AMK.
+    unfold isEqualizer in AMK.
+    use (squash_to_prop AMK). apply hs.
+    intros X.
+    apply (CokernelCompZero (Abelian_Zero A) (Abelian_Cokernels A x y M)).
+  Qed.
+
+  Definition Abelian_MonicToKernel {x y : A} (M : Monic A x y) :
+    Kernel (Abelian_Zero A) (CokernelArrow _ (Abelian_Cokernels A x y M)).
+  Proof.
+    set (AMK := Abelian_isAbelianMonicKernels A x y M).
     unfold ishinh in AMK. cbn in *. unfold ishinh_UU in AMK.
 
-    use mk_Kernel.
-    exact x. exact (MonicArrow _ M).
-    (* Here the goal should be hProp to be able to apply AMK. *)
+    use (mk_Kernel _ M). use (squash_to_prop AMK). apply hs.
+
+    intros X. apply (Abelian_MonicToKerneEq M).
+    use (squash_to_prop AMK). apply isaprop_isEqualizer.
+    intros X. induction X. induction p. induction p. unfold isEqualizer in p.
+    use mk_isEqualizer. intros w h X.
+
+    apply p.
+    (* Need the factorization result of morphisms in abelian categories to
+       prove this *)
   Abort.
 
   (** The following definition constructs cokernels from epis. *)
-  Definition Abelian_EpiToCokernel {y z : A} (E : Epi A y z) :
-    Cokernel Abelian_Zero (KernelArrow _ (Abelian_Kernels _ _ E)).
+  Definition Abelian_EpiToCokernelEq {y z : A} (E : Epi A y z) :
+    KernelArrow (Abelian_Zero A) (Abelian_Kernels A y z E) ;; E =
+    ZeroArrow A (Abelian_Zero A) (Abelian_Kernels A y z E) z.
   Proof.
-    set (AEC := Abelian_isAbelianEpiCokernels y z E).
+    set (AEC := Abelian_isAbelianEpiCokernels A y z E).
+    unfold ishinh in AEC. cbn in *. unfold ishinh_UU in AEC.
+    unfold isCoequalizer in AEC.
+    use (squash_to_prop AEC). apply hs.
+    intros X.
+    apply (KernelCompZero (Abelian_Zero A) (Abelian_Kernels A y z E)).
+  Qed.
+
+  Definition Abelian_EpiToCokernel {y z : A} (E : Epi A y z) :
+    Cokernel (Abelian_Zero A) (KernelArrow _ (Abelian_Kernels _ _ _ E)).
+  Proof.
+    set (AEC := Abelian_isAbelianEpiCokernels A y z E).
     unfold ishinh in AEC. cbn in *. unfold ishinh_UU in AEC.
 
-    use mk_Cokernel.
-    exact z. exact (EpiArrow _ E).
-    (* Here the goal should be hProp to be able to apply AEC. *)
+    use (mk_Cokernel _ E). use (squash_to_prop AEC). apply hs.
+
+    intros X. apply (Abelian_EpiToCokernelEq E).
+    use (squash_to_prop AEC). apply isaprop_isCoequalizer.
+    intros X. induction X. induction p. induction p.
+
+    use mk_isCoequalizer. intros w0 h X.
+    (* Need the factorization result of morphisms in abelian categories to
+       prove this. *)
   Abort.
 
-End def_abelian.
+End abelian_kernel_cokernel.

--- a/UniMath/CategoryTheory/Abelian.v
+++ b/UniMath/CategoryTheory/Abelian.v
@@ -186,7 +186,7 @@ Section abelian_monic_epi_iso.
   Variable A : Abelian.
   Hypothesis hs : has_homsets A.
 
-  (** If a morphism if a monic and an epi, then it is also an iso. *)
+  (** If a morphism is a monic and an epi, then it is also an iso. *)
   Lemma Abelian_monic_epi_is_iso {x y : A} {f : x --> y} :
     isMonic A f -> isEpi A f -> is_iso f.
   Proof.

--- a/UniMath/CategoryTheory/Abelian.v
+++ b/UniMath/CategoryTheory/Abelian.v
@@ -285,49 +285,108 @@ Section abelian_subobject_pullbacks.
   Variable A : Abelian_precategory.
   Hypothesis hs : has_homsets A.
 
-  Definition Abelian_subobjects_Pullback {x y z: A}
-        (M1 : Monic A x z) (M2 : Monic A y z) :
-    Pullback M1 M2.
+  (** ** Pullbacks of subobjects *)
+
+  (** Equations we are going to need to construct a Pullback. *)
+  Definition Abelian_subobjects_Pullback_eq1 {x y z : A}
+             (M1 : Monic A x z) (M2 : Monic A y z)
+             (BinProd : BinProductCone A (AMKD_Ob (Abelian_AMKD A) x z M1)
+                                       (AMKD_Ob (Abelian_AMKD A) y z M2))
+             (ker : Kernel (Abelian_Zero A)
+                           (BinProductArrow
+                              A BinProd
+                              (AMKD_Mor (Abelian_AMKD A) x z M1)
+                              (AMKD_Mor (Abelian_AMKD A) y z M2))) :
+    KernelArrow (Abelian_Zero A) ker ;; AMKD_Mor (Abelian_AMKD A) x z M1 =
+    ZeroArrow A (Abelian_Zero A) ker (AMKD_Ob (Abelian_AMKD A) x z M1).
   Proof.
-    (* Some variables we are going to use. *)
+    set (tmp := (BinProductPr1Commutes A _ _ BinProd _
+                                       (AMKD_Mor (Abelian_AMKD A) x z M1)
+                                       (AMKD_Mor (Abelian_AMKD A) y z M2))).
+    apply (maponpaths (fun h : _ => KernelArrow (Abelian_Zero A) ker ;; h))
+      in tmp.
+    apply (pathscomp0 (!tmp)).
+    rewrite assoc. rewrite (KernelCompZero (Abelian_Zero A) ker).
+    apply ZeroArrow_comp_left.
+  Qed.
+
+  Definition Abelian_subobjects_Pullback_eq2 {x y z : A}
+             (M1 : Monic A x z) (M2 : Monic A y z)
+             (BinProd : BinProductCone A (AMKD_Ob (Abelian_AMKD A) x z M1)
+                                       (AMKD_Ob (Abelian_AMKD A) y z M2))
+             (ker : Kernel (Abelian_Zero A)
+                           (BinProductArrow
+                              A BinProd
+                              (AMKD_Mor (Abelian_AMKD A) x z M1)
+                              (AMKD_Mor (Abelian_AMKD A) y z M2))) :
+    KernelArrow (Abelian_Zero A) ker ;; AMKD_Mor (Abelian_AMKD A) y z M2 =
+    ZeroArrow A (Abelian_Zero A) ker (AMKD_Ob (Abelian_AMKD A) y z M2).
+  Proof.
+    set (tmp := (BinProductPr2Commutes A _ _ BinProd _
+                                       (AMKD_Mor (Abelian_AMKD A) x z M1)
+                                       (AMKD_Mor (Abelian_AMKD A) y z M2))).
+    apply (maponpaths (fun h : _ => KernelArrow (Abelian_Zero A) ker ;; h))
+      in tmp.
+    apply (pathscomp0 (!tmp)).
+    rewrite assoc. rewrite (KernelCompZero (Abelian_Zero A) ker).
+    apply ZeroArrow_comp_left.
+  Qed.
+
+  Definition Abelian_subobjects_Pullback_eq3 {x y z : A}
+             (M1 : Monic A x z) (M2 : Monic A y z)
+             (BinProd : BinProductCone A (AMKD_Ob (Abelian_AMKD A) x z M1)
+                                       (AMKD_Ob (Abelian_AMKD A) y z M2))
+             (ker : Kernel (Abelian_Zero A)
+                           (BinProductArrow
+                              A BinProd
+                              (AMKD_Mor (Abelian_AMKD A) x z M1)
+                              (AMKD_Mor (Abelian_AMKD A) y z M2))) :
+    KernelIn (Abelian_Zero A) (Abelian_monic_kernel A M1) ker
+             (KernelArrow (Abelian_Zero A) ker)
+             (Abelian_subobjects_Pullback_eq1 M1 M2 BinProd ker)
+           ;; M1 =
+    KernelIn (Abelian_Zero A) (Abelian_monic_kernel A M2) ker
+             (KernelArrow (Abelian_Zero A) ker)
+             (Abelian_subobjects_Pullback_eq2 M1 M2 BinProd ker)
+             ;; M2.
+  Proof.
+    rewrite (KernelCommutes (Abelian_Zero A) (Abelian_monic_kernel A M1) _
+                            (KernelArrow (Abelian_Zero A) ker)).
+    rewrite (KernelCommutes (Abelian_Zero A) (Abelian_monic_kernel A M2) _
+                            (KernelArrow (Abelian_Zero A) ker)).
+    apply idpath.
+  Qed.
+
+  Definition Abelian_subobjects_Pullback_isPullback {x y z : A}
+             (M1 : Monic A x z) (M2 : Monic A y z)
+             (BinProd : BinProductCone A (AMKD_Ob (Abelian_AMKD A) x z M1)
+                                       (AMKD_Ob (Abelian_AMKD A) y z M2))
+             (ker : Kernel (Abelian_Zero A)
+                           (BinProductArrow
+                              A BinProd
+                              (AMKD_Mor (Abelian_AMKD A) x z M1)
+                              (AMKD_Mor (Abelian_AMKD A) y z M2))) :
+    isPullback M1 M2
+               (KernelIn (Abelian_Zero A) (Abelian_monic_kernel A M1) ker
+                         (KernelArrow (Abelian_Zero A) ker)
+                         (Abelian_subobjects_Pullback_eq1 M1 M2 BinProd ker))
+               (KernelIn (Abelian_Zero A) (Abelian_monic_kernel A M2) ker
+                         (KernelArrow (Abelian_Zero A) ker)
+                         (Abelian_subobjects_Pullback_eq2 M1 M2 BinProd ker))
+               (Abelian_subobjects_Pullback_eq3 M1 M2 BinProd ker).
+  Proof.
+    (* variables *)
     set (ker1 := Abelian_monic_kernel A M1).
     set (ker2 := Abelian_monic_kernel A M2).
-    set (BinProd := Abelian_BinProducts
-                      A
-                      (AMKD_Ob (Abelian_AMKD A) x z M1)
-                      (AMKD_Ob (Abelian_AMKD A) y z M2)).
     set (ar := BinProductArrow
                  A BinProd
                  (AMKD_Mor (Abelian_AMKD A) x z M1)
                  (AMKD_Mor (Abelian_AMKD A) y z M2)).
-    set (ker := Abelian_Kernels A _ _ ar).
-
-
-    (* Equalities of morphisms we are going to need. *)
-    assert (H1 : KernelArrow (Abelian_Zero A) ker
-                             ;; (AMKD_Mor (Abelian_AMKD A) x z M1)
-                 = ZeroArrow _ (Abelian_Zero A) _ _).
-    {
-      rewrite <- (BinProductPr1Commutes A _ _ BinProd _
-                                       (AMKD_Mor (Abelian_AMKD A) x z M1)
-                                       (AMKD_Mor (Abelian_AMKD A) y z M2)).
-      rewrite assoc. fold ar. rewrite (KernelCompZero (Abelian_Zero A) ker).
-      apply ZeroArrow_comp_left.
-    }
-
-    assert (H2 : KernelArrow (Abelian_Zero A) ker
-                             ;; (AMKD_Mor (Abelian_AMKD A) y z M2)
-                 = ZeroArrow _ (Abelian_Zero A) _ _).
-    {
-      rewrite <- (BinProductPr2Commutes A _ _ BinProd _
-                                       (AMKD_Mor (Abelian_AMKD A) x z M1)
-                                       (AMKD_Mor (Abelian_AMKD A) y z M2)).
-      rewrite assoc. fold ar. rewrite (KernelCompZero (Abelian_Zero A) ker).
-      apply ZeroArrow_comp_left.
-    }
 
     assert (com1 : KernelIn (Abelian_Zero A) ker1 ker
-                            (KernelArrow (Abelian_Zero A) ker) H1 ;; M1
+                            (KernelArrow (Abelian_Zero A) ker)
+                            (Abelian_subobjects_Pullback_eq1 M1 M2 BinProd ker)
+                            ;; M1
                    = KernelArrow (Abelian_Zero A) ker).
     {
       apply (KernelCommutes (Abelian_Zero A) ker1 _
@@ -335,34 +394,16 @@ Section abelian_subobject_pullbacks.
     }
 
     assert (com2 : KernelIn (Abelian_Zero A) ker2 ker
-                            (KernelArrow (Abelian_Zero A) ker) H2 ;; M2
+                            (KernelArrow (Abelian_Zero A) ker)
+                            (Abelian_subobjects_Pullback_eq2 M1 M2 BinProd ker)
+                            ;; M2
                    = KernelArrow (Abelian_Zero A) ker).
     {
       apply (KernelCommutes (Abelian_Zero A) ker2 _
                             (KernelArrow (Abelian_Zero A) ker)).
     }
 
-    use mk_Pullback.
-
-    (* Pullback object *)
-    apply ker.
-
-    (* The arrow pr1 *)
-    use (KernelIn (Abelian_Zero A) ker1 ker (KernelArrow (Abelian_Zero A) ker)).
-    apply H1.
-
-    (* The arrow pr2 *)
-    use (KernelIn (Abelian_Zero A) ker2 ker (KernelArrow (Abelian_Zero A) ker)).
-    apply H2.
-
-    (* Commutativity of the arrows pr1 and pr2 *)
-    rewrite (KernelCommutes (Abelian_Zero A) ker1 _
-                            (KernelArrow (Abelian_Zero A) ker)).
-    rewrite (KernelCommutes (Abelian_Zero A) ker2 _
-                            (KernelArrow (Abelian_Zero A) ker)).
-    apply idpath.
-
-    (* isPullback. *)
+    (* isPullback *)
     use mk_isPullback.
     intros e h k H.
 
@@ -442,58 +483,153 @@ Section abelian_subobject_pullbacks.
     apply (KernelArrowisMonic (Abelian_Zero A) ker).
     rewrite (KernelCommutes (Abelian_Zero A) ker).
     rewrite <- (KernelCommutes (Abelian_Zero A) ker1 ker
-                              (KernelArrow (Abelian_Zero A) ker) H1).
+                              (KernelArrow (Abelian_Zero A) ker)
+                              (Abelian_subobjects_Pullback_eq1 M1 M2 BinProd
+                                                               ker)).
     rewrite assoc.
     use (pathscomp0 (maponpaths (fun f : _ => f ;; KernelArrow (Abelian_Zero A)
                                              ker1) t)).
     apply idpath.
+  Qed.
+
+  (** Construction of the Pullback of subobjects. *)
+  Definition Abelian_subobjects_Pullback {x y z : A}
+        (M1 : Monic A x z) (M2 : Monic A y z) :
+    Pullback M1 M2.
+  Proof.
+    (* variables *)
+    set (ker1 := Abelian_monic_kernel A M1).
+    set (ker2 := Abelian_monic_kernel A M2).
+    set (BinProd := Abelian_BinProducts
+                      A
+                      (AMKD_Ob (Abelian_AMKD A) x z M1)
+                      (AMKD_Ob (Abelian_AMKD A) y z M2)).
+    set (ar := BinProductArrow
+                 A BinProd
+                 (AMKD_Mor (Abelian_AMKD A) x z M1)
+                 (AMKD_Mor (Abelian_AMKD A) y z M2)).
+    set (ker := Abelian_Kernels A _ _ ar).
+
+    (* Construction *)
+    use (mk_Pullback
+           M1 M2 ker
+           (KernelIn (Abelian_Zero A) ker1 ker (KernelArrow (Abelian_Zero A)
+                                                            ker)
+                     (Abelian_subobjects_Pullback_eq1 M1 M2 BinProd ker))
+           (KernelIn (Abelian_Zero A) ker2 ker (KernelArrow (Abelian_Zero A)
+                                                            ker)
+                     (Abelian_subobjects_Pullback_eq2 M1 M2 BinProd ker))
+           (Abelian_subobjects_Pullback_eq3 M1 M2 BinProd ker)
+           (Abelian_subobjects_Pullback_isPullback M1 M2 BinProd ker)).
   Defined.
 
-  Definition Abelian_quotobjects_pushout {x y z: A}
-        (E1 : Epi A x y) (E2 : Epi A x z) :
-    Pushout E1 E2.
+
+  (** ** Pushouts of quotient objects *)
+
+
+  (** Equations we are going to need to construct a pushout. *)
+  Definition Abelian_quotobjects_Pushout_eq1 {x y z : A}
+             (E1 : Epi A x y) (E2 : Epi A x z)
+             (BinCoprod : BinCoproductCocone
+                            A (AECD_Ob (Abelian_AECD A) x y E1)
+                            (AECD_Ob (Abelian_AECD A) x z E2))
+             (coker : Cokernel (Abelian_Zero A)
+                               (BinCoproductArrow
+                                  A BinCoprod
+                                  (AECD_Mor (Abelian_AECD A) x y E1)
+                                  (AECD_Mor (Abelian_AECD A) x z E2))) :
+    AECD_Mor (Abelian_AECD A) x y E1 ;; CokernelArrow (Abelian_Zero A) coker =
+       ZeroArrow A (Abelian_Zero A) (AECD_Ob (Abelian_AECD A) x y E1) coker.
   Proof.
-    (* Some variables we are going to use. *)
+    set (tmp := (BinCoproductIn1Commutes A _ _ BinCoprod _
+                                         (AECD_Mor (Abelian_AECD A) x y E1)
+                                         (AECD_Mor (Abelian_AECD A) x z E2))).
+    apply (maponpaths (fun h : _ => h ;; CokernelArrow (Abelian_Zero A) coker))
+      in tmp.
+    apply (pathscomp0 (!tmp)).
+    rewrite <- assoc. rewrite (CokernelCompZero (Abelian_Zero A) coker).
+    apply ZeroArrow_comp_right.
+  Qed.
+
+  Definition Abelian_quotobjects_Pushout_eq2 {x y z : A}
+             (E1 : Epi A x y) (E2 : Epi A x z)
+             (BinCoprod : BinCoproductCocone
+                            A (AECD_Ob (Abelian_AECD A) x y E1)
+                            (AECD_Ob (Abelian_AECD A) x z E2))
+             (coker : Cokernel (Abelian_Zero A)
+                               (BinCoproductArrow
+                                  A BinCoprod
+                                  (AECD_Mor (Abelian_AECD A) x y E1)
+                                  (AECD_Mor (Abelian_AECD A) x z E2))) :
+    AECD_Mor (Abelian_AECD A) x z E2 ;; CokernelArrow (Abelian_Zero A) coker =
+       ZeroArrow A (Abelian_Zero A) (AECD_Ob (Abelian_AECD A) x z E2) coker.
+  Proof.
+    set (tmp := (BinCoproductIn2Commutes A _ _ BinCoprod _
+                                         (AECD_Mor (Abelian_AECD A) x y E1)
+                                         (AECD_Mor (Abelian_AECD A) x z E2))).
+    apply (maponpaths (fun h : _ => h ;; CokernelArrow (Abelian_Zero A) coker))
+      in tmp.
+    apply (pathscomp0 (!tmp)).
+    rewrite <- assoc. rewrite (CokernelCompZero (Abelian_Zero A) coker).
+    apply ZeroArrow_comp_right.
+  Qed.
+
+  Definition Abelian_quotobjects_Pushout_eq3 {x y z : A}
+             (E1 : Epi A x y) (E2 : Epi A x z)
+             (BinCoprod : BinCoproductCocone
+                            A (AECD_Ob (Abelian_AECD A) x y E1)
+                            (AECD_Ob (Abelian_AECD A) x z E2))
+             (coker : Cokernel (Abelian_Zero A)
+                               (BinCoproductArrow
+                                  A BinCoprod
+                                  (AECD_Mor (Abelian_AECD A) x y E1)
+                                  (AECD_Mor (Abelian_AECD A) x z E2))) :
+    E1 ;; CokernelOut (Abelian_Zero A) (Abelian_epi_cokernel A E1) coker
+       (CokernelArrow (Abelian_Zero A) coker)
+       (Abelian_quotobjects_Pushout_eq1 E1 E2 BinCoprod coker) =
+    E2 ;; CokernelOut (Abelian_Zero A) (Abelian_epi_cokernel A E2) coker
+       (CokernelArrow (Abelian_Zero A) coker)
+       (Abelian_quotobjects_Pushout_eq2 E1 E2 BinCoprod coker).
+  Proof.
+    rewrite (CokernelCommutes (Abelian_Zero A) (Abelian_epi_cokernel A E1) _
+                              (CokernelArrow (Abelian_Zero A) coker)).
+    rewrite (CokernelCommutes (Abelian_Zero A) (Abelian_epi_cokernel A E2) _
+                              (CokernelArrow (Abelian_Zero A) coker)).
+    apply idpath.
+  Qed.
+
+  Definition Abelian_quotobjects_Pushout_isPushout {x y z : A}
+             (E1 : Epi A x y) (E2 : Epi A x z)
+             (BinCoprod : BinCoproductCocone
+                            A (AECD_Ob (Abelian_AECD A) x y E1)
+                            (AECD_Ob (Abelian_AECD A) x z E2))
+             (coker : Cokernel (Abelian_Zero A)
+                               (BinCoproductArrow
+                                  A BinCoprod
+                                  (AECD_Mor (Abelian_AECD A) x y E1)
+                                  (AECD_Mor (Abelian_AECD A) x z E2))) :
+    isPushout E1 E2
+              (CokernelOut (Abelian_Zero A) (Abelian_epi_cokernel A E1) coker
+                           (CokernelArrow (Abelian_Zero A) coker)
+                           (Abelian_quotobjects_Pushout_eq1 E1 E2 BinCoprod
+                                                            coker))
+              (CokernelOut (Abelian_Zero A) (Abelian_epi_cokernel A E2) coker
+                           (CokernelArrow (Abelian_Zero A) coker)
+                           (Abelian_quotobjects_Pushout_eq2 E1 E2 BinCoprod
+                                                            coker))
+              (Abelian_quotobjects_Pushout_eq3 E1 E2 BinCoprod coker).
+  Proof.
+    (* variables *)
     set (coker1 := Abelian_epi_cokernel A E1).
     set (coker2 := Abelian_epi_cokernel A E2).
-    set (BinCoprod := Abelian_BinCoproducts
-                        A
-                        (AECD_Ob (Abelian_AECD A) x y E1)
-                        (AECD_Ob (Abelian_AECD A) x z E2)).
     set (ar := BinCoproductArrow
                  A BinCoprod
                  (AECD_Mor (Abelian_AECD A) x y E1)
                  (AECD_Mor (Abelian_AECD A) x z E2)).
-    set (coker := Abelian_Cokernels A _ _ ar).
-
-
-    (* Equalities of morphisms we are going to need. *)
-    assert (H1 : (AECD_Mor (Abelian_AECD A) x y E1)
-                   ;; CokernelArrow (Abelian_Zero A) coker
-                 = ZeroArrow _ (Abelian_Zero A) _ _).
-    {
-      rewrite <- (BinCoproductIn1Commutes A _ _ BinCoprod _
-                                         (AECD_Mor (Abelian_AECD A) x y E1)
-                                         (AECD_Mor (Abelian_AECD A) x z E2)).
-      rewrite <- assoc. fold ar.
-      rewrite (CokernelCompZero (Abelian_Zero A) coker).
-      apply ZeroArrow_comp_right.
-    }
-
-    assert (H2 : (AECD_Mor (Abelian_AECD A) x z E2)
-                   ;; CokernelArrow (Abelian_Zero A) coker
-                 = ZeroArrow _ (Abelian_Zero A) _ _).
-    {
-      rewrite <- (BinCoproductIn2Commutes A _ _ BinCoprod _
-                                         (AECD_Mor (Abelian_AECD A) x y E1)
-                                         (AECD_Mor (Abelian_AECD A) x z E2)).
-      rewrite <- assoc. fold ar.
-      rewrite (CokernelCompZero (Abelian_Zero A) coker).
-      apply ZeroArrow_comp_right.
-    }
 
     assert (com1 : E1 ;; CokernelOut (Abelian_Zero A) coker1 coker
-                      (CokernelArrow (Abelian_Zero A) coker) H1
+                      (CokernelArrow (Abelian_Zero A) coker)
+                      (Abelian_quotobjects_Pushout_eq1 E1 E2 BinCoprod coker)
                    = CokernelArrow (Abelian_Zero A) coker).
     {
       apply (CokernelCommutes (Abelian_Zero A) coker1 _
@@ -501,36 +637,15 @@ Section abelian_subobject_pullbacks.
     }
 
     assert (com2 : E2 ;; CokernelOut (Abelian_Zero A) coker2 coker
-                      (CokernelArrow (Abelian_Zero A) coker) H2
+                      (CokernelArrow (Abelian_Zero A) coker)
+                      (Abelian_quotobjects_Pushout_eq2 E1 E2 BinCoprod coker)
                    = CokernelArrow (Abelian_Zero A) coker).
     {
       apply (CokernelCommutes (Abelian_Zero A) coker2 _
                               (CokernelArrow (Abelian_Zero A) coker)).
     }
 
-    use mk_Pushout.
-
-    (* Pushout object *)
-    apply coker.
-
-    (* The arrow pr1 *)
-    use (CokernelOut (Abelian_Zero A) coker1 coker
-                     (CokernelArrow (Abelian_Zero A) coker)).
-    apply H1.
-
-    (* The arrow pr2 *)
-    use (CokernelOut (Abelian_Zero A) coker2 coker
-                     (CokernelArrow (Abelian_Zero A) coker)).
-    apply H2.
-
-    (* Commutativity of the arrows pr1 and pr2 *)
-    rewrite (CokernelCommutes (Abelian_Zero A) coker1 _
-                              (CokernelArrow (Abelian_Zero A) coker)).
-    rewrite (CokernelCommutes (Abelian_Zero A) coker2 _
-                              (CokernelArrow (Abelian_Zero A) coker)).
-    apply idpath.
-
-    (* isPushout. *)
+    (* isPushout *)
     use mk_isPushout.
     intros e h k H.
 
@@ -615,11 +730,43 @@ Section abelian_subobject_pullbacks.
     apply (CokernelArrowisEpi (Abelian_Zero A) coker).
     rewrite (CokernelCommutes (Abelian_Zero A) coker).
     rewrite <- (CokernelCommutes (Abelian_Zero A) coker1 coker
-                                (CokernelArrow (Abelian_Zero A) coker) H1).
+                                (CokernelArrow (Abelian_Zero A) coker)
+                                (Abelian_quotobjects_Pushout_eq1
+                                   E1 E2 BinCoprod coker)).
     rewrite <- assoc.
     use (pathscomp0 (maponpaths (fun f : _ => CokernelArrow (Abelian_Zero A)
                                                          coker1 ;; f) t)).
     apply idpath.
+  Qed.
+
+  Definition Abelian_quotobjects_Pushout {x y z: A}
+        (E1 : Epi A x y) (E2 : Epi A x z) :
+    Pushout E1 E2.
+  Proof.
+    (* variables *)
+    set (coker1 := Abelian_epi_cokernel A E1).
+    set (coker2 := Abelian_epi_cokernel A E2).
+    set (BinCoprod := Abelian_BinCoproducts
+                        A
+                        (AECD_Ob (Abelian_AECD A) x y E1)
+                        (AECD_Ob (Abelian_AECD A) x z E2)).
+    set (ar := BinCoproductArrow
+                 A BinCoprod
+                 (AECD_Mor (Abelian_AECD A) x y E1)
+                 (AECD_Mor (Abelian_AECD A) x z E2)).
+    set (coker := Abelian_Cokernels A _ _ ar).
+
+    (* construction *)
+    use (mk_Pushout
+           E1 E2 coker
+           (CokernelOut (Abelian_Zero A) coker1 coker
+                        (CokernelArrow (Abelian_Zero A) coker)
+                        (Abelian_quotobjects_Pushout_eq1 E1 E2 BinCoprod coker))
+           (CokernelOut (Abelian_Zero A) coker2 coker
+                        (CokernelArrow (Abelian_Zero A) coker)
+                        (Abelian_quotobjects_Pushout_eq2 E1 E2 BinCoprod coker))
+           (Abelian_quotobjects_Pushout_eq3 E1 E2 BinCoprod coker)
+           (Abelian_quotobjects_Pushout_isPushout E1 E2 BinCoprod coker)).
   Defined.
 
 End abelian_subobject_pullbacks.
@@ -632,51 +779,60 @@ Section abelian_equalizers.
   Variable A : Abelian_precategory.
   Hypothesis hs : has_homsets A.
 
-  Lemma Abelian_Equalizer {x y : A} (f1 f2 : x --> y) :
-    Equalizer f1 f2.
+  (** ** Equalizers *)
+
+  (** Some results we are going to need to prove existence of Equalizers. *)
+  Definition Abelian_Equalizer_isMonic {x y : A} (f: x --> y) :
+    isMonic A (BinProductArrow A (Abelian_BinProducts A x y) (identity x) f).
+  Proof.
+    set (BinProd := Abelian_BinProducts A x y).
+    intros z h1 h2 H.
+    apply (maponpaths (fun h : _ => h ;; (BinProductPr1 A BinProd))) in H.
+    rewrite <- assoc in H. rewrite <- assoc in H.
+    set (com1 := BinProductPr1Commutes A _ _ BinProd x (identity x) f).
+    rewrite com1 in H.
+    rewrite (id_right A _ _ h1) in H. rewrite (id_right A _ _ h2) in H.
+    exact H.
+  Qed.
+
+  Definition Abelian_Equalizer_Pullback {x y : A} (f1 f2 : x --> y) :
+    Pullback (BinProductArrow A (Abelian_BinProducts A x y) (identity x) f1)
+             (BinProductArrow A (Abelian_BinProducts A x y) (identity x) f2)
+    := Abelian_subobjects_Pullback
+         A hs
+         (mk_Monic A _ (Abelian_Equalizer_isMonic f1))
+         (mk_Monic A _ (Abelian_Equalizer_isMonic f2)).
+
+  Definition Abelian_Equalizer_eq1 {x y : A} (f1 f2 : x --> y) :
+    PullbackPr1 (Abelian_Equalizer_Pullback f1 f2)
+    = PullbackPr2 (Abelian_Equalizer_Pullback f1 f2).
   Proof.
     set (BinProd := Abelian_BinProducts A x y).
     set (ar1 := BinProductArrow A BinProd (identity x) f1).
     set (ar2 := BinProductArrow A BinProd (identity x) f2).
+    set (Pb := Abelian_Equalizer_Pullback f1 f2).
 
-    assert (isM1 : isMonic A ar1).
-    {
-      intros z h1 h2 H.
-      apply (maponpaths (fun f : _ => f ;; (BinProductPr1 A BinProd))) in H.
-      rewrite <- assoc in H. rewrite <- assoc in H.
-      set (com1 := BinProductPr1Commutes A _ _ BinProd x (identity x) f1).
-      fold ar1 in com1. rewrite com1 in H.
-      rewrite (id_right A _ _ h1) in H. rewrite (id_right A _ _ h2) in H.
-      exact H.
-    }
+    assert (H1 : ar1 ;; (BinProductPr1 A BinProd) = identity x) by
+        apply BinProductPr1Commutes.
+    assert (H2 : ar2 ;; (BinProductPr1 A BinProd) = identity x) by
+        apply BinProductPr1Commutes.
+    use (pathscomp0 (!(id_right A _ _ (PullbackPr1 Pb)))).
+    use (pathscomp0 (!(maponpaths (fun h : _ => PullbackPr1 Pb ;; h) H1))).
+    use (pathscomp0 _ ((id_right A _ _ (PullbackPr2 Pb)))).
+    use (pathscomp0 _ (maponpaths (fun h : _ => PullbackPr2 Pb ;; h) H2)).
+    rewrite assoc. rewrite assoc. apply cancel_postcomposition.
+    apply PullbackSqrCommutes.
+  Qed.
 
-    assert (isM2 : isMonic A ar2).
-    {
-      intros z h1 h2 H.
-      apply (maponpaths (fun f : _ => f ;; (BinProductPr1 A BinProd))) in H.
-      rewrite <- assoc in H. rewrite <- assoc in H.
-      set (com1 := BinProductPr1Commutes A _ _ BinProd x (identity x) f2).
-      fold ar2 in com1. rewrite com1 in H.
-      rewrite (id_right A _ _ h1) in H. rewrite (id_right A _ _ h2) in H.
-      exact H.
-    }
-
-    set (M1 := mk_Monic A ar1 isM1).
-    set (M2 := mk_Monic A ar2 isM2).
-
-    set (Pb := Abelian_subobjects_Pullback A hs M1 M2).
-
-    assert (H : PullbackPr1 Pb = PullbackPr2 Pb).
-    {
-      assert (H1 : ar1 ;; (BinProductPr1 A BinProd) = identity x) by
-          apply BinProductPr1Commutes.
-      assert (H2 : ar2 ;; (BinProductPr1 A BinProd) = identity x) by
-          apply BinProductPr1Commutes.
-      rewrite <- (id_right A _ _ (PullbackPr1 Pb)). rewrite <- H1.
-      rewrite <- (id_right A _ _ (PullbackPr2 Pb)). rewrite <- H2.
-      rewrite assoc. rewrite assoc. apply cancel_postcomposition.
-      apply PullbackSqrCommutes.
-    }
+  Definition Abelian_Equalizer_eq2 {x y : A} (f1 f2 : x --> y) :
+    PullbackPr1 (Abelian_Equalizer_Pullback f1 f2) ;; f1
+    = PullbackPr1 (Abelian_Equalizer_Pullback f1 f2) ;; f2.
+  Proof.
+    set (BinProd := Abelian_BinProducts A x y).
+    set (ar1 := BinProductArrow A BinProd (identity x) f1).
+    set (ar2 := BinProductArrow A BinProd (identity x) f2).
+    set (H := Abelian_Equalizer_eq1 f1 f2).
+    set (Pb := Abelian_Equalizer_Pullback f1 f2).
 
     assert (H1 : BinProductArrow A BinProd (identity x) f1 ;;
                                  (BinProductPr2 A BinProd) = f1) by
@@ -686,15 +842,21 @@ Section abelian_equalizers.
                                  (BinProductPr2 A BinProd) = f2) by
         apply BinProductPr2Commutes.
 
-    use mk_Equalizer.
-    apply Pb.
-    apply (PullbackPr1 Pb).
     rewrite <- H1. rewrite <- H2. rewrite assoc. rewrite assoc.
-    apply cancel_postcomposition.
-    set (XX := PullbackSqrCommutes Pb). rewrite <- H in XX.
-    unfold M1 in XX. unfold M2 in XX. apply XX.
+    apply cancel_postcomposition. unfold BinProd.
+    set (X := PullbackSqrCommutes (Abelian_Equalizer_Pullback f1 f2)).
+    rewrite <- H in X. apply X.
+  Qed.
 
-    (* isEqualizer *)
+  Definition Abelian_isEqualizer {x y : A} (f1 f2 : x --> y) :
+    isEqualizer f1 f2 (PullbackPr1 (Abelian_Equalizer_Pullback f1 f2))
+                (Abelian_Equalizer_eq2 f1 f2).
+  Proof.
+    set (BinProd := Abelian_BinProducts A x y).
+    set (ar1 := BinProductArrow A BinProd (identity x) f1).
+    set (ar2 := BinProductArrow A BinProd (identity x) f2).
+    set (H := Abelian_Equalizer_eq1 f1 f2).
+
     apply mk_isEqualizer.
     intros w h HH.
 
@@ -727,16 +889,25 @@ Section abelian_equalizers.
       rewrite HH'. rewrite HH''. apply idpath.
     }
 
-    set (Pbar := PullbackArrow Pb w h h HH''').
+    set (Pbar := PullbackArrow (Abelian_Equalizer_Pullback f1 f2) w h h HH''').
 
     apply (unique_exists Pbar).
-    apply (PullbackArrow_PullbackPr1 Pb w h h HH''').
+    apply (PullbackArrow_PullbackPr1
+             (Abelian_Equalizer_Pullback f1 f2) w h h HH''').
     intros y0. apply hs.
     intros y0 t.
 
     apply PullbackArrowUnique.
     apply t. rewrite <- H. apply t.
-  Defined.
+  Qed.
+
+  (** Construction of the equalizer. *)
+  Definition Abelian_Equalizer {x y : A} (f1 f2 : x --> y) :
+    Equalizer f1 f2
+    := mk_Equalizer
+         f1 f2 (PullbackPr1 (Abelian_Equalizer_Pullback f1 f2))
+         (Abelian_Equalizer_eq2 f1 f2)
+         (Abelian_isEqualizer f1 f2).
 
   Corollary Abelian_Equalizers : @Equalizers A.
   Proof.
@@ -744,51 +915,61 @@ Section abelian_equalizers.
     apply Abelian_Equalizer.
   Defined.
 
-  Lemma Abelian_Coequalizer {x y : A} (f1 f2 : y --> x) :
-    Coequalizer f1 f2.
+  (** ** Coequalizers *)
+
+  (** Some results we are going to need to prove existence of Coequalizers. *)
+  Definition Abelian_Coequalizer_isEpi {x y : A} (f: y --> x) :
+    isEpi A (BinCoproductArrow A (Abelian_BinCoproducts A x y) (identity x) f).
+  Proof.
+    set (BinCoprod := Abelian_BinCoproducts A x y).
+    intros z h1 h2 H.
+    apply (maponpaths (fun f : _ => (BinCoproductIn1 A BinCoprod) ;; f)) in H.
+    rewrite assoc in H. rewrite assoc in H.
+    set (com1 := BinCoproductIn1Commutes A _ _ BinCoprod x (identity x) f).
+    rewrite com1 in H.
+    rewrite (id_left A _ _ h1) in H. rewrite (id_left A _ _ h2) in H.
+    exact H.
+  Qed.
+
+  Definition Abelian_Coequalizer_Pushout {x y : A} (f1 f2 : y --> x) :
+    Pushout (BinCoproductArrow A (Abelian_BinCoproducts A x y) (identity x) f1)
+            (BinCoproductArrow A (Abelian_BinCoproducts A x y) (identity x) f2)
+    := Abelian_quotobjects_Pushout
+         A hs
+         (mk_Epi A _ (Abelian_Coequalizer_isEpi f1))
+         (mk_Epi A _ (Abelian_Coequalizer_isEpi f2)).
+
+  Definition Abelian_Coequalizer_eq1 {x y : A} (f1 f2 : y --> x) :
+    PushoutIn1 (Abelian_Coequalizer_Pushout f1 f2)
+    = PushoutIn2 (Abelian_Coequalizer_Pushout f1 f2).
   Proof.
     set (BinCoprod := Abelian_BinCoproducts A x y).
     set (ar1 := BinCoproductArrow A BinCoprod (identity x) f1).
     set (ar2 := BinCoproductArrow A BinCoprod (identity x) f2).
+    set (Po := Abelian_Coequalizer_Pushout f1 f2).
 
-    assert (isE1 : isEpi A ar1).
-    {
-      intros z h1 h2 H.
-      apply (maponpaths (fun f : _ => (BinCoproductIn1 A BinCoprod) ;; f)) in H.
-      rewrite assoc in H. rewrite assoc in H.
-      set (com1 := BinCoproductIn1Commutes A _ _ BinCoprod x (identity x) f1).
-      fold ar1 in com1. rewrite com1 in H.
-      rewrite (id_left A _ _ h1) in H. rewrite (id_left A _ _ h2) in H.
-      exact H.
-    }
+    assert (H1 : (BinCoproductIn1 A BinCoprod) ;; ar1 = identity x) by
+        apply BinCoproductIn1Commutes.
+    assert (H2 : (BinCoproductIn1 A BinCoprod) ;; ar2 = identity x) by
+        apply BinCoproductIn1Commutes.
+    use (pathscomp0 (!(id_left A _ _ (PushoutIn1 Po)))).
+    use (pathscomp0 (!(maponpaths (fun h : _ => h ;; PushoutIn1 Po) H1))).
+    use (pathscomp0 _ ((id_left A _ _ (PushoutIn2 Po)))).
+    use (pathscomp0 _ (maponpaths (fun h : _ => h ;; PushoutIn2 Po) H2)).
+    rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
+    apply PushoutSqrCommutes.
+  Qed.
 
-    assert (isE2 : isEpi A ar2).
-    {
-      intros z h1 h2 H.
-      apply (maponpaths (fun f : _ => (BinCoproductIn1 A BinCoprod) ;; f)) in H.
-      rewrite assoc in H. rewrite assoc in H.
-      set (com1 := BinCoproductIn1Commutes A _ _ BinCoprod x (identity x) f2).
-      fold ar2 in com1. rewrite com1 in H.
-      rewrite (id_left A _ _ h1) in H. rewrite (id_left A _ _ h2) in H.
-      exact H.
-    }
+  Definition Abelian_Coequalizer_eq2 {x y : A} (f1 f2 : y --> x) :
+    f1 ;; PushoutIn1 (Abelian_Coequalizer_Pushout f1 f2)
+    = f2 ;; PushoutIn1 (Abelian_Coequalizer_Pushout f1 f2).
+  Proof.
+    set (BinCoprod := Abelian_BinCoproducts A x y).
+    set (ar1 := BinCoproductArrow A BinCoprod (identity x) f1).
+    set (ar2 := BinCoproductArrow A BinCoprod (identity x) f2).
+    set (H := Abelian_Coequalizer_eq1 f1 f2).
+    set (Pb := Abelian_Coequalizer_Pushout f1 f2).
 
-    set (E1 := mk_Epi A ar1 isE1).
-    set (E2 := mk_Epi A ar2 isE2).
-
-    set (Po := Abelian_quotobjects_pushout A hs E1 E2).
-
-    assert (H : PushoutIn1 Po = PushoutIn2 Po).
-    {
-      assert (H1 : (BinCoproductIn1 A BinCoprod) ;; ar1 = identity x) by
-          apply BinCoproductIn1Commutes.
-      assert (H2 : (BinCoproductIn1 A BinCoprod) ;; ar2 = identity x) by
-          apply BinCoproductIn1Commutes.
-      rewrite <- (id_left A _ _ (PushoutIn1 Po)). rewrite <- H1.
-      rewrite <- (id_left A _ _ (PushoutIn2 Po)). rewrite <- H2.
-      rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
-      apply PushoutSqrCommutes.
-    }
 
     assert (H1 : (BinCoproductIn2 A BinCoprod)
                    ;; BinCoproductArrow A BinCoprod (identity x) f1 = f1) by
@@ -798,16 +979,21 @@ Section abelian_equalizers.
                    ;; BinCoproductArrow A BinCoprod (identity x) f2 = f2) by
         apply BinCoproductIn2Commutes.
 
-    use mk_Coequalizer.
-    apply Po.
-    apply (PushoutIn1 Po).
-    rewrite <- H1. rewrite <- H2.
-    rewrite <- assoc. rewrite <- assoc.
-    apply cancel_precomposition.
-    set (XX := PushoutSqrCommutes Po). rewrite <- H in XX.
-    unfold E1 in XX. unfold E2 in XX. apply XX.
+    rewrite <- H1. rewrite <- H2. rewrite <- assoc. rewrite <- assoc.
+    apply cancel_precomposition. unfold BinCoprod.
+    set (X := PushoutSqrCommutes (Abelian_Coequalizer_Pushout f1 f2)).
+    rewrite <- H in X. apply X.
+  Qed.
 
-    (* isCoequalizer *)
+  Definition Abelian_isCoequalizer {x y : A} (f1 f2 : y --> x) :
+    isCoequalizer f1 f2 (PushoutIn1 (Abelian_Coequalizer_Pushout f1 f2))
+                  (Abelian_Coequalizer_eq2 f1 f2).
+  Proof.
+    set (BinCoprod := Abelian_BinCoproducts A x y).
+    set (ar1 := BinCoproductArrow A BinCoprod (identity x) f1).
+    set (ar2 := BinCoproductArrow A BinCoprod (identity x) f2).
+    set (H := Abelian_Coequalizer_eq1 f1 f2).
+
     apply mk_isCoequalizer.
     intros w h HH.
 
@@ -840,16 +1026,25 @@ Section abelian_equalizers.
       rewrite HH'. rewrite HH''. apply idpath.
     }
 
-    set (Poar := PushoutArrow Po w h h HH''').
+    set (Poar := PushoutArrow (Abelian_Coequalizer_Pushout f1 f2) w h h HH''').
 
     apply (unique_exists Poar).
-    apply (PushoutArrow_PushoutIn1 Po w h h HH''').
+    apply (PushoutArrow_PushoutIn1
+             (Abelian_Coequalizer_Pushout f1 f2) w h h HH''').
     intros y0. apply hs.
     intros y0 t.
 
     apply PushoutArrowUnique.
     apply t. rewrite <- H. apply t.
-  Defined.
+  Qed.
+
+  (** Construction of Coequalizer. *)
+  Definition Abelian_Coequalizer {x y : A} (f1 f2 : y --> x) :
+    Coequalizer f1 f2
+    := mk_Coequalizer
+         f1 f2 (PushoutIn1 (Abelian_Coequalizer_Pushout f1 f2))
+         (Abelian_Coequalizer_eq2 f1 f2)
+         (Abelian_isCoequalizer f1 f2).
 
   Corollary Abelian_Coequalizers : @Coequalizers A.
   Proof.
@@ -893,6 +1088,7 @@ Section abelian_monic_kernels.
   Variable A : Abelian_precategory.
   Hypothesis hs : has_homsets A.
 
+  (** ** KernelArrow of Monic = ArrowFromZero *)
 
   (* Hide isEqualizer behind Qed. *)
   Definition Abelian_MonicKernelZero_isEqualizer {x y : A} (M : Monic A x y) :
@@ -936,6 +1132,8 @@ Section abelian_monic_kernels.
          (ArrowsFromZero _ _ _ _ _)
          (Abelian_MonicKernelZero_isEqualizer M).
 
+  (** ** CokernelArrow of Epi = ArrowtoZero *)
+
   (* Hide isCoequalizer behind Qed. *)
   Definition Abelian_EpiCokernelZero_isCoequalizer {y z : A} (E : Epi A y z) :
     isCoequalizer E (ZeroArrow A (Abelian_Zero A) y z) (ZeroArrowTo z)
@@ -973,8 +1171,9 @@ Section abelian_monic_kernels.
          (ArrowsToZero _ _ _ _ _)
          (Abelian_EpiCokernelZero_isCoequalizer E).
 
-  (** Next, we show that a morphism is monic if its kernel is the
-    ZeroArrow from zero. *)
+  (** ** KernelArrow = FromZero ⇒ isMonic *)
+
+  (** The following Definitions is used in the next Definition. *)
   Definition Abelian_KernelZeroMonic_cokernel {x y : A} {f1 f2 : x --> y}
              (e : f1 = f2) (CK : Cokernel (Abelian_Zero A) f1) :
     Cokernel (Abelian_Zero A) f2.
@@ -1082,9 +1281,9 @@ Section abelian_monic_kernels.
   Defined.
 
 
-  (** We show that if the cokernel of a morphism is the ZeroArrow to Zero,
-    then the morphism is an Epi. *)
+  (** ** CokernelArrow = ToZero ⇒ isEpi *)
 
+  (** The following Definition is used in the next Definition. *)
   Definition Abelian_CokernelZeroEpi_kernel {x y : A} {f1 f2 : x --> y}
              (e : f1 = f2) (K : Kernel (Abelian_Zero A) f1) :
     Kernel (Abelian_Zero A) f2.
@@ -1580,34 +1779,35 @@ Section abelian_kernel_cokernel.
   Variable A : Abelian_precategory.
   Hypothesis hs : has_homsets A.
 
-  (** First, we show that every monic is a kernel of its cokernel. *)
-  Definition Abelian_MonicToKernel {x y : A} (M : Monic A x y) :
-    Kernel (Abelian_Zero A) (CokernelArrow _ (Abelian_Cokernel A M)).
+  (** ** Monic is the kernel of its cokernel *)
+
+  Definition Abelian_MonicToKernel_isMonic {x y : A} (M : Monic A x y) :
+    isMonic A (Abelian_factorization1_epi A hs M).
   Proof.
-    set (ker := Abelian_Im A M).
-    set (tmp := Abelian_factorization1 A hs M).
+    apply (isMonic_postcomp A _ (Abelian_factorization1_monic A M)).
+    rewrite <- (Abelian_factorization1 A hs M).
+    apply (pr2 M).
+  Qed.
 
-    assert (isM : isMonic A (Abelian_factorization1_epi A hs M)).
-    {
-      apply (isMonic_postcomp A _ (Abelian_factorization1_monic A M)).
-      rewrite <- tmp.
-      apply (pr2 M).
-    }
+  Definition Abelian_MonicToKernel_is_iso {x y : A} (M : Monic A x y) :
+    is_iso (Abelian_factorization1_epi A hs M).
+  Proof.
+    apply Abelian_monic_epi_is_iso.
+    apply (Abelian_MonicToKernel_isMonic M).
+    apply Abelian_factorization1_is_epi.
+    apply hs.
+  Qed.
 
-    assert (isI : is_iso (Abelian_factorization1_epi A hs M)).
-    {
-      apply Abelian_monic_epi_is_iso.
-      apply isM.
-      apply Abelian_factorization1_is_epi.
-      apply hs.
-    }
-
-    set (h := isopair (Abelian_factorization1_epi A hs M) isI).
-
-    (* The following general result constructs the kernel *)
-    apply (Kernel_up_to_iso A hs (Abelian_Zero A) M
-                            (CokernelArrow _ (Abelian_Cokernel A M)) ker h tmp).
-  Defined.
+  (** Monic is a kernel of its cokernel. *)
+  Definition Abelian_MonicToKernel {x y : A} (M : Monic A x y) :
+    Kernel (Abelian_Zero A) (CokernelArrow _ (Abelian_Cokernel A M))
+    := Kernel_up_to_iso
+         A hs (Abelian_Zero A) M
+         (CokernelArrow _ (Abelian_Cokernel A M))
+         (Abelian_Im A M)
+         (isopair (Abelian_factorization1_epi A hs M)
+                  (Abelian_MonicToKernel_is_iso M))
+         (Abelian_factorization1 A hs M).
 
   (** The following verifies that the monic M is indeed the KernelArrow. *)
   Lemma Abelian_MonicToKernel_eq {x y : A} (M : Monic A x y) :
@@ -1638,35 +1838,36 @@ Section abelian_kernel_cokernel.
     apply idpath.
   Defined.
 
-  (** Next, we show that every epi is a cokernel of its kernel. *)
-  Definition Abelian_EpiToCokernel {x y : A} (E : Epi A x y) :
-    Cokernel (Abelian_Zero A) (KernelArrow _ (Abelian_Kernel A E)).
+  (** ** Epi is the cokernel of its kernel *)
+
+  Definition Abelian_EpiToCokernel_isEpi {x y : A} (E : Epi A x y) :
+    isEpi A (Abelian_factorization2_monic A hs E).
   Proof.
-    set (coker := Abelian_CoIm A E).
-    set (tmp := Abelian_factorization2 A hs E).
+    apply (isEpi_precomp A (Abelian_factorization2_epi A E)).
+    rewrite <- (Abelian_factorization2 A hs E).
+    apply (pr2 E).
+  Qed.
 
-    assert (isE : isEpi A (Abelian_factorization2_monic A hs E)).
-    {
-      apply (isEpi_precomp A (Abelian_factorization2_epi A E)).
-      rewrite <- tmp.
-      apply (pr2 E).
-    }
+  Definition Abelian_EpiToCokernel_is_iso {x y : A} (E : Epi A x y) :
+    is_iso (Abelian_factorization2_monic A hs E).
+  Proof.
+    apply Abelian_monic_epi_is_iso.
+    apply Abelian_factorization2_is_monic.
+    apply hs.
+    apply (Abelian_EpiToCokernel_isEpi E).
+  Qed.
 
-    assert (isI : is_iso (Abelian_factorization2_monic A hs E)).
-    {
-      apply Abelian_monic_epi_is_iso.
-      apply Abelian_factorization2_is_monic.
-      apply hs.
-      apply isE.
-    }
-
-    set (h := isopair (Abelian_factorization2_monic A hs E) isI).
-
-    (* The following general result constructs the cokernel *)
-    apply (Cokernel_up_to_iso A hs (Abelian_Zero A)
-                              (KernelArrow _ (Abelian_Kernel A E)) E
-                              coker h tmp).
-  Defined.
+  (** Epi is a cokernel of its kernel. *)
+  Definition Abelian_EpiToCokernel {x y : A} (E : Epi A x y) :
+    Cokernel (Abelian_Zero A) (KernelArrow _ (Abelian_Kernel A E))
+    := Cokernel_up_to_iso
+         A hs (Abelian_Zero A)
+         (KernelArrow _ (Abelian_Kernel A E))
+         E
+         (Abelian_CoIm A E)
+         (isopair (Abelian_factorization2_monic A hs E)
+                  (Abelian_EpiToCokernel_is_iso E))
+         (Abelian_factorization2 A hs E).
 
   (** The following verifies that the epi E is indeed the CokernelArrow. *)
   Lemma Abelian_EpiToCokernel_eq {x y : A} (E : Epi A x y) :

--- a/UniMath/CategoryTheory/Abelian.v
+++ b/UniMath/CategoryTheory/Abelian.v
@@ -1,0 +1,123 @@
+(** Definition of abelian categories. *)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.Foundations.Algebra.Monoids_and_Groups.
+
+Require Import UniMath.CategoryTheory.total2_paths.
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.BinProductPrecategory.
+Require Import UniMath.CategoryTheory.PrecategoriesWithBinOps.
+Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
+Require Import UniMath.CategoryTheory.PreAdditive.
+
+Require Import UniMath.CategoryTheory.limits.zero.
+Require Import UniMath.CategoryTheory.limits.binproducts.
+Require Import UniMath.CategoryTheory.limits.bincoproducts.
+Require Import UniMath.CategoryTheory.limits.equalizers.
+Require Import UniMath.CategoryTheory.limits.coequalizers.
+Require Import UniMath.CategoryTheory.limits.kernels.
+Require Import UniMath.CategoryTheory.limits.cokernels.
+Require Import UniMath.CategoryTheory.Monics.
+Require Import UniMath.CategoryTheory.Epis.
+
+Section def_abelian.
+
+  (** An abelian category has a zero object, binary (co)products, (co)kernels
+    and every monic (resp. epi) is a kernel (resp. cokernel). *)
+  Definition AbelianData (C : precategory) : UU := Zero C.
+
+  Definition isAbelianMonicKernels (C : precategory)
+             (AD : AbelianData C) : UU :=
+    ∀ (x y : C) (M : Monic C x y),
+      (∃ (z : C) (f : y --> z) (H : M ;; f = M ;; (ZeroArrow C AD y z)),
+          isEqualizer f (ZeroArrow C AD y z) M H).
+
+  Definition isAbelianEpiCokernels (C : precategory)
+             (AD : AbelianData C) : UU :=
+    (∀ (y z : C) (E : Epi C y z),
+        (∃ (x : C) (f : x --> y) (H : f ;; E = (ZeroArrow C AD x y) ;; E),
+            isCoequalizer f (ZeroArrow C AD x y) E H)).
+
+
+  Definition isAbelian (C : precategory)
+              (AD : AbelianData C) : UU :=
+     (BinProducts C) × (BinCoproducts C)
+                     × (Kernels AD) × (Cokernels AD)
+                     × (isAbelianMonicKernels C AD)
+                     × (isAbelianEpiCokernels C AD).
+
+  Definition mk_isAbelian (C : precategory) (AD : AbelianData C)
+              (BPr : BinProducts C) (BCPr : BinCoproducts C)
+              (K : Kernels AD) (Ck : Cokernels AD)
+              (MK : isAbelianMonicKernels C AD)
+              (EC : isAbelianEpiCokernels C AD) :
+    isAbelian C AD.
+  Proof.
+    exact (BPr,,(BCPr,,(K,,(Ck,,(MK,,EC))))).
+  Defined.
+
+  (** Definition of abelian categories *)
+  Definition Abelian : UU :=
+    Σ A : (Σ C : precategory, AbelianData C),
+          isAbelian (pr1 A) (pr2 A).
+  Definition Abelian_precategory (A : Abelian) :
+    precategory := pr1 (pr1 A).
+  Coercion Abelian_precategory :
+    Abelian >-> precategory.
+
+  Definition mk_Abelian (C : precategory)
+             (AD : AbelianData C) (H : isAbelian C AD) : Abelian.
+  Proof.
+    exact (tpair _ (tpair _ C AD) H).
+  Defined.
+
+  Variable A : Abelian.
+  Hypothesis hs : has_homsets A.
+
+  (** Accessor functions. *)
+  Definition Abelian_Zero :
+    Zero A := (pr2 (pr1 A)).
+  Definition Abelian_Products :
+    BinProducts A := pr1 (pr2 A).
+  Definition Abelian_BinCoproducts :
+    BinCoproducts A := pr1 (pr2 (pr2 A)).
+  Definition Abelian_Kernels :
+    Kernels Abelian_Zero := pr1 (pr2 (pr2 (pr2 A))).
+  Definition Abelian_Cokernels :
+    Cokernels Abelian_Zero := pr1 (pr2 (pr2 (pr2 (pr2 A)))).
+  Definition Abelian_isAbelianMonicKernels
+    : isAbelianMonicKernels A (pr2 (pr1 A))
+    := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 A))))).
+  Definition Abelian_isAbelianEpiCokernels
+    : isAbelianEpiCokernels A (pr2 (pr1 A))
+    := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 A))))).
+
+
+  (** The following definition constructs kernels from monics. *)
+  Definition Abelian_MonicToKernel {x y : A} (M : Monic A x y) :
+    Kernel Abelian_Zero (CokernelArrow _ (Abelian_Cokernels _ _ M)).
+  Proof.
+    set (AMK := Abelian_isAbelianMonicKernels x y M).
+    unfold ishinh in AMK. cbn in *. unfold ishinh_UU in AMK.
+
+    use mk_Kernel.
+    exact x. exact (MonicArrow _ M).
+    (* Here the goal should be hProp to be able to apply AMK. *)
+  Abort.
+
+  (** The following definition constructs cokernels from epis. *)
+  Definition Abelian_EpiToCokernel {y z : A} (E : Epi A y z) :
+    Cokernel Abelian_Zero (KernelArrow _ (Abelian_Kernels _ _ E)).
+  Proof.
+    set (AEC := Abelian_isAbelianEpiCokernels y z E).
+    unfold ishinh in AEC. cbn in *. unfold ishinh_UU in AEC.
+
+    use mk_Cokernel.
+    exact z. exact (EpiArrow _ E).
+    (* Here the goal should be hProp to be able to apply AEC. *)
+  Abort.
+
+End def_abelian.

--- a/UniMath/CategoryTheory/Abelian.v
+++ b/UniMath/CategoryTheory/Abelian.v
@@ -902,10 +902,7 @@ Section abelian_monic_kernels.
 
 
   (** Next, we show that a morphism is monic if its kernel is the
-    arrow from zero *)
-
-  (** We use the following definition to build a cokernel in the following
-    definition.  *)
+    ZeroArrow from zero. *)
   Definition Abelian_KernelZeroMonic_cokernel {x y : A} {f1 f2 : x --> y}
              (e : f1 = f2) (CK : Cokernel (Abelian_Zero A) f1) :
     Cokernel (Abelian_Zero A) f2.
@@ -921,7 +918,7 @@ Section abelian_monic_kernels.
     induction e. apply (isCoequalizer_Coequalizer CK).
   Defined.
 
-  (** The morphism f is monic if its kernel is zero *)
+  (** The morphism f is monic if its kernel is zero. *)
   Definition Abelian_KernelZeroisMonic {x y z : A} (f : y --> z)
              (H : ZeroArrow A (Abelian_Zero A) x y ;; f =
                   ZeroArrow A (Abelian_Zero A) x z )
@@ -965,10 +962,12 @@ Section abelian_monic_kernels.
     set (ar := KernelIn (Abelian_Zero A) ker
                         (AECD_Ob (Abelian_AECD A) _ _ Coeqar_epi)
                         (AECD_Mor (Abelian_AECD A) _ _ Coeqar_epi) e2).
-    set (com1 := KernelCommutes (Abelian_Zero A) ker (AECD_Ob (Abelian_AECD A) _ _ Coeqar_epi)
+    set (com1 := KernelCommutes (Abelian_Zero A) ker
+                                (AECD_Ob (Abelian_AECD A) _ _ Coeqar_epi)
                                 (AECD_Mor (Abelian_AECD A) _ _ Coeqar_epi) e2).
 
-    assert (e3 : KernelArrow (Abelian_Zero A) ker = ZeroArrow A (Abelian_Zero A) _ _ ).
+    assert (e3 : KernelArrow (Abelian_Zero A) ker
+                 = ZeroArrow A (Abelian_Zero A) _ _ ).
     {
       apply idpath.
     }
@@ -982,7 +981,8 @@ Section abelian_monic_kernels.
     assert (e5 : is_iso (CoequalizerArrow Coeq)).
     {
       set (coker2 := Abelian_KernelZeroMonic_cokernel e4 Coeq_coker).
-      set (coker2_iso := CokernelofZeroArrow_iso (Abelian_Zero A) hs _ y coker2).
+      set (coker2_iso := CokernelofZeroArrow_iso (Abelian_Zero A)
+                                                 hs _ y coker2).
       apply (pr2 (coker2_iso)).
     }
 
@@ -1010,11 +1010,9 @@ Section abelian_monic_kernels.
   Defined.
 
 
-  (** We show that if the cokernel of a morphism is the zero to Zero,
+  (** We show that if the cokernel of a morphism is the ZeroArrow to Zero,
    then the morphism is an Epi. *)
 
-  (** We use the following definition to build a cokernel in the following
-    definition.  *)
   Definition Abelian_CokernelZeroEpi_kernel {x y : A} {f1 f2 : x --> y}
              (e : f1 = f2) (K : Kernel (Abelian_Zero A) f1) :
     Kernel (Abelian_Zero A) f2.
@@ -1030,7 +1028,7 @@ Section abelian_monic_kernels.
     induction e. apply (isEqualizer_Equalizer K).
   Defined.
 
-  (** The morphism f is monic if its kernel is zero *)
+  (** The morphism f is monic if its kernel is zero. *)
   Definition Abelian_CokernelZeroisEpi {x y z : A} (f : x --> y)
              (H : f ;; ZeroArrow A (Abelian_Zero A) y z =
                   ZeroArrow A (Abelian_Zero A) x z )
@@ -1076,7 +1074,8 @@ Section abelian_monic_kernels.
                            (AMKD_Mor (Abelian_AMKD A) _ _ Eqar_monic) e2).
     set (com1 := CokernelCommutes (Abelian_Zero A) coker
                                   (AMKD_Ob (Abelian_AMKD A) _ _ Eqar_monic)
-                                  (AMKD_Mor (Abelian_AMKD A) _ _ Eqar_monic) e2).
+                                  (AMKD_Mor (Abelian_AMKD A) _ _ Eqar_monic)
+                                  e2).
 
     assert (e3 : CokernelArrow (Abelian_Zero A) coker
                  = ZeroArrow A (Abelian_Zero A) _ _ ).
@@ -1603,7 +1602,7 @@ Section abelian_kernel_cokernel.
     apply idpath.
   Defined.
 
-  (** This generalizes the above by using any Cokernel. *)
+  (** This generalizes the above by using any Kernel. *)
   Definition Abelian_EpiToCokernel' {x y : A} (E : Epi A x y)
     (K : Kernel (Abelian_Zero A) E) :
     Cokernel (Abelian_Zero A) (KernelArrow _ K)

--- a/UniMath/CategoryTheory/Abelian.v
+++ b/UniMath/CategoryTheory/Abelian.v
@@ -35,119 +35,148 @@ Section def_abelian.
   Definition AbelianData2 (C : precategory) (AD1 : AbelianData1 C) : UU :=
     (Kernels (pr1 AD1)) × (Cokernels (pr1 AD1)).
 
-  Definition isAbelianMonicKernels (C : precategory)
+  (** This definition contains the data that every monic is a kernel of some
+    morphism. *)
+  Definition AbelianMonicKernelsData (C : precategory)
              (AD : AbelianData1 C) : UU :=
     Π (x y : C) (M : Monic C x y),
-      (∃ (z : C) (f : y --> z) (H : M ;; f = M ;; (ZeroArrow C (pr1 AD) y z)),
-          isEqualizer f (ZeroArrow C (pr1 AD) y z) M H).
+    (Σ D2 : (Σ D1 : (Σ z : C, y --> z),
+                    M ;; (pr2 D1) = M ;; (ZeroArrow C (pr1 AD) y (pr1 D1))),
+            isEqualizer (pr2 (pr1 D2)) (ZeroArrow C (pr1 AD) y (pr1 (pr1 D2)))
+                        M (pr2 D2)).
 
-  Definition isapropisAbelianMonicKernels (C : precategory)
-             (AD1 : AbelianData1 C) :
-    isaprop (isAbelianMonicKernels C AD1).
-  Proof.
-    apply impred_isaprop; intros x.
-    apply impred_isaprop; intros y.
-    apply impred_isaprop; intros M.
-    apply isapropishinh.
-  Qed.
+  (** Accessor functions for AbelianMonicKernelsData. *)
+  Definition AMKD_Ob {C : precategory} {AD : AbelianData1 C}
+             (AMKD : AbelianMonicKernelsData C AD) (x y : C)
+             (M : Monic C x y) : C := pr1 (pr1 (pr1 (AMKD x y M))).
+  Definition AMKD_Mor {C : precategory} {AD : AbelianData1 C}
+             (AMKD : AbelianMonicKernelsData C AD) (x y : C)
+             (M : Monic C x y) :
+    C⟦y, (AMKD_Ob AMKD x y M)⟧ := pr2 (pr1 (pr1 (AMKD x y M))).
+  Definition AMKD_Eq {C : precategory} {AD : AbelianData1 C}
+             (AMKD : AbelianMonicKernelsData C AD) (x y : C)
+             (M : Monic C x y) :
+    M ;; (AMKD_Mor AMKD x y M)
+    = M ;; (ZeroArrow C (pr1 AD) y (AMKD_Ob AMKD x y M))
+    := pr2 (pr1 (AMKD x y M)).
+  Definition AMKD_isE {C : precategory} {AD : AbelianData1 C}
+             (AMKD : AbelianMonicKernelsData C AD) (x y : C)
+             (M : Monic C x y) :
+    isEqualizer (AMKD_Mor AMKD x y M)
+                (ZeroArrow C (pr1 AD) y (AMKD_Ob AMKD x y M))
+                M (AMKD_Eq AMKD x y M)
+    := pr2 (AMKD x y M).
 
-  Definition isAbelianEpiCokernels (C : precategory)
+  (** This definition contains the data that every epi is a cokernel of some
+    morphism. *)
+  Definition AbelianEpiCokernelsData (C : precategory)
              (AD : AbelianData1 C) : UU :=
     (Π (y z : C) (E : Epi C y z),
-        (∃ (x : C) (f : x --> y) (H : f ;; E = (ZeroArrow C (pr1 AD) x y) ;; E),
-            isCoequalizer f (ZeroArrow C (pr1 AD) x y) E H)).
+     (Σ D2 : (Σ D1 : (Σ x : C, x --> y),
+                     (pr2 D1) ;; E = (ZeroArrow C (pr1 AD) (pr1 D1) y) ;; E),
+             isCoequalizer (pr2 (pr1 D2))
+                           (ZeroArrow C (pr1 AD) (pr1 (pr1 D2)) y)
+                           E (pr2 D2))).
 
-  Definition isapropisAbelianEpiCokernels (C : precategory)
-             (AD1 : AbelianData1 C) :
-    isaprop (isAbelianEpiCokernels C AD1).
-  Proof.
-    apply impred_isaprop; intros x.
-    apply impred_isaprop; intros y.
-    apply impred_isaprop; intros M.
-    apply isapropishinh.
-  Qed.
+  (** Accessor functions for AbelianEpiCokernelsData. *)
+  Definition AECD_Ob {C : precategory} {AD : AbelianData1 C}
+             (AECD : AbelianEpiCokernelsData C AD) (y z : C)
+             (E : Epi C y z) : C := pr1 (pr1 (pr1 (AECD y z E))).
+  Definition AECD_Mor {C : precategory} {AD : AbelianData1 C}
+             (AECD : AbelianEpiCokernelsData C AD) (y z : C)
+             (E : Epi C y z) :
+    C⟦(AECD_Ob AECD y z E), y⟧ := pr2 (pr1 (pr1 (AECD y z E))).
+  Definition AECD_Eq {C : precategory} {AD : AbelianData1 C}
+             (AECD : AbelianEpiCokernelsData C AD) (y z : C)
+             (E : Epi C y z) :
+    (AECD_Mor AECD y z E) ;; E
+    = (ZeroArrow C (pr1 AD) (AECD_Ob AECD y z E) y) ;; E
+    := pr2 (pr1 (AECD y z E)).
+  Definition AECD_isC {C : precategory} {AD : AbelianData1 C}
+             (AECD : AbelianEpiCokernelsData C AD) (y z : C)
+             (E : Epi C y z) :
+    isCoequalizer (AECD_Mor AECD y z E)
+                  (ZeroArrow C (pr1 AD) (AECD_Ob AECD y z E) y)
+                  E (AECD_Eq AECD y z E)
+    := pr2 (AECD y z E).
 
-  Definition isAbelian (C : precategory)
-              (AD1 : AbelianData1 C) : UU :=
-    (isAbelianMonicKernels C AD1) × (isAbelianEpiCokernels C AD1).
+  (** Data which contains kernels, cokernels, the data that monics are kernels
+    of some morphisms, and the data that epis are cokernels of some
+    morphisms. *)
+  Definition AbelianData (C : precategory) (AD1 : AbelianData1 C) : UU :=
+    (AbelianData2 C AD1)
+      × (AbelianMonicKernelsData C AD1)
+      × (AbelianEpiCokernelsData C AD1).
 
-  Definition isapropisAbelian (C : precategory) (AD1 : AbelianData1 C) :
-    isaprop (isAbelian C AD1).
-  Proof.
-    apply isapropdirprod.
-    apply (isapropisAbelianMonicKernels C AD1).
-    apply (isapropisAbelianEpiCokernels C AD1).
-  Qed.
-
-  Definition mk_isAbelian (C : precategory) (AD1 : AbelianData1 C)
-              (MK : isAbelianMonicKernels C AD1)
-              (EC : isAbelianEpiCokernels C AD1) :
-    isAbelian C AD1 := (MK,,EC).
-
-  (** Definition of abelian categories *)
+  (** Definition of abelian categories. *)
   Definition Abelian : UU :=
-    Σ A : (Σ C' : (Σ C : precategory, AbelianData1 C),
-                  AbelianData2 (pr1 C') (pr2 C')),
-          isAbelian (pr1 (pr1 A)) (pr2 (pr1 A)).
+    Σ A : (Σ C : precategory, AbelianData1 C), AbelianData (pr1 A) (pr2 A).
   Definition Abelian_precategory (A : Abelian) :
-    precategory := pr1 (pr1 (pr1 A)).
+    precategory := pr1 (pr1 A).
   Coercion Abelian_precategory :
     Abelian >-> precategory.
 
-  Definition mk_Abelian (C : precategory)
-             (AD1 : AbelianData1 C) (AD2 : AbelianData2 C AD1)
-             (H : isAbelian C AD1) :
-    Abelian := tpair _ (tpair _ (tpair _ C AD1) AD2) H.
+  Definition mk_Abelian (C : precategory) (AD1 : AbelianData1 C)
+             (AD : AbelianData C AD1) :
+    Abelian := tpair _ (tpair _ C AD1) AD.
 
   Variable A : Abelian.
   Hypothesis hs : has_homsets A.
 
-  (** Accessor functions. *)
+  (** Accessor functions Abelian. *)
   Definition Abelian_Zero :
-    Zero A := pr1(pr2 (pr1 (pr1 A))).
+    Zero A := pr1 (pr2 (pr1 A)).
   Definition Abelian_BinProducts :
-    BinProducts A := pr1 (pr2 (pr2 (pr1 (pr1 A)))).
+    BinProducts A := pr1 (pr2 (pr2 (pr1 A))).
   Definition Abelian_BinCoproducts :
-    BinCoproducts A := pr2 (pr2 (pr2 (pr1 (pr1 A)))).
+    BinCoproducts A := pr2 (pr2 (pr2 (pr1 A))).
+  Definition Abelian_AbelianData1 :
+    AbelianData1 A := (pr2 (pr1 A)).
   Definition Abelian_Kernels :
-    Kernels Abelian_Zero := pr1 (pr2 (pr1 A)).
+    Kernels Abelian_Zero := pr1 (pr1 (pr2 A)).
   Definition Abelian_Cokernels :
-    Cokernels Abelian_Zero := pr2 (pr2 (pr1 A)).
-  Definition Abelian_isAbelianMonicKernels
-    : isAbelianMonicKernels A (pr2 (pr1 (pr1 A)))
-    := pr1 (pr2 A).
-  Definition Abelian_isAbelianEpiCokernels
-    : isAbelianEpiCokernels A (pr2 (pr1 (pr1 A)))
-    := pr2 (pr2 A).
+    Cokernels Abelian_Zero := pr2 (pr1 (pr2 A)).
+  Definition Abelian_AMKD
+    : AbelianMonicKernelsData A (pr2 (pr1 A))
+    := pr1 (pr2 (pr2 A)).
+  Definition Abelian_AECD
+    : AbelianEpiCokernelsData A (pr2 (pr1 A))
+    := pr2 (pr2 (pr2 A)).
 
 
   (** The following definitions construct a kernel from a monic and a cokernel
     from an epi. *)
   Definition Abelian_monic_kernel {x y : A} (M : Monic A x y) :
-    ∃ (z : A) (f : y --> z), Kernel Abelian_Zero f.
+    Kernel Abelian_Zero (AMKD_Mor Abelian_AMKD x y M).
   Proof.
-    set (AMK := Abelian_isAbelianMonicKernels x y M).
-    apply AMK. intros X. induction X. induction p. induction p.
-    intros P Y. apply Y.
-    refine (tpair _ t _). refine (tpair _ t0 _).
-
-    use (mk_Kernel Abelian_Zero M). (* use the monic as the kernel. *)
-    rewrite <- (ZeroArrow_comp_right A Abelian_Zero _ _ _ M).
-    apply t1. apply p.
+    use (mk_Kernel Abelian_Zero M).
+    rewrite (AMKD_Eq Abelian_AMKD x y M).
+    apply ZeroArrow_comp_right.
+    apply (AMKD_isE Abelian_AMKD x y M).
   Defined.
 
   Definition Abelian_epi_cokernel {y z : A} (E : Epi A y z) :
-    ∃ (x : A) (f : x --> y), Cokernel Abelian_Zero f.
+    Cokernel Abelian_Zero (AECD_Mor Abelian_AECD y z E).
   Proof.
-    set (AEC := Abelian_isAbelianEpiCokernels y z E).
-    apply AEC. intros X. induction X. induction p. induction p.
-    intros P Y. apply Y.
-    refine (tpair _ t _). refine (tpair _ t0 _).
-
-    use (mk_Cokernel Abelian_Zero E). (* use the epi as the cokernel. *)
-    rewrite <- (ZeroArrow_comp_left A Abelian_Zero _ _ _ E).
-    apply t1. apply p.
+    use (mk_Cokernel Abelian_Zero E).
+    rewrite (AECD_Eq Abelian_AECD y z E).
+    apply ZeroArrow_comp_left.
+    apply (AECD_isC Abelian_AECD y z E).
   Defined.
+
+  (** The following lemmas verify that the kernel and cokernel arrows are indeed
+    the monic M and the epi E. *)
+  Lemma Abelian_monic_kernel_eq {x y : A} (M : Monic A x y) :
+    KernelArrow Abelian_Zero (Abelian_monic_kernel M) = M.
+  Proof.
+    apply idpath.
+  Qed.
+
+  Lemma Abelian_epi_cokernel_eq {x y : A} (E : Epi A x y) :
+    CokernelArrow Abelian_Zero (Abelian_epi_cokernel E) = E.
+  Proof.
+    apply idpath.
+  Qed.
 End def_abelian.
 
 (** In abelian categories morphisms which are both monic and epi are
@@ -157,45 +186,43 @@ Section abelian_monic_epi_iso.
   Variable A : Abelian.
   Hypothesis hs : has_homsets A.
 
-  (** If a morphism if a monic and epi, then it is also iso *)
+  (** If a morphism if a monic and an epi, then it is also an iso. *)
   Lemma Abelian_monic_epi_is_iso {x y : A} {f : x --> y} :
     isMonic A f -> isEpi A f -> is_iso f.
   Proof.
+
     intros M E.
     set (M1 := mk_Monic A f M).
     set (E1 := mk_Epi A f E).
-    set (AMK := Abelian_isAbelianMonicKernels A x y M1).
-    set (AEC := Abelian_isAbelianEpiCokernels A x y E1).
-    cbn in *. unfold ishinh_UU in *.
+    set (AMK := Abelian_AMKD A x y M1).
+    set (AEC := Abelian_AECD A x y E1).
 
-    use (squash_to_prop AMK). apply isaprop_is_iso.
-    intros X. induction X. induction p. induction p.
-    use (squash_to_prop AEC). apply isaprop_is_iso.
-    intros Y. induction Y. induction p0. induction p0.
+    induction AMK. induction t. induction t.
+    induction AEC. induction t0. induction t0.
 
-    unfold isEqualizer in p. unfold isCoequalizer in p0.
+    unfold isEqualizer in p. unfold isCoequalizer in p2.
 
     (* Here we construct the inverse of f *)
-    apply (pr2 E1) in t1.
+    cbn in *. apply E in p0.
     set (p' := p y (identity _)).
-    set (t'1 := maponpaths (fun h : A⟦y, t⟧ => identity _ ;; h) t1).
+    set (t'1 := maponpaths (fun h : A⟦y, t⟧ => identity _ ;; h) p0).
     cbn in t'1.
     set (p'' := p' t'1).
-    induction p''. induction t5.
+    induction p''. induction t1.
 
     use is_iso_qinv.
 
     (* The inverse of f. *)
-    exact t5.
+    exact t1.
 
     (* It remains to show that this is the inverse of f *)
     split.
-    apply (pr2 M1). cbn. rewrite <- assoc. rewrite p2.
+    apply (pr2 M1). cbn. rewrite <- assoc. rewrite p6.
     rewrite (remove_id_right A _ _ _ (identity x ;; f)).
     apply idpath. apply idpath. apply pathsinv0.
     apply id_left.
 
-    apply p2.
+    apply p6.
   Defined.
 
   (** Construction of the iso. *)
@@ -212,35 +239,349 @@ End abelian_monic_epi_iso.
 
 
 (** In the following section we prove that an abelian category has pullbacks of
-    subobjects. *)
+    subobjects and pushouts of quotient objects. *)
 Section abelian_subobject_pullbacks.
 
   Variable A : Abelian.
   Hypothesis hs : has_homsets A.
 
-  Lemma Abelian_subobjects_isPullback {x y z: A}
+  Definition Abelian_subobjects_Pullback {x y z: A}
         (M1 : Monic A x z) (M2 : Monic A y z) :
-    ∃ (a : A) (p1 : a --> x) (p2 : a --> y) (H : p1 ;; M1 = p2 ;; M2),
-      isPullback M1 M2 p1 p2 H.
+    Pullback M1 M2.
   Proof.
+    (* Some variables we are going to use. *)
     set (ker1 := Abelian_monic_kernel A M1).
     set (ker2 := Abelian_monic_kernel A M2).
-    (* These kernels are constructed in Abelian_monic_kernel in a way that M1
-       and M2 are the kernel arrows. But the construction of the kernels is
-       forgotten when I apply these. I need coq to remember this construction.
-       How do I do it? *)
-    unfold Abelian_monic_kernel in ker1. (* Here M1 is shown in the
-                                            construction *)
-    apply ker1. (* Here the reference to M1 is lost. *)
-  Abort.
+    set (BinProd := Abelian_BinProducts
+                      A
+                      (AMKD_Ob (Abelian_AMKD A) x z M1)
+                      (AMKD_Ob (Abelian_AMKD A) y z M2)).
+    set (ar := BinProductArrow
+                 A BinProd
+                 (AMKD_Mor (Abelian_AMKD A) x z M1)
+                 (AMKD_Mor (Abelian_AMKD A) y z M2)).
+    set (ker := Abelian_Kernels A _ _ ar).
 
-  Lemma Abelian_quotobject_pushout {x y z: A}
+
+    (* Equalities of morphisms we are going to need. *)
+    assert (H1 : KernelArrow (Abelian_Zero A) ker
+                             ;; (AMKD_Mor (Abelian_AMKD A) x z M1)
+                 = ZeroArrow _ (Abelian_Zero A) _ _).
+    rewrite <- (BinProductPr1Commutes A _ _ BinProd _
+                                     (AMKD_Mor (Abelian_AMKD A) x z M1)
+                                     (AMKD_Mor (Abelian_AMKD A) y z M2)).
+    rewrite assoc. fold ar. rewrite (KernelCompZero (Abelian_Zero A) ker).
+    apply ZeroArrow_comp_left.
+
+    assert (H2 : KernelArrow (Abelian_Zero A) ker
+                             ;; (AMKD_Mor (Abelian_AMKD A) y z M2)
+                 = ZeroArrow _ (Abelian_Zero A) _ _).
+    rewrite <- (BinProductPr2Commutes A _ _ BinProd _
+                                     (AMKD_Mor (Abelian_AMKD A) x z M1)
+                                     (AMKD_Mor (Abelian_AMKD A) y z M2)).
+    rewrite assoc. fold ar. rewrite (KernelCompZero (Abelian_Zero A) ker).
+    apply ZeroArrow_comp_left.
+
+    assert (com1 : KernelIn (Abelian_Zero A) ker1 ker
+                            (KernelArrow (Abelian_Zero A) ker) H1 ;; M1
+                   = KernelArrow (Abelian_Zero A) ker).
+    apply (KernelCommutes (Abelian_Zero A) ker1 _
+                          (KernelArrow (Abelian_Zero A) ker)).
+
+    assert (com2 : KernelIn (Abelian_Zero A) ker2 ker
+                            (KernelArrow (Abelian_Zero A) ker) H2 ;; M2
+                   = KernelArrow (Abelian_Zero A) ker).
+    apply (KernelCommutes (Abelian_Zero A) ker2 _
+                          (KernelArrow (Abelian_Zero A) ker)).
+
+    use mk_Pullback.
+
+    (* Pullback object *)
+    apply ker.
+
+    (* The arrow pr1 *)
+    use (KernelIn (Abelian_Zero A) ker1 ker (KernelArrow (Abelian_Zero A) ker)).
+    apply H1.
+
+    (* The arrow pr2 *)
+    use (KernelIn (Abelian_Zero A) ker2 ker (KernelArrow (Abelian_Zero A) ker)).
+    apply H2.
+
+    (* Commutativity of the arrows pr1 and pr2 *)
+    rewrite (KernelCommutes (Abelian_Zero A) ker1 _
+                            (KernelArrow (Abelian_Zero A) ker)).
+    rewrite (KernelCommutes (Abelian_Zero A) ker2 _
+                            (KernelArrow (Abelian_Zero A) ker)).
+    apply idpath.
+
+    (* isPullback. *)
+    use mk_isPullback.
+    intros e h k H.
+
+    (* First we show that h ;; M1 ;; ar = ZeroArrow by uniqueness of the
+       morphism to product. *)
+    assert (e1 : h ;; (KernelArrow (Abelian_Zero A) ker1) ;;
+                   (AMKD_Mor (Abelian_AMKD A) x z M1)
+                 = ZeroArrow _ (Abelian_Zero A) _ _).
+    rewrite <- assoc.
+    set (ee1 := KernelCompZero (Abelian_Zero A) ker1). cbn in ee1. cbn.
+    rewrite ee1.
+    apply ZeroArrow_comp_right.
+
+    assert (e2 : k ;; (KernelArrow (Abelian_Zero A) ker2) ;;
+                   (AMKD_Mor (Abelian_AMKD A) y z M2)
+                 = ZeroArrow _ (Abelian_Zero A) _ _).
+    rewrite <- assoc.
+    set (ee2 := KernelCompZero (Abelian_Zero A) ker2). cbn in ee2. cbn.
+    rewrite ee2.
+    apply ZeroArrow_comp_right.
+
+    cbn in e1, e2.
+
+    assert (e'1 : h ;; M1 ;; (AMKD_Mor (Abelian_AMKD A) y z M2)
+                  = ZeroArrow _ (Abelian_Zero A) _ _).
+    rewrite H. apply e2.
+
+    assert (e'2 : k ;; M2 ;; (AMKD_Mor (Abelian_AMKD A) x z M1)
+                  = ZeroArrow _ (Abelian_Zero A) _ _).
+    rewrite <- H. apply e1.
+
+    assert (e''1 : h ;; M1 ;; ar = ZeroArrow A (Abelian_Zero A) _ _).
+    rewrite (BinProductArrowEta A _ _ BinProd e (h ;; M1 ;; ar)).
+    use BinProductArrowZero. rewrite <- assoc.
+    set (tmp1 := BinProductPr1Commutes A _ _ BinProd _
+                                       (AMKD_Mor (Abelian_AMKD A) x z M1)
+                                       (AMKD_Mor (Abelian_AMKD A) y z M2)).
+    fold ar in tmp1. rewrite tmp1.
+    apply e1.
+
+    rewrite <- assoc.
+    set (tmp1 := BinProductPr2Commutes A _ _ BinProd _
+                                       (AMKD_Mor (Abelian_AMKD A) x z M1)
+                                       (AMKD_Mor (Abelian_AMKD A) y z M2)).
+    fold ar in tmp1. rewrite tmp1. apply e'1.
+
+    assert (e''2 : k ;; M2 ;; ar = ZeroArrow A (Abelian_Zero A) _ _).
+    rewrite (BinProductArrowEta A _ _ BinProd e (k ;; M2 ;; ar)).
+    use BinProductArrowZero. rewrite <- assoc.
+    set (tmp1 := BinProductPr1Commutes A _ _ BinProd _
+                                       (AMKD_Mor (Abelian_AMKD A) x z M1)
+                                       (AMKD_Mor (Abelian_AMKD A) y z M2)).
+    fold ar in tmp1. rewrite tmp1.
+    apply e'2.
+
+    rewrite <- assoc.
+    set (tmp1 := BinProductPr2Commutes A _ _ BinProd _
+                                       (AMKD_Mor (Abelian_AMKD A) x z M1)
+                                       (AMKD_Mor (Abelian_AMKD A) y z M2)).
+    fold ar in tmp1. rewrite tmp1. apply e2.
+
+    use unique_exists.
+    use (KernelIn (Abelian_Zero A) ker e (h ;; M1)).
+    apply e''1.
+    split.
+
+    use (KernelInsEq (Abelian_Zero A) ker1).
+    cbn. rewrite <- assoc.
+    set (com'1 := (maponpaths (fun f : _ => KernelIn (Abelian_Zero A)
+                                                  ker e (h ;; M1) e''1 ;; f)
+                              com1)). cbn in com'1.
+    use (pathscomp0 com'1).
+    use KernelCommutes.
+
+    use (KernelInsEq (Abelian_Zero A) ker2).
+    cbn. rewrite <- assoc.
+    set (com'2 := (maponpaths (fun f : _ => KernelIn (Abelian_Zero A)
+                                                  ker e (h ;; M1) e''1 ;; f)
+                              com2)). cbn in com'2.
+    use (pathscomp0 com'2). rewrite <- H.
+    use KernelCommutes.
+
+    (* Equality on equalities of morphisms *)
+    intros y0. apply isapropdirprod. apply hs. apply hs.
+
+    (* Uniqueness *)
+    intros y0 t. cbn in t. induction t.
+    apply (KernelArrowisMonic (Abelian_Zero A) ker).
+    rewrite (KernelCommutes (Abelian_Zero A) ker).
+    rewrite <- (KernelCommutes (Abelian_Zero A) ker1 ker
+                              (KernelArrow (Abelian_Zero A) ker) H1).
+    rewrite assoc.
+    use (pathscomp0 (maponpaths (fun f : _ => f ;; KernelArrow (Abelian_Zero A)
+                                             ker1) t)).
+    apply idpath.
+  Defined.
+
+  Definition Abelian_quotobject_pushout {x y z: A}
         (E1 : Epi A x y) (E2 : Epi A x z) :
-    ∃ (a : A) (i1 : y --> a) (i2 : z --> a) (H : E1 ;; i1 = E2 ;; i2),
-      isPushout E1 E2 i1 i2 H.
+    Pushout E1 E2.
   Proof.
-    (* TODO *)
-  Abort.
+    (* Some variables we are going to use. *)
+    set (coker1 := Abelian_epi_cokernel A E1).
+    set (coker2 := Abelian_epi_cokernel A E2).
+    set (BinCoprod := Abelian_BinCoproducts
+                        A
+                        (AECD_Ob (Abelian_AECD A) x y E1)
+                        (AECD_Ob (Abelian_AECD A) x z E2)).
+    set (ar := BinCoproductArrow
+                 A BinCoprod
+                 (AECD_Mor (Abelian_AECD A) x y E1)
+                 (AECD_Mor (Abelian_AECD A) x z E2)).
+    set (coker := Abelian_Cokernels A _ _ ar).
+
+
+    (* Equalities of morphisms we are going to need. *)
+    assert (H1 : (AECD_Mor (Abelian_AECD A) x y E1)
+                   ;; CokernelArrow (Abelian_Zero A) coker
+                 = ZeroArrow _ (Abelian_Zero A) _ _).
+    rewrite <- (BinCoproductIn1Commutes A _ _ BinCoprod _
+                                       (AECD_Mor (Abelian_AECD A) x y E1)
+                                       (AECD_Mor (Abelian_AECD A) x z E2)).
+    rewrite <- assoc. fold ar.
+    rewrite (CokernelCompZero (Abelian_Zero A) coker).
+    apply ZeroArrow_comp_right.
+
+    assert (H2 : (AECD_Mor (Abelian_AECD A) x z E2)
+                   ;; CokernelArrow (Abelian_Zero A) coker
+                 = ZeroArrow _ (Abelian_Zero A) _ _).
+    rewrite <- (BinCoproductIn2Commutes A _ _ BinCoprod _
+                                       (AECD_Mor (Abelian_AECD A) x y E1)
+                                       (AECD_Mor (Abelian_AECD A) x z E2)).
+    rewrite <- assoc. fold ar.
+    rewrite (CokernelCompZero (Abelian_Zero A) coker).
+    apply ZeroArrow_comp_right.
+
+    assert (com1 : E1 ;; CokernelOut (Abelian_Zero A) coker1 coker
+                      (CokernelArrow (Abelian_Zero A) coker) H1
+                   = CokernelArrow (Abelian_Zero A) coker).
+    apply (CokernelCommutes (Abelian_Zero A) coker1 _
+                            (CokernelArrow (Abelian_Zero A) coker)).
+
+    assert (com2 : E2 ;; CokernelOut (Abelian_Zero A) coker2 coker
+                      (CokernelArrow (Abelian_Zero A) coker) H2
+                   = CokernelArrow (Abelian_Zero A) coker).
+    apply (CokernelCommutes (Abelian_Zero A) coker2 _
+                            (CokernelArrow (Abelian_Zero A) coker)).
+
+    use mk_Pushout.
+
+    (* Pushout object *)
+    apply coker.
+
+    (* The arrow pr1 *)
+    use (CokernelOut (Abelian_Zero A) coker1 coker
+                     (CokernelArrow (Abelian_Zero A) coker)).
+    apply H1.
+
+    (* The arrow pr2 *)
+    use (CokernelOut (Abelian_Zero A) coker2 coker
+                     (CokernelArrow (Abelian_Zero A) coker)).
+    apply H2.
+
+    (* Commutativity of the arrows pr1 and pr2 *)
+    rewrite (CokernelCommutes (Abelian_Zero A) coker1 _
+                              (CokernelArrow (Abelian_Zero A) coker)).
+    rewrite (CokernelCommutes (Abelian_Zero A) coker2 _
+                              (CokernelArrow (Abelian_Zero A) coker)).
+    apply idpath.
+
+    (* isPushout. *)
+    use mk_isPushout.
+    intros e h k H.
+
+    (* First we show that h ;; M1 ;; ar = ZeroArrow by uniqueness of the
+       morphism to product. *)
+    assert (e1 : (AECD_Mor (Abelian_AECD A) x y E1)
+                   ;; (CokernelArrow (Abelian_Zero A) coker1) ;; h
+                 = ZeroArrow _ (Abelian_Zero A) _ _).
+    set (ee1 := CokernelCompZero (Abelian_Zero A) coker1). cbn in ee1. cbn.
+    rewrite ee1.
+    apply ZeroArrow_comp_left.
+
+    assert (e2 : (AECD_Mor (Abelian_AECD A) x z E2)
+                   ;; (CokernelArrow (Abelian_Zero A) coker2) ;; k
+                 = ZeroArrow _ (Abelian_Zero A) _ _).
+    set (ee2 := CokernelCompZero (Abelian_Zero A) coker2). cbn in ee2. cbn.
+    rewrite ee2.
+    apply ZeroArrow_comp_left.
+
+    cbn in e1, e2.
+
+    assert (e'1 : (AECD_Mor (Abelian_AECD A) x z E2) ;; E1 ;; h =
+                  ZeroArrow _ (Abelian_Zero A) _ _).
+    rewrite <- assoc. rewrite H. rewrite assoc. apply e2.
+
+    assert (e'2 : (AECD_Mor (Abelian_AECD A) x y E1) ;; E2 ;; k
+                  = ZeroArrow _ (Abelian_Zero A) _ _).
+    rewrite <- assoc. rewrite <- H. rewrite assoc. apply e1.
+
+    assert (e''1 : ar ;; (E1 ;; h) = ZeroArrow A (Abelian_Zero A) _ _).
+    rewrite assoc.
+    rewrite (BinCoproductArrowEta A _ _ BinCoprod e (ar ;; E1 ;; h)).
+    use BinCoproductArrowZero. rewrite assoc. rewrite assoc.
+    set (tmp1 := BinCoproductIn1Commutes A _ _ BinCoprod _
+                                         (AECD_Mor (Abelian_AECD A) x y E1)
+                                         (AECD_Mor (Abelian_AECD A) x z E2)).
+    fold ar in tmp1. rewrite tmp1.
+    apply e1.
+
+    rewrite assoc. rewrite assoc.
+    set (tmp1 := BinCoproductIn2Commutes A _ _ BinCoprod _
+                                         (AECD_Mor (Abelian_AECD A) x y E1)
+                                         (AECD_Mor (Abelian_AECD A) x z E2)).
+    fold ar in tmp1. rewrite tmp1. apply e'1.
+
+    assert (e''2 : ar ;; (E2 ;; k) = ZeroArrow A (Abelian_Zero A) _ _).
+    rewrite assoc.
+    rewrite (BinCoproductArrowEta A _ _ BinCoprod e (ar ;; E2 ;; k)).
+    use BinCoproductArrowZero. rewrite assoc. rewrite assoc.
+    set (tmp1 := BinCoproductIn1Commutes A _ _ BinCoprod _
+                                       (AECD_Mor (Abelian_AECD A) x y E1)
+                                       (AECD_Mor (Abelian_AECD A) x z E2)).
+    fold ar in tmp1. rewrite tmp1.
+    apply e'2.
+
+    rewrite assoc. rewrite assoc.
+    set (tmp1 := BinCoproductIn2Commutes A _ _ BinCoprod _
+                                         (AECD_Mor (Abelian_AECD A) x y E1)
+                                         (AECD_Mor (Abelian_AECD A) x z E2)).
+    fold ar in tmp1. rewrite tmp1. apply e2.
+
+    use unique_exists.
+    use (CokernelOut (Abelian_Zero A) coker e (E1 ;; h)).
+    apply e''1.
+    split.
+
+    use (CokernelOutsEq (Abelian_Zero A) coker1). cbn.
+    set (com'1 := (maponpaths (fun f : _ => f ;; CokernelOut (Abelian_Zero A)
+                                           coker e (E1 ;; h) e''1)
+                              com1)). cbn in com'1.
+    rewrite assoc.
+    use (pathscomp0 com'1).
+    use CokernelCommutes.
+
+    use (CokernelOutsEq (Abelian_Zero A) coker2). cbn.
+    set (com'2 := (maponpaths (fun f : _ => f ;; CokernelOut (Abelian_Zero A)
+                                           coker e (E1 ;; h) e''1)
+                              com2)). cbn in com'2.
+    rewrite assoc.
+    use (pathscomp0 com'2). rewrite <- H.
+    use CokernelCommutes.
+
+    (* Equality on equalities of morphisms *)
+    intros y0. apply isapropdirprod. apply hs. apply hs.
+
+    (* Uniqueness *)
+    intros y0 t. cbn in t. induction t.
+    apply (CokernelArrowisEpi (Abelian_Zero A) coker).
+    rewrite (CokernelCommutes (Abelian_Zero A) coker).
+    rewrite <- (CokernelCommutes (Abelian_Zero A) coker1 coker
+                                (CokernelArrow (Abelian_Zero A) coker) H1).
+    rewrite <- assoc.
+    use (pathscomp0 (maponpaths (fun f : _ => CokernelArrow (Abelian_Zero A)
+                                                         coker1 ;; f) t)).
+    apply idpath.
+  Defined.
 
 End abelian_subobject_pullbacks.
 
@@ -251,34 +592,220 @@ Section abelian_equalizers.
   Variable A : Abelian.
   Hypothesis hs : has_homsets A.
 
-  Lemma Abelian_equalizers {x y : A} (f1 f2 : x --> y) :
+  Lemma Abelian_Equalizers {x y : A} (f1 f2 : x --> y) :
     Equalizer f1 f2.
   Proof.
-    (* TODO *) (* Needs pullbacks *)
-  Abort.
+    set (BinProd := Abelian_BinProducts A x y).
+    set (ar1 := BinProductArrow A BinProd (identity x) f1).
+    set (ar2 := BinProductArrow A BinProd (identity x) f2).
 
-  Lemma Abelian_coequalizer {x y : A} (f1 f2 : x --> y) :
+    assert (isM1 : isMonic A ar1).
+    {
+      intros z h1 h2 H.
+      apply (maponpaths (fun f : _ => f ;; (BinProductPr1 A BinProd))) in H.
+      rewrite <- assoc in H. rewrite <- assoc in H.
+      set (com1 := BinProductPr1Commutes A _ _ BinProd x (identity x) f1).
+      fold ar1 in com1. rewrite com1 in H.
+      rewrite (id_right A _ _ h1) in H. rewrite (id_right A _ _ h2) in H.
+      exact H.
+    }
+
+    assert (isM2 : isMonic A ar2).
+    {
+      intros z h1 h2 H.
+      apply (maponpaths (fun f : _ => f ;; (BinProductPr1 A BinProd))) in H.
+      rewrite <- assoc in H. rewrite <- assoc in H.
+      set (com1 := BinProductPr1Commutes A _ _ BinProd x (identity x) f2).
+      fold ar2 in com1. rewrite com1 in H.
+      rewrite (id_right A _ _ h1) in H. rewrite (id_right A _ _ h2) in H.
+      exact H.
+    }
+
+    set (M1 := mk_Monic A ar1 isM1).
+    set (M2 := mk_Monic A ar2 isM2).
+
+    set (Pb := Abelian_subobjects_Pullback A hs M1 M2).
+
+    assert (H : PullbackPr1 Pb = PullbackPr2 Pb).
+    {
+      assert (H1 : ar1 ;; (BinProductPr1 A BinProd) = identity x) by
+          apply BinProductPr1Commutes.
+      assert (H2 : ar2 ;; (BinProductPr1 A BinProd) = identity x) by
+          apply BinProductPr1Commutes.
+      rewrite <- (id_right A _ _ (PullbackPr1 Pb)). rewrite <- H1.
+      rewrite <- (id_right A _ _ (PullbackPr2 Pb)). rewrite <- H2.
+      rewrite assoc. rewrite assoc. apply cancel_postcomposition.
+      apply PullbackSqrCommutes.
+    }
+
+    assert (H1 : BinProductArrow A BinProd (identity x) f1 ;;
+                                 (BinProductPr2 A BinProd) = f1) by
+        apply BinProductPr2Commutes.
+
+    assert (H2 : BinProductArrow A BinProd (identity x) f2 ;;
+                                 (BinProductPr2 A BinProd) = f2) by
+        apply BinProductPr2Commutes.
+
+    use mk_Equalizer.
+    apply Pb.
+    apply (PullbackPr1 Pb).
+    rewrite <- H1. rewrite <- H2. rewrite assoc. rewrite assoc.
+    apply cancel_postcomposition.
+    set (XX := PullbackSqrCommutes Pb). rewrite <- H in XX.
+    unfold M1 in XX. unfold M2 in XX. apply XX.
+
+    (* isEqualizer *)
+    apply mk_isEqualizer.
+    intros w h HH.
+
+    assert (HH' : h ;; ar1 = BinProductArrow A BinProd h (h ;; f1)).
+    {
+      apply (BinProductArrowUnique A _ _ BinProd).
+      rewrite <- assoc.
+      set (com1 := BinProductPr1Commutes A _ _ BinProd x (identity x) f1).
+      fold ar1 in com1. rewrite com1. apply id_right.
+
+      rewrite <- assoc.
+      set (com2 := BinProductPr2Commutes A _ _ BinProd x (identity x) f1).
+      fold ar1 in com2. rewrite com2. apply idpath.
+    }
+
+    assert (HH'' : h ;; ar2 = BinProductArrow A BinProd h (h ;; f1)).
+    {
+      apply (BinProductArrowUnique A _ _ BinProd).
+      rewrite <- assoc.
+      set (com1 := BinProductPr1Commutes A _ _ BinProd x (identity x) f2).
+      fold ar2 in com1. rewrite com1. apply id_right.
+
+      rewrite <- assoc.
+      set (com2 := BinProductPr2Commutes A _ _ BinProd x (identity x) f2).
+      fold ar2 in com2. rewrite com2. apply pathsinv0. apply HH.
+    }
+
+    assert (HH''' : h ;; ar1 = h ;; ar2).
+    {
+      rewrite HH'. rewrite HH''. apply idpath.
+    }
+
+    set (Pbar := PullbackArrow Pb w h h HH''').
+
+    apply (unique_exists Pbar).
+    apply (PullbackArrow_PullbackPr1 Pb w h h HH''').
+    intros y0. apply hs.
+    intros y0 t.
+
+    apply PullbackArrowUnique.
+    apply t. rewrite <- H. apply t.
+  Defined.
+
+  Lemma Abelian_Coequalizers {x y : A} (f1 f2 : y --> x) :
     Coequalizer f1 f2.
   Proof.
-    (* TODO *) (* Needs pushouts *)
-  Abort.
+    set (BinCoprod := Abelian_BinCoproducts A x y).
+    set (ar1 := BinCoproductArrow A BinCoprod (identity x) f1).
+    set (ar2 := BinCoproductArrow A BinCoprod (identity x) f2).
+
+    assert (isE1 : isEpi A ar1).
+    {
+      intros z h1 h2 H.
+      apply (maponpaths (fun f : _ => (BinCoproductIn1 A BinCoprod) ;; f)) in H.
+      rewrite assoc in H. rewrite assoc in H.
+      set (com1 := BinCoproductIn1Commutes A _ _ BinCoprod x (identity x) f1).
+      fold ar1 in com1. rewrite com1 in H.
+      rewrite (id_left A _ _ h1) in H. rewrite (id_left A _ _ h2) in H.
+      exact H.
+    }
+
+    assert (isE2 : isEpi A ar2).
+    {
+      intros z h1 h2 H.
+      apply (maponpaths (fun f : _ => (BinCoproductIn1 A BinCoprod) ;; f)) in H.
+      rewrite assoc in H. rewrite assoc in H.
+      set (com1 := BinCoproductIn1Commutes A _ _ BinCoprod x (identity x) f2).
+      fold ar2 in com1. rewrite com1 in H.
+      rewrite (id_left A _ _ h1) in H. rewrite (id_left A _ _ h2) in H.
+      exact H.
+    }
+
+    set (E1 := mk_Epi A ar1 isE1).
+    set (E2 := mk_Epi A ar2 isE2).
+
+    set (Po := Abelian_quotobject_pushout A hs E1 E2).
+
+    assert (H : PushoutIn1 Po = PushoutIn2 Po).
+    {
+      assert (H1 : (BinCoproductIn1 A BinCoprod) ;; ar1 = identity x) by
+          apply BinCoproductIn1Commutes.
+      assert (H2 : (BinCoproductIn1 A BinCoprod) ;; ar2 = identity x) by
+          apply BinCoproductIn1Commutes.
+      rewrite <- (id_left A _ _ (PushoutIn1 Po)). rewrite <- H1.
+      rewrite <- (id_left A _ _ (PushoutIn2 Po)). rewrite <- H2.
+      rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
+      apply PushoutSqrCommutes.
+    }
+
+    assert (H1 : (BinCoproductIn2 A BinCoprod)
+                   ;; BinCoproductArrow A BinCoprod (identity x) f1 = f1) by
+        apply BinCoproductIn2Commutes.
+
+    assert (H2 : (BinCoproductIn2 A BinCoprod)
+                   ;; BinCoproductArrow A BinCoprod (identity x) f2 = f2) by
+        apply BinCoproductIn2Commutes.
+
+    use mk_Coequalizer.
+    apply Po.
+    apply (PushoutIn1 Po).
+    rewrite <- H1. rewrite <- H2.
+    rewrite <- assoc. rewrite <- assoc.
+    apply cancel_precomposition.
+    set (XX := PushoutSqrCommutes Po). rewrite <- H in XX.
+    unfold E1 in XX. unfold E2 in XX. apply XX.
+
+    (* isCoequalizer *)
+    apply mk_isCoequalizer.
+    intros w h HH.
+
+    assert (HH' : ar1 ;; h = BinCoproductArrow A BinCoprod h (f1 ;; h)).
+    {
+      apply (BinCoproductArrowUnique A _ _ BinCoprod).
+      rewrite assoc.
+      set (com1 := BinCoproductIn1Commutes A _ _ BinCoprod x (identity x) f1).
+      fold ar1 in com1. rewrite com1. apply id_left.
+
+      rewrite assoc.
+      set (com2 := BinCoproductIn2Commutes A _ _ BinCoprod x (identity x) f1).
+      fold ar1 in com2. rewrite com2. apply idpath.
+    }
+
+    assert (HH'' : ar2 ;; h = BinCoproductArrow A BinCoprod h (f1 ;; h)).
+    {
+      apply (BinCoproductArrowUnique A _ _ BinCoprod).
+      rewrite assoc.
+      set (com1 := BinCoproductIn1Commutes A _ _ BinCoprod x (identity x) f2).
+      fold ar2 in com1. rewrite com1. apply id_left.
+
+      rewrite assoc.
+      set (com2 := BinCoproductIn2Commutes A _ _ BinCoprod x (identity x) f2).
+      fold ar2 in com2. rewrite com2. apply pathsinv0. apply HH.
+    }
+
+    assert (HH''' : ar1 ;; h = ar2 ;; h).
+    {
+      rewrite HH'. rewrite HH''. apply idpath.
+    }
+
+    set (Poar := PushoutArrow Po w h h HH''').
+
+    apply (unique_exists Poar).
+    apply (PushoutArrow_PushoutIn1 Po w h h HH''').
+    intros y0. apply hs.
+    intros y0 t.
+
+    apply PushoutArrowUnique.
+    apply t. rewrite <- H. apply t.
+  Defined.
 
 End abelian_equalizers.
-
-(** In this section we prove that every morphism factors as epi ;; monic *)
-Section abelian_factorization.
-
-  Variable A : Abelian.
-  Hypothesis hs : has_homsets A.
-
-  (* TODO: Needs some results on pullbacks, equalizers, and strong
-     epimorphisms. *)
-  Lemma Abelian_factorization {x y z : A} (f : x --> y) :
-    ∃ (E : Epi A x z) (M : Monic A z y), f = E ;; M.
-  Proof.
-    (* TODO *)
-  Abort.
-End abelian_factorization.
 
 (** In this section we prove that kernels of monomorphisms are given by the
   arrows from zero and cokernels of epimorphisms are given by the arrows to
@@ -313,7 +840,6 @@ Section abelian_monic_kernels.
     intros y0 Y. cbn in Y. apply ArrowsToZero.
   Defined.
 
-
   (* A cokernel of an epi is the arrow to zero. *)
   Definition Abelian_EpiCokernelZero {y z : A} (E : Epi A y z) :
     Cokernel (Abelian_Zero A) E.
@@ -340,6 +866,385 @@ Section abelian_monic_kernels.
   Defined.
 End abelian_monic_kernels.
 
+(** In this section we prove that every morphism factors as epi ;; monic in 2
+  canonical ways. To do this we need to prove that the canonical morphism
+  CoIm f --> Im f is an isomorphism. *)
+Section abelian_factorization.
+
+  Variable A : Abelian.
+  Hypothesis hs : has_homsets A.
+
+  (** Definition of coimage and image in abelian categories. *)
+  Definition Abelian_Kernel {x y : A} (f : x --> y) :
+    Kernel (Abelian_Zero A) f := Abelian_Kernels A x y f.
+  Definition Abelian_Cokernel {x y : A} (f : x --> y) :
+    Cokernel (Abelian_Zero A) f := Abelian_Cokernels A x y f.
+  Definition Abelian_CoIm {x y : A} (f : x --> y) :
+    Cokernel (Abelian_Zero A)
+             (KernelArrow (Abelian_Zero A) (Abelian_Kernel f))
+    := Abelian_Cokernels A _ _ (KernelArrow _ (Abelian_Kernel f)).
+  Definition Abelian_Im {x y : A} (f : x --> y) :
+    Kernel (Abelian_Zero A)
+           (CokernelArrow (Abelian_Zero A) (Abelian_Cokernel f))
+    := Abelian_Kernels A _ _ (CokernelArrow _ (Abelian_Cokernel f)).
+
+  (** An equation we are going to use. *)
+  Definition Abelian_CoIm_ar_eq {x y : A} (f : x --> y) :
+    KernelArrow _ (Abelian_Kernel f) ;; f
+    = ZeroArrow _ (Abelian_Zero A)  _ _.
+  Proof.
+    apply KernelCompZero.
+  Qed.
+
+  (** An arrow we are going to need. *)
+  Definition Abelian_CoIm_ar {x y : A} (f : x --> y) : A⟦Abelian_CoIm f, y⟧.
+  Proof.
+    apply (CokernelOut (Abelian_Zero A) (Abelian_CoIm f) y f
+                       (Abelian_CoIm_ar_eq f)).
+  Defined.
+
+  (** Some equations we are going to need. *)
+  Definition Abelian_CoIm_to_Im_eq1 {x y : A} (f : x --> y) :
+    CokernelArrow _ (Abelian_CoIm f)
+                  ;; Abelian_CoIm_ar f
+                  ;; CokernelArrow _ (Abelian_Cokernel f)
+    = ZeroArrow _ (Abelian_Zero A) _ _.
+  Proof.
+    set (tmp := CokernelCommutes (Abelian_Zero A)
+                                 (Abelian_CoIm f) y f (Abelian_CoIm_ar_eq f)).
+    fold (Abelian_CoIm_ar f) in tmp. rewrite tmp.
+    apply CokernelCompZero.
+  Qed.
+
+  Definition Abelian_CoIm_to_Im_eq2 {x y : A} (f : x --> y) :
+    Abelian_CoIm_ar f ;; CokernelArrow _ (Abelian_Cokernel f)
+    = ZeroArrow _ (Abelian_Zero A) _ _.
+  Proof.
+    set (isE := CokernelArrowisEpi (Abelian_Zero A) (Abelian_CoIm f)).
+    set (e1 := Abelian_CoIm_to_Im_eq1 f).
+    rewrite <- assoc in e1.
+    rewrite <- (ZeroArrow_comp_right A (Abelian_Zero A) _ _ _
+                                    (CokernelArrow (Abelian_Zero A)
+                                                   (Abelian_CoIm f)))
+      in e1.
+    apply isE in e1. exact e1.
+  Qed.
+
+  (** In this definition we construct the canonical morphism from the coimage
+    of f to the image of f. *)
+  Definition Abelian_CoIm_to_Im {x y : A} (f : x --> y) :
+    A⟦Abelian_CoIm f, Abelian_Im f⟧.
+  Proof.
+    exact (KernelIn  (Abelian_Zero A) (Abelian_Im f) (Abelian_CoIm f)
+                     (Abelian_CoIm_ar f) (Abelian_CoIm_to_Im_eq2 f)).
+  Defined.
+
+  (** The above morphism gives a way to factorize the morphism f as a composite
+    of three morphisms. *)
+  Definition Abelian_CoIm_to_Im_eq {x y : A} (f : x --> y) :
+    f = (CokernelArrow _ (Abelian_CoIm f))
+          ;; (Abelian_CoIm_to_Im f)
+          ;; (KernelArrow _ (Abelian_Im f)).
+  Proof.
+    unfold Abelian_CoIm_to_Im.
+    set (com0 := CokernelCommutes (Abelian_Zero A) (Abelian_CoIm f) y f
+                                  (Abelian_CoIm_ar_eq f)).
+    apply pathsinv0 in com0.
+    use (pathscomp0 com0).
+    rewrite <- assoc. apply cancel_precomposition.
+
+    set (com1 := KernelCommutes (Abelian_Zero A) (Abelian_Im f)
+                                (Abelian_CoIm f) (Abelian_CoIm_ar f)
+                                (Abelian_CoIm_to_Im_eq2 f)).
+    apply pathsinv0 in com1.
+    use (pathscomp0 com1).
+    apply idpath.
+  Qed.
+
+  (** Here we show that the canonical morphism CoIm f --> Im f is an
+    isomorphism. *)
+  Lemma Abelian_CoIm_to_Im_is_iso {x y : A} (f : x --> y) :
+    is_iso (Abelian_CoIm_to_Im f).
+  Proof.
+    (* It suffices to show that this morphism is monic and epi. *)
+    use Abelian_monic_epi_is_iso.
+
+    (* isMonic *)
+    use (isMonic_postcomp A _ (KernelArrow _ (Abelian_Im f))).
+    intros z g1 g2 H.
+    set (q := Abelian_Coequalizers A hs g1 g2).
+    set (ar := Abelian_CoIm_to_Im f ;; KernelArrow
+                                  (Abelian_Zero A) (Abelian_Im f)).
+    set (ar1 := CoequalizerOut q _ ar).
+    set (com1 := CoequalizerCommutes q _ _ H).
+    assert (isE : isEpi A ((CokernelArrow _ (Abelian_CoIm f))
+                             ;; (CoequalizerArrow q))).
+    {
+      apply isEpi_comp.
+      apply CokernelArrowisEpi.
+      apply CoequalizerArrowisEpi.
+    }
+
+    set (E := mk_Epi A ((CokernelArrow _ (Abelian_CoIm f))
+                          ;; (CoequalizerArrow q)) isE).
+    set (coker := Abelian_epi_cokernel A E).
+
+    assert (e0 : (AECD_Mor (Abelian_AECD A) _ _ E)
+                   ;; ((CokernelArrow _ (Abelian_CoIm f))
+                         ;; (CoequalizerArrow q))
+                 = ZeroArrow _ (Abelian_Zero A) _ (Abelian_epi_cokernel A E)).
+    {
+      set (tmp := CokernelCompZero (Abelian_Zero A) (Abelian_epi_cokernel A E)).
+      rewrite <- tmp.
+      apply cancel_precomposition.
+      unfold E. apply idpath.
+    }
+
+    assert (e : (AECD_Mor (Abelian_AECD A) _ _ E) ;; f
+                = ZeroArrow _ (Abelian_Zero A) _ _).
+    {
+      set (tmp := Abelian_CoIm_to_Im_eq f).
+      apply (maponpaths (fun f : _ => AECD_Mor (Abelian_AECD A) x q E ;; f))
+        in tmp.
+      use (pathscomp0 tmp).
+      rewrite <- assoc.
+      rewrite <- com1.
+
+
+      rewrite assoc. rewrite assoc.
+      set (tmpar1 := Abelian_CoIm_to_Im f ;; KernelArrow (Abelian_Zero A)
+                                        (Abelian_Im f)).
+      set (tmpar2 := CoequalizerOut q y tmpar1 H).
+      rewrite <- (ZeroArrow_comp_left A (Abelian_Zero A) _ _ _ tmpar2).
+      apply cancel_postcomposition.
+      rewrite <- assoc.
+
+      rewrite e0. apply idpath.
+    }
+
+    set (l := KernelIn (Abelian_Zero A) (Abelian_Kernel f) _ _ e).
+
+    assert (e1 : (AECD_Mor (Abelian_AECD A) x q E)
+                   ;; (CokernelArrow _ (Abelian_CoIm f)) =
+                 ZeroArrow _ (Abelian_Zero A) _ _).
+    {
+      set (tmp := KernelCommutes (Abelian_Zero A) (Abelian_Kernel f) _ _ e).
+      rewrite <- tmp.
+      fold l.
+      rewrite <- (ZeroArrow_comp_right A (Abelian_Zero A) _ _ _ l).
+      rewrite <- assoc.
+      apply cancel_precomposition.
+      unfold Abelian_CoIm.
+      apply CokernelCompZero.
+    }
+
+    set (ar2 := CokernelOut (Abelian_Zero A) coker _ _ e1).
+    set (com2 := CokernelCommutes (Abelian_Zero A) coker _ _ e1).
+    assert (e2 : CokernelArrow (Abelian_Zero A) (Abelian_CoIm f)
+                               ;; (CoequalizerArrow q) ;;
+                               (CokernelOut (Abelian_Zero A) coker _ _ e1)
+                 = CokernelArrow (Abelian_Zero A) (Abelian_CoIm f)).
+    {
+      apply com2.
+    }
+
+    assert (e3 : (CoequalizerArrow q) ;; (CokernelOut (Abelian_Zero A) coker
+                                                      (Abelian_CoIm f) _ e1)
+                 = identity _).
+    {
+      set (isE1 := CokernelArrowisEpi (Abelian_Zero A) (Abelian_CoIm f)).
+      unfold isEpi in isE1.
+      apply isE1. rewrite assoc.
+      rewrite id_right.
+      apply e2.
+    }
+
+    assert (e4 : isMonic A (CoequalizerArrow q)).
+    {
+      apply (isMonic_postcomp A _ (CokernelOut (Abelian_Zero A) coker
+                                               (Abelian_CoIm f) _ e1)).
+      set (tmp := @identity_isMonic A (Abelian_CoIm f)).
+      rewrite <- e3 in tmp.
+      apply tmp.
+    }
+
+    set (coeqeq := CoequalizerEqAr q).
+    apply e4 in coeqeq.
+    apply coeqeq.
+
+    (* isEpi *)
+    use (isEpi_precomp A (CokernelArrow _ (Abelian_CoIm f)) _).
+    intros z g1 g2 H.
+    set (q := Abelian_Equalizers A hs g1 g2).
+    set (ar := CokernelArrow (Abelian_Zero A) (Abelian_CoIm f)
+                             ;; Abelian_CoIm_to_Im f).
+    set (ar1 := EqualizerIn q _ ar).
+    set (com1 := EqualizerCommutes q _ _ H).
+    assert (isE : isMonic A ((EqualizerArrow q)
+                               ;; (KernelArrow _ (Abelian_Im f)))).
+    {
+      apply isMonic_comp.
+      apply EqualizerArrowisMonic.
+      apply KernelArrowisMonic.
+    }
+
+    set (M := mk_Monic A ((EqualizerArrow q)
+                            ;; (KernelArrow _ (Abelian_Im f))) isE).
+    set (ker := Abelian_monic_kernel A M).
+
+    assert (e0 : (EqualizerArrow q) ;; (KernelArrow _ (Abelian_Im f))
+                                    ;; (AMKD_Mor (Abelian_AMKD A) _ _ M)
+                 = ZeroArrow _ (Abelian_Zero A) (Abelian_monic_kernel A M) _).
+    {
+      set (tmp := KernelCompZero (Abelian_Zero A) (Abelian_monic_kernel A M)).
+      rewrite <- tmp.
+      apply cancel_postcomposition.
+      unfold M. apply idpath.
+    }
+
+    assert (e : f ;; (AMKD_Mor (Abelian_AMKD A) _ _ M)
+                = ZeroArrow _ (Abelian_Zero A) _ _).
+    {
+      set (tmp := Abelian_CoIm_to_Im_eq f).
+      apply (maponpaths (fun f : _ => f ;; AMKD_Mor (Abelian_AMKD A) q y M))
+        in tmp.
+      use (pathscomp0 tmp).
+      rewrite <- com1.
+
+      set (tmpar1 := CokernelArrow (Abelian_Zero A) (Abelian_CoIm f)
+                                   ;; Abelian_CoIm_to_Im f).
+      set (tmpar2 := EqualizerIn q x tmpar1 H).
+      rewrite <- (ZeroArrow_comp_right A (Abelian_Zero A) _ _ _ tmpar2).
+      rewrite <- assoc. rewrite <- assoc.
+      apply cancel_precomposition.
+      rewrite assoc.
+
+      rewrite e0. apply idpath.
+    }
+
+    set (l := CokernelOut (Abelian_Zero A) (Abelian_Cokernel f) _ _ e).
+
+    assert (e1 : (KernelArrow _ (Abelian_Im f))
+                   ;; (AMKD_Mor (Abelian_AMKD A) q y M)
+                 = ZeroArrow _ (Abelian_Zero A) _ _).
+    {
+      set (tmp := CokernelCommutes (Abelian_Zero A) (Abelian_Cokernel f) _ _ e).
+      rewrite <- tmp.
+      fold l.
+      rewrite <- (ZeroArrow_comp_left A (Abelian_Zero A) _ _ _ l).
+      rewrite assoc.
+      apply cancel_postcomposition.
+      unfold Abelian_Im.
+      apply KernelCompZero.
+    }
+
+    set (ar2 := KernelIn (Abelian_Zero A) ker _ _ e1).
+    set (com2 := KernelCommutes (Abelian_Zero A) ker _ _ e1).
+    assert (e2 : (KernelIn (Abelian_Zero A) ker _ _ e1)
+                   ;; (EqualizerArrow q)
+                   ;; KernelArrow (Abelian_Zero A) (Abelian_Im f)
+                 = KernelArrow (Abelian_Zero A) (Abelian_Im f)).
+    {
+      rewrite <- com2. rewrite <- assoc.
+      apply cancel_precomposition. unfold ker.
+      apply idpath.
+    }
+
+    assert (e3 : (KernelIn (Abelian_Zero A) ker (Abelian_Im f) _ e1)
+                   ;; (EqualizerArrow q)
+                 = identity _).
+    {
+      set (isM1 := KernelArrowisMonic (Abelian_Zero A) (Abelian_Im f)).
+      unfold isMonic in isM1.
+      apply isM1.
+      rewrite id_left.
+      apply e2.
+    }
+
+    assert (e4 : isEpi A (EqualizerArrow q)).
+    {
+      apply (isEpi_precomp A (KernelIn (Abelian_Zero A) ker
+                                       (Abelian_Im f) _ e1)).
+      set (tmp := @identity_isEpi A (Abelian_Im f)).
+      rewrite <- e3 in tmp.
+      apply tmp.
+    }
+
+    set (eqeq := EqualizerEqAr q).
+    apply e4 in eqeq.
+    apply eqeq.
+  Qed.
+
+  (** Since an isomorphism is both a monic and an epi, there are two canonical
+    ways to compose f as epi ;; monic by interpreting the isomorphism as a
+    monic or an epi. We define both of these factorizations. *)
+
+  (** In the first case we interpret the isomorphism as an epi. *)
+  Definition Abelian_factorization1_is_epi {x y : A} (f : x --> y) :
+    isEpi A (CokernelArrow _ (Abelian_CoIm f) ;; Abelian_CoIm_to_Im f).
+  Proof.
+    apply isEpi_comp.
+    apply CokernelArrowisEpi.
+    apply (iso_isEpi A _ (Abelian_CoIm_to_Im_is_iso f)).
+  Qed.
+
+  Definition Abelian_factorization1_epi {x y : A} (f : x --> y) :
+    Epi A x (Abelian_Im f).
+  Proof.
+    use mk_Epi.
+    exact (CokernelArrow _ (Abelian_CoIm f) ;; Abelian_CoIm_to_Im f).
+    apply Abelian_factorization1_is_epi.
+  Defined.
+
+  Definition Abelian_factorization1_monic {x y : A} (f : x --> y) :
+    Monic A (Abelian_Im f) y.
+  Proof.
+    use mk_Monic.
+    exact (KernelArrow _ (Abelian_Im f)).
+    apply KernelArrowisMonic.
+  Defined.
+
+  Definition Abelian_factorization1 {x y : A} (f : x --> y) :
+    f = (Abelian_factorization1_epi f) ;; (Abelian_factorization1_monic f).
+  Proof.
+    use (pathscomp0 (Abelian_CoIm_to_Im_eq f)).
+    apply idpath.
+  Qed.
+
+  (** In the second case we interpret the isomorphism as a monic.  *)
+  Definition Abelian_factorization2_is_monic {x y : A} (f : x --> y) :
+    isMonic A (Abelian_CoIm_to_Im f ;; (KernelArrow _ (Abelian_Im f))).
+  Proof.
+    apply isMonic_comp.
+    apply (iso_isMonic A _ (Abelian_CoIm_to_Im_is_iso f)).
+    apply KernelArrowisMonic.
+  Qed.
+
+  Definition Abelian_factorization2_monic {x y : A} (f : x --> y) :
+    Monic A (Abelian_CoIm f) y.
+  Proof.
+    use mk_Monic.
+    exact (Abelian_CoIm_to_Im f ;; (KernelArrow _ (Abelian_Im f))).
+    apply Abelian_factorization2_is_monic.
+  Defined.
+
+  Definition Abelian_factorization2_epi {x y : A} (f : x --> y) :
+    Epi A x (Abelian_CoIm f).
+  Proof.
+    use mk_Epi.
+    exact (CokernelArrow _ (Abelian_CoIm f)).
+    apply CokernelArrowisEpi.
+  Defined.
+
+  Definition Abelian_factorization2 {x y : A} (f : x --> y) :
+    f = (Abelian_factorization2_epi f) ;; (Abelian_factorization2_monic f).
+  Proof.
+    use (pathscomp0 (Abelian_CoIm_to_Im_eq f)).
+    rewrite <- assoc.
+    apply idpath.
+  Qed.
+End abelian_factorization.
+
 
 (** In this section we prove that every monic is the kernel of its cokernel and
   every epi is the cokernel of its kernel. *)
@@ -348,66 +1253,76 @@ Section abelian_kernel_cokernel.
   Variable A : Abelian.
   Hypothesis hs : has_homsets A.
 
-
-  (** The following definition constructs kernels from monics. *)
-  Definition Abelian_MonicToKerneEq {x y : A} (M : Monic A x y) :
-    M ;; CokernelArrow (Abelian_Zero A) (Abelian_Cokernels A x y M) =
-    ZeroArrow A (Abelian_Zero A) x (Abelian_Cokernels A x y M).
-  Proof.
-    set (AMK := Abelian_isAbelianMonicKernels A x y M).
-    unfold ishinh in AMK. cbn in *. unfold ishinh_UU in AMK.
-    unfold isEqualizer in AMK.
-    use (squash_to_prop AMK). apply hs.
-    intros X.
-    apply (CokernelCompZero (Abelian_Zero A) (Abelian_Cokernels A x y M)).
-  Qed.
-
+  (** First, we show that every monic is a kernel of its cokernel. *)
   Definition Abelian_MonicToKernel {x y : A} (M : Monic A x y) :
-    Kernel (Abelian_Zero A) (CokernelArrow _ (Abelian_Cokernels A x y M)).
+    Kernel (Abelian_Zero A) (CokernelArrow _ (Abelian_Cokernel A M)).
   Proof.
-    set (AMK := Abelian_isAbelianMonicKernels A x y M).
-    unfold ishinh in AMK. cbn in *. unfold ishinh_UU in AMK.
+    set (ker := Abelian_Im A M).
+    set (tmp := Abelian_factorization1 A hs M).
 
-    use (mk_Kernel _ M). use (squash_to_prop AMK). apply hs.
+    assert (isM : isMonic A (Abelian_factorization1_epi A hs M)).
+    {
+      apply (isMonic_postcomp A _ (Abelian_factorization1_monic A M)).
+      rewrite <- tmp.
+      apply (pr2 M).
+    }
 
-    intros X. apply (Abelian_MonicToKerneEq M).
-    use (squash_to_prop AMK). apply isaprop_isEqualizer.
-    intros X. induction X. induction p. induction p. unfold isEqualizer in p.
-    use mk_isEqualizer. intros w h X.
+    assert (isI : is_iso (Abelian_factorization1_epi A hs M)).
+    {
+      apply Abelian_monic_epi_is_iso.
+      apply isM.
+      apply Abelian_factorization1_is_epi.
+      apply hs.
+    }
 
-    apply p.
-    (* Need the factorization result of morphisms in abelian categories to
-       prove this *)
-  Abort.
+    set (h := isopair (Abelian_factorization1_epi A hs M) isI).
 
-  (** The following definition constructs cokernels from epis. *)
-  Definition Abelian_EpiToCokernelEq {y z : A} (E : Epi A y z) :
-    KernelArrow (Abelian_Zero A) (Abelian_Kernels A y z E) ;; E =
-    ZeroArrow A (Abelian_Zero A) (Abelian_Kernels A y z E) z.
+    (* The following general result constructs the kernel *)
+    apply (Kernel_up_to_iso A hs (Abelian_Zero A) M
+                            (CokernelArrow _ (Abelian_Cokernel A M)) ker h tmp).
+  Defined.
+
+  (** The following verifies that the monic M is indeed the KernelArrow. *)
+  Lemma Abelian_MonicToKernel_eq {x y : A} (M : Monic A x y) :
+    KernelArrow (Abelian_Zero A) (Abelian_MonicToKernel M) = M.
   Proof.
-    set (AEC := Abelian_isAbelianEpiCokernels A y z E).
-    unfold ishinh in AEC. cbn in *. unfold ishinh_UU in AEC.
-    unfold isCoequalizer in AEC.
-    use (squash_to_prop AEC). apply hs.
-    intros X.
-    apply (KernelCompZero (Abelian_Zero A) (Abelian_Kernels A y z E)).
-  Qed.
+    apply idpath.
+  Defined.
 
-  Definition Abelian_EpiToCokernel {y z : A} (E : Epi A y z) :
-    Cokernel (Abelian_Zero A) (KernelArrow _ (Abelian_Kernels _ _ _ E)).
+  (** Next, we show that every epi is a cokernel of its kernel. *)
+  Definition Abelian_EpiToCokernel {x y : A} (E : Epi A x y) :
+    Cokernel (Abelian_Zero A) (KernelArrow _ (Abelian_Kernel A E)).
   Proof.
-    set (AEC := Abelian_isAbelianEpiCokernels A y z E).
-    unfold ishinh in AEC. cbn in *. unfold ishinh_UU in AEC.
+    set (coker := Abelian_CoIm A E).
+    set (tmp := Abelian_factorization2 A hs E).
 
-    use (mk_Cokernel _ E). use (squash_to_prop AEC). apply hs.
+    assert (isE : isEpi A (Abelian_factorization2_monic A hs E)).
+    {
+      apply (isEpi_precomp A (Abelian_factorization2_epi A E)).
+      rewrite <- tmp.
+      apply (pr2 E).
+    }
 
-    intros X. apply (Abelian_EpiToCokernelEq E).
-    use (squash_to_prop AEC). apply isaprop_isCoequalizer.
-    intros X. induction X. induction p. induction p.
+    assert (isI : is_iso (Abelian_factorization2_monic A hs E)).
+    {
+      apply Abelian_monic_epi_is_iso.
+      apply Abelian_factorization2_is_monic.
+      apply hs.
+      apply isE.
+    }
 
-    use mk_isCoequalizer. intros w0 h X.
-    (* Need the factorization result of morphisms in abelian categories to
-       prove this. *)
-  Abort.
+    set (h := isopair (Abelian_factorization2_monic A hs E) isI).
 
+    (* The following general result constructs the cokernel *)
+    apply (Cokernel_up_to_iso A hs (Abelian_Zero A)
+                              (KernelArrow _ (Abelian_Kernel A E)) E
+                              coker h tmp).
+  Defined.
+
+  (** The following verifies that the epi E is indeed the CokernelArrow. *)
+  Lemma Abelian_EpiToCokernel_eq {x y : A} (E : Epi A x y) :
+    CokernelArrow (Abelian_Zero A) (Abelian_EpiToCokernel E) = E.
+  Proof.
+    apply idpath.
+  Defined.
 End abelian_kernel_cokernel.

--- a/UniMath/CategoryTheory/Abelian.v
+++ b/UniMath/CategoryTheory/Abelian.v
@@ -1,4 +1,26 @@
-(** Definition of abelian categories. *)
+(** * Abelian categories *)
+(** ** Contents
+- Definition of Abelian categories
+- If Monic and Epi, then iso
+- Pushouts of subobjects and pullbacks of quotient objects
+ - Pushouts of subobjects
+ - Pullbacks of quotient objects
+- Equalizers and Coequalizers
+ - Equalizers
+ - Coequalizers
+- Pullbacks and Pushouts
+- Results on Monics and Epis
+ - Monic implies Zero kernel
+ - Epi implies Zero cokernel
+ - Zero kernel implies Monic
+ - Zero cokernel implies Epi
+- Factorization of morphisms
+ - CoIm to Im factorization
+ - Epi ;; Monic factorization
+- Results on Kernels and Cokernels
+ - Monic are Kernels of their Cokernels
+ - Epis are Cokernels of their Kernels
+*)
 Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.Foundations.Basics.Propositions.
 Require Import UniMath.Foundations.Basics.Sets.
@@ -25,6 +47,8 @@ Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import UniMath.CategoryTheory.Monics.
 Require Import UniMath.CategoryTheory.Epis.
 
+
+(** * Definition of Abelian categories *)
 Section def_abelian.
 
   (** An abelian category has a zero object, binary (co)products, (co)kernels
@@ -144,42 +168,60 @@ Section def_abelian.
     := pr2 (pr2 (pr2 A)).
 
 
+  (** Hide the following equations behind Qed. *)
+  Definition Abelian_monic_kernel_eq {x y : A} (M : Monic A x y) :
+    M ;; AMKD_Mor Abelian_AMKD x y M
+    = ZeroArrow A Abelian_Zero x (AMKD_Ob Abelian_AMKD x y M).
+  Proof.
+    rewrite (AMKD_Eq Abelian_AMKD x y M).
+    apply ZeroArrow_comp_right.
+  Qed.
+
+  Definition Abelian_epi_cokernel_eq {y z : A} (E : Epi A y z) :
+    AECD_Mor Abelian_AECD y z E ;; E
+    = ZeroArrow A Abelian_Zero (AECD_Ob Abelian_AECD y z E) z.
+  Proof.
+    rewrite (AECD_Eq Abelian_AECD y z E).
+    apply ZeroArrow_comp_left.
+  Qed.
+
   (** The following definitions construct a kernel from a monic and a cokernel
     from an epi. *)
   Definition Abelian_monic_kernel {x y : A} (M : Monic A x y) :
-    Kernel Abelian_Zero (AMKD_Mor Abelian_AMKD x y M).
-  Proof.
-    use (mk_Kernel Abelian_Zero M).
-    rewrite (AMKD_Eq Abelian_AMKD x y M).
-    apply ZeroArrow_comp_right.
-    apply (AMKD_isE Abelian_AMKD x y M).
-  Defined.
+    Kernel Abelian_Zero (AMKD_Mor Abelian_AMKD x y M)
+    := mk_Kernel
+         Abelian_Zero
+         M
+         (AMKD_Mor Abelian_AMKD x y M)
+         (Abelian_monic_kernel_eq M)
+         (AMKD_isE Abelian_AMKD x y M).
 
   Definition Abelian_epi_cokernel {y z : A} (E : Epi A y z) :
-    Cokernel Abelian_Zero (AECD_Mor Abelian_AECD y z E).
-  Proof.
-    use (mk_Cokernel Abelian_Zero E).
-    rewrite (AECD_Eq Abelian_AECD y z E).
-    apply ZeroArrow_comp_left.
-    apply (AECD_isC Abelian_AECD y z E).
-  Defined.
+    Cokernel Abelian_Zero (AECD_Mor Abelian_AECD y z E)
+    := mk_Cokernel
+         Abelian_Zero
+         E
+         (AECD_Mor Abelian_AECD y z E)
+         (Abelian_epi_cokernel_eq E)
+         (AECD_isC Abelian_AECD y z E).
 
   (** The following lemmas verify that the kernel and cokernel arrows are indeed
     the monic M and the epi E. *)
-  Lemma Abelian_monic_kernel_eq {x y : A} (M : Monic A x y) :
+  Lemma Abelian_monic_kernel_arrow_eq {x y : A} (M : Monic A x y) :
     KernelArrow Abelian_Zero (Abelian_monic_kernel M) = M.
   Proof.
     apply idpath.
   Qed.
 
-  Lemma Abelian_epi_cokernel_eq {x y : A} (E : Epi A x y) :
+  Lemma Abelian_epi_cokernel_arrow_eq {x y : A} (E : Epi A x y) :
     CokernelArrow Abelian_Zero (Abelian_epi_cokernel E) = E.
   Proof.
     apply idpath.
   Qed.
 End def_abelian.
 
-(** In abelian categories morphisms which are both monic and epi are
+(** * If Monic and Epi, then iso
+  In abelian categories morphisms which are both monic and epi are
   isomorphisms. *)
 Section abelian_monic_epi_iso.
 
@@ -190,7 +232,6 @@ Section abelian_monic_epi_iso.
   Lemma Abelian_monic_epi_is_iso {x y : A} {f : x --> y} :
     isMonic A f -> isEpi A f -> is_iso f.
   Proof.
-
     intros M E.
     set (M1 := mk_Monic A f M).
     set (E1 := mk_Epi A f E).
@@ -212,7 +253,7 @@ Section abelian_monic_epi_iso.
 
     use is_iso_qinv.
 
-    (* The inverse of f. *)
+    (* The inverse of f *)
     exact t1.
 
     (* It remains to show that this is the inverse of f *)
@@ -223,23 +264,22 @@ Section abelian_monic_epi_iso.
     apply id_left.
 
     apply p6.
-  Defined.
+  Qed.
 
   (** Construction of the iso. *)
   Lemma Abelian_monic_epi_iso {x y : A} {f : x --> y} :
     isMonic A f -> isEpi A f -> iso x y.
   Proof.
     intros iM iE.
-    use isopair.
-    apply f.
-    apply (Abelian_monic_epi_is_iso iM iE).
+    exact (isopair f (Abelian_monic_epi_is_iso iM iE)).
   Defined.
 
 End abelian_monic_epi_iso.
 
 
-(** In the following section we prove that an abelian category has pullbacks of
-    subobjects and pushouts of quotient objects. *)
+(** * Pullbacks of subjects and pushouts of quotient objects
+  In the following section we prove that an abelian category has pullbacks of
+  subobjects and pushouts of quotient objects. *)
 Section abelian_subobject_pullbacks.
 
   Variable A : Abelian_precategory.
@@ -267,32 +307,40 @@ Section abelian_subobject_pullbacks.
     assert (H1 : KernelArrow (Abelian_Zero A) ker
                              ;; (AMKD_Mor (Abelian_AMKD A) x z M1)
                  = ZeroArrow _ (Abelian_Zero A) _ _).
-    rewrite <- (BinProductPr1Commutes A _ _ BinProd _
-                                     (AMKD_Mor (Abelian_AMKD A) x z M1)
-                                     (AMKD_Mor (Abelian_AMKD A) y z M2)).
-    rewrite assoc. fold ar. rewrite (KernelCompZero (Abelian_Zero A) ker).
-    apply ZeroArrow_comp_left.
+    {
+      rewrite <- (BinProductPr1Commutes A _ _ BinProd _
+                                       (AMKD_Mor (Abelian_AMKD A) x z M1)
+                                       (AMKD_Mor (Abelian_AMKD A) y z M2)).
+      rewrite assoc. fold ar. rewrite (KernelCompZero (Abelian_Zero A) ker).
+      apply ZeroArrow_comp_left.
+    }
 
     assert (H2 : KernelArrow (Abelian_Zero A) ker
                              ;; (AMKD_Mor (Abelian_AMKD A) y z M2)
                  = ZeroArrow _ (Abelian_Zero A) _ _).
-    rewrite <- (BinProductPr2Commutes A _ _ BinProd _
-                                     (AMKD_Mor (Abelian_AMKD A) x z M1)
-                                     (AMKD_Mor (Abelian_AMKD A) y z M2)).
-    rewrite assoc. fold ar. rewrite (KernelCompZero (Abelian_Zero A) ker).
-    apply ZeroArrow_comp_left.
+    {
+      rewrite <- (BinProductPr2Commutes A _ _ BinProd _
+                                       (AMKD_Mor (Abelian_AMKD A) x z M1)
+                                       (AMKD_Mor (Abelian_AMKD A) y z M2)).
+      rewrite assoc. fold ar. rewrite (KernelCompZero (Abelian_Zero A) ker).
+      apply ZeroArrow_comp_left.
+    }
 
     assert (com1 : KernelIn (Abelian_Zero A) ker1 ker
                             (KernelArrow (Abelian_Zero A) ker) H1 ;; M1
                    = KernelArrow (Abelian_Zero A) ker).
-    apply (KernelCommutes (Abelian_Zero A) ker1 _
-                          (KernelArrow (Abelian_Zero A) ker)).
+    {
+      apply (KernelCommutes (Abelian_Zero A) ker1 _
+                            (KernelArrow (Abelian_Zero A) ker)).
+    }
 
     assert (com2 : KernelIn (Abelian_Zero A) ker2 ker
                             (KernelArrow (Abelian_Zero A) ker) H2 ;; M2
                    = KernelArrow (Abelian_Zero A) ker).
-    apply (KernelCommutes (Abelian_Zero A) ker2 _
-                          (KernelArrow (Abelian_Zero A) ker)).
+    {
+      apply (KernelCommutes (Abelian_Zero A) ker2 _
+                            (KernelArrow (Abelian_Zero A) ker)).
+    }
 
     use mk_Pullback.
 
@@ -323,58 +371,47 @@ Section abelian_subobject_pullbacks.
     assert (e1 : h ;; (KernelArrow (Abelian_Zero A) ker1) ;;
                    (AMKD_Mor (Abelian_AMKD A) x z M1)
                  = ZeroArrow _ (Abelian_Zero A) _ _).
-    rewrite <- assoc.
-    set (ee1 := KernelCompZero (Abelian_Zero A) ker1). cbn in ee1. cbn.
-    rewrite ee1.
-    apply ZeroArrow_comp_right.
+    {
+      rewrite <- assoc.
+      set (ee1 := KernelCompZero (Abelian_Zero A) ker1). cbn in ee1. cbn.
+      rewrite ee1.
+      apply ZeroArrow_comp_right.
+    }
 
     assert (e2 : k ;; (KernelArrow (Abelian_Zero A) ker2) ;;
                    (AMKD_Mor (Abelian_AMKD A) y z M2)
                  = ZeroArrow _ (Abelian_Zero A) _ _).
-    rewrite <- assoc.
-    set (ee2 := KernelCompZero (Abelian_Zero A) ker2). cbn in ee2. cbn.
-    rewrite ee2.
-    apply ZeroArrow_comp_right.
+    {
+      rewrite <- assoc.
+      set (ee2 := KernelCompZero (Abelian_Zero A) ker2). cbn in ee2. cbn.
+      rewrite ee2.
+      apply ZeroArrow_comp_right.
+    }
 
     cbn in e1, e2.
 
     assert (e'1 : h ;; M1 ;; (AMKD_Mor (Abelian_AMKD A) y z M2)
                   = ZeroArrow _ (Abelian_Zero A) _ _).
-    rewrite H. apply e2.
-
-    assert (e'2 : k ;; M2 ;; (AMKD_Mor (Abelian_AMKD A) x z M1)
-                  = ZeroArrow _ (Abelian_Zero A) _ _).
-    rewrite <- H. apply e1.
+    {
+      rewrite H. apply e2.
+    }
 
     assert (e''1 : h ;; M1 ;; ar = ZeroArrow A (Abelian_Zero A) _ _).
-    rewrite (BinProductArrowEta A _ _ BinProd e (h ;; M1 ;; ar)).
-    use BinProductArrowZero. rewrite <- assoc.
-    set (tmp1 := BinProductPr1Commutes A _ _ BinProd _
-                                       (AMKD_Mor (Abelian_AMKD A) x z M1)
-                                       (AMKD_Mor (Abelian_AMKD A) y z M2)).
-    fold ar in tmp1. rewrite tmp1.
-    apply e1.
+    {
+      rewrite (BinProductArrowEta A _ _ BinProd e (h ;; M1 ;; ar)).
+      use BinProductArrowZero. rewrite <- assoc.
+      set (tmp1 := BinProductPr1Commutes A _ _ BinProd _
+                                         (AMKD_Mor (Abelian_AMKD A) x z M1)
+                                         (AMKD_Mor (Abelian_AMKD A) y z M2)).
+      fold ar in tmp1. rewrite tmp1.
+      apply e1.
 
-    rewrite <- assoc.
-    set (tmp1 := BinProductPr2Commutes A _ _ BinProd _
-                                       (AMKD_Mor (Abelian_AMKD A) x z M1)
-                                       (AMKD_Mor (Abelian_AMKD A) y z M2)).
-    fold ar in tmp1. rewrite tmp1. apply e'1.
-
-    assert (e''2 : k ;; M2 ;; ar = ZeroArrow A (Abelian_Zero A) _ _).
-    rewrite (BinProductArrowEta A _ _ BinProd e (k ;; M2 ;; ar)).
-    use BinProductArrowZero. rewrite <- assoc.
-    set (tmp1 := BinProductPr1Commutes A _ _ BinProd _
-                                       (AMKD_Mor (Abelian_AMKD A) x z M1)
-                                       (AMKD_Mor (Abelian_AMKD A) y z M2)).
-    fold ar in tmp1. rewrite tmp1.
-    apply e'2.
-
-    rewrite <- assoc.
-    set (tmp1 := BinProductPr2Commutes A _ _ BinProd _
-                                       (AMKD_Mor (Abelian_AMKD A) x z M1)
-                                       (AMKD_Mor (Abelian_AMKD A) y z M2)).
-    fold ar in tmp1. rewrite tmp1. apply e2.
+      rewrite <- assoc.
+      set (tmp1 := BinProductPr2Commutes A _ _ BinProd _
+                                         (AMKD_Mor (Abelian_AMKD A) x z M1)
+                                         (AMKD_Mor (Abelian_AMKD A) y z M2)).
+      fold ar in tmp1. rewrite tmp1. apply e'1.
+    }
 
     use unique_exists.
     use (KernelIn (Abelian_Zero A) ker e (h ;; M1)).
@@ -412,7 +449,7 @@ Section abelian_subobject_pullbacks.
     apply idpath.
   Defined.
 
-  Definition Abelian_quotobject_pushout {x y z: A}
+  Definition Abelian_quotobjects_pushout {x y z: A}
         (E1 : Epi A x y) (E2 : Epi A x z) :
     Pushout E1 E2.
   Proof.
@@ -434,34 +471,42 @@ Section abelian_subobject_pullbacks.
     assert (H1 : (AECD_Mor (Abelian_AECD A) x y E1)
                    ;; CokernelArrow (Abelian_Zero A) coker
                  = ZeroArrow _ (Abelian_Zero A) _ _).
-    rewrite <- (BinCoproductIn1Commutes A _ _ BinCoprod _
-                                       (AECD_Mor (Abelian_AECD A) x y E1)
-                                       (AECD_Mor (Abelian_AECD A) x z E2)).
-    rewrite <- assoc. fold ar.
-    rewrite (CokernelCompZero (Abelian_Zero A) coker).
-    apply ZeroArrow_comp_right.
+    {
+      rewrite <- (BinCoproductIn1Commutes A _ _ BinCoprod _
+                                         (AECD_Mor (Abelian_AECD A) x y E1)
+                                         (AECD_Mor (Abelian_AECD A) x z E2)).
+      rewrite <- assoc. fold ar.
+      rewrite (CokernelCompZero (Abelian_Zero A) coker).
+      apply ZeroArrow_comp_right.
+    }
 
     assert (H2 : (AECD_Mor (Abelian_AECD A) x z E2)
                    ;; CokernelArrow (Abelian_Zero A) coker
                  = ZeroArrow _ (Abelian_Zero A) _ _).
-    rewrite <- (BinCoproductIn2Commutes A _ _ BinCoprod _
-                                       (AECD_Mor (Abelian_AECD A) x y E1)
-                                       (AECD_Mor (Abelian_AECD A) x z E2)).
-    rewrite <- assoc. fold ar.
-    rewrite (CokernelCompZero (Abelian_Zero A) coker).
-    apply ZeroArrow_comp_right.
+    {
+      rewrite <- (BinCoproductIn2Commutes A _ _ BinCoprod _
+                                         (AECD_Mor (Abelian_AECD A) x y E1)
+                                         (AECD_Mor (Abelian_AECD A) x z E2)).
+      rewrite <- assoc. fold ar.
+      rewrite (CokernelCompZero (Abelian_Zero A) coker).
+      apply ZeroArrow_comp_right.
+    }
 
     assert (com1 : E1 ;; CokernelOut (Abelian_Zero A) coker1 coker
                       (CokernelArrow (Abelian_Zero A) coker) H1
                    = CokernelArrow (Abelian_Zero A) coker).
-    apply (CokernelCommutes (Abelian_Zero A) coker1 _
-                            (CokernelArrow (Abelian_Zero A) coker)).
+    {
+      apply (CokernelCommutes (Abelian_Zero A) coker1 _
+                              (CokernelArrow (Abelian_Zero A) coker)).
+    }
 
     assert (com2 : E2 ;; CokernelOut (Abelian_Zero A) coker2 coker
                       (CokernelArrow (Abelian_Zero A) coker) H2
                    = CokernelArrow (Abelian_Zero A) coker).
-    apply (CokernelCommutes (Abelian_Zero A) coker2 _
-                            (CokernelArrow (Abelian_Zero A) coker)).
+    {
+      apply (CokernelCommutes (Abelian_Zero A) coker2 _
+                              (CokernelArrow (Abelian_Zero A) coker)).
+    }
 
     use mk_Pushout.
 
@@ -494,58 +539,52 @@ Section abelian_subobject_pullbacks.
     assert (e1 : (AECD_Mor (Abelian_AECD A) x y E1)
                    ;; (CokernelArrow (Abelian_Zero A) coker1) ;; h
                  = ZeroArrow _ (Abelian_Zero A) _ _).
-    set (ee1 := CokernelCompZero (Abelian_Zero A) coker1). cbn in ee1. cbn.
-    rewrite ee1.
-    apply ZeroArrow_comp_left.
+    {
+      set (ee1 := CokernelCompZero (Abelian_Zero A) coker1). cbn in ee1. cbn.
+      rewrite ee1.
+      apply ZeroArrow_comp_left.
+    }
 
     assert (e2 : (AECD_Mor (Abelian_AECD A) x z E2)
                    ;; (CokernelArrow (Abelian_Zero A) coker2) ;; k
                  = ZeroArrow _ (Abelian_Zero A) _ _).
-    set (ee2 := CokernelCompZero (Abelian_Zero A) coker2). cbn in ee2. cbn.
-    rewrite ee2.
-    apply ZeroArrow_comp_left.
+    {
+      set (ee2 := CokernelCompZero (Abelian_Zero A) coker2). cbn in ee2. cbn.
+      rewrite ee2.
+      apply ZeroArrow_comp_left.
+    }
 
     cbn in e1, e2.
 
     assert (e'1 : (AECD_Mor (Abelian_AECD A) x z E2) ;; E1 ;; h =
                   ZeroArrow _ (Abelian_Zero A) _ _).
-    rewrite <- assoc. rewrite H. rewrite assoc. apply e2.
+    {
+      rewrite <- assoc. rewrite H. rewrite assoc. apply e2.
+    }
 
     assert (e'2 : (AECD_Mor (Abelian_AECD A) x y E1) ;; E2 ;; k
                   = ZeroArrow _ (Abelian_Zero A) _ _).
-    rewrite <- assoc. rewrite <- H. rewrite assoc. apply e1.
+    {
+      rewrite <- assoc. rewrite <- H. rewrite assoc. apply e1.
+    }
 
     assert (e''1 : ar ;; (E1 ;; h) = ZeroArrow A (Abelian_Zero A) _ _).
-    rewrite assoc.
-    rewrite (BinCoproductArrowEta A _ _ BinCoprod e (ar ;; E1 ;; h)).
-    use BinCoproductArrowZero. rewrite assoc. rewrite assoc.
-    set (tmp1 := BinCoproductIn1Commutes A _ _ BinCoprod _
-                                         (AECD_Mor (Abelian_AECD A) x y E1)
-                                         (AECD_Mor (Abelian_AECD A) x z E2)).
-    fold ar in tmp1. rewrite tmp1.
-    apply e1.
+    {
+      rewrite assoc.
+      rewrite (BinCoproductArrowEta A _ _ BinCoprod e (ar ;; E1 ;; h)).
+      use BinCoproductArrowZero. rewrite assoc. rewrite assoc.
+      set (tmp1 := BinCoproductIn1Commutes A _ _ BinCoprod _
+                                           (AECD_Mor (Abelian_AECD A) x y E1)
+                                           (AECD_Mor (Abelian_AECD A) x z E2)).
+      fold ar in tmp1. rewrite tmp1.
+      apply e1.
 
-    rewrite assoc. rewrite assoc.
-    set (tmp1 := BinCoproductIn2Commutes A _ _ BinCoprod _
-                                         (AECD_Mor (Abelian_AECD A) x y E1)
-                                         (AECD_Mor (Abelian_AECD A) x z E2)).
-    fold ar in tmp1. rewrite tmp1. apply e'1.
-
-    assert (e''2 : ar ;; (E2 ;; k) = ZeroArrow A (Abelian_Zero A) _ _).
-    rewrite assoc.
-    rewrite (BinCoproductArrowEta A _ _ BinCoprod e (ar ;; E2 ;; k)).
-    use BinCoproductArrowZero. rewrite assoc. rewrite assoc.
-    set (tmp1 := BinCoproductIn1Commutes A _ _ BinCoprod _
-                                       (AECD_Mor (Abelian_AECD A) x y E1)
-                                       (AECD_Mor (Abelian_AECD A) x z E2)).
-    fold ar in tmp1. rewrite tmp1.
-    apply e'2.
-
-    rewrite assoc. rewrite assoc.
-    set (tmp1 := BinCoproductIn2Commutes A _ _ BinCoprod _
-                                         (AECD_Mor (Abelian_AECD A) x y E1)
-                                         (AECD_Mor (Abelian_AECD A) x z E2)).
-    fold ar in tmp1. rewrite tmp1. apply e2.
+      rewrite assoc. rewrite assoc.
+      set (tmp1 := BinCoproductIn2Commutes A _ _ BinCoprod _
+                                           (AECD_Mor (Abelian_AECD A) x y E1)
+                                           (AECD_Mor (Abelian_AECD A) x z E2)).
+      fold ar in tmp1. rewrite tmp1. apply e'1.
+    }
 
     use unique_exists.
     use (CokernelOut (Abelian_Zero A) coker e (E1 ;; h)).
@@ -585,7 +624,8 @@ Section abelian_subobject_pullbacks.
 
 End abelian_subobject_pullbacks.
 
-(** In the following section we show that equalizers and coequalizers exist in
+(** * Equalizers and Coequalizers
+  In the following section we show that equalizers and coequalizers exist in
   abelian categories.  *)
 Section abelian_equalizers.
 
@@ -736,7 +776,7 @@ Section abelian_equalizers.
     set (E1 := mk_Epi A ar1 isE1).
     set (E2 := mk_Epi A ar2 isE2).
 
-    set (Po := Abelian_quotobject_pushout A hs E1 E2).
+    set (Po := Abelian_quotobjects_pushout A hs E1 E2).
 
     assert (H : PushoutIn1 Po = PushoutIn2 Po).
     {
@@ -819,7 +859,8 @@ Section abelian_equalizers.
 
 End abelian_equalizers.
 
-(** As a corollary of the above section we get that abelian categories have
+(** * Pushouts and pullbacks
+  As a corollary of the above section we get that abelian categories have
   pullbacks and pushouts. *)
 Section abelian_pushouts.
 
@@ -842,7 +883,9 @@ Section abelian_pushouts.
 
 End abelian_pushouts.
 
-(** In this section we prove that kernels of monomorphisms are given by the
+
+(** * Monic kernels and Epi cokernels
+  In this section we prove that kernels of monomorphisms are given by the
   arrows from zero and cokernels of epimorphisms are given by the arrows to
   zero. *)
 Section abelian_monic_kernels.
@@ -850,14 +893,17 @@ Section abelian_monic_kernels.
   Variable A : Abelian_precategory.
   Hypothesis hs : has_homsets A.
 
-  (* A kernel of a monic is the arrow from zero. *)
-  Definition Abelian_MonicKernelZero {x y : A} (M : Monic A x y) :
-    Kernel (Abelian_Zero A) M.
+
+  (* Hide isEqualizer behind Qed. *)
+  Definition Abelian_MonicKernelZero_isEqualizer {x y : A} (M : Monic A x y) :
+    isEqualizer M (ZeroArrow A (Abelian_Zero A) x y) (ZeroArrowFrom x)
+                (KernelEqRw (Abelian_Zero A)
+                            (ArrowsFromZero
+                               A (Abelian_Zero A)
+                               y (ZeroArrowFrom x ;; M)
+                               (ZeroArrow A (Abelian_Zero A)
+                                          (Abelian_Zero A) y))).
   Proof.
-    use mk_Kernel.
-    exact (Abelian_Zero A).
-    exact (ZeroArrowFrom _).
-    apply (ArrowsFromZero).
     use (mk_isEqualizer).
     intros w h X.
 
@@ -868,21 +914,38 @@ Section abelian_monic_kernels.
 
     use unique_exists.
     apply ZeroArrowTo.
+
+    (* Commutativity *)
     cbn. rewrite X. unfold ZeroArrow. apply idpath.
 
+    (* Equality of equalities of morphisms *)
     intros y0. apply hs.
 
-    intros y0 Y. cbn in Y. apply ArrowsToZero.
-  Defined.
+    (* Uniqueness *)
+    intros y0 Y. apply ArrowsToZero.
+  Qed.
 
-  (* A cokernel of an epi is the arrow to zero. *)
-  Definition Abelian_EpiCokernelZero {y z : A} (E : Epi A y z) :
-    Cokernel (Abelian_Zero A) E.
+
+  (* A kernel of a monic is the arrow from zero. *)
+  Definition Abelian_MonicKernelZero {x y : A} (M : Monic A x y) :
+    Kernel (Abelian_Zero A) M
+    := mk_Kernel
+         (Abelian_Zero A)
+         (ZeroArrowFrom _)
+         M
+         (ArrowsFromZero _ _ _ _ _)
+         (Abelian_MonicKernelZero_isEqualizer M).
+
+  (* Hide isCoequalizer behind Qed. *)
+  Definition Abelian_EpiCokernelZero_isCoequalizer {y z : A} (E : Epi A y z) :
+    isCoequalizer E (ZeroArrow A (Abelian_Zero A) y z) (ZeroArrowTo z)
+                  (CokernelEqRw (Abelian_Zero A)
+                                (ArrowsToZero
+                                   A (Abelian_Zero A)
+                                   y (E ;; ZeroArrowTo z)
+                                   (ZeroArrow A (Abelian_Zero A)
+                                              y (Abelian_Zero A)))).
   Proof.
-    use mk_Cokernel.
-    exact (Abelian_Zero A).
-    exact (ZeroArrowTo _).
-    apply (ArrowsToZero).
     use (mk_isCoequalizer).
     intros w h X.
 
@@ -898,8 +961,17 @@ Section abelian_monic_kernels.
     intros y0. apply hs.
 
     intros y0 Y. cbn in Y. apply ArrowsFromZero.
-  Defined.
+  Qed.
 
+  (* A cokernel of an epi is the arrow to zero. *)
+  Definition Abelian_EpiCokernelZero {y z : A} (E : Epi A y z) :
+    Cokernel (Abelian_Zero A) E
+    := mk_Cokernel
+         (Abelian_Zero A)
+         (ZeroArrowTo _)
+         E
+         (ArrowsToZero _ _ _ _ _)
+         (Abelian_EpiCokernelZero_isCoequalizer E).
 
   (** Next, we show that a morphism is monic if its kernel is the
     ZeroArrow from zero. *)
@@ -1011,7 +1083,7 @@ Section abelian_monic_kernels.
 
 
   (** We show that if the cokernel of a morphism is the ZeroArrow to Zero,
-   then the morphism is an Epi. *)
+    then the morphism is an Epi. *)
 
   Definition Abelian_CokernelZeroEpi_kernel {x y : A} {f1 f2 : x --> y}
              (e : f1 = f2) (K : Kernel (Abelian_Zero A) f1) :
@@ -1120,7 +1192,9 @@ Section abelian_monic_kernels.
   Defined.
 End abelian_monic_kernels.
 
-(** In this section we prove that every morphism factors as epi ;; monic in 2
+
+(** * Factorization of morphisms
+  In this section we prove that every morphism factors as Epi ;; Monic in 2
   canonical ways. To do this we need to prove that the canonical morphism
   CoIm f --> Im f is an isomorphism. *)
 Section abelian_factorization.
@@ -1187,11 +1261,9 @@ Section abelian_factorization.
   (** In this definition we construct the canonical morphism from the coimage
     of f to the image of f. *)
   Definition Abelian_CoIm_to_Im {x y : A} (f : x --> y) :
-    A⟦Abelian_CoIm f, Abelian_Im f⟧.
-  Proof.
-    exact (KernelIn  (Abelian_Zero A) (Abelian_Im f) (Abelian_CoIm f)
-                     (Abelian_CoIm_ar f) (Abelian_CoIm_to_Im_eq2 f)).
-  Defined.
+    A⟦Abelian_CoIm f, Abelian_Im f⟧
+    := (KernelIn (Abelian_Zero A) (Abelian_Im f) (Abelian_CoIm f)
+                 (Abelian_CoIm_ar f) (Abelian_CoIm_to_Im_eq2 f)).
 
   (** The above morphism gives a way to factorize the morphism f as a composite
     of three morphisms. *)
@@ -1500,7 +1572,8 @@ Section abelian_factorization.
 End abelian_factorization.
 
 
-(** In this section we prove that every monic is the kernel of its cokernel and
+(** * Monics are kernels of cokernels and Epis are cokernels of kernels
+  In this section we prove that every monic is the kernel of its cokernel and
   every epi is the cokernel of its kernel. *)
 Section abelian_kernel_cokernel.
 

--- a/UniMath/CategoryTheory/AbelianisAdditive.v
+++ b/UniMath/CategoryTheory/AbelianisAdditive.v
@@ -1,4 +1,9 @@
-(** We prove that Abelian_precategory is additive. *)
+(** * Abelian_precategory is Additive *)
+(** ** Contents
+- Abelian_precategory is Additive
+ - Preliminaries
+ - Abelian_precategory is Additive
+*)
 Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.Foundations.Basics.Propositions.
 Require Import UniMath.Foundations.Basics.Sets.
@@ -32,10 +37,14 @@ Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
 Require Import UniMath.CategoryTheory.PreAdditive.
 Require Import UniMath.CategoryTheory.Additive.
 
+
+(** * Abelian_precategory is Additive. *)
 Section abelian_is_additive.
 
   Variable A : Abelian_precategory.
   Hypothesis hs : has_homsets A.
+
+  (** ** Preliminaries *)
 
   (** Some maps we are going to use. *)
   Definition DiagonalMap {X : A} (BinProd : BinProductCone A X X) :
@@ -591,6 +600,8 @@ Section abelian_is_additive.
     unfold Abelian_minus_op. apply idpath.
   Qed.
 
+  (** ** Abelian_precategory is Additive *)
+
   (** The zero element in a homset of A is given by the ZeroArrow. *)
   Definition Abelian_precategory_homset_zero (X Y : A) :
     A⟦X, Y⟧ := ZeroArrow A (Abelian_Zero A) X Y.
@@ -745,7 +756,7 @@ Section abelian_is_additive.
     apply idpath.
   Qed.
 
-  Definition Abelian_precategory_homset_assoc_eq1 {X Y : A} (f g : X --> Y) :
+  Definition Abelian_precategory_homset_inv_minus {X Y : A} (f g : X --> Y) :
     Abelian_op _ _ f (Abelian_precategory_homset_inv g) =
     Abelian_minus_op f g.
   Proof.
@@ -761,11 +772,11 @@ Section abelian_is_additive.
     Abelian_op _ _ f (Abelian_precategory_homset_inv f) =
     Abelian_precategory_homset_zero X Y.
   Proof.
-    rewrite Abelian_precategory_homset_assoc_eq1.
+    rewrite Abelian_precategory_homset_inv_minus.
     apply Abelian_precategory_homset_inv_left'.
   Qed.
 
-  Definition Abelian_precategory_homset_assoc_eq3 {X Y : A} (f g : X --> Y) :
+  Definition Abelian_precategory_homset_assoc_eq1 {X Y : A} (f g : X --> Y) :
     Abelian_minus_op (Abelian_precategory_homset_zero X Y)
                      (Abelian_minus_op f g)
     = Abelian_op _ _
@@ -780,7 +791,7 @@ Section abelian_is_additive.
     apply idpath.
   Qed.
 
-  Definition Abelian_precategory_homset_assoc_eq4 {X Y : A} (f g : X --> Y) :
+  Definition Abelian_precategory_homset_assoc_eq2 {X Y : A} (f g : X --> Y) :
     Abelian_minus_op (Abelian_precategory_homset_zero X Y)
                      (Abelian_op _ _ f g)
     = Abelian_minus_op
@@ -798,7 +809,7 @@ Section abelian_is_additive.
     apply idpath.
   Qed.
 
-  Definition Abelian_precategory_homset_assoc_eq5 {X Y : A} (f g h : X --> Y) :
+  Definition Abelian_precategory_homset_assoc_eq3 {X Y : A} (f g h : X --> Y) :
      Abelian_op _ _ (Abelian_minus_op f g) h
      = Abelian_minus_op f (Abelian_minus_op g h).
   Proof.
@@ -824,11 +835,10 @@ Section abelian_is_additive.
     apply idpath.
   Qed.
 
-  (* TODO: change isPrecategorywithabgrops to PrecategoryWithAbgropsData *)
-  Definition Abelian_precategory_isPrecategoryWithAbgrops :
-    isPrecategoryWithAbgrops Abelian_precategory_PrecategoryWithBinops hs.
+  Definition Abelian_precategory_PrecategoryWithAbgropsData :
+    PrecategoryWithAbgropsData Abelian_precategory_PrecategoryWithBinops hs.
   Proof.
-    unfold isPrecategoryWithAbgrops.
+    unfold PrecategoryWithAbgropsData.
     intros x y.
 
     (* isabgrop *)
@@ -862,14 +872,12 @@ Section abelian_is_additive.
     := mk_PrecategoryWithAbgrops
          Abelian_precategory_PrecategoryWithBinops
          hs
-         Abelian_precategory_isPrecategoryWithAbgrops.
+         Abelian_precategory_PrecategoryWithAbgropsData.
 
-  (** We prove that Abelian_precategories are PreAddtitive. *)
-  Definition Abelian_precategory_PreAdditive :
-    PreAdditive.
+  (** Hide isPreAdditive behind Qed. *)
+  Definition Abelian_precategory_isPreAdditive :
+    isPreAdditive Abelian_precategory_PrecategoryWithAbgrops.
   Proof.
-    use (mk_PreAdditive Abelian_precategory_PrecategoryWithAbgrops).
-
     use mk_isPreAdditive.
 
     (* precomposition ismonoidfun *)
@@ -969,7 +977,14 @@ Section abelian_is_additive.
     unfold PrecategoryWithAbgrops_postmor. cbn.
     unfold Abelian_precategory_homset_zero.
     apply ZeroArrow_comp_left.
-  Defined.
+  Qed.
+
+  (** We prove that Abelian_precategories are PreAddtitive. *)
+  Definition Abelian_precategory_PreAdditive :
+    PreAdditive
+    := mk_PreAdditive
+         Abelian_precategory_PrecategoryWithAbgrops
+         Abelian_precategory_isPreAdditive.
 
   (** Finally, we show that Abelian_precategories are Additive. *)
   Definition Abelian_precategory_Additive :

--- a/UniMath/CategoryTheory/AbelianisAdditive.v
+++ b/UniMath/CategoryTheory/AbelianisAdditive.v
@@ -22,6 +22,8 @@ Require Import UniMath.CategoryTheory.limits.kernels.
 Require Import UniMath.CategoryTheory.limits.cokernels.
 Require Import UniMath.CategoryTheory.limits.pushouts.
 Require Import UniMath.CategoryTheory.limits.pullbacks.
+Require Import UniMath.CategoryTheory.limits.BinDirectSums.
+
 Require Import UniMath.CategoryTheory.Monics.
 Require Import UniMath.CategoryTheory.Epis.
 Require Import UniMath.CategoryTheory.Abelian.
@@ -337,7 +339,7 @@ Section abelian_is_additive.
     groups. *)
   Definition Abelian_minus_op {X Y : A} (f g : X --> Y) :
     A⟦X, Y⟧ :=
-    (BinProductArrow A (Abelian_BinProducts A Y Y) f f)
+    (BinProductArrow A (Abelian_BinProducts A Y Y) f g)
       ;; CokernelArrow _ (CokernelOfDiagonal (Abelian_BinProducts A Y Y)).
 
   Definition Abelian_op (X Y : A) : binop (A⟦X, Y⟧) :=
@@ -345,8 +347,8 @@ Section abelian_is_additive.
                  Abelian_minus_op f (Abelian_minus_op
                                        (ZeroArrow A (Abelian_Zero A) _ _) g)).
 
-  (* Construction of a precategory with binops from Abelian category. *)
-  Theorem Abelian_precategory_PrecategoryWithBinops :
+  (** Construction of a precategory with binops from Abelian category. *)
+  Definition Abelian_precategory_PrecategoryWithBinops :
     PrecategoryWithBinOps.
   Proof.
     use (mk_PrecategoryWithBinOps A).
@@ -376,6 +378,34 @@ Section abelian_is_additive.
     rewrite BinProductPr2Commutes.
     rewrite assoc. rewrite BinProductPr2Commutes.
     rewrite id_left. apply id_right.
+  Qed.
+
+  Definition Abelian_op_eq_IdZero (X : A) :
+    IdZeroMap (Abelian_BinProducts A X X)
+              ;; CokernelArrow (Abelian_Zero A)
+              (CokernelOfDiagonal (Abelian_BinProducts A X X))
+    = identity _ .
+  Proof.
+    set (r := (isopair
+                 (BinProductArrow A (Abelian_BinProducts A X X) (identity X)
+                                  (ZeroArrow A (Abelian_Zero A) X X)
+                                  ;; CokernelArrow (Abelian_Zero A)
+                                  (Abelian_Cokernel A (DiagonalMap
+                                                         (Abelian_BinProducts
+                                                            A X X))))
+                 (CokernelOfDiagonal_is_iso (Abelian_BinProducts A X X)))).
+    cbn. fold r. rewrite assoc. unfold IdZeroMap.
+    assert (e2 : BinProductArrow A (Abelian_BinProducts A X X) (identity X)
+                                 (ZeroArrow A (Abelian_Zero A) X X) ;;
+                                 CokernelArrow (Abelian_Zero A)
+                                 (Abelian_Cokernel A (DiagonalMap
+                                                        (Abelian_BinProducts
+                                                           A X X)))
+                 = r).
+    {
+      apply idpath.
+    }
+    rewrite e2. apply iso_inv_after_iso.
   Qed.
 
   Lemma Abelian_op_eq {X Y : A} (f : X --> Y) :
@@ -409,65 +439,14 @@ Section abelian_is_additive.
     rewrite <- com.
     apply cancel_precomposition.
 
-    assert (e1 : IdZeroMap (Abelian_BinProducts A X X)
-                           ;; CokernelArrow (Abelian_Zero A)
-                           (CokernelOfDiagonal (Abelian_BinProducts A X X))
-                 = identity _).
-    {
-      set (r := (isopair
-                   (BinProductArrow A (Abelian_BinProducts A X X) (identity X)
-                                    (ZeroArrow A (Abelian_Zero A) X X)
-                                    ;; CokernelArrow (Abelian_Zero A)
-                                    (Abelian_Cokernel A (DiagonalMap
-                                                           (Abelian_BinProducts
-                                                              A X X))))
-                   (CokernelOfDiagonal_is_iso (Abelian_BinProducts A X X)))).
-      cbn. fold r. rewrite assoc. unfold IdZeroMap.
-      assert (e2 : BinProductArrow A (Abelian_BinProducts A X X) (identity X)
-                                   (ZeroArrow A (Abelian_Zero A) X X) ;;
-                                   CokernelArrow (Abelian_Zero A)
-                                   (Abelian_Cokernel A (DiagonalMap
-                                                          (Abelian_BinProducts
-                                                             A X X)))
-                   = r).
-      {
-        apply idpath.
-      }
-      rewrite e2. apply iso_inv_after_iso.
-    }
-
-    assert (e2 : IdZeroMap (Abelian_BinProducts A Y Y)
-                           ;; CokernelArrow (Abelian_Zero A)
-                           (CokernelOfDiagonal (Abelian_BinProducts A Y Y))
-                 = identity _).
-    {
-      set (r := (isopair
-                   (BinProductArrow A (Abelian_BinProducts A Y Y) (identity Y)
-                                    (ZeroArrow A (Abelian_Zero A) Y Y)
-                                    ;; CokernelArrow (Abelian_Zero A)
-                                    (Abelian_Cokernel A (DiagonalMap
-                                                           (Abelian_BinProducts
-                                                              A Y Y))))
-                   (CokernelOfDiagonal_is_iso (Abelian_BinProducts A Y Y)))).
-      cbn. fold r. rewrite assoc. unfold IdZeroMap.
-      assert (e3 : BinProductArrow A (Abelian_BinProducts A Y Y) (identity Y)
-                                   (ZeroArrow A (Abelian_Zero A) Y Y) ;;
-                                   CokernelArrow (Abelian_Zero A)
-                                   (Abelian_Cokernel A (DiagonalMap
-                                                          (Abelian_BinProducts
-                                                             A Y Y)))
-                   = r).
-      {
-        apply idpath.
-      }
-      rewrite e3. apply iso_inv_after_iso.
-    }
-
+    set (e1 := Abelian_op_eq_IdZero X).
+    set (e2 := Abelian_op_eq_IdZero Y).
     set (ar' := BinProductArrow A (Abelian_BinProducts A Y Y)
                                 (BinProductPr1 A (Abelian_BinProducts A X X)
                                                ;; f)
                                 (BinProductPr2 A (Abelian_BinProducts A X X)
                                                ;; f)).
+
     assert (e3 : IdZeroMap (Abelian_BinProducts A X X) ;; ar'
                  = f ;; IdZeroMap (Abelian_BinProducts A Y Y)).
     {
@@ -493,32 +472,514 @@ Section abelian_is_additive.
     apply com.
   Qed.
 
-  (** We prove that Abelian_precategories are precategories with
-      Abgrops. *)
-  Theorem Abelian_precategory_PrecategoryWithAbgrops :
-    PrecategoryWithAbgrops.
+
+  (** Construction of morphisms to BinProducts. *)
+  Definition Abelian_mor_to_BinProd {X Y : A} (f g : X --> Y) :
+    A⟦X, (BinProductObject A (Abelian_BinProducts A Y Y))⟧
+    :=  BinProductArrow _ (Abelian_BinProducts A Y Y) f g.
+
+  Definition Abelian_mor_from_to_BinProd {X Y : A} (f g : X --> Y) :
+    A⟦BinProductObject A (Abelian_BinProducts A X X),
+      BinProductObject A (Abelian_BinProducts A Y Y)⟧
+    :=  BinProductArrow _ (Abelian_BinProducts A Y Y)
+                        (BinProductPr1 _ (Abelian_BinProducts A X X) ;; f)
+                        (BinProductPr2 _ (Abelian_BinProducts A X X) ;; g).
+
+
+  (** A few equations about the op. *)
+  Definition Abelian_precategory_op_eq1 {X Y : A} (a b c d : X --> Y) :
+    Abelian_minus_op (Abelian_mor_to_BinProd a b)
+                     (Abelian_mor_to_BinProd c d)
+    = Abelian_mor_to_BinProd (Abelian_minus_op a c)
+                             (Abelian_minus_op b d).
   Proof.
-    use (mk_PrecategoryWithAbgrops Abelian_precategory_PrecategoryWithBinops
-                                   hs).
+    set (com1 := Abelian_op_eq (BinProductPr1 A (Abelian_BinProducts A Y Y))).
+    set (com2 := Abelian_op_eq (BinProductPr2 A (Abelian_BinProducts A Y Y))).
+    unfold Abelian_minus_op. unfold Abelian_mor_to_BinProd.
+    apply BinProductArrowsEq.
+
+    (* First *)
+    rewrite <- assoc. rewrite com1.
+    rewrite BinProductPr1Commutes. rewrite assoc.
+    apply cancel_postcomposition.
+
+    (* Another BinProductArrowsEq *)
+    apply BinProductArrowsEq.
+    rewrite BinProductPr1Commutes. rewrite <- assoc.
+    rewrite BinProductPr1Commutes. rewrite assoc.
+    rewrite BinProductPr1Commutes.
+    rewrite BinProductPr1Commutes.
+    apply idpath.
+
+    rewrite BinProductPr2Commutes. rewrite <- assoc.
+    rewrite BinProductPr2Commutes. rewrite assoc.
+    rewrite BinProductPr2Commutes.
+    rewrite BinProductPr1Commutes.
+    apply idpath.
+
+    (* Second *)
+    rewrite <- assoc. rewrite com2.
+    rewrite BinProductPr2Commutes. rewrite assoc.
+    apply cancel_postcomposition.
+
+    (* Another BinProductArrowsEq *)
+    apply BinProductArrowsEq.
+    rewrite BinProductPr1Commutes. rewrite <- assoc.
+    rewrite BinProductPr1Commutes. rewrite assoc.
+    rewrite BinProductPr1Commutes.
+    rewrite BinProductPr2Commutes.
+    apply idpath.
+
+    rewrite BinProductPr2Commutes. rewrite <- assoc.
+    rewrite BinProductPr2Commutes. rewrite assoc.
+    rewrite BinProductPr2Commutes.
+    rewrite BinProductPr2Commutes.
+    apply idpath.
+  Qed.
+
+  Definition Abelian_precategory_op_eq2 {X Y : A} (a b c d : X --> Y) :
+    Abelian_mor_to_BinProd
+      (Abelian_mor_to_BinProd a b) (Abelian_mor_to_BinProd c d)
+      ;; Abelian_mor_from_to_BinProd
+      (CokernelArrow _ (CokernelOfDiagonal (Abelian_BinProducts A Y Y)))
+      (CokernelArrow _ (CokernelOfDiagonal (Abelian_BinProducts A Y Y)))
+    = Abelian_mor_to_BinProd
+        ((Abelian_mor_to_BinProd a b)
+           ;; (CokernelArrow _ (CokernelOfDiagonal
+                                  (Abelian_BinProducts A Y Y))))
+        ((Abelian_mor_to_BinProd c d)
+            ;; (CokernelArrow _ (CokernelOfDiagonal
+                                   (Abelian_BinProducts A Y Y)))).
+  Proof.
+    unfold Abelian_mor_to_BinProd.
+    unfold Abelian_mor_from_to_BinProd.
+    apply BinProductArrowsEq.
+
+    (* Pr1 *)
+    rewrite BinProductPr1Commutes. rewrite <- assoc.
+    rewrite BinProductPr1Commutes. rewrite assoc.
+    rewrite BinProductPr1Commutes. apply idpath.
+
+    (* Pr2 *)
+    rewrite BinProductPr2Commutes. rewrite <- assoc.
+    rewrite BinProductPr2Commutes. rewrite assoc.
+    rewrite BinProductPr2Commutes. apply idpath.
+  Qed.
+
+  Definition Abelian_precategory_op_eq3 {X Y : A} (a b c d : X --> Y) :
+    Abelian_minus_op (Abelian_minus_op a b)
+                     (Abelian_minus_op c d)
+    = Abelian_minus_op (Abelian_minus_op a c)
+                       (Abelian_minus_op b d).
+  Proof.
+    set (com := Abelian_op_eq
+                  (CokernelArrow (Abelian_Zero A)
+                                 (CokernelOfDiagonal
+                                    (Abelian_BinProducts A Y Y)))).
+    unfold Abelian_minus_op at 1.
+    set (tmp := Abelian_precategory_op_eq1 a c b d).
+    unfold Abelian_mor_to_BinProd in tmp.
+    rewrite <- tmp.
+
+    unfold Abelian_minus_op at 1. rewrite <- assoc. rewrite com.
+
+    rewrite assoc.
+    set (tmp1 := Abelian_precategory_op_eq2 a c b d).
+    unfold Abelian_mor_to_BinProd, Abelian_mor_from_to_BinProd in tmp1.
+    rewrite tmp1. apply cancel_postcomposition.
+
+    unfold Abelian_minus_op. apply idpath.
+  Qed.
+
+  (** The zero element in a homset of A is given by the ZeroArrow. *)
+  Definition Abelian_precategory_homset_zero (X Y : A) :
+    A⟦X, Y⟧ := ZeroArrow A (Abelian_Zero A) X Y.
+
+  (** Some equations involving Abelian_minus_op and Abelian_op. *)
+  Definition Abelian_precategory_homset_zero_right' {X Y : A} (f : X --> Y) :
+    Abelian_minus_op f (Abelian_precategory_homset_zero X Y) = f.
+  Proof.
+    unfold Abelian_precategory_homset_zero.
+    unfold Abelian_minus_op.
+    set (tmp := Abelian_op_eq_IdZero Y). unfold IdZeroMap in tmp.
+
+    assert (e1 : BinProductArrow A (Abelian_BinProducts A Y Y) f
+                                 (ZeroArrow A (Abelian_Zero A) X Y)
+                 = f ;; BinProductArrow
+                     A (Abelian_BinProducts A Y Y) (identity _)
+                     (ZeroArrow A (Abelian_Zero A) Y Y)).
+    {
+      apply BinProductArrowsEq.
+      rewrite BinProductPr1Commutes. rewrite <- assoc.
+      rewrite BinProductPr1Commutes.
+      rewrite id_right. apply idpath.
+
+      rewrite BinProductPr2Commutes. rewrite <- assoc.
+      rewrite BinProductPr2Commutes.
+      rewrite ZeroArrow_comp_right. apply idpath.
+    }
+
+    rewrite e1. rewrite <- assoc. rewrite tmp.
+    apply id_right.
+  Qed.
+
+  Definition Abelian_precategory_homset_zero_right {X Y : A} (f : X --> Y) :
+    Abelian_op _ _ f (Abelian_precategory_homset_zero X Y) = f.
+  Proof.
+    unfold Abelian_precategory_homset_zero.
+    unfold Abelian_op. unfold Abelian_minus_op at 2.
+    use (pathscomp0 _ (Abelian_precategory_homset_zero_right' f)).
+
+    assert (e1 :  (BinProductArrow A (Abelian_BinProducts A Y Y)
+                                   (ZeroArrow A (Abelian_Zero A) X Y)
+                                   (ZeroArrow A (Abelian_Zero A) X Y)
+                                   ;; CokernelArrow (Abelian_Zero A)
+                                   (CokernelOfDiagonal
+                                      (Abelian_BinProducts A Y Y)))
+                  = ZeroArrow A (Abelian_Zero A) _ _ ).
+    {
+      use (pathscomp0
+             _ (ZeroArrow_comp_left A (Abelian_Zero A) _ _ _
+                                    (CokernelArrow
+                                       (Abelian_Zero A)
+                                       (CokernelOfDiagonal
+                                          (Abelian_BinProducts A Y Y))))).
+      apply cancel_postcomposition.
+      apply BinProductArrowsEq.
+      rewrite BinProductPr1Commutes.
+      rewrite ZeroArrow_comp_left. apply idpath.
+
+      rewrite BinProductPr2Commutes.
+      rewrite ZeroArrow_comp_left. apply idpath.
+    }
+
+    rewrite e1. apply idpath.
+  Qed.
+
+  Definition Abelian_precategory_homset_inv {X Y : A} (f : X --> Y) :
+    A⟦X, Y⟧ := Abelian_minus_op (ZeroArrow _ (Abelian_Zero A) _ _) f.
+
+  Definition Abelian_precategory_homset_inv_left' {X Y : A} (f : X --> Y) :
+    Abelian_minus_op f f
+    = (Abelian_precategory_homset_zero X Y).
+  Proof.
+    unfold Abelian_precategory_homset_zero. unfold Abelian_minus_op.
+
+    assert (e1 : BinProductArrow A (Abelian_BinProducts A Y Y) f f
+                 = f ;; BinProductArrow A (Abelian_BinProducts A Y Y)
+                     (identity _ ) (identity _ )).
+    {
+      apply BinProductArrowsEq.
+      rewrite BinProductPr1Commutes. rewrite <- assoc.
+      rewrite BinProductPr1Commutes. rewrite id_right.
+      apply idpath.
+
+      rewrite BinProductPr2Commutes. rewrite <- assoc.
+      rewrite BinProductPr2Commutes. rewrite id_right.
+      apply idpath.
+    }
+
+    rewrite e1. rewrite <- assoc.
+    rewrite CokernelCompZero.
+    apply ZeroArrow_comp_right.
+  Qed.
+
+  Definition Abelian_precategory_homset_inv_left {X Y : A} (f : X --> Y) :
+    Abelian_op _ _ (Abelian_precategory_homset_inv f) f
+    = (Abelian_precategory_homset_zero X Y).
+  Proof.
+    unfold Abelian_precategory_homset_inv.
+    unfold Abelian_precategory_homset_zero.
+    unfold Abelian_op.
+    rewrite Abelian_precategory_op_eq3.
+    rewrite Abelian_precategory_homset_inv_left'.
+    rewrite Abelian_precategory_homset_inv_left'.
+    apply Abelian_precategory_homset_zero_right'.
+  Qed.
+
+  Definition Abelian_precategory_homset_zero_left {X Y : A} (f : X --> Y) :
+    Abelian_op _ _ (Abelian_precategory_homset_zero X Y) f = f.
+  Proof.
+    rewrite <- (Abelian_precategory_homset_inv_left' f).
+    set (tmp := Abelian_precategory_homset_zero_right' f).
+    apply (maponpaths (fun g : _ => Abelian_op X Y (Abelian_minus_op f f) g))
+      in tmp.
+    apply pathsinv0 in tmp.
+    use (pathscomp0 tmp).
+    unfold Abelian_op.
+    rewrite Abelian_precategory_op_eq3.
+    rewrite Abelian_precategory_homset_zero_right'.
+    rewrite Abelian_precategory_homset_zero_right'.
+    rewrite Abelian_precategory_homset_inv_left'.
+    rewrite Abelian_precategory_homset_zero_right'.
+    apply idpath.
+  Qed.
+
+  Definition Abeliain_precategory_homset_comm' {X Y : A} (f g : X --> Y) :
+    Abelian_minus_op
+      (Abelian_minus_op (Abelian_precategory_homset_zero X Y) f) g
+    = Abelian_minus_op
+        (Abelian_minus_op (Abelian_precategory_homset_zero X Y) g) f.
+  Proof.
+    rewrite <- (Abelian_precategory_homset_zero_right' g).
+    rewrite Abelian_precategory_op_eq3.
+    rewrite (Abelian_precategory_homset_zero_right' f).
+    rewrite (Abelian_precategory_homset_zero_right' g).
+    apply idpath.
+  Qed.
+
+  Definition Abelian_precategory_homset_comm {X Y : A} (f g : X --> Y) :
+    Abelian_op _ _ f g = Abelian_op _ _ g f.
+  Proof.
+    set (tmp1 := Abelian_precategory_homset_zero_left f).
+    apply (maponpaths (fun h : _ => Abelian_op X Y h g)) in tmp1.
+    apply pathsinv0 in tmp1. use (pathscomp0 tmp1).
+
+    set (tmp2 := Abelian_precategory_homset_zero_left g).
+    apply (maponpaths (fun h : _ => Abelian_op X Y h f)) in tmp2.
+    use (pathscomp0 _ tmp2).
+    unfold Abelian_op.
+    rewrite (Abelian_precategory_op_eq3 _ _ _ g).
+    rewrite (Abelian_precategory_op_eq3 _ _ _ f).
+    rewrite (Abeliain_precategory_homset_comm' _ g).
+    apply idpath.
+  Qed.
+
+  Definition Abelian_precategory_homset_assoc_eq1 {X Y : A} (f g : X --> Y) :
+    Abelian_op _ _ f (Abelian_precategory_homset_inv g) =
+    Abelian_minus_op f g.
+  Proof.
+    unfold Abelian_op.
+    unfold Abelian_precategory_homset_inv.
+    set (tmp := Abelian_precategory_homset_zero_left g).
+    unfold Abelian_op in tmp.
+    unfold Abelian_precategory_homset_zero in tmp.
+    rewrite tmp. apply idpath.
+  Qed.
+
+  Definition Abelian_precategory_homset_inv_right {X Y : A} (f : X --> Y) :
+    Abelian_op _ _ f (Abelian_precategory_homset_inv f) =
+    Abelian_precategory_homset_zero X Y.
+  Proof.
+    rewrite Abelian_precategory_homset_assoc_eq1.
+    apply Abelian_precategory_homset_inv_left'.
+  Qed.
+
+  Definition Abelian_precategory_homset_assoc_eq3 {X Y : A} (f g : X --> Y) :
+    Abelian_minus_op (Abelian_precategory_homset_zero X Y)
+                     (Abelian_minus_op f g)
+    = Abelian_op _ _
+                 (Abelian_minus_op (Abelian_precategory_homset_zero X Y) f) g.
+  Proof.
+    rewrite <- (Abelian_precategory_homset_inv_left'
+                 (Abelian_precategory_homset_zero X Y)).
+    unfold Abelian_op.
+    rewrite Abelian_precategory_op_eq3.
+    rewrite (Abelian_precategory_homset_inv_left'
+               (Abelian_precategory_homset_zero X Y)).
+    apply idpath.
+  Qed.
+
+  Definition Abelian_precategory_homset_assoc_eq4 {X Y : A} (f g : X --> Y) :
+    Abelian_minus_op (Abelian_precategory_homset_zero X Y)
+                     (Abelian_op _ _ f g)
+    = Abelian_minus_op
+        (Abelian_minus_op (Abelian_precategory_homset_zero X Y) f) g.
+  Proof.
+    set (tmp := Abelian_precategory_homset_inv_left'
+                  (Abelian_precategory_homset_zero X Y)).
+    apply (maponpaths (fun h : _ => Abelian_minus_op h (Abelian_op X Y f g)))
+      in tmp.
+    apply pathsinv0 in tmp. use (pathscomp0 tmp).
+    unfold Abelian_op.
+    rewrite Abelian_precategory_op_eq3.
+    set (tmp2 := Abelian_precategory_homset_zero_left g).
+    unfold Abelian_op in tmp2. rewrite tmp2.
+    apply idpath.
+  Qed.
+
+  Definition Abelian_precategory_homset_assoc_eq5 {X Y : A} (f g h : X --> Y) :
+     Abelian_op _ _ (Abelian_minus_op f g) h
+     = Abelian_minus_op f (Abelian_minus_op g h).
+  Proof.
+    unfold Abelian_op.
+    rewrite Abelian_precategory_op_eq3.
+    rewrite Abelian_precategory_homset_zero_right'.
+    apply idpath.
+  Qed.
+
+  Definition Abelian_precategory_homset_assoc {X Y : A} (f g h : X --> Y) :
+     Abelian_op _ _ (Abelian_op _ _ f g) h
+     = Abelian_op _ _ f (Abelian_op _ _ g h).
+  Proof.
+    set (tmp := Abelian_precategory_homset_zero_left h).
+    apply (maponpaths (fun k : _ => Abelian_op X Y (Abelian_op X Y f g) k))
+      in tmp.
+    apply pathsinv0 in tmp. use (pathscomp0 tmp).
+    unfold Abelian_op.
+    rewrite Abelian_precategory_op_eq3.
+    rewrite Abelian_precategory_homset_zero_right'.
+    rewrite Abelian_precategory_op_eq3.
+    rewrite Abelian_precategory_homset_zero_right'.
+    apply idpath.
+  Qed.
+
+  (* TODO: change isPrecategorywithabgrops to PrecategoryWithAbgropsData *)
+  Definition Abelian_precategory_isPrecategoryWithAbgrops :
+    isPrecategoryWithAbgrops Abelian_precategory_PrecategoryWithBinops hs.
+  Proof.
     unfold isPrecategoryWithAbgrops.
     intros x y.
 
     (* isabgrop *)
     split.
-  Abort.
+    use isgroppair.
+    split.
+    intros f g h. cbn.
+    apply Abelian_precategory_homset_assoc.
+    use isunitalpair. cbn.
+    apply Abelian_precategory_homset_zero.
+    split.
+    intros f.
+    apply Abelian_precategory_homset_zero_left.
+    intros f.
+    apply Abelian_precategory_homset_zero_right.
+
+    cbn. use tpair. cbn. intros f.
+    apply (Abelian_precategory_homset_inv f).
+    cbn. split.
+
+    intros f. apply Abelian_precategory_homset_inv_left.
+    intros f. apply Abelian_precategory_homset_inv_right.
+
+    intros f g.
+    apply Abelian_precategory_homset_comm.
+  Defined.
+
+  (** We prove that Abelian_precategories are PrecategoriesWithAbgrops. *)
+  Definition Abelian_precategory_PrecategoryWithAbgrops :
+    PrecategoryWithAbgrops
+    := mk_PrecategoryWithAbgrops
+         Abelian_precategory_PrecategoryWithBinops
+         hs
+         Abelian_precategory_isPrecategoryWithAbgrops.
 
   (** We prove that Abelian_precategories are PreAddtitive. *)
-  Theorem Abelian_precategory_preAdditive :
+  Definition Abelian_precategory_PreAdditive :
     PreAdditive.
   Proof.
-    (* TODO *)
-  Abort.
+    use (mk_PreAdditive Abelian_precategory_PrecategoryWithAbgrops).
+
+    use mk_isPreAdditive.
+
+    (* precomposition ismonoidfun *)
+    intros x y z f.
+    split.
+
+    intros x' x'0. unfold PrecategoryWithAbgrops_premor.
+    cbn. unfold Abelian_op. unfold Abelian_minus_op.
+    cbn in x', x'0. rewrite assoc. apply cancel_postcomposition.
+
+    assert (e2 : BinProductArrow
+                   A (Abelian_BinProducts A z z) (f ;; x')
+                   (BinProductArrow
+                      A (Abelian_BinProducts A z z)
+                      (ZeroArrow A (Abelian_Zero A) x z)
+                      (f ;; x'0)
+                      ;; CokernelArrow (Abelian_Zero A)
+                      (CokernelOfDiagonal (Abelian_BinProducts A z z)))
+                 = BinProductArrow
+                   A (Abelian_BinProducts A z z) (f ;; x')
+                   (BinProductArrow
+                      A (Abelian_BinProducts A z z)
+                      (f ;; ZeroArrow A (Abelian_Zero A) y z)
+                      (f ;; x'0)
+                      ;; CokernelArrow (Abelian_Zero A)
+                      (CokernelOfDiagonal (Abelian_BinProducts A z z)))).
+    {
+      set (tmp := ZeroArrow_comp_right A (Abelian_Zero A) x y z f).
+      apply (maponpaths
+               (fun h : _ =>
+                  BinProductArrow
+                   A (Abelian_BinProducts A z z) (f ;; x')
+                   (BinProductArrow
+                      A (Abelian_BinProducts A z z)
+                      h
+                      (f ;; x'0)
+                      ;; CokernelArrow (Abelian_Zero A)
+                      (CokernelOfDiagonal (Abelian_BinProducts A z z)))))
+        in tmp.
+      apply pathsinv0 in tmp. apply tmp.
+    }
+    apply pathsinv0 in e2.
+    use (pathscomp0 _ e2).
+    rewrite <- precompWithBinProductArrow. rewrite <- assoc.
+    rewrite <- precompWithBinProductArrow. apply idpath.
+
+    unfold PrecategoryWithAbgrops_premor. cbn.
+    unfold Abelian_precategory_homset_zero.
+    apply ZeroArrow_comp_right.
+
+    (* postcomposition is monoidfun *)
+    intros x y z f.
+    split.
+
+    intros x' x'0. unfold PrecategoryWithAbgrops_postmor.
+    cbn. unfold Abelian_op. unfold Abelian_minus_op.
+    cbn in x', x'0.
+
+    assert (e0 : BinProductArrow
+                   A (Abelian_BinProducts A z z)
+                   (ZeroArrow A (Abelian_Zero A) x z) (x'0 ;; f)
+                 = BinProductArrow
+                   A (Abelian_BinProducts A y y)
+                   (ZeroArrow A (Abelian_Zero A) x y) x'0
+                   ;; Abelian_mor_from_to_BinProd f f).
+    {
+      apply BinProductArrowsEq.
+      unfold Abelian_mor_from_to_BinProd.
+      rewrite <- assoc.
+      rewrite BinProductPr1Commutes.
+      rewrite BinProductPr1Commutes.
+      rewrite assoc.
+      rewrite BinProductPr1Commutes.
+      rewrite ZeroArrow_comp_left.
+      apply idpath.
+
+      unfold Abelian_mor_from_to_BinProd.
+      rewrite <- assoc.
+      rewrite BinProductPr2Commutes.
+      rewrite BinProductPr2Commutes.
+      rewrite assoc.
+      rewrite BinProductPr2Commutes.
+      apply idpath.
+    }
+
+    rewrite e0.
+    set (tmp := Abelian_op_eq f).
+    unfold Abelian_mor_from_to_BinProd. rewrite <- assoc. rewrite <- assoc.
+    rewrite <- tmp. rewrite assoc. rewrite assoc.
+
+    rewrite <- (postcompWithBinProductArrow
+                 A _ (Abelian_BinProducts A y y)).
+    unfold BinProductOfArrows. rewrite <- assoc. rewrite <- assoc.
+    rewrite <- tmp.
+    apply idpath.
+
+    unfold PrecategoryWithAbgrops_postmor. cbn.
+    unfold Abelian_precategory_homset_zero.
+    apply ZeroArrow_comp_left.
+  Defined.
 
   (** Finally, we show that Abelian_precategories are Additive. *)
-  Theorem Abelian_precategory_Additive :
-    PreAdditive.
+  Definition Abelian_precategory_Additive :
+    Additive.
   Proof.
-    (* TODO *)
-  Abort.
-
+    use (mk_Additive Abelian_precategory_PreAdditive).
+    use mk_isAdditive.
+    exact (Abelian_Zero A).
+    exact (BinDirectSums_from_BinProducts Abelian_precategory_PreAdditive
+                                          hs (Abelian_Zero A)
+                                          (Abelian_BinProducts A)).
+  Defined.
 End abelian_is_additive.

--- a/UniMath/CategoryTheory/AbelianisAdditive.v
+++ b/UniMath/CategoryTheory/AbelianisAdditive.v
@@ -35,7 +35,7 @@ Section abelian_is_additive.
   Variable A : Abelian_precategory.
   Hypothesis hs : has_homsets A.
 
-  (** Some maps we are going to use *)
+  (** Some maps we are going to use. *)
   Definition DiagonalMap {X : A} (BinProd : BinProductCone A X X) :
     A⟦X, (BinProductObject A BinProd)⟧
     := BinProductArrow A BinProd (identity X) (identity X).
@@ -49,7 +49,7 @@ Section abelian_is_additive.
     := BinProductArrow A BinProd (ZeroArrow A (Abelian_Zero A) X X)
                        (identity X).
 
-  (** Proofs that these maps are monics *)
+  (** Proofs that these maps are monics. *)
   Definition DiagonalMap_isMonic {X : A} (BinProd : BinProductCone A X X) :
     isMonic A (DiagonalMap BinProd).
   Proof.
@@ -86,7 +86,7 @@ Section abelian_is_additive.
     exact H.
   Qed.
 
-  (** We show that Pr1 and Pr2 are epimorphisms. *)
+  (** We show that Pr1 and Pr2 of BinProduct are epimorphisms. *)
   Definition BinProductPr1_isEpi {X : A} (BinProd : BinProductCone A X X) :
     isEpi A (BinProductPr1 A BinProd).
   Proof.
@@ -109,7 +109,7 @@ Section abelian_is_additive.
     apply identity_isEpi.
   Qed.
 
-  (** We construct kernels of Pr1 and Pr2. *)
+  (** We construct kernels of BinProduct Pr1 and Pr2. *)
   Definition KernelOfPr1_Eq {X : A} (BinProd : BinProductCone A X X) :
     ZeroIdMap BinProd ;; BinProductPr1 A BinProd
     = ZeroArrow A (Abelian_Zero A) X X.
@@ -194,16 +194,20 @@ Section abelian_is_additive.
   (** From properties of abelian categories, it follows that Pr1 and Pr2 are
     cokernels of the above kernels since they are epimorphisms. *)
   Definition CokernelOfKernelOfPr1 {X : A} (BinProd : BinProductCone A X X) :
-    Cokernel (Abelian_Zero A) (KernelArrow (Abelian_Zero A) (KernelOfPr1 BinProd)).
+    Cokernel (Abelian_Zero A) (KernelArrow (Abelian_Zero A)
+                                           (KernelOfPr1 BinProd)).
   Proof.
-    exact (Abelian_EpiToCokernel' A hs (mk_Epi A _ (BinProductPr1_isEpi BinProd))
+    exact (Abelian_EpiToCokernel' A hs
+                                  (mk_Epi A _ (BinProductPr1_isEpi BinProd))
                                   (KernelOfPr1 BinProd)).
   Defined.
 
   Definition CokernelOfKernelOfPr2 {X : A} (BinProd : BinProductCone A X X) :
-    Cokernel (Abelian_Zero A) (KernelArrow (Abelian_Zero A) (KernelOfPr2 BinProd)).
+    Cokernel (Abelian_Zero A) (KernelArrow (Abelian_Zero A)
+                                           (KernelOfPr2 BinProd)).
   Proof.
-    exact (Abelian_EpiToCokernel' A hs (mk_Epi A _ (BinProductPr2_isEpi BinProd))
+    exact (Abelian_EpiToCokernel' A hs
+                                  (mk_Epi A _ (BinProductPr2_isEpi BinProd))
                                   (KernelOfPr2 BinProd)).
   Defined.
 
@@ -241,7 +245,8 @@ Section abelian_is_additive.
     assert (H : y = ZeroArrow _ (Abelian_Zero A) w ker).
     {
       rewrite <- (id_right A _ _ y).
-      set (tmp := BinProductPr2Commutes A _ _ BinProd _ (identity X) (identity X)).
+      set (tmp := BinProductPr2Commutes A _ _ BinProd _ (identity X)
+                                        (identity X)).
       rewrite <- tmp. rewrite assoc. rewrite com1. rewrite <- assoc.
       rewrite (BinProductPr2Commutes A _ _ BinProd _ (identity X) _).
       apply ZeroArrow_comp_right.
@@ -281,7 +286,8 @@ Section abelian_is_additive.
     assert (H : y = ZeroArrow _ (Abelian_Zero A) X w).
     {
       rewrite <- (id_left A _ _ y).
-      set (tmp := BinProductPr2Commutes A _ _ BinProd _ (identity X) (identity X)).
+      set (tmp := BinProductPr2Commutes A _ _ BinProd _ (identity X)
+                                        (identity X)).
       rewrite <- tmp. rewrite <- assoc. rewrite com1. rewrite assoc.
       rewrite CokernelCompZero.
       apply ZeroArrow_comp_left.
@@ -301,7 +307,6 @@ Section abelian_is_additive.
     intros y H. apply ArrowsFromZero.
   Qed.
 
-  (** Construction of the cokernel of the DiagonalMap *)
   Definition CokernelOfDiagonal {X : A} (BinProd : BinProductCone A X X) :
     Cokernel (Abelian_Zero A) (DiagonalMap BinProd).
   Proof.
@@ -315,7 +320,7 @@ Section abelian_is_additive.
                               (iso_inv_from_iso (isopair _ X0)) (idpath _)).
   Defined.
 
-  (** Verification that the CokernelArrow of the above is what we wanted *)
+  (** Verification that the CokernelArrow of the above is what we wanted. *)
   Lemma CokernelOfDiagonal_CokernelArrowEq {X : A}
         (BinProd : BinProductCone A X X) :
     CokernelArrow _ (CokernelOfDiagonal BinProd)
@@ -411,14 +416,19 @@ Section abelian_is_additive.
     {
       set (r := (isopair
                    (BinProductArrow A (Abelian_BinProducts A X X) (identity X)
-                         (ZeroArrow A (Abelian_Zero A) X X) ;; CokernelArrow (Abelian_Zero A)
-                         (Abelian_Cokernel A (DiagonalMap (Abelian_BinProducts A X X))))
+                                    (ZeroArrow A (Abelian_Zero A) X X)
+                                    ;; CokernelArrow (Abelian_Zero A)
+                                    (Abelian_Cokernel A (DiagonalMap
+                                                           (Abelian_BinProducts
+                                                              A X X))))
                    (CokernelOfDiagonal_is_iso (Abelian_BinProducts A X X)))).
       cbn. fold r. rewrite assoc. unfold IdZeroMap.
       assert (e2 : BinProductArrow A (Abelian_BinProducts A X X) (identity X)
                                    (ZeroArrow A (Abelian_Zero A) X X) ;;
                                    CokernelArrow (Abelian_Zero A)
-                                   (Abelian_Cokernel A (DiagonalMap (Abelian_BinProducts A X X)))
+                                   (Abelian_Cokernel A (DiagonalMap
+                                                          (Abelian_BinProducts
+                                                             A X X)))
                    = r).
       {
         apply idpath.
@@ -433,14 +443,19 @@ Section abelian_is_additive.
     {
       set (r := (isopair
                    (BinProductArrow A (Abelian_BinProducts A Y Y) (identity Y)
-                         (ZeroArrow A (Abelian_Zero A) Y Y) ;; CokernelArrow (Abelian_Zero A)
-                         (Abelian_Cokernel A (DiagonalMap (Abelian_BinProducts A Y Y))))
+                                    (ZeroArrow A (Abelian_Zero A) Y Y)
+                                    ;; CokernelArrow (Abelian_Zero A)
+                                    (Abelian_Cokernel A (DiagonalMap
+                                                           (Abelian_BinProducts
+                                                              A Y Y))))
                    (CokernelOfDiagonal_is_iso (Abelian_BinProducts A Y Y)))).
       cbn. fold r. rewrite assoc. unfold IdZeroMap.
       assert (e3 : BinProductArrow A (Abelian_BinProducts A Y Y) (identity Y)
                                    (ZeroArrow A (Abelian_Zero A) Y Y) ;;
                                    CokernelArrow (Abelian_Zero A)
-                                   (Abelian_Cokernel A (DiagonalMap (Abelian_BinProducts A Y Y)))
+                                   (Abelian_Cokernel A (DiagonalMap
+                                                          (Abelian_BinProducts
+                                                             A Y Y)))
                    = r).
       {
         apply idpath.
@@ -449,8 +464,10 @@ Section abelian_is_additive.
     }
 
     set (ar' := BinProductArrow A (Abelian_BinProducts A Y Y)
-                                (BinProductPr1 A (Abelian_BinProducts A X X) ;; f)
-                                (BinProductPr2 A (Abelian_BinProducts A X X) ;; f)).
+                                (BinProductPr1 A (Abelian_BinProducts A X X)
+                                               ;; f)
+                                (BinProductPr2 A (Abelian_BinProducts A X X)
+                                               ;; f)).
     assert (e3 : IdZeroMap (Abelian_BinProducts A X X) ;; ar'
                  = f ;; IdZeroMap (Abelian_BinProducts A Y Y)).
     {

--- a/UniMath/CategoryTheory/AbelianisAdditive.v
+++ b/UniMath/CategoryTheory/AbelianisAdditive.v
@@ -1,0 +1,507 @@
+(** We prove that Abelian_precategory is additive. *)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.Foundations.Algebra.Monoids_and_Groups.
+
+Require Import UniMath.CategoryTheory.total2_paths.
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.BinProductPrecategory.
+Require Import UniMath.CategoryTheory.PrecategoriesWithBinOps.
+Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
+Require Import UniMath.CategoryTheory.PreAdditive.
+
+Require Import UniMath.CategoryTheory.limits.zero.
+Require Import UniMath.CategoryTheory.limits.binproducts.
+Require Import UniMath.CategoryTheory.limits.bincoproducts.
+Require Import UniMath.CategoryTheory.limits.equalizers.
+Require Import UniMath.CategoryTheory.limits.coequalizers.
+Require Import UniMath.CategoryTheory.limits.kernels.
+Require Import UniMath.CategoryTheory.limits.cokernels.
+Require Import UniMath.CategoryTheory.limits.pushouts.
+Require Import UniMath.CategoryTheory.limits.pullbacks.
+Require Import UniMath.CategoryTheory.Monics.
+Require Import UniMath.CategoryTheory.Epis.
+Require Import UniMath.CategoryTheory.Abelian.
+Require Import UniMath.CategoryTheory.PrecategoriesWithBinOps.
+Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
+Require Import UniMath.CategoryTheory.PreAdditive.
+Require Import UniMath.CategoryTheory.Additive.
+
+Section abelian_is_additive.
+
+  Variable A : Abelian_precategory.
+  Hypothesis hs : has_homsets A.
+
+  (** Some maps we are going to use *)
+  Definition DiagonalMap {X : A} (BinProd : BinProductCone A X X) :
+    A⟦X, (BinProductObject A BinProd)⟧
+    := BinProductArrow A BinProd (identity X) (identity X).
+
+  Definition IdZeroMap {X : A} (BinProd : BinProductCone A X X) :
+    A⟦X, (BinProductObject A BinProd)⟧
+    := BinProductArrow A BinProd (identity X)
+                       (ZeroArrow A (Abelian_Zero A) X X).
+  Definition ZeroIdMap {X : A} (BinProd : BinProductCone A X X) :
+    A⟦X, (BinProductObject A BinProd)⟧
+    := BinProductArrow A BinProd (ZeroArrow A (Abelian_Zero A) X X)
+                       (identity X).
+
+  (** Proofs that these maps are monics *)
+  Definition DiagonalMap_isMonic {X : A} (BinProd : BinProductCone A X X) :
+    isMonic A (DiagonalMap BinProd).
+  Proof.
+    intros x u v H.
+    apply (maponpaths (fun f : _ => f ;; (BinProductPr1 A BinProd))) in H.
+    repeat rewrite <- assoc in H. unfold DiagonalMap in H.
+    repeat rewrite (BinProductPr1Commutes A _ _ BinProd _
+                                          (identity X) (identity X)) in H.
+    repeat rewrite id_right in H.
+    exact H.
+  Qed.
+
+  Definition IdZeroMap_isMonic {X : A} (BinProd : BinProductCone A X X) :
+    isMonic A (IdZeroMap BinProd).
+  Proof.
+    intros x u v H.
+    apply (maponpaths (fun f : _ => f ;; (BinProductPr1 A BinProd))) in H.
+    repeat rewrite <- assoc in H. unfold IdZeroMap in H.
+    repeat rewrite (BinProductPr1Commutes A _ _ BinProd _
+                                          (identity X) _) in H.
+    repeat rewrite id_right in H.
+    exact H.
+  Qed.
+
+  Definition ZeroIdMap_isMonic {X : A} (BinProd : BinProductCone A X X) :
+    isMonic A (ZeroIdMap BinProd).
+  Proof.
+    intros x u v H.
+    apply (maponpaths (fun f : _ => f ;; (BinProductPr2 A BinProd))) in H.
+    repeat rewrite <- assoc in H. unfold ZeroIdMap in H.
+    repeat rewrite (BinProductPr2Commutes A _ _ BinProd _
+                                          _ (identity X)) in H.
+    repeat rewrite id_right in H.
+    exact H.
+  Qed.
+
+  (** We show that Pr1 and Pr2 are epimorphisms. *)
+  Definition BinProductPr1_isEpi {X : A} (BinProd : BinProductCone A X X) :
+    isEpi A (BinProductPr1 A BinProd).
+  Proof.
+    use isEpi_precomp.
+    exact X.
+    exact (IdZeroMap BinProd).
+    unfold IdZeroMap.
+    rewrite (BinProductPr1Commutes A _ _ BinProd _ (identity X) _).
+    apply identity_isEpi.
+  Qed.
+
+  Definition BinProductPr2_isEpi {X : A} (BinProd : BinProductCone A X X) :
+    isEpi A (BinProductPr2 A BinProd).
+  Proof.
+    use isEpi_precomp.
+    exact X.
+    exact (ZeroIdMap BinProd).
+    unfold ZeroIdMap.
+    rewrite (BinProductPr2Commutes A _ _ BinProd _ _ (identity X)).
+    apply identity_isEpi.
+  Qed.
+
+  (** We construct kernels of Pr1 and Pr2. *)
+  Definition KernelOfPr1_Eq {X : A} (BinProd : BinProductCone A X X) :
+    ZeroIdMap BinProd ;; BinProductPr1 A BinProd
+    = ZeroArrow A (Abelian_Zero A) X X.
+  Proof.
+    unfold ZeroIdMap.
+    rewrite (BinProductPr1Commutes A _ _ BinProd _ _ (identity X)).
+    apply idpath.
+  Qed.
+
+  Definition KernelOfPr1_isEqualizer {X : A} (BinProd : BinProductCone A X X) :
+    isEqualizer (BinProductPr1 A BinProd)
+                (ZeroArrow A (Abelian_Zero A) (BinProductObject A BinProd) X)
+                (ZeroIdMap BinProd)
+                (KernelEqRw (Abelian_Zero A) (KernelOfPr1_Eq BinProd)).
+  Proof.
+    use mk_isEqualizer.
+    intros w h H'.
+    unfold ZeroIdMap.
+    apply (unique_exists (h ;; (BinProductPr2 A BinProd))).
+    apply BinProductArrowsEq. rewrite <- assoc.
+    rewrite (BinProductPr1Commutes A _ _ BinProd _ _ (identity X)).
+    rewrite H'. repeat rewrite ZeroArrow_comp_right. apply idpath.
+    rewrite <- assoc.
+    rewrite (BinProductPr2Commutes A _ _ BinProd _ _ (identity X)).
+    apply id_right.
+
+    intros y. apply hs.
+
+    intros y H. rewrite <- H. rewrite <- assoc.
+    rewrite (BinProductPr2Commutes A _ _ BinProd _ _ (identity X)).
+    rewrite id_right. apply idpath.
+  Qed.
+
+  Definition KernelOfPr1 {X : A} (BinProd : BinProductCone A X X) :
+    Kernel (Abelian_Zero A) (BinProductPr1 A BinProd).
+  Proof.
+    exact (mk_Kernel (Abelian_Zero A) (ZeroIdMap BinProd) _
+                     (KernelOfPr1_Eq BinProd)
+                     (KernelOfPr1_isEqualizer BinProd)).
+  Defined.
+
+  Definition KernelOfPr2_Eq {X : A} (BinProd : BinProductCone A X X) :
+    IdZeroMap BinProd ;; BinProductPr2 A BinProd
+    = ZeroArrow A (Abelian_Zero A) X X.
+  Proof.
+    unfold IdZeroMap.
+    rewrite (BinProductPr2Commutes A _ _ BinProd _ (identity X) _).
+    apply idpath.
+  Qed.
+
+  Definition KernelOfPr2_isEqualizer {X : A} (BinProd : BinProductCone A X X) :
+    isEqualizer (BinProductPr2 A BinProd)
+                (ZeroArrow A (Abelian_Zero A) (BinProductObject A BinProd) X)
+                (IdZeroMap BinProd)
+                (KernelEqRw (Abelian_Zero A) (KernelOfPr2_Eq BinProd)).
+  Proof.
+    use mk_isEqualizer.
+    intros w h H'.
+    unfold IdZeroMap.
+    apply (unique_exists (h ;; (BinProductPr1 A BinProd))).
+    apply BinProductArrowsEq. rewrite <- assoc.
+    rewrite (BinProductPr1Commutes A _ _ BinProd _ (identity X) _).
+    apply id_right. rewrite <- assoc.
+    rewrite (BinProductPr2Commutes A _ _ BinProd _ (identity X) _).
+    rewrite H'. repeat rewrite ZeroArrow_comp_right. apply idpath.
+
+    intros y. apply hs.
+
+    intros y H. rewrite <- H. rewrite <- assoc.
+    rewrite (BinProductPr1Commutes A _ _ BinProd _ (identity X) _).
+    rewrite id_right. apply idpath.
+  Qed.
+
+  Definition KernelOfPr2 {X : A} (BinProd : BinProductCone A X X) :
+    Kernel (Abelian_Zero A) (BinProductPr2 A BinProd).
+  Proof.
+    exact (mk_Kernel (Abelian_Zero A) (IdZeroMap BinProd) _
+                     (KernelOfPr2_Eq BinProd)
+                     (KernelOfPr2_isEqualizer BinProd)).
+  Defined.
+
+  (** From properties of abelian categories, it follows that Pr1 and Pr2 are
+    cokernels of the above kernels since they are epimorphisms. *)
+  Definition CokernelOfKernelOfPr1 {X : A} (BinProd : BinProductCone A X X) :
+    Cokernel (Abelian_Zero A) (KernelArrow (Abelian_Zero A) (KernelOfPr1 BinProd)).
+  Proof.
+    exact (Abelian_EpiToCokernel' A hs (mk_Epi A _ (BinProductPr1_isEpi BinProd))
+                                  (KernelOfPr1 BinProd)).
+  Defined.
+
+  Definition CokernelOfKernelOfPr2 {X : A} (BinProd : BinProductCone A X X) :
+    Cokernel (Abelian_Zero A) (KernelArrow (Abelian_Zero A) (KernelOfPr2 BinProd)).
+  Proof.
+    exact (Abelian_EpiToCokernel' A hs (mk_Epi A _ (BinProductPr2_isEpi BinProd))
+                                  (KernelOfPr2 BinProd)).
+  Defined.
+
+  (** We construct a cokernel of the DiagonalMap. The CokernelOb is the
+   object X.*)
+  Lemma CokernelOfDiagonal_is_iso {X : A} (BinProd : BinProductCone A X X) :
+    is_iso ((BinProductArrow A BinProd (identity X)
+                             (ZeroArrow A (Abelian_Zero A) X X))
+              ;; (CokernelArrow (Abelian_Zero A)
+                                (Abelian_Cokernel A (DiagonalMap BinProd)))).
+  Proof.
+    set (coker := Abelian_Cokernel A (DiagonalMap BinProd)).
+    set (r := (BinProductArrow A BinProd (identity X)
+                               (ZeroArrow A (Abelian_Zero A) X X))
+                ;; (CokernelArrow (Abelian_Zero A) coker)).
+    set (M := mk_Monic A _ (DiagonalMap_isMonic BinProd)).
+    set (ker := Abelian_MonicToKernel A hs M).
+
+    apply Abelian_monic_epi_is_iso.
+
+    (* isMonic *)
+    use (@Abelian_KernelZeroisMonic A hs (Abelian_Zero A)).
+    apply ZeroArrow_comp_left.
+
+    apply mk_isEqualizer.
+    intros w h H'.
+    apply (unique_exists (ZeroArrow A (Abelian_Zero A) w (Abelian_Zero A))).
+
+    (* Commutativity *)
+    rewrite ZeroArrow_comp_right in H'. unfold r in H'. rewrite assoc in H'.
+    set (y := KernelIn _ ker _ _ H'). cbn in y.
+    set (com1 := KernelCommutes _ ker _ _ H'). cbn in com1. fold y in com1.
+    unfold DiagonalMap in com1.
+
+    assert (H : y = ZeroArrow _ (Abelian_Zero A) w ker).
+    {
+      rewrite <- (id_right A _ _ y).
+      set (tmp := BinProductPr2Commutes A _ _ BinProd _ (identity X) (identity X)).
+      rewrite <- tmp. rewrite assoc. rewrite com1. rewrite <- assoc.
+      rewrite (BinProductPr2Commutes A _ _ BinProd _ (identity X) _).
+      apply ZeroArrow_comp_right.
+    }
+
+    rewrite ZeroArrow_comp_left. cbn in H. apply pathsinv0 in H.
+    use (pathscomp0 H). rewrite <- id_right.
+    rewrite <- (BinProductPr1Commutes A _ _ BinProd _ (identity X)
+                                     (ZeroArrow _ (Abelian_Zero A) _ _)).
+    rewrite assoc. rewrite <- com1. rewrite <- assoc.
+    rewrite (BinProductPr1Commutes A _ _ BinProd _ (identity X) (identity X)).
+    rewrite id_right. apply idpath.
+
+    (* Equality on equalities of morphisms *)
+    intros y. apply hs.
+
+    (* Uniqueness *)
+    intros y H. apply ArrowsToZero.
+
+    (* isEpi *)
+    use (@Abelian_CokernelZeroisEpi A hs).
+    exact (Abelian_Zero A).
+    apply ZeroArrow_comp_right.
+
+    apply mk_isCoequalizer.
+    intros w h H'.
+    apply (unique_exists (ZeroArrow A (Abelian_Zero A) (Abelian_Zero A) w)).
+
+
+    (* Commutativity *)
+    set(coker2 := CokernelOfKernelOfPr2 BinProd).
+    set(coker2ar := CokernelArrow _ coker2). cbn in coker2ar.
+    rewrite ZeroArrow_comp_left in H'. unfold r in H'. rewrite <- assoc in H'.
+    set (y := CokernelOut _ coker2 _ _ H'). cbn in y.
+    set (com1 := CokernelCommutes _ coker2 _ _ H'). cbn in com1. fold y in com1.
+
+    assert (H : y = ZeroArrow _ (Abelian_Zero A) X w).
+    {
+      rewrite <- (id_left A _ _ y).
+      set (tmp := BinProductPr2Commutes A _ _ BinProd _ (identity X) (identity X)).
+      rewrite <- tmp. rewrite <- assoc. rewrite com1. rewrite assoc.
+      rewrite CokernelCompZero.
+      apply ZeroArrow_comp_left.
+    }
+
+    rewrite H in com1. rewrite ZeroArrow_comp_right in com1.
+    rewrite <- (ZeroArrow_comp_right A (Abelian_Zero A) _ _ _
+                                    (CokernelArrow (Abelian_Zero A) coker))
+      in com1.
+    apply CokernelArrowisEpi in com1. rewrite <- com1.
+    apply ZeroArrow_comp_left.
+
+    (* Equality on equalities of morphisms. *)
+    intros y. apply hs.
+
+    (* Uniqueness *)
+    intros y H. apply ArrowsFromZero.
+  Qed.
+
+  (** Construction of the cokernel of the DiagonalMap *)
+  Definition CokernelOfDiagonal {X : A} (BinProd : BinProductCone A X X) :
+    Cokernel (Abelian_Zero A) (DiagonalMap BinProd).
+  Proof.
+    set (X0 := CokernelOfDiagonal_is_iso BinProd).
+    exact (Cokernel_up_to_iso A hs (Abelian_Zero A) _
+                              (CokernelArrow (Abelian_Zero A)
+                                             (Abelian_Cokernel A (DiagonalMap
+                                                                    BinProd))
+                                             ;; iso_inv_from_iso (isopair _ X0))
+                              (Abelian_Cokernel A (DiagonalMap BinProd))
+                              (iso_inv_from_iso (isopair _ X0)) (idpath _)).
+  Defined.
+
+  (** Verification that the CokernelArrow of the above is what we wanted *)
+  Lemma CokernelOfDiagonal_CokernelArrowEq {X : A}
+        (BinProd : BinProductCone A X X) :
+    CokernelArrow _ (CokernelOfDiagonal BinProd)
+    = (CokernelArrow (Abelian_Zero A)
+                     (Abelian_Cokernel A (DiagonalMap BinProd))
+                     ;; iso_inv_from_iso (isopair _
+                                                  (CokernelOfDiagonal_is_iso
+                                                     BinProd))).
+  Proof.
+    apply idpath.
+  Qed.
+
+  (** We define the op which makes the homsets of an abelian category to abelian
+    groups. *)
+  Definition Abelian_minus_op {X Y : A} (f g : X --> Y) :
+    A⟦X, Y⟧ :=
+    (BinProductArrow A (Abelian_BinProducts A Y Y) f f)
+      ;; CokernelArrow _ (CokernelOfDiagonal (Abelian_BinProducts A Y Y)).
+
+  Definition Abelian_op (X Y : A) : binop (A⟦X, Y⟧) :=
+    (fun f : _ => fun g : _ =>
+                 Abelian_minus_op f (Abelian_minus_op
+                                       (ZeroArrow A (Abelian_Zero A) _ _) g)).
+
+  (* Construction of a precategory with binops from Abelian category. *)
+  Theorem Abelian_precategory_PrecategoryWithBinops :
+    PrecategoryWithBinOps.
+  Proof.
+    use (mk_PrecategoryWithBinOps A).
+    unfold PrecategoryWithBinOpsData.
+    intros x y. exact (Abelian_op x y).
+  Defined.
+
+  (** We need the following lemmas to prove that the homsets of an abelian
+     precategory are abelian groups. *)
+  Lemma Abelian_DiagonalMap_eq {X Y : A} (f : X --> Y) :
+    f ;; (DiagonalMap (Abelian_BinProducts A Y Y))
+    = (DiagonalMap (Abelian_BinProducts A X X))
+        ;; (BinProductArrow A (Abelian_BinProducts A Y Y)
+                       (BinProductPr1 _ (Abelian_BinProducts A X X) ;; f)
+                       (BinProductPr2 _ (Abelian_BinProducts A X X) ;; f)).
+  Proof.
+    unfold DiagonalMap.
+    apply BinProductArrowsEq.
+    repeat rewrite <- assoc.
+    rewrite BinProductPr1Commutes.
+    rewrite BinProductPr1Commutes.
+    rewrite assoc. rewrite BinProductPr1Commutes.
+    rewrite id_left. apply id_right.
+
+    repeat rewrite <- assoc.
+    rewrite BinProductPr2Commutes.
+    rewrite BinProductPr2Commutes.
+    rewrite assoc. rewrite BinProductPr2Commutes.
+    rewrite id_left. apply id_right.
+  Qed.
+
+  Lemma Abelian_op_eq {X Y : A} (f : X --> Y) :
+    CokernelArrow _ (CokernelOfDiagonal (Abelian_BinProducts A X X)) ;; f
+    = (BinProductArrow A (Abelian_BinProducts A Y Y)
+                       (BinProductPr1 _ (Abelian_BinProducts A X X) ;; f)
+                       (BinProductPr2 _ (Abelian_BinProducts A X X) ;; f))
+        ;; (CokernelArrow _ (CokernelOfDiagonal (Abelian_BinProducts A Y Y))).
+  Proof.
+    set (ar := (BinProductArrow A (Abelian_BinProducts A Y Y)
+                       (BinProductPr1 _ (Abelian_BinProducts A X X) ;; f)
+                       (BinProductPr2 _ (Abelian_BinProducts A X X) ;; f))
+                  ;; CokernelArrow _
+                  (CokernelOfDiagonal (Abelian_BinProducts A Y Y))).
+    assert (H: DiagonalMap (Abelian_BinProducts A X X) ;; ar =
+               ZeroArrow A (Abelian_Zero A) _ _).
+    {
+      unfold ar. rewrite assoc.
+      rewrite <- (Abelian_DiagonalMap_eq f).
+      rewrite <- assoc. rewrite CokernelCompZero.
+      apply ZeroArrow_comp_right.
+    }
+    set (g := CokernelOut (Abelian_Zero A)
+                           (CokernelOfDiagonal (Abelian_BinProducts A X X))
+                           (CokernelOfDiagonal (Abelian_BinProducts A Y Y))
+                           ar H).
+    set (com := CokernelCommutes (Abelian_Zero A)
+                           (CokernelOfDiagonal (Abelian_BinProducts A X X))
+                           (CokernelOfDiagonal (Abelian_BinProducts A Y Y))
+                           ar H).
+    rewrite <- com.
+    apply cancel_precomposition.
+
+    assert (e1 : IdZeroMap (Abelian_BinProducts A X X)
+                           ;; CokernelArrow (Abelian_Zero A)
+                           (CokernelOfDiagonal (Abelian_BinProducts A X X))
+                 = identity _).
+    {
+      set (r := (isopair
+                   (BinProductArrow A (Abelian_BinProducts A X X) (identity X)
+                         (ZeroArrow A (Abelian_Zero A) X X) ;; CokernelArrow (Abelian_Zero A)
+                         (Abelian_Cokernel A (DiagonalMap (Abelian_BinProducts A X X))))
+                   (CokernelOfDiagonal_is_iso (Abelian_BinProducts A X X)))).
+      cbn. fold r. rewrite assoc. unfold IdZeroMap.
+      assert (e2 : BinProductArrow A (Abelian_BinProducts A X X) (identity X)
+                                   (ZeroArrow A (Abelian_Zero A) X X) ;;
+                                   CokernelArrow (Abelian_Zero A)
+                                   (Abelian_Cokernel A (DiagonalMap (Abelian_BinProducts A X X)))
+                   = r).
+      {
+        apply idpath.
+      }
+      rewrite e2. apply iso_inv_after_iso.
+    }
+
+    assert (e2 : IdZeroMap (Abelian_BinProducts A Y Y)
+                           ;; CokernelArrow (Abelian_Zero A)
+                           (CokernelOfDiagonal (Abelian_BinProducts A Y Y))
+                 = identity _).
+    {
+      set (r := (isopair
+                   (BinProductArrow A (Abelian_BinProducts A Y Y) (identity Y)
+                         (ZeroArrow A (Abelian_Zero A) Y Y) ;; CokernelArrow (Abelian_Zero A)
+                         (Abelian_Cokernel A (DiagonalMap (Abelian_BinProducts A Y Y))))
+                   (CokernelOfDiagonal_is_iso (Abelian_BinProducts A Y Y)))).
+      cbn. fold r. rewrite assoc. unfold IdZeroMap.
+      assert (e3 : BinProductArrow A (Abelian_BinProducts A Y Y) (identity Y)
+                                   (ZeroArrow A (Abelian_Zero A) Y Y) ;;
+                                   CokernelArrow (Abelian_Zero A)
+                                   (Abelian_Cokernel A (DiagonalMap (Abelian_BinProducts A Y Y)))
+                   = r).
+      {
+        apply idpath.
+      }
+      rewrite e3. apply iso_inv_after_iso.
+    }
+
+    set (ar' := BinProductArrow A (Abelian_BinProducts A Y Y)
+                                (BinProductPr1 A (Abelian_BinProducts A X X) ;; f)
+                                (BinProductPr2 A (Abelian_BinProducts A X X) ;; f)).
+    assert (e3 : IdZeroMap (Abelian_BinProducts A X X) ;; ar'
+                 = f ;; IdZeroMap (Abelian_BinProducts A Y Y)).
+    {
+      unfold ar', IdZeroMap.
+      apply BinProductArrowsEq. rewrite <- assoc.
+      rewrite BinProductPr1Commutes. rewrite assoc.
+      rewrite BinProductPr1Commutes. rewrite id_left.
+      rewrite <- assoc. rewrite BinProductPr1Commutes.
+      rewrite id_right. apply idpath.
+
+      rewrite <- assoc.
+      rewrite BinProductPr2Commutes. rewrite assoc.
+      rewrite BinProductPr2Commutes.
+      rewrite <- assoc. rewrite BinProductPr2Commutes.
+      rewrite ZeroArrow_comp_right.
+      apply ZeroArrow_comp_left.
+    }
+
+    rewrite <- (id_right A _ _ f). rewrite <- e2. rewrite assoc.
+    rewrite <- e3. unfold ar'. rewrite <- assoc. fold ar.
+    rewrite <- id_left. cbn. rewrite <- e1. rewrite <- assoc.
+    apply cancel_precomposition. apply pathsinv0.
+    apply com.
+  Qed.
+
+  (** We prove that Abelian_precategories are precategories with
+      Abgrops. *)
+  Theorem Abelian_precategory_PrecategoryWithAbgrops :
+    PrecategoryWithAbgrops.
+  Proof.
+    use (mk_PrecategoryWithAbgrops Abelian_precategory_PrecategoryWithBinops
+                                   hs).
+    unfold isPrecategoryWithAbgrops.
+    intros x y.
+
+    (* isabgrop *)
+    split.
+  Abort.
+
+  (** We prove that Abelian_precategories are PreAddtitive. *)
+  Theorem Abelian_precategory_preAdditive :
+    PreAdditive.
+  Proof.
+    (* TODO *)
+  Abort.
+
+  (** Finally, we show that Abelian_precategories are Additive. *)
+  Theorem Abelian_precategory_Additive :
+    PreAdditive.
+  Proof.
+    (* TODO *)
+  Abort.
+
+End abelian_is_additive.

--- a/UniMath/CategoryTheory/Additive.v
+++ b/UniMath/CategoryTheory/Additive.v
@@ -1,4 +1,4 @@
-(** Definition of additive categories. *)
+(** * Additive categories. *)
 Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.Foundations.Basics.Propositions.
 Require Import UniMath.Foundations.Basics.Sets.
@@ -17,6 +17,7 @@ Require Import UniMath.CategoryTheory.limits.zero.
 Require Import UniMath.CategoryTheory.limits.BinDirectSums.
 
 
+(** * Definition of additive categories *)
 Section def_additive.
 
   (** A preadditive category is additive if it has a zero object and binary

--- a/UniMath/CategoryTheory/Additive.v
+++ b/UniMath/CategoryTheory/Additive.v
@@ -1,0 +1,56 @@
+(** Definition of additive categories. *)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.Foundations.Algebra.Monoids_and_Groups.
+
+Require Import UniMath.CategoryTheory.total2_paths.
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.BinProductPrecategory.
+Require Import UniMath.CategoryTheory.PrecategoriesWithBinOps.
+Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
+Require Import UniMath.CategoryTheory.PreAdditive.
+
+Require Import UniMath.CategoryTheory.limits.zero.
+Require Import UniMath.CategoryTheory.limits.BinDirectSums.
+
+
+Section def_additive.
+
+  (** A preadditive category is additive if it has a zero object and binary
+    direct sums. *)
+  Definition isAdditive (PA : PreAdditive) : UU :=
+    (Zero PA) × (BinDirectSums PA).
+
+  Definition mk_isAdditive (PA : PreAdditive)
+             (H1 : Zero PA)
+             (H2 : BinDirectSums PA) :
+    isAdditive PA.
+  Proof.
+    exact (H1,,H2).
+  Defined.
+
+  (** Definition of additive categories *)
+  Definition Additive : UU :=
+    Σ PA : PreAdditive, isAdditive PA.
+  Definition Additive_PreAdditive (A : Additive) :
+    PreAdditive := pr1 A.
+  Coercion Additive_PreAdditive :
+    Additive >-> PreAdditive.
+  Definition mk_Additive (PA : PreAdditive)
+             (H : isAdditive PA) : Additive.
+  Proof.
+    exact (tpair _ PA H).
+  Defined.
+
+  (** Accessor functions. *)
+  Definition Additive_isAdditive (A : Additive) :
+    isAdditive A := pr2 A.
+  Definition Additive_Zero (A : Additive) :
+    Zero A := (dirprod_pr1 (Additive_isAdditive A)).
+  Definition Additive_BinDirectSums (A : Additive) :
+    BinDirectSums A := (dirprod_pr2 (Additive_isAdditive A)).
+
+End def_additive.

--- a/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
+++ b/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
@@ -17,14 +17,14 @@ Section def_precategory_with_abgrops.
 
 
   (** Definition of precategories such that homsets are abgrops. *)
-  Definition isPrecategoryWithAbgrops (PB : PrecategoryWithBinOps)
+  Definition PrecategoryWithAbgropsData (PB : PrecategoryWithBinOps)
              (hs : has_homsets PB) : UU :=
     Π (x y : PB), @isabgrop (hSetpair (PB⟦x,y⟧) (hs x y))
                             (PrecategoryWithBinOps_binop PB x y).
 
   Definition PrecategoryWithAbgrops : UU :=
     Σ PA : (Σ PB : PrecategoryWithBinOps, has_homsets PB),
-           isPrecategoryWithAbgrops (pr1 PA) (pr2 PA).
+           PrecategoryWithAbgropsData (pr1 PA) (pr2 PA).
   Definition PrecategoryWithAbgrops_PrecategoryWithBinOps
              (PB : PrecategoryWithAbgrops) :
     PrecategoryWithBinOps := pr1 (pr1 PB).
@@ -32,7 +32,7 @@ Section def_precategory_with_abgrops.
     PrecategoryWithAbgrops >-> PrecategoryWithBinOps.
   Definition mk_PrecategoryWithAbgrops (PB : PrecategoryWithBinOps)
              (hs : has_homsets PB)
-             (H : isPrecategoryWithAbgrops PB hs) : PrecategoryWithAbgrops.
+             (H : PrecategoryWithAbgropsData PB hs) : PrecategoryWithAbgrops.
   Proof.
     exact (tpair _ (tpair _ PB hs) H).
   Defined.

--- a/UniMath/CategoryTheory/category_abgr.v
+++ b/UniMath/CategoryTheory/category_abgr.v
@@ -6,6 +6,8 @@ Require Import UniMath.Foundations.Basics.UnivalenceAxiom.
 
 Require Import UniMath.Foundations.Algebra.Monoids_and_Groups.
 
+Require Import UniMath.Foundations.NumberSystems.Integers.
+
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.

--- a/UniMath/CategoryTheory/category_abgr.v
+++ b/UniMath/CategoryTheory/category_abgr.v
@@ -124,7 +124,7 @@ Section ABGR_category.
       apply isapropismonoidfun.
   Defined.
 
-  Lemma habgrp_iso_equiv (A B : ob ABGR) :
+  Lemma abgrp_iso_equiv (A B : ob ABGR) :
     iso A B -> monoidiso (abgrtoabmonoid A) (abgrtoabmonoid B).
   Proof.
     intro f.
@@ -159,11 +159,11 @@ Section ABGR_category.
     apply T'.
   Defined.
 
-  Lemma abgrp_iso_equiv_is_equiv (A B : ABGR) : isweq (habgrp_iso_equiv A B).
+  Lemma abgrp_iso_equiv_is_equiv (A B : ABGR) : isweq (abgrp_iso_equiv A B).
   Proof.
     apply (gradth _ (abgr_equiv_iso A B)).
     intro; apply eq_iso. apply maponpaths.
-    unfold abgr_equiv_iso, habgrp_iso_equiv. cbn.
+    unfold abgr_equiv_iso, abgrp_iso_equiv. cbn.
     use total2_paths. cbn. unfold monoidfunconstr.
     apply subtypeEquality. intros y. apply isapropismonoidfun.
     apply maponpaths. apply subtypeEquality.
@@ -175,7 +175,7 @@ Section ABGR_category.
     apply proofirrelevance.
     apply isaprop_is_iso.
 
-    intros y. unfold habgrp_iso_equiv, abgr_equiv_iso. cbn.
+    intros y. unfold abgrp_iso_equiv, abgr_equiv_iso. cbn.
     use total2_paths. cbn. unfold monoidfunconstr.
     apply subtypeEquality. intros x. apply isapropisweq.
     apply idpath.
@@ -184,24 +184,24 @@ Section ABGR_category.
     apply isapropismonoidfun.
   Defined.
 
-  Definition habgr_iso_equiv_weq (A B : ABGR) :
+  Definition abgr_iso_equiv_weq (A B : ABGR) :
     weq (iso A B) (monoidiso (abgrtoabmonoid A) (abgrtoabmonoid B)).
   Proof.
-    exists (habgrp_iso_equiv A B).
+    exists (abgrp_iso_equiv A B).
     apply abgrp_iso_equiv_is_equiv.
   Defined.
 
-  Lemma habgr_equiv_iso_is_equiv (A B : ABGR) : isweq (abgr_equiv_iso A B).
+  Lemma abgr_equiv_iso_is_equiv (A B : ABGR) : isweq (abgr_equiv_iso A B).
   Proof.
-    apply (gradth _ (habgrp_iso_equiv A B)).
+    apply (gradth _ (abgrp_iso_equiv A B)).
     intros x. apply subtypeEquality.
     intros y. apply isapropismonoidfun.
 
-    unfold abgr_equiv_iso, habgrp_iso_equiv. cbn.
+    unfold abgr_equiv_iso, abgrp_iso_equiv. cbn.
     use total2_paths. cbn. apply idpath.
     apply isapropisweq.
 
-    intros y. unfold abgr_equiv_iso, habgrp_iso_equiv. cbn.
+    intros y. unfold abgr_equiv_iso, abgrp_iso_equiv. cbn.
     use total2_paths. cbn. unfold monoidfunconstr. cbn.
     apply subtypeEquality. intros x. apply isapropismonoidfun.
     apply idpath. apply proofirrelevance.
@@ -212,7 +212,7 @@ Section ABGR_category.
     weq (monoidiso (abgrtoabmonoid A) (abgrtoabmonoid B)) (iso A B).
   Proof.
     exists (abgr_equiv_iso A B).
-    apply habgr_equiv_iso_is_equiv.
+    apply abgr_equiv_iso_is_equiv.
   Defined.
 
 

--- a/UniMath/CategoryTheory/category_abgr.v
+++ b/UniMath/CategoryTheory/category_abgr.v
@@ -1556,7 +1556,7 @@ Section ABGR_monics.
   (** ** Epis *)
 
   (** hfiber (pr1 f) b is inhabited. *)
-  Definition ABGR_setquot_iso {A B : abgr} (f : ABGR⟦A, B⟧)
+  Definition ABGR_epi_hfiber_inhabited {A B : abgr} (f : ABGR⟦A, B⟧)
              (isE : isEpi ABGR f) (b : B)
              (H : setquotpr (ABGR_cokernel_eqrel f) b
                   = setquotpr (ABGR_cokernel_eqrel f)
@@ -1597,7 +1597,7 @@ Section ABGR_monics.
     rewrite <- (ABGR_monic_kernel_unel_rw B) in tmp1.
     set (tmp2 := @funeqpaths (pr1 B) (pr1 (ABGR_cokernel_abgr f))).
     set (tmp3 := tmp2 _ _ tmp1). cbn in tmp3.
-    apply (ABGR_setquot_iso f isE x (tmp3 x)).
+    apply (ABGR_epi_hfiber_inhabited f isE x (tmp3 x)).
   Qed.
 
 

--- a/UniMath/CategoryTheory/category_abgr.v
+++ b/UniMath/CategoryTheory/category_abgr.v
@@ -1,0 +1,955 @@
+(* The category abelian groups. *)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Basics.UnivalenceAxiom.
+
+Require Import UniMath.Foundations.Algebra.Monoids_and_Groups.
+
+Require Import UniMath.CategoryTheory.total2_paths.
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.HLevel_n_is_of_hlevel_Sn.
+
+Require Import UniMath.CategoryTheory.Monics.
+Require Import UniMath.CategoryTheory.Epis.
+
+Require Import UniMath.CategoryTheory.PrecategoriesWithBinOps.
+Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
+Require Import UniMath.CategoryTheory.PreAdditive.
+Require Import UniMath.CategoryTheory.Additive.
+
+Require Import UniMath.CategoryTheory.limits.zero.
+Require Import UniMath.CategoryTheory.limits.binproducts.
+Require Import UniMath.CategoryTheory.limits.bincoproducts.
+Require Import UniMath.CategoryTheory.limits.equalizers.
+Require Import UniMath.CategoryTheory.limits.coequalizers.
+Require Import UniMath.CategoryTheory.limits.kernels.
+Require Import UniMath.CategoryTheory.limits.cokernels.
+
+
+(** In this section we construct the category of abelian groups. *)
+Section ABGR_precategory.
+
+  Definition abgr_fun_space (A B : abgr) : hSet :=
+    hSetpair _ (isasetmonoidfun A B).
+
+  Definition abgr_precategory_ob_mor : precategory_ob_mor :=
+    tpair (fun ob : UU => ob -> ob -> UU) abgr
+          (fun A B : abgr => abgr_fun_space A B).
+
+  Definition idabgrfun (A : abgr) : monoidfun A A.
+  Proof.
+    use monoidfunconstr. intros a. exact a.
+    split.
+    intros a a'.
+    apply idpath.
+    apply idpath.
+  Defined.
+
+  Definition idabgrfun_remove_left (A B : abgr) (f : monoidfun A B) :
+    monoidfuncomp (idabgrfun A) f = f.
+  Proof.
+    unfold monoidfuncomp. unfold idabgrfun.
+    use total2_paths. cbn. unfold funcomp. apply maponpaths.
+    apply idpath. apply proofirrelevance. apply isapropismonoidfun.
+  Defined.
+
+  Definition idabgrfun_remove_right (A B : abgr) (f : monoidfun A B) :
+    monoidfuncomp f (idabgrfun B) = f.
+  Proof.
+    unfold monoidfuncomp, idabgrfun.
+    use total2_paths. cbn. unfold funcomp. apply idpath.
+    apply proofirrelevance. apply isapropismonoidfun.
+  Defined.
+
+  Definition abgrfuncomp_assoc (A B C D : abgr) (f : monoidfun A B)
+             (g : monoidfun B C) (h : monoidfun C D) :
+    monoidfuncomp (monoidfuncomp f g) h = monoidfuncomp f (monoidfuncomp g h).
+  Proof.
+    unfold monoidfuncomp. apply maponpaths.
+    apply isapropismonoidfun.
+  Defined.
+
+  Definition abgr_precategory_data : precategory_data :=
+    precategory_data_pair abgr_precategory_ob_mor
+                          (fun (A : abgr) => idabgrfun A )
+                          (fun (A B C : abgr) (f : monoidfun A B)
+                             (g : monoidfun B C) => monoidfuncomp f g).
+
+  Lemma is_precategory_abgr_precategory_data :
+    is_precategory abgr_precategory_data.
+  Proof.
+    repeat split; simpl.
+
+    intros a b f. apply idabgrfun_remove_left.
+    intros a b f. apply idabgrfun_remove_right.
+
+    intros a b c d f g h. apply pathsinv0.
+    apply (abgrfuncomp_assoc a b c d f g h).
+  Qed.
+
+  Definition abgr_precategory : precategory :=
+    tpair _ _ is_precategory_abgr_precategory_data.
+
+  Local Notation ABGR := abgr_precategory.
+  Lemma has_homsets_ABGR : has_homsets ABGR.
+  Proof. intros a b; apply isasetmonoidfun. Qed.
+
+End ABGR_precategory.
+
+Notation ABGR := abgr_precategory.
+
+Section ABGR_category.
+
+  (** ** Equivalence between isomorphisms and monoidisos *)
+
+  Lemma abgr_iso_is_equiv (A B : ob ABGR)
+        (f : iso A B) : isweq (pr1 (pr1 f)).
+  Proof.
+    apply (gradth _ (pr1monoidfun _ _ (inv_from_iso f))).
+    - intro x.
+      set (T:=iso_inv_after_iso f).
+      apply subtypeInjectivity in T.
+      set (T':=toforallpaths _ _ _ T). apply T'.
+      intro x0.
+      apply isapropismonoidfun.
+    - intros y.
+
+      set (T:=iso_after_iso_inv f).
+      apply subtypeInjectivity in T.
+      set (T':=toforallpaths _ _ _ T). apply T'.
+      intros x0.
+      apply isapropismonoidfun.
+  Defined.
+
+  Lemma habgrp_iso_equiv (A B : ob ABGR) :
+    iso A B -> monoidiso (abgrtoabmonoid A) (abgrtoabmonoid B).
+  Proof.
+    intro f.
+    use monoidisopair.
+    set (X := abgr_iso_is_equiv A B f).
+    apply (weqpair (pr1 (pr1 f)) X).
+    apply (pr2 (pr1 f)).
+  Defined.
+
+  Lemma abgr_equiv_is_iso (A B : abgr) (f : monoidiso A B) :
+    @is_isomorphism ABGR A B (monoidfunconstr (pr2 f)).
+  Proof.
+    apply (is_iso_qinv (C:=ABGR) _ (monoidfunconstr (pr2 (invmonoidiso f)))).
+    split; cbn. unfold monoidfuncomp, compose, idabgrfun, identity.
+    use total2_paths. cbn. apply funextfun. intros x.
+    apply homotinvweqweq. cbn. use total2_paths. cbn.
+    apply proofirrelevance. apply isapropisbinopfun.
+    apply proofirrelevance.  apply (pr2 (pr1 (pr1 A))).
+
+    use total2_paths. cbn. apply funextfun. intros x.
+    apply homotweqinvweq. cbn. apply proofirrelevance.
+    apply isapropismonoidfun.
+  Defined.
+
+  Lemma abgr_equiv_iso (A B : ABGR) :
+    monoidiso (abgrtoabmonoid A) (abgrtoabmonoid B) -> iso A B.
+  Proof.
+    intro f.
+    cbn in *.
+    set (T := abgr_equiv_is_iso A B f).
+    set (T' := @isopair ABGR _ _ (monoidfunconstr (pr2 f)) T).
+    apply T'.
+  Defined.
+
+  Lemma abgrp_iso_equiv_is_equiv (A B : ABGR) : isweq (habgrp_iso_equiv A B).
+  Proof.
+    apply (gradth _ (abgr_equiv_iso A B)).
+    intro; apply eq_iso. apply maponpaths.
+    unfold abgr_equiv_iso, habgrp_iso_equiv. cbn.
+    use total2_paths. cbn. unfold monoidfunconstr.
+    apply subtypeEquality. intros y. apply isapropismonoidfun.
+    apply maponpaths. apply subtypeEquality.
+    unfold isPredicate.
+
+    intros x0. apply isapropismonoidfun.
+    apply idpath.
+
+    apply proofirrelevance.
+    apply isaprop_is_iso.
+
+    intros y. unfold habgrp_iso_equiv, abgr_equiv_iso. cbn.
+    use total2_paths. cbn. unfold monoidfunconstr.
+    apply subtypeEquality. intros x. apply isapropisweq.
+    apply idpath.
+
+    apply proofirrelevance.
+    apply isapropismonoidfun.
+  Defined.
+
+  Definition habgr_iso_equiv_weq (A B : ABGR) :
+    weq (iso A B) (monoidiso (abgrtoabmonoid A) (abgrtoabmonoid B)).
+  Proof.
+    exists (habgrp_iso_equiv A B).
+    apply abgrp_iso_equiv_is_equiv.
+  Defined.
+
+  Lemma habgr_equiv_iso_is_equiv (A B : ABGR) : isweq (abgr_equiv_iso A B).
+  Proof.
+    apply (gradth _ (habgrp_iso_equiv A B)).
+    intros x. apply subtypeEquality.
+    intros y. apply isapropismonoidfun.
+
+    unfold abgr_equiv_iso, habgrp_iso_equiv. cbn.
+    use total2_paths. cbn. apply idpath.
+    apply isapropisweq.
+
+    intros y. unfold abgr_equiv_iso, habgrp_iso_equiv. cbn.
+    use total2_paths. cbn. unfold monoidfunconstr. cbn.
+    apply subtypeEquality. intros x. apply isapropismonoidfun.
+    apply idpath. apply proofirrelevance.
+    apply isaprop_is_iso.
+  Qed.
+
+  Definition hbinop_equiv_iso_weq (A B : ABGR) :
+    weq (monoidiso (abgrtoabmonoid A) (abgrtoabmonoid B)) (iso A B).
+  Proof.
+    exists (abgr_equiv_iso A B).
+    apply habgr_equiv_iso_is_equiv.
+  Defined.
+
+
+(** ** HERE ONE SHOULD ADD A PROOF THAT ABGR IS ACTUALLY A CATEGORY.
+         See category_hset.v *)
+
+End ABGR_category.
+
+
+(** ** Zero object in ABGR
+  In the following section we prove that the category of abelian groups has
+  a zero object.
+ *)
+Section ABGR_zero.
+
+  (** The zero object we use consists of one element, the unit element. *)
+  Definition ABGR_zero : abgr.
+  Proof.
+    use abgrpair.
+    use setwithbinoppair.
+    exact unitset.
+    unfold binop.
+    exact (fun i i': unitset => i).
+
+    (* isabgrop *)
+    unfold isabgrop. split.
+
+    use isgroppair. split.
+
+    unfold isassoc. intros x x' x''.
+    unfold op. cbn. apply idpath.
+    use isunitalpair. cbn. exact tt.
+
+    unfold isunit. split.
+    unfold islunit. intros x. cbn. apply isconnectedunit.
+    unfold isrunit. intros x. cbn. apply isconnectedunit.
+
+    unfold invstruct. cbn. use (tpair _ (fun _ : unit => tt)).
+    cbn. unfold isinv. split.
+    unfold islinv. intros X. apply idpath.
+    unfold isrinv. intros x. apply isconnectedunit.
+
+    unfold iscomm. intros x x'. unfold op. cbn.
+    apply isconnectedunit.
+  Defined.
+
+  (** Construction of the morphism to the zero object. *)
+  Definition ABGR_zero_from (A : abgr) : ABGR⟦A, ABGR_zero⟧.
+  Proof.
+    use monoidfunconstr.
+    exact (fun _ : A => tt).
+    unfold ismonoidfun. unfold isbinopfun. cbn. split.
+    intros x x'. apply idpath.
+    apply idpath.
+  Defined.
+
+  (** Construction of the morphisms from the zero object. *)
+  Definition ABGR_zero_to (A : abgr) : ABGR⟦ABGR_zero, A⟧.
+  Proof.
+    use monoidfunconstr.
+    exact (fun _ : ABGR_zero => unel A).
+    unfold ismonoidfun. unfold isbinopfun. cbn. split.
+    intros x x'. rewrite (runax A). apply idpath.
+    apply idpath.
+  Defined.
+
+  (** The following lemma constructs a zero object in ABGR. *)
+  Lemma ABGR_has_zero : Zero ABGR.
+  Proof.
+    use mk_Zero.
+    exact ABGR_zero.
+    use mk_isZero.
+    intros a. refine (tpair _ (ABGR_zero_to a) _).
+    intros t. use total2_paths. apply funextfun. intros x.
+
+    rewrite (isconnectedunit x tt). apply (pr2 (pr2 t)).
+    apply proofirrelevance. apply isapropismonoidfun.
+
+    intros a. refine (tpair _ (ABGR_zero_from a) _).
+    intros t. use total2_paths. apply funextfun. intros x.
+    apply isconnectedunit.
+    apply proofirrelevance. apply isapropismonoidfun.
+  Defined.
+
+
+  (** The following lemmas verify that the above definition behaves as
+    expected. *)
+  Lemma ABGR_has_zero_ob : ZeroObject (ABGR_has_zero) = ABGR_zero.
+  Proof.
+    apply idpath.
+  Qed.
+
+  Lemma ABGR_has_zero_from ( A : abgr ) :
+    @ZeroArrowFrom ABGR ABGR_has_zero A = ABGR_zero_to A.
+  Proof.
+    apply idpath.
+  Qed.
+
+  Lemma ABGR_has_zero_to (A : abgr ) :
+    @ZeroArrowTo ABGR ABGR_has_zero A = ABGR_zero_from A.
+  Proof.
+    apply idpath.
+  Qed.
+
+End ABGR_zero.
+
+
+(** ** ABGR is PreAdditive
+  In the following section we prove that the category of abelian groups is
+  preadditive. *)
+Section ABGR_preadditive.
+
+  (** Cancellation of binary operation from left and from right. *)
+  Lemma cancel_lop (X : setwithbinop) (x y z : X) :
+    x = y -> @op X z x = @op X z y.
+  Proof.
+    intros e. induction e. apply idpath.
+  Qed.
+
+  Lemma cancel_rop (X : setwithbinop) (x y z : X) :
+    x = y -> @op X x z = @op X y z.
+  Proof.
+    intros e. induction e. apply idpath.
+  Qed.
+
+  (** The binop structure on the category of abelian groups. *)
+  Definition ABGR_hombinop (X Y : ABGR) :
+    ABGR⟦X, Y⟧ -> ABGR⟦X, Y⟧ -> ABGR⟦X, Y⟧.
+  Proof.
+    intros f g.
+    use monoidfunconstr.
+    exact (fun x : (abgrtoabmonoid X) =>
+             @op (abgrtoabmonoid Y) ((pr1 f) x) ((pr1 g) x)).
+    split.
+
+    intros x x'.
+    rewrite (pr1 (pr2 f)). rewrite (pr1 (pr2 g)).
+    repeat rewrite <- (assocax (abgrtoabmonoid Y)). apply cancel_rop.
+    repeat rewrite (assocax (abgrtoabmonoid Y)). apply cancel_lop.
+    apply (pr2 (pr2 Y)).
+
+    rewrite (pr2 (pr2 f)). rewrite (pr2 (pr2 g)).
+    apply (runax (abgrtoabmonoid Y)).
+  Defined.
+
+  (** The morphism which maps everything to unit element.
+    This is actually the zero morphism. *)
+  Definition ABGR_hombinop_unel (X Y : ABGR) : ABGR⟦X, Y⟧.
+  Proof.
+    use monoidfunconstr.
+    exact (fun x : (pr1 X) => unel (abgrtoabmonoid Y)).
+    split.
+
+    intros x x'. apply pathsinv0. apply (runax (abgrtoabmonoid Y)).
+    apply idpath.
+  Defined.
+
+  (** Verification of the unit axioms for the above morphism. *)
+  Definition ABGR_hombinop_runax (X Y : ABGR) (f : ABGR⟦X, Y⟧) :
+    ABGR_hombinop X Y f (ABGR_hombinop_unel X Y) = f.
+  Proof.
+    use total2_paths. cbn. apply funextfun. intros x.
+    rewrite (runax (abgrtoabmonoid Y)). apply idpath.
+
+    apply proofirrelevance. apply isapropismonoidfun.
+  Qed.
+
+
+  Definition ABGR_hombinop_lunax (X Y : ABGR) (f : ABGR⟦X, Y⟧) :
+    ABGR_hombinop X Y (ABGR_hombinop_unel X Y) f = f.
+  Proof.
+    use total2_paths. cbn. apply funextfun. intros x.
+    rewrite (lunax (abgrtoabmonoid Y)). apply idpath.
+
+    apply proofirrelevance. apply isapropismonoidfun.
+  Qed.
+
+  (** Commutativity of the binary operation. *)
+  Definition ABGR_hombinop_comm (X Y : ABGR) :
+    ∀ (f g : ABGR⟦X, Y⟧),
+      @ABGR_hombinop X Y f g = @ABGR_hombinop X Y g f.
+  Proof.
+    intros f g. use total2_paths. cbn. apply funextfun. intros x.
+    rewrite (pr2 (pr2 Y)). apply idpath.
+
+    apply proofirrelevance. apply isapropismonoidfun.
+  Defined.
+
+  (** How operation behaves under the inverse function. *)
+  Lemma grinvcomp (Y : gr) :
+    ∀ y1 y2 : Y, grinv Y (@op Y y1 y2) = @op Y (grinv Y y2) (grinv Y y1).
+  Proof.
+    intros y1 y2.
+    apply (grrcan Y y1).
+    rewrite (assocax Y). rewrite (grlinvax Y). rewrite (runax Y).
+    apply (grrcan Y y2).
+    rewrite (grlinvax Y). rewrite (assocax Y). rewrite (grlinvax Y).
+    apply idpath.
+  Qed.
+
+
+  (** Construction of the inverse function in the category of abelian groups. *)
+  Definition ABGR_hombinop_inv (X Y : ABGR) : ABGR⟦X, Y⟧ -> ABGR⟦X, Y⟧.
+  Proof.
+    intros f.
+    use monoidfunconstr.
+    exact (fun x : (abgrtoabmonoid X) => grinv (abgrtogr Y) ((pr1 f) x)).
+    split.
+
+    intros x x'.
+    rewrite (pr1 (pr2 f)). rewrite (pr2 (pr2 Y)).
+    rewrite (grinvcomp (abgrtogr Y)).
+    apply idpath.
+
+    rewrite (pr2 (pr2 f)).
+    apply (grinvunel (abgrtogr Y)).
+  Defined.
+
+  (** Verification that this gives left and right inverse. *)
+  Definition ABGR_hombinop_linvax (X Y : ABGR) :
+    ∀ f : ABGR⟦X, Y⟧, ABGR_hombinop X Y (ABGR_hombinop_inv X Y f) f
+                      = ABGR_hombinop_unel X Y.
+  Proof.
+    intros f. use total2_paths. cbn. apply funextfun. intros x.
+    apply (grlinvax (abgrtogr Y)).
+
+    apply proofirrelevance. apply isapropismonoidfun.
+  Qed.
+
+
+  Definition ABGR_hombinop_rinvax (X Y : ABGR) :
+    ∀ f : ABGR⟦X, Y⟧, ABGR_hombinop X Y f (ABGR_hombinop_inv X Y f)
+                      = ABGR_hombinop_unel X Y.
+  Proof.
+    intros f. use total2_paths. cbn. apply funextfun. intros x.
+    apply (grrinvax (abgrtogr Y)).
+
+    apply proofirrelevance. apply isapropismonoidfun.
+  Qed.
+
+  (** Associativity of the binary operation. *)
+  Definition ABGR_hombinop_assoc (X Y : ABGR) (f g h : ABGR⟦X, Y⟧) :
+    ABGR_hombinop X Y f (ABGR_hombinop X Y g h) =
+    ABGR_hombinop X Y (ABGR_hombinop X Y f g) h.
+  Proof.
+    use total2_paths. cbn. apply funextfun. intros x.
+    rewrite (assocax (abgrtoabmonoid Y)).
+    apply idpath.
+
+    apply proofirrelevance. apply isapropismonoidfun.
+  Defined.
+
+  (** WithBinOpsData *)
+  Definition ABGR_WithBinOpsData : PrecategoryWithBinOpsData ABGR.
+  Proof.
+    unfold PrecategoryWithBinOpsData.
+    intros X Y.
+    exact (ABGR_hombinop X Y).
+  Defined.
+
+  Definition ABGR_WithBinOps : PrecategoryWithBinOps
+    := tpair _ ABGR ABGR_WithBinOpsData.
+
+  (** WithAbgrops *)
+  Definition ABGR_WithAbGrops : PrecategoryWithAbgrops.
+  Proof.
+    use (mk_PrecategoryWithAbgrops ABGR_WithBinOps has_homsets_ABGR).
+    intros X Y.
+    split.
+
+    use isgroppair.
+    split.
+
+    (* Associativity *)
+    intros x y z.
+    apply pathsinv0. apply ABGR_hombinop_assoc.
+
+    (* Unit *)
+    use isunitalpair.
+    apply ABGR_hombinop_unel.
+    split.
+    unfold islunit. intros x. apply (ABGR_hombinop_lunax X Y).
+    unfold isrunit. intros x. apply (ABGR_hombinop_runax X Y).
+
+    (* invstruct *)
+    use tpair.
+    exact (ABGR_hombinop_inv X Y).
+    cbn.
+    split.
+    intros f.
+    apply ABGR_hombinop_linvax.
+    intros f.
+    apply ABGR_hombinop_rinvax.
+
+    (* Commutativity *)
+    intros f g. apply (ABGR_hombinop_comm X Y f g).
+  Defined.
+
+  (** Finally, we prove that the category of abelian groups is preadditive. *)
+  Definition ABGR_PreAdditive : PreAdditive.
+  Proof.
+    use mk_PreAdditive.
+    exact (ABGR_WithAbGrops).
+
+    use mk_isPreAdditive.
+
+    (* First bilinearity. *)
+    intros X Y Z f.
+    split.
+
+    intros g h.
+    unfold PrecategoryWithAbgrops_premor.
+    use total2_paths. cbn. apply funextfun.
+    intros x. unfold funcomp. apply idpath.
+    apply proofirrelevance. apply isapropismonoidfun.
+
+    unfold PrecategoryWithAbgrops_premor.
+    use total2_paths. cbn. apply funextfun.
+    intros x. unfold funcomp. apply idpath.
+    apply proofirrelevance. apply isapropismonoidfun.
+
+    (* Second bilinearity. *)
+    intros X Y Z f.
+    split.
+
+    intros g h.
+    unfold PrecategoryWithAbgrops_premor.
+    use total2_paths. cbn. apply funextfun.
+    intros x. unfold funcomp. rewrite (pr1 (pr2 f)) . apply idpath.
+    apply proofirrelevance. apply isapropismonoidfun.
+
+    unfold PrecategoryWithAbgrops_premor.
+    use total2_paths. cbn. apply funextfun.
+    intros x. unfold funcomp. apply (pr2 (pr2 f)).
+    apply proofirrelevance. apply isapropismonoidfun.
+  Defined.
+End ABGR_preadditive.
+
+
+(** ** ABGR is Additive
+  In the following section we prove that the category of abelian groups is an
+  additive category.
+ *)
+Section ABGR_Additive.
+
+  (** Some lemmas useful to direct sums in the category of abelian groups. *)
+  Lemma ABGR_DirectSumPr1 (A B : abgr) : ABGR⟦abgrdirprod A B, A⟧.
+  Proof.
+    use monoidfunconstr. intros X. exact (pr1 X).
+    unfold ismonoidfun. split.
+    unfold isbinopfun. intros x x'. unfold op at 1. cbn. apply idpath.
+    cbn. apply idpath.
+  Defined.
+
+  Lemma ABGR_DirectSumPr2 (A B : abgr) : ABGR⟦abgrdirprod A B, B⟧.
+  Proof.
+    use monoidfunconstr. intros X. exact (pr2 X).
+    unfold ismonoidfun. split.
+    unfold isbinopfun. intros x x'. unfold op at 1. cbn. apply idpath.
+    cbn. apply idpath.
+  Defined.
+
+  Lemma ABGR_DirectSumIn1 (A B : abgr) : ABGR⟦A, abgrdirprod A B⟧.
+  Proof.
+    use monoidfunconstr. intros a. exact (dirprodpair a (unel B)).
+    unfold ismonoidfun. split.
+    unfold isbinopfun. intros x x'.
+    use dirprodeq. apply idpath. cbn.
+    apply pathsinv0. apply (runax B).
+    unfold dirprodpair. use total2_paths; apply idpath.
+  Defined.
+
+  Lemma ABGR_DirectSumIn2 (A B : abgr) : ABGR⟦B, abgrdirprod A B⟧.
+  Proof.
+    use monoidfunconstr. intros b. exact (dirprodpair (unel A) b).
+    unfold ismonoidfun. split.
+
+    unfold isbinopfun. intros x x'.
+    use dirprodeq. cbn. apply pathsinv0. apply (runax A). apply idpath.
+
+    unfold dirprodpair. use total2_paths; apply idpath.
+  Defined.
+
+  Lemma ABGR_DirectSumIdIn1 (A B : abgr) :
+    ABGR_DirectSumIn1 A B ;; ABGR_DirectSumPr1 A B = idabgrfun A.
+  Proof.
+    use total2_paths. cbn. use funextfun. intros x. apply idpath.
+
+    apply proofirrelevance. apply isapropismonoidfun.
+  Qed.
+
+  Lemma ABGR_DirectSumIdIn2 (A B : abgr) :
+    ABGR_DirectSumIn2 A B ;; ABGR_DirectSumPr2 A B = idabgrfun B.
+  Proof.
+    use total2_paths. cbn. use funextfun. intros x. apply idpath.
+
+    apply proofirrelevance. apply isapropismonoidfun.
+  Qed.
+
+  Lemma ABGR_DirectSumUnel1 (A B : abgr) :
+    ABGR_DirectSumIn1 A B ;; ABGR_DirectSumPr2 A B = ABGR_hombinop_unel A B.
+  Proof.
+    use total2_paths. cbn. use funextfun. intros x. apply idpath.
+
+    apply proofirrelevance. apply isapropismonoidfun.
+  Qed.
+
+  Lemma ABGR_DirectSumUnel2 (A B : abgr) :
+    ABGR_DirectSumIn2 A B ;; ABGR_DirectSumPr1 A B = ABGR_hombinop_unel B A.
+  Proof.
+    use total2_paths. cbn. use funextfun. intros x. apply idpath.
+
+    apply proofirrelevance. apply isapropismonoidfun.
+  Qed.
+
+  Lemma ABGR_DirectSumId (A B : abgr) :
+    ABGR_hombinop _ _ (ABGR_DirectSumPr1 A B ;; ABGR_DirectSumIn1 A B)
+                  (ABGR_DirectSumPr2 A B ;; ABGR_DirectSumIn2 A B)
+    = idabgrfun _.
+  Proof.
+    use total2_paths. cbn. use funextfun. intros x.
+    apply dirprodeq. apply (runax A). apply (lunax B).
+
+    apply proofirrelevance. apply isapropismonoidfun.
+  Qed.
+
+  (** A proof that the category of abelian groups is an additive category. *)
+  Definition ABGR_Additive : Additive.
+  Proof.
+    use mk_Additive.
+    exact (ABGR_PreAdditive).
+    use mk_isAdditive.
+    apply ABGR_has_zero.
+
+    intros X Y.
+    use BinDirectSums.mk_BinDirectSumCone.
+    exact (abgrdirprod X Y).
+    exact (ABGR_DirectSumIn1 _ _).
+    exact (ABGR_DirectSumIn2 _ _).
+    exact (ABGR_DirectSumPr1 _ _).
+    exact (ABGR_DirectSumPr2 _ _).
+
+    use BinDirectSums.mk_isBinDirectSumCone.
+
+    (* BinProduct *)
+    use (bincoproducts.mk_isBinCoproductCocone _ has_homsets_ABGR).
+    intros Z f g.
+
+    use (unique_exists); cbn.
+
+    (* Construction of the morphism from X ⊕ Y to Z. *)
+    use monoidfunconstr.
+    exact (pr1( ABGR_hombinop _ _ (ABGR_DirectSumPr1 X Y ;; f)
+                              (ABGR_DirectSumPr2 X Y ;; g))).
+    split.
+    intros x x'. cbn. unfold funcomp. cbn.
+    rewrite (pr1 (pr2 f)). rewrite (pr1 (pr2 g)).
+    repeat rewrite <- (assocax (abgrtoabmonoid Z)). apply cancel_rop.
+    repeat rewrite (assocax (abgrtoabmonoid Z)). apply cancel_lop.
+    apply (pr2 (pr2 Z)).
+
+    cbn. unfold funcomp. cbn.
+    set (HH := pr2 (pr2 f)). cbn in HH. rewrite -> HH.
+    set (HHg := pr2 (pr2 g)). cbn in HHg. rewrite HHg.
+    apply (runax (abgrtoabmonoid Z)).
+
+    (* Commutativity of the morphism. *)
+    split.
+
+    use total2_paths. cbn. apply funextfun. intros x.
+    unfold funcomp. cbn. set (HHg := pr2 (pr2 g)). cbn in HHg. rewrite HHg.
+    apply (runax (abgrtoabmonoid Z)).
+    apply proofirrelevance. apply isapropismonoidfun.
+
+    use total2_paths. cbn. apply funextfun. intros x.
+    unfold funcomp. cbn. set (HHf := pr2 (pr2 f)). cbn in HHf. rewrite HHf.
+    apply (lunax (abgrtoabmonoid Z)).
+    apply proofirrelevance. apply isapropismonoidfun.
+
+    (* Equality on equality of homsets *)
+    intros y. apply isapropdirprod; apply has_homsets_ABGR.
+
+    (* Uniqueness *)
+    intros y z. use total2_paths. cbn. apply funextfun. intros x.
+    unfold funcomp. rewrite <- (idabgrfun_remove_left _ _ y).
+    rewrite <- (ABGR_DirectSumId X Y). cbn. unfold funcomp.
+    rewrite <- (dirprod_pr1 z). rewrite <- (dirprod_pr2 z).
+    cbn. unfold funcomp.
+    rewrite (runax (abgrtoabmonoid X)). rewrite (lunax (abgrtoabmonoid Y)).
+    rewrite <- (pr1 (pr2 y)). cbn.
+    rewrite (runax (abgrtoabmonoid X)). rewrite (lunax (abgrtoabmonoid Y)).
+    apply idpath.
+
+    apply proofirrelevance. apply isapropismonoidfun.
+
+
+    (* BinCoproduct *)
+    use (binproducts.mk_isBinProductCone _ has_homsets_ABGR).
+    intros Z f g.
+
+    use (unique_exists); cbn.
+
+    (* Construction of the morphism from Z to X ⊕ Y. *)
+    use monoidfunconstr.
+    exact (pr1( ABGR_hombinop _ _ (f ;; ABGR_DirectSumIn1 X Y)
+                              (g ;; ABGR_DirectSumIn2 X Y))).
+    split.
+    intros x x'. cbn. apply dirprodeq.
+
+    cbn. repeat rewrite (runax (abgrtoabmonoid X)).
+    rewrite (pr1 (pr2 f)). apply idpath.
+
+    cbn. repeat rewrite (lunax (abgrtoabmonoid Y)).
+    rewrite (pr1 (pr2 g)). apply idpath.
+
+
+    apply dirprodeq.
+    cbn. set (HHf := pr2 (pr2 f)). cbn in HHf. rewrite HHf.
+    apply (runax (abgrtoabmonoid X)).
+
+    cbn. set (HHg := pr2 (pr2 g)). cbn in HHg. rewrite HHg.
+    apply (lunax (abgrtoabmonoid Y)).
+
+    (* Commutativity of the morphism. *)
+    split.
+
+    use total2_paths. cbn. apply funextfun. intros x.
+    unfold funcomp. cbn. rewrite (runax (abgrtoabmonoid X)). apply idpath.
+    apply proofirrelevance. apply isapropismonoidfun.
+
+    use total2_paths. cbn. apply funextfun. intros x.
+    unfold funcomp. cbn. rewrite (lunax (abgrtoabmonoid Y)). apply idpath.
+    apply proofirrelevance. apply isapropismonoidfun.
+
+    (* Equality on equality of homsets *)
+    intros y. apply isapropdirprod; apply has_homsets_ABGR.
+
+    (* Uniqueness *)
+    intros y z. use total2_paths. cbn. apply funextfun. intros x.
+    rewrite <- (idabgrfun_remove_right _ _ y).
+    rewrite <- (ABGR_DirectSumId X Y). cbn.
+    rewrite <- (dirprod_pr1 z). rewrite <- (dirprod_pr2 z). cbn.
+    apply idpath.
+
+    apply proofirrelevance. apply isapropismonoidfun.
+
+    (* Id1 *)
+    use total2_paths. apply funextfun. intros x. cbn. apply idpath.
+    apply proofirrelevance. apply isapropismonoidfun.
+
+    (* Id2 *)
+    use total2_paths. apply funextfun. intros x. cbn. apply idpath.
+    apply proofirrelevance. apply isapropismonoidfun.
+
+    (* Unit1 *)
+    use total2_paths. apply funextfun. intros x. cbn. apply idpath.
+    apply proofirrelevance. apply isapropismonoidfun.
+
+    (* Unit2 *)
+    use total2_paths. apply funextfun. intros x. cbn. apply idpath.
+    apply proofirrelevance. apply isapropismonoidfun.
+
+    (* ID *)
+    use total2_paths. apply funextfun. intros x. induction x.
+    cbn. apply dirprodeq. cbn. apply (runax (abgrtoabmonoid X)).
+    cbn. apply (lunax (abgrtoabmonoid Y)).
+    apply proofirrelevance. apply isapropismonoidfun.
+  Defined.
+End ABGR_Additive.
+
+Section ABGR_kernels.
+
+  (** hsubtypes for forming the subgroups kernel and image. This is needed to use
+      the relevant results in Algebra/Monoid_and_Groups.v . *)
+  Definition ABGR_kernel_hsubtype {A B : abgr} (f : monoidfun A B) : hsubtypes A
+    := (fun x : A => ishinh ((f x) = unel B)).
+
+  Definition ABGR_image_hsubtype {A B : abgr} (f : monoidfun A B) : hsubtypes B
+    := (fun y : B => ∃ x : A, (f x) = y).
+
+
+  (** Construction of the kernel of f. *)
+  Definition ABGR_kernel_subabgr {A B : abgr} (f : monoidfun A B) : @subabgrs A.
+  Proof.
+    use subgrconstr.
+    exact (@ABGR_kernel_hsubtype A B f).
+    cbn. split.
+
+    (* issubmonoid *)
+    split.
+
+    intros a a'.  induction a as [a1 a2]. induction a' as [a'1 a'2].
+    cbn in *. rewrite (pr1 (pr2 f)). unfold ishinh_UU in *.
+    intros P X. apply (a2 P). intros a3. apply (a'2 P). intros a'3. apply X.
+    cbn in *. rewrite a3. rewrite a'3. apply (runax (abgrtoabmonoid B)).
+
+    intros P X. apply X. cbn in *. rewrite <- (pr2 (pr2 f)).
+    apply idpath.
+
+    (* inverse *)
+    intros x a.
+    unfold ABGR_kernel_hsubtype in *.
+    rewrite (monoidfuninvtoinv f x).
+    cbn in *.
+    unfold ishinh_UU in *. intros P X. apply a. intros X1.
+    rewrite -> X1 in X. apply X. apply (grinvunel B).
+  Defined.
+
+  (** Construction of the morphism from the kernel of A to A. *)
+  Definition ABGR_kernel_monoidfun {A B : abgr} (f : monoidfun A B) :
+    ABGR⟦carrierofasubabgr (ABGR_kernel_subabgr f), A⟧.
+  Proof.
+    use monoidincltomonoidfun.
+    use monoidmonopair.
+    use inclpair.
+    unfold ABGR_kernel_subabgr. cbn. apply pr1carrier. apply isinclpr1carrier.
+
+    (* ismonoidfun *)
+    split.
+    cbn. intros a a'. cbn. apply idpath.
+    cbn. apply idpath.
+  Defined.
+
+  (** Construction of the image of f. *)
+  Definition ABGR_image {A B : abgr} (f : monoidfun A B) : @subabgrs B.
+  Proof.
+    unfold subabgrs.
+    use subgrconstr.
+    exact (@ABGR_image_hsubtype A B f).
+    cbn. split.
+
+    (* issubmonoid *)
+    split.
+
+    intros a a'.  induction a as [a1 a2]. induction a' as [a'1 a'2].
+    cbn in *.  unfold ishinh_UU in *.
+    intros P X. apply (a2 P). intros a3. apply (a'2 P). intros a'3. apply X.
+    cbn in *. use tpair.  induction a3. induction a'3.
+    apply (op t t0). cbn. unfold total2_rect.
+    induction a3. induction a'3. rewrite (pr1 (pr2 f)). cbn in *.
+    rewrite p. rewrite p0. apply idpath.
+
+    intros P X. apply X. use tpair. exact (unel A). cbn.
+    rewrite <- (pr2 (pr2 f)). apply idpath.
+
+    (* inverse *)
+    intros x a.
+    unfold ABGR_image_hsubtype in *. unfold ishinh in *. cbn in *.
+    unfold ishinh_UU in *. intros P X. apply a. intros X1. apply X.
+    induction X1. use tpair. apply (grinv A t). cbn.
+    set (XXt := monoidfuninvtoinv f t). cbn in XXt.
+    rewrite XXt. rewrite p. apply idpath.
+  Defined.
+
+  (** The eqrel on B used to form the quotient group of the cokernel of f *)
+  Definition ABGR_cokernel_eqrel {A B : abgr} (f : monoidfun A B) : eqrel B.
+  Proof.
+    use eqrelconstr.
+
+    (* The relation *)
+    exact (fun b1 : B => fun b2 : B => ∃ a : A, (f a) = (op b1 (grinv B b2))).
+
+    (* Transitivity *)
+    intros x1 x2 x3 y1 y2.
+    unfold ishinh in *. cbn in *. unfold ishinh_UU in *. intros P X.
+    apply y1. intros Y1. apply y2. intros Y2. induction Y1, Y2. apply X.
+    refine (tpair _ (op t t0) _). rewrite (pr1 (pr2 f)). cbn in *.
+    rewrite p. rewrite p0.
+
+    rewrite <- (assocax (abgrtoabmonoid B)).
+    rewrite (assocax (abgrtoabmonoid B) x1 _ _).
+    rewrite (grlinvax B). rewrite (runax B).
+    apply idpath.
+
+    (* Reflexivity *)
+    intros x1 y1 y2. apply y2. refine (tpair _ (unel A) _).
+    rewrite (grrinvax B). rewrite <- (pr2 (pr2 f)). apply idpath.
+
+    (* Symmetry *)
+    intros x1 x2 x3 y1 y2.
+    unfold ishinh in *. cbn in *. unfold ishinh_UU in *. apply x3.
+    intros X3. apply y2. induction X3. refine (tpair _ (grinv A t) _).
+    set (XXf := (grinvandmonoidfun A B (pr2 f) t)). cbn in XXf.
+    rewrite XXf. rewrite p.
+    set (XXB := grinvcomp B x1 (grinv B x2)). cbn in XXB.
+    rewrite XXB. rewrite grinvinv. apply idpath.
+  Defined.
+
+  (** Construction of the cokernel of f. We need to take the quotient group of
+    B by the image of f. *)
+  Definition ABGR_cokernel_abgr {A B : abgr} (f : monoidfun A B) : abgr.
+  Proof.
+    use (@abgrquot B).
+    use binopeqrelpair.
+
+    exact (ABGR_cokernel_eqrel f).
+
+    (* isbinoprel *)
+    cbn. use isbinophrelif. apply (pr2 (pr2 B)).
+    intros x1 x2 x3 y1. cbn in *. unfold ishinh_UU in *. intros P X.
+    apply y1. intros Y1. induction Y1. apply X.
+    refine (tpair _ t _). rewrite p. rewrite ((pr2 (pr2 B)) x3 _).
+    rewrite (assocax B). apply cancel_lop. rewrite ((pr2 (pr2 B)) x3 _).
+    rewrite grinvcomp. rewrite (assocax B). rewrite (grlinvax B).
+    rewrite (runax B). apply idpath.
+  Defined.
+
+  (** Construction of the monoidfun from B to the cokernel of f *)
+  Definition ABGR_cokernel_monoidfun {A B : abgr} (f : monoidfun A B) :
+    ABGR⟦B, ABGR_cokernel_abgr f⟧.
+  Proof.
+    use monoidfunconstr.
+    use (setquotpr (ABGR_cokernel_eqrel f)).
+
+    (* ismonoidfun*)
+    split. split. apply idpath.
+  Defined.
+
+
+
+
+  (** ** I'M STUCK HERE.
+         I cannot prove the following equality. The equality is needed in the
+         proof that ABGR_kernel_monoidfun is the kernel of f. *)
+
+
+  (** Proof that composing (ABGR_kernel_monoidfun f) with f yields a Zero
+    Arrow. *)
+  Definition ABGR_kernel_eq {A B : abgr} (f : monoidfun A B) :
+    (ABGR_kernel_monoidfun f) ;; f =
+    (ABGR_kernel_monoidfun f) ;; (ZeroArrow ABGR ABGR_has_zero A B).
+  Proof.
+    use total2_paths. cbn. apply funextfun. unfold funcomp, pr1carrier.
+    intros x. induction x. cbn in *. unfold ishinh_UU in p.
+
+    (* The goal should be an hProp so that we could apply p. *)
+    try apply (p (pr1 f t = 1%multmonoid)).
+  Abort.
+
+End ABGR_kernels.

--- a/UniMath/CategoryTheory/category_abgr.v
+++ b/UniMath/CategoryTheory/category_abgr.v
@@ -1,4 +1,25 @@
-(* The category abelian groups. *)
+(** * Category of abelian groups *)
+(** ** Contents
+- Definition of the category of abelian groups, ABGR
+- Iso and monoidiso are weakly equivalent
+- General results (TODO: find a place for these )
+- Zero object and Zero arrow
+ - Zero object
+ - Zero arrow
+- ABGR is PreAdditive
+- ABGR is Additive
+- Kernels and Cokernels
+ - Kernels
+ - Cokernels
+- Monics are inclusions and Epis are surjections
+ - Preliminaries
+ - Epis are surjections
+ - Monics are inclusions
+- Monics are Kernels and Epis are Cokernels
+ - Monics are Kernels
+ - Epis are Cokernels
+- ABGR is Abelian_precategory
+*)
 Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.Foundations.Basics.Propositions.
 Require Import UniMath.Foundations.Basics.Sets.
@@ -32,9 +53,12 @@ Require Import UniMath.CategoryTheory.limits.kernels.
 Require Import UniMath.CategoryTheory.limits.cokernels.
 Require Import UniMath.CategoryTheory.limits.BinDirectSums.
 
-(** In this section we construct the category of abelian groups. *)
+
+(** * Definition of the category of abelian groups
+  In this section we define the category of abelian groups. *)
 Section ABGR_precategory.
 
+  (** Objects are abgr and morphisms are monoidfun. *)
   Definition abgr_fun_space (A B : abgr) : hSet :=
     hSetpair _ (isasetmonoidfun A B).
 
@@ -50,6 +74,7 @@ Section ABGR_precategory.
     apply idpath.
   Qed.
 
+  (** Identity morphism. *)
   Definition idabgrfun (A : abgr) : monoidfun A A
     := monoidfunconstr (idabgrfun_ismonoidfun A).
 
@@ -69,6 +94,7 @@ Section ABGR_precategory.
     apply proofirrelevance. apply isapropismonoidfun.
   Qed.
 
+  (** Associativity. *)
   Definition abmonoidfuncomp_assoc (A B C D : abmonoid) (f : monoidfun A B)
              (g : monoidfun B C) (h : monoidfun C D) :
     monoidfuncomp (monoidfuncomp f g) h = monoidfuncomp f (monoidfuncomp g h).
@@ -85,6 +111,7 @@ Section ABGR_precategory.
     apply isapropismonoidfun.
   Qed.
 
+  (** Construction of the precategory ABGR. *)
   Definition abgr_precategory_data : precategory_data :=
     precategory_data_pair abgr_precategory_ob_mor
                           (fun (A : abgr) => idabgrfun A )
@@ -112,11 +139,15 @@ Section ABGR_precategory.
 
 End ABGR_precategory.
 
+
+(** Denote this category by ABGR. *)
 Notation ABGR := abgr_precategory.
 
-Section ABGR_category.
 
-  (** ** Equivalence between isomorphisms and monoidisos *)
+(** * In [ABGR], iso ≃ monoidiso
+  In this section we construct a weak equivalence between isomorphisms in
+  ABGR and monoidisos. *)
+Section ABGR_category.
 
   Lemma abgr_iso_is_equiv (A B : ob ABGR)
         (f : iso A B) : isweq (pr1 (pr1 f)).
@@ -160,7 +191,7 @@ Section ABGR_category.
     use total2_paths. cbn. apply funextfun. intros x.
     apply homotweqinvweq. cbn. apply proofirrelevance.
     apply isapropismonoidfun.
-  Defined.
+  Qed.
 
   Lemma abgr_equiv_iso (A B : ABGR) :
     monoidiso (abgrtoabmonoid A) (abgrtoabmonoid B) -> iso A B.
@@ -195,14 +226,14 @@ Section ABGR_category.
 
     apply proofirrelevance.
     apply isapropismonoidfun.
-  Defined.
+  Qed.
 
   Definition abgr_iso_equiv_weq (A B : ABGR) :
     weq (iso A B) (monoidiso (abgrtoabmonoid A) (abgrtoabmonoid B)).
   Proof.
     exists (abgrp_iso_equiv A B).
     apply abgrp_iso_equiv_is_equiv.
-  Defined.
+  Qed.
 
   Lemma abgr_equiv_iso_is_equiv (A B : ABGR) : isweq (abgr_equiv_iso A B).
   Proof.
@@ -226,7 +257,7 @@ Section ABGR_category.
   Proof.
     exists (abgr_equiv_iso A B).
     apply abgr_equiv_iso_is_equiv.
-  Defined.
+  Qed.
 
 
 (** ** HERE ONE SHOULD ADD A PROOF THAT ABGR IS ACTUALLY A CATEGORY.
@@ -235,14 +266,98 @@ Section ABGR_category.
 End ABGR_category.
 
 
-(** ** Zero object in ABGR
+(** ** General results
+  Move these *)
+Section ABGR_general.
+
+  (** Binop preserves equality. *)
+  Lemma lopeq (X : setwithbinop) (x y z : X) :
+    x = y -> @op X z x = @op X z y.
+  Proof.
+    intros e. induction e. apply idpath.
+  Qed.
+
+  Lemma ropeq (X : setwithbinop) (x y z : X) :
+    x = y -> @op X x z = @op X y z.
+  Proof.
+    intros e. induction e. apply idpath.
+  Qed.
+
+  (** How operation behaves under the inverse function. *)
+  Lemma grinvcomp (Y : gr) :
+    Π y1 y2 : Y, grinv Y (@op Y y1 y2) = @op Y (grinv Y y2) (grinv Y y1).
+  Proof.
+    intros y1 y2.
+    apply (grrcan Y y1).
+    rewrite (assocax Y). rewrite (grlinvax Y). rewrite (runax Y).
+    apply (grrcan Y y2).
+    rewrite (grlinvax Y). rewrite (assocax Y). rewrite (grlinvax Y).
+    apply idpath.
+  Qed.
+
+  (** For some reason coq does not fold unel B automatically. Thus I have
+    used the following equality. *)
+  Definition ABGR_monic_kernel_unel_rw (B : abgr) :
+    unel B = pr1 (pr2 (pr1 (pr1 (pr2 B)))).
+  Proof.
+    apply idpath.
+  Qed.
+
+  (** Monoidfun preserves inverses. *)
+  Definition monoidfun_inv {A B : abgr}
+             (f : monoidfun A B) (a : A) : f (grinv A a) = grinv B (f a).
+  Proof.
+    apply (grlcan B (f a)). rewrite (grrinvax B).
+    use (pathscomp0 (pathsinv0 (((pr1 (pr2 f)) a (grinv A a))))).
+    rewrite (grrinvax A). apply (pr2 (pr2 f)).
+  Qed.
+
+  (** Multiplication of hfibers. *)
+  Definition hfiber_op_eq {A B : abgr} (f : monoidfun A B) (b1 b2 : B)
+             (hf1 : hfiber (pr1 f) b1) (hf2 : hfiber (pr1 f) b2) :
+    pr1 f (pr1 hf1 * pr1 hf2)%multmonoid = (b1 * b2)%multmonoid.
+  Proof.
+    rewrite (pr1 (pr2 f)).
+    rewrite (pr2 hf1).
+    rewrite (pr2 hf2).
+    apply idpath.
+  Qed.
+
+  Definition hfiber_op {A B : abgr} (f : monoidfun A B) (b1 b2 : B)
+             (hf1 : hfiber (pr1 f) b1) (hf2 : hfiber (pr1 f) b2) :
+    hfiber (pr1 f) (b1 * b2)%multmonoid
+    := hfiberpair
+         (pr1 f)
+         ((pr1 hf1) * (pr1 hf2))%multmonoid
+         (hfiber_op_eq f b1 b2 hf1 hf2).
+
+  (** hsubtypes for forming the subgroups kernel and image, and also the
+    quotient group for cokernel. These are needed to use the relevant results
+    in Algebra/Monoid_and_Groups.v . *)
+  Definition ABGR_kernel_hsubtype {A B : abgr} (f : monoidfun A B) : hsubtypes A
+    := (fun x : A => ishinh ((f x) = unel B)).
+
+  Definition ABGR_image_hsubtype {A B : abgr} (f : monoidfun A B) : hsubtypes B
+    := (fun y : B => ∃ x : A, (f x) = y).
+
+  (** An equality we are going to use. *)
+  Definition funeqpaths {X Y : UU} {f g: X -> Y} (e : f = g):
+    Π (x : X), f x = g x.
+  Proof.
+    induction e. intros x. apply idpath.
+  Qed.
+End ABGR_general.
+
+
+(** * Zero object and Zero arrow
   In the following section we prove that the category of abelian groups has
-  a zero object.
- *)
+  a zero object. *)
 Section ABGR_zero.
 
+  (** Hide isabgrop behind Qed. *)
   Definition ABGR_zero_isabgrop :
     isabgrop (pr2 (setwithbinoppair unitset (λ i _ : unitset, i))).
+  Proof.
     unfold isabgrop. split.
 
     use isgroppair. split.
@@ -276,7 +391,7 @@ Section ABGR_zero.
     apply isconnectedunit.
   Qed.
 
-
+  (** Hide ismonoid behind Qed. *)
   Definition ABGR_zero_from_ismonoid (A : abgr) :
     @ismonoidfun A ABGR_zero (fun a : A => (unel ABGR_zero)).
   Proof.
@@ -289,6 +404,7 @@ Section ABGR_zero.
   Definition ABGR_zero_from (A : abgr) : ABGR⟦A, ABGR_zero⟧
     := monoidfunconstr (ABGR_zero_from_ismonoid A).
 
+  (** Hide ismonoid behind Qed. *)
   Definition ABGR_zero_to_ismonoid (A : abgr) :
     @ismonoidfun ABGR_zero A (fun a : _ => (unel A)).
   Proof.
@@ -313,6 +429,7 @@ Section ABGR_zero.
   Definition ABGR_zero_arrow (A B : abgr) : ABGR⟦A, B⟧
     := monoidfunconstr (ABGR_zero_arrow_ismonoid A B).
 
+  (** Hide isZero behind Qed. *)
   Definition ABGR_has_zero_iszero : isZero ABGR ABGR_zero.
   Proof.
     use mk_isZero.
@@ -365,26 +482,11 @@ Section ABGR_zero.
 End ABGR_zero.
 
 
-(** ** ABGR is PreAdditive
-  In the following section we prove that the category of abelian groups is
-  preadditive. *)
+(** * ABGR is PreAdditive
+  In the following section we prove that ABGR is preadditive. *)
 Section ABGR_preadditive.
 
-  (** Cancellation of binary operation from left and from right. *)
-  Lemma cancel_lop (X : setwithbinop) (x y z : X) :
-    x = y -> @op X z x = @op X z y.
-  Proof.
-    intros e. induction e. apply idpath.
-  Qed.
-
-  Lemma cancel_rop (X : setwithbinop) (x y z : X) :
-    x = y -> @op X x z = @op X y z.
-  Proof.
-    intros e. induction e. apply idpath.
-  Qed.
-
-
-
+  (** Hide ismonoidfun behind Qed. *)
   Definition ABGR_hombinop_ismonoidfun {X Y : ABGR} (f g : ABGR⟦X, Y⟧) :
     @ismonoidfun (abgrtoabmonoid X) (abgrtoabmonoid Y)
                  (fun x : pr1 X => (pr1 f x * pr1 g x)%multmonoid).
@@ -393,8 +495,8 @@ Section ABGR_preadditive.
 
     intros x x'.
     rewrite (pr1 (pr2 f)). rewrite (pr1 (pr2 g)).
-    repeat rewrite <- (assocax (abgrtoabmonoid Y)). apply cancel_rop.
-    repeat rewrite (assocax (abgrtoabmonoid Y)). apply cancel_lop.
+    repeat rewrite <- (assocax (abgrtoabmonoid Y)). apply ropeq.
+    repeat rewrite (assocax (abgrtoabmonoid Y)). apply lopeq.
     rewrite (commax (abgrtoabmonoid Y)). apply idpath.
 
     set (tmp := pr2 (pr2 f)). cbn in tmp.  use (pathscomp0 _ tmp).
@@ -413,7 +515,7 @@ Section ABGR_preadditive.
     exact (monoidfunconstr (ABGR_hombinop_ismonoidfun f g)).
   Defined.
 
-  (** Verification of the unit axioms for the above morphism. *)
+  (** Verification of the unit axioms for the above binop. *)
   Definition ABGR_hombinop_runax (X Y : ABGR) (f : ABGR⟦X, Y⟧) :
     ABGR_hombinop X Y f (ABGR_zero_arrow X Y) = f.
   Proof.
@@ -422,7 +524,6 @@ Section ABGR_preadditive.
 
     apply proofirrelevance. apply isapropismonoidfun.
   Qed.
-
 
   Definition ABGR_hombinop_lunax (X Y : ABGR) (f : ABGR⟦X, Y⟧) :
     ABGR_hombinop X Y (ABGR_zero_arrow X Y) f = f.
@@ -442,18 +543,6 @@ Section ABGR_preadditive.
     rewrite (pr2 (pr2 Y)). apply idpath.
 
     apply proofirrelevance. apply isapropismonoidfun.
-  Qed.
-
-  (** How operation behaves under the inverse function. *)
-  Lemma grinvcomp (Y : gr) :
-    Π y1 y2 : Y, grinv Y (@op Y y1 y2) = @op Y (grinv Y y2) (grinv Y y1).
-  Proof.
-    intros y1 y2.
-    apply (grrcan Y y1).
-    rewrite (assocax Y). rewrite (grlinvax Y). rewrite (runax Y).
-    apply (grrcan Y y2).
-    rewrite (grlinvax Y). rewrite (assocax Y). rewrite (grlinvax Y).
-    apply idpath.
   Qed.
 
   Definition ABGR_hombinop_inv_ismonoidfun {X Y : ABGR} (f : ABGR⟦X, Y⟧) :
@@ -490,7 +579,6 @@ Section ABGR_preadditive.
     apply proofirrelevance. apply isapropismonoidfun.
   Qed.
 
-
   Definition ABGR_hombinop_rinvax (X Y : ABGR) :
     Π f : ABGR⟦X, Y⟧, ABGR_hombinop X Y f (ABGR_hombinop_inv X Y f)
                       = ABGR_zero_arrow X Y.
@@ -513,7 +601,7 @@ Section ABGR_preadditive.
     apply proofirrelevance. apply isapropismonoidfun.
   Qed.
 
-  (** WithBinOpsData *)
+  (** ABGR is PrecategoryWithBinOps. *)
   Definition ABGR_WithBinOpsData : PrecategoryWithBinOpsData ABGR.
   Proof.
     intros X Y.
@@ -523,9 +611,7 @@ Section ABGR_preadditive.
   Definition ABGR_WithBinOps : PrecategoryWithBinOps
     := tpair _ ABGR ABGR_WithBinOpsData.
 
-
-
-  (** WithAbgrops *)
+  (** ABGR is PrecategoryWithAbgrops. *)
   Definition ABGR_WithAbGrops : PrecategoryWithAbgrops.
   Proof.
     use (mk_PrecategoryWithAbgrops ABGR_WithBinOps has_homsets_ABGR).
@@ -560,6 +646,7 @@ Section ABGR_preadditive.
     intros f g. apply (ABGR_hombinop_comm X Y f g).
   Defined.
 
+  (** Hide isPreAdditive behind Qed. *)
   Definition ABGR_isPreAdditive : isPreAdditive ABGR_WithAbGrops.
   Proof.
     use mk_isPreAdditive.
@@ -601,14 +688,12 @@ Section ABGR_preadditive.
 End ABGR_preadditive.
 
 
-(** ** ABGR is Additive
+(** * ABGR is Additive
   In the following section we prove that the category of abelian groups is an
-  additive category.
- *)
+  additive category. *)
 Section ABGR_Additive.
 
-  (** Some lemmas useful to direct sums in the category of abelian groups. *)
-
+  (** Verification of the properties of DirectSums. *)
   Lemma ABGR_DirectSumPr1_ismonoidfun (A B : abgr) :
     ismonoidfun (fun X : abgrdirprod A B => dirprod_pr1 X).
   Proof.
@@ -699,7 +784,7 @@ Section ABGR_Additive.
     apply proofirrelevance. apply isapropismonoidfun.
   Qed.
 
-  (** A proof that the category of abelian groups is an additive category. *)
+  (** Hide isAdditive behind Qed. *)
   Definition ABGR_isAdditive : isAdditive ABGR_PreAdditive.
   Proof.
     use (mk_isAdditive ABGR_PreAdditive ABGR_has_zero).
@@ -727,8 +812,8 @@ Section ABGR_Additive.
     split.
     intros x x'. cbn. unfold funcomp. cbn.
     rewrite (pr1 (pr2 f)). rewrite (pr1 (pr2 g)).
-    repeat rewrite <- (assocax (abgrtoabmonoid Z)). apply cancel_rop.
-    repeat rewrite (assocax (abgrtoabmonoid Z)). apply cancel_lop.
+    repeat rewrite <- (assocax (abgrtoabmonoid Z)). apply ropeq.
+    repeat rewrite (assocax (abgrtoabmonoid Z)). apply lopeq.
     apply (pr2 (pr2 Z)).
 
     cbn. unfold funcomp. cbn.
@@ -832,42 +917,28 @@ Section ABGR_Additive.
     use total2_paths. apply funextfun. intros x. cbn. apply idpath.
     apply proofirrelevance. apply isapropismonoidfun.
 
-    (* ID *)
+    (* Id *)
     use total2_paths. apply funextfun. intros x. induction x.
     cbn. apply dirprodeq. cbn. apply (runax (abgrtoabmonoid X)).
     cbn. apply (lunax (abgrtoabmonoid Y)).
     apply proofirrelevance. apply isapropismonoidfun.
   Qed.
 
+  (** Construction of Additive from ABGR. *)
   Definition ABGR_Additive : Additive
     := mk_Additive ABGR_PreAdditive ABGR_isAdditive.
 End ABGR_Additive.
 
 
-(** In the following section we construct Kernels and Cokernels in ABGR. *)
+(** * Kernels and Cokernels
+  In the following section we construct Kernels and Cokernels in ABGR. *)
 Section ABGR_kernels.
 
-  (** hsubtypes for forming the subgroups kernel and image, and also the
-      quotient group for cokernel. These are needed to use the relevant results
-      in Algebra/Monoid_and_Groups.v . *)
-  Definition ABGR_kernel_hsubtype {A B : abgr} (f : monoidfun A B) : hsubtypes A
-    := (fun x : A => ishinh ((f x) = unel B)).
 
-  Definition ABGR_image_hsubtype {A B : abgr} (f : monoidfun A B) : hsubtypes B
-    := (fun y : B => ∃ x : A, (f x) = y).
+  (** ** Kernels *)
 
 
-  (** An equality we are going to use. *)
-  Definition funeqpaths {X Y : UU} {f g: X -> Y} (e : f = g):
-    Π (x : X), f x = g x.
-  Proof.
-    induction e. intros x. apply idpath.
-  Qed.
-
-
-  (*** Kernels *)
-
-
+  (** Shows that kernel of f is a subgroup of f. *)
   Definition ABGR_kernel_subabgr_issubgr {A B : abgr} (f : monoidfun A B) :
     issubgr (ABGR_kernel_hsubtype f).
   Proof.
@@ -893,13 +964,12 @@ Section ABGR_kernels.
     rewrite -> X1 in X. apply X. apply (grinvunel B).
   Qed.
 
-
   (** Construction of the kernel of f. *)
   Definition ABGR_kernel_subabgr {A B : abgr} (f : monoidfun A B) : @subabgrs A
     := subgrconstr (@ABGR_kernel_hsubtype A B f)
                    (ABGR_kernel_subabgr_issubgr f).
 
-
+  (** Hide ismonoidfun behind Qed. *)
   Definition ABGR_kernel_monoidfun_ismonoidfun {A B : abgr}
              (f : monoidfun A B) :
     @ismonoidfun (ABGR_kernel_subabgr f) A
@@ -922,16 +992,19 @@ Section ABGR_kernels.
                                        (ABGR_kernel_hsubtype f)))
                           (ABGR_kernel_monoidfun_ismonoidfun f)).
 
-  (** ABGR Equality for kernels. *)
-  Definition ABGR_kernel_eq {A B : abgr} (f : monoidfun A B) :
-    (ABGR_kernel_monoidfun f) ;; f =
-    (ABGR_kernel_monoidfun f) ;; (ZeroArrow ABGR ABGR_has_zero A B).
+  (** Hide equality for kernel behind Qed. *)
+  Definition ABGR_Kernel_eq {A B : abgr} (f : monoidfun A B) :
+    ABGR_kernel_monoidfun f ;; f
+    = ZeroArrow ABGR ABGR_has_zero
+                (carrierofasubabgr (ABGR_kernel_subabgr f)) B.
   Proof.
-    use total2_paths. cbn. apply funextfun. unfold funcomp, pr1carrier.
-    intros x. induction x. cbn in *. unfold ishinh_UU in p.
-    use (squash_to_prop p). apply (pr2 (pr1 (pr1 B))).
-    intros i. rewrite ABGR_has_zero_to. rewrite ABGR_has_zero_from. cbn.
-    apply i.
+    use total2_paths. apply funextfun. intros x. induction x. cbn.
+    unfold funcomp, pr1carrier. cbn in p. cbn.
+    use (squash_to_prop p). apply (setproperty B).
+    intros X.
+    rewrite ABGR_has_zero_to. cbn.
+    rewrite ABGR_has_zero_from. cbn.
+    exact X.
 
     apply proofirrelevance. apply isapropismonoidfun.
   Qed.
@@ -961,20 +1034,11 @@ Section ABGR_kernels.
     apply proofirrelevance. cbn. apply isapropishinh.
   Defined.
 
-
-  Definition ABGR_Kernel_eq' {A B : abgr} (f : monoidfun A B) :
-    ABGR_kernel_monoidfun f ;; f
-    = ZeroArrow ABGR ABGR_has_zero
-                (carrierofasubabgr (ABGR_kernel_subabgr f)) B.
-  Proof.
-    rewrite (ABGR_kernel_eq f).
-    apply (ZeroArrow_comp_right ABGR ABGR_has_zero).
-  Qed.
-
+  (** Hide isEqualizer behind Qed. *)
   Definition ABGR_Kernel_isEqualizer {A B : abgr} (f : ABGR⟦A, B⟧) :
     isEqualizer f (ZeroArrow ABGR ABGR_has_zero A B)
                 (ABGR_kernel_monoidfun f)
-                (KernelEqRw ABGR_has_zero (ABGR_Kernel_eq' f)).
+                (KernelEqRw ABGR_has_zero (ABGR_Kernel_eq f)).
   Proof.
     induction A. induction B.
     use mk_isEqualizer.
@@ -1011,18 +1075,20 @@ Section ABGR_kernels.
          (ABGR_has_zero)
          (ABGR_kernel_monoidfun f)
          f
-         (ABGR_Kernel_eq' f)
+         (ABGR_Kernel_eq f)
          (ABGR_Kernel_isEqualizer f).
 
   (** As a corollary we get that ABGR has kernels. *)
   Corollary ABGR_kernels : Kernels ABGR_has_zero.
   Proof.
-    intros A B f. apply (ABGR_Kernel f).
+    intros A B f. exact (ABGR_Kernel f).
   Defined.
 
 
-  (*** Cokernels *)
+  (** ** Cokernels *)
 
+
+  (** A proof that the image of f is a subgroup of B. *)
   Definition ABGR_image_issubgr {A B : abgr} (f : monoidfun A B) :
     issubgr (ABGR_image_hsubtype f).
   Proof.
@@ -1057,6 +1123,7 @@ Section ABGR_kernels.
                     (ABGR_image_issubgr f).
 
 
+  (** A construction of an equivalence relation on B. *)
   Definition ABGR_cokernel_eqrel_istrans {A B : abgr} (f : monoidfun A B) :
     istrans (λ b1 b2 : B, ∃ a : A, f a = (b1 * grinv B b2)%multmonoid).
   Proof.
@@ -1091,7 +1158,7 @@ Section ABGR_kernels.
     rewrite XXB. rewrite grinvinv. apply idpath.
   Qed.
 
-  (** The eqrel on B used to form the quotient group of the cokernel of f. *)
+  (** The eqrel on B used to form the cokernel of f. *)
   Definition ABGR_cokernel_eqrel {A B : abgr} (f : monoidfun A B) : eqrel B
     := @eqrelconstr
          B
@@ -1101,6 +1168,7 @@ Section ABGR_kernels.
          (ABGR_cokernel_eqrel_issymm f).
 
 
+  (** Hide isbinoprel behind Qed. *)
   Definition ABGR_cokernel_abgr_isbinoprel {A B : abgr} (f : monoidfun A B) :
     isbinophrel (λ b1 b2 : pr1 B, ∃ a : pr1 A, pr1 f a
                                                = (b1 * grinv B b2)%multmonoid).
@@ -1109,7 +1177,7 @@ Section ABGR_kernels.
     intros x1 x2 x3 y1. cbn in *. unfold ishinh_UU in *. intros P X.
     apply y1. intros Y1. induction Y1. apply X.
     refine (tpair _ t _). rewrite p. rewrite ((pr2 (pr2 B)) x3 _).
-    rewrite (assocax B). apply cancel_lop. rewrite ((pr2 (pr2 B)) x3 _).
+    rewrite (assocax B). apply lopeq. rewrite ((pr2 (pr2 B)) x3 _).
     rewrite grinvcomp. rewrite (assocax B). rewrite (grlinvax B).
     rewrite (runax B). apply idpath.
   Qed.
@@ -1132,29 +1200,21 @@ Section ABGR_kernels.
   Defined.
 
   (** ABGR Equality for cokernels. *)
-  Definition ABGR_cokernel_eq' {A B : abgr} (f : ABGR⟦A, B⟧) :
-    f ;; (ABGR_cokernel_monoidfun f) = ABGR_zero_arrow A (ABGR_cokernel_abgr f).
+  Definition ABGR_cokernel_eq {A B : abgr} (f : ABGR⟦A, B⟧) :
+    f ;; ABGR_cokernel_monoidfun f
+    = ZeroArrow ABGR ABGR_has_zero A (ABGR_cokernel_abgr f).
   Proof.
+    rewrite ABGR_has_zero_arrow_eq.
     use total2_paths. apply funextfun. intros a.
     apply (iscompsetquotpr (ABGR_cokernel_eqrel f)).
     unfold ABGR_cokernel_eqrel.
     intros P X. cbn in *. apply X. refine (tpair _ a _).
     use (pathscomp0 (pathsinv0 (runax B (pr1 f a)))).
-    apply cancel_lop.
+    apply lopeq.
     use (pathscomp0 (pathsinv0 (grinvunel B))).
     apply maponpaths. apply idpath.
 
     apply proofirrelevance. apply isapropismonoidfun.
-  Qed.
-
-  (** ABGR Equality for cokernels. *)
-  Definition ABGR_cokernel_eq {A B : abgr} (f : ABGR⟦A, B⟧) :
-      f ;; (ABGR_cokernel_monoidfun f) =
-      (ZeroArrow ABGR ABGR_has_zero A B) ;; (ABGR_cokernel_monoidfun f).
-  Proof.
-    rewrite ZeroArrow_comp_left.
-    rewrite ABGR_has_zero_arrow_eq.
-    exact (ABGR_cokernel_eq' f).
   Qed.
 
   (** The following result is used to show that map from setquot is a
@@ -1181,7 +1241,8 @@ Section ABGR_kernels.
     rewrite h. unfold funcomp. apply idpath.
   Qed.
 
-
+  (** We show that the function is compatible with the relation. This is used
+    to get the unique CokernelOut map. *)
   Definition ABGR_CokernelArrowOutUniv_iscomprelfun {A B C : ABGR}
              (f : A --> B) (h : B --> C)
              (H : (λ x : pr1 A, (pr1 h) (pr1 f x))
@@ -1212,20 +1273,11 @@ Section ABGR_kernels.
               pr1 f a = (b1 * grinv (abgrtogr B) b2)%multmonoid)
          (pr1 C) (pr1 h) (ABGR_CokernelArrowOutUniv_iscomprelfun f h H).
 
-
-  Definition ABGR_cokernel_eq'' {A B : abgr} (f : ABGR⟦A, B⟧) :
-    f ;; ABGR_cokernel_monoidfun f
-    = ZeroArrow ABGR ABGR_has_zero A (ABGR_cokernel_abgr f).
-  Proof.
-    rewrite ABGR_has_zero_arrow_eq.
-    apply ABGR_cokernel_eq'.
-  Qed.
-
-
+  (** Hide isCoequalizer behind Qed. *)
   Definition ABGR_isCoequalizer {A B : abgr} (f : ABGR⟦A, B⟧) :
     isCoequalizer f (ZeroArrow ABGR ABGR_has_zero A B)
                   (ABGR_cokernel_monoidfun f)
-                  (CokernelEqRw ABGR_has_zero (ABGR_cokernel_eq'' f)).
+                  (CokernelEqRw ABGR_has_zero (ABGR_cokernel_eq f)).
   Proof.
     use mk_isCoequalizer.
     intros w h H'.
@@ -1278,7 +1330,7 @@ Section ABGR_kernels.
          (ABGR_has_zero)
          (ABGR_cokernel_monoidfun f)
          f
-         (ABGR_cokernel_eq'' f)
+         (ABGR_cokernel_eq f)
          (ABGR_isCoequalizer f).
 
   (** As a corollary we get that ABGR has cokernels. *)
@@ -1289,7 +1341,9 @@ Section ABGR_kernels.
 End ABGR_kernels.
 
 
-(*** Monic is an inclusion. *)
+(** * Monics are inclusions and Epis are surjections
+  In this section we show that Monics are inclusions and Epis are surjections
+  in ABGR. *)
 Section ABGR_monics.
 
   (** First we need to construct a monoidfun from hzaddabgr to A to show that
@@ -1301,7 +1355,6 @@ Section ABGR_monics.
     apply (unel A).
     apply (@op A a IHn).
   Defined.
-
 
   Definition ABGR_natset_dirprod_map {A : abgr} (a : A) :
     natset × natset -> A.
@@ -1315,7 +1368,7 @@ Section ABGR_monics.
     ABGR_natset_map a (S n) = (ABGR_natset_map a n * a)%multmonoid.
   Proof.
     induction n. cbn. rewrite (lunax A). apply (runax A).
-    cbn. rewrite (assocax A). apply cancel_lop.
+    cbn. rewrite (assocax A). apply lopeq.
     apply (commax A).
   Qed.
 
@@ -1324,7 +1377,7 @@ Section ABGR_monics.
     = (ABGR_natset_map a n * ABGR_natset_map a m)%multmonoid.
   Proof.
     induction n. rewrite (lunax A). apply idpath. cbn.
-    rewrite (assocax A). apply cancel_lop.
+    rewrite (assocax A). apply lopeq.
     unfold ABGR_natset_map in *. cbn in IHn.
     rewrite IHn. apply idpath.
   Qed.
@@ -1345,8 +1398,8 @@ Section ABGR_monics.
     intros x x'. unfold ABGR_natset_dirprod_map.
     unfold ABGR_natset_map in *. cbn in *.
     rewrite tmp1. rewrite tmp2. unfold dirprod_pr1. unfold dirprod_pr2.
-    repeat rewrite (assocax A). apply cancel_lop.
-    repeat rewrite <- (assocax A). apply cancel_rop.
+    repeat rewrite (assocax A). apply lopeq.
+    repeat rewrite <- (assocax A). apply ropeq.
     apply (commax A).
   Qed.
 
@@ -1416,7 +1469,7 @@ Section ABGR_monics.
     unfold ABGR_natset_dirprod_map. cbn. intros H.
     rewrite (commax A (grinv A a)). rewrite (commax A (grinv A a)).
     rewrite <- (assocax A). rewrite <- (assocax A).
-    apply cancel_rop. apply H.
+    apply ropeq. apply H.
   Qed.
 
   Definition ABGR_integer_map_iscomprelfun {A : abgr} (a : A) :
@@ -1468,6 +1521,7 @@ Section ABGR_monics.
     exact (ABGR_integer_map_iscomprelfun a).
   Defined.
 
+  (** Hide ismonoidfun behind Qed. *)
   Definition ABGR_integer_map_ismonoidfun {A : abgr} (a : A) :
     ismonoidfun (ABGR_integer_map a).
   Proof.
@@ -1498,19 +1552,10 @@ Section ABGR_monics.
     exact (ABGR_integer_map_ismonoidfun a).
   Defined.
 
-  (*** Epis *)
 
+  (** ** Epis *)
 
-  Definition ABGR_cokernel_zero {A B : abgr} (f : ABGR⟦A, B⟧) (b : B)
-             (H : ABGR_cokernel_monoidfun f
-                  = ABGR_zero_arrow B (ABGR_cokernel_abgr f)) :
-    hfiber (pr1 f) b.
-  Proof.
-    unfold ABGR_cokernel_monoidfun in H.
-    unfold ABGR_cokernel_abgr in H.
-  Abort.
-
-
+  (** hfiber (pr1 f) b is inhabited. *)
   Definition ABGR_setquot_iso {A B : abgr} (f : ABGR⟦A, B⟧)
              (isE : isEpi ABGR f) (b : B)
              (H : setquotpr (ABGR_cokernel_eqrel f) b
@@ -1519,17 +1564,16 @@ Section ABGR_monics.
     ∥ hfiber (pr1 f) b ∥ .
   Proof.
     set (tmp := weqpathsinsetquot (ABGR_cokernel_eqrel f) b (unel _)).
-    set (tmp1 := pr1weq (invweq tmp)).
-    set (tmp2 := tmp1 H).
-    unfold ABGR_cokernel_eqrel in tmp2. cbn in tmp2.
+    set (tmp1 := pr1weq (invweq tmp) H).
+    unfold ABGR_cokernel_eqrel in tmp1. cbn in tmp1.
 
-    intros P X. apply tmp2. intros Y. apply X.
-    induction Y.
+    intros P X. apply tmp1. intros Y. apply X. induction Y.
     rewrite grinvunel in p.
     rewrite (runax B) in p.
     apply (hfiberpair (pr1 f) t p).
   Qed.
 
+  (** This result shows that Epis are surjective. *)
   Definition ABGR_epi_issurjective {A B : abgr} (f : ABGR⟦A, B⟧)
              (isE : isEpi ABGR f) :
     issurjective (pr1 f).
@@ -1540,8 +1584,7 @@ Section ABGR_monics.
     assert (H : f ;; ABGR_cokernel_monoidfun f
                 = f ;; ABGR_zero_arrow B (ABGR_cokernel_abgr f)).
     {
-      rewrite ABGR_cokernel_eq'.
-      rewrite <- ABGR_has_zero_arrow_eq.
+      rewrite ABGR_cokernel_eq.
       rewrite <- ABGR_has_zero_arrow_eq.
       rewrite ZeroArrow_comp_right.
       apply idpath.
@@ -1551,36 +1594,17 @@ Section ABGR_monics.
     intros x.
     unfold ABGR_cokernel_monoidfun in tmp1. unfold ABGR_zero_arrow in tmp1.
     cbn in tmp1. apply base_paths in tmp1. cbn in tmp1.
-    assert (Hunel : unel B = pr1 (pr2 (pr1 (pr1 (pr2 B))))).
-    {
-      apply idpath.
-    }
-    rewrite <- Hunel in tmp1.
+    rewrite <- (ABGR_monic_kernel_unel_rw B) in tmp1.
     set (tmp2 := @funeqpaths (pr1 B) (pr1 (ABGR_cokernel_abgr f))).
     set (tmp3 := tmp2 _ _ tmp1). cbn in tmp3.
     apply (ABGR_setquot_iso f isE x (tmp3 x)).
   Qed.
 
 
-  (*** Monics *)
-
-  (** Is this a duplicate? *)
-  Definition ABGR_monoidfun_inv_eq {A B : abgr}
-             (f : monoidfun A B) (a : A) : f (grinv A a) = grinv B (f a).
-  Proof.
-    assert (H : ((f a) * (f (grinv A a)))%multmonoid = 1%multmonoid).
-    {
-      set (tmp := ((pr1 (pr2 f)) a (grinv A a))).
-      cbn in *. apply pathsinv0 in tmp. use (pathscomp0 tmp).
-      rewrite (grrinvax A). apply (pr2 (pr2 f)).
-    }
-
-    apply (grlcan B (f a)). rewrite (grrinvax B).
-    exact H.
-  Qed.
+  (** ** Monics *)
 
   (** The following equalities are needed to prove that Monics are
-     inclusions. *)
+    inclusions. *)
   Lemma ABGR_natset_dirprod_monoidfun_eq {A B : abgr} (a1 a2 : A)
         (f : monoidfun A B) (H : f a1 = f a2) :
     monoidfuncomp (ABGR_natset_dirprod_map_monoidfun a1) f
@@ -1588,29 +1612,34 @@ Section ABGR_monics.
   Proof.
     use total2_paths. cbn. unfold funcomp. apply funextfun.
     intros x. induction x. induction t. induction p.
+
+    (* p = 0 *)
     unfold ABGR_natset_dirprod_map. cbn.
     rewrite (runax A). apply idpath.
 
+    (* Inductive step on p. *)
     unfold ABGR_natset_dirprod_map. cbn.
     rewrite (lunax A). rewrite (lunax A).
     rewrite (pr1 (pr2 f)). rewrite (pr1 (pr2 f)).
     apply (maponpaths (fun h : _ => grinv B h)) in H.
-    rewrite <- (ABGR_monoidfun_inv_eq f a1) in H.
-    rewrite <- (ABGR_monoidfun_inv_eq f a2) in H.
-    cbn in *. rewrite <- H. apply cancel_lop.
+    rewrite <- (monoidfun_inv f a1) in H.
+    rewrite <- (monoidfun_inv f a2) in H.
+    cbn in *. rewrite <- H. apply lopeq.
     unfold ABGR_natset_dirprod_map in IHp. cbn in IHp.
     rewrite (lunax A) in IHp. rewrite (lunax A) in IHp. apply IHp.
 
+    (* Inductive step on t. *)
     unfold ABGR_natset_dirprod_map in *.
     unfold ABGR_natset_map in *. cbn in *.
     rewrite (assocax A). rewrite (assocax A).
     set (tmp := (pr1 (pr2 f))). cbn in tmp.
     rewrite tmp. rewrite (tmp a2). rewrite H.
-    apply cancel_lop. apply IHt.
+    apply lopeq. apply IHt.
 
     apply proofirrelevance. apply isapropismonoidfun.
   Qed.
 
+  (** Precomposing with surjective monoidfun preserves equality. *)
   Lemma ABGR_monoidfun_precomp {A :abmonoid} {B C : abgr}
         (f1 f2 : monoidfun B C) (g : monoidfun A B)
         (H : issurjective (pr1 g)) :
@@ -1629,6 +1658,8 @@ Section ABGR_monics.
     apply proofirrelevance. apply isapropismonoidfun.
   Qed.
 
+  (** Commutativity of the natset_dirprod_map with natset_to_Z and
+    integer_map. *)
   Lemma ABGR_integer_natset_map_comm {A : abgr} (a : A) :
     monoidfuncomp ABGR_natset_to_Z_monoidfun (ABGR_integer_map_monoidfun a)
     = ABGR_natset_dirprod_map_monoidfun a.
@@ -1639,7 +1670,7 @@ Section ABGR_monics.
     apply proofirrelevance. apply isapropismonoidfun.
   Qed.
 
-
+  (** Equality of monoidfun compositions. *)
   Lemma ABGR_integer_map_monoifun_eq {A B : abgr} (a1 a2 : A)
         (f : monoidfun A B) (H : f a1 = f a2) :
     monoidfuncomp (ABGR_integer_map_monoidfun a1) f
@@ -1733,85 +1764,20 @@ Section ABGR_monics.
 End ABGR_monics.
 
 
-(** In this section we prove that Monics are kernels in ABGR. *)
+(** * Monics are Kernels and Epis are Cokernels
+  In this section we prove that Monics are kernels in ABGR. *)
 Section ABGR_monic_kernels.
 
-  (*** Monics *)
+  (** ** Monics *)
 
-  (** For some reason coq does not fold unel B automatically. Thus I have
-      used the following equality. *)
-  Definition ABGR_monic_kernel_unel_rw (B : abgr) :
-    unel B = pr1 (pr2 (pr1 (pr1 (pr2 B)))).
-  Proof.
-    apply idpath.
-  Qed.
 
-  (** Suppose f is a Monic and h is a morphism to the targe of f so that
-      h composed with the cokernel of f is zero, then for any element in the
-      image of h the hfiber consists of exactly of one term. We use this
-      to define the unique map KernelIn which is needed to show that f is the
-      kernel of its cokernel. *)
-  Definition ABGR_monic_kernel_in_hfiber_iscontr {A B : abgr} (f : ABGR⟦A, B⟧)
-             (isM : isMonic ABGR f) (w : abgr) (h: ABGR⟦w, B⟧)
-             (H : h ;; CokernelArrow ABGR_has_zero (ABGR_Cokernel f) =
-                  h ;; ZeroArrow ABGR ABGR_has_zero B (ABGR_Cokernel f)) :
-    Π x : w, iscontr (hfiber (pr1 f) (pr1 h x)).
-  Proof.
-    (* Remember tmp0 this for later use in the proof. *)
-    set (tmp0 := isweqonpathsincl _ (ABGR_monic_isincl f isM)).
-    unfold isInjective in tmp0. cbn in tmp0.
-
-    intros x.
-
-    (* Construction of hfiber for x *)
-    set (tmp := ABGR_monic_isincl f isM).
-    rewrite ZeroArrow_comp_right in H.
-    rewrite ABGR_has_zero_arrow_eq in H.
-    cbn in H. unfold ABGR_zero_arrow in H.
-    apply base_paths in H. cbn in H.
-    rewrite <- ABGR_monic_kernel_unel_rw in H. unfold funcomp in H.
-    set (tmp3 := (weqpathsinsetquot (ABGR_cokernel_eqrel f)
-                                    (pr1 h x) (unel _))).
-    set (tmp4 := pr1weq (invweq tmp3)).
-    set (tmp5 := tmp4 (funeqpaths H x)).
-    cbn in tmp5.
-    rewrite (grinvunel B) in tmp5.
-    rewrite (runax B) in tmp5.
-
-    use (squash_to_prop tmp5). apply isapropiscontr.
-    intros X.
-    apply (iscontrpair (hfiberpair (pr1 f) _ (pr2 X))).
-    intros t.
-    use total2_paths. cbn.
-    set (tmp6 := tmp0 (pr1 t) (pr1 X)). unfold isweq in tmp6.
-
-    assert (e : pr1 f (pr1 t) = pr1 f (pr1 X)).
-    {
-      cbn in *.
-      rewrite (pr2 X).
-      rewrite (pr2 t).
-      apply idpath.
-    }
-    set (tmp7 := tmp6 e). unfold hfiber in tmp7.
-    exact (pr1 (pr1 tmp7)).
-
-    apply proofirrelevance. apply (setproperty B).
-  Qed.
-
-  (** We construct an hfiber for every element in the image of h. *)
-  Definition ABGR_monic_kernel_in_hfiber {A B : abgr} (f : ABGR⟦A, B⟧)
+  (** Construction of ishinh_UU hfiber. *)
+  Definition ABGR_monic_kernel_hfiber_prop {A B : abgr} (f : ABGR⟦A, B⟧)
              (isM : isMonic ABGR f) (w : abgr) (x : w) (h: ABGR⟦w, B⟧)
              (H : h ;; CokernelArrow ABGR_has_zero (ABGR_Cokernel f) =
                   h ;; ZeroArrow ABGR ABGR_has_zero B (ABGR_Cokernel f)) :
-    hfiber (pr1 f) (pr1 h x).
+    ishinh_UU (Σ a : pr1 A, pr1 f a = pr1 h x %multmonoid).
   Proof.
-    (* Need to remember H for later use *)
-    assert (H'' : h ;; CokernelArrow ABGR_has_zero (ABGR_Cokernel f) =
-                  h ;; ZeroArrow ABGR ABGR_has_zero B (ABGR_Cokernel f)).
-    {
-      apply H.
-    }
-
     rewrite ZeroArrow_comp_right in H.
     rewrite ABGR_has_zero_arrow_eq in H.
     cbn in H. unfold ABGR_zero_arrow in H.
@@ -1824,11 +1790,56 @@ Section ABGR_monic_kernels.
     cbn in tmp3.
     rewrite (grinvunel B) in tmp3.
     rewrite (runax B) in tmp3.
-    use (squash_to_prop tmp3).
-    use isapropifcontr.
-    apply (ABGR_monic_kernel_in_hfiber_iscontr f isM w h H'' x).
+    exact tmp3.
+  Qed.
 
-    intros X. apply X.
+  (** Suppose f is a Monic and h is a morphism to the targe of f so that
+    h composed with the cokernel of f is zero, then for any element in the
+    image of h the hfiber consists of exactly of one term. We use this
+    to define the unique map KernelIn which is needed to show that f is the
+    kernel of its cokernel. *)
+  Definition ABGR_monic_kernel_in_hfiber_iscontr {A B : abgr} (f : ABGR⟦A, B⟧)
+             (isM : isMonic ABGR f) (w : abgr) (h: ABGR⟦w, B⟧)
+             (H : h ;; CokernelArrow ABGR_has_zero (ABGR_Cokernel f) =
+                  h ;; ZeroArrow ABGR ABGR_has_zero B (ABGR_Cokernel f)) :
+    Π x : w, iscontr (hfiber (pr1 f) (pr1 h x)).
+  Proof.
+    intros x.
+    use (squash_to_prop (ABGR_monic_kernel_hfiber_prop f isM w x h H)).
+    apply isapropiscontr.
+    intros X.
+    apply (iscontrpair (hfiberpair (pr1 f) (pr1 X) (pr2 X))).
+
+    (* Equality in hfibers *)
+    intros t.
+    use total2_paths. cbn.
+
+    assert (e : pr1 f (pr1 t) = pr1 f (pr1 X)).
+    {
+      cbn. cbn in X, t.
+      rewrite (pr2 X).
+      apply (pr2 t).
+    }
+
+    set (isch := (isweqonpathsincl _ (ABGR_monic_isincl f isM))
+                   (pr1 t) (pr1 X) e).
+    unfold hfiber in isch. unfold iscontr in isch.
+    apply (pr1 (pr1 isch)).
+
+    apply proofirrelevance. apply (setproperty B).
+  Qed.
+
+  (** We construct an hfiber for every element in the image of h. *)
+  Definition ABGR_monic_kernel_in_hfiber {A B : abgr} (f : ABGR⟦A, B⟧)
+             (isM : isMonic ABGR f) (w : abgr) (x : w) (h: ABGR⟦w, B⟧)
+             (H : h ;; CokernelArrow ABGR_has_zero (ABGR_Cokernel f) =
+                  h ;; ZeroArrow ABGR ABGR_has_zero B (ABGR_Cokernel f)) :
+    hfiber (pr1 f) (pr1 h x).
+  Proof.
+    use (squash_to_prop (ABGR_monic_kernel_hfiber_prop f isM w x h H)).
+    apply isapropifcontr.
+    apply (ABGR_monic_kernel_in_hfiber_iscontr f isM w h H x).
+    intros X. exact X.
   Qed.
 
   (** Hide equality behind Qed. *)
@@ -1876,7 +1887,7 @@ Section ABGR_monic_kernels.
                   (ABGR_monic_kernel_in_hfiber_unel_eq f w h).
 
   (** We define the KernelIn as the morphism
-      x : w ↦ pr1 (hfiber (pr1 f) (pr1 h x)) : A . *)
+    x : w ↦ pr1 (hfiber (pr1 f) (pr1 h x)) : A . *)
   Definition ABGR_monic_kernel_in {A B : abgr} (f : ABGR⟦A, B⟧)
              (isM : isMonic ABGR f) (w : abgr) (h: ABGR⟦w, B⟧)
              (H : h ;; CokernelArrow ABGR_has_zero (ABGR_Cokernel f) =
@@ -1887,57 +1898,61 @@ Section ABGR_monic_kernels.
     exact (pr1 (ABGR_monic_kernel_in_hfiber f isM w x h H)).
   Defined.
 
-  (** Here we show that the KernelIn map is a monoidfun. *)
-  Definition ABGR_monic_kernel_in_monoidfun {A B : abgr} (f : ABGR⟦A, B⟧)
+  (** Hide ismonoidfun behind Qed. *)
+  Definition ABGR_monic_kernel_in_ismonoidfun {A B : abgr} (f : ABGR⟦A, B⟧)
              (isM : isMonic ABGR f) (w : abgr) (h: ABGR⟦w, B⟧)
              (H : h ;; CokernelArrow ABGR_has_zero (ABGR_Cokernel f) =
-                   h ;; ZeroArrow ABGR ABGR_has_zero B (ABGR_Cokernel f)) :
-    monoidfun w A.
+                  h ;; ZeroArrow ABGR ABGR_has_zero B (ABGR_Cokernel f)) :
+    ismonoidfun (ABGR_monic_kernel_in f isM w h H).
   Proof.
-    use monoidfunconstr.
-    apply (ABGR_monic_kernel_in f isM w h H).
-
+    unfold ABGR_monic_kernel_in. cbn in *.
     split.
+
+    (* isbinopfun *)
     intros x x'.
-    unfold ABGR_monic_kernel_in.
     set (tmp := ABGR_monic_kernel_in_hfiber_mult
                   f w x x' h
                   (ABGR_monic_kernel_in_hfiber f isM w x h H)
                   (ABGR_monic_kernel_in_hfiber f isM w x' h H)).
-    assert (HH : (ABGR_monic_kernel_in_hfiber f isM w (x * x')%multmonoid h H)
-                 = tmp).
+
+    assert (e : (ABGR_monic_kernel_in_hfiber f isM w (x * x')%multmonoid h H)
+                = tmp).
     {
       set (tmp2 := ABGR_monic_kernel_in_hfiber_iscontr
                      f isM w h H (x * x')%multmonoid).
       unfold iscontr in tmp2. cbn in tmp2.
-      set (tmp3 := (pr2 tmp2) tmp).
-      rewrite tmp3.
-      set (tmp4 := (pr2 tmp2) (ABGR_monic_kernel_in_hfiber
-                                 f isM w (x * x')%multmonoid h H)).
-      rewrite tmp4.
+      rewrite ((pr2 tmp2) tmp).
+      rewrite ((pr2 tmp2) (ABGR_monic_kernel_in_hfiber
+                             f isM w (x * x')%multmonoid h H)).
       apply idpath.
     }
 
-    apply base_paths in HH. use (pathscomp0 HH). unfold tmp.
+    apply base_paths in e. use (pathscomp0 e). unfold tmp.
     unfold ABGR_monic_kernel_in_hfiber_mult. cbn. apply idpath.
 
-    unfold ABGR_monic_kernel_in.
-    assert (HH : (ABGR_monic_kernel_in_hfiber f isM w 1%multmonoid h H)
-                 = (ABGR_monic_kernel_in_hfiber_unel f w h) ).
+    (* preservers units *)
+    assert (e : (ABGR_monic_kernel_in_hfiber f isM w 1%multmonoid h H)
+                = (ABGR_monic_kernel_in_hfiber_unel f w h) ).
     {
       set (tmp2 := ABGR_monic_kernel_in_hfiber_iscontr
                      f isM w h H 1%multmonoid).
       unfold iscontr in tmp2. cbn in tmp2.
-      set (tmp3 := (pr2 tmp2) (ABGR_monic_kernel_in_hfiber_unel f w h)).
-      rewrite tmp3.
-      set (tmp4 := (pr2 tmp2)
-                     (ABGR_monic_kernel_in_hfiber f isM w 1%multmonoid h H)).
-      rewrite tmp4.
+      rewrite ((pr2 tmp2) (ABGR_monic_kernel_in_hfiber_unel f w h)).
+      rewrite ((pr2 tmp2) (ABGR_monic_kernel_in_hfiber
+                             f isM w 1%multmonoid h H)).
       apply idpath.
     }
 
-    apply base_paths in HH. use (pathscomp0 HH). apply idpath.
-  Defined.
+    apply base_paths in e. use (pathscomp0 e). apply idpath.
+  Qed.
+
+  (** We show that the KernelIn map is a monoidfun. *)
+  Definition ABGR_monic_kernel_in_monoidfun {A B : abgr} (f : ABGR⟦A, B⟧)
+             (isM : isMonic ABGR f) (w : abgr) (h: ABGR⟦w, B⟧)
+             (H : h ;; CokernelArrow ABGR_has_zero (ABGR_Cokernel f) =
+                   h ;; ZeroArrow ABGR ABGR_has_zero B (ABGR_Cokernel f)) :
+    monoidfun w A
+    := monoidfunconstr (ABGR_monic_kernel_in_ismonoidfun f isM w h H).
 
   (** ** We are ready to prove that Monics are Kernels. *)
 
@@ -1996,7 +2011,7 @@ Section ABGR_monic_kernels.
          (ABGR_Monic_Kernel_eq f isM)
          (ABGR_Monic_Kernel_isEqualizer f isM).
 
-  (** Here we verify that f is the KernelArrow of the above Kernel. *)
+  (** We verify that f is the KernelArrow of the above Kernel. *)
   Definition ABGR_monic_kernel_KernelArrow {A B : abgr} (f : ABGR⟦A, B⟧)
              (isM : isMonic ABGR f) :
     KernelArrow ABGR_has_zero (ABGR_monic_kernel f isM) = f.
@@ -2005,7 +2020,7 @@ Section ABGR_monic_kernels.
   Qed.
 
 
-  (*** Epis *)
+  (** ** Epis *)
 
 
   (** Constructs a kernel_hsubtype. *)
@@ -2019,10 +2034,65 @@ Section ABGR_monic_kernels.
     apply X. apply H.
   Defined.
 
+  (** Equality we are going to need. *)
+  Lemma ABGR_epi_cokernel_out_data_eq {A B : abgr} (f : ABGR⟦A, B⟧)
+        (isE : isEpi ABGR f) (w : abgr) (h : ABGR⟦A,w⟧)
+        (H : KernelArrow ABGR_has_zero (ABGR_Kernel f) ;; h =
+             ZeroArrow ABGR ABGR_has_zero (ABGR_Kernel f) A ;; h) :
+    Π x : ABGR_kernel_hsubtype f,
+          pr1 h (pr1carrier (ABGR_kernel_hsubtype f) x) = 1%multmonoid.
+  Proof.
+    rewrite ZeroArrow_comp_left in H.
+    rewrite ABGR_has_zero_arrow_eq in H.
+    cbn in H. unfold ABGR_zero_arrow in H.
+    apply base_paths in H. cbn in H.
+    unfold funcomp in H.
+    apply (funeqpaths H).
+  Qed.
+
+  (** hfibers of the same element to unel. *)
+  Lemma ABGR_epi_cokernel_out_data_hfibers_to_unel {A B : abgr} (f : ABGR⟦A, B⟧)
+        (b : B) (hfib1 hfib2 : hfiber (pr1 f) b) :
+    (pr1 f) ((pr1 hfib1) * (grinv A (pr1 hfib2)))%multmonoid = unel B.
+  Proof.
+    rewrite (pr1 (pr2 f)).
+    apply (grrcan (abgrtogr B) (pr1 f (pr1 hfib2))).
+    rewrite (assocax B). rewrite <- (pr1 (pr2 f)).
+    rewrite (grlinvax A). rewrite (pr2 (pr2 f)).
+    rewrite (runax B). rewrite (lunax B).
+    rewrite (pr2 hfib1). rewrite (pr2 hfib2).
+    apply idpath.
+  Qed.
+
+  (** Equality on hfibers. *)
+  Lemma ABGR_epi_cokernel_out_data_hfiber_eq {A B : abgr} (f : ABGR⟦A, B⟧)
+        (isE : isEpi ABGR f) (w : abgr) (h : ABGR⟦A,w⟧)
+        (H : KernelArrow ABGR_has_zero (ABGR_Kernel f) ;; h =
+             ZeroArrow ABGR ABGR_has_zero (ABGR_Kernel f) A ;; h)
+        (b : B) (X : hfiber (pr1 f) b) :
+    Π hfib : hfiber (pr1 f) b, pr1 h (pr1 hfib) = pr1 h (pr1 X).
+  Proof.
+    intros hfib.
+    set (e1 := ABGR_epi_cokernel_out_data_hfibers_to_unel f b hfib X).
+
+    apply (grrcan (abgrtogr w) (grinv (abgrtogr w) (pr1 h (pr1 X)))).
+    rewrite (grrinvax w).
+    set (tmp1 := (monoidfun_inv h (pr1 X))). cbn in tmp1.
+    apply (maponpaths (fun k : _ => ((pr1 h (pr1 hfib)) * k)%multmonoid))
+      in tmp1.
+    apply pathsinv0 in tmp1. use (pathscomp0 tmp1).
+    rewrite <- (pr1 (pr2 h)).
+
+    set (tmp2 := ABGR_epi_cokernel_out_data_eq f isE w h H).
+    set (tmp3 := ABGR_epi_cokernel_out_kernel_hsubtype
+                   f (pr1 hfib * grinv A (pr1 X))%multmonoid e1).
+    set (tmp4 := tmp2 tmp3). cbn in tmp4. apply tmp4.
+  Qed.
+
   (** Suppose that f is an epi and h a morphism from the domain of f such that
-      composition with the kernel of f is zero. Then for all terms b of the
-      domain of f, the space of terms of the target of h, such that all hfibers
-      of b are mapped to the target, is contractible. *)
+    composition with the kernel of f is zero. Then for all terms b of the
+    domain of f, the space of terms of the target of h, such that all hfibers
+    of b are mapped to the target, is contractible. *)
   Lemma ABGR_epi_cokernel_out_data_iscontr {A B : abgr} (f : ABGR⟦A, B⟧)
         (isE : isEpi ABGR f) (w : abgr) (h : ABGR⟦A,w⟧)
         (H : KernelArrow ABGR_has_zero (ABGR_Kernel f) ;; h =
@@ -2031,119 +2101,43 @@ Section ABGR_monic_kernels.
                                                              = x).
   Proof.
     intros b.
-    rewrite ZeroArrow_comp_left in H.
-    rewrite ABGR_has_zero_arrow_eq in H.
-    cbn in H. unfold ABGR_zero_arrow in H.
-    apply base_paths in H. cbn in H.
-    unfold funcomp in H.
-
-    set (tmp0 := ABGR_epi_issurjective f isE b).
-    use (squash_to_prop tmp0). apply isapropiscontr. intros X.
-    set (tmp := funeqpaths H). cbn in tmp.
-
+    use (squash_to_prop (ABGR_epi_issurjective f isE b)).
+    apply isapropiscontr.
+    intros X.
     apply (unique_exists (pr1 h (pr1 X))).
-    intros hfib. cbn in tmp.
 
-    assert (HH : (pr1 f) ((pr1 hfib) * (grinv A (pr1 X)))%multmonoid = unel B).
-    {
-      rewrite (pr1 (pr2 f)).
-      apply (grrcan (abgrtogr B) (pr1 f (pr1 X))).
-      rewrite (assocax B). rewrite <- (pr1 (pr2 f)).
-      rewrite (grlinvax A). rewrite (pr2 (pr2 f)).
-      rewrite (runax B). rewrite (lunax B).
-      rewrite (pr2 hfib). rewrite (pr2 X).
-      apply idpath.
-    }
-
-    set (tmp1 := ABGR_epi_cokernel_out_kernel_hsubtype
-                   f (pr1 hfib * grinv A (pr1 X))%multmonoid HH).
-    set (tmp2 := tmp tmp1). cbn in tmp2.
-
-    assert (HH0 : pr1 h (pr1 hfib) = pr1 h (pr1 X)).
-    {
-      apply (grrcan (abgrtogr w) (grinv (abgrtogr w) (pr1 h (pr1 X)))).
-      rewrite (grrinvax w).
-      set (tmp3 := (ABGR_monoidfun_inv_eq h (pr1 X))). cbn in tmp3.
-      apply (maponpaths (fun k : _ => ((pr1 h (pr1 hfib)) * k)%multmonoid))
-        in tmp3.
-      apply pathsinv0 in tmp3. use (pathscomp0 tmp3).
-      rewrite <- (pr1 (pr2 h)). apply tmp2.
-    }
-    apply HH0.
+    (* Equality of hfibers *)
+    apply (ABGR_epi_cokernel_out_data_hfiber_eq f isE w h H b X).
 
     (* Equality on equalities of elements. *)
     intros y. apply impred_isaprop. intros t. apply (setproperty w).
 
     (* Uniqueness. *)
-    intros y T. set (T0 := T X). apply pathsinv0 in T0.
-    apply T0.
+    intros y T. apply (pathsinv0 (T X)).
   Qed.
 
   (** Using the above result we construct the unique term of w such that
-      all the hfibers of b are mapped to it. *)
+    all the hfibers of b are mapped to it. *)
   Lemma ABGR_epi_cokernel_out_data {A B : abgr} (b : B) (f : ABGR⟦A, B⟧)
         (isE : isEpi ABGR f) (w : abgr) (h : ABGR⟦A,w⟧)
         (H : KernelArrow ABGR_has_zero (ABGR_Kernel f) ;; h =
              ZeroArrow ABGR ABGR_has_zero (ABGR_Kernel f) A ;; h) :
     ( Σ x : w, Π (hfib : hfiber (pr1 f) b), pr1 h (pr1 hfib) = x).
   Proof.
-
-    assert (H'' : KernelArrow ABGR_has_zero (ABGR_Kernel f) ;; h =
-             ZeroArrow ABGR ABGR_has_zero (ABGR_Kernel f) A ;; h).
-    {
-      apply H.
-    }
-
-    rewrite ZeroArrow_comp_left in H.
-    rewrite ABGR_has_zero_arrow_eq in H.
-    cbn in H. unfold ABGR_zero_arrow in H.
-    apply base_paths in H. cbn in H.
-    unfold funcomp in H.
-
-    set (tmp0 := ABGR_epi_issurjective f isE b).
-    use (squash_to_prop tmp0).
+    use (squash_to_prop (ABGR_epi_issurjective f isE b)).
     apply isapropifcontr.
-    apply (ABGR_epi_cokernel_out_data_iscontr f isE w h H'' b).
+    apply (ABGR_epi_cokernel_out_data_iscontr f isE w h H b).
     intros X.
-
-    set (tmp := funeqpaths H). cbn in tmp.
-
     apply (unique_exists (pr1 h (pr1 X))).
-    intros hfib. cbn in tmp.
 
-    assert (HH : (pr1 f) ((pr1 hfib) * (grinv A (pr1 X)))%multmonoid = unel B).
-    {
-      rewrite (pr1 (pr2 f)).
-      apply (grrcan (abgrtogr B) (pr1 f (pr1 X))).
-      rewrite (assocax B). rewrite <- (pr1 (pr2 f)).
-      rewrite (grlinvax A). rewrite (pr2 (pr2 f)).
-      rewrite (runax B). rewrite (lunax B).
-      rewrite (pr2 hfib). rewrite (pr2 X).
-      apply idpath.
-    }
+    (* Equality of hfibers *)
+    apply (ABGR_epi_cokernel_out_data_hfiber_eq f isE w h H b X).
 
-    set (tmp1 := ABGR_epi_cokernel_out_kernel_hsubtype
-                   f (pr1 hfib * grinv A (pr1 X))%multmonoid HH).
-    set (tmp2 := tmp tmp1). cbn in tmp2.
-
-    assert (HH0 : pr1 h (pr1 hfib) = pr1 h (pr1 X)).
-    {
-      apply (grrcan (abgrtogr w) (grinv (abgrtogr w) (pr1 h (pr1 X)))).
-      rewrite (grrinvax w).
-      set (tmp3 := (ABGR_monoidfun_inv_eq h (pr1 X))). cbn in tmp3.
-      apply (maponpaths (fun k : _ => ((pr1 h (pr1 hfib)) * k)%multmonoid))
-        in tmp3.
-      apply pathsinv0 in tmp3. use (pathscomp0 tmp3).
-      rewrite <- (pr1 (pr2 h)). apply tmp2.
-    }
-    apply HH0.
-
-    (* Equality on equalities of terms. *)
+    (* Equality on equalities of elements. *)
     intros y. apply impred_isaprop. intros t. apply (setproperty w).
 
     (* Uniqueness *)
-    intros y T. set (T0 := T X). apply pathsinv0 in T0.
-    apply T0.
+    intros y T. apply (pathsinv0 (T X)).
   Qed.
 
   (** Construction of the cokernel out map. *)
@@ -2167,64 +2161,21 @@ Section ABGR_monic_kernels.
     Π hfib : hfiber (pr1 f) (b1 * b2)%multmonoid,
              pr1 h (pr1 hfib) = (pr1 X * pr1 X0)%multmonoid.
   Proof.
-    cbn. intros hfib.
-    assert (H'' : KernelArrow ABGR_has_zero (ABGR_Kernel f) ;; h =
-             ZeroArrow ABGR ABGR_has_zero (ABGR_Kernel f) A ;; h).
-    {
-      apply H.
-    }
+    intros hfib.
 
-    rewrite ZeroArrow_comp_left in H.
-    rewrite ABGR_has_zero_arrow_eq in H.
-    cbn in H. unfold ABGR_zero_arrow in H.
-    apply base_paths in H. cbn in H.
-    unfold funcomp in H.
+    use (squash_to_prop (ABGR_epi_issurjective f isE b1)).
+    apply (setproperty w). intros X1.
 
-    set (tmp0 := ABGR_epi_issurjective f isE b1).
-    use (squash_to_prop tmp0). apply (setproperty w).
-    intros X1.
+    use (squash_to_prop (ABGR_epi_issurjective f isE b2)).
+    apply (setproperty w). intros X2.
 
-    set (tmp1 := ABGR_epi_issurjective f isE b2).
-    use (squash_to_prop tmp1). apply (setproperty w).
-    intros X2.
-
-    set (tmp2 := ((pr2 X) X1)). cbn in tmp2. rewrite <- tmp2.
-    set (tmp3 := ((pr2 X0) X2)). cbn in tmp3. rewrite <- tmp3.
+    rewrite <- ((pr2 X) X1). rewrite <- ((pr2 X0) X2).
     rewrite <- (pr1 (pr2 h)).
-    set (tmp := funeqpaths H). cbn in tmp.
 
-    assert (HH : (pr1 f) ((pr1 hfib) * (grinv A (pr1 X1 * pr1 X2)))%multmonoid
-                 = unel B).
-    {
-      rewrite (pr1 (pr2 f)). rewrite grinvcomp. rewrite (pr1 (pr2 f)). cbn.
-      set (ttmp := ABGR_monoidfun_inv_eq f (pr1 X2)). cbn in ttmp.
-      set (ttmp1 := ABGR_monoidfun_inv_eq f (pr1 X1)). cbn in ttmp1.
-      set (ttmp2 := pr2 hfib). cbn in ttmp2.
-      cbn.
-      rewrite ttmp2. rewrite ttmp. rewrite ttmp1.
-      set (ttmp' := (pr2 X2)). cbn in ttmp'.
-      set (ttmp1' := (pr2 X1)). cbn in ttmp1'.
-      rewrite ttmp'. rewrite ttmp1'.
-      rewrite (assocax B). rewrite <- (assocax B b2).
-      rewrite (grrinvax B). rewrite (lunax B).
-      apply (grrinvax B).
-    }
-
-    set (ttmp1 := ABGR_epi_cokernel_out_kernel_hsubtype
-                    f (pr1 hfib * grinv A (pr1 X1 * pr1 X2))%multmonoid HH).
-    set (ttmp2 := tmp ttmp1). cbn in ttmp2.
-
-    assert (HH0 : pr1 h (pr1 hfib) = pr1 h (pr1 X1 * pr1 X2)%multmonoid).
-    {
-      apply (grrcan (abgrtogr w) (grinv (abgrtogr w)
-                                        (pr1 h (pr1 X1 * pr1 X2)%multmonoid))).
-      rewrite (grrinvax w).
-      set (ttmp3 := (ABGR_monoidfun_inv_eq h (pr1 X1 * pr1 X2)%multmonoid)).
-      cbn in ttmp3.
-      cbn.
-      rewrite <- ttmp3. rewrite <- (pr1 (pr2 h)). apply ttmp2.
-    }
-    apply HH0.
+    apply (ABGR_epi_cokernel_out_data_hfiber_eq
+             f isE w h H (b1 * b2)%multmonoid
+             (hfiber_op f b1 b2 X1 X2)
+             hfib).
   Qed.
 
   (** This is used to verify that CokernelOut is a binopfun. *)
@@ -2252,30 +2203,12 @@ Section ABGR_monic_kernels.
     Π hfib : hfiber (pr1 f) 1%multmonoid, pr1 h (pr1 hfib) = 1%multmonoid.
   Proof.
     intros hfib.
-
-    assert (H'' : KernelArrow ABGR_has_zero (ABGR_Kernel f) ;; h =
-             ZeroArrow ABGR ABGR_has_zero (ABGR_Kernel f) A ;; h).
-    {
-      apply H.
-    }
-
-    rewrite ZeroArrow_comp_left in H.
-    rewrite ABGR_has_zero_arrow_eq in H.
-    cbn in H. unfold ABGR_zero_arrow in H.
-    apply base_paths in H. cbn in H.
-    unfold funcomp in H.
-
-    set (tmp := funeqpaths H). cbn in tmp.
-
-    set (tmp0 := ABGR_epi_issurjective f isE 1%multmonoid).
-    use (squash_to_prop tmp0). apply (setproperty w).
-    intros X1.
-
-    set (tmp1 := (pr2 hfib)). cbn in tmp1.
-    set (ttmp1 := ABGR_epi_cokernel_out_kernel_hsubtype
-                    f (pr1 hfib) tmp1).
-    set (ttmp2 := tmp ttmp1). cbn in ttmp2.
-    apply ttmp2.
+    set (hfib_unel := hfiberpair (pr1 f) 1%multmonoid (pr2 (pr2 f))).
+    rewrite (ABGR_epi_cokernel_out_data_hfiber_eq
+             f isE w h H 1%multmonoid
+             hfib_unel
+             hfib).
+    cbn. apply (pr2 (pr2 h)).
   Qed.
 
   (** Construction of a structure for unel. *)
@@ -2302,6 +2235,8 @@ Section ABGR_monic_kernels.
     intros x x'.
     unfold ABGR_epi_cokernel_out_map.
 
+    (* The left hand side is equal to the multiplication of the datas on the
+      right hand side. *)
     set (HH0 := ABGR_epi_cokernel_out_data_mult
                   x x' f isE w h H
                   (ABGR_epi_cokernel_out_data x f isE w h H)
@@ -2321,13 +2256,15 @@ Section ABGR_monic_kernels.
 
     (* unel *)
     unfold ABGR_epi_cokernel_out_map.
-    set (HH1 := ABGR_epi_cokernel_out_data_unel f isE w h H).
+    (* The left hand side is equal to unel. *)
     assert (HH : (ABGR_epi_cokernel_out_data 1%multmonoid f isE w h H)
-                 = HH1).
+                 = (ABGR_epi_cokernel_out_data_unel f isE w h H)).
     {
-      set (tmp := (ABGR_epi_cokernel_out_data_iscontr
+      rewrite (pr2(ABGR_epi_cokernel_out_data_iscontr
                      f isE w h H 1%multmonoid)).
-      rewrite (pr2 tmp). apply pathsinv0. rewrite (pr2 tmp).
+      apply pathsinv0.
+      rewrite (pr2(ABGR_epi_cokernel_out_data_iscontr
+                     f isE w h H 1%multmonoid)).
       apply idpath.
     }
 
@@ -2370,13 +2307,9 @@ Section ABGR_monic_kernels.
 
     (* Commutativity *)
     cbn. use total2_paths. cbn. unfold funcomp. apply funextfun.
-    intros x. cbn. unfold ABGR_epi_cokernel_out_map.
-    set (tmp := pr2 ((ABGR_epi_cokernel_out_data (pr1 f x) f isE w h H))).
-    cbn in tmp.
-
-    set (tmpp := @hfiberpair _ _ (pr1 f) (pr1 f x) x (idpath _)).
-    set (tmppp := tmp tmpp). cbn. rewrite <- tmppp.
-    apply idpath.
+    intros x. apply pathsinv0. unfold ABGR_epi_cokernel_out_map.
+    apply (pr2 ((ABGR_epi_cokernel_out_data (pr1 f x) f isE w h H))
+               (@hfiberpair _ _ (pr1 f) (pr1 f x) x (idpath _))).
     apply proofirrelevance. apply isapropismonoidfun.
 
     (* Equality of equalities of morphisms *)
@@ -2385,14 +2318,10 @@ Section ABGR_monic_kernels.
     (* Uniqueness *)
     intros y T. cbn in T.
     unfold isEpi in isE. apply isE. cbn. rewrite T.
-    use total2_paths. cbn. apply funextfun. intros x.
-    apply pathsinv0. unfold funcomp. unfold ABGR_epi_cokernel_out_map.
-    set (tmp := pr2 ((ABGR_epi_cokernel_out_data (pr1 f x) f isE w h H))).
-    cbn in tmp.
-
-    set (tmpp := @hfiberpair _ _ (pr1 f) (pr1 f x) x (idpath _)).
-    set (tmppp := tmp tmpp). cbn. rewrite <- tmppp.
-    apply idpath.
+    use total2_paths. cbn. unfold funcomp. apply funextfun. intros x.
+    unfold ABGR_epi_cokernel_out_map.
+    apply (pr2 ((ABGR_epi_cokernel_out_data (pr1 f x) f isE w h H))
+               (@hfiberpair _ _ (pr1 f) (pr1 f x) x (idpath _))).
 
     apply proofirrelevance. apply isapropismonoidfun.
   Qed.
@@ -2408,7 +2337,7 @@ Section ABGR_monic_kernels.
          (ABGR_epi_cokernel_eq f isE)
          (ABGR_epi_cokernel_isCoequalizer f isE).
 
-  (** Here we verify that f is the CokernelArrow of the above Cokernel. *)
+  (** We verify that f is the CokernelArrow of the above Cokernel. *)
   Definition ABGR_epi_cokernel_CokernelArrow {A B : abgr} (f : ABGR⟦A, B⟧)
              (isE : isEpi ABGR f) :
     CokernelArrow ABGR_has_zero (ABGR_epi_cokernel f isE) = f.
@@ -2419,9 +2348,9 @@ Section ABGR_monic_kernels.
 End ABGR_monic_kernels.
 
 
-(** In this section we put all the previous results together to show that the
-    precategory ABGR, consisting of abelian groups, is an
-    Abelian_precategory. *)
+(** * ABGR is Abelian_precategory
+  In this section we put all the previous results together to show that the
+  precategory ABGR, consisting of abelian groups, is an Abelian_precategory. *)
 Section ABGR_abelian_precategory.
 
   Definition ABGR_Abelian_precategory :

--- a/UniMath/CategoryTheory/category_binops.v
+++ b/UniMath/CategoryTheory/category_binops.v
@@ -1,0 +1,200 @@
+(* The category of sets with binary operations. *)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Basics.UnivalenceAxiom.
+
+Require Import UniMath.Foundations.Algebra.BinaryOperations.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.HLevel_n_is_of_hlevel_Sn.
+
+
+Section BINOPS_precategory.
+
+  Definition binops_fun_space (A B : setwithbinop) : hSet :=
+    hSetpair _ (isasetbinopfun A B).
+
+  Definition binops_precategory_ob_mor : precategory_ob_mor :=
+    tpair (fun ob : UU => ob -> ob -> UU) setwithbinop
+          (fun A B : setwithbinop => binops_fun_space A B).
+
+  Definition idbinopfun (A : setwithbinop) : binopfun A A.
+  Proof.
+    use binopfunpair. intros a. exact a.
+    intros a a'.
+    apply idpath.
+  Defined.
+
+  Definition idbinopfun_remove_left (A B : setwithbinop) (f : binopfun A B) :
+    binopfuncomp (idbinopfun A) f = f.
+  Proof.
+    unfold binopfuncomp. unfold idbinopfun.
+    use total2_paths. cbn. unfold funcomp. apply maponpaths.
+    apply idpath. apply proofirrelevance. apply isapropisbinopfun.
+  Defined.
+
+
+  Definition idbinopfun_remove_right (A B : setwithbinop) (f : binopfun A B) :
+    binopfuncomp f (idbinopfun B) = f.
+  Proof.
+    unfold binopfuncomp. unfold idbinopfun.
+    use total2_paths. cbn. unfold funcomp. apply maponpaths.
+    apply idpath. apply proofirrelevance. apply isapropisbinopfun.
+  Defined.
+
+  Definition binopfuncomp_assoc (A B C D : setwithbinop) (f : binopfun A B)
+             (g : binopfun B C) (h : binopfun C D) :
+    binopfuncomp (binopfuncomp f g) h = binopfuncomp f (binopfuncomp g h).
+  Proof.
+    unfold binopfuncomp. apply maponpaths.
+    apply isapropisbinopfun.
+  Defined.
+
+  Definition binop_precategory_data : precategory_data :=
+    precategory_data_pair binops_precategory_ob_mor
+                          (fun (A : setwithbinop) => idbinopfun A )
+                          (fun (A B C : setwithbinop) (f : binopfun A B)
+                             (g : binopfun B C) => binopfuncomp f g).
+
+  Lemma is_precategory_binop_precategory_data :
+    is_precategory binop_precategory_data.
+  Proof.
+    repeat split; cbn.
+
+    intros a b f. apply idbinopfun_remove_left.
+    intros a b f. apply idbinopfun_remove_right.
+
+    intros a b c d f g h. apply pathsinv0.
+    apply (binopfuncomp_assoc a b c d f g h).
+  Qed.
+
+  Definition binop_precategory : precategory :=
+    tpair _ _ is_precategory_binop_precategory_data.
+
+  Local Notation BINOP := binop_precategory.
+  Lemma has_homsets_BINOP : has_homsets BINOP.
+  Proof. intros a b; apply isasetbinopfun. Qed.
+
+End BINOPS_precategory.
+
+Notation BINOP := binop_precategory.
+
+Section BINOP_category.
+
+  (** ** Equivalence between isomorphisms and binopisos *)
+
+  Lemma binop_iso_is_equiv (A B : ob BINOP)
+        (f : iso A B) : isweq (pr1 (pr1 f)).
+  Proof.
+    apply (gradth _ (pr1binopfun _ _ (inv_from_iso f))).
+    - intro x.
+      set (T:=iso_inv_after_iso f).
+      apply subtypeInjectivity in T.
+      set (T':=toforallpaths _ _ _ T). apply T'.
+      intro x0.
+      apply isapropisbinopfun.
+    - intros y.
+
+      set (T:=iso_after_iso_inv f).
+      apply subtypeInjectivity in T.
+      set (T':=toforallpaths _ _ _ T). apply T'.
+      intros x0.
+      apply isapropisbinopfun.
+  Defined.
+
+  Lemma binop_iso_equiv (A B : ob BINOP) : iso A B -> binopiso A B.
+  Proof.
+    intro f.
+    use binopisopair.
+    set (X := binop_iso_is_equiv A B f).
+    apply (weqpair (pr1 (pr1 f)) X).
+    apply (pr2 (pr1 f)).
+  Defined.
+
+  Lemma binop_equiv_is_iso (A B : setwithbinop)
+        (f : binopiso A B) :
+    @is_isomorphism BINOP A B (binopfunpair (pr1 (pr1 f)) (pr2 f)).
+  Proof.
+    apply (is_iso_qinv (C:=BINOP) _ (binopfunpair (pr1 (pr1 (invbinopiso f)))
+                                                  (pr2 (invbinopiso f)))).
+    split; cbn. unfold compose, identity. cbn. unfold binopfuncomp, idbinopfun.
+    cbn. use total2_paths. cbn. apply funextfun. intros x.
+    apply homotinvweqweq. cbn. apply impred_isaprop. intros t.
+    apply impred_isaprop. intros t0. apply (pr2 (pr1 A)).
+
+    use total2_paths. cbn. apply funextfun. intros x.
+    apply homotweqinvweq. cbn. apply impred_isaprop. intros yt.
+    apply impred_isaprop. intros t0. apply (pr2 (pr1 B)).
+  Defined.
+
+  Lemma binop_equiv_iso (A B : BINOP) : binopiso A B -> iso A B.
+  Proof.
+    intro f.
+    cbn in *.
+    set (T := binop_equiv_is_iso A B f).
+    set (T' := @isopair BINOP _ _ (binopfunpair (pr1 (pr1 f)) (pr2 f)) T).
+    apply T'.
+  Defined.
+
+  Lemma binop_iso_equiv_is_equiv (A B : BINOP) : isweq (binop_iso_equiv A B).
+  Proof.
+    apply (gradth _ (binop_equiv_iso A B)).
+    intro; apply eq_iso. apply maponpaths.
+    unfold binop_equiv_iso, binop_iso_equiv. cbn.
+    use total2_paths. cbn. unfold binopfunpair.
+    apply subtypeEquality. intros y. apply isapropisbinopfun.
+    apply maponpaths. apply subtypeEquality.
+    unfold isPredicate.
+
+    intros x0. apply isapropisbinopfun.
+    apply idpath.
+
+    apply proofirrelevance.
+    apply isaprop_is_iso.
+
+    intros y. unfold binop_iso_equiv, binop_equiv_iso. cbn.
+    use total2_paths. cbn. unfold binopfunpair.
+    apply subtypeEquality. intros x. apply isapropisweq.
+    apply idpath.
+
+    apply proofirrelevance.
+    apply isapropisbinopfun.
+  Defined.
+
+  Definition binop_iso_equiv_weq (A B : BINOP) : weq (iso A B) (binopiso A B).
+  Proof.
+    exists (binop_iso_equiv A B).
+    apply binop_iso_equiv_is_equiv.
+  Defined.
+
+  Lemma binop_equiv_iso_is_equiv (A B : BINOP) : isweq (binop_equiv_iso A B).
+  Proof.
+    apply (gradth _ (binop_iso_equiv A B)).
+    intros x. apply subtypeEquality.
+    intros y. apply isapropisbinopfun.
+
+    unfold binop_equiv_iso, binop_iso_equiv. cbn.
+    use total2_paths. cbn. apply idpath.
+    apply isapropisweq.
+
+    intros y. unfold binop_equiv_iso, binop_iso_equiv. cbn.
+    use total2_paths. cbn. unfold binopfunpair. cbn.
+    apply subtypeEquality. intros x. apply isapropisbinopfun.
+    apply idpath. apply proofirrelevance.
+    apply isaprop_is_iso.
+  Qed.
+
+  Definition binop_equiv_iso_weq (A B : BINOP) :
+    weq (binopiso A B)(iso A B).
+  Proof.
+    exists (binop_equiv_iso A B).
+    apply binop_equiv_iso_is_equiv.
+  Defined.
+
+(** ** HERE ONE SHOULD ADD A PROOF THAT BINOP IS ACTUALLY A CATEGORY.
+       See category_hset.v *)
+
+End BINOP_category.

--- a/UniMath/CategoryTheory/limits/BinDirectSums.v
+++ b/UniMath/CategoryTheory/limits/BinDirectSums.v
@@ -3,6 +3,9 @@ Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.Foundations.Basics.Propositions.
 Require Import UniMath.Foundations.Basics.Sets.
 
+Require Import UniMath.Foundations.Algebra.BinaryOperations.
+Require Import UniMath.Foundations.Algebra.Monoids_and_Groups.
+
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
@@ -340,7 +343,8 @@ Section def_bindirectsums.
 
   (** Both of the above morphisms are given by the following formula. *)
   Definition BinDirectSumIndArFormula {a b c d: A}  (f : a --> b) (g : c --> d)
-             (B1 : BinDirectSumCone a c) (B2 : BinDirectSumCone b d) : A⟦B1, B2⟧
+             (B1 : BinDirectSumCone a c) (B2 : BinDirectSumCone b d) :
+    A⟦B1, B2⟧
     := (PrecategoryWithAbgrops_op A B1 B2)
          (BinDirectSumPr1 B1 ;; f ;; BinDirectSumIn1 B2)
          (BinDirectSumPr2 B1 ;; g ;; BinDirectSumIn2 B2).
@@ -382,3 +386,200 @@ Section def_bindirectsums.
   Opaque BinDirectSumIndArEq.
 
 End def_bindirectsums.
+
+
+(** If a PreAdditive category has BinProducts, then it has all direct sums. *)
+Section bindirectsums_criteria.
+
+  Variable A : PreAdditive.
+  Hypothesis hs : has_homsets A.
+  Variable Z : Zero A.
+
+  Definition BinDirectSums_from_binproduct_bincoproducts_eq1
+             {X Y : A} (P : BinProductCone A X Y):
+    BinProductArrow A P (identity X) (ZeroArrow A Z X Y) ;; BinProductPr1 A P
+    = identity _ .
+  Proof.
+    apply BinProductPr1Commutes.
+  Qed.
+
+  Definition BinDirectSums_from_binproduct_bincoproducts_eq2
+             {X Y : A} (P : BinProductCone A X Y):
+    BinProductArrow A P (identity X) (ZeroArrow A Z X Y) ;; BinProductPr2 A P =
+      PrecategoryWithAbgrops_unel A X Y.
+  Proof.
+    rewrite (PreAdditive_unel_zero A Z).
+    apply BinProductPr2Commutes.
+  Qed.
+
+  Definition BinDirectSums_from_binproduct_bincoproducts_eq3
+             {X Y : A} (P : BinProductCone A X Y):
+    BinProductArrow A P (ZeroArrow A Z Y X) (identity _ ) ;; BinProductPr1 A P
+    = PrecategoryWithAbgrops_unel A Y X.
+  Proof.
+    rewrite (PreAdditive_unel_zero A Z).
+    apply BinProductPr1Commutes.
+  Qed.
+
+  Definition BinDirectSums_from_binproduct_bincoproducts_eq4
+             {X Y : A} (P : BinProductCone A X Y):
+    BinProductArrow A P (ZeroArrow A Z Y X) (identity _ ) ;; BinProductPr2 A P
+    = identity _ .
+  Proof.
+    apply BinProductPr2Commutes.
+  Qed.
+
+  Definition BinDirectSums_from_binproduct_bincoproducts_eq5
+             {X Y : A} (P : BinProductCone A X Y) :
+    PrecategoryWithBinOps_binop A (BinProductObject A P) (BinProductObject A P)
+                                (BinProductPr1 A P ;; BinProductArrow A P
+                                               (identity X)
+                                               (ZeroArrow A Z X Y))
+                                (BinProductPr2 A P ;; BinProductArrow A P
+                                               (ZeroArrow A Z Y X)
+                                               (identity Y))
+    = identity _ .
+  Proof.
+    apply BinProductArrowsEq.
+    set (tmp := (PreAdditive_postmor_linear
+                   A _ _ _ (BinProductPr1 A P)
+                   (BinProductPr1 A P ;; BinProductArrow A P
+                                  (identity X) (ZeroArrow A Z X Y))
+                   (BinProductPr2 A P ;; BinProductArrow A P
+                                  (ZeroArrow A Z Y X) (identity Y)))).
+    unfold PrecategoryWithAbgrops_postmor in tmp. cbn in tmp. rewrite tmp.
+    rewrite <- assoc. rewrite <- assoc.
+    rewrite BinProductPr1Commutes. rewrite BinProductPr1Commutes.
+    rewrite id_right. rewrite ZeroArrow_comp_right.
+    rewrite <- PreAdditive_unel_zero.
+    rewrite id_left.
+    apply PrecategoryWithAbgrops_runax.
+
+    set (tmp := (PreAdditive_postmor_linear
+                   A _ _ _ (BinProductPr2 A P)
+                   (BinProductPr1 A P ;; BinProductArrow A P
+                                  (identity X) (ZeroArrow A Z X Y))
+                   (BinProductPr2 A P ;; BinProductArrow A P
+                                  (ZeroArrow A Z Y X) (identity Y)))).
+    unfold PrecategoryWithAbgrops_postmor in tmp. cbn in tmp. rewrite tmp.
+    rewrite <- assoc. rewrite <- assoc.
+    rewrite BinProductPr2Commutes. rewrite BinProductPr2Commutes.
+    rewrite id_right. rewrite ZeroArrow_comp_right.
+    rewrite <- PreAdditive_unel_zero.
+    rewrite id_left.
+    apply PrecategoryWithAbgrops_lunax.
+  Qed.
+
+  Definition BinDirectSums_from_binproduct_bincoproducts_isCoproduct
+             {X Y : A} (P : BinProductCone A X Y) :
+    isBinCoproductCocone A X Y (BinProductObject A P)
+    (BinProductArrow A P (identity X) (ZeroArrow A Z X Y))
+    (BinProductArrow A P (ZeroArrow A Z Y X) (identity Y)).
+  Proof.
+    use mk_isBinCoproductCocone.
+    exact hs.
+    intros c f g.
+    apply (unique_exists
+             (PrecategoryWithAbgrops_op A (BinProductObject A P) c
+                                        (BinProductPr1 A P ;; f)
+                                        (BinProductPr2 A P ;; g))).
+    split.
+    set (tmp := (PreAdditive_premor_linear
+                   A _ _ c (BinProductArrow A P (identity X)
+                                            (ZeroArrow A Z X Y))
+
+                   (BinProductPr1 A P ;; f)
+                   (BinProductPr2 A P ;; g))).
+    unfold PrecategoryWithAbgrops_premor in tmp. cbn in tmp. cbn.
+    rewrite tmp.
+
+    rewrite assoc. rewrite assoc.
+    rewrite BinProductPr1Commutes.
+    rewrite BinProductPr2Commutes.
+    rewrite ZeroArrow_comp_left.
+    rewrite id_left.
+    rewrite <- PreAdditive_unel_zero.
+    apply PrecategoryWithAbgrops_runax.
+
+    set (tmp := (PreAdditive_premor_linear
+                   A _ _ c (BinProductArrow A P (ZeroArrow A Z Y X)
+                           (identity Y))
+                   (BinProductPr1 A P ;; f)
+                   (BinProductPr2 A P ;; g))).
+    unfold PrecategoryWithAbgrops_premor in tmp. cbn in tmp. cbn.
+    rewrite tmp.
+
+    rewrite assoc. rewrite assoc.
+    rewrite BinProductPr1Commutes.
+    rewrite BinProductPr2Commutes.
+    rewrite ZeroArrow_comp_left.
+    rewrite id_left.
+    rewrite <- PreAdditive_unel_zero.
+    apply PrecategoryWithAbgrops_lunax.
+
+    intros y. apply isapropdirprod. apply hs. apply hs.
+
+    intros y H. induction H. rewrite <- t. rewrite <- p.
+    rewrite assoc. rewrite assoc. cbn.
+    set (tmp := (PreAdditive_postmor_linear
+                   A _ _ _ y
+                   (BinProductPr1 A P ;; BinProductArrow A P
+                                  (identity X) (ZeroArrow A Z X Y))
+                   (BinProductPr2 A P ;; BinProductArrow A P
+                                  (ZeroArrow A Z Y X) (identity Y)))).
+    unfold PrecategoryWithAbgrops_postmor in tmp. cbn in tmp.
+    rewrite <- tmp.
+    rewrite (BinDirectSums_from_binproduct_bincoproducts_eq5 P).
+    rewrite id_left. apply idpath.
+  Qed.
+
+  Definition BinDirectSums_from_binproduct_bincoproducts_isProduct
+             {X Y : A} (P : BinProductCone A X Y) :
+    isBinProductCone A X Y (BinProductObject A P) (BinProductPr1 A P)
+                     (BinProductPr2 A P).
+  Proof.
+    use mk_isBinProductCone.
+    exact hs.
+
+    intros c f g.
+    apply (unique_exists (BinProductArrow A P f g)).
+    split.
+    apply BinProductPr1Commutes.
+    apply BinProductPr2Commutes.
+    intros y. apply isapropdirprod. apply hs. apply hs.
+    intros y H. induction H. rewrite <- t. rewrite <- p.
+    rewrite <- precompWithBinProductArrow.
+    apply BinProductArrowsEq.
+    rewrite <- assoc. rewrite BinProductPr1Commutes. apply idpath.
+    rewrite <- assoc. rewrite BinProductPr2Commutes. apply idpath.
+  Qed.
+
+
+  Definition BinDirectSum_from_BinProduct {X Y : A}
+             (P : BinProductCone A X Y) :
+    BinDirectSumCone A X Y
+    := mk_BinDirectSumCone
+         A X Y
+         (BinProductObject A P)
+         (BinProductArrow A P (identity X) (ZeroArrow A Z X Y))
+         (BinProductArrow A P (ZeroArrow A Z Y X) (identity Y))
+         (BinProductPr1 A P)
+         (BinProductPr2 A P)
+         (mk_isBinDirectSumCone
+            _ _ _ _ _ _ _ _
+            (BinDirectSums_from_binproduct_bincoproducts_isCoproduct P)
+            (BinDirectSums_from_binproduct_bincoproducts_isProduct P)
+            (BinDirectSums_from_binproduct_bincoproducts_eq1 P)
+            (BinDirectSums_from_binproduct_bincoproducts_eq4 P)
+            (BinDirectSums_from_binproduct_bincoproducts_eq2 P)
+            (BinDirectSums_from_binproduct_bincoproducts_eq3 P)
+            (BinDirectSums_from_binproduct_bincoproducts_eq5 P)).
+
+  Definition BinDirectSums_from_BinProducts (BinProds : BinProducts A) :
+    BinDirectSums A.
+  Proof.
+    intros X Y.
+    exact (BinDirectSum_from_BinProduct (BinProds X Y)).
+  Defined.
+
+End bindirectsums_criteria.

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -13,6 +13,7 @@ Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.BinProductPrecategory.
+Require Import UniMath.CategoryTheory.limits.zero.
 
 (** * Definition of binary coproduct of objects in a precategory *)
 Section coproduct_def.
@@ -612,3 +613,24 @@ Definition BinCoproduct_of_functors_alt {C D : precategory}
      (functor_composite (binproduct_pair_functor F G) (bincoproduct_functor HD)).
 
 End functors.
+
+(** In the following section we show that if the morphism to components are
+    zero, then the unique morphism factoring through the bincoproduct is the
+    zero morphism. *)
+Section BinCoproduct_zeroarrow.
+
+  Variable C : precategory.
+  Variable Z : Zero C.
+
+  Lemma BinCoproductArrowZero {x y z: C} {BP : BinCoproductCocone C x y}
+        (f : x --> z) (g : y --> z) :
+    f = ZeroArrow C Z _ _ -> g = ZeroArrow C Z _ _ ->
+    BinCoproductArrow C BP f g = ZeroArrow C Z _ _ .
+  Proof.
+    intros X X0. apply pathsinv0.
+    use BinCoproductArrowUnique.
+    rewrite X. apply ZeroArrow_comp_right.
+    rewrite X0. apply ZeroArrow_comp_right.
+  Qed.
+
+End BinCoproduct_zeroarrow.

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -75,6 +75,22 @@ Proof.
   apply (base_paths _ _ H').
 Qed.
 
+Lemma BinCoproductArrowsEq (c d : C) (CC : BinCoproductCocone c d) (x : C)
+      (k1 k2 : BinCoproductObject CC --> x) :
+  BinCoproductIn1 CC ;; k1 = BinCoproductIn1 CC ;; k2 ->
+  BinCoproductIn2 CC ;; k1 = BinCoproductIn2 CC ;; k2 ->
+  k1 = k2.
+Proof.
+  intros H1 H2.
+  set (p1 := BinCoproductIn1 CC ;; k1).
+  set (p2 := BinCoproductIn2 CC ;; k1).
+  rewrite (BinCoproductArrowUnique _ _ CC _ p1 p2 k1).
+  apply pathsinv0.
+  apply BinCoproductArrowUnique.
+  unfold p1. apply pathsinv0. apply H1.
+  unfold p2. apply pathsinv0. apply H2.
+  apply idpath. apply idpath.
+Qed.
 
 Lemma BinCoproductArrowEta (a b : C) (CC : BinCoproductCocone a b) (x : C)
     (f : BinCoproductObject CC --> x) :

--- a/UniMath/CategoryTheory/limits/binproducts.v
+++ b/UniMath/CategoryTheory/limits/binproducts.v
@@ -7,6 +7,7 @@ Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.BinProductPrecategory.
+Require Import UniMath.CategoryTheory.limits.zero.
 
 Local Notation "a --> b" := (precategory_morphisms a b)(at level 50).
 
@@ -317,3 +318,25 @@ Definition BinProduct_of_functors_alt {C D : precategory} (HD : BinProducts D)
   (F G : functor C D) : functor C D :=
   functor_composite (bindelta_functor C)
      (functor_composite (binproduct_pair_functor F G) (binproduct_functor HD)).
+
+
+(** In the following section we show that if the morphism to components are
+    zero, then the unique morphism factoring through the binproduct is the
+    zero morphism. *)
+Section BinProduct_zeroarrow.
+
+  Variable C : precategory.
+  Variable Z : Zero C.
+
+  Lemma BinProductArrowZero {x y z: C} {BP : BinProductCone C x y}
+        (f : z --> x) (g : z --> y) :
+    f = ZeroArrow C Z _ _ -> g = ZeroArrow C Z _ _ ->
+    BinProductArrow C BP f g = ZeroArrow C Z _ _ .
+  Proof.
+    intros X X0. apply pathsinv0.
+    use BinProductArrowUnique.
+    rewrite X. apply ZeroArrow_comp_left.
+    rewrite X0. apply ZeroArrow_comp_left.
+  Qed.
+
+End BinProduct_zeroarrow.

--- a/UniMath/CategoryTheory/limits/binproducts.v
+++ b/UniMath/CategoryTheory/limits/binproducts.v
@@ -71,6 +71,22 @@ Proof.
   apply (base_paths _ _ H').
 Qed.
 
+Lemma BinProductArrowsEq (c d : C) (P : BinProductCone c d) (x : C)
+      (k1 k2 : x --> BinProductObject P) :
+  k1 ;; BinProductPr1 P = k2 ;; BinProductPr1 P ->
+  k1 ;; BinProductPr2 P = k2 ;; BinProductPr2 P ->
+  k1 = k2.
+Proof.
+  intros H1 H2.
+  set (p1 := k1 ;; BinProductPr1 P).
+  set (p2 := k1 ;; BinProductPr2 P).
+  rewrite (BinProductArrowUnique _ _ P _ p1 p2 k1).
+  apply pathsinv0.
+  apply BinProductArrowUnique.
+  unfold p1. apply pathsinv0. apply H1.
+  unfold p2. apply pathsinv0. apply H2.
+  apply idpath. apply idpath.
+Qed.
 
 Definition mk_BinProductCone (a b : C) :
   Π (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧),

--- a/UniMath/CategoryTheory/limits/coequalizers.v
+++ b/UniMath/CategoryTheory/limits/coequalizers.v
@@ -116,7 +116,8 @@ Section def_coequalizers.
 
   Lemma CoequalizerOutsEq {y z: C} {f g : y --> z} (E : Coequalizer f g)
         {w : C} (φ1 φ2: C⟦E, w⟧)
-        (H' : (CoequalizerArrow E) ;; φ1 = (CoequalizerArrow E) ;; φ2) : φ1 = φ2.
+        (H' : (CoequalizerArrow E) ;; φ1 = (CoequalizerArrow E) ;; φ2) :
+    φ1 = φ2.
   Proof.
     apply (isCoequalizerOutsEq (isCoequalizer_Coequalizer E) _ _ H').
   Defined.

--- a/UniMath/CategoryTheory/limits/coequalizers.v
+++ b/UniMath/CategoryTheory/limits/coequalizers.v
@@ -183,12 +183,11 @@ Section def_coequalizers.
     intros z0 g0 h X.
     apply (CoequalizerOutsEq E).
     apply X.
-  Defined.
+  Qed.
 
   Lemma CoequalizerArrowEpi {y z : C} {f g : y --> z} (E : Coequalizer f g ) :
     Epi _ z E.
   Proof.
-    apply (mk_Epi _ (CoequalizerArrow E)).
-    apply (CoequalizerArrowisEpi E).
+    exact (mk_Epi C (CoequalizerArrow E) (CoequalizerArrowisEpi E)).
   Defined.
 End def_coequalizers.

--- a/UniMath/CategoryTheory/limits/cokernels.v
+++ b/UniMath/CategoryTheory/limits/cokernels.v
@@ -195,7 +195,8 @@ Section cokernels_iso.
     apply CokernelCompZero.
   Qed.
 
-  Definition Cokernel_up_to_iso_isCoequalizer {x y z : C} (f : x --> y) (g : y --> z)
+  Definition Cokernel_up_to_iso_isCoequalizer {x y z : C} (f : x --> y)
+             (g : y --> z)
              (CK : Cokernel Z f) (h : iso CK z)
              (H : g = (CokernelArrow _ CK) ;; h) :
     isCoequalizer f (ZeroArrow C Z x y) g
@@ -245,7 +246,8 @@ Section cokernels_iso.
   Qed.
 
 
-  Definition Cokernel_up_to_iso2_isCoequalizer {x y z : C} (f1 : x --> z) (f2 : y --> z)
+  Definition Cokernel_up_to_iso2_isCoequalizer {x y z : C} (f1 : x --> z)
+             (f2 : y --> z)
              (h : iso y x) (H : h ;; f1 = f2)
              (CK : Cokernel Z f1) :
     isCoequalizer f2 (ZeroArrow C Z y z) (CokernelArrow Z CK)

--- a/UniMath/CategoryTheory/limits/cokernels.v
+++ b/UniMath/CategoryTheory/limits/cokernels.v
@@ -127,6 +127,15 @@ Section def_cokernels.
              (CK CK' : Cokernel g) : iso CK CK' :=
     tpair _ _ (isiso_from_Cokernel_to_Cokernel CK CK').
 
+
+  (** Composing with the CokernelArrow gives the zero arrow. *)
+  Lemma CokernelCompZero {y z : C} {g : y --> z} (CK : Cokernel g ) :
+    g ;; CokernelArrow CK = ZeroArrow C Z y CK.
+  Proof.
+    unfold CokernelArrow. use (pathscomp0 (CoequalizerEqAr CK)).
+    apply ZeroArrow_comp_left.
+  Defined.
+
   (** It follows that CokernelArrow is an epi. *)
   Lemma CokernelArrowisEpi {y z : C} {g : y --> z} (CK : Cokernel g ) :
     isEpi _ (CokernelArrow CK).

--- a/UniMath/CategoryTheory/limits/cokernels.v
+++ b/UniMath/CategoryTheory/limits/cokernels.v
@@ -136,6 +136,23 @@ Section def_cokernels.
     apply ZeroArrow_comp_left.
   Defined.
 
+  (** Cokernel of the morphism from zero object is given by identity *)
+  Lemma CokernelToZero {y : C} (hs : has_homsets C) (f : Z --> y) : Cokernel f.
+  Proof.
+    use mk_Cokernel.
+    apply y. apply (identity y).
+    apply ArrowsFromZero.
+
+    use mk_isCoequalizer.
+    intros w h H.
+
+    use unique_exists.
+    apply h. cbn. apply id_left.
+    intros y0. apply hs.
+    cbn. intros y0 t. rewrite <- t.
+    apply pathsinv0. apply id_left.
+  Defined.
+
   (** It follows that CokernelArrow is an epi. *)
   Lemma CokernelArrowisEpi {y z : C} {g : y --> z} (CK : Cokernel g ) :
     isEpi _ (CokernelArrow CK).
@@ -143,3 +160,58 @@ Section def_cokernels.
     apply CoequalizerArrowisEpi.
   Defined.
 End def_cokernels.
+
+
+(** In the following section we construct a new cokernel from an arrow which is
+  equal to cokernelarrow of some cokernel, up to postcomposing with an
+  isomorphism *)
+Section cokernels_iso.
+
+  Variable C : precategory.
+  Variable hs : has_homsets C.
+  Variable Z : Zero C.
+
+  Definition Cokernel_up_to_iso {x y z : C} (f : x --> y) (g : y --> z)
+             (CK : Cokernel Z f) (h : iso CK z)
+             (H : g = (CokernelArrow _ CK) ;; h) :
+    Cokernel Z f.
+  Proof.
+    use mk_Cokernel.
+    exact z.
+    exact g.
+    induction CK. induction t. induction p.
+    unfold isCoequalizer in p.
+    rewrite H.
+    rewrite <- (ZeroArrow_comp_left _ _ _ _ _ h).
+    rewrite assoc.
+    apply cancel_postcomposition.
+    apply CokernelCompZero.
+
+    (* isCoequalizer *)
+    apply mk_isCoequalizer.
+    induction CK. induction t. induction p.
+    unfold isCoequalizer in p.
+    intros w h0 HH.
+    set (tmp := p w h0 HH). cbn in tmp. cbn in h.
+    induction tmp.
+    induction t1.
+
+    use unique_exists.
+    exact ((inv_from_iso h) ;; t1).
+    cbn. rewrite <- p2.
+    rewrite assoc. apply cancel_postcomposition.
+    cbn in H. rewrite H. rewrite <- assoc.
+    rewrite <- id_right. apply cancel_precomposition.
+    apply iso_inv_after_iso.
+
+    intros y0. apply hs.
+    intros y0 X. cbn in X. cbn in H.
+    rewrite H in X.
+    rewrite <- assoc in X.
+    set (tmp := p1 (tpair _ (h ;; y0) X)).
+    apply base_paths in tmp. cbn in tmp.
+    rewrite <- tmp. rewrite assoc.
+    rewrite iso_after_iso_inv.
+    apply pathsinv0. apply id_left.
+  Defined.
+End cokernels_iso.

--- a/UniMath/CategoryTheory/limits/equalizers.v
+++ b/UniMath/CategoryTheory/limits/equalizers.v
@@ -82,7 +82,8 @@ Section def_equalizers.
     EqualizerArrow E ;; f = EqualizerArrow E ;; g := pr1 (pr2 E).
 
   (** Returns the property isEqualizer from Equalizer. *)
-  Definition isEqualizer_Equalizer {y z : C} {f g : y --> z} (E : Equalizer f g) :
+  Definition isEqualizer_Equalizer {y z : C} {f g : y --> z}
+             (E : Equalizer f g) :
     isEqualizer f g (EqualizerArrow E) (EqualizerEqAr E) := pr2 (pr2 E).
 
   (** Every morphism which satisfy the equalizer equality on morphism factors

--- a/UniMath/CategoryTheory/limits/equalizers.v
+++ b/UniMath/CategoryTheory/limits/equalizers.v
@@ -179,12 +179,11 @@ Section def_equalizers.
     intros z0 g0 h X.
     apply (EqualizerInsEq E).
     apply X.
-  Defined.
+  Qed.
 
   Lemma EqualizerArrowMonic {y z : C} {f g : y --> z} (E : Equalizer f g ) :
     Monic _ E y.
   Proof.
-    apply (mk_Monic _ (EqualizerArrow E)).
-    apply (EqualizerArrowisMonic E).
+    exact (mk_Monic C (EqualizerArrow E) (EqualizerArrowisMonic E)).
   Defined.
 End def_equalizers.

--- a/UniMath/CategoryTheory/limits/kernels.v
+++ b/UniMath/CategoryTheory/limits/kernels.v
@@ -128,6 +128,23 @@ Section def_kernels.
     apply ZeroArrow_comp_right.
   Defined.
 
+  (** Kernel of the morphism to zero object is given by identity *)
+  Lemma KernelToZero {y : C} (hs : has_homsets C) (f : y --> Z) : Kernel f.
+  Proof.
+    use mk_Kernel.
+    apply y. apply (identity y).
+    apply ArrowsToZero.
+
+    use mk_isEqualizer.
+    intros w h H.
+
+    use unique_exists.
+    apply h. cbn. apply id_right.
+    intros y0. apply hs.
+    cbn. intros y0 t. rewrite <- t.
+    apply pathsinv0. apply id_right.
+  Defined.
+
   (** It follows that KernelArrow is monic. *)
   Lemma KernelArrowisMonic {y z : C} {g : y --> z} (K : Kernel g ) :
     isMonic _ (KernelArrow K).
@@ -135,3 +152,56 @@ Section def_kernels.
     exact (EqualizerArrowisMonic K).
   Defined.
 End def_kernels.
+
+(** In the following section we construct a new kernel from an arrow which is
+  equal to kernelarrow of some kernel, up to precomposing with an isomorphism *)
+Section kernels_iso.
+
+  Variable C : precategory.
+  Variable hs : has_homsets C.
+  Variable Z : Zero C.
+
+  Definition Kernel_up_to_iso {x y z : C} (f : x --> y) (g : y --> z)
+             (K : Kernel Z g) (h : iso x K)
+             (H : f = h ;; (KernelArrow _ K)) :
+    Kernel Z g.
+  Proof.
+    use mk_Kernel.
+    exact x.
+    exact f.
+    induction K. induction t. induction p.
+    unfold isEqualizer in p.
+    rewrite H.
+    rewrite <- (ZeroArrow_comp_right _ _ _ _ _ h).
+    rewrite <- assoc.
+    apply cancel_precomposition.
+    apply KernelCompZero.
+
+    (* isEqualizer *)
+    apply mk_isEqualizer.
+    induction K. induction t. induction p.
+    unfold isEqualizer in p.
+    intros w h0 HH.
+    set (tmp := p w h0 HH). cbn in tmp. cbn in h.
+    induction tmp.
+    induction t1.
+
+    use unique_exists.
+    exact (t1 ;; (inv_from_iso h)).
+    cbn. rewrite <- p2.
+    rewrite <- assoc. apply cancel_precomposition.
+    cbn in H. rewrite H. rewrite assoc.
+    rewrite <- id_left. apply cancel_postcomposition.
+    apply iso_after_iso_inv.
+
+    intros y0. apply hs.
+    intros y0 X. cbn in X. cbn in H.
+    rewrite H in X.
+    rewrite assoc in X.
+    set (tmp := p1 (tpair _ (y0 ;; h) X)).
+    apply base_paths in tmp. cbn in tmp.
+    rewrite <- tmp. rewrite <- assoc.
+    rewrite iso_inv_after_iso.
+    apply pathsinv0. apply id_right.
+  Defined.
+End kernels_iso.

--- a/UniMath/CategoryTheory/limits/kernels.v
+++ b/UniMath/CategoryTheory/limits/kernels.v
@@ -120,6 +120,14 @@ Section def_kernels.
              (K K' : Kernel g) : iso K K' :=
     tpair _ _ (isiso_from_Kernel_to_Kernel K K').
 
+  (** Composing with the KernelArrow gives the zero arrow. *)
+  Lemma KernelCompZero {x y : C} {f : x --> y} (K : Kernel f ) :
+    KernelArrow K ;; f = ZeroArrow C Z K y.
+  Proof.
+    unfold KernelArrow. use (pathscomp0 (EqualizerEqAr K)).
+    apply ZeroArrow_comp_right.
+  Defined.
+
   (** It follows that KernelArrow is monic. *)
   Lemma KernelArrowisMonic {y z : C} {g : y --> z} (K : Kernel g ) :
     isMonic _ (KernelArrow K).

--- a/UniMath/CategoryTheory/limits/kernels.v
+++ b/UniMath/CategoryTheory/limits/kernels.v
@@ -235,7 +235,8 @@ Section kernels_iso.
     apply ZeroArrow_comp_left.
   Qed.
 
-  Definition Kernel_up_to_iso2_isEqualizer {x y z : C} (f1 : x --> y) (f2 : x --> z)
+  Definition Kernel_up_to_iso2_isEqualizer {x y z : C} (f1 : x --> y)
+             (f2 : x --> z)
              (h : iso y z) (H : f1 ;; h = f2)
              (K : Kernel Z f1) :
     isEqualizer f2 (ZeroArrow C Z x z) (KernelArrow Z K)

--- a/UniMath/CategoryTheory/limits/pushouts.v
+++ b/UniMath/CategoryTheory/limits/pushouts.v
@@ -333,7 +333,7 @@ Section epi_po.
 End epi_po.
 
 
-(** Criteria for existence of pushout. *)
+(** Criteria for existence of pushouts. *)
 Section po_criteria.
 
   Variable C : precategory.
@@ -396,13 +396,15 @@ Section po_criteria.
                                (g ;; (BinCoproductIn2 C BinCoprod))) :
     Pushout f g.
   Proof.
-    use (mk_Pushout f g CEq ((BinCoproductIn1 C BinCoprod) ;; CoequalizerArrow CEq)
+    use (mk_Pushout f g CEq ((BinCoproductIn1 C BinCoprod)
+                               ;; CoequalizerArrow CEq)
                     ((BinCoproductIn2 C BinCoprod) ;; CoequalizerArrow CEq)).
     apply Pushout_from_Coequalizer_BinCoproduct_eq.
     apply Pushout_from_Coequalizer_BinCoproduct_isPushout.
   Defined.
 
-  Definition Pushouts_from_Coequalizers_BinCoproducts (BinCoprods : BinCoproducts C)
+  Definition Pushouts_from_Coequalizers_BinCoproducts
+             (BinCoprods : BinCoproducts C)
              (CEqs : @Coequalizers C) :
     @Pushouts C.
   Proof.


### PR DESCRIPTION
Hi,

this pull request contains the following
- Definition of the precategory consisting of setswithbinops.
  (category_binops.v)
- Definition of the precategory consisting of abelian groups.
  (category_abgr.v)
- Definition of additive category.
  (Additive.v)
- A proof that the category consisting of abelian groups is additive.
  (ABGR_additive in category_abgr.v)

I have not been able to do the following
- Verify that binop_precategory and abgr_precategory are actually categories and
  not just precategories with has_homsets.
- Formalization of abelian categories and the fact that the category of abelian
  groups is an abelian category.

I guess the problem in the latter is that I don't know how to work with hProp.
In particular, I don't know how to make an equality of morphisms in a
precategory with has_homsets into an hProp, if this equality is the goal. This, is
needed(?) in proving that kernels exist in abgr_precategory. Similarly, in the
definition of abelian categories I have used \forall and \exists instead of
forall and exists, and because of these I don't know how to construct kernels
and cokernels in abelian category. Please, see the end of the files
category_abgr.v and Abelian.v .

Both category_binops.v and category_abgr.v use funextfun.

If you want that I break this pull request into smaller pull requests please
let me know. All comments are welcome.
