### PR TITLE
New definition of Dcuts_minus

### DIFF
--- a/UniMath/RealNumbers/DecidableDedekindCuts.v
+++ b/UniMath/RealNumbers/DecidableDedekindCuts.v
@@ -43,7 +43,7 @@ Lemma is_zero_dec :
   Π x : Dcuts, isboolDcuts x -> (x = 0) ∨ (¬ (x = 0)).
 Proof.
   intros x Hx.
-  generalize (Hx 0%NRat) ; apply hinhfun ; intros [Hx0 | Hx0].
+  generalize (Hx 0%NRat) ; apply hinhfun ; apply sumofmaps ; intros Hx0.
   - right ; intro H.
     rewrite H in Hx0.
     now apply Dcuts_zero_empty in Hx0.

--- a/UniMath/RealNumbers/NonnegativeRationals.v
+++ b/UniMath/RealNumbers/NonnegativeRationals.v
@@ -57,33 +57,43 @@ Qed.
 Local Definition hnnq_ge : hrel hnnq_set := resrel hqgeh (hqleh 0).
 Local Lemma ispreorder_hnnq_ge : ispreorder hnnq_ge.
 Proof.
-  destruct ispreorder_hnnq_le as [Htrans Hrefl].
+  set (H := ispreorder_hnnq_le).
   split.
   intros x y z Hxy Hyz.
-  now apply Htrans with y.
+  now apply (pr1 H) with y.
   intros x.
-  now apply Hrefl.
+  now apply (pr2 H).
 Qed.
 
 Local Definition hnnq_lt : hrel hnnq_set := resrel hqlth (hqleh 0).
 Local Lemma isStrongOrder_hnnq_lt : isStrongOrder hnnq_lt.
 Proof.
-  split.
-  intros x y z.
-  now apply istranshqlth.
-  intros x.
-  now apply isirreflhqlth.
+  repeat split.
+  - intros x y z.
+    now apply istranshqlth.
+  - intros x y z Hxz.
+    generalize (hqlthorgeh (pr1 x) (pr1 y)) ; apply sumofmaps ; intros Hxy.
+    apply hinhpr ; left.
+    exact Hxy.
+    apply hinhpr ; right.
+    apply hqlehlthtrans with (pr1 x).
+    exact Hxy.
+    exact Hxz.
+  - intros x.
+    now apply isirreflhqlth.
 Qed.
 
 Local Definition hnnq_gt : hrel hnnq_set := resrel hqgth (hqleh 0).
 Local Lemma isStrongOrder_hnnq_gt : isStrongOrder hnnq_gt.
 Proof.
-  destruct isStrongOrder_hnnq_lt as [Htrans Hirrefl].
-  split.
-  intros x y z Hxy Hyz.
-  now apply Htrans with y.
+  set (H := isStrongOrder_reverse _ isStrongOrder_hnnq_lt).
+  repeat split.
+  intros x y z.
+  now apply (pr1 H).
+  intros x y z.
+  now apply (pr1 (pr2 H)).
   intros x.
-  now apply Hirrefl.
+  now apply (pr2 (pr2 H)).
 Qed.
 
 Local Lemma isEffectiveOrder_hnnq : isEffectiveOrder hnnq_le hnnq_lt.
@@ -104,26 +114,23 @@ Qed.
 Local Lemma iscomm_hnnq_plus:
   iscomm hnnq_plus.
 Proof.
-  intros (x,Hx) (y,Hy).
-  apply subtypeEquality ; simpl pr1.
-  - now intro ; apply pr2.
-  - now apply hqpluscomm.
+  intros x y.
+  apply subtypeEquality_prop.
+  now apply hqpluscomm.
 Qed.
 Local Lemma isassoc_hnnq_plus :
   isassoc hnnq_plus.
 Proof.
-  intros (x,Hx) (y,Hy) (z,Hz).
-  apply subtypeEquality ; simpl pr1.
-  - now intro ; apply pr2.
-  - now apply hqplusassoc.
+  intros x y z.
+  apply subtypeEquality_prop.
+  now apply hqplusassoc.
 Qed.
 Local Lemma islunit_hnnq_zero_plus:
   islunit hnnq_plus hnnq_zero.
 Proof.
-  intros (x,Hx).
-  apply subtypeEquality ; simpl pr1.
-  - now intro ; apply pr2.
-  - now apply hqplusl0.
+  intros x.
+  apply subtypeEquality_prop.
+  now apply hqplusl0.
 Qed.
 Local Lemma isrunit_hnnq_zero_plus:
   isrunit hnnq_plus hnnq_zero.
@@ -135,26 +142,23 @@ Qed.
 Local Lemma iscomm_hnnq_mult:
   iscomm hnnq_mult.
 Proof.
-  intros (x,Hx) (y,Hy).
-  apply subtypeEquality ; simpl pr1.
-  - now intro ; apply pr2.
-  - now apply hqmultcomm.
+  intros x y.
+  apply subtypeEquality_prop.
+  now apply hqmultcomm.
 Qed.
 Local Lemma isassoc_hnnq_mult:
   isassoc hnnq_mult.
 Proof.
-  intros (x,Hx) (y,Hy) (z,Hz).
-  apply subtypeEquality ; simpl pr1.
-  - now intro ; apply pr2.
-  - now apply hqmultassoc.
+  intros x y z.
+  apply subtypeEquality_prop.
+  now apply hqmultassoc.
 Qed.
 Local Lemma islunit_hnnq_one_mult:
   islunit hnnq_mult hnnq_one.
 Proof.
-  intros (x,Hx).
-  apply subtypeEquality ; simpl pr1.
-  - now intro ; apply pr2.
-  - now apply hqmultl1.
+  intros x.
+  apply subtypeEquality_prop.
+  now apply hqmultl1.
 Qed.
 Local Lemma isrunit_hnnq_one_mult:
   isrunit hnnq_mult hnnq_one.
@@ -167,13 +171,14 @@ Local Lemma islinv'_hnnq_inv:
   islinv' hnnq_one hnnq_mult (hnnq_lt hnnq_zero)
           (λ x : subset (hnnq_lt hnnq_zero), hnnq_inv (pr1 x)).
 Proof.
-  intros (x,Hx) Hx0.
+  intros x Hx0.
   unfold hnnq_inv.
-  destruct hqlehchoice as [Hx0' | Hx0'] ; simpl in Hx0'.
-  - apply subtypeEquality; simpl pr1.
-    + now intro ; apply pr2.
-    + apply hqislinvmultinv.
-      now apply (hqgth_hqneq x 0), Hx0'.
+  change (hqlehchoice 0 (pr1 (pr1 (x,, Hx0))) (pr2 (pr1 (x,, Hx0)))) with (hqlehchoice 0 (pr1 x) (pr2 x)).
+  generalize (hqlehchoice 0 (pr1 x) (pr2 x)).
+  apply coprod_rect ; intros Hx0'.
+  - apply subtypeEquality_prop.
+    apply hqislinvmultinv.
+    now apply (hqgth_hqneq (pr1 x) 0), Hx0'.
   - apply pathsinv0 in Hx0'.
     apply fromempty ; revert Hx0'.
     apply hqgth_hqneq, Hx0.
@@ -189,10 +194,9 @@ Qed.
 Local Lemma isldistr_hnnq_plus_mult:
   isldistr hnnq_plus hnnq_mult.
 Proof.
-  intros (x,Hx) (y,Hy) (z,Hz).
-  apply subtypeEquality ; simpl pr1.
-  - now intro ; apply pr2.
-  - now apply hqldistr.
+  intros x y z.
+  apply subtypeEquality_prop.
+  now apply hqldistr.
 Qed.
 Local Lemma isrdistr_hnnq_plus_mult:
   isrdistr hnnq_plus hnnq_mult.
@@ -342,7 +346,7 @@ Lemma plusNonnegativeRationals_correct :
   Π (x y : NonnegativeRationals),
     x + y = Rationals_to_NonnegativeRationals (pr1 x + pr1 y)%hq (hq0lehandplus _ _ (pr2 x) (pr2 y)).
 Proof.
-  intros (x,Hx) (y,Hy).
+  intros x y.
   apply subtypeEquality_prop.
   reflexivity.
 Qed.
@@ -350,20 +354,23 @@ Lemma minusNonnegativeRationals_correct :
   Π (x y : NonnegativeRationals) (Hminus : y <= x),
     x - y = Rationals_to_NonnegativeRationals (pr1 x - pr1 y)%hq (hq0leminus _ _ Hminus).
 Proof.
-  intros (x,Hx) (y,Hy) H.
+  intros x y H.
   apply subtypeEquality_prop.
   unfold minusNonnegativeRationals, hnnq_minus.
-  destruct hqgthorleh as [Hgt | Hle].
+  generalize (hqgthorleh (pr1 x) (pr1 y)).
+  apply coprod_rect ; [intros Hgt | intros Hle].
   - reflexivity.
-  - simpl in H, Hle |- *.
-    rewrite (isantisymmhqleh _ _ Hle H), hqrminus.
+  - generalize (isantisymmhqleh _ _ Hle H) ; intros Heq.
+    generalize (hq0leminus (pr1 y) (pr1 x) H).
+    rewrite Heq, hqrminus.
+    intros H0.
     reflexivity.
 Qed.
 Lemma multNonnegativeRationals_correct :
   Π (x y : NonnegativeRationals),
     x * y = Rationals_to_NonnegativeRationals (pr1 x * pr1 y)%hq ( hq0lehandmult _ _ (pr2 x) (pr2 y)).
 Proof.
-  intros (x,Hx) (y,Hy).
+  intros x y.
   apply subtypeEquality_prop.
   reflexivity.
 Qed.
@@ -371,13 +378,15 @@ Lemma invNonnegativeRationals_correct :
   Π (x : NonnegativeRationals) (Hx : 0 < x),
     / x = Rationals_to_NonnegativeRationals (/ pr1 x)%hq (hqlthtoleh _ _ (hqinv_gt0 _ Hx)).
 Proof.
-  intros (x,Hx) Hx0.
+  intros x Hx0.
   apply subtypeEquality_prop.
   unfold invNonnegativeRationals, hnnq_inv.
-  destruct hqlehchoice as [Hlt | Heq].
+  generalize (hqlehchoice 0%hq (pr1 x) (pr2 x)).
+  apply coprod_rect ; [intros Hlt | intros Heq].
   - reflexivity.
-  - simpl in Heq.
-    apply fromempty ; revert Hx Hx0.
+  - apply fromempty ; generalize Hx0.
+    rewrite (tppr x).
+    generalize (pr2 x).
     rewrite <- Heq ; intro.
     exact (isirreflhqlth 0%hq).
 Qed.
@@ -414,12 +423,12 @@ Qed.
 Lemma isdeceq_NonnegativeRationals :
   Π x y : NonnegativeRationals, (x = y) ⨿ (x != y).
 Proof.
-  intros (x,Hx) (y,Hy).
-  destruct (isdeceqhq x y) as [H|H].
+  intros x y.
+  generalize (isdeceqhq (pr1 x) (pr1 y)) ;
+  apply sumofmaps ; intros H.
   - left.
-    apply subtypeEquality; simpl pr1.
-    + now intro ; apply pr2.
-    + exact H.
+    apply subtypeEquality_prop.
+    exact H.
   - right.
     intros H0 ; apply H.
     revert H0.
@@ -442,8 +451,8 @@ Lemma le_eqorltNonnegativeRationals :
   Π x y : NonnegativeRationals, x <= y -> (x = y) ⨿ (x < y).
 Proof.
   intros x y Hle.
-  destruct (hqlehchoice (pr1 x) (pr1 y)) as [Hlt | Heq].
-  - exact Hle.
+  generalize (hqlehchoice (pr1 x) (pr1 y) Hle) ;
+    apply sumofmaps ; [intros Hlt | intros Heq].
   - right ; exact Hlt.
   - left.
     now apply subtypeEquality_prop, Heq.
@@ -452,10 +461,11 @@ Lemma noteq_ltorgtNonnegativeRationals :
   Π x y : NonnegativeRationals, x != y -> (x < y) ⨿ (x > y).
 Proof.
   intros x y Hneq.
-  destruct (isdecrel_leNonnegativeRationals x y) as [Hle|Hlt].
+  generalize (isdecrel_leNonnegativeRationals x y) ;
+    apply sumofmaps ; [intros Hle|intros Hlt].
   - left.
     apply le_eqorltNonnegativeRationals in Hle.
-    destruct Hle as [Heq | Hlt].
+    revert Hle ; apply sumofmaps ; [intros Heq | intros Hlt].
     + now apply fromempty, Hneq, Heq.
     + exact Hlt.
   - right.
@@ -466,8 +476,7 @@ Lemma eq0orgt0NonnegativeRationals :
   Π x : NonnegativeRationals, (x = 0) ⨿ (0 < x).
 Proof.
   intros x.
-  destruct (le_eqorltNonnegativeRationals 0 x) as [Hx | Hx].
-  now apply (pr2 x).
+  generalize (le_eqorltNonnegativeRationals 0 x (pr2 x)) ; apply sumofmaps ; intros Hx.
   rewrite Hx ; now left.
   right ; exact Hx.
 Qed.
@@ -535,15 +544,13 @@ Lemma between_ltNonnegativeRationals :
     x < y -> Σ t : NonnegativeRationals, x < t × t < y.
 Proof.
   intros x y H.
-  destruct (hqlth_between (pr1 x) (pr1 y) H) as [z (Hxz,Hzy)].
-  assert (Hz : hqleh 0%hq z).
+  set (z := hqlth_between (pr1 x) (pr1 y) H).
+  assert (Hz : hqleh 0%hq (pr1 z)).
   { apply istranshqleh with (pr1 x).
     now apply (pr2 x).
-    apply (hqlthtoleh (pr1 x) z), Hxz. }
-  exists (hq_to_hnnq_set z Hz).
-  split.
-  exact Hxz.
-  exact Hzy.
+    apply (hqlthtoleh (pr1 x) (pr1 z)), (pr1 (pr2 z)). }
+  exists (hq_to_hnnq_set _ Hz).
+  exact (pr2 z).
 Qed.
 
 (** *** Order and 0 *)
@@ -753,9 +760,10 @@ Qed.
 Lemma minusNonnegativeRationals_eq_zero:
   Π x y : NonnegativeRationals, x <= y -> x - y = 0.
 Proof.
-  intros (x,Hx) (y,Hy) Hle.
-  unfold minusNonnegativeRationals, hnnq_minus ; simpl pr1.
-  destruct hqgthorleh as [H | H].
+  intros x y Hle.
+  unfold minusNonnegativeRationals, hnnq_minus.
+  generalize (hqgthorleh (pr1 x) (pr1 y)).
+  apply coprod_rect ; intros H.
   - apply fromempty.
     exact (Hle H).
   - reflexivity.
@@ -764,26 +772,36 @@ Lemma minusNonnegativeRationals_plus_r :
   Π r q : NonnegativeRationals,
     r <= q -> (q - r) + r = q.
 Proof.
-  intros (r,Hr) (q,hq) H ; simpl in H.
+  intros r q H.
   unfold minusNonnegativeRationals, hnnq_minus.
-  destruct hqgthorleh as [H'|H'].
+  generalize (hqgthorleh (pr1 q) (pr1 r)).
+  apply coprod_rect ; intros H'.
   - apply subtypeEquality_prop.
