### PR TITLE
Update the summary file for the binding signatures to monads paper

### DIFF
--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -43,7 +43,7 @@ This file also contains proofs that the following functors are (omega-)cocontinu
 - Product of functors: F * G : C -> D, x |-> (x,x) |-> (F x,G x) |-> F x * G x
   [is_omega_cocont_BinProduct_of_functors_alt] [is_omega_cocont_BinProduct_of_functors]
 - Precomposition functor: _ o K : ⟦C,A⟧ -> ⟦M,A⟧ for K : M -> C
-  [is_cocont_pre_composition_functor] [is_omega_cocont_pre_composition_functor]
+  [preserves_colimit_pre_composition_functor] [is_omega_cocont_pre_composition_functor]
 - Swapping of functor category arguments:
   [is_cocont_functor_cat_swap] [is_omega_cocont_functor_cat_swap]
 
@@ -529,7 +529,7 @@ Section functor_identity.
 
 Context {C : precategory} (hsC : has_homsets C).
 
-Lemma preserves_colimit_identity{g : graph} (d : diagram g C) (L : C)
+Lemma preserves_colimit_identity {g : graph} (d : diagram g C) (L : C)
   (cc : cocone d L) : preserves_colimit (functor_identity C) d L cc.
 Proof.
 intros HcL y ccy; simpl.
@@ -1517,30 +1517,32 @@ Section pre_composition_functor.
 Context {A B C : precategory} (F : functor A B) (hsB : has_homsets B) (hsC : has_homsets C).
 (* Context (CC : Colims C). *) (* This is too strong *)
 
-Lemma is_cocont_pre_composition_functor
-  (H : Π (g : graph) (d : diagram g [B,C,hsC]) (b : B),
-       ColimCocone (diagram_pointwise hsC d b)) :
-  is_cocont (pre_composition_functor _ _ _ hsB hsC F).
+Lemma preserves_colimit_pre_composition_functor {g : graph}
+  (d : diagram g [B,C,hsC]) (G : [B,C,hsC])
+  (ccG : cocone d G) (H : Π b, ColimCocone (diagram_pointwise hsC d b)) :
+  preserves_colimit (pre_composition_functor A B C hsB hsC F) d G ccG.
 Proof.
-intros g d G ccG HccG.
+intros HccG.
 apply pointwise_Colim_is_isColimFunctor; intro a.
-apply (isColimFunctor_is_pointwise_Colim _ _ (H g d) _ _ HccG).
+now apply (isColimFunctor_is_pointwise_Colim _ _ H _ _ HccG).
 Defined.
 
-(* Which assumption is the best? *)
+(* Lemma is_cocont_pre_composition_functor *)
+(*   (H : Π (g : graph) (d : diagram g [B,C,hsC]) (b : B), *)
+(*        ColimCocone (diagram_pointwise hsC d b)) : *)
+(*   is_cocont (pre_composition_functor _ _ _ hsB hsC F). *)
+(* Proof. *)
+(* now intros g d G ccG; apply preserves_colimit_pre_composition_functor. *)
+(* Defined. *)
+
 Lemma is_omega_cocont_pre_composition_functor
-  (* (H : Π (c : chain [B,C,hsC]) (b : B), ColimCocone (diagram_pointwise hsC c b)) : *)
   (H : Colims_of_shape nat_graph C) :
   is_omega_cocont (pre_composition_functor _ _ _ hsB hsC F).
 Proof.
-intros c L ccL HccL.
-apply pointwise_Colim_is_isColimFunctor; intro a.
-use (isColimFunctor_is_pointwise_Colim _ _ _ _ _ HccL).
-intros b; apply H.
+now intros c L ccL; apply preserves_colimit_pre_composition_functor.
 Defined.
 
 Definition omega_cocont_pre_composition_functor
-  (* (H : Π (c : chain [B,C,hsC]) (b : B), ColimCocone (diagram_pointwise hsC c b))  *)
   (H : Colims_of_shape nat_graph C) :
   omega_cocont_functor [B, C, hsC] [A, C, hsC] :=
   tpair _ _ (is_omega_cocont_pre_composition_functor H).

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -92,7 +92,7 @@ Definition preserves_colimit {g : graph} (d : diagram g C) (L : C)
   (cc : cocone d L) : UU :=
   isColimCocone d L cc -> isColimCocone (mapdiagram F d) (F L) (mapcocone F d cc).
 
