### PR TITLE
rename some identifiers that are needlessly plural

### DIFF
--- a/UniMath/Algebra/Archimedean.v
+++ b/UniMath/Algebra/Archimedean.v
@@ -752,7 +752,7 @@ Proof.
     exact Hc2.*)
 Defined.
 
-Lemma natmult_commrngfrac {X : commrng} {S : subabmonoids} :
+Lemma natmult_commrngfrac {X : commrng} {S : subabmonoid} :
   Π n (x : X × S), natmult (X := commrngfrac X S) n (setquotpr (eqrelcommrngfrac X S) x) = setquotpr (eqrelcommrngfrac X S) (natmult (X := X) n (pr1 x) ,, (pr2 x)).
 Proof.
   simpl ; intros X S n x.
@@ -772,7 +772,7 @@ Proof.
     reflexivity.
 Qed.
 
-Lemma isarchcommrngfrac {X : commrng} {S : subabmonoids} (R : hrel X) Hop1 Hop2 Hs:
+Lemma isarchcommrngfrac {X : commrng} {S : subabmonoid} (R : hrel X) Hop1 Hop2 Hs:
   R 1%rng 0%rng ->
   istrans R ->
   isarchrng R -> isarchrng (X := commrngfrac X S) (commrngfracgt X S (R := R) Hop1 Hop2 Hs).

--- a/UniMath/Algebra/BinaryOperations.v
+++ b/UniMath/Algebra/BinaryOperations.v
@@ -1147,10 +1147,10 @@ Definition isabgropisob {X Y : setwithbinop} (f : binopiso X Y) (is : isabgrop (
 
 (** **** Subobjects *)
 
-Definition issubsetwithbinop {X : hSet} (opp : binop X) (A : hsubtypes X) : UU :=
+Definition issubsetwithbinop {X : hSet} (opp : binop X) (A : hsubtype X) : UU :=
   Π a a' : A, A (opp (pr1 a) (pr1 a')).
 
-Lemma isapropissubsetwithbinop {X : hSet} (opp : binop X) (A : hsubtypes X) :
+Lemma isapropissubsetwithbinop {X : hSet} (opp : binop X) (A : hsubtype X) :
   isaprop (issubsetwithbinop opp A).
 Proof.
   intros.
@@ -1160,20 +1160,20 @@ Proof.
 Defined.
 
 Definition subsetswithbinop {X : setwithbinop} : UU :=
-  total2 (fun A : hsubtypes X => issubsetwithbinop (@op X) A).
+  total2 (fun A : hsubtype X => issubsetwithbinop (@op X) A).
 
 Definition subsetswithbinoppair {X : setwithbinop} :
-  Π (t : hsubtypes X), (λ A : hsubtypes X, issubsetwithbinop op A) t →
-                       Σ A : hsubtypes X, issubsetwithbinop op A :=
-  tpair (fun A : hsubtypes X => issubsetwithbinop (@op X) A).
+  Π (t : hsubtype X), (λ A : hsubtype X, issubsetwithbinop op A) t →
+                       Σ A : hsubtype X, issubsetwithbinop op A :=
+  tpair (fun A : hsubtype X => issubsetwithbinop (@op X) A).
 
 Definition subsetswithbinopconstr {X : setwithbinop} :
-  Π (t : hsubtypes X), (λ A : hsubtypes X, issubsetwithbinop op A) t →
-                       Σ A : hsubtypes X, issubsetwithbinop op A := @subsetswithbinoppair X.
+  Π (t : hsubtype X), (λ A : hsubtype X, issubsetwithbinop op A) t →
+                       Σ A : hsubtype X, issubsetwithbinop op A := @subsetswithbinoppair X.
 
-Definition pr1subsetswithbinop (X : setwithbinop) : @subsetswithbinop X -> hsubtypes X :=
-  @pr1 _ (fun A : hsubtypes X => issubsetwithbinop (@op X) A).
-Coercion pr1subsetswithbinop : subsetswithbinop >-> hsubtypes.
+Definition pr1subsetswithbinop (X : setwithbinop) : @subsetswithbinop X -> hsubtype X :=
+  @pr1 _ (fun A : hsubtype X => issubsetwithbinop (@op X) A).
+Coercion pr1subsetswithbinop : subsetswithbinop >-> hsubtype.
 
 Definition pr2subsetswithbinop {X : setwithbinop} (Y : @subsetswithbinop X) :
   issubsetwithbinop (@op X) (pr1subsetswithbinop X Y) := pr2 Y.
@@ -1287,11 +1287,11 @@ Proof.
   simpl. unfold binop. apply qtmlt.
 Defined.
 
-Definition ispartbinophrel {X : setwithbinop} (S : hsubtypes X) (R : hrel X) : UU :=
+Definition ispartbinophrel {X : setwithbinop} (S : hsubtype X) (R : hrel X) : UU :=
   dirprod (Π a b c : X, S c -> R a b -> R (op c a) (op c b))
           (Π a b c : X, S c -> R a b -> R (op a c) (op b c)).
 
-Definition isbinoptoispartbinop {X : setwithbinop} (S : hsubtypes X) (L : hrel X)
+Definition isbinoptoispartbinop {X : setwithbinop} (S : hsubtype X) (L : hrel X)
            (is : isbinophrel L) : ispartbinophrel S L.
 Proof.
   intros X S L.
@@ -1300,7 +1300,7 @@ Proof.
   - intros a b c is. apply (pr2 d2 a b c).
 Defined.
 
-Definition ispartbinophrellogeqf {X : setwithbinop} (S : hsubtypes X) {L R : hrel X}
+Definition ispartbinophrellogeqf {X : setwithbinop} (S : hsubtype X) {L R : hrel X}
            (lg : hrellogeq L R) (isl : ispartbinophrel S L) : ispartbinophrel S R.
 Proof.
   intros. split.
@@ -1310,7 +1310,7 @@ Proof.
     apply ((pr1 (lg _ _) ((pr2 isl) _ _ _ is (pr2 (lg  _ _) rab)))).
 Defined.
 
-Lemma ispartbinophrelif {X : setwithbinop} (S : hsubtypes X) (R : hrel X) (is : iscomm (@op X))
+Lemma ispartbinophrelif {X : setwithbinop} (S : hsubtype X) (R : hrel X) (is : iscomm (@op X))
       (isl : Π a b c : X, S c -> R a b -> R (op c a) (op c b)) : ispartbinophrel S R.
 Proof.
   intros. split with isl.
@@ -1357,11 +1357,11 @@ Proof.
   apply (isl _ _ _ rab).
 Defined.
 
-Definition ispartinvbinophrel {X : setwithbinop} (S : hsubtypes X) (R : hrel X) : UU :=
+Definition ispartinvbinophrel {X : setwithbinop} (S : hsubtype X) (R : hrel X) : UU :=
   dirprod (Π a b c : X, S c -> R (op c a) (op c b) -> R a b)
           (Π a b c : X, S c -> R (op a c) (op b c) -> R a b).
 
-Definition isinvbinoptoispartinvbinop {X : setwithbinop} (S : hsubtypes X) (L : hrel X)
+Definition isinvbinoptoispartinvbinop {X : setwithbinop} (S : hsubtype X) (L : hrel X)
            (is : isinvbinophrel L) : ispartinvbinophrel S L.
 Proof.
   intros X S L.
@@ -1371,7 +1371,7 @@ Proof.
   - intros a b c s. apply (pr2 d2 a b c).
 Defined.
 
-Definition ispartinvbinophrellogeqf {X : setwithbinop} (S : hsubtypes X) {L R : hrel X}
+Definition ispartinvbinophrellogeqf {X : setwithbinop} (S : hsubtype X) {L R : hrel X}
            (lg : hrellogeq L R) (isl : ispartinvbinophrel S L) : ispartinvbinophrel S R.
 Proof.
   intros. split.
@@ -1381,7 +1381,7 @@ Proof.
     apply ((pr1 (lg _ _) ((pr2 isl) _ _ _ s (pr2 (lg  _ _) rab)))).
 Defined.
 
-Lemma ispartinvbinophrelif {X : setwithbinop} (S : hsubtypes X) (R : hrel X) (is : iscomm (@op X))
+Lemma ispartinvbinophrelif {X : setwithbinop} (S : hsubtype X) (R : hrel X) (is : iscomm (@op X))
       (isl : Π a b c : X, S c -> R (op c a) (op c b) -> R a b) : ispartinvbinophrel S R.
 Proof.
   intros. split with isl. intros a b c s rab.
@@ -1404,8 +1404,8 @@ Proof.
     apply (pr2 is). apply r.
 Defined.
 
-Lemma ispartbinophrelandfun {X Y : setwithbinop} (f : binopfun X Y) (SX : hsubtypes X)
-      (SY : hsubtypes Y) (iss : Π x : X, (SX x) -> (SY (f x))) (R : hrel Y)
+Lemma ispartbinophrelandfun {X Y : setwithbinop} (f : binopfun X Y) (SX : hsubtype X)
+      (SY : hsubtype Y) (iss : Π x : X, (SX x) -> (SY (f x))) (R : hrel Y)
       (is : @ispartbinophrel Y SY R) : @ispartbinophrel X SX (fun x x' => R (f x) (f x')).
 Proof.
   intros.
@@ -1429,8 +1429,8 @@ Proof.
     apply ((pr2 is) _ _ _ r).
 Defined.
 
-Lemma ispartinvbinophrelandfun {X Y : setwithbinop} (f : binopfun X Y) (SX : hsubtypes X)
-      (SY : hsubtypes Y) (iss : Π x : X, (SX x) -> (SY (f x))) (R : hrel Y)
+Lemma ispartinvbinophrelandfun {X Y : setwithbinop} (f : binopfun X Y) (SX : hsubtype X)
+      (SY : hsubtype Y) (iss : Π x : X, (SX x) -> (SY (f x))) (R : hrel Y)
       (is : @ispartinvbinophrel Y SY R) : @ispartinvbinophrel X SX (fun x x' => R (f x) (f x')).
 Proof.
   intros.
@@ -1747,10 +1747,10 @@ Definition iscommrngopsisob {X Y : setwith2binop} (f : twobinopiso X Y)
 
 (** **** Subobjects *)
 
-Definition issubsetwith2binop {X : setwith2binop} (A : hsubtypes X) : UU :=
+Definition issubsetwith2binop {X : setwith2binop} (A : hsubtype X) : UU :=
   dirprod (Π a a' : A, A (op1 (pr1 a) (pr1 a'))) (Π a a' : A, A (op2 (pr1 a) (pr1 a'))).
 
-Lemma isapropissubsetwith2binop {X : setwith2binop} (A : hsubtypes X) :
+Lemma isapropissubsetwith2binop {X : setwith2binop} (A : hsubtype X) :
   isaprop (issubsetwith2binop A).
 Proof.
   intros. apply (isofhleveldirprod 1).
@@ -1763,21 +1763,21 @@ Proof.
 Defined.
 
 Definition subsetswith2binop {X : setwith2binop} : UU :=
-  total2 (fun A : hsubtypes X => issubsetwith2binop A).
+  total2 (fun A : hsubtype X => issubsetwith2binop A).
 
 Definition subsetswith2binoppair {X : setwith2binop} :
-  Π (t : hsubtypes X), (λ A : hsubtypes X, issubsetwith2binop A) t →
-                       Σ A : hsubtypes X, issubsetwith2binop A :=
-  tpair (fun A : hsubtypes X => issubsetwith2binop A).
+  Π (t : hsubtype X), (λ A : hsubtype X, issubsetwith2binop A) t →
+                       Σ A : hsubtype X, issubsetwith2binop A :=
+  tpair (fun A : hsubtype X => issubsetwith2binop A).
 
 Definition subsetswith2binopconstr {X : setwith2binop} :
-  Π (t : hsubtypes X), (λ A : hsubtypes X, issubsetwith2binop A) t →
-                       Σ A : hsubtypes X, issubsetwith2binop A :=
+  Π (t : hsubtype X), (λ A : hsubtype X, issubsetwith2binop A) t →
+                       Σ A : hsubtype X, issubsetwith2binop A :=
   @subsetswith2binoppair X.
 
-Definition pr1subsetswith2binop (X : setwith2binop) : @subsetswith2binop X -> hsubtypes X :=
-  @pr1 _ (fun A : hsubtypes X => issubsetwith2binop A).
-Coercion pr1subsetswith2binop : subsetswith2binop >-> hsubtypes.
+Definition pr1subsetswith2binop (X : setwith2binop) : @subsetswith2binop X -> hsubtype X :=
+  @pr1 _ (fun A : hsubtype X => issubsetwith2binop A).
+Coercion pr1subsetswith2binop : subsetswith2binop >-> hsubtype.
 
 Definition totalsubsetwith2binop (X : setwith2binop) : @subsetswith2binop X.
 Proof.

--- a/UniMath/Algebra/Domains_and_Fields.v
+++ b/UniMath/Algebra/Domains_and_Fields.v
@@ -219,7 +219,7 @@ Proof.
 Defined.
 
 Definition rngpossubmonoid (X : rng) {R : hrel X} (is1 : isrngmultgt X R) (is2 : R 1 0) :
-  @submonoids (rngmultmonoid X).
+  @submonoid (rngmultmonoid X).
 Proof.
   intros. split with (fun x => R x 0). split.
   - intros x1 x2. apply is1. apply (pr2 x1). apply (pr2 x2).
@@ -411,7 +411,7 @@ Defined.
 
 (** **** Multiplicative submonoid of non-zero elements *)
 
-Definition intdomnonzerosubmonoid (X : intdom) : @subabmonoids (rngmultabmonoid X).
+Definition intdomnonzerosubmonoid (X : intdom) : @subabmonoid (rngmultabmonoid X).
 Proof.
   intros. split with (fun x : X => hProppair _ (isapropneg (paths x 0))). split.
   - intros a b. simpl in *. intro e.
@@ -534,7 +534,7 @@ Definition fldfracmultinv0 (X : intdom) (is : isdeceq X)
            (x : commrngfrac X (intdomnonzerosubmonoid X)) :
   commrngfrac X (intdomnonzerosubmonoid X) := setquotfun _ _ _ (fldfracmultinvintcomp X is) x.
 
-Lemma nonzeroincommrngfrac (X : commrng) (S : @submonoids (rngmultmonoid X)) (xa : dirprod X S)
+Lemma nonzeroincommrngfrac (X : commrng) (S : @submonoid (rngmultmonoid X)) (xa : dirprod X S)
       (ne : neg (paths (setquotpr (eqrelcommrngfrac X S) xa)
                        (setquotpr _ (dirprodpair 0 (unel S))))) : neg (paths (pr1 xa) 0).
 Proof.
@@ -548,7 +548,7 @@ Proof.
 Defined.
 Opaque nonzeroincommrngfrac.
 
-Lemma zeroincommrngfrac (X : intdom) (S : @submonoids (rngmultmonoid X))
+Lemma zeroincommrngfrac (X : intdom) (S : @submonoid (rngmultmonoid X))
       (is : Π s : S, neg (paths (pr1 s) 0)) (x : X) (aa : S)
       (e : paths (setquotpr (eqrelcommrngfrac X S) (dirprodpair x aa))
                  (setquotpr _ (dirprodpair 0 (unel S)))) : paths x 0.

--- a/UniMath/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Algebra/Monoids_and_Groups.v
@@ -195,10 +195,10 @@ Definition invmonoidiso {X Y : monoid} (f : monoidiso X Y) : monoidiso Y X :=
 
 (** **** Subobjects *)
 
-Definition issubmonoid {X : monoid} (A : hsubtypes X) : UU :=
+Definition issubmonoid {X : monoid} (A : hsubtype X) : UU :=
   dirprod (issubsetwithbinop (@op X) A) (A (unel X)).
 
-Lemma isapropissubmonoid {X : monoid} (A : hsubtypes X) :
+Lemma isapropissubmonoid {X : monoid} (A : hsubtype X) :
   isaprop (issubmonoid A).
 Proof.
   intros. apply (isofhleveldirprod 1).
@@ -206,28 +206,28 @@ Proof.
   - apply (pr2 (A (unel X))).
 Defined.
 
-Definition submonoids {X : monoid} : UU := total2 (fun A : hsubtypes X => issubmonoid A).
+Definition submonoid {X : monoid} : UU := total2 (fun A : hsubtype X => issubmonoid A).
 
 Definition submonoidpair {X : monoid} :
-  Π (t : hsubtypes X), (λ A : hsubtypes X, issubmonoid A) t → Σ A : hsubtypes X, issubmonoid A :=
-  tpair (fun A : hsubtypes X => issubmonoid A).
+  Π (t : hsubtype X), (λ A : hsubtype X, issubmonoid A) t → Σ A : hsubtype X, issubmonoid A :=
+  tpair (fun A : hsubtype X => issubmonoid A).
 
 Definition submonoidconstr {X : monoid} := @submonoidpair X.
 
-Definition pr1submonoids (X : monoid) : @submonoids X -> hsubtypes X := @pr1 _ _.
+Definition pr1submonoid (X : monoid) : @submonoid X -> hsubtype X := @pr1 _ _.
 
-Definition totalsubmonoid (X : monoid) : @submonoids X.
+Definition totalsubmonoid (X : monoid) : @submonoid X.
 Proof.
   intro. split with (fun x : _ => htrue). split.
   - intros x x'. apply tt.
   - apply tt.
 Defined.
 
-Definition submonoidstosubsetswithbinop (X : monoid) : @submonoids X -> @subsetswithbinop X :=
+Definition submonoidtosubsetswithbinop (X : monoid) : @submonoid X -> @subsetswithbinop X :=
   fun A : _ => subsetswithbinoppair (pr1 A) (pr1 (pr2 A)).