-    unfold hqminus ; simpl.
+    unfold hqminus.
+    pattern r at 4 ;
+      rewrite (tppr r).
+    generalize (pr1 r) (pr1 q) (pr2 r) (hq0leminus (pr1 r) (pr1 q) (hqlthtoleh (pr1 r) (pr1 q) H')) ; intros r' q' Hr Hrq.
+    simpl.
     now rewrite hqplusassoc, hqlminus, hqplusr0.
-  - apply subtypeEquality_prop ; simpl pr1.
-    rewrite hqplusl0.
-    now apply isantisymmhqleh.
+  - apply subtypeEquality_prop.
+    rewrite (tppr r).
+    generalize (isantisymmhqleh _ _ H H').
+    generalize (pr1 r) (pr2 r) (pr1 q) ; intros r' Hr' q' Heq.
+    simpl.
+    now rewrite hqplusl0.
 Qed.
 
 Lemma plusNonnegativeRationals_minus_r :
   Π q r : NonnegativeRationals, (r + q) - q = r.
 Proof.
-  intros (q,Hq) (r,Hr).
+  intros q r.
+  rewrite (tppr r), (tppr q).
+  generalize (pr1 r) (pr2 r) (pr1 q) (pr2 q) ; intros r' Hr q' Hq.
   rewrite (minusNonnegativeRationals_correct _ _ (plusNonnegativeRationals_le_l _ _)).
   apply subtypeEquality_prop.
   simpl pr1.
   unfold hqminus.
-  now rewrite hqplusassoc, (hqpluscomm q), (hqlminus q), hqplusr0.
+  now rewrite hqplusassoc, (hqpluscomm q'), (hqlminus q'), hqplusr0.
 Qed.
 Lemma plusNonnegativeRationals_minus_l :
   Π q r : NonnegativeRationals, (q + r) - q = r.
@@ -831,11 +849,12 @@ Proof.
     exact Hxy.
     apply plusNonnegativeRationals_le_r. }
   rewrite (minusNonnegativeRationals_correct _ _ Hxy), (minusNonnegativeRationals_correct _ _ Hxzy).
-  destruct x as (x,Hx0) ;
-    destruct y as (y,Hy0) ;
-    destruct z as (z,Hz0).
-  apply subtypeEquality_prop ; simpl pr1.
-  now unfold hqminus ; rewrite !hqplusassoc, (hqpluscomm z).
+  revert Hxy Hxzy.
+  rewrite (tppr x), (tppr y), (tppr z).
+  intros.
+  apply subtypeEquality_prop.
+  change (pr1 x - pr1 y + pr1 z = (pr1 x + pr1 z) - pr1 y)%hq.
+  now unfold hqminus ; rewrite !hqplusassoc, (hqpluscomm (pr1 z)).
 Qed.
 
 (** Order *)
@@ -851,7 +870,8 @@ Proof.
     + now apply lt_leNonnegativeRationals, Hlt.
   - revert Hlt.
     unfold minusNonnegativeRationals, hnnq_minus.
-    destruct hqgthorleh as [H0 | H0] ; intro Hlt.
+    generalize (hqgthorleh (pr1 y) (pr1 x)).
+    apply (coprod_rect (λ _, _ → _)) ; intros H0 ; intro Hlt.
     + exact H0.
     + now apply isirrefl_ltNonnegativeRationals in Hlt.
 Qed.
@@ -861,7 +881,8 @@ Lemma minusNonnegativeRationals_le :
 Proof.
   intros x y.
   apply_pr2 (plusNonnegativeRationals_lecompat_r y).
-  destruct (isdecrel_leNonnegativeRationals y x) as [Hle | Hlt].
+  generalize (isdecrel_leNonnegativeRationals y x) ;
+    apply sumofmaps ; [intros Hle | intros Hlt].
   - rewrite minusNonnegativeRationals_plus_r.
     now apply plusNonnegativeRationals_le_r.
     exact Hle.
@@ -876,7 +897,8 @@ Lemma minusNonnegativeRationals_lecompat_l :
   Π k x y : NonnegativeRationals, x <= y -> x - k <= y - k.
 Proof.
   intros k x y Hxy.
-  case (isdecrel_leNonnegativeRationals k x) ; intros Hkx.
+  generalize (isdecrel_leNonnegativeRationals k x) ;
+    apply sumofmaps ; intros Hkx.
   - apply_pr2 (plusNonnegativeRationals_lecompat_r k).
     rewrite !minusNonnegativeRationals_plus_r.
     exact Hxy.
@@ -890,7 +912,8 @@ Lemma minusNonnegativeRationals_lecompat_l' :
   Π k x y : NonnegativeRationals, k <= y -> x - k <= y - k -> x <= y.
 Proof.
   intros k x y Hky H.
-  case (isdecrel_leNonnegativeRationals k x) ; intros Hkx.
+  generalize (isdecrel_leNonnegativeRationals k x) ;
+    apply sumofmaps ; intros Hkx.
   - rewrite <- (minusNonnegativeRationals_plus_r _ _ Hkx), <- (minusNonnegativeRationals_plus_r _ _ Hky).
     apply plusNonnegativeRationals_lecompat_r.
     exact H.
@@ -904,7 +927,8 @@ Lemma minusNonnegativeRationals_lecompat_r :
   Π k x y : NonnegativeRationals, x <= y -> k - y <= k - x.
 Proof.
   intros k x y Hxy.
-  case (isdecrel_leNonnegativeRationals y k) ; intros Hky.
+  generalize (isdecrel_leNonnegativeRationals y k) ;
+    apply sumofmaps ; intros Hky.
   - apply_pr2 (plusNonnegativeRationals_lecompat_r y).
     rewrite minusNonnegativeRationals_plus_r, minusNonnegativeRationals_plus_exchange, iscomm_plusNonnegativeRationals, <- minusNonnegativeRationals_plus_exchange.
     apply plusNonnegativeRationals_le_l.
@@ -921,7 +945,8 @@ Lemma minusNonnegativeRationals_lecompat_r' :
   Π k x y : NonnegativeRationals, x <= k -> k - y <= k - x -> x <= y.
 Proof.
   intros k x y Hkx H.
-  case (isdecrel_leNonnegativeRationals y k) ; intros Hky.
+  generalize (isdecrel_leNonnegativeRationals y k) ;
+    apply sumofmaps ; intros Hky.
   - apply (plusNonnegativeRationals_lecompat_r y) in H.
     rewrite minusNonnegativeRationals_plus_r, iscomm_plusNonnegativeRationals in H.
     apply (plusNonnegativeRationals_lecompat_r x) in H ; rewrite isassoc_plusNonnegativeRationals, minusNonnegativeRationals_plus_r, iscomm_plusNonnegativeRationals in H.
@@ -938,7 +963,8 @@ Lemma minusNonnegativeRationals_ltcompat_l:
   Π x y z : NonnegativeRationals, x < y -> z < y -> x - z < y - z.
 Proof.
   intros x y z Hxy Hyz.
-  case (isdecrel_leNonnegativeRationals x z) ; intros Hxz.
+  generalize (isdecrel_leNonnegativeRationals x z) ;
+    apply sumofmaps ; intros Hxz.
   - rewrite minusNonnegativeRationals_eq_zero.
     apply ispositive_minusNonnegativeRationals.
     exact Hyz.
@@ -958,7 +984,8 @@ Proof.
     apply istrans_le_lt_ltNonnegativeRationals with (x - z).
     now apply isnonnegative_NonnegativeRationals.
     exact Hlt. }
-  case (isdecrel_leNonnegativeRationals x z) ; intro Hxz.
+  generalize (isdecrel_leNonnegativeRationals x z) ;
+    apply sumofmaps ; intro Hxz.
   - apply istrans_le_lt_ltNonnegativeRationals with (1 := Hxz).
     exact Hyz.
   - apply notge_ltNonnegativeRationals in Hxz ;
@@ -972,7 +999,8 @@ Lemma minusNonnegativeRationals_ltcompat_r:
   Π x y z : NonnegativeRationals, x < y -> x < z -> z - y < z - x.
 Proof.
   intros x y z Hxy Hxz.
-  case (isdecrel_leNonnegativeRationals y z) ; intros Hky.
+  generalize (isdecrel_leNonnegativeRationals y z) ;
+    apply sumofmaps ; intros Hky.
   - apply_pr2 (plusNonnegativeRationals_ltcompat_r y).
     rewrite minusNonnegativeRationals_plus_r, minusNonnegativeRationals_plus_exchange, iscomm_plusNonnegativeRationals, <- minusNonnegativeRationals_plus_exchange.
     pattern z at 1 ; rewrite <- (islunit_zeroNonnegativeRationals z).
@@ -1050,7 +1078,8 @@ Lemma multNonnegativeRationals_lecompat_l :
   Π k x y : NonnegativeRationals, x <= y -> k * x <= k * y.
 Proof.
   intros k x y Hle.
-  destruct (eq0orgt0NonnegativeRationals k) as [Hk0 | Hk0].
+  generalize (eq0orgt0NonnegativeRationals k) ;
+    apply sumofmaps ; intros Hk0.
   - rewrite Hk0.
     rewrite !islabsorb_zero_multNonnegativeRationals.
     now apply isrefl_leNonnegativeRationals.
@@ -1120,7 +1149,8 @@ Lemma multNonnegativeRationals_ltcompat:
     x < x' -> y < y' -> x * y < x' * y'.
 Proof.
   intros x x' y y' Hx Hy.
-  destruct (eq0orgt0NonnegativeRationals x) as [Hx0 | Hx0].
+  generalize (eq0orgt0NonnegativeRationals x) ;
+    apply sumofmaps ; intros Hx0.
   - rewrite Hx0, islabsorb_zero_multNonnegativeRationals.
     apply ispositive_multNonnegativeRationals.
     rewrite <- Hx0 ; exact Hx.
@@ -1176,7 +1206,8 @@ Lemma isldistr_mult_minusNonnegativeRationals:
   Π x y z : NonnegativeRationals, z * (x - y) = z * x - z * y.
 Proof.
   intros x y z.
-  destruct (isdecrel_leNonnegativeRationals x y) as [Hle | Hlt].
+  generalize (isdecrel_leNonnegativeRationals x y) ;
+    apply sumofmaps ; [ intros Hle | intros Hlt].
   - rewrite !minusNonnegativeRationals_eq_zero.
     now apply israbsorb_zero_multNonnegativeRationals.
     now apply multNonnegativeRationals_lecompat_l, Hle.
@@ -1222,8 +1253,9 @@ Qed.
 Local Lemma inv_zeroNonnegativeRationals :
   / 0 = 0.
 Proof.
-  unfold zeroNonnegativeRationals, invNonnegativeRationals, hnnq_zero, hnnq_inv ; simpl pr1.
-  case hqlehchoice ; intro H0.
+  unfold zeroNonnegativeRationals, invNonnegativeRationals, hnnq_zero, hnnq_inv ; simpl pr1 ; simpl pr2.
+  generalize (hqlehchoice 0%hq 0%hq (isreflhqleh 0%hq)) ;
+    apply coprod_rect ; intro H0.
   - now apply fromempty ; apply isirreflhqlth in H0.
   - reflexivity.
 Qed.
@@ -1249,7 +1281,8 @@ Proof.
     + apply NonnegativeRationals_neq0_gt0 ; intros Hx0.
       revert Hx ; rewrite Hx0.
       unfold invNonnegativeRationals, hnnq_inv.
-      destruct hqlehchoice as [Hx | Hx].
+      generalize (hqlehchoice 0%hq (pr1 0) (pr2 0)).
+      apply (coprod_rect (λ _, _ → _)) ; intros Hx.
       * apply fromempty ; revert Hx.
         now apply isirreflhqlth.
       * now apply isirrefl_ltNonnegativeRationals.
@@ -1259,7 +1292,8 @@ Lemma isinvolutive_invNonnegativeRationals :
   Π x, / / x = x.
 Proof.
   intros x.
-  case (eq0orgt0NonnegativeRationals x) ; intro Hx0.
+  generalize (eq0orgt0NonnegativeRationals x) ;
+    apply sumofmaps ; intro Hx0.
   - now rewrite Hx0, !inv_zeroNonnegativeRationals.
   - apply (multNonnegativeRationals_eqcompat_l (/ x)).
     apply ispositive_invNonnegativeRationals ; exact Hx0.
@@ -1326,10 +1360,12 @@ Lemma issublinear_invNonnegativeRationals :
   Π x y : NonnegativeRationals, / (x + y) <= / x + / y.
 Proof.
   intros x y.
-  destruct (eq0orgt0NonnegativeRationals x) as [Hx0 | Hx0].
+  generalize (eq0orgt0NonnegativeRationals x) ;
+    apply sumofmaps ; intros Hx0.
   rewrite Hx0, islunit_zeroNonnegativeRationals ; clear Hx0 x.
   now apply plusNonnegativeRationals_le_l.
-  destruct (eq0orgt0NonnegativeRationals y) as [Hy0 | Hy0].
+  generalize (eq0orgt0NonnegativeRationals y) ;
+    apply sumofmaps ; intros Hy0.
   rewrite Hy0, isrunit_zeroNonnegativeRationals ; clear Hy0 y.
   now apply plusNonnegativeRationals_le_r.
   apply (multNonnegativeRationals_lecompat_l' _ _ _ Hx0).
@@ -1380,7 +1416,8 @@ Lemma minus_divNonnegativeRationals :
   Π x y : NonnegativeRationals, 0 < y -> / x - / y = (y - x) / (x * y).
 Proof.
   intros x y Hy0.
-  destruct (eq0orgt0NonnegativeRationals x) as [Hx0 | Hx0].
+  generalize (eq0orgt0NonnegativeRationals x) ;
+    apply sumofmaps ; intros Hx0.
   - unfold divNonnegativeRationals.
     rewrite Hx0, islabsorb_zero_multNonnegativeRationals, inv_zeroNonnegativeRationals, israbsorb_zero_multNonnegativeRationals, minusNonnegativeRationals_zero_l.
     reflexivity.
@@ -1414,7 +1451,8 @@ Lemma divNonnegativeRationals_le1 :
   Π q r : NonnegativeRationals, q <= r -> q / r <= 1.
 Proof.
   intros q r Hrq.
-  destruct (eq0orgt0NonnegativeRationals r) as [Hr0 | Hr0].
+  generalize (eq0orgt0NonnegativeRationals r) ;
+    apply sumofmaps ; intros Hr0.
   - unfold divNonnegativeRationals.
     rewrite Hr0, inv_zeroNonnegativeRationals.
     rewrite israbsorb_zero_multNonnegativeRationals.
@@ -1432,9 +1470,11 @@ Qed.
 
 Lemma NQhalf_double : Π x, x = x / 2 + x / 2.
 Proof.
-  intros (x,Hx).
-  unfold divNonnegativeRationals, invNonnegativeRationals, hnnq_inv, twoNonnegativeRationals, Rationals_to_NonnegativeRationals ; simpl pr1.
-  destruct hqlehchoice as [H2 | H2].
+  intros x.
+  rewrite (tppr x) ; generalize (pr1 x) (pr2 x) ; clear x ; intros x Hx.
+  unfold divNonnegativeRationals, invNonnegativeRationals, hnnq_inv, twoNonnegativeRationals, Rationals_to_NonnegativeRationals ; simpl pr1 ; simpl pr2.
+  generalize (hqlehchoice 0%hq 2%hq (hqlthtoleh 0%hq 2%hq hq2_gt0)) ;
+  apply coprod_rect ; intros H2.
   apply subtypeEquality_prop ; simpl pr1.
   rewrite !(hqmultcomm x), <- hqldistr, hqmultcomm.
   apply hqplusdiv2.
@@ -1474,7 +1514,8 @@ Lemma NQmax_eq_zero :
 Proof.
   intros x y.
   unfold NQmax.
-  destruct isdecrel_leNonnegativeRationals as [Hle | Hlt] ; intro H ; split.
+  generalize (isdecrel_leNonnegativeRationals x y).
+  apply (coprod_rect (λ _, _ → _)) ; [ intros Hle | intros Hlt] ; intro H ; split.
   - apply NonnegativeRationals_eq0_le0.
     apply istrans_leNonnegativeRationals with (1 := Hle).
     now rewrite H ; apply isrefl_leNonnegativeRationals.
@@ -1489,7 +1530,8 @@ Lemma NQmax_case :
 Proof.
   intros P x y Hx Hy.
   unfold NQmax.
-  now destruct isdecrel_leNonnegativeRationals.
+  generalize (isdecrel_leNonnegativeRationals x y).
+  now apply coprod_rect.
 Qed.
 Lemma NQmax_case_strong :
   Π (P : NonnegativeRationals -> UU),
@@ -1497,7 +1539,8 @@ Lemma NQmax_case_strong :
 Proof.
   intros P x y Hx Hy.
   unfold NQmax.
-  destruct isdecrel_leNonnegativeRationals as [Hle | Hlt].
+  generalize ( isdecrel_leNonnegativeRationals x y).
+  apply coprod_rect ; [intros Hle | intros Hlt].
   - now apply Hy.
   - apply Hx.
     now apply lt_leNonnegativeRationals, notge_ltNonnegativeRationals.
@@ -1528,6 +1571,15 @@ Proof.
   rewrite iscomm_NQmax.
   now apply NQmax_le_l.
 Qed.
+
+(** ** NQmin *)
+
+Definition NQmin : binop NonnegativeRationals :=
+  λ (x y : NonnegativeRationals),
+  match (isdecrel_leNonnegativeRationals x y) with
+  | ii1 _ => x
+  | ii2 _ => y
+  end.
 
 (** ** intpart *)
 
@@ -1562,22 +1614,25 @@ Proof.
   - intros y1 y2 Hy.
     generalize (isarchrig_1 _ H (pr1 y1) (pr1 y2) Hy).
     apply hinhfun.
-    intros (n,Hn).
-    exists n.
+    intros n.
+    exists (pr1 n).
+    generalize (pr2 n) ; intros Hn.
     rewrite <- !X in Hn.
     exact Hn.
   - intros x.
     generalize (isarchrig_2 _ H (pr1 x)).
     apply hinhfun.
-    intros (n,Hn).
-    exists n.
+    intros n.
+    exists (pr1 n).
+    generalize (pr2 n) ; intros Hn.
     rewrite <- X in Hn.
     exact Hn.
   - intros x.
     generalize (isarchrig_3 _ H (pr1 x)).
     apply hinhfun.
-    intros (n,Hn).
-    exists n.
+    intros n.
+    exists (pr1 n).
+    generalize (pr2 n) ; intros Hn.
     rewrite <- X in Hn.
     exact Hn.
   - exact isrngaddhzgth.

--- a/UniMath/RealNumbers/NonnegativeReals.v
+++ b/UniMath/RealNumbers/NonnegativeReals.v
@@ -232,8 +232,9 @@ Qed.
 
 Lemma isstpo_Dcuts_lt_rel : isStrongOrder Dcuts_lt_rel.
 Proof.
-  split.
+  repeat split.
   exact istrans_Dcuts_lt_rel.
+  exact iscotrans_Dcuts_lt_rel.
   exact isirrefl_Dcuts_lt_rel.
 Qed.
 
@@ -2545,7 +2546,7 @@ Section Dcuts_minus.
   Context (Y_error : Dcuts_def_error Y).
 
 Definition Dcuts_minus_val : hsubtypes NonnegativeRationals :=
-  fun r => ∃ x, X x × Π y, (Y y) ⨿ (y = 0%NRat) → (r < x - y)%NRat.
+  fun r => ∃ x, X x × Π y, (Y y) ⨿ (y = 0%NRat) -> (r + y < x)%NRat.
 
 Lemma Dcuts_minus_bot : Dcuts_def_bot Dcuts_minus_val.
 Proof.
@@ -2554,7 +2555,8 @@ Proof.
   exists (pr1 x) ; split.
   - exact (pr1 (pr2 x)).
   - intros y Yy.
-    apply istrans_le_lt_ltNonnegativeRationals with r.
+    apply istrans_le_lt_ltNonnegativeRationals with (r + y).
+    apply plusNonnegativeRationals_lecompat_r.
     exact Hle.
     now apply (pr2 (pr2 x)).
 Qed.
@@ -2569,22 +2571,11 @@ Proof.
   - apply hinhpr ; exists (pr1 x') ; split.
     + exact (pr1 (pr2 x')).
     + intros y Yy.
-      generalize (isdecrel_leNonnegativeRationals y (pr1 x)) ; apply sumofmaps ; intro Hxy.
-      * apply istrans_lt_le_ltNonnegativeRationals with ((pr1 x - y) + (pr1 x' - pr1 x)).
-        apply plusNonnegativeRationals_ltcompat_r.
-        now apply (pr2 (pr2 x)).
-        rewrite minusNonnegativeRationals_plus_exchange.
-        rewrite iscomm_plusNonnegativeRationals, minusNonnegativeRationals_plus_r.
-        now apply isrefl_leNonnegativeRationals.
-        apply lt_leNonnegativeRationals.
-        exact (pr2 (pr2 x')).
-        exact Hxy.
-      * apply notge_ltNonnegativeRationals in Hxy.
-        apply fromempty.
-        generalize (pr2 (pr2 x) y Yy).
-        rewrite minusNonnegativeRationals_eq_zero.
-        now apply isnonnegative_NonnegativeRationals'.
-        now apply lt_leNonnegativeRationals.
+      pattern (pr1 x') at 2 ;
+        rewrite <- (minusNonnegativeRationals_plus_r _ _ (lt_leNonnegativeRationals _ _ (pr2 (pr2 x')))).
+      rewrite (iscomm_plusNonnegativeRationals r), isassoc_plusNonnegativeRationals.
+      apply plusNonnegativeRationals_ltcompat_l.
+      now apply (pr2 (pr2 x)).
   - apply plusNonnegativeRationals_lt_r.
     apply ispositive_minusNonnegativeRationals.
     exact (pr2 (pr2 x')).
@@ -2629,7 +2620,8 @@ Proof.
     pattern c at 2 ; rewrite (NQhalf_double c).
     now apply plusNonnegativeRationals_le_r.
     apply lt_leNonnegativeRationals.
-    rewrite <- (minusNonnegativeRationals_zero_r (pr1 x)).
+    pattern c at 1 ;
+      rewrite <- (isrunit_zeroNonnegativeRationals c).
     apply (pr2 (pr2 x)).
     now right.
   - generalize (isdecrel_leNonnegativeRationals (pr1 y + c / 2)%NRat (pr1 x)) ; apply sumofmaps ; intro Hxy.
@@ -2644,54 +2636,40 @@ Proof.
         exists (pr1 x) ; split.
         exact (pr1 (pr2 x)).
         intros y' Yy'.
-        apply minusNonnegativeRationals_ltcompat_r.
+        pattern (pr1 x) at 2 ;
+        rewrite <- (minusNonnegativeRationals_plus_r _ _ Hxy).
+        apply plusNonnegativeRationals_ltcompat_l.
         now apply HY.
-        apply istrans_lt_le_ltNonnegativeRationals with (pr1 y + c / 2)%NRat.
-        now apply HY.
-        exact Hxy.
-      * unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; intros x'.
-        generalize (pr2 (pr2 x') _ Yy).
-        change (¬ (pr1 x - (pr1 y + c / 2) + c < pr1 x' - pr1 y)%NRat).
-        apply (pr2 (notlt_geNonnegativeRationals _ _)).
-        apply istrans_leNonnegativeRationals with ((pr1 x + c / 2) - pr1 y)%NRat.
-        apply minusNonnegativeRationals_lecompat_l.
+      * unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; intros (x',(Xx',Hx')).
+        specialize (Hx' (pr1 y) Yy).
+        revert Hx'.
+        apply_pr2 notlt_geNonnegativeRationals.
+        apply istrans_leNonnegativeRationals with (pr1 x + c / 2)%NRat.
         apply lt_leNonnegativeRationals.
         apply notge_ltNonnegativeRationals ; intro H ; apply (pr2 (pr2 x)).
-        now apply X_bot with (1 := pr1 (pr2 x')).
-        rewrite minusNonnegativeRationals_plus_exchange.
-        apply_pr2 (plusNonnegativeRationals_lecompat_r (pr1 y)).
+        now apply X_bot with (1 := Xx').
+        rewrite isassoc_plusNonnegativeRationals, (iscomm_plusNonnegativeRationals _ (pr1 y)).
+        pattern c at 9 ; rewrite (NQhalf_double c).
+        rewrite <- (isassoc_plusNonnegativeRationals (pr1 y)), <- isassoc_plusNonnegativeRationals.
         rewrite minusNonnegativeRationals_plus_r.
-        apply_pr2 (plusNonnegativeRationals_lecompat_r (c / 2)%NRat).
-        rewrite ! isassoc_plusNonnegativeRationals.
-        rewrite <- NQhalf_double, minusNonnegativeRationals_plus_r.
-        now apply isrefl_leNonnegativeRationals.
-        apply istrans_leNonnegativeRationals with (pr1 x).
-        exact Hxy.
-        now apply plusNonnegativeRationals_le_r.
-        apply_pr2 (plusNonnegativeRationals_lecompat_r (c / 2)%NRat).
-        rewrite isassoc_plusNonnegativeRationals, <- NQhalf_double.
-        apply istrans_leNonnegativeRationals with (pr1 x).
-        exact Hxy.
-        now apply plusNonnegativeRationals_le_r.
+        apply isrefl_leNonnegativeRationals.
         exact Hxy.
     + apply notge_ltNonnegativeRationals in Hxy.
-      apply hinhpr ; left ; unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; intros x'.
-      generalize (pr2 (pr2 x') _ Yy).
-      change (¬ (c < pr1 x' - pr1 y)%NRat) ; apply (pr2 (notlt_geNonnegativeRationals _ _)).
-      generalize (isdecrel_leNonnegativeRationals (pr1 y) (pr1 x')) ; apply sumofmaps ; intro Hxy'.
-      apply_pr2 (plusNonnegativeRationals_lecompat_r (pr1 y)).
-      rewrite minusNonnegativeRationals_plus_r, iscomm_plusNonnegativeRationals.
-      pattern c at 4 ; rewrite (NQhalf_double c), <- isassoc_plusNonnegativeRationals.
+      apply hinhpr ; left ; unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; intros (x',(Xx',Hx')).
+      generalize (Hx' _ Yy).
+      apply_pr2 notlt_geNonnegativeRationals.
+      case (isdecrel_leNonnegativeRationals (pr1 y) x') ; intro Hxy'.
+      rewrite iscomm_plusNonnegativeRationals.
+      pattern c at 3 ; rewrite (NQhalf_double c), <- isassoc_plusNonnegativeRationals.
       apply istrans_leNonnegativeRationals with (pr1 x + c / 2)%NRat.
       apply lt_leNonnegativeRationals ; apply notge_ltNonnegativeRationals ; intro ; apply (pr2 (pr2 x)).
-      now apply X_bot with (1 := pr1 (pr2 x')).
+      now apply X_bot with (1 := Xx').
       apply plusNonnegativeRationals_lecompat_r.
       now apply lt_leNonnegativeRationals.
-      exact Hxy'.
       apply notge_ltNonnegativeRationals in Hxy'.
-      rewrite minusNonnegativeRationals_eq_zero.
-      now apply isnonnegative_NonnegativeRationals.
+      apply istrans_leNonnegativeRationals with (pr1 y).
       now apply lt_leNonnegativeRationals.
+      now apply plusNonnegativeRationals_le_l.
   - now apply hinhpr ; right.
 Qed.
 
@@ -2710,32 +2688,24 @@ Proof.
   intros _ Y Z ->.
   apply Dcuts_eq_is_eq ; intro r ; split.
   - intros Zr.
-    generalize (is_Dcuts_open _ _ Zr) ; apply hinhuniv ; intros q.
-    generalize (pr1 (ispositive_minusNonnegativeRationals _ _) (pr2 (pr2 q))) ; intros Hq.
-    generalize (is_Dcuts_error Y _ Hq) ; apply hinhuniv ; apply sumofmaps ; [intros nYy | ].
-    + apply hinhpr ; exists (pr1 q) ; split.
-      * apply hinhpr ; left ; right.
-        exact (pr1 (pr2 q)).
-      * intros y ; apply sumofmaps ; [intros Yy | intros Hy0].
-        apply_pr2 (plusNonnegativeRationals_ltcompat_r y).
-        rewrite minusNonnegativeRationals_plus_r.
+    generalize (is_Dcuts_open _ _ Zr) ; apply hinhuniv ; intros (q,(Zq,Hq)).
+    apply ispositive_minusNonnegativeRationals in Hq.
+    generalize (is_Dcuts_error Y _ Hq) ; apply hinhuniv ; intros [nYy | ].
+    + apply hinhpr ; exists q ; split.
+      * now apply hinhpr ; left ; right.
+      * intros y [Yy | Hy0].
         apply minusNonnegativeRationals_ltcompat_l' with r.
         rewrite plusNonnegativeRationals_minus_l.
         now apply (Dcuts_finite Y).
-        apply istrans_leNonnegativeRationals with (pr1 q - r).
-        now apply lt_leNonnegativeRationals, (Dcuts_finite Y).
-        now apply minusNonnegativeRationals_le.
-        rewrite Hy0, minusNonnegativeRationals_zero_r.
+        rewrite Hy0, isrunit_zeroNonnegativeRationals.
         now apply_pr2 ispositive_minusNonnegativeRationals.
     + intros y.
       apply hinhpr.
-      exists (pr1 y + pr1 q) ; split.
-      apply hinhpr ; right ; exists (pr1 y,,pr1 q) ; simpl ; repeat split.
+      exists (pr1 y + q) ; split.
+      apply hinhpr ; right ; exists (pr1 y,,q) ; simpl ; repeat split.
       * exact (pr1 (pr2 y)).
-      * exact (pr1 (pr2 q)).
-      * intros y' ; apply sumofmaps ; [intros Yy' | intros Hy0].
-        apply_pr2 (plusNonnegativeRationals_ltcompat_r y').
-        rewrite minusNonnegativeRationals_plus_r.
+      * exact Zq.
+      * intros y' [Yy' | Hy0].
         apply minusNonnegativeRationals_ltcompat_l' with r.
         rewrite plusNonnegativeRationals_minus_l.
         rewrite iscomm_plusNonnegativeRationals, <- minusNonnegativeRationals_plus_exchange, iscomm_plusNonnegativeRationals.
@@ -2743,28 +2713,25 @@ Proof.
         exact (pr2 (pr2 y)).
         exact Yy'.
         now apply lt_leNonnegativeRationals ; apply_pr2 ispositive_minusNonnegativeRationals.
-        apply istrans_leNonnegativeRationals with (pr1 y + (pr1 q - r)).
-        apply lt_leNonnegativeRationals, (Dcuts_finite Y).
-        exact (pr2 (pr2 y)).
-        exact Yy'.
-        apply plusNonnegativeRationals_lecompat_l.
-        now apply minusNonnegativeRationals_le.
-        rewrite Hy0, minusNonnegativeRationals_zero_r.
-        apply istrans_lt_le_ltNonnegativeRationals with (pr1 q).
+        rewrite Hy0, isrunit_zeroNonnegativeRationals.
+        apply istrans_lt_le_ltNonnegativeRationals with q.
         now apply_pr2 ispositive_minusNonnegativeRationals.
         now apply plusNonnegativeRationals_le_l.
   - apply hinhuniv ; intros q.
     generalize (pr1 (pr2 q)) ; apply hinhuniv ; apply sumofmaps ; [ apply sumofmaps ; [intros Yq | intros Zq ] | intros yz ].
     + apply fromempty, (isnonnegative_NonnegativeRationals' r).
-      rewrite <- (minusNonnegativeRationals_eq_zero (pr1 q) _ (isrefl_leNonnegativeRationals _)).
+      apply_pr2 (plusNonnegativeRationals_ltcompat_r (pr1 q)).
+      rewrite islunit_zeroNonnegativeRationals.
       apply (pr2 (pr2 q)).
       now left.
     + apply is_Dcuts_bot with (1 := Zq), lt_leNonnegativeRationals.
-      rewrite <- (minusNonnegativeRationals_zero_r (pr1 q)).
+      pattern r at 1 ;
+        rewrite <- (isrunit_zeroNonnegativeRationals r).
       apply (pr2 (pr2 q)).
       now right.
     + apply is_Dcuts_bot with (1 := pr2 (pr2 (pr2 yz))), lt_leNonnegativeRationals.
-      rewrite <- (plusNonnegativeRationals_minus_l (pr1 (pr1 yz)) (pr2 (pr1 yz))), <- (pr1 (pr2 yz)).
+      apply_pr2 (plusNonnegativeRationals_ltcompat_l (pr1 (pr1 yz))).
+      rewrite <- (pr1 (pr2 yz)), iscomm_plusNonnegativeRationals.
       apply (pr2 (pr2 q)).
       left.
       exact (pr1 (pr2 (pr2 yz))).
@@ -2782,11 +2749,11 @@ Lemma Dcuts_minus_eq_zero:
 Proof.
   intros X Y Hxy.
   apply Dcuts_eq_is_eq ; intros r ; split.
-  - apply hinhuniv ; intros x.
-    simpl ; rewrite <- (minusNonnegativeRationals_eq_zero (pr1 x) _ (isrefl_leNonnegativeRationals _)).
-    apply (pr2 (pr2 x)).
-    left; refine (Hxy _ _).
-    exact (pr1 (pr2 x)).
+  - apply hinhuniv ; intros (x,(Xx,Hx)).
+    apply_pr2 (plusNonnegativeRationals_ltcompat_r x).
+    rewrite islunit_zeroNonnegativeRationals.
+    apply Hx.
+    now left ; apply Hxy.
   - intro H.
     now apply fromempty ; apply (Dcuts_zero_empty r).
 Qed.
@@ -2804,94 +2771,62 @@ Proof.
       apply hinhpr.
       exists (pr1 q) ; split.
       exact (pr1 (pr2 q)).
-      intros z ; apply sumofmaps ; [intros Zz | intros Hz0].
-      * apply_pr2 (plusNonnegativeRationals_ltcompat_r z).
-        rewrite minusNonnegativeRationals_plus_r.
-        apply (minusNonnegativeRationals_ltcompat_l' _ _ r).
+      intros z [Zz | ->].
+      * apply (minusNonnegativeRationals_ltcompat_l' _ _ r).
         rewrite plusNonnegativeRationals_minus_l.
         now apply (Dcuts_finite Z).
-        apply istrans_leNonnegativeRationals with (pr1 q - r).
-        now apply lt_leNonnegativeRationals, (Dcuts_finite Z).
-        now apply minusNonnegativeRationals_le.
-      * now rewrite Hz0, minusNonnegativeRationals_zero_r ; apply_pr2 ispositive_minusNonnegativeRationals.
-    + intros z.
-      generalize (isdecrel_leNonnegativeRationals r (pr1 z)) ; apply sumofmaps ; intro Hzr.
+      * now rewrite isrunit_zeroNonnegativeRationals ;
+        apply_pr2 ispositive_minusNonnegativeRationals.
+    + intros (z,(Zz,nZz)).
+      case (isdecrel_leNonnegativeRationals r z) ; intro Hzr.
       * apply hinhpr ; left ; right.
-        now apply (is_Dcuts_bot _ _ (pr1 (pr2 z))).
+        now apply (is_Dcuts_bot _ _ Zz).
       * apply notge_ltNonnegativeRationals in Hzr ; apply lt_leNonnegativeRationals in Hzr.
         apply hinhpr ; right.
-        exists (r - pr1 z ,, pr1 z) ; repeat split.
+        exists (r - z ,, z) ; repeat split.
         simpl.
         now rewrite minusNonnegativeRationals_plus_r.
         apply hinhpr ; simpl.
         exists (pr1 q) ; split.
         exact (pr1 (pr2 q)).
-        intros z' ; apply sumofmaps ; [intros Zz' | intros Hz0].
-        apply_pr2 (plusNonnegativeRationals_ltcompat_r (pr1 z)).
-        rewrite minusNonnegativeRationals_plus_r.
-        rewrite minusNonnegativeRationals_plus_exchange.
-        apply_pr2 (plusNonnegativeRationals_ltcompat_r z').
+        intros z' [Zz' | ->].
+        apply_pr2 (plusNonnegativeRationals_ltcompat_r z).
+        rewrite isassoc_plusNonnegativeRationals, (iscomm_plusNonnegativeRationals z'), <- isassoc_plusNonnegativeRationals.
         rewrite minusNonnegativeRationals_plus_r.
         apply (minusNonnegativeRationals_ltcompat_l' _ _ r) ; rewrite plusNonnegativeRationals_minus_l.
         rewrite <- minusNonnegativeRationals_plus_exchange, iscomm_plusNonnegativeRationals.
         apply (Dcuts_finite Z).
-        exact (pr2 (pr2 z)).
+        exact nZz.
         exact Zz'.
         now apply lt_leNonnegativeRationals ; apply_pr2 ispositive_minusNonnegativeRationals.
-        apply istrans_leNonnegativeRationals with (pr1 z + (pr1 q - r)).
-        apply lt_leNonnegativeRationals, (Dcuts_finite Z).
-        exact (pr2 (pr2 z)).
-        exact Zz'.
-        rewrite iscomm_plusNonnegativeRationals, minusNonnegativeRationals_plus_exchange.
-        now apply minusNonnegativeRationals_le.
-        now apply lt_leNonnegativeRationals ; apply_pr2 ispositive_minusNonnegativeRationals.
-        apply istrans_leNonnegativeRationals with (pr1 z + (pr1 q - r)).
-        apply lt_leNonnegativeRationals, (Dcuts_finite Z).
-        exact (pr2 (pr2 z)).
-        exact Zz'.
-        pattern (pr1 q) at 3 ;
-          rewrite <- (minusNonnegativeRationals_plus_r r (pr1 q)), iscomm_plusNonnegativeRationals.
-        apply plusNonnegativeRationals_lecompat_l.
-        exact Hzr.
-        now apply lt_leNonnegativeRationals ; apply_pr2 ispositive_minusNonnegativeRationals.
-        exact Hzr.
-        rewrite Hz0, minusNonnegativeRationals_zero_r.
+        now apply Hzr.
+        rewrite isrunit_zeroNonnegativeRationals.
         apply istrans_le_lt_ltNonnegativeRationals with r.
         now apply minusNonnegativeRationals_le.
         now apply_pr2 ispositive_minusNonnegativeRationals.
-        exact (pr1 (pr2 z)).
-  - apply hinhuniv ; apply sumofmaps ; [ apply sumofmaps ; [ | intros Zr] | intros yzz ; rewrite (pr1 (pr2 yzz)) ].
-    + apply hinhuniv ; intros y.
-      apply (is_Dcuts_bot _ _ (pr1 (pr2 y))).
-      apply lt_leNonnegativeRationals ; rewrite <- (minusNonnegativeRationals_zero_r (pr1 y)).
-      apply (pr2 (pr2 y)).
+        exact Zz.
+  - apply hinhuniv ; intros [ | ] ; [intros [ YZr | Zr] | intros ((ryz,rz),(->,(YZr,Zr))) ].
+    + revert YZr ; apply hinhuniv ; intros (y,(Yy,Hy)).
+      apply (is_Dcuts_bot _ _ Yy).
+      apply lt_leNonnegativeRationals ; rewrite <- (isrunit_zeroNonnegativeRationals r).
+      apply Hy.
       now right.
-    + now refine (Hyz _ _).
-    + generalize (pr1 (pr2 (pr2 yzz))) ; apply hinhuniv ; simpl ; intros y.
-      apply (is_Dcuts_bot _ _ (pr1 (pr2 y))).
-      generalize (isdecrel_leNonnegativeRationals (pr1 y) (pr2 (pr1 yzz))) ; apply sumofmaps ; intro Hr.
-      * apply fromempty, (isnonnegative_NonnegativeRationals' (pr1 (pr1 yzz))).
-        rewrite <- (minusNonnegativeRationals_eq_zero _ _ Hr).
-        apply (pr2 (pr2 y)).
-        left.
-        exact (pr2 (pr2 (pr2 yzz))).
-      * apply notge_ltNonnegativeRationals in Hr ; apply lt_leNonnegativeRationals in Hr.
-        apply minusNonnegativeRationals_lecompat_l' with (pr2 (pr1 yzz)).
-        exact Hr.
-        rewrite plusNonnegativeRationals_minus_r.
-        apply lt_leNonnegativeRationals, (pr2 (pr2 y)).
-        left.
-        exact (pr2 (pr2 (pr2 yzz))).
+    + now apply Hyz.
+    + simpl in Zr |- *.
+      revert YZr ; apply hinhuniv ; simpl ; intros (y,(Yy,Hy)).
+      apply (is_Dcuts_bot _ _ Yy).
+      apply lt_leNonnegativeRationals, Hy.
+      now left.
 Qed.
 
 Lemma Dcuts_minus_le :
   Π x y, Dcuts_minus x y <= x.
 Proof.
   intros X Y r.
-  apply hinhuniv ; intros x.
-  apply is_Dcuts_bot with (1 := pr1 (pr2 x)).
-  apply lt_leNonnegativeRationals ; rewrite <- (minusNonnegativeRationals_zero_r (pr1 x)).
-  apply (pr2 (pr2 x)).
+  apply hinhuniv ; intros (x,(Xx,Hx)).
+  apply is_Dcuts_bot with (1 := Xx).
+  apply lt_leNonnegativeRationals ; rewrite <- (isrunit_zeroNonnegativeRationals r).
+  apply Hx.
   now right.
 Qed.
 
@@ -2907,24 +2842,25 @@ Proof.
     + apply hinhpr.
       exists (pr1 x') ; split.
       exact (pr1 (pr2 x')).
-      intros y ; apply sumofmaps ; [intros Yy | intros ->].
-      * apply ispositive_minusNonnegativeRationals.
+      intros y [Yy | ->].
+      * rewrite islunit_zeroNonnegativeRationals.
         apply istrans_ltNonnegativeRationals with (pr1 x).
         apply (Dcuts_finite Y).
         exact (pr1 (pr2 x)).
         exact Yy.
         exact (pr2 (pr2 x')).
-      * rewrite minusNonnegativeRationals_zero_r.
+      * rewrite islunit_zeroNonnegativeRationals.
         apply istrans_le_lt_ltNonnegativeRationals with (pr1 x).
         now apply isnonnegative_NonnegativeRationals.
         exact (pr2 (pr2 x')).
-  - apply hinhuniv ; intros r ; generalize (pr2 (pr2 r)).
-    apply hinhfun ; intros x.
-    exists (pr1 x) ; split.
-    + intros Yx ; apply (isnonnegative_NonnegativeRationals' (pr1 r)).
-      rewrite <- (minusNonnegativeRationals_eq_zero (pr1 x) _ (isrefl_leNonnegativeRationals _)).
-      now apply (pr2 (pr2 x)) ; left.
-    + exact (pr1 (pr2 x)).
+  - apply hinhuniv ; intros (r,(_)).
+    apply hinhfun ; intros (x,(Xx,Hx)).
+    exists x ; split.
+    + intros Yx ; apply (isnonnegative_NonnegativeRationals' r).
+      apply_pr2 (plusNonnegativeRationals_ltcompat_r x).
+      rewrite islunit_zeroNonnegativeRationals.
+      now apply Hx ; left.
+    + exact Xx.
 Qed.
 
 (** *** Dcuts_max *)
@@ -3025,6 +2961,29 @@ Proof.
   apply Dcuts_eq_is_eq ; intros r.
   split ; apply islogeqcommhdisj.
 Qed.
+Lemma isassoc_Dcuts_max :
+  Π x y z : Dcuts, Dcuts_max (Dcuts_max x y) z = Dcuts_max x (Dcuts_max y z).
+Proof.
+  intros x y z.
+  apply Dcuts_eq_is_eq ; intros r.
+  split.
+  - apply hinhuniv ; intros [ | Zr].
+    + apply hinhfun ; intros [Xr | Yr].
+      * now left.
+      * right ; apply hinhpr.
+        now left.
+    + apply hinhpr.
+      right ; apply hinhpr.
+      now right.
+  - apply hinhuniv ; intros [ Xr | ].
+    + apply hinhpr.
+      left ; apply hinhpr.
+      now left.
+    + apply hinhfun ; intros [Yr | Zr].
+      * left ; apply hinhpr.
+        now right.
+      * now right.
+Qed.
 
 Lemma Dcuts_max_le_l :
   Π x y : Dcuts, x <= Dcuts_max x y.
@@ -3065,28 +3024,27 @@ Lemma Dcuts_minus_plus_max :
 Proof.
   intros X Y.
   apply Dcuts_eq_is_eq ; intros r ; split.
-  - apply hinhuniv ; apply sumofmaps ; [ apply sumofmaps ; [intros XYr | intros Yr] | intros xyy ; rewrite (pr1 (pr2 xyy))].
+  - apply hinhuniv ; apply sumo fmaps ; [ apply sumofmaps ; [intros XYr | intros Yr] | intros xyy ; rewrite (pr1 (pr2 xyy))].
     + apply hinhpr ; left.
       revert XYr ; now refine (Dcuts_minus_le _ _ _).
     + now apply hinhpr ; right.
     + generalize (pr1 (pr2 (pr2 xyy))) ; apply hinhfun ; intros x.
       left ; apply is_Dcuts_bot with (1 := pr1 (pr2 x)).
-      apply lt_leNonnegativeRationals, minusNonnegativeRationals_ltcompat_l' with (pr2 (pr1 xyy)).
-      rewrite plusNonnegativeRationals_minus_r.
+      apply lt_leNonnegativeRationals.
       apply (pr2 (pr2 x)).
       left.
       exact (pr2 (pr2 (pr2 xyy))).
-  - apply hinhuniv ; apply sumofmaps ; [ intros Xr| intros Yr].
-    + generalize (is_Dcuts_open _ _ Xr) ; apply hinhuniv ; intros x.
-      generalize (pr1 (ispositive_minusNonnegativeRationals _ _) (pr2 (pr2 x))) ; intros Hx.
+  - apply hinhuniv ; intros [Xr|Yr].
+    + generalize (is_Dcuts_open _ _ Xr) ; apply hinhuniv ; intros (x,(Xx,Hx)).
+      apply ispositive_minusNonnegativeRationals in Hx.
       generalize (is_Dcuts_error Y _ Hx) ; apply hinhuniv ;
       apply sumofmaps ; [ intros nYx | intros Hyx ] ; apply_pr2_in ispositive_minusNonnegativeRationals Hx.
       * rewrite <- (Dcuts_minus_plus_r (Dcuts_minus X Y) X Y).
         exact Xr.
         apply Dcuts_lt_le_rel.
-        apply hinhpr ; exists (pr1 x - r) ; split.
+        apply hinhpr ; exists (x - r) ; split.
         exact nYx.
-        apply is_Dcuts_bot with (1 := pr1 (pr2 x)).
+        apply is_Dcuts_bot with (1 := Xx).
         now apply minusNonnegativeRationals_le.
         reflexivity.
       * rename Hyx into y.
@@ -3100,11 +3058,11 @@ Proof.
         rewrite <- (Dcuts_minus_plus_r (Dcuts_minus X Y) X Y).
         exact Xr.
         apply Dcuts_lt_le_rel.
-        apply hinhpr ; exists ((pr1 x + pr1 y) - r) ; split.
+        apply hinhpr ; exists ((x + pr1 y) - r) ; split.
         exact nYy.
-        apply is_Dcuts_bot with (1 := pr1 (pr2 x)).
-        pattern (pr1 x) at 3 ;
-          rewrite <- (plusNonnegativeRationals_minus_r r (pr1 x)).
+        apply is_Dcuts_bot with (1 := Xx).
+        pattern x at 3 ;
+          rewrite <- (plusNonnegativeRationals_minus_r r x).
         apply minusNonnegativeRationals_lecompat_l.
         apply plusNonnegativeRationals_lecompat_l.
         now apply lt_leNonnegativeRationals.
@@ -3138,41 +3096,6 @@ Proof.
   - apply NQmax_case.
     exact (pr2 (pr2 rx)).
     exact (pr2 (pr2 ry)).
-Qed.
-
-Lemma isassoc_Dcuts_max :
-  isassoc Dcuts_max.
-Proof.
-  intros x y z.
-  apply Dcuts_eq_is_eq.
-  intros r.
-  split.
-  - apply hinhuniv.
-    apply sumofmaps ; [ | intros Zr].
-    + apply hinhfun.
-      apply sumofmaps ;
-        [ intros Xr | intros Yr].
-      * now left.
-      * right.
-        apply hinhpr.
-        now left.
-    + apply hinhpr.
-      right.
-      apply hinhpr.
-      now right.
-  - apply hinhuniv.
-    apply sumofmaps ; [intros Xr | ].
-    + apply hinhpr.
-      left.
-      apply hinhpr.
-      now left.
-    + apply hinhfun.
-      apply sumofmaps ;
-        [ intros Yr | intros Zr].
-      * left.
-        apply hinhpr.
-        now right.
-      * now right.
 Qed.
 
 Lemma isldistr_Dcuts_max_mult :
@@ -3324,6 +3247,183 @@ Proof.
     split.
     apply Dcuts_zero_empty.
     exact (pr1 (pr2 (pr2 xy))).
+Qed.
+
+(** *** Dcuts_min *)
+
+Section Dcuts_min.
+
+  Context (X : hsubtypes NonnegativeRationals).
+  Context (X_bot : Dcuts_def_bot X).
+  Context (X_open : Dcuts_def_open X).
+  Context (X_finite : Dcuts_def_finite X).
+  Context (X_error : Dcuts_def_error X).
+  Context (Y : hsubtypes NonnegativeRationals).
+  Context (Y_bot : Dcuts_def_bot Y).
+  Context (Y_open : Dcuts_def_open Y).
+  Context (Y_finite : Dcuts_def_finite Y).
+  Context (Y_error : Dcuts_def_error Y).
+
+Definition Dcuts_min_val : hsubtypes NonnegativeRationals :=
+  λ r : NonnegativeRationals, X r ∧ Y r.
+
+Lemma Dcuts_min_bot : Dcuts_def_bot Dcuts_min_val.
+Proof.
+  intros r (Xr,Yr) q Hqr.
+  split.
+  - apply X_bot with (1 := Xr), Hqr.
+  - apply Y_bot with (1 := Yr), Hqr.
+Qed.
+
+Lemma Dcuts_min_open : Dcuts_def_open Dcuts_min_val.
+Proof.
+  intros r (Xr , Yr).
+  generalize (X_open _ Xr) (Y_open _ Yr).
+  apply hinhfun2 ; intros (q,(Xq,Hq)) (q',(Yq',Hq')).
+  destruct (isdecrel_ltNonnegativeRationals q q') as [H | H].
+  - exists q ; repeat split.
+    exact Xq.
+    apply Y_bot with (1 := Yq'), lt_leNonnegativeRationals, H.
+    exact Hq.
+  - exists q' ; repeat split.
+    apply X_bot with (1 := Xq), notlt_geNonnegativeRationals, H.
+    exact Yq'.
+    exact Hq'.
+Qed.
+
+Lemma Dcuts_min_error : Dcuts_def_error Dcuts_min_val.
+Proof.
+  intros c Hc.
+  generalize (X_error _ Hc) (Y_error _ Hc) ; apply hinhfun2 ; intros [nXc | (q,(Xq,Hq))] Hy.
+  - left ; intros (Xc , Yc).
+    now apply nXc.
+  - destruct Hy as [nYc | (q',(Yq',Hq'))].
+    + left ; intros (Xc , Yc).
+      now apply nYc.
+    + right.
+      destruct (isdecrel_ltNonnegativeRationals q q') as [H | H].
+      * exists q ; repeat split.
+        exact Xq.
+        apply Y_bot with (1 := Yq'), lt_leNonnegativeRationals, H.
+        intros (Xc , Yc).
+        now apply Hq.
+      * exists q' ; repeat split.
+        apply X_bot with (1 := Xq), notlt_geNonnegativeRationals, H.
+        exact Yq'.
+        intros (Xc , Yc).
+        now apply Hq'.
+Qed.
+
+End Dcuts_min.
+
+Definition Dcuts_min (X Y : Dcuts) : Dcuts :=
+  mk_Dcuts (Dcuts_min_val (pr1 X) (pr1 Y))
+           (Dcuts_min_bot (pr1 X) (is_Dcuts_bot X)
+                          (pr1 Y) (is_Dcuts_bot Y))
+           (Dcuts_min_open (pr1 X) (is_Dcuts_bot X) (is_Dcuts_open X)
+                           (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_open Y))
+           (Dcuts_min_error (pr1 X) (is_Dcuts_bot X) (is_Dcuts_error X)
+                            (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_error Y)).
+
+Lemma iscomm_Dcuts_min :
+  Π x y : Dcuts, Dcuts_min x y = Dcuts_min y x.
+Proof.
+  intros x y.
+  apply Dcuts_eq_is_eq ; intros r.
+  split ; apply weqdirprodcomm.
+Qed.
+
+Lemma isassoc_Dcuts_min :
+  Π x y z : Dcuts, Dcuts_min (Dcuts_min x y) z = Dcuts_min x (Dcuts_min y z).
+Proof.
+  intros x y z.
+  apply Dcuts_eq_is_eq ; intros r.
+  split ; intros Hr ; repeat split.
+  - apply (pr1 (pr1 Hr)).
+  - apply (pr2 (pr1 Hr)).
+  - apply (pr2 Hr).
+  - apply (pr1 Hr).
+  - apply (pr1 (pr2 Hr)).
+  - apply (pr2 (pr2 Hr)).
+Qed.
+
+Lemma Dcuts_min_le_l :
+  Π x y : Dcuts, Dcuts_min x y <= x.
+Proof.
+  now intros x y r (Xr,Yr).
+Qed.
+Lemma Dcuts_min_le_r :
+  Π x y : Dcuts, Dcuts_min x y <= y.
+Proof.
+  now intros x y r (Xr,Yr).
+Qed.
+
+Lemma Dcuts_min_carac_r :
+  Π x y : Dcuts, y <= x -> Dcuts_min x y = y.
+Proof.
+  intros x y Hxy.
+  apply Dcuts_eq_is_eq ; intros r ; split.
+  - intros (Xr,Yr).
+    exact Yr.
+  - intros Yr.
+    split.
+    now apply Hxy.
+    exact Yr.
+Qed.
+Lemma Dcuts_min_carac_l :
+  Π x y : Dcuts, x <= y -> Dcuts_min x y = x.
+Proof.
+  intros x y Hxy.
+  rewrite iscomm_Dcuts_min.
+  now apply Dcuts_min_carac_r.
+Qed.
+
+Lemma Dcuts_min_max :
+  Π x y : Dcuts,
+    Dcuts_min x (Dcuts_max x y) = x.
+Proof.
+  intros x y.
+  apply Dcuts_eq_is_eq ; intros r.
+  split.
+  - now intros (Xr,_).
+  - intros Xr.
+    split.
+    exact Xr.
+    apply hinhpr.
+    now left.
+Qed.
+Lemma Dcuts_max_min :
+  Π x y : Dcuts,
+    Dcuts_max x (Dcuts_min x y) = x.
+Proof.
+  intros x y.
+  apply Dcuts_eq_is_eq ; intros r.
+  split.
+  - now apply hinhuniv ; intros [Xr | (Xr,_)].
+  - intros Xr.
+    apply hinhpr.
+    now left.
+Qed.
+
+Lemma Dcuts_min_gt :
+  Π x y z : Dcuts,
+    z < x → z < y → z < (Dcuts_min x y).
+Proof.
+  intros x y z.
+  apply hinhfun2.
+  intros (r,(Zr,Xr)).
+  intros (q,(Zq,Yq)).
+  destruct (isdecrel_ltNonnegativeRationals r q) as [H | H].
+  - exists r.
+    repeat split.
+    + exact Zr.
+    + exact Xr.
+    + apply is_Dcuts_bot with (1 := Yq), lt_leNonnegativeRationals, H.
+  - exists q.
+    repeat split.
+    + exact Zq.
+    + apply is_Dcuts_bot with (1 := Xr), notlt_geNonnegativeRationals, H.
+    + exact Yq.
 Qed.
 
 (** *** Dcuts_half *)
@@ -4316,6 +4416,7 @@ Global Opaque Dcuts_zero
               Dcuts_mult
               Dcuts_inv
               Dcuts_max
+              Dcuts_min
               Dcuts_half.
 Global Opaque Dcuts_lim_cauchy_seq.
 
@@ -4385,6 +4486,7 @@ Definition hsubtypesNonnegativeRationals_to_NonnegativeReals
 Definition minusNonnegativeReals : binop NonnegativeReals := Dcuts_minus.
 Definition halfNonnegativeReals : unop NonnegativeReals := Dcuts_half.
 Definition maxNonnegativeReals : binop NonnegativeReals := Dcuts_max.
+Definition minNonnegativeReals : binop NonnegativeReals := Dcuts_min.
 
 Notation "x - y" := (minusNonnegativeReals x y) (at level 50, left associativity) : NR_scope.
 Notation "x / 2" := (halfNonnegativeReals x) (at level 35, no associativity) : NR_scope.
@@ -4600,6 +4702,12 @@ Proof.
     now apply (pr2 H).
   -  intros ->.
      split ; apply isrefl_leNonnegativeReals.
+Qed.
+Lemma eqNonnegativeReals_le :
+  Π x y : NonnegativeReals, x = y -> x <= y.
+Proof.
+  intros x y ->.
+  apply isrefl_leNonnegativeReals.
 Qed.
 
 Definition istrans_ltNonnegativeReals :

--- a/UniMath/RealNumbers/NonnegativeReals.v
+++ b/UniMath/RealNumbers/NonnegativeReals.v
@@ -3024,7 +3024,7 @@ Lemma Dcuts_minus_plus_max :
 Proof.
   intros X Y.
   apply Dcuts_eq_is_eq ; intros r ; split.
-  - apply hinhuniv ; apply sumo fmaps ; [ apply sumofmaps ; [intros XYr | intros Yr] | intros xyy ; rewrite (pr1 (pr2 xyy))].
+  - apply hinhuniv ; apply sumofmaps ; [ apply sumofmaps ; [intros XYr | intros Yr] | intros xyy ; rewrite (pr1 (pr2 xyy))].
     + apply hinhpr ; left.
       revert XYr ; now refine (Dcuts_minus_le _ _ _).
     + now apply hinhpr ; right.
@@ -3034,17 +3034,17 @@ Proof.
       apply (pr2 (pr2 x)).
       left.
       exact (pr2 (pr2 (pr2 xyy))).
-  - apply hinhuniv ; intros [Xr|Yr].
-    + generalize (is_Dcuts_open _ _ Xr) ; apply hinhuniv ; intros (x,(Xx,Hx)).
-      apply ispositive_minusNonnegativeRationals in Hx.
+  - apply hinhuniv ; apply sumofmaps ; [intros Xr|intros Yr].
+    + generalize (is_Dcuts_open _ _ Xr) ; apply hinhuniv ; intros x.
+      generalize (pr1 (ispositive_minusNonnegativeRationals _ _) (pr2 (pr2 x))) ; intros Hx.
       generalize (is_Dcuts_error Y _ Hx) ; apply hinhuniv ;
       apply sumofmaps ; [ intros nYx | intros Hyx ] ; apply_pr2_in ispositive_minusNonnegativeRationals Hx.
       * rewrite <- (Dcuts_minus_plus_r (Dcuts_minus X Y) X Y).
         exact Xr.
         apply Dcuts_lt_le_rel.
-        apply hinhpr ; exists (x - r) ; split.
+        apply hinhpr ; exists (pr1 x - r) ; split.
         exact nYx.
-        apply is_Dcuts_bot with (1 := Xx).
+        apply is_Dcuts_bot with (1 := pr1 (pr2 x)).
         now apply minusNonnegativeRationals_le.
         reflexivity.
       * rename Hyx into y.
@@ -3058,11 +3058,11 @@ Proof.
         rewrite <- (Dcuts_minus_plus_r (Dcuts_minus X Y) X Y).
         exact Xr.
         apply Dcuts_lt_le_rel.
-        apply hinhpr ; exists ((x + pr1 y) - r) ; split.
+        apply hinhpr ; exists ((pr1 x + pr1 y) - r) ; split.
         exact nYy.
-        apply is_Dcuts_bot with (1 := Xx).
-        pattern x at 3 ;
-          rewrite <- (plusNonnegativeRationals_minus_r r x).
+        apply is_Dcuts_bot with (1 := pr1 (pr2 x)).
+        pattern (pr1 x) at 3 ;
+          rewrite <- (plusNonnegativeRationals_minus_r r (pr1 x)).
         apply minusNonnegativeRationals_lecompat_l.
         apply plusNonnegativeRationals_lecompat_l.
         now apply lt_leNonnegativeRationals.
@@ -3269,49 +3269,56 @@ Definition Dcuts_min_val : hsubtypes NonnegativeRationals :=
 
 Lemma Dcuts_min_bot : Dcuts_def_bot Dcuts_min_val.
 Proof.
-  intros r (Xr,Yr) q Hqr.
+  intros r Hr q Hqr.
   split.
-  - apply X_bot with (1 := Xr), Hqr.
-  - apply Y_bot with (1 := Yr), Hqr.
+  - apply X_bot with (1 := pr1 Hr), Hqr.
+  - apply Y_bot with (1 := pr2 Hr), Hqr.
 Qed.
 
 Lemma Dcuts_min_open : Dcuts_def_open Dcuts_min_val.
 Proof.
-  intros r (Xr , Yr).
-  generalize (X_open _ Xr) (Y_open _ Yr).
-  apply hinhfun2 ; intros (q,(Xq,Hq)) (q',(Yq',Hq')).
-  destruct (isdecrel_ltNonnegativeRationals q q') as [H | H].
-  - exists q ; repeat split.
-    exact Xq.
-    apply Y_bot with (1 := Yq'), lt_leNonnegativeRationals, H.
-    exact Hq.
-  - exists q' ; repeat split.
-    apply X_bot with (1 := Xq), notlt_geNonnegativeRationals, H.
-    exact Yq'.
-    exact Hq'.
+  intros r Hr.
+  generalize (X_open _ (pr1 Hr)) (Y_open _ (pr2 Hr)).
+  apply hinhfun2 ; intros q q'.
+  generalize (isdecrel_ltNonnegativeRationals (pr1 q) (pr1 q')) ;
+    apply sumofmaps ; intros H.
+  - exists (pr1 q) ; repeat split.
+    exact (pr1 (pr2 q)).
+    apply Y_bot with (1 := pr1 (pr2 q')), lt_leNonnegativeRationals, H.
+    exact (pr2 (pr2 q)).
+  - exists (pr1 q') ; repeat split.
+    apply X_bot with (1 := pr1 (pr2 q)), notlt_geNonnegativeRationals, H.
+    exact (pr1 (pr2 q')).
+    exact (pr2 (pr2 q')).
 Qed.
 
 Lemma Dcuts_min_error : Dcuts_def_error Dcuts_min_val.
 Proof.
-  intros c Hc.
-  generalize (X_error _ Hc) (Y_error _ Hc) ; apply hinhfun2 ; intros [nXc | (q,(Xq,Hq))] Hy.
-  - left ; intros (Xc , Yc).
-    now apply nXc.
-  - destruct Hy as [nYc | (q',(Yq',Hq'))].
-    + left ; intros (Xc , Yc).
-      now apply nYc.
+  intros c Hc0.
+  generalize (X_error _ Hc0) (Y_error _ Hc0) ; apply hinhfun2 ; apply (sumofmaps (Z := _ → _)) ; [intros nXc | intros q] ; intros Hy.
+  - left ; intros Hc.
+    apply nXc.
+    exact (pr1 Hc).
+  - revert Hy ; apply sumofmaps ;
+    [intros nYc | intros q'].
+    + left ; intros Hc.
+      apply nYc.
+      exact (pr2 Hc).
     + right.
-      destruct (isdecrel_ltNonnegativeRationals q q') as [H | H].
-      * exists q ; repeat split.
-        exact Xq.
-        apply Y_bot with (1 := Yq'), lt_leNonnegativeRationals, H.
-        intros (Xc , Yc).
-        now apply Hq.
-      * exists q' ; repeat split.
-        apply X_bot with (1 := Xq), notlt_geNonnegativeRationals, H.
-        exact Yq'.
-        intros (Xc , Yc).
-        now apply Hq'.
+      generalize (isdecrel_ltNonnegativeRationals (pr1 q) (pr1 q')) ;
+        apply sumofmaps ; intros H.
+      * exists (pr1 q) ; repeat split.
+        exact (pr1 (pr2 q)).
+        apply Y_bot with (1 := pr1 (pr2 q')), lt_leNonnegativeRationals, H.
+        intros Hc.
+        apply (pr2 (pr2 q)).
+        exact (pr1 Hc).
+      * exists (pr1 q') ; repeat split.
+        apply X_bot with (1 := pr1 (pr2 q)), notlt_geNonnegativeRationals, H.
+        exact (pr1 (pr2 q')).
+        intros Hc.
+        apply (pr2 (pr2 q')).
+        exact (pr2 Hc).
 Qed.
 
 End Dcuts_min.
@@ -3350,12 +3357,14 @@ Qed.
 Lemma Dcuts_min_le_l :
   Π x y : Dcuts, Dcuts_min x y <= x.
 Proof.
-  now intros x y r (Xr,Yr).
+  intros x y r Hr.
+  exact (pr1 Hr).
 Qed.
 Lemma Dcuts_min_le_r :
   Π x y : Dcuts, Dcuts_min x y <= y.
 Proof.
-  now intros x y r (Xr,Yr).
+  intros x y r Hr.
+  exact (pr2 Hr).
 Qed.
 
 Lemma Dcuts_min_carac_r :
@@ -3363,8 +3372,8 @@ Lemma Dcuts_min_carac_r :
 Proof.
   intros x y Hxy.
   apply Dcuts_eq_is_eq ; intros r ; split.
-  - intros (Xr,Yr).
-    exact Yr.
+  - intros Hr.
+    exact (pr2 Hr).
   - intros Yr.
     split.
     now apply Hxy.
@@ -3385,7 +3394,8 @@ Proof.
   intros x y.
   apply Dcuts_eq_is_eq ; intros r.
   split.
-  - now intros (Xr,_).
+  - intros Hr.
+    exact (pr1 Hr).
   - intros Xr.
     split.
     exact Xr.
@@ -3399,7 +3409,9 @@ Proof.
   intros x y.
   apply Dcuts_eq_is_eq ; intros r.
   split.
-  - now apply hinhuniv ; intros [Xr | (Xr,_)].
+  - apply hinhuniv ; apply sumofmaps ; [intros Xr | intros Hr].
+    exact Xr.
+    exact (pr1 Hr).
   - intros Xr.
     apply hinhpr.
     now left.
@@ -3411,19 +3423,18 @@ Lemma Dcuts_min_gt :
 Proof.
   intros x y z.
   apply hinhfun2.
-  intros (r,(Zr,Xr)).
-  intros (q,(Zq,Yq)).
-  destruct (isdecrel_ltNonnegativeRationals r q) as [H | H].
-  - exists r.
+  intros r q.
+  generalize (isdecrel_ltNonnegativeRationals (pr1 r) (pr1 q)) ; apply sumofmaps ; intros H.
+  - exists (pr1 r).
     repeat split.
-    + exact Zr.
-    + exact Xr.
-    + apply is_Dcuts_bot with (1 := Yq), lt_leNonnegativeRationals, H.
-  - exists q.
+    + exact (pr1 (pr2 r)).
+    + exact (pr2 (pr2 r)).
+    + apply is_Dcuts_bot with (1 := pr2 (pr2 q)), lt_leNonnegativeRationals, H.
+  - exists (pr1 q).
     repeat split.
-    + exact Zq.
-    + apply is_Dcuts_bot with (1 := Xr), notlt_geNonnegativeRationals, H.
-    + exact Yq.
+    + exact (pr1 (pr2 q)).
+    + apply is_Dcuts_bot with (1 := pr2 (pr2 r)), notlt_geNonnegativeRationals, H.
+    + exact (pr2 (pr2 q)).
 Qed.
 
 (** *** Dcuts_half *)

--- a/UniMath/RealNumbers/NonnegativeReals.v
+++ b/UniMath/RealNumbers/NonnegativeReals.v
@@ -97,18 +97,18 @@ Open Scope DC_scope.
 
 Lemma is_Dcuts_bot (X : Dcuts_set) : Dcuts_def_bot (pr1 X).
 Proof.
-  destruct X as [X (Hbot,(Hopen,Hfinite))] ; simpl.
-  exact Hbot.
+  intros X.
+  exact (pr1 (pr2 X)).
 Qed.
 Lemma is_Dcuts_open (X : Dcuts_set) : Dcuts_def_open (pr1 X).
 Proof.
-  destruct X as [X (Hbot,(Hopen,Hfinite))] ; simpl.
-  exact Hopen.
+  intros X.
+  exact (pr1 (pr2 (pr2 X))).
 Qed.
 Lemma is_Dcuts_error (X : Dcuts_set) : Dcuts_def_error (pr1 X).
 Proof.
-  destruct X as [X (Hbot,(Hopen,Hfinite))] ; simpl.
-  now apply Hfinite.
+  intros X.
+  exact (pr2 (pr2 (pr2 X))).
 Qed.
 
 Definition mk_Dcuts (X : NonnegativeRationals → hProp)
@@ -630,7 +630,7 @@ Lemma isapfun_NonnegativeRationals_to_Dcuts' :
 Proof.
   intros q q' H.
   apply noteq_ltorgtNonnegativeRationals in H.
-  destruct H.
+  induction H as [H | H].
   now left ; apply (pr2 (isapfun_NonnegativeRationals_to_Dcuts_aux _ _)).
   now right ; apply (pr2 (isapfun_NonnegativeRationals_to_Dcuts_aux _ _)).
 Qed.
@@ -815,8 +815,10 @@ Proof.
         pattern c at 2 ; rewrite (NQhalf_double c).
         apply plusNonnegativeRationals_le_r.
     + intros xy.
-      generalize (isdecrel_ltNonnegativeRationals (pr1 (pr1 xy)) (c / 2)%NRat) ; apply sumofmaps ; intros Hx'.
-      generalize (isdecrel_ltNonnegativeRationals (pr2 (pr1 xy)) (c / 2)%NRat) ; apply sumofmaps ; intros Hy'.
+      generalize (isdecrel_ltNonnegativeRationals (pr1 (pr1 xy)) (c / 2)%NRat) ;
+        apply sumofmaps ; intros Hx'.
+      generalize (isdecrel_ltNonnegativeRationals (pr2 (pr1 xy)) (c / 2)%NRat) ;
+        apply sumofmaps ; intros Hy'.
       * apply (isirrefl_StrongOrder ltNonnegativeRationals c).
         pattern c at 2 ; rewrite (NQhalf_double c).
         pattern c at 1 ; rewrite (pr1 (pr2 xy)).
@@ -1552,7 +1554,8 @@ Proof.
       apply hinhuniv ; intros s.
       rewrite (pr1 (pr2 s)).
       rewrite (iscomm_multNonnegativeRationals (pr1 x)), <- isassoc_multNonnegativeRationals.
-      rewrite iscomm_multNonnegativeRationals, !isassoc_multNonnegativeRationals, isrinv_NonnegativeRationals, isrunit_oneNonnegativeRationals, iscomm_multNonnegativeRationals.
+      rewrite iscomm_multNonnegativeRationals, !isassoc_multNonnegativeRationals,
+      isrinv_NonnegativeRationals, isrunit_oneNonnegativeRationals, iscomm_multNonnegativeRationals.
       apply (pr1 (pr2 l)).
       exact (pr2 (pr2 s)).
       exact (pr2 (pr2 x)).
@@ -2005,7 +2008,8 @@ Proof.
       generalize (pr1 (pr2 (pr2 zxzy))) (pr2 (pr2 (pr2 zxzy))).
       apply hinhfun2 ; intros zx zy.
       rewrite (pr1 (pr2 zx)), (pr1 (pr2 zy)).
-      generalize (isdecrel_leNonnegativeRationals (NQmax (fst (pr1 zx)) (fst (pr1 zy))) 0%NRat) ; apply sumofmaps ; [intros Heq| intros Hlt].
+      generalize (isdecrel_leNonnegativeRationals (NQmax (fst (pr1 zx)) (fst (pr1 zy))) 0%NRat) ;
+        apply sumofmaps ; [intros Heq| intros Hlt].
       apply NonnegativeRationals_eq0_le0 in Heq.
       * apply NQmax_eq_zero in Heq.
         rewrite (pr1 Heq), (pr2 Heq).
@@ -2203,7 +2207,8 @@ Proof.
     generalize (is_Dcuts_error x _ Hr).
     apply hinhuniv ; apply sumofmaps ; [intros nXc | ].
     + apply hinhpr ; exists r' ; split.
-      * unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; apply sumofmaps ; [apply sumofmaps ; [intros Yr' | intros Xr'] | intros yx ].
+      * unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; apply sumofmaps ;
+        [apply sumofmaps ; [intros Yr' | intros Xr'] | intros yx ].
         apply (pr1 (pr2 r)), is_Dcuts_bot with (1 := Yr'), lt_leNonnegativeRationals.
         now apply_pr2 ispositive_minusNonnegativeRationals.
         apply nXc, is_Dcuts_bot with (1 := Xr'), minusNonnegativeRationals_le.
@@ -2298,7 +2303,7 @@ Proof.
   intros X Y Z.
   apply hinhuniv2 ; intros x r.
   generalize (is_Dcuts_bot _ _ (pr2 (pr2 x)) _ (isnonnegative_NonnegativeRationals _)) ; clear x ; intro X0.
-  case (eq0orgt0NonnegativeRationals (pr1 r)) ; intro Hr0.
+  induction (eq0orgt0NonnegativeRationals (pr1 r)) as [Hr0 | Hr0].
   - apply hinhpr ; exists 0%NRat ; split.
     + unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; intros yx.
       apply (pr1 (pr2 r)).
@@ -2640,14 +2645,13 @@ Proof.
         rewrite <- (minusNonnegativeRationals_plus_r _ _ Hxy).
         apply plusNonnegativeRationals_ltcompat_l.
         now apply HY.
-      * unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; intros (x',(Xx',Hx')).
-        specialize (Hx' (pr1 y) Yy).
-        revert Hx'.
+      * unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; intros x'.
+        generalize (pr2 (pr2 x') (pr1 y) Yy).
         apply_pr2 notlt_geNonnegativeRationals.
         apply istrans_leNonnegativeRationals with (pr1 x + c / 2)%NRat.
         apply lt_leNonnegativeRationals.
         apply notge_ltNonnegativeRationals ; intro H ; apply (pr2 (pr2 x)).
-        now apply X_bot with (1 := Xx').
+        now apply X_bot with (1 := pr1 (pr2 x')).
         rewrite isassoc_plusNonnegativeRationals, (iscomm_plusNonnegativeRationals _ (pr1 y)).
         pattern c at 9 ; rewrite (NQhalf_double c).
         rewrite <- (isassoc_plusNonnegativeRationals (pr1 y)), <- isassoc_plusNonnegativeRationals.
@@ -2655,15 +2659,15 @@ Proof.
         apply isrefl_leNonnegativeRationals.
         exact Hxy.
     + apply notge_ltNonnegativeRationals in Hxy.
-      apply hinhpr ; left ; unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; intros (x',(Xx',Hx')).
-      generalize (Hx' _ Yy).
+      apply hinhpr ; left ; unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; intros x'.
+      generalize (pr2 (pr2 x') _ Yy).
       apply_pr2 notlt_geNonnegativeRationals.
-      case (isdecrel_leNonnegativeRationals (pr1 y) x') ; intro Hxy'.
+      induction (isdecrel_leNonnegativeRationals (pr1 y) (pr1 x')) as [Hxy' | Hxy'].
       rewrite iscomm_plusNonnegativeRationals.
-      pattern c at 3 ; rewrite (NQhalf_double c), <- isassoc_plusNonnegativeRationals.
+      pattern c at 4 ; rewrite (NQhalf_double c), <- isassoc_plusNonnegativeRationals.
       apply istrans_leNonnegativeRationals with (pr1 x + c / 2)%NRat.
       apply lt_leNonnegativeRationals ; apply notge_ltNonnegativeRationals ; intro ; apply (pr2 (pr2 x)).
-      now apply X_bot with (1 := Xx').
+      now apply X_bot with (1 := pr1 (pr2 x')).
       apply plusNonnegativeRationals_lecompat_r.
       now apply lt_leNonnegativeRationals.
       apply notge_ltNonnegativeRationals in Hxy'.
@@ -2688,24 +2692,25 @@ Proof.
   intros _ Y Z ->.
   apply Dcuts_eq_is_eq ; intro r ; split.
   - intros Zr.
-    generalize (is_Dcuts_open _ _ Zr) ; apply hinhuniv ; intros (q,(Zq,Hq)).
-    apply ispositive_minusNonnegativeRationals in Hq.
-    generalize (is_Dcuts_error Y _ Hq) ; apply hinhuniv ; intros [nYy | ].
-    + apply hinhpr ; exists q ; split.
-      * now apply hinhpr ; left ; right.
-      * intros y [Yy | Hy0].
+    generalize (is_Dcuts_open _ _ Zr) ; apply hinhuniv ; intros q.
+    generalize (pr1 (ispositive_minusNonnegativeRationals _ _) (pr2 (pr2 q))) ; intros Hq.
+    generalize (is_Dcuts_error Y _ Hq) ; apply hinhuniv ; apply sumofmaps ; [intros nYy | ].
+    + apply hinhpr ; exists (pr1 q) ; split.
+      * apply hinhpr ; left ; right.
+        exact (pr1 (pr2 q)).
+      * intros y ; apply sumofmaps ; [intros Yy | intros ->].
         apply minusNonnegativeRationals_ltcompat_l' with r.
         rewrite plusNonnegativeRationals_minus_l.
         now apply (Dcuts_finite Y).
-        rewrite Hy0, isrunit_zeroNonnegativeRationals.
+        rewrite isrunit_zeroNonnegativeRationals.
         now apply_pr2 ispositive_minusNonnegativeRationals.
     + intros y.
       apply hinhpr.
-      exists (pr1 y + q) ; split.
-      apply hinhpr ; right ; exists (pr1 y,,q) ; simpl ; repeat split.
+      exists (pr1 y + pr1 q) ; split.
+      apply hinhpr ; right ; exists (pr1 y,,pr1 q) ; simpl ; repeat split.
       * exact (pr1 (pr2 y)).
-      * exact Zq.
-      * intros y' [Yy' | Hy0].
+      * exact (pr1 (pr2 q)).
+      * intros y' ; apply sumofmaps ; [intros Yy' | intros ->].
         apply minusNonnegativeRationals_ltcompat_l' with r.
         rewrite plusNonnegativeRationals_minus_l.
         rewrite iscomm_plusNonnegativeRationals, <- minusNonnegativeRationals_plus_exchange, iscomm_plusNonnegativeRationals.
@@ -2713,8 +2718,8 @@ Proof.
         exact (pr2 (pr2 y)).
         exact Yy'.
         now apply lt_leNonnegativeRationals ; apply_pr2 ispositive_minusNonnegativeRationals.
-        rewrite Hy0, isrunit_zeroNonnegativeRationals.
-        apply istrans_lt_le_ltNonnegativeRationals with q.
+        rewrite isrunit_zeroNonnegativeRationals.
+        apply istrans_lt_le_ltNonnegativeRationals with (pr1 q).
         now apply_pr2 ispositive_minusNonnegativeRationals.
         now apply plusNonnegativeRationals_le_l.
   - apply hinhuniv ; intros q.
@@ -2749,11 +2754,12 @@ Lemma Dcuts_minus_eq_zero:
 Proof.
   intros X Y Hxy.
   apply Dcuts_eq_is_eq ; intros r ; split.
-  - apply hinhuniv ; intros (x,(Xx,Hx)).
-    apply_pr2 (plusNonnegativeRationals_ltcompat_r x).
+  - apply hinhuniv ; intros x.
+    apply_pr2 (plusNonnegativeRationals_ltcompat_r (pr1 x)).
     rewrite islunit_zeroNonnegativeRationals.
-    apply Hx.
-    now left ; apply Hxy.
+    apply (pr2 (pr2 x)).
+    left ; apply Hxy.
+    exact (pr1 (pr2 x)).
   - intro H.
     now apply fromempty ; apply (Dcuts_zero_empty r).
 Qed.
@@ -2771,32 +2777,32 @@ Proof.
       apply hinhpr.
       exists (pr1 q) ; split.
       exact (pr1 (pr2 q)).
-      intros z [Zz | ->].
+      intros z ; apply sumofmaps ; [intros Zz | intros ->].
       * apply (minusNonnegativeRationals_ltcompat_l' _ _ r).
         rewrite plusNonnegativeRationals_minus_l.
         now apply (Dcuts_finite Z).
       * now rewrite isrunit_zeroNonnegativeRationals ;
         apply_pr2 ispositive_minusNonnegativeRationals.
-    + intros (z,(Zz,nZz)).
-      case (isdecrel_leNonnegativeRationals r z) ; intro Hzr.
+    + intros z.
+      induction (isdecrel_leNonnegativeRationals r (pr1 z)) as [Hzr | Hzr].
       * apply hinhpr ; left ; right.
-        now apply (is_Dcuts_bot _ _ Zz).
+        now apply (is_Dcuts_bot _ _ (pr1 (pr2 z))).
       * apply notge_ltNonnegativeRationals in Hzr ; apply lt_leNonnegativeRationals in Hzr.
         apply hinhpr ; right.
-        exists (r - z ,, z) ; repeat split.
+        exists (r - pr1 z ,, pr1 z) ; repeat split.
         simpl.
         now rewrite minusNonnegativeRationals_plus_r.
         apply hinhpr ; simpl.
         exists (pr1 q) ; split.
         exact (pr1 (pr2 q)).
-        intros z' [Zz' | ->].
-        apply_pr2 (plusNonnegativeRationals_ltcompat_r z).
+        intros z' ; apply sumofmaps ; [intros Zz' | intros ->].
+        apply_pr2 (plusNonnegativeRationals_ltcompat_r (pr1 z)).
         rewrite isassoc_plusNonnegativeRationals, (iscomm_plusNonnegativeRationals z'), <- isassoc_plusNonnegativeRationals.
         rewrite minusNonnegativeRationals_plus_r.
         apply (minusNonnegativeRationals_ltcompat_l' _ _ r) ; rewrite plusNonnegativeRationals_minus_l.
         rewrite <- minusNonnegativeRationals_plus_exchange, iscomm_plusNonnegativeRationals.
         apply (Dcuts_finite Z).
-        exact nZz.
+        exact (pr2 (pr2 z)).
         exact Zz'.
         now apply lt_leNonnegativeRationals ; apply_pr2 ispositive_minusNonnegativeRationals.
         now apply Hzr.
@@ -2804,29 +2810,33 @@ Proof.
         apply istrans_le_lt_ltNonnegativeRationals with r.
         now apply minusNonnegativeRationals_le.
         now apply_pr2 ispositive_minusNonnegativeRationals.
-        exact Zz.
-  - apply hinhuniv ; intros [ | ] ; [intros [ YZr | Zr] | intros ((ryz,rz),(->,(YZr,Zr))) ].
-    + revert YZr ; apply hinhuniv ; intros (y,(Yy,Hy)).
-      apply (is_Dcuts_bot _ _ Yy).
-      apply lt_leNonnegativeRationals ; rewrite <- (isrunit_zeroNonnegativeRationals r).
-      apply Hy.
+        exact (pr1 (pr2 z)).
+  - apply hinhuniv ; apply sumofmaps ; [apply sumofmaps ; [ | intros Zr] | intros ryzz ; rewrite (pr1 (pr2 ryzz)) ].
+    + apply hinhuniv ; intros y.
+      apply (is_Dcuts_bot _ _ (pr1 (pr2 y))).
+      apply lt_leNonnegativeRationals.
+      pattern r at 1 ;
+      rewrite <- (isrunit_zeroNonnegativeRationals r).
+      apply (pr2 (pr2 y)).
       now right.
     + now apply Hyz.
-    + simpl in Zr |- *.
-      revert YZr ; apply hinhuniv ; simpl ; intros (y,(Yy,Hy)).
-      apply (is_Dcuts_bot _ _ Yy).
-      apply lt_leNonnegativeRationals, Hy.
-      now left.
+    + generalize (pr1 (pr2 (pr2 ryzz))) ; apply hinhuniv ; simpl ; intros y.
+      apply (is_Dcuts_bot _ _ (pr1 (pr2 y))).
+      apply lt_leNonnegativeRationals, (pr2 (pr2 y)).
+      left.
+      exact (pr2 (pr2 (pr2 ryzz))).
 Qed.
 
 Lemma Dcuts_minus_le :
   Π x y, Dcuts_minus x y <= x.
 Proof.
   intros X Y r.
-  apply hinhuniv ; intros (x,(Xx,Hx)).
-  apply is_Dcuts_bot with (1 := Xx).
-  apply lt_leNonnegativeRationals ; rewrite <- (isrunit_zeroNonnegativeRationals r).
-  apply Hx.
+  apply hinhuniv ; intros x.
+  apply is_Dcuts_bot with (1 := pr1 (pr2 x)).
+  apply lt_leNonnegativeRationals.
+  pattern r at 1 ;
+    rewrite <- (isrunit_zeroNonnegativeRationals r).
+  apply (pr2 (pr2 x)).
   now right.
 Qed.
 
@@ -2842,7 +2852,7 @@ Proof.
     + apply hinhpr.
       exists (pr1 x') ; split.
       exact (pr1 (pr2 x')).
-      intros y [Yy | ->].
+      intros y ; apply sumofmaps ; [intros Yy | intros ->].
       * rewrite islunit_zeroNonnegativeRationals.
         apply istrans_ltNonnegativeRationals with (pr1 x).
         apply (Dcuts_finite Y).
@@ -2853,14 +2863,14 @@ Proof.
         apply istrans_le_lt_ltNonnegativeRationals with (pr1 x).
         now apply isnonnegative_NonnegativeRationals.
         exact (pr2 (pr2 x')).
-  - apply hinhuniv ; intros (r,(_)).
-    apply hinhfun ; intros (x,(Xx,Hx)).
-    exists x ; split.
-    + intros Yx ; apply (isnonnegative_NonnegativeRationals' r).
-      apply_pr2 (plusNonnegativeRationals_ltcompat_r x).
+  - apply hinhuniv ; intros r ; generalize (pr2 (pr2 r)).
+    apply hinhfun ; intros x.
+    exists (pr1 x) ; split.
+    + intros Yx ; apply (isnonnegative_NonnegativeRationals' (pr1 r)).
+      apply_pr2 (plusNonnegativeRationals_ltcompat_r (pr1 x)).
       rewrite islunit_zeroNonnegativeRationals.
-      now apply Hx ; left.
-    + exact Xx.
+      now apply (pr2 (pr2 x)) ; left.
+    + exact (pr1 (pr2 x)).
 Qed.
 
 (** *** Dcuts_max *)
@@ -2909,15 +2919,18 @@ Qed.
 Lemma Dcuts_max_error : Dcuts_def_error Dcuts_max_val.
 Proof.
   intros c Hc.
-  generalize (X_error _ Hc) (Y_error _ Hc) ; apply hinhfun2 ; apply (sumofmaps (Z := _ → _)) ; [intros nXc | intros x] ; apply sumofmaps ; [intros nYc | intros y|intros nYc | intros y].
-  - left ; unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; apply sumofmaps ; [intros Xc | intros Yc].
+  generalize (X_error _ Hc) (Y_error _ Hc) ; apply hinhfun2 ; apply (sumofmaps (Z := _ → _)) ;
+  [intros nXc | intros x] ; apply sumofmaps ; [intros nYc | intros y |intros nYc | intros y].
+  - left ; unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; apply sumofmaps ;
+    [intros Xc | intros Yc].
     + now apply nXc.
     + now apply nYc.
   - right.
     exists (pr1 y) ; split.
     + apply hinhpr ; right.
       exact (pr1 (pr2 y)).
-    + unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; apply sumofmaps ; [intros Xy | intros Yy].
+    + unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; apply sumofmaps ;
+      [intros Xy | intros Yy].
       * now apply nXc, X_bot with (1 := Xy), plusNonnegativeRationals_le_l.
       * now apply (pr2 (pr2 y)).
   - right.
@@ -2967,19 +2980,19 @@ Proof.
   intros x y z.
   apply Dcuts_eq_is_eq ; intros r.
   split.
-  - apply hinhuniv ; intros [ | Zr].
-    + apply hinhfun ; intros [Xr | Yr].
+  - apply hinhuniv ; apply sumofmaps ; [ | intros Zr].
+    + apply hinhfun ; apply sumofmaps ; [ intros Xr | intros Yr].
       * now left.
       * right ; apply hinhpr.
         now left.
     + apply hinhpr.
       right ; apply hinhpr.
       now right.
-  - apply hinhuniv ; intros [ Xr | ].
+  - apply hinhuniv ; apply sumofmaps ; [intros Xr | ].
     + apply hinhpr.
       left ; apply hinhpr.
       now left.
-    + apply hinhfun ; intros [Yr | Zr].
+    + apply hinhfun ; apply sumofmaps ; [intros Yr | intros Zr].
       * left ; apply hinhpr.
         now right.
       * now right.
@@ -3005,7 +3018,7 @@ Lemma Dcuts_max_carac_l :
 Proof.
   intros x y Hxy.
   apply Dcuts_eq_is_eq ; intros r ; split.
-  apply hinhuniv ; apply sumofmaps ; [intros Xr|intros Yr].
+  apply hinhuniv ; apply sumofmaps ; [ intros Xr | intros Yr ].
   - exact Xr.
   - now refine (Hxy _ _).
   - intros Xr.
@@ -4937,7 +4950,7 @@ Proof.
   - intro H.
     apply ap_ltNonnegativeReals.
     apply_pr2_in ap_ltNonnegativeReals H.
-    destruct H as [H | H].
+    induction H as [H | H].
     + left ;
       now apply plusNonnegativeReals_ltcompat_l.
     + right ;

--- a/UniMath/RealNumbers/Prelim.v
+++ b/UniMath/RealNumbers/Prelim.v
@@ -204,7 +204,7 @@ Proof.
   repeat split.
   - intros y1 y2 Hy.
     apply natlthchoice2 in Hy.
-    destruct Hy as [Hy | <-].
+    induction Hy as [Hy | <-].
     + apply hinhpr.
       exists 1%nat.
       exact Hy.

--- a/UniMath/RealNumbers/Prelim.v
+++ b/UniMath/RealNumbers/Prelim.v
@@ -183,7 +183,7 @@ Lemma nattorig_nattohz :
   Π n : nat, nattorig (X := hz) n = nattohz n.
 Proof.
   induction n.
-  - simpl.
+  - unfold nattorig, nattohz ; simpl.
     reflexivity.
   - rewrite nattorigS, IHn.
     apply pathsinv0, nattohzandS.
@@ -229,36 +229,40 @@ Proof.
   - reflexivity.
   - intros n m k.
     apply istransnatgth.
-  - generalize isarchnat ; intros (H,(H0,H1)).
+  - generalize isarchnat ; intros H.
     repeat split.
     + intros y1 y2 Hy.
       refine (hinhfun _ _).
-      2: apply (H y1 y2).
-      intros (n,Hn).
-      exists n.
+      2: apply ((pr1 H) y1 y2).
+      intros n.
+      exists (pr1 n).
       apply hinhpr.
       exists O.
-      now rewrite !natplusr0.
+      rewrite !natplusr0.
+      apply (pr2 n).
       revert Hy.
       apply hinhuniv.
-      intros (c,x); generalize x; clear x.
+      intros c.
+      generalize (pr2 c).
       apply natgthandplusrinv.
     + intros x.
-      generalize (H0 x).
+      generalize ((pr1 (pr2 H)) x).
       apply hinhfun.
-      intros (n,Hn).
-      exists n.
+      intros n.
+      exists (pr1 n).
       apply hinhpr.
       exists O.
-      now rewrite !natplusr0.
+      rewrite !natplusr0.
+      exact (pr2 n).
     + intros x.
-      generalize (H1 x).
+      generalize ((pr2 (pr2 H)) x).
       apply hinhfun.
-      intros (n,Hn).
-      exists n.
+      intros n.
+      exists (pr1 n).
       apply hinhpr.
       exists O.
-      now rewrite !natplusr0.
+      rewrite !natplusr0.
+      exact (pr2 n).
 Qed.
 
 Lemma isarchhq :
@@ -271,27 +275,3 @@ Proof.
 Qed.
 
 Close Scope hq_scope.
-
-(** ** A new tactic *)
-
-Ltac apply_pr2 T :=
-  first [ refine (pr2 (T) _)
-        | refine (pr2 (T _) _)
-        | refine (pr2 (T _ _) _)
-        | refine (pr2 (T _ _ _) _)
-        | refine (pr2 (T _ _ _ _) _)
-        | refine (pr2 (T _ _ _ _ _) _)
-        | refine (pr2 (T))
-        | refine (pr2 (T _))
-        | refine (pr2 (T _ _))
-        | refine (pr2 (T _ _ _))
-        | refine (pr2 (T _ _ _ _))
-        | refine (pr2 (T _ _ _ _ _)) ].
-
-Ltac apply_pr2_in T H :=
-  first [ apply (pr2 (T)) in H
-        | apply (fun H0 => pr2 (T H0)) in H
-        | apply (fun H0 H1 => pr2 (T H0 H1)) in H
-        | apply (fun H0 H1 H2 => pr2 (T H0 H1 H2)) in H
-        | apply (fun H0 H1 H2 H3 => pr2 (T H0 H1 H2 H3)) in H
-        | apply (fun H0 H1 H2 H3 H4 => pr2 (T H0 H1 H2 H3 H4)) in H ].

--- a/UniMath/RealNumbers/Reals.v
+++ b/UniMath/RealNumbers/Reals.v
@@ -1539,7 +1539,8 @@ Lemma Rabs_pr1RtoNRNR :
     (pr1 (RtoNRNR x) <= Rabs x)%NR.
 Proof.
   intros x.
-  rewrite <- (NRNRtoR_RtoNRNR x), Rabs_NRNRtoR.
+  rewrite <- (NRNRtoR_RtoNRNR x).
+  generalize (pr1 (RtoNRNR x)) (pr2 (RtoNRNR x)) ; clear x ; intros x y ; simpl.
   apply maxNonnegativeReals_le_l.
 Qed.
 Lemma Rabs_pr2RtoNRNR :
@@ -1547,7 +1548,8 @@ Lemma Rabs_pr2RtoNRNR :
     (pr2 (RtoNRNR x) <= Rabs x)%NR.
 Proof.
   intros x.
-  rewrite <- (NRNRtoR_RtoNRNR x), Rabs_NRNRtoR.
+  rewrite <- (NRNRtoR_RtoNRNR x).
+  generalize (pr1 (RtoNRNR x)) (pr2 (RtoNRNR x)) ; clear x ; intros x y ; simpl.
   apply maxNonnegativeReals_le_r.
 Qed.
 

--- a/UniMath/RealNumbers/Reals.v
+++ b/UniMath/RealNumbers/Reals.v
@@ -1534,14 +1534,6 @@ Proof.
   apply NRNRtoR_one.
 Qed.
 
-Lemma Rabs_NRNRtoR :
-  Π x y : NonnegativeReals,
-    Rabs (NRNRtoR x y) = MetricSpace.dist (X := MS_NonnegativeReals) x y.
-Proof.
-  intros x y.
-  reflexivity.
-Qed.
-
 Lemma Rabs_pr1RtoNRNR :
   Π x : Reals,
     (pr1 (RtoNRNR x) <= Rabs x)%NR.

--- a/UniMath/RealNumbers/Reals.v
+++ b/UniMath/RealNumbers/Reals.v
@@ -42,6 +42,27 @@ Proof.
   now rewrite !isassoc_plusNonnegativeReals, (iscomm_plusNonnegativeReals (pr2 x)).
 Qed.
 
+Lemma iscomprelfun_hr_to_NR :
+  iscomprelfun (Y := NonnegativeReals × NonnegativeReals) (binopeqrelabgrfrac (rigaddabmonoid NonnegativeReals))
+               (λ x : NonnegativeReals × NonnegativeReals,
+                      pr1 x - pr2 x ,, pr2 x - pr1 x).
+Proof.
+  intros x y.
+  apply hinhuniv'.
+  refine (isasetdirprod _ _ _ _ _ _) ;
+    apply (pr2 (pr1 (pr1 (pr1 NonnegativeReals)))).
+  intros c.
+  apply dirprodeq.
+  + apply iscomprelfun_NRminus.
+    apply (plusNonnegativeReals_eqcompat_l (pr1 c)).
+    exact (pr2 c).
+  + apply (iscomprelfun_NRminus (pr2 x ,, pr1 x) (pr2 y ,, pr1 y)).
+    simpl.
+    rewrite (iscomm_plusNonnegativeReals (pr2 x)), (iscomm_plusNonnegativeReals (pr2 y)).
+    apply (plusNonnegativeReals_eqcompat_l (pr1 c)), pathsinv0.
+    exact (pr2 c).
+Qed.
+
 Definition hr_to_NR (x : hr_commrng) : NonnegativeReals × NonnegativeReals.
 Proof.
   simple refine (setquotuniv _ (_,,_) _ _).
@@ -49,20 +70,7 @@ Proof.
     apply (pr2 (pr1 (pr1 (pr1 NonnegativeReals)))).
   - intros x.
     apply (pr1 x - pr2 x ,, pr2 x - pr1 x).
-  - intros x y.
-    apply hinhuniv'.
-    refine (isasetdirprod _ _ _ _ _ _) ;
-    apply (pr2 (pr1 (pr1 (pr1 NonnegativeReals)))).
-    intros (c,H).
-    apply dirprodeq.
-    + apply iscomprelfun_NRminus.
-      apply (plusNonnegativeReals_eqcompat_l c).
-      exact H.
-    + apply (iscomprelfun_NRminus (pr2 x ,, pr1 x) (pr2 y ,, pr1 y)).
-      simpl.
-      rewrite (iscomm_plusNonnegativeReals (pr2 x)), (iscomm_plusNonnegativeReals (pr2 y)).
-      apply (plusNonnegativeReals_eqcompat_l c), pathsinv0.
-      exact H.
+  - apply iscomprelfun_hr_to_NR.
 Defined.
 
 Definition hr_to_NRpos (x : hr_commrng) : NonnegativeReals := pr1 (hr_to_NR x).
@@ -83,8 +91,8 @@ Proof.
   apply (pr1 (pr2 (pr2 X))).
   apply hinhpr.
   exists 0 ; simpl.
-  change ((pr1 (pr1 x) + (pr2 (pr1 x) - pr1 (pr1 x))%NR + 0%NR) =
-   ((pr1 (pr1 x) - pr2 (pr1 x))%NR + pr2 (pr1 x) + 0%NR)).
+  change ((pr1 (pr1 x) + (pr2 (pr1 x) - pr1 (pr1 x)) + 0) =
+   ((pr1 (pr1 x) - pr2 (pr1 x)) + pr2 (pr1 x) + 0))%NR.
   rewrite !isrunit_zero_plusNonnegativeReals.
   rewrite iscomm_plusNonnegativeReals, <- !maxNonnegativeReals_minus_plus.
   now apply iscomm_maxNonnegativeReals.
@@ -454,9 +462,11 @@ Qed.
 
 Lemma isStrongOrder_hr_lt : isStrongOrder hr_lt_rel.
 Proof.
-  split.
+  repeat split.
   - apply istransabgrfracrel.
     exact istrans_ltNonnegativeReals.
+  - apply iscotransabgrfracrel.
+    exact iscotrans_ltNonnegativeReals.
   - apply isirreflabgrfracrel.
     exact isirrefl_ltNonnegativeReals.
 Qed.
@@ -545,10 +555,10 @@ Proof.
   - pattern x at 3.
     rewrite <- (hr_to_NR_bij x), <- (hr_to_NR_bij 0%rng), hr_to_NR_zero.
     unfold hr_to_NRpos, hr_to_NRneg.
-    destruct (hr_to_NR x) as (x1,x2) ; simpl pr1 ; simpl pr2 ; clear x ; intros (->,H2).
+    destruct (hr_to_NR x) as (x1,x2) ; simpl pr1 ; simpl pr2 ; clear x ; intros H2 ; rewrite (pr1 H2).
     apply NR_to_hr_lt ; simpl.
     rewrite !islunit_zero_plusNonnegativeReals.
-    now apply ispositive_apNonnegativeReals.
+    now apply ispositive_apNonnegativeReals, (pr2 H2).
   - apply_pr2 hr_to_NR_nonpositive.
     now apply hr_lt_le.
   - rewrite <- (hr_to_NR_bij x), <- (hr_to_NR_bij 0%rng), hr_to_NR_zero in X.
@@ -754,13 +764,13 @@ Proof.
     apply hr_ap_lt in Hap.
     destruct Hap as [Hlt|Hlt].
     + apply (iscotrans_hr_lt X Y Z) in Hlt.
-      revert Hlt ; apply hinhfun ; intros [Hlt|Hlt].
+      revert Hlt ; apply hinhfun ; apply sumofmaps ; intros Hlt.
       * left ; apply_pr2 hr_ap_lt.
         now left.
       * right ; apply_pr2 hr_ap_lt.
         now left.
     + apply (iscotrans_hr_lt _ Y _) in Hlt.
-      revert Hlt ; apply hinhfun ; intros [Hlt|Hlt].
+      revert Hlt ; apply hinhfun ; apply sumofmaps ; intros Hlt.
       * right ; apply_pr2 hr_ap_lt.
         now right.
       * left ; apply_pr2 hr_ap_lt.
@@ -814,13 +824,13 @@ Proof.
   intro H ; simpl in H,Hap ; rewrite !H in Hap ; clear H.
   apply ap_plusNonnegativeReals in Hap.
   apply NR_to_hr_ap.
-  revert Hap ; apply hinhuniv ; intros [Hap | Hap].
+  revert Hap ; apply hinhuniv ; apply sumofmaps ; intros Hap.
   - apply ap_multNonnegativeReals in Hap.
-    revert Hap ; apply hinhuniv ; intros [Hap | Hap].
+    revert Hap ; apply hinhuniv ; apply sumofmaps ; intros Hap.
     + exact Hap.
     + now eapply fromempty, (isirrefl_apNonnegativeReals _), Hap .
   - apply ap_multNonnegativeReals in Hap.
-    revert Hap ; apply hinhuniv ; intros [Hap | Hap].
+    revert Hap ; apply hinhuniv ; apply sumofmaps ; intros Hap.
     + rewrite (iscomm_plusNonnegativeReals (pr1 (hr_to_NR Z))), iscomm_plusNonnegativeReals.
       now apply issymm_apNonnegativeReals, Hap.
     + now eapply fromempty, (isirrefl_apNonnegativeReals _), Hap.
@@ -1012,9 +1022,11 @@ Lemma ispositive_multNonnegativeReals :
 Proof.
   intros x y.
   split.
-  - intros (Hx,Hy).
+  - intros H.
     rewrite <- (islabsorb_zero_multNonnegativeReals y).
-    now apply multNonnegativeReals_ltcompat_l.
+    apply multNonnegativeReals_ltcompat_l.
+    apply (pr2 H).
+    apply (pr1 H).
   - intros H ; split.
     eapply multNonnegativeReals_ltcompat_l'.
     rewrite islabsorb_zero_multNonnegativeReals.
@@ -1031,7 +1043,8 @@ Proof.
   intros H.
   generalize (iscotrans_ltNonnegativeReals _ x _ H).
   apply hinhfun.
-  intros [Hx|Hx].
+  apply sumofmaps ;
+  intros Hx.
   - now left.
   - right.
     rewrite <- (maxNonnegativeReals_carac_r x y).
@@ -1067,7 +1080,7 @@ Proof.
   - intros H.
     apply maxNonnegativeReals_lt' in H.
     apply le0_NonnegativeReals.
-    revert H ; apply hinhuniv ; intros [H | H] ;
+    revert H ; apply hinhuniv ; apply sumofmaps ; intros H ;
     apply_pr2_in ispositive_multNonnegativeReals H ;
     apply maxNonnegativeReals_le ;
     apply_pr2 le0_NonnegativeReals.
@@ -1078,7 +1091,7 @@ Proof.
   - intros H.
     apply maxNonnegativeReals_lt' in H.
     apply le0_NonnegativeReals.
-    revert H ; apply hinhuniv ; intros [H | H] ;
+    revert H ; apply hinhuniv ; apply sumofmaps ; intros H ;
     apply_pr2_in ispositive_multNonnegativeReals H ;
     apply maxNonnegativeReals_le ;
     apply_pr2 le0_NonnegativeReals.
@@ -1134,45 +1147,47 @@ Proof.
     repeat split.
     - intros y1 y2.
       apply hinhuniv.
-      intros (c,Hc).
+      intros c.
+      generalize (pr2 c) ; intros Hc.
       apply_pr2_in plusNonnegativeReals_ltcompat_l Hc.
       generalize (isarchrig_1 _ H _ _ Hc).
       apply hinhfun.
-      intros (n,Hn).
-      exists n.
+      intros n.
+      exists (pr1 n).
       apply hinhpr.
       exists 0%NR.
       apply plusNonnegativeReals_ltcompat_l.
-      exact Hn.
+      exact (pr2 n).
     - intros x.
       generalize (isarchrig_2 _ H x).
       apply hinhfun.
-      intros (n,Hn).
-      exists n.
+      intros n.
+      exists (pr1 n).
       apply hinhpr.
       exists 0%NR.
       apply plusNonnegativeReals_ltcompat_l.
-      exact Hn.
+      exact (pr2 n).
     - intros x.
       generalize (isarchrig_3 _ H x).
       apply hinhfun.
-      intros (n,Hn).
-      exists n.
+      intros n.
+      exists (pr1 n).
       apply hinhpr.
       exists 0%NR.
       apply plusNonnegativeReals_ltcompat_l.
-      exact Hn. }
+      exact (pr2 n). }
   intros x.
   generalize (isarchrng_isarchCF (X := hr_ConstructiveField) _ (isarchrigtorng NonnegativeReals gtNonnegativeReals ispositive_oneNonnegativeReals Hadd Htra Harch) x).
   apply hinhfun.
-  intros (n,Hn).
-  exists n.
+  intros n.
+  exists (pr1 n).
+  rewrite (tppr n) ; generalize (pr1 n) (pr2 n) ; clear n ; intros n Hn.
+  simpl pr1.
   rewrite <- (hr_to_NR_bij x), <- (hr_to_NR_bij (@nattorng hr_ConstructiveField n)) in Hn |- *.
   revert Hn.
   apply hinhfun ; simpl.
-  intros (c,Hc).
-  exists c.
-  exact Hc.
+  intros c.
+  exact c.
 Qed.
 
 (** ** Completeness *)
@@ -1199,9 +1214,9 @@ Proof.
     apply hr_to_NR_bij. }
   intros Cu c Hc.
   generalize (Cu c Hc).
-  apply hinhfun ; intros (N,Hu).
-  exists N ; intros n m Hn Hm.
-  specialize (Hu _ _ Hn Hm).
+  apply hinhfun ; intros N.
+  exists (pr1 N) ; intros n m Hn Hm.
+  generalize ((pr2 N) _ _ Hn Hm) ; intros Hu.
   split.
   - apply (plusNonnegativeReals_ltcompat_r (x m)) in Hu.
     eapply istrans_le_lt_ltNonnegativeReals, Hu.
@@ -1236,9 +1251,9 @@ Proof.
     apply hr_to_NR_bij. }
   intros Cu c Hc.
   generalize (Cu c Hc).
-  apply hinhfun ; intros (N,Hu).
-  exists N ; intros n m Hn Hm.
-  specialize (Hu _ _ Hn Hm).
+  apply hinhfun ; intros N.
+  exists (pr1 N) ; intros n m Hn Hm.
+  generalize ((pr2 N) _ _ Hn Hm) ; intros Hu.
   split.
   - apply (plusNonnegativeReals_ltcompat_r (y m)) in Hu.
     eapply istrans_le_lt_ltNonnegativeReals, Hu.
@@ -1291,8 +1306,8 @@ Proof.
   apply ispositive_halfNonnegativeReals in Hc.
   generalize (Hx _ Hc) (Hy _ Hc) ;
     apply hinhfun2 ; clear Hy Hx ;
-    intros (Nx,Hx) (Ny,Hy).
-  exists (max Nx Ny) ; intros n Hn.
+    intros Nx Ny.
+  exists (max (pr1 Nx) (pr1 Ny)) ; intros n Hn.
   rewrite <- Hxy ; simpl pr1.
   rewrite NR_to_hr_minus ; simpl.
   apply maxNonnegativeReals_lt.
@@ -1302,10 +1317,10 @@ Proof.
     apply maxNonnegativeReals_lt.
     + rewrite (double_halfNonnegativeReals c), (iscomm_plusNonnegativeReals (y n)), (isassoc_plusNonnegativeReals lx (y n)), <- (isassoc_plusNonnegativeReals (y n)), (iscomm_plusNonnegativeReals (y n)), <- !isassoc_plusNonnegativeReals, (isassoc_plusNonnegativeReals (lx + _)).
       apply plusNonnegativeReals_ltcompat.
-      apply Hx.
+      apply (pr2 Nx).
       apply istransnatleh with (2 := Hn).
       apply max_le_l.
-      apply_pr2 Hy.
+      apply_pr2 (pr2 Ny).
       apply istransnatleh with (2 := Hn).
       apply max_le_r.
     + apply plusNonnegativeReals_lt_r .
@@ -1316,10 +1331,10 @@ Proof.
     apply maxNonnegativeReals_lt.
     + rewrite (double_halfNonnegativeReals c), (iscomm_plusNonnegativeReals (x n)), (isassoc_plusNonnegativeReals ly (x n)), <- (isassoc_plusNonnegativeReals (x n)), (iscomm_plusNonnegativeReals (x n)), <- !isassoc_plusNonnegativeReals, (isassoc_plusNonnegativeReals (ly + _)).
       apply plusNonnegativeReals_ltcompat.
-      apply Hy.
+      apply (pr2 Ny).
       apply istransnatleh with (2 := Hn).
       apply max_le_r.
-      apply_pr2 Hx.
+      apply_pr2 (pr2 Nx).
       apply istransnatleh with (2 := Hn).
       apply max_le_l.
     + apply plusNonnegativeReals_lt_r .
@@ -1528,7 +1543,7 @@ Qed.
 Lemma isirrefl_Rlt :
   Π x : Reals, ¬ (x < x).
 Proof.
-  exact (pr2 isStrongOrder_hr_lt).
+  exact (pr2 (pr2 isStrongOrder_hr_lt)).
 Qed.
 Lemma istrans_Rlt :
   Π x y z : Reals, x < y -> y < z -> x < z.

--- a/UniMath/RealNumbers/Reals.v
+++ b/UniMath/RealNumbers/Reals.v
@@ -486,7 +486,7 @@ Proof.
   rewrite <- (hr_to_NR_bij x), <- (hr_to_NR_bij 0%rng), hr_to_NR_zero.
   unfold hr_to_NRneg.
   split.
-  - destruct (hr_to_NR x) as (x1,x2) ; simpl pr1 ; simpl pr2 ; clear x ; intros ->.
+  - rewrite (tppr (hr_to_NR x)) ; generalize (pr1 (hr_to_NR x)), (pr2 (hr_to_NR x)) ; intros x1 x2 ; simpl pr1 ; simpl pr2 ; clear x ; intros ->.
     apply NR_to_hr_le ; simpl.
     rewrite !isrunit_zero_plusNonnegativeReals.
     now apply isnonnegative_NonnegativeReals.
@@ -509,10 +509,12 @@ Proof.
   - pattern x at 3.
     rewrite <- (hr_to_NR_bij x), <- (hr_to_NR_bij 0%rng), hr_to_NR_zero.
     unfold hr_to_NRpos, hr_to_NRneg.
-    destruct (hr_to_NR x) as (x1,x2) ; simpl pr1 ; simpl pr2 ; clear x ; intros (H1,->).
+    rewrite (tppr (hr_to_NR x)) ;
+      generalize (pr1 (hr_to_NR x)), (pr2 (hr_to_NR x)) ;
+      intros x1 x2 ; simpl pr1 ; simpl pr2 ; clear x ; intros H1 ; rewrite (pr2 H1).
     apply NR_to_hr_lt ; simpl.
     rewrite !isrunit_zero_plusNonnegativeReals.
-    now apply ispositive_apNonnegativeReals.
+    now apply ispositive_apNonnegativeReals, (pr1 H1).
   - rewrite <- (hr_to_NR_bij x), <- (hr_to_NR_bij 0%rng), hr_to_NR_zero in X.
     apply_pr2_in NR_to_hr_lt X.
     rewrite isrunit_zero_plusNonnegativeReals, islunit_zero_plusNonnegativeReals in X.
@@ -532,7 +534,8 @@ Proof.
   rewrite <- (hr_to_NR_bij x), <- (hr_to_NR_bij 0%rng), hr_to_NR_zero.
   unfold hr_to_NRpos.
   split.
-  - destruct (hr_to_NR x) as (x1,x2) ; simpl pr1 ; simpl pr2 ; clear x ; intros ->.
+  - rewrite (tppr (hr_to_NR x)).
+    simpl pr1 ; simpl pr2 ; intros ->.
     apply NR_to_hr_le ; simpl.
     rewrite !islunit_zero_plusNonnegativeReals.
     now apply isnonnegative_NonnegativeReals.
@@ -555,7 +558,7 @@ Proof.
   - pattern x at 3.
     rewrite <- (hr_to_NR_bij x), <- (hr_to_NR_bij 0%rng), hr_to_NR_zero.
     unfold hr_to_NRpos, hr_to_NRneg.
-    destruct (hr_to_NR x) as (x1,x2) ; simpl pr1 ; simpl pr2 ; clear x ; intros H2 ; rewrite (pr1 H2).
+    rewrite (tppr (hr_to_NR x)) ; simpl pr1 ; simpl pr2 ; intros H2 ; rewrite (pr1 H2).
     apply NR_to_hr_lt ; simpl.
     rewrite !islunit_zero_plusNonnegativeReals.
     now apply ispositive_apNonnegativeReals, (pr2 H2).
@@ -737,11 +740,12 @@ Proof.
   rewrite <-  (hr_to_NR_bij X), <- (hr_to_NR_bij Y).
   split ; intro Hap.
   - apply_pr2_in NR_to_hr_ap Hap.
-    destruct Hap as [Hlt | Hlt].
+    revert Hap.
+    apply sumofmaps ; intros Hlt.
     + now left ; apply NR_to_hr_lt.
     + now right ; apply NR_to_hr_lt.
   - apply NR_to_hr_ap.
-    destruct Hap as [Hlt | Hlt].
+    revert Hap ; apply sumofmaps ; intros Hlt.
     + now left ; apply_pr2 NR_to_hr_lt.
     + now right ; apply_pr2 NR_to_hr_lt.
 Qed.
@@ -762,7 +766,7 @@ Proof.
     now apply_pr2 NR_to_hr_ap.
   - intros X Y Z Hap.
     apply hr_ap_lt in Hap.
-    destruct Hap as [Hlt|Hlt].
+    revert Hap ; apply sumofmaps ; intros Hlt.
     + apply (iscotrans_hr_lt X Y Z) in Hlt.
       revert Hlt ; apply hinhfun ; apply sumofmaps ; intros Hlt.
       * left ; apply_pr2 hr_ap_lt.
@@ -796,7 +800,7 @@ Proof.
   intro Hap.
   apply_pr2 hr_ap_lt.
   apply hr_ap_lt in Hap.
-  destruct Hap as [Hlt | Hlt].
+  revert Hap ; apply sumofmaps ; intros Hlt.
   - left.
     apply_pr2 (hr_plus_ltcompat_l X).
     exact Hlt.
@@ -834,7 +838,7 @@ Proof.
     + rewrite (iscomm_plusNonnegativeReals (pr1 (hr_to_NR Z))), iscomm_plusNonnegativeReals.
       now apply issymm_apNonnegativeReals, Hap.
     + now eapply fromempty, (isirrefl_apNonnegativeReals _), Hap.
-  - clear ; intros.
+  - clear ; intros Y Z.
     rewrite !isrdistr_plus_multNonnegativeReals.
     rewrite !isassoc_plusNonnegativeReals.
     apply_pr2 plusNonnegativeReals_eqcompat_r.
@@ -916,7 +920,8 @@ Lemma hr_ex_inv :
     hr_ap_rel x 0%rng -> multinvpair hr_commrng x.
 Proof.
   intros x Hap.
-  destruct (pr1 (hr_ap_lt _ _) Hap) as [Hlt | Hlt] ; simpl.
+  generalize (pr1 (hr_ap_lt _ _) Hap) ;
+    apply sumofmaps ; intros Hlt ; simpl.
   - eexists ; split.
     refine (hr_islinv_neg _ _).
     exact Hlt.
@@ -1628,12 +1633,10 @@ Proof.
   generalize (iscotrans_Rlt _ y _ H).
   apply hinhuniv'.
   exact isapropempty.
-  intros [h|h].
-  + generalize h.
-    apply_pr2 notRlt_Rle.
+  apply sumofmaps.
+  + apply_pr2 notRlt_Rle.
     exact Hyz.
-  + generalize h.
-    apply_pr2 notRlt_Rle.
+  + apply_pr2 notRlt_Rle.
     exact Hxy.
 Qed.
 Lemma istrans_Rle_lt :
@@ -1642,7 +1645,7 @@ Proof.
   intros x y z Hxy Hyz.
   generalize (iscotrans_Rlt _ x _ Hyz).
   apply hinhuniv.
-  intros [ H | H ].
+  apply sumofmaps ; intros H.
   apply fromempty.
   revert H.
   apply_pr2 notRlt_Rle.
@@ -1655,7 +1658,7 @@ Proof.
   intros x y z Hxy Hyz.
   generalize (iscotrans_Rlt _ z _ Hxy).
   apply hinhuniv.
-  intros [ H | H ].
+  apply sumofmaps ; intros H.
   exact H.
   apply fromempty.
   revert H.

--- a/UniMath/RealNumbers/Reals.v
+++ b/UniMath/RealNumbers/Reals.v
@@ -1534,6 +1534,31 @@ Proof.
   apply NRNRtoR_one.
 Qed.
 
+Lemma Rabs_NRNRtoR :
+  Π x y : NonnegativeReals,
+    Rabs (NRNRtoR x y) = MetricSpace.dist (X := MS_NonnegativeReals) x y.
+Proof.
+  intros x y.
+  reflexivity.
+Qed.
+
+Lemma Rabs_pr1RtoNRNR :
+  Π x : Reals,
+    (pr1 (RtoNRNR x) <= Rabs x)%NR.
+Proof.
+  intros x.
+  rewrite <- (NRNRtoR_RtoNRNR x), Rabs_NRNRtoR.
+  apply maxNonnegativeReals_le_l.
+Qed.
+Lemma Rabs_pr2RtoNRNR :
+  Π x : Reals,
+    (pr2 (RtoNRNR x) <= Rabs x)%NR.
+Proof.
+  intros x.
+  rewrite <- (NRNRtoR_RtoNRNR x), Rabs_NRNRtoR.
+  apply maxNonnegativeReals_le_r.
+Qed.
+
 (** ** Theorems about apartness and order *)
 
 Lemma ispositive_Rone : 0 < 1.
@@ -1890,4 +1915,12 @@ Lemma Rabs_Rmult :
   Π x y : Reals, (Rabs (x * y)%R = Rabs x * Rabs y)%NR.
 Proof.
   exact hr_abs_mult.
+Qed.
+
+Lemma Rabs_Ropp :
+  Π x : Reals, (Rabs (- x)%R = Rabs x).
+Proof.
+  intros x.
+  rewrite <- (NRNRtoR_RtoNRNR x).
+  apply iscomm_maxNonnegativeReals.
 Qed.

--- a/UniMath/Topology/Filters.v
+++ b/UniMath/Topology/Filters.v
@@ -65,9 +65,9 @@ Proof.
   unfold isfilter_htrue.
   rewrite <- finite_intersection_htrue.
   apply Hand.
-  intros (m,Hm).
+  intros m.
   apply fromempty.
-  revert Hm.
+  generalize (pr2 m).
   now apply negnatlthn0.
 Qed.
 
@@ -77,8 +77,9 @@ Proof.
   intros Hand A B Fa Fb.
   rewrite <- finite_intersection_and.
   apply Hand.
-  intros (m,Hm) ; simpl.
-  destruct m.
+  intros m.
+  induction m as [m Hm].
+  induction m as [ | m _].
   exact Fa.
   exact Fb.
 Qed.
@@ -126,13 +127,13 @@ Lemma emptynofilter :
   Π F : (empty → hProp) → hProp,
     ¬ isFilter F.
 Proof.
-  intros F ((Himp,Hand),Hempty).
-  apply isfilter_finite_intersection_htrue in Hand.
-  generalize (Hempty _ Hand).
+  intros F Hf.
+  generalize (isfilter_finite_intersection_htrue _ (pr2 (pr1 Hf))) ; intros Htrue.
+  generalize (pr2 Hf _ Htrue).
   apply hinhuniv'.
   apply isapropempty.
-  intros (x,_).
-  apply x.
+  intros x.
+  apply (pr1 x).
 Qed.
 
 Section PreFilter_pty.
@@ -193,7 +194,7 @@ Proof.
   generalize (filter_notempty _ Fa).
   apply hinhuniv'.
   apply isapropempty.
-  intros (_,x); generalize x; clear x.
+  intros x ; generalize (pr2 x); clear x.
   exact Ha.
 Qed.
 
@@ -314,16 +315,16 @@ Proof.
   intros A Fa.
   generalize (Hempty _ Fa).
   apply hinhfun.
-  intros (x,Ax).
-  exists (f x).
-  exact Ax.
+  intros x.
+  exists (f (pr1 x)).
+  exact (pr2 x).
 Qed.
 
 End filterim.
 
 Definition PreFilterIm {X Y : UU} (f : X → Y) (F : PreFilter X) : PreFilter Y.
 Proof.
-  intros.
+  intros X Y f F.
   simple refine (mkPreFilter _ _ _ _).
   exact (filterim f F).
   apply filterim_imply, filter_imply.
@@ -435,10 +436,10 @@ Proof.
   intros A B Ha Hb.
   generalize (Hand _ _ Ha Hb).
   apply Himp.
-  intros x (Ax,Bx) Hx.
+  intros x ABx Hx.
   split.
-  - apply Ax, Hx.
-  - apply Bx, Hx.
+  - apply (pr1 ABx), Hx.
+  - apply (pr2 ABx), Hx.
 Qed.
 Lemma filterdom_notempty :
   isfilter_notempty filterdom.
@@ -447,9 +448,9 @@ Proof.
   intros A Fa.
   generalize (Hdom _ Fa).
   apply hinhfun.
-  intros (x,(Hx,Ax)).
-  exists x.
-  now apply Ax.
+  intros x.
+  exists (pr1 x).
+  apply (pr2 (pr2 x)), (pr1 (pr2 x)).
 Qed.
 
 End filterdom.
@@ -517,10 +518,10 @@ Proof.
   intros A B Ha Hb.
   generalize (Hand _ _ Ha Hb).
   apply Himp.
-  intros x (Ax,Bx) Hx.
+  intros x ABx Hx.
   split.
-  - apply Ax.
-  - apply Bx.
+  - apply (pr1 ABx).
+  - apply (pr2 ABx).
 Qed.
 Lemma filtersubtype_notempty :
   isfilter_notempty filtersubtype.
@@ -528,9 +529,9 @@ Proof.
   intros A Fa.
   generalize (Hdom _ Fa).
   apply hinhfun.
-  intros (x,(Hx,Ax)).
-  exists (x,,Hx).
-  exact (Ax Hx).
+  intros x.
+  exists (pr1 x,,pr1 (pr2 x)).
+  exact (pr2 (pr2 x) (pr1 (pr2 x))).
 Qed.
 
 End filtersubtype.
@@ -586,7 +587,9 @@ Lemma filterdirprod_imply :
 Proof.
   intros A B Himpl.
   apply hinhfun.
-  intros (Ax,(Ay,(Fax,(Fay,Ha)))).
+  intros C.
+  generalize (pr1 C) (pr1 (pr2 C)) (pr1 (pr2 (pr2 C))) (pr1 (pr2 (pr2 (pr2 C)))) (pr2 (pr2 (pr2 (pr2 C)))) ;
+  clear C ; intros Ax Ay Fax Fay Ha.
   exists Ax, Ay.
   repeat split.
   + exact Fax.
@@ -608,7 +611,11 @@ Lemma filterdirprod_and :
 Proof.
   intros A B.
   apply hinhfun2.
-  intros (Ax,(Ay,(Fax,(Fay,Ha)))) (Bx,(By,(Fbx,(Fby,Hb)))).
+  intros C D.
+  generalize (pr1 C) (pr1 (pr2 C)) (pr1 (pr2 (pr2 C))) (pr1 (pr2 (pr2 (pr2 C)))) (pr2 (pr2 (pr2 (pr2 C)))) ;
+  clear C ; intros Ax Ay Fax Fay Ha.
+  generalize (pr1 D) (pr1 (pr2 D)) (pr1 (pr2 (pr2 D))) (pr1 (pr2 (pr2 (pr2 D)))) (pr2 (pr2 (pr2 (pr2 D)))) ;
+  clear D ; intros Bx By Fbx Fby Hb.
   exists (λ x : X, Ax x ∧ Bx x), (λ y : Y, Ay y ∧ By y).
   repeat split.
   + now apply Hand_x.
@@ -625,12 +632,16 @@ Lemma filterdirprod_notempty :
 Proof.
   intros A.
   apply hinhuniv.
-  intros (Ax,(Ay,(Fax,(Fay,Ha)))).
+  intros C.
+  generalize (pr1 C) (pr1 (pr2 C)) (pr1 (pr2 (pr2 C))) (pr1 (pr2 (pr2 (pr2 C)))) (pr2 (pr2 (pr2 (pr2 C)))) ;
+  clear C ; intros Ax Ay Fax Fay Ha.
   generalize (Hempty_x _ Fax) (Hempty_y _ Fay).
   apply hinhfun2.
-  intros (x,Axx) (y,Ayy).
-  exists (x,,y).
-  now apply Ha.
+  intros x y.
+  exists (pr1 x,,pr1 y).
+  apply Ha.
+  exact (pr2 x).
+  exact (pr2 y).
 Qed.
 
 End filterdirprod.
@@ -675,12 +686,17 @@ Proof.
   intros X Y F.
   intros A.
   apply hinhuniv.
-  intros (Ax,(Ay,(Fax,(Fay,Ha)))).
+  intros C ;
+    generalize (pr1 C) (pr1 (pr2 C)) (pr1 (pr2 (pr2 C))) (pr1 (pr2 (pr2 (pr2 C)))) (pr2 (pr2 (pr2 (pr2 C)))) ;
+    clear C ; intros Ax Ay Fax Fay Ha.
   simpl in * |-.
   generalize (filter_and _ _ _ Fax Fay).
   apply filter_imply.
-  intros (x,y) (Fx,Fy).
-  now apply Ha.
+  intros xy Fxy.
+  rewrite (tppr xy).
+  apply Ha.
+  exact (pr1 Fxy).
+  exact (pr2 Fxy).
 Qed.
 
 Goal Π {X Y : UU} (F : PreFilter X) (G : PreFilter Y),
@@ -722,10 +738,10 @@ Lemma filternat_imply :
 Proof.
   intros P Q H.
   apply hinhfun.
-  intros (N,Hp).
-  exists N.
+  intros N.
+  exists (pr1 N).
   intros n Hn.
-  now apply H, Hp.
+  now apply H, (pr2 N).
 Qed.
 Lemma filternat_htrue :
   isfilter_htrue filternat.
@@ -738,14 +754,14 @@ Lemma filternat_and :
 Proof.
   intros A B.
   apply hinhfun2.
-  intros (Na,Ha) (Nb,Hb).
-  exists (max Na Nb).
+  intros Na Nb.
+  exists (max (pr1 Na) (pr1 Nb)).
   intros n Hn.
   split.
-  + apply Ha.
+  + apply (pr2 Na).
     eapply istransnatleh, Hn.
     now apply max_le_l.
-  + apply Hb.
+  + apply (pr2 Nb).
     eapply istransnatleh, Hn.
     now apply max_le_r.
 Qed.
@@ -754,9 +770,9 @@ Lemma filternat_notempty :
 Proof.
   intros A.
   apply hinhfun.
-  intros (N,Hn).
-  exists N.
-  apply (Hn N).
+  intros N.
+  exists (pr1 N).
+  apply (pr2 N (pr1 N)).
   now apply isreflnatleh.
 Qed.
 
@@ -891,8 +907,11 @@ Proof.
   intros A Fa.
   revert His.
   apply hinhuniv.
-  intros (F,Hf).
-  apply (Hempty F Hf _ (Fa _ Hf)).
+  intros F.
+  apply (Hempty (pr1 F)).
+  exact (pr2 F).
+  apply Fa.
+  exact (pr2 F).
 Qed.
 
 End filterintersection.
@@ -987,8 +1006,8 @@ Proof.
   apply hinhpr.
   exists nil.
   split.
-  intros (m,Hm).
-  easy.
+  intros m.
+  now generalize (pr2 m).
   easy.
 Qed.
 Lemma filtergenerated_and :
@@ -1002,7 +1021,7 @@ Proof.
   + simpl ; intros m.
     set (Hm := invmap (weqfromcoprodofstn (length (pr1 Ha)) (length (pr1 Hb))) m).
     change (invmap (weqfromcoprodofstn (length (pr1 Ha)) (length (pr1 Hb))) m) with Hm.
-    destruct Hm.
+    induction Hm as [Hm | Hm].
     * rewrite coprod_rect_compute_1.
       apply (pr1 (pr2 Ha)).
     * rewrite coprod_rect_compute_2.
@@ -1025,12 +1044,13 @@ Lemma filtergenerated_notempty :
 Proof.
   intros A.
   apply hinhuniv.
-  intros (L',(Hl',Ha)).
-  generalize (Hl _ Hl').
+  intros L'.
+  generalize (Hl _ (pr1 (pr2 L'))).
   apply hinhfun.
-  intros (x,Lx).
-  exists x.
-  now apply Ha.
+  intros x.
+  exists (pr1 x).
+  apply (pr2 (pr2 L')).
+  exact (pr2 x).
 Qed.
 
 End filtergenerated.
@@ -1162,46 +1182,42 @@ Proof.
           rewrite finite_intersection_append.
           simple refine (hinhuniv _ _).
           3: apply IHl.
-          intros (C,(Fc,Hc)).
+          intros C.
           generalize (Hl (lastelement _)) ; simpl.
           rewrite append_fun_compute_2.
           apply hinhfun.
-          intros [Fl | ->].
+          apply sumofmaps ; [intros Fl | intros ->].
           + refine (tpair _ _ _).
             split.
             * apply (filter_and F).
-              apply Fc.
+              apply (pr1 (pr2 C)).
               apply Fl.
-            * intros x (H0,(H1,H2)) ; repeat split.
-              apply H0.
-              apply H2.
-              simple refine (pr2 (Hc x _)).
+            * intros x H0 ; repeat split.
+              exact (pr1 H0).
+              exact (pr2 (pr2 H0)).
+              simple refine (pr2 (pr2 (pr2 C) x _)).
               split.
-              apply H0.
-              apply H1.
-          + exists C ; split.
-            * exact Fc.
-            * intros x (H0,H1) ; repeat split.
-              apply H0.
-              apply H0.
-              simple refine (pr2 (Hc x _)).
-              split.
-              apply H0.
-              apply H1.
+              exact (pr1 H0).
+              exact (pr1 (pr2 H0)).
+          + exists (pr1 C) ; split.
+            * exact (pr1 (pr2 C)).
+            * intros x H0 ; repeat split.
+              exact (pr1 H0).
+              exact (pr1 H0).
+              simple refine (pr2 (pr2 (pr2 C) x _)).
+              exact H0.
           + intros.
             generalize (Hl (dni_lastelement m)) ; simpl.
             now rewrite append_fun_compute_1. }
       revert B.
       apply hinhuniv.
-      intros (B,(Fb,Hb)).
-      generalize (H B Fb).
+      intros B.
+      generalize (H (pr1 B) (pr1 (pr2 B))).
       apply hinhfun.
-      intros (x,(Ax,Bx)).
-      exists x.
-      simple refine (pr2 (Hb x _)).
-      split.
-      apply Ax.
-      apply Bx.
+      intros x.
+      exists (pr1 x).
+      simple refine (pr2 (pr2 (pr2 B) (pr1 x) _)).
+      exact (pr2 x).
     + split.
       * intros B Fb.
         apply hinhpr.
@@ -1352,12 +1368,12 @@ Lemma filterbase_notempty :
 Proof.
   intros A.
   apply hinhuniv.
-  intros (B,(Hb,Ha)).
-  generalize (Hfalse _ Hb).
+  intros B.
+  generalize (Hfalse _ (pr1 (pr2 B))).
   apply hinhfun.
-  intros (x,Bx).
-  exists x.
-  now apply Ha.
+  intros x.
+  exists (pr1 x).
+  apply (pr2 (pr2 B)), (pr2 x).
 Qed.
 
 Lemma base_finite_intersection :
@@ -1369,21 +1385,21 @@ Proof.
   split.
   - revert Hempty.
     apply hinhfun.
-    intros (A,Ha).
-    now exists A.
+    intros A.
+    now exists (pr1 A), (pr2 A).
   - intros A B.
     apply hinhuniv2.
-    intros (A',(Ha,Ha')) (B',(Hb,Hb')).
-    generalize (Hand _ _ Ha Hb).
+    intros A' B'.
+    generalize (Hand _ _ (pr1 (pr2 A')) (pr1 (pr2 B'))).
     apply hinhfun.
-    intros (C,(Hc,Hc')).
-    exists C.
+    intros C.
+    exists (pr1 C).
     split.
-    exact Hc.
+    exact (pr1 (pr2 C)).
     intros x Cx.
     split.
-    apply Ha', (pr1 (Hc' _ Cx)).
-    apply Hb', (pr2 (Hc' _ Cx)).
+    apply (pr2 (pr2 A')), (pr1 (pr2 (pr2 C) _ Cx)).
+    apply (pr2 (pr2 B')), (pr2 (pr2 (pr2 C) _ Cx)).
   - intros n.
     apply hinhpr.
     exists (L n).
@@ -1398,23 +1414,23 @@ Proof.
   apply funextfun ; intros P.
   apply hPropUnivalence.
   - apply hinhfun.
-    intros (A,(Ha,Ha')).
-    exists (singletonSequence A).
+    intros A.
+    exists (singletonSequence (pr1 A)).
     split.
     + intros m ; simpl.
-      exact Ha.
+      exact (pr1 (pr2 A)).
     + intros x Ax.
-      apply Ha', Ax.
+      apply (pr2 (pr2 A)), Ax.
       now exists 0%nat.
   - apply hinhuniv.
-    intros (L,(Hbase,Hinter)).
-    generalize (base_finite_intersection L Hbase).
+    intros L.
+    generalize (base_finite_intersection (pr1 L) (pr1 (pr2 L))).
     apply hinhfun.
-    intros (A,(Ha,Ha')).
-    exists A ; split.
-    exact Ha.
+    intros A.
+    exists (pr1 A) ; split.
+    exact (pr1 (pr2 A)).
     intros x Ax.
-    now apply Hinter, Ha'.
+    now apply (pr2 (pr2 L)), (pr2 (pr2 A)).
 Qed.
 
 Lemma filterbase_generated_hypothesis :
@@ -1425,19 +1441,20 @@ Proof.
   intros L Hbase.
   generalize (base_finite_intersection L Hbase).
   apply hinhuniv.
-  intros (A,(Ha,Ha')).
-  generalize (Hfalse _ Ha).
+  intros A.
+  generalize (Hfalse _ (pr1 (pr2 A))).
   apply hinhfun.
-  intros (x,Ax).
-  exists x.
-  now apply Ha'.
+  intros x.
+  exists (pr1 x).
+  apply (pr2 (pr2 A)).
+  exact (pr2 x).
 Qed.
 
 End filterbase.
 
 Definition PreFilterBase {X : UU} (base : BaseOfPreFilter X) : PreFilter X.
 Proof.
-  intros.
+  intros X base.
   simple refine (mkPreFilter _ _ _ _).
   - apply (filterbase base).
   - apply filterbase_imply.
@@ -1514,15 +1531,15 @@ Proof.
   split.
   - intros Hbase P.
     apply hinhuniv.
-    intros (A,(Ha,Ha')).
-    generalize (Hbase _ Ha).
+    intros A.
+    generalize (Hbase _ (pr1 (pr2 A))).
     apply hinhfun.
-    intros (B,(Hb,Hb')).
-    exists B.
+    intros B.
+    exists (pr1 B).
     split.
-    apply Hb.
+    apply (pr1 (pr2 B)).
     intros x Bx.
-    apply Ha', Hb', Bx.
+    apply (pr2 (pr2 A)), (pr2 (pr2 B)), Bx.
   - intros Hbase P Hp.
     apply Hbase.
     apply hinhpr.

--- a/UniMath/Topology/Prelim.v
+++ b/UniMath/Topology/Prelim.v
@@ -229,10 +229,10 @@ Qed.
 
 Lemma finite_intersection_case {X : UU} :
   Π (L : Sequence (X → hProp)),
-    finite_intersection L = match disassembleSequence L with
-                            | ii1 _ => λ _, htrue
-                            | ii2 (A,,B) => (λ x : X, A x ∧ finite_intersection B x)
-                            end.
+  finite_intersection L =
+  sumofmaps (λ _ _, htrue)
+            (λ (AB : (X → hProp) × Sequence (X → hProp)) (x : X), pr1 AB x ∧ finite_intersection (pr2 AB) x)
+            (disassembleSequence L).
 Proof.
   intros X.
   intros L.

--- a/UniMath/Topology/Prelim.v
+++ b/UniMath/Topology/Prelim.v
@@ -41,21 +41,45 @@ Proof.
   exact Hxy.
 Qed.
 
+(** ** A new tactic *)
+
+Ltac apply_pr2 T :=
+  first [ refine (pr2 (T) _)
+        | refine (pr2 (T _) _)
+        | refine (pr2 (T _ _) _)
+        | refine (pr2 (T _ _ _) _)
+        | refine (pr2 (T _ _ _ _) _)
+        | refine (pr2 (T _ _ _ _ _) _)
+        | refine (pr2 (T))
+        | refine (pr2 (T _))
+        | refine (pr2 (T _ _))
+        | refine (pr2 (T _ _ _))
+        | refine (pr2 (T _ _ _ _))
+        | refine (pr2 (T _ _ _ _ _)) ].
+
+Ltac apply_pr2_in T H :=
+  first [ apply (pr2 (T)) in H
+        | apply (fun H0 => pr2 (T H0)) in H
+        | apply (fun H0 H1 => pr2 (T H0 H1)) in H
+        | apply (fun H0 H1 H2 => pr2 (T H0 H1 H2)) in H
+        | apply (fun H0 H1 H2 H3 => pr2 (T H0 H1 H2 H3)) in H
+        | apply (fun H0 H1 H2 H3 H4 => pr2 (T H0 H1 H2 H3 H4)) in H ].
+
 (** ** About nat *)
 
 Lemma max_le_l : Π n m : nat, (n ≤ max n m)%nat.
 Proof.
-  induction n ; simpl max.
-  - intros ; reflexivity.
-  - destruct m.
+  induction n as [ | n IHn] ; simpl max.
+  - intros m ; reflexivity.
+  - induction m as [ | m _].
     + now apply isreflnatleh.
     + now apply IHn.
 Qed.
 Lemma max_le_r : Π n m : nat, (m ≤ max n m)%nat.
 Proof.
-  induction n ; simpl max.
-  - intros ; now apply isreflnatleh.
-  - destruct m.
+  induction n as [ | n IHn] ; simpl max.
+  - intros m ; now apply isreflnatleh.
+  - induction m as [ | m _].
     + reflexivity.
     + now apply IHn.
 Qed.
@@ -63,7 +87,16 @@ Qed.
 (** ** More about Sequence *)
 
 Definition singletonSequence {X} (A : X) : Sequence X := (1 ,, λ _, A).
-Definition pairSequence {X} (A B : X) : Sequence X := (2 ,, λ m, match (pr1 m) with | O => A | _ => B end).
+Definition pairSequence {X} (A B : X) : Sequence X.
+Proof.
+  intros X A B.
+  exists 2.
+  intros m.
+  induction m as [m _].
+  induction m as [ | _ _].
+  exact A.
+  exact B.
+Defined.
 
 (** ** More about sets *)
 (** union *)
@@ -95,12 +128,12 @@ Proof.
     intros C.
     generalize (pr1 (pr2 C)).
     apply hinhfun.
-    intros [<- | <-].
+    apply sumofmaps ; intros <-.
     + left.
       apply (pr2 (pr2 C)).
     + right.
       apply (pr2 (pr2 C)).
-  - apply hinhfun ; intros [Ax | Bx].
+  - apply hinhfun ; apply sumofmaps ; [ intros Ax | intros Bx].
     + exists A.
       split.
       apply hinhpr.
@@ -124,7 +157,7 @@ Proof.
   apply Hp.
   intros C.
   apply hinhuniv.
-  now intros [-> | ->].
+  now apply sumofmaps ; intros ->.
 Qed.
 
 (** finite intersection *)
@@ -146,7 +179,10 @@ Proof.
   apply hPropUnivalence.
   - intros _.
     apply tt.
-  - intros _ (m,Hm).
+  - intros _ m.
+    rewrite (tppr m) ;
+      generalize (pr1 m) (pr2 m) ;
+      clear m ; intros m Hm.
     apply fromempty.
     revert Hm.
     apply negnatlthn0.
@@ -163,11 +199,8 @@ Proof.
   - intros H.
     apply H.
     now exists 0.
-  - intros Lx (m,Hm).
-    destruct m.
-    exact Lx.
-    apply fromempty.
-    easy.
+ - intros Lx m.
+   exact Lx.
 Qed.
 
 Lemma finite_intersection_and {X : UU} :
@@ -185,12 +218,13 @@ Proof.
     reflexivity.
     simple refine (H (1,,_)).
     reflexivity.
-  - intros H (m,Hm) ; simpl.
-    destruct m.
+  - intros H m ; simpl.
+    rewrite (tppr m) ;
+      generalize (pr1 m) (pr2 m) ;
+      clear m ; intros m Hm.
+    induction m as [ | m _].
     apply (pr1 H).
-    destruct m.
     apply (pr2 H).
-    easy.
 Qed.
 
 Lemma finite_intersection_case {X : UU} :
@@ -205,19 +239,24 @@ Proof.
   apply funextfun ; intros x.
   apply hPropUnivalence.
   - intros Hx.
-    destruct L as [n L].
-    destruct n ; simpl.
+    induction L as [n L].
+    induction n as [ | n _] ; simpl.
     + apply tt.
     + split.
       apply Hx.
       intros m.
       apply Hx.
-  - destruct L as [n L].
-    destruct n ; simpl.
-    + intros _ (n,Hn).
-      now apply fromempty.
-    + intros Hx (m,Hm).
-      destruct (natlehchoice _ _ (natlthsntoleh _ _ Hm)) as [Hm' | ->].
+  - induction L as [n L].
+    induction n as [ | n _] ; simpl.
+    + intros _ n.
+      apply fromempty.
+      now generalize (pr2 n).
+    + intros Hx m.
+      rewrite (tppr m) ;
+        generalize (pr1 m) (pr2 m) ;
+        clear m ;
+        intros m Hm.
+      induction (natlehchoice _ _ (natlthsntoleh _ _ Hm)) as [Hm' | ->].
       generalize (pr2 Hx (m,,Hm')).
       unfold funcomp, dni_lastelement ; simpl.
       assert (H : Hm = natlthtolths m n Hm' ).
@@ -232,16 +271,16 @@ Lemma finite_intersection_append {X : UU} :
   Π (A : X → hProp) (L : Sequence (X → hProp)),
     finite_intersection (append L A) = (λ x : X, A x ∧ finite_intersection L x).
 Proof.
-  intros.
+  intros X A L.
   rewrite finite_intersection_case.
   simpl.
   rewrite append_fun_compute_2.
   apply funextfun ; intro x.
   apply maponpaths.
   apply map_on_two_paths.
-  destruct L ; simpl.
+  induction L as [n L] ; simpl.
   apply maponpaths.
-  apply funextfun ; intro n.
+  apply funextfun ; intro m.
   apply append_fun_compute_1.
   reflexivity.
 Qed.
@@ -256,20 +295,26 @@ Proof.
   - split.
     + rewrite <- finite_intersection_htrue.
       apply X0.
-      now intros (n,Hn).
+      intros n.
+      now generalize (pr2 n).
     + intros A B Pa Pb.
       rewrite <- finite_intersection_and.
       apply X0.
-      intros (n,Hn).
-      now destruct n ; simpl.
-  - intros (P0,P2).
+      intros n.
+      rewrite (tppr n) ;
+        generalize (pr1 n) (pr2 n) ;
+        clear n ;
+        intros n Hn.
+      now induction n as [ | n _] ; simpl.
+  - intros Hp.
     apply (Sequence_rect (P := λ L : Sequence (X → hProp),
                                      (Π n : stn (length L), P (L n)) → P (finite_intersection L))).
     + intros _.
-      now rewrite finite_intersection_htrue.
+      rewrite finite_intersection_htrue.
+      exact (pr1 Hp).
     + intros L A IHl Hl.
       rewrite finite_intersection_append.
-      apply P2.
+      apply (pr2 Hp).
       * rewrite <- (append_fun_compute_2 L A).
         now apply Hl.
       * apply IHl.

--- a/UniMath/Topology/Topology.v
+++ b/UniMath/Topology/Topology.v
@@ -60,8 +60,8 @@ Proof.
   unfold isSetOfOpen_htrue.
   rewrite <- finite_intersection_htrue.
   apply H0.
-  intros (m,Hm).
-  now apply fromempty.
+  intros m.
+  now generalize (pr2 m).
 Qed.
 Lemma isSetOfOpen_finite_intersection_and :
   isSetOfOpen_finite_intersection
@@ -70,10 +70,9 @@ Proof.
   intros H0 A B Ha Hb.
   rewrite <- finite_intersection_and.
   apply H0.
-  intros (m,Hm) ; simpl.
-  destruct m.
-  apply Ha.
-  apply Hb.
+  intros m ; simpl.
+  induction m as [m Hm].
+  now induction m.
 Qed.
 Lemma isSetOfOpen_finite_intersection_carac :
   isSetOfOpen_htrue
@@ -142,8 +141,8 @@ Lemma isOpen_htrue :
 Proof.
   rewrite <- finite_intersection_htrue.
   apply isOpen_finite_intersection.
-  intros (m,Hm).
-  now apply fromempty.
+  intros m.
+  now generalize (pr2 m).
 Qed.
 Lemma isOpen_and :
   Π A B : T → hProp,
@@ -163,7 +162,7 @@ Proof.
   apply isOpen_union.
   intros C.
   apply hinhuniv.
-  intros [-> | ->].
+  apply sumofmaps ; intros ->.
   exact Ha.
   exact Hb.
 Qed.
@@ -198,16 +197,16 @@ Proof.
       - intros Px.
         generalize (Hp _ Px).
         apply hinhfun.
-        intros (A,(Ax,Ha)).
-        exists A ; split.
+        intros A.
+        exists (pr1 A) ; split.
         split.
-        apply (pr2 A).
-        exact Ha.
-        exact Ax.
+        apply (pr2 (pr1 A)).
+        exact (pr2 (pr2 A)).
+        exact (pr1 (pr2 A)).
       - apply hinhuniv.
-        intros (A,((Ha,Hx),Ax)).
-        apply Hx.
-        exact Ax. }
+        intros A.
+        apply (pr2 (pr1 (pr2 A))).
+        exact (pr2 (pr2 A)). }
     rewrite X.
     apply isOpen_union.
     intros A Ha.
@@ -452,12 +451,14 @@ Lemma topologyfromneighborhood_open :
 Proof.
   intros L Hl x.
   apply hinhuniv.
-  intros (A,(La,Ax)).
-  apply Himpl with A.
+  intros A.
+  apply Himpl with (pr1 A).
   intros y Hy.
   apply hinhpr.
-  now exists A.
-  now apply Hl.
+  now exists (pr1 A), (pr1 (pr2 A)).
+  apply Hl.
+  exact (pr1 (pr2 A)).
+  exact (pr2 (pr2 A)).
 Qed.
 
 End TopologyFromNeighborhood.
@@ -485,7 +486,7 @@ Lemma TopologyFromNeighborhood_correct {X : UU} (N : X → (X → hProp) → hPr
   Π (x : X) (P : X → hProp),
     N x P <-> neighborhood (T := TopologyFromNeighborhood N H) x P.
 Proof.
-  intros X N (Himpl,(Htrue,(Hand,(Hpt,H)))).
+  intros X N H.
   intros x P.
   split.
   - intros Hx.
@@ -495,19 +496,42 @@ Proof.
     + intros y.
       apply (N y P).
     + simpl ; intros y Hy.
-      generalize (H _ _ Hy).
+      generalize (pr2 (pr2 (pr2 (pr2 H))) _ _ Hy).
       apply hinhuniv.
-      intros (Q,(NyQ,Hq)).
-      now apply Himpl with (2 := NyQ).
+      intros Q.
+      apply (pr1 H) with (2 := pr1 (pr2 Q)).
+      exact (pr2 (pr2 Q)).
     + split ; simpl.
       exact Hx.
       intros y.
-      now apply Hpt.
+      now apply (pr1 (pr2 (pr2 (pr2 H)))).
   - apply hinhuniv.
-    intros ((Op,Ho),(Hx,Hp)).
-    apply Himpl with Op.
-    apply Hp.
-    apply Ho, Hx.
+    intros O.
+    apply (pr1 H) with (pr1 (pr1 O)).
+    apply (pr2 (pr2 O)).
+    apply (pr2 (pr1 O)), (pr1 (pr2 O)).
+Qed.
+
+Lemma isNeighborhood_isPreFilter {X : UU} N :
+  isNeighborhood N -> Π x : X, isPreFilter (N x).
+Proof.
+  intros X N Hn x.
+  split.
+  - apply (pr1 Hn).
+  - apply isfilter_finite_intersection_carac.
+    + apply (pr1 (pr2 Hn)).
+    + apply (pr1 (pr2 (pr2 Hn))).
+Qed.
+Lemma isNeighborhood_isFilter {X : UU} N :
+  isNeighborhood N -> Π x : X, isFilter (N x).
+Proof.
+  intros X N Hn x.
+  split.
+  - apply isNeighborhood_isPreFilter, Hn.
+  - intros A Fa.
+    apply hinhpr.
+    exists x.
+    apply ((pr1 (pr2 (pr2 (pr2 Hn)))) _ _ Fa).
 Qed.
 
 (** *** Generated Topology *)
@@ -525,13 +549,13 @@ Lemma topologygenerated_imply :
 Proof.
   intros x A B H.
   apply hinhfun.
-  intros (L,(Ol,(Hl,Al))).
-  exists L.
+  intros L.
+  exists (pr1 L).
   repeat split.
-  exact Ol.
-  exact Hl.
+  exact (pr1 (pr2 L)).
+  exact (pr1 (pr2 (pr2 L))).
   intros y Hy.
-  apply H, Al, Hy.
+  apply H, (pr2 (pr2 (pr2 L))), Hy.
 Qed.
 
 Lemma topologygenerated_htrue :
@@ -541,8 +565,10 @@ Proof.
   apply hinhpr.
   exists nil.
   repeat split.
-  now intros (n,Hn).
-  now intros (n,Hn).
+  intros n.
+  now generalize (pr2 n).
+  intros n.
+  now generalize (pr2 n).
 Qed.
 
 Lemma topologygenerated_and :
@@ -550,31 +576,31 @@ Lemma topologygenerated_and :
 Proof.
   intros x A B.
   apply hinhfun2.
-  intros (La,(Hoa,(Hxa,Ha))).
-  intros (Lb,(Hob,(Hxb,Hb))).
-  exists (concatenate La Lb).
+  intros La Lb.
+  exists (concatenate (pr1 La) (pr1 Lb)).
   repeat split.
   - simpl ; intro.
-    destruct (invmap (weqfromcoprodofstn (length La) (length Lb)) n) as [m | m].
+    apply (coprod_rect (λ x, O (coprod_rect _ _ _ x))) ; intros m.
     + rewrite coprod_rect_compute_1.
-      now apply Hoa.
+      exact (pr1 (pr2 La) _).
     + rewrite coprod_rect_compute_2.
-      now apply Hob.
+      exact (pr1 (pr2 Lb) _).
   - simpl ; intro.
-    destruct (invmap (weqfromcoprodofstn (length La) (length Lb)) n) as [m | m].
+    apply (coprod_rect (λ y, (coprod_rect (λ _ : stn (length (pr1 La)) ⨿ stn (length (pr1 Lb)), X → hProp) (λ j : stn (length (pr1 La)), (pr1 La) j)
+       (λ k : stn (length (pr1 Lb)), (pr1 Lb) k) y) x)) ; intros m.
     + rewrite coprod_rect_compute_1.
-      now apply Hxa.
+      exact (pr1 (pr2 (pr2 La)) _).
     + rewrite coprod_rect_compute_2.
-      now apply Hxb.
-  - apply Ha.
+      exact (pr1 (pr2 (pr2 Lb)) _).
+  - apply (pr2 (pr2 (pr2 La))).
     intros n.
     simpl in X0.
-    specialize (X0 (weqfromcoprodofstn (length La) (length Lb) (ii1 n))).
+    specialize (X0 (weqfromcoprodofstn (length (pr1 La)) (length (pr1 Lb)) (ii1 n))).
     now rewrite homotinvweqweq, coprod_rect_compute_1 in X0.
-  - apply Hb.
+  - apply (pr2 (pr2 (pr2 Lb))).
     intros n.
     simpl in X0.
-    specialize (X0 (weqfromcoprodofstn (length La) (length Lb) (ii2 n))).
+    specialize (X0 (weqfromcoprodofstn (length (pr1 La)) (length (pr1 Lb)) (ii2 n))).
     now rewrite homotinvweqweq, coprod_rect_compute_2 in X0.
 Qed.
 
@@ -583,8 +609,9 @@ Lemma topologygenerated_point :
 Proof.
   intros x P.
   apply hinhuniv.
-  intros (L,(Ol,(Hl,Pl))).
-  now apply Pl.
+  intros L.
+  apply (pr2 (pr2 (pr2 L))).
+  exact (pr1 (pr2 (pr2 L))).
 Qed.
 
 Lemma topologygenerated_neighborhood :
@@ -595,16 +622,22 @@ Lemma topologygenerated_neighborhood :
 Proof.
   intros x P.
   apply hinhfun.
-  intros (L,(Ol,(Hl,Pl))).
-  exists (finite_intersection L).
+  intros L.
+  exists (finite_intersection (pr1 L)).
   split.
-  apply hinhpr.
-  exists L.
-  easy.
-  intros y Hy.
-  apply hinhpr.
-  exists L.
-  easy.
+  - apply hinhpr.
+    exists (pr1 L).
+    repeat split.
+    exact (pr1 (pr2 L)).
+    exact (pr1 (pr2 (pr2 L))).
+    easy.
+  - intros y Hy.
+    apply hinhpr.
+    exists (pr1 L).
+    repeat split.
+    exact (pr1 (pr2 L)).
+    exact Hy.
+    exact (pr2 (pr2 (pr2 L))).
 Qed.
 
 End topologygenerated.
@@ -634,12 +667,11 @@ Proof.
   apply hinhpr.
   exists (singletonSequence P).
   repeat split.
-  - intros ([|n],Hn).
+  - induction n as [n Hn].
     exact Op.
-    now apply fromempty.
-  - intros ([|n],Hn).
+  - intros n ;
+    induction n as [n Hn].
     exact Hx.
-    now apply fromempty.
   - intros y Hy.
     now apply (Hy (0%nat,,paths_refl _)).
 Qed.
@@ -653,17 +685,17 @@ Proof.
   intros x Px.
   generalize (Hp x Px) ; clear Hp.
   apply hinhfun.
-  intros (L,(Ol,(Hl,Pl))).
+  intros L.
   simple refine (tpair _ _ _).
   simple refine (tpair _ _ _).
-  apply (finite_intersection L).
+  apply (finite_intersection (pr1 L)).
   apply (isOpen_finite_intersection (T := X,,T)).
   intros m.
   apply Ht.
-  apply Ol.
+  apply (pr1 (pr2 L)).
   split.
-  exact Hl.
-  exact Pl.
+  exact (pr1 (pr2 (pr2 L))).
+  exact (pr2 (pr2 (pr2 L))).
 Qed.
 
 (** *** Product of topologies *)
@@ -684,12 +716,12 @@ Lemma topologydirprod_imply :
 Proof.
   intros x A B H.
   apply hinhfun.
-  intros (Ax,(Ay,(Hx,(Hy,Ha)))).
-  exists Ax, Ay ; split ; [ | split].
-  exact Hx.
-  exact Hy.
+  intros AB.
+  exists (pr1 AB), (pr1 (pr2 AB)) ; split ; [ | split].
+  exact (pr1 (pr2 (pr2 AB))).
+  exact (pr1 (pr2 (pr2 (pr2 AB)))).
   intros x' y' Hx' Hy'.
-  now apply H, Ha.
+  now apply H, (pr2 (pr2 (pr2 (pr2 AB)))).
 Qed.
 
 Lemma topologydirprod_htrue :
@@ -708,23 +740,23 @@ Lemma topologydirprod_and :
 Proof.
   intros z A B.
   apply hinhfun2.
-  intros (Ax,(Ay,(Hax,(Hay,Ha)))) (Bx,(By,(Hbx,(Hby,Hb)))).
-  exists (λ x, Ax x ∧ Bx x), (λ y, Ay y ∧ By y).
+  intros A' B'.
+  exists (λ x, pr1 A' x ∧ pr1 B' x), (λ y, pr1 (pr2 A') y ∧ pr1 (pr2 B') y).
   repeat split.
-  apply (pr1 Hax).
-  apply (pr1 Hbx).
+  apply (pr1 (pr1 (pr2 (pr2 A')))).
+  apply (pr1 (pr1 (pr2 (pr2 B')))).
   apply isOpen_and.
-  apply (pr2 Hax).
-  apply (pr2 Hbx).
-  apply (pr1 Hay).
-  apply (pr1 Hby).
+  apply (pr2 (pr1 (pr2 (pr2 A')))).
+  apply (pr2 (pr1 (pr2 (pr2 B')))).
+  apply (pr1 (pr1 (pr2 (pr2 (pr2 A'))))).
+  apply (pr1 (pr1 (pr2 (pr2 (pr2 B'))))).
   apply isOpen_and.
-  apply (pr2 Hay).
-  apply (pr2 Hby).
-  apply Ha.
+  apply (pr2 (pr1 (pr2 (pr2 (pr2 A'))))).
+  apply (pr2 (pr1 (pr2 (pr2 (pr2 B'))))).
+  apply (pr2 (pr2 (pr2 (pr2 A')))).
   apply (pr1 X).
   apply (pr1 X0).
-  apply Hb.
+  apply (pr2 (pr2 (pr2 (pr2 B')))).
   apply (pr2 X).
   apply (pr2 X0).
 Qed.
@@ -732,12 +764,13 @@ Qed.
 Lemma topologydirprod_point :
   Π (x : U × V) (P : U × V → hProp), topologydirprod x P → P x.
 Proof.
-  intros (x,y) A.
+  intros xy A.
   apply hinhuniv.
-  intros (Ax,(Ay,(Hx,(Hy,Ha)))).
-  apply Ha.
-  exact (pr1 Hx).
-  exact (pr1 Hy).
+  intros A'.
+  rewrite (tppr xy).
+  apply (pr2 (pr2 (pr2 (pr2 A')))).
+  exact (pr1 (pr1 (pr2 (pr2 A')))).
+  exact (pr1 (pr1 (pr2 (pr2 (pr2 A'))))).
 Qed.
 
 Lemma topologydirprod_neighborhood :
@@ -747,28 +780,28 @@ Lemma topologydirprod_neighborhood :
       topologydirprod x Q
                       × (Π y : U × V, Q y → topologydirprod y P).
 Proof.
-  intros (x,y) P.
+  intros xy P.
   apply hinhfun.
-  intros (Ax,(Ay,(Hx,(Hy,Ha)))).
-  exists (λ z, Ax (pr1 z) ∧ Ay (pr2 z)).
+  intros A'.
+  exists (λ z, pr1 A' (pr1 z) ∧ pr1 (pr2 A') (pr2 z)).
   split.
   - apply hinhpr.
-    exists Ax, Ay.
+    exists (pr1 A'), (pr1 (pr2 A')).
     split.
-    exact Hx.
+    exact (pr1 (pr2 (pr2 A'))).
     split.
-    exact Hy.
+    exact (pr1 (pr2 (pr2 (pr2 A')))).
     intros x' y' Ax' Ay'.
     now split.
   - intros z Az.
     apply hinhpr.
-    exists Ax, Ay.
+    exists (pr1 A'), (pr1 (pr2 A')).
     repeat split.
     exact (pr1 Az).
-    exact (pr2 Hx).
+    exact (pr2 (pr1 (pr2 (pr2 A')))).
     exact (pr2 Az).
-    exact (pr2 Hy).
-    exact Ha.
+    exact (pr2 (pr1 (pr2 (pr2 (pr2 A'))))).
+    exact (pr2 (pr2 (pr2 (pr2 A')))).
 Qed.
 
 End topologydirprod.
@@ -795,36 +828,36 @@ Lemma locally2d_correct {T S : TopologicalSet} (x : T) (y : S) :
 Proof.
   intros T S x y P.
   split ; apply hinhuniv.
-  - intros (Ax,(Ay,(Hx,(Hy,Ha)))).
+  - intros A.
     apply TopologyFromNeighborhood_correct.
-    revert Hx Hy.
+    generalize (pr1 (pr2 (pr2 A))) (pr1 (pr2 (pr2 (pr2 A)))).
     apply hinhfun2.
-    intros (Ox,(Hx,Hax)) (Oy,(Hy,Hay)).
-    exists Ox,Oy.
+    intros Ox Oy.
+    exists (pr1 Ox), (pr1 Oy).
     repeat split.
-    + exact Hx.
-    + exact (pr2 Ox).
-    + exact Hy.
-    + exact (pr2 Oy).
+    + exact (pr1 (pr2 Ox)).
+    + exact (pr2 (pr1 Ox)).
+    + exact (pr1 (pr2 Oy)).
+    + exact (pr2 (pr1 Oy)).
     + intros x' y' Hx' Hy'.
-      apply Ha.
-      now apply Hax.
-      now apply Hay.
-  - intros ((O,Ho),(Oz,Hop)) ; simpl in Oz, Hop.
-    generalize (Ho _ Oz).
+      apply (pr2 (pr2 (pr2 (pr2 A)))).
+      now apply (pr2 (pr2 Ox)).
+      now apply (pr2 (pr2 Oy)).
+  - intros O.
+    generalize (pr2 (pr1 O) _ (pr1 (pr2 O))).
     apply hinhfun.
-    intros (Ax,(Ay,(Hx,(Hy,Ha)))).
-    exists Ax, Ay.
+    intros A.
+    exists (pr1 A), (pr1 (pr2 A)).
     repeat split.
     apply (pr2 (neighborhood_isOpen _)).
-    exact (pr2 Hx).
-    exact (pr1 Hx).
+    exact (pr2 (pr1 (pr2 (pr2 A)))).
+    exact (pr1 (pr1 (pr2 (pr2 A)))).
     apply (pr2 (neighborhood_isOpen _)).
-    exact (pr2 Hy).
-    exact (pr1 Hy).
+    exact (pr2 (pr1 (pr2 (pr2 (pr2 A))))).
+    exact (pr1 (pr1 (pr2 (pr2 (pr2 A))))).
     intros x' y' Ax' Ay'.
-    apply Hop.
-    now apply Ha.
+    apply (pr2 (pr2 O)).
+    now apply (pr2 (pr2 (pr2 (pr2 A)))).
 Qed.
 
 (** *** Topology on a subtype *)
@@ -843,12 +876,12 @@ Lemma topologysubtype_imply :
 Proof.
   intros x A B H.
   apply hinhfun.
-  intros (A',(Ax,Ha)).
-  exists A'.
+  intros A'.
+  exists (pr1 A').
   split.
-  exact Ax.
+  exact (pr1 (pr2 A')).
   intros y Hy.
-  now apply H, Ha.
+  now apply H, (pr2 (pr2 A')).
 Qed.
 
 Lemma topologysubtype_htrue :
@@ -866,16 +899,16 @@ Lemma topologysubtype_and :
 Proof.
   intros x A B.
   apply hinhfun2.
-  intros (A',(Ax,Ha)) (B',(Bx,Hb)).
-  exists (λ x, A' x ∧ B' x).
+  intros A' B'.
+  exists (λ x, pr1 A' x ∧ pr1 B' x).
   repeat split.
-  exact (pr1 Ax).
-  exact (pr1 Bx).
+  exact (pr1 (pr1 (pr2 A'))).
+  exact (pr1 (pr1 (pr2 B'))).
   apply isOpen_and.
-  exact (pr2 Ax).
-  exact (pr2 Bx).
-  apply Ha, (pr1 X).
-  apply Hb, (pr2 X).
+  exact (pr2 (pr1 (pr2 A'))).
+  exact (pr2 (pr1 (pr2 B'))).
+  apply (pr2 (pr2 A')), (pr1 X).
+  apply (pr2 (pr2 B')), (pr2 X).
 Qed.
 
 Lemma topologysubtype_point :
@@ -884,8 +917,8 @@ Lemma topologysubtype_point :
 Proof.
   intros x A.
   apply hinhuniv.
-  intros (B,(Bx,Hb)).
-  apply Hb, (pr1 Bx).
+  intros B.
+  apply (pr2 (pr2 B)), (pr1 (pr1 (pr2 B))).
 Qed.
 
 Lemma topologysubtype_neighborhood :
@@ -897,18 +930,21 @@ Lemma topologysubtype_neighborhood :
 Proof.
   intros x A.
   apply hinhfun.
-  intros (B,(Bx,Hb)).
-  exists (λ y : Σ x : T, dom x, B (pr1 y)).
+  intros B.
+  exists (λ y : Σ x : T, dom x, pr1 B (pr1 y)).
   split.
-  apply hinhpr.
-  now exists B.
-  intros y By.
-  apply hinhpr.
-  exists B.
-  repeat split.
-  exact By.
-  exact (pr2 Bx).
-  exact Hb.
+  - apply hinhpr.
+    exists (pr1 B).
+    split.
+    exact (pr1 (pr2 B)).
+    easy.
+  - intros y By.
+    apply hinhpr.
+    exists (pr1 B).
+    repeat split.
+    exact By.
+    exact (pr2 (pr1 (pr2 B))).
+    exact (pr2 (pr2 B)).
 Qed.
 
 End topologysubtype.
@@ -993,7 +1029,7 @@ Definition ex_filter_lim_base  {T : TopologicalSet} (F : Filter T) :=
 Lemma is_filter_lim_base_correct {T : TopologicalSet} (F : Filter T) (x : T) base :
   is_filter_lim_base F x base <-> is_filter_lim F x.
 Proof.
-  intros.
+  intros T F x base.
   split.
   - intros Hx P HP.
     apply (pr2 (neighborhood_equiv _ base _)) in HP.
@@ -1007,17 +1043,18 @@ Qed.
 Lemma ex_filter_lim_base_correct {T : TopologicalSet} (F : Filter T) :
   ex_filter_lim_base F <-> ex_filter_lim F.
 Proof.
-  intros.
+  intros T F.
   split.
   - apply hinhfun.
-    intros (x,(base,Hx)).
-    exists x.
+    intros x.
+    exists (pr1 x).
     eapply is_filter_lim_base_correct.
-    exact Hx.
+    exact (pr2 (pr2 x)).
   - apply hinhfun.
-    intros (x,Hx).
-    exists x, (base_of_neighborhood_default x).
-    now apply (pr2 (is_filter_lim_base_correct _ _ _)).
+    intros x.
+    exists (pr1 x), (base_of_neighborhood_default (pr1 x)).
+    apply (pr2 (is_filter_lim_base_correct _ _ _)).
+    exact (pr2 x).
 Qed.
 
 (** *** Limit of a function *)
@@ -1035,7 +1072,7 @@ Definition ex_lim_base {X : UU} {T : TopologicalSet} (f : X → T) (F : Filter X
 Lemma is_lim_base_correct {X : UU} {T : TopologicalSet} (f : X → T) (F : Filter X) (x : T) base :
   is_lim_base f F x base <-> is_lim f F x.
 Proof.
-  intros.
+  intros X T f F x base.
   split.
   - intros Hx P HP.
     apply Hx, (pr2 (neighborhood_equiv _ _ _)).
@@ -1047,17 +1084,18 @@ Qed.
 Lemma ex_lim_base_correct {X : UU} {T : TopologicalSet} (f : X → T) (F : Filter X) :
   ex_lim_base f F <-> ex_lim f F.
 Proof.
-  intros.
+  intros X T f F.
   split.
   - apply hinhfun.
-    intros (x,(base,Hx)).
-    exists x.
+    intros x.
+    exists (pr1 x).
     eapply is_lim_base_correct.
-    exact Hx.
+    exact (pr2 (pr2 x)).
   - apply hinhfun.
-    intros (x,Hx).
-    exists x, (base_of_neighborhood_default x).
-    now apply (pr2 (is_lim_base_correct _ _ _ _)).
+    intros x.
+    exists (pr1 x), (base_of_neighborhood_default (pr1 x)).
+    apply (pr2 (is_lim_base_correct _ _ _ _)).
+    exact (pr2 x).
 Qed.
 
 (** *** Continuity *)
@@ -1087,6 +1125,105 @@ Definition continuous2d_base_at {U V W : TopologicalSet} (f : U → V → W)
   is_lim_base (λ z : U × V, f (pr1 z) (pr2 z))
               (FilterDirprod (locally_base x base_x) (locally_base y base_y))
               (f x y) base_fxy.
+
+(** *** Continuity of basic functions *)
+
+Lemma continuous_comp {X : UU} {U V : TopologicalSet} (f : X → U) (g : U → V) (F : Filter X) (l : U) :
+  is_lim f F l → continuous_at g l →
+  is_lim (funcomp f g) F (g l).
+Proof.
+  intros X U V f g F l.
+  apply filterlim_comp.
+Qed.
+Lemma continuous2d_comp {X : UU} {U V W : TopologicalSet} (f : X → U) (g : X → V) (h : U → V → W) (F : Filter X) (lf : U) (lg : V) :
+  is_lim f F lf → is_lim g F lg → continuous2d_at h lf lg →
+  is_lim (λ x, h (f x) (g x)) F (h lf lg).
+Proof.
+  intros X U V W f g h F lf lg Hf Hg.
+  apply (filterlim_comp (λ x, (f x ,, g x))).
+  intros P.
+  apply hinhuniv.
+  intros Hp.
+  generalize (filter_and F _ _ (Hf _ (pr1 (pr2 (pr2 Hp)))) (Hg _ (pr1 (pr2 (pr2 (pr2 Hp)))))).
+  apply (filter_imply F).
+  intros x Hx.
+  apply (pr2 (pr2 (pr2 (pr2 Hp)))).
+  exact (pr1 Hx).
+  exact (pr2 Hx).
+Qed.
+
+Lemma continuous_tpair {U V : TopologicalSet} :
+  continuous2d (W := TopologyDirprod U V) (λ (x : U) (y : V), (x,,y)).
+Proof.
+  intros U V x y P.
+  apply hinhuniv.
+  intros O.
+  simple refine (filter_imply _ _ _ _ _).
+  - exact (pr1 O).
+  - exact (pr2 (pr2 O)).
+  - generalize (pr2 (pr1 O) _ (pr1 (pr2 O))).
+    apply hinhfun.
+    intros Ho.
+    exists (pr1 Ho), (pr1 (pr2 Ho)).
+    repeat split.
+    + apply (pr2 (neighborhood_isOpen _)).
+      exact (pr2 (pr1 (pr2 (pr2 Ho)))).
+      exact (pr1 (pr1 (pr2 (pr2 Ho)))).
+    + apply (pr2 (neighborhood_isOpen _)).
+      exact (pr2 (pr1 (pr2 (pr2 (pr2 Ho))))).
+      exact (pr1 (pr1 (pr2 (pr2 (pr2 Ho))))).
+    + exact (pr2 (pr2 (pr2 (pr2 Ho)))).
+Qed.
+Lemma continuous_pr1 {U V : TopologicalSet} :
+  continuous (U := TopologyDirprod U V) (λ (xy : U × V), pr1 xy).
+Proof.
+  intros U V xy P.
+  apply hinhuniv.
+  intros O.
+  simple refine (filter_imply _ _ _ _ _).
+  - exact (pr1 (pr1 O)).
+  - exact (pr2 (pr2 O)).
+  - apply hinhpr.
+    mkpair.
+    mkpair.
+    + apply (λ xy : U × V, pr1 O (pr1 xy)).
+    + intros xy' Oxy.
+      apply hinhpr.
+      exists (pr1 O), (λ _, htrue).
+      repeat split.
+      exact Oxy.
+      exact (pr2 (pr1 O)).
+      exact isOpen_htrue.
+      easy.
+    + repeat split.
+      * exact (pr1 (pr2 O)).
+      * easy.
+Qed.
+Lemma continuous_pr2 {U V : TopologicalSet} :
+  continuous (U := TopologyDirprod U V) (λ (xy : U × V), pr2 xy).
+Proof.
+  intros U V xy P.
+  apply hinhuniv.
+  intros O.
+  simple refine (filter_imply _ _ _ _ _).
+  - exact (pr1 (pr1 O)).
+  - exact (pr2 (pr2 O)).
+  - apply hinhpr.
+    mkpair.
+    mkpair.
+    + apply (λ xy : U × V, pr1 O (pr2 xy)).
+    + intros xy' Oxy.
+      apply hinhpr.
+      exists (λ _, htrue), (pr1 O).
+      repeat split.
+      exact isOpen_htrue.
+      exact Oxy.
+      exact (pr2 (pr1 O)).
+      easy.
+    + repeat split.
+      * exact (pr1 (pr2 O)).
+      * easy.
+Qed.
 
 (** ** Topology in algebraic structures *)
 


### PR DESCRIPTION
- new definition of Dcuts_minus which need less the truncated subtraction of non-negative rationals
- definition of Dcuts_min
- add co-transitivity to StrongOrder
- remove "destruct" in various files

I didn't yet find an easy solution to remove the two match in NonnegativeRationals