### PR TITLE
improve "make clean"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /latex/*.fdb_latexmk
 /latex/*.fls
 /latex/coqdoc.sty
+/COQC.log

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ build/CoqMakefile.make: .coq_makefile_input $(COQBIN)coq_makefile
 
 # "clean::" occurs also in build/CoqMakefile.make, hence both colons
 clean::
-	rm -f .coq_makefile_input .coq_makefile_output build/CoqMakefile.make
+	rm -f .coq_makefile_input .coq_makefile_output build/CoqMakefile.make COQC.log
 	find UniMath \( -name .\*.aux -o -name \*.glob -o -name \*.v.d -o -name \*.vo \) -delete
 	find UniMath -type d -empty -delete
 clean::; rm -rf $(ENHANCEDDOCTARGET)

--- a/util/slowest
+++ b/util/slowest
@@ -9,4 +9,4 @@ echo "--- stdout ---"
 <COQC.log grep -v '^Chars '
 echo "--- slowest $n commands taking at least $min seconds ---"
 <COQC.log grep '^Chars ' |sort --key=6gr |head -"$n" |awk "\$6 >= $min"
-
+rm COQC.log


### PR DESCRIPTION
The script util/slowest now deletes a temporary file called COQC.log, and the makefile
removes, just in case.