### PR TITLE
specific notion of equalities between diagrams

### DIFF
--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -96,3 +96,4 @@ FiveLemma.v
 set_slice_fam_equiv.v
 limits/Opp.v
 limits/EffectiveEpis.v
+limits/graphs/eqdiag.v

--- a/UniMath/CategoryTheory/limits/graphs/eqdiag.v
+++ b/UniMath/CategoryTheory/limits/graphs/eqdiag.v
@@ -79,7 +79,7 @@ Lemma transport_swap: Π {X Y : UU} (P : X -> Y → UU) {x x':X} {y  y' : Y}
                         (e : x = x') (e' : y = y') (p : P x y),
                   transportf (fun a => P _ a) e' (transportf (fun a => P a _) e p) =
                   transportf (fun a => P a _) e (transportf (fun a => P _ a) e' p) .
-Proof
+Proof.
   intros.
   induction e.
   induction e'.

--- a/UniMath/CategoryTheory/limits/graphs/eqdiag.v
+++ b/UniMath/CategoryTheory/limits/graphs/eqdiag.v
@@ -81,8 +81,8 @@ Lemma transport_swap: Π {X Y : UU} (P : X -> Y → UU) {x x':X} {y  y' : Y}
                   transportf (fun a => P a _) e (transportf (fun a => P _ a) e' p) .
 Proof
   intros.
-  destruct e.
-  destruct e'.
+  induction e.
+  induction e'.
   apply idpath.
 Qed.
 
@@ -98,7 +98,7 @@ Lemma transportf_transpose {X : UU} {P : X → UU}
   {x x' : X} (e : x = x') (y : P x) (y' : P x')
 : transportb P e y' = y -> y' = transportf P e y.
 Proof.
-  intro H; destruct e; exact H.
+  intro H; induction e; exact H.
 Defined.
 
 

--- a/UniMath/CategoryTheory/limits/graphs/eqdiag.v
+++ b/UniMath/CategoryTheory/limits/graphs/eqdiag.v
@@ -1,0 +1,393 @@
+(**
+
+- Custom notion of equality between diagrams (eq_diag) over the same graph
+- Transports of cones and cocones between equal diagrams.
+- Limits/Colimits are the same for equal diagrams.
+
+This notion of equality is useful to make the link between standard 
+diagrams (pushouts, coequalizers, ...) in a functor category and
+the induced pointwise diagram given an object of the source category
+
+Example of the binary product :
+
+Let
+- C,D be two categories, 
+- A and B two functors from C to D
+- x an object of C
+
+Let J := binproduct_diagram  (A x) (B x)
+Let J' := diagram_pointwise (binproduct_diagram A B) x.
+
+J and J' are not definitionnally equal. 
+
+Let co a cone of J based on c.
+
+Using a (not too stupid) proof (e : eq_diag J J'), we can transport the cone co 
+with eq_diag_mkcone to get a cone co' of J' based on c that satisfies the 
+definitional equalities :
+  coneOut co' true  ≡ coneOut co true
+  coneOut co' false ≡ coneOut co false
+
+(true and false are the two vertices of the binproduct graph).
+
+This equality would not be needed if functional extensionality computed.
+
+ *)
+
+
+
+
+
+Require Import UniMath.Foundations.Basics.PartD.
+Require Import UniMath.Foundations.Basics.Propositions.
+Require Import UniMath.Foundations.Basics.Sets.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.whiskering.
+
+Require Import UniMath.CategoryTheory.Epis.
+
+Require Import UniMath.CategoryTheory.limits.EffectiveEpis.
+
+Require Import UniMath.CategoryTheory.limits.graphs.pullbacks.
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.limits.graphs.limits.
+Require Import UniMath.CategoryTheory.limits.graphs.pushouts.
+Require Import UniMath.CategoryTheory.limits.graphs.coequalizers.
+Require Import UniMath.CategoryTheory.limits.pushouts.
+Require Import UniMath.CategoryTheory.limits.terminal.
+Require Import UniMath.CategoryTheory.limits.kernels.
+Require Import UniMath.CategoryTheory.limits.pullbacks.
+Require Import UniMath.CategoryTheory.limits.coequalizers.
+
+Require Import UniMath.Ktheory.Utilities.
+
+
+Set Automatic Introduction.
+
+
+Lemma is_exists_unique {A : UU} {B : A → UU} (H : ∃! a : A, B a) :
+  B ( pr1 (iscontrpr1 H)).
+Proof.
+  exact(pr2 (pr1 H)).
+Qed.
+
+
+Lemma transport_swap: Π {X Y : UU} (P : X -> Y → UU) {x x':X} {y  y' : Y}
+                        (e : x = x') (e' : y = y') (p : P x y),
+                  transportf (fun a => P _ a) e' (transportf (fun a => P a _) e p) =
+                  transportf (fun a => P a _) e (transportf (fun a => P _ a) e' p) .
+  intros.
+  destruct e.
+  destruct e'.
+  apply idpath.
+Qed.
+
+
+(* stolen from TypeTheory/Display_Cats/Auxiliary.v *)
+(** Very handy for reasoning with “dependent paths” — 
+
+Note: similar to [transportf_pathsinv0_var], [transportf_pathsinv0'], 
+but not quite a special case of them, or (as far as I can find) any other 
+library lemma.
+*)
+Lemma transportf_transpose {X : UU} {P : X → UU}
+  {x x' : X} (e : x = x') (y : P x) (y' : P x')
+: transportb P e y' = y -> y' = transportf P e y.
+Proof.
+  intro H; destruct e; exact H.
+Defined.
+
+
+Lemma transportf2_comp  {X  : UU} (P : X -> X → UU) (x x'  : X)
+      (ex : x = x')  (t:P x x) :
+  transportf (fun y => P y y) ex t = transportf (fun y => P y x') ex
+                                             (transportf (fun y => P x y) ex t).
+Proof.
+  now induction ex.
+Qed.
+
+Definition eq_diag  {C : Precategory} {g : graph} (d d' : diagram g C) :=
+  Σ (eq_v : Π v: vertex g, dob d v = dob d' v), Π (v v':vertex g) (f:edge v v'),
+  transportf (fun obj => C⟦obj, dob d v'⟧)  (eq_v v) (dmor d f) =
+  transportb (fun obj => C⟦_, obj⟧) (eq_v v') (dmor d' f).
+
+Lemma eq_is_eq_diag {C : Precategory} {g : graph} (d d' : diagram g C)  :
+  d = d' -> eq_diag d d'.
+Proof.
+  intro e.
+  induction e.
+  exists (fun x => idpath _).
+  exact (fun x y z => idpath _).
+Qed.
+
+Lemma eq_diag_is_eq {C : Precategory} {g : graph} (d d' : diagram g C) :
+  eq_diag d d' -> d = d'.
+Proof.
+  intros [eqv autreq].
+  use total2_paths.
+  - apply funextfun.
+    intro v.
+    apply eqv.
+  - rewrite (transportf2_comp
+               (λ x y : vertex g → C, Π a b : vertex g, edge a b →
+                                                        C ⟦ y a, x b ⟧)).  
+    match goal with |- transportf ?Pf ?x1 (transportf ?Pf2 ?s1 ?s2 )  = _ =>
+                    set (e := x1);
+                      set (P := Pf);
+                      set (P2 := Pf2);
+                      set (tp2:=transportf P2 s1 s2);
+                      set (trp := transportf P x1 tp2)
+    end.
+    change (trp = pr2 d').
+    unfold trp.
+    apply funextsec.
+    intro v; apply funextsec; intro v'.    
+    apply funextsec; intro ed.
+    specialize (autreq v v' ed).
+    rewrite  <- (pathsinv0inv0 (eqv v)) in autreq.
+    symmetry in autreq.
+    apply transportf_transpose in autreq.
+    unfold dmor in autreq.
+    rewrite autreq.
+    rewrite pathsinv0inv0.
+    etrans.
+    symmetry.
+    apply (  transport_map (P:=P) (Q:=_) (fun x tp => tp  v v' ed)).
+    etrans.
+    apply (transportf_funextfun (fun x => C⟦ pr1 d' v,x⟧)).
+    apply maponpaths.
+    etrans.
+    symmetry.
+    apply (  transport_map (P:=P2) (Q:=_) (fun x tp => tp  v v' ed)).
+    apply (transportf_funextfun (fun x => C⟦ x,pr1 d v'⟧)).
+Qed.
+
+(* We don't want to use the equivalence with bare identity to show the 
+symmetry because we want computation (Defined)
+ *)
+Lemma sym_eq_diag  {C : Precategory} {g : graph} (d d' : diagram g C) :
+  eq_diag d d' -> eq_diag d' d.
+Proof.
+  intros eq_d.
+  set (eq_d1 := pr1 eq_d).
+  set (eq_d2 := pr2 eq_d).
+  use tpair.
+  - intro v.    
+    apply (! (eq_d1 v)).
+  - (* here we use equality *)
+    unfold eq_d1.
+    assert (heqdag:eq_diag d' d).
+    + apply eq_is_eq_diag.
+      symmetry.
+      apply eq_diag_is_eq.
+      assumption.
+    +
+(* Proof without using equality *)
+    abstract (cbn;
+    intros v v' f;
+    specialize (eq_d2 v v' f);
+    symmetry;
+    unfold transportb;
+    rewrite pathsinv0inv0;
+    apply (transportf_transpose (P:=(λ obj : C, C ⟦ obj, dob d' v' ⟧)));
+    assert (eq_d2':=transportf_transpose (P:=(precategory_morphisms (dob d' v)))
+                                         _ _ _ (! eq_d2));
+    rewrite eq_d2';
+    unfold transportb; rewrite pathsinv0inv0;
+    apply (transport_swap (fun a b => C⟦b,a⟧))).
+
+Defined.
+
+Lemma eq_diag_mkcocone  :
+  Π {C : Precategory} {g : graph} {d : diagram g C}       
+    (d' : diagram g C)
+    (heq_d: eq_diag d d')
+    {c : C} (cc:cocone d c),
+  cocone d' c.
+Proof.           
+  clear.
+  intros.
+  destruct heq_d as [heq heq2].
+  use mk_cocone.
+  intro v.
+  use (transportf (fun obj => C⟦obj,_⟧ ) (heq v)); simpl.
+  apply (coconeIn cc).
+  abstract(
+      intros u v e; simpl;
+      rewrite <- ( coconeInCommutes cc u v e);
+      apply (pathscomp0 (b:=transportb (precategory_morphisms (dob d' u)) (heq v)
+                                       (dmor d' e) ;; (coconeIn cc v)));
+      [
+        unfold transportb; (set (z:= ! heq v));
+        rewrite <- (pathsinv0inv0 (heq v));
+        symmetry;
+        apply transport_compose|];
+      etrans; [
+        apply cancel_postcomposition;
+        symmetry; apply heq2|];
+      clear;
+      now destruct (heq u)).
+Defined.
+
+
+(* The dual proof *)
+Lemma eq_diag_mkcone  :
+  Π {C : Precategory} {g : graph} {d : diagram g C}       
+    (d' : diagram g C)
+    (heq_d: eq_diag d d')
+    {c : C} (cc:cone d c),
+  cone d' c.
+Proof.           
+  clear.
+  intros.
+  set (heq := pr1 heq_d).
+  set (heq2 := pr2 heq_d).
+  use mk_cone.
+  intro v.
+  apply (transportf (fun obj => C⟦_,obj⟧ ) (heq v) (coneOut cc v)).
+    abstract(
+      intros u v e; simpl;      
+      rewrite <- ( coneOutCommutes cc u v e);
+      etrans;[
+        apply transport_compose|];
+      rewrite transport_target_postcompose;
+      apply cancel_precomposition;
+      apply transportf_transpose;
+      etrans;[
+        apply (transport_swap (fun a b => C⟦a,b⟧))|];
+      etrans;[
+        apply maponpaths;
+        symmetry;
+        apply heq2|];
+      unfold heq;
+      induction (pr1 heq_d u);
+      apply idpath).
+Defined.
+
+
+
+Lemma eq_diag_islimcone:
+  Π {C : Precategory} {g : graph} {d : diagram g C} 
+    (d' : diagram g C)
+    (eq_d : eq_diag d d')
+    {c : C} {cc:cone d c}
+    (islimcone : isLimCone _ _ cc) ,
+  isLimCone _ _ (eq_diag_mkcone d' eq_d cc).
+Proof.
+
+  intros.
+  set (eq_d1 := pr1 eq_d);
+    set (eq_d2 := pr1 eq_d).
+  set (eq_d' := sym_eq_diag _ _ eq_d).
+  set (eq_d1' := pr1 eq_d').
+  set (eq_d2' := pr2 eq_d').
+    red.
+  intros c' cc'.
+  set (cc'2 := eq_diag_mkcone _ eq_d' cc').
+  specialize (islimcone c' cc'2).
+  apply (unique_exists (pr1 (pr1 islimcone))).
+  - intro v.
+    assert (islim := is_exists_unique islimcone v).
+    cbn in islim.
+    cbn.
+    etrans.
+    symmetry.
+    apply transport_target_postcompose.
+    etrans.
+    apply maponpaths.
+    apply islim.
+    apply Utilities.transportfbinv.
+  - intro y.
+    apply impred_isaprop.
+    intro t.
+    apply homset_property.
+  - intros y hy.
+    apply (path_to_ctr _ _ islimcone).
+    intro v; specialize (hy v).
+    cbn.
+    apply transportf_transpose.
+    rewrite <- hy.
+    etrans.
+    unfold transportb.
+    rewrite pathsinv0inv0.
+    apply transport_target_postcompose.
+    apply idpath.
+Qed.
+
+(** The dual proof .
+This proof could be deduced from the previous if there was a lemma 
+stating that colimits are limits in the dual category. 
+ *)
+Lemma eq_diag_iscolimcocone:
+  Π {C : Precategory} {g : graph} {d : diagram g C} 
+    (d' : diagram g C)
+    (eq_d : eq_diag d d')
+    {c : C} {cc:cocone d c}
+    (islimcone : isColimCocone _ _ cc) ,
+  isColimCocone _ _ (eq_diag_mkcocone d' eq_d cc).
+Proof.
+  intros.
+  destruct eq_d as [eq_d1 eq_d2].
+  set (eq_d := eq_d1,,eq_d2).
+  set (eq_d'' := sym_eq_diag _ _ eq_d).
+  set (eq_d1' := pr1 eq_d'').
+  set (eq_d2' := pr2 eq_d'').
+  set (eq_d'  := (eq_d1',,eq_d2'):eq_diag d' d).
+  red.
+  intros c' cc'.
+  set (cc'2 := eq_diag_mkcocone _ eq_d' cc').
+  specialize (islimcone c' cc'2).
+  apply (unique_exists (pr1 (pr1 islimcone))).
+  - intro v.
+    assert (islim := is_exists_unique islimcone v).
+    cbn in islim.
+    cbn.
+    etrans.
+    rewrite <- (pathsinv0inv0 (eq_d1 v)).
+    symmetry.
+    apply transport_source_precompose.
+    etrans.
+    apply maponpaths.
+    apply islim.
+    cbn.
+    now apply (Utilities.transportbfinv ( (λ x' : C, C ⟦ x', c' ⟧) )).
+  - intro y.
+    apply impred_isaprop.
+    intro t.
+    apply homset_property.
+  - intros y hy.
+    apply (path_to_ctr _ _ islimcone).
+    intro v; specialize (hy v).
+    revert hy.
+    cbn.
+    intro hy.
+    apply (transportf_transpose (P:=(λ obj : C, C ⟦ obj, c' ⟧))).
+    etrans.
+    apply transport_source_precompose.      
+    unfold transportb.
+    rewrite pathsinv0inv0.
+    apply hy.
+Qed.
+
+
+Definition eq_diag_liftcolimcocone
+           {C : Precategory} {g : graph} {d : diagram g C} 
+           (d' : diagram g C)
+           (eq_d : eq_diag d d')
+           (cc:ColimCocone d ) : ColimCocone d'
+  := mk_ColimCocone _ _ _ (eq_diag_iscolimcocone _ eq_d
+                                                 (isColimCocone_ColimCocone cc)).
+
+Definition eq_diag_liftlimcone
+           {C : Precategory} {g : graph} {d : diagram g C} 
+           (d' : diagram g C)
+           (eq_d : eq_diag d d')
+           (cc:LimCone d ) : LimCone d'
+  := mk_LimCone _ _ _ (eq_diag_islimcone _ eq_d
+                                         (isLimCone_LimCone cc)).
+
+
+

--- a/UniMath/CategoryTheory/limits/graphs/eqdiag.v
+++ b/UniMath/CategoryTheory/limits/graphs/eqdiag.v
@@ -79,6 +79,7 @@ Lemma transport_swap: Π {X Y : UU} (P : X -> Y → UU) {x x':X} {y  y' : Y}
                         (e : x = x') (e' : y = y') (p : P x y),
                   transportf (fun a => P _ a) e' (transportf (fun a => P a _) e p) =
                   transportf (fun a => P a _) e (transportf (fun a => P _ a) e' p) .
+Proof
   intros.
   destruct e.
   destruct e'.

--- a/UniMath/CategoryTheory/limits/graphs/eqdiag.v
+++ b/UniMath/CategoryTheory/limits/graphs/eqdiag.v
@@ -148,25 +148,25 @@ Proof.
     apply funextsec; intro ed.
     specialize (autreq v v' ed).
     rewrite  <- (pathsinv0inv0 (eqv v)) in autreq.
-    symmetry in autreq.
+    apply pathsinv0 in autreq.
     apply transportf_transpose in autreq.
     unfold dmor in autreq.
     rewrite autreq.
     rewrite pathsinv0inv0.
     etrans.
-    symmetry.
+    eapply pathsinv0.
     apply (  transport_map (P:=P) (Q:=_) (fun x tp => tp  v v' ed)).
     etrans.
     apply (transportf_funextfun (fun x => C⟦ pr1 d' v,x⟧)).
     apply maponpaths.
     etrans.
-    symmetry.
+    eapply pathsinv0.
     apply (  transport_map (P:=P2) (Q:=_) (fun x tp => tp  v v' ed)).
     apply (transportf_funextfun (fun x => C⟦ x,pr1 d v'⟧)).
 Qed.
 
 (* We don't want to use the equivalence with bare identity to show the 
-symmetry because we want computation (Defined)
+apply pathsinv0 because we want computation (Defined)
  *)
 Lemma sym_eq_diag  {C : Precategory} {g : graph} (d d' : diagram g C) :
   eq_diag d d' -> eq_diag d' d.
@@ -181,7 +181,7 @@ Proof.
     unfold eq_d1.
     assert (heqdag:eq_diag d' d).
     + apply eq_is_eq_diag.
-      symmetry.
+      apply pathsinv0.
       apply eq_diag_is_eq.
       assumption.
     +
@@ -189,7 +189,7 @@ Proof.
     abstract (cbn;
     intros v v' f;
     specialize (eq_d2 v v' f);
-    symmetry;
+    apply pathsinv0;
     unfold transportb;
     rewrite pathsinv0inv0;
     apply (transportf_transpose (P:=(λ obj : C, C ⟦ obj, dob d' v' ⟧)));
@@ -223,11 +223,11 @@ Proof.
       [
         unfold transportb; (set (z:= ! heq v));
         rewrite <- (pathsinv0inv0 (heq v));
-        symmetry;
+        apply pathsinv0;
         apply transport_compose|];
       etrans; [
         apply cancel_postcomposition;
-        symmetry; apply heq2|];
+        eapply pathsinv0; apply heq2|];
       clear;
       now destruct (heq u)).
 Defined.
@@ -260,7 +260,7 @@ Proof.
         apply (transport_swap (fun a b => C⟦a,b⟧))|];
       etrans;[
         apply maponpaths;
-        symmetry;
+        eapply pathsinv0;
         apply heq2|];
       unfold heq;
       induction (pr1 heq_d u);
@@ -294,7 +294,7 @@ Proof.
     cbn in islim.
     cbn.
     etrans.
-    symmetry.
+    eapply pathsinv0.
     apply transport_target_postcompose.
     etrans.
     apply maponpaths.
@@ -347,7 +347,7 @@ Proof.
     cbn.
     etrans.
     rewrite <- (pathsinv0inv0 (eq_d1 v)).
-    symmetry.
+    eapply pathsinv0.
     apply transport_source_precompose.
     etrans.
     apply maponpaths.
@@ -388,6 +388,3 @@ Definition eq_diag_liftlimcone
            (cc:LimCone d ) : LimCone d'
   := mk_LimCone _ _ _ (eq_diag_islimcone _ eq_d
                                          (isLimCone_LimCone cc)).
-
-
-


### PR DESCRIPTION
This customized notion of equality between diagrams is useful to make the link between standard 
diagrams (pushouts, coequalizers, ...) in a functor category and the induced pointwise diagram given an object of the source category