### PR TITLE
fix the order of the files in UniMath/Foundations

### DIFF
--- a/UniMath/Foundations/.package/files
+++ b/UniMath/Foundations/.package/files
@@ -5,9 +5,9 @@ Basics/UnivalenceAxiom.v
 Basics/PartC.v
 Basics/PartD.v
 Basics/UnivalenceAxiom2.v
-Basics/Tests.v
 Basics/Propositions.v
 Basics/Sets.v
+Basics/Tests.v
 Algebra/BinaryOperations.v
 Algebra/Monoids_and_Groups.v
 Algebra/Rigs_and_Rings.v


### PR DESCRIPTION
Basics/Tests.v needs to go after Basics/Sets.v because it depends on it.

The Makefile doesn't get confused, but we want TAGS to be in the right order.