### PR TITLE
Multisorted signatures to "signature functors"

### DIFF
--- a/UniMath/CategoryTheory/HorizontalComposition.v
+++ b/UniMath/CategoryTheory/HorizontalComposition.v
@@ -1,26 +1,12 @@
 (** **********************************************************
 
-Benedikt Ahrens, Ralph Matthes
+Contents:
 
-SubstitutionSystems
+- Definition of horizontal composition for natural transformations ([horcomp])
 
-2015
-
-
-************************************************************)
-
-
-(** **********************************************************
-
-Contents :
-
-- Definition of horizontal composition for natural transformations
-
-
+Written by: Benedikt Ahrens, Ralph Matthes (2015)
 
 ************************************************************)
-
-
 
 Require Import UniMath.Foundations.Basics.PartD.
 
@@ -50,44 +36,38 @@ Lemma is_nat_trans_horcomp : is_nat_trans (G □ F) (G' □ F')
   (λ c : C, β (F c) ;; #G' (α _ )).
 Proof.
   intros c d f; simpl.
-  rewrite assoc.
-  rewrite nat_trans_ax.
-  repeat rewrite <- assoc; apply maponpaths.
-  repeat rewrite <- functor_comp.
-  rewrite nat_trans_ax; apply idpath.
-Defined.
+  rewrite assoc, nat_trans_ax, <- !assoc; apply maponpaths.
+  now rewrite <- !functor_comp, nat_trans_ax.
+Qed.
 
-Definition hor_comp : nat_trans (G □ F) (G' □ F') := tpair _ _ is_nat_trans_horcomp.
+Definition horcomp : nat_trans (G □ F) (G' □ F') := tpair _ _ is_nat_trans_horcomp.
 
 End horizontal_composition.
 
-Arguments hor_comp { _ _ _ } { _ _ _ _ } _ _ .
+Arguments horcomp { _ _ _ } { _ _ _ _ } _ _ .
 
-(*
-Lemma horcomp_id_left (C D : precategory) (X : functor C C) (Z Z' : functor C D)(f : nat_trans Z Z')
-  :
-  hor_comp (nat_trans_id X) f = pre_whisker f.
-*)
-Lemma horcomp_id_left (C D : precategory) (X : functor C C) (Z Z' : functor C D)(f : nat_trans Z Z')
-  :
-  Π c : C, hor_comp (nat_trans_id X) f c = f (X c).
+Lemma horcomp_id_prewhisker {C D E : precategory} (hsE : has_homsets E)
+  (X : functor C D) (Z Z' : functor D E) (f : nat_trans Z Z') :
+  horcomp (nat_trans_id X) f = pre_whisker _ f.
 Proof.
-  simpl.
-  intro c.
-  rewrite functor_id.
-  rewrite id_right.
-  apply idpath.
+apply (nat_trans_eq hsE); simpl; intro x.
+now rewrite functor_id, id_right.
+Qed.
+
+Lemma horcomp_id_left (C D : precategory) (X : functor C C) (Z Z' : functor C D)(f : nat_trans Z Z')
+  :
+  Π c : C, horcomp (nat_trans_id X) f c = f (X c).
+Proof.
+  intro c; simpl.
+  now rewrite functor_id, id_right.
 Qed.
 
 Lemma horcomp_id_postwhisker (A B C : precategory)
    (hsB : has_homsets B) (hsC : has_homsets C) (X X' : [A, B, hsB]) (α : X --> X')
    (Z : [B ,C, hsC])
-  : hor_comp α (nat_trans_id _ ) = post_whisker α Z.
+  : horcomp α (nat_trans_id _ ) = post_whisker α Z.
 Proof.
-  apply nat_trans_eq.
-  - apply hsC.
-  - intro a.
-    apply id_left.
+  apply (nat_trans_eq hsC); intro a; apply id_left.
 Qed.
 
 Definition functorial_composition_data (A B C : precategory) (hsB: has_homsets B) (hsC: has_homsets C) :

--- a/UniMath/CategoryTheory/HorizontalComposition.v
+++ b/UniMath/CategoryTheory/HorizontalComposition.v
@@ -77,7 +77,7 @@ Proof.
   exists (fun FG => functor_composite (pr1 FG) (pr2 FG)).
   intros a b αβ.
   induction αβ as [α β].
-  exact (hor_comp α β).
+  exact (horcomp α β).
 Defined.
 
 Definition functorial_composition (A B C : precategory) (hsB: has_homsets B) (hsC: has_homsets C) :

--- a/UniMath/CategoryTheory/PointedFunctorsComposition.v
+++ b/UniMath/CategoryTheory/PointedFunctorsComposition.v
@@ -43,7 +43,7 @@ Variable hs : has_homsets C.
 Definition ptd_composite (Z Z' : ptd_obj C) : precategory_Ptd C hs.
 Proof.
   exists (functor_composite Z Z').
-  apply (hor_comp (ptd_pt _ Z) (ptd_pt _ Z')).
+  apply (horcomp (ptd_pt _ Z) (ptd_pt _ Z')).
 Defined.
 
 End def_ptd.

--- a/UniMath/CategoryTheory/functor_categories.v
+++ b/UniMath/CategoryTheory/functor_categories.v
@@ -1237,8 +1237,7 @@ Proof.
 Qed.
 
 
-Definition functorPrecategory (C : precategory) (D : Precategory)
-  : Precategory.
+Definition functor_Precategory (C : precategory) (D : Precategory) : Precategory.
 Proof.
   exists (functor_precategory C D (homset_property D)).
   apply functor_category_has_homsets.

--- a/UniMath/Foundations/Combinatorics/Lists.v
+++ b/UniMath/Foundations/Combinatorics/Lists.v
@@ -78,4 +78,34 @@ Section more_lists.
 Definition map {A B : UU} (f : A -> B) : list A -> list B :=
   foldr (λ a l, cons (f a) l) nil.
 
+(** Various unfolding lemmas *)
+Lemma foldr_cons {A B : UU} (f : A -> B -> B) (b : B) (x : A) (xs : list A) :
+  foldr f b (cons x xs) = f x (foldr f b xs).
+Proof.
+now destruct xs.
+Qed.
+
+Lemma map_nil {A B : UU} (f : A -> B) : map f nil = nil.
+Proof.
+apply idpath.
+Qed.
+
+Lemma map_cons {A B : UU} (f : A -> B) (x : A) (xs : list A) :
+  map f (cons x xs) = cons (f x) (map f xs).
+Proof.
+now destruct xs.
+Qed.
+
+Lemma foldr1_cons_nil {A : UU} (f : A -> A -> A) (a : A) (x : A) :
+  foldr1 f a (cons x nil) = x.
+Proof.
+apply idpath.
+Qed.
+
+Lemma foldr1_cons {A : UU} (f : A -> A -> A) (a : A) (x y : A) (xs : list A) :
+  foldr1 f a (cons x (cons y xs)) = f x (foldr1 f a (cons y xs)).
+Proof.
+apply idpath.
+Qed.
+
 End more_lists.

--- a/UniMath/Ktheory/Precategories.v
+++ b/UniMath/Ktheory/Precategories.v
@@ -59,7 +59,7 @@ Ltac set_logic :=
                 try apply impred_isaset;
                 try apply isasetaprop)) using _M_.
 
-Notation "[ C , D ]" := (functorPrecategory C D) : cat.
+Notation "[ C , D ]" := (functor_Precategory C D) : cat.
 
 Definition oppositePrecategory (C:Precategory) : Precategory.
 Proof.

--- a/UniMath/Ktheory/Test.v
+++ b/UniMath/Ktheory/Test.v
@@ -194,7 +194,7 @@ Section coproduct_functor.
 
 Variables F G : functor C D.
 
-Definition Coproducts_functor_precat : Coproducts (functorPrecategory C D).
+Definition Coproducts_functor_precat : Coproducts (functor_Precategory C D).
 Proof.
   apply functorBinarySum.
   exact HD.

--- a/UniMath/SubstitutionSystems/.package/files
+++ b/UniMath/SubstitutionSystems/.package/files
@@ -16,4 +16,4 @@ BindingSigToMonad.v
 LamFromBindingSig.v
 MLTT79.v
 FromBindingSigsToMonads_Summary.v
-
+MultiSorted.v

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -47,27 +47,11 @@ Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
 Local Notation "[ C , D ]" := (functor_Precategory C D).
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
-(* Lemma test4 (C1 C2 : precategory) (D1 D2 : Precategory) (F : functor [C1,D1] [C2,D2]) (G : [C1,D1]) : *)
-(*   adj_equivalence_of_precats F -> *)
-(*   is_omega_cocont G -> *)
-(*   is_omega_cocont (F G). *)
-(* Proof. *)
-(* intros α HG d L ccL HccL x ccx. *)
-(* unfold is_omega_cocont in HG. *)
-(* simpl in *. *)
-(* set (αinv := adj_equivalence_inv α). *)
-(* simpl in *. *)
-(* apply (test2 hsC hsD _ H _ _ _ _ HccL). *)
-(* Defined. *)
-
-
 (** Swapping of functor arguments *)
 (* TODO: Move upstream? *)
 Section functor_swap.
 
-Context {C D : precategory} {E : Precategory}.
-
-Lemma functor_swap : functor C [D,E] → functor D [C,E].
+Lemma functor_swap {C D : precategory} {E : Precategory} : functor C [D,E] → functor D [C,E].
 Proof.
 intros F.
 mkpair.
@@ -92,11 +76,8 @@ mkpair.
   | intros a b c f g; apply (nat_trans_eq (homset_property E)); intro x; simpl; apply functor_comp]).
 Defined.
 
-(* Lemma is_omega_cocont_functor_swap *)
-(*   (F : functor C [D,E]) (HF : forall c, is_omega_cocont (F c)) : *)
-(*    is_omega_cocont (functor_swap F). *)
-
-Lemma functor_cat_swap_nat_trans (F G : functor C [D, E]) (α : nat_trans F G) :
+Lemma functor_cat_swap_nat_trans {C D : precategory} {E : Precategory}
+  (F G : functor C [D, E]) (α : nat_trans F G) :
   nat_trans (functor_swap F) (functor_swap G).
 Proof.
 mkpair.
@@ -107,10 +88,12 @@ mkpair.
 + abstract (intros a b f; apply (nat_trans_eq (homset_property E)); intro c; simpl; apply nat_trans_ax).
 Defined.
 
-Lemma functor_cat_swap : functor [C, [D, E]] [D, [C, E]].
+Lemma functor_cat_swap (C D : precategory) (E : Precategory) : functor [C, [D, E]] [D, [C, E]].
 Proof.
 mkpair.
-- apply (tpair _ functor_swap functor_cat_swap_nat_trans).
+- mkpair.
+  + apply functor_swap.
+  + apply functor_cat_swap_nat_trans.
 - abstract (split;
   [ intro F; apply (nat_trans_eq (functor_category_has_homsets _ _ (homset_property E))); simpl; intro d;
     now apply (nat_trans_eq (homset_property E))
@@ -118,62 +101,37 @@ mkpair.
     now apply (nat_trans_eq (homset_property E))]).
 Defined.
 
-End functor_swap.
-
-Section temp.
-
-(* How should one even express this: *)
-(* Lemma is_omega_cocont_functor_cat_swap : is_omega_cocont functor_cat_swap. *)
-
-(* Lemma are_adjoints_constprod_functor2 A : *)
-(*   are_adjoints (constprod_functor2 BinProductsHSET A) (exponential_functor A). *)
-(* Proof. *)
-(* mkpair. *)
-(* - mkpair. *)
-(*   + mkpair. *)
-(*     * intro x; simpl; apply dirprodpair. *)
-(*     * abstract (intros x y f; apply idpath). *)
-(*   + mkpair. *)
-(*     * intros X fx; apply (pr1 fx (pr2 fx)). *)
-(*     * abstract (intros x y f; apply idpath). *)
-(* - abstract (mkpair; *)
-(*   [ intro x; simpl; apply funextfun; intro ax; now rewrite (paireta ax) *)
-(*   | intro b; apply funextfun; intro f; apply idpath]). *)
-(* Defined. *)
-
 Definition id_functor_cat_swap (C D : precategory) (E : Precategory) :
-  nat_trans (functor_identity [C, [D, E]])
-    (functor_composite (@functor_cat_swap C D E) (@functor_cat_swap D C E)).
+  nat_trans (functor_identity [C,[D,E]])
+            (functor_composite (functor_cat_swap C D E) (functor_cat_swap D C E)).
 Proof.
 set (hsE := homset_property E).
 mkpair.
-intros F.
-mkpair.
-* intro c.
-{ mkpair.
-- now intro f; apply identity.
-- abstract (now intros a b f; rewrite id_left, id_right).
-}
-* abstract (now intros a b f; apply (nat_trans_eq hsE); intro d; simpl; rewrite id_left, id_right).
-* abstract (now intros a b f; apply nat_trans_eq; [apply functor_category_has_homsets|]; intro c;
++ intros F.
+  mkpair.
+  - intro c.
+     mkpair.
+     * now intro f; apply identity.
+     * abstract (now intros a b f; rewrite id_left, id_right).
+  - abstract (now intros a b f; apply (nat_trans_eq hsE); intro d; simpl; rewrite id_left, id_right).
++ abstract (now intros a b f; apply nat_trans_eq; [apply functor_category_has_homsets|]; intro c;
             apply (nat_trans_eq hsE); intro d; simpl; rewrite id_left, id_right).
 Defined.
 
 Definition functor_cat_swap_id (C D : precategory) (E : Precategory) :
-  nat_trans (functor_composite (@functor_cat_swap D C E) (@functor_cat_swap C D E))
-      (functor_identity [D, [C, E]]).
+  nat_trans (functor_composite (functor_cat_swap D C E) (functor_cat_swap C D E))
+            (functor_identity [D,[C,E]]).
 Proof.
 set (hsE := homset_property E).
 mkpair.
-intros F.
-mkpair.
-* intro c.
-{ mkpair.
-- now intro f; apply identity.
-- abstract (now intros a b f; rewrite id_left, id_right).
-}
-* abstract (now intros a b f; apply (nat_trans_eq hsE); intro d; simpl; rewrite id_left, id_right).
-* abstract (now intros a b f; apply nat_trans_eq; [apply functor_category_has_homsets|]; intro c;
++ intros F.
+  mkpair.
+  - intro c.
+    mkpair.
+    * now intro f; apply identity.
+    * abstract (now intros a b f; rewrite id_left, id_right).
+  - abstract (now intros a b f; apply (nat_trans_eq hsE); intro d; simpl; rewrite id_left, id_right).
++ abstract (now intros a b f; apply nat_trans_eq; [apply functor_category_has_homsets|]; intro c;
             apply (nat_trans_eq hsE); intro d; simpl; rewrite id_left, id_right).
 Defined.
 
@@ -196,51 +154,36 @@ mkpair.
 Defined.
 
 Lemma is_cocont_functor_cat_swap (C D : precategory) (E : Precategory) :
-  is_cocont (@functor_cat_swap C D E).
+  is_cocont (functor_cat_swap C D E).
 Proof.
-apply left_adjoint_cocont.
+apply left_adjoint_cocont; try apply homset_property.
 mkpair.
-apply functor_cat_swap.
-apply are_adjoint_functor_cat_swap.
-apply functor_category_has_homsets.
-apply functor_category_has_homsets.
++ apply functor_cat_swap.
++ apply are_adjoint_functor_cat_swap.
 Defined.
 
-
 Lemma is_omega_cocont_functor_cat_swap (C D : precategory) (E : Precategory) :
-  is_omega_cocont (@functor_cat_swap C D E).
+  is_omega_cocont (functor_cat_swap C D E).
 Proof.
 intros d L ccL HccL.
 apply (is_cocont_functor_cat_swap _ _ _ _ d L ccL HccL).
 Defined.
 
-(* Lemma test (C D : precategory) (E : Precategory) : adj_equivalence_of_precats (@functor_cat_swap C D E). *)
+(* Maybe prove this as well? *)
+(* Lemma equiv_functor_cat_swap (C D : precategory) (E : Precategory) :  *)
+(*   adj_equivalence_of_precats (@functor_cat_swap C D E). *)
 (* Proof. *)
 (* mkpair. *)
 (* + exists functor_cat_swap. *)
 (*   apply are_adjoint_functor_cat_swap. *)
 (* + split. *)
-(* - admit. *)
-(* - admit. *)
+(*   - admit. *)
+(*   - admit. *)
 (* Admitted. *)
 
-(* Lemma test2 (C D : Precategory) (F : functor C D) : *)
-(*   adj_equivalence_of_precats F -> is_cocont F. *)
-(* Proof. *)
-(* intro H. *)
-(* apply left_adjoint_cocont; try apply homset_property. *)
-(* apply H. *)
-(* Defined. *)
-
-(* Lemma test3 (C D : Precategory) (F : functor C D) : *)
-(*   adj_equivalence_of_precats F -> is_omega_cocont F. *)
-(* Proof. *)
-(* intros H g L ccL HccL d ccd. *)
-(* apply (test2 C D _ H _ _ _ _ HccL). *)
-(* Defined. *)
+End functor_swap.
 
 
-End temp.
 
 (** * Discrete precategories *)
 Section DiscreteCategory.
@@ -312,7 +255,7 @@ Defined.
 Definition mk_sortToC (f : sort → C) : sortToC :=
   functor_discrete_precategory _ _ f.
 
-Definition proj_gen_fun {D : precategory} {E : Precategory} (d : D) : functor [D,E] E.
+Definition proj_gen_fun (D : precategory) (E : Precategory) (d : D) : functor [D,E] E.
 Proof.
 mkpair.
 + mkpair.
@@ -329,25 +272,18 @@ mkpair.
   - intros d1 d2 f.
     mkpair.
     * simpl; intro F; apply (# F f).
-    * intros F G α; simpl in *.
-      apply pathsinv0, (nat_trans_ax α d1 d2 f).
-+ split.
-  - intros F; simpl.
-    apply nat_trans_eq; [apply homset_property|]; intro G; simpl.
-    apply functor_id.
-  - intros F G H α β; simpl.
-    apply nat_trans_eq; [apply homset_property|]; intro γ; simpl.
-    apply functor_comp.
+    * abstract (intros F G α; simpl in *; apply pathsinv0, (nat_trans_ax α d1 d2 f)).
++ abstract (split;
+  [ intros F; simpl; apply nat_trans_eq; [apply homset_property|]; intro G; simpl; apply functor_id
+  | intros F G H α β; simpl; apply nat_trans_eq; [apply homset_property|];
+    intro γ; simpl; apply functor_comp ]).
 Defined.
 
 (** Given a sort s this applies the sortToC to s and returns C *)
 Definition projSortToC (s : sort) : functor sortToC C.
 Proof.
-mkpair.
-+ mkpair.
-  - intro f; apply (pr1 f s).
-  - simpl; intros a b f; apply (f s).
-+ abstract (split; [intro f; apply idpath|intros f g h fg gh; apply idpath]).
+apply proj_gen_fun.
+apply s.
 Defined.
 
 
@@ -474,14 +410,9 @@ destruct xs as [[|n] xs].
     * apply (IHn (k,,xs)).
 Defined.
 
-(* Lemma test1 (C' D E F : Precategory) : functor C' [D,[E,F]] -> functor C' [E,[D,F]]. *)
-(* Proof. *)
-(* assert (h1 : has_homsets [D, [E, F]]). *)
-(*   apply functor_category_has_homsets. *)
-(* assert (h2 : has_homsets [E, [D, F]]). *)
-(*   apply functor_category_has_homsets. *)
-(* apply (post_composition_functor C' [D,[E,F]] [E,[D,F]] h1 h2 functor_cat_swap). *)
-(* Defined. *)
+
+
+(* From here on things are not so nice: *)
 
 Local Definition MultiSortedSigToFunctor_helper1 (C1 D E1 : precategory) (E2 : Precategory)
   : functor [E1,[C1,[D,E2]]] [E1,[D,[C1,E2]]].
@@ -495,10 +426,12 @@ Defined.
 Local Definition MultiSortedSigToFunctor_helper (C1 D E1 : precategory) (E2 : Precategory) :
   functor [E1,[C1,[D,E2]]] [C1,[D,[E1,E2]]].
 Proof.
-eapply (functor_composite functor_cat_swap).
+eapply (functor_composite (functor_cat_swap _ _ _)).
 apply MultiSortedSigToFunctor_helper1.
- Defined.
-    (* functor_composite (functor_cat_swap F) functor_cat_swap. *)
+Defined.
+
+(* The above definition might be the same as: *)
+(* functor_composite (functor_cat_swap F) functor_cat_swap. *)
 
 (* Local Definition MultiSortedSigToFunctor_helper (C1 D E1 : precategory) (E2 : Precategory) *)
 (*   (F : functor E1 [C1,[D,E2]]) : functor C1 [D,[E1,E2]]. *)
@@ -542,8 +475,9 @@ Definition MultiSortedSigToFunctor (M : MultiSortedSig) (CC : Π s, Coproducts (
   functor [sortToC,sortToC] [sortToC,sortToC].
 Proof.
 (* First reorganize so that the last sort argument is first: *)
-apply (MultiSortedSigToFunctor_helper [sortToC,sortToC] sortToC sort_cat C).
-apply (MultiSortedSigToFunctor_fun M CC).
+set (F := MultiSortedSigToFunctor_helper [sortToC,sortToC] sortToC sort_cat C).
+set (x := MultiSortedSigToFunctor_fun M CC).
+apply (F x).
 Defined.
 
 Lemma is_omega_cocont_MultiSortedSigToFunctor (M : MultiSortedSig)
@@ -553,6 +487,7 @@ Lemma is_omega_cocont_MultiSortedSigToFunctor (M : MultiSortedSig)
   (H : Π x : [sortToC, C], is_omega_cocont (constprod_functor1 BinProductsSortToCToC x)) :
    is_omega_cocont (MultiSortedSigToFunctor M CC).
 Proof.
+unfold MultiSortedSigToFunctor.
 apply is_omega_cocont_MultiSortedSigToFunctor_helper.
 intros s; apply is_omega_cocont_MultiSortedSigToFunctor_fun.
 - apply PC.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -47,6 +47,20 @@ Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
 Local Notation "[ C , D ]" := (functor_Precategory C D).
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
+(* Lemma test4 (C1 C2 : precategory) (D1 D2 : Precategory) (F : functor [C1,D1] [C2,D2]) (G : [C1,D1]) : *)
+(*   adj_equivalence_of_precats F -> *)
+(*   is_omega_cocont G -> *)
+(*   is_omega_cocont (F G). *)
+(* Proof. *)
+(* intros α HG d L ccL HccL x ccx. *)
+(* unfold is_omega_cocont in HG. *)
+(* simpl in *. *)
+(* set (αinv := adj_equivalence_inv α). *)
+(* simpl in *. *)
+(* apply (test2 hsC hsD _ H _ _ _ _ HccL). *)
+(* Defined. *)
+
+
 (** Swapping of functor arguments *)
 (* TODO: Move upstream? *)
 Section functor_swap.
@@ -104,10 +118,110 @@ mkpair.
     now apply (nat_trans_eq (homset_property E))]).
 Defined.
 
+End functor_swap.
+
+Section temp.
+
 (* How should one even express this: *)
 (* Lemma is_omega_cocont_functor_cat_swap : is_omega_cocont functor_cat_swap. *)
 
-End functor_swap.
+(* Lemma are_adjoints_constprod_functor2 A : *)
+(*   are_adjoints (constprod_functor2 BinProductsHSET A) (exponential_functor A). *)
+(* Proof. *)
+(* mkpair. *)
+(* - mkpair. *)
+(*   + mkpair. *)
+(*     * intro x; simpl; apply dirprodpair. *)
+(*     * abstract (intros x y f; apply idpath). *)
+(*   + mkpair. *)
+(*     * intros X fx; apply (pr1 fx (pr2 fx)). *)
+(*     * abstract (intros x y f; apply idpath). *)
+(* - abstract (mkpair; *)
+(*   [ intro x; simpl; apply funextfun; intro ax; now rewrite (paireta ax) *)
+(*   | intro b; apply funextfun; intro f; apply idpath]). *)
+(* Defined. *)
+
+Definition id_functor_cat_swap (C D : precategory) (E : Precategory) :
+  nat_trans (functor_identity [C, [D, E]])
+    (functor_composite (@functor_cat_swap C D E) (@functor_cat_swap D C E)).
+Proof.
+set (hsE := homset_property E).
+mkpair.
+intros F.
+mkpair.
+* intro c.
+{ mkpair.
+- now intro f; apply identity.
+- abstract (now intros a b f; rewrite id_left, id_right).
+}
+* abstract (now intros a b f; apply (nat_trans_eq hsE); intro d; simpl; rewrite id_left, id_right).
+* abstract (now intros a b f; apply nat_trans_eq; [apply functor_category_has_homsets|]; intro c;
+            apply (nat_trans_eq hsE); intro d; simpl; rewrite id_left, id_right).
+Defined.
+
+Definition functor_cat_swap_id (C D : precategory) (E : Precategory) :
+  nat_trans (functor_composite (@functor_cat_swap D C E) (@functor_cat_swap C D E))
+      (functor_identity [D, [C, E]]).
+Proof.
+set (hsE := homset_property E).
+mkpair.
+intros F.
+mkpair.
+* intro c.
+{ mkpair.
+- now intro f; apply identity.
+- abstract (now intros a b f; rewrite id_left, id_right).
+}
+* abstract (now intros a b f; apply (nat_trans_eq hsE); intro d; simpl; rewrite id_left, id_right).
+* abstract (now intros a b f; apply nat_trans_eq; [apply functor_category_has_homsets|]; intro c;
+            apply (nat_trans_eq hsE); intro d; simpl; rewrite id_left, id_right).
+Defined.
+
+Lemma form_adjunction_functor_cat_swap (C D : precategory) (E : Precategory) :
+  form_adjunction _ _ (id_functor_cat_swap C D E) (functor_cat_swap_id C D E).
+Proof.
+set (hsE := homset_property E).
+split;
+  simpl; intro F; apply (nat_trans_eq (functor_category_has_homsets _ _ hsE)); intro d;
+  apply (nat_trans_eq hsE); intro c; simpl; apply id_right.
+Admitted.
+
+Lemma are_adjoint_functor_cat_swap (C D : precategory) (E : Precategory) :
+  are_adjoints (@functor_cat_swap C D E) (@functor_cat_swap D C E).
+Proof.
+set (hsE := homset_property E).
+mkpair.
+- split; [ apply id_functor_cat_swap | apply functor_cat_swap_id ].
+- apply form_adjunction_functor_cat_swap.
+Defined.
+
+Lemma test (C D : precategory) (E : Precategory) : adj_equivalence_of_precats (@functor_cat_swap C D E).
+Proof.
+mkpair.
++ exists functor_cat_swap.
+  apply are_adjoint_functor_cat_swap.
++ split.
+- admit.
+- admit.
+Admitted.
+
+Lemma test2 (C D : Precategory) (F : functor C D) :
+  adj_equivalence_of_precats F -> is_cocont F.
+Proof.
+intro H.
+apply left_adjoint_cocont; try apply homset_property.
+apply H.
+Defined.
+
+Lemma test3 (C D : Precategory) (F : functor C D) :
+  adj_equivalence_of_precats F -> is_omega_cocont F.
+Proof.
+intros H g L ccL HccL d ccd.
+apply (test2 C D _ H _ _ _ _ HccL).
+Defined.
+
+
+End temp.
 
 (** * Discrete precategories *)
 Section DiscreteCategory.
@@ -179,7 +293,7 @@ Defined.
 Definition mk_sortToC (f : sort → C) : sortToC :=
   functor_discrete_precategory _ _ f.
 
-Definition proj_gen {D : precategory} {E : Precategory} (d : D) : functor [D,E] E.
+Definition proj_gen_fun {D : precategory} {E : Precategory} (d : D) : functor [D,E] E.
 Proof.
 mkpair.
 + mkpair.
@@ -188,6 +302,24 @@ mkpair.
 + abstract (split; [intro f; apply idpath|intros f g h fg gh; apply idpath]).
 Defined.
 
+Definition proj_gen {D : precategory} {E : Precategory} : functor D [[D,E],E].
+Proof.
+mkpair.
++ mkpair.
+  - apply proj_gen_fun.
+  - intros d1 d2 f.
+    mkpair.
+    * simpl; intro F; apply (# F f).
+    * intros F G α; simpl in *.
+      apply pathsinv0, (nat_trans_ax α d1 d2 f).
++ split.
+  - intros F; simpl.
+    apply nat_trans_eq; [apply homset_property|]; intro G; simpl.
+    apply functor_id.
+  - intros F G H α β; simpl.
+    apply nat_trans_eq; [apply homset_property|]; intro γ; simpl.
+    apply functor_comp.
+Defined.
 
 (** Given a sort s this applies the sortToC to s and returns C *)
 Definition projSortToC (s : sort) : functor sortToC C.
@@ -326,15 +458,20 @@ Defined.
 
 (* This lemma is just here to check that the correct sort_cat gets pulled out when reorganizing *)
 (*    arguments *)
-Local Definition MultiSortedSigToFunctor_helper (C1 D E1 : precategory) (C2 E2 : Precategory)
-  (F : functor E1 [[C1,C2],[D,E2]]) : functor [C1,C2] [D,[E1,E2]] :=
+Local Definition MultiSortedSigToFunctor_helper (C1 D E1 : precategory) (E2 : Precategory)
+  (F : functor E1 [C1,[D,E2]]) : functor C1 [D,[E1,E2]] :=
     functor_composite (functor_cat_swap F) functor_cat_swap.
 
-Lemma is_omega_cocont_MultiSortedSigToFunctor_helper (C1 D E1 : precategory) (C2 E2 : Precategory)
-  (F : functor E1 [[C1,C2],[D,E2]]) (HF : Π c, is_omega_cocont (F c)) :
-  is_omega_cocont (MultiSortedSigToFunctor_helper C1 D E1 C2 E2 F).
+Lemma is_omega_cocont_MultiSortedSigToFunctor_helper (C1 D E1 : precategory) (E2 : Precategory)
+  (F : functor E1 [C1,[D,E2]]) (HF : Π c, is_omega_cocont (F c)) :
+  is_omega_cocont (MultiSortedSigToFunctor_helper C1 D E1 E2 F).
+Proof.
+apply is_omega_cocont_functor_composite.
++ apply functor_category_has_homsets.
++ admit.
++ apply test3.
+  eapply test.
 Admitted.
-
 
 Definition MultiSortedSigToFunctor_fun (M : MultiSortedSig) (CC : Π s, Coproducts (indices M s) C) (s : sort) :
   [[sortToC, sortToC], [sortToC, C]].

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -48,9 +48,7 @@ Lemma horcomp_id_prewhisker {C D E : precategory} (hsE : has_homsets E)
   (X : functor C D) (Z Z' : functor D E) (f : nat_trans Z Z') :
   hor_comp (nat_trans_id X) f = pre_whisker _ f.
 Proof.
-apply (nat_trans_eq hsE).
-simpl.
-intro x.
+apply (nat_trans_eq hsE); simpl; intro x.
 now rewrite functor_id, id_right.
 Qed.
 
@@ -306,25 +304,16 @@ mkpair.
   repeat rewrite horcomp_id_postwhisker, post_whisker_identity; trivial;
     try apply has_homsets_HSET; try apply has_homsets_sortToHSET.
 + intros F G H α β. simpl in *.
-rewrite !horcomp_id_postwhisker.
+rewrite !horcomp_id_postwhisker;
+  try apply has_homsets_HSET; try apply has_homsets_sortToHSET.
 eapply pathscomp0.
 eapply maponpaths.
 apply (post_whisker_composition sortToHSET _ _ has_homsets_HSET (sortToHSETToHSET (pr2 a))).
 eapply pathscomp0.
-simpl.
-Check ( (nat_trans_comp (post_whisker α (sortToHSETToHSET (pr2 a)))
-         (post_whisker β (sortToHSETToHSET (pr2 a))))).
-(* This is not the right thing to do... *)
 apply (@horcomp_id_prewhisker sortToHSET sortToHSET HSET has_homsets_HSET  (option_list (pr1 a)) (functor_composite F (sortToHSETToHSET (pr2 a))) (functor_composite H (sortToHSETToHSET (pr2 a)))).
-simpl.
-cbn.
-apply (nat_trans_eq has_homsets_HSET).
-intro x.
-simpl.
-apply funextsec; intro xx.
-cbn.
-admit.
-Admitted.
+rewrite (pre_whisker_composition _ _ _ has_homsets_HSET).
+now rewrite !(horcomp_id_prewhisker has_homsets_HSET (option_list (pr1 a))).
+Defined.
 
 (* Definition endo_funs (xs : list (list sort × sort)) (X : functor sortToHSET sortToHSET) : *)
 (*   functor sortToHSET HSET. *)

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -47,6 +47,66 @@ Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
 Local Notation "[ C , D ]" := (functor_Precategory C D).
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
+Section move_upstream.
+
+Lemma foldr_cons {A B : UU} (f : A -> B -> B) (b : B) (x : A) (xs : list A) :
+  foldr f b (cons x xs) = f x (foldr f b xs).
+Proof.
+now destruct xs.
+Qed.
+
+Lemma map_nil {A B : UU} (f : A -> B) : map f nil = nil.
+Proof.
+apply idpath.
+Qed.
+
+Lemma map_cons {A B : UU} (f : A -> B) (x : A) (xs : list A) :
+  map f (cons x xs) = cons (f x) (map f xs).
+Proof.
+now destruct xs.
+Qed.
+
+Lemma foldr1_cons_nil {A : UU} (f : A -> A -> A) (a : A) (x : A) :
+  foldr1 f a (cons x nil) = x.
+Proof.
+apply idpath.
+Qed.
+
+Lemma foldr1_cons {A : UU} (f : A -> A -> A) (a : A) (x y : A) (xs : list A) :
+  foldr1 f a (cons x (cons y xs)) = f x (foldr1 f a (cons y xs)).
+Proof.
+apply idpath.
+Qed.
+
+Definition head {A : UU} (a : A) (xs : list A) : A.
+Proof.
+induction xs as [n xs].
+destruct n.
+- apply a.
+- simpl in xs.
+  apply (pr1 xs).
+Defined.
+
+Lemma foldr1_ind {A : UU} (P : A -> UU) (f : A -> A -> A) (a : A) (Ha : P a) :
+  Π xs, P (foldr1 f (head a xs) xs) → P (foldr1 f a xs).
+Proof.
+intros xs.
+use (list_ind (fun xs =>  P (foldr1 f (head a xs) xs) → P (foldr1 f a xs))); clear xs.
+- intros _; apply Ha.
+-
+intros x xs IH.
+intros H.
+destruct xs as [n xs].
+destruct n.
++ destruct xs.
+simpl.
+simpl in *.
+apply H.
++ apply H.
+Defined.
+
+End move_upstream.
+
 (** Swapping of functor arguments *)
 (* TODO: Move upstream? *)
 Section functor_swap.
@@ -335,11 +395,6 @@ mkpair.
 Defined.
 
 Lemma  is_omega_cocont_exp_functor a : is_omega_cocont (exp_functor a).
-Proof.
-assert (lol : is_omega_cocont (pr1 (exp_functor a)).
-unfold exp_functor.
-simpl.
-
 Admitted.
 
 (* First version: *)
@@ -365,36 +420,6 @@ set (T := constant_functor [sortToC,sortToC] [sortToC,C]
 (* TODO: Maybe use indexed finite products instead of a fold? *)
 apply (foldr1 (fun F G => BinProduct_of_functors _ _ BinProductsSortToCToC F G) T XS).
 Defined.
-
-(* TODO: move these *)
-Lemma foldr_cons {A B : UU} (f : A -> B -> B) (b : B) (x : A) (xs : list A) :
-  foldr f b (cons x xs) = f x (foldr f b xs).
-Proof.
-now destruct xs.
-Qed.
-
-Lemma map_nil {A B : UU} (f : A -> B) : map f nil = nil.
-Proof.
-apply idpath.
-Qed.
-
-Lemma map_cons {A B : UU} (f : A -> B) (x : A) (xs : list A) :
-  map f (cons x xs) = cons (f x) (map f xs).
-Proof.
-now destruct xs.
-Qed.
-
-Lemma foldr1_cons_nil {A : UU} (f : A -> A -> A) (a : A) (x : A) :
-  foldr1 f a (cons x nil) = x.
-Proof.
-apply idpath.
-Qed.
-
-Lemma foldr1_cons {A : UU} (f : A -> A -> A) (a : A) (x y : A) (xs : list A) :
-  foldr1 f a (cons x (cons y xs)) = f x (foldr1 f a (cons y xs)).
-Proof.
-apply idpath.
-Qed.
 
 (* Lemma exp_functor_cons x xs : *)
 (*   exp_functors (cons x xs) = BinProduct_of_functors _ _ BinProductsSortToCToC F (exp_functors G). *)

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -305,6 +305,10 @@ apply (functor_composite (option_list (pr1 a))
                          (functor_composite X (sortToCToC (pr2 a)))).
 Defined.
 
+Lemma is_omega_cocont_exp_fun (X : functor sortToC sortToC) (a : list sort × sort) :
+  is_omega_cocont (exp_fun X a).
+Admitted.
+
 (* This stops Coq from unfolding horcomp too much *)
 Local Arguments horcomp : simpl never.
 
@@ -330,6 +334,14 @@ mkpair.
     now rewrite (pre_whisker_composition _ _ _ hsC)]).
 Defined.
 
+Lemma  is_omega_cocont_exp_functor a : is_omega_cocont (exp_functor a).
+Proof.
+assert (lol : is_omega_cocont (pr1 (exp_functor a)).
+unfold exp_functor.
+simpl.
+
+Admitted.
+
 (* First version: *)
 (* Definition exp_funs (xs : list (list sort × sort)) (X : functor sortToC sortToC) : *)
 (*   functor sortToC C. *)
@@ -354,8 +366,64 @@ set (T := constant_functor [sortToC,sortToC] [sortToC,C]
 apply (foldr1 (fun F G => BinProduct_of_functors _ _ BinProductsSortToCToC F G) T XS).
 Defined.
 
+(* TODO: move these *)
+Lemma foldr_cons {A B : UU} (f : A -> B -> B) (b : B) (x : A) (xs : list A) :
+  foldr f b (cons x xs) = f x (foldr f b xs).
+Proof.
+now destruct xs.
+Qed.
+
+Lemma map_nil {A B : UU} (f : A -> B) : map f nil = nil.
+Proof.
+apply idpath.
+Qed.
+
+Lemma map_cons {A B : UU} (f : A -> B) (x : A) (xs : list A) :
+  map f (cons x xs) = cons (f x) (map f xs).
+Proof.
+now destruct xs.
+Qed.
+
+Lemma foldr1_cons_nil {A : UU} (f : A -> A -> A) (a : A) (x : A) :
+  foldr1 f a (cons x nil) = x.
+Proof.
+apply idpath.
+Qed.
+
+Lemma foldr1_cons {A : UU} (f : A -> A -> A) (a : A) (x y : A) (xs : list A) :
+  foldr1 f a (cons x (cons y xs)) = f x (foldr1 f a (cons y xs)).
+Proof.
+apply idpath.
+Qed.
+
+(* Lemma exp_functor_cons x xs : *)
+(*   exp_functors (cons x xs) = BinProduct_of_functors _ _ BinProductsSortToCToC F (exp_functors G). *)
+
 Lemma is_omega_cocont_exp_functors (xs : list (list sort × sort)) :
   is_omega_cocont (exp_functors xs).
+Proof.
+use (list_ind (fun xs => is_omega_cocont (exp_functors xs)) _ _ xs); simpl; clear xs.
+- apply is_omega_cocont_constant_functor.
+  apply (functor_category_has_homsets sortToC).
+- intros x xs.
+use (list_ind (fun xs => is_omega_cocont (exp_functors xs) -> is_omega_cocont (exp_functors (cons x xs))) _ _ xs); simpl; clear xs.
+
++ intros _. unfold exp_functors.
+rewrite map_cons, map_nil.
+rewrite foldr1_cons_nil.
+apply is_omega_cocont_exp_functor.
++
+intros y xs Hxs Hys.
+unfold exp_functors.
+rewrite !map_cons.
+rewrite foldr1_cons.
+apply is_omega_cocont_BinProduct_of_functors.
+admit.
+admit.
+admit.
+admit.
+apply is_omega_cocont_exp_functor.
+admit.
 Admitted.
 
 (* This lemma is just here to check that the correct sort_cat gets pulled out when reorganizing

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -153,13 +153,19 @@ mkpair.
 - apply form_adjunction_functor_cat_swap.
 Defined.
 
+Lemma is_left_adjoint_functor_cat_swap (C D : precategory) (E : Precategory) :
+  is_left_adjoint (functor_cat_swap C D E).
+Proof.
+mkpair.
++ apply functor_cat_swap.
++ apply are_adjoint_functor_cat_swap.
+Defined.
+
 Lemma is_cocont_functor_cat_swap (C D : precategory) (E : Precategory) :
   is_cocont (functor_cat_swap C D E).
 Proof.
 apply left_adjoint_cocont; try apply homset_property.
-mkpair.
-+ apply functor_cat_swap.
-+ apply are_adjoint_functor_cat_swap.
+apply is_left_adjoint_functor_cat_swap.
 Defined.
 
 Lemma is_omega_cocont_functor_cat_swap (C D : precategory) (E : Precategory) :
@@ -169,13 +175,12 @@ intros d L ccL HccL.
 apply (is_cocont_functor_cat_swap _ _ _ _ d L ccL HccL).
 Defined.
 
-(* Maybe prove this as well? *)
-(* Lemma equiv_functor_cat_swap (C D : precategory) (E : Precategory) :  *)
+(* (* Maybe prove this as well? *) *)
+(* Lemma equiv_functor_cat_swap (C D : precategory) (E : Precategory) : *)
 (*   adj_equivalence_of_precats (@functor_cat_swap C D E). *)
 (* Proof. *)
 (* mkpair. *)
-(* + exists functor_cat_swap. *)
-(*   apply are_adjoint_functor_cat_swap. *)
+(* + apply is_left_adjoint_functor_cat_swap. *)
 (* + split. *)
 (*   - admit. *)
 (*   - admit. *)

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -28,6 +28,7 @@ Require Import UniMath.CategoryTheory.CocontFunctors.
 Require Import UniMath.CategoryTheory.Monads.
 Require Import UniMath.CategoryTheory.category_hset.
 Require Import UniMath.CategoryTheory.category_hset_structures.
+Require Import UniMath.CategoryTheory.HorizontalComposition.
 
 Require Import UniMath.SubstitutionSystems.Signatures.
 Require Import UniMath.SubstitutionSystems.SignatureExamples.
@@ -36,7 +37,7 @@ Require Import UniMath.SubstitutionSystems.BinProductOfSignatures.
 Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.LiftingInitial.
 Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
-Require Import UniMath.SubstitutionSystems.Notation.
+(* Require Import UniMath.SubstitutionSystems.Notation. *)
 
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
@@ -81,6 +82,22 @@ Lemma has_homsets_sortToHSET : has_homsets sortToHSET.
 Proof.
 apply functor_category_has_homsets.
 Qed.
+
+Local Definition BinProductsSortToHSETToHSET : BinProducts [sortToHSET,HSET,has_homsets_HSET].
+Proof.
+apply (BinProducts_functor_precat _ _ BinProductsHSET).
+Defined.
+
+Local Definition CoproductsSortToHSET I (hI : isaset I) : Coproducts I sortToHSET.
+Proof.
+now apply Coproducts_functor_precat, Coproducts_HSET.
+Defined.
+
+Local Definition CoproductsSortToHSET2 I (hI : isaset I) :
+  Coproducts I [sortToHSET, sortToHSET, has_homsets_sortToHSET].
+Proof.
+now apply Coproducts_functor_precat, CoproductsSortToHSET.
+Defined.
 
 Definition mk_sortToHSET (f : sort → hSet) : sortToHSET.
 Proof.
@@ -167,14 +184,14 @@ mkpair.
     | now intros f g h fg gh; apply funextsec; intro x ]).
 Defined.
 
-Definition sortToHSETToHSet' : [sortToHSET, sortToHSET, has_homsets_sortToHSET].
-Proof.
-mkpair.
-+ mkpair.
-  admit.
-  admit.
-+ admit.
-Admitted.
+(* Definition sortToHSETToHSet' : [sortToHSET, sortToHSET, has_homsets_sortToHSET]. *)
+(* Proof. *)
+(* mkpair. *)
+(* + mkpair. *)
+(*   admit. *)
+(*   admit. *)
+(* + admit. *)
+(* Admitted. *)
 
 Definition endo_fun (X : functor sortToHSET sortToHSET) (a : list sort × sort) : functor sortToHSET HSET.
 Proof.
@@ -182,10 +199,24 @@ set (O := functor_composite (option_list (pr1 a)) X).
 apply (functor_composite O (sortToHSETToHSET (pr2 a))).
 Defined.
 
-Local Definition BinProductsSortToHSETToHSET : BinProducts [sortToHSET,HSET,has_homsets_HSET].
+Lemma endo_fun_functor (a : list sort × sort) :
+  functor [sortToHSET,sortToHSET,has_homsets_sortToHSET] [sortToHSET,HSET,has_homsets_HSET].
 Proof.
-apply (BinProducts_functor_precat _ _ BinProductsHSET).
-Defined.
+mkpair.
+- mkpair.
+  + intro X.
+    apply (endo_fun X a).
+  + intros F G α.
+unfold endo_fun.
+set (F1 := functor_composite (option_list (pr1 a)) F : functor sortToHSET sortToHSET).
+set (F1' := functor_composite (option_list (pr1 a)) G : functor sortToHSET sortToHSET).
+set (F2 := sortToHSETToHSET (pr2 a)).
+apply (@hor_comp _ _ _ F1 F1' F2 F2).
+admit.
+apply nat_trans_id.
+- admit.
+Admitted.
+
 
 Definition endo_funs (xs : list (list sort × sort)) (X : functor sortToHSET sortToHSET) :
   functor sortToHSET HSET.
@@ -196,37 +227,131 @@ set (T := constant_functor sortToHSET HSET emptyHSET).
 apply (foldr1 (fun F G => BinProductObject _ (BinProductsSortToHSETToHSET F G)) T XS).
 Defined.
 
+(* Definition MSigToFunctor_helper *)
+(*   (H : functor sortToHSET sortToHSET → sortToHSET → sort → HSET) : *)
+(*  functor [sortToHSET, sortToHSET, has_homsets_sortToHSET] *)
+(*          [sortToHSET, sortToHSET, has_homsets_sortToHSET]. *)
+(* Proof. *)
+(* mkpair. *)
+(* + mkpair. *)
+(*   - intro X. *)
+(*     mkpair. *)
+(*     * mkpair. *)
+(*     { intro f. *)
+(*       apply mk_sortToHSET; intro s. *)
+(*       apply (H X f s). *)
+(*     } *)
+(*       simpl. *)
+
+Arguments pr1 : simpl never.
+Arguments pr2 : simpl never.
+
+Definition MSigToFunctor_helper
+  (H : sort → functor [sortToHSET,sortToHSET,has_homsets_sortToHSET] [sortToHSET,HSET,has_homsets_HSET]) :
+ functor [sortToHSET, sortToHSET, has_homsets_sortToHSET]
+         [sortToHSET, sortToHSET, has_homsets_sortToHSET].
+Proof.
+mkpair.
+- mkpair.
+  + intro X.
+mkpair.
+* mkpair.
+{ intro f.
+  apply mk_sortToHSET; intro s.
+  apply (H s X).
+  apply f.
+}
+admit.
+*
+admit.
++ admit.
+- admit.
+(* { *)
+(*   intros F G α. *)
+(* simpl. *)
+(* apply nat_trans_id. *)
+(* mkpair. *)
+(* + *)
+(* simpl. *)
+(* intro s. *)
+(* apply (#(H s X) α). *)
+(* + *)
+(* now intros s t []. *)
+(* } *)
+(* * *)
+(* split. *)
+(* { simpl. *)
+(* intros F. *)
+(* simpl. *)
+(* apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ has_homsets_HSET)|]. *)
+(* simpl. *)
+
+(* apply funextsec; intro t. *)
+(* apply (functor_id (H t X)). *)
+(* } *)
+(* { *)
+(* intros F1 F2 F3 αF12 αF23; simpl in *. *)
+(* apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ has_homsets_HSET)|]. *)
+(* simpl. *)
+(* apply funextsec; intro t. *)
+(* apply (functor_comp (H t X)). *)
+(* } *)
+(* + *)
+(* simpl. *)
+(* intros F G α. *)
+(* mkpair. *)
+(* * simpl. *)
+(* intros FF. *)
+(* mkpair. *)
+(* { *)
+(* simpl. *)
+(* intro s. *)
+(* generalize ((α FF)). *)
+(* simpl. *)
+
+(* Check (H s). *)
+
+(* admit. *)
+(* } *)
+(* admit. *)
+(* * *)
+(* admit. *)
+(* - *)
+(* admit. *)
+Admitted.
+
+Definition MSigToFunctor_helper2
+  (H : functor sortToHSET sortToHSET → functor sortToHSET HSET) :
+   functor [sortToHSET, sortToHSET, has_homsets_sortToHSET]
+           [sortToHSET, HSET, has_homsets_HSET].
+Admitted.
+
+
 Definition MSigToFunctor (M : MSig) :
   functor [sortToHSET,sortToHSET,has_homsets_sortToHSET]
           [sortToHSET,sortToHSET,has_homsets_sortToHSET].
 Proof.
-unfold MSig in M.
-mkpair.
-+ mkpair.
-- intro X.
-simpl.
-mkpair.
-* mkpair.
-{ intro f.
-use mk_sortToHSET.
-intro s.
-set (Is := indices M s).
-simpl.
-mkpair.
-use total2.
-* apply Is.
-* intro y.
-set (ary := args M s y).
-(* apply (endo_funs ary (pr1 X) f). *)
-(* *simpl. *)
-(* apply isaset_total2. *)
-admit.
-* admit.
-}
-admit.
-* admit.
-- admit.
-+ admit.
+apply MSigToFunctor_helper.
+intros s.
+apply MSigToFunctor_helper2.
+intro X.
+use (coproduct_of_functors (indices M s)).
++ apply Coproducts_HSET.
+  admit.
++ intros y.
+  apply (endo_funs (args M s y) X).
 Admitted.
+
+
+
+
+
+
+
+
+
+
+
+
 
 End MBindingSig.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -310,7 +310,6 @@ set (XS := map exp_functor xs).
 set (T := constant_functor [sortToHSET,sortToHSET] [sortToHSET,HSET]
                            (constant_functor sortToHSET HSET emptyHSET)).
 (* TODO: Maybe use indexed finite products instead of a fold? *)
-(* TODO: Should we really use BinProduct_of_functors? Can we prove omega-cocont? *)
 apply (foldr1 (fun F G => BinProduct_of_functors _ _ BinProductsSortToHSETToHSET F G) T XS).
 Defined.
 

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -47,6 +47,7 @@ Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
 Local Notation "[ C , D ]" := (functor_Precategory C D).
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
+
 (** Swapping of functor arguments *)
 (* TODO: Move upstream? *)
 Section functor_swap.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -85,12 +85,8 @@ mkpair.
     - abstract (intros c d g; simpl; apply pathsinv0, nat_trans_ax).
   }
 - abstract (split;
-  [ intros d; simpl;
-    apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ hsE) |]; simpl;
-    apply funextsec; intro c; apply functor_id
-  | intros a b c f g; simpl;
-    apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ hsE) |]; simpl;
-    apply funextsec; intro x; apply functor_comp ]).
+  [ intros d; apply (nat_trans_eq hsE); intro c; simpl; apply functor_id
+  | intros a b c f g; apply (nat_trans_eq hsE); intro x; simpl; apply functor_comp]).
 Defined.
 
 (* Lift the result to functor categories. It might be good to decompose this proof as the natural
@@ -106,18 +102,12 @@ mkpair.
     mkpair.
     * intro c; apply (α c).
     * abstract (intros a b f; apply (nat_trans_eq_pointwise (nat_trans_ax α _ _ f) d)).
-  + abstract (intros a b f; simpl;
-              apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ hsE) |]; simpl;
-              apply funextsec; intro c; apply nat_trans_ax).
+  + abstract (intros a b f; apply (nat_trans_eq hsE); intro c; simpl; apply nat_trans_ax).
 - abstract (split;
-  [ intro F; simpl; apply subtypeEquality;
-      [ intro x; apply isaprop_is_nat_trans, (functor_category_has_homsets _ _ hsE)|]; simpl;
-    apply funextsec; intro d;
-    now apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ hsE) |]
-  | intros F G H α β; simpl in *; apply subtypeEquality;
-      [ intro x; apply isaprop_is_nat_trans, (functor_category_has_homsets _ _ hsE)|]; simpl;
-    apply funextsec; intro d;
-    now apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ hsE) |]]).
+  [ intro F; apply (nat_trans_eq (functor_category_has_homsets _ _ hsE)); simpl; intro d;
+    now apply (nat_trans_eq hsE)
+  | intros F G H α β; cbn; apply (nat_trans_eq (functor_category_has_homsets _ _ hsE)); intro d;
+    now apply (nat_trans_eq hsE)]).
 Defined.
 
 End functor_swap.
@@ -251,14 +241,10 @@ Defined.
 Lemma is_functor_option_functor s : is_functor (option_functor_data s).
 Proof.
 split.
-+ intros F; simpl in *.
-  apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ has_homsets_HSET)|]; simpl.
-  apply funextsec; intro t.
++ intros F; apply (nat_trans_eq has_homsets_HSET); intro t; simpl.
   induction (eq s t) as [p|p]; trivial; simpl; clear p.
   now apply funextfun; intros [].
