### PR TITLE
Minor changes to code for "from binding signatures to monads" paper

### DIFF
--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -130,8 +130,9 @@ Section omega_cocont.
 >>
    with exactly one arrow from n to S n.
 *)
+
 Definition nat_graph : graph :=
-  tpair (λ D : UU, D → D → UU) nat (λ m n, S m = n).
+  mk_graph nat (λ m n, 1 + m = n).
 
 Local Notation "'chain'" := (diagram nat_graph).
 

--- a/UniMath/CategoryTheory/Inductives/Lists.v
+++ b/UniMath/CategoryTheory/Inductives/Lists.v
@@ -209,7 +209,7 @@ apply listIndProp.
   now rewrite !foldr_cons, <- Hl.
 Qed.
 
-Definition concatenate : pr1 List -> pr1 List -> pr1 List :=
+Definition concatenate : List -> List -> List :=
   fun l l' => foldr _ l cons l'.
 
 End lists.

--- a/UniMath/CategoryTheory/Inductives/Trees.v
+++ b/UniMath/CategoryTheory/Inductives/Trees.v
@@ -238,9 +238,9 @@ Defined.
 End nat_examples.
 
 (** ** Flattening of a tree into a list *)
-Local Notation "a :: b" := (cons _ ((a,, b) : _ × _  )).
-Check concatenate.
-Definition flatten (A : HSET) : pr1 (Tree A) -> pr1 (List A).
+Local Notation "a :: b" := (cons _ a b).
+(* Check concatenate. *)
+Definition flatten (A : HSET) : pr1 (Tree A) -> List A.
 Proof.
   intro t.
   use (foldr A).

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -47,6 +47,8 @@ Definition graph := Σ (D : UU), D -> D -> UU.
 Definition vertex : graph -> UU := pr1.
 Definition edge {g : graph} : vertex g -> vertex g -> UU := pr2 g.
 
+Definition mk_graph (D : UU) (e : D → D → UU) : graph := tpair _ D e.
+
 Definition diagram (g : graph) (C : precategory) : UU :=
   Σ (f : vertex g -> C), Π (a b : vertex g), edge a b -> C⟦f a, f b⟧.
 

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -43,7 +43,7 @@ Require Import UniMath.SubstitutionSystems.LiftingInitial_alt.
 Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.Notation.
 
-Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
+Local Notation "[ C , D , hsD ]" := (functor_precategory C D hsD).
 Local Notation "'chain'" := (diagram nat_graph).
 
 (** * Definition of binding signatures *)
@@ -86,15 +86,15 @@ Section BindingSigToMonad.
 
 Context {C : precategory} (hsC : has_homsets C).
 
-Local Notation "'C2'":= ([C, C, hsC]) .
+Local Notation "'[C,C]'" := (functor_precategory C C hsC).
 
-Local Definition has_homsets_C2 : has_homsets C2.
+Local Definition has_homsets_C2 : has_homsets [C,C].
 Proof.
 apply functor_category_has_homsets.
 Defined.
 
 (** Form "_ o option^n" and return Id if n = 0 *)
-Definition precomp_option_iter (BCC : BinCoproducts C) (TC : Terminal C) (n : nat) : functor C2 C2.
+Definition precomp_option_iter (BCC : BinCoproducts C) (TC : Terminal C) (n : nat) : functor [C,C] [C,C].
 Proof.
 induction n as [|n IHn].
 - apply functor_identity.
@@ -138,7 +138,7 @@ Let constprod_functor1 := constprod_functor1 (BPC2 BPC).
 (** The H assumption follows directly if [C,C] has exponentials *)
 Lemma is_omega_cocont_Arity_to_Signature
   (TC : Terminal C) (CLC : Colims_of_shape nat_graph C)
-  (H : Π (x : C2), is_omega_cocont (constprod_functor1 x))
+  (H : Π (F : [C,C]), is_omega_cocont (constprod_functor1 F))
   (xs : list nat) :
   is_omega_cocont (Arity_to_Signature TC xs).
 Proof.
