### PR TITLE
improve timing output

### DIFF
--- a/util/slowest
+++ b/util/slowest
@@ -4,5 +4,9 @@ min=$2
 # print slowest $n step times, more than $min seconds
 shift
 shift
-"$@" >COQC.log && <COQC.log sort --key=6gr |head -"$n" |awk "\$6 >= $min"
+"$@" >COQC.log || exit 1
+echo "--- stdout ---"
+<COQC.log grep -v '^Chars '
+echo "--- slowest $n commands taking at least $min seconds ---"
+<COQC.log grep '^Chars ' |sort --key=6gr |head -"$n" |awk "\$6 >= $min"
 


### PR DESCRIPTION
When using our makefile procedure to collect the timing of every
vernacular command, it is good also to display other incidental output
from coqc.  Here we arrange for that.