-+ intros F G H αFG αGH; simpl in *.
-  apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ has_homsets_HSET)|]; simpl.
-  apply funextsec; intro t.
++ intros F G H αFG αGH; apply (nat_trans_eq has_homsets_HSET); intro t; simpl.
   induction (eq s t) as [p|p]; trivial; simpl; clear p.
   now apply funextfun; intros [].
 Qed.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -48,14 +48,6 @@ Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
 Section move_upstream.
 
-Lemma horcomp_id_prewhisker {C D E : precategory} (hsE : has_homsets E)
-  (X : functor C D) (Z Z' : functor D E) (f : nat_trans Z Z') :
-  hor_comp (nat_trans_id X) f = pre_whisker _ f.
-Proof.
-apply (nat_trans_eq hsE); simpl; intro x.
-now rewrite functor_id, id_right.
-Qed.
-
 End move_upstream.
 
 (** Swapping of functor arguments *)
@@ -275,8 +267,8 @@ apply (functor_composite (option_list (pr1 a))
                          (functor_composite X (sortToHSETToHSET (pr2 a)))).
 Defined.
 
-(* This stops Coq from unfolding hor_comp too much *)
-Local Arguments hor_comp : simpl never.
+(* This stops Coq from unfolding horcomp too much *)
+Local Arguments horcomp : simpl never.
 
 (* This is X^a as a functor between functor categories *)
 Lemma exp_functor (a : list sort × sort) :
