### PR TITLE
Various results on adjunctions

### DIFF
--- a/UniMath/CategoryTheory/AdjunctionHomTypesWeq.v
+++ b/UniMath/CategoryTheory/AdjunctionHomTypesWeq.v
@@ -35,13 +35,10 @@ Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 
 Section HomSetIso_from_Adjunction.
 
-Variables C D : precategory.
-Variable F : functor C D.
-Variable H : is_left_adjoint F.
+Context {C D : precategory} {F : functor C D} {G : functor D C} (H : are_adjoints F G).
 
-Let G := right_adjoint H.
-Let η := unit_from_left_adjoint H.
-Let ε := counit_from_left_adjoint H.
+Let η := unit_from_are_adjoints H.
+Let ε := counit_from_are_adjoints H.
 
 (** * Definition of the maps on hom-types *)
 
@@ -58,7 +55,7 @@ Lemma φ_adj_after_φ_adj_inv {A : C} {B : D} (g : A --> G B)
 Proof.
   unfold φ_adj.
   unfold φ_adj_inv.
-  assert (X':=triangle_id_right_ad _ _ _ H).
+  assert (X':=triangle_id_right_ad H).
   rewrite functor_comp.
   rewrite assoc.
   assert (X2 := nat_trans_ax η). simpl in X2.

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -88,12 +88,8 @@ Section cocont.
 
 Context {C D : precategory} (F : functor C D).
 
-Definition preserves_colimit {g : graph} (d : diagram g C) (L : C)
-  (cc : cocone d L) : UU :=
-  isColimCocone d L cc -> isColimCocone (mapdiagram F d) (F L) (mapcocone F d cc).
-
 Definition is_cocont : UU := Π {g : graph} (d : diagram g C) (L : C)
-  (cc : cocone d L), preserves_colimit d L cc.
+  (cc : cocone d L), preserves_colimit F d L cc.
 
 End cocont.
 
@@ -400,40 +396,7 @@ Section cocont_functors.
 Lemma left_adjoint_cocont {C D : precategory} (F : functor C D)
   (H : is_left_adjoint F) (hsC : has_homsets C) (hsD : has_homsets D) : is_cocont F.
 Proof.
-intros g d L ccL HccL M ccM.
-set (G := pr1 H).
-apply (@iscontrweqb _ (Σ y : C ⟦ L, G M ⟧,
-    Π i, coconeIn ccL i ;; y = φ_adj _ _ _ H (coconeIn ccM i))).
-- eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧,
-    Π i, # F (coconeIn ccL i) ;; φ_adj_inv _ _ _ H y = coconeIn ccM i)).
-  + apply (weqbandf (adjunction_hom_weq _ _ _ H L M)); simpl; intro f.
-    abstract (apply weqiff; try (apply impred; intro; apply hsD);
-    now rewrite φ_adj_inv_after_φ_adj).
-  + eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧,
-      Π i, φ_adj_inv _ _ _ _ (coconeIn ccL i ;; y) = coconeIn ccM i)).
-    * apply weqfibtototal; simpl; intro f.
-    abstract (apply weqiff; try (apply impred; intro; apply hsD); split;
-      [ intros HH i; rewrite φ_adj_inv_natural_precomp; apply HH
-      | intros HH i; rewrite <- φ_adj_inv_natural_precomp; apply HH ]).
-      (* apply weqonsecfibers; intro i. *)
-      (* rewrite φ_adj_inv_natural_precomp; apply idweq. *)
-    * apply weqfibtototal; simpl; intro f.
-    abstract (apply weqiff; [ | apply impred; intro; apply hsD | apply impred; intro; apply hsC ];
-      split; intros HH i;
-        [ now rewrite <- (HH i), φ_adj_after_φ_adj_inv
-        | now rewrite (HH i),  φ_adj_inv_after_φ_adj ]).
-      (* apply weqonsecfibers; intro i. *)
-      (* apply weqimplimpl; [ | | apply hsD | apply hsC]; intro h. *)
-      (*   now rewrite <- h, (φ_adj_after_φ_adj_inv _ _ _ H). *)
-      (* now rewrite h, (φ_adj_inv_after_φ_adj _ _ _ H). *)
-- transparent assert (X : (cocone d (G M))).
-  { use mk_cocone.
-    + intro v; apply (φ_adj C D F H (coconeIn ccM v)).
-    + abstract (intros m n e; simpl;
-                rewrite <- (coconeInCommutes ccM m n e); simpl;
-                now rewrite φ_adj_natural_precomp).
-  }
-  apply (HccL (G M) X).
+now intros g d L ccL; apply left_adjoint_preserves_colimit.
 Defined.
 
 (* Print Assumptions left_adjoint_cocont. *)

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -44,6 +44,8 @@ This file also contains proofs that the following functors are (omega-)cocontinu
   [is_omega_cocont_BinProduct_of_functors_alt] [is_omega_cocont_BinProduct_of_functors]
 - Precomposition functor: _ o K : ⟦C,A⟧ -> ⟦M,A⟧ for K : M -> C
   [preserves_colimit_pre_composition_functor] [is_omega_cocont_pre_composition_functor]
+- Postcomposition with a left adjoint:
+  [is_cocont_post_composition_functor] [is_omega_cocont_post_composition_functor]
 - Swapping of functor category arguments:
   [is_cocont_functor_cat_swap] [is_omega_cocont_functor_cat_swap]
 
@@ -1536,6 +1538,26 @@ Definition omega_cocont_pre_composition_functor_kan :
   tpair _ _ is_omega_cocont_pre_composition_functor_kan.
 
 End pre_composition_functor_kan.
+
+Section post_composition_functor.
+
+Context {C D E : precategory} (hsD : has_homsets D) (hsE : has_homsets E).
+Context (F : functor D E) (HF : is_left_adjoint F).
+
+Lemma is_cocont_post_composition_functor :
+  is_cocont (post_composition_functor C D E hsD hsE F).
+Proof.
+apply left_adjoint_cocont; try apply functor_category_has_homsets.
+apply (is_left_adjoint_post_composition_functor _ _ _ HF).
+Defined.
+
+Lemma is_omega_cocont_post_composition_functor :
+  is_omega_cocont (post_composition_functor C D E hsD hsE F).
+Proof.
+now intros c L ccL; apply is_cocont_post_composition_functor.
+Defined.
+
+End post_composition_functor.
 
 (** * Swapping of functor category arguments *)
 Section functor_swap.

--- a/UniMath/CategoryTheory/EndofunctorsMonoidal.v
+++ b/UniMath/CategoryTheory/EndofunctorsMonoidal.v
@@ -6,6 +6,7 @@ SubstitutionSystems
 
 2015
 
+Modified by: Anders Mörtberg, 2016
 
 ************************************************************)
 
@@ -19,67 +20,39 @@ Contents :
 
 ************************************************************)
 
-
 Require Import UniMath.Foundations.Basics.PartD.
 
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 
-
-Local Notation "# F" := (functor_on_morphisms F)(at level 3).
-Local Notation "F ⟶ G" := (nat_trans F G) (at level 39).
-Local Notation "G ∙ F" := (functor_composite _ _ _ F G) (at level 35).
-
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
-
-Arguments functor_composite {_ _ _} _ _ .
-
 (** There is a monoidal structure on endofunctors, given by composition.
     While this is considered to be strict in set-theoretic category theory,
     it ain't strict in type theory with respect to convertibility.
     So we consider it to be a weak monoidal structure instead.
 *)