-Definition is_cocont := Π {g : graph} (d : diagram g C) (L : C)
+Definition is_cocont : UU := Π {g : graph} (d : diagram g C) (L : C)
   (cc : cocone d L), preserves_colimit d L cc.
 
 End cocont.

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -4,6 +4,8 @@ This file provides a stable interface to the formalization of the paper:
 
   From binding signatures to monads in UniMath
 
+  https://arxiv.org/abs/1612.00693
+
 by Benedikt Ahrens, Ralph Matthes and Anders Mörtberg.
 
 
@@ -37,6 +39,7 @@ Require Import UniMath.CategoryTheory.equivalences.
 Require Import UniMath.CategoryTheory.EquivalencesExamples.
 Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
 Require Import UniMath.CategoryTheory.CocontFunctors.
+Require Import UniMath.CategoryTheory.ProductPrecategory.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.Monads.
@@ -77,7 +80,7 @@ Definition BinProduct_of_Signatures :
 
 (** Problem 8: Signatures with strength from binding signatures *)
 Definition BindingSigToSignature :
-  Π (C : precategory) (hsC : has_homsets C), BinProducts C → BinCoproducts C → Terminal C
+  Π {C : precategory} (hsC : has_homsets C), BinProducts C → BinCoproducts C → Terminal C
   → Π sig : BindingSig, Coproducts (BindingSigIndex sig) C → Signature C hsC :=
     @UniMath.SubstitutionSystems.BindingSigToMonad.BindingSigToSignature.
 
@@ -116,7 +119,7 @@ Definition preserves_colimit : Π {C D : precategory}, functor C D
   → Π {g : graph} (d : diagram g C) (L : C), cocone d L → UU :=
     @UniMath.CategoryTheory.CocontFunctors.preserves_colimit.
 
-Definition is_cocont : Π C D : precategory, functor C D → UU :=
+Definition is_cocont : Π {C D : precategory}, functor C D → UU :=
   @UniMath.CategoryTheory.CocontFunctors.is_cocont.
 
 Definition is_omega_cocont : Π {C D : precategory}, functor C D → UU :=
@@ -153,57 +156,172 @@ exact @UniMath.CategoryTheory.FunctorAlgebras.initialAlg_is_iso.
 Defined.
 
 (** Problem 28: Colimits in Set *)
-
-(** Definition 30: Smallest equivalence relation containing a relation *)
+Lemma ColimsHSET_of_shape : Π (g : graph), Colims_of_shape g HSET.
+Proof.
+exact @UniMath.CategoryTheory.category_hset_structures.ColimsHSET_of_shape.
+Defined.
 
 (** Lemma 32: Left adjoints preserve colimits *)
+Lemma left_adjoint_cocont :
+  Π (C D : precategory) (F : functor C D), is_left_adjoint F
+  → has_homsets C → has_homsets D → is_cocont F.
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.left_adjoint_cocont.
+Defined.
 
 (** Lemma 33: Examples of preservation of colimits *)
 (** (i): Identity functor *)
+Lemma preserves_colimit_identity : Π C : precategory, has_homsets C
+  → Π (g : colimits.graph) (d : colimits.diagram g C)
+    (L : C) (cc : colimits.cocone d L),
+  preserves_colimit (functor_identity C) d L cc.
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.preserves_colimit_identity.
+Defined.
+
 (** (ii): Constant functor *)
+Lemma is_omega_cocont_constant_functor : Π C D : precategory, has_homsets D
+  → Π x : D, CocontFunctors.is_omega_cocont (constant_functor C D x).
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_constant_functor.
+Defined.
+
 (** (iii): Diagonal functor *)
+Lemma is_cocont_delta_functor : Π (I : UU) (C : precategory),
+  Products I C → has_homsets C → is_cocont (delta_functor I C).
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.is_cocont_delta_functor.
+Defined.
+
+Lemma is_omega_cocont_delta_functor : Π (I : UU) (C : precategory),
+  Products I C → has_homsets C → is_omega_cocont (delta_functor I C).
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_delta_functor.
+Defined.
+
 (** (iv): Coproduct functor *)
+Lemma is_cocont_coproduct_functor :
+  Π (I : UU) (C : precategory) (PC : Coproducts I C),
+  has_homsets C → is_cocont (coproduct_functor I PC).
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.is_cocont_coproduct_functor.
+Defined.
+
+Lemma is_omega_cocont_coproduct_functor :
+  Π (I : UU) (C : precategory) (PC : Coproducts I C),
+  has_homsets C → is_omega_cocont (coproduct_functor I PC).
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_coproduct_functor.
+Defined.
 
 (** Lemma 34: Examples of preservation of cocontinuity *)
 (** (i): Composition of functors *)
