### PR TITLE
Renaming and better arguments for option_functor

### DIFF
--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -17,9 +17,9 @@ This file also contains proofs that the following functors are (omega-)cocontinu
 - Iteration of omega-cocontinuous functors: F^n : C -> C
   [is_cocont_iter_functor] [is_omega_cocont_iter_functor]
 - Pairing of (omega-)cocont functors (F,G) : A * B -> C * D, (x,y) |-> (F x,G y)
-  [is_cocont_binproduct_pair_functor] [is_omega_cocont_binproduct_pair_functor]
-- Indexed families of (omega-)cocont functors F^I : A^I -> B^I
   [is_cocont_pair_functor] [is_omega_cocont_pair_functor]
+- Indexed families of (omega-)cocont functors F^I : A^I -> B^I
+  [is_cocont_family_functor] [is_omega_cocont_family_functor]
 - Binary delta functor: C -> C^2, x |-> (x,x)
   [is_cocont_bindelta_functor] [is_omega_cocont_bindelta_functor]
 - General delta functor: C -> C^I
@@ -689,7 +689,7 @@ Definition omega_cocont_iter_functor {C : precategory} (hsC : has_homsets C)
 End iter_functor.
 
 (** ** A pair of functors (F,G) : A * B -> C * D is omega cocontinuous if F and G are *)
-Section binproduct_pair_functor.
+Section pair_functor.
 
 Context {A B C D : precategory} (F : functor A C) (G : functor B D)
         (hsA : has_homsets A) (hsB : has_homsets B) (hsC : has_homsets C) (hsD : has_homsets D).
@@ -783,14 +783,14 @@ Proof.
 now intros c L ccL M H; apply isColimCocone_pr2_functor.
 Defined.
 
-Lemma isColimCocone_binproduct_pair_functor {gr : graph}
+Lemma isColimCocone_pair_functor {gr : graph}
   (HF : Π (d : diagram gr A) (c : A) (cc : cocone d c) (h : isColimCocone d c cc),
         isColimCocone _ _ (mapcocone F d cc))
   (HG : Π (d : diagram gr B) (c : B) (cc : cocone d c) (h : isColimCocone d c cc),
         isColimCocone _ _ (mapcocone G d cc)) :
   Π (d : diagram gr (precategory_binproduct A B)) (cd : A × B) (cc : cocone d cd),
   isColimCocone _ _ cc ->
-  isColimCocone _ _ (mapcocone (binproduct_pair_functor F G) d cc).
+  isColimCocone _ _ (mapcocone (pair_functor F G) d cc).
 Proof.
 intros cAB ml ccml Hccml xy ccxy.
 transparent assert (cFAX : (cocone (mapdiagram F (mapdiagram (pr1_functor A B) cAB)) (pr1 xy))).
@@ -817,23 +817,23 @@ mkpair.
                | apply (maponpaths pr1 (hg2 (f2,, (λ n, maponpaths dirprod_pr2 (p n)))))]]).
 Defined.
 
-Lemma is_cocont_binproduct_pair_functor (HF : is_cocont F) (HG : is_cocont G) :
-  is_cocont (binproduct_pair_functor F G).
+Lemma is_cocont_pair_functor (HF : is_cocont F) (HG : is_cocont G) :
+  is_cocont (pair_functor F G).
 Proof.
 intros gr cAB ml ccml Hccml.
-now apply isColimCocone_binproduct_pair_functor; [apply HF|apply HG|].
+now apply isColimCocone_pair_functor; [apply HF|apply HG|].
 Defined.
 
