### PR TITLE
Explicit induction variables

### DIFF
--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -143,7 +143,7 @@ Definition mapchain {C D : precategory} (F : functor C D)
 Definition chain_mor {C : precategory} (c : chain C) {i j} :
   i < j -> C⟦dob c i, dob c j⟧.
 Proof.
-induction j.
+induction j as [|j IHj].
 - intros Hi0.
   destruct (negnatlthn0 0 Hi0).
 - intros Hij.
@@ -156,7 +156,7 @@ Lemma chain_mor_coconeIn {C : precategory} (c : chain C) (x : C)
   (cc : cocone c x) i : Π j (Hij : i < j),
   chain_mor c Hij ;; coconeIn cc j = coconeIn cc i.
 Proof.
-induction j.
+induction j as [|j IHj].
 - intros Hi0.
   destruct (negnatlthn0 _ Hi0).
 - intros Hij; simpl.
@@ -172,7 +172,7 @@ used for any two proofs making it easier to apply. *)
 Lemma chain_mor_right {C : precategory} {c : chain C} {i j} (Hij : i < j) (HSij : S i < j) :
   dmor c (idpath (S i)) ;; chain_mor c HSij = chain_mor c Hij.
 Proof.
-induction j.
+induction j as [|j IHj].
 - destruct (negnatlthn0 _ Hij).
 - simpl.
   destruct (natlehchoice4 _ _ Hij).
@@ -610,7 +610,7 @@ intros c L ccL HccL y ccy.
 mkpair.
 - apply (tpair _ (coconeIn ccy 0)).
   abstract (intro n; rewrite id_left; destruct ccy as [f Hf]; simpl;
-            now induction n; [apply idpath|]; rewrite IHn, <- (Hf n (S n) (idpath _)), id_left).
+            now induction n as [|n IHn]; [apply idpath|]; rewrite IHn, <- (Hf n (S n) (idpath _)), id_left).
 - abstract (intro p; apply subtypeEquality;
               [ intros f; apply impred; intro; apply hsD
               | now simpl; destruct p as [p H]; rewrite <- (H 0), id_left]).

--- a/UniMath/CategoryTheory/category_abgr.v
+++ b/UniMath/CategoryTheory/category_abgr.v
@@ -1215,7 +1215,7 @@ Section ABGR_monics.
       in ABGR. *)
   Definition ABGR_natset_map {A : abgr} (a : A) : natset -> A.
   Proof.
-    intros n. induction n.
+    intros n. induction n as [|n IHn].
     - apply (unel A).
     - apply (@op A a IHn).
   Defined.
@@ -1229,7 +1229,7 @@ Section ABGR_monics.
   Definition ABGR_natset_map_S {A : abgr} (a : A) (n : nat) :
     ABGR_natset_map a (S n) = (ABGR_natset_map a n * a)%multmonoid.
   Proof.
-    induction n.
+    induction n as [|n IHn].
     - cbn. rewrite (lunax A). apply (runax A).
     - cbn. rewrite (assocax A). apply lopeq. apply (commax A).
   Qed.
@@ -1237,7 +1237,7 @@ Section ABGR_monics.
   Definition ABGR_natset_map_plus {A : abgr} (a : A) (n m : nat) :
     ABGR_natset_map a (n + m) = (ABGR_natset_map a n * ABGR_natset_map a m)%multmonoid.
   Proof.
-    induction n.
+    induction n as [|n IHn].
     - rewrite (lunax A). apply idpath.
     - cbn. rewrite (assocax A). apply lopeq.
       unfold ABGR_natset_map in *. cbn in IHn.
@@ -1304,7 +1304,7 @@ Section ABGR_monics.
   Definition ABGR_natset_dirprod_map_ind {A : abgr} (a : A) (n m : nat) :
     ABGR_natset_dirprod_map a (n + m,,m) = ABGR_natset_dirprod_map a (n,, 0).
   Proof.
-    induction m.
+    induction m as [|m IHm].
     - rewrite natpluscomm. cbn. apply idpath.
     - rewrite natplusnsm. cbn.
       unfold ABGR_natset_dirprod_map. cbn.