@@ -287,8 +279,8 @@ mkpair.
 - mkpair.
   + intro X; apply (exp_fun X a).
   + intros F G α.
-    use (@hor_comp sortToHSET _ HSET _ _ _ _ (nat_trans_id _)).
-    use hor_comp; [ assumption | apply nat_trans_id ].
+    use (@horcomp sortToHSET _ HSET _ _ _ _ (nat_trans_id _)).
+    use horcomp; [ assumption | apply nat_trans_id ].
 - abstract (split;
   [ intro F; cbn;
     rewrite (horcomp_id_postwhisker _ _ _ has_homsets_sortToHSET has_homsets_HSET);

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -47,7 +47,7 @@ Local Notation "[ C , D ]" := (functor_Precategory C D).
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
 (** Swapping of functor arguments *)
-(* TODO: Move upstream as well? *)
+(* TODO: Move upstream? *)
 Section functor_swap.
 
 Context {C D : precategory} {E : Precategory}.
@@ -77,6 +77,33 @@ mkpair.
   | intros a b c f g; apply (nat_trans_eq (homset_property E)); intro x; simpl; apply functor_comp]).
 Defined.
 
+(* Lemma is_omega_cocont_functor_swap *)
+(*   (F : functor C [D,E]) (HF : forall c, is_omega_cocont (F c)) : *)
+(*    is_omega_cocont (functor_swap F). *)
+(* Proof. *)
+(* intros d L ccL HccL G ccG. *)
+(* simpl in G. *)
+(* transparent assert (temp : (Π c, cocone (mapdiagram (F c) d) (G c))). *)
+(* { intro c; use mk_cocone. *)
+(*   + simpl; intro n. *)
+(*     apply (pr1 (coconeIn ccG n) c). *)
+(*   + abstract (intros m n e; apply (nat_trans_eq_pointwise (coconeInCommutes ccG _ _ e) c)). *)
+(* } *)
+(* mkpair. *)
+(* + mkpair. *)
+(* - mkpair. *)
+(* * intro c. *)
+(* simpl. *)
+(* apply (HF c d L ccL HccL (G c) (temp c)). *)
+(* * intros x y f; simpl. *)
+(* destruct (HF y d L ccL HccL (G y) (temp y)) as [[hy1 hy2] hy3]. *)
+(* destruct (HF x d L ccL HccL (G x) (temp x)) as [[hx1 hx2] hx3]. *)
+(* generalize (nat_trans_ax (#F f) L L). *)
+(* admit. *)
+(* - admit. *)
+(* + admit. *)
+(* Admitted. *)
+
 (* Lift the result to functor categories. It might be good to decompose this proof as the natural
 transformations constructed might be useful later *)
 Lemma functor_cat_swap : functor [C, [D, E]] [D, [C, E]].
@@ -96,7 +123,21 @@ mkpair.
     now apply (nat_trans_eq (homset_property E))]).
 Defined.
 
+(* Lemma is_omega_cocont_functor_swap : is_cocont functor_cat_swap. *)
+(* Admitted. *)
+
 End functor_swap.
+
+(* Lemma is_omega_cocont_swap {C D : precategory} {E : Precategory} : is_cocont (@functor_cat_swap C D E). *)
+(* Proof. *)
+(* intros g d L ccL HccL F ccF. *)
+(* simpl in F. *)
+(* generalize (is_omega_cocont_functor_swap F). *)
+(* simpl. *)
+(* simpl. *)
+(* (* eapply is_cocont_iso. *) *)
+(* (* unfold iso. *) *)
+(* functor_ *)
 
 (** * Discrete precategories *)
 Section DiscreteCategory.
@@ -318,7 +359,7 @@ Defined.
 
 (* This lemma is just here to check that the correct sort_cat gets pulled out when reorganizing
    arguments *)
-Definition MultiSortedSigToFunctor_helper (C E F : precategory) (D G : Precategory)
+Local Definition MultiSortedSigToFunctor_helper (C E F : precategory) (D G : Precategory)
   (H : functor F [[C,D],[E,G]]) : functor [C,D] [E,[F,G]] :=
     functor_composite (functor_swap H) functor_cat_swap.
 
@@ -335,5 +376,20 @@ use (coproduct_of_functors (indices M s)).
 + apply Coproducts_functor_precat, CC.
 + intros y; apply (exp_functors (args M s y)).
 Defined.
+
+(* Lemma is_omega_cocont_MultiSortedSigToFunctor (M : MultiSortedSig) *)
+(*   (CC : Π s, Coproducts (indices M s) C) : is_omega_cocont (MultiSortedSigToFunctor M CC). *)
+(* Proof. *)
+(* use is_omega_cocont_functor_composite. *)
+(* + apply (functor_category_has_homsets sortToC). *)
+(* + *)
+(* apply is_omega_cocont_functor_swap. *)
+(* intro s. *)
+(* simpl. *)
+(* apply is_omega_cocont_coproduct_of_functors. *)
+(* eapply functor_swap. *)
+(*  admit. *)
+(* + admit. *)
+(* Admitted. *)
 
 End MBindingSig.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -438,12 +438,15 @@ eapply (functor_composite (functor_cat_swap _ _ _)).
 apply MultiSortedSigToFunctor_helper1.
 Defined.
 
+
+
 (* The above definition might be the same as: *)
 (* functor_composite (functor_cat_swap F) functor_cat_swap. *)
 
 (* Local Definition MultiSortedSigToFunctor_helper (C1 D E1 : precategory) (E2 : Precategory) *)
 (*   (F : functor E1 [C1,[D,E2]]) : functor C1 [D,[E1,E2]]. *)
 (*     functor_composite (functor_cat_swap F) functor_cat_swap. *)
+
 
 Lemma is_omega_cocont_MultiSortedSigToFunctor_helper (C1 D E1 : precategory) (E2 : Precategory)
   (F : functor E1 [C1,[D,E2]]) (HF : Π s, is_omega_cocont (F s)) :
@@ -454,6 +457,15 @@ apply is_omega_cocont_functor_composite.
 + admit.
 + apply is_omega_cocont_functor_cat_swap.
 Admitted.
+
+Local Definition MultiSortedSigToFunctor_helper2 (C1 D E1 : precategory) (E2 : Precategory) :
+  functor [E1,[D,[C1,E2]]] [C1,[D,[E1,E2]]].
+Proof.
+eapply functor_composite;[apply functor_cat_swap|].
+eapply functor_composite;[|apply functor_cat_swap].
+eapply functor_composite; [eapply post_composition_functor; apply functor_cat_swap|].
+apply functor_identity.
+Defined.
 
 Definition MultiSortedSigToFunctor_fun (M : MultiSortedSig) (CC : Π s, Coproducts (indices M s) C)
   : [sort_cat, [[sortToC, sortToC], [sortToC, C]]].

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -182,13 +182,17 @@ Defined.
 (* Coercion sortToHsetToFun (s : sortToHSET) : sort → HSET := pr1 s. *)
 
 Definition MSig : UU :=
-  Π (s : sort), Σ (I : UU), I → list (list sort × sort).
+  Π (s : sort), Σ (I : UU), (I → list (list sort × sort)) × (isaset I).
 
 Definition indices (M : MSig) : sort → UU := fun s => pr1 (M s).
 
 Definition args (M : MSig) (s : sort) : indices M s → list (list sort × sort) :=
-  pr2 (M s).
+  pr1 (pr2 (M s)).
 
+Lemma isaset_indices (M : MSig) (s : sort) : isaset (indices M s).
+Proof.
+apply (pr2 (pr2 (M s))).
+Qed.
 
 Local Notation "'1'" := (TerminalHSET).
 Local Notation "a ⊕ b" := (BinCoproductObject _ (BinCoproductsHSET a b)) (at level 50).
@@ -264,24 +268,24 @@ set (O := functor_composite (option_list (pr1 a)) X).
 apply (functor_composite O (sortToHSETToHSET (pr2 a))).
 Defined.
 
-Lemma endo_fun_functor (a : list sort × sort) :
-  functor [sortToHSET,sortToHSET,has_homsets_sortToHSET]
-          [sortToHSET,HSET,has_homsets_HSET].
-Proof.
-mkpair.
-- mkpair.
-  + intro X.
-    apply (endo_fun X a).
-  + intros F G α.
-unfold endo_fun.
-set (F1 := functor_composite (option_list (pr1 a)) F : functor sortToHSET sortToHSET).
-set (F1' := functor_composite (option_list (pr1 a)) G : functor sortToHSET sortToHSET).
-set (F2 := sortToHSETToHSET (pr2 a)).
-apply (@hor_comp _ _ _ F1 F1' F2 F2).
-admit.
-apply nat_trans_id.
-- admit.
-Admitted.
+(* Lemma endo_fun_functor (a : list sort × sort) : *)
+(*   functor [sortToHSET,sortToHSET,has_homsets_sortToHSET] *)
+(*           [sortToHSET,HSET,has_homsets_HSET]. *)
+(* Proof. *)
+(* mkpair. *)
+(* - mkpair. *)
+(*   + intro X. *)
+(*     apply (endo_fun X a). *)
+(*   + intros F G α. *)
+(* unfold endo_fun. *)
+(* set (F1 := functor_composite (option_list (pr1 a)) F : functor sortToHSET sortToHSET). *)
+(* set (F1' := functor_composite (option_list (pr1 a)) G : functor sortToHSET sortToHSET). *)
+(* set (F2 := sortToHSETToHSET (pr2 a)). *)
+(* apply (@hor_comp _ _ _ F1 F1' F2 F2). *)
+(* admit. *)
+(* apply nat_trans_id. *)
+(* - admit. *)
+(* Admitted. *)
 
 
 Definition endo_funs (xs : list (list sort × sort)) (X : functor sortToHSET sortToHSET) :
@@ -313,9 +317,9 @@ apply MSigToFunctor_helper.
 apply functor_sort_cat.
 intro s.
 use (coproduct_of_functors (indices M s)).
-+ admit.
++ apply Coproducts_functor_precat, Coproducts_HSET, isaset_indices.
 + intros y.
   apply (endo_funs_functor (args M s y)).
-Admitted.
+Defined.
 
 End MBindingSig.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -134,6 +134,15 @@ mkpair.
     | now intros f g h fg gh; apply funextsec; intro x ]).
 Defined.
 
+Definition sortToHSETToHSet' : [sortToHSET, sortToHSET, has_homsets_sortToHSET].
+Proof.
+mkpair.
++ mkpair.
+  admit.
+  admit.
++ admit.
+Admitted.
+
 Definition endo_fun (X : functor sortToHSET sortToHSET) (a : list sort × sort) : functor sortToHSET HSET.
 Proof.
 set (O := functor_composite (option_list (pr1 a)) X).

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -186,8 +186,13 @@ Defined.
 (*   - admit. *)
 (* Admitted. *)
 
-End functor_swap.
+(* Lemma test (C1 D1 : precategory) (C2 D2 : Precategory) (F : functor [C1,C2] [D1,D2]) *)
+(*   (HF : adj_equivalence_of_precats F) *)
+(*   (G : [C1,C2]) (HG : is_omega_cocont G) : *)
+(*   is_omega_cocont (F G). *)
+(* Admitted. *)
 
+End functor_swap.
 
 
 (** * Discrete precategories *)
@@ -229,8 +234,6 @@ mkpair.
 Defined.
 
 End DiscreteCategory.
-
-
 
 
 (** * Definition of multisorted binding signatures *)
@@ -443,7 +446,7 @@ Defined.
 (*     functor_composite (functor_cat_swap F) functor_cat_swap. *)
 
 Lemma is_omega_cocont_MultiSortedSigToFunctor_helper (C1 D E1 : precategory) (E2 : Precategory)
-  (F : functor E1 [C1,[D,E2]]) (HF : Π c, is_omega_cocont (F c)) :
+  (F : functor E1 [C1,[D,E2]]) (HF : Π s, is_omega_cocont (F s)) :
   is_omega_cocont (MultiSortedSigToFunctor_helper C1 D E1 E2 F).
 Proof.
 apply is_omega_cocont_functor_composite.
@@ -463,15 +466,16 @@ use (coproduct_of_functors (indices M s)).
 Defined.
 
 Lemma is_omega_cocont_MultiSortedSigToFunctor_fun
-  (M : MultiSortedSig) (CC : Π s, Coproducts (indices M s) C) (s : sort)
-  (CP : Products (indices M s) C)
-  (hs : isdeceq (indices M s))
+  (M : MultiSortedSig) (CC : Π s, Coproducts (indices M s) C)
+  (CP : Π s, Products (indices M s) C)
+  (hs : Π s, isdeceq (indices M s))
   (H : Π x : [sortToC, C], is_omega_cocont (constprod_functor1 BinProductsSortToCToC x)) :
-  is_omega_cocont (pr1 (MultiSortedSigToFunctor_fun M CC) s).
+  Π s, is_omega_cocont (pr1 (MultiSortedSigToFunctor_fun M CC) s).
 Proof.
+intros s.
 apply is_omega_cocont_coproduct_of_functors; try apply homset_property.
 + apply Products_functor_precat, Products_functor_precat, CP.
-+ assumption.
++ apply (hs s).
 + intros y; apply is_omega_cocont_exp_functors, H.
 Defined.
 
@@ -492,13 +496,11 @@ Lemma is_omega_cocont_MultiSortedSigToFunctor (M : MultiSortedSig)
   (H : Π x : [sortToC, C], is_omega_cocont (constprod_functor1 BinProductsSortToCToC x)) :
    is_omega_cocont (MultiSortedSigToFunctor M CC).
 Proof.
-unfold MultiSortedSigToFunctor.
-apply is_omega_cocont_MultiSortedSigToFunctor_helper.
-intros s; apply is_omega_cocont_MultiSortedSigToFunctor_fun.
-- apply PC.
-- apply Hi.
-- apply H.
-Defined.
+apply is_omega_cocont_functor_composite.
++ apply (homset_property [sortToC,sortToC]).
++ simpl. admit.
++ apply is_omega_cocont_functor_cat_swap.
+Admitted.
 
 End MBindingSig.
 

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -104,24 +104,57 @@ Definition args (M : MSig) (s : sort) : indices M s → list (list sort × sort)
 Local Notation "'1'" := (TerminalHSET).
 Local Notation "a ⊕ b" := (BinCoproductObject _ (BinCoproductsHSET a b)) (at level 50).
 
-Definition option : sort -> sortToHSET -> sortToHSET.
-Proof.
-intros s f.
-apply mk_sortToHSET; intro t.
-induction (eq s t) as [H|H].
-- apply (pr1 f t ⊕ 1). (* TODO: Can one add a coercion to make this look like sort -> Set *)
-- apply (pr1 f t).
-Defined.
+(* Definition option : sort -> sortToHSET -> sortToHSET. *)
+(* Proof. *)
+(* intros s f. *)
+(* apply mk_sortToHSET; intro t. *)
+(* induction (eq s t) as [H|H]. *)
+(* - apply (pr1 f t ⊕ 1). (* TODO: Can one add a coercion to make this look like sort -> Set *) *)
+(* - apply (pr1 f t). *)
+(* Defined. *)
 
-(* Maybe define this as a functor? *)
-Definition option_list (xs : list sort) : functor sortToHSET sortToHSET.
+Definition option_functor (s : sort) : functor sortToHSET sortToHSET.
 Proof.
 mkpair.
-+ mkpair.
-  - intro a; apply (foldr option a xs).
-  - admit.
-+ admit.
-Admitted.
+- mkpair.
++ intro f.
+apply mk_sortToHSET; intro t.
+induction (eq s t) as [H|H].
+* apply (pr1 f t ⊕ 1). (* TODO: Can one add a coercion to make this look like sort -> Set *)
+* apply (pr1 f t).
++
+intros F G α.
+mkpair.
+* simpl; intro t.
+induction (eq s t) as [p|p]; simpl; clear p.
+{ apply (coprodf (α t) (idfun unit)). }
+{ apply α. }
+* intros t1 t2 []; apply idpath.
+-
+simpl.
+split.
++ intros F; simpl in *.
+apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ has_homsets_HSET)|].
+simpl.
+apply funextsec; intro t.
+induction (eq s t) as [p|p]; trivial; simpl; clear p.
+now apply funextfun; intros [].
++
+intros F G H αFG αGH; simpl in *.
+apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ has_homsets_HSET)|].
+simpl.
+apply funextsec; intro t.
+induction (eq s t) as [p|p]; trivial; simpl; clear p.
+now apply funextfun; intros [].
+Defined.
+
+Definition option_list (xs : list sort) : functor sortToHSET sortToHSET.
+Proof.
+use (foldr _ _ xs).
++ intros s F.
+  apply (functor_composite (option_functor s) F).
++ apply functor_identity.
+Defined.
 
 Definition sortToHSETToHSET (s : sort) : functor sortToHSET HSET.
 Proof.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -42,6 +42,25 @@ Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
+Section preamble.
+
+Lemma functor_swap {C D E : precategory} {hsE : has_homsets E} :
+  functor C [D,E,hsE] → functor D [C,E,hsE].
+Admitted.
+
+Lemma functor_assoc1 {C D E F : precategory}
+  {hsD : has_homsets D } {hsE : has_homsets E} {hsF : has_homsets F} :
+  functor [[C,D,hsD],E,hsE] F → functor [C,D,hsD] [E,F,hsF].
+Admitted.
+
+Lemma functor_assoc2 {C D E F : precategory}
+  {hsD : has_homsets D } {hsE : has_homsets E} {hsF : has_homsets F} :
+  functor [C,D,hsD] [E,F,hsF] → functor [[C,D,hsD],E,hsE] F.
+Admitted.
+
+End preamble.
+
+
 Section DiscreteCategory.
 
 Variable (A : UU).
@@ -141,40 +160,40 @@ Local Notation "a ⊕ b" := (BinCoproductObject _ (BinCoproductsHSET a b)) (at l
 (* - apply (pr1 f t). *)
 (* Defined. *)
 
-Definition option_functor (s : sort) : functor sortToHSET sortToHSET.
+Definition option_functor_data  (s : sort) : functor_data sortToHSET sortToHSET.
 Proof.
 mkpair.
-- mkpair.
 + intro f.
-apply mk_sortToHSET; intro t.
-induction (eq s t) as [H|H].
-* apply (pr1 f t ⊕ 1). (* TODO: Can one add a coercion to make this look like sort -> Set *)
-* apply (pr1 f t).
-+
-intros F G α.
-mkpair.
-* simpl; intro t.
-induction (eq s t) as [p|p]; simpl; clear p.
-{ apply (coprodf (α t) (idfun unit)). }
-{ apply α. }
-* intros t1 t2 []; apply idpath.
--
-simpl.
+  apply mk_sortToHSET; intro t.
+  induction (eq s t) as [H|H].
+  * apply (pr1 f t ⊕ 1). (* TODO: Can one add a coercion to make this look like sort -> Set *)
+  * apply (pr1 f t).
++ intros F G α.
+  mkpair.
+  * simpl; intro t.
+    induction (eq s t) as [p|p]; simpl; clear p.
+    { apply (coprodf (α t) (idfun unit)). }
+    { apply α. }
+  * abstract (intros t1 t2 []; apply idpath).
+Defined.
+
+Lemma is_functor_option_functor s : is_functor (option_functor_data s).
+Proof.
 split.
 + intros F; simpl in *.
-apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ has_homsets_HSET)|].
-simpl.
-apply funextsec; intro t.
-induction (eq s t) as [p|p]; trivial; simpl; clear p.
-now apply funextfun; intros [].
-+
-intros F G H αFG αGH; simpl in *.
-apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ has_homsets_HSET)|].
-simpl.
-apply funextsec; intro t.
-induction (eq s t) as [p|p]; trivial; simpl; clear p.
-now apply funextfun; intros [].
-Defined.
+  apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ has_homsets_HSET)|]; simpl.
+  apply funextsec; intro t.
+  induction (eq s t) as [p|p]; trivial; simpl; clear p.
+  now apply funextfun; intros [].
++ intros F G H αFG αGH; simpl in *.
+  apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ has_homsets_HSET)|]; simpl.
+  apply funextsec; intro t.
+  induction (eq s t) as [p|p]; trivial; simpl; clear p.
+  now apply funextfun; intros [].
+Qed.
+
+Definition option_functor (s : sort) : functor sortToHSET sortToHSET :=
+  tpair _ _ (is_functor_option_functor s).
 
 Definition option_list (xs : list sort) : functor sortToHSET sortToHSET.
 Proof.