-(** (ii): Families of functors *)
+Lemma preserves_colimit_functor_composite :
+  Π C D E : precategory, has_homsets E
+  → Π (F : functor C D) (G : functor D E) (g : graph)
+      (d : diagram g C) (L : C) (cc : cocone d L),
+      preserves_colimit F d L cc
+  → preserves_colimit G (mapdiagram F d) (F L) (mapcocone F d cc)
+  → preserves_colimit (functor_composite F G) d L cc.
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.preserves_colimit_functor_composite.
+Defined.
 
-(** Definition 35: Exponentials *)
+Lemma is_cocont_functor_composite :
+  Π C D E : precategory, has_homsets E
+  → Π (F : functor C D) (G : functor D E), is_cocont F → is_cocont G
+  → is_cocont (functor_composite F G).
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.is_cocont_functor_composite.
+Defined.
+
+Lemma is_omega_cocont_functor_composite :
+  Π C D E : precategory, has_homsets E
+  → Π (F : functor C D) (G : functor D E), is_omega_cocont F → is_omega_cocont G
+  → is_omega_cocont (functor_composite F G).
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_functor_composite.
+Defined.
+
+(** (ii): Families of functors *)
+Lemma is_cocont_family_functor :
+  Π (I : UU) (A B : precategory), has_homsets A → has_homsets B → isdeceq I
+  → Π F : I → functor A B, (Π i : I, is_cocont (F i))
+  → is_cocont (family_functor I F).
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.is_cocont_family_functor.
+Defined.
+
+Lemma is_omega_cocont_family_functor :
+  Π (I : UU) (A B : precategory), has_homsets A → has_homsets B → isdeceq I
+  → Π F : I → functor A B, (Π i : I, is_omega_cocont (F i))
+  → is_omega_cocont (family_functor I F).
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_family_functor.
+Defined.
 
 (** Example 36: Exponentials in Set *)
+Definition has_exponentials_HSET : has_exponentials BinProductsHSET :=
+  @UniMath.CategoryTheory.category_hset_structures.has_exponentials_HSET.
 
 (** Lemma 37: Left and right product functors preserves colimits *)
+Lemma is_cocont_constprod_functor1 :
+  Π (C : precategory) (PC : BinProducts C), has_homsets C → has_exponentials PC
+  → Π x : C, is_cocont (constprod_functor1 PC x).
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.is_cocont_constprod_functor1.
+Defined.
+
+Lemma is_omega_cocont_constprod_functor1 :
+  Π (C : precategory) (PC : BinProducts C), has_homsets C → has_exponentials PC
+  → Π x : C, is_omega_cocont (constprod_functor1 PC x).
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_constprod_functor1.
+Defined.
+
+Lemma is_cocont_constprod_functor2 :
+  Π (C : precategory) (PC : BinProducts C), has_homsets C → has_exponentials PC
+  → Π x : C, is_cocont (constprod_functor2 PC x).
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.is_cocont_constprod_functor2.
+Defined.
+
+Lemma is_omega_cocont_constprod_functor2 :
+  Π (C : precategory) (PC : BinProducts C), has_homsets C → has_exponentials PC
+  → Π x : C, is_omega_cocont (constprod_functor2 PC x).
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_constprod_functor2.
+Defined.
 
 (** Theorem 38: Binary product functor is ω-cocontinuous *)
+Lemma is_omega_cocont_binproduct_functor :
+  Π (C : precategory) (PC : BinProducts C), has_homsets C
+  → (Π x : C, is_omega_cocont (constprod_functor1 PC x))
+  → is_omega_cocont (binproduct_functor PC).
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_binproduct_functor.
+Defined.
 
 (** Example 39: Lists of sets *)
-
-(** Theorem 41: Colimits of a specific shape in functor categories *)
+(* see: UniMath/CategoryTheory/Inductives/Lists.v *)
 
 (** Theorem 42: Precomposition functor preserves colimits *)
+Lemma is_cocont_pre_composition_functor :
+  Π (A B C : precategory) (F : functor A B) (hsB : has_homsets B) (hsC : has_homsets C),
+  (Π (g : graph) (d : diagram g [B, C, hsC]) (b : B), ColimCocone (diagram_pointwise hsC d b))
+  → is_cocont (pre_composition_functor A B C hsB hsC F).
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.is_cocont_pre_composition_functor.
+Defined.
+
+Lemma is_omega_cocont_pre_composition_functor :
+  Π (A B C : precategory) (F : functor A B) (hsB : has_homsets B) (hsC : has_homsets C),
+  Colims_of_shape nat_graph C → is_omega_cocont (pre_composition_functor A B C hsB hsC F).
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_pre_composition_functor.
+Defined.
 
 (** Theorem 44: Signature functor associated to a binding signature is ω-cocontinuous *)