@@ -1329,8 +1329,8 @@ Section ABGR_monics.
   Definition ABGR_integer_map_iscomprelfun {A : abgr} (a : A) :
     iscomprelfun (binopeqrelabgrfrac (rigaddabmonoid natcommrig)) (ABGR_natset_dirprod_map a).
   Proof.
-    intros x. induction x as [t p]. induction p.
-    - intros x'. induction x' as [t0 p]. induction p.
+    intros x. induction x as [t p]. induction p as [|p IHp].
+    - intros x'. induction x' as [t0 p]. induction p as [|p IHp].
       + intros H. cbn in *. use (squash_to_prop H). apply (setproperty A).
         intros H'. induction H' as [t1 p]. repeat rewrite natplusassoc in p. cbn in p.
         apply natplusrcan in p. rewrite p. apply idpath.
@@ -1338,7 +1338,7 @@ Section ABGR_monics.
         intros H'. induction H' as [t1 p0]. rewrite (natplusassoc _ 0) in p0. cbn in p0.
         apply natplusrcan in p0. rewrite <- p0.
         rewrite ABGR_natset_dirprod_map_ind. apply idpath.
-    - intros x'. induction x' as [t0 p0]. induction p0.
+    - intros x'. induction x' as [t0 p0]. induction p0 as [|p0 IHp0].
       + intros H. cbn in *. use (squash_to_prop H). apply (setproperty A).
         intros H'. induction H' as [t1 p0]. rewrite natplusassoc in p0. cbn in p0.
         apply natplusrcan in p0. rewrite p0.
@@ -1444,8 +1444,8 @@ Section ABGR_monics.
   Proof.
     use total2_paths.
     - cbn. unfold funcomp. apply funextfun.
-      intros x. induction x as [t p]. induction t.
-      + induction p.
+      intros x. induction x as [t p]. induction t as [|t IHt].
+      + induction p as [|p IHp].
         (* p = 0 *)
         * unfold ABGR_natset_dirprod_map. cbn.
           rewrite (runax A). apply idpath.

--- a/UniMath/CategoryTheory/limits/FinOrdCoproducts.v
+++ b/UniMath/CategoryTheory/limits/FinOrdCoproducts.v
@@ -77,7 +77,7 @@ Section FinOrdCoproduct_criteria.
   Theorem FinOrdCoproducts_from_Initial_and_BinCoproducts :
     Initial C -> BinCoproducts C -> FinOrdCoproducts C.
   Proof.
-    intros I BinCoprods. unfold FinOrdCoproducts. intros n. induction n.
+    intros I BinCoprods. unfold FinOrdCoproducts. intros n. induction n as [|n IHn].
 
     (* Case n = 0 *)
     apply (InitialToCoproduct I).

--- a/UniMath/CategoryTheory/limits/FinOrdProducts.v
+++ b/UniMath/CategoryTheory/limits/FinOrdProducts.v
@@ -78,7 +78,7 @@ Section FinOrdProduct_criteria.
   Theorem FinOrdProducts_from_Terminal_and_BinProducts :
     Terminal C -> BinProducts C -> FinOrdProducts C.
   Proof.
-    intros T BinProds. unfold FinOrdProducts. intros n. induction n.
+    intros T BinProds. unfold FinOrdProducts. intros n. induction n as [|n IHn].
 
     (* Case n = 0 *)
     apply (TerminalToProduct T).

--- a/UniMath/CategoryTheory/lists.v
+++ b/UniMath/CategoryTheory/lists.v
@@ -267,7 +267,7 @@ Lemma list_ind : Π (A : Type) (P : list A -> UU),
 Proof.
 intros A P Hnil Hcons xs.
 destruct xs as [n xs].
-induction n.
+induction n as [|n IHn].
 - destruct xs.
   apply Hnil.
 - destruct xs as [x xs].
@@ -308,7 +308,7 @@ Defined.
 Lemma isaset_list (A : HSET) : isaset (list (pr1 A)).
 Proof.
 apply isaset_total2; [apply isasetnat|].