-Coercion submonoidstosubsetswithbinop : submonoids >-> subsetswithbinop.
+Coercion submonoidtosubsetswithbinop : submonoid >-> subsetswithbinop.
 
-Lemma ismonoidcarrier {X : monoid} (A : @submonoids X) : ismonoidop (@op A).
+Lemma ismonoidcarrier {X : monoid} (A : @submonoid X) : ismonoidop (@op A).
 Proof.
   intros. split.
   - intros a a' a''. apply (invmaponpathsincl _ (isinclpr1carrier A)).
@@ -240,9 +240,9 @@ Proof.
       simpl. apply (runax X).
 Defined.
 
-Definition carrierofsubmonoid {X : monoid} (A : @submonoids X) : monoid.
+Definition carrierofsubmonoid {X : monoid} (A : @submonoid X) : monoid.
 Proof. intros. split with A. apply ismonoidcarrier. Defined.
-Coercion carrierofsubmonoid : submonoids >-> monoid.
+Coercion carrierofsubmonoid : submonoid >-> monoid.
 
 
 (** **** Quotient objects *)
@@ -341,10 +341,10 @@ Definition abmonoidrer (X : abmonoid) (a b c d : X) :
 
 (** **** Subobjects *)
 
-Definition subabmonoids {X : abmonoid} := @submonoids X.
-Identity Coercion id_subabmonoids : subabmonoids >-> submonoids.
+Definition subabmonoid {X : abmonoid} := @submonoid X.
+Identity Coercion id_subabmonoid : subabmonoid >-> submonoid.
 
-Lemma iscommcarrier {X : abmonoid} (A : @submonoids X) : iscomm (@op A).
+Lemma iscommcarrier {X : abmonoid} (A : @submonoid X) : iscomm (@op A).
 Proof.
   intros. intros a a'.
   apply (invmaponpathsincl _ (isinclpr1carrier A)).
@@ -352,14 +352,14 @@ Proof.
 Defined.
 Opaque iscommcarrier.
 
-Definition isabmonoidcarrier {X : abmonoid} (A : @submonoids X) :
+Definition isabmonoidcarrier {X : abmonoid} (A : @submonoid X) :
   isabmonoidop (@op A) := dirprodpair (ismonoidcarrier A) (iscommcarrier A).
 
-Definition carrierofsubabmonoid {X : abmonoid} (A : @subabmonoids X) : abmonoid.
+Definition carrierofsubabmonoid {X : abmonoid} (A : @subabmonoid X) : abmonoid.
 Proof.
-  intros. unfold subabmonoids in A. split with A. apply isabmonoidcarrier.
+  intros. unfold subabmonoid in A. split with A. apply isabmonoidcarrier.
 Defined.
-Coercion carrierofsubabmonoid : subabmonoids >-> abmonoid.
+Coercion carrierofsubabmonoid : subabmonoid >-> abmonoid.
 
 
 (** **** Quotient objects *)
@@ -408,14 +408,14 @@ of the [abmonoid] operations but does not use the unit element. *)
 
 Open Scope addmonoid_scope.
 
-Definition abmonoidfracopint (X : abmonoid) (A : @submonoids X) :
+Definition abmonoidfracopint (X : abmonoid) (A : @submonoid X) :
   binop (dirprod X A) := @op (setwithbinopdirprod X A).
 
-Definition hrelabmonoidfrac (X : abmonoid) (A : @submonoids X) : hrel (setwithbinopdirprod X A) :=
+Definition hrelabmonoidfrac (X : abmonoid) (A : @submonoid X) : hrel (setwithbinopdirprod X A) :=
   fun xa yb : dirprod X A => hexists (fun a0 : A => paths (((pr1 xa) + (pr1 (pr2 yb))) + (pr1 a0))
                                                     (((pr1 yb) + (pr1 (pr2 xa)) + (pr1 a0)))).
 
-Lemma iseqrelabmonoidfrac (X : abmonoid) (A : @submonoids X) : iseqrel (hrelabmonoidfrac X A).
+Lemma iseqrelabmonoidfrac (X : abmonoid) (A : @submonoid X) : iseqrel (hrelabmonoidfrac X A).
 Proof.
   intros.
   set (assoc := assocax X). set (comm := commax X).
@@ -458,10 +458,10 @@ Proof.
 Defined.
 Opaque iseqrelabmonoidfrac.
 
-Definition eqrelabmonoidfrac (X : abmonoid) (A : @submonoids X) : eqrel (setwithbinopdirprod X A) :=
+Definition eqrelabmonoidfrac (X : abmonoid) (A : @submonoid X) : eqrel (setwithbinopdirprod X A) :=
   eqrelpair (hrelabmonoidfrac X A) (iseqrelabmonoidfrac X A).
 
-Lemma isbinophrelabmonoidfrac (X : abmonoid) (A : @submonoids X) :
+Lemma isbinophrelabmonoidfrac (X : abmonoid) (A : @submonoid X) :
   @isbinophrel (setwithbinopdirprod X A) (eqrelabmonoidfrac X A).
 Proof.
   intros.
@@ -485,26 +485,26 @@ Proof.
 Defined.
 Opaque isbinophrelabmonoidfrac.
 
-Definition abmonoidfracop (X : abmonoid) (A : @submonoids X) :
+Definition abmonoidfracop (X : abmonoid) (A : @submonoid X) :
   binop (setquot (hrelabmonoidfrac X A)) :=
   setquotfun2 (hrelabmonoidfrac X A) (eqrelabmonoidfrac X A) (abmonoidfracopint X A)
               ((iscompbinoptransrel _ (eqreltrans _) (isbinophrelabmonoidfrac X A))).
 
-Definition binopeqrelabmonoidfrac (X : abmonoid) (A : @subabmonoids X) :
+Definition binopeqrelabmonoidfrac (X : abmonoid) (A : @subabmonoid X) :
   @binopeqrel (abmonoiddirprod X A) :=
   @binopeqrelpair (setwithbinopdirprod X A) (eqrelabmonoidfrac X A) (isbinophrelabmonoidfrac X A).
 
-Definition abmonoidfrac (X : abmonoid) (A : @submonoids X) : abmonoid :=
+Definition abmonoidfrac (X : abmonoid) (A : @submonoid X) : abmonoid :=
   abmonoidquot (binopeqrelabmonoidfrac X A).
 
-Definition prabmonoidfrac (X : abmonoid) (A : @submonoids X) : X -> A -> abmonoidfrac X A :=
+Definition prabmonoidfrac (X : abmonoid) (A : @submonoid X) : X -> A -> abmonoidfrac X A :=
   fun (x : X) (a : A) => setquotpr (eqrelabmonoidfrac X A) (dirprodpair x a).
 
 (* ??? could the use of [issubabmonoid] in [binopeqrelabmonoidfrac] and
  [submonoid] in [abmonoidfrac] lead to complications for the unification
  machinery? See also [abmonoidfracisbinoprelint] below. *)
 
-Lemma invertibilityinabmonoidfrac (X : abmonoid) (A : @submonoids X) :
+Lemma invertibilityinabmonoidfrac (X : abmonoid) (A : @submonoid X) :
   Π a a' : A, isinvertible (@op (abmonoidfrac X A)) (prabmonoidfrac X A (pr1 a) a').
 Proof.
   intros. set (R := eqrelabmonoidfrac X A). unfold isinvertible.
@@ -564,10 +564,10 @@ Defined.
 
 (** **** Canonical homomorphism to the monoid of fractions *)
 
-Definition toabmonoidfrac (X : abmonoid) (A : @submonoids X) (x : X) : abmonoidfrac X A :=
+Definition toabmonoidfrac (X : abmonoid) (A : @submonoid X) (x : X) : abmonoidfrac X A :=
   setquotpr _ (dirprodpair x (unel A)).
 