@@ -184,6 +203,7 @@ use (foldr _ _ xs).
 + apply functor_identity.
 Defined.
 
+(** This applies the sortToHSET to s *)
 Definition sortToHSETToHSET (s : sort) : functor sortToHSET HSET.
 Proof.
 mkpair.
@@ -194,15 +214,6 @@ mkpair.
     [ now intros f; apply funextsec
     | now intros f g h fg gh; apply funextsec; intro x ]).
 Defined.
-
-(* Definition sortToHSETToHSet' : [sortToHSET, sortToHSET, has_homsets_sortToHSET]. *)
-(* Proof. *)
-(* mkpair. *)
-(* + mkpair. *)
-(*   admit. *)
-(*   admit. *)
-(* + admit. *)
-(* Admitted. *)
 
 Definition endo_fun (X : functor sortToHSET sortToHSET) (a : list sort × sort) :
   functor sortToHSET HSET.
@@ -249,54 +260,43 @@ Admitted.
 (*   (H : functor sortToHSET sortToHSET → sortToHSET → sort → HSET) : *)
 (*  functor [sortToHSET, sortToHSET, has_homsets_sortToHSET] *)
 (*          [sortToHSET, sortToHSET, has_homsets_sortToHSET]. *)
-(* Proof. *)
-(* mkpair. *)
-(* + mkpair. *)
-(*   - intro X. *)
-(*     mkpair. *)
-(*     * mkpair. *)
-(*     { intro f. *)
-(*       apply mk_sortToHSET; intro s. *)
-(*       apply (H X f s). *)
-(*     } *)
-(*       simpl. *)
 
 Lemma asdf : has_homsets [sortToHSET,HSET,has_homsets_HSET].
 Proof.
 apply functor_category_has_homsets.
 Qed.
 
-Lemma lol (D : precategory)
-  (H : functor sort_cat [D,HSET,has_homsets_HSET]) :
-  functor D sortToHSET.
-Proof.
-mkpair.
-- mkpair.
-+ intros f.
-  apply mk_sortToHSET.
-  intro s.
-  apply (pr1 (H s) f).
-+ intros F G α.
-mkpair.
-* intros s.
-  apply (# (pr1 (H s)) α).
-*
-intros s t []; clear t.
-eapply pathscomp0.
-apply (id_left (# (pr1 (H s)) α)).
-apply pathsinv0.
-apply (id_right (# (pr1 (H s)) α)).
-- split.
-+ intro F.
-apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ has_homsets_HSET)|].
-apply funextsec; intro s.
-apply (functor_id ( (H s))).
-+
-intros F1 F2 F3 α12 α23.
-apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ has_homsets_HSET)|].
-apply funextsec; intro s.
-apply (functor_comp (H s)).
-Admitted. (* Defined is very slow... *)
+(* Lemma lol (D : precategory) *)
+(*   (H : functor sort_cat [D,HSET,has_homsets_HSET]) : *)
+(*   functor D sortToHSET. *)
+(* Proof. *)
+(* mkpair. *)
+(* - mkpair. *)
+(* + intros f. *)
+(*   apply mk_sortToHSET. *)
+(*   intro s. *)
+(*   apply (pr1 (H s) f). *)
+(* + intros F G α. *)
+(* mkpair. *)
+(* * intros s. *)
+(*   apply (# (pr1 (H s)) α). *)
+(* * *)
+(* intros s t []; clear t. *)
+(* eapply pathscomp0. *)
+(* apply (id_left (# (pr1 (H s)) α)). *)
+(* apply pathsinv0. *)
+(* apply (id_right (# (pr1 (H s)) α)). *)
+(* - split. *)
+(* + intro F. *)
+(* apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ has_homsets_HSET)|]. *)
+(* apply funextsec; intro s. *)
+(* apply (functor_id ( (H s))). *)
+(* + *)
+(* intros F1 F2 F3 α12 α23. *)
+(* apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ has_homsets_HSET)|]. *)
+(* apply funextsec; intro s. *)
+(* apply (functor_comp (H s)). *)
+(* Admitted. (* Defined is very slow... *) *)
 
 
 Definition lol2
@@ -304,7 +304,11 @@ Definition lol2
                sortToHSET) :
  functor [sortToHSET, sortToHSET, has_homsets_sortToHSET]
          [sortToHSET, sortToHSET, has_homsets_sortToHSET].
-Admitted.
+Proof.
+use functor_assoc1.
+- apply has_homsets_sortToHSET.
+- assumption.
+Defined.
 
 Definition MSigToFunctor_helper
   (* (H : functor sort_cat *)
@@ -320,7 +324,7 @@ Definition MSigToFunctor_helper
          [sortToHSET, sortToHSET, has_homsets_sortToHSET].
 Proof.
 apply lol2.
-apply lol.
+apply functor_swap.
 apply H.
 Defined.
 (* mkpair. *)
@@ -364,7 +368,9 @@ intro s.
 use (coproduct_of_functors (indices M s)).
 + admit.
 + intros y.
-  generalize (endo_funs_functor (args M s y)).
+  use functor_assoc2.
+  - apply has_homsets_HSET.
+  - apply (endo_funs_functor (args M s y)).
 Admitted.
 
 

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -47,37 +47,36 @@ Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
 Local Notation "[ C , D ]" := (functor_Precategory C D).
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
-Section move_upstream.
+(* Section move_upstream. *)
 
+(* Definition head {A : UU} (a : A) (xs : list A) : A. *)
+(* Proof. *)
+(* induction xs as [n xs]. *)
+(* destruct n. *)
+(* - apply a. *)
+(* - simpl in xs. *)
+(*   apply (pr1 xs). *)
+(* Defined. *)
 
-Definition head {A : UU} (a : A) (xs : list A) : A.
-Proof.
-induction xs as [n xs].
-destruct n.
-- apply a.
-- simpl in xs.
-  apply (pr1 xs).
-Defined.
+(* Lemma foldr1_ind {A : UU} (P : A -> UU) (f : A -> A -> A) (a : A) (Ha : P a) : *)
+(*   Π xs, P (foldr1 f (head a xs) xs) → P (foldr1 f a xs). *)
+(* Proof. *)
+(* intros xs. *)
+(* use (list_ind (fun xs =>  P (foldr1 f (head a xs) xs) → P (foldr1 f a xs))); clear xs. *)
+(* - intros _; apply Ha. *)
+(* - *)
+(* intros x xs IH. *)
+(* intros H. *)
+(* destruct xs as [n xs]. *)
+(* destruct n. *)
+(* + destruct xs. *)
+(* simpl. *)
+(* simpl in *. *)
+(* apply H. *)
+(* + apply H. *)
+(* Defined. *)
 
-Lemma foldr1_ind {A : UU} (P : A -> UU) (f : A -> A -> A) (a : A) (Ha : P a) :
-  Π xs, P (foldr1 f (head a xs) xs) → P (foldr1 f a xs).
-Proof.
-intros xs.
-use (list_ind (fun xs =>  P (foldr1 f (head a xs) xs) → P (foldr1 f a xs))); clear xs.
-- intros _; apply Ha.
--
-intros x xs IH.
-intros H.
-destruct xs as [n xs].
-destruct n.
-+ destruct xs.
-simpl.
-simpl in *.
-apply H.
-+ apply H.
-Defined.
-
-End move_upstream.
+(* End move_upstream. *)
 
 (** Swapping of functor arguments *)
 (* TODO: Move upstream? *)
@@ -113,36 +112,6 @@ Defined.
 (* Lemma is_omega_cocont_functor_swap *)
 (*   (F : functor C [D,E]) (HF : forall c, is_omega_cocont (F c)) : *)
 (*    is_omega_cocont (functor_swap F). *)
-(* Proof. *)
-(* intros d L ccL HccL G ccG. *)
-(* simpl in G. *)
-(* transparent assert (temp : (Π c, cocone (mapdiagram (F c) d) (G c))). *)
-(* { intro c; use mk_cocone. *)
-(*   + simpl; intro n. *)
-(*     apply (pr1 (coconeIn ccG n) c). *)
-(*   + abstract (intros m n e; apply (nat_trans_eq_pointwise (coconeInCommutes ccG _ _ e) c)). *)
-(* } *)
-(* transparent assert (apa : (nat_trans (pr1 (functor_swap F L)) G)). *)
-(* + intro c. *)
-(* apply (HF c d L ccL HccL (G c) (temp c)). *)
-(* + apply H. intros x y f. *)
-(* simpl. *)
-(* } *)
-(* mkpair. *)
-(* + mkpair. *)
-(* - mkpair. *)
-(* * intro c. *)
-(* simpl. *)
-(* apply apa. *)
-(* (* simpl. *) *)
-(* (* apply (HF c d L ccL HccL (G c) (temp c)). *) *)
-(* * intros x y f; simpl. *)
-(* (* destruct (HF y d L ccL HccL (G y) (temp y)) as [[hy1 hy2] hy3]. *) *)
-(* (* destruct (HF x d L ccL HccL (G x) (temp x)) as [[hx1 hx2] hx3]. *) *)
-(* apply (nat_trans_ax apa x y f). *)
-(* - admit. *)
-(* + admit. *)
-(* Admitted. *)
 
 Lemma functor_cat_swap_nat_trans (F G : functor C [D, E]) (α : nat_trans F G) :
   nat_trans (functor_swap F) (functor_swap G).
@@ -270,24 +239,20 @@ Local Notation "'1'" := (TerminalObject TC).
 Local Notation "a ⊕ b" := (BinCoproductObject _ (BC a b)) (at level 50).
 
 (* Code for option as a function, below is the definition as a functor *)
-(* Definition option : sort -> sortToC -> sortToC. *)
-(* Proof. *)
-(* intros s f. *)
-(* apply mk_sortToC; intro t. *)
-(* induction (eq s t) as [H|H]. *)
-(* - apply (pr1 f t ⊕ 1). *)
-(* - apply (pr1 f t). *)
-(* Defined. *)
+Definition option_fun : sort -> sortToC -> sortToC.
+Proof.
+intros s f.
+apply mk_sortToC; intro t.
+induction (eq s t) as [H|H].
+- apply (pr1 f t ⊕ 1).
+- apply (pr1 f t).
+Defined.
 
 (* The function part of Definition 3 *)
 Definition option_functor_data  (s : sort) : functor_data sortToC sortToC.
 Proof.
 mkpair.
-+ intro f.
-  apply mk_sortToC; intro t.
-  induction (eq s t) as [H|H].
-  * apply (pr1 f t ⊕ 1).
-  * apply (pr1 f t).
++ apply (option_fun s).
 + intros F G α.
   mkpair.
   * simpl; intro t.
@@ -337,9 +302,9 @@ apply (functor_composite (option_list (pr1 a))
                          (functor_composite X (sortToCToC (pr2 a)))).
 Defined.
 
-Lemma is_omega_cocont_exp_fun (X : functor sortToC sortToC) (a : list sort × sort) :
-  is_omega_cocont (exp_fun X a).
-Admitted.
+(* Lemma is_omega_cocont_exp_fun (X : functor sortToC sortToC) (a : list sort × sort) : *)
+(*   is_omega_cocont (exp_fun X a). *)
+(* Admitted. *)
 
 (* This stops Coq from unfolding horcomp too much *)
 Local Arguments horcomp : simpl never.
@@ -366,8 +331,8 @@ mkpair.
     now rewrite (pre_whisker_composition _ _ _ hsC)]).
 Defined.
 
-Lemma  is_omega_cocont_exp_functor a : is_omega_cocont (exp_functor a).
-Admitted.
+(* Lemma  is_omega_cocont_exp_functor a : is_omega_cocont (exp_functor a). *)
+(* Admitted. *)
 
 (* First version: *)
 (* Definition exp_funs (xs : list (list sort × sort)) (X : functor sortToC sortToC) : *)
@@ -393,35 +358,31 @@ set (T := constant_functor [sortToC,sortToC] [sortToC,C]
 apply (foldr1 (fun F G => BinProduct_of_functors _ _ BinProductsSortToCToC F G) T XS).
 Defined.
 
-(* Lemma exp_functor_cons x xs : *)
-(*   exp_functors (cons x xs) = BinProduct_of_functors _ _ BinProductsSortToCToC F (exp_functors G). *)
-
-Lemma is_omega_cocont_exp_functors (xs : list (list sort × sort)) :
-  is_omega_cocont (exp_functors xs).
-Proof.
-use (list_ind (fun xs => is_omega_cocont (exp_functors xs)) _ _ xs); simpl; clear xs.
-- apply is_omega_cocont_constant_functor.
-  apply (functor_category_has_homsets sortToC).
-- intros x xs.
-use (list_ind (fun xs => is_omega_cocont (exp_functors xs) -> is_omega_cocont (exp_functors (cons x xs))) _ _ xs); simpl; clear xs.
-
-+ intros _. unfold exp_functors.
-rewrite map_cons, map_nil.
-rewrite foldr1_cons_nil.
-apply is_omega_cocont_exp_functor.
-+
-intros y xs Hxs Hys.
-unfold exp_functors.
-rewrite !map_cons.
-rewrite foldr1_cons.
-apply is_omega_cocont_BinProduct_of_functors.
-admit.
-admit.
-admit.
-admit.
-apply is_omega_cocont_exp_functor.
-admit.
-Admitted.
+(* Lemma is_omega_cocont_exp_functors (xs : list (list sort × sort)) : *)
+(*   is_omega_cocont (exp_functors xs). *)
+(* Proof. *)
+(* use (list_ind (fun xs => is_omega_cocont (exp_functors xs)) _ _ xs); simpl; clear xs. *)
+(* - apply is_omega_cocont_constant_functor. *)
+(*   apply (functor_category_has_homsets sortToC). *)
+(* - intros x xs. *)
+(* use (list_ind (fun xs => is_omega_cocont (exp_functors xs) -> is_omega_cocont (exp_functors (cons x xs))) _ _ xs); simpl; clear xs. *)
+(* + intros _. unfold exp_functors. *)
+(* rewrite map_cons, map_nil. *)
+(* rewrite foldr1_cons_nil. *)
+(* apply is_omega_cocont_exp_functor. *)
+(* + *)
+(* intros y xs Hxs Hys. *)
+(* unfold exp_functors. *)
+(* rewrite !map_cons. *)
+(* rewrite foldr1_cons. *)
+(* apply is_omega_cocont_BinProduct_of_functors. *)
+(* admit. *)
+(* admit. *)
+(* admit. *)
+(* admit. *)
+(* apply is_omega_cocont_exp_functor. *)
+(* admit. *)
+(* Admitted. *)
 
 (* This lemma is just here to check that the correct sort_cat gets pulled out when reorganizing
    arguments *)
@@ -429,24 +390,10 @@ Local Definition MultiSortedSigToFunctor_helper (C1 D E1 : precategory) (C2 E2 :
   (F : functor E1 [[C1,C2],[D,E2]]) : functor [C1,C2] [D,[E1,E2]] :=
     functor_composite (functor_cat_swap F) functor_cat_swap.
 
-Lemma is_omega_cocont_MultiSortedSigToFunctor_helper (C1 D E1 : precategory) (C2 E2 : Precategory)
-  (F : functor E1 [[C1,C2],[D,E2]]) (HF : Π c, is_omega_cocont (F c)) :
-  is_omega_cocont (MultiSortedSigToFunctor_helper C1 D E1 C2 E2 F).
-Proof.
-(* unfold MultiSortedSigToFunctor_helper. *)
-(* intros diag L ccL HccL G ccG. *)
-(* mkpair. *)
-(* + mkpair. *)
-(* mkpair. *)
-(* - *)
-(* intro d. *)
-(* mkpair. *)
-(* * *)
-(* intro e1. *)
-(* simpl. *)
-(* generalize (HF e1 diag L ccL HccL (functor_swap G e1)). *)
-(* simpl. *)
-Admitted.
+(* Lemma is_omega_cocont_MultiSortedSigToFunctor_helper (C1 D E1 : precategory) (C2 E2 : Precategory) *)
+(*   (F : functor E1 [[C1,C2],[D,E2]]) (HF : Π c, is_omega_cocont (F c)) : *)
+(*   is_omega_cocont (MultiSortedSigToFunctor_helper C1 D E1 C2 E2 F). *)
+(* Admitted. *)
 
 Definition MultiSortedSigToFunctor_fun (M : MultiSortedSig) (CC : Π s, Coproducts (indices M s) C) (s : sort) :
   [[sortToC, sortToC], [sortToC, C]].
@@ -456,17 +403,17 @@ use (coproduct_of_functors (indices M s)).
 + intros y; apply (exp_functors (args M s y)).
 Defined.
 
-Lemma is_omega_cocont_MultiSortedSigToFunctor_fun
- (M : MultiSortedSig) (CC : Π s, Coproducts (indices M s) C) (s : sort)
- (CP : Products (indices M s) C)
- (hs : isdeceq (indices M s)) :
- is_omega_cocont (MultiSortedSigToFunctor_fun M CC s).
-Proof.
-apply is_omega_cocont_coproduct_of_functors; try apply homset_property.
-+ apply Products_functor_precat, Products_functor_precat, CP.
-+ assumption.
-+ intros y; apply is_omega_cocont_exp_functors.
-Defined.
+(* Lemma is_omega_cocont_MultiSortedSigToFunctor_fun *)
+(*  (M : MultiSortedSig) (CC : Π s, Coproducts (indices M s) C) (s : sort) *)
+(*  (CP : Products (indices M s) C) *)
+(*  (hs : isdeceq (indices M s)) : *)
+(*  is_omega_cocont (MultiSortedSigToFunctor_fun M CC s). *)
+(* Proof. *)
+(* apply is_omega_cocont_coproduct_of_functors; try apply homset_property. *)
+(* + apply Products_functor_precat, Products_functor_precat, CP. *)
+(* + assumption. *)
+(* + intros y; apply is_omega_cocont_exp_functors. *)
+(* Defined. *)
 
 (** * The functor constructed from a multisorted binding signature *)
 Definition MultiSortedSigToFunctor (M : MultiSortedSig) (CC : Π s, Coproducts (indices M s) C) :
@@ -479,17 +426,17 @@ apply functor_discrete_precategory; intro s.
 apply (MultiSortedSigToFunctor_fun M CC s).
 Defined.
 
-Lemma is_omega_cocont_MultiSortedSigToFunctor (M : MultiSortedSig)
-  (CC : Π s, Coproducts (indices M s) C)
-  (PC : Π s, Products (indices M s) C)
-  (Hi : Π s, isdeceq (indices M s)) :
-   is_omega_cocont (MultiSortedSigToFunctor M CC).
-Proof.
-apply is_omega_cocont_MultiSortedSigToFunctor_helper.
-intros s; apply is_omega_cocont_MultiSortedSigToFunctor_fun.
-- apply PC.
-- apply Hi.
-Defined.
+(* Lemma is_omega_cocont_MultiSortedSigToFunctor (M : MultiSortedSig) *)
+(*   (CC : Π s, Coproducts (indices M s) C) *)
+(*   (PC : Π s, Products (indices M s) C) *)
+(*   (Hi : Π s, isdeceq (indices M s)) : *)
+(*    is_omega_cocont (MultiSortedSigToFunctor M CC). *)
+(* Proof. *)
+(* apply is_omega_cocont_MultiSortedSigToFunctor_helper. *)
+(* intros s; apply is_omega_cocont_MultiSortedSigToFunctor_fun. *)
+(* - apply PC. *)
+(* - apply Hi. *)
+(* Defined. *)
 (* use is_omega_cocont_functor_composite. *)
 (* + apply (functor_category_has_homsets sortToC). *)
 (* + apply is_omega_cocont_functor_swap. *)

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -1,0 +1,96 @@
+(**
+
+Definition of multisorted binding signatures.
+
+Written by: Anders Mörtberg, 2016
+
+*)
+
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Combinatorics.Lists.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.limits.graphs.limits.
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.limits.binproducts.
+Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.limits.bincoproducts.
+Require Import UniMath.CategoryTheory.limits.coproducts.
+Require Import UniMath.CategoryTheory.limits.terminal.
+Require Import UniMath.CategoryTheory.limits.initial.
+Require Import UniMath.CategoryTheory.FunctorAlgebras.
+Require Import UniMath.CategoryTheory.exponentials.
+Require Import UniMath.CategoryTheory.CocontFunctors.
+Require Import UniMath.CategoryTheory.Monads.
+Require Import UniMath.CategoryTheory.category_hset.
+Require Import UniMath.CategoryTheory.category_hset_structures.
+
+Require Import UniMath.SubstitutionSystems.Signatures.
+Require Import UniMath.SubstitutionSystems.SignatureExamples.
+Require Import UniMath.SubstitutionSystems.SumOfSignatures.
+Require Import UniMath.SubstitutionSystems.BinProductOfSignatures.
+Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
+Require Import UniMath.SubstitutionSystems.LiftingInitial.
+Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
+Require Import UniMath.SubstitutionSystems.Notation.
+
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
+
+Section DiscreteCategory.
+
+Variable (A : UU).
+
+Definition DiscretePrecategory : precategory.
+Proof.
+use tpair.
+- use tpair.
+use tpair.
+apply A.
+simpl.
+intros a b.
+apply (a = b).
+use tpair.
+simpl.
+intro a; apply idpath.
+simpl.
+intros a b c h1 h2.
+apply (pathscomp0 h1 h2).
+- split. split; trivial.
+simpl.
+intros a b f.
+apply pathscomp0rid.
+simpl.
+intros.
+apply path_assoc.
+Defined.
+
+Lemma has_homsets_DiscretePrecategory (H : isofhlevel 3 A) : has_homsets DiscretePrecategory.
+Proof.
+simpl.
+unfold has_homsets.
+intros.
+simpl in *.
+unfold isaset in *.
+intros h1 h2.
+unfold isaprop.
+simpl.
+apply H.
+Defined.
+
+End DiscreteCategory.
+
+(** * Definition of multisorted binding signatures *)
+Section MBindingSig.
+
+Variable sort : UU.
+
+Let Dsort := DiscretePrecategory sort.
+
+Let C := [Dsort,HSET,has_homsets_HSET].
+
+
+
+End MBindingSig.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -1,11 +1,16 @@
 (**
 
-Definition of multisorted binding signatures.
+This file formalizes multisorted binding signatures:
 
-Written by: Anders Mörtberg, 2016
+- Definition of multisorted binding signatures ([MultiSortedSig])
+- Construction of a functor from a multisorted binding signature ([MultiSortedSigToFunctor])
+
+
+
+Written by: Anders Mörtberg, 2016. The formalization follows a note written by Benedikt Ahrens and
+Ralph Matthes, and is also inspired by discussions with them and Vladimir Voevodsky.
 
 *)
-
 Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.Foundations.Basics.Sets.
 Require Import UniMath.Foundations.Combinatorics.Lists.
@@ -37,7 +42,6 @@ Require Import UniMath.SubstitutionSystems.BinProductOfSignatures.
 Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.LiftingInitial.
 Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
-(* Require Import UniMath.SubstitutionSystems.Notation. *)
 
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
@@ -54,7 +58,9 @@ Qed.
 
 End move_upstream.
 
-Section preamble.
+(** Swapping of functor arguments *)
+(* TODO: Move upstream as well? *)
+Section functor_swap.
 
 Context {C D E : precategory} {hsE : has_homsets E}.
 
@@ -68,10 +74,10 @@ mkpair.
     - mkpair.
       + intro c.
         apply (pr1 (F c) d).
-        + intros a b f; apply (# F f).
-          - abstract (split;
-            [ now intro x; simpl; rewrite (functor_id F)
-            | now intros a b c f g; simpl; rewrite (functor_comp F)]).
+      + intros a b f; apply (# F f).
+    - abstract (split;
+      [ now intro x; simpl; rewrite (functor_id F)
+      | now intros a b c f g; simpl; rewrite (functor_comp F)]).
   }
   + intros a b f; simpl.
   { mkpair.
@@ -87,12 +93,14 @@ mkpair.
     apply funextsec; intro x; apply functor_comp ]).
 Defined.
 
-Lemma functor_cat_swap : functor [C, [D, E, hsE], functor_category_has_homsets _ _ hsE]
-                                 [D, [C, E, hsE], functor_category_has_homsets _ _ hsE].
+(* Lift the result to functor categories. It might be good to decompose this proof as the natural
+transformations constructed might be useful later *)
+Lemma functor_cat_swap :
+  functor [C, [D, E, hsE], functor_category_has_homsets _ _ hsE]
+          [D, [C, E, hsE], functor_category_has_homsets _ _ hsE].
 Proof.
 mkpair.
-- apply (tpair _ functor_swap); simpl.
-  intros F G α.
+- apply (tpair _ functor_swap); simpl; intros F G α.
   mkpair.
   + intros d; simpl.
     mkpair.
@@ -112,34 +120,45 @@ mkpair.
     now apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ hsE) |]]).
 Defined.
 
-End preamble.
+End functor_swap.
 
-(** * Discrete categories *)
+(** * Discrete precategories *)
 Section DiscreteCategory.
 
 Variable (A : UU).
 
-Definition DiscPrecat_data : precategory_data.
+Definition DiscretePrecategory_data : precategory_data.
 Proof.
 mkpair.
 - apply (A,,paths).
 - mkpair; [ apply idpath | apply @pathscomp0 ].
 Defined.
 
-Definition is_precategory_DiscPrecat_data : is_precategory DiscPrecat_data.
+Definition is_precategory_DiscretePrecategory_data : is_precategory DiscretePrecategory_data.
 Proof.
 split; [split|]; trivial; intros.
 + apply pathscomp0rid.
 + apply path_assoc.
 Qed.
 
-Definition DiscPrecat : precategory :=
-  (DiscPrecat_data,,is_precategory_DiscPrecat_data).
+Definition DiscretePrecategory : precategory :=
+  (DiscretePrecategory_data,,is_precategory_DiscretePrecategory_data).
 
-Lemma has_homsets_DiscPrecat (H : isofhlevel 3 A) : has_homsets DiscPrecat.
+Lemma has_homsets_DiscretePrecategory (H : isofhlevel 3 A) : has_homsets DiscretePrecategory.
 Proof.
 intros ? ? ? ? ? ?; apply H.
 Qed.
+
+(** To define a functor out of a discrete category it suffices to give a function *)
+Lemma functor_DiscretePrecategory (D : precategory) (f : A → D) :
+  functor DiscretePrecategory D.
+Proof.
+mkpair.
++ mkpair.
+  - apply f.
+  - intros s t []; apply identity.
++ abstract (now split; [intro|intros a b c [] []; simpl; rewrite id_left]).
+Defined.
 
 End DiscreteCategory.
 
@@ -149,10 +168,13 @@ Section MBindingSig.
 Variable (sort : UU).
 Variable (eq : isdeceq sort). (* Can we eliminate this assumption? *)
 
-Let sort_cat : precategory := DiscPrecat sort.
+(** Define the discrete category of sorts *)
+Let sort_cat : precategory := DiscretePrecategory sort.
+
+(** This represents "sort → HSET" *)
 Let sortToHSET : precategory := [sort_cat,HSET,has_homsets_HSET].
 
-Lemma has_homsets_sortToHSET : has_homsets sortToHSET.
+Local Lemma has_homsets_sortToHSET : has_homsets sortToHSET.
 Proof.
 apply functor_category_has_homsets.
 Qed.
@@ -162,69 +184,60 @@ Proof.
 apply (BinProducts_functor_precat _ _ BinProductsHSET).
 Defined.
 
-Local Definition CoproductsSortToHSET I (hI : isaset I) : Coproducts I sortToHSET.
-Proof.
-now apply Coproducts_functor_precat, Coproducts_HSET.
-Defined.
+Definition mk_sortToHSET (f : sort → HSET) : sortToHSET :=
+  functor_DiscretePrecategory _ _ f.
 
-Local Definition CoproductsSortToHSET2 I (hI : isaset I) :
-  Coproducts I [sortToHSET, sortToHSET, has_homsets_sortToHSET].
-Proof.
-now apply Coproducts_functor_precat, CoproductsSortToHSET.
-Defined.
-
-Lemma functor_sort_cat (D : precategory) (f : sort → D) : functor sort_cat D.
+(** Given a sort s this applies the sortToHSET to s and returns HSET *)
+Definition sortToHSETToHSET (s : sort) : functor sortToHSET HSET.
 Proof.
 mkpair.
 + mkpair.
-  - apply f.
-  - intros s t []; apply identity.
-+ abstract (now split; [intro|intros a b c [] []; simpl; rewrite id_left]).
+  - intro f; apply (pr1 f s).
+  - simpl; intros a b f H; apply (f s H).
++ abstract (split;
+    [ now intros f; apply funextsec
+    | now intros f g h fg gh; apply funextsec; intro x ]).
 Defined.
 
-Definition mk_sortToHSET (f : sort → HSET) : sortToHSET.
-Proof.
-apply (functor_sort_cat _ f).
-(* mkpair. *)
-(* + apply (tpair _ f). *)
-(*   intros a b hab; simpl; apply (transportf f hab). *)
-(* + abstract (now split; [ intros a; apply idpath | intros a b c [] [] ]). *)
-Defined.
 
-(* Coercion sortToHsetToFun (s : sortToHSET) : sort → HSET := pr1 s. *)
 
-Definition MSig : UU :=
+(** Definition of multi sorted signatures *)
+Definition MultiSortedSig : UU :=
   Π (s : sort), Σ (I : UU), (I → list (list sort × sort)) × (isaset I).
 
-Definition indices (M : MSig) : sort → UU := fun s => pr1 (M s).
+Definition indices (M : MultiSortedSig) : sort → UU := fun s => pr1 (M s).
 
-Definition args (M : MSig) (s : sort) : indices M s → list (list sort × sort) :=
+Definition args (M : MultiSortedSig) (s : sort) : indices M s → list (list sort × sort) :=
   pr1 (pr2 (M s)).
 
-Lemma isaset_indices (M : MSig) (s : sort) : isaset (indices M s).
+Lemma isaset_indices (M : MultiSortedSig) (s : sort) : isaset (indices M s).
 Proof.
 apply (pr2 (pr2 (M s))).
 Qed.
 
+
+
 Local Notation "'1'" := (TerminalHSET).
 Local Notation "a ⊕ b" := (BinCoproductObject _ (BinCoproductsHSET a b)) (at level 50).
 
+(* Code for option as a function, below is the definition as a functor *)
 (* Definition option : sort -> sortToHSET -> sortToHSET. *)
 (* Proof. *)
 (* intros s f. *)
 (* apply mk_sortToHSET; intro t. *)
 (* induction (eq s t) as [H|H]. *)
-(* - apply (pr1 f t ⊕ 1). (* TODO: Can one add a coercion to make this look like sort -> Set *) *)
+(* - apply (pr1 f t ⊕ 1). *)
 (* - apply (pr1 f t). *)
 (* Defined. *)
 
+(* The function part of Definition 3 *)
 Definition option_functor_data  (s : sort) : functor_data sortToHSET sortToHSET.
 Proof.
 mkpair.
 + intro f.
   apply mk_sortToHSET; intro t.
   induction (eq s t) as [H|H].
-  * apply (pr1 f t ⊕ 1). (* TODO: Can one add a coercion to make this look like sort -> Set *)
+  * apply (pr1 f t ⊕ 1).
   * apply (pr1 f t).
 + intros F G α.
   mkpair.
@@ -250,9 +263,11 @@ split.
   now apply funextfun; intros [].
 Qed.
 
+(* This is Definition 3 (sorted context extension) from the note *)
 Definition option_functor (s : sort) : functor sortToHSET sortToHSET :=
   tpair _ _ (is_functor_option_functor s).
 
+(* option_functor for lists (also called option in the note) *)
 Definition option_list (xs : list sort) : functor sortToHSET sortToHSET.
 Proof.
 use (foldr _ _ xs).
@@ -261,100 +276,94 @@ use (foldr _ _ xs).
 + apply functor_identity.
 Defined.
 
-(** This applies the sortToHSET to s and returns HSET *)
-Definition sortToHSETToHSET (s : sort) : functor sortToHSET HSET.
-Proof.
-mkpair.
-+ mkpair.
-  - intro f; apply (pr1 f s).
-  - simpl; intros a b f H; apply (f s H).
-+ abstract (split;
-    [ now intros f; apply funextsec
-    | now intros f g h fg gh; apply funextsec; intro x ]).
-Defined.
-
-Definition endo_fun (X : functor sortToHSET sortToHSET) (a : list sort × sort) :
+(* This is X^a, defined as a function *)
+Definition exp_fun (X : functor sortToHSET sortToHSET) (a : list sort × sort) :
   functor sortToHSET HSET.
 Proof.
 (* Version 1: *)
 (* apply (functor_composite (functor_composite (option_list (pr1 a)) X) *)
 (*                          (sortToHSETToHSET (pr2 a))). *)
 
-(* same thing but different associativity: *)
+(* Version 2: (same thing but reorganized using associativity) *)
 apply (functor_composite (option_list (pr1 a))
                          (functor_composite X (sortToHSETToHSET (pr2 a)))).
 Defined.
 
+(* This stops Coq from unfolding hor_comp too much *)
 Local Arguments hor_comp : simpl never.
 
-Lemma endo_fun_functor (a : list sort × sort) :
+(* This is X^a as a functor between functor categories *)
+Lemma exp_functor (a : list sort × sort) :
   functor [sortToHSET,sortToHSET,has_homsets_sortToHSET]
           [sortToHSET,HSET,has_homsets_HSET].
 Proof.
 mkpair.
 - mkpair.
-  + intro X.
-    apply (endo_fun X a).
+  + intro X; apply (exp_fun X a).
   + intros F G α.
-    use (@hor_comp sortToHSET _ HSET).
-    * apply (nat_trans_id _).
-    * use hor_comp; [ assumption | apply nat_trans_id ].
-- split.
-+ intro F; simpl in *.
-  repeat rewrite horcomp_id_postwhisker, post_whisker_identity; trivial;
-    try apply has_homsets_HSET; try apply has_homsets_sortToHSET.
-+ intros F G H α β. simpl in *.
-rewrite !horcomp_id_postwhisker;
-  try apply has_homsets_HSET; try apply has_homsets_sortToHSET.
-eapply pathscomp0.
-eapply maponpaths.
-apply (post_whisker_composition sortToHSET _ _ has_homsets_HSET (sortToHSETToHSET (pr2 a))).
-eapply pathscomp0.
-apply (@horcomp_id_prewhisker sortToHSET sortToHSET HSET has_homsets_HSET  (option_list (pr1 a)) (functor_composite F (sortToHSETToHSET (pr2 a))) (functor_composite H (sortToHSETToHSET (pr2 a)))).
-rewrite (pre_whisker_composition _ _ _ has_homsets_HSET).
-now rewrite !(horcomp_id_prewhisker has_homsets_HSET (option_list (pr1 a))).
+    use (@hor_comp sortToHSET _ HSET _ _ _ _ (nat_trans_id _)).
+    use hor_comp; [ assumption | apply nat_trans_id ].
+- abstract (split;
+  [ intro F; cbn;
+    rewrite (horcomp_id_postwhisker _ _ _ has_homsets_sortToHSET has_homsets_HSET);
+    rewrite post_whisker_identity; try apply has_homsets_HSET;
+    rewrite (horcomp_id_postwhisker _ _ _ has_homsets_sortToHSET has_homsets_HSET);
+    now rewrite post_whisker_identity; try apply has_homsets_HSET
+  | intros F G H α β; cbn;
+    rewrite !(horcomp_id_postwhisker _ _ _ has_homsets_sortToHSET has_homsets_HSET);
+    rewrite !(horcomp_id_prewhisker has_homsets_HSET (option_list (pr1 a)));
+    rewrite (post_whisker_composition sortToHSET _ _ has_homsets_HSET (sortToHSETToHSET (pr2 a)));
+    now rewrite (pre_whisker_composition _ _ _ has_homsets_HSET)]).
 Defined.
 
-(* Definition endo_funs (xs : list (list sort × sort)) (X : functor sortToHSET sortToHSET) : *)
+(* First version: *)
+(* Definition exp_funs (xs : list (list sort × sort)) (X : functor sortToHSET sortToHSET) : *)
 (*   functor sortToHSET HSET. *)
 (* Proof. *)
-(* set (XS := map (endo_fun X) xs). *)
+(* set (XS := map (exp_fun X) xs). *)
 (* (* The output for the empty list *) *)
 (* set (T := constant_functor sortToHSET HSET emptyHSET). *)
 (* apply (foldr1 (fun F G => BinProductObject _ (BinProductsSortToHSETToHSET F G)) T XS). *)
 (* Defined. *)
 
-Definition endo_funs_functor (xs : list (list sort × sort)) :
+(* This defines X^as where as is a list. Outputs a product of functors if the list is nonempty and
+otherwise the constant functor. *)
+Definition exp_functors (xs : list (list sort × sort)) :
   functor [sortToHSET,sortToHSET,has_homsets_sortToHSET]
           [sortToHSET,HSET,has_homsets_HSET].
 Proof.
-set (XS := map endo_fun_functor xs).
+(* Apply the exp functor to every element of the list *)
+set (XS := map exp_functor xs).
+(* If the list is empty we output the constant functor *)
 set (T := constant_functor [sortToHSET, sortToHSET, has_homsets_sortToHSET]
                            [sortToHSET, HSET, has_homsets_HSET]
                            (constant_functor sortToHSET HSET emptyHSET)).
 (* TODO: Maybe use indexed finite products instead of a fold? *)
-(* TODO: Should we use BinProduct_of_functors? *)
+(* TODO: Should we really use BinProduct_of_functors? Can we prove omega-cocont? *)
 apply (foldr1 (fun F G => BinProduct_of_functors _ _ BinProductsSortToHSETToHSET F G) T XS).
 Defined.
 
-(* This lemma is just here to check that the correct sort_cat gets pulled out *)
-Definition MSigToFunctor_helper (C D E F G : precategory)
+(* This lemma is just here to check that the correct sort_cat gets pulled out when reorganizing
+   arguments *)
+Definition MultiSortedSigToFunctor_helper (C D E F G : precategory)
   (hsD : has_homsets D) (hsG : has_homsets G)
   (H : functor F [[C,D,hsD],[E,G,hsG],functor_category_has_homsets _ _ hsG]) :
   functor [C,D,hsD] [E,[F,G,hsG],functor_category_has_homsets _ _ hsG] :=
     functor_composite (functor_swap H) functor_cat_swap.
 
-Definition MSigToFunctor (M : MSig) :
+(** * The functor constructed from a multisorted binding signature *)
+Definition MultiSortedSigToFunctor (M : MultiSortedSig) :
   functor [sortToHSET,sortToHSET,has_homsets_sortToHSET]
           [sortToHSET,sortToHSET,has_homsets_sortToHSET].
 Proof.
-apply MSigToFunctor_helper.
-apply functor_sort_cat.
-intro s.
+(* First reorganize so that the last sort argument is first: *)
+apply MultiSortedSigToFunctor_helper.
+(* As we're defining a functor out of a discrete category it suffices to give a function: *)
+apply functor_DiscretePrecategory; intro s.
+(* This is then a coproduct of functors (for this to exist the indices need to be a set) *)
 use (coproduct_of_functors (indices M s)).
 + apply Coproducts_functor_precat, Coproducts_HSET, isaset_indices.
-+ intros y.
-  apply (endo_funs_functor (args M s y)).
++ intros y; apply (exp_functors (args M s y)).
 Defined.
 
 End MBindingSig.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -49,34 +49,6 @@ Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
 Section move_upstream.
 
-Lemma foldr_cons {A B : UU} (f : A -> B -> B) (b : B) (x : A) (xs : list A) :
-  foldr f b (cons x xs) = f x (foldr f b xs).
-Proof.
-now destruct xs.
-Qed.
-
-Lemma map_nil {A B : UU} (f : A -> B) : map f nil = nil.
-Proof.
-apply idpath.
-Qed.
-
-Lemma map_cons {A B : UU} (f : A -> B) (x : A) (xs : list A) :
-  map f (cons x xs) = cons (f x) (map f xs).
-Proof.
-now destruct xs.
-Qed.
-
-Lemma foldr1_cons_nil {A : UU} (f : A -> A -> A) (a : A) (x : A) :
-  foldr1 f a (cons x nil) = x.
-Proof.
-apply idpath.
-Qed.
-
-Lemma foldr1_cons {A : UU} (f : A -> A -> A) (a : A) (x y : A) (xs : list A) :
-  foldr1 f a (cons x (cons y xs)) = f x (foldr1 f a (cons y xs)).
-Proof.
-apply idpath.
-Qed.
 
 Definition head {A : UU} (a : A) (xs : list A) : A.
 Proof.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -44,19 +44,113 @@ Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
 Section preamble.
 
-Lemma functor_swap {C D E : precategory} {hsE : has_homsets E} :
-  functor C [D,E,hsE] → functor D [C,E,hsE].
-Admitted.
+Context {C D E : precategory} {hsE : has_homsets E}.
 
-Lemma functor_assoc1 {C D E F : precategory}
-  {hsD : has_homsets D } {hsE : has_homsets E} {hsF : has_homsets F} :
-  functor [[C,D,hsD],E,hsE] F → functor [C,D,hsD] [E,F,hsF].
-Admitted.
+Lemma functor_swap : functor C [D,E,hsE] → functor D [C,E,hsE].
+Proof.
+intros F.
+mkpair.
+- mkpair.
+  + intro d; simpl.
+  { mkpair.
+    - mkpair.
+      + intro c.
+        apply (pr1 (F c) d).
+        + intros a b f; apply (# F f).
+          - abstract (split;
+            [ now intro x; simpl; rewrite (functor_id F)
+            | now intros a b c f g; simpl; rewrite (functor_comp F)]).
+  }
+  + intros a b f; simpl.
+  { mkpair.
+    - intros x; apply (# (pr1 (F x)) f).
+    - abstract (intros c d g; simpl; apply pathsinv0, nat_trans_ax).
+  }
+- abstract (split;
+  [ intros d; simpl;
+    apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ hsE) |]; simpl;
+    apply funextsec; intro c; apply functor_id
+  | intros a b c f g; simpl;
+    apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ hsE) |]; simpl;
+    apply funextsec; intro x; apply functor_comp ]).
+Defined.
 
