### PR TITLE
remove Inductive three

### DIFF
--- a/UniMath/CategoryTheory/limits/graphs/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/graphs/pullbacks.v
@@ -2,7 +2,7 @@
 Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.Foundations.Basics.Propositions.
 Require Import UniMath.Foundations.Basics.Sets.
-
+Require Import UniMath.Foundations.Combinatorics.StandardFiniteSets.
 Require Import UniMath.CategoryTheory.precategories.
 
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
@@ -15,28 +15,40 @@ Section def_pb.
 Variable C : precategory.
 Variable hs: has_homsets C.
 
-Inductive three := One | Two | Three.
+Open Scope stn.
+Definition One : three := ● 0.
+Definition Two : three := ● 1.
+Definition Three : three := ● 2.
 
 Definition pushout_graph : graph.
 Proof.
   exists three.
-  exact (fun a b =>
-           match (a,b) with
-             | (One, Two) => unit
-             | (Three, Two) => unit
-             | _ => empty
-            end).
+  apply (@three_rec (three -> UU)).
+  - apply three_rec.
+    + apply empty.
+    + apply unit.
+    + apply empty.
+  - apply (fun _ => empty).
+  - apply three_rec.
+    + apply empty.
+    + apply unit.
+    + apply empty.
 Defined.
 
 Definition pullback_diagram {a b c : C} (f : C ⟦b,a⟧) (g : C⟦c,a⟧) :
   diagram pushout_graph C.
 Proof.
-  exists (fun x => match x with
-                     | One => b
-                     | Two => a
-                     | Three => c end).
-  intros u v e.
-  induction u; induction v; simpl; try induction e; assumption.
+  exists (three_rec b a c).
+  use (three_rec_dep); cbn.
+  - use three_rec_dep; cbn.
+    + apply fromempty.
+    + intro; assumption.
+    + apply fromempty.
+  - intro; apply fromempty.
+  - use three_rec_dep; cbn.
+    + apply fromempty.
+    + intro; assumption.
+    + apply fromempty.
 Defined.
 
 Definition PullbCone {a b c : C} (f : C ⟦b,a⟧) (g : C⟦c,a⟧)
@@ -45,12 +57,18 @@ Definition PullbCone {a b c : C} (f : C ⟦b,a⟧) (g : C⟦c,a⟧)
   : cone (pullback_diagram f g) d.
 Proof.
   simple refine (mk_cone _ _  ).
-  - intro v; induction v; simpl; try assumption.
+  - use three_rec_dep; cbn; try assumption.
     apply (f' ;; f).
-  - intros u v e;
-    induction u; induction v; try induction e; simpl.
-    + apply idpath.
-    + apply (!H).
+  - use three_rec_dep; cbn; use three_rec_dep; cbn.
+    + exact (Empty_set_rect _ ).
+    + intro. apply idpath.
+    + exact (Empty_set_rect _ ).
+    + exact (Empty_set_rect _ ).
+    + exact (Empty_set_rect _ ).
+    + exact (Empty_set_rect _ ).
+    + exact (Empty_set_rect _ ).
+    + intro; apply (!H).
+    + exact (Empty_set_rect _ ).
 Defined.
 
 Definition isPullback {a b c d : C} (f : C ⟦b, a⟧) (g : C ⟦c, a⟧)
@@ -79,7 +97,7 @@ Proof.
   - set (H2 := H1 p).
     simple refine (tpair _ _ _ ).
     + exists (pr1 (pr1 H2)).
-      intro v; induction v; simpl.
+      use three_rec_dep; cbn.
       * apply (pr1 (pr2 (pr1 H2))).
       * unfold compose.
         simpl.
@@ -170,11 +188,18 @@ Definition PullbackArrow {a b c : C} {f : C⟦b, a⟧} {g : C⟦c, a⟧}
 Proof.
   simple refine (limArrow _ _ _ ).
   simple refine (mk_cone _ _ ).
-  - intro v; induction v; simpl; try assumption.
+  - use three_rec_dep; cbn; try assumption.
     apply (h ;; f).
-  - intros u v edg; induction u; induction v; try induction edg; simpl.
-    + apply idpath.
-    + apply (!H).
+  - use three_rec_dep; cbn; use three_rec_dep; cbn.
+    + exact (Empty_set_rect _ ).
+    + intro. apply idpath.
+    + exact (Empty_set_rect _ ).
+    + exact (Empty_set_rect _ ).
+    + exact (Empty_set_rect _ ).
+    + exact (Empty_set_rect _ ).
+    + exact (Empty_set_rect _ ).
+    + intro; apply (!H).
+    + exact (Empty_set_rect _ ).
 Defined.
 
 Lemma PullbackArrow_PullbackPr1 {a b c : C} {f : C⟦b , a⟧} {g : C⟦c , a⟧}
@@ -200,7 +225,7 @@ Lemma PullbackArrowUnique {a b c d : C} (f : C⟦b , a⟧) (g : C⟦c , a⟧)
   w = PullbackArrow Pb _ h k Hcomm.
 Proof.
   apply path_to_ctr.
-  intro v; induction v; simpl; try assumption.
+  use three_rec_dep; cbn; try assumption.
   set (X:= limOutCommutes Pb Three Two tt).
   eapply pathscomp0. apply maponpaths.
    eapply pathsinv0.
@@ -256,9 +281,10 @@ Proof.
         assert (XRT := coneOutCommutes cc One Two tt); simpl in XRT;
         eapply pathscomp0; [| apply (XRT)]; apply idpath
          ).
