### PR TITLE
clean up in preparation for primitive projections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,9 @@ $(LATEXDIR)/doc.pdf : $(LATEXDIR)/helper.tex
 $(LATEXDIR)/coqdoc.sty $(LATEXDIR)/helper.tex : $(VFILES:.v=.glob) $(VFILES)
 	$(COQDOC) -Q UniMath UniMath $(COQDOCLATEXOPTIONS) $(VFILES) -o $@
 
+.PHONY: enforce-max-line-length
+enforce-max-line-length:
+	LC_ALL="en_US.UTF-8" gwc -L $(VFILES) | grep -vw total | awk '{ if ($$1 > 100) { printf "%6d  %s\n", $$1, $$2 }}' | sort -r | grep .
 
 #################################
 # targets best used with INCLUDE=no

--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,8 @@ $(LATEXDIR)/coqdoc.sty $(LATEXDIR)/helper.tex : $(VFILES:.v=.glob) $(VFILES)
 .PHONY: enforce-max-line-length
 enforce-max-line-length:
 	LC_ALL="en_US.UTF-8" gwc -L $(VFILES) | grep -vw total | awk '{ if ($$1 > 100) { printf "%6d  %s\n", $$1, $$2 }}' | sort -r | grep .
+show-long-lines:
+	LC_ALL="en_US.UTF-8" grep -nE '.{101}' $(VFILES)
 
 #################################
 # targets best used with INCLUDE=no