-
 Section Monoidal_Structure_on_Endofunctors.
 
-Variable C : precategory.
+Context {C : precategory}.
 
-Definition ρ_functor (X : functor C C)
-  : nat_trans (functor_composite X (functor_identity C)) X.
-Proof.
-  exists (λ x, identity (X x) ) .
-  intros a b f. simpl.
-  pathvia (#X f).
-  - apply id_right.
-  - apply pathsinv0, id_left.
-Defined.
+Definition ρ_functor (X : functor C C) :
+  nat_trans (functor_composite X (functor_identity C)) X := nat_trans_functor_id_right X.
 
-Definition ρ_functor_inv (X : functor C C)
-  : nat_trans X (functor_composite X (functor_identity C)) := ρ_functor X.
+Definition ρ_functor_inv (X : functor C C) :
+  nat_trans X (functor_composite X (functor_identity C)) := ρ_functor X.
 
-Definition λ_functor (X : functor C C)
-  : nat_trans (functor_composite (functor_identity C) X) X
-  := ρ_functor X.
+Definition λ_functor (X : functor C C) :
+  nat_trans (functor_composite (functor_identity C) X) X := ρ_functor X.
 
-Definition λ_functor_inv (X : functor C C)
-  : nat_trans X (functor_composite (functor_identity C) X)
-  := ρ_functor X.
+Definition λ_functor_inv (X : functor C C) :
+  nat_trans X (functor_composite (functor_identity C) X) := ρ_functor X.
 
-Definition α_functor (X Y Z : functor C C)
-  : nat_trans (functor_composite (functor_composite X Y) Z)
-              (functor_composite X (functor_composite Y Z)).
-Proof.
-  exists (λ x, identity _ ).
-  intros a b f;
-  simpl.
-  rewrite id_right.
-  apply pathsinv0, id_left.
-Defined.
+Definition α_functor (X Y Z : functor C C) :
+  nat_trans (functor_composite (functor_composite X Y) Z)
+            (functor_composite X (functor_composite Y Z)) := nat_trans_functor_assoc X Y Z.
 
-Definition α_functor_inv (X Y Z : functor C C)
-  : nat_trans (functor_composite X (functor_composite Y Z))
-              (functor_composite (functor_composite X Y) Z) := α_functor X Y Z.
-
+Definition α_functor_inv (X Y Z : functor C C) :
+  nat_trans (functor_composite X (functor_composite Y Z))
+            (functor_composite (functor_composite X Y) Z) := α_functor X Y Z.
 
 End Monoidal_Structure_on_Endofunctors.

--- a/UniMath/CategoryTheory/RightKanExtension.v
+++ b/UniMath/CategoryTheory/RightKanExtension.v
@@ -152,7 +152,7 @@ End fix_T.
 Lemma RightKanExtension_from_limits : GlobalRightKanExtensionExists _ _ K _ hsC hsA.
 Proof.
 unfold GlobalRightKanExtensionExists.
-use adjunction_from_partial.
+use left_adjoint_from_partial.
 - apply R_functor.
 - apply eps.
 - intros T S α; simpl in *.

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -617,7 +617,7 @@ Defined.
 Lemma has_exponentials_functor_HSET : has_exponentials CP.
 Proof.
 intro P.
-use adjunction_from_partial.
+use left_adjoint_from_partial.
 - apply (exponential_functor_cat P).
 - intro Q; simpl; apply eval.
 - intros Q R φ; simpl in *.

--- a/UniMath/CategoryTheory/equivalences.v
+++ b/UniMath/CategoryTheory/equivalences.v
@@ -32,86 +32,102 @@ Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
-
-Local Notation "a --> b" := (precategory_morphisms a b)(at level 50).
-(*Local Notation "'hom' C" := (precategory_morphisms (C := C)) (at level 2).*)
-(* Local Notation "f ;; g" := (compose f g) (at level 50, format "f  ;;  g"). *)
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
-Arguments functor_composite {_ _ _} _ _ .
+(** * Adjunctions *)
+Section adjunctions.
 
+Definition form_adjunction {A B : precategory} (F : functor A B) (G : functor B A)
+  (eta : nat_trans (functor_identity A) (functor_composite F G))
+  (eps : nat_trans (functor_composite G F) (functor_identity B)) : UU :=
+    (Π a : A, # F (eta a) ;; eps (F a) = identity (F a)) ×
+    (Π b : B, eta (G b) ;; # G (eps b) = identity (G b)).
 
-(** * Adjunction *)
+Definition are_adjoints {A B : precategory} (F : functor A B) (G : functor B A) : UU :=
+  Σ (etaeps : (nat_trans (functor_identity A) (functor_composite F G)) ×
+              (nat_trans (functor_composite G F) (functor_identity B))),
+      form_adjunction F G (pr1 etaeps) (pr2 etaeps).
 
-Definition form_adjunction {A B : precategory}
-       (F : functor A B) (G : functor B A)
-       (eta : nat_trans (functor_identity A) (functor_composite F G))
-       (eps : nat_trans (functor_composite G F) (functor_identity B)) : UU :=
-dirprod
-  (Π a : ob A,
-       #F (eta a) ;; eps (F a) = identity (F a))
-  (Π b : ob B,
-       eta (G b) ;; #G (eps b) = identity (G b)).
+Definition unit_from_are_adjoints {A B : precategory}
+   {F : functor A B} {G : functor B A} (H : are_adjoints F G) :
+  nat_trans (functor_identity A) (functor_composite F G)
+  := pr1 (pr1 H).
 
+Definition counit_from_are_adjoints {A B : precategory}
+  {F : functor A B} {G : functor B A} (H : are_adjoints F G)  :
+   nat_trans (functor_composite G F) (functor_identity B)
+   := pr2 (pr1 H).
 
-Definition are_adjoints {A B : precategory}
-   (F : functor A B)  (G : functor B A) : UU :=
-  total2 (fun etaeps : dirprod
-            (nat_trans (functor_identity A) (functor_composite F G))
-            (nat_trans (functor_composite G F) (functor_identity B)) =>
-      form_adjunction  F G (pr1 etaeps) (pr2 etaeps)).
+Definition is_left_adjoint {A B : precategory} (F : functor A B) : UU :=
+  Σ (G : functor B A), are_adjoints F G.
 
+Definition is_right_adjoint {A B : precategory} (G : functor B A) : UU :=
+  Σ (F : functor A B), are_adjoints F G.
 
-Definition is_left_adjoint {A B : precategory}
-  (F : functor A B) : UU :=
-   total2 (fun G : functor B A => are_adjoints F G).
+Definition are_adjoints_to_is_left_adjoint {A B : precategory} (F : functor A B) (G : functor B A)
+           (H : are_adjoints F G) : is_left_adjoint F := (G,,H).
 
+Coercion are_adjoints_to_is_left_adjoint : are_adjoints >-> is_left_adjoint.
+
+Definition are_adjoints_to_is_right_adjoint {A B : precategory} (F : functor A B) (G : functor B A)
+           (H : are_adjoints F G) : is_right_adjoint G := (F,,H).
+
+Coercion are_adjoints_to_is_right_adjoint : are_adjoints >-> is_right_adjoint.
 
 Definition right_adjoint {A B : precategory}
   {F : functor A B} (H : is_left_adjoint F) : functor B A := pr1 H.
 
+Lemma is_right_adjoint_right_adjoint {A B : precategory}
+      {F : functor A B} (H : is_left_adjoint F) : is_right_adjoint (right_adjoint H).
+Proof.
+exact (F,,pr2 H).
+Defined.
+
+Definition left_adjoint {A B : precategory}
+  {G : functor B A} (H : is_right_adjoint G) : functor A B := pr1 H.
+
+Lemma is_left_adjoint_left_adjoint {A B : precategory}
+      {G : functor B A} (H : is_right_adjoint G) : is_left_adjoint (left_adjoint H).
+Proof.
+exact (G,,pr2 H).
+Defined.
 
 Definition unit_from_left_adjoint {A B : precategory}
    {F : functor A B}  (H : is_left_adjoint F) :
   nat_trans (functor_identity A) (functor_composite F (right_adjoint H))
-  := pr1 (pr1 (pr2 H)).
+  := unit_from_are_adjoints (pr2 H).
 
+Definition unit_from_right_adjoint {A B : precategory}
+   {G : functor B A}  (H : is_right_adjoint G) :
+  nat_trans (functor_identity A) (functor_composite (left_adjoint H) G)
+  := unit_from_are_adjoints (pr2 H).
 
 Definition counit_from_left_adjoint {A B : precategory}
   {F : functor A B}   (H : is_left_adjoint F)  :
  nat_trans (functor_composite (right_adjoint H) F) (functor_identity B)
-   := pr2 (pr1 (pr2 H)).
+   := counit_from_are_adjoints (pr2 H).
 
+Definition counit_from_right_adjoint {A B : precategory}
+  {G : functor B A} (H : is_right_adjoint G)  :
+ nat_trans (functor_composite G (left_adjoint H)) (functor_identity B)
+   := counit_from_are_adjoints (pr2 H).
 
-Definition triangle_id_left_ad (A B : precategory)
-  (F : functor A B) (H : is_left_adjoint F) :
-  Π (a : ob A),
-       #F (unit_from_left_adjoint H a);;
-       counit_from_left_adjoint H (F a)
-       =
-      identity (F a)
-   := pr1 (pr2 (pr2 H)).
+Definition triangle_id_left_ad {A B : precategory} {F : functor A B} {G : functor B A}
+  (H : are_adjoints F G) :
+  Π a, # F (unit_from_are_adjoints H a) ;; counit_from_are_adjoints H (F a) = identity (F a)
+   := pr1 (pr2 H).
 
-Definition triangle_id_right_ad (A B : precategory)
-   (F : functor A B)  (H : is_left_adjoint F) :
-  Π b : ob B,
-         unit_from_left_adjoint H (right_adjoint H b);;
-        #(right_adjoint H) (counit_from_left_adjoint H b) =
-        identity (right_adjoint H b)
-  := pr2 (pr2 (pr2 H)).
+Definition triangle_id_right_ad {A B : precategory} {F : functor A B} {G : functor B A}
+  (H : are_adjoints F G) :
+  Π b, unit_from_are_adjoints H (G b) ;; # G (counit_from_are_adjoints H b) = identity (G b)
+  := pr2 (pr2 H).
 
 (** * Equivalence of (pre)categories *)
 
-Definition adj_equivalence_of_precats {A B : precategory}
-  (F : functor A B) : UU :=
-   total2 (fun H : is_left_adjoint F =>
-     dirprod (Π a, is_isomorphism
-                    (unit_from_left_adjoint H a))
-             (Π b, is_isomorphism
-                    (counit_from_left_adjoint H b))
-             ).
+Definition adj_equivalence_of_precats {A B : precategory} (F : functor A B) : UU :=
+   Σ (H : is_left_adjoint F), (Π a, is_isomorphism (unit_from_left_adjoint H a)) ×
+                              (Π b, is_isomorphism (counit_from_left_adjoint H b)).
 
 Definition adj_equivalence_inv {A B : precategory}
   {F : functor A B} (HF : adj_equivalence_of_precats F) : functor B A :=
@@ -122,14 +138,16 @@ Local Notation "HF ^^-1" := (adj_equivalence_inv  HF)(at level 3).
 Definition unit_pointwise_iso_from_adj_equivalence {A B : precategory}
    {F : functor A B} (HF : adj_equivalence_of_precats F) :
     Π a, iso a (HF^^-1 (F a)).
-  intro a.
-  exists (unit_from_left_adjoint (pr1 HF) a).
-  exact (pr1 (pr2 HF) a).
+Proof.
+intro a.
+exists (unit_from_left_adjoint (pr1 HF) a).
+exact (pr1 (pr2 HF) a).
 Defined.
 
 Definition counit_pointwise_iso_from_adj_equivalence {A B : precategory}
   {F : functor A B} (HF : adj_equivalence_of_precats F) :
     Π b, iso (F (HF^^-1 b)) b.
+Proof.
   intro b.
   exists (counit_from_left_adjoint (pr1 HF) b).
   exact (pr2 (pr2 HF) b).
@@ -163,23 +181,19 @@ Defined.
 Lemma identity_functor_is_adj_equivalence {A : precategory} :
   adj_equivalence_of_precats (functor_identity A).
 Proof.
-  use tpair.
-  - use tpair.
+  mkpair.
+  - mkpair.
     + exact (functor_identity A).
-    + unfold are_adjoints.
-      use tpair.
-        exact (dirprodpair (nat_trans_id _) (nat_trans_id _)).
-        split. intros a. rewrite id_left. reflexivity.
-               intros a. rewrite id_left. reflexivity.
-  - split. intros a. unfold is_isomorphism. apply identity_is_iso.
-           intros a. unfold is_isomorphism. apply identity_is_iso.
+    + exists (nat_trans_id _,, nat_trans_id _).
+      abstract (now split; [intros a; apply id_left| intros a; apply id_left]).
+  - abstract (now split; intros a; apply identity_is_iso).
 Defined.
 
 (** * Equivalence of categories yields equivalence of object types *)
 (**  Fundamentally needed that both source and target are categories *)
 
 Lemma adj_equiv_of_cats_is_weq_of_objects (A B : precategory)
-   (HA : is_category A) (HB : is_category B) (F : ob [A, B, pr2 HB ])
+   (HA : is_category A) (HB : is_category B) (F : [A, B, pr2 HB ])
    (HF : adj_equivalence_of_precats F) : isweq (pr1 (pr1 F)).
 Proof.
   set (G := right_adjoint (pr1 HF)).
@@ -189,14 +203,9 @@ Proof.
   set (BBcat := is_category_functor_category B _ HB).
   set (Et := isotoid _ AAcat et).
   set (Ep := isotoid _ BBcat ep).
-  apply (gradth _ (fun b => pr1 (right_adjoint (pr1 HF)) b)).
-  intro a.
-  set (ou := toforallpaths _ _ _ (base_paths _ _ (base_paths _ _ Et)) a).
-  simpl in ou.
-  apply (! ou).
-  intro y.
-  set (ou := toforallpaths _ _ _ (base_paths _ _ (base_paths _ _ Ep)) y).
-  apply ou.
+  apply (gradth _ (fun b => pr1 (right_adjoint (pr1 HF)) b)); intro a.
+  apply (!toforallpaths _ _ _ (base_paths _ _ (base_paths _ _ Et)) a).
+  now apply (toforallpaths _ _ _ (base_paths _ _ (base_paths _ _ Ep))).
 Defined.
 
 Definition weq_on_objects_from_adj_equiv_of_cats (A B : precategory)
@@ -205,7 +214,7 @@ Definition weq_on_objects_from_adj_equiv_of_cats (A B : precategory)
           (ob A) (ob B).
 Proof.
   exists (pr1 (pr1 F)).
-  apply (@adj_equiv_of_cats_is_weq_of_objects _ _  HA); assumption.
+  now apply (@adj_equiv_of_cats_is_weq_of_objects _ _  HA).
 Defined.
 
 
@@ -257,8 +266,7 @@ Proof.
   rewrite iso_after_iso_inv.
   rewrite id_right.
   set (H := iso_inv_iso_inv _ _ _ f').
-  set (h':= base_paths _ _ H).
-  assumption.
+  now apply (base_paths _ _ H).
 Qed.
 
 
@@ -267,9 +275,8 @@ Lemma isaprop_pi_sigma_iso (A B : precategory) (HA : is_category A) (hsB: has_ho
   isaprop (Π b : ob B,
              total2 (fun a : ob A => iso (pr1 F a) b)).
 Proof.
-  apply impred.
-  intro b.
-  apply isaprop_sigma_iso; assumption.
+  apply impred; intro b.
+  now apply isaprop_sigma_iso.
 Qed.
 
 
@@ -573,6 +580,8 @@ mkpair; simpl.
   now rewrite HHH, <- HH.
 Qed.
 
-Definition adjunction_from_partial : is_left_adjoint F := (G,, (unit,, counit),, form_adjunctionFG).
+Definition left_adjoint_from_partial : is_left_adjoint F := (G,, (unit,, counit),, form_adjunctionFG).
+Definition right_adjoint_from_partial : is_right_adjoint G := (F,, (unit,, counit),, form_adjunctionFG).
 
 End adjunction_from_partial.
+End adjunctions.

--- a/UniMath/CategoryTheory/exponentials.v
+++ b/UniMath/CategoryTheory/exponentials.v
@@ -87,15 +87,16 @@ Definition flip_iso a : @iso [C,C,hsC] (constprod_functor1 a) (constprod_functor
   tpair _ _ (is_iso_constprod_functor1 a).
 
 Variable (a : C).
-Variable (H : is_left_adjoint (constprod_functor1 a)).
+Variable (HF : is_left_adjoint (constprod_functor1 a)).
 
 Local Notation F := (constprod_functor1 a).
 Local Notation F' := (constprod_functor2 a).
-Let G := right_adjoint H.
+Let G := right_adjoint HF.
+Let H := pr2 HF : are_adjoints F G.
 Let eta : [C,C,hsC]⟦functor_identity C,functor_composite F G⟧ := unit_from_left_adjoint H.
 Let eps : [C,C,hsC]⟦functor_composite G F,functor_identity C⟧ := counit_from_left_adjoint H.
-Let H1 := triangle_id_left_ad _ _ _ H.
-Let H2 := triangle_id_right_ad _ _ _ H.
+Let H1 := triangle_id_left_ad H.
+Let H2 := triangle_id_right_ad H.
 
 Arguments constprod_functor1 : simpl never.
 Arguments constprod_functor2 : simpl never.

--- a/UniMath/CategoryTheory/functor_categories.v
+++ b/UniMath/CategoryTheory/functor_categories.v
@@ -1332,3 +1332,42 @@ Proof.
 Defined.
 
 End functor_equalities.
+
+(** Natural transformations for reasoning about various compositions of functors *)
+Section nat_trans_functor.
+
+Context {A B C D : precategory}.
+
+Definition nat_trans_functor_id_right (F : functor A B) :
+  nat_trans (functor_composite F (functor_identity B)) F.
+Proof.
+exists (λ x, identity _).
+abstract (now intros a b f; rewrite id_left, id_right).
+Defined.
+
+Definition nat_trans_functor_id_right_inv (F : functor A B) :
+  nat_trans F (functor_composite F (functor_identity B)) :=
+    nat_trans_functor_id_right F.
+
+Definition nat_trans_functor_id_left (F : functor A B) :
+  nat_trans (functor_composite (functor_identity A) F) F :=
+    nat_trans_functor_id_right F.
+
+Definition nat_trans_functor_id_left_inv (F : functor A B) :
+  nat_trans F (functor_composite (functor_identity A) F) :=
+    nat_trans_functor_id_right F.
+
+Definition nat_trans_functor_assoc (F1 : functor A B) (F2 : functor B C) (F3 : functor C D) :
+  nat_trans (functor_composite (functor_composite F1 F2) F3)
+            (functor_composite F1 (functor_composite F2 F3)).
+Proof.
+exists (λ x, identity _).
+abstract (now intros a b f; rewrite id_right, id_left).
+Defined.
+
+Definition nat_trans_functor_assoc_inv (F1 : functor A B) (F2 : functor B C) (F3 : functor C D) :
+  nat_trans (functor_composite F1 (functor_composite F2 F3))
+            (functor_composite (functor_composite F1 F2) F3) :=
+    nat_trans_functor_assoc F1 F2 F3.
+
+End nat_trans_functor.

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -576,4 +576,49 @@ use mk_cocone.
             apply maponpaths, (coconeInCommutes dx _ _ e)).
 Defined.
 
+Definition preserves_colimit {g : graph} (d : diagram g C) (L : C)
+  (cc : cocone d L) : UU :=
+  isColimCocone d L cc -> isColimCocone (mapdiagram d) (F L) (mapcocone d cc).
+
+(** ** Left adjoints preserve colimits *)
+Lemma left_adjoint_preserves_colimit (HF : is_left_adjoint F) (hsC : has_homsets C) (hsD : has_homsets D)
+      {g : graph} (d : diagram g C) (L : C) (ccL : cocone d L) : preserves_colimit d L ccL.
+Proof.
+intros HccL M ccM.
+set (G := right_adjoint HF).
+set (H := pr2 HF : are_adjoints F G).
+apply (@iscontrweqb _ (Σ y : C ⟦ L, G M ⟧,
+    Π i, coconeIn ccL i ;; y = φ_adj H (coconeIn ccM i))).
+- eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧,
+    Π i, # F (coconeIn ccL i) ;; φ_adj_inv H y = coconeIn ccM i)).
+  + apply (weqbandf (adjunction_hom_weq H L M)); simpl; intro f.
+    abstract (apply weqiff; try (apply impred; intro; apply hsD);
+    now rewrite φ_adj_inv_after_φ_adj).
+  + eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧,
+      Π i, φ_adj_inv H (coconeIn ccL i ;; y) = coconeIn ccM i)).
+    * apply weqfibtototal; simpl; intro f.
+    abstract (apply weqiff; try (apply impred; intro; apply hsD); split;
+      [ intros HH i; rewrite φ_adj_inv_natural_precomp; apply HH
+      | intros HH i; rewrite <- φ_adj_inv_natural_precomp; apply HH ]).
+      (* apply weqonsecfibers; intro i. *)
+      (* rewrite φ_adj_inv_natural_precomp; apply idweq. *)
+    * apply weqfibtototal; simpl; intro f.
+    abstract (apply weqiff; [ | apply impred; intro; apply hsD | apply impred; intro; apply hsC ];
+      split; intros HH i;
+        [ now rewrite <- (HH i), φ_adj_after_φ_adj_inv
+        | now rewrite (HH i),  φ_adj_inv_after_φ_adj ]).
+      (* apply weqonsecfibers; intro i. *)
+      (* apply weqimplimpl; [ | | apply hsD | apply hsC]; intro h. *)
+      (*   now rewrite <- h, (φ_adj_after_φ_adj_inv _ _ _ H). *)
+      (* now rewrite h, (φ_adj_inv_after_φ_adj _ _ _ H). *)
+- transparent assert (X : (cocone d (G M))).
+  { use mk_cocone.
+    + intro v; apply (φ_adj H (coconeIn ccM v)).
+    + abstract (intros m n e; simpl;
+                rewrite <- (coconeInCommutes ccM m n e); simpl;
+                now rewrite φ_adj_natural_precomp).
+  }
+  apply (HccL (G M) X).
+Defined.
+
 End map.

--- a/UniMath/CategoryTheory/limits/graphs/limits.v
+++ b/UniMath/CategoryTheory/limits/graphs/limits.v
@@ -20,6 +20,7 @@ Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.equivalences.
 
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
@@ -473,7 +474,87 @@ Proof.
 now intros d; apply LimFunctorCone.
 Defined.
 
+Section map.
 
+Context {C D : precategory} (F : functor C D).
+
+Definition mapcone {g : graph} (d : diagram g C) {x : C}
+  (dx : cone d x) : cone (mapdiagram F d) (F x).
+Proof.
+use mk_cone.
+- simpl; intro n.
+  exact (#F (coneOut dx n)).
+- abstract (intros u v e; simpl; rewrite <- functor_comp;
+            apply maponpaths, (coneOutCommutes dx _ _ e)).
+Defined.
+
+Definition preserves_limit {g : graph} (d : diagram g C) (L : C)
+  (cc : cone d L) : UU :=
+  isLimCone d L cc -> isLimCone (mapdiagram F d) (F L) (mapcone d cc).
+
+(* Require Import UniMath.CategoryTheory.opp_precat. *)
+
+(* Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op"). *)
+
+(* Lemma is_left_adjoint_functor_opp : is_right_adjoint F → is_left_adjoint (functor_opp F). *)
+(* Proof. *)
+(*   intros H. *)
+(*   mkpair. *)
+(*   apply (functor_opp (left_adjoint H)). *)
+(*   mkpair. *)
+(*   split. *)
+(*   simpl. *)
+(*   mkpair. *)
+(*   simpl. *)
+(*   intros x. *)
+(*   apply (counit_from_right_adjoint H x). *)
+(*   admit. *)
+(*   admit. *)
+(*   admit. *)
+(*  Admitted. *)
+
+
+(** ** Right adjoints preserve limits *)
+(* Lemma right_adjoint_preserves_limit (H : is_right_adjoint F) (hsC : has_homsets C) (hsD : has_homsets D) *)
+(*       {g : graph} (d : diagram g C) (L : C) (ccL : cone d L) : preserves_limit d L ccL. *)
+(* Proof. *)
+(* intros HccL M ccM. *)
+(* set (G := left_adjoint H). *)
+(* apply (@iscontrweqb _ (Σ y : C ⟦ L, G M ⟧, *)
+(*     Π i, coconeIn ccL i ;; y = φ_adj _ _ _ H (coconeIn ccM i))). *)
+(* - eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧, *)
+(*     Π i, # F (coconeIn ccL i) ;; φ_adj_inv _ _ _ H y = coconeIn ccM i)). *)
+(*   + apply (weqbandf (adjunction_hom_weq _ _ _ H L M)); simpl; intro f. *)
+(*     abstract (apply weqiff; try (apply impred; intro; apply hsD); *)
+(*     now rewrite φ_adj_inv_after_φ_adj). *)
+(*   + eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧, *)
+(*       Π i, φ_adj_inv _ _ _ _ (coconeIn ccL i ;; y) = coconeIn ccM i)). *)
+(*     * apply weqfibtototal; simpl; intro f. *)
+(*     abstract (apply weqiff; try (apply impred; intro; apply hsD); split; *)
+(*       [ intros HH i; rewrite φ_adj_inv_natural_precomp; apply HH *)
+(*       | intros HH i; rewrite <- φ_adj_inv_natural_precomp; apply HH ]). *)
+(*       (* apply weqonsecfibers; intro i. *) *)
+(*       (* rewrite φ_adj_inv_natural_precomp; apply idweq. *) *)
+(*     * apply weqfibtototal; simpl; intro f. *)
+(*     abstract (apply weqiff; [ | apply impred; intro; apply hsD | apply impred; intro; apply hsC ]; *)
+(*       split; intros HH i; *)
+(*         [ now rewrite <- (HH i), φ_adj_after_φ_adj_inv *)
+(*         | now rewrite (HH i),  φ_adj_inv_after_φ_adj ]). *)
+(*       (* apply weqonsecfibers; intro i. *) *)
+(*       (* apply weqimplimpl; [ | | apply hsD | apply hsC]; intro h. *) *)
+(*       (*   now rewrite <- h, (φ_adj_after_φ_adj_inv _ _ _ H). *) *)
+(*       (* now rewrite h, (φ_adj_inv_after_φ_adj _ _ _ H). *) *)
+(* - transparent assert (X : (cocone d (G M))). *)
+(*   { use mk_cocone. *)
+(*     + intro v; apply (φ_adj C D F H (coconeIn ccM v)). *)
+(*     + abstract (intros m n e; simpl; *)
+(*                 rewrite <- (coconeInCommutes ccM m n e); simpl; *)
+(*                 now rewrite φ_adj_natural_precomp). *)
+(*   } *)
+(*   apply (HccL (G M) X). *)
+(* Defined. *)
+
+End map.
 
 
 (** * Definition of limits via colimits *)

--- a/UniMath/CategoryTheory/limits/graphs/limits.v
+++ b/UniMath/CategoryTheory/limits/graphs/limits.v
@@ -21,6 +21,7 @@ Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.equivalences.
+Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
 
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
@@ -492,67 +493,39 @@ Definition preserves_limit {g : graph} (d : diagram g C) (L : C)
   (cc : cone d L) : UU :=
   isLimCone d L cc -> isLimCone (mapdiagram F d) (F L) (mapcone d cc).
 
-(* Require Import UniMath.CategoryTheory.opp_precat. *)
-
-(* Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op"). *)
-
-(* Lemma is_left_adjoint_functor_opp : is_right_adjoint F → is_left_adjoint (functor_opp F). *)
-(* Proof. *)
-(*   intros H. *)
-(*   mkpair. *)
-(*   apply (functor_opp (left_adjoint H)). *)
-(*   mkpair. *)
-(*   split. *)
-(*   simpl. *)
-(*   mkpair. *)
-(*   simpl. *)
-(*   intros x. *)
-(*   apply (counit_from_right_adjoint H x). *)
-(*   admit. *)
-(*   admit. *)
-(*   admit. *)
-(*  Admitted. *)
-
-
 (** ** Right adjoints preserve limits *)
-(* Lemma right_adjoint_preserves_limit (H : is_right_adjoint F) (hsC : has_homsets C) (hsD : has_homsets D) *)
-(*       {g : graph} (d : diagram g C) (L : C) (ccL : cone d L) : preserves_limit d L ccL. *)
-(* Proof. *)
-(* intros HccL M ccM. *)
-(* set (G := left_adjoint H). *)
-(* apply (@iscontrweqb _ (Σ y : C ⟦ L, G M ⟧, *)
-(*     Π i, coconeIn ccL i ;; y = φ_adj _ _ _ H (coconeIn ccM i))). *)
-(* - eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧, *)
-(*     Π i, # F (coconeIn ccL i) ;; φ_adj_inv _ _ _ H y = coconeIn ccM i)). *)
-(*   + apply (weqbandf (adjunction_hom_weq _ _ _ H L M)); simpl; intro f. *)
-(*     abstract (apply weqiff; try (apply impred; intro; apply hsD); *)
-(*     now rewrite φ_adj_inv_after_φ_adj). *)
-(*   + eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧, *)
-(*       Π i, φ_adj_inv _ _ _ _ (coconeIn ccL i ;; y) = coconeIn ccM i)). *)
-(*     * apply weqfibtototal; simpl; intro f. *)
-(*     abstract (apply weqiff; try (apply impred; intro; apply hsD); split; *)
-(*       [ intros HH i; rewrite φ_adj_inv_natural_precomp; apply HH *)
-(*       | intros HH i; rewrite <- φ_adj_inv_natural_precomp; apply HH ]). *)
-(*       (* apply weqonsecfibers; intro i. *) *)
-(*       (* rewrite φ_adj_inv_natural_precomp; apply idweq. *) *)
-(*     * apply weqfibtototal; simpl; intro f. *)
-(*     abstract (apply weqiff; [ | apply impred; intro; apply hsD | apply impred; intro; apply hsC ]; *)
-(*       split; intros HH i; *)
-(*         [ now rewrite <- (HH i), φ_adj_after_φ_adj_inv *)
-(*         | now rewrite (HH i),  φ_adj_inv_after_φ_adj ]). *)
-(*       (* apply weqonsecfibers; intro i. *) *)
-(*       (* apply weqimplimpl; [ | | apply hsD | apply hsC]; intro h. *) *)
-(*       (*   now rewrite <- h, (φ_adj_after_φ_adj_inv _ _ _ H). *) *)
-(*       (* now rewrite h, (φ_adj_inv_after_φ_adj _ _ _ H). *) *)
-(* - transparent assert (X : (cocone d (G M))). *)
-(*   { use mk_cocone. *)
-(*     + intro v; apply (φ_adj C D F H (coconeIn ccM v)). *)
-(*     + abstract (intros m n e; simpl; *)
-(*                 rewrite <- (coconeInCommutes ccM m n e); simpl; *)
-(*                 now rewrite φ_adj_natural_precomp). *)
-(*   } *)
-(*   apply (HccL (G M) X). *)
-(* Defined. *)
+Lemma right_adjoint_preserves_limit (HF : is_right_adjoint F) (hsC : has_homsets C) (hsD : has_homsets D)
+      {g : graph} (d : diagram g C) (L : C) (ccL : cone d L) : preserves_limit d L ccL.
+Proof.
+intros HccL M ccM.
+set (G := left_adjoint HF).
+set (H := pr2 HF : are_adjoints G F).
+apply (@iscontrweqb _ (Σ y : C ⟦ G M, L ⟧,
+    Π i, y ;; coneOut ccL i = φ_adj_inv H (coneOut ccM i))).
+- eapply (weqcomp (Y := Σ y : C ⟦ G M, L ⟧,
+    Π i, φ_adj H y ;; # F (coneOut ccL i) = coneOut ccM i)).
+  + apply invweq, (weqbandf (adjunction_hom_weq H M L)); simpl; intro f.
+    abstract (now apply weqiff; try (apply impred; intro; apply hsD)).
+  + eapply (weqcomp (Y := Σ y : C ⟦ G M, L ⟧,
+      Π i, φ_adj H (y ;; coneOut ccL i) = coneOut ccM i)).
+    * apply weqfibtototal; simpl; intro f.
+      abstract (apply weqiff; try (apply impred; intro; apply hsD); split; intros HH i;
+               [ now rewrite φ_adj_natural_postcomp; apply HH
+               | now rewrite <- φ_adj_natural_postcomp; apply HH ]).
+    * apply weqfibtototal; simpl; intro f.
+      abstract (apply weqiff; [ | apply impred; intro; apply hsD | apply impred; intro; apply hsC ];
+      split; intros HH i;
+        [ now rewrite <- (HH i), φ_adj_inv_after_φ_adj
+        | now rewrite (HH i),  φ_adj_after_φ_adj_inv ]).
+- transparent assert (X : (cone d (G M))).
+  { use mk_cone.
+    + intro v; apply (φ_adj_inv H (coneOut ccM v)).
+    + intros m n e; simpl.
+      rewrite <- (coneOutCommutes ccM m n e); simpl.
+      now rewrite φ_adj_inv_natural_postcomp.
+  }
+  apply (HccL (G M) X).
+Defined.
 
 End map.
 

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -119,7 +119,7 @@ Defined.
 (** Definition 21: Preservation of colimits *)
 Definition preserves_colimit : Π {C D : precategory}, functor C D
   → Π {g : graph} (d : diagram g C) (L : C), cocone d L → UU :=
-    @UniMath.CategoryTheory.CocontFunctors.preserves_colimit.
+    @UniMath.CategoryTheory.limits.graphs.colimits.preserves_colimit.
 
 Definition is_cocont : Π {C D : precategory}, functor C D → UU :=
   @UniMath.CategoryTheory.CocontFunctors.is_cocont.

--- a/UniMath/SubstitutionSystems/GenMendlerIteration.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration.v
@@ -91,8 +91,8 @@ Variable L : functor C C'.
 
 Variable is_left_adj_L : is_left_adjoint L.
 
-Let φ := @φ_adj _ _ _ is_left_adj_L.
-Let φ_inv := @φ_adj_inv _ _ _ is_left_adj_L.
+Let φ := @φ_adj _ _ _ _ (pr2 is_left_adj_L).
+Let φ_inv := @φ_adj_inv _ _ _ _ (pr2 is_left_adj_L).
 Let R : functor _ _ := right_adjoint is_left_adj_L.
 Let η : nat_trans _ _ := unit_from_left_adjoint is_left_adj_L.
 Let ε : nat_trans _ _ := counit_from_left_adjoint is_left_adj_L.
@@ -134,14 +134,14 @@ Qed.
 
 Lemma φ_ψ_μF_eq (h: L μF --> X): φ (ψ μF h) = #F (φ h) ;; φ(ψ (R X) (ε X)).
 Proof.
-  rewrite <- φ_adj_natural_precomp.
+  rewrite <- (φ_adj_natural_precomp (pr2 is_left_adj_L)).
   apply maponpaths.
   eapply pathscomp0.
 Focus 2.
   apply ψ_naturality.
   apply maponpaths.
   rewrite truth_about_ε.
-  rewrite <- (φ_adj_inv_natural_precomp _ _ _ is_left_adj_L).
+  rewrite <- (φ_adj_inv_natural_precomp (pr2 is_left_adj_L)).
   rewrite id_right.
   apply pathsinv0.
   change (φ_inv(φ h) = h).
@@ -157,7 +157,7 @@ Proof.
   apply maponpaths.
   exact Hyp.
 *)
-  apply (invmaponpathsweq (adjunction_hom_weq _ _ _ is_left_adj_L _ _)).
+  apply (invmaponpathsweq (adjunction_hom_weq (pr2 is_left_adj_L) _ _)).
   exact Hyp.
 Qed.
 
@@ -165,10 +165,10 @@ Lemma preIt_ok : # L inF;; preIt = ψ μF preIt.
 Proof.
     apply cancel_φ.
     rewrite φ_ψ_μF_eq.
-    rewrite (φ_adj_natural_precomp _ _ _ is_left_adj_L).
+    rewrite (φ_adj_natural_precomp (pr2 is_left_adj_L)).
     unfold preIt.
-    rewrite φ_adj_after_φ_adj_inv.
-    rewrite (φ_adj_after_φ_adj_inv _ _ _ is_left_adj_L).
+    rewrite (φ_adj_after_φ_adj_inv (pr2 is_left_adj_L)).
+    rewrite (φ_adj_after_φ_adj_inv (pr2 is_left_adj_L)).
     assert (iter_eq := algebra_mor_commutes _ _ _ (InitialArrow μF_Initial ⟨_,φ (ψ (R X) (ε X))⟩)).
     exact iter_eq.
 Qed.
@@ -189,14 +189,14 @@ Focus 2.
 
     apply cancel_φ.
     unfold preIt.
-    rewrite (φ_adj_after_φ_adj_inv _ _ _ is_left_adj_L).
+    rewrite (φ_adj_after_φ_adj_inv (pr2 is_left_adj_L)).
     (* assert (iter_uniq := algebra_mor_commutes _ _ _ *)
     (*                        (InitialArrow μF_Initial ⟨_,φ (ψ (R X) (ε X))⟩)). *)
     (* simpl in iter_uniq. *)
     assert(φh_is_alg_mor: inF ;; φ h = #F(φ h) ;; φ (ψ (R X) (ε X))).
       (* remark: I am missing a definition of the algebra morphism property in UniMath.CategoryTheory.FunctorAlgebras *)
     + rewrite <- φ_ψ_μF_eq.
-      rewrite <- φ_adj_natural_precomp.
+      rewrite <- (φ_adj_natural_precomp (pr2 is_left_adj_L)).
       apply maponpaths.
       exact h_rec_eq.
     + (* set(φh_alg_mor := tpair _ _ φh_is_alg_mor : pr1 μF_Initial --> ⟨ R X, φ (ψ (R X) (ε X)) ⟩). *)

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -562,8 +562,8 @@ Proof.
 (*  destruct XZ as [X [Z e]].
   simpl.
 *)
-  set (h:= nat_trans_comp (λ_functor_inv _ (pr1 XZ)) ((nat_trans_id _) ∙∙ (pr2 (pr2 XZ)))).
-  exact (nat_trans_comp (α_functor_inv _ (pr1 (pr2 XZ)) (pr1 XZ) (pr1 XZ)) (h ∙∙ (nat_trans_id (functor_composite (pr1 (pr2 XZ)) (pr1 XZ))))).
+  set (h:= nat_trans_comp (λ_functor_inv (pr1 XZ)) ((nat_trans_id _) ∙∙ (pr2 (pr2 XZ)))).
+  exact (nat_trans_comp (α_functor_inv (pr1 (pr2 XZ)) (pr1 XZ) (pr1 XZ)) (h ∙∙ (nat_trans_id (functor_composite (pr1 (pr2 XZ)) (pr1 XZ))))).
 Defined.
 
 Lemma is_nat_trans_Flat_θ_data: is_nat_trans _ _ Flat_θ_data.

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -125,7 +125,7 @@ Local Lemma aux_iso_1_is_nat_trans (Z : Ptd) :
       BinCoproductOfArrows [C, C, hs]
         (CPEndC (functor_composite (U Z) (functor_identity C))
            ((θ_source H) (X ⊗ Z))) (CPEndC (U Z) ((θ_source H) (X ⊗ Z)))
-        (ρ_functor C (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
+        (ρ_functor (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
 Proof.
   unfold is_nat_trans; simpl.
   intros X X' α.
@@ -154,7 +154,7 @@ Definition aux_iso_1 (Z : Ptd)
 Proof.
   simple refine (tpair _ _ _).
   - intro X.
-    exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (ρ_functor _ (U Z))
+    exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (ρ_functor (U Z))
             (nat_trans_id (θ_source H (X⊗Z):functor C C))).
   - exact (aux_iso_1_is_nat_trans Z).
 Defined.
@@ -169,7 +169,7 @@ Local Lemma aux_iso_1_inv_is_nat_trans (Z : Ptd) :
       BinCoproductOfArrows [C, C, hs]
         (CPEndC (functor_composite (functor_identity C) (U Z))
            ((θ_source H) (X ⊗ Z))) (CPEndC (U Z) ((θ_source H) (X ⊗ Z)))
-        (λ_functor C (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
+        (λ_functor (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
 Proof.
   unfold is_nat_trans;
   intros X X' α.
@@ -198,7 +198,7 @@ Local Definition aux_iso_1_inv (Z: Ptd)
 Proof.
   simple refine (tpair _ _ _).
   - intro X.
-    exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (λ_functor _ (U Z))
+    exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (λ_functor (U Z))
            (nat_trans_id (θ_source H (X⊗Z):functor C C))).
   - exact (aux_iso_1_inv_is_nat_trans Z).
 Defined.

--- a/UniMath/SubstitutionSystems/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial_alt.v
@@ -134,7 +134,7 @@ Local Lemma aux_iso_1_is_nat_trans (Z : Ptd) :
       BinCoproductOfArrows [C, C, hsC]
         (CPEndC (functor_composite (U Z) (functor_identity C))
            ((θ_source H) (X ⊗ Z))) (CPEndC (U Z) ((θ_source H) (X ⊗ Z)))
-        (ρ_functor C (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
+        (ρ_functor (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
 Proof.
 intros X X' α.
 apply (nat_trans_eq hsC); intro c; simpl.
@@ -152,7 +152,7 @@ Definition aux_iso_1 (Z : Ptd)
 Proof.
 mkpair.
 - intro X.
-  exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (ρ_functor _ (U Z))
+  exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (ρ_functor (U Z))
            (nat_trans_id (θ_source H (X⊗Z):functor C C))).
 - exact (aux_iso_1_is_nat_trans Z).
 Defined.
@@ -167,7 +167,7 @@ Local Lemma aux_iso_1_inv_is_nat_trans (Z : Ptd) :
       BinCoproductOfArrows [C, C, hsC]
         (CPEndC (functor_composite (functor_identity C) (U Z))
            ((θ_source H) (X ⊗ Z))) (CPEndC (U Z) ((θ_source H) (X ⊗ Z)))
-        (λ_functor C (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
+        (λ_functor (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
 Proof.
 intros X X' α.
 apply (nat_trans_eq hsC); intro c; simpl.
@@ -185,7 +185,7 @@ Local Definition aux_iso_1_inv (Z: Ptd)
 Proof.
 mkpair.
 - intro X.
-  exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (λ_functor _ (U Z))
+  exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (λ_functor (U Z))
          (nat_trans_id (θ_source H (X⊗Z):functor C C))).
 - exact (aux_iso_1_inv_is_nat_trans Z).
 Defined.

--- a/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
@@ -503,7 +503,7 @@ Section third_monad_law_with_assoc.
 Lemma third_monad_law_from_hss :
   (`T ∘ μ_2 : EndC ⟦ functor_composite (functor_composite `T `T) `T , `T • `T ⟧) ;; μ_2
   =
-  (α_functor _ _ _ _ : functor_compose hs hs _ _  --> _) ;; (μ_2 •• `T) ;; μ_2.
+  (α_functor _ _ _ : functor_compose hs hs _ _  --> _) ;; (μ_2 •• `T) ;; μ_2.
 Proof.
   pathvia μ_3; [apply pathsinv0, μ_3_T_μ_2_μ_2 | ].
   apply pathsinv0.

--- a/UniMath/SubstitutionSystems/SignatureExamples.v
+++ b/UniMath/SubstitutionSystems/SignatureExamples.v
@@ -92,9 +92,9 @@ Definition θ_from_δ_mor (XZe : [C, C, hsC] XX Ptd) :
   [C, C, hsC] ⟦ θ_source precompG XZe, θ_target precompG XZe ⟧.
 Proof.
 set (X := pr1 XZe); set (Z := pr1 (pr2 XZe)).
-set (F1 := α_functor _ G Z X).
+set (F1 := α_functor G Z X).
 set (F2 := post_whisker (δ (pr2 XZe)) X).
-set (F3 := α_functor_inv _ Z G X).
+set (F3 := α_functor_inv Z G X).
 apply (nat_trans_comp F3 (nat_trans_comp F2 F1)).
 Defined.
 
@@ -135,11 +135,11 @@ apply functor_id.
 Qed.
 
 Let D' Ze Ze' :=
-  nat_trans_comp (α_functor _ (pr1 Ze) (pr1 Ze') G)
+  nat_trans_comp (α_functor (pr1 Ze) (pr1 Ze') G)
  (nat_trans_comp (pre_whisker (pr1 Ze) (δ Ze'))
- (nat_trans_comp (α_functor_inv _ (pr1 Ze) G (pr1 Ze'))
+ (nat_trans_comp (α_functor_inv (pr1 Ze) G (pr1 Ze'))
  (nat_trans_comp (post_whisker (δ Ze) (pr1 Ze'))
-                 (α_functor _ G (pr1 Ze) (pr1 Ze'))))).
+                 (α_functor G (pr1 Ze) (pr1 Ze'))))).
 
 Definition δ_law2 : UU := Π Ze Ze', δ (Ze p• Ze') = D' Ze Ze'.
 Hypothesis H2 : δ_law2.
@@ -182,11 +182,11 @@ Definition δ_comp_mor (Ze : ptd_obj C) :
    ⟶ functor_composite_data (functor_composite_data G1 G2) (pr1 Ze).
 Proof.
 set (Z := pr1 Ze).
-set (F1 := α_functor_inv _ Z G1 G2).
+set (F1 := α_functor_inv Z G1 G2).
 set (F2 := post_whisker (δ1 Ze) G2).
-set (F3 := α_functor _ G1 Z G2).
+set (F3 := α_functor G1 Z G2).
 set (F4 := pre_whisker G1 (δ2 Ze)).
-set (F5 := α_functor_inv _ G1 G2 Z).
+set (F5 := α_functor_inv G1 G2 Z).
 exact (nat_trans_comp F1 (nat_trans_comp F2 (nat_trans_comp F3 (nat_trans_comp F4 F5)))).
 Defined.
 

--- a/UniMath/SubstitutionSystems/Signatures.v
+++ b/UniMath/SubstitutionSystems/Signatures.v
@@ -194,7 +194,7 @@ Section Strength_law_1_intensional.
 
 Definition θ_Strength1_int : UU
   := Π X : EndC,
-     θ (X ⊗ (id_Ptd C hs)) ;; # H (λ_functor _ _ ) = λ_functor _ _ .
+     θ (X ⊗ (id_Ptd C hs)) ;; # H (λ_functor _) = λ_functor _.
 
 Lemma θ_Strength1_int_implies_θ_Strength1 : θ_Strength1_int → θ_Strength1.
 Proof.
@@ -205,7 +205,7 @@ Proof.
   intro c; simpl.
   assert (T2 := nat_trans_eq_pointwise TX c).
   simpl in *.
-  assert (X0 : λ_functor C X = identity (X : EndC)).
+  assert (X0 : λ_functor X = identity (X : EndC)).
   { apply nat_trans_eq; try assumption; intros; apply idpath. }
   rewrite X0 in T2.
   apply T2.
@@ -221,7 +221,7 @@ Proof.
   intro c; simpl.
   assert (T2 := nat_trans_eq_pointwise TX c).
   simpl in *.
-  assert (X0 : λ_functor C X = identity (X : EndC)).
+  assert (X0 : λ_functor X = identity (X : EndC)).
   { apply nat_trans_eq; try assumption; intros; apply idpath. }
   rewrite X0.
   apply T2.
@@ -244,8 +244,8 @@ Section Strength_law_2_intensional.
 
 Definition θ_Strength2_int : UU
   := Π (X : EndC) (Z Z' : Ptd),
-      θ (X ⊗ (Z p• Z'))  ;; #H (α_functor _ (U Z) (U Z') X )  =
-      (α_functor _ (U Z) (U Z') (H X) : functor_compose hs hs _ _  --> _ ) ;;
+      θ (X ⊗ (Z p• Z'))  ;; #H (α_functor (U Z) (U Z') X )  =
+      (α_functor (U Z) (U Z') (H X) : functor_compose hs hs _ _  --> _ ) ;;
       θ (X ⊗ Z') •• (U Z) ;; θ ((functor_compose hs hs (U Z') X) ⊗ Z) .
 
 Lemma θ_Strength2_int_implies_θ_Strength2 : θ_Strength2_int → θ_Strength2.
@@ -264,7 +264,7 @@ Proof.
   rewrite <- assoc.
   apply maponpaths.
   clear TXZZ'c.
-  assert (functor_comp_H := functor_comp H _ _ _ (α_functor C (pr1 Z) (pr1 Z') X)
+  assert (functor_comp_H := functor_comp H _ _ _ (α_functor (pr1 Z) (pr1 Z') X)
            (a : functor_compose hs hs (U Z) (functor_composite (U Z') X) --> Y)).
   assert (functor_comp_H_c := nat_trans_eq_pointwise functor_comp_H c).
   simpl in functor_comp_H_c.
@@ -288,7 +288,7 @@ Proof.
   unfold θ_Strength2_int, θ_Strength2.
   intros T X Z Z'.
   assert (TXZZ'_inst := T X Z Z' (functor_compose hs hs (U Z)
-          (functor_composite (U Z') X)) (α_functor C (pr1 Z) (pr1 Z') X)).
+          (functor_composite (U Z') X)) (α_functor (pr1 Z) (pr1 Z') X)).
   eapply pathscomp0. apply TXZZ'_inst.
   clear T TXZZ'_inst.
   apply nat_trans_eq; try assumption.


### PR DESCRIPTION
This PR modify the definition of adjunctions and add some new results:

- Add `is_right_adjoint` and make some results depend on `are_adjoints` instead of `is_left_adjoint`.
- Add `preserves_limit` and prove that right adjoints preserve limits. 
- Prove that postcomposition with a left adjoint is a left adjoint (and hence (omega)-cocontinuous)).
- Generalize the monoidal structure on endofunctors to arbitrary functors. The file EndofunctorsMonoidal.v now only contains instances of the more general definitions.