### PR TITLE
Various results on the category of sets and slice categories

### DIFF
--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -83,6 +83,7 @@ Require Import UniMath.CategoryTheory.AdjunctionHomTypesWeq.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.RightKanExtension.
+Require Import UniMath.CategoryTheory.slicecat.
 
 Local Notation "# F" := (functor_on_morphisms F) (at level 3).
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -699,7 +699,7 @@ transparent assert (HHH : (cocone cAB (pr1 ab,, x))).
 { use mk_cocone.
   - simpl; intro n; split;
       [ apply (# (pr1_functor A B) (pr1 ccab n)) | apply (pr1 ccx n) ].
-  - abstract (simpl; intros m n e; rewrite (paireta (dmor cAB e)); apply pathsdirprod;
+  - abstract (simpl; intros m n e; rewrite (tppr (dmor cAB e)); apply pathsdirprod;
                 [ apply (maponpaths pr1 (pr2 ccab m n e)) | apply (pr2 ccx m n e) ]).
  }
 destruct (Hccab _ HHH) as [[[x1 x2] p1] p2].
@@ -750,7 +750,7 @@ simpl in *.
 mkpair.
 - apply (tpair _ (f,,g)).
   abstract (intro n; unfold precatbinprodmor, compose; simpl;
-            now rewrite hf1, hg1, (paireta (coconeIn ccxy n))).
+            now rewrite hf1, hg1, (tppr (coconeIn ccxy n))).
 - abstract (intro t; apply subtypeEquality; simpl;
              [ intro x; apply impred; intro; apply isaset_dirprod; [ apply hsC | apply hsD ]
              | induction t as [[f1 f2] p]; simpl in *; apply pathsdirprod;

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -48,6 +48,8 @@ This file also contains proofs that the following functors are (omega-)cocontinu
   [is_cocont_post_composition_functor] [is_omega_cocont_post_composition_functor]
 - Swapping of functor category arguments:
   [is_cocont_functor_cat_swap] [is_omega_cocont_functor_cat_swap]
+- The forgetful functor from Set/X to Set preserves colimits
+  ([preserves_colimit_slicecat_to_cat_HSET])
 
 Written by: Anders Mörtberg and Benedikt Ahrens, 2015-2016
 
@@ -1578,6 +1580,83 @@ Defined.
 
 End functor_swap.
 
+
+(** * The forgetful functor from Set/X to Set preserves colimits *)
+Section cocont_slicecat_to_cat_HSET.
+
+Local Notation "HSET / X" := (slice_precat HSET X has_homsets_HSET).
+
+Lemma preserves_colimit_slicecat_to_cat_HSET (X : HSET)
+  (g : graph) (d : diagram g (HSET / X)) (L : HSET / X) (ccL : cocone d L) :
+  preserves_colimit (slicecat_to_cat has_homsets_HSET X) d L ccL.
+Proof.
+intros HccL y ccy.
+set (CC := mk_ColimCocone _ _ _ HccL).
+transparent assert (c : (HSET / X)).
+{ mkpair.
+  - exists (Σ (x : pr1 X), pr1 y).
+    abstract (apply isaset_total2; intros; apply setproperty).
+  - apply pr1.
+}
+transparent assert (cc : (cocone d c)).
+{ use mk_cocone.
+  - intros n.
+    mkpair; simpl.
+    + intros z.
+      mkpair.
+      * apply (pr2 L), (pr1 (coconeIn ccL n) z).
+      * apply (coconeIn ccy n z).
+    + abstract (now apply funextsec; intro z;
+                apply (toforallpaths _ _ _ (pr2 (coconeIn ccL n)) z)).
+  - abstract (intros m n e; apply eq_mor_slicecat, funextsec; intro z;
+    use total2_paths;
+      [ apply (maponpaths _ (toforallpaths _ _ _
+                 (maponpaths pr1 (coconeInCommutes ccL m n e)) z))|];
+    cbn in *; induction (maponpaths _ _);
+    now rewrite idpath_transportf, <- (coconeInCommutes ccy m n e)).
+}
+use unique_exists.
+- intros l; apply (pr2 (pr1 (colimArrow CC c cc) l)).
+- simpl; intro n.
+  apply funextsec; intro x; cbn.
+  now etrans; [apply maponpaths,
+                 (toforallpaths _ _ _ (maponpaths pr1 (colimArrowCommutes CC c cc n)) x)|].
+- intros z; apply impred_isaprop; intro n; apply setproperty.
+- simpl; intros f Hf.
+apply funextsec; intro l.
+transparent assert (k : (HSET/X⟦colim CC,c⟧)).
+{ mkpair.
+  - intros l'.
+    exists (pr2 L l').
+    apply (f l').
+  - abstract (now apply funextsec).
+}
+assert (Hk : (Π n, colimIn CC n ;; k = coconeIn cc n)).
+{ intros n.
+  apply subtypeEquality; [intros x; apply setproperty|].
+  apply funextsec; intro z.
+  use total2_paths; [apply idpath|].
+  now rewrite idpath_transportf; cbn; rewrite <- (toforallpaths _ _ _ (Hf n) z).
+}
+apply (maponpaths dirprod_pr2
+         (toforallpaths _ _ _ (maponpaths pr1 (colimArrowUnique CC c cc k Hk)) l)).
+Defined.
+
+Lemma is_cocont_slicecat_to_cat_HSET (X : HSET) :
+  is_cocont (slicecat_to_cat has_homsets_HSET X).
+Proof.
+intros g d L cc.
+now apply preserves_colimit_slicecat_to_cat_HSET.
+Defined.
+
+Lemma is_omega_cocont_slicecat_to_cat (X : HSET) :
+  is_omega_cocont (slicecat_to_cat has_homsets_HSET X).
+Proof.
+intros d L cc.
+now apply preserves_colimit_slicecat_to_cat_HSET.
+Defined.
+
+End cocont_slicecat_to_cat_HSET.
 End cocont_functors.
 
 (** Specialized notations for HSET *)

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -1581,13 +1581,37 @@ Defined.
 
 End functor_swap.
 
-
 (** * The forgetful functor from Set/X to Set preserves colimits *)
 Section cocont_slicecat_to_cat_HSET.
 
 Local Notation "HSET / X" := (slice_precat HSET X has_homsets_HSET).
 
 Lemma preserves_colimit_slicecat_to_cat_HSET (X : HSET)
+  (g : graph) (d : diagram g (HSET / X)) (L : HSET / X) (ccL : cocone d L) :
+  preserves_colimit (slicecat_to_cat has_homsets_HSET X) d L ccL.
+Proof.
+apply left_adjoint_preserves_colimit.
+- apply is_left_adjoint_slicecat_to_cat_HSET.
+- apply has_homsets_slice_precat.
+- apply has_homsets_HSET.
+Defined.
+
+Lemma is_cocont_slicecat_to_cat_HSET (X : HSET) :
+  is_cocont (slicecat_to_cat has_homsets_HSET X).
+Proof.
+intros g d L cc.
+now apply preserves_colimit_slicecat_to_cat_HSET.
+Defined.
+
+Lemma is_omega_cocont_slicecat_to_cat (X : HSET) :
+  is_omega_cocont (slicecat_to_cat has_homsets_HSET X).
+Proof.
+intros d L cc.
+now apply preserves_colimit_slicecat_to_cat_HSET.
+Defined.
+
+(** Direct proof that the forgetful functor Set/X to Set preserves colimits *)
+Lemma preserves_colimit_slicecat_to_cat_HSET_direct (X : HSET)
   (g : graph) (d : diagram g (HSET / X)) (L : HSET / X) (ccL : cocone d L) :
   preserves_colimit (slicecat_to_cat has_homsets_HSET X) d L ccL.
 Proof.
@@ -1641,20 +1665,6 @@ assert (Hk : (Π n, colimIn CC n ;; k = coconeIn cc n)).
 }
 apply (maponpaths dirprod_pr2
          (toforallpaths _ _ _ (maponpaths pr1 (colimArrowUnique CC c cc k Hk)) l)).
-Defined.
-
-Lemma is_cocont_slicecat_to_cat_HSET (X : HSET) :
-  is_cocont (slicecat_to_cat has_homsets_HSET X).
-Proof.
-intros g d L cc.
-now apply preserves_colimit_slicecat_to_cat_HSET.
-Defined.
-
-Lemma is_omega_cocont_slicecat_to_cat (X : HSET) :
-  is_omega_cocont (slicecat_to_cat has_homsets_HSET X).
-Proof.
-intros d L cc.
-now apply preserves_colimit_slicecat_to_cat_HSET.
 Defined.
 
 End cocont_slicecat_to_cat_HSET.

--- a/UniMath/CategoryTheory/GrothendieckTopos.v
+++ b/UniMath/CategoryTheory/GrothendieckTopos.v
@@ -32,10 +32,10 @@ Require Import UniMath.CategoryTheory.equivalences.
 Section HSET_Structures.
 
   Definition HSET_Pullbacks : @limits.pullbacks.Pullbacks HSET :=
-    equiv_Pullbacks_2 HSET has_homsets_HSET PullbacksHSET.
+    equiv_Pullbacks_2 HSET has_homsets_HSET PullbacksHSET_from_Lims.
 
   Definition HSET_Equalizers: @limits.equalizers.Equalizers HSET :=
-    equiv_Equalizers2 HSET has_homsets_HSET EqualizersHSET.
+    equiv_Equalizers2 HSET has_homsets_HSET EqualizersHSET_from_Lims.
 
 End HSET_Structures.
 

--- a/UniMath/CategoryTheory/Inductives/Lists.v
+++ b/UniMath/CategoryTheory/Inductives/Lists.v
@@ -304,7 +304,7 @@ induction n as [|n IHn]; simpl.
 - rewrite foldr_nil.
   now destruct l.
 - rewrite foldr_cons; simpl.
-  now rewrite IHn; simpl; rewrite <- (paireta l).
+  now rewrite IHn; simpl; rewrite <- (tppr l).
 Qed.
 
 Lemma to_ListK (A : HSET) : Π y : List A, to_List A (to_list A y) = y.
@@ -372,7 +372,7 @@ simple refine (tpair _ _ _).
     apply HX.
   + cbn.
     destruct cc as [f hf]; simpl; intro n.
-    apply funextfun; intro p; rewrite (paireta p).
+    apply funextfun; intro p; rewrite (tppr p).
     assert (XR := colimArrowCommutes (mk_ColimCocone hF c L ccL) _ HX n).
     unfold flip, curry, colimIn in *; simpl in *.
     now rewrite <- (toforallpaths _ _ _ (toforallpaths _ _ _ XR (pr2 p)) (pr1 p)).

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -850,10 +850,27 @@ use mk_are_adjoints.
     apply (eq_mor_slicecat _ has_homsets_HSET).
     apply funextsec; intro x1.
     use total2_paths2.
-    * apply (toforallpaths _ _ _ (!pr2 w) x1).
+    * apply (!toforallpaths _ _ _ (pr2 w) x1).
     * apply funextsec; intro y.
-      simpl.
-      admit. (* stuck *)
+      cbn.
+apply subtypeEquality.
+intros x; apply setproperty.
+simpl.
+apply subtypeEquality.
+intros x.
+apply setproperty.
+simpl.
+destruct y as [y1 y2].
+simpl in *.
+destruct w as [w Hw].
+simpl in *.
+destruct f as [f Hf].
+destruct g as [g Hg].
+destruct h as [h Hh].
+simpl in *.
+
+induction (! toforallpaths (λ _ : g, X) Hg (λ x : g, Hh (w x)) Hw x1).
+apply idpath.
 - admit.
 - admit.
 Admitted.

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -11,6 +11,7 @@ Contents:
 - Limits ([LimsHSET])
 - Binary products ([BinProductsHSET])
 - General indexed products ([ProductsHSET]
+- Pullbacks ([PullbacksHSET])
 - Terminal object ([TerminalHSET])
 - Exponentials ([has_exponentials_HSET])
 - Construction of exponentials for functors into HSET ([has_exponentials_functor_HSET])
@@ -189,7 +190,7 @@ End from_colim.
 
 Definition colimCoconeHSET : cocone D colimHSET.
 Proof.
-simple refine (mk_cocone _ _).
+use mk_cocone.
 - now apply injections.
 - abstract (intros u v e;
             apply funextfun; intros Fi; simpl;
@@ -238,14 +239,14 @@ Defined.
 Lemma BinCoproductsHSET : BinCoproducts HSET.
 Proof.
 intros A B.
-simple refine (mk_BinCoproductCocone _ _ _ _ _ _ _).
+use mk_BinCoproductCocone.
 - simpl in *; apply (tpair _ (coprod A B)).
   abstract (apply isasetcoprod; apply setproperty).
 - simpl in *; apply ii1.
 - simpl in *; intros x; apply (ii2 x).
 - apply (mk_isBinCoproductCocone _ has_homsets_HSET).
   intros C f g; simpl in *.
-  simple refine (tpair _ _ _).
+  mkpair.
   * apply (tpair _ (sumofmaps f g)); abstract (split; apply idpath).
   * abstract (intros h; apply subtypeEquality;
     [ intros x; apply isapropdirprod; apply has_homsets_HSET
@@ -255,10 +256,10 @@ simple refine (mk_BinCoproductCocone _ _ _ _ _ _ _).
                case x; intros; apply idpath]).
 Defined.
 
-Lemma Coproducts_HSET (I : UU) (HI : isaset I) : Coproducts I HSET.
+Lemma CoproductsHSET (I : UU) (HI : isaset I) : Coproducts I HSET.
 Proof.
 intros A.
-simple refine (mk_CoproductCocone _ _ _ _ _ _).
+use mk_CoproductCocone.
 - mkpair.
   + apply (Σ i, pr1 (A i)).
   + eapply (isaset_total2 _ HI); intro i; apply setproperty.
@@ -288,7 +289,7 @@ Lemma InitialHSET : Initial HSET.
 Proof.
 apply (mk_Initial emptyHSET).
 apply mk_isInitial; intro a.
-simple refine (tpair _ _ _).
+mkpair.
 - simpl; intro e; induction e.
 - abstract (intro f; apply funextfun; intro e; induction e).
 Defined.
@@ -324,7 +325,7 @@ Defined.
 
 Lemma LimConeHSET : LimCone D.
 Proof.
-simple refine (mk_LimCone _ _ _ _ ).
+use mk_LimCone.
 - apply limset.
 - apply (tpair _ (fun u f => pr1 f u)).
   abstract (intros u v e; simpl; apply funextfun; intro f; simpl; apply (pr2 f)).
@@ -377,7 +378,7 @@ Defined.
 
 Lemma cats_LimConeHSET : cats.limits.LimCone D.
 Proof.
-simple refine (mk_LimCone _ _ _ _ ).
+use mk_LimCone.
 - apply cats_limset.
 - apply (tpair _ (fun u f => pr1 f u)).
   abstract (intros u v e; apply funextfun; intro f; apply (pr2 f)).
@@ -408,18 +409,18 @@ Defined.
 
 (** end of alternative def *)
 
-(* Direct construction of binary products in HSET *)
+(** Direct construction of binary products in HSET *)
 Lemma BinProductsHSET : BinProducts HSET.
 Proof.
 intros A B.
-simple refine (mk_BinProductCone _ _ _ _ _ _ _).
+use mk_BinProductCone.
 - simpl in *; apply (tpair _ (dirprod A B)).
   abstract (apply isasetdirprod; apply setproperty).
 - simpl in *; apply pr1.
 - simpl in *; intros x; apply (pr2 x).
 - apply (mk_isBinProductCone _ has_homsets_HSET).
   intros C f g; simpl in *.
-  simple refine (tpair _ _ _).
+  mkpair.
   * apply (tpair _ (prodtofuntoprod (f ,, g))); abstract (split; apply idpath).
   * abstract (intros h; apply subtypeEquality;
     [ intros x; apply isapropdirprod; apply has_homsets_HSET
@@ -429,10 +430,10 @@ simple refine (mk_BinProductCone _ _ _ _ _ _ _).
                now case (t x)]).
 Defined.
 
-Lemma Products_HSET (I : UU) : Products I HSET.
+Lemma ProductsHSET (I : UU) : Products I HSET.
 Proof.
 intros A.
-simple refine (mk_ProductCone _ _ _ _ _ _).
+use mk_ProductCone.
 - apply (tpair _ (Π i, pr1 (A i))); apply isaset_forall_hSet.
 - simpl; intros i f; apply (f i).
 - apply (mk_isProductCone _ _ has_homsets_HSET).
@@ -475,12 +476,34 @@ Defined.
 
 End TerminalHSET_from_Lims.
 
+Lemma PullbacksHSET : Pullbacks HSET.
+Proof.
+intros A B C f g.
+use mk_Pullback.
++ simpl in *.
+  exists (Σ (xy : B × C), f (pr1 xy) = g (pr2 xy)).
+  abstract (apply isaset_total2; [ apply isasetdirprod; apply setproperty
+                                 | intros xy; apply isasetaprop, setproperty ]).
++ intros xy; apply (pr1 (pr1 xy)).
++ intros xy; apply (pr2 (pr1 xy)).
++ abstract (apply funextsec; intros [[x y] Hxy]; apply Hxy).
++ use mk_isPullback.
+  intros X f1 f2 Hf12; cbn.
+  use unique_exists.
+  - intros x.
+    exists (f1 x,,f2 x); abstract (apply (toforallpaths _ _ _ Hf12)).
+  - abstract (now split).
+  - abstract (now intros h; apply isapropdirprod; apply has_homsets_HSET).
+  - abstract (intros h [H1 H2]; apply funextsec; intro x;
+    apply subtypeEquality; [intros H; apply setproperty|]; simpl;
+    now rewrite <- (toforallpaths _ _ _ H1 x), <- (toforallpaths _ _ _ H2 x), <- tppr).
+Defined.
 
 Section PullbacksHSET_from_Lims.
 
   Require UniMath.CategoryTheory.limits.graphs.pullbacks.
 
-  Lemma PullbacksHSET : graphs.pullbacks.Pullbacks HSET.
+  Lemma PullbacksHSET_from_Lims : graphs.pullbacks.Pullbacks HSET.
   Proof.
     apply (graphs.pullbacks.Pullbacks_from_Lims HSET LimsHSET).
   Defined.
@@ -491,7 +514,7 @@ Section EqualizersHSET_from_Lims.
 
   Require UniMath.CategoryTheory.limits.graphs.equalizers.
 
-  Lemma EqualizersHSET : graphs.equalizers.Equalizers HSET.
+  Lemma EqualizersHSET_from_Lims : graphs.equalizers.Equalizers HSET.
   Proof.
     apply (graphs.equalizers.Equalizers_from_Lims HSET LimsHSET).
   Defined.
@@ -513,11 +536,6 @@ Defined.
 
 Definition flip {A B C : UU} (f : A -> B -> C) : B -> A -> C := fun x y => f y x.
 
-Lemma paireta {A B : UU} (p : A × B) : p = (pr1 p,, pr2 p).
-Proof.
-destruct p; apply idpath.
-Defined.
-
 (* This checks that if we use constprod_functor2 the flip is not necessary *)
 Lemma are_adjoints_constprod_functor2 A :
   are_adjoints (constprod_functor2 BinProductsHSET A) (exponential_functor A).
@@ -531,7 +549,7 @@ mkpair.
     * intros X fx; apply (pr1 fx (pr2 fx)).
     * abstract (intros x y f; apply idpath).
 - abstract (mkpair;
-  [ intro x; simpl; apply funextfun; intro ax; now rewrite (paireta ax)
+  [ intro x; simpl; apply funextfun; intro ax; now rewrite (tppr ax)
   | intro b; apply funextfun; intro f; apply idpath]).
 Defined.
 
@@ -548,7 +566,7 @@ mkpair.
     * intros x xf; simpl in *; apply (pr2 xf (pr1 xf)).
     * abstract (intros x y f; apply idpath).
 - abstract (mkpair;
-  [ now intro x; simpl; apply funextfun; intro ax; rewrite (paireta ax)
+  [ now intro x; simpl; apply funextfun; intro ax; rewrite (tppr ax)
   | now intro b; apply funextfun; intro f]).
 Defined.
 
@@ -595,12 +613,12 @@ mkpair.
 Defined.
 
 Local Definition eval (P Q : functor C HSET) :
- nat_trans (BinProductObject _ (CP P (exponential_functor_cat P Q)) : functor _ _) Q.
+  nat_trans (BinProductObject _ (CP P (exponential_functor_cat P Q)) : functor _ _) Q.
 Proof.
 mkpair.
 - intros c ytheta; set (y := pr1 ytheta); set (theta := pr2 ytheta);
   simpl in *.
-  simple refine (theta c _).
+  use (theta c).
   exact (identity c,,y).
 - abstract (
     intros c c' f; simpl;

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -19,6 +19,8 @@ Contents:
 - Locally cartesian closed ([Terminal_HSET_slice],
   [BinProducts_HSET_slice] and [has_exponentials_HSET_slice])
 - Products in Set/X ([Products_HSET_slice])
+- Forgetful functor Set/X to Set is left adjoint
+  ([is_left_adjoint_slicecat_to_cat])
 
 Written by: Benedikt Ahrens, Anders Mörtberg
 
@@ -699,8 +701,8 @@ Qed.
 
 End exponentials_functor_cat.
 
-(** * Set is locally cartesian closed *)
-Section locally_CCC.
+(** * Various results on Set/X *)
+Section set_slicecat.
 
 Local Notation "HSET / X" := (slice_precat HSET X has_homsets_HSET).
 
@@ -809,12 +811,8 @@ use mk_are_adjoints.
     now apply subtypeEquality; [intro z; apply setproperty|]; simpl; rewrite <- tppr.
 Defined.
 
-End locally_CCC.
-
 (** * Products in Set/X *)
 Section products_set_slice.
-
-Local Notation "HSET / X" := (slice_precat HSET X has_homsets_HSET).
 
 (* The following is an experiment which computes what the product in Set/X
    should be from the one in [X,Set] using the equivalence between Set/X
@@ -866,3 +864,53 @@ use mk_ProductCone.
 Defined.
 
 End products_set_slice.
+
+Lemma is_left_adjoint_slicecat_to_cat_HSET (X : HSET) :
+  is_left_adjoint (slicecat_to_cat has_homsets_HSET X).
+Proof.
+mkpair.
+- use mk_functor.
+  + mkpair.
+    * intro Y. {
+      mkpair.
+      - exists (Σ (x : pr1 X), pr1 Y).
+        abstract (now apply isaset_total2; intros; apply setproperty).
+      - apply pr1.
+      }
+    * intros A B f. {
+      mkpair.
+      - simpl; intros H.
+        exists (pr1 H).
+        apply (f (pr2 H)).
+      - abstract (now apply funextsec).
+      }
+  + abstract (split;
+    [ intros A; simpl; apply subtypeEquality; [intros x; apply setproperty|];
+      now apply funextsec; intros [x a]
+    | intros A B C f g; apply subtypeEquality; [intros x; apply setproperty|];
+      now apply funextsec; intros [x a]]).
+- use mk_are_adjoints.
+  + use mk_nat_trans.
+    * simpl; intros F. {
+      mkpair.
+      - simpl; intro f.
+        mkpair.
+        + apply (pr2 F f).
+        + apply f.
+      - abstract (now apply funextsec).
+      }
+    * abstract (intros Y Z F; apply (eq_mor_slicecat has_homsets_HSET);
+                apply funextsec; intro y;
+                use total2_paths2; [apply (toforallpaths _ _ _ (!pr2 F) y)|];
+                cbn in *; induction (toforallpaths _ _ _ _ _);
+                now rewrite idpath_transportf).
+  + use mk_nat_trans.
+    * intros Y xy; apply (pr2 xy).
+    * now intros Y Z f.
+  + split.
+    * now intros.
+    * intros Y; apply eq_mor_slicecat; simpl.
+      now apply funextsec; intros f; cbn; rewrite tppr.
+Defined.
+
+End set_slicecat.

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -16,6 +16,8 @@ Contents:
 - Exponentials ([has_exponentials_HSET])
 - Construction of exponentials for functors into HSET
   ([has_exponentials_functor_HSET])
+- Locally cartesian closed ([Terminal_HSET_slice],
+  [BinProducts_HSET_slice] and [has_exponentials_HSET_slice])
 
 Written by: Benedikt Ahrens, Anders Mörtberg
 
@@ -44,8 +46,6 @@ Require Import UniMath.CategoryTheory.equivalences.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.covyoneda.
 Require Import UniMath.CategoryTheory.slicecat.
-Require Import UniMath.CategoryTheory.DiscretePrecategory.
-Require Import UniMath.CategoryTheory.set_slice_fam_equiv.
 
 Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
@@ -720,81 +720,19 @@ Proof.
 now apply BinProducts_slice_precat, PullbacksHSET.
 Defined.
 
+(** Direct proof that HSET/X has exponentials using explicit formula in example 2.2 of:
 
-(* Try to prove that Set/X has exponentials it using the equivalence to [X,Set] *)
-Section via_equivalence.
-
-Context (X : HSET).
-
-Let discreteX : precategory := discrete_precategory (pr1 X).
-Local Lemma has_homsets_discreteX : has_homsets discreteX.
-Proof.
-now apply has_homsets_discrete_precategory, hlevelntosn, setproperty.
-Qed.
-
-Local Notation "'[X,HSET]'" := ([discreteX, HSET, has_homsets_HSET]).
-Local Lemma has_homsets_XHSET : has_homsets [X,HSET].
-Proof.
-apply functor_category_has_homsets.
-Qed.
-
-Let F : functor [X,HSET] (HSET / X) := fam_to_slice X.
-Let α : adj_equivalence_of_precats F := set_slice_fam_equiv X.
-Let Finv : functor (HSET / X) [X,HSET] := adj_equivalence_inv α.
-Let eta := unit_iso_from_adj_equivalence_of_precats has_homsets_XHSET α.
-Let eps := counit_iso_from_adj_equivalence_of_precats (has_homsets_slice_precat _ _ X) α.
-(* Let eta' := unit_pointwise_iso_from_adj_equivalence α. *)
-(* Let eps' := counit_pointwise_iso_from_adj_equivalence α. *)
-
-Local Lemma BinProducts_XHSET : BinProducts [X,HSET].
-Proof.
-apply BinProducts_functor_precat, BinProductsHSET.
-Defined.
-
-Lemma has_exponentials_XHSET : has_exponentials BinProducts_XHSET.
-Proof.
-apply has_exponentials_functor_HSET, has_homsets_discreteX.
-Defined.
-
-Lemma has_exponentials_HSET_slice_via_equiv : has_exponentials (BinProducts_HSET_slice X).
-Proof.
-intros Y.
-set (H := has_exponentials_XHSET (Finv Y)).
-set (H1:= pr1 H).
-set (eta1 := pr1 (pr1 (pr2 H))).
-exists (functor_composite (functor_composite Finv H1) F).
-use mk_are_adjoints.
-- admit.
-- admit.
-- admit.
-Admitted.
-
-End via_equivalence.
-
-(* This is now hfiber_hSet *)
-Definition hfiber_HSET {X Y} (f : HSET⟦X,Y⟧) (y : pr1 Y) : HSET.
-Proof.
-mkpair.
-+ apply (hfiber f y).
-+ abstract (now apply isaset_hfiber; apply setproperty).
-Defined.
+    https://ncatlab.org/nlab/show/locally+cartesian+closed+category#in_category_theory
+*)
 
 Definition hfiber_fun (X : HSET) (f : HSET / X) : HSET / X → HSET / X.
 Proof.
 intros g.
 mkpair.
-- exists (Σ x, HSET⟦hfiber_HSET (pr2 f) x,hfiber_HSET (pr2 g) x⟧).
+- exists (Σ x, HSET⟦hfiber_hSet (pr2 f) x,hfiber_hSet (pr2 g) x⟧).
   abstract (apply isaset_total2; [ apply setproperty | intros x; apply has_homsets_HSET ]).
 - now apply pr1.
 Defined.
-
-Lemma PullbackArrowUnique' {C : precategory} {a b c : C} (f : C⟦b,a⟧) (g : C⟦c,a⟧)
-      (P : Pullback f g) e (h : C⟦e,b⟧) (k : C⟦e,c⟧)
-      (Hcomm : h ;; f = k ;; g) (w : C⟦e,P⟧) (H1 : w ;; PullbackPr1 P = h) (H2 : w ;; PullbackPr2 P = k) :
-  w = PullbackArrow P e h k Hcomm.
-Proof.
-now apply PullbackArrowUnique.
-Qed.
 
 Definition hfiber_functor (X : HSET) (f : HSET / X) :
   functor (HSET / X) (HSET / X).
@@ -813,129 +751,68 @@ use mk_functor.
                   apply (pr2 (pr2 h fx))).
     - abstract (now apply funextsec).
     }
-+ abstract (split;
-            [ intros x; apply (eq_mor_slicecat _ has_homsets_HSET); simpl;
-              apply funextsec; intro y; simpl;
-              destruct y as [y hy]; use total2_paths; [ apply idpath |];
-              apply funextsec; intros w; apply subtypeEquality; [|apply idpath];
-              now intros XX; apply setproperty
-            | intros x y z g h; apply (eq_mor_slicecat _ has_homsets_HSET); simpl;
-              apply funextsec; intro w; simpl;
-              destruct w as [w hw];
-              use total2_paths; [ apply idpath |];
-              apply funextsec; intros w'; apply subtypeEquality; [|apply idpath];
-              now intros XX; apply setproperty ]).
++ split.
+  - intros x; apply (eq_mor_slicecat _ has_homsets_HSET); simpl.
+    apply funextsec; intros [y hy].
+    use total2_paths; [ apply idpath |].
+    apply funextsec; intros w; apply subtypeEquality; [|apply idpath].
+    now intros XX; apply setproperty.
+  - intros x y z g h; apply (eq_mor_slicecat _ has_homsets_HSET); simpl.
+    apply funextsec; intros [w hw].
+    use total2_paths; [ apply idpath |].
+    apply funextsec; intros w'.
+    apply subtypeEquality; [|apply idpath].
+    now intros XX; apply setproperty.
 Defined.
 
-(* Attempted direct proof using explicit formula in example 2.2 of:
-    https://ncatlab.org/nlab/show/locally+cartesian+closed+category#in_category_theory
-*)
-Lemma has_exponentials_HSET_slice_direct (X : HSET) :
-  has_exponentials (BinProducts_HSET_slice X).
+Local Definition eta X (f : HSET / X) :
+  nat_trans (functor_identity (HSET / X))
+            (functor_composite (constprod_functor1 (BinProducts_HSET_slice X) f) (hfiber_functor X f)).
+Proof.
+use mk_nat_trans.
++ intros g; simpl.
+  mkpair.
+  * intros y; simpl.
+    exists (pr2 g y); intros fgy.
+    exists ((pr1 fgy,,y),,(pr2 fgy)).
+    abstract (now apply (pr2 fgy)).
+  * abstract (now apply funextsec).
++ intros [g Hg] [h Hh] [w Hw].
+  apply (eq_mor_slicecat _ has_homsets_HSET), funextsec; intro x1.
+  apply (total2_paths2 (!toforallpaths _ _ _ Hw x1)), funextsec; intro y.
+  repeat (apply subtypeEquality; [intros x; apply setproperty|]); cbn in *.
+  now induction (! toforallpaths _ _ (λ x : g, Hh (w x)) _ _).
+Defined.
+
+Local Definition eps X (f : HSET / X) :
+  nat_trans (functor_composite (hfiber_functor X f) (constprod_functor1 (BinProducts_HSET_slice X) f))
+            (functor_identity (HSET / X)).
+Proof.
+use mk_nat_trans.
++ intros g; simpl.
+  mkpair.
+  * intros H; apply (pr1 ((pr2 (pr2 (pr1 H))) (pr1 (pr1 H),,pr2 H))).
+  * abstract (apply funextsec; intros [[x1 [x2 x3]] x4]; simpl in *;
+              now rewrite (pr2 (x3 (x1,,x4))), x4).
++ intros g h w; simpl.
+  apply (eq_mor_slicecat _ has_homsets_HSET), funextsec; intro x1; cbn.
+  now repeat apply maponpaths; apply setproperty.
+Defined.
+
+Lemma has_exponentials_HSET_slice (X : HSET) : has_exponentials (BinProducts_HSET_slice X).
 Proof.
 intros f.
 exists (hfiber_functor _ f).
 use mk_are_adjoints.
-- use mk_nat_trans.
-  + intros g.
-    simpl.
-    mkpair.
-    * intros y. simpl.
-      exists (pr2 g y).
-      intros fgy.
-      exists ((pr1 fgy,,y),,(pr2 fgy)).
-      apply (pr2 fgy).
-    * abstract (now apply funextsec).
-  + intros g h w.
-    apply (eq_mor_slicecat _ has_homsets_HSET).
-    apply funextsec; intro x1.
-    use total2_paths2.
-    * apply (!toforallpaths _ _ _ (pr2 w) x1).
-    * apply funextsec; intro y.
-      cbn.
-apply subtypeEquality.
-intros x; apply setproperty.
-simpl.
-apply subtypeEquality.
-intros x.
-apply setproperty.
-simpl.
-destruct y as [y1 y2].
-simpl in *.
-destruct w as [w Hw].
-simpl in *.
-destruct f as [f Hf].
-destruct g as [g Hg].
-destruct h as [h Hh].
-simpl in *.
-
-induction (! toforallpaths (λ _ : g, X) Hg (λ x : g, Hh (w x)) Hw x1).
-apply idpath.
-- admit.
-- admit.
-Admitted.
-
-
-(* Attempted proof using proposition 2.1 from:
-     https://ncatlab.org/nlab/show/locally+cartesian+closed+category#in_category_theory
-*)
-Definition product_hfiber_slice
-  C C' (g : HSET ⟦C,C'⟧) (f : HSET / C) : HSET / C'.
-Proof.
-exists (total2_hSet (λ (c' : pr1 C'), forall_hSet (λ (c : Σ (c : pr1 C), g c = c'), hfiber_hSet (pr2 f) (pr1 c)))).
-simpl; apply pr1.
+- apply eta.
+- apply eps.
+- split.
+  + intros x; apply eq_mor_slicecat, funextsec; intro x1.
+    now apply subtypeEquality; [intro y; apply setproperty|]; rewrite tppr.
+  + intros x; apply eq_mor_slicecat, funextsec; intro x1; simpl.
+    use total2_paths; [apply idpath|]; cbn.
+    apply funextsec; intro y.
+    now apply subtypeEquality; [intro z; apply setproperty|]; simpl; rewrite <- tppr.
 Defined.
-
-Lemma has_exponentials_HSET_slice : Π X, has_exponentials (BinProducts_HSET_slice X).
-Proof.
-use dependent_product_to_exponentials.
-intros C C' g.
-mkpair.
-- use mk_functor.
-  + mkpair.
-    * intros f.
-      apply (product_hfiber_slice C C' g f).
-    * simpl; intros x y f. {
-      mkpair.
-      - intros Hc'.
-        exists (pr1 Hc').
-        intros p.
-        exists (pr1 f (pr1 (pr2 Hc' p))).
-        abstract (now rewrite <- (pr2 (pr2 Hc' p));
-                      apply (toforallpaths _ _ _ (!pr2 f))).
-      - abstract (now apply funextfun; intro z).
-      }
-  + abstract (split;
-      [ intros x; simpl; apply subtypeEquality; [ intros ?; apply has_homsets_HSET|]; simpl;
-        apply funextfun; intros [c' Hc']; apply (total2_paths2 (idpath _));
-        rewrite idpath_transportf; apply funextsec; intro y;
-        now apply subtypeEquality; [ intros ?; apply setproperty| apply idpath]
-      | intros x y z f1 f2; simpl; apply subtypeEquality; [ intros ?; apply has_homsets_HSET|]; simpl;
-        apply funextfun; intros [c' Hc']; apply (total2_paths2 (idpath _));
-        rewrite idpath_transportf; apply funextsec; intro H;
-        now apply subtypeEquality; [ intros xx; apply setproperty| apply idpath]]).
-- use mk_are_adjoints.
-  + use mk_nat_trans.
-    * intros X; cbn. {
-      mkpair.
-      + simpl; intros x.
-        exists (pr2 X x).
-        intros H.
-        mkpair.
-        * exists (pr1 H,,x).
-          abstract (apply (pr2 H)).
-        * abstract (apply idpath).
-      + abstract (apply idpath).
-      }
-    * intros x y f.
-      apply eq_mor_slicecat.
-      apply funextsec; intro w.
-      use total2_paths2.
-      apply (!(toforallpaths _ _ _ (pr2 f) w)).
-      apply funextsec; intros w2.
-      admit. (* stuck again *)
-+ admit.
-+ admit.
-Admitted.
 
 End locally_CCC.

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -745,12 +745,12 @@ use mk_functor.
     - abstract (now apply funextsec).
     }
 + split.
-  - intros x; apply (eq_mor_slicecat _ has_homsets_HSET); simpl.
+  - intros x; apply (eq_mor_slicecat has_homsets_HSET); simpl.
     apply funextsec; intros [y hy].
     use total2_paths; [ apply idpath |].
     apply funextsec; intros w; apply subtypeEquality; [|apply idpath].
     now intros XX; apply setproperty.
-  - intros x y z g h; apply (eq_mor_slicecat _ has_homsets_HSET); simpl.
+  - intros x y z g h; apply (eq_mor_slicecat has_homsets_HSET); simpl.
     apply funextsec; intros [w hw].
     use total2_paths; [ apply idpath |].
     apply funextsec; intros w'.
@@ -771,7 +771,7 @@ use mk_nat_trans.
     abstract (now apply (pr2 fgy)).
   * abstract (now apply funextsec).
 + intros [g Hg] [h Hh] [w Hw].
-  apply (eq_mor_slicecat _ has_homsets_HSET), funextsec; intro x1.
+  apply (eq_mor_slicecat has_homsets_HSET), funextsec; intro x1.
   apply (total2_paths2 (!toforallpaths _ _ _ Hw x1)), funextsec; intro y.
   repeat (apply subtypeEquality; [intros x; apply setproperty|]); cbn in *.
   now induction (! toforallpaths _ _ (λ x : g, Hh (w x)) _ _).
@@ -788,7 +788,7 @@ use mk_nat_trans.
   * abstract (apply funextsec; intros [[x1 [x2 x3]] x4]; simpl in *;
               now rewrite (pr2 (x3 (x1,,x4))), x4).
 + intros g h w; simpl.
-  apply (eq_mor_slicecat _ has_homsets_HSET), funextsec; intro x1; cbn.
+  apply (eq_mor_slicecat has_homsets_HSET), funextsec; intro x1; cbn.
   now repeat apply maponpaths; apply setproperty.
 Defined.
 

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -14,7 +14,8 @@ Contents:
 - Pullbacks ([PullbacksHSET])
 - Terminal object ([TerminalHSET])
 - Exponentials ([has_exponentials_HSET])
-- Construction of exponentials for functors into HSET ([has_exponentials_functor_HSET])
+- Construction of exponentials for functors into HSET
+  ([has_exponentials_functor_HSET])
 
 Written by: Benedikt Ahrens, Anders Mörtberg
 
@@ -42,6 +43,7 @@ Require Import UniMath.CategoryTheory.opp_precat.
 Require Import UniMath.CategoryTheory.equivalences.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.covyoneda.
+Require Import UniMath.CategoryTheory.slicecat.
 
 Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
@@ -695,3 +697,94 @@ use left_adjoint_from_partial.
 Qed.
 
 End exponentials_functor_cat.
+
+(** * Set is locally cartesian closed *)
+Section locally_CCC.
+
+Local Notation "HSET / X" := (slice_precat HSET X has_homsets_HSET).
+
+Lemma Terminal_HSET_slice (X : HSET) : Terminal (HSET / X).
+Proof.
+now apply Terminal_slice_precat.
+Defined.
+
+Lemma BinProducts_HSET_slice (X : HSET) : BinProducts (HSET / X).
+Proof.
+now apply BinProducts_slice_precat, PullbacksHSET.
+Defined.
+
+Definition hfiber_HSET {X Y} (f : HSET⟦X,Y⟧) (y : pr1 Y) : HSET.
+Proof.
+mkpair.
++ apply (hfiber f y).
++ abstract (now apply isaset_hfiber; apply setproperty).
+Defined.
+
+Lemma has_exponentials_HSET_slice (X : HSET) : has_exponentials (BinProducts_HSET_slice X).
+Proof.
+intros f.
+mkpair.
+- mkpair.
+  + mkpair.
+    * intros g.
+      { mkpair.
+      - exists (Σ x, HSET⟦hfiber_HSET (pr2 f) x,hfiber_HSET (pr2 g) x⟧).
+        abstract (apply isaset_total2; [ apply setproperty | intros x; apply has_homsets_HSET ]).
+      - now apply pr1. }
+    * simpl; intros a b g.
+      { mkpair; simpl.
+      - intros h.
+        mkpair.
+        + apply (pr1 h).
+        + intros fx.
+          mkpair.
+          * apply (pr1 g), (pr1 (pr2 h fx)).
+          * abstract (etrans; [ apply (!toforallpaths _ _ _ (pr2 g) (pr1 (pr2 h fx)))|];
+                      apply (pr2 (pr2 h fx))).
+      - abstract (now apply funextsec).
+      }
+  + abstract (split;
+    [ intros x; apply (eq_mor_slicecat _ has_homsets_HSET); simpl;
+      apply funextsec; intro y; simpl;
+      destruct y as [y hy]; use total2_paths; [ apply idpath |];
+      apply funextsec; intros w; apply subtypeEquality; [|apply idpath];
+      now intros XX; apply setproperty
+    | intros x y z g h; apply (eq_mor_slicecat _ has_homsets_HSET); simpl;
+      apply funextsec; intro w; simpl;
+      destruct w as [w hw];
+      use total2_paths; [ apply idpath |];
+      apply funextsec; intros w'; apply subtypeEquality; [|apply idpath];
+      now intros XX; apply setproperty ]).
+- simpl.
+  mkpair.
+  + split.
+    * { mkpair.
+        - intros g.
+          cbn.
+          mkpair.
+          + simpl.
+            intros y.
+            mkpair.
+            * apply (pr2 g y).
+            * intros fgy.
+              mkpair.
+              exists (pr1 fgy,,y).
+              apply (pr2 fgy).
+              apply (pr2 fgy).
+          + now apply funextsec.
+        - intros g h w; apply (eq_mor_slicecat _ has_homsets_HSET); simpl.
+          apply funextsec; intro x.
+          use total2_paths; simpl.
+          apply (!toforallpaths _ _ _ (pr2 w) x).
+          apply funextsec; intros y.
+          apply subtypeEquality.
+          intros xx.
+          apply setproperty.
+          cbn.
+          admit.
+      }
+    * admit.
+  + admit.
+Admitted.
+
+End locally_CCC.

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -809,3 +809,44 @@ use mk_are_adjoints.
 Defined.
 
 End locally_CCC.
+
+(** * Indexed non-empty products in SET/X *)
+Section products_set_slice.
+
+Local Notation "HSET / X" := (slice_precat HSET X has_homsets_HSET).
+
+(** Note that I has to be non-empty *)
+Lemma Products_HSET_slice I X (i : I) : Products I (HSET / X).
+Proof.
+intros f.
+use mk_ProductCone.
++ mkpair.
+  - exists (Σ (a : forall_hSet (λ (i : I), pr1 (f i))),
+              Π (i j : I), pr2 (f i) (a i) = pr2 (f j) (a j)).
+    abstract (apply isaset_total2; try apply setproperty; simpl; intro a;
+    apply impred_isaset; intro j; apply impred_isaset; intro k;
+    now apply isasetaprop, setproperty).
+  - intros H; apply (pr2 (f i)), (pr1 H).
++ intros j.
+  mkpair.
+  - intros H; apply (pr1 H j).
+  - abstract (now apply funextsec; intros H; apply (pr2 H)).
++ intros g h.
+  use unique_exists.
+  - mkpair; simpl.
+    * intros x.
+      exists (λ j, pr1 (h j) x).
+      abstract (intros j k; etrans; [apply (!toforallpaths _ _ _ (pr2 (h j)) x)|];
+      now apply pathsinv0; etrans; [apply (!toforallpaths _ _ _ (pr2 (h k)) x)|]).
+    * abstract (now apply funextsec; intro x; apply (toforallpaths _ _ _ (pr2 (h i)) x)).
+  - abstract (intros j; apply subtypeEquality; [intros x; apply setproperty|];
+              now apply funextsec).
+  - abstract (intros y; apply impred_isaprop; intros; apply has_homsets_slice_precat).
+  - intros y Hy; apply subtypeEquality; [intros x; apply setproperty|]; simpl.
+    apply funextsec; intro x; apply subtypeEquality.
+    * intros w; apply impred_isaprop; intros j; apply impred_isaprop; intros k.
+      now apply setproperty.
+    * now simpl; apply funextsec; intro w; rewrite <- (Hy w).
+Defined.
+
+End products_set_slice.

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -41,13 +41,11 @@ Require Import UniMath.CategoryTheory.limits.products.
 Require Import UniMath.CategoryTheory.limits.initial.
 Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.limits.pullbacks.
-Require Import UniMath.CategoryTheory.opp_precat.
 Require Import UniMath.CategoryTheory.equivalences.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.covyoneda.
 Require Import UniMath.CategoryTheory.slicecat.
 
-Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
 (* This should be moved upstream. Constructs the smallest eqrel

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -650,35 +650,30 @@ use left_adjoint_from_partial.
 - intros Q R φ; simpl in *.
   mkpair.
   + mkpair.
-    * { mkpair.
+    * { use mk_nat_trans.
         - intros c u; simpl.
-          mkpair.
+          use mk_nat_trans.
           + simpl; intros d fx.
             apply (φ d (dirprodpair (pr2 fx) (# R (pr1 fx) u))).
-          + abstract (
-              intros a b f; simpl; cbn; unfold prodtofuntoprod;
-              apply funextsec; intro x;
-              eapply pathscomp0;
+          + intros a b f; simpl; cbn; unfold prodtofuntoprod.
+            apply funextsec; intro x.
+            etrans;
               [|apply (toforallpaths _ _ _ (nat_trans_ax φ _ _ f)
-                                     (dirprodpair (pr2 x) (# R (pr1 x) u)))]; cbn;
-              unfold prodtofuntoprod;
-              apply maponpaths, maponpaths;
-              assert (H : # R (pr1 x ;; f) = # R (pr1 x) ;; #R f);
-              [apply functor_comp|];
-              apply (toforallpaths _ _ _ H u)).
-        - abstract (
-            intros a b f; cbn;
-            apply funextsec; intros x; cbn; simpl;
-            apply subtypeEquality;
-            [intros xx; apply (isaprop_is_nat_trans _ _ has_homsets_HSET)|];
-            simpl; apply funextsec; intro y; cbn;
-            apply funextsec; intro z;
-            apply maponpaths, maponpaths;
-            unfold covyoneda_morphisms_data;
-            assert (H : # R (f ;; pr1 z) = # R f ;; # R (pr1 z));
-              [apply functor_comp|];
-            apply pathsinv0;
-            now eapply pathscomp0; [apply (toforallpaths _ _ _ H x)|]).
+                                     (dirprodpair (pr2 x) (# R (pr1 x) u)))]; cbn.
+              repeat (apply maponpaths).
+              assert (H : # R (pr1 x ;; f) = # R (pr1 x) ;; #R f).
+              { apply functor_comp. }
+              apply (toforallpaths _ _ _ H u).
+        - intros a b f; cbn.
+          apply funextsec; intros x; cbn.
+          apply subtypeEquality;
+            [intros xx; apply (isaprop_is_nat_trans _ _ has_homsets_HSET)|].
+          apply funextsec; intro y; apply funextsec; intro z; cbn.
+          repeat apply maponpaths;  unfold covyoneda_morphisms_data.
+          assert (H : # R (f ;; pr1 z) = # R f ;; # R (pr1 z)).
+          { apply functor_comp. }
+          apply pathsinv0.
+          now etrans; [apply (toforallpaths _ _ _ H x)|].
       }
     * abstract (
         apply (nat_trans_eq has_homsets_HSET); cbn; intro x;

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -478,14 +478,19 @@ Defined.
 
 End TerminalHSET_from_Lims.
 
+Definition PullbackHSET_ob {A B C : HSET} (f : HSET⟦B,A⟧) (g : HSET⟦C,A⟧) : HSET.
+Proof.
+simpl in *.
+exists (Σ (xy : B × C), f (pr1 xy) = g (pr2 xy)).
+abstract (apply isaset_total2; [ apply isasetdirprod; apply setproperty
+                               | intros xy; apply isasetaprop, setproperty ]).
+Defined.
+
 Lemma PullbacksHSET : Pullbacks HSET.
 Proof.
 intros A B C f g.
 use mk_Pullback.
-+ simpl in *.
-  exists (Σ (xy : B × C), f (pr1 xy) = g (pr2 xy)).
-  abstract (apply isaset_total2; [ apply isasetdirprod; apply setproperty
-                                 | intros xy; apply isasetaprop, setproperty ]).
++ apply (PullbackHSET_ob f g).
 + intros xy; apply (pr1 (pr1 xy)).
 + intros xy; apply (pr2 (pr1 xy)).
 + abstract (apply funextsec; intros [[x y] Hxy]; apply Hxy).
@@ -499,6 +504,12 @@ use mk_Pullback.
   - abstract (intros h [H1 H2]; apply funextsec; intro x;
     apply subtypeEquality; [intros H; apply setproperty|]; simpl;
     now rewrite <- (toforallpaths _ _ _ H1 x), <- (toforallpaths _ _ _ H2 x), <- tppr).
+Defined.
+
+Lemma test (A B C : HSET) (f : HSET⟦B,A⟧) (g : HSET⟦C,A⟧) :
+  PullbackObject (PullbacksHSET _ _ _ f g) = PullbackHSET_ob f g.
+Proof.
+  apply idpath.
 Defined.
 
 Section PullbacksHSET_from_Lims.
@@ -698,6 +709,147 @@ Qed.
 
 End exponentials_functor_cat.
 
+(** TODO: remove this *)
+Lemma toforallpaths_induction (X Y : UU) (f g : X -> Y) (P : (Π x, f x = g x) -> UU)
+ (H : Π e : f = g, P (toforallpaths _ _ _ e)) : Π i : (Π x, f x = g x), P i.
+Proof.
+ intros i. rewrite <- (homotweqinvweq (weqtoforallpaths _ f g)). apply H.
+Defined.
+
+Definition transportf_funextfun {X Y : UU} (P : Y -> UU) (F F' : X -> Y) (H : Π (x : X), F x = F' x)
+ (x : X) (f : P (F x)) :
+ transportf (λ x0 : X → Y, P (x0 x)) (funextsec _ F F' H) f = transportf (λ x0 : Y, P x0) (H x) f.
+Proof.
+ apply (toforallpaths_induction
+ _ _ F F' (fun H' => transportf (λ x0 : X → Y, P (x0 x))
+ (funextsec (λ _ : X, Y) F F' (λ x0 : X, H' x0)) f =
+ transportf (λ x0 : Y, P x0) (H' x) f)).
+ intro e. clear H.
+ set (XR := homotinvweqweq (weqtoforallpaths _ F F') e).
+ set (H := funextsec (λ _ : X, Y) F F' (λ x0 : X, toforallpaths (λ _ : X, Y) F F' e x0)).
+ set (P' := λ x0 : X → Y, P (x0 x)).
+ use pathscomp0.
+ - exact (transportf P' e f).
+ - use transportf_paths. exact XR.
+ - induction e. apply idpath.
+Defined.
+(** *** Transport source and target of a morphism *)
+Lemma transport_target_postcompose {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z)
+(e : z = w) :
+transportf (precategory_morphisms x) e (f ;; g) = f ;; transportf (precategory_morphisms y) e g.
+Proof.
+induction e. apply idpath.
+Qed.
+Lemma transport_source_precompose {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z)
+(e : x = w) :
+transportf (fun x' : ob C => precategory_morphisms x' z) e (f ;; g) =
+transportf (fun x' : ob C => precategory_morphisms x' y) e f ;; g.
+Proof.
+induction e. apply idpath.
+Qed.
+Lemma transport_compose {C : precategory} {x y z w : ob C} (f : x --> y) (g : z --> w) (e : y = z) :
+transportf (precategory_morphisms x) e f ;; g =
+f ;; transportf (fun x' : ob C => precategory_morphisms x' w) (! e) g.
+Proof.
+induction e. apply idpath.
+Qed.
+Lemma transport_compose' {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z) (e : y = w) :
+(transportf (precategory_morphisms x) e f)
+;; (transportf (fun x' : ob C => precategory_morphisms x' z) e g) = f ;; g.
+Proof.
+induction e. apply idpath.
+Qed.
+Lemma transport_target_path {C : precategory} {x y z : ob C} (f g : x --> y) (e : y = z) :
+transportf (precategory_morphisms x) e f = transportf (precategory_morphisms x) e g -> f = g.
+Proof.
+induction e. intros H. apply H.
+Qed.
+Lemma transport_source_path {C : precategory} {x y z : ob C} (f g : y --> z) (e : y = x) :
+transportf (fun x' : ob C => precategory_morphisms x' z) e f =
+transportf (fun x' : ob C => precategory_morphisms x' z) e g -> f = g.
+Proof.
+induction e. intros H. apply H.
+Qed.
+Lemma transport_source_target {X : UU} {C : precategory} {x y : X} (P : Π (x' : X), ob C)
+(P' : Π (x' : X), ob C) (f : Π (x' : X), (P x') --> (P' x')) (e : x = y) :
+transportf (fun (x' : X) => (P x') --> (P' x')) e (f x) =
+transportf (fun (x' : X) => precategory_morphisms (P x') (P' y)) e
+(transportf (precategory_morphisms (P x)) (maponpaths P' e) (f x)).
+Proof.
+rewrite <- functtransportf. unfold pathsinv0. unfold paths_rect. induction e.
+apply idpath.
+Qed.
+Lemma transport_target_source {X : UU} {C : precategory} {x y : X} (P : Π (x' : X), ob C)
+(P' : Π (x' : X), ob C) (f : Π (x' : X), (P x') --> (P' x')) (e : x = y) :
+transportf (fun (x' : X) => (P x') --> (P' x')) e (f x) =
+transportf (precategory_morphisms (P y)) (maponpaths P' e)
+(transportf (fun (x' : X) => precategory_morphisms (P x') (P' x)) e (f x)).
+Proof.
+rewrite <- functtransportf. unfold pathsinv0. unfold paths_rect. induction e.
+apply idpath.
+Qed.
+Lemma transport_source_target_comm {C : precategory} {x y x' y' : ob C} (f : x --> y) (e1 : x = x')
+(e2 : y = y') :
+transportf (fun (x'' : ob C) => precategory_morphisms x'' y') e1
+(transportf (precategory_morphisms x) e2 f) =
+transportf (precategory_morphisms x') e2
+(transportf (fun (x'' : ob C) => precategory_morphisms x'' y) e1 f).
+Proof.
+induction e1. induction e2. apply idpath.
+Qed.
+(** *** Transport a morphism using funextfun *)
+Definition transport_source_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C)
+(H : Π (x : X), F x = F' x) {x : X} (c : ob C) (f : F x --> c) :
+transportf (λ x0 : X → C, x0 x --> c) (funextfun F F' H) f =
+transportf (λ x0 : C, x0 --> c) (H x) f.
+Proof.
+exact (@transportf_funextfun X (ob C) (λ x0 : C, x0 --> c) F F' H x f).
+Qed.
+Definition transport_target_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C)
+(H : Π (x : X), F x = F' x) {x : X} {c : ob C} (f : c --> F x) :
+transportf (λ x0 : X → C, c --> x0 x) (funextfun F F' H) f =
+transportf (λ x0 : C, c --> x0) (H x) f.
+Proof.
+use transportf_funextfun.
+Qed.
+Lemma transport_mor_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C)
+(H : Π (x : X), F x = F' x) {x1 x2 : X} (f : F x1 --> F x2) :
+transportf (λ x : X → C, x x1 --> x x2) (funextfun F F' H) f =
+transportf (λ x : X → C, F' x1 --> x x2)
+(funextfun F F' (λ x : X, H x))
+(transportf (λ x : X → C, x x1 --> F x2)
+((funextfun F F' (λ x : X, H x))) f).
+Proof.
+induction (funextfun F F' (λ x : X, H x)).
+apply idpath.
+Qed.
+Lemma functor_data_eq {C C' : precategory_ob_mor} (F F' : functor_data C C')
+ (H : Π (c : C), (pr1 F) c = (pr1 F') c)
+ (H1 : Π (C1 C2 : ob C) (f : C1 --> C2),
+ transportf (λ x : C', pr1 F' C1 --> x) (H C2)
+ (transportf (λ x : C', x --> pr1 F C2) (H C1) (pr2 F C1 C2 f)) =
+   pr2 F' C1 C2 f) : F = F'.
+Proof.
+ use total2_paths.
+ - use funextfun. intros c. exact (H c).
+ - use funextsec. intros C1. use funextsec. intros C2. use funextsec. intros f.
+ assert (e : transportf (λ x : C → C', Π a b : C, a --> b → x a --> x b)
+ (funextfun (pr1 F) (pr1 F') (λ c : C, H c))
+ (pr2 F) C1 C2 f =
+ transportf (λ x : C → C', x C1 --> x C2)
+ (funextfun (pr1 F) (pr1 F') (λ c : C, H c))
+ ((pr2 F) C1 C2 f)).
+ {
+ induction (funextfun (pr1 F) (pr1 F') (λ c : C, H c)).
+ apply idpath.
+ }
+ rewrite e. clear e.
+ rewrite transport_mor_funextfun.
+ rewrite transport_source_funextfun. rewrite transport_target_funextfun.
+ exact (H1 C1 C2 f).
+Qed.
+(** END OF DELETE *)
+
 (** * Set is locally cartesian closed *)
 Section locally_CCC.
 
@@ -738,13 +890,12 @@ mkpair.
   * simpl; intros a b g.
     { mkpair; simpl.
     - intros h.
+      exists (pr1 h).
+      intros fx.
       mkpair.
-      + apply (pr1 h).
-      + intros fx.
-        mkpair.
-        * apply (pr1 g), (pr1 (pr2 h fx)).
-        * abstract (etrans; [ apply (!toforallpaths _ _ _ (pr2 g) (pr1 (pr2 h fx)))|];
-                    apply (pr2 (pr2 h fx))).
+      * apply (pr1 g), (pr1 (pr2 h fx)).
+      * abstract (etrans; [ apply (!toforallpaths _ _ _ (pr2 g) (pr1 (pr2 h fx)))|];
+                  apply (pr2 (pr2 h fx))).
     - abstract (now apply funextsec).
     }
 + abstract (split;
@@ -782,57 +933,159 @@ Proof.
 (*   set (foo := paths). *)
 (*   Check (f x1 ∘ transportb P e). *)
 
+Require Import UniMath.CategoryTheory.DiscretePrecategory.
+
+Hypothesis equiv_slice : Π (X : HSET), HSET / X ≃ [discrete_precategory (pr1 X),HSET,has_homsets_HSET].
+
+
+Lemma has_exponentials_equiv (C D : precategory) (eq : C ≃ D) : has_exponentials C → has_exponentials D.
 
 Lemma has_exponentials_HSET_slice (X : HSET) : has_exponentials (BinProducts_HSET_slice X).
 Proof.
 intros f.
-use left_adjoint_from_partial.
-- apply (hfiber_fun _ f).
-- intros g.
-  mkpair; simpl.
-  + (* intros [[x [y h]] p]. *)
-    intros H.
-    set (x := pr1 (pr1 H)).
-    set (h := pr2 (pr2 (pr1 H))).
-    set (p := pr2 H).
-    apply (pr1 (h (x,,p))).
-    (* apply (pr1 (pr2 (pr2 (pr1 H)) ((pr1 (pr1 H)),,(pr2 H)))). *)
-  + abstract (now apply funextfun; intros [[x [y h]] p]; simpl in *; rewrite (pr2 (h (x,,p))), p).
-- intros g h α.
-  use unique_exists.
-  + mkpair.
-    * intros x.
+Search weq.
+  set (X' := discrete_precategory (pr1 X)).
+  set (XHSET := [X',HSET,has_homsets_HSET]).
+  assert (has_homsets_X' : has_homsets X').
+  apply has_homsets_discrete_precategory, hlevelntosn, setproperty.
+set (α := equiv_slice X).
+set (α1 := pr1 α).
+set (α2 := invmap α).
+set (H1 := homotweqinvweq α).
+set (H2 := homotinvweqweq α).
 
-      simpl.
-      mkpair.
-      apply (pr2 h x).
-      intros fh.
-      transparent assert (asdf : (Σ xy : (pr1 (pr1 f) × pr1 (pr1 h)), pr2 f (pr1 xy) = pr2 h (pr2 xy))).
+  generalize (has_exponentials_functor_HSET X' has_homsets_X' (α1 f)).
+  unfold has_exponentials.
+  unfold is_exponentiable.
+  intros HH.
+  destruct HH as [HH1 HH2].
+  mkpair.
 
-        exists (pr1 fh,,x).
-        apply (pr2 fh).
+  Check
+  simpl.
 
-      rewrite <- (pr2 fh).
-      mkpair.
-      apply (pr1 α), asdf.
-      destruct α as [a Ha].
-      simpl in *.
-      apply (!toforallpaths _ _ _ Ha asdf).
-    * apply idpath.
-  + simpl.
 
-    apply eq_mor_slicecat.
-    simpl.
-    set (asdf := PullbackArrow _ _ _ _ _).
-    apply funextfun; intros x.
-    cbn.
-    simpl.
-    admit.
-  + admit.
-  + simpl. intros.
 
-mkpair.
-- split.
+  (* use left_adjoint_from_partial. *)
+(* - apply (hfiber_fun _ f). *)
+(* - intros g. *)
+(*   mkpair; simpl. *)
+(*   + (* intros [[x [y h]] p]. *) *)
+(*     intros H. *)
+(*     set (x := pr1 (pr1 H)). *)
+(*     set (h := pr2 (pr2 (pr1 H))). *)
+(*     set (p := pr2 H). *)
+(*     apply (pr1 (h (x,,p))). *)
+(*     (* apply (pr1 (pr2 (pr2 (pr1 H)) ((pr1 (pr1 H)),,(pr2 H)))). *) *)
+(*   + abstract (now apply funextfun; intros [[x [y h]] p]; simpl in *; rewrite (pr2 (h (x,,p))), p). *)
+(* - intros g h α. *)
+(*   use unique_exists. *)
+(*   + mkpair. *)
+(*     * intros x. *)
+(*       simpl. *)
+(*       mkpair. *)
+(*       apply (pr2 h x). *)
+(*       intros fh. *)
+(*       transparent assert (asdf : (Σ xy : (pr1 (pr1 f) × pr1 (pr1 h)), pr2 f (pr1 xy) = pr2 h (pr2 xy))). *)
+(*         exists (pr1 fh,,x). *)
+(*         apply (pr2 fh). *)
+(*       rewrite <- (pr2 fh). *)
+(*       mkpair. *)
+(*       apply (pr1 α), asdf. *)
+(*       destruct α as [a Ha]. *)
+(*       simpl in *. *)
+(*       apply (!toforallpaths _ _ _ Ha asdf). *)
+(*     * apply idpath. *)
+(*   + simpl. *)
+(*     apply eq_mor_slicecat. *)
+
+(*     simpl. *)
+(*     unfold PullbackArrow. *)
+(*     simpl. *)
+(*     unfold PullbacksHSET. *)
+(*     simpl. *)
+(*     cbn. *)
+(*     apply funextsec; intro w. *)
+(*     cbn. *)
+(*     unfold PullbacksHSET. *)
+(*     simpl. *)
+(*     unfold PullbackArrow. *)
+(*     simpl. *)
+(*     eapply maponpaths. *)
+(* destruct α as [a1 Ha1]. *)
+(* simpl in *. *)
+
+(* match goal with [|- _ = ?P ;; ?PP ] => set (foo := P); set (bar := PP) end. *)
+(* apply funextsec; intro w. *)
+(* generalize (toforallpaths _ _ _ Ha1 w). *)
+(* cbn. *)
+(* unfold foo. *)
+
+(* intros. *)
+(* match goal with [|- _ = bar (PullbackArrow ?X1 ?X2 ?X3 ?X4 ?X5 ?X6) ] => set (foo1 := X6) end. *)
+(* simpl in *. *)
+(* cbn in foo1. *)
+(* cbn. *)
+(* simpl. *)
+
+(* set (moo := PullbackPr1 (PullbacksHSET X (pr1 f) ((Σ x : pr1 X, hfiber (pr2 f) x → hfiber (pr2 g) x),, hfiber_fun_subproof X f g) *)
+(*                                        (pr2 f) pr1)). *)
+
+(* simpl in *. *)
+(* transparent assert (moo2 : (pr1 (pr1 f) → pr1 (pr1 g))). *)
+(* intros X1. *)
+(* apply a1. *)
+(* mkpair. *)
+(* split. *)
+(* apply X1. *)
+
+(* intros xx *)
+
+(* destruct XX. *)
+
+(* admit. *)
+(* assert (Π x, bar x = moo2 (moo x)). *)
+(* admit. *)
+(* rewrite (funextfun _ _ X0). *)
+(* simpl. *)
+(* simpl in moo. *)
+(* Check (pr2 g). *)
+(* apply funextsec; intro w. *)
+(* generalize (toforallpaths _ _ _ Ha1 w). *)
+(* cbn. *)
+(* destruct w as [[w1 w2] w3]. *)
+(* simpl. *)
+(* simpl in *. *)
+
+(* unfold bar. *)
+(* simpl. *)
+(* unfold foo. *)
+(* cbn. *)
+(* simpl. *)
+(* cbn. *)
+(* set (P := @paths). *)
+(* simpl in *. *)
+(* assert (bar = *)
+(* Check (PullbackPr2). *)
+(* mat *)
+(* set (foo := (λ H : Σ xy : pr1 (pr1 f) × (Σ x : pr1 X, hfiber (pr2 f) x → hfiber (pr2 g) x), pr2 f (pr1 xy) = pr1 (pr2 xy), *)
+(*    pr1 (pr2 (pr2 (pr1 H)) (pr1 (pr1 H),, pr2 H)))). *)
+(*     Search PullbackArrow. *)
+(*     apply funextsec; intro x. *)
+(*     simpl. *)
+(*     cbn. *)
+(*     set (asdf := PullbackArrow _ _ _ _ _). *)
+(*     apply funextfun; intros x. *)
+(*     cbn. *)
+(*     admit. *)
+(*   + intros. *)
+(*     simpl. *)
+(*     apply has_homsets_slice_precat. *)
+(*   +  intros. *)
+(*      simpl. *)
+(*      simpl in X0. *)
+(* mkpair. *)
+(* - split. *)
 
 Lemma has_exponentials_HSET_slice (X : HSET) : has_exponentials (BinProducts_HSET_slice X).
 Proof.
@@ -842,21 +1095,51 @@ mkpair.
 - split.
   + use mk_nat_trans.
     * intros g.
+      simpl.
     { mkpair.
-      + simpl.
-        intros y.
+      + intros y.
         exists (pr2 g y).
         intros fgy.
         exists ((pr1 fgy,,y),,(pr2 fgy)).
         apply (pr2 fgy).
-      + now apply funextsec.
+      + abstract (now apply funextsec).
     }
     * intros g h w.
-      apply (eq_mor_slicecat _ has_homsets_HSET); simpl.
-      apply funextsec; intro x.
-      use total2_paths2; simpl.
-      apply (!toforallpaths _ _ _ (pr2 w) x).
+      apply (eq_mor_slicecat _ has_homsets_HSET).
+      unfold constprod_functor1.
+      unfold BinProduct_of_functors.
+      unfold BinProduct_of_functors_data.
+      simpl.
+      Arguments constprod_functor1 : simpl never.
+      simpl.
 
+      apply funextsec; intro x.
+      use total2_paths2.
+      apply (toforallpaths _ _ _ (!pr2 w) x).
+      apply funextsec; intro y.
+
+      use total2_paths.
+      use total2_paths.
+      cbn.
+            destruct w as [w1 w2].
+            cbn.
+
+      cbn.
+      admit.
+      generalize (@PullbackArrowUnique' _ (PullbacksHSET X (pr1 f) (pr1 h) (pr2 f) (pr2 h)) ).
+      Search transportf.
+      generalize @transportf_total2.
+      destruct w as [w1 w2].
+      simpl in *.
+      destruct y as [y1 y2].
+      cbn.
+      unfold PullbackArrow.
+      simpl.
+      cbn.
+
+            cbn.
+      induction (w2).
+      cbn.
       match goal with [|- transportf ?PP ?EE ?HH = _ ] =>
                       set (P' := PP); set (E := EE); set (H := HH) end.
 

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -871,19 +871,12 @@ Proof.
 mkpair.
 - use mk_functor.
   + mkpair.
-    * intro Y. {
-      mkpair.
-      - exists (Σ (x : pr1 X), pr1 Y).
-        abstract (now apply isaset_total2; intros; apply setproperty).
-      - apply pr1.
-      }
-    * intros A B f. {
-      mkpair.
-      - simpl; intros H.
-        exists (pr1 H).
-        apply (f (pr2 H)).
-      - abstract (now apply funextsec).
-      }
+    * intro Y.
+      exists (X × Y)%set; simpl.
+      apply pr1.
+    * intros A B f.
+      exists (λ xa, pr1 xa,,f (pr2 xa)).
+      abstract (now apply funextsec).
   + abstract (split;
     [ intros A; simpl; apply subtypeEquality; [intros x; apply setproperty|];
       now apply funextsec; intros [x a]
@@ -891,14 +884,9 @@ mkpair.
       now apply funextsec; intros [x a]]).
 - use mk_are_adjoints.
   + use mk_nat_trans.
-    * simpl; intros F. {
-      mkpair.
-      - simpl; intro f.
-        mkpair.
-        + apply (pr2 F f).
-        + apply f.
-      - abstract (now apply funextsec).
-      }
+    * simpl; intros F.
+      exists (λ f, (pr2 F f,,f)).
+      abstract (now apply funextsec).
     * abstract (intros Y Z F; apply (eq_mor_slicecat has_homsets_HSET);
                 apply funextsec; intro y;
                 use total2_paths2; [apply (toforallpaths _ _ _ (!pr2 F) y)|];

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -19,8 +19,6 @@ Contents:
 - Locally cartesian closed ([Terminal_HSET_slice],
   [BinProducts_HSET_slice] and [has_exponentials_HSET_slice])
 - Products in Set/X ([Products_HSET_slice])
-- The forgetful functor from Set/X to Set preserves colimits
-  ([preserves_colimit_slicecat_to_cat_HSET])
 
 Written by: Benedikt Ahrens, Anders Mörtberg
 
@@ -48,7 +46,6 @@ Require Import UniMath.CategoryTheory.equivalences.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.covyoneda.
 Require Import UniMath.CategoryTheory.slicecat.
-Require Import UniMath.CategoryTheory.CocontFunctors.
 
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 
@@ -869,80 +866,3 @@ use mk_ProductCone.
 Defined.
 
 End products_set_slice.
-
-(** * The forgetful functor from Set/X to Set preserves colimits *)
-Section cocont_slicecat_to_cat_HSET.
-
-Local Notation "HSET / X" := (slice_precat HSET X has_homsets_HSET).
-
-Lemma preserves_colimit_slicecat_to_cat_HSET (X : HSET)
-  (g : graph) (d : diagram g (HSET / X)) (L : HSET / X) (ccL : cocone d L) :
-  preserves_colimit (slicecat_to_cat has_homsets_HSET X) d L ccL.
-Proof.
-intros HccL y ccy.
-set (CC := mk_ColimCocone _ _ _ HccL).
-transparent assert (c : (HSET / X)).
-{ mkpair.
-  - exists (Σ (x : pr1 X), pr1 y).
-    abstract (apply isaset_total2; intros; apply setproperty).
-  - apply pr1.
-}
-transparent assert (cc : (cocone d c)).
-{ use mk_cocone.
-  - intros n.
-    mkpair; simpl.
-    + intros z.
-      mkpair.
-      * apply (pr2 L), (pr1 (coconeIn ccL n) z).
-      * apply (coconeIn ccy n z).
-    + abstract (now apply funextsec; intro z;
-                apply (toforallpaths _ _ _ (pr2 (coconeIn ccL n)) z)).
-  - abstract (intros m n e; apply eq_mor_slicecat, funextsec; intro z;
-    use total2_paths;
-      [ apply (maponpaths _ (toforallpaths _ _ _
-                 (maponpaths pr1 (coconeInCommutes ccL m n e)) z))|];
-    cbn in *; induction (maponpaths _ _);
-    now rewrite idpath_transportf, <- (coconeInCommutes ccy m n e)).
-}
-use unique_exists.
-- intros l; apply (pr2 (pr1 (colimArrow CC c cc) l)).
-- simpl; intro n.
-  apply funextsec; intro x; cbn.
-  now etrans; [apply maponpaths,
-                 (toforallpaths _ _ _ (maponpaths pr1 (colimArrowCommutes CC c cc n)) x)|].
-- intros z; apply impred_isaprop; intro n; apply setproperty.
-- simpl; intros f Hf.
-apply funextsec; intro l.
-transparent assert (k : (HSET/X⟦colim CC,c⟧)).
-{ mkpair.
-  - intros l'.
-    exists (pr2 L l').
-    apply (f l').
-  - abstract (now apply funextsec).
-}
-assert (Hk : (Π n, colimIn CC n ;; k = coconeIn cc n)).
-{ intros n.
-  apply subtypeEquality; [intros x; apply setproperty|].
-  apply funextsec; intro z.
-  use total2_paths; [apply idpath|].
-  now rewrite idpath_transportf; cbn; rewrite <- (toforallpaths _ _ _ (Hf n) z).
-}
-apply (maponpaths dirprod_pr2
-         (toforallpaths _ _ _ (maponpaths pr1 (colimArrowUnique CC c cc k Hk)) l)).
-Defined.
-
-Lemma is_cocont_slicecat_to_cat_HSET (X : HSET) :
-  is_cocont (slicecat_to_cat has_homsets_HSET X).
-Proof.
-intros g d L cc.
-now apply preserves_colimit_slicecat_to_cat_HSET.
-Defined.
-
-Lemma is_omega_cocont_slicecat_to_cat (X : HSET) :
-  is_omega_cocont (slicecat_to_cat has_homsets_HSET X).
-Proof.
-intros d L cc.
-now apply preserves_colimit_slicecat_to_cat_HSET.
-Defined.
-
-End cocont_slicecat_to_cat_HSET.

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -44,6 +44,8 @@ Require Import UniMath.CategoryTheory.equivalences.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.covyoneda.
 Require Import UniMath.CategoryTheory.slicecat.
+Require Import UniMath.CategoryTheory.DiscretePrecategory.
+Require Import UniMath.CategoryTheory.set_slice_fam_equiv.
 
 Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
@@ -506,12 +508,6 @@ use mk_Pullback.
     now rewrite <- (toforallpaths _ _ _ H1 x), <- (toforallpaths _ _ _ H2 x), <- tppr).
 Defined.
 
-Lemma test (A B C : HSET) (f : HSET⟦B,A⟧) (g : HSET⟦C,A⟧) :
-  PullbackObject (PullbacksHSET _ _ _ f g) = PullbackHSET_ob f g.
-Proof.
-  apply idpath.
-Defined.
-
 Section PullbacksHSET_from_Lims.
 
   Require UniMath.CategoryTheory.limits.graphs.pullbacks.
@@ -536,7 +532,7 @@ End EqualizersHSET_from_Lims.
 
 Section exponentials.
 
-(* Define the functor: A -> _^A *)
+(** Define the functor: A -> _^A *)
 Definition exponential_functor (A : HSET) : functor HSET HSET.
 Proof.
 mkpair.
@@ -549,7 +545,7 @@ Defined.
 
 Definition flip {A B C : UU} (f : A -> B -> C) : B -> A -> C := fun x y => f y x.
 
-(* This checks that if we use constprod_functor2 the flip is not necessary *)
+(** This checks that if we use constprod_functor2 the flip is not necessary *)
 Lemma are_adjoints_constprod_functor2 A :
   are_adjoints (constprod_functor2 BinProductsHSET A) (exponential_functor A).
 Proof.
@@ -709,162 +705,73 @@ Qed.
 
 End exponentials_functor_cat.
 
-(** TODO: remove this *)
-(* Lemma toforallpaths_induction (X Y : UU) (f g : X -> Y) (P : (Π x, f x = g x) -> UU) *)
-(*  (H : Π e : f = g, P (toforallpaths _ _ _ e)) : Π i : (Π x, f x = g x), P i. *)
-(* Proof. *)
-(*  intros i. rewrite <- (homotweqinvweq (weqtoforallpaths _ f g)). apply H. *)
-(* Defined. *)
-
-(* Definition transportf_funextfun {X Y : UU} (P : Y -> UU) (F F' : X -> Y) (H : Π (x : X), F x = F' x) *)
-(*  (x : X) (f : P (F x)) : *)
-(*  transportf (λ x0 : X → Y, P (x0 x)) (funextsec _ F F' H) f = transportf (λ x0 : Y, P x0) (H x) f. *)
-(* Proof. *)
-(*  apply (toforallpaths_induction *)
-(*  _ _ F F' (fun H' => transportf (λ x0 : X → Y, P (x0 x)) *)
-(*  (funextsec (λ _ : X, Y) F F' (λ x0 : X, H' x0)) f = *)
-(*  transportf (λ x0 : Y, P x0) (H' x) f)). *)
-(*  intro e. clear H. *)
-(*  set (XR := homotinvweqweq (weqtoforallpaths _ F F') e). *)
-(*  set (H := funextsec (λ _ : X, Y) F F' (λ x0 : X, toforallpaths (λ _ : X, Y) F F' e x0)). *)
-(*  set (P' := λ x0 : X → Y, P (x0 x)). *)
-(*  use pathscomp0. *)
-(*  - exact (transportf P' e f). *)
-(*  - use transportf_paths. exact XR. *)
-(*  - induction e. apply idpath. *)
-(* Defined. *)
-(* (** *** Transport source and target of a morphism *) *)
-(* Lemma transport_target_postcompose {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z) *)
-(* (e : z = w) : *)
-(* transportf (precategory_morphisms x) e (f ;; g) = f ;; transportf (precategory_morphisms y) e g. *)
-(* Proof. *)
-(* induction e. apply idpath. *)
-(* Qed. *)
-(* Lemma transport_source_precompose {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z) *)
-(* (e : x = w) : *)
-(* transportf (fun x' : ob C => precategory_morphisms x' z) e (f ;; g) = *)
-(* transportf (fun x' : ob C => precategory_morphisms x' y) e f ;; g. *)
-(* Proof. *)
-(* induction e. apply idpath. *)
-(* Qed. *)
-(* Lemma transport_compose {C : precategory} {x y z w : ob C} (f : x --> y) (g : z --> w) (e : y = z) : *)
-(* transportf (precategory_morphisms x) e f ;; g = *)
-(* f ;; transportf (fun x' : ob C => precategory_morphisms x' w) (! e) g. *)
-(* Proof. *)
-(* induction e. apply idpath. *)
-(* Qed. *)
-(* Lemma transport_compose' {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z) (e : y = w) : *)
-(* (transportf (precategory_morphisms x) e f) *)
-(* ;; (transportf (fun x' : ob C => precategory_morphisms x' z) e g) = f ;; g. *)
-(* Proof. *)
-(* induction e. apply idpath. *)
-(* Qed. *)
-(* Lemma transport_target_path {C : precategory} {x y z : ob C} (f g : x --> y) (e : y = z) : *)
-(* transportf (precategory_morphisms x) e f = transportf (precategory_morphisms x) e g -> f = g. *)
-(* Proof. *)
-(* induction e. intros H. apply H. *)
-(* Qed. *)
-(* Lemma transport_source_path {C : precategory} {x y z : ob C} (f g : y --> z) (e : y = x) : *)
-(* transportf (fun x' : ob C => precategory_morphisms x' z) e f = *)
-(* transportf (fun x' : ob C => precategory_morphisms x' z) e g -> f = g. *)
-(* Proof. *)
-(* induction e. intros H. apply H. *)
-(* Qed. *)
-(* Lemma transport_source_target {X : UU} {C : precategory} {x y : X} (P : Π (x' : X), ob C) *)
-(* (P' : Π (x' : X), ob C) (f : Π (x' : X), (P x') --> (P' x')) (e : x = y) : *)
-(* transportf (fun (x' : X) => (P x') --> (P' x')) e (f x) = *)
-(* transportf (fun (x' : X) => precategory_morphisms (P x') (P' y)) e *)
-(* (transportf (precategory_morphisms (P x)) (maponpaths P' e) (f x)). *)
-(* Proof. *)
-(* rewrite <- functtransportf. unfold pathsinv0. unfold paths_rect. induction e. *)
-(* apply idpath. *)
-(* Qed. *)
-(* Lemma transport_target_source {X : UU} {C : precategory} {x y : X} (P : Π (x' : X), ob C) *)
-(* (P' : Π (x' : X), ob C) (f : Π (x' : X), (P x') --> (P' x')) (e : x = y) : *)
-(* transportf (fun (x' : X) => (P x') --> (P' x')) e (f x) = *)
-(* transportf (precategory_morphisms (P y)) (maponpaths P' e) *)
-(* (transportf (fun (x' : X) => precategory_morphisms (P x') (P' x)) e (f x)). *)
-(* Proof. *)
-(* rewrite <- functtransportf. unfold pathsinv0. unfold paths_rect. induction e. *)
-(* apply idpath. *)
-(* Qed. *)
-(* Lemma transport_source_target_comm {C : precategory} {x y x' y' : ob C} (f : x --> y) (e1 : x = x') *)
-(* (e2 : y = y') : *)
-(* transportf (fun (x'' : ob C) => precategory_morphisms x'' y') e1 *)
-(* (transportf (precategory_morphisms x) e2 f) = *)
-(* transportf (precategory_morphisms x') e2 *)
-(* (transportf (fun (x'' : ob C) => precategory_morphisms x'' y) e1 f). *)
-(* Proof. *)
-(* induction e1. induction e2. apply idpath. *)
-(* Qed. *)
-(* (** *** Transport a morphism using funextfun *) *)
-(* Definition transport_source_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C) *)
-(* (H : Π (x : X), F x = F' x) {x : X} (c : ob C) (f : F x --> c) : *)
-(* transportf (λ x0 : X → C, x0 x --> c) (funextfun F F' H) f = *)
-(* transportf (λ x0 : C, x0 --> c) (H x) f. *)
-(* Proof. *)
-(* exact (@transportf_funextfun X (ob C) (λ x0 : C, x0 --> c) F F' H x f). *)
-(* Qed. *)
-(* Definition transport_target_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C) *)
-(* (H : Π (x : X), F x = F' x) {x : X} {c : ob C} (f : c --> F x) : *)
-(* transportf (λ x0 : X → C, c --> x0 x) (funextfun F F' H) f = *)
-(* transportf (λ x0 : C, c --> x0) (H x) f. *)
-(* Proof. *)
-(* use transportf_funextfun. *)
-(* Qed. *)
-(* Lemma transport_mor_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C) *)
-(* (H : Π (x : X), F x = F' x) {x1 x2 : X} (f : F x1 --> F x2) : *)
-(* transportf (λ x : X → C, x x1 --> x x2) (funextfun F F' H) f = *)
-(* transportf (λ x : X → C, F' x1 --> x x2) *)
-(* (funextfun F F' (λ x : X, H x)) *)
-(* (transportf (λ x : X → C, x x1 --> F x2) *)
-(* ((funextfun F F' (λ x : X, H x))) f). *)
-(* Proof. *)
-(* induction (funextfun F F' (λ x : X, H x)). *)
-(* apply idpath. *)
-(* Qed. *)
-(* Lemma functor_data_eq {C C' : precategory_ob_mor} (F F' : functor_data C C') *)
-(*  (H : Π (c : C), (pr1 F) c = (pr1 F') c) *)
-(*  (H1 : Π (C1 C2 : ob C) (f : C1 --> C2), *)
-(*  transportf (λ x : C', pr1 F' C1 --> x) (H C2) *)
-(*  (transportf (λ x : C', x --> pr1 F C2) (H C1) (pr2 F C1 C2 f)) = *)
-(*    pr2 F' C1 C2 f) : F = F'. *)
-(* Proof. *)
-(*  use total2_paths. *)
-(*  - use funextfun. intros c. exact (H c). *)
-(*  - use funextsec. intros C1. use funextsec. intros C2. use funextsec. intros f. *)
-(*  assert (e : transportf (λ x : C → C', Π a b : C, a --> b → x a --> x b) *)
-(*  (funextfun (pr1 F) (pr1 F') (λ c : C, H c)) *)
-(*  (pr2 F) C1 C2 f = *)
-(*  transportf (λ x : C → C', x C1 --> x C2) *)
-(*  (funextfun (pr1 F) (pr1 F') (λ c : C, H c)) *)
-(*  ((pr2 F) C1 C2 f)). *)
-(*  { *)
-(*  induction (funextfun (pr1 F) (pr1 F') (λ c : C, H c)). *)
-(*  apply idpath. *)
-(*  } *)
-(*  rewrite e. clear e. *)
-(*  rewrite transport_mor_funextfun. *)
-(*  rewrite transport_source_funextfun. rewrite transport_target_funextfun. *)
-(*  exact (H1 C1 C2 f). *)
-(* Qed. *)
-(** END OF DELETE *)
-
 (** * Set is locally cartesian closed *)
 Section locally_CCC.
 
 Local Notation "HSET / X" := (slice_precat HSET X has_homsets_HSET).
 
-Lemma Terminal_HSET_slice (X : HSET) : Terminal (HSET / X).
+Lemma Terminal_HSET_slice X : Terminal (HSET / X).
 Proof.
 now apply Terminal_slice_precat.
 Defined.
 
-Lemma BinProducts_HSET_slice (X : HSET) : BinProducts (HSET / X).
+Lemma BinProducts_HSET_slice X : BinProducts (HSET / X).
 Proof.
 now apply BinProducts_slice_precat, PullbacksHSET.
 Defined.
 
+
+(* Try to prove that Set/X has exponentials it using the equivalence to [X,Set] *)
+Section via_equivalence.
+
+Context (X : HSET).
+
+Let discreteX : precategory := discrete_precategory (pr1 X).
+Local Lemma has_homsets_discreteX : has_homsets discreteX.
+Proof.
+now apply has_homsets_discrete_precategory, hlevelntosn, setproperty.
+Qed.
+
+Local Notation "'[X,HSET]'" := ([discreteX, HSET, has_homsets_HSET]).
+Local Lemma has_homsets_XHSET : has_homsets [X,HSET].
+Proof.
+apply functor_category_has_homsets.
+Qed.
+
+Let F : functor [X,HSET] (HSET / X) := fam_to_slice X.
+Let α : adj_equivalence_of_precats F := set_slice_fam_equiv X.
+Let Finv : functor (HSET / X) [X,HSET] := adj_equivalence_inv α.
+Let eta := unit_iso_from_adj_equivalence_of_precats has_homsets_XHSET α.
+Let eps := counit_iso_from_adj_equivalence_of_precats (has_homsets_slice_precat _ _ X) α.
+(* Let eta' := unit_pointwise_iso_from_adj_equivalence α. *)
+(* Let eps' := counit_pointwise_iso_from_adj_equivalence α. *)
+
+Local Lemma BinProducts_XHSET : BinProducts [X,HSET].
+Proof.
+apply BinProducts_functor_precat, BinProductsHSET.
+Defined.
+
+Lemma has_exponentials_XHSET : has_exponentials BinProducts_XHSET.
+Proof.
+apply has_exponentials_functor_HSET, has_homsets_discreteX.
+Defined.
+
+Lemma has_exponentials_HSET_slice_via_equiv : has_exponentials (BinProducts_HSET_slice X).
+Proof.
+intros Y.
+set (H := has_exponentials_XHSET (Finv Y)).
+set (H1:= pr1 H).
+set (eta1 := pr1 (pr1 (pr2 H))).
+exists (functor_composite (functor_composite Finv H1) F).
+use mk_are_adjoints.
+- admit.
+- admit.
+- admit.
+Admitted.
+
+End via_equivalence.
+
+(* This is now hfiber_hSet *)
 Definition hfiber_HSET {X Y} (f : HSET⟦X,Y⟧) (y : pr1 Y) : HSET.
 Proof.
 mkpair.
@@ -881,10 +788,18 @@ mkpair.
 - now apply pr1.
 Defined.
 
+Lemma PullbackArrowUnique' {C : precategory} {a b c : C} (f : C⟦b,a⟧) (g : C⟦c,a⟧)
+      (P : Pullback f g) e (h : C⟦e,b⟧) (k : C⟦e,c⟧)
+      (Hcomm : h ;; f = k ;; g) (w : C⟦e,P⟧) (H1 : w ;; PullbackPr1 P = h) (H2 : w ;; PullbackPr2 P = k) :
+  w = PullbackArrow P e h k Hcomm.
+Proof.
+now apply PullbackArrowUnique.
+Qed.
+
 Definition hfiber_functor (X : HSET) (f : HSET / X) :
   functor (HSET / X) (HSET / X).
 Proof.
-mkpair.
+use mk_functor.
 + mkpair.
   * apply (hfiber_fun _ f).
   * simpl; intros a b g.
@@ -912,321 +827,98 @@ mkpair.
               now intros XX; apply setproperty ]).
 Defined.
 
-Lemma PullbackArrowUnique' {C : precategory} {a b c d : C} (f : C⟦b,a⟧) (g : C⟦c,a⟧)
-      (P : Pullback f g) e (h : C⟦e,b⟧) (k : C⟦e,c⟧)
-      (Hcomm : h ;; f = k ;; g) (w : C⟦e,P⟧) (H1 : w ;; PullbackPr1 P = h) (H2 : w ;; PullbackPr2 P = k) :
-  w = PullbackArrow P e h k Hcomm.
+(* Attempted direct proof using explicit formula in example 2.2 of:
+    https://ncatlab.org/nlab/show/locally+cartesian+closed+category#in_category_theory
+*)
+Lemma has_exponentials_HSET_slice_direct (X : HSET) :
+  has_exponentials (BinProducts_HSET_slice X).
 Proof.
-now apply PullbackArrowUnique.
-Qed.
-
-Lemma eta {A : Type} (B : A → Type) (f : forall (a : A), B a) : (λ x, f x) = f.
-Proof.
-  apply idpath.
-  Qed.
-
-Lemma has_exponentials_HSET_slice (X : HSET) : has_exponentials (BinProducts_HSET_slice X).
-Proof.
-use dependent_product_to_exponentials.
+intros f.
+exists (hfiber_functor _ f).
+use mk_are_adjoints.
+- use mk_nat_trans.
+  + intros g.
+    simpl.
+    mkpair.
+    * intros y. simpl.
+      exists (pr2 g y).
+      intros fgy.
+      exists ((pr1 fgy,,y),,(pr2 fgy)).
+      apply (pr2 fgy).
+    * abstract (now apply funextsec).
+  + intros g h w.
+    apply (eq_mor_slicecat _ has_homsets_HSET).
+    apply funextsec; intro x1.
+    use total2_paths2.
+    * apply (toforallpaths _ _ _ (!pr2 w) x1).
+    * apply funextsec; intro y.
+      simpl.
+      admit. (* stuck *)
+- admit.
+- admit.
 Admitted.
 
 
-(* Lemma transportf_fun' : *)
+(* Attempted proof using proposition 2.1 from:
+     https://ncatlab.org/nlab/show/locally+cartesian+closed+category#in_category_theory
+*)
+Definition product_hfiber_slice
+  C C' (g : HSET ⟦C,C'⟧) (f : HSET / C) : HSET / C'.
+Proof.
+exists (total2_hSet (λ (c' : pr1 C'), forall_hSet (λ (c : Σ (c : pr1 C), g c = c'), hfiber_hSet (pr2 f) (pr1 c)))).
+simpl; apply pr1.
+Defined.
 
-(*   Π (X : UU) (P Q : X → UU) (x1 x2 : X) (e : x1 = x2) (f : forall x, P x → Q x), *)
-(*   transportf (λ x : X, P x → Q x) e f  =   transportf (λ x : X, P x → Q x) e (f x1). *)
-(*   intros. *)
-(*   set (foo := paths). *)
-(*   Check (f x1 ∘ transportb P e). *)
-
-(* Require Import UniMath.CategoryTheory.DiscretePrecategory. *)
-
-(* Hypothesis equiv_slice : Π (X : HSET), HSET / X ≃ [discrete_precategory (pr1 X),HSET,has_homsets_HSET]. *)
-
-
-(* Lemma has_exponentials_equiv (C D : precategory) (eq : C ≃ D) : has_exponentials C → has_exponentials D. *)
-
-(* Lemma has_exponentials_HSET_slice (X : HSET) : has_exponentials (BinProducts_HSET_slice X). *)
-(* Proof. *)
-
-(* intros f. *)
-(* Search weq. *)
-(*   set (X' := discrete_precategory (pr1 X)). *)
-(*   set (XHSET := [X',HSET,has_homsets_HSET]). *)
-(*   assert (has_homsets_X' : has_homsets X'). *)
-(*   apply has_homsets_discrete_precategory, hlevelntosn, setproperty. *)
-(* set (α := equiv_slice X). *)
-(* set (α1 := pr1 α). *)
-(* set (α2 := invmap α). *)
-(* set (H1 := homotweqinvweq α). *)
-(* set (H2 := homotinvweqweq α). *)
-
-(*   generalize (has_exponentials_functor_HSET X' has_homsets_X' (α1 f)). *)
-(*   unfold has_exponentials. *)
-(*   unfold is_exponentiable. *)
-(*   intros HH. *)
-(*   destruct HH as [HH1 HH2]. *)
-(*   mkpair. *)
-
-(*   Check *)
-(*   simpl. *)
-
-
-
-  (* use left_adjoint_from_partial. *)
-(* - apply (hfiber_fun _ f). *)
-(* - intros g. *)
-(*   mkpair; simpl. *)
-(*   + (* intros [[x [y h]] p]. *) *)
-(*     intros H. *)
-(*     set (x := pr1 (pr1 H)). *)
-(*     set (h := pr2 (pr2 (pr1 H))). *)
-(*     set (p := pr2 H). *)
-(*     apply (pr1 (h (x,,p))). *)
-(*     (* apply (pr1 (pr2 (pr2 (pr1 H)) ((pr1 (pr1 H)),,(pr2 H)))). *) *)
-(*   + abstract (now apply funextfun; intros [[x [y h]] p]; simpl in *; rewrite (pr2 (h (x,,p))), p). *)
-(* - intros g h α. *)
-(*   use unique_exists. *)
-(*   + mkpair. *)
-(*     * intros x. *)
-(*       simpl. *)
-(*       mkpair. *)
-(*       apply (pr2 h x). *)
-(*       intros fh. *)
-(*       transparent assert (asdf : (Σ xy : (pr1 (pr1 f) × pr1 (pr1 h)), pr2 f (pr1 xy) = pr2 h (pr2 xy))). *)
-(*         exists (pr1 fh,,x). *)
-(*         apply (pr2 fh). *)
-(*       rewrite <- (pr2 fh). *)
-(*       mkpair. *)
-(*       apply (pr1 α), asdf. *)
-(*       destruct α as [a Ha]. *)
-(*       simpl in *. *)
-(*       apply (!toforallpaths _ _ _ Ha asdf). *)
-(*     * apply idpath. *)
-(*   + simpl. *)
-(*     apply eq_mor_slicecat. *)
-
-(*     simpl. *)
-(*     unfold PullbackArrow. *)
-(*     simpl. *)
-(*     unfold PullbacksHSET. *)
-(*     simpl. *)
-(*     cbn. *)
-(*     apply funextsec; intro w. *)
-(*     cbn. *)
-(*     unfold PullbacksHSET. *)
-(*     simpl. *)
-(*     unfold PullbackArrow. *)
-(*     simpl. *)
-(*     eapply maponpaths. *)
-(* destruct α as [a1 Ha1]. *)
-(* simpl in *. *)
-
-(* match goal with [|- _ = ?P ;; ?PP ] => set (foo := P); set (bar := PP) end. *)
-(* apply funextsec; intro w. *)
-(* generalize (toforallpaths _ _ _ Ha1 w). *)
-(* cbn. *)
-(* unfold foo. *)
-
-(* intros. *)
-(* match goal with [|- _ = bar (PullbackArrow ?X1 ?X2 ?X3 ?X4 ?X5 ?X6) ] => set (foo1 := X6) end. *)
-(* simpl in *. *)
-(* cbn in foo1. *)
-(* cbn. *)
-(* simpl. *)
-
-(* set (moo := PullbackPr1 (PullbacksHSET X (pr1 f) ((Σ x : pr1 X, hfiber (pr2 f) x → hfiber (pr2 g) x),, hfiber_fun_subproof X f g) *)
-(*                                        (pr2 f) pr1)). *)
-
-(* simpl in *. *)
-(* transparent assert (moo2 : (pr1 (pr1 f) → pr1 (pr1 g))). *)
-(* intros X1. *)
-(* apply a1. *)
-(* mkpair. *)
-(* split. *)
-(* apply X1. *)
-
-(* intros xx *)
-
-(* destruct XX. *)
-
-(* admit. *)
-(* assert (Π x, bar x = moo2 (moo x)). *)
-(* admit. *)
-(* rewrite (funextfun _ _ X0). *)
-(* simpl. *)
-(* simpl in moo. *)
-(* Check (pr2 g). *)
-(* apply funextsec; intro w. *)
-(* generalize (toforallpaths _ _ _ Ha1 w). *)
-(* cbn. *)
-(* destruct w as [[w1 w2] w3]. *)
-(* simpl. *)
-(* simpl in *. *)
-
-(* unfold bar. *)
-(* simpl. *)
-(* unfold foo. *)
-(* cbn. *)
-(* simpl. *)
-(* cbn. *)
-(* set (P := @paths). *)
-(* simpl in *. *)
-(* assert (bar = *)
-(* Check (PullbackPr2). *)
-(* mat *)
-(* set (foo := (λ H : Σ xy : pr1 (pr1 f) × (Σ x : pr1 X, hfiber (pr2 f) x → hfiber (pr2 g) x), pr2 f (pr1 xy) = pr1 (pr2 xy), *)
-(*    pr1 (pr2 (pr2 (pr1 H)) (pr1 (pr1 H),, pr2 H)))). *)
-(*     Search PullbackArrow. *)
-(*     apply funextsec; intro x. *)
-(*     simpl. *)
-(*     cbn. *)
-(*     set (asdf := PullbackArrow _ _ _ _ _). *)
-(*     apply funextfun; intros x. *)
-(*     cbn. *)
-(*     admit. *)
-(*   + intros. *)
-(*     simpl. *)
-(*     apply has_homsets_slice_precat. *)
-(*   +  intros. *)
-(*      simpl. *)
-(*      simpl in X0. *)
-(* mkpair. *)
-(* - split. *)
-
-(* Lemma has_exponentials_HSET_slice (X : HSET) : has_exponentials (BinProducts_HSET_slice X). *)
-(* Proof. *)
-(* intros f. *)
-(* exists (hfiber_functor _ f). *)
-(* mkpair. *)
-(* - split. *)
-(*   + use mk_nat_trans. *)
-(*     * intros g. *)
-(*       simpl. *)
-(*     { mkpair. *)
-(*       + intros y. *)
-(*         exists (pr2 g y). *)
-(*         intros fgy. *)
-(*         exists ((pr1 fgy,,y),,(pr2 fgy)). *)
-(*         apply (pr2 fgy). *)
-(*       + abstract (now apply funextsec). *)
-(*     } *)
-(*     * intros g h w. *)
-(*       apply (eq_mor_slicecat _ has_homsets_HSET). *)
-(*       unfold constprod_functor1. *)
-(*       unfold BinProduct_of_functors. *)
-(*       unfold BinProduct_of_functors_data. *)
-(*       simpl. *)
-(*       Arguments constprod_functor1 : simpl never. *)
-(*       simpl. *)
-
-(*       apply funextsec; intro x. *)
-(*       use total2_paths2. *)
-(*       apply (toforallpaths _ _ _ (!pr2 w) x). *)
-(*       apply funextsec; intro y. *)
-
-(*       use total2_paths. *)
-(*       use total2_paths. *)
-(*       cbn. *)
-(*             destruct w as [w1 w2]. *)
-(*             cbn. *)
-
-(*       cbn. *)
-(*       admit. *)
-(*       generalize (@PullbackArrowUnique' _ (PullbacksHSET X (pr1 f) (pr1 h) (pr2 f) (pr2 h)) ). *)
-(*       Search transportf. *)
-(*       generalize @transportf_total2. *)
-(*       destruct w as [w1 w2]. *)
-(*       simpl in *. *)
-(*       destruct y as [y1 y2]. *)
-(*       cbn. *)
-(*       unfold PullbackArrow. *)
-(*       simpl. *)
-(*       cbn. *)
-
-(*             cbn. *)
-(*       induction (w2). *)
-(*       cbn. *)
-(*       match goal with [|- transportf ?PP ?EE ?HH = _ ] => *)
-(*                       set (P' := PP); set (E := EE); set (H := HH) end. *)
-
-(*       Search transportf. *)
-(*       (* apply funextsec; intro y. *) *)
-(*       etrans. *)
-(*       { *)
-(*         apply funextsec. *)
-(*         intros y. *)
-(*         destruct y as [y1 y2]. *)
-(*         Search transportf. *)
-(*         generalize (@transportf_total2 (pr1 X) (λ x0, hfiber (pr2 f) x0)). (λ x0 : pr1 X, forall W, W → *)
-(*        hfiber (PullbackPr1 (PullbacksHSET X (pr1 f) (pr1 h) (pr2 f) (pr2 h)) ;; pr2 f) x0)). *)
-(*         cbn. *)
-
-(*       Search transportf. *)
-(*       assert (Y : UU). admit. *)
-(*       transparent assert (foo : (P' (pr2 h (pr1 w x)) → Y)). *)
-(*       generalize (@transportf_fun (pr1 X) Y P' _ _ E). *)
-(*       Search transportb. *)
-
-(*       unfold P'. *)
-(*       match goal with [|- transportf ?PP ?EE ?HH = _ ] => *)
-(*                       set (H := HH); set (E := EE); set (P' := PP) end. *)
-
-(*         generalize (@transport_map (pr1 X)  (λ x0, hfiber (pr2 f) x0) (λ x0, hfiber (PullbackPr1 (PullbacksHSET X (pr1 f) (pr1 h) (pr2 f) (pr2 h)) ;; pr2 f) x0)). *)
-(*         Search transportf. *)
-(*       generalize (@transportf_total2 _ P'). *)
-(*       Search transportf. *)
-(*       etrans. *)
-
-(*       transparent assert (foo : (P' ((pr1 w ;; pr2 h) x) → pr1 X)). *)
-(*       cbn in *. *)
-(*       unfold hfiber in H. *)
-(*       unfold hfiber in P'. *)
-(*       unfold P'. *)
-
-(*       apply H. *)
-(*       admit. *)
-(*       generalize (@transportf_fun _ (pr1 X) P' _ _ E foo). *)
-(*       do 1 unfold P'. *)
-(*       simpl. *)
-(*       Search transportf. *)
-(*       etrans. *)
-(*       generalize (@transportf_total2 (pr1 X) (λ x0 : pr1 X, *)
-(*        hfiber (pr2 f) x0 → hfiber (PullbackPr1 (PullbacksHSET X (pr1 f) (pr1 h) (pr2 f) (pr2 h)) ;; pr2 f) x0)). *)
-(*          Search transportf total2. *)
-(*          set (apa := PullbackArrow _ _ _ _ _). *)
-(*          apply pathsinv0. *)
-(*          etrans. *)
-(*          apply eta. *)
-(*          Focus 2. *)
-(*          apply eta. *)
-(*          use PullbackArrowUnique'. *)
-(*           apply funextsec; intros y. *)
-(*           apply subtypeEquality. *)
-(*           intros xx. *)
-(*           apply setproperty. *)
-(*           cbn. *)
-(*           simpl. *)
-(*           apply subtypeEquality. *)
-(*           intros ww. *)
-(*           apply setproperty. *)
-(*           cbn. *)
-(*           destruct y as [y1 y2]. *)
-(*           simpl. *)
-(*           cbn. *)
-(*           destruct w as [w1 w2]; cbn in *. *)
-(*           apply maponpaths. *)
-(*           induction y2. *)
-
-(*           apply idpath. *)
-(*           simpl. *)
-(*           set (APA := paths). *)
-(*           eapply maponpaths. *)
-(*           use PullbackArrowUnique'. *)
-(*           admit. *)
-(*       } *)
-(*     * admit. *)
-(*   + admit. *)
-(* Admitted. *)
+Lemma has_exponentials_HSET_slice : Π X, has_exponentials (BinProducts_HSET_slice X).
+Proof.
+use dependent_product_to_exponentials.
+intros C C' g.
+mkpair.
+- use mk_functor.
+  + mkpair.
+    * intros f.
+      apply (product_hfiber_slice C C' g f).
+    * simpl; intros x y f. {
+      mkpair.
+      - intros Hc'.
+        exists (pr1 Hc').
+        intros p.
+        exists (pr1 f (pr1 (pr2 Hc' p))).
+        abstract (now rewrite <- (pr2 (pr2 Hc' p));
+                      apply (toforallpaths _ _ _ (!pr2 f))).
+      - abstract (now apply funextfun; intro z).
+      }
+  + abstract (split;
+      [ intros x; simpl; apply subtypeEquality; [ intros ?; apply has_homsets_HSET|]; simpl;
+        apply funextfun; intros [c' Hc']; apply (total2_paths2 (idpath _));
+        rewrite idpath_transportf; apply funextsec; intro y;
+        now apply subtypeEquality; [ intros ?; apply setproperty| apply idpath]
+      | intros x y z f1 f2; simpl; apply subtypeEquality; [ intros ?; apply has_homsets_HSET|]; simpl;
+        apply funextfun; intros [c' Hc']; apply (total2_paths2 (idpath _));
+        rewrite idpath_transportf; apply funextsec; intro H;
+        now apply subtypeEquality; [ intros xx; apply setproperty| apply idpath]]).
+- use mk_are_adjoints.
+  + use mk_nat_trans.
+    * intros X; cbn. {
+      mkpair.
+      + simpl; intros x.
+        exists (pr2 X x).
+        intros H.
+        mkpair.
+        * exists (pr1 H,,x).
+          abstract (apply (pr2 H)).
+        * abstract (apply idpath).
+      + abstract (apply idpath).
+      }
+    * intros x y f.
+      apply eq_mor_slicecat.
+      apply funextsec; intro w.
+      use total2_paths2.
+      apply (!(toforallpaths _ _ _ (pr2 f) w)).
+      apply funextsec; intros w2.
+      admit. (* stuck again *)
++ admit.
++ admit.
+Admitted.
 
 End locally_CCC.

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -710,144 +710,144 @@ Qed.
 End exponentials_functor_cat.
 
 (** TODO: remove this *)
-Lemma toforallpaths_induction (X Y : UU) (f g : X -> Y) (P : (Π x, f x = g x) -> UU)
- (H : Π e : f = g, P (toforallpaths _ _ _ e)) : Π i : (Π x, f x = g x), P i.
-Proof.
- intros i. rewrite <- (homotweqinvweq (weqtoforallpaths _ f g)). apply H.
-Defined.
+(* Lemma toforallpaths_induction (X Y : UU) (f g : X -> Y) (P : (Π x, f x = g x) -> UU) *)
+(*  (H : Π e : f = g, P (toforallpaths _ _ _ e)) : Π i : (Π x, f x = g x), P i. *)
+(* Proof. *)
+(*  intros i. rewrite <- (homotweqinvweq (weqtoforallpaths _ f g)). apply H. *)
+(* Defined. *)
 
-Definition transportf_funextfun {X Y : UU} (P : Y -> UU) (F F' : X -> Y) (H : Π (x : X), F x = F' x)
- (x : X) (f : P (F x)) :
- transportf (λ x0 : X → Y, P (x0 x)) (funextsec _ F F' H) f = transportf (λ x0 : Y, P x0) (H x) f.
-Proof.
- apply (toforallpaths_induction
- _ _ F F' (fun H' => transportf (λ x0 : X → Y, P (x0 x))
- (funextsec (λ _ : X, Y) F F' (λ x0 : X, H' x0)) f =
- transportf (λ x0 : Y, P x0) (H' x) f)).
- intro e. clear H.
- set (XR := homotinvweqweq (weqtoforallpaths _ F F') e).
- set (H := funextsec (λ _ : X, Y) F F' (λ x0 : X, toforallpaths (λ _ : X, Y) F F' e x0)).
- set (P' := λ x0 : X → Y, P (x0 x)).
- use pathscomp0.
- - exact (transportf P' e f).
- - use transportf_paths. exact XR.
- - induction e. apply idpath.
-Defined.
-(** *** Transport source and target of a morphism *)
-Lemma transport_target_postcompose {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z)
-(e : z = w) :
-transportf (precategory_morphisms x) e (f ;; g) = f ;; transportf (precategory_morphisms y) e g.
-Proof.
-induction e. apply idpath.
-Qed.
-Lemma transport_source_precompose {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z)
-(e : x = w) :
-transportf (fun x' : ob C => precategory_morphisms x' z) e (f ;; g) =
-transportf (fun x' : ob C => precategory_morphisms x' y) e f ;; g.
-Proof.
-induction e. apply idpath.
-Qed.
-Lemma transport_compose {C : precategory} {x y z w : ob C} (f : x --> y) (g : z --> w) (e : y = z) :
-transportf (precategory_morphisms x) e f ;; g =
-f ;; transportf (fun x' : ob C => precategory_morphisms x' w) (! e) g.
-Proof.
-induction e. apply idpath.
-Qed.
-Lemma transport_compose' {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z) (e : y = w) :
-(transportf (precategory_morphisms x) e f)
-;; (transportf (fun x' : ob C => precategory_morphisms x' z) e g) = f ;; g.
-Proof.
-induction e. apply idpath.
-Qed.
-Lemma transport_target_path {C : precategory} {x y z : ob C} (f g : x --> y) (e : y = z) :
-transportf (precategory_morphisms x) e f = transportf (precategory_morphisms x) e g -> f = g.
-Proof.
-induction e. intros H. apply H.
-Qed.
-Lemma transport_source_path {C : precategory} {x y z : ob C} (f g : y --> z) (e : y = x) :
-transportf (fun x' : ob C => precategory_morphisms x' z) e f =
-transportf (fun x' : ob C => precategory_morphisms x' z) e g -> f = g.
-Proof.
-induction e. intros H. apply H.
-Qed.
-Lemma transport_source_target {X : UU} {C : precategory} {x y : X} (P : Π (x' : X), ob C)
-(P' : Π (x' : X), ob C) (f : Π (x' : X), (P x') --> (P' x')) (e : x = y) :
-transportf (fun (x' : X) => (P x') --> (P' x')) e (f x) =
-transportf (fun (x' : X) => precategory_morphisms (P x') (P' y)) e
-(transportf (precategory_morphisms (P x)) (maponpaths P' e) (f x)).
-Proof.
-rewrite <- functtransportf. unfold pathsinv0. unfold paths_rect. induction e.
-apply idpath.
-Qed.
-Lemma transport_target_source {X : UU} {C : precategory} {x y : X} (P : Π (x' : X), ob C)
-(P' : Π (x' : X), ob C) (f : Π (x' : X), (P x') --> (P' x')) (e : x = y) :
-transportf (fun (x' : X) => (P x') --> (P' x')) e (f x) =
-transportf (precategory_morphisms (P y)) (maponpaths P' e)
-(transportf (fun (x' : X) => precategory_morphisms (P x') (P' x)) e (f x)).
-Proof.
-rewrite <- functtransportf. unfold pathsinv0. unfold paths_rect. induction e.
-apply idpath.
-Qed.
-Lemma transport_source_target_comm {C : precategory} {x y x' y' : ob C} (f : x --> y) (e1 : x = x')
-(e2 : y = y') :
-transportf (fun (x'' : ob C) => precategory_morphisms x'' y') e1
-(transportf (precategory_morphisms x) e2 f) =
-transportf (precategory_morphisms x') e2
-(transportf (fun (x'' : ob C) => precategory_morphisms x'' y) e1 f).
-Proof.
-induction e1. induction e2. apply idpath.
-Qed.
-(** *** Transport a morphism using funextfun *)
-Definition transport_source_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C)
-(H : Π (x : X), F x = F' x) {x : X} (c : ob C) (f : F x --> c) :
-transportf (λ x0 : X → C, x0 x --> c) (funextfun F F' H) f =
-transportf (λ x0 : C, x0 --> c) (H x) f.
-Proof.
-exact (@transportf_funextfun X (ob C) (λ x0 : C, x0 --> c) F F' H x f).
-Qed.
-Definition transport_target_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C)
-(H : Π (x : X), F x = F' x) {x : X} {c : ob C} (f : c --> F x) :
-transportf (λ x0 : X → C, c --> x0 x) (funextfun F F' H) f =
-transportf (λ x0 : C, c --> x0) (H x) f.
-Proof.
-use transportf_funextfun.
-Qed.
-Lemma transport_mor_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C)
-(H : Π (x : X), F x = F' x) {x1 x2 : X} (f : F x1 --> F x2) :
-transportf (λ x : X → C, x x1 --> x x2) (funextfun F F' H) f =
-transportf (λ x : X → C, F' x1 --> x x2)
-(funextfun F F' (λ x : X, H x))
-(transportf (λ x : X → C, x x1 --> F x2)
-((funextfun F F' (λ x : X, H x))) f).
-Proof.
-induction (funextfun F F' (λ x : X, H x)).
-apply idpath.
-Qed.
-Lemma functor_data_eq {C C' : precategory_ob_mor} (F F' : functor_data C C')
- (H : Π (c : C), (pr1 F) c = (pr1 F') c)
- (H1 : Π (C1 C2 : ob C) (f : C1 --> C2),
- transportf (λ x : C', pr1 F' C1 --> x) (H C2)
- (transportf (λ x : C', x --> pr1 F C2) (H C1) (pr2 F C1 C2 f)) =
-   pr2 F' C1 C2 f) : F = F'.
-Proof.
- use total2_paths.
- - use funextfun. intros c. exact (H c).
- - use funextsec. intros C1. use funextsec. intros C2. use funextsec. intros f.
- assert (e : transportf (λ x : C → C', Π a b : C, a --> b → x a --> x b)
- (funextfun (pr1 F) (pr1 F') (λ c : C, H c))
- (pr2 F) C1 C2 f =
- transportf (λ x : C → C', x C1 --> x C2)
- (funextfun (pr1 F) (pr1 F') (λ c : C, H c))
- ((pr2 F) C1 C2 f)).
- {
- induction (funextfun (pr1 F) (pr1 F') (λ c : C, H c)).
- apply idpath.
- }
- rewrite e. clear e.
- rewrite transport_mor_funextfun.
- rewrite transport_source_funextfun. rewrite transport_target_funextfun.
- exact (H1 C1 C2 f).
-Qed.
+(* Definition transportf_funextfun {X Y : UU} (P : Y -> UU) (F F' : X -> Y) (H : Π (x : X), F x = F' x) *)
+(*  (x : X) (f : P (F x)) : *)
+(*  transportf (λ x0 : X → Y, P (x0 x)) (funextsec _ F F' H) f = transportf (λ x0 : Y, P x0) (H x) f. *)
+(* Proof. *)
+(*  apply (toforallpaths_induction *)
+(*  _ _ F F' (fun H' => transportf (λ x0 : X → Y, P (x0 x)) *)
+(*  (funextsec (λ _ : X, Y) F F' (λ x0 : X, H' x0)) f = *)
+(*  transportf (λ x0 : Y, P x0) (H' x) f)). *)
+(*  intro e. clear H. *)
+(*  set (XR := homotinvweqweq (weqtoforallpaths _ F F') e). *)
+(*  set (H := funextsec (λ _ : X, Y) F F' (λ x0 : X, toforallpaths (λ _ : X, Y) F F' e x0)). *)
+(*  set (P' := λ x0 : X → Y, P (x0 x)). *)
+(*  use pathscomp0. *)
+(*  - exact (transportf P' e f). *)
+(*  - use transportf_paths. exact XR. *)
+(*  - induction e. apply idpath. *)
+(* Defined. *)
+(* (** *** Transport source and target of a morphism *) *)
+(* Lemma transport_target_postcompose {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z) *)
+(* (e : z = w) : *)
+(* transportf (precategory_morphisms x) e (f ;; g) = f ;; transportf (precategory_morphisms y) e g. *)
+(* Proof. *)
+(* induction e. apply idpath. *)
+(* Qed. *)
+(* Lemma transport_source_precompose {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z) *)
+(* (e : x = w) : *)
+(* transportf (fun x' : ob C => precategory_morphisms x' z) e (f ;; g) = *)
+(* transportf (fun x' : ob C => precategory_morphisms x' y) e f ;; g. *)
+(* Proof. *)
+(* induction e. apply idpath. *)
+(* Qed. *)
+(* Lemma transport_compose {C : precategory} {x y z w : ob C} (f : x --> y) (g : z --> w) (e : y = z) : *)
+(* transportf (precategory_morphisms x) e f ;; g = *)
+(* f ;; transportf (fun x' : ob C => precategory_morphisms x' w) (! e) g. *)
+(* Proof. *)
+(* induction e. apply idpath. *)
+(* Qed. *)
+(* Lemma transport_compose' {C : precategory} {x y z w : ob C} (f : x --> y) (g : y --> z) (e : y = w) : *)
+(* (transportf (precategory_morphisms x) e f) *)
+(* ;; (transportf (fun x' : ob C => precategory_morphisms x' z) e g) = f ;; g. *)
+(* Proof. *)
+(* induction e. apply idpath. *)
+(* Qed. *)
+(* Lemma transport_target_path {C : precategory} {x y z : ob C} (f g : x --> y) (e : y = z) : *)
+(* transportf (precategory_morphisms x) e f = transportf (precategory_morphisms x) e g -> f = g. *)
+(* Proof. *)
+(* induction e. intros H. apply H. *)
+(* Qed. *)
+(* Lemma transport_source_path {C : precategory} {x y z : ob C} (f g : y --> z) (e : y = x) : *)
+(* transportf (fun x' : ob C => precategory_morphisms x' z) e f = *)
+(* transportf (fun x' : ob C => precategory_morphisms x' z) e g -> f = g. *)
+(* Proof. *)
+(* induction e. intros H. apply H. *)
+(* Qed. *)
+(* Lemma transport_source_target {X : UU} {C : precategory} {x y : X} (P : Π (x' : X), ob C) *)
+(* (P' : Π (x' : X), ob C) (f : Π (x' : X), (P x') --> (P' x')) (e : x = y) : *)
+(* transportf (fun (x' : X) => (P x') --> (P' x')) e (f x) = *)
+(* transportf (fun (x' : X) => precategory_morphisms (P x') (P' y)) e *)
+(* (transportf (precategory_morphisms (P x)) (maponpaths P' e) (f x)). *)
+(* Proof. *)
+(* rewrite <- functtransportf. unfold pathsinv0. unfold paths_rect. induction e. *)
+(* apply idpath. *)
+(* Qed. *)
+(* Lemma transport_target_source {X : UU} {C : precategory} {x y : X} (P : Π (x' : X), ob C) *)
+(* (P' : Π (x' : X), ob C) (f : Π (x' : X), (P x') --> (P' x')) (e : x = y) : *)
+(* transportf (fun (x' : X) => (P x') --> (P' x')) e (f x) = *)
+(* transportf (precategory_morphisms (P y)) (maponpaths P' e) *)
+(* (transportf (fun (x' : X) => precategory_morphisms (P x') (P' x)) e (f x)). *)
+(* Proof. *)
+(* rewrite <- functtransportf. unfold pathsinv0. unfold paths_rect. induction e. *)
+(* apply idpath. *)
+(* Qed. *)
+(* Lemma transport_source_target_comm {C : precategory} {x y x' y' : ob C} (f : x --> y) (e1 : x = x') *)
+(* (e2 : y = y') : *)
+(* transportf (fun (x'' : ob C) => precategory_morphisms x'' y') e1 *)
+(* (transportf (precategory_morphisms x) e2 f) = *)
+(* transportf (precategory_morphisms x') e2 *)
+(* (transportf (fun (x'' : ob C) => precategory_morphisms x'' y) e1 f). *)
+(* Proof. *)
+(* induction e1. induction e2. apply idpath. *)
+(* Qed. *)
+(* (** *** Transport a morphism using funextfun *) *)
+(* Definition transport_source_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C) *)
+(* (H : Π (x : X), F x = F' x) {x : X} (c : ob C) (f : F x --> c) : *)
+(* transportf (λ x0 : X → C, x0 x --> c) (funextfun F F' H) f = *)
+(* transportf (λ x0 : C, x0 --> c) (H x) f. *)
+(* Proof. *)
+(* exact (@transportf_funextfun X (ob C) (λ x0 : C, x0 --> c) F F' H x f). *)
+(* Qed. *)
+(* Definition transport_target_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C) *)
+(* (H : Π (x : X), F x = F' x) {x : X} {c : ob C} (f : c --> F x) : *)
+(* transportf (λ x0 : X → C, c --> x0 x) (funextfun F F' H) f = *)
+(* transportf (λ x0 : C, c --> x0) (H x) f. *)
+(* Proof. *)
+(* use transportf_funextfun. *)
+(* Qed. *)
+(* Lemma transport_mor_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C) *)
+(* (H : Π (x : X), F x = F' x) {x1 x2 : X} (f : F x1 --> F x2) : *)
+(* transportf (λ x : X → C, x x1 --> x x2) (funextfun F F' H) f = *)
+(* transportf (λ x : X → C, F' x1 --> x x2) *)
+(* (funextfun F F' (λ x : X, H x)) *)
+(* (transportf (λ x : X → C, x x1 --> F x2) *)
+(* ((funextfun F F' (λ x : X, H x))) f). *)
+(* Proof. *)
+(* induction (funextfun F F' (λ x : X, H x)). *)
+(* apply idpath. *)
+(* Qed. *)
+(* Lemma functor_data_eq {C C' : precategory_ob_mor} (F F' : functor_data C C') *)
+(*  (H : Π (c : C), (pr1 F) c = (pr1 F') c) *)
+(*  (H1 : Π (C1 C2 : ob C) (f : C1 --> C2), *)
+(*  transportf (λ x : C', pr1 F' C1 --> x) (H C2) *)
+(*  (transportf (λ x : C', x --> pr1 F C2) (H C1) (pr2 F C1 C2 f)) = *)
+(*    pr2 F' C1 C2 f) : F = F'. *)
+(* Proof. *)
+(*  use total2_paths. *)
+(*  - use funextfun. intros c. exact (H c). *)
+(*  - use funextsec. intros C1. use funextsec. intros C2. use funextsec. intros f. *)
+(*  assert (e : transportf (λ x : C → C', Π a b : C, a --> b → x a --> x b) *)
+(*  (funextfun (pr1 F) (pr1 F') (λ c : C, H c)) *)
+(*  (pr2 F) C1 C2 f = *)
+(*  transportf (λ x : C → C', x C1 --> x C2) *)
+(*  (funextfun (pr1 F) (pr1 F') (λ c : C, H c)) *)
+(*  ((pr2 F) C1 C2 f)). *)
+(*  { *)
+(*  induction (funextfun (pr1 F) (pr1 F') (λ c : C, H c)). *)
+(*  apply idpath. *)
+(*  } *)
+(*  rewrite e. clear e. *)
+(*  rewrite transport_mor_funextfun. *)
+(*  rewrite transport_source_funextfun. rewrite transport_target_funextfun. *)
+(*  exact (H1 C1 C2 f). *)
+(* Qed. *)
 (** END OF DELETE *)
 
 (** * Set is locally cartesian closed *)
@@ -925,6 +925,12 @@ Proof.
   apply idpath.
   Qed.
 
+Lemma has_exponentials_HSET_slice (X : HSET) : has_exponentials (BinProducts_HSET_slice X).
+Proof.
+use dependent_product_to_exponentials.
+Admitted.
+
+
 (* Lemma transportf_fun' : *)
 
 (*   Π (X : UU) (P Q : X → UU) (x1 x2 : X) (e : x1 = x2) (f : forall x, P x → Q x), *)
@@ -933,36 +939,37 @@ Proof.
 (*   set (foo := paths). *)
 (*   Check (f x1 ∘ transportb P e). *)
 
-Require Import UniMath.CategoryTheory.DiscretePrecategory.
+(* Require Import UniMath.CategoryTheory.DiscretePrecategory. *)
 
-Hypothesis equiv_slice : Π (X : HSET), HSET / X ≃ [discrete_precategory (pr1 X),HSET,has_homsets_HSET].
+(* Hypothesis equiv_slice : Π (X : HSET), HSET / X ≃ [discrete_precategory (pr1 X),HSET,has_homsets_HSET]. *)
 
 
-Lemma has_exponentials_equiv (C D : precategory) (eq : C ≃ D) : has_exponentials C → has_exponentials D.
+(* Lemma has_exponentials_equiv (C D : precategory) (eq : C ≃ D) : has_exponentials C → has_exponentials D. *)
 
-Lemma has_exponentials_HSET_slice (X : HSET) : has_exponentials (BinProducts_HSET_slice X).
-Proof.
-intros f.
-Search weq.
-  set (X' := discrete_precategory (pr1 X)).
-  set (XHSET := [X',HSET,has_homsets_HSET]).
-  assert (has_homsets_X' : has_homsets X').
-  apply has_homsets_discrete_precategory, hlevelntosn, setproperty.
-set (α := equiv_slice X).
-set (α1 := pr1 α).
-set (α2 := invmap α).
-set (H1 := homotweqinvweq α).
-set (H2 := homotinvweqweq α).
+(* Lemma has_exponentials_HSET_slice (X : HSET) : has_exponentials (BinProducts_HSET_slice X). *)
+(* Proof. *)
 
-  generalize (has_exponentials_functor_HSET X' has_homsets_X' (α1 f)).
-  unfold has_exponentials.
-  unfold is_exponentiable.
-  intros HH.
-  destruct HH as [HH1 HH2].
-  mkpair.
+(* intros f. *)
+(* Search weq. *)
+(*   set (X' := discrete_precategory (pr1 X)). *)
+(*   set (XHSET := [X',HSET,has_homsets_HSET]). *)
+(*   assert (has_homsets_X' : has_homsets X'). *)
+(*   apply has_homsets_discrete_precategory, hlevelntosn, setproperty. *)
+(* set (α := equiv_slice X). *)
+(* set (α1 := pr1 α). *)
+(* set (α2 := invmap α). *)
+(* set (H1 := homotweqinvweq α). *)
+(* set (H2 := homotinvweqweq α). *)
 
-  Check
-  simpl.
+(*   generalize (has_exponentials_functor_HSET X' has_homsets_X' (α1 f)). *)
+(*   unfold has_exponentials. *)
+(*   unfold is_exponentiable. *)
+(*   intros HH. *)
+(*   destruct HH as [HH1 HH2]. *)
+(*   mkpair. *)
+
+(*   Check *)
+(*   simpl. *)
 
 
 
@@ -1087,139 +1094,139 @@ set (H2 := homotinvweqweq α).
 (* mkpair. *)
 (* - split. *)
 
-Lemma has_exponentials_HSET_slice (X : HSET) : has_exponentials (BinProducts_HSET_slice X).
-Proof.
-intros f.
-exists (hfiber_functor _ f).
-mkpair.
-- split.
-  + use mk_nat_trans.
-    * intros g.
-      simpl.
-    { mkpair.
-      + intros y.
-        exists (pr2 g y).
-        intros fgy.
-        exists ((pr1 fgy,,y),,(pr2 fgy)).
-        apply (pr2 fgy).
-      + abstract (now apply funextsec).
-    }
-    * intros g h w.
-      apply (eq_mor_slicecat _ has_homsets_HSET).
-      unfold constprod_functor1.
-      unfold BinProduct_of_functors.
-      unfold BinProduct_of_functors_data.
-      simpl.
-      Arguments constprod_functor1 : simpl never.
-      simpl.
+(* Lemma has_exponentials_HSET_slice (X : HSET) : has_exponentials (BinProducts_HSET_slice X). *)
+(* Proof. *)
+(* intros f. *)
+(* exists (hfiber_functor _ f). *)
+(* mkpair. *)
+(* - split. *)
+(*   + use mk_nat_trans. *)
+(*     * intros g. *)
+(*       simpl. *)
+(*     { mkpair. *)
+(*       + intros y. *)
+(*         exists (pr2 g y). *)
+(*         intros fgy. *)
+(*         exists ((pr1 fgy,,y),,(pr2 fgy)). *)
+(*         apply (pr2 fgy). *)
+(*       + abstract (now apply funextsec). *)
+(*     } *)
+(*     * intros g h w. *)
+(*       apply (eq_mor_slicecat _ has_homsets_HSET). *)
+(*       unfold constprod_functor1. *)
+(*       unfold BinProduct_of_functors. *)
+(*       unfold BinProduct_of_functors_data. *)
+(*       simpl. *)
+(*       Arguments constprod_functor1 : simpl never. *)
+(*       simpl. *)
 
-      apply funextsec; intro x.
-      use total2_paths2.
-      apply (toforallpaths _ _ _ (!pr2 w) x).
-      apply funextsec; intro y.
+(*       apply funextsec; intro x. *)
+(*       use total2_paths2. *)
+(*       apply (toforallpaths _ _ _ (!pr2 w) x). *)
+(*       apply funextsec; intro y. *)
 
-      use total2_paths.
-      use total2_paths.
-      cbn.
-            destruct w as [w1 w2].
-            cbn.
+(*       use total2_paths. *)
+(*       use total2_paths. *)
+(*       cbn. *)
+(*             destruct w as [w1 w2]. *)
+(*             cbn. *)
 
-      cbn.
-      admit.
-      generalize (@PullbackArrowUnique' _ (PullbacksHSET X (pr1 f) (pr1 h) (pr2 f) (pr2 h)) ).
-      Search transportf.
-      generalize @transportf_total2.
-      destruct w as [w1 w2].
-      simpl in *.
-      destruct y as [y1 y2].
-      cbn.
-      unfold PullbackArrow.
-      simpl.
-      cbn.
+(*       cbn. *)
+(*       admit. *)
+(*       generalize (@PullbackArrowUnique' _ (PullbacksHSET X (pr1 f) (pr1 h) (pr2 f) (pr2 h)) ). *)
+(*       Search transportf. *)
+(*       generalize @transportf_total2. *)
+(*       destruct w as [w1 w2]. *)
+(*       simpl in *. *)
+(*       destruct y as [y1 y2]. *)
+(*       cbn. *)
+(*       unfold PullbackArrow. *)
+(*       simpl. *)
+(*       cbn. *)
 
-            cbn.
-      induction (w2).
-      cbn.
-      match goal with [|- transportf ?PP ?EE ?HH = _ ] =>
-                      set (P' := PP); set (E := EE); set (H := HH) end.
+(*             cbn. *)
+(*       induction (w2). *)
+(*       cbn. *)
+(*       match goal with [|- transportf ?PP ?EE ?HH = _ ] => *)
+(*                       set (P' := PP); set (E := EE); set (H := HH) end. *)
 
-      Search transportf.
-      (* apply funextsec; intro y. *)
-      etrans.
-      {
-        apply funextsec.
-        intros y.
-        destruct y as [y1 y2].
-        Search transportf.
-        generalize (@transportf_total2 (pr1 X) (λ x0, hfiber (pr2 f) x0)). (λ x0 : pr1 X, forall W, W →
-       hfiber (PullbackPr1 (PullbacksHSET X (pr1 f) (pr1 h) (pr2 f) (pr2 h)) ;; pr2 f) x0)).
-        cbn.
+(*       Search transportf. *)
+(*       (* apply funextsec; intro y. *) *)
+(*       etrans. *)
+(*       { *)
+(*         apply funextsec. *)
+(*         intros y. *)
+(*         destruct y as [y1 y2]. *)
+(*         Search transportf. *)
+(*         generalize (@transportf_total2 (pr1 X) (λ x0, hfiber (pr2 f) x0)). (λ x0 : pr1 X, forall W, W → *)
+(*        hfiber (PullbackPr1 (PullbacksHSET X (pr1 f) (pr1 h) (pr2 f) (pr2 h)) ;; pr2 f) x0)). *)
+(*         cbn. *)
 
-      Search transportf.
-      assert (Y : UU). admit.
-      transparent assert (foo : (P' (pr2 h (pr1 w x)) → Y)).
-      generalize (@transportf_fun (pr1 X) Y P' _ _ E).
-      Search transportb.
+(*       Search transportf. *)
+(*       assert (Y : UU). admit. *)
+(*       transparent assert (foo : (P' (pr2 h (pr1 w x)) → Y)). *)
+(*       generalize (@transportf_fun (pr1 X) Y P' _ _ E). *)
+(*       Search transportb. *)
 
-      unfold P'.
-      match goal with [|- transportf ?PP ?EE ?HH = _ ] =>
-                      set (H := HH); set (E := EE); set (P' := PP) end.
+(*       unfold P'. *)
+(*       match goal with [|- transportf ?PP ?EE ?HH = _ ] => *)
+(*                       set (H := HH); set (E := EE); set (P' := PP) end. *)
 
-        generalize (@transport_map (pr1 X)  (λ x0, hfiber (pr2 f) x0) (λ x0, hfiber (PullbackPr1 (PullbacksHSET X (pr1 f) (pr1 h) (pr2 f) (pr2 h)) ;; pr2 f) x0)).
-        Search transportf.
-      generalize (@transportf_total2 _ P').
-      Search transportf.
-      etrans.
+(*         generalize (@transport_map (pr1 X)  (λ x0, hfiber (pr2 f) x0) (λ x0, hfiber (PullbackPr1 (PullbacksHSET X (pr1 f) (pr1 h) (pr2 f) (pr2 h)) ;; pr2 f) x0)). *)
+(*         Search transportf. *)
+(*       generalize (@transportf_total2 _ P'). *)
+(*       Search transportf. *)
+(*       etrans. *)
 
-      transparent assert (foo : (P' ((pr1 w ;; pr2 h) x) → pr1 X)).
-      cbn in *.
-      unfold hfiber in H.
-      unfold hfiber in P'.
-      unfold P'.
+(*       transparent assert (foo : (P' ((pr1 w ;; pr2 h) x) → pr1 X)). *)
+(*       cbn in *. *)
+(*       unfold hfiber in H. *)
+(*       unfold hfiber in P'. *)
+(*       unfold P'. *)
 
-      apply H.
-      admit.
-      generalize (@transportf_fun _ (pr1 X) P' _ _ E foo).
-      do 1 unfold P'.
-      simpl.
-      Search transportf.
-      etrans.
-      generalize (@transportf_total2 (pr1 X) (λ x0 : pr1 X,
-       hfiber (pr2 f) x0 → hfiber (PullbackPr1 (PullbacksHSET X (pr1 f) (pr1 h) (pr2 f) (pr2 h)) ;; pr2 f) x0)).
-         Search transportf total2.
-         set (apa := PullbackArrow _ _ _ _ _).
-         apply pathsinv0.
-         etrans.
-         apply eta.
-         Focus 2.
-         apply eta.
-         use PullbackArrowUnique'.
-          apply funextsec; intros y.
-          apply subtypeEquality.
-          intros xx.
-          apply setproperty.
-          cbn.
-          simpl.
-          apply subtypeEquality.
-          intros ww.
-          apply setproperty.
-          cbn.
-          destruct y as [y1 y2].
-          simpl.
-          cbn.
-          destruct w as [w1 w2]; cbn in *.
-          apply maponpaths.
-          induction y2.
+(*       apply H. *)
+(*       admit. *)
+(*       generalize (@transportf_fun _ (pr1 X) P' _ _ E foo). *)
+(*       do 1 unfold P'. *)
+(*       simpl. *)
+(*       Search transportf. *)
+(*       etrans. *)
+(*       generalize (@transportf_total2 (pr1 X) (λ x0 : pr1 X, *)
+(*        hfiber (pr2 f) x0 → hfiber (PullbackPr1 (PullbacksHSET X (pr1 f) (pr1 h) (pr2 f) (pr2 h)) ;; pr2 f) x0)). *)
+(*          Search transportf total2. *)
+(*          set (apa := PullbackArrow _ _ _ _ _). *)
+(*          apply pathsinv0. *)
+(*          etrans. *)
+(*          apply eta. *)
+(*          Focus 2. *)
+(*          apply eta. *)
+(*          use PullbackArrowUnique'. *)
+(*           apply funextsec; intros y. *)
+(*           apply subtypeEquality. *)
+(*           intros xx. *)
+(*           apply setproperty. *)
+(*           cbn. *)
+(*           simpl. *)
+(*           apply subtypeEquality. *)
+(*           intros ww. *)
+(*           apply setproperty. *)
+(*           cbn. *)
+(*           destruct y as [y1 y2]. *)
+(*           simpl. *)
+(*           cbn. *)
+(*           destruct w as [w1 w2]; cbn in *. *)
+(*           apply maponpaths. *)
+(*           induction y2. *)
 
-          apply idpath.
-          simpl.
-          set (APA := paths).
-          eapply maponpaths.
-          use PullbackArrowUnique'.
-          admit.
-      }
-    * admit.
-  + admit.
-Admitted.
+(*           apply idpath. *)
+(*           simpl. *)
+(*           set (APA := paths). *)
+(*           eapply maponpaths. *)
+(*           use PullbackArrowUnique'. *)
+(*           admit. *)
+(*       } *)
+(*     * admit. *)
+(*   + admit. *)
+(* Admitted. *)
 
 End locally_CCC.

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -720,67 +720,219 @@ mkpair.
 + abstract (now apply isaset_hfiber; apply setproperty).
 Defined.
 
+Definition hfiber_fun (X : HSET) (f : HSET / X) : HSET / X → HSET / X.
+Proof.
+intros g.
+mkpair.
+- exists (Σ x, HSET⟦hfiber_HSET (pr2 f) x,hfiber_HSET (pr2 g) x⟧).
+  abstract (apply isaset_total2; [ apply setproperty | intros x; apply has_homsets_HSET ]).
+- now apply pr1.
+Defined.
+
+Definition hfiber_functor (X : HSET) (f : HSET / X) :
+  functor (HSET / X) (HSET / X).
+Proof.
+mkpair.
++ mkpair.
+  * apply (hfiber_fun _ f).
+  * simpl; intros a b g.
+    { mkpair; simpl.
+    - intros h.
+      mkpair.
+      + apply (pr1 h).
+      + intros fx.
+        mkpair.
+        * apply (pr1 g), (pr1 (pr2 h fx)).
+        * abstract (etrans; [ apply (!toforallpaths _ _ _ (pr2 g) (pr1 (pr2 h fx)))|];
+                    apply (pr2 (pr2 h fx))).
+    - abstract (now apply funextsec).
+    }
++ abstract (split;
+            [ intros x; apply (eq_mor_slicecat _ has_homsets_HSET); simpl;
+              apply funextsec; intro y; simpl;
+              destruct y as [y hy]; use total2_paths; [ apply idpath |];
+              apply funextsec; intros w; apply subtypeEquality; [|apply idpath];
+              now intros XX; apply setproperty
+            | intros x y z g h; apply (eq_mor_slicecat _ has_homsets_HSET); simpl;
+              apply funextsec; intro w; simpl;
+              destruct w as [w hw];
+              use total2_paths; [ apply idpath |];
+              apply funextsec; intros w'; apply subtypeEquality; [|apply idpath];
+              now intros XX; apply setproperty ]).
+Defined.
+
+Lemma PullbackArrowUnique' {C : precategory} {a b c d : C} (f : C⟦b,a⟧) (g : C⟦c,a⟧)
+      (P : Pullback f g) e (h : C⟦e,b⟧) (k : C⟦e,c⟧)
+      (Hcomm : h ;; f = k ;; g) (w : C⟦e,P⟧) (H1 : w ;; PullbackPr1 P = h) (H2 : w ;; PullbackPr2 P = k) :
+  w = PullbackArrow P e h k Hcomm.
+Proof.
+now apply PullbackArrowUnique.
+Qed.
+
+Lemma eta {A : Type} (B : A → Type) (f : forall (a : A), B a) : (λ x, f x) = f.
+Proof.
+  apply idpath.
+  Qed.
+
+(* Lemma transportf_fun' : *)
+
+(*   Π (X : UU) (P Q : X → UU) (x1 x2 : X) (e : x1 = x2) (f : forall x, P x → Q x), *)
+(*   transportf (λ x : X, P x → Q x) e f  =   transportf (λ x : X, P x → Q x) e (f x1). *)
+(*   intros. *)
+(*   set (foo := paths). *)
+(*   Check (f x1 ∘ transportb P e). *)
+
+
 Lemma has_exponentials_HSET_slice (X : HSET) : has_exponentials (BinProducts_HSET_slice X).
 Proof.
 intros f.
-mkpair.
-- mkpair.
+use left_adjoint_from_partial.
+- apply (hfiber_fun _ f).
+- intros g.
+  mkpair; simpl.
+  + (* intros [[x [y h]] p]. *)
+    intros H.
+    set (x := pr1 (pr1 H)).
+    set (h := pr2 (pr2 (pr1 H))).
+    set (p := pr2 H).
+    apply (pr1 (h (x,,p))).
+    (* apply (pr1 (pr2 (pr2 (pr1 H)) ((pr1 (pr1 H)),,(pr2 H)))). *)
+  + abstract (now apply funextfun; intros [[x [y h]] p]; simpl in *; rewrite (pr2 (h (x,,p))), p).
+- intros g h α.
+  use unique_exists.
   + mkpair.
+    * intros x.
+
+      simpl.
+      mkpair.
+      apply (pr2 h x).
+      intros fh.
+      transparent assert (asdf : (Σ xy : (pr1 (pr1 f) × pr1 (pr1 h)), pr2 f (pr1 xy) = pr2 h (pr2 xy))).
+
+        exists (pr1 fh,,x).
+        apply (pr2 fh).
+
+      rewrite <- (pr2 fh).
+      mkpair.
+      apply (pr1 α), asdf.
+      destruct α as [a Ha].
+      simpl in *.
+      apply (!toforallpaths _ _ _ Ha asdf).
+    * apply idpath.
+  + simpl.
+
+    apply eq_mor_slicecat.
+    simpl.
+    set (asdf := PullbackArrow _ _ _ _ _).
+    apply funextfun; intros x.
+    cbn.
+    simpl.
+    admit.
+  + admit.
+  + simpl. intros.
+
+mkpair.
+- split.
+
+Lemma has_exponentials_HSET_slice (X : HSET) : has_exponentials (BinProducts_HSET_slice X).
+Proof.
+intros f.
+exists (hfiber_functor _ f).
+mkpair.
+- split.
+  + use mk_nat_trans.
     * intros g.
-      { mkpair.
-      - exists (Σ x, HSET⟦hfiber_HSET (pr2 f) x,hfiber_HSET (pr2 g) x⟧).
-        abstract (apply isaset_total2; [ apply setproperty | intros x; apply has_homsets_HSET ]).
-      - now apply pr1. }
-    * simpl; intros a b g.
-      { mkpair; simpl.
-      - intros h.
-        mkpair.
-        + apply (pr1 h).
-        + intros fx.
-          mkpair.
-          * apply (pr1 g), (pr1 (pr2 h fx)).
-          * abstract (etrans; [ apply (!toforallpaths _ _ _ (pr2 g) (pr1 (pr2 h fx)))|];
-                      apply (pr2 (pr2 h fx))).
-      - abstract (now apply funextsec).
-      }
-  + abstract (split;
-    [ intros x; apply (eq_mor_slicecat _ has_homsets_HSET); simpl;
-      apply funextsec; intro y; simpl;
-      destruct y as [y hy]; use total2_paths; [ apply idpath |];
-      apply funextsec; intros w; apply subtypeEquality; [|apply idpath];
-      now intros XX; apply setproperty
-    | intros x y z g h; apply (eq_mor_slicecat _ has_homsets_HSET); simpl;
-      apply funextsec; intro w; simpl;
-      destruct w as [w hw];
-      use total2_paths; [ apply idpath |];
-      apply funextsec; intros w'; apply subtypeEquality; [|apply idpath];
-      now intros XX; apply setproperty ]).
-- simpl.
-  mkpair.
-  + split.
-    * { mkpair.
-        - intros g.
-          cbn.
-          mkpair.
-          + simpl.
-            intros y.
-            mkpair.
-            * apply (pr2 g y).
-            * intros fgy.
-              mkpair.
-              exists (pr1 fgy,,y).
-              apply (pr2 fgy).
-              apply (pr2 fgy).
-          + now apply funextsec.
-        - intros g h w; apply (eq_mor_slicecat _ has_homsets_HSET); simpl.
-          apply funextsec; intro x.
-          use total2_paths; simpl.
-          apply (!toforallpaths _ _ _ (pr2 w) x).
+    { mkpair.
+      + simpl.
+        intros y.
+        exists (pr2 g y).
+        intros fgy.
+        exists ((pr1 fgy,,y),,(pr2 fgy)).
+        apply (pr2 fgy).
+      + now apply funextsec.
+    }
+    * intros g h w.
+      apply (eq_mor_slicecat _ has_homsets_HSET); simpl.
+      apply funextsec; intro x.
+      use total2_paths2; simpl.
+      apply (!toforallpaths _ _ _ (pr2 w) x).
+
+      match goal with [|- transportf ?PP ?EE ?HH = _ ] =>
+                      set (P' := PP); set (E := EE); set (H := HH) end.
+
+      Search transportf.
+      (* apply funextsec; intro y. *)
+      etrans.
+      {
+        apply funextsec.
+        intros y.
+        destruct y as [y1 y2].
+        Search transportf.
+        generalize (@transportf_total2 (pr1 X) (λ x0, hfiber (pr2 f) x0)). (λ x0 : pr1 X, forall W, W →
+       hfiber (PullbackPr1 (PullbacksHSET X (pr1 f) (pr1 h) (pr2 f) (pr2 h)) ;; pr2 f) x0)).
+        cbn.
+
+      Search transportf.
+      assert (Y : UU). admit.
+      transparent assert (foo : (P' (pr2 h (pr1 w x)) → Y)).
+      generalize (@transportf_fun (pr1 X) Y P' _ _ E).
+      Search transportb.
+
+      unfold P'.
+      match goal with [|- transportf ?PP ?EE ?HH = _ ] =>
+                      set (H := HH); set (E := EE); set (P' := PP) end.
+
+        generalize (@transport_map (pr1 X)  (λ x0, hfiber (pr2 f) x0) (λ x0, hfiber (PullbackPr1 (PullbacksHSET X (pr1 f) (pr1 h) (pr2 f) (pr2 h)) ;; pr2 f) x0)).
+        Search transportf.
+      generalize (@transportf_total2 _ P').
+      Search transportf.
+      etrans.
+
+      transparent assert (foo : (P' ((pr1 w ;; pr2 h) x) → pr1 X)).
+      cbn in *.
+      unfold hfiber in H.
+      unfold hfiber in P'.
+      unfold P'.
+
+      apply H.
+      admit.
+      generalize (@transportf_fun _ (pr1 X) P' _ _ E foo).
+      do 1 unfold P'.
+      simpl.
+      Search transportf.
+      etrans.
+      generalize (@transportf_total2 (pr1 X) (λ x0 : pr1 X,
+       hfiber (pr2 f) x0 → hfiber (PullbackPr1 (PullbacksHSET X (pr1 f) (pr1 h) (pr2 f) (pr2 h)) ;; pr2 f) x0)).
+         Search transportf total2.
+         set (apa := PullbackArrow _ _ _ _ _).
+         apply pathsinv0.
+         etrans.
+         apply eta.
+         Focus 2.
+         apply eta.
+         use PullbackArrowUnique'.
           apply funextsec; intros y.
           apply subtypeEquality.
           intros xx.
           apply setproperty.
           cbn.
+          simpl.
+          apply subtypeEquality.
+          intros ww.
+          apply setproperty.
+          cbn.
+          destruct y as [y1 y2].
+          simpl.
+          cbn.
+          destruct w as [w1 w2]; cbn in *.
+          apply maponpaths.
+          induction y2.
+
+          apply idpath.
+          simpl.
+          set (APA := paths).
+          eapply maponpaths.
+          use PullbackArrowUnique'.
           admit.
       }
     * admit.

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -810,43 +810,54 @@ Defined.
 
 End locally_CCC.
 
-(** * Indexed non-empty products in SET/X *)
 Section products_set_slice.
 
 Local Notation "HSET / X" := (slice_precat HSET X has_homsets_HSET).
 
-(** Note that I has to be non-empty *)
-Lemma Products_HSET_slice I X (i : I) : Products I (HSET / X).
+(* The following is an experiment which computes what the product in Set/X should    be from the one in [X,Set] using the equivalence between Set/X and [X,Set] *)
+(* Require Import UniMath.CategoryTheory.set_slice_fam_equiv. *)
+(* Require Import UniMath.CategoryTheory.DiscretePrecategory. *)
+
+(* Lemma Products_HSET_slice I X : Products I (HSET / X). *)
+(* Proof. *)
+(* intros F. *)
+(* set (foo1 := Products_functor_precat I (discrete_precategory (pr1 X)) HSET (ProductsHSET I) has_homsets_HSET). *)
+(* set (XHSET := [discrete_precategory (pr1 X), HSET, has_homsets_HSET]). *)
+(* set (G := λ i, slice_to_fam X (F i) : XHSET). *)
+(* set (foo2 := ProductObject I XHSET (foo1 G)). *)
+(* set (goal := pr1 (pr1 (fam_to_slice _ foo2))). *)
+(* cbn in goal. *)
+
+Lemma Products_HSET_slice I X : Products I (HSET / X).
 Proof.
-intros f.
+intros F.
 use mk_ProductCone.
 + mkpair.
-  - exists (Σ (a : forall_hSet (λ (i : I), pr1 (f i))),
-              Π (i j : I), pr2 (f i) (a i) = pr2 (f j) (a j)).
-    abstract (apply isaset_total2; try apply setproperty; simpl; intro a;
-    apply impred_isaset; intro j; apply impred_isaset; intro k;
-    now apply isasetaprop, setproperty).
-  - intros H; apply (pr2 (f i)), (pr1 H).
-+ intros j.
+  - exists (Σ x : pr1 X, Π i : I, hfiber_hSet (pr2 (F i)) x).
+    abstract (apply isaset_total2; [apply setproperty|];
+              now intros x; apply impred_isaset; intro i; apply setproperty).
+  - apply pr1.
++ intros i.
   mkpair.
-  - intros H; apply (pr1 H j).
-  - abstract (now apply funextsec; intros H; apply (pr2 H)).
-+ intros g h.
+  - intros H; apply (pr1 (pr2 H i)).
+  - abstract (now apply funextsec; intros H; apply (!pr2 (pr2 H i))).
++ intros f H.
   use unique_exists.
   - mkpair; simpl.
     * intros x.
-      exists (λ j, pr1 (h j) x).
-      abstract (intros j k; etrans; [apply (!toforallpaths _ _ _ (pr2 (h j)) x)|];
-      now apply pathsinv0; etrans; [apply (!toforallpaths _ _ _ (pr2 (h k)) x)|]).
-    * abstract (now apply funextsec; intro x; apply (toforallpaths _ _ _ (pr2 (h i)) x)).
-  - abstract (intros j; apply subtypeEquality; [intros x; apply setproperty|];
-              now apply funextsec).
-  - abstract (intros y; apply impred_isaprop; intros; apply has_homsets_slice_precat).
-  - intros y Hy; apply subtypeEquality; [intros x; apply setproperty|]; simpl.
-    apply funextsec; intro x; apply subtypeEquality.
-    * intros w; apply impred_isaprop; intros j; apply impred_isaprop; intros k.
-      now apply setproperty.
-    * now simpl; apply funextsec; intro w; rewrite <- (Hy w).
+      exists (pr2 f x).
+      intros i.
+      exists (pr1 (H i) x).
+      abstract (exact (!toforallpaths _ _ _ (pr2 (H i)) x)).
+    * abstract (now apply funextsec).
+  - abstract (now intros i; apply eq_mor_slicecat, funextsec).
+  - abstract (now intros g; apply impred_isaprop; intro i; apply has_homsets_slice_precat).
+  - abstract (simpl; intros [y1 y2] Hy; apply eq_mor_slicecat, funextsec; intro x;
+    use total2_paths; [apply (toforallpaths _ _ _ (!y2) x)|];
+    apply funextsec; intro i; apply subtypeEquality; [intros w; apply setproperty|];
+    destruct f as [f Hf]; cbn in *;
+    induction (toforallpaths (λ _ : f, X) (λ x0 : f, pr1 (y1 x0)) Hf (! y2) x);
+    now rewrite idpath_transportf, <- (Hy i)).
 Defined.
 
 End products_set_slice.

--- a/UniMath/CategoryTheory/equivalences.v
+++ b/UniMath/CategoryTheory/equivalences.v
@@ -179,6 +179,18 @@ use mk_are_adjoints.
     now apply id_left.
 Defined.
 
+Lemma is_left_adjoint_functor_composite
+  {A B : precategory} {F1 : functor A B} {F2 : functor B A}
+  (H1 : is_left_adjoint F1) (H2 : is_left_adjoint F2) :
+  is_left_adjoint (functor_composite F1 F2).
+Proof.
+mkpair.
+- apply (functor_composite (pr1 H2) (pr1 H1)).
+- apply are_adjoints_functor_composite.
+  + apply (pr2 H1).
+  + apply (pr2 H2).
+Defined.
+
 (** * Equivalence of (pre)categories *)
 
 Definition adj_equivalence_of_precats {A B : precategory} (F : functor A B) : UU :=

--- a/UniMath/CategoryTheory/equivalences.v
+++ b/UniMath/CategoryTheory/equivalences.v
@@ -53,6 +53,17 @@ Definition are_adjoints {A B : precategory} (F : functor A B) (G : functor B A) 
               (nat_trans (functor_composite G F) (functor_identity B))),
       form_adjunction F G (pr1 etaeps) (pr2 etaeps).
 
+
+Definition mk_are_adjoints {A B : precategory}
+  (F : functor A B) (G : functor B A)
+  (eta : nat_trans (functor_identity A) (functor_composite F G))
+  (eps : nat_trans (functor_composite G F) (functor_identity B))
+  (HH : form_adjunction F G eta eps) : are_adjoints F G.
+Proof.
+exists (eta,,eps).
+abstract (exact HH).
+Defined.
+
 Definition unit_from_are_adjoints {A B : precategory}
    {F : functor A B} {G : functor B A} (H : are_adjoints F G) :
   nat_trans (functor_identity A) (functor_composite F G)
@@ -126,6 +137,47 @@ Definition triangle_id_right_ad {A B : precategory} {F : functor A B} {G : funct
   (H : are_adjoints F G) :
   Π b, unit_from_are_adjoints H (G b) ;; # G (counit_from_are_adjoints H b) = identity (G b)
   := pr2 (pr2 H).
+
+Lemma are_adjoints_functor_composite
+  {A B : precategory} {F1 G2 : functor A B} {F2 G1 : functor B A}
+  (H1 : are_adjoints F1 G1) (H2 : are_adjoints F2 G2) :
+  are_adjoints (functor_composite F1 F2) (functor_composite G2 G1).
+Proof.
+destruct H1 as [[eta1 eps1] [H11 H12]].
+destruct H2 as [[eta2 eps2] [H21 H22]].
+simpl in *.
+use mk_are_adjoints.
+- apply (nat_trans_comp _ _ _ eta1).
+  use (nat_trans_comp _ _ _ _ (nat_trans_functor_assoc_inv _ _ _)).
+  apply pre_whisker.
+  apply (nat_trans_comp _ _ _ (nat_trans_functor_id_right_inv _)
+                              (post_whisker eta2 G1)).
+- use (nat_trans_comp _ _ _ _ eps2).
+  apply (nat_trans_comp _ _ _ (nat_trans_functor_assoc _ _ _)).
+  apply pre_whisker.
+  apply (nat_trans_comp _ _ _ (nat_trans_functor_assoc_inv _ _ _)).
+  apply (nat_trans_comp _ _ _ (post_whisker eps1 _)
+                              (nat_trans_functor_id_left _)).
+- split; intros a; simpl.
+  + rewrite !id_left, !id_right, <-functor_id, <- H11, !functor_comp, <-!assoc.
+    apply maponpaths; rewrite assoc.
+    etrans; [eapply cancel_postcomposition, pathsinv0, functor_comp|].
+    etrans.
+      apply cancel_postcomposition, maponpaths.
+      apply (nat_trans_ax eps1 (F1 a) (G2 (F2 (F1 a))) (eta2 (F1 a))).
+    simpl; rewrite functor_comp, <- assoc.
+    etrans; [eapply maponpaths, H21|].
+    now apply id_right.
+  + rewrite !id_left, !id_right, <- functor_id, <- H22, !functor_comp, assoc.
+    apply cancel_postcomposition; rewrite <- assoc.
+    etrans; [eapply maponpaths, pathsinv0, functor_comp|].
+    etrans.
+      eapply maponpaths, maponpaths, pathsinv0.
+      apply (nat_trans_ax eta2 (F1 (G1 (G2 a))) (G2 a) (eps1 _)).
+    simpl; rewrite functor_comp, assoc.
+    etrans; [apply cancel_postcomposition, H12|].
+    now apply id_left.
+Defined.
 
 (** * Equivalence of (pre)categories *)
 

--- a/UniMath/CategoryTheory/equivalences.v
+++ b/UniMath/CategoryTheory/equivalences.v
@@ -139,7 +139,8 @@ Definition triangle_id_right_ad {A B : precategory} {F : functor A B} {G : funct
   := pr2 (pr2 H).
 
 Lemma are_adjoints_functor_composite
-  {A B : precategory} {F1 G2 : functor A B} {F2 G1 : functor B A}
+  {A B C : precategory} {F1 : functor A B} {F2 : functor B C}
+  {G1 : functor B A} {G2 : functor C B}
   (H1 : are_adjoints F1 G1) (H2 : are_adjoints F2 G2) :
   are_adjoints (functor_composite F1 F2) (functor_composite G2 G1).
 Proof.
@@ -180,7 +181,7 @@ use mk_are_adjoints.
 Defined.
 
 Lemma is_left_adjoint_functor_composite
-  {A B : precategory} {F1 : functor A B} {F2 : functor B A}
+  {A B C : precategory} {F1 : functor A B} {F2 : functor B C}
   (H1 : is_left_adjoint F1) (H2 : is_left_adjoint F2) :
   is_left_adjoint (functor_composite F1 F2).
 Proof.

--- a/UniMath/CategoryTheory/equivalences.v
+++ b/UniMath/CategoryTheory/equivalences.v
@@ -53,7 +53,7 @@ Definition are_adjoints {A B : precategory} (F : functor A B) (G : functor B A) 
               (nat_trans (functor_composite G F) (functor_identity B))),
       form_adjunction F G (pr1 etaeps) (pr2 etaeps).
 
-
+(** Note that this makes the second component opaque for efficiency reasons *)
 Definition mk_are_adjoints {A B : precategory}
   (F : functor A B) (G : functor B A)
   (eta : nat_trans (functor_identity A) (functor_composite F G))

--- a/UniMath/CategoryTheory/equivalences.v
+++ b/UniMath/CategoryTheory/equivalences.v
@@ -192,6 +192,38 @@ mkpair.
   + apply (pr2 H2).
 Defined.
 
+Lemma is_left_adjoint_iso {A B : precategory} (hsB : has_homsets B)
+  (F G : functor A B) (αiso : @iso [A,B,hsB] F G) (HF : is_left_adjoint F) :
+  is_left_adjoint G.
+Proof.
+set (α := pr1 αiso : nat_trans F G).
+set (αinv := inv_from_iso αiso : nat_trans G F).
+destruct HF as [F' [[α' β'] [HF1 HF2]]]; simpl in HF1, HF2.
+mkpair.
+- apply F'.
+- use mk_are_adjoints.
+  + apply (nat_trans_comp _ _ _ α' (post_whisker α F')).
+  + apply (nat_trans_comp _ _ _ (pre_whisker F' αinv) β').
+  + split.
+    * simpl; intro a; rewrite assoc, functor_comp.
+      etrans; [ apply cancel_postcomposition; rewrite <- assoc;
+                apply maponpaths, (nat_trans_ax αinv)|].
+      etrans; [ rewrite assoc, <- !assoc;
+                apply maponpaths, maponpaths, (nat_trans_ax β')|].
+      simpl; rewrite assoc.
+      etrans; [ apply cancel_postcomposition, (nat_trans_ax αinv)|].
+      rewrite assoc.
+      etrans; [ apply cancel_postcomposition; rewrite <- assoc;
+                apply maponpaths, HF1|].
+      now rewrite id_right; apply (nat_trans_eq_pointwise (iso_after_iso_inv αiso)).
+    * simpl; intro b; rewrite functor_comp, assoc.
+      etrans; [ apply cancel_postcomposition; rewrite <- assoc;
+                eapply maponpaths, pathsinv0, functor_comp|].
+      etrans; [ apply cancel_postcomposition, maponpaths, maponpaths,
+                      (nat_trans_eq_pointwise (iso_inv_after_iso αiso))|].
+      now rewrite (functor_id F'), id_right, (HF2 b).
+Defined.
+
 (** * Equivalence of (pre)categories *)
 
 Definition adj_equivalence_of_precats {A B : precategory} (F : functor A B) : UU :=

--- a/UniMath/CategoryTheory/functor_categories.v
+++ b/UniMath/CategoryTheory/functor_categories.v
@@ -146,8 +146,13 @@ Qed.
 Definition functor (C C' : precategory_data) : UU :=
   total2 ( fun F : functor_data C C' => is_functor F ).
 
+(** Note that this makes the second component opaque for efficiency reasons *)
 Definition mk_functor {C C' : precategory_data} (F : functor_data C C') (H : is_functor F) :
-  functor C C' := tpair _ F H.
+  functor C C'.
+Proof.
+exists F.
+abstract (exact H).
+Defined.
 
 Lemma functor_eq (C C' : precategory_data) (hs: has_homsets C') (F F': functor C C'):
     pr1 F = pr1 F' -> F = F'.
@@ -747,7 +752,7 @@ Qed.
 Definition nat_trans {C C' : precategory_data} (F F' : functor_data C C') : UU :=
   total2 (fun t : Π x : ob C, F x -->  F' x => is_nat_trans F F' t).
 
-(* Note that the second component is made opaque *)
+(** Note that this makes the second component opaque for efficiency reasons *)
 Definition mk_nat_trans {C C' : precategory_data} (F F' : functor_data C C')
            (t : Π x : ob C, F x --> F' x) (H : is_nat_trans F F' t) :
            nat_trans F F'.

--- a/UniMath/CategoryTheory/functor_categories.v
+++ b/UniMath/CategoryTheory/functor_categories.v
@@ -747,9 +747,14 @@ Qed.
 Definition nat_trans {C C' : precategory_data} (F F' : functor_data C C') : UU :=
   total2 (fun t : Π x : ob C, F x -->  F' x => is_nat_trans F F' t).
 
+(* Note that the second component is made opaque *)
 Definition mk_nat_trans {C C' : precategory_data} (F F' : functor_data C C')
            (t : Π x : ob C, F x --> F' x) (H : is_nat_trans F F' t) :
-  nat_trans F F' := tpair _ t H.
+           nat_trans F F'.
+Proof.
+exists t.
+abstract (exact H).
+Defined.
 
 Lemma isaset_nat_trans {C C' : precategory_data} (hs: has_homsets C')
   (F F' : functor_data C C') : isaset (nat_trans F F').

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -98,6 +98,15 @@ Definition PullbackArrow {a b c : C} {f : b --> a} {g : c --> a}
    (Pb : Pullback f g) e (h : e --> b) (k : e --> c)(H : h ;; f = k ;; g) : e --> Pb :=
    pr1 (pr1 (isPullback_Pullback Pb e h k H)).
 
+Lemma PullbackArrowUnique' {a b c : C} (f : C⟦b,a⟧) (g : C⟦c,a⟧)
+      (P : Pullback f g) e (h : C⟦e,b⟧) (k : C⟦e,c⟧)
+      (Hcomm : h ;; f = k ;; g) (w : C⟦e,P⟧) (H1 : w ;; PullbackPr1 P = h) (H2 : w ;; PullbackPr2 P = k) :
+  w = PullbackArrow P e h k Hcomm.
+Proof.
+now apply PullbackArrowUnique.
+Qed.
+
+
 Lemma PullbackArrow_PullbackPr1 {a b c : C} {f : b --> a} {g : c --> a}
    (Pb : Pullback f g) e (h : e --> b) (k : e --> c)(H : h ;; f = k ;; g) :
    PullbackArrow Pb e h k H ;; PullbackPr1 Pb = h.

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -138,6 +138,26 @@ Proof.
   apply H'. assumption.
 Defined.
 
+Local Lemma postCompWithPullbackArrow_subproof
+ {c d a b x : C} (k0 : C⟦c,d⟧) {f : C⟦a,x⟧} {g : C⟦b,x⟧}
+ {h : C ⟦ d, a ⟧} {k : C ⟦ d, b ⟧} (H : h ;; f = k ;; g)  :
+  k0 ;; h ;; f = k0 ;; k ;; g.
+Proof.
+now rewrite <- assoc, H, assoc.
+Defined.
+
+Lemma postCompWithPullbackArrow
+ (c d : C) (k0 : C⟦c,d⟧) {a b x : C} {f : C⟦a,x⟧} {g : C⟦b,x⟧}
+ (Pb : Pullback f g)
+ (h : C ⟦ d, a ⟧) (k : C ⟦ d, b ⟧) (H : h ;; f = k ;; g) :
+   k0 ;; PullbackArrow Pb d h k H =
+   PullbackArrow Pb _ (k0 ;; h) (k0 ;; k) (postCompWithPullbackArrow_subproof k0 H).
+Proof.
+apply PullbackArrowUnique.
+- now rewrite <- assoc, PullbackArrow_PullbackPr1.
+- now rewrite <- assoc, PullbackArrow_PullbackPr2.
+Qed.
+
 Lemma MorphismsIntoPullbackEqual {a b c d : C} {f : b --> a} {g : c --> a}
         {p1 : d --> b} {p2 : d --> c} {H : p1 ;; f = p2;; g}
         (P : isPullback f g p1 p2 H) {e}

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -92,7 +92,7 @@ Definition isPullback_Pullback {a b c : C} {f : b --> a}{g : c --> a}
   isPullback f g (PullbackPr1 P) (PullbackPr2 P) (PullbackSqrCommutes P).
 Proof.
   exact (pr2 (pr2 P)).
-Qed.
+Defined.
 
 Definition PullbackArrow {a b c : C} {f : b --> a} {g : c --> a}
    (Pb : Pullback f g) e (h : e --> b) (k : e --> c)(H : h ;; f = k ;; g) : e --> Pb :=
@@ -144,7 +144,7 @@ Local Lemma postCompWithPullbackArrow_subproof
   k0 ;; h ;; f = k0 ;; k ;; g.
 Proof.
 now rewrite <- assoc, H, assoc.
-Defined.
+Qed.
 
 Lemma postCompWithPullbackArrow
  (c d : C) (k0 : C⟦c,d⟧) {a b x : C} {f : C⟦a,x⟧} {g : C⟦b,x⟧}

--- a/UniMath/CategoryTheory/set_slice_fam_equiv.v
+++ b/UniMath/CategoryTheory/set_slice_fam_equiv.v
@@ -131,7 +131,7 @@ Section set_slice_fam_equiv.
   Qed.
 
   Definition slice_unit := nat_trans_inv_from_pointwise_inv _ _
-                                                            (has_homsets_slice_precat _ has_homsets_HSET X) _ _
+                                                            (has_homsets_slice_precat has_homsets_HSET X) _ _
                                                             slice_counit slice_all_iso.
 
   Definition fam_unit_fun_fun (f : fam X) (x : X) :

--- a/UniMath/CategoryTheory/set_slice_fam_equiv.v
+++ b/UniMath/CategoryTheory/set_slice_fam_equiv.v
@@ -84,7 +84,7 @@ Section set_slice_fam_equiv.
   Theorem is_functor_fam_to_slice : is_functor fam_to_slice_data.
   Proof.
     split; [intro f | intros f f' f'' F F'];
-      apply slice_precat_morphisms_pr1_eq.
+      apply eq_mor_slicecat.
     + apply funextsec. intro p.
       exact (!tppr p).
     + reflexivity.
@@ -106,7 +106,7 @@ Section set_slice_fam_equiv.
   Definition is_nat_trans_slice_counit : is_nat_trans _ _ slice_counit_fun.
   Proof.
     intros f f' F.
-    apply slice_precat_morphisms_pr1_eq.
+    apply eq_mor_slicecat.
     unfold slice_counit_fun. simpl.
     unfold compose. simpl.
     apply funextsec. intro p.
@@ -190,7 +190,7 @@ Section set_slice_fam_equiv.
     unfold form_adjunction.
     split.
     + intro f.
-      apply slice_precat_morphisms_pr1_eq.
+      apply eq_mor_slicecat.
       apply funextsec. intro x.
       exact (!tppr _).
     + intro F.

--- a/UniMath/CategoryTheory/slicecat.v
+++ b/UniMath/CategoryTheory/slicecat.v
@@ -35,6 +35,7 @@ Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import UniMath.CategoryTheory.limits.binproducts.
 Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.equivalences.
+Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 
 (** * Definition of slice categories *)
@@ -635,4 +636,39 @@ exists (eta g,,eps g).
 exact (form_adjunction_eta_eps g).
 Defined.
 
+Section dependent_product.
+
+Context (H : Π {c c' : C} (g : C⟦c,c'⟧), is_left_adjoint (base_change_functor g)).
+
+Let Π_ {c c' : C} (g : C⟦c,c'⟧) : functor (C / c) (C / c') := right_adjoint (H c c' g).
+
+Definition dependent_product_to_exponentials c :
+  has_exponentials (BinProducts_slice_precat hsC PC c).
+Proof.
+intros Af.
+mkpair.
++ mkpair.
+  - mkpair.
+    * intros Af'.
+      apply (Π_ (pr2 Af) (base_change_functor (pr2 Af) Af')).
+    * intros x y f.
+{ mkpair.
+-
+apply (# (Π_ (pr2 Af))).
+mkpair.
++ apply (# (base_change_functor (pr2 Af)) f).
++ abstract (now simpl; rewrite PullbackArrow_PullbackPr1).
+- admit.
+}
+- split.
+  * intros x.
+simpl.
+admit.
+* intros x y f.
+simpl.
+admit.
++ admit.
+Admitted.
+
+End dependent_product.
 End base_change.

--- a/UniMath/CategoryTheory/slicecat.v
+++ b/UniMath/CategoryTheory/slicecat.v
@@ -23,6 +23,9 @@ Contents:
 - Binary coproducts in slice categories of categories with binary
   coproducts ([BinCoproducts_slice_precat])
 
+- Coproducts in slice categories of categories with coproducts
+  ([Coproducts_slice_precat])
+
 - Terminal object in slice categories ([Terminal_slice_precat])
 
 - Base change functor ([base_change_functor]) and proof that
@@ -41,6 +44,7 @@ Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import UniMath.CategoryTheory.limits.binproducts.
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
+Require Import UniMath.CategoryTheory.limits.coproducts.
 Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.equivalences.
 Require Import UniMath.CategoryTheory.exponentials.
@@ -498,6 +502,37 @@ use mk_BinCoproductCocone.
 Defined.
 
 End slicecat_bincoproducts.
+
+(** * Coproducts in slice categories of categories with coproducts *)
+Section slicecat_coproducts.
+
+Context {C : precategory} (hsC : has_homsets C) (I : UU) (BC : Coproducts I C).
+
+Local Notation "C / X" := (slice_precat C X hsC).
+
+Lemma Coproducts_slice_precat (x : C) : Coproducts I (C / x).
+Proof.
+intros a.
+use mk_CoproductCocone.
++ exists (CoproductObject _ _ (BC (λ i, pr1 (a i)))).
+  apply CoproductArrow; intro i; apply (pr2 (a i)).
++ intro i; mkpair; simpl.
+  - apply (CoproductIn I C (BC (λ i, pr1 (a i))) i).
+  - abstract (now rewrite (CoproductInCommutes I C _ (BC (λ i, pr1 (a i))))).
++ intros c f.
+  use unique_exists.
+  - exists (CoproductArrow _ _ _ (λ i, pr1 (f i))).
+    abstract (simpl; apply pathsinv0, CoproductArrowUnique; intro i;
+              now rewrite assoc, (CoproductInCommutes _ _ _ (BC (λ i, pr1 (a i)))), (pr2 (f i))).
+  - abstract (now intros i;
+              apply eq_mor_slicecat, (CoproductInCommutes _ _ _ (BC (λ i0 : I, pr1 (a i0))))).
+  - abstract (now intros y; apply impred; intro i; apply has_homsets_slice_precat).
+  - abstract (simpl; intros y Hy;
+              apply eq_mor_slicecat, CoproductArrowUnique;
+              intros i; apply (maponpaths pr1 (Hy i))).
+Defined.
+
+End slicecat_coproducts.
 
 Section slicecat_terminal.
 

--- a/UniMath/CategoryTheory/slicecat.v
+++ b/UniMath/CategoryTheory/slicecat.v
@@ -20,6 +20,9 @@ Contents:
 - Binary products in slice categories of categories with pullbacks
   ([BinProducts_slice_precat])
 
+- Binary coproducts in slice categories of categories with binary
+  coproducts ([BinCoproducts_slice_precat])
+
 - Terminal object in slice categories ([Terminal_slice_precat])
 
 - Base change functor ([base_change_functor]) and proof that
@@ -37,6 +40,7 @@ Require Import UniMath.CategoryTheory.limits.graphs.limits.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import UniMath.CategoryTheory.limits.binproducts.
+Require Import UniMath.CategoryTheory.limits.bincoproducts.
 Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.equivalences.
 Require Import UniMath.CategoryTheory.exponentials.
@@ -461,6 +465,39 @@ use mk_BinProductCone.
 Defined.
 
 End slicecat_binproducts.
+
+(** * Binary coproducts in slice categories of categories with binary coproducts *)
+Section slicecat_bincoproducts.
+
+Context {C : precategory} (hsC : has_homsets C) (BC : BinCoproducts C).
+
+Local Notation "C / X" := (slice_precat C X hsC).
+
+Lemma BinCoproducts_slice_precat (x : C) : BinCoproducts (C / x).
+Proof.
+intros a b.
+use mk_BinCoproductCocone.
++ exists (BinCoproductObject _ (BC (pr1 a) (pr1 b))).
+  apply (BinCoproductArrow _ _ (pr2 a) (pr2 b)).
++ mkpair.
+  - apply BinCoproductIn1.
+  - abstract (now rewrite BinCoproductIn1Commutes).
++ mkpair.
+  - apply BinCoproductIn2.
+  - abstract (now rewrite BinCoproductIn2Commutes).
++ intros c f g.
+  use unique_exists.
+  - exists (BinCoproductArrow _ _ (pr1 f) (pr1 g)).
+    abstract (apply pathsinv0, BinCoproductArrowUnique;
+      [ now rewrite assoc, (BinCoproductIn1Commutes C _ _ (BC (pr1 a) (pr1 b))), (pr2 f)
+      | now rewrite assoc, (BinCoproductIn2Commutes C _ _ (BC (pr1 a) (pr1 b))), (pr2 g)]).
+  - abstract (split; apply eq_mor_slicecat; simpl;
+             [ apply BinCoproductIn1Commutes | apply BinCoproductIn2Commutes ]).
+  - abstract (intros y; apply isapropdirprod; apply has_homsets_slice_precat).
+  - abstract (now intros y [<- <-]; apply eq_mor_slicecat, BinCoproductArrowUnique).
+Defined.
+
+End slicecat_bincoproducts.
 
 Section slicecat_terminal.
 

--- a/UniMath/CategoryTheory/slicecat.v
+++ b/UniMath/CategoryTheory/slicecat.v
@@ -38,7 +38,6 @@ Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import UniMath.CategoryTheory.limits.binproducts.
 Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.equivalences.
-Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 

--- a/UniMath/CategoryTheory/slicecat.v
+++ b/UniMath/CategoryTheory/slicecat.v
@@ -16,6 +16,9 @@ Contents:
 
 - Colimits in slice categories ([slice_precat_colims])
 
+- Binary products in slice categories of categories with pullbacks
+ ([BinProducts_slice_precat])
+
 ************************************************************)
 
 Require Import UniMath.Foundations.Basics.PartD.
@@ -26,6 +29,8 @@ Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.limits.pullbacks.
+Require Import UniMath.CategoryTheory.limits.binproducts.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 
 (** * Definition of slice categories *)
@@ -444,3 +449,33 @@ Proof.
     apply hsC.
   + exact (pr1eq).
 Defined.
+
+(** * Binary products in slice categories of categories with pullbacks *)
+Section slicecat_binproducts.
+
+Context {C : precategory} (hsC : has_homsets C) (PC : Pullbacks C).
+
+Local Notation "C / X" := (slice_precat C X hsC).
+
+Lemma BinProducts_slice_precat (x : C) : BinProducts (C / x).
+Proof.
+intros a b.
+use mk_BinProductCone.
++ exists (PullbackObject (PC _ _ _ (pr2 a) (pr2 b))).
+  apply (PullbackPr1 (PC x _ _ (pr2 a) (pr2 b)) ;; pr2 a).
++ use (PullbackPr1 _,,idpath _).
++ use (PullbackPr2 _,, PullbackSqrCommutes _).
++ intros c f g.
+  use unique_exists.
+  - mkpair.
+    * apply (PullbackArrow _ _ (pr1 f) (pr1 g)).
+      abstract (now rewrite <- (pr2 f), <- (pr2 g)).
+    * abstract (now rewrite assoc, PullbackArrow_PullbackPr1, <- (pr2 f)).
+  - abstract (split; apply eq_mor_slicecat; simpl;
+             [ apply PullbackArrow_PullbackPr1 | apply PullbackArrow_PullbackPr2 ]).
+  - abstract (now intros h; apply isapropdirprod; apply has_homsets_slice_precat).
+  - abstract (intros h [H1 H2]; apply eq_mor_slicecat, PullbackArrowUnique;
+             [ apply (maponpaths pr1 H1) | apply (maponpaths pr1 H2) ]).
+Defined.
+
+End slicecat_binproducts.

--- a/UniMath/CategoryTheory/slicecat.v
+++ b/UniMath/CategoryTheory/slicecat.v
@@ -17,7 +17,9 @@ Contents:
 - Colimits in slice categories ([slice_precat_colims])
 
 - Binary products in slice categories of categories with pullbacks
- ([BinProducts_slice_precat])
+  ([BinProducts_slice_precat])
+
+- Terminal object in slice categories ([Terminal_slice_precat])
 
 ************************************************************)
 
@@ -31,6 +33,7 @@ Require Import UniMath.CategoryTheory.limits.graphs.limits.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import UniMath.CategoryTheory.limits.binproducts.
+Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 
 (** * Definition of slice categories *)
@@ -479,3 +482,25 @@ use mk_BinProductCone.
 Defined.
 
 End slicecat_binproducts.
+
+Section slicecat_terminal.
+
+Context {C : precategory} (hsC : has_homsets C).
+
+Local Notation "C / X" := (slice_precat C X hsC).
+
+Lemma Terminal_slice_precat (x : C) : Terminal (C / x).
+Proof.
+use mk_Terminal.
+- mkpair.
+  + apply x.
+  + apply (identity x).
+- intros y.
+  use unique_exists; simpl.
+  * apply (pr2 y).
+  * abstract (now rewrite id_right).
+  * abstract (now intros f; apply hsC).
+  * abstract (now intros f ->; rewrite id_right).
+Defined.
+
+End slicecat_terminal.

--- a/UniMath/CategoryTheory/slicecat.v
+++ b/UniMath/CategoryTheory/slicecat.v
@@ -21,6 +21,9 @@ Contents:
 
 - Terminal object in slice categories ([Terminal_slice_precat])
 
+- Base change functor ([base_change_functor]) and its left adjoint
+  dependent sum functor ([dependent_sum_functor])
+
 ************************************************************)
 
 Require Import UniMath.Foundations.Basics.PartD.
@@ -443,19 +446,6 @@ Proof.
 now intros g d; apply slice_precat_ColimCocone, CC.
 Defined.
 
-(** morphisms of slice precategories with homsests equal if first projection equal *)
-Lemma slice_precat_morphisms_pr1_eq {C : precategory} (hsC : has_homsets C) (x : ob C)
-      {a b : ob (slice_precat C x hsC)} (f g : a --> b) :
-  pr1 f = pr1 g -> f = g.
-Proof.
-  intro pr1eq.
-  apply (invmaponpathsincl pr1).
-  + apply isofhlevelfpr1.
-    intro h.
-    apply hsC.
-  + exact (pr1eq).
-Defined.
-
 (** * Binary products in slice categories of categories with pullbacks *)
 Section slicecat_binproducts.
 
@@ -508,6 +498,7 @@ Defined.
 
 End slicecat_terminal.
 
+(** Base change functor: https://ncatlab.org/nlab/show/base+change *)
 Section base_change.
 
 Context {C : precategory} (hsC : has_homsets C) (PC : Pullbacks C).
@@ -568,26 +559,6 @@ Qed.
 Definition dependent_sum_functor {c c' : C} (g : C⟦c,c'⟧) : functor (C / c) (C / c') :=
   (dependent_sum_functor_data g,,is_functor_dependent_sum_functor g).
 
-Lemma temp
- {c d a b x : C} (k0 : C⟦c,d⟧) {f : C⟦a,x⟧} {g : C⟦b,x⟧}
- {h : C ⟦ d, a ⟧} {k : C ⟦ d, b ⟧} (H : h ;; f = k ;; g)  :
-  k0 ;; h ;; f = k0 ;; k ;; g.
-Proof.
-now rewrite <- assoc, H, assoc.
-Qed.
-
-(* TODO: move *)
-Lemma postCompWithPullbackArrow
- (c d : C) (k0 : C⟦c,d⟧) {a b x : C} {f : C⟦a,x⟧} {g : C⟦b,x⟧}
- (h : C ⟦ d, a ⟧) (k : C ⟦ d, b ⟧) (H : h ;; f = k ;; g) :
-   k0 ;; PullbackArrow (PC _ _ _ f g) d h k H =
-   PullbackArrow (PC _ _ _ f g) _ (k0 ;; h) (k0 ;; k) (temp k0 H).
-Proof.
-apply PullbackArrowUnique.
-- now rewrite <- assoc, PullbackArrow_PullbackPr1.
-- now rewrite <- assoc, PullbackArrow_PullbackPr2.
-Qed.
-
 Local Definition eta {c c' : C} (g : C⟦c,c'⟧) :
   nat_trans (functor_identity (C / c))
             (functor_composite (dependent_sum_functor g) (base_change_functor g)).
@@ -637,6 +608,10 @@ exists (eta g,,eps g).
 exact (form_adjunction_eta_eps g).
 Defined.
 
+(** If the base change functor has a right adjoint, called dependent product, then C / c has
+    exponentials. The formal proof is inspired by Proposition 2.1 from:
+    https://ncatlab.org/nlab/show/locally+cartesian+closed+category#in_category_theory
+*)
 Section dependent_product.
 
 Context (H : Π {c c' : C} (g : C⟦c,c'⟧), is_left_adjoint (base_change_functor g)).
@@ -644,21 +619,11 @@ Context (H : Π {c c' : C} (g : C⟦c,c'⟧), is_left_adjoint (base_change_funct
 Let dependent_product_functor {c c' : C} (g : C⟦c,c'⟧) :
   functor (C / c) (C / c') := right_adjoint (H c c' g).
 
-Let η {c c' : C} (g : C⟦c,c'⟧) :
-  nat_trans (functor_identity (C / c'))
-            (functor_composite (base_change_functor g) (dependent_product_functor g)) :=
-  unit_from_left_adjoint (H _ _ g).
-
-Let ε {c c' : C} (g : C⟦c,c'⟧) :
-  nat_trans (functor_composite (dependent_product_functor g) (base_change_functor g))
-            (functor_identity (C / c)) :=
-  counit_from_left_adjoint (H _ _ g).
-
 Let BPC c : BinProducts (C / c) := BinProducts_slice_precat hsC PC c.
 
-Lemma test c (Af : C / c) :
+Lemma const_prod_functor1_slicecat c (Af : C / c) :
   constprod_functor1 (BPC c) Af =
-   (functor_composite (base_change_functor (pr2 Af)) (dependent_sum_functor (pr2 Af))).
+  functor_composite (base_change_functor (pr2 Af)) (dependent_sum_functor (pr2 Af)).
 Proof.
 apply functor_eq; try apply has_homsets_slice_precat.
 use functor_data_eq; try trivial.
@@ -668,70 +633,16 @@ apply PullbackArrowUnique.
 - now rewrite PullbackArrow_PullbackPr2.
 Defined.
 
-Definition mk_are_adjoints {A B : precategory}
-  (F : functor A B) (G : functor B A)
-  (eta : nat_trans (functor_identity A) (functor_composite F G))
-  (eps : nat_trans (functor_composite G F) (functor_identity B))
-  (HH : form_adjunction F G eta eps) : are_adjoints F G.
-Proof.
-exists (eta,,eps).
-abstract (exact HH).
-Defined.
-
-Lemma are_adjoints_functor_composite
-  {A B : precategory} {F1 G2 : functor A B} {F2 G1 : functor B A}
-  (H1 : are_adjoints F1 G1) (H2 : are_adjoints F2 G2) :
-  are_adjoints (functor_composite F1 F2) (functor_composite G2 G1).
-Proof.
-destruct H1 as [[eta1 eps1] [H11 H12]].
-destruct H2 as [[eta2 eps2] [H21 H22]].
-simpl in *.
-use mk_are_adjoints.
-- apply (nat_trans_comp _ _ _ eta1).
-  use (nat_trans_comp _ _ _ _ (nat_trans_functor_assoc_inv _ _ _)).
-  apply pre_whisker.
-  apply (nat_trans_comp _ _ _ (nat_trans_functor_id_right_inv _)
-                              (post_whisker eta2 G1)).
-- use (nat_trans_comp _ _ _ _ eps2).
-  apply (nat_trans_comp _ _ _ (nat_trans_functor_assoc _ _ _)).
-  apply pre_whisker.
-  apply (nat_trans_comp _ _ _ (nat_trans_functor_assoc_inv _ _ _)).
-  apply (nat_trans_comp _ _ _ (post_whisker eps1 _)
-                              (nat_trans_functor_id_left _)).
-- split; intros a; simpl.
-  + rewrite !id_left, !id_right, <-functor_id, <- H11, !functor_comp, <-!assoc.
-    apply maponpaths; rewrite assoc.
-    etrans; [eapply cancel_postcomposition, pathsinv0, functor_comp|].
-    etrans.
-      apply cancel_postcomposition, maponpaths.
-      apply (nat_trans_ax eps1 (F1 a) (G2 (F2 (F1 a))) (eta2 (F1 a))).
-    simpl; rewrite functor_comp, <- assoc.
-    etrans; [eapply maponpaths, H21|].
-    now apply id_right.
-  + rewrite !id_left, !id_right, <- functor_id, <- H22, !functor_comp, assoc.
-    apply cancel_postcomposition; rewrite <- assoc.
-    etrans; [eapply maponpaths, pathsinv0, functor_comp|].
-    etrans.
-      eapply maponpaths, maponpaths, pathsinv0.
-      apply (nat_trans_ax eta2 (F1 (G1 (G2 a))) (G2 a) (eps1 _)).
-    simpl; rewrite functor_comp, assoc.
-    etrans; [apply cancel_postcomposition, H12|].
-    now apply id_left.
-Defined.
-
-Definition dependent_product_to_exponentials c :
-  has_exponentials (BPC c).
+Lemma dependent_product_to_exponentials c : has_exponentials (BPC c).
 Proof.
 intros Af.
 mkpair.
-+ eapply functor_composite.
-apply (base_change_functor (pr2 Af)).
-apply (dependent_product_functor (pr2 Af)).
-+
-rewrite test.
-use are_adjoints_functor_composite.
-apply (pr2 (H _ _ _)).
-apply are_adjoints_dependent_sum_base_change.
++ apply (functor_composite (base_change_functor (pr2 Af))
+                           (dependent_product_functor (pr2 Af))).
++ rewrite const_prod_functor1_slicecat.
+  apply are_adjoints_functor_composite.
+  - apply (pr2 (H _ _ _)).
+  - apply are_adjoints_dependent_sum_base_change.
 Defined.
 
 End dependent_product.

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -259,7 +259,7 @@ use BindingSigToSignature.
 - apply BinCoproductsHSET.
 - apply TerminalHSET.
 - apply sig.
-- apply Coproducts_HSET, (isasetifdeceq _ (BindingSigIsdeceq sig)).
+- apply CoproductsHSET, (isasetifdeceq _ (BindingSigIsdeceq sig)).
 Defined.
 
 Lemma is_omega_cocont_BindingSigToSignatureHSET (sig : BindingSig) :
@@ -271,7 +271,7 @@ apply (is_omega_cocont_Sum_of_Signatures _ (BindingSigIsdeceq sig)).
   + intros F.
     apply (is_omega_cocont_constprod_functor1 _ has_homsets_HSET2).
     apply has_exponentials_functor_HSET, has_homsets_HSET.
-- apply Products_HSET.
+- apply ProductsHSET.
 Defined.
 
 (** ** Construction of initial algebra for a signature with strength for HSET *)
@@ -297,8 +297,8 @@ intros sig; use (BindingSigToMonad _ _ _ _ _ _ _ sig).
 - intros F.
   apply (is_omega_cocont_constprod_functor1 _ has_homsets_HSET2).
   apply has_exponentials_functor_HSET, has_homsets_HSET.
-- apply Products_HSET.
-- apply Coproducts_HSET.
+- apply ProductsHSET.
+- apply CoproductsHSET.
   exact (isasetifdeceq _ (BindingSigIsdeceq sig)).
 Defined.
 

--- a/UniMath/SubstitutionSystems/LamFromBindingSig.v
+++ b/UniMath/SubstitutionSystems/LamFromBindingSig.v
@@ -172,7 +172,7 @@ rewrite assoc.
 eapply pathscomp0.
   eapply cancel_postcomposition, cancel_postcomposition.
   apply (CoproductOfArrowsIn _ _ (Coproducts_functor_precat _ _ _
-          (Coproducts_HSET _ (isasetifdeceq _ isdeceqbool))
+          (CoproductsHSET _ (isasetifdeceq _ isdeceqbool))
           _ (λ i, pr1 (Arity_to_Signature has_homsets_HSET BinProductsHSET
                          BinCoproductsHSET TerminalHSET (BindingSigMap LamSig i)) `LC_alg))).
 rewrite <- assoc.
@@ -202,7 +202,7 @@ rewrite assoc.
 eapply pathscomp0.
   eapply cancel_postcomposition, cancel_postcomposition.
   apply (CoproductOfArrowsIn _ _ (Coproducts_functor_precat _ _ _
-          (Coproducts_HSET _ (isasetifdeceq _ isdeceqbool))
+          (CoproductsHSET _ (isasetifdeceq _ isdeceqbool))
           _ (λ i, pr1 (Arity_to_Signature has_homsets_HSET BinProductsHSET
                          BinCoproductsHSET TerminalHSET (BindingSigMap LamSig i)) `LC_alg))).
 rewrite <- assoc.


### PR DESCRIPTION
This PR includes:

- Direct definition of pullbacks in HSET
- Definition of binary products in C/c when C has pullbacks
- Terminal object in C/c
- Direct proof that HSET is locally cartesian closed
- Definition of base change functor (given c -> c' it gives a functor C/c' -> C/c)
- Definition of the left adjoint to the base change functor (dependent sum functor)
- Proof that if the base change functor has a right adjoint (dependent product functor) then C/c has exponentials
- Make the second argument opaque in the constructors `mk_functor`, `mk_nat_trans` and `mk_are_adjoints`. This has the benefit that we can avoid make separate Qed'd lemmas for subproofs or using large `abstract` blocks when we want the second component opaque when constructing these things.