### PR TITLE
lazy evaluation works on maps from lists to base types

### DIFF
--- a/UniMath/CategoryTheory/Inductives/Lists.v
+++ b/UniMath/CategoryTheory/Inductives/Lists.v
@@ -196,6 +196,9 @@ apply listIndProp.
   now rewrite !foldr_cons, <- Hl.
 Qed.
 
+Definition concatenate : pr1 List -> pr1 List -> pr1 List :=
+  fun l l' => foldr _ l cons l'.
+
 End lists.
 
 (** Some examples of computations with lists over nat *)
@@ -227,6 +230,8 @@ Eval lazy in length _ testlist.
 Eval lazy in length _ testlistS.
 Eval lazy in sum testlist.
 Eval lazy in sum testlistS.
+Eval lazy in length _ (concatenate _ testlist testlistS).
+Eval lazy in sum (concatenate _ testlist testlistS).
 
 Goal (Π l, length _ (2 :: l) = S (length _ l)).
 simpl.

--- a/UniMath/CategoryTheory/Inductives/Lists.v
+++ b/UniMath/CategoryTheory/Inductives/Lists.v
@@ -221,6 +221,13 @@ Definition sum : pr1 (List natHSET) -> nat :=
 (* Eval vm_compute in sum testlist. *)
 (* Eval vm_compute in sum testlistS. *)
 
+(* All of these compute *)
+Eval lazy in length _ (nil natHSET).
+Eval lazy in length _ testlist.
+Eval lazy in length _ testlistS.
+Eval lazy in sum testlist.
+Eval lazy in sum testlistS.
+
 Goal (Π l, length _ (2 :: l) = S (length _ l)).
 simpl.
 intro l.
@@ -307,6 +314,10 @@ Defined.
 
 (* This doesn't compute: *)
 (* Eval compute in (to_list _ testlist). *)
+
+(* This does compute: *)
+Eval lazy in (to_list _ testlist).
+
 
 End list.
 

--- a/UniMath/CategoryTheory/Inductives/Trees.v
+++ b/UniMath/CategoryTheory/Inductives/Trees.v
@@ -25,6 +25,7 @@ Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.CocontFunctors.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
+Require Import UniMath.CategoryTheory.Inductives.Lists.
 
 Local Notation "# F" := (functor_on_morphisms F) (at level 3).
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
@@ -222,4 +223,35 @@ Qed.
 Definition sum : pr1 (Tree natHSET) -> nat :=
   foldr natHSET natHSET 0 (fun x => pr1 x + pr1 (pr2 x) + pr2 (pr2 x)).
 
+Definition testtree : pr1 (Tree natHSET).
+Proof.
+  use node_map; repeat split.
+  - apply 5.
+  - use node_map; repeat split.
+    + apply 6.
+    + apply leaf_map. apply tt.
+    + apply leaf_map. apply tt.
+  - apply leaf_map. apply tt.
+Defined.
+
+
 End nat_examples.
+
+(** ** Flattening of a tree into a list *)
+Local Notation "a :: b" := (cons _ ((a,, b) : _ × _  )).
+Check concatenate.
+Definition flatten (A : HSET) : pr1 (Tree A) -> pr1 (List A).
+Proof.
+  intro t.
+  use (foldr A).
+  - apply nil.
+  - intro all'.
+    set (a := pr1 all').
+    set (l := pr1 (pr2 all')).
+    set (l' := pr2 (pr2 all')). cbn beta in l'.
+    exact (concatenate _ l (concatenate _ (a :: nil _ ) l')).
+  - exact t.
+Defined.
+
+Eval lazy in Lists.sum (flatten _ testtree).
+Eval lazy in sum testtree.


### PR DESCRIPTION
- maps defined by initiality on our "inductive" type of lists over A (initial algebra of X => 1 + A x X) compute when the target type is a "base type".
- such maps don't compute, of course, when the target type is an inductive type (and hence a quotient) itself.