-Lemma functor_assoc2 {C D E F : precategory}
-  {hsD : has_homsets D } {hsE : has_homsets E} {hsF : has_homsets F} :
-  functor [C,D,hsD] [E,F,hsF] → functor [[C,D,hsD],E,hsE] F.
-Admitted.
+Lemma functor_cat_swap : functor [C, [D, E, hsE], functor_category_has_homsets _ _ hsE]
+                                 [D, [C, E, hsE], functor_category_has_homsets _ _ hsE].
+Proof.
+mkpair.
+- apply (tpair _ functor_swap); simpl.
+  intros F G α.
+  mkpair.
+  + intros d; simpl.
+    mkpair.
+    * intro c; apply (α c).
+    * abstract (intros a b f; apply (nat_trans_eq_pointwise (nat_trans_ax α _ _ f) d)).
+  + abstract (intros a b f; simpl;
+              apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ hsE) |]; simpl;
+              apply funextsec; intro c; apply nat_trans_ax).
+- abstract (split;
+  [ intro F; simpl; apply subtypeEquality;
+      [ intro x; apply isaprop_is_nat_trans, (functor_category_has_homsets _ _ hsE)|]; simpl;
+    apply funextsec; intro d;
+    now apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ hsE) |]
+  | intros F G H α β; simpl in *; apply subtypeEquality;
+      [ intro x; apply isaprop_is_nat_trans, (functor_category_has_homsets _ _ hsE)|]; simpl;
+    apply funextsec; intro d;
+    now apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ hsE) |]]).
+Defined.
+
+(* Lemma functor_assoc1 {C D E F : precategory} *)
+(*   {hsD : has_homsets D } {hsE : has_homsets E} {hsF : has_homsets F} : *)
+(*   functor [[C,D,hsD],E,hsE] F → functor [C,D,hsD] [E,F,hsF]. *)
+(* Proof. *)
+(* intros H. *)
+(* mkpair. *)
+(* - mkpair. *)
+(*   + intro FCD; simpl. *)
+(*   { mkpair. *)
+(*     - mkpair. *)
+(*       + intro e. *)
+(*         set (temp := constant_functor [C, D, hsD] E e : [[C, D, hsD], E, hsE]). *)
+(*         apply (H temp). *)
+(* + intros a b f; simpl. *)
+
+
+(*         set (temp := constant_functor [C, D, hsD] E e : [[C, D, hsD], E, hsE]). *)
+(* simpl. *)
+(*         apply (# H temp). *)
+
+(* generalyze (# *)
+
+
+(* apply *)
+(* generalize (H FCD). *)
+
+(*         apply (pr1 (F c) d). *)
+(*         + intros a b f; apply (# F f). *)
+(*           - abstract (split; *)
+(*             [ now intro x; simpl; rewrite (functor_id F) *)
+(*             | now intros a b c f g; simpl; rewrite (functor_comp F)]). *)
+(*   } *)
+(*   + intros a b f; simpl. *)
+(*   { mkpair. *)
+(*     - intros x; apply (# (pr1 (F x)) f). *)
+(*     - abstract (intros c d g; simpl; apply pathsinv0, nat_trans_ax). *)
+(*   } *)
+(* - abstract (split; *)
+(*   [ intros d; simpl; *)
+(*     apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ hsE) |]; simpl; *)
+(*     apply funextsec; intro c; apply functor_id *)
+(*   | intros a b c f g; simpl; *)
+(*     apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ hsE) |]; simpl; *)
+(*     apply funextsec; intro x; apply functor_comp ]). *)
+(* Defined. *)
+(* Admitted. *)
+
+(* Lemma functor_assoc2 {C D E F : precategory} *)
+(*   {hsD : has_homsets D } {hsE : has_homsets E} {hsF : has_homsets F} : *)
+(*   functor [C,D,hsD] [E,F,hsF] → functor [[C,D,hsD],E,hsE] F. *)
+(* Admitted. *)
 
 End preamble.
 
@@ -261,10 +355,10 @@ Admitted.
 (*  functor [sortToHSET, sortToHSET, has_homsets_sortToHSET] *)
 (*          [sortToHSET, sortToHSET, has_homsets_sortToHSET]. *)
 
-Lemma asdf : has_homsets [sortToHSET,HSET,has_homsets_HSET].
-Proof.
-apply functor_category_has_homsets.
-Qed.
+(* Lemma asdf : has_homsets [sortToHSET,HSET,has_homsets_HSET]. *)
+(* Proof. *)
+(* apply functor_category_has_homsets. *)
+(* Qed. *)
 
 (* Lemma lol (D : precategory) *)
 (*   (H : functor sort_cat [D,HSET,has_homsets_HSET]) : *)
@@ -299,34 +393,36 @@ Qed.
 (* Admitted. (* Defined is very slow... *) *)
 
 
-Definition lol2
-  (H : functor [[sortToHSET,sortToHSET,has_homsets_sortToHSET],sortToHSET,has_homsets_sortToHSET]
-               sortToHSET) :
- functor [sortToHSET, sortToHSET, has_homsets_sortToHSET]
-         [sortToHSET, sortToHSET, has_homsets_sortToHSET].
-Proof.
-use functor_assoc1.
-- apply has_homsets_sortToHSET.
-- assumption.
-Defined.
+(* Definition lol2 *)
+(*   (H : functor [[sortToHSET,sortToHSET,has_homsets_sortToHSET],sortToHSET,has_homsets_sortToHSET] *)
+(*                sortToHSET) : *)
+(*  functor [sortToHSET, sortToHSET, has_homsets_sortToHSET] *)
+(*          [sortToHSET, sortToHSET, has_homsets_sortToHSET]. *)
+(* Proof. *)
+(* use functor_assoc1. *)
+(* - apply has_homsets_sortToHSET. *)
+(* - assumption. *)
+(* Defined. *)
 
-Definition MSigToFunctor_helper
-  (* (H : functor sort_cat *)
-  (*              [[sortToHSET,sortToHSET,has_homsets_sortToHSET], *)
-  (*               [sortToHSET,HSET,has_homsets_HSET], *)
-  (*               asdf]) : *)
- ( H : functor sort_cat
-    [[[sortToHSET, sortToHSET, has_homsets_sortToHSET], sortToHSET,
-     has_homsets_sortToHSET], HSET, has_homsets_HSET]) :
+(* Definition MSigToFunctor_helper *)
+(*   (* (H : functor sort_cat *) *)
+(*   (*              [[sortToHSET,sortToHSET,has_homsets_sortToHSET], *) *)
+(*   (*               [sortToHSET,HSET,has_homsets_HSET], *) *)
+(*   (*               asdf]) : *) *)
+(*  ( H : functor sort_cat *)
+(*     [[[sortToHSET, sortToHSET, has_homsets_sortToHSET], sortToHSET, *)
+(*      has_homsets_sortToHSET], HSET, has_homsets_HSET]) : *)
+(*  functor [sortToHSET, sortToHSET, has_homsets_sortToHSET] *)
+(*          [sortToHSET, sortToHSET, has_homsets_sortToHSET]. *)
+(* Proof. *)
 
+(* use functor_assoc1. *)
+(* - apply has_homsets_sortToHSET. *)
+(* - apply functor_swap. *)
+(*   apply H. *)
+(* Defined. *)
+(* Admitted. *)
 
- functor [sortToHSET, sortToHSET, has_homsets_sortToHSET]
-         [sortToHSET, sortToHSET, has_homsets_sortToHSET].
-Proof.
-apply lol2.
-apply functor_swap.
-apply H.
-Defined.
 (* mkpair. *)
 (* * mkpair. *)
 (* { intro X. *)
@@ -358,6 +454,24 @@ Defined.
 (* (C -> D) -> (E -> F) = ((C -> D) -> E) -> F *)
 (* functor [C,D] [E,F] = functor [[C,D],E] F *)
 
+(* Variables (A : precategory). *)
+
+(* Lemma temp : has_homsets [A,HSET,has_homsets_HSET]. *)
+(* Proof. *)
+(* apply functor_category_has_homsets. *)
+(* Qed. *)
+
+(* Lemma temp2 : has_homsets [sortToHSET,HSET,has_homsets_HSET]. *)
+(* Proof. *)
+(* apply functor_category_has_homsets. *)
+(* Qed. *)
+
+Definition MSigToFunctor_helper (C D E F G : precategory)
+  (hsD : has_homsets D) (hsG : has_homsets G)
+  (H : functor F [[C,D,hsD],[E,G,hsG],functor_category_has_homsets _ _ hsG]) :
+  functor [C,D,hsD] [E,[F,G,hsG],functor_category_has_homsets _ _ hsG] :=
+    functor_composite (functor_swap H) functor_cat_swap.
+
 Definition MSigToFunctor (M : MSig) :
   functor [sortToHSET,sortToHSET,has_homsets_sortToHSET]
           [sortToHSET,sortToHSET,has_homsets_sortToHSET].
@@ -368,21 +482,7 @@ intro s.
 use (coproduct_of_functors (indices M s)).
 + admit.
 + intros y.
-  use functor_assoc2.
-  - apply has_homsets_HSET.
-  - apply (endo_funs_functor (args M s y)).
+  apply (endo_funs_functor (args M s y)).
 Admitted.
-
-
-
-
-
-
-
-
-
-
-
-
 
 End MBindingSig.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -7,6 +7,7 @@ Written by: Anders Mörtberg, 2016
 *)
 
 Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Sets.
 Require Import UniMath.Foundations.Combinatorics.Lists.
 
 Require Import UniMath.CategoryTheory.precategories.
@@ -75,12 +76,18 @@ Variable sort : UU.
 Let sort_cat : precategory := DiscPrecat sort.
 Let sortToHSET : precategory := [sort_cat,HSET,has_homsets_HSET].
 
-Definition MSig (s : sort) : UU :=
-  Σ (I : sort -> UU), I s → list (list sort × sort).
+Lemma has_homsets_sortToHSET : has_homsets sortToHSET.
+Proof.
+apply functor_category_has_homsets.
+Qed.
 
-Definition indices {s : sort} (M : MSig s) : sort → UU := pr1 M.
+Definition MSig : UU :=
+  Π (s : sort), Σ (I : UU), I → list (list sort × sort).
 
-Definition args {s : sort} (M : MSig s) : indices M s → list (list sort × sort) := pr2 M.
+Definition indices (M : MSig) : sort → UU := fun s => pr1 (M s).
+
+Definition args (M : MSig) (s : sort) : indices M s → list (list sort × sort) :=
+  pr2 (M s).
 
 
 Local Notation "'1'" := (TerminalHSET).
@@ -100,16 +107,72 @@ mkpair.
 - abstract (split; [ now intros ? | now intros ? ? ? [] [] ]). (* UGH *)
 Defined.
 
-Definition option_list (eq : isdeceq sort) : list sort -> sortToHSET -> sortToHSET.
+Definition option_list (eq : isdeceq sort) (xs : list sort) :
+  functor sortToHSET sortToHSET.
+Proof.
+mkpair.
+- mkpair.
+  + intro a.
+    apply (foldr (option eq) a xs).
+  + simpl. admit.
+- admit.
 Admitted.
 
-Definition endo_fun (a : list sort × sort) (X : functor sortToHSET sortToHSET) : functor sortToHSET HSET.
+Definition endo_fun (eq : isdeceq sort)
+  (X : functor sortToHSET sortToHSET)
+  (a : list sort × sort) :
+  functor sortToHSET HSET.
+Proof.
+destruct a as [l t].
+set (O := functor_composite (option_list eq l) X).
+mkpair.
+- mkpair.
+  + intros f.
+    apply (pr1 (O f) t).
+  + simpl. admit.
+- simpl. admit.
 Admitted.
 
-Definition endo_funs (xs : list (list sort × sort)) (X : functor sortToHSET sortToHSET) : functor sortToHSET HSET.
+Definition endo_funs (eq : isdeceq sort) (xs : list (list sort × sort))
+  (X : functor sortToHSET sortToHSET) : functor sortToHSET HSET.
+Proof.
+set (XS := map (endo_fun eq X) xs).
+(* TODO: Fold with functor product *)
 Admitted.
 
-Definition MSigToFunctor {s : sort} (M : MSig s) : functor sortToHSET sortToHSET.
+Definition MSigToFunctor (eq : isdeceq sort) (M : MSig) :
+  functor [sortToHSET,sortToHSET,has_homsets_sortToHSET]
+          [sortToHSET,sortToHSET,has_homsets_sortToHSET].
+Proof.
+unfold MSig in M.
+mkpair.
++ mkpair.
+- intro X.
+mkpair.
+* mkpair.
+{ intro f.
+mkpair.
+- mkpair.
++ intro s.
+set (Is := indices M s).
+simpl.
+mkpair.
+use total2.
+* apply Is.
+* intro y.
+set (ary := args M s y).
+apply (endo_funs eq ary X f).
+*simpl.
+apply isaset_total2.
+admit.
+admit.
++ admit.
+- admit.
+}
+admit.
+* admit.
+- admit.
++ admit.
 Admitted.
 
 End MBindingSig.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -43,42 +43,27 @@ Section DiscreteCategory.
 
 Variable (A : UU).
 
-Definition DiscretePrecategory : precategory.
+Definition DiscPrecat_data : precategory_data.
 Proof.
-use tpair.
-- use tpair.
-use tpair.
-apply A.
-simpl.
-intros a b.
-apply (a = b).
-use tpair.
-simpl.
-intro a; apply idpath.
-simpl.
-intros a b c h1 h2.
-apply (pathscomp0 h1 h2).
-- split. split; trivial.
-simpl.
-intros a b f.
-apply pathscomp0rid.
-simpl.
-intros.
-apply path_assoc.
+mkpair.
+- apply (A,,paths).
+- mkpair; [ apply idpath | apply @pathscomp0 ].
 Defined.
 
-Lemma has_homsets_DiscretePrecategory (H : isofhlevel 3 A) : has_homsets DiscretePrecategory.
+Definition is_precategory_DiscPrecat_data : is_precategory DiscPrecat_data.
 Proof.
-simpl.
-unfold has_homsets.
-intros.
-simpl in *.
-unfold isaset in *.
-intros h1 h2.
-unfold isaprop.
-simpl.
-apply H.
-Defined.
+split; [split|]; trivial; intros.
++ apply pathscomp0rid.
++ apply path_assoc.
+Qed.
+
+Definition DiscPrecat : precategory :=
+  (DiscPrecat_data,,is_precategory_DiscPrecat_data).
+
+Lemma has_homsets_DiscPrecat (H : isofhlevel 3 A) : has_homsets DiscPrecat.
+Proof.
+intros ? ? ? ? ? ?; apply H.
+Qed.
 
 End DiscreteCategory.
 
@@ -87,10 +72,44 @@ Section MBindingSig.
 
 Variable sort : UU.
 
-Let Dsort := DiscretePrecategory sort.
+Let sort_cat : precategory := DiscPrecat sort.
+Let sortToHSET : precategory := [sort_cat,HSET,has_homsets_HSET].
 
-Let C := [Dsort,HSET,has_homsets_HSET].
+Definition MSig (s : sort) : UU :=
+  Σ (I : sort -> UU), I s → list (list sort × sort).
+
+Definition indices {s : sort} (M : MSig s) : sort → UU := pr1 M.
+
+Definition args {s : sort} (M : MSig s) : indices M s → list (list sort × sort) := pr2 M.
 
 
+Local Notation "'1'" := (TerminalHSET).
+Local Notation "a ⊕ b" := (BinCoproductObject _ (BinCoproductsHSET a b)) (at level 50).
+Local Notation "a ⊛ b" := (BinProductObject _ (BinProductsHSET a b)) (at level 60).
+
+Definition option (eq : isdeceq sort) : sort -> sortToHSET -> sortToHSET.
+Proof.
+intros s f.
+mkpair.
+- mkpair.
+  + intro t.
+    induction (eq s t) as [H|H].
+    * apply (pr1 f t ⊕ 1). (* TODO: Add coercion to make this look like sort -> Set *)
+    * apply (pr1 f t).
+  + now intros t1 t2 [].
+- abstract (split; [ now intros ? | now intros ? ? ? [] [] ]). (* UGH *)
+Defined.
+
+Definition option_list (eq : isdeceq sort) : list sort -> sortToHSET -> sortToHSET.
+Admitted.
+
+Definition endo_fun (a : list sort × sort) (X : functor sortToHSET sortToHSET) : functor sortToHSET HSET.
+Admitted.
+
+Definition endo_funs (xs : list (list sort × sort)) (X : functor sortToHSET sortToHSET) : functor sortToHSET HSET.
+Admitted.
+
+Definition MSigToFunctor {s : sort} (M : MSig s) : functor sortToHSET sortToHSET.
+Admitted.
 
 End MBindingSig.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -103,7 +103,6 @@ Definition args (M : MSig) (s : sort) : indices M s → list (list sort × sort)
 
 Local Notation "'1'" := (TerminalHSET).
 Local Notation "a ⊕ b" := (BinCoproductObject _ (BinCoproductsHSET a b)) (at level 50).
-Local Notation "a ⊛ b" := (BinProductObject _ (BinProductsHSET a b)) (at level 60).
 
 Definition option : sort -> sortToHSET -> sortToHSET.
 Proof.
@@ -115,32 +114,44 @@ induction (eq s t) as [H|H].
 Defined.
 
 (* Maybe define this as a functor? *)
-Definition option_list (xs : list sort) : sortToHSET → sortToHSET.
+Definition option_list (xs : list sort) : functor sortToHSET sortToHSET.
 Proof.
-intro a.
-apply (foldr option a xs).
+mkpair.
++ mkpair.
+  - intro a; apply (foldr option a xs).
+  - admit.
++ admit.
+Admitted.
+
+Definition sortToHSETToHSET (s : sort) : functor sortToHSET HSET.
+Proof.
+mkpair.
++ mkpair.
+  - intro f; apply (pr1 f s).
+  - simpl; intros a b f H; apply (f s H).
++ abstract (split;
+    [ now intros f; apply funextsec
+    | now intros f g h fg gh; apply funextsec; intro x ]).
 Defined.
 
-(* Definition sortToHSETToHSET (s : sort) : functor sortToHSET HSET. *)
-(* Admitted. *)
-
-(* Maybe define this as a functor? *)
-Definition endo_fun (X : sortToHSET → sortToHSET) (a : list sort × sort) : sortToHSET → HSET.
+Definition endo_fun (X : functor sortToHSET sortToHSET) (a : list sort × sort) : functor sortToHSET HSET.
 Proof.
-destruct a as [l t].
-(* set (O := functor_composite (option_list eq l) X). *)
-intros f.
-apply (pr1 (X (option_list l f)) t).
+set (O := functor_composite (option_list (pr1 a)) X).
+apply (functor_composite O (sortToHSETToHSET (pr2 a))).
 Defined.
 
-Search Products "functor".
-(* Maybe define this as a functor? *)
-Definition endo_funs (xs : list (list sort × sort)) (X : sortToHSET → sortToHSET) :
-  sortToHSET → HSET.
+Local Definition BinProductsSortToHSETToHSET : BinProducts [sortToHSET,HSET,has_homsets_HSET].
+Proof.
+apply (BinProducts_functor_precat _ _ BinProductsHSET).
+Defined.
+
+Definition endo_funs (xs : list (list sort × sort)) (X : functor sortToHSET sortToHSET) :
+  functor sortToHSET HSET.
 Proof.
 set (XS := map (endo_fun X) xs).
-intro s.
-apply (foldr (fun (f : sortToHSET → HSET) (b : HSET) => pr1 (f s ⊗ b)) emptyHSET XS).
+(* The output for the empty list *)
+set (T := constant_functor sortToHSET HSET emptyHSET).
+apply (foldr1 (fun F G => BinProductObject _ (BinProductsSortToHSETToHSET F G)) T XS).
 Defined.
 
 Definition MSigToFunctor (M : MSig) :
@@ -151,6 +162,7 @@ unfold MSig in M.
 mkpair.
 + mkpair.
 - intro X.
+simpl.
 mkpair.
 * mkpair.
 { intro f.
@@ -163,11 +175,11 @@ use total2.
 * apply Is.
 * intro y.
 set (ary := args M s y).
-apply (endo_funs ary (pr1 X) f).
-*simpl.
-apply isaset_total2.
+(* apply (endo_funs ary (pr1 X) f). *)
+(* *simpl. *)
+(* apply isaset_total2. *)
 admit.
-admit.
+* admit.
 }
 admit.
 * admit.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -100,61 +100,9 @@ mkpair.
     now apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ hsE) |]]).
 Defined.
 