-Lemma is_omega_cocont_binproduct_pair_functor (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
-  is_omega_cocont (binproduct_pair_functor F G).
+Lemma is_omega_cocont_pair_functor (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
+  is_omega_cocont (pair_functor F G).
 Proof.
-now intros cAB ml ccml Hccml; apply isColimCocone_binproduct_pair_functor.
+now intros cAB ml ccml Hccml; apply isColimCocone_pair_functor.
 Defined.
 
-End binproduct_pair_functor.
+End pair_functor.
 
 (** ** A family of functor F^I : A^I -> B^I is omega cocontinuous if each F_i is *)
-Section pair_functor.
+Section family_functor.
 
 Context {I : UU} {A B : precategory} (hsA : has_homsets A) (hsB : has_homsets B).
 
@@ -904,12 +904,12 @@ Proof.
 now intros c L ccL M H; apply isColimCocone_pr_functor.
 Defined.
 
-Lemma isColimCocone_pair_functor {gr : graph} (F : Π (i : I), functor A B)
+Lemma isColimCocone_family_functor {gr : graph} (F : Π (i : I), functor A B)
   (HF : Π i (d : diagram gr A) (c : A) (cc : cocone d c) (h : isColimCocone d c cc),
         isColimCocone _ _ (mapcocone (F i) d cc)) :
   Π (d : diagram gr (product_precategory I (λ _, A))) (cd : I -> A) (cc : cocone d cd),
   isColimCocone _ _ cc ->
-  isColimCocone _ _ (mapcocone (pair_functor I F) d cc).
+  isColimCocone _ _ (mapcocone (family_functor I F) d cc).
 Proof.
 intros cAB ml ccml Hccml xy ccxy; simpl in *.
 transparent assert (cc : (Π i, cocone (mapdiagram (F i) (mapdiagram (pr_functor I (λ _ : I, A) i) cAB)) (xy i))).
@@ -932,22 +932,22 @@ mkpair.
                apply (maponpaths pr1 (pr2 (X i) H))]).
 Defined.
 
-Lemma is_cocont_pair_functor
+Lemma is_cocont_family_functor
   {F : Π (i : I), functor A B} (HF : Π (i : I), is_cocont (F i)) :
-  is_cocont (pair_functor I F).
+  is_cocont (family_functor I F).
 Proof.
 intros gr cAB ml ccml Hccml.
-apply isColimCocone_pair_functor; trivial; intro i; apply HF.
+apply isColimCocone_family_functor; trivial; intro i; apply HF.
 Defined.
 
-Lemma is_omega_cocont_pair_functor
+Lemma is_omega_cocont_family_functor
   {F : Π (i : I), functor A B} (HF : Π (i : I), is_omega_cocont (F i)) :
-  is_omega_cocont (pair_functor I F).
+  is_omega_cocont (family_functor I F).
 Proof.
-now intros cAB ml ccml Hccml; apply isColimCocone_pair_functor.
+now intros cAB ml ccml Hccml; apply isColimCocone_family_functor.
 Defined.
 
-End pair_functor.
+End family_functor.
 
 (** ** The bindelta functor C -> C^2 mapping x to (x,x) is omega cocontinuous *)
 Section bindelta_functor.
@@ -1041,7 +1041,7 @@ Proof.
 apply (is_cocont_functor_composite hsD).
   apply (is_cocont_bindelta_functor PC hsC).
 apply (is_cocont_functor_composite hsD).
-  apply (is_cocont_binproduct_pair_functor _ _ hsC hsC hsD hsD HF HG).
+  apply (is_cocont_pair_functor _ _ hsC hsC hsD hsD HF HG).
 apply (is_cocont_bincoproduct_functor _ hsD).
 Defined.
 
@@ -1052,7 +1052,7 @@ Proof.
 apply (is_omega_cocont_functor_composite hsD).
   apply (is_omega_cocont_bindelta_functor PC hsC).
 apply (is_omega_cocont_functor_composite hsD).
-  apply (is_omega_cocont_binproduct_pair_functor _ _ hsC hsC hsD hsD HF HG).
+  apply (is_omega_cocont_pair_functor _ _ hsC hsC hsD hsD HF HG).
 apply (is_omega_cocont_bincoproduct_functor _ hsD).
 Defined.
 
@@ -1098,7 +1098,7 @@ Proof.
 apply (is_cocont_functor_composite hsD).
   apply (is_cocont_delta_functor PC hsC).
 apply (is_cocont_functor_composite hsD).
-  apply (is_cocont_pair_functor hsC hsD HI HF).
+  apply (is_cocont_family_functor hsC hsD HI HF).
 apply (is_cocont_coproduct_functor _ hsD).
 Defined.
 
@@ -1109,7 +1109,7 @@ Proof.
 apply (is_omega_cocont_functor_composite hsD).
   apply (is_omega_cocont_delta_functor PC hsC).
 apply (is_omega_cocont_functor_composite hsD).
-  apply (is_omega_cocont_pair_functor hsC hsD HI HF).
+  apply (is_omega_cocont_family_functor hsC hsD HI HF).
 apply (is_omega_cocont_coproduct_functor _ hsD).
 Defined.
 
@@ -1512,7 +1512,7 @@ Proof.
 apply (is_omega_cocont_functor_composite hsD).
 - apply (is_omega_cocont_bindelta_functor PC hsC).
 - apply (is_omega_cocont_functor_composite hsD).
