### PR TITLE
Opposite categories, cone, cylinder, and translation functors

### DIFF
--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -92,3 +92,4 @@ Quotobjects.v
 GrothendieckTopos.v
 Complexes.v
 CohomologyComplex.v
+limits/Opp.v

--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -63,7 +63,7 @@ limits/graphs/equalizers.v
 limits/graphs/coequalizers.v
 limits/graphs/kernels.v
 limits/graphs/cokernels.v
-PrecategoriesWithBinOps.v
+precategoriesWithBinOps.v
 PrecategoriesWithAbgrops.v
 PreAdditive.v
 limits/BinDirectSums.v

--- a/UniMath/CategoryTheory/Abelian.v
+++ b/UniMath/CategoryTheory/Abelian.v
@@ -1484,8 +1484,8 @@ Section opp_abelian.
     apply ZerosArrowEq.
   Qed.
 
-  Lemma AbelianMonicKernelsData_opp_isCokernel {AD1 : Data1 C} (AMKD : AbelianMonicKernelsData C AD1)
-        (y z : C^op) (E : Epi (opp_precat C) y z) :
+  Lemma AbelianMonicKernelsData_opp_isCokernel {AD1 : Data1 C}
+        (AMKD : AbelianMonicKernelsData C AD1) (y z : C^op) (E : Epi (opp_precat C) y z) :
     isCokernel (Zero_opp C (pr1 AD1)) (AMKD_Mor AMKD z y (opp_Epi C E)) E
                (AbelianMonicKernelsData_opp_eq AMKD y z E).
   Proof.

--- a/UniMath/CategoryTheory/Abelian.v
+++ b/UniMath/CategoryTheory/Abelian.v
@@ -73,16 +73,13 @@ Section def_abelian.
   (** This definition contains the data that every monic is a kernel of some morphism. *)
   Definition AbelianMonicKernelsData (C : precategory) (AD : Data1 C) : UU :=
     Π (x y : C) (M : Monic C x y),
-    (Σ D2 : (Σ D1 : (Σ z : C, y --> z),
-                    M ;; (pr2 D1) = M ;; (ZeroArrow (pr1 AD) y (pr1 D1))),
-            isEqualizer (pr2 (pr1 D2)) (ZeroArrow (pr1 AD) y (pr1 (pr1 D2))) M (pr2 D2)).
+    (Σ D2 : (Σ D1 : (Σ z : C, y --> z), M ;; (pr2 D1) = ZeroArrow (pr1 AD) x (pr1 D1)),
+            isKernel (Data1_Zero AD) M (pr2 (pr1 D2)) (pr2 D2)).
 
   Definition mk_AbelianMonicKernelsData {C : precategory} (AD1 : Data1 C)
              (H : Π (x y : C) (M : Monic C x y),
-                  (Σ D2 : (Σ D1 : (Σ z : C, y --> z),
-                                  M ;; (pr2 D1) = M ;; (ZeroArrow (pr1 AD1) y (pr1 D1))),
-                          isEqualizer (pr2 (pr1 D2)) (ZeroArrow (pr1 AD1) y (pr1 (pr1 D2)))
-                                      M (pr2 D2))) :
+                  (Σ D2 : (Σ D1 : (Σ z : C, y --> z), M ;; (pr2 D1) = ZeroArrow (pr1 AD1) x (pr1 D1)),
+                          isKernel (Data1_Zero AD1) M (pr2 (pr1 D2)) (pr2 D2))) :
     AbelianMonicKernelsData C AD1 := H.
 
   (** Accessor functions for AbelianMonicKernelsData. *)
@@ -95,28 +92,25 @@ Section def_abelian.
 
   Definition AMKD_Eq {C : precategory} {AD : Data1 C} (AMKD : AbelianMonicKernelsData C AD)
              (x y : C) (M : Monic C x y) :
-    M ;; (AMKD_Mor AMKD x y M) = M ;; (ZeroArrow (pr1 AD) y (AMKD_Ob AMKD x y M)) :=
+    M ;; (AMKD_Mor AMKD x y M) = ZeroArrow (pr1 AD) x (AMKD_Ob AMKD x y M) :=
     pr2 (pr1 (AMKD x y M)).
 
-  Definition AMKD_isE {C : precategory} {AD : Data1 C} (AMKD : AbelianMonicKernelsData C AD)
+  Definition AMKD_isK {C : precategory} {AD : Data1 C} (AMKD : AbelianMonicKernelsData C AD)
              (x y : C) (M : Monic C x y) :
-    isEqualizer (AMKD_Mor AMKD x y M) (ZeroArrow (pr1 AD) y (AMKD_Ob AMKD x y M)) M
-                (AMKD_Eq AMKD x y M) := pr2 (AMKD x y M).
+    isKernel (Data1_Zero AD) M (AMKD_Mor AMKD x y M) (AMKD_Eq AMKD x y M) := pr2 (AMKD x y M).
 
   (** This definition contains the data that every epi is a cokernel of some
       morphism. *)
   Definition AbelianEpiCokernelsData (C : precategory) (AD : Data1 C) : UU :=
     (Π (y z : C) (E : Epi C y z),
-     (Σ D2 : (Σ D1 : (Σ x : C, x --> y),
-                     (pr2 D1) ;; E = (ZeroArrow (pr1 AD) (pr1 D1) y) ;; E),
-             isCoequalizer (pr2 (pr1 D2)) (ZeroArrow (pr1 AD) (pr1 (pr1 D2)) y) E (pr2 D2))).
+     (Σ D2 : (Σ D1 : (Σ x : C, x --> y), (pr2 D1) ;; E = ZeroArrow (pr1 AD) (pr1 D1) z),
+             isCokernel (Data1_Zero AD) (pr2 (pr1 D2)) E (pr2 D2))).
 
    Definition mk_AbelianEpiCokernelsData {C : precategory} (AD1 : Data1 C)
               (H : (Π (y z : C) (E : Epi C y z),
                     (Σ D2 : (Σ D1 : (Σ x : C, x --> y),
-                                   (pr2 D1) ;; E = (ZeroArrow (pr1 AD1) (pr1 D1) y) ;; E),
-                            isCoequalizer (pr2 (pr1 D2)) (ZeroArrow (pr1 AD1) (pr1 (pr1 D2)) y)
-                                          E (pr2 D2)))) :
+                                   (pr2 D1) ;; E = ZeroArrow (pr1 AD1) (pr1 D1) z),
+                            isCokernel (Data1_Zero AD1) (pr2 (pr1 D2)) E (pr2 D2)))) :
      AbelianEpiCokernelsData C AD1 := H.
 
   (** Accessor functions for AbelianEpiCokernelsData. *)
@@ -128,13 +122,12 @@ Section def_abelian.
 
   Definition AECD_Eq {C : precategory} {AD : Data1 C} (AECD : AbelianEpiCokernelsData C AD)
              (y z : C) (E : Epi C y z) :
-    (AECD_Mor AECD y z E) ;; E = (ZeroArrow (pr1 AD) (AECD_Ob AECD y z E) y) ;; E :=
+    (AECD_Mor AECD y z E) ;; E = ZeroArrow (pr1 AD) (AECD_Ob AECD y z E) z :=
     pr2 (pr1 (AECD y z E)).
 
   Definition AECD_isC {C : precategory} {AD : Data1 C} (AECD : AbelianEpiCokernelsData C AD)
              (y z : C) (E : Epi C y z) :
-    isCoequalizer (AECD_Mor AECD y z E) (ZeroArrow (pr1 AD) (AECD_Ob AECD y z E) y) E
-                  (AECD_Eq AECD y z E) := pr2 (AECD y z E).
+    isCokernel (Data1_Zero AD) (AECD_Mor AECD y z E) E (AECD_Eq AECD y z E) := pr2 (AECD y z E).
 
   (** Data which contains kernels, cokernels, the data that monics are kernels of some morphisms,
       and the data that epis are cokernels of some morphisms. *)
@@ -176,30 +169,13 @@ Section def_abelian.
 
   Definition to_AECD : AbelianEpiCokernelsData A (pr2 (pr1 A)) := pr2 (pr2 (pr2 A)).
 
-  (** Hide the following equations behind Qed. *)
-  Definition monic_kernel_eq {x y : A} (M : Monic A x y) :
-    M ;; AMKD_Mor to_AMKD x y M = ZeroArrow to_Zero x (AMKD_Ob to_AMKD x y M).
-  Proof.
-    rewrite (AMKD_Eq to_AMKD x y M).
-    apply ZeroArrow_comp_right.
-  Qed.
-
-  Definition epi_cokernel_eq {y z : A} (E : Epi A y z) :
-    AECD_Mor to_AECD y z E ;; E = ZeroArrow to_Zero (AECD_Ob to_AECD y z E) z.
-  Proof.
-    rewrite (AECD_Eq to_AECD y z E).
-    apply ZeroArrow_comp_left.
-  Qed.
-
   (** The following definitions construct a kernel from a monic and a cokernel
     from an epi. *)
   Definition monic_kernel {x y : A} (M : Monic A x y) :
-    Kernel to_Zero (AMKD_Mor to_AMKD x y M) :=
-    mk_Kernel to_Zero M (AMKD_Mor to_AMKD x y M) (monic_kernel_eq M) (AMKD_isE to_AMKD x y M).
+    Kernel to_Zero (AMKD_Mor to_AMKD x y M) := mk_Kernel to_Zero _ _ _ (AMKD_isK to_AMKD x y M).
 
   Definition epi_cokernel {y z : A} (E : Epi A y z) :
-    Cokernel to_Zero (AECD_Mor to_AECD y z E) :=
-    mk_Cokernel to_Zero E (AECD_Mor to_AECD y z E) (epi_cokernel_eq E) (AECD_isC to_AECD y z E).
+    Cokernel to_Zero (AECD_Mor to_AECD y z E) := mk_Cokernel to_Zero _ _ _ (AECD_isC to_AECD y z E).
 
   (** The following lemmas verify that the kernel and cokernel arrows are indeed
     the monic M and the epi E. *)
@@ -237,12 +213,12 @@ Section abelian_monic_epi_iso.
     set (AEC := to_AECD A x y E1).
     induction AMK as [t p]. induction t as [t p0]. induction t as [t p1].
     induction AEC as [t0 p2]. induction t0 as [t0 p3]. induction t0 as [t0 p4].
-    unfold isEqualizer in p. unfold isCoequalizer in p2.
+    unfold isKernel in p. unfold isCokernel in p2.
     (* Construct the inverse of f *)
-    cbn in *. apply E in p0.
+    cbn in *. rewrite <- (ZeroArrow_comp_right _ _ _ _ _ f) in p0. apply E in p0.
     set (p' := p y (identity _)).
     set (t'1 := maponpaths (fun h : A⟦y, t⟧ => identity _ ;; h) p0).
-    cbn in t'1.
+    cbn in t'1. rewrite (id_left (ZeroArrow _ _ _)) in t'1.
     set (p'' := p' t'1).
     induction p'' as [t1 p5]. induction t1 as [t1 p6].
     (* Show that t1 is the inverse of f *)
@@ -849,18 +825,13 @@ Section abelian_monic_kernels.
 
   (** ** KernelArrow of Monic = ArrowFromZero *)
 
-  (* Hide isEqualizer behind Qed. *)
-  Definition MonicKernelZero_isEqualizer {x y : A} (M : Monic A x y) :
-    equalizers.isEqualizer M (ZeroArrow to_Zero x y) (ZeroArrowFrom x)
-                           (KernelEqRw to_Zero (ArrowsFromZero A to_Zero y (ZeroArrowFrom x ;; M)
-                                                              (ZeroArrow to_Zero _ _))).
+  Definition MonicKernelZero_isKernel {x y : A} (M : Monic A x y) :
+    isKernel to_Zero (ZeroArrowFrom x) M
+             (ArrowsFromZero A to_Zero y (ZeroArrowFrom x ;; M) (ZeroArrow to_Zero _ _)).
   Proof.
-    use (mk_isEqualizer).
-    intros w h X.
-    (* Transform X into an equality we need *)
-    rewrite ZeroArrow_comp_right in X.
-    rewrite <- (ZeroArrow_comp_left _ _ _ x y M) in X.
-    apply (pr2 M) in X.
+    use (mk_isKernel hs).
+    intros w h X. rewrite <- (ZeroArrow_comp_left _ _ _ _ _ M) in X.
+    apply (MonicisMonic _ M) in X.
     use unique_exists.
     (* The arrow *)
     - exact (ZeroArrow to_Zero _ _).
@@ -872,28 +843,21 @@ Section abelian_monic_kernels.
     - intros y0 Y. apply ArrowsToZero.
   Qed.
 
-
   (* A kernel of a monic is the arrow from zero. *)
-  Definition MonicKernelZero {x y : A} (M : Monic A x y) :
-    Kernel to_Zero M := mk_Kernel to_Zero (ZeroArrowFrom _) M (ArrowsFromZero _ _ _ _ _)
-                                 (MonicKernelZero_isEqualizer M).
+  Definition MonicKernelZero {x y : A} (M : Monic A x y) : Kernel to_Zero M :=
+    mk_Kernel to_Zero (ZeroArrowFrom _) M _ (MonicKernelZero_isKernel M).
+
 
   (** ** CokernelArrow of Epi = Arrowto_Zero *)
 
   (* Hide isCoequalizer behind Qed. *)
-  Definition EpiCokernelZero_isCoequalizer {y z : A} (E : Epi A y z) :
-    coequalizers.isCoequalizer
-      E (ZeroArrow to_Zero y z) (ZeroArrowTo z)
-      (CokernelEqRw to_Zero (ArrowsToZero A to_Zero y (E ;; ZeroArrowTo z)
-                                         (ZeroArrow to_Zero y to_Zero))).
+  Definition EpiCokernelZero_isCokernel {y z : A} (E : Epi A y z) :
+    isCokernel to_Zero E (ZeroArrowTo z)
+             (ArrowsToZero A to_Zero y (E ;; ZeroArrowTo z) (ZeroArrow to_Zero y to_Zero)).
   Proof.
-    use (mk_isCoequalizer).
-    intros w h X.
-    (* Transform X into an equality we need *)
-    rewrite ZeroArrow_comp_left in X.
-    rewrite <- (ZeroArrow_comp_right A to_Zero y z w E) in X.
-    apply (pr2 E) in X.
-    (* iscontr *)
+    use (mk_isCokernel hs).
+    intros w h X. rewrite <- (ZeroArrow_comp_right A to_Zero y z w E) in X.
+    apply (EpiisEpi _ E) in X.
     use unique_exists.
     (* The arrow *)
     - exact (ZeroArrow to_Zero _ _).
@@ -906,9 +870,8 @@ Section abelian_monic_kernels.
   Qed.
 
   (* A cokernel of an epi is the arrow to zero. *)
-  Definition EpiCokernelZero {y z : A} (E : Epi A y z) :
-    Cokernel to_Zero E := mk_Cokernel to_Zero (ZeroArrowTo _) E (ArrowsToZero _ _ _ _ _)
-                                     (EpiCokernelZero_isCoequalizer E).
+  Definition EpiCokernelZero {y z : A} (E : Epi A y z) : Cokernel to_Zero E :=
+    mk_Cokernel to_Zero E (ZeroArrowTo z) _ (EpiCokernelZero_isCokernel E).
 
 
   (** ** KernelArrow = FromZero ⇒ isMonic *)
@@ -920,24 +883,21 @@ Section abelian_monic_kernels.
     use mk_Cokernel.
     - exact CK.
     - exact (CokernelArrow CK).
-    - induction e. set (tmp := CokernelEqAr to_Zero CK).
-      fold (CokernelArrow CK) in tmp.
-      use (pathscomp0 tmp). apply ZeroArrow_comp_left.
-    - induction e. apply (isCoequalizer_Coequalizer CK).
+    - induction e. apply CokernelCompZero.
+    - induction e. apply (CokernelisCokernel _ CK).
   Defined.
 
   (** The morphism f is monic if its kernel is zero. *)
   Lemma KernelZeroisMonic {x y z : A} (f : y --> z)
         (H : ZeroArrow to_Zero x y ;; f = ZeroArrow to_Zero x z )
-        (isE : equalizers.isEqualizer f (ZeroArrow to_Zero _ _) (ZeroArrow to_Zero _ _)
-                                      (KernelEqRw to_Zero H)) : isMonic f.
+        (isK : isKernel to_Zero (ZeroArrow to_Zero _ _) f H) : isMonic f.
   Proof.
     intros w u v H'.
     set (Coeq := Coequalizer A hs u v).
     set (Coeqar := CoequalizerOut Coeq z f H').
     set (Coeqar_epi := CoequalizerArrowEpi Coeq).
     set (Coeq_coker := epi_cokernel A Coeqar_epi).
-    set (ker := @mk_Kernel A to_Zero _ _ _ (ZeroArrow to_Zero x y) f H isE).
+    set (ker := @mk_Kernel A to_Zero _ _ _ (ZeroArrow to_Zero x y) f H isK).
     assert (e0 : CokernelArrow Coeq_coker = CoequalizerArrow Coeq).
     {
       apply idpath.
@@ -970,8 +930,7 @@ Section abelian_monic_kernels.
     assert (e5 : is_iso (CoequalizerArrow Coeq)).
     {
       set (coker2 := KernelZeroMonic_cokernel e4 Coeq_coker).
-      set (coker2_iso := CokernelofZeroArrow_iso to_Zero hs _ y coker2).
-      apply (pr2 (coker2_iso)).
+      apply (CokernelofZeroArrow_is_iso hs to_Zero coker2).
     }
     set (isoar := isopair (CoequalizerArrow Coeq) e5).
     set (coeq_eq := CoequalizerEqAr Coeq).
@@ -986,10 +945,9 @@ Section abelian_monic_kernels.
 
   Definition KernelZeroMonic {x y z : A} (f : y --> z)
              (H : ZeroArrow to_Zero x y ;; f = ZeroArrow to_Zero x z )
-             (isE : equalizers.isEqualizer f (ZeroArrow to_Zero _ _) (ZeroArrow to_Zero _ _)
-                                           (KernelEqRw to_Zero H)) :  Monic A y z.
+             (isK : isKernel to_Zero (ZeroArrow to_Zero _ _) f H) : Monic A y z.
   Proof.
-    exact (mk_Monic A f (KernelZeroisMonic f H isE)).
+    exact (mk_Monic A f (KernelZeroisMonic f H isK)).
   Defined.
 
 
@@ -1002,24 +960,21 @@ Section abelian_monic_kernels.
     use mk_Kernel.
     - exact K.
     - exact (KernelArrow K).
-    - induction e. set (tmp := KernelEqAr to_Zero K).
-      fold (KernelArrow K) in tmp.
-      use (pathscomp0 tmp). apply ZeroArrow_comp_right.
-    - induction e. apply (isEqualizer_Equalizer K).
+    - induction e. apply KernelCompZero.
+    - induction e. apply (KernelisKernel to_Zero K).
   Defined.
 
   (** The morphism f is monic if its kernel is zero. *)
   Lemma CokernelZeroisEpi {x y z : A} (f : x --> y)
              (H : f ;; ZeroArrow to_Zero y z = ZeroArrow to_Zero x z )
-             (isCE : coequalizers.isCoequalizer f (ZeroArrow to_Zero _ _) (ZeroArrow to_Zero _ _)
-                                                (CokernelEqRw to_Zero H)) : isEpi f.
+             (isCK : isCokernel to_Zero f (ZeroArrow to_Zero _ _) H) : isEpi f.
   Proof.
     intros w u v H'.
     set (Eq := Equalizer A hs u v).
     set (Eqar := EqualizerIn Eq x f H').
     set (Eqar_monic := EqualizerArrowMonic Eq).
     set (Eq_ker := monic_kernel A Eqar_monic).
-    set (coker := @mk_Cokernel A to_Zero _ _ _ (ZeroArrow to_Zero y z) f H isCE).
+    set (coker := @mk_Cokernel A to_Zero _ _ _ f (ZeroArrow to_Zero y z) H isCK).
     assert (e0 : KernelArrow Eq_ker = EqualizerArrow Eq).
     {
       apply idpath.
@@ -1053,8 +1008,7 @@ Section abelian_monic_kernels.
     assert (e5 : is_iso (EqualizerArrow Eq)).
     {
       set (ker2 := CokernelZeroEpi_kernel e4 Eq_ker).
-      set (ker2_iso := KernelofZeroArrow_iso to_Zero hs _ _ ker2).
-      apply (pr2 (ker2_iso)).
+      apply (KernelofZeroArrow_is_iso hs to_Zero ker2).
     }
     set (isoar := isopair (EqualizerArrow Eq) e5).
     set (Eq_eq := EqualizerEqAr Eq).
@@ -1068,11 +1022,10 @@ Section abelian_monic_kernels.
   Qed.
 
   Definition CokernelZeroEpi {x y z : A} (f : x --> y)
-             (H : f ;; ZeroArrow to_Zero y z = ZeroArrow to_Zero x z )
-             (isCE : coequalizers.isCoequalizer f (ZeroArrow to_Zero _ _) (ZeroArrow to_Zero _ _)
-                                                (CokernelEqRw to_Zero H)) : Epi A x y.
+             (H : f ;; ZeroArrow to_Zero y z = ZeroArrow to_Zero x z)
+             (isCK : isCokernel to_Zero f (ZeroArrow to_Zero _ _) H) : Epi A x y.
   Proof.
-    exact (mk_Epi A f (CokernelZeroisEpi f H isCE)).
+    exact (mk_Epi A f (CokernelZeroisEpi f H isCK)).
   Defined.
 
 End abelian_monic_kernels.
@@ -1435,7 +1388,7 @@ Section abelian_kernel_cokernel.
   (** This generalizes the above by using any Cokernel. *)
   Definition MonicToKernel' {x y : A} (M : Monic A x y) (CK : cokernels.Cokernel to_Zero M) :
     kernels.Kernel to_Zero (CokernelArrow CK) :=
-    Kernel_up_to_iso2 A hs to_Zero (CokernelArrow (Cokernel M)) (CokernelArrow CK)
+    @Kernel_up_to_iso2 A hs to_Zero _ _ _ (CokernelArrow (Cokernel M)) (CokernelArrow CK)
                       (iso_from_Cokernel_to_Cokernel to_Zero (Cokernel M) CK)
                       (CokernelCommutes _ _ _ _ _) (MonicToKernel M).
 
@@ -1515,36 +1468,31 @@ Section opp_abelian.
     @Data2 C^op (AbelianData1_opp AD1).
   Proof.
     use mk_Data2.
-    - exact (Cokernels_opp C (pr1 AD1) (pr2 AD2)).
-    - exact (Kernels_opp C (pr1 AD1) (pr1 AD2)).
+    - exact (Cokernels_opp C hs (pr1 AD1) (pr2 AD2)).
+    - exact (Kernels_opp C hs (pr1 AD1) (pr1 AD2)).
   Defined.
 
-
+  Local Opaque ZeroArrow.
   Lemma AbelianMonicKernelsData_opp_eq {AD1 : Data1 C} (AMKD : AbelianMonicKernelsData C AD1)
         (y z : C^op) (E : Epi (opp_precat C) y z) :
     @compose C _ _ _ E (AMKD_Mor AMKD z y (opp_Epi C E))
-    =
-    (@compose C _ _ _ E (@ZeroArrow (opp_precat C) (Zero_opp C (Data1_Zero AD1)) _ _)).
+    = @ZeroArrow (opp_precat C) (Zero_opp C (Data1_Zero AD1)) _ _.
   Proof.
-    cbn. rewrite <- ZeroArrowFrom_opp. rewrite <- ZeroArrowTo_opp.
-    apply (AMKD_Eq AMKD z y (opp_Epi C E)).
+    rewrite <- ZeroArrow_opp.
+    set (tmp := AMKD_Eq AMKD z y (opp_Epi C E)).
+    cbn in tmp. rewrite tmp. clear tmp.
+    apply ZerosArrowEq.
   Qed.
 
-  Lemma AbelianMonicKernelsData_opp_isEqualizer {AD1 : Data1 C}
-        (AMKD : AbelianMonicKernelsData C AD1)
+  Lemma AbelianMonicKernelsData_opp_isCokernel {AD1 : Data1 C} (AMKD : AbelianMonicKernelsData C AD1)
         (y z : C^op) (E : Epi (opp_precat C) y z) :
-    @coequalizers.isCoequalizer (opp_precat C) _ _ _ (AMKD_Mor AMKD z y (@opp_Epi C y z E))
-                                (@ZeroArrow (opp_precat C) (Zero_opp C (Data1_Zero AD1)) _ _)
-                                E (AbelianMonicKernelsData_opp_eq AMKD y z E).
+    isCokernel (Zero_opp C (pr1 AD1)) (AMKD_Mor AMKD z y (opp_Epi C E)) E
+               (AbelianMonicKernelsData_opp_eq AMKD y z E).
   Proof.
-    use isEqualizer_opp. cbn.
-    set (isE := AMKD_isE AMKD _ _ (opp_Epi C E)).
-    unfold ZeroArrow in isE. cbn in isE. unfold opp_mor.
-    use mk_isEqualizer.
-    intros w h H'. unfold opp_ob in H'.
-    apply (isE w h).
-    use (pathscomp0 H'). apply cancel_precomposition.
-    apply ZeroArrowEq.
+    use (isCokernel_opp _ hs).
+    - exact (Data1_Zero AD1).
+    - exact (AMKD_Eq AMKD z y (opp_Epi C E)).
+    - exact (AMKD_isK AMKD _ _ (opp_Epi C E)).
   Qed.
 
   Definition AbelianMonicKernelsData_opp {AD1 : Data1 C} (AMKD : AbelianMonicKernelsData C AD1) :
@@ -1558,32 +1506,27 @@ Section opp_abelian.
         * exact (AMKD_Ob AMKD z y (opp_Epi C E)).
         * exact (AMKD_Mor AMKD z y (opp_Epi C E)).
       + exact (AbelianMonicKernelsData_opp_eq AMKD y z E).
-    - exact (AbelianMonicKernelsData_opp_isEqualizer AMKD y z E).
+    - exact (AbelianMonicKernelsData_opp_isCokernel AMKD y z E).
   Defined.
+
 
   Lemma AbelianEpiCokernelsData_opp_eq {AD1 : Data1 C} (AECD : AbelianEpiCokernelsData C AD1)
         (y z : C^op) (M : Monic (opp_precat C) y z) :
-    M ;; (AECD_Mor AECD z y (opp_Monic C M)) = M ;; (@ZeroArrow (C^op) (Zero_opp C (pr1 AD1)) _ _).
+    AECD_Mor AECD z y (opp_Monic C M) ;; M =
+    ZeroArrow (Zero_opp C (pr1 AD1)) y (AECD_Ob AECD z y (opp_Monic C M)).
   Proof.
-    cbn.
-    rewrite <- ZeroArrowFrom_opp. rewrite <- ZeroArrowTo_opp.
-    apply (AECD_Eq AECD z y (opp_Monic C M)).
+    rewrite <- ZeroArrow_opp. apply (AECD_Eq AECD z y (opp_Monic C M)).
   Qed.
 
-  Lemma AbelianEpiCokernelsData_opp_isCoequalizer {AD1 : Data1 C}
+  Lemma AbelianEpiCokernelsData_opp_isKernel {AD1 : Data1 C}
         (AECD : AbelianEpiCokernelsData C AD1) (y z : C^op) (M : Monic (opp_precat C) y z) :
-    @equalizers.isEqualizer (opp_precat C) _ _ _ (AECD_Mor AECD z y (opp_Monic C M))
-                            (@ZeroArrow (C^op) (Zero_opp C (Data1_Zero AD1)) _ _) M
-                            (AbelianEpiCokernelsData_opp_eq AECD y z M).
+    isKernel (Zero_opp C (pr1 AD1)) M (AECD_Mor AECD z y (opp_Monic C M))
+             (AbelianEpiCokernelsData_opp_eq AECD y z M).
   Proof.
-    use isCoequalizer_opp. cbn.
-    set (isC := AECD_isC AECD _ _ (opp_Monic C M)).
-    unfold ZeroArrow in isC. cbn in isC. unfold opp_mor.
-    use mk_isCoequalizer.
-    intros w h H'. unfold opp_ob in H'.
-    apply (isC w h).
-    use (pathscomp0 H'). apply cancel_postcomposition.
-    apply ZeroArrowEq.
+    use (isKernel_opp _ hs).
+    - exact (Data1_Zero AD1).
+    - exact (AECD_Eq AECD _ _ (opp_Monic C M)).
+    - exact (AECD_isC AECD _ _ (opp_Monic C M)).
   Qed.
 
   Definition AbelianEpiCokernelsData_opp {AD1 : Data1 C} (AECD : AbelianEpiCokernelsData C AD1) :
@@ -1597,7 +1540,7 @@ Section opp_abelian.
         * exact (AECD_Ob AECD z y (opp_Monic C M) : ob C^op).
         * exact (AECD_Mor AECD z y (opp_Monic C M) : C^op⟦z, _⟧).
       + exact (AbelianEpiCokernelsData_opp_eq AECD y z M).
-    - exact (AbelianEpiCokernelsData_opp_isCoequalizer AECD y z M).
+    - exact (AbelianEpiCokernelsData_opp_isKernel AECD y z M).
   Defined.
 
   Definition AbelianData_opp {AD1 : Data1 C} (AD : AbelianData C AD1) :
@@ -1613,12 +1556,18 @@ Section opp_abelian.
 End opp_abelian.
 Section opp_abelian'.
 
-  Definition Abelian_opp (A : AbelianPreCat) : AbelianPreCat.
+  Definition Abelian_opp (A : AbelianPreCat) (hs : has_homsets A) : AbelianPreCat.
   Proof.
     use mk_Abelian.
     - exact (opp_precat (pr1 (pr1 A))).
     - exact (AbelianData1_opp _ (pr2 (pr1 A))).
-    - exact (AbelianData_opp _ (pr2 A)).
+    - exact (AbelianData_opp _ hs (pr2 A)).
   Defined.
+
+  Lemma has_homsets_Abelian_opp {A : AbelianPreCat} (hs : has_homsets A) :
+    has_homsets (Abelian_opp A hs).
+  Proof.
+    exact (has_homsets_opp hs).
+  Qed.
 
 End opp_abelian'.

--- a/UniMath/CategoryTheory/Abelian.v
+++ b/UniMath/CategoryTheory/Abelian.v
@@ -47,7 +47,7 @@ Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import UniMath.CategoryTheory.limits.Opp.
 
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
-Require Import UniMath.CategoryTheory.PrecategoriesWithBinOps.
+Require Import UniMath.CategoryTheory.precategoriesWithBinOps.
 Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
 Require Import UniMath.CategoryTheory.PreAdditive.
 

--- a/UniMath/CategoryTheory/AbelianToAdditive.v
+++ b/UniMath/CategoryTheory/AbelianToAdditive.v
@@ -14,9 +14,6 @@ Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
-Require Import UniMath.CategoryTheory.PrecategoriesWithBinOps.
-Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
-Require Import UniMath.CategoryTheory.PreAdditive.
 
 Require Import UniMath.CategoryTheory.limits.zero.
 Require Import UniMath.CategoryTheory.limits.binproducts.
@@ -31,7 +28,7 @@ Require Import UniMath.CategoryTheory.limits.BinDirectSums.
 
 Require Import UniMath.CategoryTheory.Monics.
 Require Import UniMath.CategoryTheory.Epis.
-Require Import UniMath.CategoryTheory.PrecategoriesWithBinOps.
+Require Import UniMath.CategoryTheory.precategoriesWithBinOps.
 Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
 Require Import UniMath.CategoryTheory.PreAdditive.
 Require Import UniMath.CategoryTheory.Additive.
@@ -342,10 +339,10 @@ Section abelian_is_additive.
     (fun f : _ => fun g : _ => Abelian_minus_op f (Abelian_minus_op (ZeroArrow to_Zero _ _) g)).
 
   (** Construction of a precategory with binops from Abelian category. *)
-  Definition AbelianToPrecategoryWithBinops : PrecategoryWithBinOps.
+  Definition AbelianToprecategoryWithBinops : precategoryWithBinOps.
   Proof.
-    use (mk_PrecategoryWithBinOps A).
-    unfold PrecategoryWithBinOpsData.
+    use (mk_precategoryWithBinOps A).
+    unfold precategoryWithBinOpsData.
     intros x y. exact (Abelian_op x y).
   Defined.
 
@@ -721,7 +718,7 @@ Section abelian_is_additive.
   Qed.
 
   Definition AbelianToPrecategoryWithAbgropsData :
-    PrecategoryWithAbgropsData AbelianToPrecategoryWithBinops hs.
+    PrecategoryWithAbgropsData AbelianToprecategoryWithBinops hs.
   Proof.
     unfold PrecategoryWithAbgropsData.
     intros x y.
@@ -745,7 +742,7 @@ Section abelian_is_additive.
   (** We prove that Abelian_precategories are PrecategoriesWithAbgrops. *)
   Definition AbelianToPrecategoryWithAbgrops :
     PrecategoryWithAbgrops := mk_PrecategoryWithAbgrops
-                                AbelianToPrecategoryWithBinops  hs
+                                AbelianToprecategoryWithBinops  hs
                                 AbelianToPrecategoryWithAbgropsData.
 
   (** Hide isPreAdditive behind Qed. *)

--- a/UniMath/CategoryTheory/AbelianToAdditive.v
+++ b/UniMath/CategoryTheory/AbelianToAdditive.v
@@ -121,24 +121,22 @@ Section abelian_is_additive.
     exact (BinProductPr1Commutes A _ _ BinProd _ _ (identity X)).
   Qed.
 
-  Local Lemma KernelOfPr1_isEqualizer_comm (X : A) (BinProd : BinProductCone A X X) (w : A)
+  Local Lemma KernelOfPr1_isKernel_comm (X : A) (BinProd : BinProductCone A X X) (w : A)
         (h : A ⟦ w, BinProductObject A BinProd ⟧)
-        (H' : h ;; BinProductPr1 A BinProd =
-              h ;; ZeroArrow to_Zero (BinProductObject A BinProd) X) :
+        (H' : h ;; BinProductPr1 A BinProd = ZeroArrow to_Zero _ _) :
     h ;; (BinProductPr2 A BinProd)
       ;; BinProductArrow A BinProd (ZeroArrow to_Zero X X) (identity X) = h.
   Proof.
     apply BinProductArrowsEq.
     - rewrite <- assoc. rewrite (BinProductPr1Commutes A _ _ BinProd _ _ (identity X)).
-      rewrite H'. repeat rewrite ZeroArrow_comp_right. apply idpath.
+      rewrite H'. rewrite ZeroArrow_comp_right. apply idpath.
     - rewrite <- assoc. rewrite (BinProductPr2Commutes A _ _ BinProd _ _ (identity X)).
       apply id_right.
   Qed.
 
-  Local Lemma KernelOfPr1_isEqualizer_unique (X : A) (BinProd : BinProductCone A X X) (w : A)
+  Local Lemma KernelOfPr1_isKernel_unique (X : A) (BinProd : BinProductCone A X X) (w : A)
         (h : A ⟦ w, BinProductObject A BinProd ⟧)
-        (H' : h ;; BinProductPr1 A BinProd =
-              h ;; ZeroArrow to_Zero (BinProductObject A BinProd) X)
+        (H' : h ;; BinProductPr1 A BinProd = ZeroArrow to_Zero _ _)
         (y : A ⟦ w, X ⟧)
         (H : y ;; BinProductArrow A BinProd (ZeroArrow to_Zero X X) (identity X) = h) :
     y = h ;; BinProductPr2 A BinProd.
@@ -148,30 +146,28 @@ Section abelian_is_additive.
     rewrite id_right. apply idpath.
   Qed.
 
-  Lemma KernelOfPr1_isEqualizer {X : A} (BinProd : BinProductCone A X X) :
-    equalizers.isEqualizer (BinProductPr1 A BinProd)
-                           (ZeroArrow to_Zero (BinProductObject A BinProd) X)
-                           (ZeroIdMap BinProd) (KernelEqRw to_Zero (KernelOfPr1_Eq BinProd)).
+  Lemma KernelOfPr1_isKernel {X : A} (BinProd : BinProductCone A X X) :
+    isKernel to_Zero (ZeroIdMap BinProd) (BinProductPr1 A BinProd) (KernelOfPr1_Eq BinProd).
   Proof.
-    use mk_isEqualizer.
+    use (mk_isKernel hs).
     intros w h H'.
     unfold ZeroIdMap.
     use unique_exists.
     (* The arrow *)
     - exact (h ;; (BinProductPr2 A BinProd)).
     (* commutativity *)
-    - exact (KernelOfPr1_isEqualizer_comm X BinProd w h H').
+    - exact (KernelOfPr1_isKernel_comm X BinProd w h H').
     (* equality of equalities of morphisms *)
     - intros y. apply hs.
     (* uniqueness *)
-    - exact (KernelOfPr1_isEqualizer_unique X BinProd w h H').
-  Defined.
+    - exact (KernelOfPr1_isKernel_unique X BinProd w h H').
+  Qed.
 
   Definition KernelOfPr1 {X : A} (BinProd : BinProductCone A X X) :
     kernels.Kernel to_Zero (BinProductPr1 A BinProd).
   Proof.
     exact (mk_Kernel to_Zero (ZeroIdMap BinProd) _ (KernelOfPr1_Eq BinProd)
-                     (KernelOfPr1_isEqualizer BinProd)).
+                     (KernelOfPr1_isKernel BinProd)).
   Defined.
 
   Lemma KernelOfPr2_Eq {X : A} (BinProd : BinProductCone A X X) :
@@ -181,10 +177,9 @@ Section abelian_is_additive.
     apply idpath.
   Qed.
 
-  Local Lemma KernelOfPr2_isEqualizer_comm (X : A) (BinProd : BinProductCone A X X) (w : A)
+  Local Lemma KernelOfPr2_isKernel_comm (X : A) (BinProd : BinProductCone A X X) (w : A)
         (h : A ⟦w, BinProductObject A BinProd⟧)
-        (H' : h ;; BinProductPr2 A BinProd =
-              h ;; ZeroArrow to_Zero (BinProductObject A BinProd) X) :
+        (H' : h ;; BinProductPr2 A BinProd = ZeroArrow to_Zero _ _) :
     h ;; (BinProductPr1 A BinProd)
       ;; BinProductArrow A BinProd (identity X) (ZeroArrow to_Zero X X) = h.
   Proof.
@@ -192,12 +187,12 @@ Section abelian_is_additive.
     - rewrite <- assoc. rewrite (BinProductPr1Commutes A _ _ BinProd _ (identity X) _).
       apply id_right.
     - rewrite <- assoc. rewrite (BinProductPr2Commutes A _ _ BinProd _ (identity X) _).
-      rewrite H'. repeat rewrite ZeroArrow_comp_right. apply idpath.
+      rewrite H'. rewrite ZeroArrow_comp_right. apply idpath.
   Qed.
 
-  Local Lemma KernelOfPr2_isEqualizer_unique (X : A) (BinProd : BinProductCone A X X) (w : A)
+  Local Lemma KernelOfPr2_isKernel_unique (X : A) (BinProd : BinProductCone A X X) (w : A)
         (h : A ⟦ w, BinProductObject A BinProd ⟧)
-        (H' : h ;; BinProductPr2 A BinProd = h ;; ZeroArrow to_Zero (BinProductObject A BinProd) X)
+        (H' : h ;; BinProductPr2 A BinProd = ZeroArrow to_Zero _ _)
         (y : A ⟦ w, X ⟧)
         (H : y ;; BinProductArrow A BinProd (identity X) (ZeroArrow to_Zero X X) = h) :
     y = h ;; BinProductPr1 A BinProd.
@@ -207,30 +202,28 @@ Section abelian_is_additive.
     rewrite id_right. apply idpath.
   Qed.
 
-  Definition KernelOfPr2_isEqualizer {X : A} (BinProd : BinProductCone A X X) :
-    equalizers.isEqualizer (BinProductPr2 A BinProd)
-                           (ZeroArrow to_Zero (BinProductObject A BinProd) X)
-                           (IdZeroMap BinProd) (KernelEqRw to_Zero (KernelOfPr2_Eq BinProd)).
+  Definition KernelOfPr2_isKernel {X : A} (BinProd : BinProductCone A X X) :
+    isKernel to_Zero (IdZeroMap BinProd) (BinProductPr2 A BinProd) (KernelOfPr2_Eq BinProd).
   Proof.
-    use mk_isEqualizer.
+    use (mk_isKernel hs).
     intros w h H'.
     unfold IdZeroMap.
     use unique_exists.
     (* The arrow *)
     - exact (h ;; (BinProductPr1 A BinProd)).
     (* Commutativity *)
-    - exact (KernelOfPr2_isEqualizer_comm X BinProd w h H').
+    - exact (KernelOfPr2_isKernel_comm X BinProd w h H').
     (* Equality of equalities of morphisms *)
     - intros y. apply hs.
     (* Uniqueness *)
-    - intros y H. exact (KernelOfPr2_isEqualizer_unique X BinProd w h H' y H).
-  Defined.
+    - intros y H. exact (KernelOfPr2_isKernel_unique X BinProd w h H' y H).
+  Qed.
 
   Definition KernelOfPr2 {X : A} (BinProd : BinProductCone A X X) :
     kernels.Kernel to_Zero (BinProductPr2 A BinProd).
   Proof.
     exact (mk_Kernel to_Zero (IdZeroMap BinProd) _ (KernelOfPr2_Eq BinProd)
-                     (KernelOfPr2_isEqualizer BinProd)).
+                     (KernelOfPr2_isKernel BinProd)).
   Defined.
 
   (** From properties of abelian categories, it follows that Pr1 and Pr2 are
@@ -263,13 +256,13 @@ Section abelian_is_additive.
     use monic_epi_is_iso.
     (* isMonic *)
     - use (@KernelZeroisMonic A hs to_Zero _ _ _ (ZeroArrow_comp_left _ _ _ _ _ _)).
-      use mk_isEqualizer.
+      use (mk_isKernel hs).
       intros w h H'.
       use unique_exists.
       (* The arrow *)
       + exact (ZeroArrow to_Zero w to_Zero).
       (* Commutativity *)
-      + rewrite ZeroArrow_comp_right in H'. unfold r in H'. rewrite assoc in H'.
+      + unfold r in H'. rewrite assoc in H'.
         set (y := KernelIn _ ker _ _ H'). cbn in y.
         set (com1 := KernelCommutes _ ker _ _ H'). cbn in com1. fold y in com1.
         unfold DiagonalMap in com1.
@@ -293,7 +286,7 @@ Section abelian_is_additive.
       + intros y H. apply ArrowsToZero.
     (* isEpi *)
     - use (@CokernelZeroisEpi A hs _ _ to_Zero _ (ZeroArrow_comp_right _ _ _ _ _ _)).
-      use mk_isCoequalizer.
+      use (mk_isCokernel hs).
       intros w h H'.
       use unique_exists.
       (* The arrow *)
@@ -301,7 +294,7 @@ Section abelian_is_additive.
       (* Commutativity *)
       + set(coker2 := CokernelOfKernelOfPr2 BinProd).
         set(coker2ar := CokernelArrow coker2). cbn in coker2ar.
-        rewrite ZeroArrow_comp_left in H'. unfold r in H'. rewrite <- assoc in H'.
+        unfold r in H'. rewrite <- assoc in H'.
         set (y := CokernelOut _ coker2 _ _ H'). cbn in y.
         set (com1 := CokernelCommutes _ coker2 _ _ H'). cbn in com1. fold y in com1.
         assert (H : y = ZeroArrow to_Zero X w).

--- a/UniMath/CategoryTheory/Additive.v
+++ b/UniMath/CategoryTheory/Additive.v
@@ -13,7 +13,7 @@ Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
-Require Import UniMath.CategoryTheory.PrecategoriesWithBinOps.
+Require Import UniMath.CategoryTheory.precategoriesWithBinOps.
 Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
 Require Import UniMath.CategoryTheory.PreAdditive.
 

--- a/UniMath/CategoryTheory/Additive.v
+++ b/UniMath/CategoryTheory/Additive.v
@@ -65,6 +65,22 @@ Section def_additive.
     exact (BinDirectSum_BinProduct A (to_BinDirectSums A X Y)).
   Defined.
 
+
+  Lemma to_Unel1' {A : Additive} {a b : A} (BS : BinDirectSumCone A a b) :
+    to_In1 A BS ;; to_Pr2 A BS = ZeroArrow (to_Zero A) _ _.
+  Proof.
+    rewrite (to_Unel1 A BS). apply PreAdditive_unel_zero.
+  Qed.
+
+  Lemma to_Unel2' {A : Additive} {a b : A} (BS : BinDirectSumCone A a b) :
+    to_In2 A BS ;; to_Pr1 A BS = ZeroArrow (to_Zero A) _ _.
+  Proof.
+    rewrite (to_Unel2 A BS). apply PreAdditive_unel_zero.
+  Qed.
+
+  Definition AdditiveZeroArrow {A : Additive} (x y : ob A) : A⟦x, y⟧ :=
+    ZeroArrow (to_Zero A) x y.
+
 End def_additive.
 
 

--- a/UniMath/CategoryTheory/AdditiveFunctors.v
+++ b/UniMath/CategoryTheory/AdditiveFunctors.v
@@ -26,7 +26,7 @@ Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.whiskering.
-Require Import UniMath.CategoryTheory.PrecategoriesWithBinOps.
+Require Import UniMath.CategoryTheory.precategoriesWithBinOps.
 Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
 Require Import UniMath.CategoryTheory.PreAdditive.
 Require Import UniMath.CategoryTheory.Additive.

--- a/UniMath/CategoryTheory/AdditiveFunctors.v
+++ b/UniMath/CategoryTheory/AdditiveFunctors.v
@@ -143,7 +143,7 @@ Section additivefunctor_preserves_bindirectsums.
   Qed.
 
   Lemma AdditiveFunctorInv {A B : Additive} (F : AdditiveFunctor A B) {a1 a2 : A} (f : a1 --> a2) :
-    # F (to_inv _ _ f) = to_inv _ _ (# F f).
+    # F (to_inv f) = to_inv (# F f).
   Proof.
     apply (to_lcan _ (# F f)). rewrite <- AdditiveFunctorLinear.
     rewrite rinvax. rewrite AdditiveFunctorUnel. rewrite rinvax.

--- a/UniMath/CategoryTheory/CohomologyComplex.v
+++ b/UniMath/CategoryTheory/CohomologyComplex.v
@@ -88,7 +88,7 @@ Section def_cohomology_complex.
       ;; (Diff C i) = ZeroArrow to_Zero _ _.
   Proof.
     induction (hzrminusplus i 1). cbn. unfold idfun.
-    apply (CEq (AbelianToAdditive A hs) C (i - 1)).
+    apply (DSq (AbelianToAdditive A hs) C (i - 1)).
   Qed.
 
   Local Lemma CohomologyComplex_KernelIn_eq (C : Complex (AbelianToAdditive A hs)) (i : hz) :
@@ -97,7 +97,7 @@ Section def_cohomology_complex.
   Proof.
     rewrite <- functtransportf. cbn.
     induction (hzrminusplus i 1). cbn. unfold idfun.
-    apply (CEq (AbelianToAdditive A hs) C (i - 1)).
+    apply (DSq (AbelianToAdditive A hs) C (i - 1)).
   Qed.
 
   Definition CohomologyComplex (C : (ComplexPreCat_AbelianPreCat A hs)) :
@@ -1026,7 +1026,7 @@ Section def_cohomology_homotopy.
                 Diff C2 i = ZeroArrow to_Zero (Kernel (Diff C1 i)) (C2 (i + 1)).
   Proof.
     induction (hzrminusplus i 1). cbn. unfold idfun. rewrite <- assoc. rewrite <- assoc.
-    set (tmp := CEq _ C2 (i - 1)). cbn in tmp. rewrite tmp. clear tmp.
+    set (tmp := DSq _ C2 (i - 1)). cbn in tmp. rewrite tmp. clear tmp.
     rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_right. apply idpath.
   Qed.
 
@@ -1098,7 +1098,7 @@ Section def_cohomology_homotopy.
                         (# (CohomologyFunctor_Additive A hs) g)).
     use (pathscomp0 _ (! tmp)). clear tmp.
     rewrite <- AdditiveFunctorInv.
-    set (tmp := AdditiveFunctorLinear (CohomologyFunctor_Additive A hs) f (to_inv _ _ g)).
+    set (tmp := AdditiveFunctorLinear (CohomologyFunctor_Additive A hs) f (to_inv g)).
     apply pathsinv0 in tmp. use (pathscomp0 tmp). clear tmp.
     use (squash_to_prop H). apply has_homsets_ComplexPreCat_AbelianPreCat.
     intros H'. induction H' as [H1 H2]. induction H1 as [H11 H12]. cbn in H11. cbn in H2.
@@ -1394,7 +1394,7 @@ Section def_kernel_cokernel_complex.
     rewrite <- assoc.
     rewrite <- (ZeroArrow_comp_right _ _ _ _ _ (KernelArrow (Kernel (Diff C i)))).
     apply cancel_precomposition.
-    exact (CEq (AbelianToAdditive A hs) C i).
+    exact (DSq (AbelianToAdditive A hs) C i).
   Qed.
 
   Local Lemma KernelComplex_comm (C : Complex (AbelianToAdditive A hs)) (i : hz) :
@@ -1437,7 +1437,7 @@ Section def_kernel_cokernel_complex.
     ZeroArrow to_Zero (C (i - 1)) (Cokernel (Diff C (i + 1 - 1))).
   Proof.
     induction (hzrminusplus i 1 @ hzrplusminus' i 1). cbn. unfold idfun.
-    rewrite assoc. set (tmp := CEq (AbelianToAdditive A hs) C (i - 1)). cbn in tmp.
+    rewrite assoc. set (tmp := DSq (AbelianToAdditive A hs) C (i - 1)). cbn in tmp.
     rewrite tmp. clear tmp. apply ZeroArrow_comp_left.
   Qed.
 
@@ -1485,7 +1485,7 @@ Section def_kernel_cokernel_complex.
     rewrite <- functtransportb.
     induction (hzrminusplus (i + 1) 1). cbn.
     induction (hzrplusminus' (i + 1 - 1 + 1) 1). cbn. unfold idfun.
-    exact (CEq _ C (i + 1 - 1)).
+    exact (DSq _ C (i + 1 - 1)).
   Qed.
 
   Definition CokernelComplex (C : Complex (AbelianToAdditive A hs)) :
@@ -1515,7 +1515,7 @@ Section def_kernel_cokernel_complex.
          (maponpaths C (hzrminusplus i 1)) (Diff C i) =
     ZeroArrow to_Zero (C (i - 1)) (C (i + 1)).
   Proof.
-    induction (hzrminusplus i 1). cbn. unfold idfun. exact (CEq _ C (i - 1)).
+    induction (hzrminusplus i 1). cbn. unfold idfun. exact (DSq _ C (i - 1)).
   Qed.
 
 
@@ -1529,11 +1529,11 @@ Section def_kernel_cokernel_complex.
     use CokernelOutsEq.
     rewrite assoc. rewrite CokernelCommutes. rewrite ZeroArrow_comp_right.
     induction (hzrminusplus i 1). cbn. unfold idfun.
-    exact (CEq _ C (i - 1 + 1)).
+    exact (DSq _ C (i - 1 + 1)).
   Qed.
 
   Local Lemma CokernelKernelMorphism_comm3 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
-    KernelIn to_Zero (Kernel (Diff C (i + 1))) (C i) (Diff C i) (CEq (AbelianToAdditive A hs) C i) =
+    KernelIn to_Zero (Kernel (Diff C (i + 1))) (C i) (Diff C i) (DSq (AbelianToAdditive A hs) C i) =
     transportf (λ i0 : pr1 hz, A ⟦ C i0, Cokernel (Diff C (i - 1)) ⟧) (hzrminusplus i 1)
                (CokernelArrow (Cokernel (Diff C (i - 1))))
                ;; KernelIn to_Zero (Kernel (Diff C (i + 1)))
@@ -1575,7 +1575,7 @@ Section def_kernel_cokernel_complex.
          (maponpaths C (hzrminusplus i 1)) (Diff C i) =
     ZeroArrow to_Zero (C (i - 1)) (C (i + 1)).
   Proof.
-    induction (hzrminusplus i 1). cbn. unfold idfun. exact (CEq _ C (i - 1)).
+    induction (hzrminusplus i 1). cbn. unfold idfun. exact (DSq _ C (i - 1)).
   Qed.
 
   Local Lemma CokernelKernelMorphism_comm2' (C : Complex (AbelianToAdditive A hs)) (i : hz) :
@@ -1598,7 +1598,7 @@ Section def_kernel_cokernel_complex.
   Local Lemma CokernelKernelMorphism_uni (C : Complex (AbelianToAdditive A hs)) (i : hz) :
     Π t : Σ f : A ⟦Cokernel (Diff C (i - 1)), Kernel (Diff C (i + 1))⟧,
                 (KernelIn to_Zero (Kernel (Diff C (i + 1))) (C i) (Diff C i)
-                          (CEq (AbelianToAdditive A hs) C i) =
+                          (DSq (AbelianToAdditive A hs) C i) =
                  transportf (λ i0 : pr1 hz, A ⟦ C i0, Cokernel (Diff C (i - 1)) ⟧)
                             (hzrminusplus i 1) (CokernelArrow (Cokernel (Diff C (i - 1)))) ;; f)
                   × (CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
@@ -1636,7 +1636,7 @@ Section def_kernel_cokernel_complex.
 
   Definition CokernelKernelMorphism (C : Complex (AbelianToAdditive A hs)) (i : hz) :
     iscontr (Σ f : A⟦(CokernelComplex C) i, (KernelComplex C) i⟧,
-                   ((KernelIn to_Zero (Kernel (Diff C (i + 1))) (C i) (Diff C i) (CEq _ C i)) =
+                   ((KernelIn to_Zero (Kernel (Diff C (i + 1))) (C i) (Diff C i) (DSq _ C i)) =
                     (transportf (fun (i0 : hz) => A⟦C i0, (Cokernel (Diff C (i - 1)))⟧)
                                 (hzrminusplus i 1)
                                 (CokernelArrow (Cokernel (Diff C (i - 1))))) ;; f)
@@ -2101,7 +2101,7 @@ Section def_kernel_cokernel_complex.
                  transportb (fun x' : ob A => precategory_morphisms x' _)
                             (maponpaths C (hzrplusminus i 1))
                             (KernelIn to_Zero (Kernel (Diff C (i + 1))) (C i) (Diff C i)
-                                      (CEq (AbelianToAdditive A hs) C i))).
+                                      (DSq (AbelianToAdditive A hs) C i))).
     {
       rewrite transportb_KernelIn.
       use KernelInsEq.

--- a/UniMath/CategoryTheory/CohomologyComplex.v
+++ b/UniMath/CategoryTheory/CohomologyComplex.v
@@ -41,7 +41,7 @@ Require Import UniMath.CategoryTheory.Monics.
 Require Import UniMath.CategoryTheory.Epis.
 Require Import UniMath.CategoryTheory.functor_categories.
 
-Require Import UniMath.CategoryTheory.PrecategoriesWithBinOps.
+Require Import UniMath.CategoryTheory.precategoriesWithBinOps.
 Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
 Require Import UniMath.CategoryTheory.PreAdditive.
 Require Import UniMath.CategoryTheory.Additive.

--- a/UniMath/CategoryTheory/CohomologyComplex.v
+++ b/UniMath/CategoryTheory/CohomologyComplex.v
@@ -540,7 +540,7 @@ Section def_cohomology'_complex.
   Qed.
 
   Local Lemma CohomologyComplexIso_KernelArrow (C : Complex (AbelianToAdditive A hs)) (i : hz) :
-    let K4 := mk_Kernel' _ _ _ (CohomologyComplexIso_isKernel_Eq C i)
+    let K4 := mk_Kernel _ _ _ (CohomologyComplexIso_isKernel_Eq C i)
                          (CohomologyComplexIso_isKernel C i) in
     KernelArrow K4 = KernelIn to_Zero (Kernel (Diff C i))
                               (Image
@@ -587,7 +587,7 @@ Section def_cohomology'_complex.
                  (Cokernel (transportf (precategory_morphisms (C (i - 1)))
                                        (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1))))
                  _ _ (CohomologyComplexIso_eq2 C i) in
-    isCokernel to_Zero CK1 (φ1 ;; φ2) (CohomologyComplexIso_isCokernel_Eq C i).
+    isCokernel to_Zero (φ1 ;; φ2) CK1 (CohomologyComplexIso_isCokernel_Eq C i).
   Proof.
     intros φ1 φ2 CK1.
     set (f2 := factorization2 hs (Diff C i)).
@@ -617,8 +617,8 @@ Section def_cohomology'_complex.
   Qed.
 
   Local Lemma CohomologyComplexIso_CokernelArrow (C : Complex (AbelianToAdditive A hs)) (i : hz) :
-    let CK4 := mk_Cokernel' _ _ _ (CohomologyComplexIso_isCokernel_Eq C i)
-                            (CohomologyComplexIso_isCokernel C i) in
+    let CK4 := mk_Cokernel _ _ _ (CohomologyComplexIso_isCokernel_Eq C i)
+                           (CohomologyComplexIso_isCokernel C i) in
     CokernelArrow CK4 =
     (CokernelOut to_Zero
                  (Cokernel
@@ -685,7 +685,7 @@ Section def_cohomology'_complex.
 
   Definition CohomologyComplexIso_Mor5 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
     let K1 := KernelIn to_Zero (Kernel (Diff C i)) _ _ (CohomologyComplexIso_eq1 C i) in
-    let K4 := mk_Kernel' _ _ _ (CohomologyComplexIso_isKernel_Eq C i)
+    let K4 := mk_Kernel _ _ _ (CohomologyComplexIso_isKernel_Eq C i)
                          (CohomologyComplexIso_isKernel C i) in
     A⟦Cokernel (KernelArrow K4), Cokernel K1⟧ :=
     @CokernelOutPaths_is_iso_mor
@@ -696,15 +696,15 @@ Section def_cohomology'_complex.
     let φ2 := CokernelArrow (Cokernel (transportf (precategory_morphisms (C (i - 1)))
                                                   (maponpaths C (hzrminusplus i 1))
                                                   (Diff C (i - 1)))) in
-    let K4 := mk_Kernel' _ _ _ (CohomologyComplexIso_isKernel_Eq C i)
-                         (CohomologyComplexIso_isKernel C i) in
+    let K4 := mk_Kernel _ _ _ (CohomologyComplexIso_isKernel_Eq C i)
+                        (CohomologyComplexIso_isKernel C i) in
     iso (CoImage (φ1 ;; φ2)) (Cokernel (KernelArrow K4)) :=
     let φ1 := KernelArrow (Kernel (Diff C i)) in
     let φ2 := CokernelArrow (Cokernel (transportf (precategory_morphisms (C (i - 1)))
                                                   (maponpaths C (hzrminusplus i 1))
                                                   (Diff C (i - 1)))) in
-    let K4 := mk_Kernel' _ _ _ (CohomologyComplexIso_isKernel_Eq C i)
-                         (CohomologyComplexIso_isKernel C i) in
+    let K4 := mk_Kernel _ _ _ (CohomologyComplexIso_isKernel_Eq C i)
+                        (CohomologyComplexIso_isKernel C i) in
     CohomologyComplexIso_CokerKerIso _ K4 (CoImage (φ1 ;; φ2)) (Cokernel (KernelArrow K4)).
 
   Definition CohomologyComplexIso_Mor7 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
@@ -716,14 +716,14 @@ Section def_cohomology'_complex.
     A⟦Kernel CK1,
       Kernel
         (CokernelArrow
-           (mk_Cokernel' to_Zero
-                         (KernelArrow (Kernel (Diff C i)) ;; CokernelArrow
-                                      (Cokernel
-                                         (transportf (precategory_morphisms (C (i - 1)))
-                                                     (maponpaths C (hzrminusplus i 1))
-                                                     (Diff C (i - 1))))) CK1
-                         (CohomologyComplexIso_isCokernel_Eq C i)
-                         (CohomologyComplexIso_isCokernel C i)))⟧ :=
+           (mk_Cokernel to_Zero
+                        (KernelArrow (Kernel (Diff C i)) ;; CokernelArrow
+                                     (Cokernel
+                                        (transportf (precategory_morphisms (C (i - 1)))
+                                                    (maponpaths C (hzrminusplus i 1))
+                                                    (Diff C (i - 1))))) CK1
+                        (CohomologyComplexIso_isCokernel_Eq C i)
+                        (CohomologyComplexIso_isCokernel C i)))⟧ :=
     @KernelInPaths_is_iso_mor
       A to_Zero _ _ _ _ (! (CohomologyComplexIso_CokernelArrow C i)) (Kernel _) (Kernel _).
 
@@ -732,15 +732,15 @@ Section def_cohomology'_complex.
     let φ2 := CokernelArrow (Cokernel (transportf (precategory_morphisms (C (i - 1)))
                                                   (maponpaths C (hzrminusplus i 1))
                                                   (Diff C (i - 1)))) in
-    let CK4 := mk_Cokernel' _ _ _ (CohomologyComplexIso_isCokernel_Eq C i)
-                            (CohomologyComplexIso_isCokernel C i) in
+    let CK4 := mk_Cokernel _ _ _ (CohomologyComplexIso_isCokernel_Eq C i)
+                           (CohomologyComplexIso_isCokernel C i) in
     iso (Kernel (CokernelArrow CK4)) (Image (φ1 ;; φ2)) :=
     let φ1 := KernelArrow (Kernel (Diff C i)) in
     let φ2 := CokernelArrow (Cokernel (transportf (precategory_morphisms (C (i - 1)))
                                                   (maponpaths C (hzrminusplus i 1))
                                                   (Diff C (i - 1)))) in
-    let CK4 := mk_Cokernel' _ _ _ (CohomologyComplexIso_isCokernel_Eq C i)
-                            (CohomologyComplexIso_isCokernel C i) in
+    let CK4 := mk_Cokernel _ _ _ (CohomologyComplexIso_isCokernel_Eq C i)
+                           (CohomologyComplexIso_isCokernel C i) in
     CohomologyComplexIso_KerCokerIso CK4 _ (Kernel (CokernelArrow CK4)) (Image (φ1 ;; φ2)).
 
   Definition CohomologyComplexIso_Mor_i (C : Complex (AbelianToAdditive A hs)) (i : hz) :
@@ -772,16 +772,16 @@ Section def_cohomology'_complex.
     set (CK2 := CokernelPath A to_Zero f1 (Cokernel _)).
     set (CK2' := CokernelEpiComp A hs to_Zero _ _ CK2).
     set (K3 := MonicToKernel' A hs _ CK2').
-    set (K4 := mk_Kernel' _ _ _ (CohomologyComplexIso_isKernel_Eq C i)
-                          (CohomologyComplexIso_isKernel C i)).
+    set (K4 := mk_Kernel _ _ _ (CohomologyComplexIso_isKernel_Eq C i)
+                         (CohomologyComplexIso_isKernel C i)).
     use (postcompose (CohomologyComplexIso_Mor5 C i)).
     use (postcompose (CohomologyComplexIso_Mor6 C i)).
     (* compose *)
     set (K2 := KernelPath A to_Zero f2 (Kernel _)).
     set (K2' := KernelCompMonic A hs to_Zero _ _ K2).
     set (CK3 := EpiToCokernel' A hs _ K2').
-    set (CK4 := mk_Cokernel' _ _ _ (CohomologyComplexIso_isCokernel_Eq C i)
-                             (CohomologyComplexIso_isCokernel C i)).
+    set (CK4 := mk_Cokernel _ _ _ (CohomologyComplexIso_isCokernel_Eq C i)
+                            (CohomologyComplexIso_isCokernel C i)).
     use (compose (CohomologyComplexIso_Mor7 C i)).
     use (compose (CohomologyComplexIso_Mor8 C i)).
     exact (iso_inv_from_is_iso _ (CoIm_to_Im_is_iso A hs (φ1 ;; φ2))).
@@ -1034,7 +1034,7 @@ Section def_cohomology_homotopy.
   Lemma CohomologyFunctorHomotopy {C1 C2 : Complex (AbelianToAdditive A hs)}
         (H : ComplexHomot _ C1 C2) :
     CohomologyMorphism A hs (ComplexHomotMorphism (AbelianToAdditive A hs) H) =
-    MorphismZero (AbelianToAdditive A hs) (CohomologyComplex A hs C1) (CohomologyComplex A hs C2).
+    ZeroMorphism (AbelianToAdditive A hs) (CohomologyComplex A hs C1) (CohomologyComplex A hs C2).
   Proof.
     use MorphismEq. intros i. cbn. unfold CohomologyMorphism_Mor.
     use CokernelOutsEq. rewrite CokernelCommutes.

--- a/UniMath/CategoryTheory/CohomologyComplex.v
+++ b/UniMath/CategoryTheory/CohomologyComplex.v
@@ -140,7 +140,7 @@ Section def_cohomology_complex.
   Proof.
     apply (KernelArrowisMonic to_Zero (Kernel (Diff C2 i))).
     rewrite <- assoc. rewrite <- assoc. rewrite KernelCommutes. rewrite KernelCommutes.
-    cbn. rewrite <- transportf_postcompose. cbn.
+    cbn. rewrite <- transport_target_postcompose. cbn.
     set (tmp := MComm f (i - 1)). cbn in tmp. rewrite tmp. clear tmp.
     rewrite assoc. rewrite KernelCommutes.
     induction (hzrminusplus i 1). cbn. unfold idfun. apply idpath.
@@ -1058,7 +1058,8 @@ Section def_cohomology_homotopy.
     {
       unfold tmp. clear tmp. use KernelInsEq. rewrite KernelCommutes. rewrite KernelCommutes.
       set (tmp := @to_premor_linear' (AbelianToAdditive A hs)). cbn in tmp. rewrite tmp. clear tmp.
-      rewrite transportf_postcompose. rewrite transportf_postcompose. rewrite assoc. rewrite assoc.
+      rewrite transport_target_postcompose. rewrite transport_target_postcompose.
+      rewrite assoc. rewrite assoc.
       rewrite KernelCompZero. rewrite ZeroArrow_comp_left. rewrite <- PreAdditive_unel_zero.
       set (tmp :=  @to_runax' (AbelianToAdditive A hs)). cbn in tmp. rewrite tmp. clear tmp.
       apply idpath.
@@ -1077,7 +1078,7 @@ Section def_cohomology_homotopy.
     {
       use KernelInsEq. rewrite KernelCommutes. rewrite <- assoc. rewrite <- assoc.
       apply cancel_precomposition. rewrite KernelCommutes.
-      rewrite transportf_postcompose. apply idpath.
+      rewrite transport_target_postcompose. apply idpath.
     }
     cbn. cbn in e1. rewrite e1. clear e1. rewrite <- assoc. rewrite CokernelCompZero.
     rewrite ZeroArrow_comp_right. apply idpath.
@@ -1431,8 +1432,8 @@ Section def_kernel_cokernel_complex.
 
   Local Lemma CokernelComplex_Cokernel_comm (C : Complex (AbelianToAdditive A hs)) (i : hz) :
     (Diff C (i - 1))
-      ;; (transportb (λ x' : A, A ⟦ x', C (i + 1 - 1 + 1) ⟧)
-                     (maponpaths C (hzrminusplus i 1 @ hzrplusminus' i 1)) (Diff C (i + 1 - 1)) ;;
+      ;; (transportf (λ x' : A, A ⟦ x', C (i + 1 - 1 + 1) ⟧)
+                     (! maponpaths C (hzrminusplus i 1 @ hzrplusminus' i 1)) (Diff C (i + 1 - 1)) ;;
                      CokernelArrow (Cokernel (Diff C (i + 1 - 1)))) =
     ZeroArrow to_Zero (C (i - 1)) (Cokernel (Diff C (i + 1 - 1))).
   Proof.
@@ -1443,15 +1444,15 @@ Section def_kernel_cokernel_complex.
 
   Local Lemma CokernelComplex_comm (C : Complex (AbelianToAdditive A hs)) (i : hz) :
     CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (Cokernel (Diff C (i + 1 - 1)))
-                (transportb (λ x' : A, A ⟦ x', C (i + 1 - 1 + 1) ⟧)
-                            (maponpaths C (hzrminusplus i 1 @ hzrplusminus' i 1))
+                (transportf (λ x' : A, A ⟦ x', C (i + 1 - 1 + 1) ⟧)
+                            (! maponpaths C (hzrminusplus i 1 @ hzrplusminus' i 1))
                             (Diff C (i + 1 - 1)) ;; CokernelArrow (Cokernel (Diff C (i + 1 - 1))))
                 (CokernelComplex_Cokernel_comm C i)
                 ;; CokernelOut to_Zero (Cokernel (Diff C (i + 1 - 1)))
                 (Cokernel (Diff C (i + 1 + 1 - 1)))
-                (transportb (λ x' : A, A ⟦ x', C (i + 1 + 1 - 1 + 1) ⟧)
-                            (maponpaths C
-                                        (hzrminusplus (i + 1) 1 @ hzrplusminus' (i + 1) 1))
+                (transportf (λ x' : A, A ⟦ x', C (i + 1 + 1 - 1 + 1) ⟧)
+                            (! maponpaths C
+                               (hzrminusplus (i + 1) 1 @ hzrplusminus' (i + 1) 1))
                             (Diff C (i + 1 + 1 - 1)) ;; CokernelArrow
                             (Cokernel
                                (Diff C (i + 1 + 1 - 1))))
@@ -1463,26 +1464,15 @@ Section def_kernel_cokernel_complex.
     rewrite <- assoc. rewrite CokernelCommutes. rewrite assoc.
     rewrite <- (ZeroArrow_comp_left _ _ _ _ _ (CokernelArrow (Cokernel (Diff C (i + 1 + 1 - 1))))).
     apply cancel_postcomposition.
-    use (transportb_path _ _ (maponpaths C (hzrplusminus i 1 @ hzrminusplus' i 1))).
-    rewrite <- transportb_precompose.
-    rewrite <- functtransportb. rewrite <- functtransportb.
-    rewrite transport_b_b.
-    assert (e0 : ((hzrplusminus i 1 @ hzrminusplus' i 1) @ hzrminusplus i 1 @ hzrplusminus' i 1) =
-                 idpath _).
-    {
-      apply isasethz.
-    }
+    use (transport_source_path _ _ (! maponpaths C (hzrplusminus i 1 @ hzrminusplus' i 1))).
+    rewrite <- transport_source_precompose.
+    rewrite <- maponpathsinv0. rewrite <- functtransportf.
+    rewrite <- maponpathsinv0. rewrite <- functtransportf.
+    rewrite transport_f_f.
+    assert (e0 : (! (hzrminusplus i 1 @ hzrplusminus' i 1)
+                    @ ! (hzrplusminus i 1 @ hzrminusplus' i 1)) = idpath _) by apply isasethz.
     cbn in e0. cbn. rewrite e0. clear e0. cbn. unfold idfun.
-    assert (e1 : transportb (λ x' : A, A ⟦ x', C (i + 1 + 1 - 1 + 1) ⟧)
-                            (maponpaths C (hzrplusminus i 1 @ hzrminusplus' i 1))
-                            (ZeroArrow to_Zero (C (i - 1 + 1)) (C (i + 1 + 1 - 1 + 1))) =
-                 ZeroArrow to_Zero _ _).
-    {
-      rewrite <- functtransportb. induction (hzrplusminus i 1 @ hzrminusplus' i 1).
-      cbn. unfold idfun. apply idpath.
-    }
-    cbn in e1. rewrite e1. clear e1.
-    rewrite <- functtransportb.
+    rewrite transport_source_ZeroArrow.
     induction (hzrminusplus (i + 1) 1). cbn.
     induction (hzrplusminus' (i + 1 - 1 + 1) 1). cbn. unfold idfun.
     exact (DSq _ C (i + 1 - 1)).
@@ -1497,8 +1487,8 @@ Section def_kernel_cokernel_complex.
       use CokernelOut.
       + use compose.
         * exact (C (i + 1 - 1 + 1)).
-        * use (transportb (fun x' : A => precategory_morphisms x' (C (i + 1 - 1 + 1)))
-                          (maponpaths C (hzrminusplus i 1 @ hzrplusminus' i 1))).
+        * use (transportf (fun x' : A => precategory_morphisms x' (C (i + 1 - 1 + 1)))
+                          (! maponpaths C (hzrminusplus i 1 @ hzrplusminus' i 1))).
           cbn.
           exact (Diff C (i + 1 - 1)).
         * use CokernelArrow.
@@ -1511,8 +1501,8 @@ Section def_kernel_cokernel_complex.
   (** *** Uniqueness and existence of h^i *)
 
   Local Lemma CokernelKernelMorphism_comm1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
-    Diff C (i - 1) ;; transportb (λ x : A, A ⟦x, C (i + 1)⟧)
-         (maponpaths C (hzrminusplus i 1)) (Diff C i) =
+    Diff C (i - 1) ;; transportf (λ x : A, A ⟦x, C (i + 1)⟧)
+         (! maponpaths C (hzrminusplus i 1)) (Diff C i) =
     ZeroArrow to_Zero (C (i - 1)) (C (i + 1)).
   Proof.
     induction (hzrminusplus i 1). cbn. unfold idfun. exact (DSq _ C (i - 1)).
@@ -1521,8 +1511,8 @@ Section def_kernel_cokernel_complex.
 
   Local Lemma CokernelKernelMorphism_comm2 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
     CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
-                (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
-                            (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                (transportf (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                            (! maponpaths C (hzrminusplus i 1)) (Diff C i))
                 (CokernelKernelMorphism_comm1 C i) ;; Diff C (i + 1) =
     ZeroArrow to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1 + 1)).
   Proof.
@@ -1540,39 +1530,30 @@ Section def_kernel_cokernel_complex.
                (Cokernel (Diff C (i - 1)))
                (CokernelOut to_Zero (Cokernel (Diff C (i - 1)))
                             (C (i + 1))
-                            (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
-                                        (maponpaths C (hzrminusplus i 1))
+                            (transportf (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                                        (! maponpaths C (hzrminusplus i 1))
                                         (Diff C i)) (CokernelKernelMorphism_comm1 C i))
                (CokernelKernelMorphism_comm2 C i).
   Proof.
     use KernelInsEq. rewrite KernelCommutes. rewrite <- assoc. rewrite KernelCommutes.
-    assert (e0 : transportf (λ i0 : pr1 hz, A ⟦ C i0, Cokernel (Diff C (i - 1)) ⟧)
+    assert (e1 : transportf (λ i0 : pr1 hz, A ⟦ C i0, Cokernel (Diff C (i - 1)) ⟧)
                             (hzrminusplus i 1) (CokernelArrow (Cokernel (Diff C (i - 1)))) =
-                 transportb (λ i0 : pr1 hz, A ⟦ C i0, Cokernel (Diff C (i - 1)) ⟧)
-                            (hzrminusplus' i 1) (CokernelArrow (Cokernel (Diff C (i - 1))))).
-    {
-      unfold transportb.
-      assert (e1 : ! hzrminusplus' i 1 = hzrminusplus i 1) by apply isasethz.
-      cbn in e1. rewrite e1. apply idpath.
-    }
-    rewrite e0. clear e0.
-    assert (e1 : transportb (λ i0 : pr1 hz, A ⟦ C i0, Cokernel (Diff C (i - 1)) ⟧)
-                            (hzrminusplus' i 1) (CokernelArrow (Cokernel (Diff C (i - 1)))) =
-                 transportb (λ x : A, A⟦x, Cokernel (Diff C (i - 1))⟧)
-                            (maponpaths C (hzrminusplus' i 1))
+                 transportf (λ x : A, A⟦x, Cokernel (Diff C (i - 1))⟧)
+                            (maponpaths C (hzrminusplus i 1))
                             (CokernelArrow (Cokernel (Diff C (i - 1))))).
     {
-      rewrite <- functtransportb. apply idpath.
+      rewrite <- functtransportf. apply idpath.
     }
-    rewrite e1. clear e1. rewrite <- transportb_precompose. rewrite CokernelCommutes.
-    rewrite transport_b_b. rewrite <- maponpathscomp0. rewrite <- functtransportb.
-    assert (e2 : hzrminusplus' i 1 @ hzrminusplus i 1 = idpath _) by apply isasethz.
+    rewrite e1. clear e1. rewrite <- transport_source_precompose. rewrite CokernelCommutes.
+    rewrite transport_f_f. rewrite <- maponpathsinv0. rewrite <- maponpathscomp0.
+    rewrite <- functtransportf.
+    assert (e2 : ! hzrminusplus i 1 @ hzrminusplus i 1 = idpath _) by apply isasethz.
     rewrite e2. apply idpath.
   Qed.
 
   Local Lemma CokernelKernelMorphism_comm1' (C : Complex (AbelianToAdditive A hs)) (i : hz) :
-    Diff C (i - 1) ;; transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
-         (maponpaths C (hzrminusplus i 1)) (Diff C i) =
+    Diff C (i - 1) ;; transportf (λ x : A, A ⟦ x, C (i + 1) ⟧)
+         (! maponpaths C (hzrminusplus i 1)) (Diff C i) =
     ZeroArrow to_Zero (C (i - 1)) (C (i + 1)).
   Proof.
     induction (hzrminusplus i 1). cbn. unfold idfun. exact (DSq _ C (i - 1)).
@@ -1580,13 +1561,13 @@ Section def_kernel_cokernel_complex.
 
   Local Lemma CokernelKernelMorphism_comm2' (C : Complex (AbelianToAdditive A hs)) (i : hz) :
     CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
-                (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
-                            (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                (transportf (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                            (! maponpaths C (hzrminusplus i 1)) (Diff C i))
                 (CokernelKernelMorphism_comm1' C i) =
     (KernelIn to_Zero (Kernel (Diff C (i + 1))) (Cokernel (Diff C (i - 1)))
               (CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
-                           (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
-                                       (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                           (transportf (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                                       (! maponpaths C (hzrminusplus i 1)) (Diff C i))
                            (CokernelKernelMorphism_comm1 C i))
               (CokernelKernelMorphism_comm2 C i))
       ;; (KernelArrow (Kernel (Diff C (i + 1)))).
@@ -1602,14 +1583,14 @@ Section def_kernel_cokernel_complex.
                  transportf (λ i0 : pr1 hz, A ⟦ C i0, Cokernel (Diff C (i - 1)) ⟧)
                             (hzrminusplus i 1) (CokernelArrow (Cokernel (Diff C (i - 1)))) ;; f)
                   × (CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
-                                 (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
-                                             (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                                 (transportf (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                                             (! maponpaths C (hzrminusplus i 1)) (Diff C i))
                                  (CokernelKernelMorphism_comm1' C i) =
                      f ;; KernelArrow (Kernel (Diff C (i + 1)))),
   t =
   KernelIn to_Zero (Kernel (Diff C (i + 1))) (Cokernel (Diff C (i - 1)))
     (CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
-       (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧) (maponpaths C (hzrminusplus i 1)) (Diff C i))
+       (transportf (λ x : A, A ⟦ x, C (i + 1) ⟧) (! maponpaths C (hzrminusplus i 1)) (Diff C i))
        (CokernelKernelMorphism_comm1 C i)) (CokernelKernelMorphism_comm2 C i),,
     CokernelKernelMorphism_comm3 C i,, CokernelKernelMorphism_comm2' C i.
   Proof.
@@ -1618,14 +1599,15 @@ Section def_kernel_cokernel_complex.
     - cbn. use KernelInsEq. rewrite KernelCommutes.
       use CokernelOutsEq. rewrite CokernelCommutes.
       rewrite assoc.
-      use transportb_path.
+      use transport_source_path.
       + exact (C i).
-      + exact (maponpaths C (hzrminusplus' i 1)).
-      + rewrite transport_b_b. rewrite <- maponpathscomp0.
-        assert (e0 : hzrminusplus' i 1 @ hzrminusplus i 1 = idpath _) by apply isasethz.
-        rewrite e0. clear e0. cbn. unfold idfun.
-        rewrite transportb_precompose. rewrite transportb_precompose. rewrite <- functtransportb.
-        unfold transportb.
+      + exact (! maponpaths C (hzrminusplus' i 1)).
+      + rewrite transport_f_f. rewrite <- maponpathsinv0. rewrite <- maponpathsinv0.
+        rewrite <- maponpathscomp0.
+        assert (e0 : (! hzrminusplus i 1 @ ! hzrminusplus' i 1) = idpath _) by apply isasethz.
+        cbn in e0. cbn. rewrite e0. clear e0. cbn. unfold idfun.
+        rewrite transport_source_precompose. rewrite transport_source_precompose.
+        rewrite <- functtransportf.
         assert (e1 : ! hzrminusplus' i 1 = hzrminusplus i 1) by apply isasethz.
         cbn in e1. rewrite e1. clear e1. rewrite <- t21.
         rewrite KernelCommutes. apply idpath.
@@ -1641,8 +1623,8 @@ Section def_kernel_cokernel_complex.
                                 (hzrminusplus i 1)
                                 (CokernelArrow (Cokernel (Diff C (i - 1))))) ;; f)
                      × ((CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
-                                     (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
-                                                 (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                                     (transportf (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                                                 (! maponpaths C (hzrminusplus i 1)) (Diff C i))
                                      (CokernelKernelMorphism_comm1' C i)) =
                        f ;; (KernelArrow (Kernel (Diff C (i + 1)))))).
   Proof.
@@ -1650,7 +1632,7 @@ Section def_kernel_cokernel_complex.
     - use tpair.
       + cbn. use KernelIn.
         * use CokernelOut.
-          -- exact (transportb (fun (x : A) => A⟦x, C(i + 1)⟧) (maponpaths C (hzrminusplus i 1))
+          -- exact (transportf (fun (x : A) => A⟦x, C(i + 1)⟧) (! maponpaths C (hzrminusplus i 1))
                                (Diff C i)).
           -- exact (CokernelKernelMorphism_comm1 C i).
         * exact (CokernelKernelMorphism_comm2 C i).
@@ -1667,7 +1649,8 @@ Section def_kernel_cokernel_complex.
     let CK := Cokernel (transportf (precategory_morphisms (C (i - 1)))
                                    (maponpaths C (hzrminusplus i 1)) (Diff C (i - 1))) in
     (Diff C (i - 1))
-      ;; (transportb (λ x' : A, A ⟦ x', CK⟧) (maponpaths C (hzrminusplus i 1)) (CokernelArrow CK)) =
+      ;; (transportf (λ x' : A, A ⟦ x', CK⟧)
+                     (! maponpaths C (hzrminusplus i 1)) (CokernelArrow CK)) =
     ZeroArrow to_Zero _ _.
   Proof.
     induction (hzrminusplus i 1). cbn. unfold idfun. apply CokernelCompZero.
@@ -1676,11 +1659,11 @@ Section def_kernel_cokernel_complex.
   Local Lemma CokernelKernelCohomology1_Mor1_eq1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
     (transportf (precategory_morphisms (C (i - 1))) (maponpaths C (hzrminusplus i 1))
                 (Diff C (i - 1)))
-      ;; (transportb (λ x' : A, A ⟦ x', Cokernel (Diff C (i - 1)) ⟧)
-                     (maponpaths C (! hzrminusplus i 1))
+      ;; (transportf (λ x' : A, A ⟦ x', Cokernel (Diff C (i - 1)) ⟧)
+                     (maponpaths C (hzrminusplus i 1))
                      (CokernelArrow (Cokernel (Diff C (i - 1))))) = ZeroArrow to_Zero _ _.
   Proof.
-    rewrite maponpathsinv0. rewrite transport_compose'. apply CokernelCompZero.
+    rewrite transport_compose'. use CokernelCompZero.
   Qed.
 
   Local Lemma CokernelKernelCohomology1_Mor1_comm1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
@@ -1697,12 +1680,12 @@ Section def_kernel_cokernel_complex.
          (transportf (precategory_morphisms (C (i - 1))) (maponpaths C (hzrminusplus i 1))
                      (Diff C (i - 1))))
       (Cokernel (Diff C (i - 1)))
-      (transportb (λ x' : A, A ⟦ x', Cokernel (Diff C (i - 1)) ⟧)
-                  (maponpaths C (! hzrminusplus i 1)) (CokernelArrow (Cokernel (Diff C (i - 1)))))
+      (transportf (λ x' : A, A ⟦ x', Cokernel (Diff C (i - 1)) ⟧)
+                  (maponpaths C (hzrminusplus i 1)) (CokernelArrow (Cokernel (Diff C (i - 1)))))
       (CokernelKernelCohomology1_Mor1_eq1 C i) ;;
       KernelIn to_Zero (Kernel (Diff C (i + 1))) (Cokernel (Diff C (i - 1)))
       (CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
-                   (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧) (maponpaths C (hzrminusplus i 1))
+                   (transportf (λ x : A, A ⟦ x, C (i + 1) ⟧) (! maponpaths C (hzrminusplus i 1))
                                (Diff C i))
                    (CokernelKernelMorphism_comm1 C i)) (CokernelKernelMorphism_comm2 C i) =
     ZeroArrow to_Zero _ _.
@@ -1717,17 +1700,16 @@ Section def_kernel_cokernel_complex.
     rewrite <- assoc. rewrite <- assoc. rewrite KernelCommutes. rewrite ZeroArrow_comp_left.
     cbn. cbn in K. fold K. rewrite <- (KernelCompZero to_Zero K). apply cancel_precomposition.
     use CokernelOutsEq. rewrite assoc. rewrite CokernelCommutes. rewrite CokernelCommutes.
-    use transportb_path.
+    use transport_source_path.
     - exact (C (i - 1 + 1)).
-    - exact (maponpaths C (hzrminusplus i 1)).
-    - rewrite <- (CokernelCommutes to_Zero (Cokernel (Diff C (i - 1))) _
-                                  (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
-                                              (maponpaths C (hzrminusplus i 1))
-                                              (Diff C i)) (CokernelKernelMorphism_comm1 C i)).
-      rewrite transportb_precompose. apply cancel_postcomposition. rewrite transport_b_b.
-      rewrite <- maponpathscomp0.
+    - exact (! maponpaths C (hzrminusplus i 1)).
+    - rewrite <- transport_source_precompose.
+      set (tmp := CokernelCommutes
+                    to_Zero (Cokernel (Diff C (i - 1))) _ _ (CokernelKernelMorphism_comm1 C i)).
+      cbn in tmp. cbn. rewrite tmp. clear tmp. rewrite transport_f_f.
+      rewrite <- maponpathsinv0. rewrite <- maponpathscomp0.
       assert (e0 : (hzrminusplus i 1 @ ! hzrminusplus i 1) = idpath _) by apply isasethz.
-      cbn. cbn in e0. rewrite e0. clear e0. apply idpath.
+      cbn. cbn in e0. rewrite e0. clear e0. cbn. unfold idfun. apply idpath.
   Qed.
 
   Definition CokernelKernelCohomology1_Mor1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
@@ -1745,8 +1727,8 @@ Section def_kernel_cokernel_complex.
     - cbn.
       use (compose (KernelArrow K)).
       use CokernelOut.
-      + exact (transportb (fun x' : A => A ⟦x', Cokernel (Diff C (i - 1))⟧)
-                          (maponpaths C (! hzrminusplus i 1))
+      + exact (transportf (fun x' : A => A ⟦x', Cokernel (Diff C (i - 1))⟧)
+                          (maponpaths C (hzrminusplus i 1))
                           (CokernelArrow (Cokernel (Diff C (i - 1))))).
       + exact (CokernelKernelCohomology1_Mor1_eq1 C i).
     - exact (CokernelKernelCohomology1_Mor1_comm1 C i).
@@ -1757,19 +1739,19 @@ Section def_kernel_cokernel_complex.
       (Kernel
          (KernelIn to_Zero (Kernel (Diff C (i + 1))) (Cokernel (Diff C (i - 1)))
                    (CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
-                                (transportb (λ x : A, A ⟦x, C (i + 1)⟧)
-                                            (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                                (transportf (λ x : A, A ⟦x, C (i + 1)⟧)
+                                            (! maponpaths C (hzrminusplus i 1)) (Diff C i))
                                 (CokernelKernelMorphism_comm1 C i))
                    (CokernelKernelMorphism_comm2 C i))) ;;
       CokernelOut to_Zero (Cokernel (Diff C (i - 1)))
       (Cokernel
          (transportf (precategory_morphisms (C (i - 1))) (maponpaths C (hzrminusplus i 1))
                      (Diff C (i - 1))))
-      (transportb (λ x' : A, A ⟦x', Cokernel
+      (transportf (λ x' : A, A ⟦x', Cokernel
                                       (transportf (precategory_morphisms (C (i - 1)))
                                                   (maponpaths C (hzrminusplus i 1))
                                                   (Diff C (i - 1)))⟧)
-                  (maponpaths C (hzrminusplus i 1))
+                  (! maponpaths C (hzrminusplus i 1))
                   (CokernelArrow
                      (Cokernel
                         (transportf (precategory_morphisms (C (i - 1)))
@@ -1787,46 +1769,53 @@ Section def_kernel_cokernel_complex.
     set (K := (Kernel
                  (KernelIn to_Zero (Kernel (Diff C (i + 1))) (Cokernel (Diff C (i - 1)))
                            (CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
-                                        (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
-                                                    (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                                        (transportf (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                                                    (! maponpaths C (hzrminusplus i 1)) (Diff C i))
                                         (CokernelKernelMorphism_comm1 C i))
                            (CokernelKernelMorphism_comm2 C i)))).
     cbn. cbn in K. fold K.
     set (tmp := dirprod_pr2 (pr2 (pr1 (CokernelKernelMorphism C i)))).
     assert (e0 : CokernelOut to_Zero (Cokernel (Diff C (i - 1))) CK
-                             (transportb (λ x' : A, A ⟦ x', CK ⟧) (maponpaths C (hzrminusplus i 1))
+                             (transportf (λ x' : A, A ⟦ x', CK ⟧)
+                                         (! maponpaths C (hzrminusplus i 1))
                                          (CokernelArrow CK))
                              (CokernelKernelCohomology1_eq C i) ;; CokernelOut to_Zero CK
                              (C (i + 1)) (Diff C i)
                              (CohomologyComplex_KernelIn_eq A hs C i) =
                  (KernelIn to_Zero (Kernel (Diff C (i + 1))) (Cokernel (Diff C (i - 1)))
                            (CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
-                                        (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
-                                                    (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                                        (transportf (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                                                    (! maponpaths C (hzrminusplus i 1)) (Diff C i))
                                         (CokernelKernelMorphism_comm1 C i))
                            (CokernelKernelMorphism_comm2 C i)) ;; KernelArrow (Kernel _)).
     {
       use CokernelOutsEq. rewrite assoc. rewrite CokernelCommutes.
-      use transportb_path.
+      use transport_source_path.
       + exact (C i).
-      + exact (maponpaths C (! hzrminusplus i 1)).
-      + rewrite transportb_precompose. rewrite transport_b_b.
-        rewrite <- maponpathscomp0.
-        assert (e0 : ! hzrminusplus i 1 @ hzrminusplus i 1 = idpath _) by apply isasethz.
-        rewrite e0. clear e0. cbn. unfold idfun. rewrite CokernelCommutes.
+      + exact (! maponpaths C (! hzrminusplus i 1)).
+      + rewrite transport_source_precompose. rewrite transport_f_f.
+        rewrite maponpathsinv0. rewrite pathsinv0inv0.
+        assert (e0 : (! maponpaths C (hzrminusplus i 1) @ maponpaths C (hzrminusplus i 1)) =
+                     maponpaths C (idpath _)).
+        {
+          rewrite <- maponpathsinv0. rewrite <- maponpathscomp0. apply maponpaths.
+          apply isasethz.
+        }
+        cbn. cbn in e0. rewrite e0. clear e0. cbn. unfold idfun. rewrite CokernelCommutes.
         cbn in tmp. rewrite <- tmp. clear tmp.
-        use transportb_path.
+        use transport_source_path.
         * exact (C (i - 1 + 1)).
-        * exact (maponpaths C (hzrminusplus i 1)).
-        * rewrite transportb_precompose. rewrite transportb_precompose.
-          rewrite transport_b_b. rewrite <- maponpathscomp0. rewrite pathsinv0r. cbn.
-          unfold idfun. rewrite CokernelCommutes. apply idpath.
+        * exact (! maponpaths C (hzrminusplus i 1)).
+        * rewrite transport_source_precompose. rewrite transport_source_precompose.
+          rewrite transport_f_f. rewrite <- maponpathsinv0. rewrite <- maponpathscomp0.
+          rewrite pathsinv0r. cbn. unfold idfun. rewrite CokernelCommutes.
+          rewrite maponpathsinv0. apply idpath.
     }
     rewrite <- assoc. cbn in e0. rewrite e0. clear e0.
     rewrite KernelCommutes. unfold K.
     set (CKO := CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
-                            (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
-                                        (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                            (transportf (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                                        (! maponpaths C (hzrminusplus i 1)) (Diff C i))
                             (CokernelKernelMorphism_comm1 C i)). cbn. cbn in CKO. fold CKO.
     set (K2 := Kernel (KernelIn to_Zero (Kernel (Diff C (i + 1)))
                                 (Cokernel (Diff C (i - 1))) CKO
@@ -1847,7 +1836,8 @@ Section def_kernel_cokernel_complex.
     use KernelIn.
     - use (compose (KernelArrow _)).
       use CokernelOut.
-      + exact (transportb (fun x' : A => precategory_morphisms x' _) (maponpaths C (hzrminusplus i 1))
+      + exact (transportf (fun x' : A => precategory_morphisms x' _)
+                          (! maponpaths C (hzrminusplus i 1))
                           (CokernelArrow (Cokernel (transportf (precategory_morphisms (C (i - 1)))
                                                                (maponpaths C (hzrminusplus i 1))
                                                                (Diff C (i - 1)))))).
@@ -1873,8 +1863,8 @@ Section def_kernel_cokernel_complex.
     set (K2 := (Kernel
                   (KernelIn to_Zero (Kernel (Diff C (i + 1))) (Cokernel (Diff C (i - 1)))
                             (CokernelOut to_Zero (Cokernel (Diff C (i - 1))) (C (i + 1))
-                                         (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
-                                                     (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                                         (transportf (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                                                     (! maponpaths C (hzrminusplus i 1)) (Diff C i))
                                          (CokernelKernelMorphism_comm1 C i))
                             (CokernelKernelMorphism_comm2 C i)))).
     cbn in K2. fold K2.
@@ -1891,15 +1881,15 @@ Section def_kernel_cokernel_complex.
                           (CohomologyComplexIso_Mor_i A hs C i,,
                                                       CohomologyComplexIso_is_iso_i A hs C i) ;;
                           (KernelArrow K1 ;; CokernelOut to_Zero CK2 CK1
-                                       (transportb
+                                       (transportf
                                           (λ x' : A, A ⟦ x', CK1 ⟧)
-                                          (maponpaths C (! hzrminusplus i 1))
+                                          (maponpaths C (hzrminusplus i 1))
                                           (CokernelArrow CK1))
                                        (CokernelKernelCohomology1_Mor1_eq1 C i)))) =
                  (KernelArrow K1 ;; CokernelOut to_Zero CK2 CK1
-                              (transportb
+                              (transportf
                                  (λ x' : A, A ⟦ x', CK1 ⟧)
-                                 (maponpaths C (! hzrminusplus i 1))
+                                 (maponpaths C (hzrminusplus i 1))
                                  (CokernelArrow CK1))
                               (CokernelKernelCohomology1_Mor1_eq1 C i))).
     {
@@ -1917,8 +1907,8 @@ Section def_kernel_cokernel_complex.
     apply (maponpaths
              (fun gg : _ => KernelIn to_Zero K1 K2
                                   (KernelArrow K2 ;; CokernelOut to_Zero CK1 CK2
-                                               (transportb (λ x' : A, A ⟦ x', CK2 ⟧)
-                                                           (maponpaths C (hzrminusplus i 1))
+                                               (transportf (λ x' : A, A ⟦ x', CK2 ⟧)
+                                                           (! maponpaths C (hzrminusplus i 1))
                                                            (CokernelArrow CK2))
                                                (CokernelKernelCohomology1_eq C i))
                                   (CokernelKernelCohomology1_Mor2_comm1 C i) ;; gg)) in ee.
@@ -1927,11 +1917,12 @@ Section def_kernel_cokernel_complex.
     rewrite assoc. rewrite KernelCommutes. rewrite <- id_right. rewrite <- assoc.
     apply cancel_precomposition. use CokernelOutsEq.
     rewrite id_right. rewrite assoc. rewrite CokernelCommutes.
-    use transportb_path.
+    use transport_source_path.
     -- exact (C i).
-    -- exact (maponpaths C (! hzrminusplus i 1)).
-    -- rewrite transportb_precompose. rewrite transport_b_b.
-       rewrite <- maponpathscomp0. rewrite pathsinv0l. cbn. unfold idfun.
+    -- exact (! maponpaths C (! hzrminusplus i 1)).
+    -- rewrite transport_source_precompose. rewrite transport_f_f.
+       rewrite <- maponpathsinv0. rewrite <- maponpathsinv0. rewrite <- maponpathscomp0.
+       rewrite pathsinv0inv0. rewrite pathsinv0l. cbn. unfold idfun.
        apply CokernelCommutes.
   Qed.
 
@@ -1951,24 +1942,24 @@ Section def_kernel_cokernel_complex.
     set (K2 := Kernel
                  (KernelIn to_Zero (Kernel (Diff C (i + 1))) CK1
                            (CokernelOut to_Zero CK1 (C (i + 1))
-                                        (transportb (λ x : A, A ⟦ x, C (i + 1) ⟧)
-                                                    (maponpaths C (hzrminusplus i 1)) (Diff C i))
+                                        (transportf (λ x : A, A ⟦ x, C (i + 1) ⟧)
+                                                    (! maponpaths C (hzrminusplus i 1)) (Diff C i))
                                         (CokernelKernelMorphism_comm1 C i))
                            (CokernelKernelMorphism_comm2 C i))).
     cbn in K2. fold K2.
     set (KI21 := KernelIn to_Zero K2 K1
                           ((KernelArrow K1)
                              ;; (CokernelOut to_Zero CK2 CK1
-                                             (transportb (λ x' : A, A ⟦ x', CK1 ⟧)
-                                                         (maponpaths C (! hzrminusplus i 1))
+                                             (transportf (λ x' : A, A ⟦ x', CK1 ⟧)
+                                                         (maponpaths C (hzrminusplus i 1))
                                                          (CokernelArrow CK1))
                                              (CokernelKernelCohomology1_Mor1_eq1 C i)))
                           (CokernelKernelCohomology1_Mor1_comm1 C i)).
     cbn in KI21. fold KI21.
     set (KI12 := KernelIn to_Zero K1 K2
                           (KernelArrow K2 ;; CokernelOut to_Zero CK1 CK2
-                                       (transportb (λ x' : A, A ⟦ x', CK2 ⟧)
-                                                   (maponpaths C (hzrminusplus i 1))
+                                       (transportf (λ x' : A, A ⟦ x', CK2 ⟧)
+                                                   (! maponpaths C (hzrminusplus i 1))
                                                    (CokernelArrow CK2))
                                        (CokernelKernelCohomology1_eq C i))
                           (CokernelKernelCohomology1_Mor2_comm1 C i)).
@@ -2007,11 +1998,12 @@ Section def_kernel_cokernel_complex.
     rewrite KernelCommutes.
     rewrite id_left. rewrite <- id_right. rewrite <- assoc. apply cancel_precomposition.
     use CokernelOutsEq. rewrite assoc. rewrite CokernelCommutes. rewrite id_right.
-    use transportb_path.
+    use transport_source_path.
     - exact (C (i - 1 + 1)).
-    - exact (maponpaths C (hzrminusplus i 1)).
-    - rewrite transportb_precompose. rewrite transport_b_b. rewrite <- maponpathscomp0.
-      rewrite pathsinv0r. cbn. unfold idfun. apply CokernelCommutes.
+    - exact (! maponpaths C (hzrminusplus i 1)).
+    - rewrite transport_source_precompose. rewrite transport_f_f.
+      rewrite <- maponpathsinv0. rewrite <- maponpathscomp0.
+      rewrite pathsinv0r. cbn. unfold idfun. rewrite maponpathsinv0. apply CokernelCommutes.
   Qed.
 
   Definition CokernelKernelCohomology1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
@@ -2043,34 +2035,21 @@ Section def_kernel_cokernel_complex.
                                    (hzrminusplus i 1)
                                    (CokernelArrow (Cokernel (Diff C (i - 1)))))).
     {
-      set (tmp' := transportb_isEpi A (CokernelArrow (Cokernel (Diff C (i - 1))))
-                                    (CokernelArrowisEpi _ _) (maponpaths C (hzrminusplus' i 1))).
-      unfold transportb in tmp'.
-      assert (e00 : (! maponpaths C (hzrminusplus' i 1)) = maponpaths C (hzrminusplus i 1)).
-      {
-        rewrite <- maponpathsinv0. apply maponpaths.
-        apply isasethz.
-      }
-      cbn in tmp'.
-      assert (e001 : isEpi (transportf (λ x' : A, A ⟦ x', Cokernel (Diff C (i - 1)) ⟧)
-                                       (maponpaths C (hzrminusplus i 1))
-                                       (CokernelArrow (Cokernel (Diff C (i - 1)))))).
-      {
-        induction e00. apply tmp'.
-      }
-      clear e00.
-      rewrite <- functtransportf in e001. apply e001.
+      set (tmp' := transport_source_isEpi
+                     A (CokernelArrow (Cokernel (Diff C (i - 1))))
+                     (CokernelArrowisEpi _ _) (maponpaths C (hzrminusplus i 1))).
+      rewrite <- functtransportf in tmp'. apply tmp'.
     }
     use e0. rewrite assoc. clear e0. rewrite ZeroArrow_comp_right.
     set (tmp := dirprod_pr1 (pr2 (pr1 (CokernelKernelMorphism C i)))).
     cbn in tmp. rewrite <- tmp. clear tmp.
     set (tmp := CokernelCompZero _ CK).
-    use transportb_path.
+    use transport_source_path.
     - exact (C (i + 1 - 1)).
-    - exact (maponpaths C (hzrplusminus i 1)).
-    - rewrite transportb_ZeroArrow. cbn in tmp. rewrite <- tmp. clear tmp.
-      rewrite transportb_precompose. apply cancel_postcomposition. clear CK.
-      rewrite transportb_KernelIn. use KernelInsEq.
+    - exact (! maponpaths C (hzrplusminus i 1)).
+    - rewrite transport_source_ZeroArrow. cbn in tmp. rewrite <- tmp. clear tmp.
+      rewrite transport_source_precompose. apply cancel_postcomposition. clear CK.
+      rewrite transport_source_KernelIn. use KernelInsEq.
       rewrite KernelCommutes. rewrite KernelCommutes.
       set (tmp := transport_Diff _ C i). cbn. cbn in tmp. apply tmp.
   Qed.
@@ -2098,18 +2077,18 @@ Section def_kernel_cokernel_complex.
                                       (maponpaths C (hzrminusplus (i + 1) 1))
                                       (Diff C (i + 1 - 1)))
                           (CohomologyComplex_KernelIn_eq A hs C (i + 1)) =
-                 transportb (fun x' : ob A => precategory_morphisms x' _)
-                            (maponpaths C (hzrplusminus i 1))
+                 transportf (fun x' : ob A => precategory_morphisms x' _)
+                            (! maponpaths C (hzrplusminus i 1))
                             (KernelIn to_Zero (Kernel (Diff C (i + 1))) (C i) (Diff C i)
                                       (DSq (AbelianToAdditive A hs) C i))).
     {
-      rewrite transportb_KernelIn.
+      rewrite transport_source_KernelIn.
       use KernelInsEq.
       rewrite KernelCommutes. rewrite KernelCommutes. clear tmp.
       set (tmp := transport_Diff _ C i). cbn. cbn in tmp. apply pathsinv0. apply tmp.
     }
     cbn in e0. cbn. rewrite e0. clear e0. rewrite tmp. clear tmp. cbn.
-    rewrite transportb_precompose. rewrite <- assoc. rewrite CokernelCompZero.
+    rewrite transport_source_precompose. rewrite <- assoc. rewrite CokernelCompZero.
     apply ZeroArrow_comp_right.
   Qed.
 

--- a/UniMath/CategoryTheory/Complexes.v
+++ b/UniMath/CategoryTheory/Complexes.v
@@ -1970,7 +1970,7 @@ Section transport_section'.
         (e1 : i = i') :
     H i' = transportb (fun (x : ob C) => C⟦x, f (i' + n)⟧) (maponpaths f (! e1))
                       (transportf (precategory_morphisms (f i))
-                                  (maponpaths f (hzplusladd i i' n e1)) (H i)).
+                                  (maponpaths f (hzplusradd i i' n e1)) (H i)).
   Proof.
     induction e1. apply idpath.
   Qed.
@@ -1978,7 +1978,7 @@ Section transport_section'.
   Lemma transport_mor_f_b (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f i, f (i + n)⟧) (i i' : hz)
         (e1 : i = i') :
     H i' = transportf (precategory_morphisms (f i'))
-                      (maponpaths f (hzplusladd i i' n e1))
+                      (maponpaths f (hzplusradd i i' n e1))
                       (transportb (fun (x : ob C) => C⟦x, f (i + n)⟧) (maponpaths f (! e1)) (H i)).
   Proof.
     induction e1. apply idpath.
@@ -1986,7 +1986,7 @@ Section transport_section'.
 
   Lemma transport_section' (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f i, f (i + n)⟧) (i i' : hz)
     (e1 : i = i') :
-    transportf (precategory_morphisms (f i)) (maponpaths f (hzplusladd i i' n e1)) (H i) =
+    transportf (precategory_morphisms (f i)) (maponpaths f (hzplusradd i i' n e1)) (H i) =
     transportb (fun (x : ob C) => C⟦x, f (i' + n)⟧) (maponpaths f e1) (H i').
   Proof.
     induction e1. apply idpath.

--- a/UniMath/CategoryTheory/Complexes.v
+++ b/UniMath/CategoryTheory/Complexes.v
@@ -104,6 +104,61 @@ Section def_complexes.
   Definition DSq (C : Complex) (i : hz) :
     (Diff C i) ;; (Diff C (i + 1)) = ZeroArrow (Additive.to_Zero A) _ _ := pr2 C i.
 
+  Local Lemma ComplexEq' (C1 C2 : Complex) (H : Π (i : hz), C1 i = C2 i)
+        (H1 : Π (i : hz),
+              transportf (λ x : A, C2 i --> x) (H (i + 1))
+                         (transportb (λ x : A, x --> C1 (i + 1)) (! H i) (Diff C1 i)) =
+              Diff C2 i) :
+    transportf (λ x : hz → A, Π i : hz, A ⟦ x i, x (i + 1) ⟧)
+               (funextfun (pr1 (pr1 C1)) (pr1 (pr1 C2)) (λ i : hz, H i)) (pr2 (pr1 C1)) =
+    pr2 (pr1 C2).
+  Proof.
+    use funextsec. intros i.
+    assert (e : transportf (λ x : hz → A, Π i0 : hz, A ⟦ x i0, x (i0 + 1) ⟧)
+                           (funextfun (pr1 (pr1 C1)) (pr1 (pr1 C2)) (λ i0 : hz, H i0))
+                           (pr2 (pr1 C1)) i =
+                transportf (λ x : hz → A, A ⟦ x i, x (i + 1) ⟧)
+                           (funextfun (pr1 (pr1 C1)) (pr1 (pr1 C2)) (λ i0 : hz, H i0))
+                           (pr2 (pr1 C1) i)).
+    {
+      induction (funextfun (pr1 (pr1 C1)) (pr1 (pr1 C2)) (λ i0 : hz, H i0)).
+      apply idpath.
+    }
+    rewrite e. clear e.
+    rewrite transport_mor_funextfun.
+    rewrite transportb_mor_funextfun. rewrite transportf_mor_funextfun.
+    exact (H1 i).
+  Qed.
+
+  Local Lemma ComplexEq'' (C1 C2 : Complex) (H : Π (i : hz), C1 i = C2 i)
+        (H1 : Π (i : hz),
+              transportf (λ x : A, C2 i --> x) (H (i + 1))
+                         (transportb (λ x : A, x --> C1 (i + 1)) (! H i) (Diff C1 i)) =
+              Diff C2 i) :
+    transportf
+      (λ x : Σ D : hz → A, Π i : hz, A ⟦ D i, D (i + 1) ⟧,
+                                 Π i : hz, pr2 x i ;; pr2 x (i + 1) =
+                                           ZeroArrow (Additive.to_Zero A) _ _)
+      (total2_paths (funextfun (pr1 (pr1 C1)) (pr1 (pr1 C2)) (λ i : hz, H i))
+                    (ComplexEq' C1 C2 H H1)) (pr2 C1) = pr2 C2.
+  Proof.
+    apply proofirrelevance. apply impred_isaprop. intros t. apply to_has_homsets.
+  Qed.
+
+  Lemma ComplexEq (C1 C2 : Complex) (H : Π (i : hz), C1 i = C2 i)
+        (H1 : Π (i : hz),
+              transportf (λ x : A, C2 i --> x) (H (i + 1))
+                         (transportb (λ x : A, x --> C1 (i + 1)) (! H i) (Diff C1 i)) =
+              Diff C2 i) : C1 = C2.
+  Proof.
+    use total2_paths.
+    - use total2_paths.
+      + use funextfun. intros i. exact (H i).
+      + exact (ComplexEq' C1 C2 H H1).
+    - exact (ComplexEq'' C1 C2 H H1).
+  Defined.
+
+
   (** Zero Complex *)
   Definition ZeroComplex : Complex.
   Proof.
@@ -157,7 +212,8 @@ Section def_complexes.
     (M i) ;; (Diff C2 i) = (Diff C1 i) ;; (M (i + 1)) := pr2 M i.
 
   (** A lemma to show that two morphisms are the same *)
-  Lemma MorphismEq {C1 C2 : Complex} (M1 M2 : Morphism C1 C2) (H : Π i : hz, M1 i = M2 i) : M1 = M2.
+  Lemma MorphismEq {C1 C2 : Complex} (M1 M2 : Morphism C1 C2) (H : Π i : hz, M1 i = M2 i) :
+    M1 = M2.
   Proof.
     use total2_paths.
     - use funextsec. intros i. exact (H i).
@@ -1342,8 +1398,8 @@ Section complexes_abelian.
     intros i. cbn. rewrite KernelCompZero. apply pathsinv0. apply ZeroArrowEq.
   Qed.
 
-  Local Lemma ComplexPreCat_KernelIn_comp {X Y w : Complex (AbelianToAdditive A hs)} (g : Morphism X Y)
-    (h : Morphism w X) (i : hz) :
+  Local Lemma ComplexPreCat_KernelIn_comp {X Y w : Complex (AbelianToAdditive A hs)}
+        (g : Morphism X Y) (h : Morphism w X) (i : hz) :
     let Z := Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
     MorphismComp h g = ZeroArrow Z w Y ->
     (h i) ;; (g i) = ZeroArrow to_Zero (w i) (Y i).
@@ -1354,7 +1410,7 @@ Section complexes_abelian.
   Qed.
 
   Definition ComplexPreCat_KernelIn {X Y w : Complex (AbelianToAdditive A hs)} (g : Morphism X Y)
-    (h : Morphism w X) :
+             (h : Morphism w X) :
     let Z := Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
     MorphismComp h g = ZeroArrow Z w Y ->
     (ComplexPreCat (AbelianToAdditive A hs)) ⟦w, ComplexPreCat_Kernel g⟧.
@@ -1992,8 +2048,8 @@ Section transport_section'.
     induction e1. apply idpath.
   Qed.
 
-  Lemma transport_section'' (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f (i + n), f i⟧) (i i' : hz)
-    (e1 : i + n = i' + n) (e2 : i = i') :
+  Lemma transport_section'' (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f (i + n), f i⟧)
+        (i i' : hz) (e1 : i + n = i' + n) (e2 : i = i') :
     transportf (precategory_morphisms (f (i + n))) (maponpaths f e2) (H i) =
     transportb (fun (x : ob C) => C⟦x, f i'⟧) (maponpaths f e1) (H i').
   Proof.
@@ -2409,8 +2465,8 @@ to the complex
 More precicely, on objects # X^i ↦ X^{i+1} # $ X^i ↦ X^{i+1} $ and differentials
 # d^i_X ↦ -d^{i+1}_X # $ d^i_X ↦ -d^{i+1}_X $. A morphism f : X -> Y is mapped by
 # f^i ↦ f^{i+1} # $ f^i ↦ f^{i+1} $. We also construct the inverse translation T^{-1} which is the
-unique functor such that T ∘ T^{-1} = id and T^{-1} ∘ T = id (This has not been proven yet!).
-All the functors T, T^{-1}, and T' are additive.
+unique functor such that T ∘ T^{-1} = id and T^{-1} ∘ T = id. All the functors T, T^{-1}, and T'
+are additive.
 
 The functor T : C(A) -> C(A) is constructed in [TranslationFunctor]. It is shown to be additive in
 [TranslationFunctor_Additive]. In [TranslationFunctorPreservesHomotopies] we show that T preserves
@@ -2706,8 +2762,261 @@ Section translation_functor.
     - exact InvTranslationFunctor_isAdditive.
   Defined.
 
-  (** TODO : Translation is an isomorphism with inverse the inverse translation. *)
 
+  (** *** InvTranslation functor preserves homotopies *)
+
+  Definition InvTranslationHomot {C1 C2 : Complex A} (H : ComplexHomot A C1 C2) :
+    ComplexHomot A (InvTranslationComplex C1) (InvTranslationComplex C2).
+  Proof.
+    intros i. exact (to_inv (H (i - 1))).
+  Defined.
+
+  Lemma InvTranslationFunctorHomotopies {C1 C2 : Complex A} (H : ComplexHomot A C1 C2) :
+    ComplexHomotMorphism A (InvTranslationHomot H) =
+    InvTranslationMorphism C1 C2 (ComplexHomotMorphism A H).
+  Proof.
+    unfold InvTranslationHomot. cbn. use MorphismEq. intros i. cbn.
+    induction (hzrplusminus i 1). cbn. unfold idfun. rewrite pathscomp0rid.
+    rewrite <- transportf_to_inv. rewrite <- PreAdditive_invrcomp. rewrite <- PreAdditive_invlcomp.
+    rewrite inv_inv_eq.
+    rewrite <- transportf_to_inv. rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invrcomp.
+    rewrite inv_inv_eq.
+    assert (e1 : transportf (precategory_morphisms (C1 (i + 1 - 1 - 1)))
+                            (maponpaths C1 (hzrminusplus (i + 1 - 1) 1))
+                            (Diff C1 (i + 1 - 1 - 1)) ;; H (i + 1 - 1) =
+                 transportf (precategory_morphisms (C1 (i + 1 - 1 - 1)))
+                            (maponpaths C2 (hzrplusminus (i + 1 - 1 - 1) 1))
+                            (Diff C1 (i + 1 - 1 - 1) ;; H (i + 1 - 1 - 1 + 1))).
+    {
+      rewrite transportf_postcompose. rewrite transport_compose. apply cancel_precomposition.
+      rewrite <- (transport_double_section A _ _ H _ _ (hzrminusplus (i + 1 - 1) 1)).
+      use transportf_paths.
+      assert (e2 : maponpaths (λ i0 : hz, C2 (i0 - 1)) (hzrminusplus (i + 1 - 1) 1) =
+                   maponpaths C2 (maponpaths (λ i0 : hz, i0 - 1) (hzrminusplus (i + 1 - 1) 1))).
+      {
+        induction (hzrminusplus (i + 1 - 1) 1). apply idpath.
+      }
+      rewrite e2. clear e2. apply maponpaths. apply isasethz.
+    }
+    cbn in e1. rewrite e1. clear e1. use to_lrw.
+    rewrite <- transportf_postcompose. rewrite transport_f_f.
+    assert (e2 : maponpaths (λ i0 : pr1 hz, C2 (i0 - 1)) (hzrminusplus (i + 1 - 1) 1) =
+                 maponpaths C2 (maponpaths (λ i0 : hz, i0 - 1) (hzrminusplus (i + 1 - 1) 1))).
+    {
+      induction (hzrminusplus (i + 1 - 1) 1). apply idpath.
+    }
+    rewrite e2. clear e2. rewrite <- maponpathscomp0.
+    use transportf_paths. apply maponpaths. apply isasethz.
+  Qed.
+
+  Lemma InvTranslationFunctorPreservesHomotopies {C1 C2 : Complex A}
+        (f g : (ComplexPreCat_Additive A)⟦C1, C2⟧)
+        (H : subgrhrel (ComplexHomotSubgrp A C1 C2) f g) :
+    subgrhrel (ComplexHomotSubgrp A _ _) (InvTranslationMorphism C1 C2 f)
+              (InvTranslationMorphism C1 C2 g).
+  Proof.
+    use (squash_to_prop H). apply propproperty. intros H'. clear H.
+    induction H' as [H1 H2]. induction H1 as [H11 H12]. cbn in H11.
+    use (squash_to_prop H12). apply propproperty. intros H. cbn in H2.
+    induction H as [HH1 HH2].
+    intros P X. apply X. clear X P.
+    use tpair.
+    - use tpair. cbn. exact (InvTranslationMorphism _ _ H11).
+      intros P X. apply X. clear X P.
+      use tpair.
+      + exact (InvTranslationHomot HH1).
+      + cbn. rewrite InvTranslationFunctorHomotopies. rewrite HH2. apply idpath.
+    - cbn. rewrite H2.
+      set (tmp := @AdditiveFunctorLinear (ComplexPreCat_Additive A) (ComplexPreCat_Additive A)
+                                         InvTranslationFunctor_Additive C1 C2 f (to_inv g)).
+      cbn in tmp.
+      rewrite tmp. clear tmp. apply maponpaths.
+      set (tmp := @AdditiveFunctorInv (ComplexPreCat_Additive A) (ComplexPreCat_Additive A)
+                                      InvTranslationFunctor_Additive C1 C2 g). cbn in tmp.
+      exact tmp.
+  Qed.
+
+  (** ** Translation functor is an isomorphism, with inverse the inverse translation. *)
+
+  Lemma transportf_total2_base {AA : UU} {B : AA -> UU} {BB : AA -> UU} (s s' : Σ x : AA, B x)
+        (p : pr1 s = pr1 s') (q : transportf B p (pr2 s) = pr2 s') (x : BB (pr1 s)) :
+    transportf (λ x' : Σ x : AA, B x, BB (pr1 x')) (total2_paths p q) x =
+    transportf (λ x : AA, BB x) p x.
+  Proof.
+    induction s as [s1 s2]. induction s' as [s1' s2']. cbn in *.
+    induction p. induction q. apply idpath.
+  Qed.
+
+  Lemma transportb_total2_base {AA : UU} {B : AA -> UU} (BB : AA -> UU) (s s' : Σ x : AA, B x)
+        (p : pr1 s = pr1 s') (q : transportf B p (pr2 s) = pr2 s') (x : BB (pr1 s)) :
+    transportb (λ x' : Σ x : AA, B x, BB (pr1 x')) (! total2_paths p q) x =
+    transportb (λ x : AA, BB x) (! p) x.
+  Proof.
+    unfold transportb. rewrite pathsinv0inv0. rewrite pathsinv0inv0.
+    use transportf_total2_base.
+  Qed.
+
+  Lemma ComplexEq_transportf {C1 C2 C2' : Complex A} (H : Π (i : hz), C2 i = C2' i)
+        (H1 : Π (i : hz),
+              transportf (λ x : A, C2' i --> x) (H (i + 1))
+                         (transportb (λ x : A, x --> C2 (i + 1)) (! H i) (Diff C2 i)) =
+              Diff C2' i) (f : Morphism C1 C2) (i : hz) :
+    (transportf (λ x : Complex A, Morphism C1 x) (ComplexEq A C2 C2' H H1) f) i =
+    transportf (λ x : A, C1 i --> x) (H i) (f i).
+  Proof.
+    assert (e : (transportf (λ x : Complex A, Morphism C1 x) (ComplexEq A C2 C2' H H1) f) i =
+                (transportf (λ x : Complex A, C1 i --> x i) (ComplexEq A C2 C2' H H1) (f i))).
+    {
+      induction (ComplexEq A C2 C2' H H1). apply idpath.
+    }
+    use (pathscomp0 e). clear e.
+    rewrite <- (@transportf_mor_funextfun hz _ C2 C2' H i (C1 i) (f i)).
+    unfold ComplexEq. unfold Complex_Funclass.
+    set (e := (funextfun (pr1 (pr1 C2)) (pr1 (pr1 C2')) (λ x0 : pr1 hz, H x0))).
+    cbn. cbn in e. fold e.
+    set (tmp := @transportf_total2_base _ _ (λ x0 : _ , A ⟦ pr1 (pr1 C1) i, (pr1 x0) i ⟧) C2 C2'
+                                        (total2_paths e (ComplexEq' A C2 C2' H H1))
+                                        (ComplexEq'' A C2 C2' H H1) (f i)).
+    cbn beta in tmp.
+    use (pathscomp0 tmp). clear tmp.
+    use transportf_total2_base.
+  Qed.
+
+  Lemma ComplexEq_transportb {C1 C1' C2 : Complex A} (H : Π (i : hz), C1' i = C1 i)
+        (H1 : Π (i : hz),
+              transportf (λ x : A, C1 i --> x) (H (i + 1))
+                         (transportb (λ x : A, x --> C1' (i + 1)) (! H i) (Diff C1' i)) =
+              Diff C1 i) (f : Morphism C1' C2) (i : hz) :
+    (transportb (λ x : Complex A, Morphism x C2) (! ComplexEq A C1' C1 H H1) f) i =
+    transportb (λ x : A, x --> C2 i) (! H i) (f i).
+  Proof.
+    assert (e : (transportb (λ x : Complex A, Morphism x C2) (! ComplexEq A C1' C1 H H1) f) i =
+                (transportb (λ x : Complex A, x i --> C2 i) (! ComplexEq A C1' C1 H H1) (f i))).
+    {
+      induction (ComplexEq A C1' C1 H H1). apply idpath.
+    }
+    use (pathscomp0 e). clear e.
+    rewrite <- (@transportb_mor_funextfun hz _ C1' C1 H i (C2 i) (f i)).
+    unfold ComplexEq. unfold Complex_Funclass.
+    set (e := (funextfun (pr1 (pr1 C1')) (pr1 (pr1 C1)) (λ i0 : hz, H i0))).
+    cbn. cbn in e. fold e.
+    set (tmp := @transportb_total2_base
+                  (hz -> ob A) _ (λ x0 : pr1 hz → A, A ⟦ x0 i, pr1 (pr1 C2) i ⟧)
+                  (pr1 C1') (pr1 C1) e (ComplexEq' A C1' C1 H H1) (f i)).
+    use (pathscomp0 _ tmp). clear tmp. cbn beta.
+    use transportb_total2_base.
+  Qed.
+
+  Local Lemma TranslationInvTranslation_eq1 (C : Complex A) (i : hz) :
+    transportf (λ x : A, A ⟦ C i, x ⟧) (maponpaths C (hzrminusplus (i + 1) 1))
+               (transportb (λ x : A, A ⟦ x, C (i + 1 - 1 + 1) ⟧)
+                           (! maponpaths C (hzrminusplus i 1))
+                           (transportf (precategory_morphisms (C (i - 1 + 1)))
+                                       (maponpaths (λ i0 : pr1 hz, C (i0 + 1))
+                                                   (hzrminusplus i 1 @ ! hzrplusminus i 1))
+                                       (to_inv (to_inv (Diff C (i - 1 + 1)))))) = Diff C i.
+  Proof.
+    rewrite inv_inv_eq.
+    induction (hzrminusplus i 1). cbn. unfold idfun.
+    rewrite transport_f_f.
+    assert (e : maponpaths (λ i0 : pr1 hz, (C : Complex _) (i0 + 1))
+                           (! hzrplusminus (i - 1 + 1) 1) =
+                maponpaths (C : Complex _)
+                           (maponpaths (λ i0 : hz, i0 + 1) (! hzrplusminus (i - 1 + 1) 1))).
+    {
+      induction (hzrplusminus (i - 1 + 1) 1). apply idpath.
+    }
+    cbn in e. rewrite e. clear e.
+    rewrite <- maponpathscomp0.
+    assert (e : (maponpaths (λ i0 : pr1 hz, i0 + 1) (! hzrplusminus (i - 1 + 1) 1) @
+                            hzrminusplus (i - 1 + 1 + 1) 1) = idpath _).
+    {
+      apply isasethz.
+    }
+    cbn in e. cbn. rewrite e. clear e. apply idpath.
+  Qed.
+
+  Local Lemma TranslationInvTranslation_eq2 {C1 C2 : Complex A} (f : Morphism C1 C2) :
+    transportf (λ x : Complex A, Morphism C1 x)
+               (ComplexEq A (InvTranslationComplex (TranslationComplex C2)) C2
+                          (λ i : pr1 hz, maponpaths C2 (hzrminusplus i 1))
+                          (λ i : pr1 hz, TranslationInvTranslation_eq1 C2 i))
+               (transportb (λ x : Complex A,
+                                  Morphism x (InvTranslationComplex (TranslationComplex C2)))
+                           (! ComplexEq A (InvTranslationComplex (TranslationComplex C1)) C1
+                              (λ i : pr1 hz, maponpaths C1 (hzrminusplus i 1))
+                              (λ i : pr1 hz, TranslationInvTranslation_eq1 C1 i))
+                           (InvTranslationMorphism (TranslationComplex C1) (TranslationComplex C2)
+                                                   (TranslationMorphism C1 C2 f))) = f.
+  Proof.
+    use MorphismEq. intros i. Local Opaque ComplexEq. cbn.
+    rewrite ComplexEq_transportf. rewrite ComplexEq_transportb. cbn.
+    induction (hzrminusplus i 1). cbn. unfold idfun. apply idpath.
+  Qed.
+
+  Lemma TranslationInvTranslation :
+    functor_composite TranslationFunctor InvTranslationFunctor = functor_identity _.
+  Proof.
+    use functor_eq.
+    - apply to_has_homsets.
+    - use functor_data_eq.
+      + intros C. use ComplexEq.
+        * intros i. cbn. apply maponpaths. apply (hzrminusplus i 1).
+        * intros i. cbn. exact (TranslationInvTranslation_eq1 C i).
+      + intros C1 C2 f. Local Opaque ComplexEq. cbn.
+        exact (TranslationInvTranslation_eq2 f).
+  Qed.
+
+  Local Lemma InvTranslationTranslation_eq1 (C : Complex A) (i : hz) :
+    transportf (λ x : A, A ⟦ C i, x ⟧) (maponpaths C (hzrplusminus (i + 1) 1))
+               (transportb (λ x : A, A ⟦ x, C (i + 1 + 1 - 1) ⟧) (! maponpaths C (hzrplusminus i 1))
+                           (to_inv
+                              (transportf
+                                 (precategory_morphisms (C (i + 1 - 1)))
+                                 (maponpaths C (hzrminusplus (i + 1) 1 @ ! hzrplusminus (i + 1) 1))
+                                 (to_inv (Diff C (i + 1 - 1)))))) = Diff C i.
+  Proof.
+    rewrite transportf_to_inv.
+    rewrite inv_inv_eq. rewrite <- transport_mor_f_b_comm.
+    rewrite transport_f_f. rewrite <- maponpathscomp0.
+    rewrite <- path_assoc. rewrite pathsinv0l. rewrite pathscomp0rid.
+    rewrite transport_mor_f_b_comm.
+    rewrite (transport_mor_b_f A C 1 (Diff C) _ _ (hzrplusminus i 1)).
+    rewrite maponpathsinv0. apply maponpaths.
+    use transportf_paths. apply maponpaths. apply isasethz.
+  Qed.
+
+  Local Lemma InvTranslationTranslation_eq2 {C1 C2 : Complex A} (f : Morphism C1 C2) :
+    transportf (λ x : Complex A, Morphism C1 x)
+               (ComplexEq A (TranslationComplex (InvTranslationComplex C2)) C2
+                          (λ i : pr1 hz, maponpaths C2 (hzrplusminus i 1))
+                          (λ i : pr1 hz, InvTranslationTranslation_eq1 C2 i))
+               (transportb (λ x : Complex A,
+                                  Morphism x (TranslationComplex (InvTranslationComplex C2)))
+                           (! ComplexEq A (TranslationComplex (InvTranslationComplex C1)) C1
+                              (λ i : pr1 hz, maponpaths C1 (hzrplusminus i 1))
+                              (λ i : pr1 hz, InvTranslationTranslation_eq1 C1 i))
+                           (TranslationMorphism (InvTranslationComplex C1)
+                                                (InvTranslationComplex C2)
+                                                (InvTranslationMorphism C1 C2 f))) = f.
+  Proof.
+    Local Opaque ComplexEq. use MorphismEq. intros i. cbn.
+    rewrite ComplexEq_transportf. rewrite ComplexEq_transportb. cbn.
+    induction (hzrplusminus i 1). cbn. unfold idfun. apply idpath.
+  Qed.
+
+  Lemma InvTranslationTranslation :
+    functor_composite InvTranslationFunctor TranslationFunctor = functor_identity _.
+  Proof.
+    use functor_eq.
+    - apply to_has_homsets.
+    - use functor_data_eq.
+      + intros C. use ComplexEq.
+        * intros i. cbn. apply maponpaths. apply (hzrplusminus i 1).
+        * intros i. cbn. apply (InvTranslationTranslation_eq1 C i).
+      + intros C1 C2 f. Local Opaque ComplexEq. cbn.
+        exact (InvTranslationTranslation_eq2 f).
+  Qed.
 
   (** ** Translation functor for K(A) *)
 
@@ -2762,18 +3071,34 @@ Section translation_functor.
     rewrite H'. apply hfiberpr2.
   Qed.
 
+  Definition TranslationFunctorH_Mor_data {C1 C2 : ob (ComplexHomot_Additive A)}
+             (f : ComplexHomot_Additive A ⟦C1, C2⟧) (H : hfiber # (ComplexHomotFunctor A) f) :
+    TranslationFunctorHIm f.
+  Proof.
+    use mk_TranslationFunctorHIm.
+    - exact (# (ComplexHomotFunctor A) (# (TranslationFunctor) (hfiberpr1 _ _ H))).
+    - intros f' H'. exact (TranslationFunctor_eq f H f' H').
+  Defined.
+
   Definition TranslationFunctorH_Mor {C1 C2 : ComplexHomot_Additive A}
              (f : (ComplexHomot_Additive A)⟦C1, C2⟧) : iscontr (TranslationFunctorHIm f).
   Proof.
     use (squash_to_prop (ComplexHomotFunctor_issurj A f)).
     apply isapropiscontr. intros H.
     use iscontrpair.
-    - use mk_TranslationFunctorHIm.
-      + exact (# (ComplexHomotFunctor A) (# (TranslationFunctor) (hfiberpr1 _ _ H))).
-      + intros f' H'. exact (TranslationFunctor_eq f H f' H').
+    - exact (TranslationFunctorH_Mor_data f H).
     - intros t. use TranslationFunctorHImEquality.
       use TranslationFunctorHImEq.
       exact (hfiberpr2 _ _ H).
+  Qed.
+
+  Lemma TranslationFunctorH_Mor_unique {C1 C2 : ob (ComplexHomot_Additive A)}
+        (f : ComplexHomot_Additive A ⟦C1, C2⟧) (H : hfiber # (ComplexHomotFunctor A) f) :
+    iscontrpr1 (TranslationFunctorH_Mor f) = (TranslationFunctorH_Mor_data f H).
+  Proof.
+    use TranslationFunctorHImEquality.
+    use TranslationFunctorHImEq.
+    exact (hfiberpr2 _ _ H).
   Qed.
 
   Definition TranslationFunctorH_data :
@@ -2832,10 +3157,401 @@ Section translation_functor.
     - exact TranslationFunctorH_is_functor.
   Defined.
 
-  (* TODO : Generalize the translation functor construction! Similar code was used in
-     CohomologyComplex.v to construct the cohomology functor for K(A). *)
+  Lemma TranslationFunctorH_comm :
+    functor_composite (ComplexHomotFunctor A) TranslationFunctorH =
+    functor_composite TranslationFunctor (ComplexHomotFunctor A).
+  Proof.
+    use functor_eq.
+    - apply to_has_homsets.
+    - use functor_data_eq.
+      + intros C. cbn. apply idpath.
+      + intros C1 C2 f.
+        cbn beta.
+        rewrite idpath_transportf. unfold transportb.
+        rewrite pathsinv0inv0. rewrite idpath_transportf.
+        assert (e1 : pr2 (pr1 (functor_composite (ComplexHomotFunctor A) TranslationFunctorH))
+                         C1 C2 f =
+                    # TranslationFunctorH (# (ComplexHomotFunctor A) f)) by apply idpath.
+        rewrite e1. clear e1.
+        assert (e2 : pr2 (pr1 (functor_composite TranslationFunctor (ComplexHomotFunctor A)))
+                         C1 C2 f =
+                    # (ComplexHomotFunctor A) (# TranslationFunctor f)) by apply idpath.
+        rewrite e2. clear e2.
+        use (squash_to_prop
+               (ComplexHomotFunctor_issurj
+                  A (# (ComplexHomotFunctor A) f))).
+        apply to_has_homsets. intros f'.
+        set (im := TranslationFunctorH_Mor_data (# (ComplexHomotFunctor A) f) f').
+        rewrite <- (@TranslationFunctorHImEq C1 C2 _ im f (idpath _)).
+        use TranslationFunctorHImEq.
+        exact (hfiberpr2 _ _ f').
+  Qed.
 
-  (* TODO : Translation inverse for K(A) *)
+  Lemma TranslationFunctorH_Mor_Im {C1 C2 : ob (ComplexHomot_Additive A)}
+        (f : ComplexHomot_Additive A ⟦C1, C2⟧) (f' : hfiber # (ComplexHomotFunctor A) f) :
+    # TranslationFunctorH f = # (ComplexHomotFunctor A) (# TranslationFunctor (hfiberpr1 _ _ f')).
+  Proof.
+    use TranslationFunctorHImEq. exact (hfiberpr2 _ _ f').
+  Qed.
+
+  Lemma TranslationFunctorH_isAdditiveFunctor : isAdditiveFunctor TranslationFunctorH.
+  Proof.
+    use mk_isAdditiveFunctor'.
+    - intros C1 C2.
+      use (pathscomp0 _ (@AdditiveFunctorZeroArrow
+                           (ComplexPreCat_Additive A) (ComplexHomot_Additive A)
+                           (ComplexHomotFunctor A)
+                           (TranslationFunctorH C1) (TranslationFunctorH C2))).
+      set (tmp := (@AdditiveFunctorZeroArrow
+                     (ComplexPreCat_Additive A) (ComplexPreCat_Additive A)
+                     TranslationFunctor_Additive C1 C2)).
+      apply (maponpaths (# (ComplexHomotFunctor A))) in tmp.
+      use (pathscomp0 _ tmp). clear tmp.
+      use TranslationFunctorHImEq.
+      use AdditiveFunctorZeroArrow.
+    - intros C1 C2 f g.
+      use (squash_to_prop (ComplexHomotFunctor_issurj A f)).
+      apply to_has_homsets. intros f'.
+      use (squash_to_prop (ComplexHomotFunctor_issurj A g)).
+      apply to_has_homsets. intros g'.
+      rewrite (TranslationFunctorH_Mor_Im f f').
+      rewrite (TranslationFunctorH_Mor_Im g g').
+      use (pathscomp0 _ (AdditiveFunctorLinear
+                           (ComplexHomotFunctor A) (# TranslationFunctor (hfiberpr1 _ _ f'))
+                           (# TranslationFunctor (hfiberpr1 _ _ g')))).
+      set (tmp := AdditiveFunctorLinear
+                    TranslationFunctor_Additive (hfiberpr1 _ _ f') (hfiberpr1 _ _ g')).
+      apply (maponpaths (# (ComplexHomotFunctor A))) in tmp.
+      use (pathscomp0 _ tmp). clear tmp.
+      use TranslationFunctorHImEq.
+      rewrite AdditiveFunctorLinear.
+      rewrite (hfiberpr2 _ _ f'). rewrite (hfiberpr2 _ _ g'). apply idpath.
+  Qed.
+
+  Definition TranslationFunctorH_AdditiveFunctor :
+    AdditiveFunctor (ComplexHomot_Additive A) (ComplexHomot_Additive A).
+  Proof.
+    use mk_AdditiveFunctor.
+    - exact TranslationFunctorH.
+    - exact TranslationFunctorH_isAdditiveFunctor.
+  Defined.
+
+
+  (** ** Inverse translation in K(A) *)
+
+  Definition InvTranslationFunctorHIm {C1 C2 : ComplexHomot_Additive A}
+             (f : (ComplexHomot_Additive A)⟦C1, C2⟧) : UU :=
+    Σ (h : (ComplexHomot_Additive A)⟦InvTranslationComplex C1, InvTranslationComplex C2⟧),
+    Π (f' : (ComplexPreCat_Additive A)⟦C1, C2⟧) (H : # (ComplexHomotFunctor A) f' = f),
+    h = # (ComplexHomotFunctor A) (# InvTranslationFunctor f').
+
+  Definition InvTranslationFunctorHImMor {C1 C2 : ComplexHomot_Additive A}
+             {f : (ComplexHomot_Additive A)⟦C1, C2⟧} (h : InvTranslationFunctorHIm f) :
+    (ComplexHomot_Additive A)⟦InvTranslationComplex C1, InvTranslationComplex C2⟧ := pr1 h.
+
+  Definition InvTranslationFunctorHImEq {C1 C2 : ComplexHomot_Additive A}
+             {f : (ComplexHomot_Additive A)⟦C1, C2⟧} (h : InvTranslationFunctorHIm f)
+             (f' : (ComplexPreCat_Additive A)⟦C1, C2⟧) (H : # (ComplexHomotFunctor A) f' = f) :
+    InvTranslationFunctorHImMor h = # (ComplexHomotFunctor A) (# InvTranslationFunctor f') :=
+    pr2 h f' H.
+
+  Definition mk_InvTranslationFunctorHIm {C1 C2 : ComplexHomot_Additive A}
+             {f : (ComplexHomot_Additive A)⟦C1, C2⟧}
+             (h : (ComplexHomot_Additive A)⟦InvTranslationComplex C1, InvTranslationComplex C2⟧)
+             (HH : Π (f' : (ComplexPreCat_Additive A)⟦C1, C2⟧)
+                     (H : # (ComplexHomotFunctor A) f' = f),
+                   h = # (ComplexHomotFunctor A) (# InvTranslationFunctor f')) :
+    InvTranslationFunctorHIm f := tpair _ h HH.
+
+  Lemma InvTranslationFunctorHImEquality {C1 C2 : ComplexHomot_Additive A}
+             {f : (ComplexHomot_Additive A)⟦C1, C2⟧} (h h' : InvTranslationFunctorHIm f)
+             (e : InvTranslationFunctorHImMor h = InvTranslationFunctorHImMor h') : h = h'.
+  Proof.
+    use total2_paths.
+    - exact e.
+    - apply proofirrelevance. apply impred_isaprop. intros t0.
+      apply impred_isaprop. intros H0. apply has_homsets_ComplexHomot_Additive.
+  Qed.
+
+
+  (** *** Construction of the functor *)
+
+  Lemma InvTranslationFunctor_eq {C1 C2 : ComplexHomot_Additive A}
+        (f : (ComplexHomot_Additive A)⟦C1, C2⟧) (H : hfiber # (ComplexHomotFunctor A) f)
+        (f' : (ComplexPreCat_Additive A)⟦C1, C2⟧) (H' : # (ComplexHomotFunctor A) f' = f) :
+    # (ComplexHomotFunctor A) (# InvTranslationFunctor (hfiberpr1 # (ComplexHomotFunctor A) f H)) =
+    # (ComplexHomotFunctor A) (# InvTranslationFunctor f').
+  Proof.
+    use ComplexHomotFunctor_rel_mor.
+    use InvTranslationFunctorPreservesHomotopies.
+    use ComplexHomotFunctor_mor_rel.
+    rewrite H'. apply hfiberpr2.
+  Qed.
+
+  Definition InvTranslationFunctorH_Mor_data {C1 C2 : ob (ComplexHomot_Additive A)}
+             (f : ComplexHomot_Additive A ⟦C1, C2⟧) (H : hfiber # (ComplexHomotFunctor A) f) :
+    InvTranslationFunctorHIm f.
+  Proof.
+    use mk_InvTranslationFunctorHIm.
+    - exact (# (ComplexHomotFunctor A) (# (InvTranslationFunctor) (hfiberpr1 _ _ H))).
+    - intros f' H'. exact (InvTranslationFunctor_eq f H f' H').
+  Defined.
+
+  Definition InvTranslationFunctorH_Mor {C1 C2 : ComplexHomot_Additive A}
+             (f : (ComplexHomot_Additive A)⟦C1, C2⟧) : iscontr (InvTranslationFunctorHIm f).
+  Proof.
+    use (squash_to_prop (ComplexHomotFunctor_issurj A f)).
+    apply isapropiscontr. intros H.
+    use iscontrpair.
+    - exact (InvTranslationFunctorH_Mor_data f H).
+    - intros t. use InvTranslationFunctorHImEquality.
+      use InvTranslationFunctorHImEq.
+      exact (hfiberpr2 _ _ H).
+  Qed.
+
+  Lemma InvTranslationFunctorH_Mor_unique {C1 C2 : ob (ComplexHomot_Additive A)}
+        (f : ComplexHomot_Additive A ⟦C1, C2⟧) (H : hfiber # (ComplexHomotFunctor A) f) :
+    iscontrpr1 (InvTranslationFunctorH_Mor f) = (InvTranslationFunctorH_Mor_data f H).
+  Proof.
+    use InvTranslationFunctorHImEquality.
+    use InvTranslationFunctorHImEq.
+    exact (hfiberpr2 _ _ H).
+  Qed.
+
+  Definition InvTranslationFunctorH_data :
+    functor_data (ComplexHomot_Additive A) (ComplexHomot_Additive A).
+  Proof.
+    use mk_functor_data.
+    - intros C. exact (InvTranslationComplex C).
+    - intros C1 C2 f.
+      exact (InvTranslationFunctorHImMor (iscontrpr1 (InvTranslationFunctorH_Mor f))).
+  Defined.
+
+  Lemma InvTranslationFunctorH_Mor_Id : functor_idax InvTranslationFunctorH_data.
+  Proof.
+    intros C.
+    use (pathscomp0 (InvTranslationFunctorHImEq
+                       (iscontrpr1 (InvTranslationFunctorH_Mor (identity C)))
+                       (identity _)
+                       (functor_id (ComplexHomotFunctor A) _))).
+    rewrite functor_id. rewrite functor_id. apply idpath.
+  Qed.
+
+  Lemma InvTranslationFunctorH_Mor_Comp {C1 C2 C3 : ComplexHomot_Additive A}
+             (f : (ComplexHomot_Additive A)⟦C1, C2⟧) (g : (ComplexHomot_Additive A)⟦C2, C3⟧) :
+    (InvTranslationFunctorHImMor (iscontrpr1 (InvTranslationFunctorH_Mor (f ;; g)))) =
+    (InvTranslationFunctorHImMor (iscontrpr1 (InvTranslationFunctorH_Mor f)))
+      ;; (InvTranslationFunctorHImMor (iscontrpr1 (InvTranslationFunctorH_Mor g))) .
+  Proof.
+    use (squash_to_prop (ComplexHomotFunctor_issurj A f)).
+    apply has_homsets_ComplexHomot_Additive. intros f'.
+    use (squash_to_prop (ComplexHomotFunctor_issurj A g)).
+    apply has_homsets_ComplexHomot_Additive. intros g'.
+    rewrite (InvTranslationFunctorHImEq
+               (iscontrpr1 (InvTranslationFunctorH_Mor f)) _ (hfiberpr2 _ _ f')).
+    rewrite (InvTranslationFunctorHImEq
+               (iscontrpr1 (InvTranslationFunctorH_Mor g)) _ (hfiberpr2 _ _ g')).
+    set (tmp := functor_comp (ComplexHomotFunctor A) _ _ _
+                             (# InvTranslationFunctor (hfiberpr1 # (ComplexHomotFunctor A) f f'))
+                             (# InvTranslationFunctor (hfiberpr1 # (ComplexHomotFunctor A) g g'))).
+    use (pathscomp0 _ tmp). clear tmp.
+    set (tmp := functor_comp InvTranslationFunctor _ _ _ (hfiberpr1 _ _ f') (hfiberpr1 _ _ g')).
+    apply (maponpaths (# (ComplexHomotFunctor A))) in tmp.
+    use (pathscomp0 _ tmp). clear tmp.
+    use (InvTranslationFunctorHImEq (iscontrpr1 (InvTranslationFunctorH_Mor (f ;; g)))).
+    rewrite functor_comp. rewrite (hfiberpr2 _ _ f'). rewrite (hfiberpr2 _ _ g'). apply idpath.
+  Qed.
+
+  Definition InvTranslationFunctorH_is_functor : is_functor InvTranslationFunctorH_data.
+  Proof.
+    split.
+    - exact InvTranslationFunctorH_Mor_Id.
+    - intros C1 C2 C3 f g. exact (InvTranslationFunctorH_Mor_Comp f g).
+  Qed.
+
+  Definition InvTranslationFunctorH :
+    functor (ComplexHomot_Additive A) (ComplexHomot_Additive A).
+  Proof.
+    use mk_functor.
+    - exact InvTranslationFunctorH_data.
+    - exact InvTranslationFunctorH_is_functor.
+  Defined.
+
+  Lemma InvTranslationFunctorH_comm :
+    functor_composite (ComplexHomotFunctor A) InvTranslationFunctorH =
+    functor_composite InvTranslationFunctor (ComplexHomotFunctor A).
+  Proof.
+    use functor_eq.
+    - apply to_has_homsets.
+    - use functor_data_eq.
+      + intros C. cbn. apply idpath.
+      + intros C1 C2 f.
+        cbn beta.
+        rewrite idpath_transportf. unfold transportb.
+        rewrite pathsinv0inv0. rewrite idpath_transportf.
+        assert (e1 : pr2 (pr1 (functor_composite (ComplexHomotFunctor A) InvTranslationFunctorH))
+                         C1 C2 f =
+                    # InvTranslationFunctorH (# (ComplexHomotFunctor A) f)) by apply idpath.
+        rewrite e1. clear e1.
+        assert (e2 : pr2 (pr1 (functor_composite InvTranslationFunctor (ComplexHomotFunctor A)))
+                         C1 C2 f =
+                    # (ComplexHomotFunctor A) (# InvTranslationFunctor f)) by apply idpath.
+        rewrite e2. clear e2.
+        use (squash_to_prop (ComplexHomotFunctor_issurj A (# (ComplexHomotFunctor A) f))).
+        apply to_has_homsets. intros f'.
+        set (im := InvTranslationFunctorH_Mor_data (# (ComplexHomotFunctor A) f) f').
+        rewrite <- (@InvTranslationFunctorHImEq C1 C2 _ im f (idpath _)).
+        use InvTranslationFunctorHImEq.
+        exact (hfiberpr2 _ _ f').
+  Qed.
+
+  Lemma InvTranslationFunctorH_Mor_Im {C1 C2 : ob (ComplexHomot_Additive A)}
+        (f : ComplexHomot_Additive A ⟦C1, C2⟧) (f' : hfiber # (ComplexHomotFunctor A) f) :
+    # InvTranslationFunctorH f =
+    # (ComplexHomotFunctor A) (# InvTranslationFunctor (hfiberpr1 _ _ f')).
+  Proof.
+    use InvTranslationFunctorHImEq. exact (hfiberpr2 _ _ f').
+  Qed.
+
+  Lemma InvTranslationFunctorH_isAdditiveFunctor : isAdditiveFunctor InvTranslationFunctorH.
+  Proof.
+    use mk_isAdditiveFunctor'.
+    - intros C1 C2.
+      use (pathscomp0 _ (@AdditiveFunctorZeroArrow
+                           (ComplexPreCat_Additive A) (ComplexHomot_Additive A)
+                           (ComplexHomotFunctor A)
+                           (InvTranslationFunctorH C1) (InvTranslationFunctorH C2))).
+      set (tmp := (@AdditiveFunctorZeroArrow
+                     (ComplexPreCat_Additive A) (ComplexPreCat_Additive A)
+                     InvTranslationFunctor_Additive C1 C2)).
+      apply (maponpaths (# (ComplexHomotFunctor A))) in tmp.
+      use (pathscomp0 _ tmp). clear tmp.
+      use InvTranslationFunctorHImEq.
+      use AdditiveFunctorZeroArrow.
+    - intros C1 C2 f g.
+      use (squash_to_prop (ComplexHomotFunctor_issurj A f)).
+      apply to_has_homsets. intros f'.
+      use (squash_to_prop (ComplexHomotFunctor_issurj A g)).
+      apply to_has_homsets. intros g'.
+      rewrite (InvTranslationFunctorH_Mor_Im f f').
+      rewrite (InvTranslationFunctorH_Mor_Im g g').
+      use (pathscomp0 _ (AdditiveFunctorLinear
+                           (ComplexHomotFunctor A) (# InvTranslationFunctor (hfiberpr1 _ _ f'))
+                           (# InvTranslationFunctor (hfiberpr1 _ _ g')))).
+      set (tmp := AdditiveFunctorLinear
+                    InvTranslationFunctor_Additive (hfiberpr1 _ _ f') (hfiberpr1 _ _ g')).
+      apply (maponpaths (# (ComplexHomotFunctor A))) in tmp.
+      use (pathscomp0 _ tmp). clear tmp.
+      use InvTranslationFunctorHImEq.
+      rewrite AdditiveFunctorLinear.
+      rewrite (hfiberpr2 _ _ f'). rewrite (hfiberpr2 _ _ g'). apply idpath.
+  Qed.
+
+  Definition InvTranslationFunctorH_AdditiveFunctor :
+    AdditiveFunctor (ComplexHomot_Additive A) (ComplexHomot_Additive A).
+  Proof.
+    use mk_AdditiveFunctor.
+    - exact InvTranslationFunctorH.
+    - exact InvTranslationFunctorH_isAdditiveFunctor.
+  Defined.
+
+
+  (** Translation functors in K(A) are isomorphisms and inverse to each other. *)
+
+  Lemma transportf_ComplexHomotFunctor {C1 C2 C2' : Complex A} (e : C2 = C2') (f : Morphism C1 C2) :
+    # (ComplexHomotFunctor A) (transportf (λ x : Complex A, Morphism C1 x) e f) =
+    transportf (λ x : Complex A, (ComplexHomot_Additive A)⟦C1, x⟧) e (# (ComplexHomotFunctor A) f).
+  Proof.
+    induction e. apply idpath.
+  Qed.
+
+  Lemma transportb_ComplexHomotFunctor {C1' C1 C2 : Complex A} (e : C1' = C1)
+        (f : Morphism C1' C2) :
+    # (ComplexHomotFunctor A) (transportb (λ x : Complex A, Morphism x C2) (! e) f) =
+    transportb (λ x : Complex A, (ComplexHomot_Additive A)⟦x, C2⟧) (! e)
+               (# (ComplexHomotFunctor A) f).
+  Proof.
+    induction e. apply idpath.
+  Qed.
+
+  Lemma TranslationHInvTranslationH :
+    functor_composite TranslationFunctorH InvTranslationFunctorH = functor_identity _.
+  Proof.
+    use functor_eq.
+    - apply to_has_homsets.
+    - use functor_data_eq.
+      + intros C. cbn. use ComplexEq.
+        * intros i. cbn. apply maponpaths. apply (hzrminusplus i 1).
+        * intros i. cbn. exact (TranslationInvTranslation_eq1 C i).
+      + intros C1 C2 f. cbn beta.
+        use (squash_to_prop (ComplexHomotFunctor_issurj A f)).
+        apply has_homsets_ComplexHomot_Additive. intros f'. cbn.
+        rewrite (TranslationFunctorH_Mor_unique _ f').
+        use (squash_to_prop (ComplexHomotFunctor_issurj
+                               A (TranslationFunctorHImMor (TranslationFunctorH_Mor_data f f')))).
+        apply has_homsets_ComplexHomot_Additive. intros f''.
+        rewrite (InvTranslationFunctorH_Mor_unique _ f'').
+        rewrite <- (hfiberpr2 _ _ f').
+        rewrite <- (TranslationInvTranslation_eq2 (hfiberpr1 # (ComplexHomotFunctor A) f f')).
+        rewrite transportf_ComplexHomotFunctor. rewrite transportb_ComplexHomotFunctor.
+        apply maponpaths. apply maponpaths.
+        assert (e1 : # (ComplexHomotFunctor A)
+                       (InvTranslationMorphism
+                          (TranslationComplex C1) (TranslationComplex C2)
+                          (TranslationMorphism
+                             C1 C2 (hfiberpr1 # (ComplexHomotFunctor A) f f'))) =
+                     # InvTranslationFunctorH
+                       (# (ComplexHomotFunctor A)
+                          (TranslationMorphism
+                             C1 C2 (hfiberpr1 # (ComplexHomotFunctor A) f f')))).
+        {
+          apply pathsinv0. use InvTranslationFunctorHImEq. apply idpath.
+        }
+        use (pathscomp0 _ (! e1)). clear e1.
+        apply pathsinv0. use InvTranslationFunctorHImEq.
+        set (tmp := hfiberpr2 _ _ f''). rewrite tmp. clear tmp. use TranslationFunctorHImEq.
+        apply (hfiberpr2 _ _ f').
+  Qed.
+
+  Lemma InvTranslationHTranslationH :
+    functor_composite InvTranslationFunctorH TranslationFunctorH = functor_identity _.
+  Proof.
+    use functor_eq.
+    - apply to_has_homsets.
+    - use functor_data_eq.
+      + intros C. cbn. use ComplexEq.
+        * intros i. cbn. apply maponpaths. apply (hzrplusminus i 1).
+        * intros i. cbn. exact (InvTranslationTranslation_eq1 C i).
+      + intros C1 C2 f. cbn beta.
+        use (squash_to_prop (ComplexHomotFunctor_issurj A f)).
+        apply has_homsets_ComplexHomot_Additive. intros f'. cbn.
+        rewrite (InvTranslationFunctorH_Mor_unique _ f').
+        use (squash_to_prop
+               (ComplexHomotFunctor_issurj
+                  A (InvTranslationFunctorHImMor (InvTranslationFunctorH_Mor_data f f')))).
+        apply has_homsets_ComplexHomot_Additive. intros f''.
+        rewrite (TranslationFunctorH_Mor_unique _ f'').
+        rewrite <- (hfiberpr2 _ _ f').
+        rewrite <- (InvTranslationTranslation_eq2 (hfiberpr1 # (ComplexHomotFunctor A) f f')).
+        rewrite transportf_ComplexHomotFunctor. rewrite transportb_ComplexHomotFunctor.
+        apply maponpaths. apply maponpaths.
+        assert (e1 : # (ComplexHomotFunctor A)
+                       (TranslationMorphism
+                          (InvTranslationComplex C1) (InvTranslationComplex C2)
+                          (InvTranslationMorphism
+                             C1 C2 (hfiberpr1 # (ComplexHomotFunctor A) f f'))) =
+                     # TranslationFunctorH
+                       (# (ComplexHomotFunctor A)
+                          (InvTranslationMorphism
+                             C1 C2 (hfiberpr1 # (ComplexHomotFunctor A) f f')))).
+        {
+          apply pathsinv0. use TranslationFunctorHImEq. apply idpath.
+        }
+        use (pathscomp0 _ (! e1)). clear e1.
+        apply pathsinv0. use TranslationFunctorHImEq.
+        set (tmp := hfiberpr2 _ _ f''). rewrite tmp. clear tmp. use InvTranslationFunctorHImEq.
+        apply (hfiberpr2 _ _ f').
+  Qed.
 
 End translation_functor.
 
@@ -3106,9 +3822,9 @@ by C_1^i ⊕ Cone(f)^i. The ith differential of Cyl(f) is given by
 Here d^i_C(F) is the ith differential of the mapping cone of f, see section [mapping_cone].
 We split the definition of the ith differential into a sum of 3 morphisms. These are constructed in
 [MappingCylinderDiff1], [MappingCylinderDiff3], and [MappingCylinderDiff3], and correspond the
-morphisms of the above formula, respectively. In [MappingCylinderDiff] we construct the differential.
-In [MappingCylinder_comp] we show that composition of two consecutive differentials is 0. The
-complex Cyl(f) is constructed in [MappingCylinder].
+morphisms of the above formula, respectively. In [MappingCylinderDiff] we construct the
+differential. In [MappingCylinder_comp] we show that composition of two consecutive differentials
+is 0. The complex Cyl(f) is constructed in [MappingCylinder].
 *)
 Section mapping_cylinder.
 

--- a/UniMath/CategoryTheory/Complexes.v
+++ b/UniMath/CategoryTheory/Complexes.v
@@ -45,7 +45,7 @@ Require Import UniMath.CategoryTheory.Monics.
 Require Import UniMath.CategoryTheory.Epis.
 Require Import UniMath.CategoryTheory.functor_categories.
 
-Require Import UniMath.CategoryTheory.PrecategoriesWithBinOps.
+Require Import UniMath.CategoryTheory.precategoriesWithBinOps.
 Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
 Require Import UniMath.CategoryTheory.PreAdditive.
 Require Import UniMath.CategoryTheory.Additive.
@@ -1101,9 +1101,9 @@ Section complexes_additive.
 
   Variable A : Additive.
 
-  Definition ComplexPreCat_PrecategoryWithBinOps : PrecategoryWithBinOps.
+  Definition ComplexPreCat_precategoryWithBinOps : precategoryWithBinOps.
   Proof.
-    use mk_PrecategoryWithBinOps.
+    use mk_precategoryWithBinOps.
     - exact (ComplexPreCat A).
     - intros x y. exact (MorphismOp A).
   Defined.
@@ -1111,7 +1111,7 @@ Section complexes_additive.
   Definition ComplexPreCat_PrecategoryWithAbgrops : PrecategoryWithAbgrops.
   Proof.
     use mk_PrecategoryWithAbgrops.
-    - exact ComplexPreCat_PrecategoryWithBinOps.
+    - exact ComplexPreCat_precategoryWithBinOps.
     - exact (has_homsets_ComplexPreCat A).
     - intros x y. exact (MorphismOp_isabgrop A x y).
   Defined.
@@ -2409,7 +2409,7 @@ to the complex
 More precicely, on objects # X^i ↦ X^{i+1} # $ X^i ↦ X^{i+1} $ and differentials
 # d^i_X ↦ -d^{i+1}_X # $ d^i_X ↦ -d^{i+1}_X $. A morphism f : X -> Y is mapped by
 # f^i ↦ f^{i+1} # $ f^i ↦ f^{i+1} $. We also construct the inverse translation T^{-1} which is the
-unique functor such that T ∘ T^{-1} = id and T^{-1} ∘ T = id (This is has not been proven yet!).
+unique functor such that T ∘ T^{-1} = id and T^{-1} ∘ T = id (This has not been proven yet!).
 All the functors T, T^{-1}, and T' are additive.
 
 The functor T : C(A) -> C(A) is constructed in [TranslationFunctor]. It is shown to be additive in

--- a/UniMath/CategoryTheory/Complexes.v
+++ b/UniMath/CategoryTheory/Complexes.v
@@ -107,7 +107,7 @@ Section def_complexes.
   Local Lemma ComplexEq' (C1 C2 : Complex) (H : Π (i : hz), C1 i = C2 i)
         (H1 : Π (i : hz),
               transportf (λ x : A, C2 i --> x) (H (i + 1))
-                         (transportb (λ x : A, x --> C1 (i + 1)) (! H i) (Diff C1 i)) =
+                         (transportf (λ x : A, x --> C1 (i + 1)) (H i) (Diff C1 i)) =
               Diff C2 i) :
     transportf (λ x : hz → A, Π i : hz, A ⟦ x i, x (i + 1) ⟧)
                (funextfun (pr1 (pr1 C1)) (pr1 (pr1 C2)) (λ i : hz, H i)) (pr2 (pr1 C1)) =
@@ -126,14 +126,14 @@ Section def_complexes.
     }
     rewrite e. clear e.
     rewrite transport_mor_funextfun.
-    rewrite transportb_mor_funextfun. rewrite transportf_mor_funextfun.
+    rewrite transport_source_funextfun. rewrite transport_target_funextfun.
     exact (H1 i).
   Qed.
 
   Local Lemma ComplexEq'' (C1 C2 : Complex) (H : Π (i : hz), C1 i = C2 i)
         (H1 : Π (i : hz),
               transportf (λ x : A, C2 i --> x) (H (i + 1))
-                         (transportb (λ x : A, x --> C1 (i + 1)) (! H i) (Diff C1 i)) =
+                         (transportf (λ x : A, x --> C1 (i + 1)) (H i) (Diff C1 i)) =
               Diff C2 i) :
     transportf
       (λ x : Σ D : hz → A, Π i : hz, A ⟦ D i, D (i + 1) ⟧,
@@ -148,7 +148,7 @@ Section def_complexes.
   Lemma ComplexEq (C1 C2 : Complex) (H : Π (i : hz), C1 i = C2 i)
         (H1 : Π (i : hz),
               transportf (λ x : A, C2 i --> x) (H (i + 1))
-                         (transportb (λ x : A, x --> C1 (i + 1)) (! H i) (Diff C1 i)) =
+                         (transportf (λ x : A, x --> C1 (i + 1)) (H i) (Diff C1 i)) =
               Diff C2 i) : C1 = C2.
   Proof.
     use total2_paths.
@@ -1990,21 +1990,19 @@ Section transport_diffs.
   Variable A : Additive.
 
   Lemma transport_Diff (C : Complex A) (i : hz) :
-    transportb (λ x' : A, A ⟦ x', C (i + 1) ⟧) (maponpaths C (hzrplusminus i 1)) (Diff C i) =
+    transportf (λ x' : A, A ⟦ x', C (i + 1) ⟧) (! maponpaths C (hzrplusminus i 1)) (Diff C i) =
     transportf (precategory_morphisms (C (i + 1 - 1))) (maponpaths C (hzrminusplus (i + 1) 1))
                (Diff C (i + 1 - 1)).
   Proof.
-    unfold transportb. rewrite <- functtransportf.
-    rewrite <- maponpathsinv0. rewrite <- functtransportf.
-    use transportf_path.
+    rewrite <- functtransportf. rewrite <- maponpathsinv0. rewrite <- functtransportf.
+    use transport_target_path.
     - exact (C (i + 1 - 1 + 1)).
     - exact (maponpaths C (! hzrminusplus (i + 1) 1)).
     - rewrite <- functtransportf. rewrite <- functtransportf.
       rewrite transport_f_f. rewrite pathsinv0r. cbn. unfold idfun.
       use (pathscomp0 _ (@transport_section hz _ (Diff C) i (i + 1 - 1) (! (hzrplusminus i 1)))).
       (* Split the right hand side to two transports *)
-      rewrite (@transportf_mor' hz A). unfold transportb. rewrite pathsinv0inv0.
-      rewrite functtransportf.
+      rewrite (@transport_target_source hz A).  rewrite functtransportf.
       (* Here only the equations of the first transportfs are different! *)
       use transportf_paths.
       assert (e5 : maponpaths C (! hzrminusplus (i + 1) 1) =
@@ -2022,52 +2020,52 @@ Section transport_section'.
 
   Variable C : precategory.
 
-  Lemma transport_mor_b_f (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f i, f (i + n)⟧) (i i' : hz)
-        (e1 : i = i') :
-    H i' = transportb (fun (x : ob C) => C⟦x, f (i' + n)⟧) (maponpaths f (! e1))
+  Lemma transport_hz_source_target (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f i, f (i + n)⟧)
+        (i i' : hz) (e1 : i = i') :
+    H i' = transportf (fun (x : ob C) => C⟦x, f (i' + n)⟧) (maponpaths f e1)
                       (transportf (precategory_morphisms (f i))
                                   (maponpaths f (hzplusradd i i' n e1)) (H i)).
   Proof.
     induction e1. apply idpath.
   Qed.
 
-  Lemma transport_mor_f_b (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f i, f (i + n)⟧) (i i' : hz)
-        (e1 : i = i') :
+  Lemma transport_hz_target_source (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f i, f (i + n)⟧)
+        (i i' : hz) (e1 : i = i') :
     H i' = transportf (precategory_morphisms (f i'))
                       (maponpaths f (hzplusradd i i' n e1))
-                      (transportb (fun (x : ob C) => C⟦x, f (i + n)⟧) (maponpaths f (! e1)) (H i)).
+                      (transportf (fun (x : ob C) => C⟦x, f (i + n)⟧) (maponpaths f e1) (H i)).
   Proof.
     induction e1. apply idpath.
   Qed.
 
-  Lemma transport_section' (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f i, f (i + n)⟧) (i i' : hz)
-    (e1 : i = i') :
+  Lemma transport_hz_section (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f i, f (i + n)⟧)
+        (i i' : hz) (e1 : i = i') :
     transportf (precategory_morphisms (f i)) (maponpaths f (hzplusradd i i' n e1)) (H i) =
-    transportb (fun (x : ob C) => C⟦x, f (i' + n)⟧) (maponpaths f e1) (H i').
+    transportf (fun (x : ob C) => C⟦x, f (i' + n)⟧) (maponpaths f (! e1)) (H i').
   Proof.
     induction e1. apply idpath.
   Qed.
 
-  Lemma transport_section'' (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f (i + n), f i⟧)
+  Lemma transport_hz_section' (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f (i + n), f i⟧)
         (i i' : hz) (e1 : i + n = i' + n) (e2 : i = i') :
     transportf (precategory_morphisms (f (i + n))) (maponpaths f e2) (H i) =
-    transportb (fun (x : ob C) => C⟦x, f i'⟧) (maponpaths f e1) (H i').
+    transportf (fun (x : ob C) => C⟦x, f i'⟧) (maponpaths f (! e1)) (H i').
   Proof.
     induction e2. assert (e : e1 = idpath _) by apply isasethz. rewrite e. clear e. apply idpath.
   Qed.
 
-  Lemma transport_double_section (f f' : hz -> ob C) (H : Π (i : hz), C⟦f i, f' i⟧)
+  Lemma transport_hz_double_section (f f' : hz -> ob C) (H : Π (i : hz), C⟦f i, f' i⟧)
         (i i' : hz) (e : i = i') :
     transportf (precategory_morphisms (f i)) (maponpaths f' e) (H i) =
-    transportb (fun (x : ob C) => C⟦x, f' i'⟧) (maponpaths f e) (H i').
+    transportf (fun (x : ob C) => C⟦x, f' i'⟧) (maponpaths f (! e)) (H i').
   Proof.
     induction e. apply idpath.
   Qed.
 
-  Lemma transport_hz_double_section_f_b (f f' : hz -> ob C) (H : Π (i : hz), C⟦f i, f' i⟧)
+  Lemma transport_hz_double_section_source_target (f f' : hz -> ob C) (H : Π (i : hz), C⟦f i, f' i⟧)
         (i i' : hz) (e : i = i') :
     H i' = transportf (precategory_morphisms (f i')) (maponpaths f' e)
-                      (transportb (fun (x : ob C) => C⟦x, f' i⟧) (maponpaths f (! e)) (H i)).
+                      (transportf (fun (x : ob C) => C⟦x, f' i⟧) (maponpaths f e) (H i)).
   Proof.
     induction e. apply idpath.
   Qed.
@@ -2133,37 +2131,17 @@ Section complexes_homotopies.
                        (maponpaths C2 (hzrplusminus (i + 1) 1)) (Diff C1 (i + 1) ;; H (i + 1 + 1)))
                  = ZeroArrow (Additive.to_Zero A) _ _).
     {
-      rewrite <- transportf_postcompose. rewrite assoc. rewrite (@DSq A C1 i).
-      rewrite ZeroArrow_comp_left. apply transportf_ZeroArrow.
+      rewrite <- transport_target_postcompose. rewrite assoc. rewrite (@DSq A C1 i).
+      rewrite ZeroArrow_comp_left. apply transport_target_ZeroArrow.
     }
     rewrite e1. clear e1.
     rewrite <- PreAdditive_unel_zero. rewrite to_lunax'. rewrite to_runax'.
     (* Here the idea is to apply cancel_precomposition *)
-    rewrite transportf_postcompose. rewrite <- assoc. apply cancel_precomposition.
+    rewrite transport_target_postcompose. rewrite <- assoc. apply cancel_precomposition.
     (* Other application of cancel_precomposition *)
-    rewrite transport_compose. rewrite transportf_postcompose. apply cancel_precomposition.
+    rewrite transport_compose. rewrite transport_target_postcompose. apply cancel_precomposition.
     (* Start to solve the transport stuff *)
-    rewrite <- functtransportf. rewrite <- functtransportb. unfold transportb.
-    use (transportf_path _ _ (maponpaths C2 (hzrminusplus' (i + 1) 1))).
-    rewrite <- functtransportf. rewrite <- functtransportf. rewrite transport_f_f.
-    assert (e2 : (hzrminusplus (i + 1) 1 @ hzrminusplus' (i + 1) 1) = idpath _)
-      by apply isasethz.
-    rewrite e2. clear e2. cbn. unfold idfun.
-    use (pathscomp0 _ (@transport_section hz _ (Diff C2) i (i + 1 - 1) (! (hzrplusminus i 1)))).
-    assert (e3 : (! hzrplusminus i 1) = hzrplusminus' i 1) by apply isasethz.
-    cbn. cbn in e3. rewrite e3. clear e3.
-    (* Split the right hand side to two transports *)
-    rewrite (@transportf_mor' hz A). unfold transportb. rewrite pathsinv0inv0.
-    rewrite functtransportf. cbn.
-    (* Here only the equations of the first transportfs are different! *)
-    use transportf_paths.
-    assert (e5 : maponpaths C2 (hzrminusplus' (i + 1) 1) =
-                 maponpaths (C2 ∘ (λ x' : pr1 hz, x' + 1)) (hzrplusminus' i 1)).
-    {
-      use (pathscomp0 _ (maponpathscomp (λ x' : pr1 hz, x' + 1) C2 (hzrplusminus' i 1))).
-      apply maponpaths. apply isasethz.
-    }
-    use (pathscomp0 e5). clear e5. induction (hzrplusminus' i 1). apply idpath.
+    use transport_Diff.
   Qed.
 
   (** Every homotopy H of complexes induces a morphisms of complexes. The morphisms is defined by
@@ -2266,8 +2244,8 @@ Section complexes_homotopies.
         use tpair.
         * intros i. exact (ZeroArrow (Additive.to_Zero A) _ _).
         * cbn. use MorphismEq. intros i. cbn. rewrite ZeroArrow_comp_left.
-          rewrite transportf_ZeroArrow.
-          rewrite ZeroArrow_comp_right. rewrite transportf_ZeroArrow.
+          rewrite transport_target_ZeroArrow.
+          rewrite ZeroArrow_comp_right. rewrite transport_target_ZeroArrow.
           rewrite <- PreAdditive_unel_zero. rewrite to_lunax'. apply idpath.
     - intros f H. use (squash_to_prop H). apply propproperty. intros H'. clear H.
       induction H' as [homot eq]. intros P X. apply X. clear P X.
@@ -2327,9 +2305,10 @@ Section complexes_homotopies.
     use tpair.
     - intros i. exact ((MMor g i) ;; (homot i)).
     - cbn. rewrite <- eq. use MorphismEq. intros i. cbn. rewrite assoc.
-      rewrite <- (MComm g i). rewrite transportf_postcompose. rewrite transportf_postcompose.
+      rewrite <- (MComm g i). rewrite transport_target_postcompose.
+      rewrite transport_target_postcompose.
       rewrite <- assoc. rewrite <- assoc. rewrite <- to_premor_linear'.
-      rewrite <- transportf_postcompose. rewrite <- transportf_postcompose.
+      rewrite <- transport_target_postcompose. rewrite <- transport_target_postcompose.
       apply idpath.
   Qed.
 
@@ -2581,9 +2560,10 @@ Section translation_functor.
   Proof.
     unfold TranslationHomot. cbn. use MorphismEq. intros i. cbn.
     induction (hzrminusplus i 1). cbn. rewrite pathscomp0rid. cbn. unfold idfun.
-    rewrite <- PreAdditive_invrcomp. rewrite <- transportf_to_inv.
+    rewrite <- PreAdditive_invrcomp. rewrite <- transport_target_to_inv.
     rewrite PreAdditive_invlcomp. rewrite inv_inv_eq.
-    rewrite <- transportf_to_inv. rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invrcomp.
+    rewrite <- transport_target_to_inv.
+    rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invrcomp.
     rewrite inv_inv_eq.
     assert (e : (maponpaths (λ i0 : pr1 hz, C2 (i0 + 1)) (hzrplusminus (i - 1 + 1) 1)) =
                 (maponpaths C2 (maponpaths (fun (i0 : hz) => i0 + 1) (hzrplusminus (i - 1 + 1) 1)))).
@@ -2591,6 +2571,7 @@ Section translation_functor.
       induction (hzrplusminus (i - 1 + 1) 1). apply idpath.
     }
     cbn in e. rewrite e. clear e.
+    (* The first elements of to_binop are the same *)
     assert (e1 : (transportf (precategory_morphisms (C1 (i - 1 + 1 + 1)))
                              (maponpaths C2 (maponpaths (λ i0 : pr1 hz, i0 + 1)
                                                         (hzrplusminus (i - 1 + 1) 1)))
@@ -2605,7 +2586,7 @@ Section translation_functor.
                               (maponpaths C2 (hzrplusminus (i - 1 + 1 + 1) 1))
                               (Diff C1 (i - 1 + 1 + 1) ;; H (i - 1 + 1 + 1 + 1))))).
     {
-      rewrite transportf_postcompose. rewrite transport_f_f. rewrite <- maponpathscomp0.
+      rewrite transport_target_postcompose. rewrite transport_f_f. rewrite <- maponpathscomp0.
       set (tmp := ((hzrplusminus (i - 1 + 1 + 1) 1
                                  @ ! hzrminusplus (i - 1 + 1 + 1) 1)
                      @ maponpaths (λ i0 : pr1 hz, i0 + 1) (hzrplusminus (i - 1 + 1) 1))).
@@ -2614,10 +2595,12 @@ Section translation_functor.
       induction (hzrplusminus (i - 1 + 1 + 1) 1). cbn. unfold idfun. apply idpath.
     }
     cbn in e1. rewrite e1. clear e1. use to_lrw.
-
-    set (tmp := @transport_mor_b_f A C2 1 (Diff C2) _ _ (hzrplusminus (i - 1 + 1) 1)).
-    rewrite tmp. clear tmp. rewrite maponpathsinv0. rewrite transport_compose'.
-    rewrite transportf_postcompose. apply cancel_precomposition.
+    (* Show that the first elements of to_binop are the same *)
+    set (tmp := @transport_hz_source_target A C2 1 (Diff C2) _ _ (hzrplusminus (i - 1 + 1) 1)).
+    rewrite tmp. clear tmp. rewrite transport_compose.
+    rewrite transport_target_postcompose. apply cancel_precomposition.
+    rewrite transport_f_f. rewrite <- maponpathsinv0. rewrite <- maponpathscomp0.
+    rewrite pathsinv0r. rewrite <- functtransportf. rewrite idpath_transportf.
     apply transportf_paths. apply maponpaths. apply isasethz.
   Qed.
 
@@ -2698,22 +2681,21 @@ Section translation_functor.
     (InvTranslationMorphism_mor f i) ;; (DiffInvTranslationComplex C2 i) =
     (DiffInvTranslationComplex C1 i) ;; (InvTranslationMorphism_mor f (i + 1)).
   Proof.
-    unfold DiffInvTranslationComplex. rewrite <- transportf_postcompose.
+    unfold DiffInvTranslationComplex. rewrite <- transport_target_postcompose.
     unfold InvTranslationMorphism_mor. cbn. rewrite <- PreAdditive_invrcomp.
     rewrite (MComm f (i - 1)). rewrite PreAdditive_invlcomp.
-    rewrite transportf_postcompose.
-    use transportf_path.
+    rewrite transport_target_postcompose.
+    use transport_target_path.
     - exact (C2 i).
     - exact (maponpaths C2 (hzrplusminus i 1)).
-    - rewrite transportf_postcompose. rewrite transport_f_f. rewrite <- maponpathscomp0.
+    - rewrite transport_target_postcompose. rewrite transport_f_f. rewrite <- maponpathscomp0.
       rewrite <- path_assoc. rewrite pathsinv0l. rewrite pathscomp0rid.
       induction (hzrminusplus i 1). cbn. unfold idfun.
-      rewrite transportf_postcompose.
-      set (tmp := transport_double_section A C1 C2 (MMor f) _ _ (hzrplusminus (i - 1 + 1) 1)).
+      rewrite transport_target_postcompose.
+      set (tmp := transport_hz_double_section A C1 C2 (MMor f) _ _ (hzrplusminus (i - 1 + 1) 1)).
       cbn. cbn in tmp. rewrite tmp. clear tmp.
       rewrite <- (transport_compose' _ _ (maponpaths C1 (! hzrplusminus (i - 1 + 1) 1))).
-      apply cancel_precomposition. rewrite <- maponpathsinv0. rewrite pathsinv0inv0.
-      apply idpath.
+      apply cancel_precomposition. apply idpath.
   Qed.
 
   Definition InvTranslationMorphism (C1 C2 : Complex A) (f : Morphism C1 C2) :
@@ -2777,10 +2759,10 @@ Section translation_functor.
   Proof.
     unfold InvTranslationHomot. cbn. use MorphismEq. intros i. cbn.
     induction (hzrplusminus i 1). cbn. unfold idfun. rewrite pathscomp0rid.
-    rewrite <- transportf_to_inv. rewrite <- PreAdditive_invrcomp. rewrite <- PreAdditive_invlcomp.
-    rewrite inv_inv_eq.
-    rewrite <- transportf_to_inv. rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invrcomp.
-    rewrite inv_inv_eq.
+    rewrite <- transport_target_to_inv. rewrite <- PreAdditive_invrcomp.
+    rewrite <- PreAdditive_invlcomp. rewrite inv_inv_eq.
+    rewrite <- transport_target_to_inv. rewrite <- PreAdditive_invlcomp.
+    rewrite <- PreAdditive_invrcomp. rewrite inv_inv_eq.
     assert (e1 : transportf (precategory_morphisms (C1 (i + 1 - 1 - 1)))
                             (maponpaths C1 (hzrminusplus (i + 1 - 1) 1))
                             (Diff C1 (i + 1 - 1 - 1)) ;; H (i + 1 - 1) =
@@ -2788,8 +2770,9 @@ Section translation_functor.
                             (maponpaths C2 (hzrplusminus (i + 1 - 1 - 1) 1))
                             (Diff C1 (i + 1 - 1 - 1) ;; H (i + 1 - 1 - 1 + 1))).
     {
-      rewrite transportf_postcompose. rewrite transport_compose. apply cancel_precomposition.
-      rewrite <- (transport_double_section A _ _ H _ _ (hzrminusplus (i + 1 - 1) 1)).
+      rewrite transport_target_postcompose. rewrite transport_compose. apply cancel_precomposition.
+      rewrite <- maponpathsinv0.
+      rewrite <- (transport_hz_double_section A _ _ H _ _ (hzrminusplus (i + 1 - 1) 1)).
       use transportf_paths.
       assert (e2 : maponpaths (λ i0 : hz, C2 (i0 - 1)) (hzrminusplus (i + 1 - 1) 1) =
                    maponpaths C2 (maponpaths (λ i0 : hz, i0 - 1) (hzrminusplus (i + 1 - 1) 1))).
@@ -2799,7 +2782,7 @@ Section translation_functor.
       rewrite e2. clear e2. apply maponpaths. apply isasethz.
     }
     cbn in e1. rewrite e1. clear e1. use to_lrw.
-    rewrite <- transportf_postcompose. rewrite transport_f_f.
+    rewrite <- transport_target_postcompose. rewrite transport_f_f.
     assert (e2 : maponpaths (λ i0 : pr1 hz, C2 (i0 - 1)) (hzrminusplus (i + 1 - 1) 1) =
                  maponpaths C2 (maponpaths (λ i0 : hz, i0 - 1) (hzrminusplus (i + 1 - 1) 1))).
     {
@@ -2847,19 +2830,10 @@ Section translation_functor.
     induction p. induction q. apply idpath.
   Qed.
 
-  Lemma transportb_total2_base {AA : UU} {B : AA -> UU} (BB : AA -> UU) (s s' : Σ x : AA, B x)
-        (p : pr1 s = pr1 s') (q : transportf B p (pr2 s) = pr2 s') (x : BB (pr1 s)) :
-    transportb (λ x' : Σ x : AA, B x, BB (pr1 x')) (! total2_paths p q) x =
-    transportb (λ x : AA, BB x) (! p) x.
-  Proof.
-    unfold transportb. rewrite pathsinv0inv0. rewrite pathsinv0inv0.
-    use transportf_total2_base.
-  Qed.
-
-  Lemma ComplexEq_transportf {C1 C2 C2' : Complex A} (H : Π (i : hz), C2 i = C2' i)
+  Lemma ComplexEq_transport_target {C1 C2 C2' : Complex A} (H : Π (i : hz), C2 i = C2' i)
         (H1 : Π (i : hz),
               transportf (λ x : A, C2' i --> x) (H (i + 1))
-                         (transportb (λ x : A, x --> C2 (i + 1)) (! H i) (Diff C2 i)) =
+                         (transportf (λ x : A, x --> C2 (i + 1)) (H i) (Diff C2 i)) =
               Diff C2' i) (f : Morphism C1 C2) (i : hz) :
     (transportf (λ x : Complex A, Morphism C1 x) (ComplexEq A C2 C2' H H1) f) i =
     transportf (λ x : A, C1 i --> x) (H i) (f i).
@@ -2870,7 +2844,7 @@ Section translation_functor.
       induction (ComplexEq A C2 C2' H H1). apply idpath.
     }
     use (pathscomp0 e). clear e.
-    rewrite <- (@transportf_mor_funextfun hz _ C2 C2' H i (C1 i) (f i)).
+    rewrite <- (@transport_target_funextfun hz _ C2 C2' H i (C1 i) (f i)).
     unfold ComplexEq. unfold Complex_Funclass.
     set (e := (funextfun (pr1 (pr1 C2)) (pr1 (pr1 C2')) (λ x0 : pr1 hz, H x0))).
     cbn. cbn in e. fold e.
@@ -2882,35 +2856,35 @@ Section translation_functor.
     use transportf_total2_base.
   Qed.
 
-  Lemma ComplexEq_transportb {C1 C1' C2 : Complex A} (H : Π (i : hz), C1' i = C1 i)
+  Lemma ComplexEq_transport_source {C1 C1' C2 : Complex A} (H : Π (i : hz), C1' i = C1 i)
         (H1 : Π (i : hz),
               transportf (λ x : A, C1 i --> x) (H (i + 1))
-                         (transportb (λ x : A, x --> C1' (i + 1)) (! H i) (Diff C1' i)) =
+                         (transportf (λ x : A, x --> C1' (i + 1)) (H i) (Diff C1' i)) =
               Diff C1 i) (f : Morphism C1' C2) (i : hz) :
-    (transportb (λ x : Complex A, Morphism x C2) (! ComplexEq A C1' C1 H H1) f) i =
-    transportb (λ x : A, x --> C2 i) (! H i) (f i).
+    (transportf (λ x : Complex A, Morphism x C2) (ComplexEq A C1' C1 H H1) f) i =
+    transportf (λ x : A, x --> C2 i) (H i) (f i).
   Proof.
-    assert (e : (transportb (λ x : Complex A, Morphism x C2) (! ComplexEq A C1' C1 H H1) f) i =
-                (transportb (λ x : Complex A, x i --> C2 i) (! ComplexEq A C1' C1 H H1) (f i))).
+    assert (e : (transportf (λ x : Complex A, Morphism x C2) (ComplexEq A C1' C1 H H1) f) i =
+                (transportf (λ x : Complex A, x i --> C2 i) (ComplexEq A C1' C1 H H1) (f i))).
     {
       induction (ComplexEq A C1' C1 H H1). apply idpath.
     }
     use (pathscomp0 e). clear e.
-    rewrite <- (@transportb_mor_funextfun hz _ C1' C1 H i (C2 i) (f i)).
+    rewrite <- (@transport_source_funextfun hz _ C1' C1 H i (C2 i) (f i)).
     unfold ComplexEq. unfold Complex_Funclass.
     set (e := (funextfun (pr1 (pr1 C1')) (pr1 (pr1 C1)) (λ i0 : hz, H i0))).
     cbn. cbn in e. fold e.
-    set (tmp := @transportb_total2_base
+    set (tmp := @transportf_total2_base
                   (hz -> ob A) _ (λ x0 : pr1 hz → A, A ⟦ x0 i, pr1 (pr1 C2) i ⟧)
                   (pr1 C1') (pr1 C1) e (ComplexEq' A C1' C1 H H1) (f i)).
     use (pathscomp0 _ tmp). clear tmp. cbn beta.
-    use transportb_total2_base.
+    use transportf_total2_base.
   Qed.
 
   Local Lemma TranslationInvTranslation_eq1 (C : Complex A) (i : hz) :
     transportf (λ x : A, A ⟦ C i, x ⟧) (maponpaths C (hzrminusplus (i + 1) 1))
-               (transportb (λ x : A, A ⟦ x, C (i + 1 - 1 + 1) ⟧)
-                           (! maponpaths C (hzrminusplus i 1))
+               (transportf (λ x : A, A ⟦ x, C (i + 1 - 1 + 1) ⟧)
+                           (maponpaths C (hzrminusplus i 1))
                            (transportf (precategory_morphisms (C (i - 1 + 1)))
                                        (maponpaths (λ i0 : pr1 hz, C (i0 + 1))
                                                    (hzrminusplus i 1 @ ! hzrplusminus i 1))
@@ -2941,16 +2915,16 @@ Section translation_functor.
                (ComplexEq A (InvTranslationComplex (TranslationComplex C2)) C2
                           (λ i : pr1 hz, maponpaths C2 (hzrminusplus i 1))
                           (λ i : pr1 hz, TranslationInvTranslation_eq1 C2 i))
-               (transportb (λ x : Complex A,
+               (transportf (λ x : Complex A,
                                   Morphism x (InvTranslationComplex (TranslationComplex C2)))
-                           (! ComplexEq A (InvTranslationComplex (TranslationComplex C1)) C1
-                              (λ i : pr1 hz, maponpaths C1 (hzrminusplus i 1))
-                              (λ i : pr1 hz, TranslationInvTranslation_eq1 C1 i))
+                           (ComplexEq A (InvTranslationComplex (TranslationComplex C1)) C1
+                                      (λ i : pr1 hz, maponpaths C1 (hzrminusplus i 1))
+                                      (λ i : pr1 hz, TranslationInvTranslation_eq1 C1 i))
                            (InvTranslationMorphism (TranslationComplex C1) (TranslationComplex C2)
                                                    (TranslationMorphism C1 C2 f))) = f.
   Proof.
     use MorphismEq. intros i. Local Opaque ComplexEq. cbn.
-    rewrite ComplexEq_transportf. rewrite ComplexEq_transportb. cbn.
+    rewrite ComplexEq_transport_target. rewrite ComplexEq_transport_source. cbn.
     induction (hzrminusplus i 1). cbn. unfold idfun. apply idpath.
   Qed.
 
@@ -2969,21 +2943,19 @@ Section translation_functor.
 
   Local Lemma InvTranslationTranslation_eq1 (C : Complex A) (i : hz) :
     transportf (λ x : A, A ⟦ C i, x ⟧) (maponpaths C (hzrplusminus (i + 1) 1))
-               (transportb (λ x : A, A ⟦ x, C (i + 1 + 1 - 1) ⟧) (! maponpaths C (hzrplusminus i 1))
+               (transportf (λ x : A, A ⟦ x, C (i + 1 + 1 - 1) ⟧) (maponpaths C (hzrplusminus i 1))
                            (to_inv
                               (transportf
                                  (precategory_morphisms (C (i + 1 - 1)))
                                  (maponpaths C (hzrminusplus (i + 1) 1 @ ! hzrplusminus (i + 1) 1))
                                  (to_inv (Diff C (i + 1 - 1)))))) = Diff C i.
   Proof.
-    rewrite transportf_to_inv.
-    rewrite inv_inv_eq. rewrite <- transport_mor_f_b_comm.
+    rewrite transport_target_to_inv. rewrite inv_inv_eq.
+    rewrite <- transport_source_target_comm.
     rewrite transport_f_f. rewrite <- maponpathscomp0.
     rewrite <- path_assoc. rewrite pathsinv0l. rewrite pathscomp0rid.
-    rewrite transport_mor_f_b_comm.
-    rewrite (transport_mor_b_f A C 1 (Diff C) _ _ (hzrplusminus i 1)).
-    rewrite maponpathsinv0. apply maponpaths.
-    use transportf_paths. apply maponpaths. apply isasethz.
+    rewrite (transport_hz_source_target A C 1 (Diff C) _ _ (hzrplusminus i 1)).
+    apply maponpaths. use transportf_paths. apply maponpaths. apply isasethz.
   Qed.
 
   Local Lemma InvTranslationTranslation_eq2 {C1 C2 : Complex A} (f : Morphism C1 C2) :
@@ -2991,17 +2963,17 @@ Section translation_functor.
                (ComplexEq A (TranslationComplex (InvTranslationComplex C2)) C2
                           (λ i : pr1 hz, maponpaths C2 (hzrplusminus i 1))
                           (λ i : pr1 hz, InvTranslationTranslation_eq1 C2 i))
-               (transportb (λ x : Complex A,
+               (transportf (λ x : Complex A,
                                   Morphism x (TranslationComplex (InvTranslationComplex C2)))
-                           (! ComplexEq A (TranslationComplex (InvTranslationComplex C1)) C1
-                              (λ i : pr1 hz, maponpaths C1 (hzrplusminus i 1))
-                              (λ i : pr1 hz, InvTranslationTranslation_eq1 C1 i))
+                           (ComplexEq A (TranslationComplex (InvTranslationComplex C1)) C1
+                                      (λ i : pr1 hz, maponpaths C1 (hzrplusminus i 1))
+                                      (λ i : pr1 hz, InvTranslationTranslation_eq1 C1 i))
                            (TranslationMorphism (InvTranslationComplex C1)
                                                 (InvTranslationComplex C2)
                                                 (InvTranslationMorphism C1 C2 f))) = f.
   Proof.
     Local Opaque ComplexEq. use MorphismEq. intros i. cbn.
-    rewrite ComplexEq_transportf. rewrite ComplexEq_transportb. cbn.
+    rewrite ComplexEq_transport_target. rewrite ComplexEq_transport_source. cbn.
     induction (hzrplusminus i 1). cbn. unfold idfun. apply idpath.
   Qed.
 
@@ -3167,8 +3139,7 @@ Section translation_functor.
       + intros C. cbn. apply idpath.
       + intros C1 C2 f.
         cbn beta.
-        rewrite idpath_transportf. unfold transportb.
-        rewrite pathsinv0inv0. rewrite idpath_transportf.
+        rewrite idpath_transportf. rewrite idpath_transportf.
         assert (e1 : pr2 (pr1 (functor_composite (ComplexHomotFunctor A) TranslationFunctorH))
                          C1 C2 f =
                     # TranslationFunctorH (# (ComplexHomotFunctor A) f)) by apply idpath.
@@ -3387,8 +3358,7 @@ Section translation_functor.
       + intros C. cbn. apply idpath.
       + intros C1 C2 f.
         cbn beta.
-        rewrite idpath_transportf. unfold transportb.
-        rewrite pathsinv0inv0. rewrite idpath_transportf.
+        rewrite idpath_transportf. rewrite idpath_transportf.
         assert (e1 : pr2 (pr1 (functor_composite (ComplexHomotFunctor A) InvTranslationFunctorH))
                          C1 C2 f =
                     # InvTranslationFunctorH (# (ComplexHomotFunctor A) f)) by apply idpath.
@@ -3458,17 +3428,18 @@ Section translation_functor.
 
   (** Translation functors in K(A) are isomorphisms and inverse to each other. *)
 
-  Lemma transportf_ComplexHomotFunctor {C1 C2 C2' : Complex A} (e : C2 = C2') (f : Morphism C1 C2) :
+  Lemma transport_target_ComplexHomotFunctor {C1 C2 C2' : Complex A} (e : C2 = C2')
+        (f : Morphism C1 C2) :
     # (ComplexHomotFunctor A) (transportf (λ x : Complex A, Morphism C1 x) e f) =
     transportf (λ x : Complex A, (ComplexHomot_Additive A)⟦C1, x⟧) e (# (ComplexHomotFunctor A) f).
   Proof.
     induction e. apply idpath.
   Qed.
 
-  Lemma transportb_ComplexHomotFunctor {C1' C1 C2 : Complex A} (e : C1' = C1)
+  Lemma transport_source_ComplexHomotFunctor {C1' C1 C2 : Complex A} (e : C1' = C1)
         (f : Morphism C1' C2) :
-    # (ComplexHomotFunctor A) (transportb (λ x : Complex A, Morphism x C2) (! e) f) =
-    transportb (λ x : Complex A, (ComplexHomot_Additive A)⟦x, C2⟧) (! e)
+    # (ComplexHomotFunctor A) (transportf (λ x : Complex A, Morphism x C2) e f) =
+    transportf (λ x : Complex A, (ComplexHomot_Additive A)⟦x, C2⟧) e
                (# (ComplexHomotFunctor A) f).
   Proof.
     induction e. apply idpath.
@@ -3493,7 +3464,7 @@ Section translation_functor.
         rewrite (InvTranslationFunctorH_Mor_unique _ f'').
         rewrite <- (hfiberpr2 _ _ f').
         rewrite <- (TranslationInvTranslation_eq2 (hfiberpr1 # (ComplexHomotFunctor A) f f')).
-        rewrite transportf_ComplexHomotFunctor. rewrite transportb_ComplexHomotFunctor.
+        rewrite transport_target_ComplexHomotFunctor. rewrite transport_source_ComplexHomotFunctor.
         apply maponpaths. apply maponpaths.
         assert (e1 : # (ComplexHomotFunctor A)
                        (InvTranslationMorphism
@@ -3533,7 +3504,7 @@ Section translation_functor.
         rewrite (TranslationFunctorH_Mor_unique _ f'').
         rewrite <- (hfiberpr2 _ _ f').
         rewrite <- (InvTranslationTranslation_eq2 (hfiberpr1 # (ComplexHomotFunctor A) f f')).
-        rewrite transportf_ComplexHomotFunctor. rewrite transportb_ComplexHomotFunctor.
+        rewrite transport_target_ComplexHomotFunctor. rewrite transport_source_ComplexHomotFunctor.
         apply maponpaths. apply maponpaths.
         assert (e1 : # (ComplexHomotFunctor A)
                        (TranslationMorphism
@@ -4213,8 +4184,8 @@ Section mapping_cylinder_KA_iso.
     - exact (to_Pr1 A DS2).
     - use compose.
       + exact DS3.
-      + exact (transportb (fun x' : ob A => precategory_morphisms x' DS3)
-                          (maponpaths C1 (! hzrminusplus i 1)) (to_In1 A DS3)).
+      + exact (transportf (fun x' : ob A => precategory_morphisms x' DS3)
+                          (maponpaths C1 (hzrminusplus i 1)) (to_In1 A DS3)).
       + exact (to_inv (to_In2 A DS4)).
   Defined.
 
@@ -4265,7 +4236,7 @@ Section mapping_cylinder_KA_iso.
                 (MappingCylinderIsoHomot f i ;; MappingCylinderDiff A f (i - 1))) =
     MappingCylinderIsoHomot_mor1 f i.
   Proof.
-    cbn. rewrite transportf_postcompose.
+    cbn. rewrite transport_target_postcompose.
     unfold MappingCylinderIsoHomot. unfold MappingCylinderIsoHomot_mor1. cbn.
     set (DS1 := to_BinDirectSums A (C1 (i + 1)) (C2 i)).
     set (DS2 := to_BinDirectSums A (C1 i) DS1).
@@ -4274,9 +4245,9 @@ Section mapping_cylinder_KA_iso.
     set (DS5 := to_BinDirectSums A (C1 (i - 1 + 1 + 1)) (C2 (i - 1 + 1))).
     set (DS6 := to_BinDirectSums A (C1 (i - 1 + 1)) DS5). cbn.
     rewrite <- assoc. rewrite <- assoc. rewrite <- to_premor_linear'. rewrite <- to_premor_linear'.
-    apply cancel_precomposition. rewrite <- transportf_postcompose.
+    apply cancel_precomposition. rewrite <- transport_target_postcompose.
     rewrite assoc. rewrite assoc. rewrite <- to_postmor_linear'.
-    rewrite <- transportf_postcompose. rewrite <- transportb_precompose.
+    rewrite <- transport_target_postcompose. rewrite <- transport_source_precompose.
     (* Unfold MappingCylinderDiff *)
     unfold MappingCylinderDiff. unfold MappingCylinderDiff1.
     unfold MappingCylinderDiff2. unfold MappingCylinderDiff3. cbn.
@@ -4306,9 +4277,10 @@ Section mapping_cylinder_KA_iso.
     rewrite ZeroArrow_comp_left. rewrite to_runax''.
     unfold DiffTranslationComplex. cbn.
     (* rewrite transports *)
-    rewrite <- transportb_to_binop. rewrite <- transportf_to_binop. rewrite <- transportb_to_inv.
-    rewrite <- transportf_to_inv. cbn. rewrite to_postmor_linear'. rewrite <- transportb_to_binop.
-    rewrite <- transportf_to_binop.
+    rewrite <- transport_source_to_binop. rewrite <- transport_target_to_binop.
+    rewrite <- transport_source_to_inv. rewrite <- transport_target_to_inv. cbn.
+    rewrite to_postmor_linear'.
+    rewrite <- transport_source_to_binop. rewrite <- transport_target_to_binop.
     (* The first terms of to_binop are equal, cancel them *)
     assert (e1 : (transportf
                     (precategory_morphisms (C1 i))
@@ -4319,7 +4291,7 @@ Section mapping_cylinder_KA_iso.
                                A (C1 i0)
                                (to_BinDirectSums A (C1 (i0 + 1)) (C2 i0))))
                        (hzrminusplus i 1))
-                    (transportb (λ x' : A, A ⟦ x', DS6 ⟧) (maponpaths C1 (! hzrminusplus i 1))
+                    (transportf (λ x' : A, A ⟦ x', DS6 ⟧) (maponpaths C1 (hzrminusplus i 1))
                                 (to_In1 A DS6))) = (to_In1 A DS2)).
     {
       cbn. unfold DS2, DS1, DS6, DS5.
@@ -4329,15 +4301,16 @@ Section mapping_cylinder_KA_iso.
       set (tmp'' := (fun (i0 : hz) =>
                        to_In1 A (to_BinDirectSums A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1))
                                                                               (C2 i0))))).
-      set (tmp' := @transport_hz_double_section_f_b A C1 tmp tmp'' _ _ (hzrminusplus i 1)).
+      set (tmp' := @transport_hz_double_section_source_target
+                     A C1 tmp tmp'' _ _ (hzrminusplus i 1)).
       unfold tmp'' in tmp'.
       rewrite tmp'. unfold tmp. apply idpath.
     }
     cbn in e1. cbn. rewrite <- e1. clear e1. use to_rrw.
     (* The first term of to_binop are equal, cancel them *)
-    rewrite <- to_binop_inv_inv. rewrite transportf_to_inv. rewrite transportb_to_inv.
+    rewrite <- to_binop_inv_inv. rewrite transport_target_to_inv. rewrite transport_source_to_inv.
     rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invlcomp. rewrite inv_inv_eq.
-    rewrite transportf_to_inv. rewrite transportb_to_inv. rewrite PreAdditive_invlcomp.
+    rewrite transport_target_to_inv. rewrite transport_source_to_inv. rewrite PreAdditive_invlcomp.
     rewrite PreAdditive_invlcomp. rewrite to_postmor_linear'.
     assert (e1 : (transportf (precategory_morphisms (C1 i))
                              (maponpaths
@@ -4346,8 +4319,8 @@ Section mapping_cylinder_KA_iso.
                                    A (to_BinDirectSums
                                         A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1)) (C2 i0))))
                                 (hzrminusplus i 1))
-                             (transportb (λ x' : A, A ⟦ x', DS6 ⟧)
-                                         (maponpaths C1 (! hzrminusplus i 1))
+                             (transportf (λ x' : A, A ⟦ x', DS6 ⟧)
+                                         (maponpaths C1 (hzrminusplus i 1))
                                          (Diff C1 (i - 1 + 1) ;; to_In1 A DS5 ;; to_In2 A DS6))) =
                  (Diff C1 i ;; to_In1 A DS1 ;; to_In2 A DS2)).
     {
@@ -4360,7 +4333,8 @@ Section mapping_cylinder_KA_iso.
                          ;; (to_In1 A (to_BinDirectSums A (C1 (i0 + 1)) (C2 i0)))
                          ;; (to_In2 A (to_BinDirectSums A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1))
                                                                                     (C2 i0)))))).
-      set (tmp' := @transport_hz_double_section_f_b A C1 tmp tmp'' _ _ (hzrminusplus i 1)).
+      set (tmp' := @transport_hz_double_section_source_target
+                     A C1 tmp tmp'' _ _ (hzrminusplus i 1)).
       unfold tmp'' in tmp'.
       rewrite tmp'. unfold tmp. apply idpath.
     }
@@ -4375,7 +4349,7 @@ Section mapping_cylinder_KA_iso.
                        ;; (to_In2 A (to_BinDirectSums A (C1 (i0 + 1)) (C2 i0)))
                        ;; (to_In2 A (to_BinDirectSums A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1))
                                                                                   (C2 i0)))))).
-    set (tmp' := @transport_hz_double_section_f_b A C1 tmp tmp'' _ _ (hzrminusplus i 1)).
+    set (tmp' := @transport_hz_double_section_source_target A C1 tmp tmp'' _ _ (hzrminusplus i 1)).
     unfold tmp'' in tmp'.
     rewrite tmp'. unfold tmp. apply idpath.
   Qed.
@@ -4432,7 +4406,7 @@ Section mapping_cylinder_KA_iso.
     unfold MappingCylinderDiff. unfold MappingCylinderDiff1.
     unfold MappingCylinderDiff2. unfold MappingCylinderDiff3. cbn.
     fold DS1 DS2 DS3 DS4 DS5 DS6. cbn.
-    rewrite to_postmor_linear'. rewrite to_postmor_linear'. rewrite <- transportf_to_binop.
+    rewrite to_postmor_linear'. rewrite to_postmor_linear'. rewrite <- transport_target_to_binop.
     rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
     rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
     rewrite assoc.
@@ -4449,15 +4423,15 @@ Section mapping_cylinder_KA_iso.
                                    A (to_BinDirectSums A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1))
                                                                                    (C2 i0))))
                                 (hzrplusminus i 1))
-                             (to_Pr1 A DS2 ;; Diff C1 i ;; transportb (λ x' : A, A ⟦ x', DS5 ⟧)
-                                     (maponpaths C1 (! hzrminusplus (i + 1) 1))
+                             (to_Pr1 A DS2 ;; Diff C1 i ;; transportf (λ x' : A, A ⟦ x', DS5 ⟧)
+                                     (maponpaths C1 (hzrminusplus (i + 1) 1))
                                      (to_In1 A DS5) ;; to_inv (to_In2 A DS6))) =
                  ((to_Pr1 A DS2) ;; (to_inv (Diff C1 i)) ;; (to_In1 A DS1) ;; (to_In2 A DS2))).
     {
-      rewrite transportf_postcompose. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
+      rewrite transport_target_postcompose. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
       rewrite <- assoc. apply cancel_precomposition.
       rewrite <- PreAdditive_invlcomp. rewrite PreAdditive_invrcomp. apply cancel_precomposition.
-      rewrite <- transportf_postcompose. rewrite <- transportb_precompose.
+      rewrite <- transport_target_postcompose. rewrite <- transport_source_precompose.
       rewrite <- PreAdditive_invrcomp.
       unfold DS2, DS1, DS6, DS5.
       set (tmp := fun i0 : hz => BinDirectSumConeOb
@@ -4468,14 +4442,18 @@ Section mapping_cylinder_KA_iso.
                                   ;; (to_In2 A (to_BinDirectSums
                                                   A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1))
                                                                               (C2 i0)))))))).
-      set (tmp' := @transport_hz_double_section_f_b
+      set (tmp' := @transport_hz_double_section_source_target
                      A (fun i0 : hz => C1 (i0 + 1)) tmp tmp'' _ _ (hzrplusminus i 1)).
-      unfold tmp'' in tmp'. rewrite tmp'. unfold tmp. apply maponpaths.
-      assert (e2 : maponpaths C1 (! hzrminusplus (i + 1) 1) =
-                   maponpaths (λ i0 : hz, C1 (i0 + 1)) (! hzrplusminus i 1)).
+      unfold tmp'' in tmp'. rewrite tmp'. clear tmp'. unfold tmp. clear tmp.
+      clear tmp''. apply maponpaths.
+      rewrite <- transport_source_to_inv. rewrite <- transport_source_to_inv.
+      apply maponpaths. rewrite transport_source_precompose. rewrite transport_source_precompose.
+      apply cancel_postcomposition.
+      assert (e2 : maponpaths C1 (hzrminusplus (i + 1) 1) =
+                   maponpaths (λ i0 : hz, C1 (i0 + 1)) (hzrplusminus i 1)).
       {
-        assert (e3 : maponpaths (λ i0 : hz, C1 (i0 + 1)) (! hzrplusminus i 1) =
-                     maponpaths C1 (maponpaths (fun i0 : hz => i0 + 1) (! hzrplusminus i 1))).
+        assert (e3 : maponpaths (λ i0 : hz, C1 (i0 + 1)) (hzrplusminus i 1) =
+                     maponpaths C1 (maponpaths (fun i0 : hz => i0 + 1) (hzrplusminus i 1))).
         {
           induction (hzrplusminus i 1). apply idpath.
         }
@@ -4485,12 +4463,13 @@ Section mapping_cylinder_KA_iso.
     }
     cbn in e1. cbn. rewrite <- e1. clear e1. use to_rrw.
     (* Use similar technique as above *)
-    rewrite transportf_postcompose. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
+    rewrite transport_target_postcompose. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
     rewrite <- assoc. apply cancel_precomposition.
     rewrite <- PreAdditive_invlcomp. rewrite PreAdditive_invrcomp. apply cancel_precomposition.
-    rewrite <- transportf_postcompose. rewrite <- transportb_precompose.
+    rewrite <- transport_target_postcompose. rewrite <- transport_source_precompose.
     rewrite <- PreAdditive_invrcomp.
-    unfold DS2, DS1, DS6, DS5. rewrite transportf_to_inv. rewrite transportb_to_inv.
+    unfold DS2, DS1, DS6, DS5.
+    rewrite transport_target_to_inv. rewrite transport_source_to_inv.
     rewrite inv_inv_eq.
     set (tmp := fun i0 : hz => BinDirectSumConeOb
                               A (to_BinDirectSums A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1))
@@ -4499,15 +4478,17 @@ Section mapping_cylinder_KA_iso.
                      (to_In1 A (to_BinDirectSums A (C1 (i0 + 1)) (C2 i0)))
                        ;; (to_In2 A (to_BinDirectSums
                                        A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1)) (C2 i0)))))).
-    set (tmp' := @transport_hz_double_section_f_b
+    set (tmp' := @transport_hz_double_section_source_target
                    A (fun i0 : hz => C1 (i0 + 1)) tmp tmp'' _ _ (hzrplusminus i 1)).
     unfold tmp'' in tmp'.
-    rewrite tmp'. unfold tmp. apply maponpaths.
-    assert (e2 : maponpaths C1 (! hzrminusplus (i + 1) 1) =
-                 maponpaths (λ i0 : hz, C1 (i0 + 1)) (! hzrplusminus i 1)).
+    rewrite tmp'. clear tmp'. unfold tmp. clear tmp. clear tmp''. apply maponpaths.
+    rewrite transport_source_precompose. rewrite transport_source_precompose.
+    apply cancel_postcomposition.
+    assert (e2 : maponpaths C1 (hzrminusplus (i + 1) 1) =
+                 maponpaths (λ i0 : hz, C1 (i0 + 1)) (hzrplusminus i 1)).
     {
-      assert (e3 : maponpaths (λ i0 : hz, C1 (i0 + 1)) (! hzrplusminus i 1) =
-                   maponpaths C1 (maponpaths (fun i0 : hz => i0 + 1) (! hzrplusminus i 1))).
+      assert (e3 : maponpaths (λ i0 : hz, C1 (i0 + 1)) (hzrplusminus i 1) =
+                   maponpaths C1 (maponpaths (fun i0 : hz => i0 + 1) (hzrplusminus i 1))).
       {
         induction (hzrplusminus i 1). apply idpath.
         }

--- a/UniMath/CategoryTheory/Complexes.v
+++ b/UniMath/CategoryTheory/Complexes.v
@@ -10,6 +10,11 @@
  - Precategory of complexes over an abelian category is abelian [complexes_abelian]
  - Homotopies and construction of K(A), the naive homotopy category
  - Translation functor
+  - Translation functor C(A) -> C(A)
+  - Translation functor K(A) -> K(A)
+ - Mapping cone
+ - Mapping cylinder
+ - Let f : X -> Y be a morphism of complexes, then Y is isomorphic to Cyl(f) in K(A)
 *)
 Require Import UniMath.Foundations.Basics.UnivalenceAxiom.
 Require Import UniMath.Foundations.Basics.PartD.
@@ -49,6 +54,8 @@ Require Import UniMath.CategoryTheory.AbelianToAdditive.
 Require Import UniMath.CategoryTheory.AdditiveFunctors.
 
 
+Unset Kernel Term Sharing.
+
 Open Scope hz_scope.
 Local Opaque hz isdecrelhzeq hzplus iscommrngops ZeroArrow.
 
@@ -81,21 +88,21 @@ Section def_complexes.
 
   (** Complex *)
   Definition Complex : UU :=
-    Σ D' : (Σ D : (Π i : hz, ob A), (Π i : hz, A⟦D i, D (hzplus i 1)⟧)),
-           Π i : hz, (pr2 D' i) ;; (pr2 D' (hzplus i 1)) = ZeroArrow (Additive.to_Zero A) _ _.
+    Σ D' : (Σ D : (Π i : hz, ob A), (Π i : hz, A⟦D i, D (i + 1)⟧)),
+           Π i : hz, (pr2 D' i) ;; (pr2 D' (i + 1)) = ZeroArrow (Additive.to_Zero A) _ _.
 
-  Definition mk_Complex (D : Π i : hz, ob A) (D' : Π i : hz, A⟦D i, D (hzplus i 1)⟧)
-             (D'' : Π i : hz, (D' i) ;; (D' (hzplus i 1)) = ZeroArrow (Additive.to_Zero A) _ _) :
+  Definition mk_Complex (D : Π i : hz, ob A) (D' : Π i : hz, A⟦D i, D (i + 1)⟧)
+             (D'' : Π i : hz, (D' i) ;; (D' (i + 1)) = ZeroArrow (Additive.to_Zero A) _ _) :
     Complex := ((D,,D'),,D'').
 
   (** Accessor functions *)
   Definition Complex_Funclass (C : Complex) : hz -> ob A := pr1 (pr1 C).
   Coercion Complex_Funclass : Complex >-> Funclass.
 
-  Definition Diff (C : Complex) (i : hz) : A⟦C i, C (hzplus i 1)⟧ := pr2 (pr1 C) i.
+  Definition Diff (C : Complex) (i : hz) : A⟦C i, C (i + 1)⟧ := pr2 (pr1 C) i.
 
-  Definition CEq (C : Complex) (i : hz) :
-    (Diff C i) ;; (Diff C (hzplus i 1)) = ZeroArrow (Additive.to_Zero A) _ _ := pr2 C i.
+  Definition DSq (C : Complex) (i : hz) :
+    (Diff C i) ;; (Diff C (i + 1)) = ZeroArrow (Additive.to_Zero A) _ _ := pr2 C i.
 
   (** Zero Complex *)
   Definition ZeroComplex : Complex.
@@ -118,8 +125,8 @@ Section def_complexes.
     cbn.
     rewrite BinDirectSumIndArComp.
     unfold BinDirectSumIndAr.
-    rewrite (CEq C1 i). rewrite ZeroArrow_comp_right.
-    rewrite (CEq C2 i). rewrite ZeroArrow_comp_right.
+    rewrite (DSq C1 i). rewrite ZeroArrow_comp_right.
+    rewrite (DSq C2 i). rewrite ZeroArrow_comp_right.
     apply pathsinv0.
     use ToBinDirectSumUnique.
     - apply ZeroArrow_comp_left.
@@ -143,15 +150,14 @@ Section def_complexes.
     Morphism C1 C2 := tpair _ Mors Comm.
 
   (** Accessor functions *)
-  Definition MMor {C1 C2 : Complex} (M : Morphism C1 C2) (i : hz) : A⟦C1 i, C2 i⟧ :=
-    pr1 M i.
+  Definition MMor {C1 C2 : Complex} (M : Morphism C1 C2) (i : hz) : A⟦C1 i, C2 i⟧ := pr1 M i.
+  Coercion MMor : Morphism >-> Funclass.
 
   Definition MComm {C1 C2 : Complex} (M : Morphism C1 C2) (i : hz) :
-    (MMor M i) ;; (Diff C2 i) = (Diff C1 i) ;; (MMor M (i + 1)) := pr2 M i.
+    (M i) ;; (Diff C2 i) = (Diff C1 i) ;; (M (i + 1)) := pr2 M i.
 
   (** A lemma to show that two morphisms are the same *)
-  Lemma MorphismEq {C1 C2 : Complex} (M1 M2 : Morphism C1 C2)
-        (H : Π i : hz, MMor M1 i = MMor M2 i) : M1 = M2.
+  Lemma MorphismEq {C1 C2 : Complex} (M1 M2 : Morphism C1 C2) (H : Π i : hz, M1 i = M2 i) : M1 = M2.
   Proof.
     use total2_paths.
     - use funextsec. intros i. exact (H i).
@@ -159,7 +165,7 @@ Section def_complexes.
   Qed.
 
   Lemma MorphismEq' {C1 C2 : Complex} (M1 M2 : Morphism C1 C2) (H : M1 = M2) :
-    Π i : hz, MMor M1 i = MMor M2 i.
+    Π i : hz, M1 i = M2 i.
   Proof.
     induction H.
     intros i.
@@ -231,9 +237,7 @@ Section def_complexes.
 
   (** Composition of morphisms *)
   Local Lemma MorphismCompComm {C1 C2 C3 : Complex} (M1 : Morphism C1 C2) (M2 : Morphism C2 C3)
-        (i : hz) :
-    (MMor M1 i) ;; (MMor M2 i) ;; (Diff C3 i) =
-    (Diff C1 i) ;; (MMor M1 (i + 1) ;; MMor M2 (i + 1)).
+        (i : hz) : (M1 i) ;; (M2 i) ;; (Diff C3 i) = (Diff C1 i) ;; (M1 (i + 1) ;; M2 (i + 1)).
   Proof.
     rewrite assoc.
     rewrite <- (MComm M1).
@@ -246,7 +250,7 @@ Section def_complexes.
     Morphism C1 C3.
   Proof.
     use mk_Morphism.
-    - intros i. exact ((MMor M1 i) ;; (MMor M2 i)).
+    - intros i. exact ((M1 i) ;; (M2 i)).
     - intros i. exact (MorphismCompComm M1 M2 i).
   Defined.
 
@@ -416,8 +420,8 @@ Section def_complexes.
 
   (** Additition of morphisms is pointwise addition *)
   Local Lemma MorphismOpComm {C1 C2 : Complex} (M1 M2 : Morphism C1 C2)  (i : hz) :
-    (to_binop (C1 i) (C2 i) (MMor M1 i) (MMor M2 i)) ;; (Diff C2 i) =
-    (Diff C1 i) ;; (to_binop (C1 (i + 1)) (C2 (i + 1)) (MMor M1 (i + 1)) (MMor M2 (i + 1))).
+    (to_binop (C1 i) (C2 i) (M1 i) (M2 i)) ;; (Diff C2 i) =
+    (Diff C1 i) ;; (to_binop (C1 (i + 1)) (C2 (i + 1)) (M1 (i + 1)) (M2 (i + 1))).
   Proof.
     rewrite to_postmor_linear'. rewrite to_premor_linear'.
     rewrite (MComm M1 i). rewrite (MComm M2 i). apply idpath.
@@ -426,7 +430,7 @@ Section def_complexes.
   Definition MorphismOp {C1 C2 : Complex} (M1 M2 : Morphism C1 C2) : Morphism C1 C2.
   Proof.
     use mk_Morphism.
-    - intros i. exact (to_binop _ _ (MMor M1 i) (MMor M2 i)).
+    - intros i. exact (to_binop _ _ (M1 i) (M2 i)).
     - intros i. exact (MorphismOpComm M1 M2 i).
   Defined.
 
@@ -453,8 +457,7 @@ Section def_complexes.
   Qed.
 
   Local Lemma MorphismOp_inv_comm {C1 C2 : Complex} (M : Morphism C1 C2) (i : hz) :
-    (to_inv (C1 i) (C2 i) (MMor M i)) ;; (Diff C2 i) =
-    (Diff C1 i) ;; (to_inv (C1 (i + 1)) (C2 (i + 1)) (MMor M (i + 1))).
+    (to_inv (M i)) ;; (Diff C2 i) = (Diff C1 i) ;; (to_inv (M (i + 1))).
   Proof.
     rewrite <- PreAdditive_invlcomp.
     rewrite <- PreAdditive_invrcomp.
@@ -467,7 +470,7 @@ Section def_complexes.
   Definition MorphismOp_inv {C1 C2 : Complex} (M : Morphism C1 C2) : Morphism C1 C2.
   Proof.
     use mk_Morphism.
-    - intros i. exact (to_inv (C1 i) (C2 i) (MMor M i)).
+    - intros i. exact (to_inv (M i)).
     - intros i. exact (MorphismOp_inv_comm M i).
   Defined.
 
@@ -527,9 +530,9 @@ Section def_complexes.
         (i : hz) :
     let B1 := to_BinDirectSums A (C1 i) (C2 i) in
     let B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1)) in
-    (FromBinDirectSum A B1 (MMor f i) (MMor g i)) ;; (Diff D i) =
+    (FromBinDirectSum A B1 (f i) (g i)) ;; (Diff D i) =
     (BinDirectSumIndAr A (Diff C1 i) (Diff C2 i) B1 B2)
-      ;; (FromBinDirectSum A B2 (MMor f (i + 1)) (MMor g (i + 1))).
+      ;; (FromBinDirectSum A B2 (f (i + 1)) (g (i + 1))).
   Proof.
     cbn.
     set (B1 := to_BinDirectSums A (C1 i) (C2 i)).
@@ -554,7 +557,7 @@ Section def_complexes.
     Morphism (DirectSumComplex C1 C2) D.
   Proof.
     use mk_Morphism.
-    - intros i. exact (FromBinDirectSum A _ (MMor f i) (MMor g i)).
+    - intros i. exact (FromBinDirectSum A _ (f i) (g i)).
     - intros i. exact (DirectSumMorOut_comm f g i).
   Defined.
 
@@ -562,9 +565,9 @@ Section def_complexes.
         (i : hz) :
     let B1 := to_BinDirectSums A (C1 i) (C2 i) in
     let B2 := to_BinDirectSums A (C1 (i + 1)) (C2 (i + 1)) in
-    (ToBinDirectSum A B1 (MMor f i) (MMor g i))
+    (ToBinDirectSum A B1 (f i) (g i))
       ;; (BinDirectSumIndAr A (Diff C1 i) (Diff C2 i) B1 B2) =
-    (Diff D i) ;; (ToBinDirectSum A B2 (MMor f (i + 1)) (MMor g (i + 1))).
+    (Diff D i) ;; (ToBinDirectSum A B2 (f (i + 1)) (g (i + 1))).
   Proof.
     intros B1 B2.
     rewrite BinDirectSumIndArEq1.
@@ -587,7 +590,7 @@ Section def_complexes.
     Morphism D (DirectSumComplex C1 C2).
   Proof.
     use mk_Morphism.
-    - intros i. exact (ToBinDirectSum A _ (MMor f i) (MMor g i)).
+    - intros i. exact (ToBinDirectSum A _ (f i) (g i)).
     - intros i. exact (DirectSumMorIn_comm f g i).
   Defined.
 
@@ -801,7 +804,7 @@ Section def_complexes.
         -- apply (fromempty (hzeqissi e'')).
         -- induction (isdecrelhzeq (i + 1) (i + 1 + 1)) as [e''' | n'''].
            ++ apply (fromempty (hzeqisi e''')).
-           ++ rewrite <- assoc. rewrite (CEq C i). rewrite ZeroArrow_comp_left.
+           ++ rewrite <- assoc. rewrite (DSq C i). rewrite ZeroArrow_comp_left.
               apply ZeroArrow_comp_right.
       * induction (isdecrelhzeq i (i0 + 1)) as [e'' | n''].
         -- rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_left. apply idpath.
@@ -819,7 +822,7 @@ Section def_complexes.
   Defined.
 
   Lemma FromComplex2FromObject_Eq1 {a : ob A} {C : Complex} {i : hz} (i0 : hz) (g : a --> (C i)) :
-    FromComplex2FromObject_mors g i0 = MMor (FromComplex2FromObject g) i0.
+    FromComplex2FromObject_mors g i0 = (FromComplex2FromObject g) i0.
   Proof.
     apply idpath.
   Qed.
@@ -887,7 +890,7 @@ Section def_complexes.
                       | idpath _ => f
                       end).
              rewrite <- (ZeroArrow_comp_left _ _ _ _ _ mor). unfold mor. clear mor.
-             apply cancel_postcomposition. rewrite e''. apply (! (CEq C i0)).
+             apply cancel_postcomposition. rewrite e''. apply (! (DSq C i0)).
           -- apply fromempty. apply n'''. apply (hzrminusplus' i 1).
         * induction (isdecrelhzeq (i - 1 + 1) (i0 + 1)) as [e''' | n'''].
           -- apply (fromempty (n (hzplusrcan (i - 1) i0 1 e'''))).
@@ -904,7 +907,7 @@ Section def_complexes.
   Defined.
 
   Lemma ToComplex2FromObject_Eq1 {a : ob A} {C : Complex} {i : hz} (i0 : hz) (g : (C i) --> a) :
-    ToComplex2FromObject_mors g i0 = MMor (ToComplex2FromObject g) i0.
+    ToComplex2FromObject_mors g i0 = (ToComplex2FromObject g) i0.
   Proof.
     apply idpath.
   Qed.
@@ -1284,8 +1287,8 @@ Section complexes_abelian.
   (** *** Construction of the kernel object *)
 
   Local Lemma ComplexPreCat_Kernel_moreq {Y Z : Complex (AbelianToAdditive A hs)} (g : Morphism Y Z)
-        (i : hz) : (KernelArrow (Kernel (MMor g i))) ;; (Diff Y i) ;; (MMor g (i + 1)) =
-                   ZeroArrow (@to_Zero A) (Kernel (MMor g i)) (Z (i + 1)).
+        (i : hz) : (KernelArrow (Kernel (g i))) ;; (Diff Y i) ;; (g (i + 1)) =
+                   ZeroArrow (@to_Zero A) (Kernel (g i)) (Z (i + 1)).
   Proof.
     rewrite <- assoc. cbn. set (tmp := MComm g i). cbn in tmp. rewrite <- tmp. clear tmp.
     rewrite assoc. rewrite KernelCompZero. apply ZeroArrow_comp_left.
@@ -1293,17 +1296,17 @@ Section complexes_abelian.
 
   Local Lemma ComplexPreCat_Kernel_comp {Y Z : Complex (AbelianToAdditive A hs)} (g : Morphism Y Z)
         (i : hz) :
-    (KernelIn (@to_Zero A) (Kernel (MMor g (i + 1))) (Kernel (MMor g i))
-              ((KernelArrow (Kernel (MMor g i))) ;; (Diff Y i))
+    (KernelIn (@to_Zero A) (Kernel (g (i + 1))) (Kernel (g i))
+              ((KernelArrow (Kernel (g i))) ;; (Diff Y i))
               (ComplexPreCat_Kernel_moreq g i))
-      ;; (KernelIn (@to_Zero A) (Kernel (MMor g (i + 1 + 1))) (Kernel (MMor g (i + 1)))
-                   ((KernelArrow (Kernel (MMor g (i + 1)))) ;; (Diff Y (i + 1)))
+      ;; (KernelIn (@to_Zero A) (Kernel (g (i + 1 + 1))) (Kernel (g (i + 1)))
+                   ((KernelArrow (Kernel (g (i + 1)))) ;; (Diff Y (i + 1)))
                    (ComplexPreCat_Kernel_moreq g (i + 1))) =
-    ZeroArrow (@to_Zero A) (Kernel (MMor g i)) (Kernel (MMor g (i + 1 + 1))).
+    ZeroArrow (@to_Zero A) (Kernel (g i)) (Kernel (g (i + 1 + 1))).
   Proof.
     apply KernelArrowisMonic. rewrite ZeroArrow_comp_left.
     rewrite <- assoc. rewrite KernelCommutes. rewrite assoc. rewrite KernelCommutes.
-    rewrite <- assoc. set (tmp := CEq _ Y i). cbn in tmp. rewrite tmp. clear tmp.
+    rewrite <- assoc. set (tmp := DSq _ Y i). cbn in tmp. rewrite tmp. clear tmp.
     rewrite ZeroArrow_comp_right. apply idpath.
   Qed.
 
@@ -1311,9 +1314,9 @@ Section complexes_abelian.
     ComplexPreCat (AbelianToAdditive A hs).
   Proof.
     use mk_Complex.
-    - intros i. exact (Kernel (MMor g i)).
+    - intros i. exact (Kernel (g i)).
     - intros i. cbn. use KernelIn.
-      + exact (KernelArrow (Kernel (MMor g i)) ;; Diff Y i).
+      + exact (KernelArrow (Kernel (g i)) ;; Diff Y i).
       + exact (ComplexPreCat_Kernel_moreq g i).
     - intros i. exact (ComplexPreCat_Kernel_comp g i).
   Defined.
@@ -1343,7 +1346,7 @@ Section complexes_abelian.
     (h : Morphism w X) (i : hz) :
     let Z := Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
     MorphismComp h g = ZeroArrow Z w Y ->
-    (MMor h i) ;; (MMor g i) = ZeroArrow to_Zero (w i) (Y i).
+    (h i) ;; (g i) = ZeroArrow to_Zero (w i) (Y i).
   Proof.
     intros Z H.
     set (tmp := MorphismEq' _ (MorphismComp h g) (ZeroArrow Z _ _) H i). cbn in tmp.
@@ -1362,7 +1365,7 @@ Section complexes_abelian.
     intros H.
     use mk_Morphism.
     - intros i. cbn. use KernelIn.
-      + exact (MMor h i).
+      + exact (h i).
       + apply (ComplexPreCat_KernelIn_comp g h i H).
     - intros i. cbn.
       apply KernelArrowisMonic.
@@ -1415,8 +1418,8 @@ Section complexes_abelian.
   (** *** Cokernel complex *)
   Local Lemma ComplexPreCat_Cokernel_comm {Y Z : Complex (AbelianToAdditive A hs)}
         (g : Morphism Y Z) (i : hz) :
-    (MMor g i) ;; ((Diff Z i) ;; (CokernelArrow (Cokernel (MMor g (i + 1))))) =
-    ZeroArrow (@to_Zero A) (Y i) (Cokernel (MMor g (i + 1))).
+    (g i) ;; ((Diff Z i) ;; (CokernelArrow (Cokernel (g (i + 1))))) =
+    ZeroArrow (@to_Zero A) (Y i) (Cokernel (g (i + 1))).
   Proof.
     rewrite assoc. cbn. set (tmp := MComm g i). cbn in tmp. rewrite tmp. clear tmp.
     rewrite <- assoc. rewrite CokernelCompZero. apply ZeroArrow_comp_right.
@@ -1424,17 +1427,17 @@ Section complexes_abelian.
 
   Local Lemma ComplexPreCat_Cokernel_comp {Y Z : Complex (AbelianToAdditive A hs)}
         (g : Morphism Y Z) (i : hz) :
-    (CokernelOut (@to_Zero A) (Cokernel (MMor g i)) (Cokernel (MMor g (i + 1)))
-                 ((Diff Z i) ;; (CokernelArrow (Cokernel (MMor g (i + 1)))))
+    (CokernelOut (@to_Zero A) (Cokernel (g i)) (Cokernel (g (i + 1)))
+                 ((Diff Z i) ;; (CokernelArrow (Cokernel (g (i + 1)))))
                  (ComplexPreCat_Cokernel_comm g i))
-      ;; (CokernelOut (@to_Zero A) (Cokernel (MMor g (i + 1))) (Cokernel (MMor g (i + 1 + 1)))
-                      ((Diff Z (i + 1)) ;; (CokernelArrow (Cokernel (MMor g (i + 1 + 1)))))
+      ;; (CokernelOut (@to_Zero A) (Cokernel (g (i + 1))) (Cokernel (g (i + 1 + 1)))
+                      ((Diff Z (i + 1)) ;; (CokernelArrow (Cokernel (g (i + 1 + 1)))))
                       (ComplexPreCat_Cokernel_comm g (i + 1))) =
-    ZeroArrow (@to_Zero A) (Cokernel (MMor g i)) (Cokernel (MMor g (i + 1 + 1))).
+    ZeroArrow (@to_Zero A) (Cokernel (g i)) (Cokernel (g (i + 1 + 1))).
   Proof.
     apply CokernelArrowisEpi. rewrite ZeroArrow_comp_right.
     rewrite assoc. rewrite CokernelCommutes. rewrite <- assoc. rewrite CokernelCommutes.
-    rewrite assoc. set (tmp := CEq _ Z i). cbn in tmp. cbn. rewrite tmp. clear tmp.
+    rewrite assoc. set (tmp := DSq _ Z i). cbn in tmp. cbn. rewrite tmp. clear tmp.
     rewrite ZeroArrow_comp_left. apply idpath.
   Qed.
 
@@ -1442,9 +1445,9 @@ Section complexes_abelian.
     ComplexPreCat (AbelianToAdditive A hs).
   Proof.
     use mk_Complex.
-    - intros i. exact (Cokernel (MMor g i)).
+    - intros i. exact (Cokernel (g i)).
     - intros i. cbn. use CokernelOut.
-      + exact ((Diff Z i) ;; (CokernelArrow (Cokernel (MMor g (i + 1))))).
+      + exact ((Diff Z i) ;; (CokernelArrow (Cokernel (g (i + 1))))).
       + exact (ComplexPreCat_Cokernel_comm g i).
     - intros i. exact (ComplexPreCat_Cokernel_comp g i).
   Defined.
@@ -1464,8 +1467,7 @@ Section complexes_abelian.
         (h : (ComplexPreCat (AbelianToAdditive A hs))⟦Z, w⟧)
         (i : hz) :
     let Z0 := Additive.to_Zero (ComplexPreCat_Additive (AbelianToAdditive A hs)) in
-    g ;; h = ZeroArrow Z0 Y w ->
-    (MMor g i) ;; (MMor h i) = ZeroArrow (@to_Zero A) (Y i) (w i).
+    g ;; h = ZeroArrow Z0 Y w -> (MMor g i) ;; (MMor h i) = ZeroArrow (@to_Zero A) (Y i) (w i).
   Proof.
     intros Z0. cbn. intros H. set (tmp := MorphismEq' _ (g ;; h) _ H i). cbn in tmp.
     rewrite tmp. apply ZeroArrowEq.
@@ -1574,7 +1576,7 @@ Section complexes_abelian.
   Proof.
     apply CokernelArrowisEpi. rewrite assoc. rewrite CokernelCommutes.
     rewrite <- assoc. rewrite CokernelCommutes. rewrite assoc.
-    cbn. set (tmp := CEq _ y i). cbn in tmp. rewrite tmp. clear tmp.
+    cbn. set (tmp := DSq _ y i). cbn in tmp. rewrite tmp. clear tmp.
     rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_right.
     apply idpath.
   Qed.
@@ -1752,7 +1754,7 @@ Section complexes_abelian.
   Proof.
     apply KernelArrowisMonic. rewrite <- assoc. rewrite KernelCommutes.
     rewrite assoc. rewrite KernelCommutes. rewrite <- assoc.
-    cbn. set (tmp := CEq _ x i). cbn in tmp. rewrite tmp. clear tmp.
+    cbn. set (tmp := DSq _ x i). cbn in tmp. rewrite tmp. clear tmp.
     rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left.
     apply idpath.
   Qed.
@@ -1960,6 +1962,62 @@ Section transport_diffs.
 
 End transport_diffs.
 
+Section transport_section'.
+
+  Variable C : precategory.
+
+  Lemma transport_mor_b_f (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f i, f (i + n)⟧) (i i' : hz)
+        (e1 : i = i') :
+    H i' = transportb (fun (x : ob C) => C⟦x, f (i' + n)⟧) (maponpaths f (! e1))
+                      (transportf (precategory_morphisms (f i))
+                                  (maponpaths f (hzplusladd i i' n e1)) (H i)).
+  Proof.
+    induction e1. apply idpath.
+  Qed.
+
+  Lemma transport_mor_f_b (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f i, f (i + n)⟧) (i i' : hz)
+        (e1 : i = i') :
+    H i' = transportf (precategory_morphisms (f i'))
+                      (maponpaths f (hzplusladd i i' n e1))
+                      (transportb (fun (x : ob C) => C⟦x, f (i + n)⟧) (maponpaths f (! e1)) (H i)).
+  Proof.
+    induction e1. apply idpath.
+  Qed.
+
+  Lemma transport_section' (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f i, f (i + n)⟧) (i i' : hz)
+    (e1 : i = i') :
+    transportf (precategory_morphisms (f i)) (maponpaths f (hzplusladd i i' n e1)) (H i) =
+    transportb (fun (x : ob C) => C⟦x, f (i' + n)⟧) (maponpaths f e1) (H i').
+  Proof.
+    induction e1. apply idpath.
+  Qed.
+
+  Lemma transport_section'' (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f (i + n), f i⟧) (i i' : hz)
+    (e1 : i + n = i' + n) (e2 : i = i') :
+    transportf (precategory_morphisms (f (i + n))) (maponpaths f e2) (H i) =
+    transportb (fun (x : ob C) => C⟦x, f i'⟧) (maponpaths f e1) (H i').
+  Proof.
+    induction e2. assert (e : e1 = idpath _) by apply isasethz. rewrite e. clear e. apply idpath.
+  Qed.
+
+  Lemma transport_double_section (f f' : hz -> ob C) (H : Π (i : hz), C⟦f i, f' i⟧)
+        (i i' : hz) (e : i = i') :
+    transportf (precategory_morphisms (f i)) (maponpaths f' e) (H i) =
+    transportb (fun (x : ob C) => C⟦x, f' i'⟧) (maponpaths f e) (H i').
+  Proof.
+    induction e. apply idpath.
+  Qed.
+
+  Lemma transport_hz_double_section_f_b (f f' : hz -> ob C) (H : Π (i : hz), C⟦f i, f' i⟧)
+        (i i' : hz) (e : i = i') :
+    H i' = transportf (precategory_morphisms (f i')) (maponpaths f' e)
+                      (transportb (fun (x : ob C) => C⟦x, f' i⟧) (maponpaths f (! e)) (H i)).
+  Proof.
+    induction e. apply idpath.
+  Qed.
+
+End transport_section'.
+
 
 (** * Homotopies of complexes and K(A), the naive homotopy category of A. *)
 (** ** Introduction
@@ -2012,14 +2070,14 @@ Section complexes_homotopies.
                              Diff C2 i) = ZeroArrow (Additive.to_Zero A) _ _).
     {
       induction (hzrminusplus i 1). cbn. unfold idfun. rewrite <- assoc.
-      rewrite (@CEq A C2 (i - 1)). apply ZeroArrow_comp_right.
+      rewrite (@DSq A C2 (i - 1)). apply ZeroArrow_comp_right.
     }
     rewrite e0. clear e0.
     assert (e1 : (Diff C1 i ;; transportf (precategory_morphisms (C1 (i + 1)))
                        (maponpaths C2 (hzrplusminus (i + 1) 1)) (Diff C1 (i + 1) ;; H (i + 1 + 1)))
                  = ZeroArrow (Additive.to_Zero A) _ _).
     {
-      rewrite <- transportf_postcompose. rewrite assoc. rewrite (@CEq A C1 i).
+      rewrite <- transportf_postcompose. rewrite assoc. rewrite (@DSq A C1 i).
       rewrite ZeroArrow_comp_left. apply transportf_ZeroArrow.
     }
     rewrite e1. clear e1.
@@ -2166,9 +2224,9 @@ Section complexes_homotopies.
                                  (maponpaths C2 (hzrplusminus i 1))
                                  (grinv (to_abgrop (C1 i) (C2 (i + 1 - 1)))
                                         (Diff C1 i ;; homot (i + 1)))) =
-                     to_inv _ _ (transportf (precategory_morphisms (C1 i))
-                                            (maponpaths C2 (hzrplusminus i 1))
-                                            (Diff C1 i ;; homot (i + 1)))).
+                     to_inv (transportf (precategory_morphisms (C1 i))
+                                        (maponpaths C2 (hzrplusminus i 1))
+                                        (Diff C1 i ;; homot (i + 1)))).
         {
           unfold to_inv. cbn. induction (hzrplusminus i 1). apply idpath.
         }
@@ -2176,9 +2234,9 @@ Section complexes_homotopies.
         assert (e1 : (transportf (precategory_morphisms (C1 i)) (maponpaths C2 (hzrminusplus i 1))
                                  (grinv (to_abgrop (C1 i) (C2 (i - 1)))
                                         (homot i) ;; Diff C2 (i - 1))) =
-                     to_inv _ _ (transportf (precategory_morphisms (C1 i))
-                                            (maponpaths C2 (hzrminusplus i 1))
-                                            (homot i ;; Diff C2 (i - 1)))).
+                     to_inv (transportf (precategory_morphisms (C1 i))
+                                        (maponpaths C2 (hzrminusplus i 1))
+                                        (homot i ;; Diff C2 (i - 1)))).
         {
           unfold to_inv. cbn. induction (hzrminusplus i 1). cbn. unfold idfun.
           set (tmp := @PreAdditive_invlcomp A (C1 i) (C2 (i - 1)) (C2 (i - 1 + 1))
@@ -2294,10 +2352,41 @@ Section complexes_homotopies.
     apply QuotPrecategoryAdditiveFunctor.
   Defined.
 
-  Lemma ComplexHomotFunctor_issurj {C1 C2 : ComplexPreCat_Additive A} (f : ComplexHomot_Additive⟦C1, C2⟧) :
-    ∥ hfiber (# ComplexHomotFunctor) f ∥.
+  Lemma ComplexHomotFunctor_issurj {C1 C2 : ComplexPreCat_Additive A}
+        (f : ComplexHomot_Additive⟦C1, C2⟧) : ∥ hfiber (# ComplexHomotFunctor) f ∥.
   Proof.
     apply ComplexHomot_Mor_issurj.
+  Qed.
+
+  Lemma ComplexHomotFunctor_rel_mor {C1 C2 : ComplexPreCat_Additive A}
+        (f g : (ComplexPreCat_Additive A)⟦C1, C2⟧) (H : subgrhrel (ComplexHomotSubgrp C1 C2) f g) :
+    # ComplexHomotFunctor f = # ComplexHomotFunctor g.
+  Proof.
+    apply abgrquotpr_rel_image. apply H.
+  Qed.
+
+  Lemma ComplexHomotFunctor_rel_mor' {C1 C2 : ComplexPreCat_Additive A}
+        (f g : (ComplexPreCat_Additive A)⟦C1, C2⟧) (H : ComplexHomot C1 C2)
+        (H' : to_binop _ _ f (to_inv g) = ComplexHomotMorphism H) :
+    # ComplexHomotFunctor f = # ComplexHomotFunctor g.
+  Proof.
+    apply ComplexHomotFunctor_rel_mor.
+    intros P X. apply X. clear X P. use tpair.
+    - cbn. use tpair.
+      + exact (ComplexHomotMorphism H).
+      + intros P X. apply X. clear P X. use tpair.
+        * exact H.
+        * apply idpath.
+    - cbn. apply pathsinv0. apply H'.
+  Qed.
+
+  Lemma ComplexHomotFunctor_mor_rel {C1 C2 : ComplexPreCat_Additive A}
+        (f g : (ComplexPreCat_Additive A)⟦C1, C2⟧)
+        (H : # ComplexHomotFunctor f = # ComplexHomotFunctor g) :
+    subgrhrel (ComplexHomotSubgrp C1 C2) f g.
+  Proof.
+    use (@abgrquotpr_rel_paths _ (binopeqrel_subgr_eqrel (ComplexHomotSubgrp C1 C2))).
+    apply H.
   Qed.
 
 End complexes_homotopies.
@@ -2305,76 +2394,1486 @@ End complexes_homotopies.
 
 (** * Translation funtor for C(A) and for K(A) *)
 (** ** Introduction
-   We define the translation functor T : C(A) -> C(A), which sends a complex (i ↦ X^i) to
-   (i ↦ X^{i+1}). On morphisms, T maps f to -f.
+We define the translation functor T : C(A) -> C(A) for complexes, and a translation functor
+T' : K(A) -> K(A). The functor T' is constructed so that we have the following commutative
+diagram
+                            C(A) ---T---> C(A)
+                             |             |
+                            K(A) ---T'--> K(A)
+Here the vertical functors are given by [ComplexHomotFunctor]. The functor T sends a complex
+      # ... -> X^{i-1} --(d^{i-1})--> X^i --(d^i)--> X^{i+1} -> ... #
+      $ ... -> X^{i-1} --(d^{i-1})--> X^i --(d^i)--> X^{i+1} -> ... $
+to the complex
+      # ... -> X^i --(-d^i)--> X^{i+1} --(-d^{i+1})--> X^{i+2} -> ... #
+      $ ... -> X^i --(-d^i)--> X^{i+1} --(-d^{i+1})--> X^{i+2} -> ... $
+More precicely, on objects # X^i ↦ X^{i+1} # $ X^i ↦ X^{i+1} $ and differentials
+# d^i_X ↦ -d^{i+1}_X # $ d^i_X ↦ -d^{i+1}_X $. A morphism f : X -> Y is mapped by
+# f^i ↦ f^{i+1} # $ f^i ↦ f^{i+1} $. We also construct the inverse translation T^{-1} which is the
+unique functor such that T ∘ T^{-1} = id and T^{-1} ∘ T = id (This is has not been proven yet!).
+All the functors T, T^{-1}, and T' are additive.
+
+The functor T : C(A) -> C(A) is constructed in [TranslationFunctor]. It is shown to be additive in
+[TranslationFunctor_Additive]. In [TranslationFunctorPreservesHomotopies] we show that T preserves
+homotopies, that is if f is homotopic to g, then T(f) is homotopic to T(g). In
+[InvTranslationFunctor] we construct T^{-1}.
 *)
 Section translation_functor.
 
   Variable A : Additive.
 
+
+  (** ** Translation functor for C(A) *)
+
   Local Lemma TranslationFunctor_comp (C : Complex A) (i : hz) :
-    (to_inv (C (i + 1)) (C (i + 1 + 1)) (Diff C (i + 1)))
-      ;; (to_inv (C (i + 1 + 1)) (C (i + 1 + 1 + 1)) (Diff C (i + 1 + 1))) =
-  ZeroArrow (Additive.to_Zero A) (C (i + 1)) (C (i + 1 + 1 + 1)).
+    (to_inv (Diff C (i + 1))) ;; (to_inv (Diff C (i + 1 + 1))) =
+    ZeroArrow (Additive.to_Zero A) (C (i + 1)) (C (i + 1 + 1 + 1)).
   Proof.
     rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invrcomp.
-    rewrite inv_inv_eq. apply (CEq A C (i + 1)).
+    rewrite inv_inv_eq. apply (DSq A C (i + 1)).
   Qed.
 
-  Local Lemma TranslationFunctor_comm (C1 C2 : Complex A) (f : Morphism C1 C2) (i : hz) :
-    MMor f (i + 1) ;; to_inv (C2 (i + 1)) (C2 (i + 1 + 1)) (Diff C2 (i + 1)) =
-    to_inv (C1 (i + 1)) (C1 (i + 1 + 1)) (Diff C1 (i + 1)) ;; MMor f (i + 1 + 1).
+  Definition TranslationComplex (C : Complex A) : Complex A.
   Proof.
+    use mk_Complex.
+    - intros i. exact (C (i + 1)).
+    - intros i. exact (to_inv (Diff C (i + 1))).
+    - intros i. exact (TranslationFunctor_comp C i).
+  Defined.
+
+  Definition pr11_TranslationComplex (C : Complex A) := pr1( pr1(TranslationComplex C)).
+  Definition DiffTranslationComplex (C : Complex A) (i : hz) :
+    A⟦ pr11_TranslationComplex C i, pr11_TranslationComplex C (i + 1) ⟧ := to_inv (Diff C (i + 1)).
+
+  Lemma DiffTranslationComplex_comp (C : Complex A) (i : hz) :
+    (DiffTranslationComplex C i) ;; (DiffTranslationComplex C (i + 1)) =
+    ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    exact (TranslationFunctor_comp C i).
+  Qed.
+
+  Definition TranslationMorphism_mor {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    A⟦pr11_TranslationComplex C1 i, pr11_TranslationComplex C2 i⟧ := f (i + 1).
+
+  Local Lemma TranslationFunctor_comm {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    (TranslationMorphism_mor f i) ;; (DiffTranslationComplex C2 i) =
+    (DiffTranslationComplex C1 i) ;; (TranslationMorphism_mor f (i + 1)).
+  Proof.
+    unfold DiffTranslationComplex.
     rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invrcomp.
     apply maponpaths. apply (MComm f (i + 1)).
   Qed.
 
-  (* Why Defined. does not terminate? *)
+  Definition TranslationMorphism (C1 C2 : Complex A) (f : Morphism C1 C2) :
+    Morphism (TranslationComplex C1) (TranslationComplex C2) :=
+    mk_Morphism
+      A (TranslationComplex C1) (TranslationComplex C2)
+      (λ i : hz, TranslationMorphism_mor f i) (λ i : hz, TranslationFunctor_comm f i).
+
   Definition TranslationFunctor_data :
     functor_data (ComplexPreCat_Additive A) (ComplexPreCat_Additive A).
   Proof.
+    use mk_functor_data.
+    - intros C. exact (TranslationComplex C).
+    - intros C1 C2 f. exact (TranslationMorphism C1 C2 f).
+  Defined.
+
+  Lemma TranslationFunctor_isfunctor : is_functor TranslationFunctor_data.
+  Proof.
+    split.
+    - intros C. cbn. use MorphismEq. intros i. cbn. apply idpath.
+    - intros C1 C2 C3 f g. cbn. use MorphismEq. intros i. cbn. apply idpath.
+  Qed.
+
+  Definition TranslationFunctor :
+    functor (ComplexPreCat_Additive A) (ComplexPreCat_Additive A).
+  Proof.
+    use mk_functor.
+    - exact TranslationFunctor_data.
+    - exact TranslationFunctor_isfunctor.
+  Defined.
+
+  Definition TranslationFunctor_isAdditive : isAdditiveFunctor TranslationFunctor.
+  Proof.
+    use mk_isAdditiveFunctor.
+    intros C1 C2.
+    split.
+    - intros f g. cbn. use MorphismEq. intros i. cbn. apply idpath.
+    - cbn. use MorphismEq. intros i. apply idpath.
+  Qed.
+
+  Definition TranslationFunctor_Additive :
+    AdditiveFunctor (ComplexPreCat_Additive A) (ComplexPreCat_Additive A).
+  Proof.
+    use mk_AdditiveFunctor.
+    - exact TranslationFunctor.
+    - exact TranslationFunctor_isAdditive.
+  Defined.
+
+  (** *** Translation functor preserves homotopies *)
+  Definition TranslationHomot {C1 C2 : Complex A} (H : ComplexHomot A C1 C2) :
+    ComplexHomot A (TranslationComplex C1) (TranslationComplex C2).
+  Proof.
+    intros i.
+    exact (transportf (precategory_morphisms (C1 (i + 1)))
+                      (maponpaths C2 (hzrplusminus i 1 @ ! hzrminusplus i 1))
+                      (to_inv (H (i + 1)))).
+  Defined.
+
+  Lemma TranslationFunctorHomotopies {C1 C2 : Complex A} (H : ComplexHomot A C1 C2) :
+    ComplexHomotMorphism A (TranslationHomot H) =
+    TranslationMorphism C1 C2 (ComplexHomotMorphism A H).
+  Proof.
+    unfold TranslationHomot. cbn. use MorphismEq. intros i. cbn.
+    induction (hzrminusplus i 1). cbn. rewrite pathscomp0rid. cbn. unfold idfun.
+    rewrite <- PreAdditive_invrcomp. rewrite <- transportf_to_inv.
+    rewrite PreAdditive_invlcomp. rewrite inv_inv_eq.
+    rewrite <- transportf_to_inv. rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invrcomp.
+    rewrite inv_inv_eq.
+    assert (e : (maponpaths (λ i0 : pr1 hz, C2 (i0 + 1)) (hzrplusminus (i - 1 + 1) 1)) =
+                (maponpaths C2 (maponpaths (fun (i0 : hz) => i0 + 1) (hzrplusminus (i - 1 + 1) 1)))).
+    {
+      induction (hzrplusminus (i - 1 + 1) 1). apply idpath.
+    }
+    cbn in e. rewrite e. clear e.
+    assert (e1 : (transportf (precategory_morphisms (C1 (i - 1 + 1 + 1)))
+                             (maponpaths C2 (maponpaths (λ i0 : pr1 hz, i0 + 1)
+                                                        (hzrplusminus (i - 1 + 1) 1)))
+                             ((Diff C1 (i - 1 + 1 + 1))
+                                ;; (transportf
+                                      (precategory_morphisms (C1 (i - 1 + 1 + 1 + 1)))
+                                      (maponpaths C2
+                                                  (hzrplusminus (i - 1 + 1 + 1) 1 @
+                                                                ! hzrminusplus (i - 1 + 1 + 1) 1))
+                                      (H (i - 1 + 1 + 1 + 1)))) =
+                  (transportf (precategory_morphisms (C1 (i - 1 + 1 + 1)))
+                              (maponpaths C2 (hzrplusminus (i - 1 + 1 + 1) 1))
+                              (Diff C1 (i - 1 + 1 + 1) ;; H (i - 1 + 1 + 1 + 1))))).
+    {
+      rewrite transportf_postcompose. rewrite transport_f_f. rewrite <- maponpathscomp0.
+      set (tmp := ((hzrplusminus (i - 1 + 1 + 1) 1
+                                 @ ! hzrminusplus (i - 1 + 1 + 1) 1)
+                     @ maponpaths (λ i0 : pr1 hz, i0 + 1) (hzrplusminus (i - 1 + 1) 1))).
+      assert (ee : tmp = (hzrplusminus (i - 1 + 1 + 1) 1)) by apply isasethz.
+      unfold tmp in ee. cbn in ee. unfold tmp. cbn. rewrite ee. clear ee. clear tmp.
+      induction (hzrplusminus (i - 1 + 1 + 1) 1). cbn. unfold idfun. apply idpath.
+    }
+    cbn in e1. rewrite e1. clear e1. use to_lrw.
+
+    set (tmp := @transport_mor_b_f A C2 1 (Diff C2) _ _ (hzrplusminus (i - 1 + 1) 1)).
+    rewrite tmp. clear tmp. rewrite maponpathsinv0. rewrite transport_compose'.
+    rewrite transportf_postcompose. apply cancel_precomposition.
+    apply transportf_paths. apply maponpaths. apply isasethz.
+  Qed.
+
+  Lemma TranslationFunctorPreservesHomotopies {C1 C2 : Complex A}
+        (f g : (ComplexPreCat_Additive A)⟦C1, C2⟧)
+        (H : subgrhrel (ComplexHomotSubgrp A C1 C2) f g) :
+    subgrhrel (ComplexHomotSubgrp A _ _) (TranslationMorphism C1 C2 f)
+              (TranslationMorphism C1 C2 g).
+  Proof.
+    use (squash_to_prop H). apply propproperty. intros H'. clear H.
+    induction H' as [H1 H2]. induction H1 as [H11 H12]. cbn in H11.
+    use (squash_to_prop H12). apply propproperty. intros H. cbn in H2.
+    induction H as [HH1 HH2].
+    intros P X. apply X. clear X P.
     use tpair.
-    - cbn. intros C.
-      use mk_Complex.
-      + intros i. exact (C (i + 1)).
-      + intros i. exact (to_inv (C (i + 1)) (C (i + 1 + 1)) (Diff C (i + 1))).
-      + intros i. exact (TranslationFunctor_comp C i).
-    - cbn. intros C1 C2 f.
-      use mk_Morphism.
-      + intros i. cbn. exact (MMor f (i + 1)).
-      + intros i. cbn. exact (TranslationFunctor_comm C1 C2 f i).
-        (* Show Proof. This shows the proof term as explained in 7.3.1.3 of reference manual.
-                       The proof term looks ok to me.  *)
-  Abort. (* Defined. *)
+    - use tpair. cbn. exact (TranslationMorphism _ _ H11).
+      intros P X. apply X. clear X P.
+      use tpair.
+      + exact (TranslationHomot HH1).
+      + cbn. rewrite TranslationFunctorHomotopies. rewrite HH2. apply idpath.
+    - cbn. rewrite H2.
+      set (tmp := @AdditiveFunctorLinear (ComplexPreCat_Additive A) (ComplexPreCat_Additive A)
+                                         TranslationFunctor_Additive C1 C2 f (to_inv g)).
+      cbn in tmp.
+      rewrite tmp. clear tmp. apply maponpaths.
+      set (tmp := @AdditiveFunctorInv (ComplexPreCat_Additive A) (ComplexPreCat_Additive A)
+                                      TranslationFunctor_Additive C1 C2 g). cbn in tmp.
+      exact tmp.
+  Qed.
 
-  (* This is ok *)
-  Local Definition test_complex (C : Complex A) : Complex A :=
-    mk_Complex A (λ i : hz, C (i + 1))
-               (λ i : hz, to_inv (C (i + 1)) (C (i + 1 + 1)) (Diff C (i + 1)))
-               (λ i : hz, TranslationFunctor_comp C i).
+  (** *** Inverse of the translation functor functor *)
 
-  (* This hangs *)
-  (* Definition test_morphism (C1 C2 : Complex A) (f : Morphism C1 C2) : Morphism C1 C2 :=
+  Local Lemma InvTranslationFunctor_comp (C : Complex A) (i : hz) :
+    (transportf (precategory_morphisms (C (i - 1)))
+                (maponpaths C (hzrminusplus i 1 @ ! hzrplusminus i 1))
+                (to_inv (Diff C (i - 1))))
+      ;; (transportf (precategory_morphisms (C (i + 1 - 1)))
+                     (maponpaths C (hzrminusplus (i + 1) 1 @ ! hzrplusminus (i + 1) 1))
+                     (to_inv (Diff C (i + 1 - 1)))) =
+    ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    induction (hzrminusplus (i + 1) 1 @ ! hzrplusminus (i + 1) 1).
+    induction (hzrminusplus i 1 @ ! hzrplusminus i 1). cbn. unfold idfun.
+    rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invrcomp.
+    rewrite inv_inv_eq. apply DSq.
+  Qed.
+
+  Definition InvTranslationComplex (C : Complex A) : Complex A.
+  Proof.
+    use mk_Complex.
+    - intros i. exact (C (i - 1)).
+    - intros i. exact (transportf
+                         (precategory_morphisms (C (i - 1)))
+                         (maponpaths C ((hzrminusplus i 1) @ (! hzrplusminus i 1)))
+                         (to_inv (Diff C (i - 1)))).
+    - intros i. exact (InvTranslationFunctor_comp C i).
+  Defined.
+
+  Definition pr11_InvTranslationComplex (C : Complex A) := pr1( pr1(InvTranslationComplex C)).
+  Definition DiffInvTranslationComplex (C : Complex A) (i : hz) :
+    A⟦ pr11_InvTranslationComplex C i, pr11_InvTranslationComplex C (i + 1) ⟧ :=
+    transportf
+      (precategory_morphisms (C (i - 1)))
+      (maponpaths C ((hzrminusplus i 1) @ (! hzrplusminus i 1)))
+      (to_inv (Diff C (i - 1))).
+
+  Lemma DiffInvTranslationComplex_comp (C : Complex A) (i : hz) :
+    (DiffInvTranslationComplex C i) ;; (DiffInvTranslationComplex C (i + 1)) =
+    ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    exact (InvTranslationFunctor_comp C i).
+  Qed.
+
+  Definition InvTranslationMorphism_mor {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    A⟦pr11_InvTranslationComplex C1 i, pr11_InvTranslationComplex C2 i⟧ := f (i - 1).
+
+  Local Lemma InvTranslationFunctor_comm {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    (InvTranslationMorphism_mor f i) ;; (DiffInvTranslationComplex C2 i) =
+    (DiffInvTranslationComplex C1 i) ;; (InvTranslationMorphism_mor f (i + 1)).
+  Proof.
+    unfold DiffInvTranslationComplex. rewrite <- transportf_postcompose.
+    unfold InvTranslationMorphism_mor. cbn. rewrite <- PreAdditive_invrcomp.
+    rewrite (MComm f (i - 1)). rewrite PreAdditive_invlcomp.
+    rewrite transportf_postcompose.
+    use transportf_path.
+    - exact (C2 i).
+    - exact (maponpaths C2 (hzrplusminus i 1)).
+    - rewrite transportf_postcompose. rewrite transport_f_f. rewrite <- maponpathscomp0.
+      rewrite <- path_assoc. rewrite pathsinv0l. rewrite pathscomp0rid.
+      induction (hzrminusplus i 1). cbn. unfold idfun.
+      rewrite transportf_postcompose.
+      set (tmp := transport_double_section A C1 C2 (MMor f) _ _ (hzrplusminus (i - 1 + 1) 1)).
+      cbn. cbn in tmp. rewrite tmp. clear tmp.
+      rewrite <- (transport_compose' _ _ (maponpaths C1 (! hzrplusminus (i - 1 + 1) 1))).
+      apply cancel_precomposition. rewrite <- maponpathsinv0. rewrite pathsinv0inv0.
+      apply idpath.
+  Qed.
+
+  Definition InvTranslationMorphism (C1 C2 : Complex A) (f : Morphism C1 C2) :
+    Morphism (InvTranslationComplex C1) (InvTranslationComplex C2) :=
     mk_Morphism
-      A
-      (mk_Complex A (λ i : pr1 hz, C1 (i + 1))
-                  (λ i : pr1 hz, to_inv (C1 (i + 1)) (C1 (i + 1 + 1)) (Diff C1 (i + 1)))
-                  (λ i : pr1 hz, TranslationFunctor_comp C1 i))
-      (mk_Complex A (λ i : pr1 hz, C2 (i + 1))
-                  (λ i : pr1 hz, to_inv (C2 (i + 1)) (C2 (i + 1 + 1)) (Diff C2 (i + 1)))
-                  (λ i : pr1 hz, TranslationFunctor_comp C2 i)) (λ i : hz, MMor f (i + 1))
-      (λ i : hz, TranslationFunctor_comm C1 C2 f i). *)
+      A (InvTranslationComplex C1) (InvTranslationComplex C2)
+      (λ i : hz, InvTranslationMorphism_mor f i) (λ i : hz, InvTranslationFunctor_comm f i).
 
-  (* These hang too *)
-  (*
-  Lemma test_conv (C : Complex A) (i : hz) :
-    Diff (test_complex C) i = to_inv (C (i + 1)) (C (i + 1 + 1)) (Diff C (i + 1)).
+  Definition InvTranslationFunctor_data :
+    functor_data (ComplexPreCat_Additive A) (ComplexPreCat_Additive A).
+  Proof.
+    use mk_functor_data.
+    - intros C. exact (InvTranslationComplex C).
+    - intros C1 C2 f. exact (InvTranslationMorphism C1 C2 f).
+  Defined.
 
-  Lemma test_conv' (C : Complex A) (i : hz) :
-    to_inv (C (i + 1)) (C (i + 1 + 1)) (Diff C (i + 1)) = Diff (test_complex C) i.
-   *)
+  Lemma InvTranslationFunctor_isfunctor : is_functor InvTranslationFunctor_data.
+  Proof.
+    split.
+    - intros C. cbn. use MorphismEq. intros i. cbn. apply idpath.
+    - intros C1 C2 C3 f g. cbn. use MorphismEq. intros i. cbn. apply idpath.
+  Qed.
+
+  Definition InvTranslationFunctor :
+    functor (ComplexPreCat_Additive A) (ComplexPreCat_Additive A).
+  Proof.
+    use mk_functor.
+    - exact InvTranslationFunctor_data.
+    - exact InvTranslationFunctor_isfunctor.
+  Defined.
+
+  Definition InvTranslationFunctor_isAdditive : isAdditiveFunctor InvTranslationFunctor.
+  Proof.
+    use mk_isAdditiveFunctor.
+    intros C1 C2.
+    split.
+    - intros f g. cbn. use MorphismEq. intros i. cbn. apply idpath.
+    - cbn. use MorphismEq. intros i. apply idpath.
+  Qed.
+
+  Definition InvTranslationFunctor_Additive :
+    AdditiveFunctor (ComplexPreCat_Additive A) (ComplexPreCat_Additive A).
+  Proof.
+    use mk_AdditiveFunctor.
+    - exact InvTranslationFunctor.
+    - exact InvTranslationFunctor_isAdditive.
+  Defined.
+
+  (** TODO : Translation is an isomorphism with inverse the inverse translation. *)
+
+
+  (** ** Translation functor for K(A) *)
+
+  (** *** Image for the translation functor *)
+
+  Definition TranslationFunctorHIm {C1 C2 : ComplexHomot_Additive A}
+             (f : (ComplexHomot_Additive A)⟦C1, C2⟧) : UU :=
+    Σ (h : (ComplexHomot_Additive A)⟦TranslationComplex C1, TranslationComplex C2⟧),
+    Π (f' : (ComplexPreCat_Additive A)⟦C1, C2⟧) (H : # (ComplexHomotFunctor A) f' = f),
+    h = # (ComplexHomotFunctor A) (# TranslationFunctor f').
+
+
+  Definition TranslationFunctorHImMor {C1 C2 : ComplexHomot_Additive A}
+             {f : (ComplexHomot_Additive A)⟦C1, C2⟧} (h : TranslationFunctorHIm f) :
+    (ComplexHomot_Additive A)⟦TranslationComplex C1, TranslationComplex C2⟧ := pr1 h.
+
+  Definition TranslationFunctorHImEq {C1 C2 : ComplexHomot_Additive A}
+             {f : (ComplexHomot_Additive A)⟦C1, C2⟧} (h : TranslationFunctorHIm f)
+             (f' : (ComplexPreCat_Additive A)⟦C1, C2⟧) (H : # (ComplexHomotFunctor A) f' = f) :
+    TranslationFunctorHImMor h = # (ComplexHomotFunctor A) (# TranslationFunctor f') := pr2 h f' H.
+
+  Definition mk_TranslationFunctorHIm {C1 C2 : ComplexHomot_Additive A}
+             {f : (ComplexHomot_Additive A)⟦C1, C2⟧}
+             (h : (ComplexHomot_Additive A)⟦TranslationComplex C1, TranslationComplex C2⟧)
+             (HH : Π (f' : (ComplexPreCat_Additive A)⟦C1, C2⟧)
+                     (H : # (ComplexHomotFunctor A) f' = f),
+                   h = # (ComplexHomotFunctor A) (# TranslationFunctor f')) :
+    TranslationFunctorHIm f := tpair _ h HH.
+
+  Lemma TranslationFunctorHImEquality {C1 C2 : ComplexHomot_Additive A}
+             {f : (ComplexHomot_Additive A)⟦C1, C2⟧} (h h' : TranslationFunctorHIm f)
+             (e : TranslationFunctorHImMor h = TranslationFunctorHImMor h') : h = h'.
+  Proof.
+    use total2_paths.
+    - exact e.
+    - apply proofirrelevance. apply impred_isaprop. intros t0.
+      apply impred_isaprop. intros H0. apply has_homsets_ComplexHomot_Additive.
+  Qed.
+
+
+  (** *** Construction of the functor *)
+
+  Lemma TranslationFunctor_eq {C1 C2 : ComplexHomot_Additive A}
+        (f : (ComplexHomot_Additive A)⟦C1, C2⟧) (H : hfiber # (ComplexHomotFunctor A) f)
+        (f' : (ComplexPreCat_Additive A)⟦C1, C2⟧) (H' : # (ComplexHomotFunctor A) f' = f) :
+    # (ComplexHomotFunctor A) (# TranslationFunctor (hfiberpr1 # (ComplexHomotFunctor A) f H)) =
+    # (ComplexHomotFunctor A) (# TranslationFunctor f').
+  Proof.
+    use ComplexHomotFunctor_rel_mor.
+    use TranslationFunctorPreservesHomotopies.
+    use ComplexHomotFunctor_mor_rel.
+    rewrite H'. apply hfiberpr2.
+  Qed.
+
+  Definition TranslationFunctorH_Mor {C1 C2 : ComplexHomot_Additive A}
+             (f : (ComplexHomot_Additive A)⟦C1, C2⟧) : iscontr (TranslationFunctorHIm f).
+  Proof.
+    use (squash_to_prop (ComplexHomotFunctor_issurj A f)).
+    apply isapropiscontr. intros H.
+    use iscontrpair.
+    - use mk_TranslationFunctorHIm.
+      + exact (# (ComplexHomotFunctor A) (# (TranslationFunctor) (hfiberpr1 _ _ H))).
+      + intros f' H'. exact (TranslationFunctor_eq f H f' H').
+    - intros t. use TranslationFunctorHImEquality.
+      use TranslationFunctorHImEq.
+      exact (hfiberpr2 _ _ H).
+  Qed.
+
+  Definition TranslationFunctorH_data :
+    functor_data (ComplexHomot_Additive A) (ComplexHomot_Additive A).
+  Proof.
+    use mk_functor_data.
+    - intros C. exact (TranslationComplex C).
+    - intros C1 C2 f. exact (TranslationFunctorHImMor (iscontrpr1 (TranslationFunctorH_Mor f))).
+  Defined.
+
+  Lemma TranslationFunctorH_Mor_Id : functor_idax TranslationFunctorH_data.
+  Proof.
+    intros C.
+    use (pathscomp0 (TranslationFunctorHImEq
+                       (iscontrpr1 (TranslationFunctorH_Mor (identity C)))
+                       (identity _)
+                       (functor_id (ComplexHomotFunctor A) _))).
+    rewrite functor_id. rewrite functor_id. apply idpath.
+  Qed.
+
+  Lemma TranslationFunctorH_Mor_Comp {C1 C2 C3 : ComplexHomot_Additive A}
+             (f : (ComplexHomot_Additive A)⟦C1, C2⟧) (g : (ComplexHomot_Additive A)⟦C2, C3⟧) :
+    (TranslationFunctorHImMor (iscontrpr1 (TranslationFunctorH_Mor (f ;; g)))) =
+    (TranslationFunctorHImMor (iscontrpr1 (TranslationFunctorH_Mor f)))
+      ;; (TranslationFunctorHImMor (iscontrpr1 (TranslationFunctorH_Mor g))) .
+  Proof.
+    use (squash_to_prop (ComplexHomotFunctor_issurj A f)).
+    apply has_homsets_ComplexHomot_Additive. intros f'.
+    use (squash_to_prop (ComplexHomotFunctor_issurj A g)).
+    apply has_homsets_ComplexHomot_Additive. intros g'.
+    rewrite (TranslationFunctorHImEq (iscontrpr1 (TranslationFunctorH_Mor f)) _ (hfiberpr2 _ _ f')).
+    rewrite (TranslationFunctorHImEq (iscontrpr1 (TranslationFunctorH_Mor g)) _ (hfiberpr2 _ _ g')).
+    set (tmp := functor_comp (ComplexHomotFunctor A) _ _ _
+                             (# TranslationFunctor (hfiberpr1 # (ComplexHomotFunctor A) f f'))
+                             (# TranslationFunctor (hfiberpr1 # (ComplexHomotFunctor A) g g'))).
+    use (pathscomp0 _ tmp). clear tmp.
+    set (tmp := functor_comp TranslationFunctor _ _ _ (hfiberpr1 _ _ f') (hfiberpr1 _ _ g')).
+    apply (maponpaths (# (ComplexHomotFunctor A))) in tmp.
+    use (pathscomp0 _ tmp). clear tmp.
+    use (TranslationFunctorHImEq (iscontrpr1 (TranslationFunctorH_Mor (f ;; g)))).
+    rewrite functor_comp. rewrite (hfiberpr2 _ _ f'). rewrite (hfiberpr2 _ _ g'). apply idpath.
+  Qed.
+
+  Definition TranslationFunctorH_is_functor : is_functor TranslationFunctorH_data.
+  Proof.
+    split.
+    - exact TranslationFunctorH_Mor_Id.
+    - intros C1 C2 C3 f g. exact (TranslationFunctorH_Mor_Comp f g).
+  Qed.
+
+  Definition TranslationFunctorH :
+    functor (ComplexHomot_Additive A) (ComplexHomot_Additive A).
+  Proof.
+    use mk_functor.
+    - exact TranslationFunctorH_data.
+    - exact TranslationFunctorH_is_functor.
+  Defined.
+
+  (* TODO : Generalize the translation functor construction! Similar code was used in
+     CohomologyComplex.v to construct the cohomology functor for K(A). *)
+
+  (* TODO : Translation inverse for K(A) *)
 
 End translation_functor.
+
+
+(** * Mapping cone *)
+(** ** Introduction
+In this section we construct the mapping cone, which is a complex, of a morphism f : C_1 -> C_2
+of complexes. We denote mapping cone of f by Cone(f). The objects of mapping cone are given
+by T C_1^i ⊕ C_2^i. The ith differential of Cone(f) is given by
+         #  - p_1 ;; d^{i+1}_X ;; i_1 - i_2 ;; f^{i+1} ;; p_1 + p_2 ;; d^i_Y ;; i_2 #
+         $  - p_1 ;; d^{i+1}_X ;; i_1 - i_2 ;; f^{i+1} ;; p_1 + p_2 ;; d^i_Y ;; i_2 $
+
+We split the definition of the ith differential into a sum of 3 morphisms. These are constructed in
+[MappingConeDiff1], [MappingConeDiff3], and [MappingConeDiff3], and correspond the morphisms of the
+above formula, respectively. In [MappingConeDiff] we construct the differential. In
+[MappingCone_comp] we show that composition of two consecutive differentials is 0. The complex
+Cone(f) is constructed in [MappingCone].
+*)
+Section mapping_cone.
+
+  Variable A : Additive.
+
+
+  (**  # - (p_1 ;; d^{i+1}_{C_1} ;; i_1) # *)
+  Definition MappingConeDiff1 {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    let DS1 := to_BinDirectSums A ((pr11_TranslationComplex A C1) i) (C2 i) in
+    let DS2 := to_BinDirectSums A ((pr11_TranslationComplex A C1) (i + 1)) (C2 (i + 1)) in
+    A ⟦ DS1, DS2 ⟧.
+  Proof.
+    intros DS1 DS2.
+    use compose.
+    - exact (pr11_TranslationComplex A C1 i).
+    - exact (to_Pr1 A DS1).
+    - use compose.
+      + exact (pr11_TranslationComplex A C1 (i + 1)).
+      + exact (DiffTranslationComplex A C1 i).
+      + exact (to_In1 A DS2).
+  Defined.
+
+  (**  # - (p_1 ;; f (i + 1) ;; i_2) # *)
+  Definition MappingConeDiff2 {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    let DS1 := to_BinDirectSums A ((pr11_TranslationComplex A C1) i) (C2 i) in
+    let DS2 := to_BinDirectSums A ((pr11_TranslationComplex A C1) (i + 1)) (C2 (i + 1)) in
+    A ⟦ DS1, DS2 ⟧.
+  Proof.
+    intros DS1 DS2.
+    use compose.
+    - exact (pr11_TranslationComplex A C1 i).
+    - exact (to_Pr1 A DS1).
+    - use compose.
+      + exact (C2 (i + 1)).
+      + exact (f (i + 1)).
+      + exact (to_In2 A DS2).
+  Defined.
+
+  (** # p2 ;; d^i_[C_2} ;; i2 # *)
+  Definition MappingConeDiff3 {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    let DS1 := to_BinDirectSums A ((pr11_TranslationComplex A C1) i) (C2 i) in
+    let DS2 := to_BinDirectSums A ((pr11_TranslationComplex A C1) (i + 1)) (C2 (i + 1)) in
+    A ⟦ DS1, DS2 ⟧.
+  Proof.
+    intros DS1 DS2.
+    use compose.
+    - exact (C2 i).
+    - exact (to_Pr2 A DS1).
+    - use compose.
+      + exact (C2 (i + 1)).
+      + exact (Diff C2 i).
+      + exact (to_In2 A DS2).
+  Defined.
+
+  Definition MappingConeDiff {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    let DS1 := to_BinDirectSums A ((pr11_TranslationComplex A C1) i) (C2 i) in
+    let DS2 := to_BinDirectSums A ((pr11_TranslationComplex A C1) (i + 1)) (C2 (i + 1)) in
+    A ⟦ DS1, DS2 ⟧.
+  Proof.
+    intros DS1 DS2.
+    use to_binop.
+    - exact (MappingConeDiff1 f i).
+    - use to_binop.
+      +  exact (MappingConeDiff2 f i).
+      +  exact (MappingConeDiff3 f i).
+  Defined.
+
+  Lemma MappingCone_Diff1_Diff1 {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    let DS1 := to_BinDirectSums A ((pr11_TranslationComplex A C1) i) (C2 i) in
+    let DS2 := to_BinDirectSums A ((pr11_TranslationComplex A C1) (i + 1)) (C2 (i + 1)) in
+    (MappingConeDiff1 f i) ;; (MappingConeDiff1 f (i + 1)) = ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    intros DS1 DS2. unfold MappingConeDiff1. fold DS1. fold DS2.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite <- (assoc _ _ (to_Pr1 A DS2)).
+    rewrite (to_IdIn1 A DS2). rewrite id_right.
+    rewrite <- (assoc _ _ (DiffTranslationComplex A C1 (i + 1))).
+    rewrite (DiffTranslationComplex_comp A C1 i).
+    rewrite ZeroArrow_comp_right. apply ZeroArrow_comp_left.
+  Qed.
+
+  Lemma MappingCone_Diff1_Diff3 {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    let DS1 := to_BinDirectSums A ((pr11_TranslationComplex A C1) i) (C2 i) in
+    let DS2 := to_BinDirectSums A ((pr11_TranslationComplex A C1) (i + 1)) (C2 (i + 1)) in
+    (MappingConeDiff1 f i) ;; (MappingConeDiff3 f (i + 1)) = ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    intros DS1 DS2. unfold MappingConeDiff1. unfold MappingConeDiff3. fold DS1. fold DS2.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite <- (assoc _ _ (to_Pr2 A DS2)).
+    rewrite (to_Unel1 A DS2). rewrite (PreAdditive_unel_zero _ (Additive.to_Zero A)).
+    rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left. apply ZeroArrow_comp_left.
+  Qed.
+
+  Lemma MappingCone_Diff2_Diff1 {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    let DS1 := to_BinDirectSums A ((pr11_TranslationComplex A C1) i) (C2 i) in
+    let DS2 := to_BinDirectSums A ((pr11_TranslationComplex A C1) (i + 1)) (C2 (i + 1)) in
+    let DS3 := to_BinDirectSums A ((pr11_TranslationComplex A C1) (i + 1 + 1)) (C2 (i + 1 + 1)) in
+    (MappingConeDiff2 f i) ;; (MappingConeDiff1 f (i + 1)) = ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    intros DS1 DS2 DS3. unfold MappingConeDiff2. unfold MappingConeDiff1.
+    fold DS1. fold DS2. fold DS3.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite <- (assoc _ _ (to_Pr1 A DS2)).
+    rewrite (to_Unel2 A DS2). rewrite (PreAdditive_unel_zero _ (Additive.to_Zero A)).
+    rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left. apply ZeroArrow_comp_left.
+  Qed.
+
+   Lemma MappingCone_Diff2_Diff2 {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    let DS1 := to_BinDirectSums A ((pr11_TranslationComplex A C1) i) (C2 i) in
+    let DS2 := to_BinDirectSums A ((pr11_TranslationComplex A C1) (i + 1)) (C2 (i + 1)) in
+    (MappingConeDiff2 f i) ;; (MappingConeDiff2 f (i + 1)) = ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    intros DS1 DS2. unfold MappingConeDiff2. fold DS1. fold DS2.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite <- (assoc _ _ (to_Pr1 A DS2)).
+    rewrite (to_Unel2 A DS2). rewrite (PreAdditive_unel_zero _ (Additive.to_Zero A)).
+    rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left. apply ZeroArrow_comp_left.
+  Qed.
+
+  Lemma MappingCone_Diff3_Diff1 {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    let DS1 := to_BinDirectSums A ((pr11_TranslationComplex A C1) i) (C2 i) in
+    let DS2 := to_BinDirectSums A ((pr11_TranslationComplex A C1) (i + 1)) (C2 (i + 1)) in
+    (MappingConeDiff3 f i) ;; (MappingConeDiff1 f (i + 1)) = ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    intros DS1 DS2. unfold MappingConeDiff3. unfold MappingConeDiff1. fold DS1. fold DS2.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite <- (assoc _ _ (to_Pr1 A DS2)).
+    rewrite (to_Unel2 A DS2). rewrite (PreAdditive_unel_zero _ (Additive.to_Zero A)).
+    rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left. apply ZeroArrow_comp_left.
+  Qed.
+
+  Lemma MappingCone_Diff3_Diff2 {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    let DS1 := to_BinDirectSums A ((pr11_TranslationComplex A C1) i) (C2 i) in
+    let DS2 := to_BinDirectSums A ((pr11_TranslationComplex A C1) (i + 1)) (C2 (i + 1)) in
+    (MappingConeDiff3 f i) ;; (MappingConeDiff2 f (i + 1)) = ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    intros DS1 DS2. unfold MappingConeDiff3. unfold MappingConeDiff2. fold DS1. fold DS2.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite <- (assoc _ _ (to_Pr1 A DS2)).
+    rewrite (to_Unel2 A DS2). rewrite (PreAdditive_unel_zero _ (Additive.to_Zero A)).
+    rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left. apply ZeroArrow_comp_left.
+  Qed.
+
+  Lemma MappingCone_Diff3_Diff3 {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    let DS1 := to_BinDirectSums A ((pr11_TranslationComplex A C1) i) (C2 i) in
+    let DS2 := to_BinDirectSums A ((pr11_TranslationComplex A C1) (i + 1)) (C2 (i + 1)) in
+    let DS3 := to_BinDirectSums A ((pr11_TranslationComplex A C1) (i + 1 + 1)) (C2 (i + 1 + 1)) in
+    (MappingConeDiff3 f i) ;; (MappingConeDiff3 f (i + 1)) = ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    intros DS1 DS2 DS3. unfold MappingConeDiff3. fold DS1. fold DS2. fold DS3.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite <- (assoc _ _ (to_Pr2 A DS2)).
+    rewrite (to_IdIn2 A DS2). rewrite id_right. rewrite <- (assoc _ _ (Diff C2 (i + 1))).
+    rewrite (DSq A C2 i). rewrite ZeroArrow_comp_right. apply ZeroArrow_comp_left.
+  Qed.
+
+  Lemma MappingCone_comp {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    let DS1 := to_BinDirectSums A ((pr11_TranslationComplex A C1) i) (C2 i) in
+    let DS2 := to_BinDirectSums A ((pr11_TranslationComplex A C1) (i + 1)) (C2 (i + 1)) in
+    let DS2 := to_BinDirectSums A ((pr11_TranslationComplex A C1) (i + 1 + 1)) (C2 (i + 1 + 1)) in
+    (to_binop _ _ (MappingConeDiff1 f i)
+              (to_binop _ _ (MappingConeDiff2 f i) (MappingConeDiff3 f i)))
+      ;; (to_binop _ _ (MappingConeDiff1 f (i + 1))
+                   (to_binop _ _ (MappingConeDiff2 f (i + 1)) (MappingConeDiff3 f (i + 1)))) =
+    ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    intros DS1 DS2 DS3. fold DS1. fold DS2. fold DS3.
+    rewrite to_postmor_linear'. rewrite to_postmor_linear'.
+    rewrite to_premor_linear'.
+    set (D11 := MappingCone_Diff1_Diff1 f i). fold DS1 in D11. fold DS3 in D11. cbn in D11.
+    rewrite to_premor_linear'.
+    set (D13 := MappingCone_Diff1_Diff3 f i). fold DS1 in D13. fold DS2 in D13. fold DS3 in D13.
+    cbn in D13.
+    rewrite to_premor_linear'.
+    set (D21 := MappingCone_Diff2_Diff1 f i). fold DS1 in D21. fold DS2 in D21. fold DS3 in D21.
+    cbn in D21.
+    rewrite to_premor_linear'.
+    set (D22 := MappingCone_Diff2_Diff2 f i). fold DS1 in D22. fold DS2 in D22. fold DS3 in D22.
+    cbn in D22.
+    rewrite to_premor_linear'.
+    set (D31 := MappingCone_Diff3_Diff1 f i). fold DS1 in D31. fold DS2 in D31. fold DS3 in D31.
+    cbn in D31.
+    rewrite to_premor_linear'.
+    set (D32 := MappingCone_Diff3_Diff2 f i). fold DS1 in D32. fold DS2 in D32. fold DS3 in D32.
+    cbn in D32.
+    set (D33 := MappingCone_Diff3_Diff3 f i). fold DS1 in D33. fold DS2 in D33. fold DS3 in D33.
+    cbn in D33.
+    set (tmp := to_binop
+                  DS1 DS3
+                  (to_binop DS1 DS3 (MappingConeDiff2 f i ;; MappingConeDiff1 f (i + 1))
+                            (to_binop DS1 DS3 (MappingConeDiff2 f i ;; MappingConeDiff2 f (i + 1))
+                                      (MappingConeDiff2 f i ;; MappingConeDiff3 f (i + 1))))
+                  (to_binop DS1 DS3 (MappingConeDiff3 f i ;; MappingConeDiff1 f (i + 1))
+                            (to_binop DS1 DS3 (MappingConeDiff3 f i ;; MappingConeDiff2 f (i + 1))
+                                      (MappingConeDiff3 f i ;; MappingConeDiff3 f (i + 1))))).
+    use pathscomp0.
+    - exact (to_binop DS1 DS3 (MappingConeDiff1 f i ;; MappingConeDiff2 f (i + 1)) tmp).
+    - use to_lrw.
+      rewrite <- to_lunax'. rewrite (PreAdditive_unel_zero _ (Additive.to_Zero A)).
+      cbn. rewrite <- D11. apply maponpaths.
+      rewrite <- to_runax'. rewrite (PreAdditive_unel_zero _ (Additive.to_Zero A)).
+      apply maponpaths. exact D13.
+    - unfold tmp. clear tmp.
+      set (tmp := to_binop DS1 DS3 (MappingConeDiff3 f i ;; MappingConeDiff1 f (i + 1))
+                           (to_binop DS1 DS3 (MappingConeDiff3 f i ;; MappingConeDiff2 f (i + 1))
+                                     (MappingConeDiff3 f i ;; MappingConeDiff3 f (i + 1)))).
+      use pathscomp0.
+      + exact (to_binop DS1 DS3 (MappingConeDiff1 f i ;; MappingConeDiff2 f (i + 1))
+                        (to_binop DS1 DS3 (MappingConeDiff2 f i ;; MappingConeDiff3 f (i + 1))
+                                  tmp)).
+      + use to_rrw. use to_lrw.
+        rewrite <- to_lunax'. rewrite (PreAdditive_unel_zero _ (Additive.to_Zero A)).
+        cbn. rewrite <- D21. apply maponpaths.
+        rewrite <- to_lunax'. rewrite (PreAdditive_unel_zero _ (Additive.to_Zero A)).
+        use to_lrw. exact D22.
+      + unfold tmp. use pathscomp0.
+        * exact (to_binop DS1 DS3 (MappingConeDiff1 f i ;; MappingConeDiff2 f (i + 1))
+                          (MappingConeDiff2 f i ;; MappingConeDiff3 f (i + 1))).
+        * apply maponpaths.
+          rewrite <- to_runax'. rewrite (PreAdditive_unel_zero _ (Additive.to_Zero A)).
+          cbn. rewrite <- D33. use to_rrw.
+          rewrite <- to_lunax'. rewrite (PreAdditive_unel_zero _ (Additive.to_Zero A)).
+          cbn. rewrite <- D31. apply maponpaths.
+          rewrite <- to_lunax'. rewrite (PreAdditive_unel_zero _ (Additive.to_Zero A)).
+          cbn. rewrite <- D32. apply idpath.
+        * unfold MappingConeDiff1. unfold MappingConeDiff2. unfold MappingConeDiff3.
+          fold DS1. fold DS2. fold DS3. rewrite assoc. rewrite assoc. rewrite assoc.
+          rewrite <- (assoc _ _ (to_Pr1 A DS2)). rewrite (to_IdIn1 A DS2). rewrite id_right.
+          rewrite assoc. rewrite assoc. rewrite assoc.
+          rewrite <- (assoc _ _ (to_Pr2 A DS2)). rewrite (to_IdIn2 A DS2). rewrite id_right.
+          rewrite <- to_postmor_linear'. rewrite <- (ZeroArrow_comp_left _ _ _ _ _ (to_In2 A DS3)).
+          apply cancel_postcomposition. rewrite <- assoc. rewrite <- assoc.
+          rewrite <- to_premor_linear'. rewrite <- (ZeroArrow_comp_right _ _ _ _ _ (to_Pr1 A DS1)).
+          apply cancel_precomposition. cbn. rewrite (MComm f (i + 1)).
+          rewrite <- to_postmor_linear'.
+          rewrite <- (ZeroArrow_comp_left _ _ _ _ _ (f (i + 1 + 1))).
+          apply cancel_postcomposition. use to_linvax'.
+  Qed.
+
+  Definition MappingCone {C1 C2 : Complex A} (f : Morphism C1 C2) : Complex A.
+  Proof.
+    use mk_Complex.
+    - intros i. exact (to_BinDirectSums A (TranslationComplex A C1 i) (C2 i)).
+    - intros i. exact (MappingConeDiff f i).
+    - intros i. exact (MappingCone_comp f i).
+  Defined.
+
+End mapping_cone.
+
+
+(** * Mapping cylinder *)
+(** ** Introduction
+In this section we construct the mapping cylinder, which is a complex, of a morphism f : C_1 -> C_2
+of complexes. We denote mapping cylinder of f by Cyl(f). The objects of mapping cylinder are given
+by C_1^i ⊕ Cone(f)^i. The ith differential of Cyl(f) is given by
+         #  p_1 ;; d^i_X ;; i_1 - p_2 ;; p1 ;; i_1 + p_2 ;; d^i_C(f) ;; i_2 #
+
+Here d^i_C(F) is the ith differential of the mapping cone of f, see section [mapping_cone].
+We split the definition of the ith differential into a sum of 3 morphisms. These are constructed in
+[MappingCylinderDiff1], [MappingCylinderDiff3], and [MappingCylinderDiff3], and correspond the
+morphisms of the above formula, respectively. In [MappingCylinderDiff] we construct the differential.
+In [MappingCylinder_comp] we show that composition of two consecutive differentials is 0. The
+complex Cyl(f) is constructed in [MappingCylinder].
+*)
+Section mapping_cylinder.
+
+  Variable A : Additive.
+
+  (**  # p_1 ;; d^i_X ;; i_1 # *)
+  Definition MappingCylinderDiff1 {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    let DS1' := to_BinDirectSums A (pr11_TranslationComplex A C1 i) (C2 i) in
+    let DS1 := to_BinDirectSums A (C1 i) DS1' in
+    let DS2' := to_BinDirectSums A (pr11_TranslationComplex A C1 (i + 1)) (C2 (i + 1)) in
+    let DS2 := to_BinDirectSums A (C1 (i + 1)) DS2' in
+    A ⟦ DS1, DS2 ⟧.
+  Proof.
+    intros DS1' DS1 DS2' DS2.
+    use compose.
+    - exact (C1 i).
+    - exact (to_Pr1 A DS1).
+    - use compose.
+      + exact (C1 (i + 1)).
+      + exact (Diff C1 i).
+      + exact (to_In1 A DS2).
+  Defined.
+
+  (**  # p_2 ;; (- p1) ;; i_1 # *)
+  Definition MappingCylinderDiff2 {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    let DS1' := to_BinDirectSums A (pr11_TranslationComplex A C1 i) (C2 i) in
+    let DS1 := to_BinDirectSums A (C1 i) DS1' in
+    let DS2' := to_BinDirectSums A (pr11_TranslationComplex A C1 (i + 1)) (C2 (i + 1)) in
+    let DS2 := to_BinDirectSums A (C1 (i + 1)) DS2' in
+    A ⟦ DS1, DS2 ⟧.
+  Proof.
+    intros DS1' DS1 DS2' DS2.
+    use compose.
+    - exact (DS1').
+    - exact (to_Pr2 A DS1).
+    - use compose.
+      + exact ((pr11_TranslationComplex A C1) i).
+      + exact (to_inv (to_Pr1 A DS1')).
+      + exact (to_In1 A DS2).
+  Defined.
+
+  (** p_2 ;; d^i_C(f) ;; i_2 *)
+  Definition MappingCylinderDiff3 {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    let DS1' := to_BinDirectSums A (pr11_TranslationComplex A C1 i) (C2 i) in
+    let DS1 := to_BinDirectSums A (C1 i) DS1' in
+    let DS2' := to_BinDirectSums A (pr11_TranslationComplex A C1 (i + 1)) (C2 (i + 1)) in
+    let DS2 := to_BinDirectSums A (C1 (i + 1)) DS2' in
+    A ⟦ DS1, DS2 ⟧.
+  Proof.
+    intros DS1' DS1 DS2' DS2.
+    use compose.
+    - exact DS1'.
+    - exact (to_Pr2 A DS1).
+    - use compose.
+      + exact DS2'.
+      + exact (MappingConeDiff A f i).
+      + exact (to_In2 A DS2).
+  Defined.
+
+  Definition MappingCylinderDiff {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    let DS1' := to_BinDirectSums A (pr11_TranslationComplex A C1 i) (C2 i) in
+    let DS1 := to_BinDirectSums A (C1 i) DS1' in
+    let DS2' := to_BinDirectSums A (pr11_TranslationComplex A C1 (i + 1)) (C2 (i + 1)) in
+    let DS2 := to_BinDirectSums A (C1 (i + 1)) DS2' in
+    A ⟦ DS1, DS2 ⟧.
+  Proof.
+    intros DS1 DS2.
+    use to_binop.
+    - exact (MappingCylinderDiff1 f i).
+    - use to_binop.
+      +  exact (MappingCylinderDiff2 f i).
+      +  exact (MappingCylinderDiff3 f i).
+  Defined.
+
+  Lemma MappingCylinder_Diff1_Diff1 {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    let DS1 := to_BinDirectSums A (C1 i) (MappingCone A f i) in
+    let DS2 := to_BinDirectSums A (C1 (i + 1)) (MappingCone A f i) in
+    (MappingCylinderDiff1 f i) ;; (MappingCylinderDiff1 f (i + 1)) =
+    ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    intros DS1 DS2. unfold MappingCylinderDiff1. unfold MappingCylinderDiff2. cbn.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite <- (assoc _ _ (to_Pr1 A _)).
+    set (DS3 := to_BinDirectSums A (C1 (i + 1)) (to_BinDirectSums A (C1 (i + 1 + 1)) (C2 (i + 1)))).
+    rewrite (to_IdIn1 A DS3). rewrite id_right. rewrite <- (assoc _ _ (Diff C1 (i + 1))).
+    rewrite (DSq A C1 i). rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left.
+    apply idpath.
+  Qed.
+
+  Lemma MappingCylinder_Diff1_Diff2 {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    (MappingCylinderDiff1 f i) ;; (MappingCylinderDiff2 f (i + 1)) =
+    ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    unfold MappingCylinderDiff1. unfold MappingCylinderDiff2. cbn.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite <- (assoc _ _ (to_Pr2 A _)).
+    set (DS := to_BinDirectSums A (C1 (i + 1)) (to_BinDirectSums A (C1 (i + 1 + 1)) (C2 (i + 1)))).
+    rewrite (to_Unel1' DS). rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left.
+    apply ZeroArrow_comp_left.
+  Qed.
+
+  Lemma MappingCylinder_Diff1_Diff3 {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    (MappingCylinderDiff1 f i) ;; (MappingCylinderDiff3 f (i + 1)) =
+    ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    unfold MappingCylinderDiff1. unfold MappingCylinderDiff3. cbn.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite <- (assoc _ _ (to_Pr2 A _)).
+    set (DS := to_BinDirectSums A (C1 (i + 1)) (to_BinDirectSums A (C1 (i + 1 + 1)) (C2 (i + 1)))).
+    rewrite (to_Unel1' DS). rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left.
+    apply ZeroArrow_comp_left.
+  Qed.
+
+  Lemma MappingCylinder_Diff2_Diff2 {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    (MappingCylinderDiff2 f i) ;; (MappingCylinderDiff2 f (i + 1)) =
+    ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    unfold MappingCylinderDiff2. cbn.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite <- (assoc _ _ (to_Pr2 A _)).
+    set (DS := to_BinDirectSums A (C1 (i + 1)) (to_BinDirectSums A (C1 (i + 1 + 1)) (C2 (i + 1)))).
+    rewrite (to_Unel1' DS). rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left.
+    apply ZeroArrow_comp_left.
+  Qed.
+
+  Lemma MappingCylinder_Diff2_Diff3 {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    (MappingCylinderDiff2 f i) ;; (MappingCylinderDiff3 f (i + 1)) =
+    ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    unfold MappingCylinderDiff2. unfold MappingCylinderDiff3. cbn.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite <- (assoc _ _ (to_Pr2 A _)).
+    set (DS := to_BinDirectSums A (C1 (i + 1)) (to_BinDirectSums A (C1 (i + 1 + 1)) (C2 (i + 1)))).
+    rewrite (to_Unel1' DS). rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left.
+    apply ZeroArrow_comp_left.
+  Qed.
+
+  Lemma MapingCylinder_Diff3_Diff3 {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    (MappingCylinderDiff3 f i) ;; (MappingCylinderDiff3 f (i + 1)) =
+    ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    unfold MappingCylinderDiff3. cbn.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite <- (assoc _ _ (to_Pr2 A _)).
+    set (DS := to_BinDirectSums A (C1 (i + 1)) (to_BinDirectSums A (C1 (i + 1 + 1)) (C2 (i + 1)))).
+    rewrite (to_IdIn2 A DS). rewrite id_right. rewrite <- (assoc _ (MappingConeDiff A f i)).
+    set (tmp := DSq A (MappingCone A f) i). cbn in tmp. cbn. rewrite tmp. clear tmp.
+    rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left. apply idpath.
+  Qed.
+
+  Lemma MappingCylinder_comp {C1 C2 : Complex A} (f : Morphism C1 C2) (i : hz) :
+    MappingCylinderDiff f i ;; MappingCylinderDiff f (i + 1) =
+    ZeroArrow (Additive.to_Zero A) _ _.
+  Proof.
+    unfold MappingCylinderDiff. cbn.
+    set (D11 := MappingCylinder_Diff1_Diff1 f i).
+    set (D12 := MappingCylinder_Diff1_Diff2 f i).
+    set (D13 := MappingCylinder_Diff1_Diff3 f i).
+    set (D22 := MappingCylinder_Diff2_Diff2 f i).
+    set (D23 := MappingCylinder_Diff2_Diff3 f i).
+    set (D33 := MapingCylinder_Diff3_Diff3 f i).
+    rewrite to_premor_linear'. rewrite to_premor_linear'.
+    rewrite to_postmor_linear'. rewrite to_postmor_linear'. rewrite to_postmor_linear'.
+    rewrite to_postmor_linear'. rewrite to_postmor_linear'. rewrite to_postmor_linear'.
+    cbn. cbn in D11. rewrite D11. cbn in D12. rewrite D12. cbn in D13. rewrite D13.
+    cbn in D22. rewrite D22. cbn in D23. rewrite D23. cbn in D33. rewrite D33.
+    rewrite to_lunax''. rewrite to_lunax''. rewrite to_runax''. rewrite to_runax''.
+    rewrite to_lunax''. rewrite to_runax''.
+    unfold MappingCylinderDiff1. unfold MappingCylinderDiff2. unfold MappingCylinderDiff3.
+    cbn. clear D11 D12 D13 D22 D23 D33.
+    set (DS1 := to_BinDirectSums A (C1 (i + 1)) (C2 i)).
+    set (DS1' := to_BinDirectSums A (C1 i) DS1).
+    set (DS2 := to_BinDirectSums A (C1 (i + 1 + 1 + 1)) (C2 (i + 1 + 1))).
+    set (DS2' := to_BinDirectSums A (C1 (i + 1 + 1)) DS2).
+    set (DS3 := to_BinDirectSums A (C1 (i + 1 + 1)) (C2 (i + 1))).
+    set (DS3' := to_BinDirectSums A (C1 (i + 1)) DS3). cbn.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
+    rewrite assoc. rewrite assoc. rewrite assoc.
+    rewrite <- PreAdditive_invrcomp. rewrite <- PreAdditive_invrcomp.
+    rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invlcomp.
+    rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invlcomp.
+    rewrite <- PreAdditive_invlcomp.
+    rewrite <- (assoc _ _ (to_Pr1 A DS3')). rewrite (to_IdIn1 A DS3'). rewrite id_right.
+    rewrite <- (assoc _ _ (to_Pr1 A DS3')). rewrite (to_Unel2' DS3').
+    rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_left.
+    rewrite to_runax''.
+    rewrite <- (assoc _ _ (to_Pr2 A DS3')). rewrite (to_IdIn2 A DS3').
+    rewrite id_right. rewrite to_binop_inv_inv.
+    apply cancel_inv. rewrite inv_inv_eq. rewrite to_inv_zero.
+    rewrite <- to_postmor_linear'.
+    rewrite <- (ZeroArrow_comp_left _ _ _ _ _ (to_In1 A DS2')). apply cancel_postcomposition.
+    rewrite <- assoc. rewrite <- assoc. rewrite <- to_premor_linear'.
+    rewrite <- (ZeroArrow_comp_right _ _ _ _ _ (to_Pr2 A DS1')). apply cancel_precomposition.
+    unfold MappingConeDiff.
+    unfold MappingConeDiff1. unfold MappingConeDiff2. unfold MappingConeDiff3.
+    cbn in *. fold DS1 DS1' DS2 DS2' DS3 DS3'. unfold DiffTranslationComplex.
+    rewrite assoc. rewrite assoc. rewrite <- PreAdditive_invrcomp.
+    rewrite to_postmor_linear'. rewrite <- (assoc _ _ (to_Pr1 A DS3)).
+    rewrite (to_IdIn1 A DS3). rewrite id_right. cbn.
+    rewrite to_postmor_linear'. rewrite assoc.
+    rewrite <- (assoc _ _ (to_Pr1 A DS3)). rewrite <- (assoc _ _ (to_Pr1 A DS3)).
+    rewrite (to_Unel2' DS3). rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_right.
+    rewrite to_runax''. rewrite to_runax''. rewrite (@to_rinvax' A (Additive.to_Zero A)).
+    apply idpath.
+  Qed.
+
+  Definition MappingCylinder {C1 C2 : Complex A} (f : Morphism C1 C2) : Complex A.
+  Proof.
+    use mk_Complex.
+    - intros i. exact (to_BinDirectSums
+                         A (C1 i) (to_BinDirectSums A (pr11_TranslationComplex A C1 i) (C2 i))).
+    - intros i. exact (MappingCylinderDiff f i).
+    - intros i. cbn beta. exact (MappingCylinder_comp f i).
+  Defined.
+
+End mapping_cylinder.
+
+
+(** * Let f : X -> Y, then Y is isomorphic to Cyl(f) in K(A) *)
+(** ** Introduction
+We show that in K(A) Y and Cyl(f) are isomorphic. The isomorphism is given by the morphisms
+α := i_2 ;; i_2 and β := p_1 ;; f + p_2 ;; p_2. We have α ;; β = id in C(A), but
+β ;; α ≠ id_{Cyl(f)} in C(A). We define a homotopy by χ^i := p_1 ;; i_1 ;; i_2 : Cyl(f)^i -->
+Cyl(f)^{i-1}. We show that
+       # id_{Cyl(f)} - β ;; α = χ^i ;; d^{i-1}_{Cyl(f)} + d^i_{Cyl(f)} ;; χ^{i-1} #
+       $ id_{Cyl(f)} - β ;; α = χ^i ;; d^{i-1}_{Cyl(f)} + d^i_{Cyl(f)} ;; χ^{i-1} $  ( * )
+This means that β ;; α = id_{Cyl(f)} in K(A) by the definition of homotopy of morphisms.
+Hence Y and C(f) are isomorphic.
+
+The morphisms α and β are defined in [MappingCylinderMor1_mor] and [MappingCylinderMor2_mor].
+The equality α ;; β = id is proven in [MappingCylinderIso_eq1]. The homotopy χ is constructed
+in [MappingCylinderIsoHomot]. The equality ( * ) is proven in 4 steps. These steps are
+[MappingCylinderIsoHomot_eq1], [MappingCylinderIsoHomot_eq2], [MappingCylinderIsoHomot_eq3],
+and [MappingCylinderIsoHomot_eq4]. The equality β ;; α = id is proved in [MappingCylinderIso_eq2].
+The fact that Y and Cyl(f) are isomorphic in K(A) is proved in [MappingCylinderIso].
+*)
+Section mapping_cylinder_KA_iso.
+
+  Variable A : Additive.
+
+
+  Definition MappingCylinderMor1_mor {C1 C2 : Complex A} (f : (ComplexPreCat_Additive A)⟦C1, C2⟧)
+             (i : hz) : A ⟦ C2 i, (MappingCylinder A f) i ⟧.
+  Proof.
+    unfold MappingCylinder. cbn.
+    set (DS1 := to_BinDirectSums A (C1 (i + 1)) (C2 i)).
+    set (DS2 := to_BinDirectSums A (C1 i) DS1).
+    use compose.
+    - exact DS1.
+    - use (to_In2 A DS1).
+    - use (to_In2 A DS2).
+  Defined.
+
+  Lemma MappingCylinderMor1_comm {C1 C2 : Complex A} (f : (ComplexPreCat_Additive A)⟦C1, C2⟧)
+        (i : hz) :
+    MappingCylinderMor1_mor f i ;; Diff (MappingCylinder A f) i =
+    Diff C2 i ;; MappingCylinderMor1_mor f (i + 1).
+  Proof.
+    unfold MappingCylinderMor1_mor. cbn.
+    set (DS1 := to_BinDirectSums A (C1 (i + 1)) (C2 i)).
+    set (DS2 := to_BinDirectSums A (C1 i) DS1).
+    set (DS3 := to_BinDirectSums A (C1 (i + 1 + 1)) (C2 (i + 1))).
+    set (DS4 := to_BinDirectSums A (C1 (i + 1)) DS3). rewrite assoc.
+    unfold MappingCylinderDiff. unfold MappingCylinderDiff1.
+    unfold MappingCylinderDiff2. unfold MappingCylinderDiff3.
+    cbn. fold DS1 DS2 DS3 DS4. rewrite to_premor_linear'. rewrite assoc.
+    rewrite <- (assoc _ _ (to_Pr1 A DS2)). rewrite (to_Unel2' DS2).
+    rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left.
+    rewrite to_lunax''. rewrite to_premor_linear'. rewrite assoc. rewrite assoc.
+    rewrite assoc. rewrite assoc.
+    rewrite <- (assoc _ _ (to_Pr2 A DS2)). rewrite (to_IdIn2 A DS2).
+    rewrite id_right. rewrite <- PreAdditive_invrcomp.
+    rewrite (to_Unel2' DS1). rewrite to_inv_zero. rewrite ZeroArrow_comp_left.
+    rewrite to_lunax''. apply cancel_postcomposition.
+    unfold MappingConeDiff. unfold MappingConeDiff1.
+    unfold MappingConeDiff2. unfold MappingConeDiff3.
+    cbn. fold DS1 DS2 DS3 DS4. rewrite to_premor_linear'. rewrite assoc.
+    rewrite (to_Unel2' DS1). rewrite ZeroArrow_comp_left. rewrite to_lunax''.
+    rewrite to_premor_linear'. rewrite assoc. rewrite (to_Unel2' DS1).
+    rewrite ZeroArrow_comp_left. rewrite to_lunax''. rewrite assoc.
+    rewrite (to_IdIn2 A DS1). rewrite id_left. apply idpath.
+  Qed.
+
+  Definition MappingCylinderMor1 {C1 C2 : Complex A} (f : (ComplexPreCat_Additive A)⟦C1, C2⟧) :
+    (ComplexPreCat_Additive A)⟦(ComplexHomotFunctor A C2),
+                              (ComplexHomotFunctor A (MappingCylinder A f))⟧.
+  Proof.
+    cbn. use mk_Morphism.
+    - intros i. exact (MappingCylinderMor1_mor f i).
+    - intros i. exact (MappingCylinderMor1_comm f i).
+  Defined.
+
+  Definition MappingCylinderMor2_mor {C1 C2 : Complex A} (f : (ComplexPreCat_Additive A)⟦C1, C2⟧)
+             (i : hz) : A ⟦ (MappingCylinder A f) i, C2 i ⟧.
+  Proof.
+    unfold MappingCylinder. cbn.
+    set (DS1 := to_BinDirectSums A (C1 (i + 1)) (C2 i)).
+    set (DS2 := to_BinDirectSums A (C1 i) DS1).
+    use to_binop.
+    - use compose.
+      + exact (C1 i).
+      + use (to_Pr1 A DS2).
+        + exact (MMor f i).
+    - use compose.
+      + exact DS1.
+      + use (to_Pr2 A DS2).
+      + use (to_Pr2 A DS1).
+  Defined.
+
+  Lemma MappingCylinderMor2_comm {C1 C2 : Complex A} (f : (ComplexPreCat_Additive A)⟦C1, C2⟧)
+        (i : hz) :
+    MappingCylinderMor2_mor f i ;; Diff C2 i =
+    Diff (MappingCylinder A f) i ;; MappingCylinderMor2_mor f (i + 1).
+  Proof.
+    unfold MappingCylinderMor2_mor. cbn.
+    set (DS1 := to_BinDirectSums A (C1 (i + 1)) (C2 i)).
+    set (DS2 := to_BinDirectSums A (C1 i) DS1).
+    set (DS3 := to_BinDirectSums A (C1 (i + 1 + 1)) (C2 (i + 1))).
+    set (DS4 := to_BinDirectSums A (C1 (i + 1)) DS3).
+    unfold MappingCylinderDiff. unfold MappingCylinderDiff1.
+    unfold MappingCylinderDiff2. unfold MappingCylinderDiff3.
+    cbn. fold DS1 DS2 DS3 DS4. rewrite to_postmor_linear'. rewrite to_postmor_linear'.
+    rewrite to_postmor_linear'. rewrite to_premor_linear'. rewrite to_premor_linear'.
+    rewrite to_premor_linear'. rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
+    rewrite <- (assoc _ _ (to_Pr1 A DS4)). rewrite (to_IdIn1 A DS4). rewrite id_right.
+    rewrite <- (assoc _ _ (to_Pr2 A DS4)). rewrite (to_Unel1' DS4).
+    rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left. rewrite to_runax''.
+    rewrite <- (assoc _ _ (to_Pr1 A DS4)). rewrite (to_IdIn1 A DS4). rewrite id_right.
+    rewrite <- (assoc _ _ (to_Pr2 A DS4)). rewrite (to_Unel1' DS4).
+    rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left. rewrite to_runax''.
+    rewrite <- (assoc _ _ (to_Pr1 A DS4)). rewrite (to_Unel2' DS4).
+    rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left. rewrite to_lunax''.
+    rewrite <- (assoc _ _ (to_Pr2 A DS4)). rewrite (to_IdIn2 A DS4). rewrite id_right.
+    rewrite <- assoc. rewrite (MComm f i). rewrite assoc. use to_rrw.
+    rewrite <- assoc. rewrite <- assoc. rewrite <- assoc. rewrite <- to_premor_linear'.
+    apply cancel_precomposition.
+    unfold MappingConeDiff. unfold MappingConeDiff1.
+    unfold MappingConeDiff2. unfold MappingConeDiff3.
+    cbn. fold DS1 DS2 DS3 DS4. rewrite to_postmor_linear'. rewrite to_postmor_linear'.
+    rewrite assoc. rewrite assoc. rewrite assoc.
+    rewrite <- (assoc _ _ (to_Pr2 A DS3)). rewrite (to_Unel1' DS3).
+    rewrite ZeroArrow_comp_right. rewrite to_lunax''.
+    rewrite <- (assoc _ _ (to_Pr2 A DS3)). rewrite (to_IdIn2 A DS3). rewrite id_right.
+    rewrite <- (assoc _ _ (to_Pr2 A DS3)). rewrite (to_IdIn2 A DS3). rewrite id_right.
+    rewrite <- PreAdditive_invlcomp. rewrite <- to_assoc.
+    rewrite (@to_linvax' A (Additive.to_Zero A)). rewrite to_lunax''. apply idpath.
+  Qed.
+
+  Definition MappingCylinderMor2 {C1 C2 : Complex A} (f : (ComplexPreCat_Additive A)⟦C1, C2⟧) :
+    (ComplexPreCat_Additive A)⟦(ComplexHomotFunctor A (MappingCylinder A f)),
+                               (ComplexHomotFunctor A C2)⟧.
+  Proof.
+    cbn. use mk_Morphism.
+    - intros i. exact (MappingCylinderMor2_mor f i).
+    - intros i. exact (MappingCylinderMor2_comm f i).
+  Defined.
+
+  Lemma MappingCylinderIso_eq1' {C1 C2 : Complex A} (f : (ComplexPreCat_Additive A)⟦C1, C2⟧) :
+    (MappingCylinderMor1 f) ;; (MappingCylinderMor2 f) = identity _.
+  Proof.
+    use MorphismEq. intros i. cbn. unfold MappingCylinderMor1_mor.
+    unfold MappingCylinderMor2_mor. cbn.
+    set (DS1 := to_BinDirectSums A (C1 (i + 1)) (C2 i)).
+    set (DS2 := to_BinDirectSums A (C1 i) DS1).
+    rewrite to_premor_linear'. rewrite assoc.
+    rewrite <- (assoc _ _ (to_Pr1 A DS2)). rewrite (to_Unel2' DS2).
+    rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left. rewrite to_lunax''.
+    rewrite assoc.
+    rewrite <- (assoc _ _ (to_Pr2 A DS2)). rewrite (to_IdIn2 A DS2). rewrite id_right.
+    rewrite (to_IdIn2 A DS1). apply idpath.
+  Qed.
+
+  Lemma MappingCylinderIso_eq1 {C1 C2 : Complex A} (f : (ComplexPreCat_Additive A)⟦C1, C2⟧) :
+    (# (ComplexHomotFunctor A) (MappingCylinderMor1 f))
+      ;; (# (ComplexHomotFunctor A) (MappingCylinderMor2 f)) = identity _.
+  Proof.
+    rewrite <- functor_comp. rewrite MappingCylinderIso_eq1'. rewrite functor_id.
+    apply idpath.
+  Qed.
+
+  Lemma MappingCylinderIsoHomot {C1 C2 : Complex A} (f : (ComplexPreCat_Additive A)⟦C1, C2⟧) :
+    ComplexHomot A (MappingCylinder A f) (MappingCylinder A f).
+  Proof.
+    intros i. unfold MappingCylinder. cbn.
+    set (DS1 := to_BinDirectSums A (C1 (i + 1)) (C2 i)).
+    set (DS2 := to_BinDirectSums A (C1 i) DS1).
+    set (DS3 := to_BinDirectSums A (C1 (i - 1 + 1)) (C2 (i - 1))).
+    set (DS4 := to_BinDirectSums A (C1 (i - 1)) DS3).
+    use compose.
+    - exact (C1 i).
+    - exact (to_Pr1 A DS2).
+    - use compose.
+      + exact DS3.
+      + exact (transportb (fun x' : ob A => precategory_morphisms x' DS3)
+                          (maponpaths C1 (! hzrminusplus i 1)) (to_In1 A DS3)).
+      + exact (to_inv (to_In2 A DS4)).
+  Defined.
+
+  Definition MappingCylinderIsoHomot_mor1 {C1 C2 : Complex A}
+             (f : (ComplexPreCat_Additive A)⟦C1, C2⟧) (i : hz) :
+    A⟦(MappingCylinder A f) i, (MappingCylinder A f) i⟧.
+  Proof.
+    cbn.
+    set (DS1 := to_BinDirectSums A (C1 (i + 1)) (C2 i)).
+    set (DS2 := to_BinDirectSums A (C1 i) DS1).
+    use to_binop.
+    - use compose.
+      + exact (C1 i).
+      + exact (to_Pr1 A DS2).
+      + exact (to_In1 A DS2).
+    - use to_binop.
+      + use compose.
+        * exact (C1 i).
+        * exact (to_Pr1 A DS2).
+        * use compose.
+          -- exact (C1 (i + 1)).
+          -- exact (Diff C1 i).
+          -- use compose.
+             ++ exact DS1.
+             ++ exact (to_In1 A DS1).
+             ++ exact (to_In2 A DS2).
+      + use compose.
+        * exact (C1 i).
+        * exact (to_Pr1 A DS2).
+        * use compose.
+          -- exact (C2 i).
+          -- exact (to_inv (MMor f i)).
+          -- use compose.
+             ++ exact DS1.
+             ++ exact (to_In2 A DS1).
+             ++ exact (to_In2 A DS2).
+  Defined.
+
+  Lemma MappingCylinderIsoHomot_eq1 {C1 C2 : Complex A} (f : (ComplexPreCat_Additive A)⟦C1, C2⟧)
+        (i : hz) :
+    (transportf (precategory_morphisms
+                   (to_BinDirectSums A (C1 i) (to_BinDirectSums A (C1 (i + 1)) (C2 i))))
+                (maponpaths (λ (i0 : hz),
+                             BinDirectSumConeOb
+                               A (to_BinDirectSums
+                                    A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1)) (C2 i0))))
+                            (hzrminusplus i 1))
+                (MappingCylinderIsoHomot f i ;; MappingCylinderDiff A f (i - 1))) =
+    MappingCylinderIsoHomot_mor1 f i.
+  Proof.
+    cbn. rewrite transportf_postcompose.
+    unfold MappingCylinderIsoHomot. unfold MappingCylinderIsoHomot_mor1. cbn.
+    set (DS1 := to_BinDirectSums A (C1 (i + 1)) (C2 i)).
+    set (DS2 := to_BinDirectSums A (C1 i) DS1).
+    set (DS3 := to_BinDirectSums A (C1 (i - 1 + 1)) (C2 (i - 1))).
+    set (DS4 := to_BinDirectSums A (C1 (i - 1)) DS3).
+    set (DS5 := to_BinDirectSums A (C1 (i - 1 + 1 + 1)) (C2 (i - 1 + 1))).
+    set (DS6 := to_BinDirectSums A (C1 (i - 1 + 1)) DS5). cbn.
+    rewrite <- assoc. rewrite <- assoc. rewrite <- to_premor_linear'. rewrite <- to_premor_linear'.
+    apply cancel_precomposition. rewrite <- transportf_postcompose.
+    rewrite assoc. rewrite assoc. rewrite <- to_postmor_linear'.
+    rewrite <- transportf_postcompose. rewrite <- transportb_precompose.
+    (* Unfold MappingCylinderDiff *)
+    unfold MappingCylinderDiff. unfold MappingCylinderDiff1.
+    unfold MappingCylinderDiff2. unfold MappingCylinderDiff3. cbn.
+    fold DS1 DS2 DS3 DS4 DS5 DS6. cbn. rewrite assoc. rewrite assoc. rewrite assoc.
+    rewrite assoc.
+    (* simplify *)
+    rewrite <- PreAdditive_invrcomp. rewrite <- PreAdditive_invrcomp.
+    rewrite to_premor_linear'. rewrite assoc. rewrite assoc.
+    rewrite <- PreAdditive_invlcomp. rewrite <- (assoc _ _ (to_Pr1 A DS4)).
+    rewrite (to_Unel2' DS4). rewrite ZeroArrow_comp_right. rewrite to_inv_zero.
+    rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_left. rewrite to_lunax''.
+    rewrite to_premor_linear'. rewrite assoc. rewrite assoc. rewrite assoc.
+    rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invrcomp. rewrite assoc.
+    rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invlcomp.
+    rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invlcomp.
+    rewrite <- PreAdditive_invlcomp.
+    rewrite <- (assoc _ _ (to_Pr2 A DS4)). rewrite (to_IdIn2 A DS4). rewrite id_right.
+    rewrite inv_inv_eq.
+    (* Unfold MappingConeDiff *)
+    unfold MappingConeDiff. unfold MappingConeDiff1.
+    unfold MappingConeDiff2. unfold MappingConeDiff3. cbn.
+    fold DS1 DS2 DS3 DS4 DS5 DS6. cbn. rewrite to_premor_linear'.
+    rewrite assoc. rewrite to_premor_linear'. rewrite assoc. rewrite assoc. rewrite assoc.
+    rewrite assoc. rewrite assoc.
+    rewrite (to_IdIn1 A DS3). rewrite id_left. rewrite id_left.
+    rewrite (to_Unel1' DS3). rewrite id_left. rewrite ZeroArrow_comp_left.
+    rewrite ZeroArrow_comp_left. rewrite to_runax''.
+    unfold DiffTranslationComplex. cbn.
+    (* rewrite transports *)
+    rewrite <- transportb_to_binop. rewrite <- transportf_to_binop. rewrite <- transportb_to_inv.
+    rewrite <- transportf_to_inv. cbn. rewrite to_postmor_linear'. rewrite <- transportb_to_binop.
+    rewrite <- transportf_to_binop.
+    (* The first terms of to_binop are equal, cancel them *)
+    assert (e1 : (transportf
+                    (precategory_morphisms (C1 i))
+                    (maponpaths
+                       (λ (i0 : pr1 hz),
+                        BinDirectSumConeOb
+                          A (to_BinDirectSums
+                               A (C1 i0)
+                               (to_BinDirectSums A (C1 (i0 + 1)) (C2 i0))))
+                       (hzrminusplus i 1))
+                    (transportb (λ x' : A, A ⟦ x', DS6 ⟧) (maponpaths C1 (! hzrminusplus i 1))
+                                (to_In1 A DS6))) = (to_In1 A DS2)).
+    {
+      cbn. unfold DS2, DS1, DS6, DS5.
+      set (tmp := fun (i0 : hz) =>
+                    BinDirectSumConeOb
+                      A (to_BinDirectSums A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1)) (C2 i0)))).
+      set (tmp'' := (fun (i0 : hz) =>
+                       to_In1 A (to_BinDirectSums A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1))
+                                                                              (C2 i0))))).
+      set (tmp' := @transport_hz_double_section_f_b A C1 tmp tmp'' _ _ (hzrminusplus i 1)).
+      unfold tmp'' in tmp'.
+      rewrite tmp'. unfold tmp. apply idpath.
+    }
+    cbn in e1. cbn. rewrite <- e1. clear e1. use to_rrw.
+    (* The first term of to_binop are equal, cancel them *)
+    rewrite <- to_binop_inv_inv. rewrite transportf_to_inv. rewrite transportb_to_inv.
+    rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invlcomp. rewrite inv_inv_eq.
+    rewrite transportf_to_inv. rewrite transportb_to_inv. rewrite PreAdditive_invlcomp.
+    rewrite PreAdditive_invlcomp. rewrite to_postmor_linear'.
+    assert (e1 : (transportf (precategory_morphisms (C1 i))
+                             (maponpaths
+                                (λ (i0 : pr1 hz),
+                                 BinDirectSumConeOb
+                                   A (to_BinDirectSums
+                                        A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1)) (C2 i0))))
+                                (hzrminusplus i 1))
+                             (transportb (λ x' : A, A ⟦ x', DS6 ⟧)
+                                         (maponpaths C1 (! hzrminusplus i 1))
+                                         (Diff C1 (i - 1 + 1) ;; to_In1 A DS5 ;; to_In2 A DS6))) =
+                 (Diff C1 i ;; to_In1 A DS1 ;; to_In2 A DS2)).
+    {
+      cbn. unfold DS2, DS1, DS6, DS5.
+      set (tmp := fun i0 : hz => BinDirectSumConeOb
+                                A (to_BinDirectSums A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1))
+                                                                                (C2 i0)))).
+      set (tmp'' := (fun (i0 : hz) =>
+                       (Diff C1 i0)
+                         ;; (to_In1 A (to_BinDirectSums A (C1 (i0 + 1)) (C2 i0)))
+                         ;; (to_In2 A (to_BinDirectSums A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1))
+                                                                                    (C2 i0)))))).
+      set (tmp' := @transport_hz_double_section_f_b A C1 tmp tmp'' _ _ (hzrminusplus i 1)).
+      unfold tmp'' in tmp'.
+      rewrite tmp'. unfold tmp. apply idpath.
+    }
+    rewrite <- e1. clear e1. use to_rrw.
+    (* Solve the rest *)
+    cbn. unfold DS2, DS1, DS6, DS5.
+    set (tmp := fun i0 : hz => BinDirectSumConeOb
+                              A (to_BinDirectSums A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1))
+                                                                              (C2 i0)))).
+    set (tmp'' := (fun (i0 : hz) =>
+                     (to_inv (MMor f i0))
+                       ;; (to_In2 A (to_BinDirectSums A (C1 (i0 + 1)) (C2 i0)))
+                       ;; (to_In2 A (to_BinDirectSums A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1))
+                                                                                  (C2 i0)))))).
+    set (tmp' := @transport_hz_double_section_f_b A C1 tmp tmp'' _ _ (hzrminusplus i 1)).
+    unfold tmp'' in tmp'.
+    rewrite tmp'. unfold tmp. apply idpath.
+  Qed.
+
+  Definition MappingCylinderIsoHomot_mor2 {C1 C2 : Complex A}
+             (f : (ComplexPreCat_Additive A)⟦C1, C2⟧) (i : hz) :
+    A⟦(MappingCylinder A f) i, (MappingCylinder A f) i⟧.
+  Proof.
+    cbn.
+    set (DS1 := to_BinDirectSums A (C1 (i + 1)) (C2 i)).
+    set (DS2 := to_BinDirectSums A (C1 i) DS1).
+    use to_binop.
+    - use compose.
+      + exact (C1 i).
+      + exact (to_Pr1 A DS2).
+      + use compose.
+        * exact (C1 (i + 1)).
+        * exact (to_inv (Diff C1 i)).
+        * use compose.
+          -- exact DS1.
+          -- exact (to_In1 A DS1).
+          -- exact (to_In2 A DS2).
+    - use compose.
+      + exact DS1.
+      + exact (to_Pr2 A DS2).
+      + use compose.
+        * exact (C1 (i + 1)).
+        * exact (to_Pr1 A DS1).
+        * use compose.
+          -- exact DS1.
+          -- exact (to_In1 A DS1).
+          -- exact (to_In2 A DS2).
+  Defined.
+
+  Lemma MappyngCylinderIsoHomot_eq2 {C1 C2 : Complex A} (f : (ComplexPreCat_Additive A)⟦C1, C2⟧)
+        (i : hz) :
+    (transportf (precategory_morphisms
+                   (to_BinDirectSums A (C1 i) (to_BinDirectSums A (C1 (i + 1)) (C2 i))))
+                (maponpaths (λ (i0 : pr1 hz),
+                             BinDirectSumConeOb
+                               A (to_BinDirectSums A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1))
+                                                                               (C2 i0))))
+                            (hzrplusminus i 1))
+                (MappingCylinderDiff A f i ;; MappingCylinderIsoHomot f (i + 1))) =
+    MappingCylinderIsoHomot_mor2 f i.
+  Proof.
+    cbn. unfold MappingCylinderIsoHomot. unfold MappingCylinderIsoHomot_mor2. cbn.
+    set (DS1 := to_BinDirectSums A (C1 (i + 1)) (C2 i)).
+    set (DS2 := to_BinDirectSums A (C1 i) DS1).
+    set (DS3 := to_BinDirectSums A (C1 (i + 1 + 1)) (C2 (i + 1))).
+    set (DS4 := to_BinDirectSums A (C1 (i + 1)) DS3).
+    set (DS5 := to_BinDirectSums A (C1 (i + 1 - 1 + 1)) (C2 (i + 1 - 1))).
+    set (DS6 := to_BinDirectSums A (C1 (i + 1 - 1)) DS5). cbn.
+    unfold MappingCylinderDiff. unfold MappingCylinderDiff1.
+    unfold MappingCylinderDiff2. unfold MappingCylinderDiff3. cbn.
+    fold DS1 DS2 DS3 DS4 DS5 DS6. cbn.
+    rewrite to_postmor_linear'. rewrite to_postmor_linear'. rewrite <- transportf_to_binop.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
+    rewrite assoc.
+    rewrite <- (assoc _ _ (to_Pr1 A DS4)). rewrite (to_IdIn1 A DS4). rewrite id_right.
+    rewrite <- (assoc _ _ (to_Pr1 A DS4)). rewrite (to_IdIn1 A DS4). rewrite id_right.
+    rewrite <- (assoc _ _ (to_Pr1 A DS4)). rewrite (to_Unel2' DS4).
+    rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_left.
+    rewrite to_runax''.
+    (* The first terms of to_binop are equal, cancel them *)
+    assert (e1 : (transportf (precategory_morphisms DS2)
+                             (maponpaths
+                                (λ (i0 : pr1 hz),
+                                 BinDirectSumConeOb
+                                   A (to_BinDirectSums A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1))
+                                                                                   (C2 i0))))
+                                (hzrplusminus i 1))
+                             (to_Pr1 A DS2 ;; Diff C1 i ;; transportb (λ x' : A, A ⟦ x', DS5 ⟧)
+                                     (maponpaths C1 (! hzrminusplus (i + 1) 1))
+                                     (to_In1 A DS5) ;; to_inv (to_In2 A DS6))) =
+                 ((to_Pr1 A DS2) ;; (to_inv (Diff C1 i)) ;; (to_In1 A DS1) ;; (to_In2 A DS2))).
+    {
+      rewrite transportf_postcompose. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
+      rewrite <- assoc. apply cancel_precomposition.
+      rewrite <- PreAdditive_invlcomp. rewrite PreAdditive_invrcomp. apply cancel_precomposition.
+      rewrite <- transportf_postcompose. rewrite <- transportb_precompose.
+      rewrite <- PreAdditive_invrcomp.
+      unfold DS2, DS1, DS6, DS5.
+      set (tmp := fun i0 : hz => BinDirectSumConeOb
+                                A (to_BinDirectSums A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1))
+                                                                                (C2 i0)))).
+      set (tmp'' := (fun i0 : hz =>
+                       (to_inv ((to_In1 A (to_BinDirectSums A (C1 (i0 + 1)) (C2 i0)))
+                                  ;; (to_In2 A (to_BinDirectSums
+                                                  A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1))
+                                                                              (C2 i0)))))))).
+      set (tmp' := @transport_hz_double_section_f_b
+                     A (fun i0 : hz => C1 (i0 + 1)) tmp tmp'' _ _ (hzrplusminus i 1)).
+      unfold tmp'' in tmp'. rewrite tmp'. unfold tmp. apply maponpaths.
+      assert (e2 : maponpaths C1 (! hzrminusplus (i + 1) 1) =
+                   maponpaths (λ i0 : hz, C1 (i0 + 1)) (! hzrplusminus i 1)).
+      {
+        assert (e3 : maponpaths (λ i0 : hz, C1 (i0 + 1)) (! hzrplusminus i 1) =
+                     maponpaths C1 (maponpaths (fun i0 : hz => i0 + 1) (! hzrplusminus i 1))).
+        {
+          induction (hzrplusminus i 1). apply idpath.
+        }
+        rewrite e3. clear e3. apply maponpaths. apply isasethz.
+      }
+      rewrite <- e2. apply idpath.
+    }
+    cbn in e1. cbn. rewrite <- e1. clear e1. use to_rrw.
+    (* Use similar technique as above *)
+    rewrite transportf_postcompose. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
+    rewrite <- assoc. apply cancel_precomposition.
+    rewrite <- PreAdditive_invlcomp. rewrite PreAdditive_invrcomp. apply cancel_precomposition.
+    rewrite <- transportf_postcompose. rewrite <- transportb_precompose.
+    rewrite <- PreAdditive_invrcomp.
+    unfold DS2, DS1, DS6, DS5. rewrite transportf_to_inv. rewrite transportb_to_inv.
+    rewrite inv_inv_eq.
+    set (tmp := fun i0 : hz => BinDirectSumConeOb
+                              A (to_BinDirectSums A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1))
+                                                                              (C2 i0)))).
+    set (tmp'' := (fun i0 : hz =>
+                     (to_In1 A (to_BinDirectSums A (C1 (i0 + 1)) (C2 i0)))
+                       ;; (to_In2 A (to_BinDirectSums
+                                       A (C1 i0) (to_BinDirectSums A (C1 (i0 + 1)) (C2 i0)))))).
+    set (tmp' := @transport_hz_double_section_f_b
+                   A (fun i0 : hz => C1 (i0 + 1)) tmp tmp'' _ _ (hzrplusminus i 1)).
+    unfold tmp'' in tmp'.
+    rewrite tmp'. unfold tmp. apply maponpaths.
+    assert (e2 : maponpaths C1 (! hzrminusplus (i + 1) 1) =
+                 maponpaths (λ i0 : hz, C1 (i0 + 1)) (! hzrplusminus i 1)).
+    {
+      assert (e3 : maponpaths (λ i0 : hz, C1 (i0 + 1)) (! hzrplusminus i 1) =
+                   maponpaths C1 (maponpaths (fun i0 : hz => i0 + 1) (! hzrplusminus i 1))).
+      {
+        induction (hzrplusminus i 1). apply idpath.
+        }
+        rewrite e3. clear e3. apply maponpaths. apply isasethz.
+    }
+    rewrite <- e2. apply idpath.
+  Qed.
+
+  Lemma MappingCylinderisoHomot_eq3 {C1 C2 : Complex A} (f : (ComplexPreCat_Additive A)⟦C1, C2⟧)
+        (i : hz) :
+    let DS1 := to_BinDirectSums A (C1 (i + 1)) (C2 i) in
+    let DS2 := to_BinDirectSums A (C1 i) DS1 in
+    to_binop DS2 DS2
+             (to_binop DS2 DS2 (to_Pr1 A DS2 ;; to_In1 A DS2)
+                       (to_Pr2 A DS2 ;; to_Pr1 A DS1 ;; to_In1 A DS1 ;; to_In2 A DS2))
+             (to_inv (to_Pr1 A DS2 ;; MMor f i ;; to_In2 A DS1 ;; to_In2 A DS2)) =
+    to_binop DS2 DS2 (MappingCylinderIsoHomot_mor1 f i) (MappingCylinderIsoHomot_mor2 f i).
+  Proof.
+    intros DS1 DS2.
+    unfold MappingCylinderIsoHomot_mor1. unfold MappingCylinderIsoHomot_mor2.
+    cbn. fold DS1 DS2. cbn. rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
+    rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
+    rewrite to_assoc. rewrite to_assoc. use to_rrw. rewrite to_commax'.
+    rewrite (to_commax'
+               _ _ ((to_Pr1 A DS2) ;; (to_inv (MMor f i)) ;; (to_In2 A DS1) ;; (to_In2 A DS2))).
+    rewrite to_assoc. rewrite <- PreAdditive_invrcomp. rewrite <- PreAdditive_invlcomp.
+    rewrite <- PreAdditive_invlcomp. use to_rrw. rewrite <- to_assoc.
+    rewrite <- PreAdditive_invrcomp. rewrite <- PreAdditive_invlcomp.
+    rewrite <- PreAdditive_invlcomp. rewrite (@to_rinvax' A (Additive.to_Zero A)).
+    rewrite to_lunax''. apply idpath.
+  Qed.
+
+  Lemma MappingCylinderIsoHomot_eq {C1 C2 : Complex A} (f : (ComplexPreCat_Additive A)⟦C1, C2⟧) :
+    to_binop _ _ (identity _) (to_inv (MappingCylinderMor2 f ;; MappingCylinderMor1 f)) =
+    ComplexHomotMorphism A (MappingCylinderIsoHomot f).
+  Proof.
+    use MorphismEq. intros i. cbn.
+    unfold MappingCylinderMor1_mor. unfold MappingCylinderMor2_mor. cbn.
+    set (DS1 := to_BinDirectSums A (C1 (i + 1)) (C2 i)).
+    set (DS2 := to_BinDirectSums A (C1 i) DS1).
+    rewrite to_postmor_linear'. rewrite <- to_binop_inv_inv.
+    rewrite <- (to_BinOpId A DS2).
+    assert (e : to_Pr2 A DS2 ;; to_In2 A DS2 = to_Pr2 A DS2 ;; identity _ ;; to_In2 A DS2).
+    {
+      rewrite id_right. apply idpath.
+    }
+    rewrite e. clear e. rewrite <- (to_BinOpId A DS1). rewrite to_premor_linear'.
+    rewrite to_postmor_linear'. rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
+    rewrite to_assoc. rewrite to_assoc.
+    rewrite (to_commax'
+               _ (to_inv (to_Pr1 A DS2 ;; MMor f i ;; to_In2 A DS1 ;; to_In2 A DS2))).
+    rewrite <- (to_assoc
+                 _ _ _ (to_inv (to_Pr1 A DS2 ;; MMor f i ;; to_In2 A DS1 ;; to_In2 A DS2))).
+    rewrite (@to_rinvax' A (Additive.to_Zero A)). rewrite to_lunax''. rewrite <- to_assoc.
+    use (pathscomp0 (MappingCylinderisoHomot_eq3 f i)).
+    rewrite <- (MappingCylinderIsoHomot_eq1 f i). rewrite <- (MappyngCylinderIsoHomot_eq2 f i).
+    unfold DS2. unfold DS1. apply idpath.
+  Qed.
+
+  Lemma MappingCylinderIso_eq2 {C1 C2 : Complex A} (f : (ComplexPreCat_Additive A)⟦C1, C2⟧) :
+    (# (ComplexHomotFunctor A) (MappingCylinderMor2 f))
+      ;; (# (ComplexHomotFunctor A) (MappingCylinderMor1 f)) = identity _.
+  Proof.
+    rewrite <- functor_comp. rewrite <- functor_id. apply pathsinv0.
+    use ComplexHomotFunctor_rel_mor'.
+    - exact (MappingCylinderIsoHomot f).
+    - exact (MappingCylinderIsoHomot_eq f).
+  Qed.
+
+  Definition MappingCylinderIso {C1 C2 : Complex A} (f : (ComplexPreCat_Additive A)⟦C1, C2⟧) :
+    iso (ComplexHomotFunctor A C2) (ComplexHomotFunctor A (MappingCylinder A f)).
+  Proof.
+    use tpair.
+    - exact (# (ComplexHomotFunctor A) (MappingCylinderMor1 f)).
+    - use is_iso_qinv.
+      + exact (# (ComplexHomotFunctor A) (MappingCylinderMor2 f)).
+      + split.
+        * exact (MappingCylinderIso_eq1 f).
+        * exact (MappingCylinderIso_eq2 f).
+  Qed.
+
+End mapping_cylinder_KA_iso.
 
 Local Transparent hz isdecrelhzeq hzplus iscommrngops ZeroArrow.
 Close Scope hz_scope.

--- a/UniMath/CategoryTheory/Epis.v
+++ b/UniMath/CategoryTheory/Epis.v
@@ -94,14 +94,14 @@ Section def_epi.
   Defined.
 
   (** Transport of isEpi *)
-  Lemma transportf_isEpi {x y z : C} (f : x --> y) (E : isEpi f) (e : y = z) :
+  Lemma transport_target_isEpi {x y z : C} (f : x --> y) (E : isEpi f) (e : y = z) :
     isEpi (transportf (precategory_morphisms x) e f).
   Proof.
     induction e. apply E.
   Qed.
 
-  Lemma transportb_isEpi {x y z : C} (f : y --> z) (E : isEpi f) (e : x = y) :
-    isEpi (transportb (fun x' : ob C => precategory_morphisms x' z) e f).
+  Lemma transport_source_isEpi {x y z : C} (f : y --> z) (E : isEpi f) (e : y = x) :
+    isEpi (transportf (fun x' : ob C => precategory_morphisms x' z) e f).
   Proof.
     induction e. apply E.
   Qed.

--- a/UniMath/CategoryTheory/Monics.v
+++ b/UniMath/CategoryTheory/Monics.v
@@ -95,14 +95,14 @@ Section def_monic.
   Defined.
 
   (** Transport of isMonic *)
-  Lemma transportf_isMonic {x y z : C} (f : x --> y) (E : isMonic f) (e : y = z) :
+  Lemma transport_target_isMonic {x y z : C} (f : x --> y) (E : isMonic f) (e : y = z) :
     isMonic (transportf (precategory_morphisms x) e f).
   Proof.
     induction e. apply E.
   Qed.
 
-  Lemma transportb_isMonic {x y z : C} (f : y --> z) (E : isMonic f) (e : x = y) :
-    isMonic (transportb (fun x' : ob C => precategory_morphisms x' z) e f).
+  Lemma transport_source_isMonic {x y z : C} (f : y --> z) (E : isMonic f) (e : y = x) :
+    isMonic (transportf (fun x' : ob C => precategory_morphisms x' z) e f).
   Proof.
     induction e. apply E.
   Qed.

--- a/UniMath/CategoryTheory/Morphisms.v
+++ b/UniMath/CategoryTheory/Morphisms.v
@@ -10,9 +10,10 @@ Require Import UniMath.Foundations.Basics.Sets.
 
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.opp_precat.
 
 Require Import UniMath.CategoryTheory.limits.zero.
-
+Require Import UniMath.CategoryTheory.limits.Opp.
 
 (** * Pair of morphisms *)
 Section def_morphismpair.
@@ -53,6 +54,33 @@ Arguments Ob3 [C] _.
 Arguments Mor1 [C] _.
 Arguments Mor2 [C] _.
 
+
+(** * MorphismPair and opposite categories *)
+Section MorphismPair_opp.
+
+  Definition MorphismPair_opp {C : precategory} (MP : MorphismPair C) : MorphismPair (opp_precat C).
+  Proof.
+    use mk_MorphismPair.
+    - exact (Ob3 MP).
+    - exact (Ob2 MP).
+    - exact (Ob1 MP).
+    - exact (Mor2 MP).
+    - exact (Mor1 MP).
+  Defined.
+
+  Definition opp_MorphismPair {C : precategory} (MP : MorphismPair (opp_precat C)) : MorphismPair C.
+  Proof.
+    use mk_MorphismPair.
+    - exact (Ob3 MP).
+    - exact (Ob2 MP).
+    - exact (Ob1 MP).
+    - exact (Mor2 MP).
+    - exact (Mor1 MP).
+  Defined.
+
+End MorphismPair_opp.
+
+
 (** * ShortShortExactData *)
 Section def_shortshortexactdata.
 
@@ -68,12 +96,7 @@ Section def_shortshortexactdata.
     Σ MP : MorphismPair C, Mor1 MP ;; Mor2 MP = ZeroArrow Z _ _.
 
   Definition mk_ShortShortExactData (MP : MorphismPair C)
-             (H : Mor1 MP ;; Mor2 MP = ZeroArrow Z _ _) : ShortShortExactData.
-  Proof.
-    use tpair.
-    - exact MP.
-    - exact H.
-  Defined.
+             (H : Mor1 MP ;; Mor2 MP = ZeroArrow Z _ _) : ShortShortExactData := tpair _ MP H.
 
   (** Accessor functions *)
   Definition ShortShortExactData_MorphismPair (SSED : ShortShortExactData) :
@@ -86,3 +109,43 @@ Section def_shortshortexactdata.
 End def_shortshortexactdata.
 Arguments mk_ShortShortExactData [C] _ _ _.
 Arguments ShortShortExactData_Eq [C] _ _.
+
+
+(** * ShortShortExactData and opposite categories *)
+Section shortshortexactdata_opp.
+
+  Lemma opp_ShortShortExactData_Eq {C : precategory} {Z : Zero C}
+             (SSED : ShortShortExactData (opp_precat C) (Zero_opp C Z)) :
+    Mor1 (opp_MorphismPair SSED) ;; Mor2 (opp_MorphismPair SSED) =
+    ZeroArrow Z (Ob1 (opp_MorphismPair SSED)) (Ob3 (opp_MorphismPair SSED)).
+  Proof.
+    use (pathscomp0 (@ShortShortExactData_Eq (opp_precat C) (Zero_opp C Z) SSED)).
+    rewrite <- ZeroArrow_opp. apply idpath.
+  Qed.
+
+  Definition opp_ShortShortExactData {C : precategory} {Z : Zero C}
+             (SSED : ShortShortExactData (opp_precat C) (Zero_opp C Z)) : ShortShortExactData C Z.
+  Proof.
+    use mk_ShortShortExactData.
+    - exact (opp_MorphismPair SSED).
+    - exact (opp_ShortShortExactData_Eq SSED).
+  Defined.
+
+  Lemma ShortShortExactData_opp_Eq {C : precategory} {Z : Zero C}
+        (SSED : ShortShortExactData C Z) :
+    Mor1 (MorphismPair_opp SSED) ;; Mor2 (MorphismPair_opp SSED) =
+    ZeroArrow (Zero_opp C Z) (Ob1 (MorphismPair_opp SSED)) (Ob3 (MorphismPair_opp SSED)).
+  Proof.
+    use (pathscomp0 (@ShortShortExactData_Eq C Z SSED)).
+    rewrite <- ZeroArrow_opp. apply idpath.
+  Qed.
+
+  Definition ShortShortExactData_opp {C : precategory} {Z : Zero C}
+             (SSED : ShortShortExactData C Z) : ShortShortExactData (opp_precat C) (Zero_opp C Z).
+  Proof.
+    use mk_ShortShortExactData.
+    - exact (MorphismPair_opp SSED).
+    - exact (ShortShortExactData_opp_Eq SSED).
+  Defined.
+
+End shortshortexactdata_opp.

--- a/UniMath/CategoryTheory/PreAdditive.v
+++ b/UniMath/CategoryTheory/PreAdditive.v
@@ -138,6 +138,34 @@ Section preadditive_with_zero.
     apply idpath.
   Qed.
 
+  Lemma to_lunax'' {Z : Zero A} (x y : A) (f : x --> y) : to_binop x y (ZeroArrow Z x y) f = f.
+  Proof.
+    rewrite <- to_lunax'. use to_lrw. apply pathsinv0. apply PreAdditive_unel_zero.
+  Qed.
+
+  Lemma to_runax'' {Z : Zero A} (x y : A) (f : x --> y) : to_binop x y f (ZeroArrow Z x y) = f.
+  Proof.
+    rewrite <- to_runax'. use to_rrw. apply pathsinv0. apply PreAdditive_unel_zero.
+  Qed.
+
+  Lemma to_linvax' {Z : Zero A} {x y : A} (f : A⟦x, y⟧) :
+    to_binop x y (to_inv f) f = ZeroArrow Z x y.
+  Proof.
+    rewrite linvax. apply PreAdditive_unel_zero.
+  Qed.
+
+  Lemma to_rinvax' {Z : Zero A} {x y : A} (f : A⟦x, y⟧) :
+    to_binop x y f (to_inv f) = ZeroArrow Z x y.
+  Proof.
+    rewrite rinvax. apply PreAdditive_unel_zero.
+  Qed.
+
+  Lemma to_inv_zero {Z : Zero A} {x y : A} : to_inv (ZeroArrow Z x y) = ZeroArrow Z x y.
+  Proof.
+    rewrite <- PreAdditive_unel_zero.
+    apply to_inv_unel.
+  Qed.
+
 End preadditive_with_zero.
 
 
@@ -148,29 +176,28 @@ Section preadditive_inv_comp.
   Variable A : PreAdditive.
 
   Lemma PreAdditive_invlcomp {x y z : A} (f : A⟦x, y⟧) (g : A⟦y, z⟧) :
-    (to_inv x z (f ;; g)) = (to_inv x y f) ;; g.
+    (to_inv (f ;; g)) = (to_inv f) ;; g.
   Proof.
     use (grrcan (to_abgrop x z) (f ;; g)).
     unfold to_inv at 1. rewrite grlinvax.
-    use (pathscomp0 _ (to_postmor_linear' (to_inv x y f) f g)).
+    use (pathscomp0 _ (to_postmor_linear' (to_inv f) f g)).
     rewrite linvax. rewrite to_postmor_unel'.
     unfold to_unel.
     apply idpath.
   Qed.
 
   Lemma PreAdditive_invrcomp {x y z : A} (f : A⟦x, y⟧) (g : A⟦y, z⟧) :
-    (to_inv _ _ (f ;; g)) = f ;; (to_inv _ _ g).
+    (to_inv (f ;; g)) = f ;; (to_inv g).
   Proof.
     use (grrcan (to_abgrop x z) (f ;; g)).
     unfold to_inv at 1. rewrite grlinvax.
-    use (pathscomp0 _ (to_premor_linear' f (to_inv y z g) g)).
+    use (pathscomp0 _ (to_premor_linear' f (to_inv g) g)).
     rewrite linvax. rewrite to_premor_unel'.
     unfold to_unel.
     apply idpath.
   Qed.
 
-  Lemma PreAdditive_cancel_inv {x y : A} (f g : A⟦x, y⟧) (H : (to_inv _ _ f)  = (to_inv _ _ g)) :
-    f = g.
+  Lemma PreAdditive_cancel_inv {x y : A} (f g : A⟦x, y⟧) (H : (to_inv f)  = (to_inv g)) : f = g.
   Proof.
     apply (grinvmaponpathsinv (to_abgrop x y) H).
   Qed.
@@ -410,6 +437,13 @@ Section preadditive_quotient.
         (e : setquotpr H f = setquotpr H g) : H f g.
   Proof.
     exact (abgrquotpr_rel_to_refl (! (funeqpaths (base_paths _ _ e)) g)).
+  Qed.
+
+  Lemma abgrquotpr_rel_image {A : abgr} {H : @binopeqrel A} {f g : A}
+        (e : H f g) : setquotpr H f = setquotpr H g.
+  Proof.
+    apply iscompsetquotpr.
+    exact e.
   Qed.
 
   (** *** Morphisms to elements of groups *)

--- a/UniMath/CategoryTheory/PreAdditive.v
+++ b/UniMath/CategoryTheory/PreAdditive.v
@@ -18,7 +18,7 @@ Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
-Require Import UniMath.CategoryTheory.PrecategoriesWithBinOps.
+Require Import UniMath.CategoryTheory.precategoriesWithBinOps.
 Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
 
 Require Import UniMath.CategoryTheory.limits.zero.
@@ -756,9 +756,9 @@ Section preadditive_quotient.
   (** ** Quotient precategory of PreAdditive is PreAdditive *)
 
   Opaque isbinopeqrel_subgr_eqrel isabgrquot.
-  Definition QuotPrecategory_binops : PrecategoryWithBinOps.
+  Definition QuotPrecategory_binops : precategoryWithBinOps.
   Proof.
-    use mk_PrecategoryWithBinOps.
+    use mk_precategoryWithBinOps.
     - exact QuotPrecategory.
     - intros x y. exact (@op (subabgr_quot (PAS x y))).
   Defined.

--- a/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
+++ b/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
@@ -184,21 +184,21 @@ Section transport_morphisms.
 
   Variable PA : PrecategoryWithAbgrops.
 
-  Lemma transportf_to_inv {x y z : ob PA} (f : x --> y) (e : y = z) :
+  Lemma transport_target_to_inv {x y z : ob PA} (f : x --> y) (e : y = z) :
     to_inv (transportf (precategory_morphisms x) e f) =
     transportf (precategory_morphisms x) e (to_inv f).
   Proof.
     induction e. apply idpath.
   Qed.
 
-  Lemma transportb_to_inv {x y z : ob PA} (f : y --> z) (e : x = y) :
-    to_inv (transportb (fun x' : ob PA => precategory_morphisms x' z) e f) =
-    transportb (fun x' : ob PA => precategory_morphisms x' z) e (to_inv f).
+  Lemma transport_source_to_inv {x y z : ob PA} (f : y --> z) (e : y = x) :
+    to_inv (transportf (fun x' : ob PA => precategory_morphisms x' z) e f) =
+    transportf (fun x' : ob PA => precategory_morphisms x' z) e (to_inv f).
   Proof.
     induction e. apply idpath.
   Qed.
 
-  Lemma transportf_to_binop {x y z : ob PA} (f g : x --> y) (e : y = z) :
+  Lemma transport_target_to_binop {x y z : ob PA} (f g : x --> y) (e : y = z) :
     to_binop _ _ (transportf (precategory_morphisms x) e f)
              (transportf (precategory_morphisms x) e g) =
     transportf (precategory_morphisms x) e (to_binop _ _ f g).
@@ -206,10 +206,10 @@ Section transport_morphisms.
     induction e. apply idpath.
   Qed.
 
-  Lemma transportb_to_binop {x y z : ob PA} (f g : y --> z) (e : x = y) :
-    to_binop _ _ (transportb (fun x' : ob PA => precategory_morphisms x' z) e f)
-             (transportb (fun x' : ob PA => precategory_morphisms x' z) e g) =
-    transportb (fun x' : ob PA => precategory_morphisms x' z) e (to_binop _ _ f g).
+  Lemma transport_source_to_binop {x y z : ob PA} (f g : y --> z) (e : y = x) :
+    to_binop _ _ (transportf (fun x' : ob PA => precategory_morphisms x' z) e f)
+             (transportf (fun x' : ob PA => precategory_morphisms x' z) e g) =
+    transportf (fun x' : ob PA => precategory_morphisms x' z) e (to_binop _ _ f g).
   Proof.
     induction e. apply idpath.
   Qed.

--- a/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
+++ b/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
@@ -28,6 +28,15 @@ Section def_precategory_with_abgrops.
   Coercion PrecategoryWithAbgrops_PrecategoryWithBinOps :
     PrecategoryWithAbgrops >-> PrecategoryWithBinOps.
 
+  (* Precategory with abgrops to Precategory *)
+  Definition PrecategoryWithAbgrops_Precategory (PWA : PrecategoryWithAbgrops) : Precategory.
+  Proof.
+    use tpair.
+    - exact PWA.
+    - exact (pr2 (pr1 PWA)).
+  Defined.
+  Coercion PrecategoryWithAbgrops_Precategory : PrecategoryWithAbgrops >-> Precategory.
+
   Definition mk_PrecategoryWithAbgrops (PB : PrecategoryWithBinOps) (hs : has_homsets PB)
              (H : PrecategoryWithAbgropsData PB hs) : PrecategoryWithAbgrops.
   Proof.
@@ -57,16 +66,21 @@ Section def_precategory_with_abgrops.
     apply to_lunax.
   Qed.
 
-  Definition to_runax (x y : PA) := runax (to_abgrop x y).
+  Definition to_runax (x y : PA) : isrunit op 1%multmonoid := runax (to_abgrop x y).
 
   Definition to_runax' (x y : PA) (f : x --> y) : to_binop x y f (to_unel x y) = f.
   Proof.
     apply to_runax.
   Qed.
 
-  Definition to_inv (x y : PA) :  PA⟦x, y⟧ -> PA⟦x, y⟧ := grinv (to_abgrop x y).
+  Definition to_inv {x y : PA} : PA⟦x, y⟧ -> PA⟦x, y⟧ := grinv (to_abgrop x y).
 
   Definition to_commax (x y : PA) := commax (to_abgrop x y).
+
+  Definition to_commax' {x y : ob PA} (f g : x --> y) : to_binop x y f g = to_binop x y g f.
+  Proof.
+    apply to_commax.
+  Qed.
 
   (** The following definition gives maps between abgrops homsets by precomposing and postcomposing
       with a morphism. Note that we have not required these to be abelian group morphisms of abelian
@@ -79,23 +93,35 @@ Section def_precategory_with_abgrops.
 
 
   (** Some equatios on inverses *)
-  Lemma inv_inv_eq {x y : PA} (f : PA⟦x, y⟧) : to_inv x y (to_inv x y f) = f.
+  Lemma inv_inv_eq {x y : PA} (f : PA⟦x, y⟧) : to_inv (to_inv f) = f.
   Proof.
     unfold to_inv.
     apply (grinvinv (to_abgrop x y) f).
   Qed.
 
-  Lemma cancel_inv {x y : PA} (f g : PA⟦x, y⟧) (H : (to_inv  _ _ f) = (to_inv _ _ g)) : f = g.
+  Lemma cancel_inv {x y : PA} (f g : PA⟦x, y⟧) (H : (to_inv f) = (to_inv g)) : f = g.
   Proof.
     apply (grinvmaponpathsinv (to_abgrop x y) H).
   Qed.
 
-  Lemma linvax {x y : PA} (f : PA⟦x, y⟧) : to_binop x y (to_inv x y f) f = to_unel x y.
+  Lemma to_apply_inv {x y : PA} (f g : PA⟦x, y⟧) (H : f = g) : (to_inv f) = (to_inv g).
+  Proof.
+    apply maponpaths. apply H.
+  Qed.
+
+  Lemma to_inv_unel {x y : PA} : to_inv (to_unel x y) = to_unel x y.
+  Proof.
+    unfold to_unel.
+    set (tmp := grinvunel (to_abgrop x y)). cbn in tmp. unfold to_inv.
+    apply tmp.
+  Qed.
+
+  Lemma linvax {x y : PA} (f : PA⟦x, y⟧) : to_binop x y (to_inv f) f = to_unel x y.
   Proof.
     apply (grlinvax (to_abgrop x y)).
   Qed.
 
-  Lemma rinvax {x y : PA} (f : PA⟦x, y⟧) : to_binop x y f (to_inv x y f) = to_unel x y.
+  Lemma rinvax {x y : PA} (f : PA⟦x, y⟧) : to_binop x y f (to_inv f) = to_unel x y.
   Proof.
     apply (grrinvax (to_abgrop x y)).
   Qed.
@@ -114,6 +140,30 @@ Section def_precategory_with_abgrops.
     apply (grrcan (to_abgrop x y) h H).
   Qed.
 
+  Lemma to_lrw {x y : PA} (f g h : PA⟦x, y⟧) (e : f = g) : to_binop x y f h = to_binop x y g h.
+  Proof.
+    induction e. apply idpath.
+  Qed.
+
+  Lemma to_rrw {x y : PA} (f g h : PA⟦x, y⟧) (e : g = h) : to_binop x y f g = to_binop x y f h.
+  Proof.
+    apply maponpaths. exact e.
+  Qed.
+
+  Lemma to_assoc {x y : PA} (f g h : PA⟦x, y⟧) :
+    to_binop _ _ (to_binop _ _ f g) h = to_binop _ _ f (to_binop _ _ g h).
+  Proof.
+    apply (assocax (to_abgrop x y)).
+  Qed.
+
+  Lemma to_binop_inv_inv {x y : PA} (f g : PA⟦x, y⟧) :
+    to_binop _ _ (to_inv f) (to_inv g) = to_inv (to_binop _ _ f g).
+  Proof.
+    apply (to_rcan g). rewrite to_assoc. rewrite linvax. rewrite to_runax'.
+    apply (to_rcan f). rewrite to_assoc. rewrite linvax. cbn.
+    rewrite <- (linvax (to_binop x y f g)). apply maponpaths. apply to_commax'.
+  Qed.
+
 End def_precategory_with_abgrops.
 Arguments to_has_homsets [PA] _ _ _ _ _ _.
 Arguments to_homset [PA] _ _.
@@ -125,6 +175,43 @@ Arguments to_lunax [PA] _ _ _.
 Arguments to_runax [PA] _ _ _.
 Arguments to_premor [PA] [x] [y] _ _ _.
 Arguments to_postmor [PA] _ [y] [z] _ _.
-Arguments to_inv [PA] _ _ _.
+Arguments to_inv [PA] [x] [y] _.
 Arguments inv_inv_eq [PA] [x] [y] _.
 Arguments cancel_inv [PA] [x] [y] _ _ _.
+
+
+Section transport_morphisms.
+
+  Variable PA : PrecategoryWithAbgrops.
+
+  Lemma transportf_to_inv {x y z : ob PA} (f : x --> y) (e : y = z) :
+    to_inv (transportf (precategory_morphisms x) e f) =
+    transportf (precategory_morphisms x) e (to_inv f).
+  Proof.
+    induction e. apply idpath.
+  Qed.
+
+  Lemma transportb_to_inv {x y z : ob PA} (f : y --> z) (e : x = y) :
+    to_inv (transportb (fun x' : ob PA => precategory_morphisms x' z) e f) =
+    transportb (fun x' : ob PA => precategory_morphisms x' z) e (to_inv f).
+  Proof.
+    induction e. apply idpath.
+  Qed.
+
+  Lemma transportf_to_binop {x y z : ob PA} (f g : x --> y) (e : y = z) :
+    to_binop _ _ (transportf (precategory_morphisms x) e f)
+             (transportf (precategory_morphisms x) e g) =
+    transportf (precategory_morphisms x) e (to_binop _ _ f g).
+  Proof.
+    induction e. apply idpath.
+  Qed.
+
+  Lemma transportb_to_binop {x y z : ob PA} (f g : y --> z) (e : x = y) :
+    to_binop _ _ (transportb (fun x' : ob PA => precategory_morphisms x' z) e f)
+             (transportb (fun x' : ob PA => precategory_morphisms x' z) e g) =
+    transportb (fun x' : ob PA => precategory_morphisms x' z) e (to_binop _ _ f g).
+  Proof.
+    induction e. apply idpath.
+  Qed.
+
+End transport_morphisms.

--- a/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
+++ b/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
@@ -10,23 +10,23 @@ Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
 
-Require Import UniMath.CategoryTheory.PrecategoriesWithBinOps.
+Require Import UniMath.CategoryTheory.precategoriesWithBinOps.
 
 
 Section def_precategory_with_abgrops.
 
   (** Definition of precategories such that homsets are abgrops. *)
-  Definition PrecategoryWithAbgropsData (PB : PrecategoryWithBinOps) (hs : has_homsets PB) : UU :=
+  Definition PrecategoryWithAbgropsData (PB : precategoryWithBinOps) (hs : has_homsets PB) : UU :=
     Π (x y : PB), @isabgrop (hSetpair (PB⟦x,y⟧) (hs x y)) (to_binop x y).
 
   Definition PrecategoryWithAbgrops : UU :=
-    Σ PA : (Σ PB : PrecategoryWithBinOps, has_homsets PB),
+    Σ PA : (Σ PB : precategoryWithBinOps, has_homsets PB),
            PrecategoryWithAbgropsData (pr1 PA) (pr2 PA).
 
-  Definition PrecategoryWithAbgrops_PrecategoryWithBinOps (PB : PrecategoryWithAbgrops) :
-    PrecategoryWithBinOps := pr1 (pr1 PB).
-  Coercion PrecategoryWithAbgrops_PrecategoryWithBinOps :
-    PrecategoryWithAbgrops >-> PrecategoryWithBinOps.
+  Definition PrecategoryWithAbgrops_precategoryWithBinOps (PB : PrecategoryWithAbgrops) :
+    precategoryWithBinOps := pr1 (pr1 PB).
+  Coercion PrecategoryWithAbgrops_precategoryWithBinOps :
+    PrecategoryWithAbgrops >-> precategoryWithBinOps.
 
   (* Precategory with abgrops to Precategory *)
   Definition PrecategoryWithAbgrops_Precategory (PWA : PrecategoryWithAbgrops) : Precategory.
@@ -37,7 +37,7 @@ Section def_precategory_with_abgrops.
   Defined.
   Coercion PrecategoryWithAbgrops_Precategory : PrecategoryWithAbgrops >-> Precategory.
 
-  Definition mk_PrecategoryWithAbgrops (PB : PrecategoryWithBinOps) (hs : has_homsets PB)
+  Definition mk_PrecategoryWithAbgrops (PB : precategoryWithBinOps) (hs : has_homsets PB)
              (H : PrecategoryWithAbgropsData PB hs) : PrecategoryWithAbgrops.
   Proof.
     exact (tpair _ (tpair _ PB hs) H).

--- a/UniMath/CategoryTheory/ShortExactSequences.v
+++ b/UniMath/CategoryTheory/ShortExactSequences.v
@@ -1,10 +1,12 @@
 (** * Short exact sequences *)
 (** ** Contents
-- ShortShortExact sequences
-- Remark on monics, epis, kernels, and cokernels
-- LeftShortExact sequences
-- RightShortExact sequences
-- ShortExact sequences
+- Definitions
+ - ShortShortExact sequences
+ - Remark on monics, epis, kernels, and cokernels
+ - LeftShortExact sequences
+ - RightShortExact sequences
+ - ShortExact sequences
+- Opposite category and (short/left/right)exacts
 - A criteria for ShortShortExact
  - Cokernel from ShortShortExact
  - isCoequalizer to ShortShortExact
@@ -18,6 +20,7 @@ Require Import UniMath.Foundations.Basics.Propositions.
 Require Import UniMath.Foundations.Basics.Sets.
 
 Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.opp_precat.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.Abelian.
 Require Import UniMath.CategoryTheory.Monics.
@@ -29,6 +32,7 @@ Require Import UniMath.CategoryTheory.limits.equalizers.
 Require Import UniMath.CategoryTheory.limits.coequalizers.
 Require Import UniMath.CategoryTheory.limits.kernels.
 Require Import UniMath.CategoryTheory.limits.cokernels.
+Require Import UniMath.CategoryTheory.limits.Opp.
 
 
 (** * Introduction
@@ -96,34 +100,27 @@ Section def_shortexactseqs.
     [ShortShortData] such that the image of the first morphism is the kernel of the second morphism.
     Informally, an exact sequence
                                A -> B -> C
-  *)
+   *)
 
   Definition ShortShortExact : UU :=
     Σ SSED : ShortShortExactData A to_Zero,
-             isEqualizer (Mor2 SSED) (ZeroArrow to_Zero _ _)
-                         (KernelArrow (Image SSED)) (KernelEqRw to_Zero (Image_Eq SSED)).
+             isKernel to_Zero (KernelArrow (Image SSED)) (Mor2 SSED) (Image_Eq SSED).
 
   Definition mk_ShortShortExact (SSED : ShortShortExactData A to_Zero)
-             (H : isEqualizer (Mor2 SSED) (ZeroArrow to_Zero _ _) (KernelArrow (Image SSED))
-                              (KernelEqRw to_Zero (Image_Eq SSED))) : ShortShortExact.
-  Proof.
-    use tpair.
-    - exact SSED.
-    - exact H.
-  Defined.
+             (H : isKernel to_Zero (KernelArrow (Image SSED)) (Mor2 SSED) (Image_Eq SSED)) :
+    ShortShortExact := tpair _ SSED H.
 
   (** Accessor functions *)
   Definition ShortShortExact_ShortShortExactData (SSE : ShortShortExact) :
     ShortShortExactData A to_Zero := pr1 SSE.
   Coercion ShortShortExact_ShortShortExactData : ShortShortExact >-> ShortShortExactData.
 
-  Definition ShortShortExact_isEqualizer (SSE : ShortShortExact) :
-    isEqualizer (Mor2 SSE) (ZeroArrow to_Zero _ _) (KernelArrow (Image SSE))
-                (KernelEqRw to_Zero (Image_Eq SSE)) := pr2 SSE.
+  Definition ShortShortExact_isKernel (SSE : ShortShortExact) :
+    isKernel to_Zero (KernelArrow (Image SSE)) (Mor2 SSE) (Image_Eq SSE) := pr2 SSE.
 
   Definition ShortShortExact_Kernel (SSE : ShortShortExact) : Kernel to_Zero (Mor2 SSE) :=
     mk_Kernel to_Zero (KernelArrow (Image SSE)) (Mor2 SSE) (Image_Eq SSE)
-              (ShortShortExact_isEqualizer SSE).
+               (ShortShortExact_isKernel SSE).
 
 
   (** ** Remark
@@ -147,12 +144,7 @@ Section def_shortexactseqs.
   Definition LeftShortExact : UU := Σ SSE : ShortShortExact, isMonic (Mor1 SSE).
 
   Definition mk_LeftShortExact (SSE : ShortShortExact) (isM : isMonic (Mor1 SSE)) :
-    LeftShortExact.
-  Proof.
-    use tpair.
-    - exact SSE.
-    - exact isM.
-  Defined.
+    LeftShortExact := tpair _ SSE isM.
 
   (** Accessor functions *)
   Definition LeftShortExact_ShortShortExact (LSE : LeftShortExact) : ShortShortExact := pr1 LSE.
@@ -169,12 +161,7 @@ Section def_shortexactseqs.
   Definition RightShortExact : UU := Σ SSE : ShortShortExact, isEpi (Mor2 SSE).
 
   Definition mk_RightShortExact (SSE : ShortShortExact) (isE : isEpi (Mor2 SSE)) :
-    RightShortExact.
-  Proof.
-    use tpair.
-    - exact SSE.
-    - exact isE.
-  Defined.
+    RightShortExact := tpair _ SSE isE.
 
   (** Accessor functions *)
   Definition RightShortExact_ShortShortExact (RSE : RightShortExact) : ShortShortExact := pr1 RSE.
@@ -193,14 +180,7 @@ Section def_shortexactseqs.
     Σ SSE : ShortShortExact, Monics.isMonic (Mor1 SSE) × Epis.isEpi (Mor2 SSE).
 
   Definition mk_ShortExact (SSE : ShortShortExact) (isM : Monics.isMonic (Mor1 SSE))
-             (isE : Epis.isEpi (Mor2 SSE)) : ShortExact.
-  Proof.
-    use tpair.
-    - exact SSE.
-    - use dirprodpair.
-      + exact isM.
-      + exact isE.
-  Defined.
+             (isE : Epis.isEpi (Mor2 SSE)) : ShortExact := (SSE,,(isM,,isE)).
 
   (** [LeftShortExact] and [RightShortExact] from [ShortExact] *)
   Definition ShortExact_LeftShortExact (SE : ShortExact) : LeftShortExact.
@@ -225,7 +205,7 @@ Arguments Image_Eq [A] _ _.
 Arguments CoImage [A] _.
 Arguments CoImage_Eq [A] _ _.
 Arguments mk_ShortShortExact [A] _ _ _.
-Arguments ShortShortExact_isEqualizer [A] _ _ _ _ _.
+Arguments ShortShortExact_isKernel [A] _ _ _ _ _.
 Arguments ShortShortExact_Kernel [A] _ _.
 Arguments LeftShortExact [A] _.
 Arguments mk_LeftShortExact [A] _ _ _.
@@ -253,8 +233,8 @@ Section shortshortexact_coequalizer.
     that the opposite category of an abelian category is an abelian category and that taking the
     opposite category twice, we get the same category. *)
 
-  Local Lemma ShortShortExact_isCoequalizer_eq1 (SSE : ShortShortExact hs) (w0 : A)
-        (h : A ⟦Ob2 SSE, w0⟧) (H : Mor1 SSE ;; h = (ZeroArrow to_Zero _ _) ;; h) :
+  Local Lemma ShortShortExact_isCokernel_eq1 (SSE : ShortShortExact hs) (w0 : A)
+        (h : A ⟦Ob2 SSE, w0⟧) (H : Mor1 SSE ;; h = ZeroArrow to_Zero _ _) :
     (KernelArrow (ShortShortExact_Kernel hs SSE)) ;; h = ZeroArrow to_Zero _ _.
   Proof.
     apply (factorization1_is_epi hs (Mor1 SSE)).
@@ -264,12 +244,11 @@ Section shortshortexact_coequalizer.
     cbn in tmp. rewrite assoc. unfold ShortShortExact_Kernel.
     cbn. unfold Image. rewrite <- tmp. clear tmp.
     rewrite ZeroArrow_comp_right.
-    rewrite ZeroArrow_comp_left in H.
     exact H.
   Qed.
 
-  Local Lemma ShortShortExact_isCoequalizer_eq2 (SSE : ShortShortExact hs) (w0 : A)
-        (h : A ⟦Ob2 SSE, w0⟧) (H : Mor1 SSE ;; h = (ZeroArrow to_Zero _ _) ;; h) :
+  Local Lemma ShortShortExact_isCokernel_eq2 (SSE : ShortShortExact hs) (w0 : A)
+        (h : A ⟦Ob2 SSE, w0⟧) (H : Mor1 SSE ;; h = ZeroArrow to_Zero _ _) :
     KernelArrow (Abelian.Kernel (Mor2 SSE)) ;; h = ZeroArrow to_Zero _ _.
   Proof.
     set (i := iso_from_Kernel_to_Kernel to_Zero (ShortShortExact_Kernel hs SSE)
@@ -278,19 +257,18 @@ Section shortshortexact_coequalizer.
     apply (pr2 epi). cbn. rewrite ZeroArrow_comp_right.
     rewrite assoc. unfold from_Kernel_to_Kernel.
     rewrite KernelCommutes.
-    apply (ShortShortExact_isCoequalizer_eq1 SSE w0 h H).
+    apply (ShortShortExact_isCokernel_eq1 SSE w0 h H).
   Qed.
 
-  Local Lemma  ShortShortExact_isCoequalizer (SSE : ShortShortExact hs) :
-    isCoequalizer (Mor1 SSE) (ZeroArrow to_Zero _ _) (CokernelArrow (CoImage SSE))
-                  (CokernelEqRw to_Zero (CoImage_Eq hs SSE)).
+  Local Lemma ShortShortExact_isCokernel (SSE : ShortShortExact hs) :
+    isCokernel to_Zero (Mor1 SSE) (CokernelArrow (CoImage SSE)) (CoImage_Eq hs SSE).
   Proof.
-    use mk_isCoequalizer.
+    use (mk_isCokernel hs).
     intros w0 h H'.
     use unique_exists.
     (* Construction of the morphism *)
-    - apply (CokernelOut
-               to_Zero (CoImage SSE) w0 h (ShortShortExact_isCoequalizer_eq2 SSE w0 h H')).
+    - exact (CokernelOut
+               to_Zero (CoImage SSE) w0 h (ShortShortExact_isCokernel_eq2 SSE w0 h H')).
     (* Commutativity *)
     - apply CokernelCommutes.
     (* Equality on equalities of morphisms *)
@@ -302,23 +280,22 @@ Section shortshortexact_coequalizer.
       apply CokernelCommutes.
   Qed.
 
-  Definition ShortShortExact_Coequalizer (SSE : ShortShortExact hs) :
-    Cokernel to_Zero (Mor1 SSE) := mk_Cokernel to_Zero (CokernelArrow (CoImage SSE))
-                                              (Mor1 SSE) (CoImage_Eq hs SSE)
-                                              (ShortShortExact_isCoequalizer SSE).
+  Definition ShortShortExact_Cokernel (SSE : ShortShortExact hs) :
+    Cokernel to_Zero (Mor1 SSE) := mk_Cokernel to_Zero (Mor1 SSE) (CokernelArrow (CoImage SSE))
+                                               (CoImage_Eq hs SSE)
+                                               (ShortShortExact_isCokernel SSE).
 
 
   (** ** From isCoequalizer to [ShortShortExact]
     We show that we can construct [ShortShortExact] from the isCoequalizer property proved above. *)
 
-  Local Lemma ShortShortExact_from_isCoequalizer_eq1 (SSED : ShortShortExactData A to_Zero)
+  Local Lemma ShortShortExact_from_isCokernel_eq1 (SSED : ShortShortExactData A to_Zero)
         (w : A) (h : A ⟦w, Ob2 SSED⟧)
         (H : (h ;; (CokernelArrow (Abelian.CoImage (Mor2 SSED)))) = ZeroArrow to_Zero _ _)
-        (H' : isCoequalizer (Mor1 SSED) (ZeroArrow to_Zero _ _) (CokernelArrow (CoImage SSED))
-                            (CokernelEqRw to_Zero (CoImage_Eq hs SSED))):
+        (H' : isCokernel to_Zero (Mor1 SSED) (CokernelArrow (CoImage SSED)) (CoImage_Eq hs SSED)) :
     h ;; CokernelArrow (Abelian.Cokernel (Mor1 SSED)) = ZeroArrow to_Zero _ _.
   Proof.
-    set (coker := mk_Cokernel to_Zero (CokernelArrow (CoImage SSED)) (Mor1 SSED)
+    set (coker := mk_Cokernel to_Zero (Mor1 SSED) (CokernelArrow (CoImage SSED))
                               (CoImage_Eq hs SSED) H').
     set (i := iso_from_Cokernel_to_Cokernel to_Zero (Abelian.Cokernel (Mor1 SSED)) coker).
     set (isM := iso_Monic A i (pr2 i)). apply (pr2 isM). cbn.
@@ -329,10 +306,9 @@ Section shortshortexact_coequalizer.
     exact H.
   Qed.
 
-  Local Lemma ShortShortExact_from_isCoequalizer_eq2 (SSED : ShortShortExactData A to_Zero)
-        (w : A) (h : A ⟦w, Ob2 SSED⟧) (H : h ;; Mor2 SSED = h ;; (ZeroArrow to_Zero _ _))
-        (H' : isCoequalizer (Mor1 SSED) (ZeroArrow to_Zero _ _) (CokernelArrow (CoImage SSED))
-                            (CokernelEqRw to_Zero (CoImage_Eq hs SSED))) :
+  Local Lemma ShortShortExact_from_isCokernel_eq2 (SSED : ShortShortExactData A to_Zero)
+        (w : A) (h : A ⟦w, Ob2 SSED⟧) (H : h ;; Mor2 SSED = ZeroArrow to_Zero _ _)
+        (H' : isCokernel to_Zero (Mor1 SSED) (CokernelArrow (CoImage SSED)) (CoImage_Eq hs SSED)) :
     h ;; CokernelArrow (Abelian.CoImage (Mor2 SSED)) = ZeroArrow to_Zero _ _.
   Proof.
     apply (factorization2_is_monic hs (Mor2 SSED)).
@@ -342,24 +318,21 @@ Section shortshortexact_coequalizer.
     cbn in tmp. rewrite <- assoc. rewrite <- tmp.
     clear tmp.
     rewrite ZeroArrow_comp_left.
-    rewrite ZeroArrow_comp_right in H.
     exact H.
   Qed.
 
-  Local Lemma ShortShortExact_from_isCoequalizer_isEqualizer
+  Local Lemma ShortShortExact_from_isCokernel_isKernel
         (SSED : ShortShortExactData A to_Zero)
-        (H : isCoequalizer (Mor1 SSED) (ZeroArrow to_Zero _ _) (CokernelArrow (CoImage SSED))
-                           (CokernelEqRw to_Zero (CoImage_Eq hs SSED))) :
-    isEqualizer (Mor2 SSED) (ZeroArrow to_Zero _ _) (KernelArrow (Image SSED))
-                (KernelEqRw to_Zero (Image_Eq hs SSED)).
+        (H : isCokernel to_Zero (Mor1 SSED) (CokernelArrow (CoImage SSED)) (CoImage_Eq hs SSED)) :
+    isKernel to_Zero (KernelArrow (Image SSED)) (Mor2 SSED) (Image_Eq hs SSED).
   Proof.
-    use mk_isEqualizer.
+    use (mk_isKernel hs).
     intros w h H'.
     use unique_exists.
     (* Construction of the morphism *)
     - apply (KernelIn to_Zero (Image SSED) w h
-                      (ShortShortExact_from_isCoequalizer_eq1
-                         SSED w h (ShortShortExact_from_isCoequalizer_eq2 SSED w h H' H) H)).
+                      (ShortShortExact_from_isCokernel_eq1
+                         SSED w h (ShortShortExact_from_isCokernel_eq2 SSED w h H' H) H)).
     (* Commutativity *)
     - apply KernelCommutes.
     (* Equality on equalities of morphisms *)
@@ -372,13 +345,106 @@ Section shortshortexact_coequalizer.
   Qed.
 
   Definition ShortShortExact_from_isCoequalizer (SSED : ShortShortExactData A to_Zero)
-             (H : isCoequalizer (Mor1 SSED) (ZeroArrow to_Zero _ _) (CokernelArrow (CoImage SSED))
-                                (CokernelEqRw to_Zero (CoImage_Eq hs SSED))) : ShortShortExact hs :=
-    mk_ShortShortExact hs SSED (ShortShortExact_from_isCoequalizer_isEqualizer SSED H).
+             (H : isCokernel to_Zero (Mor1 SSED) (CokernelArrow (CoImage SSED))
+                             (CoImage_Eq hs SSED)) : ShortShortExact hs :=
+    mk_ShortShortExact hs SSED (ShortShortExact_from_isCokernel_isKernel SSED H).
 
 End shortshortexact_coequalizer.
-Arguments ShortShortExact_Coequalizer [A] _ _.
+Arguments ShortShortExact_Cokernel [A] _ _.
 Arguments ShortShortExact_from_isCoequalizer [A] _ _ _.
+
+
+(** * Correspondence of shortexact in A an A^op *)
+Section shortexact_opp.
+
+  Local Opaque ZeroArrow isKernel isCokernel.
+  Definition ShortShortExact_opp {A : AbelianPreCat} {hs : has_homsets A}
+             (SSE : ShortShortExact hs) : ShortShortExact (has_homsets_Abelian_opp hs).
+  Proof.
+    use mk_ShortShortExact.
+    - exact (ShortShortExactData_opp SSE).
+    - cbn. use isKernel_opp.
+      + exact hs.
+      + exact to_Zero.
+      + exact (CoImage_Eq hs SSE).
+      + exact (CokernelisCokernel to_Zero (ShortShortExact_Cokernel hs SSE)).
+  Defined.
+
+  (** Why is this so slow? *)
+  Local Lemma opp_ShortShortExact_isKernel {A : AbelianPreCat} {hs : has_homsets A}
+        (SSE : ShortShortExact (has_homsets_Abelian_opp hs)) :
+    isKernel to_Zero (KernelArrow (Image (opp_ShortShortExactData SSE))) (Mor2 (opp_ShortShortExactData SSE))
+             (Image_Eq hs (opp_ShortShortExactData SSE)).
+  Proof.
+    cbn. use opp_isKernel.
+    - exact hs.
+    - exact (Zero_opp A to_Zero).
+    - cbn.
+      set (tmp := CoImage_Eq (has_homsets_Abelian_opp hs) SSE). cbn in tmp. apply tmp.
+    - cbn.
+      set (tmp := CokernelisCokernel to_Zero (ShortShortExact_Cokernel (has_homsets_Abelian_opp hs) SSE)).
+      cbn in tmp. apply tmp.
+  Qed.
+
+  Definition opp_ShortShortExact {A : AbelianPreCat} {hs : has_homsets A}
+             (SSE : ShortShortExact (has_homsets_Abelian_opp hs)) : ShortShortExact hs.
+  Proof.
+    use mk_ShortShortExact.
+    - exact (opp_ShortShortExactData SSE).
+    - exact (opp_ShortShortExact_isKernel SSE).
+  Defined.
+
+  Definition LeftShortExact_opp {A : AbelianPreCat} {hs : has_homsets A} (LSE : LeftShortExact hs) :
+    RightShortExact (has_homsets_Abelian_opp hs).
+  Proof.
+    use mk_RightShortExact.
+    - exact (ShortShortExact_opp LSE).
+    - use isMonic_opp. exact (isMonic hs LSE).
+  Defined.
+
+  Definition opp_LeftShortExact {A : AbelianPreCat} {hs : has_homsets A}
+             (LSE : LeftShortExact (has_homsets_Abelian_opp hs)) : RightShortExact hs.
+  Proof.
+    use mk_RightShortExact.
+    - exact (opp_ShortShortExact LSE).
+    - use opp_isMonic. exact (isMonic (has_homsets_Abelian_opp hs) LSE).
+  Defined.
+
+  Definition RightShortExact_opp {A : AbelianPreCat} {hs : has_homsets A}
+             (RSE : RightShortExact hs) : LeftShortExact (has_homsets_Abelian_opp hs).
+  Proof.
+    use mk_LeftShortExact.
+    - exact (ShortShortExact_opp RSE).
+    - use isEpi_opp. exact (isEpi hs RSE).
+  Defined.
+
+  Definition opp_RightShortExact {A : AbelianPreCat} {hs : has_homsets A}
+             (RSE : RightShortExact (has_homsets_Abelian_opp hs)) : LeftShortExact hs.
+  Proof.
+    use mk_LeftShortExact.
+    - exact (opp_ShortShortExact RSE).
+    - use opp_isEpi. exact (isEpi (has_homsets_Abelian_opp hs) RSE).
+  Defined.
+
+  Definition ShortExact_opp {A : AbelianPreCat} {hs : has_homsets A} (SE : ShortExact _ hs) :
+    ShortExact _ (has_homsets_Abelian_opp hs).
+  Proof.
+    use mk_ShortExact.
+    - exact (ShortShortExact_opp SE).
+    - use isEpi_opp. exact (isEpi hs SE).
+    - use isMonic_opp. exact (isMonic hs SE).
+  Defined.
+
+  Definition opp_ShortExact {A : AbelianPreCat} {hs : has_homsets A}
+             (SE : ShortExact _ (has_homsets_Abelian_opp hs)) : ShortExact _ hs.
+  Proof.
+    use mk_ShortExact.
+    - exact (opp_ShortShortExact SE).
+    - use opp_isEpi. exact (isEpi (has_homsets_Abelian_opp hs) SE).
+    - use opp_isMonic. exact (isMonic (has_homsets_Abelian_opp hs) SE).
+  Defined.
+
+End shortexact_opp.
 
 
 (** * Correspondence between [ShortShortExact] and [ShortExact]
@@ -417,7 +483,7 @@ Section shortexact_correspondence.
     apply (ShortShortExactData_Eq to_Zero SSE).
   Qed.
 
-  Local Lemma ShortExact_ShortShortExact_isEqualizer_Eq (SSE : ShortShortExact hs) (w : A)
+  Local Lemma ShortExact_ShortShortExact_isKernel_Eq (SSE : ShortShortExact hs) (w : A)
              (h : A ⟦w, Ob2 SSE⟧)
              (H' : h ;; CokernelArrow (Abelian.CoImage (Mor2 SSE)) = ZeroArrow to_Zero _ _) :
     let Im := Abelian.Image (Mor1 SSE) in
@@ -437,8 +503,7 @@ Section shortexact_correspondence.
     set (comm1 := KernelCommutes to_Zero (Abelian.Kernel (Mor2 SSE)) w h X).
     set (ker := ShortShortExact_Kernel hs SSE).
     set (tmp := Abelian.Kernel (Mor2 SSE)).
-    set (tmp_eq := (KernelEqAr to_Zero tmp)).
-    rewrite ZeroArrow_comp_right in tmp_eq.
+    set (tmp_eq := (KernelCompZero to_Zero tmp)).
     set (comm2 := KernelCommutes to_Zero ker tmp (KernelArrow tmp) tmp_eq).
     unfold tmp in comm2. rewrite <- comm2 in comm1. clear comm2.
     rewrite <- comm1. rewrite <- assoc. rewrite <- assoc.
@@ -446,23 +511,21 @@ Section shortexact_correspondence.
     rewrite ZeroArrow_comp_right. apply idpath.
   Qed.
 
-  Local Lemma ShortExact_ShortShortExact_isEqualizer (SSE : ShortShortExact hs) :
+  Local Lemma ShortExact_ShortShortExact_isKernel (SSE : ShortShortExact hs) :
     let Im := Abelian.Image (Mor1 SSE) in
     let CoIm := Abelian.CoImage (Mor2 SSE) in
     let MP := mk_MorphismPair (KernelArrow Im) (CokernelArrow CoIm) in
     let SSED := mk_ShortShortExactData to_Zero MP (ShortExact_from_ShortShortExact_eq SSE) in
-    isEqualizer (CokernelArrow CoIm) (ZeroArrow to_Zero _ _)
-                (KernelArrow (Image SSED)) (KernelEqRw to_Zero (Image_Eq hs SSED)).
+    isKernel to_Zero (KernelArrow (Image SSED)) (CokernelArrow CoIm) (Image_Eq hs SSED).
   Proof.
-    cbn zeta.
-    use mk_isEqualizer.
+    intros Im CoIm MP SSED.
+    use (mk_isKernel hs).
     intros w h H'.
     use unique_exists.
     (* Construction of the morphism *)
     - use KernelIn.
       + exact h.
-      + rewrite ZeroArrow_comp_right in H'.
-        apply (ShortExact_ShortShortExact_isEqualizer_Eq SSE w h H').
+      + apply (ShortExact_ShortShortExact_isKernel_Eq SSE w h H').
     (* Commutativity *)
     - apply KernelCommutes.
     (* Equality on equalities of morphisms *)
@@ -485,7 +548,7 @@ Section shortexact_correspondence.
           -- exact (KernelArrow (Abelian.Image (Mor1 SSE))).
           -- exact (CokernelArrow (Abelian.CoImage (Mor2 SSE))).
         * exact (ShortExact_from_ShortShortExact_eq SSE).
-      + exact (ShortExact_ShortShortExact_isEqualizer SSE).
+      + exact (ShortExact_ShortShortExact_isKernel SSE).
     - exact (KernelArrowisMonic to_Zero _).
     - exact (CokernelArrowisEpi to_Zero _).
   Defined.
@@ -498,15 +561,15 @@ Section shortexact_correspondence.
   Local Lemma ShortShortExact_from_isSortExact_eq {a b c : A} (f : a --> b) (g : b --> c)
              (H : (KernelArrow (Abelian.Image f)) ;; (CokernelArrow (Abelian.CoImage g))
                   = ZeroArrow to_Zero _ _)
-             (isEq : isEqualizer (CokernelArrow (Abelian.CoImage g)) (ZeroArrow to_Zero _ _)
-                                 (KernelArrow (Abelian.Image f)) (KernelEqRw to_Zero H)) :
+             (isEq : isKernel to_Zero (KernelArrow (Abelian.Image f))
+                              (CokernelArrow (Abelian.CoImage g)) H) :
     f ;; g = ZeroArrow to_Zero _ _.
   Proof.
     set (tmp := maponpaths (fun h : _ => CokernelArrow (Abelian.CoImage f) ;; (CoIm_to_Im f) ;; h) H).
     cbn in tmp. rewrite ZeroArrow_comp_right in tmp.
     apply (maponpaths (fun h : _ => h ;; (CoIm_to_Im g) ;; ((KernelArrow (Abelian.Image g))))) in tmp.
     rewrite ZeroArrow_comp_left in tmp.
-    repeat rewrite assoc in tmp.
+    rewrite assoc in tmp.
     (* Work on f in tmp *)
     set (fact := factorization2 hs f).
     unfold factorization2_epi in fact. cbn in fact.
@@ -514,23 +577,22 @@ Section shortexact_correspondence.
     (* Work of g in tmp *)
     set (fact := factorization1 hs g).
     unfold factorization2_monic in fact. cbn in fact.
-    repeat rewrite <- assoc in tmp. repeat rewrite <- assoc in fact.
+    rewrite <- assoc in tmp. rewrite <- assoc in tmp. rewrite <- assoc in fact.
     rewrite <- fact in tmp. clear fact.
     (* Follows from tmp *)
     rewrite ZeroArrow_comp_left in tmp. exact tmp.
   Qed.
 
-  Local Lemma ShortShortExact_from_isShortExact_isEqualizer_eq {a b c : A} (f : a --> b) (g : b --> c)
+  Local Lemma ShortShortExact_from_isShortExact_isKernel_eq {a b c : A} (f : a --> b) (g : b --> c)
         (H : (KernelArrow (Abelian.Image f)) ;; (CokernelArrow (Abelian.CoImage g)) =
              ZeroArrow to_Zero _ _)
-        (isEq : isEqualizer (CokernelArrow (Abelian.CoImage g)) (ZeroArrow to_Zero _ _)
-                            (KernelArrow (Abelian.Image f)) (KernelEqRw to_Zero H))
-        (w : A) (h : A ⟦w, b⟧) (H' : h ;; g = h ;; ZeroArrow to_Zero b c) :
+        (isEq : isKernel to_Zero (KernelArrow (Abelian.Image f))
+                         (CokernelArrow (Abelian.CoImage g)) H)
+        (w : A) (h : A ⟦w, b⟧) (H' : h ;; g = ZeroArrow to_Zero w c) :
     h ;; CokernelArrow (Abelian.Cokernel f) = ZeroArrow to_Zero w (Abelian.Cokernel f).
   Proof.
     set (ker := mk_Kernel to_Zero (KernelArrow (Abelian.Image f))
                           (CokernelArrow (Abelian.CoImage g)) H isEq).
-    rewrite ZeroArrow_comp_right in H'.
     (* Rewrite g in H' *)
     set (fact := factorization2 hs g).
     unfold factorization2_epi in fact. cbn in fact.
@@ -550,25 +612,23 @@ Section shortexact_correspondence.
     rewrite KernelCompZero. apply ZeroArrow_comp_right.
   Qed.
 
-  Local Lemma ShortShortExact_from_isShortExact_isEqualizer {a b c : A} (f : a --> b) (g : b --> c)
+  Local Lemma ShortShortExact_from_isShortExact_isKernel {a b c : A} (f : a --> b) (g : b --> c)
         (H : (KernelArrow (Abelian.Image f)) ;; (CokernelArrow (Abelian.CoImage g)) =
              ZeroArrow to_Zero _ _)
-        (isEq : isEqualizer (CokernelArrow (Abelian.CoImage g)) (ZeroArrow to_Zero _ _)
-                            (KernelArrow (Abelian.Image f)) (KernelEqRw to_Zero H)) :
+        (isK : isKernel to_Zero (KernelArrow (Abelian.Image f))
+                        (CokernelArrow (Abelian.CoImage g)) H) :
     let SSED := mk_ShortShortExactData to_Zero (mk_MorphismPair f g)
-                                       (ShortShortExact_from_isSortExact_eq f g H isEq) in
-    isEqualizer g (ZeroArrow to_Zero b c) (KernelArrow (Image SSED))
-                (KernelEqRw to_Zero (Image_Eq hs SSED)).
+                                       (ShortShortExact_from_isSortExact_eq f g H isK) in
+    isKernel to_Zero (KernelArrow (Image SSED)) g (Image_Eq hs SSED).
   Proof.
-    cbn zeta.
-    use mk_isEqualizer.
+    intros SSED.
+    use (mk_isKernel hs).
     intros w h H'.
-    use unique_exists; cbn in *.
+    use unique_exists.
     (* Construction of the arrow *)
-    - unfold Image; cbn.
-      use KernelIn.
+    - use KernelIn.
       + exact h.
-      + exact (ShortShortExact_from_isShortExact_isEqualizer_eq f g H isEq w h H').
+      + exact (ShortShortExact_from_isShortExact_isKernel_eq f g H isK w h H').
     (* Comutativity *)
     - apply KernelCommutes.
     (* Equality on equalities of morphisms *)
@@ -587,8 +647,8 @@ Section shortexact_correspondence.
   Definition ShortShortExact_from_isShortExact {a b c : A} (f : a --> b) (g : b --> c)
              (H : (KernelArrow (Abelian.Image f)) ;; (CokernelArrow (Abelian.CoImage g)) =
                   ZeroArrow to_Zero _ _)
-             (isEq : isEqualizer (CokernelArrow (Abelian.CoImage g)) (ZeroArrow to_Zero _ _)
-                                 (KernelArrow (Abelian.Image f)) (KernelEqRw to_Zero H)) :
+             (isEq : isKernel to_Zero (KernelArrow (Abelian.Image f))
+                              (CokernelArrow (Abelian.CoImage g)) H) :
     ShortShortExact hs.
   Proof.
     use mk_ShortShortExact.
@@ -600,7 +660,7 @@ Section shortexact_correspondence.
         * exact f.
         * exact g.
       + exact (ShortShortExact_from_isSortExact_eq f g H isEq).
-    - exact (ShortShortExact_from_isShortExact_isEqualizer f g H isEq).
+    - exact (ShortShortExact_from_isShortExact_isKernel f g H isEq).
   Defined.
 
 End shortexact_correspondence.

--- a/UniMath/CategoryTheory/ShortExactSequences.v
+++ b/UniMath/CategoryTheory/ShortExactSequences.v
@@ -370,21 +370,21 @@ Section shortexact_opp.
       + exact (CokernelisCokernel to_Zero (ShortShortExact_Cokernel hs SSE)).
   Defined.
 
-  (** Why is this so slow? *)
+  Unset Kernel Term Sharing.
   Local Lemma opp_ShortShortExact_isKernel {A : AbelianPreCat} {hs : has_homsets A}
         (SSE : ShortShortExact (has_homsets_Abelian_opp hs)) :
-    isKernel to_Zero (KernelArrow (Image (opp_ShortShortExactData SSE))) (Mor2 (opp_ShortShortExactData SSE))
+    isKernel to_Zero (KernelArrow (Image (opp_ShortShortExactData SSE)))
+             (Mor2 (opp_ShortShortExactData SSE))
              (Image_Eq hs (opp_ShortShortExactData SSE)).
   Proof.
     cbn. use opp_isKernel.
     - exact hs.
     - exact (Zero_opp A to_Zero).
-    - cbn.
-      set (tmp := CoImage_Eq (has_homsets_Abelian_opp hs) SSE). cbn in tmp. apply tmp.
-    - cbn.
-      set (tmp := CokernelisCokernel to_Zero (ShortShortExact_Cokernel (has_homsets_Abelian_opp hs) SSE)).
-      cbn in tmp. apply tmp.
+    - exact (CoImage_Eq (has_homsets_Abelian_opp hs) SSE).
+    - exact (CokernelisCokernel
+               to_Zero (ShortShortExact_Cokernel (has_homsets_Abelian_opp hs) SSE)).
   Qed.
+  Set Kernel Term Sharing.
 
   Definition opp_ShortShortExact {A : AbelianPreCat} {hs : has_homsets A}
              (SSE : ShortShortExact (has_homsets_Abelian_opp hs)) : ShortShortExact hs.

--- a/UniMath/CategoryTheory/category_abgr.v
+++ b/UniMath/CategoryTheory/category_abgr.v
@@ -935,17 +935,15 @@ Section ABGR_kernels.
   Defined.
 
   (** Hide isEqualizer behind Qed. *)
-  Definition ABGR_Kernel_isEqualizer {A B : abgr} (f : ABGR⟦A, B⟧) :
-    isEqualizer f (ZeroArrow ABGR_has_zero A B) (ABGR_kernel_monoidfun f)
-                (KernelEqRw ABGR_has_zero (ABGR_Kernel_eq f)).
+  Definition ABGR_Kernel_isKernel {A B : abgr} (f : ABGR⟦A, B⟧) :
+    isKernel ABGR_has_zero (ABGR_kernel_monoidfun f) f (ABGR_Kernel_eq f).
   Proof.
     induction A as [t p]. induction B as [t' p'].
-    use mk_isEqualizer.
+    use (mk_isKernel has_homsets_ABGR).
     intros w h H'. induction w as [tt pp]. induction h as [tt' pp'].
     use unique_exists.
     (* Construction of the unique arrow into kernel *)
-    - rewrite (ZeroArrow_comp_right ABGR ABGR_has_zero _ _) in H'.
-      rewrite (ABGR_has_zero_arrow_eq _ _) in H'.
+    - rewrite (ABGR_has_zero_arrow_eq _ _) in H'.
       apply (ABGR_KernelArrowIn _ f H').
     (* Commutativity of the kernel arrow *)
     - use total2_paths.
@@ -965,7 +963,7 @@ Section ABGR_kernels.
   (** Construction of a kernel of a morphism of abelian groups f. *)
   Definition ABGR_Kernel {A B : abgr} (f : monoidfun A B) : Kernel ABGR_has_zero f :=
     mk_Kernel (ABGR_has_zero) (ABGR_kernel_monoidfun f) f (ABGR_Kernel_eq f)
-              (ABGR_Kernel_isEqualizer f).
+              (ABGR_Kernel_isKernel f).
 
   (** As a corollary we get that ABGR has kernels. *)
   Corollary ABGR_kernels : Kernels ABGR_has_zero.
@@ -1150,53 +1148,51 @@ Section ABGR_kernels.
          (pr1 C) (pr1 h) (ABGR_CokernelArrowOutUniv_iscomprelfun f h H).
 
   (** Hide isCoequalizer behind Qed. *)
-  Definition ABGR_isCoequalizer {A B : abgr} (f : ABGR⟦A, B⟧) :
-    isCoequalizer f (ZeroArrow ABGR_has_zero A B) (ABGR_cokernel_monoidfun f)
-                  (CokernelEqRw ABGR_has_zero (ABGR_cokernel_eq f)).
+  Definition ABGR_isCokernel {A B : abgr} (f : ABGR⟦A, B⟧) :
+    isCokernel ABGR_has_zero f (ABGR_cokernel_monoidfun f) (ABGR_cokernel_eq f).
   Proof.
-    use mk_isCoequalizer.
-    - intros w h H'.
-      use unique_exists.
-      (* Construction of the unique arrow out of cokernel *)
-      + use monoidfunconstr.
-        * rewrite (ZeroArrow_comp_left ABGR ABGR_has_zero _ _) in H'.
-          rewrite (ABGR_has_zero_arrow_eq _ _) in H'.
-          apply base_paths in H'. cbn in H'. unfold funcomp in H'.
-          apply (ABGR_CokernelArrowOutUniv f _ H').
+    use (mk_isCokernel (has_homsets_ABGR)).
+    intros w h H'.
+    use unique_exists.
+    (* Construction of the unique arrow out of cokernel *)
+    - use monoidfunconstr.
+      + rewrite (ABGR_has_zero_arrow_eq _ _) in H'.
+        apply base_paths in H'. cbn in H'. unfold funcomp in H'.
+        apply (ABGR_CokernelArrowOutUniv f _ H').
         (* ismonoidfun *)
-        * split.
-          -- use isbinopfun_2of3.
-             ++ apply (pr1 B).
-             ++ apply (pr1 (ABGR_cokernel_monoidfun f)).
-             ++ apply issurjsetquotpr.
-             ++ unfold funcomp. apply (pr2 h).
-             ++ apply (pr2 (ABGR_cokernel_monoidfun f)).
-          -- cbn. set (XXh := pr2 (pr2 h)). cbn in XXh. rewrite <- XXh.
-             apply maponpaths. apply idpath.
+      + split.
+        * use isbinopfun_2of3.
+          -- apply (pr1 B).
+          -- apply (pr1 (ABGR_cokernel_monoidfun f)).
+          -- apply issurjsetquotpr.
+          -- unfold funcomp. apply (pr2 h).
+          -- apply (pr2 (ABGR_cokernel_monoidfun f)).
+        * cbn. set (XXh := pr2 (pr2 h)). cbn in XXh. rewrite <- XXh.
+          apply maponpaths. apply idpath.
       (* Commutativity *)
-      + use total2_paths.
-        * cbn. apply funextfun. intros b. apply idpath.
-        * apply proofirrelevance. apply isapropismonoidfun.
-      (* Equality on equality of morphisms *)
-      + intros y. cbn. intros x x'. apply (has_homsets_ABGR).
-      (* Uniqueness *)
-      + intros y. induction y as [t p]. intros  t0. cbn in t0.
-        use total2_paths.
-        * cbn. apply funextfun. intros z. cbn in *.
-          set (surj := issurjsetquotpr (ABGR_cokernel_eqrel f)).
-          unfold issurjective in surj. cbn in surj.
-          set (surjz := surj z).
-          use (squash_to_prop surjz). apply (pr2 (pr1 (pr1 w))).
-          intros surjz'. unfold hfiber in surjz'. induction surjz' as [t1 p0].
-          rewrite <- p0. cbn. apply base_paths in t0. cbn in t0.
-          unfold funcomp in t0. apply (funeqpaths t0 t1).
-        *  apply proofirrelevance. apply isapropismonoidfun.
+    - use total2_paths.
+      + cbn. apply funextfun. intros b. apply idpath.
+      + apply proofirrelevance. apply isapropismonoidfun.
+    (* Equality on equality of morphisms *)
+    - intros y. cbn. intros x x'. apply (has_homsets_ABGR).
+    (* Uniqueness *)
+    - intros y. induction y as [t p]. intros  t0. cbn in t0.
+      use total2_paths.
+      + cbn. apply funextfun. intros z. cbn in *.
+        set (surj := issurjsetquotpr (ABGR_cokernel_eqrel f)).
+        unfold issurjective in surj. cbn in surj.
+        set (surjz := surj z).
+        use (squash_to_prop surjz). apply (pr2 (pr1 (pr1 w))).
+        intros surjz'. unfold hfiber in surjz'. induction surjz' as [t1 p0].
+        rewrite <- p0. cbn. apply base_paths in t0. cbn in t0.
+        unfold funcomp in t0. apply (funeqpaths t0 t1).
+      + apply proofirrelevance. apply isapropismonoidfun.
   Qed.
 
   (** Construction of a cokernel of a morphism of abelian groups f. *)
   Definition ABGR_Cokernel {A B : abgr} (f : ABGR⟦A, B⟧) : Cokernel ABGR_has_zero f :=
-    mk_Cokernel (ABGR_has_zero) (ABGR_cokernel_monoidfun f) f (ABGR_cokernel_eq f)
-                (ABGR_isCoequalizer f).
+    mk_Cokernel ABGR_has_zero f (ABGR_cokernel_monoidfun f) (ABGR_cokernel_eq f)
+                (ABGR_isCokernel f).
 
   (** As a corollary we get that ABGR has cokernels. *)
   Corollary ABGR_cokernels : Cokernels ABGR_has_zero.
@@ -1575,10 +1571,9 @@ Section ABGR_monic_kernels.
   (** Construction of ishinh_UU hfiber. *)
   Definition ABGR_monic_kernel_hfiber_prop {A B : abgr} (f : ABGR⟦A, B⟧) (isM : isMonic f)
              (w : abgr) (x : w) (h: ABGR⟦w, B⟧)
-             (H : h ;; CokernelArrow (ABGR_Cokernel f) = h ;; ZeroArrow ABGR_has_zero _ _) :
+             (H : h ;; CokernelArrow (ABGR_Cokernel f) = ZeroArrow ABGR_has_zero _ _) :
     ishinh_UU (Σ a : pr1 A, pr1 f a = pr1 h x %multmonoid).
   Proof.
-    rewrite ZeroArrow_comp_right in H.
     rewrite ABGR_has_zero_arrow_eq in H.
     cbn in H. unfold ABGR_zero_arrow in H.
     apply base_paths in H. cbn in H.
@@ -1598,7 +1593,7 @@ Section ABGR_monic_kernels.
       the kernel of its cokernel. *)
   Definition ABGR_monic_kernel_in_hfiber_iscontr {A B : abgr} (f : ABGR⟦A, B⟧) (isM : isMonic f)
              (w : abgr) (h: ABGR⟦w, B⟧)
-             (H : h ;; CokernelArrow (ABGR_Cokernel f) = h ;; ZeroArrow ABGR_has_zero _ _) :
+             (H : h ;; CokernelArrow (ABGR_Cokernel f) = ZeroArrow ABGR_has_zero _ _) :
     Π x : w, iscontr (hfiber (pr1 f) (pr1 h x)).
   Proof.
     intros x.
@@ -1624,7 +1619,7 @@ Section ABGR_monic_kernels.
   (** We construct an hfiber for every element in the image of h. *)
   Definition ABGR_monic_kernel_in_hfiber {A B : abgr} (f : ABGR⟦A, B⟧) (isM : isMonic f)
              (w : abgr) (x : w) (h: ABGR⟦w, B⟧)
-             (H : h ;; CokernelArrow (ABGR_Cokernel f) = h ;; ZeroArrow ABGR_has_zero _ _) :
+             (H : h ;; CokernelArrow (ABGR_Cokernel f) = ZeroArrow ABGR_has_zero _ _) :
     hfiber (pr1 f) (pr1 h x).
   Proof.
     use (squash_to_prop (ABGR_monic_kernel_hfiber_prop f isM w x h H)).
@@ -1670,7 +1665,7 @@ Section ABGR_monic_kernels.
   (** We define the KernelIn as the morphism x : w ↦ pr1 (hfiber (pr1 f) (pr1 h x)) : A. *)
   Definition ABGR_monic_kernel_in {A B : abgr} (f : ABGR⟦A, B⟧) (isM : isMonic f) (w : abgr)
              (h: ABGR⟦w, B⟧)
-             (H : h ;; CokernelArrow (ABGR_Cokernel f) = h ;; ZeroArrow ABGR_has_zero _ _) : w -> A.
+             (H : h ;; CokernelArrow (ABGR_Cokernel f) = ZeroArrow ABGR_has_zero _ _) : w -> A.
   Proof.
     intros x.
     exact (pr1 (ABGR_monic_kernel_in_hfiber f isM w x h H)).
@@ -1679,7 +1674,7 @@ Section ABGR_monic_kernels.
   (** Hide ismonoidfun behind Qed. *)
   Definition ABGR_monic_kernel_in_ismonoidfun {A B : abgr} (f : ABGR⟦A, B⟧) (isM : isMonic f)
              (w : abgr) (h: ABGR⟦w, B⟧)
-             (H : h ;; CokernelArrow (ABGR_Cokernel f) = h ;; ZeroArrow ABGR_has_zero _ _) :
+             (H : h ;; CokernelArrow (ABGR_Cokernel f) = ZeroArrow ABGR_has_zero _ _) :
     ismonoidfun (ABGR_monic_kernel_in f isM w h H).
   Proof.
     unfold ABGR_monic_kernel_in. cbn in *.
@@ -1716,7 +1711,7 @@ Section ABGR_monic_kernels.
   (** We show that the KernelIn map is a monoidfun. *)
   Definition ABGR_monic_kernel_in_monoidfun {A B : abgr} (f : ABGR⟦A, B⟧) (isM : isMonic f)
              (w : abgr) (h: ABGR⟦w, B⟧)
-             (H : h ;; CokernelArrow (ABGR_Cokernel f) = h ;; ZeroArrow ABGR_has_zero _ _) :
+             (H : h ;; CokernelArrow (ABGR_Cokernel f) = ZeroArrow ABGR_has_zero _ _) :
     monoidfun w A := monoidfunconstr (ABGR_monic_kernel_in_ismonoidfun f isM w h H).
 
   (** ** We are ready to prove that Monics are Kernels. *)
@@ -1729,12 +1724,11 @@ Section ABGR_monic_kernels.
   Qed.
 
   (** Hide isEqualizer beind Qed. *)
-  Definition ABGR_Monic_Kernel_isEqualizer {A B : abgr} (f : ABGR⟦A, B⟧) (isM : isMonic f) :
-    isEqualizer (CokernelArrow (ABGR_Cokernel f))
-                (ZeroArrow ABGR_has_zero B (ABGR_Cokernel f)) f
-                (KernelEqRw ABGR_has_zero (CokernelCompZero ABGR_has_zero (ABGR_Cokernel f))).
+  Definition ABGR_Monic_Kernel_isKernel {A B : abgr} (f : ABGR⟦A, B⟧) (isM : isMonic f) :
+    isKernel ABGR_has_zero f (CokernelArrow (ABGR_Cokernel f))
+             (CokernelCompZero ABGR_has_zero (ABGR_Cokernel f)).
   Proof.
-    use mk_isEqualizer.
+    use (mk_isKernel has_homsets_ABGR).
     intros w h H'.
     use unique_exists.
     (* KernelIn *)
@@ -1762,7 +1756,7 @@ Section ABGR_monic_kernels.
   Definition ABGR_monic_kernel {A B : abgr} (f : ABGR⟦A, B⟧) (isM : isMonic f) :
     Kernel ABGR_has_zero (CokernelArrow (ABGR_Cokernel f)) :=
     mk_Kernel ABGR_has_zero f (CokernelArrow (ABGR_Cokernel f))
-              (ABGR_Monic_Kernel_eq f isM) (ABGR_Monic_Kernel_isEqualizer f isM).
+              (ABGR_Monic_Kernel_eq f isM) (ABGR_Monic_Kernel_isKernel f isM).
 
   (** We verify that f is the KernelArrow of the above Kernel. *)
   Definition ABGR_monic_kernel_KernelArrow {A B : abgr} (f : ABGR⟦A, B⟧) (isM : isMonic f) :
@@ -1787,10 +1781,9 @@ Section ABGR_monic_kernels.
   (** Equality we are going to need. *)
   Lemma ABGR_epi_cokernel_out_data_eq {A B : abgr} (f : ABGR⟦A, B⟧) (isE : isEpi f) (w : abgr)
         (h : ABGR⟦A,w⟧)
-        (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero (ABGR_Kernel f) A ;; h) :
+        (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero (ABGR_Kernel f) w) :
     Π x : ABGR_kernel_hsubtype f, pr1 h (pr1carrier (ABGR_kernel_hsubtype f) x) = 1%multmonoid.
   Proof.
-    rewrite ZeroArrow_comp_left in H.
     rewrite ABGR_has_zero_arrow_eq in H.
     cbn in H. unfold ABGR_zero_arrow in H.
     apply base_paths in H. cbn in H.
@@ -1815,7 +1808,7 @@ Section ABGR_monic_kernels.
   (** Equality on hfibers. *)
   Lemma ABGR_epi_cokernel_out_data_hfiber_eq {A B : abgr} (f : ABGR⟦A, B⟧) (isE : isEpi f)
         (w : abgr) (h : ABGR⟦A,w⟧)
-        (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _ ;; h)
+        (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _)
         (b : B) (X : hfiber (pr1 f) b) :
     Π hfib : hfiber (pr1 f) b, pr1 h (pr1 hfib) = pr1 h (pr1 X).
   Proof.
@@ -1837,7 +1830,7 @@ Section ABGR_monic_kernels.
       kernel of f is zero. Then for all terms b of the domain of f, the space of terms of the target
       of h, such that all hfibers of b are mapped to the target, is contractible. *)
   Lemma ABGR_epi_cokernel_out_data_iscontr {A B : abgr} (f : ABGR⟦A, B⟧) (isE : isEpi f) (w : abgr)
-        (h : ABGR⟦A, w⟧) (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _ ;; h) :
+        (h : ABGR⟦A, w⟧) (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _) :
     Π b : B, iscontr ( Σ x : w, Π (hfib : hfiber (pr1 f) b), pr1 h (pr1 hfib) = x).
   Proof.
     intros b.
@@ -1858,7 +1851,7 @@ Section ABGR_monic_kernels.
   (** Using the above result we construct the unique term of w such that all the hfibers of b are
       mapped to it. *)
   Lemma ABGR_epi_cokernel_out_data {A B : abgr} (b : B) (f : ABGR⟦A, B⟧) (isE : isEpi f) (w : abgr)
-        (h : ABGR⟦A,w⟧) (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _ ;; h) :
+        (h : ABGR⟦A,w⟧) (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _) :
     ( Σ x : w, Π (hfib : hfiber (pr1 f) b), pr1 h (pr1 hfib) = x).
   Proof.
     use (squash_to_prop (ABGR_epi_issurjective f isE b)).
@@ -1877,7 +1870,7 @@ Section ABGR_monic_kernels.
   (** Construction of the cokernel out map. *)
   Definition ABGR_epi_cokernel_out_map {A B : abgr} (f : ABGR⟦A, B⟧) (isE : isEpi f) (w : abgr)
              (h : ABGR⟦A,w⟧)
-             (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _ ;; h) : B -> w.
+             (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _) : B -> w.
   Proof.
     intros b.
     exact (pr1 (ABGR_epi_cokernel_out_data b f isE w h H)).
@@ -1886,7 +1879,7 @@ Section ABGR_monic_kernels.
   (** Hide equality behind Qed. *)
   Definition ABGR_epi_cokernel_out_data_mult_eq {A B : abgr} (b1 b2 : B) (f : ABGR⟦A, B⟧)
              (isE : isEpi f) (w : abgr) (h : ABGR⟦A, w⟧)
-             (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _ ;; h)
+             (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _)
              (X : Σ x : w, Π hfib : hfiber (pr1 f) b1, pr1 h (pr1 hfib) = x)
              (X0 : Σ x : w, Π hfib : hfiber (pr1 f) b2, pr1 h (pr1 hfib) = x) :
     Π hfib : hfiber (pr1 f) (b1 * b2)%multmonoid, pr1 h (pr1 hfib) = (pr1 X * pr1 X0)%multmonoid.
@@ -1904,7 +1897,7 @@ Section ABGR_monic_kernels.
   (** This is used to verify that CokernelOut is a binopfun. *)
   Definition ABGR_epi_cokernel_out_data_mult {A B : abgr} (b1 b2 : B) (f : ABGR⟦A, B⟧)
              (isE : isEpi f) (w : abgr) (h : ABGR⟦A, w⟧)
-             (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _ ;; h) :
+             (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _) :
     ( Σ x : w, Π (hfib : hfiber (pr1 f) b1), pr1 h (pr1 hfib) = x) ->
     ( Σ x : w, Π (hfib : hfiber (pr1 f) b2), pr1 h (pr1 hfib) = x) ->
     ( Σ x : w, Π (hfib : hfiber (pr1 f) (b1 * b2)%multmonoid), pr1 h (pr1 hfib) = x).
@@ -1917,7 +1910,7 @@ Section ABGR_monic_kernels.
   (** Hide equality behind Qed. *)
   Definition ABGR_epi_cokernel_out_data_unel_eq {A B : abgr} (f : ABGR⟦A, B⟧) (isE : isEpi f)
              (w : abgr) (h : ABGR⟦A, w⟧)
-             (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _ ;; h) :
+             (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _) :
     Π hfib : hfiber (pr1 f) 1%multmonoid, pr1 h (pr1 hfib) = 1%multmonoid.
   Proof.
     intros hfib.
@@ -1929,13 +1922,13 @@ Section ABGR_monic_kernels.
   (** Construction of a structure for unel. *)
   Definition ABGR_epi_cokernel_out_data_unel {A B : abgr} (f : ABGR⟦A, B⟧) (isE : isEpi f)
              (w : abgr) (h : ABGR⟦A, w⟧)
-             (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _ ;; h) :
+             (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _) :
     ( Σ x : w, Π (hfib : hfiber (pr1 f) 1%multmonoid),  pr1 h (pr1 hfib) = x) :=
     tpair _ 1%multmonoid (ABGR_epi_cokernel_out_data_unel_eq f isE w h H).
 
   (** We show that the cokernel_out_map ismonoidfun. *)
   Lemma ABGR_epi_cokernel_out_ismonoidfun {A B : abgr} (f : ABGR⟦A, B⟧) (isE : isEpi f) (w : abgr)
-        (h : ABGR⟦A,w⟧) (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _ ;; h) :
+        (h : ABGR⟦A,w⟧) (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _) :
     ismonoidfun (ABGR_epi_cokernel_out_map f isE w h H).
   Proof.
     split.
@@ -1973,7 +1966,7 @@ Section ABGR_monic_kernels.
   (** Construction of the monoidfun cokernel_out. *)
   Definition ABGR_epi_cokernel_out_monoidfun {A B : abgr} (f : ABGR⟦A, B⟧) (isE : isEpi f)
              (w : abgr) (h : ABGR⟦A,w⟧)
-             (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _ ;; h) :
+             (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _) :
     monoidfun B w := monoidfunconstr (ABGR_epi_cokernel_out_ismonoidfun f isE w h H).
 
 
@@ -1987,11 +1980,10 @@ Section ABGR_monic_kernels.
   Qed.
 
   (** Hide isCoequalizer behind Qed. *)
-  Definition ABGR_epi_cokernel_isCoequalizer {A B : abgr} (f : ABGR⟦A, B⟧) (isE : isEpi f) :
-    isCoequalizer (KernelArrow (ABGR_Kernel f)) (ZeroArrow ABGR_has_zero (ABGR_Kernel f) A) f
-                  (CokernelEqRw ABGR_has_zero (ABGR_epi_cokernel_eq f isE)).
+  Definition ABGR_epi_cokernel_isCokernel {A B : abgr} (f : ABGR⟦A, B⟧) (isE : isEpi f) :
+    isCokernel ABGR_has_zero (KernelArrow (ABGR_Kernel f)) f (ABGR_epi_cokernel_eq f isE).
   Proof.
-    use mk_isCoequalizer.
+    use (mk_isCokernel has_homsets_ABGR).
     intros w h H.
     use unique_exists.
     (* Arrow *)
@@ -2017,8 +2009,8 @@ Section ABGR_monic_kernels.
   (** We construct a Cokernel such that CokernelArrow = f. *)
   Definition ABGR_epi_cokernel {A B : abgr} (f : ABGR⟦A, B⟧) (isE : isEpi f) :
     Cokernel ABGR_has_zero (KernelArrow (ABGR_Kernel f)) :=
-    mk_Cokernel ABGR_has_zero f (KernelArrow (ABGR_Kernel f)) (ABGR_epi_cokernel_eq f isE)
-                (ABGR_epi_cokernel_isCoequalizer f isE).
+    mk_Cokernel ABGR_has_zero (KernelArrow (ABGR_Kernel f)) f _
+                (ABGR_epi_cokernel_isCokernel f isE).
 
   (** We verify that f is the CokernelArrow of the above Cokernel. *)
   Definition ABGR_epi_cokernel_CokernelArrow {A B : abgr} (f : ABGR⟦A, B⟧) (isE : isEpi f) :
@@ -2056,7 +2048,7 @@ Section ABGR_abelianprecat.
         * intros A B f. exact (ABGR_Cokernel f). (* Cokernels *)
       + split.
         (* Monics are kernels *)
-        * unfold AbelianMonicKernelsData.
+        * use mk_AbelianMonicKernelsData.
           intros x y M.
           set (monic_ker := ABGR_monic_kernel (pr1 M) (pr2 M)).
           use tpair.
@@ -2064,19 +2056,19 @@ Section ABGR_abelianprecat.
              ++ use tpair.
                 ** exact (ABGR_Cokernel (pr1 M)).
                 ** exact (CokernelArrow (ABGR_Cokernel (pr1 M))).
-             ++ exact (KernelEqAr ABGR_has_zero monic_ker).
-          -- exact (isEqualizer_Equalizer monic_ker).
-    (* Epis are cokernels *)
-    * unfold AbelianEpiCokernelsData.
-      intros x y E.
-      set (epi_coker := ABGR_epi_cokernel (pr1 E) (pr2 E)).
-      use tpair.
-      -- use tpair.
-         ++ use tpair.
-            ** exact (ABGR_Kernel (pr1 E)).
-            ** exact (KernelArrow (ABGR_Kernel (pr1 E))).
-         ++ exact (CokernelEqAr ABGR_has_zero epi_coker).
-      -- exact (isCoequalizer_Coequalizer epi_coker).
+             ++ exact (KernelCompZero ABGR_has_zero monic_ker).
+          -- exact (KernelisKernel _ monic_ker).
+        (* Epis are cokernels *)
+        * use mk_AbelianEpiCokernelsData.
+          intros x y E.
+          set (epi_coker := ABGR_epi_cokernel (pr1 E) (pr2 E)).
+          use tpair.
+          -- use tpair.
+             ++ use tpair.
+                ** exact (ABGR_Kernel (pr1 E)).
+                ** exact (KernelArrow (ABGR_Kernel (pr1 E))).
+             ++ exact (CokernelCompZero ABGR_has_zero epi_coker).
+          -- exact (CokernelisCokernel _ epi_coker).
   Defined.
 
 End ABGR_abelianprecat.

--- a/UniMath/CategoryTheory/category_abgr.v
+++ b/UniMath/CategoryTheory/category_abgr.v
@@ -38,7 +38,7 @@ Require Import UniMath.CategoryTheory.HLevel_n_is_of_hlevel_Sn.
 Require Import UniMath.CategoryTheory.Monics.
 Require Import UniMath.CategoryTheory.Epis.
 
-Require Import UniMath.CategoryTheory.PrecategoriesWithBinOps.
+Require Import UniMath.CategoryTheory.precategoriesWithBinOps.
 Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
 Require Import UniMath.CategoryTheory.PreAdditive.
 Require Import UniMath.CategoryTheory.Additive.
@@ -550,14 +550,14 @@ Section ABGR_preadditive.
     - apply proofirrelevance. apply isapropismonoidfun.
   Qed.
 
-  (** ABGR is PrecategoryWithBinOps. *)
-  Definition ABGR_WithBinOpsData : PrecategoryWithBinOpsData ABGR.
+  (** ABGR is precategoryWithBinOps. *)
+  Definition ABGR_WithBinOpsData : precategoryWithBinOpsData ABGR.
   Proof.
     intros X Y.
     exact (ABGR_hombinop X Y).
   Defined.
 
-  Definition ABGR_WithBinOps : PrecategoryWithBinOps := tpair _ ABGR ABGR_WithBinOpsData.
+  Definition ABGR_WithBinOps : precategoryWithBinOps := tpair _ ABGR ABGR_WithBinOpsData.
 
   (** ABGR is PrecategoryWithAbgrops. *)
   Definition ABGR_WithAbGrops : PrecategoryWithAbgrops.

--- a/UniMath/CategoryTheory/functor_categories.v
+++ b/UniMath/CategoryTheory/functor_categories.v
@@ -85,66 +85,11 @@ Proof.
   apply hs.
 Qed.
 
-Lemma toforallpaths_induction (X Y : UU) (f g : X -> Y) (P : (Π x, f x = g x) -> UU)
-      (H : Π e : f = g, P (toforallpaths _ _ _ e)) : Π i, P i.
-Proof.
-  intros.
-  set (XR := homotweqinvweq (weqtoforallpaths _ f g)). cbn in XR. simpl in XR.
-  rewrite <- XR.
-  apply H.
-Defined.
-
-Definition transportf_funextfun {X Y : UU} (P : Y -> UU) (F F' : X -> Y)
-           (H : Π (x : X), F x = F' x) (x : X) (f : P (F x)) :
-  transportf (λ x0 : X → Y, P (x0 x)) (funextsec _ F F' H) f =
-  transportf (λ x0 : Y, P x0) (H x) f.
-Proof.
-  apply (toforallpaths_induction
-           _ _ F F' (fun H' => transportf (λ x0 : X → Y, P (x0 x))
-                                       (funextsec (λ _ : X, Y) F F' (λ x0 : X, H' x0)) f =
-                            transportf (λ x0 : Y, P x0) (H' x) f)).
-  intro e. clear H.
-  set (XR := homotinvweqweq (weqtoforallpaths _ F F') e).
-  match goal with [|- transportf ?PP ?HH _ = _ ] => set (H := HH); set (P' := PP) end.
-  eapply pathscomp0.
-  - eapply (maponpaths (fun X => transportf P' X f)). apply XR.
-  - induction e. apply idpath.
-Defined.
-
-Definition transportb_mor_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C)
-           (H : Π (x : X), F x = F' x) {x : X} (c : ob C) (f : F x --> c) :
-  transportb (λ x0 : X → C, x0 x --> c) (! funextfun F F' H) f =
-  transportb (λ x0 : C, x0 --> c) (! (H x)) f.
-Proof.
-  unfold transportb. rewrite pathsinv0inv0. rewrite pathsinv0inv0.
-  exact (@transportf_funextfun X (ob C) (λ x0 : C, x0 --> c) F F' H x f).
-Qed.
-
-Definition transportf_mor_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C)
-           (H : Π (x : X), F x = F' x) {x : X} {c : ob C} (f : c --> F x)  :
-  transportf (λ x0 : X → C, c --> x0 x) (funextfun F F' H) f =
-  transportf (λ x0 : C, c --> x0) (H x) f.
-Proof.
-  use transportf_funextfun.
-Qed.
-
-Lemma transport_mor_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C)
-           (H : Π (x : X), F x = F' x) {x1 x2 : X} (f : F x1 --> F x2) :
-  transportf (λ x : X → C, x x1 --> x x2) (funextfun F F' H) f =
-  transportf (λ x : X → C, F' x1 --> x x2)
-             (funextfun F F' (λ x : X, H x))
-             (transportb (λ x : X → C, x x1 --> F x2)
-                         (! (funextfun F F' (λ x : X, H x))) f).
-Proof.
-  induction (funextfun F F' (λ x : X, H x)).
-  apply idpath.
-Qed.
-
 Lemma functor_data_eq {C C' : precategory_ob_mor} (F F' : functor_data C C')
       (H : Π (c : C), (pr1 F) c = (pr1 F') c)
       (H1 : Π (C1 C2 : ob C) (f : C1 --> C2),
             transportf (λ x : C', pr1 F' C1 --> x) (H C2)
-                       (transportb (λ x : C', x --> pr1 F C2) (! H C1) (pr2 F C1 C2 f)) =
+                       (transportf (λ x : C', x --> pr1 F C2) (H C1) (pr2 F C1 C2 f)) =
             pr2 F' C1 C2 f) : F = F'.
 Proof.
   use total2_paths.
@@ -162,7 +107,7 @@ Proof.
     }
     rewrite e. clear e.
     rewrite transport_mor_funextfun.
-    rewrite transportb_mor_funextfun. rewrite transportf_mor_funextfun.
+    rewrite transport_source_funextfun. rewrite transport_target_funextfun.
     exact (H1 C1 C2 f).
 Qed.
 

--- a/UniMath/CategoryTheory/limits/BinDirectSums.v
+++ b/UniMath/CategoryTheory/limits/BinDirectSums.v
@@ -20,7 +20,7 @@ Require Import UniMath.CategoryTheory.limits.binproducts.
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
 Require Import UniMath.CategoryTheory.limits.zero.
 
-Require Import UniMath.CategoryTheory.PrecategoriesWithBinOps.
+Require Import UniMath.CategoryTheory.precategoriesWithBinOps.
 Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
 Require Import UniMath.CategoryTheory.PreAdditive.
 Require Import UniMath.CategoryTheory.Monics.

--- a/UniMath/CategoryTheory/limits/Opp.v
+++ b/UniMath/CategoryTheory/limits/Opp.v
@@ -108,6 +108,8 @@ Section def_opposites.
     apply idpath.
   Qed.
 
+  Local Opaque ZeroArrow.
+
 
   (** ** Equalizers and Coequalizers *)
 
@@ -153,75 +155,113 @@ Section def_opposites.
 
   (** ** Kernels and Cokernels *)
 
-  Lemma opp_Kernel_eq {y z : C} (f : (C^op)⟦y, z⟧) (Z : Zero (C^op)) (K : @Kernel (C^op) Z y z f) :
-    EqualizerArrow K ;; f = EqualizerArrow K ;; ZeroArrow (opp_Zero Z) z y.
+
+  Local Lemma opp_isCokernel_eq {x y z : C^op} (f : (C^op)⟦x, y⟧) (g : C^op⟦y, z⟧) (Z : Zero (C^op))
+        (H : f ;; g = ZeroArrow Z _ _) (Z' : Zero C) :
+    (g : C⟦z, y⟧) ;; (f : C⟦y, x⟧) = ZeroArrow Z' _ _.
   Proof.
-    rewrite <- opp_ZeroArrow.
-    apply (KernelEqAr _ K).
+    cbn in *. rewrite H. rewrite opp_ZeroArrow.
+    exact (ZerosArrowEq C (opp_Zero Z) Z' z x).
   Qed.
 
-  Lemma opp_Kernel_isEqualizer {y z : C} (f : (C^op)⟦y, z⟧) (Z : Zero (C^op))
-        (K : @Kernel (C^op) Z y z f) :
-    isEqualizer f (ZeroArrow (opp_Zero Z) z y) (EqualizerArrow K) (opp_Kernel_eq f Z K).
+  Lemma opp_isCokernel {x y z : C^op} {f : (C^op)⟦x, y⟧} {g : C^op⟦y, z⟧} {Z : Zero (C^op)}
+        {H : f ;; g = ZeroArrow Z _ _} (K' : isKernel Z f g H) {Z' : Zero C} :
+    isCokernel Z' (g : C⟦z, y⟧) (f : C⟦y, x⟧) (opp_isCokernel_eq f g Z H Z').
   Proof.
-    set (isE := isEqualizer_Equalizer K).
-    use mk_isEqualizer.
-    intros w h H'.
-    apply (isE w h).
-    use (pathscomp0 H').
-    apply cancel_precomposition.
-    unfold ZeroArrow. cbn.
-    rewrite <- opp_ZeroArrowTo.
-    rewrite <- opp_ZeroArrowFrom.
-    apply idpath.
+    set (K := mk_Kernel _ _ _ _ K').
+    use mk_isCokernel.
+    - exact hs.
+    - intros w h H'.
+      rewrite <- (ZerosArrowEq C (opp_Zero Z) Z' z w) in H'.
+      rewrite <- opp_ZeroArrow in H'.
+      use unique_exists.
+      + exact (KernelIn Z K w h H').
+      + use (KernelCommutes Z K).
+      + intros y0. apply hs.
+      + cbn. intros y0 X. use (KernelInsEq Z K). rewrite (KernelCommutes Z K). cbn. rewrite X.
+        apply idpath.
+  Qed.
+
+  Local Lemma opp_Kernel_eq {y z : C} (f : (C^op)⟦y, z⟧) (Z : Zero (C^op))
+             (K : @Kernel (C^op) Z y z f) :
+    @compose C^op _ _ _ (KernelArrow K) f = ZeroArrow (opp_Zero Z) z K.
+  Proof.
+    cbn. rewrite <- opp_ZeroArrow. apply (KernelCompZero Z K).
+  Qed.
+
+  Lemma opp_Kernel_isCokernel {y z : C} (f : (C^op)⟦y, z⟧) (Z : Zero (C^op))
+             (K : @Kernel (C^op) Z y z f) :
+    isCokernel (opp_Zero Z) f (KernelArrow K) (opp_Kernel_eq f Z K).
+  Proof.
+    use mk_isCokernel.
+    - exact hs.
+    - intros w h H'. rewrite <- opp_ZeroArrow in H'.
+      use unique_exists.
+      + exact (KernelIn Z K w h H').
+      + use (KernelCommutes Z K).
+      + intros y0. apply hs.
+      + cbn. intros y0 X. use (@KernelInsEq C^op). rewrite (KernelCommutes Z K). cbn. rewrite X.
+        apply idpath.
   Qed.
 
   Definition opp_Kernel {y z : C} (f : (C^op)⟦y, z⟧) (Z : Zero (C^op))
              (K : @Kernel (C^op) Z y z f) : @Cokernel C (opp_Zero Z) z y f.
   Proof.
-    use opp_Equalizer.
-    unfold Kernel in K.
-    use mk_Equalizer.
+    use mk_Cokernel.
     - exact K.
-    - exact (EqualizerArrow K).
+    - exact (KernelArrow K).
     - exact (opp_Kernel_eq f Z K).
-    - exact (opp_Kernel_isEqualizer f Z K).
+    - exact (opp_Kernel_isCokernel f Z K).
   Defined.
 
-  Lemma opp_Cokernel_eq {y z : ob C} (f : (C^op)⟦y, z⟧) (Z : Zero (C^op))
-        (CK : @Cokernel (C^op) Z y z f) :
-    f ;; CoequalizerArrow CK =
-    @compose C^op _ _ _ (ZeroArrow (opp_Zero Z) z y) (CoequalizerArrow CK).
+  Lemma opp_isKernel {x y z : C^op} {f : (C^op)⟦x, y⟧} {g : C^op⟦y, z⟧} {Z : Zero (C^op)}
+        {H : f ;; g = ZeroArrow Z _ _} (CK' : isCokernel Z f g H) {Z' : Zero C} :
+    isKernel Z' (g : C⟦z, y⟧) (f : C⟦y, x⟧) (opp_isCokernel_eq f g Z H Z').
   Proof.
-    rewrite <- opp_ZeroArrow. exact (CokernelEqAr _ CK).
+    set (CK := mk_Cokernel _ _ _ _ CK').
+    use mk_isKernel.
+    - exact hs.
+    - intros w h H'.
+      rewrite <- (ZerosArrowEq C (opp_Zero Z) Z' w x) in H'.
+      rewrite <- opp_ZeroArrow in H'.
+      use unique_exists.
+      + exact (CokernelOut Z CK w h H').
+      + use (CokernelCommutes Z CK).
+      + intros y0. apply hs.
+      + cbn. intros y0 X. use (CokernelOutsEq _ CK). rewrite (CokernelCommutes Z CK). cbn. rewrite X.
+        apply idpath.
   Qed.
 
-  Lemma opp_Cokernel_isCoequalizer {y z : C} (f : (C^op)⟦y, z⟧)
-        (Z : Zero (C^op)) (CK : @Cokernel (C^op) Z y z f) :
-    isCoequalizer f (ZeroArrow (opp_Zero Z) z y) (CoequalizerArrow CK) (opp_Cokernel_eq f Z CK).
+  Local Lemma opp_Cokernel_eq {y z : C} (f : (C^op)⟦y, z⟧) (Z : Zero (C^op))
+             (CK : @Cokernel (C^op) Z y z f) :
+    @compose (C^op) _ _ _ f (CokernelArrow CK) = ZeroArrow (opp_Zero Z) CK y.
   Proof.
-    set (isC := isCoequalizer_Coequalizer CK).
-    use mk_isCoequalizer.
-    intros w h H'.
-    apply (isC w h).
-    use (pathscomp0 H').
-    apply cancel_postcomposition.
-    unfold ZeroArrow. cbn.
-    rewrite <- opp_ZeroArrowTo.
-    rewrite <- opp_ZeroArrowFrom.
-    apply idpath.
+    cbn. rewrite <- opp_ZeroArrow. apply (CokernelCompZero Z CK).
+  Qed.
+
+  Lemma opp_Cokernel_isKernel {y z : C} (f : (C^op)⟦y, z⟧) (Z : Zero (C^op))
+             (CK : @Cokernel (C^op) Z y z f) :
+    isKernel (opp_Zero Z) (CokernelArrow CK) f (opp_Cokernel_eq f Z CK).
+  Proof.
+    use mk_isKernel.
+    - exact hs.
+    - intros w h H'. rewrite <- opp_ZeroArrow in H'.
+      use unique_exists.
+      + exact (CokernelOut Z CK w h H').
+      + use (CokernelCommutes Z CK).
+      + intros y0. apply hs.
+      + cbn. intros y0 X. use (@CokernelOutsEq C^op). rewrite (CokernelCommutes Z CK). cbn. rewrite X.
+        apply idpath.
   Qed.
 
   Definition opp_Cokernel {y z : C} (f : (C^op)⟦y, z⟧) (Z : Zero (C^op))
              (CK : @Cokernel (C^op) Z y z f) : @Kernel C (opp_Zero Z) z y f.
   Proof.
-    use opp_Coequalizer.
-    unfold Cokernel in CK.
-    use mk_Coequalizer.
+    use mk_Kernel.
     - exact CK.
-    - exact (CoequalizerArrow CK).
+    - exact (CokernelArrow CK).
     - exact (opp_Cokernel_eq f Z CK).
-    - exact (opp_Cokernel_isCoequalizer f Z CK).
+    - exact (opp_Cokernel_isKernel f Z CK).
   Defined.
 
   Definition opp_Kernels (Z : Zero (C^op)) (K : @Kernels (C^op) Z) : @Cokernels C (opp_Zero Z).
@@ -370,6 +410,8 @@ Section def_opposites'.
     apply idpath.
   Qed.
 
+  Local Opaque ZeroArrow.
+
 
   (** ** Equalizers and Coequalizers *)
 
@@ -410,68 +452,104 @@ Section def_opposites'.
 
   (** ** Kernels and Cokernels *)
 
-  Lemma Kernel_opp_eq {y z : C} (f : C⟦y, z⟧) (Z : Zero C) (K : @Kernel C Z y z f) :
-    EqualizerArrow K ;; f = @compose C _ _ _ (EqualizerArrow K) (ZeroArrow (Zero_opp Z) z y).
+  Local Lemma isCokernel_opp_eq {x y z : C} (f : C⟦x, y⟧) (g : C⟦y, z⟧) (Z : Zero C)
+        (H : f ;; g = ZeroArrow Z _ _) (Z' : Zero C^op) :
+    (g : C^op⟦z, y⟧) ;; (f : C^op⟦y, x⟧) = ZeroArrow Z' _ _.
   Proof.
-    use (pathscomp0 (KernelEqAr _ K)).
-    apply cancel_precomposition.
-    unfold ZeroArrow.
-    rewrite opp_ZeroArrowTo. rewrite opp_ZeroArrowFrom.
-    cbn. apply pathsinv0. apply ZeroArrowEq.
+    cbn in *. rewrite H. rewrite ZeroArrow_opp.
+    exact (ZerosArrowEq C^op (Zero_opp Z) Z' z x).
   Qed.
 
-  Lemma Kernel_opp_isEqualizer {y z : C} (f : C⟦y, z⟧) (Z : Zero C) (K : @Kernel C Z y z f) :
-    isEqualizer f (ZeroArrow (Zero_opp Z) z y) (EqualizerArrow K) (Kernel_opp_eq f Z K).
+  Lemma isCokernel_opp {x y z : C} {f : C⟦x, y⟧} {g : C⟦y, z⟧} {Z : Zero C}
+        {H : f ;; g = ZeroArrow Z _ _} (K' : isKernel Z f g H) {Z' : Zero C^op} :
+    isCokernel Z' (g : C^op⟦z, y⟧) (f : C^op⟦y, x⟧) (isCokernel_opp_eq f g Z H Z').
   Proof.
-    set (isE := isEqualizer_Equalizer K).
-    use mk_isEqualizer.
-    intros w h H'.
-    apply (isE w h).
-    use (pathscomp0 H').
-    apply cancel_precomposition.
-    apply (! (ZeroArrow_opp Z)).
+    set (K := mk_Kernel _ _ _ _ K').
+    use mk_isCokernel.
+    - exact (has_homsets_opp hs).
+    - intros w h H'. cbn in H'. rewrite <- (ZerosArrowEq C^op (Zero_opp Z) Z' z w) in H'.
+      use unique_exists.
+      + rewrite <- ZeroArrow_opp in H'. exact (KernelIn Z K w h H').
+      + cbn. use (KernelCommutes Z K).
+      + intros y0. apply (has_homsets_opp hs).
+      + cbn. intros y0 X. use (KernelInsEq Z K). rewrite KernelCommutes. exact X.
+  Qed.
+
+  Local Lemma Kernel_opp_eq {y z : C} (f : C⟦y, z⟧) (Z : Zero C) (K : @Kernel C Z y z f) :
+    @compose C^op _ _ _ f (KernelArrow K) = ZeroArrow (Zero_opp Z) z K.
+  Proof.
+    cbn. rewrite (KernelCompZero Z K). apply ZeroArrow_opp.
+  Qed.
+
+  Lemma Kernel_opp_isCokernel {y z : C} (f : C⟦y, z⟧) (Z : Zero C) (K : @Kernel C Z y z f) :
+    isCokernel (Zero_opp Z) f (KernelArrow K) (Kernel_opp_eq f Z K).
+  Proof.
+    use mk_isCokernel.
+    - exact (has_homsets_opp hs).
+    - intros w h H'. cbn in H'.
+      use unique_exists.
+      + rewrite <- ZeroArrow_opp in H'. exact (KernelIn Z K w h H').
+      + cbn. use KernelCommutes.
+      + intros y0. apply (has_homsets_opp hs).
+      + cbn. intros y0 X. use KernelInsEq. rewrite KernelCommutes. exact X.
   Qed.
 
   Definition Kernel_opp {y z : C} (f : C⟦y, z⟧) (Z : Zero C) (K : @Kernel C Z y z f) :
     @Cokernel (C^op) (Zero_opp Z) z y f.
   Proof.
-    use Equalizer_opp.
-    use mk_Equalizer.
+    use mk_Cokernel.
     - exact K.
-    - exact (EqualizerArrow K).
+    - exact (KernelArrow K).
     - exact (Kernel_opp_eq f Z K).
-    - exact (Kernel_opp_isEqualizer f Z K).
+    - exact (Kernel_opp_isCokernel f Z K).
   Defined.
 
-  Lemma Cokernel_opp_eq {y z : C} (f : C⟦y, z⟧) (Z : Zero C) (CK : @Cokernel C Z y z f) :
-    f ;; CoequalizerArrow CK = @compose C _ _ _ (ZeroArrow (Zero_opp Z) z y) (CoequalizerArrow CK).
+  Lemma isKernel_opp {x y z : C^op} {f : C⟦x, y⟧} {g : C⟦y, z⟧} {Z : Zero C}
+        {H : f ;; g = ZeroArrow Z _ _} (CK' : isCokernel Z f g H) {Z' : Zero C^op} :
+    isKernel Z' (g : C^op⟦z, y⟧) (f : C^op⟦y, x⟧) (isCokernel_opp_eq f g Z H Z').
   Proof.
-    use (pathscomp0 (CokernelEqAr _ CK)).
-    apply cancel_postcomposition.
-    apply (ZeroArrow_opp Z).
+    set (CK := mk_Cokernel _ _ _ _ CK').
+    use mk_isKernel.
+    - exact (has_homsets_opp hs).
+    - intros w h H'.
+      rewrite <- (ZerosArrowEq C^op (Zero_opp Z) Z' w x) in H'.
+      rewrite <- ZeroArrow_opp in H'.
+      use unique_exists.
+      + exact (CokernelOut Z CK w h H').
+      + use (CokernelCommutes Z CK).
+      + intros y0. apply hs.
+      + cbn. intros y0 X. use (CokernelOutsEq _ CK). rewrite (CokernelCommutes Z CK). cbn. rewrite X.
+        apply idpath.
   Qed.
 
-  Lemma Cokernel_opp_isCoequalizer {y z : C} (f : C⟦y, z⟧) (Z : Zero C) (CK : @Cokernel C Z y z f) :
-    isCoequalizer f (ZeroArrow (Zero_opp Z) z y) (CoequalizerArrow CK) (Cokernel_opp_eq f Z CK).
+  Local Lemma Cokernel_opp_eq {y z : C} (f : C⟦y, z⟧) (Z : Zero C) (CK : @Cokernel C Z y z f) :
+    @compose C^op _ _ _ (CokernelArrow CK) f = ZeroArrow (Zero_opp Z) CK y.
   Proof.
-    set (isC := isCoequalizer_Coequalizer CK).
-    use mk_isCoequalizer.
-    intros w h H'.
-    apply (isC w h).
-    use (pathscomp0 H').
-    apply cancel_postcomposition.
-    apply (! (ZeroArrow_opp Z)).
+    cbn. rewrite (CokernelCompZero Z CK). apply ZeroArrow_opp.
+  Qed.
+
+  Lemma Cokernel_opp_isKernel {y z : C} (f : C⟦y, z⟧) (Z : Zero C)
+        (CK : @Cokernel C Z y z f) :
+    isKernel (Zero_opp Z) (CokernelArrow CK) f (Cokernel_opp_eq f Z CK).
+  Proof.
+    use mk_isKernel.
+    - exact (has_homsets_opp hs).
+    - intros w h H'. cbn in H'.
+      use unique_exists.
+      + rewrite <- ZeroArrow_opp in H'. exact (CokernelOut Z CK w h H').
+      + cbn. use CokernelCommutes.
+      + intros y0. apply (has_homsets_opp hs).
+      + cbn. intros y0 X. use CokernelOutsEq. rewrite CokernelCommutes. exact X.
   Qed.
 
   Definition Cokernel_opp {y z : C} (f : C⟦y, z⟧) (Z : Zero C) (CK : @Cokernel C Z y z f) :
     @Kernel (C^op) (Zero_opp Z) z y f.
   Proof.
-    use Coequalizer_opp.
-    use mk_Coequalizer.
+    use mk_Kernel.
     - exact CK.
-    - exact (CoequalizerArrow CK).
+    - exact (CokernelArrow CK).
     - exact (Cokernel_opp_eq f Z CK).
-    - exact (Cokernel_opp_isCoequalizer f Z CK).
+    - exact (Cokernel_opp_isKernel f Z CK).
   Defined.
 
   Definition Kernels_opp (Z : Zero C) (K : @Kernels C Z) : @Cokernels (C^op) (Zero_opp Z).
@@ -487,6 +565,7 @@ Section def_opposites'.
     use Cokernel_opp.
     apply (CK y x f).
   Defined.
+
 
   (** ** Pushouts and pullbacks *)
 
@@ -507,6 +586,7 @@ Section def_opposites'.
   Definition Pushouts_opp (Pos : @Pushouts C) : @Pullbacks (C^op) := Pos.
 
   Definition Pullbacks_opp (Pbs : @Pushouts C) : @Pullbacks (C^op) := Pbs.
+
 
   (** ** BinProducts and BinCoproducts *)
 

--- a/UniMath/CategoryTheory/limits/Opp.v
+++ b/UniMath/CategoryTheory/limits/Opp.v
@@ -1,0 +1,531 @@
+(** * Duality between C and C^op *)
+(** ** Contents
+- From C^op to C
+ - Monics and Epis
+ - Initial, Terminal, and Zero
+ - Equalizers and Coequalizers
+ - Kernels and Cokernels
+ - Pullbacks and Pushouts
+ - BinProducts and BinCoproducts
+- From C to C^op
+ - Monics and Epis
+ - Initial, Terminal, and Zero
+ - Equalizers and Coequalizers
+ - Kernels and Cokernels
+ - Pullbacks and Pushouts
+ - BinProducts and BinCoproducts
+*)
+
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.Monics.
+Require Import UniMath.CategoryTheory.Epis.
+Require Import UniMath.CategoryTheory.opp_precat.
+
+Require Import UniMath.CategoryTheory.limits.initial.
+Require Import UniMath.CategoryTheory.limits.terminal.
+Require Import UniMath.CategoryTheory.limits.zero.
+Require Import UniMath.CategoryTheory.limits.equalizers.
+Require Import UniMath.CategoryTheory.limits.coequalizers.
+Require Import UniMath.CategoryTheory.limits.kernels.
+Require Import UniMath.CategoryTheory.limits.cokernels.
+Require Import UniMath.CategoryTheory.limits.pushouts.
+Require Import UniMath.CategoryTheory.limits.pullbacks.
+Require Import UniMath.CategoryTheory.limits.binproducts.
+Require Import UniMath.CategoryTheory.limits.bincoproducts.
+
+
+(** * Translation of structures from C^op to C *)
+Section def_opposites.
+
+  Variable C : precategory.
+  Hypothesis hs : has_homsets C.
+
+  Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
+
+
+  (** ** Monic and Epi *)
+
+  Definition opp_isMonic {a b : C} (f : a --> b) (H : @isMonic (C^op) _ _ f) : @isEpi C _ _ f := H.
+  Opaque opp_isMonic.
+
+  Definition opp_Monic {a b : C} (f : @Monic (C^op) a b) : @Epi C b a :=
+    @mk_Epi C _ _ f (opp_isMonic f (pr2 f)).
+
+  Definition opp_isEpi {a b : C} (f : a --> b) (H : @isEpi (C^op) _ _ f) : @isMonic C _ _ f := H.
+  Opaque opp_isEpi.
+
+  Definition opp_Epi {a b : C} (f : @Epi (C^op) a b) : @Monic C b a :=
+    @mk_Monic C _ _ f (opp_isEpi f (pr2 f)).
+
+
+  (** ** Initial, Terminal, and Zero *)
+
+  Definition opp_isInitial {x : C} (H : @isInitial (C^op) x) : @isTerminal C x := H.
+
+  Definition opp_Initial (I : @Initial (C^op)) : @Terminal C :=
+    @mk_Terminal C _ (opp_isInitial (pr2 I)).
+
+  Definition opp_isTerminal {x : C} (H : @isTerminal (C^op) x) : @isInitial C x := H.
+
+  Definition opp_Terminal (T : @Terminal (C^op)) : @Initial C :=
+    @mk_Initial C _ (opp_isTerminal (pr2 T)).
+
+  Lemma opp_isZero {x : C} (H : @isZero (C^op) x) : @isZero C x.
+  Proof.
+    use mk_isZero.
+    - intros a. exact (dirprod_pr2 H a).
+    - intros a. exact (dirprod_pr1 H a).
+  Qed.
+
+  Definition opp_Zero (Z : @Zero (C^op)) : @Zero C := @mk_Zero C _ (opp_isZero (pr2 Z)).
+
+
+  (** ** Equality on ZeroArrows *)
+
+  Lemma opp_ZeroArrowTo {x : C} (Z : @Zero (C^op)) :
+    @ZeroArrowTo (C^op) Z x = @ZeroArrowFrom C (opp_Zero Z) x.
+  Proof.
+    apply ArrowsToZero.
+  Qed.
+
+  Lemma opp_ZeroArrowFrom {x : C} (Z : @Zero (C^op)) :
+    @ZeroArrowFrom (C^op) Z x = @ZeroArrowTo C (opp_Zero Z) x.
+  Proof.
+    apply ArrowsFromZero.
+  Qed.
+
+  Lemma opp_ZeroArrow {x y : C} (Z : @Zero (C^op)) :
+    @ZeroArrow (C^op) Z x y = @ZeroArrow C (opp_Zero Z) y x.
+  Proof.
+    unfold ZeroArrow.
+    rewrite opp_ZeroArrowTo.
+    rewrite opp_ZeroArrowFrom.
+    apply idpath.
+  Qed.
+
+
+  (** ** Equalizers and Coequalizers *)
+
+  Lemma opp_isEqualizer {x y z : C} (f g : (C^op)⟦y, z⟧) (e : (C^op)⟦x, y⟧) (H : e ;; f = e ;; g)
+    (H' : @isEqualizer (C^op) _ _ _ f g e H) : @isCoequalizer C _ _ _ f g e H.
+  Proof.
+    exact H'.
+  Qed.
+
+  Lemma opp_isCoequalizer {x y z : C} (f g : (C^op)⟦x, y⟧) (e : (C^op)⟦y, z⟧)
+        (H : f ;; e = g ;; e) (H' : @isCoequalizer (C^op) _ _ _ f g e H) :
+    @isEqualizer C _ _ _ f g e H.
+  Proof.
+    exact H'.
+  Qed.
+
+  Definition opp_Equalizer {y z : C} (f g : (C^op)⟦y, z⟧) (E : @Equalizer (C^op) y z f g) :
+    @Coequalizer C z y f g := @mk_Coequalizer C _ _ _ f g (EqualizerArrow E) (EqualizerEqAr E)
+                                              (opp_isEqualizer f g (EqualizerArrow E)
+                                                               (EqualizerEqAr E)
+                                                               (isEqualizer_Equalizer E)).
+
+  Definition opp_Coequalizer {y z : C} (f g : (C^op)⟦y, z⟧) (E : @Coequalizer (C^op) y z f g) :
+    @Equalizer C z y f g := @mk_Equalizer C _ _ _ f g (CoequalizerArrow E) (CoequalizerEqAr E)
+                                          (opp_isCoequalizer f g (CoequalizerArrow E)
+                                                             (CoequalizerEqAr E)
+                                                             (isCoequalizer_Coequalizer E)).
+
+  Definition opp_Equalizers (E : @Equalizers (C^op)) : @Coequalizers C.
+  Proof.
+    intros x y f g.
+    use opp_Equalizer.
+    exact (E y x f g).
+  Defined.
+
+  Definition opp_Coequalizers (E : @Coequalizers (C^op)) : @Equalizers C.
+  Proof.
+    intros x y f g.
+    use opp_Coequalizer.
+    exact (E y x f g).
+  Defined.
+
+
+  (** ** Kernels and Cokernels *)
+
+  Lemma opp_Kernel_eq {y z : C} (f : (C^op)⟦y, z⟧) (Z : Zero (C^op)) (K : @Kernel (C^op) Z y z f) :
+    EqualizerArrow K ;; f = EqualizerArrow K ;; ZeroArrow (opp_Zero Z) z y.
+  Proof.
+    rewrite <- opp_ZeroArrow.
+    apply (KernelEqAr _ K).
+  Qed.
+
+  Lemma opp_Kernel_isEqualizer {y z : C} (f : (C^op)⟦y, z⟧) (Z : Zero (C^op))
+        (K : @Kernel (C^op) Z y z f) :
+    isEqualizer f (ZeroArrow (opp_Zero Z) z y) (EqualizerArrow K) (opp_Kernel_eq f Z K).
+  Proof.
+    set (isE := isEqualizer_Equalizer K).
+    use mk_isEqualizer.
+    intros w h H'.
+    apply (isE w h).
+    use (pathscomp0 H').
+    apply cancel_precomposition.
+    unfold ZeroArrow. cbn.
+    rewrite <- opp_ZeroArrowTo.
+    rewrite <- opp_ZeroArrowFrom.
+    apply idpath.
+  Qed.
+
+  Definition opp_Kernel {y z : C} (f : (C^op)⟦y, z⟧) (Z : Zero (C^op))
+             (K : @Kernel (C^op) Z y z f) : @Cokernel C (opp_Zero Z) z y f.
+  Proof.
+    use opp_Equalizer.
+    unfold Kernel in K.
+    use mk_Equalizer.
+    - exact K.
+    - exact (EqualizerArrow K).
+    - exact (opp_Kernel_eq f Z K).
+    - exact (opp_Kernel_isEqualizer f Z K).
+  Defined.
+
+  Lemma opp_Cokernel_eq {y z : ob C} (f : (C^op)⟦y, z⟧) (Z : Zero (C^op))
+        (CK : @Cokernel (C^op) Z y z f) :
+    f ;; CoequalizerArrow CK =
+    @compose C^op _ _ _ (ZeroArrow (opp_Zero Z) z y) (CoequalizerArrow CK).
+  Proof.
+    rewrite <- opp_ZeroArrow. exact (CokernelEqAr _ CK).
+  Qed.
+
+  Lemma opp_Cokernel_isCoequalizer {y z : C} (f : (C^op)⟦y, z⟧)
+        (Z : Zero (C^op)) (CK : @Cokernel (C^op) Z y z f) :
+    isCoequalizer f (ZeroArrow (opp_Zero Z) z y) (CoequalizerArrow CK) (opp_Cokernel_eq f Z CK).
+  Proof.
+    set (isC := isCoequalizer_Coequalizer CK).
+    use mk_isCoequalizer.
+    intros w h H'.
+    apply (isC w h).
+    use (pathscomp0 H').
+    apply cancel_postcomposition.
+    unfold ZeroArrow. cbn.
+    rewrite <- opp_ZeroArrowTo.
+    rewrite <- opp_ZeroArrowFrom.
+    apply idpath.
+  Qed.
+
+  Definition opp_Cokernel {y z : C} (f : (C^op)⟦y, z⟧) (Z : Zero (C^op))
+             (CK : @Cokernel (C^op) Z y z f) : @Kernel C (opp_Zero Z) z y f.
+  Proof.
+    use opp_Coequalizer.
+    unfold Cokernel in CK.
+    use mk_Coequalizer.
+    - exact CK.
+    - exact (CoequalizerArrow CK).
+    - exact (opp_Cokernel_eq f Z CK).
+    - exact (opp_Cokernel_isCoequalizer f Z CK).
+  Defined.
+
+  Definition opp_Kernels (Z : Zero (C^op)) (K : @Kernels (C^op) Z) : @Cokernels C (opp_Zero Z).
+  Proof.
+    intros x y f.
+    use opp_Kernel.
+    apply (K y x f).
+  Defined.
+
+  Definition opp_Cokernels (Z : Zero (C^op)) (CK : @Cokernels (C^op) Z) : @Kernels C (opp_Zero Z).
+  Proof.
+    intros x y f.
+    use opp_Cokernel.
+    apply (CK y x f).
+  Defined.
+
+
+  (** ** Pushouts and pullbacks *)
+
+  Lemma opp_isPushout {a b c d : C} (f : (C^op)⟦a, b⟧) (g : (C^op)⟦a, c⟧)
+        (in1 : (C^op)⟦b, d⟧) (in2 : (C^op)⟦c, d⟧) (H : f ;; in1 = g ;; in2)
+        (iPo : @isPushout (C^op) a b c d f g in1 in2 H) : @isPullback C a b c d f g in1 in2 H.
+  Proof.
+    exact iPo.
+  Qed.
+
+  Lemma opp_isPullback {a b c d : C} (f : (C^op)⟦b, a⟧) (g : (C^op)⟦c, a⟧)
+        (p1 : (C^op)⟦d, b⟧) (p2 : (C^op)⟦d, c⟧) (H : p1 ;; f = p2 ;; g)
+        (iPb : @isPullback (C^op) a b c d f g p1 p2 H) : @isPushout C a b c d f g p1 p2 H.
+  Proof.
+    exact iPb.
+  Qed.
+
+  Definition opp_Pushout {a b c : C} (f : (C^op)⟦a, b⟧) (g : (C^op)⟦a, c⟧)
+             (Po : @Pushout (C^op) a b c f g) : @Pullback C a b c f g.
+  Proof.
+    exact Po.
+  Defined.
+
+  Definition opp_Pullback {a b c : C} (f : (C^op)⟦b, a⟧) (g : (C^op)⟦c, a⟧)
+             (Pb : @Pullback (C^op) a b c f g) : @Pushout C a b c f g.
+  Proof.
+    exact Pb.
+  Defined.
+
+  Definition opp_Pushouts (Pos : @Pushouts (C^op)) : @Pullbacks C.
+  Proof.
+    exact Pos.
+  Defined.
+
+  Definition opp_Pullbacks (Pbs : @Pushouts (C^op)) : @Pullbacks C.
+  Proof.
+    exact Pbs.
+  Defined.
+
+
+  (** ** BinProducts and BinCoproducts *)
+
+  Definition opp_isBinProductCone (c d p : C) (p1 : (C^op)⟦p, c⟧) (p2 : (C^op)⟦p, d⟧)
+             (iBPC : @isBinProductCone (C^op) c d p p1 p2) : @isBinCoproductCocone C c d p p1 p2 :=
+    iBPC.
+
+  Definition opp_isBinCoproductCone (a b co : C) (ia : (C^op)⟦a, co⟧) (ib : (C^op)⟦b, co⟧)
+             (iBCC : @isBinCoproductCocone (C^op) a b co ia ib) :
+    @isBinProductCone C a b co ia ib := iBCC.
+
+  Definition opp_BinProductCone (c d : C) (BPC : @BinProductCone (C^op) c d) :
+    @BinCoproductCocone C c d := BPC.
+
+  Definition opp_BinCoproductCoCone (c d : C) (BCC : @BinCoproductCocone (C^op) c d) :
+    @BinProductCone C c d := BCC.
+
+  Definition opp_BinProducts (BP : @BinProducts (C^op)) : @BinCoproducts C := BP.
+
+  Definition opp_BinCoproducts (BC : @BinCoproducts (C^op)) : @BinProducts C := BC.
+
+End def_opposites.
+
+
+(** * Translation of structures from C to C^op *)
+Section def_opposites'.
+
+  Variable C : precategory.
+  Hypothesis hs : has_homsets C.
+
+  Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
+
+
+  (** ** Monic and Epi *)
+
+  Definition isMonic_opp {a b : C} {f : C⟦a, b⟧} (H : @isMonic C a b f) : @isEpi (C^op) b a f := H.
+  Opaque isMonic_opp.
+
+  Definition Monic_opp {a b : C} (f : @Monic C a b) : @Epi (C^op) b a :=
+    @mk_Epi (C^op) b a f (isMonic_opp (pr2 f)).
+
+  Definition isEpi_opp {a b : C} {f : C⟦a, b⟧} (H : @isEpi C a b f) : @isMonic (C^op) b a f := H.
+  Opaque isEpi_opp.
+
+  Definition Epi_opp {a b : C} (f : @Epi C a b) : @Monic (C^op) b a :=
+    @mk_Monic (C^op) b a f (isEpi_opp (pr2 f)).
+
+
+  (** ** Initial, Terminal, and Zero *)
+
+  Definition isInitial_opp {x : C} (H : @isInitial C x) : @isTerminal (C^op) x := H.
+
+  Definition Initial_opp (I : @Initial C) : @Terminal (C^op) :=
+    @mk_Terminal (C^op) _ (isInitial_opp (pr2 I)).
+
+  Definition isTerminal_opp {x : C} (H : @isTerminal C x) : @isInitial (C^op) x := H.
+
+  Definition Terminal_opp (T : @Terminal C) : @Initial (C^op) :=
+    @mk_Initial (C^op) _ (isTerminal_opp (pr2 T)).
+
+  Lemma isZero_opp {x : C} (H : @isZero C x) : @isZero (C^op) x.
+  Proof.
+    use mk_isZero.
+    - intros a. apply (pr2 H a).
+    - intros a. apply (pr1 H a).
+  Qed.
+
+  Definition Zero_opp (T : @Zero C) : @Zero (C^op) := @mk_Zero (C^op) _ (isZero_opp (pr2 T)).
+
+
+  (** ** Equality on ZeroArrows *)
+
+  Lemma ZeroArrowTo_opp {x : C} (Z : @Zero C) :
+    @ZeroArrowTo C Z x = @ZeroArrowFrom (C^op) (Zero_opp Z) x.
+  Proof.
+    apply ArrowsToZero.
+  Qed.
+
+  Lemma ZeroArrowFrom_opp {x : C} (Z : @Zero C) :
+    @ZeroArrowFrom C Z x = @ZeroArrowTo (C^op) (Zero_opp Z) x.
+  Proof.
+    apply ArrowsFromZero.
+  Qed.
+
+  Lemma ZeroArrow_opp {x y : C} (Z : @Zero C) :
+    @ZeroArrow C Z x y = @ZeroArrow (C^op) (Zero_opp Z) y x.
+  Proof.
+    unfold ZeroArrow.
+    rewrite ZeroArrowTo_opp.
+    rewrite ZeroArrowFrom_opp.
+    apply idpath.
+  Qed.
+
+
+  (** ** Equalizers and Coequalizers *)
+
+  Definition isEqualizer_opp {x y z : C} (f g : C⟦y, z⟧) (e : C⟦x, y⟧) (H : e ;; f = e ;; g)
+             (isE : @isEqualizer C _ _ _ f g e H) : @isCoequalizer (C^op) _ _ _ f g e H := isE.
+
+  Definition isCoequalizer_opp {x y z : C} (f g : C⟦x, y⟧) (e : C⟦y, z⟧) (H : f ;; e = g ;; e)
+             (isC : @isCoequalizer C _ _ _ f g e H) : @isEqualizer (C^op) _ _ _ f g e H := isC.
+
+  Definition Equalizer_opp {y z : C} (f g : C⟦y, z⟧) (E : @Equalizer C y z f g) :
+    @Coequalizer (C^op) z y f g := @mk_Coequalizer (C^op) _ _ _ f g (EqualizerArrow E)
+                                                   (EqualizerEqAr E)
+                                                   (isEqualizer_opp f g (EqualizerArrow E)
+                                                                    (EqualizerEqAr E)
+                                                                    (isEqualizer_Equalizer E)).
+
+  Definition Coequalizer_opp {y z : C} (f g : C⟦y, z⟧) (CE : @Coequalizer C y z f g) :
+    @Equalizer (C^op) z y f g := @mk_Equalizer (C^op) _ _ _ f g (CoequalizerArrow CE)
+                                               (CoequalizerEqAr CE)
+                                               (isCoequalizer_opp f g (CoequalizerArrow CE)
+                                                                  (CoequalizerEqAr CE)
+                                                                  (isCoequalizer_Coequalizer CE)).
+
+  Definition Equalizers_opp (E : @Equalizers C) : @Coequalizers (C^op).
+  Proof.
+    intros x y f g.
+    use Equalizer_opp.
+    exact (E y x f g).
+  Defined.
+
+  Definition Coequalizers_opp (CE : @Coequalizers C) : @Equalizers (C^op).
+  Proof.
+    intros x y f g.
+    use Coequalizer_opp.
+    exact (CE y x f g).
+  Defined.
+
+
+  (** ** Kernels and Cokernels *)
+
+  Lemma Kernel_opp_eq {y z : C} (f : C⟦y, z⟧) (Z : Zero C) (K : @Kernel C Z y z f) :
+    EqualizerArrow K ;; f = @compose C _ _ _ (EqualizerArrow K) (ZeroArrow (Zero_opp Z) z y).
+  Proof.
+    use (pathscomp0 (KernelEqAr _ K)).
+    apply cancel_precomposition.
+    unfold ZeroArrow.
+    rewrite opp_ZeroArrowTo. rewrite opp_ZeroArrowFrom.
+    cbn. apply pathsinv0. apply ZeroArrowEq.
+  Qed.
+
+  Lemma Kernel_opp_isEqualizer {y z : C} (f : C⟦y, z⟧) (Z : Zero C) (K : @Kernel C Z y z f) :
+    isEqualizer f (ZeroArrow (Zero_opp Z) z y) (EqualizerArrow K) (Kernel_opp_eq f Z K).
+  Proof.
+    set (isE := isEqualizer_Equalizer K).
+    use mk_isEqualizer.
+    intros w h H'.
+    apply (isE w h).
+    use (pathscomp0 H').
+    apply cancel_precomposition.
+    apply (! (ZeroArrow_opp Z)).
+  Qed.
+
+  Definition Kernel_opp {y z : C} (f : C⟦y, z⟧) (Z : Zero C) (K : @Kernel C Z y z f) :
+    @Cokernel (C^op) (Zero_opp Z) z y f.
+  Proof.
+    use Equalizer_opp.
+    use mk_Equalizer.
+    - exact K.
+    - exact (EqualizerArrow K).
+    - exact (Kernel_opp_eq f Z K).
+    - exact (Kernel_opp_isEqualizer f Z K).
+  Defined.
+
+  Lemma Cokernel_opp_eq {y z : C} (f : C⟦y, z⟧) (Z : Zero C) (CK : @Cokernel C Z y z f) :
+    f ;; CoequalizerArrow CK = @compose C _ _ _ (ZeroArrow (Zero_opp Z) z y) (CoequalizerArrow CK).
+  Proof.
+    use (pathscomp0 (CokernelEqAr _ CK)).
+    apply cancel_postcomposition.
+    apply (ZeroArrow_opp Z).
+  Qed.
+
+  Lemma Cokernel_opp_isCoequalizer {y z : C} (f : C⟦y, z⟧) (Z : Zero C) (CK : @Cokernel C Z y z f) :
+    isCoequalizer f (ZeroArrow (Zero_opp Z) z y) (CoequalizerArrow CK) (Cokernel_opp_eq f Z CK).
+  Proof.
+    set (isC := isCoequalizer_Coequalizer CK).
+    use mk_isCoequalizer.
+    intros w h H'.
+    apply (isC w h).
+    use (pathscomp0 H').
+    apply cancel_postcomposition.
+    apply (! (ZeroArrow_opp Z)).
+  Qed.
+
+  Definition Cokernel_opp {y z : C} (f : C⟦y, z⟧) (Z : Zero C) (CK : @Cokernel C Z y z f) :
+    @Kernel (C^op) (Zero_opp Z) z y f.
+  Proof.
+    use Coequalizer_opp.
+    use mk_Coequalizer.
+    - exact CK.
+    - exact (CoequalizerArrow CK).
+    - exact (Cokernel_opp_eq f Z CK).
+    - exact (Cokernel_opp_isCoequalizer f Z CK).
+  Defined.
+
+  Definition Kernels_opp (Z : Zero C) (K : @Kernels C Z) : @Cokernels (C^op) (Zero_opp Z).
+  Proof.
+    intros x y f.
+    use Kernel_opp.
+    apply (K y x f).
+  Defined.
+
+  Definition Cokernels_opp (Z : Zero C) (CK : @Cokernels C Z) : @Kernels (C^op) (Zero_opp Z).
+  Proof.
+    intros x y f.
+    use Cokernel_opp.
+    apply (CK y x f).
+  Defined.
+
+  (** ** Pushouts and pullbacks *)
+
+  Definition isPushout_opp {a b c d : C} (f : C⟦a, b⟧) (g : C⟦a, c⟧) (in1 : C⟦b, d⟧) (in2 : C⟦c, d⟧)
+             (H : f ;; in1 = g ;; in2) (iPo : @isPushout C a b c d f g in1 in2 H) :
+    @isPullback (C^op) a b c d f g in1 in2 H := iPo.
+
+  Definition isPullback_opp {a b c d : C} (f : C⟦b, a⟧) (g : C⟦c, a⟧) (p1 : C⟦d, b⟧) (p2 : C⟦d, c⟧)
+        (H : p1 ;; f = p2 ;; g) (iPb : @isPullback C a b c d f g p1 p2 H) :
+    @isPushout (C^op) a b c d f g p1 p2 H := iPb.
+
+  Definition Pushout_opp {a b c : C} (f : C⟦a, b⟧) (g : C⟦a, c⟧) (Po : @Pushout C a b c f g) :
+    @Pullback (C^op) a b c f g := Po.
+
+  Definition Pullback_opp {a b c : C} (f : C⟦b, a⟧) (g : C⟦c, a⟧) (Pb : @Pullback C a b c f g) :
+    @Pushout (C^op) a b c f g := Pb.
+
+  Definition Pushouts_opp (Pos : @Pushouts C) : @Pullbacks (C^op) := Pos.
+
+  Definition Pullbacks_opp (Pbs : @Pushouts C) : @Pullbacks (C^op) := Pbs.
+
+  (** ** BinProducts and BinCoproducts *)
+
+  Definition isBinProductCone_opp (c d p : C) (p1 : C⟦p, c⟧) (p2 : C⟦p, d⟧)
+             (iBPC : @isBinProductCone C c d p p1 p2) :
+    @isBinCoproductCocone (C^op) c d p p1 p2 := iBPC.
+
+  Definition isBinCoproductCone_opp (a b co : C) (ia : C⟦a, co⟧) (ib : C⟦b, co⟧)
+             (iBCC : @isBinCoproductCocone C a b co ia ib) :
+    @isBinProductCone (C^op) a b co ia ib := iBCC.
+
+  Definition BinProductCone_opp (c d : C) (iBPC : @BinProductCone C c d) :
+    @BinCoproductCocone (C^op) c d := iBPC.
+
+  Definition BinCoproductCoCone_opp (c d : C) (iBCC : @BinCoproductCocone C c d) :
+    @BinProductCone (C^op) c d := iBCC.
+
+  Definition BinProducts_opp (BP : @BinProducts C) : @BinCoproducts (C^op) := BP.
+
+  Definition BinCoproducts_opp (BC : @BinCoproducts C) : @BinProducts (C^op) := BC.
+
+End def_opposites'.

--- a/UniMath/CategoryTheory/limits/coequalizers.v
+++ b/UniMath/CategoryTheory/limits/coequalizers.v
@@ -41,6 +41,19 @@ Section def_coequalizers.
     apply isapropiscontr.
   Defined.
 
+  Lemma isCoequalizer_path {hs : has_homsets C} {x y z : C} {f g : x --> y} {e : y --> z}
+        {H H' : f ;; e = g ;; e} (iC : isCoequalizer f g e H) :
+    isCoequalizer f g e H'.
+  Proof.
+    use mk_isCoequalizer.
+    intros w0 h H'0.
+    use unique_exists.
+    - exact (pr1 (pr1 (iC w0 h H'0))).
+    - exact (pr2 (pr1 (iC w0 h H'0))).
+    - intros y0. apply hs.
+    - intros y0 X. exact (base_paths _ _ (pr2 (iC w0 h H'0) (tpair _ y0 X))).
+  Defined.
+
   (** Proves that the arrow from the coequalizer object with the right
     commutativity property is unique. *)
   Lemma isCoequalizerOutUnique {y z w: C} (f g : y --> z) (e : z --> w)

--- a/UniMath/CategoryTheory/limits/cokernels.v
+++ b/UniMath/CategoryTheory/limits/cokernels.v
@@ -17,217 +17,196 @@ Require Import UniMath.CategoryTheory.Epis.
 Require Import UniMath.CategoryTheory.limits.coequalizers.
 Require Import UniMath.CategoryTheory.limits.zero.
 
-(** In this section we define cokernels and show that cokernel arrow is an
-  epi. *)
+(** In this section we define cokernels and show that cokernel arrow is an epi. *)
 Section def_cokernels.
 
   Context {C : precategory}.
-  Hypothesis Z : Zero C.
   Hypothesis hs : has_homsets C.
-
-  (** This rewrite is used to rewrite an equality f ;; g = ZeroArrow to
-     f ;; g = ZeroArrow ;; g. This is because Coequalizers need the latter
-     equality. *)
-  Lemma CokernelEqRw {x y z : C} {g : x --> y} {f : y --> z} (H : g ;; f = ZeroArrow Z x z) :
-    g ;; f = ZeroArrow Z x y ;; f.
-  Proof.
-    pathvia (ZeroArrow Z x z).
-    apply H. apply pathsinv0. apply ZeroArrow_comp_left.
-  Defined.
-
-  Lemma CokernelEqRw' {x y z : C} {f : x --> y} {g : y --> z} (H : f ;; g = ZeroArrow Z x y ;; g) :
-    f ;; g = ZeroArrow Z x z.
-  Proof.
-    rewrite ZeroArrow_comp_left in H. exact H.
-  Qed.
+  Hypothesis Z : Zero C.
 
   (** Definition and construction of Cokernels *)
-  Definition isCokernel {x y z : C} (f : y --> z) (g : x --> y) (H : g ;; f = (ZeroArrow Z x z)) : UU :=
-    isCoequalizer g (ZeroArrow Z x y) f (CokernelEqRw H).
+  Definition isCokernel {x y z : C} (f : x --> y) (g : y --> z) (H : f ;; g = (ZeroArrow Z x z)) : UU :=
+    Π (w : C) (h : y --> w) (H : f ;; h = ZeroArrow Z x w), iscontr (Σ φ : z --> w, g ;; φ = h).
 
+  Lemma isCokernel_paths  {x y z : C} (f : x --> y) (g : y --> z) (H H' : f ;; g = (ZeroArrow Z x z))
+        (isC : isCokernel f g H) : isCokernel f g H'.
+  Proof.
+    assert (e : H = H') by apply hs.
+    induction e. exact isC.
+  Qed.
 
   Local Lemma mk_isCokernel_uniqueness {x y z : C} (f : x --> y) (g : y --> z)
         (H1 : f ;; g = ZeroArrow Z x z)
-        (H2 : Π (w : C) (h : C ⟦ y, w ⟧), f ;; h = ZeroArrow Z x w →
-                                          ∃! ψ : C ⟦ z, w ⟧, g ;; ψ = h)
-        (w : C) (h : y --> w) (H' : f ;; h = ZeroArrow Z x y ;; h) :
-    Π y0 : C ⟦ z, w ⟧, g ;; y0 = h → y0 = pr1 (iscontrpr1 (H2 w h (CokernelEqRw' H'))).
+        (H2 : Π (w : C) (h : C ⟦ y, w ⟧),
+              f ;; h = ZeroArrow Z x w → ∃! ψ : C ⟦ z, w ⟧, g ;; ψ = h)
+        (w : C) (h : y --> w) (H' : f ;; h = ZeroArrow Z x w) :
+    Π y0 : C ⟦ z, w ⟧, g ;; y0 = h → y0 = pr1 (iscontrpr1 (H2 w h H')).
   Proof.
-    intros y0 H. apply (base_paths _ _ ((pr2 (H2 w h (CokernelEqRw' H'))) (tpair _ y0 H))).
+    intros y0 H. apply (base_paths _ _ ((pr2 (H2 w h H')) (tpair _ y0 H))).
   Qed.
 
   Definition mk_isCokernel {x y z : C} (f : x --> y) (g : y --> z) (H1 : f ;; g = ZeroArrow Z x z)
              (H2 : Π (w : C) (h : y --> w) (H' : f ;; h = ZeroArrow Z x w),
-                   iscontr (Σ ψ : z --> w, g ;; ψ = h)) : isCokernel g f H1.
+                   iscontr (Σ ψ : z --> w, g ;; ψ = h)) : isCokernel f g H1.
   Proof.
-    use mk_isCoequalizer.
+    unfold isCokernel.
     intros w h H'.
     use unique_exists.
-    - exact (pr1 (iscontrpr1 (H2 w h (CokernelEqRw' H')))).
-    - exact (pr2 (iscontrpr1 (H2 w h (CokernelEqRw' H')))).
+    - exact (pr1 (iscontrpr1 (H2 w h H'))).
+    - exact (pr2 (iscontrpr1 (H2 w h H'))).
     - intros y0. apply hs.
-    - exact (mk_isCokernel_uniqueness f g H1 H2 w h H').
+    - intros y0 X. exact (base_paths _ _ ((pr2 (H2 w h H')) (tpair _ y0 X))).
   Defined.
 
-  Definition Cokernel {y z : C} (g : y --> z) :
-    UU := Coequalizer g (ZeroArrow Z y z).
+  Definition Cokernel {x y : C} (f : x --> y) : UU :=
+    Σ D : (Σ z : ob C, y --> z),
+          Σ (e : f ;; (pr2 D) = ZeroArrow Z x (pr1 D)), isCokernel f (pr2 D) e.
 
-  Definition mk_Cokernel {x y z : C} (f : y --> z) (g : x --> y)
-             (H : g ;; f = (ZeroArrow Z x z))
-             (isE : isCoequalizer g (ZeroArrow Z x y) f (CokernelEqRw H))
-    : Cokernel g.
-  Proof.
-    use (mk_Coequalizer g (ZeroArrow Z x y) f (CokernelEqRw H)).
-    apply isE.
-  Defined.
+  Definition mk_Cokernel {x y z : C} (f : x --> y) (g : y --> z) (H : f ;; g = (ZeroArrow Z x z))
+             (isCK : isCokernel f g H) : Cokernel f := ((z,,g),,(H,,isCK)).
 
-  Definition mk_Cokernel' {x y z : C} (f : x --> y) (g : y --> z) (H : f ;; g = (ZeroArrow Z x z))
-             (isE : isCokernel g f H) : Cokernel f :=
-    mk_Coequalizer f (ZeroArrow Z x y) g (CokernelEqRw H) isE.
+  Definition Cokernels : UU := Π (x y : C) (f : x --> y), Cokernel f.
 
-  Definition Cokernels : UU := Π (y z : C) (g : y --> z), Cokernel g.
-  Definition hasCokernels : UU := Π (y z : C) (g : y --> z), ishinh (Cokernel g).
-  Definition CokernelOb {y z : C} {g : y --> z} (CK : Cokernel g) :
-    C := CoequalizerObject CK.
+  Definition hasCokernels : UU := Π (x y : C) (f : x --> y), ishinh (Cokernel f).
+
+  Definition CokernelOb {x y : C} {f : x --> y} (CK : Cokernel f) : ob C := pr1 (pr1 CK).
   Coercion CokernelOb : Cokernel >-> ob.
-  Definition CokernelArrow {y z : C} {g : y --> z} (CK : Cokernel g) :
-    C⟦z, CK⟧ := CoequalizerArrow CK.
-  Definition CokernelEqAr {y z : C} {g : y --> z} (CK : Cokernel g) :=
-    CoequalizerEqAr CK.
-  Definition CokernelOut {y z : C} {g : y --> z} (CK : Cokernel g)
-             (w : C) (h : z --> w) (H : g ;; h = ZeroArrow Z y w) :
-    C⟦CK, w⟧ := CoequalizerOut CK _ h (CokernelEqRw H).
 
-  (** Commutativity of Cokernels. *)
-  Lemma CokernelCommutes {y z : C} {g : y --> z} (CK : Cokernel g)
-        (w : C) (h : z --> w) (H : g ;; h = ZeroArrow Z y w) :
-    (CokernelArrow CK) ;; (CokernelOut CK w h H) = h.
-  Proof.
-    apply (CoequalizerCommutes CK).
-  Defined.
+  Definition CokernelArrow {x y : C} {f : x --> y} (CK : Cokernel f) : C⟦y, CK⟧ := pr2 (pr1 CK).
 
-  Lemma CokernelisCokernel {y z : C} {g : y --> z} (CK : Cokernel g) :
-    isCokernel (CokernelArrow CK) g (CokernelEqRw' (CokernelEqAr CK)).
+  Definition CokernelCompZero {x y : C} {f : x --> y} (CK : Cokernel f) :
+    f ;; (CokernelArrow CK) = (ZeroArrow Z x CK) := pr1 (pr2 CK).
+
+  Definition CokernelisCokernel {y z : C} {g : y --> z} (CK : Cokernel g) := pr2 (pr2 CK).
+
+  Definition CokernelOut {y z : C} {g : y --> z} (CK : Cokernel g) (w : C) (h : z --> w)
+             (H : g ;; h = ZeroArrow Z y w) : C⟦CK, w⟧ :=
+    pr1 (iscontrpr1 (CokernelisCokernel CK w h H)).
+
+  Definition CokernelCommutes {y z : C} {g : y --> z} (CK : Cokernel g) (w : C) (h : z --> w)
+        (H : g ;; h = ZeroArrow Z y w) : (CokernelArrow CK) ;; (CokernelOut CK w h H) = h
+    := pr2 (iscontrpr1 (CokernelisCokernel CK w h H)).
+
+  Local Lemma CokernelOutUnique {x y z : C} {f : x --> y} {g : y --> z} {H : f ;; g = ZeroArrow Z x z}
+        (isCK : isCokernel f g H) {w : C} {h : y --> w} (H' : f ;; h = ZeroArrow Z x w) {φ : z --> w}
+        (H'' : g ;; φ = h) :
+    φ = (pr1 (pr1 (isCK w h H'))).
   Proof.
-    apply isCoequalizer_Coequalizer.
+    exact (base_paths _ _ (pr2 (isCK w h H') (tpair _ φ H''))).
   Qed.
 
-  (** Two arrows from Cokernel, such that the compositions with CokernelArrow
-    are equal, are equal. *)
-  Lemma CokernelOutsEq {y z: C} {g : y --> z} (CK : Cokernel g)
-        {w : C} (φ1 φ2: C⟦CK, w⟧)
+  Lemma CokernelOutsEq {x y : C} {f : x --> y} (CK : Cokernel f) {w : C} (φ1 φ2 : C⟦CK, w⟧)
         (H' : (CokernelArrow CK) ;; φ1 = (CokernelArrow CK) ;; φ2) : φ1 = φ2.
   Proof.
-    apply (isCoequalizerOutsEq (isCoequalizer_Coequalizer CK) _ _ H').
-  Defined.
+    assert (H1 : f ;; ((CokernelArrow CK) ;; φ1) = ZeroArrow Z _ _).
+    {
+      rewrite assoc. rewrite CokernelCompZero. apply ZeroArrow_comp_left.
+    }
+    rewrite (CokernelOutUnique (CokernelisCokernel CK) H1 (idpath _)).
+    apply pathsinv0.
+    set (tmp := pr2 (CokernelisCokernel CK w (CokernelArrow CK ;; φ1) H1) (tpair _ φ2 (! H'))).
+    exact (base_paths _ _ tmp).
+  Qed.
 
-  Lemma CokernelOutComp {y z : C} {f : y --> z} (K : Cokernel f) {w w' : C}
-        (h1 : z --> w) (h2 : w --> w')
-        (H1 : f ;; (h1 ;; h2) = ZeroArrow Z _ _) (H2 : f ;; h1 = ZeroArrow Z _ _) :
+  Lemma CokernelOutComp {y z : C} {f : y --> z} (K : Cokernel f) {w w' : C} (h1 : z --> w)
+        (h2 : w --> w') (H1 : f ;; (h1 ;; h2) = ZeroArrow Z _ _) (H2 : f ;; h1 = ZeroArrow Z _ _) :
     CokernelOut K w' (h1 ;; h2) H1 = CokernelOut K w h1 H2 ;; h2.
   Proof.
-    apply CoequalizerOutComp.
+    use CokernelOutsEq. rewrite CokernelCommutes. rewrite assoc. rewrite CokernelCommutes.
+    apply idpath.
   Qed.
 
   (** Results on morphisms between Cokernels. *)
-  Definition identity_is_CokernelOut {y z : C} {g : y --> z}
-             (CK : Cokernel g) :
+  Definition identity_is_CokernelOut {x y : C} {f : x --> y} (CK : Cokernel f) :
     Σ φ : C⟦CK, CK⟧, (CokernelArrow CK) ;; φ = (CokernelArrow CK).
   Proof.
     exists (identity CK).
     apply id_right.
   Defined.
 
-  Lemma CokernelEndo_is_identity {y z : C} {g : y --> z} {CK : Cokernel g}
-        (φ : C⟦CK, CK⟧) (H : (CokernelArrow CK) ;; φ = CokernelArrow CK) :
-    identity CK = φ.
+  Lemma CokernelEndo_is_identity {x y : C} {f : x --> y} {CK : Cokernel f} (φ : C⟦CK, CK⟧)
+        (H : (CokernelArrow CK) ;; φ = CokernelArrow CK) : identity CK = φ.
   Proof.
     set (H1 := tpair ((fun φ' : C⟦CK, CK⟧ => _ ;; φ' = _)) φ H).
     assert (H2 : identity_is_CokernelOut CK = H1).
     - apply proofirrelevance.
       apply isapropifcontr.
-      apply (isCoequalizer_Coequalizer CK).
-      apply CokernelEqAr.
+      apply (CokernelisCokernel CK).
+      apply CokernelCompZero.
     - apply (base_paths _ _ H2).
-  Defined.
+  Qed.
 
-  Definition from_Cokernel_to_Cokernel {y z : C} {g : y --> z}
-             (CK CK': Cokernel g) : C⟦CK, CK'⟧.
+  Definition from_Cokernel_to_Cokernel {x y : C} {f : x --> y} (CK CK': Cokernel f) : C⟦CK, CK'⟧.
   Proof.
-    apply (CokernelOut CK CK' (CokernelArrow CK')).
-    pathvia (ZeroArrow Z y z ;; CokernelArrow CK').
-    apply CokernelEqAr.
-    apply ZeroArrow_comp_left.
+    use (CokernelOut CK CK' (CokernelArrow CK')).
+    use CokernelCompZero.
   Defined.
 
-  Lemma are_inverses_from_Cokernel_to_Cokernel {y z : C} {g : y --> z}
-        {CK CK': Cokernel g} :
+  Lemma are_inverses_from_Cokernel_to_Cokernel {y z : C} {g : y --> z} {CK CK': Cokernel g} :
     is_inverse_in_precat (from_Cokernel_to_Cokernel CK CK')
                          (from_Cokernel_to_Cokernel CK' CK).
   Proof.
-    split; apply pathsinv0; use CokernelEndo_is_identity;
-    unfold from_Cokernel_to_Cokernel; rewrite assoc.
-    rewrite (CokernelCommutes CK CK').
-    rewrite (CokernelCommutes CK' CK).
-    apply idpath.
+    split.
+    - unfold from_Cokernel_to_Cokernel. apply pathsinv0. use CokernelEndo_is_identity.
+      rewrite assoc. rewrite CokernelCommutes. rewrite CokernelCommutes. apply idpath.
+    - unfold from_Cokernel_to_Cokernel. apply pathsinv0. use CokernelEndo_is_identity.
+      rewrite assoc. rewrite CokernelCommutes. rewrite CokernelCommutes. apply idpath.
+  Qed.
 
-    rewrite (CokernelCommutes CK' CK).
-    rewrite (CokernelCommutes CK CK').
-    apply idpath.
-  Defined.
-
-  Lemma isiso_from_Cokernel_to_Cokernel {y z : C} {g : y --> z}
-        (CK CK' : Cokernel g) :
-    is_isomorphism (from_Cokernel_to_Cokernel CK CK').
+  Lemma is_iso_from_Cokernel_to_Cokernel {y z : C} {g : y --> z} (CK CK' : Cokernel g) :
+    is_iso (from_Cokernel_to_Cokernel CK CK').
   Proof.
     apply (is_iso_qinv _ (from_Cokernel_to_Cokernel CK' CK)).
     apply are_inverses_from_Cokernel_to_Cokernel.
-  Defined.
+  Qed.
 
-  Definition iso_from_Cokernel_to_Cokernel {y z : C} {g : y --> z}
-             (CK CK' : Cokernel g) : iso CK CK' :=
-    tpair _ _ (isiso_from_Cokernel_to_Cokernel CK CK').
-
-
-  (** Composing with the CokernelArrow gives the zero arrow. *)
-  Lemma CokernelCompZero {y z : C} {g : y --> z} (CK : Cokernel g ) :
-    g ;; CokernelArrow CK = ZeroArrow Z y CK.
-  Proof.
-    unfold CokernelArrow. use (pathscomp0 (CoequalizerEqAr CK)).
-    apply ZeroArrow_comp_left.
-  Defined.
+  Definition iso_from_Cokernel_to_Cokernel {y z : C} {g : y --> z} (CK CK' : Cokernel g) :
+    iso CK CK' := isopair _ (is_iso_from_Cokernel_to_Cokernel CK CK').
 
   (** Cokernel of the ZeroArrow is given by the identity. *)
-  Lemma CokernelofZeroArrow (x y : C) : Cokernel (ZeroArrow Z x y).
+  Lemma CokernelOfZeroArrow_isCokernel (x y : C) :
+    isCokernel (ZeroArrow Z x y) (identity y) (id_right (ZeroArrow Z x y)).
   Proof.
-    use mk_Cokernel.
-    apply y. apply (identity y).
-    apply id_right.
-
-    use mk_isCoequalizer.
-    intros w h H.
-
+    use mk_isCokernel.
+    intros w h H'.
     use unique_exists.
-    apply h. cbn. apply id_left.
-    intros y0. apply hs.
-    cbn. intros y0 t. rewrite <- t.
-    apply pathsinv0. apply id_left.
-  Defined.
+    - exact h.
+    - exact (id_left _).
+    - intros y0. apply hs.
+    - intros y0 t. cbn in t. rewrite id_left in t. exact t.
+  Qed.
+
+  Definition CokernelofZeroArrow (x y : C) : Cokernel (ZeroArrow Z x y) :=
+    mk_Cokernel (ZeroArrow Z x y) (identity y) (id_right _) (CokernelOfZeroArrow_isCokernel x y).
 
   (** More generally, the CokernelArrow of the cokernel of the ZeroArrow is an
     isomorphism. *)
-  Lemma CokernelofZeroArrow_iso (x y : C) (CK : Cokernel (ZeroArrow Z x y)) :
-    iso y CK.
+  Lemma CokernelofZeroArrow_is_iso {x y : C} (CK : Cokernel (ZeroArrow Z x y)) :
+    is_iso (CokernelArrow CK).
+  Proof.
+    set (CK' := CokernelofZeroArrow x y).
+    use is_iso_qinv.
+    - use (from_Cokernel_to_Cokernel CK CK').
+    - split.
+      + unfold from_Cokernel_to_Cokernel. rewrite CokernelCommutes. apply idpath.
+      + unfold from_Cokernel_to_Cokernel. cbn.
+        use CokernelOutsEq. rewrite assoc. rewrite CokernelCommutes.
+        rewrite id_left. rewrite id_right. apply idpath.
+  Qed.
+
+  Lemma CokernelofZeroArrow_iso (x y : C) (CK : Cokernel (ZeroArrow Z x y)) : iso y CK.
   Proof.
     exact (iso_from_Cokernel_to_Cokernel (CokernelofZeroArrow x y) CK).
   Defined.
 
   (** It follows that CokernelArrow is an epi. *)
-  Lemma CokernelArrowisEpi {y z : C} {g : y --> z} (CK : Cokernel g ) :
-    isEpi (CokernelArrow CK).
+  Lemma CokernelArrowisEpi {y z : C} {g : y --> z} (CK : Cokernel g ) : isEpi (CokernelArrow CK).
   Proof.
-    simple refine (CoequalizerArrowisEpi _).
-  Defined.
+    unfold isEpi.
+    intros z0 g0 h X.
+    use CokernelOutsEq.
+    exact X.
+  Qed.
 
   Lemma CokernelsOut_is_iso {x y : C} {f : x --> y} (CK1 CK2 : Cokernel f) :
     is_iso (CokernelOut CK1 CK2 (CokernelArrow CK2) (CokernelCompZero CK2)).
@@ -244,7 +223,84 @@ Section def_cokernels.
   Qed.
 
 End def_cokernels.
-Arguments CokernelArrow [C] [Z] [y] [z] [g] _.
+Arguments CokernelArrow [C] [Z] [x] [y] [f] _.
+
+
+(** * Correspondence between cokernels and coequalizers *)
+Section cokernels_coequalizers.
+
+  Context {C : precategory}.
+  Hypothesis hs : has_homsets C.
+  Hypothesis Z : Zero C.
+
+
+  (** ** [Coequalizer] from [Cokernel] *)
+  Lemma CokernelCoequalizer_eq {x y : ob C} {f : x --> y} (CK : Cokernel Z f) :
+    f ;; CokernelArrow CK = ZeroArrow Z x y ;; CokernelArrow CK.
+  Proof.
+    rewrite ZeroArrow_comp_left. use CokernelCompZero.
+  Qed.
+
+  Lemma CokernelCoequalizer_isCokernel {x y : ob C} {f : x --> y} (CK : Cokernel Z f) :
+    isCoequalizer f (ZeroArrow Z x y) (CokernelArrow CK) (CokernelCoequalizer_eq CK).
+  Proof.
+    use mk_isCoequalizer.
+    intros w0 h H'.
+    use unique_exists.
+    - use CokernelOut.
+      + exact h.
+      + rewrite H'. apply ZeroArrow_comp_left.
+    - use CokernelCommutes.
+    - intros y0. apply hs.
+    - intros y0 X. use CokernelOutsEq. rewrite CokernelCommutes. exact X.
+  Qed.
+
+  Definition CokernelCoequalizer {x y : ob C} {f : x --> y} (CK : Cokernel Z f) :
+    Coequalizer f (ZeroArrow Z _ _).
+  Proof.
+    use mk_Coequalizer.
+    - exact CK.
+    - exact (CokernelArrow CK).
+    - exact (CokernelCoequalizer_eq CK).
+    - exact (CokernelCoequalizer_isCokernel CK).
+  Defined.
+
+
+  (** ** [Cokernel] from [Coequalizer] *)
+
+  Lemma CoequalizerCokernel_eq {x y : ob C} {f : x --> y} (CE : Coequalizer f (ZeroArrow Z _ _)) :
+    f ;; CoequalizerArrow CE = ZeroArrow Z x CE.
+  Proof.
+    rewrite <- (ZeroArrow_comp_left _ _ _ _ _ (CoequalizerArrow CE)).
+    exact (CoequalizerEqAr CE).
+  Qed.
+
+  Lemma CoequalizerCokernel_isCokernel {x y : ob C} {f : x --> y}
+        (CE : Coequalizer f (ZeroArrow Z _ _)) :
+    isCokernel Z f (CoequalizerArrow CE) (CoequalizerCokernel_eq CE).
+  Proof.
+    use (mk_isCokernel hs).
+    intros w h H'.
+    use unique_exists.
+    - use CoequalizerOut.
+      + exact h.
+      + rewrite ZeroArrow_comp_left. exact H'.
+    - use CoequalizerCommutes.
+    - intros y0. apply hs.
+    - intros y0 X. use CoequalizerOutsEq. rewrite CoequalizerCommutes. exact X.
+  Qed.
+
+  Definition CoequalizerCokernel {x y : ob C} {f : x --> y} (CE : Coequalizer f (ZeroArrow Z _ _)) :
+    Cokernel Z f.
+  Proof.
+    use mk_Cokernel.
+    - exact CE.
+    - exact (CoequalizerArrow CE).
+    - exact (CoequalizerCokernel_eq CE).
+    - exact (CoequalizerCokernel_isCokernel CE).
+  Defined.
+
+End cokernels_coequalizers.
 
 (** In the following section we construct a new cokernel from an arrow which is
   equal to cokernelarrow of some cokernel, up to postcomposing with an
@@ -270,87 +326,62 @@ Section cokernels_iso.
     apply CokernelCompZero.
   Qed.
 
-  Definition Cokernel_up_to_iso_isCoequalizer {x y z : C} (f : x --> y)
-             (g : y --> z)
-             (CK : Cokernel Z f) (h : iso CK z)
-             (H : g = (CokernelArrow CK) ;; h) :
-    isCoequalizer f (ZeroArrow Z x y) g
-                  (CokernelEqRw Z (Cokernel_up_to_iso_eq f g CK h H)).
+  Definition Cokernel_up_to_iso_isCoequalizer {x y z : C} (f : x --> y) (g : y --> z)
+             (CK : Cokernel Z f) (h : iso CK z) (H : g = (CokernelArrow CK) ;; h) :
+    isCokernel Z f g (Cokernel_up_to_iso_eq f g CK h H).
   Proof.
-    apply mk_isCoequalizer.
-    induction CK as [t p]. induction t as [t' p']. induction p as [t'' p''].
-    unfold isCoequalizer in p''.
-    intros w h0 HH.
-    set (tmp := p'' w h0 HH). cbn in tmp. cbn in h.
-    induction tmp as [t''' p'''].
-    induction t''' as [t'''' p''''].
-
+    use (mk_isCokernel hs).
+    intros w h0 H'.
     use unique_exists.
-    exact ((inv_from_iso h) ;; t'''').
-    cbn. rewrite <- p''''.
-    rewrite assoc. apply cancel_postcomposition.
-    cbn in H. rewrite H. rewrite <- assoc.
-    rewrite <- id_right. apply cancel_precomposition.
-    apply iso_inv_after_iso.
-
-    intros y0. apply hs.
-    intros y0 X. cbn in X. cbn in H.
-    rewrite H in X.
-    rewrite <- assoc in X.
-    set (tmp := p''' (tpair _ (h ;; y0) X)).
-    apply base_paths in tmp. cbn in tmp.
-    rewrite <- tmp. rewrite assoc.
-    rewrite iso_after_iso_inv.
-    apply pathsinv0. apply id_left.
+    - exact ((inv_from_iso h) ;; (CokernelOut Z CK w h0 H')).
+    - cbn. rewrite H. rewrite assoc. rewrite <- (assoc _ h). rewrite iso_inv_after_iso.
+      rewrite id_right. use CokernelCommutes.
+    - intros y0. apply hs.
+    - intros y0 X. cbn beta in X.
+      use (pre_comp_with_iso_is_inj _ _ _ _ _ (pr2 h)). rewrite assoc.
+      set (tmp := maponpaths (fun gg : _ => gg ;; CokernelOut Z CK w h0 H')
+                             (iso_inv_after_iso h)). cbn in tmp.
+      use (pathscomp0 _ (! tmp)). clear tmp. rewrite id_left.
+      use CokernelOutsEq. rewrite CokernelCommutes. rewrite assoc.
+      rewrite <- X. apply cancel_postcomposition. rewrite H.
+      apply cancel_precomposition. apply idpath.
   Qed.
 
-  Definition Cokernel_up_to_iso {x y z : C} (f : x --> y) (g : y --> z)
-             (CK : Cokernel Z f) (h : iso CK z)
-             (H : g = (CokernelArrow CK) ;; h) :
-    Cokernel Z f
-    := (mk_Cokernel Z g _ (Cokernel_up_to_iso_eq f g CK h H)
-                    (Cokernel_up_to_iso_isCoequalizer f g CK h H)).
+  Definition Cokernel_up_to_iso {x y z : C} (f : x --> y) (g : y --> z) (CK : Cokernel Z f)
+             (h : iso CK z) (H : g = (CokernelArrow CK) ;; h) : Cokernel Z f :=
+    mk_Cokernel Z f g (Cokernel_up_to_iso_eq f g CK h H)
+                (Cokernel_up_to_iso_isCoequalizer f g CK h H).
 
-  Definition Cokernel_up_to_iso2_eq {x y z : C} (f1 : x --> z) (f2 : y --> z)
-             (h : iso y x) (H : h ;; f1 = f2)
-             (CK : Cokernel Z f1) :
-    f2 ;; CokernelArrow CK = ZeroArrow Z y CK.
+  Definition Cokernel_up_to_iso2_eq {x y z : C} (f1 : x --> z) (f2 : y --> z) (h : iso y x)
+             (H : h ;; f1 = f2) (CK : Cokernel Z f1) : f2 ;; CokernelArrow CK = ZeroArrow Z y CK.
   Proof.
     rewrite <- H. rewrite <- assoc. rewrite CokernelCompZero.
     apply ZeroArrow_comp_right.
   Qed.
 
-  Definition Cokernel_up_to_iso2_isCoequalizer {x y z : C} (f1 : x --> z)
-             (f2 : y --> z)
-             (h : iso y x) (H : h ;; f1 = f2)
-             (CK : Cokernel Z f1) :
-    isCoequalizer f2 (ZeroArrow Z y z) (CokernelArrow CK)
-                  (CokernelEqRw Z (Cokernel_up_to_iso2_eq f1 f2 h H CK)).
+  Definition Cokernel_up_to_iso2_isCoequalizer {x y z : C} (f1 : x --> z) (f2 : y --> z)
+             (h : iso y x) (H : h ;; f1 = f2) (CK : Cokernel Z f1) :
+    isCokernel Z f2 (CokernelArrow CK) (Cokernel_up_to_iso2_eq f1 f2 h H CK).
   Proof.
-    use mk_isCoequalizer.
+    use (mk_isCokernel hs).
     intros w h0 H'.
-    rewrite <- H in H'. rewrite <- assoc in H'.
-    rewrite ZeroArrow_comp_left in H'.
-    rewrite <- (ZeroArrow_comp_right C Z _ _ _ h) in H'.
-    apply (maponpaths (fun f : _ => (inv_from_iso h) ;; f)) in H'.
-    repeat rewrite assoc in H'.
-    repeat rewrite iso_after_iso_inv in H'.
-    repeat rewrite id_left in H'.
-    apply (unique_exists (CokernelOut Z CK _ _ H')).
-    apply (CokernelCommutes Z CK _ _ H').
-    intros y0. apply hs.
-    intros y0 H''. apply CokernelOutsEq.
-    rewrite H''. apply pathsinv0.
-    apply CokernelCommutes.
+    use unique_exists.
+    - use CokernelOut.
+      + exact h0.
+      + rewrite <- H in H'. rewrite <- (ZeroArrow_comp_right _ _ _ _ _ h) in H'.
+        rewrite <- assoc in H'. apply pre_comp_with_iso_is_inj in H'.
+        * exact H'.
+        * exact (pr2 h).
+    - cbn. use CokernelCommutes.
+    - intros y0. apply hs.
+    - intros y0 X. cbn beta in X. use CokernelOutsEq. rewrite CokernelCommutes.
+      exact X.
   Qed.
 
-  Definition Cokernel_up_to_iso2 {x y z : C} (f1 : x --> z) (f2 : y --> z)
-             (h : iso y x) (H : h ;; f1 = f2)
-             (CK : Cokernel Z f1) :
-    Cokernel Z f2
-    := (mk_Cokernel Z (CokernelArrow CK) _
-                    (Cokernel_up_to_iso2_eq f1 f2 h H CK)
-                    (Cokernel_up_to_iso2_isCoequalizer f1 f2 h H CK)).
+  Definition Cokernel_up_to_iso2 {x y z : C} (f1 : x --> z) (f2 : y --> z) (h : iso y x)
+             (H : h ;; f1 = f2) (CK : Cokernel Z f1) : Cokernel Z f2 :=
+    mk_Cokernel Z f2 (CokernelArrow CK) (Cokernel_up_to_iso2_eq f1 f2 h H CK)
+                (Cokernel_up_to_iso2_isCoequalizer f1 f2 h H CK).
 
 End cokernels_iso.
 
@@ -426,12 +457,11 @@ Section cokernels_epis.
         (CK : Cokernel Z (E ;; f)) : f ;; CokernelArrow CK = ZeroArrow Z y CK.
   Proof.
     use (EpiisEpi C E). rewrite ZeroArrow_comp_right. rewrite assoc.
-    exact (CokernelEqRw' Z (CokernelEqAr Z CK)).
+    use CokernelCompZero.
   Qed.
 
   Local Lemma CokernelEpiComp_isCoequalizer {x y z : C} (E : Epi C x y) (f : y --> z)
-        (CK : Cokernel Z (E ;; f)) :
-    isCokernel Z (CokernelArrow CK) f (CokernelEpiComp_eq E f CK).
+        (CK : Cokernel Z (E ;; f)) : isCokernel Z f (CokernelArrow CK) (CokernelEpiComp_eq E f CK).
   Proof.
     use mk_isCokernel.
     - exact hs.
@@ -452,7 +482,7 @@ Section cokernels_epis.
   Definition CokernelEpiComp {x y z : C} (E : Epi C x y) (f : y --> z) (CK : Cokernel Z (E ;; f)) :
     Cokernel Z f.
   Proof.
-    use mk_Cokernel'.
+    use mk_Cokernel.
     - exact CK.
     - use CokernelArrow.
     - exact (CokernelEpiComp_eq E f CK).
@@ -491,7 +521,7 @@ Section cokernel_out_paths.
   Qed.
 
   Local Lemma CokernelPath_isCokernel {x y : C} {f f' : x --> y} (e : f = f') (CK : Cokernel Z f) :
-    isCokernel Z (CokernelArrow CK) f' (CokernelPath_eq e CK).
+    isCokernel Z f' (CokernelArrow CK) (CokernelPath_eq e CK).
   Proof.
     induction e. use CokernelisCokernel.
   Qed.
@@ -500,7 +530,7 @@ Section cokernel_out_paths.
   Definition CokernelPath {x y : C} {f f' : x --> y} (e : f = f') (CK : Cokernel Z f) :
     Cokernel Z f'.
   Proof.
-    use mk_Cokernel'.
+    use mk_Cokernel.
     - exact CK.
     - use CokernelArrow.
     - exact (CokernelPath_eq e CK).

--- a/UniMath/CategoryTheory/limits/cokernels.v
+++ b/UniMath/CategoryTheory/limits/cokernels.v
@@ -1,12 +1,12 @@
-(**
+(** * Direct definition of cokernels *)
+(** ** Contents
+- Definition of cokernel
+- Correspondence of cokernels and coequalizers
+- Cokernel up to iso
+- Cokernel of [Epi] ;; morphism
+- CokernelOut of equal morphisms
+ *)
 
-Direct implementation of cokernels together with:
-
-- Proof that the cokernel arrow is epi ([CokernelArrowisEpi])
-
-Written by Tomi Pannila.
-
-*)
 Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.Foundations.Basics.Propositions.
 Require Import UniMath.Foundations.Basics.Sets.
@@ -17,7 +17,8 @@ Require Import UniMath.CategoryTheory.Epis.
 Require Import UniMath.CategoryTheory.limits.coequalizers.
 Require Import UniMath.CategoryTheory.limits.zero.
 
-(** In this section we define cokernels and show that cokernel arrow is an epi. *)
+
+(** * Definition of cokernels *)
 Section def_cokernels.
 
   Context {C : precategory}.
@@ -226,7 +227,7 @@ End def_cokernels.
 Arguments CokernelArrow [C] [Z] [x] [y] [f] _.
 
 
-(** * Correspondence between cokernels and coequalizers *)
+(** * Correspondence of cokernels and coequalizers *)
 Section cokernels_coequalizers.
 
   Context {C : precategory}.
@@ -302,9 +303,8 @@ Section cokernels_coequalizers.
 
 End cokernels_coequalizers.
 
-(** In the following section we construct a new cokernel from an arrow which is
-  equal to cokernelarrow of some cokernel, up to postcomposing with an
-  isomorphism *)
+
+(** * Cokernels up to iso*)
 Section cokernels_iso.
 
   Variable C : precategory.

--- a/UniMath/CategoryTheory/limits/equalizers.v
+++ b/UniMath/CategoryTheory/limits/equalizers.v
@@ -41,6 +41,19 @@ Section def_equalizers.
     apply isapropiscontr.
   Defined.
 
+  Lemma isEqualizer_path {hs : has_homsets C} {x y z : C} {f g : y --> z} {e : x --> y}
+        {H H' : e ;; f = e ;; g} (iC : isEqualizer f g e H) :
+    isEqualizer f g e H'.
+  Proof.
+    use mk_isEqualizer.
+    intros w0 h H'0.
+    use unique_exists.
+    - exact (pr1 (pr1 (iC w0 h H'0))).
+    - exact (pr2 (pr1 (iC w0 h H'0))).
+    - intros y0. apply hs.
+    - intros y0 X. exact (base_paths _ _ (pr2 (iC w0 h H'0) (tpair _ y0 X))).
+  Defined.
+
   (** Proves that the arrow to the equalizer object with the right
     commutativity property is unique. *)
   Lemma isEqualizerInUnique {x y z : C} (f g : y --> z) (e : x --> y)

--- a/UniMath/CategoryTheory/limits/graphs/cokernels.v
+++ b/UniMath/CategoryTheory/limits/graphs/cokernels.v
@@ -27,102 +27,83 @@ Section def_cokernels.
 
   (** ** Coincides with the direct definiton *)
   Lemma equiv_Cokernel1_eq {a b : C} (f : C⟦a, b⟧)
-        (K : limits.cokernels.Cokernel (equiv_Zero2 Z) f) :
-    f ;; limits.coequalizers.CoequalizerArrow K =
-    ZeroArrow Z a b ;; limits.coequalizers.CoequalizerArrow K.
+        (CK : limits.cokernels.Cokernel (equiv_Zero2 Z) f) :
+    f ;; (CokernelArrow CK) = ZeroArrow Z a b ;; (CokernelArrow CK).
   Proof.
-    set (tmp := limits.coequalizers.CoequalizerEqAr K).
-    set (tmp1 := equiv_ZeroArrow a b Z).
-    apply (maponpaths (fun h : _ => h ;; limits.coequalizers.CoequalizerArrow K)) in tmp1.
-    set (tmp2 := pathscomp0 tmp tmp1).
-    apply tmp2.
+    rewrite CokernelCompZero. rewrite postcomp_with_ZeroArrow. apply equiv_ZeroArrow.
   Qed.
 
   Lemma equiv_Cokernel1_isCoequalizer {a b : C} (f : C⟦a, b⟧)
-        (K : limits.cokernels.Cokernel (equiv_Zero2 Z) f) :
-    limits.coequalizers.isCoequalizer
-      f (ZeroArrow Z a b) (limits.coequalizers.CoequalizerArrow K) (equiv_Cokernel1_eq f K).
+        (CK : limits.cokernels.Cokernel (equiv_Zero2 Z) f) :
+    isCoequalizer C f (ZeroArrow Z a b) CK (CokernelArrow CK) (equiv_Cokernel1_eq f CK).
   Proof.
-    use limits.coequalizers.mk_isCoequalizer.
+    use (mk_isCoequalizer _ hs).
     intros w h H.
     use unique_exists.
     (* Construction of the morphism *)
-    - use limits.cokernels.CokernelOut.
+    - use CokernelOut.
       + exact h.
       + rewrite postcomp_with_ZeroArrow in H.
         use (pathscomp0 _ (!(equiv_ZeroArrow a w Z))).
         exact H.
     (* Commutativity *)
-    - use limits.cokernels.CokernelCommutes.
+    - use CokernelCommutes.
     (* Equality on equalities of morphisms *)
     - intros y. apply hs.
     (* Uniqueness *)
     - intros y T. cbn in T.
-      use limits.cokernels.CokernelOutsEq. unfold CokernelArrow.
+      use CokernelOutsEq. unfold CokernelArrow.
       use (pathscomp0 T). apply pathsinv0.
-      use limits.cokernels.CokernelCommutes.
+      use CokernelCommutes.
   Qed.
 
-  Definition equiv_Cokernel1 {a b : C} (f : C⟦a, b⟧) :
-    limits.cokernels.Cokernel (equiv_Zero2 Z) f -> Cokernel f.
+  Definition equiv_Cokernel1 {a b : C} (f : C⟦a, b⟧)
+             (CK : limits.cokernels.Cokernel (equiv_Zero2 Z) f) : Cokernel f.
   Proof.
-    intros K.
-    exact (equiv_Coequalizer1
-           C hs f _
-           (@limits.coequalizers.mk_Coequalizer
-              C a b K f _
-              (limits.coequalizers.CoequalizerArrow K)
-              (equiv_Cokernel1_eq f K)
-              (equiv_Cokernel1_isCoequalizer f K))).
+    use mk_Coequalizer.
+    - exact CK.
+    - exact (CokernelArrow CK).
+    - exact (equiv_Cokernel1_eq f CK).
+    - exact (equiv_Cokernel1_isCoequalizer f CK).
   Defined.
 
   (* Other direction *)
 
-  Lemma equiv_Cokernel2_eq {a b : C} (f : C⟦a, b⟧) (K : Cokernel f) :
-    f ;; CoequalizerArrow C K = limits.zero.ZeroArrow (equiv_Zero2 Z) a b ;; CoequalizerArrow C K.
+
+  Lemma equiv_Cokernel2_eq {a b : C} (f : C⟦a, b⟧) (CK : cokernels.Cokernel (equiv_Zero2 Z) f) :
+    f ;; CokernelArrow CK = ZeroArrow Z a b ;; CokernelArrow CK.
   Proof.
-    set (tmp := CoequalizerArrowEq C K).
-    set (tmp1 := equiv_ZeroArrow a b Z).
-    apply pathsinv0 in tmp1.
-    apply (maponpaths (fun h : _ => h ;; CoequalizerArrow C K)) in tmp1.
-    set (tmp2 := pathscomp0 tmp tmp1).
-    apply tmp2.
+    rewrite CokernelCompZero. rewrite postcomp_with_ZeroArrow. apply equiv_ZeroArrow.
   Qed.
 
-  Lemma equiv_Cokernel2_isCoequalizer {a b : C} (f : C⟦a, b⟧) (K : Cokernel f) :
-    isCoequalizer C f (limits.zero.ZeroArrow (equiv_Zero2 Z) a b)
-                  (CoequalizerObject C K) (CoequalizerArrow C K) (equiv_Cokernel2_eq f K).
+  Lemma equiv_Cokernel2_isCoequalizer {a b : C} (f : C⟦a, b⟧)
+        (CK : cokernels.Cokernel (equiv_Zero2 Z) f) :
+    isCoequalizer C f (ZeroArrow Z a b) CK (CokernelArrow CK) (equiv_Cokernel2_eq f CK).
   Proof.
-    use mk_isCoequalizer. apply hs.
+    use (mk_isCoequalizer _ hs).
     intros w h H.
     use unique_exists.
     (* Construction of the morphism *)
-    - use CoequalizerOut.
+    - use CokernelOut.
       + exact h.
-      + rewrite postcomp_with_ZeroArrow.
-        rewrite limits.zero.ZeroArrow_comp_left in H.
-        use (pathscomp0 H).
-        apply (equiv_ZeroArrow a w Z).
+      + use (pathscomp0 H). apply pathsinv0. rewrite postcomp_with_ZeroArrow. apply equiv_ZeroArrow.
     (* Commutativity *)
-    - use CoequalizerArrowComm.
+    - use CokernelCommutes.
     (* Equality on equalities of morphisms *)
     - intros y. apply hs.
     (* Uniqueness *)
-    - intros y T. cbn in T.
-      use CoequalizerOutUnique. exact T.
+    - intros y T. cbn in T. use CokernelOutsEq. rewrite T. rewrite CokernelCommutes.
+      apply idpath.
   Qed.
 
-  Definition equiv_Cokernel2 {a b : C} (f : C⟦a, b⟧) :
-    limits.cokernels.Cokernel (equiv_Zero2 Z) f <- Cokernel f.
+  Definition equiv_Cokernel2 {a b : C} (f : C⟦a, b⟧)
+             (CK : limits.cokernels.Cokernel (equiv_Zero2 Z) f) : Cokernel f.
   Proof.
-    intros K.
-    exact (equiv_Coequalizer2
-           C hs f _
-           (@mk_Coequalizer
-              C a b f _ (CoequalizerObject C K)
-              (CoequalizerArrow C K)
-              (equiv_Cokernel2_eq f K)
-              (equiv_Cokernel2_isCoequalizer f K))).
+    use mk_Coequalizer.
+    - exact CK.
+    - exact (CokernelArrow CK).
+    - exact (equiv_Cokernel2_eq f CK).
+    - exact (equiv_Cokernel2_isCoequalizer f CK).
   Defined.
 
 End def_cokernels.

--- a/UniMath/CategoryTheory/limits/graphs/kernels.v
+++ b/UniMath/CategoryTheory/limits/graphs/kernels.v
@@ -23,85 +23,71 @@ Section def_kernels.
   Variable hs: has_homsets C.
   Variable Z : Zero C.
 
-  Definition Kernel {a b : C} (f : C⟦a, b⟧)
-    := Equalizer C f (ZeroArrow Z a b).
+  Definition Kernel {a b : C} (f : C⟦a, b⟧) := Equalizer C f (ZeroArrow Z a b).
 
   (** ** Maps between Kernels as limits and direct definition. *)
   Lemma equiv_Kernel1_eq {a b : C} (f : C⟦a, b⟧) (K : limits.kernels.Kernel (equiv_Zero2 Z) f) :
-    limits.equalizers.EqualizerArrow K ;; f = limits.equalizers.EqualizerArrow K ;; ZeroArrow Z a b.
+    KernelArrow K ;; f = KernelArrow K ;; ZeroArrow Z a b.
   Proof.
-    set (tmp := limits.equalizers.EqualizerEqAr K).
-    set (tmp1 := equiv_ZeroArrow a b Z).
-    apply (maponpaths (fun h : _ => limits.equalizers.EqualizerArrow K ;; h)) in tmp1.
-    set (tmp2 := pathscomp0 tmp tmp1).
-    apply tmp2.
+    rewrite precomp_with_ZeroArrow. rewrite <- equiv_ZeroArrow. apply KernelCompZero.
   Qed.
 
   Lemma equiv_Kernel1_isEqualizer {a b : C} (f : C⟦a, b⟧)
         (K : limits.kernels.Kernel (equiv_Zero2 Z) f) :
-    limits.equalizers.isEqualizer
-      f (ZeroArrow Z a b) (limits.equalizers.EqualizerArrow K) (equiv_Kernel1_eq f K).
+    isEqualizer C f (ZeroArrow Z a b) K (KernelArrow K) (equiv_Kernel1_eq f K).
   Proof.
-    use limits.equalizers.mk_isEqualizer.
-    intros w h H.
+    use (mk_isEqualizer _ hs).
+    intros e h' H'.
     use unique_exists.
     (* Construction of the morphism *)
-    - use limits.kernels.KernelIn.
-      + exact h.
-      + rewrite precomp_with_ZeroArrow in H.
-        use (pathscomp0 _ (!(equiv_ZeroArrow w b Z))).
-        exact H.
+    - use KernelIn.
+      + exact h'.
+      + rewrite precomp_with_ZeroArrow in H'.
+        use (pathscomp0 _ (!(equiv_ZeroArrow e b Z))).
+        exact H'.
     (* Commutativity *)
-    - use limits.kernels.KernelCommutes.
+    - cbn. use KernelCommutes.
     (* Equality on equalities of morphisms *)
     - intros y. apply hs.
     (* Uniqueness *)
-    - intros y T. cbn in T.
+    - intros y X. cbn in X.
       use limits.kernels.KernelInsEq. unfold KernelArrow.
-      use (pathscomp0 T). apply pathsinv0.
+      use (pathscomp0 X). apply pathsinv0.
       use limits.kernels.KernelCommutes.
   Qed.
 
-  Definition equiv_Kernel1 {a b : C} (f : C⟦a, b⟧) :
-    limits.kernels.Kernel (equiv_Zero2 Z) f -> Kernel f.
+  Definition equiv_Kernel1 {a b : C} (f : C⟦a, b⟧) (K : limits.kernels.Kernel (equiv_Zero2 Z) f) :
+    Kernel f.
   Proof.
-    intros K.
-    exact (equiv_Equalizer1
-           C hs f _
-           (@limits.equalizers.mk_Equalizer
-              C K a b f _
-              (limits.equalizers.EqualizerArrow K)
-              (equiv_Kernel1_eq f K)
-              (equiv_Kernel1_isEqualizer f K))).
+    use mk_Equalizer.
+    - exact K.
+    - exact (KernelArrow K).
+    - exact (equiv_Kernel1_eq f K).
+    - exact (equiv_Kernel1_isEqualizer f K).
   Defined.
 
   (* Other direction *)
 
   Lemma equiv_Kernel2_eq {a b : C} (f : C⟦a, b⟧) (K : Kernel f) :
-    EqualizerArrow C K ;; f = EqualizerArrow C K ;; limits.zero.ZeroArrow (equiv_Zero2 Z) a b.
+    EqualizerArrow C K ;; f = limits.zero.ZeroArrow (equiv_Zero2 Z) (EqualizerObject C K) b.
   Proof.
-    set (tmp := EqualizerArrowEq C K).
-    set (tmp1 := equiv_ZeroArrow a b Z).
-    apply pathsinv0 in tmp1.
-    apply (maponpaths (fun h : _ => EqualizerArrow C K ;; h)) in tmp1.
-    set (tmp2 := pathscomp0 tmp tmp1).
-    apply tmp2.
+    rewrite (EqualizerArrowEq C K). rewrite equiv_ZeroArrow.
+    rewrite precomp_with_ZeroArrow. apply idpath.
   Qed.
 
+
   Lemma equiv_Kernel2_isEqualizer {a b : C} (f : C⟦a, b⟧) (K : Kernel f) :
-    isEqualizer C f (limits.zero.ZeroArrow (equiv_Zero2 Z) a b)
-                (EqualizerObject C K) (EqualizerArrow C K) (equiv_Kernel2_eq f K).
+    isKernel (equiv_Zero2 Z) (EqualizerArrow C K) f (equiv_Kernel2_eq f K).
   Proof.
-    use mk_isEqualizer. apply hs.
+    use (mk_isKernel hs).
     intros w h H.
     use unique_exists.
     (* Construction of the morphism *)
     - use EqualizerIn.
       + exact h.
-      + rewrite precomp_with_ZeroArrow.
-        rewrite limits.zero.ZeroArrow_comp_right in H.
-        use (pathscomp0 H).
-        apply (equiv_ZeroArrow w b Z).
+      + rewrite H.
+        rewrite precomp_with_ZeroArrow.
+        apply equiv_ZeroArrow.
     (* Commutativity *)
     - use EqualizerArrowComm.
     (* Equality on equalities of morphisms *)
@@ -111,17 +97,14 @@ Section def_kernels.
       use EqualizerInUnique. exact T.
   Qed.
 
-  Definition equiv_Kernel2 {a b : C} (f : C⟦a, b⟧) :
-    limits.kernels.Kernel (equiv_Zero2 Z) f <- Kernel f.
+  Definition equiv_Kernel2 {a b : C} (f : C⟦a, b⟧) (K : Kernel f) :
+    limits.kernels.Kernel (equiv_Zero2 Z) f.
   Proof.
-    intros K.
-    exact (equiv_Equalizer2
-           C hs f _
-           (@mk_Equalizer
-              C a b f _ (EqualizerObject C K)
-              (EqualizerArrow C K)
-              (equiv_Kernel2_eq f K)
-              (equiv_Kernel2_isEqualizer f K))).
+    use mk_Kernel.
+    - exact (EqualizerObject C K).
+    - exact (EqualizerArrow C K).
+    - exact (equiv_Kernel2_eq f K).
+    - exact (equiv_Kernel2_isEqualizer f K).
   Defined.
 
 End def_kernels.

--- a/UniMath/CategoryTheory/limits/kernels.v
+++ b/UniMath/CategoryTheory/limits/kernels.v
@@ -540,18 +540,18 @@ Section transport_kernels.
   Variable hs : has_homsets C.
   Variable Z : Zero C.
 
-  Local Lemma transportb_KernelIn_eq {x' x y z : C} (f : x --> y) {g : y --> z} (K : Kernel Z g)
-        (e : x' = x) (H : f ;; g = ZeroArrow Z _ _) :
-    (transportb (fun x' : ob C => precategory_morphisms x' y) e f) ;; g = ZeroArrow Z _ _.
+  Local Lemma transport_source_KernelIn_eq {x' x y z : C} (f : x --> y) {g : y --> z} (K : Kernel Z g)
+        (e : x = x') (H : f ;; g = ZeroArrow Z _ _) :
+    (transportf (fun x' : ob C => precategory_morphisms x' y) e f) ;; g = ZeroArrow Z _ _.
   Proof.
     induction e. apply H.
   Qed.
 
-  Lemma transportb_KernelIn {x' x y z : C} (f : x --> y) {g : y --> z} (K : Kernel Z g)
-        (e : x' = x) (H : f ;; g = ZeroArrow Z _ _) :
-    transportb (fun x' : ob C => precategory_morphisms x' K) e (KernelIn Z K _ f H) =
-    KernelIn Z K _ (transportb (fun x' : ob C => precategory_morphisms x' y) e f)
-             (transportb_KernelIn_eq f K e H).
+  Lemma transport_source_KernelIn {x' x y z : C} (f : x --> y) {g : y --> z} (K : Kernel Z g)
+        (e : x = x') (H : f ;; g = ZeroArrow Z _ _) :
+    transportf (fun x' : ob C => precategory_morphisms x' K) e (KernelIn Z K _ f H) =
+    KernelIn Z K _ (transportf (fun x' : ob C => precategory_morphisms x' y) e f)
+             (transport_source_KernelIn_eq f K e H).
   Proof.
     induction e. use KernelInsEq. cbn. unfold idfun.
     rewrite KernelCommutes. rewrite KernelCommutes.

--- a/UniMath/CategoryTheory/limits/kernels.v
+++ b/UniMath/CategoryTheory/limits/kernels.v
@@ -1,12 +1,13 @@
-(**
-
-Direct implementation of kernels together with:
-
-- Proof that the kernel arrow is monic ([KernelArrowisMonic])
-
-Written by Tomi Pannila.
-
+(** * Direct implementation of kernels *)
+(** ** Contents
+- Definition of [Kernel]
+- Correspondence of Kernels and Equalizers
+- Kernel up to isomorphism
+- Kernel of morphism ;; [Monic]
+- KernelIn of equal morphisms
+- Transport of kernels
 *)
+
 Require Import UniMath.Foundations.Basics.PartD.
 Require Import UniMath.Foundations.Basics.Propositions.
 Require Import UniMath.Foundations.Basics.Sets.
@@ -16,6 +17,7 @@ Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.Monics.
 Require Import UniMath.CategoryTheory.limits.equalizers.
 Require Import UniMath.CategoryTheory.limits.zero.
+
 
 (** Definition of kernels *)
 Section def_kernels.
@@ -299,8 +301,7 @@ Section kernel_equalizers.
 End kernel_equalizers.
 
 
-(** In the following section we construct a new kernel from an arrow which is
-  equal to kernelarrow of some kernel, up to precomposing with an isomorphism *)
+(** * Kernel up to isomorphism *)
 Section kernels_iso.
 
   Variable C : precategory.
@@ -532,7 +533,7 @@ Section kernel_in_paths.
 End kernel_in_paths.
 
 
-(** Transports of kernels *)
+(** * Transports of kernels *)
 Section transport_kernels.
 
   Variable C : precategory.

--- a/UniMath/CategoryTheory/limits/zero.v
+++ b/UniMath/CategoryTheory/limits/zero.v
@@ -155,14 +155,14 @@ Section def_zero.
 
 
   (** ** Transport of ZeroArrow *)
-  Lemma transportf_ZeroArrow {a b c : C} (Z : Zero) (e : b = c) :
+  Lemma transport_target_ZeroArrow {a b c : C} (Z : Zero) (e : b = c) :
     transportf _ e (ZeroArrow Z a b) = ZeroArrow Z a c.
   Proof.
     induction e. apply idpath.
   Qed.
 
-  Lemma transportb_ZeroArrow {a b c : C} (Z : Zero) (e : a = b) :
-    transportb (fun (a' : ob C) => precategory_morphisms a' c) e (ZeroArrow Z b c) = ZeroArrow Z a c.
+  Lemma transport_source_ZeroArrow {a b c : C} (Z : Zero) (e : b = a) :
+    transportf (fun (a' : ob C) => precategory_morphisms a' c) e (ZeroArrow Z b c) = ZeroArrow Z a c.
   Proof.
     induction e. apply idpath.
   Qed.

--- a/UniMath/CategoryTheory/limits/zero.v
+++ b/UniMath/CategoryTheory/limits/zero.v
@@ -93,6 +93,21 @@ Section def_zero.
   Definition iso_Zeros (Z Z' : Zero) : iso Z Z' :=
     tpair _ (ZeroArrowTo Z' Z) (isiso_from_Zero_to_Zero Z' Z).
 
+  Lemma ZerosArrowEq (Z Z' : Zero) (a b : C) : ZeroArrow Z a b = ZeroArrow Z' a b.
+  Proof.
+    set (i := iso_Zeros Z Z').
+    unfold ZeroArrow.
+    assert (e : ZeroArrowTo Z a ;; identity _ = ZeroArrowTo Z a) by apply id_right.
+    rewrite <- e. clear e.
+    rewrite <- (iso_inv_after_iso i). rewrite assoc.
+    assert (e1 : ZeroArrowTo Z a ;; i = ZeroArrowTo Z' a) by apply ArrowsToZero.
+    rewrite e1. clear e1.
+    assert (e2 : inv_from_iso i ;; ZeroArrowFrom Z b = ZeroArrowFrom Z' b)
+      by apply ArrowsFromZero.
+    rewrite <- assoc. rewrite e2. clear e2.
+    apply idpath.
+  Qed.
+
   Definition hasZero := ishinh Zero.
 
   Section Zero_Unique.

--- a/UniMath/CategoryTheory/opp_precat.v
+++ b/UniMath/CategoryTheory/opp_precat.v
@@ -46,12 +46,59 @@ Definition opp_precat (C : precategory) : precategory :=
 
 Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
 
+
+Definition opp_ob {C : precategory} (c : ob C) : ob C^op := c.
+
+Definition rm_opp_ob {C : Precategory} (cop : ob C^op) : ob C := cop.
+
+Definition opp_mor {C : Precategory} {b c : C} (f : C⟦b, c⟧) : C^op⟦c, b⟧ := f.
+
+Definition rm_opp_mor {C : Precategory} {b c : C} (f : C^op⟦c, b⟧) : C⟦b, c⟧ := f.
+
+Definition opp_mor_eq {C : Precategory} {a b : C} {f g : a --> b} (e : opp_mor f = opp_mor g) :
+  f = g := e.
+
+Lemma opp_opp_precat_ob_mor (C : precategory_ob_mor) : C = opp_precat_ob_mor (opp_precat_ob_mor C).
+Proof.
+  induction C as [ob mor]. apply idpath.
+Defined.
+
+Lemma opp_opp_precat_ob_mor_compute (C : precategory_ob_mor) :
+  idpath _ = maponpaths precategory_id_comp (opp_opp_precat_ob_mor C).
+Proof.
+  induction C as [ob mor]. apply idpath.
+Defined.
+
+Lemma opp_opp_precat_data (C : precategory_data) : C = opp_precat_data (opp_precat_data C).
+Proof.
+  induction C as [obmor idco].
+  induction obmor as [ob mor].
+  induction idco as [id co].
+  apply idpath.
+Defined.
+
+Lemma opp_opp_precat (C : precategory) (hs : has_homsets C) : C = C^op^op.
+Proof.
+  use total2_paths.
+  - apply opp_opp_precat_data.
+  - apply (isaprop_is_precategory _ hs).
+Qed.
+
+Definition opp_is_iso {C : precategory} {a b : C} (f : a --> b) :
+  @is_iso C a b f -> @is_iso C^op b a f.
+Proof.
+  intros H.
+  set (T := is_z_iso_from_is_iso _ H).
+  apply (is_iso_qinv (C:=C^op) _ (pr1 T)).
+  split; [ apply (pr2 (pr2 T)) | apply (pr1 (pr2 T)) ].
+Qed.
+
 Definition opp_iso {C : precategory} {a b : C} : @iso C a b -> @iso C^op b a.
-intro f.
-exists (pr1 f).
-set (T := is_z_iso_from_is_iso _ (pr2 f)).
-apply (is_iso_qinv (C:=C^op) _ (pr1 T)).
-split; [ apply (pr2 (pr2 T)) | apply (pr1 (pr2 T)) ].
+  intro f.
+  exists (pr1 f).
+  set (T := is_z_iso_from_is_iso _ (pr2 f)).
+  apply (is_iso_qinv (C:=C^op) _ (pr1 T)).
+  split; [ apply (pr2 (pr2 T)) | apply (pr1 (pr2 T)) ].
 Defined.
 
 Lemma has_homsets_opp {C : precategory} (hsC : has_homsets C) : has_homsets C^op.

--- a/UniMath/CategoryTheory/opp_precat.v
+++ b/UniMath/CategoryTheory/opp_precat.v
@@ -49,13 +49,13 @@ Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
 
 Definition opp_ob {C : precategory} (c : ob C) : ob C^op := c.
 
-Definition rm_opp_ob {C : Precategory} (cop : ob C^op) : ob C := cop.
+Definition rm_opp_ob {C : precategory} (cop : ob C^op) : ob C := cop.
 
-Definition opp_mor {C : Precategory} {b c : C} (f : C⟦b, c⟧) : C^op⟦c, b⟧ := f.
+Definition opp_mor {C : precategory} {b c : C} (f : C⟦b, c⟧) : C^op⟦c, b⟧ := f.
 
-Definition rm_opp_mor {C : Precategory} {b c : C} (f : C^op⟦c, b⟧) : C⟦b, c⟧ := f.
+Definition rm_opp_mor {C : precategory} {b c : C} (f : C^op⟦c, b⟧) : C⟦b, c⟧ := f.
 
-Definition opp_mor_eq {C : Precategory} {a b : C} {f g : a --> b} (e : opp_mor f = opp_mor g) :
+Definition opp_mor_eq {C : precategory} {a b : C} {f g : a --> b} (e : opp_mor f = opp_mor g) :
   f = g := e.
 
 Lemma opp_opp_precat_ob_mor (C : precategory_ob_mor) : C = opp_precat_ob_mor (opp_precat_ob_mor C).

--- a/UniMath/CategoryTheory/precategories.v
+++ b/UniMath/CategoryTheory/precategories.v
@@ -1300,3 +1300,13 @@ Proof.
   rewrite <- functtransportf. unfold pathsinv0. unfold paths_rect. induction e.
   apply idpath.
 Qed.
+
+Lemma transport_mor_f_b_comm {C : precategory} {x y x' y' : ob C} (f : x --> y) (e1 : x = x')
+      (e2 : y = y') :
+  transportf (precategory_morphisms x') e2
+             (transportb (fun (x'' : ob C) => precategory_morphisms x'' y) (! e1) f) =
+  transportb (fun (x'' : ob C) => precategory_morphisms x'' y') (! e1)
+             (transportf (precategory_morphisms x) e2 f).
+Proof.
+  induction e1. induction e2. apply idpath.
+Qed.

--- a/UniMath/CategoryTheory/precategories.v
+++ b/UniMath/CategoryTheory/precategories.v
@@ -1240,73 +1240,109 @@ Definition precategory_total_comp (C : precategory_data) :
 
 
 (** ** Transport of morphisms *)
-Lemma transportf_postcompose {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z)
+
+
+(** *** Transport source and target of a morphism *)
+
+Lemma transport_target_postcompose {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z)
       (e : z = w) :
   transportf (precategory_morphisms x) e (f ;; g) = f ;; transportf (precategory_morphisms y) e g.
 Proof.
   induction e. apply idpath.
 Qed.
 
-Lemma transportb_precompose {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z) (e : w = x) :
-  transportb (fun x' : ob C => precategory_morphisms x' z) e (f ;; g) =
-  transportb (fun x' : ob C => precategory_morphisms x' y) e f ;; g.
+Lemma transport_source_precompose {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z)
+      (e : x = w) :
+  transportf (fun x' : ob C => precategory_morphisms x' z) e (f ;; g) =
+  transportf (fun x' : ob C => precategory_morphisms x' y) e f ;; g.
 Proof.
   induction e. apply idpath.
 Qed.
 
 Lemma transport_compose {C : precategory} {x y z w : ob C} (f : x --> y) (g : z --> w) (e : y = z) :
   transportf (precategory_morphisms x) e f ;; g =
-  f ;; transportb (fun x' : ob C => precategory_morphisms x' w) e g.
+  f ;; transportf (fun x' : ob C => precategory_morphisms x' w) (! e) g.
 Proof.
   induction e. apply idpath.
 Qed.
 
 Lemma transport_compose' {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z) (e : y = w) :
   (transportf (precategory_morphisms x) e f)
-    ;; (transportb (fun x' : ob C => precategory_morphisms x' z) (!e) g) = f ;; g.
+    ;; (transportf (fun x' : ob C => precategory_morphisms x' z) e g) = f ;; g.
 Proof.
-  induction e. cbn. unfold idfun. apply idpath.
+  induction e. apply idpath.
 Qed.
 
-Lemma transportf_path {C : precategory} {x y z : ob C} (f g : x --> y) (e : y = z) :
+Lemma transport_target_path {C : precategory} {x y z : ob C} (f g : x --> y) (e : y = z) :
   transportf (precategory_morphisms x) e f = transportf (precategory_morphisms x) e g -> f = g.
 Proof.
   induction e. intros H. apply H.
 Qed.
 
-Lemma transportb_path {C : precategory} {x y z : ob C} (f g : y --> z) (e : x = y) :
-  transportb (fun x' : ob C => precategory_morphisms x' z) e f =
-  transportb (fun x' : ob C => precategory_morphisms x' z) e g -> f = g.
+Lemma transport_source_path {C : precategory} {x y z : ob C} (f g : y --> z) (e : y = x) :
+  transportf (fun x' : ob C => precategory_morphisms x' z) e f =
+  transportf (fun x' : ob C => precategory_morphisms x' z) e g -> f = g.
 Proof.
   induction e. intros H. apply H.
 Qed.
 
-Lemma transportf_mor {X : UU} {C : precategory} {x y : X} (P : Π (x' : X), ob C)
+Lemma transport_source_target {X : UU} {C : precategory} {x y : X} (P : Π (x' : X), ob C)
       (P' : Π (x' : X), ob C) (f : Π (x' : X), (P x') --> (P' x')) (e : x = y) :
   transportf (fun (x' : X) => (P x') --> (P' x')) e (f x) =
-  transportb (fun (x' : X) => precategory_morphisms (P x') (P' y)) (! e)
+  transportf (fun (x' : X) => precategory_morphisms (P x') (P' y)) e
              (transportf (precategory_morphisms (P x)) (maponpaths P' e) (f x)).
 Proof.
   rewrite <- functtransportf. unfold pathsinv0. unfold paths_rect. induction e.
   apply idpath.
 Qed.
 
-Lemma transportf_mor' {X : UU} {C : precategory} {x y : X} (P : Π (x' : X), ob C)
+Lemma transport_target_source {X : UU} {C : precategory} {x y : X} (P : Π (x' : X), ob C)
       (P' : Π (x' : X), ob C) (f : Π (x' : X), (P x') --> (P' x')) (e : x = y) :
   transportf (fun (x' : X) => (P x') --> (P' x')) e (f x) =
   transportf (precategory_morphisms (P y)) (maponpaths P' e)
-             (transportb (fun (x' : X) => precategory_morphisms (P x') (P' x)) (! e) (f x)).
+             (transportf (fun (x' : X) => precategory_morphisms (P x') (P' x)) e (f x)).
 Proof.
   rewrite <- functtransportf. unfold pathsinv0. unfold paths_rect. induction e.
   apply idpath.
 Qed.
 
-Lemma transport_mor_f_b_comm {C : precategory} {x y x' y' : ob C} (f : x --> y) (e1 : x = x')
+Lemma transport_source_target_comm {C : precategory} {x y x' y' : ob C} (f : x --> y) (e1 : x = x')
       (e2 : y = y') :
+  transportf (fun (x'' : ob C) => precategory_morphisms x'' y') e1
+             (transportf (precategory_morphisms x) e2 f) =
   transportf (precategory_morphisms x') e2
-             (transportb (fun (x'' : ob C) => precategory_morphisms x'' y) (! e1) f) =
-  transportb (fun (x'' : ob C) => precategory_morphisms x'' y') (! e1)
-             (transportf (precategory_morphisms x) e2 f).
+             (transportf (fun (x'' : ob C) => precategory_morphisms x'' y) e1 f).
 Proof.
   induction e1. induction e2. apply idpath.
+Qed.
+
+
+(** *** Transport a morphism using funextfun *)
+
+Definition transport_source_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C)
+           (H : Π (x : X), F x = F' x) {x : X} (c : ob C) (f : F x --> c) :
+  transportf (λ x0 : X → C, x0 x --> c) (funextfun F F' H) f =
+  transportf (λ x0 : C, x0 --> c) (H x) f.
+Proof.
+  exact (@transportf_funextfun X (ob C) (λ x0 : C, x0 --> c) F F' H x f).
+Qed.
+
+Definition transport_target_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C)
+           (H : Π (x : X), F x = F' x) {x : X} {c : ob C} (f : c --> F x)  :
+  transportf (λ x0 : X → C, c --> x0 x) (funextfun F F' H) f =
+  transportf (λ x0 : C, c --> x0) (H x) f.
+Proof.
+  use transportf_funextfun.
+Qed.
+
+Lemma transport_mor_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C)
+           (H : Π (x : X), F x = F' x) {x1 x2 : X} (f : F x1 --> F x2) :
+  transportf (λ x : X → C, x x1 --> x x2) (funextfun F F' H) f =
+  transportf (λ x : X → C, F' x1 --> x x2)
+             (funextfun F F' (λ x : X, H x))
+             (transportf (λ x : X → C, x x1 --> F x2)
+                         ((funextfun F F' (λ x : X, H x))) f).
+Proof.
+  induction (funextfun F F' (λ x : X, H x)).
+  apply idpath.
 Qed.

--- a/UniMath/CategoryTheory/precategoriesWithBinOps.v
+++ b/UniMath/CategoryTheory/precategoriesWithBinOps.v
@@ -14,20 +14,17 @@ Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
 Section def_precategory_with_binops.
 
   (** Definition of precategories such that homs are binops. *)
-  Definition PrecategoryWithBinOpsData (C : precategory) : UU := Π (x y : C), binop (C⟦x, y⟧).
+  Definition precategoryWithBinOpsData (C : precategory) : UU := Π (x y : C), binop (C⟦x, y⟧).
 
-  Definition PrecategoryWithBinOps : UU := Σ C : precategory, PrecategoryWithBinOpsData C.
+  Definition precategoryWithBinOps : UU := Σ C : precategory, precategoryWithBinOpsData C.
 
-  Definition PrecategoryWithBinOps_precategory (P : PrecategoryWithBinOps) : precategory := pr1 P.
-  Coercion PrecategoryWithBinOps_precategory : PrecategoryWithBinOps >-> precategory.
+  Definition precategoryWithBinOps_precategory (P : precategoryWithBinOps) : precategory := pr1 P.
+  Coercion precategoryWithBinOps_precategory : precategoryWithBinOps >-> precategory.
 
-  Definition mk_PrecategoryWithBinOps (C : precategory) (H : PrecategoryWithBinOpsData C) :
-    PrecategoryWithBinOps.
-  Proof.
-    exact (tpair _ C H).
-  Defined.
+  Definition mk_precategoryWithBinOps (C : precategory) (H : precategoryWithBinOpsData C) :
+    precategoryWithBinOps := tpair _ C H.
 
   (** Gives the binop of the homs from x to y. *)
-  Definition to_binop {BC : PrecategoryWithBinOps} (x y : BC) : binop (BC⟦x, y⟧) := (pr2 BC) x y.
+  Definition to_binop {BC : precategoryWithBinOps} (x y : BC) : binop (BC⟦x, y⟧) := (pr2 BC) x y.
 
 End def_precategory_with_binops.

--- a/UniMath/Foundations/Basics/PartA.v
+++ b/UniMath/Foundations/Basics/PartA.v
@@ -628,6 +628,12 @@ Proof.
   reflexivity.
 Defined.
 
+Definition idpath_transportb {X : UU} (P : X -> UU) {x : X} (p : P x) :
+  transportb P (idpath x) p = p.
+Proof.
+  intros X P x p. use idpath_transportf.
+Defined.
+
 Lemma functtransportf {X Y : UU} (f : X -> Y) (P : Y -> UU) {x x' : X}
       (e : x = x') (p : P (f x)) :
   transportf (fun x => P (f x)) e p = transportf P (maponpaths f e) p.

--- a/UniMath/Foundations/Basics/PartA.v
+++ b/UniMath/Foundations/Basics/PartA.v
@@ -628,12 +628,6 @@ Proof.
   reflexivity.
 Defined.
 
-Definition idpath_transportb {X : UU} (P : X -> UU) {x : X} (p : P x) :
-  transportb P (idpath x) p = p.
-Proof.
-  intros X P x p. use idpath_transportf.
-Defined.
-
 Lemma functtransportf {X Y : UU} (f : X -> Y) (P : Y -> UU) {x x' : X}
       (e : x = x') (p : P (f x)) :
   transportf (fun x => P (f x)) e p = transportf P (maponpaths f e) p.

--- a/UniMath/Foundations/Basics/UnivalenceAxiom.v
+++ b/UniMath/Foundations/Basics/UnivalenceAxiom.v
@@ -414,3 +414,27 @@ Proof.
 Defined.
 
 (** Check assumptions *)
+
+Lemma toforallpaths_induction (X Y : UU) (f g : X -> Y) (P : (Π x, f x = g x) -> UU)
+      (H : Π e : f = g, P (toforallpaths _ _ _ e)) : Π i : (Π x, f x = g x), P i.
+Proof.
+  intros i. rewrite <- (homotweqinvweq (weqtoforallpaths _ f g)). apply H.
+Defined.
+
+Definition transportf_funextfun {X Y : UU} (P : Y -> UU) (F F' : X -> Y) (H : Π (x : X), F x = F' x)
+           (x : X) (f : P (F x)) :
+  transportf (λ x0 : X → Y, P (x0 x)) (funextsec _ F F' H) f = transportf (λ x0 : Y, P x0) (H x) f.
+Proof.
+  apply (toforallpaths_induction
+           _ _ F F' (fun H' => transportf (λ x0 : X → Y, P (x0 x))
+                                       (funextsec (λ _ : X, Y) F F' (λ x0 : X, H' x0)) f =
+                            transportf (λ x0 : Y, P x0) (H' x) f)).
+  intro e. clear H.
+  set (XR := homotinvweqweq (weqtoforallpaths _ F F') e).
+  set (H := funextsec (λ _ : X, Y) F F' (λ x0 : X, toforallpaths (λ _ : X, Y) F F' e x0)).
+  set (P' := λ x0 : X → Y, P (x0 x)).
+  use pathscomp0.
+  - exact (transportf P' e f).
+  - use transportf_paths. exact XR.
+  - induction e. apply idpath.
+Defined.

--- a/UniMath/Foundations/NumberSystems/Integers.v
+++ b/UniMath/Foundations/NumberSystems/Integers.v
@@ -64,7 +64,7 @@ Proof . change ( isdeceq ( abgrdiff ( rigaddabmonoid natcommrig ) ) ) . apply is
 Lemma isasethz : isaset hz .
 Proof . apply ( setproperty hzaddabgr ) . Defined .
 
-Definition hzeq ( x y : hz ) : hProp := hProppair ( paths x y ) ( isasethz _ _  )  .
+Definition hzeq ( x y : hz ) : hProp := hProppair ( x = y ) ( isasethz _ _  )  .
 Definition isdecrelhzeq : isdecrel hzeq  := fun a b => isdeceqhz a b .
 Definition hzdeceq : decrel hz := decrelpair isdecrelhzeq .
 
@@ -72,7 +72,7 @@ Definition hzdeceq : decrel hz := decrelpair isdecrelhzeq .
 
 Definition hzbooleq := decreltobrel hzdeceq .
 
-Definition hzneq ( x y : hz ) : hProp := hProppair ( neg ( paths x y ) ) ( isapropneg _  )  .
+Definition hzneq ( x y : hz ) : hProp := hProppair ( neg ( x = y ) ) ( isapropneg _  )  .
 Definition isdecrelhzneq : isdecrel hzneq  := isdecnegrel _ isdecrelhzeq .
 Definition hzdecneq : decrel hz := decrelpair isdecrelhzneq .
 
@@ -92,24 +92,24 @@ Proof . apply  ( ct ( hzneq , isdecrelhzneq, 1 , 0 ) ) . Defined .
 
 (** *** Properties of addition and subtraction on [ hz ] *)
 
-Definition hzminuszero : paths ( - 0 ) 0 := rnginvunel1 hz .
+Definition hzminuszero : ( - 0 ) = 0 := rnginvunel1 hz .
 
-Lemma hzplusr0 ( x : hz ) : paths ( x + 0 ) x .
+Lemma hzplusr0 ( x : hz ) : ( x + 0 ) = x .
 Proof . intro . apply ( rngrunax1 _ x ) .  Defined .
 
-Lemma hzplusl0 ( x : hz ) : paths ( 0 + x ) x .
+Lemma hzplusl0 ( x : hz ) : ( 0 + x ) = x .
 Proof . intro . apply ( rnglunax1 _ x ) . Defined .
 
-Lemma hzplusassoc ( x y z : hz ) : paths ( ( x + y ) + z ) ( x + ( y + z ) ) .
+Lemma hzplusassoc ( x y z : hz ) : ( ( x + y ) + z ) = ( x + ( y + z ) ) .
 Proof . intros . apply ( rngassoc1 hz x y z ) . Defined .
 
-Lemma hzpluscomm ( x y : hz ) : paths ( x + y ) ( y + x ) .
+Lemma hzpluscomm ( x y : hz ) : ( x + y ) = ( y + x ) .
 Proof . intros .  apply ( rngcomm1 hz x y ) . Defined .
 
-Lemma hzlminus ( x : hz ) : paths ( -x + x ) 0 .
+Lemma hzlminus ( x : hz ) : ( -x + x ) = 0 .
 Proof . intro. apply ( rnglinvax1 hz x ) . Defined .
 
-Lemma hzrminus  ( x : hz ) : paths ( x - x ) 0 .
+Lemma hzrminus  ( x : hz ) : ( x - x ) = 0 .
 Proof . intro. apply ( rngrinvax1 hz x ) . Defined .
 
 Lemma isinclhzplusr ( n : hz ) : isincl ( fun m : hz => m + n ) .
@@ -118,19 +118,19 @@ Proof. intro . apply ( pr2 ( weqtoincl _ _ ( weqrmultingr hzaddabgr n ) ) ) . De
 Lemma isinclhzplusl ( n : hz ) : isincl ( fun m : hz => n + m ) .
 Proof.  intro.  apply ( pr2 ( weqtoincl _ _ ( weqlmultingr hzaddabgr n ) ) ) . Defined .
 
-Lemma hzpluslcan ( a b c : hz ) ( is : paths ( c + a ) ( c + b ) ) : paths a b .
+Lemma hzpluslcan ( a b c : hz ) ( is : ( c + a ) = ( c + b ) ) : a = b .
 Proof . intros . apply ( @grlcan hzaddabgr a b c is ) .  Defined .
 
-Lemma hzplusrcan ( a b c : hz ) ( is : paths ( a + c ) ( b + c ) ) : paths a b .
+Lemma hzplusrcan ( a b c : hz ) ( is : ( a + c ) = ( b + c ) ) : a = b .
 Proof . intros . apply ( @grrcan hzaddabgr a b c is ) .  Defined .
 
-Lemma hzplusradd (a b c : hz) (is : paths a b) : paths (a + c) (b + c).
+Lemma hzplusradd (a b c : hz) (is : a = b) : (a + c) = (b + c).
 Proof. intros. induction is. apply idpath. Defined.
 
-Lemma hzplusladd (a b c : hz) (is : paths a b) : paths (c + a) (c + b).
+Lemma hzplusladd (a b c : hz) (is : a = b) : (c + a) = (c + b).
 Proof. intros. apply maponpaths. apply is. Defined.
 
-Definition hzinvmaponpathsminus { a b : hz } ( e :  paths ( - a ) ( - b ) ) : paths a b := grinvmaponpathsinv hzaddabgr e .
+Definition hzinvmaponpathsminus { a b : hz } ( e : ( - a ) = ( - b ) ) : a = b := grinvmaponpathsinv hzaddabgr e .
 
 Lemma hzrplusminus (n m : hz) : n + m - m = n.
 Proof.
@@ -163,22 +163,22 @@ Opaque hzrminusplus'.
 (** *** Properties of multiplication on [ hz ] *)
 
 
-Lemma hzmultr1 ( x : hz ) : paths ( x * 1 ) x .
+Lemma hzmultr1 ( x : hz ) : ( x * 1 ) = x .
 Proof . intro . apply ( rngrunax2 _ x ) .  Defined .
 
-Lemma hzmultl1 ( x : hz ) : paths ( 1 * x ) x .
+Lemma hzmultl1 ( x : hz ) : ( 1 * x ) = x .
 Proof . intro . apply ( rnglunax2 _ x ) . Defined .
 
-Lemma hzmult0x ( x : hz ) : paths ( 0 * x ) 0 .
+Lemma hzmult0x ( x : hz ) : ( 0 * x ) = 0 .
 Proof . intro . apply ( rngmult0x _ x ) .  Defined .
 
-Lemma hzmultx0 ( x : hz ) : paths ( x * 0 ) 0 .
+Lemma hzmultx0 ( x : hz ) : ( x * 0 ) = 0 .
 Proof . intro . apply ( rngmultx0 _ x ) . Defined .
 
-Lemma hzmultassoc ( x y z : hz ) : paths ( ( x * y ) * z ) ( x * ( y * z ) ) .
+Lemma hzmultassoc ( x y z : hz ) : ( ( x * y ) * z ) = ( x * ( y * z ) ) .
 Proof . intros . apply ( rngassoc2 hz x y z ) . Defined .
 
-Lemma hzmultcomm ( x y : hz ) : paths ( x * y ) ( y * x ) .
+Lemma hzmultcomm ( x y : hz ) : ( x * y ) = ( y * x ) .
 Proof . intros .  apply ( rngcomm2 hz  x y ) . Defined .
 
 Definition hzneq0andmultlinv ( n m : hz ) ( isnm : hzneq ( n * m ) 0 ) : hzneq n 0 := rngneq0andmultlinv hz n m isnm .
@@ -241,19 +241,19 @@ Proof. apply ( istransabgrdiffrel nataddabmonoid isplushrelnatgth )  .  unfold i
 Lemma isirreflhzgth ( n : hz ) : neg ( hzgth n n ) .
 Proof. apply ( isirreflabgrdiffrel nataddabmonoid isplushrelnatgth )  . unfold isirrefl .  apply isirreflnatgth .   Defined .
 
-Lemma hzgthtoneq ( n m : hz ) ( g : hzgth n m ) : neg ( paths n m ) .
+Lemma hzgthtoneq ( n m : hz ) ( g : hzgth n m ) : neg ( n = m ) .
 Proof . intros . intro e . rewrite e in g . apply ( isirreflhzgth _ g ) . Defined .
 
 Lemma isasymmhzgth ( n m : hz ) : hzgth n m -> hzgth m n -> empty .
 Proof. apply ( isasymmabgrdiffrel nataddabmonoid isplushrelnatgth )  . unfold isasymm .  apply isasymmnatgth .  Defined .
 
-Lemma isantisymmneghzgth ( n m : hz ) : neg ( hzgth n m ) -> neg ( hzgth m n ) -> paths n m .
+Lemma isantisymmneghzgth ( n m : hz ) : neg ( hzgth n m ) -> neg ( hzgth m n ) -> n = m .
 Proof . apply ( isantisymmnegabgrdiffrel nataddabmonoid isplushrelnatgth )  . unfold isantisymmneg .  apply isantisymmnegnatgth .   Defined .
 
 Lemma isnegrelhzgth : isnegrel hzgth .
 Proof . apply isdecreltoisnegrel . apply isdecrelhzgth . Defined .
 
-Lemma iscoantisymmhzgth ( n m : hz ) : neg ( hzgth n m ) -> coprod ( hzgth m n ) ( paths n m ) .
+Lemma iscoantisymmhzgth ( n m : hz ) : neg ( hzgth n m ) -> coprod ( hzgth m n ) ( n = m ) .
 Proof . apply isantisymmnegtoiscoantisymm . apply isdecrelhzgth .  intros n m . apply isantisymmneghzgth . Defined .
 
 Lemma iscotranshzgth ( n m k : hz ) : hzgth n k -> hdisj ( hzgth n m ) ( hzgth m k ) .
@@ -269,16 +269,16 @@ Definition istranshzlth ( n m k  : hz ) : hzlth n m -> hzlth m k -> hzlth n k :=
 
 Definition isirreflhzlth ( n : hz ) : neg ( hzlth n n ) := isirreflhzgth n .
 
-Lemma hzlthtoneq ( n m : hz ) ( g : hzlth n m ) : neg ( paths n m ) .
+Lemma hzlthtoneq ( n m : hz ) ( g : hzlth n m ) : neg ( n = m ) .
 Proof . intros . intro e . rewrite e in g . apply ( isirreflhzlth _ g ) . Defined .
 
 Definition isasymmhzlth ( n m : hz ) : hzlth n m -> hzlth m n -> empty := fun lnm lmn => isasymmhzgth _ _ lmn lnm .
 
-Definition isantisymmneghztth  ( n m : hz ) : neg ( hzlth n m ) -> neg ( hzlth m n ) -> paths n m := fun nlnm nlmn => isantisymmneghzgth _ _ nlmn nlnm .
+Definition isantisymmneghztth  ( n m : hz ) : neg ( hzlth n m ) -> neg ( hzlth m n ) -> n = m := fun nlnm nlmn => isantisymmneghzgth _ _ nlmn nlnm .
 
 Definition isnegrelhzlth : isnegrel hzlth := fun n m => isnegrelhzgth m n .
 
-Definition iscoantisymmhzlth ( n m : hz ) : neg ( hzlth n m ) -> coprod ( hzlth m n ) ( paths n m ) .
+Definition iscoantisymmhzlth ( n m : hz ) : neg ( hzlth n m ) -> coprod ( hzlth m n ) ( n = m ) .
 Proof . intros n m nlnm . destruct ( iscoantisymmhzgth m n nlnm ) as [ l | e ] . apply ( ii1 l ) . apply ( ii2 ( pathsinv0 e ) ) . Defined .
 
 Definition iscotranshzlth ( n m k : hz ) : hzlth n k -> hdisj ( hzlth n m ) ( hzlth m k ) .
@@ -294,7 +294,7 @@ Proof. apply istransnegrel . unfold iscotrans. apply iscotranshzgth .  Defined.
 
 Definition isreflhzleh ( n : hz ) : hzleh n n := isirreflhzgth n .
 
-Definition isantisymmhzleh ( n m : hz ) : hzleh n m -> hzleh m n -> paths n m := isantisymmneghzgth n m .
+Definition isantisymmhzleh ( n m : hz ) : hzleh n m -> hzleh m n -> n = m := isantisymmneghzgth n m .
 
 Definition isnegrelhzleh : isnegrel hzleh .
 Proof . apply isdecreltoisnegrel . apply isdecrelhzleh . Defined .
@@ -313,7 +313,7 @@ Definition istranshzgeh ( n m k : hz ) : hzgeh n m -> hzgeh m k -> hzgeh n k := 
 
 Definition isreflhzgeh ( n : hz ) : hzgeh n n := isreflhzleh _ .
 
-Definition isantisymmhzgeh ( n m : hz ) : hzgeh n m -> hzgeh m n -> paths n m := fun gnm gmn => isantisymmhzleh _ _ gmn gnm .
+Definition isantisymmhzgeh ( n m : hz ) : hzgeh n m -> hzgeh m n -> n = m := fun gnm gmn => isantisymmhzleh _ _ gmn gnm .
 
 Definition isnegrelhzgeh : isnegrel hzgeh := fun n m => isnegrelhzleh m n .
 
@@ -359,13 +359,13 @@ Proof . intros . apply ( isdecrelhzgth n m ) .  Defined .
 
 Definition hzlthorgeh ( n m : hz ) : coprod ( hzlth n m ) ( hzgeh n m ) := hzgthorleh _ _ .
 
-Definition hzneqchoice ( n m : hz ) ( ne : neg ( paths n m ) ) : coprod ( hzgth n m ) ( hzlth n m ) .
+Definition hzneqchoice ( n m : hz ) ( ne : neg ( n = m ) ) : coprod ( hzgth n m ) ( hzlth n m ) .
 Proof . intros . destruct ( hzgthorleh n m ) as [ g | l ]  .  destruct ( hzlthorgeh n m ) as [ g' | l' ] . destruct ( isasymmhzgth _ _ g g' )  .  apply ( ii1 g ) . destruct ( hzlthorgeh n m ) as [ l' | g' ] . apply ( ii2 l' ) . destruct ( ne ( isantisymmhzleh _ _ l g' ) ) . Defined .
 
-Definition hzlehchoice ( n m : hz ) ( l : hzleh n m ) : coprod ( hzlth n m ) ( paths n m ) .
+Definition hzlehchoice ( n m : hz ) ( l : hzleh n m ) : coprod ( hzlth n m ) ( n = m ) .
 Proof .  intros . destruct ( hzlthorgeh n m ) as [ l' | g ] .   apply ( ii1 l' ) . apply ( ii2 ( isantisymmhzleh _ _ l g ) ) . Defined .
 
-Definition hzgehchoice ( n m : hz ) ( g : hzgeh n m ) : coprod ( hzgth n m ) ( paths n m ) .
+Definition hzgehchoice ( n m : hz ) ( g : hzgeh n m ) : coprod ( hzgth n m ) ( n = m ) .
 Proof .  intros . destruct ( hzgthorleh n m ) as [ g' | l ] .  apply ( ii1 g' ) .  apply ( ii2 ( isantisymmhzleh _ _ l g ) ) .  Defined .
 
 
@@ -680,16 +680,16 @@ Definition hzintdom : intdom := tpair _ _ isintdomhz .
 
 Definition hzneq0andmult ( n m : hz ) ( isn : hzneq n 0 ) ( ism : hzneq m 0 ) : hzneq ( n * m ) 0 := intdomneq0andmult hzintdom n m isn ism .
 
-Lemma hzmultlcan ( a b c : hz ) ( ne : neg ( paths c 0 ) ) ( e : paths ( c * a ) ( c * b ) ) : paths a b .
+Lemma hzmultlcan ( a b c : hz ) ( ne : neg ( c = 0 ) ) ( e : ( c * a ) = ( c * b ) ) : a = b .
 Proof . intros . apply ( intdomlcan hzintdom _ _ _ ne e ) . Defined .
 
-Lemma hzmultrcan ( a b c : hz ) ( ne : neg ( paths c 0 ) ) ( e : paths ( a * c ) ( b * c ) ) : paths a b .
+Lemma hzmultrcan ( a b c : hz ) ( ne : neg ( c = 0 ) ) ( e : ( a * c ) = ( b * c ) ) : a = b .
 Proof . intros . apply ( intdomrcan hzintdom _ _ _ ne e ) . Defined .
 
-Lemma isinclhzmultl ( n : hz )( ne : neg ( paths n 0 ) ) : isincl ( fun m : hz => n * m ) .
+Lemma isinclhzmultl ( n : hz )( ne : neg ( n = 0 ) ) : isincl ( fun m : hz => n * m ) .
 Proof.  intros .  apply ( pr1 ( intdomiscancelable hzintdom n ne ) ) . Defined .
 
-Lemma isinclhzmultr ( n : hz )( ne : neg ( paths n 0 ) ) : isincl ( fun m : hz => m * n ) .
+Lemma isinclhzmultr ( n : hz )( ne : neg ( n = 0 ) ) : isincl ( fun m : hz => m * n ) .
 Proof. intros . apply ( pr2 ( intdomiscancelable hzintdom n ne ) ) . Defined.
 
 
@@ -755,19 +755,19 @@ Proof. intros n m X . apply ( hzlehsntolth m n X ) .  Defined .
 (** *** Comparsion alternatives and [ n -> n + 1 ] *)
 
 
-Lemma hzlehchoice2 ( n m : hz ) : hzleh n m -> coprod ( hzleh ( n + 1 )  m ) ( paths n m ) .
+Lemma hzlehchoice2 ( n m : hz ) : hzleh n m -> coprod ( hzleh ( n + 1 )  m ) ( n = m ) .
 Proof . intros n m l . destruct ( hzlehchoice n m l ) as [ l' | e ] .   apply ( ii1 ( hzlthtolehsn _ _ l' ) ) . apply ( ii2 e ) .  Defined .
 
 
-Lemma hzgehchoice2 ( n m : hz ) : hzgeh n m -> coprod ( hzgeh n ( m + 1 ) ) ( paths n m ) .
+Lemma hzgehchoice2 ( n m : hz ) : hzgeh n m -> coprod ( hzgeh n ( m + 1 ) ) ( n = m ) .
 Proof . intros n m g . destruct ( hzgehchoice n m g ) as [ g' | e ] .   apply ( ii1 ( hzgthtogehsn _ _ g' ) ) . apply ( ii2 e ) . Defined .
 
 
-Lemma hzgthchoice2 ( n m : hz ) : hzgth n m -> coprod ( hzgth n ( m + 1 ) ) ( paths n ( m + 1 ) ) .
+Lemma hzgthchoice2 ( n m : hz ) : hzgth n m -> coprod ( hzgth n ( m + 1 ) ) ( n = ( m + 1 ) ) .
 Proof.  intros n m g . destruct ( hzgehchoice _ _ ( hzgthtogehsn _ _ g ) ) as [ g' | e ] . apply ( ii1 g' ) .  apply ( ii2 e ) .  Defined .
 
 
-Lemma hzlthchoice2 ( n m : hz ) : hzlth n m -> coprod ( hzlth ( n + 1 )  m ) ( paths ( n + 1 )  m ) .
+Lemma hzlthchoice2 ( n m : hz ) : hzlth n m -> coprod ( hzlth ( n + 1 )  m ) ( ( n + 1 ) = m ) .
 Proof.  intros n m l . destruct ( hzlehchoice _ _ ( hzlthtolehsn _ _ l ) ) as [ l' | e ] . apply ( ii1 l' ) .  apply ( ii2 e ) .   Defined .
 
 
@@ -790,11 +790,11 @@ Definition isinclnattohz : isincl nattohz := isincltorngdiff natcommrig ( fun n 
 
 Definition nattohzandneq ( n m : nat ) ( is : natnegpaths n m ) : hzneq ( nattohz n ) ( nattohz m ) := negf ( invmaponpathsincl _ isinclnattohz n m ) is .
 
-Definition nattohzand0 : paths ( nattohz 0%nat ) 0 := idpath _ .
+Definition nattohzand0 : ( nattohz 0%nat ) = 0 := idpath _ .
 
-Definition nattohzandS ( n : nat ) : paths ( nattohz ( S n ) ) ( 1 + nattohz n ) := isbinop1funtorngdiff natcommrig 1%nat n .
+Definition nattohzandS ( n : nat ) : ( nattohz ( S n ) ) = ( 1 + nattohz n ) := isbinop1funtorngdiff natcommrig 1%nat n .
 
-Definition nattohzand1 : paths ( nattohz 1%nat ) 1 := idpath _ .
+Definition nattohzand1 : ( nattohz 1%nat ) = 1 := idpath _ .
 
 Lemma nattorig_nattohz :
   Π n : nat, nattorig (X := hz) n = nattohz n.
@@ -806,14 +806,14 @@ Proof.
     apply pathsinv0, nattohzandS.
 Qed.
 
-Definition nattohzandplus ( n m : nat ) : paths ( nattohz ( n + m )%nat ) ( nattohz n + nattohz m ) := isbinop1funtorngdiff natcommrig n m .
+Definition nattohzandplus ( n m : nat ) : ( nattohz ( n + m )%nat ) = ( nattohz n + nattohz m ) := isbinop1funtorngdiff natcommrig n m .
 
-Definition nattohzandminus ( n m : nat ) ( is : natgeh n m ) : paths ( nattohz ( n - m )%nat ) ( nattohz n - nattohz m ) .
+Definition nattohzandminus ( n m : nat ) ( is : natgeh n m ) : ( nattohz ( n - m )%nat ) = ( nattohz n - nattohz m ) .
 Proof . intros .  apply ( hzplusrcan _ _ ( nattohz m ) ) . unfold hzminus .  rewrite ( hzplusassoc ( nattohz n ) ( - nattohz m ) ( nattohz m ) ) . rewrite ( hzlminus _ ) .   rewrite hzplusr0 .  rewrite ( pathsinv0 ( nattohzandplus _ _ ) ) .  rewrite ( minusplusnmm _ _ is ) . apply idpath . Defined .
 
 Opaque nattohzandminus .
 
-Definition nattohzandmult ( n m : nat ) : paths ( nattohz ( n * m )%nat ) ( nattohz n * nattohz m ) .
+Definition nattohzandmult ( n m : nat ) : ( nattohz ( n * m )%nat ) = ( nattohz n * nattohz m ) .
 Proof . intros . simpl . change nattohz with ( torngdiff natcommrig ) . apply ( isbinop2funtorngdiff natcommrig n m ) . Defined .
 
 Definition nattohzandgth ( n m : nat ) ( is : natgth n m ) : hzgth ( nattohz n ) ( nattohz m ) := iscomptorngdiff natcommrig isplushrelnatgth n m is .
@@ -892,11 +892,11 @@ Defined .
 
 Definition hzabsval : hz -> nat := setquotuniv _ natset hzabsvalint hzabsvalintcomp .
 
-Lemma hzabsval0 : paths ( hzabsval 0 ) 0%nat .
+Lemma hzabsval0 : ( hzabsval 0 ) = 0%nat .
 Proof .  apply idpath .  Defined .
 
-Lemma hzabsvalgth0 { x : hz } ( is : hzgth x 0 ) : paths ( nattohz ( hzabsval x ) ) x .
-Proof . assert ( int : Π x : hz , isaprop ( hzgth x 0 ->  paths ( nattohz ( hzabsval x ) ) x ) ) . intro . apply impred . intro . apply ( setproperty hz ) .  apply ( setquotunivprop _ ( fun x => hProppair _ ( int x ) ) ) . intros xa g . simpl in xa . assert ( g' := natnattohzandgth _ _ g ) . simpl in g' .  simpl .  change ( paths ( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) ( dirprodpair ( hzabsvalint xa ) 0%nat ) ) ( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) xa ) ) . apply weqpathsinsetquot . simpl . apply hinhpr . split with 0%nat .  change ( pr1 ( natgth ( pr1 xa + 0%nat ) ( pr2 xa ) ) ) in g' . rewrite ( natplusr0 _ ) in g' .  change ( paths  (hzabsvalint xa + pr2 xa + 0)%nat (pr1 xa + 0 + 0)%nat ) . rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) . unfold hzabsvalint .   destruct ( natgthorleh (pr1 xa) (pr2 xa)  ) as [ g'' | l ] .
+Lemma hzabsvalgth0 { x : hz } ( is : hzgth x 0 ) : ( nattohz ( hzabsval x ) ) = x .
+Proof . assert ( int : Π x : hz , isaprop ( hzgth x 0 -> ( nattohz ( hzabsval x ) ) = x ) ) . intro . apply impred . intro . apply ( setproperty hz ) .  apply ( setquotunivprop _ ( fun x => hProppair _ ( int x ) ) ) . intros xa g . simpl in xa . assert ( g' := natnattohzandgth _ _ g ) . simpl in g' .  simpl .  change (( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) ( dirprodpair ( hzabsvalint xa ) 0%nat ) ) = ( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) xa ) ) . apply weqpathsinsetquot . simpl . apply hinhpr . split with 0%nat .  change ( pr1 ( natgth ( pr1 xa + 0%nat ) ( pr2 xa ) ) ) in g' . rewrite ( natplusr0 _ ) in g' .  change ((hzabsvalint xa + pr2 xa + 0)%nat = (pr1 xa + 0 + 0)%nat ) . rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) . unfold hzabsvalint .   destruct ( natgthorleh (pr1 xa) (pr2 xa)  ) as [ g'' | l ] .
 
 rewrite ( minusplusnmm _ _ ( natlthtoleh _ _ g'' ) ) . apply idpath .
 
@@ -905,11 +905,11 @@ Defined .
 
 Opaque hzabsvalgth0 .
 
-Lemma hzabsvalgeh0 { x : hz } ( is : hzgeh x 0 ) : paths ( nattohz ( hzabsval x ) ) x .
+Lemma hzabsvalgeh0 { x : hz } ( is : hzgeh x 0 ) : ( nattohz ( hzabsval x ) ) = x .
 Proof .  intros . destruct ( hzgehchoice _ _ is ) as [ g | e ] .  apply ( hzabsvalgth0 g ) . rewrite e .  apply idpath .  Defined .
 
-Lemma hzabsvallth0 { x : hz } ( is : hzlth x 0 ) : paths ( nattohz ( hzabsval x ) ) ( - x ) .
-Proof . assert ( int : Π x : hz , isaprop ( hzlth x 0 ->  paths ( nattohz ( hzabsval x ) ) ( - x ) ) ) . intro . apply impred . intro . apply ( setproperty hz ) .  apply ( setquotunivprop _ ( fun x => hProppair _ ( int x ) ) ) . intros xa l . simpl in xa . assert ( l' := natnattohzandlth _ _ l ) . simpl in l' .  simpl .  change ( paths ( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) ( dirprodpair ( hzabsvalint xa ) 0%nat ) ) ( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) ( dirprodpair ( pr2 xa ) ( pr1 xa ) ) ) ) . apply weqpathsinsetquot . simpl . apply hinhpr . split with 0%nat .  change ( pr1 ( natlth ( pr1 xa + 0%nat ) ( pr2 xa ) ) ) in l' . rewrite ( natplusr0 _ ) in l' .  change ( paths  (hzabsvalint xa + pr1 xa + 0)%nat (pr2 xa + 0 + 0)%nat ) . rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) . unfold hzabsvalint .   destruct ( natgthorleh (pr1 xa) (pr2 xa)  ) as [ g | l'' ] .
+Lemma hzabsvallth0 { x : hz } ( is : hzlth x 0 ) : ( nattohz ( hzabsval x ) ) = ( - x ) .
+Proof . assert ( int : Π x : hz , isaprop ( hzlth x 0 -> ( nattohz ( hzabsval x ) ) = ( - x ) ) ) . intro . apply impred . intro . apply ( setproperty hz ) .  apply ( setquotunivprop _ ( fun x => hProppair _ ( int x ) ) ) . intros xa l . simpl in xa . assert ( l' := natnattohzandlth _ _ l ) . simpl in l' .  simpl .  change (( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) ( dirprodpair ( hzabsvalint xa ) 0%nat ) ) = ( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) ( dirprodpair ( pr2 xa ) ( pr1 xa ) ) ) ) . apply weqpathsinsetquot . simpl . apply hinhpr . split with 0%nat .  change ( pr1 ( natlth ( pr1 xa + 0%nat ) ( pr2 xa ) ) ) in l' . rewrite ( natplusr0 _ ) in l' .  change ((hzabsvalint xa + pr1 xa + 0)%nat = (pr2 xa + 0 + 0)%nat). rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) . unfold hzabsvalint .   destruct ( natgthorleh (pr1 xa) (pr2 xa)  ) as [ g | l'' ] .
 
 destruct ( isasymmnatgth _ _ g l' ) .
 
@@ -917,20 +917,20 @@ rewrite ( minusplusnmm _ _ l'' ) . apply idpath . Defined .
 
 Opaque hzabsvallth0 .
 
-Lemma hzabsvalleh0 { x : hz } ( is : hzleh x 0 ) : paths ( nattohz ( hzabsval x ) ) ( - x ) .
+Lemma hzabsvalleh0 { x : hz } ( is : hzleh x 0 ) : ( nattohz ( hzabsval x ) ) = ( - x ) .
 Proof .  intros . destruct ( hzlehchoice _ _ is ) as [ l | e ] .  apply ( hzabsvallth0 l ) . rewrite e .  apply idpath .  Defined .
 
 
-Lemma hzabsvaleq0 { x : hz } ( e :  paths ( hzabsval x ) 0%nat ) : paths x 0  .
+Lemma hzabsvaleq0 { x : hz } ( e : ( hzabsval x ) = 0%nat ) : x = 0  .
 Proof .  intros . destruct ( isdeceqhz x 0 ) as [ e0 | ne0 ] . apply e0 .  destruct ( hzneqchoice _ _ ne0 ) as [ g | l ] .
 
-assert ( e' := hzabsvalgth0 g ) . rewrite e in e' . change ( paths 0 x ) in e' .  apply ( pathsinv0 e' ) .
+assert ( e' := hzabsvalgth0 g ) . rewrite e in e' . change ( 0 = x ) in e' .  apply ( pathsinv0 e' ) .
 
-assert ( e' := hzabsvallth0 l ) . rewrite e in e' . change ( paths 0 ( - x ) ) in e' . assert ( g := hzlth0andminus l ) .  rewrite e' in g .  destruct ( isirreflhzgth _ g ) . Defined .
+assert ( e' := hzabsvallth0 l ) . rewrite e in e' . change ( 0 = ( - x ) ) in e' . assert ( g := hzlth0andminus l ) .  rewrite e' in g .  destruct ( isirreflhzgth _ g ) . Defined .
 
 Definition hzabsvalneq0 { x : hz } ne := neg_to_negProp (nP := natneq _ _) (negf ( @hzabsvaleq0 x ) ne).
 
-Lemma hzabsvalandmult ( a b : hz ) : paths ( ( hzabsval a ) * ( hzabsval b ) )%nat ( hzabsval ( a * b ) ) .
+Lemma hzabsvalandmult ( a b : hz ) : ( ( hzabsval a ) * ( hzabsval b ) )%nat = ( hzabsval ( a * b ) ) .
 Proof . intros . apply ( invmaponpathsincl _ isinclnattohz ) . rewrite ( nattohzandmult _ _ ) .  destruct ( hzgthorleh a 0 ) as [ ga | lea ] . destruct ( hzgthorleh b 0 ) as [ gb | leb ] .
 
 rewrite ( hzabsvalgth0 ga ) .  rewrite ( hzabsvalgth0 gb ) .  rewrite ( hzabsvalgth0 ( hzmultgth0gth0 ga gb ) ) . apply idpath .

--- a/UniMath/Foundations/NumberSystems/Integers.v
+++ b/UniMath/Foundations/NumberSystems/Integers.v
@@ -124,6 +124,12 @@ Proof . intros . apply ( @grlcan hzaddabgr a b c is ) .  Defined .
 Lemma hzplusrcan ( a b c : hz ) ( is : paths ( a + c ) ( b + c ) ) : paths a b .
 Proof . intros . apply ( @grrcan hzaddabgr a b c is ) .  Defined .
 
+Lemma hzplusladd (a b c : hz) (is : paths a b) : paths (a + c) (b + c).
+Proof. intros. induction is. apply idpath. Defined.
+
+Lemma hzplusradd (a b c : hz) (is : paths a b) : paths (c + a) (c + b).
+Proof. intros. apply maponpaths. apply is. Defined.
+
 Definition hzinvmaponpathsminus { a b : hz } ( e :  paths ( - a ) ( - b ) ) : paths a b := grinvmaponpathsinv hzaddabgr e .
 
 Lemma hzrplusminus (n m : hz) : n + m - m = n.

--- a/UniMath/Foundations/NumberSystems/Integers.v
+++ b/UniMath/Foundations/NumberSystems/Integers.v
@@ -124,10 +124,10 @@ Proof . intros . apply ( @grlcan hzaddabgr a b c is ) .  Defined .
 Lemma hzplusrcan ( a b c : hz ) ( is : paths ( a + c ) ( b + c ) ) : paths a b .
 Proof . intros . apply ( @grrcan hzaddabgr a b c is ) .  Defined .
 
-Lemma hzplusladd (a b c : hz) (is : paths a b) : paths (a + c) (b + c).
+Lemma hzplusradd (a b c : hz) (is : paths a b) : paths (a + c) (b + c).
 Proof. intros. induction is. apply idpath. Defined.
 
-Lemma hzplusradd (a b c : hz) (is : paths a b) : paths (c + a) (c + b).
+Lemma hzplusladd (a b c : hz) (is : paths a b) : paths (c + a) (c + b).
 Proof. intros. apply maponpaths. apply is. Defined.
 
 Definition hzinvmaponpathsminus { a b : hz } ( e :  paths ( - a ) ( - b ) ) : paths a b := grinvmaponpathsinv hzaddabgr e .

--- a/UniMath/Ktheory/Representation.v
+++ b/UniMath/Ktheory/Representation.v
@@ -1,13 +1,13 @@
 Require Import
-        UniMath.Ktheory.Tactics
-        UniMath.Ktheory.Precategories
-        UniMath.Ktheory.Bifunctor.
-Require Import
         UniMath.CategoryTheory.precategories
         UniMath.CategoryTheory.opp_precat
         UniMath.CategoryTheory.yoneda
         UniMath.CategoryTheory.functor_categories
         UniMath.CategoryTheory.category_hset.
+Require Import
+        UniMath.Ktheory.Tactics
+        UniMath.Ktheory.Precategories
+        UniMath.Ktheory.Bifunctor.
 Set Automatic Introduction.
 Local Open Scope cat.
 


### PR DESCRIPTION
This pull request contains the following changes
- Copied the changes in opp_precat.v from the Ktheory folder
- The new file limits/Opp.v contains translations of some special (co)limits in C to special
  (co)limits in C^op and vice versa.
- Opposite category of an abelian category is an abelian category, Abelian_opp, line 1559 in
  Abelian.v 
- Redefined kernels and cokernels so that they are independent of equalizers and coequalizers.
  In particular, one now uses is_Kernel and is_Cokernel instead of is_Equalizer and is_Coequalizer.
- Constructed translation functors in C(A) and K(A), see section translation_functor, line 2476 in
  Complexes.v.
- Constructed mapping cone and mapping cylinder in C(A), see sections mapping_cone, line 3573 in
  Complexes.v and mapping_cylinder, line 3829 in Complexes.v.
- Proved that for a morphism of complexes f : X -> Y, Y and Cyl(f) are isomorphic in K(A)
  (These are not isomorphic in general in C(A)!). See section mapping_cylinder_KA_iso, line 4058 in
  Complexes.v   
- Renamed PrecategoriesWithBinops to precategoriesWithBinops, made MMor a coercion in  Complexes.v,
  renamed CEq to DSq, and other fixes following suggestions of Vladimir.
- Proved that the translation functors C(A) -> C(A) and K(A) -> K(A) are isomorphisms. See
  `TranslationInvTranslation`, line 2957, `InvTranslationTranslation`, line 3008,
  `TranslationHInvTranslationH`, line 3477, `InvTranslationHTranslation`, line 3516, Complexes.v

To prove that the translation functors C(A) -> C(A), `TranslationFunctor` and
`InvTranslationFunctor`, are isomorphisms, I had to assume a new axiom. This axiom is
`transportf_funextfun`, line 90, functor_categories.v. The underlying reason why I need this axiom
is that I need to get the original pointwise equalities back from funextfun. I believe this
new axiom is not provable in UniMath because univalence, and hence funextfun, is not provable.
I think it should be provable in cubicaltt. (In experiments/uafunext1.ctt can one recover the
argument pe from funext? )

I don't know where to put the axiom `transportf_funextfun`. I think it should not be in
functor_categories.v and suggestions on where it should be, if it is accepted, are welcome.