### PR TITLE
Colimits of a specific shape

### DIFF
--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -1550,17 +1550,21 @@ apply pointwise_Colim_is_isColimFunctor; intro a.
 apply (isColimFunctor_is_pointwise_Colim _ _ (H g d) _ _ HccG).
 Defined.
 
+(* Which assumption is the best? *)
 Lemma is_omega_cocont_pre_composition_functor
-  (H : Π (c : chain [B,C,hsC]) (b : B), ColimCocone (diagram_pointwise hsC c b)) :
+  (* (H : Π (c : chain [B,C,hsC]) (b : B), ColimCocone (diagram_pointwise hsC c b)) : *)
+  (H : Colims_of_shape nat_graph C) :
   is_omega_cocont (pre_composition_functor _ _ _ hsB hsC F).
 Proof.
 intros c L ccL HccL.
 apply pointwise_Colim_is_isColimFunctor; intro a.
-apply (isColimFunctor_is_pointwise_Colim _ _ (H c) _ _ HccL).
+use (isColimFunctor_is_pointwise_Colim _ _ _ _ _ HccL).
+intros b; apply H.
 Defined.
 
 Definition omega_cocont_pre_composition_functor
-  (H : Π (c : chain [B,C,hsC]) (b : B), ColimCocone (diagram_pointwise hsC c b)) :
+  (* (H : Π (c : chain [B,C,hsC]) (b : B), ColimCocone (diagram_pointwise hsC c b))  *)
+  (H : Colims_of_shape nat_graph C) :
   omega_cocont_functor [B, C, hsC] [A, C, hsC] :=
   tpair _ _ (is_omega_cocont_pre_composition_functor H).
 

--- a/UniMath/CategoryTheory/Inductives/LambdaCalculus.v
+++ b/UniMath/CategoryTheory/Inductives/LambdaCalculus.v
@@ -103,7 +103,7 @@ Lemma lambdaFunctor_Initial :
   Initial (precategory_FunctorAlg lambdaFunctor has_homsets_HSET2).
 Proof.
 apply (colimAlgInitial _ InitialHSET2 is_omega_cocont_lambdaFunctor).
-apply ColimsFunctorCategory; apply ColimsHSET.
+apply ColimsFunctorCategory_of_shape; apply Colims_of_shape.
 Defined.
 
 (** The lambda calculus *)

--- a/UniMath/CategoryTheory/Inductives/LambdaCalculus.v
+++ b/UniMath/CategoryTheory/Inductives/LambdaCalculus.v
@@ -67,9 +67,8 @@ Proof.
 apply (Initial_functor_precat _ _ InitialHSET).
 Defined.
 
-Local Definition CCHSET (c : chain [HSET,HSET,has_homsets_HSET]) (b : HSET) :
-  ColimCocone (diagram_pointwise has_homsets_HSET c b) :=
-    ColimsHSET nat_graph (diagram_pointwise has_homsets_HSET c b).
+Local Definition CCHSET : Colims_of_shape nat_graph HSET :=
+  ColimsHSET_of_shape nat_graph.
 
 Local Notation "' x" := (omega_cocont_constant_functor has_homsets_HSET2 x)
                           (at level 10).
@@ -103,7 +102,7 @@ Lemma lambdaFunctor_Initial :
   Initial (precategory_FunctorAlg lambdaFunctor has_homsets_HSET2).
 Proof.
 apply (colimAlgInitial _ InitialHSET2 is_omega_cocont_lambdaFunctor).
-apply ColimsFunctorCategory_of_shape; apply Colims_of_shape.
+apply ColimsFunctorCategory_of_shape; apply ColimsHSET_of_shape.
 Defined.
 
 (** The lambda calculus *)

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -228,6 +228,12 @@ Proof.
 now intros g d; apply ColimCoconeHSET.
 Defined.
 
+Lemma Colims_of_shape_HSET (g : graph) :
+  Colims_of_shape g HSET.
+Proof.
+now intros d; apply ColimCoconeHSET.
+Defined.
+
 (* Direct construction of binary coproducts in HSET *)
 Lemma BinCoproductsHSET : BinCoproducts HSET.
 Proof.

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -451,7 +451,7 @@ Require UniMath.CategoryTheory.limits.graphs.binproducts.
 
 Lemma BinProductsHSET_from_Lims : graphs.binproducts.BinProducts HSET.
 Proof.
