### PR TITLE
remove submodule lablgtk

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,6 @@
 	path = sub/coq
 	url = https://github.com/coq/coq.git
 	branch = v8.5
-[submodule "sub/lablgtk"]
-	path = sub/lablgtk
-	url = http://forge.ocamlcore.org/anonscm/git/lablgtk/lablgtk.git
-	branch = master
 [submodule "sub/coq-tools"]
 	path = sub/coq-tools
 	url = https://github.com/JasonGross/coq-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
 install:
   - sudo apt-get install -y ocaml ocaml-nox ocaml-native-compilers ocaml-findlib
   - sudo apt-get install -y camlp5 camlp4-extra time libgtk2.0 libgtksourceview2.0
+  - sudo apt-get install -y liblablgtk-extras-ocaml-dev
   # get etags from emacs:
   - sudo apt-get install -y emacs
 # build coqide along with the Tactics package, just because it's a short package

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,6 +9,17 @@ available from http://brew.sh/, with the following command:
 $ brew install objective-caml camlp5 camlp4 lablgtk
 ```
 
+Also install "ocamlfind" using "homebrew" with the following commands.
+
+```bash
+$ brew tap mht208/formal
+$ brew install ocaml-findlib
+```
+
+(It is also possible to install "ocamlfind" with "opam", but that is a bit more
+complicated.  One uses "homebrew" to install "opam" and then uses "opam" to
+install "ocamlfind", but it ends up in a nonstandard place.)
+
 Under Ubuntu or Debian, you may install ocaml (and ProofGeneral) with
 
 ```bash

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,7 +23,7 @@ install "ocamlfind", but it ends up in a nonstandard place.)
 Under Ubuntu or Debian, you may install ocaml (and ProofGeneral) with
 
 ```bash
-$ sudo apt-get install ocaml ocaml-nox ocaml-native-compilers camlp4-extra proofgeneral proofgeneral-doc libgtk2.0 libgtksourceview2.0
+$ sudo apt-get install ocaml ocaml-nox ocaml-native-compilers camlp4-extra camlp5 proofgeneral proofgeneral-doc libgtk2.0 libgtksourceview2.0 liblablgtk-extras-ocaml-dev ocaml-findlib
 ```
 
 Under Mac OS X, you may obtain ProofGeneral from http://proofgeneral.inf.ed.ac.uk/.

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ ifeq "$(BUILD_COQIDE)" "yes"
 all: build-coqide
 build-coqide: sub/coq/bin/coqide
 COQIDE_OPTION := opt
-LABLGTK := -lablgtkdir "$(shell pwd)"/sub/lablgtk/src
 endif
 endif
 
@@ -149,30 +148,19 @@ distclean::          ; rm -f build/Makefile-configuration
 
 # building coq:
 export PATH:=$(shell pwd)/sub/coq/bin:$(PATH)
-sub/lablgtk/README:
-	git submodule update --init sub/lablgtk
 sub/coq/configure sub/coq/configure.ml:
 	git submodule update --init sub/coq
-ifeq "$(BUILD_COQ) $(BUILD_COQIDE)" "yes yes"
-sub/coq/config/coq_config.ml: sub/lablgtk/src/gSourceView2.cmi
-endif
 sub/coq/config/coq_config.ml: sub/coq/configure sub/coq/configure.ml
 	: making $@ because of $?
-	cd sub/coq && ./configure -coqide "$(COQIDE_OPTION)" $(LABLGTK) -with-doc no -annotate -debug -local
+	cd sub/coq && ./configure -coqide "$(COQIDE_OPTION)" -with-doc no -annotate -debug -local
 # instead of "coqlight" below, we could use simply "theories/Init/Prelude.vo"
 sub/coq/bin/coq_makefile sub/coq/bin/coqc: sub/coq/config/coq_config.ml
 .PHONY: rebuild-coq
 rebuild-coq sub/coq/bin/coq_makefile sub/coq/bin/coqc:
 	$(MAKE) -w -C sub/coq KEEP_ML4_PREPROCESSED=true VERBOSE=true READABLE_ML4=yes coqbinaries tools states
-sub/coq/bin/coqide: sub/lablgtk/README sub/coq/config/coq_config.ml
+sub/coq/bin/coqide: sub/coq/config/coq_config.ml
 	$(MAKE) -w -C sub/coq KEEP_ML4_PREPROCESSED=true VERBOSE=true READABLE_ML4=yes coqide-binaries bin/coqide
 configure-coq: sub/coq/config/coq_config.ml
-# we use sub/lablgtk/src/gSourceView2.cmi as a proxy for all of lablgtk
-# note: under Mac OS X, "homebrew" installs lablgtk without that file, but it's needed for building coqide.  That's why we build lablgtk ourselves.
-# note: lablgtk needs camlp4, not camlp5.  Strange, but it does.  So we must install that, too.
-build-lablgtk sub/lablgtk/src/gSourceView2.cmi: sub/lablgtk/README
-	cd sub/lablgtk && ./configure
-	$(MAKE) -C sub/lablgtk all byte opt world
 git-describe:
 	git describe --dirty --long --always --abbrev=40
 	git submodule foreach git describe --dirty --long --always --abbrev=40 --tags


### PR DESCRIPTION
Resolves #383.

It turns out that there is a homebrew "tap" called "mht208/formal"
that contains a recipe for building "ocamlfind", which is now required
by the makefile that builds "coq".  Here we take advantage of that to
remove the submodule "lablgtk", saving some time.

Note that "lablgtk" is used only if we build coqide.