### PR TITLE
Summary: improve INSTALL (bash under MAC OS)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,12 +1,13 @@
 Installation of UniMath
 =======================
 
-Prepare for installation by installing the OCAML compiler on your system.
-Under Mac OS X, the most convenient way to do that is with "Homebrew",
-available from http://brew.sh/, with the following command:
+Prepare for installation by installing the OCAML compiler and a more modern
+version of `bash` on your system.  Under Mac OS X, the most convenient way to
+do that is with "Homebrew", available from http://brew.sh/, with the following
+command:
 
 ```bash
-$ brew install objective-caml camlp5 camlp4 lablgtk
+$ brew install objective-caml camlp5 camlp4 lablgtk bash
 ```
 
 Also install "ocamlfind" using "homebrew" with the following commands.

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ COQBIN ?=
 COQIDE_OPTION ?= no
 ifeq "$(BUILD_COQ)" "yes"
 COQBIN=sub/coq/bin/
+all: check-first
 all: build-coq
 build-coq: sub/coq/bin/coqc
 ifeq "$(BUILD_COQIDE)" "yes"
@@ -51,7 +52,6 @@ include build/CoqMakefile.make
 endif
 everything: TAGS all html install
 check-first: enforce-linear-ordering check-travis
-all: check-first
 OTHERFLAGS += $(MOREFLAGS)
 OTHERFLAGS += -indices-matter -type-in-type -w none
 ifeq ($(VERBOSE),yes)
@@ -219,31 +219,33 @@ SHELL = bash
 enforce-linear-ordering:
 	: --- $@ ---
 	@set -e ;\
-	declare -A seqnum ;\
-	n=0 ;\
-	for i in $(VOFILES) ;\
-	do n=$$(( $$n + 1 )) ;\
-	   seqnum[$$i]=$$n ;\
-	done ;\
-	for i in $(VFILES:.v=.v.d); \
-	do head -1 $$i ;\
-	done \
-	| sed -e 's/[^ ]*\.\(glob\|v\.beautified\|v\)\([ :]\|$$\)/\2/g' -e 's/ *: */ /' \
-	| while read line ;\
-	  do for i in $$line ; do echo $$i ; done \
-	     | ( read target ; \
-		 [ "$${seqnum[$$target]}" ] || (echo unknown target: $$target >&2 ; false) ;\
-	         while read prereq ; \
-		 do [ "$${seqnum[$$prereq]}" ] || (echo unknown prereq of $$target : $$prereq >&2 ; false) ;\
-		    echo "$$(($${seqnum[$$target]} > $${seqnum[$$prereq]})) error: *** $$target should not require $$prereq" ;\
-		 done ) ;\
-	  done | grep ^0 | sed 's/^0 //' | \
-	  ( haderror= ; \
-	    while read line ; \
-	    do if [ ! "$$haderror" ] ; then haderror=1 ; fi ; \
-	       echo "$$line" ;\
-	    done ;\
-	    [ ! "$$haderror" ] )
+	if declare -A seqnum 2>/dev/null ;\
+	then n=0 ;\
+	     for i in $(VOFILES) ;\
+	     do n=$$(( $$n + 1 )) ;\
+		seqnum[$$i]=$$n ;\
+	     done ;\
+	     for i in $(VFILES:.v=.v.d); \
+	     do head -1 $$i ;\
+	     done \
+	     | sed -E -e 's/[^ ]*\.(glob|v\.beautified|v)([ :]|$$)/\2/g' -e 's/ *: */ /' \
+	     | while read line ;\
+	       do for i in $$line ; do echo $$i ; done \
+		  | ( read target ; \
+		      [ "$${seqnum[$$target]}" ] || (echo unknown target: $$target; false) >&2 ;\
+		      while read prereq ; \
+		      do [ "$${seqnum[$$prereq]}" ] || (echo "unknown prereq of $$target : $$prereq" ; false) >&2 ;\
+			 echo "$$(($${seqnum[$$target]} > $${seqnum[$$prereq]})) error: *** $$target should not require $$prereq" ;\
+		      done ) ;\
+	       done | grep ^0 | sed 's/^0 //' | \
+	       ( haderror= ; \
+		 while read line ; \
+		 do if [ ! "$$haderror" ] ; then haderror=1 ; fi ; \
+		    echo "$$line" ;\
+		 done ;\
+		 [ ! "$$haderror" ] ) ;\
+	else echo "make: *** skipping enforcement of linear ordering of packages, because 'bash' is too old" ;\
+	fi
 
 # here we ensure that the travis script checks every package
 check-travis:


### PR DESCRIPTION
Now that the Makefile uses a feature of recent versions of bash, Mac OS X users
may have to install a recent version of bash, so here we modify the install
instructions.  The feature is associative arrays, declared with `declare -A`.

Here is homebrew's bash:
```
$ /usr/local/bin/bash --version
GNU bash, version 4.4.5(1)-release (x86_64-apple-darwin16.3.0)
Copyright (C) 2016 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
```
Here is the Mac OS X bash:
```
This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

$ /bin/bash --version
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin16)
Copyright (C) 2007 Free Software Foundation, Inc.
```