-
-(** Construction 46: Datatypes specified by binding signatures (initial algebra of Id_H + H) *)
-
-(** Definition 47: Heterogeneous substitution systems *)
-
-(** Theorem 48: Construction of a substitution operation on an initial algebra *)
-
-(** Theorem 49: Construction of a monad from a substitution system *)
-
-(** Section 4.2: Binding signatures to monads *)
-
-(** Example 50: Untyped lambda calculus *)
-
-(** Example 51: Raw syntax of Martin-Löf type theory *)
-
-
-
-
-
-Local Notation "'[ C , C, hsC ]'" := (functor_precategory C C hsC).
-
 Lemma is_omega_cocont_BindingSigToSignature :
   Π (C : precategory) (hsC : has_homsets C)
   (BPC : BinProducts C) (BCC : BinCoproducts C) (TC : Terminal C),
@@ -212,30 +330,32 @@ Lemma is_omega_cocont_BindingSigToSignature :
        (constprod_functor1 (BinProducts_functor_precat C C BPC hsC) F))
   → Π (sig : BindingSig) (CC : Coproducts (BindingSigIndex sig) C),
                           Products (BindingSigIndex sig) C →
-  is_omega_cocont (BindingSigToSignature hsC BPC BCC TC sig CC).
+  is_omega_cocont (pr1 (BindingSigToSignature hsC BPC BCC TC sig CC)).
 Proof.
-  exact @UniMath.SubstitutionSystems.BindingSigToMonad.is_omega_cocont_BindingSigToSignature.
+exact @UniMath.SubstitutionSystems.BindingSigToMonad.is_omega_cocont_BindingSigToSignature.
 Defined.
 
-Definition InitialHSS :
-  Π (C : precategory) (hsC : has_homsets C) (CP : BinCoproducts C),
-  BinProducts C → Initial C → Colims_of_shape nat_graph C →
-  Π H : Signature C hsC, is_omega_cocont H →
-  Initial (hss_precategory CP H).
-Proof.
-  exact @UniMath.SubstitutionSystems.LiftingInitial_alt.InitialHSS.
-Defined.
-
+(** Construction 46: Datatypes specified by binding signatures (initial algebra of Id_H + H) *)
 Definition SignatureInitialAlgebra :
-  Π {C : precategory} (hsC : has_homsets C)
-  (BPC : BinProducts C) (BCC : BinCoproducts C),
-    Initial C → Colims_of_shape nat_graph C
+  Π {C : precategory} (hsC : has_homsets C) (BPC : BinProducts C) (BCC : BinCoproducts C),
+  Initial C → Colims_of_shape nat_graph C
   → Π s : Signature C hsC, is_omega_cocont (Signature_Functor C hsC s)
   → Initial (FunctorAlg (Id_H C hsC BCC s) (BindingSigToMonad.has_homsets_C2 hsC)).
 Proof.
-  exact @UniMath.SubstitutionSystems.BindingSigToMonad.SignatureInitialAlgebra.
+exact @UniMath.SubstitutionSystems.BindingSigToMonad.SignatureInitialAlgebra.
 Defined.
 
+(** Theorem 48: Construction of a substitution operation on an initial algebra *)
+Definition InitialHSS :
+  Π (C : precategory) (hsC : has_homsets C) (CP : BinCoproducts C),
+  BinProducts C → Initial C → Colims_of_shape nat_graph C →
+  Π H : Signature C hsC, is_omega_cocont (pr1 H) →
+  Initial (hss_precategory CP H).
+Proof.
+exact @UniMath.SubstitutionSystems.LiftingInitial_alt.InitialHSS.
+Defined.
+
+(** Section 4.2: Binding signatures to monads *)
 Definition BindingSigToMonad :
   Π (C : precategory) (hsC : has_homsets C) (BPC : BinProducts C),
   BinCoproducts C → Terminal C → Initial C → Colims_of_shape nat_graph C
@@ -247,50 +367,8 @@ Proof.
   exact @UniMath.SubstitutionSystems.BindingSigToMonad.BindingSigToMonad.
 Defined.
 
-Definition algebra_ob_pair {C : precategory} {F : functor C C} X (f : C⟦F X, X⟧)
-  : algebra_ob F.
-Proof.
-  exists X.
-  exact f.
-Defined.
+(** Example 50: Untyped lambda calculus *)
+(* See: UniMath/SubstitutionSystems/LamFromBindingSig.v *)
 
