### PR TITLE
Rename abgrfrac and Dcuts_def_error

### DIFF
--- a/UniMath/CategoryTheory/category_abgr.v
+++ b/UniMath/CategoryTheory/category_abgr.v
@@ -1327,7 +1327,7 @@ Section ABGR_monics.
   Qed.
 
   Definition ABGR_integer_map_iscomprelfun {A : abgr} (a : A) :
-    iscomprelfun (binopeqrelabgrfrac (rigaddabmonoid natcommrig)) (ABGR_natset_dirprod_map a).
+    iscomprelfun (binopeqrelabgrdiff (rigaddabmonoid natcommrig)) (ABGR_natset_dirprod_map a).
   Proof.
     intros x. induction x as [t p]. induction p as [|p IHp].
     - intros x'. induction x' as [t0 p]. induction p as [|p IHp].

--- a/UniMath/Foundations/Algebra/Archimedean.v
+++ b/UniMath/Foundations/Algebra/Archimedean.v
@@ -258,7 +258,7 @@ Proof.
 Defined.
 
 
-Local Lemma isarchabgrfrac_aux {X : abmonoid} (R : hrel X)
+Local Lemma isarchabgrdiff_aux {X : abmonoid} (R : hrel X)
       (Hr : isbinophrel R)
       (Hr' : istrans R)
       (y1 y2 x : abmonoiddirprod X X)
@@ -268,13 +268,13 @@ Local Lemma isarchabgrfrac_aux {X : abmonoid} (R : hrel X)
       (n2 : nat)
       (Hn2 : setquot_aux R (natmult n2 (pr1 y1 * pr2 y2)%multmonoid)
                          (natmult n2 (pr1 y2 * pr2 y1) * pr2 x)%multmonoid) :
-  abgrfracrel X Hr
-              (natmult (X := abgrfrac X) (n1 + n2) (setquotpr (binopeqrelabgrfrac X) y1) *
-               setquotpr (binopeqrelabgrfrac X) x)%multmonoid
-              (natmult (X := abgrfrac X) (n1 + n2) (setquotpr (binopeqrelabgrfrac X) y2)).
+  abgrdiffrel X Hr
+              (natmult (X := abgrdiff X) (n1 + n2) (setquotpr (binopeqrelabgrdiff X) y1) *
+               setquotpr (binopeqrelabgrdiff X) x)%multmonoid
+              (natmult (X := abgrdiff X) (n1 + n2) (setquotpr (binopeqrelabgrdiff X) y2)).
 Proof.
   intros.
-  assert (H0 : Π n y, natmult (X := abgrfrac X) n (setquotpr (binopeqrelabgrfrac X) y) = setquotpr (binopeqrelabgrfrac X) (natmult n (pr1 y) ,, natmult n (pr2 y))).
+  assert (H0 : Π n y, natmult (X := abgrdiff X) n (setquotpr (binopeqrelabgrdiff X) y) = setquotpr (binopeqrelabgrdiff X) (natmult n (pr1 y) ,, natmult n (pr2 y))).
   { intros n y.
     induction n as [|n IHn].
     reflexivity.
@@ -324,14 +324,14 @@ Proof.
   apply (pr1 Hr).
   apply Hc2.
 Qed.
-Lemma isarchabgrfrac {X : abmonoid} (R : hrel X)  (Hr : isbinophrel R) :
+Lemma isarchabgrdiff {X : abmonoid} (R : hrel X)  (Hr : isbinophrel R) :
   istrans R ->
   isarchmonoid (setquot_aux R) ->
-  isarchgr (X := abgrfrac X) (abgrfracrel X (L := R) Hr).
+  isarchgr (X := abgrdiff X) (abgrdiffrel X (L := R) Hr).
 Proof.
   intros X R Hr Hr' H.
-  simple refine (setquotuniv3prop _ (λ x y1 y2, (abgrfracrel X Hr y1 y2 ->
-    ∃ n : nat, abgrfracrel X Hr (natmult (X := abgrfrac X) n y1 * x)%multmonoid (natmult (X := abgrfrac X) n y2)) ,, _) _).
+  simple refine (setquotuniv3prop _ (λ x y1 y2, (abgrdiffrel X Hr y1 y2 ->
+    ∃ n : nat, abgrdiffrel X Hr (natmult (X := abgrdiff X) n y1 * x)%multmonoid (natmult (X := abgrdiff X) n y2)) ,, _) _).
   abstract apply isapropimpl, propproperty.
   intros x y1 y2 Hy.
   eapply hinhfun2.
@@ -339,7 +339,7 @@ Proof.
   2: apply (isarchmonoid_2 _ H (pr2 x) (pr1 y1 * pr2 y2)%multmonoid (pr1 y2 * pr2 y1)%multmonoid), Hy.
   intros n1 n2.
   exists (pr1 n1 + pr1 n2)%nat.
-  apply isarchabgrfrac_aux.
+  apply isarchabgrdiff_aux.
   exact Hr'.
   exact (pr2 n1).
   exact (pr2 n2).
@@ -620,9 +620,9 @@ Proof.
   abstract (apply hinhpr ; simpl ;
   exists 0%rig ; rewrite !rigrunax1 ;
   exact Hr).
-  now apply (istransabgrfracrel (rigaddabmonoid X)).
-  now generalize Hadd ; apply isbinopabgrfracrel.
-  apply (isarchabgrfrac (X := rigaddabmonoid X)).
+  now apply (istransabgrdiffrel (rigaddabmonoid X)).
+  now generalize Hadd ; apply isbinopabgrdiffrel.
+  apply (isarchabgrdiff (X := rigaddabmonoid X)).
   exact Htra.
   apply isarchrig_isarchmonoid.
   abstract (apply hinhpr ; simpl ;
@@ -642,8 +642,8 @@ Proof.
     intros (n,Hn).
     exists n.
     assert ((nattorng (X := rigtorng X) n * setquotpr
-    (binopeqrelabgrfrac (rigaddabmonoid X)) x)%rng = (setquotpr
-    (binopeqrelabgrfrac (rigaddabmonoid X)) (nattorig n * pr1 x ,,
+    (binopeqrelabgrdiff (rigaddabmonoid X)) x)%rng = (setquotpr
+    (binopeqrelabgrdiff (rigaddabmonoid X)) (nattorig n * pr1 x ,,
     nattorig n * pr2 x))%rng).
     { clear.
       induction n as [|n IHn].
@@ -679,7 +679,7 @@ Proof.
     exists (n1 + n2)%nat.
     revert Hn1 Hn2.
     assert (nattorng (X := rigtorng X) (n1 + n2) = setquotpr
-    (binopeqrelabgrfrac (rigaddabmonoid X)) (nattorig (n1 + n2) ,,
+    (binopeqrelabgrdiff (rigaddabmonoid X)) (nattorig (n1 + n2) ,,
     0%rig)).
     { generalize (n1 + n2) ; clear.
       induction n as [|n IHn].

--- a/UniMath/Foundations/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Foundations/Algebra/Monoids_and_Groups.v
@@ -37,7 +37,7 @@
   - Abelian group of fractions in the case when all elements are
     cancelable
   - Relations on the abelian group of fractions
-  - Relations and the canonical homomorphism to [abgrfrac]
+  - Relations and the canonical homomorphism to [abgrdiff]
 *)
 
 
@@ -1568,17 +1568,17 @@ Defined.
 
 Open Scope addmonoid_scope.
 
-Definition hrelabgrfrac (X : abmonoid) : hrel (dirprod X X) :=
+Definition hrelabgrdiff (X : abmonoid) : hrel (dirprod X X) :=
   fun xa1 xa2 =>
     hexists (fun x0 : X => paths (((pr1 xa1) + (pr2 xa2)) + x0) (((pr1 xa2) + (pr2 xa1)) + x0)).
 
-Definition abgrfracphi (X : abmonoid) (xa : dirprod X X) :
+Definition abgrdiffphi (X : abmonoid) (xa : dirprod X X) :
   dirprod X (totalsubtype X) := dirprodpair (pr1 xa) (carrierpair (fun x : X => htrue) (pr2 xa) tt).
 
-Definition hrelabgrfrac' (X : abmonoid) : hrel (dirprod X X) :=
-  fun xa1 xa2 => eqrelabmonoidfrac X (totalsubmonoid X) (abgrfracphi X xa1) (abgrfracphi X xa2).
+Definition hrelabgrdiff' (X : abmonoid) : hrel (dirprod X X) :=
+  fun xa1 xa2 => eqrelabmonoidfrac X (totalsubmonoid X) (abgrdiffphi X xa1) (abgrdiffphi X xa2).
 
-Lemma logeqhrelsabgrfrac (X : abmonoid) : hrellogeq (hrelabgrfrac' X) (hrelabgrfrac X).
+Lemma logeqhrelsabgrdiff (X : abmonoid) : hrellogeq (hrelabgrdiff' X) (hrelabgrdiff X).
 Proof.
   intros. split. simpl. apply hinhfun. intro t2.
   set (a0 := pr1 (pr1 t2)). split with a0. apply (pr2 t2). simpl.
@@ -1586,10 +1586,10 @@ Proof.
   apply (pr2 t2).
 Defined.
 
-Lemma iseqrelabgrfrac (X : abmonoid) : iseqrel (hrelabgrfrac X).
+Lemma iseqrelabgrdiff (X : abmonoid) : iseqrel (hrelabgrdiff X).
 Proof.
   intro.
-  apply (iseqrellogeqf (logeqhrelsabgrfrac X)).
+  apply (iseqrellogeqf (logeqhrelsabgrdiff X)).
   apply (iseqrelconstr).
   intros xx' xx'' xx'''.
   intros r1 r2.
@@ -1598,15 +1598,15 @@ Proof.
   intros xx xx'. intro r.
   apply (eqrelsymm (eqrelabmonoidfrac X (totalsubmonoid X)) _ _ r).
 Defined.
-Opaque iseqrelabgrfrac.
+Opaque iseqrelabgrdiff.
 
-Definition eqrelabgrfrac (X : abmonoid) : @eqrel (abmonoiddirprod X X) :=
-  eqrelpair _ (iseqrelabgrfrac X).
+Definition eqrelabgrdiff (X : abmonoid) : @eqrel (abmonoiddirprod X X) :=
+  eqrelpair _ (iseqrelabgrdiff X).
 
-Lemma isbinophrelabgrfrac (X : abmonoid) : @isbinophrel (abmonoiddirprod X X) (hrelabgrfrac X).
+Lemma isbinophrelabgrdiff (X : abmonoid) : @isbinophrel (abmonoiddirprod X X) (hrelabgrdiff X).
 Proof.
   intro.
-  apply (@isbinophrellogeqf (abmonoiddirprod X X) _ _ (logeqhrelsabgrfrac X)).
+  apply (@isbinophrellogeqf (abmonoiddirprod X X) _ _ (logeqhrelsabgrdiff X)).
   split. intros a b c r.
   apply (pr1 (isbinophrelabmonoidfrac X (totalsubmonoid X)) _ _
              (dirprodpair (pr1 c) (carrierpair (fun x : X => htrue) (pr2 c) tt))
@@ -1616,21 +1616,21 @@ Proof.
              (dirprodpair (pr1 c) (carrierpair (fun x : X => htrue) (pr2 c) tt))
              r).
 Defined.
-Opaque isbinophrelabgrfrac.
+Opaque isbinophrelabgrdiff.
 
-Definition binopeqrelabgrfrac (X : abmonoid) : @binopeqrel (abmonoiddirprod X X) :=
-  binopeqrelpair (eqrelabgrfrac X) (isbinophrelabgrfrac X).
+Definition binopeqrelabgrdiff (X : abmonoid) : @binopeqrel (abmonoiddirprod X X) :=
+  binopeqrelpair (eqrelabgrdiff X) (isbinophrelabgrdiff X).
 
-Definition abgrfraccarrier (X : abmonoid) : abmonoid := @abmonoidquot (abmonoiddirprod X X)
-                                                                      (binopeqrelabgrfrac X).
+Definition abgrdiffcarrier (X : abmonoid) : abmonoid := @abmonoidquot (abmonoiddirprod X X)
+                                                                      (binopeqrelabgrdiff X).
 
-Definition abgrfracinvint (X : abmonoid) :  dirprod X X -> dirprod X X :=
+Definition abgrdiffinvint (X : abmonoid) :  dirprod X X -> dirprod X X :=
   fun xs : _ => dirprodpair (pr2 xs) (pr1 xs).
 
-Lemma abgrfracinvcomp (X : abmonoid) :
-  iscomprelrelfun (hrelabgrfrac X) (eqrelabgrfrac X) (abgrfracinvint X).
+Lemma abgrdiffinvcomp (X : abmonoid) :
+  iscomprelrelfun (hrelabgrdiff X) (eqrelabgrdiff X) (abgrdiffinvint X).
 Proof.
-  intros. unfold iscomprelrelfun. unfold eqrelabgrfrac. unfold hrelabgrfrac.
+  intros. unfold iscomprelrelfun. unfold eqrelabgrdiff. unfold hrelabgrdiff.
   unfold eqrelabmonoidfrac. unfold hrelabmonoidfrac. simpl. intros xs xs'.
   apply (hinhfun). intro tt0.
   set (x := pr1 xs). set (s := pr2 xs).
@@ -1642,50 +1642,50 @@ Proof.
   set (e := commax X s x'). simpl in e. rewrite e. clear e.
   apply eq.
 Defined.
-Opaque abgrfracinvcomp.
+Opaque abgrdiffinvcomp.
 
-Definition abgrfracinv (X : abmonoid) : abgrfraccarrier X -> abgrfraccarrier X :=
-  setquotfun (hrelabgrfrac X) (eqrelabgrfrac X) (abgrfracinvint X) (abgrfracinvcomp X).
+Definition abgrdiffinv (X : abmonoid) : abgrdiffcarrier X -> abgrdiffcarrier X :=
+  setquotfun (hrelabgrdiff X) (eqrelabgrdiff X) (abgrdiffinvint X) (abgrdiffinvcomp X).
 
-Lemma abgrfracisinv (X : abmonoid) :
-  isinv (@op (abgrfraccarrier X)) (unel (abgrfraccarrier X)) (abgrfracinv X).
+Lemma abgrdiffisinv (X : abmonoid) :
+  isinv (@op (abgrdiffcarrier X)) (unel (abgrdiffcarrier X)) (abgrdiffinv X).
 Proof.
-  intros. set (R := eqrelabgrfrac X).
-  assert (isl : islinv (@op (abgrfraccarrier X)) (unel (abgrfraccarrier X)) (abgrfracinv X)).
+  intros. set (R := eqrelabgrdiff X).
+  assert (isl : islinv (@op (abgrdiffcarrier X)) (unel (abgrdiffcarrier X)) (abgrdiffinv X)).
   {
     unfold islinv.
     apply (setquotunivprop
-             R (fun x : abgrfraccarrier X => eqset (abgrfracinv X x + x) (unel (abgrfraccarrier X)))).
+             R (fun x : abgrdiffcarrier X => eqset (abgrdiffinv X x + x) (unel (abgrdiffcarrier X)))).
     intro xs.
     set (x := pr1 xs). set (s := pr2 xs).
-    apply (iscompsetquotpr R (@op (abmonoiddirprod X X) (abgrfracinvint X xs) xs) (unel _)).
+    apply (iscompsetquotpr R (@op (abmonoiddirprod X X) (abgrdiffinvint X xs) xs) (unel _)).
     simpl. apply hinhpr. split with (unel X).
     change (paths (s + x + (unel X) + (unel X)) ((unel X) + (x + s) + (unel X))).
     destruct (commax X x s). destruct (commax X (unel X) (x + s)).
     apply idpath.
   }
-  apply (dirprodpair isl (weqlinvrinv (@op (abgrfraccarrier X)) (commax (abgrfraccarrier X))
-                                      (unel (abgrfraccarrier X)) (abgrfracinv X) isl)).
+  apply (dirprodpair isl (weqlinvrinv (@op (abgrdiffcarrier X)) (commax (abgrdiffcarrier X))
+                                      (unel (abgrdiffcarrier X)) (abgrdiffinv X) isl)).
 Defined.
-Opaque abgrfracisinv.
+Opaque abgrdiffisinv.
 
-Definition abgrfrac (X : abmonoid) : abgr := abgrconstr (abgrfraccarrier X) (abgrfracinv X)
-                                                        (abgrfracisinv X).
+Definition abgrdiff (X : abmonoid) : abgr := abgrconstr (abgrdiffcarrier X) (abgrdiffinv X)
+                                                        (abgrdiffisinv X).
 
-Definition prabgrfrac (X : abmonoid) : X -> X -> abgrfrac X :=
-  fun x x' : X => setquotpr (eqrelabgrfrac X) (dirprodpair x x').
+Definition prabgrdiff (X : abmonoid) : X -> X -> abgrdiff X :=
+  fun x x' : X => setquotpr (eqrelabgrdiff X) (dirprodpair x x').
 
 
 (** **** Abelian group of fractions and abelian monoid of fractions *)
 
-Definition weqabgrfracint (X : abmonoid) : weq (dirprod X X) (dirprod X (totalsubtype X)) :=
+Definition weqabgrdiffint (X : abmonoid) : weq (dirprod X X) (dirprod X (totalsubtype X)) :=
   weqdirprodf (idweq X) (invweq (weqtotalsubtype X)).
 
-Definition weqabgrfrac (X : abmonoid) : weq (abgrfrac X) (abmonoidfrac X (totalsubmonoid X)).
+Definition weqabgrdiff (X : abmonoid) : weq (abgrdiff X) (abmonoidfrac X (totalsubmonoid X)).
 Proof.
   intros.
-  apply (weqsetquotweq (eqrelabgrfrac X)
-                       (eqrelabmonoidfrac X (totalsubmonoid X)) (weqabgrfracint X)).
+  apply (weqsetquotweq (eqrelabgrdiff X)
+                       (eqrelabmonoidfrac X (totalsubmonoid X)) (weqabgrdiffint X)).
   - simpl. intros x x'. destruct x as [ x1 x2 ]. destruct x' as [ x1' x2' ].
     simpl in *. apply hinhfun. intro tt0. destruct tt0 as [ xx0 is0 ].
     split with (carrierpair (fun x : X => htrue) xx0 tt). apply is0.
@@ -1697,90 +1697,90 @@ Defined.
 
 (** **** Canonical homomorphism to the abelian group of fractions *)
 
-Definition toabgrfrac (X : abmonoid) (x : X) : abgrfrac X := setquotpr _ (dirprodpair x (unel X)).
+Definition toabgrdiff (X : abmonoid) (x : X) : abgrdiff X := setquotpr _ (dirprodpair x (unel X)).
 
-Lemma isbinopfuntoabgrfrac (X : abmonoid) : isbinopfun (toabgrfrac X).
+Lemma isbinopfuntoabgrdiff (X : abmonoid) : isbinopfun (toabgrdiff X).
 Proof.
   intros. unfold isbinopfun. intros x1 x2.
   change (paths (setquotpr _ (dirprodpair (x1 + x2) (unel X)))
-                (setquotpr (eqrelabgrfrac X) (dirprodpair (x1 + x2) ((unel X) + (unel X))))).
+                (setquotpr (eqrelabgrdiff X) (dirprodpair (x1 + x2) ((unel X) + (unel X))))).
   apply (maponpaths (setquotpr _)).
   apply (@pathsdirprod X X).
   apply idpath.
   apply (pathsinv0 (lunax X 0)).
 Defined.
 
-Lemma isunitalfuntoabgrfrac (X : abmonoid) : paths (toabgrfrac X (unel X)) (unel (abgrfrac X)).
+Lemma isunitalfuntoabgrdiff (X : abmonoid) : paths (toabgrdiff X (unel X)) (unel (abgrdiff X)).
 Proof. intros. apply idpath. Defined.
 
-Definition ismonoidfuntoabgrfrac (X : abmonoid) : ismonoidfun (toabgrfrac X) :=
-  dirprodpair (isbinopfuntoabgrfrac X) (isunitalfuntoabgrfrac X).
+Definition ismonoidfuntoabgrdiff (X : abmonoid) : ismonoidfun (toabgrdiff X) :=
+  dirprodpair (isbinopfuntoabgrdiff X) (isunitalfuntoabgrdiff X).
 
 
 (** **** Abelian group of fractions in the case when all elements are cancelable *)
 
-Lemma isinclprabgrfrac (X : abmonoid) (iscanc : Π x : X, isrcancelable (@op X) x) :
-  Π x' : X, isincl (fun x => prabgrfrac X x x').
+Lemma isinclprabgrdiff (X : abmonoid) (iscanc : Π x : X, isrcancelable (@op X) x) :
+  Π x' : X, isincl (fun x => prabgrdiff X x x').
 Proof.
   intros.
   set (int := isinclprabmonoidfrac X (totalsubmonoid X) (fun a : totalsubmonoid X => iscanc (pr1 a))
                                    (carrierpair (fun x : X => htrue) x' tt)).
-  set (int1 := isinclcomp (inclpair _ int) (invweq (weqabgrfrac X))).
+  set (int1 := isinclcomp (inclpair _ int) (invweq (weqabgrdiff X))).
   apply int1.
 Defined.
 
-Definition isincltoabgrfrac (X : abmonoid) (iscanc : Π x : X, isrcancelable (@op X) x) :
-  isincl (toabgrfrac X) := isinclprabgrfrac X iscanc (unel X).
+Definition isincltoabgrdiff (X : abmonoid) (iscanc : Π x : X, isrcancelable (@op X) x) :
+  isincl (toabgrdiff X) := isinclprabgrdiff X iscanc (unel X).
 
-Lemma isdeceqabgrfrac (X : abmonoid) (iscanc : Π x : X, isrcancelable (@op X) x) (is : isdeceq X) :
-  isdeceq (abgrfrac X).
+Lemma isdeceqabgrdiff (X : abmonoid) (iscanc : Π x : X, isrcancelable (@op X) x) (is : isdeceq X) :
+  isdeceq (abgrdiff X).
 Proof.
   intros.
-  apply (isdeceqweqf (invweq (weqabgrfrac X))).
+  apply (isdeceqweqf (invweq (weqabgrdiff X))).
   apply (isdeceqabmonoidfrac X (totalsubmonoid X) (fun a : totalsubmonoid X => iscanc (pr1 a)) is).
 Defined.
 
 
 (** **** Relations on the abelian group of fractions *)
 
-Definition abgrfracrelint (X : abmonoid) (L : hrel X) : hrel (setwithbinopdirprod X X) :=
+Definition abgrdiffrelint (X : abmonoid) (L : hrel X) : hrel (setwithbinopdirprod X X) :=
   fun xa yb => hexists (fun c0 : X => L (((pr1 xa) + (pr2 yb)) + c0) (((pr1 yb) + (pr2 xa)) + c0)).
 
-Definition abgrfracrelint' (X : abmonoid) (L : hrel X) : hrel (setwithbinopdirprod X X) :=
-  fun xa1 xa2 => abmonoidfracrelint _ (totalsubmonoid X) L (abgrfracphi X xa1) (abgrfracphi X xa2).
+Definition abgrdiffrelint' (X : abmonoid) (L : hrel X) : hrel (setwithbinopdirprod X X) :=
+  fun xa1 xa2 => abmonoidfracrelint _ (totalsubmonoid X) L (abgrdiffphi X xa1) (abgrdiffphi X xa2).
 
-Lemma logeqabgrfracrelints (X : abmonoid) (L : hrel X) :
-  hrellogeq (abgrfracrelint' X L) (abgrfracrelint X L).
+Lemma logeqabgrdiffrelints (X : abmonoid) (L : hrel X) :
+  hrellogeq (abgrdiffrelint' X L) (abgrdiffrelint X L).
 Proof.
-  intros. split. unfold abgrfracrelint. unfold abgrfracrelint'.
+  intros. split. unfold abgrdiffrelint. unfold abgrdiffrelint'.
   simpl. apply hinhfun. intro t2. set (a0 := pr1 (pr1 t2)).
   split with a0. apply (pr2 t2). simpl. apply hinhfun.
   intro t2. set (x0 := pr1 t2). split with (tpair _ x0 tt). apply (pr2 t2).
 Defined.
 
-Lemma iscomprelabgrfracrelint (X : abmonoid) {L : hrel X} (is : isbinophrel L) :
-  iscomprelrel (eqrelabgrfrac X) (abgrfracrelint X L).
+Lemma iscomprelabgrdiffrelint (X : abmonoid) {L : hrel X} (is : isbinophrel L) :
+  iscomprelrel (eqrelabgrdiff X) (abgrdiffrelint X L).
 Proof.
-  intros. apply (iscomprelrellogeqf1 _ (logeqhrelsabgrfrac X)).
-  apply (iscomprelrellogeqf2 _ (logeqabgrfracrelints X L)).
+  intros. apply (iscomprelrellogeqf1 _ (logeqhrelsabgrdiff X)).
+  apply (iscomprelrellogeqf2 _ (logeqabgrdiffrelints X L)).
   intros x x' x0 x0' r r0.
   apply (iscomprelabmonoidfracrelint
            _ (totalsubmonoid X) (isbinoptoispartbinop _ _ is)  _ _ _ _ r r0).
 Defined.
-Opaque iscomprelabgrfracrelint.
+Opaque iscomprelabgrdiffrelint.
 
-Definition abgrfracrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) :=
-  quotrel (iscomprelabgrfracrelint X is).
+Definition abgrdiffrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) :=
+  quotrel (iscomprelabgrdiffrelint X is).
 
-Definition abgrfracrel' (X : abmonoid) {L : hrel X} (is : isbinophrel L) : hrel (abgrfrac X) :=
+Definition abgrdiffrel' (X : abmonoid) {L : hrel X} (is : isbinophrel L) : hrel (abgrdiff X) :=
   fun x x' => abmonoidfracrel X (totalsubmonoid X) (isbinoptoispartbinop _ _ is)
-                           (weqabgrfrac X x) (weqabgrfrac X x').
+                           (weqabgrdiff X x) (weqabgrdiff X x').
 
-Definition logeqabgrfracrels (X : abmonoid) {L : hrel X} (is : isbinophrel L) :
-  hrellogeq (abgrfracrel' X is) (abgrfracrel X is).
+Definition logeqabgrdiffrels (X : abmonoid) {L : hrel X} (is : isbinophrel L) :
+  hrellogeq (abgrdiffrel' X is) (abgrdiffrel X is).
 Proof.
   intros X L is x1 x2. split.
-  - assert (int : Π x x', isaprop (abgrfracrel' X is x x' -> abgrfracrel X is x x')).
+  - assert (int : Π x x', isaprop (abgrdiffrel' X is x x' -> abgrdiffrel X is x x')).
     {
       intros x x'.
       apply impred. intro.
@@ -1789,183 +1789,183 @@ Proof.
     generalize x1 x2. clear x1 x2.
     apply (setquotuniv2prop _ (fun x x' => hProppair _ (int x x'))).
     intros x x'.
-    change ((abgrfracrelint' X L x x')  -> (abgrfracrelint _ L x x')).
-    apply (pr1 (logeqabgrfracrelints X L x x')).
-  - assert (int : Π x x', isaprop (abgrfracrel X is x x' -> abgrfracrel' X is x x')).
+    change ((abgrdiffrelint' X L x x')  -> (abgrdiffrelint _ L x x')).
+    apply (pr1 (logeqabgrdiffrelints X L x x')).
+  - assert (int : Π x x', isaprop (abgrdiffrel X is x x' -> abgrdiffrel' X is x x')).
     intros x x'.
     apply impred. intro.
     apply (pr2 _).
     generalize x1 x2. clear x1 x2.
     apply (setquotuniv2prop _ (fun x x' => hProppair _ (int x x'))).
     intros x x'.
-    change ((abgrfracrelint X L x x') -> (abgrfracrelint' _ L x x')).
-    apply (pr2 (logeqabgrfracrelints X L x x')).
+    change ((abgrdiffrelint X L x x') -> (abgrdiffrelint' _ L x x')).
+    apply (pr2 (logeqabgrdiffrelints X L x x')).
 Defined.
 
-Lemma istransabgrfracrelint (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : istrans L) :
-  istrans (abgrfracrelint X L).
+Lemma istransabgrdiffrelint (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : istrans L) :
+  istrans (abgrdiffrelint X L).
 Proof.
-  intros. apply (istranslogeqf (logeqabgrfracrelints X L)).
+  intros. apply (istranslogeqf (logeqabgrdiffrelints X L)).
   intros a b c rab rbc.
   apply (istransabmonoidfracrelint
            _ (totalsubmonoid X) (isbinoptoispartbinop _ _ is)  isl _ _ _ rab rbc).
 Defined.
-Opaque istransabgrfracrelint.
+Opaque istransabgrdiffrelint.
 
-Lemma istransabgrfracrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : istrans L) :
-  istrans (abgrfracrel X is).
+Lemma istransabgrdiffrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : istrans L) :
+  istrans (abgrdiffrel X is).
 Proof.
-  intros. refine (istransquotrel _ _). apply istransabgrfracrelint.
+  intros. refine (istransquotrel _ _). apply istransabgrdiffrelint.
   - apply is.
   - apply isl.
 Defined.
 
-Lemma issymmabgrfracrelint (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : issymm L) :
-  issymm (abgrfracrelint X L).
+Lemma issymmabgrdiffrelint (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : issymm L) :
+  issymm (abgrdiffrelint X L).
 Proof.
-  intros. apply (issymmlogeqf (logeqabgrfracrelints X L)).
+  intros. apply (issymmlogeqf (logeqabgrdiffrelints X L)).
   intros a b rab.
   apply (issymmabmonoidfracrelint _ (totalsubmonoid X) (isbinoptoispartbinop _ _ is) isl _ _ rab).
 Defined.
-Opaque issymmabgrfracrelint.
+Opaque issymmabgrdiffrelint.
 
-Lemma issymmabgrfracrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : issymm L) :
-  issymm (abgrfracrel X is).
+Lemma issymmabgrdiffrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : issymm L) :
+  issymm (abgrdiffrel X is).
 Proof.
-  intros. refine (issymmquotrel _ _). apply issymmabgrfracrelint.
+  intros. refine (issymmquotrel _ _). apply issymmabgrdiffrelint.
   - apply is.
   - apply isl.
 Defined.
 
-Lemma isreflabgrfracrelint (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : isrefl L) :
-  isrefl (abgrfracrelint X L).
+Lemma isreflabgrdiffrelint (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : isrefl L) :
+  isrefl (abgrdiffrelint X L).
 Proof.
-  intros. intro xa. unfold abgrfracrelint. simpl.
+  intros. intro xa. unfold abgrdiffrelint. simpl.
   apply hinhpr. split with (unel X). apply (isl _).
 Defined.
 
-Lemma isreflabgrfracrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : isrefl L) :
-  isrefl (abgrfracrel X is).
+Lemma isreflabgrdiffrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : isrefl L) :
+  isrefl (abgrdiffrel X is).
 Proof.
-  intros. refine (isreflquotrel _ _). apply isreflabgrfracrelint.
+  intros. refine (isreflquotrel _ _). apply isreflabgrdiffrelint.
   - apply is.
   - apply isl.
 Defined.
 
-Lemma ispoabgrfracrelint (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : ispreorder L) :
-  ispreorder (abgrfracrelint X L).
+Lemma ispoabgrdiffrelint (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : ispreorder L) :
+  ispreorder (abgrdiffrelint X L).
 Proof.
-  intros. split with (istransabgrfracrelint X is (pr1 isl)).
-  apply (isreflabgrfracrelint X is (pr2 isl)).
+  intros. split with (istransabgrdiffrelint X is (pr1 isl)).
+  apply (isreflabgrdiffrelint X is (pr2 isl)).
 Defined.
 
-Lemma ispoabgrfracrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : ispreorder L) :
-  ispreorder (abgrfracrel X is).
+Lemma ispoabgrdiffrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : ispreorder L) :
+  ispreorder (abgrdiffrel X is).
 Proof.
-  intros. refine (ispoquotrel _ _). apply ispoabgrfracrelint.
+  intros. refine (ispoquotrel _ _). apply ispoabgrdiffrelint.
   - apply is.
   - apply isl.
 Defined.
 
-Lemma iseqrelabgrfracrelint (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : iseqrel L) :
-  iseqrel (abgrfracrelint X L).
+Lemma iseqrelabgrdiffrelint (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : iseqrel L) :
+  iseqrel (abgrdiffrelint X L).
 Proof.
-  intros. split with (ispoabgrfracrelint X is (pr1 isl)).
-  apply (issymmabgrfracrelint X is (pr2 isl)).
+  intros. split with (ispoabgrdiffrelint X is (pr1 isl)).
+  apply (issymmabgrdiffrelint X is (pr2 isl)).
 Defined.
 
-Lemma iseqrelabgrfracrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : iseqrel L) :
-  iseqrel (abgrfracrel X is).
+Lemma iseqrelabgrdiffrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : iseqrel L) :
+  iseqrel (abgrdiffrel X is).
 Proof.
-  intros. refine (iseqrelquotrel _ _). apply iseqrelabgrfracrelint.
+  intros. refine (iseqrelquotrel _ _). apply iseqrelabgrdiffrelint.
   - apply is.
   - apply isl.
 Defined.
 
-Lemma isantisymmnegabgrfracrel (X : abmonoid) {L : hrel X} (is : isbinophrel L)
-      (isl : isantisymmneg L) : isantisymmneg (abgrfracrel X is).
+Lemma isantisymmnegabgrdiffrel (X : abmonoid) {L : hrel X} (is : isbinophrel L)
+      (isl : isantisymmneg L) : isantisymmneg (abgrdiffrel X is).
 Proof.
-  intros. apply (isantisymmneglogeqf (logeqabgrfracrels X is)).
+  intros. apply (isantisymmneglogeqf (logeqabgrdiffrels X is)).
   intros a b rab rba.
   set (int := isantisymmnegabmonoidfracrel _ (totalsubmonoid X) (isbinoptoispartbinop _ _ is)
-                                           isl (weqabgrfrac X a) (weqabgrfrac X b) rab rba).
+                                           isl (weqabgrdiff X a) (weqabgrdiff X b) rab rba).
   apply (invmaponpathsweq _ _ _ int).
 Defined.
 
-Lemma isantisymmabgrfracrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : isantisymm L) :
-  isantisymm (abgrfracrel X is).
+Lemma isantisymmabgrdiffrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : isantisymm L) :
+  isantisymm (abgrdiffrel X is).
 Proof.
-  intros. apply (isantisymmlogeqf (logeqabgrfracrels X is)).
+  intros. apply (isantisymmlogeqf (logeqabgrdiffrels X is)).
   intros a b rab rba.
   set (int := isantisymmabmonoidfracrel _ (totalsubmonoid X) (isbinoptoispartbinop _ _ is)
-                                        isl (weqabgrfrac X a) (weqabgrfrac X b) rab rba).
+                                        isl (weqabgrdiff X a) (weqabgrdiff X b) rab rba).
   apply (invmaponpathsweq _ _ _ int).
 Defined.
-Opaque  isantisymmabgrfracrel.
+Opaque  isantisymmabgrdiffrel.
 
-Lemma isirreflabgrfracrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : isirrefl L) :
-  isirrefl (abgrfracrel X is).
+Lemma isirreflabgrdiffrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : isirrefl L) :
+  isirrefl (abgrdiffrel X is).
 Proof.
-  intros. apply (isirrefllogeqf (logeqabgrfracrels X is)).
+  intros. apply (isirrefllogeqf (logeqabgrdiffrels X is)).
   intros a raa.
   apply (isirreflabmonoidfracrel _ (totalsubmonoid X) (isbinoptoispartbinop _ _ is)
-                                 isl (weqabgrfrac X a) raa).
+                                 isl (weqabgrdiff X a) raa).
 Defined.
-Opaque isirreflabgrfracrel.
+Opaque isirreflabgrdiffrel.
 
-Lemma isasymmabgrfracrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : isasymm L) :
-  isasymm (abgrfracrel X is).
+Lemma isasymmabgrdiffrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : isasymm L) :
+  isasymm (abgrdiffrel X is).
 Proof.
-  intros. apply (isasymmlogeqf (logeqabgrfracrels X is)).
+  intros. apply (isasymmlogeqf (logeqabgrdiffrels X is)).
   intros a b rab rba.
   apply (isasymmabmonoidfracrel _ (totalsubmonoid X) (isbinoptoispartbinop _ _ is)
-                                isl (weqabgrfrac X a) (weqabgrfrac X b) rab rba).
+                                isl (weqabgrdiff X a) (weqabgrdiff X b) rab rba).
 Defined.