-  + apply (is_omega_cocont_binproduct_pair_functor _ _ hsC hsC hsD hsD HF HG).
+  + apply (is_omega_cocont_pair_functor _ _ hsC hsC hsD hsD HF HG).
   + now apply (is_omega_cocont_binproduct_functor _ hsD).
 Defined.
 

--- a/UniMath/CategoryTheory/Inductives/LambdaCalculus.v
+++ b/UniMath/CategoryTheory/Inductives/LambdaCalculus.v
@@ -82,7 +82,7 @@ Local Notation "F + G" :=
 
 Local Notation "'_' 'o' 'option'" :=
   (omega_cocont_pre_composition_functor
-      (option_functor HSET BinCoproductsHSET TerminalHSET)
+      (option_functor BinCoproductsHSET TerminalHSET)
       has_homsets_HSET has_homsets_HSET LimsHSET) (at level 10).
 
 (** The lambda calculus functor with one component for variables, one for application and one for
@@ -129,7 +129,7 @@ apply app_map.
 Defined.
 
 Let precomp_option X := (pre_composition_functor _ _ HSET has_homsets_HSET has_homsets_HSET
-                  (option_functor HSET BinCoproductsHSET TerminalHSET) X).
+                          (option_functor BinCoproductsHSET TerminalHSET) X).
 
 Definition lam_map : HSET2⟦precomp_option LambdaCalculus,LambdaCalculus⟧ :=
   BinCoproductIn2 HSET2 (BinCoproductsHSET2 _ _) ;; BinCoproductIn2 HSET2 (BinCoproductsHSET2 _ _) ;; LambdaCalculus_mor.

--- a/UniMath/CategoryTheory/PrecategoryBinProduct.v
+++ b/UniMath/CategoryTheory/PrecategoryBinProduct.v
@@ -342,7 +342,7 @@ End nat_trans_fix_snd_arg.
 (* Define pairs of functors and functors from pr1 and pr2 *)
 Section functors.
 
-Definition binproduct_pair_functor_data {A B C D : precategory}
+Definition pair_functor_data {A B C D : precategory}
   (F : functor A C) (G : functor B D) :
   functor_data (precategory_binproduct A B) (precategory_binproduct C D).
 Proof.