@@ -166,7 +166,7 @@ Defined.
 
 Lemma is_omega_cocont_BindingSigToSignature
   (TC : Terminal C) (CLC : Colims_of_shape nat_graph C)
-  (H : Π (x : C2), is_omega_cocont (constprod_functor1 x))
+  (H : Π (F : [C,C]), is_omega_cocont (constprod_functor1 F))
   (sig : BindingSig)
   (CC : Coproducts (BindingSigIndex sig) C) (PC : Products (BindingSigIndex sig) C) :
   is_omega_cocont (BindingSigToSignature TC sig CC).
@@ -220,7 +220,7 @@ Defined.
 (** ** Function from binding signatures to monads *)
 Definition BindingSigToMonad
   (TC : Terminal C) (IC : Initial C) (CLC : Colims_of_shape nat_graph C)
-  (H : Π (x : C2), is_omega_cocont (constprod_functor1 x))
+  (H : Π (F : [C,C]), is_omega_cocont (constprod_functor1 F))
   (sig : BindingSig)
   (PC : Products (BindingSigIndex sig) C) (CC : Coproducts (BindingSigIndex sig) C) :
  Monad C.

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -166,13 +166,13 @@ Defined.
 
 Lemma is_omega_cocont_BindingSigToSignature
   (TC : Terminal C) (CLC : Colims_of_shape nat_graph C)
-  (H : Π (F : [C,C]), is_omega_cocont (constprod_functor1 F))
+  (HF : Π (F : [C,C]), is_omega_cocont (constprod_functor1 F))
   (sig : BindingSig)
   (CC : Coproducts (BindingSigIndex sig) C) (PC : Products (BindingSigIndex sig) C) :
   is_omega_cocont (BindingSigToSignature TC sig CC).
 Proof.
 apply (is_omega_cocont_Sum_of_Signatures _ (BindingSigIsdeceq sig)).
-- intro i; apply is_omega_cocont_Arity_to_Signature, H; assumption.
+- intro i; apply is_omega_cocont_Arity_to_Signature, HF; assumption.
 - apply PC.
 Defined.
 
@@ -182,8 +182,8 @@ Let FunctorAlg F := FunctorAlg F has_homsets_C2.
 (** ** Construction of initial algebra for a signature with strength *)
 Definition SignatureInitialAlgebra
   (IC : Initial C) (CLC : Colims_of_shape nat_graph C)
-  (s : Signature C hsC) (Hs : is_omega_cocont s) :
-  Initial (FunctorAlg (Id_H s)).
+  (H : Signature C hsC) (Hs : is_omega_cocont H) :
+  Initial (FunctorAlg (Id_H H)).
 Proof.
 use colimAlgInitial.
 - apply (Initial_functor_precat _ _ IC).
@@ -192,6 +192,15 @@ use colimAlgInitial.
 Defined.
 
 Let HSS := @hss_precategory C hsC BCC.
+
+(* Redefine this here so that it uses the arguments above *)
+Let InitialHSS
+  (IC : Initial C) (CLC : Colims_of_shape nat_graph C)
+  (H : Signature C hsC) (Hs : is_omega_cocont H) :
+  Initial (HSS H).
+Proof.
+apply InitialHSS; assumption.
+Defined.
 
 (** ** Signature with strength and initial algebra to a HSS *)
 Definition SignatureToHSS
@@ -205,8 +214,8 @@ Defined.
 (** The above HSS is initial *)
 Definition SignatureToHSSisInitial
   (IC : Initial C) (CLC : Colims_of_shape nat_graph C)
-  (s : Signature C hsC) (Hs : is_omega_cocont s) :
-  isInitial _ (SignatureToHSS IC CLC s Hs).
+  (H : Signature C hsC) (Hs : is_omega_cocont H) :
+  isInitial _ (SignatureToHSS IC CLC H Hs).
 Proof.
 now unfold SignatureToHSS; destruct InitialHSS.
 Qed.
@@ -220,15 +229,16 @@ Defined.
 (** ** Function from binding signatures to monads *)
 Definition BindingSigToMonad
   (TC : Terminal C) (IC : Initial C) (CLC : Colims_of_shape nat_graph C)