-    + simpl. intro v; induction v; simpl.
+    + use three_rec_dep; cbn.
       * abstract (apply (pullbacks.PullbackArrow_PullbackPr1 XR)).
       * abstract (
+        simpl; cbn; unfold idfun;
         rewrite assoc;
         rewrite  (limits.pullbacks.PullbackArrow_PullbackPr1 XR);
         assert (XRT := coneOutCommutes cc One Two tt); simpl in XRT;
@@ -321,7 +347,7 @@ Lemma PullbackArrowUnique' {a b c d : C} (f : C⟦b , a⟧) (g : C⟦c , a⟧)
      w =  (pr1 (pr1 (P e (PullbCone f g _ h k Hcomm)))).
 Proof.
   apply path_to_ctr.
-  intro v; induction v; simpl.
+  use three_rec_dep; cbn.
   - assumption.
   - unfold compose; simpl.
     eapply pathscomp0. apply assoc.
@@ -337,16 +363,15 @@ Lemma PullbackEndo_is_identity {a b c : C}{f : C⟦b , a⟧} {g : C⟦c , a⟧}
        identity (lim Pb) = k.
 Proof.
   apply lim_endo_is_identity.
-  intro u; induction u; simpl.
+  use three_rec_dep.
   - apply kH1.
   - unfold limOut. simpl.
     assert (T:= coneOutCommutes (limCone Pb) Three Two tt).
-    rewrite <- T.
-    simpl.
+    eapply pathscomp0. apply maponpaths. apply (!T).
     rewrite assoc.
     eapply pathscomp0. apply cancel_postcomposition.
        apply kH2.
-       apply idpath.
+       apply T.
  - assumption.
 Qed.
 

--- a/UniMath/Foundations/Combinatorics/StandardFiniteSets.v
+++ b/UniMath/Foundations/Combinatorics/StandardFiniteSets.v
@@ -989,3 +989,37 @@ Proof.
   { apply invweq. apply (weqfp _ (stn∘x)). }
   apply weqstnsum1.
 Defined.
+
+
+Definition stn_predicate {n : nat} (P : stn n -> UU)
+           (k : nat) (h h' : k < n) :
+           P (k,,h) -> P (k,,h').
+Proof.
+  intros n P k h h' H.
+  transparent assert (X : (h = h')).
+  { apply propproperty. }
+  exact (transportf (fun x => P (k,,x)) X H).
+Defined.
+
+Definition three := stn 3.
+
+Definition three_rec {A : UU} (a b c : A) : stn 3 -> A.
+Proof.
+  intros A a b c.
+  induction 1 as [n p].
+  induction n as [_|n _]; [apply a|].
+  induction n as [_|n _]; [apply b|].
+  induction n as [_|n _]; [apply c|].
+  induction (nopathsfalsetotrue p).
+Defined.
+
+Definition three_rec_dep (P : three -> UU):
+  P (● 0) -> P (● 1) -> P (● 2) -> Π n, P n.
+Proof.
+  intros P a b c n.
+  induction n as [n p].
+  induction n as [_|n _]. eapply stn_predicate. apply a.
+  induction n as [_|n _]. eapply stn_predicate. apply b.
+  induction n as [_|n _]. eapply stn_predicate. apply c.
+  induction (nopathsfalsetotrue p).
+Defined.

--- a/UniMath/SubstitutionSystems/MLTT79.v
+++ b/UniMath/SubstitutionSystems/MLTT79.v
@@ -51,15 +51,6 @@ Local Notation "'HSET2'":= [HSET, HSET, has_homsets_HSET].
 
 Section preamble.
 
-Definition three_rec {A : UU} (a b c : A) : stn 3 -> A.
-Proof.
-induction 1 as [n p].
-induction n as [_|n _]; [apply a|].
-induction n as [_|n _]; [apply b|].
-induction n as [_|n _]; [apply c|].
-induction (nopathsfalsetotrue p).
-Defined.
-
 Definition four_rec {A : UU} (a b c d : A) : stn 4 -> A.
 Proof.
 induction 1 as [n p].


### PR DESCRIPTION
replace the inductive type `three` by `stn 3`

- leads to some increase in compile time, in particular in nested applications of the dependent eliminator