-Lemma colim_of_chain_is_initial_alg
-  : Π (C : precategory) (hsC : has_homsets C) (InitC : Initial C)
-      (F : functor C C) (HF : is_omega_cocont F)
-      (CC : ColimCocone (initChain InitC F)),
-    isInitial (FunctorAlg F hsC)
-              (algebra_ob_pair (colim CC) (colim_algebra_mor InitC HF CC)).
-Proof.
-  exact @UniMath.CategoryTheory.CocontFunctors.colimAlgIsInitial.
-Defined.
-
-Local Notation "'chain'" := (diagram nat_graph).
-
-Lemma is_omega_cocont_pre_composition_functor
-     (A B C : precategory) (F : functor A B) (hsB : has_homsets B) (hsC : has_homsets C)
-     (H : Colims_of_shape nat_graph C) :
-     is_omega_cocont (pre_composition_functor A B C hsB hsC F).
-Proof.
-  exact (@CocontFunctors.is_omega_cocont_pre_composition_functor _ _ _ _ _ _ H).
-Defined.
-
-Definition ColimCoconeHSET
-  : Π (g : graph) (D : diagram g HSET), ColimCocone D.
-Proof.
-  exact @UniMath.CategoryTheory.category_hset_structures.ColimCoconeHSET.
-Defined.
-
-Lemma is_omega_cocont_binproduct_functor
-  : Π (C : precategory) (PC : BinProducts C), has_homsets C →
-    (Π (x : C), is_omega_cocont (constprod_functor1 PC x)) →
-    is_omega_cocont (binproduct_functor PC).
-Proof.
-  exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_binproduct_functor.
-Defined.
-
-Lemma left_adjoint_cocont
-  : Π (C D : precategory) (F : functor C D),
-    is_left_adjoint F → has_homsets C → has_homsets D → is_cocont F.
-Proof.
-  exact @UniMath.CategoryTheory.CocontFunctors.left_adjoint_cocont.
-Defined.
+(** Example 51: Raw syntax of Martin-Löf type theory *)
+(* See: UniMath/SubstitutionSystems/MLTT79.v *)

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -8,7 +8,7 @@ by Benedikt Ahrens, Ralph Matthes and Anders Mörtberg.
 
 
 PLEASE DO NOT RENAME THIS FILE - its name is referenced in the article
-about this formalization
+about this formalization.
 
 *)
 Require Import UniMath.Foundations.Basics.PartD.
@@ -41,21 +41,30 @@ Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.Monads.
 Require Import UniMath.SubstitutionSystems.Signatures.
+Require Import UniMath.SubstitutionSystems.SumOfSignatures.
+Require Import UniMath.SubstitutionSystems.SignatureCategory.
 Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.BindingSigToMonad.
 Require Import UniMath.SubstitutionSystems.LiftingInitial_alt.
 
 (** Definition 1: Artiy, Binding signature *)
-
-(** Example 2: Binding signature of untyped lambda calculus *)
-
-(** Example 3: Binding signature of presyntax of Martin-Löf type theory *)
+Definition BindingSig : UU :=
+  @UniMath.SubstitutionSystems.BindingSigToMonad.BindingSig.
 
 (** Definition 4: Signatures with strength *)
+Definition Signature : Π C : precategory, has_homsets C → UU :=
+  @UniMath.SubstitutionSystems.Signatures.Signature.
 
 (** Definition 5: Morphism of signatures with strength *)
+Definition SignatureMor :
+  Π C : Precategory, Signature C (homset_property C) → Signature C (homset_property C) → UU :=
+  @UniMath.SubstitutionSystems.SignatureCategory.SignatureMor.
 
 (** Definition 6: Coproduct of signatures with strength *)
+Definition Sum_of_Signatures :
+  Π (I : UU) (C : precategory) (hsC : has_homsets C), Coproducts I C
+  → (I → Signature C hsC) → Signature C hsC :=
+    @UniMath.SubstitutionSystems.SumOfSignatures.Sum_of_Signatures.
 
 (** Definition 7: Binary product of signatures with strength *)
 

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -306,12 +306,13 @@ Defined.
 (* see: UniMath/CategoryTheory/Inductives/Lists.v *)
 
 (** Theorem 42: Precomposition functor preserves colimits *)