-  (H : Π (F : [C,C]), is_omega_cocont (constprod_functor1 F))
+  (HF : Π (F : [C,C]), is_omega_cocont (constprod_functor1 F))
   (sig : BindingSig)
-  (PC : Products (BindingSigIndex sig) C) (CC : Coproducts (BindingSigIndex sig) C) :
- Monad C.
+  (PC : Products (BindingSigIndex sig) C)
+  (CC : Coproducts (BindingSigIndex sig) C) :
+  Monad C.
 Proof.
 use Monad_from_hss.
 - apply (BindingSigToSignature TC sig CC).
 - apply (SignatureToHSS IC CLC).
-  apply (is_omega_cocont_BindingSigToSignature TC CLC H _ _ PC).
+  apply (is_omega_cocont_BindingSigToSignature TC CLC HF _ _ PC).
 Defined.
 
 End BindingSigToMonad.

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -27,7 +27,6 @@ Require Import UniMath.CategoryTheory.CocontFunctors.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.Monads.
-Require Import UniMath.CategoryTheory.RightKanExtension.
 Require Import UniMath.SubstitutionSystems.Signatures.
 Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.BindingSigToMonad.
@@ -120,14 +119,6 @@ Lemma is_omega_cocont_pre_composition_functor
      is_omega_cocont (pre_composition_functor A B C hsB hsC F).
 Proof.
   exact (@CocontFunctors.is_omega_cocont_pre_composition_functor _ _ _ _ _ _ H).
-Defined.
-
-Definition RightKanExtension_from_limits
-  : Π (M C A : precategory) (K : functor M C) (hsC : has_homsets C)
-    (hsA : has_homsets A),
-  Lims A → GlobalRightKanExtensionExists M C K A hsC hsA.
-Proof.
-  exact @UniMath.CategoryTheory.RightKanExtension.RightKanExtension_from_limits.
 Defined.
 
 Definition ColimCoconeHSET

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -35,14 +35,14 @@ Require Import UniMath.SubstitutionSystems.LiftingInitial_alt.
 
 Definition Arity_to_Signature :
   Π (C : precategory) (hsC : has_homsets C),
-  BinCoproducts C → BinProducts C → Terminal C → list nat → Signature C hsC.
+  BinProducts C → BinCoproducts C → Terminal C → list nat → Signature C hsC.
 Proof.
   exact @UniMath.SubstitutionSystems.BindingSigToMonad.Arity_to_Signature.
 Defined.
 
 Definition BindingSigToSignature :
   Π {C : precategory} (hsC : has_homsets C),
-  BinCoproducts C → BinProducts C → Terminal C →
+  BinProducts C → BinCoproducts C → Terminal C →
   Π sig : BindingSig, Coproducts (BindingSigIndex sig) C →
   Signature C hsC.
 Proof.
@@ -59,8 +59,9 @@ Proof.
 Defined.
 
 Definition SignatureInitialAlgebra :
-  Π {C : precategory} (hsC : has_homsets C) (BCC : BinCoproducts C),
-  BinProducts C → Initial C → Colims_of_shape nat_graph C
+  Π {C : precategory} (hsC : has_homsets C)
+  (BPC : BinProducts C) (BCC : BinCoproducts C),
+    Initial C → Colims_of_shape nat_graph C
   → Π s : Signature C hsC, is_omega_cocont (Signature_Functor C hsC s)
   → Initial (FunctorAlg (Id_H C hsC BCC s) (BindingSigToMonad.has_homsets_C2 hsC)).
 Proof.
@@ -68,13 +69,12 @@ Proof.
 Defined.
 
 Definition BindingSigToMonad :