-exact (binproducts.BinProducts_from_Lims _ LimsHSET).
+now apply binproducts.BinProducts_from_Lims, LimsHSET_of_shape.
 Defined.
 
 End BinProductsHSET_from_Lims.
@@ -470,7 +470,7 @@ Require UniMath.CategoryTheory.limits.graphs.terminal.
 
 Lemma TerminalHSET_from_Lims : graphs.terminal.Terminal HSET.
 Proof.
-now apply terminal.Terminal_from_Lims, LimsHSET.
+now apply terminal.Terminal_from_Lims, LimsHSET_of_shape.
 Defined.
 
 End TerminalHSET_from_Lims.

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -228,7 +228,7 @@ Proof.
 now intros g d; apply ColimCoconeHSET.
 Defined.
 
-Lemma Colims_of_shape_HSET (g : graph) :
+Lemma ColimsHSET_of_shape (g : graph) :
   Colims_of_shape g HSET.
 Proof.
 now intros d; apply ColimCoconeHSET.
@@ -279,7 +279,7 @@ Require UniMath.CategoryTheory.limits.graphs.bincoproducts.
 
 Lemma BinCoproductsHSET_from_Colims : graphs.bincoproducts.BinCoproducts HSET.
 Proof.
-exact (bincoproducts.BinCoproducts_from_Colims _ ColimsHSET).
+now apply bincoproducts.BinCoproducts_from_Colims, ColimsHSET_of_shape.
 Defined.
 
 End CoproductsHSET_from_Colims.
@@ -299,7 +299,7 @@ Require UniMath.CategoryTheory.limits.graphs.initial.
 
 Lemma InitialHSET_from_Colims : graphs.initial.Initial HSET.
 Proof.
-now apply initial.Initial_from_Colims, ColimsHSET.
+apply initial.Initial_from_Colims, ColimsHSET_of_shape.
 Defined.
 
 End InitialHSET_from_Colims.
@@ -348,6 +348,12 @@ Proof.
 now intros g d; apply LimConeHSET.
 Defined.
 
+Lemma LimsHSET_of_shape (g : graph) : Lims_of_shape g HSET.
+Proof.
+now intros d; apply LimConeHSET.
+Defined.
+
+
 (** Alternative definition of limits using cats/limits *)
 Section cats_limits.
 
@@ -393,6 +399,11 @@ End cats_limits.
 Lemma cats_LimsHSET : cats.limits.Lims HSET.
 Proof.
 now intros g d; apply cats_LimConeHSET.
+Defined.
+
+Lemma cats_LimsHSET_of_shape (g : precategory) : cats.limits.Lims_of_shape g HSET.
+Proof.
+now intros d; apply cats_LimConeHSET.
 Defined.
 
 (** end of alternative def *)

--- a/UniMath/CategoryTheory/limits/cats/limits.v
+++ b/UniMath/CategoryTheory/limits/cats/limits.v
@@ -70,10 +70,6 @@ Definition mk_LimCone {J C : precategory} (F : functor J C)
   (c : C) (cc : cone F c) (isCC : isLimCone F c cc) : LimCone F :=
   tpair _ (tpair _ c cc) isCC.
 
-Definition Lims (C : precategory) : UU := Π {J : precategory} (F : functor J C), LimCone F.
-Definition hasLims : UU  :=
-  Π {J C : precategory} (F : functor J C), ishinh (LimCone F).
-
 (* lim is the tip of the lim cone *)
 Definition lim {J C : precategory} {F : functor J C} (CC : LimCone F) : C
   := pr1 (pr1 CC).
@@ -276,9 +272,20 @@ use isopair.
               rewrite <- assoc, limArrowCommutes; eapply pathscomp0; try apply limArrowCommutes).
 Defined.
 
