### PR TITLE
Some special limits and colimits

### DIFF
--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -63,6 +63,11 @@ limits/coequalizers.v
 limits/kernels.v
 limits/cokernels.v
 limits/pushouts.v
+limits/graphs/pushouts.v
+limits/graphs/equalizers.v
+limits/graphs/coequalizers.v
+limits/graphs/kernels.v
+limits/graphs/cokernels.v
 PrecategoriesWithBinOps.v
 PrecategoriesWithAbgrops.v
 PreAdditive.v

--- a/UniMath/CategoryTheory/limits/graphs/README.md
+++ b/UniMath/CategoryTheory/limits/graphs/README.md
@@ -21,4 +21,9 @@ This directory contains a development of limits on the basis of descriptions of 
 * *binproducts.v* --- formalization as instance of limit
 * *bincoproducts.v* --- formalization as instance of colimit
 * *pullbacks.v* --- formalization as instance of limit
+* *pushouts.v* --- formalization as instance of colimit
+* *equalizers.v* --- formalization as instance of limit
+* *coequalizers.v* --- formalization as instance of colimit
+* *kernels.v* --- formalization as instance of limit
+* *cokernels.v* --- formalization as instance of colimit
 * *zero.v* --- formalization within the approach of this directory

--- a/UniMath/CategoryTheory/limits/graphs/coequalizers.v
+++ b/UniMath/CategoryTheory/limits/graphs/coequalizers.v
@@ -1,0 +1,360 @@
+(** * Coequalizers defined in terms of colimits *)
+(** ** Contents
+- Definition of coequalizers
+- Coincides with the direct definition
+*)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.limits.graphs.limits.
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.limits.coequalizers.
+
+
+(** * Definition of coequalizers in terms of colimits *)
+Section def_coequalizers.
+
+  Variable C : precategory.
+  Variable hs: has_homsets C.
+
+  Inductive two := One | Two .
+
+  Definition Coequalizer_graph : graph.
+  Proof.
+    exists two.
+    exact (fun a b =>
+             match (a, b) with
+             | (One, Two) => unit ⨿ unit
+             | _ => empty
+             end).
+  Defined.
+
+  Definition Coequalizer_diagram {a b : C} (f g : C⟦a, b⟧) :
+    diagram Coequalizer_graph C.
+  Proof.
+    unfold diagram. cbn.
+    use (tpair _ (fun x => match x with
+                        | One => a
+                        | Two => b end) _).
+    intros x y e.
+    induction x; induction y; try induction e.
+    exact f. exact g.
+  Defined.
+
+  Definition Coequalizer_cocone {a b : C} (f g : C⟦a, b⟧)
+             (d : C) (h : C⟦b, d⟧) (H : f ;; h = g ;; h) :
+    cocone (Coequalizer_diagram f g) d.
+  Proof.
+    use mk_cocone.
+    intros v. induction v.
+    exact (f ;; h). exact h.
+
+    intros u v e.
+    induction u; induction v; try induction e.
+    apply idpath. exact (!H).
+  Defined.
+
+  Definition isCoequalizer {a b : C} (f g : C⟦a, b⟧)
+             (d : C) (h : C⟦b, d⟧) (H : f ;; h = g ;; h) : UU
+    := isColimCocone (Coequalizer_diagram f g) d
+                     (Coequalizer_cocone f g d h H).
+
+  Definition mk_isCoequalizer {a b : C} (f g : C⟦a, b⟧)
+             (d : C) (h : C⟦b, d⟧) (H : f ;; h = g ;; h) :
+    (Π e (h' : C⟦b, e⟧) (H' : f ;; h' = g ;; h'),
+   iscontr (total2 (fun hk : C⟦d, e⟧ => h ;; hk = h')))
+  -> isCoequalizer f g d h H.
+  Proof.
+    intros H' x cx.
+
+    assert (H1 : f ;; coconeIn cx Two = g ;; coconeIn cx Two).
+    {
+      use (pathscomp0 (coconeInCommutes cx One Two (ii1 tt))).
+      use (pathscomp0 _ (!(coconeInCommutes cx One Two (ii2 tt)))).
+      apply idpath.
+    }
+    set (H2 := (H' x (coconeIn cx Two) H1)).
+    use tpair.
+    use (tpair _ (pr1 (pr1 H2)) _).
+    intros v. induction v. cbn.
+    use (pathscomp0 _ (coconeInCommutes cx One Two (ii1 tt))). cbn.
+    rewrite <- assoc. apply cancel_precomposition.
+    apply (pr2 (pr1 H2)).
+
+    apply (pr2 (pr1 H2)).
+
+    intro t. apply subtypeEquality.
+    intros y. apply impred. intros t0. apply hs.
+
+    (* Use uniqueness of H2 *)
+    induction t. cbn.
+    apply path_to_ctr.
+    apply (p Two).
+  Defined.
+
+  Definition Coequalizer {a b : C} (f g : C⟦a, b⟧) :=
+    ColimCocone (Coequalizer_diagram f g).
+
+  Definition mk_Coequalizer {a b : C} (f g : C⟦a, b⟧)
+             (d : C) (h : C⟦b, d⟧) (H : f ;; h = g ;; h)
+             (isCEq : isCoequalizer f g d h H) :
+    Coequalizer f g.
+  Proof.
+    use tpair.
+    use tpair.
+    exact d.
+    use Coequalizer_cocone.
+    exact h.
+    exact H.
+    exact isCEq.
+  Defined.
+
+  Definition Coequalizers : UU
+    := Π (a b : C) (f g : C⟦a, b⟧), Coequalizer f g.
+
+  Definition hasCoequalizers : UU
+    := Π (a b : C) (f g : C⟦a, b⟧), ishinh (Coequalizer f g).
+
+  Definition CoequalizerObject {a b : C} {f g : C⟦a, b⟧} :
+    Coequalizer f g -> C := fun H => colim H.
+
+  Definition CoequalizerArrow {a b : C} {f g : C⟦a, b⟧}
+             (E : Coequalizer f g) : C⟦b, colim E⟧ := colimIn E Two.
+
+  Definition CoequalizerArrowEq {a b : C} {f g : C⟦a, b⟧}
+             (E : Coequalizer f g) :
+    f ;; CoequalizerArrow E = g ;; CoequalizerArrow E.
+  Proof.
+    use (pathscomp0 (colimInCommutes E One Two (ii1 tt))).
+    use (pathscomp0 _ (!(colimInCommutes E One Two (ii2 tt)))).
+    apply idpath.
+  Qed.
+
+  Definition CoequalizerOut {a b : C} {f g : C⟦a, b⟧}
+             (E : Coequalizer f g) e (h : C⟦b, e⟧)
+             (H : f ;; h = g ;; h) :
+    C⟦colim E, e⟧.
+  Proof.
+    use colimArrow.
+    use mk_cocone.
+    intros v. induction v.
+
+    exact (f ;; h). exact h.
+    intros u v e'.
+    induction u; induction v; try induction e'.
+    apply idpath. apply (!H).
+  Defined.
+
+  Lemma CoequalizerArrowComm {a b : C} {f g : C⟦a, b⟧}
+        (E : Coequalizer f g) e (h : C⟦b, e⟧)
+        (H : f ;; h = g ;; h) :
+    CoequalizerArrow E ;; CoequalizerOut E e h H = h.
+  Proof.
+    refine (colimArrowCommutes E e _ Two).
+  Qed.
+
+  Lemma CoequalizerOutUnique {a b : C} {f g : C⟦a, b⟧}
+        (E : Coequalizer f g) e (h : C⟦b, e⟧)
+        (H : f ;; h = g ;; h)
+        (w : C⟦colim E, e⟧)
+        (H' : CoequalizerArrow E ;; w = h) :
+    w = CoequalizerOut E e h H.
+  Proof.
+    apply path_to_ctr.
+    intros v. induction v; cbn; try assumption.
+    set (X := colimInCommutes E One Two (ii1 tt)).
+    apply (maponpaths (fun h : _ => h ;; w)) in X.
+    use (pathscomp0 (!X)). cbn. rewrite <- assoc.
+    apply cancel_precomposition.
+    apply H'.
+  Qed.
+
+  Definition isCoequalizer_Coequalizer {a b : C} {f g : C⟦a, b⟧}
+             (E : Coequalizer f g) :
+    isCoequalizer f g (CoequalizerObject E) (CoequalizerArrow E)
+                  (CoequalizerArrowEq E).
+  Proof.
+    apply mk_isCoequalizer.
+    intros e h H.
+    use unique_exists.
+    exact (CoequalizerOut E e h H).
+    exact (CoequalizerArrowComm E e h H).
+
+    intros y. apply hs.
+
+    intros y t. cbn in t.
+    use CoequalizerOutUnique.
+    exact t.
+  Qed.
+
+  (** ** Coequalizers to coequalizers *)
+
+  Definition identity_is_Coequalizer_input {a b : C} {f g : C⟦a, b⟧}
+             (E : Coequalizer f g) :
+    total2 (fun hk : C⟦colim E, colim E⟧ => CoequalizerArrow E ;; hk
+                                         = CoequalizerArrow E).
+  Proof.
+    use tpair.
+    exact (identity _).
+    apply id_right.
+  Defined.
+
+  Lemma CoequalizerEndo_is_identity  {a b : C} {f g : C⟦a, b⟧}
+        (E : Coequalizer f g) (k : C⟦colim E, colim E⟧)
+        (kH :CoequalizerArrow E ;; k = CoequalizerArrow E) :
+    identity (colim E) = k.
+  Proof.
+    apply colim_endo_is_identity.
+    unfold colimIn.
+    intros u. induction u.
+    rewrite <- (coconeInCommutes (colimCocone E) One Two (ii1 tt)).
+    rewrite <- assoc. cbn. apply cancel_precomposition.
+    apply kH.
+    apply kH.
+  Qed.
+
+  Definition from_Coequalizer_to_Coequalizer {a b : C} {f g : C⟦a, b⟧}
+             (E1 E2 : Coequalizer f g) : C⟦colim E1, colim E2⟧.
+  Proof.
+    apply (CoequalizerOut E1 (colim E2) (CoequalizerArrow E2)).
+    exact (CoequalizerArrowEq E2).
+  Defined.
+
+  Lemma are_inverses_from_Coequalizer_to_Coequalizer {a b : C} {f g : C⟦a, b⟧}
+        (E1 E2 : Coequalizer f g) :
+    is_inverse_in_precat (from_Coequalizer_to_Coequalizer E2 E1)
+      (from_Coequalizer_to_Coequalizer E1 E2).
+  Proof.
+    split; apply pathsinv0.
+    apply CoequalizerEndo_is_identity.
+    rewrite assoc.
+    unfold from_Coequalizer_to_Coequalizer.
+    repeat rewrite CoequalizerArrowComm.
+    apply idpath.
+
+    apply CoequalizerEndo_is_identity.
+    rewrite assoc.
+    unfold from_Coequalizer_to_Coequalizer.
+    repeat rewrite CoequalizerArrowComm.
+    apply idpath.
+  Qed.
+
+  Lemma isiso_from_Coequalizer_to_Coequalizer {a b : C} {f g : C⟦a, b⟧}
+        (E1 E2 : Coequalizer f g) :
+    is_isomorphism (from_Coequalizer_to_Coequalizer E1 E2).
+  Proof.
+    apply (is_iso_qinv _ (from_Coequalizer_to_Coequalizer E2 E1)).
+    apply are_inverses_from_Coequalizer_to_Coequalizer.
+  Qed.
+
+  Definition iso_from_Coequalizer_to_Coequalizer {a b : C} {f g : C⟦a, b⟧}
+             (E1 E2 : Coequalizer f g) : iso (colim E1) (colim E2)
+    := tpair _ _ (isiso_from_Coequalizer_to_Coequalizer E1 E2).
+
+  Lemma inv_from_iso_iso_from_Pullback {a b : C} {f g : C⟦a , b⟧}
+        (E1 E2 : Coequalizer f g):
+    inv_from_iso (iso_from_Coequalizer_to_Coequalizer E1 E2)
+    = from_Coequalizer_to_Coequalizer E2 E1.
+  Proof.
+    apply pathsinv0.
+    apply inv_iso_unique'.
+    apply (pr1 (are_inverses_from_Coequalizer_to_Coequalizer E2 E1)).
+  Qed.
+
+
+  (** ** Connections to other colimits *)
+
+  Lemma Coequalizers_from_Colims :
+    Colims C -> Coequalizers.
+  Proof.
+    intros H a b f g. apply H.
+  Defined.
+
+End def_coequalizers.
+
+
+(** * Definitions coincide
+  In this section we show that the definition of coequalizer as a colimit
+  coincides with the direct definition. *)
+Section coequalizers_coincide.
+
+  Variable C : precategory.
+  Variable hs: has_homsets C.
+
+
+  (** ** isCoequalizers *)
+
+  Lemma equiv_isCoequalizer1 {a b : C} {f g : C⟦a, b⟧}
+        e (h : C⟦b, e⟧) (H : f ;; h = g ;; h) :
+    limits.coequalizers.isCoequalizer f g h H -> isCoequalizer C f g e h H.
+  Proof.
+    intros X.
+    set (E := limits.coequalizers.mk_Coequalizer f g h H X).
+    use mk_isCoequalizer.
+    exact hs.
+    intros e' h' H'.
+    use unique_exists.
+
+    exact (limits.coequalizers.CoequalizerOut E e' h' H').
+    exact (limits.coequalizers.CoequalizerCommutes E e' h' H').
+    intros y. apply hs.
+    intros y T. cbn in T.
+    use (limits.coequalizers.CoequalizerOutsEq E).
+    use (pathscomp0 T).
+    exact (!(limits.coequalizers.CoequalizerCommutes E e' h' H')).
+  Qed.
+
+  Lemma equiv_isCoequalizer2 {a b : C} (f g : C⟦a, b⟧)
+        e (h : C⟦b, e⟧) (H : f ;; h = g ;; h) :
+    limits.coequalizers.isCoequalizer f g h H <- isCoequalizer C f g e h H.
+  Proof.
+    intros X.
+    set (E := mk_Coequalizer C f g e h H X).
+    intros e' h' H'.
+    use unique_exists.
+
+    exact (CoequalizerOut C E e' h' H').
+    exact (CoequalizerArrowComm C E e' h' H').
+    intros y. apply hs.
+    intros y T. cbn in T.
+    use (CoequalizerOutUnique C E).
+    exact T.
+  Qed.
+
+  (** ** Coequalizers *)
+
+  Definition equiv_Coequalizer1 {a b : C} (f g : C⟦a, b⟧) :
+    limits.coequalizers.Coequalizer f g -> Coequalizer C f g.
+  Proof.
+    intros E.
+    exact (mk_Coequalizer
+             C f g
+             _
+             _
+             _
+             (equiv_isCoequalizer1
+                (limits.coequalizers.CoequalizerObject E)
+                (limits.coequalizers.CoequalizerArrow E)
+                (limits.coequalizers.CoequalizerEqAr E)
+                (limits.coequalizers.isCoequalizer_Coequalizer E))).
+  Defined.
+
+  Definition equiv_Coequalizer2 {a b : C} (f g : C⟦a, b⟧) :
+    limits.coequalizers.Coequalizer f g <- Coequalizer C f g.
+  Proof.
+    intros E.
+    exact (@limits.coequalizers.mk_Coequalizer
+             C a b (CoequalizerObject C E) f g
+             (CoequalizerArrow C E)
+             (CoequalizerArrowEq C E)
+             (@equiv_isCoequalizer2
+                a b f g (CoequalizerObject C E)
+                (CoequalizerArrow C E)
+                (CoequalizerArrowEq C E)
+                (isCoequalizer_Coequalizer C hs E))).
+  Defined.
+
+End coequalizers_coincide.

--- a/UniMath/CategoryTheory/limits/graphs/cokernels.v
+++ b/UniMath/CategoryTheory/limits/graphs/cokernels.v
@@ -49,18 +49,25 @@ Section def_cokernels.
     use limits.coequalizers.mk_isCoequalizer.
     intros w h H.
     use unique_exists.
-    use limits.cokernels.CokernelOut.
-    exact h. rewrite postcomp_with_ZeroArrow in H.
-    use (pathscomp0 _ (!(equiv_ZeroArrow a w Z))).
-    exact H.
 
-    cbn.
-    use limits.cokernels.CokernelCommutes.
-    intros y. apply hs.
-    intros y T. cbn in T.
-    use limits.cokernels.CokernelOutsEq. unfold CokernelArrow.
-    use (pathscomp0 T). apply pathsinv0.
-    use limits.cokernels.CokernelCommutes.
+    (* Construction of the morphism *)
+    - use limits.cokernels.CokernelOut.
+      + exact h.
+      + rewrite postcomp_with_ZeroArrow in H.
+        use (pathscomp0 _ (!(equiv_ZeroArrow a w Z))).
+        exact H.
+
+    (* Commutativity *)
+    - use limits.cokernels.CokernelCommutes.
+
+    (* Equality on equalities of morphisms *)
+    - intros y. apply hs.
+
+    (* Uniqueness *)
+    - intros y T. cbn in T.
+      use limits.cokernels.CokernelOutsEq. unfold CokernelArrow.
+      use (pathscomp0 T). apply pathsinv0.
+      use limits.cokernels.CokernelCommutes.
   Qed.
 
   Definition equiv_Cokernel1 {a b : C} (f : C⟦a, b⟧) :
@@ -99,17 +106,24 @@ Section def_cokernels.
     use mk_isCoequalizer. apply hs.
     intros w h H.
     use unique_exists.
-    use CoequalizerOut.
-    exact h. rewrite postcomp_with_ZeroArrow.
-    rewrite limits.zero.ZeroArrow_comp_left in H.
-    use (pathscomp0 H).
-    apply (equiv_ZeroArrow a w Z).
 
-    cbn.
-    use CoequalizerArrowComm.
-    intros y. apply hs.
-    intros y T. cbn in T.
-    use CoequalizerOutUnique. exact T.
+    (* Construction of the morphism *)
+    - use CoequalizerOut.
+      + exact h.
+      + rewrite postcomp_with_ZeroArrow.
+        rewrite limits.zero.ZeroArrow_comp_left in H.
+        use (pathscomp0 H).
+        apply (equiv_ZeroArrow a w Z).
+
+    (* Commutativity *)
+    - use CoequalizerArrowComm.
+
+    (* Equality on equalities of morphisms *)
+    - intros y. apply hs.
+
+    (* Uniqueness *)
+    - intros y T. cbn in T.
+      use CoequalizerOutUnique. exact T.
   Qed.
 
   Definition equiv_Cokernel2 {a b : C} (f : C⟦a, b⟧) :

--- a/UniMath/CategoryTheory/limits/graphs/cokernels.v
+++ b/UniMath/CategoryTheory/limits/graphs/cokernels.v
@@ -1,0 +1,128 @@
+(** * Cokernels defined in terms of colimits. *)
+(** ** Contents
+- Definition coincides with direct definition
+*)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.precategories.
+
+Require Import UniMath.CategoryTheory.limits.graphs.limits.
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.limits.graphs.zero.
+Require Import UniMath.CategoryTheory.limits.graphs.coequalizers.
+Require Import UniMath.CategoryTheory.limits.cokernels.
+
+
+(** * Definition of cokernels in terms of colimits *)
+Section def_cokernels.
+
+  Variable C : precategory.
+  Variable hs: has_homsets C.
+  Variable Z : Zero C.
+
+  Definition Cokernel {a b : C} (f : C⟦a, b⟧)
+    := Coequalizer C f (ZeroArrow Z a b).
+
+  (** ** Coincides with the direct definiton *)
+  Lemma equiv_Cokernel1_eq {a b : C} (f : C⟦a, b⟧)
+        (K : limits.cokernels.Cokernel (equiv_Zero2 Z) f) :
+    f ;; limits.coequalizers.CoequalizerArrow K
+    = ZeroArrow Z a b ;; limits.coequalizers.CoequalizerArrow K.
+  Proof.
+    set (tmp := limits.coequalizers.CoequalizerEqAr K).
+    set (tmp1 := equiv_ZeroArrow a b Z).
+    apply (maponpaths (fun h : _ => h ;; limits.coequalizers.CoequalizerArrow K))
+      in tmp1.
+    set (tmp2 := pathscomp0 tmp tmp1).
+    apply tmp2.
+  Qed.
+
+  Lemma equiv_Cokernel1_isCoequalizer {a b : C} (f : C⟦a, b⟧)
+        (K : limits.cokernels.Cokernel (equiv_Zero2 Z) f) :
+    limits.coequalizers.isCoequalizer
+      f (ZeroArrow Z a b) (limits.coequalizers.CoequalizerArrow K)
+      (equiv_Cokernel1_eq f K).
+  Proof.
+    use limits.coequalizers.mk_isCoequalizer.
+    intros w h H.
+    use unique_exists.
+    use limits.cokernels.CokernelOut.
+    exact h. rewrite postcomp_with_ZeroArrow in H.
+    use (pathscomp0 _ (!(equiv_ZeroArrow a w Z))).
+    exact H.
+
+    cbn.
+    use limits.cokernels.CokernelCommutes.
+    intros y. apply hs.
+    intros y T. cbn in T.
+    use limits.cokernels.CokernelOutsEq. unfold CokernelArrow.
+    use (pathscomp0 T). apply pathsinv0.
+    use limits.cokernels.CokernelCommutes.
+  Qed.
+
+  Definition equiv_Cokernel1 {a b : C} (f : C⟦a, b⟧) :
+    limits.cokernels.Cokernel (equiv_Zero2 Z) f -> Cokernel f.
+  Proof.
+    intros K.
+    exact (equiv_Coequalizer1
+           C hs f _
+           (@limits.coequalizers.mk_Coequalizer
+              C a b K f _
+              (limits.coequalizers.CoequalizerArrow K)
+              (equiv_Cokernel1_eq f K)
+              (equiv_Cokernel1_isCoequalizer f K))).
+  Defined.
+
+  (* Other direction *)
+
+  Lemma equiv_Cokernel2_eq {a b : C} (f : C⟦a, b⟧) (K : Cokernel f ) :
+    f ;; CoequalizerArrow C K
+    = limits.zero.ZeroArrow C (equiv_Zero2 Z) a b ;; CoequalizerArrow C K.
+  Proof.
+    set (tmp := CoequalizerArrowEq C K).
+    set (tmp1 := equiv_ZeroArrow a b Z).
+    apply pathsinv0 in tmp1.
+    apply (maponpaths (fun h : _ => h ;; CoequalizerArrow C K)) in tmp1.
+    set (tmp2 := pathscomp0 tmp tmp1).
+    apply tmp2.
+  Qed.
+
+  Lemma equiv_Cokernel2_isCoequalizer {a b : C} (f : C⟦a, b⟧)
+        (K : Cokernel f ) :
+    isCoequalizer C f (limits.zero.ZeroArrow C (equiv_Zero2 Z) a b)
+                  (CoequalizerObject C K)
+                  (CoequalizerArrow C K) (equiv_Cokernel2_eq f K).
+  Proof.
+    use mk_isCoequalizer. apply hs.
+    intros w h H.
+    use unique_exists.
+    use CoequalizerOut.
+    exact h. rewrite postcomp_with_ZeroArrow.
+    rewrite limits.zero.ZeroArrow_comp_left in H.
+    use (pathscomp0 H).
+    apply (equiv_ZeroArrow a w Z).
+
+    cbn.
+    use CoequalizerArrowComm.
+    intros y. apply hs.
+    intros y T. cbn in T.
+    use CoequalizerOutUnique. exact T.
+  Qed.
+
+  Definition equiv_Cokernel2 {a b : C} (f : C⟦a, b⟧) :
+    limits.cokernels.Cokernel (equiv_Zero2 Z) f <- Cokernel f.
+  Proof.
+    intros K.
+    exact (equiv_Coequalizer2
+           C hs f _
+           (@mk_Coequalizer
+              C a b f _ (CoequalizerObject C K)
+              (CoequalizerArrow C K)
+              (equiv_Cokernel2_eq f K)
+              (equiv_Cokernel2_isCoequalizer f K))).
+  Defined.
+
+End def_cokernels.

--- a/UniMath/CategoryTheory/limits/graphs/equalizers.v
+++ b/UniMath/CategoryTheory/limits/graphs/equalizers.v
@@ -1,0 +1,359 @@
+(** * Equalizers defined in terms of limits *)
+(** ** Contents
+- Definition of equalizers
+- Coincides with the direct definition
+*)
+
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.precategories.
+
+Require Import UniMath.CategoryTheory.limits.graphs.limits.
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.limits.equalizers.
+
+
+(** * Definition of equalizers in terms of limits *)
+Section def_equalizers.
+
+  Variable C : precategory.
+  Variable hs: has_homsets C.
+
+  Inductive two := One | Two .
+
+  Definition Equalizer_graph : graph.
+  Proof.
+    exists two.
+    exact (fun a b =>
+             match (a, b) with
+             | (One, Two) => unit ⨿ unit
+             | _ => empty
+             end).
+  Defined.
+
+  Definition Equalizer_diagram {a b : C} (f g : C⟦a, b⟧) :
+    diagram Equalizer_graph C.
+  Proof.
+    unfold diagram. cbn.
+    use (tpair _ (fun x => match x with
+                        | One => a
+                        | Two => b end) _).
+    intros x y e.
+    induction x; induction y; try induction e.
+    exact f. exact g.
+  Defined.
+
+  Definition Equalizer_cone {a b : C} (f g : C⟦a, b⟧)
+             (d : C) (h : C⟦d, a⟧) (H : h ;; f = h ;; g) :
+    cone (Equalizer_diagram f g) d.
+  Proof.
+    use mk_cone.
+    intros v. induction v.
+    exact h. exact (h ;; f).
+
+    intros u v e.
+    induction u; induction v; try induction e.
+    apply idpath. exact (!H).
+  Defined.
+
+  Definition isEqualizer {a b : C} (f g : C⟦a, b⟧)
+             (d : C) (h : C⟦d, a⟧) (H : h ;; f = h ;; g) : UU
+    := isLimCone (Equalizer_diagram f g) d (Equalizer_cone f g d h H).
+
+  Definition mk_isEqualizer {a b : C} (f g : C⟦a, b⟧)
+             (d : C) (h : C⟦d, a⟧) (H : h ;; f = h ;; g) :
+  (Π e (h' : C⟦e, a⟧) (H' : h' ;; f = h' ;; g),
+   iscontr (total2 (fun hk : C⟦e, d⟧ => hk ;; h = h')))
+  -> isEqualizer f g d h H.
+  Proof.
+    intros H' x cx.
+
+    assert (H1 : coneOut cx One ;; f = coneOut cx One ;; g).
+    {
+      use (pathscomp0 (coneOutCommutes cx One Two (ii1 tt))).
+      use (pathscomp0 _ (!(coneOutCommutes cx One Two (ii2 tt)))).
+      apply idpath.
+    }
+    set (H2 := (H' x (coneOut cx One) H1)).
+    use tpair.
+    use (tpair _ (pr1 (pr1 H2)) _).
+    intros v. induction v.
+    apply (pr2 (pr1 H2)).
+
+    use (pathscomp0 _ (coneOutCommutes cx One Two (ii1 tt))).
+    cbn. rewrite assoc. apply cancel_postcomposition.
+    apply (pr2 (pr1 H2)).
+
+    intro t. apply subtypeEquality.
+    intros y. apply impred. intros t0. apply hs.
+
+    (* Use uniqueness of H2 *)
+    induction t. cbn.
+    apply path_to_ctr.
+    apply (p One).
+  Defined.
+
+  Definition Equalizer {a b : C} (f g : C⟦a, b⟧) :=
+    LimCone (Equalizer_diagram f g).
+
+  Definition mk_Equalizer {a b : C} (f g : C⟦a, b⟧)
+             (d : C) (h : C⟦d, a⟧) (H : h ;; f = h ;; g)
+             (isEq : isEqualizer f g d h H) :
+    Equalizer f g.
+  Proof.
+    use tpair.
+    use tpair.
+    exact d.
+    use Equalizer_cone.
+    exact h.
+    exact H.
+    exact isEq.
+  Defined.
+
+  Definition Equalizers : UU
+    := Π (a b : C) (f g : C⟦a, b⟧), Equalizer f g.
+
+  Definition hasEqualizers : UU
+    := Π (a b : C) (f g : C⟦a, b⟧), ishinh (Equalizer f g).
+
+  Definition EqualizerObject {a b : C} {f g : C⟦a, b⟧} :
+    Equalizer f g -> C := fun H => lim H.
+
+  Definition EqualizerArrow {a b : C} {f g : C⟦a, b⟧}
+             (E : Equalizer f g) : C⟦lim E, a⟧ := limOut E One.
+
+  Definition EqualizerArrowEq {a b : C} {f g : C⟦a, b⟧}
+             (E : Equalizer f g) :
+    EqualizerArrow E ;; f = EqualizerArrow E ;; g.
+  Proof.
+    use (pathscomp0 (limOutCommutes E One Two (ii1 tt))).
+    use (pathscomp0 _ (!(limOutCommutes E One Two (ii2 tt)))).
+    apply idpath.
+  Qed.
+
+  Definition EqualizerIn {a b : C} {f g : C⟦a, b⟧}
+             (E : Equalizer f g) e (h : C⟦e, a⟧)
+             (H : h ;; f = h ;; g) :
+    C⟦e, lim E⟧.
+  Proof.
+    use limArrow.
+    use mk_cone.
+    intros v. induction v.
+
+    exact h. exact (h ;; f).
+    intros u v e'.
+    induction u; induction v; try induction e'.
+    apply idpath. apply (!H).
+  Defined.
+
+  Lemma EqualizerArrowComm {a b : C} {f g : C⟦a, b⟧}
+        (E : Equalizer f g) e (h : C⟦e, a⟧)
+        (H : h ;; f = h ;; g) :
+    EqualizerIn E e h H ;; EqualizerArrow E = h.
+  Proof.
+    refine (limArrowCommutes E e _ One).
+  Qed.
+
+  Lemma EqualizerInUnique {a b : C} {f g : C⟦a, b⟧}
+        (E : Equalizer f g) e (h : C⟦e, a⟧)
+        (H : h ;; f = h ;; g)
+        (w : C⟦e, lim E⟧)
+        (H' : w ;; EqualizerArrow E = h) :
+    w = EqualizerIn E e h H.
+  Proof.
+    apply path_to_ctr.
+    intros v. induction v; cbn; try assumption.
+    set (X := limOutCommutes E One Two (ii1 tt)).
+    apply (maponpaths (fun h : _ => w ;; h)) in X.
+    use (pathscomp0 (!X)). cbn. rewrite assoc.
+    apply cancel_postcomposition.
+    apply H'.
+  Qed.
+
+  Definition isEqualizer_Equalizer {a b : C} {f g : C⟦a, b⟧}
+             (E : Equalizer f g) :
+    isEqualizer f g (EqualizerObject E) (EqualizerArrow E) (EqualizerArrowEq E).
+  Proof.
+    apply mk_isEqualizer.
+    intros e h H.
+    use unique_exists.
+    exact (EqualizerIn E e h H).
+    exact (EqualizerArrowComm E e h H).
+
+    intros y. apply hs.
+
+    intros y t. cbn in t.
+    use EqualizerInUnique.
+    exact t.
+  Qed.
+
+  (** ** Equalizers to equalizers *)
+
+  Definition identity_is_Equalizer_input {a b : C} {f g : C⟦a, b⟧}
+             (E : Equalizer f g) :
+    total2 (fun hk : C⟦lim E, lim E⟧ => hk ;; EqualizerArrow E
+                                     = EqualizerArrow E).
+  Proof.
+    use tpair.
+    exact (identity _).
+    apply id_left.
+  Defined.
+
+  Lemma EqualizerEndo_is_identity  {a b : C} {f g : C⟦a, b⟧}
+        (E : Equalizer f g) (k : C⟦lim E, lim E⟧)
+        (kH : k ;; EqualizerArrow E = EqualizerArrow E) :
+    identity (lim E) = k.
+  Proof.
+    apply lim_endo_is_identity.
+    unfold limOut.
+    intros u. induction u.
+    apply kH.
+    rewrite <- (coneOutCommutes (limCone E) One Two (ii1 tt)).
+    rewrite assoc. cbn. apply cancel_postcomposition.
+    apply kH.
+  Qed.
+
+  Definition from_Equalizer_to_Equalizer {a b : C} {f g : C⟦a, b⟧}
+             (E1 E2 : Equalizer f g) : C⟦lim E1, lim E2⟧.
+  Proof.
+    apply (EqualizerIn E2 (lim E1) (EqualizerArrow E1)).
+    exact (EqualizerArrowEq E1).
+  Defined.
+
+  Lemma are_inverses_from_Equalizer_to_Equalizer {a b : C} {f g : C⟦a, b⟧}
+        (E1 E2 : Equalizer f g) :
+    is_inverse_in_precat (from_Equalizer_to_Equalizer E2 E1)
+      (from_Equalizer_to_Equalizer E1 E2).
+  Proof.
+    split; apply pathsinv0.
+    apply EqualizerEndo_is_identity.
+    rewrite <- assoc.
+    unfold from_Equalizer_to_Equalizer.
+    repeat rewrite EqualizerArrowComm.
+    apply idpath.
+
+    apply EqualizerEndo_is_identity.
+    rewrite <- assoc.
+    unfold from_Equalizer_to_Equalizer.
+    repeat rewrite EqualizerArrowComm.
+    apply idpath.
+  Qed.
+
+  Lemma isiso_from_Equalizer_to_Equalizer {a b : C} {f g : C⟦a, b⟧}
+        (E1 E2 : Equalizer f g) :
+    is_isomorphism (from_Equalizer_to_Equalizer E1 E2).
+  Proof.
+    apply (is_iso_qinv _ (from_Equalizer_to_Equalizer E2 E1)).
+    apply are_inverses_from_Equalizer_to_Equalizer.
+  Qed.
+
+  Definition iso_from_Equalizer_to_Equalizer {a b : C} {f g : C⟦a, b⟧}
+             (E1 E2 : Equalizer f g) : iso (lim E1) (lim E2)
+    := tpair _ _ (isiso_from_Equalizer_to_Equalizer E1 E2).
+
+  Lemma inv_from_iso_iso_from_Pullback {a b : C} {f g : C⟦a , b⟧}
+        (E1 E2 : Equalizer f g):
+    inv_from_iso (iso_from_Equalizer_to_Equalizer E1 E2)
+    = from_Equalizer_to_Equalizer E2 E1.
+  Proof.
+    apply pathsinv0.
+    apply inv_iso_unique'.
+    apply (pr1 (are_inverses_from_Equalizer_to_Equalizer E2 E1)).
+  Qed.
+
+
+  (** ** Connections to other limits *)
+
+  Lemma Equalizers_from_Lims :
+    Lims C -> Equalizers.
+  Proof.
+    intros H a b f g. apply H.
+  Defined.
+
+End def_equalizers.
+
+
+(** * Definitions coincide
+  In this section we show that the definition of equalizer as a limit
+  coincides with the direct definition. *)
+Section equalizers_coincide.
+
+  Variable C : precategory.
+  Variable hs: has_homsets C.
+
+  (** ** isEqualizers *)
+
+  Lemma equiv_isEqualizer1 {a b : C} {f g : C⟦a, b⟧}
+        e (h : C⟦e, a⟧) (H : h ;; f = h ;; g) :
+    limits.equalizers.isEqualizer f g h H -> isEqualizer C f g e h H.
+  Proof.
+    intros X.
+    set (E := limits.equalizers.mk_Equalizer f g h H X).
+    use mk_isEqualizer.
+    exact hs.
+    intros e' h' H'.
+    use unique_exists.
+
+    exact (limits.equalizers.EqualizerIn E e' h' H').
+    exact (limits.equalizers.EqualizerCommutes E e' h' H').
+    intros y. apply hs.
+    intros y T. cbn in T.
+    use (limits.equalizers.EqualizerInsEq E).
+    use (pathscomp0 T).
+    exact (!(limits.equalizers.EqualizerCommutes E e' h' H')).
+  Qed.
+
+  Lemma equiv_isEqualizer2 {a b : C} (f g : C⟦a, b⟧)
+        e (h : C⟦e, a⟧) (H : h ;; f = h ;; g) :
+    limits.equalizers.isEqualizer f g h H <- isEqualizer C f g e h H.
+  Proof.
+    intros X.
+    set (E := mk_Equalizer C f g e h H X).
+    intros e' h' H'.
+    use unique_exists.
+
+    exact (EqualizerIn C E e' h' H').
+    exact (EqualizerArrowComm C E e' h' H').
+    intros y. apply hs.
+    intros y T. cbn in T.
+    use (EqualizerInUnique C E).
+    exact T.
+  Qed.
+
+  (** ** Equalizers *)
+
+  Definition equiv_Equalizer1 {a b : C} (f g : C⟦a, b⟧) :
+    limits.equalizers.Equalizer f g -> Equalizer C f g.
+  Proof.
+    intros E.
+    exact (mk_Equalizer
+             C f g
+             _
+             _
+             _
+             (equiv_isEqualizer1
+                (limits.equalizers.EqualizerObject E)
+                (limits.equalizers.EqualizerArrow E)
+                (limits.equalizers.EqualizerEqAr E)
+                (limits.equalizers.isEqualizer_Equalizer E))).
+  Defined.
+
+  Definition equiv_Equalizer2 {a b : C} (f g : C⟦a, b⟧) :
+    limits.equalizers.Equalizer f g <- Equalizer C f g.
+  Proof.
+    intros E.
+    exact (@limits.equalizers.mk_Equalizer
+             C (EqualizerObject C E) a b f g
+             (EqualizerArrow C E)
+             (EqualizerArrowEq C E)
+             (@equiv_isEqualizer2
+                a b f g (EqualizerObject C E)
+                (EqualizerArrow C E)
+                (EqualizerArrowEq C E)
+                (isEqualizer_Equalizer C hs E))).
+  Defined.
+
+End equalizers_coincide.

--- a/UniMath/CategoryTheory/limits/graphs/initial.v
+++ b/UniMath/CategoryTheory/limits/graphs/initial.v
@@ -7,6 +7,7 @@ Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.limits.initial.
 
 Section def_initial.
 
@@ -113,6 +114,60 @@ Definition hasInitial := ishinh Initial.
 (* Qed. *)
 
 (* End Initial_Unique. *)
+
+Lemma isInitial_Initial (I : Initial) :
+  isInitial (InitialObject I).
+Proof.
+  use mk_isInitial.
+  intros b.
+  use tpair.
+  exact (InitialArrow I b).
+  intros t.
+  use (InitialArrowUnique I).
+Qed.
+
+
+(** ** Maps between initial as special colimit and direct definition *)
+Lemma equiv_isInitial1 (c : C) :
+  limits.initial.isInitial C c -> isInitial c.
+Proof.
+  intros X.
+  use mk_isInitial.
+  intros b.
+  apply (X b).
+Qed.
+
+Lemma equiv_isInitial2 (c : C) :
+  limits.initial.isInitial C c <- isInitial c.
+Proof.
+  intros X.
+  set (XI := mk_Initial c X).
+  intros b.
+  use tpair.
+  exact (InitialArrow XI b).
+  intros t.
+  use (InitialArrowUnique XI b).
+Qed.
+
+Definition equiv_Initial1 (c : C) :
+  limits.initial.Initial C -> Initial.
+Proof.
+  intros I.
+  use mk_Initial.
+  exact I.
+  use equiv_isInitial1.
+  exact (pr2 I).
+Defined.
+
+Definition equiv_Initial2 (c : C) :
+  limits.initial.Initial C <- Initial.
+Proof.
+  intros I.
+  use limits.initial.mk_Initial.
+  exact (InitialObject I).
+  use equiv_isInitial2.
+  use (isInitial_Initial I).
+Defined.
 
 End def_initial.
 

--- a/UniMath/CategoryTheory/limits/graphs/initial.v
+++ b/UniMath/CategoryTheory/limits/graphs/initial.v
@@ -121,9 +121,8 @@ Proof.
   use mk_isInitial.
   intros b.
   use tpair.
-  exact (InitialArrow I b).
-  intros t.
-  use (InitialArrowUnique I).
+  - exact (InitialArrow I b).
+  - intros t. use (InitialArrowUnique I).
 Qed.
 
 
@@ -144,9 +143,8 @@ Proof.
   set (XI := mk_Initial c X).
   intros b.
   use tpair.
-  exact (InitialArrow XI b).
-  intros t.
-  use (InitialArrowUnique XI b).
+  - exact (InitialArrow XI b).
+  - intros t. use (InitialArrowUnique XI b).
 Qed.
 
 Definition equiv_Initial1 (c : C) :
@@ -154,9 +152,9 @@ Definition equiv_Initial1 (c : C) :
 Proof.
   intros I.
   use mk_Initial.
-  exact I.
-  use equiv_isInitial1.
-  exact (pr2 I).
+  - exact I.
+  - use equiv_isInitial1.
+    exact (pr2 I).
 Defined.
 
 Definition equiv_Initial2 (c : C) :
@@ -164,9 +162,9 @@ Definition equiv_Initial2 (c : C) :
 Proof.
   intros I.
   use limits.initial.mk_Initial.
-  exact (InitialObject I).
-  use equiv_isInitial2.
-  use (isInitial_Initial I).
+  - exact (InitialObject I).
+  - use equiv_isInitial2.
+    use (isInitial_Initial I).
 Defined.
 
 End def_initial.

--- a/UniMath/CategoryTheory/limits/graphs/kernels.v
+++ b/UniMath/CategoryTheory/limits/graphs/kernels.v
@@ -1,0 +1,127 @@
+(** * Kernels defined in terms of limits *)
+(** ** Contents
+- Definition coincides with the direct definition
+*)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.precategories.
+
+Require Import UniMath.CategoryTheory.limits.graphs.limits.
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.limits.graphs.zero.
+Require Import UniMath.CategoryTheory.limits.graphs.equalizers.
+Require Import UniMath.CategoryTheory.limits.kernels.
+
+
+(** * Definition of kernels in terms of limits *)
+Section def_kernels.
+
+  Variable C : precategory.
+  Variable hs: has_homsets C.
+  Variable Z : Zero C.
+
+  Definition Kernel {a b : C} (f : C⟦a, b⟧)
+    := Equalizer C f (ZeroArrow Z a b).
+
+  (** ** Maps between Kernels as limits and direct definition. *)
+  Lemma equiv_Kernel1_eq {a b : C} (f : C⟦a, b⟧)
+        (K : limits.kernels.Kernel (equiv_Zero2 Z) f) :
+    limits.equalizers.EqualizerArrow K ;; f
+    = limits.equalizers.EqualizerArrow K ;; ZeroArrow Z a b.
+  Proof.
+    set (tmp := limits.equalizers.EqualizerEqAr K).
+    set (tmp1 := equiv_ZeroArrow a b Z).
+    apply (maponpaths (fun h : _ => limits.equalizers.EqualizerArrow K ;; h))
+      in tmp1.
+    set (tmp2 := pathscomp0 tmp tmp1).
+    apply tmp2.
+  Qed.
+
+  Lemma equiv_Kernel1_isEqualizer {a b : C} (f : C⟦a, b⟧)
+        (K : limits.kernels.Kernel (equiv_Zero2 Z) f) :
+    limits.equalizers.isEqualizer
+      f (ZeroArrow Z a b) (limits.equalizers.EqualizerArrow K)
+      (equiv_Kernel1_eq f K).
+  Proof.
+    use limits.equalizers.mk_isEqualizer.
+    intros w h H.
+    use unique_exists.
+    use limits.kernels.KernelIn.
+    exact h. rewrite precomp_with_ZeroArrow in H.
+    use (pathscomp0 _ (!(equiv_ZeroArrow w b Z))).
+    exact H.
+
+    cbn.
+    use limits.kernels.KernelCommutes.
+    intros y. apply hs.
+    intros y T. cbn in T.
+    use limits.kernels.KernelInsEq. unfold KernelArrow.
+    use (pathscomp0 T). apply pathsinv0.
+    use limits.kernels.KernelCommutes.
+  Qed.
+
+  Definition equiv_Kernel1 {a b : C} (f : C⟦a, b⟧) :
+    limits.kernels.Kernel (equiv_Zero2 Z) f -> Kernel f.
+  Proof.
+    intros K.
+    exact (equiv_Equalizer1
+           C hs f _
+           (@limits.equalizers.mk_Equalizer
+              C K a b f _
+              (limits.equalizers.EqualizerArrow K)
+              (equiv_Kernel1_eq f K)
+              (equiv_Kernel1_isEqualizer f K))).
+  Defined.
+
+  (* Other direction *)
+
+  Lemma equiv_Kernel2_eq {a b : C} (f : C⟦a, b⟧) (K : Kernel f ) :
+    EqualizerArrow C K ;; f
+    = EqualizerArrow C K ;; limits.zero.ZeroArrow C (equiv_Zero2 Z) a b.
+  Proof.
+    set (tmp := EqualizerArrowEq C K).
+    set (tmp1 := equiv_ZeroArrow a b Z).
+    apply pathsinv0 in tmp1.
+    apply (maponpaths (fun h : _ => EqualizerArrow C K ;; h)) in tmp1.
+    set (tmp2 := pathscomp0 tmp tmp1).
+    apply tmp2.
+  Qed.
+
+  Lemma equiv_Kernel2_isEqualizer {a b : C} (f : C⟦a, b⟧) (K : Kernel f ) :
+    isEqualizer C f (limits.zero.ZeroArrow C (equiv_Zero2 Z) a b)
+                (EqualizerObject C K)
+                (EqualizerArrow C K) (equiv_Kernel2_eq f K).
+  Proof.
+    use mk_isEqualizer. apply hs.
+    intros w h H.
+    use unique_exists.
+    use EqualizerIn.
+    exact h. rewrite precomp_with_ZeroArrow.
+    rewrite limits.zero.ZeroArrow_comp_right in H.
+    use (pathscomp0 H).
+    apply (equiv_ZeroArrow w b Z).
+
+    cbn.
+    use EqualizerArrowComm.
+    intros y. apply hs.
+    intros y T. cbn in T.
+    use EqualizerInUnique. exact T.
+  Qed.
+
+  Definition equiv_Kernel2 {a b : C} (f : C⟦a, b⟧) :
+    limits.kernels.Kernel (equiv_Zero2 Z) f <- Kernel f.
+  Proof.
+    intros K.
+    exact (equiv_Equalizer2
+           C hs f _
+           (@mk_Equalizer
+              C a b f _ (EqualizerObject C K)
+              (EqualizerArrow C K)
+              (equiv_Kernel2_eq f K)
+              (equiv_Kernel2_isEqualizer f K))).
+  Defined.
+
+End def_kernels.

--- a/UniMath/CategoryTheory/limits/graphs/kernels.v
+++ b/UniMath/CategoryTheory/limits/graphs/kernels.v
@@ -49,18 +49,25 @@ Section def_kernels.
     use limits.equalizers.mk_isEqualizer.
     intros w h H.
     use unique_exists.
-    use limits.kernels.KernelIn.
-    exact h. rewrite precomp_with_ZeroArrow in H.
-    use (pathscomp0 _ (!(equiv_ZeroArrow w b Z))).
-    exact H.
 
-    cbn.
-    use limits.kernels.KernelCommutes.
-    intros y. apply hs.
-    intros y T. cbn in T.
-    use limits.kernels.KernelInsEq. unfold KernelArrow.
-    use (pathscomp0 T). apply pathsinv0.
-    use limits.kernels.KernelCommutes.
+    (* Construction of the morphism *)
+    - use limits.kernels.KernelIn.
+      + exact h.
+      + rewrite precomp_with_ZeroArrow in H.
+        use (pathscomp0 _ (!(equiv_ZeroArrow w b Z))).
+        exact H.
+
+    (* Commutativity *)
+    - use limits.kernels.KernelCommutes.
+
+    (* Equality on equalities of morphisms *)
+    - intros y. apply hs.
+
+    (* Uniqueness *)
+    - intros y T. cbn in T.
+      use limits.kernels.KernelInsEq. unfold KernelArrow.
+      use (pathscomp0 T). apply pathsinv0.
+      use limits.kernels.KernelCommutes.
   Qed.
 
   Definition equiv_Kernel1 {a b : C} (f : C⟦a, b⟧) :
@@ -98,17 +105,24 @@ Section def_kernels.
     use mk_isEqualizer. apply hs.
     intros w h H.
     use unique_exists.
-    use EqualizerIn.
-    exact h. rewrite precomp_with_ZeroArrow.
-    rewrite limits.zero.ZeroArrow_comp_right in H.
-    use (pathscomp0 H).
-    apply (equiv_ZeroArrow w b Z).
 
-    cbn.
-    use EqualizerArrowComm.
-    intros y. apply hs.
-    intros y T. cbn in T.
-    use EqualizerInUnique. exact T.
+    (* Construction of the morphism *)
+    - use EqualizerIn.
+      + exact h.
+      + rewrite precomp_with_ZeroArrow.
+        rewrite limits.zero.ZeroArrow_comp_right in H.
+        use (pathscomp0 H).
+        apply (equiv_ZeroArrow w b Z).
+
+    (* Commutativity *)
+    - use EqualizerArrowComm.
+
+    (* Equality on equalities of morphisms *)
+    - intros y. apply hs.
+
+    (* Uniqueness *)
+    - intros y T. cbn in T.
+      use EqualizerInUnique. exact T.
   Qed.
 
   Definition equiv_Kernel2 {a b : C} (f : C⟦a, b⟧) :

--- a/UniMath/CategoryTheory/limits/graphs/pushouts.v
+++ b/UniMath/CategoryTheory/limits/graphs/pushouts.v
@@ -1,0 +1,438 @@
+(** * Pushouts defined in terms of colimits *)
+(** ** Contents
+- Definition of pushouts
+- Coincides with the direct definition
+*)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.limits.graphs.limits.
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.limits.pushouts.
+
+(** * Definition of pushouts in terms of colimits *)
+Section def_po.
+
+  Variable C : precategory.
+  Variable hs: has_homsets C.
+
+  Inductive three := One | Two | Three.
+
+  Definition pushout_graph : graph.
+  Proof.
+    exists three.
+    exact (fun a b =>
+             match (a,b) with
+             | (Two ,One) => unit
+             | (Two, Three) => unit
+             | _ => empty
+             end).
+  Defined.
+
+  Definition pushout_diagram {a b c : C} (f : C ⟦a,b⟧) (g : C⟦a,c⟧) :
+    diagram pushout_graph C.
+  Proof.
+    exists (fun x => match x with
+             | One => b
+             | Two => a
+             | Three => c end).
+    intros u v e.
+    induction u; induction v; simpl; try induction e; assumption.
+  Defined.
+
+  Definition PushoutCocone {a b c : C} (f : C ⟦a,b⟧) (g : C⟦a,c⟧)
+             (d : C) (f' : C ⟦b, d⟧) (g' : C ⟦c,d⟧)
+             (H : f ;; f' = g ;; g')
+    : cocone (pushout_diagram f g) d.
+  Proof.
+    simple refine (mk_cocone _ _  ).
+    - intro v; induction v; simpl; try assumption.
+      apply (f ;; f').
+    - intros u v e;
+        induction u; induction v; try induction e; simpl.
+      + apply idpath.
+      + apply (!H).
+  Defined.
+
+  Definition isPushout {a b c d : C} (f : C ⟦a, b⟧) (g : C ⟦a, c⟧)
+             (i1 : C⟦b,d⟧) (i2 : C⟦c,d⟧) (H : f ;; i1 = g ;; i2) : UU :=
+    isColimCocone (pushout_diagram f g) d (PushoutCocone f g d i1 i2 H).
+
+  Definition mk_isPushout {a b c d : C} (f : C ⟦a, b⟧) (g : C ⟦a, c⟧)
+             (i1 : C⟦b,d⟧) (i2 : C⟦c,d⟧) (H : f ;; i1 = g ;; i2) :
+    (Π e (h : C ⟦b,e⟧) (k : C⟦c,e⟧)(Hk : f ;; h = g ;; k ),
+     iscontr (total2 (fun hk : C⟦d,e⟧ => dirprod (i1 ;; hk = h)(i2 ;; hk = k))))
+    →
+    isPushout f g i1 i2 H.
+  Proof.
+    intros H' x cx; simpl in *.
+    set (H1 := H' x (coconeIn cx One) (coconeIn cx Three)).
+    simple refine (let p : f ;; coconeIn cx One = g ;; coconeIn cx Three
+                       := _ in _ ).
+    - set (H2 := coconeInCommutes cx Two One tt).
+    eapply pathscomp0. apply H2.
+    clear H2.
+    apply pathsinv0.
+    apply (coconeInCommutes cx Two Three tt).
+  - set (H2 := H1 p).
+    simple refine (tpair _ _ _ ).
+    + exists (pr1 (pr1 H2)).
+      intro v; induction v; simpl.
+      * apply (pr1 (pr2 (pr1 H2))).
+      * use (pathscomp0 _ (coconeInCommutes cx Two One tt)).
+        rewrite <- assoc.
+        rewrite (pr1 (pr2 (pr1 H2))).
+        apply cancel_postcomposition.
+        apply idpath.
+      * unfold compose. simpl.
+        set (X := pr2 (pr2 (pr1 H2))). simpl in *. apply X.
+    +  intro t.
+       apply subtypeEquality.
+       * simpl.
+         intro; apply impred; intro. apply hs.
+       * destruct t as [t p0]; simpl.
+         apply path_to_ctr.
+         { split.
+           - apply (p0 One).
+           - apply (p0 Three). }
+  Defined.
+
+  Definition Pushout {a b c : C} (f : C⟦a, b⟧)(g : C⟦a, c⟧) :=
+    ColimCocone (pushout_diagram f g).
+
+  Definition mk_Pushout {a b c : C} (f : C⟦a, b⟧)(g : C⟦a, c⟧)
+             (d : C) (i1 : C⟦b,d⟧) (i2 : C ⟦c,d⟧)
+             (H : f ;; i1 = g ;; i2)
+             (ispo : isPushout f g i1 i2 H)
+    : Pushout f g.
+  Proof.
+    simple refine (tpair _ _ _ ).
+    - simple refine (tpair _ _ _ ).
+      + apply d.
+      + simple refine (PushoutCocone _ _ _ _ _ _ ); assumption.
+    - apply ispo.
+  Defined.
+
+  Definition Pushouts := Π (a b c : C)(f : C⟦a, b⟧)(g : C⟦a, c⟧),
+                          Pushout f g.
+
+  Definition hasPushouts := Π (a b c : C) (f : C⟦a, b⟧) (g : C⟦a, c⟧),
+                            ishinh (Pushout f g).
+
+
+  Definition PushoutObject {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧}:
+    Pushout f g -> C := fun H => colim H.
+  (* Coercion PushoutObject : Pushout >-> ob. *)
+
+  Definition PushoutIn1 {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧}
+             (Po : Pushout f g) : C⟦b, colim Po⟧ := colimIn Po One.
+
+  Definition PushoutIn2 {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧}
+             (Po : Pushout f g) : C⟦c, colim Po⟧ := colimIn Po Three.
+
+  Definition PushoutSqrCommutes {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧}
+             (Po : Pushout f g) :
+    f ;; PushoutIn1 Po = g ;; PushoutIn2 Po.
+  Proof.
+    eapply pathscomp0; [apply (colimInCommutes Po Two One tt) |].
+    apply (!colimInCommutes Po Two Three tt) .
+  Qed.
+
+  Definition PushoutArrow {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧}
+             (Po : Pushout f g) e (h : C⟦b, e⟧) (k : C⟦c, e⟧)
+             (H : f ;; h = g ;; k)
+    : C⟦colim Po, e⟧.
+  Proof.
+    simple refine (colimArrow _ _ _ ).
+    simple refine (mk_cocone _ _ ).
+    - intro v; induction v; simpl; try assumption.
+      apply (f ;; h).
+    - intros u v edg; induction u; induction v; try induction edg; simpl.
+      + apply idpath.
+      + apply (!H).
+  Defined.
+
+  Lemma PushoutArrow_PushoutIn1 {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧}
+        (Po : Pushout f g) e (h : C⟦b , e⟧) (k : C⟦c , e⟧)
+        (H : f ;; h = g ;; k) :
+    PushoutIn1 Po ;; PushoutArrow Po e h k H = h.
+  Proof.
+    refine (colimArrowCommutes Po e _ One).
+  Qed.
+
+  Lemma PushoutArrow_PushoutIn2 {a b c : C} {f : C⟦a , b⟧} {g : C⟦a , c⟧}
+        (Po : Pushout f g) e (h : C⟦b , e⟧) (k : C⟦c , e⟧)
+        (H : f ;; h = g ;; k) :
+    PushoutIn2 Po ;; PushoutArrow Po e h k H = k.
+  Proof.
+    refine (colimArrowCommutes Po e _ Three).
+  Qed.
+
+  Lemma PushoutArrowUnique {a b c d : C} (f : C⟦a , b⟧) (g : C⟦a , c⟧)
+        (Po : Pushout f g)
+        e (h : C⟦b , e⟧) (k : C⟦c , e⟧)
+        (Hcomm : f ;; h = g ;; k)
+        (w : C⟦PushoutObject Po, e⟧)
+        (H1 : PushoutIn1 Po ;; w = h) (H2 : PushoutIn2 Po ;; w = k) :
+    w = PushoutArrow Po _ h k Hcomm.
+  Proof.
+    apply path_to_ctr.
+    intro v; induction v; simpl; try assumption.
+    set (X:= colimInCommutes Po Two Three tt). cbn in X.
+    rewrite <- X. rewrite Hcomm. rewrite <- assoc.
+    apply cancel_precomposition. apply H2.
+  Qed.
+
+  Definition isPushout_Pushout {a b c : C} {f : C⟦a, b⟧}{g : C⟦a, c⟧}
+             (P : Pushout f g) :
+    isPushout f g (PushoutIn1 P) (PushoutIn2 P) (PushoutSqrCommutes P).
+  Proof.
+    apply mk_isPushout.
+    intros e h k HK.
+    simple refine (tpair _ _ _ ).
+    - simple refine (tpair _ _ _ ).
+      + apply (PushoutArrow P _ h k HK).
+      + split.
+        * apply PushoutArrow_PushoutIn1.
+        * apply PushoutArrow_PushoutIn2.
+    - intro t.
+      apply subtypeEquality.
+      + intro. apply isapropdirprod; apply hs.
+      + destruct t as [t p]. simpl.
+        refine (PushoutArrowUnique _ _ P _ _ _ _ _ _ _ ).
+        * apply e.
+        * apply (pr1 p).
+        * apply (pr2 p).
+  Qed.
+
+  (** ** Pushouts to Pushouts *)
+
+  Definition identity_is_Pushout_input {a b c : C}{f : C⟦a , b⟧} {g : C⟦a , c⟧}
+             (Po : Pushout f g) :
+    total2 (fun hk : C⟦colim Po, colim Po⟧ =>
+              dirprod (PushoutIn1 Po ;; hk = PushoutIn1 Po)
+                      (PushoutIn2 Po ;; hk = PushoutIn2 Po)).
+  Proof.
+    exists (identity (colim Po)).
+    apply dirprodpair; apply id_right.
+  Defined.
+
+  (* was PushoutArrowUnique *)
+  Lemma PushoutArrowUnique' {a b c d : C} (f : C⟦a, b⟧) (g : C⟦a, c⟧)
+        (i1 : C⟦b, d⟧) (i2 : C⟦c, d⟧) (H : f ;; i1 = g ;; i2)
+        (P : isPushout f g i1 i2 H) e (h : C⟦b, e⟧) (k : C⟦c, e⟧)
+        (Hcomm : f ;; h = g ;; k)
+        (w : C⟦d, e⟧)
+        (H1 : i1 ;; w = h) (H2 : i2 ;; w = k) :
+    w =  (pr1 (pr1 (P e (PushoutCocone f g _ h k Hcomm)))).
+  Proof.
+    apply path_to_ctr.
+    intro v; induction v; simpl.
+    - assumption.
+    - rewrite <- assoc. apply cancel_precomposition. apply H1.
+    - assumption.
+  Qed.
+
+  Lemma PushoutEndo_is_identity {a b c : C}{f : C⟦a, b⟧} {g : C⟦a, c⟧}
+        (Po : Pushout f g) (k : C⟦colim Po , colim Po⟧)
+        (kH1 : PushoutIn1 Po ;; k = PushoutIn1 Po)
+        (kH2 : PushoutIn2 Po ;; k = PushoutIn2 Po) :
+    identity (colim Po) = k.
+  Proof.
+    apply colim_endo_is_identity.
+    intro u; induction u; simpl.
+    - apply kH1.
+    - unfold colimIn. simpl.
+      assert (T:= coconeInCommutes (colimCocone Po) Two Three tt).
+      rewrite <- T.
+      simpl.
+      rewrite <- assoc.
+      apply cancel_precomposition.
+      apply kH2.
+    - assumption.
+  Qed.
+
+  Definition from_Pushout_to_Pushout {a b c : C}{f : C⟦a , b⟧} {g : C⟦a , c⟧}
+             (Po Po': Pushout f g) : C⟦colim Po , colim Po'⟧.
+  Proof.
+    apply (PushoutArrow Po (colim Po') (PushoutIn1 _ ) (PushoutIn2 _)).
+    exact (PushoutSqrCommutes _ ).
+  Defined.
+
+  Lemma are_inverses_from_Pushout_to_Pushout {a b c : C}{f : C⟦a , b⟧}
+        {g : C⟦a , c⟧} (Po Po': Pushout f g) :
+    is_inverse_in_precat (from_Pushout_to_Pushout Po Po')
+                         (from_Pushout_to_Pushout Po' Po).
+  Proof.
+    split; apply pathsinv0;
+      apply PushoutEndo_is_identity;
+      rewrite assoc;
+      unfold from_Pushout_to_Pushout;
+      repeat rewrite PushoutArrow_PushoutIn1;
+      repeat rewrite PushoutArrow_PushoutIn2;
+      auto.
+  Qed.
+
+  Lemma isiso_from_Pushout_to_Pushout {a b c : C}{f : C⟦a , b⟧} {g : C⟦a , c⟧}
+        (Po Po': Pushout f g) :
+    is_isomorphism (from_Pushout_to_Pushout Po Po').
+  Proof.
+    apply (is_iso_qinv _ (from_Pushout_to_Pushout Po' Po)).
+    apply are_inverses_from_Pushout_to_Pushout.
+  Defined.
+
+  Definition iso_from_Pushout_to_Pushout {a b c : C}
+             {f : C⟦a , b⟧} {g : C⟦a , c⟧}
+             (Po Po': Pushout f g) : iso (colim Po) (colim Po') :=
+    tpair _ _ (isiso_from_Pushout_to_Pushout Po Po').
+
+
+  (** pushout lemma *)
+
+  Section pushout_lemma.
+
+    Variables a b c d e x : C.
+    Variables (f : C⟦a , b⟧) (g : C⟦a , c⟧) (h : C⟦b , e⟧) (k : C⟦c , e⟧)
+              (i : C⟦b , d⟧) (j : C⟦e , x⟧) (m : C⟦d , x⟧).
+    Hypothesis H1 : f ;; h = g ;; k.
+    Hypothesis H2 : i ;; m = h ;; j.
+    Hypothesis P1 : isPushout _ _ _ _ H1.
+    Hypothesis P2 : isPushout _ _ _ _ H2.
+
+    Lemma glueSquares : f ;; i ;; m = g ;; k ;; j.
+    Proof.
+      rewrite <- assoc.
+      rewrite H2.
+      rewrite <- H1.
+      repeat rewrite <- assoc.
+      apply idpath.
+    Qed.
+
+    (** TODO: isPushoutGluedSquare : isPushout (f ;; i) g m (k ;; j)
+       glueSquares. *)
+
+  End pushout_lemma.
+
+  Section Universal_Unique.
+
+    Hypothesis H : is_category C.
+
+    Lemma inv_from_iso_iso_from_Pushout (a b c : C)
+          (f : C⟦a , b⟧) (g : C⟦a , c⟧)
+          (Po : Pushout f g) (Po' : Pushout f g):
+      inv_from_iso (iso_from_Pushout_to_Pushout Po Po')
+      = from_Pushout_to_Pushout Po' Po.
+    Proof.
+      apply pathsinv0.
+      apply inv_iso_unique'.
+      set (T:= are_inverses_from_Pushout_to_Pushout Po Po').
+      apply (pr1 T).
+    Qed.
+
+  End Universal_Unique.
+
+  (** ** Connections to other colimits *)
+
+  Lemma Pushout_from_Colims :
+    Colims C -> Pushouts.
+  Proof.
+    intros H a b c f g; apply H.
+  Defined.
+
+End def_po.
+
+
+(** * Definitions coincide
+  In this section we show that pushouts defined as special colimits coincide
+  with the direct definition. *)
+Section pushout_coincide.
+
+  Variable C : precategory.
+  Variable hs: has_homsets C.
+
+  (** ** isPushout *)
+
+  Lemma equiv_isPushout1 {a b c d : C} (f : C ⟦a, b⟧) (g : C ⟦a, c⟧)
+        (i1 : C⟦b,d⟧) (i2 : C⟦c,d⟧) (H : f ;; i1 = g ;; i2) :
+    limits.pushouts.isPushout f g i1 i2 H -> isPushout C f g i1 i2 H.
+  Proof.
+    intros X R cc.
+    set (XR := limits.pushouts.mk_Pushout f g d i1 i2 H X).
+    use unique_exists.
+
+    use (limits.pushouts.PushoutArrow XR).
+    exact (coconeIn cc One).
+    exact (coconeIn cc Three).
+    use (pathscomp0 ((coconeInCommutes cc Two One tt))).
+    apply (!(coconeInCommutes cc Two Three tt)).
+
+    intros v. induction v.
+    apply (limits.pushouts.PushoutArrow_PushoutIn1 XR).
+    cbn. rewrite <- assoc.
+    rewrite (limits.pushouts.PushoutArrow_PushoutIn1 XR).
+    apply (coconeInCommutes cc Two One tt).
+
+    cbn. apply (limits.pushouts.PushoutArrow_PushoutIn2 XR).
+    intros y. cbn beta. apply impred_isaprop. intros t. apply hs.
+
+    intros y T. cbn in T.
+    use limits.pushouts.PushoutArrowUnique.
+    apply (T One).
+    apply (T Three).
+  Qed.
+
+  Lemma equiv_isPushout2 {a b c d : C} (f : C⟦a, b⟧) (g : C⟦a, c⟧)
+        (i1 : C⟦b,d⟧) (i2 : C⟦c,d⟧) (H : f ;; i1 = g ;; i2) :
+    limits.pushouts.isPushout f g i1 i2 H <- isPushout C f g i1 i2 H.
+  Proof.
+    intros X R k h HH.
+    set (XR := mk_Pushout C f g d i1 i2 H X).
+    use unique_exists.
+
+    use (PushoutArrow C XR).
+    exact k. exact h. exact HH.
+    split.
+    exact (PushoutArrow_PushoutIn1 C XR R k h HH).
+    exact (PushoutArrow_PushoutIn2 C XR R k h HH).
+    intros y. cbn beta. apply isapropdirprod; apply hs.
+
+    intros y T. cbn in T.
+    use (PushoutArrowUnique C _ _ XR).
+    exact R. exact (pr1 T). exact (pr2 T).
+  Qed.
+
+  (** ** Pushout *)
+
+  Definition equiv_Pushout1 {a b c : C} (f : C⟦a, b⟧) (g : C⟦a, c⟧) :
+    limits.pushouts.Pushout f g -> Pushout C f g.
+  Proof.
+    intros X.
+    exact (mk_Pushout
+             C f g X
+             (limits.pushouts.PushoutIn1 X)
+             (limits.pushouts.PushoutIn2 X)
+             (limits.pushouts.PushoutSqrCommutes X)
+             (equiv_isPushout1
+                _ _ _ _ _
+                (limits.pushouts.isPushout_Pushout X))).
+  Defined.
+
+  Definition equiv_Pushout2 {a b c : C} (f : C⟦a, b⟧) (g : C⟦a, c⟧) :
+    limits.pushouts.Pushout f g <- Pushout C f g.
+  Proof.
+    intros X.
+    exact (limits.pushouts.mk_Pushout
+             f g
+             (PushoutObject C X)
+             (PushoutIn1 C X)
+             (PushoutIn2 C X)
+             (PushoutSqrCommutes C X)
+             (equiv_isPushout2
+                _ _ _ _ _
+                (isPushout_Pushout C hs X))).
+  Defined.
+
+End pushout_coincide.

--- a/UniMath/CategoryTheory/limits/graphs/terminal.v
+++ b/UniMath/CategoryTheory/limits/graphs/terminal.v
@@ -8,6 +8,7 @@ Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.limits.terminal.
 
 Section def_terminal.
 
@@ -114,6 +115,56 @@ Definition hasTerminal := ishinh Terminal.
 (* Qed. *)
 
 (* End Terminal_Unique. *)
+
+Definition isTerminal_Terminal (T : Terminal) :
+  isTerminal (TerminalObject T).
+Proof.
+  use mk_isTerminal.
+  intros a.
+  use tpair.
+  exact (TerminalArrow T a).
+  intros t.
+  use (TerminalArrowUnique T a).
+Qed.
+
+
+(** ** Maps between terminal as a special limit and direct definition *)
+Lemma equiv_isTerminal1 (c : C) :
+  limits.terminal.isTerminal C c -> isTerminal c.
+Proof.
+  intros X.
+  use mk_isTerminal.
+  intros b.
+  apply (X b).
+Qed.
+
+Lemma equiv_isTerminal2 (c : C) :
+  limits.terminal.isTerminal C c <- isTerminal c.
+Proof.
+  intros X.
+  set (XT := mk_Terminal c X).
+  intros b.
+  use tpair.
+  exact (TerminalArrow XT b).
+  intros t.
+  use (TerminalArrowUnique XT b).
+Qed.
+
+Definition equiv_Terminal1 :
+  limits.terminal.Terminal C -> Terminal.
+Proof.
+  intros T.
+  exact (mk_Terminal T (equiv_isTerminal1 _ (pr2 T))).
+Defined.
+
+Definition equiv_Terminal2 :
+  limits.terminal.Terminal C <- Terminal.
+Proof.
+  intros T.
+  exact (limits.terminal.mk_Terminal
+           (TerminalObject T)
+           (equiv_isTerminal2 _ (isTerminal_Terminal T))).
+Defined.
 
 End def_terminal.
 

--- a/UniMath/CategoryTheory/limits/graphs/terminal.v
+++ b/UniMath/CategoryTheory/limits/graphs/terminal.v
@@ -122,9 +122,8 @@ Proof.
   use mk_isTerminal.
   intros a.
   use tpair.
-  exact (TerminalArrow T a).
-  intros t.
-  use (TerminalArrowUnique T a).
+  - exact (TerminalArrow T a).
+  - intros t. use (TerminalArrowUnique T a).
 Qed.
 
 
@@ -145,9 +144,8 @@ Proof.
   set (XT := mk_Terminal c X).
   intros b.
   use tpair.
-  exact (TerminalArrow XT b).
-  intros t.
-  use (TerminalArrowUnique XT b).
+  - exact (TerminalArrow XT b).
+  - intros t. use (TerminalArrowUnique XT b).
 Qed.
 
 Definition equiv_Terminal1 :

--- a/UniMath/CategoryTheory/limits/graphs/zero.v
+++ b/UniMath/CategoryTheory/limits/graphs/zero.v
@@ -200,12 +200,8 @@ Section zero_coincides.
     intros X.
     use mk_isZero.
     split.
-
-    intros d.
-    apply ((pr1 X) d).
-
-    intros d.
-    apply ((pr2 X) d).
+    - intros d. apply ((pr1 X) d).
+    - intros d. apply ((pr2 X) d).
   Qed.
 
   Lemma equiv_isZero2 (c : C) :
@@ -215,17 +211,16 @@ Section zero_coincides.
     set (XZ := mk_Zero c X).
 
     split.
-    intros b.
-    use tpair.
-    apply (InitialArrow (Zero_to_Initial XZ) b).
-    intros t.
-    use (InitialArrowUnique (Zero_to_Initial XZ) b).
-
-    intros a.
-    use tpair.
-    apply (TerminalArrow (Zero_to_Terminal XZ) a).
-    intros t.
-    use (TerminalArrowUnique (Zero_to_Terminal XZ) a).
+    - intros b.
+      use tpair.
+      apply (InitialArrow (Zero_to_Initial XZ) b).
+      intros t.
+      use (InitialArrowUnique (Zero_to_Initial XZ) b).
+    - intros a.
+      use tpair.
+      apply (TerminalArrow (Zero_to_Terminal XZ) a).
+      intros t.
+      use (TerminalArrowUnique (Zero_to_Terminal XZ) a).
   Qed.
 
   (** ** Zero **)

--- a/UniMath/CategoryTheory/limits/graphs/zero.v
+++ b/UniMath/CategoryTheory/limits/graphs/zero.v
@@ -1,6 +1,10 @@
 (** * Zero Objects
   Zero objects are objects of precategory which are both initial objects and
   terminal object. *)
+(** ** Contents
+- Definition of Zero
+- Coincides with the direct definition
+*)
 
 Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.Foundations.Basics.Propositions.
@@ -13,7 +17,10 @@ Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
 Require Import UniMath.CategoryTheory.limits.graphs.initial.
 Require Import UniMath.CategoryTheory.limits.graphs.terminal.
+Require Import UniMath.CategoryTheory.limits.zero.
 
+
+(** * Definition of zero using limits and colimits *)
 Section def_zero.
 
   Context {C : precategory}.
@@ -177,7 +184,95 @@ Section def_zero.
   Proof.
     exact(identity_iso (InitialObject I),,iso_inv_from_iso e).
   Defined.
+
 End def_zero.
+
+(** * Zero coincides with the direct definition *)
+Section zero_coincides.
+
+  Context {C : precategory}.
+
+  (** ** isZero *)
+
+  Lemma equiv_isZero1 (c : C) :
+    limits.zero.isZero C c -> isZero c.
+  Proof.
+    intros X.
+    use mk_isZero.
+    split.
+
+    intros d.
+    apply ((pr1 X) d).
+
+    intros d.
+    apply ((pr2 X) d).
+  Qed.
+
+  Lemma equiv_isZero2 (c : C) :
+    limits.zero.isZero C c <- isZero c.
+  Proof.
+    intros X.
+    set (XZ := mk_Zero c X).
+
+    split.
+    intros b.
+    use tpair.
+    apply (InitialArrow (Zero_to_Initial XZ) b).
+    intros t.
+    use (InitialArrowUnique (Zero_to_Initial XZ) b).
+
+    intros a.
+    use tpair.
+    apply (TerminalArrow (Zero_to_Terminal XZ) a).
+    intros t.
+    use (TerminalArrowUnique (Zero_to_Terminal XZ) a).
+  Qed.
+
+  (** ** Zero **)
+
+  Definition equiv_Zero1 :
+    limits.zero.Zero C -> @Zero C.
+  Proof.
+    intros Z.
+    exact (mk_Zero Z (equiv_isZero1 _ (pr2 Z))).
+  Defined.
+
+  Definition equiv_Zero2 :
+    limits.zero.Zero C <- @Zero C.
+  Proof.
+    intros Z.
+    exact (limits.zero.mk_Zero
+             (ZeroObject Z)
+             (equiv_isZero2
+                _ ((isInitial_Initial (Zero_to_Initial Z))
+                     ,,(isTerminal_Terminal (Zero_to_Terminal Z))))).
+  Defined.
+
+  (** ** Arrows *)
+
+  Lemma equiv_ZeroArrowTo (x : C) (Z : Zero) :
+    @limits.zero.ZeroArrowTo C (equiv_Zero2 Z) x = ZeroArrowTo Z x.
+  Proof.
+    apply ZeroArrowToUnique.
+  Qed.
+
+  Lemma equiv_ZeroArrowFrom (x : C) (Z : Zero) :
+    @limits.zero.ZeroArrowFrom C (equiv_Zero2 Z) x = ZeroArrowFrom Z x.
+  Proof.
+    apply ZeroArrowFromUnique.
+  Qed.
+
+  Lemma equiv_ZeroArrow (x y : C) (Z : Zero) :
+    @limits.zero.ZeroArrow C (equiv_Zero2 Z) x y = ZeroArrow Z x y.
+  Proof.
+    unfold limits.zero.ZeroArrow. unfold ZeroArrow.
+    rewrite equiv_ZeroArrowTo.
+    rewrite equiv_ZeroArrowFrom.
+    apply idpath.
+  Qed.
+
+End zero_coincides.
+
 
 (** Following Initial and Terminal, we clear implicit arguments. *)
 Arguments Zero : clear implicits.

--- a/UniMath/CategoryTheory/limits/pushouts.v
+++ b/UniMath/CategoryTheory/limits/pushouts.v
@@ -21,7 +21,7 @@ Section def_po.
   Definition isPushout {a b c d : C} (f : a --> b) (g : a --> c)
              (in1 : b --> d) (in2 : c --> d) (H : f ;; in1 = g ;; in2) : UU :=
     Π e (h : b --> e) (k : c --> e)(H : f ;; h = g ;; k),
-      iscontr (total2 (fun hk : d --> e => dirprod (in1 ;; hk = h) (in2 ;; hk = k))).
+    iscontr (total2 (fun hk : d --> e => dirprod (in1 ;; hk = h) (in2 ;; hk = k))).
 
   Lemma isaprop_isPushout {a b c d : C} (f : a --> b) (g : a --> c)
         (in1 : b --> d) (in2 : c --> d) (H : f ;; in1 = g ;; in2) :

--- a/UniMath/Foundations/Combinatorics/StandardFiniteSets.v
+++ b/UniMath/Foundations/Combinatorics/StandardFiniteSets.v
@@ -1001,6 +1001,27 @@ Proof.
   exact (transportf (fun x => P (k,,x)) X H).
 Defined.
 
+Definition two := stn 2.
+
+Definition two_rec {A : UU} (a b : A) : stn 2 -> A.
+Proof.
+  intros A a b.
+  induction 1 as [n p].
+  induction n as [_|n _]; [apply a|].
+  induction n as [_|n _]; [apply b|].
+  induction (nopathsfalsetotrue p).
+Defined.
+
+Definition two_rec_dep (P : two -> UU):
+  P (● 0) -> P (● 1) -> Π n, P n.
+Proof.
+  intros P a b n.
+  induction n as [n p].
+  induction n as [_|n _]. eapply stn_predicate. apply a.
+  induction n as [_|n _]. eapply stn_predicate. apply b.
+  induction (nopathsfalsetotrue p).
+Defined.
+
 Definition three := stn 3.
 
 Definition three_rec {A : UU} (a b c : A) : stn 3 -> A.


### PR DESCRIPTION
Hi,

I formalized some special limits and colimits using graphs, following
graphs/pullbacks.v, and I showed these definitions coincide with direct
definitions. That is, we can construct the directly defined structures from
(co)limits structures and vice versa. 

I changed slightly the definition of diagram in graphs/colimits.v . This was 
needed(?) to have two edges, between same vertices, to map into different
morphisms in a precategory C. The new definition is needed for example in
graphs/equalizers.v .