-intro n; induction n; simpl; [apply isasetunit|].
+intro n; induction n as [|n IHn]; simpl; [apply isasetunit|].
 apply isaset_dirprod; [ apply setproperty | apply IHn ].
 Qed.
 
@@ -316,7 +316,7 @@ Definition to_List (A : HSET) : list (pr1 A) -> pr1 (List A).
 Proof.
 intros l.
 destruct l as [n l].
-induction n.
+induction n as [|n IHn].
 + exact (nil A).
 + apply (cons _ (pr1 l,,IHn (pr2 l))).
 Defined.
@@ -332,7 +332,7 @@ Defined.
 Lemma to_listK (A : HSET) : Π x : list (pr1 A), to_list A (to_List A x) = x.
 Proof.
 intro l; destruct l as [n l]; unfold to_list, to_List.
-induction n; simpl.
+induction n as [|n IHn]; simpl.
 - rewrite foldr_nil.
   destruct l.
   apply idpath.
@@ -457,7 +457,7 @@ simple refine (tpair _ _ _).
     destruct cc as [f hf]; simpl in *; unfold BinCoproduct_of_functors_ob in *;
     simpl; intro n; unfold BinCoproduct_of_functors_mor in *;
     rewrite precompWithBinCoproductArrow; apply pathsinv0, BinCoproductArrowUnique;
