### PR TITLE
Direct proof that the precomposition functor is cocontinuous

### DIFF
--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -1538,26 +1538,31 @@ End BinProduct_of_functors.
 Section pre_composition_functor.
 
 Context {A B C : precategory} (F : functor A B) (hsB : has_homsets B) (hsC : has_homsets C).
-Context (CC : Colims C). (* This can be weakened *)
+(* Context (CC : Colims C). *) (* This is too strong *)
 
-Lemma is_cocont_pre_composition_functor :
+Lemma is_cocont_pre_composition_functor
+  (H : Π (g : graph) (d : diagram g [B,C,hsC]) (b : B),
+       ColimCocone (diagram_pointwise hsC d b)) :
   is_cocont (pre_composition_functor _ _ _ hsB hsC F).
 Proof.
-  intros g d G ccG HccG.
-  apply pointwise_Colim_is_isColimFunctor; intro a.
-  apply (isColimFunctor_is_pointwise_Colim _ _
-           (λ b, CC _ (diagram_pointwise _ _ b)) _ _ HccG).
+intros g d G ccG HccG.
+apply pointwise_Colim_is_isColimFunctor; intro a.
+apply (isColimFunctor_is_pointwise_Colim _ _ (H g d) _ _ HccG).
 Defined.
 
-Lemma is_omega_cocont_pre_composition_functor :
+Lemma is_omega_cocont_pre_composition_functor
+  (H : Π (c : chain [B,C,hsC]) (b : B), ColimCocone (diagram_pointwise hsC c b)) :
   is_omega_cocont (pre_composition_functor _ _ _ hsB hsC F).
 Proof.
-now intros c L ccL; apply is_cocont_pre_composition_functor.
+intros c L ccL HccL.
+apply pointwise_Colim_is_isColimFunctor; intro a.
+apply (isColimFunctor_is_pointwise_Colim _ _ (H c) _ _ HccL).
 Defined.
 
-Definition omega_cocont_pre_composition_functor :
+Definition omega_cocont_pre_composition_functor
+  (H : Π (c : chain [B,C,hsC]) (b : B), ColimCocone (diagram_pointwise hsC c b)) :
   omega_cocont_functor [B, C, hsC] [A, C, hsC] :=
-  tpair _ _ is_omega_cocont_pre_composition_functor.
+  tpair _ _ (is_omega_cocont_pre_composition_functor H).
 
 End pre_composition_functor.
 

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -1551,8 +1551,6 @@ intro a.
 apply (CC g (diagram_pointwise A C hsC g d a)).
 Defined.
 
-
-
 Lemma key2 (H : Π a, isColimCocone _ _ (cocone_pointwise _ _ _ _ d G ccG a)) :
   isColimCocone d G ccG.
 Proof.