-Lemma is_cocont_pre_composition_functor :
-  Π (A B C : precategory) (F : functor A B) (hsB : has_homsets B) (hsC : has_homsets C),
-  (Π (g : graph) (d : diagram g [B, C, hsC]) (b : B), ColimCocone (diagram_pointwise hsC d b))
-  → is_cocont (pre_composition_functor A B C hsB hsC F).
+Lemma preserves_colimit_pre_composition_functor :
+  Π (A B C : precategory) (F : functor A B) (hsB : has_homsets B) (hsC : has_homsets C)
+    (g : graph) (d : diagram g [B, C, hsC]) (G : [B, C, hsC]) (ccG : cocone d G),
+    (Π b : B, ColimCocone (diagram_pointwise hsC d b))
+  → preserves_colimit (pre_composition_functor A B C hsB hsC F) d G ccG.
 Proof.
-exact @UniMath.CategoryTheory.CocontFunctors.is_cocont_pre_composition_functor.
+exact @UniMath.CategoryTheory.CocontFunctors.preserves_colimit_pre_composition_functor.
 Defined.
 
 Lemma is_omega_cocont_pre_composition_functor :

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -1,3 +1,16 @@
+(**
+
+This file provides a stable interface to the formalization of the paper:
+
+  From binding signatures to monads in UniMath
+
+by Benedikt Ahrens, Ralph Matthes and Anders Mörtberg.
+
+
+PLEASE DO NOT RENAME THIS FILE - its name is referenced in the article
+about this formalization
+
+*)
 Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.Foundations.Basics.Propositions.
 Require Import UniMath.Foundations.Basics.Sets.
@@ -31,6 +44,91 @@ Require Import UniMath.SubstitutionSystems.Signatures.
 Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.BindingSigToMonad.
 Require Import UniMath.SubstitutionSystems.LiftingInitial_alt.
