### PR TITLE
In this commit I propose adding advice to the style guide that names …

### DIFF
--- a/UniMath/Algebra/Archimedean.v
+++ b/UniMath/Algebra/Archimedean.v
@@ -81,7 +81,7 @@ Proof.
   induction n as [|n IHn] ; intros m x.
   - reflexivity.
   - simpl (_ * _)%nat.
-    assert (S n = (n + 1)%nat).
+    assert (H : S n = (n + 1)%nat).
     { rewrite <- plus_n_Sm, <- plus_n_O.
       reflexivity. }
     rewrite H ; clear H.
@@ -108,7 +108,7 @@ Proof.
   - rewrite lunax.
     reflexivity.
   - rewrite natmultS, assocax, IHn, <- (assocax _ y).
-    assert (y + natmult n x = natmult n x + y)%addmonoid.
+    assert (X1 : (y + natmult n x = natmult n x + y)%addmonoid).
     { clear IHn.
       induction n as [|n IHn].
       - rewrite lunax, runax.
@@ -287,7 +287,7 @@ Proof.
   intros (c1,Hc1) (c2,Hc2).
   exists (c1 * c2)%multmonoid.
   eapply Hr'.
-  assert (natmult (n1 + n2) (pr1 y1) * pr1 x * natmult (n1 + n2) (pr2 y2) * (c1 * c2) = (natmult n1 (pr1 y1 * pr2 y2) * pr1 x * c1) * (natmult n2 (pr1 y1 * pr2 y2) * c2))%multmonoid.
+  assert (X0 : (natmult (n1 + n2) (pr1 y1) * pr1 x * natmult (n1 + n2) (pr2 y2) * (c1 * c2) = (natmult n1 (pr1 y1 * pr2 y2) * pr1 x * c1) * (natmult n2 (pr1 y1 * pr2 y2) * c2))%multmonoid).
   { rewrite !natmult_op, !natmult_plus, !assocax.
     apply maponpaths.
     rewrite commax, !assocax.
@@ -308,7 +308,7 @@ Proof.
   rewrite X0 ; clear X0.
   apply (pr2 Hr).
   apply Hc1.
-  assert (natmult (n1 + n2) (pr1 y2) * (natmult (n1 + n2) (pr2 y1) * pr2 x) * (c1 * c2) = (natmult n1 (pr1 y2 * pr2 y1) * c1) * (natmult n2 (pr1 y2 * pr2 y1) * pr2 x * c2))%multmonoid.
+  assert (X0 : (natmult (n1 + n2) (pr1 y2) * (natmult (n1 + n2) (pr2 y1) * pr2 x) * (c1 * c2) = (natmult n1 (pr1 y2 * pr2 y1) * c1) * (natmult n2 (pr1 y2 * pr2 y1) * pr2 x * c2))%multmonoid).
   { rewrite !natmult_op, !natmult_plus, !assocax.
     apply maponpaths.
     rewrite commax, !assocax.
@@ -575,7 +575,7 @@ Proof.
   intros X R Hop1 H.
   repeat split.
   - intros y1 y2 Hy.
-    assert (R (y1 - y2)%rng 0%rng).
+    assert (X0 : R (y1 - y2)%rng 0%rng).
     abstract (apply (pr2 (isinvbinophrelgr X Hop1)) with y2 ;
                change BinaryOperations.op with (@BinaryOperations.op1 X) ;
                rewrite rngassoc1, rnglinvax1, rnglunax1, rngrunax1 ;

--- a/UniMath/CategoryTheory/PreAdditive.v
+++ b/UniMath/CategoryTheory/PreAdditive.v
@@ -126,7 +126,7 @@ Section preadditive_with_zero.
   Proof.
     unfold ZeroArrow.
     rewrite <- (id_left (ZeroArrowFrom y)).
-    assert (identity Z = to_unel Z Z) by apply ZeroEndo_is_identity.
+    assert (X : identity Z = to_unel Z Z) by apply ZeroEndo_is_identity.
     rewrite -> X. clear X.
 
     set (Y := to_postmor_unel A Z (@ZeroArrowFrom A Z y)).

--- a/UniMath/CategoryTheory/category_abgr.v
+++ b/UniMath/CategoryTheory/category_abgr.v
@@ -1111,7 +1111,7 @@ Section ABGR_kernels.
     unfold hfiber in *. induction HH1 as [t p]. induction HH2 as [t0 p0].
     rewrite <- p. rewrite <- p0. rewrite <- f'. cbn.
 
-    assert (g (f (t * t0)%multmonoid) = (g ∘ f) (t * t0)%multmonoid).
+    assert (X : g (f (t * t0)%multmonoid) = (g ∘ f) (t * t0)%multmonoid).
     {
       unfold funcomp. apply idpath.
     }

--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -1589,7 +1589,7 @@ Proof.
   intros.
   unfold isweq.
   intro y.
-  assert (iscontr (hfiber (f ∘ g) y)).
+  assert (X0 : iscontr (hfiber (f ∘ g) y)).
   assert (efg' : Π y : Y, y = f (g y)).
   { intro y0.
     apply pathsinv0.

--- a/UniMath/Foundations/PartC.v
+++ b/UniMath/Foundations/PartC.v
@@ -1222,7 +1222,7 @@ Theorem isdecpropfibseq1 {X Y Z : UU} (f : X -> Y) (g : Y -> Z) (z : Z)
 Proof.
   intros X Y Z f g z fs isx isz.
   assert (isc : iscontr Z) by apply (iscontraprop1 isz z).
-  assert (isweq f) by apply (isweqfinfibseq f g z fs isc).
+  assert (X0 : isweq f) by apply (isweqfinfibseq f g z fs isc).
   apply (isdecpropweqf (weqpair _ X0) isx).
 Defined.
 

--- a/UniMath/Foundations/Sets.v
+++ b/UniMath/Foundations/Sets.v
@@ -402,7 +402,7 @@ Lemma isapropsubtype {X : UU} (A : hsubtypes X)
 Proof.
   intros. apply invproofirrelevance.
   intros x x'.
-  assert (isincl (@pr1 _ A)).
+  assert (X0 : isincl (@pr1 _ A)).
   {
     apply isinclpr1.
     intro x0.

--- a/UniMath/README.md
+++ b/UniMath/README.md
@@ -44,7 +44,8 @@ less fragile and to make the files have a more uniform and pleasing appearance.
 * Use `as` to name all new variables introduced by `induction` or
   `destruct`, if the corresponding type is defined in a remote location,
   because different names might be used by Coq when the definition of the type
-  is changed.
+  is changed.  Name all variables introduced by `assert`, if they are used by
+  name later, with `as` or to the left of a colon.
 * Do not end a proof with `Qed.`, except with `Goal`, for that may prevent later computations.
 * Start all proofs with `Proof.` on a separate line and end it with
   `Defined.` on a separate line, as this makes it possible for us to generate

--- a/UniMath/RealNumbers/NonnegativeReals.v
+++ b/UniMath/RealNumbers/NonnegativeReals.v
@@ -2502,7 +2502,7 @@ Proof.
     right.
     exists (pr1 q,,pr1 q).
     repeat split.
-    + assert (2 = 1+1)%NRat.
+    + assert (X : (2 = 1+1)%NRat).
       { apply subtypeEquality_prop ; simpl.
         apply hq2eq1plus1. }
       pattern 2%NRat at 1 ; rewrite X ; clear X.
@@ -2648,7 +2648,7 @@ Proof.
   apply (fun X X0 Xerr => Dcuts_def_corr_not_empty X X0 Xerr _ Hc) in Y_corr'.
   revert Y_corr' ; apply hinhuniv ; intros y.
   generalize (pr1 (pr2 y)) ; apply hinhuniv ; intros Yy.
-  assert (¬ Y (pr1 y + c / 2%NRat)).
+  assert (X0 : ¬ Y (pr1 y + c / 2%NRat)).
   { intro ; apply (pr2 (pr2 y)).
     now apply hinhpr ; left. }
   rename X0 into nYy.
@@ -3994,7 +3994,7 @@ Proof.
     + intro ; now apply is_Dcuts_bot.
     + intro ; now apply is_Dcuts_corr.
     + intros eps Heps.
-      assert (0 < NonnegativeRationals_to_Dcuts eps)
+      assert (X : 0 < NonnegativeRationals_to_Dcuts eps)
         by (now apply_pr2 isapfun_NonnegativeRationals_to_Dcuts_aux).
       generalize (HU _ X) ; clear HU.
       apply hinhfun ; intros HU.

--- a/UniMath/Topology/Topology.v
+++ b/UniMath/Topology/Topology.v
@@ -190,7 +190,7 @@ Proof.
       apply isapropimpl.
       apply propproperty. }
     set (Q := λ A : T → hProp, isOpen A ∧ (hProppair (Π y : T, A y → P y) (H A))).
-    assert (P = (union Q)).
+    assert (X : P = (union Q)).
     { apply funextfun.
       intros x.
       apply hPropUnivalence.


### PR DESCRIPTION
…of assert

variables that are referred to should be named explicitly, instead of depending
on Coq to invent a name.

I searched for such assertions and fixed them.

The idea to do this was prompted by the discussion in #551.