### PR TITLE
Substitution operation for the lambda calculus

### DIFF
--- a/UniMath/CategoryTheory/Monads.v
+++ b/UniMath/CategoryTheory/Monads.v
@@ -193,10 +193,10 @@ Definition precategory_Monad (C : precategory) (hs : has_homsets C) : precategor
 
 End Monad_precategory.
 
-(** * Theory about monads *)
-Section monad_theory.
+(** * Definition and lemmas for bind *)
+Section bind.
 
-Context {C : precategory} (hsC : has_homsets C) {T : Monad C}.
+Context {C : precategory} {T : Monad C}.
 
 (** Definition of bind *)
 Definition bind {a b : C} (f : C⟦a,T b⟧) : C⟦T a,T b⟧ := # T f ;; μ T b.
@@ -227,10 +227,12 @@ rewrite !functor_comp, <- !assoc.
 now apply maponpaths, maponpaths, (!Monad_law3 c).
 Qed.
 
+End bind.
+
 (** * Substitution operation for monads *)
 Section MonadSubst.
 
-Context (TC : Terminal C) (BC : BinCoproducts C).
+Context {C : precategory} (T : Monad C) (TC : Terminal C) (BC : BinCoproducts C).
 
 Local Notation "1" := TC.
 Local Notation "a ⊕ b" := (BinCoproductObject _ (BC a b)) (at level 50).
@@ -239,5 +241,3 @@ Definition monadSubst (a : C) (e : C⟦1,T a⟧) : C⟦T (a ⊕ 1), T a⟧ :=
   bind (BinCoproductArrow _ _ (η T a) e).
 
 End MonadSubst.
-
-End monad_theory.

--- a/UniMath/CategoryTheory/Monads.v
+++ b/UniMath/CategoryTheory/Monads.v
@@ -1,24 +1,20 @@
 (** **********************************************************
 
-Benedikt Ahrens
-started March 2015
+Contents:
+
+        - Definition of monads ([Monad])
+        - Precategory of monads [precategory_Monad C] on [C]
+        - Haskell style bind operation ([bind])
+        - A substitution operator for monads ([monadSubst])
+
+TODO:
+        - Proof that [precategory_Monad C] is saturated if [C] is
 
 
-************************************************************)
-
-
-(** **********************************************************
-
-Contents :
-
-        - precategory of monads [precategory_Monad C] on [C]
-
-TODO :
-        - Proof that [precategory_Monad C] is
-          saturated if [C] is
+Written by: Benedikt Ahrens (started March 2015)
+Extended by: Anders Mörtberg, 2016
 
 ************************************************************)
-
 
 Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.Foundations.Basics.Propositions.
@@ -28,6 +24,8 @@ Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.limits.terminal.
+Require Import UniMath.CategoryTheory.limits.bincoproducts.
 
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 Local Notation "F ⟶ G" := (nat_trans F G) (at level 39).
@@ -35,6 +33,8 @@ Local Notation "G □ F" := (functor_composite F G) (at level 35).
 
 Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 
+(** * Definition of monads *)
+Section Monad_def.
 
 Definition functor_with_μ (C : precategory) : UU
   := Σ F : functor C C, F □ F ⟶ F.
@@ -53,8 +53,7 @@ Coercion functor_with_μ_from_Monad_data (C : precategory) (F : Monad_data C)
 Definition η {C : precategory} (F : Monad_data C)
   : functor_identity C ⟶ F := pr2 F.
 