+End lim_def.
+
+Section Lims.
+
+Definition Lims (C : precategory) : UU := Π {J : precategory} (F : functor J C), LimCone F.
+Definition hasLims : UU  :=
+  Π {J C : precategory} (F : functor J C), ishinh (LimCone F).
+Definition Lims_of_shape (J C : precategory) : UU := Π (F : functor J C), LimCone F.
+
 Section Universal_Unique.
 
-Context {C : precategory} (H : is_category C).
+Context (C : category).
+
+Let H : is_category C := pr2 C.
 
 Lemma isaprop_Lims: isaprop (Lims C).
 Proof.
@@ -298,10 +305,7 @@ apply subtypeEquality.
 Qed.
 
 End Universal_Unique.
-
-End lim_def.
-
-Arguments Lims : clear implicits.
+End Lims.
 
 Section LimFunctor.
 
@@ -411,4 +415,10 @@ Lemma LimsFunctorCategory (A C : precategory) (hsC : has_homsets C)
   (HC : Lims C) : Lims [A,C,hsC].
 Proof.
 now intros g d; apply LimFunctorCone.
+Defined.
+
+Lemma LimsFunctorCategory_of_shape (J A C : precategory) (hsC : has_homsets C)
+  (HC : Lims_of_shape J C) : Lims_of_shape J [A,C,hsC].
+Proof.
+now intros d; apply LimFunctorCone.
 Defined.

--- a/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
@@ -286,7 +286,7 @@ End coproduct_unique.
 End bincoproduct_def.
 
 Lemma BinCoproducts_from_Colims (C : precategory) :
-  Colims C -> BinCoproducts C.
+  Colims_of_shape two_graph C -> BinCoproducts C.
 Proof.
 now intros H a b; apply H.
 Defined.

--- a/UniMath/CategoryTheory/limits/graphs/binproducts.v
+++ b/UniMath/CategoryTheory/limits/graphs/binproducts.v
@@ -167,7 +167,7 @@ Qed.
 End binproduct_def.
 
 Lemma BinProducts_from_Lims (C : precategory) :
-  Lims C -> BinProducts C.
+  Lims_of_shape two_graph C -> BinProducts C.
 Proof.
 now intros H a b; apply H.
 Defined.

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -72,8 +72,8 @@ End diagram_def.
 
 Coercion graph_from_precategory : precategory >-> graph.
 
-(* Definition diagram_after_functor (C : precategory) (F : functor C C) :  *)
 
+(** * Definition of colimits *)
 Section colim_def.
 
 Context {C : precategory} (hsC : has_homsets C).
@@ -113,10 +113,6 @@ Definition ColimCocone {g : graph} (d : diagram g C) : UU :=
 Definition mk_ColimCocone {g : graph} (d : diagram g C)
   (c : C) (cc : cocone d c) (isCC : isColimCocone d c cc) : ColimCocone d :=
     tpair _ (tpair _ c cc) isCC.
-
-Definition Colims : UU := Π {g : graph} (d : diagram g C), ColimCocone d.
-Definition hasColims : UU  :=
-  Π {g : graph} (d : diagram g C), ishinh (ColimCocone d).
 
 (** colim is the tip of the colim cocone *)
 Definition colim {g : graph} {d : diagram g C} (CC : ColimCocone d) : C :=
@@ -368,11 +364,26 @@ use isopair.
               rewrite assoc, colimArrowCommutes; eapply pathscomp0; try apply colimArrowCommutes).
 Defined.
 
+End colim_def.
+
+Section Colims.
+
+Definition Colims (C : precategory) : UU := Π {g : graph} (d : diagram g C), ColimCocone d.
+Definition hasColims (C : precategory) : UU  :=
+  Π {g : graph} (d : diagram g C), ishinh (ColimCocone d).
+
+(** Colimits of a specific shape *)
+Definition Colims_of_shape (g : graph) (C : precategory) : UU :=
+  Π (d : diagram g C), ColimCocone d.
+
+(** If C is a category then Colims is a prop *)
 Section Universal_Unique.
 
-Hypothesis H : is_category C.
+Variables (C : category).
 
-Lemma isaprop_Colims: isaprop Colims.
+Let H : is_category C := pr2 C.
+
+Lemma isaprop_Colims: isaprop (Colims C).
 Proof.
 apply impred; intro g; apply impred; intro cc.
 apply invproofirrelevance; intros Hccx Hccy.
