### PR TITLE
remove lemma apevalat

### DIFF
--- a/UniMath/Foundations/Basics/PartA.v
+++ b/UniMath/Foundations/Basics/PartA.v
@@ -504,9 +504,14 @@ Definition homotfun {X Y Z : UU} {f f' : X -> Y} (h : f ~ f')
 
 (** *** Equality between functions defines a homotopy *)
 
-Definition eqtohomot {X Y : UU}{f f' : X -> Y}(e : f = f') : homot f f' :=
-  fun x => maponpaths ( fun f => f x ) e.
+Definition toforallpaths {T:UU} (P:T->UU) (f g:Π t:T, P t) : f = g -> f ~ g.
+Proof. intros ? ? ? ? h t. induction h.  apply (idpath _). Defined.
 
+Definition eqtohomot     {T:UU} {P:T->UU} {f g:Π t:T, P t} : f = g -> f ~ g.
+(* the same as toforallpaths, but with different implicit arguments *)
+Proof.
+  intros ? ? ? ? e t. induction e. reflexivity.
+Defined.
 
 (** *** [ maponpaths ] for a function homotopic to the identity
 

--- a/UniMath/Foundations/Basics/UnivalenceAxiom.v
+++ b/UniMath/Foundations/Basics/UnivalenceAxiom.v
@@ -37,9 +37,6 @@ Require Export UniMath.Foundations.Basics.PartB.
 Definition eqweqmap { T1 T2 : UU } : T1 = T2 -> T1 ≃ T2.
 Proof. intro e. induction e. apply idweq. Defined.
 
-Definition toforallpaths { T : UU } (P:T -> UU) (f g :Π t:T, P t) : f = g -> f ~ g.
-Proof. intros h t. induction h.  apply (idpath _). Defined.
-
 Definition sectohfiber { X : UU } (P:X -> UU): (Π x:X, P x) -> (hfiber (fun f:_ => fun x:_ => pr1  (f x)) (fun x:X => x)) := (fun a : Π x:X, P x => tpair _ (fun x:_ => tpair _ x (a x)) (idpath (fun x:X => x))).
 
 Definition hfibertosec { X : UU } (P:X -> UU):

--- a/UniMath/Ktheory/AbelianGroup.v
+++ b/UniMath/Ktheory/AbelianGroup.v
@@ -426,7 +426,7 @@ Module Product.
        (Π i, Proj G i ∘ h = Proj G i ∘ h') -> h = h'.
     intros ? ? ? ? ? e. apply Monoid.funEquality.
     apply funextsec; intro t. apply funextsec; intro i.
-    exact (apevalat t (ap pr1 (e i))). Qed.
+    exact (eqtohomot (ap pr1 (e i)) t). Qed.
 End Product.
 Module Sum.                   (* coproducts *)
   Import Presentation.
@@ -512,7 +512,7 @@ Module Category.
         + intros p. exists (Product.Map X T p).
           apply funextsec; intro i; apply Product.Eqn.
         + intros f f' e. apply Product.UniqueMap.
-          intros i. exact (apevalat i e).
+          intros i. exact (eqtohomot e i).
     Defined.
   End Product.
 
@@ -527,7 +527,7 @@ Module Category.
         + intros p. exists (Sum.Map X T p).
           apply funextsec; intro i; apply Sum.Eqn.
         + intros f f' e. apply Sum.UniqueMap.
-          intros i. exact (apevalat i e).
+          intros i. exact (eqtohomot e i).
     Defined.
   End Sum.
 

--- a/UniMath/Ktheory/AffineLine.v
+++ b/UniMath/Ktheory/AffineLine.v
@@ -360,7 +360,7 @@ Proof. intros.
                                                               (fun t : T => weq_pathscomp0r y (s t)) t0))
                       (iscontrcoconustot Y (f t0)))
                 : @paths (GHomotopy f s (f t0)) _ _).
-       simple refine (apevalat t0 (ap pr1 ((idpath _ :
+       simple refine (eqtohomot (ap pr1 ((idpath _ :
                          (pr2
                             (thePoint
                                (iscontrweqb
@@ -370,15 +370,16 @@ Proof. intros.
                                                                           (fun t : T => weq_pathscomp0r y (s t)) t0))
                                   (iscontrcoconustot Y (f t0)))))
                            =
-                         (path_start a2)) @ a2)) @ _).
-       simple refine (apevalat t0
-                 (ap pr1
+                         (path_start a2)) @ a2)) t0 @ _).
+       simple refine (eqtohomot
+                  (ap pr1
                      (compute_pr2_invmap_weqfibtototal
                         (fun y : Y =>
                            ℤTorsorRecursion_weq
                              (fun t : T => y = f t)
                              (fun t : T => weq_pathscomp0r y (s t)) t0)
-                        (f t0,, idpath (f t0)))) @ _).
+                        (f t0,, idpath (f t0))))
+                 t0 @ _).
        exact (ℤTorsorRecursion_inv_compute _ _ _ _).
 Defined.
 