-Definition Monad_laws {C : precategory} (T : Monad_data C) : UU
-  :=
+Definition Monad_laws {C : precategory} (T : Monad_data C) : UU :=
     (
       (Π c : C, η T (T c) ;; μ T c = identity (T c))
         ×
@@ -73,6 +72,25 @@ Definition Monad (C : precategory) : UU := Σ T : Monad_data C, Monad_laws T.
 
 Coercion Monad_data_from_Monad (C : precategory) (T : Monad C) : Monad_data C := pr1 T.
 
+Lemma Monad_law1 {C : precategory} {T : Monad C} : Π c : C, η T (T c) ;; μ T c = identity (T c).
+Proof.
+exact (pr1 (pr1 (pr2 T))).
+Qed.
+
+Lemma Monad_law2 {C : precategory} {T : Monad C} : Π c : C, #T (η T c) ;; μ T c = identity (T c).
+Proof.
+exact (pr2 (pr1 (pr2 T))).
+Qed.
+
+Lemma Monad_law3 {C : precategory} {T : Monad C} : Π c : C, #T (μ T c) ;; μ T c = μ T (T c) ;; μ T c.
+Proof.
+exact (pr2 (pr2 T)).
+Qed.
+
+End Monad_def.
+
+(** * Monad precategory *)
+Section Monad_precategory.
 
 Definition Monad_Mor_laws {C : precategory} {T T' : Monad_data C} (α : T ⟶ T')
   : UU :=
@@ -108,11 +126,9 @@ Qed.
 Lemma Monad_identity_laws {C : precategory} (T : Monad C)
   : Monad_Mor_laws (nat_trans_id T).
 Proof.
-  split; intros; simpl.
-  - rewrite id_left, id_right.
-    rewrite functor_id, id_left.
-    apply idpath.
- - apply id_right.
+  split; intros a; simpl.
+  - now rewrite id_left, id_right, functor_id, id_left.
+ - now apply id_right.
 Qed.
 
 Definition Monad_identity {C : precategory} (T : Monad C)
@@ -122,20 +138,16 @@ Lemma Monad_composition_laws {C : precategory} {T T' T'' : Monad C}
   (α : Monad_Mor T T') (α' : Monad_Mor T' T'') : Monad_Mor_laws (nat_trans_comp _ _ _ α α').
 Proof.
   split; intros; simpl.
-  - repeat rewrite assoc.
-    set (H:=Monad_Mor_μ α a). clearbody H.
-    simpl in *.
-    rewrite H; clear H.
-    repeat rewrite <- assoc.
-    set (H:=Monad_Mor_μ α' a). simpl in *.
+  - rewrite assoc.
+    set (H:=Monad_Mor_μ α a); simpl in H.
+    rewrite H; clear H; rewrite <- !assoc.
+    set (H:=Monad_Mor_μ α' a); simpl in H.
     rewrite H; clear H.
     rewrite functor_comp.
     apply maponpaths.
-    repeat rewrite assoc.
-    rewrite nat_trans_ax.
-    apply idpath.
+    now rewrite !assoc, nat_trans_ax.
   - rewrite assoc.
-    set (H := Monad_Mor_η α); simpl in *; rewrite H; clear H.
+    eapply pathscomp0; [apply cancel_postcomposition, Monad_Mor_η|].
     apply Monad_Mor_η.
 Qed.
 
@@ -147,8 +159,8 @@ Definition Monad_Mor_equiv {C : precategory} (hs : has_homsets C)
   {T T' : Monad C} (α β : Monad_Mor T T')
   : α = β ≃ (pr1 α = pr1 β).
 Proof.
-  apply subtypeInjectivity.
-  intro a. apply isaprop_Monad_Mor_laws, hs.
+  apply subtypeInjectivity; intro a.
+  apply isaprop_Monad_Mor_laws, hs.
 Defined.
 
 Definition precategory_Monad_ob_mor (C : precategory) : precategory_ob_mor.
@@ -178,3 +190,54 @@ Qed.
 
 Definition precategory_Monad (C : precategory) (hs : has_homsets C) : precategory
   := tpair _ _ (precategory_Monad_axioms C hs).
+
+End Monad_precategory.
+
+(** * Theory about monads *)
+Section monad_theory.
+
+Context {C : precategory} (hsC : has_homsets C) {T : Monad C}.
+
+(** Definition of bind *)
+Definition bind {a b : C} (f : C⟦a,T b⟧) : C⟦T a,T b⟧ := # T f ;; μ T b.
+
+Lemma η_bind {a b : C} (f : C⟦a,T b⟧) : η T a ;; bind f = f.
+Proof.
+unfold bind.
+rewrite assoc.
+eapply pathscomp0;
+  [apply cancel_postcomposition, (! (nat_trans_ax (η T) _ _ f))|]; simpl.
+rewrite <- assoc.
+eapply pathscomp0; [apply maponpaths, Monad_law1|].
+apply id_right.
+Qed.
+
+Lemma bind_η {a : C} : bind (η T a) = identity (T a).
+Proof.
+apply Monad_law2.
+Qed.
+
+Lemma bind_bind {a b c : C} (f : C⟦a,T b⟧) (g : C⟦b,T c⟧) :
+  bind f ;; bind g = bind (f ;; bind g).
+Proof.
+unfold bind; rewrite <- assoc.
+eapply pathscomp0; [apply maponpaths; rewrite assoc;
+                    apply cancel_postcomposition, (!nat_trans_ax (μ T) _ _ g)|].
+rewrite !functor_comp, <- !assoc.
+now apply maponpaths, maponpaths, (!Monad_law3 c).
+Qed.
+
+(** * Substitution operation for monads *)
+Section MonadSubst.
+
+Context (TC : Terminal C) (BC : BinCoproducts C).
+
+Local Notation "1" := TC.
+Local Notation "a ⊕ b" := (BinCoproductObject _ (BC a b)) (at level 50).
+
+Definition monadSubst (a : C) (e : C⟦1,T a⟧) : C⟦T (a ⊕ 1), T a⟧ :=
+  bind (BinCoproductArrow _ _ (η T a) e).
+
+End MonadSubst.
+
+End monad_theory.

--- a/UniMath/SubstitutionSystems/LamFromBindingSig.v
+++ b/UniMath/SubstitutionSystems/LamFromBindingSig.v
@@ -139,6 +139,18 @@ eapply pathscomp0; [eapply maponpaths, BinCoproductIn1Commutes|].
 apply id_left.
 Defined.
 
+(* Lemma foldr_var_pt X (fvar : HSET2⟦1,X⟧) (fapp : HSET2⟦X ⊗ X,X⟧) (flam : HSET2⟦X + 1,X⟧) (A : HSET) (x : pr1 A) : *)
+(*   pr1 (pr1 (foldr_map X fvar fapp flam)) A (pr1 var_map A x) = pr1 fvar A x. *)
+(* Proof. *)
+(* set (H := (toforallpaths _ _ _ (nat_trans_eq_pointwise (foldr_var X fvar fapp flam) A) x)). *)
+(* (* now rewrite foldr_var. *) *)
+(* (* Arguments foldr_map : simpl never. *) *)
+(* (* Arguments alg_carrier : simpl never. *) *)
+(* (* Arguments var_map : simpl never. *) *)
+(* cbn in *. *)
+(* apply H. *)
+(* Qed. *)
+
 Lemma foldr_app X (fvar : HSET2⟦1,X⟧) (fapp : HSET2⟦X ⊗ X,X⟧) (flam : HSET2⟦X + 1,X⟧) :
   app_map ;; foldr_map X fvar fapp flam =
   # (pr1 (Id * Id)) (foldr_map X fvar fapp flam) ;; fapp.


### PR DESCRIPTION
This PR adds:

- A "bind" operation for monads (as in Haskell)
- A substitution operation for monads and from this a substitution operation for the lambda calculus