@@ -383,19 +394,16 @@ apply subtypeEquality.
   set (C' (c : C) f := Π u v (e : edge u v), @compose _ _ _ c (dmor cc e) (f v) = f u).
   rewrite (@transportf_total2 _ B C').
   apply subtypeEquality.
-  + intro; repeat (apply impred; intro); apply hsC.
+  + intro; repeat (apply impred; intro); apply category_has_homsets.
   + simpl; eapply pathscomp0; [apply transportf_isotoid_dep''|].
     apply funextsec; intro v.
     now rewrite idtoiso_isotoid; apply colimArrowCommutes.
 Qed.
 
 End Universal_Unique.
+End Colims.
 
-End colim_def.
-
-Arguments Colims : clear implicits.
-
-(** Defines colimits in functor categories when the target has colimits *)
+(** * Defines colimits in functor categories when the target has colimits *)
 Section ColimFunctor.
 
 Context {A C : precategory} (hsC : has_homsets C) {g : graph} (D : diagram g [A, C, hsC]).
@@ -510,6 +518,12 @@ Lemma ColimsFunctorCategory (A C : precategory) (hsC : has_homsets C)
   (HC : Colims C) : Colims [A,C,hsC].
 Proof.
 now intros g d; apply ColimFunctorCocone.
+Defined.
+
+Lemma ColimsFunctorCategory_of_shape (g : graph) (A C : precategory) (hsC : has_homsets C)
+  (HC : Colims_of_shape g C) : Colims_of_shape g [A,C,hsC].
+Proof.
+now intros d; apply ColimFunctorCocone.
 Defined.
 
 Lemma pointwise_Colim_is_isColimFunctor

--- a/UniMath/CategoryTheory/limits/graphs/initial.v
+++ b/UniMath/CategoryTheory/limits/graphs/initial.v
@@ -173,7 +173,7 @@ Arguments Initial : clear implicits.
 Arguments isInitial : clear implicits.
 
 Lemma Initial_from_Colims (C : precategory) :
-  Colims C -> Initial C.
+  Colims_of_shape empty_graph C -> Initial C.
 Proof.
 now intros H; apply H.
 Defined.

--- a/UniMath/CategoryTheory/limits/graphs/limits.v
+++ b/UniMath/CategoryTheory/limits/graphs/limits.v
@@ -58,10 +58,6 @@ Definition mk_LimCone {g : graph} (d : diagram g C)
   (c : C) (cc : cone d c) (isCC : isLimCone d c cc) : LimCone d
   := tpair _ (tpair _ c cc) isCC.
 
-Definition Lims : UU := Π {g : graph} (d : diagram g C), LimCone d.
-Definition hasLims : UU  :=
-  Π {g : graph} (d : diagram g C), ishinh (LimCone d).
-
 (** [lim] is the tip of the [LimCone] *)
 Definition lim {g : graph} {d : diagram g C} (CC : LimCone d) : C
   := pr1 (pr1 CC).
@@ -325,11 +321,25 @@ use isopair.
               rewrite <- assoc, limArrowCommutes; eapply pathscomp0; try apply limArrowCommutes).
 Defined.
 
+End lim_def.
+
+Section Lims.
+
+Definition Lims (C : precategory) : UU := Π {g : graph} (d : diagram g C), LimCone d.
+Definition hasLims (C : precategory) : UU  :=
+  Π {g : graph} (d : diagram g C), ishinh (LimCone d).
+
+(** Limits of a specific shape *)
+Definition Lims_of_shape (g : graph) (C : precategory) : UU :=
+  Π (d : diagram g C), LimCone d.
+
 Section Universal_Unique.
 
-Hypothesis H : is_category C.
+Variable (C : category).
 
-Lemma isaprop_Lims : isaprop Lims.
+Let H : is_category C := pr2 C.
+
+Lemma isaprop_Lims : isaprop (Lims C).
 Proof.
 apply impred; intro g; apply impred; intro cc.
 apply invproofirrelevance; intros Hccx Hccy.
@@ -340,18 +350,14 @@ apply subtypeEquality.
   set (C' (c : C) f := Π u v (e : edge u v), @compose _ c _ _ (f u) (dmor cc e) = f v).
   rewrite (@transportf_total2 _ B C').
   apply subtypeEquality.
-  + intro; repeat (apply impred; intro); apply hsC.
+  + intro; repeat (apply impred; intro); apply category_has_homsets.
   + abstract (now simpl; eapply pathscomp0; [apply transportf_isotoid_dep'|];
               apply funextsec; intro v; rewrite inv_isotoid, idtoiso_isotoid;
               cbn; unfold precomp_with; rewrite id_right; apply limArrowCommutes).
 Qed.
 
 End Universal_Unique.
-
-End lim_def.
-
-Arguments Lims : clear implicits.
-
+End Lims.
 
 (** * Limits in functor categories *)
 Section LimFunctor.
@@ -459,6 +465,12 @@ Lemma LimsFunctorCategory (A C : precategory) (hsC : has_homsets C)
   (HC : Lims C) : Lims [A,C,hsC].
 Proof.
 now intros g d; apply LimFunctorCone.
+Defined.
+
+Lemma LimsFunctorCategory_of_shape (g : graph) (A C : precategory) (hsC : has_homsets C)
+  (HC : Lims_of_shape g C) : Lims_of_shape g [A,C,hsC].
+Proof.
+now intros d; apply LimFunctorCone.
 Defined.
 
 
@@ -875,16 +887,6 @@ use (mk_ColimCocone _ (from_opp_opp_to_opp _ _ _ pr1pr1x)).
       apply (nat_trans_eq hsC); intro a; simpl.
       now rewrite <- T'.
 Defined.
-
-Lemma LimsFunctorCategory (A C : precategory) (hsC : has_homsets C)
-  (HC : Lims C) : Lims [A,C,hsC].
-Proof.
-intros g D.
-apply LimFunctorCone.
-intros.
-apply HC.
-Defined.
-
 
 End LimFunctor.
 

--- a/UniMath/CategoryTheory/limits/graphs/terminal.v
+++ b/UniMath/CategoryTheory/limits/graphs/terminal.v
@@ -170,7 +170,7 @@ Arguments Terminal : clear implicits.
 Arguments isTerminal : clear implicits.
 
 Lemma Terminal_from_Lims (C : precategory) :
-  Lims C -> Terminal C.
+  Lims_of_shape empty_graph  C -> Terminal C.
 Proof.
 now intros H; apply H.
 Defined.

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -97,10 +97,9 @@ Defined.
 
 (* TODO: Having limits and colimits should be sufficient *)
 Context (BCC : BinCoproducts C) (BPC : BinProducts C)
-        (IC : Initial C) (TC : Terminal C) (LC : Lims C)
-        (Hchain : Π (c : chain [C,C,hsC]) (b : C), ColimCocone (diagram_pointwise _ _ hsC _ c b)).
-        (* (CLC : Colims C). (* This is too strong, but still needed for HSS *) *)
-        (* (LC : Lims_of_shape nat_graph C). *)
+        (IC : Initial C) (TC : Terminal C)
+        (CLC : Colims_of_shape nat_graph C)
+        (LC : Lims C).
 
 Let optionC := (option_functor BCC TC).
 
@@ -116,7 +115,7 @@ Lemma is_omega_cocont_precomp_option_iter (n : nat) : is_omega_cocont (precomp_o
 Proof.
 destruct n; simpl.
 - apply (is_omega_cocont_functor_identity has_homsets_C2).
-- apply (is_omega_cocont_pre_composition_functor _ _ _ Hchain).
+- apply is_omega_cocont_pre_composition_functor, CLC.
 Defined.
 
 Definition precomp_option_iter_Signature (n : nat) : Signature C hsC.
@@ -173,8 +172,7 @@ apply (is_omega_cocont_Sum_of_Signatures _ (BindingSigIsdeceq sig)).
 Defined.
 
 (** ** Construction of initial algebra for a signature with strength *)
-Definition SignatureInitialAlgebra (s : Signature C hsC) (Hs : is_omega_cocont s)
-  (CLC : Colims C) (* This is too strong? *) :
+Definition SignatureInitialAlgebra (s : Signature C hsC) (Hs : is_omega_cocont s) :
   Initial (FunctorAlg (Id_H C hsC BCC s) has_homsets_C2).
 Proof.
 use colimAlgInitial.
@@ -212,12 +210,12 @@ Definition BindingSigToMonad (sig : BindingSig)
   (CC : Coproducts (BindingSigIndex sig) C)
   (PC : Products (BindingSigIndex sig) C)
   (H : Π (x : C2), is_omega_cocont (constprod_functor1 (BinProducts_functor_precat _ _ BPC hsC) x))
-  (CLC : Colims C) : Monad C.
+   : Monad C.
 Proof.
 use (Monad_from_hss _ hsC BCC).
 - apply (BindingSigToSignature sig CC).
 - apply SignatureToHSS.
-  apply SignatureInitialAlgebra; [|apply CLC].
+  apply SignatureInitialAlgebra.
   apply (is_omega_cocont_BindingSigToSignature _ _ PC H).
 Defined.
 
@@ -247,7 +245,7 @@ Lemma is_omega_cocont_BindingSigToSignatureHSET (sig : BindingSig) :
 Proof.
 apply (is_omega_cocont_Sum_of_Signatures _ (BindingSigIsdeceq sig)).
 - intro i; apply is_omega_cocont_Arity_to_Signature.
-  + intros c b; apply (ColimsHSET nat_graph (diagram_pointwise has_homsets_HSET c b)).
+  + apply ColimsHSET_of_shape.
   + intros F.
     apply (is_omega_cocont_constprod_functor1 _ has_homsets_HSET2).
     apply has_exponentials_functor_HSET, has_homsets_HSET.
@@ -258,11 +256,10 @@ Defined.
 Definition SignatureInitialAlgebraHSET (s : Signature HSET has_homsets_HSET) (Hs : is_omega_cocont s) :
   Initial (FunctorAlg (Id_H _ _ BinCoproductsHSET s) has_homsets_HSET2).
 Proof.
-apply SignatureInitialAlgebra.
+apply SignatureInitialAlgebra; try assumption.
 - apply BinProductsHSET.
 - apply InitialHSET.
-- apply Hs.
-- apply ColimsHSET.
+- apply ColimsHSET_of_shape.
 Defined.
 
 (** ** Binding signature to a monad for HSET *)
@@ -274,15 +271,14 @@ use (BindingSigToMonad _ _ _ _ _ _ _ sig).
 - apply BinProductsHSET.
 - apply InitialHSET.
 - apply TerminalHSET.
+- apply ColimsHSET_of_shape.
 - apply LimsHSET.
-- intros c b; apply (ColimsHSET nat_graph (diagram_pointwise has_homsets_HSET c b)).
 - apply Coproducts_HSET.
   exact (isasetifdeceq _ (BindingSigIsdeceq sig)).
 - apply Products_HSET.
 - intros F.
   apply (is_omega_cocont_constprod_functor1 _ has_homsets_HSET2).
   apply has_exponentials_functor_HSET, has_homsets_HSET.
-- apply ColimsHSET.
 Defined.
 
 End BindingSigToMonadHSET.

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -98,8 +98,9 @@ Defined.
 (* TODO: Having limits and colimits should be sufficient *)
 Context (BCC : BinCoproducts C) (BPC : BinProducts C)
         (IC : Initial C) (TC : Terminal C) (LC : Lims C)
-        (Hchain : Π (c : chain [C,C,hsC]) (b : C), ColimCocone (diagram_pointwise hsC c b)).
+        (Hchain : Π (c : chain [C,C,hsC]) (b : C), ColimCocone (diagram_pointwise _ _ hsC _ c b)).
         (* (CLC : Colims C). (* This is too strong, but still needed for HSS *) *)
+        (* (LC : Lims_of_shape nat_graph C). *)
 
 Let optionC := (option_functor BCC TC).
 
@@ -185,7 +186,7 @@ use colimAlgInitial.
   + apply functor_category_has_homsets.
   + apply is_omega_cocont_constant_functor, functor_category_has_homsets.
   + apply Hs.
-- apply ColimsFunctorCategory; apply CLC.
+- apply ColimsFunctorCategory_of_shape, CLC.
 Defined.
 
 (** ** Signature with strength and initial algebra to a HSS *)

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -68,7 +68,7 @@ Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
 Lemma is_omega_cocont_pre_composition_functor
      (A B C : precategory) (F : functor A B) (hsB : has_homsets B) (hsC : has_homsets C)
-     (H : Π (c : chain [B,C,hsC]) (b : B), ColimCocone (diagram_pointwise hsC c b)) :
+     (H : Colims_of_shape nat_graph C) :
      is_omega_cocont (pre_composition_functor A B C hsB hsC F).
 Proof.
   exact (@CocontFunctors.is_omega_cocont_pre_composition_functor _ _ _ _ _ _ H).

--- a/UniMath/SubstitutionSystems/LamHSET.v
+++ b/UniMath/SubstitutionSystems/LamHSET.v
@@ -59,8 +59,8 @@ use colimAlgInitial.
     * apply is_omega_cocont_constprod_functor1.
       apply functor_category_has_homsets.
       apply (has_exponentials_functor_HSET _ has_homsets_HSET).
-    * apply LimsHSET.
-- apply ColimsFunctorCategory; apply ColimsHSET.
+    * apply ColimsHSET_of_shape.
+- apply ColimsFunctorCategory_of_shape; apply ColimsHSET_of_shape.
 Defined.
 
 Lemma KanExt_HSET : Π Z : precategory_Ptd HSET has_homsets_HSET,

--- a/UniMath/SubstitutionSystems/LamHSET.v
+++ b/UniMath/SubstitutionSystems/LamHSET.v
@@ -68,8 +68,7 @@ Lemma KanExt_HSET : Π Z : precategory_Ptd HSET has_homsets_HSET,
      (U Z) HSET has_homsets_HSET has_homsets_HSET.
 Proof.
 intro Z.
-apply RightKanExtension_from_limits.
-apply LimsHSET.
+apply RightKanExtension_from_limits, LimsHSET.
 Defined.
 
 Definition LamHSS_Initial_HSET : Initial (hss_precategory BinCoproductsHSET Lam_S).

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -40,7 +40,7 @@ Require Import UniMath.SubstitutionSystems.Notation.
 Require Import UniMath.CategoryTheory.CocontFunctors.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.whiskering.
-Require Import UniMath.CategoryTheory.limits.graphs.limits.
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 
 Arguments θ_source {_ _} _ .
 Arguments θ_target {_ _} _ .
@@ -165,10 +165,10 @@ Definition Abs_H : functor [C, C, hs] [C, C, hs] :=
  (* tpair _ _ is_functor_Abs_H_data. *)
   pre_composition_functor _ _ _ hs _ (option_functor CC terminal).
 
-Lemma is_omega_cocont_Abs_H (LC : Lims C) : is_omega_cocont Abs_H.
+Lemma is_omega_cocont_Abs_H (CLC : Colims_of_shape nat_graph C) : is_omega_cocont Abs_H.
 Proof.
 unfold Abs_H.
-apply (is_omega_cocont_pre_composition_functor_kan _ _ _ LC).
+apply (is_omega_cocont_pre_composition_functor _ _ _ CLC).
 Defined.
 
 
@@ -669,7 +669,7 @@ Definition Lam_Sig: Signature C hs :=
 
 Lemma is_omega_cocont_Lam
   (hE : Π x, is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C CP hs) x))
-  (LC : Lims C) : is_omega_cocont (Signature_Functor _ _ Lam_Sig).
+  (LC : Colims_of_shape nat_graph C) : is_omega_cocont (Signature_Functor _ _ Lam_Sig).
 Proof.
 apply is_omega_cocont_BinCoproduct_of_functors.
 - apply (BinProducts_functor_precat _ _ CP).


### PR DESCRIPTION
This PR introduce `Colims_of_shape g C` where g is a graph in order to get better control over the shape of the diagrams in C that we can compute colimits of (and similarily for limits). We then use this everywhere possible in order to make sure that the graphs we quantify over are small. 