### PR TITLE
remove broken import and thus make UniMath compile again

### DIFF
--- a/UniMath/CategoryTheory/LocalizingClass.v
+++ b/UniMath/CategoryTheory/LocalizingClass.v
@@ -6,7 +6,6 @@ Require Import UniMath.Foundations.Basics.Sets.
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
-(* Require Import UniMath.CategoryTheory.BinProductPrecategory. *)
 Require Import UniMath.CategoryTheory.functor_categories.
 
 (** * Localizing class and localization of categories.

--- a/UniMath/CategoryTheory/LocalizingClass.v
+++ b/UniMath/CategoryTheory/LocalizingClass.v
@@ -6,7 +6,7 @@ Require Import UniMath.Foundations.Basics.Sets.
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
-Require Import UniMath.CategoryTheory.BinProductPrecategory.
+(* Require Import UniMath.CategoryTheory.BinProductPrecategory. *)
 Require Import UniMath.CategoryTheory.functor_categories.
 
 (** * Localizing class and localization of categories.


### PR DESCRIPTION
Merging #473 has broken UniMath due to an obsolete Import.
This PR removes that obsolete import.