+
+(** Definition 1: Artiy, Binding signature *)
+
+(** Example 2: Binding signature of untyped lambda calculus *)
+
+(** Example 3: Binding signature of presyntax of Martin-Löf type theory *)
+
+(** Definition 4: Signatures with strength *)
+
+(** Definition 5: Morphism of signatures with strength *)
+
+(** Definition 6: Coproduct of signatures with strength *)
+
+(** Definition 7: Binary product of signatures with strength *)
+
+(** Problem 8: Signatures with strength from binding signatures *)
+
+(** Definition 15: Graph *)
+
+(** Definition 16: Diagram *)
+
+(** Definition 18: Cocone *)
+
+(** Definition 19: Colimiting cocone *)
+
+(** Remark 20: Uniqueness of colimits *)
+
+(** Definition 21: Preservation of colimits *)
+
+(** Lemma 22: Invariance of cocontinuity under isomorphism *)
+
+(** Problem 23: Colimits in functor categories *)
+
+(** Problem 25: Initial algebras of ω-cocontinuous functors *)
+
+(** Lemma 26: Lambek's lemma *)
+
+(** Problem 28: Colimits in Set *)
+
+(** Definition 30: Smallest equivalence relation containing a relation *)
+
+(** Lemma 32: Left adjoints preserve colimits *)
+
+(** Lemma 33: Examples of preservation of colimits *)
+(** (i): Identity functor *)
+(** (ii): Constant functor *)
+(** (iii): Diagonal functor *)
+(** (iv): Coproduct functor *)
+
+(** Lemma 34: Examples of preservation of cocontinuity *)
+(** (i): Composition of functors *)
+(** (ii): Families of functors *)
+
+(** Definition 35: Exponentials *)
+
+(** Example 36: Exponentials in Set *)
+
+(** Lemma 37: Left and right product functors preserves colimits *)
+
+(** Theorem 38: Binary product functor is ω-cocontinuous *)
+
+(** Example 39: Lists of sets *)
+
+(** Theorem 41: Colimits of a specific shape in functor categories *)
+
+(** Theorem 42: Precomposition functor preserves colimits *)
+
+(** Theorem 44: Signature functor associated to a binding signature is ω-cocontinuous *)
+
+(** Construction 46: Datatypes specified by binding signatures (initial algebra of Id_H + H) *)
+
+(** Definition 47: Heterogeneous substitution systems *)
+
+(** Theorem 48: Construction of a substitution operation on an initial algebra *)
+
+(** Theorem 49: Construction of a monad from a substitution system *)
+
+(** Section 4.2: Binding signatures to monads *)
+
+(** Example 50: Untyped lambda calculus *)
+
+(** Example 51: Raw syntax of Martin-Löf type theory *)
+
+
+
 
 Definition Arity_to_Signature :
   Π (C : precategory) (hsC : has_homsets C),

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -84,6 +84,8 @@ Definition BindingSigToSignature :
   → Π sig : BindingSig, Coproducts (BindingSigIndex sig) C → Signature C hsC :=
     @UniMath.SubstitutionSystems.BindingSigToMonad.BindingSigToSignature.
 
+(** Definition 10 and Lemma 11 and 12: see UniMath/SubstitutionSystems/SignatureExamples.v *)
+
 (** Definition 15: Graph *)
 Definition graph : UU := @UniMath.CategoryTheory.limits.graphs.colimits.graph.
 
@@ -347,13 +349,22 @@ exact @UniMath.SubstitutionSystems.BindingSigToMonad.SignatureInitialAlgebra.
 Defined.
 
 (** Theorem 48: Construction of a substitution operation on an initial algebra *)
-Definition InitialHSS :
+Definition InitHSS :
   Π (C : precategory) (hsC : has_homsets C) (CP : BinCoproducts C),
   BinProducts C → Initial C → Colims_of_shape nat_graph C →
-  Π H : Signature C hsC, is_omega_cocont (pr1 H) →
-  Initial (hss_precategory CP H).
+  Π H : Signature C hsC, is_omega_cocont (pr1 H) → hss_precategory CP H.
 Proof.
-exact @UniMath.SubstitutionSystems.LiftingInitial_alt.InitialHSS.
+exact @UniMath.SubstitutionSystems.LiftingInitial_alt.InitHSS.
+Defined.
+
+Lemma isInitial_InitHSS :
+  Π (C : precategory) (hsC : has_homsets C) (CP : BinCoproducts C)
+  (BPC : BinProducts C) (IC : Initial C)
+  (CC : Colims_of_shape nat_graph C) (H : Signature C hsC)
+  (HH : is_omega_cocont (pr1 H)),
+  isInitial (hss_precategory CP H) (InitHSS C hsC CP BPC IC CC H HH).
+Proof.
+exact @UniMath.SubstitutionSystems.LiftingInitial_alt.isInitial_InitHSS.
 Defined.
 
 (** Section 4.2: Binding signatures to monads *)

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -41,13 +41,16 @@ Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.Monads.
 Require Import UniMath.SubstitutionSystems.Signatures.
+Require Import UniMath.SubstitutionSystems.BinProductOfSignatures.
 Require Import UniMath.SubstitutionSystems.SumOfSignatures.
 Require Import UniMath.SubstitutionSystems.SignatureCategory.
 Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.BindingSigToMonad.
 Require Import UniMath.SubstitutionSystems.LiftingInitial_alt.
 
-(** Definition 1: Artiy, Binding signature *)
+Local Notation "[ C , D , hsD ]" := (functor_precategory C D hsD).
+
+(** Definition 1: Binding signature *)
 Definition BindingSig : UU :=
   @UniMath.SubstitutionSystems.BindingSigToMonad.BindingSig.
 
@@ -67,28 +70,87 @@ Definition Sum_of_Signatures :
     @UniMath.SubstitutionSystems.SumOfSignatures.Sum_of_Signatures.
 
 (** Definition 7: Binary product of signatures with strength *)
+Definition BinProduct_of_Signatures :
+  Π (C : precategory) (hsC : has_homsets C), BinProducts C
+  → Signature C hsC → Signature C hsC → Signature C hsC :=
+    @UniMath.SubstitutionSystems.BinProductOfSignatures.BinProduct_of_Signatures.
 
 (** Problem 8: Signatures with strength from binding signatures *)
+Definition BindingSigToSignature :
+  Π (C : precategory) (hsC : has_homsets C), BinProducts C → BinCoproducts C → Terminal C
+  → Π sig : BindingSig, Coproducts (BindingSigIndex sig) C → Signature C hsC :=
+    @UniMath.SubstitutionSystems.BindingSigToMonad.BindingSigToSignature.
 
 (** Definition 15: Graph *)
+Definition graph : UU := @UniMath.CategoryTheory.limits.graphs.colimits.graph.
 
 (** Definition 16: Diagram *)
+Definition diagram : graph → precategory → UU :=
+  @UniMath.CategoryTheory.limits.graphs.colimits.diagram.
 
 (** Definition 18: Cocone *)
+Definition cocone : Π {C : precategory} {g : graph}, diagram g C → C → UU :=
+  @UniMath.CategoryTheory.limits.graphs.colimits.cocone.
 
 (** Definition 19: Colimiting cocone *)
+Definition isColimCocone : Π {C : precategory} {g : graph} (d : diagram g C)
+  (c0 : C), cocone d c0 → UU :=
+    @UniMath.CategoryTheory.limits.graphs.colimits.isColimCocone.
+
+(** Colimits of a specific shape *)
+Definition Colims_of_shape : graph → precategory → UU :=
+  @UniMath.CategoryTheory.limits.graphs.colimits.Colims_of_shape.
+
+(** Colimits of any shape *)
+Definition Colims : precategory → UU :=
+  @UniMath.CategoryTheory.limits.graphs.colimits.Colims.
 
 (** Remark 20: Uniqueness of colimits *)
+Lemma isaprop_Colims : Π C : category, isaprop (Colims C).
+Proof.
+exact @UniMath.CategoryTheory.limits.graphs.colimits.isaprop_Colims.
+Defined.
 
 (** Definition 21: Preservation of colimits *)
+Definition preserves_colimit : Π {C D : precategory}, functor C D
+  → Π {g : graph} (d : diagram g C) (L : C), cocone d L → UU :=
+    @UniMath.CategoryTheory.CocontFunctors.preserves_colimit.
+
+Definition is_cocont : Π C D : precategory, functor C D → UU :=
+  @UniMath.CategoryTheory.CocontFunctors.is_cocont.
+
+Definition is_omega_cocont : Π {C D : precategory}, functor C D → UU :=
+  @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont.
 
 (** Lemma 22: Invariance of cocontinuity under isomorphism *)
+Lemma preserves_colimit_iso :
+  Π (C D : precategory) (hsD : has_homsets D) (F G : functor C D) (α : @iso [C,D,hsD] F G)
+    (g : graph) (d : diagram g C) (L : C) (cc : cocone d L),
+  preserves_colimit F d L cc → preserves_colimit G d L cc.
+Proof.
+exact @UniMath.CategoryTheory.CocontFunctors.preserves_colimit_iso.
+Defined.
 
 (** Problem 23: Colimits in functor categories *)
+Definition ColimsFunctorCategory_of_shape :
+  Π (g : graph) (A C : precategory) (hsC : has_homsets C),
+  Colims_of_shape g C → Colims_of_shape g [A,C,hsC] :=
+    @UniMath.CategoryTheory.limits.graphs.colimits.ColimsFunctorCategory_of_shape.
 
 (** Problem 25: Initial algebras of ω-cocontinuous functors *)
+Definition colimAlgInitial :
+  Π (C : precategory) (hsC : has_homsets C) (InitC : Initial C)
+    (F : functor C C), is_omega_cocont F → ColimCocone (initChain InitC F) →
+  Initial (FunctorAlg F hsC) :=
+    @UniMath.CategoryTheory.CocontFunctors.colimAlgInitial.
 
 (** Lemma 26: Lambek's lemma *)
+Lemma initialAlg_is_iso :
+  Π (C : precategory) (hsC : has_homsets C) (F : functor C C)
+    (Aa : algebra_ob F), isInitial (FunctorAlg F hsC) Aa → is_iso (alg_map F Aa).
+Proof.
+exact @UniMath.CategoryTheory.FunctorAlgebras.initialAlg_is_iso.
+Defined.
 
 (** Problem 28: Colimits in Set *)
 
@@ -139,21 +201,6 @@ Definition Sum_of_Signatures :
 
 
 
-Definition Arity_to_Signature :
-  Π (C : precategory) (hsC : has_homsets C),
-  BinProducts C → BinCoproducts C → Terminal C → list nat → Signature C hsC.
-Proof.
-  exact @UniMath.SubstitutionSystems.BindingSigToMonad.Arity_to_Signature.
-Defined.
-
-Definition BindingSigToSignature :
-  Π {C : precategory} (hsC : has_homsets C),
-  BinProducts C → BinCoproducts C → Terminal C →
-  Π sig : BindingSig, Coproducts (BindingSigIndex sig) C →
-  Signature C hsC.
-Proof.
-  exact @UniMath.SubstitutionSystems.BindingSigToMonad.BindingSigToSignature.
-Defined.
 
 Local Notation "'[ C , C, hsC ]'" := (functor_precategory C C hsC).
 
@@ -218,7 +265,6 @@ Proof.
 Defined.
 
 Local Notation "'chain'" := (diagram nat_graph).
-Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
 Lemma is_omega_cocont_pre_composition_functor
      (A B C : precategory) (F : functor A B) (hsB : has_homsets B) (hsC : has_homsets C)


### PR DESCRIPTION
This PR updates the summary file for our recent paper on the translation from binding signatures to monads. It now lists all the major results and definitions of the paper with links to where they are in the development. While doing this I noticed that we didn't specify which universe `is_cocont` was supposed to be in so that it ended up in `Type` instead of `UU`, this has now been fixed. 