@@ -351,11 +351,11 @@ mkpair.
 - intros x y f; simpl; apply (precatbinprodmor (# F (pr1 f)) (# G (pr2 f))).
 Defined.
 
-Definition binproduct_pair_functor {A B C D : precategory}
+Definition pair_functor {A B C D : precategory}
   (F : functor A C) (G : functor B D) :
   functor (precategory_binproduct A B) (precategory_binproduct C D).
 Proof.
-apply (tpair _ (binproduct_pair_functor_data F G)).
+apply (tpair _ (pair_functor_data F G)).
 abstract (split;
   [ intro x; simpl; rewrite !functor_id; apply idpath
   | intros x y z f g; simpl; rewrite !functor_comp; apply idpath]).

--- a/UniMath/CategoryTheory/ProductPrecategory.v
+++ b/UniMath/CategoryTheory/ProductPrecategory.v
@@ -83,7 +83,7 @@ End power_precategory.
 
 Section functors.
 
-Definition pair_functor_data (I : UU) {A B : I -> precategory}
+Definition family_functor_data (I : UU) {A B : I -> precategory}
   (F : Π (i : I), functor (A i) (B i)) :
   functor_data (product_precategory I A)
                (product_precategory I B).
@@ -93,12 +93,12 @@ mkpair.
 - intros a b f i; apply (# (F i) (f i)).
 Defined.
 
-Definition pair_functor (I : UU) {A B : I -> precategory}
+Definition family_functor (I : UU) {A B : I -> precategory}
   (F : Π (i : I), functor (A i) (B i)) :
   functor (product_precategory I A)
           (product_precategory I B).
 Proof.
-apply (tpair _ (pair_functor_data I F)).
+apply (tpair _ (family_functor_data I F)).
 abstract
   (split; [ intro x; apply funextsec; intro i; simpl; apply functor_id
           | intros x y z f g; apply funextsec; intro i; apply functor_comp]).

--- a/UniMath/CategoryTheory/bicategories/Cat.v
+++ b/UniMath/CategoryTheory/bicategories/Cat.v
@@ -27,7 +27,7 @@ Definition Catlike_associator ( a b c d : precategory )
    (hsB : has_homsets b) (hsC : has_homsets c) (hsD : has_homsets d) :
    nat_trans
      (functor_composite
-        (binproduct_pair_functor
+        (pair_functor
            (functor_identity (functor_precategory a b hsB))
            (functorial_composition b c d hsC hsD))
         (functorial_composition a b d hsB hsD))
@@ -36,7 +36,7 @@ Definition Catlike_associator ( a b c d : precategory )
            (functor_precategory b c hsC)
            (functor_precategory c d hsD))
         (functor_composite
-           (binproduct_pair_functor
+           (pair_functor
               (functorial_composition a b c hsB hsC)
               (functor_identity (functor_precategory c d hsD)))
            (functorial_composition a c d hsC hsD))).

--- a/UniMath/CategoryTheory/bicategories/prebicategory.v
+++ b/UniMath/CategoryTheory/bicategories/prebicategory.v
@@ -121,12 +121,12 @@ Local Notation "alpha ;hi; beta" := (compose_2mor_iso_horizontal alpha beta) (at
 Definition associator_trans_type { C : prebicategory_id_comp } (a b c d : C) :=
   nat_trans
     (functor_composite
-      (binproduct_pair_functor (functor_identity _) (compose_functor b c d))
+      (pair_functor (functor_identity _) (compose_functor b c d))
       (compose_functor a b d))
     (functor_composite
       (precategory_binproduct_assoc _ _ _)
       (functor_composite
-        (binproduct_pair_functor (compose_functor a b c) (functor_identity _))
+        (pair_functor (compose_functor a b c) (functor_identity _))
         (compose_functor a c d))).
 
 Definition left_unitor_trans_type { C : prebicategory_id_comp } (a b : C) :=

--- a/UniMath/CategoryTheory/bicategories/whiskering.v
+++ b/UniMath/CategoryTheory/bicategories/whiskering.v
@@ -261,7 +261,7 @@ Lemma associator_naturality {C : prebicategory} { a b c d : C }
 Proof.
   pathvia ((functor_on_morphisms
             (functor_composite
-              (binproduct_pair_functor (functor_identity _) (compose_functor b c d))
+              (pair_functor (functor_identity _) (compose_functor b c d))
               (compose_functor a b d))
            (precatbinprodmor alpha (precatbinprodmor beta gamma)))
            ;v; associator f' g' h'
@@ -273,7 +273,7 @@ Proof.
             (functor_composite
               (precategory_binproduct_assoc _ _ _)
               (functor_composite
-                (binproduct_pair_functor (compose_functor a b c) (functor_identity _))
+                (pair_functor (compose_functor a b c) (functor_identity _))
                 (compose_functor a c d)))
             (precatbinprodmor alpha (precatbinprodmor beta gamma)))).
     apply (nat_trans_ax (associator_trans a b c d) _ _

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -675,7 +675,7 @@ Defined.
 Definition BinCoproduct_of_functors_alt {C D : precategory}
   (HD : BinCoproducts D) (F G : functor C D) : functor C D :=
   functor_composite (bindelta_functor C)
-     (functor_composite (binproduct_pair_functor F G) (bincoproduct_functor HD)).
+     (functor_composite (pair_functor F G) (bincoproduct_functor HD)).
 
 End functors.
 

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -949,10 +949,8 @@ End def_functor_pointwise_coprod.
 
 Section option_functor.
 
-Variables (C : precategory) (hsC : has_homsets C) (CC : BinCoproducts C).
-
-Variable terminal : Terminal C.
-Let one : C :=  @TerminalObject C terminal.
+Context {C : precategory} (CC : BinCoproducts C) (TC : Terminal C).
+Let one : C := TerminalObject TC.
 
 Definition option_functor : functor C C :=
   BinCoproduct_of_functors C C CC (constant_functor _ _ one) (functor_identity C).

--- a/UniMath/CategoryTheory/limits/binproducts.v
+++ b/UniMath/CategoryTheory/limits/binproducts.v
@@ -357,7 +357,7 @@ End binproduct_functor.
 Definition BinProduct_of_functors_alt {C D : precategory} (HD : BinProducts D)
   (F G : functor C D) : functor C D :=
   functor_composite (bindelta_functor C)
-     (functor_composite (binproduct_pair_functor F G) (binproduct_functor HD)).
+     (functor_composite (pair_functor F G) (binproduct_functor HD)).
 
 
 (** In the following section we show that if the morphism to components are

--- a/UniMath/CategoryTheory/limits/coproducts.v
+++ b/UniMath/CategoryTheory/limits/coproducts.v
@@ -208,7 +208,7 @@ End functors.
 Definition coproduct_of_functors_alt (I : UU) {C D : precategory}
   (HD : Coproducts I D) (F : I -> functor C D) : functor C D :=
   functor_composite (delta_functor I C)
-     (functor_composite (pair_functor _ F)
+     (functor_composite (family_functor _ F)
                         (coproduct_functor _ HD)).
 
 (** * Coproducts lift to functor categories *)

--- a/UniMath/CategoryTheory/limits/products.v
+++ b/UniMath/CategoryTheory/limits/products.v
@@ -210,7 +210,7 @@ Definition product_of_functors_alt
   (I : UU) {C D : precategory} (HD : Products I D)
   (F : Π (i : I), functor C D) : functor C D :=
    functor_composite (delta_functor I C)
-     (functor_composite (pair_functor _ F) (product_functor _ HD)).
+     (functor_composite (family_functor _ F) (product_functor _ HD)).
 
 (** * Products lift to functor categories *)
 Section def_functor_pointwise_prod.

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -98,7 +98,7 @@ Context (BCC : BinCoproducts C) (BPC : BinProducts C)
         (IC : Initial C) (TC : Terminal C)
         (LC : Lims C) (CLC : Colims C).
 
-Let optionC := (option_functor C BCC TC).
+Let optionC := (option_functor BCC TC).
 
 (** Form "_ o option^n" and return Id if n = 0 *)
 Definition precomp_option_iter (n : nat) : functor C2 C2.

--- a/UniMath/SubstitutionSystems/LamFromBindingSig.v
+++ b/UniMath/SubstitutionSystems/LamFromBindingSig.v
@@ -48,7 +48,7 @@ Local Notation "'Id'" := (functor_identity _).
 Local Notation "F * G" := (H HSET has_homsets_HSET BinProductsHSET F G).
 Local Notation "F + G" := (BinSumOfSignatures.H _ _ BinCoproductsHSET F G).
 Local Notation "'_' 'o' 'option'" :=
-  (ℓ (option_functor HSET BinCoproductsHSET TerminalHSET)) (at level 10).
+  (ℓ (option_functor BinCoproductsHSET TerminalHSET)) (at level 10).
 
 Local Definition has_homsets_HSET2 : has_homsets HSET2.
 Proof.
@@ -62,7 +62,7 @@ Defined.
 
 Local Notation "x ⊗ y" := (BinProductObject _ (BinProductsHSET2 x y)) (at level 10).
 Let precomp_option X := (pre_composition_functor _ _ HSET has_homsets_HSET has_homsets_HSET
-                        (option_functor HSET BinCoproductsHSET TerminalHSET) X).
+                          (option_functor BinCoproductsHSET TerminalHSET) X).
 Local Notation "X + 1" := (precomp_option X) (at level 50).
 Local Notation "'1'" := (functor_identity HSET).
 

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -163,7 +163,7 @@ Defined.
 
 Definition Abs_H : functor [C, C, hs] [C, C, hs] :=
  (* tpair _ _ is_functor_Abs_H_data. *)
-  pre_composition_functor _ _ _ hs _ (option_functor C CC terminal).
+  pre_composition_functor _ _ _ hs _ (option_functor CC terminal).
 
 Lemma is_omega_cocont_Abs_H (LC : Lims C) : is_omega_cocont Abs_H.
 Proof.

--- a/UniMath/SubstitutionSystems/SignatureExamples.v
+++ b/UniMath/SubstitutionSystems/SignatureExamples.v
@@ -254,7 +254,7 @@ Variables (C : precategory) (hsC : has_homsets C) (TC : Terminal C) (CC : BinCop
 
 Local Notation "'Ptd'" := (precategory_Ptd C hsC).
 
-Let opt := option_functor C CC TC.
+Let opt := option_functor CC TC.
 
 Definition δ_option_mor (Ze : Ptd) (c : C) :  C ⟦ BinCoproductObject C (CC TC (pr1 Ze c)),
                                                   pr1 Ze (BinCoproductObject C (CC TC c)) ⟧.


### PR DESCRIPTION
This PR does the following:

- Rename `pair_functor` to `family_functor`
- Rename `binproduct_pair_functor` to `pair_functor`
- Removes unnecessary assumption of has_homsets and makes the category implicit for `option_functor`.