### PR TITLE
decidable proofs

### DIFF
--- a/UniMath/Foundations/Basics/Sets.v
+++ b/UniMath/Foundations/Basics/Sets.v
@@ -1141,6 +1141,25 @@ Defined.
 Notation " 'ct' ( R , is , x , y ) " := (ctlong R is x y (idpath true))
                                           (at level 70).
 
+(* An alternative to [ct], with tactics and negations *)
+
+Definition deceq_to_decrel {X:UU} : isdeceq X -> decrel X.
+Proof. intros ? i. use decrelpair.
+       - intros x y. exists (x=y). now apply isasetifdeceq.
+       - exact i.
+Defined.
+
+Ltac exact_op x := (* from Jason Gross: same as "exact", but with unification the opposite way *)
+  let T := type of x in
+  let G := match goal with |- ?G => constr:(G) end in
+  exact ((@id G : T -> G) x).
+
+(* I don't know why exact_op works better here, but with "exact", the code in RealNumbers/Prelim.v breaks *)
+Ltac confirm_yes d x y := exact_op (pathstor d x y (idpath true)).
+Ltac confirm_no  d x y := exact_op (pathstonegr d x y (idpath false)).
+Ltac confirm_equal     i := match goal with |- ?x = ?y => confirm_yes (deceq_to_decrel i) x y end.
+Ltac confirm_not_equal i := match goal with |- ?x != ?y => confirm_no (deceq_to_decrel i) x y end.
+
 (** *** Restriction of a relation to a subtype *)
 
 Definition resrel {X : UU} (L : hrel X) (P : hsubtypes X) : hrel P

--- a/UniMath/Ktheory/Tactics.v
+++ b/UniMath/Ktheory/Tactics.v
@@ -3,11 +3,6 @@ Require Import UniMath.Foundations.Basics.Sets UniMath.Foundations.Basics.Unival
 
 Notation ap := maponpaths (only parsing).
 
-Ltac exact_op x := (* from Jason Gross: same as "exact", but with unification the opposite way *)
-  let T := type of x in
-  let G := match goal with |- ?G => constr:(G) end in
-  exact ((@id G : T -> G) x).
-
 Definition post_cat {X} {x y z:X} {p:y = z} : x = y -> x = z.
 Proof. intros q. exact (pathscomp0 q p). Defined.
 

--- a/UniMath/RealNumbers/Prelim.v
+++ b/UniMath/RealNumbers/Prelim.v
@@ -21,11 +21,9 @@ Notation "2" := (hztohq (nattohz 2)) : hq_scope.
 
 Lemma hzone_neg_hzzero : neg (1%hz = 0%hz).
 Proof.
-  apply (hzgthtoneq 1%hz 0%hz).
-  rewrite <- nattohzand1.
-  apply nattohzandgth.
-  apply paths_refl.
+  confirm_not_equal isdeceqhz.
 Qed.
+
 Definition one_intdomnonzerosubmonoid : intdomnonzerosubmonoid hzintdom.
 Proof.
   exists 1%hz ; simpl.
@@ -34,27 +32,24 @@ Defined.
 
 Opaque hz.
 
-Lemma hq2eq1plus1 :
-  2 = 1 + 1.
+Lemma hq2eq1plus1 : 2 = 1 + 1.
 Proof.
-  rewrite <- hztohqand1, <- nattohzand1.
-  now rewrite <- hztohqandplus, <- nattohzandplus.
+  confirm_equal isdeceqhq.
 Qed.
 
 Lemma hq2_gt0 : 2 > 0.
 Proof.
-  rewrite <- hztohqand0, <- nattohzand0.
-  now apply hztohqandgth, nattohzandgth.
+  confirm_yes hqgthdec 2 0.
 Qed.
+
 Lemma hq1_gt0 : 1 > 0.
 Proof.
-  rewrite <- hztohqand0, <- hztohqand1.
-  rewrite <- nattohzand1, <- nattohzand0.
-  now apply hztohqandgth, nattohzandgth.
+  confirm_yes hqgthdec 1 0.
 Qed.
+
 Lemma hq1ge0 : (0 <= 1)%hq.
 Proof.
-  now apply hqlthtoleh, hq1_gt0.
+  confirm_yes hqlehdec 0 1.
 Qed.
 
 Lemma hqgth_hqneq :


### PR DESCRIPTION
Here is one of the ideas of #257, implemented in a way closer to spirit of
Vladimir's original code about going back and forth between decidable relations
and relations with boolean values.  The way I implemented it in #257 was using
decidable relations whose values are always one of two propositions:
`hTrue` or `hFalse`.  The two ways are equivalent.

This should simplify #257.

When trying to prove a statement that is decidable, it is not necessary
to think about the proof, because the proof of decidability implements
an algorithm for deciding.  All we need to do is to figure out how to
"run" it.  The same applies to proving the negation of such a statement.

Here we offer some tactics that make the notation for doing so easy.

The idea is similar to the "canonical term" notation "ct", and we put it
in the same place in the code.

We illustrate the method by cleaning up 5 proofs about rational numbers
in RealNumbers/Prelim.v, each of which seemed ad hoc.  The new proofs
seem more uniform and involve no thought when constructing them.