### PR TITLE
Updated doc for substitution systems

### DIFF
--- a/UniMath/CategoryTheory/README.md
+++ b/UniMath/CategoryTheory/README.md
@@ -49,6 +49,24 @@ The toplevel files contain the formalization of the Rezk Completion:
 * *rezk_completion.v*
   * put the previous files together and exhibit the Rezk completion
 
+### many more files that were not needed for the Rezk completion
+* *AdjunctionHomTypesWeq.v*
+  * Derivation of the data of an adjunction in terms of equivalence of hom-types from the definition of adjunction in terms of unit and counit
+* *EndofunctorsMonoidal.v*
+  * Definition of the (weak) monoidal structure on endofunctors
+* *HorizontalComposition.v*
+  * Definition of horizontal composition for natural transformations
+* *PointedFunctors.v*
+  * Definition of precategory of pointed endofunctors
+  * Forgetful functor to precategory of endofunctors
+* *PointedFunctorsComposition.v*
+  * Definition of composition of pointed functors
+* *ProductPrecategory.v*
+  * Definition of the cartesian product of two precategories
+  * From a functor on a product of precategories to a functor on one of the categories by fixing the argument in the other component
+* *RightKanExtension.v*
+  * Definition of global right Kan extension as right adjoint to precomposition
+  
 ### The subdirectories
 
 * *limits*

--- a/UniMath/CategoryTheory/limits/README.md
+++ b/UniMath/CategoryTheory/limits/README.md
@@ -35,7 +35,7 @@ This directory contains the definition of some limits for the notion of precateg
 * *kernels.v* --- direct formalization of kernels
 * *cokernels.v* --- direct formalization of cokernels
 * *FunctorsPointwiseBinProduct.v*  --- definition of a binary product structure on a functor category by taking pointwise binary products in the target category
-* *FunctorsPointwiseBinCoproduct.v* --- definition of a coproduct structure on a functor category by taking pointwise coproducts in the target category; option functor as special case
+* *FunctorsPointwiseBinCoproduct.v* --- definition of a coproduct structure on a functor category by taking pointwise binary coproducts in the target category; option functor as special case
 * *FunctorsPointwiseProduct.v* --- same with arbitrary products
 * *FunctorsPointwiseCoproduct.v* --- same with arbitrary coproducts
 * *graphs* --- development of limits on the basis of descriptions of diagrams by graphs

