### PR TITLE
Alternative definition of GenMendlerIteration and LiftingInitial

### DIFF
--- a/UniMath/SubstitutionSystems/.package/files
+++ b/UniMath/SubstitutionSystems/.package/files
@@ -10,6 +10,7 @@ LiftingInitial.v
 Lam.v
 LamSignature.v
 GenMendlerIteration.v
+GenMendlerIteration_alt.v
 Notation.v
 SubstitutionSystems_Summary.v
 LamHSET.v

--- a/UniMath/SubstitutionSystems/.package/files
+++ b/UniMath/SubstitutionSystems/.package/files
@@ -7,6 +7,7 @@ SignatureCategory.v
 SignatureExamples.v
 MonadsFromSubstitutionSystems.v
 LiftingInitial.v
+LiftingInitial_alt.v
 Lam.v
 LamSignature.v
 GenMendlerIteration.v

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -173,13 +173,7 @@ Definition SignatureInitialAlgebra (s : Signature C hsC) (Hs : is_omega_cocont s
 Proof.
 use colimAlgInitial.
 - apply (Initial_functor_precat _ _ IC).
-- unfold Id_H, Const_plus_H.
-  apply is_omega_cocont_BinCoproduct_of_functors.
-  + apply (BinProducts_functor_precat _ _ BPC).
-  + apply functor_category_has_homsets.
-  + apply functor_category_has_homsets.
-  + apply is_omega_cocont_constant_functor, functor_category_has_homsets.
-  + apply Hs.
+- apply (is_omega_cocont_Id_H _ _ _ BPC _ Hs).
 - apply ColimsFunctorCategory_of_shape, CLC.
 Defined.
 

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -20,7 +20,6 @@ Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.whiskering.
-Require Import UniMath.CategoryTheory.limits.graphs.limits.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.limits.binproducts.
 Require Import UniMath.CategoryTheory.limits.products.
@@ -34,14 +33,13 @@ Require Import UniMath.CategoryTheory.CocontFunctors.
 Require Import UniMath.CategoryTheory.Monads.
 Require Import UniMath.CategoryTheory.category_hset.
 Require Import UniMath.CategoryTheory.category_hset_structures.
-Require Import UniMath.CategoryTheory.RightKanExtension.
 
 Require Import UniMath.SubstitutionSystems.Signatures.
 Require Import UniMath.SubstitutionSystems.SignatureExamples.
 Require Import UniMath.SubstitutionSystems.SumOfSignatures.
 Require Import UniMath.SubstitutionSystems.BinProductOfSignatures.
 Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
-Require Import UniMath.SubstitutionSystems.LiftingInitial.
+Require Import UniMath.SubstitutionSystems.LiftingInitial_alt.
 Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.Notation.
 
@@ -95,11 +93,9 @@ Proof.
 apply functor_category_has_homsets.
 Defined.
 
-(* TODO: Having limits and colimits should be sufficient *)
 Context (BCC : BinCoproducts C) (BPC : BinProducts C)
         (IC : Initial C) (TC : Terminal C)
-        (CLC : Colims_of_shape nat_graph C)
-        (LC : Lims C).
+        (CLC : Colims_of_shape nat_graph C).
 
 Let optionC := (option_functor BCC TC).
 
@@ -189,17 +185,14 @@ Defined.
 
 (** ** Signature with strength and initial algebra to a HSS *)
 Definition SignatureToHSS (s : Signature C hsC)
-  (Hs : Initial (FunctorAlg (Id_H C hsC BCC s) has_homsets_C2)) :
-  hss_precategory BCC s.
+  (Hs : is_omega_cocont s) : hss_precategory BCC s.
 Proof.
-apply InitialHSS.
-- intro Z; apply RightKanExtension_from_limits, LC.
-- apply Hs.
+now apply InitialHSS.
 Defined.
 
 (** The above HSS is initial *)
 Definition SignatureToHSSisInitial (s : Signature C hsC)
-  (Hs : Initial (FunctorAlg (Id_H C hsC BCC s) has_homsets_C2)) :
+  (Hs : is_omega_cocont s) :
   isInitial _ (SignatureToHSS s Hs).
 Proof.
 now unfold SignatureToHSS; destruct InitialHSS.
@@ -215,7 +208,6 @@ Proof.
 use (Monad_from_hss _ hsC BCC).
 - apply (BindingSigToSignature sig CC).
 - apply SignatureToHSS.
-  apply SignatureInitialAlgebra.
   apply (is_omega_cocont_BindingSigToSignature _ _ PC H).
 Defined.
 
@@ -265,14 +257,13 @@ Defined.
 (** ** Binding signature to a monad for HSET *)
 Definition BindingSigToMonadHSET (sig : BindingSig) : Monad HSET.
 Proof.
-use (BindingSigToMonad _ _ _ _ _ _ _ sig).
+use (BindingSigToMonad _ _ _ _ _ _ sig).
 - apply has_homsets_HSET.
 - apply BinCoproductsHSET.
 - apply BinProductsHSET.
 - apply InitialHSET.
 - apply TerminalHSET.
 - apply ColimsHSET_of_shape.
-- apply LimsHSET.
 - apply Coproducts_HSET.
   exact (isasetifdeceq _ (BindingSigIsdeceq sig)).
 - apply Products_HSET.

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -26,12 +26,15 @@ Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
 Require Import UniMath.CategoryTheory.CocontFunctors.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.Monads.
 Require Import UniMath.CategoryTheory.RightKanExtension.
 Require Import UniMath.SubstitutionSystems.BindingSigToMonad.
+Require Import UniMath.SubstitutionSystems.Signatures.
+Require Import UniMath.SubstitutionSystems.LiftingInitial_alt.
 
 Definition Arity_to_Signature :
   Π (C : precategory) (hsC : has_homsets C),
-  BinCoproducts C → BinProducts C → Terminal C → list nat → Signatures.Signature C hsC.
+  BinCoproducts C → BinProducts C → Terminal C → list nat → Signature C hsC.
 Proof.
   exact @BindingSigToMonad.Arity_to_Signature.
 Defined.
@@ -40,7 +43,7 @@ Definition BindingSigToSignature :
   Π {C : precategory} (hsC : has_homsets C),
   BinCoproducts C → BinProducts C → Terminal C →
   Π sig : BindingSig, Coproducts (BindingSigIndex sig) C →
-  Signatures.Signature C hsC.
+  Signature C hsC.
 Proof.
   exact @UniMath.SubstitutionSystems.BindingSigToMonad.BindingSigToSignature.
 Defined.
@@ -48,9 +51,8 @@ Defined.
 Definition SignatureInitialAlgebra :
   Π {C : precategory} (hsC : has_homsets C) (BCC : BinCoproducts C),
   BinProducts C → Initial C → Colims_of_shape nat_graph C
-  → Π s : Signatures.Signature C hsC,
-          is_omega_cocont (Signatures.Signature_Functor C hsC s)
-  → Initial (FunctorAlg (LiftingInitial_alt.Id_H C hsC BCC s) (BindingSigToMonad.has_homsets_C2 hsC)).
+  → Π s : Signature C hsC, is_omega_cocont (Signature_Functor C hsC s)
+  → Initial (FunctorAlg (Id_H C hsC BCC s) (BindingSigToMonad.has_homsets_C2 hsC)).
 Proof.
   exact @UniMath.SubstitutionSystems.BindingSigToMonad.SignatureInitialAlgebra.
 Defined.
@@ -62,7 +64,7 @@ Definition BindingSigToMonad :
   → Π sig : BindingSig, Coproducts (BindingSigIndex sig) C
   → Products (BindingSigIndex sig) C
   → (Π F, is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C BPC hsC) F)) →
-  Monads.Monad C.
+  Monad C.
 Proof.
   exact @UniMath.SubstitutionSystems.BindingSigToMonad.BindingSigToMonad.
 Defined.

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -28,15 +28,16 @@ Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.Monads.
 Require Import UniMath.CategoryTheory.RightKanExtension.
-Require Import UniMath.SubstitutionSystems.BindingSigToMonad.
 Require Import UniMath.SubstitutionSystems.Signatures.
+Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
+Require Import UniMath.SubstitutionSystems.BindingSigToMonad.
 Require Import UniMath.SubstitutionSystems.LiftingInitial_alt.
 
 Definition Arity_to_Signature :
   Π (C : precategory) (hsC : has_homsets C),
   BinCoproducts C → BinProducts C → Terminal C → list nat → Signature C hsC.
 Proof.
-  exact @BindingSigToMonad.Arity_to_Signature.
+  exact @UniMath.SubstitutionSystems.BindingSigToMonad.Arity_to_Signature.
 Defined.
 
 Definition BindingSigToSignature :
@@ -46,6 +47,15 @@ Definition BindingSigToSignature :
   Signature C hsC.
 Proof.
   exact @UniMath.SubstitutionSystems.BindingSigToMonad.BindingSigToSignature.
+Defined.
+
+Definition InitialHSS :
+  Π (C : precategory) (hsC : has_homsets C) (CP : BinCoproducts C),
+  BinProducts C → Initial C → Colims_of_shape nat_graph C →
+  Π H : Signature C hsC, is_omega_cocont H →
+  Initial (hss_precategory CP H).
+Proof.
+  exact @UniMath.SubstitutionSystems.LiftingInitial_alt.InitialHSS.
 Defined.
 
 Definition SignatureInitialAlgebra :
@@ -83,7 +93,7 @@ Lemma colim_of_chain_is_initial_alg
     isInitial (FunctorAlg F hsC)
               (algebra_ob_pair (colim CC) (colim_algebra_mor InitC HF CC)).
 Proof.
-  exact @CocontFunctors.colimAlgIsInitial.
+  exact @UniMath.CategoryTheory.CocontFunctors.colimAlgIsInitial.
 Defined.
 
 Local Notation "'chain'" := (diagram nat_graph).
@@ -100,15 +110,15 @@ Defined.
 Definition RightKanExtension_from_limits
   : Π (M C A : precategory) (K : functor M C) (hsC : has_homsets C)
     (hsA : has_homsets A),
-  Lims A → RightKanExtension.GlobalRightKanExtensionExists M C K A hsC hsA.
+  Lims A → GlobalRightKanExtensionExists M C K A hsC hsA.
 Proof.
-  exact @RightKanExtension.RightKanExtension_from_limits.
+  exact @UniMath.CategoryTheory.RightKanExtension.RightKanExtension_from_limits.
 Defined.
 
 Definition ColimCoconeHSET
   : Π (g : graph) (D : diagram g HSET), ColimCocone D.
 Proof.
-  exact category_hset_structures.ColimCoconeHSET.
+  exact @UniMath.CategoryTheory.category_hset_structures.ColimCoconeHSET.
 Defined.
 
 Lemma is_omega_cocont_binproduct_functor
@@ -116,12 +126,12 @@ Lemma is_omega_cocont_binproduct_functor
     (Π x : C, is_omega_cocont (constprod_functor1 PC x)) →
     is_omega_cocont (binproduct_functor PC).
 Proof.
-  exact @CocontFunctors.is_omega_cocont_binproduct_functor.
+  exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_binproduct_functor.
 Defined.
 
 Lemma left_adjoint_cocont
   : Π (C D : precategory) (F : functor C D),
     is_left_adjoint F → has_homsets C → has_homsets D → is_cocont F.
 Proof.
-  exact @CocontFunctors.left_adjoint_cocont.
+  exact @UniMath.CategoryTheory.CocontFunctors.left_adjoint_cocont.
 Defined.

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -45,6 +45,27 @@ Proof.
   exact @UniMath.SubstitutionSystems.BindingSigToMonad.BindingSigToSignature.
 Defined.
 
+Definition SignatureInitialAlgebra :
+  Π {C : precategory} (hsC : has_homsets C) (BCC : BinCoproducts C),
+  BinProducts C → Initial C → Colims_of_shape nat_graph C
+  → Π s : Signatures.Signature C hsC,
+          is_omega_cocont (Signatures.Signature_Functor C hsC s)
+  → Initial (FunctorAlg (LiftingInitial_alt.Id_H C hsC BCC s) (BindingSigToMonad.has_homsets_C2 hsC)).
+Proof.
+  exact @UniMath.SubstitutionSystems.BindingSigToMonad.SignatureInitialAlgebra.
+Defined.
+
+Definition BindingSigToMonad :
+  Π (C : precategory) (hsC : has_homsets C),
+  BinCoproducts C → Π BPC : BinProducts C,
+  Initial C → Terminal C → Colims_of_shape nat_graph C
+  → Π sig : BindingSig, Coproducts (BindingSigIndex sig) C
+  → Products (BindingSigIndex sig) C
+  → (Π F, is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C BPC hsC) F)) →
+  Monads.Monad C.
+Proof.
+  exact @UniMath.SubstitutionSystems.BindingSigToMonad.BindingSigToMonad.
+Defined.
 
 Definition algebra_ob_pair {C : precategory} {F : functor C C} X (f : C⟦F X, X⟧)
   : algebra_ob F.

--- a/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
@@ -168,9 +168,79 @@ Proof.
 apply (colimArrowCommutes temp).
 Qed.
 