-Opaque isasymmabgrfracrel.
+Opaque isasymmabgrdiffrel.
 
-Lemma iscoasymmabgrfracrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : iscoasymm L) :
-  iscoasymm (abgrfracrel X is).
+Lemma iscoasymmabgrdiffrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : iscoasymm L) :
+  iscoasymm (abgrdiffrel X is).
 Proof.
-  intros. apply (iscoasymmlogeqf (logeqabgrfracrels X is)).
+  intros. apply (iscoasymmlogeqf (logeqabgrdiffrels X is)).
   intros a b rab.
   apply (iscoasymmabmonoidfracrel _ (totalsubmonoid X) (isbinoptoispartbinop _ _ is)
-                                  isl (weqabgrfrac X a) (weqabgrfrac X b) rab).
+                                  isl (weqabgrdiff X a) (weqabgrdiff X b) rab).
 Defined.
-Opaque iscoasymmabgrfracrel.
+Opaque iscoasymmabgrdiffrel.
 
-Lemma istotalabgrfracrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : istotal L) :
-  istotal (abgrfracrel X is).
+Lemma istotalabgrdiffrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : istotal L) :
+  istotal (abgrdiffrel X is).
 Proof.
-  intros. apply (istotallogeqf (logeqabgrfracrels X is)).
+  intros. apply (istotallogeqf (logeqabgrdiffrels X is)).
   intros a b.
   apply (istotalabmonoidfracrel _ (totalsubmonoid X) (isbinoptoispartbinop _ _ is)
-                                isl (weqabgrfrac X a) (weqabgrfrac X b)).
+                                isl (weqabgrdiff X a) (weqabgrdiff X b)).
 Defined.
