### PR TITLE
Added complexes

### DIFF
--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -89,3 +89,4 @@ UnderPrecategories.v
 Subobjects.v
 Quotobjects.v
 GrothendieckTopos.v
+Complexes.v

--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -90,3 +90,4 @@ Subobjects.v
 Quotobjects.v
 GrothendieckTopos.v
 Complexes.v
+CohomologyComplex.v

--- a/UniMath/CategoryTheory/Additive.v
+++ b/UniMath/CategoryTheory/Additive.v
@@ -1,4 +1,8 @@
 (** * Additive categories. *)
+(** * Contents
+- Definition of additive categories
+- Quotient of an additive category is additive
+*)
 Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.Foundations.Basics.Propositions.
 Require Import UniMath.Foundations.Basics.Sets.
@@ -22,8 +26,7 @@ Require Import UniMath.CategoryTheory.limits.BinDirectSums.
 (** * Definition of additive categories *)
 Section def_additive.
 
-  (** A preadditive category is additive if it has a zero object and binary
-    direct sums. *)
+  (** A preadditive category is additive if it has a zero object and binary direct sums. *)
   Definition isAdditive (PA : PreAdditive) : UU := (Zero PA) × (BinDirectSums PA).
 
   Definition mk_isAdditive (PA : PreAdditive) (H1 : Zero PA) (H2 : BinDirectSums PA) :
@@ -63,3 +66,25 @@ Section def_additive.
   Defined.
 
 End def_additive.
+
+
+(** * Quotient is additive
+    We show that quotient of an additive category by certain subgroups is additive. In particular,
+    this is used to show that the naive homotopy category of the category of chain complexes is an
+    Additive precategory. *)
+Section additive_quot_additive.
+
+  Variable A : Additive.
+  Hypothesis PAS : PreAdditiveSubabgrs A.
+  Hypothesis PAC : PreAdditiveComps A PAS.
+
+  Definition QuotPrecategory_Additive : Additive.
+  Proof.
+    use mk_Additive.
+    - exact (QuotPrecategory_PreAdditive A PAS PAC).
+    - use mk_isAdditive.
+      + exact (QuotPrecategory_Zero A PAS PAC (to_Zero A)).
+      + exact (QuotPrecategory_BinDirectSums A (to_BinDirectSums A) PAS PAC).
+  Defined.
+
+End additive_quot_additive.

--- a/UniMath/CategoryTheory/Additive.v
+++ b/UniMath/CategoryTheory/Additive.v
@@ -14,6 +14,8 @@ Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
 Require Import UniMath.CategoryTheory.PreAdditive.
 
 Require Import UniMath.CategoryTheory.limits.zero.
+Require Import UniMath.CategoryTheory.limits.bincoproducts.
+Require Import UniMath.CategoryTheory.limits.binproducts.
 Require Import UniMath.CategoryTheory.limits.BinDirectSums.
 
 
@@ -47,5 +49,17 @@ Section def_additive.
   Definition to_Zero (A : Additive) : Zero A := dirprod_pr1 (to_isAdditive A).
 
   Definition to_BinDirectSums (A : Additive) : BinDirectSums A := dirprod_pr2 (to_isAdditive A).
+
+  Definition to_BinCoproducts (A : Additive) : BinCoproducts A.
+  Proof.
+    intros X Y.
+    exact (BinDirectSum_BinCoproduct A (to_BinDirectSums A X Y)).
+  Defined.
+
+  Definition to_BinProducts (A : Additive) : BinProducts A.
+  Proof.
+    intros X Y.
+    exact (BinDirectSum_BinProduct A (to_BinDirectSums A X Y)).
+  Defined.
 
 End def_additive.

--- a/UniMath/CategoryTheory/CohomologyComplex.v
+++ b/UniMath/CategoryTheory/CohomologyComplex.v
@@ -3,9 +3,9 @@
 - Cohomology functor C(A) -> C(A)
 - Alternative definition of cohomology complex
 - Quasi-isomorphism in C(A)
-- Cohomology functor K(A) -> K(A)
- - Construction of K(A) -> K(A)
- - K(A) -> K(A) is additive
+- Cohomology functor K(A) -> C(A)
+ - Construction of K(A) -> C(A)
+ - K(A) -> C(A) is additive
  - Quasi-isomorphisms in K(A)
 - Complex of kernels and complex of cokernels
  - Construction of the complexes
@@ -982,14 +982,14 @@ End def_cohomology_functor_additive.
 
 
 
-(** * We show that CohomologyFunctor factors though naive homotopy category *)
+(** * CohomologyFunctor factors through naive homotopy category *)
 (** ** Introduction
    We show that there exists a functor K(A) -> K(A) such that the following diagram is commutative
                            C(A) -> C(A)
-                             |       |
-                           K(A) -> K(A)
+                             |      ||         (Think this as a triangle)
+                           K(A) -> C(A)
    Here C(A) -> C(A) is the cohomology functor H : C(A) -> C(A), [CohomologyFunctor], see section
-   [def_cohomology_complex]. The vertical functor C(A) -> K(A) are the canonical functors
+   [def_cohomology_complex]. The vertical functor C(A) -> K(A) is the canonical functor
    [ComplexHomotFunctor]. The constructed functor K(A) -> K(A) is also additive. Using this
    functor we define quasi-isomorphisms for K(A).
 
@@ -997,17 +997,17 @@ End def_cohomology_functor_additive.
    commute because the vertical functors are identity on objects. To construct the map on morphisms
    we  first show that two homotopic, [ComplexHomotSubset], morphisms in C(A) are mapped to the
    same morphism by the cohomology functor for C(A). Thus, given a morphism f in K(A), for every
-   morphism f' which maps to f by C(A) -> K(A) the image under C(A) -> C(A) -> K(A) is the same,
-   that is, is contractible. This is the observation we use to define the map on morphisms. After
-   this observation it is easy to see that the diagram is commutative.
+   morphism f' which maps to f by C(A) -> K(A) the image under C(A) -> C(A) is the same, that is,
+   is contractible. This is the observation we use to define the map on morphisms. After this
+   observation it is easy to see that the diagram is commutative.
 
    In [CohomologyFunctorHomotopy] it is shown that a morphism induced by homotopy is sent to the
    zero morphism in C(A). In [CohomologyFunctorHomotopies] we use this observation to prove that
    two homotopic morphisms are sent to the same morphisms by the cohomology functor. In
    [CohomologyFunctorH_Mor] we show that the image on morphisms is contractible, in
-   [CohomologyFunctorH_functor_data] we construct the functor data for K(A) -> K(A), and finally
+   [CohomologyFunctorH_functor_data] we construct the functor data for K(A) -> C(A), and finally
    in [CohomologyFunctorH] we construct the functor. Commutativity of the diagram is proved in
-   [CohomologyFunctorHCommutes]. The fact that K(A) -> K(A) is additive is proved in
+   [CohomologyFunctorHCommutes]. The fact that K(A) -> C(A) is additive is proved in
    [CohomologyFunctorH_Additive].
 *)
 Section def_cohomology_homotopy.
@@ -1112,34 +1112,32 @@ Section def_cohomology_homotopy.
 
   Definition CohomologyFunctorHIm {C1 C2 : ComplexHomot_Additive (AbelianToAdditive A hs)}
              (f : ComplexHomot_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧) : UU :=
-    Σ (h : ComplexHomot_Additive (AbelianToAdditive A hs) ⟦CohomologyComplex A hs C1,
-                                                           CohomologyComplex A hs C2⟧),
+    Σ (h : (ComplexPreCat_Additive (AbelianToAdditive A hs))⟦CohomologyComplex A hs C1,
+                                                             CohomologyComplex A hs C2⟧),
     Π (f' : ComplexPreCat_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧)
       (H : # (ComplexHomotFunctor (AbelianToAdditive A hs)) f' = f),
-    h = # (ComplexHomotFunctor (AbelianToAdditive A hs)) (# (CohomologyFunctor A hs) f').
+    h = # (CohomologyFunctor A hs) f'.
 
   Definition CohomologyFunctorHImMor {C1 C2 : ComplexHomot_Additive (AbelianToAdditive A hs)}
              {f : ComplexHomot_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧}
              (h : CohomologyFunctorHIm f) :
-    ComplexHomot_Additive (AbelianToAdditive A hs) ⟦CohomologyComplex A hs C1,
-                                                    CohomologyComplex A hs C2⟧ := pr1 h.
+    (ComplexPreCat_Additive (AbelianToAdditive A hs))⟦CohomologyComplex A hs C1,
+                                                      CohomologyComplex A hs C2⟧ := pr1 h.
 
   Definition CohomologyFunctorHImEq {C1 C2 : ComplexHomot_Additive (AbelianToAdditive A hs)}
              {f : ComplexHomot_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧}
              (h : CohomologyFunctorHIm f)
              (f' : ComplexPreCat_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧)
              (H : # (ComplexHomotFunctor (AbelianToAdditive A hs)) f' = f) :
-    (CohomologyFunctorHImMor h) =
-    # (ComplexHomotFunctor (AbelianToAdditive A hs)) (# (CohomologyFunctor A hs) f') := pr2 h f' H.
+    CohomologyFunctorHImMor h = # (CohomologyFunctor A hs) f' := pr2 h f' H.
 
   Definition mk_CohomologyFunctorHIm {C1 C2 : ComplexHomot_Additive (AbelianToAdditive A hs)}
-             (f : ComplexHomot_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧)
-             (h : ComplexHomot_Additive (AbelianToAdditive A hs) ⟦CohomologyComplex A hs C1,
-                                                                  CohomologyComplex A hs C2⟧)
+             (f : (ComplexHomot_Additive (AbelianToAdditive A hs))⟦C1, C2⟧)
+             (h : (ComplexPreCat_Additive (AbelianToAdditive A hs))⟦CohomologyComplex A hs C1,
+                                                                    CohomologyComplex A hs C2⟧)
              (HH : Π (f' : ComplexPreCat_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧)
                      (H : # (ComplexHomotFunctor (AbelianToAdditive A hs)) f' = f),
-                   h = # (ComplexHomotFunctor (AbelianToAdditive A hs))
-                         (# (CohomologyFunctor A hs) f')) : CohomologyFunctorHIm f :=
+                   h = # (CohomologyFunctor A hs) f') : CohomologyFunctorHIm f :=
     tpair _ h HH.
 
   Lemma CohomologyFunctorHImEquality {C1 C2 : ComplexHomot_Additive (AbelianToAdditive A hs)}
@@ -1150,7 +1148,7 @@ Section def_cohomology_homotopy.
     use total2_paths.
     - exact e.
     - apply proofirrelevance. apply impred_isaprop. intros t0.
-      apply impred_isaprop. intros H0. apply has_homsets_ComplexHomot_Additive.
+      apply impred_isaprop. intros H0. apply has_homsets_ComplexPreCat.
   Qed.
 
   (** ** Construction of the functor and commutativity  *)
@@ -1160,10 +1158,8 @@ Section def_cohomology_homotopy.
         (H : hfiber # (ComplexHomotFunctor (AbelianToAdditive A hs)) f)
         (f' : ComplexPreCat_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧)
         (H' : # (ComplexHomotFunctor (AbelianToAdditive A hs)) f' = f) :
-    # (ComplexHomotFunctor (AbelianToAdditive A hs)) (# (CohomologyFunctor A hs) (pr1 H)) =
-    # (ComplexHomotFunctor (AbelianToAdditive A hs)) (# (CohomologyFunctor A hs) f').
+    # (CohomologyFunctor A hs) (pr1 H) = # (CohomologyFunctor A hs) f'.
   Proof.
-    apply maponpaths.
     use CohomologyFunctorHomotopies.
     use (@abgrquotpr_rel_paths _ (binopeqrel_subgr_eqrel
                                     (ComplexHomotSubgrp (AbelianToAdditive A hs) C1 C2))).
@@ -1178,8 +1174,7 @@ Section def_cohomology_homotopy.
     apply isapropiscontr. intros H.
     use iscontrpair.
     - use mk_CohomologyFunctorHIm.
-      + exact (# ((ComplexHomotFunctor (AbelianToAdditive A hs)))
-                 (# (CohomologyFunctor A hs) (hfiberpr1 _ _ H))).
+      + exact ((# (CohomologyFunctor A hs) (hfiberpr1 _ _ H))).
       + intros f' H'. exact (CohomologyFunctorH_Mor_eq f H f' H').
     - intros t. use CohomologyFunctorHImEquality.
       use CohomologyFunctorHImEq.
@@ -1193,7 +1188,7 @@ Section def_cohomology_homotopy.
                        (iscontrpr1 (CohomologyFunctorH_Mor (identity C)))
                        (identity _)
                        (functor_id (ComplexHomotFunctor (AbelianToAdditive A hs)) _))).
-    rewrite functor_id. rewrite functor_id. apply idpath.
+    rewrite functor_id. apply idpath.
   Qed.
 
   Lemma CohomologyFunctorH_Mor_Comp {C1 C2 C3 : ComplexHomot_Additive (AbelianToAdditive A hs)}
@@ -1204,17 +1199,12 @@ Section def_cohomology_homotopy.
       ;; (CohomologyFunctorHImMor (iscontrpr1 (CohomologyFunctorH_Mor g))) .
   Proof.
     use (squash_to_prop (ComplexHomotFunctor_issurj (AbelianToAdditive A hs) f)).
-    apply has_homsets_ComplexHomot_Additive. intros f'.
+    apply has_homsets_ComplexPreCat. intros f'.
     use (squash_to_prop (ComplexHomotFunctor_issurj (AbelianToAdditive A hs) g)).
-    apply has_homsets_ComplexHomot_Additive. intros g'.
+    apply has_homsets_ComplexPreCat. intros g'.
     rewrite (CohomologyFunctorHImEq (iscontrpr1 (CohomologyFunctorH_Mor f)) _ (hfiberpr2 _ _ f')).
     rewrite (CohomologyFunctorHImEq (iscontrpr1 (CohomologyFunctorH_Mor g)) _ (hfiberpr2 _ _ g')).
-    set (tmp := functor_comp (ComplexHomotFunctor (AbelianToAdditive A hs)) _ _ _
-                             (# (CohomologyFunctor A hs) (hfiberpr1 _ _ f'))
-                             (# (CohomologyFunctor A hs) (hfiberpr1 _ _ g'))).
-    use (pathscomp0 _ tmp). clear tmp.
     set (tmp := functor_comp (CohomologyFunctor A hs) _ _ _ (hfiberpr1 _ _ f') (hfiberpr1 _ _ g')).
-    apply (maponpaths (# (ComplexHomotFunctor (AbelianToAdditive A hs)))) in tmp.
     use (pathscomp0 _ tmp). clear tmp.
     use (CohomologyFunctorHImEq (iscontrpr1 (CohomologyFunctorH_Mor (f ;; g)))).
     rewrite functor_comp. rewrite (hfiberpr2 _ _ f'). rewrite (hfiberpr2 _ _ g'). apply idpath.
@@ -1222,7 +1212,7 @@ Section def_cohomology_homotopy.
 
   Definition CohomologyFunctorH_functor_data :
     functor_data (ComplexHomot_Additive (AbelianToAdditive A hs))
-                 (ComplexHomot_Additive (AbelianToAdditive A hs)).
+                 (ComplexPreCat_Additive (AbelianToAdditive A hs)).
   Proof.
     use tpair.
     - intros C. exact (CohomologyComplex A hs C).
@@ -1238,7 +1228,7 @@ Section def_cohomology_homotopy.
 
   Definition CohomologyFunctorH :
     functor (ComplexHomot_Additive (AbelianToAdditive A hs))
-            (ComplexHomot_Additive (AbelianToAdditive A hs)).
+            (ComplexPreCat_Additive (AbelianToAdditive A hs)).
   Proof.
     use tpair.
     - exact CohomologyFunctorH_functor_data.
@@ -1247,7 +1237,7 @@ Section def_cohomology_homotopy.
 
   Lemma CohomologyFunctorHCommutes :
     functor_composite (ComplexHomotFunctor (AbelianToAdditive A hs)) CohomologyFunctorH =
-    functor_composite (CohomologyFunctor A hs) (ComplexHomotFunctor (AbelianToAdditive A hs)).
+    (CohomologyFunctor A hs).
   Proof.
     use total2_paths.
     - use total2_paths.
@@ -1262,7 +1252,7 @@ Section def_cohomology_homotopy.
                      (# (ComplexHomotFunctor (AbelianToAdditive A hs)) f))) f
                (idpath _)).
     - apply proofirrelevance. apply isaprop_is_functor.
-      use has_homsets_ComplexHomot_Additive.
+      use has_homsets_ComplexPreCat.
   Qed.
 
 
@@ -1273,33 +1263,24 @@ Section def_cohomology_homotopy.
         (C1 C2 : (ComplexHomot_Additive (AbelianToAdditive A hs))) :
     # CohomologyFunctorH
       (ZeroArrow (Additive.to_Zero (ComplexHomot_Additive (AbelianToAdditive A hs))) C1 C2) =
-    ZeroArrow (Additive.to_Zero (ComplexHomot_Additive (AbelianToAdditive A hs)))
+    ZeroArrow (Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)))
               (CohomologyFunctorH C1) (CohomologyFunctorH C2).
   Proof.
+    use (pathscomp0 _ (@AdditiveFunctorZeroArrow
+                         (ComplexPreCat_Additive (AbelianToAdditive A hs))
+                         (ComplexPreCat_Additive (AbelianToAdditive A hs))
+                         (CohomologyFunctor_Additive A hs) C1 C2)).
     assert (e0 : # (ComplexHomotFunctor (AbelianToAdditive A hs))
                    (ZeroArrow (Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)))
                               _ _) =
                  ZeroArrow (Additive.to_Zero (ComplexHomot_Additive (AbelianToAdditive A hs)))
-                           (CohomologyFunctorH C1) (CohomologyFunctorH C2)).
+                           C1 C2).
     {
       apply AdditiveFunctorZeroArrow.
     }
     rewrite <- e0. clear e0.
-    assert (e1 : # (ComplexHomotFunctor (AbelianToAdditive A hs))
-                   (ZeroArrow (Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)))
-                              (CohomologyFunctorH C1) (CohomologyFunctorH C2)) =
-                 # (ComplexHomotFunctor (AbelianToAdditive A hs))
-                   (# (CohomologyFunctor A hs) (ZeroArrow to_Zero _ _))).
-    {
-      apply maponpaths. apply pathsinv0.
-      apply (@AdditiveFunctorZeroArrow
-               (ComplexPreCat_Additive (AbelianToAdditive A hs))
-               (ComplexPreCat_Additive (AbelianToAdditive A hs))
-               (CohomologyFunctor_Additive A hs)).
-    }
-    rewrite e1. clear e1.
     use CohomologyFunctorHImEq.
-    apply AdditiveFunctorZeroArrow.
+    apply idpath.
   Qed.
 
   Local Lemma CohomologyFunctorH_Additive_linear
@@ -1310,9 +1291,9 @@ Section def_cohomology_homotopy.
              (# CohomologyFunctorH f) (# CohomologyFunctorH g).
   Proof.
     use (squash_to_prop (ComplexHomotFunctor_issurj (AbelianToAdditive A hs) f)).
-    apply has_homsets_ComplexHomot_Additive. intros f'.
+    apply has_homsets_ComplexPreCat. intros f'.
     use (squash_to_prop (ComplexHomotFunctor_issurj (AbelianToAdditive A hs) g)).
-    apply has_homsets_ComplexHomot_Additive. intros g'.
+    apply has_homsets_ComplexPreCat. intros g'.
     cbn.
     rewrite (CohomologyFunctorHImEq (iscontrpr1 (CohomologyFunctorH_Mor f))
                                     (hfiberpr1 _ _ f') (hfiberpr2 _ _ f')).
@@ -1320,21 +1301,10 @@ Section def_cohomology_homotopy.
                                     (hfiberpr1 _ _ g') (hfiberpr2 _ _ g')).
     set (tmp := @AdditiveFunctorLinear
                   (ComplexPreCat_Additive (AbelianToAdditive A hs))
-                  (ComplexHomot_Additive (AbelianToAdditive A hs))
-                  (ComplexHomotFunctor (AbelianToAdditive A hs))
-                  (CohomologyComplex A hs C1) (CohomologyComplex A hs C2)
-                  (# (CohomologyFunctor A hs)
-                     (hfiberpr1 # (ComplexHomotFunctor (AbelianToAdditive A hs)) f f'))
-                  (# (CohomologyFunctor A hs)
-                     (hfiberpr1 # (ComplexHomotFunctor (AbelianToAdditive A hs)) g g'))).
-    use (pathscomp0 _ tmp). clear tmp.
-    set (tmp := @AdditiveFunctorLinear
-                  (ComplexPreCat_Additive (AbelianToAdditive A hs))
                   (ComplexPreCat_Additive (AbelianToAdditive A hs))
                   (CohomologyFunctor_Additive A hs) C1 C2
                   (hfiberpr1 # (ComplexHomotFunctor (AbelianToAdditive A hs)) f f')
                   (hfiberpr1 # (ComplexHomotFunctor (AbelianToAdditive A hs)) g g')).
-    apply (maponpaths # (ComplexHomotFunctor (AbelianToAdditive A hs))) in tmp.
     use (pathscomp0 _ tmp). clear tmp.
     use (CohomologyFunctorHImEq (iscontrpr1 (CohomologyFunctorH_Mor (to_binop C1 C2 f g)))).
     rewrite AdditiveFunctorLinear.
@@ -1344,7 +1314,7 @@ Section def_cohomology_homotopy.
   Local Lemma CohomologyFunctorH_isAdditive : isAdditiveFunctor CohomologyFunctorH.
   Proof.
     refine (@mk_isAdditiveFunctor' (ComplexHomot_Additive (AbelianToAdditive A hs))
-                                   (ComplexHomot_Additive (AbelianToAdditive A hs))
+                                   (ComplexPreCat_Additive (AbelianToAdditive A hs))
                                    CohomologyFunctorH _ _).
     - intros C1 C2. exact (CohomologyFunctorH_Additive_zero C1 C2).
     - intros C1 C2 f g. exact (CohomologyFunctorH_Additive_linear f g).
@@ -1352,7 +1322,7 @@ Section def_cohomology_homotopy.
 
   Definition CohomologyFunctorH_Additive :
     AdditiveFunctor (ComplexHomot_Additive (AbelianToAdditive A hs))
-                    (ComplexHomot_Additive (AbelianToAdditive A hs)).
+                    (ComplexPreCat_Additive (AbelianToAdditive A hs)).
   Proof.
     use mk_AdditiveFunctor.
     - exact CohomologyFunctorH.
@@ -1384,7 +1354,7 @@ Section def_cohomology_homotopy.
     isHQIS (f1 ;; f2).
   Proof.
     unfold isHQIS. rewrite functor_comp.
-    apply (@is_iso_comp_of_isos (ComplexHomot_Additive (AbelianToAdditive A hs)) _ _ _
+    apply (@is_iso_comp_of_isos (ComplexPreCat_Additive (AbelianToAdditive A hs)) _ _ _
                                 (isopair _ H1) (isopair _ H2)).
   Qed.
 

--- a/UniMath/CategoryTheory/CohomologyComplex.v
+++ b/UniMath/CategoryTheory/CohomologyComplex.v
@@ -1,0 +1,2182 @@
+(** * Cohomology of complexes *)
+(** ** Contents
+- Cohomology functor C(A) -> C(A)
+- Alternative definition of cohomology complex
+- Quasi-isomorphism in C(A)
+- Cohomology functor K(A) -> K(A)
+ - Construction of K(A) -> K(A)
+ - K(A) -> K(A) is additive
+ - Quasi-isomorphisms in K(A)
+- Complex of kernels and complex of cokernels
+ - Construction of the complexes
+ - Cohomology and morphisms from cokernels to kernels
+ *)
+
+Require Import UniMath.Foundations.Basics.UnivalenceAxiom.
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.Foundations.Algebra.BinaryOperations.
+Require Import UniMath.Foundations.Algebra.Monoids_and_Groups.
+
+Require Import UniMath.Foundations.NumberSystems.NaturalNumbers.
+Require Import UniMath.Foundations.NumberSystems.Integers.
+
+Require Import UniMath.CategoryTheory.total2_paths.
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+
+Require Import UniMath.CategoryTheory.limits.zero.
+Require Import UniMath.CategoryTheory.limits.binproducts.
+Require Import UniMath.CategoryTheory.limits.bincoproducts.
+Require Import UniMath.CategoryTheory.limits.equalizers.
+Require Import UniMath.CategoryTheory.limits.coequalizers.
+Require Import UniMath.CategoryTheory.limits.kernels.
+Require Import UniMath.CategoryTheory.limits.cokernels.
+Require Import UniMath.CategoryTheory.limits.pushouts.
+Require Import UniMath.CategoryTheory.limits.pullbacks.
+Require Import UniMath.CategoryTheory.limits.BinDirectSums.
+Require Import UniMath.CategoryTheory.Monics.
+Require Import UniMath.CategoryTheory.Epis.
+Require Import UniMath.CategoryTheory.functor_categories.
+
+Require Import UniMath.CategoryTheory.PrecategoriesWithBinOps.
+Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
+Require Import UniMath.CategoryTheory.PreAdditive.
+Require Import UniMath.CategoryTheory.Additive.
+Require Import UniMath.CategoryTheory.Abelian.
+Require Import UniMath.CategoryTheory.AbelianToAdditive.
+Require Import UniMath.CategoryTheory.AdditiveFunctors.
+Require Import UniMath.CategoryTheory.Complexes.
+
+
+Open Scope hz_scope.
+Local Opaque hz isdecrelhzeq hzplus iscommrngops.
+
+(** * Cohomology functor *)
+(** ** Introduction
+   In this section we define the cohomology functor H : C(A) -> C(A). Suppose A is the category of
+   abelian groups. Then H sends a complex
+                     ... -> X^{i-1} -> X^i -> X^{i+1} -> ...
+   to the complex
+     ... -> Ker d^{i-1} / Im d^{i-2} -> Ker d^i / Im d^{i-1} -> Ker d^{i+1} / Im d^i -> ...
+   where the differentials are given by zero morphisms. A morphism f : X -> Y is sent to the induced
+   morphism. That is, f^i : X^i -> Y^i induces a morphism (H f)^i : ker d^i_X / Im d^{i-1}_X ->
+   ker d^i_Y / Im d^{i-1}_Y as one can check.
+
+   In category theory, there are two isomorphic ways to define the cohomology complex. We use the
+   following definition. The ith cohomology is defined to be the cokernel of the morphism X^{i-1} ->
+   Ker d^i, the KernelIn map of Ker d^i obtained by using the fact that d^{i-1} ;; d^i = 0. If f is
+   a morphism of complexes, then by using properties of kernelin and cokernelout we construct the
+   induced morphism.
+
+   The map on complexes is constructed in [CohomologyComplex]. The map on morphisms is constructed
+   in [CohomologyMorphism]. The functor_data is contructed from these in [CohomologyFunctor_data],
+   and finally in [CohomologyFunctor] we prove that this data defines a functor.
+*)
+Section def_cohomology_complex.
+
+  Variable A : AbelianPreCat.
+  Variable hs : has_homsets A.
+
+  (** ** Cohomology complex *)
+
+  Local Lemma CohomologyComplex_KernelIn_eq' (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    (transportf (λ x : pr1 hz, A ⟦ C (i - 1), C x ⟧) (hzrminusplus i 1) (Diff C (i - 1)))
+      ;; (Diff C i) = ZeroArrow to_Zero _ _.
+  Proof.
+    induction (hzrminusplus i 1). cbn. unfold idfun.
+    apply (CEq (AbelianToAdditive A hs) C (i - 1)).
+  Qed.
+
+  Local Lemma CohomologyComplex_KernelIn_eq (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+      (transportf (precategory_morphisms (C (i - 1))) (maponpaths C (hzrminusplus i 1))
+                  (Diff C (i - 1))) ;; (Diff C i) = ZeroArrow to_Zero _ _.
+  Proof.
+    rewrite <- functtransportf. cbn.
+    induction (hzrminusplus i 1). cbn. unfold idfun.
+    apply (CEq (AbelianToAdditive A hs) C (i - 1)).
+  Qed.
+
+  Definition CohomologyComplex (C : (ComplexPreCat_AbelianPreCat A hs)) :
+    ComplexPreCat_AbelianPreCat A hs.
+  Proof.
+    cbn in *.
+    use mk_Complex.
+    - intros i.
+      exact (Abelian.Cokernel (KernelIn to_Zero (Abelian.Kernel (Diff C i)) _ _
+                                        (CohomologyComplex_KernelIn_eq C i))).
+    - intros i. exact (ZeroArrow (to_Zero) _ _).
+    - intros i. cbn. apply ZeroArrow_comp_left.
+  Defined.
+
+  (** ** Cohomology morphism *)
+
+  Local Lemma CohomologyMorphism_KernelIn_comm {C1 C2 : Complex (AbelianToAdditive A hs)}
+        (f : Morphism C1 C2) (i : hz) :
+    KernelArrow (Kernel (Diff C1 i)) ;; MMor f i ;; Diff C2 i =
+    ZeroArrow to_Zero (Kernel (Diff C1 i)) (C2 (i + 1)).
+  Proof.
+    rewrite <- assoc. set (tmp := MComm f i). cbn in tmp. rewrite tmp. clear tmp.
+    rewrite assoc. rewrite KernelCompZero. apply ZeroArrow_comp_left.
+  Qed.
+
+  Local Lemma CohomolohyMorphism_Ker_comm {C1 C2 : Complex (AbelianToAdditive A hs)}
+        (f : Morphism C1 C2) (i : hz) :
+    (KernelIn to_Zero (Kernel (Diff C1 i)) (C1 (i - 1))
+              (transportf (precategory_morphisms (C1 (i - 1))) (maponpaths C1 (hzrminusplus i 1))
+                          (Diff C1 (i - 1)))
+              (CohomologyComplex_KernelIn_eq C1 i))
+      ;; (KernelIn to_Zero (Kernel (Diff C2 i)) (Kernel (Diff C1 i))
+                   (KernelArrow (Kernel (Diff C1 i)) ;; MMor f i)
+                   (CohomologyMorphism_KernelIn_comm f i)) =
+    (MMor f (i - 1))
+      ;; (KernelIn to_Zero (Kernel (Diff C2 i)) (C2 (i - 1))
+                   (transportf (precategory_morphisms (C2 (i - 1)))
+                               (maponpaths C2 (hzrminusplus i 1)) (Diff C2 (i - 1)))
+                   (CohomologyComplex_KernelIn_eq C2 i)).
+  Proof.
+    apply (KernelArrowisMonic to_Zero (Kernel (Diff C2 i))).
+    rewrite <- assoc. rewrite <- assoc. rewrite KernelCommutes. rewrite KernelCommutes.
+    cbn. rewrite <- transportf_postcompose. cbn.
+    set (tmp := MComm f (i - 1)). cbn in tmp. rewrite tmp. clear tmp.
+    rewrite assoc. rewrite KernelCommutes.
+    induction (hzrminusplus i 1). cbn. unfold idfun. apply idpath.
+  Qed.
+
+  Local Lemma CohomologyMorphism_Ker_Coker_Zero {C1 C2 : Complex (AbelianToAdditive A hs)}
+        (f : Morphism C1 C2) (i : hz) :
+    (KernelIn to_Zero (Kernel (Diff C1 i)) (C1 (i - 1))
+              (transportf (precategory_morphisms (C1 (i - 1))) (maponpaths C1 (hzrminusplus i 1))
+                          (Diff C1 (i - 1))) (CohomologyComplex_KernelIn_eq C1 i))
+      ;; ((KernelIn to_Zero (Kernel (Diff C2 i)) (Kernel (Diff C1 i))
+                    (KernelArrow (Kernel (Diff C1 i)) ;; MMor f i)
+                    (CohomologyMorphism_KernelIn_comm f i))
+            ;;  (CokernelArrow
+                   (Cokernel
+                      (KernelIn to_Zero (Kernel (Diff C2 i)) (C2 (i - 1))
+                                (transportf (precategory_morphisms (C2 (i - 1)))
+                                            (maponpaths C2 (hzrminusplus i 1))
+                                            (Diff C2 (i - 1)))
+                                (CohomologyComplex_KernelIn_eq C2 i))))) =
+    ZeroArrow to_Zero _ _.
+  Proof.
+    rewrite assoc. rewrite CohomolohyMorphism_Ker_comm. rewrite <- assoc.
+    rewrite CokernelCompZero. apply ZeroArrow_comp_right.
+  Qed.
+
+  Definition CohomologyMorphism_Mor {C1 C2 : Complex (AbelianToAdditive A hs)} (f : Morphism C1 C2)
+             (i : hz) :
+    AbelianToAdditive A hs ⟦((CohomologyComplex C1) : Complex (AbelianToAdditive A hs)) i,
+                            ((CohomologyComplex C2) : Complex (AbelianToAdditive A hs)) i⟧.
+  Proof.
+    cbn.
+    use CokernelOut.
+    - use compose.
+      + exact (Kernel (Diff C2 i)).
+      + use KernelIn.
+        * use compose.
+          -- exact (C1 i).
+          -- use KernelArrow.
+          -- exact (MMor f i).
+        * exact (CohomologyMorphism_KernelIn_comm f i).
+      + use CokernelArrow.
+    - apply CohomologyMorphism_Ker_Coker_Zero.
+  Defined.
+
+  Local Lemma CohomologyMorphism_Mor_comm {C1 C2 : Complex (AbelianToAdditive A hs)}
+        (f : Morphism C1 C2) (i : hz) :
+    (CohomologyMorphism_Mor f i)
+      ;; (Diff ((CohomologyComplex C2) : Complex (AbelianToAdditive A hs)) i) =
+    (Diff ((CohomologyComplex C1) : Complex (AbelianToAdditive A hs)) i)
+      ;; (CohomologyMorphism_Mor f (i + 1)).
+  Proof.
+    cbn. rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_right. apply idpath.
+  Qed.
+
+  Definition CohomologyMorphism {C1 C2 : Complex (AbelianToAdditive A hs)} (f : Morphism C1 C2) :
+    Morphism (CohomologyComplex C1) (CohomologyComplex C2).
+  Proof.
+    use mk_Morphism.
+    - intros i. exact (CohomologyMorphism_Mor f i).
+    - intros i. exact (CohomologyMorphism_Mor_comm f i).
+  Defined.
+
+  (** ** Cohomology functor *)
+
+  Definition CohomologyFunctor_data :
+    functor_data (ComplexPreCat_AbelianPreCat A hs) (ComplexPreCat_AbelianPreCat A hs).
+  Proof.
+    use tpair.
+    - cbn. intros C. exact (CohomologyComplex C).
+    - cbn. intros C1 C2 f. exact (CohomologyMorphism f).
+  Defined.
+
+  Local Lemma CohomologyFunctor_id (C : (ComplexPreCat_AbelianPreCat A hs)) :
+    CohomologyMorphism (IdMor C) = IdMor (CohomologyComplex C).
+  Proof.
+    cbn in *.
+    use MorphismEq.
+    intros i. cbn. apply pathsinv0.
+    apply CokernelEndo_is_identity. unfold CohomologyMorphism_Mor. rewrite CokernelCommutes.
+    rewrite <- id_left. apply cancel_postcomposition.
+    use KernelInsEq. rewrite KernelCommutes.
+    rewrite id_left. rewrite id_right. apply idpath.
+  Qed.
+
+  Local Lemma CohomologyFunctor_assoc {C1 C2 C3 : (ComplexPreCat_AbelianPreCat A hs)}
+        (f : (ComplexPreCat_AbelianPreCat A hs)⟦C1, C2⟧)
+        (g : (ComplexPreCat_AbelianPreCat A hs)⟦C2, C3⟧) :
+    # CohomologyFunctor_data (f ;; g) = # CohomologyFunctor_data f ;; # CohomologyFunctor_data g.
+  Proof.
+    cbn in *.
+    use MorphismEq.
+    intros i. cbn. unfold CohomologyMorphism_Mor. use CokernelOutsEq. rewrite CokernelCommutes.
+    rewrite assoc. rewrite CokernelCommutes.
+    rewrite <- assoc. rewrite CokernelCommutes.
+    rewrite assoc. apply cancel_postcomposition.
+    use KernelInsEq. rewrite KernelCommutes.
+    rewrite <- assoc. rewrite KernelCommutes.
+    rewrite assoc. rewrite KernelCommutes.
+    cbn. rewrite assoc. apply idpath.
+  Qed.
+
+  Definition CohomologyFunctor :
+    functor (ComplexPreCat_AbelianPreCat A hs) (ComplexPreCat_AbelianPreCat A hs).
+  Proof.
+    use tpair.
+    - exact CohomologyFunctor_data.
+    - cbn. split.
+      + intros C. cbn. exact (CohomologyFunctor_id C).
+      + intros C1 C2 C3 f g. exact (CohomologyFunctor_assoc f g).
+  Defined.
+
+End def_cohomology_complex.
+
+
+(** * Alternative definition of Cohomology complex *)
+(** ** Introduction
+   We construct an isomorphic alternative of [CohomologyComplex].
+*)
+Section def_cohomology'_complex.
+
+  Variable A : AbelianPreCat.
+  Variable hs : has_homsets A.
+
+  Definition CohomologyComplex' (C : (ComplexPreCat_AbelianPreCat A hs)) :
+    (ComplexPreCat_AbelianPreCat A hs).
+  Proof.
+    cbn in *.
+    use mk_Complex.
+    - intros i.
+      exact (Kernel (CokernelOut to_Zero (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                                               (maponpaths C (hzrminusplus i 1))
+                                                               (Diff C (i - 1)))) _ (Diff C i)
+                                 (CohomologyComplex_KernelIn_eq A hs C i))).
+    - intros i. exact (ZeroArrow to_Zero _ _).
+    - intros i. apply ZeroArrow_comp_left.
+  Defined.
+
+  Local Lemma CohomologyComplexIso_eq1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    (factorization1_monic
+       A (transportf (precategory_morphisms (C (i - 1)))
+                     (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1))))
+      ;; (Diff C i) = ZeroArrow to_Zero _ _.
+  Proof.
+    use (EpiisEpi A (factorization1_epi A hs (transportf (precategory_morphisms (C (i - 1)))
+                                                         (maponpaths C (hzrminusplus i 1))
+                                                         (Diff C (i - 1))))).
+    rewrite assoc. rewrite <- factorization1. rewrite ZeroArrow_comp_right.
+    exact (CohomologyComplex_KernelIn_eq A hs C i).
+  Qed.
+
+  Local Lemma CohomologyComplexIso_eq1' (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    (factorization1_epi
+       A hs (transportf (precategory_morphisms (C (i - 1)))
+                        (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1))))
+      ;; (factorization1_monic
+            A (transportf (precategory_morphisms (C (i - 1)))
+                          (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1))))
+      ;; (Diff C i) = ZeroArrow to_Zero _ _.
+  Proof.
+    rewrite <- factorization1. exact (CohomologyComplex_KernelIn_eq A hs C i).
+  Qed.
+
+  Local Lemma CohomologyComplexIso_eq2 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    (transportf (precategory_morphisms (C (i - 1))) (maponpaths C (hzrminusplus i 1))
+                (Diff C (i - 1)))
+      ;; (factorization2_epi A (Diff C i)) = ZeroArrow to_Zero _ _.
+  Proof.
+    use (MonicisMonic A (factorization2_monic A hs (Diff C i))).
+    rewrite <- assoc.
+    set (tmp := factorization1 hs (Diff C i)). cbn in tmp. cbn. rewrite <- assoc in tmp.
+    rewrite <- tmp. clear tmp. rewrite ZeroArrow_comp_left.
+    exact (CohomologyComplex_KernelIn_eq A hs C i).
+  Qed.
+
+  Local Lemma CohomologyComplexIso_eq2' (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    (transportf (precategory_morphisms (C (i - 1))) (maponpaths C (hzrminusplus i 1))
+                (Diff C (i - 1)))
+      ;; ((factorization2_epi A (Diff C i)) ;; (factorization2_monic A hs (Diff C i))) =
+    ZeroArrow to_Zero _ _.
+  Proof.
+    rewrite <- factorization2. exact (CohomologyComplex_KernelIn_eq A hs C i).
+  Qed.
+
+  Local Lemma CohomologyComplexIso_KerCokerIso_eq1 {x y : A} {f : A⟦x, y⟧}
+        (CK1 CK2 : cokernels.Cokernel to_Zero f)
+        (K1 : kernels.Kernel to_Zero (CokernelArrow CK1))
+        (K2 : kernels.Kernel to_Zero (CokernelArrow CK2)) :
+    KernelArrow K1 ;; CokernelArrow CK2 = ZeroArrow to_Zero K1 CK2.
+  Proof.
+    assert (e1 : CokernelArrow CK2 =
+                 (CokernelArrow CK1) ;; (CokernelOut to_Zero CK1 CK2 (CokernelArrow CK2)
+                                                     (CokernelCompZero to_Zero CK2))).
+    {
+      rewrite CokernelCommutes. apply idpath.
+    }
+    rewrite e1. rewrite assoc. rewrite KernelCompZero. apply ZeroArrow_comp_left.
+  Qed.
+
+  Local Lemma CohomologyComplexIso_KerCokerIso_eq2 {x y : A} {f : A⟦x, y⟧}
+        (CK1 CK2 : cokernels.Cokernel to_Zero f)
+        (K1 : kernels.Kernel to_Zero (CokernelArrow CK1))
+        (K2 : kernels.Kernel to_Zero (CokernelArrow CK2)) :
+    KernelArrow K2 ;; CokernelArrow CK1 = ZeroArrow to_Zero K2 CK1.
+  Proof.
+    assert (e1 : CokernelArrow CK1 =
+                 (CokernelArrow CK2) ;; (CokernelOut to_Zero CK2 CK1 (CokernelArrow CK1)
+                                                     (CokernelCompZero to_Zero CK1))).
+    {
+      rewrite CokernelCommutes. apply idpath.
+    }
+    rewrite e1. rewrite assoc. rewrite KernelCompZero. apply ZeroArrow_comp_left.
+  Qed.
+
+  Definition CohomologyComplexIso_KerCokerIso {x y : A} {f : A⟦x, y⟧}
+        (CK1 CK2 : cokernels.Cokernel to_Zero f)
+        (K1 : kernels.Kernel to_Zero (CokernelArrow CK1))
+        (K2 : kernels.Kernel to_Zero (CokernelArrow CK2)) : iso K1 K2.
+  Proof.
+    use isopair.
+    - use KernelIn.
+      + use KernelArrow.
+      + exact (CohomologyComplexIso_KerCokerIso_eq1 CK1 CK2 K1 K2).
+    - use is_iso_qinv.
+      + use KernelIn.
+        * use KernelArrow.
+        * exact (CohomologyComplexIso_KerCokerIso_eq2 CK1 CK2 K1 K2).
+      + split.
+        * use (KernelArrowisMonic to_Zero K1).
+          rewrite <- assoc. rewrite KernelCommutes. rewrite KernelCommutes.
+          rewrite id_left. apply idpath.
+        * use (KernelArrowisMonic to_Zero K2).
+          rewrite <- assoc. rewrite KernelCommutes. rewrite KernelCommutes.
+          rewrite id_left. apply idpath.
+  Qed.
+
+  Local Lemma CohomologyComplexIso_CokerKerIso_eq1 {x y : A} {f : A⟦x, y⟧}
+        (K1 K2 : kernels.Kernel to_Zero f)
+        (CK1 : cokernels.Cokernel to_Zero (KernelArrow K1))
+        (CK2 : cokernels.Cokernel to_Zero (KernelArrow K2)) :
+    KernelArrow K1 ;; CokernelArrow CK2 = ZeroArrow to_Zero K1 CK2.
+  Proof.
+    assert (e1 : KernelArrow K1 = (KernelIn to_Zero K2 K1 (KernelArrow K1)
+                                            (KernelCompZero to_Zero K1)) ;; (KernelArrow K2)).
+    {
+      rewrite KernelCommutes. apply idpath.
+    }
+    rewrite e1. rewrite <- assoc. rewrite CokernelCompZero. apply ZeroArrow_comp_right.
+  Qed.
+
+  Local Lemma CohomologyComplexIso_CokerKerIso_eq2 {x y : A} {f : A⟦x, y⟧}
+        (K1 K2 : kernels.Kernel to_Zero f)
+        (CK1 : cokernels.Cokernel to_Zero (KernelArrow K1))
+        (CK2 : cokernels.Cokernel to_Zero (KernelArrow K2)) :
+    KernelArrow K2 ;; CokernelArrow CK1 = ZeroArrow to_Zero K2 CK1.
+  Proof.
+    assert (e2 : KernelArrow K2 = (KernelIn to_Zero K1 K2 (KernelArrow K2)
+                                            (KernelCompZero to_Zero K2)) ;; (KernelArrow K1)).
+    {
+      rewrite KernelCommutes. apply idpath.
+    }
+    rewrite e2. rewrite <- assoc. rewrite CokernelCompZero. apply ZeroArrow_comp_right.
+  Qed.
+
+  Definition CohomologyComplexIso_CokerKerIso {x y : A} {f : A⟦x, y⟧}
+        (K1 K2 : kernels.Kernel to_Zero f)
+        (CK1 : cokernels.Cokernel to_Zero (KernelArrow K1))
+        (CK2 : cokernels.Cokernel to_Zero (KernelArrow K2)) : iso CK1 CK2.
+  Proof.
+    use isopair.
+    - use CokernelOut.
+      + use CokernelArrow.
+      + exact (CohomologyComplexIso_CokerKerIso_eq1 K1 K2 CK1 CK2).
+    - use is_iso_qinv.
+      + use CokernelOut.
+        * use CokernelArrow.
+        * exact (CohomologyComplexIso_CokerKerIso_eq2 K1 K2 CK1 CK2).
+      + split.
+        * use (CokernelArrowisEpi to_Zero CK1).
+          rewrite assoc. rewrite CokernelCommutes. rewrite CokernelCommutes.
+          rewrite id_right. apply idpath.
+        * use (CokernelArrowisEpi to_Zero CK2).
+          rewrite assoc. rewrite CokernelCommutes. rewrite CokernelCommutes.
+          rewrite id_right. apply idpath.
+  Qed.
+
+  Local Lemma CohomologyComplexIso_isMonic (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let K1 := KernelIn to_Zero (Kernel (Diff C i)) _ _ (CohomologyComplexIso_eq1 C i) in
+    isMonic K1.
+  Proof.
+    intros K1.
+    use isMonic_postcomp.
+    - exact (C i).
+    - use KernelArrow.
+    - unfold K1. rewrite KernelCommutes. apply MonicisMonic.
+  Qed.
+
+  Local Lemma CohomologyComplexIso_isEpi (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let CK1 := CokernelOut
+                 to_Zero
+                 (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                       (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1))))
+                 _ _ (CohomologyComplexIso_eq2 C i) in
+    isEpi CK1.
+  Proof.
+    intros CK1.
+    use isEpi_precomp.
+    - exact (C i).
+    - use CokernelArrow.
+    - unfold CK1. rewrite CokernelCommutes. apply EpiisEpi.
+  Qed.
+
+  Local Lemma CohomologyComplexIso_mor_eq1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let K1 := KernelIn to_Zero (Kernel (Diff C i)) _ _ (CohomologyComplexIso_eq1 C i) in
+    (factorization1_epi
+       A hs (transportf (precategory_morphisms (C (i - 1)))
+                        (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1)))) ;; K1 =
+    KernelIn to_Zero (Abelian.Kernel (Diff C i)) _ _ (CohomologyComplex_KernelIn_eq A hs C i).
+  Proof.
+    intros K1.
+    unfold K1.
+    rewrite <- (@KernelInComp A to_Zero _ _ _ _ _ _ _ _ (CohomologyComplexIso_eq1' C i)).
+    use KernelInsEq. rewrite KernelCommutes. rewrite KernelCommutes.
+    apply pathsinv0. apply factorization1.
+  Qed.
+
+  Local Lemma CohomologyComplexIso_mor_eq2 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let CK1 := CokernelOut
+                 to_Zero
+                 (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                       (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1))))
+                 _ _ (CohomologyComplexIso_eq2 C i) in
+    (CokernelOut
+       to_Zero
+       (Cokernel
+          (transportf (precategory_morphisms (C (i - 1)))
+                      (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1))))
+       (C (i + 1)) (Diff C i) (CohomologyComplex_KernelIn_eq A hs C i)) =
+    CK1 ;; (factorization2_monic A hs (Diff C i)).
+  Proof.
+    intros CK1.
+    unfold CK1.
+    rewrite <- (@CokernelOutComp A to_Zero _ _ _ _ _ _ _ _ (CohomologyComplexIso_eq2' C i)).
+    use CokernelOutsEq. rewrite CokernelCommutes. rewrite CokernelCommutes.
+    apply factorization2.
+  Qed.
+
+  Local Lemma CohomologyComplexIso_isKernel_Eq (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let φ1 := KernelArrow (Kernel (Diff C i)) in
+    let φ2 := CokernelArrow (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                                  (maponpaths C (hzrminusplus i 1))
+                                                  (Diff C (i - 1)))) in
+    let K1 := KernelIn to_Zero (Kernel (Diff C i)) _ _ (CohomologyComplexIso_eq1 C i) in
+    K1 ;; (φ1 ;; φ2) = ZeroArrow to_Zero _ _.
+  Proof.
+    intros φ1 φ2 K1.
+    rewrite assoc. unfold K1. unfold φ1. rewrite KernelCommutes.
+    set (f1 := factorization1 hs (transportf (precategory_morphisms (C (i - 1)))
+                                             (maponpaths C (hzrminusplus i 1))
+                                             (Diff C (i - 1)))).
+    set (CK2 := CokernelPath A to_Zero f1 (Cokernel _)).
+    set (CK2' := CokernelEpiComp A hs to_Zero _ _ CK2).
+    set (K3 := MonicToKernel' A hs _ CK2').
+    apply (KernelCompZero to_Zero K3).
+  Qed.
+
+  Local Lemma CohomologyComplexIso_isKernel (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let φ1 := KernelArrow (Kernel (Diff C i)) in
+    let φ2 := CokernelArrow (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                                  (maponpaths C (hzrminusplus i 1))
+                                                  (Diff C (i - 1)))) in
+    let K1 := KernelIn to_Zero (Kernel (Diff C i)) _ _ (CohomologyComplexIso_eq1 C i) in
+    isKernel to_Zero K1 (φ1 ;; φ2) (CohomologyComplexIso_isKernel_Eq C i).
+  Proof.
+    intros φ1 φ2 K1.
+    set (f1 := factorization1 hs (transportf (precategory_morphisms (C (i - 1)))
+                                             (maponpaths C (hzrminusplus i 1))
+                                             (Diff C (i - 1)))).
+    set (CK2 := CokernelPath A to_Zero f1 (Cokernel _)).
+    set (CK2' := CokernelEpiComp A hs to_Zero _ _ CK2).
+    set (K3 := MonicToKernel' A hs _ CK2').
+    use mk_isKernel.
+    - exact hs.
+    - intros w h H'. rewrite assoc in H'.
+      use unique_exists.
+      + exact (KernelIn to_Zero K3 _ (h ;; φ1) H').
+      + cbn beta.
+        use (KernelArrowisMonic to_Zero (Kernel (Diff C i))). unfold K1.
+        rewrite <- assoc. rewrite KernelCommutes.
+        fold φ1. rewrite <- (KernelCommutes to_Zero K3 _ _ H').
+        apply cancel_precomposition. apply idpath.
+      + intros y. apply hs.
+      + intros y X. cbn beta in X. apply (CohomologyComplexIso_isMonic C i). fold K1. rewrite X.
+        use (KernelArrowisMonic to_Zero (Kernel (Diff C i))). unfold K1.
+        rewrite <- assoc. rewrite KernelCommutes.
+        rewrite (KernelCommutes to_Zero K3). apply idpath.
+  Qed.
+
+  Local Lemma CohomologyComplexIso_KernelArrow (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let K4 := mk_Kernel' _ _ _ (CohomologyComplexIso_isKernel_Eq C i)
+                         (CohomologyComplexIso_isKernel C i) in
+    KernelArrow K4 = KernelIn to_Zero (Kernel (Diff C i))
+                              (Image
+                                 (transportf (precategory_morphisms (C (i - 1)))
+                                             (maponpaths C (hzrminusplus i 1))
+                                             (Diff C (i - 1))))
+                              (factorization1_monic
+                                 A (transportf (precategory_morphisms (C (i - 1)))
+                                               (maponpaths C (hzrminusplus i 1))
+                                               (Diff C (i - 1))))
+                              (CohomologyComplexIso_eq1 C i).
+  Proof.
+    apply idpath.
+  Qed.
+
+  Local Lemma CohomologyComplexIso_isCokernel_Eq (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let φ1 := KernelArrow (Kernel (Diff C i)) in
+    let φ2 := CokernelArrow (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                                  (maponpaths C (hzrminusplus i 1))
+                                                  (Diff C (i - 1)))) in
+    let CK1 := CokernelOut
+                 to_Zero
+                 (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                       (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1))))
+                 _ _ (CohomologyComplexIso_eq2 C i) in
+    φ1 ;; φ2 ;; CK1 = ZeroArrow to_Zero _ _.
+  Proof.
+    intros φ1 φ2 CK1.
+    unfold CK1. unfold φ2. rewrite <- assoc. rewrite CokernelCommutes.
+    set (f2 := factorization2 hs (Diff C i)).
+    set (K2 := KernelPath A to_Zero f2 (Kernel _)).
+    set (K2' := KernelCompMonic A hs to_Zero _ _ K2).
+    set (CK3 := EpiToCokernel' A hs _ K2').
+    apply (CokernelCompZero to_Zero CK3).
+  Qed.
+
+  Local Lemma CohomologyComplexIso_isCokernel (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let φ1 := KernelArrow (Kernel (Diff C i)) in
+    let φ2 := CokernelArrow (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                                  (maponpaths C (hzrminusplus i 1))
+                                                  (Diff C (i - 1)))) in
+    let CK1 := CokernelOut
+                 to_Zero
+                 (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                       (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1))))
+                 _ _ (CohomologyComplexIso_eq2 C i) in
+    isCokernel to_Zero CK1 (φ1 ;; φ2) (CohomologyComplexIso_isCokernel_Eq C i).
+  Proof.
+    intros φ1 φ2 CK1.
+    set (f2 := factorization2 hs (Diff C i)).
+    set (K2 := KernelPath A to_Zero f2 (Kernel _)).
+    set (K2' := KernelCompMonic A hs to_Zero _ _ K2).
+    set (CK3 := EpiToCokernel' A hs _ K2').
+    use mk_isCokernel.
+    - exact hs.
+    - intros w h H'. rewrite <- assoc in H'.
+      use unique_exists.
+      + exact (CokernelOut to_Zero CK3 _ (φ2 ;; h) H').
+      + cbn beta.
+        use (CokernelArrowisEpi to_Zero (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                                              (maponpaths C (hzrminusplus i 1))
+                                                              (Diff C (i - 1))))).
+        unfold CK1. rewrite assoc. rewrite CokernelCommutes. fold φ2.
+        rewrite <- (CokernelCommutes to_Zero CK3 _ _ H').
+        apply cancel_postcomposition. apply idpath.
+      + intros y. apply hs.
+      + intros y X. cbn beta in X. apply (CohomologyComplexIso_isEpi C i). fold CK1. rewrite X.
+        use (CokernelArrowisEpi to_Zero (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                                              (maponpaths C (hzrminusplus i 1))
+                                                              (Diff C (i - 1))))).
+        unfold CK1.
+        rewrite assoc.  rewrite CokernelCommutes.
+        rewrite (CokernelCommutes to_Zero CK3). apply idpath.
+  Qed.
+
+  Local Lemma CohomologyComplexIso_CokernelArrow (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let CK4 := mk_Cokernel' _ _ _ (CohomologyComplexIso_isCokernel_Eq C i)
+                            (CohomologyComplexIso_isCokernel C i) in
+    CokernelArrow CK4 =
+    (CokernelOut to_Zero
+                 (Cokernel
+                    (transportf (precategory_morphisms (C (i - 1)))
+                                (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1))))
+                 (CoImage (Diff C i)) (factorization2_epi A (Diff C i))
+                 (CohomologyComplexIso_eq2 C i)).
+  Proof.
+    apply idpath.
+  Qed.
+
+  Definition CohomologyComplexIso_Mor1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let K1 := KernelIn to_Zero (Kernel (Diff C i)) _ _ (CohomologyComplexIso_eq1 C i) in
+    A⟦Cokernel
+        (factorization1_epi
+           A hs (transportf (precategory_morphisms (C (i - 1))) (maponpaths C (hzrminusplus i 1))
+                            (Diff C (i - 1))) ;; K1),
+       Cokernel
+         (KernelIn to_Zero (Kernel (Diff C i)) (C (i - 1))
+                   (transportf (precategory_morphisms (C (i - 1))) (maponpaths C (hzrminusplus i 1))
+                               (Diff C (i - 1))) (CohomologyComplex_KernelIn_eq A hs C i))⟧ :=
+    @CokernelOutPaths_is_iso_mor
+      A to_Zero _ _ _ _ (CohomologyComplexIso_mor_eq1 C i) (Cokernel _) (Cokernel _).
+
+  Definition CohomologyComplexIso_Mor2 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let K1 := KernelIn to_Zero (Kernel (Diff C i)) _ _ (CohomologyComplexIso_eq1 C i) in
+    A ⟦Cokernel K1,
+       Cokernel
+         (factorization1_epi
+            A hs (transportf (precategory_morphisms (C (i - 1))) (maponpaths C (hzrminusplus i 1))
+                             (Diff C (i - 1))) ;; K1)⟧ :=
+    let K1 := KernelIn to_Zero (Kernel (Diff C i)) _ _ (CohomologyComplexIso_eq1 C i) in
+    CokernelEpiComp_mor2
+      A to_Zero (factorization1_epi A hs (transportf (precategory_morphisms (C (i - 1)))
+                                                     (maponpaths C (hzrminusplus i 1))
+                                                     (Diff C (i - 1))))
+      K1 (Cokernel _) (Cokernel _).
+
+  Definition CohomologyComplexIso_Mor3 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let CK1 := CokernelOut
+                 to_Zero
+                 (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                       (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1))))
+                 _ _ (CohomologyComplexIso_eq2 C i) in
+    A⟦Kernel
+        (CokernelOut
+           to_Zero (Cokernel
+                      (transportf (precategory_morphisms (C (i - 1)))
+                                  (maponpaths C (hzrminusplus i 1))
+                                  (Diff C (i - 1)))) (C (i + 1)) (Diff C i)
+           (CohomologyComplex_KernelIn_eq A hs C i)),
+      Kernel (CK1 ;; factorization2_monic A hs (Diff C i))⟧ :=
+    @KernelInPaths_is_iso_mor
+      A to_Zero _ _ _ _ (CohomologyComplexIso_mor_eq2 C i) (Kernel _) (Kernel _).
+
+  Definition CohomologyComplexIso_Mor4 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let CK1 := CokernelOut
+                 to_Zero
+                 (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                       (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1))))
+                 _ _ (CohomologyComplexIso_eq2 C i) in
+    A ⟦Kernel (CK1 ;; factorization2_monic A hs (Diff C i)), Kernel CK1⟧ :=
+    (KernelCompMonic_mor1 A to_Zero _ _ (Kernel _) (Kernel _)).
+
+  Definition CohomologyComplexIso_Mor5 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let K1 := KernelIn to_Zero (Kernel (Diff C i)) _ _ (CohomologyComplexIso_eq1 C i) in
+    let K4 := mk_Kernel' _ _ _ (CohomologyComplexIso_isKernel_Eq C i)
+                         (CohomologyComplexIso_isKernel C i) in
+    A⟦Cokernel (KernelArrow K4), Cokernel K1⟧ :=
+    @CokernelOutPaths_is_iso_mor
+      A to_Zero _ _ _ _ (CohomologyComplexIso_KernelArrow C i) (Cokernel _) (Cokernel _).
+
+  Definition CohomologyComplexIso_Mor6 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let φ1 := KernelArrow (Kernel (Diff C i)) in
+    let φ2 := CokernelArrow (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                                  (maponpaths C (hzrminusplus i 1))
+                                                  (Diff C (i - 1)))) in
+    let K4 := mk_Kernel' _ _ _ (CohomologyComplexIso_isKernel_Eq C i)
+                         (CohomologyComplexIso_isKernel C i) in
+    iso (CoImage (φ1 ;; φ2)) (Cokernel (KernelArrow K4)) :=
+    let φ1 := KernelArrow (Kernel (Diff C i)) in
+    let φ2 := CokernelArrow (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                                  (maponpaths C (hzrminusplus i 1))
+                                                  (Diff C (i - 1)))) in
+    let K4 := mk_Kernel' _ _ _ (CohomologyComplexIso_isKernel_Eq C i)
+                         (CohomologyComplexIso_isKernel C i) in
+    CohomologyComplexIso_CokerKerIso _ K4 (CoImage (φ1 ;; φ2)) (Cokernel (KernelArrow K4)).
+
+  Definition CohomologyComplexIso_Mor7 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let CK1 := CokernelOut
+                 to_Zero
+                 (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                       (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1))))
+                 _ _ (CohomologyComplexIso_eq2 C i) in
+    A⟦Kernel CK1,
+      Kernel
+        (CokernelArrow
+           (mk_Cokernel' to_Zero
+                         (KernelArrow (Kernel (Diff C i)) ;; CokernelArrow
+                                      (Cokernel
+                                         (transportf (precategory_morphisms (C (i - 1)))
+                                                     (maponpaths C (hzrminusplus i 1))
+                                                     (Diff C (i - 1))))) CK1
+                         (CohomologyComplexIso_isCokernel_Eq C i)
+                         (CohomologyComplexIso_isCokernel C i)))⟧ :=
+    @KernelInPaths_is_iso_mor
+      A to_Zero _ _ _ _ (! (CohomologyComplexIso_CokernelArrow C i)) (Kernel _) (Kernel _).
+
+  Definition CohomologyComplexIso_Mor8 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let φ1 := KernelArrow (Kernel (Diff C i)) in
+    let φ2 := CokernelArrow (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                                  (maponpaths C (hzrminusplus i 1))
+                                                  (Diff C (i - 1)))) in
+    let CK4 := mk_Cokernel' _ _ _ (CohomologyComplexIso_isCokernel_Eq C i)
+                            (CohomologyComplexIso_isCokernel C i) in
+    iso (Kernel (CokernelArrow CK4)) (Image (φ1 ;; φ2)) :=
+    let φ1 := KernelArrow (Kernel (Diff C i)) in
+    let φ2 := CokernelArrow (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                                  (maponpaths C (hzrminusplus i 1))
+                                                  (Diff C (i - 1)))) in
+    let CK4 := mk_Cokernel' _ _ _ (CohomologyComplexIso_isCokernel_Eq C i)
+                            (CohomologyComplexIso_isCokernel C i) in
+    CohomologyComplexIso_KerCokerIso CK4 _ (Kernel (CokernelArrow CK4)) (Image (φ1 ;; φ2)).
+
+  Definition CohomologyComplexIso_Mor_i (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    AbelianToAdditive A hs ⟦((CohomologyComplex' C)  : Complex (AbelianToAdditive A hs)) i,
+                            ((CohomologyComplex A hs C) : Complex (AbelianToAdditive A hs)) i⟧.
+  Proof.
+    cbn.
+    set (φ1 := KernelArrow (Kernel (Diff C i))).
+    set (φ2 := CokernelArrow (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                                   (maponpaths C (hzrminusplus i 1))
+                                                   (Diff C (i - 1))))).
+    (* The idea is to pre- and postcompose with morphisms to reach inverse of
+       [CoIm_to_Im_is_iso]. *)
+    (* Change source and target by compose and postcompose with isomorphisms *)
+    set (f1 := factorization1 hs (transportf (precategory_morphisms (C (i - 1)))
+                                             (maponpaths C (hzrminusplus i 1))
+                                             (Diff C (i - 1)))).
+    set (f2 := factorization2 hs (Diff C i)).
+    set (K1 := KernelIn to_Zero (Kernel (Diff C i)) _ _ (CohomologyComplexIso_eq1 C i)).
+    set (CK1 := CokernelOut to_Zero (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                                          (maponpaths C (hzrminusplus i 1))
+                                                          (Diff C (i - 1)))) _
+                            _ (CohomologyComplexIso_eq2 C i)).
+    use (postcompose (CohomologyComplexIso_Mor1 C i)).
+    use (postcompose (CohomologyComplexIso_Mor2 C i)).
+    use (compose (CohomologyComplexIso_Mor3 C i)).
+    use (compose (CohomologyComplexIso_Mor4 C i)).
+    (* Postcompose *)
+    set (CK2 := CokernelPath A to_Zero f1 (Cokernel _)).
+    set (CK2' := CokernelEpiComp A hs to_Zero _ _ CK2).
+    set (K3 := MonicToKernel' A hs _ CK2').
+    set (K4 := mk_Kernel' _ _ _ (CohomologyComplexIso_isKernel_Eq C i)
+                          (CohomologyComplexIso_isKernel C i)).
+    use (postcompose (CohomologyComplexIso_Mor5 C i)).
+    use (postcompose (CohomologyComplexIso_Mor6 C i)).
+    (* compose *)
+    set (K2 := KernelPath A to_Zero f2 (Kernel _)).
+    set (K2' := KernelCompMonic A hs to_Zero _ _ K2).
+    set (CK3 := EpiToCokernel' A hs _ K2').
+    set (CK4 := mk_Cokernel' _ _ _ (CohomologyComplexIso_isCokernel_Eq C i)
+                             (CohomologyComplexIso_isCokernel C i)).
+    use (compose (CohomologyComplexIso_Mor7 C i)).
+    use (compose (CohomologyComplexIso_Mor8 C i)).
+    exact (iso_inv_from_is_iso _ (CoIm_to_Im_is_iso A hs (φ1 ;; φ2))).
+  Defined.
+
+  Local Lemma CohomologyComplexIso_Mor_comm (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    (CohomologyComplexIso_Mor_i C i) ;; ZeroArrow to_Zero _ _ =
+    ZeroArrow to_Zero _ _ ;; (CohomologyComplexIso_Mor_i C (i + 1)).
+  Proof.
+    rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_right. apply idpath.
+  Qed.
+
+  Definition CohomologyComplexIso_Mor (C : Complex (AbelianToAdditive A hs)) :
+    ComplexPreCat_AbelianPreCat A hs ⟦CohomologyComplex' C, CohomologyComplex A hs C⟧.
+  Proof.
+    use mk_Morphism.
+    - intros i. exact (CohomologyComplexIso_Mor_i C i).
+    - intros i. exact (CohomologyComplexIso_Mor_comm C i).
+  Defined.
+
+  Lemma CohomologyComplexIso_is_iso_i (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    is_iso (CohomologyComplexIso_Mor_i C i).
+  Proof.
+    unfold CohomologyComplexIso_Mor. cbn.
+    unfold CohomologyComplexIso_Mor_i. cbn.
+    unfold postcompose. use is_iso_comp_of_is_isos.
+    - use is_iso_comp_of_is_isos.
+      + use is_iso_comp_of_is_isos.
+        * unfold CohomologyComplexIso_Mor3.
+          apply KernelInPaths_is_iso.
+        * use is_iso_comp_of_is_isos.
+          -- unfold CohomologyComplexIso_Mor4.
+              set (CK1 := Cokernel
+                            (transportf (precategory_morphisms (C (i - 1)))
+                                        (maponpaths C (hzrminusplus i 1))
+                                        (Diff C (i - 1)))).
+              set (K1 := Kernel
+                           (CokernelOut to_Zero CK1 (CoImage (Diff C i))
+                                        (factorization2_epi A (Diff C i))
+                                        (CohomologyComplexIso_eq2 C i))).
+              apply (KernelCompMonic1 A to_Zero
+                                      (CokernelOut to_Zero CK1 (CoImage (Diff C i))
+                                                   (factorization2_epi A (Diff C i))
+                                                   (CohomologyComplexIso_eq2 C i))
+                                      (factorization2_monic A hs (Diff C i)) (Kernel _) K1).
+          -- use is_iso_comp_of_is_isos.
+             ++ use is_iso_comp_of_is_isos.
+                ** use is_iso_comp_of_is_isos.
+                   --- unfold CohomologyComplexIso_Mor7.
+                       apply KernelInPaths_is_iso.
+                   --- use is_iso_comp_of_is_isos.
+                       +++ unfold CohomologyComplexIso_Mor8. apply pr2.
+                       +++ apply is_iso_inv_from_iso.
+                ** unfold CohomologyComplexIso_Mor6. apply pr2.
+             ++ unfold CohomologyComplexIso_Mor5. apply CokernelOutPaths_is_iso.
+      + unfold CohomologyComplexIso_Mor2.
+        set (K1 := KernelIn to_Zero (Kernel (Diff C i)) _ _ (CohomologyComplexIso_eq1 C i)).
+        apply (CokernelEpiComp2 A to_Zero
+                                (factorization1_epi
+                                   A hs (transportf (precategory_morphisms (C (i - 1)))
+                                                    (maponpaths C (hzrminusplus i 1))
+                                                    (Diff C (i - 1))))
+                                K1 (Cokernel _) (Cokernel _)).
+    - unfold CohomologyComplexIso_Mor1. apply CokernelOutPaths_is_iso.
+  Qed.
+
+  Local Lemma CohomologyComplexIso_is_iso (C : Complex (AbelianToAdditive A hs)) :
+    is_iso (CohomologyComplexIso_Mor C).
+  Proof.
+    use ComplexIsoIndexIso. intros i. exact (CohomologyComplexIso_is_iso_i C i).
+  Qed.
+
+  Definition CohomologyComplexIso (C : Complex (AbelianToAdditive A hs)) :
+    iso (CohomologyComplex' C) (CohomologyComplex A hs C).
+  Proof.
+    use isopair.
+    - exact (CohomologyComplexIso_Mor C).
+    - exact (CohomologyComplexIso_is_iso C).
+  Defined.
+
+End def_cohomology'_complex.
+
+
+(** * Definition of quasi-isomorphisms *)
+(** ** Introduction
+   A quasi-isomorphism is a morphism of complexes which maps to an isomorphisms by the cohomology
+   functor H : C(A) -> C(A). See section [def_cohomology_complex] for definition of this functor.
+
+   Quasi-isomorphisms are defined in [isQIS]. In [IdentityIsQIS] we show that identity morphism is
+   a quasi-isomorphism, and in [CompIsQIS] we show that composition of quasi-isomorphisms is a
+   quasi-isomorphism.
+*)
+Section def_quasi_isomorphisms.
+
+  Variable A : AbelianPreCat.
+  Variable hs : has_homsets A.
+
+  Definition isQIS {C1 C2 : (ComplexPreCat_AbelianPreCat A hs)}
+             (f : (ComplexPreCat_AbelianPreCat A hs)⟦C1, C2⟧) : UU :=
+    is_iso (#(CohomologyFunctor A hs) f).
+
+  Lemma isaprop_isQIS {C1 C2 : (ComplexPreCat_AbelianPreCat A hs)}
+        (f : (ComplexPreCat_AbelianPreCat A hs)⟦C1, C2⟧) : isaprop (isQIS f).
+  Proof.
+    apply isaprop_is_iso.
+  Qed.
+
+  Lemma IdentityIsQIS (C : (ComplexPreCat_AbelianPreCat A hs)) : isQIS (identity C).
+  Proof.
+    exact (pr2 (functor_on_iso (CohomologyFunctor A hs) (identity_iso C))).
+  Qed.
+
+  Lemma CompIsQIS {C1 C2 C3 : (ComplexPreCat_AbelianPreCat A hs)}
+        (f1 : (ComplexPreCat_AbelianPreCat A hs)⟦C1, C2⟧) (H1 : isQIS f1)
+        (f2 : (ComplexPreCat_AbelianPreCat A hs)⟦C2, C3⟧) (H2 : isQIS f2) :
+    isQIS (f1 ;; f2).
+  Proof.
+    unfold isQIS. rewrite functor_comp.
+    apply (@is_iso_comp_of_isos (ComplexPreCat_AbelianPreCat A hs) _ _ _
+                                (isopair _ H1) (isopair _ H2)).
+  Qed.
+
+End def_quasi_isomorphisms.
+
+
+(** * Cohomology functor is an additive functor *)
+(** ** Introduction
+   In this section we show that the cohomology functor, [CohomologyFunctor], is an additive functor.
+   This is shown in [CohomologyFunctor_Additive]. *)
+Section def_cohomology_functor_additive.
+
+  Variable A : AbelianPreCat.
+  Variable hs : has_homsets A.
+
+  Local Lemma CohomologyFunctor_isAdditive : isAdditiveFunctor (CohomologyFunctor A hs).
+  Proof.
+    use mk_isAdditiveFunctor.
+    intros C1 C2.
+    use tpair.
+    - intros f1 f2.
+      use MorphismEq.
+      intros i. cbn in *. unfold CohomologyMorphism_Mor.
+      set (CK1 := Cokernel
+                    (KernelIn to_Zero (Kernel (Diff C1 i)) (C1 (i - 1))
+                              (transportf (precategory_morphisms (C1 (i - 1)))
+                                          (maponpaths C1 (hzrminusplus i 1)) (Diff C1 (i - 1)))
+                              (CohomologyComplex_KernelIn_eq A hs C1 i))).
+      cbn in CK1. fold CK1.
+      set (CK2 := Cokernel
+                    (KernelIn to_Zero (Kernel (Diff C2 i)) (C2 (i - 1))
+                              (transportf (precategory_morphisms (C2 (i - 1)))
+                                          (maponpaths C2 (hzrminusplus i 1)) (Diff C2 (i - 1)))
+                              (CohomologyComplex_KernelIn_eq A hs C2 i))).
+      cbn in CK2. fold CK2.
+      set (tmp := CokernelOutOp (AbelianToAdditive A hs)).
+      cbn in tmp. rewrite <- tmp. clear tmp.
+      use CokernelOutsEq. rewrite CokernelCommutes. rewrite CokernelCommutes.
+      set (tmp := @to_postmor_linear' (AbelianToAdditive A hs)). cbn in tmp.
+      rewrite <- tmp. clear tmp. apply cancel_postcomposition.
+      set (tmp := KernelInOp (AbelianToAdditive A hs)).
+      cbn in tmp. rewrite <- tmp. clear tmp.
+      use KernelInsEq. rewrite KernelCommutes. rewrite KernelCommutes.
+      set (tmp := @to_premor_linear' (AbelianToAdditive A hs)). cbn in tmp.
+      rewrite <- tmp. clear tmp. apply idpath.
+    - cbn.
+      use MorphismEq.
+      intros i. cbn in *. unfold CohomologyMorphism_Mor.
+      set (CK1 := Cokernel
+                    (KernelIn to_Zero (Kernel (Diff C1 i)) (C1 (i - 1))
+                              (transportf (precategory_morphisms (C1 (i - 1)))
+                                          (maponpaths C1 (hzrminusplus i 1)) (Diff C1 (i - 1)))
+                              (CohomologyComplex_KernelIn_eq A hs C1 i))).
+      cbn in CK1. fold CK1.
+      set (CK2 := Cokernel
+                    (KernelIn to_Zero (Kernel (Diff C2 i)) (C2 (i - 1))
+                              (transportf (precategory_morphisms (C2 (i - 1)))
+                                          (maponpaths C2 (hzrminusplus i 1)) (Diff C2 (i - 1)))
+                              (CohomologyComplex_KernelIn_eq A hs C2 i))).
+      cbn in CK2. fold CK2.
+      use CokernelOutsEq.
+      rewrite CokernelCommutes. rewrite ZeroArrow_comp_right.
+      rewrite <- (ZeroArrow_comp_left _ _ _ _ _ (CokernelArrow CK2)).
+      apply cancel_postcomposition.
+      use KernelInsEq.
+      rewrite KernelCommutes.
+      rewrite ZeroArrow_comp_left. cbn. rewrite ZeroArrow_comp_right. apply idpath.
+  Qed.
+
+  Definition CohomologyFunctor_Additive :
+    AdditiveFunctor (ComplexPreCat_Additive (AbelianToAdditive A hs))
+                    (ComplexPreCat_Additive (AbelianToAdditive A hs)).
+  Proof.
+    use mk_AdditiveFunctor.
+    - exact (CohomologyFunctor A hs).
+    - exact CohomologyFunctor_isAdditive.
+  Defined.
+
+End def_cohomology_functor_additive.
+
+
+
+(** * We show that CohomologyFunctor factors though naive homotopy category *)
+(** ** Introduction
+   We show that there exists a functor K(A) -> K(A) such that the following diagram is commutative
+                           C(A) -> C(A)
+                             |       |
+                           K(A) -> K(A)
+   Here C(A) -> C(A) is the cohomology functor H : C(A) -> C(A), [CohomologyFunctor], see section
+   [def_cohomology_complex]. The vertical functor C(A) -> K(A) are the canonical functors
+   [ComplexHomotFunctor]. The constructed functor K(A) -> K(A) is also additive. Using this
+   functor we define quasi-isomorphisms for K(A).
+
+   On objects this functor sends a complex X to its cohomology complex. This is easily verified to
+   commute because the vertical functors are identity on objects. To construct the map on morphisms
+   we  first show that two homotopic, [ComplexHomotSubset], morphisms in C(A) are mapped to the
+   same morphism by the cohomology functor for C(A). Thus, given a morphism f in K(A), for every
+   morphism f' which maps to f by C(A) -> K(A) the image under C(A) -> C(A) -> K(A) is the same,
+   that is, is contractible. This is the observation we use to define the map on morphisms. After
+   this observation it is easy to see that the diagram is commutative.
+
+   In [CohomologyFunctorHomotopy] it is shown that a morphism induced by homotopy is sent to the
+   zero morphism in C(A). In [CohomologyFunctorHomotopies] we use this observation to prove that
+   two homotopic morphisms are sent to the same morphisms by the cohomology functor. In
+   [CohomologyFunctorH_Mor] we show that the image on morphisms is contractible, in
+   [CohomologyFunctorH_functor_data] we construct the functor data for K(A) -> K(A), and finally
+   in [CohomologyFunctorH] we construct the functor. Commutativity of the diagram is proved in
+   [CohomologyFunctorHCommutes]. The fact that K(A) -> K(A) is additive is proved in
+   [CohomologyFunctorH_Additive].
+*)
+Section def_cohomology_homotopy.
+
+  Variable A : AbelianPreCat.
+  Variable hs : has_homsets A.
+
+
+  (** ** Homotopic maps are mapped to equal morphisms by the cohomology functor C(A) -> C(A) *)
+
+  Lemma CohomologyFunctorHomotopy_eq1 {C1 C2 : Complex (AbelianToAdditive A hs)}
+        (H : ComplexHomot _ C1 C2) (i : hz) :
+    KernelArrow (Kernel (Diff C1 i)) ;; transportf (precategory_morphisms (C1 i))
+                (maponpaths C2 (hzrminusplus i 1)) (H i ;; Diff C2 (i - 1)) ;;
+                Diff C2 i = ZeroArrow to_Zero (Kernel (Diff C1 i)) (C2 (i + 1)).
+  Proof.
+    induction (hzrminusplus i 1). cbn. unfold idfun. rewrite <- assoc. rewrite <- assoc.
+    set (tmp := CEq _ C2 (i - 1)). cbn in tmp. rewrite tmp. clear tmp.
+    rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_right. apply idpath.
+  Qed.
+
+  (** Homotopy is mapped to ZeroArrow *)
+  Lemma CohomologyFunctorHomotopy {C1 C2 : Complex (AbelianToAdditive A hs)}
+        (H : ComplexHomot _ C1 C2) :
+    CohomologyMorphism A hs (ComplexHomotMorphism (AbelianToAdditive A hs) H) =
+    MorphismZero (AbelianToAdditive A hs) (CohomologyComplex A hs C1) (CohomologyComplex A hs C2).
+  Proof.
+    use MorphismEq. intros i. cbn. unfold CohomologyMorphism_Mor.
+    use CokernelOutsEq. rewrite CokernelCommutes.
+    rewrite ZeroArrow_comp_right.
+    set (tmp := @KernelIn _ to_Zero _ _ _ (Kernel (Diff C2 i)) (Kernel (Diff C1 i))
+                          (KernelArrow (Kernel (Diff C1 i)) ;;
+                                       (transportf (precategory_morphisms (C1 i))
+                                                   (maponpaths C2 (hzrminusplus i 1))
+                                                   (H i ;; Diff C2 (i - 1))))
+                          (CohomologyFunctorHomotopy_eq1 H i)).
+    assert (e0 : KernelIn to_Zero (Kernel (Diff C2 i)) (Kernel (Diff C1 i))
+    (KernelArrow (Kernel (Diff C1 i)) ;; Abelian_op A hs (C1 i) (C2 i)
+                                           (transportf (precategory_morphisms (C1 i))
+                                                       (maponpaths C2 (hzrminusplus i 1))
+                                                       (H i ;; Diff C2 (i - 1)))
+                                           (transportf (precategory_morphisms (C1 i))
+                                                       (maponpaths C2 (hzrplusminus i 1))
+                                                       (Diff C1 i ;; H (i + 1))))
+    (CohomologyMorphism_KernelIn_comm A hs (ComplexHomotMorphism (AbelianToAdditive A hs) H) i) =
+                 tmp).
+    {
+      unfold tmp. clear tmp. use KernelInsEq. rewrite KernelCommutes. rewrite KernelCommutes.
+      set (tmp := @to_premor_linear' (AbelianToAdditive A hs)). cbn in tmp. rewrite tmp. clear tmp.
+      rewrite transportf_postcompose. rewrite transportf_postcompose. rewrite assoc. rewrite assoc.
+      rewrite KernelCompZero. rewrite ZeroArrow_comp_left. rewrite <- PreAdditive_unel_zero.
+      set (tmp :=  @to_runax' (AbelianToAdditive A hs)). cbn in tmp. rewrite tmp. clear tmp.
+      apply idpath.
+    }
+    cbn. cbn in e0. rewrite e0. clear e0. unfold tmp. clear tmp.
+    assert (e1 : KernelIn to_Zero (Kernel (Diff C2 i)) (Kernel (Diff C1 i))
+                          ((KernelArrow (Kernel (Diff C1 i)))
+                             ;; (transportf (precategory_morphisms (C1 i))
+                                            (maponpaths C2 (hzrminusplus i 1))
+                                            (H i ;; Diff C2 (i - 1))))
+                          (CohomologyFunctorHomotopy_eq1 H i) =
+                 (KernelArrow (Kernel (Diff C1 i)))
+                   ;; (H i)
+                   ;; (KernelIn (to_Zero) (Abelian.Kernel (Diff C2 i)) _ _
+                                (CohomologyComplex_KernelIn_eq A hs C2 i))).
+    {
+      use KernelInsEq. rewrite KernelCommutes. rewrite <- assoc. rewrite <- assoc.
+      apply cancel_precomposition. rewrite KernelCommutes.
+      rewrite transportf_postcompose. apply idpath.
+    }
+    cbn. cbn in e1. rewrite e1. clear e1. rewrite <- assoc. rewrite CokernelCompZero.
+    rewrite ZeroArrow_comp_right. apply idpath.
+  Qed.
+
+  Lemma CohomologyFunctorHomotopies {C1 C2 : Complex (AbelianToAdditive A hs)}
+        (f g : (ComplexPreCat_Additive (AbelianToAdditive A hs))⟦C1, C2⟧)
+        (H : subgrhrel (ComplexHomotSubgrp (AbelianToAdditive A hs) C1 C2) f g) :
+    # (CohomologyFunctor_Additive A hs) f = # (CohomologyFunctor_Additive A hs) g.
+  Proof.
+    set (inv := @to_inv (ComplexPreCat_Additive (AbelianToAdditive A hs)) _ _
+                        (# (CohomologyFunctor_Additive A hs) g)).
+    set (tmp := @grrcan (@to_abgrop (ComplexPreCat_Additive (AbelianToAdditive A hs)) _ _)
+                        (# (CohomologyFunctor_Additive A hs) f)
+                        (# (CohomologyFunctor_Additive A hs) g) inv).
+    apply tmp. clear tmp. unfold inv. clear inv.
+    set (tmp := @rinvax (ComplexPreCat_Additive (AbelianToAdditive A hs)) _ _
+                        (# (CohomologyFunctor_Additive A hs) g)).
+    use (pathscomp0 _ (! tmp)). clear tmp.
+    rewrite <- AdditiveFunctorInv.
+    set (tmp := AdditiveFunctorLinear (CohomologyFunctor_Additive A hs) f (to_inv _ _ g)).
+    apply pathsinv0 in tmp. use (pathscomp0 tmp). clear tmp.
+    use (squash_to_prop H). apply has_homsets_ComplexPreCat_AbelianPreCat.
+    intros H'. induction H' as [H1 H2]. induction H1 as [H11 H12]. cbn in H11. cbn in H2.
+    cbn. rewrite <- H2. clear H.
+    use (squash_to_prop H12). apply has_homsets_ComplexPreCat_AbelianPreCat.
+    intros G. induction G as [G1 G2]. rewrite <- G2. clear H11 H12 H2 G2.
+    apply CohomologyFunctorHomotopy.
+  Qed.
+
+
+  (** ** Structure for the image of a morphism to make type cheking faster *)
+
+  Definition CohomologyFunctorHIm {C1 C2 : ComplexHomot_Additive (AbelianToAdditive A hs)}
+             (f : ComplexHomot_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧) : UU :=
+    Σ (h : ComplexHomot_Additive (AbelianToAdditive A hs) ⟦CohomologyComplex A hs C1,
+                                                           CohomologyComplex A hs C2⟧),
+    Π (f' : ComplexPreCat_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧)
+      (H : # (ComplexHomotFunctor (AbelianToAdditive A hs)) f' = f),
+    h = # (ComplexHomotFunctor (AbelianToAdditive A hs)) (# (CohomologyFunctor A hs) f').
+
+  Definition CohomologyFunctorHImMor {C1 C2 : ComplexHomot_Additive (AbelianToAdditive A hs)}
+             {f : ComplexHomot_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧}
+             (h : CohomologyFunctorHIm f) :
+    ComplexHomot_Additive (AbelianToAdditive A hs) ⟦CohomologyComplex A hs C1,
+                                                    CohomologyComplex A hs C2⟧ := pr1 h.
+
+  Definition CohomologyFunctorHImEq {C1 C2 : ComplexHomot_Additive (AbelianToAdditive A hs)}
+             {f : ComplexHomot_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧}
+             (h : CohomologyFunctorHIm f)
+             (f' : ComplexPreCat_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧)
+             (H : # (ComplexHomotFunctor (AbelianToAdditive A hs)) f' = f) :
+    (CohomologyFunctorHImMor h) =
+    # (ComplexHomotFunctor (AbelianToAdditive A hs)) (# (CohomologyFunctor A hs) f') := pr2 h f' H.
+
+  Definition mk_CohomologyFunctorHIm {C1 C2 : ComplexHomot_Additive (AbelianToAdditive A hs)}
+             (f : ComplexHomot_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧)
+             (h : ComplexHomot_Additive (AbelianToAdditive A hs) ⟦CohomologyComplex A hs C1,
+                                                                  CohomologyComplex A hs C2⟧)
+             (HH : Π (f' : ComplexPreCat_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧)
+                     (H : # (ComplexHomotFunctor (AbelianToAdditive A hs)) f' = f),
+                   h = # (ComplexHomotFunctor (AbelianToAdditive A hs))
+                         (# (CohomologyFunctor A hs) f')) : CohomologyFunctorHIm f :=
+    tpair _ h HH.
+
+  Lemma CohomologyFunctorHImEquality {C1 C2 : ComplexHomot_Additive (AbelianToAdditive A hs)}
+             {f : ComplexHomot_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧}
+             (h : CohomologyFunctorHIm f) (h' : CohomologyFunctorHIm f)
+             (e : CohomologyFunctorHImMor h = CohomologyFunctorHImMor h') : h = h'.
+  Proof.
+    use total2_paths.
+    - exact e.
+    - apply proofirrelevance. apply impred_isaprop. intros t0.
+      apply impred_isaprop. intros H0. apply has_homsets_ComplexHomot_Additive.
+  Qed.
+
+  (** ** Construction of the functor and commutativity  *)
+
+  Lemma CohomologyFunctorH_Mor_eq {C1 C2 : ComplexHomot_Additive (AbelianToAdditive A hs)}
+        (f : ComplexHomot_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧)
+        (H : hfiber # (ComplexHomotFunctor (AbelianToAdditive A hs)) f)
+        (f' : ComplexPreCat_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧)
+        (H' : # (ComplexHomotFunctor (AbelianToAdditive A hs)) f' = f) :
+    # (ComplexHomotFunctor (AbelianToAdditive A hs)) (# (CohomologyFunctor A hs) (pr1 H)) =
+    # (ComplexHomotFunctor (AbelianToAdditive A hs)) (# (CohomologyFunctor A hs) f').
+  Proof.
+    apply maponpaths.
+    use CohomologyFunctorHomotopies.
+    use (@abgrquotpr_rel_paths _ (binopeqrel_subgr_eqrel
+                                    (ComplexHomotSubgrp (AbelianToAdditive A hs) C1 C2))).
+    use (pathscomp0 (hfiberpr2 _ _ H)). apply pathsinv0. exact H'.
+  Qed.
+
+  Definition CohomologyFunctorH_Mor {C1 C2 : ComplexHomot_Additive (AbelianToAdditive A hs)}
+             (f : ComplexHomot_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧) :
+    iscontr (CohomologyFunctorHIm f).
+  Proof.
+    use (squash_to_prop (ComplexHomotFunctor_issurj (AbelianToAdditive A hs) f)).
+    apply isapropiscontr. intros H.
+    use iscontrpair.
+    - use mk_CohomologyFunctorHIm.
+      + exact (# ((ComplexHomotFunctor (AbelianToAdditive A hs)))
+                 (# (CohomologyFunctor A hs) (hfiberpr1 _ _ H))).
+      + intros f' H'. exact (CohomologyFunctorH_Mor_eq f H f' H').
+    - intros t. use CohomologyFunctorHImEquality.
+      use CohomologyFunctorHImEq.
+      exact (hfiberpr2 _ _ H).
+  Qed.
+
+  Lemma CohomologyFunctorH_Mor_Id (C : ComplexHomot_Additive (AbelianToAdditive A hs)) :
+    CohomologyFunctorHImMor (iscontrpr1 (CohomologyFunctorH_Mor (identity C))) = identity _.
+  Proof.
+    use (pathscomp0 (CohomologyFunctorHImEq
+                       (iscontrpr1 (CohomologyFunctorH_Mor (identity C)))
+                       (identity _)
+                       (functor_id (ComplexHomotFunctor (AbelianToAdditive A hs)) _))).
+    rewrite functor_id. rewrite functor_id. apply idpath.
+  Qed.
+
+  Lemma CohomologyFunctorH_Mor_Comp {C1 C2 C3 : ComplexHomot_Additive (AbelianToAdditive A hs)}
+             (f : ComplexHomot_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧)
+             (g : ComplexHomot_Additive (AbelianToAdditive A hs) ⟦C2, C3⟧) :
+    (CohomologyFunctorHImMor (iscontrpr1 (CohomologyFunctorH_Mor (f ;; g)))) =
+    (CohomologyFunctorHImMor (iscontrpr1 (CohomologyFunctorH_Mor f)))
+      ;; (CohomologyFunctorHImMor (iscontrpr1 (CohomologyFunctorH_Mor g))) .
+  Proof.
+    use (squash_to_prop (ComplexHomotFunctor_issurj (AbelianToAdditive A hs) f)).
+    apply has_homsets_ComplexHomot_Additive. intros f'.
+    use (squash_to_prop (ComplexHomotFunctor_issurj (AbelianToAdditive A hs) g)).
+    apply has_homsets_ComplexHomot_Additive. intros g'.
+    rewrite (CohomologyFunctorHImEq (iscontrpr1 (CohomologyFunctorH_Mor f)) _ (hfiberpr2 _ _ f')).
+    rewrite (CohomologyFunctorHImEq (iscontrpr1 (CohomologyFunctorH_Mor g)) _ (hfiberpr2 _ _ g')).
+    set (tmp := functor_comp (ComplexHomotFunctor (AbelianToAdditive A hs)) _ _ _
+                             (# (CohomologyFunctor A hs) (hfiberpr1 _ _ f'))
+                             (# (CohomologyFunctor A hs) (hfiberpr1 _ _ g'))).
+    use (pathscomp0 _ tmp). clear tmp.
+    set (tmp := functor_comp (CohomologyFunctor A hs) _ _ _ (hfiberpr1 _ _ f') (hfiberpr1 _ _ g')).
+    apply (maponpaths (# (ComplexHomotFunctor (AbelianToAdditive A hs)))) in tmp.
+    use (pathscomp0 _ tmp). clear tmp.
+    use (CohomologyFunctorHImEq (iscontrpr1 (CohomologyFunctorH_Mor (f ;; g)))).
+    rewrite functor_comp. rewrite (hfiberpr2 _ _ f'). rewrite (hfiberpr2 _ _ g'). apply idpath.
+  Qed.
+
+  Definition CohomologyFunctorH_functor_data :
+    functor_data (ComplexHomot_Additive (AbelianToAdditive A hs))
+                 (ComplexHomot_Additive (AbelianToAdditive A hs)).
+  Proof.
+    use tpair.
+    - intros C. exact (CohomologyComplex A hs C).
+    - intros C1 C2 f. exact (CohomologyFunctorHImMor (iscontrpr1 (CohomologyFunctorH_Mor f))).
+  Defined.
+
+  Local Lemma CohomologyFunctorH_isfunctor : is_functor CohomologyFunctorH_functor_data.
+  Proof.
+    split.
+    - intros C. use CohomologyFunctorH_Mor_Id.
+    - intros C1 C2 C3 f1 f2. use (CohomologyFunctorH_Mor_Comp f1 f2).
+  Qed.
+
+  Definition CohomologyFunctorH :
+    functor (ComplexHomot_Additive (AbelianToAdditive A hs))
+            (ComplexHomot_Additive (AbelianToAdditive A hs)).
+  Proof.
+    use tpair.
+    - exact CohomologyFunctorH_functor_data.
+    - exact CohomologyFunctorH_isfunctor.
+  Defined.
+
+  Lemma CohomologyFunctorHCommutes :
+    functor_composite (ComplexHomotFunctor (AbelianToAdditive A hs)) CohomologyFunctorH =
+    functor_composite (CohomologyFunctor A hs) (ComplexHomotFunctor (AbelianToAdditive A hs)).
+  Proof.
+    use total2_paths.
+    - use total2_paths.
+      + apply idpath.
+      + rewrite idpath_transportf.
+        use funextsec. intros C1.
+        use funextsec. intros C2.
+        use funextsec. intros f.
+        use (CohomologyFunctorHImEq
+               (iscontrpr1
+                  (CohomologyFunctorH_Mor
+                     (# (ComplexHomotFunctor (AbelianToAdditive A hs)) f))) f
+               (idpath _)).
+    - apply proofirrelevance. apply isaprop_is_functor.
+      use has_homsets_ComplexHomot_Additive.
+  Qed.
+
+
+  (** ** Additivity of CohomologyFunctorH *)
+
+  Local Opaque to_binop.
+  Local Lemma CohomologyFunctorH_Additive_zero
+        (C1 C2 : (ComplexHomot_Additive (AbelianToAdditive A hs))) :
+    # CohomologyFunctorH
+      (ZeroArrow (Additive.to_Zero (ComplexHomot_Additive (AbelianToAdditive A hs))) C1 C2) =
+    ZeroArrow (Additive.to_Zero (ComplexHomot_Additive (AbelianToAdditive A hs)))
+              (CohomologyFunctorH C1) (CohomologyFunctorH C2).
+  Proof.
+    assert (e0 : # (ComplexHomotFunctor (AbelianToAdditive A hs))
+                   (ZeroArrow (Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)))
+                              _ _) =
+                 ZeroArrow (Additive.to_Zero (ComplexHomot_Additive (AbelianToAdditive A hs)))
+                           (CohomologyFunctorH C1) (CohomologyFunctorH C2)).
+    {
+      apply AdditiveFunctorZeroArrow.
+    }
+    rewrite <- e0. clear e0.
+    assert (e1 : # (ComplexHomotFunctor (AbelianToAdditive A hs))
+                   (ZeroArrow (Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)))
+                              (CohomologyFunctorH C1) (CohomologyFunctorH C2)) =
+                 # (ComplexHomotFunctor (AbelianToAdditive A hs))
+                   (# (CohomologyFunctor A hs) (ZeroArrow to_Zero _ _))).
+    {
+      apply maponpaths. apply pathsinv0.
+      apply (@AdditiveFunctorZeroArrow
+               (ComplexPreCat_Additive (AbelianToAdditive A hs))
+               (ComplexPreCat_Additive (AbelianToAdditive A hs))
+               (CohomologyFunctor_Additive A hs)).
+    }
+    rewrite e1. clear e1.
+    use CohomologyFunctorHImEq.
+    apply AdditiveFunctorZeroArrow.
+  Qed.
+
+  Local Lemma CohomologyFunctorH_Additive_linear
+        {C1 C2 : (ComplexHomot_Additive (AbelianToAdditive A hs))}
+        (f g : (ComplexHomot_Additive (AbelianToAdditive A hs))⟦C1, C2⟧) :
+    # CohomologyFunctorH (to_binop C1 C2 f g) =
+    to_binop (CohomologyFunctorH C1) (CohomologyFunctorH C2)
+             (# CohomologyFunctorH f) (# CohomologyFunctorH g).
+  Proof.
+    use (squash_to_prop (ComplexHomotFunctor_issurj (AbelianToAdditive A hs) f)).
+    apply has_homsets_ComplexHomot_Additive. intros f'.
+    use (squash_to_prop (ComplexHomotFunctor_issurj (AbelianToAdditive A hs) g)).
+    apply has_homsets_ComplexHomot_Additive. intros g'.
+    cbn.
+    rewrite (CohomologyFunctorHImEq (iscontrpr1 (CohomologyFunctorH_Mor f))
+                                    (hfiberpr1 _ _ f') (hfiberpr2 _ _ f')).
+    rewrite (CohomologyFunctorHImEq (iscontrpr1 (CohomologyFunctorH_Mor g))
+                                    (hfiberpr1 _ _ g') (hfiberpr2 _ _ g')).
+    set (tmp := @AdditiveFunctorLinear
+                  (ComplexPreCat_Additive (AbelianToAdditive A hs))
+                  (ComplexHomot_Additive (AbelianToAdditive A hs))
+                  (ComplexHomotFunctor (AbelianToAdditive A hs))
+                  (CohomologyComplex A hs C1) (CohomologyComplex A hs C2)
+                  (# (CohomologyFunctor A hs)
+                     (hfiberpr1 # (ComplexHomotFunctor (AbelianToAdditive A hs)) f f'))
+                  (# (CohomologyFunctor A hs)
+                     (hfiberpr1 # (ComplexHomotFunctor (AbelianToAdditive A hs)) g g'))).
+    use (pathscomp0 _ tmp). clear tmp.
+    set (tmp := @AdditiveFunctorLinear
+                  (ComplexPreCat_Additive (AbelianToAdditive A hs))
+                  (ComplexPreCat_Additive (AbelianToAdditive A hs))
+                  (CohomologyFunctor_Additive A hs) C1 C2
+                  (hfiberpr1 # (ComplexHomotFunctor (AbelianToAdditive A hs)) f f')
+                  (hfiberpr1 # (ComplexHomotFunctor (AbelianToAdditive A hs)) g g')).
+    apply (maponpaths # (ComplexHomotFunctor (AbelianToAdditive A hs))) in tmp.
+    use (pathscomp0 _ tmp). clear tmp.
+    use (CohomologyFunctorHImEq (iscontrpr1 (CohomologyFunctorH_Mor (to_binop C1 C2 f g)))).
+    rewrite AdditiveFunctorLinear.
+    rewrite (hfiberpr2 _ _ f'). rewrite (hfiberpr2 _ _ g'). apply idpath.
+  Qed.
+
+  Local Lemma CohomologyFunctorH_isAdditive : isAdditiveFunctor CohomologyFunctorH.
+  Proof.
+    refine (@mk_isAdditiveFunctor' (ComplexHomot_Additive (AbelianToAdditive A hs))
+                                   (ComplexHomot_Additive (AbelianToAdditive A hs))
+                                   CohomologyFunctorH _ _).
+    - intros C1 C2. exact (CohomologyFunctorH_Additive_zero C1 C2).
+    - intros C1 C2 f g. exact (CohomologyFunctorH_Additive_linear f g).
+  Qed.
+
+  Definition CohomologyFunctorH_Additive :
+    AdditiveFunctor (ComplexHomot_Additive (AbelianToAdditive A hs))
+                    (ComplexHomot_Additive (AbelianToAdditive A hs)).
+  Proof.
+    use mk_AdditiveFunctor.
+    - exact CohomologyFunctorH.
+    - exact CohomologyFunctorH_isAdditive.
+  Defined.
+  Local Transparent to_binop.
+
+
+  (** ** Quasi-isomorphisms in K(A) *)
+
+  Definition isHQIS {C1 C2 : (ComplexHomot_Additive (AbelianToAdditive A hs))}
+             (f : (ComplexHomot_Additive (AbelianToAdditive A hs))⟦C1, C2⟧) : UU :=
+    is_iso (# CohomologyFunctorH_Additive f).
+
+  Lemma isaprop_isHQIS {C1 C2 : (ComplexHomot_Additive (AbelianToAdditive A hs))}
+             (f : (ComplexHomot_Additive (AbelianToAdditive A hs))⟦C1, C2⟧) : isaprop (isHQIS f).
+  Proof.
+    apply isaprop_is_iso.
+  Qed.
+
+  Lemma IdentityIsHQIS (C : (ComplexHomot_Additive (AbelianToAdditive A hs))) : isHQIS (identity C).
+  Proof.
+    exact (pr2 (functor_on_iso CohomologyFunctorH (identity_iso C))).
+  Qed.
+
+  Lemma CompIsHQIS {C1 C2 C3 : (ComplexHomot_Additive (AbelianToAdditive A hs))}
+        (f1 : (ComplexHomot_Additive (AbelianToAdditive A hs))⟦C1, C2⟧) (H1 : isHQIS f1)
+        (f2 : (ComplexHomot_Additive (AbelianToAdditive A hs))⟦C2, C3⟧) (H2 : isHQIS f2) :
+    isHQIS (f1 ;; f2).
+  Proof.
+    unfold isHQIS. rewrite functor_comp.
+    apply (@is_iso_comp_of_isos (ComplexHomot_Additive (AbelianToAdditive A hs)) _ _ _
+                                (isopair _ H1) (isopair _ H2)).
+  Qed.
+
+End def_cohomology_homotopy.
+
+
+(** * Complex of kernels and complex of cokernels
+   Let X be a complex. We construct a complex of kernels, which has objects ker d^{i+1}, and a
+   complex of cokernels, which has objects coker d^{i-1}. The differentials of these complexes are
+   the induced morphisms obtained by KernelIn and CokernelOut. For all integers i, we construct a
+   morphisms h^i : coker d^{i-1} -> ker d^{i+1}, which is unique up to 2 commutative triangles.
+   We show that the ith cohomology of X is isomorphic to the kernel of h^i and that the (i+1)th
+   cohomology of X is isomorphic to cokernel of h^i. These results will be used, together with the
+   snake lemma, to construct the long exact sequence associated to a short exact sequence of
+   complexes.
+
+   The complex of kernels is constructed in [KernelComplex]. The complex of cokernels is
+   constructed in [CokernelComplex]. The morphism h^i is constructed in [CokernelKernelMorphism],
+   where it is also shown to be unique with respect to the 2 commutative triangles. An isomorphism
+   of ith cohomology of X with the kernel of h^i is constructed in [CokernelKernelCohomology1]. An
+   isomorphism of the (i+1)th cohomology of X with cokernel of h^i is constructed in
+   [CokernelKernelCohomology2].
+ *)
+Section def_kernel_cokernel_complex.
+
+  Variable A : AbelianPreCat.
+  Variable hs : has_homsets A.
+
+  (** ** Construction of kernel and cokernel complexes *)
+  (** *** Complex of kernels *)
+
+  Local Lemma KernelComplex_Kernel_comm (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    KernelArrow (Kernel (Diff C i)) ;; Diff C i ;; Diff C (i + 1) =
+    ZeroArrow to_Zero (Kernel (Diff C i)) (C (i + 1 + 1)).
+  Proof.
+    rewrite <- assoc.
+    rewrite <- (ZeroArrow_comp_right _ _ _ _ _ (KernelArrow (Kernel (Diff C i)))).
+    apply cancel_precomposition.
+    exact (CEq (AbelianToAdditive A hs) C i).
+  Qed.
+
+  Local Lemma KernelComplex_comm (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    (KernelIn to_Zero (Kernel (Diff C (i + 1))) (Kernel (Diff C i))
+              (KernelArrow (Kernel (Diff C i)) ;; Diff C i)
+              (KernelComplex_Kernel_comm C i))
+      ;; (KernelIn to_Zero (Kernel (Diff C (i + 1 + 1))) (Kernel (Diff C (i + 1)))
+                   (KernelArrow (Kernel (Diff C (i + 1))) ;; Diff C (i + 1))
+                   (KernelComplex_Kernel_comm C (i + 1))) =
+    ZeroArrow to_Zero (Kernel (Diff C i)) (Kernel (Diff C (i + 1 + 1))).
+  Proof.
+    use KernelInsEq.
+    rewrite <- assoc. rewrite KernelCommutes. rewrite assoc. rewrite KernelCommutes.
+    rewrite ZeroArrow_comp_left. exact (KernelComplex_Kernel_comm C i).
+  Qed.
+
+  Definition KernelComplex (C : Complex (AbelianToAdditive A hs)) :
+    Complex (AbelianToAdditive A hs).
+  Proof.
+    use mk_Complex.
+    - intros i. exact (Kernel (Diff C (i + 1))).
+    - intros i. cbn.
+      use KernelIn.
+      + use compose.
+        * exact (C (i + 1)).
+        * use KernelArrow.
+        * exact (Diff C (i + 1)).
+      + exact (KernelComplex_Kernel_comm C (i + 1)).
+    - intros i. cbn. exact (KernelComplex_comm C (i + 1)).
+  Defined.
+
+
+  (** *** Complex of cokernels *)
+
+  Local Lemma CokernelComplex_Cokernel_comm (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    (Diff C (i - 1))
+      ;; (transportb (λ x' : A, A ⟦ x', C (i + 1 - 1 + 1) ⟧)
+                     (maponpaths C (hzrminusplus i 1 @ hzrplusminus' i 1)) (Diff C (i + 1 - 1)) ;;
+                     CokernelArrow (Cokernel (Diff C (i + 1 - 1)))) =
+    ZeroArrow to_Zero (C (i - 1)) (Cokernel (Diff C (i + 1 - 1))).
+  Proof.
+    induction (hzrminusplus i 1 @ hzrplusminus' i 1). cbn. unfold idfun.
+    rewrite assoc. set (tmp := CEq (AbelianToAdditive A hs) C (i - 1)). cbn in tmp.
+    rewrite tmp. clear tmp. apply ZeroArrow_comp_left.
+  Qed.
+
+  Local Lemma CokernelComplex_comm (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (Cokernel (Diff C (i + 1 - 1)))
+                (transportb (λ x' : A, A ⟦ x', C (i + 1 - 1 + 1) ⟧)
+                            (maponpaths C (hzrminusplus i 1 @ hzrplusminus' i 1))
+                            (Diff C (i + 1 - 1)) ;; CokernelArrow (Cokernel (Diff C (i + 1 - 1))))
+                (CokernelComplex_Cokernel_comm C i)
+                ;; CokernelOut to_Zero (Cokernel (Diff C (i + 1 - 1)))
+                (Cokernel (Diff C (i + 1 + 1 - 1)))
+                (transportb (λ x' : A, A ⟦ x', C (i + 1 + 1 - 1 + 1) ⟧)
+                            (maponpaths C
+                                        (hzrminusplus (i + 1) 1 @ hzrplusminus' (i + 1) 1))
+                            (Diff C (i + 1 + 1 - 1)) ;; CokernelArrow
+                            (Cokernel
+                               (Diff C (i + 1 + 1 - 1))))
+                (CokernelComplex_Cokernel_comm C (i + 1)) =
+    ZeroArrow to_Zero (Cokernel (Diff C (i - 1))) (Cokernel (Diff C (i + 1 + 1 - 1))).
+  Proof.
+    use (CokernelArrowisEpi to_Zero (Cokernel (Diff C (i - 1)))).
+    rewrite ZeroArrow_comp_right. rewrite assoc. rewrite CokernelCommutes.
+    rewrite <- assoc. rewrite CokernelCommutes. rewrite assoc.
+    rewrite <- (ZeroArrow_comp_left _ _ _ _ _ (CokernelArrow (Cokernel (Diff C (i + 1 + 1 - 1))))).
+    apply cancel_postcomposition.
+    use (transportb_path _ _ (maponpaths C (hzrplusminus i 1 @ hzrminusplus' i 1))).
+    rewrite <- transportb_precompose.
+    rewrite <- functtransportb. rewrite <- functtransportb.
+    rewrite transport_b_b.
+    assert (e0 : ((hzrplusminus i 1 @ hzrminusplus' i 1) @ hzrminusplus i 1 @ hzrplusminus' i 1) =
+                 idpath _).
+    {
+      apply isasethz.
+    }
+    cbn in e0. cbn. rewrite e0. clear e0. cbn. unfold idfun.
+    assert (e1 : transportb (λ x' : A, A ⟦ x', C (i + 1 + 1 - 1 + 1) ⟧)
+                            (maponpaths C (hzrplusminus i 1 @ hzrminusplus' i 1))
+                            (ZeroArrow to_Zero (C (i - 1 + 1)) (C (i + 1 + 1 - 1 + 1))) =
+                 ZeroArrow to_Zero _ _).
+    {
+      rewrite <- functtransportb. induction (hzrplusminus i 1 @ hzrminusplus' i 1).
+      cbn. unfold idfun. apply idpath.
+    }
+    cbn in e1. rewrite e1. clear e1.
+    rewrite <- functtransportb.
+    induction (hzrminusplus (i + 1) 1). cbn.
+    induction (hzrplusminus' (i + 1 - 1 + 1) 1). cbn. unfold idfun.
+    exact (CEq _ C (i + 1 - 1)).
+  Qed.
+
+  Definition CokernelComplex (C : Complex (AbelianToAdditive A hs)) :
+    Complex (AbelianToAdditive A hs).
+  Proof.
+    use mk_Complex.
+    - intros i. exact (Cokernel (Diff C (i - 1))).
+    - intros i. cbn.
+      use CokernelOut.
+      + use compose.
+        * exact (C (i + 1 - 1 + 1)).
+        * use (transportb (fun x' : A => precategory_morphisms x' (C (i + 1 - 1 + 1)))
+                          (maponpaths C (hzrminusplus i 1 @ hzrplusminus' i 1))).
+          cbn.
+          exact (Diff C (i + 1 - 1)).
+        * use CokernelArrow.
+      + exact (CokernelComplex_Cokernel_comm C i).
+    - intros i. cbn. exact (CokernelComplex_comm C i).
+  Defined.
+
+
+  (** ** Construction of h^i and isomorphisms with cohomology *)
+  (** *** Uniqueness and existence of h^i *)
+
+  Local Lemma CokernelKernelMorphism_comm1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    Diff C (i - 1) ;; transportb (λ x : A, A ⟦x, C (i + 1)⟧)
+         (maponpaths C (hzrminusplus i 1)) (Diff C i) =
+    ZeroArrow to_Zero (C (i - 1)) (C (i + 1)).
+  Proof.
+    induction (hzrminusplus i 1). cbn. unfold idfun. exact (CEq _ C (i - 1)).
+  Qed.
+
+
+  Local Lemma CokernelKernelMorphism_comm2 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
+                (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                            (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                (CokernelKernelMorphism_comm1 C i) ;; Diff C (i + 1) =
+    ZeroArrow to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1 + 1)).
+  Proof.
+    use CokernelOutsEq.
+    rewrite assoc. rewrite CokernelCommutes. rewrite ZeroArrow_comp_right.
+    induction (hzrminusplus i 1). cbn. unfold idfun.
+    exact (CEq _ C (i - 1 + 1)).
+  Qed.
+
+  Local Lemma CokernelKernelMorphism_comm3 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    KernelIn to_Zero (Kernel (Diff C (i + 1))) (C i) (Diff C i) (CEq (AbelianToAdditive A hs) C i) =
+    transportf (λ i0 : pr1 hz, A ⟦ C i0, Cokernel (Diff C (i - 1)) ⟧) (hzrminusplus i 1)
+               (CokernelArrow (Cokernel (Diff C (i - 1))))
+               ;; KernelIn to_Zero (Kernel (Diff C (i + 1)))
+               (Cokernel (Diff C (i - 1)))
+               (CokernelOut to_Zero (Cokernel (Diff C (i - 1)))
+                            (C (i + 1))
+                            (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                                        (maponpaths C (hzrminusplus i 1))
+                                        (Diff C i)) (CokernelKernelMorphism_comm1 C i))
+               (CokernelKernelMorphism_comm2 C i).
+  Proof.
+    use KernelInsEq. rewrite KernelCommutes. rewrite <- assoc. rewrite KernelCommutes.
+    assert (e0 : transportf (λ i0 : pr1 hz, A ⟦ C i0, Cokernel (Diff C (i - 1)) ⟧)
+                            (hzrminusplus i 1) (CokernelArrow (Cokernel (Diff C (i - 1)))) =
+                 transportb (λ i0 : pr1 hz, A ⟦ C i0, Cokernel (Diff C (i - 1)) ⟧)
+                            (hzrminusplus' i 1) (CokernelArrow (Cokernel (Diff C (i - 1))))).
+    {
+      unfold transportb.
+      assert (e1 : ! hzrminusplus' i 1 = hzrminusplus i 1) by apply isasethz.
+      cbn in e1. rewrite e1. apply idpath.
+    }
+    rewrite e0. clear e0.
+    assert (e1 : transportb (λ i0 : pr1 hz, A ⟦ C i0, Cokernel (Diff C (i - 1)) ⟧)
+                            (hzrminusplus' i 1) (CokernelArrow (Cokernel (Diff C (i - 1)))) =
+                 transportb (λ x : A, A⟦x, Cokernel (Diff C (i - 1))⟧)
+                            (maponpaths C (hzrminusplus' i 1))
+                            (CokernelArrow (Cokernel (Diff C (i - 1))))).
+    {
+      rewrite <- functtransportb. apply idpath.
+    }
+    rewrite e1. clear e1. rewrite <- transportb_precompose. rewrite CokernelCommutes.
+    rewrite transport_b_b. rewrite <- maponpathscomp0. rewrite <- functtransportb.
+    assert (e2 : hzrminusplus' i 1 @ hzrminusplus i 1 = idpath _) by apply isasethz.
+    rewrite e2. apply idpath.
+  Qed.
+
+  Local Lemma CokernelKernelMorphism_comm1' (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    Diff C (i - 1) ;; transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
+         (maponpaths C (hzrminusplus i 1)) (Diff C i) =
+    ZeroArrow to_Zero (C (i - 1)) (C (i + 1)).
+  Proof.
+    induction (hzrminusplus i 1). cbn. unfold idfun. exact (CEq _ C (i - 1)).
+  Qed.
+
+  Local Lemma CokernelKernelMorphism_comm2' (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
+                (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                            (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                (CokernelKernelMorphism_comm1' C i) =
+    (KernelIn to_Zero (Kernel (Diff C (i + 1))) (Cokernel (Diff C (i - 1)))
+              (CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
+                           (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                                       (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                           (CokernelKernelMorphism_comm1 C i))
+              (CokernelKernelMorphism_comm2 C i))
+      ;; (KernelArrow (Kernel (Diff C (i + 1)))).
+  Proof.
+    rewrite KernelCommutes. use CokernelOutsEq.
+    rewrite CokernelCommutes. rewrite CokernelCommutes. apply idpath.
+  Qed.
+
+  Local Lemma CokernelKernelMorphism_uni (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    Π t : Σ f : A ⟦Cokernel (Diff C (i - 1)), Kernel (Diff C (i + 1))⟧,
+                (KernelIn to_Zero (Kernel (Diff C (i + 1))) (C i) (Diff C i)
+                          (CEq (AbelianToAdditive A hs) C i) =
+                 transportf (λ i0 : pr1 hz, A ⟦ C i0, Cokernel (Diff C (i - 1)) ⟧)
+                            (hzrminusplus i 1) (CokernelArrow (Cokernel (Diff C (i - 1)))) ;; f)
+                  × (CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
+                                 (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                                             (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                                 (CokernelKernelMorphism_comm1' C i) =
+                     f ;; KernelArrow (Kernel (Diff C (i + 1)))),
+  t =
+  KernelIn to_Zero (Kernel (Diff C (i + 1))) (Cokernel (Diff C (i - 1)))
+    (CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
+       (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧) (maponpaths C (hzrminusplus i 1)) (Diff C i))
+       (CokernelKernelMorphism_comm1 C i)) (CokernelKernelMorphism_comm2 C i),,
+    CokernelKernelMorphism_comm3 C i,, CokernelKernelMorphism_comm2' C i.
+  Proof.
+    intros t. induction t as [t1 t2]. induction t2 as [t21 t22].
+    use total2_paths.
+    - cbn. use KernelInsEq. rewrite KernelCommutes.
+      use CokernelOutsEq. rewrite CokernelCommutes.
+      rewrite assoc.
+      use transportb_path.
+      + exact (C i).
+      + exact (maponpaths C (hzrminusplus' i 1)).
+      + rewrite transport_b_b. rewrite <- maponpathscomp0.
+        assert (e0 : hzrminusplus' i 1 @ hzrminusplus i 1 = idpath _) by apply isasethz.
+        rewrite e0. clear e0. cbn. unfold idfun.
+        rewrite transportb_precompose. rewrite transportb_precompose. rewrite <- functtransportb.
+        unfold transportb.
+        assert (e1 : ! hzrminusplus' i 1 = hzrminusplus i 1) by apply isasethz.
+        cbn in e1. rewrite e1. clear e1. rewrite <- t21.
+        rewrite KernelCommutes. apply idpath.
+    - apply proofirrelevance. apply isapropdirprod.
+      + apply hs.
+      + apply hs.
+  Qed.
+
+  Definition CokernelKernelMorphism (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    iscontr (Σ f : A⟦(CokernelComplex C) i, (KernelComplex C) i⟧,
+                   ((KernelIn to_Zero (Kernel (Diff C (i + 1))) (C i) (Diff C i) (CEq _ C i)) =
+                    (transportf (fun (i0 : hz) => A⟦C i0, (Cokernel (Diff C (i - 1)))⟧)
+                                (hzrminusplus i 1)
+                                (CokernelArrow (Cokernel (Diff C (i - 1))))) ;; f)
+                     × ((CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
+                                     (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                                                 (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                                     (CokernelKernelMorphism_comm1' C i)) =
+                       f ;; (KernelArrow (Kernel (Diff C (i + 1)))))).
+  Proof.
+    use tpair.
+    - use tpair.
+      + cbn. use KernelIn.
+        * use CokernelOut.
+          -- exact (transportb (fun (x : A) => A⟦x, C(i + 1)⟧) (maponpaths C (hzrminusplus i 1))
+                               (Diff C i)).
+          -- exact (CokernelKernelMorphism_comm1 C i).
+        * exact (CokernelKernelMorphism_comm2 C i).
+      + cbn. split.
+        * exact (CokernelKernelMorphism_comm3 C i).
+        * exact (CokernelKernelMorphism_comm2' C i).
+    - cbn. exact (CokernelKernelMorphism_uni C i).
+  Defined.
+
+
+  (** *** Kernel and cohomology *)
+
+  Local Lemma CokernelKernelCohomology1_eq (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let CK := Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                   (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1))) in
+    (Diff C (i - 1))
+      ;; (transportb (λ x' : A, A ⟦ x', CK⟧) (maponpaths C (hzrminusplus i 1)) (CokernelArrow CK)) =
+    ZeroArrow to_Zero _ _.
+  Proof.
+    induction (hzrminusplus i 1). cbn. unfold idfun. apply CokernelCompZero.
+  Qed.
+
+  Local Lemma CokernelKernelCohomology1_Mor1_eq1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    (transportf (precategory_morphisms (C (i - 1))) (maponpaths C (hzrminusplus i 1))
+                (Diff C (i - 1)))
+      ;; (transportb (λ x' : A, A ⟦ x', Cokernel (Diff C (i - 1)) ⟧)
+                     (maponpaths C (! hzrminusplus i 1))
+                     (CokernelArrow (Cokernel (Diff C (i - 1))))) = ZeroArrow to_Zero _ _.
+  Proof.
+    rewrite maponpathsinv0. rewrite transport_compose'. apply CokernelCompZero.
+  Qed.
+
+  Local Lemma CokernelKernelCohomology1_Mor1_comm1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    KernelArrow
+      (Kernel
+         (CokernelOut to_Zero
+                      (Cokernel
+                         (transportf (precategory_morphisms (C (i - 1)))
+                                     (maponpaths C (hzrminusplus i 1))
+                                     (Diff C (i - 1)))) (C (i + 1)) (Diff C i)
+                      (CohomologyComplex_KernelIn_eq A hs C i))) ;;
+      CokernelOut to_Zero
+      (Cokernel
+         (transportf (precategory_morphisms (C (i - 1))) (maponpaths C (hzrminusplus i 1))
+                     (Diff C (i - 1))))
+      (Cokernel (Diff C (i - 1)))
+      (transportb (λ x' : A, A ⟦ x', Cokernel (Diff C (i - 1)) ⟧)
+                  (maponpaths C (! hzrminusplus i 1)) (CokernelArrow (Cokernel (Diff C (i - 1)))))
+      (CokernelKernelCohomology1_Mor1_eq1 C i) ;;
+      KernelIn to_Zero (Kernel (Diff C (i + 1))) (Cokernel (Diff C (i - 1)))
+      (CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
+                   (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧) (maponpaths C (hzrminusplus i 1))
+                               (Diff C i))
+                   (CokernelKernelMorphism_comm1 C i)) (CokernelKernelMorphism_comm2 C i) =
+    ZeroArrow to_Zero _ _.
+  Proof.
+    set (K := Kernel
+                (CokernelOut to_Zero
+                             (Cokernel
+                                (transportf (precategory_morphisms (C (i - 1)))
+                                            (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1))))
+                             (C (i + 1)) (Diff C i) (CohomologyComplex_KernelIn_eq A hs C i))).
+    cbn. use (KernelArrowisMonic to_Zero (Kernel (Diff C (i + 1)))).
+    rewrite <- assoc. rewrite <- assoc. rewrite KernelCommutes. rewrite ZeroArrow_comp_left.
+    cbn. cbn in K. fold K. rewrite <- (KernelCompZero to_Zero K). apply cancel_precomposition.
+    use CokernelOutsEq. rewrite assoc. rewrite CokernelCommutes. rewrite CokernelCommutes.
+    use transportb_path.
+    - exact (C (i - 1 + 1)).
+    - exact (maponpaths C (hzrminusplus i 1)).
+    - rewrite <- (CokernelCommutes to_Zero (Cokernel (Diff C (i - 1))) _
+                                  (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                                              (maponpaths C (hzrminusplus i 1))
+                                              (Diff C i)) (CokernelKernelMorphism_comm1 C i)).
+      rewrite transportb_precompose. apply cancel_postcomposition. rewrite transport_b_b.
+      rewrite <- maponpathscomp0.
+      assert (e0 : (hzrminusplus i 1 @ ! hzrminusplus i 1) = idpath _) by apply isasethz.
+      cbn. cbn in e0. rewrite e0. clear e0. apply idpath.
+  Qed.
+
+  Definition CokernelKernelCohomology1_Mor1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    A⟦(((CohomologyFunctor A hs C) : Complex (AbelianToAdditive A hs)) i),
+      (Kernel (pr1 (pr1 (CokernelKernelMorphism C i))))⟧.
+  Proof.
+    set (K := Kernel
+                (CokernelOut to_Zero
+                             (Cokernel
+                                (transportf (precategory_morphisms (C (i - 1)))
+                                            (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1))))
+                             (C (i + 1)) (Diff C i) (CohomologyComplex_KernelIn_eq A hs C i))).
+    use (compose (iso_inv_from_is_iso _ (CohomologyComplexIso_is_iso_i A hs C i))).
+    use KernelIn.
+    - cbn.
+      use (compose (KernelArrow K)).
+      use CokernelOut.
+      + exact (transportb (fun x' : A => A ⟦x', Cokernel (Diff C (i - 1))⟧)
+                          (maponpaths C (! hzrminusplus i 1))
+                          (CokernelArrow (Cokernel (Diff C (i - 1))))).
+      + exact (CokernelKernelCohomology1_Mor1_eq1 C i).
+    - exact (CokernelKernelCohomology1_Mor1_comm1 C i).
+  Defined.
+
+  Local Lemma CokernelKernelCohomology1_Mor2_comm1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    KernelArrow
+      (Kernel
+         (KernelIn to_Zero (Kernel (Diff C (i + 1))) (Cokernel (Diff C (i - 1)))
+                   (CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
+                                (transportb (λ x : A, A ⟦x, C (i + 1)⟧)
+                                            (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                                (CokernelKernelMorphism_comm1 C i))
+                   (CokernelKernelMorphism_comm2 C i))) ;;
+      CokernelOut to_Zero (Cokernel (Diff C (i - 1)))
+      (Cokernel
+         (transportf (precategory_morphisms (C (i - 1))) (maponpaths C (hzrminusplus i 1))
+                     (Diff C (i - 1))))
+      (transportb (λ x' : A, A ⟦x', Cokernel
+                                      (transportf (precategory_morphisms (C (i - 1)))
+                                                  (maponpaths C (hzrminusplus i 1))
+                                                  (Diff C (i - 1)))⟧)
+                  (maponpaths C (hzrminusplus i 1))
+                  (CokernelArrow
+                     (Cokernel
+                        (transportf (precategory_morphisms (C (i - 1)))
+                                    (maponpaths C (hzrminusplus i 1))
+                                    (Diff C (i - 1)))))) (CokernelKernelCohomology1_eq C i) ;;
+      (CokernelOut to_Zero
+                   (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                         (maponpaths C (hzrminusplus i 1))
+                                         (Diff C (i - 1)))) (C (i + 1)) (Diff C i)
+                   (CohomologyComplex_KernelIn_eq A hs C i)) = ZeroArrow to_Zero _ _.
+  Proof.
+    set (CK := Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                    (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1)))).
+    cbn. cbn in CK. fold CK.
+    set (K := (Kernel
+                 (KernelIn to_Zero (Kernel (Diff C (i + 1))) (Cokernel (Diff C (i - 1)))
+                           (CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
+                                        (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                                                    (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                                        (CokernelKernelMorphism_comm1 C i))
+                           (CokernelKernelMorphism_comm2 C i)))).
+    cbn. cbn in K. fold K.
+    set (tmp := dirprod_pr2 (pr2 (pr1 (CokernelKernelMorphism C i)))).
+    assert (e0 : CokernelOut to_Zero (Cokernel (Diff C (i - 1))) CK
+                             (transportb (λ x' : A, A ⟦ x', CK ⟧) (maponpaths C (hzrminusplus i 1))
+                                         (CokernelArrow CK))
+                             (CokernelKernelCohomology1_eq C i) ;; CokernelOut to_Zero CK
+                             (C (i + 1)) (Diff C i)
+                             (CohomologyComplex_KernelIn_eq A hs C i) =
+                 (KernelIn to_Zero (Kernel (Diff C (i + 1))) (Cokernel (Diff C (i - 1)))
+                           (CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
+                                        (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                                                    (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                                        (CokernelKernelMorphism_comm1 C i))
+                           (CokernelKernelMorphism_comm2 C i)) ;; KernelArrow (Kernel _)).
+    {
+      use CokernelOutsEq. rewrite assoc. rewrite CokernelCommutes.
+      use transportb_path.
+      + exact (C i).
+      + exact (maponpaths C (! hzrminusplus i 1)).
+      + rewrite transportb_precompose. rewrite transport_b_b.
+        rewrite <- maponpathscomp0.
+        assert (e0 : ! hzrminusplus i 1 @ hzrminusplus i 1 = idpath _) by apply isasethz.
+        rewrite e0. clear e0. cbn. unfold idfun. rewrite CokernelCommutes.
+        cbn in tmp. rewrite <- tmp. clear tmp.
+        use transportb_path.
+        * exact (C (i - 1 + 1)).
+        * exact (maponpaths C (hzrminusplus i 1)).
+        * rewrite transportb_precompose. rewrite transportb_precompose.
+          rewrite transport_b_b. rewrite <- maponpathscomp0. rewrite pathsinv0r. cbn.
+          unfold idfun. rewrite CokernelCommutes. apply idpath.
+    }
+    rewrite <- assoc. cbn in e0. rewrite e0. clear e0.
+    rewrite KernelCommutes. unfold K.
+    set (CKO := CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
+                            (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                                        (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                            (CokernelKernelMorphism_comm1 C i)). cbn. cbn in CKO. fold CKO.
+    set (K2 := Kernel (KernelIn to_Zero (Kernel (Diff C (i + 1)))
+                                (Cokernel (Diff C (i - 1))) CKO
+                                (CokernelKernelMorphism_comm2 C i))).
+    rewrite <- (ZeroArrow_comp_left _ _ _ _ _ (KernelArrow (Kernel (Diff C (i + 1))))).
+    rewrite <- (KernelCompZero to_Zero K2).
+    unfold CKO. unfold K2. clear K2. unfold CKO. clear CKO. cbn.
+    rewrite <- assoc.
+    apply cancel_precomposition.
+    apply pathsinv0. use KernelCommutes.
+  Qed.
+
+  Definition CokernelKernelCohomology1_Mor2 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    A⟦(Kernel (pr1 (pr1 (CokernelKernelMorphism C i)))),
+      (((CohomologyFunctor A hs C) : Complex (AbelianToAdditive A hs)) i)⟧.
+  Proof.
+    use (postcompose (CohomologyComplexIso_Mor_i A hs C i)). cbn.
+    use KernelIn.
+    - use (compose (KernelArrow _)).
+      use CokernelOut.
+      + exact (transportb (fun x' : A => precategory_morphisms x' _) (maponpaths C (hzrminusplus i 1))
+                          (CokernelArrow (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                                               (maponpaths C (hzrminusplus i 1))
+                                                               (Diff C (i - 1)))))).
+      + exact (CokernelKernelCohomology1_eq C i).
+    - exact (CokernelKernelCohomology1_Mor2_comm1 C i).
+  Defined.
+
+  Local Lemma CokernelKernelCohomology1_id1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    CokernelKernelCohomology1_Mor2 C i ;; CokernelKernelCohomology1_Mor1 C i =
+    identity (Kernel (pr1 (pr1 (CokernelKernelMorphism C i)))).
+  Proof.
+    unfold CokernelKernelCohomology1_Mor2. unfold postcompose.
+    unfold CokernelKernelCohomology1_Mor1. cbn.
+    (* Make the goal more readable *)
+    set (K1 := Kernel
+                 (CokernelOut to_Zero
+                              (Cokernel
+                                 (transportf (precategory_morphisms (C (i - 1)))
+                                             (maponpaths C (hzrminusplus i 1))
+                                             (Diff C (i - 1)))) (C (i + 1)) (Diff C i)
+                              (CohomologyComplex_KernelIn_eq A hs C i))).
+    cbn in K1. fold K1.
+    set (K2 := (Kernel
+                  (KernelIn to_Zero (Kernel (Diff C (i + 1))) (Cokernel (Diff C (i - 1)))
+                            (CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
+                                         (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                                                     (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                                         (CokernelKernelMorphism_comm1 C i))
+                            (CokernelKernelMorphism_comm2 C i)))).
+    cbn in K2. fold K2.
+    set (CK1 := (Cokernel (Diff C (i - 1)))).
+    set (CK2 := (Cokernel
+                   (transportf (precategory_morphisms (C (i - 1))) (maponpaths C (hzrminusplus i 1))
+                               (Diff C (i - 1))))). cbn in CK2. fold CK2.
+
+    use KernelInsEq. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
+    rewrite KernelCommutes. rewrite id_left.
+    (* Get rid of the inv_from_iso stuff *)
+    assert (ee : ((CohomologyComplexIso_Mor_i A hs C i)
+                    ;; (inv_from_iso
+                          (CohomologyComplexIso_Mor_i A hs C i,,
+                                                      CohomologyComplexIso_is_iso_i A hs C i) ;;
+                          (KernelArrow K1 ;; CokernelOut to_Zero CK2 CK1
+                                       (transportb
+                                          (λ x' : A, A ⟦ x', CK1 ⟧)
+                                          (maponpaths C (! hzrminusplus i 1))
+                                          (CokernelArrow CK1))
+                                       (CokernelKernelCohomology1_Mor1_eq1 C i)))) =
+                 (KernelArrow K1 ;; CokernelOut to_Zero CK2 CK1
+                              (transportb
+                                 (λ x' : A, A ⟦ x', CK1 ⟧)
+                                 (maponpaths C (! hzrminusplus i 1))
+                                 (CokernelArrow CK1))
+                              (CokernelKernelCohomology1_Mor1_eq1 C i))).
+    {
+      rewrite assoc. rewrite assoc. apply cancel_postcomposition.
+      assert (ee' : (CohomologyComplexIso_Mor_i A hs C i)
+                      ;; (inv_from_iso ((CohomologyComplexIso_Mor_i A hs C i)
+                                          ,, (CohomologyComplexIso_is_iso_i A hs C i))) =
+                    identity _).
+      {
+        apply (iso_inv_after_iso (isopair _ (CohomologyComplexIso_is_iso_i A hs C i))).
+      }
+      cbn beta in ee'. rewrite ee'. clear ee'. apply id_left.
+    }
+    cbn in ee. cbn.
+    apply (maponpaths
+             (fun gg : _ => KernelIn to_Zero K1 K2
+                                  (KernelArrow K2 ;; CokernelOut to_Zero CK1 CK2
+                                               (transportb (λ x' : A, A ⟦ x', CK2 ⟧)
+                                                           (maponpaths C (hzrminusplus i 1))
+                                                           (CokernelArrow CK2))
+                                               (CokernelKernelCohomology1_eq C i))
+                                  (CokernelKernelCohomology1_Mor2_comm1 C i) ;; gg)) in ee.
+    use (pathscomp0 ee). clear ee.
+    (* Use KernelCommutes and CokernelCommutes to solve the goal *)
+    rewrite assoc. rewrite KernelCommutes. rewrite <- id_right. rewrite <- assoc.
+    apply cancel_precomposition. use CokernelOutsEq.
+    rewrite id_right. rewrite assoc. rewrite CokernelCommutes.
+    use transportb_path.
+    -- exact (C i).
+    -- exact (maponpaths C (! hzrminusplus i 1)).
+    -- rewrite transportb_precompose. rewrite transport_b_b.
+       rewrite <- maponpathscomp0. rewrite pathsinv0l. cbn. unfold idfun.
+       apply CokernelCommutes.
+  Qed.
+
+  Local Lemma CokernelKernelCohomology1_id2 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    CokernelKernelCohomology1_Mor1 C i ;; CokernelKernelCohomology1_Mor2 C i =
+    identity _.
+  Proof.
+    unfold CokernelKernelCohomology1_Mor2. unfold postcompose.
+    unfold CokernelKernelCohomology1_Mor1. cbn.
+    (* Make the goal more readable *)
+    set (CK1 := (Cokernel (Diff C (i - 1)))).
+    set (CK2 := (Cokernel (transportf (precategory_morphisms (C (i - 1)))
+                                      (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1))))).
+    cbn in CK2. fold CK2.
+    set (K1 := Kernel (CokernelOut to_Zero CK2 (C (i + 1)) (Diff C i)
+                                   (CohomologyComplex_KernelIn_eq A hs C i))).
+    set (K2 := Kernel
+                 (KernelIn to_Zero (Kernel (Diff C (i + 1))) CK1
+                           (CokernelOut to_Zero CK1 (C (i + 1))
+                                        (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                                                    (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                                        (CokernelKernelMorphism_comm1 C i))
+                           (CokernelKernelMorphism_comm2 C i))).
+    cbn in K2. fold K2.
+    set (KI21 := KernelIn to_Zero K2 K1
+                          ((KernelArrow K1)
+                             ;; (CokernelOut to_Zero CK2 CK1
+                                             (transportb (λ x' : A, A ⟦ x', CK1 ⟧)
+                                                         (maponpaths C (! hzrminusplus i 1))
+                                                         (CokernelArrow CK1))
+                                             (CokernelKernelCohomology1_Mor1_eq1 C i)))
+                          (CokernelKernelCohomology1_Mor1_comm1 C i)).
+    cbn in KI21. fold KI21.
+    set (KI12 := KernelIn to_Zero K1 K2
+                          (KernelArrow K2 ;; CokernelOut to_Zero CK1 CK2
+                                       (transportb (λ x' : A, A ⟦ x', CK2 ⟧)
+                                                   (maponpaths C (hzrminusplus i 1))
+                                                   (CokernelArrow CK2))
+                                       (CokernelKernelCohomology1_eq C i))
+                          (CokernelKernelCohomology1_Mor2_comm1 C i)).
+    cbn in KI12. fold KI12.
+    (* Begin to prove the equality *)
+    (* Cancel the inv_from_iso *)
+    use (pre_comp_with_iso_is_inj _ _ _ _ _ (CohomologyComplexIso_is_iso_i A hs C i)).
+    rewrite assoc. rewrite assoc. rewrite assoc.
+    assert (e : (CohomologyComplexIso_Mor_i A hs C i)
+                  ;; (inv_from_iso ((CohomologyComplexIso_Mor_i A hs C i)
+                                      ,, (CohomologyComplexIso_is_iso_i A hs C i))) = identity _).
+    {
+      apply (iso_inv_after_iso (isopair _ (CohomologyComplexIso_is_iso_i A hs C i))).
+    }
+    cbn beta in e. rewrite id_right.
+    apply (maponpaths (fun gg : _ => gg ;; KI21 ;; KI12 ;; CohomologyComplexIso_Mor_i A hs C i))
+      in e.
+    use (pathscomp0 e). clear e. rewrite id_left.
+    (* Cancel the last morphism *)
+    use (post_comp_with_iso_is_inj
+           _ _ _ _  (is_iso_inv_from_iso (isopair _ (CohomologyComplexIso_is_iso_i A hs C i)))).
+    rewrite <- assoc. rewrite <- assoc.
+    assert (ee : (CohomologyComplexIso_Mor_i A hs C i)
+                   ;; (inv_from_iso (isopair _ (CohomologyComplexIso_is_iso_i A hs C i))) =
+                 identity _).
+    {
+      apply (iso_inv_after_iso (isopair _ (CohomologyComplexIso_is_iso_i A hs C i))).
+    }
+    cbn beta in ee. rewrite ee.
+    apply (maponpaths (fun gg : _ => KI21 ;; (KI12 ;; gg))) in ee. use (pathscomp0 ee). clear ee.
+    rewrite id_right.
+    (* Solve by using KernelInsEq *)
+    unfold KI12, KI21. clear KI12 KI21. unfold K1, K2. clear K1 K2. unfold CK1, CK2. clear CK1 CK2.
+    cbn.
+    use KernelInsEq. rewrite <- assoc. rewrite KernelCommutes. rewrite assoc.
+    rewrite KernelCommutes.
+    rewrite id_left. rewrite <- id_right. rewrite <- assoc. apply cancel_precomposition.
+    use CokernelOutsEq. rewrite assoc. rewrite CokernelCommutes. rewrite id_right.
+    use transportb_path.
+    - exact (C (i - 1 + 1)).
+    - exact (maponpaths C (hzrminusplus i 1)).
+    - rewrite transportb_precompose. rewrite transport_b_b. rewrite <- maponpathscomp0.
+      rewrite pathsinv0r. cbn. unfold idfun. apply CokernelCommutes.
+  Qed.
+
+  Definition CokernelKernelCohomology1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    iso (Kernel (pr1 (pr1 (CokernelKernelMorphism C i))))
+        ((((CohomologyFunctor A hs C) : Complex (AbelianToAdditive A hs)) i)).
+  Proof.
+    use isopair.
+    - exact (CokernelKernelCohomology1_Mor2 C i).
+    - use is_iso_qinv.
+      + exact (CokernelKernelCohomology1_Mor1 C i).
+      + split.
+        * exact (CokernelKernelCohomology1_id1 C i).
+        * exact (CokernelKernelCohomology1_id2 C i).
+  Defined.
+
+
+  (** *** Cokernel and cohomology *)
+
+  Local Lemma CokernelKernelCohomology2_comm1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    let CK := Cokernel (KernelIn to_Zero (Kernel (Diff C (i + 1))) (C (i + 1 - 1))
+                                 (transportf (precategory_morphisms (C (i + 1 - 1)))
+                                             (maponpaths C (hzrminusplus (i + 1) 1))
+                                             (Diff C (i + 1 - 1)))
+                                 (CohomologyComplex_KernelIn_eq A hs C (i + 1))) in
+    pr1 (pr1 (CokernelKernelMorphism C i)) ;; CokernelArrow CK = ZeroArrow to_Zero _ _.
+  Proof.
+    intros CK. cbn.
+    assert (e0 : isEpi (transportf (λ i0 : pr1 hz, A ⟦C i0, Cokernel (Diff C (i - 1))⟧)
+                                   (hzrminusplus i 1)
+                                   (CokernelArrow (Cokernel (Diff C (i - 1)))))).
+    {
+      set (tmp' := transportb_isEpi A (CokernelArrow (Cokernel (Diff C (i - 1))))
+                                    (CokernelArrowisEpi _ _) (maponpaths C (hzrminusplus' i 1))).
+      unfold transportb in tmp'.
+      assert (e00 : (! maponpaths C (hzrminusplus' i 1)) = maponpaths C (hzrminusplus i 1)).
+      {
+        rewrite <- maponpathsinv0. apply maponpaths.
+        apply isasethz.
+      }
+      cbn in tmp'.
+      assert (e001 : isEpi (transportf (λ x' : A, A ⟦ x', Cokernel (Diff C (i - 1)) ⟧)
+                                       (maponpaths C (hzrminusplus i 1))
+                                       (CokernelArrow (Cokernel (Diff C (i - 1)))))).
+      {
+        induction e00. apply tmp'.
+      }
+      clear e00.
+      rewrite <- functtransportf in e001. apply e001.
+    }
+    use e0. rewrite assoc. clear e0. rewrite ZeroArrow_comp_right.
+    set (tmp := dirprod_pr1 (pr2 (pr1 (CokernelKernelMorphism C i)))).
+    cbn in tmp. rewrite <- tmp. clear tmp.
+    set (tmp := CokernelCompZero _ CK).
+    use transportb_path.
+    - exact (C (i + 1 - 1)).
+    - exact (maponpaths C (hzrplusminus i 1)).
+    - rewrite transportb_ZeroArrow. cbn in tmp. rewrite <- tmp. clear tmp.
+      rewrite transportb_precompose. apply cancel_postcomposition. clear CK.
+      rewrite transportb_KernelIn. use KernelInsEq.
+      rewrite KernelCommutes. rewrite KernelCommutes.
+      set (tmp := transport_Diff _ C i). cbn. cbn in tmp. apply tmp.
+  Qed.
+
+  Definition CokernelKernelCohomology2_Mor1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    A⟦(Cokernel (pr1 (pr1 (CokernelKernelMorphism C i)))),
+      ((((CohomologyFunctor A hs C) : Complex (AbelianToAdditive A hs)) (i + 1)))⟧.
+  Proof.
+    use CokernelOut.
+    - use CokernelArrow.
+    - exact (CokernelKernelCohomology2_comm1 C i).
+  Defined.
+
+  Local Lemma CokernelKernelCohomology2_comm2 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    (KernelIn to_Zero (Kernel (Diff C (i + 1))) (C (i + 1 - 1))
+              (transportf (precategory_morphisms (C (i + 1 - 1)))
+                          (maponpaths C (hzrminusplus (i + 1) 1))
+                          (Diff C (i + 1 - 1))) (CohomologyComplex_KernelIn_eq A hs C (i + 1)))
+      ;; (CokernelArrow (Cokernel (pr1 (pr1 (CokernelKernelMorphism C i))))) =
+    ZeroArrow to_Zero _ _.
+  Proof.
+    set (tmp := dirprod_pr1 (pr2 (pr1 (CokernelKernelMorphism C i)))).
+    assert (e0 : KernelIn to_Zero (Kernel (Diff C (i + 1))) (C (i + 1 - 1))
+                          (transportf (precategory_morphisms (C (i + 1 - 1)))
+                                      (maponpaths C (hzrminusplus (i + 1) 1))
+                                      (Diff C (i + 1 - 1)))
+                          (CohomologyComplex_KernelIn_eq A hs C (i + 1)) =
+                 transportb (fun x' : ob A => precategory_morphisms x' _)
+                            (maponpaths C (hzrplusminus i 1))
+                            (KernelIn to_Zero (Kernel (Diff C (i + 1))) (C i) (Diff C i)
+                                      (CEq (AbelianToAdditive A hs) C i))).
+    {
+      rewrite transportb_KernelIn.
+      use KernelInsEq.
+      rewrite KernelCommutes. rewrite KernelCommutes. clear tmp.
+      set (tmp := transport_Diff _ C i). cbn. cbn in tmp. apply pathsinv0. apply tmp.
+    }
+    cbn in e0. cbn. rewrite e0. clear e0. rewrite tmp. clear tmp. cbn.
+    rewrite transportb_precompose. rewrite <- assoc. rewrite CokernelCompZero.
+    apply ZeroArrow_comp_right.
+  Qed.
+
+  Definition CokernelKernelCohomology2_Mor2 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    A⟦((((CohomologyFunctor A hs C) : Complex (AbelianToAdditive A hs)) (i + 1))),
+      (Cokernel (pr1 (pr1 (CokernelKernelMorphism C i))))⟧.
+  Proof.
+    use CokernelOut.
+    - use CokernelArrow.
+    - exact (CokernelKernelCohomology2_comm2 C i).
+  Defined.
+
+  Local Lemma CokernelKernelCohomology2_inverses (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    is_inverse_in_precat (CokernelKernelCohomology2_Mor1 C i) (CokernelKernelCohomology2_Mor2 C i).
+  Proof.
+    split.
+    - unfold CokernelKernelCohomology2_Mor1. use CokernelOutsEq.
+      rewrite assoc. rewrite CokernelCommutes.
+      unfold CokernelKernelCohomology2_Mor2.
+      cbn. rewrite CokernelCommutes. rewrite id_right. apply idpath.
+    - unfold CokernelKernelCohomology2_Mor2. use CokernelOutsEq.
+      rewrite assoc. cbn. rewrite CokernelCommutes.
+      unfold CokernelKernelCohomology2_Mor1.
+      cbn. rewrite CokernelCommutes. rewrite id_right. apply idpath.
+  Qed.
+
+  Definition CokernelKernelCohomology2 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
+    iso (Cokernel (pr1 (pr1 (CokernelKernelMorphism C i))))
+        ((((CohomologyFunctor A hs C) : Complex (AbelianToAdditive A hs)) (i + 1))).
+  Proof.
+    use isopair.
+    - exact (CokernelKernelCohomology2_Mor1 C i).
+    - use is_iso_qinv.
+      + exact (CokernelKernelCohomology2_Mor2 C i).
+      + exact (CokernelKernelCohomology2_inverses C i).
+  Defined.
+
+End def_kernel_cokernel_complex.
+
+Local Transparent hz isdecrelhzeq hzplus iscommrngops.
+Close Scope hz_scope.

--- a/UniMath/CategoryTheory/Complexes.v
+++ b/UniMath/CategoryTheory/Complexes.v
@@ -8,6 +8,7 @@
  - The precategory of complexes over an additive precategory is an additive category,
    [complexes_additive]
  - Precategory of complexes over an abelian category is abelian [complexes_abelian]
+ - Homotopies and construction of K(A), the naive homotopy category
 *)
 Require Import UniMath.Foundations.Basics.UnivalenceAxiom.
 Require Import UniMath.Foundations.Basics.PartD.
@@ -88,10 +89,10 @@ Section def_complexes.
   Definition Complex_Funclass (C : Complex) : hz -> ob A := pr1 (pr1 C).
   Coercion Complex_Funclass : Complex >-> Funclass.
 
-  Definition Diff {C : Complex} (i : hz) : A⟦C i, C (hzplus i 1)⟧ := pr2 (pr1 C) i.
+  Definition Diff (C : Complex) (i : hz) : A⟦C i, C (hzplus i 1)⟧ := pr2 (pr1 C) i.
 
   Definition CEq (C : Complex) (i : hz) :
-    (Diff i) ;; (Diff (hzplus i 1)) = ZeroArrow (Additive.to_Zero A) _ _ := pr2 C i.
+    (Diff C i) ;; (Diff C (hzplus i 1)) = ZeroArrow (Additive.to_Zero A) _ _ := pr2 C i.
 
   (** Zero Complex *)
   Definition ZeroComplex : Complex.
@@ -107,8 +108,8 @@ Section def_complexes.
     let B1 := to_BinDirectSums A (C1 i) (C2 i) in
     let B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1)) in
     let B3 := to_BinDirectSums A (C1 (i + 1 + 1)) (C2 (i + 1 + 1)) in
-    (BinDirectSumIndAr A (@Diff C1 i) (@Diff C2 i) B1 B2)
-      ;; (BinDirectSumIndAr A (@Diff C1 (i + 1)) (@Diff C2 (i + 1)) B2 B3) =
+    (BinDirectSumIndAr A (Diff C1 i) (Diff C2 i) B1 B2)
+      ;; (BinDirectSumIndAr A (Diff C1 (i + 1)) (Diff C2 (i + 1)) B2 B3) =
     ZeroArrow (Additive.to_Zero A) B1 B3.
   Proof.
     cbn.
@@ -126,16 +127,16 @@ Section def_complexes.
   Proof.
     use mk_Complex.
     - intros i. exact (to_BinDirectSums A (C1 i) (C2 i)).
-    - intros i. exact (BinDirectSumIndAr A (@Diff C1 i) (@Diff C2 i) _ _).
+    - intros i. exact (BinDirectSumIndAr A (Diff C1 i) (Diff C2 i) _ _).
     - intros i. exact (DirectSumComplex_comm i).
   Defined.
 
   (** Morphism of complexes *)
   Definition Morphism (C1 C2 : Complex) : UU :=
-    Σ D : (Π i : hz, A⟦C1 i, C2 i⟧), Π i : hz, (D i) ;; (@Diff C2 i) = (@Diff C1 i) ;; (D (i + 1)).
+    Σ D : (Π i : hz, A⟦C1 i, C2 i⟧), Π i : hz, (D i) ;; (Diff C2 i) = (Diff C1 i) ;; (D (i + 1)).
 
   Definition mk_Morphism (C1 C2 : Complex) (Mors : Π i : hz, A⟦C1 i, C2 i⟧)
-             (Comm : Π i : hz, (Mors i) ;; (@Diff C2 i) = (@Diff C1 i) ;; (@Mors (i + 1))) :
+             (Comm : Π i : hz, (Mors i) ;; (Diff C2 i) = (Diff C1 i) ;; (Mors (i + 1))) :
     Morphism C1 C2 := tpair _ Mors Comm.
 
   (** Accessor functions *)
@@ -143,7 +144,7 @@ Section def_complexes.
     pr1 M i.
 
   Definition MComm {C1 C2 : Complex} (M : Morphism C1 C2) (i : hz) :
-    (MMor M i) ;; (@Diff C2 i) = (@Diff C1 i) ;; (MMor M (i + 1)) := pr2 M i.
+    (MMor M i) ;; (Diff C2 i) = (Diff C1 i) ;; (MMor M (i + 1)) := pr2 M i.
 
   (** A lemma to show that two morphisms are the same *)
   Lemma MorphismEq {C1 C2 : Complex} (M1 M2 : Morphism C1 C2)
@@ -176,7 +177,7 @@ Section def_complexes.
 
   (** Identity Morphism *)
   Local Lemma IdMorComm (C1 : Complex) (i : hz) :
-    (identity (C1 i)) ;; (@Diff C1 i) = (@Diff C1 i) ;; (identity (C1 (i + 1))).
+    (identity (C1 i)) ;; (Diff C1 i) = (Diff C1 i) ;; (identity (C1 (i + 1))).
   Proof.
     rewrite id_left.
     rewrite id_right.
@@ -192,7 +193,7 @@ Section def_complexes.
 
   (** Morphisms from and to Zero complex *)
   Local Lemma MorphismFromZero_comm (C : Complex) (i : hz) :
-    (ZeroArrow (Additive.to_Zero A) (Additive.to_Zero A) (C i)) ;; (Diff i) =
+    (ZeroArrow (Additive.to_Zero A) (Additive.to_Zero A) (C i)) ;; (Diff C i) =
     (ZeroArrow (Additive.to_Zero A) (Additive.to_Zero A) (Additive.to_Zero A))
       ;; (ZeroArrow (Additive.to_Zero A) (Additive.to_Zero A) (C (i + 1))).
   Proof.
@@ -211,7 +212,7 @@ Section def_complexes.
   Local Lemma MorphismToZero_comm (C : Complex) (i : hz) :
     (ZeroArrow (Additive.to_Zero A) (C i) (Additive.to_Zero A))
       ;; (ZeroArrow (Additive.to_Zero A) (Additive.to_Zero A) (Additive.to_Zero A)) =
-    (Diff i) ;; ZeroArrow (Additive.to_Zero A) (C (i + 1)) (Additive.to_Zero A).
+    (Diff C i) ;; ZeroArrow (Additive.to_Zero A) (C (i + 1)) (Additive.to_Zero A).
   Proof.
     rewrite ZeroArrow_comp_right.
     rewrite ZeroArrow_comp_right.
@@ -228,8 +229,8 @@ Section def_complexes.
   (** Composition of morphisms *)
   Local Lemma MorphismCompComm {C1 C2 C3 : Complex} (M1 : Morphism C1 C2) (M2 : Morphism C2 C3)
         (i : hz) :
-    (MMor M1 i) ;; (MMor M2 i) ;; (@Diff C3 i) =
-    (@Diff C1 i) ;; (MMor M1 (i + 1) ;; MMor M2 (i + 1)).
+    (MMor M1 i) ;; (MMor M2 i) ;; (Diff C3 i) =
+    (Diff C1 i) ;; (MMor M1 (i + 1) ;; MMor M2 (i + 1)).
   Proof.
     rewrite assoc.
     rewrite <- (MComm M1).
@@ -256,8 +257,8 @@ Section def_complexes.
   Local Lemma DirectSumComplexIn1_comm (C1 C2 : Complex) (i : hz) :
     let B1 := to_BinDirectSums A (C1 i) (C2 i) in
     let B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1)) in
-    (to_In1 A B1) ;; (BinDirectSumIndAr A (@Diff C1 i) (@Diff C2 i) B1 B2) =
-    (@Diff C1 i) ;; (to_In1 A B2).
+    (to_In1 A B1) ;; (BinDirectSumIndAr A (Diff C1 i) (Diff C2 i) B1 B2) =
+    (Diff C1 i) ;; (to_In1 A B2).
   Proof.
     cbn.
     set (B1 := to_BinDirectSums A (C1 i) (C2 i)).
@@ -281,8 +282,8 @@ Section def_complexes.
   Local Lemma DirectSumComplexIn2_comm (C1 C2 : Complex) (i : hz) :
     let B1 := to_BinDirectSums A (C1 i) (C2 i) in
     let B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1)) in
-    (to_In2 A B1) ;; (BinDirectSumIndAr A (@Diff C1 i) (@Diff C2 i) B1 B2) =
-    (@Diff C2 i) ;; (to_In2 A B2).
+    (to_In2 A B1) ;; (BinDirectSumIndAr A (Diff C1 i) (Diff C2 i) B1 B2) =
+    (Diff C2 i) ;; (to_In2 A B2).
   Proof.
     cbn.
     set (B1 := to_BinDirectSums A (C1 i) (C2 i)).
@@ -305,8 +306,8 @@ Section def_complexes.
   Local Lemma DirectSumComplexPr1_comm (C1 C2 : Complex) (i : hz) :
     let B1 := to_BinDirectSums A (C1 i) (C2 i) in
     let B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1)) in
-    (to_Pr1 A B1) ;; (@Diff C1 i) =
-    (BinDirectSumIndAr A (@Diff C1 i) (@Diff C2 i) B1 B2) ;; (to_Pr1 A B2).
+    (to_Pr1 A B1) ;; (Diff C1 i) =
+    (BinDirectSumIndAr A (Diff C1 i) (Diff C2 i) B1 B2) ;; (to_Pr1 A B2).
   Proof.
     cbn.
     set (B1 := to_BinDirectSums A (C1 i) (C2 i)).
@@ -330,8 +331,8 @@ Section def_complexes.
   Local Lemma DirectSumComplexPr2_comm (C1 C2 : Complex) (i : hz) :
     let B1 := to_BinDirectSums A (C1 i) (C2 i) in
     let B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1)) in
-    (to_Pr2 A B1) ;; (@Diff C2 i) =
-    (BinDirectSumIndAr A (@Diff C1 i) (@Diff C2 i) B1 B2) ;; (to_Pr2 A B2).
+    (to_Pr2 A B1) ;; (Diff C2 i) =
+    (BinDirectSumIndAr A (Diff C1 i) (Diff C2 i) B1 B2) ;; (to_Pr2 A B2).
   Proof.
     cbn.
     set (B1 := to_BinDirectSums A (C1 i) (C2 i)).
@@ -399,8 +400,8 @@ Section def_complexes.
 
   (** Additition of morphisms is pointwise addition *)
   Local Lemma MorphismOpComm {C1 C2 : Complex} (M1 M2 : Morphism C1 C2)  (i : hz) :
-    (to_binop (C1 i) (C2 i) (MMor M1 i) (MMor M2 i)) ;; (@Diff C2 i) =
-    (@Diff C1 i) ;; (to_binop (C1 (i + 1)) (C2 (i + 1)) (MMor M1 (i + 1)) (MMor M2 (i + 1))).
+    (to_binop (C1 i) (C2 i) (MMor M1 i) (MMor M2 i)) ;; (Diff C2 i) =
+    (Diff C1 i) ;; (to_binop (C1 (i + 1)) (C2 (i + 1)) (MMor M1 (i + 1)) (MMor M2 (i + 1))).
   Proof.
     rewrite to_postmor_linear'. rewrite to_premor_linear'.
     rewrite (MComm M1 i). rewrite (MComm M2 i). apply idpath.
@@ -422,8 +423,8 @@ Section def_complexes.
   Qed.
 
   Lemma MorphismZeroComm (C1 C2 : Complex) (i : hz) :
-    (ZeroArrow (Additive.to_Zero A) (C1 i) (C2 i)) ;; (@Diff C2 i) =
-    (@Diff C1 i) ;; (ZeroArrow (Additive.to_Zero A) (C1 (i + 1)) (C2 (i + 1))).
+    (ZeroArrow (Additive.to_Zero A) (C1 i) (C2 i)) ;; (Diff C2 i) =
+    (Diff C1 i) ;; (ZeroArrow (Additive.to_Zero A) (C1 (i + 1)) (C2 (i + 1))).
   Proof.
     rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_right. apply idpath.
   Qed.
@@ -450,8 +451,8 @@ Section def_complexes.
   Qed.
 
   Local Lemma MorphismOp_inv_comm {C1 C2 : Complex} (M : Morphism C1 C2) (i : hz) :
-    (to_inv (C1 i) (C2 i) (MMor M i)) ;; (@Diff C2 i) =
-    (@Diff C1 i) ;; (to_inv (C1 (i + 1)) (C2 (i + 1)) (MMor M (i + 1))).
+    (to_inv (C1 i) (C2 i) (MMor M i)) ;; (Diff C2 i) =
+    (Diff C1 i) ;; (to_inv (C1 (i + 1)) (C2 (i + 1)) (MMor M (i + 1))).
   Proof.
     rewrite <- PreAdditive_invlcomp.
     rewrite <- PreAdditive_invrcomp.
@@ -524,8 +525,8 @@ Section def_complexes.
         (i : hz) :
     let B1 := to_BinDirectSums A (C1 i) (C2 i) in
     let B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1)) in
-    (FromBinDirectSum A B1 (MMor f i) (MMor g i)) ;; (@Diff D i) =
-    (BinDirectSumIndAr A (@Diff C1 i) (@Diff C2 i) B1 B2)
+    (FromBinDirectSum A B1 (MMor f i) (MMor g i)) ;; (Diff D i) =
+    (BinDirectSumIndAr A (Diff C1 i) (Diff C2 i) B1 B2)
       ;; (FromBinDirectSum A B2 (MMor f (i + 1)) (MMor g (i + 1))).
   Proof.
     cbn.
@@ -560,8 +561,8 @@ Section def_complexes.
     let B1 := to_BinDirectSums A (C1 i) (C2 i) in
     let B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1)) in
     (ToBinDirectSum A B1 (MMor f i) (MMor g i))
-      ;; (BinDirectSumIndAr A (@Diff C1 i) (@Diff C2 i) B1 B2) =
-    (@Diff D i) ;; (ToBinDirectSum A B2 (MMor f (i + 1)) (MMor g (i + 1))).
+      ;; (BinDirectSumIndAr A (Diff C1 i) (Diff C2 i) B1 B2) =
+    (Diff D i) ;; (ToBinDirectSum A B2 (MMor f (i + 1)) (MMor g (i + 1))).
   Proof.
     intros B1 B2.
     rewrite BinDirectSumIndArEq1.
@@ -649,8 +650,8 @@ Section def_complexes.
   Defined.
 
   Local Lemma ObjectMorToComplexMor_comm {a b : ob A} (f : a --> b) (i : hz) :
-    Π i0 : hz, (ObjectMorToComplexMor_mors f i i0) ;; (@Diff (ComplexFromObject b i) i0) =
-               (@Diff (ComplexFromObject a i) i0) ;; (ObjectMorToComplexMor_mors f i (i0 + 1)).
+    Π i0 : hz, (ObjectMorToComplexMor_mors f i i0) ;; (Diff (ComplexFromObject b i) i0) =
+               (Diff (ComplexFromObject a i) i0) ;; (ObjectMorToComplexMor_mors f i (i0 + 1)).
   Proof.
     intros i0.
     unfold ComplexFromObject. unfold ComplexFromObject_mors. unfold ComplexFromObject_obs. cbn.
@@ -771,13 +772,13 @@ Section def_complexes.
     induction (isdecrelhzeq i i0) as [e | n].
     + induction e. exact f.
     + induction (isdecrelhzeq (i + 1) i0) as [e' | n'].
-      * induction e'. exact (f ;; (Diff i)).
+      * induction e'. exact (f ;; (Diff C i)).
       * apply (ZeroArrow (Additive.to_Zero A)).
   Defined.
 
   Local Lemma FromComplex2FromObject_comm {a : ob A} {C : Complex} {i : hz} (f : a --> (C i)) :
-    Π i0 : hz, (FromComplex2FromObject_mors f i0) ;; (@Diff C i0) =
-               (@Diff (Complex2FromObject a i) i0) ;; (FromComplex2FromObject_mors f (i0 + 1)).
+    Π i0 : hz, (FromComplex2FromObject_mors f i0) ;; (Diff C i0) =
+               (Diff (Complex2FromObject a i) i0) ;; (FromComplex2FromObject_mors f (i0 + 1)).
   Proof.
     intros i0.
     unfold Complex2FromObject. unfold Complex2FromObject_obs. unfold Complex2FromObject_mors.
@@ -830,7 +831,7 @@ Section def_complexes.
     induction (isdecrelhzeq (i - 1) i0) as [e | n].
     - induction (isdecrelhzeq i (i - 1 + 1)) as [e' | n'].
       + eapply compose.
-        * induction e. exact (Diff (i - 1)).
+        * induction e. exact (Diff C (i - 1)).
         * induction e'. exact f.
       + apply fromempty. apply n'. apply pathsinv0. apply (hzrminusplus i 1).
     - induction (isdecrelhzeq (i - 1 + 1) i0) as [e' | n'].
@@ -842,8 +843,8 @@ Section def_complexes.
   Defined.
 
   Local Lemma ToComplex2FromObject_comm {a : ob A} {C : Complex} {i : hz} (f : (C i) --> a) :
-    Π i0 : hz, (ToComplex2FromObject_mors f i0) ;; (@Diff (Complex2FromObject a (i - 1)) i0) =
-               (@Diff C i0) ;; (ToComplex2FromObject_mors f (i0 + 1)).
+    Π i0 : hz, (ToComplex2FromObject_mors f i0) ;; (Diff (Complex2FromObject a (i - 1)) i0) =
+               (Diff C i0) ;; (ToComplex2FromObject_mors f (i0 + 1)).
   Proof.
     intros i0.
     unfold Complex2FromObject. unfold Complex2FromObject_obs. unfold Complex2FromObject_mors.

--- a/UniMath/CategoryTheory/Complexes.v
+++ b/UniMath/CategoryTheory/Complexes.v
@@ -1,0 +1,1906 @@
+(** * The category of complexes over an additive category *)
+(** ** Contents
+ - Definition of complexes [def_complexes]
+   - Complexes and morphisms between complexes
+   - Direct sum of complexes
+   - Construction of some complexes from objects
+ - The precategory of complexes over an additive precategory [complexes_precategory]
+ - The precategory of complexes over an additive precategory is an additive category,
+   [complexes_additive]
+ - Precategory of complexes over an abelian category is abelian [complexes_abelian]
+*)
+Require Import UniMath.Foundations.Basics.UnivalenceAxiom.
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.Foundations.Algebra.Monoids_and_Groups.
+
+Require Import UniMath.Foundations.NumberSystems.NaturalNumbers.
+Require Import UniMath.Foundations.NumberSystems.Integers.
+
+Require Import UniMath.CategoryTheory.total2_paths.
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+
+Require Import UniMath.CategoryTheory.limits.zero.
+Require Import UniMath.CategoryTheory.limits.binproducts.
+Require Import UniMath.CategoryTheory.limits.bincoproducts.
+Require Import UniMath.CategoryTheory.limits.equalizers.
+Require Import UniMath.CategoryTheory.limits.coequalizers.
+Require Import UniMath.CategoryTheory.limits.kernels.
+Require Import UniMath.CategoryTheory.limits.cokernels.
+Require Import UniMath.CategoryTheory.limits.pushouts.
+Require Import UniMath.CategoryTheory.limits.pullbacks.
+Require Import UniMath.CategoryTheory.limits.BinDirectSums.
+Require Import UniMath.CategoryTheory.Monics.
+Require Import UniMath.CategoryTheory.Epis.
+
+Require Import UniMath.CategoryTheory.PrecategoriesWithBinOps.
+Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
+Require Import UniMath.CategoryTheory.PreAdditive.
+Require Import UniMath.CategoryTheory.Additive.
+Require Import UniMath.CategoryTheory.Abelian.
+Require Import UniMath.CategoryTheory.AbelianToAdditive.
+
+
+(** ** Introduction
+   A complex consists of an objects C_i, for every integer i, and a morphism C_i --> C_{i+1} for
+   every i, such that composition of two such morphisms is the zero morphism. One visualizes
+   complexes as
+                            ... --> C_{i-1} --> C_i --> C_{i+1} --> ...
+   A morphism of complexes from a complex C to a complex D is a collection of morphisms C_i --> D_i
+   for every integer i, such that for every i the following diagram is commutative
+                                 C_i --> C_{i+1}
+                                  |        |
+                                 D_i --> D_{i+1}
+
+   Composition of morphisms is defined as pointwise composition. It is easy to check that this forms
+   a morphisms of complexes. Identity morphism is indexwise identity.
+
+     The direct sum of complexes is given by taking pointwise direct sum of the underlying objects.
+   The morphisms between the objects in direct sum complex is given by the following formula
+                 Pr1 ;; (C_i --> C_{i+1]) ;; In1 + Pr2 ;; (D_i --> D_{i+1}) ;; In2
+   Again, it is easy to check that this is well defined. Clearly, the zero complex is given by zero
+   objects and zero morphisms. To show that this defines a direct sum in the category of complexes
+   is straightforward.
+*)
+
+Open Scope hz_scope.
+Local Opaque hz isdecrelhzeq hzplus iscommrngops.
+
+(** * Definition of complexes *)
+Section def_complexes.
+
+  Variable A : Additive.
+
+  (** Complex *)
+  Definition Complex : UU :=
+    Σ D' : (Σ D : (Π i : hz, ob A), (Π i : hz, A⟦D i, D (hzplus i 1)⟧)),
+           Π i : hz, (pr2 D' i) ;; (pr2 D' (hzplus i 1)) = ZeroArrow (Additive.to_Zero A) _ _.
+
+  Definition mk_Complex (D : Π i : hz, ob A) (D' : Π i : hz, A⟦D i, D (hzplus i 1)⟧)
+             (D'' : Π i : hz, D' i ;; D' (hzplus i 1) = ZeroArrow (Additive.to_Zero A) _ _) :
+    Complex := ((D,,D'),,D'').
+
+  (** Accessor functions *)
+  Definition COb (C : Complex) (i : hz) : ob A := pr1 (pr1 C) i.
+
+  Definition CMor (C : Complex) (i : hz) : A⟦COb C i, COb C (hzplus i 1)⟧ := pr2 (pr1 C) i.
+
+  Definition CEq (C : Complex) (i : hz) :
+    (CMor C i) ;; (CMor C (hzplus i 1)) = ZeroArrow (Additive.to_Zero A) _ _ := pr2 C i.
+
+  (** Zero Complex *)
+  Definition ZeroComplex : Complex.
+  Proof.
+    use mk_Complex.
+    - intros i. exact (Additive.to_Zero A).
+    - intros i. exact (ZeroArrow (Additive.to_Zero A) _ _).
+    - intros i. apply ZeroArrowEq.
+  Defined.
+
+  (** Direct sum of two complexes *)
+  Local Lemma DirectSumComplex_comm (C1 C2 : Complex) (i : hz) :
+    let B1 := to_BinDirectSums A (COb C1 i) (COb C2 i) in
+    let B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1)) in
+    let B3 := to_BinDirectSums A (COb C1 (i + 1 + 1)) (COb C2 (i + 1 + 1)) in
+    (BinDirectSumIndAr A (CMor C1 i) (CMor C2 i) B1 B2)
+      ;; (BinDirectSumIndAr A (CMor C1 (i + 1)) (CMor C2 (i + 1)) B2 B3)  =
+    ZeroArrow (Additive.to_Zero A) B1 B3.
+  Proof.
+    cbn.
+    rewrite BinDirectSumIndArComp.
+    unfold BinDirectSumIndAr.
+    rewrite (CEq C1 i). rewrite ZeroArrow_comp_right.
+    rewrite (CEq C2 i). rewrite ZeroArrow_comp_right.
+    apply pathsinv0.
+    use ToBinDirectSumUnique.
+    - apply ZeroArrow_comp_left.
+    - apply ZeroArrow_comp_left.
+  Qed.
+
+  Definition DirectSumComplex (C1 C2 : Complex) : Complex.
+  Proof.
+    use mk_Complex.
+    - intros i. exact (to_BinDirectSums A (COb C1 i) (COb C2 i)).
+    - intros i. exact (BinDirectSumIndAr A (CMor C1 i) (CMor C2 i) _ _).
+    - intros i. exact (DirectSumComplex_comm C1 C2 i).
+  Defined.
+
+  (** Morphism of complexes *)
+  Definition Morphism (C1 C2 : Complex) : UU :=
+    Σ D : (Π i : hz, A⟦COb C1 i, COb C2 i⟧), Π i : hz, D i ;; CMor C2 i = CMor C1 i ;; D (i + 1).
+
+  Definition mk_Morphism (C1 C2 : Complex) (Mors : Π i : hz, A⟦COb C1 i, COb C2 i⟧)
+             (Comm : Π i : hz, Mors i ;; CMor C2 i = CMor C1 i ;; Mors (i + 1)) : Morphism C1 C2 :=
+    tpair _ Mors Comm.
+
+  (** Accessor functions *)
+  Definition MMor {C1 C2 : Complex} (M : Morphism C1 C2) (i : hz) : A⟦COb C1 i, COb C2 i⟧ :=
+    pr1 M i.
+
+  Definition MComm {C1 C2 : Complex} (M : Morphism C1 C2) (i : hz) :
+    MMor M i ;; CMor C2 i = CMor C1 i ;; MMor M (i + 1) := pr2 M i.
+
+  (** A lemma to show that two morphisms are the same *)
+  Lemma MorphismEq {C1 C2 : Complex} (M1 M2 : Morphism C1 C2)
+        (H : Π i : hz, MMor M1 i = MMor M2 i) : M1 = M2.
+  Proof.
+    use total2_paths.
+    - use funextsec. intros i. exact (H i).
+    - use proofirrelevance. apply impred_isaprop. intros t. apply to_has_homsets.
+  Qed.
+
+  Lemma MorphismEq' {C1 C2 : Complex} (M1 M2 : Morphism C1 C2) (H : M1 = M2) :
+    Π i : hz, MMor M1 i = MMor M2 i.
+  Proof.
+    induction H.
+    intros i.
+    apply idpath.
+  Qed.
+
+  (** The collection of morphism between two complexes is a set *)
+  Lemma Morphisms_isaset (C1 C2 : Complex) : isaset (Morphism C1 C2).
+  Proof.
+    apply isaset_total2.
+    - apply impred_isaset.
+      intros t. apply to_has_homsets.
+    - intros x. apply impred_isaset.
+      intros t. apply isasetaprop. apply to_has_homsets.
+  Qed.
+
+  Definition Morphisms_hSet (C1 C2 : Complex) : hSet := hSetpair _ (Morphisms_isaset C1 C2).
+
+  (** Identity Morphism *)
+  Local Lemma IdMorComm (C1 : Complex) (i : hz) :
+    identity (COb C1 i) ;; CMor C1 i = CMor C1 i ;; identity (COb C1 (i + 1)).
+  Proof.
+    rewrite id_left.
+    rewrite id_right.
+    apply idpath.
+  Qed.
+
+  Definition IdMor (C1 : Complex) : Morphism C1 C1.
+  Proof.
+    use mk_Morphism.
+    - intros i. exact (identity _).
+    - intros i. exact (IdMorComm C1 i).
+  Defined.
+
+  (** Morphisms from and to Zero complex *)
+  Local Lemma MorphismFromZero_comm (C : Complex) (i : hz) :
+    (ZeroArrow (Additive.to_Zero A) (Additive.to_Zero A) (COb C i)) ;; (CMor C i) =
+    (ZeroArrow (Additive.to_Zero A) (Additive.to_Zero A) (Additive.to_Zero A))
+      ;; (ZeroArrow (Additive.to_Zero A) (Additive.to_Zero A) (COb C (i + 1))).
+  Proof.
+    rewrite ZeroArrow_comp_left.
+    rewrite ZeroArrow_comp_left.
+    apply idpath.
+  Qed.
+
+  Definition MorphismFromZero (C : Complex) : Morphism ZeroComplex C.
+  Proof.
+    use mk_Morphism.
+    - intros i. exact (ZeroArrow (Additive.to_Zero A) _ _).
+    - intros i. exact (MorphismFromZero_comm C i).
+  Defined.
+
+  Local Lemma MorphismToZero_comm (C : Complex) (i : hz) :
+    (ZeroArrow (Additive.to_Zero A) (COb C i) (Additive.to_Zero A))
+      ;; (ZeroArrow (Additive.to_Zero A) (Additive.to_Zero A) (Additive.to_Zero A)) =
+    CMor C i ;; ZeroArrow (Additive.to_Zero A) (COb C (i + 1)) (Additive.to_Zero A).
+  Proof.
+    rewrite ZeroArrow_comp_right.
+    rewrite ZeroArrow_comp_right.
+    apply idpath.
+  Qed.
+
+  Definition MorphismToZero (C : Complex) : Morphism C ZeroComplex.
+  Proof.
+    use mk_Morphism.
+    - intros i. exact (ZeroArrow (Additive.to_Zero A) _ _).
+    - intros i. exact (MorphismToZero_comm C i).
+  Defined.
+
+  (** Composition of morphisms *)
+  Local Lemma MorphismCompComm {C1 C2 C3 : Complex} (M1 : Morphism C1 C2) (M2 : Morphism C2 C3)
+        (i : hz) :
+    MMor M1 i ;; MMor M2 i ;; CMor C3 i = CMor C1 i ;; (MMor M1 (i + 1) ;; MMor M2 (i + 1)).
+  Proof.
+    rewrite assoc.
+    rewrite <- (MComm M1).
+    rewrite <- assoc. rewrite <- assoc.
+    apply cancel_precomposition.
+    exact (MComm M2 i).
+  Qed.
+
+  Definition MorphismComp {C1 C2 C3 : Complex} (M1 : Morphism C1 C2) (M2 : Morphism C2 C3) :
+    Morphism C1 C3.
+  Proof.
+    use mk_Morphism.
+    - intros i. exact (MMor M1 i ;; MMor M2 i).
+    - intros i. exact (MorphismCompComm M1 M2 i).
+  Defined.
+
+  (** ZeroMorphism as the composite of to zero and from zero *)
+  Definition ComplexZeroMorphism (C1 C2 : Complex) : Morphism C1 C2 :=
+    MorphismComp (MorphismToZero C1) (MorphismFromZero C2).
+
+  (** ** Direct sums *)
+
+  (** Inclusions and projections from the DirectSumComplex *)
+  Local Lemma DirectSumComplexIn1_comm (C1 C2 : Complex) (i : hz) :
+    let B1 := to_BinDirectSums A (COb C1 i) (COb C2 i) in
+    let B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1)) in
+    to_In1 A B1 ;; BinDirectSumIndAr A (CMor C1 i) (CMor C2 i) B1 B2  = CMor C1 i ;; to_In1 A B2.
+  Proof.
+    cbn.
+    set (B1 := to_BinDirectSums A (COb C1 i) (COb C2 i)).
+    set (B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1))).
+    rewrite BinDirectSumIndArEq1.
+    unfold BinDirectSumIndArFormula.
+    rewrite to_premor_linear'.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
+    rewrite (to_IdIn1 A B1). rewrite (to_Unel1 A B1).
+    rewrite id_left. rewrite to_postmor_unel'. rewrite to_postmor_unel'.
+    rewrite to_runax'. apply idpath.
+  Qed.
+
+  Definition DirectSumComplexIn1 (C1 C2 : Complex) : Morphism C1 (DirectSumComplex C1 C2).
+  Proof.
+    use mk_Morphism.
+    - intros i. exact (to_In1 A (to_BinDirectSums A (COb C1 i) (COb C2 i))).
+    - intros i. exact (DirectSumComplexIn1_comm C1 C2 i).
+  Defined.
+
+  Local Lemma DirectSumComplexIn2_comm (C1 C2 : Complex) (i : hz) :
+    let B1 := to_BinDirectSums A (COb C1 i) (COb C2 i) in
+    let B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1)) in
+    to_In2 A B1 ;; BinDirectSumIndAr A (CMor C1 i) (CMor C2 i) B1 B2  = CMor C2 i ;; to_In2 A B2.
+  Proof.
+    cbn.
+    set (B1 := to_BinDirectSums A (COb C1 i) (COb C2 i)).
+    set (B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1))).
+    rewrite BinDirectSumIndArEq1.
+    unfold BinDirectSumIndArFormula.
+    rewrite to_premor_linear'. rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
+    rewrite (to_IdIn2 A B1). rewrite (to_Unel2 A B1).
+    rewrite id_left. rewrite to_postmor_unel'. rewrite to_postmor_unel'.
+    rewrite to_lunax'. apply idpath.
+  Qed.
+
+  Definition DirectSumComplexIn2 (C1 C2 : Complex) : Morphism C2 (DirectSumComplex C1 C2).
+  Proof.
+    use mk_Morphism.
+    - intros i. exact (to_In2 A (to_BinDirectSums A (COb C1 i) (COb C2 i))).
+    - intros i. exact (DirectSumComplexIn2_comm C1 C2 i).
+  Defined.
+
+  Local Lemma DirectSumComplexPr1_comm (C1 C2 : Complex) (i : hz) :
+    let B1 := to_BinDirectSums A (COb C1 i) (COb C2 i) in
+    let B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1)) in
+    to_Pr1 A B1 ;; CMor C1 i = (BinDirectSumIndAr A (CMor C1 i) (CMor C2 i) B1 B2) ;; (to_Pr1 A B2).
+  Proof.
+    cbn.
+    set (B1 := to_BinDirectSums A (COb C1 i) (COb C2 i)).
+    set (B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1))).
+    rewrite BinDirectSumIndArEq1.
+    unfold BinDirectSumIndArFormula.
+    rewrite to_postmor_linear'.
+    rewrite <- assoc. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
+    rewrite (to_IdIn1 A B2). rewrite (to_Unel2 A B2).
+    rewrite id_right. rewrite to_premor_unel'. rewrite to_premor_unel'.
+    rewrite to_runax'. apply idpath.
+  Qed.
+
+  Definition DirectSumComplexPr1 (C1 C2 : Complex) : Morphism (DirectSumComplex C1 C2) C1.
+  Proof.
+    use mk_Morphism.
+    - intros i. exact (to_Pr1 A (to_BinDirectSums A (COb C1 i) (COb C2 i))).
+    - intros i. exact (DirectSumComplexPr1_comm C1 C2 i).
+  Defined.
+
+  Local Lemma DirectSumComplexPr2_comm (C1 C2 : Complex) (i : hz) :
+    let B1 := to_BinDirectSums A (COb C1 i) (COb C2 i) in
+    let B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1)) in
+    to_Pr2 A B1 ;; CMor C2 i = (BinDirectSumIndAr A (CMor C1 i) (CMor C2 i) B1 B2) ;; (to_Pr2 A B2).
+  Proof.
+    cbn.
+    set (B1 := to_BinDirectSums A (COb C1 i) (COb C2 i)).
+    set (B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1))).
+    rewrite BinDirectSumIndArEq1.
+    unfold BinDirectSumIndArFormula.
+    rewrite to_postmor_linear'.
+    rewrite <- assoc. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
+    rewrite (to_IdIn2 A B2). rewrite (to_Unel1 A B2).
+    rewrite id_right. rewrite to_premor_unel'. rewrite to_premor_unel'.
+    rewrite to_lunax'. apply idpath.
+  Qed.
+
+  Definition DirectSumComplexPr2 (C1 C2 : Complex) : Morphism (DirectSumComplex C1 C2) C2.
+  Proof.
+    use mk_Morphism.
+    - intros i. exact (to_Pr2 A (to_BinDirectSums A (COb C1 i) (COb C2 i))).
+    - intros i. exact (DirectSumComplexPr2_comm C1 C2 i).
+  Defined.
+
+  (** The equations for composing in1, in2, pr1, and pr2. *)
+  Lemma DirectSumIdIn1 (C1 C2 : Complex) :
+    IdMor C1 = MorphismComp (DirectSumComplexIn1 C1 C2) (DirectSumComplexPr1 C1 C2).
+  Proof.
+    use MorphismEq.
+    intros i. cbn.
+    set (B := to_BinDirectSums A (COb C1 i) (COb C2 i)).
+    rewrite (to_IdIn1 A B).
+    apply idpath.
+  Qed.
+
+  Lemma DirectSumIdIn2 (C1 C2 : Complex) :
+    IdMor C2 = MorphismComp (DirectSumComplexIn2 C1 C2) (DirectSumComplexPr2 C1 C2).
+  Proof.
+    use MorphismEq.
+    intros i. cbn.
+    set (B := to_BinDirectSums A (COb C1 i) (COb C2 i)).
+    rewrite (to_IdIn2 A B).
+    apply idpath.
+  Qed.
+
+  Lemma DirectSumUnit1 (C1 C2 : Complex) :
+    MorphismComp (DirectSumComplexIn1 C1 C2) (DirectSumComplexPr2 C1 C2) =
+    ComplexZeroMorphism C1 C2.
+  Proof.
+    use MorphismEq.
+    intros i. cbn.
+    set (B := to_BinDirectSums A (COb C1 i) (COb C2 i)).
+    rewrite (to_Unel1 A B).
+    rewrite ZeroArrow_comp_left.
+    apply PreAdditive_unel_zero.
+  Qed.
+
+  Lemma DirectSumUnit2 (C1 C2 : Complex) :
+    MorphismComp (DirectSumComplexIn2 C1 C2) (DirectSumComplexPr1 C1 C2) =
+    ComplexZeroMorphism C2 C1.
+  Proof.
+    use MorphismEq.
+    intros i. cbn.
+    set (B := to_BinDirectSums A (COb C1 i) (COb C2 i)).
+    rewrite (to_Unel2 A B).
+    rewrite ZeroArrow_comp_left.
+    apply PreAdditive_unel_zero.
+  Qed.
+
+  (** Additition of morphisms is pointwise addition *)
+  Local Lemma MorphismOpComm {C1 C2 : Complex} (M1 M2 : Morphism C1 C2)  (i : hz) :
+    to_binop (COb C1 i) (COb C2 i) (MMor M1 i) (MMor M2 i) ;; CMor C2 i =
+    CMor C1 i ;; to_binop (COb C1 (i + 1)) (COb C2 (i + 1)) (MMor M1 (i + 1)) (MMor M2 (i + 1)).
+  Proof.
+    rewrite to_postmor_linear'. rewrite to_premor_linear'.
+    rewrite (MComm M1 i). rewrite (MComm M2 i). apply idpath.
+  Qed.
+
+  Definition MorphismOp {C1 C2 : Complex} (M1 M2 : Morphism C1 C2) : Morphism C1 C2.
+  Proof.
+    use mk_Morphism.
+    - intros i. exact (to_binop _ _ (MMor M1 i) (MMor M2 i)).
+    - intros i. exact (MorphismOpComm M1 M2 i).
+  Defined.
+
+  Lemma MorphismOp_isassoc (C1 C2 : Complex) : @isassoc (Morphisms_hSet C1 C2) MorphismOp.
+  Proof.
+    intros M1 M2 M3.
+    use MorphismEq.
+    intros i. cbn.
+    apply (assocax (to_abgrop (COb C1 i) (COb C2 i))).
+  Qed.
+
+  Lemma MorphismZeroComm (C1 C2 : Complex) (i : hz) :
+    ZeroArrow (Additive.to_Zero A) (COb C1 i) (COb C2 i) ;; CMor C2 i =
+    CMor C1 i ;; ZeroArrow (Additive.to_Zero A) (COb C1 (i + 1)) (COb C2 (i + 1)).
+  Proof.
+    rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_right. apply idpath.
+  Qed.
+
+  Definition MorphismZero (C1 C2 : Complex) : Morphism C1 C2.
+  Proof.
+    use mk_Morphism.
+    - intros i. exact (ZeroArrow (Additive.to_Zero A) _ _).
+    - intros i. exact (MorphismZeroComm C1 C2 i).
+  Defined.
+
+  Lemma MorphismOp_isunit (C1 C2 : Complex) :
+    @isunit (Morphisms_hSet C1 C2) MorphismOp (MorphismZero C1 C2).
+  Proof.
+    split.
+    - intros M.
+      use MorphismEq.
+      intros i. cbn. rewrite <- PreAdditive_unel_zero.
+      rewrite to_lunax'. apply idpath.
+    - intros M.
+      use MorphismEq.
+      intros i. cbn. rewrite <- PreAdditive_unel_zero.
+      rewrite to_runax'. apply idpath.
+  Qed.
+
+  Local Lemma MorphismOp_inv_comm (C1 C2 : Complex) (M : Morphism C1 C2) (i : hz) :
+    to_inv (COb C1 i) (COb C2 i) (MMor M i) ;; CMor C2 i =
+    CMor C1 i ;; to_inv (COb C1 (i + 1)) (COb C2 (i + 1)) (MMor M (i + 1)).
+  Proof.
+    rewrite <- PreAdditive_invlcomp.
+    rewrite <- PreAdditive_invrcomp.
+    apply PreAdditive_cancel_inv.
+    rewrite inv_inv_eq.
+    rewrite inv_inv_eq.
+    exact (MComm M i).
+  Qed.
+
+  Definition MorphismOp_inv (C1 C2 : Complex) (M : Morphism C1 C2) : Morphism C1 C2.
+  Proof.
+    use mk_Morphism.
+    - intros i. exact (to_inv (COb C1 i) (COb C2 i) (MMor M i)).
+    - intros i. exact (MorphismOp_inv_comm C1 C2 M i).
+  Defined.
+
+  Lemma MorphismOp_isinv (C1 C2 : Complex) :
+    @isinv (Morphisms_hSet C1 C2) MorphismOp (MorphismZero C1 C2) (MorphismOp_inv C1 C2).
+  Proof.
+    split.
+    - intros H.
+      use MorphismEq.
+      intros i. cbn.
+      rewrite (linvax A (MMor H i)).
+      apply PreAdditive_unel_zero.
+    - intros H.
+      use MorphismEq.
+      intros i. cbn.
+      rewrite (rinvax A (MMor H i)).
+      apply PreAdditive_unel_zero.
+  Qed.
+
+  Definition MorphismOp_iscomm (C1 C2 : Complex) : @iscomm (Morphisms_hSet C1 C2) MorphismOp.
+  Proof.
+    intros M1 M2.
+    use MorphismEq.
+    intros i. cbn.
+    apply (commax (to_abgrop (COb C1 i) (COb C2 i)) (MMor M1 i) (MMor M2 i)).
+  Qed.
+
+  Definition MorphismOp_isabgrop (C1 C2 : Complex) : @isabgrop (Morphisms_hSet C1 C2) MorphismOp.
+  Proof.
+    split.
+    - use isgroppair.
+      + split.
+        * exact (MorphismOp_isassoc C1 C2).
+        * use isunitalpair.
+          -- exact (MorphismZero C1 C2).
+          -- exact (MorphismOp_isunit C1 C2).
+      + use tpair.
+        * exact (MorphismOp_inv C1 C2).
+        * exact (MorphismOp_isinv C1 C2).
+    - exact (MorphismOp_iscomm C1 C2).
+  Defined.
+
+  (** pr1 ;; in1 + pr2 ;; in2 = id *)
+  Lemma DirectSumId (C1 C2 : Complex) :
+    MorphismOp (MorphismComp (DirectSumComplexPr1 C1 C2) (DirectSumComplexIn1 C1 C2))
+               (MorphismComp (DirectSumComplexPr2 C1 C2) (DirectSumComplexIn2 C1 C2)) =
+    IdMor (DirectSumComplex C1 C2).
+  Proof.
+    use MorphismEq.
+    intros i. cbn.
+    set (B := to_BinDirectSums A (COb C1 i) (COb C2 i)).
+    apply (to_BinOpId A B).
+  Qed.
+
+  (** The unique morphisms in and out of BinDirectSum *)
+  Local Lemma DirectSumMorOut_comm (C1 C2 D : Complex) (f : Morphism C1 D) (g : Morphism C2 D)
+        (i : hz) :
+    let B1 := to_BinDirectSums A (COb C1 i) (COb C2 i) in
+    let B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1)) in
+    FromBinDirectSum A B1 (MMor f i) (MMor g i) ;;  CMor D i =
+    (BinDirectSumIndAr A (CMor C1 i) (CMor C2 i) B1 B2)
+      ;; (FromBinDirectSum A B2 (MMor f (i + 1)) (MMor g (i + 1))).
+  Proof.
+    cbn.
+    set (B1 := to_BinDirectSums A (COb C1 i) (COb C2 i)).
+    set (B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1))).
+    rewrite BinDirectSumIndArEq1.
+    unfold BinDirectSumIndArFormula. cbn.
+    rewrite to_postmor_linear'.
+    rewrite <- assoc. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
+    rewrite BinDirectSumIn1Commutes.
+    rewrite BinDirectSumIn2Commutes.
+    rewrite <- (MComm f i).
+    rewrite <- (MComm g i).
+    rewrite assoc. rewrite assoc.
+    rewrite <- to_postmor_linear'.
+    apply cancel_postcomposition.
+    rewrite <- FromBinDirectSumFormulaUnique.
+    unfold FromBinDirectSumFormula.
+    apply idpath.
+  Qed.
+
+  Definition DirectSumMorOut (C1 C2 D: Complex) (f : Morphism C1 D) (g : Morphism C2 D) :
+    Morphism (DirectSumComplex C1 C2) D.
+  Proof.
+    use mk_Morphism.
+    - intros i. exact (FromBinDirectSum A _ (MMor f i) (MMor g i)).
+    - intros i. exact (DirectSumMorOut_comm C1 C2 D f g i).
+  Defined.
+
+  Local Lemma DirectSumMorIn_comm (C1 C2 D : Complex) (f : Morphism D C1) (g : Morphism D C2)
+        (i : hz) :
+    let B1 := to_BinDirectSums A (COb C1 i) (COb C2 i) in
+    let B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1)) in
+    (ToBinDirectSum A B1 (MMor f i) (MMor g i))
+      ;; (BinDirectSumIndAr A (CMor C1 i) (CMor C2 i) B1 B2) =
+    CMor D i ;; ToBinDirectSum A B2 (MMor f (i + 1)) (MMor g (i + 1)).
+  Proof.
+    cbn.
+    set (B1 := to_BinDirectSums A (COb C1 i) (COb C2 i)).
+    set (B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1))).
+    rewrite BinDirectSumIndArEq1.
+    unfold BinDirectSumIndArFormula.
+    rewrite to_premor_linear'.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
+    rewrite BinDirectSumPr1Commutes.
+    rewrite BinDirectSumPr2Commutes.
+    rewrite (MComm f i).
+    rewrite (MComm g i).
+    rewrite <- assoc. rewrite <- assoc.
+    rewrite <- to_premor_linear'.
+    apply cancel_precomposition.
+    rewrite <- ToBinDirectSumFormulaUnique.
+    unfold ToBinDirectSumFormula.
+    apply idpath.
+  Qed.
+
+  Definition DirectSumMorIn (C1 C2 D : Complex) (f : Morphism D C1) (g : Morphism D C2) :
+    Morphism D (DirectSumComplex C1 C2).
+  Proof.
+    use mk_Morphism.
+    - intros i. exact (ToBinDirectSum A _ (MMor f i) (MMor g i)).
+    - intros i. exact (DirectSumMorIn_comm C1 C2 D f g i).
+  Defined.
+
+
+  (** ** Construction of a complexes with one object *)
+  (** ... -> 0 -> X -> 0 -> ... *)
+
+  Definition ComplexFromObject_obs (X : ob A) (i : hz) : hz -> A.
+  Proof.
+    intros i0.
+    induction (isdecrelhzeq i i0) as [e | n].
+    - exact X.
+    - exact (Additive.to_Zero A).
+  Defined.
+
+  Definition ComplexFromObject_mors (X : ob A) (i : hz) :
+    Π i0 : hz, A ⟦ComplexFromObject_obs X i i0, ComplexFromObject_obs X i (i0 + 1)⟧.
+  Proof.
+    intros i0.
+    unfold ComplexFromObject_obs. unfold coprod_rect.
+    induction (isdecrelhzeq i i0) as [e | n].
+    - induction (isdecrelhzeq i (i0 + 1)) as [e' | n'].
+      + apply (fromempty (hzeqeisi e e')).
+      + apply (ZeroArrow (Additive.to_Zero A)).
+    - induction (isdecrelhzeq i (i0 + 1)) as [e' | n'].
+      + apply (ZeroArrow (Additive.to_Zero A)).
+      + apply (ZeroArrow (Additive.to_Zero A)).
+  Defined.
+
+  Local Lemma ComplexFromObject_comm (X : ob A) (i : hz) :
+    Π i0 : hz, ComplexFromObject_mors X i i0 ;; ComplexFromObject_mors X i (i0 + 1) =
+               ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    intros i0.
+    unfold ComplexFromObject_obs. unfold ComplexFromObject_mors. unfold coprod_rect. cbn.
+    induction (isdecrelhzeq i i0) as [e | n].
+    + induction (isdecrelhzeq i (i0 + 1)) as [e' | n'].
+      * apply (fromempty (hzeqeisi e e')).
+      * apply ZeroArrow_comp_left.
+    + induction (isdecrelhzeq i (i0 + 1)) as [e' | n'].
+      * apply ZeroArrow_comp_left.
+      * apply ZeroArrow_comp_left.
+  Qed.
+
+  Definition ComplexFromObject (X : ob A) (i : hz) : Complex.
+  Proof.
+    use mk_Complex.
+    - exact (ComplexFromObject_obs X i).
+    - exact (ComplexFromObject_mors X i).
+    - exact (ComplexFromObject_comm X i).
+  Defined.
+
+  (** A morphisms in A induces a morphisms of ComplexFromObjects *)
+  Definition ObjectMorToComplexMor_mors {a b : ob A} (f : a --> b) (i : hz) :
+    Π i0 : hz, A ⟦COb (ComplexFromObject a i) i0, COb (ComplexFromObject b i) i0⟧.
+  Proof.
+    intros i0.
+    unfold ComplexFromObject. cbn. unfold ComplexFromObject_obs. cbn. unfold coprod_rect.
+    induction (isdecrelhzeq i i0) as [e | n].
+    - exact f.
+    - apply (ZeroArrow (Additive.to_Zero A)).
+  Defined.
+
+  Local Lemma ObjectMorToComplexMor_comm {a b : ob A} (f : a --> b) (i : hz) :
+    Π i0 : hz, ObjectMorToComplexMor_mors f i i0 ;; CMor (ComplexFromObject b i) i0 =
+               CMor (ComplexFromObject a i) i0 ;; ObjectMorToComplexMor_mors f i (i0 + 1).
+  Proof.
+    intros i0.
+    unfold ComplexFromObject. unfold ComplexFromObject_mors. unfold ComplexFromObject_obs. cbn.
+    unfold ObjectMorToComplexMor_mors. cbn. unfold coprod_rect.
+    induction (isdecrelhzeq i i0) as [e | n].
+    - induction (isdecrelhzeq i (i0 + 1)) as [e' | n'].
+      + apply (fromempty (hzeqeisi e e')).
+      + rewrite ZeroArrow_comp_left. apply ZeroArrow_comp_right.
+    - induction (isdecrelhzeq i (i0 + 1)) as [e' | n'].
+      + rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_left. apply idpath.
+      + rewrite ZeroArrow_comp_left. apply idpath.
+  Qed.
+
+  Definition ObjectMorToComplexMor {a b : ob A} (f : a --> b) (i : hz) :
+    Morphism (ComplexFromObject a i) (ComplexFromObject b i).
+  Proof.
+    use mk_Morphism.
+    - exact (ObjectMorToComplexMor_mors f i).
+    - exact (ObjectMorToComplexMor_comm f i).
+  Defined.
+
+
+  (** ** Construction of a complex with 2 nonzero objects and morphisms to and from it *)
+
+  Definition Complex2FromObject_obs (a : ob A) (i : hz) : hz -> ob A.
+  Proof.
+    intros i0.
+    induction (isdecrelhzeq i i0) as [e | n].
+    - exact a.
+    - induction (isdecrelhzeq (i + 1) i0) as [e' | n'].
+      + exact a.
+      + exact (Additive.to_Zero A).
+  Defined.
+
+  Definition Complex2FromObject_mors (a : ob A) (i : hz) :
+    Π i0 : hz, A ⟦Complex2FromObject_obs a i i0, Complex2FromObject_obs a i (i0 + 1)⟧.
+  Proof.
+    intros i0. unfold Complex2FromObject_obs. cbn. unfold coprod_rect.
+    induction (isdecrelhzeq i i0) as [e | n].
+    + induction (isdecrelhzeq i (i0 + 1)) as [e' | n'].
+      * apply (fromempty (hzeqeisi e e')).
+      * induction (isdecrelhzeq (i + 1) (i0 + 1)) as [e'' | n''].
+        -- apply identity.
+        -- apply fromempty. apply n''. induction e. apply idpath.
+    + induction (isdecrelhzeq (i + 1) i0) as [e' | n'].
+      * induction (isdecrelhzeq i (i0 + 1)) as [e'' | n''].
+        -- apply fromempty. cbn in e'. rewrite <- e' in e''. apply (hzeqissi e'').
+        -- induction (isdecrelhzeq (i + 1) (i0 + 1)) as [e''' | n'''].
+           ++ cbn in e'. rewrite e' in e'''.
+              apply (fromempty (hzeqisi e''')).
+           ++ apply (ZeroArrow (Additive.to_Zero A)).
+      * induction (isdecrelhzeq i (i0 + 1)) as [e'' | n''].
+        -- apply (ZeroArrow (Additive.to_Zero A)).
+        -- induction (isdecrelhzeq (i + 1) (i0 + 1)) as [e''' | n'''].
+           ++ apply fromempty. apply n. apply (hzplusrcan _ _ 1). apply e'''.
+           ++ apply (ZeroArrow (Additive.to_Zero A)).
+  Defined.
+
+  Local Lemma Complex2FromObject_comm (a : ob A) (i : hz) :
+    Π i0 : hz, Complex2FromObject_mors a i i0 ;; Complex2FromObject_mors a i (i0 + 1) =
+               ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    intros i0.
+    unfold Complex2FromObject_obs. unfold Complex2FromObject_mors. unfold coprod_rect.
+    induction (isdecrelhzeq i i0) as [e | n].
+    - induction (isdecrelhzeq i (i0 + 1)) as [e' | n'].
+      + apply (fromempty (hzeqeisi e e')).
+      + induction (isdecrelhzeq (i + 1) (i0 + 1)) as [e'' | n''].
+        * rewrite id_left.
+          induction (isdecrelhzeq i (i0 + 1 + 1)) as [e''' | n'''].
+          -- apply (fromempty (hzeqeissi e e''')).
+          -- induction (isdecrelhzeq (i + 1) (i0 + 1 + 1)) as [e'''' | n''''].
+             ++ apply (fromempty (hzeqeisi e'' e'''')).
+             ++ apply idpath.
+        * apply fromempty. apply n''. cbn. cbn in e. rewrite e. apply idpath.
+    - induction (isdecrelhzeq (i + 1) i0) as [e' | n'].
+      + induction (isdecrelhzeq i (i0 + 1)) as [e'' | n''].
+        * apply (fromempty (hzeqsnmnsm e' e'')).
+        * induction (isdecrelhzeq (i + 1) (i0 + 1)) as [e''' | n'''].
+          -- apply (fromempty (hzeqeisi e' e''')).
+          -- induction (isdecrelhzeq i (i0 + 1 + 1)) as [e'''' | n''''].
+             ++ apply ZeroArrow_comp_left.
+             ++ induction (isdecrelhzeq (i + 1) (i0 + 1 + 1)) as [e5 | n5].
+                ** apply (fromempty (hzeqeissi e' e5)).
+                ** apply ZeroArrow_comp_left.
+      + induction (isdecrelhzeq i (i0 + 1)) as [e'' | n''].
+        * induction (isdecrelhzeq i (i0 + 1 + 1)) as [e3 | n3].
+          -- apply (fromempty (hzeqeisi e'' e3)).
+          -- induction (isdecrelhzeq (i + 1) (i0 + 1 + 1)) as [e4 | n4].
+             ++ apply ZeroArrow_comp_left.
+             ++ apply fromempty. apply n4. cbn in e''. rewrite e''. apply idpath.
+        * induction (isdecrelhzeq (i + 1) (i0 + 1)) as [e3 | n3].
+          -- apply fromempty. apply n. apply (hzplusrcan _ _ 1). apply e3.
+          -- induction (isdecrelhzeq i (i0 + 1 + 1)) as [e4 | n4].
+             ++ apply ZeroArrow_comp_left.
+             ++ induction (isdecrelhzeq (i + 1) (i0 + 1 + 1)) as [e5 | n5].
+                ** apply fromempty. apply n''. apply (hzplusrcan _ _ 1). apply e5.
+                ** apply ZeroArrow_comp_left.
+  Qed.
+
+  (** This constructs the complex ... --> 0 --> X -Id-> X --> 0 --> ... *)
+  Definition Complex2FromObject (a : ob A) (i : hz) : Complex.
+  Proof.
+    use mk_Complex.
+    - exact (Complex2FromObject_obs a i).
+    - exact (Complex2FromObject_mors a i).
+    - exact (Complex2FromObject_comm a i).
+  Defined.
+
+  (** *** Morphism from Complex2FromObject to complex *)
+
+  Definition FromComplex2FromObject_mors {a : ob A} (C : Complex) (i : hz) (f : a --> (COb C i)) :
+    Π i0 : hz, A ⟦ COb (Complex2FromObject a i) i0, COb C i0 ⟧.
+  Proof.
+    intros i0.
+    unfold Complex2FromObject. unfold Complex2FromObject_obs. unfold Complex2FromObject_mors. cbn.
+    unfold coprod_rect.
+    induction (isdecrelhzeq i i0) as [e | n].
+    + induction e. exact f.
+    + induction (isdecrelhzeq (i + 1) i0) as [e' | n'].
+      * induction e'. exact (f ;; (CMor C i)).
+      * apply (ZeroArrow (Additive.to_Zero A)).
+  Defined.
+
+  Local Lemma FromComplex2FromObject_comm {a : ob A} (C : Complex) (i : hz) (f : a --> (COb C i)) :
+    Π i0 : hz, FromComplex2FromObject_mors C i f i0 ;; CMor C i0 =
+               CMor (Complex2FromObject a i) i0 ;; FromComplex2FromObject_mors C i f (i0 + 1).
+  Proof.
+    intros i0.
+    unfold Complex2FromObject. unfold Complex2FromObject_obs. unfold Complex2FromObject_mors.
+    unfold FromComplex2FromObject_mors. cbn. unfold coprod_rect. cbn.
+    unfold paths_rect. cbn.
+    induction (isdecrelhzeq i i0) as [e | n].
+    + induction e.
+      induction (isdecrelhzeq i (i + 1)) as [e' | n'].
+      * apply (fromempty (hzeqisi e')).
+      * induction (isdecrelhzeq (i + 1) (i + 1)) as [e'' | n''].
+        -- rewrite id_left.
+           rewrite (pr1 (isasethz (i + 1) (i + 1) e'' (idpath (i + 1)))).
+           apply idpath.
+        -- apply (fromempty (n'' (idpath (i + 1)))).
+    + induction (isdecrelhzeq (i + 1) i0) as [e' | n'].
+      * induction e'. cbn.
+        induction (isdecrelhzeq i (i + 1 + 1)) as [e'' | n''].
+        -- apply (fromempty (hzeqissi e'')).
+        -- induction (isdecrelhzeq (i + 1) (i + 1 + 1)) as [e''' | n'''].
+           ++ apply (fromempty (hzeqisi e''')).
+           ++ rewrite <- assoc. rewrite (CEq C i). rewrite ZeroArrow_comp_left.
+              apply ZeroArrow_comp_right.
+      * induction (isdecrelhzeq i (i0 + 1)) as [e'' | n''].
+        -- rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_left. apply idpath.
+        -- induction (isdecrelhzeq (i + 1) (i0 + 1)) as [e''' | n'''].
+           ++ apply (fromempty (n (hzplusrcan i i0 1 e'''))).
+           ++ rewrite ZeroArrow_comp_right. apply ZeroArrow_comp_left.
+  Qed.
+
+  Definition FromComplex2FromObject {a : ob A} (C : Complex) (i : hz) (f : a --> (COb C i)) :
+    Morphism (Complex2FromObject a i) C.
+  Proof.
+    use mk_Morphism.
+    - exact (FromComplex2FromObject_mors C i f).
+    - exact (FromComplex2FromObject_comm C i f).
+  Defined.
+
+  Lemma FromComplex2FromObject_Eq1 {a : ob A} (C : Complex) (i i0 : hz) (g : a --> (COb C i)) :
+    FromComplex2FromObject_mors C i g i0 = MMor (FromComplex2FromObject C i g) i0.
+  Proof.
+    apply idpath.
+  Qed.
+
+  (** *** Morphism from complex to Complex2FromObject *)
+
+  Definition ToComplex2FromObject_mors {a : ob A} (C : Complex) (i : hz) (f : (COb C i) --> a) :
+    Π i0 : hz, A ⟦COb C i0, COb (Complex2FromObject a (i - 1)) i0⟧.
+  Proof.
+    intros i0. unfold Complex2FromObject. unfold Complex2FromObject_obs. cbn. unfold coprod_rect.
+    induction (isdecrelhzeq (i - 1) i0) as [e | n].
+    - induction (isdecrelhzeq i (i - 1 + 1)) as [e' | n'].
+      + eapply compose.
+        * induction e. exact (CMor C (i - 1)).
+        * induction e'. exact f.
+      + apply fromempty. apply n'. apply pathsinv0. apply (hzrminusplus i 1).
+    - induction (isdecrelhzeq (i - 1 + 1) i0) as [e' | n'].
+      + induction e'.
+        induction (isdecrelhzeq i (i - 1 + 1)) as [e'' | n''].
+        * induction e''. exact f.
+        * apply fromempty. apply n''. apply (hzrminusplus' i 1).
+      + apply (ZeroArrow (Additive.to_Zero A)).
+  Defined.
+
+  Local Lemma ToComplex2FromObject_comm {a : ob A} (C : Complex) (i : hz) (f : (COb C i) --> a) :
+    Π i0 : hz, ToComplex2FromObject_mors C i f i0 ;; CMor (Complex2FromObject a (i - 1)) i0 =
+               CMor C i0 ;; ToComplex2FromObject_mors C i f (i0 + 1).
+  Proof.
+    intros i0.
+    unfold Complex2FromObject. unfold Complex2FromObject_obs. unfold Complex2FromObject_mors.
+    unfold ToComplex2FromObject_mors. unfold coprod_rect. unfold paths_rect. cbn.
+    induction (isdecrelhzeq (i - 1) i0) as [e | n].
+    - induction e.
+      induction (isdecrelhzeq (i - 1 + 1) i) as [e' | n'].
+      + induction e'.
+        induction (isdecrelhzeq (i - 1)  (i - 1 + 1)) as [e'' | n''].
+        * apply fromempty. apply (hzeqisi e'').
+        * induction (isdecrelhzeq i (i - 1 + 1)) as [e''' | n'''].
+          -- rewrite isdecrelhzeqi. rewrite id_right.
+             apply cancel_precomposition. induction e'''.
+             exact (idpath f).
+          -- apply fromempty. apply n'''. apply (hzrminusplus' i 1).
+      + induction (isdecrelhzeq (i - 1)  (i - 1 + 1)) as [e'' | n''].
+        * apply fromempty. apply (hzeqisi e'').
+        * induction (isdecrelhzeq i (i - 1 + 1)) as [e''' | n'''].
+          -- rewrite isdecrelhzeqi. rewrite id_right.
+             apply cancel_precomposition.
+             induction e'''.
+             exact (idpath f).
+          -- apply fromempty. apply n'''. apply (hzrminusplus' i 1).
+    - induction (isdecrelhzeq (i - 1 + 1) i0) as [e' | n'].
+      + induction e'.
+        induction (isdecrelhzeq i (i - 1 + 1)) as [e'' | n''].
+        * induction (isdecrelhzeq (i - 1) (i - 1 + 1 + 1)) as [e''' | n'''].
+          -- apply fromempty. apply (hzeqissi e''').
+          -- induction (isdecrelhzeq (i - 1 + 1) (i - 1 + 1 + 1)) as [e'''' | n''''].
+             ++ apply fromempty. apply (hzeqisi e'''').
+             ++ rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_right.
+                apply idpath.
+        * apply (fromempty (n'' (hzrminusplus' i 1))).
+      + induction (isdecrelhzeq (i - 1) (i0 + 1)) as [e'' | n''].
+        * induction (isdecrelhzeq i (i - 1 + 1)) as [e''' | n'''].
+          -- rewrite assoc. rewrite ZeroArrow_comp_right.
+             set (mor := match e''' in (_ = y) return (A ⟦ COb C y, a ⟧) with
+                      | idpath _ => f
+                      end).
+             rewrite <- (ZeroArrow_comp_left _ _ _ _ _ mor). unfold mor. clear mor.
+             apply cancel_postcomposition. rewrite e''. apply (! (CEq C i0)).
+          -- apply fromempty. apply n'''. apply (hzrminusplus' i 1).
+        * induction (isdecrelhzeq (i - 1 + 1) (i0 + 1)) as [e''' | n'''].
+          -- apply (fromempty (n (hzplusrcan (i - 1) i0 1 e'''))).
+          -- rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_right.
+             apply idpath.
+  Qed.
+
+  Definition ToComplex2FromObject {a : ob A} (C : Complex) (i : hz) (f : (COb C i) --> a) :
+    Morphism C (Complex2FromObject a (i - 1)).
+  Proof.
+    use mk_Morphism.
+    - exact (ToComplex2FromObject_mors C i f).
+    - exact (ToComplex2FromObject_comm C i f).
+  Defined.
+
+  Lemma ToComplex2FromObject_Eq1 {a : ob A} (C : Complex) (i i0 : hz) (g : (COb C i ) --> a) :
+    ToComplex2FromObject_mors C i g i0 = MMor (ToComplex2FromObject C i g) i0.
+  Proof.
+    apply idpath.
+  Qed.
+
+End def_complexes.
+Arguments COb [A] _ _.
+Arguments CMor [A] _ _.
+Arguments ZeroComplex [A].
+Arguments Morphism [A] _ _.
+Arguments MorphismEq [A] [C1] [C2] _ _ _.
+Arguments MorphismFromZero [A] _.
+Arguments MorphismToZero [A] _.
+Arguments MMor [A] [C1] [C2] _ _.
+Arguments MComm [A] [C1] [C2] _ _.
+Arguments IdMor [A] _.
+Arguments MorphismComp [A] [C1] [C2] [C3] _ _.
+
+
+(** * The category of complexes
+     The precategory of complexes over an additive category consists of the following data:
+   - Objects are complexes over the additive category
+   - Morphisms are morphisms of complexes.
+*)
+Section complexes_precat.
+
+  Variable A : Additive.
+
+  Definition ComplexPreCat_ob_mor : precategory_ob_mor :=
+    tpair (fun ob : UU => ob -> ob -> UU) (Complex A) (fun C1 C2 : Complex A => Morphism C1 C2).
+
+  Definition ComplexPreCat_data : precategory_data :=
+    precategory_data_pair
+      ComplexPreCat_ob_mor (fun (C : Complex A) => IdMor C)
+      (fun (C1 C2 C3 : Complex A) (M1 : Morphism C1 C2) (M2 : Morphism C2 C3) => MorphismComp M1 M2).
+
+  Lemma is_precategory_ComplexPreCat_data : is_precategory ComplexPreCat_data.
+  Proof.
+    split.
+    - split.
+      + intros a b f.
+        use MorphismEq.
+        intros i. cbn.
+        apply id_left.
+      + intros a b f.
+        use MorphismEq.
+        intros i. cbn.
+        apply id_right.
+    - intros a b c d f g h.
+      use MorphismEq.
+      intros i. cbn.
+      apply assoc.
+  Qed.
+
+  Definition ComplexPreCat : precategory := tpair _ _ is_precategory_ComplexPreCat_data.
+
+  Lemma has_homsets_ComplexPreCat : has_homsets ComplexPreCat.
+  Proof.
+    intros C1 C2. cbn.
+    apply isaset_total2.
+    - apply impred_isaset.
+      intros t. apply to_has_homsets.
+    - intros x. apply impred_isaset.
+      intros t. apply isasetaprop. apply to_has_homsets.
+  Qed.
+
+
+  (** ** Monic of complexes is indexwise monic *)
+
+  Local Lemma ComplexMonicIndexMonic_eq {C1 C2 : Complex A} (M : Monic ComplexPreCat C1 C2) (i : hz)
+        (a : A) (g h : A ⟦a, COb C1 i⟧)
+        (H : g ;; MMor (MonicArrow _ M) i = h ;; MMor (MonicArrow _ M) i) :
+    FromComplex2FromObject_mors A C1 i g i = FromComplex2FromObject_mors A C1 i h i.
+  Proof.
+    use (pathscomp0 (FromComplex2FromObject_Eq1 A C1 i i g)).
+    use (pathscomp0 _ (! (FromComplex2FromObject_Eq1 A C1 i i h))).
+    use MorphismEq'.
+    use (MonicisMonic ComplexPreCat M). cbn.
+    use MorphismEq.
+    intros i0. cbn.
+    unfold FromComplex2FromObject_mors. unfold coprod_rect. unfold Complex2FromObject_obs. cbn.
+    induction (isdecrelhzeq i i0) as [T | F].
+    - induction T. exact H.
+    - induction (isdecrelhzeq (i + 1) i0) as [T' | F'].
+      + induction T'. cbn. rewrite <- assoc. rewrite <- assoc. rewrite <- MComm.
+        rewrite assoc. rewrite assoc. apply cancel_postcomposition.
+        exact H.
+      + apply idpath.
+  Qed.
+
+  Lemma ComplexMonicIndexMonic {C1 C2 : Complex A} (M : Monic ComplexPreCat C1 C2) :
+    Π i : hz, isMonic (@MMor A C1 C2 (MonicArrow _ M) i).
+  Proof.
+    intros i a g h H.
+    set (tmp := ComplexMonicIndexMonic_eq M i a g h H).
+    unfold FromComplex2FromObject_mors in tmp. cbn in tmp.
+    unfold coprod_rect in tmp. unfold Complex2FromObject_obs in tmp.
+    unfold paths_rect in tmp. cbn in tmp.
+    rewrite (isdecrelhzeqi i) in tmp.
+    exact tmp.
+  Qed.
+
+
+  (** ** Epi of complexes is indexwise epi *)
+
+  Local Lemma ComplexEpiIndexEpi_eq {C1 C2 : Complex A} (E : Epi ComplexPreCat C1 C2) (i : hz)
+        (a : A) (g h : A ⟦ COb C2 i, a ⟧)
+        (H : MMor (EpiArrow _ E) i ;; g = MMor (EpiArrow _ E) i ;; h) :
+    ToComplex2FromObject_mors A C2 i g i = ToComplex2FromObject_mors A C2 i h i.
+  Proof.
+    use (pathscomp0 (ToComplex2FromObject_Eq1 A C2 i i g)).
+    use (pathscomp0 _ (! (ToComplex2FromObject_Eq1 A C2 i i h))).
+    use MorphismEq'.
+    use (EpiisEpi ComplexPreCat E). cbn.
+    use MorphismEq.
+    intros i0. cbn.
+    unfold ToComplex2FromObject_mors. unfold coprod_rect. unfold Complex2FromObject_obs. cbn.
+    induction (isdecrelhzeq (i - 1) i0) as [T | F].
+    - induction T.
+      induction (isdecrelhzeq i (i - 1 + 1)) as [e' | n'].
+      + unfold paths_rect. rewrite assoc. rewrite assoc.
+        rewrite (MComm (EpiArrow _ E)). rewrite <- assoc. rewrite <- assoc.
+        apply cancel_precomposition. induction e'. exact H.
+      + apply (fromempty (n' (! hzrminusplus i 1))).
+    - induction (isdecrelhzeq (i - 1 + 1) i0) as [e' | n'].
+      + unfold paths_rect. induction e'.
+        induction (isdecrelhzeq i (i - 1 + 1)) as [e'' | n''].
+        * induction e''. apply H.
+        * apply (fromempty (n'' (hzrminusplus' i 1))).
+      + apply idpath.
+  Qed.
+
+  Lemma ComplexEpiIndexEpi {C1 C2 : Complex A} (E : Epi ComplexPreCat C1 C2) :
+    Π i : hz, isEpi (@MMor A C1 C2 (EpiArrow _ E) i).
+  Proof.
+    intros i a g h H.
+    set (tmp := ComplexEpiIndexEpi_eq E i a g h H).
+    unfold ToComplex2FromObject_mors in tmp. cbn in tmp.
+    unfold coprod_rect in tmp. unfold Complex2FromObject_obs in tmp.
+    unfold paths_rect in tmp. cbn in tmp.
+    rewrite (isdecrelhzeqminusplus i) in tmp.
+    rewrite (isdecrelhzeqminusplus' i) in tmp.
+    rewrite (isdecrelhzeqpii i) in tmp.
+    induction (hzrminusplus i 1).
+    induction (hzrminusplus' i 1).
+    exact tmp.
+  Qed.
+
+End complexes_precat.
+
+
+(** * The category of complexes over Additive is Additive *)
+Section complexes_additive.
+
+  Variable A : Additive.
+
+  Definition ComplexPreCat_PrecategoryWithBinOps : PrecategoryWithBinOps.
+  Proof.
+    use mk_PrecategoryWithBinOps.
+    - exact (ComplexPreCat A).
+    - intros x y. exact (MorphismOp A).
+  Defined.
+
+  Definition ComplexPreCat_PrecategoryWithAbgrops : PrecategoryWithAbgrops.
+  Proof.
+    use mk_PrecategoryWithAbgrops.
+    - exact ComplexPreCat_PrecategoryWithBinOps.
+    - exact (has_homsets_ComplexPreCat A).
+    - intros x y. exact (MorphismOp_isabgrop A x y).
+  Defined.
+
+  Lemma ComplexPreCat_isPreAdditive : isPreAdditive ComplexPreCat_PrecategoryWithAbgrops.
+  Proof.
+    split.
+    - intros x y z f.
+      split.
+      + intros g h.
+        use MorphismEq.
+        intros i.
+        apply to_premor_linear'.
+      + use MorphismEq.
+        intros i. cbn.
+        apply ZeroArrow_comp_right.
+    - intros x y z f.
+      split.
+      + intros g h.
+        use MorphismEq.
+        intros i.
+        apply to_postmor_linear'.
+      + use MorphismEq.
+        intros i. cbn.
+        apply ZeroArrow_comp_left.
+  Qed.
+
+  Lemma ComplexPreCat_PreAdditive : PreAdditive.
+  Proof.
+    use mk_PreAdditive.
+    - exact ComplexPreCat_PrecategoryWithAbgrops.
+    - exact ComplexPreCat_isPreAdditive.
+  Defined.
+
+  Lemma ComplexPreCat_isZero : isZero ComplexPreCat_PreAdditive ZeroComplex.
+  Proof.
+    split.
+    - intros C.
+      use tpair.
+      + exact (MorphismFromZero C).
+      + cbn. intros t.
+        use MorphismEq.
+        intros i. cbn.
+        apply ArrowsFromZero.
+    - intros C.
+      use tpair.
+      + exact (MorphismToZero C).
+      + cbn. intros t.
+        use MorphismEq.
+        intros i. cbn.
+        apply ArrowsToZero.
+  Qed.
+
+  Lemma ComplexPreCat_isBinCoproductCocone (C1 C2 : Complex A) :
+    isBinCoproductCocone ComplexPreCat_PreAdditive C1 C2 (DirectSumComplex A C1 C2)
+                         (DirectSumComplexIn1 A C1 C2) (DirectSumComplexIn2 A C1 C2).
+  Proof.
+    use mk_isBinCoproductCocone.
+    - apply has_homsets_ComplexPreCat.
+    - intros D f g.
+      use unique_exists.
+      + exact (DirectSumMorOut A C1 C2 D f g).
+      (* Commutativity *)
+      + split.
+        * use MorphismEq.
+          intros i. cbn.
+          apply BinDirectSumIn1Commutes.
+        * use MorphismEq.
+          intros i. cbn.
+          apply BinDirectSumIn2Commutes.
+      + intros y. apply isapropdirprod.
+        * apply has_homsets_ComplexPreCat.
+        * apply has_homsets_ComplexPreCat.
+      + intros y T. cbn beta in T.
+        use MorphismEq.
+        intros i. cbn.
+        use FromBinDirectSumUnique.
+        * rewrite <- (pr1 T). apply idpath.
+        * rewrite <- (pr2 T). apply idpath.
+  Qed.
+
+  Lemma ComplexPreCat_isBinProductCone (C1 C2 : Complex A) :
+    isBinProductCone ComplexPreCat_PreAdditive C1 C2 (DirectSumComplex A C1 C2)
+                     (DirectSumComplexPr1 A C1 C2) (DirectSumComplexPr2 A C1 C2).
+  Proof.
+    use mk_isBinProductCone.
+    - apply has_homsets_ComplexPreCat.
+    - intros D f g.
+      use unique_exists.
+      + exact (DirectSumMorIn A C1 C2 D f g).
+      (* Commutativity *)
+      + split.
+        * use MorphismEq.
+          intros i. cbn.
+          apply BinDirectSumPr1Commutes.
+        * use MorphismEq.
+          intros i. cbn.
+          apply BinDirectSumPr2Commutes.
+      + intros y. apply isapropdirprod.
+        * apply has_homsets_ComplexPreCat.
+        * apply has_homsets_ComplexPreCat.
+      + intros y T. cbn beta in T.
+        use MorphismEq.
+        intros i. cbn.
+        use ToBinDirectSumUnique.
+        * rewrite <- (pr1 T). apply idpath.
+        * rewrite <- (pr2 T). apply idpath.
+  Qed.
+
+  Lemma ComplexPreCat_ZeroEq (C1 C2 : Complex A) :
+    ComplexZeroMorphism A C1 C2 = MorphismZero A C1 C2.
+  Proof.
+    use MorphismEq.
+    intros i. cbn.
+    apply ZeroArrow_comp_left.
+  Qed.
+
+  Lemma ComplexPreCat_isBinDirectSumCone (C1 C2 : Complex A) :
+    isBinDirectSumCone
+      ComplexPreCat_PreAdditive C1 C2 (DirectSumComplex A C1 C2) (DirectSumComplexIn1 A C1 C2)
+      (DirectSumComplexIn2 A C1 C2) (DirectSumComplexPr1 A C1 C2) (DirectSumComplexPr2 A C1 C2).
+  Proof.
+    use mk_isBinDirectSumCone.
+    - exact (ComplexPreCat_isBinCoproductCocone C1 C2).
+    - exact (ComplexPreCat_isBinProductCone C1 C2).
+    - apply (! (DirectSumIdIn1 A C1 C2)).
+    - apply (! (DirectSumIdIn2 A C1 C2)).
+    - cbn. rewrite (DirectSumUnit1 A C1 C2). apply ComplexPreCat_ZeroEq.
+    - cbn. rewrite (DirectSumUnit2 A C1 C2). apply ComplexPreCat_ZeroEq.
+    - apply (DirectSumId A C1 C2).
+  Qed.
+
+  (** The category of complexes over an additive category is additive *)
+  Definition ComplexPreCat_Additive : Additive.
+  Proof.
+    use mk_Additive.
+    - exact ComplexPreCat_PreAdditive.
+    - use mk_isAdditive.
+      + use mk_Zero.
+        * exact ZeroComplex.
+        * exact ComplexPreCat_isZero.
+      + intros C1 C2.
+        use (mk_BinDirectSumCone ComplexPreCat_PreAdditive).
+        * exact (DirectSumComplex A C1 C2).
+        * exact (DirectSumComplexIn1 A C1 C2).
+        * exact (DirectSumComplexIn2 A C1 C2).
+        * exact (DirectSumComplexPr1 A C1 C2).
+        * exact (DirectSumComplexPr2 A C1 C2).
+        * exact (ComplexPreCat_isBinDirectSumCone C1 C2).
+  Defined.
+
+End complexes_additive.
+
+
+(** * Complexes over Abelian is Abelian *)
+Section complexes_abelian.
+
+  Variable A : AbelianPreCat.
+  Variable hs : has_homsets A.
+
+  (** ** Kernels in Complexes over Abelian *)
+  (** *** Construction of the kernel object *)
+
+  Local Lemma ComplexPreCat_Kernel_moreq {Y Z : Complex (AbelianToAdditive A hs)} (g : Morphism Y Z)
+        (i : hz) : KernelArrow (Kernel (MMor g i)) ;; CMor Y i ;; MMor g (i + 1) =
+                   ZeroArrow (@to_Zero A) (Kernel (MMor g i)) (COb Z (i + 1)).
+  Proof.
+    rewrite <- assoc. cbn. set (tmp := MComm g i). cbn in tmp. rewrite <- tmp. clear tmp.
+    rewrite assoc. rewrite KernelCompZero. apply ZeroArrow_comp_left.
+  Qed.
+
+  Local Lemma ComplexPreCat_Kernel_comp {Y Z : Complex (AbelianToAdditive A hs)} (g : Morphism Y Z)
+        (i : hz) :
+    KernelIn (@to_Zero A) (Kernel (MMor g (i + 1))) (Kernel (MMor g i))
+             (KernelArrow (Kernel (MMor g i)) ;; CMor Y i)
+             (ComplexPreCat_Kernel_moreq g i) ;;
+             KernelIn (@to_Zero A) (Kernel (MMor g (i + 1 + 1))) (Kernel (MMor g (i + 1)))
+             (KernelArrow (Kernel (MMor g (i + 1))) ;; CMor Y (i + 1))
+             (ComplexPreCat_Kernel_moreq g (i + 1)) =
+    ZeroArrow (@to_Zero A) (Kernel (MMor g i)) (Kernel (MMor g (i + 1 + 1))).
+  Proof.
+    apply KernelArrowisMonic. rewrite ZeroArrow_comp_left.
+    rewrite <- assoc. rewrite KernelCommutes. rewrite assoc. rewrite KernelCommutes.
+    rewrite <- assoc. set (tmp := CEq _ Y i). cbn in tmp. rewrite tmp. clear tmp.
+    rewrite ZeroArrow_comp_right. apply idpath.
+  Qed.
+
+  Definition ComplexPreCat_Kernel {Y Z : Complex (AbelianToAdditive A hs)} (g : Morphism Y Z) :
+    ComplexPreCat (AbelianToAdditive A hs).
+  Proof.
+    use mk_Complex.
+    - intros i. exact (Kernel (MMor g i)).
+    - intros i. cbn. use KernelIn.
+      + exact (KernelArrow (Kernel (MMor g i)) ;; CMor Y i).
+      + exact (ComplexPreCat_Kernel_moreq g i).
+    - intros i. exact (ComplexPreCat_Kernel_comp g i).
+  Defined.
+
+  (** *** Construction of the KernelArrow *)
+  Local Lemma ComplexPreCat_KernelArrow_eq (Y Z : Complex (AbelianToAdditive A hs))
+        (g : Morphism Y Z) (i : hz) :
+    KernelArrow (Kernel (MMor g i)) ;; CMor Y i =
+    KernelIn (@to_Zero A) (Kernel (MMor g (i + 1))) (Kernel (MMor g i))
+             (KernelArrow (Kernel (MMor g i)) ;; CMor Y i)
+             (ComplexPreCat_Kernel_moreq g i) ;;
+             KernelArrow (Kernel (MMor g (i + 1))).
+  Proof.
+    rewrite KernelCommutes. apply idpath.
+  Qed.
+
+  Definition ComplexPreCat_KernelArrow {Y Z : Complex (AbelianToAdditive A hs)}
+             (g : Morphism Y Z) : Morphism (ComplexPreCat_Kernel g) Y.
+  Proof.
+    use mk_Morphism.
+    - intros i. use KernelArrow.
+    - intros i. use ComplexPreCat_KernelArrow_eq.
+  Defined.
+
+
+  (** *** isEqualizer  *)
+  Local Lemma ComplexPreCat_Kernels_comp {X Y : Complex (AbelianToAdditive A hs)}
+        (g : Morphism X Y) :
+    let Z := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                      ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs)) in
+    MorphismComp (ComplexPreCat_KernelArrow g) g =
+    MorphismComp (ZeroArrowTo (ComplexPreCat_Kernel g)) (@ZeroArrowFrom _ Z Y).
+  Proof.
+    use MorphismEq.
+    intros i. cbn. rewrite KernelCompZero. apply pathsinv0. apply ZeroArrowEq.
+  Qed.
+
+  Local Lemma ComplexPreCat_KernelIn_comp {X Y w : Complex (AbelianToAdditive A hs)} (g : Morphism X Y)
+    (h : Morphism w X) (i : hz) :
+    let Z := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                      ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs)) in
+    MorphismComp h g = ZeroArrow Z w Y ->
+    MMor h i ;; MMor g i = ZeroArrow to_Zero (COb w i) (COb Y i).
+  Proof.
+    intros Z H.
+    set (tmp := MorphismEq' _ (MorphismComp h g) (ZeroArrow Z _ _) H i). cbn in tmp.
+    cbn. rewrite tmp. clear tmp. apply ZeroArrowEq.
+  Qed.
+
+  Definition ComplexPreCat_KernelIn {X Y w : Complex (AbelianToAdditive A hs)} (g : Morphism X Y)
+    (h : Morphism w X) :
+    let Z := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                      ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs)) in
+    MorphismComp h g = ZeroArrow Z w Y ->
+    (ComplexPreCat (AbelianToAdditive A hs)) ⟦w, ComplexPreCat_Kernel g⟧.
+  Proof.
+    cbn.
+    set (Z := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                       ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs))).
+    intros H.
+    use mk_Morphism.
+    - intros i. cbn. use KernelIn.
+      + exact (MMor h i).
+      + apply (ComplexPreCat_KernelIn_comp g h i H).
+    - intros i. cbn.
+      apply KernelArrowisMonic.
+      rewrite <- assoc. rewrite <- assoc. rewrite KernelCommutes. rewrite KernelCommutes.
+      rewrite assoc. rewrite KernelCommutes.
+      apply (MComm h i).
+  Defined.
+
+  Local Lemma ComplexPreCat_Kernels_isEqualizer {X Y : Complex (AbelianToAdditive A hs)}
+        (g : Morphism X Y) :
+    let Z := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                      ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs)) in
+    @equalizers.isEqualizer
+      (ComplexPreCat (AbelianToAdditive A hs)) _ _ _
+      g (MorphismComp (@ZeroArrowTo _ Z X) (@ZeroArrowFrom _ Z Y)) (ComplexPreCat_KernelArrow g)
+      (KernelEqRw Z (ComplexPreCat_Kernels_comp g)).
+  Proof.
+    cbn. set (Z := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                            ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs))).
+    use mk_isEqualizer.
+    intros w h H'. rewrite (@ZeroArrow_comp_right _ Z) in H'.
+    use unique_exists.
+    - exact (ComplexPreCat_KernelIn g h H').
+    - cbn. use MorphismEq. intros i. use KernelCommutes.
+    - intros y. apply has_homsets_ComplexPreCat.
+    - intros y T. cbn beta in T.
+      use MorphismEq.
+      intros i. cbn.
+      apply KernelArrowisMonic.
+      rewrite KernelCommutes.
+      apply (MorphismEq' _ _ _ T i).
+  Qed.
+
+  (** *** Kernels *)
+  Definition ComplexPreCat_Kernels :
+    Kernels (@mk_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs))
+                      ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs))).
+  Proof.
+    intros X Y f. cbn in *.
+    use mk_Kernel.
+    (* Kernel complex *)
+    - exact (ComplexPreCat_Kernel f).
+    (* Kernel arrow *)
+    - exact (ComplexPreCat_KernelArrow f).
+    (* Composition KernelArrow ;; g = ZeroArrow *)
+    - exact (ComplexPreCat_Kernels_comp f).
+    (* isEqualizer property *)
+    - exact (ComplexPreCat_Kernels_isEqualizer f).
+  Defined.
+
+
+  (** ** Cokernels in Complexes over Abelian *)
+
+  (** *** Cokernel complex *)
+  Local Lemma ComplexPreCat_Cokernel_eq (Y Z : Complex (AbelianToAdditive A hs)) (g : Morphism Y Z)
+        (i : hz) : MMor g i ;; (CMor Z i ;; CokernelArrow (Cokernel (MMor g (i + 1)))) =
+                   ZeroArrow (@to_Zero A) (COb Y i) (Cokernel (MMor g (i + 1))).
+  Proof.
+    rewrite assoc. cbn. set (tmp := MComm g i). cbn in tmp. rewrite tmp. clear tmp.
+    rewrite <- assoc. rewrite CokernelCompZero. apply ZeroArrow_comp_right.
+  Qed.
+
+  Local Lemma ComplexPreCat_Cokernel_comp (Y Z : Complex (AbelianToAdditive A hs))
+        (g : Morphism Y Z) (i : hz) :
+    (CokernelOut (@to_Zero A) (Cokernel (MMor g i)) (Cokernel (MMor g (i + 1)))
+                 (CMor Z i ;; CokernelArrow (Cokernel (MMor g (i + 1))))
+                 (ComplexPreCat_Cokernel_eq Y Z g i))
+      ;; (CokernelOut (@to_Zero A) (Cokernel (MMor g (i + 1))) (Cokernel (MMor g (i + 1 + 1)))
+                      (CMor Z (i + 1) ;; CokernelArrow (Cokernel (MMor g (i + 1 + 1))))
+                      (ComplexPreCat_Cokernel_eq Y Z g (i + 1))) =
+    ZeroArrow (@to_Zero A) (Cokernel (MMor g i)) (Cokernel (MMor g (i + 1 + 1))).
+  Proof.
+    apply CokernelArrowisEpi. rewrite ZeroArrow_comp_right.
+    rewrite assoc. rewrite CokernelCommutes. rewrite <- assoc. rewrite CokernelCommutes.
+    rewrite assoc. set (tmp := CEq _ Z i). cbn in tmp. cbn. rewrite tmp. clear tmp.
+    rewrite ZeroArrow_comp_left. apply idpath.
+  Qed.
+
+  Definition ComplexPreCat_Cokernel {Y Z : Complex (AbelianToAdditive A hs)} (g : Morphism Y Z) :
+    ComplexPreCat (AbelianToAdditive A hs).
+  Proof.
+    use mk_Complex.
+    - intros i. exact (Cokernel (MMor g i)).
+    - intros i. cbn. use CokernelOut.
+      + exact (CMor Z i ;; CokernelArrow (Cokernel (MMor g (i + 1)))).
+      + exact (ComplexPreCat_Cokernel_eq Y Z g i).
+    - intros i. exact (ComplexPreCat_Cokernel_comp Y Z g i).
+  Defined.
+
+  (** *** CokernelArrow *)
+  Local Lemma ComplexPreCat_CokernelArrow_comm (Y Z : Complex (AbelianToAdditive A hs))
+        (g : Morphism Y Z) (i : hz) :
+    (CokernelArrow (Cokernel (MMor g i)))
+      ;; (CokernelOut (@to_Zero A) (Cokernel (MMor g i)) (Cokernel (MMor g (i + 1)))
+                      (CMor Z i ;; CokernelArrow (Cokernel (MMor g (i + 1))))
+                      (ComplexPreCat_Cokernel_eq Y Z g i)) =
+    CMor Z i ;; CokernelArrow (Cokernel (MMor g (i + 1))).
+  Proof.
+    rewrite CokernelCommutes. apply idpath.
+  Qed.
+
+  Definition ComplexPreCat_CokernelArrow {Y Z : Complex (AbelianToAdditive A hs)}
+             (g : Morphism Y Z) : Morphism Z (ComplexPreCat_Cokernel g).
+  Proof.
+    use mk_Morphism.
+    - intros i. use CokernelArrow.
+    - intros i. use ComplexPreCat_CokernelArrow_comm.
+  Defined.
+
+  (** *** Cokernel *)
+  Local Lemma ComplexPreCat_CokernelCompZero {Y Z w : Complex (AbelianToAdditive A hs)}
+        (g : (ComplexPreCat (AbelianToAdditive A hs))⟦Y, Z⟧)
+        (h : (ComplexPreCat (AbelianToAdditive A hs))⟦Z, w⟧)
+        (i : hz) :
+    let Z0 := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                       ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs)) in
+    g ;; h = ZeroArrow Z0 Y w ->
+    MMor g i ;; MMor h i = ZeroArrow (@to_Zero A) (COb Y i) (COb w i).
+  Proof.
+    intros Z0. cbn. intros H. set (tmp := MorphismEq' _ (g ;; h) _ H i). cbn in tmp.
+    rewrite tmp. apply ZeroArrowEq.
+  Qed.
+
+  Local Lemma ComplexPreCat_Cokernels_eq (Y Z : Complex (AbelianToAdditive A hs))
+        (g : (ComplexPreCat (AbelianToAdditive A hs))⟦Y, Z⟧)
+        (w : (ComplexPreCat (AbelianToAdditive A hs)))
+        (h : (ComplexPreCat (AbelianToAdditive A hs))⟦Z, w⟧)
+        (H' : g ;; h =
+              ZeroArrow (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                                  ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs))) Y w)
+        (i : hz) :
+    CokernelOut (@to_Zero A) (Cokernel (MMor g i)) (COb w i) (MMor h i)
+                (ComplexPreCat_CokernelCompZero g h i H') ;; CMor w i =
+    (CokernelOut (@to_Zero A) (Cokernel (MMor g i)) (Cokernel (MMor g (i + 1)))
+                 (CMor Z i ;; CokernelArrow (Cokernel (MMor g (i + 1))))
+                 (ComplexPreCat_Cokernel_eq Y Z g i))
+      ;; (CokernelOut (@to_Zero A) (Cokernel (MMor g (i + 1)))
+                      (COb w (i + 1)) (MMor h (i + 1))
+                      (ComplexPreCat_CokernelCompZero g h (i + 1) H')).
+  Proof.
+    apply CokernelArrowisEpi.
+    rewrite assoc. rewrite assoc. rewrite CokernelCommutes.
+    rewrite CokernelCommutes. rewrite <- assoc. rewrite CokernelCommutes.
+    apply (MComm h i).
+  Qed.
+
+  Local Lemma ComplexPreCat_Cokernels_comp {Y Z : Complex (AbelianToAdditive A hs)}
+        (g : (ComplexPreCat (AbelianToAdditive A hs))⟦Y, Z⟧) :
+    let Z0 := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                       ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs)) in
+    MorphismComp g (ComplexPreCat_CokernelArrow g) =
+    MorphismComp (@ZeroArrowTo _ Z0 Y) (@ZeroArrowFrom _ Z0 (ComplexPreCat_Cokernel g)).
+  Proof.
+    use MorphismEq.
+    intros i. cbn. rewrite CokernelCompZero. apply pathsinv0. apply ZeroArrowEq.
+  Qed.
+
+  Local Lemma ComplexPreCat_Cokernels_isEqualizer {Y Z : Complex (AbelianToAdditive A hs)}
+        (g : (ComplexPreCat (AbelianToAdditive A hs))⟦Y, Z⟧) :
+    let Z0 := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                       ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs)) in
+    coequalizers.isCoequalizer
+      g (MorphismComp (@ZeroArrowTo _ Z0 Y) (@ZeroArrowFrom _ Z0 Z))
+      (ComplexPreCat_CokernelArrow g) (CokernelEqRw Z0 (ComplexPreCat_Cokernels_comp g)).
+  Proof.
+    intros Z0.
+    use mk_isCoequalizer.
+    intros w h H'. rewrite (@ZeroArrow_comp_left _ Z0) in H'.
+    use unique_exists.
+    - use mk_Morphism.
+      + intros i. cbn. use CokernelOut.
+        * exact (MMor h i).
+        * exact (ComplexPreCat_CokernelCompZero g h i H').
+      + intros i. cbn. apply ComplexPreCat_Cokernels_eq.
+    - cbn. use MorphismEq. intros i. use CokernelCommutes.
+    - intros y. apply has_homsets_ComplexPreCat.
+    - intros y T. cbn beta in T.
+      use MorphismEq.
+      intros i. cbn.
+      apply CokernelArrowisEpi.
+      rewrite CokernelCommutes.
+      set (tmp := MorphismEq' _ _ _ T i). cbn in tmp.
+      exact tmp.
+  Qed.
+
+  Definition ComplexPreCat_Cokernels :
+    Cokernels (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                        ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs))).
+  Proof.
+    intros Y Z g. cbn in *.
+    use mk_Cokernel.
+    (* Cokernel *)
+    - exact (ComplexPreCat_Cokernel g).
+    (* CokernelArrow *)
+    - exact(ComplexPreCat_CokernelArrow g).
+    (* Composition is zero *)
+    - exact (ComplexPreCat_Cokernels_comp g).
+    (* isCoequalizer *)
+    - exact (ComplexPreCat_Cokernels_isEqualizer g).
+  Defined.
+
+
+  (** ** Monics are kernels *)
+
+  (** *** Kernel complex from Monic *)
+  Local Lemma ComplexPreCat_Monic_Kernel_Complex_comm
+    {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
+    (M : Monic (ComplexPreCat_Additive (AbelianToAdditive A hs)) x y) (i : hz) :
+    (MMor (MonicArrow _ M) i)
+      ;; (CMor y i ;; CokernelArrow (Cokernel (MMor (MonicArrow _ M) (i + 1)))) =
+    ZeroArrow (@to_Zero A) (COb x i) (Cokernel (MMor (MonicArrow _ M) (i + 1))).
+  Proof.
+    rewrite assoc. rewrite (MComm (MonicArrow _ M)). rewrite <- assoc.
+    rewrite CokernelCompZero. apply ZeroArrow_comp_right.
+  Qed.
+
+  Local Lemma ComplexPreCat_Monic_Kernel_Complex_comp
+    {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
+    (M : Monic (ComplexPreCat_Additive (AbelianToAdditive A hs)) x y) (i : hz) :
+    (CokernelOut to_Zero (Cokernel (MMor (MonicArrow _ M) i))
+                 (Cokernel (MMor (MonicArrow _ M) (i + 1)))
+                 (CMor y i ;; CokernelArrow (Cokernel (MMor (MonicArrow _ M) (i + 1))))
+                 (ComplexPreCat_Monic_Kernel_Complex_comm M i))
+      ;; (CokernelOut to_Zero (Cokernel (MMor (MonicArrow _ M) (i + 1)))
+                      (Cokernel (MMor (MonicArrow _ M) (i + 1 + 1)))
+                      (CMor y (i + 1)
+                            ;; CokernelArrow (Cokernel (MMor (MonicArrow _ M) (i + 1 + 1))))
+                      (ComplexPreCat_Monic_Kernel_Complex_comm M (i + 1))) =
+    ZeroArrow
+      to_Zero (Cokernel (MMor (MonicArrow _ M) i)) (Cokernel (MMor (MonicArrow _ M) (i + 1 + 1))).
+  Proof.
+    apply CokernelArrowisEpi. rewrite assoc. rewrite CokernelCommutes.
+    rewrite <- assoc. rewrite CokernelCommutes. rewrite assoc.
+    cbn. set (tmp := CEq _ y i). cbn in tmp. rewrite tmp. clear tmp.
+    rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_right.
+    apply idpath.
+  Qed.
+
+  Definition ComplexPreCat_Monic_Kernel_Complex
+    {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
+    (M : Monic (ComplexPreCat_Additive (AbelianToAdditive A hs)) x y) :
+    ComplexPreCat_Additive (AbelianToAdditive A hs).
+  Proof.
+    use mk_Complex.
+    - intros i. exact (Cokernel (@MMor _ x y (MonicArrow _ M) i)).
+    - intros i. cbn. use CokernelOut.
+      + exact (CMor y i ;; (CokernelArrow (Cokernel (@MMor _ x y (MonicArrow _ M) (i + 1))))).
+      + apply ComplexPreCat_Monic_Kernel_Complex_comm.
+    - intros i. cbn. exact (ComplexPreCat_Monic_Kernel_Complex_comp M i).
+  Defined.
+
+  (** *** The morphisms which has Monic M as the kernel  *)
+  Definition KernelMorphism {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
+             (M : Monic (ComplexPreCat_Additive (AbelianToAdditive A hs)) x y) :
+    Morphism y (ComplexPreCat_Monic_Kernel_Complex M).
+  Proof.
+    use mk_Morphism.
+    - intros i. apply CokernelArrow.
+    - intros i. cbn. rewrite CokernelCommutes. apply idpath.
+  Defined.
+
+  (** *** KernelIn *)
+  Local Lemma KernelMorphism_eq {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
+        (M : Monic (ComplexPreCat_Additive (AbelianToAdditive A hs)) x y) :
+    let Z := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                      (@ZeroComplex (AbelianToAdditive A hs))
+                      (ComplexPreCat_isZero (AbelianToAdditive A hs)) in
+    MorphismComp (MonicArrow _ M) (KernelMorphism M) =
+    MorphismComp (MonicArrow _ M)
+                 (MorphismComp
+                    (@ZeroArrowTo (ComplexPreCat (AbelianToAdditive A hs)) Z y)
+                    (@ZeroArrowFrom (ComplexPreCat (AbelianToAdditive A hs)) Z
+                                    (@ComplexPreCat_Monic_Kernel_Complex x y M))).
+  Proof.
+    use MorphismEq.
+    intros i. cbn. rewrite CokernelCompZero.
+    rewrite assoc. apply pathsinv0. apply ZeroArrowEq.
+  Qed.
+
+  Lemma ComplexMonicKernelInComm (x y : Complex (AbelianToAdditive A hs))
+        (M : Monic (ComplexPreCat (AbelianToAdditive A hs)) x y)
+        (w : ComplexPreCat (AbelianToAdditive A hs))
+        (h : (ComplexPreCat (AbelianToAdditive A hs))⟦w, y⟧)
+        (H' : h ;; KernelMorphism M =
+              h ;; (MorphismComp
+                      (@ZeroArrowTo (ComplexPreCat (AbelianToAdditive A hs))
+                                    (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                                              (@ZeroComplex (AbelianToAdditive A hs))
+                                              (ComplexPreCat_isZero (AbelianToAdditive A hs))) y)
+                      (@ZeroArrowFrom (ComplexPreCat (AbelianToAdditive A hs))
+                                      (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                                                (@ZeroComplex (AbelianToAdditive A hs))
+                                                (ComplexPreCat_isZero (AbelianToAdditive A hs)))
+                                      (@ComplexPreCat_Monic_Kernel_Complex x y M))))
+        (i : hz) :
+    MMor h i ;; CokernelArrow (Cokernel (MMor (MonicArrow _ M) i)) =
+    ZeroArrow (@to_Zero A) (COb w i) (Cokernel (MMor (MonicArrow _ M) i)).
+  Proof.
+    set (H'' := MorphismEq' _ _ _ H' i). cbn in H''. cbn. rewrite H''.
+    rewrite assoc. apply ZeroArrowEq.
+  Qed.
+
+  Definition ComplexMonicKernelIn (x y : Complex (AbelianToAdditive A hs))
+             (M : Monic (ComplexPreCat (AbelianToAdditive A hs)) x y)
+             (w : ComplexPreCat (AbelianToAdditive A hs))
+             (h : (ComplexPreCat (AbelianToAdditive A hs))⟦w, y⟧)
+             (H' : h ;; KernelMorphism M =
+                   h ;; (MorphismComp
+                           (@ZeroArrowTo
+                              (ComplexPreCat (AbelianToAdditive A hs))
+                              (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                                        (@ZeroComplex (AbelianToAdditive A hs))
+                                        (ComplexPreCat_isZero (AbelianToAdditive A hs))) y)
+                           (@ZeroArrowFrom
+                              (ComplexPreCat (AbelianToAdditive A hs))
+                              (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                                        (@ZeroComplex (AbelianToAdditive A hs))
+                                        (ComplexPreCat_isZero (AbelianToAdditive A hs)))
+                              (@ComplexPreCat_Monic_Kernel_Complex x y M)))) :
+    (ComplexPreCat (AbelianToAdditive A hs))⟦w, x⟧.
+  Proof.
+    set (isM := ComplexMonicIndexMonic _ M).
+    use mk_Morphism.
+    - intros i.
+      set (ker := MonicToKernel A hs (mk_Monic _ _ (isM i))).
+      apply (KernelIn (@to_Zero A) ker (COb w i) (MMor h i) (ComplexMonicKernelInComm x y M w h H' i)).
+    - intros i.
+      set (ker := MonicToKernel A hs (mk_Monic _ _ (isM (i + 1)))).
+      cbn in *. apply (KernelArrowisMonic _ ker).
+      rewrite <- assoc. rewrite <- assoc. fold ker.
+      rewrite (KernelCommutes _ ker). cbn. use (pathscomp0 _ (MComm h i)).
+      set (tmp := MComm (MonicArrow _ M) i). cbn in tmp. rewrite <- tmp. clear tmp.
+      rewrite assoc. apply cancel_postcomposition.
+      set (tmp := KernelCommutes _ (MonicToKernel A hs (mk_Monic A _ (isM i)))
+                                 (COb w i) (MMor h i)).
+      set (tmp0 := KernelEqAr _ (MonicToKernel A hs (mk_Monic A _ (isM i)))). cbn in tmp0.
+      rewrite ZeroArrow_comp_right in tmp0. cbn in tmp. apply tmp.
+  Defined.
+
+  (** *** MonicKernelsData *)
+
+  Definition ComplexPreCatAbelianMonicKernelsData_isEqualizer
+             {x y : Complex (AbelianToAdditive A hs)}
+             (M : Monic (ComplexPreCat (AbelianToAdditive A hs)) x y) :
+    let Z := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                      (@ZeroComplex (AbelianToAdditive A hs))
+                      (ComplexPreCat_isZero (AbelianToAdditive A hs)) in
+    @equalizers.isEqualizer (ComplexPreCat (AbelianToAdditive A hs)) _ _ _
+                            (KernelMorphism M)
+                            (MorphismComp (@ZeroArrowTo _ Z y)
+                                          (ZeroArrowFrom (ComplexPreCat_Monic_Kernel_Complex M))) M
+                            (KernelMorphism_eq M).
+  Proof.
+    cbn.
+    set (isM := ComplexMonicIndexMonic _ M).
+    use mk_isEqualizer.
+    intros w h H'.
+    use unique_exists.
+    - apply (ComplexMonicKernelIn x y M w h H').
+    - cbn. use MorphismEq.
+      intros i. cbn.
+      apply (KernelCommutes _ (MonicToKernel A hs (mk_Monic A _ (isM i))) (COb w i) (MMor h i)).
+    - intros y0. apply has_homsets_ComplexPreCat.
+    - intros y0 T. cbn in T.
+      use MorphismEq.
+      intros i. apply (isM i).
+      set (tmp :=  MorphismEq' _ _ _ T i). cbn in tmp. cbn. rewrite tmp.
+      apply pathsinv0. clear tmp.
+      apply (KernelCommutes _ (MonicToKernel A hs (mk_Monic A _ (isM i))) (COb w i) (MMor h i)).
+  Qed.
+
+  Definition ComplexPreCatAbelianMonicKernelsData :
+    AbelianMonicKernelsData
+      (ComplexPreCat (AbelianToAdditive A hs))
+      (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs)) ZeroComplex
+                (ComplexPreCat_isZero (AbelianToAdditive A hs)),,
+                Additive.to_BinProducts (ComplexPreCat_Additive (AbelianToAdditive A hs)),,
+                Additive.to_BinCoproducts (ComplexPreCat_Additive (AbelianToAdditive A hs))).
+  Proof.
+    intros x y M.
+    set (isM := ComplexMonicIndexMonic _ M).
+    use tpair.
+    - use tpair.
+      + use tpair.
+        * exact (ComplexPreCat_Monic_Kernel_Complex M).
+        * exact (KernelMorphism M).
+      + exact (KernelMorphism_eq M).
+    - exact (ComplexPreCatAbelianMonicKernelsData_isEqualizer M).
+  Defined.
+
+  (** ** Epis are Cokernels *)
+
+  Local Lemma ComplexPreCat_Epi_Cokernel_Complex_comm
+        {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
+        (E : Epi (ComplexPreCat_Additive (AbelianToAdditive A hs)) x y) (i : hz) :
+    KernelArrow (Kernel (MMor (EpiArrow _ E) i)) ;; CMor x i ;; MMor (EpiArrow _ E) (i + 1) =
+    ZeroArrow (@to_Zero A) (Kernel (MMor (EpiArrow _ E) i)) (COb y (i + 1)).
+  Proof.
+    rewrite <- assoc. rewrite <- (MComm (EpiArrow _ E)). rewrite assoc.
+    rewrite KernelCompZero. apply ZeroArrow_comp_left.
+  Qed.
+
+  Definition ComplexPreCat_Epi_Cokernel_Complex
+             {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
+             (E : Epi (ComplexPreCat_Additive (AbelianToAdditive A hs)) x y) :
+    ComplexPreCat_Additive (AbelianToAdditive A hs).
+  Proof.
+    use mk_Complex.
+    - intros i.
+      set (mor := EpiArrow _ E). cbn in mor.
+      set (tmp := @MMor _ x y mor i).
+      exact (Kernel tmp).
+    - intros i. cbn. use KernelIn.
+      + set (mor := EpiArrow _ E). cbn in mor.
+        set (tmp := @MMor _ x y mor i).
+        exact ((KernelArrow (Kernel tmp)) ;; CMor x i).
+      + apply ComplexPreCat_Epi_Cokernel_Complex_comm.
+    - intros i. cbn.
+      apply KernelArrowisMonic. rewrite <- assoc. rewrite KernelCommutes.
+      rewrite assoc. rewrite KernelCommutes. rewrite <- assoc.
+      cbn. set (tmp := CEq _ x i). cbn in tmp. rewrite tmp. clear tmp.
+      rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left.
+      apply idpath.
+  Defined.
+
+  Definition CokernelMorphism
+             {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
+             (E : Epi (ComplexPreCat_Additive (AbelianToAdditive A hs)) x y) :
+    Morphism (ComplexPreCat_Epi_Cokernel_Complex E) x.
+  Proof.
+    use mk_Morphism.
+    - intros i. cbn. apply KernelArrow.
+    - intros i. cbn. rewrite KernelCommutes. apply idpath.
+  Defined.
+
+  Definition CokernelMorphism_eq
+             {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
+             (E : Epi (ComplexPreCat_Additive (AbelianToAdditive A hs)) x y) :
+    MorphismComp (CokernelMorphism E) (EpiArrow _ E) =
+    MorphismComp (MorphismComp
+                    (@ZeroArrowTo (ComplexPreCat (AbelianToAdditive A hs))
+                                  (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                                            (@ZeroComplex (AbelianToAdditive A hs))
+                                            (ComplexPreCat_isZero (AbelianToAdditive A hs)))
+                                  (ComplexPreCat_Epi_Cokernel_Complex E))
+                    (@ZeroArrowFrom (ComplexPreCat (AbelianToAdditive A hs))
+                                    (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                                              (@ZeroComplex (AbelianToAdditive A hs))
+                                              (ComplexPreCat_isZero (AbelianToAdditive A hs)))
+                                    x)) (EpiArrow _ E).
+  Proof.
+    use MorphismEq.
+    intros i. cbn. rewrite KernelCompZero.
+    rewrite <- assoc. apply pathsinv0. apply ZeroArrowEq.
+  Qed.
+
+  Local Lemma ComplexPreCatCokernelOut_comm
+    {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
+    (E : Epi (ComplexPreCat (AbelianToAdditive A hs)) x y)
+    (w0 : ComplexPreCat (AbelianToAdditive A hs))
+    (h : (ComplexPreCat (AbelianToAdditive A hs))⟦x, w0⟧)
+    (H' : MorphismComp
+            (MorphismComp
+               (@ZeroArrowTo (ComplexPreCat (AbelianToAdditive A hs))
+                             (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                                       (@ZeroComplex (AbelianToAdditive A hs))
+                                       (ComplexPreCat_isZero (AbelianToAdditive A hs)))
+                             (ComplexPreCat_Epi_Cokernel_Complex E))
+               (@ZeroArrowFrom (ComplexPreCat (AbelianToAdditive A hs))
+                               (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                                         (@ZeroComplex (AbelianToAdditive A hs))
+                                         (ComplexPreCat_isZero (AbelianToAdditive A hs)))
+                               x)) h = MorphismComp (@CokernelMorphism x y E) h) (i : hz) :
+    KernelArrow (Kernel (MMor (EpiArrow _ E) i)) ;; MMor h i =
+    ZeroArrow (@to_Zero A) (Kernel (MMor (EpiArrow _ E) i)) (COb w0 i).
+  Proof.
+    set (H'' := MorphismEq' _ _ _ H' i). cbn in H''. cbn. rewrite <- H''.
+    rewrite <- assoc. apply ZeroArrowEq.
+  Qed.
+
+  Definition ComplexPreCatCokernelOut
+    {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
+    (E : Epi (ComplexPreCat (AbelianToAdditive A hs)) x y)
+    (w0 : ComplexPreCat (AbelianToAdditive A hs))
+    (h : (ComplexPreCat (AbelianToAdditive A hs))⟦x, w0⟧)
+    (H' : MorphismComp
+            (MorphismComp
+               (@ZeroArrowTo (ComplexPreCat (AbelianToAdditive A hs))
+                             (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                                       (@ZeroComplex (AbelianToAdditive A hs))
+                                       (ComplexPreCat_isZero (AbelianToAdditive A hs)))
+                             (ComplexPreCat_Epi_Cokernel_Complex E))
+               (@ZeroArrowFrom (ComplexPreCat (AbelianToAdditive A hs))
+                               (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
+                                         (@ZeroComplex (AbelianToAdditive A hs))
+                                         (ComplexPreCat_isZero (AbelianToAdditive A hs)))
+                               x)) h = MorphismComp (@CokernelMorphism x y E) h) :
+    (ComplexPreCat (AbelianToAdditive A hs))⟦y, w0⟧.
+  Proof.
+    set (isE := ComplexEpiIndexEpi _ E).
+    use mk_Morphism.
+    - intros i.
+      set (coker := EpiToCokernel A hs (mk_Epi _ _ (isE i))).
+      apply (CokernelOut (@to_Zero A) coker _ (MMor h i)).
+      apply (ComplexPreCatCokernelOut_comm E w0 h H').
+    - intros i.
+      set (coker := EpiToCokernel A hs (mk_Epi _ _ (isE i))).
+      cbn in *. apply (CokernelArrowisEpi _ coker). repeat rewrite assoc. fold coker.
+      rewrite (CokernelCommutes _ coker). cbn. use (pathscomp0 (MComm h i)).
+      set (tmp := MComm (EpiArrow _ E) i). cbn in tmp. rewrite tmp. clear tmp.
+      rewrite <- assoc. apply cancel_precomposition.
+      set (tmp := CokernelCommutes _ (EpiToCokernel A hs (mk_Epi A _ (isE (i + 1))))).
+      set (tmp0 := CokernelEqAr _ (EpiToCokernel A hs (mk_Epi A _ (isE (i + 1))))). cbn in tmp0.
+      rewrite ZeroArrow_comp_left in tmp0. cbn in tmp. apply pathsinv0. apply tmp.
+  Defined.
+
+  (** *** EpisCokernelsData *)
+
+  Local Lemma ComplexPreCatAbelianEpiCokernelsData_isCoequalizer
+        {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
+        (E : Epi (ComplexPreCat_Additive (AbelianToAdditive A hs)) x y) :
+    let Add := ComplexPreCat_Additive (AbelianToAdditive A hs) in
+    @coequalizers.isCoequalizer Add _ _ _ (CokernelMorphism E)
+      (MorphismComp (ZeroArrowTo (ComplexPreCat_Epi_Cokernel_Complex E)) (ZeroArrowFrom x)) E
+      (CokernelMorphism_eq E).
+  Proof.
+    cbn zeta. set (isE := ComplexEpiIndexEpi (AbelianToAdditive A hs) E).
+    use mk_isCoequalizer.
+    intros w0 h H'.
+    use unique_exists.
+    - apply (ComplexPreCatCokernelOut E w0 h (! H')).
+    - cbn. use MorphismEq.
+      intros i. cbn.
+      apply (CokernelCommutes _ (EpiToCokernel A hs (mk_Epi A _ (isE i))) (COb w0 i) (MMor h i)).
+    - intros y0. apply has_homsets_ComplexPreCat.
+    - intros y0 T. cbn in T.
+      use MorphismEq.
+      intros i. apply (isE i).
+      set (tmp :=  MorphismEq' _ _ _ T i). cbn in tmp. cbn. rewrite tmp.
+      apply pathsinv0. clear tmp.
+      apply (CokernelCommutes _ (EpiToCokernel A hs (mk_Epi A _ (isE i))) (COb w0 i) (MMor h i)).
+  Qed.
+
+  Definition ComplexPreCatAbelianEpiCokernelsData :
+    let Add := ComplexPreCat_Additive (AbelianToAdditive A hs) in
+    AbelianEpiCokernelsData
+      Add ((Additive.to_Zero Add)
+             ,, (Additive.to_BinProducts Add),, (Additive.to_BinCoproducts Add)).
+  Proof.
+    cbn zeta. intros x y E.
+    set (isE := ComplexEpiIndexEpi _ E).
+    use tpair.
+    - use tpair.
+      + use tpair.
+        * exact (ComplexPreCat_Epi_Cokernel_Complex E).
+        * exact (CokernelMorphism E).
+      + exact (CokernelMorphism_eq E).
+    - exact (ComplexPreCatAbelianEpiCokernelsData_isCoequalizer E).
+  Defined.
+
+  (** ** Complexes over Abelian is Abelian *)
+
+  Definition ComplexPreCat_AbelianPreCat : AbelianPreCat.
+  Proof.
+    use mk_Abelian.
+    - exact (ComplexPreCat_Additive (AbelianToAdditive A hs)).
+    - split.
+      + exact (Additive.to_Zero _).
+      + split.
+        * exact (Additive.to_BinProducts (ComplexPreCat_Additive (AbelianToAdditive A hs))).
+        * exact (Additive.to_BinCoproducts (ComplexPreCat_Additive (AbelianToAdditive A hs))).
+    - split.
+      + split.
+        * cbn. exact ComplexPreCat_Kernels.
+        * cbn. exact ComplexPreCat_Cokernels.
+      + split.
+        * exact ComplexPreCatAbelianMonicKernelsData.
+        * exact ComplexPreCatAbelianEpiCokernelsData.
+  Defined.
+
+End complexes_abelian.
+
+Local Transparent hz isdecrelhzeq hzplus iscommrngops.
+Close Scope hz_scope.

--- a/UniMath/CategoryTheory/Complexes.v
+++ b/UniMath/CategoryTheory/Complexes.v
@@ -80,16 +80,17 @@ Section def_complexes.
            Π i : hz, (pr2 D' i) ;; (pr2 D' (hzplus i 1)) = ZeroArrow (Additive.to_Zero A) _ _.
 
   Definition mk_Complex (D : Π i : hz, ob A) (D' : Π i : hz, A⟦D i, D (hzplus i 1)⟧)
-             (D'' : Π i : hz, D' i ;; D' (hzplus i 1) = ZeroArrow (Additive.to_Zero A) _ _) :
+             (D'' : Π i : hz, (D' i) ;; (D' (hzplus i 1)) = ZeroArrow (Additive.to_Zero A) _ _) :
     Complex := ((D,,D'),,D'').
 
   (** Accessor functions *)
-  Definition COb (C : Complex) (i : hz) : ob A := pr1 (pr1 C) i.
+  Definition Complex_Funclass (C : Complex) : hz -> ob A := pr1 (pr1 C).
+  Coercion Complex_Funclass : Complex >-> Funclass.
 
-  Definition CMor (C : Complex) (i : hz) : A⟦COb C i, COb C (hzplus i 1)⟧ := pr2 (pr1 C) i.
+  Definition Diff {C : Complex} (i : hz) : A⟦C i, C (hzplus i 1)⟧ := pr2 (pr1 C) i.
 
   Definition CEq (C : Complex) (i : hz) :
-    (CMor C i) ;; (CMor C (hzplus i 1)) = ZeroArrow (Additive.to_Zero A) _ _ := pr2 C i.
+    (Diff i) ;; (Diff (hzplus i 1)) = ZeroArrow (Additive.to_Zero A) _ _ := pr2 C i.
 
   (** Zero Complex *)
   Definition ZeroComplex : Complex.
@@ -101,12 +102,12 @@ Section def_complexes.
   Defined.
 
   (** Direct sum of two complexes *)
-  Local Lemma DirectSumComplex_comm (C1 C2 : Complex) (i : hz) :
-    let B1 := to_BinDirectSums A (COb C1 i) (COb C2 i) in
-    let B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1)) in
-    let B3 := to_BinDirectSums A (COb C1 (i + 1 + 1)) (COb C2 (i + 1 + 1)) in
-    (BinDirectSumIndAr A (CMor C1 i) (CMor C2 i) B1 B2)
-      ;; (BinDirectSumIndAr A (CMor C1 (i + 1)) (CMor C2 (i + 1)) B2 B3)  =
+  Local Lemma DirectSumComplex_comm {C1 C2 : Complex} (i : hz) :
+    let B1 := to_BinDirectSums A (C1 i) (C2 i) in
+    let B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1)) in
+    let B3 := to_BinDirectSums A (C1 (i + 1 + 1)) (C2 (i + 1 + 1)) in
+    (BinDirectSumIndAr A (@Diff C1 i) (@Diff C2 i) B1 B2)
+      ;; (BinDirectSumIndAr A (@Diff C1 (i + 1)) (@Diff C2 (i + 1)) B2 B3) =
     ZeroArrow (Additive.to_Zero A) B1 B3.
   Proof.
     cbn.
@@ -123,25 +124,25 @@ Section def_complexes.
   Definition DirectSumComplex (C1 C2 : Complex) : Complex.
   Proof.
     use mk_Complex.
-    - intros i. exact (to_BinDirectSums A (COb C1 i) (COb C2 i)).
-    - intros i. exact (BinDirectSumIndAr A (CMor C1 i) (CMor C2 i) _ _).
-    - intros i. exact (DirectSumComplex_comm C1 C2 i).
+    - intros i. exact (to_BinDirectSums A (C1 i) (C2 i)).
+    - intros i. exact (BinDirectSumIndAr A (@Diff C1 i) (@Diff C2 i) _ _).
+    - intros i. exact (DirectSumComplex_comm i).
   Defined.
 
   (** Morphism of complexes *)
   Definition Morphism (C1 C2 : Complex) : UU :=
-    Σ D : (Π i : hz, A⟦COb C1 i, COb C2 i⟧), Π i : hz, D i ;; CMor C2 i = CMor C1 i ;; D (i + 1).
+    Σ D : (Π i : hz, A⟦C1 i, C2 i⟧), Π i : hz, (D i) ;; (@Diff C2 i) = (@Diff C1 i) ;; (D (i + 1)).
 
-  Definition mk_Morphism (C1 C2 : Complex) (Mors : Π i : hz, A⟦COb C1 i, COb C2 i⟧)
-             (Comm : Π i : hz, Mors i ;; CMor C2 i = CMor C1 i ;; Mors (i + 1)) : Morphism C1 C2 :=
-    tpair _ Mors Comm.
+  Definition mk_Morphism (C1 C2 : Complex) (Mors : Π i : hz, A⟦C1 i, C2 i⟧)
+             (Comm : Π i : hz, (Mors i) ;; (@Diff C2 i) = (@Diff C1 i) ;; (@Mors (i + 1))) :
+    Morphism C1 C2 := tpair _ Mors Comm.
 
   (** Accessor functions *)
-  Definition MMor {C1 C2 : Complex} (M : Morphism C1 C2) (i : hz) : A⟦COb C1 i, COb C2 i⟧ :=
+  Definition MMor {C1 C2 : Complex} (M : Morphism C1 C2) (i : hz) : A⟦C1 i, C2 i⟧ :=
     pr1 M i.
 
   Definition MComm {C1 C2 : Complex} (M : Morphism C1 C2) (i : hz) :
-    MMor M i ;; CMor C2 i = CMor C1 i ;; MMor M (i + 1) := pr2 M i.
+    (MMor M i) ;; (@Diff C2 i) = (@Diff C1 i) ;; (MMor M (i + 1)) := pr2 M i.
 
   (** A lemma to show that two morphisms are the same *)
   Lemma MorphismEq {C1 C2 : Complex} (M1 M2 : Morphism C1 C2)
@@ -174,7 +175,7 @@ Section def_complexes.
 
   (** Identity Morphism *)
   Local Lemma IdMorComm (C1 : Complex) (i : hz) :
-    identity (COb C1 i) ;; CMor C1 i = CMor C1 i ;; identity (COb C1 (i + 1)).
+    (identity (C1 i)) ;; (@Diff C1 i) = (@Diff C1 i) ;; (identity (C1 (i + 1))).
   Proof.
     rewrite id_left.
     rewrite id_right.
@@ -190,9 +191,9 @@ Section def_complexes.
 
   (** Morphisms from and to Zero complex *)
   Local Lemma MorphismFromZero_comm (C : Complex) (i : hz) :
-    (ZeroArrow (Additive.to_Zero A) (Additive.to_Zero A) (COb C i)) ;; (CMor C i) =
+    (ZeroArrow (Additive.to_Zero A) (Additive.to_Zero A) (C i)) ;; (Diff i) =
     (ZeroArrow (Additive.to_Zero A) (Additive.to_Zero A) (Additive.to_Zero A))
-      ;; (ZeroArrow (Additive.to_Zero A) (Additive.to_Zero A) (COb C (i + 1))).
+      ;; (ZeroArrow (Additive.to_Zero A) (Additive.to_Zero A) (C (i + 1))).
   Proof.
     rewrite ZeroArrow_comp_left.
     rewrite ZeroArrow_comp_left.
@@ -207,9 +208,9 @@ Section def_complexes.
   Defined.
 
   Local Lemma MorphismToZero_comm (C : Complex) (i : hz) :
-    (ZeroArrow (Additive.to_Zero A) (COb C i) (Additive.to_Zero A))
+    (ZeroArrow (Additive.to_Zero A) (C i) (Additive.to_Zero A))
       ;; (ZeroArrow (Additive.to_Zero A) (Additive.to_Zero A) (Additive.to_Zero A)) =
-    CMor C i ;; ZeroArrow (Additive.to_Zero A) (COb C (i + 1)) (Additive.to_Zero A).
+    (Diff i) ;; ZeroArrow (Additive.to_Zero A) (C (i + 1)) (Additive.to_Zero A).
   Proof.
     rewrite ZeroArrow_comp_right.
     rewrite ZeroArrow_comp_right.
@@ -226,7 +227,8 @@ Section def_complexes.
   (** Composition of morphisms *)
   Local Lemma MorphismCompComm {C1 C2 C3 : Complex} (M1 : Morphism C1 C2) (M2 : Morphism C2 C3)
         (i : hz) :
-    MMor M1 i ;; MMor M2 i ;; CMor C3 i = CMor C1 i ;; (MMor M1 (i + 1) ;; MMor M2 (i + 1)).
+    (MMor M1 i) ;; (MMor M2 i) ;; (@Diff C3 i) =
+    (@Diff C1 i) ;; (MMor M1 (i + 1) ;; MMor M2 (i + 1)).
   Proof.
     rewrite assoc.
     rewrite <- (MComm M1).
@@ -239,7 +241,7 @@ Section def_complexes.
     Morphism C1 C3.
   Proof.
     use mk_Morphism.
-    - intros i. exact (MMor M1 i ;; MMor M2 i).
+    - intros i. exact ((MMor M1 i) ;; (MMor M2 i)).
     - intros i. exact (MorphismCompComm M1 M2 i).
   Defined.
 
@@ -251,13 +253,14 @@ Section def_complexes.
 
   (** Inclusions and projections from the DirectSumComplex *)
   Local Lemma DirectSumComplexIn1_comm (C1 C2 : Complex) (i : hz) :
-    let B1 := to_BinDirectSums A (COb C1 i) (COb C2 i) in
-    let B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1)) in
-    to_In1 A B1 ;; BinDirectSumIndAr A (CMor C1 i) (CMor C2 i) B1 B2  = CMor C1 i ;; to_In1 A B2.
+    let B1 := to_BinDirectSums A (C1 i) (C2 i) in
+    let B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1)) in
+    (to_In1 A B1) ;; (BinDirectSumIndAr A (@Diff C1 i) (@Diff C2 i) B1 B2) =
+    (@Diff C1 i) ;; (to_In1 A B2).
   Proof.
     cbn.
-    set (B1 := to_BinDirectSums A (COb C1 i) (COb C2 i)).
-    set (B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1))).
+    set (B1 := to_BinDirectSums A (C1 i) (C2 i)).
+    set (B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1))).
     rewrite BinDirectSumIndArEq1.
     unfold BinDirectSumIndArFormula.
     rewrite to_premor_linear'.
@@ -270,18 +273,19 @@ Section def_complexes.
   Definition DirectSumComplexIn1 (C1 C2 : Complex) : Morphism C1 (DirectSumComplex C1 C2).
   Proof.
     use mk_Morphism.
-    - intros i. exact (to_In1 A (to_BinDirectSums A (COb C1 i) (COb C2 i))).
+    - intros i. exact (to_In1 A (to_BinDirectSums A (C1 i) (C2 i))).
     - intros i. exact (DirectSumComplexIn1_comm C1 C2 i).
   Defined.
 
   Local Lemma DirectSumComplexIn2_comm (C1 C2 : Complex) (i : hz) :
-    let B1 := to_BinDirectSums A (COb C1 i) (COb C2 i) in
-    let B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1)) in
-    to_In2 A B1 ;; BinDirectSumIndAr A (CMor C1 i) (CMor C2 i) B1 B2  = CMor C2 i ;; to_In2 A B2.
+    let B1 := to_BinDirectSums A (C1 i) (C2 i) in
+    let B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1)) in
+    (to_In2 A B1) ;; (BinDirectSumIndAr A (@Diff C1 i) (@Diff C2 i) B1 B2) =
+    (@Diff C2 i) ;; (to_In2 A B2).
   Proof.
     cbn.
-    set (B1 := to_BinDirectSums A (COb C1 i) (COb C2 i)).
-    set (B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1))).
+    set (B1 := to_BinDirectSums A (C1 i) (C2 i)).
+    set (B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1))).
     rewrite BinDirectSumIndArEq1.
     unfold BinDirectSumIndArFormula.
     rewrite to_premor_linear'. rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
@@ -293,18 +297,19 @@ Section def_complexes.
   Definition DirectSumComplexIn2 (C1 C2 : Complex) : Morphism C2 (DirectSumComplex C1 C2).
   Proof.
     use mk_Morphism.
-    - intros i. exact (to_In2 A (to_BinDirectSums A (COb C1 i) (COb C2 i))).
+    - intros i. exact (to_In2 A (to_BinDirectSums A (C1 i) (C2 i))).
     - intros i. exact (DirectSumComplexIn2_comm C1 C2 i).
   Defined.
 
   Local Lemma DirectSumComplexPr1_comm (C1 C2 : Complex) (i : hz) :
-    let B1 := to_BinDirectSums A (COb C1 i) (COb C2 i) in
-    let B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1)) in
-    to_Pr1 A B1 ;; CMor C1 i = (BinDirectSumIndAr A (CMor C1 i) (CMor C2 i) B1 B2) ;; (to_Pr1 A B2).
+    let B1 := to_BinDirectSums A (C1 i) (C2 i) in
+    let B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1)) in
+    (to_Pr1 A B1) ;; (@Diff C1 i) =
+    (BinDirectSumIndAr A (@Diff C1 i) (@Diff C2 i) B1 B2) ;; (to_Pr1 A B2).
   Proof.
     cbn.
-    set (B1 := to_BinDirectSums A (COb C1 i) (COb C2 i)).
-    set (B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1))).
+    set (B1 := to_BinDirectSums A (C1 i) (C2 i)).
+    set (B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1))).
     rewrite BinDirectSumIndArEq1.
     unfold BinDirectSumIndArFormula.
     rewrite to_postmor_linear'.
@@ -317,18 +322,19 @@ Section def_complexes.
   Definition DirectSumComplexPr1 (C1 C2 : Complex) : Morphism (DirectSumComplex C1 C2) C1.
   Proof.
     use mk_Morphism.
-    - intros i. exact (to_Pr1 A (to_BinDirectSums A (COb C1 i) (COb C2 i))).
+    - intros i. exact (to_Pr1 A (to_BinDirectSums A (C1 i) (C2 i))).
     - intros i. exact (DirectSumComplexPr1_comm C1 C2 i).
   Defined.
 
   Local Lemma DirectSumComplexPr2_comm (C1 C2 : Complex) (i : hz) :
-    let B1 := to_BinDirectSums A (COb C1 i) (COb C2 i) in
-    let B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1)) in
-    to_Pr2 A B1 ;; CMor C2 i = (BinDirectSumIndAr A (CMor C1 i) (CMor C2 i) B1 B2) ;; (to_Pr2 A B2).
+    let B1 := to_BinDirectSums A (C1 i) (C2 i) in
+    let B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1)) in
+    (to_Pr2 A B1) ;; (@Diff C2 i) =
+    (BinDirectSumIndAr A (@Diff C1 i) (@Diff C2 i) B1 B2) ;; (to_Pr2 A B2).
   Proof.
     cbn.
-    set (B1 := to_BinDirectSums A (COb C1 i) (COb C2 i)).
-    set (B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1))).
+    set (B1 := to_BinDirectSums A (C1 i) (C2 i)).
+    set (B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1))).
     rewrite BinDirectSumIndArEq1.
     unfold BinDirectSumIndArFormula.
     rewrite to_postmor_linear'.
@@ -341,7 +347,7 @@ Section def_complexes.
   Definition DirectSumComplexPr2 (C1 C2 : Complex) : Morphism (DirectSumComplex C1 C2) C2.
   Proof.
     use mk_Morphism.
-    - intros i. exact (to_Pr2 A (to_BinDirectSums A (COb C1 i) (COb C2 i))).
+    - intros i. exact (to_Pr2 A (to_BinDirectSums A (C1 i) (C2 i))).
     - intros i. exact (DirectSumComplexPr2_comm C1 C2 i).
   Defined.
 
@@ -351,7 +357,7 @@ Section def_complexes.
   Proof.
     use MorphismEq.
     intros i. cbn.
-    set (B := to_BinDirectSums A (COb C1 i) (COb C2 i)).
+    set (B := to_BinDirectSums A (C1 i) (C2 i)).
     rewrite (to_IdIn1 A B).
     apply idpath.
   Qed.
@@ -361,7 +367,7 @@ Section def_complexes.
   Proof.
     use MorphismEq.
     intros i. cbn.
-    set (B := to_BinDirectSums A (COb C1 i) (COb C2 i)).
+    set (B := to_BinDirectSums A (C1 i) (C2 i)).
     rewrite (to_IdIn2 A B).
     apply idpath.
   Qed.
@@ -372,7 +378,7 @@ Section def_complexes.
   Proof.
     use MorphismEq.
     intros i. cbn.
-    set (B := to_BinDirectSums A (COb C1 i) (COb C2 i)).
+    set (B := to_BinDirectSums A (C1 i) (C2 i)).
     rewrite (to_Unel1 A B).
     rewrite ZeroArrow_comp_left.
     apply PreAdditive_unel_zero.
@@ -384,7 +390,7 @@ Section def_complexes.
   Proof.
     use MorphismEq.
     intros i. cbn.
-    set (B := to_BinDirectSums A (COb C1 i) (COb C2 i)).
+    set (B := to_BinDirectSums A (C1 i) (C2 i)).
     rewrite (to_Unel2 A B).
     rewrite ZeroArrow_comp_left.
     apply PreAdditive_unel_zero.
@@ -392,8 +398,8 @@ Section def_complexes.
 
   (** Additition of morphisms is pointwise addition *)
   Local Lemma MorphismOpComm {C1 C2 : Complex} (M1 M2 : Morphism C1 C2)  (i : hz) :
-    to_binop (COb C1 i) (COb C2 i) (MMor M1 i) (MMor M2 i) ;; CMor C2 i =
-    CMor C1 i ;; to_binop (COb C1 (i + 1)) (COb C2 (i + 1)) (MMor M1 (i + 1)) (MMor M2 (i + 1)).
+    (to_binop (C1 i) (C2 i) (MMor M1 i) (MMor M2 i)) ;; (@Diff C2 i) =
+    (@Diff C1 i) ;; (to_binop (C1 (i + 1)) (C2 (i + 1)) (MMor M1 (i + 1)) (MMor M2 (i + 1))).
   Proof.
     rewrite to_postmor_linear'. rewrite to_premor_linear'.
     rewrite (MComm M1 i). rewrite (MComm M2 i). apply idpath.
@@ -411,12 +417,12 @@ Section def_complexes.
     intros M1 M2 M3.
     use MorphismEq.
     intros i. cbn.
-    apply (assocax (to_abgrop (COb C1 i) (COb C2 i))).
+    apply (assocax (to_abgrop (C1 i) (C2 i))).
   Qed.
 
   Lemma MorphismZeroComm (C1 C2 : Complex) (i : hz) :
-    ZeroArrow (Additive.to_Zero A) (COb C1 i) (COb C2 i) ;; CMor C2 i =
-    CMor C1 i ;; ZeroArrow (Additive.to_Zero A) (COb C1 (i + 1)) (COb C2 (i + 1)).
+    (ZeroArrow (Additive.to_Zero A) (C1 i) (C2 i)) ;; (@Diff C2 i) =
+    (@Diff C1 i) ;; (ZeroArrow (Additive.to_Zero A) (C1 (i + 1)) (C2 (i + 1))).
   Proof.
     rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_right. apply idpath.
   Qed.
@@ -442,9 +448,9 @@ Section def_complexes.
       rewrite to_runax'. apply idpath.
   Qed.
 
-  Local Lemma MorphismOp_inv_comm (C1 C2 : Complex) (M : Morphism C1 C2) (i : hz) :
-    to_inv (COb C1 i) (COb C2 i) (MMor M i) ;; CMor C2 i =
-    CMor C1 i ;; to_inv (COb C1 (i + 1)) (COb C2 (i + 1)) (MMor M (i + 1)).
+  Local Lemma MorphismOp_inv_comm {C1 C2 : Complex} (M : Morphism C1 C2) (i : hz) :
+    (to_inv (C1 i) (C2 i) (MMor M i)) ;; (@Diff C2 i) =
+    (@Diff C1 i) ;; (to_inv (C1 (i + 1)) (C2 (i + 1)) (MMor M (i + 1))).
   Proof.
     rewrite <- PreAdditive_invlcomp.
     rewrite <- PreAdditive_invrcomp.
@@ -454,15 +460,15 @@ Section def_complexes.
     exact (MComm M i).
   Qed.
 
-  Definition MorphismOp_inv (C1 C2 : Complex) (M : Morphism C1 C2) : Morphism C1 C2.
+  Definition MorphismOp_inv {C1 C2 : Complex} (M : Morphism C1 C2) : Morphism C1 C2.
   Proof.
     use mk_Morphism.
-    - intros i. exact (to_inv (COb C1 i) (COb C2 i) (MMor M i)).
-    - intros i. exact (MorphismOp_inv_comm C1 C2 M i).
+    - intros i. exact (to_inv (C1 i) (C2 i) (MMor M i)).
+    - intros i. exact (MorphismOp_inv_comm M i).
   Defined.
 
   Lemma MorphismOp_isinv (C1 C2 : Complex) :
-    @isinv (Morphisms_hSet C1 C2) MorphismOp (MorphismZero C1 C2) (MorphismOp_inv C1 C2).
+    @isinv (Morphisms_hSet C1 C2) MorphismOp (MorphismZero C1 C2) MorphismOp_inv.
   Proof.
     split.
     - intros H.
@@ -482,7 +488,7 @@ Section def_complexes.
     intros M1 M2.
     use MorphismEq.
     intros i. cbn.
-    apply (commax (to_abgrop (COb C1 i) (COb C2 i)) (MMor M1 i) (MMor M2 i)).
+    apply (commax (to_abgrop (C1 i) (C2 i)) (MMor M1 i) (MMor M2 i)).
   Qed.
 
   Definition MorphismOp_isabgrop (C1 C2 : Complex) : @isabgrop (Morphisms_hSet C1 C2) MorphismOp.
@@ -495,7 +501,7 @@ Section def_complexes.
           -- exact (MorphismZero C1 C2).
           -- exact (MorphismOp_isunit C1 C2).
       + use tpair.
-        * exact (MorphismOp_inv C1 C2).
+        * exact MorphismOp_inv.
         * exact (MorphismOp_isinv C1 C2).
     - exact (MorphismOp_iscomm C1 C2).
   Defined.
@@ -508,22 +514,22 @@ Section def_complexes.
   Proof.
     use MorphismEq.
     intros i. cbn.
-    set (B := to_BinDirectSums A (COb C1 i) (COb C2 i)).
+    set (B := to_BinDirectSums A (C1 i) (C2 i)).
     apply (to_BinOpId A B).
   Qed.
 
   (** The unique morphisms in and out of BinDirectSum *)
-  Local Lemma DirectSumMorOut_comm (C1 C2 D : Complex) (f : Morphism C1 D) (g : Morphism C2 D)
+  Local Lemma DirectSumMorOut_comm {C1 C2 D : Complex} (f : Morphism C1 D) (g : Morphism C2 D)
         (i : hz) :
-    let B1 := to_BinDirectSums A (COb C1 i) (COb C2 i) in
-    let B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1)) in
-    FromBinDirectSum A B1 (MMor f i) (MMor g i) ;;  CMor D i =
-    (BinDirectSumIndAr A (CMor C1 i) (CMor C2 i) B1 B2)
+    let B1 := to_BinDirectSums A (C1 i) (C2 i) in
+    let B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1)) in
+    (FromBinDirectSum A B1 (MMor f i) (MMor g i)) ;; (@Diff D i) =
+    (BinDirectSumIndAr A (@Diff C1 i) (@Diff C2 i) B1 B2)
       ;; (FromBinDirectSum A B2 (MMor f (i + 1)) (MMor g (i + 1))).
   Proof.
     cbn.
-    set (B1 := to_BinDirectSums A (COb C1 i) (COb C2 i)).
-    set (B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1))).
+    set (B1 := to_BinDirectSums A (C1 i) (C2 i)).
+    set (B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1))).
     rewrite BinDirectSumIndArEq1.
     unfold BinDirectSumIndArFormula. cbn.
     rewrite to_postmor_linear'.
@@ -540,25 +546,23 @@ Section def_complexes.
     apply idpath.
   Qed.
 
-  Definition DirectSumMorOut (C1 C2 D: Complex) (f : Morphism C1 D) (g : Morphism C2 D) :
+  Definition DirectSumMorOut {C1 C2 D : Complex} (f : Morphism C1 D) (g : Morphism C2 D) :
     Morphism (DirectSumComplex C1 C2) D.
   Proof.
     use mk_Morphism.
     - intros i. exact (FromBinDirectSum A _ (MMor f i) (MMor g i)).
-    - intros i. exact (DirectSumMorOut_comm C1 C2 D f g i).
+    - intros i. exact (DirectSumMorOut_comm f g i).
   Defined.
 
-  Local Lemma DirectSumMorIn_comm (C1 C2 D : Complex) (f : Morphism D C1) (g : Morphism D C2)
+  Local Lemma DirectSumMorIn_comm {C1 C2 D : Complex} (f : Morphism D C1) (g : Morphism D C2)
         (i : hz) :
-    let B1 := to_BinDirectSums A (COb C1 i) (COb C2 i) in
-    let B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1)) in
+    let B1 := to_BinDirectSums A (C1 i) (C2 i) in
+    let B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1)) in
     (ToBinDirectSum A B1 (MMor f i) (MMor g i))
-      ;; (BinDirectSumIndAr A (CMor C1 i) (CMor C2 i) B1 B2) =
-    CMor D i ;; ToBinDirectSum A B2 (MMor f (i + 1)) (MMor g (i + 1)).
+      ;; (BinDirectSumIndAr A (@Diff C1 i) (@Diff C2 i) B1 B2) =
+    (@Diff D i) ;; (ToBinDirectSum A B2 (MMor f (i + 1)) (MMor g (i + 1))).
   Proof.
-    cbn.
-    set (B1 := to_BinDirectSums A (COb C1 i) (COb C2 i)).
-    set (B2 := to_BinDirectSums A (COb C1 (i + 1)) (COb C2 (i + 1))).
+    intros B1 B2.
     rewrite BinDirectSumIndArEq1.
     unfold BinDirectSumIndArFormula.
     rewrite to_premor_linear'.
@@ -575,12 +579,12 @@ Section def_complexes.
     apply idpath.
   Qed.
 
-  Definition DirectSumMorIn (C1 C2 D : Complex) (f : Morphism D C1) (g : Morphism D C2) :
+  Definition DirectSumMorIn {C1 C2 D : Complex} (f : Morphism D C1) (g : Morphism D C2) :
     Morphism D (DirectSumComplex C1 C2).
   Proof.
     use mk_Morphism.
     - intros i. exact (ToBinDirectSum A _ (MMor f i) (MMor g i)).
-    - intros i. exact (DirectSumMorIn_comm C1 C2 D f g i).
+    - intros i. exact (DirectSumMorIn_comm f g i).
   Defined.
 
 
@@ -610,7 +614,7 @@ Section def_complexes.
   Defined.
 
   Local Lemma ComplexFromObject_comm (X : ob A) (i : hz) :
-    Π i0 : hz, ComplexFromObject_mors X i i0 ;; ComplexFromObject_mors X i (i0 + 1) =
+    Π i0 : hz, (ComplexFromObject_mors X i i0) ;; (ComplexFromObject_mors X i (i0 + 1)) =
                ZeroArrow (Additive.to_Zero A) _ _.
   Proof.
     intros i0.
@@ -634,7 +638,7 @@ Section def_complexes.
 
   (** A morphisms in A induces a morphisms of ComplexFromObjects *)
   Definition ObjectMorToComplexMor_mors {a b : ob A} (f : a --> b) (i : hz) :
-    Π i0 : hz, A ⟦COb (ComplexFromObject a i) i0, COb (ComplexFromObject b i) i0⟧.
+    Π i0 : hz, A ⟦(ComplexFromObject a i) i0, (ComplexFromObject b i) i0⟧.
   Proof.
     intros i0.
     unfold ComplexFromObject. cbn. unfold ComplexFromObject_obs. cbn. unfold coprod_rect.
@@ -644,8 +648,8 @@ Section def_complexes.
   Defined.
 
   Local Lemma ObjectMorToComplexMor_comm {a b : ob A} (f : a --> b) (i : hz) :
-    Π i0 : hz, ObjectMorToComplexMor_mors f i i0 ;; CMor (ComplexFromObject b i) i0 =
-               CMor (ComplexFromObject a i) i0 ;; ObjectMorToComplexMor_mors f i (i0 + 1).
+    Π i0 : hz, (ObjectMorToComplexMor_mors f i i0) ;; (@Diff (ComplexFromObject b i) i0) =
+               (@Diff (ComplexFromObject a i) i0) ;; (ObjectMorToComplexMor_mors f i (i0 + 1)).
   Proof.
     intros i0.
     unfold ComplexFromObject. unfold ComplexFromObject_mors. unfold ComplexFromObject_obs. cbn.
@@ -705,7 +709,7 @@ Section def_complexes.
   Defined.
 
   Local Lemma Complex2FromObject_comm (a : ob A) (i : hz) :
-    Π i0 : hz, Complex2FromObject_mors a i i0 ;; Complex2FromObject_mors a i (i0 + 1) =
+    Π i0 : hz, (Complex2FromObject_mors a i i0) ;; (Complex2FromObject_mors a i (i0 + 1)) =
                ZeroArrow (Additive.to_Zero A) _ _.
   Proof.
     intros i0.
@@ -757,8 +761,8 @@ Section def_complexes.
 
   (** *** Morphism from Complex2FromObject to complex *)
 
-  Definition FromComplex2FromObject_mors {a : ob A} (C : Complex) (i : hz) (f : a --> (COb C i)) :
-    Π i0 : hz, A ⟦ COb (Complex2FromObject a i) i0, COb C i0 ⟧.
+  Definition FromComplex2FromObject_mors {a : ob A} {C : Complex} {i : hz} (f : a --> (C i)) :
+    Π i0 : hz, A ⟦(Complex2FromObject a i) i0, C i0⟧.
   Proof.
     intros i0.
     unfold Complex2FromObject. unfold Complex2FromObject_obs. unfold Complex2FromObject_mors. cbn.
@@ -766,13 +770,13 @@ Section def_complexes.
     induction (isdecrelhzeq i i0) as [e | n].
     + induction e. exact f.
     + induction (isdecrelhzeq (i + 1) i0) as [e' | n'].
-      * induction e'. exact (f ;; (CMor C i)).
+      * induction e'. exact (f ;; (Diff i)).
       * apply (ZeroArrow (Additive.to_Zero A)).
   Defined.
 
-  Local Lemma FromComplex2FromObject_comm {a : ob A} (C : Complex) (i : hz) (f : a --> (COb C i)) :
-    Π i0 : hz, FromComplex2FromObject_mors C i f i0 ;; CMor C i0 =
-               CMor (Complex2FromObject a i) i0 ;; FromComplex2FromObject_mors C i f (i0 + 1).
+  Local Lemma FromComplex2FromObject_comm {a : ob A} {C : Complex} {i : hz} (f : a --> (C i)) :
+    Π i0 : hz, (FromComplex2FromObject_mors f i0) ;; (@Diff C i0) =
+               (@Diff (Complex2FromObject a i) i0) ;; (FromComplex2FromObject_mors f (i0 + 1)).
   Proof.
     intros i0.
     unfold Complex2FromObject. unfold Complex2FromObject_obs. unfold Complex2FromObject_mors.
@@ -802,30 +806,30 @@ Section def_complexes.
            ++ rewrite ZeroArrow_comp_right. apply ZeroArrow_comp_left.
   Qed.
 
-  Definition FromComplex2FromObject {a : ob A} (C : Complex) (i : hz) (f : a --> (COb C i)) :
+  Definition FromComplex2FromObject {a : ob A} {C : Complex} {i : hz} (f : a --> (C i)) :
     Morphism (Complex2FromObject a i) C.
   Proof.
     use mk_Morphism.
-    - exact (FromComplex2FromObject_mors C i f).
-    - exact (FromComplex2FromObject_comm C i f).
+    - exact (FromComplex2FromObject_mors f).
+    - exact (FromComplex2FromObject_comm f).
   Defined.
 
-  Lemma FromComplex2FromObject_Eq1 {a : ob A} (C : Complex) (i i0 : hz) (g : a --> (COb C i)) :
-    FromComplex2FromObject_mors C i g i0 = MMor (FromComplex2FromObject C i g) i0.
+  Lemma FromComplex2FromObject_Eq1 {a : ob A} {C : Complex} {i : hz} (i0 : hz) (g : a --> (C i)) :
+    FromComplex2FromObject_mors g i0 = MMor (FromComplex2FromObject g) i0.
   Proof.
     apply idpath.
   Qed.
 
   (** *** Morphism from complex to Complex2FromObject *)
 
-  Definition ToComplex2FromObject_mors {a : ob A} (C : Complex) (i : hz) (f : (COb C i) --> a) :
-    Π i0 : hz, A ⟦COb C i0, COb (Complex2FromObject a (i - 1)) i0⟧.
+  Definition ToComplex2FromObject_mors {a : ob A} {C : Complex} {i : hz} (f : (C i) --> a) :
+    Π i0 : hz, A ⟦C i0, (Complex2FromObject a (i - 1)) i0⟧.
   Proof.
     intros i0. unfold Complex2FromObject. unfold Complex2FromObject_obs. cbn. unfold coprod_rect.
     induction (isdecrelhzeq (i - 1) i0) as [e | n].
     - induction (isdecrelhzeq i (i - 1 + 1)) as [e' | n'].
       + eapply compose.
-        * induction e. exact (CMor C (i - 1)).
+        * induction e. exact (Diff (i - 1)).
         * induction e'. exact f.
       + apply fromempty. apply n'. apply pathsinv0. apply (hzrminusplus i 1).
     - induction (isdecrelhzeq (i - 1 + 1) i0) as [e' | n'].
@@ -836,9 +840,9 @@ Section def_complexes.
       + apply (ZeroArrow (Additive.to_Zero A)).
   Defined.
 
-  Local Lemma ToComplex2FromObject_comm {a : ob A} (C : Complex) (i : hz) (f : (COb C i) --> a) :
-    Π i0 : hz, ToComplex2FromObject_mors C i f i0 ;; CMor (Complex2FromObject a (i - 1)) i0 =
-               CMor C i0 ;; ToComplex2FromObject_mors C i f (i0 + 1).
+  Local Lemma ToComplex2FromObject_comm {a : ob A} {C : Complex} {i : hz} (f : (C i) --> a) :
+    Π i0 : hz, (ToComplex2FromObject_mors f i0) ;; (@Diff (Complex2FromObject a (i - 1)) i0) =
+               (@Diff C i0) ;; (ToComplex2FromObject_mors f (i0 + 1)).
   Proof.
     intros i0.
     unfold Complex2FromObject. unfold Complex2FromObject_obs. unfold Complex2FromObject_mors.
@@ -875,7 +879,7 @@ Section def_complexes.
       + induction (isdecrelhzeq (i - 1) (i0 + 1)) as [e'' | n''].
         * induction (isdecrelhzeq i (i - 1 + 1)) as [e''' | n'''].
           -- rewrite assoc. rewrite ZeroArrow_comp_right.
-             set (mor := match e''' in (_ = y) return (A ⟦ COb C y, a ⟧) with
+             set (mor := match e''' in (_ = y) return (A ⟦ C y, a ⟧) with
                       | idpath _ => f
                       end).
              rewrite <- (ZeroArrow_comp_left _ _ _ _ _ mor). unfold mor. clear mor.
@@ -887,23 +891,22 @@ Section def_complexes.
              apply idpath.
   Qed.
 
-  Definition ToComplex2FromObject {a : ob A} (C : Complex) (i : hz) (f : (COb C i) --> a) :
+  Definition ToComplex2FromObject {a : ob A} {C : Complex} {i : hz} (f : (C i) --> a) :
     Morphism C (Complex2FromObject a (i - 1)).
   Proof.
     use mk_Morphism.
-    - exact (ToComplex2FromObject_mors C i f).
-    - exact (ToComplex2FromObject_comm C i f).
+    - exact (ToComplex2FromObject_mors f).
+    - exact (ToComplex2FromObject_comm f).
   Defined.
 
-  Lemma ToComplex2FromObject_Eq1 {a : ob A} (C : Complex) (i i0 : hz) (g : (COb C i ) --> a) :
-    ToComplex2FromObject_mors C i g i0 = MMor (ToComplex2FromObject C i g) i0.
+  Lemma ToComplex2FromObject_Eq1 {a : ob A} {C : Complex} {i : hz} (i0 : hz) (g : (C i) --> a) :
+    ToComplex2FromObject_mors g i0 = MMor (ToComplex2FromObject g) i0.
   Proof.
     apply idpath.
   Qed.
 
 End def_complexes.
-Arguments COb [A] _ _.
-Arguments CMor [A] _ _.
+Arguments Diff [A] _ _.
 Arguments ZeroComplex [A].
 Arguments Morphism [A] _ _.
 Arguments MorphismEq [A] [C1] [C2] _ _ _.
@@ -966,12 +969,12 @@ Section complexes_precat.
   (** ** Monic of complexes is indexwise monic *)
 
   Local Lemma ComplexMonicIndexMonic_eq {C1 C2 : Complex A} (M : Monic ComplexPreCat C1 C2) (i : hz)
-        (a : A) (g h : A ⟦a, COb C1 i⟧)
-        (H : g ;; MMor (MonicArrow _ M) i = h ;; MMor (MonicArrow _ M) i) :
-    FromComplex2FromObject_mors A C1 i g i = FromComplex2FromObject_mors A C1 i h i.
+        {a : A} (g h : A ⟦a, C1 i⟧)
+        (H : g ;; (MMor (MonicArrow _ M) i) = h ;; (MMor (MonicArrow _ M) i)) :
+    FromComplex2FromObject_mors A g i = FromComplex2FromObject_mors A h i.
   Proof.
-    use (pathscomp0 (FromComplex2FromObject_Eq1 A C1 i i g)).
-    use (pathscomp0 _ (! (FromComplex2FromObject_Eq1 A C1 i i h))).
+    use (pathscomp0 (FromComplex2FromObject_Eq1 A i g)).
+    use (pathscomp0 _ (! (FromComplex2FromObject_Eq1 A i h))).
     use MorphismEq'.
     use (MonicisMonic ComplexPreCat M). cbn.
     use MorphismEq.
@@ -990,7 +993,7 @@ Section complexes_precat.
     Π i : hz, isMonic (@MMor A C1 C2 (MonicArrow _ M) i).
   Proof.
     intros i a g h H.
-    set (tmp := ComplexMonicIndexMonic_eq M i a g h H).
+    set (tmp := ComplexMonicIndexMonic_eq M i g h H).
     unfold FromComplex2FromObject_mors in tmp. cbn in tmp.
     unfold coprod_rect in tmp. unfold Complex2FromObject_obs in tmp.
     unfold paths_rect in tmp. cbn in tmp.
@@ -1002,12 +1005,12 @@ Section complexes_precat.
   (** ** Epi of complexes is indexwise epi *)
 
   Local Lemma ComplexEpiIndexEpi_eq {C1 C2 : Complex A} (E : Epi ComplexPreCat C1 C2) (i : hz)
-        (a : A) (g h : A ⟦ COb C2 i, a ⟧)
-        (H : MMor (EpiArrow _ E) i ;; g = MMor (EpiArrow _ E) i ;; h) :
-    ToComplex2FromObject_mors A C2 i g i = ToComplex2FromObject_mors A C2 i h i.
+        {a : A} (g h : A ⟦C2 i, a⟧)
+        (H : (MMor (EpiArrow _ E) i) ;; g = (MMor (EpiArrow _ E) i) ;; h) :
+    ToComplex2FromObject_mors A g i = ToComplex2FromObject_mors A h i.
   Proof.
-    use (pathscomp0 (ToComplex2FromObject_Eq1 A C2 i i g)).
-    use (pathscomp0 _ (! (ToComplex2FromObject_Eq1 A C2 i i h))).
+    use (pathscomp0 (ToComplex2FromObject_Eq1 A i g)).
+    use (pathscomp0 _ (! (ToComplex2FromObject_Eq1 A i h))).
     use MorphismEq'.
     use (EpiisEpi ComplexPreCat E). cbn.
     use MorphismEq.
@@ -1032,7 +1035,7 @@ Section complexes_precat.
     Π i : hz, isEpi (@MMor A C1 C2 (EpiArrow _ E) i).
   Proof.
     intros i a g h H.
-    set (tmp := ComplexEpiIndexEpi_eq E i a g h H).
+    set (tmp := ComplexEpiIndexEpi_eq E i g h H).
     unfold ToComplex2FromObject_mors in tmp. cbn in tmp.
     unfold coprod_rect in tmp. unfold Complex2FromObject_obs in tmp.
     unfold paths_rect in tmp. cbn in tmp.
@@ -1124,7 +1127,7 @@ Section complexes_additive.
     - apply has_homsets_ComplexPreCat.
     - intros D f g.
       use unique_exists.
-      + exact (DirectSumMorOut A C1 C2 D f g).
+      + exact (DirectSumMorOut A f g).
       (* Commutativity *)
       + split.
         * use MorphismEq.
@@ -1152,7 +1155,7 @@ Section complexes_additive.
     - apply has_homsets_ComplexPreCat.
     - intros D f g.
       use unique_exists.
-      + exact (DirectSumMorIn A C1 C2 D f g).
+      + exact (DirectSumMorIn A f g).
       (* Commutativity *)
       + split.
         * use MorphismEq.
@@ -1227,8 +1230,8 @@ Section complexes_abelian.
   (** *** Construction of the kernel object *)
 
   Local Lemma ComplexPreCat_Kernel_moreq {Y Z : Complex (AbelianToAdditive A hs)} (g : Morphism Y Z)
-        (i : hz) : KernelArrow (Kernel (MMor g i)) ;; CMor Y i ;; MMor g (i + 1) =
-                   ZeroArrow (@to_Zero A) (Kernel (MMor g i)) (COb Z (i + 1)).
+        (i : hz) : (KernelArrow (Kernel (MMor g i))) ;; (Diff Y i) ;; (MMor g (i + 1)) =
+                   ZeroArrow (@to_Zero A) (Kernel (MMor g i)) (Z (i + 1)).
   Proof.
     rewrite <- assoc. cbn. set (tmp := MComm g i). cbn in tmp. rewrite <- tmp. clear tmp.
     rewrite assoc. rewrite KernelCompZero. apply ZeroArrow_comp_left.
@@ -1236,12 +1239,12 @@ Section complexes_abelian.
 
   Local Lemma ComplexPreCat_Kernel_comp {Y Z : Complex (AbelianToAdditive A hs)} (g : Morphism Y Z)
         (i : hz) :
-    KernelIn (@to_Zero A) (Kernel (MMor g (i + 1))) (Kernel (MMor g i))
-             (KernelArrow (Kernel (MMor g i)) ;; CMor Y i)
-             (ComplexPreCat_Kernel_moreq g i) ;;
-             KernelIn (@to_Zero A) (Kernel (MMor g (i + 1 + 1))) (Kernel (MMor g (i + 1)))
-             (KernelArrow (Kernel (MMor g (i + 1))) ;; CMor Y (i + 1))
-             (ComplexPreCat_Kernel_moreq g (i + 1)) =
+    (KernelIn (@to_Zero A) (Kernel (MMor g (i + 1))) (Kernel (MMor g i))
+              ((KernelArrow (Kernel (MMor g i))) ;; (Diff Y i))
+              (ComplexPreCat_Kernel_moreq g i))
+      ;; (KernelIn (@to_Zero A) (Kernel (MMor g (i + 1 + 1))) (Kernel (MMor g (i + 1)))
+                   ((KernelArrow (Kernel (MMor g (i + 1)))) ;; (Diff Y (i + 1)))
+                   (ComplexPreCat_Kernel_moreq g (i + 1))) =
     ZeroArrow (@to_Zero A) (Kernel (MMor g i)) (Kernel (MMor g (i + 1 + 1))).
   Proof.
     apply KernelArrowisMonic. rewrite ZeroArrow_comp_left.
@@ -1256,37 +1259,25 @@ Section complexes_abelian.
     use mk_Complex.
     - intros i. exact (Kernel (MMor g i)).
     - intros i. cbn. use KernelIn.
-      + exact (KernelArrow (Kernel (MMor g i)) ;; CMor Y i).
+      + exact (KernelArrow (Kernel (MMor g i)) ;; Diff Y i).
       + exact (ComplexPreCat_Kernel_moreq g i).
     - intros i. exact (ComplexPreCat_Kernel_comp g i).
   Defined.
 
   (** *** Construction of the KernelArrow *)
-  Local Lemma ComplexPreCat_KernelArrow_eq (Y Z : Complex (AbelianToAdditive A hs))
-        (g : Morphism Y Z) (i : hz) :
-    KernelArrow (Kernel (MMor g i)) ;; CMor Y i =
-    KernelIn (@to_Zero A) (Kernel (MMor g (i + 1))) (Kernel (MMor g i))
-             (KernelArrow (Kernel (MMor g i)) ;; CMor Y i)
-             (ComplexPreCat_Kernel_moreq g i) ;;
-             KernelArrow (Kernel (MMor g (i + 1))).
-  Proof.
-    rewrite KernelCommutes. apply idpath.
-  Qed.
-
   Definition ComplexPreCat_KernelArrow {Y Z : Complex (AbelianToAdditive A hs)}
              (g : Morphism Y Z) : Morphism (ComplexPreCat_Kernel g) Y.
   Proof.
     use mk_Morphism.
     - intros i. use KernelArrow.
-    - intros i. use ComplexPreCat_KernelArrow_eq.
+    - intros i. exact (! (KernelCommutes _ _ _ _ _)).
   Defined.
 
 
   (** *** isEqualizer  *)
   Local Lemma ComplexPreCat_Kernels_comp {X Y : Complex (AbelianToAdditive A hs)}
         (g : Morphism X Y) :
-    let Z := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                      ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs)) in
+    let Z := Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
     MorphismComp (ComplexPreCat_KernelArrow g) g =
     MorphismComp (ZeroArrowTo (ComplexPreCat_Kernel g)) (@ZeroArrowFrom _ Z Y).
   Proof.
@@ -1296,10 +1287,9 @@ Section complexes_abelian.
 
   Local Lemma ComplexPreCat_KernelIn_comp {X Y w : Complex (AbelianToAdditive A hs)} (g : Morphism X Y)
     (h : Morphism w X) (i : hz) :
-    let Z := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                      ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs)) in
+    let Z := Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
     MorphismComp h g = ZeroArrow Z w Y ->
-    MMor h i ;; MMor g i = ZeroArrow to_Zero (COb w i) (COb Y i).
+    (MMor h i) ;; (MMor g i) = ZeroArrow to_Zero (w i) (Y i).
   Proof.
     intros Z H.
     set (tmp := MorphismEq' _ (MorphismComp h g) (ZeroArrow Z _ _) H i). cbn in tmp.
@@ -1308,8 +1298,7 @@ Section complexes_abelian.
 
   Definition ComplexPreCat_KernelIn {X Y w : Complex (AbelianToAdditive A hs)} (g : Morphism X Y)
     (h : Morphism w X) :
-    let Z := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                      ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs)) in
+    let Z := Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
     MorphismComp h g = ZeroArrow Z w Y ->
     (ComplexPreCat (AbelianToAdditive A hs)) ⟦w, ComplexPreCat_Kernel g⟧.
   Proof.
@@ -1330,8 +1319,7 @@ Section complexes_abelian.
 
   Local Lemma ComplexPreCat_Kernels_isEqualizer {X Y : Complex (AbelianToAdditive A hs)}
         (g : Morphism X Y) :
-    let Z := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                      ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs)) in
+    let Z := Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
     @equalizers.isEqualizer
       (ComplexPreCat (AbelianToAdditive A hs)) _ _ _
       g (MorphismComp (@ZeroArrowTo _ Z X) (@ZeroArrowFrom _ Z Y)) (ComplexPreCat_KernelArrow g)
@@ -1374,22 +1362,23 @@ Section complexes_abelian.
   (** ** Cokernels in Complexes over Abelian *)
 
   (** *** Cokernel complex *)
-  Local Lemma ComplexPreCat_Cokernel_eq (Y Z : Complex (AbelianToAdditive A hs)) (g : Morphism Y Z)
-        (i : hz) : MMor g i ;; (CMor Z i ;; CokernelArrow (Cokernel (MMor g (i + 1)))) =
-                   ZeroArrow (@to_Zero A) (COb Y i) (Cokernel (MMor g (i + 1))).
+  Local Lemma ComplexPreCat_Cokernel_comm {Y Z : Complex (AbelianToAdditive A hs)}
+        (g : Morphism Y Z) (i : hz) :
+    (MMor g i) ;; ((Diff Z i) ;; (CokernelArrow (Cokernel (MMor g (i + 1))))) =
+    ZeroArrow (@to_Zero A) (Y i) (Cokernel (MMor g (i + 1))).
   Proof.
     rewrite assoc. cbn. set (tmp := MComm g i). cbn in tmp. rewrite tmp. clear tmp.
     rewrite <- assoc. rewrite CokernelCompZero. apply ZeroArrow_comp_right.
   Qed.
 
-  Local Lemma ComplexPreCat_Cokernel_comp (Y Z : Complex (AbelianToAdditive A hs))
+  Local Lemma ComplexPreCat_Cokernel_comp {Y Z : Complex (AbelianToAdditive A hs)}
         (g : Morphism Y Z) (i : hz) :
     (CokernelOut (@to_Zero A) (Cokernel (MMor g i)) (Cokernel (MMor g (i + 1)))
-                 (CMor Z i ;; CokernelArrow (Cokernel (MMor g (i + 1))))
-                 (ComplexPreCat_Cokernel_eq Y Z g i))
+                 ((Diff Z i) ;; (CokernelArrow (Cokernel (MMor g (i + 1)))))
+                 (ComplexPreCat_Cokernel_comm g i))
       ;; (CokernelOut (@to_Zero A) (Cokernel (MMor g (i + 1))) (Cokernel (MMor g (i + 1 + 1)))
-                      (CMor Z (i + 1) ;; CokernelArrow (Cokernel (MMor g (i + 1 + 1))))
-                      (ComplexPreCat_Cokernel_eq Y Z g (i + 1))) =
+                      ((Diff Z (i + 1)) ;; (CokernelArrow (Cokernel (MMor g (i + 1 + 1)))))
+                      (ComplexPreCat_Cokernel_comm g (i + 1))) =
     ZeroArrow (@to_Zero A) (Cokernel (MMor g i)) (Cokernel (MMor g (i + 1 + 1))).
   Proof.
     apply CokernelArrowisEpi. rewrite ZeroArrow_comp_right.
@@ -1404,29 +1393,18 @@ Section complexes_abelian.
     use mk_Complex.
     - intros i. exact (Cokernel (MMor g i)).
     - intros i. cbn. use CokernelOut.
-      + exact (CMor Z i ;; CokernelArrow (Cokernel (MMor g (i + 1)))).
-      + exact (ComplexPreCat_Cokernel_eq Y Z g i).
-    - intros i. exact (ComplexPreCat_Cokernel_comp Y Z g i).
+      + exact ((Diff Z i) ;; (CokernelArrow (Cokernel (MMor g (i + 1))))).
+      + exact (ComplexPreCat_Cokernel_comm g i).
+    - intros i. exact (ComplexPreCat_Cokernel_comp g i).
   Defined.
 
   (** *** CokernelArrow *)
-  Local Lemma ComplexPreCat_CokernelArrow_comm (Y Z : Complex (AbelianToAdditive A hs))
-        (g : Morphism Y Z) (i : hz) :
-    (CokernelArrow (Cokernel (MMor g i)))
-      ;; (CokernelOut (@to_Zero A) (Cokernel (MMor g i)) (Cokernel (MMor g (i + 1)))
-                      (CMor Z i ;; CokernelArrow (Cokernel (MMor g (i + 1))))
-                      (ComplexPreCat_Cokernel_eq Y Z g i)) =
-    CMor Z i ;; CokernelArrow (Cokernel (MMor g (i + 1))).
-  Proof.
-    rewrite CokernelCommutes. apply idpath.
-  Qed.
-
   Definition ComplexPreCat_CokernelArrow {Y Z : Complex (AbelianToAdditive A hs)}
              (g : Morphism Y Z) : Morphism Z (ComplexPreCat_Cokernel g).
   Proof.
     use mk_Morphism.
     - intros i. use CokernelArrow.
-    - intros i. use ComplexPreCat_CokernelArrow_comm.
+    - intros i. use CokernelCommutes.
   Defined.
 
   (** *** Cokernel *)
@@ -1434,31 +1412,28 @@ Section complexes_abelian.
         (g : (ComplexPreCat (AbelianToAdditive A hs))⟦Y, Z⟧)
         (h : (ComplexPreCat (AbelianToAdditive A hs))⟦Z, w⟧)
         (i : hz) :
-    let Z0 := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                       ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs)) in
+    let Z0 := Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
     g ;; h = ZeroArrow Z0 Y w ->
-    MMor g i ;; MMor h i = ZeroArrow (@to_Zero A) (COb Y i) (COb w i).
+    (MMor g i) ;; (MMor h i) = ZeroArrow (@to_Zero A) (Y i) (w i).
   Proof.
     intros Z0. cbn. intros H. set (tmp := MorphismEq' _ (g ;; h) _ H i). cbn in tmp.
     rewrite tmp. apply ZeroArrowEq.
   Qed.
 
-  Local Lemma ComplexPreCat_Cokernels_eq (Y Z : Complex (AbelianToAdditive A hs))
+  Local Lemma ComplexPreCat_Cokernels_Eq {Y Z w : Complex (AbelianToAdditive A hs)}
         (g : (ComplexPreCat (AbelianToAdditive A hs))⟦Y, Z⟧)
-        (w : (ComplexPreCat (AbelianToAdditive A hs)))
         (h : (ComplexPreCat (AbelianToAdditive A hs))⟦Z, w⟧)
-        (H' : g ;; h =
-              ZeroArrow (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                                  ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs))) Y w)
+        (H : g ;; h =
+             ZeroArrow (Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs))) Y w)
         (i : hz) :
-    CokernelOut (@to_Zero A) (Cokernel (MMor g i)) (COb w i) (MMor h i)
-                (ComplexPreCat_CokernelCompZero g h i H') ;; CMor w i =
+    (CokernelOut (@to_Zero A) (Cokernel (MMor g i)) (w i) (MMor h i)
+                 (ComplexPreCat_CokernelCompZero g h i H)) ;; (Diff w i) =
     (CokernelOut (@to_Zero A) (Cokernel (MMor g i)) (Cokernel (MMor g (i + 1)))
-                 (CMor Z i ;; CokernelArrow (Cokernel (MMor g (i + 1))))
-                 (ComplexPreCat_Cokernel_eq Y Z g i))
+                 ((Diff Z i) ;; (CokernelArrow (Cokernel (MMor g (i + 1)))))
+                 (ComplexPreCat_Cokernel_comm g i))
       ;; (CokernelOut (@to_Zero A) (Cokernel (MMor g (i + 1)))
-                      (COb w (i + 1)) (MMor h (i + 1))
-                      (ComplexPreCat_CokernelCompZero g h (i + 1) H')).
+                      (w (i + 1)) (MMor h (i + 1))
+                      (ComplexPreCat_CokernelCompZero g h (i + 1) H)).
   Proof.
     apply CokernelArrowisEpi.
     rewrite assoc. rewrite assoc. rewrite CokernelCommutes.
@@ -1466,10 +1441,9 @@ Section complexes_abelian.
     apply (MComm h i).
   Qed.
 
-  Local Lemma ComplexPreCat_Cokernels_comp {Y Z : Complex (AbelianToAdditive A hs)}
+  Local Lemma ComplexPreCat_Cokernels_Comp {Y Z : Complex (AbelianToAdditive A hs)}
         (g : (ComplexPreCat (AbelianToAdditive A hs))⟦Y, Z⟧) :
-    let Z0 := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                       ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs)) in
+    let Z0 := Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
     MorphismComp g (ComplexPreCat_CokernelArrow g) =
     MorphismComp (@ZeroArrowTo _ Z0 Y) (@ZeroArrowFrom _ Z0 (ComplexPreCat_Cokernel g)).
   Proof.
@@ -1477,13 +1451,12 @@ Section complexes_abelian.
     intros i. cbn. rewrite CokernelCompZero. apply pathsinv0. apply ZeroArrowEq.
   Qed.
 
-  Local Lemma ComplexPreCat_Cokernels_isEqualizer {Y Z : Complex (AbelianToAdditive A hs)}
+  Local Lemma ComplexPreCat_Cokernels_isCoequalizer {Y Z : Complex (AbelianToAdditive A hs)}
         (g : (ComplexPreCat (AbelianToAdditive A hs))⟦Y, Z⟧) :
-    let Z0 := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                       ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs)) in
+    let Z0 := Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
     coequalizers.isCoequalizer
       g (MorphismComp (@ZeroArrowTo _ Z0 Y) (@ZeroArrowFrom _ Z0 Z))
-      (ComplexPreCat_CokernelArrow g) (CokernelEqRw Z0 (ComplexPreCat_Cokernels_comp g)).
+      (ComplexPreCat_CokernelArrow g) (CokernelEqRw Z0 (ComplexPreCat_Cokernels_Comp g)).
   Proof.
     intros Z0.
     use mk_isCoequalizer.
@@ -1493,7 +1466,7 @@ Section complexes_abelian.
       + intros i. cbn. use CokernelOut.
         * exact (MMor h i).
         * exact (ComplexPreCat_CokernelCompZero g h i H').
-      + intros i. cbn. apply ComplexPreCat_Cokernels_eq.
+      + intros i. cbn. use ComplexPreCat_Cokernels_Eq.
     - cbn. use MorphismEq. intros i. use CokernelCommutes.
     - intros y. apply has_homsets_ComplexPreCat.
     - intros y T. cbn beta in T.
@@ -1506,8 +1479,7 @@ Section complexes_abelian.
   Qed.
 
   Definition ComplexPreCat_Cokernels :
-    Cokernels (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                        ZeroComplex (ComplexPreCat_isZero (AbelianToAdditive A hs))).
+    Cokernels (Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs))).
   Proof.
     intros Y Z g. cbn in *.
     use mk_Cokernel.
@@ -1516,9 +1488,9 @@ Section complexes_abelian.
     (* CokernelArrow *)
     - exact(ComplexPreCat_CokernelArrow g).
     (* Composition is zero *)
-    - exact (ComplexPreCat_Cokernels_comp g).
+    - exact (ComplexPreCat_Cokernels_Comp g).
     (* isCoequalizer *)
-    - exact (ComplexPreCat_Cokernels_isEqualizer g).
+    - exact (ComplexPreCat_Cokernels_isCoequalizer g).
   Defined.
 
 
@@ -1529,8 +1501,8 @@ Section complexes_abelian.
     {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
     (M : Monic (ComplexPreCat_Additive (AbelianToAdditive A hs)) x y) (i : hz) :
     (MMor (MonicArrow _ M) i)
-      ;; (CMor y i ;; CokernelArrow (Cokernel (MMor (MonicArrow _ M) (i + 1)))) =
-    ZeroArrow (@to_Zero A) (COb x i) (Cokernel (MMor (MonicArrow _ M) (i + 1))).
+      ;; ((Diff y i) ;; (CokernelArrow (Cokernel (MMor (MonicArrow _ M) (i + 1))))) =
+    ZeroArrow (@to_Zero A) _ (Cokernel (MMor (MonicArrow _ M) (i + 1))).
   Proof.
     rewrite assoc. rewrite (MComm (MonicArrow _ M)). rewrite <- assoc.
     rewrite CokernelCompZero. apply ZeroArrow_comp_right.
@@ -1541,12 +1513,12 @@ Section complexes_abelian.
     (M : Monic (ComplexPreCat_Additive (AbelianToAdditive A hs)) x y) (i : hz) :
     (CokernelOut to_Zero (Cokernel (MMor (MonicArrow _ M) i))
                  (Cokernel (MMor (MonicArrow _ M) (i + 1)))
-                 (CMor y i ;; CokernelArrow (Cokernel (MMor (MonicArrow _ M) (i + 1))))
+                 ((Diff y i) ;; (CokernelArrow (Cokernel (MMor (MonicArrow _ M) (i + 1)))))
                  (ComplexPreCat_Monic_Kernel_Complex_comm M i))
       ;; (CokernelOut to_Zero (Cokernel (MMor (MonicArrow _ M) (i + 1)))
                       (Cokernel (MMor (MonicArrow _ M) (i + 1 + 1)))
-                      (CMor y (i + 1)
-                            ;; CokernelArrow (Cokernel (MMor (MonicArrow _ M) (i + 1 + 1))))
+                      ((Diff y (i + 1))
+                         ;; (CokernelArrow (Cokernel (MMor (MonicArrow _ M) (i + 1 + 1)))))
                       (ComplexPreCat_Monic_Kernel_Complex_comm M (i + 1))) =
     ZeroArrow
       to_Zero (Cokernel (MMor (MonicArrow _ M) i)) (Cokernel (MMor (MonicArrow _ M) (i + 1 + 1))).
@@ -1566,8 +1538,8 @@ Section complexes_abelian.
     use mk_Complex.
     - intros i. exact (Cokernel (@MMor _ x y (MonicArrow _ M) i)).
     - intros i. cbn. use CokernelOut.
-      + exact (CMor y i ;; (CokernelArrow (Cokernel (@MMor _ x y (MonicArrow _ M) (i + 1))))).
-      + apply ComplexPreCat_Monic_Kernel_Complex_comm.
+      + exact ((Diff y i) ;; (CokernelArrow (Cokernel (@MMor _ x y (MonicArrow _ M) (i + 1))))).
+      + use ComplexPreCat_Monic_Kernel_Complex_comm.
     - intros i. cbn. exact (ComplexPreCat_Monic_Kernel_Complex_comp M i).
   Defined.
 
@@ -1578,15 +1550,13 @@ Section complexes_abelian.
   Proof.
     use mk_Morphism.
     - intros i. apply CokernelArrow.
-    - intros i. cbn. rewrite CokernelCommutes. apply idpath.
+    - intros i. use CokernelCommutes.
   Defined.
 
   (** *** KernelIn *)
   Local Lemma KernelMorphism_eq {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
         (M : Monic (ComplexPreCat_Additive (AbelianToAdditive A hs)) x y) :
-    let Z := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                      (@ZeroComplex (AbelianToAdditive A hs))
-                      (ComplexPreCat_isZero (AbelianToAdditive A hs)) in
+    let Z := Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
     MorphismComp (MonicArrow _ M) (KernelMorphism M) =
     MorphismComp (MonicArrow _ M)
                  (MorphismComp
@@ -1594,69 +1564,73 @@ Section complexes_abelian.
                     (@ZeroArrowFrom (ComplexPreCat (AbelianToAdditive A hs)) Z
                                     (@ComplexPreCat_Monic_Kernel_Complex x y M))).
   Proof.
+    intros Z.
     use MorphismEq.
     intros i. cbn. rewrite CokernelCompZero.
     rewrite assoc. apply pathsinv0. apply ZeroArrowEq.
   Qed.
 
-  Lemma ComplexMonicKernelInComm (x y : Complex (AbelianToAdditive A hs))
+  Local Lemma ComplexMonicKernelInComm {x y : Complex (AbelianToAdditive A hs)}
         (M : Monic (ComplexPreCat (AbelianToAdditive A hs)) x y)
-        (w : ComplexPreCat (AbelianToAdditive A hs))
+        {w : ComplexPreCat (AbelianToAdditive A hs)}
         (h : (ComplexPreCat (AbelianToAdditive A hs))⟦w, y⟧)
-        (H' : h ;; KernelMorphism M =
-              h ;; (MorphismComp
-                      (@ZeroArrowTo (ComplexPreCat (AbelianToAdditive A hs))
-                                    (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                                              (@ZeroComplex (AbelianToAdditive A hs))
-                                              (ComplexPreCat_isZero (AbelianToAdditive A hs))) y)
-                      (@ZeroArrowFrom (ComplexPreCat (AbelianToAdditive A hs))
-                                      (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                                                (@ZeroComplex (AbelianToAdditive A hs))
-                                                (ComplexPreCat_isZero (AbelianToAdditive A hs)))
-                                      (@ComplexPreCat_Monic_Kernel_Complex x y M))))
+        (H : let Z := @Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
+             h ;; (KernelMorphism M) =
+             h ;; (MorphismComp (@ZeroArrowTo _ Z y)
+                                (@ZeroArrowFrom _ Z (@ComplexPreCat_Monic_Kernel_Complex x y M))))
         (i : hz) :
-    MMor h i ;; CokernelArrow (Cokernel (MMor (MonicArrow _ M) i)) =
-    ZeroArrow (@to_Zero A) (COb w i) (Cokernel (MMor (MonicArrow _ M) i)).
+    (MMor h i) ;; (CokernelArrow (Cokernel (MMor (MonicArrow _ M) i))) =
+    ZeroArrow (@to_Zero A) _ (Cokernel (MMor (MonicArrow _ M) i)).
   Proof.
-    set (H'' := MorphismEq' _ _ _ H' i). cbn in H''. cbn. rewrite H''.
+    set (H' := MorphismEq' _ _ _ H i). cbn in H'. cbn. rewrite H'.
     rewrite assoc. apply ZeroArrowEq.
   Qed.
 
-  Definition ComplexMonicKernelIn (x y : Complex (AbelianToAdditive A hs))
+  Local Lemma ComplexMonicKernelIn_Complex_Comm {x y w : Complex (AbelianToAdditive A hs)}
+        (M : Monic (ComplexPreCat (AbelianToAdditive A hs)) x y)
+        (h : (ComplexPreCat (AbelianToAdditive A hs))⟦w, y⟧) (i : hz)
+        (H : let Z := @Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
+             h ;; KernelMorphism M =
+             h ;; (MorphismComp (@ZeroArrowTo _ Z y)
+                                (@ZeroArrowFrom _ Z (@ComplexPreCat_Monic_Kernel_Complex x y M)))) :
+    (KernelIn
+       to_Zero
+       (MonicToKernel A hs (mk_Monic A (MMor (MonicArrow _ M) i) ((ComplexMonicIndexMonic _ M) i)))
+       (w i) (MMor h i) (ComplexMonicKernelInComm M h H i)) ;; (Diff x i) =
+    (Diff w i)
+      ;; (KernelIn
+            to_Zero
+            (MonicToKernel A hs (mk_Monic A (MMor (MonicArrow _ M) (i + 1))
+                                          ((ComplexMonicIndexMonic _ M) (i + 1))))
+            (w (i + 1)) (MMor h (i + 1)) (ComplexMonicKernelInComm M h H (i + 1))).
+  Proof.
+    set (isM := ComplexMonicIndexMonic _ M).
+    set (ker := MonicToKernel A hs (mk_Monic _ _ (isM (i + 1)))).
+    cbn in *. apply (KernelArrowisMonic _ ker).
+    rewrite <- assoc. rewrite <- assoc. fold ker.
+    rewrite (KernelCommutes _ ker). cbn. use (pathscomp0 _ (MComm h i)).
+    set (tmp := MComm (MonicArrow _ M) i). cbn in tmp. rewrite <- tmp. clear tmp.
+    rewrite assoc. apply cancel_postcomposition.
+    apply (KernelCommutes _ (MonicToKernel A hs (mk_Monic A _ (isM i))) (w i) (MMor h i)).
+  Qed.
+
+  Definition ComplexMonicKernelIn {x y : Complex (AbelianToAdditive A hs)}
              (M : Monic (ComplexPreCat (AbelianToAdditive A hs)) x y)
-             (w : ComplexPreCat (AbelianToAdditive A hs))
-             (h : (ComplexPreCat (AbelianToAdditive A hs))⟦w, y⟧)
-             (H' : h ;; KernelMorphism M =
-                   h ;; (MorphismComp
-                           (@ZeroArrowTo
-                              (ComplexPreCat (AbelianToAdditive A hs))
-                              (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                                        (@ZeroComplex (AbelianToAdditive A hs))
-                                        (ComplexPreCat_isZero (AbelianToAdditive A hs))) y)
-                           (@ZeroArrowFrom
-                              (ComplexPreCat (AbelianToAdditive A hs))
-                              (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                                        (@ZeroComplex (AbelianToAdditive A hs))
-                                        (ComplexPreCat_isZero (AbelianToAdditive A hs)))
-                              (@ComplexPreCat_Monic_Kernel_Complex x y M)))) :
+             {w : ComplexPreCat (AbelianToAdditive A hs)}
+             (h : (ComplexPreCat (AbelianToAdditive A hs))⟦w, y⟧) :
+    let Z := Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
+    h ;; (KernelMorphism M) =
+    h ;; (MorphismComp (@ZeroArrowTo _ Z y)
+                       (@ZeroArrowFrom _ Z (ComplexPreCat_Monic_Kernel_Complex M))) ->
     (ComplexPreCat (AbelianToAdditive A hs))⟦w, x⟧.
   Proof.
+    intros Z H'.
     set (isM := ComplexMonicIndexMonic _ M).
     use mk_Morphism.
     - intros i.
-      set (ker := MonicToKernel A hs (mk_Monic _ _ (isM i))).
-      apply (KernelIn (@to_Zero A) ker (COb w i) (MMor h i) (ComplexMonicKernelInComm x y M w h H' i)).
-    - intros i.
-      set (ker := MonicToKernel A hs (mk_Monic _ _ (isM (i + 1)))).
-      cbn in *. apply (KernelArrowisMonic _ ker).
-      rewrite <- assoc. rewrite <- assoc. fold ker.
-      rewrite (KernelCommutes _ ker). cbn. use (pathscomp0 _ (MComm h i)).
-      set (tmp := MComm (MonicArrow _ M) i). cbn in tmp. rewrite <- tmp. clear tmp.
-      rewrite assoc. apply cancel_postcomposition.
-      set (tmp := KernelCommutes _ (MonicToKernel A hs (mk_Monic A _ (isM i)))
-                                 (COb w i) (MMor h i)).
-      set (tmp0 := KernelEqAr _ (MonicToKernel A hs (mk_Monic A _ (isM i)))). cbn in tmp0.
-      rewrite ZeroArrow_comp_right in tmp0. cbn in tmp. apply tmp.
+      exact (KernelIn to_Zero (MonicToKernel A hs (mk_Monic _ _ (isM i))) _ (MMor h i)
+                      (ComplexMonicKernelInComm M h H' i)).
+    - intros i. exact (ComplexMonicKernelIn_Complex_Comm M h i H').
   Defined.
 
   (** *** MonicKernelsData *)
@@ -1664,42 +1638,37 @@ Section complexes_abelian.
   Definition ComplexPreCatAbelianMonicKernelsData_isEqualizer
              {x y : Complex (AbelianToAdditive A hs)}
              (M : Monic (ComplexPreCat (AbelianToAdditive A hs)) x y) :
-    let Z := @mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                      (@ZeroComplex (AbelianToAdditive A hs))
-                      (ComplexPreCat_isZero (AbelianToAdditive A hs)) in
-    @equalizers.isEqualizer (ComplexPreCat (AbelianToAdditive A hs)) _ _ _
-                            (KernelMorphism M)
-                            (MorphismComp (@ZeroArrowTo _ Z y)
-                                          (ZeroArrowFrom (ComplexPreCat_Monic_Kernel_Complex M))) M
-                            (KernelMorphism_eq M).
+    let Z := Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
+    @equalizers.isEqualizer
+      (ComplexPreCat (AbelianToAdditive A hs)) _ _ _ (KernelMorphism M)
+      (MorphismComp (@ZeroArrowTo _ Z y) (ZeroArrowFrom (ComplexPreCat_Monic_Kernel_Complex M))) M
+      (KernelMorphism_eq M).
   Proof.
-    cbn.
+    intros Z.
     set (isM := ComplexMonicIndexMonic _ M).
     use mk_isEqualizer.
     intros w h H'.
     use unique_exists.
-    - apply (ComplexMonicKernelIn x y M w h H').
+    - apply (ComplexMonicKernelIn M h H').
     - cbn. use MorphismEq.
       intros i. cbn.
-      apply (KernelCommutes _ (MonicToKernel A hs (mk_Monic A _ (isM i))) (COb w i) (MMor h i)).
+      apply (KernelCommutes _ (MonicToKernel A hs (mk_Monic A _ (isM i))) _ (MMor h i)).
     - intros y0. apply has_homsets_ComplexPreCat.
     - intros y0 T. cbn in T.
       use MorphismEq.
       intros i. apply (isM i).
       set (tmp :=  MorphismEq' _ _ _ T i). cbn in tmp. cbn. rewrite tmp.
       apply pathsinv0. clear tmp.
-      apply (KernelCommutes _ (MonicToKernel A hs (mk_Monic A _ (isM i))) (COb w i) (MMor h i)).
+      apply (KernelCommutes _ (MonicToKernel A hs (mk_Monic A _ (isM i))) _ (MMor h i)).
   Qed.
 
   Definition ComplexPreCatAbelianMonicKernelsData :
+    let Add := ComplexPreCat_Additive (AbelianToAdditive A hs) in
     AbelianMonicKernelsData
-      (ComplexPreCat (AbelianToAdditive A hs))
-      (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs)) ZeroComplex
-                (ComplexPreCat_isZero (AbelianToAdditive A hs)),,
-                Additive.to_BinProducts (ComplexPreCat_Additive (AbelianToAdditive A hs)),,
-                Additive.to_BinCoproducts (ComplexPreCat_Additive (AbelianToAdditive A hs))).
+      Add ((Additive.to_Zero Add)
+             ,, (Additive.to_BinProducts Add),, (Additive.to_BinCoproducts Add)).
   Proof.
-    intros x y M.
+    intros Add x y M.
     set (isM := ComplexMonicIndexMonic _ M).
     use tpair.
     - use tpair.
@@ -1710,16 +1679,36 @@ Section complexes_abelian.
     - exact (ComplexPreCatAbelianMonicKernelsData_isEqualizer M).
   Defined.
 
+
   (** ** Epis are Cokernels *)
 
   Local Lemma ComplexPreCat_Epi_Cokernel_Complex_comm
         {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
         (E : Epi (ComplexPreCat_Additive (AbelianToAdditive A hs)) x y) (i : hz) :
-    KernelArrow (Kernel (MMor (EpiArrow _ E) i)) ;; CMor x i ;; MMor (EpiArrow _ E) (i + 1) =
-    ZeroArrow (@to_Zero A) (Kernel (MMor (EpiArrow _ E) i)) (COb y (i + 1)).
+    (KernelArrow (Kernel (MMor (EpiArrow _ E) i))) ;; (Diff x i) ;; (MMor (EpiArrow _ E) (i + 1)) =
+    ZeroArrow (@to_Zero A) (Kernel (MMor (EpiArrow _ E) i)) _.
   Proof.
     rewrite <- assoc. rewrite <- (MComm (EpiArrow _ E)). rewrite assoc.
     rewrite KernelCompZero. apply ZeroArrow_comp_left.
+  Qed.
+
+  Local Lemma ComplexPreCat_Epi_Cokernel_Complex_comp
+        {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
+        (E : Epi (ComplexPreCat_Additive (AbelianToAdditive A hs)) x y) (i : hz) :
+    (KernelIn to_Zero (Kernel (MMor (EpiArrow _ E) (i + 1))) (Kernel (MMor (EpiArrow _ E) i))
+              ((KernelArrow (Kernel (MMor (EpiArrow _ E) i))) ;; (Diff x i))
+              (ComplexPreCat_Epi_Cokernel_Complex_comm E i))
+      ;; (KernelIn to_Zero (Kernel (MMor (EpiArrow _ E) (i + 1 + 1)))
+                   (Kernel (MMor (EpiArrow _ E) (i + 1)))
+                   ((KernelArrow (Kernel (MMor (EpiArrow _ E) (i + 1)))) ;; (Diff x (i + 1)))
+                   (ComplexPreCat_Epi_Cokernel_Complex_comm E (i + 1))) =
+    ZeroArrow to_Zero (Kernel (MMor (EpiArrow _ E) i)) (Kernel (MMor (EpiArrow _ E) (i + 1 + 1))).
+  Proof.
+    apply KernelArrowisMonic. rewrite <- assoc. rewrite KernelCommutes.
+    rewrite assoc. rewrite KernelCommutes. rewrite <- assoc.
+    cbn. set (tmp := CEq _ x i). cbn in tmp. rewrite tmp. clear tmp.
+    rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left.
+    apply idpath.
   Qed.
 
   Definition ComplexPreCat_Epi_Cokernel_Complex
@@ -1729,111 +1718,96 @@ Section complexes_abelian.
   Proof.
     use mk_Complex.
     - intros i.
-      set (mor := EpiArrow _ E). cbn in mor.
-      set (tmp := @MMor _ x y mor i).
-      exact (Kernel tmp).
+      exact (Kernel (@MMor _ x y (EpiArrow _ E) i)).
     - intros i. cbn. use KernelIn.
-      + set (mor := EpiArrow _ E). cbn in mor.
-        set (tmp := @MMor _ x y mor i).
-        exact ((KernelArrow (Kernel tmp)) ;; CMor x i).
+      + exact ((KernelArrow (Kernel (@MMor _ x y (EpiArrow _ E) i))) ;; (Diff x i)).
       + apply ComplexPreCat_Epi_Cokernel_Complex_comm.
-    - intros i. cbn.
-      apply KernelArrowisMonic. rewrite <- assoc. rewrite KernelCommutes.
-      rewrite assoc. rewrite KernelCommutes. rewrite <- assoc.
-      cbn. set (tmp := CEq _ x i). cbn in tmp. rewrite tmp. clear tmp.
-      rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left.
-      apply idpath.
+    - intros i. exact (ComplexPreCat_Epi_Cokernel_Complex_comp E i).
   Defined.
 
-  Definition CokernelMorphism
-             {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
+  (** This is the morphism which has E as cokernel *)
+  Definition CokernelMorphism {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
              (E : Epi (ComplexPreCat_Additive (AbelianToAdditive A hs)) x y) :
     Morphism (ComplexPreCat_Epi_Cokernel_Complex E) x.
   Proof.
     use mk_Morphism.
-    - intros i. cbn. apply KernelArrow.
-    - intros i. cbn. rewrite KernelCommutes. apply idpath.
+    - intros i. cbn. use KernelArrow.
+    - intros i. cbn. exact (! (KernelCommutes _ _ _ _ _)).
   Defined.
 
-  Definition CokernelMorphism_eq
-             {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
+  Definition CokernelMorphism_eq {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
              (E : Epi (ComplexPreCat_Additive (AbelianToAdditive A hs)) x y) :
+    let Z := Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
     MorphismComp (CokernelMorphism E) (EpiArrow _ E) =
-    MorphismComp (MorphismComp
-                    (@ZeroArrowTo (ComplexPreCat (AbelianToAdditive A hs))
-                                  (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                                            (@ZeroComplex (AbelianToAdditive A hs))
-                                            (ComplexPreCat_isZero (AbelianToAdditive A hs)))
-                                  (ComplexPreCat_Epi_Cokernel_Complex E))
-                    (@ZeroArrowFrom (ComplexPreCat (AbelianToAdditive A hs))
-                                    (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                                              (@ZeroComplex (AbelianToAdditive A hs))
-                                              (ComplexPreCat_isZero (AbelianToAdditive A hs)))
-                                    x)) (EpiArrow _ E).
+    MorphismComp (MorphismComp (@ZeroArrowTo _ Z (ComplexPreCat_Epi_Cokernel_Complex E))
+                               (@ZeroArrowFrom _ Z x)) (EpiArrow _ E).
   Proof.
     use MorphismEq.
     intros i. cbn. rewrite KernelCompZero.
     rewrite <- assoc. apply pathsinv0. apply ZeroArrowEq.
   Qed.
 
-  Local Lemma ComplexPreCatCokernelOut_comm
-    {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
+  Local Lemma ComplexPreCatCokernelOut_comp
+    {x y w0 : ComplexPreCat_Additive (AbelianToAdditive A hs)}
     (E : Epi (ComplexPreCat (AbelianToAdditive A hs)) x y)
-    (w0 : ComplexPreCat (AbelianToAdditive A hs))
     (h : (ComplexPreCat (AbelianToAdditive A hs))⟦x, w0⟧)
-    (H' : MorphismComp
-            (MorphismComp
-               (@ZeroArrowTo (ComplexPreCat (AbelianToAdditive A hs))
-                             (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                                       (@ZeroComplex (AbelianToAdditive A hs))
-                                       (ComplexPreCat_isZero (AbelianToAdditive A hs)))
-                             (ComplexPreCat_Epi_Cokernel_Complex E))
-               (@ZeroArrowFrom (ComplexPreCat (AbelianToAdditive A hs))
-                               (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                                         (@ZeroComplex (AbelianToAdditive A hs))
-                                         (ComplexPreCat_isZero (AbelianToAdditive A hs)))
-                               x)) h = MorphismComp (@CokernelMorphism x y E) h) (i : hz) :
+    (H : let Z := Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
+         MorphismComp
+           (MorphismComp
+              (@ZeroArrowTo _ Z (ComplexPreCat_Epi_Cokernel_Complex E))
+              (@ZeroArrowFrom _ Z x)) h = MorphismComp (@CokernelMorphism x y E) h) (i : hz) :
     KernelArrow (Kernel (MMor (EpiArrow _ E) i)) ;; MMor h i =
-    ZeroArrow (@to_Zero A) (Kernel (MMor (EpiArrow _ E) i)) (COb w0 i).
+    ZeroArrow (@to_Zero A) (Kernel (MMor (EpiArrow _ E) i)) _.
   Proof.
-    set (H'' := MorphismEq' _ _ _ H' i). cbn in H''. cbn. rewrite <- H''.
+    set (H' := MorphismEq' _ _ _ H i). cbn in H'. cbn. rewrite <- H'.
     rewrite <- assoc. apply ZeroArrowEq.
   Qed.
 
-  Definition ComplexPreCatCokernelOut
-    {x y : ComplexPreCat_Additive (AbelianToAdditive A hs)}
-    (E : Epi (ComplexPreCat (AbelianToAdditive A hs)) x y)
-    (w0 : ComplexPreCat (AbelianToAdditive A hs))
+  Local Lemma ComplexPreCatCokernelOut_comm
+    {x y w0 : ComplexPreCat_Additive (AbelianToAdditive A hs)}
+    (E : Epi (ComplexPreCat (AbelianToAdditive A hs)) x y) (i : hz)
     (h : (ComplexPreCat (AbelianToAdditive A hs))⟦x, w0⟧)
-    (H' : MorphismComp
-            (MorphismComp
-               (@ZeroArrowTo (ComplexPreCat (AbelianToAdditive A hs))
-                             (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                                       (@ZeroComplex (AbelianToAdditive A hs))
-                                       (ComplexPreCat_isZero (AbelianToAdditive A hs)))
-                             (ComplexPreCat_Epi_Cokernel_Complex E))
-               (@ZeroArrowFrom (ComplexPreCat (AbelianToAdditive A hs))
-                               (@mk_Zero (ComplexPreCat (AbelianToAdditive A hs))
-                                         (@ZeroComplex (AbelianToAdditive A hs))
-                                         (ComplexPreCat_isZero (AbelianToAdditive A hs)))
-                               x)) h = MorphismComp (@CokernelMorphism x y E) h) :
-    (ComplexPreCat (AbelianToAdditive A hs))⟦y, w0⟧.
+    (H : let Z := Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
+         MorphismComp
+           (MorphismComp
+              (@ZeroArrowTo _ Z (ComplexPreCat_Epi_Cokernel_Complex E)) (@ZeroArrowFrom _ Z x)) h =
+         MorphismComp (@CokernelMorphism x y E) h) :
+    let isE := ComplexEpiIndexEpi _ E in
+    (CokernelOut to_Zero
+                 (EpiToCokernel A hs (mk_Epi A (MMor (EpiArrow _ E) i) (isE i))) _ (MMor h i)
+                 (ComplexPreCatCokernelOut_comp E h H i)) ;; (Diff w0 i) =
+    (Diff y i)
+      ;; (CokernelOut to_Zero
+                      (EpiToCokernel A hs (mk_Epi A (MMor (EpiArrow _ E) (i + 1)) (isE (i + 1))))
+                      _ (MMor h (i + 1)) (ComplexPreCatCokernelOut_comp E h H (i + 1))).
+  Proof.
+    intros isE.
+    apply pathsinv0.
+    set (coker := EpiToCokernel A hs (mk_Epi _ _ (isE i))).
+    apply (CokernelArrowisEpi _ coker). rewrite assoc. rewrite assoc. rewrite CokernelCommutes.
+    use (pathscomp0 _ (! (MComm h i))). cbn.
+    set (tmp := MComm (EpiArrow _ E) i). cbn in tmp. rewrite tmp. clear tmp.
+    rewrite <- assoc. apply cancel_precomposition.
+    apply (CokernelCommutes _ (EpiToCokernel A hs (mk_Epi A _ (isE (i + 1))))).
+  Qed.
+
+  Definition ComplexPreCatCokernelOut
+    {x y z : ComplexPreCat_Additive (AbelianToAdditive A hs)}
+    (E : Epi (ComplexPreCat (AbelianToAdditive A hs)) x y)
+    (h : (ComplexPreCat (AbelianToAdditive A hs))⟦x, z⟧)
+    (H : let Z := Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
+         MorphismComp
+           (MorphismComp
+              (@ZeroArrowTo _ Z (ComplexPreCat_Epi_Cokernel_Complex E)) (@ZeroArrowFrom _ Z x)) h =
+         MorphismComp (@CokernelMorphism x y E) h) :
+    (ComplexPreCat (AbelianToAdditive A hs))⟦y, z⟧.
   Proof.
     set (isE := ComplexEpiIndexEpi _ E).
     use mk_Morphism.
-    - intros i.
-      set (coker := EpiToCokernel A hs (mk_Epi _ _ (isE i))).
-      apply (CokernelOut (@to_Zero A) coker _ (MMor h i)).
-      apply (ComplexPreCatCokernelOut_comm E w0 h H').
-    - intros i.
-      set (coker := EpiToCokernel A hs (mk_Epi _ _ (isE i))).
-      cbn in *. apply (CokernelArrowisEpi _ coker). repeat rewrite assoc. fold coker.
-      rewrite (CokernelCommutes _ coker). cbn. use (pathscomp0 (MComm h i)).
-      set (tmp := MComm (EpiArrow _ E) i). cbn in tmp. rewrite tmp. clear tmp.
-      rewrite <- assoc. apply cancel_precomposition.
-      set (tmp := CokernelCommutes _ (EpiToCokernel A hs (mk_Epi A _ (isE (i + 1))))).
-      set (tmp0 := CokernelEqAr _ (EpiToCokernel A hs (mk_Epi A _ (isE (i + 1))))). cbn in tmp0.
-      rewrite ZeroArrow_comp_left in tmp0. cbn in tmp. apply pathsinv0. apply tmp.
+    - intros i. exact (CokernelOut
+                         (@to_Zero A) (EpiToCokernel A hs (mk_Epi _ _ (isE i))) _ (MMor h i)
+                         (ComplexPreCatCokernelOut_comp E h H i)).
+    - intros i. exact (ComplexPreCatCokernelOut_comm E i h H).
   Defined.
 
   (** *** EpisCokernelsData *)
@@ -1846,21 +1820,22 @@ Section complexes_abelian.
       (MorphismComp (ZeroArrowTo (ComplexPreCat_Epi_Cokernel_Complex E)) (ZeroArrowFrom x)) E
       (CokernelMorphism_eq E).
   Proof.
-    cbn zeta. set (isE := ComplexEpiIndexEpi (AbelianToAdditive A hs) E).
+    intros Add.
+    set (isE := ComplexEpiIndexEpi (AbelianToAdditive A hs) E).
     use mk_isCoequalizer.
     intros w0 h H'.
     use unique_exists.
-    - apply (ComplexPreCatCokernelOut E w0 h (! H')).
+    - apply (ComplexPreCatCokernelOut E h (! H')).
     - cbn. use MorphismEq.
       intros i. cbn.
-      apply (CokernelCommutes _ (EpiToCokernel A hs (mk_Epi A _ (isE i))) (COb w0 i) (MMor h i)).
+      apply (CokernelCommutes _ (EpiToCokernel A hs (mk_Epi A _ (isE i))) _ (MMor h i)).
     - intros y0. apply has_homsets_ComplexPreCat.
     - intros y0 T. cbn in T.
       use MorphismEq.
       intros i. apply (isE i).
       set (tmp :=  MorphismEq' _ _ _ T i). cbn in tmp. cbn. rewrite tmp.
       apply pathsinv0. clear tmp.
-      apply (CokernelCommutes _ (EpiToCokernel A hs (mk_Epi A _ (isE i))) (COb w0 i) (MMor h i)).
+      apply (CokernelCommutes _ (EpiToCokernel A hs (mk_Epi A _ (isE i))) _ (MMor h i)).
   Qed.
 
   Definition ComplexPreCatAbelianEpiCokernelsData :
@@ -1869,7 +1844,7 @@ Section complexes_abelian.
       Add ((Additive.to_Zero Add)
              ,, (Additive.to_BinProducts Add),, (Additive.to_BinCoproducts Add)).
   Proof.
-    cbn zeta. intros x y E.
+    intros Add x y E.
     set (isE := ComplexEpiIndexEpi _ E).
     use tpair.
     - use tpair.
@@ -1880,6 +1855,7 @@ Section complexes_abelian.
     - exact (ComplexPreCatAbelianEpiCokernelsData_isCoequalizer E).
   Defined.
 
+
   (** ** Complexes over Abelian is Abelian *)
 
   Definition ComplexPreCat_AbelianPreCat : AbelianPreCat.
@@ -1887,7 +1863,7 @@ Section complexes_abelian.
     use mk_Abelian.
     - exact (ComplexPreCat_Additive (AbelianToAdditive A hs)).
     - split.
-      + exact (Additive.to_Zero _).
+      + exact (Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs))).
       + split.
         * exact (Additive.to_BinProducts (ComplexPreCat_Additive (AbelianToAdditive A hs))).
         * exact (Additive.to_BinCoproducts (ComplexPreCat_Additive (AbelianToAdditive A hs))).

--- a/UniMath/CategoryTheory/Epis.v
+++ b/UniMath/CategoryTheory/Epis.v
@@ -46,6 +46,8 @@ Section def_epi.
   Definition EpiArrow {x y : C} (E : Epi x y) : C⟦x, y⟧ := pr1 E.
   Coercion EpiArrow : Epi >-> precategory_morphisms.
 
+  Definition EpiisEpi {x y : C} (E : Epi x y) : isEpi E := pr2 E.
+
   (** Isomorphism to isEpi and Epi. *)
   Lemma iso_isEpi {x y : C} (f : x --> y) (H : is_iso f) : isEpi f.
   Proof.

--- a/UniMath/CategoryTheory/Epis.v
+++ b/UniMath/CategoryTheory/Epis.v
@@ -93,6 +93,19 @@ Section def_epi.
     apply (X w _ _ H).
   Defined.
 
+  (** Transport of isEpi *)
+  Lemma transportf_isEpi {x y z : C} (f : x --> y) (E : isEpi f) (e : y = z) :
+    isEpi (transportf (precategory_morphisms x) e f).
+  Proof.
+    induction e. apply E.
+  Qed.
+
+  Lemma transportb_isEpi {x y z : C} (f : y --> z) (E : isEpi f) (e : x = y) :
+    isEpi (transportb (fun x' : ob C => precategory_morphisms x' z) e f).
+  Proof.
+    induction e. apply E.
+  Qed.
+
 End def_epi.
 Arguments isEpi [C] [x] [y] _.
 

--- a/UniMath/CategoryTheory/Monics.v
+++ b/UniMath/CategoryTheory/Monics.v
@@ -94,6 +94,19 @@ Section def_monic.
     apply (X w _ _ H).
   Defined.
 
+  (** Transport of isMonic *)
+  Lemma transportf_isMonic {x y z : C} (f : x --> y) (E : isMonic f) (e : y = z) :
+    isMonic (transportf (precategory_morphisms x) e f).
+  Proof.
+    induction e. apply E.
+  Qed.
+
+  Lemma transportb_isMonic {x y z : C} (f : y --> z) (E : isMonic f) (e : x = y) :
+    isMonic (transportb (fun x' : ob C => precategory_morphisms x' z) e f).
+  Proof.
+    induction e. apply E.
+  Qed.
+
 End def_monic.
 Arguments isMonic [C] [y] [z] _.
 

--- a/UniMath/CategoryTheory/Monics.v
+++ b/UniMath/CategoryTheory/Monics.v
@@ -46,6 +46,8 @@ Section def_monic.
   Definition MonicArrow {y z : C} (M : Monic y z) : C⟦y, z⟧ := pr1 M.
   Coercion MonicArrow : Monic >-> precategory_morphisms.
 
+  Definition MonicisMonic {y z : C} (M : Monic y z) : isMonic M := pr2 M.
+
   (** Isomorphism to isMonic and Monic. *)
   Lemma iso_isMonic {y x : C} (f : y --> x) (H : is_iso f) : isMonic f.
   Proof.

--- a/UniMath/CategoryTheory/PreAdditive.v
+++ b/UniMath/CategoryTheory/PreAdditive.v
@@ -1,4 +1,11 @@
-(** ** Definition of preadditive categories. *)
+(** * Definition of preadditive categories. *)
+(** ** Contents
+- Definition of preadditive categories [PreAdditive]
+- Zero and unit element coincide
+- Composition and inverses
+- Quotient of PreAdditive
+ *)
+
 Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.Foundations.Basics.Propositions.
 Require Import UniMath.Foundations.Basics.Sets.
@@ -16,6 +23,9 @@ Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
 Require Import UniMath.CategoryTheory.limits.zero.
 
 
+(** * Definition of a PreAdditive precategory
+   A preadditive precategory is a precategory such that the sets of morphisms are abelian groups and
+   pre- and postcomposing with a morphisms is a monoidfun of the abelian groups. *)
 Section def_preadditive.
 
   (** In preadditive category precomposition and postcomposition for any
@@ -55,8 +65,7 @@ Section def_preadditive.
 
   Variable A : PreAdditive.
 
-  (** The following give that premor and postmor are linear. That is
-      mor(op x y) = op (mor x) (mor y). *)
+  (** The following give that premor and postmor are linear. *)
   Definition to_premor_linear {x y : A} (z : A) (f : x --> y) :
     isbinopfun (to_premor z f) := dirprod_pr1 (to_premor_monoid A x y z f).
 
@@ -76,8 +85,7 @@ Section def_preadditive.
     apply to_postmor_linear.
   Qed.
 
-  (** The following says that composing with zero object yields a zero
-      object. *)
+  (** The following says that composing with zero object yields a zero object. *)
   Definition to_premor_unel {x y : A} (z : A) (f : x --> y) :
     to_premor z f 1%multmonoid = 1%multmonoid := dirprod_pr2 (to_premor_monoid A x y z f).
 
@@ -102,8 +110,9 @@ Arguments to_premor_linear' [A] [x] [y] [z] _ _ _.
 Arguments to_postmor_linear' [A] [x] [y] [z] _ _ _.
 
 
-(** In the following section we prove that if a preadditive category has a zero
-    object, then in a homset the unit element is given by the zero arrow *)
+(** * Zero and unit
+   In the following section we prove that if a preadditive category has a zero
+   object, then in a homset the unit element is given by the zero arrow *)
 Section preadditive_with_zero.
 
   Variable A : PreAdditive.
@@ -130,7 +139,9 @@ Section preadditive_with_zero.
 End preadditive_with_zero.
 
 
-(** Some equations on inverses in PreAdditiev categories *)
+
+(** * Inverses and composition
+   Some equations on inverses in PreAdditive categories *)
 Section preadditive_inv_comp.
 
   Variable A : PreAdditive.
@@ -164,3 +175,660 @@ Section preadditive_inv_comp.
   Qed.
 
 End preadditive_inv_comp.
+
+
+(** * Quotient of homsets
+   Suppose you have a subgroup for each set of morphisms such that pre- and postcompositions map
+   morphisms in a subgroup to another subgroup. Then one can form a new Preadditive category by
+   taking the same objects and morphisms as elements of the quotient groups. We call this
+   [PreAdditiveQuot]. An example of this construction is when one wants to form the naive homotopy
+   category from a category of complexes. *)
+Section preadditive_quotient.
+
+  Variable PA : PreAdditive.
+
+  (** For every set morphisms we have a subgroup. *)
+  Definition PreAdditiveSubabgrs : UU := Π (x y : ob PA), @subabgrs (to_abgrop x y).
+
+  Hypothesis PAS : PreAdditiveSubabgrs.
+
+  (** Pre- and postcomposing with an element in the subgroups gives an element of a subgroup.
+      This is important since we want pre- and postcomposition with unit element to be
+      the unit element in the new precategory. *)
+  Definition PreAdditiveComps : UU :=
+    Π (x y : ob PA),
+    (Π (z : ob PA) (f : x --> y) (inf : pr1submonoids _ (PAS x y) f) (g : y --> z),
+     pr1submonoids _ (PAS x z) (f ;; g))
+      × (Π (z : ob PA) (f : x --> y) (g : y --> z) (ing : pr1submonoids _ (PAS y z) g),
+         pr1submonoids _ (PAS x z) (f ;; g)).
+
+  Hypothesis PAC : PreAdditiveComps.
+
+  (** ** Here are some random results copied from category_abgr.v.
+     Theses should be deleted, removed, renamed, generalized, or ...*)
+
+  (** The hProp which tells if two elements of A belong to the same equivalence class in A/B *)
+  Definition subgrhrel_hprop {A : gr} (B : @subgrs A) (a1 a2 : A) : hProp :=
+    hexists (fun b : B => pr1 b = (a1 * grinv A a2)%multmonoid).
+
+  (** Construct a relation using the above hProp *)
+  Definition subgrhrel {A : gr} (B : @subgrs A) : @hrel A :=
+    (fun a1 : A => fun a2 : A => (subgrhrel_hprop B a1 a2)).
+
+  (** Some equalities *)
+  Local Lemma ropeq (X : setwithbinop) (x y z : X) : x = y -> @op X x z = @op X y z.
+  Proof.
+    intros e. induction e. apply idpath.
+  Qed.
+
+  Local Lemma grinvop (Y : gr) :
+    Π y1 y2 : Y, grinv Y (@op Y y1 y2) = @op Y (grinv Y y2) (grinv Y y1).
+  Proof.
+    intros y1 y2.
+    apply (grrcan Y y1).
+    rewrite (assocax Y). rewrite (grlinvax Y). rewrite (runax Y).
+    apply (grrcan Y y2).
+    rewrite (grlinvax Y). rewrite (assocax Y). rewrite (grlinvax Y).
+    apply idpath.
+  Qed.
+
+  (** Let B be a subgroup of A. Then the canonical map A -> A/B is a monoidfun. *)
+  Local Lemma abgrquotpr_ismonoidfun {A : abgr} (H : @binopeqrel A) :
+    @ismonoidfun A (abgrquot H) (fun a : A => setquotpr H a).
+  Proof.
+    split.
+    - split.
+    - apply idpath.
+  Qed.
+
+  Local Lemma funeqpaths {X Y : UU} {f g : X -> Y} (e : f = g) : Π (x : X), f x = g x.
+  Proof.
+    induction e. intros x. apply idpath.
+  Qed.
+
+  Local Definition abgrquotpr_monoidfun {A : abgr} (H : @binopeqrel A) : monoidfun A (abgrquot H) :=
+    monoidfunconstr (abgrquotpr_ismonoidfun H).
+
+  Local Lemma monoidfun_inv {A B : abgr} (f : monoidfun A B) (a : A) :
+    f (grinv A a) = grinv B (f a).
+  Proof.
+    apply (grlcan B (f a)). rewrite (grrinvax B).
+    use (pathscomp0 (pathsinv0 (((pr1 (pr2 f)) a (grinv A a))))).
+    rewrite (grrinvax A). apply (pr2 (pr2 f)).
+  Qed.
+
+  (** The relation we defined is an equivalence relation *)
+  Lemma iseqrel_subgrhrel (A : gr) (B : @subgrs A) : iseqrel (subgrhrel B).
+  Proof.
+    unfold subgrhrel. unfold subgrhrel_hprop.
+    use iseqrelconstr.
+    (* istrans *)
+    - intros x1 x2 x3 y1 y2. cbn in *. unfold ishinh_UU in *. intros P X.
+      apply y1. intros Y1. apply y2. intros Y2.
+      induction Y1 as [t p]. induction Y2 as [t0 p0]. apply X.
+      use tpair.
+      + use tpair.
+        * exact (op (pr1 t) (pr1 t0)).
+        * exact (pr2subsetswithbinop B t t0).
+      + cbn. rewrite p. rewrite p0. rewrite <- (assocax A).
+        apply ropeq. rewrite assocax. rewrite grlinvax. rewrite runax.
+        apply idpath.
+    (* isrefl *)
+    - intros x. intros P X. apply X.
+      use tpair.
+      + exact (unel B).
+      + cbn. apply pathsinv0. apply (grrinvax A).
+    (* issymm *)
+    - intros x y. cbn. unfold ishinh_UU. intros H P X. apply H. intros H'. clear H.
+      apply X. clear X. induction H' as [t p].
+      use tpair.
+      + exact (grinv B t).
+      + cbn. rewrite p. clear p. rewrite grinvop. rewrite grinvinv. apply idpath.
+  Qed.
+
+  (** The relation we defined respects binary operations. Note that we use commax, thus the proof
+      does not work for nonabelian groups. *)
+  Lemma isbinopeqrel_subgr_eqrel {A : abgr} (B : @subabgrs A) :
+    isbinophrel (eqrelpair (subgrhrel B) (iseqrel_subgrhrel A B)).
+  Proof.
+    use isbinophrelif.
+    - apply (pr2 (pr2 A)).
+    - intros a b c X. cbn in *. unfold ishinh_UU in *. intros P X'. apply X.
+      intros X''. clear X. apply X'. clear X'.
+      use tpair.
+      + exact (pr1 X'').
+      + cbn. rewrite (pr2 X''). clear X''. clear B. rewrite grinvop.
+        rewrite (commax A c). rewrite (assocax A). rewrite (commax A c).
+        rewrite (assocax A). rewrite grlinvax. rewrite runax. apply idpath.
+  Qed.
+
+  (** Thus the relation is a binopeqrel *)
+  Lemma binopeqrel_subgr_eqrel {A : abgr} (B : @subabgrs A) : @binopeqrel A.
+  Proof.
+    use binopeqrelpair.
+    - exact (eqrelpair _ (iseqrel_subgrhrel A B)).
+    - exact (isbinopeqrel_subgr_eqrel B).
+  Defined.
+
+  (** These are the homsets in our new category. *)
+  Definition subabgr_quot {A : abgr} (B : @subabgrs A) : abgr :=
+    abgrquot (binopeqrel_subgr_eqrel B).
+
+  Definition QuotPrecategory_homsets (c d : ob PA) : abgr := subabgr_quot (PAS c d).
+
+  Definition QuotPrecategory_ob_mor : precategory_ob_mor :=
+    tpair (fun ob : UU => ob -> ob -> UU) (ob PA) (fun A B : ob PA => QuotPrecategory_homsets A B).
+
+
+  (** ** Composition of morphisms *)
+
+  (** *** Some lemmas *)
+
+  (** If images of f1 and f2 are equal, then f * inv f2 is mapped to unit. *)
+  Local Lemma abgrquotpr_rels_to_unel {A : abgr} {f1 f2 : A} {H : @binopeqrel A} {f : abgrquot H}
+             (e1 : setquotpr H f1 = f) (e2 : setquotpr H f2 = f) :
+    setquotpr H (f1 * grinv A f2)%multmonoid = setquotpr H 1%multmonoid.
+  Proof.
+    rewrite <- e2 in e1. clear e2.
+    apply (maponpaths (fun f : _ => (f * (@grinv (abgrquot H) (setquotpr H f2)))%multmonoid)) in e1.
+    rewrite grrinvax in e1. apply e1.
+  Qed.
+
+  (** Equality on relation to refl *)
+  Local Lemma abgrquotpr_rel_to_refl {A : abgr} {H : @binopeqrel A} {f g : A} (e : H g g = H f g) :
+    H f g.
+  Proof.
+    induction e.
+    apply eqrelrefl.
+  Qed.
+
+  Local Lemma abgrquotpr_rel_paths {A : abgr} {H : @binopeqrel A} {f g : A}
+        (e : setquotpr H f = setquotpr H g) : H f g.
+  Proof.
+    exact (abgrquotpr_rel_to_refl (! (funeqpaths (base_paths _ _ e)) g)).
+  Qed.
+
+  (** *** Morphisms to elements of groups *)
+  Local Lemma mor_to_elem {a b : PA} (f : PA⟦a, b⟧) (H : pr1 (PAS a b) f) : carrier (pr1 (PAS a b)).
+  Proof.
+    use tpair.
+    - exact f.
+    - exact H.
+  Defined.
+
+  Local Lemma to_inv_elem {a b : PA} (f : PA⟦a, b⟧) (H : pr1 (PAS a b) f) : carrier (pr1 (PAS a b)).
+  Proof.
+    use tpair.
+    - exact (@grinv (to_abgrop a b) f).
+    - apply (pr2 (pr2 (PAS a b))). exact H.
+  Defined.
+
+  Local Lemma to_op_elem {A B : PA} (f g : PA⟦A, B⟧) (H1 : pr1 (PAS A B) f) (H2 : pr1 (PAS A B) g) :
+    pr1 (PAS A B) (to_binop A B f g).
+  Proof.
+    set (tmp := pr1 (pr1 (pr2 (PAS A B)))). cbn in tmp. unfold issubsetwithbinop in tmp.
+    set (a := mor_to_elem f H1). set (a' := mor_to_elem g H2).
+    apply (tmp a a').
+  Qed.
+
+  (** *** Composition of morphisms in the quotient precategory *)
+
+  Local Lemma QuotPrecategory_comp_iscontr_PAS_eq {A : abgr} {a b c : A}
+        (e : a = (b * (grinv A c))%multmonoid) : b = (a * c)%multmonoid.
+  Proof.
+    rewrite e. rewrite assocax. rewrite grlinvax. rewrite runax. apply idpath.
+  Qed.
+
+  Lemma QuotPrecategory_comp_iscontr_PAS {A B C : PA} {t : pr1 (PAS A B)} {t' : pr1 (PAS B C)}
+        {f1 f'1 : PA⟦A, B⟧} {g1 g'1 : PA⟦B, C⟧}
+        (p : pr1 t = to_binop A B f'1 (grinv (to_abgrop A B) f1))
+        (p' : pr1 t' = to_binop B C g'1 (grinv (to_abgrop B C) g1)) :
+    pr1 (PAS A C) (to_binop A C (f1 ;; g1) (grinv (to_abgrop A C) (f'1 ;; g'1))).
+  Proof.
+    set (e1 := QuotPrecategory_comp_iscontr_PAS_eq p).
+    set (e2 := QuotPrecategory_comp_iscontr_PAS_eq p').
+    rewrite e1. rewrite e2. clear e1 e2 p p'. cbn.
+    rewrite to_premor_linear'. rewrite to_postmor_linear'. rewrite to_postmor_linear'.
+    set (ac := assocax (to_abgrop A C)). unfold isassoc in ac. cbn in ac.
+    set (comm := commax (to_abgrop A C)). unfold iscomm in comm. cbn in comm.
+    rewrite (comm _ (f1 ;; g1)). rewrite <- (ac _ (f1 ;; g1) _).
+    rewrite (comm _ (f1 ;; g1)). rewrite ac. rewrite ac.
+    set (i := grinvop (to_abgrop A C)). cbn in i. rewrite i. repeat rewrite <- ac.
+    rewrite comm. rewrite <- ac.
+    set (il := linvax _ (f1 ;; g1)). unfold to_inv in il. rewrite il. clear il.
+    set (lu := to_lunax A C). unfold islunit in lu. cbn in lu. unfold to_unel. rewrite lu.
+
+    set (tmp := pr2 (pr2 (PAS A C))). cbn in tmp. apply tmp. clear tmp.
+    use to_op_elem.
+    - use to_op_elem.
+      + apply (dirprod_pr1 (PAC A B) C (pr1 t) (pr2 t) (pr1 t')).
+      + apply (dirprod_pr2 (PAC A B) C f1 (pr1 t') (pr2 t')).
+    - apply (dirprod_pr1 (PAC A B) C (pr1 t) (pr2 t) g1).
+  Qed.
+
+  (** The following Lemma is used to define composition of morphisms in the quotient precategory.
+      It shows that composition is well defined in QuotPrecategory_ob_mor. *)
+  Lemma QuotPrecategory_comp_iscontr {A B C : ob PA} (f : QuotPrecategory_ob_mor⟦A, B⟧)
+             (g : QuotPrecategory_ob_mor⟦B, C⟧) :
+    iscontr (Σ h : QuotPrecategory_ob_mor⟦A, C⟧,
+                   (Π (f' : PA⟦A, B⟧) (e1 : setquotpr _ f' = f)
+                      (g' : PA⟦B, C⟧) (e2 : setquotpr _ g' = g), setquotpr _ (f' ;; g') = h)).
+  Proof.
+    cbn in *.
+    set (f'1 := @issurjsetquotpr (to_abgrop A B) (binopeqrel_subgr_eqrel (PAS A B)) f).
+    set (g'1 := @issurjsetquotpr (to_abgrop B C) (binopeqrel_subgr_eqrel (PAS B C)) g).
+    use (squash_to_prop f'1). apply isapropiscontr. intros f''1. clear f'1.
+    use (squash_to_prop g'1). apply isapropiscontr. intros g''1. clear g'1.
+    induction f''1 as [f'1 f''1]. induction g''1 as [g'1 g''1]. cbn in *.
+    use unique_exists.
+    - use (setquotpr (binopeqrel_subgr_eqrel (PAS A C)) (f'1 ;; g'1)).
+    - intros f1 Hf g1 Hg. cbn.
+      apply (iscompsetquotpr (eqrelpair _ (iseqrel_subgrhrel (to_abgrop A C) (PAS A C)))).
+      set (HH := @abgrquotpr_rels_to_unel
+                   (to_abgrop A B) f'1 f1 (binopeqrel_subgr_eqrel (PAS A B)) f f''1 Hf).
+      set (HH' := @abgrquotpr_rels_to_unel
+                    (to_abgrop B C) g'1 g1 (binopeqrel_subgr_eqrel (PAS B C)) g g''1 Hg).
+      apply abgrquotpr_rel_paths in HH. apply abgrquotpr_rel_paths in HH'.
+      use (squash_to_prop HH). apply propproperty. intros HHH. clear HH.
+      use (squash_to_prop HH'). apply propproperty. intros HHH'. clear HH'.
+      cbn in HHH. cbn in HHH'. induction HHH as [t p]. induction HHH' as [t' p'].
+      rewrite grinvunel in p. rewrite grinvunel in p'.
+      set (tmp := to_runax A B). unfold isrunit in tmp. cbn in tmp. rewrite tmp in p. clear tmp.
+      set (tmp := to_runax B C). unfold isrunit in tmp. cbn in tmp. rewrite tmp in p'. clear tmp.
+      cbn. unfold ishinh_UU. intros P X. apply X. clear X P.
+      use tpair.
+      + use tpair.
+        * exact (to_binop A C (f1 ;; g1) (grinv (to_abgrop A C) (f'1 ;; g'1))).
+        * apply (QuotPrecategory_comp_iscontr_PAS p p').
+      + apply idpath.
+    - intros y.
+      apply impred. intros t.
+      apply impred. intros H.
+      apply impred. intros t0.
+      apply impred. intros H0.
+      apply isasetsetquot.
+    - intros y T. cbn in T.
+      set (T' := T f'1 f''1 g'1 g''1). rewrite <- T'. apply idpath.
+  Defined.
+  Opaque QuotPrecategory_comp_iscontr.
+
+  Definition QuotPrecategory_comp {A B C : ob PA} (f : QuotPrecategory_ob_mor⟦A, B⟧)
+             (g : QuotPrecategory_ob_mor⟦B, C⟧) : QuotPrecategory_ob_mor⟦A, C⟧.
+  Proof.
+    exact (pr1 (pr1 (QuotPrecategory_comp_iscontr f g))).
+  Defined.
+
+  Definition to_quot_mor {x y : ob PA} (f : PA⟦x, y⟧) : QuotPrecategory_ob_mor⟦x, y⟧.
+  Proof.
+    use setquotpr. exact f.
+  Defined.
+
+
+  (** ** Some equations on linearity, compositions, and binops *)
+
+  Lemma QuotPrecategory_comp_linear {x y z : ob PA} (f : PA⟦x, y⟧) (g : PA⟦y, z⟧) :
+    QuotPrecategory_comp (to_quot_mor f) (to_quot_mor g) = to_quot_mor (f ;; g).
+  Proof.
+    unfold to_quot_mor. unfold QuotPrecategory_comp.
+    apply pathsinv0.
+    use (pr2 (pr1 (QuotPrecategory_comp_iscontr
+                           (setquotpr (binopeqrel_subgr_eqrel (PAS x y)) f)
+                           (setquotpr (binopeqrel_subgr_eqrel (PAS y z)) g)))).
+    - apply idpath.
+    - apply idpath.
+  Qed.
+
+  (** Pre- and postcomposition respect binop. *)
+  Local Lemma QuotPrecategory_premor {x y z : PA} (f : PA⟦x, y⟧) (g h : PA⟦y, z⟧) :
+    QuotPrecategory_comp (to_quot_mor f) ((to_quot_mor g * to_quot_mor h)%multmonoid) =
+    ((QuotPrecategory_comp (to_quot_mor f) (to_quot_mor g)) *
+     (QuotPrecategory_comp (to_quot_mor f) (to_quot_mor h)))%multmonoid.
+  Proof.
+    Opaque binopeqrel_subgr_eqrel isabgrquot setquotfun2.
+    apply pathsinv0. cbn.
+    eapply pathscomp0.
+    - rewrite QuotPrecategory_comp_linear. rewrite QuotPrecategory_comp_linear.
+      use setquotfun2comm.
+    - apply pathsinv0.
+      unfold to_quot_mor.
+      set (tmp := setquotfun2comm (binopeqrel_subgr_eqrel (PAS y z))
+                                  (binopeqrel_subgr_eqrel (PAS y z))
+                                  (to_binop y z)
+                                  (iscompbinoptransrel
+                                     (binopeqrel_subgr_eqrel (PAS y z))
+                                     (eqreltrans (binopeqrel_subgr_eqrel (PAS y z)))
+                                     (pr2 (binopeqrel_subgr_eqrel (PAS y z))))).
+      rewrite tmp. clear tmp.
+      rewrite <- to_premor_linear'.
+      apply pathsinv0.
+      unfold QuotPrecategory_comp.
+      apply (pr2 (pr1 (QuotPrecategory_comp_iscontr
+                         (setquotpr (binopeqrel_subgr_eqrel (PAS x y)) f)
+                         (setquotpr (binopeqrel_subgr_eqrel (PAS y z)) (to_binop y z g h))))).
+      + apply idpath.
+      + apply idpath.
+  Qed.
+
+  Local Lemma QuotPrecategory_postmor {x y z : PA} (f : PA⟦y, z⟧) (g h : PA⟦x, y⟧) :
+    QuotPrecategory_comp (to_quot_mor g * to_quot_mor h)%multmonoid (to_quot_mor f) =
+    ((QuotPrecategory_comp (to_quot_mor g) (to_quot_mor f)) *
+     (QuotPrecategory_comp (to_quot_mor h) (to_quot_mor f)))%multmonoid.
+  Proof.
+    apply pathsinv0. cbn.
+    eapply pathscomp0.
+    - rewrite QuotPrecategory_comp_linear. rewrite QuotPrecategory_comp_linear.
+      use setquotfun2comm.
+    - unfold to_quot_mor. rewrite setquotfun2comm.
+      unfold QuotPrecategory_comp.
+      rewrite <- to_postmor_linear'.
+      apply (pr2 (pr1 (QuotPrecategory_comp_iscontr
+                         (setquotpr (binopeqrel_subgr_eqrel (PAS x y)) (to_binop x y g h))
+                         (setquotpr (binopeqrel_subgr_eqrel (PAS y z)) f)))).
+      + apply idpath.
+      + apply idpath.
+  Qed.
+
+  (** Composing with the unit element gives the unit element. *)
+  Local Lemma quot_comp_unel_left {x y z : PA} (f : PA⟦x, y⟧) :
+    QuotPrecategory_comp (to_quot_mor f) (to_quot_mor (to_unel y z)) = (to_quot_mor (to_unel x z)).
+  Proof.
+    rewrite <- (to_premor_unel' _ _ f). unfold to_quot_mor. apply pathsinv0.
+    unfold QuotPrecategory_comp.
+    apply (pr2 (pr1 (QuotPrecategory_comp_iscontr
+                       (setquotpr (binopeqrel_subgr_eqrel (PAS x y)) f)
+                       (setquotpr (binopeqrel_subgr_eqrel (PAS y z)) (to_unel y z))))).
+    - apply idpath.
+    - apply idpath.
+  Qed.
+
+  Local Lemma quot_comp_unel_right {x y z : PA} (f : PA⟦y, z⟧) :
+    QuotPrecategory_comp (to_quot_mor (to_unel x y)) (to_quot_mor f) =
+    (to_quot_mor (to_unel x z)).
+  Proof.
+    rewrite <- (to_postmor_unel' _ _ f). unfold to_quot_mor. apply pathsinv0.
+    unfold QuotPrecategory_comp.
+    apply (pr2 (pr1 (QuotPrecategory_comp_iscontr
+                       (setquotpr (binopeqrel_subgr_eqrel (PAS x y)) (to_unel x y))
+                       (setquotpr (binopeqrel_subgr_eqrel (PAS y z)) f)))).
+    - apply idpath.
+    - apply idpath.
+  Qed.
+
+
+  (** ** Construction of the QuotPrecategory *)
+
+  Definition QuotPrecategory_data : precategory_data :=
+    precategory_data_pair
+      QuotPrecategory_ob_mor (fun (A : ob PA) => setquotpr _ (identity A) )
+      (fun (A B C : ob PA) (f : QuotPrecategory_ob_mor⟦A, B⟧)
+         (g : QuotPrecategory_ob_mor⟦B, C⟧) => QuotPrecategory_comp f g).
+
+  (** The following two lemmas are used to show associaticity of composition in
+      QuotPrecategory. *)
+  Lemma assoc1 {a b c d : QuotPrecategory_data} (f : QuotPrecategory_data ⟦a, b⟧)
+        (g : QuotPrecategory_data ⟦b, c⟧) (h : QuotPrecategory_data ⟦c, d⟧)
+        (f1 : PA⟦a, b⟧) (f2 : setquotpr (binopeqrel_subgr_eqrel (PAS a b)) f1 = f)
+        (g1 : PA⟦b, c⟧) (g2 : setquotpr (binopeqrel_subgr_eqrel (PAS b c)) g1 = g)
+        (h1 : PA⟦c, d⟧) (h2 : setquotpr (binopeqrel_subgr_eqrel (PAS c d)) h1 = h) :
+    QuotPrecategory_comp f (QuotPrecategory_comp g h) =
+    setquotpr (binopeqrel_subgr_eqrel (PAS a d)) (f1 ;; (g1 ;; h1)).
+  Proof.
+    apply pathsinv0.
+    set (ic2 := QuotPrecategory_comp_iscontr g h).
+    set (ic3 := QuotPrecategory_comp_iscontr f (pr1 (pr1 ic2))).
+    set (tmp := pr2 (pr1 ic3)). cbn beta in tmp. unfold QuotPrecategory_comp.
+    fold ic2. fold ic3. use tmp.
+    - exact f2.
+    - use (pr2 (pr1 ic2)).
+      + exact g2.
+      + exact h2.
+  Qed.
+
+  Lemma assoc2 {a b c d : QuotPrecategory_data} (f : QuotPrecategory_data ⟦a, b⟧)
+        (g : QuotPrecategory_data ⟦b, c⟧) (h : QuotPrecategory_data ⟦c, d⟧)
+        (f1 : PA⟦a, b⟧) (f2 : setquotpr (binopeqrel_subgr_eqrel (PAS a b)) f1 = f)
+        (g1 : PA⟦b, c⟧) (g2 : setquotpr (binopeqrel_subgr_eqrel (PAS b c)) g1 = g)
+        (h1 : PA⟦c, d⟧) (h2 : setquotpr (binopeqrel_subgr_eqrel (PAS c d)) h1 = h) :
+    setquotpr (binopeqrel_subgr_eqrel (PAS a d)) ((f1 ;; g1) ;; h1) =
+    QuotPrecategory_comp (QuotPrecategory_comp f g) h.
+  Proof.
+    set (ic1 := QuotPrecategory_comp_iscontr f g).
+    set (ic4 := QuotPrecategory_comp_iscontr (pr1 (pr1 ic1)) h).
+    set (tmp := pr2 (pr1 ic4)). cbn beta in tmp. unfold QuotPrecategory_comp.
+    fold ic1. fold ic4. use tmp.
+    - use (pr2 (pr1 ic1)).
+      + exact f2.
+      + exact g2.
+    - exact h2.
+  Qed.
+
+  (** QuotPrecategory is a precategory *)
+  Lemma is_precategory_QuotPrecategory_data : is_precategory QuotPrecategory_data.
+  Proof.
+    split.
+    - split.
+      (* id left *)
+      + intros a b f. apply pathsinv0. cbn. unfold QuotPrecategory_comp.
+        set (f'' := @issurjsetquotpr (to_abgrop a b) (binopeqrel_subgr_eqrel (PAS a b)) f).
+        use (squash_to_prop f''). apply isasetsetquot. intros f'. clear f''.
+        induction f' as [f1 f2]. rewrite <- f2. cbn in f1, a, b.
+        eapply pathscomp0.
+        * apply maponpaths. exact (! (id_left f1)).
+        * apply (pr2 (pr1 (QuotPrecategory_comp_iscontr
+                             (setquotpr (binopeqrel_subgr_eqrel (PAS a a)) (@identity PA a))
+                             (setquotpr (binopeqrel_subgr_eqrel (PAS a b)) f1)))).
+          -- apply idpath.
+          -- apply idpath.
+      (* id right *)
+      + intros a b f. apply pathsinv0. cbn. unfold QuotPrecategory_comp.
+        set (f'' := @issurjsetquotpr (to_abgrop a b) (binopeqrel_subgr_eqrel (PAS a b)) f).
+        use (squash_to_prop f''). apply isasetsetquot. intros f'. clear f''.
+        induction f' as [f1 f2]. rewrite <- f2. cbn in f1, a, b.
+        eapply pathscomp0.
+        * apply maponpaths. exact (! (id_right f1)).
+        * apply (pr2 (pr1 (QuotPrecategory_comp_iscontr
+                             (setquotpr (binopeqrel_subgr_eqrel (PAS a b)) f1)
+                             (setquotpr (binopeqrel_subgr_eqrel (PAS b b)) (@identity PA b))))).
+          -- apply idpath.
+          -- apply idpath.
+    (* assoc *)
+    - intros a b c d f g h. cbn.
+      set (f'' := @issurjsetquotpr (to_abgrop a b) (binopeqrel_subgr_eqrel (PAS a b)) f).
+      use (squash_to_prop f''). apply isasetsetquot. intros f'. clear f''.
+      set (g'' := @issurjsetquotpr (to_abgrop b c) (binopeqrel_subgr_eqrel (PAS b c)) g).
+      use (squash_to_prop g''). apply isasetsetquot. intros g'. clear g''.
+      set (h'' := @issurjsetquotpr (to_abgrop c d) (binopeqrel_subgr_eqrel (PAS c d)) h).
+      use (squash_to_prop h''). apply isasetsetquot. intros h'. clear h''.
+      induction f' as [f1 f2]. induction g' as [g1 g2]. induction h' as [h1 h2].
+      cbn in f1, g1, h1.
+      rewrite (assoc1 f g h f1 f2 g1 g2 h1 h2).
+      rewrite <- (assoc2 f g h f1 f2 g1 g2 h1 h2).
+      rewrite assoc. apply idpath.
+  Qed.
+
+  Definition QuotPrecategory : precategory :=
+    tpair _ _ is_precategory_QuotPrecategory_data.
+
+  Lemma has_homsets_QuotPrecategory : has_homsets QuotPrecategory.
+  Proof.
+    intros a b. apply isasetsetquot.
+  Qed.
+
+
+  (** ** Quotient precategory of PreAdditive is PreAdditive *)
+
+  Opaque isbinopeqrel_subgr_eqrel isabgrquot.
+  Definition QuotPrecategory_binops : PrecategoryWithBinOps.
+  Proof.
+    use mk_PrecategoryWithBinOps.
+    - exact QuotPrecategory.
+    - intros x y. exact (@op (subabgr_quot (PAS x y))).
+  Defined.
+
+  Local Lemma QuotPrecategory_isabgrops (x y : QuotPrecategory_binops) :
+    @isabgrop
+      (hSetpair (@setquot (PA ⟦ x, y ⟧) (@binopeqrel_subgr_eqrel (@to_abgrop PA x y) (PAS x y)))
+                (has_homsets_QuotPrecategory x y))
+      (@setquotfun2 (PA ⟦ x, y ⟧) (PA ⟦ x, y ⟧)
+                    (@binopeqrel_subgr_eqrel (@to_abgrop PA x y) (PAS x y))
+                    (@binopeqrel_subgr_eqrel (@to_abgrop PA x y) (PAS x y)) (@to_binop PA x y)
+                    (@iscompbinoptransrel
+                       (@to_setwithbinoppair PA x y)
+                       (@binopeqrel_subgr_eqrel (@to_abgrop PA x y) (PAS x y))
+                       (@eqreltrans (PA ⟦ x, y ⟧)
+                                    (@binopeqrel_subgr_eqrel (@to_abgrop PA x y) (PAS x y)))
+                       (@pr2 (eqrel (PA ⟦ x, y ⟧))
+                             (λ R : eqrel (PA ⟦ x, y ⟧),
+                                    @isbinophrel (@to_setwithbinoppair PA x y) R)
+                             (@binopeqrel_subgr_eqrel (@to_abgrop PA x y) (PAS x y))))).
+  Proof.
+    exact (pr2 (subabgr_quot (PAS x y))).
+  Defined.
+  Opaque QuotPrecategory_isabgrops.
+  (* isabgrops contains construction the unel of the homset. Thus this opaque might be problematic
+     later. Use Transparent QuotPrecategory_isabgrops if needed. *)
+
+  Definition QuotPrecategory_abgrops : PrecategoryWithAbgrops.
+  Proof.
+    use mk_PrecategoryWithAbgrops.
+    - exact QuotPrecategory_binops.
+    - exact has_homsets_QuotPrecategory.
+    - intros x y. exact (QuotPrecategory_isabgrops x y).
+  Defined.
+
+  (** Don't know why we need unel and unel'. Try to fix this if you can. *)
+  Local Lemma quot_unel (x y : PA) :
+    @to_unel QuotPrecategory_abgrops x y = to_quot_mor (@to_unel PA x y).
+  Proof.
+    unfold to_unel. unfold to_quot_mor. apply pathsinv0. apply idpath.
+  Qed.
+
+  Local Lemma quot_unel' (x y : PA) : @to_unel QuotPrecategory_abgrops x y = 1%multmonoid.
+  Proof.
+    unfold to_unel.
+    apply idpath.
+  Qed.
+
+  Local Lemma PreAdditive_pre_linear (x y z : PA) (f : setquot (binopeqrel_subgr_eqrel (PAS x y))) :
+    isbinopfun (@to_premor QuotPrecategory_abgrops x y z f).
+  Proof.
+    set (f'1 := @issurjsetquotpr (to_abgrop x y) (binopeqrel_subgr_eqrel (PAS x y)) f).
+    use (squash_to_prop f'1). apply isapropisbinopfun. intros f1. clear f'1.
+    intros g h. cbn in g, h. cbn.
+    set (g'1 := @issurjsetquotpr (to_abgrop y z) (binopeqrel_subgr_eqrel (PAS y z)) g).
+    use (squash_to_prop g'1). apply has_homsets_QuotPrecategory. intros g1. clear g'1.
+    set (h'1 := @issurjsetquotpr (to_abgrop y z) (binopeqrel_subgr_eqrel (PAS y z)) h).
+    use (squash_to_prop h'1). apply has_homsets_QuotPrecategory. intros h1. clear h'1.
+    induction f1 as [f1 f2]. induction g1 as [g1 g2]. induction h1 as [h1 h2].
+    unfold to_premor. rewrite <- f2. rewrite <- g2. rewrite <- h2.
+    set (tmp := QuotPrecategory_premor f1 g1 h1). unfold to_quot_mor in tmp. cbn.
+    exact tmp.
+  Qed.
+
+  Local Lemma PreAdditive_pre_unel (x y z : PA) (f : setquot (binopeqrel_subgr_eqrel (PAS x y))) :
+    @to_premor QuotPrecategory_abgrops x y z f 1%multmonoid = 1%multmonoid.
+  Proof.
+    cbn. rewrite <- quot_unel'. rewrite <- quot_unel'. rewrite quot_unel. rewrite quot_unel.
+    set (f'1 := @issurjsetquotpr (to_abgrop x y) (binopeqrel_subgr_eqrel (PAS x y)) f).
+    use (squash_to_prop f'1). apply has_homsets_QuotPrecategory. intros f1. clear f'1.
+    induction f1 as [f1 f2].
+    unfold to_premor. cbn. unfold QuotPrecategory_comp.
+    set (tmp := @quot_comp_unel_left x y z f1). unfold to_quot_mor in tmp.
+    unfold QuotPrecategory_comp in tmp. rewrite <- f2. unfold to_quot_mor.
+    exact tmp.
+  Qed.
+
+  Local Lemma PreAdditive_post_linear (x y z : PA)
+        (f : setquot (binopeqrel_subgr_eqrel (PAS y z))) :
+    isbinopfun (@to_postmor QuotPrecategory_abgrops x y z f).
+  Proof.
+    set (f'1 := @issurjsetquotpr (to_abgrop y z) (binopeqrel_subgr_eqrel (PAS y z)) f).
+    use (squash_to_prop f'1). apply isapropisbinopfun. intros f1. clear f'1.
+    intros g h. cbn in g, h. cbn.
+    set (g'1 := @issurjsetquotpr (to_abgrop x y) (binopeqrel_subgr_eqrel (PAS x y)) g).
+    use (squash_to_prop g'1). apply has_homsets_QuotPrecategory. intros g1. clear g'1.
+    set (h'1 := @issurjsetquotpr (to_abgrop x y) (binopeqrel_subgr_eqrel (PAS x y)) h).
+    use (squash_to_prop h'1). apply has_homsets_QuotPrecategory. intros h1. clear h'1.
+    induction f1 as [f1 f2]. induction g1 as [g1 g2]. induction h1 as [h1 h2].
+    unfold to_postmor. rewrite <- f2. rewrite <- g2. rewrite <- h2.
+    set (tmp := QuotPrecategory_postmor f1 g1 h1). unfold to_quot_mor in tmp. cbn.
+    exact tmp.
+  Qed.
+
+  Local Lemma PreAdditive_post_unel (x y z : PA) (f : setquot (binopeqrel_subgr_eqrel (PAS y z))) :
+    @to_postmor QuotPrecategory_abgrops x y z f 1%multmonoid = 1%multmonoid.
+  Proof.
+    cbn. rewrite <- quot_unel'. rewrite <- quot_unel'. rewrite quot_unel. rewrite quot_unel.
+    set (f'1 := @issurjsetquotpr (to_abgrop y z) (binopeqrel_subgr_eqrel (PAS y z)) f).
+    use (squash_to_prop f'1). apply has_homsets_QuotPrecategory. intros f1. clear f'1.
+    induction f1 as [f1 f2].
+    unfold to_postmor. cbn. unfold QuotPrecategory_comp.
+    set (tmp := @quot_comp_unel_right x y z f1). unfold to_quot_mor in tmp.
+    unfold QuotPrecategory_comp in tmp. rewrite <- f2. unfold to_quot_mor.
+    exact tmp.
+  Qed.
+
+  Definition QuotPrecategory_PreAdditive : PreAdditive.
+  Proof.
+    use mk_PreAdditive.
+    - exact QuotPrecategory_abgrops.
+    - split.
+      + intros x y z f. cbn in f, x, y, z.
+        split.
+        * exact (PreAdditive_pre_linear x y z f).
+        * exact (PreAdditive_pre_unel x y z f).
+      + intros x y z f. cbn in f, x, y, z.
+        split.
+        * exact (PreAdditive_post_linear x y z f).
+        * exact (PreAdditive_post_unel x y z f).
+  Defined.
+
+  Lemma setquotpr_linear {x y : PA} (f g : PA⟦x, y⟧) :
+    to_quot_mor (@to_binop PA _ _ f g) =
+    @to_binop QuotPrecategory_PreAdditive _ _ (to_quot_mor f) (to_quot_mor g).
+  Proof.
+    set (tmp := pr1 (abgrquotpr_ismonoidfun (binopeqrel_subgr_eqrel (PAS x y))) f g).
+    cbn beta in tmp. unfold to_quot_mor. apply tmp.
+  Qed.
+
+  Lemma comp_eq {x y z : PA} (f : QuotPrecategory_PreAdditive⟦x, y⟧)
+        (g : QuotPrecategory_PreAdditive⟦y, z⟧) : QuotPrecategory_comp f g = f ;; g.
+  Proof.
+    apply idpath.
+  Qed.
+
+
+  (** ** If PA has a zero object, then so does QuotPrecategory of PA *)
+
+  Variable Z : Zero PA.
+
+  Lemma QuotPrecategory_isZero : isZero QuotPrecategory Z.
+  Proof.
+    use mk_isZero.
+    - intros a.
+      use tpair.
+      + exact (to_quot_mor (@ZeroArrowFrom PA Z a)).
+      + cbn beta. intros t.
+        set (t'1 := @issurjsetquotpr (to_abgrop Z a) (binopeqrel_subgr_eqrel (PAS Z a)) t).
+        use (squash_to_prop t'1). apply has_homsets_QuotPrecategory. intros t1. clear t'1.
+        induction t1 as [t1 t2]. rewrite <- t2. unfold to_quot_mor. apply maponpaths.
+        apply ArrowsFromZero.
+    - intros a.
+      use tpair.
+      + exact (to_quot_mor (@ZeroArrowTo PA Z a)).
+      + cbn beta. intros t.
+        set (t'1 := @issurjsetquotpr (to_abgrop a Z) (binopeqrel_subgr_eqrel (PAS a Z)) t).
+        use (squash_to_prop t'1). apply has_homsets_QuotPrecategory. intros t1. clear t'1.
+        induction t1 as [t1 t2]. rewrite <- t2. unfold to_quot_mor. apply maponpaths.
+        apply ArrowsToZero.
+  Defined.
+  Opaque QuotPrecategory_isZero.
+
+  Definition QuotPrecategory_Zero : @Zero QuotPrecategory.
+  Proof.
+    use mk_Zero.
+    - exact Z.
+    - exact QuotPrecategory_isZero.
+  Defined.
+
+End preadditive_quotient.

--- a/UniMath/CategoryTheory/PreAdditive.v
+++ b/UniMath/CategoryTheory/PreAdditive.v
@@ -129,6 +129,7 @@ Section preadditive_with_zero.
 
 End preadditive_with_zero.
 
+
 (** Some equations on inverses in PreAdditiev categories *)
 Section preadditive_inv_comp.
 
@@ -154,6 +155,12 @@ Section preadditive_inv_comp.
     rewrite linvax. rewrite to_premor_unel'.
     unfold to_unel.
     apply idpath.
+  Qed.
+
+  Lemma PreAdditive_cancel_inv {x y : A} (f g : A⟦x, y⟧) (H : (to_inv _ _ f)  = (to_inv _ _ g)) :
+    f = g.
+  Proof.
+    apply (grinvmaponpathsinv (to_abgrop x y) H).
   Qed.
 
 End preadditive_inv_comp.

--- a/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
+++ b/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
@@ -66,9 +66,11 @@ Section def_precategory_with_abgrops.
 
   Definition to_inv (x y : PA) :  PA⟦x, y⟧ -> PA⟦x, y⟧ := grinv (to_abgrop x y).
 
-  (** The following definition gives maps between abgrops homsets by
-    precomposing and postcomposing with a morphism. Note that we have
-    not required these to be abelian group morphisms of abelian groups. *)
+  Definition to_commax (x y : PA) := commax (to_abgrop x y).
+
+  (** The following definition gives maps between abgrops homsets by precomposing and postcomposing
+      with a morphism. Note that we have not required these to be abelian group morphisms of abelian
+      groups. *)
   Definition to_premor {x y : PA} (z : PA) (f : x --> y) : to_abgrop y z -> to_abgrop x z :=
     fun (g : (to_abgrop y z)) => f ;; g.
 

--- a/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
+++ b/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
@@ -100,6 +100,20 @@ Section def_precategory_with_abgrops.
     apply (grrinvax (to_abgrop x y)).
   Qed.
 
+  Lemma to_lcan {x y : PA} {f g : PA⟦x, y⟧} (h : PA⟦x, y⟧) :
+    to_binop x y h f = to_binop x y h g -> f = g.
+  Proof.
+    intros H.
+    apply (grlcan (to_abgrop x y) h H).
+  Qed.
+
+  Lemma to_rcan {x y : PA} {f g : PA⟦x, y⟧} (h : PA⟦x, y⟧) :
+    to_binop x y f h = to_binop x y g h -> f = g.
+  Proof.
+    intros H.
+    apply (grrcan (to_abgrop x y) h H).
+  Qed.
+
 End def_precategory_with_abgrops.
 Arguments to_has_homsets [PA] _ _ _ _ _ _.
 Arguments to_homset [PA] _ _.

--- a/UniMath/CategoryTheory/limits/BinDirectSums.v
+++ b/UniMath/CategoryTheory/limits/BinDirectSums.v
@@ -1,5 +1,5 @@
 (** * Direct definition of binary direct sum using preadditive categories. *)
-(** ** Contensts
+(** ** Contents
 - Definition of binary direct sums (also known as biproducts)
 - Criteria for binary direct sums
 - Quotient has binary direct sums

--- a/UniMath/CategoryTheory/limits/BinDirectSums.v
+++ b/UniMath/CategoryTheory/limits/BinDirectSums.v
@@ -1,4 +1,10 @@
-(** ** Direct definition of binary direct sum using preadditive categories. *)
+(** * Direct definition of binary direct sum using preadditive categories. *)
+(** ** Contensts
+- Definition of binary direct sums (also known as biproducts)
+- Criteria for binary direct sums
+- Quotient has binary direct sums
+*)
+
 Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.Foundations.Basics.Propositions.
 Require Import UniMath.Foundations.Basics.Sets.
@@ -21,8 +27,8 @@ Require Import UniMath.CategoryTheory.Monics.
 Require Import UniMath.CategoryTheory.Epis.
 
 
-(** BinDirectSum is at the same time product and coproduct of the underlying objects together with
-    the following equalities
+(** BinDirectSumCone is at the same time product and coproduct of the underlying objects together
+    with the following equalities
 
     i1 ;; p1 = identity  and   i2 ;; p2 = identity
     i1 ;; p2 = unit      and   i2 ;; p1 = unit
@@ -551,3 +557,193 @@ Section bindirectsums_criteria.
   Defined.
 
 End bindirectsums_criteria.
+
+
+(** * BinDirectSums in quotient of PreAdditive category
+   In this section we show that, if a PreAdditive A has BinDirectSums, then the quotient of the
+   preadditive category has BinDirectSums. This is used to show that quotient of an Additive is
+   Additive. *)
+Section bindirectsums_in_quot.
+
+  Variable A : PreAdditive.
+  Hypothesis Z : Zero A.
+  Hypothesis BD : BinDirectSums A.
+  Hypothesis PAS : PreAdditiveSubabgrs A.
+  Hypothesis PAC : PreAdditiveComps A PAS.
+
+  Lemma QuotPrecategory_isBinCoproductCocone (x y : A) :
+    isBinCoproductCocone (QuotPrecategory_PreAdditive A PAS PAC) x y (BD x y)
+                         (to_quot_mor A PAS (to_In1 A (BD x y)))
+                         (to_quot_mor A PAS (to_In2 A (BD x y))).
+  Proof.
+    use mk_isBinCoproductCocone.
+    - apply has_homsets_QuotPrecategory.
+    - intros c f g.
+      set (f'' := @issurjsetquotpr (@to_abgrop A x c) (binopeqrel_subgr_eqrel (PAS x c)) f).
+      use (squash_to_prop f''). apply isapropiscontr. intros f'. clear f''.
+      set (g'' := @issurjsetquotpr (@to_abgrop A y c) (binopeqrel_subgr_eqrel (PAS y c)) g).
+      use (squash_to_prop g''). apply isapropiscontr. intros g'. clear g''.
+      induction f' as [f1 f2]. induction g' as [g1 g2]. cbn in f1, g1.
+      use unique_exists.
+      + exact (to_quot_mor A PAS (FromBinDirectSum A (BD x y) f1 g1)).
+      + cbn beta. split.
+        * cbn.
+          rewrite BinDirectSumIn1Commutes. exact f2.
+        * cbn. rewrite BinDirectSumIn2Commutes. exact g2.
+      + intros y0. apply isapropdirprod; apply has_homsets_QuotPrecategory.
+      + intros y0 T. cbn beta in T. induction T as [T1 T2].
+        * set (y'' := @issurjsetquotpr (@to_abgrop A (BD x y) c)
+                                       (binopeqrel_subgr_eqrel (PAS (BD x y) c)) y0).
+          use (squash_to_prop y''). apply has_homsets_QuotPrecategory. intros y'. clear y''.
+          induction y' as [y1 y2]. rewrite <- y2. rewrite <- y2 in T1. rewrite <- y2 in T2.
+          cbn in y1.
+          rewrite <- (@id_left (QuotPrecategory_PreAdditive A PAS PAC) _ _
+                              (setquotpr (binopeqrel_subgr_eqrel (PAS (BD x y) c)) y1)).
+          rewrite <- (@id_left A _ _ (FromBinDirectSum A (BD x y) f1 g1)).
+          rewrite <- (to_BinOpId A (BD x y)). rewrite to_postmor_linear'.
+          repeat rewrite <- assoc.
+          rewrite BinDirectSumIn1Commutes.
+          rewrite BinDirectSumIn2Commutes.
+          rewrite <- f2 in T1. rewrite <- g2 in T2. unfold to_quot_mor.
+          set (tmp := @setquotpr_linear A PAS PAC (BD x y) c). unfold to_quot_mor in tmp.
+          rewrite tmp. clear tmp.
+          set (tmp := @QuotPrecategory_comp_linear A PAS PAC (BD x y) x c).
+          unfold to_quot_mor in tmp. rewrite <- tmp. clear tmp.
+          rewrite <- T1.
+          set (tmp := @QuotPrecategory_comp_linear A PAS PAC (BD x y) y c).
+          unfold to_quot_mor in tmp. rewrite <- tmp. clear tmp.
+          rewrite <- T2. unfold to_quot_mor. rewrite comp_eq. rewrite comp_eq.
+          rewrite assoc. rewrite assoc.
+          rewrite <- to_postmor_linear'.
+          repeat rewrite <- comp_eq.
+          set (tmp := @QuotPrecategory_comp_linear A PAS PAC (BD x y) x (BD x y)).
+          unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
+          set (tmp := @QuotPrecategory_comp_linear A PAS PAC (BD x y) y (BD x y)).
+          unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
+          set (tmp := @setquotpr_linear A PAS PAC (BD x y) (BD x y)). unfold to_quot_mor in tmp.
+          rewrite <- tmp. clear tmp.
+          rewrite comp_eq.
+          rewrite (to_BinOpId A (BD x y)).
+          rewrite comp_eq. apply cancel_postcomposition.
+          apply idpath.
+  Defined.
+  Opaque QuotPrecategory_isBinCoproductCocone.
+
+  Lemma QuotPrecategory_isBinProductCone (x y : A) :
+    isBinProductCone (QuotPrecategory_PreAdditive A PAS PAC) x y (BD x y)
+                     (to_quot_mor A PAS (to_Pr1 A (BD x y)))
+                     (to_quot_mor A PAS (to_Pr2 A (BD x y))).
+  Proof.
+    use mk_isBinProductCone.
+    - apply has_homsets_QuotPrecategory.
+    - intros c f g.
+      set (f'' := @issurjsetquotpr (@to_abgrop A c x) (binopeqrel_subgr_eqrel (PAS c x)) f).
+      use (squash_to_prop f''). apply isapropiscontr. intros f'. clear f''.
+      set (g'' := @issurjsetquotpr (@to_abgrop A c y) (binopeqrel_subgr_eqrel (PAS c y)) g).
+      use (squash_to_prop g''). apply isapropiscontr. intros g'. clear g''.
+      induction f' as [f1 f2]. induction g' as [g1 g2]. cbn in f1, g1.
+      use unique_exists.
+      + exact (to_quot_mor A PAS (ToBinDirectSum A (BD x y) f1 g1)).
+      + cbn beta. split.
+        * cbn. rewrite BinDirectSumPr1Commutes. exact f2.
+        * cbn. rewrite BinDirectSumPr2Commutes. exact g2.
+      + intros y0. apply isapropdirprod; apply has_homsets_QuotPrecategory.
+      + intros y0 T. cbn beta in T. induction T as [T1 T2].
+        * set (y'' := @issurjsetquotpr (@to_abgrop A c (BD x y))
+                                       (binopeqrel_subgr_eqrel (PAS c (BD x y))) y0).
+          use (squash_to_prop y''). apply has_homsets_QuotPrecategory. intros y'. clear y''.
+          induction y' as [y1 y2]. rewrite <- y2. rewrite <- y2 in T1. rewrite <- y2 in T2.
+          cbn in y1.
+          rewrite <- (@id_right (QuotPrecategory_PreAdditive A PAS PAC) _ _
+                               (setquotpr (binopeqrel_subgr_eqrel (PAS c (BD x y))) y1)).
+          rewrite <- (@id_right A _ _ (ToBinDirectSum A (BD x y) f1 g1)).
+          rewrite <- (to_BinOpId A (BD x y)). rewrite to_premor_linear'.
+          repeat rewrite assoc.
+          rewrite BinDirectSumPr1Commutes.
+          rewrite BinDirectSumPr2Commutes.
+          rewrite <- f2 in T1. rewrite <- g2 in T2. unfold to_quot_mor.
+          set (tmp := @setquotpr_linear A PAS PAC c (BD x y)). unfold to_quot_mor in tmp.
+          rewrite tmp. clear tmp.
+          set (tmp := @QuotPrecategory_comp_linear A PAS PAC c x (BD x y)).
+          unfold to_quot_mor in tmp. rewrite <- tmp. clear tmp.
+          rewrite <- T1.
+          set (tmp := @QuotPrecategory_comp_linear A PAS PAC c y (BD x y)).
+          unfold to_quot_mor in tmp. rewrite <- tmp. clear tmp.
+          rewrite <- T2. unfold to_quot_mor. rewrite comp_eq. rewrite comp_eq.
+          rewrite <- assoc. rewrite <- assoc.
+          rewrite <- to_premor_linear'.
+          repeat rewrite <- comp_eq.
+          set (tmp := @QuotPrecategory_comp_linear A PAS PAC (BD x y) x (BD x y)).
+          unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
+          set (tmp := @QuotPrecategory_comp_linear A PAS PAC (BD x y) y (BD x y)).
+          unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
+          set (tmp := @setquotpr_linear A PAS PAC (BD x y) (BD x y)). unfold to_quot_mor in tmp.
+          rewrite <- tmp. clear tmp.
+          rewrite comp_eq.
+          rewrite (to_BinOpId A (BD x y)).
+          rewrite comp_eq. apply cancel_precomposition.
+          apply idpath.
+  Defined.
+  Opaque QuotPrecategory_isBinProductCone.
+
+  Opaque QuotPrecategory_PreAdditive. (* This speeds up the following proof significantly. *)
+  Lemma QuotPrecategory_isBinDirectSumCone (x y : A) :
+    isBinDirectSumCone
+      (QuotPrecategory_PreAdditive A PAS PAC) x y (BD x y)
+      (to_quot_mor A PAS (to_In1 A (BD x y))) (to_quot_mor A PAS (to_In2 A (BD x y)))
+      (to_quot_mor A PAS (to_Pr1 A (BD x y))) (to_quot_mor A PAS (to_Pr2 A (BD x y))).
+  Proof.
+    use mk_isBinDirectSumCone.
+    - exact (QuotPrecategory_isBinCoproductCocone x y).
+    - exact (QuotPrecategory_isBinProductCone x y).
+    - unfold to_quot_mor.
+      rewrite <- comp_eq.
+      set (tmp := @QuotPrecategory_comp_linear A PAS PAC x (BD x y) x).
+      unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
+      rewrite (to_IdIn1 A (BD x y)).
+      apply idpath.
+    - unfold to_quot_mor.
+      rewrite <- comp_eq.
+      set (tmp := @QuotPrecategory_comp_linear A PAS PAC y (BD x y) y).
+      unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
+      rewrite (to_IdIn2 A (BD x y)).
+      apply idpath.
+    - unfold to_quot_mor.
+      rewrite <- comp_eq.
+      set (tmp := @QuotPrecategory_comp_linear A PAS PAC x (BD x y) y).
+      unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
+      rewrite (to_Unel1 A (BD x y)).
+      apply idpath.
+    - unfold to_quot_mor.
+      rewrite <- comp_eq.
+      set (tmp := @QuotPrecategory_comp_linear A PAS PAC y (BD x y) x).
+      unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
+      rewrite (to_Unel2 A (BD x y)).
+      apply idpath.
+    - unfold to_quot_mor.
+      repeat rewrite <- comp_eq.
+      set (tmp := @QuotPrecategory_comp_linear A PAS PAC (BD x y) x (BD x y)).
+      unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
+      set (tmp := @QuotPrecategory_comp_linear A PAS PAC (BD x y) y (BD x y)).
+      unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
+      set (tmp := @setquotpr_linear A PAS PAC (BD x y) (BD x y)). unfold to_quot_mor in tmp.
+      rewrite <- tmp. clear tmp.
+      rewrite (to_BinOpId A (BD x y)).
+      apply idpath.
+  Defined.
+  Opaque QuotPrecategory_isBinDirectSumCone.
+  Transparent QuotPrecategory_PreAdditive. (* Transparent again *)
+
+  Definition QuotPrecategory_BinDirectSums : BinDirectSums (QuotPrecategory_PreAdditive A PAS PAC).
+  Proof.
+    intros x y.
+    use mk_BinDirectSumCone.
+    - exact (BD x y).
+    - exact (to_quot_mor A PAS (to_In1 A (BD x y))).
+    - exact (to_quot_mor A PAS (to_In2 A (BD x y))).
+    - exact (to_quot_mor A PAS (to_Pr1 A (BD x y))).
+    - exact (to_quot_mor A PAS (to_Pr2 A (BD x y))).
+    - exact (QuotPrecategory_isBinDirectSumCone x y).
+  Defined.
+
+End bindirectsums_in_quot.

--- a/UniMath/CategoryTheory/limits/BinDirectSums.v
+++ b/UniMath/CategoryTheory/limits/BinDirectSums.v
@@ -345,6 +345,32 @@ Section def_bindirectsums.
   Defined.
   Opaque BinDirectSumIndArEq.
 
+  (** ** Composition of IndAr *)
+  Lemma BinDirectSumIndArComp {a b c d e f : A} (f1 : a --> b) (f2 : b --> c)
+        (g1 : d --> e) (g2 : e --> f) (B1 : BinDirectSumCone a d) (B2 : BinDirectSumCone b e)
+        (B3 : BinDirectSumCone c f) :
+    BinDirectSumIndAr f1 g1 B1 B2 ;; BinDirectSumIndAr f2 g2 B2 B3 =
+    BinDirectSumIndAr (f1 ;; f2) (g1 ;; g2) B1 B3.
+  Proof.
+    rewrite BinDirectSumIndArEq1. rewrite BinDirectSumIndArEq1. rewrite BinDirectSumIndArEq1.
+    unfold BinDirectSumIndArFormula.
+    rewrite to_postmor_linear'.
+    rewrite to_premor_linear'.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
+    rewrite <- (assoc _ (to_In1 B2)). rewrite <- (assoc _ (to_In1 B2)).
+    rewrite (to_IdIn1 B2). rewrite id_right.
+    rewrite (to_Unel1 B2). rewrite to_premor_unel'.
+    rewrite to_postmor_unel'. rewrite to_postmor_unel'. rewrite to_runax'.
+    rewrite to_premor_linear'.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
+    rewrite <- (assoc _ (to_In2 B2)). rewrite <- (assoc _ (to_In2 B2)).
+    rewrite (to_IdIn2 B2). rewrite id_right.
+    rewrite (to_Unel2 B2). rewrite to_premor_unel'.
+    rewrite to_postmor_unel'. rewrite to_postmor_unel'.
+    rewrite to_lunax'.
+    apply idpath.
+  Qed.
+
 End def_bindirectsums.
 
 (** In1 and In2 are monics, and Pr1 and Pr2 are epis. *)

--- a/UniMath/CategoryTheory/limits/coequalizers.v
+++ b/UniMath/CategoryTheory/limits/coequalizers.v
@@ -130,6 +130,15 @@ Section def_coequalizers.
     apply (isCoequalizerOutsEq (isCoequalizer_Coequalizer E) _ _ H').
   Defined.
 
+  Lemma CoequalizerOutComp {y z : C} {f g : y --> z} (CE : Coequalizer f g) {w w' : C}
+        (h1 : z --> w) (h2 : w --> w')
+        (H1 : f ;; (h1 ;; h2) = g ;; (h1 ;; h2)) (H2 : f ;; h1 = g ;; h1) :
+    CoequalizerOut CE w' (h1 ;; h2) H1 = CoequalizerOut CE w h1 H2 ;; h2.
+  Proof.
+    use CoequalizerOutsEq. rewrite CoequalizerCommutes. rewrite assoc.
+    rewrite CoequalizerCommutes. apply idpath.
+  Qed.
+
   (** Morphisms between coequalizer objects with the right commutativity
     equalities. *)
   Definition identity_is_CoequalizerOut {y z : C} {f g : y --> z}

--- a/UniMath/CategoryTheory/limits/equalizers.v
+++ b/UniMath/CategoryTheory/limits/equalizers.v
@@ -127,6 +127,16 @@ Section def_equalizers.
     apply (isEqualizerInsEq (isEqualizer_Equalizer E) _ _ H').
   Defined.
 
+  Lemma EqualizerInComp {y z : C} {f g : y --> z} (E : Equalizer f g) {x x' : C}
+        (h1 : x --> x') (h2 : x' --> y)
+        (H1 : h1 ;; h2 ;; f = h1 ;; h2 ;; g) (H2 : h2 ;; f = h2 ;; g) :
+    EqualizerIn E x (h1 ;; h2) H1 = h1 ;; EqualizerIn E x' h2 H2.
+  Proof.
+    use EqualizerInsEq. rewrite EqualizerCommutes.
+    rewrite <- assoc. rewrite EqualizerCommutes.
+    apply idpath.
+  Qed.
+
   (** Morphisms between equalizer objects with the right commutativity
     equalities. *)
   Definition identity_is_EqualizerIn {y z : C} {f g : y --> z}

--- a/UniMath/CategoryTheory/limits/zero.v
+++ b/UniMath/CategoryTheory/limits/zero.v
@@ -137,6 +137,21 @@ Section def_zero.
         rewrite <- assoc. rewrite (iso_after_iso_inv i). rewrite id_right.
         apply ArrowsToZero.
   Qed.
+
+
+  (** ** Transport of ZeroArrow *)
+  Lemma transportf_ZeroArrow {a b c : C} (Z : Zero) (e : b = c) :
+    transportf _ e (ZeroArrow Z a b) = ZeroArrow Z a c.
+  Proof.
+    induction e. apply idpath.
+  Qed.
+
+  Lemma transportb_ZeroArrow {a b c : C} (Z : Zero) (e : a = b) :
+    transportb (fun (a' : ob C) => precategory_morphisms a' c) e (ZeroArrow Z b c) = ZeroArrow Z a c.
+  Proof.
+    induction e. apply idpath.
+  Qed.
+
 End def_zero.
 
 

--- a/UniMath/CategoryTheory/precategories.v
+++ b/UniMath/CategoryTheory/precategories.v
@@ -1227,3 +1227,58 @@ Definition precategory_total_comp (C : precategory_data) :
   fun f g e =>
      tpair _ (dirprodpair (pr1 (pr1 f))(pr2 (pr1 g)))
         ((pr2 f ;; idtomor _ _ e) ;; pr2 g).
+
+
+(** ** Transport of morphisms *)
+Lemma transportf_postcompose {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z) (e : z = w) :
+  transportf (precategory_morphisms x) e (f ;; g) = f ;; transportf (precategory_morphisms y) e g.
+Proof.
+  induction e. apply idpath.
+Qed.
+
+Lemma transportb_precompose {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z) (e : w = x) :
+  transportb (fun x' : ob C => precategory_morphisms x' z) e (f ;; g) =
+  transportb (fun x' : ob C => precategory_morphisms x' y) e f ;; g.
+Proof.
+  induction e. apply idpath.
+Qed.
+
+Lemma transport_compose {C : precategory} {x y z w : ob C} (f : x --> y) (g : z --> w) (e : y = z) :
+  transportf (precategory_morphisms x) e f ;; g =
+  f ;; transportb (fun x' : ob C => precategory_morphisms x' w) e g.
+Proof.
+  induction e. apply idpath.
+Qed.
+
+Lemma transportf_paths {C : precategory} {x y z : ob C} (f g : x --> y) (e : y = z) :
+  transportf (precategory_morphisms x) e f = transportf (precategory_morphisms x) e g -> f = g.
+Proof.
+  induction e. intros H. apply H.
+Qed.
+
+Lemma transportb_paths {C : precategory} {x y z : ob C} (f g : y --> z) (e : x = y) :
+  transportb (fun x' : ob C => precategory_morphisms x' z) e f =
+  transportb (fun x' : ob C => precategory_morphisms x' z) e g -> f = g.
+Proof.
+  induction e. intros H. apply H.
+Qed.
+
+Lemma transportf_mor {X : UU} {C : precategory} {x y : X} (P : Π (x' : X), ob C)
+      (P' : Π (x' : X), ob C) (f : Π (x' : X), (P x') --> (P' x')) (e : x = y) :
+  transportf (fun (x' : X) => (P x') --> (P' x')) e (f x) =
+  transportb (fun (x' : X) => precategory_morphisms (P x') (P' y)) (! e)
+             (transportf (precategory_morphisms (P x)) (maponpaths P' e) (f x)).
+Proof.
+  rewrite <- functtransportf. unfold pathsinv0. unfold paths_rect. induction e.
+  apply idpath.
+Qed.
+
+Lemma transportf_mor' {X : UU} {C : precategory} {x y : X} (P : Π (x' : X), ob C)
+      (P' : Π (x' : X), ob C) (f : Π (x' : X), (P x') --> (P' x')) (e : x = y) :
+  transportf (fun (x' : X) => (P x') --> (P' x')) e (f x) =
+  transportf (precategory_morphisms (P y)) (maponpaths P' e)
+             (transportb (fun (x' : X) => precategory_morphisms (P x') (P' x)) (! e) (f x)).
+Proof.
+  rewrite <- functtransportf. unfold pathsinv0. unfold paths_rect. induction e.
+  apply idpath.
+Qed.

--- a/UniMath/CategoryTheory/precategories.v
+++ b/UniMath/CategoryTheory/precategories.v
@@ -1250,13 +1250,13 @@ Proof.
   induction e. apply idpath.
 Qed.
 
-Lemma transportf_paths {C : precategory} {x y z : ob C} (f g : x --> y) (e : y = z) :
+Lemma transportf_path {C : precategory} {x y z : ob C} (f g : x --> y) (e : y = z) :
   transportf (precategory_morphisms x) e f = transportf (precategory_morphisms x) e g -> f = g.
 Proof.
   induction e. intros H. apply H.
 Qed.
 
-Lemma transportb_paths {C : precategory} {x y z : ob C} (f g : y --> z) (e : x = y) :
+Lemma transportb_path {C : precategory} {x y z : ob C} (f g : y --> z) (e : x = y) :
   transportb (fun x' : ob C => precategory_morphisms x' z) e f =
   transportb (fun x' : ob C => precategory_morphisms x' z) e g -> f = g.
 Proof.

--- a/UniMath/CategoryTheory/precategories.v
+++ b/UniMath/CategoryTheory/precategories.v
@@ -97,6 +97,8 @@ Definition compose { C : precategory_data }
 
 Local Notation "f ;; g" := (compose f g) (at level 50, format "f  ;;  g").
 
+Definition postcompose  {C : precategory_data} {a b c : C} (g : b --> c) (f : a --> b) : a --> c :=
+  compose f g.
 
 (** ** Axioms of a precategory *)
 (**
@@ -449,6 +451,14 @@ Proof.
   apply (isweqhomot' _ _ T).
   intro h. apply assoc.
 Defined.
+
+Lemma is_iso_comp_of_is_isos {C : precategory} {a b c : ob C}
+      (f : a --> b) (g : b --> c) (H1 : is_iso f) (H2 : is_iso g) : is_iso (f ;; g).
+Proof.
+  set (i1 := isopair f H1).
+  set (i2 := isopair g H2).
+  exact (is_iso_comp_of_isos i1 i2).
+Qed.
 
 Definition iso_comp {C : precategory} {a b c : ob C}
   (f : iso a b) (g : iso b c) : iso a c.
@@ -1230,7 +1240,8 @@ Definition precategory_total_comp (C : precategory_data) :
 
 
 (** ** Transport of morphisms *)
-Lemma transportf_postcompose {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z) (e : z = w) :
+Lemma transportf_postcompose {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z)
+      (e : z = w) :
   transportf (precategory_morphisms x) e (f ;; g) = f ;; transportf (precategory_morphisms y) e g.
 Proof.
   induction e. apply idpath.
@@ -1248,6 +1259,13 @@ Lemma transport_compose {C : precategory} {x y z w : ob C} (f : x --> y) (g : z 
   f ;; transportb (fun x' : ob C => precategory_morphisms x' w) e g.
 Proof.
   induction e. apply idpath.
+Qed.
+
+Lemma transport_compose' {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z) (e : y = w) :
+  (transportf (precategory_morphisms x) e f)
+    ;; (transportb (fun x' : ob C => precategory_morphisms x' z) (!e) g) = f ;; g.
+Proof.
+  induction e. cbn. unfold idfun. apply idpath.
 Qed.
 
 Lemma transportf_path {C : precategory} {x y z : ob C} (f g : x --> y) (e : y = z) :

--- a/UniMath/Foundations/Algebra/BinaryOperations.v
+++ b/UniMath/Foundations/Algebra/BinaryOperations.v
@@ -1177,6 +1177,9 @@ Definition pr1subsetswithbinop (X : setwithbinop) : @subsetswithbinop X -> hsubt
   @pr1 _ (fun A : hsubtypes X => issubsetwithbinop (@op X) A).
 Coercion pr1subsetswithbinop : subsetswithbinop >-> hsubtypes.
 
+Definition pr2subsetswithbinop {X : setwithbinop} (Y : @subsetswithbinop X) :
+  issubsetwithbinop (@op X) (pr1subsetswithbinop X Y) := pr2 Y.
+
 Definition totalsubsetwithbinop (X : setwithbinop) : @subsetswithbinop X.
 Proof.
   intros. split with (fun x : X => htrue). intros x x'. apply tt.

--- a/UniMath/Foundations/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Foundations/Algebra/Monoids_and_Groups.v
@@ -1505,7 +1505,7 @@ Proof. intros. split with (setwithbinopdirprod X Y). apply isgrdirprod. Defined.
 
 (** **** Basic definitions *)
 
-Definition abgr : UU := total2 (fun X : setwithbinop =>  isabgrop (@op X)).
+Definition abgr : UU := total2 (fun X : setwithbinop => isabgrop (@op X)).
 
 Definition abgrpair (X : setwithbinop) (is : isabgrop (@op X)) : abgr :=
   tpair (fun X : setwithbinop =>  isabgrop (@op X)) X is.

--- a/UniMath/Foundations/Basics/PartA.v
+++ b/UniMath/Foundations/Basics/PartA.v
@@ -703,7 +703,12 @@ Proof.
   intros. induction e. apply idpath.
 Defined.
 
-
+Lemma transportf_paths {X : UU} (P : X -> UU) {x1 x2 : X} {e1 e2 : x1 = x2} (e : e1 = e2)
+      (p : P x1) : transportf P e1 p = transportf P e2 p.
+Proof.
+  intros X P x1 x2 e1 e2 e p. induction e. apply idpath.
+Defined.
+Opaque transportf_paths.
 
 (** *** A series of lemmas about paths and [ total2 ]
 

--- a/UniMath/Foundations/Basics/PartA.v
+++ b/UniMath/Foundations/Basics/PartA.v
@@ -955,6 +955,8 @@ Definition hfiberpair {X Y : UU} (f : X -> Y) {y : Y}
 
 Definition hfiberpr1 {X Y : UU} (f : X -> Y) (y : Y) : hfiber f y -> X := pr1.
 
+Definition hfiberpr2 {X Y : UU} (f : X -> Y) (y : Y) (y' : hfiber f y) : f (hfiberpr1 f y y') = y :=
+  pr2 y'.
 
 (** *** The functions between the hfibers of homotopic functions over the same point *)
 

--- a/UniMath/Foundations/NumberSystems/Integers.v
+++ b/UniMath/Foundations/NumberSystems/Integers.v
@@ -126,6 +126,27 @@ Proof . intros . apply ( @grrcan hzaddabgr a b c is ) .  Defined .
 
 Definition hzinvmaponpathsminus { a b : hz } ( e :  paths ( - a ) ( - b ) ) : paths a b := grinvmaponpathsinv hzaddabgr e .
 
+Lemma hzrplusminus (n m : hz) : n + m - m = n.
+Proof.
+  intros n m. unfold hzminus, hzplus, hzplus. rewrite rngassoc1.
+  set (tmp := hzrminus m). unfold hzminus, hzplus in tmp. rewrite tmp. clear tmp.
+  apply hzplusr0.
+Defined.
+Opaque hzrplusminus.
+
+Lemma hzrminusplus (n m : hz) : n - m + m = n.
+Proof.
+  intros n m. unfold hzplus, hzminus. rewrite rngassoc1.
+  rewrite hzlminus. apply hzplusr0.
+Defined.
+Opaque hzrminusplus.
+
+
+Lemma hzrminusplus' (n m : hz) : n = n - m + m.
+Proof.
+  intros n m. apply pathsinv0. apply hzrminusplus.
+Defined.
+Opaque hzrminusplus'.
 
 (** *** Properties of multiplication on [ hz ] *)
 
@@ -907,5 +928,121 @@ rewrite ( hzabsvalgth0 ga ) .  rewrite ( hzabsvalleh0 leb ) . rewrite ( hzabsval
 rewrite ( hzabsvalgth0 gb ) .  rewrite ( hzabsvalleh0 lea ) . rewrite ( hzabsvalleh0 ( hzmultleh0gth0 lea gb ) ) . apply ( rnglmultminus hz ) .
 
 rewrite ( hzabsvalleh0 lea ) . rewrite ( hzabsvalleh0 leb ) . rewrite ( hzabsvalgeh0 ( hzmultleh0leh0 lea leb ) ) .  apply (rngmultminusminus hz ) . Defined .
+
+
+
+(** *** Some common equalities on integers *)
+(** These lemmas are used for example in Complexes.v to construct complexes. *)
+Local Opaque hz isdecrelhzeq iscommrngops.
+
+Lemma hzeqbooleqii (i : hz) : hzbooleq i i = true.
+Proof.
+  intros i.
+  unfold hzbooleq. unfold decreltobrel. induction (pr2 hzdeceq i i) as [T | F].
+  - apply idpath.
+  - apply fromempty. apply F. apply idpath.
+Qed.
+
+Lemma hzbooleqisi (i : hz) : hzbooleq i (i + 1) = false.
+Proof.
+  intros i.
+  unfold hzbooleq, decreltobrel. cbn.
+  induction (isdecrelhzeq i (i + 1)) as [e | n].
+  - apply fromempty. apply (ct (hzneq, isdecrelhzneq, 1, 0)).
+    apply (hzpluslcan 1 0 i (! (pathscomp0 (hzplusr0 i) e))).
+  - apply idpath.
+Qed.
+
+Lemma hzbooleqissi (i : hz) : hzbooleq i (i + 1 + 1) = false.
+Proof.
+  intros i.
+  unfold hzbooleq. unfold decreltobrel. cbn.
+  induction (isdecrelhzeq i (i + 1 + 1)) as [e | n].
+  - apply fromempty. apply (ct (hzneq, isdecrelhzneq, 1 + 1, 0)).
+    rewrite hzplusassoc in e. apply (hzpluslcan (1 + 1) 0 i (! (pathscomp0 (hzplusr0 i) e))).
+  - apply idpath.
+Qed.
+
+Lemma hzeqeisi {i i0 : hz} (e : hzeq i i0) (e' : hzeq i (i0 + 1)) : empty.
+Proof.
+  intros i i0 e e'.
+  apply nopathstruetofalse.
+  use (pathscomp0 _ (hzbooleqisi i0)).
+  rewrite <- e'. rewrite <- e.
+  apply (! (hzeqbooleqii i)).
+Qed.
+
+Lemma hzeqisi {i : hz} (e' : hzeq i (i + 1)) : empty.
+Proof.
+  intros i e'.
+  apply nopathstruetofalse. rewrite <- (hzbooleqisi i). rewrite <- e'.
+  apply (! (hzeqbooleqii i)).
+Qed.
+
+Lemma hzeqissi {i : hz} (e : hzeq i (i + 1 + 1)) : empty.
+Proof.
+  intros i e.
+  set (tmp := hzbooleqissi i). cbn in e. rewrite <- e in tmp.
+  rewrite (hzeqbooleqii i) in tmp. apply nopathstruetofalse. apply tmp.
+Qed.
+
+Lemma hzeqeissi {i i0 : hz} (e : hzeq i i0) (e' : hzeq i (i0 + 1 + 1)) : empty.
+Proof.
+  intros i e0 e e'.
+  cbn in e. rewrite e in e'. apply (hzeqissi e').
+Qed.
+
+Lemma hzeqsnmnsm {n m : hz} (e : hzeq (n + 1) m) (e' : hzeq n (m + 1)) : empty.
+Proof.
+  intros n m e e'.
+  cbn in e. rewrite <- e in e'. apply (hzeqissi e').
+Qed.
+
+Lemma isdecrelhzeqi (i : hz) : isdecrelhzeq i i = ii1 (idpath _).
+Proof.
+  intros i.
+  induction (isdecrelhzeq i i) as [T | F].
+  - apply maponpaths. apply isasethz.
+  - apply fromempty. apply F. apply idpath.
+Qed.
+
+Lemma isdecrelhzeqminusplus (i j : hz) : isdecrelhzeq i (i - j + j) = ii1 (hzrminusplus' i j).
+Proof.
+  intros i j.
+  induction (isdecrelhzeq i (i - j + j)) as [T | F].
+  - apply maponpaths. apply isasethz.
+  - apply fromempty. apply F. apply (hzrminusplus' i j).
+Qed.
+
+Lemma isdecrelhzeqminusplus' (i j : hz) : isdecrelhzeq (i - j + j) i = ii1 (hzrminusplus i j).
+Proof.
+  intros i j.
+  induction (isdecrelhzeq (i - j + j) i) as [T | F].
+  - apply maponpaths. apply isasethz.
+  - apply fromempty. apply F. apply (hzrminusplus i j).
+Qed.
+
+Lemma hzeqpii {i : hz} (e : hzeq (i - 1) i) : empty.
+Proof.
+  intros i e.
+  cbn in e.
+  rewrite <- (hzplusr0 i) in e. unfold hzminus in e.
+  rewrite hzplusassoc in e.
+  set (e' := hzpluslcan _ _ _ e). rewrite hzplusl0 in e'.
+  set (tmp := ( ct ( hzneq , isdecrelhzneq, - (1) , 0 ) )). cbn in tmp.
+  apply tmp. apply e'.
+Qed.
+
+Lemma isdecrelhzeqpii (i : hz) :
+  isdecrelhzeq (i - 1) i = ii2 (fun (e : hzeq (i - 1) i) => hzeqpii e).
+Proof.
+  intros i.
+  induction (isdecrelhzeq (i - 1) i) as [e | n].
+  - apply fromempty. apply (hzeqpii e).
+  - apply maponpaths. apply funextfun. intros e.
+    apply fromempty. apply n. apply e.
+Qed.
+
+Local Transparent hz isdecrelhzeq iscommrngops.
 
 (* End of the file hz.v *)

--- a/UniMath/Foundations/NumberSystems/Integers.v
+++ b/UniMath/Foundations/NumberSystems/Integers.v
@@ -134,6 +134,12 @@ Proof.
 Defined.
 Opaque hzrplusminus.
 
+Lemma hzrplusminus' (n m : hz) : n = n + m - m.
+Proof.
+  intros n m. apply pathsinv0. apply hzrplusminus.
+Defined.
+Opaque hzrplusminus'.
+
 Lemma hzrminusplus (n m : hz) : n - m + m = n.
 Proof.
   intros n m. unfold hzplus, hzminus. rewrite rngassoc1.


### PR DESCRIPTION
This PR contains definition of (cochain) complexes. The following two results are proved
- The category of complexes over an additive precategory is an additive precategory,
  ComplexPreCat_Additive, line 1199, Complexes.v
- The category of complexes over an abelian precategory is an abelian precategory,
  ComplexPreCat_AbelianPreCat, line 1885, Complexes.v

Suggestions for improvements are welcome.

Tomi