-  Π (C : precategory) (hsC : has_homsets C),
-  BinCoproducts C → Π BPC : BinProducts C,
-  Initial C → Terminal C → Colims_of_shape nat_graph C
-  → Π sig : BindingSig, Coproducts (BindingSigIndex sig) C
-  → Products (BindingSigIndex sig) C
-  → (Π F, is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C BPC hsC) F)) →
-  Monad C.
+  Π (C : precategory) (hsC : has_homsets C) (BPC : BinProducts C),
+  BinCoproducts C → Terminal C → Initial C → Colims_of_shape nat_graph C
+  → (Π F, is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C BPC hsC) F))
+  → Π sig : BindingSig, Products (BindingSigIndex sig) C
+  → Coproducts (BindingSigIndex sig) C
+  → Monad C.
 Proof.
   exact @UniMath.SubstitutionSystems.BindingSigToMonad.BindingSigToMonad.
 Defined.

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -49,6 +49,21 @@ Proof.
   exact @UniMath.SubstitutionSystems.BindingSigToMonad.BindingSigToSignature.
 Defined.
 
+Local Notation "'[ C , C, hsC ]'" := (functor_precategory C C hsC).
+
+Lemma is_omega_cocont_BindingSigToSignature :
+  Π (C : precategory) (hsC : has_homsets C)
+  (BPC : BinProducts C) (BCC : BinCoproducts C) (TC : Terminal C),
+  Colims_of_shape nat_graph C →
+  (Π F : functor_precategory C C hsC, is_omega_cocont
+       (constprod_functor1 (BinProducts_functor_precat C C BPC hsC) F))
+  → Π (sig : BindingSig) (CC : Coproducts (BindingSigIndex sig) C),
+                          Products (BindingSigIndex sig) C →
+  is_omega_cocont (BindingSigToSignature hsC BPC BCC TC sig CC).
+Proof.
+  exact @UniMath.SubstitutionSystems.BindingSigToMonad.is_omega_cocont_BindingSigToSignature.
+Defined.
+
 Definition InitialHSS :
   Π (C : precategory) (hsC : has_homsets C) (CP : BinCoproducts C),
   BinProducts C → Initial C → Colims_of_shape nat_graph C →
@@ -123,7 +138,7 @@ Defined.
 
 Lemma is_omega_cocont_binproduct_functor
   : Π (C : precategory) (PC : BinProducts C), has_homsets C →
-    (Π x : C, is_omega_cocont (constprod_functor1 PC x)) →
+    (Π (x : C), is_omega_cocont (constprod_functor1 PC x)) →
     is_omega_cocont (binproduct_functor PC).
 Proof.
   exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_binproduct_functor.

--- a/UniMath/SubstitutionSystems/LamFromBindingSig.v
+++ b/UniMath/SubstitutionSystems/LamFromBindingSig.v
@@ -35,7 +35,7 @@ Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.LamSignature.
 Require Import UniMath.SubstitutionSystems.Notation.
 Require Import UniMath.SubstitutionSystems.BindingSigToMonad.
-Require Import UniMath.SubstitutionSystems.LiftingInitial.
+Require Import UniMath.SubstitutionSystems.LiftingInitial_alt.
 
 Section Lam.
 
@@ -77,15 +77,16 @@ Definition LamSig : BindingSig :=
 Definition LamSignature : Signature HSET has_homsets_HSET :=
   BindingSigToSignatureHSET LamSig.
 
-Definition LamFunctor : functor HSET2 HSET2 :=
-  Id_H _ _ BinCoproductsHSET LamSignature.
+Let Id_H := Id_H _ has_homsets_HSET BinCoproductsHSET.
 
-Definition LamMonad : Monad HSET := BindingSigToMonadHSET LamSig.
+Definition LamFunctor : functor HSET2 HSET2 := Id_H LamSignature.
 
 Lemma lambdaFunctor_Initial : Initial (FunctorAlg LamFunctor has_homsets_HSET2).
 Proof.
 apply SignatureInitialAlgebraHSET, is_omega_cocont_BindingSigToSignatureHSET.
 Defined.
+
+Definition LamMonad : Monad HSET := BindingSigToMonadHSET LamSig.
 
 Definition LC : HSET2 :=
   alg_carrier _ (InitialObject lambdaFunctor_Initial).