-(* Lemma functor_assoc1 {C D E F : precategory} *)
-(*   {hsD : has_homsets D } {hsE : has_homsets E} {hsF : has_homsets F} : *)
-(*   functor [[C,D,hsD],E,hsE] F → functor [C,D,hsD] [E,F,hsF]. *)
-(* Proof. *)
-(* intros H. *)
-(* mkpair. *)
-(* - mkpair. *)
-(*   + intro FCD; simpl. *)
-(*   { mkpair. *)
-(*     - mkpair. *)
-(*       + intro e. *)
-(*         set (temp := constant_functor [C, D, hsD] E e : [[C, D, hsD], E, hsE]). *)
-(*         apply (H temp). *)
-(* + intros a b f; simpl. *)
-
-
-(*         set (temp := constant_functor [C, D, hsD] E e : [[C, D, hsD], E, hsE]). *)
-(* simpl. *)
-(*         apply (# H temp). *)
-
-(* generalyze (# *)
-
-
-(* apply *)
-(* generalize (H FCD). *)
-
-(*         apply (pr1 (F c) d). *)
-(*         + intros a b f; apply (# F f). *)
-(*           - abstract (split; *)
-(*             [ now intro x; simpl; rewrite (functor_id F) *)
-(*             | now intros a b c f g; simpl; rewrite (functor_comp F)]). *)
-(*   } *)
-(*   + intros a b f; simpl. *)
-(*   { mkpair. *)
-(*     - intros x; apply (# (pr1 (F x)) f). *)
-(*     - abstract (intros c d g; simpl; apply pathsinv0, nat_trans_ax). *)
-(*   } *)
-(* - abstract (split; *)
-(*   [ intros d; simpl; *)
-(*     apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ hsE) |]; simpl; *)
-(*     apply funextsec; intro c; apply functor_id *)
-(*   | intros a b c f g; simpl; *)
-(*     apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ hsE) |]; simpl; *)
-(*     apply funextsec; intro x; apply functor_comp ]). *)
-(* Defined. *)
-(* Admitted. *)
-
-(* Lemma functor_assoc2 {C D E F : precategory} *)
-(*   {hsD : has_homsets D } {hsE : has_homsets E} {hsF : has_homsets F} : *)
-(*   functor [C,D,hsD] [E,F,hsF] → functor [[C,D,hsD],E,hsE] F. *)
-(* Admitted. *)
-
 End preamble.
 
-
+(** * Discrete categories *)
 Section DiscreteCategory.
 
 Variable (A : UU).
@@ -297,7 +245,7 @@ use (foldr _ _ xs).
 + apply functor_identity.
 Defined.
 
-(** This applies the sortToHSET to s *)
+(** This applies the sortToHSET to s and returns HSET *)
 Definition sortToHSETToHSET (s : sort) : functor sortToHSET HSET.
 Proof.
 mkpair.
@@ -350,122 +298,7 @@ Definition endo_funs_functor (xs : list (list sort × sort)) :
           [sortToHSET,HSET,has_homsets_HSET].
 Admitted.
 
-(* Definition MSigToFunctor_helper *)
-(*   (H : functor sortToHSET sortToHSET → sortToHSET → sort → HSET) : *)
-(*  functor [sortToHSET, sortToHSET, has_homsets_sortToHSET] *)
-(*          [sortToHSET, sortToHSET, has_homsets_sortToHSET]. *)
-
-(* Lemma asdf : has_homsets [sortToHSET,HSET,has_homsets_HSET]. *)
-(* Proof. *)
-(* apply functor_category_has_homsets. *)
-(* Qed. *)
-
-(* Lemma lol (D : precategory) *)
-(*   (H : functor sort_cat [D,HSET,has_homsets_HSET]) : *)
-(*   functor D sortToHSET. *)
-(* Proof. *)
-(* mkpair. *)
-(* - mkpair. *)
-(* + intros f. *)
-(*   apply mk_sortToHSET. *)
-(*   intro s. *)
-(*   apply (pr1 (H s) f). *)
-(* + intros F G α. *)
-(* mkpair. *)
-(* * intros s. *)
-(*   apply (# (pr1 (H s)) α). *)
-(* * *)
-(* intros s t []; clear t. *)
-(* eapply pathscomp0. *)
-(* apply (id_left (# (pr1 (H s)) α)). *)
-(* apply pathsinv0. *)
-(* apply (id_right (# (pr1 (H s)) α)). *)
-(* - split. *)
-(* + intro F. *)
-(* apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ has_homsets_HSET)|]. *)
-(* apply funextsec; intro s. *)
-(* apply (functor_id ( (H s))). *)
-(* + *)
-(* intros F1 F2 F3 α12 α23. *)
-(* apply subtypeEquality; [intro x; apply (isaprop_is_nat_trans _ _ has_homsets_HSET)|]. *)
-(* apply funextsec; intro s. *)
-(* apply (functor_comp (H s)). *)
-(* Admitted. (* Defined is very slow... *) *)
-
-
-(* Definition lol2 *)
-(*   (H : functor [[sortToHSET,sortToHSET,has_homsets_sortToHSET],sortToHSET,has_homsets_sortToHSET] *)
-(*                sortToHSET) : *)
-(*  functor [sortToHSET, sortToHSET, has_homsets_sortToHSET] *)
-(*          [sortToHSET, sortToHSET, has_homsets_sortToHSET]. *)
-(* Proof. *)
-(* use functor_assoc1. *)
-(* - apply has_homsets_sortToHSET. *)
-(* - assumption. *)
-(* Defined. *)
-
-(* Definition MSigToFunctor_helper *)
-(*   (* (H : functor sort_cat *) *)
-(*   (*              [[sortToHSET,sortToHSET,has_homsets_sortToHSET], *) *)
-(*   (*               [sortToHSET,HSET,has_homsets_HSET], *) *)
-(*   (*               asdf]) : *) *)
-(*  ( H : functor sort_cat *)
-(*     [[[sortToHSET, sortToHSET, has_homsets_sortToHSET], sortToHSET, *)
-(*      has_homsets_sortToHSET], HSET, has_homsets_HSET]) : *)
-(*  functor [sortToHSET, sortToHSET, has_homsets_sortToHSET] *)
-(*          [sortToHSET, sortToHSET, has_homsets_sortToHSET]. *)
-(* Proof. *)
-
-(* use functor_assoc1. *)
-(* - apply has_homsets_sortToHSET. *)
-(* - apply functor_swap. *)
-(*   apply H. *)
-(* Defined. *)
-(* Admitted. *)
-
-(* mkpair. *)
-(* * mkpair. *)
-(* { intro X. *)
-(*   apply lol. *)
-(*   mkpair. *)
-(*   + mkpair. *)
-(*   - intro s. *)
-(*     apply (pr1 (H s) X). *)
-(*   - intros s t []. *)
-(*     set (XX :=  ((pr1 (H s)) X)). *)
-(*     simpl in XX. *)
-(*     apply (@nat_trans_id sortToHSET HSET XX). *)
-(* + split. *)
-(* - intro x. *)
-(* simpl. *)
-(* apply idpath. *)
-(* - intros x y z [] []. *)
-
-(*  simpl in *. *)
-(* apply subtypeEquality; [intro xx; apply (isaprop_is_nat_trans _ _ has_homsets_HSET)|]. *)
-(* apply funextsec; intro s. *)
-(* apply idpath. *)
-(* } *)
-(* intros F G α. *)
-(* admit. *)
-(* * admit. *)
-(* Admitted. *)
-
-(* (C -> D) -> (E -> F) = ((C -> D) -> E) -> F *)
-(* functor [C,D] [E,F] = functor [[C,D],E] F *)
-
-(* Variables (A : precategory). *)
-
-(* Lemma temp : has_homsets [A,HSET,has_homsets_HSET]. *)
-(* Proof. *)
-(* apply functor_category_has_homsets. *)
-(* Qed. *)
-
-(* Lemma temp2 : has_homsets [sortToHSET,HSET,has_homsets_HSET]. *)
-(* Proof. *)
-(* apply functor_category_has_homsets. *)
-(* Qed. *)
-
+(* This lemma is just here to check that the correct sort_cat gets pulled out *)
 Definition MSigToFunctor_helper (C D E F G : precategory)
   (hsD : has_homsets D) (hsG : has_homsets G)
   (H : functor F [[C,D,hsD],[E,G,hsG],functor_category_has_homsets _ _ hsG]) :

--- a/UniMath/SubstitutionSystems/Notation.v
+++ b/UniMath/SubstitutionSystems/Notation.v
@@ -43,7 +43,7 @@ Arguments functor_composite {_ _ _} _ _ .
 Arguments nat_trans_comp {_ _ _ _ _} _ _ .
 Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 Notation "G • F" := (functor_composite F G : [ _ , _ , _ ]) (at level 35).
-Notation "α ∙∙ β" := (hor_comp β α) (at level 20).
+Notation "α ∙∙ β" := (horcomp β α) (at level 20).
 Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 
 Notation "α 'ø' Z" := (pre_whisker Z α)  (at level 25).

--- a/UniMath/SubstitutionSystems/SignatureExamples.v
+++ b/UniMath/SubstitutionSystems/SignatureExamples.v
@@ -40,7 +40,7 @@ Local Notation "'EndC'":= ([C, C, hsC]) .
 
 Definition δ_source_ob (Ze : Ptd) : EndC := G • pr1 Ze.
 Definition δ_source_mor {Ze Ze' : Ptd} (α : Ze --> Ze') :
-  δ_source_ob Ze --> δ_source_ob Ze' := hor_comp (pr1 α) (nat_trans_id G).
+  δ_source_ob Ze --> δ_source_ob Ze' := horcomp (pr1 α) (nat_trans_id G).
 
 Definition δ_source_functor_data : functor_data Ptd EndC.
 Proof.
@@ -63,7 +63,7 @@ Definition δ_source : functor Ptd EndC := tpair _ _ is_functor_δ_source.
 
 Definition δ_target_ob (Ze : Ptd) : EndC := pr1 Ze • G.
 Definition δ_target_mor {Ze Ze' : Ptd} (α : Ze --> Ze') :
-  δ_target_ob Ze --> δ_target_ob Ze' := hor_comp (nat_trans_id G) (pr1 α).
+  δ_target_ob Ze --> δ_target_ob Ze' := horcomp (nat_trans_id G) (pr1 α).
 
 Definition δ_target_functor_data : functor_data Ptd EndC.
 Proof.

--- a/UniMath/SubstitutionSystems/Signatures.v
+++ b/UniMath/SubstitutionSystems/Signatures.v
@@ -66,7 +66,7 @@ Local Notation "'EndC'":= ([C, C, hs]) .
 Definition θ_source_ob (FX : EndC XX Ptd) : [C, C, hs] := H (pr1 FX) • U (pr2 FX).
 
 Definition θ_source_mor {FX FX' : EndC XX Ptd} (αβ : FX --> FX')
-  : θ_source_ob FX --> θ_source_ob FX' := hor_comp (#U (pr2 αβ)) (#H (pr1 αβ)).
+  : θ_source_ob FX --> θ_source_ob FX' := horcomp (#U (pr2 αβ)) (#H (pr1 αβ)).
 
 
 Definition θ_source_functor_data : functor_data (EndC XX Ptd) EndC.
@@ -164,7 +164,7 @@ Proof.
     apply nat_trans_eq.
     + apply hs.
     + intro c.
-      unfold hor_comp; simpl.
+      unfold horcomp; simpl.
       destruct FX as [F X];
       destruct FX' as [F' X'];
       destruct FX'' as [F'' X'']; simpl in *.


### PR DESCRIPTION
This PR contains:

- Definition of discrete precategories.
- Definition of multisorted signatures.
- Construction of a "signature functor" from a multisorted signature.

For now everything is in one file, I plan to put things in appropriate files soon. Also for now I've assumed that the sort has decidable equality, I'll try to get rid of this assumption later. I also had to assume that the indices form a set, I will probably have to assume that they even have decidable equality for proving that the indexed coproduct in the last definition is omega cocontinuous. 