--- a/UniMath/Ktheory/GroupAction.v
+++ b/UniMath/Ktheory/GroupAction.v
@@ -152,7 +152,7 @@ Proof. intros ? [X [Xm Xu Xa]] [Y [Ym Yu Ya]] ? .
        simpl in p. destruct p; simpl. unfold transportf; simpl. unfold idfun; simpl.
        simple refine (weqpair _ _).
        { intros p g x. simpl in x. simpl.
-         exact (apevalat x (apevalat g (ap act_mult p))). }
+         exact (eqtohomot (eqtohomot (ap act_mult p) g) x). }
        simple refine (gradth _ _ _ _).
        { unfold cast; simpl.
          intro i.
@@ -263,9 +263,11 @@ Proof. intros.
 
 Definition Action_univalence_inv_comp_eval {G:gr} {X Y:Action G} (f:ActionIso X Y) (x:X) :
   castAction (Action_univalence_inv f) x = f x.
-Proof. intros. exact (apevalat x (ap pr1weq
-                             (ap underlyingIso
-                                 (Action_univalence_inv_comp f)))). Defined.
+Proof. intros. exact (eqtohomot
+                        (ap pr1weq
+                            (ap underlyingIso
+                                (Action_univalence_inv_comp f)))
+                        x). Defined.
 
 (** ** Torsors *)
 

--- a/UniMath/Ktheory/Precategories.v
+++ b/UniMath/Ktheory/Precategories.v
@@ -231,12 +231,12 @@ Notation "p ◽ b" := (nattrans_object_application b p) (at level 40) : cat.
 
 Definition arrow_mor_id {C:Precategory} {c:C} {X:[C^op,SET]} (x:c⇒X) :
   x ⟲ identity c = x
-  := apevalat x (functor_id X c).
+  := eqtohomot (functor_id X c) x.
 
 Definition arrow_mor_mor_assoc {C:Precategory} {c c' c'':C} {X:[C^op,SET]}
            (g:c''-->c') (f:c'-->c) (x:c⇒X) :
   x ⟲ (f ∘ g) = (x ⟲ f) ⟲ g
-  := apevalat x (functor_comp X c c' c'' f g).
+  := eqtohomot (functor_comp X c c' c'' f g) x.
 
 Definition nattrans_naturality {B C:Precategory} {F F':[B, C]} {b b':B}
            (p : F --> F') (f : b --> b') :
@@ -250,7 +250,7 @@ Proof. reflexivity. Defined.
 Definition nattrans_arrow_mor_assoc {C:Precategory} {c' c:C} {X X':[C^op,SET]}
            (g:c'-->c) (x:c⇒X) (p:X-->X') :
   p ⟳ (x ⟲ g) = (p ⟳ x) ⟲ g
-  := apevalat x (nat_trans_ax p _ _ g).
+  := eqtohomot (nat_trans_ax p _ _ g) x.
 
 Definition nattrans_arrow_id {C:Precategory} {c:C} {X:[C^op,SET]} (x:c⇒X) :
   nat_trans_id _ ⟳ x = x
@@ -322,8 +322,8 @@ Proof.
   split.
   - intro i. set (F := isopair f i).
     refine (gradth f (inv_from_iso F)
-                   (λ x, apevalat x (iso_inv_after_iso F))
-                   (λ y, apevalat y (iso_after_iso_inv F))).
+                   (λ x, eqtohomot (iso_inv_after_iso F) x)
+                   (λ y, eqtohomot (iso_after_iso_inv F) y)).
   - exact (λ i Z, weqproperty (weqbfun (Z:hSet) (weqpair f i))).
 Defined.
 
@@ -522,7 +522,7 @@ Proof.
 Defined.
 
 Lemma identityFunction : Π (T:SET) (f:T-->T) (t:T:hSet), f = identity T -> f t = t.
-Proof. intros ? ? ?. exact (apevalat t). Defined.
+Proof. intros ? ? ? e. exact (eqtohomot e t). Defined.
 
 Lemma identityFunction' : Π (T:SET) (t:T:hSet), identity T t = t.
 Proof. reflexivity. Defined.

--- a/UniMath/Ktheory/README.md
+++ b/UniMath/Ktheory/README.md
@@ -31,6 +31,10 @@ where I started writing this code.
 I thank The Ambrose Monell Foundation for supporting my stay at the Institute
 for Advanced Study in Fall, 2015, where I continued working on this code.
 
+I thank the Friends of the Institute for Advanced Study for supporting my stay
+at the Institute for Advanced Study in Spring, 2017, where I continued working
+on this code.
+
 Overview of contents
 ====================
 

--- a/UniMath/Ktheory/RawMatrix.v
+++ b/UniMath/Ktheory/RawMatrix.v
@@ -27,7 +27,7 @@ Proof. intros. apply invweq. apply to_row. Defined.
 Lemma from_row_entry {C:Precategory} {I} {b:I -> ob C}
            (B:Sum b) {d:ob C} (f : Π j, Hom C (b j) d) :
   Π j, from_row B f ∘ opp_mor (universalElement B j) = f j.
-Proof. intros. exact (apevalat j (homotweqinvweq (to_row B) f)). Qed.
+Proof. intros. exact (eqtohomot (homotweqinvweq (to_row B) f) j). Qed.
 
 Definition to_col {C:Precategory} {I} {d:I -> ob C} (D:Product d) {b:ob C} :
   (Hom C b (universalObject D)) ≃ (Π i, Hom C b (d i)).
@@ -42,7 +42,7 @@ Lemma from_col_entry {C:Precategory} {I} {b:I -> ob C}
            (D:Product b) {d:ob C} (f : Π i, Hom C d (b i)) :
   Π i, universalElement D i ∘ from_col D f = f i.
 Proof. intros.
-  apply (apevalat i (homotweqinvweq (to_col D) f )). Qed.
+  apply (eqtohomot (homotweqinvweq (to_col D) f ) i). Qed.
 
 Definition to_matrix {C:Precategory}
            {I} {d:I -> ob C} (D:Product d)
@@ -67,7 +67,7 @@ Lemma from_matrix_entry {C:Precategory}
            {J} {b:J -> ob C} (B:Sum b)
            (f : Π i j, Hom C (b j) (d i)) :
   Π i j, (universalElement D i ∘ from_matrix D B f) ∘ opp_mor (universalElement B j) = f i j.
-Proof. intros. exact (apevalat j (apevalat i (homotweqinvweq (to_matrix D B) f))). Qed.
+Proof. intros. exact (eqtohomot (eqtohomot (homotweqinvweq (to_matrix D B) f) i) j). Qed.
 
 Lemma from_matrix_entry_assoc {C:Precategory}
            {I} {d:I -> ob C} (D:Product d)

--- a/UniMath/Ktheory/Representation.v
+++ b/UniMath/Ktheory/Representation.v
@@ -29,7 +29,7 @@ Proof.
     + unshelve refine (twooutof3c_iff_1_homot _ _ _ _ _).
       * exact (pr1 i ◽ opp_ob b).
       * intro f; unfold funcomp; simpl.
-        exact (apevalat x (nat_trans_ax (pr1 i) _ _ f)).
+        exact (eqtohomot (nat_trans_ax (pr1 i) _ _ f) x).
       * exact (hset_iso_is_equiv _ _ (I b)).
     + apply isapropisweq.
     + apply isapropisweq.

--- a/UniMath/Ktheory/Utilities.v
+++ b/UniMath/Ktheory/Utilities.v
@@ -294,13 +294,8 @@ Definition homotsec {T} {P:T->UU} (f g:Section P) := Π t, f t = g t.
 (* compare with [adjev] *)
 Definition evalat {T} {P:T->UU} (t:T) (f:Section P) := f t.
 
-(* compare this with [toforallpaths]: *)
-Definition apevalat {T} {P:T->UU} (t:T) {f g:Section P}
-  : f = g -> f t = g t
-  := ap (evalat t).
-
 Definition apfun {X Y} {f f':X->Y} (p:f = f') {x x'} (q:x = x') : f x = f' x'.
-  intros. destruct q. exact (apevalat x p). Defined.
+  intros. destruct q. exact (eqtohomot p x). Defined.
 
 Definition aptwice {X Y Z} (f:X->Y->Z) {a a' b b'} (p:a = a') (q:b = b') : f a b = f a' b'.
   intros. exact (apfun (ap f p) q). Defined.


### PR DESCRIPTION
In pull request #527 Vladimir introduced the function `eqtohomot` to replace
`apevalat` partially.  In this pull request I eliminate `apevalat` in favor of
`eqhomotop`, generalizing `eqtohomot` from functions to sections to make that
possible.  I also moved the definition of `toforallpaths` to PartA, to point
out that the only difference between it and `eqtohomot` is the number of
implicit arguments.

Probably we should eliminate `toforallpaths` in favor of `eqtohomot` later on.