### PR TITLE
More on cocontinuous functors and (co)limits

### DIFF
--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -747,50 +747,26 @@ Proof.
 now intros c L ccL M H; apply isColimCocone_pr2_functor.
 Defined.
 
-Local Definition cFAX {gr : graph} (cAB : diagram gr (binproduct_precategory A B))
-  (xy : C × D) (ccxy : cocone (mapdiagram (binproduct_pair_functor F G) cAB) xy) :
-  cocone (mapdiagram F (mapdiagram (pr1_functor A B) cAB)) (pr1 xy).
-Proof.
-use mk_cocone.
-- intro n; apply (pr1 (pr1 ccxy n)).
-- abstract (intros m n e; apply (maponpaths dirprod_pr1 (pr2 ccxy m n e))).
-Defined.
-
-Local Definition cGBY {gr : graph} (cAB : diagram gr (binproduct_precategory A B))
-  (xy : C × D) (ccxy : cocone (mapdiagram (binproduct_pair_functor F G) cAB) xy) :
-  (cocone (mapdiagram G (mapdiagram (pr2_functor A B) cAB)) (pr2 xy)).
-Proof.
-use mk_cocone.
-- intro n; apply (pr2 (pr1 ccxy n)).
-- abstract (intros m n e; apply (maponpaths dirprod_pr2 (pr2 ccxy m n e))).
-Defined.
-
-Lemma is_cocont_binproduct_pair_functor (HF : is_cocont F) (HG : is_cocont G) :
-  is_cocont (binproduct_pair_functor F G).
-Proof.
-intros gr cAB ml ccml Hccml xy ccxy.
-set (cFAX := cFAX cAB xy ccxy); set (cGBY := cGBY cAB xy ccxy).
-destruct (HF _ _ _ _ (isColimCocone_pr1_functor cAB ml ccml Hccml) _ cFAX) as [[f hf1] hf2].
-destruct (HG _ _ _ _ (isColimCocone_pr2_functor cAB ml ccml Hccml) _ cGBY) as [[g hg1] hg2].
-simpl in *.
-mkpair.
-- apply (tpair _ (f,,g)).
-  abstract (intro n; unfold binprodcatmor, compose; simpl;
-            now rewrite hf1, hg1, (paireta (coconeIn ccxy n))).
-- abstract (intro t; apply subtypeEquality; simpl;
-             [ intro x; apply impred; intro; apply isaset_dirprod; [ apply hsC | apply hsD ]
-             | induction t as [[f1 f2] p]; simpl in *; apply pathsdirprod;
-               [ apply (maponpaths pr1 (hf2 (f1,, (λ n, maponpaths pr1 (p n)))))
-               | apply (maponpaths pr1 (hg2 (f2,, (λ n, maponpaths dirprod_pr2 (p n)))))]]).
-Defined.
-
-(** Note that this proof is more less the same as the above one. However we cannot use it as the
-    assumptions are too strong *)
-Lemma is_omega_cocont_binproduct_pair_functor (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
-  is_omega_cocont (binproduct_pair_functor F G).
+Lemma isColimCocone_binproduct_pair_functor {gr : graph}
+  (HF : Π (d : diagram gr A) (c : A) (cc : cocone d c) (h : isColimCocone d c cc),
+        isColimCocone _ _ (mapcocone F d cc))
+  (HG : Π (d : diagram gr B) (c : B) (cc : cocone d c) (h : isColimCocone d c cc),
+        isColimCocone _ _ (mapcocone G d cc)) :
+  Π (d : diagram gr (binproduct_precategory A B)) (cd : A × B) (cc : cocone d cd),
+  isColimCocone _ _ cc ->
+  isColimCocone _ _ (mapcocone (binproduct_pair_functor F G) d cc).
 Proof.
 intros cAB ml ccml Hccml xy ccxy.
-set (cFAX := cFAX cAB xy ccxy); set (cGBY := cGBY cAB xy ccxy).
+transparent assert (cFAX : (cocone (mapdiagram F (mapdiagram (pr1_functor A B) cAB)) (pr1 xy))).
+{ use mk_cocone.
+  - intro n; apply (pr1 (pr1 ccxy n)).
+  - abstract (intros m n e; apply (maponpaths dirprod_pr1 (pr2 ccxy m n e))).
+}
+transparent assert (cGBY : (cocone (mapdiagram G (mapdiagram (pr2_functor A B) cAB)) (pr2 xy))).
+{ use mk_cocone.
+  - intro n; apply (pr2 (pr1 ccxy n)).
+  - abstract (intros m n e; apply (maponpaths dirprod_pr2 (pr2 ccxy m n e))).
+}
 destruct (HF _ _ _ (isColimCocone_pr1_functor cAB ml ccml Hccml) _ cFAX) as [[f hf1] hf2].
 destruct (HG _ _ _ (isColimCocone_pr2_functor cAB ml ccml Hccml) _ cGBY) as [[g hg1] hg2].
 simpl in *.
@@ -803,6 +779,19 @@ mkpair.
              | induction t as [[f1 f2] p]; simpl in *; apply pathsdirprod;
                [ apply (maponpaths pr1 (hf2 (f1,, (λ n, maponpaths pr1 (p n)))))
                | apply (maponpaths pr1 (hg2 (f2,, (λ n, maponpaths dirprod_pr2 (p n)))))]]).
+Defined.
+
+Lemma is_cocont_binproduct_pair_functor (HF : is_cocont F) (HG : is_cocont G) :
+  is_cocont (binproduct_pair_functor F G).
+Proof.
+intros gr cAB ml ccml Hccml.
+now apply isColimCocone_binproduct_pair_functor; [apply HF|apply HG|].
+Defined.
+
+Lemma is_omega_cocont_binproduct_pair_functor (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
+  is_omega_cocont (binproduct_pair_functor F G).
+Proof.
+now intros cAB ml ccml Hccml; apply isColimCocone_binproduct_pair_functor.
 Defined.
 
 End binproduct_pair_functor.
@@ -879,46 +868,19 @@ Proof.
 now intros c L ccL M H; apply isColimCocone_pr_functor.
 Defined.
 
-(** This is used in the both of the next two proofs *)
-Local Definition cc {gr : graph} (F : Π (i : I), functor A B)
-  (cAB : diagram gr (product_precategory I (λ _ : I, A)))
-  (xy : I → B) (ccxy : cocone (mapdiagram (pair_functor I F) cAB) xy) (i : I) :
-  cocone (mapdiagram (F i) (mapdiagram (pr_functor I (λ _ : I, A) i) cAB)) (xy i).
-Proof.
-use mk_cocone.
-- intro n; apply (pr1 ccxy n).
-- abstract (intros m n e; apply (toforallpaths _ _ _ (pr2 ccxy m n e) i)).
-Defined.
-
-Lemma is_cocont_pair_functor
-  {F : Π (i : I), functor A B} (HF : Π (i : I), is_cocont (F i)) :
-  is_cocont (pair_functor I F).
-Proof.
-intros gr cAB ml ccml Hccml xy ccxy; simpl in *.
-set (cc := cc F cAB xy ccxy).
-set (X i := HF i _ _ _ _ (isColimCocone_pr_functor _ _ _ Hccml i) (xy i) (cc i)).
-mkpair.
-- mkpair.
-  + intro i; apply (pr1 (pr1 (X i))).
-  + abstract (intro n; apply funextsec; intro j; apply (pr2 (pr1 (X j)) n)).
-- abstract (intro t; apply subtypeEquality; simpl;
-             [ intro x; apply impred; intro; apply impred_isaset; intro i; apply hsB
-             | destruct t as [f1 f2]; simpl in *;  apply funextsec; intro i;
-               transparent assert (H : (Σ x : B ⟦ (F i) (ml i), xy i ⟧,
-                                       Π n, # (F i) (coconeIn ccml n i) ;; x =
-                                       coconeIn ccxy n i));
-                [apply (tpair _ (f1 i)); intro n; apply (toforallpaths _ _ _ (f2 n) i)|];
-               apply (maponpaths pr1 (pr2 (X i) H))]).
-Defined.
-
-(** Note that this proof is more less the same as the above one. However we cannot use it as the
-    assumptions are too strong *)
-Lemma is_omega_cocont_pair_functor
-  {F : Π (i : I), functor A B} (HF : Π (i : I), is_omega_cocont (F i)) :
-  is_omega_cocont (pair_functor I F).
+Lemma isColimCocone_pair_functor {gr : graph} (F : Π (i : I), functor A B)
+  (HF : Π i (d : diagram gr A) (c : A) (cc : cocone d c) (h : isColimCocone d c cc),
+        isColimCocone _ _ (mapcocone (F i) d cc)) :
+  Π (d : diagram gr (product_precategory I (λ _, A))) (cd : I -> A) (cc : cocone d cd),
+  isColimCocone _ _ cc ->
+  isColimCocone _ _ (mapcocone (pair_functor I F) d cc).
 Proof.
 intros cAB ml ccml Hccml xy ccxy; simpl in *.
-set (cc := cc F cAB xy ccxy).
+transparent assert (cc : (Π i, cocone (mapdiagram (F i) (mapdiagram (pr_functor I (λ _ : I, A) i) cAB)) (xy i))).
+{ intro i; use mk_cocone.
+  - intro n; apply (pr1 ccxy n).
+  - abstract (intros m n e; apply (toforallpaths _ _ _ (pr2 ccxy m n e) i)).
+}
 set (X i := HF i _ _ _ (isColimCocone_pr_functor _ _ _ Hccml i) (xy i) (cc i)).
 mkpair.
 - mkpair.
@@ -932,6 +894,21 @@ mkpair.
                                        coconeIn ccxy n i));
                 [apply (tpair _ (f1 i)); intro n; apply (toforallpaths _ _ _ (f2 n) i)|];
                apply (maponpaths pr1 (pr2 (X i) H))]).
+Defined.
+
+Lemma is_cocont_pair_functor
+  {F : Π (i : I), functor A B} (HF : Π (i : I), is_cocont (F i)) :
+  is_cocont (pair_functor I F).
+Proof.
+intros gr cAB ml ccml Hccml.
+apply isColimCocone_pair_functor; trivial; intro i; apply HF.
+Defined.
+
+Lemma is_omega_cocont_pair_functor
+  {F : Π (i : I), functor A B} (HF : Π (i : I), is_omega_cocont (F i)) :
+  is_omega_cocont (pair_functor I F).
+Proof.
+now intros cAB ml ccml Hccml; apply isColimCocone_pair_functor.
 Defined.
 
 End pair_functor.

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -501,12 +501,10 @@ Qed.
 
 Lemma αinv_f_unique y (ccGy : cocone (mapdiagram G d) y) (f : D⟦F L,y⟧)
      (Hf : Π v,coconeIn (mapcocone F d cc) v ;; f = coconeIn (ccFy y ccGy) v)
-     (HHf : Π t : Σ x, Π v, coconeIn (mapcocone F d cc) v ;; x = coconeIn _ v, t = f,, Hf) :
-     Π t : Σ x, Π v, # G (coconeIn cc v) ;; x = coconeIn ccGy v,
-     t = pr1 αinv L ;; f,, αinv_f_commutes y ccGy f Hf.
+     (HHf : Π t : Σ x, Π v, coconeIn (mapcocone F d cc) v ;; x = coconeIn _ v, t = f,, Hf)
+      f' (Hf' : Π v, # G (coconeIn cc v) ;; f' = coconeIn ccGy v) :
+      f' = pr1 αinv L ;; f.
 Proof.
-intros [f' Hf'].
-apply subtypeEquality; simpl; [intro; apply impred; intro; apply hsD|].
 transparent assert (HH : (Σ x : D ⟦ F L, y ⟧,
             Π v : vertex g,
             coconeIn (mapcocone F d cc) v ;; x = coconeIn (ccFy y ccGy) v)).
