### PR TITLE
Added Grothendieck toposes

### DIFF
--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -85,3 +85,7 @@ Morphisms.v
 AdditiveFunctors.v
 LocalizingClass.v
 DiscretePrecategory.v
+UnderPrecategories.v
+Subobjects.v
+Quotobjects.v
+GrothendieckTopos.v

--- a/UniMath/CategoryTheory/Abelian.v
+++ b/UniMath/CategoryTheory/Abelian.v
@@ -2,9 +2,9 @@
 (** ** Contents
 - Definition of Abelian categories
 - If Monic and Epi, then iso
-- Pushouts of subobjects and pullbacks of quotient objects
- - Pushouts of subobjects
- - Pullbacks of quotient objects
+- Pushouts of monics and pullbacks of epis
+ - Pushouts of monics
+ - Pullbacks of epis
 - Equalizers and Coequalizers
  - Equalizers
  - Coequalizers
@@ -232,10 +232,10 @@ Section abelian_monic_epi_iso.
 End abelian_monic_epi_iso.
 
 
-(** * Pullbacks of subjects and pushouts of quotient objects
+(** * Pullbacks of monics and pushouts of epis
   In the following section we prove that an abelian category has pullbacks of
-  subobjects and pushouts of quotient objects. *)
-Section abelian_subobject_pullbacks.
+  monics and pushouts of epis. *)
+Section abelian_monic_pullbacks.
 
   Variable A : AbelianPreCat.
   Hypothesis hs : has_homsets A.
@@ -540,7 +540,7 @@ Section abelian_subobject_pullbacks.
                     (epis_Pushout_isPushout E1 E2 BinCoprod coker)).
   Defined.
 