--- a/UniMath/SubstitutionSystems/README.md
+++ b/UniMath/SubstitutionSystems/README.md
@@ -9,56 +9,61 @@ Report on the formalization and some additional results are given in
 
 Ahrens & Matthes, [Heterogeneous substitution systems revisited](http://arxiv.org/abs/1601.04299)
 
-# Contents
+# Contents (alphabetic order of files)
 
-* *AdjunctionHomTypesWeq.v*
-  * Derivation of the data of an adjunction in terms of equivalence of hom-types from the definition of adjunction in terms of unit and counit
-* *Auxiliary.v*
-  * various helper lemmas that should be moved upstream
-* *EndofunctorsMonoidal.v*
-  * Definition of the (weak) monoidal structure on endofunctors
-* *FunctorsPointwiseCoproduct.v*
-  * Definition of a coproduct structure on a functor category by taking pointwise coproducts in the target category
-* *FunctorsPointwiseProduct.v*
-  * Definition of a product structure on a functor category by taking pointwise products in the target category
+* *BinProductOfSignatures.v* --- in particular infers strength for the product and proves omega-cocontinuity 
+* *BinSumOfSignatures.v* --- same with sums instead of products (needed to model finitely many constructors)
 * *GenMendlerIteration.v*
+  * assumes an initial algebra
   * Derivation of Generalized Mendler Iteration
   * Instantiation to a special case, Specialized Mendler Iteration
   * Proof of a fusion law à la Bird-Paterson (Generalised folds for nested datatypes) for Generalized Mendler Iteration
-* *HorizontalComposition.v*
-  * Definition of horizontal composition for natural transformations
+* *GenSigToMonad.v*
+  * defines the notion of "general signature" which captures a decidable set of constructors with finitely many binders in their finitely many arguments - this is a purely syntactic definition
+  * signatures in the sense of this package are derived
+  * a lot of material also from CategoryTheory is employed to get an initial algebra interpreting the general signature and getting the associated initial heterogeneous substitution system and monad
+* *LamFromGenSig.v*
+  * signature of lambda calculus obtained from general constructions starting from a "general signatures" (a variation on the development in LamFromSig.v)
+* *LamFromSig.v*
+  * signature of lambda calculus obtained from general constructions
+  * equational laws for catamorphisms/folds on lamba calculus
+* *LamHSET.v* --- instantiates the main result of LiftingInitial.v for Lam in the category HSET and obtains an initial heterogeneous substitution system and a monad
 * *LamSignature.v*
-  * Definition of the arities of the constructors of lambda calculus
-  * Definition of the signatures of lambda calculus and lambda calculus with explicit flattening
+  * "Manual" definition of the arities of the constructors of lambda calculus
+  * "Manual" definition of the signatures of lambda calculus and lambda calculus with explicit flattening
+  * omega-cocontinuity only for lambda calculus established by reference to general results, no such result for lambda calculus with explicit flattening
 * *Lam.v*
   * Specification of an initial morphism of substitution systems from lambda calculus with explicit flattening to lambda calculus
+  * the bracket property still has a very long monolithic proof
 * *LiftingInitial.v*
   * Construction of a substitution system from an initial algebra 
   * Proof that the substitution system constructed from an initial algebra is an initial substitution system
+* *MLTT79.v* --- the syntax of Martin-Löf's type theory in the style of LamFromGenSig.v
 * *MonadsFromSubstitutionSystems.v*
   * Construction of a monad from a substitution system
   * Proof that morphism of hss gives morphism of monads
   * Bundling that into a functor
   * Proof that the functor is faithful
-* *PointedFunctors.v*
-  * Definition of precategory of pointed endofunctors
-  * Forgetful functor to precategory of endofunctors
-* *PointedFunctorsComposition.v*
-  * Definition of composition of pointed functors
-* *ProductPrecategory.v*
-  * Definition of the cartesian product of two precategories
-  * From a functor on a product of precategories to a functor on one of the categories by fixing the argument in the other component
-* *RightKanExtension.v*
-  * Definition of global right Kan extension as right adjoint to precomposition
+* *Notation.v* --- notation that is used in this package but that is not specific to the topic of the package
+* *SignatureExamples.v*
+   * provides a general construction of θ in a signature in the case when the functor is precomposition with a functor G by starting with a family of simpler
+   distributive laws δ
+   * multiplication of distributive laws δ
+   * distributive laws δ for option and iterations of a functor
 * *Signatures.v*
   * Definition of signatures
   * Proof that two forms of strength laws are equivalent
+* *SigToMonad.v*
+  * based on syntactic notion of signature that underlies LamFromSig.v
+  * puts together all the needed semantic signature lemmas over HSET as base category, instantiates main results for obtaining a monad 
+* *SubstitutionSystems_Summary.v* --- provides a stable interface to
+  the formalization of heterogeneous substitution systems as
+  defined by Matthes and Uustalu
 * *SubstitutionSystems.v*
   * Definition of heterogeneous substitution systems
   * Various lemmas about the substitution ("bracket") operation
   * Definition of precategory of substitution systems
-* *SumOfSignatures.v*
-  * Definition of the sum of two signatures, in particular proof of strength laws for the sum
+* *SumOfSignatures.v* --- generalization of BinSumOfSignatures.v to sums over a decidable index set
 
 
 

--- a/UniMath/SubstitutionSystems/README.md
+++ b/UniMath/SubstitutionSystems/README.md
@@ -22,8 +22,7 @@ Ahrens & Matthes, [Heterogeneous substitution systems revisited](http://arxiv.or
   * defines the notion of "general signature" which captures a decidable set of constructors with finitely many binders in their finitely many arguments - this is a purely syntactic definition
   * signatures in the sense of this package are derived
   * a lot of material also from CategoryTheory is employed to get an initial algebra interpreting the general signature and getting the associated initial heterogeneous substitution system and monad
-* *LamFromGenSig.v*
-  * signature of lambda calculus obtained from general constructions starting from a "general signatures" (a variation on the development in LamFromSig.v)
+* *LamFromGenSig.v* --- signature of lambda calculus obtained from general constructions starting from a "general signatures" (a variation on the development in LamFromSig.v)
 * *LamFromSig.v*
   * signature of lambda calculus obtained from general constructions
   * equational laws for catamorphisms/folds on lamba calculus


### PR DESCRIPTION
just an overhaul of the README so that precisely the existing files are described
doc of files that are now elsewhere has been moved to the relevant README - see the commit log