+Lemma is_iso_inF : is_iso inF.
+Proof.
+(* Use Lambek's lemma, this could be extracted from the concrete proof as well *)
+apply (initialAlg_is_iso _ hsC), pr2.
+Defined.
+
+Let inF_iso : iso (F μF) μF := isopair _ is_iso_inF.
+Let inF_inv : C⟦μF,F μF⟧ := inv_from_iso inF_iso.
+
 (* The direction ** -> * *)
-Lemma SS_imp_S h (H : Π n, # L (e n) ;; h = Pow n IC z) : # L inF ;; h = ψ μF h.
-Admitted.
+Lemma SS_imp_S (H : Π n, # L (e n) ;; preIt = Pow n IC z) : # L inF ;; preIt = ψ μF preIt.
+Proof.
+assert (H' : Π n, # L (e (S n)) ;; # L inF_inv ;; ψ μF preIt = pr1 (Pow (S n)) _ z).
+{ intro n.
+  rewrite e_comm, functor_comp.
+  eapply pathscomp0.
+  eapply cancel_postcomposition.
+  rewrite <-assoc.
+  eapply maponpaths.
+  rewrite <- functor_comp.
+  generalize (iso_inv_after_iso inF_iso).
+  simpl.
+  intros XXX.
+  eapply maponpaths.
+  apply XXX.
+  rewrite functor_id.
+  rewrite id_right.
+  assert (H1 : # L (# F (e n)) ;; ψ μF preIt = ψ (iter_functor F n 0) (# L (e n) ;; preIt)).
+      apply pathsinv0, (toforallpaths _ _ _ (nat_trans_ax ψ _ _ (e n))).
+  eapply pathscomp0. apply H1.
+  rewrite H.
+  apply idpath.
+}
+assert (HH : preIt = # L inF_inv ;; ψ μF preIt).
+apply pathsinv0.
+(* transparent assert (apa : (iso (L (F μF)) (L μF))). *)
+(* apply (isopair (# L inF)), functor_on_iso_is_iso. *)
+(* apply pathsinv0, (@iso_inv_to_left _ _ _ _ apa preIt (ψ μF preIt)). *)
+
+apply (colimArrowUnique temp); simpl; intro n.
+destruct n.
+- apply (InitialArrowUnique ILD).
+- simpl.
+  eapply pathscomp0.
+  Focus 2.
+  apply H'.
+  rewrite assoc.
+  apply idpath.
+- eapply pathscomp0. eapply maponpaths.
+  apply HH.
+  rewrite assoc, <- functor_comp.
+  unfold inF_inv.
+  generalize (iso_inv_after_iso inF_iso).
+  simpl.
+  intros XXX.
+  rewrite XXX.
+  now rewrite functor_id, id_left.
+Qed.
+
+(* General version, not needed? *)
+(* Lemma SS_imp_S h (H : Π n, # L (e n) ;; h = Pow n IC z) : # L inF ;; h = ψ μF h. *)
+(* Proof. *)
+(* assert (H' : Π n, # L (e (S n)) ;; # L inF_inv ;; ψ μF h = pr1 (Pow (S n)) _ z). *)
+(* admit. *)
+(* generalize (@colimArrowUnique D nat_graph LchnF temp X). *)
+(* Check (# L inF_inv ;; ψ μF h). *)
+(* Check (# L inF). *)
+(* transparent assert (apa : (iso (L (F μF)) (L μF))). *)
+(* apply (isopair (# L inF)), functor_on_iso_is_iso. *)
+(* apply pathsinv0, (@iso_inv_to_left _ _ _ _ apa h (ψ μF h)). *)
+(* Check colimArrowUnique. *)
+(* Qed. *)
+
 
 (* The direction * -> ** *)
 Lemma S_imp_SS h n : # L inF ;; h = ψ μF h → # L (e n) ;; h = Pow n IC z.
@@ -187,8 +257,7 @@ Qed.
 
 Lemma preIt_ok : # L inF ;; preIt = ψ μF preIt.
 Proof.
-  apply (SS_imp_S preIt); intro n.
-  apply eqSS.
+apply SS_imp_S; intro n; apply eqSS.
 Qed.
 
 Lemma preIt_uniq (t : Σ h, # L inF ;; h = ψ μF h) : t = (preIt,,preIt_ok).

--- a/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
@@ -12,6 +12,8 @@ Require Import UniMath.CategoryTheory.CocontFunctors.
 Require Import UniMath.CategoryTheory.yoneda.
 (* Require Import UniMath.CategoryTheory.equivalences. (* for adjunctions *) *)
 (* Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq. (* for alternative reading of adj *) *)
+Require Import UniMath.CategoryTheory.HorizontalComposition.
+Require Import UniMath.CategoryTheory.whiskering.
 
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 Local Notation "F ⟶ G" := (nat_trans F G) (at level 39).
@@ -32,20 +34,26 @@ Context {C : precategory} (hsC : has_homsets C) (IC : Initial C)
         (CC : Colims_of_shape nat_graph C) (F : functor C C)
         (HF : is_omega_cocont F).
 
+Local Notation "0" := (InitialObject IC).
+
 Let AF := FunctorAlg F hsC.
 Let chnF := initChain IC F.
 
 Definition μF_Initial : Initial AF := colimAlgInitial hsC IC HF (CC chnF).
 
 Let μF : C := alg_carrier _ (InitialObject μF_Initial).
-Let inF : F μF --> μF := alg_map _ (InitialObject μF_Initial).
+Let inF : C⟦F μF,μF⟧ := alg_map _ (InitialObject μF_Initial).
+Local Definition e : Π (n : nat), C⟦iter_functor F n IC,μF⟧ := colimIn (CC chnF).
 
 Context {D : precategory} (hsD : has_homsets D).
 
 Section the_iteration_principle.
 
 Variables (X : D) (L : functor C D).
-Hypothesis (IL : isInitial D (L IC)) (HL : is_omega_cocont L).
+Hypothesis (IL : isInitial D (L 0)) (HL : is_omega_cocont L).
+
+Let ILD : Initial D := tpair _ _ IL.
+Local Notation "'L0'" := (InitialObject ILD).
 
 Let Yon : functor D^op HSET := yoneda_objects D hsD X.
 
@@ -58,45 +66,54 @@ Variable ψ : ψ_source ⟶ ψ_target.
 
 Let LchnF : chain D := mapchain L chnF.
 
-
-Definition iter_functor' {C' : precategory} (F' : functor C' C') (n : nat) : functor C' C'.
-Proof.
-  induction n as [ | n IHn].
-  - apply functor_identity.
-  - apply (functor_composite F' IHn).
-Defined.
+(* Definition iter_functor' {C' : precategory} (F' : functor C' C') (n : nat) : functor C' C'. *)
+(* Proof. *)
+(*   induction n as [ | n IHn]. *)
+(*   - apply functor_identity. *)
+(*   - apply (functor_composite F' IHn). *)
+(* Defined. *)
 
 Definition Pow_source : functor C^op HSET := ψ_source.
 Definition Pow_target (n : nat) : functor C^op HSET :=
   functor_composite (functor_opp (iter_functor F n)) ψ_source.
 
-(* Proof. *)
-(* induction n as [|n _]. *)
-(* - apply Pow_source. *)
-(* - apply (functor_composite (functor_opp (iter_functor F (S n))) ψ_source). *)
-(* Defined. *)
-
-
-Require Import UniMath.CategoryTheory.HorizontalComposition.
-Require Import UniMath.CategoryTheory.whiskering.
-
 Definition Pow (n : nat) : Pow_source ⟶ Pow_target n.
 Proof.
 induction n as [|n Pown].
 - apply nat_trans_id.
-- eapply nat_trans_comp.
-+ apply Pown.
-+ (* eapply nat_trans_comp. *)
-apply (@pre_whisker C^op C^op HSET (functor_opp (iter_functor F n)) _ _ ψ).
-(* apply nat_trans_id. *)
+- apply (nat_trans_comp Pown (pre_whisker (functor_opp (iter_functor F n)) ψ)).
 Defined.
 
+Lemma PowSn (n : nat) : Pow (S n) = nat_trans_comp (Pow n) (pre_whisker (functor_opp (iter_functor F n)) ψ).
+Proof.
+apply idpath.
+Qed.
+
+Local Definition z : D⟦L0,X⟧ := InitialArrow ILD X.
+
+Lemma Pow_cocone_subproof n :
+  dmor LchnF (idpath (S n)) ;; pr1 (Pow (S n)) IC z = pr1 (Pow n) IC z.
+Proof.
+induction n as [|n IHn].
++ cbn.
+  apply (InitialArrowUnique ILD).
++ change ( pr1 (Pow (S (S n))) _ z) with (ψ (iter_functor F (S n) 0) (Pow (S n) _ z)).
+  assert (H : dmor LchnF (idpath (S (S n))) ;; ψ ((iter_functor F (S n)) IC) ((Pow (S n)) IC z) =
+              ψ (iter_functor F n 0) (dmor LchnF (idpath (S n)) ;; pr1 (Pow (S n)) _ z)).
+    apply pathsinv0, (toforallpaths _ _ _ (nat_trans_ax ψ _ _ (dmor chnF (idpath (S n))))).
+  now rewrite H, IHn.
+Qed.
+
 Definition Pow_cocone : cocone LchnF X.
-Admitted.
+Proof.
+use mk_cocone.
+- intro n.
+  apply (pr1 (Pow n) _ z).
+- abstract (intros n m []; clear m; apply Pow_cocone_subproof).
+Defined.
 
 Definition preIt : D⟦L μF,X⟧.
-Proof.
-Check (@colimArrow D nat_graph LchnF _ X Pow_cocone).
+Admitted.
 
 Lemma preIt_ok : # L inF ;; preIt = ψ μF preIt.
 Admitted.
@@ -159,10 +176,10 @@ Variables (X X' : D).
 Let Yon : functor D^op HSET := yoneda_objects D hsD X.
 Let Yon' : functor D^op HSET := yoneda_objects D hsD X'.
 
-Variables (L : functor C D) (HL : is_omega_cocont L) (IL : isInitial D (L I)).
+Variables (L : functor C D) (HL : is_omega_cocont L) (IL : isInitial D (L 0)).
 Variables (ψ : ψ_source X L ⟶ ψ_target X L).
 
-Variables (L' : functor C D) (HL' : is_omega_cocont L') (IL' : isInitial D (L' I)).
+Variables (L' : functor C D) (HL' : is_omega_cocont L') (IL' : isInitial D (L' 0)).
 Variables (ψ' : ψ_source X' L' ⟶ ψ_target X' L').
 
 Variables (Φ : functor_composite (functor_opp L) Yon ⟶ functor_composite (functor_opp L') Yon').
@@ -193,261 +210,261 @@ End GenMenIt.
 (********* OLD STUFF *)
 (** * Generalized Iteration in Mendler-style *)
 
-Section GenMenIt.
+(* Section GenMenIt. *)
 
-Variable C : precategory.
-Variable hsC : has_homsets C.
+(* Variable C : precategory. *)
+(* Variable hsC : has_homsets C. *)
 
-Variable F : functor C C.
+(* Variable F : functor C C. *)
 
-Let AF := FunctorAlg F hsC.
+(* Let AF := FunctorAlg F hsC. *)
 
-Definition AlgConstr (A : C) (α : F A --> A) : AF.
-Proof.
-  exists A.
-  exact α.
-Defined.
+(* Definition AlgConstr (A : C) (α : F A --> A) : AF. *)
+(* Proof. *)
+(*   exists A. *)
+(*   exact α. *)
+(* Defined. *)
 
-Notation "⟨ A , α ⟩" := (AlgConstr A α).
-(* \<  , \> *)
+(* Notation "⟨ A , α ⟩" := (AlgConstr A α). *)
+(* (* \<  , \> *) *)
 
-Variable μF_Initial : Initial AF.
+(* Variable μF_Initial : Initial AF. *)
 
-Let μF : C := alg_carrier _ (InitialObject μF_Initial).
-Let inF : F μF --> μF := alg_map _ (InitialObject μF_Initial).
+(* Let μF : C := alg_carrier _ (InitialObject μF_Initial). *)
+(* Let inF : F μF --> μF := alg_map _ (InitialObject μF_Initial). *)
 
-Let iter {A : C} (α : F A --> A) : μF --> A :=
-  ↓(InitialArrow μF_Initial ⟨A,α⟩).
+(* Let iter {A : C} (α : F A --> A) : μF --> A := *)
+(*   ↓(InitialArrow μF_Initial ⟨A,α⟩). *)
 
-Variable C' : precategory.
-Variable hsC' : has_homsets C'.
-
-
-Section the_iteration_principle.
-
-Variable X : C'.
-
-Let Yon : functor C'^op HSET := yoneda_objects C' hsC' X.
-
-Variable L : functor C C'.
-
-Variable is_left_adj_L : is_left_adjoint L.
-
-Let φ := @φ_adj _ _ _ is_left_adj_L.
-Let φ_inv := @φ_adj_inv _ _ _ is_left_adj_L.
-Let R : functor _ _ := right_adjoint is_left_adj_L.
-Let η : nat_trans _ _ := unit_from_left_adjoint is_left_adj_L.
-Let ε : nat_trans _ _ := counit_from_left_adjoint is_left_adj_L.
-(* Let φ_natural_precomp := @φ_adj_natural_precomp _ _ _ is_left_adj_L.
-Let φ_inv_natural_precomp := @φ_adj_inv_natural_precomp _ _ _ is_left_adj_L.
-Let φ_after_φ_inv := @φ_adj_after_φ_adj_inv _ _ _ is_left_adj_L.
-Let φ_inv_after_φ := @φ_adj_inv_after_φ_adj _ _ _ is_left_adj_L.*)
+(* Variable C' : precategory. *)
+(* Variable hsC' : has_homsets C'. *)
 
 
-Arguments φ {_ _} _ .
-Arguments φ_inv {_ _} _ .
+(* Section the_iteration_principle. *)
 
-Definition ψ_source : functor C^op HSET := functor_composite (functor_opp L) Yon.
-Definition ψ_target : functor C^op HSET := functor_composite (functor_opp F) ψ_source.
+(* Variable X : C'. *)
 
-Section general_case.
+(* Let Yon : functor C'^op HSET := yoneda_objects C' hsC' X. *)
 
-Variable ψ : ψ_source ⟶ ψ_target.
+(* Variable L : functor C C'. *)
 
-Definition preIt : L μF --> X := φ_inv (iter (φ (ψ (R X) (ε X)))).
+(* Variable is_left_adj_L : is_left_adjoint L. *)
 
-
-Lemma ψ_naturality (A B: C)(h: B --> A)(f: L A --> X): ψ B (#L h;; f) = #L (#F h);; ψ A f.
-Proof.
-  assert (ψ_is_nat := nat_trans_ax ψ);
-  assert (ψ_is_nat_inst1 := ψ_is_nat _ _ h).
-  (* assert (ψ_is_nat_inst2 := aux0 _ _ _ _ f ψ_is_nat_inst1). *)
-  assert (ψ_is_nat_inst2 := toforallpaths _ _ _ ψ_is_nat_inst1 f).
-  apply ψ_is_nat_inst2.
-Qed.
-
-Lemma truth_about_ε (A: C'): ε A = φ_inv (identity (R A)).
-Proof.
-  unfold φ_inv, φ_adj_inv.
-  rewrite functor_id.
-  apply pathsinv0.
-  apply id_left.
-Qed.
-
-Lemma φ_ψ_μF_eq (h: L μF --> X): φ (ψ μF h) = #F (φ h) ;; φ(ψ (R X) (ε X)).
-Proof.
-  rewrite <- φ_adj_natural_precomp.
-  apply maponpaths.
-  eapply pathscomp0.
-Focus 2.
-  apply ψ_naturality.
-  apply maponpaths.
-  rewrite truth_about_ε.
-  rewrite <- (φ_adj_inv_natural_precomp _ _ _ is_left_adj_L).
-  rewrite id_right.
-  apply pathsinv0.
-  change (φ_inv(φ h) = h).
-  apply φ_adj_inv_after_φ_adj.
-Qed.
-
-Lemma cancel_φ {A: C}{B: C'} (f g : L A --> B): φ f = φ g -> f = g.
-Proof.
-  intro Hyp.
-(* pedestrian way:
-  rewrite <- (φ_adj_inv_after_φ_adj _ _ _ is_left_adj_L f).
-  rewrite <- (φ_adj_inv_after_φ_adj _ _ _ is_left_adj_L g).
-  apply maponpaths.
-  exact Hyp.
-*)
-  apply (invmaponpathsweq (adjunction_hom_weq _ _ _ is_left_adj_L _ _)).
-  exact Hyp.
-Qed.
-
-Lemma preIt_ok : # L inF;; preIt = ψ μF preIt.
-Proof.
-    apply cancel_φ.
-    rewrite φ_ψ_μF_eq.
-    rewrite (φ_adj_natural_precomp _ _ _ is_left_adj_L).
-    unfold preIt.
-    rewrite φ_adj_after_φ_adj_inv.
-    rewrite (φ_adj_after_φ_adj_inv _ _ _ is_left_adj_L).
-    assert (iter_eq := algebra_mor_commutes _ _ _ (InitialArrow μF_Initial ⟨_,φ (ψ (R X) (ε X))⟩)).
-    exact iter_eq.
-Qed.
-
-Lemma preIt_uniq (t : Σ h : L μF --> X, # L inF;; h = ψ μF h):
-    t = tpair (λ h : L μF --> X, # L inF;; h = ψ μF h) preIt preIt_ok.
-Proof.
-    destruct t as [h h_rec_eq]; simpl.
-    assert (same: h = preIt).
-Focus 2.
-    apply subtypeEquality.
-    + intro.
-      simpl.
-      apply hsC'.
-Focus 2.
-    simpl.
-    exact same.
-
-    apply cancel_φ.
-    unfold preIt.
-    rewrite (φ_adj_after_φ_adj_inv _ _ _ is_left_adj_L).
-    (* assert (iter_uniq := algebra_mor_commutes _ _ _ *)
-    (*                        (InitialArrow μF_Initial ⟨_,φ (ψ (R X) (ε X))⟩)). *)
-    (* simpl in iter_uniq. *)
-    assert(φh_is_alg_mor: inF ;; φ h = #F(φ h) ;; φ (ψ (R X) (ε X))).
-      (* remark: I am missing a definition of the algebra morphism property in UniMath.CategoryTheory.FunctorAlgebras *)
-    + rewrite <- φ_ψ_μF_eq.
-      rewrite <- φ_adj_natural_precomp.
-      apply maponpaths.
-      exact h_rec_eq.
-    + (* set(φh_alg_mor := tpair _ _ φh_is_alg_mor : pr1 μF_Initial --> ⟨ R X, φ (ψ (R X) (ε X)) ⟩). *)
-       simple refine (let X : AF ⟦ InitialObject μF_Initial, ⟨ R X, φ (ψ (R X) (ε X)) ⟩ ⟧ := _ in _).
-       * apply (tpair _ (φ h)); assumption.
-       * apply (maponpaths pr1 (InitialArrowUnique _ _ X0)).
-Qed.
-
-Theorem GenMendlerIteration : iscontr (Σ h : L μF --> X, #L inF ;; h = ψ μF h).
-Proof.
-  simple refine (tpair _ _ _ ).
-  - exists preIt.
-    exact preIt_ok.
-  - exact preIt_uniq.
-Defined.
-
-Definition It : L μF --> X := pr1 (pr1 GenMendlerIteration).
-Lemma It_is_preIt : It = preIt.
-Proof.
-  apply idpath.
-Qed.
-
-End general_case.
-
-(** * Specialized Mendler Iteration *)
-
-Section special_case.
-
-  Variable G : functor C' C'.
-  Variable ρ : G X --> X.
-  Variable θ : functor_composite F L ⟶ functor_composite L G.
+(* Let φ := @φ_adj _ _ _ is_left_adj_L. *)
+(* Let φ_inv := @φ_adj_inv _ _ _ is_left_adj_L. *)
+(* Let R : functor _ _ := right_adjoint is_left_adj_L. *)
+(* Let η : nat_trans _ _ := unit_from_left_adjoint is_left_adj_L. *)
+(* Let ε : nat_trans _ _ := counit_from_left_adjoint is_left_adj_L. *)
+(* (* Let φ_natural_precomp := @φ_adj_natural_precomp _ _ _ is_left_adj_L. *)
+(* Let φ_inv_natural_precomp := @φ_adj_inv_natural_precomp _ _ _ is_left_adj_L. *)
+(* Let φ_after_φ_inv := @φ_adj_after_φ_adj_inv _ _ _ is_left_adj_L. *)
+(* Let φ_inv_after_φ := @φ_adj_inv_after_φ_adj _ _ _ is_left_adj_L.*) *)
 
 
-  Lemma is_nat_trans_ψ_from_comps
-        :  is_nat_trans ψ_source ψ_target
-                        (λ (A : C^op) (f : yoneda_objects_ob C' X (L A)), θ A;; # G f;; ρ).
-  Proof.
-    intros A B h.
-      apply funextfun.
-      intro f.
-      simpl.
-      unfold compose at 1 5; simpl.
-      rewrite functor_comp.
-      repeat rewrite assoc.
-      assert (θ_nat_trans_ax := nat_trans_ax θ).
-      unfold functor_composite in θ_nat_trans_ax.
-      simpl in θ_nat_trans_ax.
-      rewrite <- θ_nat_trans_ax.
-      apply idpath.
-   Qed.
+(* Arguments φ {_ _} _ . *)
+(* Arguments φ_inv {_ _} _ . *)
 
-  Definition ψ_from_comps : ψ_source ⟶ ψ_target.
-  Proof.
-    simple refine (tpair _ _ _ ).
-    - intro A. simpl. intro f.
-      unfold yoneda_objects_ob in *.
-      exact (θ A ;; #G f ;; ρ).
-    - apply is_nat_trans_ψ_from_comps.
-  Defined.
+(* Definition ψ_source : functor C^op HSET := functor_composite (functor_opp L) Yon. *)
+(* Definition ψ_target : functor C^op HSET := functor_composite (functor_opp F) ψ_source. *)
+
+(* Section general_case. *)
+
+(* Variable ψ : ψ_source ⟶ ψ_target. *)
+
+(* Definition preIt : L μF --> X := φ_inv (iter (φ (ψ (R X) (ε X)))). *)
 
 
-  Definition SpecialGenMendlerIteration :
-    iscontr
-      (Σ h : L μF --> X, # L inF ;; h = θ μF ;; #G h ;; ρ)
-    := GenMendlerIteration ψ_from_comps.
+(* Lemma ψ_naturality (A B: C)(h: B --> A)(f: L A --> X): ψ B (#L h;; f) = #L (#F h);; ψ A f. *)
+(* Proof. *)
+(*   assert (ψ_is_nat := nat_trans_ax ψ); *)
+(*   assert (ψ_is_nat_inst1 := ψ_is_nat _ _ h). *)
+(*   (* assert (ψ_is_nat_inst2 := aux0 _ _ _ _ f ψ_is_nat_inst1). *) *)
+(*   assert (ψ_is_nat_inst2 := toforallpaths _ _ _ ψ_is_nat_inst1 f). *)
+(*   apply ψ_is_nat_inst2. *)
+(* Qed. *)
 
-End special_case.
+(* Lemma truth_about_ε (A: C'): ε A = φ_inv (identity (R A)). *)
+(* Proof. *)
+(*   unfold φ_inv, φ_adj_inv. *)
+(*   rewrite functor_id. *)
+(*   apply pathsinv0. *)
+(*   apply id_left. *)
+(* Qed. *)
 
-End the_iteration_principle.
+(* Lemma φ_ψ_μF_eq (h: L μF --> X): φ (ψ μF h) = #F (φ h) ;; φ(ψ (R X) (ε X)). *)
+(* Proof. *)
+(*   rewrite <- φ_adj_natural_precomp. *)
+(*   apply maponpaths. *)
+(*   eapply pathscomp0. *)
+(* Focus 2. *)
+(*   apply ψ_naturality. *)
+(*   apply maponpaths. *)
+(*   rewrite truth_about_ε. *)
+(*   rewrite <- (φ_adj_inv_natural_precomp _ _ _ is_left_adj_L). *)
+(*   rewrite id_right. *)
+(*   apply pathsinv0. *)
+(*   change (φ_inv(φ h) = h). *)
+(*   apply φ_adj_inv_after_φ_adj. *)
+(* Qed. *)
 
-(** * Fusion law for Generalized Iteration in Mendler-style *)
+(* Lemma cancel_φ {A: C}{B: C'} (f g : L A --> B): φ f = φ g -> f = g. *)
+(* Proof. *)
+(*   intro Hyp. *)
+(* (* pedestrian way: *)
+(*   rewrite <- (φ_adj_inv_after_φ_adj _ _ _ is_left_adj_L f). *)
+(*   rewrite <- (φ_adj_inv_after_φ_adj _ _ _ is_left_adj_L g). *)
+(*   apply maponpaths. *)
+(*   exact Hyp. *)
+(* *) *)
+(*   apply (invmaponpathsweq (adjunction_hom_weq _ _ _ is_left_adj_L _ _)). *)
+(*   exact Hyp. *)
+(* Qed. *)
 
-Variable X X': C'.
-Let Yon : functor C'^op HSET := yoneda_objects C' hsC' X.
-Let Yon' : functor C'^op HSET := yoneda_objects C' hsC' X'.
-Variable L : functor C C'.
-Variable is_left_adj_L : is_left_adjoint L.
-Variable ψ : ψ_source X L ⟶ ψ_target X L.
-Variable L' : functor C C'.
-Variable is_left_adj_L' : is_left_adjoint L'.
-Variable ψ' : ψ_source X' L' ⟶ ψ_target X' L'.
+(* Lemma preIt_ok : # L inF;; preIt = ψ μF preIt. *)
+(* Proof. *)
+(*     apply cancel_φ. *)
+(*     rewrite φ_ψ_μF_eq. *)
+(*     rewrite (φ_adj_natural_precomp _ _ _ is_left_adj_L). *)
+(*     unfold preIt. *)
+(*     rewrite φ_adj_after_φ_adj_inv. *)
+(*     rewrite (φ_adj_after_φ_adj_inv _ _ _ is_left_adj_L). *)
+(*     assert (iter_eq := algebra_mor_commutes _ _ _ (InitialArrow μF_Initial ⟨_,φ (ψ (R X) (ε X))⟩)). *)
+(*     exact iter_eq. *)
+(* Qed. *)
 
-Variable Φ : functor_composite (functor_opp L) Yon ⟶ functor_composite (functor_opp L') Yon'.
+(* Lemma preIt_uniq (t : Σ h : L μF --> X, # L inF;; h = ψ μF h): *)
+(*     t = tpair (λ h : L μF --> X, # L inF;; h = ψ μF h) preIt preIt_ok. *)
+(* Proof. *)
+(*     destruct t as [h h_rec_eq]; simpl. *)
+(*     assert (same: h = preIt). *)
+(* Focus 2. *)
+(*     apply subtypeEquality. *)
+(*     + intro. *)
+(*       simpl. *)
+(*       apply hsC'. *)
+(* Focus 2. *)
+(*     simpl. *)
+(*     exact same. *)
 
-Section fusion_law.
+(*     apply cancel_φ. *)
+(*     unfold preIt. *)
+(*     rewrite (φ_adj_after_φ_adj_inv _ _ _ is_left_adj_L). *)
+(*     (* assert (iter_uniq := algebra_mor_commutes _ _ _ *) *)
+(*     (*                        (InitialArrow μF_Initial ⟨_,φ (ψ (R X) (ε X))⟩)). *) *)
+(*     (* simpl in iter_uniq. *) *)
+(*     assert(φh_is_alg_mor: inF ;; φ h = #F(φ h) ;; φ (ψ (R X) (ε X))). *)
+(*       (* remark: I am missing a definition of the algebra morphism property in UniMath.CategoryTheory.FunctorAlgebras *) *)
+(*     + rewrite <- φ_ψ_μF_eq. *)
+(*       rewrite <- φ_adj_natural_precomp. *)
+(*       apply maponpaths. *)
+(*       exact h_rec_eq. *)
+(*     + (* set(φh_alg_mor := tpair _ _ φh_is_alg_mor : pr1 μF_Initial --> ⟨ R X, φ (ψ (R X) (ε X)) ⟩). *) *)
+(*        simple refine (let X : AF ⟦ InitialObject μF_Initial, ⟨ R X, φ (ψ (R X) (ε X)) ⟩ ⟧ := _ in _). *)
+(*        * apply (tpair _ (φ h)); assumption. *)
+(*        * apply (maponpaths pr1 (InitialArrowUnique _ _ X0)). *)
+(* Qed. *)
 
-  Variable H : ψ μF ;; Φ (F μF) = Φ μF ;; ψ' μF.
+(* Theorem GenMendlerIteration : iscontr (Σ h : L μF --> X, #L inF ;; h = ψ μF h). *)
+(* Proof. *)
+(*   simple refine (tpair _ _ _ ). *)
+(*   - exists preIt. *)
+(*     exact preIt_ok. *)
+(*   - exact preIt_uniq. *)
+(* Defined. *)
 
-  Theorem fusion_law : Φ μF (It X L is_left_adj_L ψ) = It X' L' is_left_adj_L' ψ'.
-  Proof.
-    apply pathsinv0.
-    apply pathsinv0.
-    apply path_to_ctr.
-    assert (Φ_is_nat := nat_trans_ax Φ).
-    assert (Φ_is_nat_inst1 := Φ_is_nat _ _ inF).
-    assert (Φ_is_nat_inst2 := toforallpaths _ _ _ Φ_is_nat_inst1 (It X L is_left_adj_L ψ)).
-    unfold compose in Φ_is_nat_inst2; simpl in Φ_is_nat_inst2.
-    simpl.
-    rewrite <- Φ_is_nat_inst2.
-    assert (H_inst :=  toforallpaths _ _ _ H (It X L is_left_adj_L ψ)).
-    unfold compose in H_inst; simpl in H_inst.
-    rewrite <- H_inst.
-    apply maponpaths.
-    rewrite It_is_preIt.
-    apply preIt_ok.
-  Qed.
+(* Definition It : L μF --> X := pr1 (pr1 GenMendlerIteration). *)
+(* Lemma It_is_preIt : It = preIt. *)
+(* Proof. *)
+(*   apply idpath. *)
+(* Qed. *)
 
-End fusion_law.
+(* End general_case. *)
+
+(* (** * Specialized Mendler Iteration *) *)
+
+(* Section special_case. *)
+
+(*   Variable G : functor C' C'. *)
+(*   Variable ρ : G X --> X. *)
+(*   Variable θ : functor_composite F L ⟶ functor_composite L G. *)
 
 
+(*   Lemma is_nat_trans_ψ_from_comps *)
+(*         :  is_nat_trans ψ_source ψ_target *)
+(*                         (λ (A : C^op) (f : yoneda_objects_ob C' X (L A)), θ A;; # G f;; ρ). *)
+(*   Proof. *)
+(*     intros A B h. *)
+(*       apply funextfun. *)
+(*       intro f. *)
+(*       simpl. *)
+(*       unfold compose at 1 5; simpl. *)
+(*       rewrite functor_comp. *)
+(*       repeat rewrite assoc. *)
+(*       assert (θ_nat_trans_ax := nat_trans_ax θ). *)
+(*       unfold functor_composite in θ_nat_trans_ax. *)
+(*       simpl in θ_nat_trans_ax. *)
+(*       rewrite <- θ_nat_trans_ax. *)
+(*       apply idpath. *)
+(*    Qed. *)
 
-End GenMenIt.
+(*   Definition ψ_from_comps : ψ_source ⟶ ψ_target. *)
+(*   Proof. *)
+(*     simple refine (tpair _ _ _ ). *)
+(*     - intro A. simpl. intro f. *)
+(*       unfold yoneda_objects_ob in *. *)
+(*       exact (θ A ;; #G f ;; ρ). *)
+(*     - apply is_nat_trans_ψ_from_comps. *)
+(*   Defined. *)
+
+
+(*   Definition SpecialGenMendlerIteration : *)
+(*     iscontr *)
+(*       (Σ h : L μF --> X, # L inF ;; h = θ μF ;; #G h ;; ρ) *)
+(*     := GenMendlerIteration ψ_from_comps. *)
+
+(* End special_case. *)
+
+(* End the_iteration_principle. *)
+
+(* (** * Fusion law for Generalized Iteration in Mendler-style *) *)
+
+(* Variable X X': C'. *)
+(* Let Yon : functor C'^op HSET := yoneda_objects C' hsC' X. *)
+(* Let Yon' : functor C'^op HSET := yoneda_objects C' hsC' X'. *)
+(* Variable L : functor C C'. *)
+(* Variable is_left_adj_L : is_left_adjoint L. *)
+(* Variable ψ : ψ_source X L ⟶ ψ_target X L. *)
+(* Variable L' : functor C C'. *)
+(* Variable is_left_adj_L' : is_left_adjoint L'. *)
+(* Variable ψ' : ψ_source X' L' ⟶ ψ_target X' L'. *)
+
+(* Variable Φ : functor_composite (functor_opp L) Yon ⟶ functor_composite (functor_opp L') Yon'. *)
+
+(* Section fusion_law. *)
+
+(*   Variable H : ψ μF ;; Φ (F μF) = Φ μF ;; ψ' μF. *)
+
+(*   Theorem fusion_law : Φ μF (It X L is_left_adj_L ψ) = It X' L' is_left_adj_L' ψ'. *)
+(*   Proof. *)
+(*     apply pathsinv0. *)
+(*     apply pathsinv0. *)
+(*     apply path_to_ctr. *)
+(*     assert (Φ_is_nat := nat_trans_ax Φ). *)
+(*     assert (Φ_is_nat_inst1 := Φ_is_nat _ _ inF). *)
+(*     assert (Φ_is_nat_inst2 := toforallpaths _ _ _ Φ_is_nat_inst1 (It X L is_left_adj_L ψ)). *)
+(*     unfold compose in Φ_is_nat_inst2; simpl in Φ_is_nat_inst2. *)
+(*     simpl. *)
+(*     rewrite <- Φ_is_nat_inst2. *)
+(*     assert (H_inst :=  toforallpaths _ _ _ H (It X L is_left_adj_L ψ)). *)
+(*     unfold compose in H_inst; simpl in H_inst. *)
+(*     rewrite <- H_inst. *)
+(*     apply maponpaths. *)
+(*     rewrite It_is_preIt. *)
+(*     apply preIt_ok. *)
+(*   Qed. *)
+
+(* End fusion_law. *)
+
+
+
+(* End GenMenIt. *)

--- a/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
@@ -53,8 +53,7 @@ Context {D : precategory} (hsD : has_homsets D).
 Section the_iteration_principle.
 
 Variables (X : D) (L : functor C D).
-Hypothesis (* HH : preserves initial L? *)
-        (HL : is_omega_cocont L).
+Hypothesis (IL : isInitial D (L I)) (HL : is_omega_cocont L).
 
 Let Yon : functor D^op HSET := yoneda_objects D hsD X.
 
@@ -65,21 +64,29 @@ Section general_case.
 
 Variable ψ : ψ_source ⟶ ψ_target.
 
-Theorem GenMendlerIteration : iscontr (Σ h : L μF --> X, #L inF ;; h = ψ μF h).
-Proof.
-  admit.
-  (* simple refine (tpair _ _ _ ). *)
-  (* - exists preIt. *)
-  (*   exact preIt_ok. *)
-  (* - exact preIt_uniq. *)
+Definition preIt : L μF --> X.
 Admitted.
+
+Lemma preIt_ok : # L inF ;; preIt = ψ μF preIt.
+Admitted.
+
+Lemma preIt_uniq (t : Σ h : L μF --> X, # L inF ;; h = ψ μF h):
+    t = tpair (λ h : L μF --> X, # L inF ;; h = ψ μF h) preIt preIt_ok.
+Admitted.
+
+Theorem GenMendlerIteration : ∃! (h : L μF --> X), #L inF ;; h = ψ μF h.
+Proof.
+mkpair.
+- apply (preIt,,preIt_ok).
+- exact preIt_uniq.
+Defined.
 
 Definition It : L μF --> X := pr1 (pr1 GenMendlerIteration).
 
-(* Lemma It_is_preIt : It = preIt. *)
-(* Proof. *)
-(*   apply idpath. *)
-(* Qed. *)
+Lemma It_is_preIt : It = preIt.
+Proof.
+  apply idpath.
+Qed.
 
 End general_case.
 
@@ -122,33 +129,32 @@ Variables (X X' : D).
 Let Yon : functor D^op HSET := yoneda_objects D hsD X.
 Let Yon' : functor D^op HSET := yoneda_objects D hsD X'.
 
-Variables (L : functor C D) (HL : is_omega_cocont L).
+Variables (L : functor C D) (HL : is_omega_cocont L) (IL : isInitial D (L I)).
 Variables (ψ : ψ_source X L ⟶ ψ_target X L).
 
-Variables (L' : functor C D) (HL' : is_omega_cocont L').
+Variables (L' : functor C D) (HL' : is_omega_cocont L') (IL' : isInitial D (L' I)).
 Variables (ψ' : ψ_source X' L' ⟶ ψ_target X' L').
 
 Variables (Φ : functor_composite (functor_opp L) Yon ⟶ functor_composite (functor_opp L') Yon').
 
 Variables (H : ψ μF ;; Φ (F μF) = Φ μF ;; ψ' μF).
 
-Theorem fusion_law : Φ μF (It X L HL ψ) = It X' L' HL' ψ'.
+Theorem fusion_law : Φ μF (It X L IL HL ψ) = It X' L' IL' HL' ψ'.
 Proof.
 apply path_to_ctr.
 assert (Φ_is_nat := nat_trans_ax Φ).
 assert (Φ_is_nat_inst1 := Φ_is_nat _ _ inF).
-assert (Φ_is_nat_inst2 := toforallpaths _ _ _ Φ_is_nat_inst1 (It X L HL ψ)).
+assert (Φ_is_nat_inst2 := toforallpaths _ _ _ Φ_is_nat_inst1 (It X L IL HL ψ)).
 unfold compose in Φ_is_nat_inst2; simpl in Φ_is_nat_inst2.
 simpl.
 rewrite <- Φ_is_nat_inst2.
-assert (H_inst :=  toforallpaths _ _ _ H (It X L HL ψ)).
+assert (H_inst :=  toforallpaths _ _ _ H (It X L IL HL ψ)).
 unfold compose in H_inst; simpl in H_inst.
 rewrite <- H_inst.
 apply maponpaths.
-admit.
-(* rewrite It_is_preIt. *)
-(* apply preIt_ok. *)
-Admitted.
+rewrite It_is_preIt.
+apply preIt_ok.
+Qed.
 
 End fusion_law.
 End GenMenIt.

--- a/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
@@ -1,0 +1,430 @@
+Require Import UniMath.Foundations.Basics.PartD.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.limits.initial.
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.FunctorAlgebras.
+Require Import UniMath.CategoryTheory.category_hset.
+Require Import UniMath.CategoryTheory.opp_precat.
+Require Import UniMath.CategoryTheory.CocontFunctors.
+Require Import UniMath.CategoryTheory.yoneda.
+(* Require Import UniMath.CategoryTheory.equivalences. (* for adjunctions *) *)
+(* Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq. (* for alternative reading of adj *) *)
+
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
+Local Notation "F ⟶ G" := (nat_trans F G) (at level 39).
+Arguments functor_composite {_ _ _} _ _ .
+Arguments nat_trans_comp {_ _ _ _ _} _ _ .
+Local Notation "G ∙ F" := (functor_composite F G : [ _ , _ , _ ]) (at level 35).
+Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
+Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
+Local Notation "↓ f" := (mor_from_algebra_mor _ _ _ f) (at level 3, format "↓ f").
+
+(** Goal: derive Generalized Iteration in Mendler-style and a fusion law *)
+
+(** * Generalized Iteration in Mendler-style *)
+Section GenMenIt.
+
+Context {C : precategory} (hsC : has_homsets C) (I : Initial C)
+        (CC : Colims_of_shape nat_graph C) (F : functor C C)
+        (HF : is_omega_cocont F).
+
+Let AF := FunctorAlg F hsC.
+
+(* Definition AlgConstr (A : C) (α : F A --> A) : AF. *)
+(* Proof. *)
+(*   exists A. *)
+(*   exact α. *)
+(* Defined. *)
+
+(* Notation "⟨ A , α ⟩" := (AlgConstr A α). *)
+(* (* \<  , \> *) *)
+
+Definition μF_Initial : Initial AF :=
+  colimAlgInitial hsC I HF (CC (initChain I F)).
+
+Let μF : C := alg_carrier _ (InitialObject μF_Initial).
+Let inF : F μF --> μF := alg_map _ (InitialObject μF_Initial).
+
+Context {D : precategory} (hsD : has_homsets D).
+
+Section the_iteration_principle.
+
+Variables (X : D) (L : functor C D).
+Hypothesis (* HH : preserves initial L? *)
+        (HL : is_omega_cocont L).
+
+Let Yon : functor D^op HSET := yoneda_objects D hsD X.
+
+Definition ψ_source : functor C^op HSET := functor_composite (functor_opp L) Yon.
+Definition ψ_target : functor C^op HSET := functor_composite (functor_opp F) ψ_source.
+
+Section general_case.
+
+Variable ψ : ψ_source ⟶ ψ_target.
+
+Theorem GenMendlerIteration : iscontr (Σ h : L μF --> X, #L inF ;; h = ψ μF h).
+Proof.
+  admit.
+  (* simple refine (tpair _ _ _ ). *)
+  (* - exists preIt. *)
+  (*   exact preIt_ok. *)
+  (* - exact preIt_uniq. *)
+Admitted.
+
+Definition It : L μF --> X := pr1 (pr1 GenMendlerIteration).
+
+(* Lemma It_is_preIt : It = preIt. *)
+(* Proof. *)
+(*   apply idpath. *)
+(* Qed. *)
+
+End general_case.
+
+(** * Specialized Mendler Iteration *)
+Section special_case.
+
+  Variable G : functor D D.
+  Variable ρ : G X --> X.
+  Variable θ : functor_composite F L ⟶ functor_composite L G.
+
+  Lemma is_nat_trans_ψ_from_comps
+        :  is_nat_trans ψ_source ψ_target
+                        (λ (A : C^op) (f : yoneda_objects_ob D X (L A)), θ A;; # G f;; ρ).
+  Proof.
+    intros A B h.
+      apply funextfun.
+      intro f.
+      simpl.
+      unfold compose at 1 5; simpl.
+      rewrite functor_comp.
+      repeat rewrite assoc.
+      assert (θ_nat_trans_ax := nat_trans_ax θ).
+      unfold functor_composite in θ_nat_trans_ax.
+      simpl in θ_nat_trans_ax.
+      rewrite <- θ_nat_trans_ax.
+      apply idpath.
+   Qed.
+
+  Definition ψ_from_comps : ψ_source ⟶ ψ_target.
+  Proof.
+    simple refine (tpair _ _ _ ).
+    - intro A. simpl. intro f.
+      unfold yoneda_objects_ob in *.
+      exact (θ A ;; #G f ;; ρ).
+    - apply is_nat_trans_ψ_from_comps.
+  Defined.
+
+
+  Definition SpecialGenMendlerIteration :
+    iscontr
+      (Σ h : L μF --> X, # L inF ;; h = θ μF ;; #G h ;; ρ)
+    := GenMendlerIteration ψ_from_comps.
+
+End special_case.
+End the_iteration_principle.
+
+
+(** * Fusion law for Generalized Iteration in Mendler-style *)
+Section fusion_law.
+
+Variables (X X' : D).
+
+Let Yon : functor D^op HSET := yoneda_objects D hsD X.
+Let Yon' : functor D^op HSET := yoneda_objects D hsD X'.
+
+Variables (L : functor C D) (HL : is_omega_cocont L).
+Variables (ψ : ψ_source X L ⟶ ψ_target X L).
+
+Variables (L' : functor C D) (HL' : is_omega_cocont L').
+Variables (ψ' : ψ_source X' L' ⟶ ψ_target X' L').
+
+Variables (Φ : functor_composite (functor_opp L) Yon ⟶ functor_composite (functor_opp L') Yon').
+
+Variables (H : ψ μF ;; Φ (F μF) = Φ μF ;; ψ' μF).
+
+Theorem fusion_law : Φ μF (It X L HL ψ) = It X' L' HL' ψ'.
+Proof.
+apply path_to_ctr.
+assert (Φ_is_nat := nat_trans_ax Φ).
+assert (Φ_is_nat_inst1 := Φ_is_nat _ _ inF).
+assert (Φ_is_nat_inst2 := toforallpaths _ _ _ Φ_is_nat_inst1 (It X L HL ψ)).
+unfold compose in Φ_is_nat_inst2; simpl in Φ_is_nat_inst2.
+simpl.
+rewrite <- Φ_is_nat_inst2.
+assert (H_inst :=  toforallpaths _ _ _ H (It X L HL ψ)).
+unfold compose in H_inst; simpl in H_inst.
+rewrite <- H_inst.
+apply maponpaths.
+admit.
+(* rewrite It_is_preIt. *)
+(* apply preIt_ok. *)
+Admitted.
+
+End fusion_law.
+End GenMenIt.
+
+
+(********* OLD STUFF *)
+(** * Generalized Iteration in Mendler-style *)
+
+Section GenMenIt.
+
+Variable C : precategory.
+Variable hsC : has_homsets C.
+
+Variable F : functor C C.
+
+Let AF := FunctorAlg F hsC.
+
+Definition AlgConstr (A : C) (α : F A --> A) : AF.
+Proof.
+  exists A.
+  exact α.
+Defined.
+
+Notation "⟨ A , α ⟩" := (AlgConstr A α).
+(* \<  , \> *)
+
+Variable μF_Initial : Initial AF.
+
+Let μF : C := alg_carrier _ (InitialObject μF_Initial).
+Let inF : F μF --> μF := alg_map _ (InitialObject μF_Initial).
+
+Let iter {A : C} (α : F A --> A) : μF --> A :=
+  ↓(InitialArrow μF_Initial ⟨A,α⟩).
+
+Variable C' : precategory.
+Variable hsC' : has_homsets C'.
+
+
+Section the_iteration_principle.
+
+Variable X : C'.
+
+Let Yon : functor C'^op HSET := yoneda_objects C' hsC' X.
+
+Variable L : functor C C'.
+
+Variable is_left_adj_L : is_left_adjoint L.
+
+Let φ := @φ_adj _ _ _ is_left_adj_L.
+Let φ_inv := @φ_adj_inv _ _ _ is_left_adj_L.
+Let R : functor _ _ := right_adjoint is_left_adj_L.
+Let η : nat_trans _ _ := unit_from_left_adjoint is_left_adj_L.
+Let ε : nat_trans _ _ := counit_from_left_adjoint is_left_adj_L.
+(* Let φ_natural_precomp := @φ_adj_natural_precomp _ _ _ is_left_adj_L.
+Let φ_inv_natural_precomp := @φ_adj_inv_natural_precomp _ _ _ is_left_adj_L.
+Let φ_after_φ_inv := @φ_adj_after_φ_adj_inv _ _ _ is_left_adj_L.
+Let φ_inv_after_φ := @φ_adj_inv_after_φ_adj _ _ _ is_left_adj_L.*)
+
+
+Arguments φ {_ _} _ .
+Arguments φ_inv {_ _} _ .
+
+Definition ψ_source : functor C^op HSET := functor_composite (functor_opp L) Yon.
+Definition ψ_target : functor C^op HSET := functor_composite (functor_opp F) ψ_source.
+
+Section general_case.
+
+Variable ψ : ψ_source ⟶ ψ_target.
+
+Definition preIt : L μF --> X := φ_inv (iter (φ (ψ (R X) (ε X)))).
+
+
+Lemma ψ_naturality (A B: C)(h: B --> A)(f: L A --> X): ψ B (#L h;; f) = #L (#F h);; ψ A f.
+Proof.
+  assert (ψ_is_nat := nat_trans_ax ψ);
+  assert (ψ_is_nat_inst1 := ψ_is_nat _ _ h).
+  (* assert (ψ_is_nat_inst2 := aux0 _ _ _ _ f ψ_is_nat_inst1). *)
+  assert (ψ_is_nat_inst2 := toforallpaths _ _ _ ψ_is_nat_inst1 f).
+  apply ψ_is_nat_inst2.
+Qed.
+
+Lemma truth_about_ε (A: C'): ε A = φ_inv (identity (R A)).
+Proof.
+  unfold φ_inv, φ_adj_inv.
+  rewrite functor_id.
+  apply pathsinv0.
+  apply id_left.
+Qed.
+
+Lemma φ_ψ_μF_eq (h: L μF --> X): φ (ψ μF h) = #F (φ h) ;; φ(ψ (R X) (ε X)).
+Proof.
+  rewrite <- φ_adj_natural_precomp.
+  apply maponpaths.
+  eapply pathscomp0.
+Focus 2.
+  apply ψ_naturality.
+  apply maponpaths.
+  rewrite truth_about_ε.
+  rewrite <- (φ_adj_inv_natural_precomp _ _ _ is_left_adj_L).
+  rewrite id_right.
+  apply pathsinv0.
+  change (φ_inv(φ h) = h).
+  apply φ_adj_inv_after_φ_adj.
+Qed.
+
+Lemma cancel_φ {A: C}{B: C'} (f g : L A --> B): φ f = φ g -> f = g.
+Proof.
+  intro Hyp.
+(* pedestrian way:
+  rewrite <- (φ_adj_inv_after_φ_adj _ _ _ is_left_adj_L f).
+  rewrite <- (φ_adj_inv_after_φ_adj _ _ _ is_left_adj_L g).
+  apply maponpaths.
+  exact Hyp.
+*)
+  apply (invmaponpathsweq (adjunction_hom_weq _ _ _ is_left_adj_L _ _)).
+  exact Hyp.
+Qed.
+
+Lemma preIt_ok : # L inF;; preIt = ψ μF preIt.
+Proof.
+    apply cancel_φ.
+    rewrite φ_ψ_μF_eq.
+    rewrite (φ_adj_natural_precomp _ _ _ is_left_adj_L).
+    unfold preIt.
+    rewrite φ_adj_after_φ_adj_inv.
+    rewrite (φ_adj_after_φ_adj_inv _ _ _ is_left_adj_L).
+    assert (iter_eq := algebra_mor_commutes _ _ _ (InitialArrow μF_Initial ⟨_,φ (ψ (R X) (ε X))⟩)).
+    exact iter_eq.
+Qed.
+
+Lemma preIt_uniq (t : Σ h : L μF --> X, # L inF;; h = ψ μF h):
+    t = tpair (λ h : L μF --> X, # L inF;; h = ψ μF h) preIt preIt_ok.
+Proof.
+    destruct t as [h h_rec_eq]; simpl.
+    assert (same: h = preIt).
+Focus 2.
+    apply subtypeEquality.
+    + intro.
+      simpl.
+      apply hsC'.
+Focus 2.
+    simpl.
+    exact same.
+
+    apply cancel_φ.
+    unfold preIt.
+    rewrite (φ_adj_after_φ_adj_inv _ _ _ is_left_adj_L).
+    (* assert (iter_uniq := algebra_mor_commutes _ _ _ *)
+    (*                        (InitialArrow μF_Initial ⟨_,φ (ψ (R X) (ε X))⟩)). *)
+    (* simpl in iter_uniq. *)
+    assert(φh_is_alg_mor: inF ;; φ h = #F(φ h) ;; φ (ψ (R X) (ε X))).
+      (* remark: I am missing a definition of the algebra morphism property in UniMath.CategoryTheory.FunctorAlgebras *)
+    + rewrite <- φ_ψ_μF_eq.
+      rewrite <- φ_adj_natural_precomp.
+      apply maponpaths.
+      exact h_rec_eq.
+    + (* set(φh_alg_mor := tpair _ _ φh_is_alg_mor : pr1 μF_Initial --> ⟨ R X, φ (ψ (R X) (ε X)) ⟩). *)
+       simple refine (let X : AF ⟦ InitialObject μF_Initial, ⟨ R X, φ (ψ (R X) (ε X)) ⟩ ⟧ := _ in _).
+       * apply (tpair _ (φ h)); assumption.
+       * apply (maponpaths pr1 (InitialArrowUnique _ _ X0)).
+Qed.
+
+Theorem GenMendlerIteration : iscontr (Σ h : L μF --> X, #L inF ;; h = ψ μF h).
+Proof.
+  simple refine (tpair _ _ _ ).
+  - exists preIt.
+    exact preIt_ok.
+  - exact preIt_uniq.
+Defined.
+
+Definition It : L μF --> X := pr1 (pr1 GenMendlerIteration).
+Lemma It_is_preIt : It = preIt.
+Proof.
+  apply idpath.
+Qed.
+
+End general_case.
+
+(** * Specialized Mendler Iteration *)
+
+Section special_case.
+
+  Variable G : functor C' C'.
+  Variable ρ : G X --> X.
+  Variable θ : functor_composite F L ⟶ functor_composite L G.
+
+
+  Lemma is_nat_trans_ψ_from_comps
+        :  is_nat_trans ψ_source ψ_target
+                        (λ (A : C^op) (f : yoneda_objects_ob C' X (L A)), θ A;; # G f;; ρ).
+  Proof.
+    intros A B h.
+      apply funextfun.
+      intro f.
+      simpl.
+      unfold compose at 1 5; simpl.
+      rewrite functor_comp.
+      repeat rewrite assoc.
+      assert (θ_nat_trans_ax := nat_trans_ax θ).
+      unfold functor_composite in θ_nat_trans_ax.
+      simpl in θ_nat_trans_ax.
+      rewrite <- θ_nat_trans_ax.
+      apply idpath.
+   Qed.
+
+  Definition ψ_from_comps : ψ_source ⟶ ψ_target.
+  Proof.
+    simple refine (tpair _ _ _ ).
+    - intro A. simpl. intro f.
+      unfold yoneda_objects_ob in *.
+      exact (θ A ;; #G f ;; ρ).
+    - apply is_nat_trans_ψ_from_comps.
+  Defined.
+
+
+  Definition SpecialGenMendlerIteration :
+    iscontr
+      (Σ h : L μF --> X, # L inF ;; h = θ μF ;; #G h ;; ρ)
+    := GenMendlerIteration ψ_from_comps.
+
+End special_case.
+
+End the_iteration_principle.
+
+(** * Fusion law for Generalized Iteration in Mendler-style *)
+
+Variable X X': C'.
+Let Yon : functor C'^op HSET := yoneda_objects C' hsC' X.
+Let Yon' : functor C'^op HSET := yoneda_objects C' hsC' X'.
+Variable L : functor C C'.
+Variable is_left_adj_L : is_left_adjoint L.
+Variable ψ : ψ_source X L ⟶ ψ_target X L.
+Variable L' : functor C C'.
+Variable is_left_adj_L' : is_left_adjoint L'.
+Variable ψ' : ψ_source X' L' ⟶ ψ_target X' L'.
+
+Variable Φ : functor_composite (functor_opp L) Yon ⟶ functor_composite (functor_opp L') Yon'.
+
+Section fusion_law.
+
+  Variable H : ψ μF ;; Φ (F μF) = Φ μF ;; ψ' μF.
+
+  Theorem fusion_law : Φ μF (It X L is_left_adj_L ψ) = It X' L' is_left_adj_L' ψ'.
+  Proof.
+    apply pathsinv0.
+    apply pathsinv0.
+    apply path_to_ctr.
+    assert (Φ_is_nat := nat_trans_ax Φ).
+    assert (Φ_is_nat_inst1 := Φ_is_nat _ _ inF).
+    assert (Φ_is_nat_inst2 := toforallpaths _ _ _ Φ_is_nat_inst1 (It X L is_left_adj_L ψ)).
+    unfold compose in Φ_is_nat_inst2; simpl in Φ_is_nat_inst2.
+    simpl.
+    rewrite <- Φ_is_nat_inst2.
+    assert (H_inst :=  toforallpaths _ _ _ H (It X L is_left_adj_L ψ)).
+    unfold compose in H_inst; simpl in H_inst.
+    rewrite <- H_inst.
+    apply maponpaths.
+    rewrite It_is_preIt.
+    apply preIt_ok.
+  Qed.
+
+End fusion_law.
+
+
+
+End GenMenIt.

--- a/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
@@ -45,6 +45,8 @@ Let μF : C := alg_carrier _ (InitialObject μF_Initial).
 Let inF : C⟦F μF,μF⟧ := alg_map _ (InitialObject μF_Initial).
 Local Definition e : Π (n : nat), C⟦iter_functor F n IC,μF⟧ := colimIn (CC chnF).
 
+Definition cocone_μF : cocone chnF μF := colimCocone (CC chnF).
+
 Context {D : precategory} (hsD : has_homsets D).
 
 Section the_iteration_principle.
@@ -97,7 +99,7 @@ Proof.
 induction n as [|n IHn].
 + cbn.
   apply (InitialArrowUnique ILD).
-+ change ( pr1 (Pow (S (S n))) _ z) with (ψ (iter_functor F (S n) 0) (Pow (S n) _ z)).
++ change (pr1 (Pow (S (S n))) _ z) with (ψ (iter_functor F (S n) 0) (Pow (S n) _ z)).
   assert (H : dmor LchnF (idpath (S (S n))) ;; ψ ((iter_functor F (S n)) IC) ((Pow (S n)) IC z) =
               ψ (iter_functor F n 0) (dmor LchnF (idpath (S n)) ;; pr1 (Pow (S n)) _ z)).
     apply pathsinv0, (toforallpaths _ _ _ (nat_trans_ax ψ _ _ (dmor chnF (idpath (S n))))).
@@ -112,8 +114,18 @@ use mk_cocone.
 - abstract (intros n m []; clear m; apply Pow_cocone_subproof).
 Defined.
 
+Definition temp : ColimCocone LchnF.
+Proof.
+use mk_ColimCocone.
+- apply (L μF).
+- apply (mapcocone L _ cocone_μF).
+- apply HL, (isColimCocone_from_ColimCocone (CC chnF)).
+Defined.
+
 Definition preIt : D⟦L μF,X⟧.
-Admitted.
+Proof.
+apply (@colimArrow D nat_graph LchnF temp X Pow_cocone).
+Defined.
 
 Lemma preIt_ok : # L inF ;; preIt = ψ μF preIt.
 Admitted.

--- a/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
@@ -47,6 +47,41 @@ Local Definition e : Π (n : nat), C⟦iter_functor F n IC,μF⟧ := colimIn (CC
 
 Definition cocone_μF : cocone chnF μF := colimCocone (CC chnF).
 
+(* Let FchnF := mapdiagram F chnF. *)
+
+(* Lemma cocone_F : cocone FchnF (F μF). *)
+(* Proof. *)
+(* use mk_cocone. *)
+(* - intros n. *)
+(*   apply (# F (e n)). *)
+(* - intros m n e. *)
+(*   simpl. rewrite <- functor_comp. *)
+(*   generalize (coconeInCommutes cocone_μF m n e). *)
+(*   cbn. *)
+(*   destruct e. *)
+(*   simpl. *)
+(*   unfold e. *)
+(*   unfold colimIn. *)
+(*   unfold cocone_μF. *)
+(*   intros HH. *)
+(*   apply maponpaths. *)
+(*   apply HH. *)
+(* Defined. *)
+
+(* Lemma cocone_F' : cocone FchnF μF. *)
+(* Proof. *)
+(* use mk_cocone. *)
+(* - intros n. *)
+(*   apply (e (S n)). *)
+(* - intros m n []; clear n. *)
+(*   apply (coconeInCommutes (colimCocone (CC chnF)) (S m) _ (idpath _)). *)
+(* Defined. *)
+
+Lemma e_comm (n : nat) : e (S n) = # F (e n) ;; inF.
+Proof.
+apply pathsinv0, (colimArrowCommutes (mk_ColimCocone _ _ _ (HF _ _ _ (isColimCocone_from_ColimCocone (CC chnF))))).
+Qed.
+
 Context {D : precategory} (hsD : has_homsets D).
 
 Section the_iteration_principle.
@@ -63,6 +98,7 @@ Definition ψ_source : functor C^op HSET := functor_composite (functor_opp L) Yo
 Definition ψ_target : functor C^op HSET := functor_composite (functor_opp F) ψ_source.
 
 Section general_case.
+
 
 Variable ψ : ψ_source ⟶ ψ_target.
 
@@ -133,16 +169,25 @@ apply (colimArrowCommutes temp).
 Qed.
 
 (* The direction ** -> * *)
-Lemma SS_imp_S h n : # L (e n) ;; h = Pow n IC z -> # L inF ;; h = ψ μF h.
+Lemma SS_imp_S h (H : Π n, # L (e n) ;; h = Pow n IC z) : # L inF ;; h = ψ μF h.
 Admitted.
 
 (* The direction * -> ** *)
 Lemma S_imp_SS h n : # L inF ;; h = ψ μF h → # L (e n) ;; h = Pow n IC z.
-Admitted.
+Proof.
+intros Hh.
+induction n.
+- cbn.
+  apply (InitialArrowUnique ILD).
+- rewrite e_comm, functor_comp, <- assoc, Hh.
+  assert (H : # L (# F (e n)) ;; ψ μF h = ψ (iter_functor F n 0) (# L (e n) ;; h)).
+    apply pathsinv0, (toforallpaths _ _ _ (nat_trans_ax ψ _ _ (e n))).
+  now rewrite H, IHn.
+Qed.
 
 Lemma preIt_ok : # L inF ;; preIt = ψ μF preIt.
 Proof.
-  apply (SS_imp_S preIt 0).
+  apply (SS_imp_S preIt); intro n.
   apply eqSS.
 Qed.
 

--- a/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
@@ -127,11 +127,37 @@ Proof.
 apply (@colimArrow D nat_graph LchnF temp X Pow_cocone).
 Defined.
 
-Lemma preIt_ok : # L inF ;; preIt = ψ μF preIt.
+Lemma eqSS n : # L (e n) ;; preIt = Pow n IC z.
+Proof.
+apply (colimArrowCommutes temp).
+Qed.
+
+(* The direction ** -> * *)
+Lemma SS_imp_S h n : # L (e n) ;; h = Pow n IC z -> # L inF ;; h = ψ μF h.
 Admitted.
 
-Lemma preIt_uniq (t : Σ h, # L inF ;; h = ψ μF h) : t = (preIt,,preIt_ok).
+(* The direction * -> ** *)
+Lemma S_imp_SS h n : # L inF ;; h = ψ μF h → # L (e n) ;; h = Pow n IC z.
 Admitted.
+
+Lemma preIt_ok : # L inF ;; preIt = ψ μF preIt.
+Proof.
+  apply (SS_imp_S preIt 0).
+  apply eqSS.
+Qed.
+
+Lemma preIt_uniq (t : Σ h, # L inF ;; h = ψ μF h) : t = (preIt,,preIt_ok).
+Proof.
+apply subtypeEquality.
+- intros f; apply hsD.
+- simpl.
+  destruct t as [f Hf]; simpl.
+  unfold preIt.
+  apply (colimArrowUnique temp); intro n.
+  simpl.
+  apply S_imp_SS.
+  apply Hf.
+Qed.
 
 Theorem GenMendlerIteration : ∃! (h : L μF --> X), #L inF ;; h = ψ μF h.
 Proof.

--- a/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
@@ -2,15 +2,17 @@
 
 Contents:
 
-- Derivation of Generalized Iteration in Mendler-style Instantiation to a special case, Specialized
-- Mendler Iteration Proof of a fusion law à la Bird-Paterson (Generalised folds for nested
-- datatypes) for Generalized Iteration in Mendler-style
+- Derivation of Generalized Iteration in Mendler-style
+  Instantiation to a special case, Specialized
+- Mendler Iteration Proof of a fusion law à la Bird-Paterson
+  (Generalised folds for nested datatypes, theorem 1) for
+  Generalized Iteration in Mendler-style
 
-This file differs from GenMendlerIteration.v in the hypotheses. Here we use omega cocontinuity
-instead of Kan extensions.
+This file differs from GenMendlerIteration.v in the hypotheses.
+Here we use omega cocontinuity instead of Kan extensions.
 
-Written by: Anders Mörtberg, 2016
-Based on a note of Ralph Matthes
+Written by: Anders Mörtberg, 2016.
+Based on a note by Ralph Matthes.
 
 ************************************************************)
 
@@ -52,19 +54,17 @@ Local Notation "0" := (InitialObject IC).
 
 Let AF := FunctorAlg F hsC.
 Let chnF := initChain IC F.
-
-Definition μF_Initial : Initial AF := colimAlgInitial hsC IC HF (CC chnF).
-
+Let μF_Initial : Initial AF := colimAlgInitial hsC IC HF (CC chnF).
 Let μF : C := alg_carrier _ (InitialObject μF_Initial).
 Let inF : C⟦F μF,μF⟧ := alg_map _ (InitialObject μF_Initial).
-Local Definition e : Π (n : nat), C⟦iter_functor F n IC,μF⟧ := colimIn (CC chnF).
-
-Definition cocone_μF : cocone chnF μF := colimCocone (CC chnF).
+Let e : Π (n : nat), C⟦iter_functor F n IC,μF⟧ := colimIn (CC chnF).
+Let cocone_μF : cocone chnF μF := colimCocone (CC chnF).
 
 Local Lemma e_comm (n : nat) : e (S n) = # F (e n) ;; inF.
 Proof.
 apply pathsinv0,
-      (colimArrowCommutes (mk_ColimCocone _ _ _ (HF _ _ _ (isColimCocone_from_ColimCocone (CC chnF))))).
+      (colimArrowCommutes (mk_ColimCocone _ _ _ (HF _ _ _
+                          (isColimCocone_from_ColimCocone (CC chnF))))).
 Qed.
 
 Context {D : precategory} (hsD : has_homsets D).
@@ -86,6 +86,7 @@ Section general_case.
 Variable (ψ : ψ_source ⟶ ψ_target).
 
 Let LchnF : chain D := mapchain L chnF.
+Let z : D⟦L0,X⟧ := InitialArrow ILD X.
 
 Local Definition Pow_source : functor C^op HSET := ψ_source.
 Local Definition Pow_target (n : nat) : functor C^op HSET :=
@@ -97,8 +98,6 @@ induction n as [|n Pown].
 - apply nat_trans_id.
 - apply (nat_trans_comp Pown (pre_whisker (functor_opp (iter_functor F n)) ψ)).
 Defined.
-
-Local Definition z : D⟦L0,X⟧ := InitialArrow ILD X.
 
 Local Lemma Pow_cocone_subproof n :
   dmor LchnF (idpath (S n)) ;; pr1 (Pow (S n)) IC z = pr1 (Pow n) IC z.

--- a/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
@@ -1,3 +1,19 @@
+(** **********************************************************
+
+Contents:
+
+- Derivation of Generalized Iteration in Mendler-style Instantiation to a special case, Specialized
+- Mendler Iteration Proof of a fusion law à la Bird-Paterson (Generalised folds for nested
+- datatypes) for Generalized Iteration in Mendler-style
+
+This file differs from GenMendlerIteration.v in the hypotheses. Here we use omega cocontinuity
+instead of Kan extensions.
+
+Written by: Anders Mörtberg, 2016
+Based on a note of Ralph Matthes
+
+************************************************************)
+
 Require Import UniMath.Foundations.Basics.PartD.
 
 Require Import UniMath.CategoryTheory.precategories.
@@ -10,8 +26,6 @@ Require Import UniMath.CategoryTheory.category_hset.
 Require Import UniMath.CategoryTheory.opp_precat.
 Require Import UniMath.CategoryTheory.CocontFunctors.
 Require Import UniMath.CategoryTheory.yoneda.
-(* Require Import UniMath.CategoryTheory.equivalences. (* for adjunctions *) *)
-(* Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq. (* for alternative reading of adj *) *)
 Require Import UniMath.CategoryTheory.HorizontalComposition.
 Require Import UniMath.CategoryTheory.whiskering.
 
@@ -47,47 +61,17 @@ Local Definition e : Π (n : nat), C⟦iter_functor F n IC,μF⟧ := colimIn (CC
 
 Definition cocone_μF : cocone chnF μF := colimCocone (CC chnF).
 
-(* Let FchnF := mapdiagram F chnF. *)
-
-(* Lemma cocone_F : cocone FchnF (F μF). *)
-(* Proof. *)
-(* use mk_cocone. *)
-(* - intros n. *)
-(*   apply (# F (e n)). *)
-(* - intros m n e. *)
-(*   simpl. rewrite <- functor_comp. *)
-(*   generalize (coconeInCommutes cocone_μF m n e). *)
-(*   cbn. *)
-(*   destruct e. *)
-(*   simpl. *)
-(*   unfold e. *)
-(*   unfold colimIn. *)
-(*   unfold cocone_μF. *)
-(*   intros HH. *)
-(*   apply maponpaths. *)
-(*   apply HH. *)
-(* Defined. *)
-
-(* Lemma cocone_F' : cocone FchnF μF. *)
-(* Proof. *)
-(* use mk_cocone. *)
-(* - intros n. *)
-(*   apply (e (S n)). *)
-(* - intros m n []; clear n. *)
-(*   apply (coconeInCommutes (colimCocone (CC chnF)) (S m) _ (idpath _)). *)
-(* Defined. *)
-
-Lemma e_comm (n : nat) : e (S n) = # F (e n) ;; inF.
+Local Lemma e_comm (n : nat) : e (S n) = # F (e n) ;; inF.
 Proof.
-apply pathsinv0, (colimArrowCommutes (mk_ColimCocone _ _ _ (HF _ _ _ (isColimCocone_from_ColimCocone (CC chnF))))).
+apply pathsinv0,
+      (colimArrowCommutes (mk_ColimCocone _ _ _ (HF _ _ _ (isColimCocone_from_ColimCocone (CC chnF))))).
 Qed.
 
 Context {D : precategory} (hsD : has_homsets D).
 
 Section the_iteration_principle.
 
-Variables (X : D) (L : functor C D).
-Hypothesis (IL : isInitial D (L 0)) (HL : is_omega_cocont L).
+Variables (X : D) (L : functor C D) (IL : isInitial D (L 0)) (HL : is_omega_cocont L).
 
 Let ILD : Initial D := tpair _ _ IL.
 Local Notation "'L0'" := (InitialObject ILD).
@@ -99,37 +83,24 @@ Definition ψ_target : functor C^op HSET := functor_composite (functor_opp F) ψ
 
 Section general_case.
 
-
-Variable ψ : ψ_source ⟶ ψ_target.
+Variable (ψ : ψ_source ⟶ ψ_target).
 
 Let LchnF : chain D := mapchain L chnF.
 
-(* Definition iter_functor' {C' : precategory} (F' : functor C' C') (n : nat) : functor C' C'. *)
-(* Proof. *)
-(*   induction n as [ | n IHn]. *)
-(*   - apply functor_identity. *)
-(*   - apply (functor_composite F' IHn). *)
-(* Defined. *)
-
-Definition Pow_source : functor C^op HSET := ψ_source.
-Definition Pow_target (n : nat) : functor C^op HSET :=
+Local Definition Pow_source : functor C^op HSET := ψ_source.
+Local Definition Pow_target (n : nat) : functor C^op HSET :=
   functor_composite (functor_opp (iter_functor F n)) ψ_source.
 
-Definition Pow (n : nat) : Pow_source ⟶ Pow_target n.
+Local Definition Pow (n : nat) : Pow_source ⟶ Pow_target n.
 Proof.
 induction n as [|n Pown].
 - apply nat_trans_id.
 - apply (nat_trans_comp Pown (pre_whisker (functor_opp (iter_functor F n)) ψ)).
 Defined.
 
-Lemma PowSn (n : nat) : Pow (S n) = nat_trans_comp (Pow n) (pre_whisker (functor_opp (iter_functor F n)) ψ).
-Proof.
-apply idpath.
-Qed.
-
 Local Definition z : D⟦L0,X⟧ := InitialArrow ILD X.
 
-Lemma Pow_cocone_subproof n :
+Local Lemma Pow_cocone_subproof n :
   dmor LchnF (idpath (S n)) ;; pr1 (Pow (S n)) IC z = pr1 (Pow n) IC z.
 Proof.
 induction n as [|n IHn].
@@ -142,7 +113,7 @@ induction n as [|n IHn].
   now rewrite H, IHn.
 Qed.
 
-Definition Pow_cocone : cocone LchnF X.
+Local Definition Pow_cocone : cocone LchnF X.
 Proof.
 use mk_cocone.
 - intro n.
@@ -150,7 +121,7 @@ use mk_cocone.
 - abstract (intros n m []; clear m; apply Pow_cocone_subproof).
 Defined.
 
-Definition temp : ColimCocone LchnF.
+Local Definition CC_LchnF : ColimCocone LchnF.
 Proof.
 use mk_ColimCocone.
 - apply (L μF).
@@ -158,17 +129,14 @@ use mk_ColimCocone.
 - apply HL, (isColimCocone_from_ColimCocone (CC chnF)).
 Defined.
 
-Definition preIt : D⟦L μF,X⟧.
-Proof.
-apply (@colimArrow D nat_graph LchnF temp X Pow_cocone).
-Defined.
+Definition preIt : D⟦L μF,X⟧ := colimArrow CC_LchnF X Pow_cocone.
 
-Lemma eqSS n : # L (e n) ;; preIt = Pow n IC z.
+Local Lemma eqSS n : # L (e n) ;; preIt = Pow n IC z.
 Proof.
-apply (colimArrowCommutes temp).
+apply (colimArrowCommutes CC_LchnF).
 Qed.
 
-Lemma is_iso_inF : is_iso inF.
+Local Lemma is_iso_inF : is_iso inF.
 Proof.
 (* Use Lambek's lemma, this could be extracted from the concrete proof as well *)
 apply (initialAlg_is_iso _ hsC), pr2.
@@ -176,71 +144,6 @@ Defined.
 
 Let inF_iso : iso (F μF) μF := isopair _ is_iso_inF.
 Let inF_inv : C⟦μF,F μF⟧ := inv_from_iso inF_iso.
-
-(* The direction ** -> * *)
-Lemma SS_imp_S (H : Π n, # L (e n) ;; preIt = Pow n IC z) : # L inF ;; preIt = ψ μF preIt.
-Proof.
-assert (H' : Π n, # L (e (S n)) ;; # L inF_inv ;; ψ μF preIt = pr1 (Pow (S n)) _ z).
-{ intro n.
-  rewrite e_comm, functor_comp.
-  eapply pathscomp0.
-  eapply cancel_postcomposition.
-  rewrite <-assoc.
-  eapply maponpaths.
-  rewrite <- functor_comp.
-  generalize (iso_inv_after_iso inF_iso).
-  simpl.
-  intros XXX.
-  eapply maponpaths.
-  apply XXX.
-  rewrite functor_id.
-  rewrite id_right.
-  assert (H1 : # L (# F (e n)) ;; ψ μF preIt = ψ (iter_functor F n 0) (# L (e n) ;; preIt)).
-      apply pathsinv0, (toforallpaths _ _ _ (nat_trans_ax ψ _ _ (e n))).
-  eapply pathscomp0. apply H1.
-  rewrite H.
-  apply idpath.
-}
-assert (HH : preIt = # L inF_inv ;; ψ μF preIt).
-apply pathsinv0.
-(* transparent assert (apa : (iso (L (F μF)) (L μF))). *)
-(* apply (isopair (# L inF)), functor_on_iso_is_iso. *)
-(* apply pathsinv0, (@iso_inv_to_left _ _ _ _ apa preIt (ψ μF preIt)). *)
-
-apply (colimArrowUnique temp); simpl; intro n.
-destruct n.
-- apply (InitialArrowUnique ILD).
-- simpl.
-  eapply pathscomp0.
-  Focus 2.
-  apply H'.
-  rewrite assoc.
-  apply idpath.
-- eapply pathscomp0. eapply maponpaths.
-  apply HH.
-  rewrite assoc, <- functor_comp.
-  unfold inF_inv.
-  generalize (iso_inv_after_iso inF_iso).
-  simpl.
-  intros XXX.
-  rewrite XXX.
-  now rewrite functor_id, id_left.
-Qed.
-
-(* General version, not needed? *)
-(* Lemma SS_imp_S h (H : Π n, # L (e n) ;; h = Pow n IC z) : # L inF ;; h = ψ μF h. *)
-(* Proof. *)
-(* assert (H' : Π n, # L (e (S n)) ;; # L inF_inv ;; ψ μF h = pr1 (Pow (S n)) _ z). *)
-(* admit. *)
-(* generalize (@colimArrowUnique D nat_graph LchnF temp X). *)
-(* Check (# L inF_inv ;; ψ μF h). *)
-(* Check (# L inF). *)
-(* transparent assert (apa : (iso (L (F μF)) (L μF))). *)
-(* apply (isopair (# L inF)), functor_on_iso_is_iso. *)
-(* apply pathsinv0, (@iso_inv_to_left _ _ _ _ apa h (ψ μF h)). *)
-(* Check colimArrowUnique. *)
-(* Qed. *)
-
 
 (* The direction * -> ** *)
 Lemma S_imp_SS h n : # L inF ;; h = ψ μF h → # L (e n) ;; h = Pow n IC z.
@@ -255,22 +158,45 @@ induction n.
   now rewrite H, IHn.
 Qed.
 
+(* The direction ** -> * *)
+Local Lemma SS_imp_S (H : Π n, # L (e n) ;; preIt = Pow n IC z) : # L inF ;; preIt = ψ μF preIt.
+Proof.
+assert (H'' : # L inF ;; # L inF_inv = identity _).
+{ rewrite <- functor_comp,  <- functor_id.
+   apply maponpaths, (iso_inv_after_iso inF_iso). }
+assert (H' : Π n, # L (e (S n)) ;; # L inF_inv ;; ψ μF preIt = pr1 (Pow (S n)) _ z).
+{ intro n.
+  rewrite e_comm, functor_comp.
+  eapply pathscomp0;
+   [apply cancel_postcomposition; rewrite <-assoc;  apply maponpaths, H''|].
+  rewrite id_right.
+  assert (H1 : # L (# F (e n)) ;; ψ μF preIt = ψ (iter_functor F n 0) (# L (e n) ;; preIt)).
+  { apply pathsinv0, (toforallpaths _ _ _ (nat_trans_ax ψ _ _ (e n))). }
+  eapply pathscomp0; [ apply H1|].
+  now rewrite H.
+}
+assert (HH : preIt = # L inF_inv ;; ψ μF preIt).
+{ apply pathsinv0, (colimArrowUnique CC_LchnF); simpl; intro n.
+  destruct n.
+  - apply (InitialArrowUnique ILD).
+  - simpl; eapply pathscomp0; [| apply H'].
+    now apply assoc.
+}
+eapply pathscomp0; [ apply maponpaths, HH|].
+now rewrite assoc, H'', id_left.
+Qed.
+
 Lemma preIt_ok : # L inF ;; preIt = ψ μF preIt.
 Proof.
-apply SS_imp_S; intro n; apply eqSS.
+now apply SS_imp_S; intro n; apply eqSS.
 Qed.
 
 Lemma preIt_uniq (t : Σ h, # L inF ;; h = ψ μF h) : t = (preIt,,preIt_ok).
 Proof.
-apply subtypeEquality.
-- intros f; apply hsD.
-- simpl.
-  destruct t as [f Hf]; simpl.
-  unfold preIt.
-  apply (colimArrowUnique temp); intro n.
-  simpl.
-  apply S_imp_SS.
-  apply Hf.
+apply subtypeEquality; [intros f; apply hsD|]; simpl.
+destruct t as [f Hf]; simpl.
+apply (colimArrowUnique CC_LchnF); intro n.
+now apply S_imp_SS, Hf.
 Qed.
 
 Theorem GenMendlerIteration : ∃! (h : L μF --> X), #L inF ;; h = ψ μF h.
@@ -284,7 +210,7 @@ Definition It : L μF --> X := pr1 (pr1 GenMendlerIteration).
 
 Lemma It_is_preIt : It = preIt.
 Proof.
-  apply idpath.
+apply idpath.
 Qed.
 
 End general_case.
@@ -357,266 +283,3 @@ Qed.
 
 End fusion_law.
 End GenMenIt.
-
-
-(********* OLD STUFF *)
-(** * Generalized Iteration in Mendler-style *)
-
-(* Section GenMenIt. *)
-
-(* Variable C : precategory. *)
-(* Variable hsC : has_homsets C. *)
-
-(* Variable F : functor C C. *)
-
-(* Let AF := FunctorAlg F hsC. *)
-
-(* Definition AlgConstr (A : C) (α : F A --> A) : AF. *)
-(* Proof. *)
-(*   exists A. *)
-(*   exact α. *)
-(* Defined. *)
-
-(* Notation "⟨ A , α ⟩" := (AlgConstr A α). *)
-(* (* \<  , \> *) *)
-
-(* Variable μF_Initial : Initial AF. *)
-
-(* Let μF : C := alg_carrier _ (InitialObject μF_Initial). *)
-(* Let inF : F μF --> μF := alg_map _ (InitialObject μF_Initial). *)
-
-(* Let iter {A : C} (α : F A --> A) : μF --> A := *)
-(*   ↓(InitialArrow μF_Initial ⟨A,α⟩). *)
-
-(* Variable C' : precategory. *)
-(* Variable hsC' : has_homsets C'. *)
-
-
-(* Section the_iteration_principle. *)
-
-(* Variable X : C'. *)
-
-(* Let Yon : functor C'^op HSET := yoneda_objects C' hsC' X. *)
-
-(* Variable L : functor C C'. *)
-
-(* Variable is_left_adj_L : is_left_adjoint L. *)
-
-(* Let φ := @φ_adj _ _ _ is_left_adj_L. *)
-(* Let φ_inv := @φ_adj_inv _ _ _ is_left_adj_L. *)
-(* Let R : functor _ _ := right_adjoint is_left_adj_L. *)
-(* Let η : nat_trans _ _ := unit_from_left_adjoint is_left_adj_L. *)
-(* Let ε : nat_trans _ _ := counit_from_left_adjoint is_left_adj_L. *)
-(* (* Let φ_natural_precomp := @φ_adj_natural_precomp _ _ _ is_left_adj_L. *)
-(* Let φ_inv_natural_precomp := @φ_adj_inv_natural_precomp _ _ _ is_left_adj_L. *)
-(* Let φ_after_φ_inv := @φ_adj_after_φ_adj_inv _ _ _ is_left_adj_L. *)
-(* Let φ_inv_after_φ := @φ_adj_inv_after_φ_adj _ _ _ is_left_adj_L.*) *)
-
-
-(* Arguments φ {_ _} _ . *)
-(* Arguments φ_inv {_ _} _ . *)
-
-(* Definition ψ_source : functor C^op HSET := functor_composite (functor_opp L) Yon. *)
-(* Definition ψ_target : functor C^op HSET := functor_composite (functor_opp F) ψ_source. *)
-
-(* Section general_case. *)
-
-(* Variable ψ : ψ_source ⟶ ψ_target. *)
-
-(* Definition preIt : L μF --> X := φ_inv (iter (φ (ψ (R X) (ε X)))). *)
-
-
-(* Lemma ψ_naturality (A B: C)(h: B --> A)(f: L A --> X): ψ B (#L h;; f) = #L (#F h);; ψ A f. *)
-(* Proof. *)
-(*   assert (ψ_is_nat := nat_trans_ax ψ); *)
-(*   assert (ψ_is_nat_inst1 := ψ_is_nat _ _ h). *)
-(*   (* assert (ψ_is_nat_inst2 := aux0 _ _ _ _ f ψ_is_nat_inst1). *) *)
-(*   assert (ψ_is_nat_inst2 := toforallpaths _ _ _ ψ_is_nat_inst1 f). *)
-(*   apply ψ_is_nat_inst2. *)
-(* Qed. *)
-
-(* Lemma truth_about_ε (A: C'): ε A = φ_inv (identity (R A)). *)
-(* Proof. *)
-(*   unfold φ_inv, φ_adj_inv. *)
-(*   rewrite functor_id. *)
-(*   apply pathsinv0. *)
-(*   apply id_left. *)
-(* Qed. *)
-
-(* Lemma φ_ψ_μF_eq (h: L μF --> X): φ (ψ μF h) = #F (φ h) ;; φ(ψ (R X) (ε X)). *)
-(* Proof. *)
-(*   rewrite <- φ_adj_natural_precomp. *)
-(*   apply maponpaths. *)
-(*   eapply pathscomp0. *)
-(* Focus 2. *)
-(*   apply ψ_naturality. *)
-(*   apply maponpaths. *)
-(*   rewrite truth_about_ε. *)
-(*   rewrite <- (φ_adj_inv_natural_precomp _ _ _ is_left_adj_L). *)
-(*   rewrite id_right. *)
-(*   apply pathsinv0. *)
-(*   change (φ_inv(φ h) = h). *)
-(*   apply φ_adj_inv_after_φ_adj. *)
-(* Qed. *)
-
-(* Lemma cancel_φ {A: C}{B: C'} (f g : L A --> B): φ f = φ g -> f = g. *)
-(* Proof. *)
-(*   intro Hyp. *)
-(* (* pedestrian way: *)
-(*   rewrite <- (φ_adj_inv_after_φ_adj _ _ _ is_left_adj_L f). *)
-(*   rewrite <- (φ_adj_inv_after_φ_adj _ _ _ is_left_adj_L g). *)
-(*   apply maponpaths. *)
-(*   exact Hyp. *)
-(* *) *)
-(*   apply (invmaponpathsweq (adjunction_hom_weq _ _ _ is_left_adj_L _ _)). *)
-(*   exact Hyp. *)
-(* Qed. *)
-
-(* Lemma preIt_ok : # L inF;; preIt = ψ μF preIt. *)
-(* Proof. *)
-(*     apply cancel_φ. *)
-(*     rewrite φ_ψ_μF_eq. *)
-(*     rewrite (φ_adj_natural_precomp _ _ _ is_left_adj_L). *)
-(*     unfold preIt. *)
-(*     rewrite φ_adj_after_φ_adj_inv. *)
-(*     rewrite (φ_adj_after_φ_adj_inv _ _ _ is_left_adj_L). *)
-(*     assert (iter_eq := algebra_mor_commutes _ _ _ (InitialArrow μF_Initial ⟨_,φ (ψ (R X) (ε X))⟩)). *)
-(*     exact iter_eq. *)
-(* Qed. *)
-
-(* Lemma preIt_uniq (t : Σ h : L μF --> X, # L inF;; h = ψ μF h): *)
-(*     t = tpair (λ h : L μF --> X, # L inF;; h = ψ μF h) preIt preIt_ok. *)
-(* Proof. *)
-(*     destruct t as [h h_rec_eq]; simpl. *)
-(*     assert (same: h = preIt). *)
-(* Focus 2. *)
-(*     apply subtypeEquality. *)
-(*     + intro. *)
-(*       simpl. *)
-(*       apply hsC'. *)
-(* Focus 2. *)
-(*     simpl. *)
-(*     exact same. *)
-
-(*     apply cancel_φ. *)
-(*     unfold preIt. *)
-(*     rewrite (φ_adj_after_φ_adj_inv _ _ _ is_left_adj_L). *)
-(*     (* assert (iter_uniq := algebra_mor_commutes _ _ _ *) *)
-(*     (*                        (InitialArrow μF_Initial ⟨_,φ (ψ (R X) (ε X))⟩)). *) *)
-(*     (* simpl in iter_uniq. *) *)
-(*     assert(φh_is_alg_mor: inF ;; φ h = #F(φ h) ;; φ (ψ (R X) (ε X))). *)
-(*       (* remark: I am missing a definition of the algebra morphism property in UniMath.CategoryTheory.FunctorAlgebras *) *)
-(*     + rewrite <- φ_ψ_μF_eq. *)
-(*       rewrite <- φ_adj_natural_precomp. *)
-(*       apply maponpaths. *)
-(*       exact h_rec_eq. *)
-(*     + (* set(φh_alg_mor := tpair _ _ φh_is_alg_mor : pr1 μF_Initial --> ⟨ R X, φ (ψ (R X) (ε X)) ⟩). *) *)
-(*        simple refine (let X : AF ⟦ InitialObject μF_Initial, ⟨ R X, φ (ψ (R X) (ε X)) ⟩ ⟧ := _ in _). *)
-(*        * apply (tpair _ (φ h)); assumption. *)
-(*        * apply (maponpaths pr1 (InitialArrowUnique _ _ X0)). *)
-(* Qed. *)
-
-(* Theorem GenMendlerIteration : iscontr (Σ h : L μF --> X, #L inF ;; h = ψ μF h). *)
-(* Proof. *)
-(*   simple refine (tpair _ _ _ ). *)
-(*   - exists preIt. *)
-(*     exact preIt_ok. *)
-(*   - exact preIt_uniq. *)
-(* Defined. *)
-
-(* Definition It : L μF --> X := pr1 (pr1 GenMendlerIteration). *)
-(* Lemma It_is_preIt : It = preIt. *)
-(* Proof. *)
-(*   apply idpath. *)
-(* Qed. *)
-
-(* End general_case. *)
-
-(* (** * Specialized Mendler Iteration *) *)
-
-(* Section special_case. *)
-
-(*   Variable G : functor C' C'. *)
-(*   Variable ρ : G X --> X. *)
-(*   Variable θ : functor_composite F L ⟶ functor_composite L G. *)
-
-
-(*   Lemma is_nat_trans_ψ_from_comps *)
-(*         :  is_nat_trans ψ_source ψ_target *)
-(*                         (λ (A : C^op) (f : yoneda_objects_ob C' X (L A)), θ A;; # G f;; ρ). *)
-(*   Proof. *)
-(*     intros A B h. *)
-(*       apply funextfun. *)
-(*       intro f. *)
-(*       simpl. *)
-(*       unfold compose at 1 5; simpl. *)
-(*       rewrite functor_comp. *)
-(*       repeat rewrite assoc. *)
-(*       assert (θ_nat_trans_ax := nat_trans_ax θ). *)
-(*       unfold functor_composite in θ_nat_trans_ax. *)
-(*       simpl in θ_nat_trans_ax. *)
-(*       rewrite <- θ_nat_trans_ax. *)
-(*       apply idpath. *)
-(*    Qed. *)
-
-(*   Definition ψ_from_comps : ψ_source ⟶ ψ_target. *)
-(*   Proof. *)
-(*     simple refine (tpair _ _ _ ). *)
-(*     - intro A. simpl. intro f. *)
-(*       unfold yoneda_objects_ob in *. *)
-(*       exact (θ A ;; #G f ;; ρ). *)
-(*     - apply is_nat_trans_ψ_from_comps. *)
-(*   Defined. *)
-
-
-(*   Definition SpecialGenMendlerIteration : *)
-(*     iscontr *)
-(*       (Σ h : L μF --> X, # L inF ;; h = θ μF ;; #G h ;; ρ) *)
-(*     := GenMendlerIteration ψ_from_comps. *)
-
-(* End special_case. *)
-
-(* End the_iteration_principle. *)
-
-(* (** * Fusion law for Generalized Iteration in Mendler-style *) *)
-
-(* Variable X X': C'. *)
-(* Let Yon : functor C'^op HSET := yoneda_objects C' hsC' X. *)
-(* Let Yon' : functor C'^op HSET := yoneda_objects C' hsC' X'. *)
-(* Variable L : functor C C'. *)
-(* Variable is_left_adj_L : is_left_adjoint L. *)
-(* Variable ψ : ψ_source X L ⟶ ψ_target X L. *)
-(* Variable L' : functor C C'. *)
-(* Variable is_left_adj_L' : is_left_adjoint L'. *)
-(* Variable ψ' : ψ_source X' L' ⟶ ψ_target X' L'. *)
-
-(* Variable Φ : functor_composite (functor_opp L) Yon ⟶ functor_composite (functor_opp L') Yon'. *)
-
-(* Section fusion_law. *)
-
-(*   Variable H : ψ μF ;; Φ (F μF) = Φ μF ;; ψ' μF. *)
-
-(*   Theorem fusion_law : Φ μF (It X L is_left_adj_L ψ) = It X' L' is_left_adj_L' ψ'. *)
-(*   Proof. *)
-(*     apply pathsinv0. *)
-(*     apply pathsinv0. *)
-(*     apply path_to_ctr. *)
-(*     assert (Φ_is_nat := nat_trans_ax Φ). *)
-(*     assert (Φ_is_nat_inst1 := Φ_is_nat _ _ inF). *)
-(*     assert (Φ_is_nat_inst2 := toforallpaths _ _ _ Φ_is_nat_inst1 (It X L is_left_adj_L ψ)). *)
-(*     unfold compose in Φ_is_nat_inst2; simpl in Φ_is_nat_inst2. *)
-(*     simpl. *)
-(*     rewrite <- Φ_is_nat_inst2. *)
-(*     assert (H_inst :=  toforallpaths _ _ _ H (It X L is_left_adj_L ψ)). *)
-(*     unfold compose in H_inst; simpl in H_inst. *)
-(*     rewrite <- H_inst. *)
-(*     apply maponpaths. *)
-(*     rewrite It_is_preIt. *)
-(*     apply preIt_ok. *)
-(*   Qed. *)
-
-(* End fusion_law. *)
-
-
-
-(* End GenMenIt. *)

--- a/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
@@ -86,46 +86,33 @@ End general_case.
 (** * Specialized Mendler Iteration *)
 Section special_case.
 
-  Variable G : functor D D.
-  Variable ρ : G X --> X.
-  Variable θ : functor_composite F L ⟶ functor_composite L G.
+Variables (G : functor D D) (ρ : G X --> X).
+Variables (θ : functor_composite F L ⟶ functor_composite L G).
 
-  Lemma is_nat_trans_ψ_from_comps
-        :  is_nat_trans ψ_source ψ_target
-                        (λ (A : C^op) (f : yoneda_objects_ob D X (L A)), θ A;; # G f;; ρ).
-  Proof.
-    intros A B h.
-      apply funextfun.
-      intro f.
-      simpl.
-      unfold compose at 1 5; simpl.
-      rewrite functor_comp.
-      repeat rewrite assoc.
-      assert (θ_nat_trans_ax := nat_trans_ax θ).
-      unfold functor_composite in θ_nat_trans_ax.
-      simpl in θ_nat_trans_ax.
-      rewrite <- θ_nat_trans_ax.
-      apply idpath.
-   Qed.
+Lemma is_nat_trans_ψ_from_comps :
+        is_nat_trans ψ_source ψ_target
+          (λ A (f : yoneda_objects_ob D X (L A)), θ A ;; # G f ;; ρ).
+Proof.
+intros A B h; apply funextfun; intro f; cbn.
+rewrite functor_comp, !assoc.
+assert (θ_nat_trans_ax := nat_trans_ax θ); simpl in θ_nat_trans_ax.
+now rewrite <- θ_nat_trans_ax.
+Qed.
 
-  Definition ψ_from_comps : ψ_source ⟶ ψ_target.
-  Proof.
-    simple refine (tpair _ _ _ ).
-    - intro A. simpl. intro f.
-      unfold yoneda_objects_ob in *.
-      exact (θ A ;; #G f ;; ρ).
-    - apply is_nat_trans_ψ_from_comps.
-  Defined.
+Definition ψ_from_comps : ψ_source ⟶ ψ_target.
+Proof.
+mkpair.
+- intros A f.
+  exact (θ A ;; #G f ;; ρ).
+- apply is_nat_trans_ψ_from_comps.
+Defined.
 
-
-  Definition SpecialGenMendlerIteration :
-    iscontr
-      (Σ h : L μF --> X, # L inF ;; h = θ μF ;; #G h ;; ρ)
+Definition SpecialGenMendlerIteration :
+  ∃! (h : L μF --> X), # L inF ;; h = θ μF ;; #G h ;; ρ
     := GenMendlerIteration ψ_from_comps.
 
 End special_case.
 End the_iteration_principle.
-
 
 (** * Fusion law for Generalized Iteration in Mendler-style *)
 Section fusion_law.

--- a/UniMath/SubstitutionSystems/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial_alt.v
@@ -89,7 +89,7 @@ apply is_omega_cocont_BinCoproduct_of_functors; try apply functor_category_has_h
 Defined.
 
 Definition InitAlg : Alg :=
-  InitialObject (μF_Initial hsEndC InitialEndC Colims_of_shape_nat_graph_EndC Id_H is_omega_cocont_Id_H).
+  InitialObject (colimAlgInitial hsEndC InitialEndC is_omega_cocont_Id_H (Colims_of_shape_nat_graph_EndC _)).
 
 Lemma isInitial_pre_comp (Z : Ptd) : isInitial [C, C, hsC] (ℓ (U Z) InitialEndC).
 Proof.

--- a/UniMath/SubstitutionSystems/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial_alt.v
@@ -488,7 +488,7 @@ mkpair.
             apply pathsinv0, assoc).
 Defined.
 
-Let IA := μF_Initial hsEndC InitialEndC Colims_of_shape_nat_graph_EndC Id_H is_omega_cocont_Id_H.
+Let IA := colimAlgInitial hsEndC InitialEndC is_omega_cocont_Id_H (Colims_of_shape_nat_graph_EndC _).
 
 Lemma ishssMor_InitAlg (T' : hss CP H) :
   @ishssMor C hsC CP H InitHSS T'

--- a/UniMath/SubstitutionSystems/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial_alt.v
@@ -42,6 +42,9 @@ Variable hs : has_homsets C.
 
 Variable CP : BinCoproducts C.
 
+Variables (IC : Initial C) (CC : Colims_of_shape nat_graph C).
+Variables (BPC : BinProducts C).
+
 Local Notation "'EndC'":= ([C, C, hs]) .
 Local Notation "'Ptd'" := (precategory_Ptd C hs).
 
@@ -56,6 +59,8 @@ Let CPEndEndC:= BinCoproducts_functor_precat _ _ CPEndC hsEndC: BinCoproducts En
 Variable H : Signature C hs.
 Let θ := theta H.
 
+Variable (HH : is_omega_cocont H).
+
 Definition Const_plus_H (X : EndC) : functor EndC EndC
   := BinCoproduct_of_functors _ _ CPEndC (constant_functor _ _ X) H.
   (* := sum_of_functors CPEndC (constant_functor _ _ X) H. *)
@@ -65,52 +70,32 @@ Definition Id_H :  functor [C, C, hs] [C, C, hs]
 
 Let Alg : precategory := FunctorAlg Id_H hsEndC.
 
-
-(* Variables (IC : Initial C) (CC : Colims_of_shape nat_graph C) (F : functor C C) *)
-(*           (HF : is_omega_cocont F). *)
-
-
-(* SpecialGenMendlerIteration : *)
-(* Π (C : precategory) (hsC : has_homsets C) (IC : Initial C) *)
-(* (CC : Colims_of_shape nat_graph C) (F : functor C C)  *)
-(* (HF : is_omega_cocont F) (D : precategory), *)
-(* has_homsets D *)
-(* → Π (X : D) (L : functor C D), *)
-(*   isInitial D (L IC) *)
-(*   → is_omega_cocont L *)
-(*     → Π (G : functor D D) (ρ : D ⟦ G X, X ⟧) *)
-(*       (θ : functor_composite F L ⟶ functor_composite L G), *)
-(*       ∃! h : D ⟦ L (μF_Initial hsC IC CC F HF), X ⟧, *)
-(*       # L (alg_map F (μF_Initial hsC IC CC F HF)) ;; h = *)
-(*       θ (μF_Initial hsC IC CC F HF) ;; # G h ;; ρ *)
-
-(* SpecialGenMendlerIteration : *)
-(* Π (C : precategory) (hsC : has_homsets C) (F : functor C C) *)
-(* (μF_Initial : Initial (FunctorAlg F hsC)) (C' : precategory), *)
-(* has_homsets C' *)
-(* → Π (X : C') (L : functor C C'), *)
-(*   equivalences.is_left_adjoint L *)
-(*   → Π (G : functor C' C') (ρ : C' ⟦ G X, X ⟧) *)
-(*     (θ : functor_composite F L ⟶ functor_composite L G), *)
-(*     ∃! h : C' ⟦ L μF_Initial, X ⟧, *)
-(*     # L (alg_map F μF_Initial) ;; h = θ μF_Initial ;; # G h ;; ρ *)
-
-(* Variable IA : Initial Alg. *)
-
 Lemma arg1 : Initial EndC.
-Admitted.
+Proof.
+apply Initial_functor_precat, IC.
+Defined.
 
 Lemma arg2 : Colims_of_shape nat_graph EndC.
-Admitted.
+Proof.
+apply ColimsFunctorCategory_of_shape, CC.
+Defined.
 
 Lemma arg3 : is_omega_cocont Id_H.
-Admitted.
+Proof.
+unfold Id_H, Const_plus_H.
+apply is_omega_cocont_BinCoproduct_of_functors; try apply functor_category_has_homsets.
+- apply (BinProducts_functor_precat _ _ BPC).
+- apply is_omega_cocont_constant_functor, functor_category_has_homsets.
+- apply HH.
+Defined.
 
 Lemma arg4 (Z : Ptd) : isInitial [C, C, hs] (ℓ (U Z) arg1).
 Admitted.
 
 Lemma arg5 (Z : Ptd) : is_omega_cocont (pre_composition_functor C C C hs hs (U Z)).
-Admitted.
+Proof.
+apply is_omega_cocont_pre_composition_functor, CC.
+Defined.
 
 Definition SpecializedGMIt (Z : Ptd) (X : EndC) : Π (G : functor [C, C, hs] [C, C, hs]) (ρ : [C, C, hs] ⟦ G X, X ⟧)
    (θ : functor_composite Id_H (ℓ (U Z)) ⟶ functor_composite (ℓ (U Z)) G),

--- a/UniMath/SubstitutionSystems/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial_alt.v
@@ -1,0 +1,915 @@
+Set Kernel Term Sharing.
+
+Require Import UniMath.Foundations.Basics.PartD.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.Monads.
+Require Import UniMath.CategoryTheory.limits.binproducts.
+Require Import UniMath.CategoryTheory.limits.bincoproducts.
+Require Import UniMath.CategoryTheory.limits.initial.
+Require Import UniMath.CategoryTheory.FunctorAlgebras.
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.CocontFunctors.
+Require Import UniMath.CategoryTheory.opp_precat.
+Require Import UniMath.CategoryTheory.yoneda.
+Require Import UniMath.CategoryTheory.category_hset.
+Require Import UniMath.CategoryTheory.PointedFunctors.
+Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
+Require Import UniMath.CategoryTheory.HorizontalComposition.
+Require Import UniMath.CategoryTheory.PointedFunctorsComposition.
+Require Import UniMath.SubstitutionSystems.Signatures.
+Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
+Require Import UniMath.SubstitutionSystems.GenMendlerIteration_alt.
+(* Require Import UniMath.CategoryTheory.RightKanExtension. *)
+(* Require Import UniMath.SubstitutionSystems.GenMendlerIteration. *)
+Require Import UniMath.CategoryTheory.EndofunctorsMonoidal.
+Require Import UniMath.SubstitutionSystems.Notation.
+
+Local Coercion alg_carrier : algebra_ob >-> ob.
+
+Arguments θ_source {_ _} _ .
+Arguments θ_target {_ _} _ .
+Arguments θ_Strength1 {_ _ _} _ .
+Arguments θ_Strength2 {_ _ _} _ .
+
+Section Precategory_Algebra.
+
+Variable C : precategory.
+Variable hs : has_homsets C.
+
+Variable CP : BinCoproducts C.
+
+Local Notation "'EndC'":= ([C, C, hs]) .
+Local Notation "'Ptd'" := (precategory_Ptd C hs).
+
+Let hsEndC : has_homsets EndC := functor_category_has_homsets C C hs.
+Let CPEndC : BinCoproducts EndC := BinCoproducts_functor_precat _ _ CP hs.
+Let EndEndC := [EndC, EndC, hsEndC].
+Let CPEndEndC:= BinCoproducts_functor_precat _ _ CPEndC hsEndC: BinCoproducts EndEndC.
+
+
+(* Variable KanExt : Π Z : Ptd, GlobalRightKanExtensionExists _ _ (U Z) _ hs hs. *)
+
+Variable H : Signature C hs.
+Let θ := theta H.
+
+Definition Const_plus_H (X : EndC) : functor EndC EndC
+  := BinCoproduct_of_functors _ _ CPEndC (constant_functor _ _ X) H.
+  (* := sum_of_functors CPEndC (constant_functor _ _ X) H. *)
+
+Definition Id_H :  functor [C, C, hs] [C, C, hs]
+ := Const_plus_H (functor_identity _ : EndC).
+
+Let Alg : precategory := FunctorAlg Id_H hsEndC.
+
+
+(* Variables (IC : Initial C) (CC : Colims_of_shape nat_graph C) (F : functor C C) *)
+(*           (HF : is_omega_cocont F). *)
+
+
+(* SpecialGenMendlerIteration : *)
+(* Π (C : precategory) (hsC : has_homsets C) (IC : Initial C) *)
+(* (CC : Colims_of_shape nat_graph C) (F : functor C C)  *)
+(* (HF : is_omega_cocont F) (D : precategory), *)
+(* has_homsets D *)
+(* → Π (X : D) (L : functor C D), *)
+(*   isInitial D (L IC) *)
+(*   → is_omega_cocont L *)
+(*     → Π (G : functor D D) (ρ : D ⟦ G X, X ⟧) *)
+(*       (θ : functor_composite F L ⟶ functor_composite L G), *)
+(*       ∃! h : D ⟦ L (μF_Initial hsC IC CC F HF), X ⟧, *)
+(*       # L (alg_map F (μF_Initial hsC IC CC F HF)) ;; h = *)
+(*       θ (μF_Initial hsC IC CC F HF) ;; # G h ;; ρ *)
+
+(* SpecialGenMendlerIteration : *)
+(* Π (C : precategory) (hsC : has_homsets C) (F : functor C C) *)
+(* (μF_Initial : Initial (FunctorAlg F hsC)) (C' : precategory), *)
+(* has_homsets C' *)
+(* → Π (X : C') (L : functor C C'), *)
+(*   equivalences.is_left_adjoint L *)
+(*   → Π (G : functor C' C') (ρ : C' ⟦ G X, X ⟧) *)
+(*     (θ : functor_composite F L ⟶ functor_composite L G), *)
+(*     ∃! h : C' ⟦ L μF_Initial, X ⟧, *)
+(*     # L (alg_map F μF_Initial) ;; h = θ μF_Initial ;; # G h ;; ρ *)
+
+(* Variable IA : Initial Alg. *)
+
+Lemma arg1 : Initial EndC.
+Admitted.
+
+Lemma arg2 : Colims_of_shape nat_graph EndC.
+Admitted.
+
+Lemma arg3 : is_omega_cocont Id_H.
+Admitted.
+
+Lemma arg4 (Z : Ptd) : isInitial [C, C, hs] (ℓ (U Z) arg1).
+Admitted.
+
+Lemma arg5 (Z : Ptd) : is_omega_cocont (pre_composition_functor C C C hs hs (U Z)).
+Admitted.
+
+Definition SpecializedGMIt (Z : Ptd) (X : EndC) : Π (G : functor [C, C, hs] [C, C, hs]) (ρ : [C, C, hs] ⟦ G X, X ⟧)
+   (θ : functor_composite Id_H (ℓ (U Z)) ⟶ functor_composite (ℓ (U Z)) G),
+   ∃! h : [C, C, hs] ⟦ ℓ (U Z) (pr1 (InitialObject (μF_Initial hsEndC arg1 arg2 Id_H arg3))), X ⟧,
+   # (ℓ (U Z)) (alg_map Id_H (InitialObject (μF_Initial hsEndC arg1 arg2 Id_H arg3))) ;; h =
+   θ (pr1 (InitialObject (μF_Initial hsEndC arg1 arg2 Id_H arg3))) ;; # G h ;; ρ
+ :=
+  SpecialGenMendlerIteration hsEndC arg1 arg2 Id_H arg3 hsEndC X (ℓ (U Z)) (arg4 Z) (arg5 Z).
+
+Definition θ_in_first_arg (Z: Ptd)
+  : functor_fix_snd_arg [C, C,hs] Ptd [C, C, hs] (θ_source H) Z
+    ⟶
+    functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_target H) Z
+  := nat_trans_fix_snd_arg _ _ _ _ _ θ Z.
+
+(* Definition InitAlg : Alg := InitialObject IA. *)
+Definition InitAlg : Alg := InitialObject (μF_Initial hsEndC arg1 arg2 Id_H arg3).
+
+
+Local Lemma aux_iso_1_is_nat_trans (Z : Ptd) :
+   is_nat_trans
+     (functor_composite Id_H (ℓ (U Z)))
+     (pr1 (BinCoproductObject EndEndC
+        (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+           (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_source H) Z))))
+     (λ X : [C, C, hs],
+      BinCoproductOfArrows [C, C, hs]
+        (CPEndC (functor_composite (U Z) (functor_identity C))
+           ((θ_source H) (X ⊗ Z))) (CPEndC (U Z) ((θ_source H) (X ⊗ Z)))
+        (ρ_functor C (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
+Proof.
+  unfold is_nat_trans; simpl.
+  intros X X' α.
+  apply nat_trans_eq; try (exact hs).
+  intro c.
+  simpl.
+  unfold coproduct_nat_trans_data; simpl.
+  unfold coproduct_nat_trans_in1_data, coproduct_nat_trans_in2_data; simpl.
+  eapply pathscomp0; [apply BinCoproductOfArrows_comp |].
+  eapply pathscomp0. Focus 2. eapply pathsinv0. apply BinCoproductOfArrows_comp.
+  apply BinCoproductOfArrows_eq.
+  - eapply pathscomp0. apply id_left.
+    apply pathsinv0.
+    apply id_right.
+  - rewrite functor_id.
+    do 2 rewrite id_right.
+    apply pathsinv0, id_left.
+Qed.
+
+Definition aux_iso_1 (Z : Ptd)
+  : EndEndC
+    ⟦ functor_composite Id_H (ℓ (U Z)),
+      BinCoproductObject EndEndC
+           (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+              (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_source H) Z))⟧.
+Proof.
+  simple refine (tpair _ _ _).
+  - intro X.
+    exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (ρ_functor _ (U Z))
+            (nat_trans_id (θ_source H (X⊗Z):functor C C))).
+  - exact (aux_iso_1_is_nat_trans Z).
+Defined.
+
+Local Lemma aux_iso_1_inv_is_nat_trans (Z : Ptd) :
+   is_nat_trans
+     (pr1 (BinCoproductObject EndEndC
+        (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+           (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_source H) Z))) )
+     (functor_composite Id_H (ℓ (U Z)))
+     (λ X : [C, C, hs],
+      BinCoproductOfArrows [C, C, hs]
+        (CPEndC (functor_composite (functor_identity C) (U Z))
+           ((θ_source H) (X ⊗ Z))) (CPEndC (U Z) ((θ_source H) (X ⊗ Z)))
+        (λ_functor C (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
+Proof.
+  unfold is_nat_trans;
+  intros X X' α.
+  apply nat_trans_eq; try (exact hs).
+  intro c; simpl.
+  unfold coproduct_nat_trans_data; simpl.
+  unfold coproduct_nat_trans_in1_data, coproduct_nat_trans_in2_data; simpl.
+  eapply pathscomp0. apply BinCoproductOfArrows_comp.
+  eapply pathscomp0. Focus 2. eapply pathsinv0. apply BinCoproductOfArrows_comp.
+  apply BinCoproductOfArrows_eq.
+  - rewrite id_right.
+    apply pathsinv0.
+    apply id_right.
+  - rewrite functor_id.
+    do 2 rewrite id_right.
+    apply pathsinv0.
+    apply id_left.
+Qed.
+
+Local Definition aux_iso_1_inv (Z: Ptd)
+  : EndEndC
+    ⟦ BinCoproductObject EndEndC
+           (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+              (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_source H) Z)),
+      functor_composite Id_H (ℓ (U Z)) ⟧.
+Proof.
+  simple refine (tpair _ _ _).
+  - intro X.
+    exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (λ_functor _ (U Z))
+           (nat_trans_id (θ_source H (X⊗Z):functor C C))).
+  - exact (aux_iso_1_inv_is_nat_trans Z).
+Defined.
+
+(*
+Definition G_Thm15 (X : EndC) := coproduct_functor _ _ CPEndC
+                       (constant_functor _ _ X)
+                       H.
+ *)
+
+Local Lemma aux_iso_2_inv_is_nat_trans (Z : Ptd) :
+   is_nat_trans
+     (pr1 (BinCoproductObject EndEndC
+        (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+           (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs](θ_target H) Z))) )
+     (functor_composite (ℓ (U Z))
+        (Const_plus_H (U Z)))
+     (λ X : [C, C, hs],
+      nat_trans_id
+        (BinCoproductObject [C, C, hs] (CPEndC (U Z) ((θ_target H) (X ⊗ Z)))
+         :functor C C)).
+Proof.
+  unfold is_nat_trans; simpl.
+  intros X X' α.
+  rewrite (@id_left EndC).
+  rewrite (@id_right EndC).
+  apply nat_trans_eq; try (exact hs).
+  intro c; simpl.
+  unfold coproduct_nat_trans_data; simpl.
+  unfold coproduct_nat_trans_in1_data, coproduct_nat_trans_in2_data; simpl.
+  apply BinCoproductOfArrows_eq.
+  + apply idpath.
+  + unfold functor_fix_snd_arg_mor; simpl.
+    unfold θ_target_mor; simpl.
+    revert c.
+    apply nat_trans_eq_pointwise.
+    apply maponpaths.
+    apply nat_trans_eq; try (exact hs).
+    intro c.
+    simpl.
+    rewrite <- (nat_trans_ax α).
+    rewrite functor_id.
+    apply id_left.
+Qed.
+
+Local Definition aux_iso_2_inv (Z : Ptd)
+  : EndEndC
+    ⟦ BinCoproductObject EndEndC
+         (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+                    (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_target H) Z)),
+      functor_composite (ℓ (U Z) )   (Const_plus_H (U Z)) ⟧.
+Proof.
+  simple refine (tpair _ _ _).
+  - intro X.
+    exact (nat_trans_id ((@BinCoproductObject EndC (U Z) (θ_target H (X⊗Z)) (CPEndC _ _) )
+             : functor C C)).
+  - exact (aux_iso_2_inv_is_nat_trans Z).
+Defined.
+
+Definition θ'_Thm15 (Z: Ptd)
+  : EndEndC
+    ⟦ BinCoproductObject EndEndC
+        (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+           (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_source H) Z)),
+      BinCoproductObject EndEndC
+        (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+            (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_target H) Z)) ⟧
+  := BinCoproductOfArrows
+   EndEndC (CPEndEndC _ _) (CPEndEndC _ _)
+   (identity (constant_functor EndC _ (U Z): functor_precategory EndC EndC hsEndC))
+   (θ_in_first_arg Z).
+
+Definition ρ_Thm15 (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧)
+  : [C, C, hs] ⟦ BinCoproductObject [C, C, hs] (CPEndC (U Z) (H `InitAlg)), `InitAlg ⟧
+  := @BinCoproductArrow
+   EndC _ _  (CPEndC (U Z)
+   (H (alg_carrier _ InitAlg))) (alg_carrier _ InitAlg) (#U f)
+   (BinCoproductIn2 _ (CPEndC _ _) ;; (alg_map _ InitAlg)).
+
+
+Definition SpecializedGMIt_Thm15 (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧)
+  : ∃! h : [C, C, hs]
+              ⟦ ℓ (U Z) (pr1 InitAlg),
+              pr1 InitAlg ⟧,
+       # (ℓ (U Z)) (alg_map Id_H InitAlg) ;; h =
+       pr1 (aux_iso_1 Z ;; θ'_Thm15 Z ;; aux_iso_2_inv Z)
+         (pr1 InitAlg) ;;
+       # (Const_plus_H (U Z)) h ;; ρ_Thm15 Z f :=
+   (SpecializedGMIt Z (pr1 InitAlg) (Const_plus_H (U Z))
+     (ρ_Thm15 Z f) (aux_iso_1 Z ;; θ'_Thm15 Z ;; aux_iso_2_inv Z)).
+
+Definition bracket_Thm15 (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧)
+  : [C, C, hs]
+       ⟦ ℓ (U Z) (pr1 InitAlg), pr1 InitAlg ⟧
+  := pr1 (pr1 (SpecializedGMIt_Thm15 Z f)).
+
+Notation "⦃ f ⦄" := (bracket_Thm15 _ f) (at level 0).
+
+(* we prove the individual components for ease of compilation *)
+Lemma bracket_Thm15_ok_part1 (Z: Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧):
+ # U f
+ =
+ # (pr1 (ℓ (U Z))) (η InitAlg) ;; ⦃f⦄.
+Proof.
+  apply nat_trans_eq; try (exact hs).
+  intro c.
+  assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))).
+  assert (h_eq' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
+               (((aux_iso_1_inv Z):(_⟶_)) _);; m) h_eq);
+  clear h_eq.
+  simpl in h_eq'.
+  assert (h_eq1' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
+               (BinCoproductIn1 EndC (CPEndC _ _));; m) h_eq');
+  clear h_eq'.
+  assert (h_eq1'_inst := nat_trans_eq_pointwise h_eq1' c);
+  clear h_eq1'.
+(* match goal right in the beginning in contrast with earlier approach - suggestion by Benedikt *)
+  match goal with |[ H1 : _  = ?f |- _ = _   ] =>
+         pathvia f end.
+
+  - clear h_eq1'_inst.
+    unfold coproduct_nat_trans_data; simpl.
+    unfold coproduct_nat_trans_in1_data ; simpl.
+    repeat rewrite <- assoc .
+    apply BinCoproductIn1Commutes_right_in_ctx_dir.
+    unfold λ_functor; simpl.
+    rewrite id_left.
+    apply BinCoproductIn1Commutes_right_in_ctx_dir.
+    unfold ρ_functor; simpl.
+    rewrite id_left.
+    apply BinCoproductIn1Commutes_right_in_ctx_dir.
+    rewrite (@id_left EndC).
+    rewrite id_left.
+    apply BinCoproductIn1Commutes_right_in_ctx_dir.
+    rewrite (@id_left EndC).
+    apply BinCoproductIn1Commutes_right_dir.
+    apply idpath.
+  - rewrite <- h_eq1'_inst.
+    clear h_eq1'_inst.
+    apply BinCoproductIn1Commutes_left_in_ctx_dir.
+    unfold λ_functor, nat_trans_id; simpl.
+    rewrite id_left.
+    repeat rewrite (id_left EndEndC).
+    repeat rewrite (id_left EndC).
+    unfold functor_fix_snd_arg_ob.
+    repeat rewrite assoc.
+(*    apply maponpaths. *)
+    apply idpath.
+Qed.
+
+(* produce some output to keep TRAVIS running *)
+Check bracket_Thm15_ok_part1.
+
+Lemma bracket_Thm15_ok_part2 (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧):
+ (theta H) ((alg_carrier _ InitAlg) ⊗ Z) ;;  # H ⦃f⦄ ;; τ InitAlg
+  =
+   # (pr1 (ℓ (U Z))) (τ InitAlg) ;; ⦃f⦄.
+Proof.
+  apply nat_trans_eq; try (exact hs).
+  intro c.
+  assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))).
+  assert (h_eq' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
+                  (((aux_iso_1_inv Z):(_⟶_)) _);; m) h_eq);
+  clear h_eq.
+ (*        simpl in h_eq'. (* until here same as in previous lemma *) *)
+
+  assert (h_eq2' := maponpaths (fun m:EndC⟦_,pr1 InitAlg⟧ =>
+                (BinCoproductIn2 EndC (CPEndC _ _));; m) h_eq').
+  clear h_eq'.
+  assert (h_eq2'_inst := nat_trans_eq_pointwise h_eq2' c).
+  clear h_eq2'.
+  match goal with |[ H1 : _  = ?f |- _ = _   ] =>
+                   pathvia (f) end.
+  - clear h_eq2'_inst.
+    apply BinCoproductIn2Commutes_right_in_ctx_dir.
+    unfold aux_iso_1; simpl.
+    rewrite id_right.
+    rewrite id_left.
+    do 3 rewrite <- assoc.
+    apply BinCoproductIn2Commutes_right_in_ctx_dir.
+    unfold nat_trans_id; simpl. rewrite id_left.
+    apply BinCoproductIn2Commutes_right_in_ctx_dir.
+    unfold nat_trans_fix_snd_arg_data.
+    apply BinCoproductIn2Commutes_right_in_double_ctx_dir.
+    rewrite <- assoc.
+    apply maponpaths.
+    eapply pathscomp0. Focus 2. apply assoc.
+    apply maponpaths.
+    apply pathsinv0.
+    apply BinCoproductIn2Commutes.
+
+(* alternative with slightly less precise control: *)
+(*            do 4 rewrite <- assoc. *)
+(*            apply BinCoproductIn2Commutes_right_in_ctx_dir. *)
+(*            rewrite id_left. *)
+(*            apply BinCoproductIn2Commutes_right_in_ctx_dir. *)
+(*            apply BinCoproductIn2Commutes_right_in_ctx_dir. *)
+(*            unfold nat_trans_fix_snd_arg_data. *)
+(*            rewrite id_left. *)
+(*            apply BinCoproductIn2Commutes_right_in_double_ctx_dir. *)
+(*            do 2 rewrite <- assoc. *)
+(*            apply maponpaths. *)
+(*            apply maponpaths. *)
+(*            apply pathsinv0. *)
+(*            apply BinCoproductIn2Commutes. *)
+(* *)
+
+  - rewrite <- h_eq2'_inst. clear h_eq2'_inst.
+    apply BinCoproductIn2Commutes_left_in_ctx_dir.
+    repeat rewrite id_left.
+    apply assoc.
+Qed.
+
+(* produce some output to keep TRAVIS running *)
+Check bracket_Thm15_ok_part2.
+
+
+Lemma bracket_Thm15_ok (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧)
+ : bracket_property_parts f ⦃f⦄.
+Proof.
+  split.
+  + exact (bracket_Thm15_ok_part1 Z f).
+  + exact (bracket_Thm15_ok_part2 Z f).
+Qed.
+
+Lemma bracket_Thm15_ok_cor (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧):
+ bracket_property f (bracket_Thm15 Z f).
+Proof.
+  apply whole_from_parts.
+  apply bracket_Thm15_ok.
+Qed.
+
+Local Lemma foo' (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
+ Π t : Σ h : [C, C, hs] ⟦ functor_composite (U Z) (pr1  InitAlg),
+                         pr1 InitAlg ⟧,
+       bracket_property f h,
+   t
+   =
+   tpair
+     (λ h : [C, C, hs]
+            ⟦ functor_composite (U Z) (pr1 InitAlg),
+              pr1 InitAlg ⟧,
+       bracket_property f h)
+      ⦃f⦄ (bracket_Thm15_ok_cor Z f).
+Proof.
+  intros [h' h'_eq].
+  apply subtypeEquality.
+  - intro.
+    unfold bracket_property.
+    apply isaset_nat_trans. exact hs.
+  - simpl.
+    apply parts_from_whole in h'_eq.
+(*    destruct h'_eq as [h'_eq1 h'_eq2]. *)
+    unfold bracket_Thm15.
+    apply path_to_ctr.
+    apply nat_trans_eq; try (exact hs).
+    intro c; simpl.
+    unfold coproduct_nat_trans_data.
+    repeat rewrite (@id_left EndC).
+    rewrite id_right.
+    repeat rewrite <- @assoc.
+    eapply pathscomp0. Focus 2. eapply pathsinv0. apply postcompWithBinCoproductArrow.
+    apply BinCoproductArrowUnique.
+    + destruct h'_eq as [h'_eq1 _ ]. (*clear h'_eq2.*)
+      simpl.
+      rewrite id_left.
+      assert (h'_eq1_inst := nat_trans_eq_pointwise h'_eq1 c);
+        clear h'_eq1.
+      simpl in h'_eq1_inst.
+      unfold coproduct_nat_trans_in1_data in h'_eq1_inst; simpl in h'_eq1_inst.
+      rewrite <- @assoc in h'_eq1_inst.
+      eapply pathscomp0.
+      eapply pathsinv0. exact h'_eq1_inst.
+      clear h'_eq1_inst.
+      apply BinCoproductIn1Commutes_right_in_ctx_dir.
+      apply BinCoproductIn1Commutes_right_in_ctx_dir.
+      apply BinCoproductIn1Commutes_right_dir.
+        apply idpath.
+    + destruct h'_eq as [_ h'_eq2]. (*clear h'_eq2.*)
+      assert (h'_eq2_inst := nat_trans_eq_pointwise h'_eq2 c);
+        clear h'_eq2.
+      simpl in h'_eq2_inst.
+      unfold coproduct_nat_trans_in2_data in h'_eq2_inst; simpl in h'_eq2_inst.
+      apply pathsinv0 in h'_eq2_inst.
+      rewrite <- assoc in h'_eq2_inst.
+      eapply pathscomp0. exact h'_eq2_inst. clear h'_eq2_inst.
+      apply BinCoproductIn2Commutes_right_in_ctx_dir.
+      apply BinCoproductIn2Commutes_right_in_double_ctx_dir.
+      unfold nat_trans_fix_snd_arg_data; simpl.
+      do 2 rewrite <- assoc.
+      apply maponpaths.
+      rewrite <- assoc.
+      apply maponpaths.
+      apply pathsinv0.
+      apply BinCoproductIn2Commutes.
+Qed.
+
+Definition bracket_for_InitAlg : bracket InitAlg.
+Proof.
+  intros Z f.
+  unshelve refine (tpair _ _ _ ).
+  - unshelve refine (tpair _ _ _ ).
+    + exact (bracket_Thm15 Z f).
+    + exact (bracket_Thm15_ok_cor Z f).
+       (* B: better to prove the whole outside, and apply it here *)
+     (* when the first components were not opaque, the following proof
+        became extremely slow *)
+  - apply foo'.
+Defined.
+
+(* produce some output to keep TRAVIS running *)
+Check bracket_for_InitAlg.
+
+
+Definition InitHSS : hss_precategory CP H.
+Proof.
+ (*
+  red. (* FORBIDDEN, otherwise universe problem when checking the definition *)
+  unfold hss_precategory; simpl.
+*)
+  exists (InitAlg).
+  exact bracket_for_InitAlg.
+Defined.
+
+
+Local Definition Ghat : EndEndC := Const_plus_H (pr1 InitAlg).
+
+Definition constant_nat_trans (C' D : precategory)
+   (hsD : has_homsets D)
+   (d d' : D)
+   (m : d --> d')
+    : [C', D, hsD] ⟦constant_functor C' D d, constant_functor C' D d'⟧.
+Proof.
+  exists (fun _ => m).
+  abstract (
+    intros ? ? ? ;
+    pathvia m ;
+    [
+    apply id_left |
+    apply pathsinv0 ;
+  apply id_right] ).
+Defined.
+
+Definition thetahat_0 (Z : Ptd) (f : Z --> ptd_from_alg  InitAlg):
+EndEndC
+⟦ BinCoproductObject EndEndC
+    (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+       (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_source H) Z)),
+BinCoproductObject EndEndC
+  (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (pr1 InitAlg))
+             (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_target H) Z)) ⟧ .
+Proof.
+  exact (BinCoproductOfArrows EndEndC (CPEndEndC _ _) (CPEndEndC _ _)
+                           (constant_nat_trans _ _ hsEndC _ _ (#U f))
+                           (θ_in_first_arg Z)).
+Defined.
+
+Local Definition iso1' (Z : Ptd) :  EndEndC ⟦ functor_composite Id_H
+                                        (ℓ (U Z)),
+ BinCoproductObject EndEndC
+    (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
+               (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_source H) Z)) ⟧.
+Proof.
+  exact (aux_iso_1 Z).
+Defined.
+
+
+Local Lemma is_nat_trans_iso2' (Z : Ptd) :
+   is_nat_trans
+     (pr1 (BinCoproductObject EndEndC
+        (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (pr1 InitAlg))
+           (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_target H) Z))))
+     (functor_composite (ℓ (U Z)) Ghat)
+     (λ X : [C, C, hs],
+      nat_trans_id
+        (BinCoproductObject [C, C, hs]
+           (CPEndC
+              ((constant_functor [C, C, hs] [C, C, hs] (pr1 InitAlg)) X)
+              ((θ_target H) (X ⊗ Z)))
+         :functor C C)).
+Proof.
+  unfold is_nat_trans; simpl.
+  intros X X' α.
+  rewrite (@id_left EndC).
+  rewrite (@id_right EndC).
+  apply nat_trans_eq; try (exact hs).
+  intro c; simpl.
+  unfold coproduct_nat_trans_data; simpl.
+  unfold coproduct_nat_trans_in1_data, coproduct_nat_trans_in2_data; simpl.
+  apply BinCoproductOfArrows_eq.
+  - apply idpath.
+  - unfold functor_fix_snd_arg_mor; simpl.
+    unfold θ_target_mor; simpl.
+    revert c.
+    apply nat_trans_eq_pointwise.
+    apply maponpaths.
+    apply nat_trans_eq; try (exact hs).
+    intro c.
+    simpl.
+    rewrite <- (nat_trans_ax α).
+    rewrite functor_id.
+    apply id_left.
+Qed.
+
+Local Definition iso2' (Z : Ptd) : EndEndC ⟦
+  BinCoproductObject EndEndC
+  (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (pr1 InitAlg))
+             (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_target H) Z)),
+  functor_composite (ℓ (U Z)) Ghat ⟧.
+Proof.
+    simple refine (tpair _ _ _).
+  - intro X.
+    exact (nat_trans_id ((@BinCoproductObject EndC _ (θ_target H (X⊗Z)) (CPEndC _ _) )
+            : functor C C)).
+  - exact (is_nat_trans_iso2' Z).
+Defined.
+
+Definition thetahat (Z : Ptd)  (f : Z --> ptd_from_alg  InitAlg)
+           : EndEndC ⟦ functor_composite Id_H
+                                        (ℓ (U Z)),
+                     functor_composite (ℓ (U Z)) (Ghat) ⟧.
+Proof.
+  exact (iso1' Z ;; thetahat_0 Z f ;; iso2' Z).
+Defined.
+
+
+
+Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
+
+Let Yon (X : EndC) : functor EndC^op HSET := yoneda_objects EndC hsEndC X.
+
+Definition Phi_fusion (Z : Ptd) (X : EndC) (b : pr1 InitAlg --> X) :
+  functor_composite (functor_opp (ℓ (U Z))) (Yon (pr1 InitAlg))
+   ⟶
+  functor_composite (functor_opp (ℓ (U Z))) (Yon X) .
+Proof.
+  simple refine (tpair _ _ _ ).
+  - intro Y.
+    intro a.
+    exact (a ;; b).
+  - abstract (
+    intros ? ? ? ; simpl ;
+    apply funextsec ;
+    intro ;
+    unfold yoneda_objects_ob ; simpl ;
+    unfold compose ;
+    simpl ;
+    apply nat_trans_eq ;
+    [
+      assumption
+        |
+      simpl ; intros ? ;
+      apply pathsinv0, assoc ]).
+Defined.
+
+Let IA := μF_Initial hsEndC arg1 arg2 Id_H arg3.
+
+Lemma ishssMor_InitAlg (T' : hss CP H) :
+  @ishssMor C hs CP H
+        InitHSS T'
+           (InitialArrow IA (pr1 T') : @algebra_mor EndC Id_H InitAlg T' ).
+Proof.
+  unfold ishssMor.
+  unfold isbracketMor.
+  intros Z f.
+  set (β0 := InitialArrow IA (pr1 T')).
+  match goal with | [|- _ ;; ?b = _ ] => set (β := b) end.
+  set ( rhohat := BinCoproductArrow EndC  (CPEndC _ _ )  β (tau_from_alg T')
+                  :  pr1 Ghat T' --> T').
+  set (X:= SpecializedGMIt Z _ Ghat rhohat (thetahat Z f)).
+  pathvia (pr1 (pr1 X)).
+  -
+    set (TT := @fusion_law EndC hsEndC arg1 arg2 Id_H arg3 _ hsEndC (pr1 (InitAlg)) T').
+(* set (TT:= fusion_law _ _ _ IA _ hsEndC (pr1 InitAlg) T' _ (KanExt Z)). *)
+    set (Psi := ψ_from_comps (Id_H) hsEndC _ (ℓ (U Z)) (Const_plus_H (U Z)) (ρ_Thm15 Z f)
+                             (aux_iso_1 Z ;; θ'_Thm15 Z ;; aux_iso_2_inv Z) ).
+    set (T2 := TT _ (arg5 Z) (arg4 Z) Psi).
+    set (T3 := T2 (ℓ (U Z)) (arg5 Z)).
+    set (Psi' := ψ_from_comps (Id_H) hsEndC _ (ℓ (U Z)) (Ghat) (rhohat)
+                             (iso1' Z ;; thetahat_0 Z f ;; iso2' Z) ).
+    set (T4 := T3 (arg4 Z) Psi').
+    set (Φ := (Phi_fusion Z T' β)).
+    set (T5 := T4 Φ).
+    pathvia (Φ _ (fbracket InitHSS f)).
+    + apply idpath.
+    + eapply pathscomp0. Focus 2. apply T5.
+      (* hypothesis of fusion law *)
+      apply funextsec. intro t.
+      simpl.
+      unfold compose. simpl.
+      apply nat_trans_eq. assumption.
+      simpl.
+      intro c.
+      rewrite id_right.
+      rewrite id_right.
+      (* should be decomposed into two diagrams *)
+      apply BinCoproductArrow_eq_cor.
+      * (* first diagram *)
+        clear TT T2 T3 T4 T5.
+        do 5 rewrite <- assoc.
+        apply BinCoproductIn1Commutes_left_in_ctx_dir.
+        apply BinCoproductIn1Commutes_right_in_ctx_dir.
+        simpl.
+        rewrite id_left.
+        apply BinCoproductIn1Commutes_left_in_ctx_dir.
+        apply BinCoproductIn1Commutes_right_in_ctx_dir.
+        simpl.
+        rewrite id_left.
+        apply BinCoproductIn1Commutes_left_in_ctx_dir.
+        simpl.
+        rewrite id_left.
+        apply BinCoproductIn1Commutes_left_in_ctx_dir.
+        rewrite <- assoc.
+        apply maponpaths.
+        apply BinCoproductIn1Commutes_right_in_ctx_dir.
+        simpl.
+        rewrite id_left.
+        apply BinCoproductIn1Commutes_right_dir.
+        apply idpath.
+      * (* a bit out of order what follows *)
+        apply cancel_postcomposition.
+        apply idpath.
+      * (* second diagram *)
+        clear TT T2 T3 T4 T5.
+        do 5 rewrite <- assoc.
+        apply BinCoproductIn2Commutes_left_in_ctx_dir.
+        apply BinCoproductIn2Commutes_right_in_ctx_dir.
+        rewrite (@id_left EndC).
+        apply BinCoproductIn2Commutes_left_in_ctx_dir.
+        apply BinCoproductIn2Commutes_right_in_ctx_dir.
+        simpl.
+        unfold nat_trans_fix_snd_arg_data.
+        repeat rewrite <- assoc.
+        apply maponpaths.
+        apply BinCoproductIn2Commutes_left_in_ctx_dir.
+        apply BinCoproductIn2Commutes_right_in_ctx_dir.
+        simpl.
+        assert (H_nat_inst := functor_comp H _ _ _ t β).
+        assert (H_nat_inst_c := nat_trans_eq_pointwise H_nat_inst c); clear H_nat_inst.
+        {
+          match goal with |[ H1 : _  = ?f |- _ = _;; ?g ;; ?h  ] =>
+             pathvia (f;;g;;h) end.
+          + clear H_nat_inst_c.
+            simpl.
+            repeat rewrite <- assoc.
+            apply maponpaths.
+            apply BinCoproductIn2Commutes_left_in_ctx_dir.
+            simpl.
+            unfold coproduct_nat_trans_in2_data, coproduct_nat_trans_data.
+            assert (Hyp := τ_part_of_alg_mor _ hs CP _ _ _ (InitialArrow IA (pr1 T'))).
+            assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp.
+            simpl in Hyp_c.
+            eapply pathscomp0. eapply pathsinv0. exact Hyp_c.
+            clear Hyp_c.
+            apply maponpaths.
+            apply pathsinv0.
+            apply BinCoproductIn2Commutes.
+          + rewrite <- H_nat_inst_c.
+            apply idpath.
+        }
+  - apply pathsinv0.
+    apply path_to_ctr.
+    (* now a lot of serious verification work to be done *)
+    apply nat_trans_eq; try (exact hs).
+    intro c.
+    simpl.
+    rewrite id_right.
+    (* look at type: *)
+(*        match goal with | [ |- ?l = _ ] => let ty:= (type of l) in idtac ty end. *)
+    apply BinCoproductArrow_eq_cor.
+    + repeat rewrite <- assoc.
+      apply BinCoproductIn1Commutes_right_in_ctx_dir.
+      simpl.
+      unfold coproduct_nat_trans_in1_data,
+             coproduct_nat_trans_in2_data,
+             coproduct_nat_trans_data.
+      rewrite id_left.
+      apply BinCoproductIn1Commutes_right_in_ctx_dir.
+      simpl.
+      repeat rewrite <- assoc.
+      eapply pathscomp0. Focus 2. apply maponpaths. apply BinCoproductIn1Commutes_right_in_ctx_dir.
+        rewrite id_left. apply BinCoproductIn1Commutes_right_dir. apply idpath.
+      do 2 rewrite assoc.
+      eapply pathscomp0.
+        apply cancel_postcomposition.
+        assert (ptd_mor_commutes_inst := ptd_mor_commutes _ (ptd_from_alg_mor _ hs CP H β0) ((pr1 Z) c)).
+        apply ptd_mor_commutes_inst.
+      assert (fbracket_η_inst := fbracket_η T' (f;; ptd_from_alg_mor _ hs CP H β0)).
+      assert (fbracket_η_inst_c := nat_trans_eq_pointwise fbracket_η_inst c); clear fbracket_η_inst.
+      apply (!fbracket_η_inst_c).
+    + (* now the difficult case *)
+      repeat rewrite <- assoc.
+      apply BinCoproductIn2Commutes_right_in_ctx_dir.
+      simpl.
+      unfold coproduct_nat_trans_in1_data, coproduct_nat_trans_in2_data, coproduct_nat_trans_data.
+      rewrite id_left.
+      apply BinCoproductIn2Commutes_right_in_ctx_dir.
+      unfold nat_trans_fix_snd_arg_data.
+      simpl.
+      unfold coproduct_nat_trans_in2_data.
+      repeat rewrite <- assoc.
+      eapply pathscomp0. Focus 2.
+        apply maponpaths.
+        apply BinCoproductIn2Commutes_right_in_ctx_dir.
+        rewrite <- assoc.
+        apply maponpaths.
+        apply BinCoproductIn2Commutes_right_dir.
+        apply idpath.
+      do 2 rewrite assoc.
+      eapply pathscomp0.
+        apply cancel_postcomposition.
+        eapply pathsinv0.
+        assert (τ_part_of_alg_mor_inst := τ_part_of_alg_mor _ hs CP H _ _ β0).
+        assert (τ_part_of_alg_mor_inst_Zc :=
+                  nat_trans_eq_pointwise τ_part_of_alg_mor_inst ((pr1 Z) c));
+          clear τ_part_of_alg_mor_inst.
+        apply τ_part_of_alg_mor_inst_Zc.
+      simpl.
+      unfold coproduct_nat_trans_in2_data.
+      repeat rewrite <- assoc.
+      eapply pathscomp0.
+        apply maponpaths.
+        rewrite assoc.
+        eapply pathsinv0.
+        assert (fbracket_τ_inst := fbracket_τ T' (f;; ptd_from_alg_mor _ hs CP H β0)).
+        assert (fbracket_τ_inst_c := nat_trans_eq_pointwise fbracket_τ_inst c); clear fbracket_τ_inst.
+        apply fbracket_τ_inst_c.
+      simpl.
+      unfold coproduct_nat_trans_in2_data.
+      repeat rewrite assoc.
+      apply cancel_postcomposition.
+      apply cancel_postcomposition.
+      assert (Hyp:
+                 ((# (pr1 (ℓ(U Z))) (# H β));;
+                 (theta H) ((alg_carrier _  T') ⊗ Z);;
+                 # H (fbracket T' (f;; ptd_from_alg_mor C hs CP H β0))
+                 =
+                 θ (tpair (λ _ : functor C C, ptd_obj C) (alg_carrier _ (InitialObject IA)) Z) ;;
+                 # H (# (pr1 (ℓ(U Z))) β ;;
+                 fbracket T' (f;; ptd_from_alg_mor C hs CP H β0)))).
+
+      Focus 2.
+      assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp.
+      exact Hyp_c.
+
+      clear c. clear X. clear rhohat.
+      rewrite (functor_comp H).
+      rewrite assoc.
+      apply cancel_postcomposition.
+      fold θ.
+      apply nat_trans_eq; try (exact hs).
+      intro c.
+      assert (θ_nat_1_pointwise_inst := θ_nat_1_pointwise _ hs H θ _ _ β Z c).
+      eapply pathscomp0 ; [exact θ_nat_1_pointwise_inst | ].
+      clear θ_nat_1_pointwise_inst.
+      simpl.
+      apply maponpaths.
+      assert (Hyp: # H (β ∙∙ nat_trans_id (pr1 Z)) = # H (# (pr1 (ℓ(U Z))) β)).
+      { apply maponpaths.
+        apply nat_trans_eq; try (exact hs).
+        intro c'.
+        simpl.
+        rewrite functor_id.
+        apply id_right. }
+      apply (nat_trans_eq_pointwise Hyp c).
+Qed.
+
+Definition hss_InitMor : Π T' : hss CP H, hssMor InitHSS T'.
+Proof.
+  intro T'.
+  exists (InitialArrow IA (pr1 T')).
+  apply ishssMor_InitAlg.
+Defined.
+
+Lemma hss_InitMor_unique (T' : hss_precategory CP H):
+  Π t : hss_precategory CP H ⟦ InitHSS, T' ⟧, t = hss_InitMor T'.
+Proof.
+  intro t.
+  apply (invmap (hssMor_eq1 _ _ _ _ _ _ _ _ )).
+  apply (@InitialArrowUnique _ IA (pr1 T') (pr1 t)).
+Qed.
+
+Lemma isInitial_InitHSS : isInitial (hss_precategory CP H) InitHSS.
+Proof.
+  simple refine (mk_isInitial _ _).
+  intro T.
+  exists (hss_InitMor T).
+  apply hss_InitMor_unique.
+Defined.
+
+
+Lemma InitialHSS : Initial (hss_precategory CP H).
+Proof.
+  simple refine (mk_Initial InitHSS _).
+  apply isInitial_InitHSS.
+Defined.
+
+
+End Precategory_Algebra.

--- a/UniMath/SubstitutionSystems/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial_alt.v
@@ -90,7 +90,27 @@ apply is_omega_cocont_BinCoproduct_of_functors; try apply functor_category_has_h
 Defined.
 
 Lemma arg4 (Z : Ptd) : isInitial [C, C, hs] (ℓ (U Z) arg1).
-Admitted.
+Proof.
+use mk_isInitial.
+intros F.
+mkpair.
+simpl.
+mkpair.
+intros c.
+simpl.
+apply InitialArrow.
+intros x y f.
+cbn.
+apply InitialArrowEq.
+intros FF.
+apply subtypeEquality.
+intros x.
+apply isaprop_is_nat_trans.
+apply hs.
+simpl.
+apply funextsec; intro c.
+apply InitialArrowUnique.
+Defined.
 
 Lemma arg5 (Z : Ptd) : is_omega_cocont (pre_composition_functor C C C hs hs (U Z)).
 Proof.

--- a/UniMath/SubstitutionSystems/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial_alt.v
@@ -1,3 +1,17 @@
+(** **********************************************************
+
+Contents:
+
+- Construction of a substitution system from an initial algebra Proof that the substitution system
+- Constructed from an initial algebra is an initial substitution system
+
+This file differs from LiftingInitial.v in the hypotheses. Here we use omega cocontinuity instead of
+Kan extensions.
+
+Written by: Anders Mörtberg, 2016 (adapted from LiftingInitial.v)
+
+************************************************************)
+
 Set Kernel Term Sharing.
 
 Require Import UniMath.Foundations.Basics.PartD.
@@ -56,17 +70,17 @@ Definition Id_H :  functor [C, C, hsC] [C, C, hsC]
 
 Let Alg : precategory := FunctorAlg Id_H hsEndC.
 
-Lemma arg1 : Initial EndC.
+Let InitialEndC : Initial EndC.
 Proof.
 apply Initial_functor_precat, IC.
 Defined.
 
-Lemma arg2 : Colims_of_shape nat_graph EndC.
+Let Colims_of_shape_nat_graph_EndC : Colims_of_shape nat_graph EndC.
 Proof.
 apply ColimsFunctorCategory_of_shape, CC.
 Defined.
 
-Lemma arg3 : is_omega_cocont Id_H.
+Lemma is_omega_cocont_Id_H : is_omega_cocont Id_H.
 Proof.
 apply is_omega_cocont_BinCoproduct_of_functors; try apply functor_category_has_homsets.
 - apply (BinProducts_functor_precat _ _ BPC).
@@ -74,10 +88,10 @@ apply is_omega_cocont_BinCoproduct_of_functors; try apply functor_category_has_h
 - apply HH.
 Defined.
 
-(* Definition InitAlg : Alg := InitialObject IA. *)
-Definition InitAlg : Alg := InitialObject (μF_Initial hsEndC arg1 arg2 Id_H arg3).
+Definition InitAlg : Alg :=
+  InitialObject (μF_Initial hsEndC InitialEndC Colims_of_shape_nat_graph_EndC Id_H is_omega_cocont_Id_H).
 
-Lemma arg4 (Z : Ptd) : isInitial [C, C, hsC] (ℓ (U Z) arg1).
+Lemma isInitial_pre_comp (Z : Ptd) : isInitial [C, C, hsC] (ℓ (U Z) InitialEndC).
 Proof.
 use mk_isInitial; intros F.
 mkpair.
@@ -89,7 +103,7 @@ mkpair.
     | apply funextsec; intro c; apply InitialArrowUnique]).
 Defined.
 
-Lemma arg5 (Z : Ptd) : is_omega_cocont (pre_composition_functor C C C hsC hsC (U Z)).
+Local Lemma HU (Z : Ptd) : is_omega_cocont (pre_composition_functor C C C hsC hsC (U Z)).
 Proof.
 apply is_omega_cocont_pre_composition_functor, CC.
 Defined.
@@ -100,7 +114,8 @@ Definition SpecializedGMIt (Z : Ptd) (X : EndC) :
   ∃! h : [C, C, hsC] ⟦ ℓ (U Z) (alg_carrier _ InitAlg), X ⟧,
     # (ℓ (U Z)) (alg_map Id_H InitAlg) ;; h =
     θ (alg_carrier _ InitAlg) ;; # G h ;; ρ
- := SpecialGenMendlerIteration hsEndC arg1 arg2 Id_H arg3 hsEndC X (ℓ (U Z)) (arg4 Z) (arg5 Z).
+  := SpecialGenMendlerIteration hsEndC InitialEndC Colims_of_shape_nat_graph_EndC
+                                Id_H is_omega_cocont_Id_H hsEndC X (ℓ (U Z)) (isInitial_pre_comp Z) (HU Z).
 
 Definition θ_in_first_arg (Z: Ptd)
   : functor_fix_snd_arg [C, C,hsC] Ptd [C, C, hsC] (θ_source H) Z
@@ -473,7 +488,7 @@ mkpair.
             apply pathsinv0, assoc).
 Defined.
 
-Let IA := μF_Initial hsEndC arg1 arg2 Id_H arg3.
+Let IA := μF_Initial hsEndC InitialEndC Colims_of_shape_nat_graph_EndC Id_H is_omega_cocont_Id_H.
 
 Lemma ishssMor_InitAlg (T' : hss CP H) :
   @ishssMor C hsC CP H InitHSS T'
@@ -486,14 +501,15 @@ set (rhohat := BinCoproductArrow EndC  (CPEndC _ _ )  β (tau_from_alg T')
                 :  pr1 Ghat T' --> T').
 set (X:= SpecializedGMIt Z _ Ghat rhohat (thetahat Z f)).
 pathvia (pr1 (pr1 X)).
-- set (TT := @fusion_law EndC hsEndC arg1 arg2 Id_H arg3 _ hsEndC (pr1 (InitAlg)) T').
+- set (TT := @fusion_law EndC hsEndC InitialEndC Colims_of_shape_nat_graph_EndC
+                         Id_H is_omega_cocont_Id_H _ hsEndC (pr1 (InitAlg)) T').
   set (Psi := ψ_from_comps (Id_H) hsEndC _ (ℓ (U Z)) (Const_plus_H (U Z)) (ρ_Thm15 Z f)
                              (aux_iso_1 Z ;; θ'_Thm15 Z ;; aux_iso_2_inv Z) ).
-  set (T2 := TT _ (arg5 Z) (arg4 Z) Psi).
-  set (T3 := T2 (ℓ (U Z)) (arg5 Z)).
+  set (T2 := TT _ (HU Z) (isInitial_pre_comp Z) Psi).
+  set (T3 := T2 (ℓ (U Z)) (HU Z)).
   set (Psi' := ψ_from_comps (Id_H) hsEndC _ (ℓ (U Z)) (Ghat) (rhohat)
                            (iso1' Z ;; thetahat_0 Z f ;; iso2' Z) ).
-  set (T4 := T3 (arg4 Z) Psi').
+  set (T4 := T3 (isInitial_pre_comp Z) Psi').
   set (Φ := (Phi_fusion Z T' β)).
   set (T5 := T4 Φ).
   pathvia (Φ _ (fbracket InitHSS f)); trivial.


### PR DESCRIPTION
Implement alternative versions of GenMendlerIteration and LiftingInitial. These new files produce the same results, but have a different set of hypotheses. In particular there is no need for the construction of Kan extension but we can rely on omega cocontinuity instead. 

This is used in BindingSigToMonad in order to eliminate the hypotheses of general limits which was needed for the construction of Kan extensions. The code there now only needs the existence of colimits for omega chains. 