@@ -1564,72 +1562,122 @@ Proof.
     - apply H.
   }
   transparent assert (D' : (ColimCocone d)).
-  { use mk_ColimCocone.
-    - apply G.
-    - apply ccG.
-    - intros G' ccG'.
-      simpl in *.
-      set (apa := cocone_pointwise _ _ _ _ d G' ccG').
-      (* transparent assert (apa : (Π a, cocone (diagram_pointwise A C hsC g d a) (G' a))). *)
-      (* { intros a; use mk_cocone. *)
-      (*   - intros v; apply (pr1 (coconeIn ccG' v)). *)
-      (*   - intros u v e; apply (nat_trans_eq_pointwise (coconeInCommutes ccG' u v e) a). *)
-      (* } *)
-      use unique_exists.
-      + mkpair.
-        * intro a.
-          apply (colimArrow (bar a) _ (apa a)).
-        * intros a b f.
-          apply pathsinv0.
-          eapply pathscomp0.
-          apply (postcompWithColimArrow _ (bar a)).
-          apply pathsinv0.
-          apply (colimArrowUnique (bar a)); intro v.
-          simpl.
-          cbn.
-          admit.
-      + simpl.
-        intro v.
-        apply (nat_trans_eq hsC); simpl; intro a.
-        apply (pr2 (pr1 (H a (G' a) (apa a)))).
-      + intros α; apply impred; intro v.
-        apply functor_category_has_homsets.
-      + simpl; intros α H1.
-        apply (nat_trans_eq hsC); intro a; simpl.
-        transparent assert (foo : (Σ x : C ⟦ (pr1 G) a, G' a ⟧,
-                                         Π v : vertex g, coconeIn (cocone_pointwise A C hsC g d G ccG a) v ;; x = coconeIn (apa a) v)).
-        mkpair.
-        apply α.
-        intros v; simpl.
-        apply (nat_trans_eq_pointwise (H1 v) a).
-        apply (maponpaths pr1 (pr2 (H a (G' a) (apa a)) foo)).
+  { apply (ColimFunctorCocone _ _ _ _ _ bar).
   }
   use is_iso_isColim.
   - apply functor_category_has_homsets.
   - apply D'.
   - use is_iso_qinv.
-    + cbn. apply nat_trans_id.
+    + cbn.
+      mkpair.
+      * intros a; simpl.
+        apply identity.
+      * intros a b f; rewrite id_left, id_right.
+        cbn.
+        Check (ColimFunctor_mor A C hsC g d bar a b f).
+        admit.
     + split.
       * assert (temp : colimArrow D' G ccG ;; nat_trans_id (pr1 G) = colimArrow D' G ccG).
         apply (nat_trans_eq hsC); simpl; intro x.
         now rewrite id_right.
-        eapply pathscomp0. apply temp.
+        cbn.
+        apply (nat_trans_eq hsC).
+
+        simpl.
+        intros x.
+        rewrite id_right.
         apply pathsinv0.
         apply colimArrowUnique.
         intros v.
         now rewrite id_right.
-      * unfold compose.
+      * apply (nat_trans_eq hsC).
+        intro a.
         simpl.
-        assert (temp : nat_trans_comp _ _ _ (nat_trans_id (pr1 G)) (colimArrow D' G ccG) = colimArrow D' G ccG).
-        apply (nat_trans_eq hsC); simpl; intro x.
-        now rewrite id_left.
-        eapply pathscomp0.
-        simpl.
-        apply temp.
+        rewrite id_left.
         apply pathsinv0.
+        apply (colimArrowUnique (bar a)); intro u.
         simpl.
-        now apply (colimArrowUnique D'); intro u; rewrite id_right.
+        now rewrite id_right.
 Admitted.
+
+(* First try *)
+(* Lemma key2 (H : Π a, isColimCocone _ _ (cocone_pointwise _ _ _ _ d G ccG a)) : *)
+(* isColimCocone d G ccG. *)
+(* Proof. *)
+(* transparent assert (bar : (Π a, ColimCocone (diagram_pointwise A C hsC g d a))). *)
+(* { intro a. *)
+(* use mk_ColimCocone. *)
+(* - apply (pr1 G a). *)
+(* - apply cocone_pointwise, ccG. *)
+(* - apply H. *)
+(* } *)
+(* transparent assert (D' : (ColimCocone d)). *)
+(* { use mk_ColimCocone. *)
+(* - apply G. *)
+(* - apply ccG. *)
+(* - intros G' ccG'. *)
+(* simpl in *. *)
+(* set (apa := cocone_pointwise _ _ _ _ d G' ccG'). *)
+(* (* transparent assert (apa : (Π a, cocone (diagram_pointwise A C hsC g d a) (G' a))). *) *)
+(* (* { intros a; use mk_cocone. *) *)
+(* (* - intros v; apply (pr1 (coconeIn ccG' v)). *) *)
+(* (* - intros u v e; apply (nat_trans_eq_pointwise (coconeInCommutes ccG' u v e) a). *) *)
+(* (* } *) *)
+(* use unique_exists. *)
+(* + mkpair. *)
+(* * intro a. *)
+(* apply (colimArrow (bar a) _ (apa a)). *)
+(* * intros a b f. *)
+(* apply pathsinv0. *)
+(* eapply pathscomp0. *)
+(* apply (postcompWithColimArrow _ (bar a)). *)
+(* apply pathsinv0. *)
+(* apply (colimArrowUnique (bar a)); intro v. *)
+(* simpl. *)
+(* cbn. *)
+(* admit. *)
+(* + simpl. *)
+(* intro v. *)
+(* apply (nat_trans_eq hsC); simpl; intro a. *)
+(* apply (pr2 (pr1 (H a (G' a) (apa a)))). *)
+(* + intros α; apply impred; intro v. *)
+(* apply functor_category_has_homsets. *)
+(* + simpl; intros α H1. *)
+(* apply (nat_trans_eq hsC); intro a; simpl. *)
+(* transparent assert (foo : (Σ x : C ⟦ (pr1 G) a, G' a ⟧, *)
+(* Π v : vertex g, coconeIn (cocone_pointwise A C hsC g d G ccG a) v ;; x = coconeIn (apa a) v)). *)
+(* mkpair. *)
+(* apply α. *)
+(* intros v; simpl. *)
+(* apply (nat_trans_eq_pointwise (H1 v) a). *)
+(* apply (maponpaths pr1 (pr2 (H a (G' a) (apa a)) foo)). *)
+(* } *)
+(* use is_iso_isColim. *)
+(* - apply functor_category_has_homsets. *)
+(* - apply D'. *)
+(* - use is_iso_qinv. *)
+(* + cbn. apply nat_trans_id. *)
+(* + split. *)
+(* * assert (temp : colimArrow D' G ccG ;; nat_trans_id (pr1 G) = colimArrow D' G ccG). *)
+(* apply (nat_trans_eq hsC); simpl; intro x. *)
+(* now rewrite id_right. *)
+(* eapply pathscomp0. apply temp. *)
+(* apply pathsinv0. *)
+(* apply colimArrowUnique. *)
+(* intros v. *)
+(* now rewrite id_right. *)
+(* * unfold compose. *)
+(* simpl. *)
+(* assert (temp : nat_trans_comp _ _ _ (nat_trans_id (pr1 G)) (colimArrow D' G ccG) = colimArrow D' G ccG). *)
+(* apply (nat_trans_eq hsC); simpl; intro x. *)
+(* now rewrite id_left. *)
+(* eapply pathscomp0. *)
+(* simpl. *)
+(* apply temp. *)
+(* apply pathsinv0. *)
+(* simpl. *)
+(* now apply (colimArrowUnique D'); intro u; rewrite id_right. *)
+(* Admitted. *)
 
 End temp.
 

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -1535,41 +1535,6 @@ Definition omega_cocont_BinProduct_of_functors (F G : omega_cocont_functor C D) 
 
 End BinProduct_of_functors.
 
-(* WIP *)
-Section temp.
-
-Lemma key2 {A C : precategory} (hsC: has_homsets C) {g : graph}
-  (d : diagram g [A,C,hsC]) (G : [A,C,hsC]) (ccG : cocone d G)
-  (H : Π a, isColimCocone _ _ (cocone_pointwise _ _ _ _ d G ccG a)) :
-  isColimCocone d G ccG.
-Proof.
-transparent assert (CC : (Π a, ColimCocone (diagram_pointwise A C hsC g d a))).
-{ intro a; use mk_ColimCocone.
-  - apply (pr1 G a).
-  - apply cocone_pointwise, ccG.
-  - apply H.
-}
-set (D' := ColimFunctorCocone _ _ _ _ _ CC).
-use is_iso_isColim.
-- apply functor_category_has_homsets.
-- apply D'.
-- use is_iso_qinv.
-  + mkpair.
-    * intros a; apply identity.
-    * abstract (intros a b f; rewrite id_left, id_right; simpl;
-                apply (colimArrowUnique (CC a)); intro u; cbn;
-                now rewrite <- (nat_trans_ax (coconeIn ccG u))).
-  + abstract (split;
-    [ apply (nat_trans_eq hsC); intros x; simpl; rewrite id_right;
-      apply pathsinv0, colimArrowUnique; intros v;
-      now rewrite id_right
-    | apply (nat_trans_eq hsC); intros x; simpl; rewrite id_left;
-      apply pathsinv0, (colimArrowUnique (CC x)); intro u;
-      now rewrite id_right]).
-Defined.
-
-End temp.
-
 (** ** Direct proof that the precomposition functor is cocontinuous *)
 Section pre_composition_functor.
 
@@ -1580,7 +1545,7 @@ Lemma is_cocont_pre_composition_functor :
   is_cocont (pre_composition_functor _ _ _ hsB hsC F).
 Proof.
   intros g d G ccG HccG.
-  apply key2; intro a.
+  apply pointwise_Colim_is_isColimFunctor; intro a.
   apply (isColimFunctor_is_pointwise_Colim _ _ _ _ _
            (λ b, CC _ (diagram_pointwise _ _ _ _ _ b)) _ _ HccG).
 Defined.

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -1545,8 +1545,8 @@ Lemma is_cocont_pre_composition_functor :
 Proof.
   intros g d G ccG HccG.
   apply pointwise_Colim_is_isColimFunctor; intro a.
-  apply (isColimFunctor_is_pointwise_Colim _ _ _ _ _
-           (λ b, CC _ (diagram_pointwise _ _ _ _ _ b)) _ _ HccG).
+  apply (isColimFunctor_is_pointwise_Colim _ _
+           (λ b, CC _ (diagram_pointwise _ _ b)) _ _ HccG).
 Defined.
 
 Lemma is_omega_cocont_pre_composition_functor :

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -1511,8 +1511,8 @@ Proof.
 apply (is_omega_cocont_functor_composite hsD).
 - apply (is_omega_cocont_bindelta_functor PC hsC).
 - apply (is_omega_cocont_functor_composite hsD).
-+ apply (is_omega_cocont_pair_functor _ _ hsC hsC hsD hsD HF HG).
-+ now apply (is_omega_cocont_binproduct_functor _ hsD).
+  + apply (is_omega_cocont_pair_functor _ _ hsC hsC hsD hsD HF HG).
+  + now apply (is_omega_cocont_binproduct_functor _ hsD).
 Defined.
 
 Definition omega_cocont_BinProduct_of_functors_alt (F G : omega_cocont_functor C D) :

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -1562,8 +1562,7 @@ Proof.
     - apply H.
   }
   transparent assert (D' : (ColimCocone d)).
-  { apply (ColimFunctorCocone _ _ _ _ _ bar).
-  }
+  { apply (ColimFunctorCocone _ _ _ _ _ bar). }
   use is_iso_isColim.
   - apply functor_category_has_homsets.
   - apply D'.
@@ -1573,16 +1572,9 @@ Proof.
       * intros a; simpl.
         apply identity.
       * intros a b f; rewrite id_left, id_right.
-        cbn.
-        Check (ColimFunctor_mor A C hsC g d bar a b f).
         admit.
     + split.
-      * assert (temp : colimArrow D' G ccG ;; nat_trans_id (pr1 G) = colimArrow D' G ccG).
-        apply (nat_trans_eq hsC); simpl; intro x.
-        now rewrite id_right.
-        cbn.
-        apply (nat_trans_eq hsC).
-
+      * apply (nat_trans_eq hsC).
         simpl.
         intros x.
         rewrite id_right.

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -1512,8 +1512,8 @@ Proof.
 apply (is_omega_cocont_functor_composite hsD).
 - apply (is_omega_cocont_bindelta_functor PC hsC).
 - apply (is_omega_cocont_functor_composite hsD).
-  + apply (is_omega_cocont_pair_functor _ _ hsC hsC hsD hsD HF HG).
-  + now apply (is_omega_cocont_binproduct_functor _ hsD).
++ apply (is_omega_cocont_pair_functor _ _ hsC hsC hsD hsD HF HG).
++ now apply (is_omega_cocont_binproduct_functor _ hsD).
 Defined.
 
 Definition omega_cocont_BinProduct_of_functors_alt (F G : omega_cocont_functor C D) :
@@ -1535,7 +1535,132 @@ Definition omega_cocont_BinProduct_of_functors (F G : omega_cocont_functor C D) 
 
 End BinProduct_of_functors.
 
-(** ** Precomposition functor is cocontinuous *)
+(* WIP *)
+Section temp.
+
+Context {A C : precategory} (hsC: has_homsets C) {g : graph}
+        (d : diagram g [A,C,hsC]) (G : [A,C,hsC]) (ccG : cocone d G)
+        (CC : Colims C). (* This is overkill *)
+
+Lemma key1 : isColimCocone d G ccG →
+             Π a, isColimCocone (diagram_pointwise _ _ _ _ d a) _ (cocone_pointwise _ _ _ _ d G ccG a).
+Proof.
+intros HccG.
+apply isColimFunctor_is_pointwise_Colim; try assumption.
+intro a.
+apply (CC g (diagram_pointwise A C hsC g d a)).
+Defined.
+
+
+
+Lemma key2 (H : Π a, isColimCocone _ _ (cocone_pointwise _ _ _ _ d G ccG a)) :
+  isColimCocone d G ccG.
+Proof.
+  transparent assert (bar : (Π a, ColimCocone (diagram_pointwise A C hsC g d a))).
+  { intro a.
+    use mk_ColimCocone.
+    - apply (pr1 G a).
+    - apply cocone_pointwise, ccG.
+    - apply H.
+  }
+  transparent assert (D' : (ColimCocone d)).
+  { use mk_ColimCocone.
+    - apply G.
+    - apply ccG.
+    - intros G' ccG'.
+      simpl in *.
+      set (apa := cocone_pointwise _ _ _ _ d G' ccG').
+      (* transparent assert (apa : (Π a, cocone (diagram_pointwise A C hsC g d a) (G' a))). *)
+      (* { intros a; use mk_cocone. *)
+      (*   - intros v; apply (pr1 (coconeIn ccG' v)). *)
+      (*   - intros u v e; apply (nat_trans_eq_pointwise (coconeInCommutes ccG' u v e) a). *)
+      (* } *)
+      use unique_exists.
+      + mkpair.
+        * intro a.
+          apply (colimArrow (bar a) _ (apa a)).
+        * intros a b f.
+          apply pathsinv0.
+          eapply pathscomp0.
+          apply (postcompWithColimArrow _ (bar a)).
+          apply pathsinv0.
+          apply (colimArrowUnique (bar a)); intro v.
+          simpl.
+          cbn.
+          admit.
+      + simpl.
+        intro v.
+        apply (nat_trans_eq hsC); simpl; intro a.
+        apply (pr2 (pr1 (H a (G' a) (apa a)))).
+      + intros α; apply impred; intro v.
+        apply functor_category_has_homsets.
+      + simpl; intros α H1.
+        apply (nat_trans_eq hsC); intro a; simpl.
+        transparent assert (foo : (Σ x : C ⟦ (pr1 G) a, G' a ⟧,
+                                         Π v : vertex g, coconeIn (cocone_pointwise A C hsC g d G ccG a) v ;; x = coconeIn (apa a) v)).
+        mkpair.
+        apply α.
+        intros v; simpl.
+        apply (nat_trans_eq_pointwise (H1 v) a).
+        apply (maponpaths pr1 (pr2 (H a (G' a) (apa a)) foo)).
+  }
+  use is_iso_isColim.
+  - apply functor_category_has_homsets.
+  - apply D'.
+  - use is_iso_qinv.
+    + cbn. apply nat_trans_id.
+    + split.
+      * assert (temp : colimArrow D' G ccG ;; nat_trans_id (pr1 G) = colimArrow D' G ccG).
+        apply (nat_trans_eq hsC); simpl; intro x.
+        now rewrite id_right.
+        eapply pathscomp0. apply temp.
+        apply pathsinv0.
+        apply colimArrowUnique.
+        intros v.
+        now rewrite id_right.
+      * unfold compose.
+        simpl.
+        assert (temp : nat_trans_comp _ _ _ (nat_trans_id (pr1 G)) (colimArrow D' G ccG) = colimArrow D' G ccG).
+        apply (nat_trans_eq hsC); simpl; intro x.
+        now rewrite id_left.
+        eapply pathscomp0.
+        simpl.
+        apply temp.
+        apply pathsinv0.
+        simpl.
+        now apply (colimArrowUnique D'); intro u; rewrite id_right.
+Admitted.
+
+End temp.
+
+(** ** Direct proof that the precomposition functor is cocontinuous *)
+Section pre_composition_functor_direct.
+
+Context {A B C : precategory} (F : functor A B) (hsB : has_homsets B) (hsC : has_homsets C).
+Context (CC : Colims C).
+
+Lemma is_cocont_pre_composition_functor_direct :
+  is_cocont (pre_composition_functor _ _ _ hsB hsC F).
+Proof.
+  intros g d G ccG HccG.
+  apply key2; intro a.
+  apply CC.
+  apply (key1 _ _ _ _ CC HccG).
+Defined.
+
+Lemma is_omega_cocont_pre_composition_functor_direct :
+  is_omega_cocont (pre_composition_functor _ _ _ hsB hsC F).
+Proof.
+now intros c L ccL; apply is_cocont_pre_composition_functor_direct.
+Defined.
+
+Definition omega_cocont_pre_composition_functor_direct :
+  omega_cocont_functor [B, C, hsC] [A, C, hsC] :=
+  tpair _ _ is_omega_cocont_pre_composition_functor_direct.
+
+End pre_composition_functor_direct.
+
+(** ** Precomposition functor is cocontinuous using construction of right Kan extensions *)
 Section pre_composition_functor.
 
 Context {M C A : precategory} (K : functor M C) (hsC : has_homsets C)

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -78,7 +78,6 @@ Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.RightKanExtension.
-Require Import UniMath.CategoryTheory.CommaCategories.
 
 Local Notation "# F" := (functor_on_morphisms F) (at level 3).
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
@@ -1565,180 +1564,24 @@ End pre_composition_functor.
 (** ** Precomposition functor is cocontinuous using construction of right Kan extensions *)
 Section pre_composition_functor_kan.
 
-Context {M C A : precategory} (K : functor M C) (hsC : has_homsets C)
-        (hsA : has_homsets A) (LA : Lims A).
-
-Local Notation "c ↓ K" := (cComma hsC K c) (at level 30).
-
-Section fix_T.
-
-Variable (T : functor M A).
-
-Local Definition Q (c : C) : functor (c ↓ K) M := cComma_pr1 hsC K c.
-
-Local Definition QT (c : C) : diagram (c ↓ K) A :=
-  diagram_from_functor _ _ (functor_composite (Q c) T).
-
-Local Definition R (c : C) : A := lim (LA _ (QT c)).
-
-Local Definition lambda (c : C) : cone (QT c) (R c) := limCone (LA _ (QT c)).
-
-Local Definition Rmor_cone (c c' : C) (g : C⟦c,c'⟧) : cone (QT c') (R c).
-Proof.
-use mk_cone.
-- intro m1f1.
-  transparent assert (m1gf1 : (c ↓ K)).
-  { mkpair.
-    + apply (pr1 m1f1).
-    + apply (g ;; pr2 m1f1). }
-  exact (coneOut (lambda c) m1gf1).
-- intros x y f; simpl in *.
-  transparent assert (e : ((c ↓ K) ⟦ pr1 x,, g ;; pr2 x, pr1 y,, g ;; pr2 y ⟧)).
-  { mkpair.
-    + apply (pr1 f).
-    + now rewrite <- assoc; rewrite (pr2 f). }
-  exact (coneOutCommutes (lambda c) _ _ e).
-Defined.
-
-Local Definition Rmor (c c' : C) (g : C⟦c,c'⟧) : A⟦R c,R c'⟧ :=
-  limArrow (LA (c' ↓ K) (QT c')) (R c) (Rmor_cone c c' g).
-
-Local Definition R_data : functor_data C A := R,,Rmor.
-Local Lemma R_is_functor : is_functor R_data.
-Proof.
-split.
-- intros c; simpl.
-  apply pathsinv0, limArrowUnique.
-  intro c'; simpl; rewrite !id_left.
-  now destruct c'.
-- intros c c' c'' f f'; simpl.
-  apply pathsinv0, limArrowUnique; intros x; simpl.
-  rewrite <- assoc; eapply pathscomp0.
-  apply maponpaths, (limArrowCommutes _ _ (Rmor_cone c' c'' f')).
-  eapply pathscomp0.
-  apply (limArrowCommutes _ _ (Rmor_cone c c' f) (pr1 x,,f' ;; pr2 x)).
-  destruct x.
-  now rewrite <- assoc.
-Qed.
-
-Local Definition R_functor : functor C A := tpair _ R_data R_is_functor.
-
-Local Definition eps_n (n : M) : A⟦R_functor (K n),T n⟧ :=
-  coneOut (lambda (K n)) (n,,identity (K n)).
-
-Local Definition Kid n : K n ↓ K := (n,, identity (K n)).
-
-Local Lemma eps_is_nat_trans : is_nat_trans (functor_composite_data K R_data) T eps_n.
-Proof.
-intros n n' h; simpl.
-eapply pathscomp0.
-apply (limArrowCommutes (LA (K n' ↓ K) (QT (K n'))) (R (K n))
-       (Rmor_cone (K n) (K n') (# K h)) (Kid n')).
-unfold eps_n; simpl.
-transparent assert (v : (K n ↓ K)).
-{ apply (n',, # K h ;; identity (K n')). }
-transparent assert (e : (K n ↓ K ⟦ Kid n, v ⟧)).
-{ mkpair.
-  + apply h.
-  + abstract (now rewrite id_left, id_right).
-}
-now apply pathsinv0; eapply pathscomp0; [apply (coneOutCommutes (lambda (K n)) _ _ e)|].
-Qed.
-
-Local Definition eps : [M,A,hsA]⟦functor_composite K R_functor,T⟧ :=
-  tpair _ eps_n eps_is_nat_trans.
-
-End fix_T.
-
-(** Construction of right Kan extensions based on MacLane, CWM, X.3 (p. 233) *)
-Lemma RightKanExtension_from_limits : GlobalRightKanExtensionExists _ _ K _ hsC hsA.
-Proof.
-unfold GlobalRightKanExtensionExists.
-use adjunction_from_partial.
-- apply R_functor.
-- apply eps.
-- intros T S α; simpl in *.
-
-  transparent assert (cc : (Π c, cone (QT T c) (S c))).
-  { intro c.
-    use mk_cone.
-    + intro mf; apply (# S (pr2 mf) ;; α (pr1 mf)).
-    + abstract (intros fm fm' h; simpl; rewrite <- assoc;
-                eapply pathscomp0; [apply maponpaths, (pathsinv0 (nat_trans_ax α _ _ (pr1 h)))|];
-                simpl; rewrite assoc, <- functor_comp; apply cancel_postcomposition, maponpaths, (pr2 h)).
-  }
-
-  transparent assert (σ : (Π c, A ⟦ S c, R T c ⟧)).
-  { intro c; apply (limArrow _ _ (cc c)). }
-
-  set (lambda' := fun c' mf' => limOut (LA (c' ↓ K) (QT T c')) mf').
-
-  (* this is the conclusion from the big diagram (8) in MacLane's proof *)
-  assert (H : Π c c' (g : C ⟦ c, c' ⟧) (mf' : c' ↓ K),
-                # S g ;; σ c' ;; lambda' _ mf' = σ c ;; Rmor T c c' g ;; lambda' _ mf').
-  { intros c c' g mf'.
-    rewrite <- !assoc.
-    apply pathsinv0; eapply pathscomp0.
-    apply maponpaths, (limArrowCommutes _ _ (Rmor_cone T c c' g) mf').
-    apply pathsinv0; eapply pathscomp0.
-    eapply maponpaths, (limArrowCommutes _ _ (cc c') mf').
-    simpl; rewrite assoc, <- functor_comp.
-    set (mf := tpair _ (pr1 mf') (g ;; pr2 mf') : c ↓ K).
-    apply pathsinv0.
-    exact (limArrowCommutes (LA (c ↓ K) (QT T c)) (S c) (cc c) mf).
-  }
-
-  assert (is_nat_trans_σ : is_nat_trans S (R_data T) σ).
-  { intros c c' g; simpl.
-    transparent assert (ccc : (cone (QT T c') (S c))).
-    { use mk_cone.
-      - intro mf'; apply (σ c ;; Rmor T c c' g ;; limOut (LA (c' ↓ K) (QT T c')) mf').
-      - abstract (intros u v e; simpl; rewrite <- !assoc;
-                  apply maponpaths, maponpaths, (limOutCommutes (LA (c' ↓ K) (QT T c')) u v e)).
-    }
-    rewrite (limArrowUnique (LA (c' ↓ K) (QT T c')) _ ccc (# S g ;; σ c') (H _ _ _)).
-    now apply pathsinv0, limArrowUnique.
-  }
-
-  mkpair.
-  + apply (tpair _ (tpair _ σ is_nat_trans_σ)).
-    apply (nat_trans_eq hsA); intro n; cbn.
-    generalize (limArrowCommutes (LA (K n ↓ K) (QT T (K n))) _ (cc _) (Kid n)); simpl.
-    now rewrite functor_id, id_left.
-  + intro x.
-    apply subtypeEquality; [intros xx; apply (isaset_nat_trans hsA)|].
-    apply subtypeEquality; [intros xx; apply (isaprop_is_nat_trans _ _ hsA)|]; simpl.
-    apply funextsec; intro c.
-    apply limArrowUnique; intro u; simpl.
-    destruct x as [t p]; simpl.
-    assert (temp : α (pr1 u) = nat_trans_comp _ _ T (pre_whisker K t) (eps T) (pr1 u)).
-      now rewrite p.
-    rewrite temp; simpl.
-    destruct u as [n g]; simpl in *.
-    apply pathsinv0; eapply pathscomp0;
-    [rewrite assoc; apply cancel_postcomposition, (nat_trans_ax t _ _ g)|].
-    rewrite <- !assoc; apply maponpaths.
-    generalize (limArrowCommutes (LA (K n ↓ K) _) _ (Rmor_cone T c (K n) g) (Kid n)).
-    now simpl; rewrite id_right.
-Defined.
+Context {A B C : precategory} (F : functor A B) (hsB : has_homsets B) (hsC : has_homsets C).
+Context (LC : Lims C).
 
 Lemma is_cocont_pre_composition_functor_kan :
-  is_cocont (pre_composition_functor _ _ _ hsC hsA K).
+  is_cocont (pre_composition_functor _ _ _ hsB hsC F).
 Proof.
-apply left_adjoint_cocont.
-- apply RightKanExtension_from_limits.
-- apply functor_category_has_homsets.
-- apply functor_category_has_homsets.
+apply left_adjoint_cocont; try apply functor_category_has_homsets.
+apply (RightKanExtension_from_limits _ _ _ LC).
 Qed.
 
 Lemma is_omega_cocont_pre_composition_functor_kan :
-  is_omega_cocont (pre_composition_functor _ _ _ hsC hsA K).
+  is_omega_cocont (pre_composition_functor _ _ _ hsB hsC F).
 Proof.
 now intros c L ccL; apply is_cocont_pre_composition_functor_kan.
 Defined.
 
 Definition omega_cocont_pre_composition_functor_kan :
-  omega_cocont_functor [C, A, hsA] [M, A, hsA] :=
+  omega_cocont_functor [B, C, hsC] [A, C, hsC] :=
   tpair _ _ is_omega_cocont_pre_composition_functor_kan.
 
 End pre_composition_functor_kan.

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -1538,179 +1538,67 @@ End BinProduct_of_functors.
 (* WIP *)
 Section temp.
 
-Context {A C : precategory} (hsC: has_homsets C) {g : graph}
-        (d : diagram g [A,C,hsC]) (G : [A,C,hsC]) (ccG : cocone d G)
-        (CC : Colims C). (* This is overkill *)
-
-Lemma key1 : isColimCocone d G ccG →
-             Π a, isColimCocone (diagram_pointwise _ _ _ _ d a) _ (cocone_pointwise _ _ _ _ d G ccG a).
-Proof.
-intros HccG.
-apply isColimFunctor_is_pointwise_Colim; try assumption.
-intro a.
-apply (CC g (diagram_pointwise A C hsC g d a)).
-Defined.
-
-Lemma key2 (H : Π a, isColimCocone _ _ (cocone_pointwise _ _ _ _ d G ccG a)) :
+Lemma key2 {A C : precategory} (hsC: has_homsets C) {g : graph}
+  (d : diagram g [A,C,hsC]) (G : [A,C,hsC]) (ccG : cocone d G)
+  (H : Π a, isColimCocone _ _ (cocone_pointwise _ _ _ _ d G ccG a)) :
   isColimCocone d G ccG.
 Proof.
-  transparent assert (bar : (Π a, ColimCocone (diagram_pointwise A C hsC g d a))).
-  { intro a.
-    use mk_ColimCocone.
-    - apply (pr1 G a).
-    - apply cocone_pointwise, ccG.
-    - apply H.
-  }
-  transparent assert (D' : (ColimCocone d)).
-  { apply (ColimFunctorCocone _ _ _ _ _ bar). }
-  use is_iso_isColim.
-  - apply functor_category_has_homsets.
-  - apply D'.
-  - use is_iso_qinv.
-    + cbn.
-      mkpair.
-      * intros a; simpl.
-        apply identity.
-      * intros a b f; rewrite id_left, id_right.
-        cbn.
-        unfold ColimFunctor_mor.
-        unfold colimOfArrows.
-        match goal with |[|- _ = colimArrow _ _ ?CCCCCC] =>
-                    set (CCC:= CCCCCC) end.
-        use (colimArrowUnique (bar a) _ CCC).
-        intro u. cbn.
-        assert (XR := nat_trans_ax (coconeIn ccG u)).
-        rewrite <- XR.
-        apply idpath.
-    + split.
-      * apply (nat_trans_eq hsC).
-        simpl.
-        intros x.
-        rewrite id_right.
-        apply pathsinv0.
-        apply colimArrowUnique.
-        intros v.
-        now rewrite id_right.
-      * apply (nat_trans_eq hsC).
-        intro a.
-        simpl.
-        rewrite id_left.
-        apply pathsinv0.
-        apply (colimArrowUnique (bar a)); intro u.
-        simpl.
-        now rewrite id_right.
+transparent assert (CC : (Π a, ColimCocone (diagram_pointwise A C hsC g d a))).
+{ intro a; use mk_ColimCocone.
+  - apply (pr1 G a).
+  - apply cocone_pointwise, ccG.
+  - apply H.
+}
+set (D' := ColimFunctorCocone _ _ _ _ _ CC).
+use is_iso_isColim.
+- apply functor_category_has_homsets.
+- apply D'.
+- use is_iso_qinv.
+  + mkpair.
+    * intros a; apply identity.
+    * abstract (intros a b f; rewrite id_left, id_right; simpl;
+                apply (colimArrowUnique (CC a)); intro u; cbn;
+                now rewrite <- (nat_trans_ax (coconeIn ccG u))).
+  + abstract (split;
+    [ apply (nat_trans_eq hsC); intros x; simpl; rewrite id_right;
+      apply pathsinv0, colimArrowUnique; intros v;
+      now rewrite id_right
+    | apply (nat_trans_eq hsC); intros x; simpl; rewrite id_left;
+      apply pathsinv0, (colimArrowUnique (CC x)); intro u;
+      now rewrite id_right]).
 Defined.
-
-
-(* First try *)
-(* Lemma key2 (H : Π a, isColimCocone _ _ (cocone_pointwise _ _ _ _ d G ccG a)) : *)
-(* isColimCocone d G ccG. *)
-(* Proof. *)
-(* transparent assert (bar : (Π a, ColimCocone (diagram_pointwise A C hsC g d a))). *)
-(* { intro a. *)
-(* use mk_ColimCocone. *)
-(* - apply (pr1 G a). *)
-(* - apply cocone_pointwise, ccG. *)
-(* - apply H. *)
-(* } *)
-(* transparent assert (D' : (ColimCocone d)). *)
-(* { use mk_ColimCocone. *)
-(* - apply G. *)
-(* - apply ccG. *)
-(* - intros G' ccG'. *)
-(* simpl in *. *)
-(* set (apa := cocone_pointwise _ _ _ _ d G' ccG'). *)
-(* (* transparent assert (apa : (Π a, cocone (diagram_pointwise A C hsC g d a) (G' a))). *) *)
-(* (* { intros a; use mk_cocone. *) *)
-(* (* - intros v; apply (pr1 (coconeIn ccG' v)). *) *)
-(* (* - intros u v e; apply (nat_trans_eq_pointwise (coconeInCommutes ccG' u v e) a). *) *)
-(* (* } *) *)
-(* use unique_exists. *)
-(* + mkpair. *)
-(* * intro a. *)
-(* apply (colimArrow (bar a) _ (apa a)). *)
-(* * intros a b f. *)
-(* apply pathsinv0. *)
-(* eapply pathscomp0. *)
-(* apply (postcompWithColimArrow _ (bar a)). *)
-(* apply pathsinv0. *)
-(* apply (colimArrowUnique (bar a)); intro v. *)
-(* simpl. *)
-(* cbn. *)
-(* admit. *)
-(* + simpl. *)
-(* intro v. *)
-(* apply (nat_trans_eq hsC); simpl; intro a. *)
-(* apply (pr2 (pr1 (H a (G' a) (apa a)))). *)
-(* + intros α; apply impred; intro v. *)
-(* apply functor_category_has_homsets. *)
-(* + simpl; intros α H1. *)
-(* apply (nat_trans_eq hsC); intro a; simpl. *)
-(* transparent assert (foo : (Σ x : C ⟦ (pr1 G) a, G' a ⟧, *)
-(* Π v : vertex g, coconeIn (cocone_pointwise A C hsC g d G ccG a) v ;; x = coconeIn (apa a) v)). *)
-(* mkpair. *)
-(* apply α. *)
-(* intros v; simpl. *)
-(* apply (nat_trans_eq_pointwise (H1 v) a). *)
-(* apply (maponpaths pr1 (pr2 (H a (G' a) (apa a)) foo)). *)
-(* } *)
-(* use is_iso_isColim. *)
-(* - apply functor_category_has_homsets. *)
-(* - apply D'. *)
-(* - use is_iso_qinv. *)
-(* + cbn. apply nat_trans_id. *)
-(* + split. *)
-(* * assert (temp : colimArrow D' G ccG ;; nat_trans_id (pr1 G) = colimArrow D' G ccG). *)
-(* apply (nat_trans_eq hsC); simpl; intro x. *)
-(* now rewrite id_right. *)
-(* eapply pathscomp0. apply temp. *)
-(* apply pathsinv0. *)
-(* apply colimArrowUnique. *)
-(* intros v. *)
-(* now rewrite id_right. *)
-(* * unfold compose. *)
-(* simpl. *)
-(* assert (temp : nat_trans_comp _ _ _ (nat_trans_id (pr1 G)) (colimArrow D' G ccG) = colimArrow D' G ccG). *)
-(* apply (nat_trans_eq hsC); simpl; intro x. *)
-(* now rewrite id_left. *)
-(* eapply pathscomp0. *)
-(* simpl. *)
-(* apply temp. *)
-(* apply pathsinv0. *)
-(* simpl. *)
-(* now apply (colimArrowUnique D'); intro u; rewrite id_right. *)
-(* Admitted. *)
 
 End temp.
 
 (** ** Direct proof that the precomposition functor is cocontinuous *)
-Section pre_composition_functor_direct.
+Section pre_composition_functor.
 
 Context {A B C : precategory} (F : functor A B) (hsB : has_homsets B) (hsC : has_homsets C).
-Context (CC : Colims C).
+Context (CC : Colims C). (* This can be weakened *)
 
-Lemma is_cocont_pre_composition_functor_direct :
+Lemma is_cocont_pre_composition_functor :
   is_cocont (pre_composition_functor _ _ _ hsB hsC F).
 Proof.
   intros g d G ccG HccG.
   apply key2; intro a.
-  apply (key1 _ _ _ _ CC HccG).
+  apply (isColimFunctor_is_pointwise_Colim _ _ _ _ _
+           (λ b, CC _ (diagram_pointwise _ _ _ _ _ b)) _ _ HccG).
 Defined.
 
-Lemma is_omega_cocont_pre_composition_functor_direct :
+Lemma is_omega_cocont_pre_composition_functor :
   is_omega_cocont (pre_composition_functor _ _ _ hsB hsC F).
 Proof.
-now intros c L ccL; apply is_cocont_pre_composition_functor_direct.
+now intros c L ccL; apply is_cocont_pre_composition_functor.
 Defined.
 
-Definition omega_cocont_pre_composition_functor_direct :
+Definition omega_cocont_pre_composition_functor :
   omega_cocont_functor [B, C, hsC] [A, C, hsC] :=
-  tpair _ _ is_omega_cocont_pre_composition_functor_direct.
+  tpair _ _ is_omega_cocont_pre_composition_functor.
 
-End pre_composition_functor_direct.
+End pre_composition_functor.
 
 (** ** Precomposition functor is cocontinuous using construction of right Kan extensions *)
-Section pre_composition_functor.
+Section pre_composition_functor_kan.
 
 Context {M C A : precategory} (K : functor M C) (hsC : has_homsets C)
         (hsA : has_homsets A) (LA : Lims A).
@@ -1869,7 +1757,7 @@ use adjunction_from_partial.
     now simpl; rewrite id_right.
 Defined.
 
-Lemma is_cocont_pre_composition_functor :
+Lemma is_cocont_pre_composition_functor_kan :
   is_cocont (pre_composition_functor _ _ _ hsC hsA K).
 Proof.
 apply left_adjoint_cocont.
@@ -1878,17 +1766,17 @@ apply left_adjoint_cocont.
 - apply functor_category_has_homsets.
 Qed.
 
-Lemma is_omega_cocont_pre_composition_functor :
+Lemma is_omega_cocont_pre_composition_functor_kan :
   is_omega_cocont (pre_composition_functor _ _ _ hsC hsA K).
 Proof.
-now intros c L ccL; apply is_cocont_pre_composition_functor.
+now intros c L ccL; apply is_cocont_pre_composition_functor_kan.
 Defined.
 
-Definition omega_cocont_pre_composition_functor :
+Definition omega_cocont_pre_composition_functor_kan :
   omega_cocont_functor [C, A, hsA] [M, A, hsA] :=
-  tpair _ _ is_omega_cocont_pre_composition_functor.
+  tpair _ _ is_omega_cocont_pre_composition_functor_kan.
 
-End pre_composition_functor.
+End pre_composition_functor_kan.
 
 End cocont_functors.
 

--- a/UniMath/CategoryTheory/Inductives/LambdaCalculus.v
+++ b/UniMath/CategoryTheory/Inductives/LambdaCalculus.v
@@ -36,6 +36,7 @@ Require Import UniMath.CategoryTheory.whiskering.
 
 Local Notation "# F" := (functor_on_morphisms F) (at level 3).
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
+Local Notation "'chain'" := (diagram nat_graph).
 
 Section lambdacalculus.
 
@@ -66,6 +67,10 @@ Proof.
 apply (Initial_functor_precat _ _ InitialHSET).
 Defined.
 
+Local Definition CCHSET (c : chain [HSET,HSET,has_homsets_HSET]) (b : HSET) :
+  ColimCocone (diagram_pointwise has_homsets_HSET c b) :=
+    ColimsHSET nat_graph (diagram_pointwise has_homsets_HSET c b).
+
 Local Notation "' x" := (omega_cocont_constant_functor has_homsets_HSET2 x)
                           (at level 10).
 
@@ -83,7 +88,7 @@ Local Notation "F + G" :=
 Local Notation "'_' 'o' 'option'" :=
   (omega_cocont_pre_composition_functor
       (option_functor BinCoproductsHSET TerminalHSET)
-      has_homsets_HSET has_homsets_HSET ColimsHSET) (at level 10).
+      has_homsets_HSET has_homsets_HSET CCHSET) (at level 10).
 
 (** The lambda calculus functor with one component for variables, one for application and one for
     abstraction/lambda *)

--- a/UniMath/CategoryTheory/Inductives/LambdaCalculus.v
+++ b/UniMath/CategoryTheory/Inductives/LambdaCalculus.v
@@ -83,7 +83,7 @@ Local Notation "F + G" :=
 Local Notation "'_' 'o' 'option'" :=
   (omega_cocont_pre_composition_functor
       (option_functor BinCoproductsHSET TerminalHSET)
-      has_homsets_HSET has_homsets_HSET LimsHSET) (at level 10).
+      has_homsets_HSET has_homsets_HSET ColimsHSET) (at level 10).
 
 (** The lambda calculus functor with one component for variables, one for application and one for
     abstraction/lambda *)

--- a/UniMath/CategoryTheory/RightKanExtension.v
+++ b/UniMath/CategoryTheory/RightKanExtension.v
@@ -8,18 +8,21 @@ SubstitutionSystems
 2015
 
 
+Extended by: Anders Mörtberg, 2016
+
 ************************************************************)
 
 
 (** **********************************************************
 
-Contents :
+Contents:
 
 - Definition of global right Kan extension as right adjoint to precomposition
 
+- Construction of right Kan extensions when the target category has limits
+    ([RightKanExtension_from_limits])
 
 ************************************************************)
-
 
 Require Import UniMath.Foundations.Basics.PartD.
 
@@ -29,8 +32,13 @@ Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.equivalences.
 Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.limits.graphs.limits.
+Require Import UniMath.CategoryTheory.CommaCategories.
 
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
+(** * Definition of global right Kan extension as right adjoint to precomposition *)
 Section RightKanExtension.
 
 Variables C D : precategory.
@@ -50,3 +58,166 @@ Definition GlobalRan (H : GlobalRightKanExtensionExists)
   : functor _ _ := right_adjoint H.
 
 End RightKanExtension.
+
+
+(** * Construction of right Kan extensions when the target category has limits *)
+Section RightKanExtensionFromLims.
+
+Context {M C A : precategory} (K : functor M C) (hsC : has_homsets C)
+        (hsA : has_homsets A) (LA : Lims A).
+
+Local Notation "c ↓ K" := (cComma hsC K c) (at level 30).
+
+Section fix_T.
+
+Variable (T : functor M A).
+
+Local Definition Q (c : C) : functor (c ↓ K) M := cComma_pr1 hsC K c.
+
+Local Definition QT (c : C) : diagram (c ↓ K) A :=
+  diagram_from_functor _ _ (functor_composite (Q c) T).
+
+Local Definition R (c : C) : A := lim (LA _ (QT c)).
+
+Local Definition lambda (c : C) : cone (QT c) (R c) := limCone (LA _ (QT c)).
+
+Local Definition Rmor_cone (c c' : C) (g : C⟦c,c'⟧) : cone (QT c') (R c).
+Proof.
+use mk_cone.
+- intro m1f1.
+  transparent assert (m1gf1 : (c ↓ K)).
+  { mkpair.
+    + apply (pr1 m1f1).
+    + apply (g ;; pr2 m1f1). }
+  exact (coneOut (lambda c) m1gf1).
+- intros x y f; simpl in *.
+  transparent assert (e : ((c ↓ K) ⟦ pr1 x,, g ;; pr2 x, pr1 y,, g ;; pr2 y ⟧)).
+  { mkpair.
+    + apply (pr1 f).
+    + now rewrite <- assoc; rewrite (pr2 f). }
+  exact (coneOutCommutes (lambda c) _ _ e).
+Defined.
+
+Local Definition Rmor (c c' : C) (g : C⟦c,c'⟧) : A⟦R c,R c'⟧ :=
+  limArrow (LA (c' ↓ K) (QT c')) (R c) (Rmor_cone c c' g).
+
+Local Definition R_data : functor_data C A := R,,Rmor.
+Local Lemma R_is_functor : is_functor R_data.
+Proof.
+split.
+- intros c; simpl.
+  apply pathsinv0, limArrowUnique.
+  intro c'; simpl; rewrite !id_left.
+  now destruct c'.
+- intros c c' c'' f f'; simpl.
+  apply pathsinv0, limArrowUnique; intros x; simpl.
+  rewrite <- assoc; eapply pathscomp0.
+  apply maponpaths, (limArrowCommutes _ _ (Rmor_cone c' c'' f')).
+  eapply pathscomp0.
+  apply (limArrowCommutes _ _ (Rmor_cone c c' f) (pr1 x,,f' ;; pr2 x)).
+  destruct x.
+  now rewrite <- assoc.
+Qed.
+
+Local Definition R_functor : functor C A := tpair _ R_data R_is_functor.
+
+Local Definition eps_n (n : M) : A⟦R_functor (K n),T n⟧ :=
+  coneOut (lambda (K n)) (n,,identity (K n)).
+
+Local Definition Kid n : K n ↓ K := (n,, identity (K n)).
+
+Local Lemma eps_is_nat_trans : is_nat_trans (functor_composite_data K R_data) T eps_n.
+Proof.
+intros n n' h; simpl.
+eapply pathscomp0.
+apply (limArrowCommutes (LA (K n' ↓ K) (QT (K n'))) (R (K n))
+       (Rmor_cone (K n) (K n') (# K h)) (Kid n')).
+unfold eps_n; simpl.
+transparent assert (v : (K n ↓ K)).
+{ apply (n',, # K h ;; identity (K n')). }
+transparent assert (e : (K n ↓ K ⟦ Kid n, v ⟧)).
+{ mkpair.
+  + apply h.
+  + abstract (now rewrite id_left, id_right).
+}
+now apply pathsinv0; eapply pathscomp0; [apply (coneOutCommutes (lambda (K n)) _ _ e)|].
+Qed.
+
+Local Definition eps : [M,A,hsA]⟦functor_composite K R_functor,T⟧ :=
+  tpair _ eps_n eps_is_nat_trans.
+
+End fix_T.
+
+(** Construction of right Kan extensions based on MacLane, CWM, X.3 (p. 233) *)
+Lemma RightKanExtension_from_limits : GlobalRightKanExtensionExists _ _ K _ hsC hsA.
+Proof.
+unfold GlobalRightKanExtensionExists.
+use adjunction_from_partial.
+- apply R_functor.
+- apply eps.
+- intros T S α; simpl in *.
+
+  transparent assert (cc : (Π c, cone (QT T c) (S c))).
+  { intro c.
+    use mk_cone.
+    + intro mf; apply (# S (pr2 mf) ;; α (pr1 mf)).
+    + abstract (intros fm fm' h; simpl; rewrite <- assoc;
+                eapply pathscomp0; [apply maponpaths, (pathsinv0 (nat_trans_ax α _ _ (pr1 h)))|];
+                simpl; rewrite assoc, <- functor_comp; apply cancel_postcomposition, maponpaths, (pr2 h)).
+  }
+
+  transparent assert (σ : (Π c, A ⟦ S c, R T c ⟧)).
+  { intro c; apply (limArrow _ _ (cc c)). }
+
+  set (lambda' := fun c' mf' => limOut (LA (c' ↓ K) (QT T c')) mf').
+
+  (* this is the conclusion from the big diagram (8) in MacLane's proof *)
+  assert (H : Π c c' (g : C ⟦ c, c' ⟧) (mf' : c' ↓ K),
+                # S g ;; σ c' ;; lambda' _ mf' = σ c ;; Rmor T c c' g ;; lambda' _ mf').
+  { intros c c' g mf'.
+    rewrite <- !assoc.
+    apply pathsinv0; eapply pathscomp0.
+    apply maponpaths, (limArrowCommutes _ _ (Rmor_cone T c c' g) mf').
+    apply pathsinv0; eapply pathscomp0.
+    eapply maponpaths, (limArrowCommutes _ _ (cc c') mf').
+    simpl; rewrite assoc, <- functor_comp.
+    set (mf := tpair _ (pr1 mf') (g ;; pr2 mf') : c ↓ K).
+    apply pathsinv0.
+    exact (limArrowCommutes (LA (c ↓ K) (QT T c)) (S c) (cc c) mf).
+  }
+
+  assert (is_nat_trans_σ : is_nat_trans S (R_data T) σ).
+  { intros c c' g; simpl.
+    transparent assert (ccc : (cone (QT T c') (S c))).
+    { use mk_cone.
+      - intro mf'; apply (σ c ;; Rmor T c c' g ;; limOut (LA (c' ↓ K) (QT T c')) mf').
+      - abstract (intros u v e; simpl; rewrite <- !assoc;
+                  apply maponpaths, maponpaths, (limOutCommutes (LA (c' ↓ K) (QT T c')) u v e)).
+    }
+    rewrite (limArrowUnique (LA (c' ↓ K) (QT T c')) _ ccc (# S g ;; σ c') (H _ _ _)).
+    now apply pathsinv0, limArrowUnique.
+  }
+
+  mkpair.
+  + apply (tpair _ (tpair _ σ is_nat_trans_σ)).
+    apply (nat_trans_eq hsA); intro n; cbn.
+    generalize (limArrowCommutes (LA (K n ↓ K) (QT T (K n))) _ (cc _) (Kid n)); simpl.
+    now rewrite functor_id, id_left.
+  + intro x.
+    apply subtypeEquality; [intros xx; apply (isaset_nat_trans hsA)|].
+    apply subtypeEquality; [intros xx; apply (isaprop_is_nat_trans _ _ hsA)|]; simpl.
+    apply funextsec; intro c.
+    apply limArrowUnique; intro u; simpl.
+    destruct x as [t p]; simpl.
+    assert (temp : α (pr1 u) = nat_trans_comp _ _ T (pre_whisker K t) (eps T) (pr1 u)).
+      now rewrite p.
+    rewrite temp; simpl.
+    destruct u as [n g]; simpl in *.
+    apply pathsinv0; eapply pathscomp0;
+    [rewrite assoc; apply cancel_postcomposition, (nat_trans_ax t _ _ g)|].
+    rewrite <- !assoc; apply maponpaths.
+    generalize (limArrowCommutes (LA (K n ↓ K) _) _ (Rmor_cone T c (K n) g) (Kid n)).
+    now simpl; rewrite id_right.
+Defined.
+
+End RightKanExtensionFromLims.

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -507,11 +507,36 @@ Proof.
   apply  (is_functor_iso_pointwise_if_iso _ _ _ _ _ _ XR).
 Defined.
 
-
 End ColimFunctor.
 
 Lemma ColimsFunctorCategory (A C : precategory) (hsC : has_homsets C)
   (HC : Colims C) : Colims [A,C,hsC].
 Proof.
 now intros g d; apply ColimFunctorCocone.
+Defined.
+
+Lemma pointwise_Colim_is_isColimFunctor
+  {A C : precategory} (hsC: has_homsets C) {g : graph}
+  (d : diagram g [A,C,hsC]) (G : [A,C,hsC]) (ccG : cocone d G)
+  (H : Π a, isColimCocone _ _ (cocone_pointwise _ _ _ _ d G ccG a)) :
+  isColimCocone d G ccG.
+Proof.
+set (CC a := mk_ColimCocone _ _ _ (H a)).
+set (D' := ColimFunctorCocone _ _ _ _ _ CC).
+use is_iso_isColim.
+- apply functor_category_has_homsets.
+- apply D'.
+- use is_iso_qinv.
+  + mkpair.
+    * intros a; apply identity.
+    * abstract (intros a b f; rewrite id_left, id_right; simpl;
+                apply (colimArrowUnique (CC a)); intro u; cbn;
+                now rewrite <- (nat_trans_ax (coconeIn ccG u))).
+  + abstract (split;
+    [ apply (nat_trans_eq hsC); intros x; simpl; rewrite id_right;
+      apply pathsinv0, colimArrowUnique; intros v;
+      now rewrite id_right
+    | apply (nat_trans_eq hsC); intros x; simpl; rewrite id_left;
+      apply pathsinv0, (colimArrowUnique (CC x)); intro u;
+      now rewrite id_right]).
 Defined.

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -398,11 +398,8 @@ Arguments Colims : clear implicits.
 (** Defines colimits in functor categories when the target has colimits *)
 Section ColimFunctor.
 
-Variable A C : precategory.
+Context {A C : precategory} (hsC : has_homsets C) {g : graph} (D : diagram g [A, C, hsC]).
 (* Variable HC : Colims C. *) (* Too strong! *)
-Variable hsC : has_homsets C.
-Variable g : graph.
-Variable D : diagram g [A, C, hsC].
 
 Definition diagram_pointwise (a : A) : diagram g C.
 Proof.
@@ -518,11 +515,11 @@ Defined.
 Lemma pointwise_Colim_is_isColimFunctor
   {A C : precategory} (hsC: has_homsets C) {g : graph}
   (d : diagram g [A,C,hsC]) (G : [A,C,hsC]) (ccG : cocone d G)
-  (H : Π a, isColimCocone _ _ (cocone_pointwise _ _ _ _ d G ccG a)) :
+  (H : Π a, isColimCocone _ _ (cocone_pointwise hsC d G ccG a)) :
   isColimCocone d G ccG.
 Proof.
 set (CC a := mk_ColimCocone _ _ _ (H a)).
-set (D' := ColimFunctorCocone _ _ _ _ _ CC).
+set (D' := ColimFunctorCocone _ _ CC).
 use is_iso_isColim.
 - apply functor_category_has_homsets.
 - apply D'.

--- a/UniMath/CategoryTheory/limits/graphs/limits.v
+++ b/UniMath/CategoryTheory/limits/graphs/limits.v
@@ -354,21 +354,11 @@ Arguments Lims : clear implicits.
 
 
 (** * Limits in functor categories *)
-
 Section LimFunctor.
 
-Variable A C : precategory.
-Variable hsC : has_homsets C.
-Variable g : graph.
-Variable D : diagram g [A, C, hsC].
+Context {A C : precategory} (hsC : has_homsets C) {g : graph} (D : diagram g [A, C, hsC]).
 
-(* Definition diagram_pointwise (a : A) : diagram g C. *)
-(* Proof. *)
-(* exists (fun v => pr1 (dob D v) a); intros u v e. *)
-(* now apply (pr1 (dmor D e) a). *)
-(* Defined. *)
-
-Variable (HCg : Π (a : A), LimCone (diagram_pointwise A C hsC g D a)).
+Variable (HCg : Π (a : A), LimCone (diagram_pointwise hsC D a)).
 
 Definition LimFunctor_ob (a : A) : C := lim (HCg a).
 
@@ -409,7 +399,7 @@ mkpair.
 Defined.
 
 Definition cone_pointwise (F : [A,C,hsC]) (cc : cone D F) a :
-  cone (diagram_pointwise _ _ _ _ D a) (pr1 F a).
+  cone (diagram_pointwise _ D a) (pr1 F a).
 Proof.
 simple refine (mk_cone _ _).
 - now intro v; apply (pr1 (coneOut cc v) a).
@@ -454,9 +444,7 @@ Defined.
 
 Definition isLimFunctor_is_pointwise_Lim
   (X : [A,C,hsC]) (R : cone D X) (H : isLimCone D X R)
-  : Π a, isLimCone (diagram_pointwise _ _ hsC _ D a)
-                   _
-                   (cone_pointwise X R a).
+  : Π a, isLimCone (diagram_pointwise hsC D a) _ (cone_pointwise X R a).
 Proof.
   intro a.
   apply (is_iso_isLim hsC _ (HCg a)).
@@ -839,12 +827,10 @@ Lemma LimFunctorCone (A C : precategory) (hsC : has_homsets C)
   (D : diagram g [A, C, hsC]^op)
   (HC : Π a : A^op,
             LimCone
-              (diagram_pointwise A^op C^op (has_homsets_opp hsC) g
-                 (get_diagram A C hsC g D) a))
-
+              (diagram_pointwise (has_homsets_opp hsC) (get_diagram A C hsC g D) a))
   : LimCone D.
 Proof.
-set (HColim := ColimFunctorCocone A^op C^op  (has_homsets_opp hsC) g (get_diagram _ _ _ _ D) HC).
+set (HColim := ColimFunctorCocone (has_homsets_opp hsC) (get_diagram _ _ _ _ D) HC).
 destruct HColim as [pr1x pr2x].
 destruct pr1x as [pr1pr1x pr2pr1x].
 destruct pr2pr1x as [pr1pr2pr1x pr2pr2pr1x].

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -46,6 +46,7 @@ Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.Notation.
 
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
+Local Notation "'chain'" := (diagram nat_graph).
 
 (** * Definition of binding signatures *)
 Section BindingSig.
@@ -96,8 +97,9 @@ Defined.
 
 (* TODO: Having limits and colimits should be sufficient *)
 Context (BCC : BinCoproducts C) (BPC : BinProducts C)
-        (IC : Initial C) (TC : Terminal C)
-        (LC : Lims C) (CLC : Colims C).
+        (IC : Initial C) (TC : Terminal C) (LC : Lims C)
+        (Hchain : Π (c : chain [C,C,hsC]) (b : C), ColimCocone (diagram_pointwise hsC c b)).
+        (* (CLC : Colims C). (* This is too strong, but still needed for HSS *) *)
 
 Let optionC := (option_functor BCC TC).
 
@@ -113,7 +115,7 @@ Lemma is_omega_cocont_precomp_option_iter (n : nat) : is_omega_cocont (precomp_o
 Proof.
 destruct n; simpl.
 - apply (is_omega_cocont_functor_identity has_homsets_C2).
-- apply (is_omega_cocont_pre_composition_functor _ _ _ CLC).
+- apply (is_omega_cocont_pre_composition_functor _ _ _ Hchain).
 Defined.
 
 Definition precomp_option_iter_Signature (n : nat) : Signature C hsC.
@@ -170,7 +172,8 @@ apply (is_omega_cocont_Sum_of_Signatures _ (BindingSigIsdeceq sig)).
 Defined.
 
 (** ** Construction of initial algebra for a signature with strength *)
-Definition SignatureInitialAlgebra (s : Signature C hsC) (Hs : is_omega_cocont s) :
+Definition SignatureInitialAlgebra (s : Signature C hsC) (Hs : is_omega_cocont s)
+  (CLC : Colims C) (* This is too strong? *) :
   Initial (FunctorAlg (Id_H C hsC BCC s) has_homsets_C2).
 Proof.
 use colimAlgInitial.
@@ -205,14 +208,15 @@ Qed.
 
 (** ** Function from binding signatures to monads *)
 Definition BindingSigToMonad (sig : BindingSig)
-  (CC : Coproducts (BindingSigIndex sig) C) (PC : Products (BindingSigIndex sig) C)
-  (H : Π (x : C2), is_omega_cocont (constprod_functor1 (BinProducts_functor_precat _ _ BPC hsC) x)) :
-  Monad C.
+  (CC : Coproducts (BindingSigIndex sig) C)
+  (PC : Products (BindingSigIndex sig) C)
+  (H : Π (x : C2), is_omega_cocont (constprod_functor1 (BinProducts_functor_precat _ _ BPC hsC) x))
+  (CLC : Colims C) : Monad C.
 Proof.
 use (Monad_from_hss _ hsC BCC).
 - apply (BindingSigToSignature sig CC).
 - apply SignatureToHSS.
-  apply SignatureInitialAlgebra.
+  apply SignatureInitialAlgebra; [|apply CLC].
   apply (is_omega_cocont_BindingSigToSignature _ _ PC H).
 Defined.
 
@@ -242,7 +246,7 @@ Lemma is_omega_cocont_BindingSigToSignatureHSET (sig : BindingSig) :
 Proof.
 apply (is_omega_cocont_Sum_of_Signatures _ (BindingSigIsdeceq sig)).
 - intro i; apply is_omega_cocont_Arity_to_Signature.
-  + apply ColimsHSET.
+  + intros c b; apply (ColimsHSET nat_graph (diagram_pointwise has_homsets_HSET c b)).
   + intros F.
     apply (is_omega_cocont_constprod_functor1 _ has_homsets_HSET2).
     apply has_exponentials_functor_HSET, has_homsets_HSET.
@@ -256,8 +260,8 @@ Proof.
 apply SignatureInitialAlgebra.
 - apply BinProductsHSET.
 - apply InitialHSET.
-- apply ColimsHSET.
 - apply Hs.
+- apply ColimsHSET.
 Defined.
 
 (** ** Binding signature to a monad for HSET *)
@@ -270,13 +274,14 @@ use (BindingSigToMonad _ _ _ _ _ _ _ sig).
 - apply InitialHSET.
 - apply TerminalHSET.
 - apply LimsHSET.
-- apply ColimsHSET.
+- intros c b; apply (ColimsHSET nat_graph (diagram_pointwise has_homsets_HSET c b)).
 - apply Coproducts_HSET.
   exact (isasetifdeceq _ (BindingSigIsdeceq sig)).
 - apply Products_HSET.
 - intros F.
   apply (is_omega_cocont_constprod_functor1 _ has_homsets_HSET2).
   apply has_exponentials_functor_HSET, has_homsets_HSET.
+- apply ColimsHSET.
 Defined.
 
 End BindingSigToMonadHSET.

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -112,7 +112,7 @@ Lemma is_omega_cocont_precomp_option_iter (n : nat) : is_omega_cocont (precomp_o
 Proof.
 destruct n; simpl.
 - apply (is_omega_cocont_functor_identity has_homsets_C2).
-- apply (is_omega_cocont_pre_composition_functor _ _ _ LC).
+- apply (is_omega_cocont_pre_composition_functor _ _ _ CLC).
 Defined.
 
 Definition precomp_option_iter_Signature (n : nat) : Signature C hsC.
@@ -241,7 +241,7 @@ Lemma is_omega_cocont_BindingSigToSignatureHSET (sig : BindingSig) :
 Proof.
 apply (is_omega_cocont_Sum_of_Signatures _ (BindingSigIsdeceq sig)).
 - intro i; apply is_omega_cocont_Arity_to_Signature.
-  + apply LimsHSET.
+  + apply ColimsHSET.
   + intros F.
     apply (is_omega_cocont_constprod_functor1 _ has_homsets_HSET2).
     apply has_exponentials_functor_HSET, has_homsets_HSET.

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -34,6 +34,7 @@ Require Import UniMath.CategoryTheory.CocontFunctors.
 Require Import UniMath.CategoryTheory.Monads.
 Require Import UniMath.CategoryTheory.category_hset.
 Require Import UniMath.CategoryTheory.category_hset_structures.
+Require Import UniMath.CategoryTheory.RightKanExtension.
 
 Require Import UniMath.SubstitutionSystems.Signatures.
 Require Import UniMath.SubstitutionSystems.SignatureExamples.

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -63,13 +63,15 @@ Proof.
   exact @CocontFunctors.colimAlgIsInitial.
 Defined.
 
+Local Notation "'chain'" := (diagram nat_graph).
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
 Lemma is_omega_cocont_pre_composition_functor
-  : Π (M C A : precategory) (K : functor M C) (hsC : has_homsets C)
-     (hsA : has_homsets A),
-   Colims A → is_omega_cocont (pre_composition_functor M C A hsC hsA K).
+     (A B C : precategory) (F : functor A B) (hsB : has_homsets B) (hsC : has_homsets C)
+     (H : Π (c : chain [B,C,hsC]) (b : B), ColimCocone (diagram_pointwise hsC c b)) :
+     is_omega_cocont (pre_composition_functor A B C hsB hsC F).
 Proof.
-  exact @CocontFunctors.is_omega_cocont_pre_composition_functor.
+  exact (@CocontFunctors.is_omega_cocont_pre_composition_functor _ _ _ _ _ _ H).
 Defined.
 
 Definition RightKanExtension_from_limits

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -26,6 +26,7 @@ Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
 Require Import UniMath.CategoryTheory.CocontFunctors.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.RightKanExtension.
 Require Import UniMath.SubstitutionSystems.BindingSigToMonad.
 
 Definition Arity_to_Signature :
@@ -76,7 +77,7 @@ Definition RightKanExtension_from_limits
     (hsA : has_homsets A),
   Lims A → RightKanExtension.GlobalRightKanExtensionExists M C K A hsC hsA.
 Proof.
-  exact @CocontFunctors.RightKanExtension_from_limits.
+  exact @RightKanExtension.RightKanExtension_from_limits.
 Defined.
 
 Definition ColimCoconeHSET

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -66,7 +66,7 @@ Defined.
 Lemma is_omega_cocont_pre_composition_functor
   : Π (M C A : precategory) (K : functor M C) (hsC : has_homsets C)
      (hsA : has_homsets A),
-   Lims A → is_omega_cocont (pre_composition_functor M C A hsC hsA K).
+   Colims A → is_omega_cocont (pre_composition_functor M C A hsC hsA K).
 Proof.
   exact @CocontFunctors.is_omega_cocont_pre_composition_functor.
 Defined.

--- a/UniMath/SubstitutionSystems/LamHSET.v
+++ b/UniMath/SubstitutionSystems/LamHSET.v
@@ -34,6 +34,7 @@ Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.category_hset.
 Require Import UniMath.CategoryTheory.category_hset_structures.
 Require Import UniMath.CategoryTheory.CocontFunctors.
+Require Import UniMath.CategoryTheory.RightKanExtension.
 
 Section LamHSET.
 

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -168,7 +168,7 @@ Definition Abs_H : functor [C, C, hs] [C, C, hs] :=
 Lemma is_omega_cocont_Abs_H (LC : Lims C) : is_omega_cocont Abs_H.
 Proof.
 unfold Abs_H.
-apply (is_omega_cocont_pre_composition_functor _ _ _ LC).
+apply (is_omega_cocont_pre_composition_functor_kan _ _ _ LC).
 Defined.
 
 


### PR DESCRIPTION
This PR implements:

- A direct proof that the precomposition functor is cocontinuous (not relying on construction of right Kan extensions from limits)
- Move the construction of right Kan extensions from limits to the file on Kan extensions
- Make some arguments implicit in the construction of (co)limits in functor categories