-End abelian_subobject_pullbacks.
+End abelian_monic_pullbacks.
 
 (** * Equalizers and Coequalizers
   In the following section we show that equalizers and coequalizers exist in

--- a/UniMath/CategoryTheory/Epis.v
+++ b/UniMath/CategoryTheory/Epis.v
@@ -1,21 +1,41 @@
-(* Definition of epi *)
+(** * Epis *)
+(** ** Contents
+- Definition of Epis
+- Construction of the subcategory of Epis
+- Construction of Epis in functor categories
+*)
+
 Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.Foundations.Basics.Propositions.
 Require Import UniMath.Foundations.Basics.Sets.
 
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.sub_precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
 
+
+(** * Definition of Epis *)
 Section def_epi.
 
   Variable C : precategory.
+  Hypothesis hs : has_homsets C.
 
   (** Definition and construction of isEpi. *)
   Definition isEpi {x y : C} (f : x --> y) : UU :=
     Π (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h.
-  Definition mk_isEpi {x y : C} (f : x --> y) :
-    (Π (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h) -> isEpi f.
-  Proof. intros X. unfold isEpi. apply X.  Defined.
+
+  Definition mk_isEpi {x y : C} (f : x --> y)
+             (H : Π (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h) : isEpi f := H.
+
+  Lemma isapropisEpi {y z : C} (f : y --> z) : isaprop (isEpi f).
+  Proof.
+    apply impred_isaprop; intros t.
+    apply impred_isaprop; intros g.
+    apply impred_isaprop; intros h.
+    apply impred_isaprop; intros H.
+    apply hs.
+  Qed.
 
   (** Definition and construction of Epi. *)
   Definition Epi (x y : C) : UU := Σ f : x --> y, isEpi f.
@@ -36,14 +56,20 @@ Section def_epi.
   Defined.
 
   Lemma iso_Epi {x y : C} (f : x --> y) (H : is_iso f) : Epi x y.
-  Proof. apply (mk_Epi f (iso_isEpi f H)). Defined.
+  Proof.
+    apply (mk_Epi f (iso_isEpi f H)).
+  Defined.
 
   (** Identity to isEpi and Epi. *)
   Lemma identity_isEpi {x : C} : isEpi (identity x).
-  Proof. apply (iso_isEpi (identity x) (identity_is_iso _ x)). Defined.
+  Proof.
+    apply (iso_isEpi (identity x) (identity_is_iso _ x)).
+  Defined.
 
   Lemma identity_Epi {x : C} : Epi x x.
-  Proof. exact (tpair _ (identity x) (identity_isEpi)). Defined.
+  Proof.
+    exact (tpair _ (identity x) (identity_isEpi)).
+  Defined.
 
   (** Composition of isEpis and Epis. *)
   Definition isEpi_comp {x y z : C} (f : x --> y) (g : y --> z) :
@@ -57,8 +83,7 @@ Section def_epi.
     Epi x z := tpair _ (E1 ;; E2) (isEpi_comp E1 E2 (pr2 E1) (pr2 E2)).
 
   (** If precomposition of g with f is an epi, then g is an epi. *)
-  Definition isEpi_precomp {x y z : C} (f : x --> y) (g : y --> z) :
-    isEpi (f ;; g) -> isEpi g.
+  Definition isEpi_precomp {x y z : C} (f : x --> y) (g : y --> z) : isEpi (f ;; g) -> isEpi g.
   Proof.
     intros X. intros w φ ψ H.
     apply (maponpaths (fun g' => f ;; g')) in H.
@@ -68,3 +93,56 @@ Section def_epi.
 
 End def_epi.
 Arguments isEpi [C] [x] [y] _.
+
+
+(** * Construction of the subcategory consisting of all epis. *)
+Section epis_subcategory.
+
+  Variable C : precategory.
+  Hypothesis hs : has_homsets C.
+
+  Definition hsubtypes_obs_isEpi : hsubtypes C := (fun c : C => hProppair _ isapropunit).
+
+  Definition hsubtypes_mors_isEpi : Π (a b : C), hsubtypes (C⟦a, b⟧) :=
+    (fun a b : C => (fun f : C⟦a, b⟧ => hProppair _ (isapropisEpi C hs f))).
+
+  Definition subprecategory_of_epis : sub_precategories C.
+  Proof.
+    use tpair.
+    split.
+    - exact hsubtypes_obs_isEpi.
+    - exact hsubtypes_mors_isEpi.
+    - cbn. unfold is_sub_precategory. cbn.
+      split.
+      + intros a tt. exact (identity_isEpi C).
+      + apply isEpi_comp.
+  Defined.
+
+  Definition has_homsets_subprecategory_of_epis : has_homsets subprecategory_of_epis.
+  Proof.
+    intros a b.
+    apply is_set_sub_precategory_morphisms.
+    exact hs.
+  Qed.
+
+  Definition subprecategory_of_epis_ob (c : C) : ob (subprecategory_of_epis) := tpair _ c tt.
+
+End epis_subcategory.
+
+
+(** * In functor categories epis can be constructed from pointwise epis *)
+Section epis_functorcategories.
+
+  Lemma is_nat_trans_epi_from_pointwise_epis (C D : precategory) (hs : has_homsets D)
+        (F G : ob (functor_precategory C D hs)) (α : F --> G) (H : Π a : ob C, isEpi (pr1 α a)) :
+    isEpi α.
+  Proof.
+    intros G' β η H'.
+    use (nat_trans_eq hs).
+    intros x.
+    set (H'' := nat_trans_eq_pointwise H' x). cbn in H''.
+    apply (H x) in H''.
+    exact H''.
+  Qed.
+
+End epis_functorcategories.

--- a/UniMath/CategoryTheory/GrothendieckTopos.v
+++ b/UniMath/CategoryTheory/GrothendieckTopos.v
@@ -1,0 +1,194 @@
+(** * Grothendick toposes *)
+(** ** Contents
+- Definition of Grothendieck topology
+ - Grothendieck topologies
+ - Precategory of sheaves
+- Grothendieck toposes
+*)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.limits.pullbacks.
+Require Import UniMath.CategoryTheory.limits.equalizers.
+Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.limits.pullbacks.
+Require Import UniMath.CategoryTheory.slicecat.
+Require Import UniMath.CategoryTheory.Monics.
+Require Import UniMath.CategoryTheory.Subobjects.
+Require Import UniMath.CategoryTheory.yoneda.
+Require Import UniMath.CategoryTheory.category_hset.
+Require Import UniMath.CategoryTheory.opp_precat.
+Require Import UniMath.CategoryTheory.category_hset_structures.
+Require Import UniMath.CategoryTheory.limits.graphs.pullbacks.
+Require Import UniMath.CategoryTheory.limits.graphs.equalizers.
+Require Import UniMath.CategoryTheory.sub_precategories.
+Require Import UniMath.CategoryTheory.equivalences.
+
+(** HSET Pullbacks and Equalizers from limits to direct definition *)
+Section HSET_Structures.
+
+  Definition HSET_Pullbacks : @limits.pullbacks.Pullbacks HSET :=
+    equiv_Pullbacks_2 HSET has_homsets_HSET PullbacksHSET.
+
+  Definition HSET_Equalizers: @limits.equalizers.Equalizers HSET :=
+    equiv_Equalizers2 HSET has_homsets_HSET EqualizersHSET.
+
+End HSET_Structures.
+
+(** * Definiton of Grothendieck topology
+    The following definition is a formalization of the definition in Sheaves in Geometry and Logic,
+    Saunders Mac Lane and Ieke Moerdijk, pages 109 and 110.
+
+    Grothendieck topology is a collection J(c) of subobjects of the Yoneda functor, for every object
+    of C, such that:
+    - The Yoneda functor y(c) is in J(c).
+    - Pullback of a subobject in J(c) along any morphism h : c' --> c is in J(c')
+    - If S is a subobject of y(c) such that for all objects c' and all morphisms
+      h : c' --> c in C the pullback of S along h is in J(c'), then S is in J(c).
+  *)
+Section def_grothendiecktopology.
+
+  Variable C : precategory.
+  Hypothesis hs : has_homsets C.
+
+  (** A sieve on c is a subobject of the yoneda functor. *)
+  Definition sieve (c : C) : UU :=
+    SubobjectsPrecategory
+      (functor_precategory (opp_precat C) HSET has_homsets_HSET)
+      (functor_category_has_homsets (opp_precat C) HSET has_homsets_HSET)
+      (yoneda C hs c).
+
+  (* Coq does not automatically convert the following types *)
+  Definition FunctorPrecatObToFunctor
+             (c : functor_precategory (opp_precat C) HSET has_homsets_HSET) :
+    functor (opp_precat C) HSET := c.
+
+  Definition FunctorPrecatMorToNatTrans
+             {c c': functor_precategory (opp_precat C) HSET has_homsets_HSET} (h : c --> c') :
+    nat_trans (FunctorPrecatObToFunctor c) (FunctorPrecatObToFunctor c') := h.
+
+  Definition sieve_functor {c : C} (S : sieve c) : functor (opp_precat C) HSET :=
+    precategory_object_from_sub_precategory_object _ _ (slicecat_ob_object _ _ S).
+
+  Definition sieve_nat_trans {c : C} (S : sieve c) :
+    nat_trans (sieve_functor S) (FunctorPrecatObToFunctor (yoneda C hs c)) :=
+    precategory_morphism_from_sub_precategory_morphism _ _ _ _ (slicecat_ob_morphism _ _ S).
+
+
+  (** ** Grothendieck topology *)
+
+  Definition collection_of_sieves : UU := Π (c : C), hsubtypes (sieve c).
+
+  Definition isGrothendieckTopology_maximal_sieve (COS : collection_of_sieves) : UU :=
+    Π (c : C), COS c (SubobjectsPrecategory_ob
+                        (functor_precategory (opp_precat C) HSET has_homsets_HSET)
+                        (functor_category_has_homsets (opp_precat C) HSET has_homsets_HSET)
+                        (identity (yoneda C hs c)) (identity_isMonic _)).
+
+  Definition isGrothendieckTopology_stability (COS : collection_of_sieves) : UU :=
+    Π (c c' : C) (h : c' --> c) (s : sieve c),
+    COS c s ->
+    COS c' (PullbackSubobject
+              _ _
+              (FunctorPrecategoryPullbacks (opp_precat C) HSET has_homsets_HSET HSET_Pullbacks)
+              s (yoneda_morphisms C hs _ _ h)).
+
+  Definition isGrothendieckTopology_transitivity (COS : collection_of_sieves) : UU :=
+    Π (c : C) (s : sieve c),
+    (Π (c' : C) (h : c' --> c),
+     COS c' (PullbackSubobject
+               _ _
+               (FunctorPrecategoryPullbacks (opp_precat C) HSET has_homsets_HSET HSET_Pullbacks)
+               s (yoneda_morphisms C hs _ _ h))
+     -> COS c s).
+
+  Definition isGrothendieckTopology (COS : collection_of_sieves) : UU :=
+    (isGrothendieckTopology_maximal_sieve COS)
+      × (isGrothendieckTopology_stability COS)
+      × (isGrothendieckTopology_transitivity COS).
+
+  Definition GrothendieckTopology : UU :=
+    Σ COS : collection_of_sieves, isGrothendieckTopology COS.
+
+  (** Accessor functions *)
+  Definition GrothendieckTopology_COS (GT : GrothendieckTopology) : collection_of_sieves := pr1 GT.
+
+  Definition GrothendieckTopology_isGrothendieckTopology (GT : GrothendieckTopology) :
+    isGrothendieckTopology (GrothendieckTopology_COS GT) := pr2 GT.
+
+
+  (** ** Sheaves *)
+
+  (** For some reason I need the following *)
+  Definition Presheaf : UU := functor (opp_precat C) HSET.
+
+  Definition PresheafToFunctor (P : Presheaf) : functor (opp_precat C) HSET := P.
+
+  Definition mk_Presheaf (F : functor (opp_precat C) HSET) : Presheaf := F.
+
+  (** This is a formalization of the definition on page 122 *)
+  Definition isSheaf (P : Presheaf) (GT : GrothendieckTopology) : UU :=
+    Π (c : C) (S : sieve c) (isCOS : GrothendieckTopology_COS GT c S)
+      (τ : nat_trans (sieve_functor S) (PresheafToFunctor P)),
+    iscontr (Σ η : nat_trans (FunctorPrecatObToFunctor (yoneda C hs c)) (PresheafToFunctor P),
+                   nat_trans_comp _ _ _ (sieve_nat_trans S) η = τ).
+
+  Lemma isaprop_isSheaf (GT : GrothendieckTopology) (P : Presheaf) : isaprop(isSheaf P GT).
+  Proof.
+    apply impred_isaprop; intros t.
+    apply impred_isaprop; intros S.
+    apply impred_isaprop; intros isCOS.
+    apply impred_isaprop; intros τ.
+    apply isapropiscontr.
+  Qed.
+
+  (** The category of sheaves is the full subcategory of presheaves consisting of the presheaves
+      which satisfy the isSheaf proposition. *)
+  Definition hsubtypes_obs_isSheaf (GT : GrothendieckTopology) :
+    hsubtypes (functor_precategory (opp_precat C) HSET has_homsets_HSET) :=
+    (fun P : functor_precategory (opp_precat C) HSET has_homsets_HSET =>
+       hProppair _ (isaprop_isSheaf GT (mk_Presheaf P))).
+
+  Definition PrecategoryOfSheaves (GT : GrothendieckTopology) :
+    sub_precategories (functor_precategory (opp_precat C) HSET has_homsets_HSET) :=
+    full_sub_precategory (hsubtypes_obs_isSheaf GT).
+
+End def_grothendiecktopology.
+
+
+(** * Definition of Grothendieck topos
+    Grothendieck topos is a precategory which is equivalent to the category of sheaves on some
+    Grothendieck topology. *)
+Section def_grothendiecktopos.
+
+  Variable C : precategory.
+  Hypothesis hs : has_homsets C.
+
+  (** Here (pr1 D) is the precategory which is equivalent to the precategory of sheaves on the
+      Grothendieck topology (pr2 D). *)
+  Definition GrothendieckTopos : UU :=
+    Σ D' : (Σ D : precategory × (GrothendieckTopology C hs),
+                  functor (pr1 D) (PrecategoryOfSheaves C hs (pr2 D))),
+           (adj_equivalence_of_precats (pr2 D')).
+
+  (** Accessor functions *)
+  Definition GrothendieckTopos_precategory (GT : GrothendieckTopos) : precategory :=
+    pr1 (pr1 (pr1 GT)).
+  Coercion GrothendieckTopos_precategory : GrothendieckTopos >-> precategory.
+
+  Definition GrothendieckTopos_GrothendieckTopology (GT : GrothendieckTopos) :
+    GrothendieckTopology C hs := pr2 (pr1 (pr1 GT)).
+
+  Definition GrothendieckTopos_functor (GT : GrothendieckTopos) :
+    functor (GrothendieckTopos_precategory GT)
+            (PrecategoryOfSheaves C hs (GrothendieckTopos_GrothendieckTopology GT)) :=
+    pr2 (pr1 GT).
+
+  Definition GrothendieckTopos_equivalence (GT : GrothendieckTopos) :
+    adj_equivalence_of_precats (GrothendieckTopos_functor GT) := pr2 GT.
+
+End def_grothendiecktopos.

--- a/UniMath/CategoryTheory/Monics.v
+++ b/UniMath/CategoryTheory/Monics.v
@@ -1,26 +1,46 @@
-(* Definition of monic *)
+(** * Monics *)
+(** ** Contents
+- Definitions of Monics
+- Construction of the subcategory of Monics
+- Construction of monics in functor categories
+*)
+
 Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.Foundations.Basics.Propositions.
 Require Import UniMath.Foundations.Basics.Sets.
 
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.sub_precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
 
+
+(** * Definition of Monics *)
 Section def_monic.
 
   Variable C : precategory.
+  Hypothesis hs : has_homsets C.
 
   (** Definition and construction of isMonic. *)
   Definition isMonic {y z : C} (f : y --> z) : UU :=
     Π (x : C) (g h : x --> y), g ;; f = h ;; f -> g = h.
-  Definition mk_isMonic {y z : C} (f : y --> z) :
-    (Π (x : C) (g h : x --> y), g ;; f = h ;; f -> g = h) -> isMonic f.
-  Proof. intros X. unfold isMonic. apply X.  Defined.
+
+  Definition mk_isMonic {y z : C} (f : y --> z)
+             (H : Π (x : C) (g h : x --> y), g ;; f = h ;; f -> g = h) : isMonic f := H.
+
+  Lemma isapropisMonic {y z : C} (f : y --> z) : isaprop (isMonic f).
+  Proof.
+    apply impred_isaprop; intros t.
+    apply impred_isaprop; intros g.
+    apply impred_isaprop; intros h.
+    apply impred_isaprop; intros H.
+    apply hs.
+  Qed.
 
   (** Definition and construction of Monic. *)
   Definition Monic (y z : C) : UU := Σ f : y --> z, isMonic f.
-  Definition mk_Monic {y z : C} (f : y --> z) (H : isMonic f) :
-    Monic y z := tpair _ f H.
+
+  Definition mk_Monic {y z : C} (f : y --> z) (H : isMonic f) : Monic y z := tpair _ f H.
 
   (** Gets the arrow out of Monic. *)
   Definition MonicArrow {y z : C} (M : Monic y z) : C⟦y, z⟧ := pr1 M.
@@ -36,14 +56,20 @@ Section def_monic.
   Defined.
 
   Lemma iso_Monic {y x : C} (f : y --> x) (H : is_iso f) : Monic y x.
-  Proof. apply (mk_Monic f (iso_isMonic f H)). Defined.
+  Proof.
+    apply (mk_Monic f (iso_isMonic f H)).
+  Defined.
 
   (** Identity to isMonic and Monic. *)
   Lemma identity_isMonic {x : C} : isMonic (identity x).
-  Proof. apply (iso_isMonic (identity x) (identity_is_iso _ x)). Defined.
+  Proof.
+    apply (iso_isMonic (identity x) (identity_is_iso _ x)).
+  Defined.
 
   Lemma identity_Monic {x : C} : Monic x x.
-  Proof. exact (tpair _ (identity x) (identity_isMonic)). Defined.
+  Proof.
+    exact (tpair _ (identity x) (identity_isMonic)).
+  Defined.
 
   (** Composition of isMonics and Monics. *)
   Definition isMonic_comp {x y z : C} (f : x --> y) (g : y --> z) :
@@ -68,3 +94,60 @@ Section def_monic.
 
 End def_monic.
 Arguments isMonic [C] [y] [z] _.
+
+
+(** * Construction of the subcategory consisting of all monics. *)
+Section monics_subcategory.
+
+  Variable C : precategory.
+  Hypothesis hs : has_homsets C.
+
+  Definition hsubtypes_obs_isMonic : hsubtypes C := (fun c : C => hProppair _ isapropunit).
+
+  Definition hsubtypes_mors_isMonic : Π (a b : C), hsubtypes (C⟦a, b⟧) :=
+    (fun a b : C => (fun f : C⟦a, b⟧ => hProppair _ (isapropisMonic C hs f))).
+
+  Definition subprecategory_of_monics : sub_precategories C.
+  Proof.
+    use tpair.
+    split.
+    - exact hsubtypes_obs_isMonic.
+    - exact hsubtypes_mors_isMonic.
+    - cbn. unfold is_sub_precategory. cbn.
+      split.
+      + intros a tt. exact (identity_isMonic C).
+      + apply isMonic_comp.
+  Defined.
+
+  Definition has_homsets_subprecategory_of_monics : has_homsets subprecategory_of_monics.
+  Proof.
+    intros a b.
+    apply is_set_sub_precategory_morphisms.
+    exact hs.
+  Qed.
+
+  Definition subprecategory_of_monics_ob (c : C) : ob (subprecategory_of_monics) := tpair _ c tt.
+
+  Definition subprecategory_of_monics_mor {c' c : C} (f : c' --> c) (isM : isMonic f) :
+    subprecategory_of_monics⟦subprecategory_of_monics_ob c', subprecategory_of_monics_ob c⟧ :=
+    tpair _ f isM.
+
+End monics_subcategory.
+
+
+(** * In functor categories monics can be constructed from pointwise monics *)
+Section monics_functorcategories.
+
+  Lemma is_nat_trans_monic_from_pointwise_monics (C D : precategory) (hs : has_homsets D)
+        (F G : ob (functor_precategory C D hs)) (α : F --> G) (H : Π a : ob C, isMonic (pr1 α a)) :
+    isMonic α.
+  Proof.
+    intros G' β η H'.
+    use (nat_trans_eq hs).
+    intros x.
+    set (H'' := nat_trans_eq_pointwise H' x). cbn in H''.
+    apply (H x) in H''.
+    exact H''.
+  Qed.
+
+End monics_functorcategories.

--- a/UniMath/CategoryTheory/Quotobjects.v
+++ b/UniMath/CategoryTheory/Quotobjects.v
@@ -1,0 +1,46 @@
+(** * Quotobjects *)
+
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.UnderPrecategories.
+Require Import UniMath.CategoryTheory.Epis.
+Require Import UniMath.CategoryTheory.sub_precategories.
+
+Require Import UniMath.CategoryTheory.limits.pushouts.
+
+
+(** * Definition of quotient objects *)
+Section def_quotobjects.
+
+  Variable C : precategory.
+  Hypothesis hs : has_homsets C.
+
+  Definition QuotobjectsPrecategory (c : C) : UU :=
+    UnderPrecategory (subprecategory_of_epis C hs)
+                     (has_homsets_subprecategory_of_epis C hs)
+                     (subprecategory_of_epis_ob C hs c).
+
+  (** Construction of a quotient object from an epi *)
+  Definition QuotobjectsPrecategory_ob {c c' : C} (h : C⟦c, c'⟧) (isE : isEpi h) :
+    QuotobjectsPrecategory c := tpair _ (subprecategory_of_epis_ob C hs c') (tpair _ h isE).
+
+  Hypothesis hpo : @Pushouts C.
+
+  (** Given any quotient object Q of c and a morphism h : c -> c', by taking then pushout of Q by h
+      we obtain a quotient object of c'. *)
+  Definition PushoutQuotobject {c : C} (Q : QuotobjectsPrecategory c) {c' : C} (h : C⟦c, c'⟧) :
+    QuotobjectsPrecategory c'.
+  Proof.
+    set (po := hpo _ _ _ h (pr1 (pr2 Q))).
+    use QuotobjectsPrecategory_ob.
+    - exact po.
+    - exact (limits.pushouts.PushoutIn1 po).
+    - use EpiPushoutisEpi'.
+  Defined.
+
+End def_quotobjects.

--- a/UniMath/CategoryTheory/Subobjects.v
+++ b/UniMath/CategoryTheory/Subobjects.v
@@ -1,0 +1,46 @@
+(** * Subobjects *)
+
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.slicecat.
+Require Import UniMath.CategoryTheory.Monics.
+Require Import UniMath.CategoryTheory.sub_precategories.
+
+Require Import UniMath.CategoryTheory.limits.pullbacks.
+
+
+(** * Definition of subobjects *)
+Section def_subobjects.
+
+  Variable C : precategory.
+  Hypothesis hs : has_homsets C.
+
+  Definition SubobjectsPrecategory (c : C) : UU :=
+    slice_precat (subprecategory_of_monics C hs)
+                 (subprecategory_of_monics_ob C hs c)
+                 (has_homsets_subprecategory_of_monics C hs).
+
+  (** Construction of a subobject from a monic *)
+  Definition SubobjectsPrecategory_ob {c c' : C} (h : C⟦c', c⟧) (isM : isMonic h) :
+    SubobjectsPrecategory c := tpair _ (subprecategory_of_monics_ob C hs c') (tpair _ h isM).
+
+  Hypothesis hpb : @Pullbacks C.
+
+  (** Given any subobject S of c and a morphism h : c' -> c, by taking then pullback of S by h we
+      obtain a subobject of c'. *)
+  Definition PullbackSubobject {c : C} (S : SubobjectsPrecategory c) {c' : C} (h : C⟦c', c⟧) :
+    SubobjectsPrecategory c'.
+  Proof.
+    set (pb := hpb _ _ _ h (pr1 (pr2 S))).
+    use SubobjectsPrecategory_ob.
+    - exact pb.
+    - exact (limits.pullbacks.PullbackPr1 pb).
+    - use MonicPullbackisMonic'.
+  Defined.
+
+End def_subobjects.

--- a/UniMath/CategoryTheory/UnderPrecategories.v
+++ b/UniMath/CategoryTheory/UnderPrecategories.v
@@ -1,0 +1,167 @@
+(** Undercategories *)
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+
+Section def_underprecategories.
+
+  Variable C : precategory.
+  Hypothesis hs : has_homsets C.
+  Variable c : ob C.
+
+  (* Objects *)
+  Definition Under_ob : UU := Σ d, C⟦c, d⟧.
+
+  Definition mk_Under_ob {d : ob C} (f : C⟦c, d⟧) : Under_ob := tpair _ d f.
+
+  (* Accessor functions *)
+  Definition Under_ob_cod (X : Under_ob) : ob C := pr1 X.
+
+  Definition Under_ob_mor (X : Under_ob) : C⟦c, Under_ob_cod X⟧ := pr2 X.
+
+  (* Morphisms *)
+  Definition Under_mor (X Y : Under_ob) : UU :=
+    Σ f : C⟦Under_ob_cod X, Under_ob_cod Y⟧, Under_ob_mor X ;; f = Under_ob_mor Y.
+
+  Definition mk_Under_mor (X Y : Under_ob) (f : C⟦Under_ob_cod X, Under_ob_cod Y⟧)
+             (H : Under_ob_mor X ;; f = Under_ob_mor Y) : Under_mor X Y := tpair _ f H.
+
+  (* Accessor functions *)
+  Definition Under_mor_mor {X Y : Under_ob} (M : Under_mor X Y) :
+    C⟦Under_ob_cod X, Under_ob_cod Y⟧ := pr1 M.
+
+  Definition Under_mor_eq {X Y : Under_ob} (M : Under_mor X Y) :
+    Under_ob_mor X ;; Under_mor_mor M = Under_ob_mor Y := pr2 M.
+
+  (* An undercategory has_homsets *)
+  Definition isaset_Under_mor (X Y : Under_ob) : isaset (Under_mor X Y).
+  Proof.
+    apply (isofhleveltotal2 2).
+    - apply hs.
+    - intros x.
+      apply hlevelntosn.
+      apply hs.
+  Qed.
+
+  Definition Under_mor_equality (X Y : Under_ob) (f f' : Under_mor X Y) : pr1 f = pr1 f' -> f = f'.
+  Proof.
+    intro H.
+    apply subtypeEquality.
+    intro x.
+    apply hs.
+    exact H.
+  Qed.
+
+  Definition Under_id (X : Under_ob) : Under_mor X X := mk_Under_mor X X (identity _) (id_right _ ).
+
+  Local Lemma Under_comp_eq {X Y Z : Under_ob} (f : Under_mor X Y) (g : Under_mor Y Z) :
+    Under_ob_mor X ;; (Under_mor_mor f ;; Under_mor_mor g) = Under_ob_mor Z.
+  Proof.
+    rewrite assoc.
+    rewrite (Under_mor_eq f).
+    exact (Under_mor_eq g).
+  Qed.
+
+  Definition Under_comp (X Y Z : Under_ob) : Under_mor X Y -> Under_mor Y Z -> Under_mor X Z.
+  Proof.
+    intros f g.
+    exact (mk_Under_mor X Z (Under_mor_mor f ;; Under_mor_mor g) (Under_comp_eq f g)).
+  Defined.
+
+  Definition UnderPrecategory_ob_mor : precategory_ob_mor.
+  Proof.
+    exists Under_ob.
+    exact Under_mor.
+  Defined.
+
+  Definition UnderPrecategory_data : precategory_data.
+  Proof.
+    exists UnderPrecategory_ob_mor.
+    split.
+    - exact Under_id.
+    - exact Under_comp.
+  Defined.
+
+  Definition is_precategory_UnderPrecategory_data : is_precategory UnderPrecategory_data.
+  Proof.
+    repeat split.
+    - intros. apply Under_mor_equality. apply id_left.
+    - intros. apply Under_mor_equality. apply id_right.
+    - intros. apply Under_mor_equality. apply assoc.
+  Defined.
+
+  Definition UnderPrecategory : precategory.
+  Proof.
+    exists UnderPrecategory_data.
+    exact is_precategory_UnderPrecategory_data.
+  Defined.
+
+  Lemma has_homsets_Under : has_homsets UnderPrecategory.
+  Proof.
+    intros X Y.
+    apply (isaset_Under_mor X Y).
+  Qed.
+
+End def_underprecategories.
+
+
+(** * Morphism of tips induces a functor *)
+Section undercategories_morphisms.
+
+  Variable C : precategory.
+  Hypothesis hs : has_homsets C.
+
+  Local Notation "c / C" := (@UnderPrecategory C hs c).
+
+  Definition Under_precategories_mor_ob {c c' : C} (h : C⟦c, c'⟧) : c' / C → c / C.
+  Proof.
+    intro af.
+    exists (pr1 af).
+    exact (h ;; pr2 af).
+  Defined.
+
+  Local Lemma Under_precategories_mor_mor_eq {c c' : C} (h : C⟦c, c'⟧)
+             (af af' : c' / C) (g : (c' / C)⟦af, af'⟧) :
+    (Under_ob_mor C c (Under_precategories_mor_ob h af)) ;; (Under_mor_mor C c' g) =
+    (Under_ob_mor C c (Under_precategories_mor_ob h af')).
+  Proof.
+    cbn.
+    rewrite <- assoc.
+    apply cancel_precomposition.
+    set (tmp := Under_mor_eq C c' g).
+    unfold Under_mor_mor.
+    unfold Under_mor_mor, Under_ob_mor in tmp.
+    exact tmp.
+  Qed.
+
+  Definition Under_precategories_mor_mor {c c' : C} (h : C⟦c, c'⟧) (af af' : c' / C)
+             (g : (c' / C)⟦af, af'⟧) : (c / C) ⟦Under_precategories_mor_ob h af,
+                                                Under_precategories_mor_ob h af'⟧.
+  Proof.
+    exists (Under_mor_mor C c' g).
+    exact (Under_precategories_mor_mor_eq h af af' g).
+  Defined.
+
+  Definition Under_precategories_mor_functor_data {c c' : C} (h : C⟦c, c'⟧) :
+    functor_data (c' / C) (c / C).
+  Proof.
+    exists (Under_precategories_mor_ob h).
+    exact (Under_precategories_mor_mor h).
+  Defined.
+
+  Lemma is_functor_Under_mor_functor_data {c c' : C} (h : C⟦c, c'⟧) :
+    is_functor (Under_precategories_mor_functor_data h).
+  Proof.
+    split.
+    - intro. apply (Under_mor_equality _ hs). apply idpath.
+    - intros ? ? ? ? ?. apply (Under_mor_equality _ hs). apply idpath.
+  Defined.
+
+  Definition functor_Under_precategories_mor {c c' : C} (h : C⟦c, c'⟧) :
+    functor _ _ := tpair _ _ (is_functor_Under_mor_functor_data h).
+
+End undercategories_morphisms.

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -475,12 +475,28 @@ Defined.
 
 End TerminalHSET_from_Lims.
 
-(*
-Lemma PullbacksHSET : Pullbacks HSET.
-Proof.
-now apply Pullbacks_from_Lims, LimsHSET.
-Qed.
-*)
+
+Section PullbacksHSET_from_Lims.
+
+  Require UniMath.CategoryTheory.limits.graphs.pullbacks.
+
+  Lemma PullbacksHSET : graphs.pullbacks.Pullbacks HSET.
+  Proof.
+    apply (graphs.pullbacks.Pullbacks_from_Lims HSET LimsHSET).
+  Defined.
+
+End PullbacksHSET_from_Lims.
+
+Section EqualizersHSET_from_Lims.
+
+  Require UniMath.CategoryTheory.limits.graphs.equalizers.
+
+  Lemma EqualizersHSET : graphs.equalizers.Equalizers HSET.
+  Proof.
+    apply (graphs.equalizers.Equalizers_from_Lims HSET LimsHSET).
+  Defined.
+
+End EqualizersHSET_from_Lims.
 
 Section exponentials.
 

--- a/UniMath/CategoryTheory/functor_categories.v
+++ b/UniMath/CategoryTheory/functor_categories.v
@@ -65,7 +65,7 @@ Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 (** * Functors : Morphisms of precategories *)
 Section functors.
 
-Definition functor_data (C C' : precategory_ob_mor) :=
+Definition functor_data (C C' : precategory_ob_mor) : UU :=
   total2 ( fun F : ob C -> ob C' =>  Π a b : ob C, a --> b -> F a --> F b).
 
 Definition mk_functor_data {C C' : precategory_ob_mor} (F : ob C -> ob C')
@@ -85,8 +85,8 @@ Proof.
   apply hs.
 Qed.
 
-Definition functor_data_constr ( C C' : precategory_ob_mor )
-           ( F : ob C -> ob C' ) ( Fm : Π a b : ob C, a --> b -> F a --> F b ) :
+Definition functor_data_constr (C C' : precategory_ob_mor)
+           (F : ob C -> ob C') (Fm : Π a b : ob C, a --> b -> F a --> F b) :
   functor_data C C' := tpair _ F Fm .
 
 Definition functor_on_objects {C C' : precategory_ob_mor}
@@ -105,7 +105,7 @@ Definition functor_compax {C C' : precategory_data} (F : functor_data C C') :=
   Π a b c : ob C, Π f : a --> b, Π g : b --> c, #F (f ;; g) = #F f ;; #F g .
 
 Definition is_functor {C C' : precategory_data} (F : functor_data C C') :=
-     dirprod ( functor_idax F ) ( functor_compax F ) .
+  dirprod ( functor_idax F ) ( functor_compax F ) .
 
 Lemma isaprop_is_functor (C C' : precategory_data) (hs: has_homsets C')
       (F : functor_data C C') : isaprop (is_functor F).
@@ -117,7 +117,7 @@ Proof.
   apply hs.
 Qed.
 
-Definition functor (C C' : precategory_data) :=
+Definition functor (C C' : precategory_data) : UU :=
   total2 ( fun F : functor_data C C' => is_functor F ).
 
 Definition mk_functor {C C' : precategory_data} (F : functor_data C C') (H : is_functor F) :
@@ -718,9 +718,12 @@ Proof.
 Qed.
 
 
-Definition nat_trans {C C' : precategory_data}
-  (F F' : functor_data C C') := total2 (
-   fun t : Π x : ob C, F x -->  F' x => is_nat_trans F F' t).
+Definition nat_trans {C C' : precategory_data} (F F' : functor_data C C') : UU :=
+  total2 (fun t : Π x : ob C, F x -->  F' x => is_nat_trans F F' t).
+
+Definition mk_nat_trans {C C' : precategory_data} (F F' : functor_data C C')
+           (t : Π x : ob C, F x --> F' x) (H : is_nat_trans F F' t) :
+  nat_trans F F' := tpair _ t H.
 
 Lemma isaset_nat_trans {C C' : precategory_data} (hs: has_homsets C')
   (F F' : functor_data C C') : isaset (nat_trans F F').
@@ -759,7 +762,6 @@ Proof.
   intro h.
   now apply toforallpaths, maponpaths.
 Qed.
-
 
 (** ** Functor category [[C, D]] *)
 

--- a/UniMath/CategoryTheory/limits/graphs/coequalizers.v
+++ b/UniMath/CategoryTheory/limits/graphs/coequalizers.v
@@ -36,8 +36,7 @@ Section def_coequalizers.
     - apply (fun _ => empty).
   Defined.
 
-  Definition Coequalizer_diagram {a b : C} (f g : C⟦a, b⟧) :
-    diagram Coequalizer_graph C.
+  Definition Coequalizer_diagram {a b : C} (f g : C⟦a, b⟧) : diagram Coequalizer_graph C.
   Proof.
     exists (two_rec a b).
     use two_rec_dep; cbn.
@@ -48,9 +47,8 @@ Section def_coequalizers.
     - intro. apply fromempty.
   Defined.
 
-  Definition Coequalizer_cocone {a b : C} (f g : C⟦a, b⟧)
-             (d : C) (h : C⟦b, d⟧) (H : f ;; h = g ;; h) :
-    cocone (Coequalizer_diagram f g) d.
+  Definition Coequalizer_cocone {a b : C} (f g : C⟦a, b⟧) (d : C) (h : C⟦b, d⟧)
+             (H : f ;; h = g ;; h) : cocone (Coequalizer_diagram f g) d.
   Proof.
     use mk_cocone.
     - use two_rec_dep; cbn.
@@ -65,19 +63,17 @@ Section def_coequalizers.
       + exact (Empty_set_rect _).
   Defined.
 
-  Definition isCoequalizer {a b : C} (f g : C⟦a, b⟧)
-             (d : C) (h : C⟦b, d⟧) (H : f ;; h = g ;; h) : UU
-    := isColimCocone (Coequalizer_diagram f g) d
-                     (Coequalizer_cocone f g d h H).
+  Definition isCoequalizer {a b : C} (f g : C⟦a, b⟧) (d : C) (h : C⟦b, d⟧)
+             (H : f ;; h = g ;; h) : UU := isColimCocone (Coequalizer_diagram f g) d
+                                                         (Coequalizer_cocone f g d h H).
 
-  Definition mk_isCoequalizer {a b : C} (f g : C⟦a, b⟧)
-             (d : C) (h : C⟦b, d⟧) (H : f ;; h = g ;; h) :
+  Definition mk_isCoequalizer {a b : C} (f g : C⟦a, b⟧) (d : C) (h : C⟦b, d⟧)
+             (H : f ;; h = g ;; h) :
     (Π e (h' : C⟦b, e⟧) (H' : f ;; h' = g ;; h'),
-   iscontr (total2 (fun hk : C⟦d, e⟧ => h ;; hk = h')))
-  -> isCoequalizer f g d h H.
+     iscontr (total2 (fun hk : C⟦d, e⟧ => h ;; hk = h'))) ->
+    isCoequalizer f g d h H.
   Proof.
     intros H' x cx.
-
     assert (H1 : f ;; coconeIn cx Two = g ;; coconeIn cx Two).
     {
       use (pathscomp0 (coconeInCommutes cx One Two (ii1 tt))).
@@ -85,7 +81,6 @@ Section def_coequalizers.
       apply idpath.
     }
     set (H2 := (H' x (coconeIn cx Two) H1)).
-
     use tpair.
     - use (tpair _ (pr1 (pr1 H2)) _).
       use two_rec_dep; cbn; unfold idfun.
@@ -100,13 +95,10 @@ Section def_coequalizers.
       apply (p Two).
   Defined.
 
-  Definition Coequalizer {a b : C} (f g : C⟦a, b⟧) :=
-    ColimCocone (Coequalizer_diagram f g).
+  Definition Coequalizer {a b : C} (f g : C⟦a, b⟧) : UU := ColimCocone (Coequalizer_diagram f g).
 
-  Definition mk_Coequalizer {a b : C} (f g : C⟦a, b⟧)
-             (d : C) (h : C⟦b, d⟧) (H : f ;; h = g ;; h)
-             (isCEq : isCoequalizer f g d h H) :
-    Coequalizer f g.
+  Definition mk_Coequalizer {a b : C} (f g : C⟦a, b⟧) (d : C) (h : C⟦b, d⟧) (H : f ;; h = g ;; h)
+             (isCEq : isCoequalizer f g d h H) : Coequalizer f g.
   Proof.
     use tpair.
     - use tpair.
@@ -117,20 +109,17 @@ Section def_coequalizers.
     - exact isCEq.
   Defined.
 
-  Definition Coequalizers : UU
-    := Π (a b : C) (f g : C⟦a, b⟧), Coequalizer f g.
+  Definition Coequalizers : UU := Π (a b : C) (f g : C⟦a, b⟧), Coequalizer f g.
 
-  Definition hasCoequalizers : UU
-    := Π (a b : C) (f g : C⟦a, b⟧), ishinh (Coequalizer f g).
+  Definition hasCoequalizers : UU := Π (a b : C) (f g : C⟦a, b⟧), ishinh (Coequalizer f g).
 
   Definition CoequalizerObject {a b : C} {f g : C⟦a, b⟧} :
     Coequalizer f g -> C := fun H => colim H.
 
-  Definition CoequalizerArrow {a b : C} {f g : C⟦a, b⟧}
-             (E : Coequalizer f g) : C⟦b, colim E⟧ := colimIn E Two.
+  Definition CoequalizerArrow {a b : C} {f g : C⟦a, b⟧} (E : Coequalizer f g) :
+    C⟦b, colim E⟧ := colimIn E Two.
 
-  Definition CoequalizerArrowEq {a b : C} {f g : C⟦a, b⟧}
-             (E : Coequalizer f g) :
+  Definition CoequalizerArrowEq {a b : C} {f g : C⟦a, b⟧} (E : Coequalizer f g) :
     f ;; CoequalizerArrow E = g ;; CoequalizerArrow E.
   Proof.
     use (pathscomp0 (colimInCommutes E One Two (ii1 tt))).
@@ -138,10 +127,8 @@ Section def_coequalizers.
     apply idpath.
   Qed.
 
-  Definition CoequalizerOut {a b : C} {f g : C⟦a, b⟧}
-             (E : Coequalizer f g) e (h : C⟦b, e⟧)
-             (H : f ;; h = g ;; h) :
-    C⟦colim E, e⟧.
+  Definition CoequalizerOut {a b : C} {f g : C⟦a, b⟧} (E : Coequalizer f g) e (h : C⟦b, e⟧)
+             (H : f ;; h = g ;; h) : C⟦colim E, e⟧.
   Proof.
     use colimArrow.
     use mk_cocone.
@@ -157,19 +144,14 @@ Section def_coequalizers.
       + exact (Empty_set_rect _).
   Defined.
 
-  Lemma CoequalizerArrowComm {a b : C} {f g : C⟦a, b⟧}
-        (E : Coequalizer f g) e (h : C⟦b, e⟧)
-        (H : f ;; h = g ;; h) :
-    CoequalizerArrow E ;; CoequalizerOut E e h H = h.
+  Lemma CoequalizerArrowComm {a b : C} {f g : C⟦a, b⟧} (E : Coequalizer f g) (e : C) (h : C⟦b, e⟧)
+        (H : f ;; h = g ;; h) : CoequalizerArrow E ;; CoequalizerOut E e h H = h.
   Proof.
     refine (colimArrowCommutes E e _ Two).
   Qed.
 
-  Lemma CoequalizerOutUnique {a b : C} {f g : C⟦a, b⟧}
-        (E : Coequalizer f g) e (h : C⟦b, e⟧)
-        (H : f ;; h = g ;; h)
-        (w : C⟦colim E, e⟧)
-        (H' : CoequalizerArrow E ;; w = h) :
+  Lemma CoequalizerOutUnique {a b : C} {f g : C⟦a, b⟧} (E : Coequalizer f g) (e : C) (h : C⟦b, e⟧)
+        (H : f ;; h = g ;; h) (w : C⟦colim E, e⟧) (H' : CoequalizerArrow E ;; w = h) :
     w = CoequalizerOut E e h H.
   Proof.
     apply path_to_ctr.
@@ -182,21 +164,17 @@ Section def_coequalizers.
     - apply H'.
   Qed.
 
-  Definition isCoequalizer_Coequalizer {a b : C} {f g : C⟦a, b⟧}
-             (E : Coequalizer f g) :
+  Definition isCoequalizer_Coequalizer {a b : C} {f g : C⟦a, b⟧} (E : Coequalizer f g) :
     isCoequalizer f g (CoequalizerObject E) (CoequalizerArrow E)
                   (CoequalizerArrowEq E).
   Proof.
     apply mk_isCoequalizer.
     intros e h H.
     use (unique_exists (CoequalizerOut E e h H)).
-
     (* Commutativity *)
     - exact (CoequalizerArrowComm E e h H).
-
     (* Equality on equalities of morphisms *)
     - intros y. apply hs.
-
     (* Uniqueness *)
     - intros y t. cbn in t.
       use CoequalizerOutUnique.
@@ -205,19 +183,16 @@ Section def_coequalizers.
 
   (** ** Coequalizers to coequalizers *)
 
-  Definition identity_is_Coequalizer_input {a b : C} {f g : C⟦a, b⟧}
-             (E : Coequalizer f g) :
-    total2 (fun hk : C⟦colim E, colim E⟧ => CoequalizerArrow E ;; hk
-                                         = CoequalizerArrow E).
+  Definition identity_is_Coequalizer_input {a b : C} {f g : C⟦a, b⟧} (E : Coequalizer f g) :
+    total2 (fun hk : C⟦colim E, colim E⟧ => CoequalizerArrow E ;; hk = CoequalizerArrow E).
   Proof.
     use tpair.
     exact (identity _).
     apply id_right.
   Defined.
 
-  Lemma CoequalizerEndo_is_identity  {a b : C} {f g : C⟦a, b⟧}
-        (E : Coequalizer f g) (k : C⟦colim E, colim E⟧)
-        (kH :CoequalizerArrow E ;; k = CoequalizerArrow E) :
+  Lemma CoequalizerEndo_is_identity  {a b : C} {f g : C⟦a, b⟧} (E : Coequalizer f g)
+        (k : C⟦colim E, colim E⟧) (kH :CoequalizerArrow E ;; k = CoequalizerArrow E) :
     identity (colim E) = k.
   Proof.
     apply colim_endo_is_identity.
@@ -231,8 +206,8 @@ Section def_coequalizers.
     + apply kH.
   Qed.
 
-  Definition from_Coequalizer_to_Coequalizer {a b : C} {f g : C⟦a, b⟧}
-             (E1 E2 : Coequalizer f g) : C⟦colim E1, colim E2⟧.
+  Definition from_Coequalizer_to_Coequalizer {a b : C} {f g : C⟦a, b⟧} (E1 E2 : Coequalizer f g) :
+    C⟦colim E1, colim E2⟧.
   Proof.
     apply (CoequalizerOut E1 (colim E2) (CoequalizerArrow E2)).
     exact (CoequalizerArrowEq E2).
@@ -241,7 +216,7 @@ Section def_coequalizers.
   Lemma are_inverses_from_Coequalizer_to_Coequalizer {a b : C} {f g : C⟦a, b⟧}
         (E1 E2 : Coequalizer f g) :
     is_inverse_in_precat (from_Coequalizer_to_Coequalizer E2 E1)
-      (from_Coequalizer_to_Coequalizer E1 E2).
+                         (from_Coequalizer_to_Coequalizer E1 E2).
   Proof.
     split; apply pathsinv0.
     - apply CoequalizerEndo_is_identity.
@@ -256,8 +231,7 @@ Section def_coequalizers.
       apply idpath.
   Qed.
 
-  Lemma isiso_from_Coequalizer_to_Coequalizer {a b : C} {f g : C⟦a, b⟧}
-        (E1 E2 : Coequalizer f g) :
+  Lemma isiso_from_Coequalizer_to_Coequalizer {a b : C} {f g : C⟦a, b⟧} (E1 E2 : Coequalizer f g) :
     is_isomorphism (from_Coequalizer_to_Coequalizer E1 E2).
   Proof.
     apply (is_iso_qinv _ (from_Coequalizer_to_Coequalizer E2 E1)).
@@ -265,13 +239,12 @@ Section def_coequalizers.
   Qed.
 
   Definition iso_from_Coequalizer_to_Coequalizer {a b : C} {f g : C⟦a, b⟧}
-             (E1 E2 : Coequalizer f g) : iso (colim E1) (colim E2)
-    := tpair _ _ (isiso_from_Coequalizer_to_Coequalizer E1 E2).
+             (E1 E2 : Coequalizer f g) : iso (colim E1) (colim E2) :=
+    tpair _ _ (isiso_from_Coequalizer_to_Coequalizer E1 E2).
 
-  Lemma inv_from_iso_iso_from_Pullback {a b : C} {f g : C⟦a , b⟧}
-        (E1 E2 : Coequalizer f g):
-    inv_from_iso (iso_from_Coequalizer_to_Coequalizer E1 E2)
-    = from_Coequalizer_to_Coequalizer E2 E1.
+  Lemma inv_from_iso_iso_from_Pullback {a b : C} {f g : C⟦a , b⟧} (E1 E2 : Coequalizer f g):
+    inv_from_iso (iso_from_Coequalizer_to_Coequalizer E1 E2) =
+    from_Coequalizer_to_Coequalizer E2 E1.
   Proof.
     apply pathsinv0.
     apply inv_iso_unique'.
@@ -281,8 +254,7 @@ Section def_coequalizers.
 
   (** ** Connections to other colimits *)
 
-  Lemma Coequalizers_from_Colims :
-    Colims C -> Coequalizers.
+  Lemma Coequalizers_from_Colims : Colims C -> Coequalizers.
   Proof.
     intros H a b f g. apply H.
   Defined.
@@ -291,8 +263,8 @@ End def_coequalizers.
 
 
 (** * Definitions coincide
-  In this section we show that the definition of coequalizer as a colimit
-  coincides with the direct definition. *)
+    In this section we show that the definition of coequalizer as a colimit coincides with the
+    direct definition. *)
 Section coequalizers_coincide.
 
   Variable C : precategory.
@@ -301,8 +273,7 @@ Section coequalizers_coincide.
 
   (** ** isCoequalizers *)
 
-  Lemma equiv_isCoequalizer1 {a b : C} {f g : C⟦a, b⟧}
-        e (h : C⟦b, e⟧) (H : f ;; h = g ;; h) :
+  Lemma equiv_isCoequalizer1 {a b : C} {f g : C⟦a, b⟧} (e : C) (h : C⟦b, e⟧) (H : f ;; h = g ;; h) :
     limits.coequalizers.isCoequalizer f g h H -> isCoequalizer C f g e h H.
   Proof.
     intros X.
@@ -310,13 +281,10 @@ Section coequalizers_coincide.
     use (mk_isCoequalizer C hs).
     intros e' h' H'.
     use (unique_exists (limits.coequalizers.CoequalizerOut E e' h' H')).
-
     (* Commutativity *)
     - exact (limits.coequalizers.CoequalizerCommutes E e' h' H').
-
     (* Equality on equalities of morphisms *)
     - intros y. apply hs.
-
     (* Uniqueness *)
     - intros y T. cbn in T.
       use (limits.coequalizers.CoequalizerOutsEq E).
@@ -324,21 +292,17 @@ Section coequalizers_coincide.
       exact (!(limits.coequalizers.CoequalizerCommutes E e' h' H')).
   Qed.
 
-  Lemma equiv_isCoequalizer2 {a b : C} (f g : C⟦a, b⟧)
-        e (h : C⟦b, e⟧) (H : f ;; h = g ;; h) :
+  Lemma equiv_isCoequalizer2 {a b : C} (f g : C⟦a, b⟧) (e : C) (h : C⟦b, e⟧) (H : f ;; h = g ;; h) :
     limits.coequalizers.isCoequalizer f g h H <- isCoequalizer C f g e h H.
   Proof.
     intros X.
     set (E := mk_Coequalizer C f g e h H X).
     intros e' h' H'.
     use (unique_exists (CoequalizerOut C E e' h' H')).
-
     (* Commutativity *)
     - exact (CoequalizerArrowComm C E e' h' H').
-
     (* Equality on equalities of morphisms *)
     - intros y. apply hs.
-
     (* Uniqueness *)
     - intros y T. cbn in T.
       use (CoequalizerOutUnique C E).
@@ -352,10 +316,7 @@ Section coequalizers_coincide.
   Proof.
     intros E.
     exact (mk_Coequalizer
-             C f g
-             _
-             _
-             _
+             C f g _ _ _
              (equiv_isCoequalizer1
                 (limits.coequalizers.CoequalizerObject E)
                 (limits.coequalizers.CoequalizerArrow E)

--- a/UniMath/CategoryTheory/limits/graphs/cokernels.v
+++ b/UniMath/CategoryTheory/limits/graphs/cokernels.v
@@ -23,19 +23,17 @@ Section def_cokernels.
   Variable hs: has_homsets C.
   Variable Z : Zero C.
 
-  Definition Cokernel {a b : C} (f : C⟦a, b⟧)
-    := Coequalizer C f (ZeroArrow Z a b).
+  Definition Cokernel {a b : C} (f : C⟦a, b⟧) := Coequalizer C f (ZeroArrow Z a b).
 
   (** ** Coincides with the direct definiton *)
   Lemma equiv_Cokernel1_eq {a b : C} (f : C⟦a, b⟧)
         (K : limits.cokernels.Cokernel (equiv_Zero2 Z) f) :
-    f ;; limits.coequalizers.CoequalizerArrow K
-    = ZeroArrow Z a b ;; limits.coequalizers.CoequalizerArrow K.
+    f ;; limits.coequalizers.CoequalizerArrow K =
+    ZeroArrow Z a b ;; limits.coequalizers.CoequalizerArrow K.
   Proof.
     set (tmp := limits.coequalizers.CoequalizerEqAr K).
     set (tmp1 := equiv_ZeroArrow a b Z).
-    apply (maponpaths (fun h : _ => h ;; limits.coequalizers.CoequalizerArrow K))
-      in tmp1.
+    apply (maponpaths (fun h : _ => h ;; limits.coequalizers.CoequalizerArrow K)) in tmp1.
     set (tmp2 := pathscomp0 tmp tmp1).
     apply tmp2.
   Qed.
@@ -43,26 +41,21 @@ Section def_cokernels.
   Lemma equiv_Cokernel1_isCoequalizer {a b : C} (f : C⟦a, b⟧)
         (K : limits.cokernels.Cokernel (equiv_Zero2 Z) f) :
     limits.coequalizers.isCoequalizer
-      f (ZeroArrow Z a b) (limits.coequalizers.CoequalizerArrow K)
-      (equiv_Cokernel1_eq f K).
+      f (ZeroArrow Z a b) (limits.coequalizers.CoequalizerArrow K) (equiv_Cokernel1_eq f K).
   Proof.
     use limits.coequalizers.mk_isCoequalizer.
     intros w h H.
     use unique_exists.
-
     (* Construction of the morphism *)
     - use limits.cokernels.CokernelOut.
       + exact h.
       + rewrite postcomp_with_ZeroArrow in H.
         use (pathscomp0 _ (!(equiv_ZeroArrow a w Z))).
         exact H.
-
     (* Commutativity *)
     - use limits.cokernels.CokernelCommutes.
-
     (* Equality on equalities of morphisms *)
     - intros y. apply hs.
-
     (* Uniqueness *)
     - intros y T. cbn in T.
       use limits.cokernels.CokernelOutsEq. unfold CokernelArrow.
@@ -85,9 +78,8 @@ Section def_cokernels.
 
   (* Other direction *)
 
-  Lemma equiv_Cokernel2_eq {a b : C} (f : C⟦a, b⟧) (K : Cokernel f ) :
-    f ;; CoequalizerArrow C K
-    = limits.zero.ZeroArrow (equiv_Zero2 Z) a b ;; CoequalizerArrow C K.
+  Lemma equiv_Cokernel2_eq {a b : C} (f : C⟦a, b⟧) (K : Cokernel f) :
+    f ;; CoequalizerArrow C K = limits.zero.ZeroArrow (equiv_Zero2 Z) a b ;; CoequalizerArrow C K.
   Proof.
     set (tmp := CoequalizerArrowEq C K).
     set (tmp1 := equiv_ZeroArrow a b Z).
@@ -97,16 +89,13 @@ Section def_cokernels.
     apply tmp2.
   Qed.
 
-  Lemma equiv_Cokernel2_isCoequalizer {a b : C} (f : C⟦a, b⟧)
-        (K : Cokernel f ) :
+  Lemma equiv_Cokernel2_isCoequalizer {a b : C} (f : C⟦a, b⟧) (K : Cokernel f) :
     isCoequalizer C f (limits.zero.ZeroArrow (equiv_Zero2 Z) a b)
-                  (CoequalizerObject C K)
-                  (CoequalizerArrow C K) (equiv_Cokernel2_eq f K).
+                  (CoequalizerObject C K) (CoequalizerArrow C K) (equiv_Cokernel2_eq f K).
   Proof.
     use mk_isCoequalizer. apply hs.
     intros w h H.
     use unique_exists.
-
     (* Construction of the morphism *)
     - use CoequalizerOut.
       + exact h.
@@ -114,13 +103,10 @@ Section def_cokernels.
         rewrite limits.zero.ZeroArrow_comp_left in H.
         use (pathscomp0 H).
         apply (equiv_ZeroArrow a w Z).
-
     (* Commutativity *)
     - use CoequalizerArrowComm.
-
     (* Equality on equalities of morphisms *)
     - intros y. apply hs.
-
     (* Uniqueness *)
     - intros y T. cbn in T.
       use CoequalizerOutUnique. exact T.

--- a/UniMath/CategoryTheory/limits/graphs/equalizers.v
+++ b/UniMath/CategoryTheory/limits/graphs/equalizers.v
@@ -37,8 +37,7 @@ Section def_equalizers.
     - apply (fun _ => empty).
   Defined.
 
-  Definition Equalizer_diagram {a b : C} (f g : C⟦a, b⟧) :
-    diagram Equalizer_graph C.
+  Definition Equalizer_diagram {a b : C} (f g : C⟦a, b⟧) : diagram Equalizer_graph C.
   Proof.
     exists (two_rec a b).
     use two_rec_dep; cbn.
@@ -49,8 +48,7 @@ Section def_equalizers.
     - intro. apply fromempty.
   Defined.
 
-  Definition Equalizer_cone {a b : C} (f g : C⟦a, b⟧)
-             (d : C) (h : C⟦d, a⟧) (H : h ;; f = h ;; g) :
+  Definition Equalizer_cone {a b : C} (f g : C⟦a, b⟧) (d : C) (h : C⟦d, a⟧) (H : h ;; f = h ;; g) :
     cone (Equalizer_diagram f g) d.
   Proof.
     use mk_cone.
@@ -66,15 +64,12 @@ Section def_equalizers.
       + exact (Empty_set_rect _).
   Defined.
 
-  Definition isEqualizer {a b : C} (f g : C⟦a, b⟧)
-             (d : C) (h : C⟦d, a⟧) (H : h ;; f = h ;; g) : UU
-    := isLimCone (Equalizer_diagram f g) d (Equalizer_cone f g d h H).
+  Definition isEqualizer {a b : C} (f g : C⟦a, b⟧) (d : C) (h : C⟦d, a⟧) (H : h ;; f = h ;; g) :
+    UU := isLimCone (Equalizer_diagram f g) d (Equalizer_cone f g d h H).
 
-  Definition mk_isEqualizer {a b : C} (f g : C⟦a, b⟧)
-             (d : C) (h : C⟦d, a⟧) (H : h ;; f = h ;; g) :
-  (Π e (h' : C⟦e, a⟧) (H' : h' ;; f = h' ;; g),
-   iscontr (total2 (fun hk : C⟦e, d⟧ => hk ;; h = h')))
-  -> isEqualizer f g d h H.
+  Definition mk_isEqualizer {a b : C} (f g : C⟦a, b⟧) (d : C) (h : C⟦d, a⟧) (H : h ;; f = h ;; g) :
+    (Π e (h' : C⟦e, a⟧) (H' : h' ;; f = h' ;; g),
+     iscontr (total2 (fun hk : C⟦e, d⟧ => hk ;; h = h'))) -> isEqualizer f g d h H.
   Proof.
     intros H' x cx.
 
@@ -99,12 +94,10 @@ Section def_equalizers.
       apply (p One).
   Defined.
 
-  Definition Equalizer {a b : C} (f g : C⟦a, b⟧) :=
-    LimCone (Equalizer_diagram f g).
+  Definition Equalizer {a b : C} (f g : C⟦a, b⟧) := LimCone (Equalizer_diagram f g).
 
-  Definition mk_Equalizer {a b : C} (f g : C⟦a, b⟧)
-             (d : C) (h : C⟦d, a⟧) (H : h ;; f = h ;; g)
-             (isEq : isEqualizer f g d h H) :
+  Definition mk_Equalizer {a b : C} (f g : C⟦a, b⟧) (d : C) (h : C⟦d, a⟧)
+             (H : h ;; f = h ;; g) (isEq : isEqualizer f g d h H) :
     Equalizer f g.
   Proof.
     use tpair.
@@ -116,20 +109,16 @@ Section def_equalizers.
     - exact isEq.
   Defined.
 
-  Definition Equalizers : UU
-    := Π (a b : C) (f g : C⟦a, b⟧), Equalizer f g.
+  Definition Equalizers : UU := Π (a b : C) (f g : C⟦a, b⟧), Equalizer f g.
 
-  Definition hasEqualizers : UU
-    := Π (a b : C) (f g : C⟦a, b⟧), ishinh (Equalizer f g).
+  Definition hasEqualizers : UU := Π (a b : C) (f g : C⟦a, b⟧), ishinh (Equalizer f g).
 
-  Definition EqualizerObject {a b : C} {f g : C⟦a, b⟧} :
-    Equalizer f g -> C := fun H => lim H.
+  Definition EqualizerObject {a b : C} {f g : C⟦a, b⟧} : Equalizer f g -> C := fun H => lim H.
 
-  Definition EqualizerArrow {a b : C} {f g : C⟦a, b⟧}
-             (E : Equalizer f g) : C⟦lim E, a⟧ := limOut E One.
+  Definition EqualizerArrow {a b : C} {f g : C⟦a, b⟧} (E : Equalizer f g) :
+    C⟦lim E, a⟧ := limOut E One.
 
-  Definition EqualizerArrowEq {a b : C} {f g : C⟦a, b⟧}
-             (E : Equalizer f g) :
+  Definition EqualizerArrowEq {a b : C} {f g : C⟦a, b⟧} (E : Equalizer f g) :
     EqualizerArrow E ;; f = EqualizerArrow E ;; g.
   Proof.
     use (pathscomp0 (limOutCommutes E One Two (ii1 tt))).
@@ -137,10 +126,8 @@ Section def_equalizers.
     apply idpath.
   Qed.
 
-  Definition EqualizerIn {a b : C} {f g : C⟦a, b⟧}
-             (E : Equalizer f g) e (h : C⟦e, a⟧)
-             (H : h ;; f = h ;; g) :
-    C⟦e, lim E⟧.
+  Definition EqualizerIn {a b : C} {f g : C⟦a, b⟧} (E : Equalizer f g) (e : C) (h : C⟦e, a⟧)
+             (H : h ;; f = h ;; g) : C⟦e, lim E⟧.
   Proof.
     use limArrow.
     use mk_cone.
@@ -156,19 +143,14 @@ Section def_equalizers.
       + exact (Empty_set_rect _).
   Defined.
 
-  Lemma EqualizerArrowComm {a b : C} {f g : C⟦a, b⟧}
-        (E : Equalizer f g) e (h : C⟦e, a⟧)
-        (H : h ;; f = h ;; g) :
-    EqualizerIn E e h H ;; EqualizerArrow E = h.
+  Lemma EqualizerArrowComm {a b : C} {f g : C⟦a, b⟧} (E : Equalizer f g) (e : C) (h : C⟦e, a⟧)
+        (H : h ;; f = h ;; g) : EqualizerIn E e h H ;; EqualizerArrow E = h.
   Proof.
     refine (limArrowCommutes E e _ One).
   Qed.
 
-  Lemma EqualizerInUnique {a b : C} {f g : C⟦a, b⟧}
-        (E : Equalizer f g) e (h : C⟦e, a⟧)
-        (H : h ;; f = h ;; g)
-        (w : C⟦e, lim E⟧)
-        (H' : w ;; EqualizerArrow E = h) :
+  Lemma EqualizerInUnique {a b : C} {f g : C⟦a, b⟧} (E : Equalizer f g) (e : C) (h : C⟦e, a⟧)
+        (H : h ;; f = h ;; g) (w : C⟦e, lim E⟧) (H' : w ;; EqualizerArrow E = h) :
     w = EqualizerIn E e h H.
   Proof.
     apply path_to_ctr.
@@ -181,20 +163,16 @@ Section def_equalizers.
       apply H'.
   Qed.
 
-  Definition isEqualizer_Equalizer {a b : C} {f g : C⟦a, b⟧}
-             (E : Equalizer f g) :
+  Definition isEqualizer_Equalizer {a b : C} {f g : C⟦a, b⟧} (E : Equalizer f g) :
     isEqualizer f g (EqualizerObject E) (EqualizerArrow E) (EqualizerArrowEq E).
   Proof.
     apply mk_isEqualizer.
     intros e h H.
     use (unique_exists (EqualizerIn E e h H)).
-
     (* Commutativity *)
     - exact (EqualizerArrowComm E e h H).
-
     (* Equality on equalities of morphisms *)
     - intros y. apply hs.
-
     (* Uniqueness *)
     - intros y t. cbn in t.
       use EqualizerInUnique.
@@ -203,19 +181,16 @@ Section def_equalizers.
 
   (** ** Equalizers to equalizers *)
 
-  Definition identity_is_Equalizer_input {a b : C} {f g : C⟦a, b⟧}
-             (E : Equalizer f g) :
-    total2 (fun hk : C⟦lim E, lim E⟧ => hk ;; EqualizerArrow E
-                                     = EqualizerArrow E).
+  Definition identity_is_Equalizer_input {a b : C} {f g : C⟦a, b⟧} (E : Equalizer f g) :
+    total2 (fun hk : C⟦lim E, lim E⟧ => hk ;; EqualizerArrow E = EqualizerArrow E).
   Proof.
     use tpair.
     exact (identity _).
     apply id_left.
   Defined.
 
-  Lemma EqualizerEndo_is_identity  {a b : C} {f g : C⟦a, b⟧}
-        (E : Equalizer f g) (k : C⟦lim E, lim E⟧)
-        (kH : k ;; EqualizerArrow E = EqualizerArrow E) :
+  Lemma EqualizerEndo_is_identity  {a b : C} {f g : C⟦a, b⟧} (E : Equalizer f g)
+        (k : C⟦lim E, lim E⟧) (kH : k ;; EqualizerArrow E = EqualizerArrow E) :
     identity (lim E) = k.
   Proof.
     apply lim_endo_is_identity.
@@ -229,17 +204,16 @@ Section def_equalizers.
       apply kH.
   Qed.
 
-  Definition from_Equalizer_to_Equalizer {a b : C} {f g : C⟦a, b⟧}
-             (E1 E2 : Equalizer f g) : C⟦lim E1, lim E2⟧.
+  Definition from_Equalizer_to_Equalizer {a b : C} {f g : C⟦a, b⟧} (E1 E2 : Equalizer f g) :
+    C⟦lim E1, lim E2⟧.
   Proof.
     apply (EqualizerIn E2 (lim E1) (EqualizerArrow E1)).
     exact (EqualizerArrowEq E1).
   Defined.
 
-  Lemma are_inverses_from_Equalizer_to_Equalizer {a b : C} {f g : C⟦a, b⟧}
-        (E1 E2 : Equalizer f g) :
+  Lemma are_inverses_from_Equalizer_to_Equalizer {a b : C} {f g : C⟦a, b⟧} (E1 E2 : Equalizer f g) :
     is_inverse_in_precat (from_Equalizer_to_Equalizer E2 E1)
-      (from_Equalizer_to_Equalizer E1 E2).
+                         (from_Equalizer_to_Equalizer E1 E2).
   Proof.
     split; apply pathsinv0.
     - apply EqualizerEndo_is_identity.
@@ -254,22 +228,18 @@ Section def_equalizers.
       apply idpath.
   Qed.
 
-  Lemma isiso_from_Equalizer_to_Equalizer {a b : C} {f g : C⟦a, b⟧}
-        (E1 E2 : Equalizer f g) :
+  Lemma isiso_from_Equalizer_to_Equalizer {a b : C} {f g : C⟦a, b⟧} (E1 E2 : Equalizer f g) :
     is_isomorphism (from_Equalizer_to_Equalizer E1 E2).
   Proof.
     apply (is_iso_qinv _ (from_Equalizer_to_Equalizer E2 E1)).
     apply are_inverses_from_Equalizer_to_Equalizer.
   Qed.
 
-  Definition iso_from_Equalizer_to_Equalizer {a b : C} {f g : C⟦a, b⟧}
-             (E1 E2 : Equalizer f g) : iso (lim E1) (lim E2)
-    := tpair _ _ (isiso_from_Equalizer_to_Equalizer E1 E2).
+  Definition iso_from_Equalizer_to_Equalizer {a b : C} {f g : C⟦a, b⟧} (E1 E2 : Equalizer f g) :
+    iso (lim E1) (lim E2) := tpair _ _ (isiso_from_Equalizer_to_Equalizer E1 E2).
 
-  Lemma inv_from_iso_iso_from_Pullback {a b : C} {f g : C⟦a , b⟧}
-        (E1 E2 : Equalizer f g):
-    inv_from_iso (iso_from_Equalizer_to_Equalizer E1 E2)
-    = from_Equalizer_to_Equalizer E2 E1.
+  Lemma inv_from_iso_iso_from_Pullback {a b : C} {f g : C⟦a , b⟧} (E1 E2 : Equalizer f g):
+    inv_from_iso (iso_from_Equalizer_to_Equalizer E1 E2) = from_Equalizer_to_Equalizer E2 E1.
   Proof.
     apply pathsinv0.
     apply inv_iso_unique'.
@@ -296,10 +266,10 @@ Section equalizers_coincide.
   Variable C : precategory.
   Variable hs: has_homsets C.
 
+
   (** ** isEqualizers *)
 
-  Lemma equiv_isEqualizer1 {a b : C} {f g : C⟦a, b⟧}
-        e (h : C⟦e, a⟧) (H : h ;; f = h ;; g) :
+  Lemma equiv_isEqualizer1 {a b : C} {f g : C⟦a, b⟧} (e : C) (h : C⟦e, a⟧) (H : h ;; f = h ;; g) :
     limits.equalizers.isEqualizer f g h H -> isEqualizer C f g e h H.
   Proof.
     intros X.
@@ -307,13 +277,10 @@ Section equalizers_coincide.
     use (mk_isEqualizer C hs).
     intros e' h' H'.
     use (unique_exists (limits.equalizers.EqualizerIn E e' h' H')).
-
     (* Commutativity *)
     - exact (limits.equalizers.EqualizerCommutes E e' h' H').
-
     (* Equality on equalities of morphisms *)
     - intros y. apply hs.
-
     (* Uniqueness *)
     - intros y T. cbn in T.
       use (limits.equalizers.EqualizerInsEq E).
@@ -321,26 +288,23 @@ Section equalizers_coincide.
       exact (!(limits.equalizers.EqualizerCommutes E e' h' H')).
   Qed.
 
-  Lemma equiv_isEqualizer2 {a b : C} (f g : C⟦a, b⟧)
-        e (h : C⟦e, a⟧) (H : h ;; f = h ;; g) :
+  Lemma equiv_isEqualizer2 {a b : C} (f g : C⟦a, b⟧) (e : C) (h : C⟦e, a⟧) (H : h ;; f = h ;; g) :
     limits.equalizers.isEqualizer f g h H <- isEqualizer C f g e h H.
   Proof.
     intros X.
     set (E := mk_Equalizer C f g e h H X).
     intros e' h' H'.
     use (unique_exists (EqualizerIn C E e' h' H')).
-
     (* Commutativity *)
     - exact (EqualizerArrowComm C E e' h' H').
-
     (* Equality on equalities of morphisms *)
     - intros y. apply hs.
-
     (* Uniqueness *)
     - intros y T. cbn in T.
       use (EqualizerInUnique C E).
       exact T.
   Qed.
+
 
   (** ** Equalizers *)
 
@@ -349,10 +313,20 @@ Section equalizers_coincide.
   Proof.
     intros E.
     exact (mk_Equalizer
-             C f g
-             _
-             _
-             _
+             C f g _ _ _
+             (equiv_isEqualizer1
+                (limits.equalizers.EqualizerObject E)
+                (limits.equalizers.EqualizerArrow E)
+                (limits.equalizers.EqualizerEqAr E)
+                (limits.equalizers.isEqualizer_Equalizer E))).
+  Defined.
+
+  Definition equiv_Equalizers1 : @limits.equalizers.Equalizers C -> Equalizers C.
+  Proof.
+    intros E' a b f g.
+    set (E := E' a b f g).
+    exact (mk_Equalizer
+             C f g _ _ _
              (equiv_isEqualizer1
                 (limits.equalizers.EqualizerObject E)
                 (limits.equalizers.EqualizerArrow E)
@@ -364,6 +338,21 @@ Section equalizers_coincide.
     limits.equalizers.Equalizer f g <- Equalizer C f g.
   Proof.
     intros E.
+    exact (@limits.equalizers.mk_Equalizer
+             C (EqualizerObject C E) a b f g
+             (EqualizerArrow C E)
+             (EqualizerArrowEq C E)
+             (@equiv_isEqualizer2
+                a b f g (EqualizerObject C E)
+                (EqualizerArrow C E)
+                (EqualizerArrowEq C E)
+                (isEqualizer_Equalizer C hs E))).
+  Defined.
+
+  Definition equiv_Equalizers2 : @limits.equalizers.Equalizers C <- Equalizers C.
+  Proof.
+    intros E' a b f g.
+    set (E := E' a b f g).
     exact (@limits.equalizers.mk_Equalizer
              C (EqualizerObject C E) a b f g
              (EqualizerArrow C E)

--- a/UniMath/CategoryTheory/limits/graphs/kernels.v
+++ b/UniMath/CategoryTheory/limits/graphs/kernels.v
@@ -27,15 +27,12 @@ Section def_kernels.
     := Equalizer C f (ZeroArrow Z a b).
 
   (** ** Maps between Kernels as limits and direct definition. *)
-  Lemma equiv_Kernel1_eq {a b : C} (f : C⟦a, b⟧)
-        (K : limits.kernels.Kernel (equiv_Zero2 Z) f) :
-    limits.equalizers.EqualizerArrow K ;; f
-    = limits.equalizers.EqualizerArrow K ;; ZeroArrow Z a b.
+  Lemma equiv_Kernel1_eq {a b : C} (f : C⟦a, b⟧) (K : limits.kernels.Kernel (equiv_Zero2 Z) f) :
+    limits.equalizers.EqualizerArrow K ;; f = limits.equalizers.EqualizerArrow K ;; ZeroArrow Z a b.
   Proof.
     set (tmp := limits.equalizers.EqualizerEqAr K).
     set (tmp1 := equiv_ZeroArrow a b Z).
-    apply (maponpaths (fun h : _ => limits.equalizers.EqualizerArrow K ;; h))
-      in tmp1.
+    apply (maponpaths (fun h : _ => limits.equalizers.EqualizerArrow K ;; h)) in tmp1.
     set (tmp2 := pathscomp0 tmp tmp1).
     apply tmp2.
   Qed.
@@ -43,26 +40,21 @@ Section def_kernels.
   Lemma equiv_Kernel1_isEqualizer {a b : C} (f : C⟦a, b⟧)
         (K : limits.kernels.Kernel (equiv_Zero2 Z) f) :
     limits.equalizers.isEqualizer
-      f (ZeroArrow Z a b) (limits.equalizers.EqualizerArrow K)
-      (equiv_Kernel1_eq f K).
+      f (ZeroArrow Z a b) (limits.equalizers.EqualizerArrow K) (equiv_Kernel1_eq f K).
   Proof.
     use limits.equalizers.mk_isEqualizer.
     intros w h H.
     use unique_exists.
-
     (* Construction of the morphism *)
     - use limits.kernels.KernelIn.
       + exact h.
       + rewrite precomp_with_ZeroArrow in H.
         use (pathscomp0 _ (!(equiv_ZeroArrow w b Z))).
         exact H.
-
     (* Commutativity *)
     - use limits.kernels.KernelCommutes.
-
     (* Equality on equalities of morphisms *)
     - intros y. apply hs.
-
     (* Uniqueness *)
     - intros y T. cbn in T.
       use limits.kernels.KernelInsEq. unfold KernelArrow.
@@ -85,9 +77,8 @@ Section def_kernels.
 
   (* Other direction *)
 
-  Lemma equiv_Kernel2_eq {a b : C} (f : C⟦a, b⟧) (K : Kernel f ) :
-    EqualizerArrow C K ;; f
-    = EqualizerArrow C K ;; limits.zero.ZeroArrow (equiv_Zero2 Z) a b.
+  Lemma equiv_Kernel2_eq {a b : C} (f : C⟦a, b⟧) (K : Kernel f) :
+    EqualizerArrow C K ;; f = EqualizerArrow C K ;; limits.zero.ZeroArrow (equiv_Zero2 Z) a b.
   Proof.
     set (tmp := EqualizerArrowEq C K).
     set (tmp1 := equiv_ZeroArrow a b Z).
@@ -97,15 +88,13 @@ Section def_kernels.
     apply tmp2.
   Qed.
 
-  Lemma equiv_Kernel2_isEqualizer {a b : C} (f : C⟦a, b⟧) (K : Kernel f ) :
+  Lemma equiv_Kernel2_isEqualizer {a b : C} (f : C⟦a, b⟧) (K : Kernel f) :
     isEqualizer C f (limits.zero.ZeroArrow (equiv_Zero2 Z) a b)
-                (EqualizerObject C K)
-                (EqualizerArrow C K) (equiv_Kernel2_eq f K).
+                (EqualizerObject C K) (EqualizerArrow C K) (equiv_Kernel2_eq f K).
   Proof.
     use mk_isEqualizer. apply hs.
     intros w h H.
     use unique_exists.
-
     (* Construction of the morphism *)
     - use EqualizerIn.
       + exact h.
@@ -113,13 +102,10 @@ Section def_kernels.
         rewrite limits.zero.ZeroArrow_comp_right in H.
         use (pathscomp0 H).
         apply (equiv_ZeroArrow w b Z).
-
     (* Commutativity *)
     - use EqualizerArrowComm.
-
     (* Equality on equalities of morphisms *)
     - intros y. apply hs.
-
     (* Uniqueness *)
     - intros y T. cbn in T.
       use EqualizerInUnique. exact T.

--- a/UniMath/CategoryTheory/limits/graphs/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/graphs/pullbacks.v
@@ -202,25 +202,25 @@ Proof.
     + exact (Empty_set_rect _ ).
 Defined.
 
-Lemma PullbackArrow_PullbackPr1 {a b c : C} {f : C⟦b , a⟧} {g : C⟦c , a⟧}
-   (Pb : Pullback f g) e (h : C⟦e , b⟧) (k : C⟦e , c⟧)(H : h ;; f = k ;; g) :
+Lemma PullbackArrow_PullbackPr1 {a b c : C} {f : C⟦b, a⟧} {g : C⟦c, a⟧}
+   (Pb : Pullback f g) e (h : C⟦e, b⟧) (k : C⟦e, c⟧)(H : h ;; f = k ;; g) :
    PullbackArrow Pb e h k H ;; PullbackPr1 Pb = h.
 Proof.
   refine (limArrowCommutes Pb e _ One).
 Qed.
 
-Lemma PullbackArrow_PullbackPr2 {a b c : C} {f : C⟦b , a⟧} {g : C⟦c , a⟧}
-   (Pb : Pullback f g) e (h : C⟦e , b⟧) (k : C⟦e , c⟧)(H : h ;; f = k ;; g) :
+Lemma PullbackArrow_PullbackPr2 {a b c : C} {f : C⟦b, a⟧} {g : C⟦c, a⟧}
+   (Pb : Pullback f g) e (h : C⟦e, b⟧) (k : C⟦e, c⟧)(H : h ;; f = k ;; g) :
    PullbackArrow Pb e h k H ;; PullbackPr2 Pb = k.
 Proof.
   refine (limArrowCommutes Pb e _ Three).
 Qed.
 
-Lemma PullbackArrowUnique {a b c d : C} (f : C⟦b , a⟧) (g : C⟦c , a⟧)
+Lemma PullbackArrowUnique {a b c d : C} (f : C⟦b, a⟧) (g : C⟦c, a⟧)
      (Pb : Pullback f g)
-     e (h : C⟦e , b⟧) (k : C⟦e , c⟧)
+     e (h : C⟦e, b⟧) (k : C⟦e, c⟧)
      (Hcomm : h ;; f = k ;; g)
-     (w : C⟦e , PullbackObject Pb⟧)
+     (w : C⟦e, PullbackObject Pb⟧)
      (H1 : w ;; PullbackPr1 Pb  = h) (H2 : w ;; PullbackPr2 Pb = k) :
   w = PullbackArrow Pb _ h k Hcomm.
 Proof.
@@ -264,8 +264,8 @@ Qed.
 *)
 
 Lemma equiv_isPullback_1 {a b c d : C} (f : C ⟦b, a⟧) (g : C ⟦c, a⟧)
-           (p1 : C⟦d,b⟧) (p2 : C⟦d,c⟧) (H : p1 ;; f = p2;; g) :
-limits.pullbacks.isPullback f g p1 p2 H -> isPullback f g p1 p2 H.
+      (p1 : C⟦d,b⟧) (p2 : C⟦d,c⟧) (H : p1 ;; f = p2;; g) :
+  limits.pullbacks.isPullback f g p1 p2 H -> isPullback f g p1 p2 H.
 Proof.
   intro X.
   intros R cc.
@@ -298,11 +298,35 @@ Proof.
     simpl; destruct t as [t HH];  simpl in *;
     apply limits.pullbacks.PullbackArrowUnique;
     [ apply (HH One) | apply (HH Three)] ).
+Qed.
+
+Definition equiv_Pullback_1 {a b c : C} (f : C⟦b, a⟧) (g : C⟦c, a⟧) :
+  limits.pullbacks.Pullback f g -> Pullback f g.
+Proof.
+  intros X.
+  exact (mk_Pullback
+           f g (limits.pullbacks.PullbackObject X)
+           (limits.pullbacks.PullbackPr1 X)
+           (limits.pullbacks.PullbackPr2 X)
+           (limits.pullbacks.PullbackSqrCommutes X)
+           (equiv_isPullback_1 _ _ _ _ _ (limits.pullbacks.isPullback_Pullback X))).
+Defined.
+
+Definition equiv_Pullbacks_1: @limits.pullbacks.Pullbacks C -> Pullbacks.
+Proof.
+  intros X' a b c f g.
+  set (X := X' a b c f g).
+  exact (mk_Pullback
+           f g (limits.pullbacks.PullbackObject X)
+           (limits.pullbacks.PullbackPr1 X)
+           (limits.pullbacks.PullbackPr2 X)
+           (limits.pullbacks.PullbackSqrCommutes X)
+           (equiv_isPullback_1 _ _ _ _ _ (limits.pullbacks.isPullback_Pullback X))).
 Defined.
 
 Lemma equiv_isPullback_2 {a b c d : C} (f : C ⟦b, a⟧) (g : C ⟦c, a⟧)
-           (p1 : C⟦d,b⟧) (p2 : C⟦d,c⟧) (H : p1 ;; f = p2;; g) :
-limits.pullbacks.isPullback f g p1 p2 H <- isPullback f g p1 p2 H.
+      (p1 : C⟦d,b⟧) (p2 : C⟦d,c⟧) (H : p1 ;; f = p2;; g) :
+  limits.pullbacks.isPullback f g p1 p2 H <- isPullback f g p1 p2 H.
 Proof.
   intro X.
   set (XR := mk_Pullback _ _ _ _ _  _ X).
@@ -320,14 +344,40 @@ Proof.
     use (PullbackArrowUnique _ _ XR);
     [apply R | apply (pr1 Hx) | apply (pr2 Hx) ]
     ).
+Qed.
+
+Definition equiv_Pullback_2 {a b c : C} (f : C⟦b, a⟧) (g : C⟦c, a⟧) :
+  limits.pullbacks.Pullback f g <- Pullback f g.
+Proof.
+  intros X.
+  exact (limits.pullbacks.mk_Pullback
+           f g
+           (PullbackObject X)
+           (PullbackPr1 X)
+           (PullbackPr2 X)
+           (PullbackSqrCommutes X)
+           (equiv_isPullback_2 _ _ _ _ _ (isPullback_Pullback X))).
+Defined.
+
+Definition equiv_Pullbacks_2 : @limits.pullbacks.Pullbacks C <- Pullbacks.
+Proof.
+  intros X' a b c f g.
+  set (X := X' a b c f g).
+  exact (limits.pullbacks.mk_Pullback
+           f g
+           (PullbackObject X)
+           (PullbackPr1 X)
+           (PullbackPr2 X)
+           (PullbackSqrCommutes X)
+           (equiv_isPullback_2 _ _ _ _ _ (isPullback_Pullback X))).
 Defined.
 
 
 
 
 
-Definition identity_is_Pullback_input {a b c : C}{f : C⟦b , a⟧} {g : C⟦c , a⟧} (Pb : Pullback f g) :
- total2 (fun hk : C⟦lim Pb , lim Pb⟧ =>
+Definition identity_is_Pullback_input {a b c : C}{f : C⟦b, a⟧} {g : C⟦c, a⟧} (Pb : Pullback f g) :
+ total2 (fun hk : C⟦lim Pb, lim Pb⟧ =>
    dirprod (hk ;; PullbackPr1 Pb = PullbackPr1 Pb)(hk ;; PullbackPr2 Pb = PullbackPr2 Pb)).
 Proof.
   exists (identity (lim Pb)).
@@ -338,13 +388,11 @@ Defined.
 
 
 (* was PullbackArrowUnique *)
-Lemma PullbackArrowUnique' {a b c d : C} (f : C⟦b , a⟧) (g : C⟦c , a⟧)
-        (p1 : C⟦d , b⟧) (p2 : C⟦d , c⟧) (H : p1 ;; f = p2;; g)
-     (P : isPullback f g p1 p2 H) e (h : C⟦e , b⟧) (k : C⟦e , c⟧)
-     (Hcomm : h ;; f = k ;; g)
-     (w : C⟦e , d⟧)
-     (H1 : w ;; p1 = h) (H2 : w ;; p2 = k) :
-     w =  (pr1 (pr1 (P e (PullbCone f g _ h k Hcomm)))).
+Lemma PullbackArrowUnique' {a b c d : C} (f : C⟦b, a⟧) (g : C⟦c, a⟧)
+      (p1 : C⟦d, b⟧) (p2 : C⟦d, c⟧) (H : p1 ;; f = p2 ;; g) (P : isPullback f g p1 p2 H)
+      (e : C) (h : C⟦e, b⟧) (k : C⟦e, c⟧) (Hcomm : h ;; f = k ;; g) (w : C⟦e, d⟧)
+      (H1 : w ;; p1 = h) (H2 : w ;; p2 = k) :
+  w =  (pr1 (pr1 (P e (PullbCone f g _ h k Hcomm)))).
 Proof.
   apply path_to_ctr.
   use three_rec_dep; cbn.
@@ -357,10 +405,9 @@ Proof.
 Qed.
 
 
-Lemma PullbackEndo_is_identity {a b c : C}{f : C⟦b , a⟧} {g : C⟦c , a⟧}
-   (Pb : Pullback f g) (k : C⟦lim Pb , lim Pb⟧) (kH1 : k ;; PullbackPr1 Pb = PullbackPr1 Pb)
-                                       (kH2 : k ;; PullbackPr2 Pb = PullbackPr2 Pb) :
-       identity (lim Pb) = k.
+Lemma PullbackEndo_is_identity {a b c : C}{f : C⟦b, a⟧} {g : C⟦c, a⟧} (Pb : Pullback f g)
+      (k : C⟦lim Pb, lim Pb⟧) (kH1 : k ;; PullbackPr1 Pb = PullbackPr1 Pb)
+      (kH2 : k ;; PullbackPr2 Pb = PullbackPr2 Pb) : identity (lim Pb) = k.
 Proof.
   apply lim_endo_is_identity.
   use three_rec_dep.
@@ -376,18 +423,17 @@ Proof.
 Qed.
 
 
-Definition from_Pullback_to_Pullback {a b c : C}{f : C⟦b , a⟧} {g : C⟦c , a⟧}
-   (Pb Pb': Pullback f g) : C⟦lim Pb , lim Pb'⟧.
+Definition from_Pullback_to_Pullback {a b c : C} {f : C⟦b, a⟧} {g : C⟦c, a⟧}
+           (Pb Pb': Pullback f g) : C⟦lim Pb, lim Pb'⟧.
 Proof.
   apply (PullbackArrow Pb' (lim Pb) (PullbackPr1 _ ) (PullbackPr2 _)).
   exact (PullbackSqrCommutes _ ).
 Defined.
 
 
-Lemma are_inverses_from_Pullback_to_Pullback {a b c : C}{f : C⟦b , a⟧} {g : C⟦c , a⟧}
-   (Pb Pb': Pullback f g) :
-is_inverse_in_precat (from_Pullback_to_Pullback Pb Pb')
-  (from_Pullback_to_Pullback Pb' Pb).
+Lemma are_inverses_from_Pullback_to_Pullback {a b c : C} {f : C⟦b, a⟧} {g : C⟦c, a⟧}
+      (Pb Pb': Pullback f g) :
+  is_inverse_in_precat (from_Pullback_to_Pullback Pb Pb') (from_Pullback_to_Pullback Pb' Pb).
 Proof.
   split; apply pathsinv0;
   apply PullbackEndo_is_identity;
@@ -399,17 +445,16 @@ Proof.
 Qed.
 
 
-Lemma isiso_from_Pullback_to_Pullback {a b c : C}{f : C⟦b , a⟧} {g : C⟦c , a⟧}
-   (Pb Pb': Pullback f g) :
-      is_isomorphism (from_Pullback_to_Pullback Pb Pb').
+Lemma isiso_from_Pullback_to_Pullback {a b c : C} {f : C⟦b, a⟧} {g : C⟦c, a⟧}
+      (Pb Pb': Pullback f g) : is_isomorphism (from_Pullback_to_Pullback Pb Pb').
 Proof.
   apply (is_iso_qinv _ (from_Pullback_to_Pullback Pb' Pb)).
   apply are_inverses_from_Pullback_to_Pullback.
 Defined.
 
 
-Definition iso_from_Pullback_to_Pullback {a b c : C}{f : C⟦b , a⟧} {g : C⟦c , a⟧}
-   (Pb Pb': Pullback f g) : iso (lim Pb) (lim Pb') :=
+Definition iso_from_Pullback_to_Pullback {a b c : C} {f : C⟦b, a⟧} {g : C⟦c, a⟧}
+           (Pb Pb': Pullback f g) : iso (lim Pb) (lim Pb') :=
   tpair _ _ (isiso_from_Pullback_to_Pullback Pb Pb').
 
 
@@ -418,8 +463,8 @@ Definition iso_from_Pullback_to_Pullback {a b c : C}{f : C⟦b , a⟧} {g : C⟦
 Section pullback_lemma.
 
 Variables a b c d e x : C.
-Variables (f : C⟦b , a⟧) (g : C⟦c , a⟧) (h : C⟦e , b⟧) (k : C⟦e , c⟧)
-          (i : C⟦d , b⟧) (j : C⟦x , e⟧) (m : C⟦x , d⟧).
+Variables (f : C⟦b, a⟧) (g : C⟦c, a⟧) (h : C⟦e, b⟧) (k : C⟦e, c⟧)
+          (i : C⟦d, b⟧) (j : C⟦x, e⟧) (m : C⟦x, d⟧).
 Hypothesis H1 : h ;; f = k ;; g.
 Hypothesis H2 : m ;; i = j ;; h.
 Hypothesis P1 : isPullback _ _ _ _ H1.
@@ -484,7 +529,7 @@ Section Universal_Unique.
 Hypothesis H : is_category C.
 
 
-Lemma inv_from_iso_iso_from_Pullback (a b c : C) (f : C⟦b , a⟧) (g : C⟦c , a⟧)
+Lemma inv_from_iso_iso_from_Pullback (a b c : C) (f : C⟦b, a⟧) (g : C⟦c, a⟧)
   (Pb : Pullback f g) (Pb' : Pullback f g):
     inv_from_iso (iso_from_Pullback_to_Pullback Pb Pb') = from_Pullback_to_Pullback Pb' Pb.
 Proof.

--- a/UniMath/CategoryTheory/limits/graphs/pushouts.v
+++ b/UniMath/CategoryTheory/limits/graphs/pushouts.v
@@ -15,6 +15,7 @@ Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.limits.pushouts.
 
+
 (** * Definition of pushouts in terms of colimits *)
 Section def_po.
 
@@ -41,7 +42,7 @@ Section def_po.
       + apply empty.
   Defined.
 
-  Definition pushout_diagram {a b c : C} (f : C ⟦a,b⟧) (g : C⟦a,c⟧) :
+  Definition pushout_diagram {a b c : C} (f : C ⟦a, b⟧) (g : C⟦a, c⟧) :
     diagram pushout_graph C.
   Proof.
     exists (three_rec a b c).
@@ -57,10 +58,9 @@ Section def_po.
       + apply fromempty.
   Defined.
 
-  Definition PushoutCocone {a b c : C} (f : C ⟦a,b⟧) (g : C⟦a,c⟧)
-             (d : C) (f' : C ⟦b, d⟧) (g' : C ⟦c,d⟧)
-             (H : f ;; f' = g ;; g')
-    : cocone (pushout_diagram f g) d.
+  Definition PushoutCocone {a b c : C} (f : C ⟦a, b⟧) (g : C⟦a, c⟧) (d : C)
+             (f' : C ⟦b, d⟧) (g' : C ⟦c, d⟧) (H : f ;; f' = g ;; g') :
+    cocone (pushout_diagram f g) d.
   Proof.
     simple refine (mk_cocone _ _  ).
     - use three_rec_dep; cbn; try assumption.
@@ -78,14 +78,13 @@ Section def_po.
   Defined.
 
   Definition isPushout {a b c d : C} (f : C ⟦a, b⟧) (g : C ⟦a, c⟧)
-             (i1 : C⟦b,d⟧) (i2 : C⟦c,d⟧) (H : f ;; i1 = g ;; i2) : UU :=
+             (i1 : C⟦b, d⟧) (i2 : C⟦c, d⟧) (H : f ;; i1 = g ;; i2) : UU :=
     isColimCocone (pushout_diagram f g) d (PushoutCocone f g d i1 i2 H).
 
   Definition mk_isPushout {a b c d : C} (f : C ⟦a, b⟧) (g : C ⟦a, c⟧)
-             (i1 : C⟦b,d⟧) (i2 : C⟦c,d⟧) (H : f ;; i1 = g ;; i2) :
-    (Π e (h : C ⟦b,e⟧) (k : C⟦c,e⟧)(Hk : f ;; h = g ;; k ),
-     iscontr (total2 (fun hk : C⟦d,e⟧ => dirprod (i1 ;; hk = h)(i2 ;; hk = k))))
-    →
+             (i1 : C⟦b, d⟧) (i2 : C⟦c, d⟧) (H : f ;; i1 = g ;; i2) :
+    (Π e (h : C ⟦b, e⟧) (k : C⟦c, e⟧)(Hk : f ;; h = g ;; k ),
+     iscontr (total2 (fun hk : C⟦d, e⟧ => dirprod (i1 ;; hk = h)(i2 ;; hk = k)))) →
     isPushout f g i1 i2 H.
   Proof.
     intros H' x cx; simpl in *.
@@ -118,14 +117,12 @@ Section def_po.
            - apply (p0 Three). }
   Defined.
 
-  Definition Pushout {a b c : C} (f : C⟦a, b⟧)(g : C⟦a, c⟧) :=
+  Definition Pushout {a b c : C} (f : C⟦a, b⟧) (g : C⟦a, c⟧) : UU :=
     ColimCocone (pushout_diagram f g).
 
-  Definition mk_Pushout {a b c : C} (f : C⟦a, b⟧)(g : C⟦a, c⟧)
-             (d : C) (i1 : C⟦b,d⟧) (i2 : C ⟦c,d⟧)
-             (H : f ;; i1 = g ;; i2)
-             (ispo : isPushout f g i1 i2 H)
-    : Pushout f g.
+  Definition mk_Pushout {a b c : C} (f : C⟦a, b⟧) (g : C⟦a, c⟧) (d : C)
+             (i1 : C⟦b,d⟧) (i2 : C ⟦c,d⟧) (H : f ;; i1 = g ;; i2)
+             (ispo : isPushout f g i1 i2 H) : Pushout f g.
   Proof.
     simple refine (tpair _ _ _ ).
     - simple refine (tpair _ _ _ ).
@@ -134,35 +131,29 @@ Section def_po.
     - apply ispo.
   Defined.
 
-  Definition Pushouts := Π (a b c : C)(f : C⟦a, b⟧)(g : C⟦a, c⟧),
-                          Pushout f g.
+  Definition Pushouts : UU := Π (a b c : C) (f : C⟦a, b⟧)(g : C⟦a, c⟧), Pushout f g.
 
-  Definition hasPushouts := Π (a b c : C) (f : C⟦a, b⟧) (g : C⟦a, c⟧),
-                            ishinh (Pushout f g).
-
+  Definition hasPushouts : UU := Π (a b c : C) (f : C⟦a, b⟧) (g : C⟦a, c⟧), ishinh (Pushout f g).
 
   Definition PushoutObject {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧}:
     Pushout f g -> C := fun H => colim H.
   (* Coercion PushoutObject : Pushout >-> ob. *)
 
-  Definition PushoutIn1 {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧}
-             (Po : Pushout f g) : C⟦b, colim Po⟧ := colimIn Po Two.
+  Definition PushoutIn1 {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧} (Po : Pushout f g) :
+    C⟦b, colim Po⟧ := colimIn Po Two.
 
-  Definition PushoutIn2 {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧}
-             (Po : Pushout f g) : C⟦c, colim Po⟧ := colimIn Po Three.
+  Definition PushoutIn2 {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧} (Po : Pushout f g) :
+    C⟦c, colim Po⟧ := colimIn Po Three.
 
-  Definition PushoutSqrCommutes {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧}
-             (Po : Pushout f g) :
+  Definition PushoutSqrCommutes {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧} (Po : Pushout f g) :
     f ;; PushoutIn1 Po = g ;; PushoutIn2 Po.
   Proof.
     eapply pathscomp0; [apply (colimInCommutes Po One Two tt) |].
     apply (!colimInCommutes Po One Three tt).
   Qed.
 
-  Definition PushoutArrow {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧}
-             (Po : Pushout f g) e (h : C⟦b, e⟧) (k : C⟦c, e⟧)
-             (H : f ;; h = g ;; k)
-    : C⟦colim Po, e⟧.
+  Definition PushoutArrow {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧} (Po : Pushout f g) (e : C)
+             (h : C⟦b, e⟧) (k : C⟦c, e⟧) (H : f ;; h = g ;; k) : C⟦colim Po, e⟧.
   Proof.
     simple refine (colimArrow _ _ _ ).
     simple refine (mk_cocone _ _ ).
@@ -180,27 +171,22 @@ Section def_po.
       + exact (Empty_set_rect _).
   Defined.
 
-  Lemma PushoutArrow_PushoutIn1 {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧}
-        (Po : Pushout f g) e (h : C⟦b , e⟧) (k : C⟦c , e⟧)
-        (H : f ;; h = g ;; k) :
+  Lemma PushoutArrow_PushoutIn1 {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧}  (Po : Pushout f g)
+        (e : C) (h : C⟦b , e⟧) (k : C⟦c, e⟧) (H : f ;; h = g ;; k) :
     PushoutIn1 Po ;; PushoutArrow Po e h k H = h.
   Proof.
     refine (colimArrowCommutes Po e _ Two).
   Qed.
 
-  Lemma PushoutArrow_PushoutIn2 {a b c : C} {f : C⟦a , b⟧} {g : C⟦a , c⟧}
-        (Po : Pushout f g) e (h : C⟦b , e⟧) (k : C⟦c , e⟧)
-        (H : f ;; h = g ;; k) :
+  Lemma PushoutArrow_PushoutIn2 {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧} (Po : Pushout f g)
+        (e : C) (h : C⟦b, e⟧) (k : C⟦c, e⟧) (H : f ;; h = g ;; k) :
     PushoutIn2 Po ;; PushoutArrow Po e h k H = k.
   Proof.
     refine (colimArrowCommutes Po e _ Three).
   Qed.
 
-  Lemma PushoutArrowUnique {a b c d : C} (f : C⟦a , b⟧) (g : C⟦a , c⟧)
-        (Po : Pushout f g)
-        e (h : C⟦b , e⟧) (k : C⟦c , e⟧)
-        (Hcomm : f ;; h = g ;; k)
-        (w : C⟦PushoutObject Po, e⟧)
+  Lemma PushoutArrowUnique {a b c d : C} (f : C⟦a, b⟧) (g : C⟦a, c⟧) (Po : Pushout f g) (e : C)
+        (h : C⟦b, e⟧) (k : C⟦c, e⟧) (Hcomm : f ;; h = g ;; k) (w : C⟦PushoutObject Po, e⟧)
         (H1 : PushoutIn1 Po ;; w = h) (H2 : PushoutIn2 Po ;; w = k) :
     w = PushoutArrow Po _ h k Hcomm.
   Proof.
@@ -212,8 +198,7 @@ Section def_po.
     apply H1.
   Qed.
 
-  Definition isPushout_Pushout {a b c : C} {f : C⟦a, b⟧}{g : C⟦a, c⟧}
-             (P : Pushout f g) :
+  Definition isPushout_Pushout {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧} (P : Pushout f g) :
     isPushout f g (PushoutIn1 P) (PushoutIn2 P) (PushoutSqrCommutes P).
   Proof.
     apply mk_isPushout.
@@ -234,25 +219,21 @@ Section def_po.
         * apply (pr2 p).
   Qed.
 
+
   (** ** Pushouts to Pushouts *)
 
-  Definition identity_is_Pushout_input {a b c : C}{f : C⟦a , b⟧} {g : C⟦a , c⟧}
-             (Po : Pushout f g) :
-    total2 (fun hk : C⟦colim Po, colim Po⟧ =>
-              dirprod (PushoutIn1 Po ;; hk = PushoutIn1 Po)
-                      (PushoutIn2 Po ;; hk = PushoutIn2 Po)).
+  Definition identity_is_Pushout_input {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧} (Po : Pushout f g) :
+    total2 (fun hk : C⟦colim Po, colim Po⟧ => dirprod (PushoutIn1 Po ;; hk = PushoutIn1 Po)
+                                                   (PushoutIn2 Po ;; hk = PushoutIn2 Po)).
   Proof.
     exists (identity (colim Po)).
     apply dirprodpair; apply id_right.
   Defined.
 
   (* was PushoutArrowUnique *)
-  Lemma PushoutArrowUnique' {a b c d : C} (f : C⟦a, b⟧) (g : C⟦a, c⟧)
-        (i1 : C⟦b, d⟧) (i2 : C⟦c, d⟧) (H : f ;; i1 = g ;; i2)
-        (P : isPushout f g i1 i2 H) e (h : C⟦b, e⟧) (k : C⟦c, e⟧)
-        (Hcomm : f ;; h = g ;; k)
-        (w : C⟦d, e⟧)
-        (H1 : i1 ;; w = h) (H2 : i2 ;; w = k) :
+  Lemma PushoutArrowUnique' {a b c d : C} (f : C⟦a, b⟧) (g : C⟦a, c⟧) (i1 : C⟦b, d⟧) (i2 : C⟦c, d⟧)
+        (H : f ;; i1 = g ;; i2) (P : isPushout f g i1 i2 H) e (h : C⟦b, e⟧) (k : C⟦c, e⟧)
+        (Hcomm : f ;; h = g ;; k) (w : C⟦d, e⟧) (H1 : i1 ;; w = h) (H2 : i2 ;; w = k) :
     w =  (pr1 (pr1 (P e (PushoutCocone f g _ h k Hcomm)))).
   Proof.
     apply path_to_ctr.
@@ -261,10 +242,9 @@ Section def_po.
     apply H1.
   Qed.
 
-  Lemma PushoutEndo_is_identity {a b c : C}{f : C⟦a, b⟧} {g : C⟦a, c⟧}
-        (Po : Pushout f g) (k : C⟦colim Po , colim Po⟧)
-        (kH1 : PushoutIn1 Po ;; k = PushoutIn1 Po)
-        (kH2 : PushoutIn2 Po ;; k = PushoutIn2 Po) :
+  Lemma PushoutEndo_is_identity {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧} (Po : Pushout f g)
+        (k : C⟦colim Po , colim Po⟧)
+        (kH1 : PushoutIn1 Po ;; k = PushoutIn1 Po) (kH2 : PushoutIn2 Po ;; k = PushoutIn2 Po) :
     identity (colim Po) = k.
   Proof.
     apply colim_endo_is_identity.
@@ -279,17 +259,16 @@ Section def_po.
     - apply kH2.
   Qed.
 
-  Definition from_Pushout_to_Pushout {a b c : C}{f : C⟦a , b⟧} {g : C⟦a , c⟧}
+  Definition from_Pushout_to_Pushout {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧}
              (Po Po': Pushout f g) : C⟦colim Po , colim Po'⟧.
   Proof.
     apply (PushoutArrow Po (colim Po') (PushoutIn1 _ ) (PushoutIn2 _)).
     exact (PushoutSqrCommutes _ ).
   Defined.
 
-  Lemma are_inverses_from_Pushout_to_Pushout {a b c : C}{f : C⟦a , b⟧}
-        {g : C⟦a , c⟧} (Po Po': Pushout f g) :
-    is_inverse_in_precat (from_Pushout_to_Pushout Po Po')
-                         (from_Pushout_to_Pushout Po' Po).
+  Lemma are_inverses_from_Pushout_to_Pushout {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧}
+        (Po Po': Pushout f g) :
+    is_inverse_in_precat (from_Pushout_to_Pushout Po Po') (from_Pushout_to_Pushout Po' Po).
   Proof.
     split; apply pathsinv0;
       apply PushoutEndo_is_identity;
@@ -300,16 +279,14 @@ Section def_po.
       auto.
   Qed.
 
-  Lemma isiso_from_Pushout_to_Pushout {a b c : C}{f : C⟦a , b⟧} {g : C⟦a , c⟧}
-        (Po Po': Pushout f g) :
-    is_isomorphism (from_Pushout_to_Pushout Po Po').
+  Lemma isiso_from_Pushout_to_Pushout {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧}
+        (Po Po': Pushout f g) : is_isomorphism (from_Pushout_to_Pushout Po Po').
   Proof.
     apply (is_iso_qinv _ (from_Pushout_to_Pushout Po' Po)).
     apply are_inverses_from_Pushout_to_Pushout.
   Defined.
 
-  Definition iso_from_Pushout_to_Pushout {a b c : C}
-             {f : C⟦a , b⟧} {g : C⟦a , c⟧}
+  Definition iso_from_Pushout_to_Pushout {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧}
              (Po Po': Pushout f g) : iso (colim Po) (colim Po') :=
     tpair _ _ (isiso_from_Pushout_to_Pushout Po Po').
 
@@ -319,8 +296,8 @@ Section def_po.
   Section pushout_lemma.
 
     Variables a b c d e x : C.
-    Variables (f : C⟦a , b⟧) (g : C⟦a , c⟧) (h : C⟦b , e⟧) (k : C⟦c , e⟧)
-              (i : C⟦b , d⟧) (j : C⟦e , x⟧) (m : C⟦d , x⟧).
+    Variables (f : C⟦a, b⟧) (g : C⟦a, c⟧) (h : C⟦b, e⟧) (k : C⟦c, e⟧)
+              (i : C⟦b, d⟧) (j : C⟦e, x⟧) (m : C⟦d, x⟧).
     Hypothesis H1 : f ;; h = g ;; k.
     Hypothesis H2 : i ;; m = h ;; j.
     Hypothesis P1 : isPushout _ _ _ _ H1.
@@ -335,8 +312,7 @@ Section def_po.
       apply idpath.
     Qed.
 
-    (** TODO: isPushoutGluedSquare : isPushout (f ;; i) g m (k ;; j)
-       glueSquares. *)
+    (** TODO: isPushoutGluedSquare : isPushout (f ;; i) g m (k ;; j) glueSquares. *)
 
   End pushout_lemma.
 
@@ -344,11 +320,9 @@ Section def_po.
 
     Hypothesis H : is_category C.
 
-    Lemma inv_from_iso_iso_from_Pushout (a b c : C)
-          (f : C⟦a , b⟧) (g : C⟦a , c⟧)
+    Lemma inv_from_iso_iso_from_Pushout (a b c : C) (f : C⟦a, b⟧) (g : C⟦a, c⟧)
           (Po : Pushout f g) (Po' : Pushout f g):
-      inv_from_iso (iso_from_Pushout_to_Pushout Po Po')
-      = from_Pushout_to_Pushout Po' Po.
+      inv_from_iso (iso_from_Pushout_to_Pushout Po Po') = from_Pushout_to_Pushout Po' Po.
     Proof.
       apply pathsinv0.
       apply inv_iso_unique'.
@@ -358,10 +332,10 @@ Section def_po.
 
   End Universal_Unique.
 
+
   (** ** Connections to other colimits *)
 
-  Lemma Pushout_from_Colims :
-    Colims C -> Pushouts.
+  Lemma Pushout_from_Colims : Colims C -> Pushouts.
   Proof.
     intros H a b c f g; apply H.
   Defined.
@@ -377,10 +351,11 @@ Section pushout_coincide.
   Variable C : precategory.
   Variable hs: has_homsets C.
 
+
   (** ** isPushout *)
 
   Lemma equiv_isPushout1 {a b c d : C} (f : C ⟦a, b⟧) (g : C ⟦a, c⟧)
-        (i1 : C⟦b,d⟧) (i2 : C⟦c,d⟧) (H : f ;; i1 = g ;; i2) :
+        (i1 : C⟦b, d⟧) (i2 : C⟦c, d⟧) (H : f ;; i1 = g ;; i2) :
     limits.pushouts.isPushout f g i1 i2 H -> isPushout C f g i1 i2 H.
   Proof.
     intros X R cc.
@@ -410,7 +385,7 @@ Section pushout_coincide.
   Qed.
 
   Lemma equiv_isPushout2 {a b c d : C} (f : C⟦a, b⟧) (g : C⟦a, c⟧)
-        (i1 : C⟦b,d⟧) (i2 : C⟦c,d⟧) (H : f ;; i1 = g ;; i2) :
+        (i1 : C⟦b, d⟧) (i2 : C⟦c, d⟧) (H : f ;; i1 = g ;; i2) :
     limits.pushouts.isPushout f g i1 i2 H <- isPushout C f g i1 i2 H.
   Proof.
     intros X R k h HH.
@@ -429,6 +404,7 @@ Section pushout_coincide.
     exact R. exact (pr1 T). exact (pr2 T).
   Qed.
 
+
   (** ** Pushout *)
 
   Definition equiv_Pushout1 {a b c : C} (f : C⟦a, b⟧) (g : C⟦a, c⟧) :
@@ -440,9 +416,7 @@ Section pushout_coincide.
              (limits.pushouts.PushoutIn1 X)
              (limits.pushouts.PushoutIn2 X)
              (limits.pushouts.PushoutSqrCommutes X)
-             (equiv_isPushout1
-                _ _ _ _ _
-                (limits.pushouts.isPushout_Pushout X))).
+             (equiv_isPushout1 _ _ _ _ _ (limits.pushouts.isPushout_Pushout X))).
   Defined.
 
   Definition equiv_Pushout2 {a b c : C} (f : C⟦a, b⟧) (g : C⟦a, c⟧) :
@@ -455,9 +429,7 @@ Section pushout_coincide.
              (PushoutIn1 C X)
              (PushoutIn2 C X)
              (PushoutSqrCommutes C X)
-             (equiv_isPushout2
-                _ _ _ _ _
-                (isPushout_Pushout C hs X))).
+             (equiv_isPushout2 _ _ _ _ _ (isPushout_Pushout C hs X))).
   Defined.
 
 End pushout_coincide.

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -994,3 +994,209 @@ Defined.
 Definition BinProductsFromPullbacks : BinProducts C := BinProductCone_PullbackCone.
 
 End binproduct_from_pullback.
+
+
+(** * Pullbacks in functor_precategory
+    We construct pullbacks in the functor category [D, C, hs] from pullbacks of C. *)
+Section pullbacks_functor_category.
+
+  Variable D C : precategory.
+  Hypothesis hs : has_homsets C.
+  Hypothesis hpb : @Pullbacks C.
+
+  Local Lemma FunctorPrecategoryPullbacks_eq (F G H : functor D C) (α : nat_trans G F)
+        (β : nat_trans H F) (a b : D) (f : D ⟦a, b⟧) :
+    PullbackPr1 (hpb _ _ _ (α a) (β a)) ;; # G f ;; α b =
+    PullbackPr2 (hpb _ _ _ (α a) (β a)) ;; # H f ;; β b.
+  Proof.
+    set (pba := hpb _ _ _ (α a) (β a)).
+    repeat rewrite <- assoc.
+    rewrite (nat_trans_ax α a b f).
+    rewrite (nat_trans_ax β a b f).
+    repeat rewrite assoc.
+    apply cancel_postcomposition.
+    exact (PullbackSqrCommutes pba).
+  Qed.
+
+  Local Lemma FunctorPrecategoryPullbacks_isfunctor (F G H : functor D C) (α : nat_trans G F)
+        (β : nat_trans H F) :
+    is_functor
+      (mk_functor_data
+         (λ d : D, hpb (F d) (G d) (H d) (α d) (β d))
+         (λ (a b : D) (f : D ⟦ a, b ⟧),
+          PullbackArrow
+            (hpb (F b) (G b) (H b) (α b) (β b))
+            (hpb (F a) (G a) (H a) (α a) (β a))
+            (PullbackPr1 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # G f)
+            (PullbackPr2 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # H f)
+            (FunctorPrecategoryPullbacks_eq F G H α β a b f))).
+  Proof.
+    split.
+    intros x. apply pathsinv0. cbn.
+    use PullbackArrowUnique.
+    rewrite functor_id. rewrite id_left. rewrite id_right. apply idpath.
+    rewrite functor_id. rewrite id_left. rewrite id_right. apply idpath.
+    intros x y z f g.
+    set (px := hpb (F x) (G x) (H x) (α x) (β x)).
+    set (py := hpb (F y) (G y) (H y) (α y) (β y)).
+    set (pz := hpb (F z) (G z) (H z) (α z) (β z)).
+    set (pz1 := PullbackArrow_PullbackPr1 pz py (PullbackPr1 py ;; # G g)
+                                          (PullbackPr2 py ;; # H g)
+                                          (FunctorPrecategoryPullbacks_eq
+                                             F G H α β y z g)).
+    set (pz2 := PullbackArrow_PullbackPr2 pz py (PullbackPr1 py ;; # G g)
+                                          (PullbackPr2 py ;; # H g)
+                                          (FunctorPrecategoryPullbacks_eq
+                                             F G H α β y z g)).
+    set (py1 := PullbackArrow_PullbackPr1 py px (PullbackPr1 px ;; # G f)
+                                          (PullbackPr2 px ;; # H f)
+                                          (FunctorPrecategoryPullbacks_eq
+                                             F G H α β x y f)).
+    set (py2 := PullbackArrow_PullbackPr2 py px (PullbackPr1 px ;; # G f)
+                                          (PullbackPr2 px ;; # H f)
+                                          (FunctorPrecategoryPullbacks_eq
+                                             F G H α β x y f)).
+    apply pathsinv0. cbn. fold px. fold py. fold pz.
+    use PullbackArrowUnique.
+    rewrite functor_comp. rewrite assoc.
+    rewrite <- assoc. rewrite pz1. rewrite assoc.
+    apply cancel_postcomposition.
+    apply py1.
+
+    rewrite functor_comp. rewrite assoc.
+    rewrite <- assoc. rewrite pz2. rewrite assoc.
+    apply cancel_postcomposition.
+    apply py2.
+  Qed.
+
+  Local Lemma FunctorPrecategoryPullbacks_is_nat_trans1 (F G H : functor D C) (α : nat_trans G F)
+        (β : nat_trans H F) :
+    is_nat_trans
+      (mk_functor_data
+         (λ d : D, hpb (F d) (G d) (H d) (α d) (β d))
+         (λ (a b : D) (f : D ⟦ a, b ⟧),
+          PullbackArrow
+            (hpb (F b) (G b) (H b) (α b) (β b))
+            (hpb (F a) (G a) (H a) (α a) (β a))
+            (PullbackPr1 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # G f)
+            (PullbackPr2 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # H f)
+            (FunctorPrecategoryPullbacks_eq F G H α β a b f))) G
+      (λ x : D, PullbackPr1 (hpb (F x) (G x) (H x) (α x) (β x))).
+  Proof.
+    intros x x' f. cbn.
+    set (px := hpb (F x) (G x) (H x) (α x) (β x)).
+    set (px' := hpb (F x') (G x') (H x') (α x') (β x')).
+    apply (PullbackArrow_PullbackPr1 px' px (PullbackPr1 px ;; # G f)
+                                     (PullbackPr2 px ;; # H f)
+                                     (FunctorPrecategoryPullbacks_eq
+                                        F G H α β x x' f)).
+  Qed.
+
+  Local Lemma FunctorPrecategoryPullbacks_is_nat_trans2 (F G H : functor D C) (α : nat_trans G F)
+        (β : nat_trans H F) :
+    is_nat_trans
+      (mk_functor_data
+         (λ d : D, hpb (F d) (G d) (H d) (α d) (β d))
+         (λ (a b : D) (f : D ⟦ a, b ⟧),
+          PullbackArrow
+            (hpb (F b) (G b) (H b) (α b) (β b))
+            (hpb (F a) (G a) (H a) (α a) (β a))
+            (PullbackPr1 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # G f)
+            (PullbackPr2 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # H f)
+            (FunctorPrecategoryPullbacks_eq F G H α β a b f))) H
+      (λ x : D, PullbackPr2 (hpb (F x) (G x) (H x) (α x) (β x))).
+  Proof.
+    intros x x' f. cbn.
+    set (px := hpb (F x) (G x) (H x) (α x) (β x)).
+    set (px' := hpb (F x') (G x') (H x') (α x') (β x')).
+    apply (PullbackArrow_PullbackPr2 px' px (PullbackPr1 px ;; # G f)
+                                     (PullbackPr2 px ;; # H f)
+                                     (FunctorPrecategoryPullbacks_eq
+                                        F G H α β x x' f)).
+  Qed.
+
+  Local Lemma FunctorPrecategoryPullbacks_comm
+        (F G H : functor D C)
+        (α : nat_trans G F)
+        (β : nat_trans H F) :
+    nat_trans_comp
+      (mk_functor_data
+         (λ d : D, hpb (F d) (G d) (H d) (α d) (β d))
+         (λ (a b : D) (f : D ⟦ a, b ⟧),
+          PullbackArrow
+            (hpb (F b) (G b) (H b) (α b) (β b))
+            (hpb (F a) (G a) (H a) (α a) (β a))
+            (PullbackPr1 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # G f)
+            (PullbackPr2 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # H f)
+            (FunctorPrecategoryPullbacks_eq F G H α β a b f))) G F
+      (mk_nat_trans
+         (mk_functor_data
+            (λ d : D, hpb (F d) (G d) (H d) (α d) (β d))
+            (λ (a b : D) (f : D ⟦ a, b ⟧),
+             PullbackArrow
+               (hpb (F b) (G b) (H b) (α b) (β b))
+               (hpb (F a) (G a) (H a) (α a) (β a))
+               (PullbackPr1 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # G f)
+               (PullbackPr2 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # H f)
+               (FunctorPrecategoryPullbacks_eq F G H α β a b f))) G
+         (λ x : D, PullbackPr1 (hpb (F x) (G x) (H x) (α x) (β x)))
+         (FunctorPrecategoryPullbacks_is_nat_trans1 F G H α β)) α =
+    nat_trans_comp
+      (mk_functor_data
+         (λ d : D, hpb (F d) (G d) (H d) (α d) (β d))
+         (λ (a b : D) (f : D ⟦ a, b ⟧),
+          PullbackArrow
+            (hpb (F b) (G b) (H b) (α b) (β b))
+            (hpb (F a) (G a) (H a) (α a) (β a))
+            (PullbackPr1 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # G f)
+            (PullbackPr2 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # H f)
+            (FunctorPrecategoryPullbacks_eq F G H α β a b f))) H F
+      (mk_nat_trans
+         (mk_functor_data
+            (λ d : D, hpb (F d) (G d) (H d) (α d) (β d))
+            (λ (a b : D) (f : D ⟦ a, b ⟧),
+             PullbackArrow
+               (hpb (F b) (G b) (H b) (α b) (β b))
+               (hpb (F a) (G a) (H a) (α a) (β a))
+               (PullbackPr1 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # G f)
+               (PullbackPr2 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # H f)
+               (FunctorPrecategoryPullbacks_eq F G H α β a b f))) H
+         (λ x : D, PullbackPr2 (hpb (F x) (G x) (H x) (α x) (β x)))
+         (FunctorPrecategoryPullbacks_is_nat_trans2 F G H α β)) β.
+  Proof.
+    use (nat_trans_eq hs). intros x. cbn.
+    apply (PullbackSqrCommutes (hpb (F x) (G x) (H x) (α x) (β x))).
+  Qed.
+
+  Definition FunctorPrecategoryPullbacks : @Pullbacks (functor_precategory D C hs).
+  Proof.
+    intros F G H α β. cbn in F, G, H, α, β.
+    use mk_Pullback.
+    (* Pullback object *)
+    - use mk_functor.
+      + use mk_functor_data.
+        * intros d.
+          exact (PullbackObject (hpb _ _ _ (α d) (β d))).
+        * intros a b f.
+          use (PullbackArrow (hpb _ _ _ (α b) (β b)) _
+                             (PullbackPr1 (hpb _ _ _ (α a) (β a)) ;; (# G f))
+                             (PullbackPr2 (hpb _ _ _ (α a) (β a)) ;; (# H f))
+                             (FunctorPrecategoryPullbacks_eq F G H α β a b f)).
+      + exact (FunctorPrecategoryPullbacks_isfunctor F G H α β).
+    (* Pr1 *)
+    - cbn. use mk_nat_trans.
+      + intros x. cbn.
+        exact (PullbackPr1 (hpb (F x) (G x) (H x) (α x) (β x))).
+      + exact (FunctorPrecategoryPullbacks_is_nat_trans1 F G H α β).
+    (* Pr2 *)
+    - cbn. use mk_nat_trans.
+      + intros x. cbn.
+        exact (PullbackPr2 (hpb (F x) (G x) (H x) (α x) (β x))).
+      + exact (FunctorPrecategoryPullbacks_is_nat_trans2 F G H α β).
+    (* Commutativity of the square *)
+    - cbn. exact (FunctorPrecategoryPullbacks_comm F G H α β).
+    (* isPullback *)
+    - cbn. apply pb_if_pointwise_pb. intros x. cbn. apply isPullback_Pullback.
+  Defined.
+
+End pullbacks_functor_category.

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -1069,19 +1069,25 @@ Section pullbacks_functor_category.
     apply py2.
   Qed.
 
+  Local Definition FunctorPrecategoryPullbacks_functor (F G H : functor D C) (α : nat_trans G F)
+        (β : nat_trans H F) : functor D C.
+  Proof.
+    use mk_functor.
+    - use mk_functor_data.
+      + intros d.
+        exact (PullbackObject (hpb _ _ _ (α d) (β d))).
+      + intros a b f.
+        use (PullbackArrow (hpb _ _ _ (α b) (β b)) _
+                           (PullbackPr1 (hpb _ _ _ (α a) (β a)) ;; (# G f))
+                           (PullbackPr2 (hpb _ _ _ (α a) (β a)) ;; (# H f))
+                           (FunctorPrecategoryPullbacks_eq F G H α β a b f)).
+    - exact (FunctorPrecategoryPullbacks_isfunctor F G H α β).
+  Defined.
+
   Local Lemma FunctorPrecategoryPullbacks_is_nat_trans1 (F G H : functor D C) (α : nat_trans G F)
         (β : nat_trans H F) :
-    is_nat_trans
-      (mk_functor_data
-         (λ d : D, hpb (F d) (G d) (H d) (α d) (β d))
-         (λ (a b : D) (f : D ⟦ a, b ⟧),
-          PullbackArrow
-            (hpb (F b) (G b) (H b) (α b) (β b))
-            (hpb (F a) (G a) (H a) (α a) (β a))
-            (PullbackPr1 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # G f)
-            (PullbackPr2 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # H f)
-            (FunctorPrecategoryPullbacks_eq F G H α β a b f))) G
-      (λ x : D, PullbackPr1 (hpb (F x) (G x) (H x) (α x) (β x))).
+    is_nat_trans (FunctorPrecategoryPullbacks_functor F G H α β) G
+                 (λ x : D, PullbackPr1 (hpb (F x) (G x) (H x) (α x) (β x))).
   Proof.
     intros x x' f. cbn.
     set (px := hpb (F x) (G x) (H x) (α x) (β x)).
@@ -1092,19 +1098,18 @@ Section pullbacks_functor_category.
                                         F G H α β x x' f)).
   Qed.
 
+  Local Definition FunctorPrecategoryPullbacks_nat_trans1 (F G H : functor D C) (α : nat_trans G F)
+        (β : nat_trans H F) : nat_trans (FunctorPrecategoryPullbacks_functor F G H α β) G.
+  Proof.
+    use mk_nat_trans.
+    - intros x. exact (PullbackPr1 (hpb (F x) (G x) (H x) (α x) (β x))).
+    - exact (FunctorPrecategoryPullbacks_is_nat_trans1 F G H α β).
+  Defined.
+
   Local Lemma FunctorPrecategoryPullbacks_is_nat_trans2 (F G H : functor D C) (α : nat_trans G F)
         (β : nat_trans H F) :
-    is_nat_trans
-      (mk_functor_data
-         (λ d : D, hpb (F d) (G d) (H d) (α d) (β d))
-         (λ (a b : D) (f : D ⟦ a, b ⟧),
-          PullbackArrow
-            (hpb (F b) (G b) (H b) (α b) (β b))
-            (hpb (F a) (G a) (H a) (α a) (β a))
-            (PullbackPr1 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # G f)
-            (PullbackPr2 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # H f)
-            (FunctorPrecategoryPullbacks_eq F G H α β a b f))) H
-      (λ x : D, PullbackPr2 (hpb (F x) (G x) (H x) (α x) (β x))).
+    is_nat_trans (FunctorPrecategoryPullbacks_functor F G H α β) H
+                 (λ x : D, PullbackPr2 (hpb (F x) (G x) (H x) (α x) (β x))).
   Proof.
     intros x x' f. cbn.
     set (px := hpb (F x) (G x) (H x) (α x) (β x)).
@@ -1115,56 +1120,21 @@ Section pullbacks_functor_category.
                                         F G H α β x x' f)).
   Qed.
 
-  Local Lemma FunctorPrecategoryPullbacks_comm
-        (F G H : functor D C)
-        (α : nat_trans G F)
-        (β : nat_trans H F) :
-    nat_trans_comp
-      (mk_functor_data
-         (λ d : D, hpb (F d) (G d) (H d) (α d) (β d))
-         (λ (a b : D) (f : D ⟦ a, b ⟧),
-          PullbackArrow
-            (hpb (F b) (G b) (H b) (α b) (β b))
-            (hpb (F a) (G a) (H a) (α a) (β a))
-            (PullbackPr1 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # G f)
-            (PullbackPr2 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # H f)
-            (FunctorPrecategoryPullbacks_eq F G H α β a b f))) G F
-      (mk_nat_trans
-         (mk_functor_data
-            (λ d : D, hpb (F d) (G d) (H d) (α d) (β d))
-            (λ (a b : D) (f : D ⟦ a, b ⟧),
-             PullbackArrow
-               (hpb (F b) (G b) (H b) (α b) (β b))
-               (hpb (F a) (G a) (H a) (α a) (β a))
-               (PullbackPr1 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # G f)
-               (PullbackPr2 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # H f)
-               (FunctorPrecategoryPullbacks_eq F G H α β a b f))) G
-         (λ x : D, PullbackPr1 (hpb (F x) (G x) (H x) (α x) (β x)))
-         (FunctorPrecategoryPullbacks_is_nat_trans1 F G H α β)) α =
-    nat_trans_comp
-      (mk_functor_data
-         (λ d : D, hpb (F d) (G d) (H d) (α d) (β d))
-         (λ (a b : D) (f : D ⟦ a, b ⟧),
-          PullbackArrow
-            (hpb (F b) (G b) (H b) (α b) (β b))
-            (hpb (F a) (G a) (H a) (α a) (β a))
-            (PullbackPr1 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # G f)
-            (PullbackPr2 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # H f)
-            (FunctorPrecategoryPullbacks_eq F G H α β a b f))) H F
-      (mk_nat_trans
-         (mk_functor_data
-            (λ d : D, hpb (F d) (G d) (H d) (α d) (β d))
-            (λ (a b : D) (f : D ⟦ a, b ⟧),
-             PullbackArrow
-               (hpb (F b) (G b) (H b) (α b) (β b))
-               (hpb (F a) (G a) (H a) (α a) (β a))
-               (PullbackPr1 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # G f)
-               (PullbackPr2 (hpb (F a) (G a) (H a) (α a) (β a)) ;; # H f)
-               (FunctorPrecategoryPullbacks_eq F G H α β a b f))) H
-         (λ x : D, PullbackPr2 (hpb (F x) (G x) (H x) (α x) (β x)))
-         (FunctorPrecategoryPullbacks_is_nat_trans2 F G H α β)) β.
+
+  Local Definition FunctorPrecategoryPullbacks_nat_trans2 (F G H : functor D C) (α : nat_trans G F)
+        (β : nat_trans H F) : nat_trans (FunctorPrecategoryPullbacks_functor F G H α β) H.
   Proof.
-    use (nat_trans_eq hs). intros x. cbn.
+    use mk_nat_trans.
+    - intros x. exact (PullbackPr2 (hpb (F x) (G x) (H x) (α x) (β x))).
+    - exact (FunctorPrecategoryPullbacks_is_nat_trans2 F G H α β).
+  Defined.
+
+  Local Lemma FunctorPrecategoryPullbacks_comm (F G H : functor D C) (α : nat_trans G F)
+        (β : nat_trans H F) :
+    nat_trans_comp _ _ _ (FunctorPrecategoryPullbacks_nat_trans1 F G H α β) α =
+    nat_trans_comp _ _ _ (FunctorPrecategoryPullbacks_nat_trans2 F G H α β) β.
+  Proof.
+    use (nat_trans_eq hs). intros x.
     apply (PullbackSqrCommutes (hpb (F x) (G x) (H x) (α x) (β x))).
   Qed.
 
@@ -1173,30 +1143,15 @@ Section pullbacks_functor_category.
     intros F G H α β. cbn in F, G, H, α, β.
     use mk_Pullback.
     (* Pullback object *)
-    - use mk_functor.
-      + use mk_functor_data.
-        * intros d.
-          exact (PullbackObject (hpb _ _ _ (α d) (β d))).
-        * intros a b f.
-          use (PullbackArrow (hpb _ _ _ (α b) (β b)) _
-                             (PullbackPr1 (hpb _ _ _ (α a) (β a)) ;; (# G f))
-                             (PullbackPr2 (hpb _ _ _ (α a) (β a)) ;; (# H f))
-                             (FunctorPrecategoryPullbacks_eq F G H α β a b f)).
-      + exact (FunctorPrecategoryPullbacks_isfunctor F G H α β).
+    - exact (FunctorPrecategoryPullbacks_functor F G H α β).
     (* Pr1 *)
-    - cbn. use mk_nat_trans.
-      + intros x. cbn.
-        exact (PullbackPr1 (hpb (F x) (G x) (H x) (α x) (β x))).
-      + exact (FunctorPrecategoryPullbacks_is_nat_trans1 F G H α β).
+    - exact (FunctorPrecategoryPullbacks_nat_trans1 F G H α β).
     (* Pr2 *)
-    - cbn. use mk_nat_trans.
-      + intros x. cbn.
-        exact (PullbackPr2 (hpb (F x) (G x) (H x) (α x) (β x))).
-      + exact (FunctorPrecategoryPullbacks_is_nat_trans2 F G H α β).
+    - exact (FunctorPrecategoryPullbacks_nat_trans2 F G H α β).
     (* Commutativity of the square *)
-    - cbn. exact (FunctorPrecategoryPullbacks_comm F G H α β).
+    - exact (FunctorPrecategoryPullbacks_comm F G H α β).
     (* isPullback *)
-    - cbn. apply pb_if_pointwise_pb. intros x. cbn. apply isPullback_Pullback.
+    - apply pb_if_pointwise_pb. intros x. cbn. apply isPullback_Pullback.
   Defined.
 
 End pullbacks_functor_category.

--- a/UniMath/CategoryTheory/limits/pushouts.v
+++ b/UniMath/CategoryTheory/limits/pushouts.v
@@ -304,8 +304,8 @@ Section epi_po.
   Variable C : precategory.
 
   (** The pushout of an epimorphism is an epimorphism. *)
-  Lemma EpiPushoutEpi {a b c : C} (E : Epi _ a b) (g : a --> c)
-        (PB : Pushout E g) : isEpi (PushoutIn2 PB).
+  Lemma EpiPushoutisEpi {a b c : C} (E : Epi _ a b) (g : a --> c) (PB : Pushout E g) :
+    isEpi (PushoutIn2 PB).
   Proof.
     apply mk_isEpi. intros z g0 h X.
     use (MorphismsOutofPushoutEqual (isPushout_Pushout PB) _ _ _ X).
@@ -318,8 +318,8 @@ Section epi_po.
   Defined.
 
   (** Same result for the other morphism *)
-  Lemma EpiPushoutEpi' {a b c : C} (f : a --> b) (E : Epi _ a c)
-        (PB : Pushout f E) : isEpi (PushoutIn1 PB).
+  Lemma EpiPushoutisEpi' {a b c : C} (f : a --> b) (E : Epi _ a c) (PB : Pushout f E) :
+    isEpi (PushoutIn1 PB).
   Proof.
     apply mk_isEpi. intros z g0 h X.
     use (MorphismsOutofPushoutEqual (isPushout_Pushout PB) _ _ X).

--- a/UniMath/CategoryTheory/slicecat.v
+++ b/UniMath/CategoryTheory/slicecat.v
@@ -52,9 +52,21 @@ Section slice_precat_def.
 Variable C : precategory.
 Variable x : C.
 
+(* Accessor functions *)
 Definition slicecat_ob := total2 (fun (a : C) => a --> x).
 Definition slicecat_mor (f g : slicecat_ob) :=
   total2 (fun h : pr1 f --> pr1 g => pr2 f = h ;; pr2 g).
+
+Definition slicecat_ob_object (f : slicecat_ob) : ob C := pr1 f.
+
+Definition slicecat_ob_morphism (f : slicecat_ob) : C⟦slicecat_ob_object f, x⟧ := pr2 f.
+
+(* Accessor functions *)
+Definition slicecat_mor_morphism {f g : slicecat_ob} (h : slicecat_mor f g) :
+  C⟦slicecat_ob_object f, slicecat_ob_object g⟧ := pr1 h.
+
+Definition slicecat_mor_comm {f g : slicecat_ob} (h : slicecat_mor f g) :
+  (slicecat_ob_morphism f) = (slicecat_mor_morphism h) ;; (slicecat_ob_morphism g) := pr2 h.
 
 Definition slice_precat_ob_mor : precategory_ob_mor :=
   tpair _ _ slicecat_mor.
@@ -65,8 +77,8 @@ Definition id_slice_precat (c : slice_precat_ob_mor) : c --> c :=
 Definition comp_slice_precat_subproof (a b c : slice_precat_ob_mor)
   (f : a --> b) (g : b --> c) : pr2 a = (pr1 f ;; pr1 g) ;; pr2 c.
 Proof.
-rewrite <- assoc, (!(pr2 g)).
-exact (pr2 f).
+  rewrite <- assoc, (!(pr2 g)).
+  exact (pr2 f).
 Qed.
 
 Definition comp_slice_precat (a b c : slice_precat_ob_mor)


### PR DESCRIPTION
Hi,

this pull request contains the following:
- Formalization of undercategories (dual to slice_precat) in
  UnderPrecategories.v.
- Formalization of Subobjects and Quotobjects in C of an object c.
  These are defined by first taking the subcategory consisting of
  all monics (resp. epis) of C and then taking slice_precat
  (resp. UnderPrecategory) of c in this category. Subobjects (resp.
  quotient objects) are then objects of this category.
- Formalization of Grothendieck toposes in GrothendieckTopos.v .
  This definition should be carefully checked. I followed the definition 
  found in "Sheaves in Geometry and Logic", page 110.

Changes in other files:
- In Abelian.v, changed "subobject" to "monic" and "quotobject" to "epi".
- In Monics.v and Epis.v I defined the subcategories consisting of all
  monics and epis, respectively, and gave method to construct monics and epis in
  functor categories.
- In more_on_pullbacks.v, showed that a functor category [D, C hsC] has
  pullbacks if C has pullbacks using the result on pointwise isPullback.
- In functor_precategories.v I added functions "mk_*" to construct things.
- In yoneda.v I added a construction of a natural transformation
  yoneda c -> yoneda c' from a morphism h : c --> c'.
- pushouts.v, fixed typos
- graphs/pullbacks.v , if pullbacks exist as limits, then pullbacks exist as
  direct definition, and vice versa.
- category_hset_structures.v, uncomment the proof about pullbacks as a
  special case of limits.

All comments are welcome.