@@ -515,8 +513,8 @@ transparent assert (HH : (Σ x : D ⟦ F L, y ⟧,
   - abstract (intro v; rewrite <- Hf', !assoc; apply cancel_postcomposition, nat_trans_ax).
 }
 apply pathsinv0.
-generalize (maponpaths pr1 (HHf HH)); simpl; intro Htemp.
-rewrite <- Htemp, assoc.
+generalize (maponpaths pr1 (HHf HH)); intro Htemp; simpl in *.
+rewrite <- Htemp; simpl; rewrite assoc.
 eapply pathscomp0.
   apply cancel_postcomposition.
   apply (nat_trans_eq_pointwise (@iso_after_iso_inv [C,D,hsD] _ _ (isopair _ Hα))).
@@ -528,9 +526,12 @@ Proof.
 intros HccL y ccGy.
 set (H := HF HccL y (ccFy y ccGy)).
 set (f := pr1 (pr1 H)); set (Hf := pr2 (pr1 H)); set (HHf := pr2 H).
-mkpair.
-- apply (pr1 αinv L ;; f ,, αinv_f_commutes y ccGy f Hf).
-- abstract (apply αinv_f_unique; intro t; rewrite (HHf t); apply tppr).
+use unique_exists.
+- apply (pr1 αinv L ;; f).
+- simpl; apply (αinv_f_commutes y ccGy f Hf).
+- abstract (intro; apply impred; intro; apply hsD).
+- abstract (simpl in *; intros f' Hf'; apply (αinv_f_unique y ccGy f Hf); trivial;
+            intro t; rewrite (HHf t); apply tppr).
 Defined.
 
 End preserves_colimit_iso.

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -245,12 +245,12 @@ Commentationes Mathematicae Universitatis Carolinae 015.4 (1974): 589-602.
 *)
 Section colim_initial_algebra.
 
-Variables (C : precategory) (hsC : has_homsets C) (InitC : Initial C).
+Context {C : precategory} (hsC : has_homsets C) (InitC : Initial C).
 
 (* It is important that these are not packaged together as it is
    sometimes necessary to control how opaque HF is. See
    isalghom_pr1foldr in lists.v *)
-Variables (F : functor C C) (HF : is_omega_cocont F).
+Context {F : functor C C} (HF : is_omega_cocont F).
 
 Let Fchain : chain C := initChain InitC F.
 
@@ -657,44 +657,39 @@ End iter_functor.
 (** ** A pair of functors (F,G) : A * B -> C * D is omega cocontinuous if F and G are *)
 Section binproduct_pair_functor.
 
-Variables A B C D : precategory.
-Variables (F : functor A C) (G : functor B D).
-Variables (hsA : has_homsets A) (hsB : has_homsets B).
-Variables (hsC : has_homsets C) (hsD : has_homsets D).
+Context {A B C D : precategory} (F : functor A C) (G : functor B D)
+        (hsA : has_homsets A) (hsB : has_homsets B) (hsC : has_homsets C) (hsD : has_homsets D).
 
-(* Maybe generalize these to arbitrary diagrams? *)
-Local Definition cocone_pr1_functor (cAB : chain (binproduct_precategory A B))
+
+Local Definition cocone_pr1_functor {g : graph} (cAB : diagram g (binproduct_precategory A B))
   (ab : A × B) (ccab : cocone cAB ab) :
-  cocone (mapchain (pr1_functor A B) cAB) (ob1 ab).
+  cocone (mapdiagram (pr1_functor A B) cAB) (ob1 ab).
 Proof.
-simple refine (mk_cocone _ _).
+use mk_cocone.
 - simpl; intro n; apply (mor1 (coconeIn ccab n)).
 - abstract (simpl; intros m n e; now rewrite <- (coconeInCommutes ccab m n e)).
 Defined.
 
-Local Lemma isColimCocone_pr1_functor (cAB : chain (binproduct_precategory A B))
+Local Lemma isColimCocone_pr1_functor {g : graph} (cAB : diagram g (binproduct_precategory A B))
   (ab : A × B) (ccab : cocone cAB ab) (Hccab : isColimCocone cAB ab ccab) :
-   isColimCocone (mapchain (pr1_functor A B) cAB) (ob1 ab)
+   isColimCocone (mapdiagram (pr1_functor A B) cAB) (ob1 ab)
      (mapcocone (pr1_functor A B) cAB ccab).
 Proof.
 intros x ccx.
-simple refine (let HHH : cocone cAB (x,, ob2 ab) := _ in _).
-{ simple refine (mk_cocone _ _).
+transparent assert (HHH : (cocone cAB (x,, ob2 ab))).
+{ use mk_cocone.
   - simpl; intro n; split;
       [ apply (pr1 ccx n) | apply (# (pr2_functor A B) (pr1 ccab n)) ].
-  - abstract(
-    simpl; intros m n e; rewrite (tppr (dmor cAB e));
-    apply pathsdirprod; [ apply (pr2 ccx m n e)
-                        | apply (maponpaths dirprod_pr2 ((pr2 ccab) m n e)) ]).
+  - abstract(simpl; intros m n e; rewrite (tppr (dmor cAB e)); apply pathsdirprod;
+               [ apply (pr2 ccx m n e) | apply (maponpaths dirprod_pr2 ((pr2 ccab) m n e)) ]).
 }
-destruct (Hccab _ HHH) as [[[x1 x2] p1] p2]; simpl in *.
+destruct (Hccab _ HHH) as [[[x1 x2] p1] p2].
 mkpair.
 - apply (tpair _ x1).
   abstract (intro n; apply (maponpaths pr1 (p1 n))).
 - intro t.
-  simple refine (let X : Σ x0,
-           Π v : nat, coconeIn ccab v ;; x0 =
-                      binprodcatmor (pr1 ccx v) (pr2 (pr1 ccab v)) := _ in _).
+  transparent assert (X : (Σ x0, Π v, coconeIn ccab v ;; x0 =
+                                 binprodcatmor (pr1 ccx v) (pr2 (pr1 ccab v)))).
   { mkpair.
     - split; [ apply (pr1 t) | apply (identity _) ].
     - abstract (intro n; rewrite id_right; apply pathsdirprod;
@@ -705,43 +700,40 @@ mkpair.
             | apply (maponpaths (fun x => pr1 (pr1 x)) (p2 X))]).
 Defined.
 
-Lemma is_omega_cocont_pr1_functor : is_omega_cocont (pr1_functor A B).
+Lemma is_cocont_pr1_functor : is_cocont (pr1_functor A B).
 Proof.
-intros c L ccL M.
-now apply isColimCocone_pr1_functor.
+now intros c L ccL M H; apply isColimCocone_pr1_functor.
 Defined.
 
-Local Definition cocone_pr2_functor (cAB : chain (binproduct_precategory A B))
+Local Definition cocone_pr2_functor {g : graph} (cAB : diagram g (binproduct_precategory A B))
   (ab : A × B) (ccab : cocone cAB ab) :
-  cocone (mapchain (pr2_functor A B) cAB) (pr2 ab).
+  cocone (mapdiagram (pr2_functor A B) cAB) (pr2 ab).
 Proof.
-simple refine (mk_cocone _ _).
+use mk_cocone.
 - simpl; intro n; apply (pr2 (coconeIn ccab n)).
 - abstract (simpl; intros m n e; now rewrite <- (coconeInCommutes ccab m n e)).
 Defined.
 
-Local Lemma isColimCocone_pr2_functor (cAB : chain (binproduct_precategory A B))
+Local Lemma isColimCocone_pr2_functor {g : graph} (cAB : diagram g (binproduct_precategory A B))
   (ab : A × B) (ccab : cocone cAB ab) (Hccab : isColimCocone cAB ab ccab) :
-   isColimCocone (mapchain (pr2_functor A B) cAB) (pr2 ab)
+   isColimCocone (mapdiagram (pr2_functor A B) cAB) (pr2 ab)
      (mapcocone (pr2_functor A B) cAB ccab).
 Proof.
 intros x ccx.
-simple refine (let HHH : cocone cAB (pr1 ab,, x) := _ in _).
-{ simple refine (mk_cocone _ _).
+transparent assert (HHH : (cocone cAB (pr1 ab,, x))).
+{ use mk_cocone.
   - simpl; intro n; split;
       [ apply (# (pr1_functor A B) (pr1 ccab n)) | apply (pr1 ccx n) ].
-  - abstract(
-    simpl; intros m n e; rewrite (paireta (dmor cAB e)); apply pathsdirprod;
-      [ apply (maponpaths pr1 (pr2 ccab m n e)) | apply (pr2 ccx m n e) ]).
+  - abstract (simpl; intros m n e; rewrite (paireta (dmor cAB e)); apply pathsdirprod;
+                [ apply (maponpaths pr1 (pr2 ccab m n e)) | apply (pr2 ccx m n e) ]).
  }
-destruct (Hccab _ HHH) as [[[x1 x2] p1] p2]; simpl in *.
+destruct (Hccab _ HHH) as [[[x1 x2] p1] p2].
 mkpair.
 - apply (tpair _ x2).
   abstract (intro n; apply (maponpaths dirprod_pr2 (p1 n))).
 - intro t.
-  simple refine (let X : Σ x0,
-           Π v : nat, coconeIn ccab v ;; x0 =
-                      binprodcatmor (pr1 (pr1 ccab v)) (pr1 ccx v) := _ in _).
+  transparent assert (X : (Σ x0, Π v, coconeIn ccab v ;; x0 =
+                                 binprodcatmor (pr1 (pr1 ccab v)) (pr1 ccx v))).
   { mkpair.
     - split; [ apply (identity _) | apply (pr1 t) ].
     - abstract (intro n; rewrite id_right; apply pathsdirprod;
@@ -752,23 +744,56 @@ mkpair.
               | apply (maponpaths (fun x => dirprod_pr2 (pr1 x)) (p2 X)) ]).
 Defined.
 
-Lemma is_omega_cocont_pr2_functor : is_omega_cocont (pr2_functor A B).
+Lemma is_cocont_pr2_functor : is_cocont (pr2_functor A B).
 Proof.
-intros c L ccL M.
-now apply isColimCocone_pr2_functor.
+now intros c L ccL M H; apply isColimCocone_pr2_functor.
+Defined.
+
+(* TODO: refactor this and the below proof? *)
+Lemma is_cocont_binproduct_pair_functor (HF : is_cocont F) (HG : is_cocont G) :
+  is_cocont (binproduct_pair_functor F G).
+Proof.
+intros gr cAB ml ccml Hccml xy ccxy; simpl in *.
+simple refine (let cFAX : cocone (mapdiagram F (mapdiagram (pr1_functor A B) cAB))
+                                 (pr1 xy) := _ in _).
+{ simple refine (mk_cocone _ _).
+  - intro n; apply (pr1 (pr1 ccxy n)).
+  - abstract (intros m n e; apply (maponpaths pr1 (pr2 ccxy m n e))).
+}
+simple refine (let cGBY : cocone (mapdiagram G (mapdiagram (pr2_functor A B) cAB))
+                                 (pr2 xy) := _ in _).
+{ simple refine (mk_cocone _ _).
+  - intro n; apply (pr2 (pr1 ccxy n)).
+  - abstract (intros m n e; apply (maponpaths dirprod_pr2 (pr2 ccxy m n e))).
+}
+destruct (HF _ _ _ _ (isColimCocone_pr1_functor cAB ml ccml Hccml) _ cFAX) as [[f hf1] hf2].
+destruct (HG _ _ _ _ (isColimCocone_pr2_functor cAB ml ccml Hccml) _ cGBY) as [[g hg1] hg2].
+simpl in *.
+mkpair.
+- apply (tpair _ (f,,g)).
+  abstract (intro n; unfold binprodcatmor, compose; simpl;
+            now rewrite hf1, hg1, (paireta (coconeIn ccxy n))).
+- intro t.
+  apply subtypeEquality; simpl.
+  + intro x; apply impred; intro.
+    apply isaset_dirprod; [ apply hsC | apply hsD ].
+  + induction t as [[f1 f2] p]; simpl in *.
+    apply pathsdirprod.
+    * apply (maponpaths pr1 (hf2 (f1,, (λ n, maponpaths pr1 (p n))))).
+    * apply (maponpaths pr1 (hg2 (f2,, (λ n, maponpaths dirprod_pr2 (p n))))).
 Defined.
 
 Lemma is_omega_cocont_binproduct_pair_functor (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
   is_omega_cocont (binproduct_pair_functor F G).
 Proof.
 intros cAB ml ccml Hccml xy ccxy; simpl in *.
-simple refine (let cFAX : cocone (mapchain F (mapchain (pr1_functor A B) cAB))
+simple refine (let cFAX : cocone (mapdiagram F (mapdiagram (pr1_functor A B) cAB))
                                  (pr1 xy) := _ in _).
 { simple refine (mk_cocone _ _).
   - intro n; apply (pr1 (pr1 ccxy n)).
   - abstract (intros m n e; apply (maponpaths pr1 (pr2 ccxy m n e))).
 }
-simple refine (let cGBY : cocone (mapchain G (mapchain (pr2_functor A B)cAB))
+simple refine (let cGBY : cocone (mapdiagram G (mapdiagram (pr2_functor A B) cAB))
                                  (pr2 xy) := _ in _).
 { simple refine (mk_cocone _ _).
   - intro n; apply (pr2 (pr1 ccxy n)).
@@ -796,9 +821,7 @@ End binproduct_pair_functor.
 (** ** A family of functor F^I : A^I -> B^I is omega cocontinuous if each F_i is *)
 Section pair_functor.
 
-Variables (I : UU) (A B : precategory).
-Variables (F : Π (i : I), functor A B).
-Variables (hsA : has_homsets A) (hsB : has_homsets B).
+Context {I : UU} {A B : precategory} (hsA : has_homsets A) (hsB : has_homsets B).
 
 (* I needs to have decidable equality for pr_functor to be omega cocont *)
 Hypothesis (HI : isdeceq I).
@@ -812,7 +835,7 @@ now unfold ifI; destruct (HI i i) as [p|p]; [|destruct (p (idpath _))].
 Defined.
 
 Local Lemma isColimCocone_pr_functor
-  (c : chain (power_precategory I A))
+  {g : graph} (c : diagram g (power_precategory I A))
   (L : power_precategory I A) (ccL : cocone c L)
   (M : isColimCocone c L ccL) : Π i,
   isColimCocone _ _ (mapcocone (pr_functor I (fun _ => A) i) c ccL).
@@ -863,14 +886,43 @@ mkpair.
   now rewrite hp, idpath_transportf.
 Defined.
 
-Lemma is_omega_cocont_pr_functor (i : I) : is_omega_cocont (pr_functor I (fun _ => A) i).
+Lemma is_cocont_pr_functor (i : I) : is_cocont (pr_functor I (fun _ => A) i).
 Proof.
-intros c L ccL M.
-now apply isColimCocone_pr_functor.
+now intros c L ccL M H; apply isColimCocone_pr_functor.
+Defined.
+
+(* TODO: refactor this and the below proof? *)
+Lemma is_cocont_pair_functor
+  {F : Π (i : I), functor A B} (HF : Π (i : I), is_cocont (F i)) :
+  is_cocont (pair_functor I F).
+Proof.
+intros gr cAB ml ccml Hccml xy ccxy; simpl in *.
+simple refine (let cc i : cocone (mapdiagram (F i)
+                                 (mapdiagram (pr_functor I (fun _ => A) i) cAB)) (xy i) := _ in _).
+{ simple refine (mk_cocone _ _).
+  - intro n; apply (pr1 ccxy n).
+  - abstract (intros m n e;
+              apply (toforallpaths _ _ _ (pr2 ccxy m n e) i)).
+}
+set (X i := HF i _ _ _ _ (isColimCocone_pr_functor _ _ _ Hccml i) (xy i) (cc i)).
+mkpair.
+- mkpair.
+  + intro i; apply (pr1 (pr1 (X i))).
+  + abstract (intro n; apply funextsec; intro j; apply (pr2 (pr1 (X j)) n)).
+- intro t.
+  apply subtypeEquality; simpl.
+  + intro x; apply impred; intro; apply impred_isaset; intro i; apply hsB.
+  + destruct t as [f1 f2]; simpl in *.
+    apply funextsec; intro i.
+    simple refine (let H : Σ x : B ⟦ (F i) (ml i), xy i ⟧,
+                          Π n, # (F i) (coconeIn ccml n i) ;; x =
+                               coconeIn ccxy n i := _ in _).
+    { apply (tpair _ (f1 i)); intro n; apply (toforallpaths _ _ _ (f2 n) i). }
+    apply (maponpaths pr1 (pr2 (X i) H)).
 Defined.
 
 Lemma is_omega_cocont_pair_functor
-  (HF : Π (i : I), is_omega_cocont (F i)) :
+  {F : Π (i : I), functor A B} (HF : Π (i : I), is_omega_cocont (F i)) :
   is_omega_cocont (pair_functor I F).
 Proof.
 intros cAB ml ccml Hccml xy ccxy; simpl in *.
@@ -905,7 +957,7 @@ Section bindelta_functor.
 
 Variables (C : precategory) (PC : BinProducts C) (hsC : has_homsets C).
 
-Lemma cocont_bindelta_functor : is_cocont (bindelta_functor C).
+Lemma is_cocont_bindelta_functor : is_cocont (bindelta_functor C).
 Proof.
 apply (left_adjoint_cocont _ (is_left_adjoint_bindelta_functor PC) hsC).
 abstract (apply (has_homsets_binproduct_precategory _ _ hsC hsC)).
@@ -913,8 +965,7 @@ Defined.
 
 Lemma is_omega_cocont_bindelta_functor : is_omega_cocont (bindelta_functor C).
 Proof.
-intros c L ccL.
-apply cocont_bindelta_functor.
+now intros c L ccL; apply is_cocont_bindelta_functor.
 Defined.
 
 End bindelta_functor.
@@ -924,7 +975,7 @@ Section delta_functor.
 
 Variables (I : UU) (C : precategory) (PC : Products I C) (hsC : has_homsets C).
 
-Lemma cocont_delta_functor : is_cocont (delta_functor I C).
+Lemma is_cocont_delta_functor : is_cocont (delta_functor I C).
 Proof.
 apply (left_adjoint_cocont _ (is_left_adjoint_delta_functor _ PC) hsC).
 abstract (apply (has_homsets_power_precategory _ _ hsC)).
@@ -933,8 +984,7 @@ Defined.
 Lemma is_omega_cocont_delta_functor :
   is_omega_cocont (delta_functor I C).
 Proof.
-intros c L ccL.
-apply cocont_delta_functor.
+now intros c L ccL; apply is_cocont_delta_functor.
 Defined.
 
 End delta_functor.
@@ -944,7 +994,7 @@ Section bincoprod_functor.
 
 Variables (C : precategory) (PC : BinCoproducts C) (hsC : has_homsets C).
 
-Lemma cocont_bincoproduct_functor : is_cocont (bincoproduct_functor PC).
+Lemma is_cocont_bincoproduct_functor : is_cocont (bincoproduct_functor PC).
 Proof.
 apply (left_adjoint_cocont _ (is_left_adjoint_bincoproduct_functor PC)).
 - abstract (apply has_homsets_binproduct_precategory; apply hsC).
@@ -954,7 +1004,7 @@ Defined.
 Lemma is_omega_cocont_bincoproduct_functor :
   is_omega_cocont (bincoproduct_functor PC).
 Proof.
-intros c L ccL; apply cocont_bincoproduct_functor.
+now intros c L ccL; apply is_cocont_bincoproduct_functor.
 Defined.
 
 End bincoprod_functor.
@@ -976,7 +1026,7 @@ Defined.
 Lemma is_omega_cocont_indexed_coproduct_functor :
   is_omega_cocont (indexed_coproduct_functor _ PC).
 Proof.
-intros c L ccL; apply cocont_indexed_coproduct_functor.
+now intros c L ccL; apply cocont_indexed_coproduct_functor.
 Defined.
 
 End coprod_functor.
@@ -987,20 +1037,20 @@ Section BinCoproduct_of_functors.
 Context {C D : precategory} (PC : BinProducts C) (HD : BinCoproducts D)
         (hsC : has_homsets C) (hsD : has_homsets D).
 
-Lemma is_omega_cocont_BinCoproduct_of_functors_alt (F G : functor C D)
+Lemma is_omega_cocont_BinCoproduct_of_functors_alt {F G : functor C D}
   (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
   is_omega_cocont (BinCoproduct_of_functors_alt HD F G).
 Proof.
 apply (is_omega_cocont_functor_composite hsD).
   apply (is_omega_cocont_bindelta_functor _ PC hsC).
 apply (is_omega_cocont_functor_composite hsD).
-  apply (is_omega_cocont_binproduct_pair_functor _ _ _ _ _ _ hsC hsC hsD hsD HF HG).
+  apply (is_omega_cocont_binproduct_pair_functor _ _ hsC hsC hsD hsD HF HG).
 apply (is_omega_cocont_bincoproduct_functor _ _ hsD).
 Defined.
 
 Definition omega_cocont_BinCoproduct_of_functors_alt (F G : omega_cocont_functor C D) :
   omega_cocont_functor C D :=
-    tpair _ _ (is_omega_cocont_BinCoproduct_of_functors_alt _ _ (pr2 F) (pr2 G)).
+    tpair _ _ (is_omega_cocont_BinCoproduct_of_functors_alt (pr2 F) (pr2 G)).
 
 Lemma is_omega_cocont_BinCoproduct_of_functors (F G : functor C D)
   (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
@@ -1008,7 +1058,7 @@ Lemma is_omega_cocont_BinCoproduct_of_functors (F G : functor C D)
 Proof.
 exact (transportf _
          (BinCoproduct_of_functors_alt_eq_BinCoproduct_of_functors C D HD hsD F G)
-         (is_omega_cocont_BinCoproduct_of_functors_alt _ _ HF HG)).
+         (is_omega_cocont_BinCoproduct_of_functors_alt HF HG)).
 Defined.
 
 Definition omega_cocont_BinCoproduct_of_functors
@@ -1033,7 +1083,7 @@ Proof.
 apply (is_omega_cocont_functor_composite hsD).
   apply (is_omega_cocont_delta_functor _ _ PC hsC).
 apply (is_omega_cocont_functor_composite hsD).
-  apply (is_omega_cocont_pair_functor _ _ _ _ hsC hsD HI HF).
+  apply (is_omega_cocont_pair_functor hsC hsD HI HF).
 apply (is_omega_cocont_indexed_coproduct_functor _ _ _ hsD).
 Defined.
 
@@ -1064,21 +1114,20 @@ Section constprod_functors.
 Variables (C : precategory) (PC : BinProducts C) (hsC : has_homsets C).
 Variables (hE : has_exponentials PC).
 
-Lemma cocont_constprod_functor1 (x : C) : is_cocont (constprod_functor1 PC x).
+Lemma is_cocont_constprod_functor1 (x : C) : is_cocont (constprod_functor1 PC x).
 Proof.
-apply (left_adjoint_cocont _ (hE _) hsC hsC).
+exact (left_adjoint_cocont _ (hE _) hsC hsC).
 Defined.
 
 Lemma is_omega_cocont_constprod_functor1 (x : C) : is_omega_cocont (constprod_functor1 PC x).
 Proof.
-intros c L ccL.
-apply cocont_constprod_functor1.
+now intros c L ccL; apply is_cocont_constprod_functor1.
 Defined.
 
 Definition omega_cocont_constprod_functor1 (x : C) :
   omega_cocont_functor C C := tpair _ _ (is_omega_cocont_constprod_functor1 x).
 
-Lemma cocont_constprod_functor2 (x : C) : is_cocont (constprod_functor2 PC x).
+Lemma is_cocont_constprod_functor2 (x : C) : is_cocont (constprod_functor2 PC x).
 Proof.
 apply left_adjoint_cocont; try apply hsC.
 apply (is_left_adjoint_constprod_functor2 PC hsC), hE.
@@ -1086,8 +1135,7 @@ Defined.
 
 Lemma is_omega_cocont_constprod_functor2 (x : C) : is_omega_cocont (constprod_functor2 PC x).
 Proof.
-intros c L ccL.
-apply cocont_constprod_functor2.
+now intros c L ccL; apply is_cocont_constprod_functor2.
 Defined.
 
 Definition omega_cocont_constprod_functor2 (x : C) :
@@ -1107,8 +1155,7 @@ Variable omega_cocont_constprod_functor1 :
 Let omega_cocont_constprod_functor2 :
   Π x : C, is_omega_cocont (constprod_functor2 PC x).
 Proof.
-intro x.
-now apply (is_omega_cocont_iso hsC (flip_iso PC hsC x)).
+now intro x; apply (is_omega_cocont_iso hsC (flip_iso PC hsC x)).
 Defined.
 
 Local Definition fun_lt (cAB : chain (binproduct_precategory C C)) :
@@ -1216,10 +1263,10 @@ Let L := pr1 LM : C.
 Let M := pr2 LM : (λ _ : C, C) (pr1 LM).
 Let cA := mapchain (pr1_functor C C) cAB : chain C.
 Let cB := mapchain (pr2_functor C C) cAB : chain C.
-Let HA := isColimCocone_pr1_functor _ _ hsC _ _ _ HccLM
-  : isColimCocone cA L (cocone_pr1_functor C C cAB LM ccLM).
-Let HB := isColimCocone_pr2_functor _ _ hsC _ _ _ HccLM
-  : isColimCocone cB M (cocone_pr2_functor C C cAB LM ccLM).
+Let HA := isColimCocone_pr1_functor hsC _ _ _ HccLM
+  : isColimCocone cA L (cocone_pr1_functor cAB LM ccLM).
+Let HB := isColimCocone_pr2_functor hsC _ _ _ HccLM
+  : isColimCocone cB M (cocone_pr2_functor cAB LM ccLM).
 
 (* Form the colimiting cocones of "A_i * B_0 -> A_i * B_1 -> ..." *)
 Let HAiB := λ i, omega_cocont_constprod_functor1 (pr1 (pr1 cAB i)) _ _ _ HB.
@@ -1434,7 +1481,7 @@ Proof.
 apply (is_omega_cocont_functor_composite hsD).
 - apply (is_omega_cocont_bindelta_functor _ PC hsC).
 - apply (is_omega_cocont_functor_composite hsD).
-  + apply (is_omega_cocont_binproduct_pair_functor _ _ _ _ _ _ hsC hsC hsD hsD HF HG).
+  + apply (is_omega_cocont_binproduct_pair_functor _ _ hsC hsC hsD hsD HF HG).
   + now apply (is_omega_cocont_binproduct_functor _ _ hsD).
 Defined.
 
@@ -1618,7 +1665,7 @@ use adjunction_from_partial.
     now simpl; rewrite id_right.
 Defined.
 
-Lemma cocont_pre_composition_functor :
+Lemma is_cocont_pre_composition_functor :
   is_cocont (pre_composition_functor _ _ _ hsC hsA K).
 Proof.
 apply left_adjoint_cocont.
@@ -1630,8 +1677,7 @@ Qed.
 Lemma is_omega_cocont_pre_composition_functor :
   is_omega_cocont (pre_composition_functor _ _ _ hsC hsA K).
 Proof.
-intros c L ccL.
-apply cocont_pre_composition_functor.
+now intros c L ccL; apply is_cocont_pre_composition_functor.
 Defined.
 
 Definition omega_cocont_pre_composition_functor :

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -89,9 +89,8 @@ Context {C D : precategory} (F : functor C D).
 
 Definition mapdiagram {g : graph} (d : diagram g C) : diagram g D.
 Proof.
-simple refine (tpair _ _ _).
-- intros n.
-  apply (F (dob d n)).
+mkpair.
+- intros n; apply (F (dob d n)).
 - simpl; intros m n e.
   apply (# F (dmor d e)).
 Defined.
@@ -99,7 +98,7 @@ Defined.
 Definition mapcocone {g : graph} (d : diagram g C) {x : C}
   (dx : cocone d x) : cocone (mapdiagram d) (F x).
 Proof.
-simple refine (mk_cocone _ _).
+use mk_cocone.
 - simpl; intro n.
   exact (#F (coconeIn dx n)).
 - abstract (intros u v e; simpl; rewrite <- functor_comp;
@@ -265,16 +264,15 @@ Let FHC : ColimCocone FFchain := mk_ColimCocone _ _ _ FHC'.
 
 Local Definition shiftCocone : cocone FFchain L.
 Proof.
-simple refine (mk_cocone _ _).
+use mk_cocone.
 - intro n; apply (coconeIn (colimCocone CC) (S n)).
 - abstract (intros m n e; destruct e ;
             apply (coconeInCommutes (colimCocone CC) (S m) _ (idpath _))).
 Defined.
 
-Local Definition unshiftCocone (x : C) : cocone FFchain x -> cocone Fchain x.
+Local Definition unshiftCocone (x : C) (cc : cocone FFchain x) : cocone Fchain x.
 Proof.
-intros cc.
-simple refine (mk_cocone _ _).
+use mk_cocone.
 - simpl; intro n.
   induction n as [|n]; simpl.
   + apply InitialArrow.
@@ -451,8 +449,8 @@ apply (@iscontrweqb _ (Σ y : C ⟦ L, G M ⟧,
       (* apply weqimplimpl; [ | | apply hsD | apply hsC]; intro h. *)
       (*   now rewrite <- h, (φ_adj_after_φ_adj_inv _ _ _ H). *)
       (* now rewrite h, (φ_adj_inv_after_φ_adj _ _ _ H). *)
-- simple refine (let X : cocone d (G M) := _ in _).
-  { simple refine (mk_cocone _ _).
+- transparent assert (X : (cocone d (G M))).
+  { use mk_cocone.
     + intro v; apply (φ_adj C D F H (coconeIn ccM v)).
     + abstract (intros m n e; simpl;
                 rewrite <- (coconeInCommutes ccM m n e); simpl;
@@ -754,15 +752,13 @@ Lemma is_cocont_binproduct_pair_functor (HF : is_cocont F) (HG : is_cocont G) :
   is_cocont (binproduct_pair_functor F G).
 Proof.
 intros gr cAB ml ccml Hccml xy ccxy; simpl in *.
-simple refine (let cFAX : cocone (mapdiagram F (mapdiagram (pr1_functor A B) cAB))
-                                 (pr1 xy) := _ in _).
-{ simple refine (mk_cocone _ _).
+transparent assert (cFAX : (cocone (mapdiagram F (mapdiagram (pr1_functor A B) cAB)) (pr1 xy))).
+{ use mk_cocone.
   - intro n; apply (pr1 (pr1 ccxy n)).
   - abstract (intros m n e; apply (maponpaths pr1 (pr2 ccxy m n e))).
 }
-simple refine (let cGBY : cocone (mapdiagram G (mapdiagram (pr2_functor A B) cAB))
-                                 (pr2 xy) := _ in _).
-{ simple refine (mk_cocone _ _).
+transparent assert (cGBY : (cocone (mapdiagram G (mapdiagram (pr2_functor A B) cAB)) (pr2 xy))).
+{ use mk_cocone.
   - intro n; apply (pr2 (pr1 ccxy n)).
   - abstract (intros m n e; apply (maponpaths dirprod_pr2 (pr2 ccxy m n e))).
 }
@@ -787,15 +783,13 @@ Lemma is_omega_cocont_binproduct_pair_functor (HF : is_omega_cocont F) (HG : is_
   is_omega_cocont (binproduct_pair_functor F G).
 Proof.
 intros cAB ml ccml Hccml xy ccxy; simpl in *.
-simple refine (let cFAX : cocone (mapdiagram F (mapdiagram (pr1_functor A B) cAB))
-                                 (pr1 xy) := _ in _).
-{ simple refine (mk_cocone _ _).
+transparent assert (cFAX : (cocone (mapdiagram F (mapdiagram (pr1_functor A B) cAB)) (pr1 xy))).
+{ use mk_cocone.
   - intro n; apply (pr1 (pr1 ccxy n)).
   - abstract (intros m n e; apply (maponpaths pr1 (pr2 ccxy m n e))).
 }
-simple refine (let cGBY : cocone (mapdiagram G (mapdiagram (pr2_functor A B) cAB))
-                                 (pr2 xy) := _ in _).
-{ simple refine (mk_cocone _ _).
+transparent assert (cGBY : (cocone (mapdiagram G (mapdiagram (pr2_functor A B) cAB)) (pr2 xy))).
+{ use mk_cocone.
   - intro n; apply (pr2 (pr1 ccxy n)).
   - abstract (intros m n e; apply (maponpaths dirprod_pr2 (pr2 ccxy m n e))).
 }
@@ -841,9 +835,9 @@ Local Lemma isColimCocone_pr_functor
   isColimCocone _ _ (mapcocone (pr_functor I (fun _ => A) i) c ccL).
 Proof.
 intros i x ccx; simpl in *.
-simple refine (let HHH : cocone c (fun j => ifI i j x (L j)) := _ in _).
+transparent assert (HHH : (cocone c (fun j => ifI i j x (L j)))).
 { unfold ifI.
-  simple refine (mk_cocone _ _).
+  use mk_cocone.
   - simpl; intros n j.
     destruct (HI i j) as [p|p].
     + apply (transportf (fun i => A ⟦ dob c n i, x ⟧) p (coconeIn ccx n)).
@@ -867,8 +861,7 @@ mkpair.
     assert (hp : p = idpath i); [apply (isasetifdeceq _ HI)|];
     now rewrite hp, idpath_transportf).
 - intro t.
-  simple refine (let X : Σ x0,
-           Π n, coconeIn ccL n ;; x0 = coconeIn HHH n := _ in _).
+  transparent assert (X : (Σ x0, Π n, coconeIn ccL n ;; x0 = coconeIn HHH n)).
   { mkpair.
     - simpl; intro j; unfold ifI.
       destruct (HI i j).
@@ -899,7 +892,7 @@ Proof.
 intros gr cAB ml ccml Hccml xy ccxy; simpl in *.
 simple refine (let cc i : cocone (mapdiagram (F i)
                                  (mapdiagram (pr_functor I (fun _ => A) i) cAB)) (xy i) := _ in _).
-{ simple refine (mk_cocone _ _).
+{ use mk_cocone.
   - intro n; apply (pr1 ccxy n).
   - abstract (intros m n e;
               apply (toforallpaths _ _ _ (pr2 ccxy m n e) i)).
@@ -914,9 +907,9 @@ mkpair.
   + intro x; apply impred; intro; apply impred_isaset; intro i; apply hsB.
   + destruct t as [f1 f2]; simpl in *.
     apply funextsec; intro i.
-    simple refine (let H : Σ x : B ⟦ (F i) (ml i), xy i ⟧,
-                          Π n, # (F i) (coconeIn ccml n i) ;; x =
-                               coconeIn ccxy n i := _ in _).
+    transparent assert (H : (Σ x : B ⟦ (F i) (ml i), xy i ⟧,
+                             Π n, # (F i) (coconeIn ccml n i) ;; x =
+                                  coconeIn ccxy n i)).
     { apply (tpair _ (f1 i)); intro n; apply (toforallpaths _ _ _ (f2 n) i). }
     apply (maponpaths pr1 (pr2 (X i) H)).
 Defined.
@@ -928,7 +921,7 @@ Proof.
 intros cAB ml ccml Hccml xy ccxy; simpl in *.
 simple refine (let cc i : cocone (mapchain (F i)
                                  (mapchain (pr_functor I (fun _ => A) i) cAB)) (xy i) := _ in _).
-{ simple refine (mk_cocone _ _).
+{ use mk_cocone.
   - intro n; apply (pr1 ccxy n).
   - abstract (intros m n e;
               apply (toforallpaths _ _ _ (pr2 ccxy m n e) i)).
@@ -943,9 +936,9 @@ mkpair.
   + intro x; apply impred; intro; apply impred_isaset; intro i; apply hsB.
   + destruct t as [f1 f2]; simpl in *.
     apply funextsec; intro i.
-    simple refine (let H : Σ x : B ⟦ (F i) (ml i), xy i ⟧,
-                          Π n, # (F i) (coconeIn ccml n i) ;; x =
-                               coconeIn ccxy n i := _ in _).
+    transparent assert (H : (Σ x : B ⟦ (F i) (ml i), xy i ⟧,
+                             Π n, # (F i) (coconeIn ccml n i) ;; x =
+                                  coconeIn ccxy n i)).
     { apply (tpair _ (f1 i)); intro n; apply (toforallpaths _ _ _ (f2 n) i). }
     apply (maponpaths pr1 (pr2 (X i) H)).
 Defined.
@@ -955,7 +948,7 @@ End pair_functor.
 (** ** The bindelta functor C -> C^2 mapping x to (x,x) is omega cocontinuous *)
 Section bindelta_functor.
 
-Variables (C : precategory) (PC : BinProducts C) (hsC : has_homsets C).
+Context {C : precategory} (PC : BinProducts C) (hsC : has_homsets C).
 
 Lemma is_cocont_bindelta_functor : is_cocont (bindelta_functor C).
 Proof.
@@ -973,7 +966,7 @@ End bindelta_functor.
 (** ** The generalized delta functor C -> C^I is omega cocontinuous *)
 Section delta_functor.
 
-Variables (I : UU) (C : precategory) (PC : Products I C) (hsC : has_homsets C).
+Context {I : UU} {C : precategory} (PC : Products I C) (hsC : has_homsets C).
 
 Lemma is_cocont_delta_functor : is_cocont (delta_functor I C).
 Proof.
@@ -992,7 +985,7 @@ End delta_functor.
 (** ** The functor "+ : C^2 -> C" is cocontinuous *)
 Section bincoprod_functor.
 
-Variables (C : precategory) (PC : BinCoproducts C) (hsC : has_homsets C).
+Context {C : precategory} (PC : BinCoproducts C) (hsC : has_homsets C).
 
 Lemma is_cocont_bincoproduct_functor : is_cocont (bincoproduct_functor PC).
 Proof.
@@ -1012,10 +1005,9 @@ End bincoprod_functor.
 (** ** The functor "+ : C^I -> C" is cocontinuous *)
 Section coprod_functor.
 
-Variables (I : UU) (C : precategory) (PC : Coproducts I C).
-Variable (hsC : has_homsets C).
+Context {I : UU} {C : precategory} (PC : Coproducts I C) (hsC : has_homsets C).
 
-Lemma cocont_indexed_coproduct_functor :
+Lemma is_cocont_indexed_coproduct_functor :
   is_cocont (indexed_coproduct_functor _ PC).
 Proof.
 apply (left_adjoint_cocont _ (is_left_adjoint_indexed_coproduct_functor _ PC)).
@@ -1026,7 +1018,7 @@ Defined.
 Lemma is_omega_cocont_indexed_coproduct_functor :
   is_omega_cocont (indexed_coproduct_functor _ PC).
 Proof.
-now intros c L ccL; apply cocont_indexed_coproduct_functor.
+now intros c L ccL; apply is_cocont_indexed_coproduct_functor.
 Defined.
 
 End coprod_functor.
@@ -1042,10 +1034,10 @@ Lemma is_omega_cocont_BinCoproduct_of_functors_alt {F G : functor C D}
   is_omega_cocont (BinCoproduct_of_functors_alt HD F G).
 Proof.
 apply (is_omega_cocont_functor_composite hsD).
-  apply (is_omega_cocont_bindelta_functor _ PC hsC).
+  apply (is_omega_cocont_bindelta_functor PC hsC).
 apply (is_omega_cocont_functor_composite hsD).
   apply (is_omega_cocont_binproduct_pair_functor _ _ hsC hsC hsD hsD HF HG).
-apply (is_omega_cocont_bincoproduct_functor _ _ hsD).
+apply (is_omega_cocont_bincoproduct_functor _ hsD).
 Defined.
 
 Definition omega_cocont_BinCoproduct_of_functors_alt (F G : omega_cocont_functor C D) :
@@ -1071,20 +1063,18 @@ End BinCoproduct_of_functors.
 (** ** Coproduct of families of functors: + F_i : C -> D is omega cocontinuous *)
 Section coproduct_of_functors.
 
-Variables (I : UU) (C D : precategory) (PC : Products I C).
-Variables (HD : Coproducts I D).
-Variables (hsC : has_homsets C) (hsD : has_homsets D).
-Variable (HI : isdeceq I).
+Context {I : UU} {C D : precategory} (PC : Products I C) (HD : Coproducts I D)
+        (hsC : has_homsets C) (hsD : has_homsets D) (HI : isdeceq I).
 
 Lemma is_omega_cocont_coproduct_of_functors_alt (F : Π i, functor C D)
   (HF : Π i, is_omega_cocont (F i)) :
   is_omega_cocont (coproduct_of_functors_alt _ HD F).
 Proof.
 apply (is_omega_cocont_functor_composite hsD).
-  apply (is_omega_cocont_delta_functor _ _ PC hsC).
+  apply (is_omega_cocont_delta_functor PC hsC).
 apply (is_omega_cocont_functor_composite hsD).
   apply (is_omega_cocont_pair_functor hsC hsD HI HF).
-apply (is_omega_cocont_indexed_coproduct_functor _ _ _ hsD).
+apply (is_omega_cocont_indexed_coproduct_functor _ hsD).
 Defined.
 
 Definition omega_cocont_coproduct_of_functors_alt
@@ -1111,8 +1101,7 @@ End coproduct_of_functors.
 (** ** Constant product functors: C -> C, x |-> a * x  and  x |-> x * a are cocontinuous *)
 Section constprod_functors.
 
-Variables (C : precategory) (PC : BinProducts C) (hsC : has_homsets C).
-Variables (hE : has_exponentials PC).
+Context {C : precategory} (PC : BinProducts C) (hsC : has_homsets C) (hE : has_exponentials PC).
 
 Lemma is_cocont_constprod_functor1 (x : C) : is_cocont (constprod_functor1 PC x).
 Proof.
@@ -1146,7 +1135,7 @@ End constprod_functors.
 (** ** The functor "* : C^2 -> C" is omega cocontinuous *)
 Section binprod_functor.
 
-Variables (C : precategory) (PC : BinProducts C) (hsC : has_homsets C).
+Context {C : precategory} (PC : BinProducts C) (hsC : has_homsets C).
 
 (* This hypothesis follow directly if C has exponentials *)
 Variable omega_cocont_constprod_functor1 :
@@ -1245,19 +1234,16 @@ Local Definition ccAiB_K (cAB : chain (binproduct_precategory C C)) (K : C)
   cocone (mapchain (constprod_functor1 PC (pr1 (pr1 cAB i)))
          (mapchain (pr2_functor C C) cAB)) K.
 Proof.
-simple refine (mk_cocone _ _).
+use mk_cocone.
 + intro j; apply (map_to_K cAB K ccK i j).
 + simpl; intros j k e; apply map_to_K_commutes.
 Defined.
 
 Section omega_cocont_binproduct.
 
-Variable cAB : chain (binproduct_precategory C C).
-Variable LM : C × C.
-Variable ccLM : cocone cAB LM.
-Variable HccLM : isColimCocone cAB LM ccLM.
-Variable K : C.
-Variable ccK : cocone (mapchain (binproduct_functor PC) cAB) K.
+Context {cAB : chain (binproduct_precategory C C)} {LM : C × C}
+        {ccLM : cocone cAB LM} (HccLM : isColimCocone cAB LM ccLM)
+        {K : C} (ccK : cocone (mapchain (binproduct_functor PC) cAB) K).
 
 Let L := pr1 LM : C.
 Let M := pr2 LM : (λ _ : C, C) (pr1 LM).
@@ -1479,10 +1465,10 @@ Lemma is_omega_cocont_BinProduct_of_functors_alt (F G : functor C D)
   is_omega_cocont (BinProduct_of_functors_alt PD F G).
 Proof.
 apply (is_omega_cocont_functor_composite hsD).
-- apply (is_omega_cocont_bindelta_functor _ PC hsC).
+- apply (is_omega_cocont_bindelta_functor PC hsC).
 - apply (is_omega_cocont_functor_composite hsD).
   + apply (is_omega_cocont_binproduct_pair_functor _ _ hsC hsC hsD hsD HF HG).
-  + now apply (is_omega_cocont_binproduct_functor _ _ hsD).
+  + now apply (is_omega_cocont_binproduct_functor _ hsD).
 Defined.
 
 Definition omega_cocont_BinProduct_of_functors_alt (F G : omega_cocont_functor C D) :
@@ -1507,10 +1493,8 @@ End BinProduct_of_functors.
 (** ** Precomposition functor is cocontinuous *)
 Section pre_composition_functor.
 
-Variables M C A : precategory.
-Variables (K : functor M C).
-Variables (hsC : has_homsets C) (hsA : has_homsets A).
-Variables (LA : Lims A).
+Context {M C A : precategory} (K : functor M C) (hsC : has_homsets C)
+        (hsA : has_homsets A) (LA : Lims A).
 
 Local Notation "c ↓ K" := (cComma hsC K c) (at level 30).
 
@@ -1700,7 +1684,7 @@ Notation "'Id'" := (omega_cocont_functor_identity has_homsets_HSET) :
 Notation "F * G" :=
   (omega_cocont_BinProduct_of_functors_alt BinProductsHSET _
      has_homsets_HSET has_homsets_HSET
-     (is_omega_cocont_constprod_functor1 _ _ has_homsets_HSET has_exponentials_HSET)
+     (is_omega_cocont_constprod_functor1 _ has_homsets_HSET has_exponentials_HSET)
      F G) : cocont_functor_hset_scope.
 
 Notation "F + G" :=

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -747,21 +747,29 @@ Proof.
 now intros c L ccL M H; apply isColimCocone_pr2_functor.
 Defined.
 
-(* TODO: refactor this and the below proof? *)
+Local Definition cFAX {gr : graph} (cAB : diagram gr (binproduct_precategory A B))
+  (xy : C × D) (ccxy : cocone (mapdiagram (binproduct_pair_functor F G) cAB) xy) :
+  cocone (mapdiagram F (mapdiagram (pr1_functor A B) cAB)) (pr1 xy).
+Proof.
+use mk_cocone.
+- intro n; apply (pr1 (pr1 ccxy n)).
+- abstract (intros m n e; apply (maponpaths dirprod_pr1 (pr2 ccxy m n e))).
+Defined.
+
+Local Definition cGBY {gr : graph} (cAB : diagram gr (binproduct_precategory A B))
+  (xy : C × D) (ccxy : cocone (mapdiagram (binproduct_pair_functor F G) cAB) xy) :
+  (cocone (mapdiagram G (mapdiagram (pr2_functor A B) cAB)) (pr2 xy)).
+Proof.
+use mk_cocone.
+- intro n; apply (pr2 (pr1 ccxy n)).
+- abstract (intros m n e; apply (maponpaths dirprod_pr2 (pr2 ccxy m n e))).
+Defined.
+
 Lemma is_cocont_binproduct_pair_functor (HF : is_cocont F) (HG : is_cocont G) :
   is_cocont (binproduct_pair_functor F G).
 Proof.
-intros gr cAB ml ccml Hccml xy ccxy; simpl in *.
-transparent assert (cFAX : (cocone (mapdiagram F (mapdiagram (pr1_functor A B) cAB)) (pr1 xy))).
-{ use mk_cocone.
-  - intro n; apply (pr1 (pr1 ccxy n)).
-  - abstract (intros m n e; apply (maponpaths pr1 (pr2 ccxy m n e))).
-}
-transparent assert (cGBY : (cocone (mapdiagram G (mapdiagram (pr2_functor A B) cAB)) (pr2 xy))).
-{ use mk_cocone.
-  - intro n; apply (pr2 (pr1 ccxy n)).
-  - abstract (intros m n e; apply (maponpaths dirprod_pr2 (pr2 ccxy m n e))).
-}
+intros gr cAB ml ccml Hccml xy ccxy.
+set (cFAX := cFAX cAB xy ccxy); set (cGBY := cGBY cAB xy ccxy).
 destruct (HF _ _ _ _ (isColimCocone_pr1_functor cAB ml ccml Hccml) _ cFAX) as [[f hf1] hf2].
 destruct (HG _ _ _ _ (isColimCocone_pr2_functor cAB ml ccml Hccml) _ cGBY) as [[g hg1] hg2].
 simpl in *.
@@ -769,30 +777,20 @@ mkpair.
 - apply (tpair _ (f,,g)).
   abstract (intro n; unfold binprodcatmor, compose; simpl;
             now rewrite hf1, hg1, (paireta (coconeIn ccxy n))).
-- intro t.
-  apply subtypeEquality; simpl.
-  + intro x; apply impred; intro.
-    apply isaset_dirprod; [ apply hsC | apply hsD ].
-  + induction t as [[f1 f2] p]; simpl in *.
-    apply pathsdirprod.
-    * apply (maponpaths pr1 (hf2 (f1,, (λ n, maponpaths pr1 (p n))))).
-    * apply (maponpaths pr1 (hg2 (f2,, (λ n, maponpaths dirprod_pr2 (p n))))).
+- abstract (intro t; apply subtypeEquality; simpl;
+             [ intro x; apply impred; intro; apply isaset_dirprod; [ apply hsC | apply hsD ]
+             | induction t as [[f1 f2] p]; simpl in *; apply pathsdirprod;
+               [ apply (maponpaths pr1 (hf2 (f1,, (λ n, maponpaths pr1 (p n)))))
+               | apply (maponpaths pr1 (hg2 (f2,, (λ n, maponpaths dirprod_pr2 (p n)))))]]).
 Defined.
 
+(** Note that this proof is more less the same as the above one. However we cannot use it as the
+    assumptions are too strong *)
 Lemma is_omega_cocont_binproduct_pair_functor (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
   is_omega_cocont (binproduct_pair_functor F G).
 Proof.
-intros cAB ml ccml Hccml xy ccxy; simpl in *.
-transparent assert (cFAX : (cocone (mapdiagram F (mapdiagram (pr1_functor A B) cAB)) (pr1 xy))).
-{ use mk_cocone.
-  - intro n; apply (pr1 (pr1 ccxy n)).
-  - abstract (intros m n e; apply (maponpaths pr1 (pr2 ccxy m n e))).
-}
-transparent assert (cGBY : (cocone (mapdiagram G (mapdiagram (pr2_functor A B) cAB)) (pr2 xy))).
-{ use mk_cocone.
-  - intro n; apply (pr2 (pr1 ccxy n)).
-  - abstract (intros m n e; apply (maponpaths dirprod_pr2 (pr2 ccxy m n e))).
-}
+intros cAB ml ccml Hccml xy ccxy.
+set (cFAX := cFAX cAB xy ccxy); set (cGBY := cGBY cAB xy ccxy).
 destruct (HF _ _ _ (isColimCocone_pr1_functor cAB ml ccml Hccml) _ cFAX) as [[f hf1] hf2].
 destruct (HG _ _ _ (isColimCocone_pr2_functor cAB ml ccml Hccml) _ cGBY) as [[g hg1] hg2].
 simpl in *.
@@ -800,14 +798,11 @@ mkpair.
 - apply (tpair _ (f,,g)).
   abstract (intro n; unfold binprodcatmor, compose; simpl;
             now rewrite hf1, hg1, (paireta (coconeIn ccxy n))).
-- intro t.
-  apply subtypeEquality; simpl.
-  + intro x; apply impred; intro.
-    apply isaset_dirprod; [ apply hsC | apply hsD ].
-  + induction t as [[f1 f2] p]; simpl in *.
-    apply pathsdirprod.
-    * apply (maponpaths pr1 (hf2 (f1,, (λ n, maponpaths pr1 (p n))))).
-    * apply (maponpaths pr1 (hg2 (f2,, (λ n, maponpaths dirprod_pr2 (p n))))).
+- abstract (intro t; apply subtypeEquality; simpl;
+             [ intro x; apply impred; intro; apply isaset_dirprod; [ apply hsC | apply hsD ]
+             | induction t as [[f1 f2] p]; simpl in *; apply pathsdirprod;
+               [ apply (maponpaths pr1 (hf2 (f1,, (λ n, maponpaths pr1 (p n)))))
+               | apply (maponpaths pr1 (hg2 (f2,, (λ n, maponpaths dirprod_pr2 (p n)))))]]).
 Defined.
 
 End binproduct_pair_functor.
@@ -884,63 +879,59 @@ Proof.
 now intros c L ccL M H; apply isColimCocone_pr_functor.
 Defined.
 
-(* TODO: refactor this and the below proof? *)
+(** This is used in the both of the next two proofs *)
+Local Definition cc {gr : graph} (F : Π (i : I), functor A B)
+  (cAB : diagram gr (product_precategory I (λ _ : I, A)))
+  (xy : I → B) (ccxy : cocone (mapdiagram (pair_functor I F) cAB) xy) (i : I) :
+  cocone (mapdiagram (F i) (mapdiagram (pr_functor I (λ _ : I, A) i) cAB)) (xy i).
+Proof.
+use mk_cocone.
+- intro n; apply (pr1 ccxy n).
+- abstract (intros m n e; apply (toforallpaths _ _ _ (pr2 ccxy m n e) i)).
+Defined.
+
 Lemma is_cocont_pair_functor
   {F : Π (i : I), functor A B} (HF : Π (i : I), is_cocont (F i)) :
   is_cocont (pair_functor I F).
 Proof.
 intros gr cAB ml ccml Hccml xy ccxy; simpl in *.
-simple refine (let cc i : cocone (mapdiagram (F i)
-                                 (mapdiagram (pr_functor I (fun _ => A) i) cAB)) (xy i) := _ in _).
-{ use mk_cocone.
-  - intro n; apply (pr1 ccxy n).
-  - abstract (intros m n e;
-              apply (toforallpaths _ _ _ (pr2 ccxy m n e) i)).
-}
+set (cc := cc F cAB xy ccxy).
 set (X i := HF i _ _ _ _ (isColimCocone_pr_functor _ _ _ Hccml i) (xy i) (cc i)).
 mkpair.
 - mkpair.
   + intro i; apply (pr1 (pr1 (X i))).
   + abstract (intro n; apply funextsec; intro j; apply (pr2 (pr1 (X j)) n)).
-- intro t.
-  apply subtypeEquality; simpl.
-  + intro x; apply impred; intro; apply impred_isaset; intro i; apply hsB.
-  + destruct t as [f1 f2]; simpl in *.
-    apply funextsec; intro i.
-    transparent assert (H : (Σ x : B ⟦ (F i) (ml i), xy i ⟧,
-                             Π n, # (F i) (coconeIn ccml n i) ;; x =
-                                  coconeIn ccxy n i)).
-    { apply (tpair _ (f1 i)); intro n; apply (toforallpaths _ _ _ (f2 n) i). }
-    apply (maponpaths pr1 (pr2 (X i) H)).
+- abstract (intro t; apply subtypeEquality; simpl;
+             [ intro x; apply impred; intro; apply impred_isaset; intro i; apply hsB
+             | destruct t as [f1 f2]; simpl in *;  apply funextsec; intro i;
+               transparent assert (H : (Σ x : B ⟦ (F i) (ml i), xy i ⟧,
+                                       Π n, # (F i) (coconeIn ccml n i) ;; x =
+                                       coconeIn ccxy n i));
+                [apply (tpair _ (f1 i)); intro n; apply (toforallpaths _ _ _ (f2 n) i)|];
+               apply (maponpaths pr1 (pr2 (X i) H))]).
 Defined.
 
+(** Note that this proof is more less the same as the above one. However we cannot use it as the
+    assumptions are too strong *)
 Lemma is_omega_cocont_pair_functor
   {F : Π (i : I), functor A B} (HF : Π (i : I), is_omega_cocont (F i)) :
   is_omega_cocont (pair_functor I F).
 Proof.
 intros cAB ml ccml Hccml xy ccxy; simpl in *.
-simple refine (let cc i : cocone (mapchain (F i)
-                                 (mapchain (pr_functor I (fun _ => A) i) cAB)) (xy i) := _ in _).
-{ use mk_cocone.
-  - intro n; apply (pr1 ccxy n).
-  - abstract (intros m n e;
-              apply (toforallpaths _ _ _ (pr2 ccxy m n e) i)).
-}
+set (cc := cc F cAB xy ccxy).
 set (X i := HF i _ _ _ (isColimCocone_pr_functor _ _ _ Hccml i) (xy i) (cc i)).
 mkpair.
 - mkpair.
   + intro i; apply (pr1 (pr1 (X i))).
   + abstract (intro n; apply funextsec; intro j; apply (pr2 (pr1 (X j)) n)).
-- intro t.
-  apply subtypeEquality; simpl.
-  + intro x; apply impred; intro; apply impred_isaset; intro i; apply hsB.
-  + destruct t as [f1 f2]; simpl in *.
-    apply funextsec; intro i.
-    transparent assert (H : (Σ x : B ⟦ (F i) (ml i), xy i ⟧,
-                             Π n, # (F i) (coconeIn ccml n i) ;; x =
-                                  coconeIn ccxy n i)).
-    { apply (tpair _ (f1 i)); intro n; apply (toforallpaths _ _ _ (f2 n) i). }
-    apply (maponpaths pr1 (pr2 (X i) H)).
+- abstract (intro t; apply subtypeEquality; simpl;
+             [ intro x; apply impred; intro; apply impred_isaset; intro i; apply hsB
+             | destruct t as [f1 f2]; simpl in *;  apply funextsec; intro i;
+               transparent assert (H : (Σ x : B ⟦ (F i) (ml i), xy i ⟧,
+                                       Π n, # (F i) (coconeIn ccml n i) ;; x =
+                                       coconeIn ccxy n i));
+                [apply (tpair _ (f1 i)); intro n; apply (toforallpaths _ _ _ (f2 n) i)|];
+               apply (maponpaths pr1 (pr2 (X i) H))]).
 Defined.
 
 End pair_functor.

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -468,7 +468,10 @@ Defined.
 (** Cocontinuity is preserved by isomorphic functors *)
 Section cocont_iso.
 
-Context {C D : precategory} (hsD : has_homsets D) {F G : functor C D} (αiso : @iso [C,D,hsD] F G).
+(* As this section is proving a proposition, the hypothesis can be weakened from a specified iso to
+F and G being isomorphic. *)
+Context {C D : precategory} (hsD : has_homsets D) {F G : functor C D}
+        (αiso : @is_iso [C,D,hsD] F G).
 
 Section preserves_colimit_iso.
 

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -9,37 +9,41 @@ The main result is Adámek's theorem for constructing initial algebras of omega-
 This file also contains proofs that the following functors are (omega-)cocontinuous:
 
 - Identity functor
-  [is_omega_cocont_functor_identity]
+  [is_cocont_functor_identity] [is_omega_cocont_functor_identity]
 - Constant functor: F_x : C -> D, c |-> x
   [is_omega_cocont_constant_functor]
 - Composition of omega-cocontinuous functors
-  [is_omega_cocont_functor_composite]
+  [is_cocont_functor_composite] [is_omega_cocont_functor_composite]
 - Iteration of omega-cocontinuous functors: F^n : C -> C
-  [is_omega_cocont_iter_functor]
-- Pairing of omega-cocont functors (F,G) : A * B -> C * D, (x,y) |-> (F x,G y)
-  [is_omega_cocont_binproduct_pair_functor]
-- Indexed families of omega-cocont functors F^I : A^I -> B^I
-  [is_omega_cocont_pair_functor]
+  [is_cocont_iter_functor] [is_omega_cocont_iter_functor]
+- Pairing of (omega-)cocont functors (F,G) : A * B -> C * D, (x,y) |-> (F x,G y)
+  [is_cocont_binproduct_pair_functor] [is_omega_cocont_binproduct_pair_functor]
+- Indexed families of (omega-)cocont functors F^I : A^I -> B^I
+  [is_cocont_pair_functor] [is_omega_cocont_pair_functor]
 - Binary delta functor: C -> C^2, x |-> (x,x)
-  [cocont_bindelta_functor] [is_omega_cocont_bindelta_functor]
+  [is_cocont_bindelta_functor] [is_omega_cocont_bindelta_functor]
 - General delta functor: C -> C^I
-  [is_omega_cocont_delta_functor]
+  [is_cocont_delta_functor] [is_omega_cocont_delta_functor]
 - Binary coproduct functor: C^2 -> C, (x,y) |-> x + y
-  [cocont_bincoproduct_functor] [is_omega_cocont_bincoproduct_functor]
+  [is_cocont_bincoproduct_functor] [is_omega_cocont_bincoproduct_functor]
 - General coproduct functor: C^I -> C
-  [cocont_indexed_coproduct_functor] [is_omega_cocont_indexed_coproduct_functor]
-- Binary coproduct of functors: F + G : C -> D, x |-> (x,x) |-> (F x,G x) |-> F x + G x
+  [is_cocont_indexed_coproduct_functor] [is_omega_cocont_indexed_coproduct_functor]
+- Binary coproduct of functors: F + G : C -> D, x |-> (x,x) |-> (F x,G x) |-> F x
+ + G x
+  [is_cocont_BinCoproduct_of_functors_alt] [is_cocont_BinCoproduct_of_functors]
   [is_omega_cocont_BinCoproduct_of_functors_alt] [is_omega_cocont_BinCoproduct_of_functors]
 - Coproduct of families of functors: + F_i : C -> D  (generalization of coproduct of functors)
+  [is_cocont_coproduct_of_functors_alt] [is_cocont_coproduct_of_functors]
   [is_omega_cocont_coproduct_of_functors_alt] [is_omega_cocont_coproduct_of_functors]
 - Constant product functors: C -> C, x |-> a * x  and  x |-> x * a
+  [is_cocont_constprod_functor1] [is_cocont_constprod_functor2]
   [is_omega_cocont_constprod_functor1] [is_omega_cocont_constprod_functor2]
 - Binary product functor: C^2 -> C, (x,y) |-> x * y
   [is_omega_cocont_binproduct_functor]
 - Product of functors: F * G : C -> D, x |-> (x,x) |-> (F x,G x) |-> F x * G x
   [is_omega_cocont_BinProduct_of_functors_alt] [is_omega_cocont_BinProduct_of_functors]
 - Precomposition functor: _ o K : ⟦C,A⟧ -> ⟦M,A⟧ for K : M -> C
-  [is_omega_cocont_pre_composition_functor]
+  [is_cocont_pre_composition_functor] [is_omega_cocont_pre_composition_functor]
 
 
 Written by: Anders Mörtberg and Benedikt Ahrens, 2015-2016
@@ -539,14 +543,14 @@ mkpair.
     | apply (colimArrowUnique CC); intro n; apply (pr2 t)]).
 Defined.
 
-Lemma is_cocont_identity : is_cocont (functor_identity C).
+Lemma is_cocont_functor_identity : is_cocont (functor_identity C).
 Proof.
 now intros g; apply preserves_colimit_identity.
 Defined.
 
 Lemma is_omega_cocont_functor_identity : is_omega_cocont (functor_identity C).
 Proof.
-now intros c; apply is_cocont_identity.
+now intros c; apply is_cocont_functor_identity.
 Defined.
 
 Definition omega_cocont_functor_identity : omega_cocont_functor C C :=
@@ -635,8 +639,16 @@ Definition omega_cocont_functor_composite
 
 End functor_composite.
 
-(** ** Functor iteration preserves omega cocontinuity *)
+(** ** Functor iteration preserves (omega)-cocontinuity *)
 Section iter_functor.
+
+Lemma is_cocont_iter_functor {C : precategory} (hsC : has_homsets C)
+  (F : functor C C) (hF : is_cocont F) n : is_cocont (iter_functor F n).
+Proof.
+induction n as [|n IH]; simpl.
+- apply (is_cocont_functor_identity hsC).
+- apply (is_cocont_functor_composite hsC _ _ IH hF).
+Defined.
 
 Lemma is_omega_cocont_iter_functor {C : precategory} (hsC : has_homsets C)
   (F : functor C C) (hF : is_omega_cocont F) n : is_omega_cocont (iter_functor F n).
@@ -997,6 +1009,18 @@ Section BinCoproduct_of_functors.
 Context {C D : precategory} (PC : BinProducts C) (HD : BinCoproducts D)
         (hsC : has_homsets C) (hsD : has_homsets D).
 
+
+Lemma is_cocont_BinCoproduct_of_functors_alt {F G : functor C D}
+  (HF : is_cocont F) (HG : is_cocont G) :
+  is_cocont (BinCoproduct_of_functors_alt HD F G).
+Proof.
+apply (is_cocont_functor_composite hsD).
+  apply (is_cocont_bindelta_functor PC hsC).
+apply (is_cocont_functor_composite hsD).
+  apply (is_cocont_binproduct_pair_functor _ _ hsC hsC hsD hsD HF HG).
+apply (is_cocont_bincoproduct_functor _ hsD).
+Defined.
+
 Lemma is_omega_cocont_BinCoproduct_of_functors_alt {F G : functor C D}
   (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
   is_omega_cocont (BinCoproduct_of_functors_alt HD F G).
@@ -1011,6 +1035,15 @@ Defined.
 Definition omega_cocont_BinCoproduct_of_functors_alt (F G : omega_cocont_functor C D) :
   omega_cocont_functor C D :=
     tpair _ _ (is_omega_cocont_BinCoproduct_of_functors_alt (pr2 F) (pr2 G)).
+
+Lemma is_cocont_BinCoproduct_of_functors (F G : functor C D)
+  (HF : is_cocont F) (HG : is_cocont G) :
+  is_cocont (BinCoproduct_of_functors _ _ HD F G).
+Proof.
+exact (transportf _
+         (BinCoproduct_of_functors_alt_eq_BinCoproduct_of_functors C D HD hsD F G)
+         (is_cocont_BinCoproduct_of_functors_alt HF HG)).
+Defined.
 
 Lemma is_omega_cocont_BinCoproduct_of_functors (F G : functor C D)
   (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
@@ -1034,6 +1067,17 @@ Section coproduct_of_functors.
 Context {I : UU} {C D : precategory} (PC : Products I C) (HD : Coproducts I D)
         (hsC : has_homsets C) (hsD : has_homsets D) (HI : isdeceq I).
 
+Lemma is_cocont_coproduct_of_functors_alt (F : Π i, functor C D)
+  (HF : Π i, is_cocont (F i)) :
+  is_cocont (coproduct_of_functors_alt _ HD F).
+Proof.
+apply (is_cocont_functor_composite hsD).
+  apply (is_cocont_delta_functor PC hsC).
+apply (is_cocont_functor_composite hsD).
+  apply (is_cocont_pair_functor hsC hsD HI HF).
+apply (is_cocont_indexed_coproduct_functor _ hsD).
+Defined.
+
 Lemma is_omega_cocont_coproduct_of_functors_alt (F : Π i, functor C D)
   (HF : Π i, is_omega_cocont (F i)) :
   is_omega_cocont (coproduct_of_functors_alt _ HD F).
@@ -1049,6 +1093,15 @@ Definition omega_cocont_coproduct_of_functors_alt
   (F : Π i, omega_cocont_functor C D) :
   omega_cocont_functor C D :=
     tpair _ _ (is_omega_cocont_coproduct_of_functors_alt _ (fun i => pr2 (F i))).
+
+Lemma is_cocont_coproduct_of_functors (F : Π (i : I), functor C D)
+  (HF : Π i, is_cocont (F i)) :
+  is_cocont (coproduct_of_functors I _ _ HD F).
+Proof.
+exact (transportf _
+        (coproduct_of_functors_alt_eq_coproduct_of_functors I C D HD hsD F)
+        (is_cocont_coproduct_of_functors_alt _ HF)).
+Defined.
 
 Lemma is_omega_cocont_coproduct_of_functors (F : Π (i : I), functor C D)
   (HF : Π i, is_omega_cocont (F i)) :

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -471,7 +471,7 @@ Section cocont_iso.
 (* As this section is proving a proposition, the hypothesis can be weakened from a specified iso to
 F and G being isomorphic. *)
 Context {C D : precategory} (hsD : has_homsets D) {F G : functor C D}
-        (αiso : @is_iso [C,D,hsD] F G).
+        (αiso : @iso [C,D,hsD] F G).
 
 Section preserves_colimit_iso.
 

--- a/UniMath/CategoryTheory/lambdacalculus.v
+++ b/UniMath/CategoryTheory/lambdacalculus.v
@@ -66,14 +66,14 @@ Local Notation "'Id'" := (omega_cocont_functor_identity has_homsets_HSET2).
 Local Notation "F * G" :=
   (omega_cocont_BinProduct_of_functors_alt BinProductsHSET2 _
      has_homsets_HSET2 has_homsets_HSET2
-     (is_omega_cocont_constprod_functor1 _ _ has_homsets_HSET2 has_exponentials_HSET2) F G).
+     (is_omega_cocont_constprod_functor1 _ has_homsets_HSET2 has_exponentials_HSET2) F G).
 
 Local Notation "F + G" :=
   (omega_cocont_BinCoproduct_of_functors_alt BinProductsHSET2 BinCoproductsHSET2
      has_homsets_HSET2 has_homsets_HSET2 F G).
 
 Local Notation "'_' 'o' 'option'" :=
-  (omega_cocont_pre_composition_functor _ _ _
+  (omega_cocont_pre_composition_functor
       (option_functor HSET BinCoproductsHSET TerminalHSET)
       has_homsets_HSET has_homsets_HSET cats_LimsHSET) (at level 10).
 

--- a/UniMath/CategoryTheory/lambdacalculus.v
+++ b/UniMath/CategoryTheory/lambdacalculus.v
@@ -87,7 +87,7 @@ Let is_omega_cocont_lambdaFunctor : is_omega_cocont lambdaFunctor :=
 Lemma lambdaFunctor_Initial :
   Initial (precategory_FunctorAlg lambdaFunctor has_homsets_HSET2).
 Proof.
-apply (colimAlgInitial _ _ InitialHSET2 _ is_omega_cocont_lambdaFunctor).
+apply (colimAlgInitial _ InitialHSET2 is_omega_cocont_lambdaFunctor).
 apply ColimsFunctorCategory; apply ColimsHSET.
 Defined.
 

--- a/UniMath/CategoryTheory/lambdacalculus.v
+++ b/UniMath/CategoryTheory/lambdacalculus.v
@@ -64,11 +64,12 @@ Local Notation "' x" := (omega_cocont_constant_functor has_homsets_HSET2 x)
 Local Notation "'Id'" := (omega_cocont_functor_identity has_homsets_HSET2).
 
 Local Notation "F * G" :=
-  (omega_cocont_BinProduct_of_functors_alt _ _ BinProductsHSET2 _
-     has_exponentials_HSET2 has_homsets_HSET2 has_homsets_HSET2 F G).
+  (omega_cocont_BinProduct_of_functors_alt BinProductsHSET2 _
+     has_homsets_HSET2 has_homsets_HSET2
+     (is_omega_cocont_constprod_functor1 _ _ has_homsets_HSET2 has_exponentials_HSET2) F G).
 
 Local Notation "F + G" :=
-  (omega_cocont_BinCoproduct_of_functors_alt _ _ BinProductsHSET2 BinCoproductsHSET2
+  (omega_cocont_BinCoproduct_of_functors_alt BinProductsHSET2 BinCoproductsHSET2
      has_homsets_HSET2 has_homsets_HSET2 F G).
 
 Local Notation "'_' 'o' 'option'" :=

--- a/UniMath/CategoryTheory/limits/cats/limits.v
+++ b/UniMath/CategoryTheory/limits/cats/limits.v
@@ -265,6 +265,40 @@ split.
 Defined.
 *)
 
+Definition iso_from_lim_to_lim {J C : precategory} {F : functor J C}
+  (CC CC' : LimCone F) : iso (lim CC) (lim CC').
+Proof.
+use isopair.
+- apply limArrow, limCone.
+- use is_iso_qinv.
+  + apply limArrow, limCone.
+  + abstract (now split; apply pathsinv0, lim_endo_is_identity; intro u;
+              rewrite <- assoc, limArrowCommutes; eapply pathscomp0; try apply limArrowCommutes).
+Defined.
+
+Section Universal_Unique.
+
+Context {C : precategory} (H : is_category C).
+
+Lemma isaprop_Lims: isaprop (Lims C).
+Proof.
+apply impred; intro J; apply impred; intro F.
+apply invproofirrelevance; intros Hccx Hccy.
+apply subtypeEquality.
+- intro; apply isaprop_isLimCone.
+- apply (total2_paths (isotoid _ H (iso_from_lim_to_lim Hccx Hccy))).
+  set (B c := Π v, C⟦c,F v⟧).
+  set (C' (c : C) f := Π u v (e : J⟦u,v⟧), @compose _ c _ _ (f u) (# F e) = f v).
+  rewrite (@transportf_total2 _ B C').
+  apply subtypeEquality.
+  + intro; repeat (apply impred; intro); apply (pr2 H).
+  + abstract (now simpl; eapply pathscomp0; [apply transportf_isotoid_dep'|];
+              apply funextsec; intro v; rewrite inv_isotoid, idtoiso_isotoid;
+              cbn; unfold precomp_with; rewrite id_right; apply limArrowCommutes).
+Qed.
+
+End Universal_Unique.
+
 End lim_def.
 
 Arguments Lims : clear implicits.

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -354,47 +354,6 @@ simple refine (tpair _ _ _).
     now rewrite <- (Hf u), assoc, colimArrowCommutes.
 Defined.
 
-Section Universal_Unique.
-
-Hypothesis H : is_category C.
-
-
-(* Definition from_Pullback_to_Pullback {a b c : C}{f : b --> a} {g : c --> a} *)
-(*    (Pb Pb': Pullback f g) : Pb --> Pb'. *)
-(* Proof. *)
-(*   apply (PullbackArrow Pb' Pb (PullbackPr1 _ ) (PullbackPr2 _)). *)
-(*   exact (PullbackSqrCommutes _ ). *)
-(* Defined. *)
-
-
-(* Lemma are_inverses_from_Pullback_to_Pullback {a b c : C}{f : b --> a} {g : c --> a} *)
-(*    (Pb Pb': Pullback f g) : *)
-(* is_inverse_in_precat (from_Pullback_to_Pullback Pb Pb') *)
-(*   (from_Pullback_to_Pullback Pb' Pb). *)
-(* Proof. *)
-(*   split; apply pathsinv0; *)
-(*   apply PullbackEndo_is_identity; *)
-(*   rewrite <- assoc; *)
-(*   unfold from_Pullback_to_Pullback; *)
-(*   repeat rewrite PullbackArrow_PullbackPr1; *)
-(*   repeat rewrite PullbackArrow_PullbackPr2; *)
-(*   auto. *)
-(* Qed. *)
-
-
-(* Lemma isiso_from_Pullback_to_Pullback {a b c : C}{f : b --> a} {g : c --> a} *)
-(*    (Pb Pb': Pullback f g) : *)
-(*       is_isomorphism (from_Pullback_to_Pullback Pb Pb'). *)
-(* Proof. *)
-(*   apply (is_iso_qinv _ (from_Pullback_to_Pullback Pb' Pb)). *)
-(*   apply are_inverses_from_Pullback_to_Pullback. *)
-(* Defined. *)
-
-
-(* Definition iso_from_Pullback_to_Pullback {a b c : C}{f : b --> a} {g : c --> a} *)
-(*    (Pb Pb': Pullback f g) : iso Pb Pb' := *)
-(*   tpair _ _ (isiso_from_Pullback_to_Pullback Pb Pb'). *)
-
 Definition iso_from_Colim_to_Colim {g : graph} {d : diagram g C}
   (CC CC' : ColimCocone d) : iso (colim CC) (colim CC').
 Proof.
@@ -406,49 +365,25 @@ use isopair.
               rewrite assoc, colimArrowCommutes; eapply pathscomp0; try apply colimArrowCommutes).
 Defined.
 
-Lemma my_transportf_isotoid_dep' (J : UU)
-  (F : J -> C)
-   (a a' : C) (p : a = a') (f : Π c, F c --> a) :
- transportf (fun x : C => Π c, F c --> x) p f = fun c => f c ;; idtoiso p.
-Proof.
-  destruct p.
-  apply funextsec.
-  intro. simpl.
-  apply (! id_right _ _ _ _).
-Defined.
+Section Universal_Unique.
+
+Hypothesis H : is_category C.
 
 Lemma isaprop_Colims: isaprop Colims.
 Proof.
 apply impred; intro g; apply impred; intro cc.
-apply invproofirrelevance.
-intros Hccx Hccy.
+apply invproofirrelevance; intros Hccx Hccy.
 apply subtypeEquality.
 - intro; apply isaprop_isColimCocone.
--
-apply (total2_paths (isotoid _ H (iso_from_Colim_to_Colim Hccx Hccy))).
-set (B c := forall v : vertex g, precategory_morphisms (dob cc v) c).
-set (C0 c f := forall (u v : vertex g) (e : edge u v),
-           paths (@compose _ _ _ c (dmor cc e) (f v)) (f u)).
-assert (test : forall (x1 x2 : C)
-          (p : x1 = x2) (yz : total2 (fun y : B x1 => C0 x1 y)),
-        transportf (λ c : C, total2 (fun y : B c => C0 c y)) p yz =
-          (transportf B p (pr1 yz),,transportD B C0 p (pr1 yz) (pr2 yz))).
-  apply @transportf_total2.
-rewrite test. (* GAH!!! *)
-
-apply subtypeEquality.
-intro.
-apply impred; intro.
-apply impred; intro.
-apply impred; intro.
-apply hsC.
-simpl.
-eapply pathscomp0.
-apply (my_transportf_isotoid_dep' (vertex g)).
-apply funextsec; intro v.
-rewrite idtoiso_isotoid.
-simpl.
-apply colimArrowCommutes.
+- apply (total2_paths (isotoid _ H (iso_from_Colim_to_Colim Hccx Hccy))).
+  set (B c := Π v, C⟦dob cc v,c⟧).
+  set (C' (c : C) f := Π u v (e : edge u v), @compose _ _ _ c (dmor cc e) (f v) = f u).
+  rewrite (@transportf_total2 _ B C').
+  apply subtypeEquality.
+  + intro; repeat (apply impred; intro); apply hsC.
+  + simpl; eapply pathscomp0; [apply transportf_isotoid_dep''|].
+    apply funextsec; intro v.
+    now rewrite idtoiso_isotoid; apply colimArrowCommutes.
 Qed.
 
 End Universal_Unique.

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -354,7 +354,7 @@ simple refine (tpair _ _ _).
     now rewrite <- (Hf u), assoc, colimArrowCommutes.
 Defined.
 
-Definition iso_from_Colim_to_Colim {g : graph} {d : diagram g C}
+Definition iso_from_colim_to_colim {g : graph} {d : diagram g C}
   (CC CC' : ColimCocone d) : iso (colim CC) (colim CC').
 Proof.
 use isopair.
@@ -375,7 +375,7 @@ apply impred; intro g; apply impred; intro cc.
 apply invproofirrelevance; intros Hccx Hccy.
 apply subtypeEquality.
 - intro; apply isaprop_isColimCocone.
-- apply (total2_paths (isotoid _ H (iso_from_Colim_to_Colim Hccx Hccy))).
+- apply (total2_paths (isotoid _ H (iso_from_colim_to_colim Hccx Hccy))).
   set (B c := Π v, C⟦dob cc v,c⟧).
   set (C' (c : C) f := Π u v (e : edge u v), @compose _ _ _ c (dmor cc e) (f v) = f u).
   rewrite (@transportf_total2 _ B C').

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -412,23 +412,16 @@ use isopair.
               rewrite assoc, colimArrowCommutes; eapply pathscomp0; try apply colimArrowCommutes).
 Defined.
 
-Lemma my_transportf_isotoid_dep
-     : Π (C : precategory) (H : is_category C) (a a' : C) (p : iso a a')
-       (f : Π c : C, C ⟦ a, c ⟧),
-       transportf (fun x : C => Π c, x --> c) (isotoid C H p) f =
-(* (isotoid C H p # f)%transport = *)
-       (λ c : C, inv_from_iso p ;; f c).
-Admitted.
-
-(*      : Π (C : precategory) (H : is_category C) (a a' b : C) *)
-(*        (p : iso a a') (f : C ⟦ a, b ⟧), *)
-(*        (isotoid C H p # f)%transport = inv_from_iso p ;; f *)
-
-(* transportf_isotoid *)
-(*      : Π (C : precategory) (H : is_category C) (a a' b : C) *)
-(*        (p : iso a a') (f : C ⟦ a, b ⟧), *)
-(*        (isotoid C H p # f)%transport = inv_from_iso p ;; f *)
-
+Lemma my_transportf_isotoid_dep' (J : UU)
+  (F : J -> C)
+   (a a' : C) (p : a = a') (f : Π c, F c --> a) :
+ transportf (fun x : C => Π c, F c --> x) p f = fun c => f c ;; idtoiso p.
+Proof.
+  destruct p.
+  apply funextsec.
+  intro. simpl.
+  apply (! id_right _ _ _ _).
+Defined.
 
 Lemma isaprop_Colims: isaprop Colims.
 Proof.
@@ -456,159 +449,15 @@ apply impred; intro.
 apply impred; intro.
 apply hsC.
 simpl.
-
-(* TODO: Stuck after this... *)
-
+eapply pathscomp0.
+apply (my_transportf_isotoid_dep' (vertex g)).
 apply funextsec; intro v.
+rewrite idtoiso_isotoid.
 simpl.
-Check (pr1 (pr2 (pr1 Hccx)) v).
-
-set (ttf := transportf).
-Check (ttf B (pr1 (pr1 Hccx)) (pr1 (pr1 Hccy))
-    (isotoid C H (iso_from_Colim_to_Colim Hccx Hccy))
-    (pr1 (pr2 (pr1 Hccx)))).
-generalize idtoiso_precompose.
-rewrite id
-
-eapply pathscomp0.
-generalize (my_transportf_isotoid_dep C H _ _  (iso_from_Colim_to_Colim Hccx Hccy)).
-Check (pr1 (pr2 (pr1 Hccx))).
-eapply pathscomp0.
-apply transportf_isotoid.
-
-(* destruct Hccx as [[x ccx] Hccx]. *)
-(* destruct Hccy as [[y ccy] Hccy]. *)
-(* simpl in *. *)
-apply funextsec; intro v.
-simpl.
-Check (pr1 ccy).
-
-clear HH.
-unfold colimCocone.
-simpl.
-destruct ccx as [a b].
-simpl.
-simpl.
-Check (colimCocone Hccy).
-
-rewrite HH.
-
-assert (H : transportf _ (pr2 (pr1 Hccx)) (isotoid C H (iso_from_Colim_to_Colim Hccx Hccy)) =
-            (isotoid C H (iso_from_Colim_to_Colim Hccx Hccy) # pr2 (pr1 Hccx))%transport).
-Check (colimCocone
-eapply (my_transportf_isotoid_dep C H _ _ (iso_from_Colim_to_Colim Hccx Hccy)).
-Check transportf_isotoid.
-eapply (transportf_isotoid C (colim Hccx) (colim Hccy) (iso_from_Colim_to_Colim Hccx Hccy)).
-Search "isotoid" "dep".
-Search transportf isotoid.
-eapply (transportf_isotoid C H (colim Hccx) (colim Hccy) _ (iso_from_Colim_to_Colim Hccx Hccy) (coconeIn (pr2 (pr1 Hccx)))).
-
-
-Check (isotoid C H (iso_from_Colim_to_Colim Hccx Hccy)).
-eapply
-
-
-_ (fun _ => UU) (fun _ _ => UU) (isotoid C H (iso_from_Colim_to_Colim Hccx Hccy))).
-
-Search transportf total2.
-Check (a,,b).
-simpl.
-
-simpl.
-cbn.
-Check (pr2 (pr1 Hccx)).
-
-simpl.
-
-transportf_isotoid_dep.
-
-Search transportf.
-rewrite transportf_dirprod.
-
-eapply pathscomp0.
-generalize (transportf_isotoid _ H).
-(* _ _ _  (iso_from_Colim_to_Colim Hccx Hccy)). *)
-intro HH.
-destruct ccx as [a b].
-unfold transportf.
-unfold constr1.
-simpl.
-simpl.
-Check (ccocone cc).
-simpl in *.
-eapply HH.
-Check (pr1 ccx).
-
-unfold is_category in *.
-assert (p : x = y).
-  admit.
-eapply total2_paths.
-simpl.
-Unshelve.
-Focus 2.
-simpl.
-apply p.
-
-apply (@total2_paths p).
-
-
-apply (total2_paths  (isotoid _ H (iso_from_Pullback_to_Pullback Pb Pb' ))).
-    rewrite transportf_dirprod, transportf_isotoid.
-    rewrite inv_from_iso_iso_from_Pullback.
-    rewrite transportf_isotoid.
-    rewrite inv_from_iso_iso_from_Pullback.
-    destruct Pb as [Cone bla];
-    destruct Pb' as [Cone' bla'];
-    simpl in *.
-    destruct Cone as [p [h k]];
-    destruct Cone' as [p' [h' k']];
-    simpl in *.
-    unfold from_Pullback_to_Pullback;
-    rewrite PullbackArrow_PullbackPr2, PullbackArrow_PullbackPr1.
-    apply idpath.
+apply colimArrowCommutes.
 Qed.
 
-(* Lemma inv_from_iso_iso_from_Pullback (a b c : C) (f : b --> a) (g : c --> a) *)
-(*   (Pb : Pullback f g) (Pb' : Pullback f g): *)
-(*     inv_from_iso (iso_from_Pullback_to_Pullback Pb Pb') = from_Pullback_to_Pullback Pb' Pb. *)
-(* Proof. *)
-(*   apply pathsinv0. *)
-(*   apply inv_iso_unique'. *)
-(*   set (T:= are_inverses_from_Pullback_to_Pullback Pb Pb'). *)
-(*   apply (pr1 T). *)
-(* Qed. *)
-
-(* Lemma isaprop_Pullbacks: isaprop Pullbacks. *)
-(* Proof. *)
-(*   apply impred; intro a; *)
-(*   apply impred; intro b; *)
-(*   apply impred; intro c; *)
-(*   apply impred; intro f; *)
-(*   apply impred; intro g; *)
-(*   apply invproofirrelevance. *)
-(*   intros Pb Pb'. *)
-(*   apply subtypeEquality. *)
-(*   - intro; apply isofhleveltotal2. *)
-(*     + apply hs. *)
-(*     + intros; apply isaprop_isPullback. *)
-(*   - apply (total2_paths  (isotoid _ H (iso_from_Pullback_to_Pullback Pb Pb' ))). *)
-(*     rewrite transportf_dirprod, transportf_isotoid. *)
-(*     rewrite inv_from_iso_iso_from_Pullback. *)
-(*     rewrite transportf_isotoid. *)
-(*     rewrite inv_from_iso_iso_from_Pullback. *)
-(*     destruct Pb as [Cone bla]; *)
-(*     destruct Pb' as [Cone' bla']; *)
-(*     simpl in *. *)
-(*     destruct Cone as [p [h k]]; *)
-(*     destruct Cone' as [p' [h' k']]; *)
-(*     simpl in *. *)
-(*     unfold from_Pullback_to_Pullback; *)
-(*     rewrite PullbackArrow_PullbackPr2, PullbackArrow_PullbackPr1. *)
-(*     apply idpath. *)
-(* Qed. *)
-
 End Universal_Unique.
-
 
 End colim_def.
 

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -29,12 +29,6 @@ Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
 Section move_upstream.
 
-Lemma path_to_ctr (A : UU) (B : A -> UU) (isc : iscontr (total2 (fun a => B a)))
-           (a : A) (p : B a) : a = pr1 (pr1 isc).
-Proof.
-exact (maponpaths pr1 (pr2 isc (tpair _ a p))).
-Defined.
-
 Lemma uniqueExists (A : UU) (P : A -> UU)
   (Hexists : iscontr (total2 (fun a => P a)))
   (a b : A) (Ha : P a) (Hb : P b) : a = b.

--- a/UniMath/CategoryTheory/limits/graphs/limits.v
+++ b/UniMath/CategoryTheory/limits/graphs/limits.v
@@ -314,6 +314,40 @@ split.
 Defined.
 *)
 
+Definition iso_from_lim_to_lim {g : graph} {d : diagram g C}
+  (CC CC' : LimCone d) : iso (lim CC) (lim CC').
+Proof.
+use isopair.
+- apply limArrow, limCone.
+- use is_iso_qinv.
+  + apply limArrow, limCone.
+  + abstract (now split; apply pathsinv0, lim_endo_is_identity; intro u;
+              rewrite <- assoc, limArrowCommutes; eapply pathscomp0; try apply limArrowCommutes).
+Defined.
+
+Section Universal_Unique.
+
+Hypothesis H : is_category C.
+
+Lemma isaprop_Lims: isaprop Lims.
+Proof.
+apply impred; intro g; apply impred; intro cc.
+apply invproofirrelevance; intros Hccx Hccy.
+apply subtypeEquality.
+- intro; apply isaprop_isLimCone.
+- apply (total2_paths (isotoid _ H (iso_from_lim_to_lim Hccx Hccy))).
+  set (B c := Π v, C⟦c,dob cc v⟧).
+  set (C' (c : C) f := Π u v (e : edge u v), @compose _ c _ _ (f u) (dmor cc e) = f v).
+  rewrite (@transportf_total2 _ B C').
+  apply subtypeEquality.
+  + intro; repeat (apply impred; intro); apply hsC.
+  + abstract (now simpl; eapply pathscomp0; [apply transportf_isotoid_dep'|];
+              apply funextsec; intro v; rewrite inv_isotoid, idtoiso_isotoid;
+              cbn; unfold precomp_with; rewrite id_right; apply limArrowCommutes).
+Qed.
+
+End Universal_Unique.
+
 End lim_def.
 
 Arguments Lims : clear implicits.

--- a/UniMath/CategoryTheory/lists.v
+++ b/UniMath/CategoryTheory/lists.v
@@ -38,7 +38,7 @@ Let is_omega_cocont_listFunctor : is_omega_cocont listFunctor := pr2 listOmegaFu
 Lemma listFunctor_Initial :
   Initial (precategory_FunctorAlg listFunctor has_homsets_HSET).
 Proof.
-apply (colimAlgInitial _ _ InitialHSET _ is_omega_cocont_listFunctor (ColimCoconeHSET _ _)).
+apply (colimAlgInitial _ InitialHSET is_omega_cocont_listFunctor (ColimCoconeHSET _ _)).
 Defined.
 
 Definition List : HSET :=
@@ -504,7 +504,7 @@ Defined.
 Lemma listFunctor_Initial :
   Initial (precategory_FunctorAlg listFunctor has_homsets_HSET).
 Proof.
-apply (colimAlgInitial _ _ InitialHSET _ omega_cocont_listFunctor (ColimCoconeHSET _ _)).
+apply (colimAlgInitial _ InitialHSET omega_cocont_listFunctor (ColimCoconeHSET _ _)).
 Defined.
 
 Definition List : HSET :=

--- a/UniMath/CategoryTheory/precategories.v
+++ b/UniMath/CategoryTheory/precategories.v
@@ -1133,15 +1133,19 @@ Proof.
   apply idpath.
 Qed.
 
-Lemma transportf_isotoid_dep' (J : UU) (C : precategory)
-  (F : J -> C)
-   (a a' : C) (p : a = a') (f : Π c, a --> F c) :
- transportf (fun x : C => Π c, x --> F c) p f = fun c => idtoiso (!p) ;; f c.
+Lemma transportf_isotoid_dep' (J : UU) (C : precategory) (F : J -> C)
+  (a a' : C) (p : a = a') (f : Π c, a --> F c) :
+  transportf (fun x : C => Π c, x --> F c) p f = fun c => idtoiso (!p) ;; f c.
 Proof.
-  destruct p.
-  apply funextsec.
-  intro. simpl.
-  apply (! id_left _ _ _ _).
+  now destruct p; apply funextsec; intro x; rewrite id_left.
+Defined.
+
+(* This and the above name is not very good... *)
+ Lemma transportf_isotoid_dep'' (J : UU) (C : precategory) (F : J -> C)
+   (a a' : C) (p : a = a') (f : Π c, F c --> a) :
+   transportf (fun x : C => Π c, F c --> x) p f = fun c => f c ;; idtoiso p.
+Proof.
+  now destruct p; apply funextsec; intro x; rewrite id_right.
 Defined.
 
 

--- a/UniMath/CategoryTheory/precategories.v
+++ b/UniMath/CategoryTheory/precategories.v
@@ -1133,7 +1133,7 @@ Proof.
   apply idpath.
 Qed.
 
-Lemma transportf_isotoid_dep' (J C : precategory)
+Lemma transportf_isotoid_dep' (J : UU) (C : precategory)
   (F : J -> C)
    (a a' : C) (p : a = a') (f : Π c, a --> F c) :
  transportf (fun x : C => Π c, x --> F c) p f = fun c => idtoiso (!p) ;; f c.

--- a/UniMath/CategoryTheory/trees.v
+++ b/UniMath/CategoryTheory/trees.v
@@ -43,7 +43,7 @@ Let is_omega_cocont_treeFunctor : is_omega_cocont treeFunctor := pr2 treeOmegaFu
 Lemma treeFunctor_Initial :
   Initial (precategory_FunctorAlg treeFunctor has_homsets_HSET).
 Proof.
-apply (colimAlgInitial _ _ InitialHSET _ is_omega_cocont_treeFunctor (ColimCoconeHSET _ _)).
+apply (colimAlgInitial _ InitialHSET is_omega_cocont_treeFunctor (ColimCoconeHSET _ _)).
 Defined.
 
 Definition Tree : HSET :=

--- a/UniMath/SubstitutionSystems/BinProductOfSignatures.v
+++ b/UniMath/SubstitutionSystems/BinProductOfSignatures.v
@@ -276,7 +276,7 @@ Defined.
 
 Lemma is_omega_cocont_BinProduct_of_Signatures (S1 S2 : Signature C hsC)
   (h1 : is_omega_cocont S1) (h2 : is_omega_cocont S2)
-  (hE : has_exponentials (BinProducts_functor_precat C C PC hsC)) :
+  (hE : Π x, is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C PC hsC) x)) :
   is_omega_cocont (BinProduct_of_Signatures S1 S2).
 Proof.
 destruct S1 as [F1 [F2 [F3 F4]]]; simpl in *.

--- a/UniMath/SubstitutionSystems/FromSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromSigsToMonads_Summary.v
@@ -63,7 +63,7 @@ Lemma is_omega_cocont_pre_composition_functor
      (hsA : has_homsets A),
    Lims A → is_omega_cocont (pre_composition_functor M C A hsC hsA K).
 Proof.
-  exact CocontFunctors.is_omega_cocont_pre_composition_functor.
+  exact @CocontFunctors.is_omega_cocont_pre_composition_functor.
 Defined.
 
 Definition RightKanExtension_from_limits
@@ -71,7 +71,7 @@ Definition RightKanExtension_from_limits
     (hsA : has_homsets A),
   Lims A → RightKanExtension.GlobalRightKanExtensionExists M C K A hsC hsA.
 Proof.
-  exact CocontFunctors.RightKanExtension_from_limits.
+  exact @CocontFunctors.RightKanExtension_from_limits.
 Defined.
 
 Definition ColimCoconeHSET
@@ -85,7 +85,7 @@ Lemma is_omega_cocont_binproduct_functor
     (Π x : C, is_omega_cocont (constprod_functor1 PC x)) →
     is_omega_cocont (binproduct_functor PC).
 Proof.
-  exact CocontFunctors.is_omega_cocont_binproduct_functor.
+  exact @CocontFunctors.is_omega_cocont_binproduct_functor.
 Defined.
 
 Lemma left_adjoint_cocont

--- a/UniMath/SubstitutionSystems/FromSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromSigsToMonads_Summary.v
@@ -83,7 +83,6 @@ Defined.
 Lemma is_omega_cocont_binproduct_functor
   : Π (C : precategory) (PC : BinProducts C), has_homsets C →
     (Π x : C, is_omega_cocont (constprod_functor1 PC x)) →
-    (Π x : C, is_omega_cocont (constprod_functor2 PC x)) →
     is_omega_cocont (binproduct_functor PC).
 Proof.
   exact CocontFunctors.is_omega_cocont_binproduct_functor.

--- a/UniMath/SubstitutionSystems/FromSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromSigsToMonads_Summary.v
@@ -52,9 +52,9 @@ Lemma colim_of_chain_is_initial_alg
       (F : functor C C) (HF : is_omega_cocont F)
       (CC : ColimCocone (initChain InitC F)),
     isInitial (FunctorAlg F hsC)
-              (algebra_ob_pair (colim CC) (colim_algebra_mor C InitC F HF CC)).
+              (algebra_ob_pair (colim CC) (colim_algebra_mor InitC HF CC)).
 Proof.
-  exact CocontFunctors.colimAlgIsInitial.
+  exact @CocontFunctors.colimAlgIsInitial.
 Defined.
 
 

--- a/UniMath/SubstitutionSystems/LamHSET.v
+++ b/UniMath/SubstitutionSystems/LamHSET.v
@@ -58,7 +58,9 @@ use colimAlgInitial.
   + apply functor_category_has_homsets.
   + apply is_omega_cocont_constant_functor; apply functor_category_has_homsets.
   + apply is_omega_cocont_Lam.
-    * apply (has_exponentials_functor_HSET _ has_homsets_HSET).
+    * apply is_omega_cocont_constprod_functor1.
+      apply functor_category_has_homsets.
+      apply (has_exponentials_functor_HSET _ has_homsets_HSET).
     * apply cats_LimsHSET.
 - apply ColimsFunctorCategory; apply ColimsHSET.
 Defined.

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -170,7 +170,7 @@ Definition Abs_H : functor [C, C, hs] [C, C, hs] :=
 Lemma is_omega_cocont_Abs_H (LC : Lims C) : is_omega_cocont Abs_H.
 Proof.
 unfold Abs_H.
-apply (is_omega_cocont_pre_composition_functor _ _ _ _ _ _ LC).
+apply (is_omega_cocont_pre_composition_functor _ _ _ LC).
 Defined.
 
 

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -85,13 +85,13 @@ Proof.
   exact CP.
 Defined.
 
-Lemma is_omega_cocont_App_H (hE : has_exponentials (BinProducts_functor_precat C C CP hs)) :
+Lemma is_omega_cocont_App_H
+  (hE : Π x, is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C CP hs) x)) :
   is_omega_cocont App_H.
 Proof.
 unfold App_H, square_functor.
-apply is_omega_cocont_BinProduct_of_functors.
+apply is_omega_cocont_BinProduct_of_functors; try assumption.
 - apply (BinProducts_functor_precat _ _ CP).
-- apply hE.
 - apply functor_category_has_homsets.
 - apply functor_category_has_homsets.
 - apply (is_omega_cocont_functor_identity (functor_category_has_homsets _ _ hs)).
@@ -669,8 +669,9 @@ Defined.
 Definition Lam_Sig: Signature C hs :=
   BinSum_of_Signatures C hs CC App_Sig Abs_Sig.
 
-Lemma is_omega_cocont_Lam (hE : has_exponentials (BinProducts_functor_precat C C CP hs)) (LC : Lims C) :
-  is_omega_cocont (Signature_Functor _ _ Lam_Sig).
+Lemma is_omega_cocont_Lam
+  (hE : Π x, is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C CP hs) x))
+  (LC : Lims C) : is_omega_cocont (Signature_Functor _ _ Lam_Sig).
 Proof.
 apply is_omega_cocont_BinCoproduct_of_functors.
 - apply (BinProducts_functor_precat _ _ CP).

--- a/UniMath/SubstitutionSystems/SigToMonad.v
+++ b/UniMath/SubstitutionSystems/SigToMonad.v
@@ -131,6 +131,8 @@ destruct n.
     apply is_omega_cocont_BinProduct_of_Signatures.
     apply is_omega_cocont_precomp_option_iter.
     apply IH.
+    apply is_omega_cocont_constprod_functor1.
+    apply has_homsets_HSET2.
     apply has_exponentials_HSET2.
 Defined.
 

--- a/UniMath/SubstitutionSystems/SigToMonad.v
+++ b/UniMath/SubstitutionSystems/SigToMonad.v
@@ -91,7 +91,7 @@ Lemma is_omega_cocont_precomp_option_iter (n : nat) : is_omega_cocont (precomp_o
 Proof.
 destruct n; simpl.
 - apply (is_omega_cocont_functor_identity has_homsets_HSET2).
-- apply (is_omega_cocont_pre_composition_functor _ _ _ (iter_functor1 _ optionHSET n) _ _ cats_LimsHSET).
+- apply (is_omega_cocont_pre_composition_functor (iter_functor1 _ optionHSET n) _ _ cats_LimsHSET).
 Defined.
 
 Definition precomp_option_iter_Signature (n : nat) : Signature HSET has_homsets_HSET.


### PR DESCRIPTION
This PR contains some new theory about (co)limits and more cleaning:

* Given two isomorphic functor F and G, if F preserves colimits then G also does. This is then used to drop one of the hypotheses for `is_omega_cocont_binproduct_functor`.
* Generalize assumption for the proofs about `binproduct_pair_functor` and `pair_functor` so that they hold for arbitrary diagrams and not just for chains (this makes it possible to prove that these functors are cocontinuous and not just only omega-cocontinuous).  
* A proof that `isaprop Colims` (and the same for both versions of limits) for univalent/saturated categories. 
* More cleaning (more implicit arguments, use tactics like `use`, `mkpair`...)