-Opaque istotalabgrfracrel.
+Opaque istotalabgrdiffrel.
 
-Lemma iscotransabgrfracrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : iscotrans L) :
-  iscotrans (abgrfracrel X is).
+Lemma iscotransabgrdiffrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) (isl : iscotrans L) :
+  iscotrans (abgrdiffrel X is).
 Proof.
-  intros. apply (iscotranslogeqf (logeqabgrfracrels X is)).
+  intros. apply (iscotranslogeqf (logeqabgrdiffrels X is)).
   intros a b c.
   apply (iscotransabmonoidfracrel _ (totalsubmonoid X) (isbinoptoispartbinop _ _ is)
-                                  isl (weqabgrfrac X a) (weqabgrfrac X b) (weqabgrfrac X c)).
+                                  isl (weqabgrdiff X a) (weqabgrdiff X b) (weqabgrdiff X c)).
 Defined.
-Opaque iscotransabgrfracrel.
+Opaque iscotransabgrdiffrel.
 
-Lemma abgrfracrelimpl (X : abmonoid) {L L' : hrel X} (is : isbinophrel L) (is' : isbinophrel L')
-      (impl : Π x x', L x x' -> L' x x') (x x' : abgrfrac X) (ql : abgrfracrel X is x x') :
-  abgrfracrel X is' x x'.
+Lemma abgrdiffrelimpl (X : abmonoid) {L L' : hrel X} (is : isbinophrel L) (is' : isbinophrel L')
+      (impl : Π x x', L x x' -> L' x x') (x x' : abgrdiff X) (ql : abgrdiffrel X is x x') :
+  abgrdiffrel X is' x x'.
 Proof.
   intros. generalize ql. refine (quotrelimpl _ _ _ _ _).
   intros x0 x0'. simpl. apply hinhfun. intro t2. split with (pr1 t2).
   apply (impl _ _ (pr2 t2)).
 Defined.
-Opaque abgrfracrelimpl.
+Opaque abgrdiffrelimpl.
 
-Lemma abgrfracrellogeq (X : abmonoid) {L L' : hrel X} (is : isbinophrel L) (is' : isbinophrel L')
-      (lg : Π x x', L x x' <-> L' x x') (x x' : abgrfrac X) :
-  (abgrfracrel X is x x') <-> (abgrfracrel X is' x x').
+Lemma abgrdiffrellogeq (X : abmonoid) {L L' : hrel X} (is : isbinophrel L) (is' : isbinophrel L')
+      (lg : Π x x', L x x' <-> L' x x') (x x' : abgrdiff X) :
+  (abgrdiffrel X is x x') <-> (abgrdiffrel X is' x x').
 Proof.
   intros. refine (quotrellogeq _ _ _ _ _). intros x0 x0'. split.
   - simpl. apply hinhfun. intro t2. split with (pr1 t2).
@@ -1973,66 +1973,66 @@ Proof.
   - simpl. apply hinhfun. intro t2. split with (pr1 t2).
     apply (pr2 (lg _ _) (pr2 t2)).
 Defined.
-Opaque abgrfracrellogeq.
+Opaque abgrdiffrellogeq.
 
-Lemma isbinopabgrfracrelint (X : abmonoid) {L : hrel X} (is : isbinophrel L) :
-  @isbinophrel (setwithbinopdirprod X X) (abgrfracrelint X L).
+Lemma isbinopabgrdiffrelint (X : abmonoid) {L : hrel X} (is : isbinophrel L) :
+  @isbinophrel (setwithbinopdirprod X X) (abgrdiffrelint X L).
 Proof.
-  intros. apply (isbinophrellogeqf (logeqabgrfracrelints X L)). split.
+  intros. apply (isbinophrellogeqf (logeqabgrdiffrelints X L)). split.
   - intros a b c lab.
     apply (pr1 (ispartbinopabmonoidfracrelint _ (totalsubmonoid X) (isbinoptoispartbinop _ _ is))
-               (abgrfracphi X a) (abgrfracphi X b) (abgrfracphi X c) tt lab).
+               (abgrdiffphi X a) (abgrdiffphi X b) (abgrdiffphi X c) tt lab).
   - intros a b c lab.
     apply (pr2 (ispartbinopabmonoidfracrelint _ (totalsubmonoid X) (isbinoptoispartbinop _ _ is))
-               (abgrfracphi X a) (abgrfracphi X b) (abgrfracphi X c) tt lab).
+               (abgrdiffphi X a) (abgrdiffphi X b) (abgrdiffphi X c) tt lab).
 Defined.
-Opaque isbinopabgrfracrelint.
+Opaque isbinopabgrdiffrelint.
 
-Lemma isbinopabgrfracrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) :
-  @isbinophrel (abgrfrac X) (abgrfracrel X is).
+Lemma isbinopabgrdiffrel (X : abmonoid) {L : hrel X} (is : isbinophrel L) :
+  @isbinophrel (abgrdiff X) (abgrdiffrel X is).
 Proof.
   intros.
-  apply (isbinopquotrel (binopeqrelabgrfrac X) (iscomprelabgrfracrelint X is)).
-  apply (isbinopabgrfracrelint X is).
+  apply (isbinopquotrel (binopeqrelabgrdiff X) (iscomprelabgrdiffrelint X is)).
+  apply (isbinopabgrdiffrelint X is).
 Defined.
 
-Definition isdecabgrfracrelint (X : abmonoid) {L : hrel X}
-           (is : isinvbinophrel L) (isl : isdecrel L) : isdecrel (abgrfracrelint X L).
+Definition isdecabgrdiffrelint (X : abmonoid) {L : hrel X}
+           (is : isinvbinophrel L) (isl : isdecrel L) : isdecrel (abgrdiffrelint X L).
 Proof.
   intros. intros xa1 xa2.
   set (x1 := pr1 xa1). set (a1 := pr2 xa1).
   set (x2 := pr1 xa2). set (a2 := pr2 xa2).
   assert (int : coprod (L (x1 + a2) (x2 + a1)) (neg (L (x1 + a2) (x2 + a1)))) by apply (isl _ _).
   destruct int as [ l | nl ].
-  - apply ii1. unfold abgrfracrelint. apply hinhpr. split with (unel X).
+  - apply ii1. unfold abgrdiffrelint. apply hinhpr. split with (unel X).
     rewrite (runax X _). rewrite (runax X _). apply l.
-  - apply ii2. generalize nl. clear nl. apply negf. unfold abgrfracrelint.
+  - apply ii2. generalize nl. clear nl. apply negf. unfold abgrdiffrelint.
     simpl. apply (@hinhuniv _ (hProppair _ (pr2 (L _ _)))).
     intro t2l. destruct t2l as [ c0a l ]. simpl. apply ((pr2 is) _ _ c0a l).
 Defined.
 
-Definition isdecabgrfracrel (X : abmonoid) {L : hrel X} (is : isbinophrel L)
-           (isi : isinvbinophrel L) (isl : isdecrel L) : isdecrel (abgrfracrel X is).
+Definition isdecabgrdiffrel (X : abmonoid) {L : hrel X} (is : isbinophrel L)
+           (isi : isinvbinophrel L) (isl : isdecrel L) : isdecrel (abgrdiffrel X is).
 Proof.
-  intros. refine (isdecquotrel _ _). apply isdecabgrfracrelint.
+  intros. refine (isdecquotrel _ _). apply isdecabgrdiffrelint.
   - apply isi.
   - apply isl.
 Defined.
 
 
-(** **** Relations and the canonical homomorphism to [ abgrfrac ] *)
+(** **** Relations and the canonical homomorphism to [ abgrdiff ] *)
 
-Lemma iscomptoabgrfrac (X : abmonoid) {L : hrel X} (is : isbinophrel L) :
-  iscomprelrelfun L (abgrfracrel X is) (toabgrfrac X).
+Lemma iscomptoabgrdiff (X : abmonoid) {L : hrel X} (is : isbinophrel L) :
+  iscomprelrelfun L (abgrdiffrel X is) (toabgrdiff X).
 Proof.
   intros. unfold iscomprelrelfun.
   intros x x' l.
-  change (abgrfracrelint X L (dirprodpair x (unel X)) (dirprodpair x' (unel X))).
+  change (abgrdiffrelint X L (dirprodpair x (unel X)) (dirprodpair x' (unel X))).
   simpl. apply (hinhpr). split with (unel X).
   apply ((pr2 is) _ _ 0). apply ((pr2 is) _ _ 0).
   apply l.
 Defined.
-Opaque iscomptoabgrfrac.
+Opaque iscomptoabgrdiff.
 
 Close Scope addmonoid_scope.
 

--- a/UniMath/Foundations/Algebra/Rigs_and_Rings.v
+++ b/UniMath/Foundations/Algebra/Rigs_and_Rings.v
@@ -1075,7 +1075,7 @@ Definition rngdirprod (X Y : rng) : rng := @rngpair (setwith2binopdirprod X Y) (
 
 Open Scope rig_scope.
 
-Definition rigtorngaddabgr (X : rig) : abgr := abgrfrac (rigaddabmonoid X).
+Definition rigtorngaddabgr (X : rig) : abgr := abgrdiff (rigaddabmonoid X).
 
 Definition rigtorngcarrier (X : rig) : hSet := pr1 (pr1 (rigtorngaddabgr X)).
 
@@ -1088,7 +1088,7 @@ Definition rigtorngop1axs (X : rig) : isabgrop (rigtorngop1 X) := pr2 (rigtornga
 
 Definition rigtorngunel1 (X : rig) : rigtorngcarrier X := unel (rigtorngaddabgr X).
 
-Definition eqrelrigtorng (X : rig) : eqrel (dirprod X X) := eqrelabgrfrac (rigaddabmonoid X).
+Definition eqrelrigtorng (X : rig) : eqrel (dirprod X X) := eqrelabgrdiff (rigaddabmonoid X).
 
 Definition rigtorngop2int (X : rig) : binop (dirprod X X) :=
   fun xx xx' : dirprod X X =>
@@ -1310,7 +1310,7 @@ Definition torngdiff (X : rig) (x : X) : rigtorng X := setquotpr _ (dirprodpair 
 Lemma isbinop1funtorngdiff (X : rig) : @isbinopfun (rigaddabmonoid X) (rigtorng X) (torngdiff X).
 Proof.
   intros. unfold isbinopfun. intros x x'.
-  apply (isbinopfuntoabgrfrac (rigaddabmonoid X) x x').
+  apply (isbinopfuntoabgrdiff (rigaddabmonoid X) x x').
 Defined.
 Opaque isbinop1funtorngdiff.
 
@@ -1348,13 +1348,13 @@ Definition isrigfuntorngdiff (X : rig) : @isrigfun X (rigtorng X) (torngdiff X) 
   dirprodpair (isaddmonoidfuntorngdiff X) (ismultmonoidfuntorngdiff X).
 
 Definition isincltorngdiff (X : rig) (iscanc : Π x : X, @isrcancelable X (@op1 X) x) :
-  isincl (torngdiff X) := isincltoabgrfrac (rigaddabmonoid X) iscanc.
+  isincl (torngdiff X) := isincltoabgrdiff (rigaddabmonoid X) iscanc.
 
 
 (** **** Relations similar to "greater" or "greater or equal" on the ring associated with a rig *)
 
 Definition rigtorngrel (X : rig) {R : hrel X} (is : @isbinophrel (rigaddabmonoid X) R) :
-  hrel (rigtorng X) := abgrfracrel (rigaddabmonoid X) is.
+  hrel (rigtorng X) := abgrdiffrel (rigaddabmonoid X) is.
 
 Lemma isrngrigtorngmultgt (X : rig) {R : hrel X} (is0 : @isbinophrel (rigaddabmonoid X) R)
       (is : isrigmultgt X R) : isrngmultgt (rigtorng X) (rigtorngrel X is0).
@@ -1376,11 +1376,11 @@ Proof.
   apply (setquotuniv2prop _ (fun a b => hProppair _ (int a b))).
 
   intros xa1 xa2.
-  change ((abgrfracrelint (rigaddabmonoid X) R) xa1 (dirprodpair (@rigunel1 X) (@rigunel1 X)) ->
-          (abgrfracrelint (rigaddabmonoid X) R) xa2 (dirprodpair (@rigunel1 X) (@rigunel1 X)) ->
-          (abgrfracrelint (rigaddabmonoid X) R (@rigtorngop2int X xa1 xa2)
+  change ((abgrdiffrelint (rigaddabmonoid X) R) xa1 (dirprodpair (@rigunel1 X) (@rigunel1 X)) ->
+          (abgrdiffrelint (rigaddabmonoid X) R) xa2 (dirprodpair (@rigunel1 X) (@rigunel1 X)) ->
+          (abgrdiffrelint (rigaddabmonoid X) R (@rigtorngop2int X xa1 xa2)
                           (dirprodpair (@rigunel1 X) (@rigunel1 X)))).
-  unfold abgrfracrelint. simpl. apply hinhfun2. intros t22 t21.
+  unfold abgrdiffrelint. simpl. apply hinhfun2. intros t22 t21.
   set (c2 := pr1 t21). set (c1 := pr1 t22).
   set (r1 := pr2 t21). set (r2 := pr2 t22).
   set (x1 := pr1 xa1). set (a1 := pr2 xa1).
@@ -1420,7 +1420,7 @@ Opaque isrngrigtorngmultgt.
 Definition isdecrigtorngrel (X : rig) {R : hrel X} (is : @isbinophrel (rigaddabmonoid X) R)
            (is' : @isinvbinophrel (rigaddabmonoid X) R) (isd : isdecrel R) :
   isdecrel (rigtorngrel X is).
-Proof. intros. apply (isdecabgrfracrel (rigaddabmonoid X) is is' isd). Defined.
+Proof. intros. apply (isdecabgrdiffrel (rigaddabmonoid X) is is' isd). Defined.
 
 Lemma isinvrngrigtorngmultgt (X : rig) {R : hrel X} (is0 : @isbinophrel (rigaddabmonoid X) R)
       (is1 : @isinvbinophrel (rigaddabmonoid X) R) (is : isinvrigmultgt X R) :
@@ -1437,11 +1437,11 @@ Proof.
     apply (setquotuniv2prop _ (fun a b => hProppair _ (int a b))).
 
     intros xa1 xa2.
-    change ((abgrfracrelint (rigaddabmonoid X) R (@rigtorngop2int X xa1 xa2)
+    change ((abgrdiffrelint (rigaddabmonoid X) R (@rigtorngop2int X xa1 xa2)
                             (dirprodpair (@rigunel1 X) (@rigunel1 X))) ->
-            (abgrfracrelint (rigaddabmonoid X) R) xa1 (dirprodpair (@rigunel1 X) (@rigunel1 X)) ->
-            (abgrfracrelint (rigaddabmonoid X) R) xa2 (dirprodpair (@rigunel1 X) (@rigunel1 X))).
-    unfold abgrfracrelint. simpl. apply hinhfun2. intros t22 t21.
+            (abgrdiffrelint (rigaddabmonoid X) R) xa1 (dirprodpair (@rigunel1 X) (@rigunel1 X)) ->
+            (abgrdiffrelint (rigaddabmonoid X) R) xa2 (dirprodpair (@rigunel1 X) (@rigunel1 X))).
+    unfold abgrdiffrelint. simpl. apply hinhfun2. intros t22 t21.
     set (c2 := pr1 t22). set (c1 := pr1 t21).
     set (r1 := pr2 t21). set (r2 := pr2 t22).
     set (x1 := pr1 xa1). set (a1 := pr2 xa1).
@@ -1467,11 +1467,11 @@ Proof.
     apply (setquotuniv2prop _ (fun a b => hProppair _ (int a b))).
 
     intros xa1 xa2.
-    change ((abgrfracrelint (rigaddabmonoid X) R (@rigtorngop2int X xa1 xa2)
+    change ((abgrdiffrelint (rigaddabmonoid X) R (@rigtorngop2int X xa1 xa2)
                             (dirprodpair (@rigunel1 X) (@rigunel1 X))) ->
-            (abgrfracrelint (rigaddabmonoid X) R) xa2 (dirprodpair (@rigunel1 X) (@rigunel1 X)) ->
-            (abgrfracrelint (rigaddabmonoid X) R) xa1 (dirprodpair (@rigunel1 X) (@rigunel1 X))).
-    unfold abgrfracrelint. simpl. apply hinhfun2. intros t22 t21.
+            (abgrdiffrelint (rigaddabmonoid X) R) xa2 (dirprodpair (@rigunel1 X) (@rigunel1 X)) ->
+            (abgrdiffrelint (rigaddabmonoid X) R) xa1 (dirprodpair (@rigunel1 X) (@rigunel1 X))).
+    unfold abgrdiffrelint. simpl. apply hinhfun2. intros t22 t21.
     set (c2 := pr1 t22). set (c1 := pr1 t21).
     set (r1 := pr2 t21). set (r2 := pr2 t22).
     set (x1 := pr1 xa1). set (a1 := pr2 xa1).
@@ -1494,7 +1494,7 @@ Opaque isinvrngrigtorngmultgt.
 (** **** Realations and the canonical homomorphism to the ring associated with a rig (ring of differences) *)
 
 Definition iscomptorngdiff (X : rig) {L : hrel X} (is0 : @isbinophrel (rigaddabmonoid X) L) :
-  iscomprelrelfun L (rigtorngrel X is0) (torngdiff X) := iscomptoabgrfrac (rigaddabmonoid X) is0.
+  iscomprelrelfun L (rigtorngrel X is0) (torngdiff X) := iscomptoabgrdiff (rigaddabmonoid X) is0.
 Opaque iscomptorngdiff.
 
 Close Scope rig_scope.

--- a/UniMath/Foundations/NumberSystems/Integers.v
+++ b/UniMath/Foundations/NumberSystems/Integers.v
@@ -59,7 +59,7 @@ Delimit Scope hz_scope with hz .
 (** *** Properties of equlaity on [ hz ] *)
 
 Theorem isdeceqhz : isdeceq hz .
-Proof . change ( isdeceq ( abgrfrac ( rigaddabmonoid natcommrig ) ) ) . apply isdeceqabgrfrac . apply isinclnatplusr .  apply isdeceqnat .  Defined .
+Proof . change ( isdeceq ( abgrdiff ( rigaddabmonoid natcommrig ) ) ) . apply isdeceqabgrdiff . apply isinclnatplusr .  apply isdeceqnat .  Defined .
 
 Lemma isasethz : isaset hz .
 Proof . apply ( setproperty hzaddabgr ) . Defined .
@@ -206,19 +206,19 @@ Definition hzgehdec := decrelpair isdecrelhzgeh .
 
 
 Lemma istranshzgth ( n m k : hz ) : hzgth n m -> hzgth m k -> hzgth n k .
-Proof. apply ( istransabgrfracrel nataddabmonoid isplushrelnatgth )  .  unfold istrans .  apply istransnatgth .  Defined.
+Proof. apply ( istransabgrdiffrel nataddabmonoid isplushrelnatgth )  .  unfold istrans .  apply istransnatgth .  Defined.
 
 Lemma isirreflhzgth ( n : hz ) : neg ( hzgth n n ) .
-Proof. apply ( isirreflabgrfracrel nataddabmonoid isplushrelnatgth )  . unfold isirrefl .  apply isirreflnatgth .   Defined .
+Proof. apply ( isirreflabgrdiffrel nataddabmonoid isplushrelnatgth )  . unfold isirrefl .  apply isirreflnatgth .   Defined .
 
 Lemma hzgthtoneq ( n m : hz ) ( g : hzgth n m ) : neg ( paths n m ) .
 Proof . intros . intro e . rewrite e in g . apply ( isirreflhzgth _ g ) . Defined .
 
 Lemma isasymmhzgth ( n m : hz ) : hzgth n m -> hzgth m n -> empty .
-Proof. apply ( isasymmabgrfracrel nataddabmonoid isplushrelnatgth )  . unfold isasymm .  apply isasymmnatgth .  Defined .
+Proof. apply ( isasymmabgrdiffrel nataddabmonoid isplushrelnatgth )  . unfold isasymm .  apply isasymmnatgth .  Defined .
 
 Lemma isantisymmneghzgth ( n m : hz ) : neg ( hzgth n m ) -> neg ( hzgth m n ) -> paths n m .
-Proof . apply ( isantisymmnegabgrfracrel nataddabmonoid isplushrelnatgth )  . unfold isantisymmneg .  apply isantisymmnegnatgth .   Defined .
+Proof . apply ( isantisymmnegabgrdiffrel nataddabmonoid isplushrelnatgth )  . unfold isantisymmneg .  apply isantisymmnegnatgth .   Defined .
 
 Lemma isnegrelhzgth : isnegrel hzgth .
 Proof . apply isdecreltoisnegrel . apply isdecrelhzgth . Defined .
@@ -368,10 +368,10 @@ Proof . intros n m k l1 l2 . apply ( hzgthgehtrans k m n l2 l1 ) . Defined .
 
 
 Definition hzgthandplusl ( n m k : hz ) : hzgth n m -> hzgth ( k + n ) ( k + m ) .
-Proof. apply ( pr1 ( isbinopabgrfracrel nataddabmonoid isplushrelnatgth ) ) .   Defined .
+Proof. apply ( pr1 ( isbinopabgrdiffrel nataddabmonoid isplushrelnatgth ) ) .   Defined .
 
 Definition hzgthandplusr ( n m k : hz ) : hzgth n m -> hzgth ( n + k ) ( m + k ) .
-Proof. apply ( pr2 ( isbinopabgrfracrel nataddabmonoid isplushrelnatgth ) ) .  Defined .
+Proof. apply ( pr2 ( isbinopabgrdiffrel nataddabmonoid isplushrelnatgth ) ) .  Defined .
 
 Definition hzgthandpluslinv  ( n m k : hz ) : hzgth ( k + n ) ( k + m ) -> hzgth n m  .
 Proof. intros n m k g . set ( g' := hzgthandplusl _ _ ( - k ) g ) . clearbody g' . rewrite ( pathsinv0 ( hzplusassoc _ _ n ) ) in g' . rewrite ( pathsinv0 ( hzplusassoc _ _ m ) ) in g' .  rewrite ( hzlminus k ) in g' . rewrite ( hzplusl0 _ ) in g' .   rewrite ( hzplusl0 _ ) in g' . apply g' .  Defined .
@@ -686,9 +686,9 @@ Definition hzgehtogehs ( n m : hz ) : hzgeh n m -> hzgeh ( n + 1 ) m := hzlehtol
 Lemma hzgthtogehsn ( n m : hz ) : hzgth n m -> hzgeh n ( m + 1 ) .
 Proof. assert ( int : Π n m , isaprop ( hzgth n m -> hzgeh n ( m + 1 )  ) ) .
        { intros . apply impred . intro . apply ( pr2 _ ) . }
-       unfold hzgth in * .  apply ( setquotuniv2prop _ ( fun n m => hProppair _ ( int n m ) ) ) . set ( R := abgrfracrelint nataddabmonoid natgth ) .
+       unfold hzgth in * .  apply ( setquotuniv2prop _ ( fun n m => hProppair _ ( int n m ) ) ) . set ( R := abgrdiffrelint nataddabmonoid natgth ) .
        intros x x' .  change ( R x x' -> ( neg ( R ( @op ( abmonoiddirprod (rigaddabmonoid natcommrig) (rigaddabmonoid natcommrig) ) x' ( dirprodpair 1%nat 0%nat ) ) x ) ) ) .
-       unfold R . unfold abgrfracrelint . simpl .
+       unfold R . unfold abgrdiffrelint . simpl .
        apply ( @hinhuniv _  (hProppair ( neg ( ishinh_UU _ ) ) ( isapropneg _ ) ) ) .
        intro t2 . simpl . unfold neg .  apply ( @hinhuniv _ ( hProppair _ isapropempty ) ) .
        intro t2' .
@@ -796,8 +796,8 @@ Definition nattohzandgeh ( n m : nat ) ( is : natgeh n m ) : hzgeh ( nattohz n )
 Definition hzabsvalint : ( dirprod nat nat ) -> nat .
 Proof . intro nm . destruct ( natgthorleh ( pr1 nm ) ( pr2  nm ) ) .  apply ( minus ( pr1 nm ) ( pr2 nm ) ) . apply ( minus ( pr2 nm ) ( pr1 nm ) ) . Defined .
 
-Lemma hzabsvalintcomp : @iscomprelfun ( dirprod nat nat ) nat ( hrelabgrfrac nataddabmonoid )  hzabsvalint .
-Proof . unfold iscomprelfun .  intros x x' . unfold hrelabgrfrac . simpl . apply ( @hinhuniv _ ( hProppair _ ( isasetnat (hzabsvalint x) (hzabsvalint x') ) ) ) .  unfold hzabsvalint . set ( n := ( pr1 x ) : nat  ) . set ( m := ( pr2 x ) : nat ) . set ( n' := ( pr1 x' ) : nat ) . set ( m' := ( pr2 x' ) : nat ) .   set ( int := natgthorleh n m ) . set ( int' := natgthorleh n' m' ) .   intro tt0 . simpl .  destruct tt0 as [ x0 eq ] .  simpl in eq .  assert ( e' := invmaponpathsincl _ ( isinclnatplusr x0 ) _ _ eq ) .
+Lemma hzabsvalintcomp : @iscomprelfun ( dirprod nat nat ) nat ( hrelabgrdiff nataddabmonoid )  hzabsvalint .
+Proof . unfold iscomprelfun .  intros x x' . unfold hrelabgrdiff . simpl . apply ( @hinhuniv _ ( hProppair _ ( isasetnat (hzabsvalint x) (hzabsvalint x') ) ) ) .  unfold hzabsvalint . set ( n := ( pr1 x ) : nat  ) . set ( m := ( pr2 x ) : nat ) . set ( n' := ( pr1 x' ) : nat ) . set ( m' := ( pr2 x' ) : nat ) .   set ( int := natgthorleh n m ) . set ( int' := natgthorleh n' m' ) .   intro tt0 . simpl .  destruct tt0 as [ x0 eq ] .  simpl in eq .  assert ( e' := invmaponpathsincl _ ( isinclnatplusr x0 ) _ _ eq ) .
 
 destruct int as [isgt | isle ] . destruct int' as [ isgt' | isle' ] .
 
@@ -818,7 +818,7 @@ Lemma hzabsval0 : paths ( hzabsval 0 ) 0%nat .
 Proof .  apply idpath .  Defined .
 
 Lemma hzabsvalgth0 { x : hz } ( is : hzgth x 0 ) : paths ( nattohz ( hzabsval x ) ) x .
-Proof . assert ( int : Π x : hz , isaprop ( hzgth x 0 ->  paths ( nattohz ( hzabsval x ) ) x ) ) . intro . apply impred . intro . apply ( setproperty hz ) .  apply ( setquotunivprop _ ( fun x => hProppair _ ( int x ) ) ) . intros xa g . simpl in xa . assert ( g' := natnattohzandgth _ _ g ) . simpl in g' .  simpl .  change ( paths ( setquotpr (eqrelabgrfrac (rigaddabmonoid natcommrig)) ( dirprodpair ( hzabsvalint xa ) 0%nat ) ) ( setquotpr (eqrelabgrfrac (rigaddabmonoid natcommrig)) xa ) ) . apply weqpathsinsetquot . simpl . apply hinhpr . split with 0%nat .  change ( pr1 ( natgth ( pr1 xa + 0%nat ) ( pr2 xa ) ) ) in g' . rewrite ( natplusr0 _ ) in g' .  change ( paths  (hzabsvalint xa + pr2 xa + 0)%nat (pr1 xa + 0 + 0)%nat ) . rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) . unfold hzabsvalint .   destruct ( natgthorleh (pr1 xa) (pr2 xa)  ) as [ g'' | l ] .
+Proof . assert ( int : Π x : hz , isaprop ( hzgth x 0 ->  paths ( nattohz ( hzabsval x ) ) x ) ) . intro . apply impred . intro . apply ( setproperty hz ) .  apply ( setquotunivprop _ ( fun x => hProppair _ ( int x ) ) ) . intros xa g . simpl in xa . assert ( g' := natnattohzandgth _ _ g ) . simpl in g' .  simpl .  change ( paths ( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) ( dirprodpair ( hzabsvalint xa ) 0%nat ) ) ( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) xa ) ) . apply weqpathsinsetquot . simpl . apply hinhpr . split with 0%nat .  change ( pr1 ( natgth ( pr1 xa + 0%nat ) ( pr2 xa ) ) ) in g' . rewrite ( natplusr0 _ ) in g' .  change ( paths  (hzabsvalint xa + pr2 xa + 0)%nat (pr1 xa + 0 + 0)%nat ) . rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) . unfold hzabsvalint .   destruct ( natgthorleh (pr1 xa) (pr2 xa)  ) as [ g'' | l ] .
 
 rewrite ( minusplusnmm _ _ ( natlthtoleh _ _ g'' ) ) . apply idpath .
 
@@ -831,7 +831,7 @@ Lemma hzabsvalgeh0 { x : hz } ( is : hzgeh x 0 ) : paths ( nattohz ( hzabsval x 
 Proof .  intros . destruct ( hzgehchoice _ _ is ) as [ g | e ] .  apply ( hzabsvalgth0 g ) . rewrite e .  apply idpath .  Defined .
 
 Lemma hzabsvallth0 { x : hz } ( is : hzlth x 0 ) : paths ( nattohz ( hzabsval x ) ) ( - x ) .
-Proof . assert ( int : Π x : hz , isaprop ( hzlth x 0 ->  paths ( nattohz ( hzabsval x ) ) ( - x ) ) ) . intro . apply impred . intro . apply ( setproperty hz ) .  apply ( setquotunivprop _ ( fun x => hProppair _ ( int x ) ) ) . intros xa l . simpl in xa . assert ( l' := natnattohzandlth _ _ l ) . simpl in l' .  simpl .  change ( paths ( setquotpr (eqrelabgrfrac (rigaddabmonoid natcommrig)) ( dirprodpair ( hzabsvalint xa ) 0%nat ) ) ( setquotpr (eqrelabgrfrac (rigaddabmonoid natcommrig)) ( dirprodpair ( pr2 xa ) ( pr1 xa ) ) ) ) . apply weqpathsinsetquot . simpl . apply hinhpr . split with 0%nat .  change ( pr1 ( natlth ( pr1 xa + 0%nat ) ( pr2 xa ) ) ) in l' . rewrite ( natplusr0 _ ) in l' .  change ( paths  (hzabsvalint xa + pr1 xa + 0)%nat (pr2 xa + 0 + 0)%nat ) . rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) . unfold hzabsvalint .   destruct ( natgthorleh (pr1 xa) (pr2 xa)  ) as [ g | l'' ] .
+Proof . assert ( int : Π x : hz , isaprop ( hzlth x 0 ->  paths ( nattohz ( hzabsval x ) ) ( - x ) ) ) . intro . apply impred . intro . apply ( setproperty hz ) .  apply ( setquotunivprop _ ( fun x => hProppair _ ( int x ) ) ) . intros xa l . simpl in xa . assert ( l' := natnattohzandlth _ _ l ) . simpl in l' .  simpl .  change ( paths ( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) ( dirprodpair ( hzabsvalint xa ) 0%nat ) ) ( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) ( dirprodpair ( pr2 xa ) ( pr1 xa ) ) ) ) . apply weqpathsinsetquot . simpl . apply hinhpr . split with 0%nat .  change ( pr1 ( natlth ( pr1 xa + 0%nat ) ( pr2 xa ) ) ) in l' . rewrite ( natplusr0 _ ) in l' .  change ( paths  (hzabsvalint xa + pr1 xa + 0)%nat (pr2 xa + 0 + 0)%nat ) . rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) . unfold hzabsvalint .   destruct ( natgthorleh (pr1 xa) (pr2 xa)  ) as [ g | l'' ] .
 
 destruct ( isasymmnatgth _ _ g l' ) .
 

--- a/UniMath/RealNumbers/NonnegativeReals.v
+++ b/UniMath/RealNumbers/NonnegativeReals.v
@@ -21,11 +21,11 @@ Definition Dcuts_def_open (X : hsubtypes NonnegativeRationals) : UU :=
         X x -> ∃ y : NonnegativeRationals, (X y) × (x < y).
 Definition Dcuts_def_finite (X : hsubtypes NonnegativeRationals) : hProp :=
   ∃ ub : NonnegativeRationals, ¬ (X ub).
-Definition Dcuts_def_error (X : hsubtypes NonnegativeRationals) : UU :=
+Definition Dcuts_def_corr (X : hsubtypes NonnegativeRationals) : UU :=
   Π r : NonnegativeRationals, 0 < r -> (¬ (X r)) ∨ Σ q : NonnegativeRationals, (X q) × (¬ (X (q + r))).
 
-Lemma Dcuts_def_error_finite (X : hsubtypes NonnegativeRationals) :
-  Dcuts_def_error X → Dcuts_def_finite X.
+Lemma Dcuts_def_corr_finite (X : hsubtypes NonnegativeRationals) :
+  Dcuts_def_corr X → Dcuts_def_finite X.
 Proof.
   intros X Hx.
   specialize (Hx _ ispositive_oneNonnegativeRationals).
@@ -35,8 +35,8 @@ Proof.
   - apply hinhpr ; exists (pr1 x + 1) ; exact (pr2 (pr2 x)).
 Qed.
 
-Lemma Dcuts_def_error_not_empty (X : hsubtypes NonnegativeRationals) :
-  X 0 -> Dcuts_def_error X ->
+Lemma Dcuts_def_corr_not_empty (X : hsubtypes NonnegativeRationals) :
+  X 0 -> Dcuts_def_corr X ->
   Π c : NonnegativeRationals,
     (0 < c)%NRat -> ∃ x : NonnegativeRationals, X x × ¬ X (x + c).
 Proof.
@@ -62,7 +62,7 @@ Proof.
   repeat (apply impred_isaprop ; intro).
   now apply pr2.
 Qed.
-Lemma isaprop_Dcuts_def_error (X : hsubtypes NonnegativeRationals) : isaprop (Dcuts_def_error X).
+Lemma isaprop_Dcuts_def_corr (X : hsubtypes NonnegativeRationals) : isaprop (Dcuts_def_corr X).
 Proof.
   intros X.
   repeat (apply impred_isaprop ; intro).
@@ -70,13 +70,13 @@ Proof.
 Qed.
 
 Lemma isaprop_Dcuts_hsubtypes (X : hsubtypes NonnegativeRationals) :
-  isaprop (Dcuts_def_bot X × Dcuts_def_open X × Dcuts_def_error X).
+  isaprop (Dcuts_def_bot X × Dcuts_def_open X × Dcuts_def_corr X).
 Proof.
   intro X.
   apply isofhleveldirprod, isofhleveldirprod.
   - exact (isaprop_Dcuts_def_bot X).
   - exact (isaprop_Dcuts_def_open X).
-  - exact (isaprop_Dcuts_def_error X).
+  - exact (isaprop_Dcuts_def_corr X).
 Qed.
 
 Definition Dcuts_hsubtypes : hsubtypes (hsubtypes NonnegativeRationals) :=
@@ -105,7 +105,7 @@ Proof.
   intros X.
   exact (pr1 (pr2 (pr2 X))).
 Qed.
-Lemma is_Dcuts_error (X : Dcuts_set) : Dcuts_def_error (pr1 X).
+Lemma is_Dcuts_corr (X : Dcuts_set) : Dcuts_def_corr (pr1 X).
 Proof.
   intros X.
   exact (pr2 (pr2 (pr2 X))).
@@ -114,7 +114,7 @@ Qed.
 Definition mk_Dcuts (X : NonnegativeRationals → hProp)
                     (Hbot : Dcuts_def_bot X)
                     (Hopen : Dcuts_def_open X)
-                    (Herror : Dcuts_def_error X) : Dcuts_set.
+                    (Herror : Dcuts_def_corr X) : Dcuts_set.
 Proof.
   intros X Hbot Hopen Herror.
   exists X ; repeat split.
@@ -199,7 +199,7 @@ Proof.
   assert (Hr0 : 0%NRat < pr1 r' - pr1 r).
   { apply ispositive_minusNonnegativeRationals.
     exact (pr2 (pr2 r')). }
-  generalize (is_Dcuts_error y _ Hr0) ; apply hinhuniv ; apply sumofmaps ; [intros Yq | intros q].
+  generalize (is_Dcuts_corr y _ Hr0) ; apply hinhuniv ; apply sumofmaps ; [intros Yq | intros q].
   - apply Utilities.squash_element ;
     right ; apply Utilities.squash_element.
     exists (pr1 r') ; split.
@@ -261,7 +261,7 @@ Proof.
   - intros Hnlt y Yy.
     generalize (is_Dcuts_open _ _ Yy) ; apply hinhuniv ; intros y'.
     generalize (pr1 (ispositive_minusNonnegativeRationals _ _) (pr2 (pr2 y'))) ; intros Hy.
-    generalize (is_Dcuts_error X _ Hy).
+    generalize (is_Dcuts_corr X _ Hy).
     apply hinhuniv.
     apply sumofmaps ; [intros nXc | ].
     + apply fromempty, Hnlt.
@@ -566,8 +566,8 @@ Proof.
   exact (pr2 (pr2 n)).
   exact (pr1 (pr2 n)).
 Qed.
-Lemma NonnegativeRationals_to_Dcuts_error (q : NonnegativeRationals) :
-  Dcuts_def_error (λ r : NonnegativeRationals, (r < q)%NRat).
+Lemma NonnegativeRationals_to_Dcuts_corr (q : NonnegativeRationals) :
+  Dcuts_def_corr (λ r : NonnegativeRationals, (r < q)%NRat).
 Proof.
   intros q.
   intros r Hr0.
@@ -594,7 +594,7 @@ Definition NonnegativeRationals_to_Dcuts (q : NonnegativeRationals) : Dcuts :=
   mk_Dcuts (fun r => (r < q)%NRat)
            (NonnegativeRationals_to_Dcuts_bot q)
            (NonnegativeRationals_to_Dcuts_open q)
-           (NonnegativeRationals_to_Dcuts_error q).
+           (NonnegativeRationals_to_Dcuts_corr q).
 
 
 Lemma isapfun_NonnegativeRationals_to_Dcuts_aux :
@@ -716,11 +716,11 @@ Section Dcuts_plus.
   Context (X : hsubtypes NonnegativeRationals).
   Context (X_bot : Dcuts_def_bot X).
   Context (X_open : Dcuts_def_open X).
-  Context (X_error : Dcuts_def_error X).
+  Context (X_corr : Dcuts_def_corr X).
   Context (Y : hsubtypes NonnegativeRationals).
   Context (Y_bot : Dcuts_def_bot Y).
   Context (Y_open : Dcuts_def_open Y).
-  Context (Y_error : Dcuts_def_error Y).
+  Context (Y_corr : Dcuts_def_corr Y).
 
 Definition Dcuts_plus_val : hsubtypes NonnegativeRationals :=
   λ r : NonnegativeRationals,
@@ -800,11 +800,11 @@ Proof.
       exact (pr2 (pr2 nx)).
       exact (pr2 (pr2 ny)).
 Qed.
-Lemma Dcuts_plus_error : Dcuts_def_error Dcuts_plus_val.
+Lemma Dcuts_plus_corr : Dcuts_def_corr Dcuts_plus_val.
 Proof.
   intros c Hc.
   apply ispositive_NQhalf in Hc.
-  generalize (X_error _ Hc) (Y_error _ Hc).
+  generalize (X_corr _ Hc) (Y_corr _ Hc).
   apply hinhfun2 ; apply (sumofmaps (Z := _ → _)) ; intros Hx ; apply sumofmaps ; intros Hy.
   - left.
     unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; apply sumofmaps.
@@ -959,8 +959,8 @@ Definition Dcuts_plus (X Y : Dcuts) : Dcuts :=
                            (pr1 Y) (is_Dcuts_bot Y))
            (Dcuts_plus_open (pr1 X) (is_Dcuts_open X)
                             (pr1 Y) (is_Dcuts_open Y))
-           (Dcuts_plus_error (pr1 X) (is_Dcuts_bot X) (is_Dcuts_error X)
-                             (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_error Y)).
+           (Dcuts_plus_corr (pr1 X) (is_Dcuts_bot X) (is_Dcuts_corr X)
+                             (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_corr Y)).
 
 (** ** Multiplication in Dcuts *)
 
@@ -972,7 +972,7 @@ Section Dcuts_NQmult.
   Context (Y_bot : Dcuts_def_bot Y).
   Context (Y_open : Dcuts_def_open Y).
   Context (Y_finite : Dcuts_def_finite Y).
-  Context (Y_error : Dcuts_def_error Y).
+  Context (Y_corr : Dcuts_def_corr Y).
 
 Definition Dcuts_NQmult_val : hsubtypes NonnegativeRationals :=
   fun r => ∃ ry : NonnegativeRationals, r = x * ry × Y ry.
@@ -1042,11 +1042,11 @@ Proof.
   exact Hy'.
 Qed.
 
-Lemma Dcuts_NQmult_error : Dcuts_def_error Dcuts_NQmult_val.
+Lemma Dcuts_NQmult_corr : Dcuts_def_corr Dcuts_NQmult_val.
 Proof.
   intros c Hc.
   assert (Hcx : (0 < c / x)%NRat) by (now apply ispositive_divNonnegativeRationals).
-  generalize (Y_error _ Hcx).
+  generalize (Y_corr _ Hcx).
   apply hinhfun ; apply sumofmaps ; intros Hy.
   - left.
     unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ;
@@ -1096,7 +1096,7 @@ Definition Dcuts_NQmult x (Y : Dcuts) Hx : Dcuts :=
   mk_Dcuts (Dcuts_NQmult_val x (pr1 Y))
            (Dcuts_NQmult_bot x (pr1 Y) (is_Dcuts_bot Y))
            (Dcuts_NQmult_open x Hx (pr1 Y) (is_Dcuts_open Y))
-           (Dcuts_NQmult_error x Hx (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_error Y)).
+           (Dcuts_NQmult_corr x Hx (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_corr Y)).
 
 Section Dcuts_mult.
 
@@ -1104,12 +1104,12 @@ Section Dcuts_mult.
   Context (X_bot : Dcuts_def_bot X).
   Context (X_open : Dcuts_def_open X).
   Context (X_finite : Dcuts_def_finite X).
-  Context (X_error : Dcuts_def_error X).
+  Context (X_corr : Dcuts_def_corr X).
   Context (Y : hsubtypes NonnegativeRationals).
   Context (Y_bot : Dcuts_def_bot Y).
   Context (Y_open : Dcuts_def_open Y).
   Context (Y_finite : Dcuts_def_finite Y).
-  Context (Y_error : Dcuts_def_error Y).
+  Context (Y_corr : Dcuts_def_corr Y).
 
 Definition Dcuts_mult_val : hsubtypes NonnegativeRationals :=
   fun r => ∃ xy : NonnegativeRationals * NonnegativeRationals,
@@ -1187,11 +1187,11 @@ Qed.
 
 Context (Hx1 : ¬ X 1%NRat).
 
-Lemma Dcuts_mult_error_aux : Dcuts_def_error Dcuts_mult_val.
+Lemma Dcuts_mult_corr_aux : Dcuts_def_corr Dcuts_mult_val.
 Proof.
   intros c Hc0.
   apply ispositive_NQhalf in Hc0.
-  generalize (Y_error _ Hc0).
+  generalize (Y_corr _ Hc0).
   apply hinhuniv ; apply sumofmaps ; intros Hy.
   - apply hinhpr ; left.
     unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ;
@@ -1217,7 +1217,7 @@ Proof.
     set (cx := ((c / 2) / (pr1 y + (c / 2)))%NRat).
     assert (Hcx0 : (0 < cx)%NRat)
       by (now apply ispositive_divNonnegativeRationals).
-    generalize (X_error _ Hcx0) ; apply hinhfun ; apply sumofmaps ; intros H.
+    generalize (X_corr _ Hcx0) ; apply hinhfun ; apply sumofmaps ; intros H.
     + left.
       unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ;
       intros xy.
@@ -1281,19 +1281,19 @@ Section Dcuts_mult'.
   Context (X_bot : Dcuts_def_bot X).
   Context (X_open : Dcuts_def_open X).
   Context (X_finite : Dcuts_def_finite X).
-  Context (X_error : Dcuts_def_error X).
+  Context (X_corr : Dcuts_def_corr X).
   Context (Y : hsubtypes NonnegativeRationals).
   Context (Y_bot : Dcuts_def_bot Y).
   Context (Y_open : Dcuts_def_open Y).
   Context (Y_finite : Dcuts_def_finite Y).
-  Context (Y_error : Dcuts_def_error Y).
+  Context (Y_corr : Dcuts_def_corr Y).
 
-Lemma Dcuts_mult_error : Dcuts_def_error (Dcuts_mult_val X Y).
+Lemma Dcuts_mult_corr : Dcuts_def_corr (Dcuts_mult_val X Y).
 Proof.
   intros c Hc.
-  generalize (X_error 1%NRat ispositive_oneNonnegativeRationals).
+  generalize (X_corr 1%NRat ispositive_oneNonnegativeRationals).
   apply hinhuniv ; apply sumofmaps ; [ intros Hx1 | intros x].
-  - now apply Dcuts_mult_error_aux.
+  - now apply Dcuts_mult_corr_aux.
   - assert (Hx1 : (0 < pr1 x + 1)%NRat).
     { apply istrans_lt_le_ltNonnegativeRationals with (1 := ispositive_oneNonnegativeRationals).
       apply plusNonnegativeRationals_le_l. }
@@ -1327,18 +1327,18 @@ Proof.
         exact (pr2 (pr2 (pr2 xy))). }
     rewrite Heq.
     revert c Hc.
-    apply Dcuts_NQmult_error.
+    apply Dcuts_NQmult_corr.
     + exact Hx1.
     + apply Dcuts_mult_bot, Y_bot.
       now apply Dcuts_NQmult_bot.
-    + apply Dcuts_mult_error_aux.
+    + apply Dcuts_mult_corr_aux.
       now apply Dcuts_NQmult_bot.
-      apply Dcuts_NQmult_error.
+      apply Dcuts_NQmult_corr.
       now apply ispositive_invNonnegativeRationals.
       exact X_bot.
-      exact X_error.
+      exact X_corr.
       exact Y_bot.
-      exact Y_error.
+      exact Y_corr.
       unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ;
       intros rx.
       apply (pr2 (pr2 x)), X_bot with (1 := pr2 (pr2 rx)).
@@ -1359,8 +1359,8 @@ Definition Dcuts_mult (X Y : Dcuts) : Dcuts :=
                            (pr1 Y) (is_Dcuts_bot Y))
            (Dcuts_mult_open (pr1 X) (is_Dcuts_open X)
                             (pr1 Y) (is_Dcuts_open Y))
-           (Dcuts_mult_error (pr1 X) (is_Dcuts_bot X) (is_Dcuts_error X)
-                             (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_error Y)).
+           (Dcuts_mult_corr (pr1 X) (is_Dcuts_bot X) (is_Dcuts_corr X)
+                             (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_corr Y)).
 
 (** ** Multiplicative inverse in Dcuts *)
 
@@ -1370,7 +1370,7 @@ Context (X : hsubtypes NonnegativeRationals).
 Context (X_bot : Dcuts_def_bot X).
 Context (X_open : Dcuts_def_open X).
 Context (X_finite : Dcuts_def_finite X).
-Context (X_error : Dcuts_def_error X).
+Context (X_corr : Dcuts_def_corr X).
 Context (X_0 : X 0%NRat).
 
 Definition Dcuts_inv_val : hsubtypes NonnegativeRationals :=
@@ -1495,21 +1495,21 @@ Qed.
 
 Context (X_1 : X 1%NRat).
 
-Lemma Dcuts_inv_error_aux : Dcuts_def_error Dcuts_inv_val.
+Lemma Dcuts_inv_corr_aux : Dcuts_def_corr Dcuts_inv_val.
 Proof.
   assert (Π c, (0 < c)%NRat -> hexists (λ q : NonnegativeRationals, X q × ¬ X (q + c))).
   { intros c Hc0.
-    generalize (X_error c Hc0) ; apply hinhuniv ; apply sumofmaps ; [ intros nXc | intros H].
+    generalize (X_corr c Hc0) ; apply hinhuniv ; apply sumofmaps ; [ intros nXc | intros H].
     - apply hinhpr.
       exists 0%NRat ; split.
       + exact X_0.
       + now rewrite islunit_zeroNonnegativeRationals.
     - apply hinhpr ; exact H. }
-  clear X_error ; rename X0 into X_error.
+  clear X_corr ; rename X0 into X_corr.
 
   intros c Hc0.
   apply ispositive_NQhalf in Hc0.
-  specialize (X_error _ Hc0) ; revert X_error.
+  specialize (X_corr _ Hc0) ; revert X_corr.
   apply hinhfun ; intros r.
   right.
   exists (/ (NQmax 1%NRat (pr1 r) + c))%NRat ; split.
@@ -1562,12 +1562,12 @@ Context (X : hsubtypes NonnegativeRationals).
 Context (X_bot : Dcuts_def_bot X).
 Context (X_open : Dcuts_def_open X).
 Context (X_finite : Dcuts_def_finite X).
-Context (X_error : Dcuts_def_error X).
+Context (X_corr : Dcuts_def_corr X).
 Context (X_0 : X 0%NRat).
 
-Lemma Dcuts_inv_error : Dcuts_def_error (Dcuts_inv_val X).
+Lemma Dcuts_inv_corr : Dcuts_def_corr (Dcuts_inv_val X).
 Proof.
-  generalize (X_open _ X_0) ; apply (hinhuniv (P := hProppair _ (isaprop_Dcuts_def_error _))) ; intros x.
+  generalize (X_open _ X_0) ; apply (hinhuniv (P := hProppair _ (isaprop_Dcuts_def_corr _))) ; intros x.
   set (Y := Dcuts_NQmult_val (/ (pr1 x))%NRat X).
   assert (Y_1 : Y 1%NRat).
   { unfold Y ; apply hinhpr ; exists (pr1 x) ; split.
@@ -1608,17 +1608,17 @@ Proof.
       exact (pr1 (pr2 (pr2 l))).
       exact (pr2 (pr2 (pr2 l))). }
   rewrite Heq.
-  apply Dcuts_NQmult_error.
+  apply Dcuts_NQmult_corr.
   apply ispositive_invNonnegativeRationals.
   exact (pr2 (pr2 x)).
   now apply Dcuts_inv_bot.
-  apply Dcuts_inv_error_aux.
+  apply Dcuts_inv_corr_aux.
   now unfold Y ; apply Dcuts_NQmult_bot.
-  unfold Y ; apply Dcuts_NQmult_error.
+  unfold Y ; apply Dcuts_NQmult_corr.
   apply ispositive_invNonnegativeRationals.
   exact (pr2 (pr2 x)).
   exact X_bot.
-  exact X_error.
+  exact X_corr.
   apply hinhpr ; exists 0%NRat ; split.
   now rewrite israbsorb_zero_multNonnegativeRationals.
   exact X_0.
@@ -1634,11 +1634,11 @@ Proof.
   - now apply Dcuts_inv_bot.
   - apply Dcuts_inv_open.
     now apply is_Dcuts_bot.
-    now apply Dcuts_def_error_finite, is_Dcuts_error.
-  - apply Dcuts_inv_error.
+    now apply Dcuts_def_corr_finite, is_Dcuts_corr.
+  - apply Dcuts_inv_corr.
     now apply is_Dcuts_bot.
     now apply is_Dcuts_open.
-    now apply is_Dcuts_error.
+    now apply is_Dcuts_corr.
     now apply_pr2 Dcuts_apzero_notempty.
 Defined.
 
@@ -2149,7 +2149,7 @@ Proof.
         apply istrans_ltNonnegativeRationals with q.
         exact Hq0.
         exact (pr1 (pr2 t)). }
-      generalize (Dcuts_def_error_not_empty _ Hx0 (is_Dcuts_error x) _ Hc0).
+      generalize (Dcuts_def_corr_not_empty _ Hx0 (is_Dcuts_corr x) _ Hc0).
       apply hinhfun ; intros r'.
       exists ((q * / (NQmax (pr1 r) (pr1 r')))%NRat,NQmax (pr1 r) (pr1 r')) ; repeat split.
       * simpl.
@@ -2240,7 +2240,7 @@ Proof.
     generalize (is_Dcuts_open _ _ (pr2 (pr2 r))) ; apply hinhuniv ; intros r'.
     generalize (pr1 r') (pr1 (pr2 r')) (pr2 (pr2 r')) ; clear r' ; intros r' Zr' Hr.
     apply ispositive_minusNonnegativeRationals in Hr.
-    generalize (is_Dcuts_error x _ Hr).
+    generalize (is_Dcuts_corr x _ Hr).
     apply hinhuniv ; apply sumofmaps ; [intros nXc | ].
     + apply hinhpr ; exists r' ; split.
       * unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; apply sumofmaps ;
@@ -2361,7 +2361,7 @@ Proof.
       exact (pr2 (pr2 r')).
       exact Hr0.
       exact (pr2 (pr2 x)). }
-    generalize (Dcuts_def_error_not_empty _ X0 (is_Dcuts_error _) _ Hc0) ; apply hinhfun ; intros x'.
+    generalize (Dcuts_def_corr_not_empty _ X0 (is_Dcuts_corr _) _ Hc0) ; apply hinhfun ; intros x'.
     exists (pr1 r * (NQmax (pr1 x) (pr1 x') + c))%NRat ; split.
     + unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; intros yx.
       generalize (pr1 (pr2 yx)) ; apply gtNonnegativeRationals_noteq.
@@ -2580,11 +2580,11 @@ Section Dcuts_minus.
   Context (X : hsubtypes NonnegativeRationals).
   Context (X_bot : Dcuts_def_bot X).
   Context (X_open : Dcuts_def_open X).
-  Context (X_error : Dcuts_def_error X).
+  Context (X_corr : Dcuts_def_corr X).
   Context (Y : hsubtypes NonnegativeRationals).
   Context (Y_bot : Dcuts_def_bot Y).
   Context (Y_open : Dcuts_def_open Y).
-  Context (Y_error : Dcuts_def_error Y).
+  Context (Y_corr : Dcuts_def_corr Y).
 
 Definition Dcuts_minus_val : hsubtypes NonnegativeRationals :=
   fun r => ∃ x, X x × Π y, (Y y) ⨿ (y = 0%NRat) -> (r + y < x)%NRat.
@@ -2622,11 +2622,11 @@ Proof.
     exact (pr2 (pr2 x')).
 Qed.
 
-Lemma Dcuts_minus_error : Dcuts_def_error Dcuts_minus_val.
+Lemma Dcuts_minus_corr : Dcuts_def_corr Dcuts_minus_val.
 Proof.
-  assert (Y_error' : Dcuts_def_error (λ y, Y y ∨ (y = 0%NRat))).
+  assert (Y_corr' : Dcuts_def_corr (λ y, Y y ∨ (y = 0%NRat))).
   { intros c Hc.
-    generalize (Y_error c Hc) ; apply hinhfun ; apply sumofmaps ; [intros Yc | intros y ].
+    generalize (Y_corr c Hc) ; apply hinhfun ; apply sumofmaps ; [intros Yc | intros y ].
     - left.
       intros H ; apply Yc ; clear Yc ; revert H.
       apply hinhuniv ; apply sumofmaps ; [intros Yc | intros Hc0].
@@ -2645,14 +2645,14 @@ Proof.
           now apply ispositive_plusNonnegativeRationals_r. }
   intros c Hc.
   apply ispositive_NQhalf in Hc.
-  apply (fun X X0 Xerr => Dcuts_def_error_not_empty X X0 Xerr _ Hc) in Y_error'.
-  revert Y_error' ; apply hinhuniv ; intros y.
+  apply (fun X X0 Xerr => Dcuts_def_corr_not_empty X X0 Xerr _ Hc) in Y_corr'.
+  revert Y_corr' ; apply hinhuniv ; intros y.
   generalize (pr1 (pr2 y)) ; apply hinhuniv ; intros Yy.
   assert (¬ Y (pr1 y + c / 2%NRat)).
   { intro ; apply (pr2 (pr2 y)).
     now apply hinhpr ; left. }
   rename X0 into nYy.
-  generalize (X_error _ Hc) ; apply hinhuniv ; apply sumofmaps ; [intros Xc | intros x].
+  generalize (X_corr _ Hc) ; apply hinhuniv ; apply sumofmaps ; [intros Xc | intros x].
 
   - apply hinhpr ; left ; intro H ; apply Xc.
     revert H ; apply hinhuniv ; intros x.
@@ -2723,8 +2723,8 @@ Definition Dcuts_minus (X Y : Dcuts) : Dcuts :=
   mk_Dcuts (Dcuts_minus_val (pr1 X) (pr1 Y))
            (Dcuts_minus_bot (pr1 X) (pr1 Y))
            (Dcuts_minus_open (pr1 X) (is_Dcuts_open X) (pr1 Y))
-           (Dcuts_minus_error (pr1 X) (is_Dcuts_bot X) (is_Dcuts_error X)
-                              (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_error Y)).
+           (Dcuts_minus_corr (pr1 X) (is_Dcuts_bot X) (is_Dcuts_corr X)
+                              (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_corr Y)).
 
 Lemma Dcuts_minus_correct_l:
   Π x y z : Dcuts, x = Dcuts_plus y z -> z = Dcuts_minus x y.
@@ -2734,7 +2734,7 @@ Proof.
   - intros Zr.
     generalize (is_Dcuts_open _ _ Zr) ; apply hinhuniv ; intros q.
     generalize (pr1 (ispositive_minusNonnegativeRationals _ _) (pr2 (pr2 q))) ; intros Hq.
-    generalize (is_Dcuts_error Y _ Hq) ; apply hinhuniv ; apply sumofmaps ; [intros nYy | ].
+    generalize (is_Dcuts_corr Y _ Hq) ; apply hinhuniv ; apply sumofmaps ; [intros nYy | ].
     + apply hinhpr ; exists (pr1 q) ; split.
       * apply hinhpr ; left ; right.
         exact (pr1 (pr2 q)).
@@ -2811,7 +2811,7 @@ Proof.
   - intros Yr.
     generalize (is_Dcuts_open _ _ Yr) ; apply hinhuniv ; intros q.
     generalize (pr1 (ispositive_minusNonnegativeRationals _ _) (pr2 (pr2 q))) ; intros Hq.
-    generalize (is_Dcuts_error Z _ Hq).
+    generalize (is_Dcuts_corr Z _ Hq).
     apply hinhuniv ; apply sumofmaps ; [intros nZ | ].
     + apply hinhpr ; left ; left.
       apply hinhpr.
@@ -2921,12 +2921,12 @@ Section Dcuts_max.
   Context (X_bot : Dcuts_def_bot X).
   Context (X_open : Dcuts_def_open X).
   Context (X_finite : Dcuts_def_finite X).
-  Context (X_error : Dcuts_def_error X).
+  Context (X_corr : Dcuts_def_corr X).
   Context (Y : hsubtypes NonnegativeRationals).
   Context (Y_bot : Dcuts_def_bot Y).
   Context (Y_open : Dcuts_def_open Y).
   Context (Y_finite : Dcuts_def_finite Y).
-  Context (Y_error : Dcuts_def_error Y).
+  Context (Y_corr : Dcuts_def_corr Y).
 
 Definition Dcuts_max_val : hsubtypes NonnegativeRationals :=
   λ r : NonnegativeRationals, X r ∨ Y r.
@@ -2956,10 +2956,10 @@ Proof.
     exact (pr2 (pr2 q)).
 Qed.
 
-Lemma Dcuts_max_error : Dcuts_def_error Dcuts_max_val.
+Lemma Dcuts_max_corr : Dcuts_def_corr Dcuts_max_val.
 Proof.
   intros c Hc.
-  generalize (X_error _ Hc) (Y_error _ Hc) ; apply hinhfun2 ; apply (sumofmaps (Z := _ → _)) ;
+  generalize (X_corr _ Hc) (Y_corr _ Hc) ; apply hinhfun2 ; apply (sumofmaps (Z := _ → _)) ;
   [intros nXc | intros x] ; apply sumofmaps ; [intros nYc | intros y |intros nYc | intros y].
   - left ; unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; apply sumofmaps ;
     [intros Xc | intros Yc].
@@ -3004,8 +3004,8 @@ Definition Dcuts_max (X Y : Dcuts) : Dcuts :=
                           (pr1 Y) (is_Dcuts_bot Y))
            (Dcuts_max_open (pr1 X) (is_Dcuts_open X)
                            (pr1 Y) (is_Dcuts_open Y))
-           (Dcuts_max_error (pr1 X) (is_Dcuts_bot X) (is_Dcuts_error X)
-                            (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_error Y)).
+           (Dcuts_max_corr (pr1 X) (is_Dcuts_bot X) (is_Dcuts_corr X)
+                            (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_corr Y)).
 
 Lemma iscomm_Dcuts_max :
   Π x y : Dcuts, Dcuts_max x y = Dcuts_max y x.
@@ -3090,7 +3090,7 @@ Proof.
   - apply hinhuniv ; apply sumofmaps ; [intros Xr|intros Yr].
     + generalize (is_Dcuts_open _ _ Xr) ; apply hinhuniv ; intros x.
       generalize (pr1 (ispositive_minusNonnegativeRationals _ _) (pr2 (pr2 x))) ; intros Hx.
-      generalize (is_Dcuts_error Y _ Hx) ; apply hinhuniv ;
+      generalize (is_Dcuts_corr Y _ Hx) ; apply hinhuniv ;
       apply sumofmaps ; [ intros nYx | intros Hyx ] ; apply_pr2_in ispositive_minusNonnegativeRationals Hx.
       * rewrite <- (Dcuts_minus_plus_r (Dcuts_minus X Y) X Y).
         exact Xr.
@@ -3312,12 +3312,12 @@ Section Dcuts_min.
   Context (X_bot : Dcuts_def_bot X).
   Context (X_open : Dcuts_def_open X).
   Context (X_finite : Dcuts_def_finite X).
-  Context (X_error : Dcuts_def_error X).
+  Context (X_corr : Dcuts_def_corr X).
   Context (Y : hsubtypes NonnegativeRationals).
   Context (Y_bot : Dcuts_def_bot Y).
   Context (Y_open : Dcuts_def_open Y).
   Context (Y_finite : Dcuts_def_finite Y).
-  Context (Y_error : Dcuts_def_error Y).
+  Context (Y_corr : Dcuts_def_corr Y).
 
 Definition Dcuts_min_val : hsubtypes NonnegativeRationals :=
   λ r : NonnegativeRationals, X r ∧ Y r.
@@ -3347,10 +3347,10 @@ Proof.
     exact (pr2 (pr2 q')).
 Qed.
 
-Lemma Dcuts_min_error : Dcuts_def_error Dcuts_min_val.
+Lemma Dcuts_min_corr : Dcuts_def_corr Dcuts_min_val.
 Proof.
   intros c Hc0.
-  generalize (X_error _ Hc0) (Y_error _ Hc0) ; apply hinhfun2 ; apply (sumofmaps (Z := _ → _)) ; [intros nXc | intros q] ; intros Hy.
+  generalize (X_corr _ Hc0) (Y_corr _ Hc0) ; apply hinhfun2 ; apply (sumofmaps (Z := _ → _)) ; [intros nXc | intros q] ; intros Hy.
   - left ; intros Hc.
     apply nXc.
     exact (pr1 Hc).
@@ -3384,8 +3384,8 @@ Definition Dcuts_min (X Y : Dcuts) : Dcuts :=
                           (pr1 Y) (is_Dcuts_bot Y))
            (Dcuts_min_open (pr1 X) (is_Dcuts_bot X) (is_Dcuts_open X)
                            (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_open Y))
-           (Dcuts_min_error (pr1 X) (is_Dcuts_bot X) (is_Dcuts_error X)
-                            (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_error Y)).
+           (Dcuts_min_corr (pr1 X) (is_Dcuts_bot X) (is_Dcuts_corr X)
+                            (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_corr Y)).
 
 Lemma iscomm_Dcuts_min :
   Π x y : Dcuts, Dcuts_min x y = Dcuts_min y x.
@@ -3506,7 +3506,7 @@ Section Dcuts_half.
 Context (X : hsubtypes NonnegativeRationals)
         (X_bot : Dcuts_def_bot X)
         (X_open : Dcuts_def_open X)
-        (X_error : Dcuts_def_error X).
+        (X_corr : Dcuts_def_corr X).
 
 Definition Dcuts_half_val : hsubtypes NonnegativeRationals :=
   λ r, X (r + r).
@@ -3533,12 +3533,12 @@ Proof.
     exact ispositive_twoNonnegativeRationals.
     exact ispositive_twoNonnegativeRationals.
 Qed.
-Lemma Dcuts_half_error : Dcuts_def_error Dcuts_half_val.
+Lemma Dcuts_half_corr : Dcuts_def_corr Dcuts_half_val.
 Proof.
   intros c Hc.
   assert (Hc0 : (0 < c + c)%NRat)
     by (now apply ispositive_plusNonnegativeRationals_l).
-  generalize (X_error _ Hc0) ; apply hinhfun ; apply sumofmaps ; [intros Hx | intros r].
+  generalize (X_corr _ Hc0) ; apply hinhfun ; apply sumofmaps ; [intros Hx | intros r].
   - left ; exact Hx.
   - right.
     exists (pr1 r / 2)%NRat ; split.
@@ -3562,7 +3562,7 @@ Definition Dcuts_half (x : Dcuts) : Dcuts :=
   mk_Dcuts (Dcuts_half_val (pr1 x))
            (Dcuts_half_bot (pr1 x) (is_Dcuts_bot x))
            (Dcuts_half_open (pr1 x) (is_Dcuts_open x))
-           (Dcuts_half_error (pr1 x) (is_Dcuts_bot x) (is_Dcuts_error x)).
+           (Dcuts_half_corr (pr1 x) (is_Dcuts_bot x) (is_Dcuts_corr x)).
 
 Lemma Dcuts_half_le :
   Π x : Dcuts, Dcuts_half x <= x.
@@ -3674,7 +3674,7 @@ Lemma Dcuts_locatedness :
 Proof.
   intros X p q Hlt.
   apply ispositive_minusNonnegativeRationals in Hlt.
-  generalize (is_Dcuts_error X _ Hlt).
+  generalize (is_Dcuts_corr X _ Hlt).
   apply_pr2_in ispositive_minusNonnegativeRationals Hlt.
   apply hinhuniv ; apply sumofmaps ; [ intros Xr | ].
   - apply hinhpr ; right.
@@ -3703,7 +3703,7 @@ Section Dcuts_lim.
 Context (U : nat -> hsubtypes NonnegativeRationals)
         (U_bot : Π n : nat, Dcuts_def_bot (U n))
         (U_open : Π n : nat, Dcuts_def_open (U n))
-        (U_error : Π n : nat, Dcuts_def_error (U n)).
+        (U_corr : Π n : nat, Dcuts_def_corr (U n)).
 
 Context (U_cauchy :
            Π eps : NonnegativeRationals,
@@ -3740,13 +3740,13 @@ Proof.
   - apply plusNonnegativeRationals_lt_r, ispositive_NQhalf.
     exact (pr1 (pr2 c)).
 Qed.
-Lemma Dcuts_lim_cauchy_error : Dcuts_def_error Dcuts_lim_cauchy_val.
+Lemma Dcuts_lim_cauchy_corr : Dcuts_def_corr Dcuts_lim_cauchy_val.
 Proof.
   intros c Hc.
   apply ispositive_NQhalf, ispositive_NQhalf in Hc.
   generalize (U_cauchy _ Hc) ; clear U_cauchy ; apply hinhuniv ; intros N.
   generalize (λ n Hn, pr2 N n (pr1 N) Hn (isreflnatleh _)) ; intro Hu.
-  generalize (U_error (pr1 N) _ Hc).
+  generalize (U_corr (pr1 N) _ Hc).
   apply hinhuniv ; apply sumofmaps ; intros HuN.
   - apply hinhpr ; left.
     intro ; apply HuN ; clear HuN.
@@ -3990,9 +3990,9 @@ Proof.
   - apply Dcuts_lim_cauchy_bot.
     intro ; now apply is_Dcuts_bot.
   - apply Dcuts_lim_cauchy_open.
-  - apply Dcuts_lim_cauchy_error.
+  - apply Dcuts_lim_cauchy_corr.
     + intro ; now apply is_Dcuts_bot.
-    + intro ; now apply is_Dcuts_error.
+    + intro ; now apply is_Dcuts_corr.
     + intros eps Heps.
       assert (0 < NonnegativeRationals_to_Dcuts eps)
         by (now apply_pr2 isapfun_NonnegativeRationals_to_Dcuts_aux).
@@ -4139,7 +4139,7 @@ Section Dcuts_of_Dcuts.
 Context (E : hsubtypes Dcuts).
 Context (E_bot : Π x : Dcuts, E x -> Π y : Dcuts, y <= x -> E y).
 Context (E_open : Π x : Dcuts, E x -> ∃ y : Dcuts, x < y × E y).
-Context (E_error: Π c : Dcuts, 0 < c -> (¬ E c) ∨ (hexists (λ P, E P × ¬ E (Dcuts_plus P c)))).
+Context (E_corr: Π c : Dcuts, 0 < c -> (¬ E c) ∨ (hexists (λ P, E P × ¬ E (Dcuts_plus P c)))).
 
 Definition Dcuts_of_Dcuts_val : NonnegativeRationals → hProp :=
   λ r : NonnegativeRationals, ∃ X : Dcuts, (E X) × (r ∈ X).
@@ -4174,13 +4174,13 @@ Proof.
   exact (pr2 (pr2 n)).
 Qed.
 
-Lemma Dcuts_of_Dcuts_error:
-  Dcuts_def_error Dcuts_of_Dcuts_val.
+Lemma Dcuts_of_Dcuts_corr:
+  Dcuts_def_corr Dcuts_of_Dcuts_val.
 Proof.
   intros c Hc.
   apply ispositive_NQhalf in Hc.
   apply (pr2 (isapfun_NonnegativeRationals_to_Dcuts_aux _ _)) in Hc.
-  generalize (E_error _ Hc).
+  generalize (E_corr _ Hc).
   apply isapfun_NonnegativeRationals_to_Dcuts_aux in Hc.
   apply hinhuniv ; apply sumofmaps ; [intros He | ].
   - apply hinhpr ; left.
@@ -4199,7 +4199,7 @@ Proof.
       rewrite (NQhalf_double c).
     apply plusNonnegativeRationals_le_r.
   - apply hinhuniv ; intros X.
-    generalize (is_Dcuts_error (pr1 X) _ Hc).
+    generalize (is_Dcuts_corr (pr1 X) _ Hc).
     apply hinhfun ; apply sumofmaps ; [intros Xc | ].
     + left.
       unfold neg ; apply hinhuniv'.
@@ -4288,15 +4288,15 @@ Qed.
 
 End Dcuts_of_Dcuts.
 
-Definition Dcuts_of_Dcuts (E : hsubtypes Dcuts) E_bot E_error : Dcuts :=
-  mk_Dcuts (Dcuts_of_Dcuts_val E) (Dcuts_of_Dcuts_bot E) (Dcuts_of_Dcuts_open E) (Dcuts_of_Dcuts_error E E_bot E_error).
+Definition Dcuts_of_Dcuts (E : hsubtypes Dcuts) E_bot E_corr : Dcuts :=
+  mk_Dcuts (Dcuts_of_Dcuts_val E) (Dcuts_of_Dcuts_bot E) (Dcuts_of_Dcuts_open E) (Dcuts_of_Dcuts_corr E E_bot E_corr).
 
 Section Dcuts_of_Dcuts'.
 
 Context (E : hsubtypes NonnegativeRationals).
 Context (E_bot : Dcuts_def_bot E).
 Context (E_open : Dcuts_def_open E).
-Context (E_error : Dcuts_def_error E).
+Context (E_corr : Dcuts_def_corr E).
 
 Definition Dcuts_of_Dcuts'_val : hsubtypes Dcuts :=
   λ x : Dcuts, ∃ r : NonnegativeRationals, (¬ (r ∈ x)) × E r.
@@ -4344,7 +4344,7 @@ Proof.
       exact (pr2 (pr2 s)).
 Qed.
 
-Lemma Dcuts_of_Dcuts'_error:
+Lemma Dcuts_of_Dcuts'_corr:
   Π c : Dcuts, 0 < c -> (¬ Dcuts_of_Dcuts'_val c) ∨ (hexists (λ P, Dcuts_of_Dcuts'_val P × ¬ Dcuts_of_Dcuts'_val (Dcuts_plus P c))).
 Proof.
   intros C HC.
@@ -4359,7 +4359,7 @@ Proof.
     - eapply istrans_le_lt_ltNonnegativeRationals, (pr2 (pr2 c)).
       now apply isnonnegative_NonnegativeRationals. }
   revert X ; apply hinhuniv ; intros c.
-  generalize (E_error _ (pr2 (pr2 c))).
+  generalize (E_corr _ (pr2 (pr2 c))).
   apply hinhfun.
   apply sumofmaps ; [intros Ec | intros q].
   - left.
@@ -4410,7 +4410,7 @@ Qed.
 End Dcuts_of_Dcuts'.
 
 Lemma Dcuts_of_Dcuts_bij :
-  Π x : Dcuts, Dcuts_of_Dcuts (Dcuts_of_Dcuts'_val (pr1 x)) (Dcuts_of_Dcuts'_bot (pr1 x)) (Dcuts_of_Dcuts'_error (pr1 x) (is_Dcuts_bot x) (is_Dcuts_error x)) = x.
+  Π x : Dcuts, Dcuts_of_Dcuts (Dcuts_of_Dcuts'_val (pr1 x)) (Dcuts_of_Dcuts'_bot (pr1 x)) (Dcuts_of_Dcuts'_corr (pr1 x) (is_Dcuts_bot x) (is_Dcuts_corr x)) = x.
 Proof.
   intros x.
   apply Dcuts_eq_is_eq.
@@ -4478,16 +4478,16 @@ Proof.
     apply (pr2 (pr2 r)).
 Qed.
 
-Lemma isub_Dcuts_of_Dcuts (E : hsubtypes Dcuts) E_bot E_error :
-  isUpperBound (X := PreorderedSetEffectiveOrder eo_Dcuts) E (Dcuts_of_Dcuts E E_bot E_error).
+Lemma isub_Dcuts_of_Dcuts (E : hsubtypes Dcuts) E_bot E_corr :
+  isUpperBound (X := PreorderedSetEffectiveOrder eo_Dcuts) E (Dcuts_of_Dcuts E E_bot E_corr).
 Proof.
   intros ;
   intros x Ex r Hr.
   apply hinhpr.
   now exists x.
 Qed.
-Lemma islbub_Dcuts_of_Dcuts (E : hsubtypes Dcuts) E_bot E_error :
-  isSmallerThanUpperBounds (X := PreorderedSetEffectiveOrder eo_Dcuts) E (Dcuts_of_Dcuts E E_bot E_error).
+Lemma islbub_Dcuts_of_Dcuts (E : hsubtypes Dcuts) E_bot E_corr :
+  isSmallerThanUpperBounds (X := PreorderedSetEffectiveOrder eo_Dcuts) E (Dcuts_of_Dcuts E E_bot E_corr).
 Proof.
   intros.
   intros x Hx ; simpl.
@@ -4497,12 +4497,12 @@ Proof.
   intros H ; simple refine (H _ _).
   exact (pr2 (pr2 y)).
 Qed.
-Lemma islub_Dcuts_of_Dcuts (E : hsubtypes eo_Dcuts) E_bot E_error :
-  isLeastUpperBound (X := PreorderedSetEffectiveOrder eo_Dcuts) E (Dcuts_of_Dcuts E E_bot E_error).
+Lemma islub_Dcuts_of_Dcuts (E : hsubtypes eo_Dcuts) E_bot E_corr :
+  isLeastUpperBound (X := PreorderedSetEffectiveOrder eo_Dcuts) E (Dcuts_of_Dcuts E E_bot E_corr).
 Proof.
   split.
-  exact (isub_Dcuts_of_Dcuts E E_bot E_error).
-  exact (islbub_Dcuts_of_Dcuts E E_bot E_error).
+  exact (isub_Dcuts_of_Dcuts E E_bot E_corr).
+  exact (islbub_Dcuts_of_Dcuts E E_bot E_corr).
 Qed.
 
 
@@ -4585,7 +4585,7 @@ Definition hsubtypesNonnegativeRationals_to_NonnegativeReals
   (Xopen : Π x : NonnegativeRationals,
              X x ->
              hexists (fun y : NonnegativeRationals => dirprod (X y) (x < y)%NRat))
-  (Xtop : Dcuts_def_error X) : NonnegativeReals :=
+  (Xtop : Dcuts_def_corr X) : NonnegativeReals :=
   mk_Dcuts X Xbot Xopen Xtop.
 
 Definition minusNonnegativeReals : binop NonnegativeReals := Dcuts_minus.
@@ -5347,7 +5347,7 @@ Proof.
     apply multNonnegativeReals_lecompat_r'.
     apply lt_leNonnegativeReals, (pr2 (pr2 r1)).
   - intros x.
-    generalize (Dcuts_def_error_finite _ (is_Dcuts_error x)).
+    generalize (Dcuts_def_corr_finite _ (is_Dcuts_corr x)).
     apply hinhuniv ; intros r.
     generalize (isarchrig_2 _ H (pr1 r)).
     apply hinhfun.

--- a/UniMath/RealNumbers/Reals.v
+++ b/UniMath/RealNumbers/Reals.v
@@ -15,7 +15,7 @@ Open Scope NR_scope.
 Definition hr_commrng : commrng := commrigtocommrng NonnegativeReals.
 
 Definition NR_to_hr : NonnegativeReals × NonnegativeReals → hr_commrng
-  := setquotpr (binopeqrelabgrfrac (rigaddabmonoid NonnegativeReals)).
+  := setquotpr (binopeqrelabgrdiff (rigaddabmonoid NonnegativeReals)).
 
 Definition nat_to_hr (n : nat) : hr_commrng :=
   NR_to_hr (nat_to_NonnegativeReals n,,0).
@@ -43,7 +43,7 @@ Proof.
 Qed.
 
 Lemma iscomprelfun_hr_to_NR :
-  iscomprelfun (Y := NonnegativeReals × NonnegativeReals) (binopeqrelabgrfrac (rigaddabmonoid NonnegativeReals))
+  iscomprelfun (Y := NonnegativeReals × NonnegativeReals) (binopeqrelabgrdiff (rigaddabmonoid NonnegativeReals))
                (λ x : NonnegativeReals × NonnegativeReals,
                       pr1 x - pr2 x ,, pr2 x - pr1 x).
 Proof.
@@ -235,7 +235,7 @@ Proof.
   unfold BinaryOperations.op1 ; simpl.
   unfold rigtorngop1 ; simpl.
   unfold NR_to_hr.
-  apply (setquotfun2comm (binopeqrelabgrfrac (rigaddabmonoid NonnegativeReals)) (binopeqrelabgrfrac (rigaddabmonoid NonnegativeReals))).
+  apply (setquotfun2comm (binopeqrelabgrdiff (rigaddabmonoid NonnegativeReals)) (binopeqrelabgrdiff (rigaddabmonoid NonnegativeReals))).
 Qed.
 
 (** opp *)
@@ -246,9 +246,9 @@ Lemma NR_to_hr_opp :
 Proof.
   intros x.
   unfold rnginv1, grinv_is ; simpl.
-  unfold abgrfracinv.
+  unfold abgrdiffinv.
   unfold NR_to_hr.
-  apply (setquotfuncomm (binopeqrelabgrfrac (rigaddabmonoid NonnegativeReals)) (binopeqrelabgrfrac (rigaddabmonoid NonnegativeReals))).
+  apply (setquotfuncomm (binopeqrelabgrdiff (rigaddabmonoid NonnegativeReals)) (binopeqrelabgrdiff (rigaddabmonoid NonnegativeReals))).
 Qed.
 
 Lemma hr_to_NR_opp :
@@ -356,7 +356,7 @@ Proof.
   unfold BinaryOperations.op2 ; simpl.
   unfold rigtorngop2 ; simpl.
   unfold NR_to_hr.
-  apply (setquotfun2comm (binopeqrelabgrfrac (rigaddabmonoid NonnegativeReals)) (binopeqrelabgrfrac (rigaddabmonoid NonnegativeReals))).
+  apply (setquotfun2comm (binopeqrelabgrdiff (rigaddabmonoid NonnegativeReals)) (binopeqrelabgrdiff (rigaddabmonoid NonnegativeReals))).
 Qed.
 
 (** *** Order *)
@@ -454,7 +454,7 @@ Qed.
 Lemma isantisymm_hr_le :
   isantisymm hr_le_rel.
 Proof.
-  apply isantisymmabgrfracrel.
+  apply isantisymmabgrdiffrel.
   intros X Y Hxy Hyx.
   apply isantisymm_leNonnegativeReals.
   now split.
@@ -463,17 +463,17 @@ Qed.
 Lemma isStrongOrder_hr_lt : isStrongOrder hr_lt_rel.
 Proof.
   repeat split.
-  - apply istransabgrfracrel.
+  - apply istransabgrdiffrel.
     exact istrans_ltNonnegativeReals.
-  - apply iscotransabgrfracrel.
+  - apply iscotransabgrdiffrel.
     exact iscotrans_ltNonnegativeReals.
-  - apply isirreflabgrfracrel.
+  - apply isirreflabgrdiffrel.
     exact isirrefl_ltNonnegativeReals.
 Qed.
 Lemma iscotrans_hr_lt :
   iscotrans hr_lt_rel.
 Proof.
-  apply iscotransabgrfracrel.
+  apply iscotransabgrdiffrel.
   exact iscotrans_ltNonnegativeReals.
 Qed.
 


### PR DESCRIPTION
Rename abgrfrac into abgrdiff (for group of differences)
Rename Dcuts_def_error into Dcuts_def_corr (for correctness)