--- a/UniMath/.dir-locals.el
+++ b/UniMath/.dir-locals.el
@@ -1,6 +1,7 @@
 ((coq-mode
   . ((eval . 
 	   (let ((unimath-topdir (expand-file-name (locate-dominating-file buffer-file-name "UniMath"))))
+	     (setq fill-column 100)
 	     (make-local-variable 'coq-use-project-file)
 	     (setq coq-use-project-file nil)
 	     (make-local-variable 'coq-prog-args)

--- a/UniMath/CategoryTheory/Abelian.v
+++ b/UniMath/CategoryTheory/Abelian.v
@@ -238,8 +238,8 @@ Section abelian_monic_epi_iso.
     set (AMK := Abelian_AMKD A x y M1).
     set (AEC := Abelian_AECD A x y E1).
 
-    induction AMK. induction t. induction t.
-    induction AEC. induction t0. induction t0.
+    induction AMK as [t p]. induction t as [t p0]. induction t as [t p1].
+    induction AEC as [t0 p2]. induction t0 as [t0 p3]. induction t0 as [t0 p4].
 
     unfold isEqualizer in p. unfold isCoequalizer in p2.
 
@@ -249,7 +249,7 @@ Section abelian_monic_epi_iso.
     set (t'1 := maponpaths (fun h : A⟦y, t⟧ => identity _ ;; h) p0).
     cbn in t'1.
     set (p'' := p' t'1).
-    induction p''. induction t1.
+    induction p'' as [t1 p5]. induction t1 as [t1 p6].
 
     use is_iso_qinv.
 
@@ -479,7 +479,7 @@ Section abelian_subobject_pullbacks.
     intros y0. apply isapropdirprod. apply hs. apply hs.
 
     (* Uniqueness *)
-    intros y0 t. cbn in t. induction t.
+    intros y0 t. cbn in t. induction t as [t p].
     apply (KernelArrowisMonic (Abelian_Zero A) ker).
     rewrite (KernelCommutes (Abelian_Zero A) ker).
     rewrite <- (KernelCommutes (Abelian_Zero A) ker1 ker
@@ -726,7 +726,7 @@ Section abelian_subobject_pullbacks.
     intros y0. apply isapropdirprod. apply hs. apply hs.
 
     (* Uniqueness *)
-    intros y0 t. cbn in t. induction t.
+    intros y0 t. cbn in t. induction t as [t p].
     apply (CokernelArrowisEpi (Abelian_Zero A) coker).
     rewrite (CokernelCommutes (Abelian_Zero A) coker).
     rewrite <- (CokernelCommutes (Abelian_Zero A) coker1 coker

--- a/UniMath/CategoryTheory/category_abgr.v
+++ b/UniMath/CategoryTheory/category_abgr.v
@@ -998,7 +998,7 @@ Section ABGR_kernels.
     = ZeroArrow ABGR ABGR_has_zero
                 (carrierofasubabgr (ABGR_kernel_subabgr f)) B.
   Proof.
-    use total2_paths. apply funextfun. intros x. induction x. cbn.
+    use total2_paths. apply funextfun. intros x. induction x as [t p]. cbn.
     unfold funcomp, pr1carrier. cbn in p. cbn.
     use (squash_to_prop p). apply (setproperty B).
     intros X.
@@ -1100,9 +1100,9 @@ Section ABGR_kernels.
     intros a a'.  induction a as [a1 a2]. induction a' as [a'1 a'2].
     cbn in *.  unfold ishinh_UU in *.
     intros P X. apply (a2 P). intros a3. apply (a'2 P). intros a'3. apply X.
-    cbn in *. use tpair.  induction a3. induction a'3.
+    cbn in *. use tpair.  induction a3 as [t p]. induction a'3 as [t0 p0].
     apply (op t t0). cbn. unfold total2_rect.
-    induction a3. induction a'3. rewrite (pr1 (pr2 f)). cbn in *.
+    induction a3 as [t p]. induction a'3 as [t0 p0]. rewrite (pr1 (pr2 f)). cbn in *.
     rewrite p. rewrite p0. apply idpath.
 
     intros P X. apply X. use tpair. exact (unel A). cbn.
@@ -1112,7 +1112,7 @@ Section ABGR_kernels.
     intros x a.
     unfold ABGR_image_hsubtype in *. unfold ishinh in *. cbn in *.
     unfold ishinh_UU in *. intros P X. apply a. intros X1. apply X.
-    induction X1. use tpair. apply (grinv A t). cbn.
+    induction X1 as [t p]. use tpair. apply (grinv A t). cbn.
     set (XXt := monoidfuninvtoinv f t). cbn in XXt.
     rewrite XXt. rewrite p. apply idpath.
   Qed.
@@ -1129,7 +1129,7 @@ Section ABGR_kernels.
   Proof.
     intros x1 x2 x3 y1 y2.
     unfold ishinh in *. cbn in *. unfold ishinh_UU in *. intros P X.
-    apply y1. intros Y1. apply y2. intros Y2. induction Y1, Y2. apply X.
+    apply y1. intros Y1. apply y2. intros Y2. induction Y1 as [t p], Y2 as [t0 p0]. apply X.
     refine (tpair _ (op t t0) _). rewrite (pr1 (pr2 f)). cbn in *.
     rewrite p. rewrite p0.
 
@@ -1151,7 +1151,7 @@ Section ABGR_kernels.
   Proof.
     intros x1 x2 x3 y1 y2.
     unfold ishinh in *. cbn in *. unfold ishinh_UU in *. apply x3.
-    intros X3. apply y2. induction X3. refine (tpair _ (grinv A t) _).
+    intros X3. apply y2. induction X3 as [t p]. refine (tpair _ (grinv A t) _).
     set (XXf := (grinvandmonoidfun A B (pr2 f) t)). cbn in XXf.
     rewrite XXf. rewrite p.
     set (XXB := grinvcomp B x1 (grinv B x2)). cbn in XXB.
@@ -1175,7 +1175,7 @@ Section ABGR_kernels.
   Proof.
     use isbinophrelif. apply (pr2 (pr2 B)).
     intros x1 x2 x3 y1. cbn in *. unfold ishinh_UU in *. intros P X.
-    apply y1. intros Y1. induction Y1. apply X.
+    apply y1. intros Y1. induction Y1 as [t p]. apply X.
     refine (tpair _ t _). rewrite p. rewrite ((pr2 (pr2 B)) x3 _).
     rewrite (assocax B). apply lopeq. rewrite ((pr2 (pr2 B)) x3 _).
     rewrite grinvcomp. rewrite (assocax B). rewrite (grlinvax B).
@@ -1232,7 +1232,7 @@ Section ABGR_kernels.
     intros HH1.
     use (squash_to_prop H2). apply (pr2 (pr1 C)).
     intros HH2.
-    unfold hfiber in *. induction HH1. induction HH2.
+    unfold hfiber in *. induction HH1 as [t p]. induction HH2 as [t0 p0].
     rewrite <- p. rewrite <- p0. rewrite <- f'. cbn.
 
     assert (g (f (t * t0)%multmonoid) = (g ∘ f) (t * t0)%multmonoid).
@@ -1253,7 +1253,7 @@ Section ABGR_kernels.
   Proof.
     intros x x' X.
     use (squash_to_prop X). apply (pr2 (pr1 (pr1 C))).
-    intros X'. induction X'.
+    intros X'. induction X' as [t p].
     set (Y := funeqpaths H t). cbn in Y.
     apply (maponpaths (pr1 h)) in p. cbn in *.
     rewrite Y in p. rewrite (pr1 (pr2 h)) in p.
@@ -1309,14 +1309,14 @@ Section ABGR_kernels.
     intros y. cbn. intros x x'. apply (has_homsets_ABGR).
 
     (* Uniqueness *)
-    intros y. induction y. intros  t0. cbn in t0.
+    intros y. induction y as [t p]. intros  t0. cbn in t0.
     use total2_paths. cbn. apply funextfun.
     intros z. cbn in *.
     set (surj := issurjsetquotpr (ABGR_cokernel_eqrel f)).
     unfold issurjective in surj. cbn in surj.
     set (surjz := surj z).
     use (squash_to_prop surjz). apply (pr2 (pr1 (pr1 w))).
-    intros surjz'. unfold hfiber in surjz'. induction surjz'.
+    intros surjz'. unfold hfiber in surjz'. induction surjz' as [t1 p0].
     rewrite <- p0. cbn. apply base_paths in t0. cbn in t0.
     unfold funcomp in t0. apply (funeqpaths t0 t1).
 
@@ -1476,26 +1476,26 @@ Section ABGR_monics.
     iscomprelfun (binopeqrelabgrfrac (rigaddabmonoid natcommrig))
                  (ABGR_natset_dirprod_map a).
   Proof.
-    intros x. induction x. induction p.
+    intros x. induction x as [t p]. induction p.
 
-    intros x'. induction x'. induction p.
+    intros x'. induction x' as [t0 p]. induction p.
     intros H. cbn in *. use (squash_to_prop H). apply (setproperty A).
-    intros H'. induction H'. repeat rewrite natplusassoc in p. cbn in p.
+    intros H'. induction H' as [t1 p]. repeat rewrite natplusassoc in p. cbn in p.
     apply natplusrcan in p. rewrite p. apply idpath.
 
     intros H. cbn in *. use (squash_to_prop H). apply (setproperty A).
-    intros H'. induction H'. rewrite (natplusassoc _ 0) in p0. cbn in p0.
+    intros H'. induction H' as [t1 p0]. rewrite (natplusassoc _ 0) in p0. cbn in p0.
     apply natplusrcan in p0. rewrite <- p0.
     rewrite ABGR_natset_dirprod_map_ind. apply idpath.
 
-    intros x'. induction x'. induction p0.
+    intros x'. induction x' as [t0 p0]. induction p0.
     intros H. cbn in *. use (squash_to_prop H). apply (setproperty A).
-    intros H'. induction H'. rewrite natplusassoc in p0. cbn in p0.
+    intros H'. induction H' as [t1 p0]. rewrite natplusassoc in p0. cbn in p0.
     apply natplusrcan in p0. rewrite p0.
     rewrite ABGR_natset_dirprod_map_ind. apply idpath.
 
     intros H. cbn in *. use (squash_to_prop H). apply (setproperty A).
-    intros H'. induction H'. apply natplusrcan in p1.
+    intros H'. induction H' as [t1 p1]. apply natplusrcan in p1.
     repeat rewrite natplusnsm in p1. cbn in p1.
     apply invmaponpathsS in p1.
     set (tmp := IHp (t0,,p0)). cbn in tmp.
@@ -1567,7 +1567,7 @@ Section ABGR_monics.
     set (tmp1 := pr1weq (invweq tmp) H).
     unfold ABGR_cokernel_eqrel in tmp1. cbn in tmp1.
 
-    intros P X. apply tmp1. intros Y. apply X. induction Y.
+    intros P X. apply tmp1. intros Y. apply X. induction Y as [t p].
     rewrite grinvunel in p.
     rewrite (runax B) in p.
     apply (hfiberpair (pr1 f) t p).
@@ -1611,7 +1611,7 @@ Section ABGR_monics.
     = monoidfuncomp (ABGR_natset_dirprod_map_monoidfun a2) f.
   Proof.
     use total2_paths. cbn. unfold funcomp. apply funextfun.
-    intros x. induction x. induction t. induction p.
+    intros x. induction x as [t p]. induction t. induction p.
 
     (* p = 0 *)
     unfold ABGR_natset_dirprod_map. cbn.
@@ -1651,7 +1651,7 @@ Section ABGR_monics.
     apply base_paths in X. cbn in X. unfold funcomp in X.
     unfold issurjective in H.
     use (squash_to_prop (H x)). use (setproperty C).
-    intros h. induction h.
+    intros h. induction h as [t p].
     rewrite <- p.
     apply (funeqpaths X t).
 

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -620,7 +620,7 @@ use adjunction_from_partial.
         apply maponpaths;
         assert (H : # R (identity x) = identity (R x));
           [apply functor_id|];
-        destruct p; apply maponpaths; simpl;
+        induction p as [t p]; apply maponpaths; simpl;
         now apply pathsinv0; eapply pathscomp0; [apply (toforallpaths _ _ _ H p)|]).
   + abstract (
     intros [t p]; apply subtypeEquality; simpl;

--- a/UniMath/CategoryTheory/cocontfunctors.v
+++ b/UniMath/CategoryTheory/cocontfunctors.v
@@ -277,7 +277,7 @@ mkpair.
   apply subtypeEquality; simpl.
   + intro x; apply impred; intro.
     apply isaset_dirprod; [ apply hsC | apply hsD ].
-  + destruct t as [[f1 f2] ?]; simpl in *.
+  + induction t as [[f1 f2] p]; simpl in *.
     apply pathsdirprod.
     * apply (maponpaths pr1 (hf2 (f1,, (λ n, maponpaths pr1 (p n))))).
     * apply (maponpaths pr1 (hg2 (f2,, (λ n, maponpaths dirprod_pr2 (p n))))).
@@ -856,10 +856,10 @@ Proof.
   apply subtypeEquality; simpl.
   + intro; apply impred; intros; apply hsC.
   + apply (colimArrowUnique HAiM K ccAiM_K).
-    destruct t; simpl; intro i.
+    induction t as [t p]; simpl; intro i.
     apply (colimArrowUnique (CCAiB i) K (ccAiB_K i)).
     simpl; intros j; unfold map_to_K.
-    destruct (natlthorgeh i j).
+    induction (natlthorgeh i j) as [h|h].
     * rewrite <- (p j); unfold fun_lt.
       rewrite !assoc.
       apply cancel_postcomposition.

--- a/UniMath/CategoryTheory/limits/BinDirectSums.v
+++ b/UniMath/CategoryTheory/limits/BinDirectSums.v
@@ -519,7 +519,7 @@ Section bindirectsums_criteria.
 
     intros y. apply isapropdirprod. apply hs. apply hs.
 
-    intros y H. induction H. rewrite <- t. rewrite <- p.
+    intros y H. induction H as [t p]. rewrite <- t. rewrite <- p.
     rewrite assoc. rewrite assoc. cbn.
     set (tmp := (PreAdditive_postmor_linear
                    A _ _ _ y
@@ -547,7 +547,7 @@ Section bindirectsums_criteria.
     apply BinProductPr1Commutes.
     apply BinProductPr2Commutes.
     intros y. apply isapropdirprod. apply hs. apply hs.
-    intros y H. induction H. rewrite <- t. rewrite <- p.
+    intros y H. induction H as [t p]. rewrite <- t. rewrite <- p.
     rewrite <- precompWithBinProductArrow.
     apply BinProductArrowsEq.
     rewrite <- assoc. rewrite BinProductPr1Commutes. apply idpath.

--- a/UniMath/CategoryTheory/limits/FinOrdCoproducts.v
+++ b/UniMath/CategoryTheory/limits/FinOrdCoproducts.v
@@ -100,7 +100,7 @@ Section FinOrdCoproduct_criteria.
     use (mk_CoproductCocone (stn (S n)) C a (BinCoproductObject _ BinCone) _).
 
     (* Construction of the arrows from a i to BinCone *)
-    intros i. induction (natlehchoice4 (pr1 i) _ (pr2 i)).
+    intros i. induction (natlehchoice4 (pr1 i) _ (pr2 i)) as [a0|b].
     exact (idtoiso (maponpaths a (dni_lastelement_eq n i a0))
                    ;; m1 (stnpair n (pr1 i) a0)).
     exact (idtoiso (maponpaths a (lastelement_eq n i b))
@@ -128,7 +128,7 @@ Section FinOrdCoproduct_criteria.
     use (CoproductArrow _ _ Cone2). intros i. exact (g (lastelement n)).
 
     (* First commutativity. *)
-    intros i. unfold coprod_rect. induction (natlehchoice4 (pr1 i) n (pr2 i)).
+    intros i. unfold coprod_rect. induction (natlehchoice4 (pr1 i) n (pr2 i)) as [a0|b].
     rewrite (dni_lastelement_eq n i a0). repeat rewrite <- assoc.
     apply remove_id_left. apply idpath.
 
@@ -160,7 +160,7 @@ Section FinOrdCoproduct_criteria.
     intros i. rewrite <- (X (dni_lastelement i)). rewrite assoc.
     apply cancel_postcomposition.
     induction (natlehchoice4 (pr1 (dni_lastelement i)) n
-                             (pr2 (dni_lastelement i))).
+                             (pr2 (dni_lastelement i))) as [a0|b].
     unfold m1. rewrite assoc. unfold in1.
     apply cancel_postcomposition.
     unfold Cone1In. apply pathsinv0.
@@ -184,7 +184,7 @@ Section FinOrdCoproduct_criteria.
     apply CoproductArrowUnique.
     intros i. rewrite <- (X (lastelement n)). rewrite assoc.
     apply cancel_postcomposition.
-    induction (natlehchoice4 (pr1 (lastelement n)) n (pr2 (lastelement n))).
+    induction (natlehchoice4 (pr1 (lastelement n)) n (pr2 (lastelement n))) as [a0|b].
 
     (* This case is false because of a0 *)
     apply fromempty. cbn in a0. apply (isirreflnatlth _ a0).

--- a/UniMath/CategoryTheory/limits/FinOrdProducts.v
+++ b/UniMath/CategoryTheory/limits/FinOrdProducts.v
@@ -103,7 +103,7 @@ Section FinOrdProduct_criteria.
     use (mk_ProductCone (stn (S n)) C a BinConeOb _).
 
     (* Construction of the arrows from a i to BinConeOb *)
-    intros i. induction (natlehchoice4 (pr1 i) _ (pr2 i)).
+    intros i. induction (natlehchoice4 (pr1 i) _ (pr2 i)) as [a0|b].
     exact (m1 (stnpair n (pr1 i) a0) ;;
               idtoiso (! maponpaths a (dni_lastelement_eq n i a0))).
     exact (m2 (invweq(weqstn1tounit) tt) ;;
@@ -129,7 +129,7 @@ Section FinOrdProduct_criteria.
     use (ProductArrow _ _ Cone2). intros i. exact (g (lastelement n)).
 
     (* First commutativity. *)
-    intros i. unfold coprod_rect. induction (natlehchoice4 (pr1 i) n (pr2 i)).
+    intros i. unfold coprod_rect. induction (natlehchoice4 (pr1 i) n (pr2 i)) as [a0|b].
     rewrite (dni_lastelement_eq n i a0). repeat rewrite assoc.
     apply remove_id_right. apply idpath.
 
@@ -161,7 +161,7 @@ Section FinOrdProduct_criteria.
     intros i. rewrite <- (X (dni_lastelement i)). rewrite <- assoc.
     apply cancel_precomposition.
     induction (natlehchoice4 (pr1 (dni_lastelement i)) n
-                             (pr2 (dni_lastelement i))).
+                             (pr2 (dni_lastelement i))) as [a0|b].
     unfold m1. rewrite <- assoc. unfold p1.
     apply cancel_precomposition.
     unfold Cone1Pr. apply pathsinv0.
@@ -187,7 +187,7 @@ Section FinOrdProduct_criteria.
     apply ProductArrowUnique.
     intros i. rewrite <- (X (lastelement n)).  rewrite <- assoc.
     apply cancel_precomposition.
-    induction (natlehchoice4 (pr1 (lastelement n)) n (pr2 (lastelement n))).
+    induction (natlehchoice4 (pr1 (lastelement n)) n (pr2 (lastelement n))) as [a0|b].
 
     (* This case is false because of a0 *)
     apply fromempty. cbn in a0. apply (isirreflnatlth _ a0).

--- a/UniMath/CategoryTheory/limits/cokernels.v
+++ b/UniMath/CategoryTheory/limits/cokernels.v
@@ -186,8 +186,8 @@ Section cokernels_iso.
              (H : g = (CokernelArrow _ CK) ;; h) :
     f ;; g = ZeroArrow C Z x z.
   Proof.
-    induction CK. induction t. induction p.
-    unfold isCoequalizer in p.
+    induction CK as [t p]. induction t as [t' p']. induction p as [t'' p''].
+    unfold isCoequalizer in p''.
     rewrite H.
     rewrite <- (ZeroArrow_comp_left _ _ _ _ _ h).
     rewrite assoc.
@@ -203,16 +203,16 @@ Section cokernels_iso.
                   (CokernelEqRw Z (Cokernel_up_to_iso_eq f g CK h H)).
   Proof.
     apply mk_isCoequalizer.
-    induction CK. induction t. induction p.
-    unfold isCoequalizer in p.
+    induction CK as [t p]. induction t as [t' p']. induction p as [t'' p''].
+    unfold isCoequalizer in p''.
     intros w h0 HH.
-    set (tmp := p w h0 HH). cbn in tmp. cbn in h.
-    induction tmp.
-    induction t1.
+    set (tmp := p'' w h0 HH). cbn in tmp. cbn in h.
+    induction tmp as [t''' p'''].
+    induction t''' as [t'''' p''''].
 
     use unique_exists.
-    exact ((inv_from_iso h) ;; t1).
-    cbn. rewrite <- p2.
+    exact ((inv_from_iso h) ;; t'''').
+    cbn. rewrite <- p''''.
     rewrite assoc. apply cancel_postcomposition.
     cbn in H. rewrite H. rewrite <- assoc.
     rewrite <- id_right. apply cancel_precomposition.
@@ -222,7 +222,7 @@ Section cokernels_iso.
     intros y0 X. cbn in X. cbn in H.
     rewrite H in X.
     rewrite <- assoc in X.
-    set (tmp := p1 (tpair _ (h ;; y0) X)).
+    set (tmp := p''' (tpair _ (h ;; y0) X)).
     apply base_paths in tmp. cbn in tmp.
     rewrite <- tmp. rewrite assoc.
     rewrite iso_after_iso_inv.

--- a/UniMath/CategoryTheory/limits/graphs/coequalizers.v
+++ b/UniMath/CategoryTheory/limits/graphs/coequalizers.v
@@ -95,7 +95,7 @@ Section def_coequalizers.
       + apply (pr2 (pr1 H2)).
     - intro t. apply subtypeEquality.
       intros y. apply impred. intros t0. apply hs.
-      induction t. cbn.
+      induction t as [t p]. cbn.
       apply path_to_ctr.
       apply (p Two).
   Defined.

--- a/UniMath/CategoryTheory/limits/graphs/equalizers.v
+++ b/UniMath/CategoryTheory/limits/graphs/equalizers.v
@@ -94,7 +94,7 @@ Section def_equalizers.
          apply (pr2 (pr1 H2)).
     - intro t. apply subtypeEquality.
       intros y. apply impred. intros t0. apply hs.
-      induction t. cbn.
+      induction t as [t p]. cbn.
       apply path_to_ctr.
       apply (p One).
   Defined.

--- a/UniMath/CategoryTheory/limits/kernels.v
+++ b/UniMath/CategoryTheory/limits/kernels.v
@@ -176,8 +176,8 @@ Section kernels_iso.
              (H : f = h ;; (KernelArrow _ K)) :
     f ;; g = ZeroArrow C Z x z.
   Proof.
-    induction K. induction t. induction p.
-    unfold isEqualizer in p.
+    induction K as [t p]. induction t as [t' p']. induction p as [t'' p''].
+    unfold isEqualizer in p''.
     rewrite H.
     rewrite <- (ZeroArrow_comp_right _ _ _ _ _ h).
     rewrite <- assoc.
@@ -193,16 +193,16 @@ Section kernels_iso.
                 (KernelEqRw Z (Kernel_up_to_iso_eq f g K h H)).
   Proof.
    apply mk_isEqualizer.
-    induction K. induction t. induction p.
-    unfold isEqualizer in p.
+    induction K as [t p]. induction t as [t' p']. induction p as [t'' p''].
+    unfold isEqualizer in p''.
     intros w h0 HH.
-    set (tmp := p w h0 HH). cbn in tmp. cbn in h.
-    induction tmp.
-    induction t1.
+    set (tmp := p'' w h0 HH). cbn in tmp. cbn in h.
+    induction tmp as [t''' p'''].
+    induction t''' as [t'''' p''''].
 
     use unique_exists.
-    exact (t1 ;; (inv_from_iso h)).
-    cbn. rewrite <- p2.
+    exact (t'''' ;; (inv_from_iso h)).
+    cbn. rewrite <- p''''.
     rewrite <- assoc. apply cancel_precomposition.
     cbn in H. rewrite H. rewrite assoc.
     rewrite <- id_left. apply cancel_postcomposition.
@@ -212,7 +212,7 @@ Section kernels_iso.
     intros y0 X. cbn in X. cbn in H.
     rewrite H in X.
     rewrite assoc in X.
-    set (tmp := p1 (tpair _ (y0 ;; h) X)).
+    set (tmp := p''' (tpair _ (y0 ;; h) X)).
     apply base_paths in tmp. cbn in tmp.
     rewrite <- tmp. rewrite <- assoc.
     rewrite iso_inv_after_iso.

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -404,7 +404,7 @@ Section pb_criteria.
     intros y. apply isapropdirprod. apply hs. apply hs.
 
     (* Uniqueness *)
-    intros y H. induction H. apply EqualizerInsEq. apply BinProductArrowsEq.
+    intros y H. induction H as [t p]. apply EqualizerInsEq. apply BinProductArrowsEq.
     rewrite assoc in t. rewrite t.
     rewrite (EqualizerCommutes Eq e _). apply pathsinv0.
     exact (BinProductPr1Commutes C _ _ BinProd _ h k).

--- a/UniMath/CategoryTheory/limits/pushouts.v
+++ b/UniMath/CategoryTheory/limits/pushouts.v
@@ -380,7 +380,7 @@ Section po_criteria.
     intros y. apply isapropdirprod. apply hs. apply hs.
 
     (* Uniqueness *)
-    intros y H. induction H. apply CoequalizerOutsEq.
+    intros y H. induction H as [t p]. apply CoequalizerOutsEq.
     apply BinCoproductArrowsEq.
     rewrite <- assoc in t. rewrite t.
     rewrite (CoequalizerCommutes CEq e _). apply pathsinv0.

--- a/UniMath/Foundations/Basics/Preamble.v
+++ b/UniMath/Foundations/Basics/Preamble.v
@@ -74,7 +74,8 @@ The coproduct of two types is introduced in Coq.Init.Datatypes by the lines:
 Inductive coprod (__A__ __B__:Type) : Type :=
   | inl : __A__ -> coprod __A__ __B__
   | inr : __B__ -> coprod __A__ __B__.
-(* Do not use "induction" on an element of this type without specifying names; seeing __A__ or __B__ will indicate that you did that. *)
+(* Do not use "induction" on an element of this type without specifying names; seeing __A__ or __B__
+   will indicate that you did that. *)
 
 Arguments coprod_rect {_ _} _ _ _ _.
 
@@ -141,9 +142,11 @@ if we used "Record", has a known interpretation in the framework of the univalen
 
 (* or total2 as an inductive type:  *)
 
-    Inductive total2 { T: Type } ( P: T -> Type ) := tpair : Π ( __t__ : T ) ( __p__ : P __t__ ) , total2 P .
-    (* Do not use "induction" without specifying names; seeing __t__ or __p__ will indicate that you did that. *)
-    (* This will prepare for the use of primitive projections, when the names will be pr1 and pr2. *)
+    Inductive total2 { T: Type } ( P: T -> Type ) := tpair : Π (__t__:T) (__p__:P __t__), total2 P.
+
+    (* Do not use "induction" without specifying names; seeing __t__ or __p__ will indicate that you
+       did that.  This will prepare for the use of primitive projections, when the names will be pr1
+       and pr2. *)
 
     Definition pr1 { T : Type } { P : T -> Type } ( t : total2 P ) : T .
     Proof . intros .  induction t as [ t p ] . exact t . Defined.

--- a/UniMath/Foundations/Basics/Preamble.v
+++ b/UniMath/Foundations/Basics/Preamble.v
@@ -67,17 +67,23 @@ The coproduct of two types is introduced in Coq.Init.Datatypes by the lines:
   | inr : B -> sum A B. ]
 *)
 
-Notation coprod := sum .
+(* Notation coprod := sum . *)
+(* Notation coprod_rect := sum_rect. *)
+
+Inductive coprod (__A__ __B__:Type) : Type :=
+  | inl : __A__ -> coprod __A__ __B__
+  | inr : __B__ -> coprod __A__ __B__.
+(* Do not use "induction" on an element of this type without specifying names; seeing __A__ or __B__ will indicate that you did that. *)
+
+Arguments coprod_rect {_ _} _ _ _ _.
 
 Notation ii1fun := inl .
 Notation ii2fun := inr .
 
 Notation ii1 := inl .
 Notation ii2 := inr .
-Implicit Arguments ii1 [ A B ] .
-Implicit Arguments ii2 [ A B ] .
-
-Notation coprod_rect := sum_rect.
+Arguments ii1 {A B} _ : rename.
+Arguments ii2 {A B} _ : rename.
 
 Notation "X ⨿ Y" := (coprod X Y) (at level 50, left associativity).
   (* type this in emacs with C-X 8 RET AMALGAMATION OR COPRODUCT *)
@@ -134,7 +140,9 @@ if we used "Record", has a known interpretation in the framework of the univalen
 
 (* or total2 as an inductive type:  *)
 
-    Inductive total2 { T: Type } ( P: T -> Type ) := tpair : Π ( t : T ) ( p : P t ) , total2 P .
+    Inductive total2 { T: Type } ( P: T -> Type ) := tpair : Π ( __t__ : T ) ( __p__ : P __t__ ) , total2 P .
+    (* Do not use "induction" without specifying names; seeing __t__ or __p__ will indicate that you did that. *)
+    (* This will prepare for the use of primitive projections, when the names will be pr1 and pr2. *)
 
     Definition pr1 { T : Type } { P : T -> Type } ( t : total2 P ) : T .
     Proof . intros .  induction t as [ t p ] . exact t . Defined.

--- a/UniMath/Foundations/Basics/Preamble.v
+++ b/UniMath/Foundations/Basics/Preamble.v
@@ -1,7 +1,8 @@
 (** * Introduction. Vladimir Voevodsky . Feb. 2010 - Sep. 2011
 
-This is the first in the group of files which contain the (current state of) the mathematical library for the proof assistant Coq based on the Univalent Foundations.
-It contains some new notations for constructions defined in Coq.Init library as well as the definition of dependent sum.
+This is the first in the group of files which contain the (current state of) the mathematical
+library for the proof assistant Coq based on the Univalent Foundations.  It contains some new
+notations for constructions defined in Coq.Init library as well as the definition of dependent sum.
 
 
 *)
@@ -11,7 +12,7 @@ It contains some new notations for constructions defined in Coq.Init library as 
 
 (** Preamble. *)
 
-Unset Automatic Introduction.  (** This line has to be removed for the file to compile with Coq8.2 *)
+Unset Automatic Introduction.
 
 (** Universe structure *)
 
@@ -202,7 +203,9 @@ Inductive Phant ( T : Type ) := phant : Phant T .
 
 
 
-(** The following command checks whether the flag [-indices-matter] which modifies the universe level assignment for inductive types has been set. With the flag it returns [ paths 0 0 : UUU ] . Without the flag it returns [ paths 0 0 : Prop ]. *)
+(** The following command checks whether the flag [-indices-matter] which modifies the universe
+level assignment for inductive types has been set. With the flag it returns [ paths 0 0 : UUU
+]. Without the flag it returns [ paths 0 0 : Prop ]. *)
 
 Check (O = O) .
 

--- a/UniMath/Foundations/Combinatorics/StandardFiniteSets.v
+++ b/UniMath/Foundations/Combinatorics/StandardFiniteSets.v
@@ -526,7 +526,7 @@ Proof.
       induction e. rewrite idpath_transportf. rewrite stn_left_compute. unfold dni,di, stntonat; simpl.
       induction (natlthorgeh i j) as [R|R].
       { unfold stntonat; simpl; repeat rewrite transport_stn; simpl.
-        induction (natlthorgeh i j). { simpl. reflexivity. } { simpl. contradicts R (natlehneggth b). }}
+        induction (natlthorgeh i j) as [a|b]. { simpl. reflexivity. } { simpl. contradicts R (natlehneggth b). }}
       { unfold stntonat; simpl; repeat rewrite transport_stn; simpl.
         induction (natlthorgeh i j) as [V|V]. { simpl. contradicts I (natlehneggth R). } { simpl. reflexivity. }}}
     { apply stnsum_eq; intro i. induction i as [i I]. apply maponpaths.

--- a/UniMath/Foundations/Combinatorics/Tests.v
+++ b/UniMath/Foundations/Combinatorics/Tests.v
@@ -272,7 +272,7 @@ Module Test_fin.
   Goal 15 = finsum (isfinitestn _) (λ i:stn 6, i). reflexivity. Qed.
   Goal 20 = finsum isfinitebool (λ i:bool, 10). reflexivity. Qed.
   Goal 21 = finsum (isfinitecoprod isfinitebool isfinitebool)
-             (sum_rect (λ _, nat) (bool_rect _ 10 4) (bool_rect _  6 1)).
+             (coprod_rect (λ _, nat) (bool_rect _ 10 4) (bool_rect _  6 1)).
     reflexivity. Qed.
 
   Goal 10 = finsum' (isfinitestn _) (λ i:stn 5, i). reflexivity. Defined. (* fixed! *)

--- a/UniMath/Ktheory/MetricTree.v
+++ b/UniMath/Ktheory/MetricTree.v
@@ -26,7 +26,7 @@ Lemma mt_path_refl (T:Tree) (x y:T) : x = y -> mt_dist _ x y = 0.
 Proof. intros ? ? ? e. destruct e. apply mt_refl. Qed.
 
 Lemma tree_deceq (T:Tree) : isdeceq T.
-Proof. intros. intros t u. induction (isdeceqnat (mt_dist T t u) 0).
+Proof. intros. intros t u. induction (isdeceqnat (mt_dist T t u) 0) as [a|b].
        { apply inl. apply mt_anti. assumption. }
        { apply inr. intro e. apply b. destruct e. apply mt_refl. } Qed.
 

--- a/UniMath/README.md
+++ b/UniMath/README.md
@@ -50,6 +50,8 @@ according to the following principles.
   HTML with expansible/collapsible proofs.
 * Use Unicode notation freely, but make the parsing conventions uniform across files, and consider
   putting them into a scope.
+* Each line should be limited to at most 100 (unicode) characters.  The makefile target `enforce-max-line-length`
+  can be used to detect nonconforming files.
 
 Our files don't adhere yet to all of these conventions, but it's a goal we
 strive for.

--- a/UniMath/README.md
+++ b/UniMath/README.md
@@ -50,8 +50,10 @@ according to the following principles.
   HTML with expansible/collapsible proofs.
 * Use Unicode notation freely, but make the parsing conventions uniform across files, and consider
   putting them into a scope.
-* Each line should be limited to at most 100 (unicode) characters.  The makefile target `enforce-max-line-length`
-  can be used to detect nonconforming files.
+* Each line should be limited to at most 100 (unicode) characters.  The
+  makefile target `enforce-max-line-length` can be used to detect nonconforming
+  files, and the target `show-long-lines` can be used to display the
+  nonconforming lines.
 
 Our files don't adhere yet to all of these conventions, but it's a goal we
 strive for.


### PR DESCRIPTION
The use of "induction" or "destruct" on an element of type "total2 P"
without explicit names for the new variables will result in invented
names such as t, p, t0, p0, ..., but those will change to pr1, pr2,
... when we switch to primitive projections.  We locate and fix all such
usage by renaming the two parts of total2.  We do something similar for
elements of type 'coprod A B'.