-Lemma isbinopfuntoabmonoidfrac (X : abmonoid) (A : @submonoids X) : isbinopfun (toabmonoidfrac X A).
+Lemma isbinopfuntoabmonoidfrac (X : abmonoid) (A : @submonoid X) : isbinopfun (toabmonoidfrac X A).
 Proof.
   intros. unfold isbinopfun. intros x1 x2.
   change (paths (setquotpr _ (dirprodpair (x1 + x2) (@unel A)))
@@ -578,21 +578,21 @@ Proof.
   apply (pathsinv0 (lunax A 0)).
 Defined.
 
-Lemma isunitalfuntoabmonoidfrac (X : abmonoid) (A : @submonoids X) :
+Lemma isunitalfuntoabmonoidfrac (X : abmonoid) (A : @submonoid X) :
   paths (toabmonoidfrac X A (unel X)) (unel (abmonoidfrac X A)).
 Proof. intros. apply idpath. Defined.
 
-Definition ismonoidfuntoabmonoidfrac (X : abmonoid) (A : @submonoids X) :
+Definition ismonoidfuntoabmonoidfrac (X : abmonoid) (A : @submonoid X) :
   ismonoidfun (toabmonoidfrac X A) :=
   dirprodpair (isbinopfuntoabmonoidfrac X A) (isunitalfuntoabmonoidfrac X A).
 
 
 (** **** Abelian monoid of fractions in the case when elements of the localziation submonoid are cancelable *)
 
-Definition hrel0abmonoidfrac (X : abmonoid) (A : @submonoids X) : hrel (dirprod X A) :=
+Definition hrel0abmonoidfrac (X : abmonoid) (A : @submonoid X) : hrel (dirprod X A) :=
   fun xa yb : setdirprod X A => eqset ((pr1 xa) + (pr1 (pr2 yb))) ((pr1 yb) + (pr1 (pr2 xa))).
 
-Lemma weqhrelhrel0abmonoidfrac (X : abmonoid) (A : @submonoids X)
+Lemma weqhrelhrel0abmonoidfrac (X : abmonoid) (A : @submonoid X)
       (iscanc : Π a : A, isrcancelable (@op X) (pr1carrier _ a))
       (xa xa' : dirprod X A) : weq (eqrelabmonoidfrac X A xa xa') (hrel0abmonoidfrac X A xa xa').
 Proof.
@@ -606,7 +606,7 @@ Proof.
   apply (setproperty X).
 Defined.
 
-Lemma isinclprabmonoidfrac (X : abmonoid) (A : @submonoids X)
+Lemma isinclprabmonoidfrac (X : abmonoid) (A : @submonoid X)
       (iscanc : Π a : A, isrcancelable (@op X) (pr1carrier _ a)) :
   Π a' : A, isincl (fun x => prabmonoidfrac X A x a').
 Proof.
@@ -622,11 +622,11 @@ Proof.
     apply e''.
 Defined.
 
-Definition isincltoabmonoidfrac (X : abmonoid) (A : @submonoids X)
+Definition isincltoabmonoidfrac (X : abmonoid) (A : @submonoid X)
            (iscanc : Π a : A, isrcancelable (@op X) (pr1carrier _ a)) :
   isincl (toabmonoidfrac X A) := isinclprabmonoidfrac X A iscanc (unel A).
 
-Lemma isdeceqabmonoidfrac (X : abmonoid) (A : @submonoids X)
+Lemma isdeceqabmonoidfrac (X : abmonoid) (A : @submonoid X)
       (iscanc : Π a : A, isrcancelable (@op X) (pr1carrier _ a)) (is : isdeceq X) :
   isdeceq (abmonoidfrac X A).
 Proof.
@@ -641,12 +641,12 @@ Defined.
 
 (** **** Relations on the abelian monoid of fractions *)
 
-Definition abmonoidfracrelint (X : abmonoid) (A : @subabmonoids X) (L : hrel X) :
+Definition abmonoidfracrelint (X : abmonoid) (A : @subabmonoid X) (L : hrel X) :
   hrel (setwithbinopdirprod X A) :=
   fun xa yb => hexists (fun c0 : A => L (((pr1 xa) + (pr1 (pr2 yb))) + (pr1 c0))
                                   (((pr1 yb) + (pr1 (pr2 xa))) + (pr1 c0))).
 
-Lemma iscomprelabmonoidfracrelint (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma iscomprelabmonoidfracrelint (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) : iscomprelrel (eqrelabmonoidfrac X A) (abmonoidfracrelint X A L).
 Proof.
   intros. set (assoc := (assocax X) : isassoc (@op X)).
@@ -693,10 +693,10 @@ Proof.
 Defined.
 Opaque iscomprelabmonoidfracrelint.
 
-Definition abmonoidfracrel (X : abmonoid) (A : @submonoids X) {L : hrel X}
+Definition abmonoidfracrel (X : abmonoid) (A : @submonoid X) {L : hrel X}
            (is : ispartbinophrel A L) := quotrel (iscomprelabmonoidfracrelint X A is).
 
-Lemma istransabmonoidfracrelint (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma istransabmonoidfracrelint (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : istrans L) : istrans (abmonoidfracrelint X A L).
 Proof.
   intros.
@@ -741,7 +741,7 @@ Proof.
 Defined.
 Opaque istransabmonoidfracrelint.
 
-Lemma istransabmonoidfracrel (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma istransabmonoidfracrel (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : istrans L) : istrans (abmonoidfracrel X A is).
 Proof.
   intros. apply istransquotrel. apply istransabmonoidfracrelint.
@@ -749,7 +749,7 @@ Proof.
   - apply isl.
 Defined.
 
-Lemma issymmabmonoidfracrelint (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma issymmabmonoidfracrelint (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : issymm L) : issymm (abmonoidfracrelint X A L).
 Proof.
   intros. intros xa1 xa2. unfold abmonoidfracrelint. simpl.
@@ -759,7 +759,7 @@ Proof.
 Defined.
 Opaque issymmabmonoidfracrelint.
 
-Lemma issymmabmonoidfracrel (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma issymmabmonoidfracrel (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : issymm L) : issymm (abmonoidfracrel X A is).
 Proof.
   intros. apply issymmquotrel. apply issymmabmonoidfracrelint.
@@ -767,14 +767,14 @@ Proof.
   - apply isl.
 Defined.
 
-Lemma isreflabmonoidfracrelint (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma isreflabmonoidfracrelint (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : isrefl L) : isrefl (abmonoidfracrelint X A L).
 Proof.
   intros. intro xa. unfold abmonoidfracrelint. simpl. apply hinhpr.
   split with (unel A). apply (isl _).
 Defined.
 
-Lemma isreflabmonoidfracrel (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma isreflabmonoidfracrel (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : isrefl L) : isrefl (abmonoidfracrel X A is).
 Proof.
   intros. apply isreflquotrel. apply isreflabmonoidfracrelint.
@@ -782,28 +782,28 @@ Proof.
   - apply isl.
 Defined.
 
-Lemma ispoabmonoidfracrelint (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma ispoabmonoidfracrelint (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : ispreorder L) : ispreorder (abmonoidfracrelint X A L).
 Proof.
   intros. split with (istransabmonoidfracrelint X A is (pr1 isl)).
   apply (isreflabmonoidfracrelint X A is (pr2 isl)).
 Defined.
 
-Lemma ispoabmonoidfracrel (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma ispoabmonoidfracrel (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : ispreorder L) : ispreorder (abmonoidfracrel X A is).
 Proof.
   intros. apply ispoquotrel. apply ispoabmonoidfracrelint.
   apply is. apply isl.
 Defined.
 
-Lemma iseqrelabmonoidfracrelint (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma iseqrelabmonoidfracrelint (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : iseqrel L) : iseqrel (abmonoidfracrelint X A L).
 Proof.
   intros. split with (ispoabmonoidfracrelint X A is (pr1 isl)).
   apply (issymmabmonoidfracrelint X A is (pr2 isl)).
 Defined.
 
-Lemma iseqrelabmonoidfracrel (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma iseqrelabmonoidfracrel (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : iseqrel L) : iseqrel (abmonoidfracrel X A is).
 Proof.
   intros. apply iseqrelquotrel. apply iseqrelabmonoidfracrelint.
@@ -811,7 +811,7 @@ Proof.
   - apply isl.
 Defined.
 
-Lemma isirreflabmonoidfracrelint (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma isirreflabmonoidfracrelint (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : isirrefl L) : isirrefl (abmonoidfracrelint X A L).
 Proof.
   intros. unfold isirrefl. intro xa. unfold abmonoidfracrelint. simpl.
@@ -819,7 +819,7 @@ Proof.
   intro t2. apply (isl _ (pr2 t2)).
 Defined.
 
-Lemma isirreflabmonoidfracrel (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma isirreflabmonoidfracrel (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : isirrefl L) : isirrefl (abmonoidfracrel X A is).
 Proof.
   intros. apply isirreflquotrel. apply isirreflabmonoidfracrelint.
@@ -827,7 +827,7 @@ Proof.
   - apply isl.
 Defined.
 
-Lemma isasymmabmonoidfracrelint (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma isasymmabmonoidfracrelint (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : isasymm L) : isasymm (abmonoidfracrelint X A L).
 Proof.
   intros.
@@ -858,7 +858,7 @@ Proof.
 Defined.
 Opaque isasymmabmonoidfracrelint.
 
-Lemma isasymmabmonoidfracrel (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma isasymmabmonoidfracrel (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : isasymm L) : isasymm (abmonoidfracrel X A is).
 Proof.
   intros. apply isasymmquotrel. apply isasymmabmonoidfracrelint.
@@ -866,7 +866,7 @@ Proof.
   - apply isl.
 Defined.
 
-Lemma iscoasymmabmonoidfracrelint (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma iscoasymmabmonoidfracrelint (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : iscoasymm L) : iscoasymm (abmonoidfracrelint X A L).
 Proof.
   intros.
@@ -882,7 +882,7 @@ Proof.
 Defined.
 Opaque isasymmabmonoidfracrelint.
 
-Lemma iscoasymmabmonoidfracrel (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma iscoasymmabmonoidfracrel (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : iscoasymm L) : iscoasymm (abmonoidfracrel X A is).
 Proof.
   intros. apply iscoasymmquotrel. apply iscoasymmabmonoidfracrelint.
@@ -890,7 +890,7 @@ Proof.
   - apply isl.
 Defined.
 
-Lemma istotalabmonoidfracrelint (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma istotalabmonoidfracrelint (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : istotal L) : istotal (abmonoidfracrelint X A L).
 Proof.
   intros. unfold istotal. intros x1 x2. unfold abmonoidfracrelint.
@@ -905,7 +905,7 @@ Proof.
   apply l.
 Defined.
 
-Lemma istotalabmonoidfracrel (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma istotalabmonoidfracrel (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : istotal L) : istotal (abmonoidfracrel X A is).
 Proof.
   intros. apply istotalquotrel. apply istotalabmonoidfracrelint.
@@ -913,7 +913,7 @@ Proof.
   - apply isl.
 Defined.
 
-Lemma iscotransabmonoidfracrelint (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma iscotransabmonoidfracrelint (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : iscotrans L) : iscotrans (abmonoidfracrelint X A L).
 Proof.
   intros.
@@ -951,7 +951,7 @@ Proof.
 Defined.
 Opaque iscotransabmonoidfracrelint.
 
-Lemma iscotransabmonoidfracrel (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma iscotransabmonoidfracrel (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : iscotrans L) : iscotrans (abmonoidfracrel X A is).
 Proof.
   intros. apply iscotransquotrel. apply iscotransabmonoidfracrelint.
@@ -959,7 +959,7 @@ Proof.
   - apply isl.
 Defined.
 
-Lemma isantisymmnegabmonoidfracrel (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma isantisymmnegabmonoidfracrel (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : isantisymmneg L) : isantisymmneg (abmonoidfracrel X A is).
 Proof.
   intros.
@@ -987,7 +987,7 @@ Proof.
 Defined.
 Opaque isantisymmnegabmonoidfracrel.
 
-Lemma isantisymmabmonoidfracrel (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma isantisymmabmonoidfracrel (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (isl : isantisymm L) : isantisymm (abmonoidfracrel X A is).
 Proof.
   intros.
@@ -1036,7 +1036,7 @@ Proof.
 Defined.
 Opaque isantisymmabmonoidfracrel.
 
-Lemma ispartbinopabmonoidfracrelint (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma ispartbinopabmonoidfracrelint (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) :
   @ispartbinophrel (setwithbinopdirprod X A) (fun xa => A (pr1 xa)) (abmonoidfracrelint X A L).
 Proof.
@@ -1063,7 +1063,7 @@ Opaque ispartbinopabmonoidfracrelint.
 
 (* ??? Coq 8.4-8.5 trunk hangs here on the following line:
 
-Axiom ispartlbinopabmonoidfracrel : Π (X : abmonoid) (A : @subabmonoids X)
+Axiom ispartlbinopabmonoidfracrel : Π (X : abmonoid) (A : @subabmonoid X)
  {L : hrel X} (is : ispartbinophrel A L) (aa aa' : A)
  (z z' : abmonoidfrac X A) (l : abmonoidfracrel X A is z z'),
 abmonoidfracrel X A is ((prabmonoidfrac X A (pr1 aa) aa') + z)
@@ -1071,7 +1071,7 @@ abmonoidfracrel X A is ((prabmonoidfrac X A (pr1 aa) aa') + z)
 
 *)
 
-Lemma ispartlbinopabmonoidfracrel (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma ispartlbinopabmonoidfracrel (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (aa aa' : A) (z z' : abmonoidfrac X A)
       (l : abmonoidfracrel X A is z z') :
   abmonoidfracrel X A is
@@ -1110,7 +1110,7 @@ Proof.
 Defined.
 Opaque ispartlbinopabmonoidfracrel.
 
-Lemma ispartrbinopabmonoidfracrel (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Lemma ispartrbinopabmonoidfracrel (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (aa aa' : A) (z z' : abmonoidfrac X A)
       (l : abmonoidfracrel X A is z z') :
   abmonoidfracrel X A is
@@ -1154,7 +1154,7 @@ Proof.
 Defined.
 Opaque ispartrbinopabmonoidfracrel.
 
-Lemma abmonoidfracrelimpl (X : abmonoid) (A : @subabmonoids X) {L L' : hrel X}
+Lemma abmonoidfracrelimpl (X : abmonoid) (A : @subabmonoid X) {L L' : hrel X}
       (is : ispartbinophrel A L) (is' : ispartbinophrel A L')
       (impl : Π x x', L x x' -> L' x x') (x x' : abmonoidfrac X A)
       (ql : abmonoidfracrel X A is x x') : abmonoidfracrel X A is' x x'.
@@ -1165,7 +1165,7 @@ Proof.
 Defined.
 Opaque abmonoidfracrelimpl.
 
-Lemma abmonoidfracrellogeq (X : abmonoid) (A : @subabmonoids X) {L L' : hrel X}
+Lemma abmonoidfracrellogeq (X : abmonoid) (A : @subabmonoid X) {L L' : hrel X}
       (is : ispartbinophrel A L) (is' : ispartbinophrel A L')
       (lg : Π x x', L x x' <-> L' x x') (x x' : abmonoidfrac X A) :
   (abmonoidfracrel X A is x x') <-> (abmonoidfracrel X A is' x x').
@@ -1178,7 +1178,7 @@ Proof.
 Defined.
 Opaque abmonoidfracrellogeq.
 
-Definition isdecabmonoidfracrelint (X : abmonoid) (A : @subabmonoids X) {L : hrel X}
+Definition isdecabmonoidfracrelint (X : abmonoid) (A : @subabmonoid X) {L : hrel X}
            (is : ispartinvbinophrel A L) (isl : isdecrel L) : isdecrel (abmonoidfracrelint X A L).
 Proof.
   intros. intros xa1 xa2.
@@ -1198,7 +1198,7 @@ Proof.
     apply ((pr2 is) _ _ _ (pr2 c0a) l).
 Defined.
 
-Definition isdecabmonoidfracrel (X : abmonoid) (A : @submonoids X) {L : hrel X}
+Definition isdecabmonoidfracrel (X : abmonoid) (A : @submonoid X) {L : hrel X}
            (is : ispartbinophrel A L) (isi : ispartinvbinophrel A L)
            (isl : isdecrel L) : isdecrel (abmonoidfracrel X A is).
 Proof.
@@ -1210,7 +1210,7 @@ Defined.
 
 (** **** Relations and the canonical homomorphism to [abmonoidfrac] *)
 
-Lemma iscomptoabmonoidfrac (X : abmonoid) (A : @submonoids X) {L : hrel X}
+Lemma iscomptoabmonoidfrac (X : abmonoid) (A : @submonoid X) {L : hrel X}
       (is : ispartbinophrel A L) : iscomprelrelfun L (abmonoidfracrel X A is) (toabmonoidfrac X A).
 Proof.
   intros. unfold iscomprelrelfun. intros x x' l.
@@ -1385,10 +1385,10 @@ Defined.
 
 (** **** Subobjects *)
 
-Definition issubgr {X : gr} (A : hsubtypes X) : UU :=
+Definition issubgr {X : gr} (A : hsubtype X) : UU :=
   dirprod (issubmonoid A) (Π x : X, A x -> A (grinv X x)).
 
-Lemma isapropissubgr {X : gr} (A : hsubtypes X) : isaprop (issubgr A).
+Lemma isapropissubgr {X : gr} (A : hsubtype X) : isaprop (issubgr A).
 Proof.
   intros. apply (isofhleveldirprod 1).
   - apply isapropissubmonoid.
@@ -1397,21 +1397,21 @@ Proof.
     apply (pr2 (A (grinv X x))).
 Defined.
 
-Definition subgrs {X : gr} : UU := total2 (fun A : hsubtypes X => issubgr A).
+Definition subgr {X : gr} : UU := total2 (fun A : hsubtype X => issubgr A).
 
 Definition subgrpair {X : gr} :
-  Π (t : hsubtypes X), (λ A : hsubtypes X, issubgr A) t → Σ A : hsubtypes X, issubgr A :=
-  tpair (fun A : hsubtypes X => issubgr A).
+  Π (t : hsubtype X), (λ A : hsubtype X, issubgr A) t → Σ A : hsubtype X, issubgr A :=
+  tpair (fun A : hsubtype X => issubgr A).
 
 Definition subgrconstr {X : gr} :
-  Π (t : hsubtypes X), (λ A : hsubtypes X, issubgr A) t → Σ A : hsubtypes X, issubgr A :=
+  Π (t : hsubtype X), (λ A : hsubtype X, issubgr A) t → Σ A : hsubtype X, issubgr A :=
   @subgrpair X.
 
-Definition subgrstosubmonoids (X : gr) : @subgrs X -> @submonoids X :=
+Definition subgrtosubmonoid (X : gr) : @subgr X -> @submonoid X :=
   fun A : _ => submonoidpair (pr1 A) (pr1 (pr2 A)).
-Coercion subgrstosubmonoids : subgrs >-> submonoids.
+Coercion subgrtosubmonoid : subgr >-> submonoid.
 
-Lemma isinvoncarrier {X : gr} (A : @subgrs X) :
+Lemma isinvoncarrier {X : gr} (A : @subgr X) :
   isinv (@op A) (unel A) (fun a : A => carrierpair _ (grinv X (pr1 a)) (pr2 (pr2 A) (pr1 a) (pr2 a))).
 Proof.
   intros. split.
@@ -1421,14 +1421,14 @@ Proof.
     simpl. apply (grrinvax X (pr1 a)).
 Defined.
 
-Definition isgrcarrier {X : gr} (A : @subgrs X) : isgrop (@op A) :=
+Definition isgrcarrier {X : gr} (A : @subgr X) : isgrop (@op A) :=
   tpair _ (ismonoidcarrier A)
         (tpair _ (fun a : A => carrierpair _ (grinv X (pr1 a)) (pr2 (pr2 A) (pr1 a) (pr2 a)))
                (isinvoncarrier A)).
 
-Definition carrierofasubgr {X : gr} (A : @subgrs X) : gr.
+Definition carrierofasubgr {X : gr} (A : @subgr X) : gr.
 Proof. intros. split with A. apply (isgrcarrier A). Defined.
-Coercion carrierofasubgr : subgrs >-> gr.
+Coercion carrierofasubgr : subgr >-> gr.
 
 
 (** **** Quotient objects *)
@@ -1523,18 +1523,18 @@ Coercion abgrtoabmonoid : abgr >-> abmonoid.
 
 (** **** Subobjects *)
 
-Definition subabgrs {X : abgr} := @subgrs X.
-Identity Coercion id_subabgrs : subabgrs >-> subgrs.
+Definition subabgr {X : abgr} := @subgr X.
+Identity Coercion id_subabgr : subabgr >-> subgr.
 
-Lemma isabgrcarrier {X : abgr} (A : @subgrs X) : isabgrop (@op A).
+Lemma isabgrcarrier {X : abgr} (A : @subgr X) : isabgrop (@op A).
 Proof.
   intros. split with (isgrcarrier A).
   apply (pr2 (@isabmonoidcarrier X A)).
 Defined.
 
-Definition carrierofasubabgr {X : abgr} (A : @subabgrs X) : abgr.
+Definition carrierofasubabgr {X : abgr} (A : @subabgr X) : abgr.
 Proof. intros. split with A. apply isabgrcarrier. Defined.
-Coercion carrierofasubabgr : subabgrs >-> abgr.
+Coercion carrierofasubabgr : subabgr >-> abgr.
 
 
 (** **** Quotient objects *)

--- a/UniMath/Algebra/Rigs_and_Rings.v
+++ b/UniMath/Algebra/Rigs_and_Rings.v
@@ -195,36 +195,36 @@ Definition isinvrigmultgt (X : rig) (R : hrel X) : UU :=
 
 (** **** Subobjects *)
 
-Definition issubrig {X : rig} (A : hsubtypes X) : UU :=
+Definition issubrig {X : rig} (A : hsubtype X) : UU :=
   dirprod (@issubmonoid (rigaddabmonoid X) A) (@issubmonoid (rigmultmonoid X) A).
 
-Lemma isapropissubrig {X : rig} (A : hsubtypes X) : isaprop (issubrig A).
+Lemma isapropissubrig {X : rig} (A : hsubtype X) : isaprop (issubrig A).
 Proof.
   intros. apply (isofhleveldirprod 1).
   - apply isapropissubmonoid.
   - apply isapropissubmonoid.
 Defined.
 
-Definition subrigs (X : rig) : UU := total2 (fun  A : hsubtypes X => issubrig A).
+Definition subrig (X : rig) : UU := total2 (fun  A : hsubtype X => issubrig A).
 
 Definition subrigpair {X : rig} :
-  Π (t : hsubtypes X), (λ A : hsubtypes X, issubrig A) t → Σ A : hsubtypes X, issubrig A :=
-  tpair (fun  A : hsubtypes X => issubrig A).
+  Π (t : hsubtype X), (λ A : hsubtype X, issubrig A) t → Σ A : hsubtype X, issubrig A :=
+  tpair (fun  A : hsubtype X => issubrig A).
 
-Definition pr1subrig (X : rig) : @subrigs X -> hsubtypes X :=
-  @pr1 _ (fun  A : hsubtypes X => issubrig A).
+Definition pr1subrig (X : rig) : @subrig X -> hsubtype X :=
+  @pr1 _ (fun  A : hsubtype X => issubrig A).
 
-Definition subrigtosubsetswith2binop (X : rig) : subrigs X -> @subsetswith2binop X :=
+Definition subrigtosubsetswith2binop (X : rig) : subrig X -> @subsetswith2binop X :=
   fun A : _ => subsetswith2binoppair (pr1 A) (dirprodpair (pr1 (pr1 (pr2 A))) (pr1 (pr2 (pr2 A)))).
-Coercion subrigtosubsetswith2binop : subrigs >-> subsetswith2binop.
+Coercion subrigtosubsetswith2binop : subrig >-> subsetswith2binop.
 
-Definition rigaddsubmonoid {X : rig} : subrigs X -> @subabmonoids (rigaddabmonoid X) :=
+Definition rigaddsubmonoid {X : rig} : subrig X -> @subabmonoid (rigaddabmonoid X) :=
   fun A : _ => @submonoidpair (rigaddabmonoid X) (pr1 A) (pr1 (pr2 A)).
 
-Definition rigmultsubmonoid {X : rig} : subrigs X -> @submonoids (rigmultmonoid X) :=
+Definition rigmultsubmonoid {X : rig} : subrig X -> @submonoid (rigmultmonoid X) :=
   fun A : _ => @submonoidpair (rigmultmonoid X) (pr1 A) (pr2 (pr2 A)).
 
-Lemma isrigcarrier {X : rig} (A : subrigs X) : isrigops (@op1 A) (@op2 A).
+Lemma isrigcarrier {X : rig} (A : subrig X) : isrigops (@op1 A) (@op2 A).
 Proof.
   intros. split.
   - split with (dirprodpair (isabmonoidcarrier (rigaddsubmonoid A))
@@ -241,9 +241,9 @@ Proof.
       simpl. apply rigrdistr.
 Defined.
 
-Definition carrierofasubrig (X : rig) (A : subrigs X) : rig.
+Definition carrierofasubrig (X : rig) (A : subrig X) : rig.
 Proof. intros. split with A. apply isrigcarrier. Defined.
-Coercion carrierofasubrig : subrigs >-> rig.
+Coercion carrierofasubrig : subrig >-> rig.
 
 
 (** **** Quotient objects *)
@@ -377,7 +377,7 @@ Defined.
 
 (** **** Subobjects *)
 
-Lemma iscommrigcarrier {X : commrig} (A : @subrigs X) : iscommrigops (@op1 A) (@op2 A).
+Lemma iscommrigcarrier {X : commrig} (A : @subrig X) : iscommrigops (@op1 A) (@op2 A).
 Proof.
   intros. split with (isrigcarrier A).
   apply (pr2 (@isabmonoidcarrier (commrigmultabmonoid X) (rigmultsubmonoid A))).
@@ -386,7 +386,7 @@ Defined.
 (* ??? slows down at the last [ apply ] and at [ Defined ] (oct.16.2011 - does
   not slow down anymore with two Dan's patches) *)
 
-Definition carrierofasubcommrig {X : commrig} (A : @subrigs X) : commrig :=
+Definition carrierofasubcommrig {X : commrig} (A : @subrig X) : commrig :=
   commrigpair A (iscommrigcarrier A).
 
 
@@ -963,37 +963,37 @@ Close Scope rng_scope.
 
 (** **** Subobjects *)
 
-Definition issubrng {X : rng} (A : hsubtypes X) : UU :=
+Definition issubrng {X : rng} (A : hsubtype X) : UU :=
   dirprod (@issubgr X A) (@issubmonoid (rngmultmonoid X) A).
 
-Lemma isapropissubrng {X : rng} (A : hsubtypes X) : isaprop (issubrng A).
+Lemma isapropissubrng {X : rng} (A : hsubtype X) : isaprop (issubrng A).
 Proof.
   intros. apply (isofhleveldirprod 1).
   - apply isapropissubgr.
   - apply isapropissubmonoid.
 Defined.
 
-Definition subrngs (X : rng) : UU := total2 (fun A : hsubtypes X => issubrng A).
+Definition subrng (X : rng) : UU := total2 (fun A : hsubtype X => issubrng A).
 
 Definition subrngpair {X : rng} :
-  Π (t : hsubtypes X), (λ A : hsubtypes X, issubrng A) t → Σ A : hsubtypes X, issubrng A :=
-  tpair (fun A : hsubtypes X => issubrng A).
+  Π (t : hsubtype X), (λ A : hsubtype X, issubrng A) t → Σ A : hsubtype X, issubrng A :=
+  tpair (fun A : hsubtype X => issubrng A).
 
-Definition pr1subrng (X : rng) : @subrngs X -> hsubtypes X :=
-  @pr1 _ (fun A : hsubtypes X => issubrng A).
+Definition pr1subrng (X : rng) : @subrng X -> hsubtype X :=
+  @pr1 _ (fun A : hsubtype X => issubrng A).
 
-Definition subrngtosubsetswith2binop (X : rng) : subrngs X -> @subsetswith2binop X :=
+Definition subrngtosubsetswith2binop (X : rng) : subrng X -> @subsetswith2binop X :=
   fun A : _ => subsetswith2binoppair
               (pr1 A) (dirprodpair (pr1 (pr1 (pr1 (pr2 A)))) (pr1 (pr2 (pr2 A)))).
-Coercion subrngtosubsetswith2binop : subrngs >-> subsetswith2binop.
+Coercion subrngtosubsetswith2binop : subrng >-> subsetswith2binop.
 
-Definition addsubgr {X : rng} : subrngs X -> @subgrs X :=
+Definition addsubgr {X : rng} : subrng X -> @subgr X :=
   fun A : _ => @subgrpair X (pr1 A) (pr1 (pr2 A)).
 
-Definition multsubmonoid {X : rng} : subrngs X -> @submonoids (rngmultmonoid X) :=
+Definition multsubmonoid {X : rng} : subrng X -> @submonoid (rngmultmonoid X) :=
   fun A : _ => @submonoidpair (rngmultmonoid X) (pr1 A) (pr2 (pr2 A)).
 
-Lemma isrngcarrier {X : rng} (A : subrngs X) : isrngops (@op1 A) (@op2 A).
+Lemma isrngcarrier {X : rng} (A : subrng X) : isrngops (@op1 A) (@op2 A).
 Proof.
   intros.
   split with (dirprodpair (isabgrcarrier (addsubgr A)) (ismonoidcarrier (multsubmonoid A))).
@@ -1006,9 +1006,9 @@ Proof.
     simpl. apply rngrdistr.
 Defined.
 
-Definition carrierofasubrng (X : rng) (A : subrngs X) : rng.
+Definition carrierofasubrng (X : rng) (A : subrng X) : rng.
 Proof. intros. split with A. apply isrngcarrier. Defined.
-Coercion carrierofasubrng : subrngs >-> rng.
+Coercion carrierofasubrng : subrng >-> rng.
 
 
 (** **** Quotient objects *)
@@ -1554,13 +1554,13 @@ Close Scope rng_scope.
 
 (** **** Subobjects *)
 
-Lemma iscommrngcarrier {X : commrng} (A : @subrngs X) : iscommrngops (@op1 A) (@op2 A).
+Lemma iscommrngcarrier {X : commrng} (A : @subrng X) : iscommrngops (@op1 A) (@op2 A).
 Proof.
   intros. split with (isrngcarrier A).
   apply (pr2 (@isabmonoidcarrier (rngmultabmonoid X) (multsubmonoid A))).
 Defined.
 
-Definition carrierofasubcommrng {X : commrng} (A : @subrngs X) : commrng :=
+Definition carrierofasubcommrng {X : commrng} (A : @subrng X) : commrng :=
   commrngpair A (iscommrngcarrier A).
 
 
@@ -1628,25 +1628,25 @@ Close Scope rig_scope.
 
 Open Scope rng_scope.
 
-Definition commrngfracop1int (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Definition commrngfracop1int (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   binop (dirprod X S) := fun x1s1 x2s2 : dirprod X S =>
                            @dirprodpair X S (((pr1 (pr2 x2s2)) * (pr1 x1s1)) +
                                              ((pr1 (pr2 x1s1)) * (pr1 x2s2)))
                                         (@op S (pr2 x1s1) (pr2 x2s2)).
 
-Definition commrngfracop2int (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Definition commrngfracop2int (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   binop (dirprod X S) := abmonoidfracopint (rngmultabmonoid X) S.
 
-Definition commrngfracunel1int (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Definition commrngfracunel1int (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   dirprod X S := dirprodpair 0 (unel S).
 
-Definition commrngfracunel2int (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Definition commrngfracunel2int (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   dirprod X S := dirprodpair 1 (unel S).
 
-Definition commrngfracinv1int (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Definition commrngfracinv1int (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   dirprod X S -> dirprod X S := fun xs : _ => dirprodpair ((-1) * (pr1 xs)) (pr2 xs).
 
-Definition eqrelcommrngfrac (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Definition eqrelcommrngfrac (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   eqrel (dirprod X S) := eqrelabmonoidfrac (rngmultabmonoid X) S.
 
 Lemma commrngfracl1 (X : commrng) (x1 x2 x3 x4 a1 a2 s1 s2 s3 s4 : X)
@@ -1697,7 +1697,7 @@ Proof.
 Defined.
 Opaque commrngfracl1.
 
-Lemma commrngfracop1comp (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Lemma commrngfracop1comp (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   iscomprelrelfun2 (eqrelcommrngfrac X S) (eqrelcommrngfrac X S) (commrngfracop1int X S).
 Proof.
   intros. intros xs1 xs2 xs3 xs4. simpl.
@@ -1712,7 +1712,7 @@ Proof.
 Defined.
 Opaque commrngfracop1comp.
 
-Definition commrngfracop1 (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Definition commrngfracop1 (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   binop (setquotinset (eqrelcommrngfrac X S)) :=
   setquotfun2 (eqrelcommrngfrac X S) (eqrelcommrngfrac X S)
               (commrngfracop1int X S) (commrngfracop1comp X S).
@@ -1735,7 +1735,7 @@ Proof.
 Defined.
 Opaque commrngfracl2.
 
-Lemma commrngfracassoc1 (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Lemma commrngfracassoc1 (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   isassoc (commrngfracop1 X S).
 Proof.
   intros.
@@ -1760,7 +1760,7 @@ Proof.
 Defined.
 Opaque commrngfracassoc1.
 
-Lemma commrngfraccomm1 (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Lemma commrngfraccomm1 (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   iscomm (commrngfracop1 X S).
 Proof.
   intros.
@@ -1784,13 +1784,13 @@ Proof.
 Defined.
 Opaque commrngfraccomm1.
 
-Definition commrngfracunel1 (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Definition commrngfracunel1 (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   setquot (eqrelcommrngfrac X S) := setquotpr (eqrelcommrngfrac X S) (commrngfracunel1int X S).
 
-Definition commrngfracunel2 (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Definition commrngfracunel2 (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   setquot (eqrelcommrngfrac X S) := setquotpr (eqrelcommrngfrac X S) (commrngfracunel2int X S).
 
-Lemma commrngfracinv1comp (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Lemma commrngfracinv1comp (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   iscomprelrelfun (eqrelcommrngfrac X S) (eqrelcommrngfrac X S) (commrngfracinv1int X S).
 Proof.
   intros.
@@ -1806,12 +1806,12 @@ Proof.
   apply (maponpaths (fun x0 : X => -1 * x0) (pr2 tt0)).
 Defined.
 
-Definition commrngfracinv1 (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Definition commrngfracinv1 (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   setquot (eqrelcommrngfrac X S) → setquot (eqrelcommrngfrac X S) :=
   setquotfun (eqrelcommrngfrac X S) (eqrelcommrngfrac X S)
              (commrngfracinv1int X S) (commrngfracinv1comp X S).
 
-Lemma commrngfracisinv1 (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Lemma commrngfracisinv1 (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   isinv (commrngfracop1 X S) (commrngfracunel1 X S) (commrngfracinv1 X S).
 Proof.
   intros.
@@ -1844,7 +1844,7 @@ Proof.
 Defined.
 Opaque commrngfracisinv1.
 
-Lemma commrngfraclunit1 (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Lemma commrngfraclunit1 (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   islunit (commrngfracop1 X S) (commrngfracunel1 X S).
 Proof.
   intros.
@@ -1870,7 +1870,7 @@ Proof.
 Defined.
 Opaque commrngfraclunit1.
 
-Lemma commrngfracrunit1 (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Lemma commrngfracrunit1 (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   isrunit (commrngfracop1 X S) (commrngfracunel1 X S).
 Proof.
   intros.
@@ -1879,21 +1879,21 @@ Proof.
 Defined.
 Opaque commrngfracrunit1.
 
-Definition commrngfracunit1 (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Definition commrngfracunit1 (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   ismonoidop (commrngfracop1 X S) :=
   tpair _ (commrngfracassoc1 X S)
         (tpair _ (commrngfracunel1 X S)
                (dirprodpair (commrngfraclunit1 X S) (commrngfracrunit1 X S))).
 
-Definition commrngfracop2 (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Definition commrngfracop2 (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   binop (setquotinset (eqrelcommrngfrac X S)) := abmonoidfracop (rngmultabmonoid X) S.
 
-Lemma commrngfraccomm2 (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Lemma commrngfraccomm2 (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   iscomm (commrngfracop2 X S).
 Proof. intros. apply (commax (abmonoidfrac (rngmultabmonoid X) S)). Defined.
 Opaque commrngfraccomm2.
 
-Lemma commrngfracldistr (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Lemma commrngfracldistr (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   isldistr (commrngfracop1 X S) (commrngfracop2 X S).
 Proof.
   intros.
@@ -1951,7 +1951,7 @@ Proof.
 Defined.
 Opaque commrngfracldistr.
 
-Lemma commrngfracrdistr (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Lemma commrngfracrdistr (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   isrdistr (commrngfracop1 X S) (commrngfracop2 X S).
 Proof.
   intros.
@@ -1970,7 +1970,7 @@ Defined.
    properties.
 *)
 
-Definition commrngfrac (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) : commrng.
+Definition commrngfrac (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) : commrng.
 Proof.
   intros.
   set (R := eqrelcommrngfrac  X S).
@@ -1987,10 +1987,10 @@ Proof.
   - apply (dirprodpair (commrngfracldistr X S) (commrngfracrdistr X S)).
 Defined.
 
-Definition prcommrngfrac (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Definition prcommrngfrac (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   X -> S -> commrngfrac X S := fun x s => setquotpr _ (dirprodpair x s).
 
-Lemma invertibilityincommrngfrac (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Lemma invertibilityincommrngfrac (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   Π a a' : S, isinvertible (@op2 (commrngfrac X S)) (prcommrngfrac X S (pr1 a) a').
 Proof.
   intros.
@@ -2000,10 +2000,10 @@ Defined.
 
 (** **** Canonical homomorphism to the ring of fractions *)
 
-Definition tocommrngfrac (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) (x : X) :
+Definition tocommrngfrac (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) (x : X) :
   commrngfrac X S := setquotpr _ (dirprodpair x (unel S)).
 
-Lemma isbinop1funtocommrngfrac (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Lemma isbinop1funtocommrngfrac (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   @isbinopfun X (commrngfrac X S) (tocommrngfrac X S).
 Proof.
   intros. unfold isbinopfun. intros x x'.
@@ -2019,20 +2019,20 @@ Proof.
 Defined.
 Opaque isbinop1funtocommrngfrac.
 
-Lemma isunital1funtocommrngfrac (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Lemma isunital1funtocommrngfrac (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   paths (tocommrngfrac X S 0) 0.
 Proof. intros. apply idpath. Defined.
 Opaque isunital1funtocommrngfrac.
 
-Definition isaddmonoidfuntocommrngfrac (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Definition isaddmonoidfuntocommrngfrac (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   @ismonoidfun X (commrngfrac X S) (tocommrngfrac X S) :=
   dirprodpair (isbinop1funtocommrngfrac X S) (isunital1funtocommrngfrac X S).
 
-Definition tocommrngfracandminus0 (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) (x : X) :
+Definition tocommrngfracandminus0 (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) (x : X) :
   paths (tocommrngfrac X S (- x)) (- tocommrngfrac X S x) :=
   grinvandmonoidfun _ _ (isaddmonoidfuntocommrngfrac X S) x.
 
-Definition tocommrngfracandminus (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) (x y : X) :
+Definition tocommrngfracandminus (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) (x y : X) :
   paths (tocommrngfrac X S (x - y)) (tocommrngfrac X S x - tocommrngfrac X S y).
 Proof.
   intros.
@@ -2044,32 +2044,32 @@ Proof.
 Defined.
 Opaque tocommrngfracandminus.
 
-Definition isbinop2funtocommrngfrac (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Definition isbinop2funtocommrngfrac (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   @isbinopfun (rngmultmonoid X) (rngmultmonoid (commrngfrac X S)) (tocommrngfrac X S) :=
   isbinopfuntoabmonoidfrac (rngmultabmonoid X) S.
 Opaque isbinop2funtocommrngfrac.
 
-Lemma isunital2funtocommrngfrac (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Lemma isunital2funtocommrngfrac (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   paths (tocommrngfrac X S 1) 1.
 Proof. intros. apply idpath. Defined.
 Opaque isunital2funtocommrngfrac.
 
-Definition ismultmonoidfuntocommrngfrac (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Definition ismultmonoidfuntocommrngfrac (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   @ismonoidfun (rngmultmonoid X) (rngmultmonoid (commrngfrac X S)) (tocommrngfrac X S) :=
   dirprodpair (isbinop2funtocommrngfrac X S) (isunital2funtocommrngfrac X S).
 
-Definition isrngfuntocommrngfrac (X : commrng) (S : @subabmonoids (rngmultabmonoid X)) :
+Definition isrngfuntocommrngfrac (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   @isrngfun X (commrngfrac X S) (tocommrngfrac X S) :=
   dirprodpair (isaddmonoidfuntocommrngfrac X S) (ismultmonoidfuntocommrngfrac X S).
 
 
 (** **** Ring of fractions in the case when all elements which are being inverted are cancelable *)
 
-Definition hrelcommrngfrac0 (X : commrng) (S : @submonoids (rngmultabmonoid X)) :
+Definition hrelcommrngfrac0 (X : commrng) (S : @submonoid (rngmultabmonoid X)) :
   hrel (dirprod X S) :=
   fun xa yb : setdirprod X S => eqset ((pr1 xa) * (pr1 (pr2 yb))) ((pr1 yb) * (pr1 (pr2 xa))).
 
-Lemma weqhrelhrel0commrngfrac (X : commrng) (S : @submonoids (rngmultabmonoid X))
+Lemma weqhrelhrel0commrngfrac (X : commrng) (S : @submonoid (rngmultabmonoid X))
       (iscanc : Π a : S, isrcancelable (@op2 X) (pr1carrier _ a)) (xa xa' : dirprod X S) :
   weq (eqrelcommrngfrac X S xa xa') (hrelcommrngfrac0 X S xa xa').
 Proof.
@@ -2086,7 +2086,7 @@ Proof.
 Defined.
 Opaque weqhrelhrel0abmonoidfrac.
 
-Lemma isinclprcommrngfrac (X : commrng) (S : @submonoids (rngmultabmonoid X))
+Lemma isinclprcommrngfrac (X : commrng) (S : @submonoid (rngmultabmonoid X))
       (iscanc : Π a : S, isrcancelable (@op2 X) (pr1carrier _ a)) :
   Π a' : S, isincl (fun x => prcommrngfrac X S x a').
 Proof.
@@ -2100,11 +2100,11 @@ Proof.
   simpl in e''. apply (invmaponpathsincl _ (iscanc a')). apply e''.
 Defined.
 
-Definition isincltocommrngfrac (X : commrng) (S : @submonoids (rngmultabmonoid X))
+Definition isincltocommrngfrac (X : commrng) (S : @submonoid (rngmultabmonoid X))
            (iscanc : Π a : S, isrcancelable (@op2 X) (pr1carrier _ a)) :
   isincl (tocommrngfrac X S) := isinclprcommrngfrac X S iscanc (unel S).
 
-Lemma isdeceqcommrngfrac (X : commrng) (S : @submonoids (rngmultabmonoid X))
+Lemma isdeceqcommrngfrac (X : commrng) (S : @submonoid (rngmultabmonoid X))
       (iscanc : Π a : S, isrcancelable (@op2 X) (pr1carrier _ a)) (is : isdeceq X) :
   isdeceq (commrngfrac X S).
 Proof.
@@ -2119,7 +2119,7 @@ Defined.
 
 (** **** Relations similar to "greater" or "greater or equal"  on the rings of fractions *)
 
-Lemma ispartbinopcommrngfracgt (X : commrng) (S : @submonoids (rngmultabmonoid X)) {R : hrel X}
+Lemma ispartbinopcommrngfracgt (X : commrng) (S : @submonoid (rngmultabmonoid X)) {R : hrel X}
       (is0 : @isbinophrel (rigaddabmonoid X) R) (is1 : isrngmultgt X R)
       (is2 : Π c : X, S c -> R c 0) : @ispartbinophrel (rngmultabmonoid X) S R.
 Proof.
@@ -2130,12 +2130,12 @@ Proof.
     apply (isrngmultgttoisrrngmultgt X is0 is1 _ _ _ (is2 c s) rab).
 Defined.
 
-Definition commrngfracgt (X : commrng) (S : @submonoids (rngmultabmonoid X)) {R : hrel X}
+Definition commrngfracgt (X : commrng) (S : @submonoid (rngmultabmonoid X)) {R : hrel X}
            (is0 : @isbinophrel (rigaddabmonoid X) R) (is1 : isrngmultgt X R)
            (is2 : Π c : X, S c -> R c 0) : hrel (commrngfrac X S) :=
   abmonoidfracrel (rngmultabmonoid X) S (ispartbinopcommrngfracgt X S is0 is1 is2).
 
-Lemma isrngmultcommrngfracgt (X : commrng) (S : @submonoids (rngmultabmonoid X)) {R : hrel X}
+Lemma isrngmultcommrngfracgt (X : commrng) (S : @submonoid (rngmultabmonoid X)) {R : hrel X}
       (is0 : @isbinophrel (rigaddabmonoid X) R) (is1 : isrngmultgt X R)
       (is2 : Π c : X, S c -> R c 0) : isrngmultgt (commrngfrac X S) (commrngfracgt X S is0 is1 is2).
 Proof.
@@ -2194,7 +2194,7 @@ Proof.
 Defined.
 Opaque isrngmultcommrngfracgt.
 
-Lemma isrngaddcommrngfracgt (X : commrng) (S : @submonoids (rngmultabmonoid X)) {R : hrel X}
+Lemma isrngaddcommrngfracgt (X : commrng) (S : @submonoid (rngmultabmonoid X)) {R : hrel X}
       (is0 : @isbinophrel (rigaddabmonoid X) R) (is1 : isrngmultgt X R)
       (is2 : Π c : X, S c -> R c 0) : @isbinophrel (commrngfrac X S) (commrngfracgt X S is0 is1 is2).
 Proof.
@@ -2242,7 +2242,7 @@ Proof.
 Defined.
 Opaque isrngaddcommrngfracgt.
 
-Definition isdeccommrngfracgt (X : commrng) (S : @submonoids (rngmultabmonoid X)) {R : hrel X}
+Definition isdeccommrngfracgt (X : commrng) (S : @submonoid (rngmultabmonoid X)) {R : hrel X}
            (is0 : @isbinophrel (rigaddabmonoid X) R) (is1 : isrngmultgt X R)
            (is2 : Π c : X, S c -> R c 0) (is' : @ispartinvbinophrel (rngmultabmonoid X) S R)
            (isd : isdecrel R) : isdecrel (commrngfracgt X S is0 is1 is2).
@@ -2255,7 +2255,7 @@ Defined.
 
 (** **** Realations and the canonical homomorphism to the ring of fractions *)
 
-Definition iscomptocommrngfrac (X : commrng) (S : @submonoids (rngmultabmonoid X)) {L : hrel X}
+Definition iscomptocommrngfrac (X : commrng) (S : @submonoid (rngmultabmonoid X)) {L : hrel X}
            (is0 : @isbinophrel (rigaddabmonoid X) L) (is1 : isrngmultgt X L)
            (is2 : Π c : X, S c -> L c 0) :
   iscomprelrelfun L (commrngfracgt X S is0 is1 is2) (tocommrngfrac X S) :=

--- a/UniMath/CategoryTheory/Epis.v
+++ b/UniMath/CategoryTheory/Epis.v
@@ -125,17 +125,17 @@ Section epis_subcategory.
   Variable C : precategory.
   Hypothesis hs : has_homsets C.
 
-  Definition hsubtypes_obs_isEpi : hsubtypes C := (fun c : C => hProppair _ isapropunit).
+  Definition hsubtype_obs_isEpi : hsubtype C := (fun c : C => hProppair _ isapropunit).
 
-  Definition hsubtypes_mors_isEpi : Π (a b : C), hsubtypes (C⟦a, b⟧) :=
+  Definition hsubtype_mors_isEpi : Π (a b : C), hsubtype (C⟦a, b⟧) :=
     (fun a b : C => (fun f : C⟦a, b⟧ => hProppair _ (isapropisEpi C hs f))).
 
   Definition subprecategory_of_epis : sub_precategories C.
   Proof.
     use tpair.
     split.
-    - exact hsubtypes_obs_isEpi.
-    - exact hsubtypes_mors_isEpi.
+    - exact hsubtype_obs_isEpi.
+    - exact hsubtype_mors_isEpi.
     - cbn. unfold is_sub_precategory. cbn.
       split.
       + intros a tt. exact (identity_isEpi C).

--- a/UniMath/CategoryTheory/GrothendieckTopos.v
+++ b/UniMath/CategoryTheory/GrothendieckTopos.v
@@ -81,7 +81,7 @@ Section def_grothendiecktopology.
 
   (** ** Grothendieck topology *)
 
-  Definition collection_of_sieves : UU := Π (c : C), hsubtypes (sieve c).
+  Definition collection_of_sieves : UU := Π (c : C), hsubtype (sieve c).
 
   Definition isGrothendieckTopology_maximal_sieve (COS : collection_of_sieves) : UU :=
     Π (c : C), COS c (SubobjectsPrecategory_ob
@@ -148,14 +148,14 @@ Section def_grothendiecktopology.
 
   (** The category of sheaves is the full subcategory of presheaves consisting of the presheaves
       which satisfy the isSheaf proposition. *)
-  Definition hsubtypes_obs_isSheaf (GT : GrothendieckTopology) :
-    hsubtypes (functor_precategory (opp_precat C) HSET has_homsets_HSET) :=
+  Definition hsubtype_obs_isSheaf (GT : GrothendieckTopology) :
+    hsubtype (functor_precategory (opp_precat C) HSET has_homsets_HSET) :=
     (fun P : functor_precategory (opp_precat C) HSET has_homsets_HSET =>
        hProppair _ (isaprop_isSheaf GT (mk_Presheaf P))).
 
   Definition PrecategoryOfSheaves (GT : GrothendieckTopology) :
     sub_precategories (functor_precategory (opp_precat C) HSET has_homsets_HSET) :=
-    full_sub_precategory (hsubtypes_obs_isSheaf GT).
+    full_sub_precategory (hsubtype_obs_isSheaf GT).
 
 End def_grothendiecktopology.
 

--- a/UniMath/CategoryTheory/LocalizingClass.v
+++ b/UniMath/CategoryTheory/LocalizingClass.v
@@ -31,7 +31,7 @@ Section def_roofs.
   Variable C : precategory.
   Hypothesis hs : has_homsets C.
 
-  Definition SubsetsOfMors : UU := Π (x y : ob C), hsubtypes (hSetpair (C⟦x, y⟧) (hs x y)).
+  Definition SubsetsOfMors : UU := Π (x y : ob C), hsubtype (hSetpair (C⟦x, y⟧) (hs x y)).
 
   (** ** Localizing classes *)
 
@@ -336,24 +336,24 @@ Section def_roofs.
   Qed.
 
   (** We are interested in the equivalence classes of roofs. *)
-  (* Definition eqclass {X : UU} {r : eqrel X} : UU := Σ A : hsubtypes X, iseqclass r A. *)
+  (* Definition eqclass {X : UU} {r : eqrel X} : UU := Σ A : hsubtype X, iseqclass r A. *)
 
   Definition RoofEqclass (x y : ob C) : UU :=
-    Σ A : hsubtypes (Roof x y), iseqclass (eqrelpair _ (RoofEqrel x y)) A.
+    Σ A : hsubtype (Roof x y), iseqclass (eqrelpair _ (RoofEqrel x y)) A.
 
   Lemma isasetRoofEqclass (x y : ob C) : isaset (RoofEqclass x y).
   Proof.
     apply isaset_total2.
-    - apply isasethsubtypes.
+    - apply isasethsubtype.
     - intros x0.
       apply isasetaprop.
       apply isapropiseqclass.
   Defined.
 
-  Definition mk_RoofEqclass {x y : ob C} (A : hsubtypes (Roof x y))
+  Definition mk_RoofEqclass {x y : ob C} (A : hsubtype (Roof x y))
              (H : iseqclass (eqrelpair _ (RoofEqrel x y)) A) : RoofEqclass x y := tpair _ A H.
 
-  Definition RoofEqclassIn {x y : ob C} (RE : RoofEqclass x y) : hsubtypes (Roof x y) := pr1 RE.
+  Definition RoofEqclassIn {x y : ob C} (RE : RoofEqclass x y) : hsubtype (Roof x y) := pr1 RE.
 
   Definition RoofEqclassIs {x y : ob C} (RE : RoofEqclass x y) :
     iseqclass (eqrelpair _ (RoofEqrel x y)) (RoofEqclassIn RE) := pr2 RE.

--- a/UniMath/CategoryTheory/Monics.v
+++ b/UniMath/CategoryTheory/Monics.v
@@ -122,17 +122,17 @@ Section monics_subcategory.
   Variable C : precategory.
   Hypothesis hs : has_homsets C.
 
-  Definition hsubtypes_obs_isMonic : hsubtypes C := (fun c : C => hProppair _ isapropunit).
+  Definition hsubtype_obs_isMonic : hsubtype C := (fun c : C => hProppair _ isapropunit).
 
-  Definition hsubtypes_mors_isMonic : Π (a b : C), hsubtypes (C⟦a, b⟧) :=
+  Definition hsubtype_mors_isMonic : Π (a b : C), hsubtype (C⟦a, b⟧) :=
     (fun a b : C => (fun f : C⟦a, b⟧ => hProppair _ (isapropisMonic C hs f))).
 
   Definition subprecategory_of_monics : sub_precategories C.
   Proof.
     use tpair.
     split.
-    - exact hsubtypes_obs_isMonic.
-    - exact hsubtypes_mors_isMonic.
+    - exact hsubtype_obs_isMonic.
+    - exact hsubtype_mors_isMonic.
     - cbn. unfold is_sub_precategory. cbn.
       split.
       + intros a tt. exact (identity_isMonic C).

--- a/UniMath/CategoryTheory/PreAdditive.v
+++ b/UniMath/CategoryTheory/PreAdditive.v
@@ -299,7 +299,7 @@ Section preadditive_quotient.
   Variable PA : PreAdditive.
 
   (** For every set morphisms we have a subgroup. *)
-  Definition PreAdditiveSubabgrs : UU := Π (x y : ob PA), @subabgrs (to_abgrop x y).
+  Definition PreAdditiveSubabgrs : UU := Π (x y : ob PA), @subabgr (to_abgrop x y).
 
   Hypothesis PAS : PreAdditiveSubabgrs.
 
@@ -308,10 +308,10 @@ Section preadditive_quotient.
       the unit element in the new precategory. *)
   Definition PreAdditiveComps : UU :=
     Π (x y : ob PA),
-    (Π (z : ob PA) (f : x --> y) (inf : pr1submonoids _ (PAS x y) f) (g : y --> z),
-     pr1submonoids _ (PAS x z) (f ;; g))
-      × (Π (z : ob PA) (f : x --> y) (g : y --> z) (ing : pr1submonoids _ (PAS y z) g),
-         pr1submonoids _ (PAS x z) (f ;; g)).
+    (Π (z : ob PA) (f : x --> y) (inf : pr1submonoid _ (PAS x y) f) (g : y --> z),
+     pr1submonoid _ (PAS x z) (f ;; g))
+      × (Π (z : ob PA) (f : x --> y) (g : y --> z) (ing : pr1submonoid _ (PAS y z) g),
+         pr1submonoid _ (PAS x z) (f ;; g)).
 
   Hypothesis PAC : PreAdditiveComps.
 
@@ -319,11 +319,11 @@ Section preadditive_quotient.
      Theses should be deleted, removed, renamed, generalized, or ...*)
 
   (** The hProp which tells if two elements of A belong to the same equivalence class in A/B *)
-  Definition subgrhrel_hprop {A : gr} (B : @subgrs A) (a1 a2 : A) : hProp :=
+  Definition subgrhrel_hprop {A : gr} (B : @subgr A) (a1 a2 : A) : hProp :=
     hexists (fun b : B => pr1 b = (a1 * grinv A a2)%multmonoid).
 
   (** Construct a relation using the above hProp *)
-  Definition subgrhrel {A : gr} (B : @subgrs A) : @hrel A :=
+  Definition subgrhrel {A : gr} (B : @subgr A) : @hrel A :=
     (fun a1 : A => fun a2 : A => (subgrhrel_hprop B a1 a2)).
 
   (** Some equalities *)
@@ -369,7 +369,7 @@ Section preadditive_quotient.
   Qed.
 
   (** The relation we defined is an equivalence relation *)
-  Lemma iseqrel_subgrhrel (A : gr) (B : @subgrs A) : iseqrel (subgrhrel B).
+  Lemma iseqrel_subgrhrel (A : gr) (B : @subgr A) : iseqrel (subgrhrel B).
   Proof.
     unfold subgrhrel. unfold subgrhrel_hprop.
     use iseqrelconstr.
@@ -399,7 +399,7 @@ Section preadditive_quotient.
 
   (** The relation we defined respects binary operations. Note that we use commax, thus the proof
       does not work for nonabelian groups. *)
-  Lemma isbinopeqrel_subgr_eqrel {A : abgr} (B : @subabgrs A) :
+  Lemma isbinopeqrel_subgr_eqrel {A : abgr} (B : @subabgr A) :
     isbinophrel (eqrelpair (subgrhrel B) (iseqrel_subgrhrel A B)).
   Proof.
     use isbinophrelif.
@@ -414,7 +414,7 @@ Section preadditive_quotient.
   Qed.
 
   (** Thus the relation is a binopeqrel *)
-  Lemma binopeqrel_subgr_eqrel {A : abgr} (B : @subabgrs A) : @binopeqrel A.
+  Lemma binopeqrel_subgr_eqrel {A : abgr} (B : @subabgr A) : @binopeqrel A.
   Proof.
     use binopeqrelpair.
     - exact (eqrelpair _ (iseqrel_subgrhrel A B)).
@@ -422,7 +422,7 @@ Section preadditive_quotient.
   Defined.
 
   (** These are the homsets in our new category. *)
-  Definition subabgr_quot {A : abgr} (B : @subabgrs A) : abgr :=
+  Definition subabgr_quot {A : abgr} (B : @subabgr A) : abgr :=
     abgrquot (binopeqrel_subgr_eqrel B).
 
   Definition QuotPrecategory_homsets (c d : ob PA) : abgr := subabgr_quot (PAS c d).

--- a/UniMath/CategoryTheory/category_abgr.v
+++ b/UniMath/CategoryTheory/category_abgr.v
@@ -306,12 +306,12 @@ Section ABGR_general.
              (hf2 : hfiber (pr1 f) b2) : hfiber (pr1 f) (b1 * b2)%multmonoid :=
     hfiberpair (pr1 f) ((pr1 hf1) * (pr1 hf2))%multmonoid (hfiber_op_eq f b1 b2 hf1 hf2).
 
-  (** hsubtypes for forming the subgroups kernel and image, and also the quotient group for
+  (** hsubtype for forming the subgroups kernel and image, and also the quotient group for
       cokernel. These are needed to use the relevant results in Algebra/Monoid_and_Groups.v. *)
-  Definition ABGR_kernel_hsubtype {A B : abgr} (f : monoidfun A B) : hsubtypes A :=
+  Definition ABGR_kernel_hsubtype {A B : abgr} (f : monoidfun A B) : hsubtype A :=
     (fun x : A => ishinh ((f x) = unel B)).
 
-  Definition ABGR_image_hsubtype {A B : abgr} (f : monoidfun A B) : hsubtypes B :=
+  Definition ABGR_image_hsubtype {A B : abgr} (f : monoidfun A B) : hsubtype B :=
     (fun y : B => ∃ x : A, (f x) = y).
 
   (** An equality we are going to use. *)
@@ -874,7 +874,7 @@ Section ABGR_kernels.
   Qed.
 
   (** Construction of the kernel of f. *)
-  Definition ABGR_kernel_subabgr {A B : abgr} (f : monoidfun A B) : @subabgrs A
+  Definition ABGR_kernel_subabgr {A B : abgr} (f : monoidfun A B) : @subabgr A
     := subgrconstr (@ABGR_kernel_hsubtype A B f) (ABGR_kernel_subabgr_issubgr f).
 
   (** Hide ismonoidfun behind Qed. *)
@@ -1000,7 +1000,7 @@ Section ABGR_kernels.
   Qed.
 
   (** Construction of the image of f. *)
-  Definition ABGR_image {A B : abgr} (f : monoidfun A B) : @subabgrs B :=
+  Definition ABGR_image {A B : abgr} (f : monoidfun A B) : @subabgr B :=
     @subgrconstr B (@ABGR_image_hsubtype A B f) (ABGR_image_issubgr f).
 
   (** A construction of an equivalence relation on B. *)

--- a/UniMath/CategoryTheory/functor_categories.v
+++ b/UniMath/CategoryTheory/functor_categories.v
@@ -638,7 +638,7 @@ Definition is_in_img_functor {C D : precategory_data} (F : functor C D)
   total2 (fun c : ob C => iso (F c) d)).
 
 Definition sub_img_functor {C D : precategory_data}(F : functor C D) :
-    hsubtypes (ob D) :=
+    hsubtype (ob D) :=
        fun d : ob D => is_in_img_functor F d.
 
 

--- a/UniMath/CategoryTheory/sub_precategories.v
+++ b/UniMath/CategoryTheory/sub_precategories.v
@@ -57,21 +57,21 @@ Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 *)
 
 Definition is_sub_precategory {C : precategory}
-    (C' : hsubtypes C)
-    (Cmor' : Π a b : C, hsubtypes (a --> b)) :=
+    (C' : hsubtype C)
+    (Cmor' : Π a b : C, hsubtype (a --> b)) :=
  dirprod (Π a : C, C' a ->  Cmor' _ _ (identity a ))
          (Π (a b c : C) (f: a --> b) (g : b --> c),
                    Cmor' _ _ f -> Cmor' _ _  g -> Cmor' _ _  (f ;; g)).
 
 Definition sub_precategories (C : precategory) := total2 (
-   fun C' : dirprod (hsubtypes (ob C))
-                    (Π a b:ob C, hsubtypes (a --> b)) =>
+   fun C' : dirprod (hsubtype (ob C))
+                    (Π a b:ob C, hsubtype (a --> b)) =>
         is_sub_precategory (pr1 C') (pr2 C')).
 
 (** A full subcategory has the true predicate on morphisms *)
 
 Lemma is_sub_precategory_full (C : precategory)
-         (C':hsubtypes (ob C)) :
+         (C':hsubtype (ob C)) :
         is_sub_precategory C' (fun a b => fun f => htrue).
 Proof.
   split;
@@ -79,7 +79,7 @@ Proof.
 Defined.
 
 Definition full_sub_precategory {C : precategory}
-         (C': hsubtypes (ob C)) :
+         (C': hsubtype (ob C)) :
    sub_precategories C :=
   tpair _  (dirprodpair C' (fun a b f => htrue)) (is_sub_precategory_full C C').
 
@@ -93,14 +93,14 @@ Definition full_sub_precategory {C : precategory}
 
 Definition sub_precategory_predicate_objects {C : precategory}
      (C': sub_precategories C):
-       hsubtypes (ob C) := pr1 (pr1 C').
+       hsubtype (ob C) := pr1 (pr1 C').
 
 Definition sub_ob {C : precategory}(C': sub_precategories C): UU :=
      (*carrier*) (sub_precategory_predicate_objects C').
 
 
 Definition sub_precategory_predicate_morphisms {C : precategory}
-        (C':sub_precategories C) (a b : C) : hsubtypes (a --> b) := pr2 (pr1 C') a b.
+        (C':sub_precategories C) (a b : C) : hsubtype (a --> b) := pr2 (pr1 C') a b.
 
 Definition sub_precategory_morphisms {C : precategory}(C':sub_precategories C)
       (a b : C) : UU :=  sub_precategory_predicate_morphisms C' a b.
@@ -324,19 +324,19 @@ Definition functor_full_img {C D: precategory}
 (** does of course not need the category hypothesis *)
 
 Definition hom_in_subcat_from_hom_in_precat (C : precategory)
- (C' : hsubtypes (ob C))
+ (C' : hsubtype (ob C))
   (a b : ob (full_sub_precategory C'))
       (f : pr1 a --> pr1 b) : a --> b :=
        tpair _ f tt.
 
 Definition hom_in_precat_from_hom_in_full_subcat (C : precategory)
- (C' : hsubtypes (ob C))
+ (C' : hsubtype (ob C))
   (a b : ob (full_sub_precategory C')) :
      a --> b -> pr1 a --> pr1 b := @pr1 _ _ .
 
 
 Lemma isweq_hom_in_precat_from_hom_in_full_subcat (C : precategory)
- (C' : hsubtypes (ob C))
+ (C' : hsubtype (ob C))
     (a b : ob (full_sub_precategory C')):
  isweq (hom_in_precat_from_hom_in_full_subcat _ _ a b).
 Proof.
@@ -350,7 +350,7 @@ Proof.
 Defined.
 
 Lemma isweq_hom_in_subcat_from_hom_in_precat (C : precategory)
- (C' : hsubtypes (ob C))
+ (C' : hsubtype (ob C))
     (a b : ob (full_sub_precategory C')):
  isweq (hom_in_subcat_from_hom_in_precat  _ _ a b).
 Proof.
@@ -365,7 +365,7 @@ Proof.
 Defined.
 
 Definition weq_hom_in_subcat_from_hom_in_precat (C : precategory)
-     (C' : hsubtypes (ob C))
+     (C' : hsubtype (ob C))
     (a b : ob (full_sub_precategory C')): weq (pr1 a --> pr1 b) (a-->b) :=
   tpair _ _ (isweq_hom_in_subcat_from_hom_in_precat C C' a b).
 
@@ -473,7 +473,7 @@ Section full_sub_cat.
 Variable C : precategory.
 Hypothesis H : is_category C.
 
-Variable C' : hsubtypes (ob C).
+Variable C' : hsubtype (ob C).
 
 
 (** *** Isos in the full subcategory are equivalent to isos in the precategory *)

--- a/UniMath/Foundations/Sets.v
+++ b/UniMath/Foundations/Sets.v
@@ -291,32 +291,32 @@ Defined.
 
 (** *** General definitions *)
 
-Definition hsubtypes (X : UU) : UU := X -> hProp.
-Identity Coercion id_hsubtypes :  hsubtypes >-> Funclass.
-Definition carrier {X : UU} (A : hsubtypes X) := total2 A.
-Coercion carrier : hsubtypes >-> Sortclass.
-Definition carrierpair {X : UU} (A : hsubtypes X) :
+Definition hsubtype (X : UU) : UU := X -> hProp.
+Identity Coercion id_hsubtype :  hsubtype >-> Funclass.
+Definition carrier {X : UU} (A : hsubtype X) := total2 A.
+Coercion carrier : hsubtype >-> Sortclass.
+Definition carrierpair {X : UU} (A : hsubtype X) :
    Π t : X, A t → Σ x : X, A x := tpair A.
-Definition pr1carrier {X : UU} (A : hsubtypes X) := @pr1 _ _  : carrier A -> X.
+Definition pr1carrier {X : UU} (A : hsubtype X) := @pr1 _ _  : carrier A -> X.
 
-Lemma isinclpr1carrier {X : UU} (A : hsubtypes X) : isincl (@pr1carrier X A).
+Lemma isinclpr1carrier {X : UU} (A : hsubtype X) : isincl (@pr1carrier X A).
 Proof. intros. apply (isinclpr1 A (fun x : _ => pr2 (A x))). Defined.
 
-Lemma isasethsubtypes (X : UU) : isaset (hsubtypes X).
+Lemma isasethsubtype (X : UU) : isaset (hsubtype X).
 Proof.
   intro X.
-  change (isofhlevel 2 (hsubtypes X)).
+  change (isofhlevel 2 (hsubtype X)).
   apply impred; intro x.
   exact isasethProp.
 Defined.
 
-Definition totalsubtype (X : UU) : hsubtypes X := fun x => htrue.
+Definition totalsubtype (X : UU) : hsubtype X := fun x => htrue.
 
 Definition weqtotalsubtype (X : UU) : totalsubtype X ≃ X.
 Proof. intro. apply weqpr1. intro. apply iscontrunit. Defined.
 
 Definition weq_subtypes {X Y : UU} (w : X ≃ Y)
-           (S : hsubtypes X) (T : hsubtypes Y) :
+           (S : hsubtype X) (T : hsubtype Y) :
            (Π x, S x <-> T (w x)) -> carrier S ≃ carrier T.
 Proof.
   intros ? ? ? ? ? eq. apply (weqbandf w). intro x. apply weqiff.
@@ -325,18 +325,18 @@ Proof.
   - apply propproperty.
 Defined.
 
-Definition DecidableSubtype_to_hsubtypes {X : UU} (P : DecidableSubtype X) :
-  hsubtypes X
+Definition DecidableSubtype_to_hsubtype {X : UU} (P : DecidableSubtype X) :
+  hsubtype X
   := λ x, DecidableProposition_to_hProp (P x).
-Coercion DecidableSubtype_to_hsubtypes : DecidableSubtype >-> hsubtypes.
+Coercion DecidableSubtype_to_hsubtype : DecidableSubtype >-> hsubtype.
 
 (** *** Direct product of two subtypes *)
 
-Definition subtypesdirprod {X Y : UU} (A : hsubtypes X) (B : hsubtypes Y) :
-  hsubtypes (dirprod X Y) := fun xy : _ => hconj (A (pr1 xy)) (B (pr2 xy)).
+Definition subtypesdirprod {X Y : UU} (A : hsubtype X) (B : hsubtype Y) :
+  hsubtype (dirprod X Y) := fun xy : _ => hconj (A (pr1 xy)) (B (pr2 xy)).
 
 Definition fromdsubtypesdirprodcarrier {X Y : UU}
-           (A : hsubtypes X) (B : hsubtypes Y)
+           (A : hsubtype X) (B : hsubtype Y)
            (xyis : subtypesdirprod A B) : dirprod A B.
 Proof.
   intros.
@@ -347,7 +347,7 @@ Proof.
 Defined.
 
 Definition tosubtypesdirprodcarrier {X Y : UU}
-           (A : hsubtypes X) (B : hsubtypes Y)
+           (A : hsubtype X) (B : hsubtype Y)
            (xisyis : dirprod A B) : subtypesdirprod A B.
 Proof.
   intros.
@@ -358,7 +358,7 @@ Proof.
   apply (tpair (subtypesdirprod A B) (dirprodpair x y) (dirprodpair isx isy)).
 Defined.
 
-Lemma weqsubtypesdirprod {X Y : UU} (A : hsubtypes X) (B : hsubtypes Y) :
+Lemma weqsubtypesdirprod {X Y : UU} (A : hsubtype X) (B : hsubtype Y) :
   subtypesdirprod A B ≃ A × B.
 Proof.
   intros.
@@ -384,7 +384,7 @@ Proof.
   apply (gradth _ _ egf efg).
 Defined.
 
-Lemma ishinhsubtypesdirprod  {X Y : UU} (A : hsubtypes X) (B : hsubtypes Y)
+Lemma ishinhsubtypedirprod  {X Y : UU} (A : hsubtype X) (B : hsubtype Y)
       (isa : ishinh A) (isb : ishinh B) : ishinh (subtypesdirprod A B).
 Proof.
   intros.
@@ -397,7 +397,7 @@ Defined.
 (** *** A subtype with paths between any two elements is an [hProp]. *)
 
 
-Lemma isapropsubtype {X : UU} (A : hsubtypes X)
+Lemma isapropsubtype {X : UU} (A : hsubtype X)
       (is : Π (x1 x2 : X), A x1 -> A x2 -> x1 = x2) : isaprop (carrier A).
 Proof.
   intros. apply invproofirrelevance.
@@ -1206,25 +1206,25 @@ Ltac confirm_equal_absurd i := match goal with |- ?x = ?y → ∅ => confirm_no 
 
 (** *** Restriction of a relation to a subtype *)
 
-Definition resrel {X : UU} (L : hrel X) (P : hsubtypes X) : hrel P
+Definition resrel {X : UU} (L : hrel X) (P : hsubtype X) : hrel P
   := fun p1 p2 => L (pr1 p1) (pr1 p2).
 
-Definition istransresrel {X : UU} (L : hrel X) (P : hsubtypes X)
+Definition istransresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : istrans L) : istrans (resrel L P).
 Proof.
   intros. intros x1 x2 x3 r12 r23.
   apply (isl _ (pr1 x2) _ r12 r23).
 Defined.
 
-Definition isreflresrel {X : UU} (L : hrel X) (P : hsubtypes X)
+Definition isreflresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : isrefl L) : isrefl (resrel L P).
 Proof. intros. intro x. apply isl. Defined.
 
-Definition issymmresrel {X : UU} (L : hrel X) (P : hsubtypes X)
+Definition issymmresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : issymm L) : issymm (resrel L P).
 Proof. intros. intros x1 x2 r12. apply isl. apply r12. Defined.
 
-Definition isporesrel {X : UU} (L : hrel X) (P : hsubtypes X)
+Definition isporesrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : ispreorder L) : ispreorder (resrel L P).
 Proof.
   intros.
@@ -1232,56 +1232,56 @@ Proof.
                      (isreflresrel L P (pr2 isl))).
 Defined.
 
-Definition iseqrelresrel {X : UU} (L : hrel X) (P : hsubtypes X)
+Definition iseqrelresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : iseqrel L) : iseqrel (resrel L P).
 Proof.
   intros.
   apply (dirprodpair (isporesrel L P (pr1 isl)) (issymmresrel L P (pr2 isl))).
 Defined.
 
-Definition isirreflresrel {X : UU} (L : hrel X) (P : hsubtypes X)
+Definition isirreflresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : isirrefl L) : isirrefl (resrel L P).
 Proof. intros. intros x r. apply (isl _ r). Defined.
 
-Definition isasymmresrel {X : UU} (L : hrel X) (P : hsubtypes X)
+Definition isasymmresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : isasymm L) : isasymm (resrel L P).
 Proof. intros. intros x1 x2 r12 r21. apply (isl _ _ r12 r21). Defined.
 
-Definition iscoasymmresrel {X : UU} (L : hrel X) (P : hsubtypes X)
+Definition iscoasymmresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : iscoasymm L) : iscoasymm (resrel L P).
 Proof. intros. intros x1 x2 r12. apply (isl _ _ r12). Defined.
 
-Definition istotalresrel {X : UU} (L : hrel X) (P : hsubtypes X)
+Definition istotalresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : istotal L) : istotal (resrel L P).
 Proof. intros. intros x1 x2. apply isl. Defined.
 
-Definition iscotransresrel {X : UU} (L : hrel X) (P : hsubtypes X)
+Definition iscotransresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : iscotrans L) : iscotrans (resrel L P).
 Proof. intros. intros x1 x2 x3 r13. apply (isl _ _ _ r13). Defined.
 
-Definition isdecrelresrel {X : UU} (L : hrel X) (P : hsubtypes X)
+Definition isdecrelresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : isdecrel L) : isdecrel (resrel L P).
 Proof. intros. intros x1 x2. apply isl. Defined.
 
-Definition isnegrelresrel {X : UU} (L : hrel X) (P : hsubtypes X)
+Definition isnegrelresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : isnegrel L) : isnegrel (resrel L P).
 Proof. intros. intros x1 x2 nnr. apply (isl _ _ nnr). Defined.
 
-Definition isantisymmresrel {X : UU} (L : hrel X) (P : hsubtypes X)
+Definition isantisymmresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : isantisymm L) : isantisymm (resrel L P).
 Proof.
   intros. intros x1 x2 r12 r21.
   apply (invmaponpathsincl _ (isinclpr1carrier _) _ _ (isl _ _ r12 r21)).
 Defined.
 
-Definition isantisymmnegresrel {X : UU} (L : hrel X) (P : hsubtypes X)
+Definition isantisymmnegresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : isantisymmneg L) : isantisymmneg (resrel L P).
 Proof.
   intros. intros x1 x2 nr12 nr21.
   apply (invmaponpathsincl _ (isinclpr1carrier _) _ _ (isl _ _ nr12 nr21)).
 Defined.
 
-Definition iscoantisymmresrel {X : UU} (L : hrel X) (P : hsubtypes X)
+Definition iscoantisymmresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : iscoantisymm L) : iscoantisymm (resrel L P).
 Proof.
   intros. intros x1 x2 r12. destruct (isl _ _ r12) as [ l | e ].
@@ -1289,7 +1289,7 @@ Proof.
   - apply ii2. apply (invmaponpathsincl _ (isinclpr1carrier _) _ _ e).
 Defined.
 
-Definition  neqchoiceresrel {X : UU} (L : hrel X) (P : hsubtypes X)
+Definition  neqchoiceresrel {X : UU} (L : hrel X) (P : hsubtype X)
             (isl : neqchoice L) : neqchoice (resrel L P).
 Proof.
   intros. intros x1 x2 ne.
@@ -1303,26 +1303,26 @@ Defined.
 
 
 
-Definition iseqclass {X : UU} (R : hrel X) (A : hsubtypes X) : UU
+Definition iseqclass {X : UU} (R : hrel X) (A : hsubtype X) : UU
   := dirprod (ishinh (carrier A))
              (dirprod (Π x1 x2 : X, R x1 x2 -> A x1 -> A x2)
                       (Π x1 x2 : X, A x1 ->  A x2 -> R x1 x2)).
-Definition iseqclassconstr {X : UU} (R : hrel X) {A : hsubtypes X}
+Definition iseqclassconstr {X : UU} (R : hrel X) {A : hsubtype X}
            (ax0 : ishinh (carrier A))
            (ax1 : Π x1 x2 : X, R x1 x2 -> A x1 -> A x2)
            (ax2 : Π x1 x2 : X, A x1 ->  A x2 -> R x1 x2) : iseqclass R A
   := dirprodpair ax0 (dirprodpair ax1 ax2).
 
-Definition eqax0 {X : UU} {R : hrel X} {A : hsubtypes X} :
+Definition eqax0 {X : UU} {R : hrel X} {A : hsubtype X} :
   iseqclass R A -> ishinh (carrier A) := fun is : iseqclass R A => pr1 is.
-Definition eqax1 {X : UU} {R : hrel X} {A : hsubtypes X} :
+Definition eqax1 {X : UU} {R : hrel X} {A : hsubtype X} :
   iseqclass R A -> Π x1 x2 : X, R x1 x2 -> A x1 -> A x2
   := fun is : iseqclass R A => pr1 (pr2 is).
-Definition eqax2 {X : UU} {R : hrel X} {A : hsubtypes X} :
+Definition eqax2 {X : UU} {R : hrel X} {A : hsubtype X} :
   iseqclass R A -> Π x1 x2 : X, A x1 -> A x2 -> R x1 x2
   := fun is : iseqclass R A => pr2 (pr2 is).
 
-Lemma isapropiseqclass {X : UU} (R : hrel X) (A : hsubtypes X) :
+Lemma isapropiseqclass {X : UU} (R : hrel X) (A : hsubtype X) :
   isaprop (iseqclass R A).
 Proof.
 intros X R A.
@@ -1339,7 +1339,7 @@ Defined.
 (** *** Direct product of equivalence classes *)
 
 Lemma iseqclassdirprod {X Y : UU} {R : hrel X} {Q : hrel Y}
-      {A : hsubtypes X} {B : hsubtypes Y}
+      {A : hsubtype X} {B : hsubtype Y}
       (isa : iseqclass R A) (isb : iseqclass Q B) :
   iseqclass (hreldirprod R Q) (subtypesdirprod A B).
 Proof.
@@ -1347,7 +1347,7 @@ Proof.
   set (XY := dirprod X Y).
   set (AB := subtypesdirprod A B).
   set (RQ := hreldirprod R Q).
-  set (ax0 := ishinhsubtypesdirprod A B (eqax0 isa) (eqax0 isb)).
+  set (ax0 := ishinhsubtypedirprod A B (eqax0 isa) (eqax0 isb)).
   assert (ax1 : Π xy1 xy2 : XY, RQ xy1 xy2 -> AB xy1 -> AB xy2).
   {
     intros xy1 xy2 rq ab1.
@@ -1560,11 +1560,11 @@ be considered in the section about types of h-level 3.
 
 Definition setquot {X : UU} (R : hrel X) : UU
   := total2 (fun A : _ => iseqclass R A).
-Definition setquotpair {X : UU} (R : hrel X) (A : hsubtypes X)
+Definition setquotpair {X : UU} (R : hrel X) (A : hsubtype X)
            (is : iseqclass R A) : setquot R := tpair _ A is.
-Definition pr1setquot {X : UU} (R : hrel X) : setquot R -> (hsubtypes X)
+Definition pr1setquot {X : UU} (R : hrel X) : setquot R -> (hsubtype X)
   := @pr1 _ (fun A : _ => iseqclass R A).
-Coercion pr1setquot : setquot >-> hsubtypes.
+Coercion pr1setquot : setquot >-> hsubtype.
 
 Lemma isinclpr1setquot {X : UU} (R : hrel X) : isincl (pr1setquot R).
 Proof.
@@ -1578,7 +1578,7 @@ Coercion setquottouu0 : setquot >-> Sortclass.
 Theorem isasetsetquot {X : UU} (R : hrel X) : isaset (setquot R).
 Proof.
   intros X R.
-  apply (isasetsubset (@pr1 _ _) (isasethsubtypes X)).
+  apply (isasetsubset (@pr1 _ _) (isasethsubtype X)).
   apply isinclpr1; intro x.
   now apply isapropiseqclass.
 Defined.
@@ -2474,10 +2474,10 @@ Definition decquotrel {X : UU} {R : eqrel X} (L : decrel X)
 (** *** Subtypes of quotients and quotients of subtypes *)
 
 
-Definition reseqrel {X : UU} (R : eqrel X) (P : hsubtypes X) : eqrel P :=
+Definition reseqrel {X : UU} (R : eqrel X) (P : hsubtype X) : eqrel P :=
   eqrelpair _ (iseqrelresrel R P (pr2 R)).
 
-Lemma iseqclassresrel {X : UU} (R : hrel X) (P Q : hsubtypes X)
+Lemma iseqclassresrel {X : UU} (R : hrel X) (P Q : hsubtype X)
       (is : iseqclass R Q) (is' : Π x, Q x -> P x) :
   iseqclass (resrel R P) (fun x : P => Q (pr1 x)).
 Proof.
@@ -2490,7 +2490,7 @@ Proof.
     + intros p1 p2 q1 q2. apply ((pr2 (pr2 is)) _ _ q1 q2).
 Defined.
 
-Definition fromsubquot {X : UU} (R : eqrel X) (P : hsubtypes (setquot R))
+Definition fromsubquot {X : UU} (R : eqrel X) (P : hsubtype (setquot R))
            (p : P) : setquot (resrel R (funcomp (setquotpr R) P)).
 Proof.
   intros.
@@ -2500,7 +2500,7 @@ Proof.
   simpl in e. unfold funcomp. rewrite e. apply (pr2 p).
 Defined.
 
-Definition tosubquot {X : UU} (R : eqrel X) (P : hsubtypes (setquot R)) :
+Definition tosubquot {X : UU} (R : eqrel X) (P : hsubtype (setquot R)) :
   setquot (resrel R (funcomp (setquotpr R) P)) -> P.
 Proof.
   intros X R P.
@@ -2518,7 +2518,7 @@ Proof.
   simpl. apply (iscompsetquotpr). apply rp12.
 Defined.
 
-Definition weqsubquot {X : UU} (R : eqrel X) (P : hsubtypes (setquot R)) :
+Definition weqsubquot {X : UU} (R : eqrel X) (P : hsubtype (setquot R)) :
   weq P (setquot (resrel R (funcomp (setquotpr R) P))).
 Proof.
   intros.
@@ -2571,7 +2571,7 @@ Defined.
 (** Comment: unfortunetely [weqsubquot] is not as useful as it should be at
   moment due to the failure of the following code to work:
 
-  [Lemma test (X : UU) (R : eqrel X) (P : hsubtypes (setquot R)) (x : X)
+  [Lemma test (X : UU) (R : eqrel X) (P : hsubtype (setquot R)) (x : X)
    (is : P (setquotpr R x)) :
      paths (setquotpr (reseqrel R (funcomp (setquotpr R) P)) (tpair _ x is))
            (fromsubquot R P (tpair _ (setquotpr R x) is)).

--- a/UniMath/HomologicalAlgebra/Complexes.v
+++ b/UniMath/HomologicalAlgebra/Complexes.v
@@ -2164,7 +2164,7 @@ Section complexes_homotopies.
       which have a path to a morphism induced by a homotopy H by [ComplexHomotMorphism]. Our goal is
       to show that this subset is an abelian subgroup, and thus we can form the quotient group. *)
   Definition ComplexHomotSubset (C1 C2 : Complex A) :
-    @hsubtypes ((ComplexPreCat_Additive A)⟦C1, C2⟧) :=
+    @hsubtype ((ComplexPreCat_Additive A)⟦C1, C2⟧) :=
     (fun (f : ((ComplexPreCat_Additive A)⟦C1, C2⟧)) =>
        ∃ (H : ComplexHomot C1 C2), ComplexHomotMorphism H = f).
 
@@ -2286,7 +2286,7 @@ Section complexes_homotopies.
   Qed.
 
   Definition ComplexHomotSubgrp (C1 C2 : Complex A) :
-    @subabgrs (@to_abgrop (ComplexPreCat_Additive A) C1 C2).
+    @subabgr (@to_abgrop (ComplexPreCat_Additive A) C1 C2).
   Proof.
     use subgrconstr.
     - exact (ComplexHomotSubset C1 C2).

--- a/UniMath/NumberSystems/NaturalNumbersAlgebra.v
+++ b/UniMath/NumberSystems/NaturalNumbersAlgebra.v
@@ -21,7 +21,7 @@ Definition natmultabmonoid : abmonoid :=
 
 (** *** Submonoid of non-zero elements in [nat] *)
 
-Definition natnonzero : @subabmonoids natmultabmonoid.
+Definition natnonzero : @subabmonoid natmultabmonoid.
 Proof.
   split with (λ a, a ≠ 0). unfold issubmonoid. split.
   - unfold issubsetwithbinop. intros a a'.

--- a/UniMath/NumberSystems/RationalNumbers.v
+++ b/UniMath/NumberSystems/RationalNumbers.v
@@ -663,7 +663,7 @@ Proof . intros . apply ( intdomrcan hq _ _ _ ne e ) . Defined .
 
 (** *** Positive rationals *)
 
-Definition hqpos : @subabmonoids hqmultabmonoid .
+Definition hqpos : @subabmonoid hqmultabmonoid .
 Proof . split with ( fun x => hqgth x 0 ) . split .  intros x1 x2 . apply ( isrngmulthqgth ) . apply ( pr2 x1 ) .  apply ( pr2 x2 ) .  apply ( ct ( hqgth , isdecrelhqgth , 1 , 0 ) ) . Defined .
 
 

--- a/UniMath/RealNumbers/DecidableDedekindCuts.v
+++ b/UniMath/RealNumbers/DecidableDedekindCuts.v
@@ -20,7 +20,7 @@ Proof.
   intros r.
   apply pr2.
 Qed.
-Definition isboolDcuts : hsubtypes Dcuts :=
+Definition isboolDcuts : hsubtype Dcuts :=
   (fun x : Dcuts => hProppair _ (isboolDcuts_isaprop x)).
 
 Lemma isaset_boolDcuts : isaset isboolDcuts.

--- a/UniMath/RealNumbers/NonnegativeReals.v
+++ b/UniMath/RealNumbers/NonnegativeReals.v
@@ -13,18 +13,18 @@ Local Open Scope tap_scope.
 
 (** ** Definition of Dedekind cuts *)
 
-Definition Dcuts_def_bot (X : hsubtypes NonnegativeRationals) : UU :=
+Definition Dcuts_def_bot (X : hsubtype NonnegativeRationals) : UU :=
   Π x : NonnegativeRationals,
         X x -> Π y : NonnegativeRationals, y <= x -> X y.
-Definition Dcuts_def_open (X : hsubtypes NonnegativeRationals) : UU :=
+Definition Dcuts_def_open (X : hsubtype NonnegativeRationals) : UU :=
   Π x : NonnegativeRationals,
         X x -> ∃ y : NonnegativeRationals, (X y) × (x < y).
-Definition Dcuts_def_finite (X : hsubtypes NonnegativeRationals) : hProp :=
+Definition Dcuts_def_finite (X : hsubtype NonnegativeRationals) : hProp :=
   ∃ ub : NonnegativeRationals, ¬ (X ub).
-Definition Dcuts_def_corr (X : hsubtypes NonnegativeRationals) : UU :=
+Definition Dcuts_def_corr (X : hsubtype NonnegativeRationals) : UU :=
   Π r : NonnegativeRationals, 0 < r -> (¬ (X r)) ∨ Σ q : NonnegativeRationals, (X q) × (¬ (X (q + r))).
 
-Lemma Dcuts_def_corr_finite (X : hsubtypes NonnegativeRationals) :
+Lemma Dcuts_def_corr_finite (X : hsubtype NonnegativeRationals) :
   Dcuts_def_corr X → Dcuts_def_finite X.
 Proof.
   intros X Hx.
@@ -35,7 +35,7 @@ Proof.
   - apply hinhpr ; exists (pr1 x + 1) ; exact (pr2 (pr2 x)).
 Qed.
 
-Lemma Dcuts_def_corr_not_empty (X : hsubtypes NonnegativeRationals) :
+Lemma Dcuts_def_corr_not_empty (X : hsubtype NonnegativeRationals) :
   X 0 -> Dcuts_def_corr X ->
   Π c : NonnegativeRationals,
     (0 < c)%NRat -> ∃ x : NonnegativeRationals, X x × ¬ X (x + c).
@@ -50,26 +50,26 @@ Proof.
   - apply hinhpr ; exact Hx'.
 Qed.
 
-Lemma isaprop_Dcuts_def_bot (X : hsubtypes NonnegativeRationals) : isaprop (Dcuts_def_bot X).
+Lemma isaprop_Dcuts_def_bot (X : hsubtype NonnegativeRationals) : isaprop (Dcuts_def_bot X).
 Proof.
   intros X.
   repeat (apply impred_isaprop ; intro).
   now apply pr2.
 Qed.
-Lemma isaprop_Dcuts_def_open (X : hsubtypes NonnegativeRationals) : isaprop (Dcuts_def_open X).
+Lemma isaprop_Dcuts_def_open (X : hsubtype NonnegativeRationals) : isaprop (Dcuts_def_open X).
 Proof.
   intros X.
   repeat (apply impred_isaprop ; intro).
   now apply pr2.
 Qed.
-Lemma isaprop_Dcuts_def_corr (X : hsubtypes NonnegativeRationals) : isaprop (Dcuts_def_corr X).
+Lemma isaprop_Dcuts_def_corr (X : hsubtype NonnegativeRationals) : isaprop (Dcuts_def_corr X).
 Proof.
   intros X.
   repeat (apply impred_isaprop ; intro).
   now apply pr2.
 Qed.
 
-Lemma isaprop_Dcuts_hsubtypes (X : hsubtypes NonnegativeRationals) :
+Lemma isaprop_Dcuts_hsubtype (X : hsubtype NonnegativeRationals) :
   isaprop (Dcuts_def_bot X × Dcuts_def_open X × Dcuts_def_corr X).
 Proof.
   intro X.
@@ -79,18 +79,18 @@ Proof.
   - exact (isaprop_Dcuts_def_corr X).
 Qed.
 
-Definition Dcuts_hsubtypes : hsubtypes (hsubtypes NonnegativeRationals) :=
-  fun X : hsubtypes NonnegativeRationals => hProppair _ (isaprop_Dcuts_hsubtypes X).
-Lemma isaset_Dcuts : isaset (carrier Dcuts_hsubtypes).
+Definition Dcuts_hsubtype : hsubtype (hsubtype NonnegativeRationals) :=
+  fun X : hsubtype NonnegativeRationals => hProppair _ (isaprop_Dcuts_hsubtype X).
+Lemma isaset_Dcuts : isaset (carrier Dcuts_hsubtype).
 Proof.
   apply isasetsubset with pr1.
-  apply isasethsubtypes.
+  apply isasethsubtype.
   apply isinclpr1.
   intro x.
   apply pr2.
 Qed.
 Definition Dcuts_set : hSet := hSetpair _ isaset_Dcuts.
-Definition pr1Dcuts (x : Dcuts_set) : hsubtypes NonnegativeRationals := pr1 x.
+Definition pr1Dcuts (x : Dcuts_set) : hsubtype NonnegativeRationals := pr1 x.
 Notation "x ∈ X" := (pr1Dcuts X x) (at level 70, no associativity) : DC_scope.
 
 Open Scope DC_scope.
@@ -713,16 +713,16 @@ Qed.
 
 Section Dcuts_plus.
 
-  Context (X : hsubtypes NonnegativeRationals).
+  Context (X : hsubtype NonnegativeRationals).
   Context (X_bot : Dcuts_def_bot X).
   Context (X_open : Dcuts_def_open X).
   Context (X_corr : Dcuts_def_corr X).
-  Context (Y : hsubtypes NonnegativeRationals).
+  Context (Y : hsubtype NonnegativeRationals).
   Context (Y_bot : Dcuts_def_bot Y).
   Context (Y_open : Dcuts_def_open Y).
   Context (Y_corr : Dcuts_def_corr Y).
 
-Definition Dcuts_plus_val : hsubtypes NonnegativeRationals :=
+Definition Dcuts_plus_val : hsubtype NonnegativeRationals :=
   λ r : NonnegativeRationals,
         ((X r) ⨿ (Y r)) ∨
         (Σ xy : NonnegativeRationals × NonnegativeRationals, (r = (pr1 xy + pr2 xy)%NRat) × ((X (pr1 xy)) × (Y (pr2 xy)))).
@@ -968,13 +968,13 @@ Section Dcuts_NQmult.
 
   Context (x : NonnegativeRationals).
   Context (Hx : (0 < x)%NRat).
-  Context (Y : hsubtypes NonnegativeRationals).
+  Context (Y : hsubtype NonnegativeRationals).
   Context (Y_bot : Dcuts_def_bot Y).
   Context (Y_open : Dcuts_def_open Y).
   Context (Y_finite : Dcuts_def_finite Y).
   Context (Y_corr : Dcuts_def_corr Y).
 
-Definition Dcuts_NQmult_val : hsubtypes NonnegativeRationals :=
+Definition Dcuts_NQmult_val : hsubtype NonnegativeRationals :=
   fun r => ∃ ry : NonnegativeRationals, r = x * ry × Y ry.
 
 Lemma Dcuts_NQmult_bot : Dcuts_def_bot Dcuts_NQmult_val.
@@ -1100,18 +1100,18 @@ Definition Dcuts_NQmult x (Y : Dcuts) Hx : Dcuts :=
 
 Section Dcuts_mult.
 
-  Context (X : hsubtypes NonnegativeRationals).
+  Context (X : hsubtype NonnegativeRationals).
   Context (X_bot : Dcuts_def_bot X).
   Context (X_open : Dcuts_def_open X).
   Context (X_finite : Dcuts_def_finite X).
   Context (X_corr : Dcuts_def_corr X).
-  Context (Y : hsubtypes NonnegativeRationals).
+  Context (Y : hsubtype NonnegativeRationals).
   Context (Y_bot : Dcuts_def_bot Y).
   Context (Y_open : Dcuts_def_open Y).
   Context (Y_finite : Dcuts_def_finite Y).
   Context (Y_corr : Dcuts_def_corr Y).
 
-Definition Dcuts_mult_val : hsubtypes NonnegativeRationals :=
+Definition Dcuts_mult_val : hsubtype NonnegativeRationals :=
   fun r => ∃ xy : NonnegativeRationals * NonnegativeRationals,
                            r = (fst xy * snd xy)%NRat × X (fst xy) × Y (snd xy).
 
@@ -1277,12 +1277,12 @@ End Dcuts_mult.
 
 Section Dcuts_mult'.
 
-  Context (X : hsubtypes NonnegativeRationals).
+  Context (X : hsubtype NonnegativeRationals).
   Context (X_bot : Dcuts_def_bot X).
   Context (X_open : Dcuts_def_open X).
   Context (X_finite : Dcuts_def_finite X).
   Context (X_corr : Dcuts_def_corr X).
-  Context (Y : hsubtypes NonnegativeRationals).
+  Context (Y : hsubtype NonnegativeRationals).
   Context (Y_bot : Dcuts_def_bot Y).
   Context (Y_open : Dcuts_def_open Y).
   Context (Y_finite : Dcuts_def_finite Y).
@@ -1366,14 +1366,14 @@ Definition Dcuts_mult (X Y : Dcuts) : Dcuts :=
 
 Section Dcuts_inv.
 
-Context (X : hsubtypes NonnegativeRationals).
+Context (X : hsubtype NonnegativeRationals).
 Context (X_bot : Dcuts_def_bot X).
 Context (X_open : Dcuts_def_open X).
 Context (X_finite : Dcuts_def_finite X).
 Context (X_corr : Dcuts_def_corr X).
 Context (X_0 : X 0%NRat).
 
-Definition Dcuts_inv_val : hsubtypes NonnegativeRationals :=
+Definition Dcuts_inv_val : hsubtype NonnegativeRationals :=
   λ r : NonnegativeRationals,
         hexists (λ l : NonnegativeRationals, (Π rx : NonnegativeRationals, X rx -> (r * rx <= l)%NRat)
                                                × (0 < l)%NRat × (l < 1)%NRat).
@@ -1558,7 +1558,7 @@ End Dcuts_inv.
 
 Section Dcuts_inv'.
 
-Context (X : hsubtypes NonnegativeRationals).
+Context (X : hsubtype NonnegativeRationals).
 Context (X_bot : Dcuts_def_bot X).
 Context (X_open : Dcuts_def_open X).
 Context (X_finite : Dcuts_def_finite X).
@@ -2577,16 +2577,16 @@ Defined.
 
 Section Dcuts_minus.
 
-  Context (X : hsubtypes NonnegativeRationals).
+  Context (X : hsubtype NonnegativeRationals).
   Context (X_bot : Dcuts_def_bot X).
   Context (X_open : Dcuts_def_open X).
   Context (X_corr : Dcuts_def_corr X).
-  Context (Y : hsubtypes NonnegativeRationals).
+  Context (Y : hsubtype NonnegativeRationals).
   Context (Y_bot : Dcuts_def_bot Y).
   Context (Y_open : Dcuts_def_open Y).
   Context (Y_corr : Dcuts_def_corr Y).
 
-Definition Dcuts_minus_val : hsubtypes NonnegativeRationals :=
+Definition Dcuts_minus_val : hsubtype NonnegativeRationals :=
   fun r => ∃ x, X x × Π y, (Y y) ⨿ (y = 0%NRat) -> (r + y < x)%NRat.
 
 Lemma Dcuts_minus_bot : Dcuts_def_bot Dcuts_minus_val.
@@ -2917,18 +2917,18 @@ Qed.
 
 Section Dcuts_max.
 
-  Context (X : hsubtypes NonnegativeRationals).
+  Context (X : hsubtype NonnegativeRationals).
   Context (X_bot : Dcuts_def_bot X).
   Context (X_open : Dcuts_def_open X).
   Context (X_finite : Dcuts_def_finite X).
   Context (X_corr : Dcuts_def_corr X).
-  Context (Y : hsubtypes NonnegativeRationals).
+  Context (Y : hsubtype NonnegativeRationals).
   Context (Y_bot : Dcuts_def_bot Y).
   Context (Y_open : Dcuts_def_open Y).
   Context (Y_finite : Dcuts_def_finite Y).
   Context (Y_corr : Dcuts_def_corr Y).
 
-Definition Dcuts_max_val : hsubtypes NonnegativeRationals :=
+Definition Dcuts_max_val : hsubtype NonnegativeRationals :=
   λ r : NonnegativeRationals, X r ∨ Y r.
 
 Lemma Dcuts_max_bot : Dcuts_def_bot Dcuts_max_val.
@@ -3308,18 +3308,18 @@ Qed.
 
 Section Dcuts_min.
 
-  Context (X : hsubtypes NonnegativeRationals).
+  Context (X : hsubtype NonnegativeRationals).
   Context (X_bot : Dcuts_def_bot X).
   Context (X_open : Dcuts_def_open X).
   Context (X_finite : Dcuts_def_finite X).
   Context (X_corr : Dcuts_def_corr X).
-  Context (Y : hsubtypes NonnegativeRationals).
+  Context (Y : hsubtype NonnegativeRationals).
   Context (Y_bot : Dcuts_def_bot Y).
   Context (Y_open : Dcuts_def_open Y).
   Context (Y_finite : Dcuts_def_finite Y).
   Context (Y_corr : Dcuts_def_corr Y).
 
-Definition Dcuts_min_val : hsubtypes NonnegativeRationals :=
+Definition Dcuts_min_val : hsubtype NonnegativeRationals :=
   λ r : NonnegativeRationals, X r ∧ Y r.
 
 Lemma Dcuts_min_bot : Dcuts_def_bot Dcuts_min_val.
@@ -3503,12 +3503,12 @@ Qed.
 
 Section Dcuts_half.
 
-Context (X : hsubtypes NonnegativeRationals)
+Context (X : hsubtype NonnegativeRationals)
         (X_bot : Dcuts_def_bot X)
         (X_open : Dcuts_def_open X)
         (X_corr : Dcuts_def_corr X).
 
-Definition Dcuts_half_val : hsubtypes NonnegativeRationals :=
+Definition Dcuts_half_val : hsubtype NonnegativeRationals :=
   λ r, X (r + r).
 Lemma Dcuts_half_bot : Dcuts_def_bot Dcuts_half_val.
 Proof.
@@ -3700,7 +3700,7 @@ Qed.
 
 Section Dcuts_lim.
 
-Context (U : nat -> hsubtypes NonnegativeRationals)
+Context (U : nat -> hsubtype NonnegativeRationals)
         (U_bot : Π n : nat, Dcuts_def_bot (U n))
         (U_open : Π n : nat, Dcuts_def_open (U n))
         (U_corr : Π n : nat, Dcuts_def_corr (U n)).
@@ -3712,7 +3712,7 @@ Context (U_cauchy :
                      (λ N : nat,
                             Π n m : nat, N ≤ n -> N ≤ m -> (Π r, U n r -> Dcuts_plus_val (U m) (λ q, (q < eps)%NRat) r) × (Π r, U m r -> Dcuts_plus_val (U n) (λ q, (q < eps)%NRat) r))).
 
-Definition Dcuts_lim_cauchy_val : hsubtypes NonnegativeRationals :=
+Definition Dcuts_lim_cauchy_val : hsubtype NonnegativeRationals :=
 λ r : NonnegativeRationals, hexists (λ c : NonnegativeRationals, (0 < c)%NRat × Σ N : nat, Π n : nat, N ≤ n -> U n (r + c)).
 
 Lemma Dcuts_lim_cauchy_bot : Dcuts_def_bot Dcuts_lim_cauchy_val.
@@ -4136,7 +4136,7 @@ Qed.
 
 Section Dcuts_of_Dcuts.
 
-Context (E : hsubtypes Dcuts).
+Context (E : hsubtype Dcuts).
 Context (E_bot : Π x : Dcuts, E x -> Π y : Dcuts, y <= x -> E y).
 Context (E_open : Π x : Dcuts, E x -> ∃ y : Dcuts, x < y × E y).
 Context (E_corr: Π c : Dcuts, 0 < c -> (¬ E c) ∨ (hexists (λ P, E P × ¬ E (Dcuts_plus P c)))).
@@ -4288,17 +4288,17 @@ Qed.
 
 End Dcuts_of_Dcuts.
 
-Definition Dcuts_of_Dcuts (E : hsubtypes Dcuts) E_bot E_corr : Dcuts :=
+Definition Dcuts_of_Dcuts (E : hsubtype Dcuts) E_bot E_corr : Dcuts :=
   mk_Dcuts (Dcuts_of_Dcuts_val E) (Dcuts_of_Dcuts_bot E) (Dcuts_of_Dcuts_open E) (Dcuts_of_Dcuts_corr E E_bot E_corr).
 
 Section Dcuts_of_Dcuts'.
 
-Context (E : hsubtypes NonnegativeRationals).
+Context (E : hsubtype NonnegativeRationals).
 Context (E_bot : Dcuts_def_bot E).
 Context (E_open : Dcuts_def_open E).
 Context (E_corr : Dcuts_def_corr E).
 
-Definition Dcuts_of_Dcuts'_val : hsubtypes Dcuts :=
+Definition Dcuts_of_Dcuts'_val : hsubtype Dcuts :=
   λ x : Dcuts, ∃ r : NonnegativeRationals, (¬ (r ∈ x)) × E r.
 
 Lemma Dcuts_of_Dcuts'_bot :
@@ -4442,7 +4442,7 @@ Proof.
       exact (pr2 (pr2 q)).
 Qed.
 Lemma Dcuts_of_Dcuts_bij' :
-  Π E : hsubtypes Dcuts, Π (E_bot : Π x : Dcuts, E x -> Π y : Dcuts, y <= x -> E y) (E_open : Π x : Dcuts, E x -> ∃ y : Dcuts, x < y × E y),
+  Π E : hsubtype Dcuts, Π (E_bot : Π x : Dcuts, E x -> Π y : Dcuts, y <= x -> E y) (E_open : Π x : Dcuts, E x -> ∃ y : Dcuts, x < y × E y),
     Dcuts_of_Dcuts'_val (Dcuts_of_Dcuts_val E) = E.
 Proof.
   intros.
@@ -4478,7 +4478,7 @@ Proof.
     apply (pr2 (pr2 r)).
 Qed.
 
-Lemma isub_Dcuts_of_Dcuts (E : hsubtypes Dcuts) E_bot E_corr :
+Lemma isub_Dcuts_of_Dcuts (E : hsubtype Dcuts) E_bot E_corr :
   isUpperBound (X := PreorderedSetEffectiveOrder eo_Dcuts) E (Dcuts_of_Dcuts E E_bot E_corr).
 Proof.
   intros ;
@@ -4486,7 +4486,7 @@ Proof.
   apply hinhpr.
   now exists x.
 Qed.
-Lemma islbub_Dcuts_of_Dcuts (E : hsubtypes Dcuts) E_bot E_corr :
+Lemma islbub_Dcuts_of_Dcuts (E : hsubtype Dcuts) E_bot E_corr :
   isSmallerThanUpperBounds (X := PreorderedSetEffectiveOrder eo_Dcuts) E (Dcuts_of_Dcuts E E_bot E_corr).
 Proof.
   intros.
@@ -4497,7 +4497,7 @@ Proof.
   intros H ; simple refine (H _ _).
   exact (pr2 (pr2 y)).
 Qed.
-Lemma islub_Dcuts_of_Dcuts (E : hsubtypes eo_Dcuts) E_bot E_corr :
+Lemma islub_Dcuts_of_Dcuts (E : hsubtype eo_Dcuts) E_bot E_corr :
   isLeastUpperBound (X := PreorderedSetEffectiveOrder eo_Dcuts) E (Dcuts_of_Dcuts E E_bot E_corr).
 Proof.
   split.
@@ -4576,9 +4576,9 @@ Definition divNonnegativeReals (x y : NonnegativeReals) (Hy0 : y ≠ 0) : Nonneg
 
 (** ** Special functions *)
 
-Definition NonnegativeReals_to_hsubtypesNonnegativeRationals :
-  NonnegativeReals → (hsubtypes NonnegativeRationals) := pr1.
-Definition hsubtypesNonnegativeRationals_to_NonnegativeReals
+Definition NonnegativeReals_to_hsubtypeNonnegativeRationals :
+  NonnegativeReals → (hsubtype NonnegativeRationals) := pr1.
+Definition hsubtypeNonnegativeRationals_to_NonnegativeReals
   (X : NonnegativeRationals -> hProp)
   (Xbot : Π x : NonnegativeRationals,
             X x -> Π y : NonnegativeRationals, (y <= x)%NRat -> X y)

--- a/UniMath/RealNumbers/Sets.v
+++ b/UniMath/RealNumbers/Sets.v
@@ -9,25 +9,25 @@ Require Import UniMath.Algebra.BinaryOperations
 
 (** ** Subsets *)
 
-Lemma isaset_hsubtypes {X : hSet} (Hsub : hsubtypes X) : isaset (carrier Hsub).
+Lemma isaset_hsubtype {X : hSet} (Hsub : hsubtype X) : isaset (carrier Hsub).
 Proof.
   intros X Hsub.
   apply (isasetsubset pr1 (pr2 X) (isinclpr1 (λ x : X, Hsub x) (λ x : X, pr2 (Hsub x)))).
 Qed.
-Definition subset {X : hSet} (Hsub : hsubtypes X) : hSet :=
-  hSetpair (carrier Hsub) (isaset_hsubtypes Hsub).
-Definition makeSubset {X : hSet} {Hsub : hsubtypes X} (x : X) (Hx : Hsub x) : subset Hsub :=
+Definition subset {X : hSet} (Hsub : hsubtype X) : hSet :=
+  hSetpair (carrier Hsub) (isaset_hsubtype Hsub).
+Definition makeSubset {X : hSet} {Hsub : hsubtype X} (x : X) (Hx : Hsub x) : subset Hsub :=
   x,, Hx.
 
 (** ** Additional definitions *)
 
 Definition unop (X : UU) := X → X.
 
-Definition islinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtypes X) (inv : subset exinv -> X) :=
+Definition islinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtype X) (inv : subset exinv -> X) :=
   Π (x : X) (Hx : exinv x), op (inv (x ,, Hx)) x = x1.
-Definition isrinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtypes X) (inv : subset exinv -> X) :=
+Definition isrinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtype X) (inv : subset exinv -> X) :=
   Π (x : X) (Hx : exinv x), op x (inv (x ,, Hx)) = x1.
-Definition isinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtypes X) (inv : subset exinv -> X)  :=
+Definition isinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtype X) (inv : subset exinv -> X)  :=
   islinv' x1 op exinv inv × isrinv' x1 op exinv inv.
 
 (** ** Properties of [po] *)
@@ -347,22 +347,22 @@ Section LeastUpperBound.
 Context {X : PreorderedSet}.
 Local Notation "x <= y" := (pr1 (pr2 X) x y).
 
-Definition isUpperBound (E : hsubtypes X) (ub : X) : UU :=
+Definition isUpperBound (E : hsubtype X) (ub : X) : UU :=
   Π x : X, E x -> x <= ub.
-Definition isSmallerThanUpperBounds (E : hsubtypes X) (lub : X) : UU :=
+Definition isSmallerThanUpperBounds (E : hsubtype X) (lub : X) : UU :=
   Π ub : X, isUpperBound E ub -> lub <= ub.
 
-Definition isLeastUpperBound (E : hsubtypes X) (lub : X) : UU :=
+Definition isLeastUpperBound (E : hsubtype X) (lub : X) : UU :=
   dirprod (isUpperBound E lub) (isSmallerThanUpperBounds E lub).
-Definition LeastUpperBound (E : hsubtypes X) : UU :=
+Definition LeastUpperBound (E : hsubtype X) : UU :=
   Σ lub : X, isLeastUpperBound E lub.
-Definition pairLeastUpperBound (E : hsubtypes X) (lub : X)
+Definition pairLeastUpperBound (E : hsubtype X) (lub : X)
            (is : isLeastUpperBound E lub) : LeastUpperBound E :=
   tpair (isLeastUpperBound E) lub is.
-Definition pr1LeastUpperBound {E : hsubtypes X} :
+Definition pr1LeastUpperBound {E : hsubtype X} :
   LeastUpperBound E → X := pr1.
 
-Lemma isapropLeastUpperBound (E : hsubtypes X) (H : isantisymm (λ x y : X, x <= y)) :
+Lemma isapropLeastUpperBound (E : hsubtype X) (H : isantisymm (λ x y : X, x <= y)) :
   isaprop (LeastUpperBound E).
 Proof.
   intros E H x y.
@@ -392,22 +392,22 @@ Section GreatestLowerBound.
 Context {X : PreorderedSet}.
 Local Notation "x >= y" := (pr1 (pr2 X) y x).
 
-Definition isLowerBound (E : hsubtypes X) (ub : X) : UU :=
+Definition isLowerBound (E : hsubtype X) (ub : X) : UU :=
   Π x : X, E x -> x >= ub.
-Definition isBiggerThanLowerBounds (E : hsubtypes X) (lub : X) : UU :=
+Definition isBiggerThanLowerBounds (E : hsubtype X) (lub : X) : UU :=
   Π ub : X, isLowerBound E ub -> lub >= ub.
 
-Definition isGreatestLowerBound (E : hsubtypes X) (glb : X) : UU :=
+Definition isGreatestLowerBound (E : hsubtype X) (glb : X) : UU :=
   dirprod (isLowerBound E glb) (isBiggerThanLowerBounds E glb).
-Definition GreatestLowerBound (E : hsubtypes X) : UU :=
+Definition GreatestLowerBound (E : hsubtype X) : UU :=
   Σ glb : X, isGreatestLowerBound E glb.
-Definition pairGreatestLowerBound (E : hsubtypes X) (glb : X)
+Definition pairGreatestLowerBound (E : hsubtype X) (glb : X)
            (is : isGreatestLowerBound E glb) : GreatestLowerBound E :=
   tpair (isGreatestLowerBound E) glb is.
-Definition pr1GreatestLowerBound {E : hsubtypes X} :
+Definition pr1GreatestLowerBound {E : hsubtype X} :
   GreatestLowerBound E → X := pr1.
 
-Lemma isapropGreatestLowerBound (E : hsubtypes X) (H : isantisymm (λ x y : X, x >= y)) :
+Lemma isapropGreatestLowerBound (E : hsubtype X) (H : isantisymm (λ x y : X, x >= y)) :
   isaprop (GreatestLowerBound E).
 Proof.
   intros E H x y.
@@ -433,7 +433,7 @@ Qed.
 End GreatestLowerBound.
 
 Definition isCompleteSpace (X : PreorderedSet) :=
-  Π E : hsubtypes X,
+  Π E : hsubtype X,
     hexists (isUpperBound E) -> hexists E -> LeastUpperBound E.
 Definition CompleteSpace  :=
   Σ X : PreorderedSet, isCompleteSpace X.


### PR DESCRIPTION
    subabmonoids -> subabmonoid
    submonoids -> submonoid
    hsubtypes -> hsubtype
    subgrs -> subgr
    subabgrs -> subabgr
    subrigs -> subrig
    subrngs -> subrng

Notice that for types that are not implemented as subtypes, the identifiers are
not plural, so there is an inconsistency.  These types include gr, monoid, rng,
hSet, hProp, rig, setwithbinop, and subset.