--- a/UniMath/SubstitutionSystems/LamFromBindingSig.v
+++ b/UniMath/SubstitutionSystems/LamFromBindingSig.v
@@ -1,6 +1,7 @@
 (**
 
-Obtain the lambda calculus from the signature { [0,0], [1] }.
+Obtain the lambda calculus and a substitution monad on Set from the signature { [0,0], [1] }.
+
 
 Written by: Anders Mörtberg, 2016
 

--- a/UniMath/SubstitutionSystems/LamFromBindingSig.v
+++ b/UniMath/SubstitutionSystems/LamFromBindingSig.v
@@ -171,8 +171,8 @@ eapply pathscomp0.
   eapply cancel_postcomposition, cancel_postcomposition.
   apply (CoproductOfArrowsIn _ _ (Coproducts_functor_precat _ _ _
           (Coproducts_HSET _ (isasetifdeceq _ isdeceqbool))
-          _ (λ i, pr1 (Arity_to_Signature has_homsets_HSET BinCoproductsHSET
-                         BinProductsHSET TerminalHSET (BindingSigMap LamSig i)) `LC_alg))).
+          _ (λ i, pr1 (Arity_to_Signature has_homsets_HSET BinProductsHSET
+                         BinCoproductsHSET TerminalHSET (BindingSigMap LamSig i)) `LC_alg))).
 rewrite <- assoc.
 eapply pathscomp0; [eapply maponpaths, BinCoproductIn2Commutes|].
 rewrite <- assoc.
@@ -201,8 +201,8 @@ eapply pathscomp0.
   eapply cancel_postcomposition, cancel_postcomposition.
   apply (CoproductOfArrowsIn _ _ (Coproducts_functor_precat _ _ _
           (Coproducts_HSET _ (isasetifdeceq _ isdeceqbool))
-          _ (λ i, pr1 (Arity_to_Signature has_homsets_HSET BinCoproductsHSET
-                         BinProductsHSET TerminalHSET (BindingSigMap LamSig i)) `LC_alg))).
+          _ (λ i, pr1 (Arity_to_Signature has_homsets_HSET BinProductsHSET
+                         BinCoproductsHSET TerminalHSET (BindingSigMap LamSig i)) `LC_alg))).
 rewrite <- assoc.
 eapply pathscomp0.
   eapply maponpaths, BinCoproductIn2Commutes.

--- a/UniMath/SubstitutionSystems/LamHSET.v
+++ b/UniMath/SubstitutionSystems/LamHSET.v
@@ -25,7 +25,7 @@ Require Import UniMath.CategoryTheory.Monads.
 Require Import UniMath.SubstitutionSystems.BinSumOfSignatures.
 Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.LamSignature.
-Require Import UniMath.SubstitutionSystems.LiftingInitial.
+Require Import UniMath.SubstitutionSystems.LiftingInitial_alt.
 Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.Notation.
 
@@ -34,7 +34,7 @@ Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.category_hset.
 Require Import UniMath.CategoryTheory.category_hset_structures.
 Require Import UniMath.CategoryTheory.CocontFunctors.
-Require Import UniMath.CategoryTheory.RightKanExtension.
+(* Require Import UniMath.CategoryTheory.RightKanExtension. *)
 
 Section LamHSET.
 
@@ -44,6 +44,15 @@ Let Lam_S : Signature HSET has_homsets_HSET :=
 Local Notation "'EndHSET'":= ([HSET, HSET, has_homsets_HSET]) .
 
 Let hsEndC : has_homsets EndHSET := functor_category_has_homsets _ _ has_homsets_HSET.
+
+Local Lemma is_omega_cocont_Lam_S : is_omega_cocont Lam_S.
+Proof.
+apply is_omega_cocont_Lam.
+* apply is_omega_cocont_constprod_functor1.
+  apply functor_category_has_homsets.
+  apply (has_exponentials_functor_HSET _ has_homsets_HSET).
+* apply ColimsHSET_of_shape.
+Defined.
 
 Lemma Lam_Initial_HSET : Initial (precategory_FunctorAlg (Id_H _ _ BinCoproductsHSET Lam_S) hsEndC).
 Proof.
@@ -55,27 +64,25 @@ use colimAlgInitial.
   + apply functor_category_has_homsets.
   + apply functor_category_has_homsets.
   + apply is_omega_cocont_constant_functor; apply functor_category_has_homsets.
-  + apply is_omega_cocont_Lam.
-    * apply is_omega_cocont_constprod_functor1.
-      apply functor_category_has_homsets.
-      apply (has_exponentials_functor_HSET _ has_homsets_HSET).
-    * apply ColimsHSET_of_shape.
+  + apply is_omega_cocont_Lam_S.
 - apply ColimsFunctorCategory_of_shape; apply ColimsHSET_of_shape.
 Defined.
 
-Lemma KanExt_HSET : Π Z : precategory_Ptd HSET has_homsets_HSET,
-   RightKanExtension.GlobalRightKanExtensionExists HSET HSET
-     (U Z) HSET has_homsets_HSET has_homsets_HSET.
-Proof.
-intro Z.
-apply RightKanExtension_from_limits, LimsHSET.
-Defined.
+(* Lemma KanExt_HSET : Π Z : precategory_Ptd HSET has_homsets_HSET, *)
+(*    RightKanExtension.GlobalRightKanExtensionExists HSET HSET *)
+(*      (U Z) HSET has_homsets_HSET has_homsets_HSET. *)
+(* Proof. *)
+(* intro Z. *)
+(* apply RightKanExtension_from_limits, LimsHSET. *)
+(* Defined. *)
 
 Definition LamHSS_Initial_HSET : Initial (hss_precategory BinCoproductsHSET Lam_S).
 Proof.
 apply InitialHSS.
-- apply KanExt_HSET.
-- apply Lam_Initial_HSET.
+- apply BinProductsHSET.
+- apply InitialHSET.
+- apply ColimsHSET_of_shape.
+- apply is_omega_cocont_Lam_S.
 Defined.
 
 Definition LamMonad : Monad HSET.

--- a/UniMath/SubstitutionSystems/MLTT79.v
+++ b/UniMath/SubstitutionSystems/MLTT79.v
@@ -38,7 +38,7 @@ Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.LamSignature.
 Require Import UniMath.SubstitutionSystems.Notation.
 Require Import UniMath.SubstitutionSystems.BindingSigToMonad.
-Require Import UniMath.SubstitutionSystems.LiftingInitial.
+Require Import UniMath.SubstitutionSystems.LiftingInitial_alt.
 
 Local Infix "::" := (@cons nat).
 Local Notation "[]" := (@nil nat) (at level 0, format "[]").
@@ -196,8 +196,9 @@ Definition MLTT79Sig := PiSig ++ SigmaSig ++ SumSig ++ IdSig ++
 
 Definition MLTT79Signature : SigHSET := BindingSigToSignatureHSET MLTT79Sig.
 
-Definition MLTT79Functor : functor HSET2 HSET2 :=
-  Id_H _ _ BinCoproductsHSET MLTT79Signature.
+Let Id_H := Id_H _ has_homsets_HSET BinCoproductsHSET.
+
+Definition MLTT79Functor : functor HSET2 HSET2 := Id_H MLTT79Signature.
 
 Definition MLTT79Monad : Monad HSET := BindingSigToMonadHSET MLTT79Sig.
 

--- a/UniMath/SubstitutionSystems/MLTT79.v
+++ b/UniMath/SubstitutionSystems/MLTT79.v
@@ -1,7 +1,7 @@
 (**
 
-Syntax of Martin-Löf type theory a la "Constructive Mathematics and
-Computer Programming" (1979).
+This file constructs a substitution monad on Set from a binding signature for the syntax of
+Martin-Löf type theory a la "Constructive Mathematics and Computer Programming" (1979).
 
 Written by: Anders Mörtberg, 2016
 


### PR DESCRIPTION
Mostly cosmetic changes to make the code for the paper look better. The only interesting  change is to now use the new version of LiftingInitial in LamFromBindingSig, LamHSET and MLTT79 so that they don't depend on the existence of Kan extensions anymore. 