-    [ rewrite id_left; induction n; [apply idpath|];
+    [ rewrite id_left; induction n as [|n IHn]; [apply idpath|];
       now rewrite <- IHn, <- (hf n _ (idpath _)), assoc,
                   BinCoproductOfArrowsIn1, id_left
     | rewrite <- (hf n _ (idpath _)); destruct ccL as [t p]; destruct t as [t p0]; simpl in *;

--- a/UniMath/Foundations/Algebra/Archimedean.v
+++ b/UniMath/Foundations/Algebra/Archimedean.v
@@ -50,7 +50,7 @@ Lemma nattorig_natmult :
     (nattorig n * x)%rig = natmult (X := rigaddabmonoid X) n x.
 Proof.
   intros.
-  induction n.
+  induction n as [|n IHn].
   - now apply rigmult0x.
   - rewrite nattorigS, natmultS.
     now rewrite rigrdistr, IHn, riglunax2.
@@ -59,7 +59,7 @@ Lemma natmult_plus :
   Π {X : monoid} (n m : nat) (x : X),
     natmult (n + m) x = (natmult n x + natmult m x)%addmonoid.
 Proof.
-  induction n ; intros m x.
+  induction n as [|n IHn] ; intros m x.
   - rewrite plus_O_n, lunax.
     reflexivity.
   - rewrite plus_Sn_m, !natmultS, IHn, assocax.
@@ -77,7 +77,7 @@ Lemma natmult_mult :
   Π {X : monoid} (n m : nat) (x : X),
     natmult (n * m) x = (natmult n (natmult m x))%addmonoid.
 Proof.
-  induction n ; intros m x.
+  induction n as [|n IHn] ; intros m x.
   - reflexivity.
   - simpl (_ * _)%nat.
     assert (S n = (n + 1)%nat).
@@ -103,13 +103,13 @@ Lemma natmult_op {X : monoid} :
     -> natmult n (x + y)%addmonoid = (natmult n x + natmult n y)%addmonoid.
 Proof.
   intros.
-  induction n.
+  induction n as [|n IHn].
   - rewrite lunax.
     reflexivity.
   - rewrite natmultS, assocax, IHn, <- (assocax _ y).
     assert (y + natmult n x = natmult n x + y)%addmonoid.
     { clear IHn.
-      induction n.
+      induction n as [|n IHn].
       - rewrite lunax, runax.
         reflexivity.
       - rewrite !natmultS, <- assocax, <- X0, !assocax, IHn.
@@ -123,7 +123,7 @@ Lemma natmult_binophrel {X : monoid} (R : hrel X) :
   Π (n : nat) (x y : X), R x y -> R (natmult (S n) x) (natmult (S n) y).
 Proof.
   intros X R Hr Hop n x y H.
-  induction n.
+  induction n as [|n IHn].
   exact H.
   rewrite !(natmultS (S _)).
   eapply Hr.
@@ -275,7 +275,7 @@ Proof.
   intros.
   assert (H0 : Π n y, natmult (X := abgrfrac X) n (setquotpr (binopeqrelabgrfrac X) y) = setquotpr (binopeqrelabgrfrac X) (natmult n (pr1 y) ,, natmult n (pr2 y))).
   { intros n y.
-    induction n.
+    induction n as [|n IHn].
     reflexivity.
     rewrite !natmultS, IHn.
     reflexivity. }
@@ -635,7 +635,7 @@ Proof.
     (binopeqrelabgrfrac (rigaddabmonoid X)) (nattorig n * pr1 x ,,
     nattorig n * pr2 x))%rng).
     { clear.
-      induction n.
+      induction n as [|n IHn].
       - rewrite !rigmult0x, rngmult0x.
         reflexivity.
       - unfold nattorng.
@@ -671,7 +671,7 @@ Proof.
     (binopeqrelabgrfrac (rigaddabmonoid X)) (nattorig (n1 + n2) ,,
     0%rig)).
     { generalize (n1 + n2) ; clear.
-      induction n.
+      induction n as [|n IHn].
       - reflexivity.
       - unfold nattorng ; rewrite !nattorigS.
         rewrite <- (riglunax1 _ 0%rig).
@@ -706,7 +706,7 @@ Lemma natmult_commrngfrac {X : commrng} {S : subabmonoids} :
   Π n (x : X × S), natmult (X := commrngfrac X S) n (setquotpr (eqrelcommrngfrac X S) x) = setquotpr (eqrelcommrngfrac X S) (natmult (X := X) n (pr1 x) ,, (pr2 x)).
 Proof.
   simpl ; intros X S n x.
-  induction n.
+  induction n as [|n IHn].
   - apply (iscompsetquotpr (eqrelcommrngfrac X S)).
     apply hinhpr ; simpl.
     exists (pr2 x).
@@ -869,7 +869,7 @@ Proof.
     intros n x.
     unfold nattorng.
     rewrite (nattorig_natmult (X := fldfrac X is)), (nattorig_natmult (X := commrngfrac X (@rngpossubmonoid X R is1 is2))).
-    induction n.
+    induction n as [|n IHn].
     - refine (pr2 (pr1 (isrngfunweqfldfracgt_f _ _ _ _ _ _ _))).
       exact irr.
     - rewrite !natmultS, <- IHn.

--- a/UniMath/Foundations/NumberSystems/NaturalNumbers.v
+++ b/UniMath/Foundations/NumberSystems/NaturalNumbers.v
@@ -1228,7 +1228,7 @@ where "n - m" := (minus n m) : nat_scope.
 
 Definition minuseq0 (n m : nat) (is : n <= m) : n - m = 0.
 Proof.
-  intros n m. generalize n. clear n. induction m.
+  intros n m. generalize n. clear n. induction m as [|m IHm].
   - intros n is. rewrite (natleh0tois0 is). simpl. apply idpath.
   - intro n. destruct n.
     + intro. apply idpath.
@@ -2391,7 +2391,7 @@ Defined.
 
 Lemma natlehtole (n m : nat) : n ≤ m ->  le n m.
 Proof.
-  intros n m H. induction m.
+  intros n m H. induction m as [|m IHm].
   - assert (int := natleh0tois0 H). clear H. destruct int. apply le_n.
   - set (int2 := natlehchoice2 n (S m) H).
     destruct int2 as [ isnatleh | iseq ].

--- a/UniMath/Ktheory/AbelianMonoid.v
+++ b/UniMath/Ktheory/AbelianMonoid.v
@@ -649,18 +649,18 @@ Definition NN := Free.make unit.
 Module NN_agreement.
   Import Presentation.
   Definition mult {X:abmonoid} (n:nat) (x:X) : X.
-    intros. induction n. exact (unel _). exact (x + IHn). Defined.
+    intros. induction n as [|n IHn]. exact (unel _). exact (x + IHn). Defined.
   Local Notation "n * x" := ( mult n x ).
   Lemma mult_one (n:nat) : n * (1 : nataddabmonoid) = n.
-  Proof. intro. induction n. { reflexivity. } { exact (ap S IHn). } Qed.
+  Proof. intro. induction n as [|n IHn]. { reflexivity. } { exact (ap S IHn). } Qed.
   Lemma mult_fun {X Y:abmonoid} (f:Hom X Y) (n:nat) (x:X) : f(n*x) = n*f x.
-  Proof. intros. induction n. { exact (Monoid.unitproperty f). }
+  Proof. intros. induction n as [|n IHn]. { exact (Monoid.unitproperty f). }
          { simple refine (Monoid.multproperty f x (n*x) @ _).
            { simpl. simpl in IHn. induction IHn. reflexivity. } } Qed.
   Lemma uniq_fun {X:abmonoid} (f g:Hom nataddabmonoid X) :
     f 1 = g 1 -> homot f g.
   Proof. intros ? ? ? e n.
-         induction n.
+         induction n as [|n IHn].
          { exact (Monoid.unitproperty f @ !Monoid.unitproperty g). }
          { exact (Monoid.multproperty f 1 n
                 @ aptwice (fun x y => x+y) e IHn

--- a/UniMath/Ktheory/Halfline.v
+++ b/UniMath/Ktheory/Halfline.v
@@ -27,13 +27,13 @@ Definition halfline := ∥ ℕ ∥.
 
 Definition makeNullHomotopy {Y} {f:ℕ->Y} (s:target_paths f) {y:Y} (h0:y=f 0) :
   nullHomotopyFrom f y.
-Proof. intros. intro n. induction n. { exact (h0). } { exact (IHn @ s _). } Defined.
+Proof. intros. intro n. induction n as [|n IHn]. { exact (h0). } { exact (IHn @ s _). } Defined.
 
 Definition map {Y} {f:ℕ->Y} (s:target_paths f) :
   halfline -> GuidedHomotopy f s.
 Proof. intros ? ? ? r. apply (squash_to_prop r).
        { apply isapropifcontr. apply iscontrGuidedHomotopy. }
-       { intro n. exists (f n). induction n.
+       { intro n. exists (f n). induction n as [|n IHn].
          { exists (makeNullHomotopy s (idpath _)). intro n. reflexivity. }
          { exact (transportf (gHomotopy f s) (s n) IHn). } } Defined.
 

--- a/UniMath/Ktheory/MetricTree.v
+++ b/UniMath/Ktheory/MetricTree.v
@@ -61,7 +61,7 @@ Require Import UniMath.Ktheory.Nat.
 
 Definition nat_tree : Tree.
 Proof. refine (make nat nat_dist _ _ _ _ _).
-       { intro m. induction m. { reflexivity. } { rewrite nat_dist_S. assumption. } }
+       { intro m. induction m as [|m IHm]. { reflexivity. } { rewrite nat_dist_S. assumption. } }
        { apply nat_dist_anti. } { apply nat_dist_symm. }
        { apply nat_dist_trans. }
        { intros m n e. assert (d := natneqchoice _ _ (neg_to_negProp e)). clear e.
@@ -70,7 +70,7 @@ Proof. refine (make nat nat_dist _ _ _ _ _).
            { split.
              { apply nat_dist_gt. exact h. }
              { destruct (natgthorleh (S n) n) as [_|j].
-               { clear h. induction n. { reflexivity. } { apply IHn. } }
+               { clear h. induction n as [|n IHn]. { reflexivity. } { apply IHn. } }
                { apply fromempty. clear h. contradicts j (negnatSleh n). }}} }
          { exists (n - 1).
            { split.

--- a/UniMath/Ktheory/Nat.v
+++ b/UniMath/Ktheory/Nat.v
@@ -21,9 +21,9 @@ Module Uniqueness.
   Proof. intros. simple refine (_,,gradth _ _ _ _).
          { intros h. split.
            { exact (h 0). } { intros. exact (h (S n) @ ap (IH n) (! h n)). } }
-         { intros [h0 h'] ?. induction n as [|n'].
+         { intros [h0 h'] ?. induction n as [|n' IHn'].
            { exact h0. } { exact (h' n' @ ap (IH n') IHn'). } }
-         { simpl. intros h. apply funextsec; intros n; simpl. induction n.
+         { simpl. intros h. apply funextsec; intros n; simpl. induction n as [|n IHn].
            { simpl. reflexivity. }
            { simpl. rewrite <- path_assoc. simple refine (_ @ pathscomp0rid _).
              rewrite <- maponpathscomp0. rewrite IHn. rewrite pathsinv0l.
@@ -98,21 +98,21 @@ Module Discern.
   Defined.
 
   Lemma nat_discern_isaprop m n : isaprop (nat_discern m n).
-  Proof. intros m. induction m.
-         { intros n. induction n.
+  Proof. intros m. induction m as [|m IHm].
+         { intros n. induction n as [|n IHn].
            { apply isapropifcontr. apply iscontrunit. }
            { simpl. apply isapropempty. } }
-         { intros n. induction n.
+         { intros n. induction n as [|n IHn].
            { simpl. apply isapropempty. }
            { simpl. apply IHm. } } Defined.
 
   Lemma nat_discern_unit m : nat_discern m m = unit.
-  Proof. intros m. induction m. { reflexivity. } { simpl. apply IHm. } Defined.
+  Proof. intros m. induction m as [|m IHm]. { reflexivity. } { simpl. apply IHm. } Defined.
 
   Lemma nat_discern_iscontr m : iscontr (nat_discern m m).
   Proof. intros m. apply iscontr_if_inhab_prop.
          { apply nat_discern_isaprop. }
-         { induction m. { exact tt. } { simpl. exact IHm. } } Defined.
+         { induction m as [|m IHm]. { exact tt. } { simpl. exact IHm. } } Defined.
 
   Fixpoint helper_A m n : nat_dist m n = 0 -> nat_discern m n.
   Proof. intros ? ?. destruct m as [|m'].
@@ -148,7 +148,7 @@ Module Discern.
   Proof. intros. simple refine (gradth _ (helper_C _ _) _ _).
          { intro e. assert(p := ! helper_B _ _ e). destruct p.
            apply proofirrelevancecontr. apply nat_discern_iscontr. }
-         { intro e. destruct e. induction m.
+         { intro e. destruct e. induction m as [|m IHm].
            { reflexivity. }
            { exact (  ap (helper_B (S m) (S m)) (! apSC _ _ (idpath m))
                     @ ap (ap S) IHm). } } Defined.
@@ -324,10 +324,10 @@ Proof. intros ? ? i. apply negnatgthtoleh. intro k.
 Defined.
 
 Lemma minusxx m : m - m = 0.
-Proof. intro. induction m. reflexivity. simpl. assumption. Defined.
+Proof. intro. induction m as [|m IHm]. reflexivity. simpl. assumption. Defined.
 
 Lemma minusSxx m : S m - m = 1.
-Proof. intro. induction m. reflexivity. assumption. Defined.
+Proof. intro. induction m as [|m IHm]. reflexivity. assumption. Defined.
 
 Lemma natminusminus n m : m ≤ n -> n - (n - m) = m.
 Proof. intros ? ? i. assert (b := plusminusnmm m (n-m)).

--- a/UniMath/RealNumbers/NonnegativeRationals.v
+++ b/UniMath/RealNumbers/NonnegativeRationals.v
@@ -1613,7 +1613,7 @@ Proof.
   apply isarchfld_isarchrng in H.
   apply isarchrng_isarchrig in H.
   assert (Π n, pr1 (nattorig (X := pr1 (CommDivRig_DivRig NonnegativeRationals)) n) = nattorig (X := pr1fld hq) n).
-  { induction n.
+  { induction n as [|n IHn].
     - reflexivity.
     - rewrite !nattorigS, <- IHn.
       reflexivity. }

--- a/UniMath/RealNumbers/NonnegativeReals.v
+++ b/UniMath/RealNumbers/NonnegativeReals.v
@@ -4684,7 +4684,7 @@ Qed.
 Lemma NonnegativeRationals_to_NonnegativeReals_nattorig :
   Π n : nat, NonnegativeRationals_to_NonnegativeReals (nattorig n) = nattorig n.
 Proof.
-  induction n.
+  induction n as [|n IHn].
   - reflexivity.
   - rewrite !nattorigS.
     rewrite NonnegativeRationals_to_NonnegativeReals_plus, IHn.

--- a/UniMath/RealNumbers/Prelim.v
+++ b/UniMath/RealNumbers/Prelim.v
@@ -177,7 +177,7 @@ Qed.
 Lemma nattorig_nattohz :
   Π n : nat, nattorig (X := hz) n = nattohz n.
 Proof.
-  induction n.
+  induction n as [|n IHn].
   - unfold nattorig, nattohz ; simpl.
     reflexivity.
   - rewrite nattorigS, IHn.
@@ -187,7 +187,7 @@ Qed.
 Lemma nattorig_nat :
   Π n : nat, nattorig (X := natcommrig) n = n.
 Proof.
-  induction n.
+  induction n as [|n IHn].
   reflexivity.
   rewrite nattorigS, IHn.
   reflexivity.

--- a/UniMath/SubstitutionSystems/SigToMonad.v
+++ b/UniMath/SubstitutionSystems/SigToMonad.v
@@ -119,7 +119,7 @@ Proof.
 destruct xs as [n xs].
 destruct n.
 - destruct xs; simpl; apply (is_omega_cocont_functor_identity has_homsets_HSET2).
-- induction n.
+- induction n as [|n IHn].
   + destruct xs as [m []]; simpl.
     apply is_omega_cocont_precomp_option_iter.
   + destruct xs as [m xs].
@@ -150,7 +150,7 @@ destruct s as [n xs].
 destruct n.
 - destruct xs.
   apply (is_omega_cocont_functor_identity has_homsets_HSET2).
-- induction n.
+- induction n as [|n IHn].
   + destruct xs as [xs []]; simpl.
     apply is_omega_cocont_Arity_to_Signature.
   + destruct xs as [m xs].

--- a/UniMath/SubstitutionSystems/SignatureExamples.v
+++ b/UniMath/SubstitutionSystems/SignatureExamples.v
@@ -384,7 +384,7 @@ Fixpoint iter_functor1 (n : nat) : functor C C := match n with
 
 Definition δ_iter_functor1 n : δ_source C hsC (iter_functor1 n) ⟶ δ_target C hsC (iter_functor1 n).
 Proof.
-induction n.
+induction n as [|n IHn].
 - apply δ.
 - apply δ_comp.
   + apply IHn.

--- a/UniMath/Tactics/Nat_Tactics.v
+++ b/UniMath/Tactics/Nat_Tactics.v
@@ -95,14 +95,14 @@ Definition minus0r : Π n, n - 0 = n :=
 
 Definition minusnn0 n : n - n = 0.
 Proof.
-  intro n. induction n; [exact (idpath 0) | exact IHn].
+  intro n. induction n as [|n IHn]; [exact (idpath 0) | exact IHn].
 Defined.
 
 (** minus0l and Lemma minussn1 n : (S n) - 1 change to n - 0 should be changed in tactics.*)
 
 Definition minusgeh n m : n >= (n - m).
 Proof.
-  intro n. induction n; intros. apply isreflnatgeh.
+  intro n. induction n as [|n IHn]; intros. apply isreflnatgeh.
   destruct m. rewrite minus0r. apply isreflnatgeh.
   apply (istransnatgeh _ n _). apply natgthtogeh. apply natgthsnn.
   apply IHn.


### PR DESCRIPTION
I located all the uses of "induction" without explicit names that
involve names starting with "IH" and made the names explicit.