### PR TITLE
replace Π with ∏ and Σ with ∑

### DIFF
--- a/UniMath/Algebra/Apartness.v
+++ b/UniMath/Algebra/Apartness.v
@@ -53,11 +53,11 @@ Proof.
   apply isapropiscotrans.
 Qed.
 
-Definition aprel (X : UU) := Σ ap : hrel X, isaprel ap.
+Definition aprel (X : UU) := ∑ ap : hrel X, isaprel ap.
 Definition aprel_pr1 {X : UU} (ap : aprel X) : hrel X := pr1 ap.
 Coercion aprel_pr1 : aprel >-> hrel.
 
-Definition apSet := Σ X : hSet, aprel X.
+Definition apSet := ∑ X : hSet, aprel X.
 Definition apSet_pr1 (X : apSet) : hSet := pr1 X.
 Coercion apSet_pr1 : apSet >-> hSet.
 Arguments apSet_pr1 X: simpl never.
@@ -70,21 +70,21 @@ Open Scope ap_scope.
 (** Lemmas about apartness *)
 
 Lemma isirreflapSet {X : apSet} :
-  Π x : X, ¬ (x # x).
+  ∏ x : X, ¬ (x # x).
 Proof.
   intros ?.
   exact (pr1 (pr2 (pr2 X))).
 Qed.
 
 Lemma issymmapSet {X : apSet} :
-  Π x y : X, x # y -> y # x.
+  ∏ x y : X, x # y -> y # x.
 Proof.
   intros ?.
   exact (pr1 (pr2 (pr2 (pr2 X)))).
 Qed.
 
 Lemma iscotransapSet {X : apSet} :
-  Π x y z : X, x # z -> x # y ∨ y # z.
+  ∏ x y z : X, x # z -> x # y ∨ y # z.
 Proof.
   intros ?.
   exact (pr2 (pr2 (pr2 (pr2 X)))).
@@ -94,15 +94,15 @@ Close Scope ap_scope.
 (** ** Tight apartness *)
 
 Definition istight {X : UU} (R : hrel X) :=
-  Π x y : X, ¬ (R x y) -> x = y.
+  ∏ x y : X, ¬ (R x y) -> x = y.
 Definition istightap {X : UU} (ap : hrel X) :=
   isaprel ap × istight ap.
 
-Definition tightap (X : UU) := Σ ap : hrel X, istightap ap.
+Definition tightap (X : UU) := ∑ ap : hrel X, istightap ap.
 Definition tightap_aprel {X : UU} (ap : tightap X) : aprel X := pr1 ap ,, (pr1 (pr2 ap)).
 Coercion tightap_aprel : tightap >-> aprel.
 
-Definition tightapSet := Σ X : hSet, tightap X.
+Definition tightapSet := ∑ X : hSet, tightap X.
 Definition tightapSet_apSet (X : tightapSet) : apSet := pr1 X ,, (tightap_aprel (pr2 X)).
 Coercion tightapSet_apSet : tightapSet >-> apSet.
 
@@ -115,42 +115,42 @@ Open Scope tap_scope.
 (** Some lemmas *)
 
 Lemma isirrefltightapSet {X : tightapSet} :
-  Π x : X, ¬ (x ≠ x).
+  ∏ x : X, ¬ (x ≠ x).
 Proof.
   intros ?.
   exact isirreflapSet.
 Qed.
 
 Lemma issymmtightapSet {X : tightapSet} :
-  Π x y : X, x ≠ y -> y ≠ x.
+  ∏ x y : X, x ≠ y -> y ≠ x.
 Proof.
   intros ?.
   exact issymmapSet.
 Qed.
 
 Lemma iscotranstightapSet {X : tightapSet} :
-  Π x y z : X, x ≠ z -> x ≠ y ∨ y ≠ z.
+  ∏ x y z : X, x ≠ z -> x ≠ y ∨ y ≠ z.
 Proof.
   intros ?.
   exact iscotransapSet.
 Qed.
 
 Lemma istighttightapSet {X : tightapSet} :
-  Π x y : X, ¬ (x ≠ y) -> x = y.
+  ∏ x y : X, ¬ (x ≠ y) -> x = y.
 Proof.
   intros ?.
   exact (pr2 (pr2 (pr2 X))).
 Qed.
 
 Lemma istighttightapSet_rev {X : tightapSet} :
-  Π x y : X, x = y -> ¬ (x ≠ y).
+  ∏ x y : X, x = y -> ¬ (x ≠ y).
 Proof.
   intros ? x _ <-.
   now apply isirrefltightapSet.
 Qed.
 
 Lemma tightapSet_dec {X : tightapSet} :
-  LEM -> Π x y : X, (x != y <-> x ≠ y).
+  LEM -> ∏ x y : X, (x != y <-> x ≠ y).
 Proof.
   intros ? Hdec x y.
   destruct (Hdec (x ≠ y)) as [ Hneq | Heq ].
@@ -171,7 +171,7 @@ Qed.
 (** ** Operations and apartness *)
 
 Definition isapunop {X : tightapSet} (op :unop X) :=
-  Π x y : X, op x ≠ op y -> x ≠ y.
+  ∏ x y : X, op x ≠ op y -> x ≠ y.
 Lemma isaprop_isapunop {X : tightapSet} (op :unop X) :
   isaprop (isapunop op).
 Proof.
@@ -183,9 +183,9 @@ Proof.
 Qed.
 
 Definition islapbinop {X : tightapSet} (op : binop X) :=
-  Π x, isapunop (λ y, op y x).
+  ∏ x, isapunop (λ y, op y x).
 Definition israpbinop {X : tightapSet} (op : binop X) :=
-  Π x, isapunop (λ y, op x y).
+  ∏ x, isapunop (λ y, op x y).
 Definition isapbinop {X : tightapSet} (op : binop X) :=
   (islapbinop op) × (israpbinop op).
 Lemma isaprop_islapbinop {X : tightapSet} (op : binop X) :
@@ -211,18 +211,18 @@ Proof.
   now apply isaprop_israpbinop.
 Qed.
 
-Definition apbinop (X : tightapSet) := Σ op : binop X, isapbinop op.
+Definition apbinop (X : tightapSet) := ∑ op : binop X, isapbinop op.
 Definition apbinop_pr1 {X : tightapSet} (op : apbinop X) : binop X := pr1 op.
 Coercion apbinop_pr1 : apbinop >-> binop.
 
-Definition apsetwithbinop := Σ X : tightapSet, apbinop X.
+Definition apsetwithbinop := ∑ X : tightapSet, apbinop X.
 Definition apsetwithbinop_pr1 (X : apsetwithbinop) : tightapSet := pr1 X.
 Coercion apsetwithbinop_pr1 : apsetwithbinop >-> tightapSet.
 Definition apsetwithbinop_setwithbinop : apsetwithbinop -> setwithbinop :=
   λ X : apsetwithbinop, (apSet_pr1 (apsetwithbinop_pr1 X)),, (pr1 (pr2 X)).
 Definition op {X : apsetwithbinop} : binop X := op (X := apsetwithbinop_setwithbinop X).
 
-Definition apsetwith2binop := Σ X : tightapSet, apbinop X × apbinop X.
+Definition apsetwith2binop := ∑ X : tightapSet, apbinop X × apbinop X.
 Definition apsetwith2binop_pr1 (X : apsetwith2binop) : tightapSet := pr1 X.
 Coercion apsetwith2binop_pr1 : apsetwith2binop >-> tightapSet.
 Definition apsetwith2binop_setwith2binop : apsetwith2binop -> setwith2binop :=
@@ -238,21 +238,21 @@ Section apsetwithbinop_pty.
 Context {X : apsetwithbinop}.
 
 Lemma islapbinop_op :
-  Π x x' y : X, op x y ≠ op x' y -> x ≠ x'.
+  ∏ x x' y : X, op x y ≠ op x' y -> x ≠ x'.
 Proof.
   intros x y y'.
   now apply (pr1 (pr2 (pr2 X))).
 Qed.
 
 Lemma israpbinop_op :
-  Π x y y' : X, op x y ≠ op x y' -> y ≠ y'.
+  ∏ x y y' : X, op x y ≠ op x y' -> y ≠ y'.
 Proof.
   intros x y y'.
   now apply (pr2 (pr2 (pr2 X))).
 Qed.
 
 Lemma isapbinop_op :
-  Π x x' y y' : X, op x y ≠ op x' y' -> x ≠ x' ∨ y ≠ y'.
+  ∏ x x' y y' : X, op x y ≠ op x' y' -> x ≠ x' ∨ y ≠ y'.
 Proof.
   intros x x' y y' Hop.
   apply (iscotranstightapSet _ (op x' y)) in Hop.
@@ -275,37 +275,37 @@ Definition apsetwith2binop_apsetwithbinop2 : apsetwithbinop :=
   (pr1 X) ,, (pr2 (pr2 X)).
 
 Lemma islapbinop_op1 :
-  Π x x' y : X, op1 x y ≠ op1 x' y -> x ≠ x'.
+  ∏ x x' y : X, op1 x y ≠ op1 x' y -> x ≠ x'.
 Proof.
   exact (islapbinop_op (X := apsetwith2binop_apsetwithbinop1)).
 Qed.
 
 Lemma israpbinop_op1 :
-  Π x y y' : X, op1 x y ≠ op1 x y' -> y ≠ y'.
+  ∏ x y y' : X, op1 x y ≠ op1 x y' -> y ≠ y'.
 Proof.
   exact (israpbinop_op (X := apsetwith2binop_apsetwithbinop1)).
 Qed.
 
 Lemma isapbinop_op1 :
-  Π x x' y y' : X, op1 x y ≠ op1 x' y' -> x ≠ x' ∨ y ≠ y'.
+  ∏ x x' y y' : X, op1 x y ≠ op1 x' y' -> x ≠ x' ∨ y ≠ y'.
 Proof.
   exact (isapbinop_op (X := apsetwith2binop_apsetwithbinop1)).
 Qed.
 
 Lemma islapbinop_op2 :
-  Π x x' y : X, op2 x y ≠ op2 x' y -> x ≠ x'.
+  ∏ x x' y : X, op2 x y ≠ op2 x' y -> x ≠ x'.
 Proof.
   exact (islapbinop_op (X := apsetwith2binop_apsetwithbinop2)).
 Qed.
 
 Lemma israpbinop_op2 :
-  Π x y y' : X, op2 x y ≠ op2 x y' -> y ≠ y'.
+  ∏ x y y' : X, op2 x y ≠ op2 x y' -> y ≠ y'.
 Proof.
   exact (israpbinop_op (X := apsetwith2binop_apsetwithbinop2)).
 Qed.
 
 Lemma isapbinop_op2 :
-  Π x x' y y' : X, op2 x y ≠ op2 x' y' -> x ≠ x' ∨ y ≠ y'.
+  ∏ x x' y y' : X, op2 x y ≠ op2 x' y' -> x ≠ x' ∨ y ≠ y'.
 Proof.
   exact (isapbinop_op (X := apsetwith2binop_apsetwithbinop2)).
 Qed.

--- a/UniMath/Algebra/Archimedean.v
+++ b/UniMath/Algebra/Archimedean.v
@@ -31,7 +31,7 @@ Definition nattorng {X : rng} (n : nat) : X :=
   nattorig (X := rngtorig X) n.
 
 Lemma natmultS :
-  Π {X : monoid} (n : nat) (x : X),
+  ∏ {X : monoid} (n : nat) (x : X),
     natmult (S n) x = (x + natmult n x)%addmonoid.
 Proof.
   intros X n x.
@@ -40,14 +40,14 @@ Proof.
   - reflexivity.
 Qed.
 Lemma nattorigS {X : rig} :
-  Π (n : nat), nattorig (X := X) (S n) = (1 + nattorig n)%rig.
+  ∏ (n : nat), nattorig (X := X) (S n) = (1 + nattorig n)%rig.
 Proof.
   intros.
   now apply (natmultS (X := rigaddabmonoid X)).
 Qed.
 
 Lemma nattorig_natmult :
-  Π {X : rig} (n : nat) (x : X),
+  ∏ {X : rig} (n : nat) (x : X),
     (nattorig n * x)%rig = natmult (X := rigaddabmonoid X) n x.
 Proof.
   intros.
@@ -57,7 +57,7 @@ Proof.
     now rewrite rigrdistr, IHn, riglunax2.
 Qed.
 Lemma natmult_plus :
-  Π {X : monoid} (n m : nat) (x : X),
+  ∏ {X : monoid} (n m : nat) (x : X),
     natmult (n + m) x = (natmult n x + natmult m x)%addmonoid.
 Proof.
   induction n as [|n IHn] ; intros m x.
@@ -67,7 +67,7 @@ Proof.
     reflexivity.
 Qed.
 Lemma nattorig_plus :
-  Π {X : rig} (n m : nat),
+  ∏ {X : rig} (n m : nat),
     (nattorig (n + m) : X) = (nattorig n + nattorig m)%rig.
 Proof.
   intros X n m.
@@ -75,7 +75,7 @@ Proof.
 Qed.
 
 Lemma natmult_mult :
-  Π {X : monoid} (n m : nat) (x : X),
+  ∏ {X : monoid} (n m : nat) (x : X),
     natmult (n * m) x = (natmult n (natmult m x))%addmonoid.
 Proof.
   induction n as [|n IHn] ; intros m x.
@@ -89,7 +89,7 @@ Proof.
     reflexivity.
 Qed.
 Lemma nattorig_mult :
-  Π {X : rig} (n m : nat),
+  ∏ {X : rig} (n m : nat),
     (nattorig (n * m) : X) = (nattorig n * nattorig m)%rig.
 Proof.
   intros X n m.
@@ -99,7 +99,7 @@ Proof.
 Qed.
 
 Lemma natmult_op {X : monoid} :
-  Π (n : nat) (x y : X),
+  ∏ (n : nat) (x y : X),
     (x + y = y + x)%addmonoid
     -> natmult n (x + y)%addmonoid = (natmult n x + natmult n y)%addmonoid.
 Proof.
@@ -121,7 +121,7 @@ Qed.
 
 Lemma natmult_binophrel {X : monoid} (R : hrel X) :
   istrans R -> isbinophrel R ->
-  Π (n : nat) (x y : X), R x y -> R (natmult (S n) x) (natmult (S n) y).
+  ∏ (n : nat) (x y : X), R x y -> R (natmult (S n) x) (natmult (S n) y).
 Proof.
   intros X R Hr Hop n x y H.
   induction n as [|n IHn].
@@ -179,7 +179,7 @@ Qed.
 
 Lemma isequiv_setquot_aux {X : abmonoid} (R : hrel X) :
   isinvbinophrel R ->
-  Π x y : X, (setquot_aux R) x y <-> R x y.
+  ∏ x y : X, (setquot_aux R) x y <-> R x y.
 Proof.
   intros X R H x y.
   split.
@@ -197,20 +197,20 @@ Qed.
 (** ** Archimedean property in a monoid *)
 
 Definition isarchmonoid {X : abmonoid} (R : hrel X) :=
-  Π x y1 y2 : X,
+  ∏ x y1 y2 : X,
     R y1 y2 ->
     (∃ n : nat, R (natmult n y1 + x)%addmonoid (natmult n y2))
       × (∃ n : nat, R (natmult n y1) (natmult n y2 + x)%addmonoid).
 
 Definition isarchmonoid_1 {X : abmonoid} (R : hrel X) :
   isarchmonoid R ->
-  Π x y1 y2 : X,
+  ∏ x y1 y2 : X,
     R y1 y2 ->
     ∃ n : nat, R (natmult n y1 + x)%addmonoid (natmult n y2) :=
   λ H x y1 y2 Hy, (pr1 (H x y1 y2 Hy)).
 Definition isarchmonoid_2 {X : abmonoid} (R : hrel X) :
   isarchmonoid R ->
-  Π x y1 y2 : X,
+  ∏ x y1 y2 : X,
     R y1 y2 ->
     ∃ n : nat, R (natmult n y1) (natmult n y2 + x)%addmonoid :=
   λ H x y1 y2 Hy, (pr2 (H x y1 y2 Hy)).
@@ -218,13 +218,13 @@ Definition isarchmonoid_2 {X : abmonoid} (R : hrel X) :
 (** ** Archimedean property in a group *)
 
 Definition isarchgr {X : abgr} (R : hrel X) :=
-  Π x y1 y2 : X,
+  ∏ x y1 y2 : X,
     R y1 y2 ->
     ∃ n : nat, R (natmult n y1 + x)%addmonoid (natmult n y2).
 
 Local Lemma isarchgr_isarchmonoid_aux {X : abgr} (R : hrel X) :
   isbinophrel R ->
-  Π (n : nat) (x y1 y2 : X),
+  ∏ (n : nat) (x y1 y2 : X),
     R (natmult n y1 * grinv X x)%multmonoid (natmult n y2) -> R (natmult n y1) (natmult n y2 * x)%multmonoid.
 Proof.
   intros X R Hop.
@@ -275,7 +275,7 @@ Local Lemma isarchabgrdiff_aux {X : abmonoid} (R : hrel X)
               (natmult (X := abgrdiff X) (n1 + n2) (setquotpr (binopeqrelabgrdiff X) y2)).
 Proof.
   intros.
-  assert (H0 : Π n y, natmult (X := abgrdiff X) n (setquotpr (binopeqrelabgrdiff X) y) = setquotpr (binopeqrelabgrdiff X) (natmult n (pr1 y) ,, natmult n (pr2 y))).
+  assert (H0 : ∏ n y, natmult (X := abgrdiff X) n (setquotpr (binopeqrelabgrdiff X) y) = setquotpr (binopeqrelabgrdiff X) (natmult n (pr1 y) ,, natmult n (pr2 y))).
   { intros n y.
     induction n as [|n IHn].
     reflexivity.
@@ -349,21 +349,21 @@ Defined.
 (** ** Archimedean property in a rig *)
 
 Definition isarchrig {X : rig} (R : hrel X) :=
-  (Π y1 y2 : X, R y1 y2 -> ∃ n : nat, R (nattorig n * y1)%rig (1 + nattorig n * y2)%rig)
-    × (Π x : X, ∃ n : nat, R (nattorig n) x)
-    × (Π x : X, ∃ n : nat, R (nattorig n + x)%rig 0%rig).
+  (∏ y1 y2 : X, R y1 y2 -> ∃ n : nat, R (nattorig n * y1)%rig (1 + nattorig n * y2)%rig)
+    × (∏ x : X, ∃ n : nat, R (nattorig n) x)
+    × (∏ x : X, ∃ n : nat, R (nattorig n + x)%rig 0%rig).
 
 Definition isarchrig_diff {X : rig} (R : hrel X) :
   isarchrig R ->
-  Π y1 y2 : X, R y1 y2 -> ∃ n : nat, R (nattorig n * y1)%rig (1 + nattorig n * y2)%rig :=
+  ∏ y1 y2 : X, R y1 y2 -> ∃ n : nat, R (nattorig n * y1)%rig (1 + nattorig n * y2)%rig :=
   pr1.
 Definition isarchrig_gt {X : rig} (R : hrel X) :
   isarchrig R ->
-  Π x : X, ∃ n : nat, R (nattorig n) x :=
+  ∏ x : X, ∃ n : nat, R (nattorig n) x :=
   λ H, (pr1 (pr2 H)).
 Definition isarchrig_pos {X : rig} (R : hrel X) :
   isarchrig R ->
-  Π x : X, ∃ n : nat, R (nattorig n + x)%rig 0%rig :=
+  ∏ x : X, ∃ n : nat, R (nattorig n + x)%rig 0%rig :=
 
   λ H, (pr2 (pr2 H)).
 
@@ -558,15 +558,15 @@ Defined.
 (** ** Archimedean property in a ring *)
 
 Definition isarchrng {X : rng} (R : hrel X) :=
-  (Π x : X, R x 0%rng -> ∃ n : nat, R (nattorng n * x)%rng 1%rng)
-    × (Π x : X, ∃ n : nat, R (nattorng n) x).
+  (∏ x : X, R x 0%rng -> ∃ n : nat, R (nattorng n * x)%rng 1%rng)
+    × (∏ x : X, ∃ n : nat, R (nattorng n) x).
 
 Definition isarchrng_1 {X : rng} (R : hrel X) :
   isarchrng R ->
-  Π x : X, R x 0%rng -> ∃ n : nat, R (nattorng n * x)%rng 1%rng := pr1.
+  ∏ x : X, R x 0%rng -> ∃ n : nat, R (nattorng n * x)%rng 1%rng := pr1.
 Definition isarchrng_2 {X : rng} (R : hrel X) :
   isarchrng R ->
-  Π x : X, ∃ n : nat, R (nattorng n) x := pr2.
+  ∏ x : X, ∃ n : nat, R (nattorng n) x := pr2.
 
 Lemma isarchrng_isarchrig {X : rng} (R : hrel X) :
   isbinophrel (X := rigaddabmonoid X) R ->
@@ -649,7 +649,7 @@ Proof.
 Defined.
 
 Theorem isarchrigtorng :
-  Π (X : rig) (R : hrel X) (Hr : R 1%rig 0%rig)
+  ∏ (X : rig) (R : hrel X) (Hr : R 1%rig 0%rig)
     (Hadd : isbinophrel (X := rigaddabmonoid X) R)
     (Htra : istrans R)
     (Harch : isarchrig (setquot_aux (X := rigaddabmonoid X) R)), isarchrng (X := rigtorng X) (rigtorngrel X Hadd).
@@ -753,7 +753,7 @@ Proof.
 Defined.
 
 Lemma natmult_commrngfrac {X : commrng} {S : subabmonoid} :
-  Π n (x : X × S), natmult (X := commrngfrac X S) n (setquotpr (eqrelcommrngfrac X S) x) = setquotpr (eqrelcommrngfrac X S) (natmult (X := X) n (pr1 x) ,, (pr2 x)).
+  ∏ n (x : X × S), natmult (X := commrngfrac X S) n (setquotpr (eqrelcommrngfrac X S) x) = setquotpr (eqrelcommrngfrac X S) (natmult (X := X) n (pr1 x) ,, (pr2 x)).
 Proof.
   simpl ; intros X S n x.
   induction n as [|n IHn].
@@ -784,7 +784,7 @@ Proof.
     intros x Hx.
     revert Hx ; apply hinhuniv ; intros (c,Hx) ; simpl in Hx.
     rewrite !(rngmult0x X), (rngrunax2 X) in Hx.
-    apply (hinhfun (X := Σ n, commrngfracgt X S Hop1 Hop2 Hs (setquotpr (eqrelcommrngfrac X S) ((nattorng n * pr1 x)%rng,, pr2 x)) 1%rng)).
+    apply (hinhfun (X := ∑ n, commrngfracgt X S Hop1 Hop2 Hs (setquotpr (eqrelcommrngfrac X S) ((nattorng n * pr1 x)%rng,, pr2 x)) 1%rng)).
     intros H.
     eexists (pr1 H).
     unfold nattorng.
@@ -822,7 +822,7 @@ Proof.
       exact Hn.
   - simple refine (setquotunivprop _ _ _).
     intros x.
-    apply (hinhfun (X := Σ n : nat, commrngfracgt X S Hop1 Hop2 Hs
+    apply (hinhfun (X := ∑ n : nat, commrngfracgt X S Hop1 Hop2 Hs
      (setquotpr (eqrelcommrngfrac X S) (nattorng n,, unel S))
      (setquotpr (eqrelcommrngfrac X S) x))).
     intros (n,Hn).
@@ -872,10 +872,10 @@ Qed.
 (** ** Archimedean property in a field *)
 
 Definition isarchfld {X : fld} (R : hrel X) :=
-  Π x : X, ∃ n : nat, R (nattorng n) x.
+  ∏ x : X, ∃ n : nat, R (nattorng n) x.
 
 Lemma isarchfld_isarchrng {X : fld} (R : hrel X) :
-  Π (Hadd : isbinophrel (X := rigaddabmonoid X) R) ( Hmult : isrngmultgt X R)
+  ∏ (Hadd : isbinophrel (X := rigaddabmonoid X) R) ( Hmult : isrngmultgt X R)
     (Hirr : isirrefl R),
     isarchfld R -> isarchrng R.
 Proof.
@@ -914,7 +914,7 @@ Proof.
   unfold fldfracgt.
   generalize (isarchcommrngfrac (X := X) (S := rngpossubmonoid X is1 is2) R is0 is1 (λ (c : X) (r : (rngpossubmonoid X is1 is2) c), r) is2 tra X0).
   intros.
-  assert (H_f : Π n x, (weqfldfracgt_f X is is0 is1 is2 nc (nattorng n * x)%rng) = (nattorng n * weqfldfracgt_f X is is0 is1 is2 nc x)%rng).
+  assert (H_f : ∏ n x, (weqfldfracgt_f X is is0 is1 is2 nc (nattorng n * x)%rng) = (nattorng n * weqfldfracgt_f X is is0 is1 is2 nc x)%rng).
   { clear -irr.
     intros n x.
     unfold nattorng.
@@ -953,12 +953,12 @@ Defined.
 (** ** Archimedean property in a constructive field *)
 
 Definition isarchCF {X : ConstructiveField} (R : hrel X) :=
-  Π x : X, ∃ n : nat, R (nattorng n) x.
+  ∏ x : X, ∃ n : nat, R (nattorng n) x.
 
 Lemma isarchCF_isarchrng {X : ConstructiveField} (R : hrel X) :
-  Π (Hadd : isbinophrel (X := rigaddabmonoid X) R) ( Hmult : isrngmultgt X R)
+  ∏ (Hadd : isbinophrel (X := rigaddabmonoid X) R) ( Hmult : isrngmultgt X R)
     (Hirr : isirrefl R),
-    (Π x : X, R x 0%CF -> (x ≠ 0)%CF) ->
+    (∏ x : X, R x 0%CF -> (x ≠ 0)%CF) ->
     isarchCF R -> isarchrng R.
 Proof.
   intros X R Hadd Hmult Hirr H0 H.

--- a/UniMath/Algebra/BinaryOperations.v
+++ b/UniMath/Algebra/BinaryOperations.v
@@ -72,7 +72,7 @@ Definition isinvertible {X : UU} (opp : binop X) (x : X) : UU :=
 (** *)
 
 Definition isassoc {X : hSet} (opp : binop X) : UU :=
-  Π x x' x'', paths (opp (opp x x') x'') (opp x (opp x' x'')).
+  ∏ x x' x'', paths (opp (opp x x') x'') (opp x (opp x' x'')).
 
 Lemma isapropisassoc {X : hSet} (opp : binop X) : isaprop (isassoc opp).
 Proof.
@@ -85,7 +85,7 @@ Defined.
 
 (** *)
 
-Definition islunit {X : hSet} (opp : binop X) (un0 : X) : UU := Π x : X, paths (opp un0 x) x.
+Definition islunit {X : hSet} (opp : binop X) (un0 : X) : UU := ∏ x : X, paths (opp un0 x) x.
 
 Lemma isapropislunit {X : hSet} (opp : binop X) (un0 : X) : isaprop (islunit opp un0).
 Proof.
@@ -94,7 +94,7 @@ Proof.
   simpl. apply (setproperty X).
 Defined.
 
-Definition isrunit {X : hSet} (opp : binop X) (un0 : X) : UU := Π x : X, paths (opp x un0) x.
+Definition isrunit {X : hSet} (opp : binop X) (un0 : X) : UU := ∏ x : X, paths (opp x un0) x.
 
 Lemma isapropisrunit {X : hSet} (opp : binop X) (un0 : X) : isaprop (isrunit opp un0).
 Proof.
@@ -145,7 +145,7 @@ Defined.
 (** *)
 
 Definition islinv {X : hSet} (opp : binop X) (un0 : X) (inv0 : X -> X) : UU :=
-  Π x : X, paths (opp (inv0 x) x) un0.
+  ∏ x : X, paths (opp (inv0 x) x) un0.
 
 Lemma isapropislinv {X : hSet} (opp : binop X) (un0 : X) (inv0 : X -> X) :
   isaprop (islinv opp un0 inv0).
@@ -156,7 +156,7 @@ Proof.
 Defined.
 
 Definition isrinv {X : hSet} (opp : binop X) (un0 : X) (inv0 : X -> X) : UU :=
-  Π x : X, paths (opp x (inv0 x)) un0.
+  ∏ x : X, paths (opp x (inv0 x)) un0.
 
 Lemma isapropisrinv {X : hSet} (opp : binop X) (un0 : X) (inv0 : X -> X) :
   isaprop (isrinv opp un0 inv0).
@@ -208,14 +208,14 @@ Proof.
   destruct istr as [ inv0 axs ].
   destruct isun0 as [ un0 unaxs ].
   simpl in * |-.
-  assert (egf : Π x : _, paths (g (f x)) x).
+  assert (egf : ∏ x : _, paths (g (f x)) x).
   {
     intro x. unfold f. unfold g.
     destruct (pathsinv0 (assoc x x0 (inv0 x0))).
     set (e := pr2 axs x0). simpl in e. rewrite e.
     apply (pr2 unaxs x).
   }
-  assert (efg : Π x : _, paths (f (g x)) x).
+  assert (efg : ∏ x : _, paths (f (g x)) x).
   {
     intro x. unfold f. unfold g.
     destruct (pathsinv0 (assoc x (inv0 x0) x0)).
@@ -235,14 +235,14 @@ Proof.
   destruct istr as [ inv0 axs ].
   destruct isun0 as [ un0 unaxs ].
   simpl in * |-.
-  assert (egf : Π x : _, paths (g (f x)) x).
+  assert (egf : ∏ x : _, paths (g (f x)) x).
   {
     intro x. unfold f. unfold g.
     destruct (assoc (inv0 x0) x0 x).
     set (e := pr1 axs x0). simpl in e. rewrite e.
     apply (pr1 unaxs x).
   }
-  assert (efg : Π x : _, paths (f (g x)) x).
+  assert (efg : ∏ x : _, paths (f (g x)) x).
   {
     intro x. unfold f. unfold g.
     destruct (assoc x0 (inv0 x0) x).
@@ -257,9 +257,9 @@ Lemma isapropinvstruct {X : hSet} {opp : binop X} (is : ismonoidop opp) :
 Proof.
   intros. apply isofhlevelsn. intro is0.
   set (un0 := pr1 (pr2 is)).
-  assert (int : Π (i : X -> X),
-                isaprop (dirprod (Π x : X, paths (opp (i x) x) un0)
-                                 (Π x : X, paths (opp x (i x)) un0))).
+  assert (int : ∏ (i : X -> X),
+                isaprop (dirprod (∏ x : X, paths (opp (i x) x) un0)
+                                 (∏ x : X, paths (opp x (i x)) un0))).
   {
     intro i. apply (isofhleveldirprod 1).
     - apply impred. intro x. simpl. apply (setproperty X).
@@ -282,7 +282,7 @@ Defined.
 (* (** Unitary monoid where all elements are invertible is a group *)
 
 Definition allinvvertibleinv {X : hSet} {opp : binop X} (is : ismonoidop opp)
-  (allinv : Π x : X, islinvertible opp x) : X -> X
+  (allinv : ∏ x : X, islinvertible opp x) : X -> X
   := fun x : X => invmap (weqpair _ (allinv x)) (unel_is is).
 
 *)
@@ -290,7 +290,7 @@ Definition allinvvertibleinv {X : hSet} {opp : binop X} (is : ismonoidop opp)
 (** The following lemma is an analog of [Bourbaki, Alg. 1, ex. 2, p. 132] *)
 
 Lemma isgropif {X : hSet} {opp : binop X} (is0 : ismonoidop opp)
-      (is : Π x : X, hexists (fun x0 : X => eqset (opp x x0) (unel_is is0))) : isgrop opp.
+      (is : ∏ x : X, hexists (fun x0 : X => eqset (opp x x0) (unel_is is0))) : isgrop opp.
 Proof.
   intros. split with is0.
   destruct is0 as [ assoc isun0 ].
@@ -298,7 +298,7 @@ Proof.
   simpl in is.
   simpl in unaxs0. simpl in un0.
   simpl in assoc. simpl in unaxs0.
-  assert (l1 : Π x' : X, isincl (fun x0 : X => opp x0 x')).
+  assert (l1 : ∏ x' : X, isincl (fun x0 : X => opp x0 x')).
   {
     intro x'.
     apply (@hinhuniv (total2 (fun x0 : X => paths (opp x' x0) un0))
@@ -315,7 +315,7 @@ Proof.
         rewrite e. apply idpath.
     -  apply (is x').
   }
-  assert (is' : Π x : X, hexists (fun x0 : X => eqset (opp x0 x) un0)).
+  assert (is' : ∏ x : X, hexists (fun x0 : X => eqset (opp x0 x) un0)).
   {
     intro x. apply (fun f : _  => hinhuniv f (is x)). intro s1.
     destruct s1 as [ x' eq ]. apply hinhpr. split with x'. simpl.
@@ -323,7 +323,7 @@ Proof.
     rewrite (assoc x' x x'). rewrite eq. rewrite (pr1 unaxs0 x').
     unfold unel_is. simpl. rewrite (pr2 unaxs0 x'). apply idpath.
   }
-  assert (l1' : Π x' : X, isincl (fun x0 : X => opp x' x0)).
+  assert (l1' : ∏ x' : X, isincl (fun x0 : X => opp x' x0)).
   {
     intro x'.
     apply (@hinhuniv (total2 (fun x0 : X => paths (opp x0 x') un0))
@@ -339,7 +339,7 @@ Proof.
         rewrite e. apply idpath.
     - apply (is' x').
   }
-  assert (int : Π x : X, isaprop (total2 (fun x0 : X => eqset (opp x0 x) un0))).
+  assert (int : ∏ x : X, isaprop (total2 (fun x0 : X => eqset (opp x0 x) un0))).
   {
     intro x. apply isapropsubtype. intros x1 x2. intros eq1 eq2.
     apply (invmaponpathsincl _ (l1 x)).
@@ -358,7 +358,7 @@ Defined.
 
 (** *)
 
-Definition iscomm {X : hSet} (opp : binop X) : UU := Π x x' : X, paths (opp x x') (opp x' x).
+Definition iscomm {X : hSet} (opp : binop X) : UU := ∏ x x' : X, paths (opp x x') (opp x' x).
 
 Lemma isapropiscomm {X : hSet} (opp : binop X) : isaprop (iscomm opp).
 Proof.
@@ -502,7 +502,7 @@ Defined.
 (** *)
 
 Definition isldistr {X : hSet} (opp1 opp2 : binop X) : UU :=
-  Π x x' x'' : X, paths (opp2 x'' (opp1 x x')) (opp1 (opp2 x'' x) (opp2 x'' x')).
+  ∏ x x' x'' : X, paths (opp2 x'' (opp1 x x')) (opp1 (opp2 x'' x) (opp2 x'' x')).
 
 Lemma isapropisldistr {X : hSet} (opp1 opp2 : binop X) : isaprop (isldistr opp1 opp2).
 Proof.
@@ -514,7 +514,7 @@ Proof.
 Defined.
 
 Definition isrdistr {X : hSet} (opp1 opp2 : binop X) : UU :=
-  Π x x' x'' : X, paths (opp2 (opp1 x x') x'') (opp1 (opp2 x x'') (opp2 x' x'')).
+  ∏ x x' x'' : X, paths (opp2 (opp1 x x') x'') (opp1 (opp2 x x'') (opp2 x' x'')).
 
 Lemma isapropisrdistr {X : hSet} (opp1 opp2 : binop X) : isaprop (isrdistr opp1 opp2).
 Proof.
@@ -561,8 +561,8 @@ Defined.
 Definition isrigops {X : hSet} (opp1 opp2 : binop X) : UU :=
   dirprod (total2
              (fun (axs : dirprod (isabmonoidop opp1) (ismonoidop opp2)) =>
-                (dirprod (Π x : X, paths (opp2 (unel_is (pr1 axs)) x) (unel_is (pr1 axs))))
-                  (Π x : X, paths (opp2 x (unel_is (pr1 axs))) (unel_is (pr1 axs)))))
+                (dirprod (∏ x : X, paths (opp2 (unel_is (pr1 axs)) x) (unel_is (pr1 axs))))
+                  (∏ x : X, paths (opp2 x (unel_is (pr1 axs))) (unel_is (pr1 axs)))))
           (isdistr opp1 opp2).
 
 Definition rigop1axs_is {X : hSet} {opp1 opp2 : binop X} :
@@ -645,7 +645,7 @@ Proof.
 Defined.
 
 Lemma multx0_is_l {X : hSet} {opp1 opp2 : binop X} (is1 : isgrop opp1) (is2 : ismonoidop opp2)
-      (is12 : isdistr opp1 opp2) : Π x : X, paths (opp2 x (unel_is (pr1 is1))) (unel_is (pr1 is1)).
+      (is12 : isdistr opp1 opp2) : ∏ x : X, paths (opp2 x (unel_is (pr1 is1))) (unel_is (pr1 is1)).
 Proof.
   intros.
   destruct is12 as [ ldistr0 rdistr0 ].
@@ -661,7 +661,7 @@ Defined.
 Opaque multx0_is_l.
 
 Lemma mult0x_is_l {X : hSet} {opp1 opp2 : binop X} (is1 : isgrop opp1) (is2 : ismonoidop opp2)
-      (is12 : isdistr opp1 opp2) : Π x : X, paths (opp2 (unel_is (pr1 is1)) x) (unel_is (pr1 is1)).
+      (is12 : isdistr opp1 opp2) : ∏ x : X, paths (opp2 (unel_is (pr1 is1)) x) (unel_is (pr1 is1)).
 Proof.
   intros.
   destruct is12 as [ ldistr0 rdistr0 ].
@@ -742,18 +742,18 @@ Proof.
 Defined.
 
 Definition rngmultx0_is {X : hSet} {opp1 opp2 : binop X} (is : isrngops opp1 opp2) :
-  Π (x : X), opp2 x (unel_is (pr1 (rngop1axs_is is))) = unel_is (pr1 (rngop1axs_is is)) :=
+  ∏ (x : X), opp2 x (unel_is (pr1 (rngop1axs_is is))) = unel_is (pr1 (rngop1axs_is is)) :=
   multx0_is_l (rngop1axs_is is) (rngop2axs_is is) (rngdistraxs_is is).
 
 Definition rngmult0x_is {X : hSet} {opp1 opp2 : binop X} (is : isrngops opp1 opp2) :
-  Π (x : X), opp2 (unel_is (pr1 (rngop1axs_is is))) x = unel_is (pr1 (rngop1axs_is is)) :=
+  ∏ (x : X), opp2 (unel_is (pr1 (rngop1axs_is is))) x = unel_is (pr1 (rngop1axs_is is)) :=
   mult0x_is_l (rngop1axs_is is) (rngop2axs_is is) (rngdistraxs_is is).
 
 Definition rngminus1_is {X : hSet} {opp1 opp2 : binop X} (is : isrngops opp1 opp2) : pr1hSet X :=
   minus1_is_l (rngop1axs_is is) (rngop2axs_is is).
 
 Definition rngmultwithminus1_is {X : hSet} {opp1 opp2 : binop X} (is : isrngops opp1 opp2) :
-  Π (x : X),
+  ∏ (x : X),
   opp2 (minus1_is_l (rngop1axs_is is) (rngop2axs_is is)) x = grinv_is (rngop1axs_is is) x :=
   isminusmultwithminus1_is_l (rngop1axs_is is) (rngop2axs_is is) (rngdistraxs_is is).
 
@@ -836,7 +836,7 @@ Notation "x * y" := (op x y) : multoperation_scope.
 (** **** Functions compatible with a binary operation (homomorphisms) and their properties *)
 
 Definition isbinopfun {X Y : setwithbinop} (f : X -> Y) : UU :=
-  Π x x' : X, paths (f (op x x')) (op (f x) (f x')).
+  ∏ x x' : X, paths (f (op x x')) (op (f x) (f x')).
 
 Lemma isapropisbinopfun {X Y : setwithbinop} (f : X -> Y) : isaprop (isbinopfun f).
 Proof.
@@ -1148,7 +1148,7 @@ Definition isabgropisob {X Y : setwithbinop} (f : binopiso X Y) (is : isabgrop (
 (** **** Subobjects *)
 
 Definition issubsetwithbinop {X : hSet} (opp : binop X) (A : hsubtype X) : UU :=
-  Π a a' : A, A (opp (pr1 a) (pr1 a')).
+  ∏ a a' : A, A (opp (pr1 a) (pr1 a')).
 
 Lemma isapropissubsetwithbinop {X : hSet} (opp : binop X) (A : hsubtype X) :
   isaprop (issubsetwithbinop opp A).
@@ -1163,13 +1163,13 @@ Definition subsetswithbinop {X : setwithbinop} : UU :=
   total2 (fun A : hsubtype X => issubsetwithbinop (@op X) A).
 
 Definition subsetswithbinoppair {X : setwithbinop} :
-  Π (t : hsubtype X), (λ A : hsubtype X, issubsetwithbinop op A) t →
-                       Σ A : hsubtype X, issubsetwithbinop op A :=
+  ∏ (t : hsubtype X), (λ A : hsubtype X, issubsetwithbinop op A) t →
+                       ∑ A : hsubtype X, issubsetwithbinop op A :=
   tpair (fun A : hsubtype X => issubsetwithbinop (@op X) A).
 
 Definition subsetswithbinopconstr {X : setwithbinop} :
-  Π (t : hsubtype X), (λ A : hsubtype X, issubsetwithbinop op A) t →
-                       Σ A : hsubtype X, issubsetwithbinop op A := @subsetswithbinoppair X.
+  ∏ (t : hsubtype X), (λ A : hsubtype X, issubsetwithbinop op A) t →
+                       ∑ A : hsubtype X, issubsetwithbinop op A := @subsetswithbinoppair X.
 
 Definition pr1subsetswithbinop (X : setwithbinop) : @subsetswithbinop X -> hsubtype X :=
   @pr1 _ (fun A : hsubtype X => issubsetwithbinop (@op X) A).
@@ -1199,7 +1199,7 @@ Coercion carrierofasubsetwithbinop : subsetswithbinop >-> setwithbinop.
 (** **** Relations compatible with a binary operation and quotient objects *)
 
 Definition isbinophrel {X : setwithbinop} (R : hrel X) : UU :=
-  dirprod (Π a b c : X, R a b -> R (op c a) (op c b)) (Π a b c : X, R a b -> R (op a c) (op b c)).
+  dirprod (∏ a b c : X, R a b -> R (op c a) (op c b)) (∏ a b c : X, R a b -> R (op a c) (op b c)).
 
 Definition isbinophrellogeqf {X : setwithbinop} {L R : hrel X}
            (lg : hrellogeq L R) (isl : isbinophrel L) : isbinophrel R.
@@ -1227,7 +1227,7 @@ Proof.
 Defined.
 
 Lemma isbinophrelif {X : setwithbinop} (R : hrel X) (is : iscomm (@op X))
-      (isl : Π a b c : X, R a b -> R (op c a) (op c b)) : isbinophrel R.
+      (isl : ∏ a b c : X, R a b -> R (op c a) (op c b)) : isbinophrel R.
 Proof.
   intros. split with isl. intros a b c rab.
   destruct (is c a). destruct (is c b). apply (isl _ _ _ rab).
@@ -1252,7 +1252,7 @@ Defined.
 Definition binophrel {X : setwithbinop} : UU := total2 (fun R : hrel X => isbinophrel R).
 
 Definition binophrelpair {X : setwithbinop} :
-  Π (t : hrel X), (λ R : hrel X, isbinophrel R) t → Σ R : hrel X, isbinophrel R :=
+  ∏ (t : hrel X), (λ R : hrel X, isbinophrel R) t → ∑ R : hrel X, isbinophrel R :=
   tpair (fun R : hrel X => isbinophrel R).
 
 Definition pr1binophrel (X : setwithbinop) : @binophrel X -> hrel X :=
@@ -1262,7 +1262,7 @@ Coercion pr1binophrel : binophrel >-> hrel.
 Definition binoppo {X : setwithbinop} : UU := total2 (fun R : po X => isbinophrel R).
 
 Definition binoppopair {X : setwithbinop} :
-  Π (t : po X), (λ R : po X, isbinophrel R) t → Σ R : po X, isbinophrel R :=
+  ∏ (t : po X), (λ R : po X, isbinophrel R) t → ∑ R : po X, isbinophrel R :=
   tpair (fun R : po X => isbinophrel R).
 
 Definition pr1binoppo (X : setwithbinop) : @binoppo X -> po X := @pr1 _ (fun R : po X => isbinophrel R).
@@ -1271,7 +1271,7 @@ Coercion pr1binoppo : binoppo >-> po.
 Definition binopeqrel {X : setwithbinop} : UU := total2 (fun R : eqrel X => isbinophrel R).
 
 Definition binopeqrelpair {X : setwithbinop} :
-  Π (t : eqrel X), (λ R : eqrel X, isbinophrel R) t → Σ R : eqrel X, isbinophrel R :=
+  ∏ (t : eqrel X), (λ R : eqrel X, isbinophrel R) t → ∑ R : eqrel X, isbinophrel R :=
   tpair (fun R : eqrel X => isbinophrel R).
 
 Definition pr1binopeqrel (X : setwithbinop) : @binopeqrel X -> eqrel X :=
@@ -1288,8 +1288,8 @@ Proof.
 Defined.
 
 Definition ispartbinophrel {X : setwithbinop} (S : hsubtype X) (R : hrel X) : UU :=
-  dirprod (Π a b c : X, S c -> R a b -> R (op c a) (op c b))
-          (Π a b c : X, S c -> R a b -> R (op a c) (op b c)).
+  dirprod (∏ a b c : X, S c -> R a b -> R (op c a) (op c b))
+          (∏ a b c : X, S c -> R a b -> R (op a c) (op b c)).
 
 Definition isbinoptoispartbinop {X : setwithbinop} (S : hsubtype X) (L : hrel X)
            (is : isbinophrel L) : ispartbinophrel S L.
@@ -1311,7 +1311,7 @@ Proof.
 Defined.
 
 Lemma ispartbinophrelif {X : setwithbinop} (S : hsubtype X) (R : hrel X) (is : iscomm (@op X))
-      (isl : Π a b c : X, S c -> R a b -> R (op c a) (op c b)) : ispartbinophrel S R.
+      (isl : ∏ a b c : X, S c -> R a b -> R (op c a) (op c b)) : ispartbinophrel S R.
 Proof.
   intros. split with isl.
   intros a b c s rab. destruct (is c a). destruct (is c b).
@@ -1322,7 +1322,7 @@ Defined.
 (** **** Relations inversely compatible with a binary operation *)
 
 Definition isinvbinophrel {X : setwithbinop} (R : hrel X) : UU :=
-  dirprod (Π a b c : X, R (op c a) (op c b) ->  R a b) (Π a b c : X, R (op a c) (op b c) -> R a b).
+  dirprod (∏ a b c : X, R (op c a) (op c b) ->  R a b) (∏ a b c : X, R (op a c) (op b c) -> R a b).
 
 Definition isinvbinophrellogeqf {X : setwithbinop} {L R : hrel X} (lg : hrellogeq L R)
            (isl : isinvbinophrel L) : isinvbinophrel R.
@@ -1350,7 +1350,7 @@ Proof.
 Defined.
 
 Lemma isinvbinophrelif {X : setwithbinop} (R : hrel X) (is : iscomm (@op X))
-      (isl : Π a b c : X,  R (op c a) (op c b) -> R a b) : isinvbinophrel R.
+      (isl : ∏ a b c : X,  R (op c a) (op c b) -> R a b) : isinvbinophrel R.
 Proof.
   intros. split with isl. intros a b c rab.
   destruct (is c a). destruct (is c b).
@@ -1358,8 +1358,8 @@ Proof.
 Defined.
 
 Definition ispartinvbinophrel {X : setwithbinop} (S : hsubtype X) (R : hrel X) : UU :=
-  dirprod (Π a b c : X, S c -> R (op c a) (op c b) -> R a b)
-          (Π a b c : X, S c -> R (op a c) (op b c) -> R a b).
+  dirprod (∏ a b c : X, S c -> R (op c a) (op c b) -> R a b)
+          (∏ a b c : X, S c -> R (op a c) (op b c) -> R a b).
 
 Definition isinvbinoptoispartinvbinop {X : setwithbinop} (S : hsubtype X) (L : hrel X)
            (is : isinvbinophrel L) : ispartinvbinophrel S L.
@@ -1382,7 +1382,7 @@ Proof.
 Defined.
 
 Lemma ispartinvbinophrelif {X : setwithbinop} (S : hsubtype X) (R : hrel X) (is : iscomm (@op X))
-      (isl : Π a b c : X, S c -> R (op c a) (op c b) -> R a b) : ispartinvbinophrel S R.
+      (isl : ∏ a b c : X, S c -> R (op c a) (op c b) -> R a b) : ispartinvbinophrel S R.
 Proof.
   intros. split with isl. intros a b c s rab.
   destruct (is c a). destruct (is c b).
@@ -1396,7 +1396,7 @@ Lemma binophrelandfun {X Y : setwithbinop} (f : binopfun X Y) (R : hrel Y) (is :
   @isbinophrel X (fun x x' => R (f x) (f x')).
 Proof.
   intros.
-  set (ish := (pr2 f) : Π a0 b0, paths (f (op a0 b0)) (op (f a0) (f b0))).
+  set (ish := (pr2 f) : ∏ a0 b0, paths (f (op a0 b0)) (op (f a0) (f b0))).
   split.
   - intros a b c r. rewrite (ish _ _). rewrite (ish _ _).
     apply (pr1 is). apply r.
@@ -1405,11 +1405,11 @@ Proof.
 Defined.
 
 Lemma ispartbinophrelandfun {X Y : setwithbinop} (f : binopfun X Y) (SX : hsubtype X)
-      (SY : hsubtype Y) (iss : Π x : X, (SX x) -> (SY (f x))) (R : hrel Y)
+      (SY : hsubtype Y) (iss : ∏ x : X, (SX x) -> (SY (f x))) (R : hrel Y)
       (is : @ispartbinophrel Y SY R) : @ispartbinophrel X SX (fun x x' => R (f x) (f x')).
 Proof.
   intros.
-  set (ish := (pr2 f) : Π a0 b0, paths (f (op a0 b0)) (op (f a0) (f b0))).
+  set (ish := (pr2 f) : ∏ a0 b0, paths (f (op a0 b0)) (op (f a0) (f b0))).
   split.
   - intros a b c s r. rewrite (ish _ _). rewrite (ish _ _).
     apply ((pr1 is) _ _ _ (iss _ s) r).
@@ -1421,7 +1421,7 @@ Lemma invbinophrelandfun {X Y : setwithbinop} (f : binopfun X Y) (R : hrel Y)
       (is : @isinvbinophrel Y R) : @isinvbinophrel X (fun x x' => R (f x) (f x')).
 Proof.
   intros.
-  set (ish := (pr2 f) : Π a0 b0, paths (f (op a0 b0)) (op (f a0) (f b0))).
+  set (ish := (pr2 f) : ∏ a0 b0, paths (f (op a0 b0)) (op (f a0) (f b0))).
   split.
   - intros a b c r. rewrite (ish _ _) in r. rewrite (ish _ _) in r.
     apply ((pr1 is) _ _ _ r).
@@ -1430,11 +1430,11 @@ Proof.
 Defined.
 
 Lemma ispartinvbinophrelandfun {X Y : setwithbinop} (f : binopfun X Y) (SX : hsubtype X)
-      (SY : hsubtype Y) (iss : Π x : X, (SX x) -> (SY (f x))) (R : hrel Y)
+      (SY : hsubtype Y) (iss : ∏ x : X, (SX x) -> (SY (f x))) (R : hrel Y)
       (is : @ispartinvbinophrel Y SY R) : @ispartinvbinophrel X SX (fun x x' => R (f x) (f x')).
 Proof.
   intros.
-  set (ish := (pr2 f) : Π a0 b0, paths (f (op a0 b0)) (op (f a0) (f b0))).
+  set (ish := (pr2 f) : ∏ a0 b0, paths (f (op a0 b0)) (op (f a0) (f b0))).
   split.
   - intros a b c s r. rewrite (ish _ _) in r. rewrite (ish _ _) in r.
     apply ((pr1 is) _ _ _ (iss _ s) r).
@@ -1449,14 +1449,14 @@ Lemma isbinopquotrel {X : setwithbinop} (R : @binopeqrel X) {L : hrel X} (is : i
       (isl : isbinophrel L) : @isbinophrel (setwithbinopquot R) (quotrel is).
 Proof.
   intros. unfold isbinophrel. split.
-  - assert (int : Π (a b c : setwithbinopquot R),
+  - assert (int : ∏ (a b c : setwithbinopquot R),
                   isaprop (quotrel is a b -> quotrel is (op c a) (op c b))).
     {
       intros a b c. apply impred. intro. apply (pr2 (quotrel is _ _)).
     }
     apply (setquotuniv3prop R (fun a b c => hProppair _ (int a b c))).
     exact (pr1 isl).
-  - assert (int : Π (a b c : setwithbinopquot R),
+  - assert (int : ∏ (a b c : setwithbinopquot R),
                   isaprop (quotrel is a b -> quotrel is (op a c) (op b c))).
     {
       intros a b c. apply impred. intro. apply (pr2 (quotrel is _ _)).
@@ -1506,8 +1506,8 @@ Notation "x * y" := (op2 x y) : twobinops_scope.
 (** **** Functions compatible with a pair of binary operation (homomorphisms) and their properties *)
 
 Definition istwobinopfun {X Y : setwith2binop} (f : X -> Y) : UU :=
-  dirprod (Π x x' : X, paths (f (op1 x x')) (op1 (f x) (f x')))
-          (Π x x' : X, paths (f (op2 x x')) (op2 (f x) (f x'))).
+  dirprod (∏ x x' : X, paths (f (op1 x x')) (op1 (f x) (f x')))
+          (∏ x x' : X, paths (f (op2 x x')) (op2 (f x) (f x'))).
 
 Lemma isapropistwobinopfun {X Y : setwith2binop} (f : X -> Y) : isaprop (istwobinopfun f).
 Proof.
@@ -1748,7 +1748,7 @@ Definition iscommrngopsisob {X Y : setwith2binop} (f : twobinopiso X Y)
 (** **** Subobjects *)
 
 Definition issubsetwith2binop {X : setwith2binop} (A : hsubtype X) : UU :=
-  dirprod (Π a a' : A, A (op1 (pr1 a) (pr1 a'))) (Π a a' : A, A (op2 (pr1 a) (pr1 a'))).
+  dirprod (∏ a a' : A, A (op1 (pr1 a) (pr1 a'))) (∏ a a' : A, A (op2 (pr1 a) (pr1 a'))).
 
 Lemma isapropissubsetwith2binop {X : setwith2binop} (A : hsubtype X) :
   isaprop (issubsetwith2binop A).
@@ -1766,13 +1766,13 @@ Definition subsetswith2binop {X : setwith2binop} : UU :=
   total2 (fun A : hsubtype X => issubsetwith2binop A).
 
 Definition subsetswith2binoppair {X : setwith2binop} :
-  Π (t : hsubtype X), (λ A : hsubtype X, issubsetwith2binop A) t →
-                       Σ A : hsubtype X, issubsetwith2binop A :=
+  ∏ (t : hsubtype X), (λ A : hsubtype X, issubsetwith2binop A) t →
+                       ∑ A : hsubtype X, issubsetwith2binop A :=
   tpair (fun A : hsubtype X => issubsetwith2binop A).
 
 Definition subsetswith2binopconstr {X : setwith2binop} :
-  Π (t : hsubtype X), (λ A : hsubtype X, issubsetwith2binop A) t →
-                       Σ A : hsubtype X, issubsetwith2binop A :=
+  ∏ (t : hsubtype X), (λ A : hsubtype X, issubsetwith2binop A) t →
+                       ∑ A : hsubtype X, issubsetwith2binop A :=
   @subsetswith2binoppair X.
 
 Definition pr1subsetswith2binop (X : setwith2binop) : @subsetswith2binop X -> hsubtype X :=
@@ -1825,7 +1825,7 @@ Defined.
 Definition twobinophrel {X : setwith2binop} : UU := total2 (fun R : hrel X => is2binophrel R).
 
 Definition twobinophrelpair {X : setwith2binop} :
-  Π (t : hrel X), (λ R : hrel X, is2binophrel R) t → Σ R : hrel X, is2binophrel R :=
+  ∏ (t : hrel X), (λ R : hrel X, is2binophrel R) t → ∑ R : hrel X, is2binophrel R :=
   tpair (fun R : hrel X => is2binophrel R).
 
 Definition pr1twobinophrel (X : setwith2binop) : @twobinophrel X -> hrel X :=
@@ -1835,7 +1835,7 @@ Coercion pr1twobinophrel : twobinophrel >-> hrel.
 Definition twobinoppo {X : setwith2binop} : UU := total2 (fun R : po X => is2binophrel R).
 
 Definition twobinoppopair {X : setwith2binop} :
-  Π (t : po X), (λ R : po X, is2binophrel R) t → Σ R : po X, is2binophrel R :=
+  ∏ (t : po X), (λ R : po X, is2binophrel R) t → ∑ R : po X, is2binophrel R :=
   tpair (fun R : po X => is2binophrel R).
 
 Definition pr1twobinoppo (X : setwith2binop) : @twobinoppo X -> po X :=
@@ -1845,7 +1845,7 @@ Coercion pr1twobinoppo : twobinoppo >-> po.
 Definition twobinopeqrel {X : setwith2binop} : UU := total2 (fun R : eqrel X => is2binophrel R).
 
 Definition twobinopeqrelpair {X : setwith2binop} :
-  Π (t : eqrel X), (λ R : eqrel X, is2binophrel R) t → Σ R : eqrel X, is2binophrel R :=
+  ∏ (t : eqrel X), (λ R : eqrel X, is2binophrel R) t → ∑ R : eqrel X, is2binophrel R :=
   tpair (fun R : eqrel X => is2binophrel R).
 
 Definition pr1twobinopeqrel (X : setwith2binop) : @twobinopeqrel X -> eqrel X :=

--- a/UniMath/Algebra/ConstructiveStructures.v
+++ b/UniMath/Algebra/ConstructiveStructures.v
@@ -13,13 +13,13 @@ Require Export UniMath.Algebra.Domains_and_Fields.
 
 Definition isnonzeroCR (X : rig) (R : tightap X) := R 1%rig 0%rig.
 Definition isConstrDivRig (X : rig) (R : tightap X) :=
-  isnonzeroCR X R × (Π x : X, R x 0%rig -> multinvpair X x).
+  isnonzeroCR X R × (∏ x : X, R x 0%rig -> multinvpair X x).
 
 (** ** Constructive rig with division *)
 
 Definition ConstructiveDivisionRig :=
-  Σ X : rig,
-  Σ R : tightap X,
+  ∑ X : rig,
+  ∑ R : tightap X,
         isapbinop (X := (pr1 (pr1 X)) ,, R) BinaryOperations.op1
       × isapbinop (X := (pr1 (pr1 X)) ,, R) BinaryOperations.op2
       × isConstrDivRig X R.
@@ -61,22 +61,22 @@ Section CDR_pty.
 Context {X : ConstructiveDivisionRig}.
 
 Lemma isirrefl_CDRap :
-  Π x : X, ¬ (x ≠ x).
+  ∏ x : X, ¬ (x ≠ x).
 Proof.
   exact (pr1 (pr1 (pr2 (pr1 (pr2 X))))).
 Qed.
 Lemma issymm_CDRap :
-  Π x y : X, x ≠ y -> y ≠ x.
+  ∏ x y : X, x ≠ y -> y ≠ x.
 Proof.
   exact (pr1 (pr2 (pr1 (pr2 (pr1 (pr2 X)))))).
 Qed.
 Lemma iscotrans_CDRap :
-  Π x y z : X, x ≠ z -> x ≠ y ∨ y ≠ z.
+  ∏ x y z : X, x ≠ z -> x ≠ y ∨ y ≠ z.
 Proof.
   exact (pr2 (pr2 (pr1 (pr2 (pr1 (pr2 X)))))).
 Qed.
 Lemma istight_CDRap :
-  Π x y : X, ¬ (x ≠ y) -> x = y.
+  ∏ x y : X, ¬ (x ≠ y) -> x = y.
 Proof.
   exact (pr2 (pr2 (pr1 (pr2 X)))).
 Qed.
@@ -87,102 +87,102 @@ Proof.
 Qed.
 
 Lemma islunit_CDRzero_CDRplus :
-  Π x : X, 0 + x = x.
+  ∏ x : X, 0 + x = x.
 Proof.
   now apply riglunax1.
 Qed.
 Lemma isrunit_CDRzero_CDRplus :
-  Π x : X, x + 0 = x.
+  ∏ x : X, x + 0 = x.
 Proof.
   now apply rigrunax1.
 Qed.
 Lemma isassoc_CDRplus :
-  Π x y z : X, x + y + z = x + (y + z).
+  ∏ x y z : X, x + y + z = x + (y + z).
 Proof.
   now apply rigassoc1.
 Qed.
 Lemma iscomm_CDRplus :
-  Π x y : X, x + y = y + x.
+  ∏ x y : X, x + y = y + x.
 Proof.
   now apply rigcomm1.
 Qed.
 Lemma islunit_CDRone_CDRmult :
-  Π x : X, 1 * x = x.
+  ∏ x : X, 1 * x = x.
 Proof.
   now apply riglunax2.
 Qed.
 Lemma isrunit_CDRone_CDRmult :
-  Π x : X, x * 1 = x.
+  ∏ x : X, x * 1 = x.
 Proof.
   now apply rigrunax2.
 Qed.
 Lemma isassoc_CDRmult :
-  Π x y z : X, x * y * z = x * (y * z).
+  ∏ x y z : X, x * y * z = x * (y * z).
 Proof.
   now apply rigassoc2.
 Qed.
 Lemma islinv_CDRinv :
-  Π (x : X) (Hx0 : x ≠ (0 : X)),
+  ∏ (x : X) (Hx0 : x ≠ (0 : X)),
     (CDRinv x Hx0) * x = 1.
 Proof.
   intros x Hx0.
   apply (pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 X)))) x Hx0))).
 Qed.
 Lemma isrinv_CDRinv :
-  Π (x : X) (Hx0 : x ≠ (0 : X)),
+  ∏ (x : X) (Hx0 : x ≠ (0 : X)),
     x * (CDRinv x Hx0) = 1.
 Proof.
   intros x Hx0.
   apply (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 X)))) x Hx0))).
 Qed.
 Lemma islabsorb_CDRzero_CDRmult :
-  Π x : X, 0 * x = 0.
+  ∏ x : X, 0 * x = 0.
 Proof.
   now apply rigmult0x.
 Qed.
 Lemma israbsorb_CDRzero_CDRmult :
-  Π x : X, x * 0 = 0.
+  ∏ x : X, x * 0 = 0.
 Proof.
   now apply rigmultx0.
 Qed.
 Lemma isldistr_CDRplus_CDRmult :
-  Π x y z : X, z * (x + y) = z * x + z * y.
+  ∏ x y z : X, z * (x + y) = z * x + z * y.
 Proof.
   now apply rigdistraxs.
 Qed.
 
 Lemma apCDRplus :
-  Π x x' y y' : X,
+  ∏ x x' y y' : X,
     x + y ≠ x' + y' -> x ≠ x' ∨ y ≠ y'.
 Proof.
   exact (isapbinop_op1 (X := ConstructiveDivisionRig_apsetwith2binop X)).
 Qed.
 Lemma CDRplus_apcompat_l :
-  Π x y z : X, y + x ≠ z + x -> y ≠ z.
+  ∏ x y z : X, y + x ≠ z + x -> y ≠ z.
 Proof.
   intros x y z.
   exact (islapbinop_op1 (X := ConstructiveDivisionRig_apsetwith2binop X) _ _ _).
 Qed.
 Lemma CDRplus_apcompat_r :
-  Π x y z : X, x + y ≠ x + z -> y ≠ z.
+  ∏ x y z : X, x + y ≠ x + z -> y ≠ z.
 Proof.
   exact (israpbinop_op1 (X := ConstructiveDivisionRig_apsetwith2binop X)).
 Qed.
 
 Lemma apCDRmult :
-  Π x x' y y' : X,
+  ∏ x x' y y' : X,
     x * y ≠ x' * y' -> x ≠ x' ∨ y ≠ y'.
 Proof.
   exact (isapbinop_op2 (X := ConstructiveDivisionRig_apsetwith2binop X)).
 Qed.
 Lemma CDRmult_apcompat_l :
-  Π x y z : X, y * x ≠ z * x -> y ≠ z.
+  ∏ x y z : X, y * x ≠ z * x -> y ≠ z.
 Proof.
   intros x y z.
   exact (islapbinop_op2 (X := ConstructiveDivisionRig_apsetwith2binop X) _ _ _).
 Qed.
 Lemma CDRmult_apcompat_l' :
-  Π x y z : X, x ≠ 0 -> y ≠ z -> y * x ≠ z * x.
+  ∏ x y z : X, x ≠ 0 -> y ≠ z -> y * x ≠ z * x.
 Proof.
   intros x y z Hx Hap.
   refine (CDRmult_apcompat_l (CDRinv x Hx) _ _ _).
@@ -190,12 +190,12 @@ Proof.
   exact Hap.
 Qed.
 Lemma CDRmult_apcompat_r :
-  Π x y z : X, x * y ≠ x * z -> y ≠ z.
+  ∏ x y z : X, x * y ≠ x * z -> y ≠ z.
 Proof.
   exact (israpbinop_op2 (X := ConstructiveDivisionRig_apsetwith2binop X)).
 Qed.
 Lemma CDRmult_apcompat_r' :
-  Π x y z : X, x ≠ 0 -> y ≠ z -> x * y ≠ x * z.
+  ∏ x y z : X, x ≠ 0 -> y ≠ z -> x * y ≠ x * z.
 Proof.
   intros x y z Hx Hap.
   refine (CDRmult_apcompat_r (CDRinv x Hx) _ _ _).
@@ -204,7 +204,7 @@ Proof.
 Qed.
 
 Lemma CDRmultapCDRzero :
-  Π x y : X, x * y ≠ 0 -> x ≠ 0 ∧ y ≠ 0.
+  ∏ x y : X, x * y ≠ 0 -> x ≠ 0 ∧ y ≠ 0.
 Proof.
   intros x y Hmult.
   split.
@@ -223,8 +223,8 @@ End CDR_pty.
 (** ** Constructive commutative rig with division *)
 
 Definition ConstructiveCommutativeDivisionRig :=
-  Σ X : commrig,
-  Σ R : tightap X,
+  ∑ X : commrig,
+  ∑ R : tightap X,
         isapbinop (X := (pr1 (pr1 X)) ,, R) BinaryOperations.op1
       × isapbinop (X := (pr1 (pr1 X)) ,, R) BinaryOperations.op2
       × isConstrDivRig X R.
@@ -266,22 +266,22 @@ Section CCDR_pty.
 Context {X : ConstructiveCommutativeDivisionRig}.
 
 Lemma isirrefl_CCDRap :
-  Π x : X, ¬ (x ≠ x).
+  ∏ x : X, ¬ (x ≠ x).
 Proof.
   exact (isirrefl_CDRap (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma issymm_CCDRap :
-  Π x y : X, x ≠ y -> y ≠ x.
+  ∏ x y : X, x ≠ y -> y ≠ x.
 Proof.
   exact (issymm_CDRap (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma iscotrans_CCDRap :
-  Π x y z : X, x ≠ z -> x ≠ y ∨ y ≠ z.
+  ∏ x y z : X, x ≠ z -> x ≠ y ∨ y ≠ z.
 Proof.
   exact (iscotrans_CDRap (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma istight_CCDRap :
-  Π x y : X, ¬ (x ≠ y) -> x = y.
+  ∏ x y : X, ¬ (x ≠ y) -> x = y.
 Proof.
   exact (istight_CDRap (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
@@ -292,74 +292,74 @@ Proof.
 Qed.
 
 Lemma islunit_CCDRzero_CCDRplus :
-  Π x : X, 0 + x = x.
+  ∏ x : X, 0 + x = x.
 Proof.
   now apply riglunax1.
 Qed.
 Lemma isrunit_CCDRzero_CCDRplus :
-  Π x : X, x + 0 = x.
+  ∏ x : X, x + 0 = x.
 Proof.
   now apply rigrunax1.
 Qed.
 Lemma isassoc_CCDRplus :
-  Π x y z : X, x + y + z = x + (y + z).
+  ∏ x y z : X, x + y + z = x + (y + z).
 Proof.
   now apply rigassoc1.
 Qed.
 Lemma iscomm_CCDRplus :
-  Π x y : X, x + y = y + x.
+  ∏ x y : X, x + y = y + x.
 Proof.
   now apply rigcomm1.
 Qed.
 Lemma islunit_CCDRone_CCDRmult :
-  Π x : X, 1 * x = x.
+  ∏ x : X, 1 * x = x.
 Proof.
   now apply riglunax2.
 Qed.
 Lemma isrunit_CCDRone_CCDRmult :
-  Π x : X, x * 1 = x.
+  ∏ x : X, x * 1 = x.
 Proof.
   now apply rigrunax2.
 Qed.
 Lemma isassoc_CCDRmult :
-  Π x y z : X, x * y * z = x * (y * z).
+  ∏ x y z : X, x * y * z = x * (y * z).
 Proof.
   now apply rigassoc2.
 Qed.
 Lemma iscomm_CCDRmult :
-  Π x y : X, x * y = y * x.
+  ∏ x y : X, x * y = y * x.
 Proof.
   now apply rigcomm2.
 Qed.
 Lemma islinv_CCDRinv :
-  Π (x : X) (Hx0 : x ≠ (0 : X)),
+  ∏ (x : X) (Hx0 : x ≠ (0 : X)),
     (CDRinv (X := X) x Hx0) * x = 1.
 Proof.
   exact (islinv_CDRinv (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma isrinv_CCDRinv :
-  Π (x : X) (Hx0 : x ≠ (0 : X)),
+  ∏ (x : X) (Hx0 : x ≠ (0 : X)),
     x * (CDRinv (X := X) x Hx0) = 1.
 Proof.
   exact (isrinv_CDRinv (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma islabsorb_CCDRzero_CCDRmult :
-  Π x : X, 0 * x = 0.
+  ∏ x : X, 0 * x = 0.
 Proof.
   now apply rigmult0x.
 Qed.
 Lemma israbsorb_CCDRzero_CCDRmult :
-  Π x : X, x * 0 = 0.
+  ∏ x : X, x * 0 = 0.
 Proof.
   now apply rigmultx0.
 Qed.
 Lemma isldistr_CCDRplus_CCDRmult :
-  Π x y z : X, z * (x + y) = z * x + z * y.
+  ∏ x y z : X, z * (x + y) = z * x + z * y.
 Proof.
   now apply rigdistraxs.
 Qed.
 Lemma isrdistr_CCDRplus_CCDRmult :
-  Π x y z : X, (x + y) * z = x * z + y * z.
+  ∏ x y z : X, (x + y) * z = x * z + y * z.
 Proof.
   intros x y z.
   rewrite !(iscomm_CCDRmult _ z).
@@ -367,51 +367,51 @@ Proof.
 Qed.
 
 Lemma apCCDRplus :
-  Π x x' y y' : X,
+  ∏ x x' y y' : X,
     x + y ≠ x' + y' -> x ≠ x' ∨ y ≠ y'.
 Proof.
   exact (apCDRplus (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma CCDRplus_apcompat_l :
-  Π x y z : X, y + x ≠ z + x -> y ≠ z.
+  ∏ x y z : X, y + x ≠ z + x -> y ≠ z.
 Proof.
   exact (CDRplus_apcompat_l (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma CCDRplus_apcompat_r :
-  Π x y z : X, x + y ≠ x + z -> y ≠ z.
+  ∏ x y z : X, x + y ≠ x + z -> y ≠ z.
 Proof.
   exact (CDRplus_apcompat_r (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 
 Lemma apCCDRmult :
-  Π x x' y y' : X,
+  ∏ x x' y y' : X,
     x * y ≠ x' * y' -> x ≠ x' ∨ y ≠ y'.
 Proof.
   exact (apCDRmult (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma CCDRmult_apcompat_l :
-  Π x y z : X, y * x ≠ z * x -> y ≠ z.
+  ∏ x y z : X, y * x ≠ z * x -> y ≠ z.
 Proof.
   exact (CDRmult_apcompat_l (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma CCDRmult_apcompat_l' :
-  Π x y z : X, x ≠ 0 -> y ≠ z -> y * x ≠ z * x.
+  ∏ x y z : X, x ≠ 0 -> y ≠ z -> y * x ≠ z * x.
 Proof.
   exact (CDRmult_apcompat_l' (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma CCDRmult_apcompat_r :
-  Π x y z : X, x * y ≠ x * z -> y ≠ z.
+  ∏ x y z : X, x * y ≠ x * z -> y ≠ z.
 Proof.
   exact (CDRmult_apcompat_r (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 Lemma CCDRmult_apcompat_r' :
-  Π x y z : X, x ≠ 0 -> y ≠ z -> x * y ≠ x * z.
+  ∏ x y z : X, x ≠ 0 -> y ≠ z -> x * y ≠ x * z.
 Proof.
   exact (CDRmult_apcompat_r' (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
 
 Lemma CCDRmultapCCDRzero :
-  Π x y : X, x * y ≠ 0 -> x ≠ 0 ∧ y ≠ 0.
+  ∏ x y : X, x * y ≠ 0 -> x ≠ 0 ∧ y ≠ 0.
 Proof.
   exact (CDRmultapCDRzero (X := ConstructiveCommutativeDivisionRig_ConstructiveDivisionRig X)).
 Qed.
@@ -423,8 +423,8 @@ End CCDR_pty.
 (** ** Constructive Field *)
 
 Definition ConstructiveField :=
-  Σ X : commrng,
-  Σ R : tightap X,
+  ∑ X : commrng,
+  ∑ R : tightap X,
         isapbinop (X := (pr1 (pr1 X)) ,, R) BinaryOperations.op1
       × isapbinop (X := (pr1 (pr1 X)) ,, R) BinaryOperations.op2
       × isConstrDivRig X R.
@@ -469,22 +469,22 @@ Section CF_pty.
 Context {X : ConstructiveField}.
 
 Lemma isirrefl_CFap :
-  Π x : X, ¬ (x ≠ x).
+  ∏ x : X, ¬ (x ≠ x).
 Proof.
   exact (isirrefl_CCDRap (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma issymm_CFap :
-  Π x y : X, x ≠ y -> y ≠ x.
+  ∏ x y : X, x ≠ y -> y ≠ x.
 Proof.
   exact (issymm_CCDRap (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma iscotrans_CFap :
-  Π x y z : X, x ≠ z -> x ≠ y ∨ y ≠ z.
+  ∏ x y z : X, x ≠ z -> x ≠ y ∨ y ≠ z.
 Proof.
   exact (iscotrans_CCDRap (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma istight_CFap :
-  Π x y : X, ¬ (x ≠ y) -> x = y.
+  ∏ x y : X, ¬ (x ≠ y) -> x = y.
 Proof.
   exact (istight_CCDRap (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
@@ -495,85 +495,85 @@ Proof.
 Qed.
 
 Lemma islunit_CFzero_CFplus :
-  Π x : X, 0 + x = x.
+  ∏ x : X, 0 + x = x.
 Proof.
   now apply rnglunax1.
 Qed.
 Lemma isrunit_CFzero_CFplus :
-  Π x : X, x + 0 = x.
+  ∏ x : X, x + 0 = x.
 Proof.
   now apply rngrunax1.
 Qed.
 Lemma isassoc_CFplus :
-  Π x y z : X, x + y + z = x + (y + z).
+  ∏ x y z : X, x + y + z = x + (y + z).
 Proof.
   now apply rngassoc1.
 Qed.
 Lemma islinv_CFopp :
-  Π x : X, - x + x = 0.
+  ∏ x : X, - x + x = 0.
 Proof.
   now apply rnglinvax1.
 Qed.
 Lemma isrinv_CFopp :
-  Π x : X, x + - x = 0.
+  ∏ x : X, x + - x = 0.
 Proof.
   now apply rngrinvax1.
 Qed.
 
 Lemma iscomm_CFplus :
-  Π x y : X, x + y = y + x.
+  ∏ x y : X, x + y = y + x.
 Proof.
   now apply rngcomm1.
 Qed.
 Lemma islunit_CFone_CFmult :
-  Π x : X, 1 * x = x.
+  ∏ x : X, 1 * x = x.
 Proof.
   now apply rnglunax2.
 Qed.
 Lemma isrunit_CFone_CFmult :
-  Π x : X, x * 1 = x.
+  ∏ x : X, x * 1 = x.
 Proof.
   now apply rngrunax2.
 Qed.
 Lemma isassoc_CFmult :
-  Π x y z : X, x * y * z = x * (y * z).
+  ∏ x y z : X, x * y * z = x * (y * z).
 Proof.
   now apply rngassoc2.
 Qed.
 Lemma iscomm_CFmult :
-  Π x y : X, x * y = y * x.
+  ∏ x y : X, x * y = y * x.
 Proof.
   now apply rngcomm2.
 Qed.
 Lemma islinv_CFinv :
-  Π (x : X) (Hx0 : x ≠ 0),
+  ∏ (x : X) (Hx0 : x ≠ 0),
     (CFinv x Hx0) * x = 1.
 Proof.
   exact (islinv_CCDRinv (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma isrinv_CFinv :
-  Π (x : X) (Hx0 : x ≠ 0),
+  ∏ (x : X) (Hx0 : x ≠ 0),
     x * (CFinv x Hx0) = 1.
 Proof.
   exact (isrinv_CCDRinv (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma islabsorb_CFzero_CFmult :
-  Π x : X, 0 * x = 0.
+  ∏ x : X, 0 * x = 0.
 Proof.
   now apply rngmult0x.
 Qed.
 Lemma israbsorb_CFzero_CFmult :
-  Π x : X, x * 0 = 0.
+  ∏ x : X, x * 0 = 0.
 Proof.
   now apply rngmultx0.
 Qed.
 Lemma isldistr_CFplus_CFmult :
-  Π x y z : X, z * (x + y) = z * x + z * y.
+  ∏ x y z : X, z * (x + y) = z * x + z * y.
 Proof.
   now apply rngdistraxs.
 Qed.
 Lemma isrdistr_CFplus_CFmult :
-  Π x y z : X, (x + y) * z = x * z + y * z.
+  ∏ x y z : X, (x + y) * z = x * z + y * z.
 Proof.
   intros.
   rewrite !(iscomm_CFmult _ z).
@@ -581,13 +581,13 @@ Proof.
 Qed.
 
 Lemma apCFplus :
-  Π x x' y y' : X,
+  ∏ x x' y y' : X,
     x + y ≠ x' + y' -> x ≠ x' ∨ y ≠ y'.
 Proof.
   exact (apCCDRplus (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma CFplus_apcompat_l :
-  Π x y z : X, y + x ≠ z + x <-> y ≠ z.
+  ∏ x y z : X, y + x ≠ z + x <-> y ≠ z.
 Proof.
   intros x y z.
   split.
@@ -599,7 +599,7 @@ Proof.
     exact Hap.
 Qed.
 Lemma CFplus_apcompat_r :
-  Π x y z : X, x + y ≠ x + z <-> y ≠ z.
+  ∏ x y z : X, x + y ≠ x + z <-> y ≠ z.
 Proof.
   intros x y z.
   rewrite !(iscomm_CFplus x).
@@ -607,34 +607,34 @@ Proof.
 Qed.
 
 Lemma apCFmult :
-  Π x x' y y' : X,
+  ∏ x x' y y' : X,
     x * y ≠ x' * y' -> x ≠ x' ∨ y ≠ y'.
 Proof.
   exact (apCCDRmult (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma CFmult_apcompat_l :
-  Π x y z : X, y * x ≠ z * x -> y ≠ z.
+  ∏ x y z : X, y * x ≠ z * x -> y ≠ z.
 Proof.
   exact (CCDRmult_apcompat_l (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma CFmult_apcompat_l' :
-  Π x y z : X, x ≠ 0 -> y ≠ z -> y * x ≠ z * x.
+  ∏ x y z : X, x ≠ 0 -> y ≠ z -> y * x ≠ z * x.
 Proof.
   exact (CCDRmult_apcompat_l' (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma CFmult_apcompat_r :
-  Π x y z : X, x * y ≠ x * z -> y ≠ z.
+  ∏ x y z : X, x * y ≠ x * z -> y ≠ z.
 Proof.
   exact (CCDRmult_apcompat_r (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 Lemma CFmult_apcompat_r' :
-  Π x y z : X, x ≠ 0 -> y ≠ z -> x * y ≠ x * z.
+  ∏ x y z : X, x ≠ 0 -> y ≠ z -> x * y ≠ x * z.
 Proof.
   exact (CCDRmult_apcompat_r' (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.
 
 Lemma CFmultapCFzero :
-  Π x y : X, x * y ≠ 0 -> x ≠ 0 ∧ y ≠ 0.
+  ∏ x y : X, x * y ≠ 0 -> x ≠ 0 ∧ y ≠ 0.
 Proof.
   exact (CCDRmultapCCDRzero (X := ConstructiveField_ConstructiveCommutativeDivisionRig X)).
 Qed.

--- a/UniMath/Algebra/DivisionRig.v
+++ b/UniMath/Algebra/DivisionRig.v
@@ -20,7 +20,7 @@ Require Export UniMath.Algebra.Domains_and_Fields.
 Definition isnonzerorig (X : rig) : UU := (1%rig : X) != 0%rig.
 
 Definition isDivRig (X : rig) : UU :=
-  isnonzerorig X × (Π x : X, x != 0%rig -> multinvpair X x).
+  isnonzerorig X × (∏ x : X, x != 0%rig -> multinvpair X x).
 
 Lemma isaprop_isDivRig (X : rig) : isaprop (isDivRig X).
 Proof.
@@ -36,7 +36,7 @@ Definition isDivRig_zero {X : rig} (is : isDivRig X) : X := 0%rig.
 Definition isDivRig_one {X : rig} (is : isDivRig X) : X := 1%rig.
 Definition isDivRig_plus {X : rig} (is : isDivRig X) : binop X := λ x y : X, (x + y)%rig.
 Definition isDivRig_mult {X : rig} (is : isDivRig X) : binop X := λ x y : X, (x * y)%rig.
-Definition isDivRig_inv {X : rig} (is : isDivRig X) : (Σ  x : X, x != isDivRig_zero is) -> X :=
+Definition isDivRig_inv {X : rig} (is : isDivRig X) : (∑  x : X, x != isDivRig_zero is) -> X :=
   λ x, pr1 ((pr2 is) (pr1 x) (pr2 x)).
 
 Definition isDivRig_isassoc_plus {X : rig} (is : isDivRig X) : isassoc (isDivRig_plus is)
@@ -56,10 +56,10 @@ Definition isDivRig_isrunit_x1 {X : rig} (is : isDivRig X) : isrunit (isDivRig_m
   := rigrunax2 X.
 
 Definition isDivRig_islinv {X : rig} (is : isDivRig X) :
-  Π (x : X) (Hx : x != isDivRig_zero is), isDivRig_mult is (isDivRig_inv is (x,, Hx)) x = isDivRig_one is
+  ∏ (x : X) (Hx : x != isDivRig_zero is), isDivRig_mult is (isDivRig_inv is (x,, Hx)) x = isDivRig_one is
   := λ (x : X) (Hx : x != isDivRig_zero is), pr1 (pr2 (pr2 is x Hx)).
 Definition isDivRig_isrinv {X : rig} (is : isDivRig X) :
-  Π (x : X) (Hx : x != isDivRig_zero is), isDivRig_mult is x (isDivRig_inv is (x,, Hx)) = isDivRig_one is
+  ∏ (x : X) (Hx : x != isDivRig_zero is), isDivRig_mult is x (isDivRig_inv is (x,, Hx)) = isDivRig_one is
   := λ (x : X) (Hx : x != isDivRig_zero is), pr2 (pr2 (pr2 is x Hx)).
 
 Definition isDivRig_isldistr {X : rig} (is : isDivRig X) : isldistr (isDivRig_plus is) (isDivRig_mult is) := rigldistr X.
@@ -68,7 +68,7 @@ Definition isDivRig_isrdistr {X : rig} (is : isDivRig X) : isrdistr (isDivRig_pl
 (** DivRig *)
 
 Definition DivRig : UU :=
-  Σ (X : rig), isDivRig X.
+  ∑ (X : rig), isDivRig X.
 Definition pr1DivRig (F : DivRig) : hSet := pr1 F.
 Coercion pr1DivRig : DivRig >-> hSet.
 
@@ -76,8 +76,8 @@ Definition zeroDivRig {F : DivRig} : F := isDivRig_zero (pr2 F).
 Definition oneDivRig {F : DivRig} : F := isDivRig_one (pr2 F).
 Definition plusDivRig {F : DivRig} : binop F := isDivRig_plus (pr2 F).
 Definition multDivRig {F : DivRig} : binop F := isDivRig_mult (pr2 F).
-Definition invDivRig {F : DivRig} : (Σ x : F, x != zeroDivRig) -> F := isDivRig_inv (pr2 F).
-Definition divDivRig {F : DivRig} : F -> (Σ x : F, x != zeroDivRig) -> F := fun x y => multDivRig x (invDivRig y).
+Definition invDivRig {F : DivRig} : (∑ x : F, x != zeroDivRig) -> F := isDivRig_inv (pr2 F).
+Definition divDivRig {F : DivRig} : F -> (∑ x : F, x != zeroDivRig) -> F := fun x y => multDivRig x (invDivRig y).
 
 Definition DivRig_isDivRig (F : DivRig) :
   isDivRig (pr1 F) := (pr2 F).
@@ -100,40 +100,40 @@ Section DivRig_pty.
 Context {F : DivRig}.
 
 Definition DivRig_isassoc_plus:
-  Π x y z : F, x + y + z = x + (y + z) :=
+  ∏ x y z : F, x + y + z = x + (y + z) :=
   isDivRig_isassoc_plus (DivRig_isDivRig F).
 Definition DivRig_islunit_zero:
-  Π x : F, 0 + x = x :=
+  ∏ x : F, 0 + x = x :=
   isDivRig_islunit_x0 (DivRig_isDivRig F).
 Definition DivRig_isrunit_zero:
-  Π x : F, x + 0 = x :=
+  ∏ x : F, x + 0 = x :=
   isDivRig_isrunit_x0 (DivRig_isDivRig F).
 Definition DivRig_iscomm_plus:
-  Π x y : F, x + y = y + x :=
+  ∏ x y : F, x + y = y + x :=
   isDivRig_iscomm_plus (DivRig_isDivRig F).
 
 Definition DivRig_isassoc_mult:
-  Π x y z : F, x * y * z = x * (y * z) :=
+  ∏ x y z : F, x * y * z = x * (y * z) :=
   isDivRig_isassoc_mult (DivRig_isDivRig F).
 Definition DivRig_islunit_one:
-  Π x : F, 1 * x = x :=
+  ∏ x : F, 1 * x = x :=
   isDivRig_islunit_x1 (DivRig_isDivRig F).
 Definition DivRig_isrunit_one:
-  Π x : F, x * 1 = x :=
+  ∏ x : F, x * 1 = x :=
   isDivRig_isrunit_x1 (DivRig_isDivRig F).
 
 Definition DivRig_islinv:
-  Π (x : F) (Hx : x != 0), / (x,, Hx) * x = 1 :=
+  ∏ (x : F) (Hx : x != 0), / (x,, Hx) * x = 1 :=
   isDivRig_islinv (DivRig_isDivRig F).
 Definition DivRig_isrinv:
-  Π (x : F) (Hx : x != 0), x * / (x,, Hx) = 1 :=
+  ∏ (x : F) (Hx : x != 0), x * / (x,, Hx) = 1 :=
   isDivRig_isrinv (DivRig_isDivRig F).
 
 Definition DivRig_isldistr:
-  Π x y z : F, z * (x + y) = z * x + z * y :=
+  ∏ x y z : F, z * (x + y) = z * x + z * y :=
   isDivRig_isldistr (DivRig_isDivRig F).
 Definition DivRig_isrdistr:
-  Π x y z : F, (x + y) * z = x * z + y * z :=
+  ∏ x y z : F, (x + y) * z = x * z + y * z :=
   isDivRig_isrdistr (DivRig_isDivRig F).
 
 End DivRig_pty.
@@ -141,7 +141,7 @@ End DivRig_pty.
 (** ** Definition of a Commutative DivRig *)
 
 Definition CommDivRig : UU :=
-  Σ (X : commrig), isDivRig X.
+  ∑ (X : commrig), isDivRig X.
 Definition CommDivRig_DivRig (F : CommDivRig) : DivRig := commrigtorig (pr1 F) ,, pr2 F.
 Coercion CommDivRig_DivRig : CommDivRig >-> DivRig.
 
@@ -152,43 +152,43 @@ Open Scope dr_scope.
 Context {F : CommDivRig}.
 
 Definition CommDivRig_isassoc_plus:
-  Π x y z : F, x + y + z = x + (y + z) :=
+  ∏ x y z : F, x + y + z = x + (y + z) :=
   DivRig_isassoc_plus.
 Definition CommDivRig_islunit_zero:
-  Π x : F, 0 + x = x :=
+  ∏ x : F, 0 + x = x :=
   DivRig_islunit_zero.
 Definition CommDivRig_isrunit_zero:
-  Π x : F, x + 0 = x :=
+  ∏ x : F, x + 0 = x :=
   DivRig_isrunit_zero.
 Definition CommDivRig_iscomm_plus:
-  Π x y : F, x + y = y + x :=
+  ∏ x y : F, x + y = y + x :=
   DivRig_iscomm_plus.
 
 Definition CommDivRig_isassoc_mult:
-  Π x y z : F, x * y * z = x * (y * z) :=
+  ∏ x y z : F, x * y * z = x * (y * z) :=
   DivRig_isassoc_mult.
 Definition CommDivRig_islunit_one:
-  Π x : F, 1 * x = x :=
+  ∏ x : F, 1 * x = x :=
   DivRig_islunit_one.
 Definition CommDivRig_isrunit_one:
-  Π x : F, x * 1 = x :=
+  ∏ x : F, x * 1 = x :=
   DivRig_isrunit_one.
 Definition CommDivRig_iscomm_mult:
-  Π x y : F, x * y = y * x :=
+  ∏ x y : F, x * y = y * x :=
   rigcomm2 (pr1 F).
 
 Definition CommDivRig_islinv:
-  Π (x : F) (Hx : x != 0), / (x,, Hx) * x = 1 :=
+  ∏ (x : F) (Hx : x != 0), / (x,, Hx) * x = 1 :=
   DivRig_islinv.
 Definition CommDivRig_isrinv:
-  Π (x : F) (Hx : x != 0), x * / (x,, Hx) = 1 :=
+  ∏ (x : F) (Hx : x != 0), x * / (x,, Hx) = 1 :=
   DivRig_isrinv.
 
 Definition CommDivRig_isldistr:
-  Π x y z : F, z * (x + y) = z * x + z * y :=
+  ∏ x y z : F, z * (x + y) = z * x + z * y :=
   DivRig_isldistr.
 Definition CommDivRig_isrdistr:
-  Π x y z : F, (x + y) * z = x * z + y * z :=
+  ∏ x y z : F, (x + y) * z = x * z + y * z :=
   DivRig_isrdistr.
 
 Close Scope dr_scope.

--- a/UniMath/Algebra/Domains_and_Fields.v
+++ b/UniMath/Algebra/Domains_and_Fields.v
@@ -36,7 +36,7 @@ Require Export UniMath.Algebra.Rigs_and_Rings.
 (** To one binary operation *)
 
 Lemma islcancelableif {X : hSet} (opp : binop X) (x : X)
-      (is : Π a b : X, paths (opp x a) (opp x b) -> paths a b) : islcancelable opp x.
+      (is : ∏ a b : X, paths (opp x a) (opp x b) -> paths a b) : islcancelable opp x.
 Proof.
   intros. apply isinclbetweensets.
   - apply (setproperty X).
@@ -45,7 +45,7 @@ Proof.
 Defined.
 
 Lemma isrcancelableif {X : hSet} (opp : binop X) (x : X)
-      (is : Π a b : X, paths (opp a x) (opp b x) -> paths a b) : isrcancelable opp x.
+      (is : ∏ a b : X, paths (opp a x) (opp b x) -> paths a b) : isrcancelable opp x.
 Proof.
   intros. apply isinclbetweensets.
   - apply (setproperty X).
@@ -54,8 +54,8 @@ Proof.
 Defined.
 
 Definition iscancelableif {X : hSet} (opp : binop X) (x : X)
-           (isl : Π a b : X, paths (opp x a) (opp x b) -> paths a b)
-           (isr : Π a b : X, paths (opp a x) (opp b x) -> paths a b) :
+           (isl : ∏ a b : X, paths (opp x a) (opp x b) -> paths a b)
+           (isr : ∏ a b : X, paths (opp a x) (opp b x) -> paths a b) :
   iscancelable opp x := dirprodpair (islcancelableif opp x isl) (isrcancelableif opp x isr).
 
 (** To monoids *)
@@ -310,7 +310,7 @@ Proof.
 Defined.
 
 Definition isintdom (X : commrng) : UU :=
-  dirprod (isnonzerorng X) (Π (a1 a2 : X), paths (a1 * a2) 0 -> hdisj (eqset a1 0) (eqset a2 0)).
+  dirprod (isnonzerorng X) (∏ (a1 a2 : X), paths (a1 * a2) 0 -> hdisj (eqset a1 0) (eqset a2 0)).
 
 Definition intdom : UU := total2 (fun X : commrng => isintdom X).
 
@@ -320,7 +320,7 @@ Coercion pr1intdom : intdom >-> commrng.
 Definition nonzeroax (X : intdom) : neg (@paths X 1 0) := pr1 (pr2 X).
 
 Definition intdomax (X : intdom) :
-  Π (a1 a2 : X), paths (a1 * a2) 0 -> hdisj (eqset a1 0) (eqset a2 0) := pr2 (pr2 X).
+  ∏ (a1 a2 : X), paths (a1 * a2) 0 -> hdisj (eqset a1 0) (eqset a2 0) := pr2 (pr2 X).
 
 
 (** **** Computational lemmas for integral domains *)
@@ -362,7 +362,7 @@ Proof.
   intros. intro e. destruct (ism (intdomax2l X n m e isn )).
 Defined.
 
-Lemma intdomlcan (X : intdom) : Π (a b c : X), neg (paths c 0) -> paths (c * a) (c * b) -> paths a b.
+Lemma intdomlcan (X : intdom) : ∏ (a b c : X), neg (paths c 0) -> paths (c * a) (c * b) -> paths a b.
 Proof.
   intros X a b c ne e.
   apply (@grtopathsxy X a b). change (paths (a - b) 0).
@@ -382,7 +382,7 @@ Proof.
 Defined.
 Opaque intdomlcan.
 
-Lemma intdomrcan (X : intdom) : Π (a b c : X), neg (paths c 0) -> paths (a * c) (b * c) -> paths a b.
+Lemma intdomrcan (X : intdom) : ∏ (a b c : X), neg (paths c 0) -> paths (a * c) (b * c) -> paths a b.
 Proof.
   intros X a b c ne e. apply (@grtopathsxy X a b). change (paths (a - b) 0).
   assert (e' := grfrompathsxy X e). change (paths ((a * c) - (b * c)) 0) in e'.
@@ -445,7 +445,7 @@ Defined.
 (** **** Main definitions *)
 
 Definition isafield (X : commrng) : UU :=
-  dirprod (isnonzerorng X) (Π x : X, coprod (multinvpair X x) (paths x 0)).
+  dirprod (isnonzerorng X) (∏ x : X, coprod (multinvpair X x) (paths x 0)).
 
 Definition fld : UU := total2 (fun X : commrng => isafield X).
 
@@ -549,7 +549,7 @@ Defined.
 Opaque nonzeroincommrngfrac.
 
 Lemma zeroincommrngfrac (X : intdom) (S : @submonoid (rngmultmonoid X))
-      (is : Π s : S, neg (paths (pr1 s) 0)) (x : X) (aa : S)
+      (is : ∏ s : S, neg (paths (pr1 s) 0)) (x : X) (aa : S)
       (e : paths (setquotpr (eqrelcommrngfrac X S) (dirprodpair x aa))
                  (setquotpr _ (dirprodpair 0 (unel S)))) : paths x 0.
 Proof.
@@ -580,7 +580,7 @@ Lemma islinvinfldfrac (X : intdom) (is : isdeceq X) (x : commrngfrac X (intdomno
       (ne : neg (paths x 0)) : paths ((fldfracmultinv0 X is x) * x) 1.
 Proof.
   intros X is.
-  assert (int : Π x0, isaprop (neg (paths x0 0) -> paths ((fldfracmultinv0 X is x0) * x0) 1)).
+  assert (int : ∏ x0, isaprop (neg (paths x0 0) -> paths ((fldfracmultinv0 X is x0) * x0) 1)).
   {
     intro x0.
     apply impred. intro.
@@ -767,7 +767,7 @@ Proof.
   set (f := weqfldfracgt_f X is is0 is1 is2 nc).
   set (g := weqfldfracgt_b X is is1 is2 ir).
   split with f.
-  assert (egf : Π a, paths (g (f a)) a).
+  assert (egf : ∏ a, paths (g (f a)) a).
   {
     unfold fldfrac. simpl.
     apply (setquotunivprop _ (fun a => hProppair _ (isasetsetquot _ (g (f a)) a))).
@@ -785,7 +785,7 @@ Proof.
       rewrite (rngrmultminus X _ _). rewrite (rnglmultminus X _ _).
       apply idpath.
   }
-  assert (efg : Π a, paths (f (g a)) a).
+  assert (efg : ∏ a, paths (f (g a)) a).
   {
     unfold fldfrac. simpl.
     apply (setquotunivprop _ (fun a => hProppair _ (isasetsetquot _ (f (g a)) a))).
@@ -816,7 +816,7 @@ Proof.
   split.
   - split.
     + unfold isbinopfun.
-      change (Π x x' : commrngfrac X (rngpossubmonoid X is1 is2),
+      change (∏ x x' : commrngfrac X (rngpossubmonoid X is1 is2),
                        paths (g (x + x')) ((g x) + (g x'))).
       apply (setquotuniv2prop
                _ (fun x x' : commrngfrac X (rngpossubmonoid X is1 is2) =>
@@ -851,7 +851,7 @@ Proof.
         simpl. apply idpath.
   - split.
     + unfold isbinopfun.
-      change (Π x x' : commrngfrac X (rngpossubmonoid X is1 is2),
+      change (∏ x x' : commrngfrac X (rngpossubmonoid X is1 is2),
                        paths (g (x * x')) ((g x) * (g x'))).
       apply (setquotuniv2prop
                _ (fun x x' : commrngfrac X (rngpossubmonoid X is1 is2) =>
@@ -1014,7 +1014,7 @@ Proof.
   intros. intros x1 x2 l.
   assert (int := iscomptocommrngfrac X (rngpossubmonoid X is1 is2) is0 is1 (fun c r => r)).
   simpl in int. unfold fldfracgt. unfold iscomprelrelfun in int.
-  assert (ee : Π x : X, paths (tocommrngfrac X (rngpossubmonoid X is1 is2) x)
+  assert (ee : ∏ x : X, paths (tocommrngfrac X (rngpossubmonoid X is1 is2) x)
                               (weqfldfracgt_f X is is0 is1 is2 nc (tofldfrac X is x))).
   {
     intros x.

--- a/UniMath/Algebra/IteratedBinaryOperations.v
+++ b/UniMath/Algebra/IteratedBinaryOperations.v
@@ -88,12 +88,12 @@ Proof.
   intros.
   induction n as [|n IH].
   - reflexivity.
-  - assert (specialcase : Π (y:stn _->M) (g : stn _ ≃ stn _), g (lastelement n) = lastelement n ->
+  - assert (specialcase : ∏ (y:stn _->M) (g : stn _ ≃ stn _), g (lastelement n) = lastelement n ->
         sequenceProduct (S n,, y) = sequenceProduct (S n,, y ∘ g)).
     { intros ? ? a. rewrite 2? sequenceProductStep. change ((_ ∘ _) _) with (y (g (lastelement n))).
       rewrite a. apply (maponpaths (λ m, m * _)). change (_ ∘ _ ∘ _) with (y ∘ (g ∘ dni_lastelement)).
       set (h := eqweqmap (maponpaths stn_compl a)).
-      assert (pr1_h : Π i, pr1 (pr1 (h i)) = pr1 (pr1 i)). { intros. induction a. reflexivity. }
+      assert (pr1_h : ∏ i, pr1 (pr1 (h i)) = pr1 (pr1 i)). { intros. induction a. reflexivity. }
       set (wc := weqdnicompl n (lastelement n)).
       set (g' := (invweq wc ∘ (h ∘ (weqoncompl_ne g (lastelement n) (stnneq _) (stnneq _) ∘ wc))) %weq).
       intermediate_path (sequenceProduct (n,, y ∘ dni_lastelement ∘ g')).

--- a/UniMath/Algebra/Lattice.v
+++ b/UniMath/Algebra/Lattice.v
@@ -6,17 +6,17 @@ A Course in Universal Algebra-With 36 Illustrations. Chapter I)
 A lattice is a set with two binary operators min and max such that:
 - min and max are associative
 - min and max are commutative
-- Π x y : X, min x (max x y) = x
-- Π x y : X, max x (min x y) = x
+- ∏ x y : X, min x (max x y) = x
+- ∏ x y : X, max x (min x y) = x
 
 In a lattice, we can define a partial order:
 - le := λ (x y : X), min is x y = x
 
 Lattice with a strict order:
 A lattice with a strict order gt is lattice such that:
-- Π (x y : X), (¬ gt x y) <-> le x y
-- Π x y z : X, gt x z → gt y z → gt (min x y) z
-- Π x y z : X, gt z x → gt z y → gt z (max is x y)
+- ∏ (x y : X), (¬ gt x y) <-> le x y
+- ∏ x y z : X, gt x z → gt y z → gt (min x y) z
+- ∏ x y z : X, gt z x → gt z y → gt z (max is x y)
 
 Lattice with a total and decidable order:
 - le is total and decidable
@@ -27,7 +27,7 @@ Lattice in an abelian monoid:
 - compatibility and cancelation of addition for le
 
 Truncated minus is a lattice:
-- a function minus such that: Π (x y : X), (minus x y) + y = max x y *)
+- a function minus such that: ∏ (x y : X), (minus x y) + y = max x y *)
 
 Require Export UniMath.Algebra.Monoids_and_Groups.
 
@@ -37,7 +37,7 @@ Unset Automatic Introduction.
 (* todo : move it into UniMath.Foundations.Sets *)
 
 Definition isStrongOrder {X : UU} (R : hrel X) := istrans R × iscotrans R × isirrefl R.
-Definition StrongOrder (X : UU) := Σ R : hrel X, isStrongOrder R.
+Definition StrongOrder (X : UU) := ∑ R : hrel X, isStrongOrder R.
 Definition pairStrongOrder {X : UU} (R : hrel X) (is : isStrongOrder R) : StrongOrder X :=
   tpair (fun R : hrel X => isStrongOrder R ) R is.
 Definition pr1StrongOrder {X : UU} : StrongOrder X → hrel X := pr1.
@@ -78,9 +78,9 @@ Definition StrongOrder_setquot {X : UU} {R : eqrel X} {L : StrongOrder X} (is : 
 Definition latticeop {X : hSet} (min max : binop X) :=
   ((isassoc min) × (iscomm min))
     × ((isassoc max) × (iscomm max))
-    × (Π x y : X, min x (max x y) = x)
-    × (Π x y : X, max x (min x y) = x).
-Definition lattice (X : hSet) := Σ min max : binop X, latticeop min max.
+    × (∏ x y : X, min x (max x y) = x)
+    × (∏ x y : X, max x (min x y) = x).
+Definition lattice (X : hSet) := ∑ min max : binop X, latticeop min max.
 
 Definition mklattice {X : hSet} {min max : binop X} : latticeop min max → lattice X :=
   λ (is : latticeop min max), min,, max ,, is.
@@ -102,14 +102,14 @@ Definition isassoc_Lmax : isassoc (Lmax is) :=
 Definition iscomm_Lmax : iscomm (Lmax is) :=
   pr2 (pr1 (pr2 (pr2 (pr2 is)))).
 Definition Lmin_absorb :
-  Π x y : X, Lmin is x (Lmax is x y) = x :=
+  ∏ x y : X, Lmin is x (Lmax is x y) = x :=
   pr1 (pr2 (pr2 (pr2 (pr2 is)))).
 Definition Lmax_absorb :
-  Π x y : X, Lmax is x (Lmin is x y) = x :=
+  ∏ x y : X, Lmax is x (Lmin is x y) = x :=
   pr2 (pr2 (pr2 (pr2 (pr2 is)))).
 
 Lemma Lmin_id :
-  Π x : X, Lmin is x x = x.
+  ∏ x : X, Lmin is x x = x.
 Proof.
   intros x.
   apply (pathscomp0 (b := Lmin is x (Lmax is x (Lmin is x x)))).
@@ -117,7 +117,7 @@ Proof.
   - apply Lmin_absorb.
 Qed.
 Lemma Lmax_id :
-  Π x : X, Lmax is x x = x.
+  ∏ x : X, Lmax is x x = x.
 Proof.
   intros x.
   apply (pathscomp0 (b := Lmax is x (Lmin is x (Lmax is x x)))).
@@ -167,7 +167,7 @@ Proof.
 Qed.
 
 Lemma Lmin_le_l :
-  Π x y : X, Lle is (Lmin is x y) x.
+  ∏ x y : X, Lle is (Lmin is x y) x.
 Proof.
   intros x y.
   simpl.
@@ -175,14 +175,14 @@ Proof.
   reflexivity.
 Qed.
 Lemma Lmin_le_r :
-  Π x y : X, Lle is (Lmin is x y) y.
+  ∏ x y : X, Lle is (Lmin is x y) y.
 Proof.
   intros x y.
   rewrite iscomm_Lmin.
   apply Lmin_le_l.
 Qed.
 Lemma Lmin_le_case :
-  Π x y z : X, Lle is z x → Lle is z y → Lle is z (Lmin is x y).
+  ∏ x y z : X, Lle is z x → Lle is z y → Lle is z (Lmin is x y).
 Proof.
   intros x y z <- <-.
   simpl.
@@ -194,14 +194,14 @@ Proof.
 Qed.
 
 Lemma Lmax_le_l :
-  Π x y : X, Lle is x (Lmax is x y).
+  ∏ x y : X, Lle is x (Lmax is x y).
 Proof.
   intros x y.
   simpl.
   apply Lmin_absorb.
 Qed.
 Lemma Lmax_le_r :
-  Π x y : X, Lle is y (Lmax is x y).
+  ∏ x y : X, Lle is y (Lmax is x y).
 Proof.
   intros x y.
   rewrite iscomm_Lmax.
@@ -209,7 +209,7 @@ Proof.
 Qed.
 Lemma Lmax_le_case :
   isrdistr (Lmax is) (Lmin is)
-  → Π x y z : X, Lle is x z → Lle is y z → Lle is (Lmax is x y) z.
+  → ∏ x y z : X, Lle is x z → Lle is y z → Lle is (Lmax is x y) z.
 Proof.
   intros H x y z <- <-.
   rewrite <- H.
@@ -217,13 +217,13 @@ Proof.
 Qed.
 
 Lemma Lmin_le_eq_l :
-  Π x y : X, Lle is x y → Lmin is x y = x.
+  ∏ x y : X, Lle is x y → Lmin is x y = x.
 Proof.
   intros x y H.
   apply H.
 Qed.
 Lemma Lmin_le_eq_r :
-  Π x y : X, Lle is y x → Lmin is x y = y.
+  ∏ x y : X, Lle is y x → Lmin is x y = y.
 Proof.
   intros x y H.
   rewrite iscomm_Lmin.
@@ -231,14 +231,14 @@ Proof.
 Qed.
 
 Lemma Lmax_le_eq_l :
-  Π x y : X, Lle is y x → Lmax is x y = x.
+  ∏ x y : X, Lle is y x → Lmax is x y = x.
 Proof.
   intros x y <-.
   rewrite iscomm_Lmin.
   apply Lmax_absorb.
 Qed.
 Lemma Lmax_le_eq_r :
-  Π x y : X, Lle is x y → Lmax is x y = y.
+  ∏ x y : X, Lle is x y → Lmax is x y = y.
 Proof.
   intros x y H.
   rewrite iscomm_Lmax.
@@ -285,39 +285,39 @@ Proof.
 Qed.
 
 Definition Lmin_ge_l :
-  Π (x y : X), Lge is x (Lmin is x y) :=
+  ∏ (x y : X), Lge is x (Lmin is x y) :=
   Lmin_le_l is.
 Definition Lmin_ge_r :
-  Π (x y : X), Lge is y (Lmin is x y) :=
+  ∏ (x y : X), Lge is y (Lmin is x y) :=
   Lmin_le_r is.
 Definition Lmin_ge_case :
-  Π (x y z : X),
+  ∏ (x y z : X),
   Lge is x z → Lge is y z → Lge is (Lmin is x y) z :=
   Lmin_le_case is.
 
 Definition Lmax_ge_l :
-  Π (x y : X), Lge is (Lmax is x y) x :=
+  ∏ (x y : X), Lge is (Lmax is x y) x :=
   Lmax_le_l is.
 Definition Lmax_ge_r :
-  Π (x y : X), Lge is (Lmax is x y) y :=
+  ∏ (x y : X), Lge is (Lmax is x y) y :=
   Lmax_le_r is.
 Definition Lmax_ge_case :
   isrdistr (Lmax is) (Lmin is)
-  → Π x y z : X, Lge is z x → Lge is z y → Lge is z (Lmax is x y) :=
+  → ∏ x y z : X, Lge is z x → Lge is z y → Lge is z (Lmax is x y) :=
   Lmax_le_case is.
 
 Definition Lmin_ge_eq_l :
-  Π (x y : X), Lge is y x → Lmin is x y = x :=
+  ∏ (x y : X), Lge is y x → Lmin is x y = x :=
   Lmin_le_eq_l is.
 Definition Lmin_ge_eq_r :
-  Π (x y : X), Lge is x y → Lmin is x y = y :=
+  ∏ (x y : X), Lge is x y → Lmin is x y = y :=
   Lmin_le_eq_r is.
 
 Definition Lmax_ge_eq_l :
-  Π (x y : X), Lge is x y → Lmax is x y = x :=
+  ∏ (x y : X), Lge is x y → Lmax is x y = x :=
   Lmax_le_eq_l is.
 Definition Lmax_ge_eq_r :
-  Π (x y : X), Lge is y x → Lmax is x y = y :=
+  ∏ (x y : X), Lge is y x → Lmax is x y = y :=
   Lmax_le_eq_r is.
 
 End Lge_pty.
@@ -325,12 +325,12 @@ End Lge_pty.
 (** ** Lattice with a strong order *)
 
 Definition latticewithgtrel {X : hSet} (is : lattice X) (gt : StrongOrder X) :=
-  (Π x y : X, (¬ (gt x y)) <-> Lle is x y)
-    × (Π x y z : X, gt x z → gt y z → gt (Lmin is x y) z)
-    × (Π x y z : X, gt z x → gt z y → gt z (Lmax is x y)).
+  (∏ x y : X, (¬ (gt x y)) <-> Lle is x y)
+    × (∏ x y z : X, gt x z → gt y z → gt (Lmin is x y) z)
+    × (∏ x y z : X, gt z x → gt z y → gt z (Lmax is x y)).
 
 Definition latticewithgt (X : hSet) :=
-  Σ (is : lattice X) (gt : StrongOrder X), latticewithgtrel is gt.
+  ∑ (is : lattice X) (gt : StrongOrder X), latticewithgtrel is gt.
 
 Definition lattice_latticewithgt {X : hSet} : latticewithgt X → lattice X :=
   pr1.
@@ -347,10 +347,10 @@ Context {X : hSet}
         (is : latticewithgt X).
 
 Definition notLgt_Lle :
-  Π x y : X, (¬ Lgt is x y) → Lle is x y :=
+  ∏ x y : X, (¬ Lgt is x y) → Lle is x y :=
   λ x y : X, pr1 (pr1 (pr2 (pr2 is)) x y).
 Definition Lle_notLgt :
-  Π x y : X, Lle is x y → ¬ Lgt is x y :=
+  ∏ x y : X, Lle is x y → ¬ Lgt is x y :=
   λ x y : X, pr2 (pr1 (pr2 (pr2 is)) x y).
 
 Definition isirrefl_Lgt : isirrefl (Lgt is) :=
@@ -363,7 +363,7 @@ Definition isasymm_Lgt : isasymm (Lgt is) :=
   isasymm_StrongOrder (Lgt is).
 
 Lemma Lgt_Lge :
-  Π x y : X, Lgt is x y → Lge is x y.
+  ∏ x y : X, Lgt is x y → Lge is x y.
 Proof.
   intros x y H.
   apply notLgt_Lle.
@@ -374,7 +374,7 @@ Proof.
 Qed.
 
 Lemma istrans_Lgt_Lge :
-  Π x y z : X, Lgt is x y → Lge is y z → Lgt is x z.
+  ∏ x y z : X, Lgt is x y → Lge is y z → Lgt is x z.
 Proof.
   intros x y z Hgt Hge.
   generalize (iscotrans_Lgt _ z _ Hgt).
@@ -387,7 +387,7 @@ Proof.
     exact H.
 Qed.
 Lemma istrans_Lge_Lgt :
-  Π x y z : X, Lge is x y → Lgt is y z → Lgt is x z.
+  ∏ x y z : X, Lge is x y → Lgt is y z → Lgt is x z.
 Proof.
   intros x y z Hge Hgt.
   generalize (iscotrans_Lgt _ x _ Hgt).
@@ -401,11 +401,11 @@ Proof.
 Qed.
 
 Definition Lmin_Lgt :
-  Π x y z : X, Lgt is x z → Lgt is y z → Lgt is (Lmin is x y) z :=
+  ∏ x y z : X, Lgt is x z → Lgt is y z → Lgt is (Lmin is x y) z :=
   pr1 (pr2 (pr2 (pr2 is))).
 
 Definition Lmax_Lgt :
-  Π x y z : X, Lgt is z x → Lgt is z y → Lgt is z (Lmax is x y) :=
+  ∏ x y z : X, Lgt is z x → Lgt is z y → Lgt is z (Lmax is x y) :=
   pr2 (pr2 (pr2 (pr2 is))).
 
 End latticewithgt_pty.
@@ -413,7 +413,7 @@ End latticewithgt_pty.
 (** ** Lattice with a total order *)
 
 Definition latticedec (X : hSet) :=
-  Σ is : lattice X, istotal (Lle is) × (isdecrel (Lle is)).
+  ∑ is : lattice X, istotal (Lle is) × (isdecrel (Lle is)).
 Definition lattice_latticedec {X : hSet} (is : latticedec X) : lattice X :=
   pr1 is.
 Coercion lattice_latticedec : latticedec >-> lattice.
@@ -428,7 +428,7 @@ Context {X : hSet}
         (is : latticedec X).
 
 Lemma Lmin_case_strong :
-  Π (P : X → UU) (x y : X),
+  ∏ (P : X → UU) (x y : X),
   (Lle is x y → P x) → (Lle is y x → P y) → P (Lmin is x y).
 Proof.
   intros P x y Hx Hy.
@@ -447,7 +447,7 @@ Proof.
       exact H0.
 Qed.
 Lemma Lmin_case :
-  Π (P : X → UU) (x y : X),
+  ∏ (P : X → UU) (x y : X),
   P x → P y → P (Lmin is x y).
 Proof.
   intros P x y Hx Hy.
@@ -457,7 +457,7 @@ Proof.
 Qed.
 
 Lemma Lmax_case_strong :
-  Π (P : X → UU) (x y : X),
+  ∏ (P : X → UU) (x y : X),
   (Lle is y x → P x) → (Lle is x y → P y) → P (Lmax is x y).
 Proof.
   intros P x y Hx Hy.
@@ -476,7 +476,7 @@ Proof.
       exact H0.
 Qed.
 Lemma Lmax_case :
-  Π (P : X → UU) (x y : X),
+  ∏ (P : X → UU) (x y : X),
   P x → P y → P (Lmax is x y).
 Proof.
   intros P x y Hx Hy.
@@ -498,7 +498,7 @@ Definition latticedec_gt_rel : hrel X :=
   λ x y, hneg (Lle is x y).
 
 Lemma latticedec_gt_ge :
-  Π x y : X, latticedec_gt_rel x y → Lge is x y.
+  ∏ x y : X, latticedec_gt_rel x y → Lge is x y.
 Proof.
   intros x y Hxy.
   generalize (istotal_latticedec is x y).
@@ -545,7 +545,7 @@ Proof.
 Defined.
 
 Lemma latticedec_notgtle :
-  Π (x y : X), ¬ latticedec_gt_so x y → Lle is x y.
+  ∏ (x y : X), ¬ latticedec_gt_so x y → Lle is x y.
 Proof.
   intros x y H.
   induction (isdecrel_latticedec is x y) as [H0 | H0].
@@ -555,14 +555,14 @@ Proof.
 Qed.
 
 Lemma latticedec_lenotgt :
-  Π (x y : X), Lle is x y → ¬ latticedec_gt_so x y.
+  ∏ (x y : X), Lle is x y → ¬ latticedec_gt_so x y.
 Proof.
   intros x y H H0.
   apply H0, H.
 Qed.
 
 Lemma latticedec_gtmin :
-  Π (x y z : X),
+  ∏ (x y z : X),
   latticedec_gt_so x z
   → latticedec_gt_so y z → latticedec_gt_so (Lmin is x y) z.
 Proof.
@@ -573,7 +573,7 @@ Proof.
 Qed.
 
 Lemma latticedec_gtmax :
-  Π (x y z : X),
+  ∏ (x y z : X),
   latticedec_gt_so z x
   → latticedec_gt_so z y → latticedec_gt_so z (Lmax is x y).
 Proof.
@@ -604,18 +604,18 @@ Section lattice_abmonoid.
 
 Context {X : abmonoid}
         (is : lattice X)
-        (is0 : Π x y z : X, y + x = z + x → y = z)
+        (is0 : ∏ x y z : X, y + x = z + x → y = z)
         (is2 : isrdistr (Lmin is) op).
 
 Lemma op_le_r :
-  Π k x y : X, Lle is x y → Lle is (x + k) (y + k).
+  ∏ k x y : X, Lle is x y → Lle is (x + k) (y + k).
 Proof.
   intros k x y H.
   unfold Lle ; simpl.
   now rewrite <- is2, H.
 Qed.
 Lemma op_le_r' :
-  Π k x y : X, Lle is (x + k) (y + k) → Lle is x y.
+  ∏ k x y : X, Lle is (x + k) (y + k) → Lle is x y.
 Proof.
   intros k x y H.
   apply (is0 k).
@@ -627,7 +627,7 @@ End lattice_abmonoid.
 (** ** Truncated minus *)
 
 Definition istruncminus {X : abmonoid} (is : lattice X) (minus : binop X) :=
-  Π x y : X, minus x y + y = Lmax is x y.
+  ∏ x y : X, minus x y + y = Lmax is x y.
 Lemma isaprop_istruncminus {X : abmonoid} (is : lattice X) (minus : binop X) :
   isaprop (istruncminus is minus).
 Proof.
@@ -638,9 +638,9 @@ Proof.
 Qed.
 
 Definition extruncminus {X : abmonoid} (is : lattice X) :=
-  Σ minus : binop X, istruncminus is minus.
+  ∑ minus : binop X, istruncminus is minus.
 Lemma isaprop_extruncminus {X : abmonoid} (is : lattice X)
-      (Hop : Π x y z : X, y + x = z + x → y = z) :
+      (Hop : ∏ x y z : X, y + x = z + x → y = z) :
   isaprop (extruncminus is).
 Proof.
   intros X is Hop.
@@ -666,7 +666,7 @@ Definition truncminus {X : abmonoid} {is : lattice X} (ex : extruncminus is) : b
   pr1 ex.
 
 Lemma istruncminus_ex {X : abmonoid} {is : lattice X} (ex : extruncminus is) :
-  Π x y : X, truncminus ex x y + y = Lmax is x y.
+  ∏ x y : X, truncminus ex x y + y = Lmax is x y.
 Proof.
   intros X is ex.
   apply (pr2 ex).
@@ -677,14 +677,14 @@ Section truncminus_pty.
 Context {X : abmonoid}
         {is : lattice X}
         (ex : extruncminus is)
-        (is1 : Π x y z : X, y + x = z + x → y = z)
+        (is1 : ∏ x y z : X, y + x = z + x → y = z)
         (is2 : isrdistr (Lmax is) op)
         (is3 : isrdistr (Lmin is) op)
         (is4 : isrdistr (Lmin is) (Lmax is))
         (is5 : isrdistr (Lmax is) (Lmin is)).
 
 Lemma truncminus_0_r :
-  Π x : X, truncminus ex x 0 = Lmax is x 0.
+  ∏ x : X, truncminus ex x 0 = Lmax is x 0.
 Proof.
   intros x.
   rewrite <- (runax _ (truncminus _ _ _)).
@@ -692,7 +692,7 @@ Proof.
 Qed.
 
 Lemma truncminus_eq_0 :
-  Π x y : X, Lle is x y → truncminus ex x y = 0.
+  ∏ x y : X, Lle is x y → truncminus ex x y = 0.
 Proof.
   intros x y H.
   apply (is1 y).
@@ -701,13 +701,13 @@ Proof.
 Qed.
 
 Lemma truncminus_0_l_ge0 :
-  Π x : X, Lle is 0 x → truncminus ex 0 x = 0.
+  ∏ x : X, Lle is 0 x → truncminus ex 0 x = 0.
 Proof.
   intros x Hx.
   apply truncminus_eq_0, Hx.
 Qed.
 Lemma truncminus_0_l_le0 :
-  Π x : X, Lle is x 0 → truncminus ex 0 x + x = 0.
+  ∏ x : X, Lle is x 0 → truncminus ex 0 x + x = 0.
 Proof.
   intros x Hx.
   rewrite istruncminus_ex.
@@ -715,7 +715,7 @@ Proof.
 Qed.
 
 Lemma truncminus_ge_0 :
-  Π x y : X, Lle is 0 (truncminus ex x y).
+  ∏ x y : X, Lle is 0 (truncminus ex x y).
 Proof.
   intros x y.
   apply (op_le_r' _ is1 is3 y).
@@ -724,7 +724,7 @@ Proof.
 Qed.
 
 Lemma truncminus_le :
-  Π x y : X,
+  ∏ x y : X,
           Lle is 0 x → Lle is 0 y
           → Lle is (truncminus ex x y) x.
 Proof.
@@ -745,7 +745,7 @@ Proof.
 Qed.
 
 Lemma truncminus_truncminus :
-  Π x y, Lle is 0 x → Lle is x y → truncminus ex y (truncminus ex y x) = x.
+  ∏ x y, Lle is 0 x → Lle is x y → truncminus ex y (truncminus ex y x) = x.
 Proof.
   intros x y Hx Hxy.
   apply (is1 (truncminus ex y x)).
@@ -761,7 +761,7 @@ Proof.
 Qed.
 
 Lemma truncminus_le_r :
-  Π k x y : X, Lle is x y → Lle is (truncminus ex x k) (truncminus ex y k).
+  ∏ k x y : X, Lle is x y → Lle is (truncminus ex x k) (truncminus ex y k).
 Proof.
   intros k x y <-.
   apply (is1 k).
@@ -770,7 +770,7 @@ Proof.
   reflexivity.
 Qed.
 Lemma truncminus_le_l :
-  Π k x y : X, Lle is y x → Lle is (truncminus ex k x) (truncminus ex k y).
+  ∏ k x y : X, Lle is y x → Lle is (truncminus ex k x) (truncminus ex k y).
 Proof.
   intros k x y H.
   apply (is1 y).
@@ -782,7 +782,7 @@ Proof.
 Qed.
 
 Lemma truncminus_Lmax_l :
-  Π (k x y : X),
+  ∏ (k x y : X),
   truncminus ex (Lmax is x y) k = Lmax is (truncminus ex x k) (truncminus ex y k).
 Proof.
   intros k x y.
@@ -792,7 +792,7 @@ Proof.
   reflexivity.
 Qed.
 Lemma truncminus_Lmax_r :
-  Π (k x y : X),
+  ∏ (k x y : X),
   Lle is (Lmin is (y + y) (x + x)) (x + y) →
   truncminus ex k (Lmax is x y) = Lmin is (truncminus ex k x) (truncminus ex k y).
 Proof.
@@ -835,7 +835,7 @@ Proof.
 Qed.
 
 Lemma truncminus_Lmin_l :
-  Π k x y : X, truncminus ex (Lmin is x y) k = Lmin is (truncminus ex x k) (truncminus ex y k).
+  ∏ k x y : X, truncminus ex (Lmin is x y) k = Lmin is (truncminus ex x k) (truncminus ex y k).
 Proof.
   intros k x y.
   apply (is1 k).
@@ -859,11 +859,11 @@ Section truncminus_gt.
 Context {X : abmonoid}
         (is : latticewithgt X)
         (ex : extruncminus is)
-        (is0 : Π x y z : X, Lgt is y z → Lgt is (y + x) (z + x))
-        (is1 : Π x y z : X, Lgt is (y + x) (z + x) → Lgt is y z).
+        (is0 : ∏ x y z : X, Lgt is y z → Lgt is (y + x) (z + x))
+        (is1 : ∏ x y z : X, Lgt is (y + x) (z + x) → Lgt is y z).
 
 Lemma truncminus_pos :
-  Π x y : X, Lgt is x y → Lgt is (truncminus ex x y) 0.
+  ∏ x y : X, Lgt is x y → Lgt is (truncminus ex x y) 0.
 Proof.
   intros x y.
   intros H.
@@ -875,7 +875,7 @@ Proof.
 Qed.
 
 Lemma truncminus_pos' :
-  Π x y : X, Lgt is (truncminus ex x y) 0 → Lgt is x y.
+  ∏ x y : X, Lgt is (truncminus ex x y) 0 → Lgt is x y.
 Proof.
   intros x y Hgt.
   apply (is0 y) in Hgt.

--- a/UniMath/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Algebra/Monoids_and_Groups.v
@@ -69,11 +69,11 @@ Require Export UniMath.Algebra.BinaryOperations.
 Definition monoid : UU := total2 (fun X : setwithbinop => ismonoidop (@op X)).
 
 Definition monoidpair :
-  Π (t : setwithbinop), (λ X : setwithbinop, ismonoidop op) t → Σ X : setwithbinop, ismonoidop op :=
+  ∏ (t : setwithbinop), (λ X : setwithbinop, ismonoidop op) t → ∑ X : setwithbinop, ismonoidop op :=
   tpair (fun X : setwithbinop => ismonoidop (@op X)).
 
 Definition monoidconstr :
-  Π (t : setwithbinop), (λ X : setwithbinop, ismonoidop op) t → Σ X : setwithbinop, ismonoidop op :=
+  ∏ (t : setwithbinop), (λ X : setwithbinop, ismonoidop op) t → ∑ X : setwithbinop, ismonoidop op :=
   monoidpair.
 
 Definition pr1monoid : monoid -> setwithbinop := @pr1 _ _.
@@ -209,7 +209,7 @@ Defined.
 Definition submonoid {X : monoid} : UU := total2 (fun A : hsubtype X => issubmonoid A).
 
 Definition submonoidpair {X : monoid} :
-  Π (t : hsubtype X), (λ A : hsubtype X, issubmonoid A) t → Σ A : hsubtype X, issubmonoid A :=
+  ∏ (t : hsubtype X), (λ A : hsubtype X, issubmonoid A) t → ∑ A : hsubtype X, issubmonoid A :=
   tpair (fun A : hsubtype X => issubmonoid A).
 
 Definition submonoidconstr {X : monoid} := @submonoidpair X.
@@ -321,13 +321,13 @@ Defined.
 Definition abmonoid : UU := total2 (fun X : setwithbinop => isabmonoidop (@op X)).
 
 Definition abmonoidpair :
-  Π (t : setwithbinop), (λ X : setwithbinop, isabmonoidop op) t →
-                        Σ X : setwithbinop, isabmonoidop op :=
+  ∏ (t : setwithbinop), (λ X : setwithbinop, isabmonoidop op) t →
+                        ∑ X : setwithbinop, isabmonoidop op :=
   tpair (fun X : setwithbinop => isabmonoidop (@op X)).
 
 Definition abmonoidconstr :
-  Π (t : setwithbinop), (λ X : setwithbinop, isabmonoidop op) t →
-                        Σ X : setwithbinop, isabmonoidop op := abmonoidpair.
+  ∏ (t : setwithbinop), (λ X : setwithbinop, isabmonoidop op) t →
+                        ∑ X : setwithbinop, isabmonoidop op := abmonoidpair.
 
 Definition abmonoidtomonoid : abmonoid -> monoid :=
   fun X : _ => monoidpair (pr1 X) (pr1 (pr2 X)).
@@ -505,7 +505,7 @@ Definition prabmonoidfrac (X : abmonoid) (A : @submonoid X) : X -> A -> abmonoid
  machinery? See also [abmonoidfracisbinoprelint] below. *)
 
 Lemma invertibilityinabmonoidfrac (X : abmonoid) (A : @submonoid X) :
-  Π a a' : A, isinvertible (@op (abmonoidfrac X A)) (prabmonoidfrac X A (pr1 a) a').
+  ∏ a a' : A, isinvertible (@op (abmonoidfrac X A)) (prabmonoidfrac X A (pr1 a) a').
 Proof.
   intros. set (R := eqrelabmonoidfrac X A). unfold isinvertible.
   assert (isl : islinvertible (@op (abmonoidfrac X A))
@@ -514,7 +514,7 @@ Proof.
     unfold islinvertible.
     set (f := fun x0 : abmonoidfrac X A => prabmonoidfrac X A (pr1 a) a' + x0).
     set (g := fun x0 : abmonoidfrac X A => prabmonoidfrac X A (pr1 a') a + x0).
-    assert (egf : Π x0 : _, paths (g (f x0)) x0).
+    assert (egf : ∏ x0 : _, paths (g (f x0)) x0).
     {
       apply (setquotunivprop R (fun x0 : abmonoidfrac X A => eqset (g (f x0)) x0)).
       intro xb. simpl.
@@ -534,7 +534,7 @@ Proof.
       simpl in e. destruct e.
       apply idpath.
     }
-    assert (efg : Π x0 : _, paths (f (g x0)) x0).
+    assert (efg : ∏ x0 : _, paths (f (g x0)) x0).
     {
       apply (setquotunivprop R (fun x0 : abmonoidfrac X A => eqset (f (g x0)) x0)).
       intro xb. simpl.
@@ -593,7 +593,7 @@ Definition hrel0abmonoidfrac (X : abmonoid) (A : @submonoid X) : hrel (dirprod X
   fun xa yb : setdirprod X A => eqset ((pr1 xa) + (pr1 (pr2 yb))) ((pr1 yb) + (pr1 (pr2 xa))).
 
 Lemma weqhrelhrel0abmonoidfrac (X : abmonoid) (A : @submonoid X)
-      (iscanc : Π a : A, isrcancelable (@op X) (pr1carrier _ a))
+      (iscanc : ∏ a : A, isrcancelable (@op X) (pr1carrier _ a))
       (xa xa' : dirprod X A) : weq (eqrelabmonoidfrac X A xa xa') (hrel0abmonoidfrac X A xa xa').
 Proof.
   intros. unfold eqrelabmonoidfrac. unfold hrelabmonoidfrac. simpl.
@@ -607,8 +607,8 @@ Proof.
 Defined.
 
 Lemma isinclprabmonoidfrac (X : abmonoid) (A : @submonoid X)
-      (iscanc : Π a : A, isrcancelable (@op X) (pr1carrier _ a)) :
-  Π a' : A, isincl (fun x => prabmonoidfrac X A x a').
+      (iscanc : ∏ a : A, isrcancelable (@op X) (pr1carrier _ a)) :
+  ∏ a' : A, isincl (fun x => prabmonoidfrac X A x a').
 Proof.
   intros. apply isinclbetweensets.
   - apply (setproperty X).
@@ -623,11 +623,11 @@ Proof.
 Defined.
 
 Definition isincltoabmonoidfrac (X : abmonoid) (A : @submonoid X)
-           (iscanc : Π a : A, isrcancelable (@op X) (pr1carrier _ a)) :
+           (iscanc : ∏ a : A, isrcancelable (@op X) (pr1carrier _ a)) :
   isincl (toabmonoidfrac X A) := isinclprabmonoidfrac X A iscanc (unel A).
 
 Lemma isdeceqabmonoidfrac (X : abmonoid) (A : @submonoid X)
-      (iscanc : Π a : A, isrcancelable (@op X) (pr1carrier _ a)) (is : isdeceq X) :
+      (iscanc : ∏ a : A, isrcancelable (@op X) (pr1carrier _ a)) (is : isdeceq X) :
   isdeceq (abmonoidfrac X A).
 Proof.
   intros. apply (isdeceqsetquot (eqrelabmonoidfrac X A)). intros xa xa'.
@@ -963,7 +963,7 @@ Lemma isantisymmnegabmonoidfracrel (X : abmonoid) (A : @subabmonoid X) {L : hrel
       (is : ispartbinophrel A L) (isl : isantisymmneg L) : isantisymmneg (abmonoidfracrel X A is).
 Proof.
   intros.
-  assert (int : Π x1 x2, isaprop (neg (abmonoidfracrel X A is x1 x2) ->
+  assert (int : ∏ x1 x2, isaprop (neg (abmonoidfracrel X A is x1 x2) ->
                                   neg (abmonoidfracrel X A is x2 x1) ->
                                   paths x1 x2)).
   {
@@ -993,7 +993,7 @@ Proof.
   intros.
   set (assoc := (assocax X) : isassoc (@op X)). unfold isassoc in assoc.
   set (comm := commax X). unfold iscomm in comm. unfold isantisymm.
-  assert (int : Π x1 x2, isaprop ((abmonoidfracrel X A is x1 x2) ->
+  assert (int : ∏ x1 x2, isaprop ((abmonoidfracrel X A is x1 x2) ->
                                   (abmonoidfracrel X A is x2 x1) ->
                                   paths x1 x2)).
   {
@@ -1063,7 +1063,7 @@ Opaque ispartbinopabmonoidfracrelint.
 
 (* ??? Coq 8.4-8.5 trunk hangs here on the following line:
 
-Axiom ispartlbinopabmonoidfracrel : Π (X : abmonoid) (A : @subabmonoid X)
+Axiom ispartlbinopabmonoidfracrel : ∏ (X : abmonoid) (A : @subabmonoid X)
  {L : hrel X} (is : ispartbinophrel A L) (aa aa' : A)
  (z z' : abmonoidfrac X A) (l : abmonoidfracrel X A is z z'),
 abmonoidfracrel X A is ((prabmonoidfrac X A (pr1 aa) aa') + z)
@@ -1081,7 +1081,7 @@ Proof.
   set (assoc := (assocax X) : isassoc (@op X)). unfold isassoc in assoc.
   set (comm := commax X). unfold iscomm in comm.
   set (rer := abmonoidrer X).
-  assert (int : Π z z', isaprop (abmonoidfracrel X A is z z' ->
+  assert (int : ∏ z z', isaprop (abmonoidfracrel X A is z z' ->
                                  abmonoidfracrel
                                    X A is (prabmonoidfrac X A (pr1 aa) aa' + z)
                                    (prabmonoidfrac X A (pr1 aa) aa' + z'))).
@@ -1120,7 +1120,7 @@ Proof.
   set (assoc := (assocax X) : isassoc (@op X)). unfold isassoc in assoc.
   set (comm := commax X). unfold iscomm in comm.
   set (rer := abmonoidrer X).
-  assert (int : Π (z z' : abmonoidfrac X A),
+  assert (int : ∏ (z z' : abmonoidfrac X A),
                 isaprop (abmonoidfracrel X A is z z' ->
                          abmonoidfracrel X A is
                                          (z + (prabmonoidfrac X A (pr1 aa) aa'))
@@ -1156,7 +1156,7 @@ Opaque ispartrbinopabmonoidfracrel.
 
 Lemma abmonoidfracrelimpl (X : abmonoid) (A : @subabmonoid X) {L L' : hrel X}
       (is : ispartbinophrel A L) (is' : ispartbinophrel A L')
-      (impl : Π x x', L x x' -> L' x x') (x x' : abmonoidfrac X A)
+      (impl : ∏ x x', L x x' -> L' x x') (x x' : abmonoidfrac X A)
       (ql : abmonoidfracrel X A is x x') : abmonoidfracrel X A is' x x'.
 Proof.
   intros. generalize ql. apply quotrelimpl. intros x0 x0'.
@@ -1167,7 +1167,7 @@ Opaque abmonoidfracrelimpl.
 
 Lemma abmonoidfracrellogeq (X : abmonoid) (A : @subabmonoid X) {L L' : hrel X}
       (is : ispartbinophrel A L) (is' : ispartbinophrel A L')
-      (lg : Π x x', L x x' <-> L' x x') (x x' : abmonoidfrac X A) :
+      (lg : ∏ x x', L x x' <-> L' x x') (x x' : abmonoidfrac X A) :
   (abmonoidfracrel X A is x x') <-> (abmonoidfracrel X A is' x x').
 Proof.
   intros. apply quotrellogeq. intros x0 x0'. split.
@@ -1231,11 +1231,11 @@ Close Scope addmonoid_scope.
 Definition gr : UU := total2 (fun X : setwithbinop =>  isgrop (@op X)).
 
 Definition grpair :
-  Π (t : setwithbinop), (λ X : setwithbinop, isgrop op) t → Σ X : setwithbinop, isgrop op :=
+  ∏ (t : setwithbinop), (λ X : setwithbinop, isgrop op) t → ∑ X : setwithbinop, isgrop op :=
   tpair (fun X : setwithbinop => isgrop (@op X)).
 
 Definition grconstr :
-  Π (t : setwithbinop), (λ X : setwithbinop, isgrop op) t → Σ X : setwithbinop, isgrop op :=
+  ∏ (t : setwithbinop), (λ X : setwithbinop, isgrop op) t → ∑ X : setwithbinop, isgrop op :=
   grpair.
 
 Definition grtomonoid : gr -> monoid := fun X : _ => monoidpair (pr1 X) (pr1 (pr2 X)).
@@ -1386,7 +1386,7 @@ Defined.
 (** **** Subobjects *)
 
 Definition issubgr {X : gr} (A : hsubtype X) : UU :=
-  dirprod (issubmonoid A) (Π x : X, A x -> A (grinv X x)).
+  dirprod (issubmonoid A) (∏ x : X, A x -> A (grinv X x)).
 
 Lemma isapropissubgr {X : gr} (A : hsubtype X) : isaprop (issubgr A).
 Proof.
@@ -1400,11 +1400,11 @@ Defined.
 Definition subgr {X : gr} : UU := total2 (fun A : hsubtype X => issubgr A).
 
 Definition subgrpair {X : gr} :
-  Π (t : hsubtype X), (λ A : hsubtype X, issubgr A) t → Σ A : hsubtype X, issubgr A :=
+  ∏ (t : hsubtype X), (λ A : hsubtype X, issubgr A) t → ∑ A : hsubtype X, issubgr A :=
   tpair (fun A : hsubtype X => issubgr A).
 
 Definition subgrconstr {X : gr} :
-  Π (t : hsubtype X), (λ A : hsubtype X, issubgr A) t → Σ A : hsubtype X, issubgr A :=
+  ∏ (t : hsubtype X), (λ A : hsubtype X, issubgr A) t → ∑ A : hsubtype X, issubgr A :=
   @subgrpair X.
 
 Definition subgrtosubmonoid (X : gr) : @subgr X -> @submonoid X :=
@@ -1719,8 +1719,8 @@ Definition ismonoidfuntoabgrdiff (X : abmonoid) : ismonoidfun (toabgrdiff X) :=
 
 (** **** Abelian group of fractions in the case when all elements are cancelable *)
 
-Lemma isinclprabgrdiff (X : abmonoid) (iscanc : Π x : X, isrcancelable (@op X) x) :
-  Π x' : X, isincl (fun x => prabgrdiff X x x').
+Lemma isinclprabgrdiff (X : abmonoid) (iscanc : ∏ x : X, isrcancelable (@op X) x) :
+  ∏ x' : X, isincl (fun x => prabgrdiff X x x').
 Proof.
   intros.
   set (int := isinclprabmonoidfrac X (totalsubmonoid X) (fun a : totalsubmonoid X => iscanc (pr1 a))
@@ -1729,10 +1729,10 @@ Proof.
   apply int1.
 Defined.
 
-Definition isincltoabgrdiff (X : abmonoid) (iscanc : Π x : X, isrcancelable (@op X) x) :
+Definition isincltoabgrdiff (X : abmonoid) (iscanc : ∏ x : X, isrcancelable (@op X) x) :
   isincl (toabgrdiff X) := isinclprabgrdiff X iscanc (unel X).
 
-Lemma isdeceqabgrdiff (X : abmonoid) (iscanc : Π x : X, isrcancelable (@op X) x) (is : isdeceq X) :
+Lemma isdeceqabgrdiff (X : abmonoid) (iscanc : ∏ x : X, isrcancelable (@op X) x) (is : isdeceq X) :
   isdeceq (abgrdiff X).
 Proof.
   intros.
@@ -1780,7 +1780,7 @@ Definition logeqabgrdiffrels (X : abmonoid) {L : hrel X} (is : isbinophrel L) :
   hrellogeq (abgrdiffrel' X is) (abgrdiffrel X is).
 Proof.
   intros X L is x1 x2. split.
-  - assert (int : Π x x', isaprop (abgrdiffrel' X is x x' -> abgrdiffrel X is x x')).
+  - assert (int : ∏ x x', isaprop (abgrdiffrel' X is x x' -> abgrdiffrel X is x x')).
     {
       intros x x'.
       apply impred. intro.
@@ -1791,7 +1791,7 @@ Proof.
     intros x x'.
     change ((abgrdiffrelint' X L x x')  -> (abgrdiffrelint _ L x x')).
     apply (pr1 (logeqabgrdiffrelints X L x x')).
-  - assert (int : Π x x', isaprop (abgrdiffrel X is x x' -> abgrdiffrel' X is x x')).
+  - assert (int : ∏ x x', isaprop (abgrdiffrel X is x x' -> abgrdiffrel' X is x x')).
     intros x x'.
     apply impred. intro.
     apply (pr2 _).
@@ -1954,7 +1954,7 @@ Defined.
 Opaque iscotransabgrdiffrel.
 
 Lemma abgrdiffrelimpl (X : abmonoid) {L L' : hrel X} (is : isbinophrel L) (is' : isbinophrel L')
-      (impl : Π x x', L x x' -> L' x x') (x x' : abgrdiff X) (ql : abgrdiffrel X is x x') :
+      (impl : ∏ x x', L x x' -> L' x x') (x x' : abgrdiff X) (ql : abgrdiffrel X is x x') :
   abgrdiffrel X is' x x'.
 Proof.
   intros. generalize ql. refine (quotrelimpl _ _ _ _ _).
@@ -1964,7 +1964,7 @@ Defined.
 Opaque abgrdiffrelimpl.
 
 Lemma abgrdiffrellogeq (X : abmonoid) {L L' : hrel X} (is : isbinophrel L) (is' : isbinophrel L')
-      (lg : Π x x', L x x' <-> L' x x') (x x' : abgrdiff X) :
+      (lg : ∏ x x', L x x' <-> L' x x') (x x' : abgrdiff X) :
   (abgrdiffrel X is x x') <-> (abgrdiffrel X is' x x').
 Proof.
   intros. refine (quotrellogeq _ _ _ _ _). intros x0 x0'. split.

--- a/UniMath/Algebra/Rigs_and_Rings.v
+++ b/UniMath/Algebra/Rigs_and_Rings.v
@@ -93,10 +93,10 @@ Definition riglunax1 (X : rig) : islunit op1 (@rigunel1 X) := lunax_is (rigop1ax
 
 Definition rigrunax1 (X : rig) : isrunit op1 (@rigunel1 X) := runax_is (rigop1axs X).
 
-Definition rigmult0x (X : rig) : Π x : X, paths (op2 (@rigunel1 X) x) (@rigunel1 X) :=
+Definition rigmult0x (X : rig) : ∏ x : X, paths (op2 (@rigunel1 X) x) (@rigunel1 X) :=
   rigmult0x_is (pr2 X).
 
-Definition rigmultx0 (X : rig) : Π x : X, paths (op2 x (@rigunel1 X)) (@rigunel1 X) :=
+Definition rigmultx0 (X : rig) : ∏ x : X, paths (op2 x (@rigunel1 X)) (@rigunel1 X) :=
   rigmultx0_is (pr2 X).
 
 Definition rigcomm1 (X : rig) : iscomm (@op1 X) := commax_is (rigop1axs X).
@@ -119,8 +119,8 @@ Definition rigrdistr (X : rig) : isrdistr (@op1 X) (@op2 X) := pr2 (pr2 (pr2 X))
 
 Definition rigconstr {X : hSet} (opp1 opp2 : binop X) (ax11 : ismonoidop opp1)
            (ax12 : iscomm opp1) (ax2 : ismonoidop opp2)
-           (m0x : Π x : X, paths (opp2 (unel_is ax11) x) (unel_is ax11))
-           (mx0 : Π x : X, paths (opp2 x (unel_is ax11)) (unel_is ax11))
+           (m0x : ∏ x : X, paths (opp2 (unel_is ax11) x) (unel_is ax11))
+           (mx0 : ∏ x : X, paths (opp2 x (unel_is ax11)) (unel_is ax11))
            (dax : isdistr opp1 opp2) : rig.
 Proof.
   intros. split with (setwith2binoppair X (dirprodpair opp1 opp2)). split.
@@ -186,11 +186,11 @@ Defined.
 (** **** Relations similar to "greater" or "greater or equal" on rigs *)
 
 Definition isrigmultgt (X : rig) (R : hrel X) :=
-  Π (a b c d : X), R a b -> R c d -> R (op1 (op2 a c) (op2 b d)) (op1 (op2 a d) (op2 b c)).
+  ∏ (a b c d : X), R a b -> R c d -> R (op1 (op2 a c) (op2 b d)) (op1 (op2 a d) (op2 b c)).
 
 Definition isinvrigmultgt (X : rig) (R : hrel X) : UU :=
-  dirprod (Π (a b c d : X), R (op1 (op2 a c) (op2 b d)) (op1 (op2 a d) (op2 b c)) -> R a b -> R c d)
-          (Π (a b c d : X), R (op1 (op2 a c) (op2 b d)) (op1 (op2 a d) (op2 b c)) -> R c d -> R a b).
+  dirprod (∏ (a b c d : X), R (op1 (op2 a c) (op2 b d)) (op1 (op2 a d) (op2 b c)) -> R a b -> R c d)
+          (∏ (a b c d : X), R (op1 (op2 a c) (op2 b d)) (op1 (op2 a d) (op2 b c)) -> R c d -> R a b).
 
 
 (** **** Subobjects *)
@@ -208,7 +208,7 @@ Defined.
 Definition subrig (X : rig) : UU := total2 (fun  A : hsubtype X => issubrig A).
 
 Definition subrigpair {X : rig} :
-  Π (t : hsubtype X), (λ A : hsubtype X, issubrig A) t → Σ A : hsubtype X, issubrig A :=
+  ∏ (t : hsubtype X), (λ A : hsubtype X, issubrig A) t → ∑ A : hsubtype X, issubrig A :=
   tpair (fun  A : hsubtype X => issubrig A).
 
 Definition pr1subrig (X : rig) : @subrig X -> hsubtype X :=
@@ -332,8 +332,8 @@ Definition commrigpair (X : setwith2binop) (is : iscommrigops (@op1 X) (@op2 X))
 Definition commrigconstr {X : hSet} (opp1 opp2 : binop X)
            (ax11 : ismonoidop opp1) (ax12 : iscomm opp1)
            (ax2 : ismonoidop opp2) (ax22 : iscomm opp2)
-           (m0x : Π x : X, paths (opp2 (unel_is ax11) x) (unel_is ax11))
-           (mx0 : Π x : X, paths (opp2 x (unel_is ax11)) (unel_is ax11))
+           (m0x : ∏ x : X, paths (opp2 (unel_is ax11) x) (unel_is ax11))
+           (mx0 : ∏ x : X, paths (opp2 x (unel_is ax11)) (unel_is ax11))
            (dax : isdistr opp1 opp2) : commrig.
 Proof.
   intros. split with  (setwith2binoppair X (dirprodpair opp1 opp2)).
@@ -360,7 +360,7 @@ Definition commrigmultabmonoid (X : commrig) : abmonoid :=
 (** **** Relations similar to "greater" on commutative rigs *)
 
 Lemma isinvrigmultgtif (X : commrig) (R : hrel X)
-      (is2 : Π a b c d, R (op1 (op2 a c) (op2 b d)) (op1 (op2 a d) (op2 b c)) -> R a b -> R c d) :
+      (is2 : ∏ a b c d, R (op1 (op2 a c) (op2 b d)) (op1 (op2 a d) (op2 b c)) -> R a b -> R c d) :
   isinvrigmultgt X R.
 Proof.
   intros. split.
@@ -444,10 +444,10 @@ Definition rngrunax1 (X : rng) : isrunit op1 (@rngunel1 X) := runax_is (rngop1ax
 
 Definition rnginv1 {X : rng} : X -> X := grinv_is (rngop1axs X).
 
-Definition rnglinvax1 (X : rng) : Π x : X, paths (op1 (rnginv1 x) x) rngunel1 :=
+Definition rnglinvax1 (X : rng) : ∏ x : X, paths (op1 (rnginv1 x) x) rngunel1 :=
   grlinvax_is (rngop1axs X).
 
-Definition rngrinvax1 (X : rng) : Π x : X, paths (op1 x (rnginv1 x)) rngunel1 :=
+Definition rngrinvax1 (X : rng) : ∏ x : X, paths (op1 x (rnginv1 x)) rngunel1 :=
   grrinvax_is (rngop1axs X).
 
 Definition rngcomm1 (X : rng) : iscomm (@op1 X) := commax_is (rngop1axs X).
@@ -473,15 +473,15 @@ Definition rngconstr {X : hSet} (opp1 opp2 : binop X) (ax11 : isgrop opp1) (ax12
   @rngpair (setwith2binoppair X (dirprodpair opp1 opp2))
            (dirprodpair (dirprodpair (dirprodpair ax11 ax12) ax2) dax).
 
-Definition rngmultx0 (X : rng) : Π x : X, paths (op2 x rngunel1) rngunel1 :=
+Definition rngmultx0 (X : rng) : ∏ x : X, paths (op2 x rngunel1) rngunel1 :=
   rngmultx0_is (rngaxs X).
 
-Definition rngmult0x (X : rng) : Π x : X, paths (op2 rngunel1 x) rngunel1 :=
+Definition rngmult0x (X : rng) : ∏ x : X, paths (op2 rngunel1 x) rngunel1 :=
   rngmult0x_is (rngaxs X).
 
 Definition rngminus1 {X : rng} : X := rngminus1_is (rngaxs X).
 
-Definition rngmultwithminus1 (X : rng) : Π x : X, paths (op2 rngminus1 x) (rnginv1 x) :=
+Definition rngmultwithminus1 (X : rng) : ∏ x : X, paths (op2 rngminus1 x) (rnginv1 x) :=
   rngmultwithminus1_is (rngaxs X).
 
 Definition rngaddabgr (X : rng) : abgr := abgrpair (setwithbinoppair X op1) (rngop1axs X).
@@ -530,7 +530,7 @@ Open Scope rng_scope.
 
 Definition rnginvunel1 (X : rng) : -0 = 0 := grinvunel X.
 
-Lemma rngismultlcancelableif (X : rng) (x : X) (isl : Π y, paths (x * y) 0 -> paths y 0) :
+Lemma rngismultlcancelableif (X : rng) (x : X) (isl : ∏ y, paths (x * y) 0 -> paths y 0) :
   islcancelable op2 x.
 Proof.
   intros.
@@ -553,7 +553,7 @@ Proof.
 Defined.
 Opaque  rngismultlcancelableif.
 
-Lemma rngismultrcancelableif (X : rng) (x : X) (isr : Π y, paths (y * x) 0 -> paths y 0) :
+Lemma rngismultrcancelableif (X : rng) (x : X) (isr : ∏ y, paths (y * x) 0 -> paths y 0) :
   isrcancelable op2 x.
 Proof.
   intros. apply (@isinclbetweensets X X).
@@ -575,8 +575,8 @@ Proof.
 Defined.
 Opaque rngismultrcancelableif.
 
-Lemma rngismultcancelableif (X : rng) (x : X) (isl : Π y, paths (x * y) 0 -> paths y 0)
-      (isr : Π y, paths (y * x) 0 -> paths y 0) : iscancelable op2 x.
+Lemma rngismultcancelableif (X : rng) (x : X) (isl : ∏ y, paths (x * y) 0 -> paths y 0)
+      (isr : ∏ y, paths (y * x) 0 -> paths y 0) : iscancelable op2 x.
 Proof.
   intros.
   apply (dirprodpair (rngismultlcancelableif X x isl) (rngismultrcancelableif X x isr)).
@@ -636,7 +636,7 @@ Definition rngtolt0 (X : rng) {R : hrel X} (is0 : @isbinophrel X R) {x : X}
 
 (** **** Relations compatible with the multiplicative structure on rings *)
 
-Definition isrngmultgt (X : rng) (R : hrel X) : UU := Π a b, R a 0 -> R b 0 -> R (a * b) 0.
+Definition isrngmultgt (X : rng) (R : hrel X) : UU := ∏ a b, R a 0 -> R b 0 -> R (a * b) 0.
 
 Lemma rngmultgt0lt0 (X : rng) {R : hrel X} (is0 : @isbinophrel X R) (is : isrngmultgt X R) {x y : X}
       (isx : R x 0) (isy : R 0 y) : R 0 (x * y).
@@ -681,7 +681,7 @@ Defined.
 Opaque rngmultlt0lt0.
 
 Lemma isrngmultgttoislrngmultgt (X : rng) {R : hrel X} (is0 : @isbinophrel X R)
-      (is : isrngmultgt X R) : Π a b c : X, R c 0 -> R a b -> R (c * a) (c * b).
+      (is : isrngmultgt X R) : ∏ a b c : X, R c 0 -> R a b -> R (c * a) (c * b).
 Proof.
   intros X R is0 is a b c rc0 rab.
   set (rab':= (pr2 is0) _ _ (- b) rab). clearbody rab'.
@@ -700,7 +700,7 @@ Defined.
 Opaque isrngmultgttoislrngmultgt.
 
 Lemma islrngmultgttoisrngmultgt (X : rng) {R : hrel X}
-      (is : Π a b c : X, R c 0 -> R a b -> R (c * a) (c * b)) : isrngmultgt X R.
+      (is : ∏ a b c : X, R c 0 -> R a b -> R (c * a) (c * b)) : isrngmultgt X R.
 Proof.
   intros. intros a b ra rb.
   set (int := is b 0 a ra rb). clearbody int. rewrite (rngmultx0 X _) in int.
@@ -709,7 +709,7 @@ Defined.
 Opaque islrngmultgttoisrngmultgt.
 
 Lemma isrngmultgttoisrrngmultgt (X : rng) {R : hrel X} (is0 : @isbinophrel X R)
-      (is : isrngmultgt X R) : Π a b c : X, R c 0 -> R a b -> R (a * c) (b * c).
+      (is : isrngmultgt X R) : ∏ a b c : X, R c 0 -> R a b -> R (a * c) (b * c).
 Proof.
   intros X R is0 is a b c rc0 rab.
   set (rab' := (pr2 is0) _ _ (- b) rab). clearbody rab'.
@@ -728,7 +728,7 @@ Defined.
 Opaque isrngmultgttoisrrngmultgt.
 
 Lemma isrrngmultgttoisrngmultgt (X : rng) {R : hrel X}
-      (is1 : Π a b c : X, R c 0 -> R a b -> R (a * c) (b * c)) : isrngmultgt X R.
+      (is1 : ∏ a b c : X, R c 0 -> R a b -> R (a * c) (b * c)) : isrngmultgt X R.
 Proof.
   intros. intros a b ra rb.
   set (int := is1 _ _ _ rb ra). clearbody int.
@@ -797,10 +797,10 @@ Opaque isrigmultgttoisrngmultgt.
 
 
 Definition isinvrngmultgt (X : rng) (R : hrel X) : UU :=
-  dirprod (Π a b, R (a * b) 0 -> R a 0 -> R b 0) (Π a b, R (a * b) 0 -> R b 0 -> R a 0).
+  dirprod (∏ a b, R (a * b) 0 -> R a 0 -> R b 0) (∏ a b, R (a * b) 0 -> R b 0 -> R a 0).
 
 Lemma isinvrngmultgttoislinvrngmultgt (X : rng) {R : hrel X} (is0 : @isbinophrel X R)
-      (is : isinvrngmultgt X R) : Π a b c : X, R c 0 -> R (c * a) (c * b) -> R a b.
+      (is : isinvrngmultgt X R) : ∏ a b c : X, R c 0 -> R (c * a) (c * b) -> R a b.
 Proof.
   intros X R is0 is a b c rc0 r.
   set (rab':= (pr2 is0) _ _ (c * - b) r).
@@ -819,7 +819,7 @@ Defined.
 Opaque isinvrngmultgttoislinvrngmultgt.
 
 Lemma isinvrngmultgttoisrinvrngmultgt (X : rng) {R : hrel X} (is0 : @isbinophrel X R)
-      (is : isinvrngmultgt X R) : Π a b c : X, R c 0 -> R (a * c) (b * c) -> R a b.
+      (is : isinvrngmultgt X R) : ∏ a b c : X, R c 0 -> R (a * c) (b * c) -> R a b.
 Proof.
   intros X R is0 is a b c rc0 r.
   set (rab':= (pr2 is0) _ _ (- b * c) r). clearbody rab'.
@@ -838,8 +838,8 @@ Defined.
 Opaque isinvrngmultgttoisrinvrngmultgt.
 
 Lemma islrinvrngmultgttoisinvrngmultgt (X : rng) {R : hrel X}
-      (isl : Π a b c : X, R c 0 -> R (c * a) (c * b) -> R a b)
-      (isr : Π a b c : X, R c 0 -> R (a * c) (b * c) -> R a b) : isinvrngmultgt X R.
+      (isl : ∏ a b c : X, R c 0 -> R (c * a) (c * b) -> R a b)
+      (isr : ∏ a b c : X, R c 0 -> R (a * c) (b * c) -> R a b) : isinvrngmultgt X R.
 Proof.
   intros. split.
   - intros a b rab ra.
@@ -935,7 +935,7 @@ Lemma rngmultgtandfun {X Y : rng} (f : rngfun X Y) (R : hrel Y) (isr : isrngmult
 Proof.
   intros. intros a b ra rb.
   set (ax0 := (pr2 (pr1 (pr2 f))) : paths (f 0) 0).
-  set (ax1 := (pr1 (pr2 (pr2 f))) : Π a b, paths (f (a * b)) ((f a) * (f b))).
+  set (ax1 := (pr1 (pr2 (pr2 f))) : ∏ a b, paths (f (a * b)) ((f a) * (f b))).
   rewrite ax0 in ra. rewrite ax0 in rb.
   rewrite ax0. rewrite (ax1 _ _).
   apply (isr _ _ ra rb).
@@ -946,7 +946,7 @@ Lemma rnginvmultgtandfun {X Y : rng} (f : rngfun X Y) (R : hrel Y) (isr : isinvr
 Proof.
   intros.
   set (ax0 := (pr2 (pr1 (pr2 f))) : paths (f 0) 0).
-  set (ax1 := (pr1 (pr2 (pr2 f))) : Π a b, paths (f (a * b)) ((f a) * (f b))).
+  set (ax1 := (pr1 (pr2 (pr2 f))) : ∏ a b, paths (f (a * b)) ((f a) * (f b))).
   split.
   - intros a b rab ra.
     rewrite ax0 in ra. rewrite ax0 in rab.
@@ -976,7 +976,7 @@ Defined.
 Definition subrng (X : rng) : UU := total2 (fun A : hsubtype X => issubrng A).
 
 Definition subrngpair {X : rng} :
-  Π (t : hsubtype X), (λ A : hsubtype X, issubrng A) t → Σ A : hsubtype X, issubrng A :=
+  ∏ (t : hsubtype X), (λ A : hsubtype X, issubrng A) t → ∑ A : hsubtype X, issubrng A :=
   tpair (fun A : hsubtype X => issubrng A).
 
 Definition pr1subrng (X : rng) : @subrng X -> hsubtype X :=
@@ -1347,7 +1347,7 @@ Definition ismultmonoidfuntorngdiff (X : rig) :
 Definition isrigfuntorngdiff (X : rig) : @isrigfun X (rigtorng X) (torngdiff X) :=
   dirprodpair (isaddmonoidfuntorngdiff X) (ismultmonoidfuntorngdiff X).
 
-Definition isincltorngdiff (X : rig) (iscanc : Π x : X, @isrcancelable X (@op1 X) x) :
+Definition isincltorngdiff (X : rig) (iscanc : ∏ x : X, @isrcancelable X (@op1 X) x) :
   isincl (torngdiff X) := isincltoabgrdiff (rigaddabmonoid X) iscanc.
 
 
@@ -1362,9 +1362,9 @@ Proof.
   intros.
   set (assoc := rigassoc1 X). set (comm := rigcomm1 X).
   set (rer := (abmonoidrer (rigaddabmonoid X)) :
-                Π a b c d : X, paths ((a + b) + (c + d)) ((a + c) + (b + d))).
+                ∏ a b c d : X, paths ((a + b) + (c + d)) ((a + c) + (b + d))).
   set (ld := rigldistr X). set (rd := rigrdistr X).
-  assert (int : Π a b, isaprop (rigtorngrel X is0 a rngunel1 -> rigtorngrel X is0 b rngunel1 ->
+  assert (int : ∏ a b, isaprop (rigtorngrel X is0 a rngunel1 -> rigtorngrel X is0 b rngunel1 ->
                                 rigtorngrel X is0 (a * b) rngunel1)).
   {
     intros a b.
@@ -1427,7 +1427,7 @@ Lemma isinvrngrigtorngmultgt (X : rig) {R : hrel X} (is0 : @isbinophrel (rigadda
   isinvrngmultgt (rigtorng X) (rigtorngrel X is0).
 Proof.
   intros. split.
-  - assert (int : Π a b, isaprop (rigtorngrel X is0 (a * b) rngunel1 ->
+  - assert (int : ∏ a b, isaprop (rigtorngrel X is0 (a * b) rngunel1 ->
                                   rigtorngrel X is0 a rngunel1 ->
                                   rigtorngrel X is0 b rngunel1)).
     intros.
@@ -1457,7 +1457,7 @@ Proof.
     rewrite (rigrunax1 X _). rewrite (rigrunax1 X _).
     apply ((pr1 is) _ _ _ _ r2' r1').
 
-  - assert (int : Π a b, isaprop (rigtorngrel X is0 (a * b) rngunel1 ->
+  - assert (int : ∏ a b, isaprop (rigtorngrel X is0 (a * b) rngunel1 ->
                                   rigtorngrel X is0 b rngunel1 ->
                                   rigtorngrel X is0 a rngunel1)).
     intros.
@@ -1509,7 +1509,7 @@ Definition iscommrng (X : setwith2binop) : UU := iscommrngops (@op1 X) (@op2 X).
 Definition commrng : UU := total2 (fun X : setwith2binop => iscommrngops (@op1 X) (@op2 X)).
 
 Definition commrngpair (X : setwith2binop) (is : iscommrngops (@op1 X) (@op2 X)) :
-  Σ X0 : setwith2binop, iscommrngops op1 op2 :=
+  ∑ X0 : setwith2binop, iscommrngops op1 op2 :=
   tpair (fun X : setwith2binop => iscommrngops (@op1 X) (@op2 X)) X is.
 
 Definition commrngconstr {X : hSet} (opp1 opp2 : binop X)
@@ -1538,12 +1538,12 @@ Coercion commrngtocommrig : commrng >-> commrig.
 
 Open Scope rng_scope.
 
-Lemma commrngismultcancelableif (X : commrng) (x : X) (isl : Π y, paths (x * y) 0 -> paths y 0) :
+Lemma commrngismultcancelableif (X : commrng) (x : X) (isl : ∏ y, paths (x * y) 0 -> paths y 0) :
   iscancelable op2 x.
 Proof.
   intros. split.
   - apply (rngismultlcancelableif X x isl).
-  - assert (isr : Π y, paths (y * x) 0 -> paths y 0).
+  - assert (isr : ∏ y, paths (y * x) 0 -> paths y 0).
     intros y e. rewrite (rngcomm2 X _ _) in e. apply (isl y e).
     apply (rngismultrcancelableif X x isr).
 Defined.
@@ -1743,7 +1743,7 @@ Proof.
   set (add1int := commrngfracop1int X S).
   set (add1 := commrngfracop1 X S).
   unfold isassoc.
-  assert (int : Π (xs xs' xs'' : dirprod X S),
+  assert (int : ∏ (xs xs' xs'' : dirprod X S),
                 paths (setquotpr R (add1int (add1int xs xs') xs''))
                       (setquotpr R (add1int xs (add1int xs' xs'')))).
   unfold add1int. unfold commrngfracop1int. intros xs xs' xs''.
@@ -1991,7 +1991,7 @@ Definition prcommrngfrac (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
   X -> S -> commrngfrac X S := fun x s => setquotpr _ (dirprodpair x s).
 
 Lemma invertibilityincommrngfrac (X : commrng) (S : @subabmonoid (rngmultabmonoid X)) :
-  Π a a' : S, isinvertible (@op2 (commrngfrac X S)) (prcommrngfrac X S (pr1 a) a').
+  ∏ a a' : S, isinvertible (@op2 (commrngfrac X S)) (prcommrngfrac X S (pr1 a) a').
 Proof.
   intros.
   apply (invertibilityinabmonoidfrac (rngmultabmonoid X) S).
@@ -2070,7 +2070,7 @@ Definition hrelcommrngfrac0 (X : commrng) (S : @submonoid (rngmultabmonoid X)) :
   fun xa yb : setdirprod X S => eqset ((pr1 xa) * (pr1 (pr2 yb))) ((pr1 yb) * (pr1 (pr2 xa))).
 
 Lemma weqhrelhrel0commrngfrac (X : commrng) (S : @submonoid (rngmultabmonoid X))
-      (iscanc : Π a : S, isrcancelable (@op2 X) (pr1carrier _ a)) (xa xa' : dirprod X S) :
+      (iscanc : ∏ a : S, isrcancelable (@op2 X) (pr1carrier _ a)) (xa xa' : dirprod X S) :
   weq (eqrelcommrngfrac X S xa xa') (hrelcommrngfrac0 X S xa xa').
 Proof.
   intros. unfold eqrelabmonoidfrac. unfold hrelabmonoidfrac. simpl.
@@ -2087,8 +2087,8 @@ Defined.
 Opaque weqhrelhrel0abmonoidfrac.
 
 Lemma isinclprcommrngfrac (X : commrng) (S : @submonoid (rngmultabmonoid X))
-      (iscanc : Π a : S, isrcancelable (@op2 X) (pr1carrier _ a)) :
-  Π a' : S, isincl (fun x => prcommrngfrac X S x a').
+      (iscanc : ∏ a : S, isrcancelable (@op2 X) (pr1carrier _ a)) :
+  ∏ a' : S, isincl (fun x => prcommrngfrac X S x a').
 Proof.
   intros. apply isinclbetweensets.
   apply (setproperty X). apply (setproperty (commrngfrac X S)).
@@ -2101,11 +2101,11 @@ Proof.
 Defined.
 
 Definition isincltocommrngfrac (X : commrng) (S : @submonoid (rngmultabmonoid X))
-           (iscanc : Π a : S, isrcancelable (@op2 X) (pr1carrier _ a)) :
+           (iscanc : ∏ a : S, isrcancelable (@op2 X) (pr1carrier _ a)) :
   isincl (tocommrngfrac X S) := isinclprcommrngfrac X S iscanc (unel S).
 
 Lemma isdeceqcommrngfrac (X : commrng) (S : @submonoid (rngmultabmonoid X))
-      (iscanc : Π a : S, isrcancelable (@op2 X) (pr1carrier _ a)) (is : isdeceq X) :
+      (iscanc : ∏ a : S, isrcancelable (@op2 X) (pr1carrier _ a)) (is : isdeceq X) :
   isdeceq (commrngfrac X S).
 Proof.
   intros. apply (isdeceqsetquot (eqrelcommrngfrac X S)). intros xa xa'.
@@ -2121,7 +2121,7 @@ Defined.
 
 Lemma ispartbinopcommrngfracgt (X : commrng) (S : @submonoid (rngmultabmonoid X)) {R : hrel X}
       (is0 : @isbinophrel (rigaddabmonoid X) R) (is1 : isrngmultgt X R)
-      (is2 : Π c : X, S c -> R c 0) : @ispartbinophrel (rngmultabmonoid X) S R.
+      (is2 : ∏ c : X, S c -> R c 0) : @ispartbinophrel (rngmultabmonoid X) S R.
 Proof.
   intros. split.
   - intros a b c s rab.
@@ -2132,18 +2132,18 @@ Defined.
 
 Definition commrngfracgt (X : commrng) (S : @submonoid (rngmultabmonoid X)) {R : hrel X}
            (is0 : @isbinophrel (rigaddabmonoid X) R) (is1 : isrngmultgt X R)
-           (is2 : Π c : X, S c -> R c 0) : hrel (commrngfrac X S) :=
+           (is2 : ∏ c : X, S c -> R c 0) : hrel (commrngfrac X S) :=
   abmonoidfracrel (rngmultabmonoid X) S (ispartbinopcommrngfracgt X S is0 is1 is2).
 
 Lemma isrngmultcommrngfracgt (X : commrng) (S : @submonoid (rngmultabmonoid X)) {R : hrel X}
       (is0 : @isbinophrel (rigaddabmonoid X) R) (is1 : isrngmultgt X R)
-      (is2 : Π c : X, S c -> R c 0) : isrngmultgt (commrngfrac X S) (commrngfracgt X S is0 is1 is2).
+      (is2 : ∏ c : X, S c -> R c 0) : isrngmultgt (commrngfrac X S) (commrngfracgt X S is0 is1 is2).
 Proof.
   intros.
   set (rer2 := (abmonoidrer (rngmultabmonoid X)) :
-                 Π a b c d : X, paths ((a * b) * (c * d)) ((a * c) * (b * d))).
+                 ∏ a b c d : X, paths ((a * b) * (c * d)) ((a * c) * (b * d))).
   apply islrngmultgttoisrngmultgt.
-  assert (int : Π (a b c : rngaddabgr (commrngfrac X S)),
+  assert (int : ∏ (a b c : rngaddabgr (commrngfrac X S)),
                 isaprop (commrngfracgt X S is0 is1 is2 c 0 ->
                          commrngfracgt X S is0 is1 is2 a b ->
                          commrngfracgt X S is0 is1 is2 (c * a) (c * b))).
@@ -2196,14 +2196,14 @@ Opaque isrngmultcommrngfracgt.
 
 Lemma isrngaddcommrngfracgt (X : commrng) (S : @submonoid (rngmultabmonoid X)) {R : hrel X}
       (is0 : @isbinophrel (rigaddabmonoid X) R) (is1 : isrngmultgt X R)
-      (is2 : Π c : X, S c -> R c 0) : @isbinophrel (commrngfrac X S) (commrngfracgt X S is0 is1 is2).
+      (is2 : ∏ c : X, S c -> R c 0) : @isbinophrel (commrngfrac X S) (commrngfracgt X S is0 is1 is2).
 Proof.
   intros.
   set (rer2 := (abmonoidrer (rngmultabmonoid X)) :
-                 Π a b c d : X, paths ((a * b) * (c * d)) ((a * c) * (b * d))).
+                 ∏ a b c d : X, paths ((a * b) * (c * d)) ((a * c) * (b * d))).
   apply isbinophrelif. intros a b. apply (rngcomm1 (commrngfrac X S) a b).
 
-  assert (int : Π (a b c : rngaddabgr (commrngfrac X S)),
+  assert (int : ∏ (a b c : rngaddabgr (commrngfrac X S)),
                 isaprop (commrngfracgt X S is0 is1 is2 a b ->
                          commrngfracgt X S is0 is1 is2 (op c a) (op c b))).
   {
@@ -2244,7 +2244,7 @@ Opaque isrngaddcommrngfracgt.
 
 Definition isdeccommrngfracgt (X : commrng) (S : @submonoid (rngmultabmonoid X)) {R : hrel X}
            (is0 : @isbinophrel (rigaddabmonoid X) R) (is1 : isrngmultgt X R)
-           (is2 : Π c : X, S c -> R c 0) (is' : @ispartinvbinophrel (rngmultabmonoid X) S R)
+           (is2 : ∏ c : X, S c -> R c 0) (is' : @ispartinvbinophrel (rngmultabmonoid X) S R)
            (isd : isdecrel R) : isdecrel (commrngfracgt X S is0 is1 is2).
 Proof.
   intros.
@@ -2257,7 +2257,7 @@ Defined.
 
 Definition iscomptocommrngfrac (X : commrng) (S : @submonoid (rngmultabmonoid X)) {L : hrel X}
            (is0 : @isbinophrel (rigaddabmonoid X) L) (is1 : isrngmultgt X L)
-           (is2 : Π c : X, S c -> L c 0) :
+           (is2 : ∏ c : X, S c -> L c 0) :
   iscomprelrelfun L (commrngfracgt X S is0 is1 is2) (tocommrngfrac X S) :=
   iscomptoabmonoidfrac (rngmultabmonoid X) S (ispartbinopcommrngfracgt X S is0 is1 is2).
 Opaque iscomptocommrngfrac.

--- a/UniMath/Algebra/Tests.v
+++ b/UniMath/Algebra/Tests.v
@@ -11,11 +11,11 @@ Module Test_assoc.
 
   Open Scope multmonoid.
 
-  Goal Π (M:monoid) (f:stn 3 -> M),
+  Goal ∏ (M:monoid) (f:stn 3 -> M),
          sequenceProduct(3,,f) = 1 * f(●O) * f(●1%nat) * f(●2).
   Proof. reflexivity. Defined.
 
-  Goal Π (M:monoid) (f:stn 3 -> Sequence M),
+  Goal ∏ (M:monoid) (f:stn 3 -> Sequence M),
          doubleProduct(3,,f) =
             1 * sequenceProduct (f(●0))
               * sequenceProduct (f(●1%nat))
@@ -23,13 +23,13 @@ Module Test_assoc.
   Proof. reflexivity. Defined.
 
   (* demonstrate that the Coq parser is left-associative with "*" *)
-  Goal Π (M:monoid) (x y z:M), x*y*z = (x*y)*z. Proof. reflexivity. Defined.
-  Goal Π (M:monoid) (x y z:M), x*y*z = x*(y*z). Proof. apply assocax. Defined.
+  Goal ∏ (M:monoid) (x y z:M), x*y*z = (x*y)*z. Proof. reflexivity. Defined.
+  Goal ∏ (M:monoid) (x y z:M), x*y*z = x*(y*z). Proof. apply assocax. Defined.
 
   (* demonstrate that the Coq parser is left-associative with "+" *)
   Open Scope addmonoid.
-  Goal Π (M:monoid) (x y z:M), x+y+z = (x+y)+z. Proof. reflexivity. Defined.
-  Goal Π (M:monoid) (x y z:M), x+y+z = x+(y+z). Proof. apply assocax. Defined.
+  Goal ∏ (M:monoid) (x y z:M), x+y+z = (x+y)+z. Proof. reflexivity. Defined.
+  Goal ∏ (M:monoid) (x y z:M), x+y+z = x+(y+z). Proof. apply assocax. Defined.
 
 End Test_assoc.
 

--- a/UniMath/CategoryTheory/Abelian.v
+++ b/UniMath/CategoryTheory/Abelian.v
@@ -72,13 +72,13 @@ Section def_abelian.
 
   (** This definition contains the data that every monic is a kernel of some morphism. *)
   Definition AbelianMonicKernelsData (C : precategory) (AD : Data1 C) : UU :=
-    Π (x y : C) (M : Monic C x y),
-    (Σ D2 : (Σ D1 : (Σ z : C, y --> z), M ;; (pr2 D1) = ZeroArrow (pr1 AD) x (pr1 D1)),
+    ∏ (x y : C) (M : Monic C x y),
+    (∑ D2 : (∑ D1 : (∑ z : C, y --> z), M ;; (pr2 D1) = ZeroArrow (pr1 AD) x (pr1 D1)),
             isKernel (Data1_Zero AD) M (pr2 (pr1 D2)) (pr2 D2)).
 
   Definition mk_AbelianMonicKernelsData {C : precategory} (AD1 : Data1 C)
-             (H : Π (x y : C) (M : Monic C x y),
-                  (Σ D2 : (Σ D1 : (Σ z : C, y --> z), M ;; (pr2 D1) = ZeroArrow (pr1 AD1) x (pr1 D1)),
+             (H : ∏ (x y : C) (M : Monic C x y),
+                  (∑ D2 : (∑ D1 : (∑ z : C, y --> z), M ;; (pr2 D1) = ZeroArrow (pr1 AD1) x (pr1 D1)),
                           isKernel (Data1_Zero AD1) M (pr2 (pr1 D2)) (pr2 D2))) :
     AbelianMonicKernelsData C AD1 := H.
 
@@ -102,13 +102,13 @@ Section def_abelian.
   (** This definition contains the data that every epi is a cokernel of some
       morphism. *)
   Definition AbelianEpiCokernelsData (C : precategory) (AD : Data1 C) : UU :=
-    (Π (y z : C) (E : Epi C y z),
-     (Σ D2 : (Σ D1 : (Σ x : C, x --> y), (pr2 D1) ;; E = ZeroArrow (pr1 AD) (pr1 D1) z),
+    (∏ (y z : C) (E : Epi C y z),
+     (∑ D2 : (∑ D1 : (∑ x : C, x --> y), (pr2 D1) ;; E = ZeroArrow (pr1 AD) (pr1 D1) z),
              isCokernel (Data1_Zero AD) (pr2 (pr1 D2)) E (pr2 D2))).
 
    Definition mk_AbelianEpiCokernelsData {C : precategory} (AD1 : Data1 C)
-              (H : (Π (y z : C) (E : Epi C y z),
-                    (Σ D2 : (Σ D1 : (Σ x : C, x --> y),
+              (H : (∏ (y z : C) (E : Epi C y z),
+                    (∑ D2 : (∑ D1 : (∑ x : C, x --> y),
                                    (pr2 D1) ;; E = ZeroArrow (pr1 AD1) (pr1 D1) z),
                             isCokernel (Data1_Zero AD1) (pr2 (pr1 D2)) E (pr2 D2)))) :
      AbelianEpiCokernelsData C AD1 := H.
@@ -139,7 +139,7 @@ Section def_abelian.
     AbelianData C AD1 := (H1,,(H2,,H3)).
 
   (** Definition of abelian categories. *)
-  Definition AbelianPreCat : UU := Σ A : (Σ C : precategory, Data1 C), AbelianData (pr1 A) (pr2 A).
+  Definition AbelianPreCat : UU := ∑ A : (∑ C : precategory, Data1 C), AbelianData (pr1 A) (pr2 A).
 
   Definition precategory_of_AbelianPreCat (A : AbelianPreCat) : precategory := pr1 (pr1 A).
   Coercion precategory_of_AbelianPreCat : AbelianPreCat >-> precategory.

--- a/UniMath/CategoryTheory/Additive.v
+++ b/UniMath/CategoryTheory/Additive.v
@@ -42,7 +42,7 @@ Section def_additive.
   Defined.
 
   (** Definition of additive categories *)
-  Definition Additive : UU := Σ PA : PreAdditive, isAdditive PA.
+  Definition Additive : UU := ∑ PA : PreAdditive, isAdditive PA.
 
   Definition Additive_PreAdditive (A : Additive) : PreAdditive := pr1 A.
   Coercion Additive_PreAdditive : Additive >-> PreAdditive.
@@ -386,7 +386,7 @@ Section monics_and_epis_in_additive.
   Variable A : Additive.
 
   Lemma to_isMonic {x y : ob A} (f : x --> y)
-        (H : Π (z : ob A) (g : z --> x) (H : g ;; f = ZeroArrow (to_Zero A) _ _),
+        (H : ∏ (z : ob A) (g : z --> x) (H : g ;; f = ZeroArrow (to_Zero A) _ _),
              g = ZeroArrow (to_Zero A) _ _ ) : isMonic f.
   Proof.
     use mk_isMonic.
@@ -400,7 +400,7 @@ Section monics_and_epis_in_additive.
   Qed.
 
   Lemma to_isEpi {x y : ob A} (f : x --> y)
-        (H : Π (z : ob A) (g : y --> z) (H : f ;; g = ZeroArrow (to_Zero A) _ _),
+        (H : ∏ (z : ob A) (g : y --> z) (H : f ;; g = ZeroArrow (to_Zero A) _ _),
              g = ZeroArrow (to_Zero A) _ _ ) : isEpi f.
   Proof.
     use mk_isEpi.

--- a/UniMath/CategoryTheory/AdditiveFunctors.v
+++ b/UniMath/CategoryTheory/AdditiveFunctors.v
@@ -45,10 +45,10 @@ Section def_additivefunctor.
   (** ** isAdditiveFunctor *)
 
   Definition isAdditiveFunctor {A B : Additive} (F : functor A B) : UU :=
-    Π (a1 a2 : A), @ismonoidfun (to_abgrop a1 a2) (to_abgrop (F a1) (F a2)) (# F).
+    ∏ (a1 a2 : A), @ismonoidfun (to_abgrop a1 a2) (to_abgrop (F a1) (F a2)) (# F).
 
   Definition mk_isAdditiveFunctor {A B : Additive} (F : functor A B)
-             (H : Π (a1 a2 : A),
+             (H : ∏ (a1 a2 : A),
                   @ismonoidfun (to_abgrop a1 a2) (to_abgrop (F a1) (F a2)) (# F)) :
     isAdditiveFunctor F.
   Proof.
@@ -57,9 +57,9 @@ Section def_additivefunctor.
   Qed.
 
   Definition mk_isAdditiveFunctor' {A B : Additive} (F : functor A B)
-             (H1 : Π (a1 a2 : A), (# F (ZeroArrow (to_Zero A) a1 a2)) =
+             (H1 : ∏ (a1 a2 : A), (# F (ZeroArrow (to_Zero A) a1 a2)) =
                                   ZeroArrow (to_Zero B) (F a1) (F a2))
-             (H2 : Π (a1 a2 : A) (f g : A⟦a1, a2⟧), # F (to_binop _ _ f g) =
+             (H2 : ∏ (a1 a2 : A) (f g : A⟦a1, a2⟧), # F (to_binop _ _ f g) =
                                                     to_binop _ _ (# F f) (# F g)) :
     isAdditiveFunctor F.
   Proof.
@@ -84,7 +84,7 @@ Section def_additivefunctor.
 
   (** ** Additive functor *)
 
-  Definition AdditiveFunctor (A B : Additive) : UU := Σ F : (functor A B), isAdditiveFunctor F.
+  Definition AdditiveFunctor (A B : Additive) : UU := ∑ F : (functor A B), isAdditiveFunctor F.
 
   Definition mk_AdditiveFunctor {A B : Additive} (F : functor A B) (H : isAdditiveFunctor F) :
     AdditiveFunctor A B := tpair _ F H.
@@ -107,7 +107,7 @@ End def_additivefunctor.
 Section additivefunctor_preserves_bindirectsums.
 
   Definition PreservesBinDirectSums {A B : Additive} (F : functor A B) : UU :=
-    Π (a1 a2 : A) (DS : BinDirectSumCone A a1 a2),
+    ∏ (a1 a2 : A) (DS : BinDirectSumCone A a1 a2),
     isBinDirectSumCone B (F a1) (F a2) (F DS)
                        (# F (to_In1 A DS)) (# F (to_In2 A DS))
                        (# F (to_Pr1 A DS)) (# F (to_Pr2 A DS)).

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -93,7 +93,7 @@ Section cocont.
 
 Context {C D : precategory} (F : functor C D).
 
-Definition is_cocont : UU := Π {g : graph} (d : diagram g C) (L : C)
+Definition is_cocont : UU := ∏ {g : graph} (d : diagram g C) (L : C)
   (cc : cocone d L), preserves_colimit F d L cc.
 
 End cocont.
@@ -130,7 +130,7 @@ induction j as [|j IHj].
 Defined.
 
 Lemma chain_mor_coconeIn {C : precategory} (c : chain C) (x : C)
-  (cc : cocone c x) i : Π j (Hij : i < j),
+  (cc : cocone c x) i : ∏ j (Hij : i < j),
   chain_mor c Hij ;; coconeIn cc j = coconeIn cc i.
 Proof.
 induction j as [|j IHj].
@@ -194,11 +194,11 @@ induction m as [|m IHm]; simpl.
 Defined.
 
 Definition is_omega_cocont {C D : precategory} (F : functor C D) : UU :=
-  Π (c : chain C) (L : C) (cc : cocone c L),
+  ∏ (c : chain C) (L : C) (cc : cocone c L),
   preserves_colimit F c L cc.
 
 Definition omega_cocont_functor (C D : precategory) : UU :=
-  Σ (F : functor C D), is_omega_cocont F.
+  ∑ (F : functor C D), is_omega_cocont F.
 
 End omega_cocont.
 
@@ -431,8 +431,8 @@ use mk_cocone.
 Defined.
 
 Lemma αinv_f_commutes y (ccGy : cocone (mapdiagram G d) y) (f : D⟦F L,y⟧)
-       (Hf : Π v,coconeIn (mapcocone F d cc) v ;; f = coconeIn (ccFy y ccGy) v) :
-       Π v, # G (coconeIn cc v) ;; (pr1 αinv L ;; f) = coconeIn ccGy v.
+       (Hf : ∏ v,coconeIn (mapcocone F d cc) v ;; f = coconeIn (ccFy y ccGy) v) :
+       ∏ v, # G (coconeIn cc v) ;; (pr1 αinv L ;; f) = coconeIn ccGy v.
 Proof.
 intro v; rewrite assoc.
 eapply pathscomp0; [apply cancel_postcomposition, nat_trans_ax|].
@@ -444,13 +444,13 @@ now rewrite id_left.
 Qed.
 
 Lemma αinv_f_unique y (ccGy : cocone (mapdiagram G d) y) (f : D⟦F L,y⟧)
-     (Hf : Π v,coconeIn (mapcocone F d cc) v ;; f = coconeIn (ccFy y ccGy) v)
-     (HHf : Π t : Σ x, Π v, coconeIn (mapcocone F d cc) v ;; x = coconeIn _ v, t = f,, Hf)
-      f' (Hf' : Π v, # G (coconeIn cc v) ;; f' = coconeIn ccGy v) :
+     (Hf : ∏ v,coconeIn (mapcocone F d cc) v ;; f = coconeIn (ccFy y ccGy) v)
+     (HHf : ∏ t : ∑ x, ∏ v, coconeIn (mapcocone F d cc) v ;; x = coconeIn _ v, t = f,, Hf)
+      f' (Hf' : ∏ v, # G (coconeIn cc v) ;; f' = coconeIn ccGy v) :
       f' = pr1 αinv L ;; f.
 Proof.
-transparent assert (HH : (Σ x : D ⟦ F L, y ⟧,
-            Π v : vertex g,
+transparent assert (HH : (∑ x : D ⟦ F L, y ⟧,
+            ∏ v : vertex g,
             coconeIn (mapcocone F d cc) v ;; x = coconeIn (ccFy y ccGy) v)).
 { mkpair.
   - apply (pr1 α L ;; f').
@@ -533,7 +533,7 @@ Context {C D : precategory} (hsD : has_homsets D) (x : D).
 
 (* Without the conn argument this is is too weak as diagrams are not necessarily categories *)
 Lemma preserves_colimit_constant_functor {g : graph} (v : vertex g)
-  (conn : Π (u : vertex g), edge v u)
+  (conn : ∏ (u : vertex g), edge v u)
   (d : diagram g C) (L : C) (cc : cocone d L) :
   preserves_colimit (constant_functor C D x) d L cc.
 Proof.
@@ -666,7 +666,7 @@ mkpair.
 - apply (tpair _ x1).
   abstract (intro n; apply (maponpaths pr1 (p1 n))).
 - intro t.
-  transparent assert (X : (Σ x0, Π v, coconeIn ccab v ;; x0 =
+  transparent assert (X : (∑ x0, ∏ v, coconeIn ccab v ;; x0 =
                                  precatbinprodmor (pr1 ccx v) (pr2 (pr1 ccab v)))).
   { mkpair.
     - split; [ apply (pr1 t) | apply (identity _) ].
@@ -710,7 +710,7 @@ mkpair.
 - apply (tpair _ x2).
   abstract (intro n; apply (maponpaths dirprod_pr2 (p1 n))).
 - intro t.
-  transparent assert (X : (Σ x0, Π v, coconeIn ccab v ;; x0 =
+  transparent assert (X : (∑ x0, ∏ v, coconeIn ccab v ;; x0 =
                                  precatbinprodmor (pr1 (pr1 ccab v)) (pr1 ccx v))).
   { mkpair.
     - split; [ apply (identity _) | apply (pr1 t) ].
@@ -728,11 +728,11 @@ now intros c L ccL M H; apply isColimCocone_pr2_functor.
 Defined.
 
 Lemma isColimCocone_pair_functor {gr : graph}
-  (HF : Π (d : diagram gr A) (c : A) (cc : cocone d c) (h : isColimCocone d c cc),
+  (HF : ∏ (d : diagram gr A) (c : A) (cc : cocone d c) (h : isColimCocone d c cc),
         isColimCocone _ _ (mapcocone F d cc))
-  (HG : Π (d : diagram gr B) (c : B) (cc : cocone d c) (h : isColimCocone d c cc),
+  (HG : ∏ (d : diagram gr B) (c : B) (cc : cocone d c) (h : isColimCocone d c cc),
         isColimCocone _ _ (mapcocone G d cc)) :
-  Π (d : diagram gr (precategory_binproduct A B)) (cd : A × B) (cc : cocone d cd),
+  ∏ (d : diagram gr (precategory_binproduct A B)) (cd : A × B) (cc : cocone d cd),
   isColimCocone _ _ cc ->
   isColimCocone _ _ (mapcocone (pair_functor F G) d cc).
 Proof.
@@ -795,7 +795,7 @@ Defined.
 Local Lemma isColimCocone_pr_functor
   {g : graph} (c : diagram g (power_precategory I A))
   (L : power_precategory I A) (ccL : cocone c L)
-  (M : isColimCocone c L ccL) : Π i,
+  (M : isColimCocone c L ccL) : ∏ i,
   isColimCocone _ _ (mapcocone (pr_functor I (fun _ => A) i) c ccL).
 Proof.
 intros i x ccx; simpl in *.
@@ -825,7 +825,7 @@ mkpair.
     assert (hp : p = idpath i); [apply (isasetifdeceq _ HI)|];
     now rewrite hp, idpath_transportf).
 - intro t.
-  transparent assert (X : (Σ x0, Π n, coconeIn ccL n ;; x0 = coconeIn HHH n)).
+  transparent assert (X : (∑ x0, ∏ n, coconeIn ccL n ;; x0 = coconeIn HHH n)).
   { mkpair.
     - simpl; intro j; unfold ifI.
       destruct (HI i j).
@@ -848,15 +848,15 @@ Proof.
 now intros c L ccL M H; apply isColimCocone_pr_functor.
 Defined.
 
-Lemma isColimCocone_family_functor {gr : graph} (F : Π (i : I), functor A B)
-  (HF : Π i (d : diagram gr A) (c : A) (cc : cocone d c) (h : isColimCocone d c cc),
+Lemma isColimCocone_family_functor {gr : graph} (F : ∏ (i : I), functor A B)
+  (HF : ∏ i (d : diagram gr A) (c : A) (cc : cocone d c) (h : isColimCocone d c cc),
         isColimCocone _ _ (mapcocone (F i) d cc)) :
-  Π (d : diagram gr (product_precategory I (λ _, A))) (cd : I -> A) (cc : cocone d cd),
+  ∏ (d : diagram gr (product_precategory I (λ _, A))) (cd : I -> A) (cc : cocone d cd),
   isColimCocone _ _ cc ->
   isColimCocone _ _ (mapcocone (family_functor I F) d cc).
 Proof.
 intros cAB ml ccml Hccml xy ccxy; simpl in *.
-transparent assert (cc : (Π i, cocone (mapdiagram (F i) (mapdiagram (pr_functor I (λ _ : I, A) i) cAB)) (xy i))).
+transparent assert (cc : (∏ i, cocone (mapdiagram (F i) (mapdiagram (pr_functor I (λ _ : I, A) i) cAB)) (xy i))).
 { intro i; use mk_cocone.
   - intro n; simple refine (pr1 ccxy n _).
   - abstract (intros m n e; apply (toforallpaths _ _ _ (pr2 ccxy m n e) i)).
@@ -869,15 +869,15 @@ mkpair.
 - abstract (intro t; apply subtypeEquality; simpl;
              [ intro x; apply impred; intro; apply impred_isaset; intro i; apply hsB
              | destruct t as [f1 f2]; simpl in *;  apply funextsec; intro i;
-               transparent assert (H : (Σ x : B ⟦ (F i) (ml i), xy i ⟧,
-                                       Π n, # (F i) (coconeIn ccml n i) ;; x =
+               transparent assert (H : (∑ x : B ⟦ (F i) (ml i), xy i ⟧,
+                                       ∏ n, # (F i) (coconeIn ccml n i) ;; x =
                                        coconeIn ccxy n i));
                 [apply (tpair _ (f1 i)); intro n; apply (toforallpaths _ _ _ (f2 n) i)|];
                apply (maponpaths pr1 (pr2 (X i) H))]).
 Defined.
 
 Lemma is_cocont_family_functor
-  {F : Π (i : I), functor A B} (HF : Π (i : I), is_cocont (F i)) :
+  {F : ∏ (i : I), functor A B} (HF : ∏ (i : I), is_cocont (F i)) :
   is_cocont (family_functor I F).
 Proof.
 intros gr cAB ml ccml Hccml.
@@ -885,7 +885,7 @@ apply isColimCocone_family_functor; trivial; intro i; apply HF.
 Defined.
 
 Lemma is_omega_cocont_family_functor
-  {F : Π (i : I), functor A B} (HF : Π (i : I), is_omega_cocont (F i)) :
+  {F : ∏ (i : I), functor A B} (HF : ∏ (i : I), is_omega_cocont (F i)) :
   is_omega_cocont (family_functor I F).
 Proof.
 now intros cAB ml ccml Hccml; apply isColimCocone_family_functor.
@@ -1035,8 +1035,8 @@ Section coproduct_of_functors.
 Context {I : UU} {C D : precategory} (PC : Products I C) (HD : Coproducts I D)
         (hsC : has_homsets C) (hsD : has_homsets D) (HI : isdeceq I).
 
-Lemma is_cocont_coproduct_of_functors_alt (F : Π i, functor C D)
-  (HF : Π i, is_cocont (F i)) :
+Lemma is_cocont_coproduct_of_functors_alt (F : ∏ i, functor C D)
+  (HF : ∏ i, is_cocont (F i)) :
   is_cocont (coproduct_of_functors_alt _ HD F).
 Proof.
 apply (is_cocont_functor_composite hsD).
@@ -1046,8 +1046,8 @@ apply (is_cocont_functor_composite hsD).
 apply (is_cocont_coproduct_functor _ hsD).
 Defined.
 
-Lemma is_omega_cocont_coproduct_of_functors_alt (F : Π i, functor C D)
-  (HF : Π i, is_omega_cocont (F i)) :
+Lemma is_omega_cocont_coproduct_of_functors_alt (F : ∏ i, functor C D)
+  (HF : ∏ i, is_omega_cocont (F i)) :
   is_omega_cocont (coproduct_of_functors_alt _ HD F).
 Proof.
 apply (is_omega_cocont_functor_composite hsD).
@@ -1058,12 +1058,12 @@ apply (is_omega_cocont_coproduct_functor _ hsD).
 Defined.
 
 Definition omega_cocont_coproduct_of_functors_alt
-  (F : Π i, omega_cocont_functor C D) :
+  (F : ∏ i, omega_cocont_functor C D) :
   omega_cocont_functor C D :=
     tpair _ _ (is_omega_cocont_coproduct_of_functors_alt _ (fun i => pr2 (F i))).
 
-Lemma is_cocont_coproduct_of_functors (F : Π (i : I), functor C D)
-  (HF : Π i, is_cocont (F i)) :
+Lemma is_cocont_coproduct_of_functors (F : ∏ (i : I), functor C D)
+  (HF : ∏ i, is_cocont (F i)) :
   is_cocont (coproduct_of_functors I _ _ HD F).
 Proof.
 exact (transportf _
@@ -1071,8 +1071,8 @@ exact (transportf _
         (is_cocont_coproduct_of_functors_alt _ HF)).
 Defined.
 
-Lemma is_omega_cocont_coproduct_of_functors (F : Π (i : I), functor C D)
-  (HF : Π i, is_omega_cocont (F i)) :
+Lemma is_omega_cocont_coproduct_of_functors (F : ∏ (i : I), functor C D)
+  (HF : ∏ i, is_omega_cocont (F i)) :
   is_omega_cocont (coproduct_of_functors I _ _ HD F).
 Proof.
 exact (transportf _
@@ -1081,7 +1081,7 @@ exact (transportf _
 Defined.
 
 Definition omega_cocont_coproduct_of_functors
-  (F : Π i, omega_cocont_functor C D) :
+  (F : ∏ i, omega_cocont_functor C D) :
   omega_cocont_functor C D :=
     tpair _ _ (is_omega_cocont_coproduct_of_functors _ (fun i => pr2 (F i))).
 
@@ -1128,16 +1128,16 @@ Context {C : precategory} (PC : BinProducts C) (hsC : has_homsets C).
 
 (* This hypothesis follow directly if C has exponentials *)
 Variable omega_cocont_constprod_functor1 :
-  Π x : C, is_omega_cocont (constprod_functor1 PC x).
+  ∏ x : C, is_omega_cocont (constprod_functor1 PC x).
 
 Let omega_cocont_constprod_functor2 :
-  Π x : C, is_omega_cocont (constprod_functor2 PC x).
+  ∏ x : C, is_omega_cocont (constprod_functor2 PC x).
 Proof.
 now intro x; apply (is_omega_cocont_iso hsC (flip_iso PC hsC x)).
 Defined.
 
 Local Definition fun_lt (cAB : chain (precategory_binproduct C C)) :
-  Π i j, i < j ->
+  ∏ i j, i < j ->
               C ⟦ BinProductObject C (PC (ob1 (dob cAB i)) (ob2 (dob cAB j))),
                   BinProductObject C (PC (ob1 (dob cAB j)) (ob2 (dob cAB j))) ⟧.
 Proof.
@@ -1146,7 +1146,7 @@ apply (BinProductOfArrows _ _ _ (mor1 (chain_mor cAB hij)) (identity _)).
 Defined.
 
 Local Definition fun_gt (cAB : chain (precategory_binproduct C C)) :
-  Π i j, i > j ->
+  ∏ i j, i > j ->
               C ⟦ BinProductObject C (PC (ob1 (dob cAB i)) (ob2 (dob cAB j))),
                   BinProductObject C (PC (ob1 (dob cAB i)) (ob2 (dob cAB i))) ⟧.
 Proof.
@@ -1264,7 +1264,7 @@ Proof.
   apply BinProductOfArrows; [apply (dmor cAB (idpath _)) | apply identity ].
 Defined.
 
-Local Lemma fNat : Π i u v (e : edge u v),
+Local Lemma fNat : ∏ i u v (e : edge u v),
    dmor (mapchain (constprod_functor1 PC _) cB) e ;; f i v =
    f i u ;; dmor (mapchain (constprod_functor1 PC _) cB) e.
 Proof.
@@ -1283,7 +1283,7 @@ Proof.
     apply (colimOfArrows (CCAiB i) (CCAiB (S i)) (f i) (fNat i)).
 Defined.
 
-Local Lemma AiM_chain_eq : Π i, dmor AiM_chain (idpath (S i)) =
+Local Lemma AiM_chain_eq : ∏ i, dmor AiM_chain (idpath (S i)) =
                        dmor (mapchain (constprod_functor2 PC M) cA) (idpath _).
 Proof.
   intro i; simpl; unfold colimOfArrows, BinProduct_of_functors_mor; simpl.
@@ -1297,7 +1297,7 @@ Proof.
 Qed.
 
 (* Define a cocone over K from the A_i * M chain *)
-Local Lemma ccAiM_K_subproof : Π u v (e : edge u v),
+Local Lemma ccAiM_K_subproof : ∏ u v (e : edge u v),
    dmor (mapdiagram (constprod_functor2 PC M) cA) e ;;
    colimArrow (CCAiB v) K (ccAiB_K v) = colimArrow (CCAiB u) K (ccAiB_K u).
 Proof.
@@ -1352,7 +1352,7 @@ Qed.
 Local Definition ccAiM_K := mk_cocone _ ccAiM_K_subproof.
 
 Local Lemma is_cocone_morphism :
- Π v : nat,
+ ∏ v : nat,
    BinProductOfArrows C (PC L M) (PC (pr1 (dob cAB v)) (pr2 (dob cAB v)))
      (pr1 (coconeIn ccLM v)) (pr2 (coconeIn ccLM v)) ;;
    colimArrow HAiM K ccAiM_K = coconeIn ccK v.
@@ -1377,8 +1377,8 @@ Proof.
 Qed.
 
 Local Lemma is_unique_cocone_morphism :
- Π t : Σ x : C ⟦ BinProductObject C (PC L M), K ⟧,
-       Π v : nat,
+ ∏ t : ∑ x : C ⟦ BinProductObject C (PC L M), K ⟧,
+       ∏ v : nat,
        BinProductOfArrows C (PC L M) (PC (pr1 (dob cAB v)) (pr2 (dob cAB v)))
          (pr1 (coconeIn ccLM v)) (pr2 (coconeIn ccLM v)) ;; x =
        coconeIn ccK v, t = colimArrow HAiM K ccAiM_K,, is_cocone_morphism.
@@ -1418,7 +1418,7 @@ Proof.
 Qed.
 
 Local Definition isColimProductOfColims :  ∃! x : C ⟦ BinProductObject C (PC L M), K ⟧,
-   Π v : nat,
+   ∏ v : nat,
    BinProductOfArrows C (PC L M) (PC (pr1 (dob cAB v)) (pr2 (dob cAB v)))
      (pr1 (coconeIn ccLM v)) (pr2 (coconeIn ccLM v)) ;; x =
    coconeIn ccK v.
@@ -1447,7 +1447,7 @@ Context {C D : precategory} (PC : BinProducts C) (PD : BinProducts D)
         (hsC : has_homsets C) (hsD : has_homsets D).
 
 Variable omega_cocont_constprod_functor1 :
-  Π x : D, is_omega_cocont (constprod_functor1 PD x).
+  ∏ x : D, is_omega_cocont (constprod_functor1 PD x).
 
 Lemma is_omega_cocont_BinProduct_of_functors_alt (F G : functor C D)
   (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
@@ -1487,7 +1487,7 @@ Context {A B C : precategory} (F : functor A B) (hsB : has_homsets B) (hsC : has
 
 Lemma preserves_colimit_pre_composition_functor {g : graph}
   (d : diagram g [B,C,hsC]) (G : [B,C,hsC])
-  (ccG : cocone d G) (H : Π b, ColimCocone (diagram_pointwise hsC d b)) :
+  (ccG : cocone d G) (H : ∏ b, ColimCocone (diagram_pointwise hsC d b)) :
   preserves_colimit (pre_composition_functor A B C hsB hsC F) d G ccG.
 Proof.
 intros HccG.
@@ -1496,7 +1496,7 @@ now apply (isColimFunctor_is_pointwise_Colim _ _ H _ _ HccG).
 Defined.
 
 (* Lemma is_cocont_pre_composition_functor *)
-(*   (H : Π (g : graph) (d : diagram g [B,C,hsC]) (b : B), *)
+(*   (H : ∏ (g : graph) (d : diagram g [B,C,hsC]) (b : B), *)
 (*        ColimCocone (diagram_pointwise hsC d b)) : *)
 (*   is_cocont (pre_composition_functor _ _ _ hsB hsC F). *)
 (* Proof. *)
@@ -1619,7 +1619,7 @@ intros HccL y ccy.
 set (CC := mk_ColimCocone _ _ _ HccL).
 transparent assert (c : (HSET / X)).
 { mkpair.
-  - exists (Σ (x : pr1 X), pr1 y).
+  - exists (∑ (x : pr1 X), pr1 y).
     abstract (apply isaset_total2; intros; apply setproperty).
   - apply pr1.
 }
@@ -1656,7 +1656,7 @@ transparent assert (k : (HSET/X⟦colim CC,c⟧)).
     apply (f l').
   - abstract (now apply funextsec).
 }
-assert (Hk : (Π n, colimIn CC n ;; k = coconeIn cc n)).
+assert (Hk : (∏ n, colimIn CC n ;; k = coconeIn cc n)).
 { intros n.
   apply subtypeEquality; [intros x; apply setproperty|].
   apply funextsec; intro z.

--- a/UniMath/CategoryTheory/CommaCategories.v
+++ b/UniMath/CategoryTheory/CommaCategories.v
@@ -43,9 +43,9 @@ Variable hsM : has_homsets M.
 Variable K : functor M C.
 Variable c : C.
 
-Definition ccomma_object : UU := Σ m, C⟦c, K m⟧.
+Definition ccomma_object : UU := ∑ m, C⟦c, K m⟧.
 Definition ccomma_morphism (a b : ccomma_object) : UU
-  := Σ f : _ ⟦pr1 a, pr1 b⟧, pr2 a ;; #K f = pr2 b.
+  := ∑ f : _ ⟦pr1 a, pr1 b⟧, pr2 a ;; #K f = pr2 b.
 
 Definition isaset_ccomma_morphism a b : isaset (ccomma_morphism a b).
 Proof.

--- a/UniMath/CategoryTheory/DiscretePrecategory.v
+++ b/UniMath/CategoryTheory/DiscretePrecategory.v
@@ -57,7 +57,7 @@ Defined.
 (** A natural transformation of functors is given by a family of morphisms *)
 Definition is_nat_trans_discrete_precategory {D : precategory} (Dhom : has_homsets D)
            {f g : functor_precategory discrete_precategory D Dhom}
-           (F : Π x : A , (pr1 f) x --> (pr1 g) x)
+           (F : ∏ x : A , (pr1 f) x --> (pr1 g) x)
   : is_nat_trans (pr1 f) (pr1 g) F.
 Proof.
   intros x y h.

--- a/UniMath/CategoryTheory/EpiFacts.v
+++ b/UniMath/CategoryTheory/EpiFacts.v
@@ -45,13 +45,13 @@ Section EffectiveEpi.
   Definition kernel_pair := Pullback  f f.
 
   Definition isEffective :=
-    Σ  g:kernel_pair,
+    ∑  g:kernel_pair,
          (isCoequalizer (PullbackPr1 g)
                         (PullbackPr2 g) f (PullbackSqrCommutes g)).
 End EffectiveEpi.
 
 Definition EpisAreEffective (C:precategory) :=
-  Π (A B:C) (f:C⟦A,B⟧), isEpi f -> isEffective f.
+  ∏ (A B:C) (f:C⟦A,B⟧), isEpi f -> isEffective f.
 
 
 
@@ -97,7 +97,7 @@ Section IsEffectivePw.
 
   Context {X Y :functor C D } {a:X⟶Y}.
 
-  Lemma isEffectivePw : (Π (x:C), isEffective (a x)) -> isEffective (C:=CD) a.
+  Lemma isEffectivePw : (∏ (x:C), isEffective (a x)) -> isEffective (C:=CD) a.
   Proof.
     intros h.
     red.
@@ -157,7 +157,7 @@ Section PointwiseEpi.
   Defined.
 
   Lemma Pushouts_pw_epi (colimD : graphs.pushouts.Pushouts D) (A B : functor C D)
-       (a: A⟶B)  (epia:isEpi (C:=CD) a) : Π (x:C), isEpi (a x).
+       (a: A⟶B)  (epia:isEpi (C:=CD) a) : ∏ (x:C), isEpi (a x).
   Proof.
     intro  x; simpl.
     apply (epi_to_pushout (C:=CD)) in epia.

--- a/UniMath/CategoryTheory/Epis.v
+++ b/UniMath/CategoryTheory/Epis.v
@@ -27,10 +27,10 @@ Section def_epi.
 
   (** Definition and construction of isEpi. *)
   Definition isEpi {x y : C} (f : x --> y) : UU :=
-    Π (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h.
+    ∏ (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h.
 
   Definition mk_isEpi {x y : C} (f : x --> y)
-             (H : Π (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h) : isEpi f := H.
+             (H : ∏ (z : C) (g h : y --> z), f ;; g = f ;; h -> g = h) : isEpi f := H.
 
   Lemma isapropisEpi {y z : C} (f : y --> z) : isaprop (isEpi f).
   Proof.
@@ -42,7 +42,7 @@ Section def_epi.
   Qed.
 
   (** Definition and construction of Epi. *)
-  Definition Epi (x y : C) : UU := Σ f : x --> y, isEpi f.
+  Definition Epi (x y : C) : UU := ∑ f : x --> y, isEpi f.
   Definition mk_Epi {x y : C} (f : x --> y) (H : isEpi f) :
     Epi x y := tpair _ f H.
 
@@ -127,7 +127,7 @@ Section epis_subcategory.
 
   Definition hsubtype_obs_isEpi : hsubtype C := (fun c : C => hProppair _ isapropunit).
 
-  Definition hsubtype_mors_isEpi : Π (a b : C), hsubtype (C⟦a, b⟧) :=
+  Definition hsubtype_mors_isEpi : ∏ (a b : C), hsubtype (C⟦a, b⟧) :=
     (fun a b : C => (fun f : C⟦a, b⟧ => hProppair _ (isapropisEpi C hs f))).
 
   Definition subprecategory_of_epis : sub_precategories C.
@@ -158,7 +158,7 @@ End epis_subcategory.
 Section epis_functorcategories.
 
   Lemma is_nat_trans_epi_from_pointwise_epis (C D : precategory) (hs : has_homsets D)
-        (F G : ob (functor_precategory C D hs)) (α : F --> G) (H : Π a : ob C, isEpi (pr1 α a)) :
+        (F G : ob (functor_precategory C D hs)) (α : F --> G) (H : ∏ a : ob C, isEpi (pr1 α a)) :
     isEpi α.
   Proof.
     intros G' β η H'.

--- a/UniMath/CategoryTheory/FiveLemma.v
+++ b/UniMath/CategoryTheory/FiveLemma.v
@@ -201,8 +201,8 @@ Section five_lemma_data.
   (** *** Define row for [FiveLemma] *)
 
   Definition FiveRow : UU :=
-    Σ (FRO : FiveRowObs),
-    (Σ (FRD : FiveRowDiffs FRO), (Σ (FRDE : FiveRowDiffsEq FRD), FiveRowExacts FRDE)).
+    ∑ (FRO : FiveRowObs),
+    (∑ (FRD : FiveRowDiffs FRO), (∑ (FRDE : FiveRowDiffsEq FRD), FiveRowExacts FRDE)).
 
   Definition mk_FiveRow (FRO : FiveRowObs) (FRD : FiveRowDiffs FRO) (FRDE : FiveRowDiffsEq FRD)
              (FRE : FiveRowExacts FRDE) : FiveRow := (FRO,,(FRD,,(FRDE,,FRE))).
@@ -280,7 +280,7 @@ Section five_lemma_data.
   (** *** Morphism of rows *)
 
   Definition FiveRowMorphism (FR1 FR2 : FiveRow) : UU :=
-    Σ (FRMs : FiveRowMors FR1 FR2), FiveRowMorsComm FRMs.
+    ∑ (FRMs : FiveRowMors FR1 FR2), FiveRowMorsComm FRMs.
 
   Definition mk_FiveRowMorphism (FR1 FR2 : FiveRow) (FRMs : FiveRowMors FR1 FR2)
              (FRMC : FiveRowMorsComm FRMs) : FiveRowMorphism FR1 FR2 := (FRMs,,FRMC).

--- a/UniMath/CategoryTheory/FunctorAlgebras.v
+++ b/UniMath/CategoryTheory/FunctorAlgebras.v
@@ -37,7 +37,7 @@ Section Algebra_Definition.
 
 Context {C : precategory} (F : functor C C).
 
-Definition algebra_ob : UU := Σ X : C, F X --> X.
+Definition algebra_ob : UU := ∑ X : C, F X --> X.
 
 (* this coercion causes confusion, and it is not inserted when parsing most of the time
    thus removing coercion globally
@@ -51,7 +51,7 @@ Definition is_algebra_mor (X Y : algebra_ob) (f : alg_carrier X --> alg_carrier 
   := alg_map X ;; f = #F f ;; alg_map Y.
 
 Definition algebra_mor (X Y : algebra_ob) : UU :=
-  Σ f : X --> Y, is_algebra_mor X Y f.
+  ∑ f : X --> Y, is_algebra_mor X Y f.
 
 Coercion mor_from_algebra_mor (X Y : algebra_ob) (f : algebra_mor X Y) : X --> Y := pr1 f.
 
@@ -147,7 +147,7 @@ Section FunctorAlg_saturated.
 Hypothesis H : is_category C.
 
 Definition algebra_eq_type (X Y : FunctorAlg (pr2 H)) : UU
-  := Σ p : iso (pr1 X) (pr1 Y), pr2 X ;; p = #F p ;; pr2 Y.
+  := ∑ p : iso (pr1 X) (pr1 Y), pr2 X ;; p = #F p ;; pr2 Y.
 
 Definition algebra_ob_eq (X Y : FunctorAlg (pr2 H)) :
   (X = Y) ≃ algebra_eq_type X Y.
@@ -221,7 +221,7 @@ Proof.
 Defined.
 
 Definition algebra_iso_first_iso {X Y : FunctorAlg (pr2 H)}
-  : iso X Y ≃ Σ f : X --> Y, is_iso (pr1 f).
+  : iso X Y ≃ ∑ f : X --> Y, is_iso (pr1 f).
 Proof.
   apply (weqbandf (idweq _ )).
   intro f.
@@ -248,7 +248,7 @@ Proof.
 Defined.
 
 Definition algebra_iso_rearrange {X Y : FunctorAlg (pr2 H)}
-  : (Σ f : X --> Y, is_iso (pr1 f)) ≃ algebra_eq_type X Y.
+  : (∑ f : X --> Y, is_iso (pr1 f)) ≃ algebra_eq_type X Y.
 Proof.
   eapply weqcomp.
   - apply weqtotal2asstor.

--- a/UniMath/CategoryTheory/GrothendieckTopos.v
+++ b/UniMath/CategoryTheory/GrothendieckTopos.v
@@ -81,16 +81,16 @@ Section def_grothendiecktopology.
 
   (** ** Grothendieck topology *)
 
-  Definition collection_of_sieves : UU := Π (c : C), hsubtype (sieve c).
+  Definition collection_of_sieves : UU := ∏ (c : C), hsubtype (sieve c).
 
   Definition isGrothendieckTopology_maximal_sieve (COS : collection_of_sieves) : UU :=
-    Π (c : C), COS c (SubobjectsPrecategory_ob
+    ∏ (c : C), COS c (SubobjectsPrecategory_ob
                         (functor_precategory (opp_precat C) HSET has_homsets_HSET)
                         (functor_category_has_homsets (opp_precat C) HSET has_homsets_HSET)
                         (identity (yoneda C hs c)) (identity_isMonic _)).
 
   Definition isGrothendieckTopology_stability (COS : collection_of_sieves) : UU :=
-    Π (c c' : C) (h : c' --> c) (s : sieve c),
+    ∏ (c c' : C) (h : c' --> c) (s : sieve c),
     COS c s ->
     COS c' (PullbackSubobject
               _ _
@@ -98,8 +98,8 @@ Section def_grothendiecktopology.
               s (yoneda_morphisms C hs _ _ h)).
 
   Definition isGrothendieckTopology_transitivity (COS : collection_of_sieves) : UU :=
-    Π (c : C) (s : sieve c),
-    (Π (c' : C) (h : c' --> c),
+    ∏ (c : C) (s : sieve c),
+    (∏ (c' : C) (h : c' --> c),
      COS c' (PullbackSubobject
                _ _
                (FunctorPrecategoryPullbacks (opp_precat C) HSET has_homsets_HSET HSET_Pullbacks)
@@ -112,7 +112,7 @@ Section def_grothendiecktopology.
       × (isGrothendieckTopology_transitivity COS).
 
   Definition GrothendieckTopology : UU :=
-    Σ COS : collection_of_sieves, isGrothendieckTopology COS.
+    ∑ COS : collection_of_sieves, isGrothendieckTopology COS.
 
   (** Accessor functions *)
   Definition GrothendieckTopology_COS (GT : GrothendieckTopology) : collection_of_sieves := pr1 GT.
@@ -132,9 +132,9 @@ Section def_grothendiecktopology.
 
   (** This is a formalization of the definition on page 122 *)
   Definition isSheaf (P : Presheaf) (GT : GrothendieckTopology) : UU :=
-    Π (c : C) (S : sieve c) (isCOS : GrothendieckTopology_COS GT c S)
+    ∏ (c : C) (S : sieve c) (isCOS : GrothendieckTopology_COS GT c S)
       (τ : nat_trans (sieve_functor S) (PresheafToFunctor P)),
-    iscontr (Σ η : nat_trans (FunctorPrecatObToFunctor (yoneda C hs c)) (PresheafToFunctor P),
+    iscontr (∑ η : nat_trans (FunctorPrecatObToFunctor (yoneda C hs c)) (PresheafToFunctor P),
                    nat_trans_comp _ _ _ (sieve_nat_trans S) η = τ).
 
   Lemma isaprop_isSheaf (GT : GrothendieckTopology) (P : Presheaf) : isaprop(isSheaf P GT).
@@ -171,7 +171,7 @@ Section def_grothendiecktopos.
   (** Here (pr1 D) is the precategory which is equivalent to the precategory of sheaves on the
       Grothendieck topology (pr2 D). *)
   Definition GrothendieckTopos : UU :=
-    Σ D' : (Σ D : precategory × (GrothendieckTopology C hs),
+    ∑ D' : (∑ D : precategory × (GrothendieckTopology C hs),
                   functor (pr1 D) (PrecategoryOfSheaves C hs (pr2 D))),
            (adj_equivalence_of_precats (pr2 D')).
 

--- a/UniMath/CategoryTheory/HLevel_n_is_of_hlevel_Sn.v
+++ b/UniMath/CategoryTheory/HLevel_n_is_of_hlevel_Sn.v
@@ -46,7 +46,7 @@ Defined.
     the hProposition [P] with this fibration.
 *)
 
-Lemma ident_is_prop : Π (P : UU -> hProp) (X X' : UU)
+Lemma ident_is_prop : ∏ (P : UU -> hProp) (X X' : UU)
       (pX : P X) (pX' : P X') (w : X = X'),
    isaprop (transportf (fun X => P X) w pX = pX').
 Proof.
@@ -135,7 +135,7 @@ Defined.
 
 (** *** The case [n = S n'] *)
 
-Lemma isofhlevelSnpathspace : Π n : nat, Π X Y : UU,
+Lemma isofhlevelSnpathspace : ∏ n : nat, ∏ X Y : UU,
       isofhlevel (S n) Y -> isofhlevel (S n) (X = Y).
 Proof.
   intros n X Y pY.
@@ -154,7 +154,7 @@ Defined.
 
 (** ** The lemma itself *)
 
-Lemma isofhlevelpathspace : Π n : nat, Π X Y : UU,
+Lemma isofhlevelpathspace : ∏ n : nat, ∏ X Y : UU,
       isofhlevel n X -> isofhlevel n Y -> isofhlevel n (X = Y).
 Proof.
   intros n.
@@ -178,7 +178,7 @@ Definition HLevel n := total2 (fun X : UU => isofhlevel n X).
 
 (** * Main theorem: [HLevel n] is of hlevel [S n] *)
 
-Lemma hlevel_of_hlevels : Π n,
+Lemma hlevel_of_hlevels : ∏ n,
       isofhlevel (S n) (HLevel n).
 Proof.
   intro n.
@@ -210,7 +210,7 @@ Proof.
   exact (weqcomp f g).
 Defined.
 
-Corollary UA_for_HLevels : Π (n : nat)
+Corollary UA_for_HLevels : ∏ (n : nat)
       (X X' : HLevel n),
      weq (X = X') (weq (pr1 X) (pr1 X')).
 Proof.

--- a/UniMath/CategoryTheory/HorizontalComposition.v
+++ b/UniMath/CategoryTheory/HorizontalComposition.v
@@ -56,7 +56,7 @@ Qed.
 
 Lemma horcomp_id_left (C D : precategory) (X : functor C C) (Z Z' : functor C D)(f : nat_trans Z Z')
   :
-  Π c : C, horcomp (nat_trans_id X) f c = f (X c).
+  ∏ c : C, horcomp (nat_trans_id X) f c = f (X c).
 Proof.
   intro c; simpl.
   now rewrite functor_id, id_right.

--- a/UniMath/CategoryTheory/Inductives/Lists.v
+++ b/UniMath/CategoryTheory/Inductives/Lists.v
@@ -125,11 +125,11 @@ Transparent foldr_map.
 (** The induction principle for lists defined using foldr *)
 Section list_induction.
 
-Variables (P : List -> UU) (PhSet : Π l, isaset (P l)).
+Variables (P : List -> UU) (PhSet : ∏ l, isaset (P l)).
 Variables (P0 : P nil)
-          (Pc : Π a l, P l -> P (cons a l)).
+          (Pc : ∏ a l, P l -> P (cons a l)).
 
-Let P' : UU := Σ l, P l.
+Let P' : UU := ∑ l, P l.
 Let P0' : P' := (nil,, P0).
 Let Pc' : pr1 A  → P' -> P' :=
   λ (a : pr1 A) (p : P'), cons a (pr1 p),,Pc a (pr1 p) (pr2 p).
@@ -174,7 +174,7 @@ Defined.
 End list_induction.
 
 Lemma listIndhProp (P : List → hProp) :
-  P nil → (Π a l, P l → P (cons a l)) → Π l, P l.
+  P nil → (∏ a l, P l → P (cons a l)) → ∏ l, P l.
 Proof.
 intros Pnil Pcons.
 apply listInd; try assumption.
@@ -182,8 +182,8 @@ intro l; apply isasetaprop, propproperty.
 Defined.
 
 (* This variation is easier to use *)
-Lemma listIndProp (P : List → UU) (HP : Π l, isaprop (P l)) :
-  P nil → (Π a l, P l → P (cons a l)) → Π l, P l.
+Lemma listIndProp (P : List → UU) (HP : ∏ l, isaprop (P l)) :
+  P nil → (∏ a l, P l → P (cons a l)) → ∏ l, P l.
 Proof.
 intros Pnil Pcons.
 apply listInd; try assumption.
@@ -199,7 +199,7 @@ Definition length : List -> nat := foldr natHSET 0 (λ _ (n : nat), 1 + n).
 Definition map (f : A -> A) : List -> List :=
   foldr _ nil (λ (x : A) (xs : List), cons (f x) xs).
 
-Lemma length_map (f : A -> A) : Π xs, length (map f xs) = length xs.
+Lemma length_map (f : A -> A) : ∏ xs, length (map f xs) = length xs.
 Proof.
 apply listIndProp.
 - intros l; apply isasetnat.
@@ -246,7 +246,7 @@ Eval lazy in sum testlistS.
 Eval lazy in length _ (concatenate _ testlist testlistS).
 Eval lazy in sum (concatenate _ testlist testlistS).
 
-Goal (Π l, length _ (2 :: l) = S (length _ l)).
+Goal (∏ l, length _ (2 :: l) = S (length _ l)).
 simpl.
 intro l.
 try apply idpath. (* this doesn't work *)
@@ -261,7 +261,7 @@ Abort.
 
 (* Eval compute in const 0 (nil natHSET). *)
 
-(* Axiom const' : Π {A B : UU}, A -> B -> A. *)
+(* Axiom const' : ∏ {A B : UU}, A -> B -> A. *)
 
 (* Eval compute in const' 0 1. *)
 (* Eval compute in const' 0 (nil natHSET). *)
@@ -297,7 +297,7 @@ apply (foldr A (list (pr1 A),,isaset_list A)).
   apply (tpair _ (S (pr1 L)) (a,,pr2 L)).
 Defined.
 
-Lemma to_listK (A : HSET) : Π x : list (pr1 A), to_list A (to_List A x) = x.
+Lemma to_listK (A : HSET) : ∏ x : list (pr1 A), to_list A (to_List A x) = x.
 Proof.
 intro l; destruct l as [n l]; unfold to_list, to_List.
 induction n as [|n IHn]; simpl.
@@ -307,7 +307,7 @@ induction n as [|n IHn]; simpl.
   now rewrite IHn; simpl; rewrite <- (tppr l).
 Qed.
 
-Lemma to_ListK (A : HSET) : Π y : List A, to_List A (to_list A y) = y.
+Lemma to_ListK (A : HSET) : ∏ y : List A, to_List A (to_list A y) = y.
 Proof.
 apply listIndProp.
 * intro l; apply setproperty.
@@ -436,7 +436,7 @@ simple refine (tpair _ _ _).
   | destruct t as [t p]; destruct ccL as [t0 p0]; unfold BinCoproduct_of_functors_mor in *; destruct t0 as [t0 p1]; simpl;
     apply BinCoproductArrowUnique;
     [ now rewrite <- (p 0), assoc, BinCoproductOfArrowsIn1, id_left
-    | simple refine (let temp : Σ x0 : C ⟦ c, HcL ⟧, Π v : nat,
+    | simple refine (let temp : ∑ x0 : C ⟦ c, HcL ⟧, ∏ v : nat,
          coconeIn L v ;; x0 = BinCoproductIn2 C (PC x (dob hF v)) ;; f v := _ in _);
          [ apply (tpair _ (BinCoproductIn2 C (PC x c) ;; t));
           now intro n; rewrite <- (p n), !assoc, BinCoproductOfArrowsIn2|];
@@ -552,11 +552,11 @@ Transparent foldr_map.
 (* This defines the induction principle for lists using foldr *)
 Section list_induction.
 
-Variables (P : pr1 List -> UU) (PhSet : Π l, isaset (P l)).
+Variables (P : pr1 List -> UU) (PhSet : ∏ l, isaset (P l)).
 Variables (P0 : P nil)
-          (Pc : Π (a : pr1 A) (l : pr1 List), P l -> P (cons (a,,l))).
+          (Pc : ∏ (a : pr1 A) (l : pr1 List), P l -> P (cons (a,,l))).
 
-Let P' : UU := Σ l, P l.
+Let P' : UU := ∑ l, P l.
 Let P0' : P' := (nil,, P0).
 Let Pc' : pr1 A × P' -> P' :=
   λ ap : pr1 A × P', cons (pr1 ap,, pr1 (pr2 ap)),,Pc (pr1 ap) (pr1 (pr2 ap)) (pr2 (pr2 ap)).
@@ -594,8 +594,8 @@ Defined.
 
 End list_induction.
 
-Lemma listIndProp (P : pr1 List -> UU) (HP : Π l, isaprop (P l)) :
-  P nil -> (Π a l, P l → P (cons (a,, l))) -> Π l, P l.
+Lemma listIndProp (P : pr1 List -> UU) (HP : ∏ l, isaprop (P l)) :
+  P nil -> (∏ a l, P l → P (cons (a,, l))) -> ∏ l, P l.
 Proof.
 intros Pnil Pcons.
 apply listInd; try assumption.
@@ -614,7 +614,7 @@ Definition length : pr1 List -> nat :=
 Definition map (f : pr1 A -> pr1 A) : pr1 List -> pr1 List :=
   foldr _ nil (λ xxs : pr1 A × pr1 List, cons (f (pr1 xxs),, pr2 xxs)).
 
-Lemma length_map (f : pr1 A -> pr1 A) : Π xs, length (map f xs) = length xs.
+Lemma length_map (f : pr1 A -> pr1 A) : ∏ xs, length (map f xs) = length xs.
 Proof.
 apply listIndProp.
 - intros l; apply isasetnat.
@@ -661,7 +661,7 @@ Definition sum : pr1 (List natHSET) -> nat :=
 (* native_compute. *)
 (* Abort. *)
 
-Goal (Π l, length _ (2 :: l) = S (length _ l)).
+Goal (∏ l, length _ (2 :: l) = S (length _ l)).
 simpl.
 intro l.
 try apply idpath. (* this doesn't work *)

--- a/UniMath/CategoryTheory/Inductives/Trees.v
+++ b/UniMath/CategoryTheory/Inductives/Trees.v
@@ -130,11 +130,11 @@ Transparent foldr_map.
 (** This defines the induction principle for trees using foldr *)
 Section tree_induction.
 
-Variables (P : pr1 Tree -> UU) (PhSet : Π l, isaset (P l)).
+Variables (P : pr1 Tree -> UU) (PhSet : ∏ l, isaset (P l)).
 Variables (P0 : P leaf)
-          (Pc : Π (a : pr1 A) (l1 l2 : pr1 Tree), P l1 -> P l2 -> P (node (a,,l1,,l2))).
+          (Pc : ∏ (a : pr1 A) (l1 l2 : pr1 Tree), P l1 -> P l2 -> P (node (a,,l1,,l2))).
 
-Let P' : UU := Σ l, P l.
+Let P' : UU := ∑ l, P l.
 Let P0' : P' := (leaf,, P0).
 Let Pc' : pr1 A × P' × P' -> P'.
 Proof.
@@ -182,8 +182,8 @@ Defined.
 
 End tree_induction.
 
-Lemma treeIndProp (P : pr1 Tree -> UU) (HP : Π l, isaprop (P l)) :
-  P leaf -> (Π a l1 l2, P l1 → P l2 → P (node (a,,l1,,l2))) -> Π l, P l.
+Lemma treeIndProp (P : pr1 Tree -> UU) (HP : ∏ l, isaprop (P l)) :
+  P leaf -> (∏ a l1 l2, P l1 → P l2 → P (node (a,,l1,,l2))) -> ∏ l, P l.
 Proof.
 intros Pnil Pcons.
 apply treeInd; try assumption.
@@ -210,7 +210,7 @@ Definition map (f : nat -> nat) (l : pr1 (Tree natHSET)) : pr1 (Tree natHSET) :=
   foldr natHSET (Tree natHSET) (leaf natHSET)
       (λ a, node natHSET (f (pr1 a),, pr1 (pr2 a),, pr2 (pr2 a))) l.
 
-Lemma size_map (f : nat -> nat) : Π l, size (map f l) = size l.
+Lemma size_map (f : nat -> nat) : ∏ l, size (map f l) = size l.
 Proof.
 apply treeIndProp.
 - intros l. apply isasetnat.

--- a/UniMath/CategoryTheory/LocalizingClass.v
+++ b/UniMath/CategoryTheory/LocalizingClass.v
@@ -31,27 +31,27 @@ Section def_roofs.
   Variable C : precategory.
   Hypothesis hs : has_homsets C.
 
-  Definition SubsetsOfMors : UU := Π (x y : ob C), hsubtype (hSetpair (C⟦x, y⟧) (hs x y)).
+  Definition SubsetsOfMors : UU := ∏ (x y : ob C), hsubtype (hSetpair (C⟦x, y⟧) (hs x y)).
 
   (** ** Localizing classes *)
 
   (** *** Identities and compositions are in the subset of morphisms *)
   Definition isLocalizingClass1 (SOM : SubsetsOfMors) : UU :=
-    (Π (x : ob C), SOM x x (identity x))
-      × (Π (x y z : ob C) (f : x --> y) (e1 : SOM x y f) (g : y --> z) (e2 : SOM y z g),
+    (∏ (x : ob C), SOM x x (identity x))
+      × (∏ (x y z : ob C) (f : x --> y) (e1 : SOM x y f) (g : y --> z) (e2 : SOM y z g),
          SOM x z (f ;; g)).
 
   Definition isLocClassIs {SOM : SubsetsOfMors} (H : isLocalizingClass1 SOM) :
-    Π (x : ob C), SOM x x (identity x) := pr1 H.
+    ∏ (x : ob C), SOM x x (identity x) := pr1 H.
 
   Definition isLocClassComp {SOM : SubsetsOfMors} (H : isLocalizingClass1 SOM) :
-    Π (x y z : ob C) (f : x --> y) (e1 : SOM x y f) (g : y --> z) (e2 : SOM y z g),
+    ∏ (x y z : ob C) (f : x --> y) (e1 : SOM x y f) (g : y --> z) (e2 : SOM y z g),
     SOM x z (f ;; g) := pr2 H.
 
   (** **** Squares *)
   Definition LocSqr1 (SOM : SubsetsOfMors) {x y z : ob C} (s : x --> y) (e1 : SOM x y s)
              (f : x --> z) : UU :=
-    Σ D : (Σ (w : ob C), C⟦y, w⟧ × C⟦z, w⟧),
+    ∑ D : (∑ (w : ob C), C⟦y, w⟧ × C⟦z, w⟧),
           (SOM z (pr1 D) (dirprod_pr2 (pr2 D)))
             × (s ;; (dirprod_pr1 (pr2 D)) = f ;; (dirprod_pr2 (pr2 D))).
 
@@ -75,7 +75,7 @@ Section def_roofs.
 
   Definition LocSqr2 (SOM : SubsetsOfMors) {y z w : ob C} (s : y --> w) (e1 : SOM y w s)
              (f : z --> w) : UU :=
-    Σ D : (Σ (x : ob C), C⟦x, y⟧ × C⟦x, z⟧),
+    ∑ D : (∑ (x : ob C), C⟦x, y⟧ × C⟦x, z⟧),
           (SOM (pr1 D) z (dirprod_pr2 (pr2 D)))
             × ((dirprod_pr1 (pr2 D)) ;; s = (dirprod_pr2 (pr2 D)) ;; f).
 
@@ -99,21 +99,21 @@ Section def_roofs.
 
   (** *** Completion to squares *)
   Definition isLocalizingClass2 (SOM : SubsetsOfMors) : UU :=
-    (Π (x y z : ob C) (s : x --> y) (e1 : SOM x y s) (f : x --> z), (LocSqr1 SOM s e1 f))
-      × (Π (y z w : ob C) (s : y --> w) (e1 : SOM y w s) (f : z --> w), (LocSqr2 SOM s e1 f)).
+    (∏ (x y z : ob C) (s : x --> y) (e1 : SOM x y s) (f : x --> z), (LocSqr1 SOM s e1 f))
+      × (∏ (y z w : ob C) (s : y --> w) (e1 : SOM y w s) (f : z --> w), (LocSqr2 SOM s e1 f)).
 
   Definition isLocClassSqr1 {SOM : SubsetsOfMors} (H : isLocalizingClass2 SOM) :
-    Π (x y z : ob C) (s : x --> y) (e1 : SOM x y s) (f : x --> z), LocSqr1 SOM s e1 f :=
+    ∏ (x y z : ob C) (s : x --> y) (e1 : SOM x y s) (f : x --> z), LocSqr1 SOM s e1 f :=
     dirprod_pr1 H.
 
   Definition isLocClassSqr2 {SOM : SubsetsOfMors} (H : isLocalizingClass2 SOM) :
-    Π (y z w : ob C) (s : y --> w) (e1 : SOM y w s) (f : z --> w), LocSqr2 SOM s e1 f :=
+    ∏ (y z w : ob C) (s : y --> w) (e1 : SOM y w s) (f : z --> w), LocSqr2 SOM s e1 f :=
     dirprod_pr2 H.
 
   (** **** Pre- and post switch *)
   Definition PreSwitch (SOM : SubsetsOfMors) {x y z : ob C} (s : x --> y) (e : SOM x y s)
              (f g : y --> z) (H : s ;; f = s ;; g) : UU :=
-    Σ D : (Σ (w : ob C), C⟦z, w⟧), (SOM z (pr1 D) (pr2 D)) × (f ;; (pr2 D) = g ;; (pr2 D)).
+    ∑ D : (∑ (w : ob C), C⟦z, w⟧), (SOM z (pr1 D) (pr2 D)) × (f ;; (pr2 D) = g ;; (pr2 D)).
 
   Definition PreSwitchOb {SOM : SubsetsOfMors} {x y z : ob C} {s : x --> y} {e : SOM x y s}
              {f g : y --> z} {H : s ;; f = s ;; g} (PreS : PreSwitch SOM s e f g H) : ob C :=
@@ -136,7 +136,7 @@ Section def_roofs.
 
   Definition PostSwitch (SOM : SubsetsOfMors) {y z w : ob C} (f g : y --> z) (s : z --> w)
              (e : SOM z w s) (H : f ;; s = g ;; s) : UU :=
-    Σ D : (Σ (x : ob C), C⟦x, y⟧), (SOM (pr1 D) y (pr2 D)) × ((pr2 D) ;; f = (pr2 D) ;; g).
+    ∑ D : (∑ (x : ob C), C⟦x, y⟧), (SOM (pr1 D) y (pr2 D)) × ((pr2 D) ;; f = (pr2 D) ;; g).
 
   Definition PostSwitchOb {SOM : SubsetsOfMors} {y z w : ob C} {f g : y --> z} {s : z --> w}
              {e : SOM z w s} {H : f ;; s = g ;; s} (PostS : PostSwitch SOM f g s e H) : ob C :=
@@ -157,17 +157,17 @@ Section def_roofs.
 
   (** *** Pre- and postcomposition with morphisms in the subset *)
   Definition isLocalizingClass3 (SOM : SubsetsOfMors) : UU :=
-    (Π (x y z : ob C) (s : x --> y) (e : SOM x y s) (f g : y --> z) (H : s ;; f = s ;; g),
+    (∏ (x y z : ob C) (s : x --> y) (e : SOM x y s) (f g : y --> z) (H : s ;; f = s ;; g),
      PreSwitch SOM s e f g H)
-      × (Π (y z w : ob C) (f g : y --> z) (s : z --> w) (e : SOM z w s) (H : f ;; s = g ;; s),
+      × (∏ (y z w : ob C) (f g : y --> z) (s : z --> w) (e : SOM z w s) (H : f ;; s = g ;; s),
          PostSwitch SOM f g s e H).
 
   Definition isLocClassPre {SOM : SubsetsOfMors} (H : isLocalizingClass3 SOM) :
-    Π (x y z : ob C) (s : x --> y) (e : SOM x y s) (f g : y --> z) (H : s ;; f = s ;; g),
+    ∏ (x y z : ob C) (s : x --> y) (e : SOM x y s) (f g : y --> z) (H : s ;; f = s ;; g),
     PreSwitch SOM s e f g H := dirprod_pr1 H.
 
   Definition isLocClassPost {SOM : SubsetsOfMors} (H : isLocalizingClass3 SOM) :
-    Π (y z w : ob C) (f g : y --> z) (s : z --> w) (e : SOM z w s) (H : f ;; s = g ;; s),
+    ∏ (y z w : ob C) (f g : y --> z) (s : z --> w) (e : SOM z w s) (H : f ;; s = g ;; s),
     PostSwitch SOM f g s e H := dirprod_pr2 H.
 
   (** *** Localizing class *)
@@ -197,7 +197,7 @@ Section def_roofs.
 
   (** ** Roofs *)
   Definition Roof (x y : ob C) : UU :=
-    Σ D : (Σ z : ob C, C⟦z, x⟧ × C⟦z, y⟧), (SOM (pr1 D) x (dirprod_pr1 (pr2 D))).
+    ∑ D : (∑ z : ob C, C⟦z, x⟧ × C⟦z, y⟧), (SOM (pr1 D) x (dirprod_pr1 (pr2 D))).
 
   Definition mk_Roof (x y z : ob C) (s : z --> x) (f : z --> y) (e : SOM z x s) : Roof x y :=
     tpair _ (tpair _ z (s,,f)) e.
@@ -213,7 +213,7 @@ Section def_roofs.
 
   (** ** Coroofs *)
   Definition Coroof (x y : ob C) : UU :=
-    Σ D : (Σ z : ob C, C⟦x, z⟧ × C⟦y, z⟧), (SOM y (pr1 D) (dirprod_pr2 (pr2 D))).
+    ∑ D : (∑ z : ob C, C⟦x, z⟧ × C⟦y, z⟧), (SOM y (pr1 D) (dirprod_pr2 (pr2 D))).
 
   Definition mk_Coroof (x y z : ob C) (f : x --> z) (s : y --> z) (e : SOM y z s) : Coroof x y :=
     tpair _ (tpair _ z (f,,s)) e.
@@ -240,7 +240,7 @@ Section def_roofs.
   (** ** RoofTop *)
   (** These are used to define an equivalence relation between roofs *)
   Definition RoofTop {x y : ob C} (R1 R2 : Roof x y) : UU :=
-    Σ D : (Σ w : ob C, C⟦w, R1⟧ × C⟦w, R2⟧),
+    ∑ D : (∑ w : ob C, C⟦w, R1⟧ × C⟦w, R2⟧),
           (SOM (pr1 D) x ((dirprod_pr1 (pr2 D)) ;; (RoofMor1 R1)))
             × ((dirprod_pr1 (pr2 D)) ;; (RoofMor1 R1) = (dirprod_pr2 (pr2 D)) ;; (RoofMor1 R2))
             × ((dirprod_pr1 (pr2 D)) ;; (RoofMor2 R1) = (dirprod_pr2 (pr2 D)) ;; (RoofMor2 R2)).
@@ -336,10 +336,10 @@ Section def_roofs.
   Qed.
 
   (** We are interested in the equivalence classes of roofs. *)
-  (* Definition eqclass {X : UU} {r : eqrel X} : UU := Σ A : hsubtype X, iseqclass r A. *)
+  (* Definition eqclass {X : UU} {r : eqrel X} : UU := ∑ A : hsubtype X, iseqclass r A. *)
 
   Definition RoofEqclass (x y : ob C) : UU :=
-    Σ A : hsubtype (Roof x y), iseqclass (eqrelpair _ (RoofEqrel x y)) A.
+    ∑ A : hsubtype (Roof x y), iseqclass (eqrelpair _ (RoofEqrel x y)) A.
 
   Lemma isasetRoofEqclass (x y : ob C) : isaset (RoofEqclass x y).
   Proof.
@@ -359,8 +359,8 @@ Section def_roofs.
     iseqclass (eqrelpair _ (RoofEqrel x y)) (RoofEqclassIn RE) := pr2 RE.
 
   Definition RoofEqclassEq {x y : ob C} (RE1 RE2 : RoofEqclass x y)
-             (H1 : Π (R : Roof x y) (H : (pr1 RE1) R), (pr1 RE2) R)
-             (H2 : Π (R : Roof x y) (H : (pr1 RE2) R), (pr1 RE1) R) : RE1 = RE2.
+             (H1 : ∏ (R : Roof x y) (H : (pr1 RE1) R), (pr1 RE2) R)
+             (H2 : ∏ (R : Roof x y) (H : (pr1 RE2) R), (pr1 RE1) R) : RE1 = RE2.
   Proof.
     use total2_paths.
     - use funextfun. intros g.
@@ -483,7 +483,7 @@ Section def_roofs.
 
   (** Construct a "commutative coroof" from RoofTop *)
   Definition RoofTopToCoroof {x y : ob C} {R1 R2 : Roof x y} (T : RoofTop R1 R2) :
-    Σ CR : Coroof x y, (RoofMor1 R1 ;; CoroofMor1 CR = RoofMor2 R1 ;; CoroofMor2 CR)
+    ∑ CR : Coroof x y, (RoofMor1 R1 ;; CoroofMor1 CR = RoofMor2 R1 ;; CoroofMor2 CR)
                          × (RoofMor1 R2 ;; CoroofMor1 CR = RoofMor2 R2 ;; CoroofMor2 CR).
   Proof.
     set (sqr1 := isLocClassSqr1 iLC _ _ _ (RoofMor1 R1) (RoofMor1Is R1) (RoofMor2 R1)).
@@ -640,8 +640,8 @@ Section def_roofs.
   Qed.
 
   Lemma roof_comp_iscontr (x y z : ob C) (e1 : RoofEqclass x y) (e2 : RoofEqclass y z) :
-    iscontr (Σ e3 : RoofEqclass x z,
-                    Π (f : Roof x y) (s1 : (RoofEqclassIn e1) f)
+    iscontr (∑ e3 : RoofEqclass x z,
+                    ∏ (f : Roof x y) (s1 : (RoofEqclassIn e1) f)
                       (g : Roof y z) (s2 : (RoofEqclassIn e2) g),
                     (RoofEqclassIn e3) (roof_comp f g)).
   Proof.
@@ -1247,7 +1247,7 @@ Section def_roofs.
   (** This definition is the map used by the unique localization functor to map morphisms.
       It sends a roof (s, f) to the composite (# F s)^{-1} ;; (# F f). *)
   Definition MorMap (D : precategory) (hsD : has_homsets D) (F : functor C D) (x y : ob C)
-             (H : Π (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f)) :
+             (H : ∏ (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f)) :
     Roof x y -> D⟦F x, F y⟧.
   Proof.
     intros R.
@@ -1277,7 +1277,7 @@ Section def_roofs.
 
   (** These two lemmas are used in the proof of [MorMap_iscomprelfun]. *)
   Lemma MorMap_top_mor1_is_iso (D : precategory) (hsD : has_homsets D) (F : functor C D)
-        (x y : ob C) (H : Π (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f))
+        (x y : ob C) (H : ∏ (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f))
         (R1 R2 : Roof x y) (T : RoofTop R1 R2) : is_iso (# F (RoofTopMor1 T)).
   Proof.
     use (@is_iso_pre D).
@@ -1288,7 +1288,7 @@ Section def_roofs.
   Qed.
 
   Lemma MorMap_top_mor2_is_iso (D : precategory) (hsD : has_homsets D) (F : functor C D)
-        (x y : ob C) (H : Π (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f))
+        (x y : ob C) (H : ∏ (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f))
         (R1 R2 : Roof x y) (T : RoofTop R1 R2) : is_iso (# F (RoofTopMor2 T)).
   Proof.
     use (@is_iso_pre D).
@@ -1310,7 +1310,7 @@ Section def_roofs.
   (** MorMap is compatible with equivalence relation of roofs when one assumes that all the
       morpsisms in SOM are mapped to isomorphisms. *)
   Lemma MorMap_iscomprelfun (D : precategory) (hsD : has_homsets D) (F : functor C D) (x y : ob C)
-             (H : Π (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f)) :
+             (H : ∏ (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f)) :
     iscomprelfun (eqrelpair _ (RoofEqrel x y)) (MorMap D hsD F x y H).
   Proof.
     intros R1 R2 T'.
@@ -1344,10 +1344,10 @@ Section def_roofs.
       eqclass are mapped to. This uses the assumption H' which says that all morphisms in SOM
       are mapped to isomorphisms in D. *)
   Lemma MorMap_iscontr (D : precategory) (hsD : has_homsets D) (F : functor C D)
-        (H' : Π (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f))
+        (H' : ∏ (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f))
         (x y : C) (eqclass : RoofEqclass x y) :
-    iscontr (Σ g : D⟦F x, F y⟧,
-                   Π (R : Roof x y) (H1 : RoofEqclassIn (eqclass) R), g = MorMap D hsD F x y H' R).
+    iscontr (∑ g : D⟦F x, F y⟧,
+                   ∏ (R : Roof x y) (H1 : RoofEqclassIn (eqclass) R), g = MorMap D hsD F x y H' R).
   Proof.
     use (squash_to_prop (pr1 (RoofEqclassIs eqclass))). apply isapropiscontr. intros R.
     induction R as [R1 R2].
@@ -1367,7 +1367,7 @@ Section def_roofs.
 
   (** MorMap equality from MorMap_iscontr *)
   Lemma MorMap_iscontr_eq (D : precategory) (hsD : has_homsets D) (F : functor C D)
-        (H' : Π (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f))
+        (H' : ∏ (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f))
         (x y : C) (eqclass : RoofEqclass x y) (R : Roof x y) (H1 : RoofEqclassIn eqclass R) :
     pr1 (pr1 (MorMap_iscontr D hsD F H' x y eqclass)) = MorMap D hsD F x y H' R.
   Proof.
@@ -1401,7 +1401,7 @@ Section def_roofs.
 
   (** MorMap is linear with respect to composition in D *)
   Lemma MorMap_compose (D : precategory) (hsD : has_homsets D) (F : functor C D)
-        (H' : Π (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f))
+        (H' : ∏ (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f))
         {x y z : ob C} (R1 : Roof x y) (R2 : Roof y z) :
     MorMap D hsD F x z H' (roof_comp R1 R2) = MorMap D hsD F x y H' R1 ;; MorMap D hsD F y z H' R2.
   Proof.
@@ -1566,7 +1566,7 @@ Section def_roofs.
       indeed a functor. *)
   Lemma LocalizationUniversalFunctor_isfunctor
     (D : precategory) (hsD : has_homsets D) (F : functor C D)
-    (H' : Π (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f)) :
+    (H' : ∏ (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f)) :
     @is_functor loc_precategory_data D
       (functor_data_constr
          loc_precategory_ob_mor D (λ x : C, F x)
@@ -1602,7 +1602,7 @@ Section def_roofs.
 
   (** The universal functor which we use to factor F through loc_precategory *)
   Definition LocalizationUniversalFunctor (D : precategory) (hsD : has_homsets D) (F : functor C D)
-             (H' : Π (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f)) :
+             (H' : ∏ (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f)) :
     functor loc_precategory D.
   Proof.
     use mk_functor.
@@ -1615,7 +1615,7 @@ Section def_roofs.
   (** We show that LocalizationUniversalFunctor satisfies the commutativity required for the
       universal functor. *)
   Definition LocalizationUniversalFunctorComm (D : precategory) (hsD : has_homsets D)
-             (F : functor C D) (H' : Π (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f)) :
+             (F : functor C D) (H' : ∏ (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f)) :
     functor_composite FunctorToLocalization (LocalizationUniversalFunctor D hsD F H') = F.
   Proof.
     use (functor_eq _ _ hsD).
@@ -1640,7 +1640,7 @@ Section def_roofs.
 
   (** This lemma shows uniqueness of the functor LocalizationUniversalFunctor *)
   Lemma LocalizationUniversalFunctorUnique (D : precategory) (hsD : has_homsets D) (F : functor C D)
-        (H' : Π (x y : C) (f : C ⟦ x, y ⟧), SOM x y f → is_iso (# F f))
+        (H' : ∏ (x y : C) (f : C ⟦ x, y ⟧), SOM x y f → is_iso (# F f))
         (y : functor loc_precategory D) (T : functor_composite FunctorToLocalization y = F) :
     y = (LocalizationUniversalFunctor D hsD F H').
   Proof.
@@ -1682,8 +1682,8 @@ Section def_roofs.
 
   (** The following lemma only applies when the objects of D satisfy isaset. *)
   Lemma LocalizationUniversalProperty (D : precategory) (hsD : has_homsets D) (hssD : isaset D)
-        (F : functor C D) (H' : Π (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f)) :
-    iscontr (Σ H : functor loc_precategory D, functor_composite FunctorToLocalization H = F).
+        (F : functor C D) (H' : ∏ (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f)) :
+    iscontr (∑ H : functor loc_precategory D, functor_composite FunctorToLocalization H = F).
   Proof.
     use unique_exists.
     (* The functor *)
@@ -1699,7 +1699,7 @@ Section def_roofs.
 
   (** The functor FunctorToLocalization maps morphisms in SOM to isomorphisms *)
   Definition FunctorToLocalization_is_iso :
-    Π (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# FunctorToLocalization f).
+    ∏ (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# FunctorToLocalization f).
   Proof.
     intros x y f s. cbn.
     use (@is_iso_qinv loc_precategory).
@@ -1753,13 +1753,13 @@ Section def_roofs.
   (** Localization of categories is unique up to isomorphism of categories and loc_precategory is
       one such precategory. *)
   Lemma LocalizationUniversalCategory (CC : precategory) (hss : has_homsets CC)
-        (In : functor C CC) (H' : Π (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# In f))
-        (HH : Π (D : precategory) (hsD : has_homsets D)
-                (F : functor C D) (H' : Π (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f)),
-              Σ HH : functor CC D, (functor_composite In HH = F)
-                                     × (Π (yy : functor CC D) (comm : functor_composite In yy = F),
+        (In : functor C CC) (H' : ∏ (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# In f))
+        (HH : ∏ (D : precategory) (hsD : has_homsets D)
+                (F : functor C D) (H' : ∏ (x y : C) (f : x --> y) (s : SOM x y f), is_iso (# F f)),
+              ∑ HH : functor CC D, (functor_composite In HH = F)
+                                     × (∏ (yy : functor CC D) (comm : functor_composite In yy = F),
                                         yy = HH)) :
-    Σ D : (functor CC loc_precategory × functor loc_precategory CC),
+    ∑ D : (functor CC loc_precategory × functor loc_precategory CC),
           (functor_composite (dirprod_pr1 D) (dirprod_pr2 D) = (functor_identity _))
             × (functor_composite (dirprod_pr2 D) (dirprod_pr1 D) = (functor_identity _)).
   Proof.

--- a/UniMath/CategoryTheory/Monads.v
+++ b/UniMath/CategoryTheory/Monads.v
@@ -39,7 +39,7 @@ Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 Section Monad_def.
 
 Definition functor_with_μ (C : precategory) : UU
-  := Σ F : functor C C, F □ F ⟶ F.
+  := ∑ F : functor C C, F □ F ⟶ F.
 
 Coercion functor_from_functor_with_μ (C : precategory) (F : functor_with_μ C)
   : functor C C := pr1 F.
@@ -47,7 +47,7 @@ Coercion functor_from_functor_with_μ (C : precategory) (F : functor_with_μ C)
 Definition μ {C : precategory} (F : functor_with_μ C) : F□F ⟶ F := pr2 F.
 
 Definition Monad_data (C : precategory) : UU :=
-   Σ F : functor_with_μ C, functor_identity C ⟶ F.
+   ∑ F : functor_with_μ C, functor_identity C ⟶ F.
 
 Coercion functor_with_μ_from_Monad_data (C : precategory) (F : Monad_data C)
   : functor_with_μ C := pr1 F.
@@ -57,11 +57,11 @@ Definition η {C : precategory} (F : Monad_data C)
 
 Definition Monad_laws {C : precategory} (T : Monad_data C) : UU :=
     (
-      (Π c : C, η T (T c) ;; μ T c = identity (T c))
+      (∏ c : C, η T (T c) ;; μ T c = identity (T c))
         ×
-      (Π c : C, #T (η T c) ;; μ T c = identity (T c)))
+      (∏ c : C, #T (η T c) ;; μ T c = identity (T c)))
       ×
-    (Π c : C, #T (μ T c) ;; μ T c = μ T (T c) ;; μ T c).
+    (∏ c : C, #T (μ T c) ;; μ T c = μ T (T c) ;; μ T c).
 
 Lemma isaprop_Monad_laws (C : precategory) (hs : has_homsets C) (T : Monad_data C) :
    isaprop (Monad_laws T).
@@ -70,21 +70,21 @@ Proof.
   apply impred; intro c; apply hs.
 Qed.
 
-Definition Monad (C : precategory) : UU := Σ T : Monad_data C, Monad_laws T.
+Definition Monad (C : precategory) : UU := ∑ T : Monad_data C, Monad_laws T.
 
 Coercion Monad_data_from_Monad (C : precategory) (T : Monad C) : Monad_data C := pr1 T.
 
-Lemma Monad_law1 {C : precategory} {T : Monad C} : Π c : C, η T (T c) ;; μ T c = identity (T c).
+Lemma Monad_law1 {C : precategory} {T : Monad C} : ∏ c : C, η T (T c) ;; μ T c = identity (T c).
 Proof.
 exact (pr1 (pr1 (pr2 T))).
 Qed.
 
-Lemma Monad_law2 {C : precategory} {T : Monad C} : Π c : C, #T (η T c) ;; μ T c = identity (T c).
+Lemma Monad_law2 {C : precategory} {T : Monad C} : ∏ c : C, #T (η T c) ;; μ T c = identity (T c).
 Proof.
 exact (pr2 (pr1 (pr2 T))).
 Qed.
 
-Lemma Monad_law3 {C : precategory} {T : Monad C} : Π c : C, #T (μ T c) ;; μ T c = μ T (T c) ;; μ T c.
+Lemma Monad_law3 {C : precategory} {T : Monad C} : ∏ c : C, #T (μ T c) ;; μ T c = μ T (T c) ;; μ T c.
 Proof.
 exact (pr2 (pr2 T)).
 Qed.
@@ -96,8 +96,8 @@ Section Monad_precategory.
 
 Definition Monad_Mor_laws {C : precategory} {T T' : Monad_data C} (α : T ⟶ T')
   : UU :=
-  (Π a : C, μ T a ;; α a = α (T a) ;; #T' (α a) ;; μ T' a) ×
-  (Π a : C, η T a ;; α a = η T' a).
+  (∏ a : C, μ T a ;; α a = α (T a) ;; #T' (α a) ;; μ T' a) ×
+  (∏ a : C, η T a ;; α a = η T' a).
 
 Lemma isaprop_Monad_Mor_laws (C : precategory) (hs : has_homsets C)
   (T T' : Monad_data C) (α : T ⟶ T')
@@ -108,19 +108,19 @@ Proof.
 Qed.
 
 Definition Monad_Mor {C : precategory} (T T' : Monad C) : UU
-  := Σ α : T ⟶ T', Monad_Mor_laws α.
+  := ∑ α : T ⟶ T', Monad_Mor_laws α.
 
 Coercion nat_trans_from_monad_mor (C : precategory) (T T' : Monad C) (s : Monad_Mor T T')
   : T ⟶ T' := pr1 s.
 
 Definition Monad_Mor_η {C : precategory} {T T' : Monad C} (α : Monad_Mor T T')
-  : Π a : C, η T a ;; α a = η T' a.
+  : ∏ a : C, η T a ;; α a = η T' a.
 Proof.
   exact (pr2 (pr2 α)).
 Qed.
 
 Definition Monad_Mor_μ {C : precategory} {T T' : Monad C} (α : Monad_Mor T T')
-  : Π a : C, μ T a ;; α a = α (T a) ;; #T' (α a) ;; μ T' a.
+  : ∏ a : C, μ T a ;; α a = α (T a) ;; #T' (α a) ;; μ T' a.
 Proof.
   exact (pr1 (pr2 α)).
 Qed.

--- a/UniMath/CategoryTheory/Monics.v
+++ b/UniMath/CategoryTheory/Monics.v
@@ -23,10 +23,10 @@ Section def_monic.
 
   (** Definition and construction of isMonic. *)
   Definition isMonic {y z : C} (f : y --> z) : UU :=
-    Π (x : C) (g h : x --> y), g ;; f = h ;; f -> g = h.
+    ∏ (x : C) (g h : x --> y), g ;; f = h ;; f -> g = h.
 
   Definition mk_isMonic {y z : C} (f : y --> z)
-             (H : Π (x : C) (g h : x --> y), g ;; f = h ;; f -> g = h) : isMonic f := H.
+             (H : ∏ (x : C) (g h : x --> y), g ;; f = h ;; f -> g = h) : isMonic f := H.
 
   Lemma isapropisMonic {y z : C} (f : y --> z) : isaprop (isMonic f).
   Proof.
@@ -38,7 +38,7 @@ Section def_monic.
   Qed.
 
   (** Definition and construction of Monic. *)
-  Definition Monic (y z : C) : UU := Σ f : y --> z, isMonic f.
+  Definition Monic (y z : C) : UU := ∑ f : y --> z, isMonic f.
 
   Definition mk_Monic {y z : C} (f : y --> z) (H : isMonic f) : Monic y z := tpair _ f H.
 
@@ -124,7 +124,7 @@ Section monics_subcategory.
 
   Definition hsubtype_obs_isMonic : hsubtype C := (fun c : C => hProppair _ isapropunit).
 
-  Definition hsubtype_mors_isMonic : Π (a b : C), hsubtype (C⟦a, b⟧) :=
+  Definition hsubtype_mors_isMonic : ∏ (a b : C), hsubtype (C⟦a, b⟧) :=
     (fun a b : C => (fun f : C⟦a, b⟧ => hProppair _ (isapropisMonic C hs f))).
 
   Definition subprecategory_of_monics : sub_precategories C.
@@ -159,7 +159,7 @@ End monics_subcategory.
 Section monics_functorcategories.
 
   Lemma is_nat_trans_monic_from_pointwise_monics (C D : precategory) (hs : has_homsets D)
-        (F G : ob (functor_precategory C D hs)) (α : F --> G) (H : Π a : ob C, isMonic (pr1 α a)) :
+        (F G : ob (functor_precategory C D hs)) (α : F --> G) (H : ∏ a : ob C, isMonic (pr1 α a)) :
     isMonic α.
   Proof.
     intros G' β η H'.

--- a/UniMath/CategoryTheory/Morphisms.v
+++ b/UniMath/CategoryTheory/Morphisms.v
@@ -20,7 +20,7 @@ Section def_morphismpair.
 
   Variable C : precategory.
 
-  Definition MorphismPair : UU := Σ (a b c : C), (a --> b × b --> c).
+  Definition MorphismPair : UU := ∑ (a b c : C), (a --> b × b --> c).
 
   Definition mk_MorphismPair {a b c : C} (f : a --> b) (g : b --> c) : MorphismPair.
   Proof.
@@ -69,7 +69,7 @@ Section def_morphismpair.
   Definition MPComm2 {MP1 MP2 : MorphismPair} {MPM : MPMorMors MP1 MP2} (MPMC : MPMorComms MPM) :
     MPMors2 MPM ;; Mor2 MP2 = Mor2 MP1 ;; MPMors3 MPM := dirprod_pr2 MPMC.
 
-  Definition MPMorphism (MP1 MP2 : MorphismPair) : UU := Σ MPM : MPMorMors MP1 MP2, MPMorComms MPM.
+  Definition MPMorphism (MP1 MP2 : MorphismPair) : UU := ∑ MPM : MPMorMors MP1 MP2, MPMorComms MPM.
 
   Definition MPMorphism_MPMorMors {MP1 MP2 : MorphismPair} (MPM : MPMorphism MP1 MP2) :
     MPMorMors MP1 MP2 := pr1 MPM.
@@ -126,7 +126,7 @@ Section def_shortshortexactdata.
     morphism. *)
 
   Definition ShortShortExactData : UU :=
-    Σ MP : MorphismPair C, Mor1 MP ;; Mor2 MP = ZeroArrow Z _ _.
+    ∑ MP : MorphismPair C, Mor1 MP ;; Mor2 MP = ZeroArrow Z _ _.
 
   Definition mk_ShortShortExactData (MP : MorphismPair C)
              (H : Mor1 MP ;; Mor2 MP = ZeroArrow Z _ _) : ShortShortExactData := tpair _ MP H.

--- a/UniMath/CategoryTheory/PointedFunctors.v
+++ b/UniMath/CategoryTheory/PointedFunctors.v
@@ -39,16 +39,16 @@ Section def_ptd.
 Variable C : precategory.
 Hypothesis hs : has_homsets C.
 
-Definition ptd_obj : UU := Σ F : functor C C, functor_identity C ⟶ F.
+Definition ptd_obj : UU := ∑ F : functor C C, functor_identity C ⟶ F.
 
 Coercion functor_from_ptd_obj (F : ptd_obj) : functor C C := pr1 F.
 
 Definition ptd_pt (F : ptd_obj) : functor_identity C ⟶ F := pr2 F.
 
-Definition is_ptd_mor {F G : ptd_obj}(α: F ⟶ G) : UU := Π c : C, ptd_pt F c ;; α c = ptd_pt G c.
+Definition is_ptd_mor {F G : ptd_obj}(α: F ⟶ G) : UU := ∏ c : C, ptd_pt F c ;; α c = ptd_pt G c.
 
 Definition ptd_mor (F G : ptd_obj) : UU :=
-  Σ α : F ⟶ G, is_ptd_mor α.
+  ∑ α : F ⟶ G, is_ptd_mor α.
 
 Coercion nat_trans_from_ptd_mor {F G : ptd_obj} (a : ptd_mor F G) : nat_trans F G := pr1 a.
 
@@ -62,7 +62,7 @@ Proof.
 Defined.
 
 Definition ptd_mor_commutes {F G : ptd_obj} (α : ptd_mor F G)
-  : Π c : C, ptd_pt F c ;; α c = ptd_pt G c.
+  : ∏ c : C, ptd_pt F c ;; α c = ptd_pt G c.
 Proof.
   exact (pr2 α).
 Qed.

--- a/UniMath/CategoryTheory/PreAdditive.v
+++ b/UniMath/CategoryTheory/PreAdditive.v
@@ -36,25 +36,25 @@ Section def_preadditive.
       morphism yields a morphism of abelian groups. Classically one says that
       composition is bilinear with respect to the abelian groups? *)
   Definition isPreAdditive (PA : PrecategoryWithAbgrops) : UU :=
-    (Π (x y z : PA) (f : x --> y), ismonoidfun (to_premor z f))
-      × (Π (x y z : PA) (f : y --> z), ismonoidfun (to_postmor x f)).
+    (∏ (x y z : PA) (f : x --> y), ismonoidfun (to_premor z f))
+      × (∏ (x y z : PA) (f : y --> z), ismonoidfun (to_postmor x f)).
 
   Definition mk_isPreAdditive (PA : PrecategoryWithAbgrops)
-             (H1 : Π (x y z : PA) (f : x --> y), ismonoidfun (to_premor z f))
-             (H2 : Π (x y z : PA) (f : y --> z), ismonoidfun (to_postmor x f)) :
+             (H1 : ∏ (x y z : PA) (f : x --> y), ismonoidfun (to_premor z f))
+             (H2 : ∏ (x y z : PA) (f : y --> z), ismonoidfun (to_postmor x f)) :
     isPreAdditive PA.
   Proof.
     exact (H1,,H2).
   Defined.
 
   Definition to_premor_monoid {PWA : PrecategoryWithAbgrops} (iPA : isPreAdditive PWA) :
-    Π (x y z : PWA) (f : x --> y), ismonoidfun (to_premor z f) := dirprod_pr1 iPA.
+    ∏ (x y z : PWA) (f : x --> y), ismonoidfun (to_premor z f) := dirprod_pr1 iPA.
 
   Definition to_postmor_monoid {PWA : PrecategoryWithAbgrops} (iPA : isPreAdditive PWA) :
-    Π (x y z : PWA) (f : y --> z), ismonoidfun (to_postmor x f) := dirprod_pr2 iPA.
+    ∏ (x y z : PWA) (f : y --> z), ismonoidfun (to_postmor x f) := dirprod_pr2 iPA.
 
   (** Definition of preadditive categories *)
-  Definition PreAdditive : UU := Σ PA : PrecategoryWithAbgrops, isPreAdditive PA.
+  Definition PreAdditive : UU := ∑ PA : PrecategoryWithAbgrops, isPreAdditive PA.
 
   Definition PreAdditive_PrecategoryWithAbgrops (A : PreAdditive) : PrecategoryWithAbgrops := pr1 A.
   Coercion PreAdditive_PrecategoryWithAbgrops : PreAdditive >-> PrecategoryWithAbgrops.
@@ -299,7 +299,7 @@ Section preadditive_quotient.
   Variable PA : PreAdditive.
 
   (** For every set morphisms we have a subgroup. *)
-  Definition PreAdditiveSubabgrs : UU := Π (x y : ob PA), @subabgr (to_abgrop x y).
+  Definition PreAdditiveSubabgrs : UU := ∏ (x y : ob PA), @subabgr (to_abgrop x y).
 
   Hypothesis PAS : PreAdditiveSubabgrs.
 
@@ -307,10 +307,10 @@ Section preadditive_quotient.
       This is important since we want pre- and postcomposition with unit element to be
       the unit element in the new precategory. *)
   Definition PreAdditiveComps : UU :=
-    Π (x y : ob PA),
-    (Π (z : ob PA) (f : x --> y) (inf : pr1submonoid _ (PAS x y) f) (g : y --> z),
+    ∏ (x y : ob PA),
+    (∏ (z : ob PA) (f : x --> y) (inf : pr1submonoid _ (PAS x y) f) (g : y --> z),
      pr1submonoid _ (PAS x z) (f ;; g))
-      × (Π (z : ob PA) (f : x --> y) (g : y --> z) (ing : pr1submonoid _ (PAS y z) g),
+      × (∏ (z : ob PA) (f : x --> y) (g : y --> z) (ing : pr1submonoid _ (PAS y z) g),
          pr1submonoid _ (PAS x z) (f ;; g)).
 
   Hypothesis PAC : PreAdditiveComps.
@@ -333,7 +333,7 @@ Section preadditive_quotient.
   Qed.
 
   Local Lemma grinvop (Y : gr) :
-    Π y1 y2 : Y, grinv Y (@op Y y1 y2) = @op Y (grinv Y y2) (grinv Y y1).
+    ∏ y1 y2 : Y, grinv Y (@op Y y1 y2) = @op Y (grinv Y y2) (grinv Y y1).
   Proof.
     intros y1 y2.
     apply (grrcan Y y1).
@@ -352,7 +352,7 @@ Section preadditive_quotient.
     - apply idpath.
   Qed.
 
-  Local Lemma funeqpaths {X Y : UU} {f g : X -> Y} (e : f = g) : Π (x : X), f x = g x.
+  Local Lemma funeqpaths {X Y : UU} {f g : X -> Y} (e : f = g) : ∏ (x : X), f x = g x.
   Proof.
     induction e. intros x. apply idpath.
   Qed.
@@ -533,8 +533,8 @@ Section preadditive_quotient.
       It shows that composition is well defined in QuotPrecategory_ob_mor. *)
   Lemma QuotPrecategory_comp_iscontr {A B C : ob PA} (f : QuotPrecategory_ob_mor⟦A, B⟧)
              (g : QuotPrecategory_ob_mor⟦B, C⟧) :
-    iscontr (Σ h : QuotPrecategory_ob_mor⟦A, C⟧,
-                   (Π (f' : PA⟦A, B⟧) (e1 : setquotpr _ f' = f)
+    iscontr (∑ h : QuotPrecategory_ob_mor⟦A, C⟧,
+                   (∏ (f' : PA⟦A, B⟧) (e1 : setquotpr _ f' = f)
                       (g' : PA⟦B, C⟧) (e2 : setquotpr _ g' = g), setquotpr _ (f' ;; g') = h)).
   Proof.
     cbn in *.

--- a/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
+++ b/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
@@ -17,10 +17,10 @@ Section def_precategory_with_abgrops.
 
   (** Definition of precategories such that homsets are abgrops. *)
   Definition PrecategoryWithAbgropsData (PB : precategoryWithBinOps) (hs : has_homsets PB) : UU :=
-    Π (x y : PB), @isabgrop (hSetpair (PB⟦x,y⟧) (hs x y)) (to_binop x y).
+    ∏ (x y : PB), @isabgrop (hSetpair (PB⟦x,y⟧) (hs x y)) (to_binop x y).
 
   Definition PrecategoryWithAbgrops : UU :=
-    Σ PA : (Σ PB : precategoryWithBinOps, has_homsets PB),
+    ∑ PA : (∑ PB : precategoryWithBinOps, has_homsets PB),
            PrecategoryWithAbgropsData (pr1 PA) (pr2 PA).
 
   Definition PrecategoryWithAbgrops_precategoryWithBinOps (PB : PrecategoryWithAbgrops) :

--- a/UniMath/CategoryTheory/ProductPrecategory.v
+++ b/UniMath/CategoryTheory/ProductPrecategory.v
@@ -25,9 +25,9 @@ Variables C : I -> precategory.
 Definition product_precategory_ob_mor : precategory_ob_mor.
 Proof.
 mkpair.
-- apply (Π (i : I), ob (C i)).
+- apply (∏ (i : I), ob (C i)).
 - intros f g.
-  apply (Π i, f i --> g i).
+  apply (∏ i, f i --> g i).
 Defined.
 
 Definition product_precategory_data : precategory_data.
@@ -52,7 +52,7 @@ Qed.
 Definition product_precategory : precategory
   := tpair _ _ is_precategory_product_precategory_data.
 
-Definition has_homsets_product_precategory (hsC : Π (i:I), has_homsets (C i)) :
+Definition has_homsets_product_precategory (hsC : ∏ (i:I), has_homsets (C i)) :
   has_homsets product_precategory.
 Proof.
 intros a b; simpl.
@@ -84,7 +84,7 @@ End power_precategory.
 Section functors.
 
 Definition family_functor_data (I : UU) {A B : I -> precategory}
-  (F : Π (i : I), functor (A i) (B i)) :
+  (F : ∏ (i : I), functor (A i) (B i)) :
   functor_data (product_precategory I A)
                (product_precategory I B).
 Proof.
@@ -94,7 +94,7 @@ mkpair.
 Defined.
 
 Definition family_functor (I : UU) {A B : I -> precategory}
-  (F : Π (i : I), functor (A i) (B i)) :
+  (F : ∏ (i : I), functor (A i) (B i)) :
   functor (product_precategory I A)
           (product_precategory I B).
 Proof.

--- a/UniMath/CategoryTheory/PseudoElements.v
+++ b/UniMath/CategoryTheory/PseudoElements.v
@@ -86,7 +86,7 @@ Section def_pseudo_element.
 
   (** ** Definition of pseudo elements *)
 
-  Definition PseudoElem (c : A) : UU := Σ d : A, d --> c.
+  Definition PseudoElem (c : A) : UU := ∑ d : A, d --> c.
 
   Definition mk_PseudoElem {c d : A} (f : d --> c) : PseudoElem c := tpair _ d f.
 
@@ -100,7 +100,7 @@ Section def_pseudo_element.
 
   (** Pseudo equality *)
   Definition PEq {c : A} (PE1 PE2 : PseudoElem c) : UU :=
-    Σ (Y : ob A) (E1 : Epi A Y (PseudoOb PE2)) (E2 : Epi A Y (PseudoOb PE1)), E1 ;; PE2 = E2 ;; PE1.
+    ∑ (Y : ob A) (E1 : Epi A Y (PseudoOb PE2)) (E2 : Epi A Y (PseudoOb PE1)), E1 ;; PE2 = E2 ;; PE1.
 
   Definition mk_PEq {c : A} (PE1 PE2 : PseudoElem c) {Y : ob A} (E1 : Epi A Y (PseudoOb PE2))
              (E2 : Epi A Y (PseudoOb PE1)) (H : E1 ;; PE2 = E2 ;; PE1) : PEq PE1 PE2 :=
@@ -211,7 +211,7 @@ Section def_pseudo_element.
   (** *** Pseudo fiber *)
 
   Definition PFiber {c d : ob A} (f : c --> d) (b : PseudoElem d) : UU :=
-    Σ (a : PseudoElem c), PEq (PseudoIm a f) b.
+    ∑ (a : PseudoElem c), PEq (PseudoIm a f) b.
 
   Definition mk_PFiber {c d : ob A} (f : c --> d) (b : PseudoElem d) (a : PseudoElem c)
              (H : PEq (PseudoIm a f) b) : PFiber f b := tpair _ a H.
@@ -340,7 +340,7 @@ Section def_pseudo_element.
 
   (** *** Zero criteria *)
   Lemma PEq_ZeroArrow {c d : ob A} (f : c --> d) :
-    f = ZeroArrow to_Zero _ _ <-> (Π (a : PseudoElem c), a ;; f = ZeroArrow to_Zero _ _).
+    f = ZeroArrow to_Zero _ _ <-> (∏ (a : PseudoElem c), a ;; f = ZeroArrow to_Zero _ _).
   Proof.
     split.
     - intros H. intros a. rewrite H. apply ZeroArrow_comp_right.
@@ -351,7 +351,7 @@ Section def_pseudo_element.
   (** *** isMonic criteria *)
 
   Lemma PEq_isMonic {c d : ob A} (f : c --> d) :
-    isMonic f <-> (Π (d' : ob A) (a : PseudoElem c),
+    isMonic f <-> (∏ (d' : ob A) (a : PseudoElem c),
                  PEq (PseudoIm a f) (PZero d') -> ZeroArrow to_Zero _ _ = a).
   Proof.
     split.
@@ -366,7 +366,7 @@ Section def_pseudo_element.
   Qed.
 
   Lemma PEq_isMonic' {c d : ob A} (f : c --> d) :
-    isMonic f <-> (Π (a a' : PseudoElem c), PEq (PseudoIm a f) (PseudoIm a' f) -> PEq a a').
+    isMonic f <-> (∏ (a a' : PseudoElem c), PEq (PseudoIm a f) (PseudoIm a' f) -> PEq a a').
   Proof.
     split.
     - intros isM. intros a a' X.
@@ -385,7 +385,7 @@ Section def_pseudo_element.
 
   (** *** isEpi criteria *)
 
-  Lemma PEq_isEpi {c d : ob A} (f : c --> d) : isEpi f <-> (Π (b : PseudoElem d), PFiber f b).
+  Lemma PEq_isEpi {c d : ob A} (f : c --> d) : isEpi f <-> (∏ (b : PseudoElem d), PFiber f b).
   Proof.
     split.
     - intros isE b.
@@ -414,7 +414,7 @@ Section def_pseudo_element.
 
   Lemma PEq_isExact {x y z : ob A} (f : x --> y) (g : y --> z) (H : f ;; g = ZeroArrow to_Zero _ _) :
     isExact A hs f g H <->
-    Π (b : PseudoElem y) (H : b ;; g = ZeroArrow to_Zero _ _), PFiber f b.
+    ∏ (b : PseudoElem y) (H : b ;; g = ZeroArrow to_Zero _ _), PFiber f b.
   Proof.
     split.
     - intros isK b H'. unfold isExact in isK.
@@ -484,14 +484,14 @@ Section def_pseudo_element.
   (** **** Data for Difference *)
   Definition PDiff {x y : ob A} {a a' : PseudoElem x} (f : x --> y)
              (H : PEq (PseudoIm a f) (PseudoIm a' f)) : UU :=
-    Σ (a'' : PseudoElem x) (H' : a'' ;; f = ZeroArrow to_Zero _ _),
-    Π (z : ob A) (g : x --> z),
+    ∑ (a'' : PseudoElem x) (H' : a'' ;; f = ZeroArrow to_Zero _ _),
+    ∏ (z : ob A) (g : x --> z),
     a ;; g = ZeroArrow to_Zero _ _ -> PEq (PseudoIm a' g) (PseudoIm a'' g).
 
   Definition mk_PDiff {x y : ob A} {a a' : PseudoElem x} (f : x --> y)
              (H : PEq (PseudoIm a f) (PseudoIm a' f)) (a'' : PseudoElem x)
              (H' : a'' ;; f = ZeroArrow to_Zero _ _)
-             (H'' : Π (z : ob A) (g : x --> z),
+             (H'' : ∏ (z : ob A) (g : x --> z),
                     a ;; g = ZeroArrow to_Zero _ _ -> PEq (PseudoIm a' g) (PseudoIm a'' g)) :
     PDiff f H := (a'',,(H',,H'')).
 
@@ -505,7 +505,7 @@ Section def_pseudo_element.
 
   Definition PDiffEq {x y : ob A} {a a' : PseudoElem x} {f : x --> y}
              {H : PEq (PseudoIm a f) (PseudoIm a' f)} (PD : PDiff f H) :
-    Π (z : ob A) (g : x --> z),
+    ∏ (z : ob A) (g : x --> z),
     a ;; g = ZeroArrow to_Zero _ _ -> PEq (PseudoIm a' g) (PseudoIm PD g) := pr2 (pr2 PD).
 
   (** **** Difference criteria *)
@@ -597,7 +597,7 @@ Section def_pseudo_element.
 
   Definition PEq_Pullback {x y z : ob A} (f : x --> z) (g : y --> z) (Pb : Pullback f g)
              (a : PseudoElem x) (b : PseudoElem y) (H : PEq (PseudoIm a f) (PseudoIm b g)) :
-    Σ (d : PseudoElem Pb), (PEq (PseudoIm d (PullbackPr1 Pb)) a)
+    ∑ (d : PseudoElem Pb), (PEq (PseudoIm d (PullbackPr1 Pb)) a)
                              × (PEq (PseudoIm d (PullbackPr2 Pb))) b.
   Proof.
     set (mor1 := PEqEpi1 H ;; b). set (mor2 := PEqEpi2 H ;; a).

--- a/UniMath/CategoryTheory/RModules.v
+++ b/UniMath/CategoryTheory/RModules.v
@@ -48,7 +48,7 @@ Section RModule_def.
 
 
 Definition RModule_data (D:precategory) : UU
-  := Σ F : functor B D, F □ M ⟶ F.
+  := ∑ F : functor B D, F □ M ⟶ F.
 
 Coercion functor_from_RModule_data (C : precategory) (F : RModule_data C)
   : functor B C := pr1 F.
@@ -56,8 +56,8 @@ Coercion functor_from_RModule_data (C : precategory) (F : RModule_data C)
 Definition σ {C : precategory} (F : RModule_data C) : F□M ⟶ F := pr2 F.
 
 Definition RModule_laws  {C:precategory} (T : RModule_data C) : UU :=
-      (Π c : B, #T (η M c) ;; σ T c = identity (T c))
-        × (Π c : B, #T ((μ M) c) ;; σ T c = σ T (M c) ;; σ T c).
+      (∏ c : B, #T (η M c) ;; σ T c = identity (T c))
+        × (∏ c : B, #T ((μ M) c) ;; σ T c = σ T (M c) ;; σ T c).
 
 Lemma isaprop_RModule_laws (C : precategory) (hs : has_homsets C) (T : RModule_data C) :
    isaprop (RModule_laws T).
@@ -66,18 +66,18 @@ Proof.
   apply impred; intro c; apply hs.
 Qed.
 
-Definition RModule (C : precategory) : UU := Σ T : RModule_data C, RModule_laws T.
+Definition RModule (C : precategory) : UU := ∑ T : RModule_data C, RModule_laws T.
 
 Coercion RModule_data_from_RModule (C : precategory) (T : RModule C) : RModule_data C := pr1 T.
 
 
-Lemma RModule_law1 {C : precategory} {T : RModule C} : Π c : B, #T (η M c) ;; σ T c = identity (T c).
+Lemma RModule_law1 {C : precategory} {T : RModule C} : ∏ c : B, #T (η M c) ;; σ T c = identity (T c).
 Proof.
 exact ( (pr1 (pr2 T))).
 Qed.
 
 Lemma RModule_law2 {C : precategory} {T : RModule C} :
-  Π c : B, #T ((μ M) c) ;; σ T c = σ T (M c) ;; σ T c.
+  ∏ c : B, #T ((μ M) c) ;; σ T c = σ T (M c) ;; σ T c.
 Proof.
 exact (pr2 ( (pr2 T))).
 Qed.
@@ -89,7 +89,7 @@ Section RModule_precategory.
 
 Definition RModule_Mor_laws {C : precategory} {T T' : RModule_data C} (α : T ⟶ T')
   : UU :=
-  Π a : B, α (M a) ;; σ T' a = σ T a ;; α a.
+  ∏ a : B, α (M a) ;; σ T' a = σ T a ;; α a.
 
 
 Lemma isaprop_RModule_Mor_laws (C : precategory) (hs : has_homsets C)
@@ -100,14 +100,14 @@ Proof.
 Qed.
 
 Definition RModule_Mor {C : precategory} (T T' : RModule C) : UU
-  := Σ α : T ⟶ T', RModule_Mor_laws α.
+  := ∑ α : T ⟶ T', RModule_Mor_laws α.
 
 
 Coercion nat_trans_from_module_mor (C : precategory) (T T' : RModule C) (s : RModule_Mor T T')
    : T ⟶ T' := pr1 s.
 
 Definition RModule_Mor_σ {C : precategory} {T T' : RModule C} (α : RModule_Mor T T')
-           : Π a : B, α (M a) ;; σ T' a = σ T a ;; α a
+           : ∏ a : B, α (M a) ;; σ T' a = σ T a ;; α a
   := pr2 α.
 
 Lemma RModule_identity_laws {C : precategory} (T : RModule C)
@@ -228,7 +228,7 @@ Section Pullback_module.
 
   Definition pb_RModule_σ : T □ M ⟶ T :=  nat_trans_comp _ _ _ (T ∘ m)  (σ _ T).
 
-  Definition pb_RModule_data : Σ F : functor B C, F □ M ⟶ F :=
+  Definition pb_RModule_data : ∑ F : functor B C, F □ M ⟶ F :=
     tpair _ (T:functor B C) pb_RModule_σ.
 
   Lemma pb_RModule_laws : RModule_laws M pb_RModule_data.

--- a/UniMath/CategoryTheory/RightKanExtension.v
+++ b/UniMath/CategoryTheory/RightKanExtension.v
@@ -157,7 +157,7 @@ use left_adjoint_from_partial.
 - apply eps.
 - intros T S α; simpl in *.
 
-  transparent assert (cc : (Π c, cone (QT T c) (S c))).
+  transparent assert (cc : (∏ c, cone (QT T c) (S c))).
   { intro c.
     use mk_cone.
     + intro mf; apply (# S (pr2 mf) ;; α (pr1 mf)).
@@ -166,13 +166,13 @@ use left_adjoint_from_partial.
                 simpl; rewrite assoc, <- functor_comp; apply cancel_postcomposition, maponpaths, (pr2 h)).
   }
 
-  transparent assert (σ : (Π c, A ⟦ S c, R T c ⟧)).
+  transparent assert (σ : (∏ c, A ⟦ S c, R T c ⟧)).
   { intro c; apply (limArrow _ _ (cc c)). }
 
   set (lambda' := fun c' mf' => limOut (LA (c' ↓ K) (QT T c')) mf').
 
   (* this is the conclusion from the big diagram (8) in MacLane's proof *)
-  assert (H : Π c c' (g : C ⟦ c, c' ⟧) (mf' : c' ↓ K),
+  assert (H : ∏ c c' (g : C ⟦ c, c' ⟧) (mf' : c' ↓ K),
                 # S g ;; σ c' ;; lambda' _ mf' = σ c ;; Rmor T c c' g ;; lambda' _ mf').
   { intros c c' g mf'.
     rewrite <- !assoc.

--- a/UniMath/CategoryTheory/SetValuedFunctors.v
+++ b/UniMath/CategoryTheory/SetValuedFunctors.v
@@ -27,7 +27,7 @@ Require Import UniMath.CategoryTheory.limits.coequalizers.
 Lemma is_pointwise_epi_from_set_nat_trans_epi (C:precategory)
       (F G : functor C hset_precategory) (f:nat_trans F G)
       (h:isEpi (C:=functor_precategory C _ has_homsets_HSET) f)
-  : Π (x:C), isEpi (f x).
+  : ∏ (x:C), isEpi (f x).
 Proof.
   apply (Pushouts_pw_epi (D:=hset_Precategory)).
   apply PushoutsHSET_from_Colims.
@@ -61,7 +61,7 @@ Section LiftEpiNatTrans.
   Context {A B C:functor CC HSET} (p:nat_trans A B)
           (f:nat_trans A C).
 
-  Hypothesis (comp_epi: Π (X:CC)  (x y: pr1hSet (A X)),
+  Hypothesis (comp_epi: ∏ (X:CC)  (x y: pr1hSet (A X)),
                         p X x =  p X y -> f X x = f X y).
 
   Hypothesis (surjectivep : isEpi (C:=C_SET) p).
@@ -113,7 +113,7 @@ Section LiftEpiNatTrans.
     now rewrite <- univ_surj_nt_ax.
   Qed.
 
-  Lemma univ_surj_nt_unique : Π g  (H : nat_trans_comp _ _ _ p  g = f)
+  Lemma univ_surj_nt_unique : ∏ g  (H : nat_trans_comp _ _ _ p  g = f)
                                 b, g b = univ_surj_nt b.
   Proof.
     intros g hg b.
@@ -145,10 +145,10 @@ Section QuotientFunctor.
   Variable (R:functor D HSET).
 
   (** This is ~_X *)
-  Variable (hequiv : Π (d:D),eqrel (pr1hSet (R d))).
+  Variable (hequiv : ∏ (d:D),eqrel (pr1hSet (R d))).
 
   (** The relations satisfied by hequiv (~_X) *)
-  Hypothesis (congru: Π (x y:D) (f:D⟦ x,  y⟧), iscomprelrelfun (hequiv x) (hequiv y) (#R f)).
+  Hypothesis (congru: ∏ (x y:D) (f:D⟦ x,  y⟧), iscomprelrelfun (hequiv x) (hequiv y) (#R f)).
 
   (** Definition of the quotient functor *)
   (* not using setquotinset directly because as isasetsetquot is not opaque it would make
@@ -186,7 +186,7 @@ Section QuotientFunctor.
 
   Definition quot_functor  : functor D HSET := tpair _ _ is_functor_quot_functor_data.
 
-  Definition pr_quot_functor_data : Π x , HSET ⟦R x, quot_functor x⟧ :=
+  Definition pr_quot_functor_data : ∏ x , HSET ⟦R x, quot_functor x⟧ :=
     fun x a => setquotpr _ a.
 
   Lemma is_nat_trans_pr_quot_functor : is_nat_trans _ _ pr_quot_functor_data.

--- a/UniMath/CategoryTheory/ShortExactSequences.v
+++ b/UniMath/CategoryTheory/ShortExactSequences.v
@@ -257,7 +257,7 @@ Section def_shortexactseqs.
    *)
 
   Definition ShortShortExact : UU :=
-    Σ SSED : ShortShortExactData A to_Zero,
+    ∑ SSED : ShortShortExactData A to_Zero,
              isKernel to_Zero (KernelArrow (Image SSED)) (Mor2 SSED) (Image_Eq SSED).
 
   Definition mk_ShortShortExact (SSED : ShortShortExactData A to_Zero)
@@ -295,7 +295,7 @@ Section def_shortexactseqs.
                             0 -> A -> B -> C
   *)
 
-  Definition LeftShortExact : UU := Σ SSE : ShortShortExact, isMonic (Mor1 SSE).
+  Definition LeftShortExact : UU := ∑ SSE : ShortShortExact, isMonic (Mor1 SSE).
 
   Definition mk_LeftShortExact (SSE : ShortShortExact) (isM : isMonic (Mor1 SSE)) :
     LeftShortExact := tpair _ SSE isM.
@@ -312,7 +312,7 @@ Section def_shortexactseqs.
                                A -> B -> C -> 0
    *)
 
-  Definition RightShortExact : UU := Σ SSE : ShortShortExact, isEpi (Mor2 SSE).
+  Definition RightShortExact : UU := ∑ SSE : ShortShortExact, isEpi (Mor2 SSE).
 
   Definition mk_RightShortExact (SSE : ShortShortExact) (isE : isEpi (Mor2 SSE)) :
     RightShortExact := tpair _ SSE isE.
@@ -331,7 +331,7 @@ Section def_shortexactseqs.
   *)
 
   Definition ShortExact : UU :=
-    Σ SSE : ShortShortExact, Monics.isMonic (Mor1 SSE) × Epis.isEpi (Mor2 SSE).
+    ∑ SSE : ShortShortExact, Monics.isMonic (Mor1 SSE) × Epis.isEpi (Mor2 SSE).
 
   Definition mk_ShortExact (SSE : ShortShortExact) (isM : Monics.isMonic (Mor1 SSE))
              (isE : Epis.isEpi (Mor2 SSE)) : ShortExact := (SSE,,(isM,,isE)).

--- a/UniMath/CategoryTheory/UnderPrecategories.v
+++ b/UniMath/CategoryTheory/UnderPrecategories.v
@@ -14,7 +14,7 @@ Section def_underprecategories.
   Variable c : ob C.
 
   (* Objects *)
-  Definition Under_ob : UU := Σ d, C⟦c, d⟧.
+  Definition Under_ob : UU := ∑ d, C⟦c, d⟧.
 
   Definition mk_Under_ob {d : ob C} (f : C⟦c, d⟧) : Under_ob := tpair _ d f.
 
@@ -25,7 +25,7 @@ Section def_underprecategories.
 
   (* Morphisms *)
   Definition Under_mor (X Y : Under_ob) : UU :=
-    Σ f : C⟦Under_ob_cod X, Under_ob_cod Y⟧, Under_ob_mor X ;; f = Under_ob_mor Y.
+    ∑ f : C⟦Under_ob_cod X, Under_ob_cod Y⟧, Under_ob_mor X ;; f = Under_ob_mor Y.
 
   Definition mk_Under_mor (X Y : Under_ob) (f : C⟦Under_ob_cod X, Under_ob_cod Y⟧)
              (H : Under_ob_mor X ;; f = Under_ob_mor Y) : Under_mor X Y := tpair _ f H.

--- a/UniMath/CategoryTheory/category_abgr.v
+++ b/UniMath/CategoryTheory/category_abgr.v
@@ -266,7 +266,7 @@ Section ABGR_general.
   Qed.
 
   (** How operation behaves under the inverse function. *)
-  Lemma grinvcomp (Y : gr) : Π y1 y2 : Y, grinv Y (@op Y y1 y2) = @op Y (grinv Y y2) (grinv Y y1).
+  Lemma grinvcomp (Y : gr) : ∏ y1 y2 : Y, grinv Y (@op Y y1 y2) = @op Y (grinv Y y2) (grinv Y y1).
   Proof.
     intros y1 y2.
     apply (grrcan Y y1).
@@ -315,7 +315,7 @@ Section ABGR_general.
     (fun y : B => ∃ x : A, (f x) = y).
 
   (** An equality we are going to use. *)
-  Definition funeqpaths {X Y : UU} {f g: X -> Y} (e : f = g) : Π (x : X), f x = g x.
+  Definition funeqpaths {X Y : UU} {f g: X -> Y} (e : f = g) : ∏ (x : X), f x = g x.
   Proof.
     induction e. intros x. apply idpath.
   Qed.
@@ -352,7 +352,7 @@ Section ABGR_zero.
                                           (ABGR_zero_isabgrop).
 
   (** The zero object is connected. *)
-  Lemma ABGR_zero_connected : Π x x' : ABGR_zero, x = x'.
+  Lemma ABGR_zero_connected : ∏ x x' : ABGR_zero, x = x'.
   Proof.
     unfold ABGR_zero. cbn. intros x x'.
     apply isconnectedunit.
@@ -496,7 +496,7 @@ Section ABGR_preadditive.
 
   (** Commutativity of the binary operation. *)
   Definition ABGR_hombinop_comm (X Y : ABGR) :
-    Π (f g : ABGR⟦X, Y⟧), @ABGR_hombinop X Y f g = @ABGR_hombinop X Y g f.
+    ∏ (f g : ABGR⟦X, Y⟧), @ABGR_hombinop X Y f g = @ABGR_hombinop X Y g f.
   Proof.
     intros f g. use total2_paths.
     - cbn. apply funextfun. intros x. rewrite (pr2 (pr2 Y)). apply idpath.
@@ -526,7 +526,7 @@ Section ABGR_preadditive.
 
   (** Verification that this gives left and right inverse. *)
   Definition ABGR_hombinop_linvax (X Y : ABGR) :
-    Π f : ABGR⟦X, Y⟧, ABGR_hombinop X Y (ABGR_hombinop_inv X Y f) f  = ABGR_zero_arrow X Y.
+    ∏ f : ABGR⟦X, Y⟧, ABGR_hombinop X Y (ABGR_hombinop_inv X Y f) f  = ABGR_zero_arrow X Y.
   Proof.
     intros f. use total2_paths.
     - cbn. apply funextfun. intros x. apply (grlinvax (abgrtogr Y)).
@@ -534,7 +534,7 @@ Section ABGR_preadditive.
   Qed.
 
   Definition ABGR_hombinop_rinvax (X Y : ABGR) :
-    Π f : ABGR⟦X, Y⟧, ABGR_hombinop X Y f (ABGR_hombinop_inv X Y f) = ABGR_zero_arrow X Y.
+    ∏ f : ABGR⟦X, Y⟧, ABGR_hombinop X Y f (ABGR_hombinop_inv X Y f) = ABGR_zero_arrow X Y.
   Proof.
     intros f. use total2_paths.
     - cbn. apply funextfun. intros x. apply (grrinvax (abgrtogr Y)).
@@ -1344,7 +1344,7 @@ Section ABGR_monics.
         repeat rewrite natplusnsm in p1. cbn in p1.
         apply invmaponpathsS in p1.
         set (tmp := IHp (t0,,p0)). cbn in tmp.
-        assert (tmp1 : ishinh_UU(Σ x0 : nat, t + p0 + x0 = t0 + p + x0)).
+        assert (tmp1 : ishinh_UU(∑ x0 : nat, t + p0 + x0 = t0 + p + x0)).
         {
           unfold ishinh_UU. intros P X. apply X.
           refine (tpair _ 0 _).
@@ -1572,7 +1572,7 @@ Section ABGR_monic_kernels.
   Definition ABGR_monic_kernel_hfiber_prop {A B : abgr} (f : ABGR⟦A, B⟧) (isM : isMonic f)
              (w : abgr) (x : w) (h: ABGR⟦w, B⟧)
              (H : h ;; CokernelArrow (ABGR_Cokernel f) = ZeroArrow ABGR_has_zero _ _) :
-    ishinh_UU (Σ a : pr1 A, pr1 f a = pr1 h x %multmonoid).
+    ishinh_UU (∑ a : pr1 A, pr1 f a = pr1 h x %multmonoid).
   Proof.
     rewrite ABGR_has_zero_arrow_eq in H.
     cbn in H. unfold ABGR_zero_arrow in H.
@@ -1594,7 +1594,7 @@ Section ABGR_monic_kernels.
   Definition ABGR_monic_kernel_in_hfiber_iscontr {A B : abgr} (f : ABGR⟦A, B⟧) (isM : isMonic f)
              (w : abgr) (h: ABGR⟦w, B⟧)
              (H : h ;; CokernelArrow (ABGR_Cokernel f) = ZeroArrow ABGR_has_zero _ _) :
-    Π x : w, iscontr (hfiber (pr1 f) (pr1 h x)).
+    ∏ x : w, iscontr (hfiber (pr1 f) (pr1 h x)).
   Proof.
     intros x.
     use (squash_to_prop (ABGR_monic_kernel_hfiber_prop f isM w x h H)).
@@ -1782,7 +1782,7 @@ Section ABGR_monic_kernels.
   Lemma ABGR_epi_cokernel_out_data_eq {A B : abgr} (f : ABGR⟦A, B⟧) (isE : isEpi f) (w : abgr)
         (h : ABGR⟦A,w⟧)
         (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero (ABGR_Kernel f) w) :
-    Π x : ABGR_kernel_hsubtype f, pr1 h (pr1carrier (ABGR_kernel_hsubtype f) x) = 1%multmonoid.
+    ∏ x : ABGR_kernel_hsubtype f, pr1 h (pr1carrier (ABGR_kernel_hsubtype f) x) = 1%multmonoid.
   Proof.
     rewrite ABGR_has_zero_arrow_eq in H.
     cbn in H. unfold ABGR_zero_arrow in H.
@@ -1810,7 +1810,7 @@ Section ABGR_monic_kernels.
         (w : abgr) (h : ABGR⟦A,w⟧)
         (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _)
         (b : B) (X : hfiber (pr1 f) b) :
-    Π hfib : hfiber (pr1 f) b, pr1 h (pr1 hfib) = pr1 h (pr1 X).
+    ∏ hfib : hfiber (pr1 f) b, pr1 h (pr1 hfib) = pr1 h (pr1 X).
   Proof.
     intros hfib.
     set (e1 := ABGR_epi_cokernel_out_data_hfibers_to_unel f b hfib X).
@@ -1831,7 +1831,7 @@ Section ABGR_monic_kernels.
       of h, such that all hfibers of b are mapped to the target, is contractible. *)
   Lemma ABGR_epi_cokernel_out_data_iscontr {A B : abgr} (f : ABGR⟦A, B⟧) (isE : isEpi f) (w : abgr)
         (h : ABGR⟦A, w⟧) (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _) :
-    Π b : B, iscontr ( Σ x : w, Π (hfib : hfiber (pr1 f) b), pr1 h (pr1 hfib) = x).
+    ∏ b : B, iscontr ( ∑ x : w, ∏ (hfib : hfiber (pr1 f) b), pr1 h (pr1 hfib) = x).
   Proof.
     intros b.
     use (squash_to_prop (ABGR_epi_issurjective f isE b)).
@@ -1852,7 +1852,7 @@ Section ABGR_monic_kernels.
       mapped to it. *)
   Lemma ABGR_epi_cokernel_out_data {A B : abgr} (b : B) (f : ABGR⟦A, B⟧) (isE : isEpi f) (w : abgr)
         (h : ABGR⟦A,w⟧) (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _) :
-    ( Σ x : w, Π (hfib : hfiber (pr1 f) b), pr1 h (pr1 hfib) = x).
+    ( ∑ x : w, ∏ (hfib : hfiber (pr1 f) b), pr1 h (pr1 hfib) = x).
   Proof.
     use (squash_to_prop (ABGR_epi_issurjective f isE b)).
     apply isapropifcontr.
@@ -1880,9 +1880,9 @@ Section ABGR_monic_kernels.
   Definition ABGR_epi_cokernel_out_data_mult_eq {A B : abgr} (b1 b2 : B) (f : ABGR⟦A, B⟧)
              (isE : isEpi f) (w : abgr) (h : ABGR⟦A, w⟧)
              (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _)
-             (X : Σ x : w, Π hfib : hfiber (pr1 f) b1, pr1 h (pr1 hfib) = x)
-             (X0 : Σ x : w, Π hfib : hfiber (pr1 f) b2, pr1 h (pr1 hfib) = x) :
-    Π hfib : hfiber (pr1 f) (b1 * b2)%multmonoid, pr1 h (pr1 hfib) = (pr1 X * pr1 X0)%multmonoid.
+             (X : ∑ x : w, ∏ hfib : hfiber (pr1 f) b1, pr1 h (pr1 hfib) = x)
+             (X0 : ∑ x : w, ∏ hfib : hfiber (pr1 f) b2, pr1 h (pr1 hfib) = x) :
+    ∏ hfib : hfiber (pr1 f) (b1 * b2)%multmonoid, pr1 h (pr1 hfib) = (pr1 X * pr1 X0)%multmonoid.
   Proof.
     intros hfib.
     use (squash_to_prop (ABGR_epi_issurjective f isE b1)).
@@ -1898,9 +1898,9 @@ Section ABGR_monic_kernels.
   Definition ABGR_epi_cokernel_out_data_mult {A B : abgr} (b1 b2 : B) (f : ABGR⟦A, B⟧)
              (isE : isEpi f) (w : abgr) (h : ABGR⟦A, w⟧)
              (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _) :
-    ( Σ x : w, Π (hfib : hfiber (pr1 f) b1), pr1 h (pr1 hfib) = x) ->
-    ( Σ x : w, Π (hfib : hfiber (pr1 f) b2), pr1 h (pr1 hfib) = x) ->
-    ( Σ x : w, Π (hfib : hfiber (pr1 f) (b1 * b2)%multmonoid), pr1 h (pr1 hfib) = x).
+    ( ∑ x : w, ∏ (hfib : hfiber (pr1 f) b1), pr1 h (pr1 hfib) = x) ->
+    ( ∑ x : w, ∏ (hfib : hfiber (pr1 f) b2), pr1 h (pr1 hfib) = x) ->
+    ( ∑ x : w, ∏ (hfib : hfiber (pr1 f) (b1 * b2)%multmonoid), pr1 h (pr1 hfib) = x).
   Proof.
     intros X X0.
     exact (tpair _ ((pr1 X) * (pr1 X0))%multmonoid
@@ -1911,7 +1911,7 @@ Section ABGR_monic_kernels.
   Definition ABGR_epi_cokernel_out_data_unel_eq {A B : abgr} (f : ABGR⟦A, B⟧) (isE : isEpi f)
              (w : abgr) (h : ABGR⟦A, w⟧)
              (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _) :
-    Π hfib : hfiber (pr1 f) 1%multmonoid, pr1 h (pr1 hfib) = 1%multmonoid.
+    ∏ hfib : hfiber (pr1 f) 1%multmonoid, pr1 h (pr1 hfib) = 1%multmonoid.
   Proof.
     intros hfib.
     set (hfib_unel := hfiberpair (pr1 f) 1%multmonoid (pr2 (pr2 f))).
@@ -1923,7 +1923,7 @@ Section ABGR_monic_kernels.
   Definition ABGR_epi_cokernel_out_data_unel {A B : abgr} (f : ABGR⟦A, B⟧) (isE : isEpi f)
              (w : abgr) (h : ABGR⟦A, w⟧)
              (H : KernelArrow (ABGR_Kernel f) ;; h = ZeroArrow ABGR_has_zero _ _) :
-    ( Σ x : w, Π (hfib : hfiber (pr1 f) 1%multmonoid),  pr1 h (pr1 hfib) = x) :=
+    ( ∑ x : w, ∏ (hfib : hfiber (pr1 f) 1%multmonoid),  pr1 h (pr1 hfib) = x) :=
     tpair _ 1%multmonoid (ABGR_epi_cokernel_out_data_unel_eq f isE w h H).
 
   (** We show that the cokernel_out_map ismonoidfun. *)

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -65,7 +65,7 @@ Variable A : UU.
 Variable R0 : hrel A.
 
 Lemma isaprop_eqrel_from_hrel a b :
-  isaprop (Π R : eqrel A, (Π x y, R0 x y -> R x y) -> R a b).
+  isaprop (∏ R : eqrel A, (∏ x y, R0 x y -> R x y) -> R a b).
 Proof.
   apply impred; intro R; apply impred_prop.
 Qed.
@@ -87,8 +87,8 @@ now intros H R HR; apply HR.
 Qed.
 
 (* eqrel_from_hrel is the *smallest* relation containing R0 *)
-Lemma minimal_eqrel_from_hrel (R : eqrel A) (H : Π a b, R0 a b -> R a b) :
-  Π a b, eqrel_from_hrel a b -> R a b.
+Lemma minimal_eqrel_from_hrel (R : eqrel A) (H : ∏ a b, R0 a b -> R a b) :
+  ∏ a b, eqrel_from_hrel a b -> R a b.
 Proof.
 now intros a b H'; apply (H' _ H).
 Qed.
@@ -104,11 +104,11 @@ Section colimits.
 Variable g : graph.
 Variable D : diagram g HSET.
 
-Local Definition cobase : UU := Σ j : vertex g, pr1hSet (dob D j).
+Local Definition cobase : UU := ∑ j : vertex g, pr1hSet (dob D j).
 
 (* Theory about hprop is in UniMath.Foundations.Propositions *)
 Local Definition rel0 : hrel cobase := λ (ia jb : cobase),
-  hProppair (ishinh (Σ f : edge (pr1 ia) (pr1 jb), dmor D f (pr2 ia) = pr2 jb))
+  hProppair (ishinh (∑ f : edge (pr1 ia) (pr1 jb), dmor D f (pr2 ia) = pr2 jb))
             (isapropishinh _).
 
 Local Definition rel : hrel cobase := eqrel_from_hrel rel0.
@@ -211,7 +211,7 @@ use mk_cocone.
 Defined.
 
 Definition ColimHSETArrow (c : HSET) (cc : cocone D c) :
-  Σ x : HSET ⟦ colimHSET, c ⟧, Π v : vertex g, injections v ;; x = coconeIn cc v.
+  ∑ x : HSET ⟦ colimHSET, c ⟧, ∏ v : vertex g, injections v ;; x = coconeIn cc v.
 Proof.
 exists (from_colimHSET _ cc).
 abstract (intro i; simpl; unfold injections, compose, from_colimHSET; simpl;
@@ -272,7 +272,7 @@ Proof.
 intros A.
 use mk_CoproductCocone.
 - mkpair.
-  + apply (Σ i, pr1 (A i)).
+  + apply (∑ i, pr1 (A i)).
   + eapply (isaset_total2 _ HI); intro i; apply setproperty.
 - simpl; apply tpair.
 - apply (mk_isCoproductCocone _ _ has_homsets_HSET).
@@ -322,8 +322,8 @@ Variable g : graph.
 Variable D : diagram g HSET.
 
 Definition limset_UU : UU :=
-  Σ (f : Π u : vertex g, pr1hSet (dob D u)),
-    Π u v (e : edge u v), dmor D e (f u) = f v.
+  ∑ (f : ∏ u : vertex g, pr1hSet (dob D u)),
+    ∏ u v (e : edge u v), dmor D e (f u) = f v.
 
 Definition limset : HSET.
 Proof.
@@ -375,8 +375,8 @@ Variable J : precategory.
 Variable D : functor J HSET.
 
 Definition cats_limset_UU : UU :=
-  Σ (f : Π u, pr1hSet (D u)),
-    Π u v (e : J⟦u,v⟧), # D e (f u) = f v.
+  ∑ (f : ∏ u, pr1hSet (D u)),
+    ∏ u v (e : J⟦u,v⟧), # D e (f u) = f v.
 
 Definition cats_limset : HSET.
 Proof.
@@ -445,7 +445,7 @@ Lemma ProductsHSET (I : UU) : Products I HSET.
 Proof.
 intros A.
 use mk_ProductCone.
-- apply (tpair _ (Π i, pr1 (A i))); apply isaset_forall_hSet.
+- apply (tpair _ (∏ i, pr1 (A i))); apply isaset_forall_hSet.
 - simpl; intros i f; apply (f i).
 - apply (mk_isProductCone _ _ has_homsets_HSET).
   intros C f; simpl in *.
@@ -490,7 +490,7 @@ End TerminalHSET_from_Lims.
 Definition PullbackHSET_ob {A B C : HSET} (f : HSET⟦B,A⟧) (g : HSET⟦C,A⟧) : HSET.
 Proof.
 simpl in *.
-exists (Σ (xy : B × C), f (pr1 xy) = g (pr2 xy)).
+exists (∑ (xy : B × C), f (pr1 xy) = g (pr2 xy)).
 abstract (apply isaset_total2; [ apply isasetdirprod; apply setproperty
                                | intros xy; apply isasetaprop, setproperty ]).
 Defined.
@@ -741,7 +741,7 @@ Definition hfiber_fun (X : HSET) (f : HSET / X) : HSET / X → HSET / X.
 Proof.
 intros g.
 mkpair.
-- exists (Σ x, HSET⟦hfiber_hSet (pr2 f) x,hfiber_hSet (pr2 g) x⟧).
+- exists (∑ x, HSET⟦hfiber_hSet (pr2 f) x,hfiber_hSet (pr2 g) x⟧).
   abstract (apply isaset_total2; [ apply setproperty | intros x; apply has_homsets_HSET ]).
 - now apply pr1.
 Defined.
@@ -852,7 +852,7 @@ Proof.
 intros F.
 use mk_ProductCone.
 + mkpair.
-  - exists (Σ x : pr1 X, Π i : I, hfiber_hSet (pr2 (F i)) x).
+  - exists (∑ x : pr1 X, ∏ i : I, hfiber_hSet (pr2 (F i)) x).
     abstract (apply isaset_total2; [apply setproperty|];
               now intros x; apply impred_isaset; intro i; apply setproperty).
   - apply pr1.
@@ -925,7 +925,7 @@ Lemma pullback_HSET_univprop_elements {P A B C : HSET}
     {f : HSET ⟦ A, C ⟧} {g : HSET ⟦ B, C ⟧}
     (ep : p1 ;; f = p2 ;; g)
     (pb : isPullback f g p1 p2 ep)
-  : (Π a b (e : f a = g b), ∃! ab, p1 ab = a × p2 ab = b).
+  : (∏ a b (e : f a = g b), ∃! ab, p1 ab = a × p2 ab = b).
 Proof.
   intros a b e.
   set (Pb := (mk_Pullback _ _ _ _ _ _ pb)).
@@ -975,7 +975,7 @@ enjoyed by surjections (univ_surj)
     intros.
     red.
     intros C u equ.
-    assert (hcompat :   Π x y : pr1 A, f x = f y → u x = u y).
+    assert (hcompat :   ∏ x y : pr1 A, f x = f y → u x = u y).
     {
       intros x y eqfxy.
       assert (hpb:=pullback_HSET_univprop_elements

--- a/UniMath/CategoryTheory/covyoneda.v
+++ b/UniMath/CategoryTheory/covyoneda.v
@@ -82,7 +82,7 @@ Definition covyoneda_objects (C : precategory) (hs: has_homsets C) (c : C^op) :
 (** ** On morphisms *)
 
 Definition covyoneda_morphisms_data (C : precategory) (hs: has_homsets C) (c c' : C^op)
-    (f : C^op⟦c,c'⟧) : Π a : C,
+    (f : C^op⟦c,c'⟧) : ∏ a : C,
          HSET⟦covyoneda_objects C hs c a,covyoneda_objects C hs c' a⟧.
 Proof.
 simpl in f; intros a g.

--- a/UniMath/CategoryTheory/equivalences.v
+++ b/UniMath/CategoryTheory/equivalences.v
@@ -45,11 +45,11 @@ Section adjunctions.
 Definition form_adjunction {A B : precategory} (F : functor A B) (G : functor B A)
   (eta : nat_trans (functor_identity A) (functor_composite F G))
   (eps : nat_trans (functor_composite G F) (functor_identity B)) : UU :=
-    (Π a : A, # F (eta a) ;; eps (F a) = identity (F a)) ×
-    (Π b : B, eta (G b) ;; # G (eps b) = identity (G b)).
+    (∏ a : A, # F (eta a) ;; eps (F a) = identity (F a)) ×
+    (∏ b : B, eta (G b) ;; # G (eps b) = identity (G b)).
 
 Definition are_adjoints {A B : precategory} (F : functor A B) (G : functor B A) : UU :=
-  Σ (etaeps : (nat_trans (functor_identity A) (functor_composite F G)) ×
+  ∑ (etaeps : (nat_trans (functor_identity A) (functor_composite F G)) ×
               (nat_trans (functor_composite G F) (functor_identity B))),
       form_adjunction F G (pr1 etaeps) (pr2 etaeps).
 
@@ -75,10 +75,10 @@ Definition counit_from_are_adjoints {A B : precategory}
    := pr2 (pr1 H).
 
 Definition is_left_adjoint {A B : precategory} (F : functor A B) : UU :=
-  Σ (G : functor B A), are_adjoints F G.
+  ∑ (G : functor B A), are_adjoints F G.
 
 Definition is_right_adjoint {A B : precategory} (G : functor B A) : UU :=
-  Σ (F : functor A B), are_adjoints F G.
+  ∑ (F : functor A B), are_adjoints F G.
 
 Definition are_adjoints_to_is_left_adjoint {A B : precategory} (F : functor A B) (G : functor B A)
            (H : are_adjoints F G) : is_left_adjoint F := (G,,H).
@@ -130,12 +130,12 @@ Definition counit_from_right_adjoint {A B : precategory}
 
 Definition triangle_id_left_ad {A B : precategory} {F : functor A B} {G : functor B A}
   (H : are_adjoints F G) :
-  Π a, # F (unit_from_are_adjoints H a) ;; counit_from_are_adjoints H (F a) = identity (F a)
+  ∏ a, # F (unit_from_are_adjoints H a) ;; counit_from_are_adjoints H (F a) = identity (F a)
    := pr1 (pr2 H).
 
 Definition triangle_id_right_ad {A B : precategory} {F : functor A B} {G : functor B A}
   (H : are_adjoints F G) :
-  Π b, unit_from_are_adjoints H (G b) ;; # G (counit_from_are_adjoints H b) = identity (G b)
+  ∏ b, unit_from_are_adjoints H (G b) ;; # G (counit_from_are_adjoints H b) = identity (G b)
   := pr2 (pr2 H).
 
 Lemma are_adjoints_functor_composite
@@ -227,8 +227,8 @@ Defined.
 (** * Equivalence of (pre)categories *)
 
 Definition adj_equivalence_of_precats {A B : precategory} (F : functor A B) : UU :=
-   Σ (H : is_left_adjoint F), (Π a, is_isomorphism (unit_from_left_adjoint H a)) ×
-                              (Π b, is_isomorphism (counit_from_left_adjoint H b)).
+   ∑ (H : is_left_adjoint F), (∏ a, is_isomorphism (unit_from_left_adjoint H a)) ×
+                              (∏ b, is_isomorphism (counit_from_left_adjoint H b)).
 
 Definition adj_equivalence_inv {A B : precategory}
   {F : functor A B} (HF : adj_equivalence_of_precats F) : functor B A :=
@@ -238,7 +238,7 @@ Local Notation "HF ^^-1" := (adj_equivalence_inv  HF)(at level 3).
 
 Definition unit_pointwise_iso_from_adj_equivalence {A B : precategory}
    {F : functor A B} (HF : adj_equivalence_of_precats F) :
-    Π a, iso a (HF^^-1 (F a)).
+    ∏ a, iso a (HF^^-1 (F a)).
 Proof.
 intro a.
 exists (unit_from_left_adjoint (pr1 HF) a).
@@ -247,7 +247,7 @@ Defined.
 
 Definition counit_pointwise_iso_from_adj_equivalence {A B : precategory}
   {F : functor A B} (HF : adj_equivalence_of_precats F) :
-    Π b, iso (F (HF^^-1 b)) b.
+    ∏ b, iso (F (HF^^-1 b)) b.
 Proof.
   intro b.
   exists (counit_from_left_adjoint (pr1 HF) b).
@@ -325,7 +325,7 @@ Defined.
 
 Lemma isaprop_sigma_iso (A B : precategory) (HA : is_category A) (*hsB: has_homsets B*)
      (F : functor A B) (HF : fully_faithful F) :
-      Π b : ob B,
+      ∏ b : ob B,
   isaprop (total2 (fun a : ob A => iso (pr1 F a) b)).
 Proof.
   intro b.
@@ -373,7 +373,7 @@ Qed.
 
 Lemma isaprop_pi_sigma_iso (A B : precategory) (HA : is_category A) (hsB: has_homsets B)
      (F : ob [A, B, hsB]) (HF : fully_faithful F) :
-  isaprop (Π b : ob B,
+  isaprop (∏ b : ob B,
              total2 (fun a : ob A => iso (pr1 F a) b)).
 Proof.
   apply impred; intro b.
@@ -599,11 +599,11 @@ Section adjunction_from_partial.
 
 Definition is_universal_arrow_from {D C : precategory}
   (S : functor D C) (c : C) (r : D) (v : C⟦S r, c⟧) : UU :=
-  Π (d : D) (f : C⟦S d,c⟧), ∃! (f' : D⟦d,r⟧), f = # S f' ;; v.
+  ∏ (d : D) (f : C⟦S d,c⟧), ∃! (f' : D⟦d,r⟧), f = # S f' ;; v.
 
 Variables (X A : precategory) (F : functor X A).
-Variables (G0 : ob A -> ob X) (eps : Π a, A⟦F (G0 a),a⟧).
-Hypothesis (Huniv : Π a, is_universal_arrow_from F a (G0 a) (eps a)).
+Variables (G0 : ob A -> ob X) (eps : ∏ a, A⟦F (G0 a),a⟧).
+Hypothesis (Huniv : ∏ a, is_universal_arrow_from F a (G0 a) (eps a)).
 
 Local Definition G_data : functor_data A X.
 Proof.
@@ -696,8 +696,8 @@ Let G : functor E D := right_adjoint HF.
 Let H : are_adjoints F G := pr2 HF.
 Let η : nat_trans (functor_identity D) (functor_composite F G):= unit_from_left_adjoint H.
 Let ε : nat_trans (functor_composite G F) (functor_identity E) := counit_from_left_adjoint H.
-Let H1 : Π a : D, # F (η a) ;; ε (F a) = identity (F a) := triangle_id_left_ad H.
-Let H2 : Π b : E, η (G b) ;; # G (ε b) = identity (G b) := triangle_id_right_ad H.
+Let H1 : ∏ a : D, # F (η a) ;; ε (F a) = identity (F a) := triangle_id_left_ad H.
+Let H2 : ∏ b : E, η (G b) ;; # G (ε b) = identity (G b) := triangle_id_right_ad H.
 
 Lemma is_left_adjoint_post_composition_functor :
   is_left_adjoint (post_composition_functor C D E hsD hsE F).

--- a/UniMath/CategoryTheory/exponentials.v
+++ b/UniMath/CategoryTheory/exponentials.v
@@ -26,7 +26,7 @@ Definition constprod_functor2 (a : C) : functor C C :=
 
 Definition is_exponentiable (a : C) : UU := is_left_adjoint (constprod_functor1 a).
 
-Definition has_exponentials : UU := Π (a : C), is_exponentiable a.
+Definition has_exponentials : UU := ∏ (a : C), is_exponentiable a.
 
 Definition nat_trans_constprod_functor1 (a : C) :
   nat_trans (constprod_functor1 a) (constprod_functor2 a).

--- a/UniMath/CategoryTheory/functor_categories.v
+++ b/UniMath/CategoryTheory/functor_categories.v
@@ -66,10 +66,10 @@ Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 Section functors.
 
 Definition functor_data (C C' : precategory_ob_mor) : UU :=
-  total2 ( fun F : ob C -> ob C' =>  Π a b : ob C, a --> b -> F a --> F b).
+  total2 ( fun F : ob C -> ob C' =>  ∏ a b : ob C, a --> b -> F a --> F b).
 
 Definition mk_functor_data {C C' : precategory_ob_mor} (F : ob C -> ob C')
-           (H : Π a b : ob C, a --> b -> F a --> F b) : functor_data C C' := tpair _ F H.
+           (H : ∏ a b : ob C, a --> b -> F a --> F b) : functor_data C C' := tpair _ F H.
 
 Lemma functor_data_isaset (C C' : precategory_ob_mor) (hs : has_homsets C') (hsC' : isaset C') :
   isaset (functor_data C C').
@@ -86,8 +86,8 @@ Proof.
 Qed.
 
 Lemma functor_data_eq {C C' : precategory_ob_mor} (F F' : functor_data C C')
-      (H : Π (c : C), (pr1 F) c = (pr1 F') c)
-      (H1 : Π (C1 C2 : ob C) (f : C1 --> C2),
+      (H : ∏ (c : C), (pr1 F) c = (pr1 F') c)
+      (H1 : ∏ (C1 C2 : ob C) (f : C1 --> C2),
             transportf (λ x : C', pr1 F' C1 --> x) (H C2)
                        (transportf (λ x : C', x --> pr1 F C2) (H C1) (pr2 F C1 C2 f)) =
             pr2 F' C1 C2 f) : F = F'.
@@ -95,7 +95,7 @@ Proof.
   use total2_paths.
   - use funextfun. intros c. exact (H c).
   - use funextsec. intros C1. use funextsec. intros C2. use funextsec. intros f.
-    assert (e : transportf (λ x : C → C', Π a b : C, a --> b → x a --> x b)
+    assert (e : transportf (λ x : C → C', ∏ a b : C, a --> b → x a --> x b)
                            (funextfun (pr1 F) (pr1 F') (λ c : C, H c))
                            (pr2 F) C1 C2 f =
                 transportf (λ x : C → C', x C1 --> x C2)
@@ -112,7 +112,7 @@ Proof.
 Qed.
 
 Definition functor_data_constr (C C' : precategory_ob_mor)
-           (F : ob C -> ob C') (Fm : Π a b : ob C, a --> b -> F a --> F b) :
+           (F : ob C -> ob C') (Fm : ∏ a b : ob C, a --> b -> F a --> F b) :
   functor_data C C' := tpair _ F Fm .
 
 Definition functor_on_objects {C C' : precategory_ob_mor}
@@ -125,10 +125,10 @@ Definition functor_on_morphisms {C C' : precategory_ob_mor} (F : functor_data C 
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
 Definition functor_idax {C C' : precategory_data} (F : functor_data C C') :=
-  Π a : ob C, #F (identity a) = identity (F a).
+  ∏ a : ob C, #F (identity a) = identity (F a).
 
 Definition functor_compax {C C' : precategory_data} (F : functor_data C C') :=
-  Π a b c : ob C, Π f : a --> b, Π g : b --> c, #F (f ;; g) = #F f ;; #F g .
+  ∏ a b c : ob C, ∏ f : a --> b, ∏ g : b --> c, #F (f ;; g) = #F f ;; #F g .
 
 Definition is_functor {C C' : precategory_data} (F : functor_data C C') :=
   dirprod ( functor_idax F ) ( functor_compax F ) .
@@ -197,13 +197,13 @@ Proof.
 Defined.
 
 Definition functor_id {C C' : precategory_data}(F : functor C C'):
-       Π a : ob C, #F (identity a) = identity (F a) := pr1 (pr2 F).
+       ∏ a : ob C, #F (identity a) = identity (F a) := pr1 (pr2 F).
 
 
 Definition functor_comp {C C' : precategory_data}
       (F : functor C C'):
-       Π a b c : ob C, Π f : a --> b,
-                 Π g : b --> c,
+       ∏ a b c : ob C, ∏ f : a --> b,
+                 ∏ g : b --> c,
                 #F (f ;; g) = #F f ;; #F g := pr2 (pr2 F).
 
 
@@ -315,7 +315,7 @@ Qed.
 (** ** Fully faithful functors *)
 
 Definition fully_faithful {C D : precategory_data} (F : functor C D) :=
-  Π a b : ob C,
+  ∏ a b : ob C,
     isweq (functor_on_morphisms F (a:=a) (b:=b)).
 
 Lemma isaprop_fully_faithful (C D : precategory_data) (F : functor C D) :
@@ -555,12 +555,12 @@ Qed.
 (** ** Essentially surjective functors *)
 
 Definition essentially_surjective {C D : precategory_data} (F : functor C D) :=
-  Π b, ishinh (total2 (fun a => iso (F a) b)).
+  ∏ b, ishinh (total2 (fun a => iso (F a) b)).
 
 (** ** Faithful functors *)
 
 Definition faithful {C D : precategory_data} (F : functor C D) :=
-  Π a b : ob C, isincl (fun f : a --> b => #F f).
+  ∏ a b : ob C, isincl (fun f : a --> b => #F f).
 
 Lemma isaprop_faithful (C D : precategory_data) (F : functor C D) :
    isaprop (faithful F).
@@ -573,7 +573,7 @@ Qed.
 
 
 Definition full {C D : precategory_data} (F : functor C D) :=
-   Π a b: C, issurjective (fun f : a --> b => #F f).
+   ∏ a b: C, issurjective (fun f : a --> b => #F f).
 
 
 
@@ -735,13 +735,13 @@ Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
 Definition is_nat_trans {C C' : precategory_data}
   (F F' : functor_data C C')
-  (t : Π x : ob C, F x -->  F' x) :=
-  Π (x x' : ob C)(f : x --> x'),
+  (t : ∏ x : ob C, F x -->  F' x) :=
+  ∏ (x x' : ob C)(f : x --> x'),
     # F f ;; t x' = t x ;; #F' f.
 
 
 Lemma isaprop_is_nat_trans (C C' : precategory_data) (hs: has_homsets C')
-  (F F' : functor_data C C') (t : Π x : ob C, F x -->  F' x):
+  (F F' : functor_data C C') (t : ∏ x : ob C, F x -->  F' x):
   isaprop (is_nat_trans F F' t).
 Proof.
   repeat (apply impred; intro).
@@ -750,11 +750,11 @@ Qed.
 
 
 Definition nat_trans {C C' : precategory_data} (F F' : functor_data C C') : UU :=
-  total2 (fun t : Π x : ob C, F x -->  F' x => is_nat_trans F F' t).
+  total2 (fun t : ∏ x : ob C, F x -->  F' x => is_nat_trans F F' t).
 
 (** Note that this makes the second component opaque for efficiency reasons *)
 Definition mk_nat_trans {C C' : precategory_data} (F F' : functor_data C C')
-           (t : Π x : ob C, F x --> F' x) (H : is_nat_trans F F' t) :
+           (t : ∏ x : ob C, F x --> F' x) (H : is_nat_trans F F' t) :
            nat_trans F F'.
 Proof.
 exists t.
@@ -771,19 +771,19 @@ Qed.
 
 Definition nat_trans_data {C C' : precategory_data}
  {F F' : functor_data C C'}(a : nat_trans F F') :
-   Π x : ob C, F x --> F' x := pr1 a.
+   ∏ x : ob C, F x --> F' x := pr1 a.
 Coercion nat_trans_data : nat_trans >-> Funclass.
 
 Definition nat_trans_ax {C C' : precategory_data}
   {F F' : functor_data C C'} (a : nat_trans F F') :
-  Π (x x' : ob C)(f : x --> x'),
+  ∏ (x x' : ob C)(f : x --> x'),
     #F f ;; a x' = a x ;; #F' f := pr2 a.
 
 (** Equality between two natural transformations *)
 
 Lemma nat_trans_eq {C C' : precategory_data} (hs: has_homsets C')
   (F F' : functor_data C C')(a a' : nat_trans F F'):
-  (Π x, a x = a' x) -> a = a'.
+  (∏ x, a x = a' x) -> a = a'.
 Proof.
   intro H.
   assert (H' : pr1 a = pr1 a').
@@ -793,7 +793,7 @@ Qed.
 
 Definition nat_trans_eq_pointwise {C C' : precategory_data}
    {F F' : functor_data C C'} {a a' : nat_trans F F'}:
-      a = a' -> Π x, a x = a' x.
+      a = a' -> ∏ x, a x = a' x.
 Proof.
   intro h.
   now apply toforallpaths, maponpaths.
@@ -893,7 +893,7 @@ Definition functor_composite_as_ob {C C' C'' : precategory}
 Lemma nat_trans_comp_pointwise (C : precategory_data)(C' : precategory) (hs: has_homsets C')
   (F G H : ob [C, C', hs]) (A : F --> G) (A' : G --> H)
    (B : F --> H) : A ;; A' = B ->
-        Π a, pr1 A a ;; pr1 A' a = pr1 B a.
+        ∏ a, pr1 A a ;; pr1 A' a = pr1 B a.
 Proof.
   intros H' a.
   pathvia (pr1 (A ;; A') a).
@@ -909,7 +909,7 @@ Variable hsD : has_homsets D.
 Context {F G : functor C D}.
 Variables alpha beta : nat_trans F G.
 
-Definition nat_trans_eq_weq : weq (alpha = beta) (Π c, alpha c = beta c).
+Definition nat_trans_eq_weq : weq (alpha = beta) (∏ c, alpha c = beta c).
 Proof.
   eapply weqcomp.
   - apply subtypeInjectivity.
@@ -956,7 +956,7 @@ Qed.
 Definition nat_trans_inv_from_pointwise_inv (C : precategory_data)(D : precategory)
   (hs: has_homsets D)
   (F G : ob [C,D,hs]) (A : F --> G)
-  (H : Π a : ob C, is_isomorphism (pr1 A a)) :
+  (H : ∏ a : ob C, is_isomorphism (pr1 A a)) :
     G --> F := tpair _ _ (is_nat_trans_inv_from_pointwise_inv _ _ _ _ _ _ H).
 
 Definition nat_trans_inv_from_pointwise_inv_ext {C : precategory_data}{D : precategory}
@@ -977,7 +977,7 @@ Defined.
 
 Lemma is_inverse_nat_trans_inv_from_pointwise_inv (C : precategory_data)(C' : precategory) (hs: has_homsets C')
     (F G : [C, C', hs]) (A : F --> G)
-   (H : Π a : C, is_isomorphism (pr1 A a)) :
+   (H : ∏ a : C, is_isomorphism (pr1 A a)) :
   is_inverse_in_precat A (nat_trans_inv_from_pointwise_inv C C' _ F G A H).
 Proof.
   simpl; split; simpl.
@@ -995,7 +995,7 @@ Qed.
 Lemma functor_iso_if_pointwise_iso (C : precategory_data) (C' : precategory)
   (hs: has_homsets C')
  (F G : ob [C, C', hs]) (A : F --> G) :
-   (Π a : ob C, is_isomorphism (pr1 A a)) ->
+   (∏ a : ob C, is_isomorphism (pr1 A a)) ->
            is_isomorphism A .
 Proof.
   intro H.
@@ -1006,7 +1006,7 @@ Defined.
 Definition functor_iso_from_pointwise_iso (C : precategory_data)(C' : precategory)
   (hs: has_homsets C')
  (F G : ob [C, C', hs]) (A : F --> G)
-   (H : Π a : ob C, is_isomorphism (pr1 A a)) :
+   (H : ∏ a : ob C, is_isomorphism (pr1 A a)) :
      iso F G :=
  tpair _ _ (functor_iso_if_pointwise_iso _ _ _ _ _ _ H).
 
@@ -1015,7 +1015,7 @@ Lemma is_functor_iso_pointwise_if_iso (C : precategory_data)(C' : precategory)
   (hs: has_homsets C')
  (F G : ob [C, C', hs]) (A : F --> G) :
   is_isomorphism A ->
-       Π a : ob C, is_isomorphism (pr1 A a).
+       ∏ a : ob C, is_isomorphism (pr1 A a).
 Proof.
   intros H a.
   set (T:= inv_from_iso (tpair _ A H)).
@@ -1033,7 +1033,7 @@ Defined.
 Lemma nat_trans_inv_pointwise_inv_before (C : precategory_data) (C' : precategory)
   (hs: has_homsets C')
  (F G : ob [C, C', hs]) (A : F --> G) (Aiso: is_isomorphism A) :
-       Π a : C, pr1 (inv_from_iso (isopair A Aiso)) a ;; pr1 A a = identity _ .
+       ∏ a : C, pr1 (inv_from_iso (isopair A Aiso)) a ;; pr1 A a = identity _ .
 Proof.
   intro a.
   set (T:= inv_from_iso (isopair A Aiso)).
@@ -1045,7 +1045,7 @@ Defined.
 Lemma nat_trans_inv_pointwise_inv_after (C : precategory_data) (C' : precategory)
   (hs: has_homsets C')
  (F G : ob [C, C', hs]) (A : F --> G) (Aiso: is_isomorphism A) :
-       Π a : C, pr1 A a ;; pr1 (inv_from_iso (isopair A Aiso)) a = identity _ .
+       ∏ a : C, pr1 A a ;; pr1 (inv_from_iso (isopair A Aiso)) a = identity _ .
 Proof.
   intro a.
   set (T:= inv_from_iso (isopair A Aiso)).
@@ -1059,7 +1059,7 @@ Definition functor_iso_pointwise_if_iso (C : precategory_data) (C' : precategory
   (hs: has_homsets C')
  (F G : ob [C, C',hs]) (A : F --> G)
   (H : is_isomorphism A) :
-     Π a : ob C,
+     ∏ a : ob C,
        iso (pr1 F a) (pr1 G a) :=
   fun a => tpair _ _ (is_functor_iso_pointwise_if_iso C C' _ F G A H a).
 
@@ -1096,11 +1096,11 @@ Defined.
 
 Lemma transport_of_functor_map_is_pointwise (C : precategory_data) (D : precategory)
       (F0 G0 : ob C -> ob D)
-    (F1 : Π a b : ob C, a --> b -> F0 a --> F0 b)
+    (F1 : ∏ a b : ob C, a --> b -> F0 a --> F0 b)
    (gamma : F0  = G0 )
     (a b : ob C) (f : a --> b) :
 transportf (fun x : ob C -> ob D =>
-            Π a0 b0 : ob  C, a0 --> b0 -> x a0 --> x b0)
+            ∏ a0 b0 : ob  C, a0 --> b0 -> x a0 --> x b0)
            gamma  F1 a b f =
 transportf (fun TT : ob D => G0 a --> TT)
   (toforallpaths (fun _ : ob C => D) F0 G0 gamma b)
@@ -1111,8 +1111,8 @@ Proof.
   apply idpath.
 Defined.
 
-Lemma toforallpaths_funextsec : Π (T : UU) (P : T -> UU) (f g : Π t : T, P t)
-          (h : Π t : T, f t = g t),
+Lemma toforallpaths_funextsec : ∏ (T : UU) (P : T -> UU) (f g : ∏ t : T, P t)
+          (h : ∏ t : T, f t = g t),
             toforallpaths _  _ _ (funextsec _ _ _ h) = h.
 Proof.
   intros T P f g h.

--- a/UniMath/CategoryTheory/limits/BinDirectSums.v
+++ b/UniMath/CategoryTheory/limits/BinDirectSums.v
@@ -108,7 +108,7 @@ Section def_bindirectsums.
 
   (** Definition of BinDirectSums. *)
   Definition BinDirectSumCone (a b : A) : UU :=
-    Σ coab : (Σ co : A, a --> co × b --> co × co --> a × co --> b),
+    ∑ coab : (∑ co : A, a --> co × b --> co × co --> a × co --> b),
              isBinDirectSumCone a b (pr1 coab) (pr1 (pr2 coab)) (pr1 (pr2 (pr2 coab)))
                                 (pr1 (pr2 (pr2 (pr2 coab)))) (pr2 (pr2 (pr2 (pr2 coab)))).
 
@@ -118,7 +118,7 @@ Section def_bindirectsums.
     BinDirectSumCone a b := tpair _ (tpair _ co (i1,,(i2,,(p1,,p2)))) H.
 
   (** BinDirectSum in categories. *)
-  Definition BinDirectSums : UU := Π (a b : A), BinDirectSumCone a b.
+  Definition BinDirectSums : UU := ∏ (a b : A), BinDirectSumCone a b.
 
   Definition has_BinDirectSums : UU := ishinh BinDirectSums.
 
@@ -166,28 +166,28 @@ Section def_bindirectsums.
 
   (** Commutativity of BinDirectSum. *)
   Definition BinDirectSumIn1Commutes {a b : A} (B : BinDirectSumCone a b) :
-    Π (c : A) (f : a --> c) (g : b --> c), (to_In1 B) ;; (FromBinDirectSum B f g) = f.
+    ∏ (c : A) (f : a --> c) (g : b --> c), (to_In1 B) ;; (FromBinDirectSum B f g) = f.
   Proof.
     intros c f g.
     apply (BinCoproductIn1Commutes A a b (BinDirectSum_BinCoproduct B) c f g).
   Qed.
 
   Definition BinDirectSumIn2Commutes {a b : A} (B : BinDirectSumCone a b) :
-    Π (c : A) (f : a --> c) (g : b --> c), (to_In2 B) ;; (FromBinDirectSum B f g) = g.
+    ∏ (c : A) (f : a --> c) (g : b --> c), (to_In2 B) ;; (FromBinDirectSum B f g) = g.
   Proof.
     intros c f g.
     apply (BinCoproductIn2Commutes A a b (BinDirectSum_BinCoproduct B) c f g).
   Qed.
 
   Definition BinDirectSumPr1Commutes {a b : A} (B : BinDirectSumCone a b) :
-    Π (c : A) (f : c --> a) (g : c --> b), (ToBinDirectSum B f g) ;; (to_Pr1 B) = f.
+    ∏ (c : A) (f : c --> a) (g : c --> b), (ToBinDirectSum B f g) ;; (to_Pr1 B) = f.
   Proof.
     intros c f g.
     apply (BinProductPr1Commutes A a b (BinDirectSum_BinProduct B) c f g).
   Qed.
 
   Definition BinDirectSumPr2Commutes {a b : A} (B : BinDirectSumCone a b) :
-    Π (c : A) (f : c --> a) (g : c --> b), (ToBinDirectSum B f g) ;; (to_Pr2 B) = g.
+    ∏ (c : A) (f : c --> a) (g : c --> b), (ToBinDirectSum B f g) ;; (to_Pr2 B) = g.
   Proof.
     intros c f g.
     apply (BinProductPr2Commutes A a b (BinDirectSum_BinProduct B) c f g).

--- a/UniMath/CategoryTheory/limits/FinOrdCoproducts.v
+++ b/UniMath/CategoryTheory/limits/FinOrdCoproducts.v
@@ -21,7 +21,7 @@ Section def_FinOrdCoproducts.
   Variable C : precategory.
 
   Definition FinOrdCoproducts : UU :=
-    Π (n : nat) (a : stn n -> C), CoproductCocone (stn n) C a.
+    ∏ (n : nat) (a : stn n -> C), CoproductCocone (stn n) C a.
   Definition hasFinOrdCoproducts := ishinh FinOrdCoproducts.
 
 End def_FinOrdCoproducts.
@@ -35,7 +35,7 @@ Section FinOrdCoproduct_criteria.
 
   (** Case n = 0 of the theorem. *)
   Lemma InitialToCoproduct (I : Initial C):
-    Π (a : stn 0 -> C), CoproductCocone (stn 0) C a.
+    ∏ (a : stn 0 -> C), CoproductCocone (stn 0) C a.
   Proof.
     intros a.
     use (mk_CoproductCocone _ _ _ I
@@ -51,7 +51,7 @@ Section FinOrdCoproduct_criteria.
 
   (** Case n = 1 of the theorem. *)
   Lemma ObjectToCoproduct:
-    Π (a : stn 1 -> C), CoproductCocone (stn 1) C a.
+    ∏ (a : stn 1 -> C), CoproductCocone (stn 1) C a.
   Proof.
     intros a.
     set (stn1ob := invweq(weqstn1tounit) tt).

--- a/UniMath/CategoryTheory/limits/FinOrdProducts.v
+++ b/UniMath/CategoryTheory/limits/FinOrdProducts.v
@@ -21,7 +21,7 @@ Section def_FinOrdProducts.
   Variable C : precategory.
 
   Definition FinOrdProducts : UU :=
-    Π (n : nat) (a : stn n -> C), ProductCone (stn n) C a.
+    ∏ (n : nat) (a : stn n -> C), ProductCone (stn n) C a.
   Definition hasFinOrdProducts := ishinh FinOrdProducts.
 
 End def_FinOrdProducts.
@@ -35,7 +35,7 @@ Section FinOrdProduct_criteria.
 
   (** Case n = 0 of the theorem. *)
   Lemma TerminalToProduct (T : Terminal C):
-    Π (a : stn 0 -> C), ProductCone (stn 0) C a.
+    ∏ (a : stn 0 -> C), ProductCone (stn 0) C a.
   Proof.
     intros a.
     use (mk_ProductCone _ _ _ T
@@ -51,7 +51,7 @@ Section FinOrdProduct_criteria.
 
   (** Case n = 1 of the theorem. *)
   Lemma identity_to_product:
-    Π (a : stn 1 -> C), ProductCone (stn 1) C a.
+    ∏ (a : stn 1 -> C), ProductCone (stn 1) C a.
   Proof.
     intros a.
     set (stn1ob := invweq(weqstn1tounit) tt).

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -37,8 +37,8 @@ Section coproduct_def.
 Variable C : precategory.
 
 Definition isBinCoproductCocone (a b co : C) (ia : a --> co) (ib : b --> co) :=
-  Π (c : C) (f : a --> c) (g : b --> c),
-  iscontr (Σ fg : co --> c, (ia ;; fg = f) × (ib ;; fg = g)).
+  ∏ (c : C) (f : a --> c) (g : b --> c),
+  iscontr (∑ fg : co --> c, (ia ;; fg = f) × (ib ;; fg = g)).
 
 Lemma isaprop_isBinCoproductCocone {a b co : C} {ia : a --> co} {ib : b --> co} :
   isaprop (isBinCoproductCocone a b co ia ib).
@@ -50,11 +50,11 @@ Proof.
 Qed.
 
 Definition BinCoproductCocone (a b : C) :=
-   Σ coiaib : (Σ co : C, a --> co × b --> co),
+   ∑ coiaib : (∑ co : C, a --> co × b --> co),
       isBinCoproductCocone a b (pr1 coiaib) (pr1 (pr2 coiaib)) (pr2 (pr2 coiaib)).
 
 
-Definition BinCoproducts := Π (a b : C), BinCoproductCocone a b.
+Definition BinCoproducts := ∏ (a b : C), BinCoproductCocone a b.
 Definition hasBinCoproducts := ishinh BinCoproducts.
 
 Definition BinCoproductObject {a b : C} (CC : BinCoproductCocone a b) : C := pr1 (pr1 CC).
@@ -76,14 +76,14 @@ Proof.
 Defined.
 
 Lemma BinCoproductIn1Commutes (a b : C) (CC : BinCoproductCocone a b):
-     Π (c : C) (f : a --> c) g, BinCoproductIn1 CC ;; BinCoproductArrow CC f g  = f.
+     ∏ (c : C) (f : a --> c) g, BinCoproductIn1 CC ;; BinCoproductArrow CC f g  = f.
 Proof.
   intros c f g.
   exact (pr1 (pr2 (pr1 (isBinCoproductCocone_BinCoproductCocone CC _ f g)))).
 Qed.
 
 Lemma BinCoproductIn2Commutes (a b : C) (CC : BinCoproductCocone a b):
-     Π (c : C) (f : a --> c) g, BinCoproductIn2 CC ;; BinCoproductArrow CC f g = g.
+     ∏ (c : C) (f : a --> c) g, BinCoproductIn2 CC ;; BinCoproductArrow CC f g = g.
 Proof.
   intros c f g.
   exact (pr2 (pr2 (pr1 (isBinCoproductCocone_BinCoproductCocone CC _ f g)))).
@@ -149,7 +149,7 @@ Qed.
 
 
 Definition mk_BinCoproductCocone (a b : C) :
-  Π (c : C) (f : a --> c) (g : b --> c),
+  ∏ (c : C) (f : a --> c) (g : b --> c),
    isBinCoproductCocone _ _ _ f g →  BinCoproductCocone a b.
 Proof.
   intros.
@@ -162,7 +162,7 @@ Defined.
 
 Definition mk_isBinCoproductCocone (hsC : has_homsets C) (a b co : C)
    (ia : a --> co) (ib : b --> co) :
-   (Π (c : C) (f : a --> c) (g : b --> c),
+   (∏ (c : C) (f : a --> c) (g : b --> c),
     ∃! k : C ⟦co, c⟧,
       ia ;; k = f ×
       ib ;; k = g)
@@ -224,7 +224,7 @@ Lemma BinCoproduct_endo_is_identity (CC : BinCoproductCocone a b)
   : identity _ = k.
 Proof.
   set (H' := pr2 CC _ (BinCoproductIn1 CC) (BinCoproductIn2 CC) ); simpl in *.
-  set (X := (Σ fg : pr1 (pr1 CC) --> BinCoproductObject CC,
+  set (X := (∑ fg : pr1 (pr1 CC) --> BinCoproductObject CC,
           pr1 (pr2 (pr1 CC));; fg = BinCoproductIn1 CC
           × pr2 (pr2 (pr1 CC));; fg = BinCoproductIn2 CC)).
   set (t1 := tpair _ k (dirprodpair H1 H2) : X).
@@ -771,7 +771,7 @@ Proof.
 now apply (functor_eq _ _ hsD).
 Defined.
 
-Definition coproduct_nat_trans_in1_data : Π c, F c --> BinCoproduct_of_functors c
+Definition coproduct_nat_trans_in1_data : ∏ c, F c --> BinCoproduct_of_functors c
   := λ c : C, BinCoproductIn1 _ (HD (F c) (G c)).
 
 Lemma is_nat_trans_coproduct_nat_trans_in1_data
@@ -792,7 +792,7 @@ Qed.
 Definition coproduct_nat_trans_in1 : nat_trans _ _
   := tpair _ _ is_nat_trans_coproduct_nat_trans_in1_data.
 
-Definition coproduct_nat_trans_in2_data : Π c, G c --> BinCoproduct_of_functors c
+Definition coproduct_nat_trans_in2_data : ∏ c, G c --> BinCoproduct_of_functors c
   := λ c : C, BinCoproductIn2 _ (HD (F c) (G c)).
 
 Lemma is_nat_trans_coproduct_nat_trans_in2_data
@@ -822,7 +822,7 @@ Variable A : functor C D.
 Variable f : F ⟶ A.
 Variable g : G ⟶ A.
 
-Definition coproduct_nat_trans_data : Π c, BinCoproduct_of_functors c --> A c.
+Definition coproduct_nat_trans_data : ∏ c, BinCoproduct_of_functors c --> A c.
 Proof.
   intro c.
   apply BinCoproductArrow.
@@ -876,8 +876,8 @@ End vertex.
 
 Lemma coproduct_nat_trans_univ_prop (A : [C, D, hsD])
   (f : (F : [C,D,hsD]) --> A) (g : (G : [C,D,hsD]) --> A) :
-   Π
-   t : Σ fg : (BinCoproduct_of_functors:[C,D,hsD]) --> A,
+   ∏
+   t : ∑ fg : (BinCoproduct_of_functors:[C,D,hsD]) --> A,
        (coproduct_nat_trans_in1 : (F:[C,D,hsD]) --> BinCoproduct_of_functors);; fg = f
       ×
        (coproduct_nat_trans_in2: (G : [C,D,hsD]) --> BinCoproduct_of_functors);; fg = g,

--- a/UniMath/CategoryTheory/limits/binproducts.v
+++ b/UniMath/CategoryTheory/limits/binproducts.v
@@ -35,7 +35,7 @@ Section binproduct_def.
 Variable C : precategory.
 
 Definition isBinProductCone (c d p : C) (p1 : p --> c) (p2 : p --> d) :=
-  Π (a : C) (f : a --> c) (g : a --> d),
+  ∏ (a : C) (f : a --> c) (g : a --> d),
   iscontr (total2 (fun fg : a --> p => dirprod (fg ;; p1 = f) (fg ;; p2 = g))).
 
 Lemma isaprop_isBinProductCone (c d p : C) (p1 : p --> c) (p2 : p --> d) :
@@ -52,7 +52,7 @@ Definition BinProductCone (c d : C) :=
              isBinProductCone c d (pr1 pp1p2) (pr1 (pr2 pp1p2)) (pr2 (pr2 pp1p2))).
 
 
-Definition BinProducts := Π (c d : C), BinProductCone c d.
+Definition BinProducts := ∏ (c d : C), BinProductCone c d.
 Definition hasBinProducts := ishinh BinProducts.
 
 Definition BinProductObject {c d : C} (P : BinProductCone c d) : C := pr1 (pr1 P).
@@ -74,14 +74,14 @@ Proof.
 Defined.
 
 Lemma BinProductPr1Commutes (c d : C) (P : BinProductCone c d):
-     Π (a : C) (f : a --> c) g, BinProductArrow P f g ;; BinProductPr1 P = f.
+     ∏ (a : C) (f : a --> c) g, BinProductArrow P f g ;; BinProductPr1 P = f.
 Proof.
   intros a f g.
   exact (pr1 (pr2 (pr1 (isBinProductCone_BinProductCone P _ f g)))).
 Qed.
 
 Lemma BinProductPr2Commutes (c d : C) (P : BinProductCone c d):
-     Π (a : C) (f : a --> c) g, BinProductArrow P f g ;; BinProductPr2 P = g.
+     ∏ (a : C) (f : a --> c) g, BinProductArrow P f g ;; BinProductPr2 P = g.
 Proof.
   intros a f g.
   exact (pr2 (pr2 (pr1 (isBinProductCone_BinProductCone P _ f g)))).
@@ -116,7 +116,7 @@ Proof.
 Qed.
 
 Definition mk_BinProductCone (a b : C) :
-  Π (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧),
+  ∏ (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧),
    isBinProductCone _ _ _ f g -> BinProductCone a b.
 Proof.
   intros.
@@ -129,7 +129,7 @@ Defined.
 
 Definition mk_isBinProductCone (hsC : has_homsets C) (a b p : C)
   (pa : C⟦p,a⟧) (pb : C⟦p,b⟧) :
-  (Π (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧),
+  (∏ (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧),
     ∃! k : C⟦c,p⟧, k ;; pa = f × k ;; pb = g) ->
   isBinProductCone a b p pa pb.
 Proof.
@@ -427,7 +427,7 @@ Proof.
 now apply (functor_eq _ _ hsD).
 Defined.
 
-Definition binproduct_nat_trans_pr1_data : Π c, BinProduct_of_functors c --> F c
+Definition binproduct_nat_trans_pr1_data : ∏ c, BinProduct_of_functors c --> F c
   := λ c : C, BinProductPr1 _ (HD (F c) (G c)).
 
 Lemma is_nat_trans_binproduct_nat_trans_pr1_data
@@ -445,7 +445,7 @@ Definition binproduct_nat_trans_pr1 : nat_trans _ _
   := tpair _ _ is_nat_trans_binproduct_nat_trans_pr1_data.
 
 
-Definition binproduct_nat_trans_pr2_data : Π c, BinProduct_of_functors c --> G c
+Definition binproduct_nat_trans_pr2_data : ∏ c, BinProduct_of_functors c --> G c
   := λ c : C, BinProductPr2 _ (HD (F c) (G c)).
 
 Lemma is_nat_trans_binproduct_nat_trans_pr2_data
@@ -471,7 +471,7 @@ Variable A : functor C D.
 Variable f : A ⟶ F.
 Variable g : A ⟶ G.
 
-Definition binproduct_nat_trans_data : Π c,  A c --> BinProduct_of_functors c.
+Definition binproduct_nat_trans_data : ∏ c,  A c --> BinProduct_of_functors c.
 Proof.
   intro c.
   apply BinProductArrow.
@@ -523,8 +523,8 @@ End vertex.
 
 Lemma binproduct_nat_trans_univ_prop (A : [C, D, hsD])
   (f : (A --> (F:[C,D,hsD]))) (g : A --> (G:[C,D,hsD])) :
-   Π
-   t : Σ fg : A --> (BinProduct_of_functors:[C,D,hsD]),
+   ∏
+   t : ∑ fg : A --> (BinProduct_of_functors:[C,D,hsD]),
        fg ;; (binproduct_nat_trans_pr1 : (BinProduct_of_functors:[C,D,hsD]) --> F) = f
       ×
        fg ;; (binproduct_nat_trans_pr2 : (BinProduct_of_functors:[C,D,hsD]) --> G) = g,

--- a/UniMath/CategoryTheory/limits/cats/limits.v
+++ b/UniMath/CategoryTheory/limits/cats/limits.v
@@ -43,28 +43,28 @@ End move_upstream.
 Section lim_def.
 
 Definition cone {J C : precategory} (F : functor J C) (c : C) : UU :=
-  Σ (f : Π (v : J), C⟦c,F v⟧),
-    Π (u v : J) (e : J⟦u,v⟧), f u ;; # F e = f v.
+  ∑ (f : ∏ (v : J), C⟦c,F v⟧),
+    ∏ (u v : J) (e : J⟦u,v⟧), f u ;; # F e = f v.
 
 Definition mk_cone {J C : precategory} {F : functor J C} {c : C}
-  (f : Π v, C⟦c, F v⟧) (Hf : Π u v (e : J⟦u,v⟧) , f u ;; # F e  = f v) :
+  (f : ∏ v, C⟦c, F v⟧) (Hf : ∏ u v (e : J⟦u,v⟧) , f u ;; # F e  = f v) :
   cone F c := tpair _ f Hf.
 
 Definition coneOut {J C : precategory} {F : functor J C} {c : C} (cc : cone F c) :
-  Π v, C⟦c, F v⟧ := pr1 cc.
+  ∏ v, C⟦c, F v⟧ := pr1 cc.
 
 Lemma coneOutCommutes {J C : precategory} {F : functor J C} {c : C}
-  (cc : cone F c) : Π u v (e : J⟦u,v⟧), coneOut cc u ;; # F e = coneOut cc v.
+  (cc : cone F c) : ∏ u v (e : J⟦u,v⟧), coneOut cc u ;; # F e = coneOut cc v.
 Proof.
 apply (pr2 cc).
 Qed.
 
 Definition isLimCone {J C : precategory} (F : functor J C)
-  (l : C) (cc0 : cone F l) : UU := Π (c : C) (cc : cone F c),
-    iscontr (Σ x : C⟦c,l⟧, Π v, x ;; coneOut cc0 v = coneOut cc v).
+  (l : C) (cc0 : cone F l) : UU := ∏ (c : C) (cc : cone F c),
+    iscontr (∑ x : C⟦c,l⟧, ∏ v, x ;; coneOut cc0 v = coneOut cc v).
 
 Definition LimCone {J C : precategory} (F : functor J C) : UU :=
-  Σ (A : (Σ l, cone F l)), isLimCone F (pr1 A) (pr2 A).
+  ∑ (A : (∑ l, cone F l)), isLimCone F (pr1 A) (pr2 A).
 
 Definition mk_LimCone {J C : precategory} (F : functor J C)
   (c : C) (cc : cone F c) (isCC : isLimCone F c cc) : LimCone F :=
@@ -78,18 +78,18 @@ Definition limCone {J C : precategory} {F : functor J C} (CC : LimCone F) :
   cone F (lim CC) := pr2 (pr1 CC).
 
 Definition limOut {J C : precategory} {F : functor J C} (CC : LimCone F) :
-  Π v, C⟦lim CC,F v⟧ := coneOut (limCone CC).
+  ∏ v, C⟦lim CC,F v⟧ := coneOut (limCone CC).
 
 Lemma limOutCommutes {J C : precategory} {F : functor J C}
-  (CC : LimCone F) : Π u v (e : J⟦u,v⟧),
+  (CC : LimCone F) : ∏ u v (e : J⟦u,v⟧),
    limOut CC u ;; # F e = limOut CC v.
 Proof.
 exact (coneOutCommutes (limCone CC)).
 Qed.
 
 Lemma limUnivProp {J C : precategory} {F : functor J C}
-  (CC : LimCone F) : Π (c : C) (cc : cone F c),
-  iscontr (Σ x : C⟦c, lim CC⟧, Π v, x ;; limOut CC v = coneOut cc v).
+  (CC : LimCone F) : ∏ (c : C) (cc : cone F c),
+  iscontr (∑ x : C⟦c, lim CC⟧, ∏ v, x ;; limOut CC v = coneOut cc v).
 Proof.
 exact (pr2 CC).
 Qed.
@@ -118,7 +118,7 @@ Qed.
 
 Lemma limArrowUnique {J C : precategory} {F : functor J C} (CC : LimCone F)
   (c : C) (cc : cone F c) (k : C⟦c, lim CC⟧)
-  (Hk : Π u, k ;; limOut CC u = coneOut cc u) :
+  (Hk : ∏ u, k ;; limOut CC u = coneOut cc u) :
   k = limArrow CC c cc.
 Proof.
 now apply path_to_ctr, Hk.
@@ -126,7 +126,7 @@ Qed.
 
 Lemma Cone_precompose {J C : precategory} {F : functor J C}
   {c : C} (cc : cone F c) (x : C) (f : C⟦x,c⟧) :
-    Π u v (e : J⟦u,v⟧), (f ;; coneOut cc u) ;; # F e = f ;; coneOut cc v.
+    ∏ u v (e : J⟦u,v⟧), (f ;; coneOut cc u) ;; # F e = f ;; coneOut cc v.
 Proof.
 now intros u v e; rewrite <- assoc, coneOutCommutes.
 Qed.
@@ -141,8 +141,8 @@ Qed.
 
 Definition limOfArrows {J C : precategory} {F1 F2 : functor J C}
   (CC1 : LimCone F1) (CC2 : LimCone F2)
-  (f : Π u, C⟦F1 u,F2 u⟧)
-  (fNat : Π u v (e : J⟦u,v⟧), f u ;; # F2 e = # F1 e ;; f v) :
+  (f : ∏ u, C⟦F1 u,F2 u⟧)
+  (fNat : ∏ u v (e : J⟦u,v⟧), f u ;; # F2 e = # F1 e ;; f v) :
   C⟦lim CC1 , lim CC2⟧.
 Proof.
 apply limArrow; simple refine (mk_cone _ _).
@@ -153,9 +153,9 @@ Defined.
 
 Lemma limOfArrowsOut {J C : precategory} {F1 F2 : functor J C}
   (CC1 : LimCone F1) (CC2 : LimCone F2)
-  (f : Π u, C⟦F1 u,F2 u⟧)
-  (fNat : Π u v (e : J⟦u,v⟧), f u ;; # F2 e = # F1 e ;; f v) :
-    Π u, limOfArrows CC1 CC2 f fNat ;; limOut CC2 u =
+  (f : ∏ u, C⟦F1 u,F2 u⟧)
+  (fNat : ∏ u v (e : J⟦u,v⟧), f u ;; # F2 e = # F1 e ;; f v) :
+    ∏ u, limOfArrows CC1 CC2 f fNat ;; limOut CC2 u =
           limOut CC1 u ;; f u.
 Proof.
 now unfold limOfArrows; intro u; rewrite limArrowCommutes.
@@ -164,8 +164,8 @@ Qed.
 Lemma postCompWithLimOfArrows_subproof
   {J C : precategory} {F1 F2 : functor J C}
   (CC1 : LimCone F1) (CC2 : LimCone F2)
-  (f : Π u, C⟦F1 u,F2 u⟧)
-  (fNat : Π u v (e : J⟦u,v⟧), f u ;; # F2 e = # F1 e ;; f v)
+  (f : ∏ u, C⟦F1 u,F2 u⟧)
+  (fNat : ∏ u v (e : J⟦u,v⟧), f u ;; # F2 e = # F1 e ;; f v)
   (x : C) (cc : cone F1 x) u v (e : J⟦u,v⟧) :
     (coneOut cc u ;; f u) ;; # F2 e = coneOut cc v ;; f v.
 Proof.
@@ -175,8 +175,8 @@ Defined.
 Lemma postcompWithLimOfArrows
   {J C : precategory} {F1 F2 : functor J C}
   (CC1 : LimCone F1) (CC2 : LimCone F2)
-  (f : Π u, C⟦F1 u,F2 u⟧)
-  (fNat : Π u v (e : J⟦u,v⟧), f u ;; # F2 e = # F1 e ;; f v)
+  (f : ∏ u, C⟦F1 u,F2 u⟧)
+  (fNat : ∏ u v (e : J⟦u,v⟧), f u ;; # F2 e = # F1 e ;; f v)
   (x : C) (cc : cone F1 x) :
      limArrow CC1 x cc ;; limOfArrows CC1 CC2 f fNat =
        limArrow CC2 x (mk_cone (λ u, coneOut cc u ;; f u)
@@ -198,7 +198,7 @@ Qed.
 
 Lemma lim_endo_is_identity {J C : precategory} {F : functor J C}
   (CC : LimCone F) (k : lim CC --> lim CC)
-  (H : Π u, k ;; limOut CC u = limOut CC u) :
+  (H : ∏ u, k ;; limOut CC u = limOut CC u) :
   identity _ = k.
 Proof.
 unshelve refine (uniqueExists _ _ (limUnivProp CC _ _) _ _ _ _).
@@ -216,13 +216,13 @@ Defined.
 
 Lemma isColim_weq_subproof1 {g : graph} (D : diagram g C)
   (c : C) (cc : cocone D c) (d : C) (k : C⟦c,d⟧) :
-  Π u, coconeIn cc u ;; k = pr1 (Cocone_by_postcompose D c cc d k) u.
+  ∏ u, coconeIn cc u ;; k = pr1 (Cocone_by_postcompose D c cc d k) u.
 Proof.
 now intro u.
 Qed.
 
 Lemma isColim_weq_subproof2 (g : graph) (D : diagram g C)
-  (c : C) (cc : cocone D c) (H : Π d, isweq (Cocone_by_postcompose D c cc d))
+  (c : C) (cc : cocone D c) (H : ∏ d, isweq (Cocone_by_postcompose D c cc d))
   (d : C) (cd : cocone D d) (u : vertex g) :
     coconeIn cc u ;; invmap (weqpair _ (H d)) cd = coconeIn cd u.
 Proof.
@@ -232,7 +232,7 @@ now rewrite p.
 Qed.
 
 Lemma isColim_weq {g : graph} (D : diagram g C) (c : C) (cc : cocone D c) :
-  isColimCocone D c cc <-> Π d, isweq (Cocone_by_postcompose D c cc d).
+  isColimCocone D c cc <-> ∏ d, isweq (Cocone_by_postcompose D c cc d).
 Proof.
 split.
 - intros H d.
@@ -276,10 +276,10 @@ End lim_def.
 
 Section Lims.
 
-Definition Lims (C : precategory) : UU := Π {J : precategory} (F : functor J C), LimCone F.
+Definition Lims (C : precategory) : UU := ∏ {J : precategory} (F : functor J C), LimCone F.
 Definition hasLims : UU  :=
-  Π {J C : precategory} (F : functor J C), ishinh (LimCone F).
-Definition Lims_of_shape (J C : precategory) : UU := Π (F : functor J C), LimCone F.
+  ∏ {J C : precategory} (F : functor J C), ishinh (LimCone F).
+Definition Lims_of_shape (J C : precategory) : UU := ∏ (F : functor J C), LimCone F.
 
 Section Universal_Unique.
 
@@ -294,8 +294,8 @@ apply invproofirrelevance; intros Hccx Hccy.
 apply subtypeEquality.
 - intro; apply isaprop_isLimCone.
 - apply (total2_paths (isotoid _ H (iso_from_lim_to_lim Hccx Hccy))).
-  set (B c := Π v, C⟦c,F v⟧).
-  set (C' (c : C) f := Π u v (e : J⟦u,v⟧), @compose _ c _ _ (f u) (# F e) = f v).
+  set (B c := ∏ v, C⟦c,F v⟧).
+  set (C' (c : C) f := ∏ u v (e : J⟦u,v⟧), @compose _ c _ _ (f u) (# F e) = f v).
   rewrite (@transportf_total2 _ B C').
   apply subtypeEquality.
   + intro; repeat (apply impred; intro); apply (pr2 H).
@@ -326,7 +326,7 @@ mkpair.
       apply (toforallpaths _ _ _ (maponpaths pr1 (functor_comp D x y z f g)) a)]).
 Defined.
 
-Variable (HCg : Π (a : A), LimCone (functor_pointwise a)).
+Variable (HCg : ∏ (a : A), LimCone (functor_pointwise a)).
 
 Definition LimFunctor_ob (a : A) : C := lim (HCg a).
 
@@ -376,8 +376,8 @@ simple refine (mk_cone _ _).
 Defined.
 
 Lemma LimFunctor_unique (F : [A, C, hsC]) (cc : cone D F) :
-  iscontr (Σ x : [A, C, hsC] ⟦ F, LimFunctor ⟧,
-            Π v, x ;; lim_nat_trans_in_data v = coneOut cc v).
+  iscontr (∑ x : [A, C, hsC] ⟦ F, LimFunctor ⟧,
+            ∏ v, x ;; lim_nat_trans_in_data v = coneOut cc v).
 Proof.
 mkpair.
 - mkpair.

--- a/UniMath/CategoryTheory/limits/coequalizers.v
+++ b/UniMath/CategoryTheory/limits/coequalizers.v
@@ -22,13 +22,13 @@ Section def_coequalizers.
   (** Definition and construction of isCoequalizer. *)
   Definition isCoequalizer {x y z : C} (f g : x --> y) (e : y --> z)
              (H : f ;; e = g ;; e) : UU :=
-    Π (w : C) (h : y --> w) (H : f ;; h = g ;; h),
-      iscontr (Σ φ : z --> w, e ;; φ  = h).
+    ∏ (w : C) (h : y --> w) (H : f ;; h = g ;; h),
+      iscontr (∑ φ : z --> w, e ;; φ  = h).
 
   Definition mk_isCoequalizer {y z w : C} (f g : y --> z) (e : z --> w)
              (H : f ;; e = g ;; e) :
-    (Π (w0 : C) (h : z --> w0) (H' : f ;; h = g ;; h),
-        iscontr (Σ ψ : w --> w0, e ;; ψ = h)) -> isCoequalizer f g e H.
+    (∏ (w0 : C) (h : z --> w0) (H' : f ;; h = g ;; h),
+        iscontr (∑ ψ : w --> w0, e ;; ψ = h)) -> isCoequalizer f g e H.
   Proof.
     intros X. unfold isCoequalizer. exact X.
   Defined.
@@ -69,8 +69,8 @@ Section def_coequalizers.
 
   (** Definition and construction of coequalizers. *)
   Definition Coequalizer {y z : C} (f g : y --> z) : UU :=
-    Σ e : (Σ w : C, z --> w),
-          (Σ H : f ;; (pr2 e) = g ;; (pr2 e), isCoequalizer f g (pr2 e) H).
+    ∑ e : (∑ w : C, z --> w),
+          (∑ H : f ;; (pr2 e) = g ;; (pr2 e), isCoequalizer f g (pr2 e) H).
 
   Definition mk_Coequalizer {y z w : C} (f g : y --> z) (e : z --> w)
              (H : f ;; e = g ;; e) (isE : isCoequalizer f g e H) :
@@ -84,10 +84,10 @@ Section def_coequalizers.
   Defined.
 
   (** Coequalizers in precategories. *)
-  Definition Coequalizers := Π (y z : C) (f g : y --> z),
+  Definition Coequalizers := ∏ (y z : C) (f g : y --> z),
       Coequalizer f g.
 
-  Definition hasCoequalizers := Π (y z : C) (f g : y --> z),
+  Definition hasCoequalizers := ∏ (y z : C) (f g : y --> z),
       ishinh (Coequalizer f g).
 
   (** Returns the coequalizer object. *)
@@ -156,7 +156,7 @@ Section def_coequalizers.
     equalities. *)
   Definition identity_is_CoequalizerOut {y z : C} {f g : y --> z}
              (E : Coequalizer f g) :
-    Σ φ : C⟦E, E⟧, (CoequalizerArrow E) ;; φ = (CoequalizerArrow E).
+    ∑ φ : C⟦E, E⟧, (CoequalizerArrow E) ;; φ = (CoequalizerArrow E).
   Proof.
     exists (identity E).
     apply id_right.

--- a/UniMath/CategoryTheory/limits/cokernels.v
+++ b/UniMath/CategoryTheory/limits/cokernels.v
@@ -27,7 +27,7 @@ Section def_cokernels.
 
   (** Definition and construction of Cokernels *)
   Definition isCokernel {x y z : C} (f : x --> y) (g : y --> z) (H : f ;; g = (ZeroArrow Z x z)) : UU :=
-    Π (w : C) (h : y --> w) (H : f ;; h = ZeroArrow Z x w), iscontr (Σ φ : z --> w, g ;; φ = h).
+    ∏ (w : C) (h : y --> w) (H : f ;; h = ZeroArrow Z x w), iscontr (∑ φ : z --> w, g ;; φ = h).
 
   Lemma isCokernel_paths  {x y z : C} (f : x --> y) (g : y --> z) (H H' : f ;; g = (ZeroArrow Z x z))
         (isC : isCokernel f g H) : isCokernel f g H'.
@@ -38,17 +38,17 @@ Section def_cokernels.
 
   Local Lemma mk_isCokernel_uniqueness {x y z : C} (f : x --> y) (g : y --> z)
         (H1 : f ;; g = ZeroArrow Z x z)
-        (H2 : Π (w : C) (h : C ⟦ y, w ⟧),
+        (H2 : ∏ (w : C) (h : C ⟦ y, w ⟧),
               f ;; h = ZeroArrow Z x w → ∃! ψ : C ⟦ z, w ⟧, g ;; ψ = h)
         (w : C) (h : y --> w) (H' : f ;; h = ZeroArrow Z x w) :
-    Π y0 : C ⟦ z, w ⟧, g ;; y0 = h → y0 = pr1 (iscontrpr1 (H2 w h H')).
+    ∏ y0 : C ⟦ z, w ⟧, g ;; y0 = h → y0 = pr1 (iscontrpr1 (H2 w h H')).
   Proof.
     intros y0 H. apply (base_paths _ _ ((pr2 (H2 w h H')) (tpair _ y0 H))).
   Qed.
 
   Definition mk_isCokernel {x y z : C} (f : x --> y) (g : y --> z) (H1 : f ;; g = ZeroArrow Z x z)
-             (H2 : Π (w : C) (h : y --> w) (H' : f ;; h = ZeroArrow Z x w),
-                   iscontr (Σ ψ : z --> w, g ;; ψ = h)) : isCokernel f g H1.
+             (H2 : ∏ (w : C) (h : y --> w) (H' : f ;; h = ZeroArrow Z x w),
+                   iscontr (∑ ψ : z --> w, g ;; ψ = h)) : isCokernel f g H1.
   Proof.
     unfold isCokernel.
     intros w h H'.
@@ -60,15 +60,15 @@ Section def_cokernels.
   Defined.
 
   Definition Cokernel {x y : C} (f : x --> y) : UU :=
-    Σ D : (Σ z : ob C, y --> z),
-          Σ (e : f ;; (pr2 D) = ZeroArrow Z x (pr1 D)), isCokernel f (pr2 D) e.
+    ∑ D : (∑ z : ob C, y --> z),
+          ∑ (e : f ;; (pr2 D) = ZeroArrow Z x (pr1 D)), isCokernel f (pr2 D) e.
 
   Definition mk_Cokernel {x y z : C} (f : x --> y) (g : y --> z) (H : f ;; g = (ZeroArrow Z x z))
              (isCK : isCokernel f g H) : Cokernel f := ((z,,g),,(H,,isCK)).
 
-  Definition Cokernels : UU := Π (x y : C) (f : x --> y), Cokernel f.
+  Definition Cokernels : UU := ∏ (x y : C) (f : x --> y), Cokernel f.
 
-  Definition hasCokernels : UU := Π (x y : C) (f : x --> y), ishinh (Cokernel f).
+  Definition hasCokernels : UU := ∏ (x y : C) (f : x --> y), ishinh (Cokernel f).
 
   Definition CokernelOb {x y : C} {f : x --> y} (CK : Cokernel f) : ob C := pr1 (pr1 CK).
   Coercion CokernelOb : Cokernel >-> ob.
@@ -119,7 +119,7 @@ Section def_cokernels.
 
   (** Results on morphisms between Cokernels. *)
   Definition identity_is_CokernelOut {x y : C} {f : x --> y} (CK : Cokernel f) :
-    Σ φ : C⟦CK, CK⟧, (CokernelArrow CK) ;; φ = (CokernelArrow CK).
+    ∑ φ : C⟦CK, CK⟧, (CokernelArrow CK) ;; φ = (CokernelArrow CK).
   Proof.
     exists (identity CK).
     apply id_right.

--- a/UniMath/CategoryTheory/limits/cones.v
+++ b/UniMath/CategoryTheory/limits/cones.v
@@ -24,7 +24,7 @@ Variable hs: has_homsets C.
 Variable F : functor J C.
 
 Definition ConeData := total2 (
-  fun a : C => Π j : J, a --> F j).
+  fun a : C => ∏ j : J, a --> F j).
 
 Definition ConeTop (a : ConeData) : C := pr1 a.
 Definition ConeMor (a : ConeData) (j : J) : ConeTop a --> F j := (pr2 a) j.
@@ -40,7 +40,7 @@ Proof.
 Defined.
 
 Definition ConeProp (a : ConeData) :=
-  Π j j' (f : j --> j'), ConeMor a j ;; #F f = ConeMor a j'.
+  ∏ j j' (f : j --> j'), ConeMor a j ;; #F f = ConeMor a j'.
 
 Lemma isaprop_ConeProp (a : ConeData) : isaprop (ConeProp a).
 Proof.
@@ -75,7 +75,7 @@ Coercion ConeProp_from_Cone : Cone >-> ConeProp.
 
 
 Lemma cone_prop (a : Cone) :
-  Π j j' (f : j --> j'), ConeMor a j ;; #F f = ConeMor a j'.
+  ∏ j j' (f : j --> j'), ConeMor a j ;; #F f = ConeMor a j'.
 Proof.
   exact (pr2 a).
 Qed.
@@ -90,7 +90,7 @@ Defined.
 
 Definition Cone_Mor (M N : Cone) :=
   total2 (fun f : ConeTop M --> ConeTop N =>
-        Π j : J, f ;; ConeMor N j = ConeMor M j).
+        ∏ j : J, f ;; ConeMor N j = ConeMor M j).
 
 
 Lemma isaset_Cone_Mor (M N : Cone) : isaset (Cone_Mor M N).
@@ -117,7 +117,7 @@ Proof.
 Qed.
 
 Lemma cone_mor_prop M N (f : Cone_Mor M N) :
-    Π j : J, ConeConnect f ;; ConeMor N j = ConeMor M j.
+    ∏ j : J, ConeConnect f ;; ConeMor N j = ConeMor M j.
 Proof.
   exact (pr2 f).
 Qed.
@@ -285,7 +285,7 @@ Proof.
 Defined.
 
 
-Lemma isotoid_CONE_idtoiso (M N : CONE) : Π p : M = N, isotoid_CONE (idtoiso p) = p.
+Lemma isotoid_CONE_idtoiso (M N : CONE) : ∏ p : M = N, isotoid_CONE (idtoiso p) = p.
 Proof.
   intro p.
   induction p.
@@ -302,7 +302,7 @@ Proof.
   apply idpath.
 Qed.
 
-Lemma idtoiso_isotoid_CONE (M N : CONE) : Π f : iso M N, idtoiso (isotoid_CONE f) = f.
+Lemma idtoiso_isotoid_CONE (M N : CONE) : ∏ f : iso M N, idtoiso (isotoid_CONE f) = f.
 Proof.
   intro f.
   apply eq_iso.

--- a/UniMath/CategoryTheory/limits/coproducts.v
+++ b/UniMath/CategoryTheory/limits/coproducts.v
@@ -28,19 +28,19 @@ Section coproduct_def.
 Variables (I : UU) (C : precategory).
 
 Definition isCoproductCocone (a : I -> C) (co : C)
-  (ia : Π i, a i --> co) :=
-  Π (c : C) (f : Π i, a i --> c),
-    iscontr (total2 (fun (g : co --> c) => Π i, ia i ;; g = f i)).
+  (ia : ∏ i, a i --> co) :=
+  ∏ (c : C) (f : ∏ i, a i --> c),
+    iscontr (total2 (fun (g : co --> c) => ∏ i, ia i ;; g = f i)).
 
 Definition CoproductCocone (a : I -> C) :=
-   Σ coia : (Σ co : C, Π i, a i --> co),
+   ∑ coia : (∑ co : C, ∏ i, a i --> co),
           isCoproductCocone a (pr1 coia) (pr2 coia).
 
-Definition Coproducts := Π (a : I -> C), CoproductCocone a.
+Definition Coproducts := ∏ (a : I -> C), CoproductCocone a.
 Definition hasCoproducts := ishinh Coproducts.
 
 Definition CoproductObject {a : I -> C} (CC : CoproductCocone a) : C := pr1 (pr1 CC).
-Definition CoproductIn {a : I -> C} (CC : CoproductCocone a): Π i, a i --> CoproductObject CC :=
+Definition CoproductIn {a : I -> C} (CC : CoproductCocone a): ∏ i, a i --> CoproductObject CC :=
   pr2 (pr1 CC).
 
 Definition isCoproductCocone_CoproductCocone {a : I -> C} (CC : CoproductCocone a) :
@@ -49,14 +49,14 @@ Proof.
   exact (pr2 CC).
 Defined.
 
-Definition CoproductArrow {a : I -> C} (CC : CoproductCocone a) {c : C} (f : Π i, a i --> c) :
+Definition CoproductArrow {a : I -> C} (CC : CoproductCocone a) {c : C} (f : ∏ i, a i --> c) :
       CoproductObject CC --> c.
 Proof.
   exact (pr1 (pr1 (isCoproductCocone_CoproductCocone CC _ f))).
 Defined.
 
 Lemma CoproductInCommutes (a : I -> C) (CC : CoproductCocone a) :
-     Π (c : C) (f : Π i, a i --> c) i, CoproductIn CC i ;; CoproductArrow CC f = f i.
+     ∏ (c : C) (f : ∏ i, a i --> c) i, CoproductIn CC i ;; CoproductArrow CC f = f i.
 Proof.
   intros c f i.
   exact (pr2 (pr1 (isCoproductCocone_CoproductCocone CC _ f)) i).
@@ -71,8 +71,8 @@ Proof.
 Qed.
 
 Lemma CoproductArrowUnique (a : I -> C) (CC : CoproductCocone a) (x : C)
-    (f : Π i, a i --> x) (k : CoproductObject CC --> x)
-    (Hk : Π i, CoproductIn CC i ;; k = f i) :
+    (f : ∏ i, a i --> x) (k : CoproductObject CC --> x)
+    (Hk : ∏ i, CoproductIn CC i ;; k = f i) :
   k = CoproductArrow CC f.
 Proof.
   set (H' := pr2 (isCoproductCocone_CoproductCocone CC _ f) (k,,Hk)).
@@ -88,19 +88,19 @@ Qed.
 
 
 Definition CoproductOfArrows {a : I -> C} (CCab : CoproductCocone a) {c : I -> C}
-    (CCcd : CoproductCocone c) (f : Π i, a i --> c i) :
+    (CCcd : CoproductCocone c) (f : ∏ i, a i --> c i) :
           CoproductObject CCab --> CoproductObject CCcd :=
     CoproductArrow CCab (fun i => f i ;; CoproductIn CCcd i).
 
 Lemma CoproductOfArrowsIn {a : I -> C} (CCab : CoproductCocone a) {c : I -> C}
-    (CCcd : CoproductCocone c) (f : Π i, a i --> c i) :
-    Π i, CoproductIn CCab i ;; CoproductOfArrows CCab CCcd f = f i ;; CoproductIn CCcd i.
+    (CCcd : CoproductCocone c) (f : ∏ i, a i --> c i) :
+    ∏ i, CoproductIn CCab i ;; CoproductOfArrows CCab CCcd f = f i ;; CoproductIn CCcd i.
 Proof.
   unfold CoproductOfArrows; intro i.
   apply CoproductInCommutes.
 Qed.
 
-Definition mk_CoproductCocone (a : I -> C) (c : C) (f : Π i, a i --> c) :
+Definition mk_CoproductCocone (a : I -> C) (c : C) (f : ∏ i, a i --> c) :
    isCoproductCocone _ _ f →  CoproductCocone a.
 Proof.
 intro H.
@@ -110,8 +110,8 @@ mkpair.
 Defined.
 
 Definition mk_isCoproductCocone (hsC : has_homsets C) (a : I -> C) (co : C)
-  (f : Π i, a i --> co) : (Π (c : C) (g : Π i, a i --> c),
-                                  ∃! k : C ⟦co, c⟧, Π i, f i ;; k = g i)
+  (f : ∏ i, a i --> co) : (∏ (c : C) (g : ∏ i, a i --> c),
+                                  ∃! k : C ⟦co, c⟧, ∏ i, f i ;; k = g i)
    →    isCoproductCocone a co f.
 Proof.
   intros H c cc.
@@ -119,8 +119,8 @@ Proof.
 Defined.
 
 Lemma precompWithCoproductArrow {a : I -> C} (CCab : CoproductCocone a) {c : I -> C}
-    (CCcd : CoproductCocone c) (f : Π i, a i --> c i)
-    {x : C} (k : Π i, c i --> x) :
+    (CCcd : CoproductCocone c) (f : ∏ i, a i --> c i)
+    {x : C} (k : ∏ i, c i --> x) :
         CoproductOfArrows CCab CCcd f ;; CoproductArrow CCcd k =
          CoproductArrow CCab (fun i => f i ;; k i).
 Proof.
@@ -129,7 +129,7 @@ now rewrite assoc, CoproductOfArrowsIn, <- assoc, CoproductInCommutes.
 Qed.
 
 Lemma postcompWithCoproductArrow {a : I -> C} (CCab : CoproductCocone a) {c : C}
-    (f : Π i, a i --> c) {x : C} (k : c --> x)  :
+    (f : ∏ i, a i --> c) {x : C} (k : c --> x)  :
        CoproductArrow CCab f ;; k = CoproductArrow CCab (fun i => f i ;; k).
 Proof.
 apply CoproductArrowUnique; intro i.
@@ -138,7 +138,7 @@ Qed.
 
 Lemma Coproduct_endo_is_identity (a : I -> C) (CC : CoproductCocone a)
   (k : CoproductObject CC --> CoproductObject CC)
-  (H1 : Π i, CoproductIn CC i ;; k = CoproductIn CC i)
+  (H1 : ∏ i, CoproductIn CC i ;; k = CoproductIn CC i)
   : identity _ = k.
 Proof.
 apply pathsinv0.
@@ -163,7 +163,7 @@ Variables (I : UU) (C : precategory) (CC : Coproducts I C).
 (* Qed. *)
 
 Definition CoproductOfArrows_comp (a b c : I -> C)
-  (f : Π i, a i --> b i) (g : Π i, b i --> c i) :
+  (f : ∏ i, a i --> b i) (g : ∏ i, b i --> c i) :
    CoproductOfArrows _ _ _ _ f ;; CoproductOfArrows _ _ (CC _) (CC _) g
    = CoproductOfArrows _ _ (CC _) (CC _)(fun i => f i ;; g i).
 Proof.
@@ -172,7 +172,7 @@ rewrite assoc, CoproductOfArrowsIn.
 now rewrite <- assoc, CoproductOfArrowsIn, assoc.
 Qed.
 
-Definition CoproductOfArrows_eq (a c : I -> C) (f f' : Π i, a i --> c i) : f = f' ->
+Definition CoproductOfArrows_eq (a c : I -> C) (f f' : ∏ i, a i --> c i) : f = f' ->
   CoproductOfArrows _ _ _ _ f = CoproductOfArrows _ _ (CC _) (CC _) f'.
 Proof.
 now induction 1.
@@ -281,7 +281,7 @@ Definition coproduct_nat_trans_in i : nat_trans (F i) coproduct_of_functors :=
 Section vertex.
 
 Variable A : functor C D.
-Variable f : Π i, nat_trans (F i) A.
+Variable f : ∏ i, nat_trans (F i) A.
 
 Definition coproduct_nat_trans_data c :
   coproduct_of_functors c --> A c :=
@@ -348,7 +348,7 @@ exists F.
 abstract (intros u v e; induction e).
 Defined.
 
-Definition CoproductsCocone c (F : I → C) (H : Π i, F i --> c) :
+Definition CoproductsCocone c (F : I → C) (H : ∏ i, F i --> c) :
   cocone (coproducts_diagram F) c.
 Proof.
 mkpair.

--- a/UniMath/CategoryTheory/limits/equalizers.v
+++ b/UniMath/CategoryTheory/limits/equalizers.v
@@ -22,13 +22,13 @@ Section def_equalizers.
   (** Definition and construction of isEqualizer. *)
   Definition isEqualizer {x y z : C} (f g : y --> z) (e : x --> y)
              (H : e ;; f = e ;; g) : UU :=
-    Π (w : C) (h : w --> y) (H : h ;; f = h ;; g),
-      iscontr (Σ φ : w --> x, φ ;; e = h).
+    ∏ (w : C) (h : w --> y) (H : h ;; f = h ;; g),
+      iscontr (∑ φ : w --> x, φ ;; e = h).
 
   Definition mk_isEqualizer {x y z : C} (f g : y --> z) (e : x --> y)
              (H : e ;; f = e ;; g) :
-    (Π (w : C) (h : w --> y) (H' : h ;; f = h ;; g),
-        iscontr (Σ ψ : w --> x, ψ ;; e = h)) -> isEqualizer f g e H.
+    (∏ (w : C) (h : w --> y) (H' : h ;; f = h ;; g),
+        iscontr (∑ ψ : w --> x, ψ ;; e = h)) -> isEqualizer f g e H.
   Proof.
     intros X. unfold isEqualizer. exact X.
   Defined.
@@ -69,8 +69,8 @@ Section def_equalizers.
 
   (** Definition and construction of equalizers. *)
   Definition Equalizer {y z : C} (f g : y --> z) : UU :=
-    Σ e : (Σ w : C, w --> y),
-          (Σ H : (pr2 e) ;; f = (pr2 e) ;; g, isEqualizer f g (pr2 e) H).
+    ∑ e : (∑ w : C, w --> y),
+          (∑ H : (pr2 e) ;; f = (pr2 e) ;; g, isEqualizer f g (pr2 e) H).
 
   Definition mk_Equalizer {x y z : C} (f g : y --> z) (e : x --> y)
              (H : e ;; f = e ;; g) (isE : isEqualizer f g e H) :
@@ -84,9 +84,9 @@ Section def_equalizers.
   Defined.
 
   (** Equalizers in precategories. *)
-  Definition Equalizers : UU := Π (y z : C) (f g : y --> z), Equalizer f g.
+  Definition Equalizers : UU := ∏ (y z : C) (f g : y --> z), Equalizer f g.
 
-  Definition hasEqualizers : UU := Π (y z : C) (f g : y --> z),
+  Definition hasEqualizers : UU := ∏ (y z : C) (f g : y --> z),
       ishinh (Equalizer f g).
 
   (** Returns the equalizer object. *)
@@ -154,7 +154,7 @@ Section def_equalizers.
     equalities. *)
   Definition identity_is_EqualizerIn {y z : C} {f g : y --> z}
              (E : Equalizer f g) :
-    Σ φ : C⟦E, E⟧, φ ;; (EqualizerArrow E) = (EqualizerArrow E).
+    ∑ φ : C⟦E, E⟧, φ ;; (EqualizerArrow E) = (EqualizerArrow E).
   Proof.
     exists (identity E).
     apply id_left.

--- a/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
@@ -48,7 +48,7 @@ Definition isBinCoproductCocone (a b co : C) (ia : a --> co) (ib : b --> co) :=
   isColimCocone (bincoproduct_diagram a b) co (CopCocone ia ib).
 
 Definition mk_isBinCoproductCocone (hsC : has_homsets C)(a b co : C) (ia : a --> co) (ib : b --> co) :
-   (Π (c : C) (f : a --> c) (g : b --> c),
+   (∏ (c : C) (f : a --> c) (g : b --> c),
     ∃! k : C ⟦co, c⟧,
       ia ;; k = f ×
       ib ;; k = g)
@@ -72,7 +72,7 @@ Definition BinCoproductCocone (a b : C) :=
   ColimCocone (bincoproduct_diagram a b).
 
 Definition mk_BinCoproductCocone (a b : C) :
-  Π (c : C) (f : a --> c) (g : b --> c),
+  ∏ (c : C) (f : a --> c) (g : b --> c),
    isBinCoproductCocone _ _ _ f g →  BinCoproductCocone a b.
 Proof.
   intros.
@@ -82,7 +82,7 @@ Proof.
   - apply X.
 Defined.
 
-Definition BinCoproducts := Π (a b : C), BinCoproductCocone a b.
+Definition BinCoproducts := ∏ (a b : C), BinCoproductCocone a b.
 Definition hasBinCoproducts := ishinh BinCoproducts.
 
 Definition BinCoproductObject {a b : C} (CC : BinCoproductCocone a b) : C := colim CC.
@@ -104,7 +104,7 @@ Proof.
 Defined.
 
 Lemma BinCoproductIn1Commutes (a b : C) (CC : BinCoproductCocone a b):
-     Π (c : C) (f : a --> c) g, BinCoproductIn1 CC ;; BinCoproductArrow CC f g  = f.
+     ∏ (c : C) (f : a --> c) g, BinCoproductIn1 CC ;; BinCoproductArrow CC f g  = f.
 Proof.
   intros c f g.
   unfold BinCoproductIn1.
@@ -113,7 +113,7 @@ Proof.
 Qed.
 
 Lemma BinCoproductIn2Commutes (a b : C) (CC : BinCoproductCocone a b):
-     Π (c : C) (f : a --> c) g, BinCoproductIn2 CC ;; BinCoproductArrow CC f g = g.
+     ∏ (c : C) (f : a --> c) g, BinCoproductIn2 CC ;; BinCoproductArrow CC f g = g.
 Proof.
   intros c f g.
   unfold BinCoproductIn1.

--- a/UniMath/CategoryTheory/limits/graphs/binproducts.v
+++ b/UniMath/CategoryTheory/limits/graphs/binproducts.v
@@ -41,7 +41,7 @@ Definition isBinProductCone (c d p : C) (p1 : C⟦p,c⟧) (p2 : C⟦p,d⟧) :=
 
 Definition mk_isBinProductCone (hsC : has_homsets C) (a b p : C)
   (pa : C⟦p,a⟧) (pb : C⟦p,b⟧) :
-  (Π (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧),
+  (∏ (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧),
     ∃! k : C⟦c,p⟧, k ;; pa = f × k ;; pb = g) ->
   isBinProductCone a b p pa pb.
 Proof.
@@ -60,7 +60,7 @@ Defined.
 Definition BinProductCone (a b : C) := LimCone (binproduct_diagram a b).
 
 Definition mk_BinProductCone (a b : C) :
-  Π (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧),
+  ∏ (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧),
    isBinProductCone _ _ _ f g -> BinProductCone a b.
 Proof.
   intros.
@@ -70,7 +70,7 @@ Proof.
   - apply X.
 Defined.
 
-Definition BinProducts := Π (a b : C), BinProductCone a b.
+Definition BinProducts := ∏ (a b : C), BinProductCone a b.
 
 (* What is the best definition of this? *)
 (* Definition hasBinProducts (C : precategory) := ishinh (BinProducts C). *)
@@ -95,14 +95,14 @@ simple refine (mk_cone _ _).
 Defined.
 
 Lemma BinProductPr1Commutes (a b : C) (P : BinProductCone a b):
-     Π (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧), BinProductArrow P f g ;; BinProductPr1 P = f.
+     ∏ (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧), BinProductArrow P f g ;; BinProductPr1 P = f.
 Proof.
 intros c f g.
 apply (limArrowCommutes P c (ProdCone f g) true).
 Qed.
 
 Lemma BinProductPr2Commutes (a b : C) (P : BinProductCone a b):
-     Π (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧), BinProductArrow P f g ;; BinProductPr2 P = g.
+     ∏ (c : C) (f : C⟦c,a⟧) (g : C⟦c,b⟧), BinProductArrow P f g ;; BinProductPr2 P = g.
 Proof.
 intros c f g.
 apply (limArrowCommutes P c (ProdCone f g) false).

--- a/UniMath/CategoryTheory/limits/graphs/coequalizers.v
+++ b/UniMath/CategoryTheory/limits/graphs/coequalizers.v
@@ -69,7 +69,7 @@ Section def_coequalizers.
 
   Definition mk_isCoequalizer {a b : C} (f g : C⟦a, b⟧) (d : C) (h : C⟦b, d⟧)
              (H : f ;; h = g ;; h) :
-    (Π e (h' : C⟦b, e⟧) (H' : f ;; h' = g ;; h'),
+    (∏ e (h' : C⟦b, e⟧) (H' : f ;; h' = g ;; h'),
      iscontr (total2 (fun hk : C⟦d, e⟧ => h ;; hk = h'))) ->
     isCoequalizer f g d h H.
   Proof.
@@ -109,9 +109,9 @@ Section def_coequalizers.
     - exact isCEq.
   Defined.
 
-  Definition Coequalizers : UU := Π (a b : C) (f g : C⟦a, b⟧), Coequalizer f g.
+  Definition Coequalizers : UU := ∏ (a b : C) (f g : C⟦a, b⟧), Coequalizer f g.
 
-  Definition hasCoequalizers : UU := Π (a b : C) (f g : C⟦a, b⟧), ishinh (Coequalizer f g).
+  Definition hasCoequalizers : UU := ∏ (a b : C) (f g : C⟦a, b⟧), ishinh (Coequalizer f g).
 
   Definition CoequalizerObject {a b : C} {f g : C⟦a, b⟧} :
     Coequalizer f g -> C := fun H => colim H.

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -42,7 +42,7 @@ End move_upstream.
 (** Definition of graphs and diagrams *)
 Section diagram_def.
 
-Definition graph := Σ (D : UU), D -> D -> UU.
+Definition graph := ∑ (D : UU), D -> D -> UU.
 
 Definition vertex : graph -> UU := pr1.
 Definition edge {g : graph} : vertex g -> vertex g -> UU := pr2 g.
@@ -50,13 +50,13 @@ Definition edge {g : graph} : vertex g -> vertex g -> UU := pr2 g.
 Definition mk_graph (D : UU) (e : D → D → UU) : graph := tpair _ D e.
 
 Definition diagram (g : graph) (C : precategory) : UU :=
-  Σ (f : vertex g -> C), Π (a b : vertex g), edge a b -> C⟦f a, f b⟧.
+  ∑ (f : vertex g -> C), ∏ (a b : vertex g), edge a b -> C⟦f a, f b⟧.
 
 Definition dob {g : graph} {C : precategory} (d : diagram g C) : vertex g -> C :=
   pr1 d.
 
 Definition dmor {g : graph} {C : precategory} (d : diagram g C) :
-  Π {a b}, edge a b -> C⟦dob d a,dob d b⟧ := pr2 d.
+  ∏ {a b}, edge a b -> C⟦dob d a,dob d b⟧ := pr2 d.
 
 Section diagram_from_functor.
 
@@ -82,19 +82,19 @@ Context {C : precategory} (hsC : has_homsets C).
 
 (** A cocone with tip c over a diagram d *)
 Definition cocone {g : graph} (d : diagram g C) (c : C) : UU :=
-  Σ (f : Π (v : vertex g), C⟦dob d v,c⟧),
-    Π (u v : vertex g) (e : edge u v), dmor d e ;; f v = f u.
+  ∑ (f : ∏ (v : vertex g), C⟦dob d v,c⟧),
+    ∏ (u v : vertex g) (e : edge u v), dmor d e ;; f v = f u.
 
 Definition mk_cocone {g : graph} {d : diagram g C} {c : C}
-  (f : Π v, C⟦dob d v,c⟧) (Hf : Π u v e, dmor d e ;; f v = f u) :
+  (f : ∏ v, C⟦dob d v,c⟧) (Hf : ∏ u v e, dmor d e ;; f v = f u) :
   cocone d c := tpair _ f Hf.
 
 (** The injections to c in the cocone *)
 Definition coconeIn {g : graph} {d : diagram g C} {c : C} (cc : cocone d c) :
-  Π v, C⟦dob d v,c⟧ := pr1 cc.
+  ∏ v, C⟦dob d v,c⟧ := pr1 cc.
 
 Lemma coconeInCommutes {g : graph} {d : diagram g C} {c : C} (cc : cocone d c) :
-  Π u v (e : edge u v), dmor d e ;; coconeIn cc v = coconeIn cc u.
+  ∏ u v (e : edge u v), dmor d e ;; coconeIn cc v = coconeIn cc u.
 Proof.
 exact (pr2 cc).
 Qed.
@@ -103,14 +103,14 @@ Qed.
    diagram there is a unique morphism from the tip of cc0 to the tip
    of cc *)
 Definition isColimCocone {g : graph} (d : diagram g C) (c0 : C)
-  (cc0 : cocone d c0) : UU := Π (c : C) (cc : cocone d c),
-    iscontr (Σ x : C⟦c0,c⟧, Π v, coconeIn cc0 v ;; x = coconeIn cc v).
+  (cc0 : cocone d c0) : UU := ∏ (c : C) (cc : cocone d c),
+    iscontr (∑ x : C⟦c0,c⟧, ∏ v, coconeIn cc0 v ;; x = coconeIn cc v).
 
 (* Definition isColim {g : graph} (d : diagram g C) (L : C) := *)
-(*   Σ c : cocone d L, isColimCocone d L c. *)
+(*   ∑ c : cocone d L, isColimCocone d L c. *)
 
 Definition ColimCocone {g : graph} (d : diagram g C) : UU :=
-  Σ (A : (Σ c0 : C, cocone d c0)), isColimCocone d (pr1 A) (pr2 A).
+  ∑ (A : (∑ c0 : C, cocone d c0)), isColimCocone d (pr1 A) (pr2 A).
 
 Definition mk_ColimCocone {g : graph} (d : diagram g C)
   (c : C) (cc : cocone d c) (isCC : isColimCocone d c cc) : ColimCocone d :=
@@ -127,18 +127,18 @@ Definition isColimCocone_from_ColimCocone {g : graph} {d : diagram g C} (CC : Co
   isColimCocone d (colim CC) _ := pr2 CC.
 
 Definition colimIn {g : graph} {d : diagram g C} (CC : ColimCocone d) :
-  Π (v : vertex g), C⟦dob d v,colim CC⟧ := coconeIn (colimCocone CC).
+  ∏ (v : vertex g), C⟦dob d v,colim CC⟧ := coconeIn (colimCocone CC).
 
 Lemma colimInCommutes {g : graph} {d : diagram g C}
-  (CC : ColimCocone d) : Π (u v : vertex g) (e : edge u v),
+  (CC : ColimCocone d) : ∏ (u v : vertex g) (e : edge u v),
    dmor d e ;; colimIn CC v = colimIn CC u.
 Proof.
 exact (coconeInCommutes (colimCocone CC)).
 Qed.
 
 Lemma colimUnivProp {g : graph} {d : diagram g C}
-  (CC : ColimCocone d) : Π (c : C) (cc : cocone d c),
-  iscontr (Σ x : C⟦colim CC,c⟧, Π (v : vertex g), colimIn CC v ;; x = coconeIn cc v).
+  (CC : ColimCocone d) : ∏ (c : C) (cc : cocone d c),
+  iscontr (∑ x : C⟦colim CC,c⟧, ∏ (v : vertex g), colimIn CC v ;; x = coconeIn cc v).
 Proof.
 exact (pr2 CC).
 Qed.
@@ -166,7 +166,7 @@ Qed.
 
 Lemma colimArrowUnique {g : graph} {d : diagram g C} (CC : ColimCocone d)
   (c : C) (cc : cocone d c) (k : C⟦colim CC,c⟧)
-  (Hk : Π (u : vertex g), colimIn CC u ;; k = coconeIn cc u) :
+  (Hk : ∏ (u : vertex g), colimIn CC u ;; k = coconeIn cc u) :
   k = colimArrow CC c cc.
 Proof.
 now apply path_to_ctr, Hk.
@@ -174,7 +174,7 @@ Qed.
 
 Lemma Cocone_postcompose {g : graph} {d : diagram g C}
   {c : C} (cc : cocone d c) (x : C) (f : C⟦c,x⟧) :
-    Π u v (e : edge u v), dmor d e ;; (coconeIn cc v ;; f) = coconeIn cc u ;; f.
+    ∏ u v (e : edge u v), dmor d e ;; (coconeIn cc v ;; f) = coconeIn cc u ;; f.
 Proof.
 now intros u v e; rewrite assoc, coconeInCommutes.
 Qed.
@@ -190,8 +190,8 @@ Qed.
 
 Definition colimOfArrows {g : graph} {d1 d2 : diagram g C}
   (CC1 : ColimCocone d1) (CC2 : ColimCocone d2)
-  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : Π u v (e : edge u v), dmor d1 e ;; f v = f u ;; dmor d2 e) :
+  (f : ∏ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : ∏ u v (e : edge u v), dmor d1 e ;; f v = f u ;; dmor d2 e) :
   C⟦colim CC1,colim CC2⟧.
 Proof.
 apply colimArrow; simple refine (mk_cocone _ _).
@@ -202,9 +202,9 @@ Defined.
 
 Lemma colimOfArrowsIn {g : graph} (d1 d2 : diagram g C)
   (CC1 : ColimCocone d1) (CC2 : ColimCocone d2)
-  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : Π u v (e : edge u v), dmor d1 e ;; f v = f u ;; dmor d2 e) :
-    Π u, colimIn CC1 u ;; colimOfArrows CC1 CC2 f fNat =
+  (f : ∏ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : ∏ u v (e : edge u v), dmor d1 e ;; f v = f u ;; dmor d2 e) :
+    ∏ u, colimIn CC1 u ;; colimOfArrows CC1 CC2 f fNat =
          f u ;; colimIn CC2 u.
 Proof.
 now unfold colimOfArrows; intro u; rewrite colimArrowCommutes.
@@ -212,8 +212,8 @@ Qed.
 
 Lemma preCompWithColimOfArrows_subproof {g : graph} {d1 d2 : diagram g C}
   (CC1 : ColimCocone d1) (CC2 : ColimCocone d2)
-  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : Π u v (e : edge u v), dmor d1 e ;; f v = f u ;; dmor d2 e)
+  (f : ∏ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : ∏ u v (e : edge u v), dmor d1 e ;; f v = f u ;; dmor d2 e)
   (x : C) (cc : cocone d2 x) u v (e : edge u v) :
      dmor d1 e ;; (f v ;; coconeIn cc v) = f u ;; coconeIn cc u.
 Proof.
@@ -222,8 +222,8 @@ Qed.
 
 Lemma precompWithColimOfArrows {g : graph} (d1 d2 : diagram g C)
   (CC1 : ColimCocone d1) (CC2 : ColimCocone d2)
-  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : Π u v (e : edge u v), dmor d1 e ;; f v = f u ;; dmor d2 e)
+  (f : ∏ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : ∏ u v (e : edge u v), dmor d1 e ;; f v = f u ;; dmor d2 e)
   (x : C) (cc : cocone d2 x) :
   colimOfArrows CC1 CC2 f fNat ;; colimArrow CC2 x cc =
   colimArrow CC1 x (mk_cocone (λ u, f u ;; coconeIn cc u)
@@ -245,7 +245,7 @@ Qed.
 
 Lemma colim_endo_is_identity {g : graph} (D : diagram g C)
   (CC : ColimCocone D) (k : colim CC --> colim CC)
-  (H : Π u, colimIn CC u ;; k = colimIn CC u) :
+  (H : ∏ u, colimIn CC u ;; k = colimIn CC u) :
   identity _ = k.
 Proof.
 unshelve refine (uniqueExists _ _ (colimUnivProp CC _ _) _ _ _ _).
@@ -263,13 +263,13 @@ Defined.
 
 Lemma isColim_weq_subproof1 {g : graph} (D : diagram g C)
   (c : C) (cc : cocone D c) (d : C) (k : C⟦c,d⟧) :
-  Π u, coconeIn cc u ;; k = pr1 (Cocone_by_postcompose D c cc d k) u.
+  ∏ u, coconeIn cc u ;; k = pr1 (Cocone_by_postcompose D c cc d k) u.
 Proof.
 now intro u.
 Qed.
 
 Lemma isColim_weq_subproof2 (g : graph) (D : diagram g C)
-  (c : C) (cc : cocone D c) (H : Π d, isweq (Cocone_by_postcompose D c cc d))
+  (c : C) (cc : cocone D c) (H : ∏ d, isweq (Cocone_by_postcompose D c cc d))
   (d : C) (cd : cocone D d) (u : vertex g) :
     coconeIn cc u ;; invmap (weqpair _ (H d)) cd = coconeIn cd u.
 Proof.
@@ -279,7 +279,7 @@ now rewrite p.
 Qed.
 
 Lemma isColim_weq {g : graph} (D : diagram g C) (c : C) (cc : cocone D c) :
-  isColimCocone D c cc <-> Π d, isweq (Cocone_by_postcompose D c cc d).
+  isColimCocone D c cc <-> ∏ d, isweq (Cocone_by_postcompose D c cc d).
 Proof.
 split.
 - intros H d.
@@ -370,13 +370,13 @@ End colim_def.
 
 Section Colims.
 
-Definition Colims (C : precategory) : UU := Π {g : graph} (d : diagram g C), ColimCocone d.
+Definition Colims (C : precategory) : UU := ∏ {g : graph} (d : diagram g C), ColimCocone d.
 Definition hasColims (C : precategory) : UU  :=
-  Π {g : graph} (d : diagram g C), ishinh (ColimCocone d).
+  ∏ {g : graph} (d : diagram g C), ishinh (ColimCocone d).
 
 (** Colimits of a specific shape *)
 Definition Colims_of_shape (g : graph) (C : precategory) : UU :=
-  Π (d : diagram g C), ColimCocone d.
+  ∏ (d : diagram g C), ColimCocone d.
 
 (** If C is a category then Colims is a prop *)
 Section Universal_Unique.
@@ -392,8 +392,8 @@ apply invproofirrelevance; intros Hccx Hccy.
 apply subtypeEquality.
 - intro; apply isaprop_isColimCocone.
 - apply (total2_paths (isotoid _ H (iso_from_colim_to_colim Hccx Hccy))).
-  set (B c := Π v, C⟦dob cc v,c⟧).
-  set (C' (c : C) f := Π u v (e : edge u v), @compose _ _ _ c (dmor cc e) (f v) = f u).
+  set (B c := ∏ v, C⟦dob cc v,c⟧).
+  set (C' (c : C) f := ∏ u v (e : edge u v), @compose _ _ _ c (dmor cc e) (f v) = f u).
   rewrite (@transportf_total2 _ B C').
   apply subtypeEquality.
   + intro; repeat (apply impred; intro); apply category_has_homsets.
@@ -417,7 +417,7 @@ exists (fun v => pr1 (dob D v) a); intros u v e.
 now apply (pr1 (dmor D e) a).
 Defined.
 
-Variable (HCg : Π (a : A), ColimCocone (diagram_pointwise a)).
+Variable (HCg : ∏ (a : A), ColimCocone (diagram_pointwise a)).
 
 Definition ColimFunctor_ob (a : A) : C := colim (HCg a).
 
@@ -467,8 +467,8 @@ simple refine (mk_cocone _ _).
 Defined.
 
 Lemma ColimFunctor_unique (F : [A, C, hsC]) (cc : cocone D F) :
-  iscontr (Σ x : [A, C, hsC] ⟦ ColimFunctor, F ⟧,
-            Π v : vertex g, colim_nat_trans_in_data v ;; x = coconeIn cc v).
+  iscontr (∑ x : [A, C, hsC] ⟦ ColimFunctor, F ⟧,
+            ∏ v : vertex g, colim_nat_trans_in_data v ;; x = coconeIn cc v).
 Proof.
 simple refine (tpair _ _ _).
 - simple refine (tpair _ _ _).
@@ -506,7 +506,7 @@ Defined.
 
 Definition isColimFunctor_is_pointwise_Colim
   (X : [A,C,hsC]) (R : cocone D X) (H : isColimCocone D X R)
-  : Π a, isColimCocone (diagram_pointwise a) _ (cocone_pointwise X R a).
+  : ∏ a, isColimCocone (diagram_pointwise a) _ (cocone_pointwise X R a).
 Proof.
   intro a.
   apply (is_iso_isColim hsC _ (HCg a)).
@@ -531,7 +531,7 @@ Defined.
 Lemma pointwise_Colim_is_isColimFunctor
   {A C : precategory} (hsC: has_homsets C) {g : graph}
   (d : diagram g [A,C,hsC]) (G : [A,C,hsC]) (ccG : cocone d G)
-  (H : Π a, isColimCocone _ _ (cocone_pointwise hsC d G ccG a)) :
+  (H : ∏ a, isColimCocone _ _ (cocone_pointwise hsC d G ccG a)) :
   isColimCocone d G ccG.
 Proof.
 set (CC a := mk_ColimCocone _ _ _ (H a)).
@@ -587,15 +587,15 @@ Proof.
 intros HccL M ccM.
 set (G := right_adjoint HF).
 set (H := pr2 HF : are_adjoints F G).
-apply (@iscontrweqb _ (Σ y : C ⟦ L, G M ⟧,
-    Π i, coconeIn ccL i ;; y = φ_adj H (coconeIn ccM i))).
-- eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧,
-    Π i, # F (coconeIn ccL i) ;; φ_adj_inv H y = coconeIn ccM i)).
+apply (@iscontrweqb _ (∑ y : C ⟦ L, G M ⟧,
+    ∏ i, coconeIn ccL i ;; y = φ_adj H (coconeIn ccM i))).
+- eapply (weqcomp (Y := ∑ y : C ⟦ L, G M ⟧,
+    ∏ i, # F (coconeIn ccL i) ;; φ_adj_inv H y = coconeIn ccM i)).
   + apply (weqbandf (adjunction_hom_weq H L M)); simpl; intro f.
     abstract (apply weqiff; try (apply impred; intro; apply hsD);
     now rewrite φ_adj_inv_after_φ_adj).
-  + eapply (weqcomp (Y := Σ y : C ⟦ L, G M ⟧,
-      Π i, φ_adj_inv H (coconeIn ccL i ;; y) = coconeIn ccM i)).
+  + eapply (weqcomp (Y := ∑ y : C ⟦ L, G M ⟧,
+      ∏ i, φ_adj_inv H (coconeIn ccL i ;; y) = coconeIn ccM i)).
     * apply weqfibtototal; simpl; intro f.
     abstract (apply weqiff; try (apply impred; intro; apply hsD); split;
       [ intros HH i; rewrite φ_adj_inv_natural_precomp; apply HH

--- a/UniMath/CategoryTheory/limits/graphs/eqdiag.v
+++ b/UniMath/CategoryTheory/limits/graphs/eqdiag.v
@@ -60,7 +60,7 @@ Proof.
 Qed.
 
 
-Lemma transport_swap: Π {X Y : UU} (P : X -> Y → UU) {x x':X} {y  y' : Y}
+Lemma transport_swap: ∏ {X Y : UU} (P : X -> Y → UU) {x x':X} {y  y' : Y}
                         (e : x = x') (e' : y = y') (p : P x y),
                   transportf (fun a => P _ a) e' (transportf (fun a => P a _) e p) =
                   transportf (fun a => P a _) e (transportf (fun a => P _ a) e' p) .
@@ -96,7 +96,7 @@ Proof.
 Qed.
 
 Definition eq_diag  {C : Precategory} {g : graph} (d d' : diagram g C) :=
-  Σ (eq_v : Π v: vertex g, dob d v = dob d' v), Π (v v':vertex g) (f:edge v v'),
+  ∑ (eq_v : ∏ v: vertex g, dob d v = dob d' v), ∏ (v v':vertex g) (f:edge v v'),
   transportf (fun obj => C⟦obj, dob d v'⟧)  (eq_v v) (dmor d f) =
   transportb (fun obj => C⟦_, obj⟧) (eq_v v') (dmor d' f).
 
@@ -118,7 +118,7 @@ Proof.
     intro v.
     apply eqv.
   - rewrite (transportf2_comp
-               (λ x y : vertex g → C, Π a b : vertex g, edge a b →
+               (λ x y : vertex g → C, ∏ a b : vertex g, edge a b →
                                                         C ⟦ y a, x b ⟧)).
     match goal with |- transportf ?Pf ?x1 (transportf ?Pf2 ?s1 ?s2 )  = _ =>
                     set (e := x1);
@@ -188,7 +188,7 @@ Proof.
 Defined.
 
 Lemma eq_diag_mkcocone  :
-  Π {C : Precategory} {g : graph} {d : diagram g C}
+  ∏ {C : Precategory} {g : graph} {d : diagram g C}
     (d' : diagram g C)
     (heq_d: eq_diag d d')
     {c : C} (cc:cocone d c),
@@ -221,7 +221,7 @@ Defined.
 
 (* The dual proof *)
 Lemma eq_diag_mkcone  :
-  Π {C : Precategory} {g : graph} {d : diagram g C}
+  ∏ {C : Precategory} {g : graph} {d : diagram g C}
     (d' : diagram g C)
     (heq_d: eq_diag d d')
     {c : C} (cc:cone d c),
@@ -256,7 +256,7 @@ Defined.
 
 
 Lemma eq_diag_islimcone:
-  Π {C : Precategory} {g : graph} {d : diagram g C}
+  ∏ {C : Precategory} {g : graph} {d : diagram g C}
     (d' : diagram g C)
     (eq_d : eq_diag d d')
     {c : C} {cc:cone d c}
@@ -308,7 +308,7 @@ This proof could be deduced from the previous if there was a lemma
 stating that colimits are limits in the dual category.
  *)
 Lemma eq_diag_iscolimcocone:
-  Π {C : Precategory} {g : graph} {d : diagram g C}
+  ∏ {C : Precategory} {g : graph} {d : diagram g C}
     (d' : diagram g C)
     (eq_d : eq_diag d d')
     {c : C} {cc:cocone d c}

--- a/UniMath/CategoryTheory/limits/graphs/equalizers.v
+++ b/UniMath/CategoryTheory/limits/graphs/equalizers.v
@@ -68,7 +68,7 @@ Section def_equalizers.
     UU := isLimCone (Equalizer_diagram f g) d (Equalizer_cone f g d h H).
 
   Definition mk_isEqualizer {a b : C} (f g : C⟦a, b⟧) (d : C) (h : C⟦d, a⟧) (H : h ;; f = h ;; g) :
-    (Π e (h' : C⟦e, a⟧) (H' : h' ;; f = h' ;; g),
+    (∏ e (h' : C⟦e, a⟧) (H' : h' ;; f = h' ;; g),
      iscontr (total2 (fun hk : C⟦e, d⟧ => hk ;; h = h'))) -> isEqualizer f g d h H.
   Proof.
     intros H' x cx.
@@ -109,9 +109,9 @@ Section def_equalizers.
     - exact isEq.
   Defined.
 
-  Definition Equalizers : UU := Π (a b : C) (f g : C⟦a, b⟧), Equalizer f g.
+  Definition Equalizers : UU := ∏ (a b : C) (f g : C⟦a, b⟧), Equalizer f g.
 
-  Definition hasEqualizers : UU := Π (a b : C) (f g : C⟦a, b⟧), ishinh (Equalizer f g).
+  Definition hasEqualizers : UU := ∏ (a b : C) (f g : C⟦a, b⟧), ishinh (Equalizer f g).
 
   Definition EqualizerObject {a b : C} {f g : C⟦a, b⟧} : Equalizer f g -> C := fun H => lim H.
 

--- a/UniMath/CategoryTheory/limits/graphs/initial.v
+++ b/UniMath/CategoryTheory/limits/graphs/initial.v
@@ -32,9 +32,9 @@ Defined.
 
 Definition isInitial (a : C) :=
   isColimCocone initDiagram a (initCocone a).
- (* Π b : C, iscontr (a --> b). *)
+ (* ∏ b : C, iscontr (a --> b). *)
 
-Definition mk_isInitial (a : C) (H : Π (b : C), iscontr (a --> b)) :
+Definition mk_isInitial (a : C) (H : ∏ (b : C), iscontr (a --> b)) :
   isInitial a.
 Proof.
 intros b cb.

--- a/UniMath/CategoryTheory/limits/graphs/limits.v
+++ b/UniMath/CategoryTheory/limits/graphs/limits.v
@@ -31,30 +31,30 @@ Section lim_def.
 Context {C : precategory} (hsC : has_homsets C).
 
 Definition cone {g : graph} (d : diagram g C) (c : C) : UU :=
-  Σ (f : Π (v : vertex g), C⟦c,dob d v⟧),
-    Π (u v : vertex g) (e : edge u v), f u ;; dmor d e = f v.
+  ∑ (f : ∏ (v : vertex g), C⟦c,dob d v⟧),
+    ∏ (u v : vertex g) (e : edge u v), f u ;; dmor d e = f v.
 
 Definition mk_cone {g : graph} {d : diagram g C} {c : C}
-  (f : Π v, C⟦c, dob d v⟧) (Hf : Π u v (e : edge u v), f u ;; dmor d e = f v) :
+  (f : ∏ v, C⟦c, dob d v⟧) (Hf : ∏ u v (e : edge u v), f u ;; dmor d e = f v) :
   cone d c
   := tpair _ f Hf.
 
 (** The injections to c in the cocone *)
 Definition coneOut {g : graph} {d : diagram g C} {c : C} (cc : cone d c) :
-  Π v, C⟦c, dob d v⟧ := pr1 cc.
+  ∏ v, C⟦c, dob d v⟧ := pr1 cc.
 
 Lemma coneOutCommutes {g : graph} {d : diagram g C} {c : C} (cc : cone d c) :
-  Π u v (e : edge u v), coneOut cc u ;; dmor d e = coneOut cc v.
+  ∏ u v (e : edge u v), coneOut cc u ;; dmor d e = coneOut cc v.
 Proof.
 apply (pr2 cc).
 Qed.
 
 Definition isLimCone {g : graph} (d : diagram g C) (c0 : C)
-  (cc0 : cone d c0) : UU := Π (c : C) (cc : cone d c),
-    iscontr (Σ x : C⟦c,c0⟧, Π v, x ;; coneOut cc0 v = coneOut cc v).
+  (cc0 : cone d c0) : UU := ∏ (c : C) (cc : cone d c),
+    iscontr (∑ x : C⟦c,c0⟧, ∏ v, x ;; coneOut cc0 v = coneOut cc v).
 
 Definition LimCone {g : graph} (d : diagram g C) : UU :=
-   Σ (A : (Σ l, cone d l)), isLimCone d (pr1 A) (pr2 A).
+   ∑ (A : (∑ l, cone d l)), isLimCone d (pr1 A) (pr2 A).
 
 Definition mk_LimCone {g : graph} (d : diagram g C)
   (c : C) (cc : cone d c) (isCC : isLimCone d c cc) : LimCone d
@@ -68,18 +68,18 @@ Definition limCone {g : graph} {d : diagram g C} (CC : LimCone d) :
   cone d (lim CC) := pr2 (pr1 CC).
 
 Definition limOut {g : graph} {d : diagram g C} (CC : LimCone d) :
-  Π (v : vertex g), C⟦lim CC, dob d v⟧ := coneOut (limCone CC).
+  ∏ (v : vertex g), C⟦lim CC, dob d v⟧ := coneOut (limCone CC).
 
 Lemma limOutCommutes {g : graph} {d : diagram g C}
-  (CC : LimCone d) : Π (u v : vertex g) (e : edge u v),
+  (CC : LimCone d) : ∏ (u v : vertex g) (e : edge u v),
    limOut CC u ;; dmor d e = limOut CC v.
 Proof.
 exact (coneOutCommutes (limCone CC)).
 Qed.
 
 Lemma limUnivProp {g : graph} {d : diagram g C}
-  (CC : LimCone d) : Π (c : C) (cc : cone d c),
-  iscontr (Σ x : C⟦c, lim CC⟧, Π (v : vertex g), x ;; limOut CC v = coneOut cc v).
+  (CC : LimCone d) : ∏ (c : C) (cc : cone d c),
+  iscontr (∑ x : C⟦c, lim CC⟧, ∏ (v : vertex g), x ;; limOut CC v = coneOut cc v).
 Proof.
 apply (pr2 CC).
 Qed.
@@ -109,7 +109,7 @@ Qed.
 
 Lemma limArrowUnique {g : graph} {d : diagram g C} (CC : LimCone d)
   (c : C) (cc : cone d c) (k : C⟦c, lim CC⟧)
-  (Hk : Π (u : vertex g), k ;; limOut CC u = coneOut cc u) :
+  (Hk : ∏ (u : vertex g), k ;; limOut CC u = coneOut cc u) :
   k = limArrow CC c cc.
 Proof.
 now apply path_to_ctr, Hk.
@@ -117,7 +117,7 @@ Qed.
 
 Lemma Cone_precompose {g : graph} {d : diagram g C}
   {c : C} (cc : cone d c) (x : C) (f : C⟦x,c⟧) :
-    Π u v (e : edge u v), (f ;; coneOut cc u) ;; dmor d e = f ;; coneOut cc v.
+    ∏ u v (e : edge u v), (f ;; coneOut cc u) ;; dmor d e = f ;; coneOut cc v.
 Proof.
 now intros u v e; rewrite <- assoc, coneOutCommutes.
 Qed.
@@ -132,8 +132,8 @@ Qed.
 
 Definition limOfArrows {g : graph} {d1 d2 : diagram g C}
   (CC1 : LimCone d1) (CC2 : LimCone d2)
-  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : Π u v (e : edge u v), f u ;; dmor d2 e = dmor d1 e ;; f v) :
+  (f : ∏ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : ∏ u v (e : edge u v), f u ;; dmor d2 e = dmor d1 e ;; f v) :
   C⟦lim CC1 , lim CC2⟧.
 Proof.
 apply limArrow; simple refine (mk_cone _ _).
@@ -144,9 +144,9 @@ Defined.
 
 Lemma limOfArrowsOut {g : graph} (d1 d2 : diagram g C)
   (CC1 : LimCone d1) (CC2 : LimCone d2)
-  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : Π u v (e : edge u v), f u ;; dmor d2 e = dmor d1 e ;; f v) :
-    Π u, limOfArrows CC1 CC2 f fNat ;; limOut CC2 u =
+  (f : ∏ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : ∏ u v (e : edge u v), f u ;; dmor d2 e = dmor d1 e ;; f v) :
+    ∏ u, limOfArrows CC1 CC2 f fNat ;; limOut CC2 u =
           limOut CC1 u ;; f u.
 Proof.
 now unfold limOfArrows; intro u; rewrite limArrowCommutes.
@@ -154,8 +154,8 @@ Qed.
 
 Lemma postCompWithLimOfArrows_subproof {g : graph} {d1 d2 : diagram g C}
   (CC1 : LimCone d1) (CC2 : LimCone d2)
-  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : Π u v (e : edge u v), f u ;; dmor d2 e = dmor d1 e ;; f v)
+  (f : ∏ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : ∏ u v (e : edge u v), f u ;; dmor d2 e = dmor d1 e ;; f v)
   (x : C) (cc : cone d1 x) u v (e : edge u v) :
     (coneOut cc u ;; f u) ;; dmor d2 e = coneOut cc v ;; f v.
 Proof.
@@ -164,8 +164,8 @@ Defined.
 
 Lemma postCompWithLimOfArrows {g : graph} (d1 d2 : diagram g C)
   (CC1 : LimCone d1) (CC2 : LimCone d2)
-  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : Π u v (e : edge u v), f u ;; dmor d2 e = dmor d1 e ;; f v)
+  (f : ∏ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : ∏ u v (e : edge u v), f u ;; dmor d2 e = dmor d1 e ;; f v)
   (x : C) (cc : cone d1 x) :
      limArrow CC1 x cc ;; limOfArrows CC1 CC2 f fNat =
        limArrow CC2 x (mk_cone (λ u, coneOut cc u ;; f u)
@@ -187,7 +187,7 @@ Qed.
 
 Lemma lim_endo_is_identity {g : graph} (D : diagram g C)
   (CC : LimCone D) (k : lim CC --> lim CC)
-  (H : Π u, k ;; limOut CC u = limOut CC u) :
+  (H : ∏ u, k ;; limOut CC u = limOut CC u) :
   identity _ = k.
 Proof.
 unshelve refine (uniqueExists _ _ (limUnivProp CC _ _) _ _ _ _).
@@ -267,13 +267,13 @@ Defined.
 
 Lemma isColim_weq_subproof1 {g : graph} (D : diagram g C)
   (c : C) (cc : cocone D c) (d : C) (k : C⟦c,d⟧) :
-  Π u, coconeIn cc u ;; k = pr1 (Cocone_by_postcompose D c cc d k) u.
+  ∏ u, coconeIn cc u ;; k = pr1 (Cocone_by_postcompose D c cc d k) u.
 Proof.
 now intro u.
 Qed.
 
 Lemma isColim_weq_subproof2 (g : graph) (D : diagram g C)
-  (c : C) (cc : cocone D c) (H : Π d, isweq (Cocone_by_postcompose D c cc d))
+  (c : C) (cc : cocone D c) (H : ∏ d, isweq (Cocone_by_postcompose D c cc d))
   (d : C) (cd : cocone D d) (u : vertex g) :
     coconeIn cc u ;; invmap (weqpair _ (H d)) cd = coconeIn cd u.
 Proof.
@@ -283,7 +283,7 @@ now rewrite p.
 Qed.
 
 Lemma isColim_weq {g : graph} (D : diagram g C) (c : C) (cc : cocone D c) :
-  isColimCocone D c cc <-> Π d, isweq (Cocone_by_postcompose D c cc d).
+  isColimCocone D c cc <-> ∏ d, isweq (Cocone_by_postcompose D c cc d).
 Proof.
 split.
 - intros H d.
@@ -327,13 +327,13 @@ End lim_def.
 
 Section Lims.
 
-Definition Lims (C : precategory) : UU := Π {g : graph} (d : diagram g C), LimCone d.
+Definition Lims (C : precategory) : UU := ∏ {g : graph} (d : diagram g C), LimCone d.
 Definition hasLims (C : precategory) : UU  :=
-  Π {g : graph} (d : diagram g C), ishinh (LimCone d).
+  ∏ {g : graph} (d : diagram g C), ishinh (LimCone d).
 
 (** Limits of a specific shape *)
 Definition Lims_of_shape (g : graph) (C : precategory) : UU :=
-  Π (d : diagram g C), LimCone d.
+  ∏ (d : diagram g C), LimCone d.
 
 Section Universal_Unique.
 
@@ -348,8 +348,8 @@ apply invproofirrelevance; intros Hccx Hccy.
 apply subtypeEquality.
 - intro; apply isaprop_isLimCone.
 - apply (total2_paths (isotoid _ H (iso_from_lim_to_lim Hccx Hccy))).
-  set (B c := Π v, C⟦c,dob cc v⟧).
-  set (C' (c : C) f := Π u v (e : edge u v), @compose _ c _ _ (f u) (dmor cc e) = f v).
+  set (B c := ∏ v, C⟦c,dob cc v⟧).
+  set (C' (c : C) f := ∏ u v (e : edge u v), @compose _ c _ _ (f u) (dmor cc e) = f v).
   rewrite (@transportf_total2 _ B C').
   apply subtypeEquality.
   + intro; repeat (apply impred; intro); apply category_has_homsets.
@@ -366,7 +366,7 @@ Section LimFunctor.
 
 Context {A C : precategory} (hsC : has_homsets C) {g : graph} (D : diagram g [A, C, hsC]).
 
-Variable (HCg : Π (a : A), LimCone (diagram_pointwise hsC D a)).
+Variable (HCg : ∏ (a : A), LimCone (diagram_pointwise hsC D a)).
 
 Definition LimFunctor_ob (a : A) : C := lim (HCg a).
 
@@ -416,8 +416,8 @@ simple refine (mk_cone _ _).
 Defined.
 
 Lemma LimFunctor_unique (F : [A, C, hsC]) (cc : cone D F) :
-  iscontr (Σ x : [A, C, hsC] ⟦ F, LimFunctor ⟧,
-            Π v, x ;; lim_nat_trans_in_data v = coneOut cc v).
+  iscontr (∑ x : [A, C, hsC] ⟦ F, LimFunctor ⟧,
+            ∏ v, x ;; lim_nat_trans_in_data v = coneOut cc v).
 Proof.
 mkpair.
 - mkpair.
@@ -452,7 +452,7 @@ Defined.
 
 Definition isLimFunctor_is_pointwise_Lim
   (X : [A,C,hsC]) (R : cone D X) (H : isLimCone D X R)
-  : Π a, isLimCone (diagram_pointwise hsC D a) _ (cone_pointwise X R a).
+  : ∏ a, isLimCone (diagram_pointwise hsC D a) _ (cone_pointwise X R a).
 Proof.
   intro a.
   apply (is_iso_isLim hsC _ (HCg a)).
@@ -500,14 +500,14 @@ Proof.
 intros HccL M ccM.
 set (G := left_adjoint HF).
 set (H := pr2 HF : are_adjoints G F).
-apply (@iscontrweqb _ (Σ y : C ⟦ G M, L ⟧,
-    Π i, y ;; coneOut ccL i = φ_adj_inv H (coneOut ccM i))).
-- eapply (weqcomp (Y := Σ y : C ⟦ G M, L ⟧,
-    Π i, φ_adj H y ;; # F (coneOut ccL i) = coneOut ccM i)).
+apply (@iscontrweqb _ (∑ y : C ⟦ G M, L ⟧,
+    ∏ i, y ;; coneOut ccL i = φ_adj_inv H (coneOut ccM i))).
+- eapply (weqcomp (Y := ∑ y : C ⟦ G M, L ⟧,
+    ∏ i, φ_adj H y ;; # F (coneOut ccL i) = coneOut ccM i)).
   + apply invweq, (weqbandf (adjunction_hom_weq H M L)); simpl; intro f.
     abstract (now apply weqiff; try (apply impred; intro; apply hsD)).
-  + eapply (weqcomp (Y := Σ y : C ⟦ G M, L ⟧,
-      Π i, φ_adj H (y ;; coneOut ccL i) = coneOut ccM i)).
+  + eapply (weqcomp (Y := ∑ y : C ⟦ G M, L ⟧,
+      ∏ i, φ_adj H (y ;; coneOut ccL i) = coneOut ccM i)).
     * apply weqfibtototal; simpl; intro f.
       abstract (apply weqiff; try (apply impred; intro; apply hsD); split; intros HH i;
                [ now rewrite φ_adj_natural_postcomp; apply HH
@@ -548,8 +548,8 @@ Context {C : precategory} (hsC : has_homsets C).
 (* A cone with tip c over a diagram d *)
 (*
 Definition cocone {g : graph} (d : diagram g C) (c : C) : UU :=
-  Σ (f : Π (v : vertex g), C⟦dob d v,c⟧),
-    Π (u v : vertex g) (e : edge u v), dmor d e ;; f v = f u.
+  ∑ (f : ∏ (v : vertex g), C⟦dob d v,c⟧),
+    ∏ (u v : vertex g) (e : edge u v), dmor d e ;; f v = f u.
 *)
 
 Definition opp_diagram g C := diagram g C^op.
@@ -559,21 +559,21 @@ Definition cone {g : graph} (d : diagram g C^op) (c : C) : UU :=
 
 (*
 Definition mk_cocone {g : graph} {d : diagram g C} {c : C}
-  (f : Π v, C⟦dob d v,c⟧) (Hf : Π u v e, dmor d e ;; f v = f u) :
+  (f : ∏ v, C⟦dob d v,c⟧) (Hf : ∏ u v e, dmor d e ;; f v = f u) :
   cocone d c := tpair _ f Hf.
 *)
 
 Definition mk_cone {g : graph} {d : diagram g C^op} {c : C}
-  (f : Π v, C⟦c, dob d v⟧) (Hf : Π u v (e : edge u v) , f v ;; dmor d e  = f u) :
+  (f : ∏ v, C⟦c, dob d v⟧) (Hf : ∏ u v (e : edge u v) , f v ;; dmor d e  = f u) :
   cone d c
   := tpair _ f Hf.
 
 (* The injections to c in the cocone *)
 Definition coneOut {g : graph} {d : diagram g C^op} {c : C} (cc : cone d c) :
-  Π v, C⟦c, dob d v⟧ := coconeIn cc.
+  ∏ v, C⟦c, dob d v⟧ := coconeIn cc.
 
 Lemma coneOutCommutes {g : graph} {d : diagram g C^op} {c : C} (cc : cone d c) :
-  Π u v (e : edge u v), coneOut cc v ;; dmor d e = coneOut cc u.
+  ∏ u v (e : edge u v), coneOut cc v ;; dmor d e = coneOut cc u.
 Proof.
   apply (coconeInCommutes cc).
 Qed.
@@ -585,9 +585,9 @@ Definition isLimCone {g : graph} (d : diagram g C^op) (c0 : C)
   (cc0 : cone d c0) : UU :=
    isColimCocone _ _ cc0.
 (*
-Π (c : C) (cc : cone d c),
+∏ (c : C) (cc : cone d c),
       isColimCocone
-    iscontr (Σ x : C⟦c0,c⟧, Π v, coconeIn cc0 v ;; x = coconeIn cc v).
+    iscontr (∑ x : C⟦c0,c⟧, ∏ v, coconeIn cc0 v ;; x = coconeIn cc v).
 *)
 
 Definition LimCone {g : graph} (d : diagram g C^op) : UU :=
@@ -602,9 +602,9 @@ simple refine (mk_ColimCocone _ _ _ _  ).
 - apply isCC.
 Defined.
 
-Definition Lims : UU := Π {g : graph} (d : diagram g C^op), LimCone d.
+Definition Lims : UU := ∏ {g : graph} (d : diagram g C^op), LimCone d.
 Definition hasLims : UU  :=
-  Π {g : graph} (d : diagram g C^op), ishinh (LimCone d).
+  ∏ {g : graph} (d : diagram g C^op), ishinh (LimCone d).
 
 (* lim is the tip of the lim cone *)
 Definition lim {g : graph} {d : diagram g C^op} (CC : LimCone d) : C
@@ -614,18 +614,18 @@ Definition limCone {g : graph} {d : diagram g C^op} (CC : LimCone d) :
   cone d (lim CC) := colimCocone CC.
 
 Definition limOut {g : graph} {d : diagram g C^op} (CC : LimCone d) :
-  Π (v : vertex g), C⟦lim CC, dob d v⟧ := coneOut (limCone CC).
+  ∏ (v : vertex g), C⟦lim CC, dob d v⟧ := coneOut (limCone CC).
 
 Lemma limOutCommutes {g : graph} {d : diagram g C^op}
-  (CC : LimCone d) : Π (u v : vertex g) (e : edge u v),
+  (CC : LimCone d) : ∏ (u v : vertex g) (e : edge u v),
    limOut CC v ;; dmor d e = limOut CC u.
 Proof.
 exact (coneOutCommutes (limCone CC)).
 Qed.
 
 Lemma limUnivProp {g : graph} {d : diagram g C^op}
-  (CC : LimCone d) : Π (c : C) (cc : cone d c),
-  iscontr (Σ x : C⟦c, lim CC⟧, Π (v : vertex g), x ;; limOut CC v = coneOut cc v).
+  (CC : LimCone d) : ∏ (c : C) (cc : cone d c),
+  iscontr (∑ x : C⟦c, lim CC⟧, ∏ (v : vertex g), x ;; limOut CC v = coneOut cc v).
 Proof.
 apply (colimUnivProp CC).
 Qed.
@@ -650,7 +650,7 @@ Qed.
 
 Lemma limArrowUnique {g : graph} {d : diagram g C^op} (CC : LimCone d)
   (c : C) (cc : cone d c) (k : C⟦c, lim CC⟧)
-  (Hk : Π (u : vertex g), k ;; limOut CC u = coneOut cc u) :
+  (Hk : ∏ (u : vertex g), k ;; limOut CC u = coneOut cc u) :
   k = limArrow CC c cc.
 Proof.
   apply (colimArrowUnique CC c cc k Hk).
@@ -658,7 +658,7 @@ Qed.
 
 Lemma Cone_precompose {g : graph} {d : diagram g C^op}
   {c : C} (cc : cone d c) (x : C) (f : C⟦x,c⟧) :
-    Π u v (e : edge u v), (f ;; coneOut cc v) ;; dmor d e = f ;; coneOut cc u.
+    ∏ u v (e : edge u v), (f ;; coneOut cc v) ;; dmor d e = f ;; coneOut cc u.
 Proof.
   apply (Cocone_postcompose cc x f).
 Qed.
@@ -673,8 +673,8 @@ Qed.
 
 Definition limOfArrows {g : graph} {d1 d2 : diagram g C^op}
   (CC1 : LimCone d1) (CC2 : LimCone d2)
-  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : Π u v (e : edge u v), f v ;; (dmor d2 e : C⟦dob d2 v, dob d2 u⟧)
+  (f : ∏ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : ∏ u v (e : edge u v), f v ;; (dmor d2 e : C⟦dob d2 v, dob d2 u⟧)
                               =
                                 (dmor d1 e : C⟦dob d1 v, dob d1 u⟧);; f u) :
   C⟦lim CC1 , lim CC2⟧.
@@ -686,9 +686,9 @@ Defined.
 
 Lemma limOfArrowsOut {g : graph} (d1 d2 : diagram g C^op)
   (CC1 : LimCone d1) (CC2 : LimCone d2)
-  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : Π u v (e : edge u v), f v ;; dmor d2 e = (dmor d1 e : C ⟦ _ , _ ⟧)  ;; f u) :
-    Π u, limOfArrows CC1 CC2 f fNat ;; limOut CC2 u =
+  (f : ∏ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : ∏ u v (e : edge u v), f v ;; dmor d2 e = (dmor d1 e : C ⟦ _ , _ ⟧)  ;; f u) :
+    ∏ u, limOfArrows CC1 CC2 f fNat ;; limOut CC2 u =
           limOut CC1 u ;; f u.
 Proof.
   apply (colimOfArrowsIn _ _ CC2 CC1 f fNat).
@@ -696,8 +696,8 @@ Qed.
 
 Lemma postCompWithLimOfArrows_subproof {g : graph} {d1 d2 : diagram g C^op}
   (CC1 : LimCone d1) (CC2 : LimCone d2)
-  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : Π u v (e : edge u v), f v ;; dmor d2 e = (dmor d1 e : C ⟦ _ , _ ⟧)  ;; f u)
+  (f : ∏ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : ∏ u v (e : edge u v), f v ;; dmor d2 e = (dmor d1 e : C ⟦ _ , _ ⟧)  ;; f u)
   (x : C) (cc : cone d1 x) u v (e : edge u v) :
     (coneOut cc v ;; f v) ;; dmor d2 e = coneOut cc u ;; f u.
 Proof.
@@ -706,8 +706,8 @@ Defined.
 
 Lemma postcompWithColimOfArrows {g : graph} (d1 d2 : diagram g C^op)
   (CC1 : LimCone d1) (CC2 : LimCone d2)
-  (f : Π (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
-  (fNat : Π u v (e : edge u v), f v ;; dmor d2 e = (dmor d1 e : C ⟦ _ , _ ⟧)  ;; f u)
+  (f : ∏ (u : vertex g), C⟦dob d1 u,dob d2 u⟧)
+  (fNat : ∏ u v (e : edge u v), f v ;; dmor d2 e = (dmor d1 e : C ⟦ _ , _ ⟧)  ;; f u)
   (x : C) (cc : cone d1 x) :
      limArrow CC1 x cc ;; limOfArrows CC1 CC2 f fNat =
        limArrow CC2 x (mk_cone (λ u, coneOut cc u ;; f u)
@@ -734,7 +734,7 @@ Qed.
 
 Lemma lim_endo_is_identity {g : graph} (D : diagram g C^op)
   (CC : LimCone D) (k : lim CC --> lim CC)
-  (H : Π u, k ;; limOut CC u = limOut CC u) :
+  (H : ∏ u, k ;; limOut CC u = limOut CC u) :
   identity _ = k.
 Proof.
 unshelve refine (uniqueExists _ _ (limUnivProp CC _ _) _ _ _ _).
@@ -754,13 +754,13 @@ Defined.
 
 Lemma isColim_weq_subproof1 {g : graph} (D : diagram g C)
   (c : C) (cc : cocone D c) (d : C) (k : C⟦c,d⟧) :
-  Π u, coconeIn cc u ;; k = pr1 (Cocone_by_postcompose D c cc d k) u.
+  ∏ u, coconeIn cc u ;; k = pr1 (Cocone_by_postcompose D c cc d k) u.
 Proof.
 now intro u.
 Qed.
 
 Lemma isColim_weq_subproof2 (g : graph) (D : diagram g C)
-  (c : C) (cc : cocone D c) (H : Π d, isweq (Cocone_by_postcompose D c cc d))
+  (c : C) (cc : cocone D c) (H : ∏ d, isweq (Cocone_by_postcompose D c cc d))
   (d : C) (cd : cocone D d) (u : vertex g) :
     coconeIn cc u ;; invmap (weqpair _ (H d)) cd = coconeIn cd u.
 Proof.
@@ -770,7 +770,7 @@ now rewrite p.
 Qed.
 
 Lemma isColim_weq {g : graph} (D : diagram g C) (c : C) (cc : cocone D c) :
-  isColimCocone D c cc <-> Π d, isweq (Cocone_by_postcompose D c cc d).
+  isColimCocone D c cc <-> ∏ d, isweq (Cocone_by_postcompose D c cc d).
 Proof.
 split.
 - intros H d.
@@ -891,7 +891,7 @@ Defined.
 Lemma LimFunctorCone (A C : precategory) (hsC : has_homsets C)
   (g : graph)
   (D : diagram g [A, C, hsC]^op)
-  (HC : Π a : A^op,
+  (HC : ∏ a : A^op,
             LimCone
               (diagram_pointwise (has_homsets_opp hsC) (get_diagram A C hsC g D) a))
   : LimCone D.
@@ -923,11 +923,11 @@ use (mk_ColimCocone _ (from_opp_opp_to_opp _ _ _ pr1pr1x)).
   + intro H; destruct H as [f Hf]; apply subtypeEquality.
     * abstract (intro β; repeat (apply impred; intro);
         now apply (has_homsets_opp (functor_category_has_homsets A C hsC))).
-    * match goal with |[ H2 : Π _ : ?TT ,  _ = _ ,,_   |- _ ] =>
+    * match goal with |[ H2 : ∏ _ : ?TT ,  _ = _ ,,_   |- _ ] =>
                        transparent assert (T : TT) end.
       (*
-      refine (let T : Σ x : nat_trans pr1pr1x (functor_opp F),
-                         Π v, nat_trans_comp (functor_opp (pr1 D v)) _ _
+      refine (let T : ∑ x : nat_trans pr1pr1x (functor_opp F),
+                         ∏ v, nat_trans_comp (functor_opp (pr1 D v)) _ _
                                 (pr1pr2pr1x v) x =
                                coconeIn (get_cocone A C hsC g D F ccF) v :=
                   _ in _).
@@ -1011,8 +1011,8 @@ refine (mk_cocone _ _).
 Defined.
 
 Lemma ColimFunctor_unique (F : [A, C, hsC]) (cc : cocone D F) :
-  iscontr (Σ x : [A, C, hsC] ⟦ ColimFunctor, F ⟧,
-            Π v : vertex g, colim_nat_trans_in_data v ;; x = coconeIn cc v).
+  iscontr (∑ x : [A, C, hsC] ⟦ ColimFunctor, F ⟧,
+            ∏ v : vertex g, colim_nat_trans_in_data v ;; x = coconeIn cc v).
 Proof.
 refine (tpair _ _ _).
 - refine (tpair _ _ _).

--- a/UniMath/CategoryTheory/limits/graphs/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/graphs/pullbacks.v
@@ -75,13 +75,13 @@ Definition isPullback {a b c d : C} (f : C ⟦b, a⟧) (g : C ⟦c, a⟧)
            (p1 : C⟦d,b⟧) (p2 : C⟦d,c⟧) (H : p1 ;; f = p2;; g) : UU :=
     isLimCone (pullback_diagram f g) d (PullbCone f g d p1 p2 H).
 (*
-   Π e (h : e --> b) (k : e --> c)(H : h ;; f = k ;; g ),
+   ∏ e (h : e --> b) (k : e --> c)(H : h ;; f = k ;; g ),
       iscontr (total2 (fun hk : e --> d => dirprod (hk ;; p1 = h)(hk ;; p2 = k))).
  *)
 
 Definition mk_isPullback {a b c d : C} (f : C ⟦b, a⟧) (g : C ⟦c, a⟧)
            (p1 : C⟦d,b⟧) (p2 : C⟦d,c⟧) (H : p1 ;; f = p2;; g) :
-  (Π e (h : C ⟦e, b⟧) (k : C⟦e,c⟧)(Hk : h ;; f = k ;; g ),
+  (∏ e (h : C ⟦e, b⟧) (k : C⟦e,c⟧)(Hk : h ;; f = k ;; g ),
       iscontr (total2 (fun hk : C⟦e,d⟧ => dirprod (hk ;; p1 = h)(hk ;; p2 = k))))
   →
   isPullback f g p1 p2 H.
@@ -154,10 +154,10 @@ Definition Pullback {a b c : C} (f : b --> a)(g : c --> a) :=
         isPullback f g (pr1 (pr2 pfg)) (pr2 (pr2 pfg)) H)).
  *)
 
-Definition Pullbacks := Π (a b c : C)(f : C⟦b, a⟧)(g : C⟦c, a⟧),
+Definition Pullbacks := ∏ (a b c : C)(f : C⟦b, a⟧)(g : C⟦c, a⟧),
        Pullback f g.
 
-Definition hasPullbacks := Π (a b c : C) (f : C⟦b, a⟧) (g : C⟦c, a⟧),
+Definition hasPullbacks := ∏ (a b c : C) (f : C⟦b, a⟧) (g : C⟦c, a⟧),
          ishinh (Pullback f g).
 
 

--- a/UniMath/CategoryTheory/limits/graphs/pushouts.v
+++ b/UniMath/CategoryTheory/limits/graphs/pushouts.v
@@ -83,7 +83,7 @@ Section def_po.
 
   Definition mk_isPushout {a b c d : C} (f : C ⟦a, b⟧) (g : C ⟦a, c⟧)
              (i1 : C⟦b, d⟧) (i2 : C⟦c, d⟧) (H : f ;; i1 = g ;; i2) :
-    (Π e (h : C ⟦b, e⟧) (k : C⟦c, e⟧)(Hk : f ;; h = g ;; k ),
+    (∏ e (h : C ⟦b, e⟧) (k : C⟦c, e⟧)(Hk : f ;; h = g ;; k ),
      iscontr (total2 (fun hk : C⟦d, e⟧ => dirprod (i1 ;; hk = h)(i2 ;; hk = k)))) →
     isPushout f g i1 i2 H.
   Proof.
@@ -131,9 +131,9 @@ Section def_po.
     - apply ispo.
   Defined.
 
-  Definition Pushouts : UU := Π (a b c : C) (f : C⟦a, b⟧)(g : C⟦a, c⟧), Pushout f g.
+  Definition Pushouts : UU := ∏ (a b c : C) (f : C⟦a, b⟧)(g : C⟦a, c⟧), Pushout f g.
 
-  Definition hasPushouts : UU := Π (a b c : C) (f : C⟦a, b⟧) (g : C⟦a, c⟧), ishinh (Pushout f g).
+  Definition hasPushouts : UU := ∏ (a b c : C) (f : C⟦a, b⟧) (g : C⟦a, c⟧), ishinh (Pushout f g).
 
   Definition PushoutObject {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧}:
     Pushout f g -> C := fun H => colim H.

--- a/UniMath/CategoryTheory/limits/graphs/terminal.v
+++ b/UniMath/CategoryTheory/limits/graphs/terminal.v
@@ -35,7 +35,7 @@ Defined.
 Definition isTerminal (a : C) :=
   isLimCone termDiagram a (termCone a).
 
-Definition mk_isTerminal (b : C) (H : Π (a : C), iscontr (a --> b)) :
+Definition mk_isTerminal (b : C) (H : ∏ (a : C), iscontr (a --> b)) :
   isTerminal b.
 Proof.
 intros a ca.

--- a/UniMath/CategoryTheory/limits/graphs/zero.v
+++ b/UniMath/CategoryTheory/limits/graphs/zero.v
@@ -31,12 +31,12 @@ Section def_zero.
   (** Construction of isZero for an object c from the conditions that the space
     of all morphisms from c to any object d is contractible and and the space of
     all morphisms from any object d to c is contractible. *)
-  Definition mk_isZero (c : C) (H : (Π (d : C), iscontr (c --> d))
-                                      × (Π (d : C), iscontr (d --> c))) :
+  Definition mk_isZero (c : C) (H : (∏ (d : C), iscontr (c --> d))
+                                      × (∏ (d : C), iscontr (d --> c))) :
     isZero c := mk_isInitial c (dirprod_pr1 H),,mk_isTerminal c (dirprod_pr2 H).
 
   (** Definition of Zero. *)
-  Definition Zero : UU := Σ c : C, isZero c.
+  Definition Zero : UU := ∑ c : C, isZero c.
   Definition mk_Zero (c : C) (H : isZero c) : Zero := tpair _ c H.
   Definition ZeroObject (Z : Zero) : C := pr1 Z.
 

--- a/UniMath/CategoryTheory/limits/initial.v
+++ b/UniMath/CategoryTheory/limits/initial.v
@@ -21,7 +21,7 @@ Section def_initial.
 
 Variable C : precategory.
 
-Definition isInitial (a : C) : UU := Π b : C, iscontr (a --> b).
+Definition isInitial (a : C) : UU := ∏ b : C, iscontr (a --> b).
 
 Definition Initial : UU := total2 (fun a => isInitial a).
 
@@ -55,7 +55,7 @@ Proof.
   exact H.
 Defined.
 
-Definition mk_isInitial (a : C) (H : Π (b : C), iscontr (a --> b)) :
+Definition mk_isInitial (a : C) (H : ∏ (b : C), iscontr (a --> b)) :
   isInitial a.
 Proof.
   exact H.
@@ -113,7 +113,7 @@ Section Initial_and_EmptyCoprod.
     refine (mk_Initial (CoproductObject _ _ X) _).
     refine (mk_isInitial _ _).
     intros b.
-    assert (H : Π i : empty, C⟦fromempty i, b⟧) by
+    assert (H : ∏ i : empty, C⟦fromempty i, b⟧) by
         (intros i; apply (fromempty i)).
     apply (iscontrpair (CoproductArrow _ _ X H)); intros t.
     apply CoproductArrowUnique; intros i; apply (fromempty i).
@@ -150,7 +150,7 @@ End Initial_and_EmptyCoprod.
 (* apply (mk_Initial c); apply mk_isInitial; intros b. *)
 (* case (iscc _ (initCocone b)); intros f Hf; destruct f as [f fcomm]. *)
 (* apply (tpair _ f); intro g. *)
-(* transparent assert (X : (Σ x : c --> b, Π v, *)
+(* transparent assert (X : (∑ x : c --> b, ∏ v, *)
 (*                        coconeIn cc v ;; x = coconeIn (initCocone b) v)). *)
 (*   { apply (tpair _ g); intro u; induction u. } *)
 (* apply (maponpaths pr1 (Hf X)). *)

--- a/UniMath/CategoryTheory/limits/kernels.v
+++ b/UniMath/CategoryTheory/limits/kernels.v
@@ -29,7 +29,7 @@ Section def_kernels.
 
   (** Definition and construction of Kernels *)
   Definition isKernel {x y z : C} (f : x --> y) (g : y --> z) (H : f ;; g = ZeroArrow Z x z) : UU :=
-    Π (w : C) (h : w --> y) (H : h ;; g = ZeroArrow Z w z), iscontr (Σ φ : w --> x, φ ;; f = h).
+    ∏ (w : C) (h : w --> y) (H : h ;; g = ZeroArrow Z w z), iscontr (∑ φ : w --> x, φ ;; f = h).
 
   Lemma isKernel_paths {x y z : C} (f : x --> y) (g : y --> z) (H H' : f ;; g = (ZeroArrow Z x z))
         (isK : isKernel f g H) : isKernel f g H'.
@@ -39,8 +39,8 @@ Section def_kernels.
   Qed.
 
   Definition mk_isKernel {x y z : C} (f : x --> y) (g : y --> z) (H1 : f ;; g = ZeroArrow Z x z)
-             (H2 : Π (w : C) (h : w --> y) (H' : h ;; g = ZeroArrow Z w z),
-                   iscontr (Σ ψ : w --> x, ψ ;; f = h)) : isKernel f g H1.
+             (H2 : ∏ (w : C) (h : w --> y) (H' : h ;; g = ZeroArrow Z w z),
+                   iscontr (∑ ψ : w --> x, ψ ;; f = h)) : isKernel f g H1.
   Proof.
     unfold isKernel.
     intros w h H.
@@ -52,15 +52,15 @@ Section def_kernels.
   Defined.
 
   Definition Kernel {y z : C} (g : y --> z) : UU :=
-    Σ D : (Σ x : ob C, x --> y),
-          Σ (e : (pr2 D) ;; g = ZeroArrow Z (pr1 D) z), isKernel (pr2 D) g e.
+    ∑ D : (∑ x : ob C, x --> y),
+          ∑ (e : (pr2 D) ;; g = ZeroArrow Z (pr1 D) z), isKernel (pr2 D) g e.
 
   Definition mk_Kernel {x y z : C} (f : x --> y) (g : y --> z) (H : f ;; g = (ZeroArrow Z x z))
              (isE : isKernel f g H) : Kernel g := ((x,,f),,(H,,isE)).
 
-  Definition Kernels : UU := Π (y z : C) (g : y --> z), Kernel g.
+  Definition Kernels : UU := ∏ (y z : C) (g : y --> z), Kernel g.
 
-  Definition hasKernels : UU := Π (y z : C) (g : y --> z), ishinh (Kernel g).
+  Definition hasKernels : UU := ∏ (y z : C) (g : y --> z), ishinh (Kernel g).
 
   (** Accessor functions *)
   Definition KernelOb {y z : C} {g : y --> z} (K : Kernel g) : C := pr1 (pr1 K).
@@ -114,7 +114,7 @@ Section def_kernels.
 
   (** Results on morphisms between Kernels. *)
   Definition identity_is_KernelIn {y z : C} {g : y --> z} (K : Kernel g) :
-    Σ φ : C⟦K, K⟧, φ ;; (KernelArrow K) = (KernelArrow K).
+    ∑ φ : C⟦K, K⟧, φ ;; (KernelArrow K) = (KernelArrow K).
   Proof.
     exists (identity K).
     apply id_left.

--- a/UniMath/CategoryTheory/limits/products.v
+++ b/UniMath/CategoryTheory/limits/products.v
@@ -30,36 +30,36 @@ Section product_def.
 
 Variable (I : UU) (C : precategory).
 
-Definition isProductCone (c : Π (i : I), C) (p : C)
-  (pi : Π i, p --> c i) :=
-  Π (a : C) (f : Π i, a --> c i),
-    iscontr (total2 (fun (fap : a --> p) => Π i, fap ;; pi i = f i)).
+Definition isProductCone (c : ∏ (i : I), C) (p : C)
+  (pi : ∏ i, p --> c i) :=
+  ∏ (a : C) (f : ∏ i, a --> c i),
+    iscontr (total2 (fun (fap : a --> p) => ∏ i, fap ;; pi i = f i)).
 
-Definition ProductCone (ci : Π i, C) :=
-   total2 (fun pp1p2 : total2 (fun p : C => Π i, p --> ci i) =>
+Definition ProductCone (ci : ∏ i, C) :=
+   total2 (fun pp1p2 : total2 (fun p : C => ∏ i, p --> ci i) =>
              isProductCone ci (pr1 pp1p2) (pr2 pp1p2)).
 
-Definition Products := Π (ci : Π i, C), ProductCone ci.
+Definition Products := ∏ (ci : ∏ i, C), ProductCone ci.
 Definition hasProducts := ishinh Products.
 
-Definition ProductObject {c : Π i, C} (P : ProductCone c) : C := pr1 (pr1 P).
-Definition ProductPr {c : Π i, C} (P : ProductCone c) : Π i, ProductObject P --> c i :=
+Definition ProductObject {c : ∏ i, C} (P : ProductCone c) : C := pr1 (pr1 P).
+Definition ProductPr {c : ∏ i, C} (P : ProductCone c) : ∏ i, ProductObject P --> c i :=
   pr2 (pr1 P).
 
-Definition isProductCone_ProductCone {c : Π i, C} (P : ProductCone c) :
+Definition isProductCone_ProductCone {c : ∏ i, C} (P : ProductCone c) :
    isProductCone c (ProductObject P) (ProductPr P).
  Proof.
   exact (pr2 P).
 Defined.
 
-Definition ProductArrow {c : Π i, C} (P : ProductCone c) {a : C} (f : Π i, a --> c i)
+Definition ProductArrow {c : ∏ i, C} (P : ProductCone c) {a : C} (f : ∏ i, a --> c i)
   : a --> ProductObject P.
 Proof.
   apply (pr1 (pr1 (isProductCone_ProductCone P _ f))).
 Defined.
 
-Lemma ProductPrCommutes (c : Π i, C) (P : ProductCone c) :
-     Π (a : C) (f : Π i, a --> c i) i, ProductArrow P f ;; ProductPr P i = f i.
+Lemma ProductPrCommutes (c : ∏ i, C) (P : ProductCone c) :
+     ∏ (a : C) (f : ∏ i, a --> c i) i, ProductArrow P f ;; ProductPr P i = f i.
 Proof.
   intros a f i.
   apply (pr2 (pr1 (isProductCone_ProductCone P _ f)) i).
@@ -73,52 +73,52 @@ Proof.
   apply id_right.
 Qed.
 
-Lemma ProductArrowUnique (c : Π i, C) (P : ProductCone c) (x : C)
-    (f : Π i, x --> c i) (k : x --> ProductObject P)
-    (Hk : Π i, k ;; ProductPr P i = f i) : k = ProductArrow P f.
+Lemma ProductArrowUnique (c : ∏ i, C) (P : ProductCone c) (x : C)
+    (f : ∏ i, x --> c i) (k : x --> ProductObject P)
+    (Hk : ∏ i, k ;; ProductPr P i = f i) : k = ProductArrow P f.
 Proof.
   set (H' := pr2 (isProductCone_ProductCone P _ f) (k,,Hk)).
   apply (base_paths _ _ H').
 Qed.
 
-Definition mk_ProductCone (a : Π i, C) :
-  Π (c : C) (f : Π i, C⟦c,a i⟧), isProductCone _ _ f -> ProductCone a.
+Definition mk_ProductCone (a : ∏ i, C) :
+  ∏ (c : C) (f : ∏ i, C⟦c,a i⟧), isProductCone _ _ f -> ProductCone a.
 Proof.
   intros c f X.
   simple refine (tpair _ (c,,f) X).
 Defined.
 
 Definition mk_isProductCone (hsC : has_homsets C) (a : I -> C) (p : C)
-  (pa : Π i, C⟦p,a i⟧) : (Π (c : C) (f : Π i, C⟦c,a i⟧),
-                                  ∃! k : C⟦c,p⟧, Π i, k ;; pa i = f i) ->
+  (pa : ∏ i, C⟦p,a i⟧) : (∏ (c : C) (f : ∏ i, C⟦c,a i⟧),
+                                  ∃! k : C⟦c,p⟧, ∏ i, k ;; pa i = f i) ->
                               isProductCone a p pa.
 Proof.
 intros H c cc; apply H.
 Defined.
 
-Lemma ProductArrowEta (c : Π i, C) (P : ProductCone c) (x : C)
+Lemma ProductArrowEta (c : ∏ i, C) (P : ProductCone c) (x : C)
     (f : x --> ProductObject P) :
     f = ProductArrow P (fun i => f ;; ProductPr P i).
 Proof.
   now apply ProductArrowUnique.
 Qed.
 
-Definition ProductOfArrows {c : Π i, C} (Pc : ProductCone c) {a : Π i, C}
-    (Pa : ProductCone a) (f : Π i, a i --> c i) :
+Definition ProductOfArrows {c : ∏ i, C} (Pc : ProductCone c) {a : ∏ i, C}
+    (Pa : ProductCone a) (f : ∏ i, a i --> c i) :
       ProductObject Pa --> ProductObject Pc :=
     ProductArrow Pc (fun i => ProductPr Pa i ;; f i).
 
-Lemma ProductOfArrowsPr {c : Π i, C} (Pc : ProductCone c) {a : Π i, C}
-    (Pa : ProductCone a) (f : Π i, a i --> c i) :
-    Π i, ProductOfArrows Pc Pa f ;; ProductPr Pc i = ProductPr Pa i ;; f i.
+Lemma ProductOfArrowsPr {c : ∏ i, C} (Pc : ProductCone c) {a : ∏ i, C}
+    (Pa : ProductCone a) (f : ∏ i, a i --> c i) :
+    ∏ i, ProductOfArrows Pc Pa f ;; ProductPr Pc i = ProductPr Pa i ;; f i.
 Proof.
   unfold ProductOfArrows; intro i.
   now rewrite (ProductPrCommutes _ _ _ _ i).
 Qed.
 
-Lemma postcompWithProductArrow {c : Π i, C} (Pc : ProductCone c) {a : Π i, C}
-    (Pa : ProductCone a) (f : Π i, a i --> c i)
-    {x : C} (k : Π i, x --> a i) :
+Lemma postcompWithProductArrow {c : ∏ i, C} (Pc : ProductCone c) {a : ∏ i, C}
+    (Pa : ProductCone a) (f : ∏ i, a i --> c i)
+    {x : C} (k : ∏ i, x --> a i) :
         ProductArrow Pa k ;; ProductOfArrows Pc Pa f =
         ProductArrow Pc (fun i => k i ;; f i).
 Proof.
@@ -126,8 +126,8 @@ apply ProductArrowUnique; intro i.
 now rewrite <- assoc, ProductOfArrowsPr, assoc, ProductPrCommutes.
 Qed.
 
-Lemma precompWithProductArrow {c : Π i, C} (Pc : ProductCone c)
-  {a : C} (f : Π i, a --> c i) {x : C} (k : x --> a)  :
+Lemma precompWithProductArrow {c : ∏ i, C} (Pc : ProductCone c)
+  {a : C} (f : ∏ i, a --> c i) {x : C} (k : x --> a)  :
        k ;; ProductArrow Pc f = ProductArrow Pc (fun i => k ;; f i).
 Proof.
 apply ProductArrowUnique; intro i.
@@ -140,8 +140,8 @@ Section Products.
 
 Variables (I : UU) (C : precategory) (CC : Products I C).
 
-Definition ProductOfArrows_comp (a b c : Π (i : I), C)
-  (f : Π i, a i --> b i) (g : Π i, b i --> c i)
+Definition ProductOfArrows_comp (a b c : ∏ (i : I), C)
+  (f : ∏ i, a i --> b i) (g : ∏ i, b i --> c i)
   : ProductOfArrows _ _ _ _ f ;; ProductOfArrows _ _ _ (CC _) g
     = ProductOfArrows _ _ (CC _) (CC _) (fun i => f i ;; g i).
 Proof.
@@ -165,11 +165,11 @@ Section Product_unique.
 
 Variables (I : UU) (C : precategory).
 Variable CC : Products I C.
-Variables a : Π (i : I), C.
+Variables a : ∏ (i : I), C.
 
 Lemma Product_endo_is_identity (P : ProductCone _ _ a)
   (k : ProductObject _ _ P --> ProductObject _ _ P)
-  (H1 : Π i, k ;; ProductPr _ _ P i = ProductPr _ _ P i)
+  (H1 : ∏ i, k ;; ProductPr _ _ P i = ProductPr _ _ P i)
   : identity _ = k.
 Proof.
   apply pathsinv0.
@@ -211,7 +211,7 @@ End product_functor.
 (* The product of a family of functors *)
 Definition product_of_functors_alt
   (I : UU) {C D : precategory} (HD : Products I D)
-  (F : Π (i : I), functor C D) : functor C D :=
+  (F : ∏ (i : I), functor C D) : functor C D :=
    functor_composite (delta_functor I C)
      (functor_composite (family_functor _ F) (product_functor _ HD)).
 
@@ -285,7 +285,7 @@ Section vertex.
 (** The product morphism of a diagram with vertex [A] *)
 
 Variable A : functor C D.
-Variable f : Π i, nat_trans A (F i).
+Variable f : ∏ i, nat_trans A (F i).
 
 Definition product_nat_trans_data c :
   A c --> product_of_functors c:=
@@ -350,7 +350,7 @@ exists F.
 abstract (intros u v e; induction e).
 Defined.
 
-Definition productscone c (F : I → C) (H : Π i, c --> F i) :
+Definition productscone c (F : I → C) (H : ∏ i, c --> F i) :
   cone (products_diagram F) c.
 Proof.
 mkpair.

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -33,7 +33,7 @@ Context {C : precategory} (hsC : has_homsets C).
 
 Definition isPullback {a b c d : C} (f : b --> a) (g : c --> a)
         (p1 : d --> b) (p2 : d --> c) (H : p1 ;; f = p2;; g) : UU :=
-   Π e (h : e --> b) (k : e --> c)(H : h ;; f = k ;; g ),
+   ∏ e (h : e --> b) (k : e --> c)(H : h ;; f = k ;; g ),
       iscontr (total2 (fun hk : e --> d => dirprod (hk ;; p1 = h)(hk ;; p2 = k))).
 
 Lemma isaprop_isPullback {a b c d : C} (f : b --> a) (g : c --> a)
@@ -63,10 +63,10 @@ Definition Pullback {a b c : C} (f : b --> a)(g : c --> a) :=
          total2 (fun H : pr1 (pr2 pfg) ;; f = pr2 (pr2 pfg) ;; g =>
         isPullback f g (pr1 (pr2 pfg)) (pr2 (pr2 pfg)) H)).
 
-Definition Pullbacks := Π (a b c : C)(f : b --> a)(g : c --> a),
+Definition Pullbacks := ∏ (a b c : C)(f : b --> a)(g : c --> a),
        Pullback f g.
 
-Definition hasPullbacks := Π (a b c : C) (f : b --> a) (g : c --> a),
+Definition hasPullbacks := ∏ (a b c : C) (f : b --> a) (g : c --> a),
          ishinh (Pullback f g).
 
 
@@ -138,7 +138,7 @@ Defined.
 
 Definition mk_isPullback {a b c d : C} (f : C ⟦b, a⟧) (g : C ⟦c, a⟧)
            (p1 : C⟦d,b⟧) (p2 : C⟦d,c⟧) (H : p1 ;; f = p2;; g) :
-  (Π e (h : C ⟦e, b⟧) (k : C⟦e,c⟧)(Hk : h ;; f = k ;; g ),
+  (∏ e (h : C ⟦e, b⟧) (k : C⟦e,c⟧)(Hk : h ;; f = k ;; g ),
       iscontr (total2 (fun hk : C⟦e,d⟧ => dirprod (hk ;; p1 = h)(hk ;; p2 = k))))
   →
   isPullback f g p1 p2 H.
@@ -530,7 +530,7 @@ Defined.
 
 Definition pb_of_section (isPb : isPullback _ _ _ _ H)
   (s : C⟦a,c⟧) (K : s ;; g = identity _ )
-  : Σ s' : C⟦b, d⟧, s' ;; h = identity _ .
+  : ∑ s' : C⟦b, d⟧, s' ;; h = identity _ .
 Proof.
   simple refine (tpair _ _ _ ).
   - simple refine (PullbackArrow (mk_Pullback _ _ _ _ _ _ isPb) b (identity _ )
@@ -545,9 +545,9 @@ Ltac mk_pair := simple refine (tpair _ _ _ ).
 (** Diagonal morphisms are equivalent to sections *)
 
 Definition section_from_diagonal (isPb : isPullback _ _ _ _ H)
-  : (Σ x : C⟦b, c⟧, x ;; g = f)
+  : (∑ x : C⟦b, c⟧, x ;; g = f)
     ->
-    Σ s' : C⟦b, d⟧, s' ;; h = identity _ .
+    ∑ s' : C⟦b, d⟧, s' ;; h = identity _ .
 Proof.
   intro X.
   mk_pair.
@@ -557,9 +557,9 @@ Proof.
 Defined.
 
 Definition diagonal_from_section (isPb : isPullback _ _ _ _ H)
-  : (Σ x : C⟦b, c⟧, x ;; g = f)
+  : (∑ x : C⟦b, c⟧, x ;; g = f)
     <-
-    Σ s' : C⟦b, d⟧, s' ;; h = identity _ .
+    ∑ s' : C⟦b, d⟧, s' ;; h = identity _ .
 Proof.
   intro X.
   exists (pr1 X ;; k).
@@ -567,9 +567,9 @@ Proof.
 Defined.
 
 Definition weq_section_from_diagonal (isPb : isPullback _ _ _ _ H)
-  : (Σ x : C⟦b, c⟧, x ;; g = f)
+  : (∑ x : C⟦b, c⟧, x ;; g = f)
     ≃
-    Σ s' : C⟦b, d⟧, s' ;; h = identity _ .
+    ∑ s' : C⟦b, d⟧, s' ;; h = identity _ .
 Proof.
   exists (section_from_diagonal isPb).
   apply (gradth _ (diagonal_from_section isPb )).
@@ -904,7 +904,7 @@ Definition maps_pb_square_to_pb_square
   isPullback _ _ _ _ H -> isPullback _ _ _ _ (functor_on_square H).
 
 Definition maps_pb_squares_to_pb_squares :=
-   Π {a b c d : C}
+   ∏ {a b c d : C}
      {f : C ⟦b, a⟧} {g : C ⟦c, a⟧} {h : C⟦d, b⟧} {k : C⟦d,c⟧}
      (H : h ;; f = k ;; g),
      maps_pb_square_to_pb_square H.
@@ -937,15 +937,15 @@ Arguments mk_Pullback {_ _ _ _ _ _ _ _ _ _ } _ .
 
 Let Hcommx x := nat_trans_eq_pointwise Hcomm x.
 
-Local Definition g (T : Π x, isPullback _ _ _ _ (Hcommx x))
+Local Definition g (T : ∏ x, isPullback _ _ _ _ (Hcommx x))
   E (h : CD ⟦ E, G ⟧) (k : CD ⟦ E, H ⟧)
-  (Hhk : h ;; a = k ;; b) : Π x, D ⟦ pr1 E x, pr1 J x ⟧.
+  (Hhk : h ;; a = k ;; b) : ∏ x, D ⟦ pr1 E x, pr1 J x ⟧.
 Proof.
 intro x; apply (PullbackArrow (mk_Pullback (T x)) _ (pr1 h x) (pr1 k x)).
 abstract (apply (nat_trans_eq_pointwise Hhk)).
 Defined.
 
-Local Lemma is_nat_trans_g (T : Π x, isPullback _ _ _ _ (Hcommx x))
+Local Lemma is_nat_trans_g (T : ∏ x, isPullback _ _ _ _ (Hcommx x))
   E (h : CD ⟦ E, G ⟧) (k : CD ⟦ E, H ⟧)
   (Hhk : h ;; a = k ;; b) : is_nat_trans _ _ (λ x : C, g T E h k Hhk x).
 Proof.
@@ -959,7 +959,7 @@ apply (MorphismsIntoPullbackEqual (T y)).
   now rewrite (PullbackArrow_PullbackPr2 (mk_Pullback (T x))), (nat_trans_ax k).
 Qed.
 
-Lemma pb_if_pointwise_pb : (Π x, isPullback _ _ _ _ (Hcommx x)) ->
+Lemma pb_if_pointwise_pb : (∏ x, isPullback _ _ _ _ (Hcommx x)) ->
   isPullback _ _ _ _ Hcomm.
 Proof.
 intro T.

--- a/UniMath/CategoryTheory/limits/pushouts.v
+++ b/UniMath/CategoryTheory/limits/pushouts.v
@@ -22,7 +22,7 @@ Section def_po.
 
   Definition isPushout {a b c d : C} (f : a --> b) (g : a --> c)
              (in1 : b --> d) (in2 : c --> d) (H : f ;; in1 = g ;; in2) : UU :=
-    Π e (h : b --> e) (k : c --> e)(H : f ;; h = g ;; k),
+    ∏ e (h : b --> e) (k : c --> e)(H : f ;; h = g ;; k),
     iscontr (total2 (fun hk : d --> e => dirprod (in1 ;; hk = h) (in2 ;; hk = k))).
 
   Lemma isaprop_isPushout {a b c d : C} (f : a --> b) (g : a --> c)
@@ -52,10 +52,10 @@ Section def_po.
               total2 (fun H : f ;; pr1 (pr2 pfg) = g ;; pr2 (pr2 pfg) =>
                         isPushout f g (pr1 (pr2 pfg)) (pr2 (pr2 pfg)) H)).
 
-  Definition Pushouts := Π (a b c : C) (f : a --> b) (g : a --> c),
+  Definition Pushouts := ∏ (a b c : C) (f : a --> b) (g : a --> c),
       Pushout f g.
 
-  Definition hasPushouts := Π (a b c : C) (f : a --> b) (g : a --> c),
+  Definition hasPushouts := ∏ (a b c : C) (f : a --> b) (g : a --> c),
       ishinh (Pushout f g).
 
 
@@ -121,7 +121,7 @@ Section def_po.
 
   Definition mk_isPushout {a b c d : C} (f : C ⟦a, b⟧) (g : C ⟦a, c⟧)
              (in1 : C⟦b,d⟧) (in2 : C⟦c,d⟧) (H : f ;; in1 = g ;; in2) :
-    (Π e (h : C ⟦b, e⟧) (k : C⟦c,e⟧)(Hk : f ;; h = g ;; k),
+    (∏ e (h : C ⟦b, e⟧) (k : C⟦c,e⟧)(Hk : f ;; h = g ;; k),
         iscontr (total2 (fun hk : C⟦d,e⟧ =>
                            dirprod (in1 ;; hk = h)(in2 ;; hk = k))))
     →

--- a/UniMath/CategoryTheory/limits/terminal.v
+++ b/UniMath/CategoryTheory/limits/terminal.v
@@ -21,7 +21,7 @@ Section def_terminal.
 
 Variable C : precategory.
 
-Definition isTerminal (b : C) : UU := Π a : C, iscontr (a --> b).
+Definition isTerminal (b : C) : UU := ∏ a : C, iscontr (a --> b).
 
 Definition Terminal : UU := total2 (fun a => isTerminal a).
 
@@ -33,7 +33,7 @@ Proof.
   exists b; exact H.
 Defined.
 
-Definition mk_isTerminal (b : C) (H : Π (a : C), iscontr (a --> b)) :
+Definition mk_isTerminal (b : C) (H : ∏ (a : C), iscontr (a --> b)) :
   isTerminal b.
 Proof.
   exact H.
@@ -114,7 +114,7 @@ Section Terminal_and_EmptyProd.
     refine (mk_Terminal (ProductObject _ C X) _).
     refine (mk_isTerminal _ _).
     intros a.
-    assert (H : Π i : empty, C⟦a, fromempty i⟧) by
+    assert (H : ∏ i : empty, C⟦a, fromempty i⟧) by
         (intros i; apply (fromempty i)).
     apply (iscontrpair (ProductArrow _ _ X H)); intros t.
     apply ProductArrowUnique; intros i; apply (fromempty i).
@@ -155,8 +155,8 @@ End Terminal_and_EmptyProd.
 (* apply (mk_Terminal c); apply mk_isTerminal; intros b. *)
 (* case (iscc _ (termCone b)); intros f Hf; destruct f as [f fcomm]. *)
 (* apply (tpair _ f); intro g. *)
-(* simple refine (let X : Σ x : b --> c, *)
-(*                        Π v, coconeIn cc v ;; x = coconeIn (termCone b) v := _ in _). *)
+(* simple refine (let X : ∑ x : b --> c, *)
+(*                        ∏ v, coconeIn cc v ;; x = coconeIn (termCone b) v := _ in _). *)
 (*   { apply (tpair _ g); intro u; induction u. } *)
 (* apply (maponpaths pr1 (Hf X)). *)
 (* Defined. *)

--- a/UniMath/CategoryTheory/limits/zero.v
+++ b/UniMath/CategoryTheory/limits/zero.v
@@ -16,7 +16,7 @@ Section def_zero.
   Variable C : precategory.
 
   Definition isZero (b : C) : UU :=
-    (Π a : C, iscontr (b --> a)) × (Π a : C, iscontr (a --> b)).
+    (∏ a : C, iscontr (b --> a)) × (∏ a : C, iscontr (a --> b)).
 
   Definition Zero : UU := total2 (fun a => isZero a).
 
@@ -28,8 +28,8 @@ Section def_zero.
     exists b; exact H.
   Defined.
 
-  Definition mk_isZero (b : C) (H : Π (a : C), iscontr (b --> a))
-             (H' : Π (a : C), iscontr (a --> b)) : isZero b.
+  Definition mk_isZero (b : C) (H : ∏ (a : C), iscontr (b --> a))
+             (H' : ∏ (a : C), iscontr (a --> b)) : isZero b.
   Proof.
     unfold isZero.  exact ((H,,H')).
   Defined.

--- a/UniMath/CategoryTheory/opp_precat.v
+++ b/UniMath/CategoryTheory/opp_precat.v
@@ -109,7 +109,7 @@ Proof. intros a b; apply hsC. Qed.
 
 Definition functor_opp_data {C D : precategory} (F : functor C D) :
   functor_data C^op D^op :=
-    tpair (fun F : C^op -> D^op => Π a b, C^op ⟦a, b⟧ -> D^op ⟦F a, F b⟧) F
+    tpair (fun F : C^op -> D^op => ∏ a b, C^op ⟦a, b⟧ -> D^op ⟦F a, F b⟧) F
           (fun (a b : C) (f : C⟦b, a⟧) => functor_on_morphisms F f).
 
 Lemma is_functor_functor_opp {C D : precategory} (F : functor C D) :
@@ -144,7 +144,7 @@ Lemma opp_functor_essentially_surjective :
 Proof.
   intros HF d.
   set (TH := HF d).
-  set (X:=@hinhuniv  (Σ a : C, iso (F a) d)).
+  set (X:=@hinhuniv  (∑ a : C, iso (F a) d)).
   refine (X _ _ TH).
   intro H. clear TH. clear X.
   apply hinhpr.

--- a/UniMath/CategoryTheory/precategories.v
+++ b/UniMath/CategoryTheory/precategories.v
@@ -23,7 +23,7 @@ Contents :  Definition of
                   Analogue to [gradth]: [is_iso_qinv]
 
                 Isomorphisms II: [z_iso]
-                  Definition: [is_z_iso f := Σ g, ...]
+                  Definition: [is_z_iso f := ∑ g, ...]
                   Relationship between [z_iso] and [iso]
 
                 Categories have groupoid as objects
@@ -70,15 +70,15 @@ Local Notation "a --> b" := (precategory_morphisms a b)(at level 50).
 *)
 
 Definition precategory_id_comp (C : precategory_ob_mor) :=
-     dirprod (Π c : C, c --> c) (* identities *)
-             (Π a b c : C,
+     dirprod (∏ c : C, c --> c) (* identities *)
+             (∏ a b c : C,
                  a --> b -> b --> c -> a --> c).
 
 Definition precategory_data := total2 precategory_id_comp.
 
 Definition precategory_data_pair (C : precategory_ob_mor)
-    (id : Π c : C, c --> c)
-    (comp: Π a b c : C,
+    (id : ∏ c : C, c --> c)
+    (comp: ∏ a b c : C,
          a --> b -> b --> c -> a --> c) : precategory_data :=
    tpair _ C (dirprodpair id comp).
 
@@ -88,7 +88,7 @@ Coercion precategory_ob_mor_from_precategory_data :
   precategory_data >-> precategory_ob_mor.
 
 Definition identity { C : precategory_data } :
-    Π c : C, c --> c :=
+    ∏ c : C, c --> c :=
          pr1 (pr2 C).
 
 Definition compose { C : precategory_data }
@@ -107,15 +107,15 @@ Definition postcompose  {C : precategory_data} {a b c : C} (g : b --> c) (f : a 
 *)
 
 Definition is_precategory (C : precategory_data) :=
-   dirprod (dirprod (Π (a b : C) (f : a --> b),
+   dirprod (dirprod (∏ (a b : C) (f : a --> b),
                          identity a ;; f = f)
-                     (Π (a b : C) (f : a --> b),
+                     (∏ (a b : C) (f : a --> b),
                          f ;; identity b = f))
-            (Π (a b c d : C)
+            (∏ (a b c d : C)
                     (f : a --> b)(g : b --> c) (h : c --> d),
                      f ;; (g ;; h) = (f ;; g) ;; h).
 (*
-Definition is_hs_precategory_data (C : precategory_data) := Π (a b : C), isaset (a --> b).
+Definition is_hs_precategory_data (C : precategory_data) := ∏ (a b : C), isaset (a --> b).
 *)
 (*
 Definition hs_precategory_data := total2 is_hs_precategory_data.
@@ -128,7 +128,7 @@ Coercion precategory_data_from_hs_precategory_data : hs_precategory_data >-> pre
 Definition precategory := total2 is_precategory.
 
 Definition hs_precategory := total2 (fun C : precategory_data =>
-  dirprod (is_precategory C) (Π a b : C, isaset (a --> b))).
+  dirprod (is_precategory C) (∏ a b : C, isaset (a --> b))).
 
 Definition hs_precategory_has_homsets (C : hs_precategory) := pr2 (pr2 C).
 
@@ -144,7 +144,7 @@ Definition precategory_from_hs_precategory (C : hs_precategory) : precategory :=
   tpair _ (pr1 C) (pr1 (pr2 C)).
 Coercion precategory_from_hs_precategory : hs_precategory >-> precategory.
 
-Definition has_homsets (C : precategory_ob_mor) := Π a b : C, isaset (a --> b).
+Definition has_homsets (C : precategory_ob_mor) := ∏ a b : C, isaset (a --> b).
 
 Lemma isaprop_has_homsets (C : precategory_ob_mor) : isaprop (has_homsets C).
 Proof.
@@ -152,7 +152,7 @@ Proof.
   apply isapropisaset.
 Qed.
 
-Definition Precategory := Σ C:precategory, has_homsets C.
+Definition Precategory := ∑ C:precategory, has_homsets C.
 Definition Precategory_pair C h : Precategory := C,,h.
 Definition Precategory_to_precategory : Precategory -> precategory := pr1.
 Coercion Precategory_to_precategory : Precategory >-> precategory.
@@ -169,15 +169,15 @@ Qed.
 
 
 Definition id_left (C : precategory) :
-   Π (a b : C) (f : a --> b),
+   ∏ (a b : C) (f : a --> b),
            identity a ;; f = f := pr1 (pr1 (pr2 C)).
 
 Definition id_right (C : precategory) :
-   Π (a b : C) (f : a --> b),
+   ∏ (a b : C) (f : a --> b),
            f ;; identity b = f := pr2 (pr1 (pr2 C)).
 
 Definition assoc (C : precategory) :
-   Π (a b c d : C)
+   ∏ (a b c d : C)
           (f : a --> b)(g : b --> c) (h : c --> d),
                      f ;; (g ;; h) = (f ;; g) ;; h := pr2 (pr2 C).
 
@@ -287,7 +287,7 @@ Definition precomp_with {C : precategory_data} {a b : C} (f : a --> b) {c} (g : 
    f ;; g.
 
 Definition is_iso {C : precategory_data} {a b : C} (f : a --> b) :=
-  Π c, isweq (precomp_with f (c:=c)).
+  ∏ c, isweq (precomp_with f (c:=c)).
 
 Definition is_isomorphism {C: precategory_data}{a b : C} (f : a --> b) := is_iso f.
 
@@ -437,7 +437,7 @@ Qed.
 (** Stability under composition, inverses etc *)
 
 Definition isweqhomot' {X Y} (f g : X -> Y) (H : isweq f)
-      (homot : Π x, f x = g x) : isweq g.
+      (homot : ∏ x, f x = g x) : isweq g.
 Proof.
   apply (isweqhomot f g homot H).
 Defined.
@@ -939,7 +939,7 @@ Defined.
 
 (* use eta expanded version to force printing of object arguments *)
 Definition is_category (C : precategory) :=
-  dirprod (Π (a b : ob C), isweq (fun p : a = b => idtoiso p))
+  dirprod (∏ (a b : ob C), isweq (fun p : a = b => idtoiso p))
           (has_homsets C).
 
 Lemma eq_idtoiso_idtomor {C:precategory} (a b:ob C) (e:a = b) :
@@ -979,7 +979,7 @@ Definition category_has_homsets ( C : category )
 Lemma category_has_groupoid_ob (C : category): isofhlevel 3 (ob C).
 Proof.
   change (isofhlevel 3 C) with
-        (Π a b : C, isofhlevel 2 (a = b)).
+        (∏ a b : C, isofhlevel 2 (a = b)).
   intros a b.
   apply (isofhlevelweqb _ (tpair _ _ (pr1 (pr2 C) a b))).
   apply isaset_iso.
@@ -1151,8 +1151,8 @@ Proof.
 Qed.
 
 Lemma transportf_isotoid_dep (C : precategory)
-   (a a' : C) (p : a = a') (f : Π c, a --> c) :
- transportf (fun x : C => Π c, x --> c) p f = fun c => idtoiso (!p) ;; f c.
+   (a a' : C) (p : a = a') (f : ∏ c, a --> c) :
+ transportf (fun x : C => ∏ c, x --> c) p f = fun c => idtoiso (!p) ;; f c.
 Proof.
   destruct p.
   simpl.
@@ -1163,16 +1163,16 @@ Proof.
 Qed.
 
 Lemma transportf_isotoid_dep' (J : UU) (C : precategory) (F : J -> C)
-  (a a' : C) (p : a = a') (f : Π c, a --> F c) :
-  transportf (fun x : C => Π c, x --> F c) p f = fun c => idtoiso (!p) ;; f c.
+  (a a' : C) (p : a = a') (f : ∏ c, a --> F c) :
+  transportf (fun x : C => ∏ c, x --> F c) p f = fun c => idtoiso (!p) ;; f c.
 Proof.
   now destruct p; apply funextsec; intro x; rewrite id_left.
 Defined.
 
 (* This and the above name is not very good... *)
  Lemma transportf_isotoid_dep'' (J : UU) (C : precategory) (F : J -> C)
-   (a a' : C) (p : a = a') (f : Π c, F c --> a) :
-   transportf (fun x : C => Π c, F c --> x) p f = fun c => f c ;; idtoiso p.
+   (a a' : C) (p : a = a') (f : ∏ c, F c --> a) :
+   transportf (fun x : C => ∏ c, F c --> x) p f = fun c => f c ;; idtoiso p.
 Proof.
   now destruct p; apply funextsec; intro x; rewrite id_right.
 Defined.
@@ -1216,7 +1216,7 @@ Definition precategory_total_id (C : precategory_data) :
       fun c => tpair _ (dirprodpair c c) (identity c).
 
 Definition precategory_total_comp'' (C : precategory_data) :
-      Π f g : total_morphisms C,
+      ∏ f g : total_morphisms C,
         precategory_target C f = precategory_source C g ->
          total_morphisms C.
 Proof.
@@ -1231,7 +1231,7 @@ Proof.
 Defined.
 
 Definition precategory_total_comp (C : precategory_data) :
-      Π f g : total_morphisms C,
+      ∏ f g : total_morphisms C,
         precategory_target C f = precategory_source C g ->
          total_morphisms C :=
   fun f g e =>
@@ -1286,8 +1286,8 @@ Proof.
   induction e. intros H. apply H.
 Qed.
 
-Lemma transport_source_target {X : UU} {C : precategory} {x y : X} (P : Π (x' : X), ob C)
-      (P' : Π (x' : X), ob C) (f : Π (x' : X), (P x') --> (P' x')) (e : x = y) :
+Lemma transport_source_target {X : UU} {C : precategory} {x y : X} (P : ∏ (x' : X), ob C)
+      (P' : ∏ (x' : X), ob C) (f : ∏ (x' : X), (P x') --> (P' x')) (e : x = y) :
   transportf (fun (x' : X) => (P x') --> (P' x')) e (f x) =
   transportf (fun (x' : X) => precategory_morphisms (P x') (P' y)) e
              (transportf (precategory_morphisms (P x)) (maponpaths P' e) (f x)).
@@ -1296,8 +1296,8 @@ Proof.
   apply idpath.
 Qed.
 
-Lemma transport_target_source {X : UU} {C : precategory} {x y : X} (P : Π (x' : X), ob C)
-      (P' : Π (x' : X), ob C) (f : Π (x' : X), (P x') --> (P' x')) (e : x = y) :
+Lemma transport_target_source {X : UU} {C : precategory} {x y : X} (P : ∏ (x' : X), ob C)
+      (P' : ∏ (x' : X), ob C) (f : ∏ (x' : X), (P x') --> (P' x')) (e : x = y) :
   transportf (fun (x' : X) => (P x') --> (P' x')) e (f x) =
   transportf (precategory_morphisms (P y)) (maponpaths P' e)
              (transportf (fun (x' : X) => precategory_morphisms (P x') (P' x)) e (f x)).
@@ -1320,7 +1320,7 @@ Qed.
 (** *** Transport a morphism using funextfun *)
 
 Definition transport_source_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C)
-           (H : Π (x : X), F x = F' x) {x : X} (c : ob C) (f : F x --> c) :
+           (H : ∏ (x : X), F x = F' x) {x : X} (c : ob C) (f : F x --> c) :
   transportf (λ x0 : X → C, x0 x --> c) (funextfun F F' H) f =
   transportf (λ x0 : C, x0 --> c) (H x) f.
 Proof.
@@ -1328,7 +1328,7 @@ Proof.
 Qed.
 
 Definition transport_target_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C)
-           (H : Π (x : X), F x = F' x) {x : X} {c : ob C} (f : c --> F x)  :
+           (H : ∏ (x : X), F x = F' x) {x : X} {c : ob C} (f : c --> F x)  :
   transportf (λ x0 : X → C, c --> x0 x) (funextfun F F' H) f =
   transportf (λ x0 : C, c --> x0) (H x) f.
 Proof.
@@ -1336,7 +1336,7 @@ Proof.
 Qed.
 
 Lemma transport_mor_funextfun {X : UU} {C : precategory_ob_mor} (F F' : X -> ob C)
-           (H : Π (x : X), F x = F' x) {x1 x2 : X} (f : F x1 --> F x2) :
+           (H : ∏ (x : X), F x = F' x) {x1 x2 : X} (f : F x1 --> F x2) :
   transportf (λ x : X → C, x x1 --> x x2) (funextfun F F' H) f =
   transportf (λ x : X → C, F' x1 --> x x2)
              (funextfun F F' (λ x : X, H x))

--- a/UniMath/CategoryTheory/precategoriesWithBinOps.v
+++ b/UniMath/CategoryTheory/precategoriesWithBinOps.v
@@ -14,9 +14,9 @@ Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
 Section def_precategory_with_binops.
 
   (** Definition of precategories such that homs are binops. *)
-  Definition precategoryWithBinOpsData (C : precategory) : UU := Π (x y : C), binop (C⟦x, y⟧).
+  Definition precategoryWithBinOpsData (C : precategory) : UU := ∏ (x y : C), binop (C⟦x, y⟧).
 
-  Definition precategoryWithBinOps : UU := Σ C : precategory, precategoryWithBinOpsData C.
+  Definition precategoryWithBinOps : UU := ∑ C : precategory, precategoryWithBinOpsData C.
 
   Definition precategoryWithBinOps_precategory (P : precategoryWithBinOps) : precategory := pr1 P.
   Coercion precategoryWithBinOps_precategory : precategoryWithBinOps >-> precategory.

--- a/UniMath/CategoryTheory/precomp_ess_surj.v
+++ b/UniMath/CategoryTheory/precomp_ess_surj.v
@@ -81,10 +81,10 @@ Section preimage.
 Local Definition X (b : B) := total2 (
  fun ck :
   total2 (fun c : C =>
-                Π a : A,
+                ∏ a : A,
                      iso (H a) b -> iso (F a) c) =>
-    Π t t' : total2 (fun a : A => iso (H a) b),
-          Π f : pr1 t --> pr1 t',
+    ∏ t t' : total2 (fun a : A => iso (H a) b),
+          ∏ f : pr1 t --> pr1 t',
              (#H f ;; pr2 t' = pr2 t ->
                     #F f ;; pr2 ck (pr1 t') (pr2 t') = pr2 ck (pr1 t) (pr2 t))).
 
@@ -93,7 +93,7 @@ Local Definition kX {b : B} (t : X b) := (pr2 (pr1 t)).
 (** The following is the third component of the center of [X b] *)
 
 Lemma X_aux_type_center_of_contr_proof (b : B) (anot : A) (hnot : iso (H anot) b) :
-  Π (t t' : total2 (fun a :  A => iso (H a) b))
+  ∏ (t t' : total2 (fun a :  A => iso (H a) b))
     (f : pr1 t --> pr1 t'),
   #H f;; pr2 t' = pr2 t ->
   #F f;;
@@ -137,7 +137,7 @@ Defined.
 (** Any inhabitant of [X b] is equal to the center of [X b]. *)
 
 Lemma X_aux_type_contr_eq (b : B) (anot : A) (hnot : iso (H anot) b) :
-   Π t : X b, t = X_aux_type_center_of_contr b anot hnot.
+   ∏ t : X b, t = X_aux_type_center_of_contr b anot hnot.
 Proof.
   intro t.
   assert (Hpr1 : pr1 (X_aux_type_center_of_contr b anot hnot) = pr1 t).
@@ -186,7 +186,7 @@ Qed.
 
 (** Putting everything together: [X b] is contractible. *)
 
-Definition iscontr_X : Π b : B, iscontr (X b).
+Definition iscontr_X : ∏ b : B, iscontr (X b).
 Proof.
   intro b.
   assert (HH : isaprop (iscontr (X b))).
@@ -206,7 +206,7 @@ Definition Go : B -> C :=
    fun b : B => pr1 (pr1 (pr1 (iscontr_X b))).
 
 Local Definition k (b : B) :
-     Π a : A, iso (H a) b -> iso (F a) (Go b) :=
+     ∏ a : A, iso (H a) b -> iso (F a) (Go b) :=
               pr2 (pr1 (pr1 (iscontr_X b))).
 
 Local Definition q (b : B) := pr2 (pr1 (iscontr_X b)).
@@ -224,7 +224,7 @@ Defined.
        modulo transport along [Xphi b t]. *)
 
 Definition Xkphi_transp (b : B) (t : X b) :
-     Π a : A, Π h : iso (H a) b,
+     ∏ a : A, ∏ h : iso (H a) b,
   transportf _ (Xphi b t) (kX t) a h =  k b a h.
 Proof.
   unfold k.
@@ -237,7 +237,7 @@ Qed.
     as [k b], modulo postcomposition with an isomorphism. *)
 
 Definition Xkphi_idtoiso (b : B) (t : X b) :
-    Π a : A, Π h : iso (H a) b,
+    ∏ a : A, ∏ h : iso (H a) b,
    k b a h ;; idtoiso (!Xphi b t) = kX t a h.
 Proof.
   intros a h.
@@ -251,7 +251,7 @@ Qed.
 (*
 Lemma k_transport (b : ob B) (*t : X b*) (c : ob C)
    (p : pr1 (pr1 t) = c) (a : ob A) (h : iso (pr1 H a) b):
-transportf (fun c' : ob C => Π a : ob A, iso (pr1 H a) b ->
+transportf (fun c' : ob C => ∏ a : ob A, iso (pr1 H a) b ->
                           iso ((pr1 F) a) c')
    p (k) a h = (k b) b a h ;; idtoiso p .
 *)
@@ -264,16 +264,16 @@ transportf (fun c' : ob C => Π a : ob A, iso (pr1 H a) b ->
 
 Local Definition Y {b b' : B} (f : b --> b') :=
   total2 (fun g : Go b --> Go b' =>
-      Π a : A,
-        Π h : iso (H a) b,
-          Π a' : A,
-            Π h' : iso (H a') b',
-              Π l : a --> a',
+      ∏ a : A,
+        ∏ h : iso (H a) b,
+          ∏ a' : A,
+            ∏ h' : iso (H a') b',
+              ∏ l : a --> a',
                 #H l ;; h' = h ;; f -> #F l ;; k b' a' h' = k b a h ;; g).
 
 Lemma Y_inhab_proof (b b' : B) (f : b --> b') (a0 : A) (h0 : iso (H a0) b)
     (a0' : A) (h0' : iso (H a0') b') :
-  Π (a : A) (h : iso (H a) b) (a' : A) (h' : iso (H a') b')
+  ∏ (a : A) (h : iso (H a) b) (a' : A) (h' : iso (H a') b')
     (l : a --> a'),
   #H l;; h' = h;; f ->
   #F l;; k b' a' h' =
@@ -371,7 +371,7 @@ Defined.
 Lemma Y_contr_eq (b b' : B) (f : b --> b')
      (a0 : A) (h0 : iso (H a0) b)
      (a0' : A) (h0' : iso (H a0') b') :
-  Π t : Y f, t = Y_inhab b b' f a0 h0 a0' h0'.
+  ∏ t : Y f, t = Y_inhab b b' f a0 h0 a0' h0'.
 Proof.
   intro t.
   apply pathsinv0.
@@ -430,7 +430,7 @@ Proof.
   split. unfold functor_idax. simpl.
   intro b.
 
-  assert (PR2 : Π (a : A) (h : iso (H a) b) (a' : A)
+  assert (PR2 : ∏ (a : A) (h : iso (H a) b) (a' : A)
           (h' : iso (H a') b)
     (l : a --> a'),
   #H l;; h' = h;; identity b ->
@@ -487,7 +487,7 @@ Proof.
     repeat rewrite assoc; apply idpath.
 
 
-  assert (PR2 : Π (a : A) (h : iso (H a) b)(a' : A)
+  assert (PR2 : ∏ (a : A) (h : iso (H a) b)(a' : A)
           (h' : iso (H a') b') (l : a --> a'),
            #H l;; h' = h;; f ->
            #F l;; k b' a' h' =
@@ -577,7 +577,7 @@ Proof.
     apply idpath.
 
   clear PR2.
-  assert (PR2 : Π (a : A) (h : iso (H a) b') (a' : A)
+  assert (PR2 : ∏ (a : A) (h : iso (H a) b') (a' : A)
             (h' : iso (H a') b'') (l : a --> a'),
          #H l;; h' = h;; f' ->
            #F l;; k b'' a' h' =
@@ -654,7 +654,7 @@ Proof.
     apply idpath.
 
   clear PR2.
-  assert (PR2 : Π (a : A) (h : iso (H a) b) (a' : A)
+  assert (PR2 : ∏ (a : A) (h : iso (H a) b) (a' : A)
              (h' : iso (H a') b'') (l : a --> a'),
           #H l;; h' = h;; (f;; f') ->
           #F l;; k b'' a' h' =
@@ -755,7 +755,7 @@ Definition GG : [B, C, pr2 Ccat] := tpair _ preimage_functor_data
    This allows to prove [G (H a) = F a]. *)
 
 Lemma qF (a0 : A) :
-  Π (t t' : total2 (fun a :  A => iso (H a) (H a0)))
+  ∏ (t t' : total2 (fun a :  A => iso (H a) (H a0)))
     (f : pr1 t --> pr1 t'),
   #H f;; pr2 t' = pr2 t ->
   #F f;; #F (fH^-1 (pr2 t')) =
@@ -775,7 +775,7 @@ Proof.
 Qed.
 
 
-Definition kFa (a0 : A) : Π a : A,
+Definition kFa (a0 : A) : ∏ a : A,
   iso (H a) (H a0) -> iso (F a) (F a0) :=
  fun (a : A) (h : iso (H a) (H a0)) =>
    functor_on_iso F
@@ -814,7 +814,7 @@ Proof.
   rewrite <- idtoiso_precompose.
   rewrite idtoiso_inv.
   rewrite <- assoc.
-  assert (PSIf : Π (a : A) (h : iso (H a) (H a0)) (a' : A)
+  assert (PSIf : ∏ (a : A) (h : iso (H a) (H a0)) (a' : A)
   (h' : iso (H a') (H a0')) (l : a --> a'),
          #H l;; h' = h;; #H f ->
          #F l;; k (H a0') a' h' =

--- a/UniMath/CategoryTheory/precomp_fully_faithful.v
+++ b/UniMath/CategoryTheory/precomp_fully_faithful.v
@@ -113,7 +113,7 @@ Variable gamma : nat_trans
 
 Lemma isaprop_aux_space (b : B) :
     isaprop (total2 (fun g : F b --> G b =>
-      Π a : A, Π f : iso (H a) b,
+      ∏ a : A, ∏ f : iso (H a) b,
            gamma a = #F f ;; g ;; #G (inv_from_iso f))).
 Proof.
   apply invproofirrelevance.
@@ -176,18 +176,18 @@ Qed.
 
 Lemma iscontr_aux_space (b : B) :
    iscontr (total2 (fun g : F b --> G b =>
-      Π a : A, Π f : iso (H a) b,
+      ∏ a : A, ∏ f : iso (H a) b,
            gamma a = #F f ;; g ;; #G (inv_from_iso f)  )).
 Proof.
   set (X := isapropiscontr (total2
      (fun g : F b --> G b =>
-      Π (a : A) (f : iso (H a) b),
+      ∏ (a : A) (f : iso (H a) b),
       gamma a = (#F f;; g);; #G (inv_from_iso f)))).
   apply (p b (tpair (fun x => isaprop x) _ X)).
   intros [anot h].
   simpl in *.
   set (g := #F (inv_from_iso h) ;; gamma anot ;; #G h).
-  assert (gp : Π (a : A)
+  assert (gp : ∏ (a : A)
                      (f : iso (H a) b),
                  gamma a = #F f ;; g ;; #G (inv_from_iso f)).
     clear X.
@@ -221,7 +221,7 @@ Proof.
 Defined.
 
 
-Definition pdelta : Π b : B, F b --> G b :=
+Definition pdelta : ∏ b : B, F b --> G b :=
          fun b => pr1 (pr1 (iscontr_aux_space b)).
 
 Lemma is_nat_trans_pdelta :

--- a/UniMath/CategoryTheory/rezk_completion.v
+++ b/UniMath/CategoryTheory/rezk_completion.v
@@ -73,13 +73,13 @@ End rezk.
 (** * Universal property of the Rezk completion *)
 
 Definition functor_from (C : precategory) : UU
-  := Σ D : category, functor C D.
+  := ∑ D : category, functor C D.
 
 Coercion target_category (C : precategory) (X : functor_from C) : category := pr1 X.
 Definition func_functor_from {C : precategory} (X : functor_from C) : functor C X := pr2 X.
 
 Definition is_initial_functor_from (C : precategory) (X : functor_from C) : UU
-  := Π X' : functor_from C,
+  := ∏ X' : functor_from C,
      ∃! H : functor X X',
        functor_composite (func_functor_from X) H = func_functor_from X'.
 
@@ -160,7 +160,7 @@ Defined.
 
 Definition Rezk_completion_endo_is_identity (D : functor_from A)
            (DH : is_initial_functor_from A D)
-  : Π X : functor D D, functor_composite (func_functor_from D) X = func_functor_from D
+  : ∏ X : functor D D, functor_composite (func_functor_from D) X = func_functor_from D
         ->
         X = functor_identity D.
 Proof.

--- a/UniMath/CategoryTheory/set_slice_fam_equiv.v
+++ b/UniMath/CategoryTheory/set_slice_fam_equiv.v
@@ -96,7 +96,7 @@ Section set_slice_fam_equiv.
   Definition slice_counit_fun (f : slice X) :
     (functor_composite_data slice_to_fam_data fam_to_slice_data) f --> (functor_identity_data _) f.
   Proof.
-    exists (fun h : (Σ x : X, hfiber (pr2 f) x) => pr1 (pr2 h)).
+    exists (fun h : (∑ x : X, hfiber (pr2 f) x) => pr1 (pr2 h)).
     simpl.
     apply funextsec.
     intro p.

--- a/UniMath/CategoryTheory/slicecat.v
+++ b/UniMath/CategoryTheory/slicecat.v
@@ -267,7 +267,7 @@ now rewrite assoc, <- (pr2 h).
 Qed.
 
 Definition slicecat_functor_data : functor_data (C / x) (C / y) :=
-  tpair (λ F, Π a b, C/x⟦a,b⟧ → C/y⟦F a,F b⟧) slicecat_functor_ob
+  tpair (λ F, ∏ a b, C/x⟦a,b⟧ → C/y⟦F a,F b⟧) slicecat_functor_ob
         (λ a b h, (pr1 h,,slicecat_functor_subproof _ _ h)).
 
 Lemma is_functor_slicecat_functor : is_functor slicecat_functor_data.
@@ -347,7 +347,7 @@ assert (H1 : transportf (fun x : C / z => pr1 x --> b)
                  (fun p => tpair _ a p = tpair _ a _) (idpath (tpair _ a _))
                  (assoc fax f g)) h = h).
   case (assoc fax f g); apply idpath.
-assert (H2 : Π h', h' = h ->
+assert (H2 : ∏ h', h' = h ->
              transportf (fun x : C / z => a --> pr1 x)
                         (Foundations.PartA.internal_paths_rew_r _ _ _
                            (fun p => tpair _ b p = tpair _ b _) (idpath _)
@@ -649,7 +649,7 @@ Defined.
 *)
 Section dependent_product.
 
-Context (H : Π {c c' : C} (g : C⟦c,c'⟧), is_left_adjoint (base_change_functor g)).
+Context (H : ∏ {c c' : C} (g : C⟦c,c'⟧), is_left_adjoint (base_change_functor g)).
 
 Let dependent_product_functor {c c' : C} (g : C⟦c,c'⟧) :
   functor (C / c) (C / c') := right_adjoint (H c c' g).

--- a/UniMath/CategoryTheory/sub_precategories.v
+++ b/UniMath/CategoryTheory/sub_precategories.v
@@ -58,14 +58,14 @@ Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
 Definition is_sub_precategory {C : precategory}
     (C' : hsubtype C)
-    (Cmor' : Π a b : C, hsubtype (a --> b)) :=
- dirprod (Π a : C, C' a ->  Cmor' _ _ (identity a ))
-         (Π (a b c : C) (f: a --> b) (g : b --> c),
+    (Cmor' : ∏ a b : C, hsubtype (a --> b)) :=
+ dirprod (∏ a : C, C' a ->  Cmor' _ _ (identity a ))
+         (∏ (a b c : C) (f: a --> b) (g : b --> c),
                    Cmor' _ _ f -> Cmor' _ _  g -> Cmor' _ _  (f ;; g)).
 
 Definition sub_precategories (C : precategory) := total2 (
    fun C' : dirprod (hsubtype (ob C))
-                    (Π a b:ob C, hsubtype (a --> b)) =>
+                    (∏ a b:ob C, hsubtype (a --> b)) =>
         is_sub_precategory (pr1 C') (pr2 C')).
 
 (** A full subcategory has the true predicate on morphisms *)
@@ -110,13 +110,13 @@ Definition sub_precategory_morphisms {C : precategory}(C':sub_precategories C)
 *)
 
 Definition sub_precategory_id (C : precategory)(C':sub_precategories C) :
-   Π a : ob C,
+   ∏ a : ob C,
        sub_precategory_predicate_objects C' a ->
        sub_precategory_predicate_morphisms  C' _ _ (identity a) :=
          pr1 (pr2 C').
 
 Definition sub_precategory_comp (C : precategory)(C':sub_precategories C) :
-   Π (a b c: ob C) (f: a --> b) (g : b --> c),
+   ∏ (a b c: ob C) (f: a --> b) (g : b --> c),
           sub_precategory_predicate_morphisms C' _ _ f ->
           sub_precategory_predicate_morphisms C' _ _ g ->
           sub_precategory_predicate_morphisms C' _ _  (f ;; g) :=

--- a/UniMath/CategoryTheory/yoneda.v
+++ b/UniMath/CategoryTheory/yoneda.v
@@ -95,7 +95,7 @@ Definition yoneda_objects (C : precategory) (hs: has_homsets C) (c : C) :
 (** ** On morphisms *)
 
 Definition yoneda_morphisms_data (C : precategory)(hs: has_homsets C) (c c' : C)
-    (f : hom C c c') : Π a : ob C^op,
+    (f : hom C c c') : ∏ a : ob C^op,
          hom _ (yoneda_objects C hs c a) ( yoneda_objects C hs c' a) :=
             fun a g => g ;; f.
 

--- a/UniMath/Combinatorics/FiniteSequences.v
+++ b/UniMath/Combinatorics/FiniteSequences.v
@@ -5,7 +5,7 @@ Unset Automatic Introduction.
 (* end of move upstream *)
 
 
-Definition Sequence X := Σ n, stn n -> X.
+Definition Sequence X := ∑ n, stn n -> X.
 
 Notation seq := Sequence.
 
@@ -27,7 +27,7 @@ Definition transport_stn m n i (b:i<m) (p:m=n) :
 Proof. intros. induction p. reflexivity. Defined.
 
 Definition sequenceEquality {X m n} (f:stn m->X) (g:stn n->X) (p:m=n) :
-  (Π i, f i = g (transportf stn p i))
+  (∏ i, f i = g (transportf stn p i))
   -> transportf (λ m, stn m->X) p f = g.
 Proof. intros ? ? ? ? ? ? e. induction p. apply funextfun. exact e. Defined.
 
@@ -61,7 +61,7 @@ Defined.
 
 Definition seq_key_eq_lemma' {X :UU} (g g' : seq X) :
   seq_len g = seq_len g' ->
-  (Π i, Σ ltg : i < seq_len g, Σ ltg' : i < seq_len g',
+  (∏ i, ∑ ltg : i < seq_len g, ∑ ltg' : i < seq_len g',
                                         g (i ,, ltg) = g' (i ,, ltg')) ->
   g=g'.
 Proof.
@@ -151,7 +151,7 @@ Defined.
 
 (* Three ways.  Use induction: *)
 
-Definition iscontr_rect' X (i : iscontr X) (x0 : X) (P : X ->UU) (p0 : P x0) : Π x:X, P x.
+Definition iscontr_rect' X (i : iscontr X) (x0 : X) (P : X ->UU) (p0 : P x0) : ∏ x:X, P x.
 Proof. intros. induction (pr1 (isapropifcontr i x0 x)). exact p0. Defined.
 
 Definition iscontr_rect_compute' X (i : iscontr X) (x : X) (P : X ->UU) (p : P x) :
@@ -166,7 +166,7 @@ Defined.
 
 (* ... or use weqsecovercontr, but specializing x to pr1 i: *)
 
-Definition iscontr_rect'' X (i : iscontr X) (P : X ->UU) (p0 : P (pr1 i)) : Π x:X, P x.
+Definition iscontr_rect'' X (i : iscontr X) (P : X ->UU) (p0 : P (pr1 i)) : ∏ x:X, P x.
 Proof. intros. exact (invmap (weqsecovercontr P i) p0 x). Defined.
 
 Definition iscontr_rect_compute'' X (i : iscontr X) (P : X ->UU) (p : P(pr1 i)) :
@@ -181,7 +181,7 @@ Definition iscontr_adjointness X (is:iscontr X) (x:X) : pr1 (isapropifcontr is x
    the weq [unit ≃ X] would give it to us, in the case where x is [pr1 is] *)
 Proof. intros. now apply isasetifcontr. Defined.
 
-Definition iscontr_rect X (is : iscontr X) (x0 : X) (P : X ->UU) (p0 : P x0) : Π x:X, P x.
+Definition iscontr_rect X (is : iscontr X) (x0 : X) (P : X ->UU) (p0 : P x0) : ∏ x:X, P x.
 Proof. intros. exact (transportf P (pr1 (isapropifcontr is x0 x)) p0). Defined.
 
 Definition iscontr_rect_compute X (is : iscontr X) (x : X) (P : X ->UU) (p : P x) :
@@ -189,11 +189,11 @@ Definition iscontr_rect_compute X (is : iscontr X) (x : X) (P : X ->UU) (p : P x
 Proof. intros. unfold iscontr_rect. now rewrite iscontr_adjointness. Defined.
 
 Corollary weqsecovercontr':     (* reprove weqsecovercontr, move upstream *)
-  Π (X:UU) (P:X->UU) (is:iscontr X), (Π x:X, P x) ≃ P (pr1 is).
+  ∏ (X:UU) (P:X->UU) (is:iscontr X), (∏ x:X, P x) ≃ P (pr1 is).
 Proof.
   intros.
   set (x0 := pr1 is).
-  set (secs := Π x : X, P x).
+  set (secs := ∏ x : X, P x).
   set (fib  := P x0).
   set (destr := (λ f, f x0) : secs->fib).
   set (constr:= iscontr_rect X is x0 P : fib->secs).
@@ -297,7 +297,7 @@ Defined.
 
 Definition Sequence_rect {X} {P : Sequence X ->UU}
            (p0 : P nil)
-           (ind : Π (x : Sequence X) (y : X), P x -> P (append x y))
+           (ind : ∏ (x : Sequence X) (y : X), P x -> P (append x y))
            (x : Sequence X) : P x.
 Proof. intros. induction x as [n x]. induction n as [|n IH].
   - exact (transportf P (nil_unique x) p0).
@@ -308,7 +308,7 @@ Proof. intros. induction x as [n x]. induction n as [|n IH].
 Defined.
 
 Lemma Sequence_rect_compute_nil {X} {P : Sequence X ->UU} (p0 : P nil)
-      (ind : Π (s : Sequence X) (x : X), P s -> P (append s x)) :
+      (ind : ∏ (s : Sequence X) (x : X), P s -> P (append s x)) :
   Sequence_rect p0 ind nil = p0.
 Proof.
   intros.
@@ -321,7 +321,7 @@ Defined.
 
 Lemma Sequence_rect_compute_cons
       {X} {P : Sequence X ->UU} (p0 : P nil)
-      (ind : Π (s : Sequence X) (x : X), P s -> P (append s x))
+      (ind : ∏ (s : Sequence X) (x : X), P s -> P (append s x))
       (x:X) (l:Sequence X) :
   Sequence_rect p0 ind (append l x) = ind l x (Sequence_rect p0 ind l).
 Proof.
@@ -422,9 +422,9 @@ Proof.
 Defined.
 
 Definition total2_step_f {n} (X:stn (S n) ->UU) :
-  (Σ i, X i)
+  (∑ i, X i)
     ->
-  (Σ (i:stn n), X (dni _ (lastelement _) i)) ⨿ X (lastelement _).
+  (∑ (i:stn n), X (dni _ (lastelement _) i)) ⨿ X (lastelement _).
 Proof.
   intros ? ? [[j J] x].
   induction (natlehchoice4 j n J) as [J'|K].
@@ -441,9 +441,9 @@ Proof.
 Defined.
 
 Definition total2_step_b {n} (X:stnset (S n) ->UU) :
-  (Σ (i:stn n), X (dni _ (lastelement _) i)) ⨿ X (lastelement _)
+  (∑ (i:stn n), X (dni _ (lastelement _) i)) ⨿ X (lastelement _)
     ->
-  (Σ i, X i).
+  (∑ i, X i).
 Proof.
   intros ? ? x.
   induction x as [jx|x].
@@ -474,12 +474,12 @@ Proof.
 Defined.
 
 Definition total2_step {n} (X:stnset (S n) ->UU) :
-  (Σ i, X i) ≃ (Σ (i:stn n), X (dni _ (lastelement _) i)) ⨿ X (lastelement _).
+  (∑ i, X i) ≃ (∑ (i:stn n), X (dni _ (lastelement _) i)) ⨿ X (lastelement _).
 Proof.
   intros. set (f := weqdnicoprod n (lastelement _)).
-  intermediate_weq (Σ x : stn n ⨿ unit, X (f x)).
+  intermediate_weq (∑ x : stn n ⨿ unit, X (f x)).
   { apply invweq. apply weqfp. }
-  intermediate_weq ((Σ i, X (f (ii1 i))) ⨿ Σ t, X (f (ii2 t))).
+  intermediate_weq ((∑ i, X (f (ii1 i))) ⨿ ∑ t, X (f (ii2 t))).
   { apply weqtotal2overcoprod. }
   apply weqcoprodf. { apply weqfibtototal; intro i. apply idweq. }
   apply weqtotal2overunit.
@@ -526,14 +526,14 @@ Proof.
 Defined.
 
 Corollary total2_step' {n} (f:stn (S n) -> nat) :
-  (Σ i, stn (f i))
+  (∑ i, stn (f i))
     ≃
-  (Σ (i:stn n), stn (f (dni _ (lastelement _) i))) ⨿ stn (f (lastelement _)).
+  (∑ (i:stn n), stn (f (dni _ (lastelement _) i))) ⨿ stn (f (lastelement _)).
 Proof. intros. apply (total2_step (stn ∘ f)). Defined.
 
-Definition weqstnsum1' {n} (f:stn (S n)->nat ) : (Σ i, stn (f i)) ≃ stn (stnsum f).
+Definition weqstnsum1' {n} (f:stn (S n)->nat ) : (∑ i, stn (f i)) ≃ stn (stnsum f).
 Proof. intros.
-  intermediate_weq ((Σ (i:stn n), stn (f (dni _ (lastelement _) i))) ⨿ stn (f (lastelement _))).
+  intermediate_weq ((∑ (i:stn n), stn (f (dni _ (lastelement _) i))) ⨿ stn (f (lastelement _))).
   { apply total2_step'. }
   intermediate_weq (stn (stnsum (f ∘ dni n (lastelement n))) ⨿ stn (f (lastelement n))).
   { apply weqcoprodf. { apply weqstnsum1. } apply idweq. }

--- a/UniMath/Combinatorics/FiniteSets.v
+++ b/UniMath/Combinatorics/FiniteSets.v
@@ -56,7 +56,7 @@ Defined.
 
 Definition nelstructoncoprod { X  Y : UU } { n m : nat } ( sx : nelstruct n X ) ( sy : nelstruct m Y ) : nelstruct ( n + m ) ( coprod X Y ) := weqcomp ( invweq ( weqfromcoprodofstn n m ) ) ( weqcoprodf sx sy ) .
 
-Definition nelstructontotal2 { X : UU } ( P : X -> UU ) ( f : X -> nat ) { n : nat } ( sx : nelstruct n X ) ( fs : Π x : X , nelstruct ( f x ) ( P x ) ) : nelstruct ( stnsum ( funcomp ( pr1 sx ) f ) ) ( total2 P )  := weqcomp ( invweq ( weqstnsum ( funcomp ( pr1 sx ) P ) ( funcomp ( pr1 sx ) f ) ( fun i : stn n => fs ( ( pr1 sx ) i ) ) ) )  ( weqfp sx P )  .
+Definition nelstructontotal2 { X : UU } ( P : X -> UU ) ( f : X -> nat ) { n : nat } ( sx : nelstruct n X ) ( fs : ∏ x : X , nelstruct ( f x ) ( P x ) ) : nelstruct ( stnsum ( funcomp ( pr1 sx ) f ) ) ( total2 P )  := weqcomp ( invweq ( weqstnsum ( funcomp ( pr1 sx ) P ) ( funcomp ( pr1 sx ) f ) ( fun i : stn n => fs ( ( pr1 sx ) i ) ) ) )  ( weqfp sx P )  .
 
 Definition nelstructondirprod { X Y : UU } { n m : nat } ( sx : nelstruct n X ) ( sy : nelstruct m Y ) : nelstruct ( n * m ) ( dirprod X Y ) := weqcomp ( invweq ( weqfromprodofstn n m ) ) ( weqdirprodf sx sy ) .
 
@@ -64,7 +64,7 @@ Definition nelstructondirprod { X Y : UU } { n m : nat } ( sx : nelstruct n X ) 
 
 Definition nelstructonfun { X Y : UU } { n m : nat } ( sx : nelstruct n X ) ( sy : nelstruct m Y ) : nelstruct ( natpower m n ) ( X -> Y ) := weqcomp ( invweq ( weqfromfunstntostn n m ) ) ( weqcomp ( weqbfun _ ( invweq sx ) ) ( weqffun _ sy ) )  .
 
-Definition nelstructonforall { X : UU } ( P : X -> UU ) ( f : X -> nat ) { n : nat } ( sx : nelstruct n X ) ( fs : Π x : X , nelstruct ( f x ) ( P x ) ) : nelstruct ( stnprod ( funcomp ( pr1 sx ) f ) ) ( Π x : X , P x )  := invweq ( weqcomp ( weqonsecbase P sx ) ( weqstnprod ( funcomp ( pr1 sx ) P ) ( funcomp ( pr1 sx ) f ) ( fun i : stn n => fs ( ( pr1 sx ) i ) ) ) )  .
+Definition nelstructonforall { X : UU } ( P : X -> UU ) ( f : X -> nat ) { n : nat } ( sx : nelstruct n X ) ( fs : ∏ x : X , nelstruct ( f x ) ( P x ) ) : nelstruct ( stnprod ( funcomp ( pr1 sx ) f ) ) ( ∏ x : X , P x )  := invweq ( weqcomp ( weqonsecbase P sx ) ( weqstnprod ( funcomp ( pr1 sx ) P ) ( funcomp ( pr1 sx ) f ) ( fun i : stn n => fs ( ( pr1 sx ) i ) ) ) )  .
 
 Definition nelstructonweq { X : UU } { n : nat } ( sx : nelstruct n X ) : nelstruct ( factorial n ) ( weq X X ) := weqcomp ( invweq ( weqfromweqstntostn n ) ) ( weqcomp ( weqbweq _ ( invweq sx ) ) ( weqfweq _ sx ) ) .
 
@@ -145,7 +145,7 @@ Proof . intros . unfold finstruct .  unfold finstruct in sx . destruct sx as [ n
 
 Definition finstructoncoprod { X  Y : UU } ( sx : finstruct X ) ( sy : finstruct Y ) : finstruct ( coprod X Y ) := tpair _ ( ( pr1 sx ) + ( pr1 sy ) ) ( nelstructoncoprod ( pr2 sx ) ( pr2 sy ) ) .
 
-Definition finstructontotal2 { X : UU } ( P : X -> UU )   ( sx : finstruct X ) ( fs : Π x : X , finstruct ( P x ) ) : finstruct ( total2 P ) := tpair _ ( stnsum ( funcomp ( pr1 ( pr2 sx ) ) ( fun x : X =>  pr1 ( fs x ) ) ) ) ( nelstructontotal2 P ( fun x : X => pr1 ( fs x ) ) ( pr2 sx ) ( fun x : X => pr2 ( fs x ) ) ) .
+Definition finstructontotal2 { X : UU } ( P : X -> UU )   ( sx : finstruct X ) ( fs : ∏ x : X , finstruct ( P x ) ) : finstruct ( total2 P ) := tpair _ ( stnsum ( funcomp ( pr1 ( pr2 sx ) ) ( fun x : X =>  pr1 ( fs x ) ) ) ) ( nelstructontotal2 P ( fun x : X => pr1 ( fs x ) ) ( pr2 sx ) ( fun x : X => pr2 ( fs x ) ) ) .
 
 Definition finstructondirprod { X Y : UU } ( sx : finstruct X ) ( sy : finstruct Y ) : finstruct ( dirprod X Y ) := tpair _ ( ( pr1 sx ) * ( pr1 sy ) ) ( nelstructondirprod ( pr2 sx ) ( pr2 sy ) ) .
 
@@ -154,7 +154,7 @@ Definition finstructondecsubset { X : UU }  ( f : X -> bool ) ( sx : finstruct X
 
 Definition finstructonfun { X Y : UU } ( sx : finstruct X ) ( sy : finstruct Y ) : finstruct ( X -> Y ) := tpair _ ( natpower ( pr1 sy ) ( pr1 sx ) ) ( nelstructonfun ( pr2 sx ) ( pr2 sy ) ) .
 
-Definition finstructonforall { X : UU } ( P : X -> UU )  ( sx : finstruct X ) ( fs : Π x : X , finstruct ( P x ) ) : finstruct ( Π x : X , P x )  := tpair _ ( stnprod ( funcomp ( pr1 ( pr2 sx ) ) ( fun x : X =>  pr1 ( fs x ) ) ) ) ( nelstructonforall P ( fun x : X => pr1 ( fs x ) ) ( pr2 sx ) ( fun x : X => pr2 ( fs x ) ) ) .
+Definition finstructonforall { X : UU } ( P : X -> UU )  ( sx : finstruct X ) ( fs : ∏ x : X , finstruct ( P x ) ) : finstruct ( ∏ x : X , P x )  := tpair _ ( stnprod ( funcomp ( pr1 ( pr2 sx ) ) ( fun x : X =>  pr1 ( fs x ) ) ) ) ( nelstructonforall P ( fun x : X => pr1 ( fs x ) ) ( pr2 sx ) ( fun x : X => pr2 ( fs x ) ) ) .
 
 Definition finstructonweq { X : UU }  ( sx : finstruct X ) : finstruct ( weq X X ) := tpair _ ( factorial ( pr1 sx ) ) ( nelstructonweq ( pr2 sx ) ) .
 
@@ -165,7 +165,7 @@ Definition finstructonweq { X : UU }  ( sx : finstruct X ) : finstruct ( weq X X
 
 Definition isfinite  ( X : UU ) := ishinh ( finstruct X ) .
 
-Definition FiniteSet := Σ X:UU, isfinite X.
+Definition FiniteSet := ∑ X:UU, isfinite X.
 
 Definition isfinite_to_FiniteSet {X:UU} (f:isfinite X) : FiniteSet := X,,f.
 
@@ -223,8 +223,8 @@ Definition isfinitecompl { X : UU } ( x : X ) ( sx : isfinite X ) : isfinite ( c
 
 Definition isfinitecoprod { X  Y : UU } ( sx : isfinite X ) ( sy : isfinite Y ) : isfinite ( coprod X Y ) := hinhfun2 ( fun sx0 : _ => fun sy0 : _ => finstructoncoprod sx0 sy0 ) sx sy .
 
-Definition isfinitetotal2 { X : UU } ( P : X -> UU ) ( sx : isfinite X ) ( fs : Π x : X , isfinite ( P x ) ) : isfinite ( total2 P ) .
-Proof . intros . set ( fs' := ischoicebasefiniteset sx _ fs ) .  apply ( hinhfun2 ( fun fx0 : Π x : X , finstruct ( P x )  => fun sx0 : _ => finstructontotal2 P sx0 fx0 ) fs' sx ) .  Defined .
+Definition isfinitetotal2 { X : UU } ( P : X -> UU ) ( sx : isfinite X ) ( fs : ∏ x : X , isfinite ( P x ) ) : isfinite ( total2 P ) .
+Proof . intros . set ( fs' := ischoicebasefiniteset sx _ fs ) .  apply ( hinhfun2 ( fun fx0 : ∏ x : X , finstruct ( P x )  => fun sx0 : _ => finstructontotal2 P sx0 fx0 ) fs' sx ) .  Defined .
 
 Definition isfinitedirprod { X Y : UU } ( sx : isfinite X ) ( sy : isfinite Y ) : isfinite ( dirprod X Y ) := hinhfun2 ( fun sx0 : _ => fun sy0 : _ => finstructondirprod sx0 sy0 ) sx sy .
 
@@ -232,8 +232,8 @@ Definition isfinitedecsubset { X : UU } ( f : X -> bool ) ( sx : isfinite X ) : 
 
 Definition isfinitefun { X Y : UU } ( sx : isfinite X ) ( sy : isfinite Y ) : isfinite ( X -> Y ) := hinhfun2 ( fun sx0 : _ => fun sy0 : _ => finstructonfun sx0 sy0 ) sx sy .
 
-Definition isfiniteforall { X : UU } ( P : X -> UU ) ( sx : isfinite X ) ( fs : Π x : X , isfinite ( P x ) ) : isfinite ( Π x : X , P x ) .
-Proof . intros . set ( fs' := ischoicebasefiniteset sx _ fs ) .  apply ( hinhfun2 ( fun fx0 : Π x : X , finstruct ( P x )  => fun sx0 : _ => finstructonforall P sx0 fx0 ) fs' sx ) .  Defined .
+Definition isfiniteforall { X : UU } ( P : X -> UU ) ( sx : isfinite X ) ( fs : ∏ x : X , isfinite ( P x ) ) : isfinite ( ∏ x : X , P x ) .
+Proof . intros . set ( fs' := ischoicebasefiniteset sx _ fs ) .  apply ( hinhfun2 ( fun fx0 : ∏ x : X , finstruct ( P x )  => fun sx0 : _ => finstructonforall P sx0 fx0 ) fs' sx ) .  Defined .
 
 Definition isfiniteweq { X : UU } ( sx : isfinite X ) : isfinite ( weq X X ) := hinhfun ( fun sx0 : _ =>  finstructonweq sx0 ) sx .
 
@@ -278,7 +278,7 @@ Proof.
   unfold isfinite in fin.
   unfold finstruct in fin.
   unfold nelstruct in fin.
-  set (sum := λ (x : Σ n, stn n ≃ X), stnsum (f ∘ pr2 x)).
+  set (sum := λ (x : ∑ n, stn n ≃ X), stnsum (f ∘ pr2 x)).
   apply (squash_to_set isasetnat sum).
   { intros.
     induction x as [n x].

--- a/UniMath/Combinatorics/Lists.v
+++ b/UniMath/Combinatorics/Lists.v
@@ -54,7 +54,7 @@ Defined.
 Lemma list_ind_compute_2
       (P : list -> UU)
       (p0 : P nil)
-      (ind : Π (x : A) (xs : list), P xs -> P (x :: xs))
+      (ind : ∏ (x : A) (xs : list), P xs -> P (x :: xs))
       (x : A) (xs : list)
       (f := list_ind P p0 ind) :
   f (x::xs) = ind x xs (f xs).

--- a/UniMath/Combinatorics/Lists.v
+++ b/UniMath/Combinatorics/Lists.v
@@ -24,7 +24,7 @@ Section lists.
 Context {A : UU}.
 
 (** The type of lists *)
-Definition list : UU := Σ n, iterprod n A.
+Definition list : UU := ∑ n, iterprod n A.
 
 (** The empty list *)
 Definition nil : list := (0,,tt).
@@ -36,10 +36,10 @@ Definition cons (x : A) (xs : list) : list :=
 Local Notation "[]" := nil (at level 0, format "[]").
 Local Infix "::" := cons.
 
-Lemma list_ind : Π (P : list -> UU),
+Lemma list_ind : ∏ (P : list -> UU),
      P nil
-  -> (Π (x : A) (xs : list), P xs -> P (x :: xs))
-  -> Π xs, P xs.
+  -> (∏ (x : A) (xs : list), P xs -> P (x :: xs))
+  -> ∏ xs, P xs.
 Proof.
 intros P Hnil Hcons xs.
 induction xs as [n xs].

--- a/UniMath/Combinatorics/OrderedSets.v
+++ b/UniMath/Combinatorics/OrderedSets.v
@@ -33,7 +33,7 @@ Definition tallyStandardSubset {n} (P: DecidableSubtype (stn n)) : stn (S n).
 Proof. intros. exists (stnsum (λ x, choice (P x) 1 0)). apply natlehtolthsn.
        apply (istransnatleh (m := stnsum(λ _ : stn n, 1))).
        { apply stnsum_le; intro i. apply bound01. }
-       assert ( p : Π r s, r = s -> (r ≤ s)%nat). { intros ? ? e. destruct e. apply isreflnatleh. }
+       assert ( p : ∏ r s, r = s -> (r ≤ s)%nat). { intros ? ? e. destruct e. apply isreflnatleh. }
        apply p. apply stnsum_1.
 Defined.
 
@@ -51,7 +51,7 @@ Defined.
 (* types and univalence *)
 
 Theorem UU_rect (X Y : UU) (P : X ≃ Y -> UU) :
-  (Π e : X=Y, P (univalence _ _ e)) -> Π f, P f.
+  (∏ e : X=Y, P (univalence _ _ e)) -> ∏ f, P f.
 Proof.
   intros ? ? ? ih ?.
   set (p := ih (invmap (univalence _ _) f)).
@@ -62,7 +62,7 @@ Defined.
 Ltac type_induction f e := generalize f; apply UU_rect; intro e; clear f.
 
 Theorem hSet_rect (X Y : hSet) (P : X ≃ Y -> UU) :
-  (Π e : X=Y, P (hSet_univalence _ _ e)) -> Π f, P f.
+  (∏ e : X=Y, P (hSet_univalence _ _ e)) -> ∏ f, P f.
 Proof.
   intros ? ? ? ih ?.
   Set Printing Coercions.
@@ -152,14 +152,14 @@ Proof. reflexivity. Defined.
                   pathToEq : (X=Y) -> PosetEquivalence X Y.
 
     PosetEquivalence_rect
-         : Π (X Y : Poset) (P : PosetEquivalence X Y -> Type),
-           (Π e : X = Y, P (pathToEq X Y e)) ->
-           Π p : PosetEquivalence X Y, P p
+         : ∏ (X Y : Poset) (P : PosetEquivalence X Y -> Type),
+           (∏ e : X = Y, P (pathToEq X Y e)) ->
+           ∏ p : PosetEquivalence X Y, P p
 
 *)
 
 Theorem PosetEquivalence_rect (X Y : Poset) (P : X ≅ Y -> UU) :
-  (Π e : X = Y, P (Poset_univalence_map e)) -> Π f, P f.
+  (∏ e : X = Y, P (Poset_univalence_map e)) -> ∏ f, P f.
 Proof.
   intros ? ? ? ih ?.
   set (p := ih (invmap (Poset_univalence _ _) f)).
@@ -194,7 +194,7 @@ Defined.
 
 (** see Bourbaki, Set Theory, III.1, where they are called totally ordered sets *)
 
-Definition OrderedSet := Σ X:Poset, istotal (posetRelation X).
+Definition OrderedSet := ∑ X:Poset, istotal (posetRelation X).
 
 Ltac unwrap_OrderedSet X :=
   induction X as [X total];
@@ -246,7 +246,7 @@ Proof. intros ? i ? ?. apply isdeceq_isdec_ordering. now apply isfinite_isdeceq.
 Defined.
 
 Corollary isdeceq_isdec_lessthan (X:OrderedSet) :
-  isdeceq X -> Π (x y:X), decidable (x < y).
+  isdeceq X -> ∏ (x y:X), decidable (x < y).
 Proof.
   intros ? i ? ?. apply decidable_dirprod.
   - now apply isdeceq_isdec_ordering.
@@ -256,7 +256,7 @@ Proof.
     * apply i.
 Defined.
 
-Corollary isfinite_isdec_lessthan (X:OrderedSet) : isfinite X -> Π (x y:X), decidable (x < y).
+Corollary isfinite_isdec_lessthan (X:OrderedSet) : isfinite X -> ∏ (x y:X), decidable (x < y).
 Proof. intros ? i ? ?. apply isdeceq_isdec_lessthan. now apply isfinite_isdeceq.
 Defined.
 
@@ -278,7 +278,7 @@ Proof. intros. exact ((Poset_univalence _ _) ∘ (underlyingPoset_weq _ _))%weq.
 Defined.
 
 Theorem OrderedSetEquivalence_rect (X Y : OrderedSet) (P : X ≅ Y -> UU) :
-  (Π e : X = Y, P (OrderedSet_univalence _ _ e)) -> Π f, P f.
+  (∏ e : X = Y, P (OrderedSet_univalence _ _ e)) -> ∏ f, P f.
 Proof.
   intros ? ? ? ih ?.
   set (p := ih (invmap (OrderedSet_univalence _ _) f)).
@@ -290,7 +290,7 @@ Ltac oset_induction f e := generalize f; apply OrderedSetEquivalence_rect; intro
 
 (* standard ordered sets *)
 
-Definition FiniteOrderedSet := Σ X:OrderedSet, isfinite X.
+Definition FiniteOrderedSet := ∑ X:OrderedSet, isfinite X.
 Definition underlyingOrderedSet (X:FiniteOrderedSet) : OrderedSet := pr1 X.
 Coercion underlyingOrderedSet : FiniteOrderedSet >-> OrderedSet.
 Definition finitenessProperty (X:FiniteOrderedSet) : isfinite X := pr2 X.
@@ -399,21 +399,21 @@ Close Scope foset.
 
 Definition lexicographicOrder
            (X:hSet) (Y:X->hSet)
-           (R:hrel X) (S : Π x, hrel (Y x)) : hrel (Σ x, Y x)%set.
+           (R:hrel X) (S : ∏ x, hrel (Y x)) : hrel (∑ x, Y x)%set.
   intros ? ? ? ? u u'.
   set (x := pr1 u). set (y := pr2 u). set (x' := pr1 u'). set (y' := pr2 u').
   exact ((x != x' ∧ R x x') ∨ (∃ e : x = x', S x' (transportf Y e y) y'))%set.
 Defined.
 
-Lemma lex_isrefl (X:hSet) (Y:X->hSet) (R:hrel X) (S : Π x, hrel (Y x)) :
-  (Π x, isrefl(S x)) -> isrefl (lexicographicOrder X Y R S).
+Lemma lex_isrefl (X:hSet) (Y:X->hSet) (R:hrel X) (S : ∏ x, hrel (Y x)) :
+  (∏ x, isrefl(S x)) -> isrefl (lexicographicOrder X Y R S).
 Proof.
   intros ? ? ? ? Srefl u. induction u as [x y]. apply hdisj_in2; simpl.
   apply hinhpr. exists (idpath x). apply Srefl.
 Defined.
 
-Lemma lex_istrans (X:hSet) (Y:X->hSet) (R:hrel X) (S : Π x, hrel (Y x)) :
-  isantisymm R -> istrans R -> (Π x, istrans(S x)) -> istrans (lexicographicOrder X Y R S).
+Lemma lex_istrans (X:hSet) (Y:X->hSet) (R:hrel X) (S : ∏ x, hrel (Y x)) :
+  isantisymm R -> istrans R -> (∏ x, istrans(S x)) -> istrans (lexicographicOrder X Y R S).
 Proof.
   intros ? ? ? ? Ranti Rtrans Strans u u' u'' p q.
   induction u as [x y]. induction u' as [x' y']. induction u'' as [x'' y''].
@@ -450,8 +450,8 @@ Defined.
 Local Ltac unwrap a := apply (squash_to_prop a);
     [ apply isaset_total2_hSet | simpl; clear a; intro a; simpl in a ].
 
-Lemma lex_isantisymm (X:hSet) (Y:X->hSet) (R:hrel X) (S : Π x, hrel (Y x)) :
-  isantisymm R -> (Π x, isantisymm(S x)) -> isantisymm (lexicographicOrder X Y R S).
+Lemma lex_isantisymm (X:hSet) (Y:X->hSet) (R:hrel X) (S : ∏ x, hrel (Y x)) :
+  isantisymm R -> (∏ x, isantisymm(S x)) -> isantisymm (lexicographicOrder X Y R S).
 Proof.
   intros ? ? ? ? Ranti Santi u u' a b.
   induction u as [x y]; induction u' as [x' y'].
@@ -467,8 +467,8 @@ Proof.
     { apply (Santi x' y y' s s'). }
     induction t. reflexivity. Defined.
 
-Lemma lex_istotal (X:hSet) (Y:X->hSet) (R:hrel X) (S : Π x, hrel (Y x)) :
-  isdeceq X -> istotal R -> (Π x, istotal(S x)) -> istotal (lexicographicOrder X Y R S).
+Lemma lex_istotal (X:hSet) (Y:X->hSet) (R:hrel X) (S : ∏ x, hrel (Y x)) :
+  isdeceq X -> istotal R -> (∏ x, istotal(S x)) -> istotal (lexicographicOrder X Y R S).
 Proof.
   intros ? ? ? ? Xdec Rtot Stot u u'. induction u as [x y]. induction u' as [x' y'].
   induction (Xdec x x') as [eq|ne].
@@ -489,7 +489,7 @@ Proof.
   {
     simple refine (_,,_).
     { simple refine (_,,_).
-      { exact (Σ x, Y x)%set. }
+      { exact (∑ x, Y x)%set. }
       simple refine (_,,_).
       { apply lexicographicOrder. apply posetRelation. intro. apply posetRelation. }
       split.
@@ -512,13 +512,13 @@ Proof.
   intro; apply finitenessProperty.
 Defined.
 
-Notation "'Σ'  x .. y , P" := (concatenateFiniteOrderedSets (fun x => .. (concatenateFiniteOrderedSets (fun y => P)) ..))
+Notation "'∑'  x .. y , P" := (concatenateFiniteOrderedSets (fun x => .. (concatenateFiniteOrderedSets (fun y => P)) ..))
   (at level 200, x binder, y binder, right associativity) : foset.
-  (* type this in emacs in agda-input method with \Sigma *)
+  (* type this in emacs in agda-input method with \sum *)
 
 (** sorting finite ordered sets *)
 
-Definition FiniteStructure (X:OrderedSet) := Σ n, ⟦ n ⟧ %foset ≅ X.
+Definition FiniteStructure (X:OrderedSet) := ∑ n, ⟦ n ⟧ %foset ≅ X.
 
 Local Lemma std_auto n : iscontr (⟦ n ⟧ ≅ ⟦ n ⟧) %foset.
 Proof.
@@ -570,26 +570,26 @@ Abort.
 Open Scope logic.
 
 Definition isLattice {X:hSet} (le:hrel X) (min max:binop X) :=
-  Σ po : isPartialOrder le,
-  Σ lub : Π x y z, le x z ∧ le y z <-> le (max x y) z,
-  Σ glb : Π x y t, le t x ∧ le t y <-> le t (min x y),
+  ∑ po : isPartialOrder le,
+  ∑ lub : ∏ x y z, le x z ∧ le y z <-> le (max x y) z,
+  ∑ glb : ∏ x y t, le t x ∧ le t y <-> le t (min x y),
   unit.
 
 Definition istrans2 {X:hSet} (le lt:hrel X) :=
-  Σ transltle: Π x y z, lt x y -> le y z -> lt x z,
-  Σ translelt: Π x y z, le x y -> lt y z -> lt x z,
+  ∑ transltle: ∏ x y z, lt x y -> le y z -> lt x z,
+  ∑ translelt: ∏ x y z, le x y -> lt y z -> lt x z,
   unit.
 
-Definition iswklin {X} (lt:hrel X) := Π x y z, lt x y -> lt x z ∨ lt z y.
+Definition iswklin {X} (lt:hrel X) := ∏ x y z, lt x y -> lt x z ∨ lt z y.
 
 Definition isComputablyOrdered {X:hSet}
            (lt:hrel X) (min max:binop X) :=
   let le x y := ¬ lt y x in
-  Σ latt: isLattice le min max,
-  Σ trans2: istrans2 le lt,
-  Σ translt: istrans lt,
-  Σ irrefl: isirrefl lt,
-  Σ cotrans: iscotrans lt,
+  ∑ latt: isLattice le min max,
+  ∑ trans2: istrans2 le lt,
+  ∑ translt: istrans lt,
+  ∑ irrefl: isirrefl lt,
+  ∑ cotrans: iscotrans lt,
   unit.
 
 Local Ltac expand ic :=

--- a/UniMath/Combinatorics/StandardFiniteSets.v
+++ b/UniMath/Combinatorics/StandardFiniteSets.v
@@ -19,7 +19,7 @@ Require Export UniMath.Foundations.NaturalNumbers .
 
 (** ** Standard finite sets [ stn ] . *)
 
-Definition stn ( n : nat ) := Σ m, m < n.
+Definition stn ( n : nat ) := ∑ m, m < n.
 Definition stnpair n m (l:m<n) := (m,,l) : stn n.
 Definition stntonat ( n : nat ) : stn n -> nat := @pr1 _ _ .
 Coercion stntonat : stn >-> nat .
@@ -273,7 +273,7 @@ Definition weqdnicompl n (i:stn(S n)): stn n ≃ stn_compl i.
 Proof.
   intros.
   set (w := weqdicompl (stntonat _ i)).
-  assert (eq : Π j, j < n <-> pr1 (w j) < S n).
+  assert (eq : ∏ j, j < n <-> pr1 (w j) < S n).
   { simpl in w. intros j. unfold w.
     change (pr1 ((weqdicompl i) j)) with (di (stntonat _ i) j).
     unfold di.
@@ -403,7 +403,7 @@ Proof. set ( f := fun x : stn 1 => tt ) . apply weqcontrcontr .  split with ( la
 Corollary iscontrstn1 : iscontr ( stn 1 ) .
 Proof. apply iscontrifweqtounit . apply weqstn1tounit . Defined .
 
-Corollary isconnectedstn1 : Π i1 i2 : stn 1, i1 = i2.
+Corollary isconnectedstn1 : ∏ i1 i2 : stn 1, i1 = i2.
 Proof.
   intros i1 i2.
   apply (invmaponpathsweq weqstn1tounit).
@@ -415,8 +415,8 @@ Proof. intros . apply ( isinclbetweensets f ( isasetstn 1 ) is ) . intros x x' e
 
 Definition weqstn2tobool : weq ( stn 2 ) bool .
 Proof. set ( f := fun j : stn 2 => match ( isdeceqnat j 0 ) with ii1 _ => false | ii2 _ => true end ) . set ( g := fun b : bool => match b with false => stnpair 2 0 ( idpath true ) | true => stnpair 2 1 ( idpath true ) end ) .  split with f .
-assert ( egf : Π j : _ , paths ( g ( f j ) ) j ) . intro j . unfold f .  destruct ( isdeceqnat j 0 ) as [ e | ne ] .  apply ( invmaponpathsincl _ ( isinclstntonat 2 ) ) . rewrite e .   apply idpath .  apply ( invmaponpathsincl _ ( isinclstntonat 2 ) ) . destruct j as [ j l ] . simpl . set ( l' := natlthtolehsn _ _ l ) .  destruct ( natlehchoice _ _ l' ) as [ l'' | e ] . simpl in ne . destruct  ( ne ( natlth1tois0 _ l'' ) ) .  apply ( pathsinv0 ( invmaponpathsS _ _ e ) ) .
-assert ( efg : Π b : _ , paths ( f ( g b ) ) b ) . intro b .  unfold g .  destruct b . apply idpath . apply idpath.
+assert ( egf : ∏ j : _ , paths ( g ( f j ) ) j ) . intro j . unfold f .  destruct ( isdeceqnat j 0 ) as [ e | ne ] .  apply ( invmaponpathsincl _ ( isinclstntonat 2 ) ) . rewrite e .   apply idpath .  apply ( invmaponpathsincl _ ( isinclstntonat 2 ) ) . destruct j as [ j l ] . simpl . set ( l' := natlthtolehsn _ _ l ) .  destruct ( natlehchoice _ _ l' ) as [ l'' | e ] . simpl in ne . destruct  ( ne ( natlth1tois0 _ l'' ) ) .  apply ( pathsinv0 ( invmaponpathsS _ _ e ) ) .
+assert ( efg : ∏ b : _ , paths ( f ( g b ) ) b ) . intro b .  unfold g .  destruct b . apply idpath . apply idpath.
 apply ( gradth _ _ egf efg ) . Defined .
 
 Lemma isinjstntonat n : isInjectiveFunction (pr1 : stnset n -> natset).
@@ -462,7 +462,7 @@ Proof.
 Defined.
 
 Lemma weqfromcoprodofstn_eq1 (n m : nat) :
-  Π x : stn n ⨿ stn m, weqfromcoprodofstn_invmap n m (weqfromcoprodofstn_map n m x) = x.
+  ∏ x : stn n ⨿ stn m, weqfromcoprodofstn_invmap n m (weqfromcoprodofstn_map n m x) = x.
 Proof.
   intros n m x.
   unfold weqfromcoprodofstn_map, weqfromcoprodofstn_invmap. unfold coprod_rect.
@@ -480,7 +480,7 @@ Proof.
 Qed.
 
 Lemma weqfromcoprodofstn_eq2 (n m : nat) :
-  Π y : stn (n + m), weqfromcoprodofstn_map n m (weqfromcoprodofstn_invmap n m y) = y.
+  ∏ y : stn (n + m), weqfromcoprodofstn_map n m (weqfromcoprodofstn_invmap n m y) = y.
 Proof.
   intros n m x.
   unfold weqfromcoprodofstn_map, weqfromcoprodofstn_invmap. unfold coprod_rect.
@@ -554,7 +554,7 @@ Lemma transport_stnsum {m n} (e:m=n) (g:stn n->nat) :
   stnsum g = stnsum (λ i, g(transportf stn e i)).
 Proof. intros. induction e. reflexivity. Defined.
 
-Lemma stnsum_le {n} (f g:stn n->nat) : (Π i, f i ≤ g i) -> stnsum f ≤ stnsum g.
+Lemma stnsum_le {n} (f g:stn n->nat) : (∏ i, f i ≤ g i) -> stnsum f ≤ stnsum g.
 Proof.
   intros ? ? ? le. induction n as [|n IH]. { simpl. reflexivity. }
   apply natlehandplus. { apply IH. intro i. apply le. } apply le.
@@ -658,7 +658,7 @@ Proof.
   apply (istransnatleh W); clear W. apply natlehnplusnm.
 Defined.
 
-Definition weqstnsum_invmap { n : nat } (f : stn n -> nat) : (Σ i, stn (f i)) <- stn (stnsum f).
+Definition weqstnsum_invmap { n : nat } (f : stn n -> nat) : (∑ i, stn (f i)) <- stn (stnsum f).
 Proof.
   intros ? ?. induction n as [|n IH].
   { intros l. induction (negstn0 l). }
@@ -686,7 +686,7 @@ Proof.
   apply natplusr0.
 Defined.
 
-Definition weqstnsum_map { n : nat } (f : stn n -> nat) : (Σ i, stn (f i)) -> stn (stnsum f).
+Definition weqstnsum_map { n : nat } (f : stn n -> nat) : (∑ i, stn (f i)) -> stn (stnsum f).
 Proof.
   intros ? ? ij; induction ij as [i j]; induction i as [i I]; induction j as [j J].
   (* assert (I' := natlthtoleh _ _ I). *)
@@ -709,7 +709,7 @@ Proof.
   exact (natlthlehtrans j _ _ M K).
 Defined.
 
-Theorem weqstnsum1 { n : nat } (f : stn n -> nat) : (Σ i, stn (f i)) ≃ stn (stnsum f).
+Theorem weqstnsum1 { n : nat } (f : stn n -> nat) : (∑ i, stn (f i)) ≃ stn (stnsum f).
 Proof.
   intros. induction n as [ | n IHn ].
   { simpl. apply weqtoempty2. { exact pr1. } exact negstn0. }
@@ -722,25 +722,25 @@ Proof.
 Defined.
 
 Theorem weqstnsum { n : nat } (P : stn n -> UU) (f : stn n -> nat) :
-  (Π i, stn (f i) ≃ P i) -> total2 P ≃ stn (stnsum f).
+  (∏ i, stn (f i) ≃ P i) -> total2 P ≃ stn (stnsum f).
 Proof.
   intros ? ? ? w.
-  intermediate_weq (Σ i, stn (f i)).
+  intermediate_weq (∑ i, stn (f i)).
   - apply invweq. now apply weqfibtototal.
   - apply weqstnsum1.
 Defined.
 
-Corollary weqstnsum2 { X : UU } ( n : nat ) ( f : stn n -> nat ) ( g : X -> stn n ) ( ww : Π i : stn n , weq ( stn ( f i ) ) ( hfiber g i ) ) : weq X ( stn ( stnsum f ) ) .
+Corollary weqstnsum2 { X : UU } ( n : nat ) ( f : stn n -> nat ) ( g : X -> stn n ) ( ww : ∏ i : stn n , weq ( stn ( f i ) ) ( hfiber g i ) ) : weq X ( stn ( stnsum f ) ) .
 Proof. intros . assert ( w : weq X ( total2 ( fun i : stn n => hfiber g i ) ) ) . apply weqtococonusf . apply ( weqcomp w ( weqstnsum ( fun i : stn n => hfiber g i ) f ww ) ) .   Defined .
 
 (** lexical enumeration of pairs of natural numbers *)
 
-Definition lexicalEnumeration {n} (m:stn n->nat) := invweq (weqstnsum1 m) : stn (stnsum m) ≃ (Σ i : stn n, stn (m i)).
-Definition inverse_lexicalEnumeration {n} (m:stn n->nat) := weqstnsum1 m : (Σ i : stn n, stn (m i)) ≃ stn (stnsum m).
+Definition lexicalEnumeration {n} (m:stn n->nat) := invweq (weqstnsum1 m) : stn (stnsum m) ≃ (∑ i : stn n, stn (m i)).
+Definition inverse_lexicalEnumeration {n} (m:stn n->nat) := weqstnsum1 m : (∑ i : stn n, stn (m i)) ≃ stn (stnsum m).
 
-Definition lex_curry {X n} (m:stn n->nat) : (stn (stnsum m) -> X) -> (Π (i:stn n), stn (m i) -> X).
+Definition lex_curry {X n} (m:stn n->nat) : (stn (stnsum m) -> X) -> (∏ (i:stn n), stn (m i) -> X).
 Proof. intros ? ? ? f ? j. exact (f (inverse_lexicalEnumeration m (i,,j))). Defined.
-Definition lex_uncurry {X n} (m:stn n->nat) : (Π (i:stn n), stn (m i) -> X) -> (stn (stnsum m) -> X).
+Definition lex_uncurry {X n} (m:stn n->nat) : (∏ (i:stn n), stn (m i) -> X) -> (stn (stnsum m) -> X).
 Proof. intros ? ? ? g ij. exact (uncurry g (lexicalEnumeration m ij)). Defined.
 
 (** two generalizations of stnsum, potentially useful *)
@@ -767,7 +767,7 @@ Theorem weqfromprodofstn ( n m : nat ) : stn n × stn m ≃ stn (n * m).
 Proof.
   intros.
   induction ( natgthorleh m 0 ) as [ is | i ] .
-  - assert ( i1 : Π i j : nat, i < n -> j < m -> j + i * m < n * m).
+  - assert ( i1 : ∏ i j : nat, i < n -> j < m -> j + i * m < n * m).
     + intros i j li lj.
       apply (natlthlehtrans ( j + i * m ) ( ( S i ) * m ) ( n * m )).
       * change (S i * m) with (i*m + m).
@@ -815,7 +815,7 @@ Defined.
 Theorem weqfromdecsubsetofstn { n : nat } ( f : stn n -> bool ) : total2 ( fun x : nat => weq ( hfiber f true ) ( stn x ) ) .
 Proof . intro . induction n as [ | n IHn ] . intros .    split with 0 .  assert ( g : ( hfiber f true ) -> ( stn 0 ) ) . intro hf . destruct hf as [ i e ] .  destruct ( weqstn0toempty i ) .  apply ( weqtoempty2 g weqstn0toempty ) . intro . set ( g := weqfromcoprodofstn 1 n ) .   change ( 1 + n ) with ( S n ) in g .
 
-set ( fl := fun i : stn 1 => f ( g ( ii1 i ) ) ) .   set ( fh := fun i : stn n => f ( g ( ii2 i ) ) ) . assert ( w : weq ( hfiber f true ) ( hfiber ( sumofmaps fl fh ) true ) ) .  set ( int := invweq ( weqhfibersgwtog g f true  ) ) .  assert ( h : Π x : _ , paths ( f ( g x ) ) ( sumofmaps fl fh x ) ) . intro . destruct x as [ x1 | xn ] . apply idpath . apply idpath .   apply ( weqcomp int ( weqhfibershomot _ _ h true ) ) .  set ( w' := weqcomp w ( invweq ( weqhfibersofsumofmaps fl fh true ) ) ) .
+set ( fl := fun i : stn 1 => f ( g ( ii1 i ) ) ) .   set ( fh := fun i : stn n => f ( g ( ii2 i ) ) ) . assert ( w : weq ( hfiber f true ) ( hfiber ( sumofmaps fl fh ) true ) ) .  set ( int := invweq ( weqhfibersgwtog g f true  ) ) .  assert ( h : ∏ x : _ , paths ( f ( g x ) ) ( sumofmaps fl fh x ) ) . intro . destruct x as [ x1 | xn ] . apply idpath . apply idpath .   apply ( weqcomp int ( weqhfibershomot _ _ h true ) ) .  set ( w' := weqcomp w ( invweq ( weqhfibersofsumofmaps fl fh true ) ) ) .
 
 set ( x0 := pr1 ( IHn fh ) ) . set ( w0 := pr2 ( IHn fh ) ) . simpl in w0 . destruct ( boolchoice ( fl ( lastelement 0 ) ) ) as [ i | ni ] .
 
@@ -861,7 +861,7 @@ Proof.
   apply (maponpaths (λ i, i * f (lastelement _))). apply IH. intro x. apply h.
 Defined.
 
-Theorem weqstnprod { n : nat } ( P : stn n -> UU ) ( f : stn n -> nat ) ( ww : Π i : stn n , weq ( stn ( f i ) )  ( P i ) ) : weq ( Π x : stn n , P x  ) ( stn ( stnprod f ) ) .
+Theorem weqstnprod { n : nat } ( P : stn n -> UU ) ( f : stn n -> nat ) ( ww : ∏ i : stn n , weq ( stn ( f i ) )  ( P i ) ) : weq ( ∏ x : stn n , P x  ) ( stn ( stnprod f ) ) .
 Proof .
   intro n .
   induction n as [ | n IHn ] .
@@ -956,11 +956,11 @@ Proof. intros n n' X. apply (eqfromdnegeq nat isdeceqnat _ _  (dnegf (@weqtoeqst
 (** ** Some results on bounded quantification *)
 
 
-Lemma weqforallnatlehn0 ( F : nat -> hProp ) : weq ( Π n : nat , natleh n 0 -> F n ) ( F 0 ) .
-Proof . intros .  assert ( lg : ( Π n : nat , natleh n 0 -> F n ) <-> ( F 0 ) ) . split . intro f .  apply ( f 0 ( isreflnatleh 0 ) ) .  intros f0 n l .  set ( e := natleh0tois0 l ) .  rewrite e .  apply f0 . assert ( is1 : isaprop ( Π n : nat , natleh n 0 -> F n ) ) . apply impred . intro n . apply impred .   intro l .  apply ( pr2 ( F n ) ) .  apply ( weqimplimpl ( pr1 lg ) ( pr2 lg ) is1 ( pr2 ( F 0 ) ) ) . Defined .
+Lemma weqforallnatlehn0 ( F : nat -> hProp ) : weq ( ∏ n : nat , natleh n 0 -> F n ) ( F 0 ) .
+Proof . intros .  assert ( lg : ( ∏ n : nat , natleh n 0 -> F n ) <-> ( F 0 ) ) . split . intro f .  apply ( f 0 ( isreflnatleh 0 ) ) .  intros f0 n l .  set ( e := natleh0tois0 l ) .  rewrite e .  apply f0 . assert ( is1 : isaprop ( ∏ n : nat , natleh n 0 -> F n ) ) . apply impred . intro n . apply impred .   intro l .  apply ( pr2 ( F n ) ) .  apply ( weqimplimpl ( pr1 lg ) ( pr2 lg ) is1 ( pr2 ( F 0 ) ) ) . Defined .
 
-Lemma weqforallnatlehnsn' ( n' : nat ) ( F : nat -> hProp ) : weq ( Π n : nat , natleh n ( S n' ) -> F n ) ( dirprod ( Π n : nat , natleh n n' -> F n ) ( F ( S n' ) ) ) .
-Proof . intros . assert ( lg : ( Π n : nat , natleh n ( S n' ) -> F n ) <-> dirprod ( Π n : nat , natleh n n' -> F n ) ( F ( S n' ) ) ) .  split . intro f.  apply ( dirprodpair ( fun n => fun l => ( f n ( natlehtolehs _ _ l ) ) ) ( f ( S n' ) ( isreflnatleh _ ) ) ) .  intro d2 . intro n .  intro l .  destruct ( natlehchoice2 _ _ l ) as [ h | e ] . simpl in h .  apply ( pr1 d2 n h ) . destruct d2 as [ f2 d2 ] .  rewrite e .  apply d2 . assert ( is1 : isaprop ( Π n : nat , natleh n ( S n' ) -> F n ) ) . apply impred . intro n . apply impred . intro l . apply ( pr2 ( F n ) ) . assert ( is2 : isaprop ( dirprod ( Π n : nat , natleh n n' -> F n ) ( F ( S n' ) ) ) ) . apply isapropdirprod . apply impred . intro n . apply impred . intro l . apply ( pr2 ( F n ) ) .   apply ( pr2 ( F ( S n' ) ) ) .  apply ( weqimplimpl ( pr1 lg ) ( pr2 lg ) is1 is2 ) . Defined .
+Lemma weqforallnatlehnsn' ( n' : nat ) ( F : nat -> hProp ) : weq ( ∏ n : nat , natleh n ( S n' ) -> F n ) ( dirprod ( ∏ n : nat , natleh n n' -> F n ) ( F ( S n' ) ) ) .
+Proof . intros . assert ( lg : ( ∏ n : nat , natleh n ( S n' ) -> F n ) <-> dirprod ( ∏ n : nat , natleh n n' -> F n ) ( F ( S n' ) ) ) .  split . intro f.  apply ( dirprodpair ( fun n => fun l => ( f n ( natlehtolehs _ _ l ) ) ) ( f ( S n' ) ( isreflnatleh _ ) ) ) .  intro d2 . intro n .  intro l .  destruct ( natlehchoice2 _ _ l ) as [ h | e ] . simpl in h .  apply ( pr1 d2 n h ) . destruct d2 as [ f2 d2 ] .  rewrite e .  apply d2 . assert ( is1 : isaprop ( ∏ n : nat , natleh n ( S n' ) -> F n ) ) . apply impred . intro n . apply impred . intro l . apply ( pr2 ( F n ) ) . assert ( is2 : isaprop ( dirprod ( ∏ n : nat , natleh n n' -> F n ) ( F ( S n' ) ) ) ) . apply isapropdirprod . apply impred . intro n . apply impred . intro l . apply ( pr2 ( F n ) ) .   apply ( pr2 ( F ( S n' ) ) ) .  apply ( weqimplimpl ( pr1 lg ) ( pr2 lg ) is1 is2 ) . Defined .
 
 Lemma weqexistsnatlehn0 ( P : nat -> hProp  ) : weq ( hexists ( fun n : nat => dirprod ( natleh n 0 ) ( P n ) ) ) ( P 0 ) .
 Proof . intro . assert ( lg : hexists ( fun n : nat => dirprod ( natleh n 0 ) ( P n ) ) <-> P 0  ) . split .  simpl . apply ( @hinhuniv _ ( P 0 ) ) .  intro t2 .  destruct t2 as [ n d2 ] . destruct d2 as [ l p ] . set ( e := natleh0tois0 l ) . clearbody e .  destruct e . apply p . intro p . apply hinhpr . split with 0 .  split with ( isreflnatleh 0 ) .  apply p . apply ( weqimplimpl ( pr1 lg ) ( pr2 lg ) ( pr2 _ ) ( pr2 _ ) ) .  Defined .
@@ -969,31 +969,31 @@ Lemma weqexistsnatlehnsn' ( n' : nat ) ( P : nat -> hProp  ) : weq ( hexists ( f
 Proof . intros . assert ( lg : hexists ( fun n : nat => dirprod ( natleh n ( S n' ) ) ( P n ) )  <-> hdisj ( hexists ( fun n : nat => dirprod ( natleh n n' ) ( P n ) ) )  ( P ( S n' ) )  ) . split . apply hinhfun .   intro t2 .  destruct t2 as [ n d2 ] . destruct d2 as [ l p ] . destruct ( natlehchoice2 _ _ l ) as [ h | nh ] . simpl in h . apply ii1 .  apply hinhpr . split with n .  apply ( dirprodpair h p ) . destruct nh .  apply ( ii2 p ) . simpl . apply ( @hinhuniv _ ( ishinh _ ) ) . intro c .  destruct c as [ t | p ] .  generalize t . simpl . apply hinhfun .  clear t . intro t . destruct t as [ n d2 ] . destruct d2 as [ l p ] . split with n .  split with ( natlehtolehs _ _ l ) .  apply p .  apply hinhpr . split with ( S n' ) .  split with ( isreflnatleh _ ) . apply p .  apply ( weqimplimpl ( pr1 lg ) ( pr2 lg ) ( pr2 _ ) ( pr2 _ ) ) .  Defined .
 
 
-Lemma isdecbexists ( n : nat ) ( P : nat -> UU ) ( is : Π n' , isdecprop ( P n' ) ) : isdecprop ( hexists ( fun n' => dirprod ( natleh n' n ) ( P n' ) ) ) .
+Lemma isdecbexists ( n : nat ) ( P : nat -> UU ) ( is : ∏ n' , isdecprop ( P n' ) ) : isdecprop ( hexists ( fun n' => dirprod ( natleh n' n ) ( P n' ) ) ) .
 Proof . intros .  set ( P' := fun n' : nat => hProppair _ ( is n' ) ) . induction n as [ | n IHn ] . apply ( isdecpropweqb ( weqexistsnatlehn0 P' ) ) . apply ( is 0 ) .   apply ( isdecpropweqb ( weqexistsnatlehnsn' _ P' ) ) . apply isdecprophdisj . apply IHn . apply ( is ( S n ) ) . Defined .
 
-Lemma isdecbforall ( n : nat ) ( P : nat -> UU ) ( is : Π n' , isdecprop ( P n' ) ) : isdecprop ( Π n' , natleh n' n -> P n' )  .
+Lemma isdecbforall ( n : nat ) ( P : nat -> UU ) ( is : ∏ n' , isdecprop ( P n' ) ) : isdecprop ( ∏ n' , natleh n' n -> P n' )  .
 Proof . intros .  set ( P' := fun n' : nat => hProppair _ ( is n' ) ) . induction n as [ | n IHn ] . apply ( isdecpropweqb ( weqforallnatlehn0 P' ) ) . apply ( is 0 ) .   apply ( isdecpropweqb ( weqforallnatlehnsn' _ P' ) ) . apply isdecpropdirprod . apply IHn . apply ( is ( S n ) ) . Defined .
 
 
 
-(** The following lemma finds the largest [ n' ] such that [ neg ( P n' ) ] . It is a stronger form of ( neg Π ) -> ( exists neg ) in the case of bounded quantification of decidable propositions. *)
+(** The following lemma finds the largest [ n' ] such that [ neg ( P n' ) ] . It is a stronger form of ( neg ∏ ) -> ( exists neg ) in the case of bounded quantification of decidable propositions. *)
 
-Lemma negbforalldectototal2neg ( n : nat ) ( P : nat -> UU ) ( is : Π n' : nat , isdecprop ( P n' ) ) : neg ( Π n' : nat , natleh n' n -> P n' ) -> total2 ( fun n' => dirprod ( natleh n' n ) ( neg ( P n' ) ) ) .
+Lemma negbforalldectototal2neg ( n : nat ) ( P : nat -> UU ) ( is : ∏ n' : nat , isdecprop ( P n' ) ) : neg ( ∏ n' : nat , natleh n' n -> P n' ) -> total2 ( fun n' => dirprod ( natleh n' n ) ( neg ( P n' ) ) ) .
 Proof . intros n P is . set ( P' := fun n' : nat => hProppair _ ( is n' ) ) . induction n as [ | n IHn ] . intro nf . set ( nf0 := negf ( invweq ( weqforallnatlehn0 P' ) ) nf ) . split with 0 . apply ( dirprodpair ( isreflnatleh 0 ) nf0 ) .   intro nf . set ( nf2 := negf ( invweq ( weqforallnatlehnsn' n P' ) ) nf ) . set ( nf3 := fromneganddecy ( is ( S n ) ) nf2 ) . destruct nf3 as [ f1 | f2 ] . set ( int := IHn f1 ) .  destruct int as [ n' d2 ] . destruct d2 as [ l np ] . split with n' .  split with ( natlehtolehs _ _ l ) .  apply np . split with ( S n ) . split with ( isreflnatleh _ ) . apply f2 .  Defined .
 
 
 (** ** Accessibility - the least element of an inhabited decidable subset of [nat] *)
 
-Definition natdecleast ( F : nat -> UU ) ( is : Π n , isdecprop ( F n ) ) := total2 ( fun  n : nat => dirprod ( F n ) ( Π n' : nat , F n' -> natleh n n' ) ) .
+Definition natdecleast ( F : nat -> UU ) ( is : ∏ n , isdecprop ( F n ) ) := total2 ( fun  n : nat => dirprod ( F n ) ( ∏ n' : nat , F n' -> natleh n n' ) ) .
 
-Lemma isapropnatdecleast ( F : nat -> UU ) ( is : Π n , isdecprop ( F n ) ) : isaprop ( natdecleast F is ) .
-Proof . intros . set ( P := fun n' : nat => hProppair _ ( is n' ) ) . assert ( int1 : Π n : nat, isaprop ( dirprod ( F n ) ( Π n' : nat , F n' -> natleh n n' ) ) ) .  intro n . apply isapropdirprod . apply ( pr2 ( P n ) ) .  apply impred . intro t .  apply impred .  intro .  apply ( pr2 ( natleh n t ) ) . set ( int2 := ( fun n : nat => hProppair _ ( int1 n ) ) : nat -> hProp ) .   change ( isaprop ( total2 int2 ) ) . apply isapropsubtype . intros x1 x2 .  intros c1 c2 . simpl in * . destruct c1 as [ e1 c1 ] . destruct c2 as [ e2 c2 ] . set ( l1 := c1 x2 e2 ) .  set ( l2 := c2 x1 e1 ) . apply ( isantisymmnatleh _ _ l1 l2 ) .  Defined .
+Lemma isapropnatdecleast ( F : nat -> UU ) ( is : ∏ n , isdecprop ( F n ) ) : isaprop ( natdecleast F is ) .
+Proof . intros . set ( P := fun n' : nat => hProppair _ ( is n' ) ) . assert ( int1 : ∏ n : nat, isaprop ( dirprod ( F n ) ( ∏ n' : nat , F n' -> natleh n n' ) ) ) .  intro n . apply isapropdirprod . apply ( pr2 ( P n ) ) .  apply impred . intro t .  apply impred .  intro .  apply ( pr2 ( natleh n t ) ) . set ( int2 := ( fun n : nat => hProppair _ ( int1 n ) ) : nat -> hProp ) .   change ( isaprop ( total2 int2 ) ) . apply isapropsubtype . intros x1 x2 .  intros c1 c2 . simpl in * . destruct c1 as [ e1 c1 ] . destruct c2 as [ e2 c2 ] . set ( l1 := c1 x2 e2 ) .  set ( l2 := c2 x1 e1 ) . apply ( isantisymmnatleh _ _ l1 l2 ) .  Defined .
 
-Theorem accth ( F : nat -> UU ) ( is : Π n , isdecprop ( F n ) )  ( is' : hexists F ) : natdecleast F is .
+Theorem accth ( F : nat -> UU ) ( is : ∏ n , isdecprop ( F n ) )  ( is' : hexists F ) : natdecleast F is .
 Proof . intros F is . simpl . apply (@hinhuniv _ ( hProppair _ ( isapropnatdecleast F is ) ) ) . intro t2. destruct t2 as [ n l ] . simpl .
 
-set ( F' := fun n' : nat => hexists ( fun n'' => dirprod ( natleh n'' n' ) ( F n'' ) ) ) .  assert ( X : Π n' , F' n' -> natdecleast F is ) .  intro n' .    induction n' as [ | n' IHn' ] . apply ( @hinhuniv _  ( hProppair _ ( isapropnatdecleast F is ) ) ) . intro t2 . destruct t2 as [ n'' is'' ] . destruct is'' as [ l'' d'' ] .  split with 0 .  split . set ( e := natleh0tois0 l'' ) . clearbody e . destruct e . apply d'' .  apply ( fun n' => fun f : _ => natleh0n n' ) .  apply ( @hinhuniv _  ( hProppair _ ( isapropnatdecleast F is ) ) ) . intro t2 .  destruct t2 as [ n'' is'' ] . set ( j := natlehchoice2 _ _ ( pr1 is'' ) ) .  destruct j as [ jl | je ] .  simpl .  apply ( IHn' ( hinhpr ( tpair _ n'' ( dirprodpair jl ( pr2 is'' ) ) ) ) ) .  simpl . rewrite je in is''  .  destruct is'' as [ nn is'' ] .  clear nn. clear je . clear n'' .
+set ( F' := fun n' : nat => hexists ( fun n'' => dirprod ( natleh n'' n' ) ( F n'' ) ) ) .  assert ( X : ∏ n' , F' n' -> natdecleast F is ) .  intro n' .    induction n' as [ | n' IHn' ] . apply ( @hinhuniv _  ( hProppair _ ( isapropnatdecleast F is ) ) ) . intro t2 . destruct t2 as [ n'' is'' ] . destruct is'' as [ l'' d'' ] .  split with 0 .  split . set ( e := natleh0tois0 l'' ) . clearbody e . destruct e . apply d'' .  apply ( fun n' => fun f : _ => natleh0n n' ) .  apply ( @hinhuniv _  ( hProppair _ ( isapropnatdecleast F is ) ) ) . intro t2 .  destruct t2 as [ n'' is'' ] . set ( j := natlehchoice2 _ _ ( pr1 is'' ) ) .  destruct j as [ jl | je ] .  simpl .  apply ( IHn' ( hinhpr ( tpair _ n'' ( dirprodpair jl ( pr2 is'' ) ) ) ) ) .  simpl . rewrite je in is''  .  destruct is'' as [ nn is'' ] .  clear nn. clear je . clear n'' .
 
 assert ( is' : isdecprop ( F' n' ) ) . apply ( isdecbexists n' F is ) .   destruct ( pr1 is' ) as [ f | nf ] .  apply ( IHn'  f ) .  split with ( S n' ) .  split with is'' . intros n0 fn0 . destruct ( natlthorgeh n0 ( S n' ) )  as [ l' | g' ] .  set ( i' := natlthtolehsn _ _ l' ) .  destruct ( nf ( hinhpr ( tpair _ n0 ( dirprodpair i' fn0 ) ) ) ) .   apply g' .
 
@@ -1011,7 +1011,7 @@ Proof.
   exact e.
 Defined.
 
-Corollary dni_lastelement_eq : Π (n : nat) (i : stn (S n)) (ie : pr1 i < n),
+Corollary dni_lastelement_eq : ∏ (n : nat) (i : stn (S n)) (ie : pr1 i < n),
     i = dni_lastelement (stnpair n (pr1 i) ie).
 Proof.
   intros n i ie.
@@ -1019,7 +1019,7 @@ Proof.
   apply idpath.
 Defined.
 
-Corollary lastelement_eq : Π (n : nat) (i : stn (S n)) (e : pr1 i = n),
+Corollary lastelement_eq : ∏ (n : nat) (i : stn (S n)) (e : pr1 i = n),
     i = lastelement n.
 Proof.
   intros n i e.
@@ -1038,23 +1038,23 @@ Ltac inductive_reflexivity i b :=
 
 (** general associativity for addition in nat *)
 
-Theorem nat_plus_associativity {n} {m:stn n->nat} (k:Π (ij : Σ i, stn (m i)), nat) :
+Theorem nat_plus_associativity {n} {m:stn n->nat} (k:∏ (ij : ∑ i, stn (m i)), nat) :
   stnsum (λ i, stnsum (curry k i)) = stnsum (k ∘ lexicalEnumeration m).
 Proof.
   intros. apply weqtoeqstn.
-  intermediate_weq (Σ i, stn (stnsum (curry k i))).
+  intermediate_weq (∑ i, stn (stnsum (curry k i))).
   { apply invweq. apply weqstnsum1. }
-  intermediate_weq (Σ i j, stn (curry k i j)).
+  intermediate_weq (∑ i j, stn (curry k i j)).
   { apply weqfibtototal; intro i. apply invweq. apply weqstnsum1. }
-  intermediate_weq (Σ ij, stn (k ij)).
+  intermediate_weq (∑ ij, stn (k ij)).
   { exact (weqtotal2asstol (stn ∘ m) (stn ∘ k)). }
-  intermediate_weq (Σ ij, stn (k (lexicalEnumeration m ij))).
+  intermediate_weq (∑ ij, stn (k (lexicalEnumeration m ij))).
   { apply (weqbandf (inverse_lexicalEnumeration m)). intro ij. apply eqweqmap.
     apply (maponpaths stn), (maponpaths k). apply pathsinv0, homotinvweqweq. }
   { apply inverse_lexicalEnumeration. }
 Defined.
 
-Corollary nat_plus_associativity' n (m:stn n->nat) (k:Π i, stn (m i) -> nat) :
+Corollary nat_plus_associativity' n (m:stn n->nat) (k:∏ i, stn (m i) -> nat) :
   stnsum (λ i, stnsum (k i)) = stnsum (uncurry k ∘ lexicalEnumeration m).
 Proof. intros. exact (nat_plus_associativity (uncurry k)). Defined.
 
@@ -1063,9 +1063,9 @@ Proof. intros. exact (nat_plus_associativity (uncurry k)). Defined.
 Theorem nat_plus_commutativity {n} (x:stn n -> nat)
         (f:stn n ≃ stn n) : stnsum x = stnsum (x∘f).
 Proof.
-  intros. apply weqtoeqstn. intermediate_weq (Σ i, stn (x i)).
+  intros. apply weqtoeqstn. intermediate_weq (∑ i, stn (x i)).
   { apply invweq. apply weqstnsum1. }
-  intermediate_weq (Σ i, stn (x(f i))).
+  intermediate_weq (∑ i, stn (x(f i))).
   { apply invweq. apply (weqfp _ (stn∘x)). }
   apply weqstnsum1.
 Defined.
@@ -1093,7 +1093,7 @@ Proof.
 Defined.
 
 Definition two_rec_dep (P : two -> UU):
-  P (● 0) -> P (● 1) -> Π n, P n.
+  P (● 0) -> P (● 1) -> ∏ n, P n.
 Proof.
   intros P a b n.
   induction n as [n p].
@@ -1115,7 +1115,7 @@ Proof.
 Defined.
 
 Definition three_rec_dep (P : three -> UU):
-  P (● 0) -> P (● 1) -> P (● 2) -> Π n, P n.
+  P (● 0) -> P (● 1) -> P (● 2) -> ∏ n, P n.
 Proof.
   intros P a b c n.
   induction n as [n p].

--- a/UniMath/Combinatorics/Tests.v
+++ b/UniMath/Combinatorics/Tests.v
@@ -13,7 +13,7 @@ Module Test_stn.
   Goal (stnel(6,3) ≠ stnel(6,4)). easy. Defined.
   Goal ¬(stnel(6,3) ≠ stnel(6,3)). easy. Defined.
 
-  Goal Π m n (i:m≤n) (j:stn m), pr1 (stnmtostnn m n i j) = pr1 j.
+  Goal ∏ m n (i:m≤n) (j:stn m), pr1 (stnmtostnn m n i j) = pr1 j.
     intros. induction j as [j J]. reflexivity.
   Defined.
 
@@ -138,15 +138,15 @@ Module Test_stn.
   End Test2.
 
   (* confirm that [stnsum] is associative in the same way as the parser, which is left associative *)
-  Goal Π (f : stn 3 -> nat), stnsum f =  f(●0) + f(●1)  +  f(●2). reflexivity. Defined.
-  Goal Π (f : stn 3 -> nat), stnsum f = (f(●0) + f(●1)) +  f(●2). reflexivity. Defined.
+  Goal ∏ (f : stn 3 -> nat), stnsum f =  f(●0) + f(●1)  +  f(●2). reflexivity. Defined.
+  Goal ∏ (f : stn 3 -> nat), stnsum f = (f(●0) + f(●1)) +  f(●2). reflexivity. Defined.
 
   Module Test_weqstnsum.
     (* this module exports nothing *)
     Let X := stnset 7.
     Let f (x:X) : nat := pr1 x.
 
-    Let h  : stn _ <- Σ x, stnset (f x) := weqstnsum_map f.
+    Let h  : stn _ <- ∑ x, stnset (f x) := weqstnsum_map f.
     Goal h(●1,,●0) = ●0. reflexivity. Defined.
     Goal h(●4,,●0) = ●6. reflexivity. Defined.
     Goal h(●1,,●0) = ●0. reflexivity. Defined.
@@ -159,7 +159,7 @@ Module Test_stn.
     Goal h(●5,,●0) = ●10. reflexivity. Defined.
     Goal h(●6,,●0) = ●15. reflexivity. Defined.
 
-    Let h' : stn _ -> Σ x, stnset (f x) := weqstnsum_invmap f.
+    Let h' : stn _ -> ∑ x, stnset (f x) := weqstnsum_invmap f.
     Goal h'(●0) = (●1,,●0). reflexivity. Defined.
     Goal h'(●1) = (●2,,●0). reflexivity. Defined.
     Goal h'(●2) = (●2,,●1). reflexivity. Defined.
@@ -176,7 +176,7 @@ Module Test_stn.
     (* this module exports nothing *)
     Let X := stnset 6.
     Let Y (x:X) := stnset (pr1 x).
-    Let W := Σ x, Y x.
+    Let W := ∑ x, Y x.
     Let w := (●3,,●2) : W.
     Let w' := (●4,,●2) : W.
     Let f : W ≃ stn 15 := weqstnsum1 _.
@@ -208,7 +208,7 @@ Module Test_stn.
   End Test_weqfromprodofstn.
 
   (* confirm that [stnprod] is associative in the same way as the parser *)
-  Goal Π (f : stn 3 -> nat), stnprod f = f(●0) * f(●1) * f(●2).
+  Goal ∏ (f : stn 3 -> nat), stnprod f = f(●0) * f(●1) * f(●2).
   Proof. reflexivity. Defined.
 
 
@@ -225,7 +225,7 @@ Module Test_stn.
           * contradicts (negnatlthn0 n) b.
     Defined.
 
-  Goal Π n, testfun n < 5.
+  Goal ∏ n, testfun n < 5.
     Proof.
       intros.
       induction n as [i c].
@@ -267,7 +267,7 @@ Module Test_fin.
   (* Eval compute in (carddneg _  (isfinitedirprod _ _ (isfinitestn (S (S (S (S O)))))  (isfinitestn (S (S (S O)))))). *)
   (* Eval lazy in   (pr1 (finitestructcomplement _ (dirprodpair _ _ tt tt) (finitestructdirprod _ _ (finitestructunit) (finitestructunit)))). *)
 
-  Goal Π X (fin : finstruct X) (f : X -> nat),
+  Goal ∏ X (fin : finstruct X) (f : X -> nat),
     finsum (hinhpr fin) f = stnsum (f ∘ pr1weq (pr2 fin)).
   Proof. reflexivity. Qed.
 
@@ -333,7 +333,7 @@ Module Test_fin.
     (* test isfinitetotal2 *)
 
     Let Y' (x:X) : hSet := Y.
-    Let W := Σ x, Y' x.
+    Let W := ∑ x, Y' x.
     Let eqW : DecidableRelation W :=
       isfinite_to_DecidableEquality (isfinitetotal2 Y' finX (λ _, finY)).
     Goal decide (eqW (x,,y) (x',,y')) = false.
@@ -341,7 +341,7 @@ Module Test_fin.
     Defined.
 
     (* test isfiniteforall *)
-    Let T := Π x, Y' x.
+    Let T := ∏ x, Y' x.
     Let eqT : DecidableRelation T :=
       isfinite_to_DecidableEquality (isfiniteforall Y' finX (λ _, finY)).
     Goal decide (eqT (λ _, y) (λ _, y)) = true.
@@ -387,7 +387,7 @@ Module Test_ord.
     Let R := λ (x x':X), (pr1 x ≤ pr1 x')%dnat.
     Let Y := λ x:X, stnset (pr1 x).
     Let S := λ (x:X) (y y':Y x), (pr1 y ≤ pr1 y')%dnat.
-    Let Z := Σ x, Y x.
+    Let Z := ∑ x, Y x.
     Let T := lexicographicOrder X Y R S.
 
     Let x2 := ●2 : X.
@@ -413,7 +413,7 @@ Module Test_ord.
 
     Goal choice (i < j)%foset true false = true. reflexivity. Defined.
 
-    Let X := (Σ i:⟦ 4 ⟧, ⟦ pr1 i ⟧)%foset.
+    Let X := (∑ i:⟦ 4 ⟧, ⟦ pr1 i ⟧)%foset.
     Let x := ( ●2 ,, ●1 ):X.
     Let y := ( ●3 ,, ●1 ):X.
 
@@ -442,7 +442,7 @@ Module Test_ord.
 
   End TestLex2.
 
-  Goal Π X (lt:hrel X), iscotrans lt <-> iswklin lt.
+  Goal ∏ X (lt:hrel X), iscotrans lt <-> iswklin lt.
   Proof.
     intros. unfold iscotrans, iswklin. split.
     { intros i x1 x3 x2. apply i. }

--- a/UniMath/Folds/UnicodeNotations.v
+++ b/UniMath/Folds/UnicodeNotations.v
@@ -3,9 +3,9 @@ Require Export UniMath.Foundations.PartD.
 Require Export UniMath.Foundations.Propositions.
 
 (*
-Notation "'Π'  x .. y , P" := (Π x, .. (Π y, P) ..)
+Notation "'∏'  x .. y , P" := (∏ x, .. (∏ y, P) ..)
   (at level 200, x binder, y binder, right associativity) : type_scope.
-Notation "'Σ'  x .. y , P" := (total2 (fun x => .. (total2 (fun y => P)) ..))
+Notation "'∑'  x .. y , P" := (total2 (fun x => .. (total2 (fun y => P)) ..))
   (at level 200, x binder, y binder, right associativity) : type_scope.
 Notation "A × B" := (dirprod A B) (at level 80, no associativity) : type_scope.
 Notation "X ≃ Y" := (weq X Y) (at level 80, no associativity) : type_scope.

--- a/UniMath/Folds/folds_isomorphism.v
+++ b/UniMath/Folds/folds_isomorphism.v
@@ -7,8 +7,8 @@ Contents of this file:
 
   - Definition of type of isomorphism [folds_iso a b] in a FOLDS precategory
     - consists of two families of isos and an iso, see [folds_iso_data]
-      - [ϕ₁ : Π x, x ⇒ a → x ⇒ b]
-      - [ϕ₂ : Π z, a ⇒ z → b ⇒ z]
+      - [ϕ₁ : ∏ x, x ⇒ a → x ⇒ b]
+      - [ϕ₂ : ∏ z, a ⇒ z → b ⇒ z]
       - [ϕ∙ :      a ⇒ a → b ⇒ b]
     - and a number of logical equivalences, see [folds_iso_prop]
   - Some lemmas expressing naturality of maps [ϕX]
@@ -51,8 +51,8 @@ Local Notation "'id' a" := (identity (C:=C') a) (at level 30).
 
 
 Definition folds_iso_data (a b : C) : UU :=
-  ((Π {x : C}, (x ⇒ a) ≃ (x ⇒ b))
- × (Π {z : C}, (a ⇒ z) ≃ (b ⇒ z)))
+  ((∏ {x : C}, (x ⇒ a) ≃ (x ⇒ b))
+ × (∏ {z : C}, (a ⇒ z) ≃ (b ⇒ z)))
 ×             ((a ⇒ a) ≃ (b ⇒ b)).
 
 Definition ϕ₁ {a b : C} (f : folds_iso_data a b) {x : C} : (x ⇒ a) ≃ (x ⇒ b) :=
@@ -65,14 +65,14 @@ Notation "ϕ∙" := ϕo. (* works as a notation, but not as an identifier *)
 
 
 Definition folds_iso_prop {a b : C} (i : folds_iso_data a b) : UU :=
-  ((((Π (x y : C) (f : x ⇒ y) (g : y ⇒ a) (h : x ⇒ a), T f g h ≃ T f ((ϕ₁ i) g) ((ϕ₁ i) h))
-   × (Π (x z : C) (f : x ⇒ a) (g : a ⇒ z) (h : x ⇒ z), T f g h ≃ T ((ϕ₁ i) f) ((ϕ₂ i) g) h))
-   × (Π (z w : C) (f : a ⇒ z) (g : z ⇒ w) (h : a ⇒ w), T f g h ≃ T ((ϕ₂ i) f) g ((ϕ₂ i) h)))
- × (((Π (x : C) (f : x ⇒ a) (g : a ⇒ a) (h : x ⇒ a),   T f g h ≃ T ((ϕ₁ i) f) ((ϕo i) g) ((ϕ₁ i) h))
-   × (Π (x : C) (f : a ⇒ x) (g : x ⇒ a) (h : a ⇒ a),   T f g h ≃ T ((ϕ₂ i) f) ((ϕ₁ i) g) ((ϕ∙ i) h)))
-  × ((Π (x : C) (f : a ⇒ a) (g h : a ⇒ x),             T f g h ≃ T ((ϕ∙ i) f) ((ϕ₂ i) g) ((ϕ₂ i) h))
-   × (Π f g h : a ⇒ a,                                 T f g h ≃ T ((ϕ∙ i) f) ((ϕ∙ i) g) ((ϕ∙ i) h)))))
-   × (Π f : a ⇒ a,                                     I f ≃ I ((ϕ∙ i) f)).
+  ((((∏ (x y : C) (f : x ⇒ y) (g : y ⇒ a) (h : x ⇒ a), T f g h ≃ T f ((ϕ₁ i) g) ((ϕ₁ i) h))
+   × (∏ (x z : C) (f : x ⇒ a) (g : a ⇒ z) (h : x ⇒ z), T f g h ≃ T ((ϕ₁ i) f) ((ϕ₂ i) g) h))
+   × (∏ (z w : C) (f : a ⇒ z) (g : z ⇒ w) (h : a ⇒ w), T f g h ≃ T ((ϕ₂ i) f) g ((ϕ₂ i) h)))
+ × (((∏ (x : C) (f : x ⇒ a) (g : a ⇒ a) (h : x ⇒ a),   T f g h ≃ T ((ϕ₁ i) f) ((ϕo i) g) ((ϕ₁ i) h))
+   × (∏ (x : C) (f : a ⇒ x) (g : x ⇒ a) (h : a ⇒ a),   T f g h ≃ T ((ϕ₂ i) f) ((ϕ₁ i) g) ((ϕ∙ i) h)))
+  × ((∏ (x : C) (f : a ⇒ a) (g h : a ⇒ x),             T f g h ≃ T ((ϕ∙ i) f) ((ϕ₂ i) g) ((ϕ₂ i) h))
+   × (∏ f g h : a ⇒ a,                                 T f g h ≃ T ((ϕ∙ i) f) ((ϕ∙ i) g) ((ϕ∙ i) h)))))
+   × (∏ f : a ⇒ a,                                     I f ≃ I ((ϕ∙ i) f)).
 
 Definition isaprop_folds_iso_prop (a b : C) (i : folds_iso_data a b) : isaprop (folds_iso_prop i).
 Proof.
@@ -80,7 +80,7 @@ Proof.
    repeat (apply impred; intro); apply isapropweqtoprop; apply pr2.
 Qed.
 
-Definition folds_iso (a b : C) := Σ i : folds_iso_data a b, folds_iso_prop i.
+Definition folds_iso (a b : C) := ∑ i : folds_iso_data a b, folds_iso_prop i.
 
 Definition folds_iso_data_from_folds_iso {a b : C} : folds_iso a b → folds_iso_data a b
   := λ i, pr1 i.
@@ -192,7 +192,7 @@ Variables i i' : folds_iso a b.
 
 Hypothesis H : ϕ₁ i (id _ ) = ϕ₁ i' (id _ ).
 
-Lemma ϕ₂_determined : Π x (f : a ⇒ x) , ϕ₂ i f = ϕ₂ i' f.
+Lemma ϕ₂_determined : ∏ x (f : a ⇒ x) , ϕ₂ i f = ϕ₂ i' f.
 Proof.
   intros x f.
   rewrite (ϕ₂_is_comp i).
@@ -209,7 +209,7 @@ Proof.
   apply idpath.
 Qed.
 
-Lemma ϕo_determined : Π f, ϕ∙ i f = ϕ∙ i' f.
+Lemma ϕo_determined : ∏ f, ϕ∙ i f = ϕ∙ i' f.
 Proof.
   intro f.
   do 2 rewrite ϕo_ϕ₁_ϕ₂.

--- a/UniMath/Folds/folds_pre_2_cat.v
+++ b/UniMath/Folds/folds_pre_2_cat.v
@@ -59,7 +59,7 @@ Local Notation "p ## a" := (transportf _ p a) (at level 3, only parsing).
 
 (** ** Objects and a dependent type of morphisms *)
 
-Definition folds_3_ob_mor := Σ a : UU, a → a → UU.
+Definition folds_3_ob_mor := ∑ a : UU, a → a → UU.
 Definition folds_3_ob_mor_pair (ob : UU)(mor : ob → ob → UU) : folds_3_ob_mor
   := tpair _ ob mor.
 
@@ -76,46 +76,46 @@ Definition double_transport {C : folds_3_ob_mor} {a a' b b' : ob C}
 (** ** Identity, composition, and equality, given through predicates *)
 (** We do not assume those to be propositions.  *)
 
-Definition folds_3_id_comp_eq := Σ C : folds_3_ob_mor,
- ( (Π a : C, a ⇒ a → UU)
- × (Π (a b c : C), (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → UU))
- × Π a b : C, a ⇒ b → a ⇒ b → UU.
+Definition folds_3_id_comp_eq := ∑ C : folds_3_ob_mor,
+ ( (∏ a : C, a ⇒ a → UU)
+ × (∏ (a b c : C), (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → UU))
+ × ∏ a b : C, a ⇒ b → a ⇒ b → UU.
 
 
 Definition folds_ob_mor_from_folds_id_comp (C : folds_3_id_comp_eq) : folds_3_ob_mor := pr1 C.
 Coercion folds_ob_mor_from_folds_id_comp : folds_3_id_comp_eq >-> folds_3_ob_mor.
 
-Definition I {C : folds_3_id_comp_eq} : Π {a : C}, a ⇒ a → UU := pr1 (pr1 (pr2 C)).
+Definition I {C : folds_3_id_comp_eq} : ∏ {a : C}, a ⇒ a → UU := pr1 (pr1 (pr2 C)).
 Definition T {C : folds_3_id_comp_eq} :
-      Π {a b c : C}, (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → UU := pr2 (pr1 (pr2 C)).
+      ∏ {a b c : C}, (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → UU := pr2 (pr1 (pr2 C)).
 Definition E {C : folds_3_id_comp_eq} :
-      Π {a b : C}, a ⇒ b → a ⇒ b → UU := pr2 (pr2 C).
+      ∏ {a b : C}, a ⇒ b → a ⇒ b → UU := pr2 (pr2 C).
 
 (** ** E is an "equality", i.e. a congruence and equivalence *)
 
 Definition E_is_good_to_I_and_T (C : folds_3_id_comp_eq) : UU :=
-  (((Π (a b : C) (f : a ⇒ b), E f f) (* refl *)
- ×  (Π (a b : C) (f g : a ⇒ b), E f g → E g f)) (* sym *)
-×   (Π (a b : C) (f g h : a ⇒ b), E f g → E g h → E f h))
-×  ((Π (a : C) (f g : a ⇒ a), E f g → I f → I g)
-×   (Π (a b c : C) (f f' : a ⇒ b) (g g' : b ⇒ c) (h h' : a ⇒ c),
+  (((∏ (a b : C) (f : a ⇒ b), E f f) (* refl *)
+ ×  (∏ (a b : C) (f g : a ⇒ b), E f g → E g f)) (* sym *)
+×   (∏ (a b : C) (f g h : a ⇒ b), E f g → E g h → E f h))
+×  ((∏ (a : C) (f g : a ⇒ a), E f g → I f → I g)
+×   (∏ (a b c : C) (f f' : a ⇒ b) (g g' : b ⇒ c) (h h' : a ⇒ c),
                       E f f' → E g g' → E h h' → T f g h → T f' g' h')).
 
 (** **  The axioms for identity *)
 
 Definition folds_ax_id (C : folds_3_id_comp_eq) :=
-     (Π a : C, ∥ Σ f : a ⇒ a, I f ∥ )  (* there is a thing satisfying I *)
- ×  ((Π (a b : C) (f : a ⇒ b)(i : b ⇒ b), I i → T f i f) (* I is post neutral *)
-  ×  (Π (a b : C) (f : a ⇒ b)(i : a ⇒ a), I i → T i f f)). (* I is pre neutral *)
+     (∏ a : C, ∥ ∑ f : a ⇒ a, I f ∥ )  (* there is a thing satisfying I *)
+ ×  ((∏ (a b : C) (f : a ⇒ b)(i : b ⇒ b), I i → T f i f) (* I is post neutral *)
+  ×  (∏ (a b : C) (f : a ⇒ b)(i : a ⇒ a), I i → T i f f)). (* I is pre neutral *)
 
 (** ** The axioms for composition *)
 
 Definition folds_ax_comp (C : folds_3_id_comp_eq) :=
-     (Π {a b c : C} (f : a ⇒ b) (g : b ⇒ c), ∥ Σ h : a ⇒ c, T f g h ∥ )
+     (∏ {a b c : C} (f : a ⇒ b) (g : b ⇒ c), ∥ ∑ h : a ⇒ c, T f g h ∥ )
                                                         (* there is a composite *)
- × ( (Π {a b c : C} {f : a ⇒ b} {g : b ⇒ c} {h k : a ⇒ c}, T f g h → T f g k → E h k )
+ × ( (∏ {a b c : C} {f : a ⇒ b} {g : b ⇒ c} {h k : a ⇒ c}, T f g h → T f g k → E h k )
                                                         (* composite is unique mod E *)
-  ×  (Π {a b c d : C} (f : a ⇒ b) (g : b ⇒ c) (h : c ⇒ d) (fg : a ⇒ c)
+  ×  (∏ {a b c d : C} (f : a ⇒ b) (g : b ⇒ c) (h : c ⇒ d) (fg : a ⇒ c)
                       (gh : b ⇒ d) (fg_h : a ⇒ d) (f_gh : a ⇒ d),
        T f g fg → T g h gh → T fg h fg_h → T f gh f_gh → E f_gh fg_h)).
                                                         (* composition is assoc mod E *)
@@ -127,7 +127,7 @@ Definition folds_ax_comp (C : folds_3_id_comp_eq) :=
   satisfying the categorical axioms modulo [E] and [E] is an "equality"
 *)
 
-Definition folds_pre_3_cat := Σ C : folds_3_id_comp_eq,
+Definition folds_pre_3_cat := ∑ C : folds_3_id_comp_eq,
      (folds_ax_id C
     × folds_ax_comp C)
     × E_is_good_to_I_and_T C.
@@ -139,11 +139,11 @@ Coercion folds_id_comp_from_folds_precat : folds_pre_3_cat >-> folds_3_id_comp_e
 (** they are 3-precategories such that T, I and E are hProps *)
 
 Definition is_folds_pre_2_cat (C : folds_pre_3_cat) :=
-   ( (Π (a : C) (i : a ⇒ a), isaprop (I i))
-  ×  (Π (a b c : C) (f : a ⇒ b) (g : b ⇒ c) (h : a ⇒ c), isaprop (T f g h)))
- ×   (Π (a b : C) (f g : a ⇒ b), isaprop (E f g)).
+   ( (∏ (a : C) (i : a ⇒ a), isaprop (I i))
+  ×  (∏ (a b c : C) (f : a ⇒ b) (g : b ⇒ c) (h : a ⇒ c), isaprop (T f g h)))
+ ×   (∏ (a b : C) (f g : a ⇒ b), isaprop (E f g)).
 
-Definition folds_pre_2_cat : UU := Σ C, is_folds_pre_2_cat C.
+Definition folds_pre_2_cat : UU := ∑ C, is_folds_pre_2_cat C.
 
 Ltac folds_pre_2_cat_props C :=
      try apply (pr2 (pr1 (pr2 C)));
@@ -158,19 +158,19 @@ Coercion folds_3_from_folds_2 : folds_pre_2_cat >-> folds_pre_3_cat.
 (** * FOLDS-2-isomorphisms *)
 
 Definition folds_iso {C: folds_pre_3_cat} {a b : C} (f g : a ⇒ b) : UU :=
-(((Π (x : C) (u : x ⇒ a) (v : x ⇒ b), T u f v ≃ T u g v)
-  × (Π (x : C) (u : a ⇒ x) (v : x ⇒ b), T u v f ≃ T u v g))
- × (Π (x : C) (u : b ⇒ x) (v : a ⇒ x), T f u v ≃ T g u v))
-× ((((Π (u : a ⇒ b) (p : b = a), T p ## f f u ≃ T p ## g g u)
-     × (Π (u : b ⇒ b) (p : a = a), T (transportf (λ a, a ⇒ b) p f) u f ≃
+(((∏ (x : C) (u : x ⇒ a) (v : x ⇒ b), T u f v ≃ T u g v)
+  × (∏ (x : C) (u : a ⇒ x) (v : x ⇒ b), T u v f ≃ T u v g))
+ × (∏ (x : C) (u : b ⇒ x) (v : a ⇒ x), T f u v ≃ T g u v))
+× ((((∏ (u : a ⇒ b) (p : b = a), T p ## f f u ≃ T p ## g g u)
+     × (∏ (u : b ⇒ b) (p : a = a), T (transportf (λ a, a ⇒ b) p f) u f ≃
                                    T (transportf (λ a, a ⇒ b) p g) u g))
-    × ((Π (u : a ⇒ a) (p : b = b), T u p ## f f ≃ T u p ## g g)
-       × (Π (p : a = a) (q : b = a) (r : b = b),
+    × ((∏ (u : a ⇒ a) (p : b = b), T u p ## f f ≃ T u p ## g g)
+       × (∏ (p : a = a) (q : b = a) (r : b = b),
           T (double_transport p q f) r ## f f
           ≃ T (double_transport p q g) r ## g g)))
-   × (((Π p : b = a, I p ## f ≃ I p ## g) × (Π u : a ⇒ b, E f u ≃ E g u))
-      × ((Π u : a ⇒ b, E u f ≃ E u g)
-         × (Π (p : a = a) (q : b = b),
+   × (((∏ p : b = a, I p ## f ≃ I p ## g) × (∏ u : a ⇒ b, E f u ≃ E g u))
+      × ((∏ u : a ⇒ b, E u f ≃ E u g)
+         × (∏ (p : a = a) (q : b = b),
             E (double_transport p q f) f ≃ E (double_transport p q g) g)))).
 
 Lemma isaprop_folds_2_iso (C : folds_pre_2_cat) (a b : C) (f g : a ⇒ b) :
@@ -192,14 +192,14 @@ Defined.
 
 (** * In FOLDS-2-precats, [folds_iso f g <-> E f g] *)
 
-Lemma E_transport_source : Π (C : folds_pre_2_cat) (a a' b : C) (f g : a ⇒ b) (p : a = a'),
+Lemma E_transport_source : ∏ (C : folds_pre_2_cat) (a a' b : C) (f g : a ⇒ b) (p : a = a'),
           E f g → E (transportf (λ c, c ⇒ b) p f) (transportf (λ c, c ⇒ b) p g).
 Proof.
   intros. destruct p.
   assumption.
 Defined.
 
-Lemma E_transport_target : Π (C : folds_pre_2_cat) (a b b' : C) (f g : a ⇒ b) (p : b = b'),
+Lemma E_transport_target : ∏ (C : folds_pre_2_cat) (a b b' : C) (f g : a ⇒ b) (p : b = b'),
           E f g → E (transportf (λ c, a ⇒ c) p f) (transportf (λ c, a ⇒ c) p g).
 Proof.
   intros. destruct p.
@@ -276,7 +276,7 @@ Defined.
 
 
 Definition is_univalent_folds_pre_2_cat (C : folds_pre_2_cat) : UU :=
-   Π (a b : C) (f g : a ⇒ b), isweq (@idtoiso2 _ _ _ f g).
+   ∏ (a b : C) (f g : a ⇒ b), isweq (@idtoiso2 _ _ _ f g).
 
 Lemma isaprop_is_univalent_folds_2_precat (C : folds_pre_2_cat) :
    isaprop (is_univalent_folds_pre_2_cat C).
@@ -296,10 +296,10 @@ Definition isotoid2 (C : folds_pre_2_cat) (H : is_univalent_folds_pre_2_cat C)
  *)
 
 Definition is_folds_precategory (C : folds_pre_2_cat) : UU :=
-     (Π a b : C, isaset (a ⇒ b))
- ×  ((Π {a b c : C} {f : a ⇒ b} {g : b ⇒ c} {h k : a ⇒ c},
+     (∏ a b : C, isaset (a ⇒ b))
+ ×  ((∏ {a b c : C} {f : a ⇒ b} {g : b ⇒ c} {h k : a ⇒ c},
                   T f g h → T f g k → h = k )       (* T is unique mod identity *)
-  ×  (Π {a b c d : C} (f : a ⇒ b) (g : b ⇒ c) (h : c ⇒ d)
+  ×  (∏ {a b c d : C} (f : a ⇒ b) (g : b ⇒ c) (h : c ⇒ d)
                   (fg : a ⇒ c) (gh : b ⇒ d) (fg_h : a ⇒ d) (f_gh : a ⇒ d),
                T f g fg → T g h gh →
                   T fg h fg_h → T f gh f_gh → f_gh = fg_h)). (* T is assoc mod identity *)
@@ -367,7 +367,7 @@ Section folds_precat_implies_univalent.
 Variable C : folds_pre_2_cat.
 
 Hypothesis H : is_folds_precategory C.
-Hypothesis standardness : Π (a b : C) (f g : a ⇒ b), E f g → f = g.
+Hypothesis standardness : ∏ (a b : C) (f g : a ⇒ b), E f g → f = g.
 
 Lemma folds_2_iso_implies_identity (a b : C) (f g : a ⇒ b) : folds_iso f g → f = g.
 Proof.

--- a/UniMath/Folds/folds_precat.v
+++ b/UniMath/Folds/folds_precat.v
@@ -23,7 +23,7 @@ Require Import UniMath.CategoryTheory.total2_paths.
 
 (** ** Objects and a dependent type of morphisms *)
 
-Definition folds_ob_mor := Σ a : UU, a → a → UU.
+Definition folds_ob_mor := ∑ a : UU, a → a → UU.
 Definition folds_ob_mor_pair (ob : UU)(mor : ob → ob → UU) :
     folds_ob_mor := tpair _ ob mor.
 
@@ -33,28 +33,28 @@ Coercion ob : folds_ob_mor >-> UU.
 Definition folds_morphisms {C : folds_ob_mor} : C → C → UU := pr2 C.
 Local Notation "a ⇒ b" := (folds_morphisms a b)(at level 50).
 
-Definition has_folds_homsets (C : folds_ob_mor) : UU := Π a b: C, isaset (a ⇒ b).
+Definition has_folds_homsets (C : folds_ob_mor) : UU := ∏ a b: C, isaset (a ⇒ b).
 
 (** ** Identity and composition, given through predicates *)
 
-Definition folds_id_T := Σ C : folds_ob_mor,
-    (Π a : C, a ⇒ a → hProp)
- ×  (Π (a b c : C), (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → hProp).
+Definition folds_id_T := ∑ C : folds_ob_mor,
+    (∏ a : C, a ⇒ a → hProp)
+ ×  (∏ (a b c : C), (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → hProp).
 
 Definition folds_ob_mor_from_folds_id_comp (C : folds_id_T) : folds_ob_mor := pr1 C.
 Coercion folds_ob_mor_from_folds_id_comp : folds_id_T >-> folds_ob_mor.
 
-Definition I {C : folds_id_T} : Π {a : C}, a ⇒ a → hProp
+Definition I {C : folds_id_T} : ∏ {a : C}, a ⇒ a → hProp
   := pr1 (pr2 C).
-Definition T {C : folds_id_T} : Π {a b c : C}, (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → hProp
+Definition T {C : folds_id_T} : ∏ {a b c : C}, (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → hProp
   := pr2 (pr2 C).
 
 (** **  The axioms for identity *)
 
 Definition folds_ax_I (C : folds_id_T) :=
-     (Π a : C, ∥ Σ f : a ⇒ a, I f ∥ )  (* there is an id *)
-  × ((Π (a b : C) (f : a ⇒ b)(i : b ⇒ b), I i → T f i f) (* id is post neutral *)
-   × (Π (a b : C) (f : a ⇒ b)(i : a ⇒ a), I i → T i f f)). (* id is pre neutral *)
+     (∏ a : C, ∥ ∑ f : a ⇒ a, I f ∥ )  (* there is an id *)
+  × ((∏ (a b : C) (f : a ⇒ b)(i : b ⇒ b), I i → T f i f) (* id is post neutral *)
+   × (∏ (a b : C) (f : a ⇒ b)(i : a ⇒ a), I i → T i f f)). (* id is pre neutral *)
 
 Lemma isaprop_folds_ax_id C : isaprop (folds_ax_I C).
 Proof.
@@ -65,10 +65,10 @@ Proof.
 Qed.
 
 Definition folds_ax_T (C : folds_id_T) :=
-     (Π {a b c : C} (f : a ⇒ b) (g : b ⇒ c), ∥ Σ h : a ⇒ c, T f g h ∥ ) (* there is a composite *)
- ×  ((Π {a b c : C} {f : a ⇒ b} {g : b ⇒ c} {h k : a ⇒ c},
+     (∏ {a b c : C} (f : a ⇒ b) (g : b ⇒ c), ∥ ∑ h : a ⇒ c, T f g h ∥ ) (* there is a composite *)
+ ×  ((∏ {a b c : C} {f : a ⇒ b} {g : b ⇒ c} {h k : a ⇒ c},
                   T f g h → T f g k → h = k )       (* composite is unique *)
-  ×  (Π {a b c d : C} (f : a ⇒ b) (g : b ⇒ c) (h : c ⇒ d)
+  ×  (∏ {a b c d : C} (f : a ⇒ b) (g : b ⇒ c) (h : c ⇒ d)
                   (fg : a ⇒ c) (gh : b ⇒ d) (fg_h : a ⇒ d) (f_gh : a ⇒ d),
                T f g fg → T g h gh →
                   T fg h fg_h → T f gh f_gh → f_gh = fg_h)). (* composition is assoc *)
@@ -82,7 +82,7 @@ Proof.
 Qed.
 
 
-Definition folds_precat := Σ C : folds_id_T, folds_ax_I C × folds_ax_T C.
+Definition folds_precat := ∑ C : folds_id_T, folds_ax_I C × folds_ax_T C.
 
 Definition folds_id_comp_from_folds_precat (C : folds_precat) : folds_id_T := pr1 C.
 Coercion folds_id_comp_from_folds_precat : folds_precat >-> folds_id_T.
@@ -98,7 +98,7 @@ Section some_lemmas_about_folds_precats.
 
 Variable C : folds_precat.
 
-Lemma I_unique : Π (a : C) (i i' : a ⇒ a), I i → I i' → i = i'.
+Lemma I_unique : ∏ (a : C) (i i' : a ⇒ a), I i → I i' → i = i'.
 Proof.
   intros a i i' Hi Hi'.
   destruct C as [CC [Cid Ccomp]]; simpl in *.
@@ -109,11 +109,11 @@ Proof.
   apply (pr1 (pr2 Ccomp) _ _ _ _ _ _ _ H1 H2).
 Qed.
 
-Lemma I_contr : Π a : C, iscontr (Σ f : a ⇒ a, I f).
+Lemma I_contr : ∏ a : C, iscontr (∑ f : a ⇒ a, I f).
 Proof.
   intro a.
   set (H := pr1 (pr1 (pr2 C)) a).
-  set (H' := hProppair (iscontr (Σ f : a ⇒ a, I f))
+  set (H' := hProppair (iscontr (∑ f : a ⇒ a, I f))
                       (isapropiscontr _ )).
   apply (H H'); simpl.
   intro t; exists t.
@@ -131,10 +131,10 @@ Proof.
   apply (pr2 (pr1 (I_contr a))).
 Defined.
 
-Lemma T_contr : Π (a b c : C) (f : a ⇒ b) (g : b ⇒ c), iscontr (Σ h, T f g h).
+Lemma T_contr : ∏ (a b c : C) (f : a ⇒ b) (g : b ⇒ c), iscontr (∑ h, T f g h).
 Proof.
   intros a b c f g.
-  set (H' := hProppair (iscontr (Σ h : a ⇒ c, T f g h))
+  set (H' := hProppair (iscontr (∑ h : a ⇒ c, T f g h))
                       (isapropiscontr _ )).
   apply (pr1 (pr2 (pr2 C)) a b c f g H').
   simpl; intro t; exists t.

--- a/UniMath/Folds/from_precats_to_folds_and_back.v
+++ b/UniMath/Folds/from_precats_to_folds_and_back.v
@@ -58,8 +58,8 @@ Proof.
 Defined.
 
 Definition folds_id_comp_from_precat_data : folds_id_T :=
-  tpair (λ C : folds_ob_mor, (Π a : C, a ⇒ a → hProp)
-                           × (Π (a b c : C), (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → hProp))
+  tpair (λ C : folds_ob_mor, (∏ a : C, a ⇒ a → hProp)
+                           × (∏ (a b c : C), (a ⇒ b) → (b ⇒ c) → (a ⇒ c) → hProp))
         (pr1 C) (dirprodpair (@id_pred) (@comp_pred)).
 
 End data.

--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -144,8 +144,8 @@ Require Export UniMath.Foundations.Preamble.
 
 (** *** Canonical functions from [ empty ] and to [ unit ] *)
 
-Definition fromempty  : Π X : UU , empty -> X. (* type this in emacs in agda-input method
-with \Pi *)
+Definition fromempty  : ∏ X : UU , empty -> X. (* type this in emacs in agda-input method
+with \prod *)
 Proof.
   intro X.
   intro H.
@@ -171,12 +171,12 @@ Notation "g ∘ f" := (funcomp f g) (at level 50, left associativity).
 (** back and forth between functions of pairs and functions returning
   functions *)
 
-Definition curry {X Z : UU} {Y : X -> UU} (f : (Σ x : X, Y x) -> Z) :
-  Π x, Y x -> Z.
+Definition curry {X Z : UU} {Y : X -> UU} (f : (∑ x : X, Y x) -> Z) :
+  ∏ x, Y x -> Z.
 Proof. intros ? ? ? ? ? y. exact (f (x,,y)). Defined.
 
-Definition uncurry {X Z : UU} {Y : X -> UU} (g : Π x : X, Y x -> Z) :
-  (Σ x, Y x) -> Z.
+Definition uncurry {X Z : UU} {Y : X -> UU} (g : ∏ x : X, Y x -> Z) :
+  (∑ x, Y x) -> Z.
 Proof. intros ? ? ? ? xy. exact (g (pr1 xy) (pr2 xy)). Defined.
 
 (** *** Definition of binary operation *)
@@ -202,7 +202,7 @@ Definition adjev2 {X Y : UU} (phi : ((X -> Y) -> Y) -> Y) : X -> Y :=
 
 (** *** Pairwise direct products *)
 
-Definition dirprod (X Y : UU) := Σ x:X, Y.
+Definition dirprod (X Y : UU) := ∑ x:X, Y.
 
 Notation "A × B" := (dirprod A B) (at level 75, right associativity) : type_scope.
 
@@ -323,12 +323,12 @@ Proof.
   apply idpath.
 Defined.
 
-Lemma uncurry_curry {X Z : UU} {Y : X -> UU} (f : (Σ x : X, Y x) -> Z) :
-  Π p, uncurry (curry f) p = f p.
+Lemma uncurry_curry {X Z : UU} {Y : X -> UU} (f : (∑ x : X, Y x) -> Z) :
+  ∏ p, uncurry (curry f) p = f p.
 Proof. intros. induction p as [x y]. reflexivity. Defined.
 
-Lemma curry_uncurry {X Z : UU} {Y : X -> UU} (g : Π x : X, Y x -> Z) :
-  Π x y, curry (uncurry g) x y = g x y.
+Lemma curry_uncurry {X Z : UU} {Y : X -> UU} (g : ∏ x : X, Y x -> Z) :
+  ∏ x y, curry (uncurry g) x y = g x y.
 Proof. reflexivity. Defined.
 
 
@@ -487,8 +487,8 @@ Defined.
 
 (** *** Homotopy between functions *)
 
-Definition homot {X : UU} {P : X -> UU} (f g : Π x : X, P x) :=
-  Π x : X , f x = g x.
+Definition homot {X : UU} {P : X -> UU} (f g : ∏ x : X, P x) :=
+  ∏ x : X , f x = g x.
 
 Notation "f ~ g" := (homot f g) (at level 70, no associativity).
 
@@ -507,10 +507,10 @@ Definition homotfun {X Y Z : UU} {f f' : X -> Y} (h : f ~ f')
 
 (** *** Equality between functions defines a homotopy *)
 
-Definition toforallpaths {T:UU} (P:T->UU) (f g:Π t:T, P t) : f = g -> f ~ g.
+Definition toforallpaths {T:UU} (P:T->UU) (f g:∏ t:T, P t) : f = g -> f ~ g.
 Proof. intros ? ? ? ? h t. induction h.  apply (idpath _). Defined.
 
-Definition eqtohomot     {T:UU} {P:T->UU} {f g:Π t:T, P t} : f = g -> f ~ g.
+Definition eqtohomot     {T:UU} {P:T->UU} {f g:∏ t:T, P t} : f = g -> f ~ g.
 (* the same as toforallpaths, but with different implicit arguments *)
 Proof.
   intros ? ? ? ? e t. induction e. reflexivity.
@@ -528,10 +528,10 @@ equivalence. *)
 [ homot f ( idfun X ) ] *)
 
 Definition maponpathshomidinv {X : UU} (f : X -> X)
-           (h : Π x : X, f x = x) (x x' : X) (e : f x = f x') :
+           (h : ∏ x : X, f x = x) (x x' : X) (e : f x = f x') :
   x = x' := ! (h x) @ e @ (h x').
 
-Lemma maponpathshomid1 {X : UU} (f : X -> X) (h: Π x : X, f x = x)
+Lemma maponpathshomid1 {X : UU} (f : X -> X) (h: ∏ x : X, f x = x)
       {x x' : X} (e : x = x') : maponpaths f e = (h x) @ e @ (! h x').
 Proof.
   intros. induction e. simpl.
@@ -539,7 +539,7 @@ Proof.
   apply pathsinv0r.
 Defined.
 
-Lemma maponpathshomid2 {X : UU} (f : X -> X) (h : Π x : X, f x = x)
+Lemma maponpathshomid2 {X : UU} (f : X -> X) (h : ∏ x : X, f x = x)
       (x x' : X) (e: f x = f x') :
   maponpaths f (maponpathshomidinv f h _ _ e) = e.
 Proof.
@@ -547,7 +547,7 @@ Proof.
   unfold maponpathshomidinv.
   apply (pathscomp0 (maponpathshomid1 f h (! h x @ e @ h x'))).
 
-  assert (l : Π (X : UU) (a b c d : X) (p : a = b) (q : a = c) (r : c = d),
+  assert (l : ∏ (X : UU) (a b c d : X) (p : a = b) (q : a = c) (r : c = d),
               p @ (!p @ q @ r) @ !r = q).
   { intros. induction p. induction q. induction r. apply idpath. }
 
@@ -561,7 +561,7 @@ Defined.
 [ homot ( funcomp s p ) ( idfun X ) ] *)
 
 Definition pathssec1 {X Y : UU} (s : X -> Y) (p : Y -> X)
-           (eps : Π (x : X) , p (s x) = x)
+           (eps : ∏ (x : X) , p (s x) = x)
            (x : X) (y : Y) (e : s x = y) : x = p y.
 Proof.
   intros.
@@ -570,7 +570,7 @@ Proof.
 Defined.
 
 Definition pathssec2 {X Y : UU} (s : X -> Y) (p : Y -> X)
-           (eps : Π (x : X), p (s x) = x)
+           (eps : ∏ (x : X), p (s x) = x)
            (x x' : X) (e : s x = s x') : x = x'.
 Proof.
   intros.
@@ -579,19 +579,19 @@ Proof.
 Defined.
 
 Definition pathssec2id {X Y : UU} (s : X -> Y) (p : Y -> X)
-           (eps : Π x : X, p (s x) = x)
+           (eps : ∏ x : X, p (s x) = x)
            (x : X) : pathssec2 s p eps _ _ (idpath (s x)) = idpath x.
 Proof.
   intros.
   unfold pathssec2. unfold pathssec1. simpl.
-  assert (e : Π X : UU, Π a b : X,
-                                Π p : a = b, (! p @ idpath _) @ p = idpath _).
+  assert (e : ∏ X : UU, ∏ a b : X,
+                                ∏ p : a = b, (! p @ idpath _) @ p = idpath _).
   { intros. induction p0. simpl. apply idpath. }
   apply e.
 Defined.
 
 Definition pathssec3 {X Y : UU} (s : X -> Y) (p : Y -> X)
-           (eps : Π x : X, p (s x) = x) {x x' : X} (e : x = x') :
+           (eps : ∏ x : X, p (s x) = x) {x x' : X} (e : x = x') :
   pathssec2 s p eps  _ _ (maponpaths s e) = e.
 Proof.
   intros. induction e. simpl.
@@ -611,9 +611,9 @@ Proof.
 Defined.
 
 Definition constr1 {X : UU} (P : X -> UU) {x x' : X} (e : x = x') :
-  Σ (f : P x -> P x'),
-  Σ (ee : Π p : P x, tpair _ x p = tpair _ x' (f p)),
-  Π (pp : P x), maponpaths pr1 (ee pp) = e.
+  ∑ (f : P x -> P x'),
+  ∑ (ee : ∏ p : P x, tpair _ x p = tpair _ x' (f p)),
+  ∏ (pp : P x), maponpaths pr1 (ee pp) = e.
 Proof.
   intros. induction e.
   split with (idfun (P x)).
@@ -685,14 +685,14 @@ Proof.
   intros. induction e'. induction e. reflexivity.
 Defined.
 
-Definition transport_map {X : UU} {P Q : X -> UU} (f : Π x, P x -> Q x)
+Definition transport_map {X : UU} {P Q : X -> UU} (f : ∏ x, P x -> Q x)
            {x : X} {y : X} (e : x = y) (p : P x) :
   transportf Q e (f x p) = f y (transportf P e p).
 Proof.
   intros. induction e. reflexivity.
 Defined.
 
-Definition transport_section {X : UU} {P:X -> UU} (f : Π x, P x)
+Definition transport_section {X : UU} {P:X -> UU} (f : ∏ x, P x)
            {x : X} {y : X} (e : x = y) :
   transportf P e (f x) = f y.
 Proof.
@@ -746,7 +746,7 @@ Proof.
   apply maponpaths; assumption.
 Defined.
 
-Lemma total2_paths {A : UU} {B : A -> UU} {s s' : Σ x, B x}
+Lemma total2_paths {A : UU} {B : A -> UU} {s s' : ∑ x, B x}
       (p : pr1 s = pr1 s')
       (q : transportf B p (pr2 s) = pr2 s') : s = s'.
 Proof.
@@ -758,7 +758,7 @@ Proof.
   apply idpath.
 Defined.
 
-Lemma total2_paths_b {A : UU} {B : A -> UU} {s s' : Σ x, B x}
+Lemma total2_paths_b {A : UU} {B : A -> UU} {s s' : ∑ x, B x}
       (p : pr1 s = pr1 s')
       (q : pr2 s = transportb B p (pr2 s')) : s = s'.
 Proof.
@@ -794,14 +794,14 @@ Proof.
   intros. now apply maponpaths.
 Defined.
 
-Definition fiber_paths {A : UU} {B : A -> UU} {u v : Σ x, B x} (p : u = v) :
+Definition fiber_paths {A : UU} {B : A -> UU} {u v : ∑ x, B x} (p : u = v) :
   transportf (fun x => B x) (base_paths _ _ p) (pr2 u) = pr2 v.
 Proof.
   induction p.
   apply idpath.
 Defined.
 
-Lemma total2_fiber_paths {A : UU} {B : A -> UU} {x y : Σ x, B x} (p : x = y) :
+Lemma total2_fiber_paths {A : UU} {B : A -> UU} {x y : ∑ x, B x} (p : x = y) :
   total2_paths  _ (fiber_paths p) = p.
 Proof.
   induction p.
@@ -809,7 +809,7 @@ Proof.
   apply idpath.
 Defined.
 
-Lemma base_total2_paths {A : UU} {B : A -> UU} {x y : Σ x, B x}
+Lemma base_total2_paths {A : UU} {B : A -> UU} {x y : ∑ x, B x}
       {p : pr1 x = pr1 y} (q : transportf _ p (pr2 x) = pr2 y) :
   (base_paths _ _ (total2_paths _ q)) = p.
 Proof.
@@ -823,7 +823,7 @@ Defined.
 
 
 Lemma transportf_fiber_total2_paths {A : UU} (B : A -> UU)
-      (x y : Σ x, B x)
+      (x y : ∑ x, B x)
       (p : pr1 x = pr1 y) (q : transportf _ p (pr2 x) = pr2 y) :
   transportf (fun p' : pr1 x = pr1 y => transportf _ p' (pr2 x) = pr2 y)
              (base_total2_paths q)  (fiber_paths (total2_paths _ q)) = q.
@@ -839,7 +839,7 @@ Defined.
 
 (** *** Lemmas about transport adapted from the HoTT library and the HoTT book *)
 
-Definition transportD {A : UU} (B : A -> UU) (C : Π a : A, B a -> UU)
+Definition transportD {A : UU} (B : A -> UU) (C : ∏ a : A, B a -> UU)
            {x1 x2 : A} (p : x1 = x2) (y : B x1) (z : C x1 y) :
   C x2 (transportf _ p y).
 Proof.
@@ -849,9 +849,9 @@ Proof.
 Defined.
 
 
-Definition transportf_total2 {A : UU} {B : A -> UU} {C : Π a:A, B a -> UU}
-           {x1 x2 : A} (p : x1 = x2) (yz : Σ y : B x1, C x1 y) :
-  transportf (fun x => Σ y : B x, C x y) p yz =
+Definition transportf_total2 {A : UU} {B : A -> UU} {C : ∏ a:A, B a -> UU}
+           {x1 x2 : A} (p : x1 = x2) (yz : ∑ y : B x1, C x1 y) :
+  transportf (fun x => ∑ y : B x, C x y) p yz =
   tpair (fun y => C x2 y) (transportf _ p  (pr1 yz))
         (transportD _ _ p (pr1 yz) (pr2 yz)).
 Proof.
@@ -862,7 +862,7 @@ Proof.
 Defined.
 
 Definition transportf_dirprod (A : UU) (B B' : A -> UU)
-           (x x' : Σ a, B a × B' a) (p : pr1 x = pr1 x') :
+           (x x' : ∑ a, B a × B' a) (p : pr1 x = pr1 x') :
   transportf (fun a => dirprod (B a) (B' a)) p (pr2 x) =
   dirprodpair (transportf (fun a => B a) p (pr1 (pr2 x)))
               (transportf (fun a => B' a) p (pr2 (pr2 x))).
@@ -872,7 +872,7 @@ Proof.
 Defined.
 
 Definition transportb_dirprod (A : UU) (B B' : A -> UU)
-  (x x' : Σ a,  B a × B' a)  (p : pr1 x = pr1 x') :
+  (x x' : ∑ a,  B a × B' a)  (p : pr1 x = pr1 x') :
   transportb (fun a => dirprod (B a) (B' a)) p (pr2 x') =
     dirprodpair (transportb (fun a => B a) p (pr1 (pr2 x')))
                 (transportb (fun a => B' a) p (pr2 (pr2 x'))).
@@ -932,20 +932,20 @@ Defined.
 
 (** *** Contractibility [ iscontr ] *)
 
-Definition iscontr (T:UU) : UU := Σ cntr:T, Π t:T, t=cntr.
+Definition iscontr (T:UU) : UU := ∑ cntr:T, ∏ t:T, t=cntr.
 
 Notation "'∃!' x .. y , P"
-  := (iscontr (Σ x, .. (Σ y, P) ..))
+  := (iscontr (∑ x, .. (∑ y, P) ..))
        (at level 200, x binder, y binder, right associativity) : type_scope.
 (* type this in emacs in agda-input method with \ex ! *)
 
-Definition iscontrpair {T : UU} : Π x : T, (Π t : T, t = x) -> iscontr T
+Definition iscontrpair {T : UU} : ∏ x : T, (∏ t : T, t = x) -> iscontr T
   := tpair _.
 
 Definition iscontrpr1 {T : UU} : iscontr T -> T := pr1.
 
 Lemma iscontrretract {X Y : UU} (p : X -> Y) (s : Y -> X)
-      (eps : Π y : Y, p (s y) = y) (is : iscontr X) : iscontr Y.
+      (eps : ∏ y : Y, p (s y) = y) (is : iscontr X) : iscontr Y.
 Proof.
   intros.
   induction is as [x fe].
@@ -972,7 +972,7 @@ Defined.
 
 (** *** Homotopy fibers [ hfiber ] *)
 
-Definition hfiber {X Y : UU}  (f : X -> Y) (y : Y) : UU := Σ x:X, f x = y.
+Definition hfiber {X Y : UU}  (f : X -> Y) (y : Y) : UU := ∑ x:X, f x = y.
 
 Definition hfiberpair {X Y : UU} (f : X -> Y) {y : Y}
            (x : X) (e : f x = y) : hfiber f y :=
@@ -1057,14 +1057,14 @@ Defined.
 
 (** *** Coconuses: spaces of paths that begin [ coconusfromt ] or end [ coconustot ] at a given point *)
 
-Definition coconusfromt (T : UU) (t : T) := Σ t' : T, t = t'.
+Definition coconusfromt (T : UU) (t : T) := ∑ t' : T, t = t'.
 
 Definition coconusfromtpair (T : UU) {t t' : T} (e: t = t') : coconusfromt T t
   := tpair _ t' e.
 
 Definition coconusfromtpr1 (T : UU) (t : T) : coconusfromt T t -> T := pr1.
 
-Definition coconustot (T : UU) (t : T) := Σ t' : T, t' = t.
+Definition coconustot (T : UU) (t : T) := ∑ t' : T, t' = t.
 
 Definition coconustotpair (T : UU) {t t' : T} (e: t' = t) : coconustot T t
   := tpair _ t' e.
@@ -1117,7 +1117,7 @@ Defined.
 
 The definitions differ by the (non) associativity of the [ total2 ].  *)
 
-Definition pathsspace (T : UU) := Σ t:T, coconusfromt T t.
+Definition pathsspace (T : UU) := ∑ t:T, coconusfromt T t.
 
 Definition pathsspacetriple (T : UU) {t1 t2 : T}
            (e : t1 = t2) : pathsspace T := tpair _ t1 (coconusfromtpair T e).
@@ -1125,12 +1125,12 @@ Definition pathsspacetriple (T : UU) {t1 t2 : T}
 Definition deltap (T : UU) : T -> pathsspace T :=
   fun (t : T) => pathsspacetriple T (idpath t).
 
-Definition pathsspace' (T : UU) := Σ xy : dirprod T T, pr1 xy = pr2 xy.
+Definition pathsspace' (T : UU) := ∑ xy : dirprod T T, pr1 xy = pr2 xy.
 
 
 (** *** Coconus of a function: the total space of the family of h-fibers *)
 
-Definition coconusf {X Y : UU} (f : X -> Y) := Σ y:Y, hfiber f y.
+Definition coconusf {X Y : UU} (f : X -> Y) := ∑ y:Y, hfiber f y.
 
 Definition fromcoconusf {X Y : UU} (f : X -> Y) : coconusf f -> X :=
   fun (yxe : coconusf f) => pr1 (pr2 yxe).
@@ -1139,7 +1139,7 @@ Definition tococonusf {X Y : UU} (f : X -> Y) : X -> coconusf f :=
   fun (x : _) => tpair _ (f x) (hfiberpair f x (idpath _)).
 
 Lemma homottofromcoconusf {X Y : UU} (f : X -> Y) :
-  Π yxe : coconusf f, tococonusf f (fromcoconusf f yxe) = yxe.
+  ∏ yxe : coconusf f, tococonusf f (fromcoconusf f yxe) = yxe.
 Proof.
   intros.
   induction yxe as [y xe].
@@ -1152,7 +1152,7 @@ Proof.
 Defined.
 
 Lemma homotfromtococonusf {X Y : UU} (f : X -> Y) :
-  Π x : X, fromcoconusf f (tococonusf f x) = x.
+  ∏ x : X, fromcoconusf f (tococonusf f x) = x.
 Proof.
   intros.
   unfold fromcoconusf.
@@ -1167,7 +1167,7 @@ Defined.
 (** *** Basics - [ isweq ] and [ weq ] *)
 
 Definition isweq {X Y : UU} (f : X -> Y) : UU :=
-  Π y : Y, iscontr (hfiber f y).
+  ∏ y : Y, iscontr (hfiber f y).
 
 Lemma idisweq (T : UU) : isweq (idfun T).
 Proof.
@@ -1180,7 +1180,7 @@ Proof.
   apply idpath.
 Defined.
 
-Definition weq (X Y : UU) : UU := Σ f:X->Y, isweq f.
+Definition weq (X Y : UU) : UU := ∑ f:X->Y, isweq f.
 
 Notation "X ≃ Y" := (weq X Y) (at level 80, no associativity) : type_scope.
 (* written \simeq in Agda input method *)
@@ -1196,7 +1196,7 @@ Proof.
 Defined.
 
 Definition weqccontrhfiber2 {X Y : UU} (w : X ≃ Y) (y : Y) :
-  Π x : hfiber w y, x = weqccontrhfiber w y.
+  ∏ x : hfiber w y, x = weqccontrhfiber w y.
 Proof.
   intros. unfold weqccontrhfiber. apply (pr2 (pr2 w y)).
 Defined.
@@ -1235,7 +1235,7 @@ Definition invmap {X Y : UU} (w : X ≃ Y) : Y -> X :=
     corrected in order for lemma [ homotweqinvweqweq ] to hold. *)
 
 Definition homotweqinvweq {X Y : UU} (w : X ≃ Y) :
-  Π y : Y, w (invmap w y) = y.
+  ∏ y : Y, w (invmap w y) = y.
 Proof.
   intros.
   unfold invmap.
@@ -1243,7 +1243,7 @@ Proof.
 Defined.
 
 Definition homotinvweqweq0 {X Y : UU} (w : X ≃ Y) :
-  Π x : X, x = invmap w (w x).
+  ∏ x : X, x = invmap w (w x).
 Proof.
   intros.
   unfold invmap.
@@ -1254,7 +1254,7 @@ Proof.
 Defined.
 
 Definition homotinvweqweq {X Y : UU} (w : X ≃ Y) :
-  Π x : X, invmap w (w x) = x
+  ∏ x : X, invmap w (w x) = x
   := fun (x : X) => ! (homotinvweqweq0 w x).
 
 Definition invmaponpathsweq {X Y : UU} (w : X ≃ Y) (x x' : X) :
@@ -1392,7 +1392,7 @@ Ltac intermediate_iscontr Y' := apply (iscontrweqb (Y := Y')).
 (** [ unit ] is contractible (recall that [ tt ] is the name of the
     canonical term of the type [ unit ]). *)
 
-Lemma isconnectedunit : Π x x' : unit, x = x'.
+Lemma isconnectedunit : ∏ x x' : unit, x = x'.
 Proof.
   intros. induction x. induction x'. apply idpath.
 Defined.
@@ -1407,12 +1407,12 @@ Proof.
   intro cp. induction cp as [x t]. induction x. apply t.
 Defined.
 
-Lemma unitl2: Π e : tt = tt, unitl1 (unitl0 e) = e.
+Lemma unitl2: ∏ e : tt = tt, unitl1 (unitl0 e) = e.
 Proof.
   intros. unfold unitl0. simpl. apply idpath.
 Defined.
 
-Lemma unitl3: Π e : tt = tt, e = idpath tt.
+Lemma unitl3: ∏ e : tt = tt, e = idpath tt.
 Proof.
   intros.
 
@@ -1483,8 +1483,8 @@ Definition hfibersgftog {X Y Z : UU} (f : X -> Y) (g : Y -> Z) (z : Z)
   hfiberpair g (f (pr1 xe)) (pr2 xe).
 
 Lemma constr2 {X Y : UU} (f : X -> Y) (g : Y -> X)
-      (efg: Π y : Y, f (g y) = y) (x0 : X) (xe : hfiber g x0) :
-  Σ xe' : hfiber (g ∘ f) x0, xe = hfibersgftog f g x0 xe'.
+      (efg: ∏ y : Y, f (g y) = y) (x0 : X) (xe : hfiber g x0) :
+  ∑ xe' : hfiber (g ∘ f) x0, xe = hfibersgftog f g x0 xe'.
 Proof.
   intros.
   induction xe as [y0 e].
@@ -1500,7 +1500,7 @@ Proof.
 Defined.
 
 Lemma iscontrhfiberl1 {X Y : UU} (f : X -> Y) (g : Y -> X)
-      (efg: Π y : Y, f (g y) = y) (x0 : X)
+      (efg: ∏ y : Y, f (g y) = y) (x0 : X)
       (is : iscontr (hfiber (g ∘ f) x0)) : iscontr (hfiber g x0).
 Proof.
   intros.
@@ -1539,7 +1539,7 @@ Proof.
   simpl.
 
   (* A little lemma: *)
-  assert (ee : Π a b c : Y, Π p : a = b, Π q : b = c,
+  assert (ee : ∏ a b c : Y, ∏ p : a = b, ∏ q : b = c,
                                                !p @ (p @ q) = q).
   { intros. induction p. induction q. apply idpath. }
 
@@ -1583,14 +1583,14 @@ Proof.
 Defined.
 
 Theorem gradth {X Y : UU} (f : X -> Y) (g : Y -> X)
-        (egf: Π x : X, g (f x) = x)
-        (efg: Π y : Y, f (g y) = y) : isweq f.
+        (egf: ∏ x : X, g (f x) = x)
+        (efg: ∏ y : Y, f (g y) = y) : isweq f.
 Proof.
   intros.
   unfold isweq.
   intro y.
   assert (iscontr (hfiber (f ∘ g) y)).
-  assert (efg' : Π y : Y, y = f (g y)).
+  assert (efg' : ∏ y : Y, y = f (g y)).
   { intro y0.
     apply pathsinv0.
     apply (efg y0). }
@@ -1600,12 +1600,12 @@ Proof.
 Defined.
 
 Definition weqgradth {X Y : UU} (f : X -> Y) (g : Y -> X)
-           (egf: Π x : X, g (f x) = x)
-           (efg: Π y : Y, f (g y) = y) : X ≃ Y :=
+           (egf: ∏ x : X, g (f x) = x)
+           (efg: ∏ y : Y, f (g y) = y) : X ≃ Y :=
   weqpair _ (gradth _ _ egf efg).
 
 Definition bijective {X Y:UU} (f:X->Y) :=
-  (Π y, Σ x, f x = y) × (Π x x', f x = f x' -> x = x').
+  (∏ y, ∑ x, f x = y) × (∏ x x', f x = f x' -> x = x').
 
 Corollary bijection_to_weq {X Y:UU} (f:X->Y) : bijective f -> isweq f.
 Proof.
@@ -1623,9 +1623,9 @@ Defined.
 Corollary isweqinvmap {X Y : UU} (w : weq X Y) : isweq (invmap w).
 Proof.
   intros.
-  assert (efg : Π (y : Y), w (invmap w y) = y).
+  assert (efg : ∏ (y : Y), w (invmap w y) = y).
   apply homotweqinvweq.
-  assert (egf : Π (x : X), invmap w (w x) = x).
+  assert (egf : ∏ (x : X), invmap w (w x) = x).
   apply homotinvweqweq.
   apply (gradth _ _ efg egf).
 Defined.
@@ -1649,8 +1649,8 @@ Defined.
     http://github.com/HoTT/HoTT.
  *)
 
-Definition PathPair {A : UU} {B : A -> UU} (x y : Σ x, B x) :=
-  Σ p : pr1 x = pr1 y, transportf _ p (pr2 x) = pr2 y.
+Definition PathPair {A : UU} {B : A -> UU} (x y : ∑ x, B x) :=
+  ∑ p : pr1 x = pr1 y, transportf _ p (pr2 x) = pr2 y.
 
 Notation "a ╝ b" := (PathPair a b) (at level 70, no associativity) : type_scope.
 (* the two horizontal lines represent an equality in the base and
@@ -1658,7 +1658,7 @@ Notation "a ╝ b" := (PathPair a b) (at level 70, no associativity) : type_scop
 (* in agda input mode use \--= and select the 6-th one in the first set,
    or use \chimney *)
 
-Theorem total2_paths_equiv {A : UU} (B : A -> UU) (x y : Σ x, B x) :
+Theorem total2_paths_equiv {A : UU} (B : A -> UU) (x y : ∑ x, B x) :
   x = y  ≃  x ╝ y.
 Proof.
   intros A B x y.
@@ -1666,7 +1666,7 @@ Proof.
             tpair (fun p : pr1 x = pr1 y => transportf _ p (pr2 x) = pr2 y)
                   (base_paths _ _ r) (fiber_paths r)).
   apply (gradth _
-                (fun (pq : Σ p : pr1 x = pr1 y, transportf _ p (pr2 x) = pr2 y) =>
+                (fun (pq : ∑ p : pr1 x = pr1 y, transportf _ p (pr2 x) = pr2 y) =>
                    total2_paths (pr1 pq) (pr2 pq))).
   - intro p.
     apply total2_fiber_paths.
@@ -1683,9 +1683,9 @@ Proof.
   set (f := fun (t : unit) => pr1 is).
   set (g := fun (x : X) => tt).
   split with f.
-  assert (egf : Π t : unit, g (f t) = t).
+  assert (egf : ∏ t : unit, g (f t) = t).
   { intro. induction t. apply idpath. }
-  assert (efg : Π x : X, f (g x) = x).
+  assert (efg : ∏ x : X, f (g x) = x).
   { intro. apply (! (pr2 is x)). }
   apply (gradth _ _ egf efg).
 Defined.
@@ -1726,9 +1726,9 @@ Proof.
   intros.
   set (f := fun (e : x = x') => e @ e').
   set (g := fun (e'' : x = x'') => e'' @ (! e')).
-  assert (egf : Π e : _, g (f e) = e).
+  assert (egf : ∏ e : _, g (f e) = e).
   { intro e. induction e. induction e'. apply idpath. }
-  assert (efg : Π e : _, f (g e) = e).
+  assert (efg : ∏ e : _, f (g e) = e).
   { intro e. induction e. induction e'. apply idpath. }
   apply (gradth f g egf efg).
 Defined.
@@ -1757,9 +1757,9 @@ Corollary isweqdeltap (T : UU) : isweq (deltap T).
 Proof.
   intros.
   set (ff := deltap T). set (gg := fun (z : pathsspace T) => pr1 z).
-  assert (egf : Π t : T, gg (ff t) = t).
+  assert (egf : ∏ t : T, gg (ff t) = t).
   { intro. apply idpath. }
-  assert (efg : Π (tte : _), ff (gg tte) = tte).
+  assert (efg : ∏ (tte : _), ff (gg tte) = tte).
   { intro tte. induction tte as [t c].
     induction c as [x e]. induction e.
     apply idpath.
@@ -1774,9 +1774,9 @@ Proof.
   set (f := fun (a : pathsspace' T) => pr1 (pr1 a)).
   set (g := fun (t : T) =>
               tpair _ (dirprodpair t t) (idpath t) : pathsspace' T).
-  assert (efg : Π t : T, f (g t) = t).
+  assert (efg : ∏ t : T, f (g t) = t).
   { intros t. unfold f. unfold g. simpl. apply idpath. }
-  assert (egf : Π a : _, g (f a) = a).
+  assert (egf : ∏ a : _, g (f a) = a).
   { intros a. induction a as [xy e].
     induction xy as [x y]. simpl in e.
     induction e. unfold f. unfold g.
@@ -1796,7 +1796,7 @@ Proof.
 
   split with ff.
 
-  assert (effgg : Π xe : _, ff (gg xe) = xe).
+  assert (effgg : ∏ xe : _, ff (gg xe) = xe).
   {
     intro xe.
     induction xe as [x e].
@@ -1808,7 +1808,7 @@ Proof.
     apply (hfibertriangle2 g xe1 xe2 (idpath x) eee).
   }
 
-  assert (eggff : Π xe : _, gg (ff xe) = xe).
+  assert (eggff : ∏ xe : _, gg (ff xe) = xe).
   {
     intro xe.
     induction xe as [x e].
@@ -1840,7 +1840,7 @@ Proof.
 
   set (invf := invgf ∘ g).
 
-  assert (efinvf : Π y : Y, f (invf y) = y).
+  assert (efinvf : ∏ y : Y, f (invf y) = y).
   {
     intro y.
     assert (int1 : g (f (invf y)) = g y).
@@ -1848,7 +1848,7 @@ Proof.
     apply (invmaponpathsweq gw _ _  int1).
   }
 
-  assert (einvff: Π x : X, invf (f x) = x).
+  assert (einvff: ∏ x : X, invf (f x) = x).
   { intro. unfold invf. apply (homotinvweqweq gfw x). }
 
   apply (gradth f invf einvff efinvf).
@@ -1865,10 +1865,10 @@ Proof.
 
   set (invg := f ∘ invgf).
 
-  assert (eginvg : Π z : Z, g (invg z) = z).
+  assert (eginvg : ∏ z : Z, g (invg z) = z).
   { intro. unfold invg. apply (homotweqinvweq wgf z). }
 
-  assert (einvgg : Π y : Y, invg (g y) = y).
+  assert (einvgg : ∏ y : Y, invg (g y) = y).
   { intro. unfold invg.
 
     assert (isinvf: isweq invf).
@@ -1905,7 +1905,7 @@ Proof.
 Defined.
 
 Lemma isweql3 {X Y : UU} (f : X -> Y) (g : Y -> X)
-      (egf : Π x : X, g (f x) = x) : isweq f -> isweq g.
+      (egf : ∏ x : X, g (f x) = x) : isweq f -> isweq g.
 Proof.
   intros X Y f g egf w.
   assert (int1 : isweq (g ∘ f)).
@@ -1928,7 +1928,7 @@ Proof.
   set (gf := g ∘ f).
   set (invgf := invf ∘ invg).
 
-  assert (egfinvgf : Π x : X, invgf (gf x) = x).
+  assert (egfinvgf : ∏ x : X, invgf (gf x) = x).
   {
     intros x.
     assert (int1 : invf (invg (g (f x))) = invf (f x)).
@@ -1939,7 +1939,7 @@ Proof.
     apply int2.
   }
 
-  assert (einvgfgf : Π z : Z, gf (invgf z) = z).
+  assert (einvgfgf : ∏ z : Z, gf (invgf z) = z).
   {
     intros z.
     assert (int1 : g (f (invgf z)) = g (invg z)).
@@ -2074,10 +2074,10 @@ Theorem isweqdirprodf {X Y X' Y' : UU} (w : X ≃ Y) (w' : weq X' Y') :
 Proof.
   intros.
   set (f := dirprodf w w'). set (g := dirprodf (invweq w) (invweq w')).
-  assert (egf : Π a : _, (g (f a)) = a).
+  assert (egf : ∏ a : _, (g (f a)) = a).
   intro a. induction a as [ x x' ].  simpl. apply pathsdirprod.
   apply (homotinvweqweq w x).  apply (homotinvweqweq w' x').
-  assert (efg : Π a : _, (f (g a)) = a).
+  assert (efg : ∏ a : _, (f (g a)) = a).
   intro a. induction a as [ x x' ].  simpl. apply pathsdirprod.
   apply (homotweqinvweq w x). apply (homotweqinvweq w' x').
   apply (gradth _ _ egf efg).
@@ -2094,8 +2094,8 @@ Proof.
   set (f := fun x : X => dirprodpair x tt).
   split with f.
   set (g := fun xu : dirprod X unit => pr1 xu).
-  assert (egf : Π x : X, (g (f x)) = x). intro. apply idpath.
-  assert (efg : Π xu : _, (f (g xu)) = xu). intro. induction xu as [ t x ].
+  assert (egf : ∏ x : X, (g (f x)) = x). intro. apply idpath.
+  assert (efg : ∏ xu : _, (f (g xu)) = xu). intro. induction xu as [ t x ].
   induction x. apply idpath.
   apply (gradth f g egf efg).
 Defined.
@@ -2104,7 +2104,7 @@ Defined.
 (** *** Associativity of [ total2 ] as a weak equivalence *)
 
 Lemma total2asstor {X : UU} (P : X -> UU) (Q : total2 P -> UU) :
-  total2 Q ->  Σ x:X, Σ p : P x, Q (tpair P x p).
+  total2 Q ->  ∑ x:X, ∑ p : P x, Q (tpair P x p).
 Proof.
   intros X P Q xpq.
   exists (pr1 (pr1 xpq)).
@@ -2115,7 +2115,7 @@ Proof.
 Defined.
 
 Lemma total2asstol {X : UU} (P : X -> UU) (Q : total2 P -> UU) :
-  (Σ x : X, Σ p : P x, Q (tpair P x p)) -> total2 Q.
+  (∑ x : X, ∑ p : P x, Q (tpair P x p)) -> total2 Q.
 Proof.
   intros X P Q xpq.
   mkpair.
@@ -2129,20 +2129,20 @@ Defined.
 
 
 Theorem weqtotal2asstor {X : UU} (P : X -> UU) (Q : total2 P -> UU) :
-  weq (total2 Q) (Σ x : X, Σ p : P x, Q (tpair P x p)).
+  weq (total2 Q) (∑ x : X, ∑ p : P x, Q (tpair P x p)).
 Proof.
   intros.
   set (f := total2asstor P Q). set (g:= total2asstol P Q).
   split with f.
-  assert (egf : Π xpq : _ , (g (f xpq)) = xpq).
+  assert (egf : ∏ xpq : _ , (g (f xpq)) = xpq).
   intro. induction xpq as [ xp q ]. induction xp as [ x p ]. apply idpath.
-  assert (efg : Π xpq : _ , (f (g xpq)) = xpq).
+  assert (efg : ∏ xpq : _ , (f (g xpq)) = xpq).
   intro. induction xpq as [ x pq ]. induction pq as [ p q ]. apply idpath.
   apply (gradth _ _ egf efg).
 Defined.
 
 Definition weqtotal2asstol {X : UU} (P : X -> UU) (Q : total2 P -> UU) :
-  weq (Σ x : X, Σ p : P x, Q (tpair P x p)) (total2 Q)
+  weq (∑ x : X, ∑ p : P x, Q (tpair P x p)) (total2 Q)
   := invweq (weqtotal2asstor P Q).
 
 (** *** Associativity and commutativity of direct products as weak equivalences *)
@@ -2162,15 +2162,15 @@ Proof.
   intros.
   set (f := fun xy : dirprod X Y => dirprodpair (pr2 xy) (pr1 xy)).
   set (g := fun yx : dirprod Y X => dirprodpair (pr2 yx) (pr1 yx)).
-  assert (egf : Π xy : _, (g (f xy)) = xy).
+  assert (egf : ∏ xy : _, (g (f xy)) = xy).
   intro. induction xy. apply idpath.
-  assert (efg : Π yx : _, (f (g yx)) = yx).
+  assert (efg : ∏ yx : _, (f (g yx)) = yx).
   intro. induction yx. apply idpath.
   split with f. apply (gradth _ _ egf efg).
 Defined.
 
 Definition weqtotal2dirprodcomm {X Y : UU} (P : X × Y -> UU) :
-  (Σ xy : X × Y, P xy) ≃ (Σ xy : Y × X, P (weqdirprodcomm _ _ xy)).
+  (∑ xy : X × Y, P xy) ≃ (∑ xy : Y × X, P (weqdirprodcomm _ _ xy)).
 Proof.
   intros.
   use weqgradth.
@@ -2185,7 +2185,7 @@ Proof.
 Defined.
 
 Definition weqtotal2dirprodassoc  {X Y : UU} (P : X × Y -> UU) :
-  (Σ xy : X × Y, P xy) ≃ (Σ (x : X) (y : Y), P (x,,y)).
+  (∑ xy : X × Y, P xy) ≃ (∑ (x : X) (y : Y), P (x,,y)).
   intros.
   simple refine (weqgradth _ _ _ _).
   - intros xyp. induction xyp as [xy p]. induction xy as [x y].
@@ -2199,7 +2199,7 @@ Definition weqtotal2dirprodassoc  {X Y : UU} (P : X × Y -> UU) :
 Defined.
 
 Definition weqtotal2dirprodassoc' {X Y : UU} (P : X × Y -> UU) :
-  (Σ xy : X × Y, P xy) ≃ (Σ (y : Y) (x : X), P (x,,y)).
+  (∑ xy : X × Y, P xy) ≃ (∑ (y : Y) (x : X), P (x,,y)).
 Proof.
   intros.
   simple refine (weqgradth _ _ _ _).
@@ -2214,7 +2214,7 @@ Proof.
 Defined.
 
 Definition weqtotal2comm12 {X} (P Q : X -> UU) :
-  (Σ (w : Σ x, P x), Q (pr1 w)) ≃ (Σ (w : Σ x, Q x), P (pr1 w)).
+  (∑ (w : ∑ x, P x), Q (pr1 w)) ≃ (∑ (w : ∑ x, Q x), P (pr1 w)).
 Proof.
   intros.
   simple refine (weqgradth _ _ _ _).
@@ -2256,11 +2256,11 @@ Proof.
   intros.
   set (f := rdistrtoprod X Y Z). set (g := rdistrtocoprod X Y Z).
 
-  assert (egf: Π a:_, (g (f a)) = a).
+  assert (egf: ∏ a:_, (g (f a)) = a).
   intro. induction a as [ d | d ]. induction d. apply idpath. induction d.
   apply idpath.
 
-  assert (efg: Π a:_, (f (g a)) = a). intro. induction a as [ t x ].
+  assert (efg: ∏ a:_, (f (g a)) = a). intro. induction a as [ t x ].
   induction x. apply idpath. apply idpath.
 
   apply (gradth f g egf efg).
@@ -2278,7 +2278,7 @@ Definition weqrdistrtocoprod (X Y Z : UU)
 (** *** Total space of a family over a coproduct *)
 
 Definition fromtotal2overcoprod {X Y : UU} (P : X ⨿ Y -> UU) (xyp : total2 P) :
-  coprod (Σ x : X, P (ii1 x)) (Σ y : Y, P (ii2 y)).
+  coprod (∑ x : X, P (ii1 x)) (∑ y : Y, P (ii2 y)).
 Proof.
   intros.
   set (PX := fun x : X => P (ii1 x)). set (PY := fun y : Y => P (ii2 y)).
@@ -2287,7 +2287,7 @@ Proof.
 Defined.
 
 Definition tototal2overcoprod {X Y : UU} (P : X ⨿ Y -> UU)
-           (xpyp : coprod (Σ x : X, P (ii1 x)) (Σ y : Y, P (ii2 y))) : total2 P.
+           (xpyp : coprod (∑ x : X, P (ii1 x)) (∑ y : Y, P (ii2 y))) : total2 P.
 Proof.
   intros.
   induction xpyp as [ xp | yp ]. induction xp as [ x p ].
@@ -2296,12 +2296,12 @@ Proof.
 Defined.
 
 Theorem weqtotal2overcoprod {X Y : UU} (P : X ⨿ Y -> UU) :
-  (Σ xy, P xy) ≃ (Σ x : X, P (ii1 x)) ⨿ (Σ y : Y, P (ii2 y)).
+  (∑ xy, P xy) ≃ (∑ x : X, P (ii1 x)) ⨿ (∑ y : Y, P (ii2 y)).
 Proof.
   intros.
   set (f := fromtotal2overcoprod P). set (g := tototal2overcoprod P).
   split with f.
-  assert (egf : Π a : _ , (g (f a)) = a).
+  assert (egf : ∏ a : _ , (g (f a)) = a).
   { intro a.
     induction a as [ xy p ].
     induction xy as [ x | y ].
@@ -2309,7 +2309,7 @@ Proof.
     apply idpath.
     simpl.
     apply idpath. }
-  assert (efg : Π a : _ , (f (g a)) = a).
+  assert (efg : ∏ a : _ , (f (g a)) = a).
   { intro a.
     induction a as [ xp | yp ].
     induction xp as [ x p ].
@@ -2357,10 +2357,10 @@ Defined.
 Theorem isweqcoprodasstor (X Y Z : UU): isweq (coprodasstor X Y Z).
 Proof.
   intros. set (f := coprodasstor X Y Z). set (g := coprodasstol X Y Z).
-  assert (egf : Π xyz:_, (g (f xyz)) = xyz).
+  assert (egf : ∏ xyz:_, (g (f xyz)) = xyz).
   intro xyz. induction xyz as [ c | z ].  induction c.
   apply idpath. apply idpath. apply idpath.
-  assert (efg : Π xyz:_, (f (g xyz)) = xyz). intro xyz.
+  assert (efg : ∏ xyz:_, (f (g xyz)) = xyz). intro xyz.
   induction xyz as [ x | c ].  apply idpath. induction c.
   apply idpath. apply idpath.
   apply (gradth f g egf efg).
@@ -2380,9 +2380,9 @@ Theorem isweqcoprodcomm (X Y : UU) : isweq (coprodcomm X Y).
 Proof.
   intros.
   set (f := coprodcomm X Y). set (g := coprodcomm Y X).
-  assert (egf : Π xy : _, (g (f xy)) = xy). intro.
+  assert (egf : ∏ xy : _, (g (f xy)) = xy). intro.
   induction xy. apply idpath. apply idpath.
-  assert (efg : Π yx : _, (f (g yx)) = yx). intro.
+  assert (efg : ∏ yx : _, (f (g yx)) = yx). intro.
   induction yx. apply idpath. apply idpath.
   apply (gradth f g egf efg).
 Defined.
@@ -2399,8 +2399,8 @@ Proof.
                               | ii1 x => x
                               | ii2 y => fromempty (nf y)
                               end).
-  assert (egf : Π x : X, (g (f x)) = x). intro. apply idpath.
-  assert (efg : Π xy : X ⨿ Y, (f (g xy)) = xy). intro.
+  assert (egf : ∏ x : X, (g (f x)) = x). intro. apply idpath.
+  assert (efg : ∏ xy : X ⨿ Y, (f (g xy)) = xy). intro.
   induction xy as [ x | y ]. apply idpath. apply (fromempty (nf y)).
   apply (gradth f g egf efg).
 Defined.
@@ -2416,8 +2416,8 @@ Proof.
                              | ii1 x => fromempty (nf x)
                              | ii2 y => y
                              end).
-  assert (egf : Π y : Y, (g (f y)) = y). intro. apply idpath.
-  assert (efg : Π xy : X ⨿ Y, (f (g xy)) = xy). intro.
+  assert (egf : ∏ y : Y, (g (f y)) = y). intro. apply idpath.
+  assert (efg : ∏ xy : X ⨿ Y, (f (g xy)) = xy). intro.
   induction xy as [ x | y ]. apply (fromempty (nf x)). apply idpath.
   apply (gradth f g egf efg).
 Defined.
@@ -2460,11 +2460,11 @@ Proof.
   intros.
   set (finv := invmap w). set (ginv := invmap w').
   set (ff := coprodf w w'). set (gg := coprodf finv ginv).
-  assert (egf : Π xy : X ⨿ Y, (gg (ff xy)) = xy).
+  assert (egf : ∏ xy : X ⨿ Y, (gg (ff xy)) = xy).
   intro. induction xy as [ x | y ]. simpl.
   apply (maponpaths (@ii1 X Y) (homotinvweqweq w x)).
   apply (maponpaths (@ii2 X Y) (homotinvweqweq w' y)).
-  assert (efg : Π xy' : coprod X' Y', (ff (gg xy')) = xy').
+  assert (efg : ∏ xy' : coprod X' Y', (ff (gg xy')) = xy').
   intro. induction xy' as [ x | y ]. simpl.
   apply (maponpaths (@ii1 X' Y') (homotweqinvweq w x)).
   apply (maponpaths (@ii2 X' Y') (homotweqinvweq w' y)).
@@ -2549,11 +2549,11 @@ Proof.
   split with f.
   set (g := fun t:bool => match t with true => ii1 tt | false => ii2 tt end).
 
-  assert (egf : Π xx : _, g (f xx) = xx).
+  assert (egf : ∏ xx : _, g (f xx) = xx).
   intro xx. induction xx as [ u | u ]. induction u. apply idpath.
   induction u. apply idpath.
 
-  assert (efg : Π t : _, f (g t) = t). induction t. apply idpath.
+  assert (efg : ∏ t : _, f (g t) = t). induction t. apply idpath.
   apply idpath.
 
   apply (gradth f g egf efg).
@@ -2590,9 +2590,9 @@ Theorem isweqcoprodtoboolsum (X Y : UU) : isweq (coprodtoboolsum X Y).
 Proof.
   intros.
   set (f := coprodtoboolsum X Y). set (g := boolsumtocoprod X Y).
-  assert (egf : Π xy : X ⨿ Y , (g (f xy)) = xy).
+  assert (egf : ∏ xy : X ⨿ Y , (g (f xy)) = xy).
   induction xy. apply idpath. apply idpath.
-  assert (efg : Π xy : total2 (boolsumfun X Y), (f (g xy)) = xy).
+  assert (efg : ∏ xy : total2 (boolsumfun X Y), (f (g xy)) = xy).
   intro. induction xy as [ t x ]. induction t. apply idpath. apply idpath.
   apply (gradth f g egf efg).
 Defined.
@@ -2608,7 +2608,7 @@ Definition weqboolsumtocoprod (X Y : UU) := weqpair _ (isweqboolsumtocoprod X Y)
 (** *** Splitting of [ X ] into a coproduct defined by a function [ X -> Y ⨿ Z ] *)
 
 Definition weqcoprodsplit {X Y Z : UU} (f : X -> coprod Y Z) :
-  X ≃ (Σ y : Y, hfiber f (ii1 y)) ⨿ (Σ z : Z, hfiber f (ii2 z)).
+  X ≃ (∑ y : Y, hfiber f (ii1 y)) ⨿ (∑ z : Z, hfiber f (ii2 z)).
 Proof.
   intros.
   set (w1 := weqtococonusf f).
@@ -2660,12 +2660,12 @@ space is weakly equivalent to this fiber. *)
 (* The current proof added by P. L. Lumsdaine, 2016 *)
 
 Theorem onefiber {X : UU} (P : X -> UU) (x : X)
-        (c : Π x' : X, (x = x') ⨿ ¬ P x') : isweq (λ p, tpair P x p).
+        (c : ∏ x' : X, (x = x') ⨿ ¬ P x') : isweq (λ p, tpair P x p).
 Proof.
   intros.
   set (f := fun p : P x => tpair _ x p).
   set (cx := c x).
-  transparent assert (cnew : (Π x' : X, (x = x') ⨿ ¬ P x')).
+  transparent assert (cnew : (∏ x' : X, (x = x') ⨿ ¬ P x')).
   { intro x'. refine (coprod_rect (fun _ => _) _ _ (cx)).
     - intro x0. refine (coprod_rect (fun _ => _) _ _ (c x')).
       + intro ee. apply ii1; exact (pathscomp0 (pathsinv0 x0) ee).
@@ -2680,7 +2680,7 @@ Proof.
               end).
 
 
-  assert (efg : Π pp : total2 P, (f (g pp)) = pp).
+  assert (efg : ∏ pp : total2 P, (f (g pp)) = pp).
   intro. induction pp as [ t x0 ]. set (cnewt := cnew t).
   unfold g. unfold f. simpl. change (cnew t) with cnewt.
   induction cnewt as [ x1 | y ].
@@ -2694,7 +2694,7 @@ Proof.
   assert (e : (cnewx) = (ii1  (idpath x))).
   apply (maponpaths (@ii1 (x = x) (P x -> empty)) (pathsinv0l x0)).
 
-  assert (egf : Π p: P x, (g (f p)) = p). intro. simpl in g.
+  assert (egf : ∏ p: P x, (g (f p)) = p). intro. simpl in g.
   unfold g. unfold f. simpl.
 
   set (ff := fun cc:coprod (x = x) (P x -> empty) =>
@@ -2728,7 +2728,7 @@ important computational toolboxes of homotopy theory.
 Given a pair of functions [ (f : X -> Y) (g : Y -> Z) ] and a point [ z : Z ] ,
 a structure of the complex on such a triple is a homotopy from the composition
 [ funcomp f g ] to the constant function [ X -> Z ] corresponding to [ z ] i.e.
-a term [ ez : Π x : X, (g (f x)) = z ]. Specifing such a structure is
+a term [ ez : ∏ x : X, (g (f x)) = z ]. Specifing such a structure is
 essentially equivalent to specifing a structure of the form
 [ ezmap : X -> hfiber g z ]. The mapping in one direction is given in the
 definition of [ ezmap ] below. The mapping in another is given by
@@ -2787,7 +2787,7 @@ functions [ (f : X -> Y) (g : Y -> Z) ] and any terms
   [ (f : X -> Y) (g : Y -> Z) ] relative to a term [ z : Z ]. *)
 
 Definition complxstr {X Y Z : UU} (f : X -> Y) (g : Y -> Z) (z : Z)
-  := Π x : X, (g (f x)) = z.
+  := ∏ x : X, (g (f x)) = z.
 
 
 (** The structure of a fibration sequence on a complex. *)
@@ -2800,7 +2800,7 @@ Definition isfibseq {X Y Z : UU} (f : X -> Y) (g : Y -> Z) (z : Z)
            (ez : complxstr f g z) := isweq (ezmap f g z ez).
 
 Definition fibseqstr {X Y Z : UU} (f : X -> Y) (g : Y -> Z) (z : Z)
-  := Σ ez : complxstr f g z, isfibseq f g z ez.
+  := ∑ ez : complxstr f g z, isfibseq f g z ez.
 Definition fibseqstrpair {X Y Z : UU} (f : X -> Y) (g : Y -> Z) (z : Z)
   := tpair (fun ez : complxstr f g z => isfibseq f g z ez).
 Definition fibseqstrtocomplxstr {X Y Z : UU} (f : X -> Y) (g : Y -> Z) (z : Z) :
@@ -2846,11 +2846,11 @@ Theorem isweqezmap1 {X Y Z : UU} (f : X -> Y) (g : Y -> Z) (z : Z)
 Proof.
   intros.
   set (ff := ezmap1 f g z fs y). set (gg := invezmap1 f g z (pr1 fs) y).
-  assert (egf : Π e : _, (gg (ff e)) = e).
+  assert (egf : ∏ e : _, (gg (ff e)) = e).
   intro. simpl.
   apply (hfibertriangle1inv0 g (homotweqinvweq (ezweq f g z fs)
                                                (hfiberpair g y e))).
-  assert (efg : Π xe : _, (ff (gg xe)) = xe).
+  assert (efg : ∏ xe : _, (ff (gg xe)) = xe).
   intro. induction xe as [ x e ]. induction e. simpl.
   unfold ff. unfold ezmap1. unfold d1.
   change (hfiberpair g (f x) (pr1 fs x)) with (ezmap f g z fs x).
@@ -2919,9 +2919,9 @@ Definition isweqezmappr1 {Z : UU} (P : Z -> UU) (z : Z) :
   isweq (ezmappr1 P z).
 Proof.
   intros.
-  assert (egf : Π x: P z , (invezmappr1 _ z ((ezmappr1 P z) x)) = x).
+  assert (egf : ∏ x: P z , (invezmappr1 _ z ((ezmappr1 P z) x)) = x).
   intro. unfold ezmappr1. unfold invezmappr1. simpl. apply idpath.
-  assert (efg : Π x: hfiber (@pr1 Z P) z ,
+  assert (efg : ∏ x: hfiber (@pr1 Z P) z ,
                      (ezmappr1 _ z (invezmappr1 P z x)) = x).
   intros. induction x as [ x t0 ]. induction t0. simpl in x. simpl.
   induction x. simpl. unfold transportf. unfold ezmappr1. apply idpath.
@@ -2959,7 +2959,7 @@ Theorem isfibseqg {Y Z : UU} (g : Y -> Z) (z : Z) :
   isfibseq (hfiberpr1 g z) g z (fun ye: _ => pr2 ye).
 Proof.
   intros.
-  assert (Y0 : Π ye' : hfiber g z,
+  assert (Y0 : ∏ ye' : hfiber g z,
                        ye' = (ezmap (hfiberpr1 g z) g z (fun ye: _ => pr2 ye)
                                     ye')).
   intro. apply tppr. apply (isweqhomot _ _ Y0 (idisweq _)).
@@ -3099,11 +3099,11 @@ Theorem isweqezmaphf {X Y Z : UU} (f : X -> Y) (g : Y -> Z)
 Proof.
   intros.
   set (ff := ezmaphf f g z ye). set (gg := invezmaphf f g z ye).
-  assert (egf : Π xe : _ , (gg (ff xe)) = xe).
+  assert (egf : ∏ xe : _ , (gg (ff xe)) = xe).
   induction ye as [ y e ]. induction e. intro xe.
   apply (hfibertriangle2 f (gg (ff xe)) xe (idpath (pr1 xe))).
   induction xe as [ x ex ]. simpl in ex. induction ex. simpl. apply idpath.
-  assert (efg : Π xee' : _ , (ff (gg xee')) = xee').
+  assert (efg : ∏ xee' : _ , (ff (gg xee')) = xee').
   induction ye as [ y e ]. induction e. intro xee'.
   assert (hint : (ff (gg xee'))
                  = (ffgg f g (g y) (hfiberpair g y (idpath _)) xee')).
@@ -3150,12 +3150,12 @@ equivalences. *)
 
 *)
 
-Definition totalfun {X : UU} (P Q : X -> UU) (f : Π x : X, P x -> Q x)
+Definition totalfun {X : UU} (P Q : X -> UU) (f : ∏ x : X, P x -> Q x)
   := (fun z: total2 P => tpair Q (pr1 z) (f (pr1 z) (pr2 z))).
 
 
-Theorem isweqtotaltofib {X : UU} (P Q : X -> UU) (f : Π x : X, P x -> Q x):
-  isweq (totalfun _ _ f) -> Π x : X, isweq (f x).
+Theorem isweqtotaltofib {X : UU} (P Q : X -> UU) (f : ∏ x : X, P x -> Q x):
+  isweq (totalfun _ _ f) -> ∏ x : X, isweq (f x).
 Proof.
   intros X P Q f X0 x.
   set (totp := total2 P). set (totq := total2 Q).
@@ -3173,19 +3173,19 @@ Proof.
   assert (is2 : isweq h).
   apply (twooutof3c ip hfx (isweqezmappr1 P x) H).
   set (h':= fun p: P x => iq ((f x) p)).
-  assert (ee : Π p:P x, (h p) = (h' p)). intro. apply idpath.
+  assert (ee : ∏ p:P x, (h p) = (h' p)). intro. apply idpath.
   assert (X2 : isweq h'). apply (isweqhomot h h' ee is2).
   apply (twooutof3a (f x) iq X2).
   apply (isweqezmappr1 Q x).
 Defined.
 
 
-Definition weqtotaltofib {X : UU} (P Q : X -> UU) (f : Π x : X , P x -> Q x)
+Definition weqtotaltofib {X : UU} (P Q : X -> UU) (f : ∏ x : X , P x -> Q x)
            (is : isweq (totalfun _ _ f)) (x : X) : weq (P x) (Q x)
   := weqpair _ (isweqtotaltofib P Q f is x).
 
 
-Theorem isweqfibtototal {X : UU} (P Q : X -> UU) (f : Π x : X, weq (P x) (Q x)) :
+Theorem isweqfibtototal {X : UU} (P Q : X -> UU) (f : ∏ x : X, weq (P x) (Q x)) :
   isweq (totalfun _ _ f).
 Proof.
   intros X P Q f.
@@ -3208,8 +3208,8 @@ Proof.
   apply (iscontrweqf (weqpair intmap (isweqinvezmaphf fpq pr1q x xqe)) isint).
 Defined.
 
-Definition weqfibtototal {X : UU} (P Q : X -> UU) (f : Π x, P x ≃ Q x) :
-  (Σ x, P x) ≃ (Σ x, Q x) := weqpair _ (isweqfibtototal P Q f).
+Definition weqfibtototal {X : UU} (P Q : X -> UU) (f : ∏ x, P x ≃ Q x) :
+  (∑ x, P x) ≃ (∑ x, Q x) := weqpair _ (isweqfibtototal P Q f).
 
 
 (** *** Function [ fpmap ] between the total spaces from a function between the bases
@@ -3222,10 +3222,10 @@ particular, if  [ f ] is a weak equivalence then so is [ fpmap ]. *)
 
 
 Definition fpmap {X Y : UU} (f : X -> Y) (P : Y -> UU) :
-  (Σ x, P (f x)) -> (Σ y, P y) := λ z, tpair P (f (pr1 z)) (pr2 z).
+  (∑ x, P (f x)) -> (∑ y, P y) := λ z, tpair P (f (pr1 z)) (pr2 z).
 
 Definition hffpmap2 {X Y : UU} (f : X -> Y) (P : Y -> UU) :
-  (Σ x, P (f x)) -> Σ u : total2 P, hfiber f (pr1 u).
+  (∑ x, P (f x)) -> ∑ u : total2 P, hfiber f (pr1 u).
 Proof.
   intros X Y f P X0.
   set (u:= fpmap f P X0).
@@ -3245,13 +3245,13 @@ Proof.
   set (g := fun z: total2 (fun u: coconusfromt X x => P (pr1 u))
             => transportf P (pathsinv0 (pr2 (pr1 z))) (pr2 z)).
 
-  assert (efg : Π z : total2 (fun u : coconusfromt X x => P (pr1 u)),
+  assert (efg : ∏ z : total2 (fun u : coconusfromt X x => P (pr1 u)),
                       (f (g z)) = z).
   intro.
   induction z as [ t x0 ]. induction t as [ t x1 ].
   simpl. induction x1. simpl. apply idpath.
 
-  assert (egf : Π p : P x , (g (f p)) = p). intro. apply idpath.
+  assert (egf : ∏ p : P x , (g (f p)) = p). intro. apply idpath.
 
   apply (gradth f g egf efg).
 Defined.
@@ -3274,13 +3274,13 @@ Proof.
                            (tpair P (pr1 (pr1 (pr2 z))) (pr2 (pr2 z)))
                            (hfiberpair f (pr1 z) (pr2 (pr1 (pr2 z))))).
 
-  assert (fromto : Π u : (total2 (fun u : total2 P => hfiber f (pr1 u))),
+  assert (fromto : ∏ u : (total2 (fun u : total2 P => hfiber f (pr1 u))),
                          (fromint (toint u)) = u).
   simpl in toint. simpl in fromint. simpl.
   intro u. induction u as [ t x ]. induction x. induction t as [ p0 p1 ].
   simpl. unfold toint. unfold fromint. simpl. apply idpath.
 
-  assert (tofrom : Π u : int, (toint (fromint u)) = u).
+  assert (tofrom : ∏ u : int, (toint (fromint u)) = u).
   intro. induction u as [ t x ]. induction x as [ t0 x ]. induction t0.
   simpl in x. simpl. unfold fromint. unfold toint. simpl. apply idpath.
 
@@ -3290,7 +3290,7 @@ Proof.
   set (h := fun u : total2 (fun x : X => P (f x)) => toint ((hffpmap2 f P) u)).
   simpl in h.
 
-  assert (l1 : Π x : X, isweq (fun p: P (f x) =>
+  assert (l1 : ∏ x : X, isweq (fun p: P (f x) =>
                                  tpair (fun u : coconusfromt _ (f x) => P (pr1 u))
                                        (coconusfromtpair _ (idpath (f x))) p)).
   intro. apply (centralfiber P (f x)).
@@ -3311,7 +3311,7 @@ Definition hfiberfpmap {X Y : UU} (f : X -> Y) (P : Y -> UU) (yp : total2 P) :
 Proof.
   intros X Y f P yp X0.
   set (int1:= hfibersgftog (hffpmap2 f P)
-                           (fun u : (Σ u : total2 P, hfiber f (pr1  u))
+                           (fun u : (∑ u : total2 P, hfiber f (pr1  u))
                             => (pr1 u)) yp).
   set (phi := invezmappr1 (fun u:total2 P => hfiber f (pr1 u)) yp).
   apply (phi (int1 X0)).
@@ -3351,13 +3351,13 @@ Proof.
 Defined.
 
 Definition weqfp_map {X Y : UU} (w : X ≃ Y) (P : Y -> UU) :
-  (Σ x, P(w x)) -> (Σ y, P y).
+  (∑ x, P(w x)) -> (∑ y, P y).
 Proof.
   intros ? ? ? ? xp. exact (w (pr1 xp),,pr2 xp).
 Defined.
 
 Definition weqfp_invmap {X Y : UU} (w : X ≃ Y) (P : Y -> UU) :
-  (Σ y, P y) -> (Σ x, P(w x)).
+  (∑ y, P y) -> (∑ x, P(w x)).
 Proof.
   intros ? ? ? ? yp.
   exact (invmap w (pr1 yp),,
@@ -3365,7 +3365,7 @@ Proof.
 Defined.
 
 Definition weqfp {X Y : UU} (w : X ≃ Y) (P : Y -> UU) :
-  (Σ x : X, P (w x)) ≃ (Σ y, P y).
+  (∑ x : X, P (w x)) ≃ (∑ y, P y).
 Proof.
   intros.
   exists (weqfp_map w P).
@@ -3402,38 +3402,38 @@ Defined.
 Definition tototal2overunit (P : unit -> UU) (p : P tt) : total2 P
   := tpair P tt p.
 
-Theorem weqtotal2overunit (P : unit -> UU) : (Σ u, P u) ≃ P tt.
+Theorem weqtotal2overunit (P : unit -> UU) : (∑ u, P u) ≃ P tt.
 Proof.
   intro.
   set (f := fromtotal2overunit P). set (g := tototal2overunit P).
   split with f.
-  assert (egf : Π a : _ , (g (f a)) = a).
+  assert (egf : ∏ a : _ , (g (f a)) = a).
   intro a. induction a as [ t p ]. induction t. apply idpath.
-  assert (efg : Π a : _ , (f (g a)) = a).
+  assert (efg : ∏ a : _ , (f (g a)) = a).
   intro a. apply idpath. apply (gradth _ _ egf efg).
 Defined.
 
 (** *** The function on the total spaces from functions on the bases and on the fibers *)
 
 Definition bandfmap {X Y : UU} (f : X -> Y) (P : X -> UU) (Q : Y -> UU)
-           (fm : Π x : X, P x -> (Q (f x))) :
-  (Σ x, P x) -> (Σ x, Q x) := λ xp, f (pr1 xp) ,, fm (pr1 xp) (pr2 xp).
+           (fm : ∏ x : X, P x -> (Q (f x))) :
+  (∑ x, P x) -> (∑ x, Q x) := λ xp, f (pr1 xp) ,, fm (pr1 xp) (pr2 xp).
 
 Theorem isweqbandfmap {X Y : UU} (w : X ≃ Y) (P : X -> UU) (Q : Y -> UU)
-        (fw : Π x : X, weq (P x) (Q (w x))) : isweq (bandfmap  _ P Q fw).
+        (fw : ∏ x : X, weq (P x) (Q (w x))) : isweq (bandfmap  _ P Q fw).
 Proof.
   intros.
   set (f1 := totalfun P _ fw).
   set (is1 := isweqfibtototal P (fun x:X => Q (w x)) fw).
   set (f2:= fpmap w Q).
   set (is2:= isweqfpmap w Q).
-  assert (h: Π xp: total2 P, (f2 (f1 xp)) = (bandfmap w P Q fw xp)).
+  assert (h: ∏ xp: total2 P, (f2 (f1 xp)) = (bandfmap w P Q fw xp)).
   intro. induction xp. apply idpath.
   apply (isweqhomot _ _ h (twooutof3c f1 f2 is1 is2)).
 Defined.
 
 Definition weqbandf {X Y : UU} (w : X ≃ Y) (P : X -> UU) (Q : Y -> UU)
-           (fw : Π x : X, weq (P x) (Q (w x)))
+           (fw : ∏ x : X, weq (P x) (Q (w x)))
   := weqpair _ (isweqbandfmap w P Q fw).
 
 
@@ -3443,7 +3443,7 @@ Definition weqbandf {X Y : UU} (w : X ≃ Y) (P : X -> UU) (Q : Y -> UU)
 (** *** Homotopy commutative squares *)
 
 Definition commsqstr {X X' Y Z : UU} (g' : Z -> X') (f' : X' -> Y) (g : Z -> X)
-           (f : X -> Y) := Π (z : Z), (f' (g' z)) = (f (g z)).
+           (f : X -> Y) := ∏ (z : Z), (f' (g' z)) = (f (g z)).
 
 Definition hfibersgtof' {X X' Y Z : UU} (f : X -> Y) (f' : X' -> Y) (g : Z -> X)
            (g' : Z -> X') (h : commsqstr g' f' g f) (x : X) (ze : hfiber g x) :
@@ -3502,12 +3502,12 @@ Definition commsqZtohfp {X X' Y Z : UU} (f : X -> Y) (f' : X' -> Y)
 
 Definition commsqZtohfphomot {X X' Y Z : UU} (f : X -> Y) (f' : X' -> Y)
            (g : Z -> X) (g' : Z -> X') (h : commsqstr g' f' g f) :
-  Π z : Z, (hfpg _ _ (commsqZtohfp _ _ _ _ h z)) = (g z)
+  ∏ z : Z, (hfpg _ _ (commsqZtohfp _ _ _ _ h z)) = (g z)
   := fun z : _ => idpath _.
 
 Definition commsqZtohfphomot' {X X' Y Z : UU} (f : X -> Y) (f' : X' -> Y)
            (g : Z -> X) (g' : Z -> X') (h : commsqstr g' f' g f) :
-  Π z : Z, (hfpg' _ _ (commsqZtohfp _ _ _ _ h z)) = (g' z)
+  ∏ z : Z, (hfpg' _ _ (commsqZtohfp _ _ _ _ h z)) = (g' z)
   := fun z : _ => idpath _.
 
 
@@ -3582,20 +3582,20 @@ Proof.
   set (ff := hfibertohfp f y).
   set (gg := hfptohfiber f y).
   split with ff.
-  assert (egf : Π xe : _, (gg (ff xe)) = xe).
+  assert (egf : ∏ xe : _, (gg (ff xe)) = xe).
   intro. induction xe. apply idpath.
-  assert (efg : Π hf : _, (ff (gg hf)) = hf).
+  assert (efg : ∏ hf : _, (ff (gg hf)) = hf).
   intro.
   induction hf as [ tx e ]. induction tx as [ t x ].
   induction t. apply idpath. apply (gradth _ _ egf efg).
 Defined.
 
 Lemma hfp_left {X Y Z : UU} (f : X -> Z) (g : Y -> Z) :
-  hfp f g ≃ Σ x, hfiber g (f x).
+  hfp f g ≃ ∑ x, hfiber g (f x).
 Proof. intros. apply weqtotal2dirprodassoc. Defined.
 
 Definition hfp_right {X Y Z : UU} (f : X -> Z) (g : Y -> Z) :
-  hfp f g ≃ Σ y, hfiber f (g y).
+  hfp f g ≃ ∑ y, hfiber f (g y).
 Proof.
   intros. simple refine (weqgradth _ _ _ _).
   - intros [[x y] e]. exact (y,,x,,!e).
@@ -3605,7 +3605,7 @@ Proof.
 Defined.
 
 Definition hfiber_comm {X Y Z : UU} (f : X -> Z) (g : Y -> Z) :
-  (Σ x, hfiber g (f x)) ≃ (Σ y, hfiber f (g y)).
+  (∑ x, hfiber g (f x)) ≃ (∑ y, hfiber f (g y)).
 Proof.
   intros. simple refine (weqgradth _ _ _ _).
   - intros [x [y e]]. exact (y,,x,,!e).
@@ -3651,7 +3651,7 @@ Proof.
   set (d := weqhfptohfpoverX f f').
   set (b0 := totalfun _ _ (hfibersgtof' f f' g g' h)).
 
-  assert (h1 : Π z : Z, (d (c z)) = (b0 (a z))).
+  assert (h1 : ∏ z : Z, (d (c z)) = (b0 (a z))).
   intro. simpl. unfold b0. unfold a. unfold weqtococonusf. unfold tococonusf.
   simpl. unfold totalfun, total2asstor, hfibersgtof'; simpl.
   assert (e : (h z) = (pathscomp0 (h z) (idpath (f (g z))))).
@@ -3672,7 +3672,7 @@ Definition weqhfibersgtof' {X X' Y Z : UU} (f : X -> Y) (f' : X' -> Y)
 
 Lemma ishfsqweqhfibersgtof' {X X' Y Z : UU} (f : X -> Y) (f' : X' -> Y)
       (g : Z -> X) (g' : Z -> X') (h : commsqstr g' f' g f)
-      (is : Π x : X, isweq (hfibersgtof' f f' g g' h x)) : hfsqstr f f' g g'.
+      (is : ∏ x : X, isweq (hfibersgtof' f f' g g' h x)) : hfsqstr f f' g g'.
 Proof.
   intros. split with h.
   set (a := weqtococonusf g).
@@ -3680,7 +3680,7 @@ Proof.
   set (d := weqhfptohfpoverX f f').
   set (b := weqfibtototal _ _ (fun x : X => weqpair _ (is x))).
 
-  assert (h1 : Π z : Z, (d (c0 z)) = (b (a z))).
+  assert (h1 : ∏ z : Z, (d (c0 z)) = (b (a z))).
   intro. simpl. unfold b. unfold a. unfold weqtococonusf. unfold tococonusf.
   simpl. unfold totalfun, total2asstor, hfibersgtof'; simpl.
   assert (e : (h z) = (pathscomp0 (h z) (idpath (f (g z))))).
@@ -3705,7 +3705,7 @@ Proof.
   set (d' := weqhfptohfpoverX' f f').
   set (b0' := totalfun _ _ (hfibersg'tof f f' g g' h)).
 
-  assert (h1 : Π z : Z, (d' (c' z)) = (b0' (a' z))).
+  assert (h1 : ∏ z : Z, (d' (c' z)) = (b0' (a' z))).
   intro. unfold b0'. unfold a'. unfold weqtococonusf. unfold tococonusf.
   unfold totalfun, hfibersg'tof; simpl.
   assert (e : (pathsinv0 (h z))
@@ -3726,7 +3726,7 @@ Definition weqhfibersg'tof {X X' Y Z : UU} (f : X -> Y) (f' : X' -> Y)
 
 Lemma ishfsqweqhfibersg'tof {X X' Y Z : UU} (f : X -> Y) (f' : X' -> Y)
       (g : Z -> X) (g' : Z -> X') (h : commsqstr g' f' g f)
-      (is : Π x' : X', isweq (hfibersg'tof f f' g g' h x')) : hfsqstr f f' g g'.
+      (is : ∏ x' : X', isweq (hfibersg'tof f f' g g' h x')) : hfsqstr f f' g g'.
 Proof.
   intros.
   split with h.
@@ -3735,7 +3735,7 @@ Proof.
   set (d' := weqhfptohfpoverX' f f').
   set (b' := weqfibtototal _ _ (fun x' : X' => weqpair _ (is x'))).
 
-  assert (h1 : Π z : Z, (d' (c0' z)) = (b' (a' z))).
+  assert (h1 : ∏ z : Z, (d' (c0' z)) = (b' (a' z))).
   intro. simpl. unfold b'. unfold a'. unfold weqtococonusf. unfold tococonusf.
   unfold totalfun, total2asstor, hfibersg'tof; simpl.
   assert (e : (pathsinv0 (h z)) =
@@ -3757,7 +3757,7 @@ Proof.
   set (th := transposcommsqstr f f' g g' h).
   split with th.
   set (w1 := weqhfpcomm f f').
-  assert (h1 : Π z : Z, (w1 (commsqZtohfp f f' g g' h z))
+  assert (h1 : ∏ z : Z, (w1 (commsqZtohfp f f' g g' h z))
                         = (commsqZtohfp f' f g' g th z)).
   intro. unfold commsqZtohfp. simpl. unfold fpmap. unfold totalfun.
   simpl. apply idpath.

--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -164,7 +164,7 @@ Definition termfun {X : UU} (x : X) : unit -> X := fun (t : unit) => x.
 
 Definition idfun (T : UU) := λ t:T, t.
 
-Definition funcomp {X Y : UU} {Z:Y->UU} (f : X -> Y) (g : Π y:Y, Z y) := λ x, g (f x).
+Definition funcomp {X Y : UU} {Z:Y->UU} (f : X -> Y) (g : ∏ y:Y, Z y) := λ x, g (f x).
 
 Notation "g ∘ f" := (funcomp f g) (at level 50, left associativity).
 

--- a/UniMath/Foundations/PartB.v
+++ b/UniMath/Foundations/PartB.v
@@ -51,13 +51,13 @@ Require Export UniMath.Foundations.PartA.
 Fixpoint isofhlevel (n : nat) (X : UU) : UU
   := match n with
      | O => iscontr X
-     | S m => Π x : X, Π x' : X, (isofhlevel m (paths x x'))
+     | S m => ∏ x : X, ∏ x' : X, (isofhlevel m (paths x x'))
      end.
 
 (* induction induction *)
 
 Theorem hlevelretract (n : nat) {X Y : UU} (p : X -> Y) (s : Y -> X)
-        (eps : Π y : Y , paths (p (s y)) y) : isofhlevel n X -> isofhlevel n Y.
+        (eps : ∏ y : Y , paths (p (s y)) y) : isofhlevel n X -> isofhlevel n Y.
 Proof.
   intro.
   induction n as [ | n IHn ].
@@ -91,10 +91,10 @@ Lemma isofhlevelsn (n : nat) {X : UU} (f : X -> isofhlevel (S n) X) :
 Proof. intros. simpl. intros x x'. apply (f x x x'). Defined.
 
 Lemma isofhlevelssn (n : nat) {X : UU}
-      (is : Π x : X, isofhlevel (S n) (paths x x)) : isofhlevel (S (S n)) X.
+      (is : ∏ x : X, isofhlevel (S n) (paths x x)) : isofhlevel (S (S n)) X.
 Proof.
   intros. simpl. intros x x'.
-  change (Π (x0 x'0 : paths x x'), isofhlevel n (paths x0 x'0))
+  change (∏ (x0 x'0 : paths x x'), isofhlevel n (paths x0 x'0))
   with (isofhlevel (S n) (paths x x')).
   assert (X1 : paths x x' -> isofhlevel (S n) (paths x x'))
     by (intro X2; induction X2; apply (is x)).
@@ -111,11 +111,11 @@ Defined.
 
 
 Definition isofhlevelf (n : nat) {X Y : UU} (f : X -> Y) : UU
-  := Π y : Y, isofhlevel n (hfiber f y).
+  := ∏ y : Y, isofhlevel n (hfiber f y).
 
 
 Theorem isofhlevelfhomot (n : nat) {X Y : UU} (f f' : X -> Y)
-        (h : Π x : X, paths (f x) (f' x)) :
+        (h : ∏ x : X, paths (f x) (f' x)) :
   isofhlevelf n f -> isofhlevelf n f'.
 Proof.
   intros n X Y f f' h X0.
@@ -174,15 +174,15 @@ Proof.
     apply (isweqcontrcontr f X0 is1).
 
   - intros X Y f X0 X1. unfold isofhlevelf. simpl.
-    assert (is1 : Π x' x : X, isofhlevel n (paths x' x))
+    assert (is1 : ∏ x' x : X, isofhlevel n (paths x' x))
       by (simpl in X0; assumption).
-    assert (is2 : Π y' y : Y, isofhlevel (S n) (paths y' y))
+    assert (is2 : ∏ y' y : Y, isofhlevel (S n) (paths y' y))
       by (simpl in X1; simpl; assumption).
-    assert (is3 : Π (y : Y) (x : X) (xe' : hfiber f y),
+    assert (is3 : ∏ (y : Y) (x : X) (xe' : hfiber f y),
                   isofhlevelf n (d2g f x xe'))
       by (intros; apply (IHn _ _ (d2g  f x xe') (is1 (pr1 xe') x)
                              (is2 (f x) y))).
-    assert (is4 : Π (y : Y) (x : X) (xe' : hfiber f y) (e : paths (f x) y),
+    assert (is4 : ∏ (y : Y) (x : X) (xe' : hfiber f y) (e : paths (f x) y),
                   isofhlevel n (paths (hfiberpair f x e) xe'))
       by (intros; apply (isofhlevelweqb n (ezweq3g f x xe' e) (is3 y x xe' e))).
     intros y xe xe'. induction xe as [ t x ].
@@ -198,16 +198,16 @@ Proof.
   - intros X Y f X0 X1.
     apply (iscontrweqb (weqpair f X0) X1).
   - intros X Y f X0 X1. simpl.
-    assert (is1 : Π (y : Y) (xe xe': hfiber f y), isofhlevel n (paths xe xe'))
+    assert (is1 : ∏ (y : Y) (xe xe': hfiber f y), isofhlevel n (paths xe xe'))
            by (intros; apply (X0 y)).
-    assert (is2 : Π (y : Y) (x : X) (xe' : hfiber f y),
+    assert (is2 : ∏ (y : Y) (x : X) (xe' : hfiber f y),
                   isofhlevelf n (d2g f x xe')).
     {
       intros. unfold isofhlevel. intro y0.
       apply (isofhlevelweqf n (ezweq3g f x xe' y0)
                             (is1 y (hfiberpair f x y0) xe')).
     }
-    assert (is3 : Π (y' y : Y), isofhlevel n (paths y' y))
+    assert (is3 : ∏ (y' y : Y), isofhlevel n (paths y' y))
       by (simpl in X1; assumption).
     intros x' x.
     set (y := f x'). set (e' := idpath y). set (xe' := hfiberpair f x' e').
@@ -220,7 +220,7 @@ Defined.
 
 
 Theorem  isofhlevelffib (n : nat) {X : UU} (P : X -> UU) (x : X)
-         (is : Π x' : X, isofhlevel n (paths x' x)) : isofhlevelf n (tpair P x).
+         (is : ∏ x' : X, isofhlevel n (paths x' x)) : isofhlevelf n (tpair P x).
 Proof.
   intros. unfold isofhlevelf. intro xp.
   apply (isofhlevelweqf n (ezweq1pr1 P x xp) (is (pr1 xp))).
@@ -229,7 +229,7 @@ Defined.
 
 
 Theorem isofhlevelfhfiberpr1y (n : nat) {X Y : UU} (f : X -> Y) (y : Y)
-        (is : Π y' : Y, isofhlevel n (paths y' y)) :
+        (is : ∏ y' : Y, isofhlevel n (paths y' y)) :
   isofhlevelf n (hfiberpr1 f y).
 Proof.
   intros. unfold isofhlevelf. intro x.
@@ -328,7 +328,7 @@ Defined.
 
 
 Corollary isofhlevelfhomot2 (n : nat) {X X' Y : UU} (f : X -> Y) (f' : X' -> Y)
-          (w : weq X X') (h : Π x : X, paths (f x) (f' (w x))) :
+          (w : weq X X') (h : ∏ x : X, paths (f x) (f' (w x))) :
   isofhlevelf n f -> isofhlevelf n f'.
 Proof.
   intros n X X' Y f f' w h X0.
@@ -351,7 +351,7 @@ Proof.
     apply (isofhlevelweqf n (ezweq3g f x xe' y0)
                           (X0 y (hfiberpair f x y0) xe')).
   }
-  assert (h : Π ee : paths x' x, paths (d2g f x xe' ee)
+  assert (h : ∏ ee : paths x' x, paths (d2g f x xe' ee)
                                        (maponpaths f (pathsinv0 ee))).
   {
     intro.
@@ -367,7 +367,7 @@ Defined.
 
 
 Theorem isofhlevelfsn (n : nat) {X Y : UU} (f : X -> Y) :
-  (Π x x' : X, isofhlevelf n (@maponpaths _ _ f x x')) -> isofhlevelf (S n) f.
+  (∏ x x' : X, isofhlevelf n (@maponpaths _ _ f x x')) -> isofhlevelf (S n) f.
 Proof.
   intros n X Y f X0. unfold isofhlevelf. intro y. simpl.
   intros x x'.
@@ -376,7 +376,7 @@ Proof.
   set (xe := hfiberpair f x e).
   set (d3 := d2g f x xe'). simpl in d3.
   assert (is1 : isofhlevelf n (d2g f x xe')).
-  assert (h : Π ee : paths x' x, paths (maponpaths f (pathsinv0  ee))
+  assert (h : ∏ ee : paths x' x, paths (maponpaths f (pathsinv0  ee))
                                        (d2g  f x xe' ee)).
   {
     intro. unfold d2g. simpl.
@@ -391,11 +391,11 @@ Defined.
 
 
 Theorem isofhlevelfssn (n : nat) {X Y : UU} (f : X -> Y) :
-  (Π x : X, isofhlevelf (S n) (@maponpaths _ _ f x x))
+  (∏ x : X, isofhlevelf (S n) (@maponpaths _ _ f x x))
   -> isofhlevelf (S (S n)) f.
 Proof.
   intros n X Y f X0. unfold isofhlevelf. intro y.
-  assert (Π xe0 : hfiber f y, isofhlevel (S n) (paths xe0 xe0)).
+  assert (∏ xe0 : hfiber f y, isofhlevel (S n) (paths xe0 xe0)).
   {
     intro. induction xe0 as [ x e ]. induction e.
     set (e':= idpath (f x)).
@@ -404,7 +404,7 @@ Proof.
     set (d3:= d2g f x xe'). simpl in d3.
     assert (is1: isofhlevelf (S n) (d2g f x xe')).
     {
-      assert (h : Π ee: paths x x, paths (maponpaths f (pathsinv0 ee))
+      assert (h : ∏ ee: paths x x, paths (maponpaths f (pathsinv0 ee))
                                          (d2g f x xe' ee)).
       {
         intro. unfold d2g. simpl.
@@ -431,13 +431,13 @@ Defined.
 
 
 Theorem isofhlevelfpr1 (n : nat) {X : UU} (P : X -> UU)
-        (is : Π x : X, isofhlevel n (P x)) : isofhlevelf n (@pr1 X P).
+        (is : ∏ x : X, isofhlevel n (P x)) : isofhlevelf n (@pr1 X P).
 Proof.
   intros. unfold isofhlevelf. intro x.
   apply (isofhlevelweqf n (ezweqpr1  _ x) (is x)).
 Defined.
 
-Lemma isweqpr1 {Z : UU} (P : Z -> UU) (is1 : Π z : Z, iscontr (P z)) :
+Lemma isweqpr1 {Z : UU} (P : Z -> UU) (is1 : ∏ z : Z, iscontr (P z)) :
   isweq (@pr1 Z P).
 Proof.
   intros. unfold isweq. intro y.
@@ -445,7 +445,7 @@ Proof.
   assumption.
 Defined.
 
-Definition weqpr1 {Z : UU} (P : Z -> UU) (is : Π z : Z , iscontr (P z)) :
+Definition weqpr1 {Z : UU} (P : Z -> UU) (is : ∏ z : Z , iscontr (P z)) :
   weq (total2 P) Z := weqpair _ (isweqpr1 P is).
 
 
@@ -454,7 +454,7 @@ Definition weqpr1 {Z : UU} (P : Z -> UU) (is : Π z : Z , iscontr (P z)) :
 (** *** h-level of the total space [ total2 ] *)
 
 Theorem isofhleveltotal2 (n : nat) {X : UU} (P : X -> UU) (is1 : isofhlevel n X)
-        (is2 : Π x : X, isofhlevel n (P x)) : isofhlevel n (total2 P).
+        (is2 : ∏ x : X, isofhlevel n (P x)) : isofhlevel n (total2 P).
 Proof.
   intros.
   apply (isofhlevelXfromfY n (@pr1 _ _)).
@@ -494,7 +494,7 @@ Proof. intros. apply isofhleveltotal2. assumption. intro. assumption. Defined.
 
 Definition isaprop := isofhlevel 1.
 
-Definition isPredicate {X : UU} (Y : X -> UU) := Π x : X, isaprop (Y x).
+Definition isPredicate {X : UU} (Y : X -> UU) := ∏ x : X, isaprop (Y x).
 
 Definition isapropunit : isaprop unit := iscontrpathsinunit.
 
@@ -517,9 +517,9 @@ Proof.
   intro. induction n as [ | n IHn ].
   - intro. apply isapropifcontr.
   - intro. intro X.
-    change (Π t1 t2 : T, isofhlevel (S n) (paths t1 t2)).
+    change (∏ t1 t2 : T, isofhlevel (S n) (paths t1 t2)).
     intros t1 t2.
-    change (Π t1 t2 : T, isofhlevel n (paths t1 t2)) in X.
+    change (∏ t1 t2 : T, isofhlevel n (paths t1 t2)) in X.
     set (XX := X t1 t2).
     apply (IHn _ XX).
 Defined.
@@ -571,7 +571,7 @@ Proof.
 Defined.
 
 Definition weqhfiberunit {X Z : UU} (i : X -> Z) (z : Z) :
-  (Σ x, hfiber (λ _ : unit, z) (i x)) ≃ hfiber i z.
+  (∑ x, hfiber (λ _ : unit, z) (i x)) ≃ hfiber i z.
 Proof.
   intros. simple refine (weqgradth _ _ _ _).
   + intros [x [t e]]. exact (x,,!e).
@@ -604,13 +604,13 @@ Proof.
   apply (isofhlevelsn O H).
 Defined.
 
-Lemma proofirrelevance (X : UU) (is : isaprop X) : Π x x' : X , paths x x'.
+Lemma proofirrelevance (X : UU) (is : isaprop X) : ∏ x x' : X , paths x x'.
 Proof.
   intros. unfold isaprop in is. unfold isofhlevel in is.
   apply (pr1 (is x x')).
 Defined.
 
-Lemma invproofirrelevance (X : UU) (ee : Π x x' : X , paths x x') : isaprop X.
+Lemma invproofirrelevance (X : UU) (ee : ∏ x x' : X , paths x x') : isaprop X.
 Proof.
   intros. unfold isaprop. unfold isofhlevel. intro x.
   assert (is1 : iscontr X) by
@@ -639,9 +639,9 @@ Lemma isweqimplimpl {X Y : UU} (f : X -> Y) (g : Y -> X) (isx : isaprop X)
       (isy : isaprop Y) : isweq f.
 Proof.
   intros.
-  assert (isx0: Π x : X, paths (g (f x)) x)
+  assert (isx0: ∏ x : X, paths (g (f x)) x)
          by (intro; apply proofirrelevance; apply isx).
-  assert (isy0 : Π y : Y, paths (f (g y)) y)
+  assert (isy0 : ∏ y : Y, paths (f (g y)) y)
          by (intro; apply proofirrelevance; apply isy).
   apply (gradth f g isx0 isy0).
 Defined.
@@ -755,7 +755,7 @@ Definition isapropinclb {X Y : UU} (f : X -> Y) (isf : isincl f) :
 
 
 Lemma iscontrhfiberofincl {X Y : UU} (f : X -> Y) :
-  isincl f -> (Π x : X, iscontr (hfiber f (f x))).
+  isincl f -> (∏ x : X, iscontr (hfiber f (f x))).
 Proof.
   intros X Y f X0 x. unfold isofhlevelf in X0.
   set (isy := X0 (f x)).
@@ -764,10 +764,10 @@ Defined.
 
 (* see incl_injectivity for the equivalence between isincl and isInjective *)
 Definition isInjective {X Y : UU} (f : X -> Y)
-  := Π (x x' : X), isweq (maponpaths f : x = x' -> f x = f x').
+  := ∏ (x x' : X), isweq (maponpaths f : x = x' -> f x = f x').
 
 Definition Injectivity {X Y : UU} (f : X -> Y) :
-  isInjective f -> Π (x x' : X), x = x'  ≃  f x = f x'.
+  isInjective f -> ∏ (x x' : X), x = x'  ≃  f x = f x'.
 Proof. intros ? ? ? i ? ?. exact (weqpair _ (i x x')). Defined.
 
 Lemma isweqonpathsincl {X Y : UU} (f : X -> Y) : isincl f -> isInjective f.
@@ -777,7 +777,7 @@ Definition weqonpathsincl {X Y : UU} (f : X -> Y) (is : isincl f) (x x' : X)
   := weqpair _ (isweqonpathsincl f is x x').
 
 Definition invmaponpathsincl {X Y : UU} (f : X -> Y) :
-  isincl f -> Π x x', f x = f x' -> x = x'.
+  isincl f -> ∏ x x', f x = f x' -> x = x'.
 Proof.
   intros ? ? ? is x x'.
   exact (invmap (weqonpathsincl f is x x')).
@@ -786,11 +786,11 @@ Defined.
 Lemma isinclweqonpaths {X Y : UU} (f : X -> Y) : isInjective f -> isincl f.
 Proof. intros X Y f X0. apply (isofhlevelfsn O f X0). Defined.
 
-Definition isinclpr1 {X : UU} (P : X -> UU) (is : Π x : X, isaprop (P x)) :
+Definition isinclpr1 {X : UU} (P : X -> UU) (is : ∏ x : X, isaprop (P x)) :
   isincl (@pr1 X P):= isofhlevelfpr1 (S O) P is.
 
 Theorem subtypeInjectivity {A : UU} (B : A -> UU) :
-  isPredicate B -> Π (x y : total2 B), (x = y) ≃ (pr1 x = pr1 y).
+  isPredicate B -> ∏ (x y : total2 B), (x = y) ≃ (pr1 x = pr1 y).
 Proof.
   intros. apply Injectivity. apply isweqonpathsincl. now apply isinclpr1.
 Defined.
@@ -808,7 +808,7 @@ Proof. intros ? ? ? ? e is. apply (total2_paths e). apply is. Defined.
 
 (* This corollary of subtypeEquality is used for categories. *)
 Corollary unique_exists {A : UU} {B : A -> UU} (x : A) (b : B x)
-          (h : Π y, isaprop (B y)) (H : Π y, B y -> y = x) :
+          (h : ∏ y, isaprop (B y)) (H : ∏ y, B y -> y = x) :
   iscontr (total2 (fun t : A => B t)).
 Proof.
   intros A B x b h H.
@@ -844,7 +844,7 @@ Defined.
 
 (** *** Basics about types of h-level 2 - "sets" *)
 
-Definition isaset (X : UU) : UU := Π x x' : X, isaprop (x = x').
+Definition isaset (X : UU) : UU := ∏ x x' : X, isaprop (x = x').
 
 (* Definition isaset := isofhlevel 2. *)
 
@@ -863,7 +863,7 @@ Lemma isasetaprop {X : UU} (is : isaprop X) : isaset X.
 Proof. intros. apply (isofhlevelsnprop 1 is). Defined.
 
 Corollary isaset_total2 {X : UU} (P : X->UU) :
-  isaset X -> (Π x, isaset (P x)) -> isaset (Σ x, P x).
+  isaset X -> (∏ x, isaset (P x)) -> isaset (∑ x, P x).
 Proof. intros. apply (isofhleveltotal2 2); assumption. Defined.
 
 Corollary isaset_dirprod {X Y : UU} : isaset X -> isaset Y -> isaset (X × Y).
@@ -890,7 +890,7 @@ Proof.
   exact (X0 x x').
 Defined.
 
-Lemma isasetifiscontrloops (X : UU) : (Π x : X, iscontr (paths x x)) -> isaset X.
+Lemma isasetifiscontrloops (X : UU) : (∏ x : X, iscontr (paths x x)) -> isaset X.
 Proof.
   intros X X0. unfold isaset. unfold isofhlevel. intros x x' x0 x0'.
   induction x0.
@@ -899,11 +899,11 @@ Proof.
 Defined.
 
 Lemma iscontrloopsifisaset (X : UU) :
-  (isaset X) -> (Π x : X, iscontr (paths x x)).
+  (isaset X) -> (∏ x : X, iscontr (paths x x)).
 Proof.
   intros X X0 x. unfold isaset in X0. unfold isofhlevel in X0.
-  change (Π (x x' : X) (x0 x'0 : paths x x'), iscontr (paths x0 x'0))
-  with (Π (x x' : X), isaprop (paths x x')) in X0.
+  change (∏ (x x' : X) (x0 x'0 : paths x x'), iscontr (paths x0 x'0))
+  with (∏ (x x' : X), isaprop (paths x x')) in X0.
   apply (iscontraprop1 (X0 x x) (idpath x)).
 Defined.
 
@@ -929,7 +929,7 @@ Proof. intros. refine (isofhlevelfhfiberpr1 _ _ _ _). assumption. Defined.
 
 Theorem isinclbetweensets {X Y : UU} (f : X -> Y)
         (isx : isaset X) (isy : isaset Y)
-        (inj : Π x x' : X , (paths (f x) (f x') -> paths x x')) : isincl f.
+        (inj : ∏ x x' : X , (paths (f x) (f x') -> paths x x')) : isincl f.
 Proof.
   intros. apply isinclweqonpaths. intros x x'.
   apply (isweqimplimpl (@maponpaths _ _ f x x') (inj x x') (isx x x')
@@ -966,7 +966,7 @@ Defined.
 
 (** *** Propositions equivalent to negations of propositions *)
 
-Definition negProp P := Σ Q, isaprop Q × (¬P <-> Q).
+Definition negProp P := ∑ Q, isaprop Q × (¬P <-> Q).
 
 Definition negProp_to_type {P} (negP : negProp P) := pr1 negP.
 
@@ -986,15 +986,15 @@ Coercion negProp_to_neg : negProp >-> Funclass.
 Definition neg_to_negProp {P} {nP : negProp P} : ¬P -> nP.
 Proof. intros ? ? np. exact (pr1 (negProp_to_iff nP) np). Defined.
 
-Definition negPred {X:UU} (x  :X) (P:Π y:X, UU)      := Π y  , negProp (P y).
+Definition negPred {X:UU} (x  :X) (P:∏ y:X, UU)      := ∏ y  , negProp (P y).
 
-Definition negReln {X:UU}         (P:Π (x y:X), UU)  := Π x y, negProp (P x y).
+Definition negReln {X:UU}         (P:∏ (x y:X), UU)  := ∏ x y, negProp (P x y).
 
 Definition neqProp {X:UU} (x y:X) :=            negProp (x=y).
 
-Definition neqPred {X:UU} (x  :X) := Π y,       negProp (x=y).
+Definition neqPred {X:UU} (x  :X) := ∏ y,       negProp (x=y).
 
-Definition neqReln (X:UU)         := Π (x y:X), negProp (x=y).
+Definition neqReln (X:UU)         := ∏ (x y:X), negProp (x=y).
 
 (** Complementary propositions  *)
 
@@ -1114,7 +1114,7 @@ Defined.
 
 (** *** Types with decidable equality *)
 
-Definition isdeceq (X:UU) : UU := Π (x x':X), (x=x') ⨿ (x!=x').
+Definition isdeceq (X:UU) : UU := ∏ (x x':X), (x=x') ⨿ (x!=x').
 
 Lemma isdeceqweqf {X Y : UU} (w : weq X Y) (is : isdeceq X) : isdeceq Y.
 Proof.
@@ -1186,8 +1186,8 @@ Defined.
 
 (** *** Isolated points *)
 
-Definition isisolated (X:UU) (x:X) := Π x':X, (x = x') ⨿ (x != x').
-Definition isisolated_ne (X:UU) (x:X) (neq_x:neqPred x) := Π y:X, (x=y) ⨿ neq_x y.
+Definition isisolated (X:UU) (x:X) := ∏ x':X, (x = x') ⨿ (x != x').
+Definition isisolated_ne (X:UU) (x:X) (neq_x:neqPred x) := ∏ y:X, (x=y) ⨿ neq_x y.
 
 Definition isisolated_to_isisolated_ne {X x neq_x} :
   isisolated X x -> isisolated_ne X x neq_x.
@@ -1205,8 +1205,8 @@ Proof.
   - apply ii2. now simple refine (negProp_to_neg _).
 Defined.
 
-Definition isolated ( T : UU ) := Σ t:T, isisolated _ t.
-Definition isolated_ne ( T : UU ) (neq:neqReln T) := Σ t:T, isisolated_ne _ t (neq t).
+Definition isolated ( T : UU ) := ∑ t:T, isisolated _ t.
+Definition isolated_ne ( T : UU ) (neq:neqReln T) := ∑ t:T, isisolated_ne _ t (neq t).
 
 Definition isolatedpair ( T : UU ) (t:T) (i:isisolated _ t) : isolated T
   := (t,,i).
@@ -1218,7 +1218,7 @@ Definition pr1isolated ( T : UU ) (x:isolated T) : T := pr1 x.
 Definition pr1isolated_ne ( T : UU ) (neq:neqReln T) (x:isolated_ne T neq) : T := pr1 x.
 
 Theorem isaproppathsfromisolated (X : UU) (x : X) (is : isisolated X x) :
-  Π x', isaprop(x = x').
+  ∏ x', isaprop(x = x').
 Proof.
   intros. apply iscontraprop1inv. intro e. induction e.
   set (f := fun e : paths x x => coconusfromtpair _ e).
@@ -1250,7 +1250,7 @@ Proof.
 Defined.
 
 Theorem isaproppathstoisolated (X : UU) (x : X) (is : isisolated X x) :
-  Π x' : X, isaprop (x' = x).
+  ∏ x' : X, isaprop (x' = x).
 Proof.
   intros.
   apply (isofhlevelweqf 1 (weqpathsinv0 x x')
@@ -1362,13 +1362,13 @@ Proof.
   intros.
   set (ff := subsetsplit f). set (gg := subsetsplitinv f).
   split with ff.
-  assert (egf : Π a : _, paths (gg (ff a)) a).
+  assert (egf : ∏ a : _, paths (gg (ff a)) a).
   {
     intros. unfold ff. unfold subsetsplit.
     induction (boolchoice (f a)) as [ et | ef ]. simpl. apply idpath. simpl.
     apply idpath.
   }
-  assert (efg : Π a : _, paths (ff (gg a)) a).
+  assert (efg : ∏ a : _, paths (ff (gg a)) a).
   {
     intros. induction a as [ et | ef ].
     - induction et as [ x et' ]. simpl. unfold ff. unfold subsetsplit.

--- a/UniMath/Foundations/PartC.v
+++ b/UniMath/Foundations/PartC.v
@@ -112,7 +112,7 @@ Defined.
 (** *** Basic results on complements to a point *)
 
 
-Definition compl (X : UU) (x : X) := Σ x', x != x'.
+Definition compl (X : UU) (x : X) := ∑ x', x != x'.
 Definition complpair (X : UU) (x : X) := tpair (fun x' : X => neg (paths x x')).
 Definition pr1compl (X : UU) (x : X) := @pr1 _ (fun x' : X => neg (paths x x')).
 
@@ -120,7 +120,7 @@ Definition pr1compl (X : UU) (x : X) := @pr1 _ (fun x' : X => neg (paths x x')).
 Lemma isinclpr1compl (X : UU) (x : X) : isincl (pr1compl X x).
 Proof. intros. apply (isinclpr1 _ (fun x' : X => isapropneg _)). Defined.
 
-Definition compl_ne (X:UU) (x:X) (neq_x : neqPred x) := Σ y, neq_x y.
+Definition compl_ne (X:UU) (x:X) (neq_x : neqPred x) := ∑ y, neq_x y.
 
 Definition compl_ne_pair (X : UU) (x : X) (neq_x : neqPred x) (y : X)
            (ne :neq_x y) :
@@ -201,7 +201,7 @@ Defined.
 Definition weqoncompl {X Y : UU} (w : X ≃ Y) x : compl X x ≃ compl Y (w x).
 Proof.
   (* uses [funextemptyAxiom] *)
-  intros. intermediate_weq (Σ x', w x != w x').
+  intros. intermediate_weq (∑ x', w x != w x').
   - apply weqfibtototal; intro x'. apply weqiff.
     {apply logeqnegs. apply weq_to_iff. apply weqonpaths. }
     {apply isapropneg. }
@@ -213,7 +213,7 @@ Definition weqoncompl_ne {X Y : UU} (w : X ≃ Y) (x : X) (neq_x : neqPred x)
            (neq_wx : neqPred (w x))
   : compl_ne X x neq_x ≃ compl_ne Y (w x) neq_wx.
 Proof.
-  intros. intermediate_weq (Σ x', neq_wx (w x')).
+  intros. intermediate_weq (∑ x', neq_wx (w x')).
   - apply weqfibtototal; intro x'.
     apply weqiff.
     {intermediate_logeq (x != x').
@@ -227,7 +227,7 @@ Proof.
 Defined.
 
 Definition weqoncompl_compute {X Y : UU} (w : weq X Y) (x : X) :
-  Π x', pr1 (weqoncompl w x x') = w (pr1 x').
+  ∏ x', pr1 (weqoncompl w x x') = w (pr1 x').
 Proof. intros. induction x' as [x' b]. reflexivity. Defined.
 
 Definition weqoncompl_ne_compute {X Y : UU}
@@ -331,7 +331,7 @@ Theorem isweqrecompl (X : UU) (x : X) (is : isisolated X x) :
 Proof.
   intros. set (f := recompl _ x). set (g := invrecompl X x is).
   unfold invrecompl in g. simpl in g.
-  assert (efg: Π x' : X, paths (f (g x')) x').
+  assert (efg: ∏ x' : X, paths (f (g x')) x').
   {
     intro. induction (is x') as [ x0 | e ].
     - induction x0. unfold f. unfold g. simpl. unfold recompl. simpl.
@@ -343,7 +343,7 @@ Proof.
       + induction (e x0).
       + simpl. apply idpath.
   }
-  assert (egf : Π u : coprod (compl X x) unit, paths (g (f u)) u).
+  assert (egf : ∏ u : coprod (compl X x) unit, paths (g (f u)) u).
   {
     unfold isisolated in is. intro. induction (is (f u)) as [ p | e ].
     - induction u as [ c | u].
@@ -546,9 +546,9 @@ Proof.
   set (f := funtranspos (tpair _ t1 is1) (tpair _ t2 is2)).
   set (g := funtranspos (tpair _ t2 is2) (tpair _ t1 is1)).
   split with f.
-  assert (egf : Π t : T, paths (g (f t)) t)
+  assert (egf : ∏ t : T, paths (g (f t)) t)
     by (intro; refine (homottranspost2t1t1t2 _ _ _ _ _)).
-  assert (efg : Π t : T, paths (f (g t)) t)
+  assert (efg : ∏ t : T, paths (f (g t)) t)
     by (intro; refine (homottranspost2t1t1t2 _ _ _ _ _)).
   apply (gradth _ _ egf efg).
 Defined.
@@ -676,7 +676,7 @@ Proof.
   set (f := @ii1 X Y). set (g := coprodtoboolsum X Y).
   set (gf := fun x : X => (g (f x))).
   set (gf' := fun x : X => tpair (boolsumfun X Y) true x).
-  assert (h : Π x : X, paths (gf' x) (gf x))
+  assert (h : ∏ x : X, paths (gf' x) (gf x))
     by (intro; apply idpath).
   assert (is1 : isofhlevelf (S O) gf')
     by apply (isofhlevelfsnfib O (boolsumfun X Y) true (isasetbool true true)).
@@ -710,7 +710,7 @@ Proof.
   set (f := @ii2 X Y). set (g := coprodtoboolsum X Y).
   set (gf := fun y : Y => (g (f y))).
   set (gf' := fun y : Y => tpair (boolsumfun X Y) false y).
-  assert (h : Π y : Y, paths (gf' y) (gf y))
+  assert (h : ∏ y : Y, paths (gf' y) (gf y))
     by (intro; apply idpath).
   assert (is1 : isofhlevelf (S O) gf')
     by apply (isofhlevelfsnfib O (boolsumfun X Y) false
@@ -934,13 +934,13 @@ Proof.
   set (ff := coprodofhfiberstohfiber f g z).
   set (gg := hfibertocoprodofhfibers f g z).
   split with ff.
-  assert (effgg : Π hsfg : _, paths (ff (gg hsfg)) hsfg).
+  assert (effgg : ∏ hsfg : _, paths (ff (gg hsfg)) hsfg).
   {
     intro. induction hsfg as [ xy e ]. induction xy as [ x | y ].
     - simpl. apply idpath.
     - simpl. apply idpath.
   }
-  assert (eggff : Π hfg : _, paths (gg (ff hfg)) hfg).
+  assert (eggff : ∏ hfg : _, paths (gg (ff hfg)) hfg).
   {
     intro. induction hfg as [ hf | hg ]. induction hf as [ x fe ].
     - simpl. apply idpath.
@@ -971,7 +971,7 @@ Defined.
 
 
 Lemma noil1 {X Y Z : UU} (f : X -> Z) (g : Y -> Z)
-      (noi : Π (x : X) (y : Y), neg (paths (f x) (g y))) (z : Z) :
+      (noi : ∏ (x : X) (y : Y), neg (paths (f x) (g y))) (z : Z) :
   hfiber f z -> hfiber g z -> empty.
 Proof.
   intros X Y Z f g noi z hfz hgz.
@@ -981,7 +981,7 @@ Defined.
 
 
 Lemma weqhfibernoi1 {X Y Z : UU} (f : X -> Z) (g : Y -> Z)
-      (noi : Π (x : X) (y : Y), neg (paths (f x) (g y))) (z : Z)
+      (noi : ∏ (x : X) (y : Y), neg (paths (f x) (g y))) (z : Z)
       (xe : hfiber f z) : weq (hfiber (sumofmaps f g) z) (hfiber f z).
 Proof.
   intros.
@@ -991,7 +991,7 @@ Proof.
 Defined.
 
 Lemma weqhfibernoi2 {X Y Z : UU} (f : X -> Z) (g : Y -> Z)
-      (noi : Π (x : X) (y : Y), neg (paths (f x) (g y))) (z : Z)
+      (noi : ∏ (x : X) (y : Y), neg (paths (f x) (g y))) (z : Z)
       (ye : hfiber g z) : weq (hfiber (sumofmaps f g) z) (hfiber g z).
 Proof.
   intros. set (w1 := invweq (weqhfibersofsumofmaps f g z)).
@@ -1004,7 +1004,7 @@ Defined.
 
 Theorem isofhlevelfsumofmapsnoi (n : nat) {X Y Z : UU} (f : X -> Z) (g : Y -> Z)
         (isf : isofhlevelf n f) (isg : isofhlevelf n g)
-        (noi : Π (x : X) (y : Y), neg (paths (f x) (g y))) :
+        (noi : ∏ (x : X) (y : Y), neg (paths (f x) (g y))) :
   isofhlevelf n (sumofmaps f g).
 Proof.
   intros. intro z. induction n as [ | n ].
@@ -1053,7 +1053,7 @@ Theorem isweqtocompltoii1x (X Y : UU) (x : X) : isweq (tocompltoii1x X Y x).
 Proof.
   intros.
   set (f := tocompltoii1x X Y x). set (g := fromcompltoii1x X Y x).
-  assert (egf : Π nexy : _, paths (g (f nexy)) nexy).
+  assert (egf : ∏ nexy : _, paths (g (f nexy)) nexy).
   {
     intro. induction nexy as [ c | y ].
     - induction c as [ t x0 ]. simpl.
@@ -1064,7 +1064,7 @@ Proof.
       apply (maponpaths (fun ee : neg (paths x t) => ii1 (complpair X x t ee)) e).
     - apply idpath.
   }
-  assert (efg: Π neii1x : _, paths (f (g neii1x)) neii1x).
+  assert (efg: ∏ neii1x : _, paths (f (g neii1x)) neii1x).
   {
     intro. induction neii1x as [ t x0 ]. induction t as [ x1 | y ].
     - simpl.
@@ -1110,7 +1110,7 @@ Theorem isweqtocompltoii2y (X Y : UU) (y : Y) : isweq (tocompltoii2y X Y y).
 Proof.
   intros.
   set (f := tocompltoii2y X Y y). set (g := fromcompltoii2y X Y y).
-  assert (egf : Π nexy : _, paths (g (f nexy)) nexy).
+  assert (egf : ∏ nexy : _, paths (g (f nexy)) nexy).
   {
     intro. induction nexy as [ x | c ].
     - apply idpath.
@@ -1123,7 +1123,7 @@ Proof.
 
       apply (maponpaths (fun ee : neg (paths y t) => ii2 (complpair _ y t ee)) e).
   }
-  assert (efg : Π neii2x : _, paths (f (g neii2x)) neii2x).
+  assert (efg : ∏ neii2x : _, paths (f (g neii2x)) neii2x).
   {
     intro. induction neii2x as [ t x ]. induction t as [ x0 | y0 ].
     - simpl.
@@ -1162,8 +1162,8 @@ Lemma isweqtocompltodisjoint (X : UU) : isweq (tocompltodisjoint X).
 Proof.
   intros.
   set (ff := tocompltodisjoint X). set (gg := fromcompltodisjoint X).
-  assert (egf : Π x : X, paths (gg (ff x)) x) by (intro; apply idpath).
-  assert (efg : Π xx : _, paths (ff (gg xx)) xx).
+  assert (egf : ∏ x : X, paths (gg (ff x)) x) by (intro; apply idpath).
+  assert (efg : ∏ xx : _, paths (ff (gg xx)) xx).
   {
     intro. induction xx as [ t x ]. induction t as [ x0 | u ].
     - simpl. unfold ff. unfold tocompltodisjoint. simpl.
@@ -1201,7 +1201,7 @@ Proof.
   intros. apply (isdecpropif _ (isasetifdeceq _ is x x') (is x x')).
 Defined.
 
-Lemma isdeceqif {X : UU} (is : Π x x' : X, isdecprop (paths x x')) : isdeceq X.
+Lemma isdeceqif {X : UU} (is : ∏ x x' : X, isdecprop (paths x x')) : isdeceq X.
 Proof. intros. intros x x'. apply (pr1 (is x x')). Defined.
 
 Lemma isaninv1 (X : UU) : isdecprop X -> isaninvprop X.
@@ -1304,7 +1304,7 @@ Defined.
 
 
 
-Definition isdecincl {X Y : UU} (f : X -> Y) := Π y : Y, isdecprop (hfiber f y).
+Definition isdecincl {X Y : UU} (f : X -> Y) := ∏ y : Y, isdecprop (hfiber f y).
 Lemma isdecincltoisincl {X Y : UU} (f : X -> Y) : isdecincl f -> isincl f.
 Proof. intros X Y f is. intro y. apply (isdecproptoisaprop _ (is y)). Defined.
 Coercion isdecincltoisincl : isdecincl >-> isincl.
@@ -1346,7 +1346,7 @@ Proof.
 Defined.
 
 
-Lemma isdecinclpr1 {X : UU} (P : X -> UU) (is : Π x : X, isdecprop (P x)) :
+Lemma isdecinclpr1 {X : UU} (P : X -> UU) (is : ∏ x : X, isdecprop (P x)) :
   isdecincl (@pr1 _ P).
 Proof.
   intros. intro x.
@@ -1356,7 +1356,7 @@ Defined.
 
 
 Theorem isdecinclhomot {X Y : UU} (f g : X -> Y)
-        (h : Π x : X, paths (f x) (g x)) (is : isdecincl f) : isdecincl g.
+        (h : ∏ x : X, paths (f x) (g x)) (is : isdecincl f) : isdecincl g.
 Proof.
   intros. intro y.
   apply (isdecpropweqf (weqhfibershomot f g h y) (is y)).
@@ -1368,10 +1368,10 @@ Theorem isdecinclcomp {X Y Z : UU} (f : X -> Y) (g : Y -> Z)
 Proof.
   intros. intro z.
   set (gf := fun x : X => g (f x)).
-  assert (wy : Π ye : hfiber g z, weq (hfiber f (pr1 ye))
+  assert (wy : ∏ ye : hfiber g z, weq (hfiber f (pr1 ye))
                                       (hfiber (hfibersgftog f g z) ye))
     by apply ezweqhf.
-  assert (ww : Π y : Y, weq (hfiber f y) (hfiber gf (g y))).
+  assert (ww : ∏ y : Y, weq (hfiber f y) (hfiber gf (g y))).
   {
     intro. apply (samehfibers f g). apply (isdecincltoisincl _ isg).
   }
@@ -1423,12 +1423,12 @@ Theorem isisolateddecinclf {X Y : UU} (f : X -> Y) (x : X) :
   isdecincl f -> isisolated X x -> isisolated Y (f x).
 Proof.
   intros X Y f x isf isx.
-  assert (is' : Π y : Y, isdecincl (d1g f y x)).
+  assert (is' : ∏ y : Y, isdecincl (d1g f y x)).
   {
     intro y. intro xe. set (w := ezweq2g f x xe).
     apply (isdecpropweqf w (isdecproppathstoisolated X x isx _)).
   }
-  assert (is'' : Π y : Y, isdecprop (paths (f x) y))
+  assert (is'' : ∏ y : Y, isdecprop (paths (f x) y))
     by (intro; apply (isdecpropfromdecincl _ (is' y) (isf y))).
   intro y'.
   apply (pr1 (is'' y')).
@@ -1442,14 +1442,14 @@ Defined.
 Definition negimage {X Y : UU} (f : X -> Y) : UU
   := total2 (fun y : Y => neg (hfiber f y)).
 Definition negimagepair {X Y : UU} (f : X -> Y) :
-  Π t : Y, ¬ hfiber f t → Σ y : Y, ¬ hfiber f y
+  ∏ t : Y, ¬ hfiber f t → ∑ y : Y, ¬ hfiber f y
   := tpair (fun y : Y => neg (hfiber f y)).
 
 Lemma isinclfromcoprodwithnegimage {X Y : UU} (f : X -> Y) (is : isincl f) :
   isincl (sumofmaps f (@pr1 _ (fun y : Y => neg (hfiber f y)))).
 Proof.
   intros.
-  assert (noi : Π (x : X) (nx : negimage f), neg (paths (f x) (pr1 nx))).
+  assert (noi : ∏ (x : X) (nx : negimage f), neg (paths (f x) (pr1 nx))).
   {
     intros x nx e. induction nx as [ y nhf ]. simpl in e.
     apply (nhf (hfiberpair _ x e)).

--- a/UniMath/Foundations/PartD.v
+++ b/UniMath/Foundations/PartD.v
@@ -7,12 +7,12 @@ Only one universe is used and never as a type.
 *)
 
 (** ** Contents
-- Sections of "double fibration" [(P : T -> UU) (PP : Π t : T, P t -> UU)] and
+- Sections of "double fibration" [(P : T -> UU) (PP : ∏ t : T, P t -> UU)] and
   pairs of sections
  - General case
  - Functions on dependent sum (to a [total2])
  - Functions to direct product
-- Homotopy fibers of the map [Π x : X, P x -> Π x : X, Q x]
+- Homotopy fibers of the map [∏ x : X, P x -> ∏ x : X, Q x]
  - General case
  - The weak equivalence between sections spaces (dependent products) defined
    by a family of weak equivalences [weq (P x) (Q x)]
@@ -65,15 +65,15 @@ Unset Automatic Introduction.
 
 Require Export UniMath.Foundations.PartC.
 
-(** ** Sections of "double fibration" [(P : T -> UU) (PP : Π t : T, P t -> UU)] and pairs of sections *)
+(** ** Sections of "double fibration" [(P : T -> UU) (PP : ∏ t : T, P t -> UU)] and pairs of sections *)
 
 
 
 (** *** General case *)
 
-Definition totaltoforall {X : UU} (P : X -> UU) (PP : Π x : X, P x -> UU) :
-  total2 (fun s0 : Π x : X, P x
-          => Π x : X, PP x (s0 x)) -> Π x : X, total2 (PP x).
+Definition totaltoforall {X : UU} (P : X -> UU) (PP : ∏ x : X, P x -> UU) :
+  total2 (fun s0 : ∏ x : X, P x
+          => ∏ x : X, PP x (s0 x)) -> ∏ x : X, total2 (PP x).
 Proof.
   intros X P PP X0 x.
   exists (pr1 X0 x).
@@ -81,24 +81,24 @@ Proof.
 Defined.
 
 
-Definition foralltototal {X : UU} (P : X -> UU) (PP : Π x : X, P x -> UU) :
-  (Π x : X, total2 (PP x))
-  -> total2 (fun s0 : Π x : X, P x => Π x : X, PP x (s0 x)).
+Definition foralltototal {X : UU} (P : X -> UU) (PP : ∏ x : X, P x -> UU) :
+  (∏ x : X, total2 (PP x))
+  -> total2 (fun s0 : ∏ x : X, P x => ∏ x : X, PP x (s0 x)).
 Proof.
   intros X P PP X0.
   exists (fun x : X => pr1 (X0 x)).
   apply (fun x : X => pr2 (X0 x)).
 Defined.
 
-Lemma lemmaeta1 {X : UU} (P : X -> UU) (Q : (Π x : X, P x) -> UU)
-      (s0 : Π x : X, P x) (q : Q (fun x : X => (s0 x))) :
-  paths (tpair (fun s : (Π x : X, P x) => Q (fun x : X => (s x))) s0 q)
-        (tpair (fun s : (Π x : X, P x) => Q (fun x : X => (s x)))
+Lemma lemmaeta1 {X : UU} (P : X -> UU) (Q : (∏ x : X, P x) -> UU)
+      (s0 : ∏ x : X, P x) (q : Q (fun x : X => (s0 x))) :
+  paths (tpair (fun s : (∏ x : X, P x) => Q (fun x : X => (s x))) s0 q)
+        (tpair (fun s : (∏ x : X, P x) => Q (fun x : X => (s x)))
                (fun x : X => (s0 x)) q).
 Proof. reflexivity. Defined.
 
-Definition totaltoforalltototal {X : UU} (P : X -> UU) (PP : Π x : X, P x -> UU)
-           (ss : total2 (fun s0 : Π x : X, P x => Π x : X, PP x (s0 x))) :
+Definition totaltoforalltototal {X : UU} (P : X -> UU) (PP : ∏ x : X, P x -> UU)
+           (ss : total2 (fun s0 : ∏ x : X, P x => ∏ x : X, PP x (s0 x))) :
   paths (foralltototal _ _ (totaltoforall  _ _ ss)) ss.
 Proof.
   intros; induction ss; apply idpath.
@@ -106,17 +106,17 @@ Defined.
 
 
 
-Definition foralltototaltoforall {X : UU} (P : X -> UU) (PP : Π x : X, P x -> UU)
-           (ss : Π x : X, total2 (PP x)) :
+Definition foralltototaltoforall {X : UU} (P : X -> UU) (PP : ∏ x : X, P x -> UU)
+           (ss : ∏ x : X, total2 (PP x)) :
   paths (totaltoforall _ _ (foralltototal _ _ ss)) ss.
 Proof.
   intros. unfold foralltototal. unfold totaltoforall. simpl.
-  assert (ee: Π x : X, paths (tpair (PP x) (pr1 (ss x)) (pr2 (ss x))) (ss x))
+  assert (ee: ∏ x : X, paths (tpair (PP x) (pr1 (ss x)) (pr2 (ss x))) (ss x))
     by (intro; apply (pathsinv0 (tppr (ss x)))).
   apply (funextsec). assumption.
 Defined.
 
-Theorem isweqforalltototal {X : UU} (P : X -> UU) (PP : Π x : X, P x -> UU) :
+Theorem isweqforalltototal {X : UU} (P : X -> UU) (PP : ∏ x : X, P x -> UU) :
   isweq (foralltototal P PP).
 Proof.
   intros.
@@ -124,7 +124,7 @@ Proof.
                 (foralltototaltoforall P PP) (totaltoforalltototal P PP)).
 Defined.
 
-Theorem isweqtotaltoforall {X : UU} (P : X -> UU) (PP : Π x : X, P x -> UU) :
+Theorem isweqtotaltoforall {X : UU} (P : X -> UU) (PP : ∏ x : X, P x -> UU) :
   isweq (totaltoforall P PP).
 Proof.
   intros.
@@ -132,10 +132,10 @@ Proof.
                 (totaltoforalltototal P PP) (foralltototaltoforall P PP)).
 Defined.
 
-Definition weqforalltototal {X : UU} (P : X -> UU) (PP : Π x : X, P x -> UU)
+Definition weqforalltototal {X : UU} (P : X -> UU) (PP : ∏ x : X, P x -> UU)
   := weqpair _ (isweqforalltototal P PP).
 
-Definition weqtotaltoforall {X : UU} (P : X -> UU) (PP : Π x : X, P x -> UU)
+Definition weqtotaltoforall {X : UU} (P : X -> UU) (PP : ∏ x : X, P x -> UU)
   := invweq (weqforalltototal P PP).
 
 
@@ -143,7 +143,7 @@ Definition weqtotaltoforall {X : UU} (P : X -> UU) (PP : Π x : X, P x -> UU)
 (** *** Functions to a dependent sum (to a [ total2 ]) *)
 
 Definition weqfuntototaltototal (X : UU) {Y : UU} (Q : Y -> UU) :
-  weq (X -> total2 Q) (total2 (fun f : X -> Y => Π x : X, Q (f x)))
+  weq (X -> total2 Q) (total2 (fun f : X -> Y => ∏ x : X, Q (f x)))
   := weqforalltototal (fun x : X => Y) (fun x : X => Q).
 
 
@@ -170,30 +170,30 @@ Proof.
   - intro a. now induction a as [ fy fz ].
 Defined.
 
-(** ** Homotopy fibers of the map [Π x : X, P x -> Π x : X, Q x] *)
+(** ** Homotopy fibers of the map [∏ x : X, P x -> ∏ x : X, Q x] *)
 
 (** *** General case *)
 
-Definition maponsec {X : UU}  (P Q : X -> UU) (f : Π x : X, P x -> Q x) :
-  (Π x : X, P x) -> (Π x : X, Q x)
-  := fun s : Π x : X, P x => (fun x : X => (f x) (s x)).
+Definition maponsec {X : UU}  (P Q : X -> UU) (f : ∏ x : X, P x -> Q x) :
+  (∏ x : X, P x) -> (∏ x : X, Q x)
+  := fun s : ∏ x : X, P x => (fun x : X => (f x) (s x)).
 
 Definition maponsec1 {X Y : UU} (P : Y -> UU) (f : X -> Y) :
-  (Π y : Y, P y) -> (Π x : X, P (f x))
-  := fun sy : Π y : Y, P y => (fun x : X => sy (f x)).
+  (∏ y : Y, P y) -> (∏ x : X, P (f x))
+  := fun sy : ∏ y : Y, P y => (fun x : X => sy (f x)).
 
 
 
-Definition hfibertoforall {X : UU} (P Q : X -> UU) (f : Π x : X, P x -> Q x)
-           (s : Π x : X, Q x) :
-  hfiber  (@maponsec _ _ _ f) s -> Π x : X, hfiber  (f x) (s x).
+Definition hfibertoforall {X : UU} (P Q : X -> UU) (f : ∏ x : X, P x -> Q x)
+           (s : ∏ x : X, Q x) :
+  hfiber  (@maponsec _ _ _ f) s -> ∏ x : X, hfiber  (f x) (s x).
 Proof.
   intro. intro. intro. intro. intro. unfold hfiber.
-  set (map1 := totalfun (fun pointover : Π x : X, P x =>
+  set (map1 := totalfun (fun pointover : ∏ x : X, P x =>
                            paths (fun x : X => f x (pointover x)) s)
-                        (fun pointover : Π x : X, P x =>
-                           Π x : X, paths  ((f x) (pointover x)) (s x))
-                        (fun pointover: Π x : X, P x =>
+                        (fun pointover : ∏ x : X, P x =>
+                           ∏ x : X, paths  ((f x) (pointover x)) (s x))
+                        (fun pointover: ∏ x : X, P x =>
                            toforallpaths _ (fun x : X => f x (pointover x)) s)).
   set (map2 := totaltoforall P (fun x : X =>
                                   (fun pointover : P x =>
@@ -203,37 +203,37 @@ Defined.
 
 
 
-Definition foralltohfiber {X : UU} (P Q : X -> UU) (f : Π x : X, P x -> Q x)
-           (s : Π x : X, Q x) :
-  (Π x : X, hfiber (f x) (s x)) -> hfiber (maponsec _ _ f) s.
+Definition foralltohfiber {X : UU} (P Q : X -> UU) (f : ∏ x : X, P x -> Q x)
+           (s : ∏ x : X, Q x) :
+  (∏ x : X, hfiber (f x) (s x)) -> hfiber (maponsec _ _ f) s.
 Proof.
   intro. intro. intro. intro. intro. unfold hfiber.
   set (map2inv := foralltototal P (fun x : X => (fun pointover : P x =>
                                                 paths (f x pointover) (s x)))).
-  set (map1inv :=  totalfun (fun pointover : Π x : X, P x =>
-                               Π x : X, paths  ((f x) (pointover x)) (s x))
-                            (fun pointover : Π x : X, P x =>
+  set (map1inv :=  totalfun (fun pointover : ∏ x : X, P x =>
+                               ∏ x : X, paths  ((f x) (pointover x)) (s x))
+                            (fun pointover : ∏ x : X, P x =>
                                paths (fun x : X => f x (pointover x)) s)
-                            (fun pointover: Π x : X, P x =>
+                            (fun pointover: ∏ x : X, P x =>
                                funextsec _ (fun x : X => f x (pointover x)) s)).
   set (themap := fun a : _ => map1inv (map2inv a)). assumption.
 Defined.
 
 
-Theorem isweqhfibertoforall {X : UU} (P Q : X -> UU) (f : Π x : X, P x -> Q x)
-        (s : Π x : X, Q x) : isweq (hfibertoforall _ _ f s).
+Theorem isweqhfibertoforall {X : UU} (P Q : X -> UU) (f : ∏ x : X, P x -> Q x)
+        (s : ∏ x : X, Q x) : isweq (hfibertoforall _ _ f s).
 Proof.
   intro. intro. intro. intro. intro.
-  set (map1 := totalfun (fun pointover : Π x : X, P x =>
+  set (map1 := totalfun (fun pointover : ∏ x : X, P x =>
                            paths  (fun x : X => f x (pointover x)) s)
-                        (fun pointover : Π x : X, P x =>
-                           Π x : X, paths  ((f x) (pointover x)) (s x))
-                        (fun pointover: Π x : X, P x =>
+                        (fun pointover : ∏ x : X, P x =>
+                           ∏ x : X, paths  ((f x) (pointover x)) (s x))
+                        (fun pointover: ∏ x : X, P x =>
                            toforallpaths _ (fun x : X => f x (pointover x)) s)).
   set (map2 := totaltoforall P (fun x : X => (fun pointover : P x =>
                                              paths (f x pointover) (s x)))).
   assert (is1 : isweq map1)
-    by apply (isweqfibtototal _ _ (fun pointover: Π x : X, P x =>
+    by apply (isweqfibtototal _ _ (fun pointover: ∏ x : X, P x =>
                                      weqtoforallpaths
                                        _ (fun x : X => f x (pointover x)) s)).
   assert (is2 : isweq map2)
@@ -242,13 +242,13 @@ Proof.
 Defined.
 
 
-Definition weqhfibertoforall {X : UU} (P Q : X -> UU) (f : Π x : X, P x -> Q x)
-           (s : Π x : X, Q x) := weqpair _ (isweqhfibertoforall P Q f s).
+Definition weqhfibertoforall {X : UU} (P Q : X -> UU) (f : ∏ x : X, P x -> Q x)
+           (s : ∏ x : X, Q x) := weqpair _ (isweqhfibertoforall P Q f s).
 
 
 
-Theorem isweqforalltohfiber {X : UU} (P Q : X -> UU) (f : Π x : X, P x -> Q x)
-        (s : Π x : X, Q x) : isweq (foralltohfiber  _ _ f s).
+Theorem isweqforalltohfiber {X : UU} (P Q : X -> UU) (f : ∏ x : X, P x -> Q x)
+        (s : ∏ x : X, Q x) : isweq (foralltohfiber  _ _ f s).
 Proof.
   intro. intro. intro. intro. intro.
   set (map2inv := foralltototal P (fun x : X => (fun pointover : P x =>
@@ -257,26 +257,26 @@ Proof.
   assert (is2 : isweq map2inv).
   apply (isweqforalltototal P (fun x : X => (fun pointover : P x =>
                                             paths (f x pointover) (s x)))).
-  set (map1inv := totalfun (fun pointover : Π x : X, P x =>
-                              Π x : X, paths ((f x) (pointover x)) (s x))
-                           (fun pointover : Π x : X, P x =>
+  set (map1inv := totalfun (fun pointover : ∏ x : X, P x =>
+                              ∏ x : X, paths ((f x) (pointover x)) (s x))
+                           (fun pointover : ∏ x : X, P x =>
                               paths (fun x : X => f x (pointover x)) s)
-                           (fun pointover: Π x : X, P x =>
+                           (fun pointover: ∏ x : X, P x =>
                               funextsec _  (fun x : X => f x (pointover x)) s)).
   assert (is1 : isweq map1inv).
 
   (* ??? in this place 8.4 (actually trunk to 8.5) hangs if the next command is
 
-    apply (isweqfibtototal _ _ (fun pointover: Π x : X, P x =>
+    apply (isweqfibtototal _ _ (fun pointover: ∏ x : X, P x =>
     weqfunextsec _ (fun x : X => f x (pointover x)) s)).
 
     and no -no-sharing option is turned on. It also hangs on
 
-    exact (isweqfibtototal (fun pointover : Π x : X, P x =>
-                Π x : X, paths (f x (pointover x)) (s x))
-                  (fun pointover : Π x : X, P x =>
+    exact (isweqfibtototal (fun pointover : ∏ x : X, P x =>
+                ∏ x : X, paths (f x (pointover x)) (s x))
+                  (fun pointover : ∏ x : X, P x =>
                 paths (fun x : X => f x (pointover x)) s)
-                  (fun pointover: Π x : X, P x =>
+                  (fun pointover: ∏ x : X, P x =>
                 weqfunextsec Q (fun x : X => f x (pointover x)) s)).
 
     for at least 2hrs. After adding "Opaque funextsec." the "exact" commend
@@ -285,15 +285,15 @@ Proof.
 
     Resoved (2014.10.23). *)
 
-  apply (isweqfibtototal _ _ (fun pointover: Π x : X, P x =>
+  apply (isweqfibtototal _ _ (fun pointover: ∏ x : X, P x =>
                                 weqfunextsec _ (fun x : X => f x (pointover x))
                                              s)).
   apply (twooutof3c map2inv map1inv is2 is1).
 Defined.
 
 
-Definition weqforalltohfiber {X : UU} (P Q : X -> UU) (f : Π x : X, P x -> Q x)
-           (s : Π x : X, Q x) := weqpair _ (isweqforalltohfiber P Q f s).
+Definition weqforalltohfiber {X : UU} (P Q : X -> UU) (f : ∏ x : X, P x -> Q x)
+           (s : ∏ x : X, Q x) := weqpair _ (isweqforalltohfiber P Q f s).
 
 
 
@@ -302,20 +302,20 @@ Definition weqforalltohfiber {X : UU} (P Q : X -> UU) (f : Π x : X, P x -> Q x)
 
 
 
-Corollary isweqmaponsec {X : UU} (P Q : X -> UU) (f : Π x : X, weq (P x) (Q x)) :
+Corollary isweqmaponsec {X : UU} (P Q : X -> UU) (f : ∏ x : X, weq (P x) (Q x)) :
   isweq (maponsec _ _ f).
 Proof.
   intros. unfold isweq. intro y.
-  assert (is1 : iscontr (Π x : X, hfiber (f x) (y x))).
+  assert (is1 : iscontr (∏ x : X, hfiber (f x) (y x))).
   {
-    assert (is2 : Π x : X, iscontr (hfiber (f x) (y x)))
+    assert (is2 : ∏ x : X, iscontr (hfiber (f x) (y x)))
       by (intro x; apply ((pr2 (f x)) (y x))).
     apply funcontr. assumption.
   }
   apply (iscontrweqb (weqhfibertoforall P Q f y) is1).
 Defined.
 
-Definition weqonsecfibers {X : UU} (P Q : X -> UU) (f : Π x : X, weq (P x) (Q x))
+Definition weqonsecfibers {X : UU} (P Q : X -> UU) (f : ∏ x : X, weq (P x) (Q x))
   := weqpair _ (isweqmaponsec P Q f).
 
 
@@ -338,24 +338,24 @@ Definition weqffun (X : UU) {Y Z : UU} (w : weq Y Z) : weq (X -> Y) (X -> Z)
 
 
 Definition maponsec1l0 {X : UU} (P : X -> UU) (f : X -> X)
-           (h : Π x : X, paths (f x) x) (s : Π x : X, P x) : (Π x : X, P x)
+           (h : ∏ x : X, paths (f x) x) (s : ∏ x : X, P x) : (∏ x : X, P x)
   := (fun x : X => transportf P (h x) (s (f x))).
 
-Lemma maponsec1l1 {X : UU} (P : X -> UU) (x : X) (s :Π x : X, P x) :
+Lemma maponsec1l1 {X : UU} (P : X -> UU) (x : X) (s :∏ x : X, P x) :
   paths (maponsec1l0 P (fun x : X => x) (fun x : X => idpath x) s x) (s x).
 Proof. intros. unfold maponsec1l0. apply idpath. Defined.
 
 
-Lemma maponsec1l2 {X : UU} (P : X -> UU) (f : X -> X) (h : Π x : X, paths (f x) x)
-      (s : Π x : X, P x) (x : X) : paths (maponsec1l0 P f h s x) (s x).
+Lemma maponsec1l2 {X : UU} (P : X -> UU) (f : X -> X) (h : ∏ x : X, paths (f x) x)
+      (s : ∏ x : X, P x) (x : X) : paths (maponsec1l0 P f h s x) (s x).
 Proof.
   intros.
-  set (map := fun ff : total2 (fun f0 : X ->X => Π x : X, paths (f0 x) x) =>
+  set (map := fun ff : total2 (fun f0 : X ->X => ∏ x : X, paths (f0 x) x) =>
                 maponsec1l0 P (pr1 ff) (pr2 ff) s x).
-  assert (is1 : iscontr (total2 (fun f0 : X ->X => Π x : X, paths (f0 x) x)))
+  assert (is1 : iscontr (total2 (fun f0 : X ->X => ∏ x : X, paths (f0 x) x)))
     by apply funextcontr.
-  assert (e: paths (tpair (fun f0 : X ->X => Π x : X, paths (f0 x) x) f h)
-                   (tpair (fun f0 : X ->X => Π x : X, paths (f0 x) x)
+  assert (e: paths (tpair (fun f0 : X ->X => ∏ x : X, paths (f0 x) x) f h)
+                   (tpair (fun f0 : X ->X => ∏ x : X, paths (f0 x) x)
                           (fun x0 : X => x0) (fun x0 : X => idpath x0)))
     by (apply proofirrelevancecontr; assumption).
   apply (maponpaths map e).
@@ -369,13 +369,13 @@ Proof.
   set (map := maponsec1  P f).
   set (invf := invmap f).
   set (e1 := homotweqinvweq f). set (e2 := homotinvweqweq f).
-  set (im1 := fun sx : Π x : X, P (f x) => (fun y : Y => sx (invf y))).
-  set (im2 := fun sy': Π y : Y, P (f (invf y)) =>
+  set (im1 := fun sx : ∏ x : X, P (f x) => (fun y : Y => sx (invf y))).
+  set (im2 := fun sy': ∏ y : Y, P (f (invf y)) =>
                 (fun y : Y => transportf _ (homotweqinvweq f y) (sy' y))).
-  set (invmapp := (fun sx : Π x : X, P (f x) => im2 (im1 sx))).
+  set (invmapp := (fun sx : ∏ x : X, P (f x) => im2 (im1 sx))).
 
-  assert (efg0 : Π sx : (Π x : X, P (f x)),
-                        Π x : X, paths ((map (invmapp sx)) x) (sx x)).
+  assert (efg0 : ∏ sx : (∏ x : X, P (f x)),
+                        ∏ x : X, paths ((map (invmapp sx)) x) (sx x)).
   {
     intro. intro. unfold map. unfold invmapp. unfold im1. unfold im2.
     unfold maponsec1. simpl. fold invf. set (ee := e2 x). fold invf in ee.
@@ -398,10 +398,10 @@ Proof.
       by apply (maponsec1l2 (fun x : X => P (f x)) ff e3x sx x).
     apply (pathscomp0 (pathscomp0 e5 e6) e7).
   }
-  assert (efg : Π sx : (Π x : X, P (f x)), paths (map (invmapp sx)) sx)
+  assert (efg : ∏ sx : (∏ x : X, P (f x)), paths (map (invmapp sx)) sx)
     by (intro; apply (funextsec _ _ _ (efg0 sx))).
 
-  assert (egf0 : Π sy : (Π y : Y, P y), Π y : Y, paths ((invmapp (map sy)) y)
+  assert (egf0 : ∏ sy : (∏ y : Y, P y), ∏ y : Y, paths ((invmapp (map sy)) y)
                                                        (sy y)).
   {
     intros. unfold invmapp. unfold map. unfold im1. unfold im2.
@@ -409,14 +409,14 @@ Proof.
     set (ff := fun y : Y => f (invf y)). fold invf.
     apply (maponsec1l2 P ff (homotweqinvweq f) sy y).
   }
-  assert (egf : Π sy : (Π y : Y, P y), paths (invmapp (map sy)) sy)
+  assert (egf : ∏ sy : (∏ y : Y, P y), paths (invmapp (map sy)) sy)
     by (intro; apply (funextsec _ _ _ (egf0 sy))).
 
   apply (gradth map invmapp egf efg).
 Defined.
 
 Definition weqonsecbase {X Y : UU} (P : Y -> UU) (f : weq X Y)
-  : weq (Π y : Y, P y) (Π x : X, P (f x))
+  : weq (∏ y : Y, P y) (∏ x : X, P (f x))
   := weqpair _ (isweqmaponsec1 P f).
 
 
@@ -448,7 +448,7 @@ Definition weqbfun {X Y : UU} (Z : UU) (w : weq X Y) : weq (Y -> Z) (X -> Z)
 
 (** *** General case *)
 
-Definition iscontrsecoverempty (P : empty -> UU) : iscontr (Π x : empty, P x).
+Definition iscontrsecoverempty (P : empty -> UU) : iscontr (∏ x : empty, P x).
 Proof.
   intro. split with (fun x : empty => fromempty x).
   intro t. apply funextsec.
@@ -456,20 +456,20 @@ Proof.
 Defined.
 
 Definition iscontrsecoverempty2 {X : UU} (P : X -> UU) (is : neg X) :
-  iscontr (Π x : X, P x).
+  iscontr (∏ x : X, P x).
 Proof.
   intros. set (w := weqtoempty is). set (w' := weqonsecbase P (invweq w)).
   apply (iscontrweqb w' (iscontrsecoverempty _)).
 Defined.
 
 Definition secovercoprodtoprod {X Y : UU} (P : coprod X Y -> UU)
-           (a : Π xy : coprod X Y, P xy) :
-  dirprod (Π x : X, P (ii1 x)) (Π y : Y, P (ii2 y))
+           (a : ∏ xy : coprod X Y, P xy) :
+  dirprod (∏ x : X, P (ii1 x)) (∏ y : Y, P (ii2 y))
   := dirprodpair (fun x : X => a (ii1 x)) (fun y : Y => a (ii2 y)).
 
 Definition prodtosecovercoprod {X Y : UU} (P : coprod X Y -> UU)
-           (a : dirprod (Π x : X, P (ii1 x)) (Π y : Y, P (ii2 y))) :
-  Π xy : coprod X Y, P xy.
+           (a : dirprod (∏ x : X, P (ii1 x)) (∏ y : Y, P (ii2 y))) :
+  ∏ xy : coprod X Y, P xy.
 Proof.
   intros. induction xy as [ x | y ].
   - apply (pr1 a x).
@@ -478,19 +478,19 @@ Defined.
 
 
 Definition weqsecovercoprodtoprod {X Y : UU} (P : coprod X Y -> UU) :
-  weq (Π xy : coprod X Y, P xy)
-      (dirprod (Π x : X, P (ii1 x)) (Π y : Y, P (ii2 y))).
+  weq (∏ xy : coprod X Y, P xy)
+      (dirprod (∏ x : X, P (ii1 x)) (∏ y : Y, P (ii2 y))).
 Proof.
   intros.
   set (f := secovercoprodtoprod P). set (g := prodtosecovercoprod P).
   split with f.
-  assert (egf : Π a : _, paths (g (f a)) a).
+  assert (egf : ∏ a : _, paths (g (f a)) a).
   {
     intro. apply funextsec.
     intro t. induction t as [ x | y ].
     apply idpath. apply idpath.
   }
-  assert (efg : Π a : _, paths (f (g a)) a).
+  assert (efg : ∏ a : _, paths (f (g a)) a).
   {
     intro. induction a as [ ax ay ].
     apply (pathsdirprod). apply funextsec.
@@ -546,50 +546,50 @@ Defined.
 (** *** General case *)
 
 
-Definition tosecoverunit (P : unit -> UU) (p : P tt) : Π t : unit, P t.
+Definition tosecoverunit (P : unit -> UU) (p : P tt) : ∏ t : unit, P t.
 Proof. intros. induction t. apply p. Defined.
 
-Definition weqsecoverunit (P : unit -> UU) : weq (Π t : unit, P t) (P tt).
+Definition weqsecoverunit (P : unit -> UU) : weq (∏ t : unit, P t) (P tt).
 Proof.
   intro.
-  set (f := fun a : Π t : unit, P t => a tt). set (g := tosecoverunit P).
+  set (f := fun a : ∏ t : unit, P t => a tt). set (g := tosecoverunit P).
   split with f.
-  assert (egf : Π a : _, paths (g (f a)) a).
+  assert (egf : ∏ a : _, paths (g (f a)) a).
   {
     intro. apply funextsec.
     intro t. induction t. apply idpath.
   }
-  assert (efg : Π a : _, paths (f (g a)) a) by (intros; apply idpath).
+  assert (efg : ∏ a : _, paths (f (g a)) a) by (intros; apply idpath).
   apply (gradth _ _ egf efg).
 Defined.
 
 
 Definition weqsecovercontr {X : UU} (P : X -> UU) (is : iscontr X) :
-  weq (Π x : X, P x) (P (pr1 is)).
+  weq (∏ x : X, P x) (P (pr1 is)).
 Proof.
   intros. set (w1 := weqonsecbase P (wequnittocontr is)).
   apply (weqcomp w1 (weqsecoverunit _)).
 Defined.
 
 Definition tosecovertotal2 {X : UU} (P : X -> UU) (Q : total2 P -> UU)
-           (a : Π x : X, Π p : P x, Q (tpair _ x p)) :
-  Π xp : total2 P, Q xp.
+           (a : ∏ x : X, ∏ p : P x, Q (tpair _ x p)) :
+  ∏ xp : total2 P, Q xp.
 Proof. intros. induction xp as [ x p ]. apply (a x p). Defined.
 
 
 Definition weqsecovertotal2 {X : UU} (P : X -> UU) (Q : total2 P -> UU) :
-  weq (Π xp : total2 P, Q xp) (Π x : X, Π p : P x, Q (tpair _ x p)).
+  weq (∏ xp : total2 P, Q xp) (∏ x : X, ∏ p : P x, Q (tpair _ x p)).
 Proof.
   intros.
-  set (f := fun a : Π xp : total2 P, Q xp => fun x : X => fun p : P x =>
+  set (f := fun a : ∏ xp : total2 P, Q xp => fun x : X => fun p : P x =>
                                                       a (tpair _ x p)).
   set (g := tosecovertotal2 P Q). split with f.
-  assert (egf : Π a : _, paths (g (f a)) a).
+  assert (egf : ∏ a : _, paths (g (f a)) a).
   {
     intro. apply funextsec.
     intro xp. induction xp as [ x p ]. apply idpath.
   }
-  assert (efg : Π a : _, paths (f (g a)) a).
+  assert (efg : ∏ a : _, paths (f (g a)) a).
   {
     intro. apply funextsec.
     intro x. apply funextsec.
@@ -611,12 +611,12 @@ Definition weqfunfromcontr {X : UU} (Y : UU) (is : iscontr X) : weq (X -> Y) Y
 (** *** Functions from [ total2 ] *)
 
 Definition weqfunfromtotal2 {X : UU} (P : X -> UU) (Y : UU) :
-  weq (total2 P -> Y) (Π x : X, P x -> Y) := weqsecovertotal2 P _.
+  weq (total2 P -> Y) (∏ x : X, P x -> Y) := weqsecovertotal2 P _.
 
 (** *** Functions from direct product *)
 
 Definition weqfunfromdirprod (X X' Y : UU) :
-  weq (dirprod X X' -> Y) (Π x : X, X' -> Y) := weqsecovertotal2 _ _.
+  weq (dirprod X X' -> Y) (∏ x : X, X' -> Y) := weqsecovertotal2 _ _.
 
 
 
@@ -638,14 +638,14 @@ Definition weqfunfromdirprod (X X' Y : UU) :
 (** *** General case *)
 
 Theorem impred (n : nat) {T : UU} (P : T -> UU) :
-  (Π t : T, isofhlevel n (P t)) -> (isofhlevel n (Π t : T, P t)).
+  (∏ t : T, isofhlevel n (P t)) -> (isofhlevel n (∏ t : T, P t)).
 Proof.
   intro. induction n as [ | n IHn ].
   - intros T P X. apply (funcontr P X).
   - intros T P X. unfold isofhlevel in X. unfold isofhlevel. intros x x'.
-    assert (is : Π t : T, isofhlevel n (paths (x t) (x' t)))
+    assert (is : ∏ t : T, isofhlevel n (paths (x t) (x' t)))
       by (intro; apply (X t (x t) (x' t))).
-    assert (is2 : isofhlevel n (Π t : T, paths (x t) (x' t)))
+    assert (is2 : isofhlevel n (∏ t : T, paths (x t) (x' t)))
       by apply (IHn _ (fun t0 : T => paths (x t0) (x' t0)) is).
     set (u := toforallpaths P x x').
     assert (is3: isweq u) by apply isweqtoforallpaths.
@@ -656,23 +656,23 @@ Proof.
 Defined.
 
 Corollary impred_iscontr {T : UU} (P : T -> UU) :
-  (Π t : T, iscontr (P t)) -> (iscontr (Π t : T, P t)).
+  (∏ t : T, iscontr (P t)) -> (iscontr (∏ t : T, P t)).
 Proof. intros. apply (impred 0). assumption. Defined.
 
 Corollary impred_isaprop {T : UU} (P : T -> UU) :
-  (Π t : T, isaprop (P t)) -> (isaprop (Π t : T, P t)).
+  (∏ t : T, isaprop (P t)) -> (isaprop (∏ t : T, P t)).
 Proof. apply impred. Defined.
 
 Corollary impred_isaset {T : UU} (P : T -> UU) :
-  (Π t : T, isaset (P t)) -> (isaset (Π t : T, P t)).
+  (∏ t : T, isaset (P t)) -> (isaset (∏ t : T, P t)).
 Proof. intros. apply (impred 2). assumption. Defined.
 
 Corollary impredtwice  (n : nat) {T T' : UU} (P : T -> T' -> UU) :
-  (Π (t : T) (t': T'), isofhlevel n (P t t'))
-  -> (isofhlevel n (Π (t : T) (t': T'), P t t')).
+  (∏ (t : T) (t': T'), isofhlevel n (P t t'))
+  -> (isofhlevel n (∏ (t : T) (t': T'), P t t')).
 Proof.
   intros n T T' P X.
-  assert (is1 : Π t : T, isofhlevel n (Π t': T', P t t'))
+  assert (is1 : ∏ t : T, isofhlevel n (∏ t': T', P t t'))
     by (intro; apply (impred n _ (X t))).
   apply (impred n _ is1).
 Defined.
@@ -689,16 +689,16 @@ Proof.
   intro. induction n as [ | n IHn ]. intros X Y X0. simpl.
   split with (fun x : X => pr1 (X0 x)).
   - intro t.
-    assert (s1 : Π x : X, paths (t x) (pr1 (X0 x)))
+    assert (s1 : ∏ x : X, paths (t x) (pr1 (X0 x)))
            by (intro; apply proofirrelevancecontr; apply (X0 x)).
     apply funextsec. assumption.
   - intros X Y X0. simpl.
     assert (X1 : X -> isofhlevel (S n) (X -> Y))
       by (intro X1; apply impred; assumption).
     intros x x'.
-    assert (s1 : isofhlevel n (Π xx : X, paths (x xx) (x' xx)))
+    assert (s1 : isofhlevel n (∏ xx : X, paths (x xx) (x' xx)))
            by (apply impred; intro t; apply (X0 t)).
-    assert (w : weq (Π xx : X, paths (x xx) (x' xx)) (paths x x'))
+    assert (w : weq (∏ xx : X, paths (x xx) (x' xx)) (paths x x'))
       by apply (weqfunextsec  _ x x').
     apply (isofhlevelweqf n w s1).
 Defined.
@@ -746,12 +746,12 @@ Proof. intros. apply impred. intro. apply (isapropifnegtrue is). Defined.
 Theorem iscontriscontr {X : UU} (is : iscontr X) : iscontr (iscontr X).
 Proof.
   intros X X0.
-  assert (is0 : Π (x x' : X), paths x x')
+  assert (is0 : ∏ (x x' : X), paths x x')
          by (apply proofirrelevancecontr; assumption).
-  assert (is1 : Π cntr : X, iscontr (Π x : X, paths x cntr)).
+  assert (is1 : ∏ cntr : X, iscontr (∏ x : X, paths x cntr)).
   {
     intro.
-    assert (is2 : Π x : X, iscontr (paths x cntr)).
+    assert (is2 : ∏ x : X, iscontr (paths x cntr)).
     {
       assert (is2 : isaprop X)
              by (apply isapropifcontr; assumption).
@@ -760,10 +760,10 @@ Proof.
     }
     apply funcontr. assumption.
   }
-  set (f := @pr1 X (fun cntr : X => Π x : X, paths x cntr)).
+  set (f := @pr1 X (fun cntr : X => ∏ x : X, paths x cntr)).
   assert (X1 : isweq f)
     by (apply isweqpr1; assumption).
-  change (total2 (fun cntr : X => Π x : X, paths x cntr)) with (iscontr X) in X1.
+  change (total2 (fun cntr : X => ∏ x : X, paths x cntr)) with (iscontr X) in X1.
   apply (iscontrweqb (weqpair f X1)). assumption.
 Defined.
 
@@ -915,12 +915,12 @@ Proof.
   set (f := fun a : weq X Y => weqcomp a w).
   set (g := fun b : weq X Z => weqcomp b (invweq w)).
   split with f.
-  assert (egf : Π a : _, paths (g (f a)) a).
+  assert (egf : ∏ a : _, paths (g (f a)) a).
   {
     intro a. apply (invmaponpathsincl _ (isinclpr1weq _ _)). apply funextfun.
     intro x. apply (homotinvweqweq w (a x)).
   }
-  assert (efg : Π b : _, paths (f (g b)) b).
+  assert (efg : ∏ b : _, paths (f (g b)) b).
   {
     intro b. apply (invmaponpathsincl _ (isinclpr1weq _ _)). apply funextfun.
     intro x. apply (homotweqinvweq w (b x)).
@@ -934,12 +934,12 @@ Proof.
   set (f := fun a : weq Y Z => weqcomp w a).
   set (g := fun b : weq X Z => weqcomp (invweq w) b).
   split with f.
-  assert (egf : Π a : _, paths (g (f a)) a).
+  assert (egf : ∏ a : _, paths (g (f a)) a).
   {
     intro a. apply (invmaponpathsincl _ (isinclpr1weq _ _)). apply funextfun.
     intro y. apply (maponpaths a (homotweqinvweq w y)).
   }
-  assert (efg : Π b : _, paths (f (g b)) b).
+  assert (efg : ∏ b : _, paths (f (g b)) b).
   {
     intro b. apply (invmaponpathsincl _ (isinclpr1weq _ _)). apply funextfun.
     intro x. apply (maponpaths b (homotinvweqweq w x)).
@@ -966,12 +966,12 @@ Proof.
   set (f := fun w : weq X Y => invweq w).
   set (g := fun w : weq Y X => invweq w).
   split with f.
-  assert (egf : Π w : _, paths (g (f w)) w).
+  assert (egf : ∏ w : _, paths (g (f w)) w).
   {
     intro. apply (invmaponpathsincl _ (isinclpr1weq _ _)). apply funextfun.
     intro x. apply idpath.
   }
-  assert (efg : Π w : _, paths (f (g w)) w).
+  assert (efg : ∏ w : _, paths (f (g w)) w).
   {
     intro. apply (invmaponpathsincl _ (isinclpr1weq _ _)). apply funextfun.
     intro x. apply idpath.
@@ -1173,7 +1173,7 @@ Defined.
 
 
 Definition locsplit (X : UU) (Y : UU) (f : X -> Y)
-:= Π y : Y, coprod (hfiber  f y) (hfiber  f y -> empty).
+:= ∏ y : Y, coprod (hfiber  f y) (hfiber  f y -> empty).
 
 Definition dnegimage (X : UU) (Y : UU) (f : X -> Y)
 := total2 Y (fun y : Y => dneg(hfiber  f y)).

--- a/UniMath/Foundations/Preamble.v
+++ b/UniMath/Foundations/Preamble.v
@@ -90,9 +90,9 @@ Arguments ii2 {A B} _ : rename.
 Notation "X ⨿ Y" := (coprod X Y) (at level 50, left associativity).
   (* type this in emacs with C-X 8 RET AMALGAMATION OR COPRODUCT *)
 
-Notation "'Π'  x .. y , P" := (forall x, .. (forall y, P) ..)
+Notation "'∏'  x .. y , P" := (forall x, .. (forall y, P) ..)
   (at level 200, x binder, y binder, right associativity) : type_scope.
-  (* type this in emacs in agda-input method with \Pi *)
+  (* type this in emacs in agda-input method with \prod *)
 
 Notation "'λ' x .. y , t" := (fun x => .. (fun y => t) ..)
   (at level 200, x binder, y binder, right associativity).
@@ -100,15 +100,15 @@ Notation "'λ' x .. y , t" := (fun x => .. (fun y => t) ..)
 
 Definition coprod_rect_compute_1
            (A B : UU) (P : A ⨿ B -> UU)
-           (f : Π (a : A), P (ii1 a))
-           (g : Π (b : B), P (ii2 b)) (a:A) :
+           (f : ∏ (a : A), P (ii1 a))
+           (g : ∏ (b : B), P (ii2 b)) (a:A) :
   coprod_rect P f g (ii1 a) = f a.
 Proof. reflexivity. Defined.
 
 Definition coprod_rect_compute_2
            (A B : UU) (P : A ⨿ B -> UU)
-           (f : Π a : A, P (ii1 a))
-           (g : Π b : B, P (ii2 b)) (b:B) :
+           (f : ∏ a : A, P (ii1 a))
+           (g : ∏ b : B, P (ii2 b)) (b:B) :
   coprod_rect P f g (ii2 b) = g b.
 Proof. reflexivity. Defined.
 
@@ -142,7 +142,7 @@ if we used "Record", has a known interpretation in the framework of the univalen
 
 (* or total2 as an inductive type:  *)
 
-    Inductive total2 { T: Type } ( P: T -> Type ) := tpair : Π (__t__:T) (__p__:P __t__), total2 P.
+    Inductive total2 { T: Type } ( P: T -> Type ) := tpair : ∏ (__t__:T) (__p__:P __t__), total2 P.
 
     (* Do not use "induction" without specifying names; seeing __t__ or __p__ will indicate that you *)
     (*    did that.  This will prepare for the use of primitive projections, when the names will be pr1 *)
@@ -175,15 +175,15 @@ Defined.
 
 Print whether_primitive_projections.
 
-Notation "'Σ'  x .. y , P" := (total2 (fun x => .. (total2 (fun y => P)) ..))
+Notation "'∑'  x .. y , P" := (total2 (fun x => .. (total2 (fun y => P)) ..))
   (at level 200, x binder, y binder, right associativity) : type_scope.
-  (* type this in emacs in agda-input method with \Sigma *)
+  (* type this in emacs in agda-input method with \sum *)
 
 Notation "x ,, y" := (tpair _ x y) (at level 60, right associativity). (* looser than '+' *)
 
 Ltac mkpair := (simple refine (tpair _ _ _ ) ; [| cbn]).
 
-Goal Π X (Y : X -> UU) (x : X) (y : Y x), Σ x, Y x.
+Goal ∏ X (Y : X -> UU) (x : X) (y : Y x), ∑ x, Y x.
   intros X Y x y.
   mkpair.
   - apply x.
@@ -191,7 +191,7 @@ Goal Π X (Y : X -> UU) (x : X) (y : Y x), Σ x, Y x.
 Defined.
 
 (* print out this theorem to see whether "induction" compiles to "match" *)
-Goal Π X (Y:X->UU) (w:Σ x, Y x), X.
+Goal ∏ X (Y:X->UU) (w:∑ x, Y x), X.
   intros.
   induction w as [x y].
   exact x.
@@ -199,7 +199,7 @@ Defined.
 
 (* Step through this proof to demonstrate eta expansion for pairs, if primitive
    projections are on: *)
-Goal Π X (Y:X->UU) (w:Σ x, Y x), w = (pr1 w,, pr2 w).
+Goal ∏ X (Y:X->UU) (w:∑ x, Y x), w = (pr1 w,, pr2 w).
 Proof. try reflexivity. Abort.
 
 Definition rewrite_pr1_tpair {X} {P:X->UU} x p : pr1 (tpair P x p) = x.

--- a/UniMath/Foundations/Propositions.v
+++ b/UniMath/Foundations/Propositions.v
@@ -104,17 +104,17 @@ Coercion negProp_to_hProp : negProp >-> hProp.
    arguments: *)
 
 Corollary subtypeInjectivity_prop {A : UU} (B : A -> hProp) :
-  Π (x y : total2 B), (x = y) ≃ (pr1 x = pr1 y).
+  ∏ (x y : total2 B), (x = y) ≃ (pr1 x = pr1 y).
 Proof. intros. apply subtypeInjectivity. intro. apply propproperty. Defined.
 
 Corollary subtypeEquality_prop {A : UU} {B : A -> hProp}
    {s s' : total2 (fun x => B x)} : pr1 s = pr1 s' -> s = s'.
 Proof. intros A B s s'. apply invmap. apply subtypeInjectivity_prop. Defined.
 
-Corollary impred_prop {T : UU} (P : T -> hProp) : isaprop (Π t : T, P t).
+Corollary impred_prop {T : UU} (P : T -> hProp) : isaprop (∏ t : T, P t).
 Proof. intros. apply impred; intro. apply propproperty. Defined.
 
-Corollary isaprop_total2 (X : hProp) (Y : X -> hProp) : isaprop (Σ x, Y x).
+Corollary isaprop_total2 (X : hProp) (Y : X -> hProp) : isaprop (∑ x, Y x).
 Proof.
   intros.
   apply (isofhleveltotal2 1).
@@ -122,16 +122,16 @@ Proof.
   - intro x. apply propproperty.
 Defined.
 
-Lemma isaprop_forall_hProp (X : UU) (Y : X -> hProp) : isaprop (Π x, Y x).
+Lemma isaprop_forall_hProp (X : UU) (Y : X -> hProp) : isaprop (∏ x, Y x).
 Proof. intros. apply impred_isaprop. intro x. apply propproperty. Defined.
 
 Definition forall_hProp {X : UU} (Y : X -> hProp) : hProp
-  := hProppair (Π x, Y x) (isaprop_forall_hProp X Y).
+  := hProppair (∏ x, Y x) (isaprop_forall_hProp X Y).
 
 Notation "∀  x .. y , P"
   := (forall_hProp (fun x => .. (forall_hProp (fun y => P))..))
        (at level 200, x binder, y binder, right associativity) : type_scope.
-  (* type this in emacs in agda-input method with \Pi *)
+  (* type this in emacs in agda-input method with \prod *)
 
 (** The following re-definitions should make proofs easier in the future when
   the unification algorithms in Coq are improved. At the moment they create more
@@ -169,7 +169,7 @@ Definition isdecEq (X : UU) : hProp := hProppair _ (isapropisdeceq X).
 
 
 
-Definition ishinh_UU (X : UU) : UU := Π P : hProp, ((X -> P) -> P).
+Definition ishinh_UU (X : UU) : UU := ∏ P : hProp, ((X -> P) -> P).
 
 Lemma isapropishinh (X : UU) : isaprop (ishinh_UU X).
 Proof.
@@ -273,10 +273,10 @@ of connected components) **)
 Definition image {X Y : UU} (f : X -> Y) : UU
   := total2 (fun y : Y => ishinh (hfiber f y)).
 Definition imagepair {X Y : UU} (f : X -> Y) :
-  Π (t : Y), (λ y : Y, ∥ hfiber f y ∥) t → Σ y : Y, ∥ hfiber f y ∥
+  ∏ (t : Y), (λ y : Y, ∥ hfiber f y ∥) t → ∑ y : Y, ∥ hfiber f y ∥
   := tpair (fun y : Y => ishinh (hfiber f y)).
 Definition pr1image {X Y : UU} (f : X -> Y) :
-  (Σ y : Y, ∥ hfiber f y ∥) → Y
+  (∑ y : Y, ∥ hfiber f y ∥) → Y
   := @pr1 _  (fun y : Y => ishinh (hfiber f y)).
 
 Definition prtoimage {X Y : UU} (f : X -> Y) : X -> image f.
@@ -285,7 +285,7 @@ Proof.
   apply (imagepair _ (f X0) (hinhpr (hfiberpair f X0 (idpath _)))).
 Defined.
 
-Definition issurjective {X Y : UU} (f : X -> Y) := Π y : Y, ishinh (hfiber f y).
+Definition issurjective {X Y : UU} (f : X -> Y) := ∏ y : Y, ishinh (hfiber f y).
 
 Lemma isapropissurjective {X Y : UU} (f : X -> Y) : isaprop (issurjective f).
 Proof.
@@ -411,7 +411,7 @@ Local Open Scope logic.
 Definition hexists {X : UU} (P : X -> UU) := ∥ total2 P ∥.
 
 Notation "'∃' x .. y , P"
-  := (ishinh (Σ x ,.. (Σ y , P)..))
+  := (ishinh (∑ x ,.. (∑ y , P)..))
        (at level 200, x binder, y binder, right associativity) : type_scope.
   (* in agda-input method, type \ex *)
 
@@ -470,23 +470,23 @@ Defined.
 (** *** Negation and quantification.
 
 There are four standard implications in classical logic which can be summarized
-as (neg (Π P)) <-> (exists (neg P)) and (neg (exists P)) <-> (Π (neg P)). Of
+as (neg (∏ P)) <-> (exists (neg P)) and (neg (exists P)) <-> (∏ (neg P)). Of
 these four implications three are provable in the intuitionistic logic. The
-remaining implication (neg (Π P)) -> (exists (neg P)) is not provable in
+remaining implication (neg (∏ P)) -> (exists (neg P)) is not provable in
 general. For a proof in the case of bounded quantification of decidable
 predicates on natural numbers see hnat.v. For some other cases when these
 implications hold see ???. *)
 
 Lemma hexistsnegtonegforall {X : UU} (F : X -> UU) :
-  (∃ x : X, neg (F x)) -> neg (Π x : X, F x).
+  (∃ x : X, neg (F x)) -> neg (∏ x : X, F x).
 Proof.
   intros X F. simpl.
-  apply (@hinhuniv _ (hProppair _ (isapropneg (Π x : X, F x)))).
+  apply (@hinhuniv _ (hProppair _ (isapropneg (∏ x : X, F x)))).
   simpl. intros t2 f2. destruct t2 as [ x d2 ]. apply (d2 (f2 x)).
 Defined.
 
 Lemma forallnegtoneghexists {X : UU} (F : X -> UU) :
-  (Π x : X, neg (F x)) -> neg (∃ x, F x).
+  (∏ x : X, neg (F x)) -> neg (∃ x, F x).
 Proof.
   intros X F nf.
   change ((ishinh_UU (total2 F)) -> hfalse).
@@ -494,14 +494,14 @@ Proof.
 Defined.
 
 Lemma neghexisttoforallneg {X : UU} (F : X -> UU) :
-  ¬ (∃ x, F x) -> Π x : X, ¬ (F x).
+  ¬ (∃ x, F x) -> ∏ x : X, ¬ (F x).
 Proof.
   intros X F nhe x. intro fx.
   apply (nhe (hinhpr (tpair F x fx))).
 Defined.
 
 Definition weqforallnegtonegexists {X : UU} (F : X -> UU) :
-  weq (Π x : X, ¬ F x) (¬ ∃ x, F x).
+  weq (∏ x : X, ¬ F x) (¬ ∃ x, F x).
 Proof.
   intros.
   apply (weqimplimpl (forallnegtoneghexists F) (neghexisttoforallneg F)).
@@ -634,7 +634,7 @@ Definition hinhimplinhdneg (X : UU) (inx1 : ishinh X) : isinhdneg X
 
 (** ** Decidability *)
 
-Definition ComplementaryPair : UU := Σ (P Q : UU), complementary P Q.
+Definition ComplementaryPair : UU := ∑ (P Q : UU), complementary P Q.
 Definition Part1 (C : ComplementaryPair) : UU := pr1 C.
 Definition Part2 (C : ComplementaryPair) : UU := pr1 (pr2 C).
 Definition pair_contradiction (C : ComplementaryPair) : Part1 C -> Part2 C -> ∅
@@ -789,7 +789,7 @@ Defined.
    We don't state LEM as an axiom, because we want to force it
    to be a hypothesis of any corollaries of any theorems that
    appeal to it. *)
-Definition LEM : UU := Π P : hProp, decidable P.
+Definition LEM : UU := ∏ P : hProp, decidable P.
 
 Lemma LEM_for_sets (X : UU) : LEM -> isaset X -> isdeceq X.
 Proof. intros X lem is x y. exact (lem (hProppair (x = y) (is x y))). Defined.
@@ -811,7 +811,7 @@ Defined.
 
 (* all of this will be redone: *)
 
-Definition DecidableProposition : UU := Σ X : UU, isdecprop X.
+Definition DecidableProposition : UU := ∑ X : UU, isdecprop X.
 
 Definition isdecprop_to_DecidableProposition {X : UU} (i : isdecprop X) :
   DecidableProposition := X,,i.
@@ -929,7 +929,7 @@ Proof.
 Defined.
 
 Definition decidableSubtypeCarrier {X : UU} : DecidableSubtype X -> UU.
-Proof. intros ? S. exact (Σ x, S x). Defined.
+Proof. intros ? S. exact (∑ x, S x). Defined.
 
 Definition decidableSubtypeCarrier' {X : UU} : DecidableSubtype X -> UU.
 Proof. intros ? P.
@@ -964,7 +964,7 @@ Defined.
 
 (** ** Univalence for hProp *)
 
-Theorem hPropUnivalence : Π (P Q : hProp), (P -> Q) -> (Q -> P) -> P = Q.
+Theorem hPropUnivalence : ∏ (P Q : hProp), (P -> Q) -> (Q -> P) -> P = Q.
   (* this theorem replaced a former axiom, with the same statement, called
      "uahp" *)
 Proof.
@@ -1004,7 +1004,7 @@ Proof.
                              @eqweqmaphProp (pr1 XY) (pr2 XY)): Z1 -> Z2)).
   set (g := (totalfun _ _ (fun XY : hProp × hProp =>
                              @weqtopathshProp (pr1 XY) (pr2 XY)): Z2 -> Z1)).
-  assert (efg : Π z2 : Z2 , paths (f (g z2)) z2).
+  assert (efg : ∏ z2 : Z2 , paths (f (g z2)) z2).
   {
     intros. induction z2 as [ XY w].
     exact (maponpaths (fun w : weq (pr1 XY) (pr2 XY) => tpair P2 XY w)
@@ -1012,9 +1012,9 @@ Proof.
   }
 
   set (h := fun a1 : Z1 => (pr1 (pr1 a1))).
-  assert (egf0 : Π a1 : Z1, paths (pr1 (g (f a1))) (pr1 a1))
+  assert (egf0 : ∏ a1 : Z1, paths (pr1 (g (f a1))) (pr1 a1))
          by (intro; apply idpath).
-  assert (egf1 : Π a1 a1' : Z1, paths (pr1 a1') (pr1 a1) -> paths a1' a1).
+  assert (egf1 : ∏ a1 a1' : Z1, paths (pr1 a1') (pr1 a1) -> paths a1' a1).
   {
     intros ? ? X.
     set (X' := maponpaths (@pr1 _ _) X).

--- a/UniMath/Foundations/Sets.v
+++ b/UniMath/Foundations/Sets.v
@@ -111,7 +111,7 @@ Defined.
 Definition setcoprod (X Y : hSet) : hSet.
 Proof. intros. exists (X ⨿ Y). apply isasetcoprod; apply setproperty. Defined.
 
-Lemma isaset_total2_hSet (X : hSet) (Y : X -> hSet) : isaset (Σ x, Y x).
+Lemma isaset_total2_hSet (X : hSet) (Y : X -> hSet) : isaset (∑ x, Y x).
 Proof.
   intros. apply isaset_total2.
   - apply setproperty.
@@ -119,28 +119,28 @@ Proof.
 Defined.
 
 Definition total2_hSet {X : hSet} (Y : X -> hSet) : hSet
-  := hSetpair (Σ x, Y x) (isaset_total2_hSet X Y).
+  := hSetpair (∑ x, Y x) (isaset_total2_hSet X Y).
 
 Definition hfiber_hSet {X : hSet} {Y : hSet} (f : X → Y) (y : Y) : hSet
   := hSetpair (hfiber f y) (isaset_hfiber f y (pr2 X) (pr2 Y)).
 
 Delimit Scope set with set.
 
-Notation "'Σ' x .. y , P" := (total2_hSet (fun x =>.. (total2_hSet (fun y => P))..))
+Notation "'∑' x .. y , P" := (total2_hSet (fun x =>.. (total2_hSet (fun y => P))..))
   (at level 200, x binder, y binder, right associativity) : set.
-  (* type this in emacs in agda-input method with \Sigma *)
+  (* type this in emacs in agda-input method with \sum *)
 
-Lemma isaset_forall_hSet (X : UU) (Y : X -> hSet) : isaset (Π x, Y x).
+Lemma isaset_forall_hSet (X : UU) (Y : X -> hSet) : isaset (∏ x, Y x).
 Proof. intros. apply impred_isaset. intro x. apply setproperty. Defined.
 
 Definition forall_hSet {X : UU} (Y : X -> hSet) : hSet
-  := hSetpair (Π x, Y x) (isaset_forall_hSet X Y).
+  := hSetpair (∏ x, Y x) (isaset_forall_hSet X Y).
 
-Notation "'Π' x .. y , P" := (forall_hSet (fun x =>.. (forall_hSet (fun y => P))..))
+Notation "'∏' x .. y , P" := (forall_hSet (fun x =>.. (forall_hSet (fun y => P))..))
   (at level 200, x binder, y binder, right associativity) : set.
-  (* type this in emacs in agda-input method with \Sigma *)
+  (* type this in emacs in agda-input method with \sum *)
 
-Lemma isaset_total2_subset (X : hSet) (Y : X -> hProp) : isaset (Σ x, Y x).
+Lemma isaset_total2_subset (X : hSet) (Y : X -> hProp) : isaset (∑ x, Y x).
 Proof.
   intros. apply isaset_total2.
   - apply setproperty.
@@ -148,12 +148,12 @@ Proof.
 Defined.
 
 Definition total2_subset {X : hSet} (Y : X -> hProp) : hSet
-  := hSetpair (Σ x, Y x) (isaset_total2_subset X Y).
+  := hSetpair (∑ x, Y x) (isaset_total2_subset X Y).
 
-Notation "'Σ' x .. y , P"
+Notation "'∑' x .. y , P"
   := (total2_subset (fun x =>.. (total2_subset (fun y => P))..))
   (at level 200, x binder, y binder, right associativity) : subset.
-  (* type this in emacs in agda-input method with \Sigma *)
+  (* type this in emacs in agda-input method with \sum *)
 
 Delimit Scope subset with subset.
 
@@ -186,7 +186,7 @@ Definition boolset : hSet := hSetpair bool isasetbool.
 
 Definition isInjectiveFunction {X Y : hSet} (f : X -> Y) : hProp.
 Proof.
-  intros. exists (Π (x x': X), f x = f x' -> x = x').
+  intros. exists (∏ (x x': X), f x = f x' -> x = x').
   abstract (
       intros; apply impred; intro x; apply impred; intro y;
       apply impred; intro e; apply setproperty)
@@ -219,7 +219,7 @@ to satisfy weak axiom of choice.
 *)
 
 Definition ischoicebase_uu1 (X : UU)
-  := Π P : X -> UU, (Π x : X, ishinh (P x)) -> ishinh (Π x : X, P x).
+  := ∏ P : X -> UU, (∏ x : X, ishinh (P x)) -> ishinh (∏ x : X, P x).
 
 (** Uses RR1 *)
 Lemma isapropischoicebase (X : UU) : isaprop (ischoicebase_uu1 X).
@@ -296,7 +296,7 @@ Identity Coercion id_hsubtype :  hsubtype >-> Funclass.
 Definition carrier {X : UU} (A : hsubtype X) := total2 A.
 Coercion carrier : hsubtype >-> Sortclass.
 Definition carrierpair {X : UU} (A : hsubtype X) :
-   Π t : X, A t → Σ x : X, A x := tpair A.
+   ∏ t : X, A t → ∑ x : X, A x := tpair A.
 Definition pr1carrier {X : UU} (A : hsubtype X) := @pr1 _ _  : carrier A -> X.
 
 Lemma isinclpr1carrier {X : UU} (A : hsubtype X) : isincl (@pr1carrier X A).
@@ -317,7 +317,7 @@ Proof. intro. apply weqpr1. intro. apply iscontrunit. Defined.
 
 Definition weq_subtypes {X Y : UU} (w : X ≃ Y)
            (S : hsubtype X) (T : hsubtype Y) :
-           (Π x, S x <-> T (w x)) -> carrier S ≃ carrier T.
+           (∏ x, S x <-> T (w x)) -> carrier S ≃ carrier T.
 Proof.
   intros ? ? ? ? ? eq. apply (weqbandf w). intro x. apply weqiff.
   - apply eq.
@@ -365,7 +365,7 @@ Proof.
   set (f := fromdsubtypesdirprodcarrier A B).
   set (g := tosubtypesdirprodcarrier A B).
   split with f.
-  assert (egf : Π a : _, paths (g (f a)) a).
+  assert (egf : ∏ a : _, paths (g (f a)) a).
   {
     intro a.
     destruct a as [ xy is ].
@@ -373,7 +373,7 @@ Proof.
     destruct is as [ isx isy ].
     apply idpath.
   }
-  assert (efg : Π a : _, paths (f (g a)) a).
+  assert (efg : ∏ a : _, paths (f (g a)) a).
   {
     intro a.
     destruct a as [ xis yis ].
@@ -398,7 +398,7 @@ Defined.
 
 
 Lemma isapropsubtype {X : UU} (A : hsubtype X)
-      (is : Π (x1 x2 : X), A x1 -> A x2 -> x1 = x2) : isaprop (carrier A).
+      (is : ∏ (x1 x2 : X), A x1 -> A x2 -> x1 = x2) : isaprop (carrier A).
 Proof.
   intros. apply invproofirrelevance.
   intros x x'.
@@ -416,10 +416,10 @@ Proof.
 Defined.
 
 Definition squash_pairs_to_set {Y : UU} (F : Y -> UU) :
-  (isaset Y) -> (Π y y', F y -> F y' -> y = y') -> (∃ y, F y) -> Y.
+  (isaset Y) -> (∏ y y', F y -> F y' -> y = y') -> (∃ y, F y) -> Y.
 Proof.
   intros ? ? is e.
-  set (P := Σ y, ∥ F y ∥).
+  set (P := ∑ y, ∥ F y ∥).
   assert (iP : isaprop P).
   {
     apply isapropsubtype. intros y y' f f'.
@@ -438,10 +438,10 @@ Proof.
 Defined.
 
 Definition squash_to_set {X Y : UU} (is : isaset Y) (f : X -> Y) :
-          (Π x x', f x = f x') -> ∥ X ∥ -> Y.
+          (∏ x x', f x = f x') -> ∥ X ∥ -> Y.
 Proof.
   intros ? ? ? ? e w.
-  set (P := Σ y, ∃ x, f x = y).
+  set (P := ∑ y, ∃ x, f x = y).
   assert (j : isaprop P).
   {
     apply isapropsubtype; intros y y' j j'.
@@ -486,13 +486,13 @@ Coercion DecidableRelation_to_hrel : DecidableRelation >-> hrel.
 
 
 Definition istrans {X : UU} (R : hrel X) : UU
-  := Π (x1 x2 x3 : X), R x1 x2 -> R x2 x3 -> R x1 x3.
+  := ∏ (x1 x2 x3 : X), R x1 x2 -> R x2 x3 -> R x1 x3.
 
 Definition isrefl {X : UU} (R : hrel X) : UU
-  := Π x : X, R x x.
+  := ∏ x : X, R x x.
 
 Definition issymm {X : UU} (R : hrel X) : UU
-  := Π (x1 x2 : X), R x1 x2 -> R x2 x1.
+  := ∏ (x1 x2 : X), R x1 x2 -> R x2 x1.
 
 Definition ispreorder {X : UU} (R : hrel X) : UU := istrans R × isrefl R.
 
@@ -501,27 +501,27 @@ Definition iseqrelconstr {X : UU} {R : hrel X}
            (trans0 : istrans R) (refl0 : isrefl R) (symm0 : issymm R) :
   iseqrel R := dirprodpair (dirprodpair trans0 refl0) symm0.
 
-Definition isirrefl {X : UU} (R : hrel X) : UU := Π x : X, ¬ R x x.
+Definition isirrefl {X : UU} (R : hrel X) : UU := ∏ x : X, ¬ R x x.
 
 Definition isasymm {X : UU} (R : hrel X) : UU
-  := Π (x1 x2 : X), R x1 x2 -> R x2 x1 -> empty.
+  := ∏ (x1 x2 : X), R x1 x2 -> R x2 x1 -> empty.
 
-Definition iscoasymm {X : UU} (R : hrel X) : UU := Π x1 x2, ¬ R x1 x2 -> R x2 x1.
+Definition iscoasymm {X : UU} (R : hrel X) : UU := ∏ x1 x2, ¬ R x1 x2 -> R x2 x1.
 
-Definition istotal {X : UU} (R : hrel X) : UU := Π x1 x2, R x1 x2 ∨ R x2 x1.
+Definition istotal {X : UU} (R : hrel X) : UU := ∏ x1 x2, R x1 x2 ∨ R x2 x1.
 
-Definition isdectotal {X : UU} (R : hrel X) : UU := Π x1 x2, R x1 x2 ⨿ R x2 x1.
+Definition isdectotal {X : UU} (R : hrel X) : UU := ∏ x1 x2, R x1 x2 ⨿ R x2 x1.
 
 Definition iscotrans {X : UU} (R : hrel X) : UU
-  := Π x1 x2 x3, R x1 x3 -> R x1 x2 ∨ R x2 x3.
+  := ∏ x1 x2 x3, R x1 x3 -> R x1 x2 ∨ R x2 x3.
 
 Definition isdeccotrans {X : UU} (R : hrel X) : UU
-  := Π x1 x2 x3, R x1 x3 -> R x1 x2 ⨿ R x2 x3.
+  := ∏ x1 x2 x3, R x1 x3 -> R x1 x2 ⨿ R x2 x3.
 
-Definition isdecrel {X : UU} (R : hrel X) : UU := Π x1 x2, R x1 x2 ⨿ ¬ R x1 x2.
+Definition isdecrel {X : UU} (R : hrel X) : UU := ∏ x1 x2, R x1 x2 ⨿ ¬ R x1 x2.
 
 Definition isnegrel {X : UU} (R : hrel X) : UU
-  := Π x1 x2, ¬ ¬ R x1 x2 -> R x1 x2.
+  := ∏ x1 x2, ¬ ¬ R x1 x2 -> R x1 x2.
 
 (** Note that the property of being (co-)antisymmetric is different from other
   properties of relations which we consider due to the presence of [paths] in
@@ -530,7 +530,7 @@ Definition isnegrel {X : UU} (R : hrel X) : UU
   the original relation was not. *)
 
 Definition isantisymm {X : UU} (R : hrel X) : UU
-  := Π (x1 x2 : X), R x1 x2 -> R x2 x1 -> x1 = x2.
+  := ∏ (x1 x2 : X), R x1 x2 -> R x2 x1 -> x1 = x2.
 
 Definition isPartialOrder {X : UU} (R : hrel X) : UU
   := ispreorder R × isantisymm R.
@@ -539,17 +539,17 @@ Ltac unwrap_isPartialOrder i :=
   induction i as [transrefl antisymm]; induction transrefl as [trans refl].
 
 Definition isantisymmneg {X : UU} (R : hrel X) : UU
-  := Π (x1 x2 : X), ¬ R x1 x2 -> ¬ R x2 x1 -> x1 = x2.
+  := ∏ (x1 x2 : X), ¬ R x1 x2 -> ¬ R x2 x1 -> x1 = x2.
 
 Definition iscoantisymm {X : UU} (R : hrel X) : UU
-  := Π x1 x2, ¬ R x1 x2 -> R x2 x1 ⨿ (x1 = x2).
+  := ∏ x1 x2, ¬ R x1 x2 -> R x2 x1 ⨿ (x1 = x2).
 
 (** Note that the following condition on a relation is different from all the
   other which we have considered since it is not a property but a structure,
   i.e. it is in general unclear whether [isaprop (neqchoice R)] is provable. *)
 
 Definition neqchoice {X : UU} (R : hrel X) : UU
-  := Π x1 x2, x1 != x2 -> R x1 x2 ⨿ R x2 x1.
+  := ∏ x1 x2, x1 != x2 -> R x1 x2 ⨿ R x2 x1.
 
 (** proofs that the properties are propositions  *)
 
@@ -638,27 +638,27 @@ Proof. intros. intro e. rewrite e in r. apply (is b r). Defined.
 (** *** Standard properties of relations and logical equivalences *)
 
 Definition hrellogeq {X : UU} (L R : hrel X) : UU
-  := Π x1 x2, (L x1 x2 <-> R x1 x2).
+  := ∏ x1 x2, (L x1 x2 <-> R x1 x2).
 
 Definition istranslogeqf {X : UU} {L R : hrel X}
-           (lg : Π x1 x2, L x1 x2 <-> R x1 x2) (isl : istrans L) : istrans R.
+           (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : istrans L) : istrans R.
 Proof.
   intros. intros x1 x2 x3 r12 r23.
   apply ((pr1 (lg _ _)) (isl _ _ _ ((pr2 (lg _ _)) r12) ((pr2 (lg _ _)) r23))).
 Defined.
 
 Definition isrefllogeqf {X : UU} {L R : hrel X}
-           (lg : Π x1 x2, L x1 x2 <-> R x1 x2) (isl : isrefl L) : isrefl R.
+           (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : isrefl L) : isrefl R.
 Proof. intros. intro x. apply (pr1 (lg _ _) (isl x)). Defined.
 
 Definition issymmlogeqf {X : UU} {L R : hrel X}
-           (lg : Π x1 x2, L x1 x2 <-> R x1 x2) (isl : issymm L) : issymm R.
+           (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : issymm L) : issymm R.
 Proof.
   intros. intros x1 x2 r12.
   apply (pr1 (lg _ _) (isl _ _ (pr2 (lg _ _) r12))).
 Defined.
 
-Definition ispologeqf {X : UU} {L R : hrel X} (lg : Π x1 x2, L x1 x2 <-> R x1 x2)
+Definition ispologeqf {X : UU} {L R : hrel X} (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2)
            (isl : ispreorder L) : ispreorder R.
 Proof.
   intros.
@@ -666,32 +666,32 @@ Proof.
 Defined.
 
 Definition iseqrellogeqf {X : UU} {L R : hrel X}
-           (lg : Π x1 x2, L x1 x2 <-> R x1 x2) (isl : iseqrel L) : iseqrel R.
+           (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : iseqrel L) : iseqrel R.
 Proof.
   intros.
   apply (dirprodpair (ispologeqf lg (pr1 isl)) (issymmlogeqf lg (pr2 isl))).
 Defined.
 
 Definition isirrefllogeqf {X : UU} {L R : hrel X}
-           (lg : Π x1 x2, L x1 x2 <-> R x1 x2) (isl : isirrefl L) : isirrefl R.
+           (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : isirrefl L) : isirrefl R.
 Proof. intros. intros x r. apply (isl _ (pr2 (lg x x) r)). Defined.
 
 Definition isasymmlogeqf {X : UU} {L R : hrel X}
-           (lg : Π x1 x2, L x1 x2 <-> R x1 x2) (isl : isasymm L) : isasymm R.
+           (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : isasymm L) : isasymm R.
 Proof.
   intros. intros x1 x2 r12 r21.
   apply (isl _ _ (pr2 (lg _ _) r12) (pr2 (lg _ _) r21)).
 Defined.
 
 Definition iscoasymmlogeqf {X : UU} {L R : hrel X}
-           (lg : Π x1 x2, L x1 x2 <-> R x1 x2) (isl : iscoasymm L) : iscoasymm R.
+           (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : iscoasymm L) : iscoasymm R.
 Proof.
   intros. intros x1 x2 r12.
   apply ((pr1 (lg _ _)) (isl _ _ (negf (pr1 (lg _ _)) r12))).
 Defined.
 
 Definition istotallogeqf {X : UU} {L R : hrel X}
-           (lg : Π x1 x2, L x1 x2 <-> R x1 x2) (isl : istotal L) : istotal R.
+           (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : istotal L) : istotal R.
 Proof.
   intros. intros x1 x2. set (int := isl x1 x2).
   generalize int. clear int. simpl. apply hinhfun.
@@ -699,7 +699,7 @@ Proof.
 Defined.
 
 Definition iscotranslogeqf {X : UU} {L R : hrel X}
-           (lg : Π x1 x2, L x1 x2 <-> R x1 x2) (isl : iscotrans L) : iscotrans R.
+           (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : iscotrans L) : iscotrans R.
 Proof.
   intros. intros x1 x2 x3 r13.
   set (int := isl x1 x2 x3 (pr2 (lg _ _) r13)). generalize int.
@@ -708,7 +708,7 @@ Proof.
 Defined.
 
 Definition isdecrellogeqf {X : UU} {L R : hrel X}
-           (lg : Π x1 x2, L x1 x2 <-> R x1 x2) (isl : isdecrel L) : isdecrel R.
+           (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : isdecrel L) : isdecrel R.
 Proof.
   intros. intros x1 x2.
   destruct (isl x1 x2) as [ l | nl ].
@@ -717,14 +717,14 @@ Proof.
 Defined.
 
 Definition isnegrellogeqf {X : UU} {L R : hrel X}
-           (lg : Π x1 x2, L x1 x2 <-> R x1 x2) (isl : isnegrel L) : isnegrel R.
+           (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : isnegrel L) : isnegrel R.
 Proof.
   intros. intros x1 x2 nnr.
   apply ((pr1 (lg _ _)) (isl _ _ (negf (negf (pr2 (lg _ _))) nnr))).
 Defined.
 
 Definition isantisymmlogeqf {X : UU} {L R : hrel X}
-           (lg : Π x1 x2, L x1 x2 <-> R x1 x2) (isl : isantisymm L) :
+           (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : isantisymm L) :
   isantisymm R.
 Proof.
   intros. intros x1 x2 r12 r21.
@@ -732,7 +732,7 @@ Proof.
 Defined.
 
 Definition isantisymmneglogeqf {X : UU} {L R : hrel X}
-           (lg : Π x1 x2, L x1 x2 <-> R x1 x2) (isl : isantisymmneg L) :
+           (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : isantisymmneg L) :
   isantisymmneg R.
 Proof.
   intros. intros x1 x2 nr12 nr21.
@@ -740,7 +740,7 @@ Proof.
 Defined.
 
 Definition iscoantisymmlogeqf {X : UU} {L R : hrel X}
-           (lg : Π x1 x2, L x1 x2 <-> R x1 x2) (isl : iscoantisymm L) :
+           (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : iscoantisymm L) :
   iscoantisymm R.
 Proof.
   intros. intros x1 x2 r12.
@@ -749,7 +749,7 @@ Proof.
 Defined.
 
 Definition neqchoicelogeqf {X : UU} {L R : hrel X}
-           (lg : Π x1 x2, L x1 x2 <-> R x1 x2) (isl : neqchoice L) : neqchoice R.
+           (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : neqchoice L) : neqchoice R.
 Proof.
   intros. intros x1 x2 ne.
   apply (coprodf (pr1 (lg x1 x2)) (pr1 (lg x2 x1)) (isl _ _ ne)).
@@ -760,13 +760,13 @@ Defined.
 (** *** Preorderings, partial orderings, and associated types. *)
 
 (* preoderings *)
-Definition po (X : UU) : UU := Σ R : hrel X, ispreorder R.
+Definition po (X : UU) : UU := ∑ R : hrel X, ispreorder R.
 Definition popair {X : UU} (R : hrel X) (is : ispreorder R) : po X
   := tpair ispreorder R is.
 Definition carrierofpo (X : UU) : po X -> (X -> X -> hProp) := @pr1 _ ispreorder.
 Coercion carrierofpo : po >-> Funclass.
 
-Definition PreorderedSet : UU := Σ X : hSet, po X.
+Definition PreorderedSet : UU := ∑ X : hSet, po X.
 Definition PreorderedSetPair (X : hSet) (R :po X) : PreorderedSet
   := tpair _ X R.
 Definition carrierofPreorderedSet : PreorderedSet -> hSet := pr1.
@@ -774,14 +774,14 @@ Coercion carrierofPreorderedSet : PreorderedSet >-> hSet.
 Definition PreorderedSetRelation (X : PreorderedSet) : hrel X := pr1 (pr2 X).
 
 (* partial orderings *)
-Definition PartialOrder (X : hSet) : UU := Σ R : hrel X, isPartialOrder R.
+Definition PartialOrder (X : hSet) : UU := ∑ R : hrel X, isPartialOrder R.
 Definition PartialOrderpair {X : hSet} (R : hrel X) (is : isPartialOrder R) :
   PartialOrder X
   := tpair isPartialOrder R is.
 Definition carrierofPartialOrder {X : hSet} : PartialOrder X -> hrel X := pr1.
 Coercion carrierofPartialOrder : PartialOrder >-> hrel.
 
-Definition Poset : UU := Σ X, PartialOrder X.
+Definition Poset : UU := ∑ X, PartialOrder X.
 Definition Posetpair (X : hSet) (R : PartialOrder X) : Poset
   := tpair PartialOrder X R.
 Definition carrierofposet : Poset -> hSet := pr1.
@@ -801,18 +801,18 @@ Delimit Scope poset with poset.
 Notation "m ≤ n" := (posetRelation _ m n) (no associativity, at level 70) :
                       poset.
 Definition isaposetmorphism {X Y : Poset} (f : X -> Y)
-  := (Π x x' : X, x ≤ x' -> f x ≤ f x')%poset.
+  := (∏ x x' : X, x ≤ x' -> f x ≤ f x')%poset.
 Definition posetmorphism (X Y : Poset) : UU
   := total2 (fun f : X -> Y => isaposetmorphism f).
 Definition posetmorphismpair (X Y : Poset) :
-  Π t : X → Y, isaposetmorphism t → Σ f : X → Y, isaposetmorphism f
+  ∏ t : X → Y, isaposetmorphism t → ∑ f : X → Y, isaposetmorphism f
   := tpair (fun f : X -> Y => isaposetmorphism f).
 Definition carrierofposetmorphism (X Y : Poset) : posetmorphism X Y -> (X -> Y)
   := @pr1 _ _.
 Coercion carrierofposetmorphism : posetmorphism >-> Funclass.
 
 Definition isdec_ordering (X : Poset) : UU
-  := Π (x y : X), decidable (x ≤ y)%poset.
+  := ∏ (x y : X), decidable (x ≤ y)%poset.
 
 Lemma isaprop_isaposetmorphism {X Y : Poset} (f : X -> Y) :
   isaprop (isaposetmorphism f).
@@ -858,7 +858,7 @@ Proof.
 Defined.
 
 Definition PosetEquivalence (X Y : Poset) : UU
-  := Σ f : X ≃ Y, isPosetEquivalence f.
+  := ∑ f : X ≃ Y, isPosetEquivalence f.
 
 Local Open Scope poset.
 Notation "X ≅ Y" := (PosetEquivalence X Y) (at level 60, no associativity) :
@@ -884,10 +884,10 @@ Defined.
 (** poset concepts *)
 
 Notation "m < n" := (m ≤ n × m != n)%poset (only parsing) : poset.
-Definition isMinimal {X : Poset} (x : X) : UU := Π y, x ≤ y.
-Definition isMaximal {X : Poset} (x : X) : UU := Π y, y ≤ x.
+Definition isMinimal {X : Poset} (x : X) : UU := ∏ y, x ≤ y.
+Definition isMaximal {X : Poset} (x : X) : UU := ∏ y, y ≤ x.
 Definition consecutive {X : Poset} (x y : X) : UU
-  := x < y × Π z, ¬ (x < z × z < y).
+  := x < y × ∏ z, ¬ (x < z × z < y).
 
 Lemma isaprop_isMinimal {X : Poset} (x : X) : isaprop (isMaximal x).
 Proof.
@@ -1305,21 +1305,21 @@ Defined.
 
 Definition iseqclass {X : UU} (R : hrel X) (A : hsubtype X) : UU
   := dirprod (ishinh (carrier A))
-             (dirprod (Π x1 x2 : X, R x1 x2 -> A x1 -> A x2)
-                      (Π x1 x2 : X, A x1 ->  A x2 -> R x1 x2)).
+             (dirprod (∏ x1 x2 : X, R x1 x2 -> A x1 -> A x2)
+                      (∏ x1 x2 : X, A x1 ->  A x2 -> R x1 x2)).
 Definition iseqclassconstr {X : UU} (R : hrel X) {A : hsubtype X}
            (ax0 : ishinh (carrier A))
-           (ax1 : Π x1 x2 : X, R x1 x2 -> A x1 -> A x2)
-           (ax2 : Π x1 x2 : X, A x1 ->  A x2 -> R x1 x2) : iseqclass R A
+           (ax1 : ∏ x1 x2 : X, R x1 x2 -> A x1 -> A x2)
+           (ax2 : ∏ x1 x2 : X, A x1 ->  A x2 -> R x1 x2) : iseqclass R A
   := dirprodpair ax0 (dirprodpair ax1 ax2).
 
 Definition eqax0 {X : UU} {R : hrel X} {A : hsubtype X} :
   iseqclass R A -> ishinh (carrier A) := fun is : iseqclass R A => pr1 is.
 Definition eqax1 {X : UU} {R : hrel X} {A : hsubtype X} :
-  iseqclass R A -> Π x1 x2 : X, R x1 x2 -> A x1 -> A x2
+  iseqclass R A -> ∏ x1 x2 : X, R x1 x2 -> A x1 -> A x2
   := fun is : iseqclass R A => pr1 (pr2 is).
 Definition eqax2 {X : UU} {R : hrel X} {A : hsubtype X} :
-  iseqclass R A -> Π x1 x2 : X, A x1 -> A x2 -> R x1 x2
+  iseqclass R A -> ∏ x1 x2 : X, A x1 -> A x2 -> R x1 x2
   := fun is : iseqclass R A => pr2 (pr2 is).
 
 Lemma isapropiseqclass {X : UU} (R : hrel X) (A : hsubtype X) :
@@ -1348,13 +1348,13 @@ Proof.
   set (AB := subtypesdirprod A B).
   set (RQ := hreldirprod R Q).
   set (ax0 := ishinhsubtypedirprod A B (eqax0 isa) (eqax0 isb)).
-  assert (ax1 : Π xy1 xy2 : XY, RQ xy1 xy2 -> AB xy1 -> AB xy2).
+  assert (ax1 : ∏ xy1 xy2 : XY, RQ xy1 xy2 -> AB xy1 -> AB xy2).
   {
     intros xy1 xy2 rq ab1.
     apply (dirprodpair (eqax1 isa _ _ (pr1 rq) (pr1 ab1))
                        (eqax1 isb _ _ (pr2 rq) (pr2 ab1))).
   }
-  assert (ax2 : Π xy1 xy2 : XY, AB xy1 -> AB xy2 -> RQ xy1 xy2).
+  assert (ax2 : ∏ xy1 xy2 : XY, AB xy1 -> AB xy2 -> RQ xy1 xy2).
   {
     intros xy1 xy2 ab1 ab2.
     apply (dirprodpair (eqax2 isa _ _ (pr1 ab1) (pr1 ab2))
@@ -1369,7 +1369,7 @@ Defined.
 
 Theorem surjectionisepitosets {X Y Z : UU} (f : X -> Y) (g1 g2 : Y -> Z)
         (is1 : issurjective f) (is2 : isaset Z)
-        (isf : Π x : X, g1 (f x) = g2 (f x)) : Π y : Y, g1 y = g2 y.
+        (isf : ∏ x : X, g1 (f x) = g2 (f x)) : ∏ y : Y, g1 y = g2 y.
 Proof.
   intros.
   set (P1:= hProppair (paths (g1 y) (g2 y)) (is2 (g1 y) (g2 y))).
@@ -1412,14 +1412,14 @@ Qed.
 TODO find a proof without univalence for propositions (if possible)
 *)
 Lemma epiissurjectiontosets {A B : UU} (p : A -> B) (isB:isaset B)
-      (epip : Π (C:hSet) (g1 g2:B->C), (Π x : A, g1 (p x) = g2 (p x)) ->
-                               (Π y : B, g1 y = g2 y)) :   issurjective p.
+      (epip : ∏ (C:hSet) (g1 g2:B->C), (∏ x : A, g1 (p x) = g2 (p x)) ->
+                               (∏ y : B, g1 y = g2 y)) :   issurjective p.
 Proof.
   intros.
   assert(pred_set : isaset (B -> hProp)).
   { apply (isaset_set_fun_space _ (hSetpair _ isasethProp)). }
   specialize (epip (hSetpair _ pred_set)
-                   (fun b x => ∥ Σ y : hfiber p b, x = p (pr1 y) ∥ )
+                   (fun b x => ∥ ∑ y : hfiber p b, x = p (pr1 y) ∥ )
                    (fun b x => hProppair (x = b) (isB x b))
                ).
   lapply epip.
@@ -1473,11 +1473,11 @@ Section LiftSurjection.
   Hypothesis hsc:isaset C.
   Variables (p : A -> B ) (f: A -> C ).
 
-  Hypothesis comp_f_epi: Π x y, p x =  p y -> f x = f y.
+  Hypothesis comp_f_epi: ∏ x y, p x =  p y -> f x = f y.
   Hypothesis surjectivep : issurjective p.
 
   (* Reformulation of the previous hypothesis *)
-  Lemma surjective_iscontr_im : Π b : B, iscontr
+  Lemma surjective_iscontr_im : ∏ b : B, iscontr
                                         (image (fun (x:hfiber p b) => f (pr1 x))).
   Proof.
     intro b.
@@ -1502,7 +1502,7 @@ Section LiftSurjection.
   Definition univ_surj : B -> C :=
     fun b => (pr1 (pr1 (surjective_iscontr_im b))).
 
-  Lemma univ_surj_ax : Π x,  univ_surj (p x) = f x.
+  Lemma univ_surj_ax : ∏ x,  univ_surj (p x) = f x.
   Proof.
     intro x.
     apply pathsinv0.
@@ -1515,7 +1515,7 @@ Section LiftSurjection.
     apply (pr2 r).
   Qed.
 
-  Lemma univ_surj_unique : Π (g : B -> C) (H : Π a : A, g (p a) = f a)
+  Lemma univ_surj_unique : ∏ (g : B -> C) (H : ∏ a : A, g (p a) = f a)
                             (b : B), g b = univ_surj b.
   Proof.
     intros g H b.
@@ -1639,7 +1639,7 @@ Defined.
 
 
 Definition iscomprelfun {X Y : UU} (R : hrel X) (f : X -> Y) : UU
-  := Π x x' : X, R x x' -> f x = f x'.
+  := ∏ x x' : X, R x x' -> f x = f x'.
 
 Lemma iscomprelfunlogeqf {X Y : UU} {R L : hrel X} (lg : hrellogeq L R)
       (f : X -> Y) (is : iscomprelfun L f) : iscomprelfun R f.
@@ -1682,7 +1682,7 @@ Defined.
 
 Theorem setquotunivcomm {X : UU} (R : eqrel X) (Y : hSet) (f : X -> Y)
         (is : iscomprelfun R f) :
-  Π x : X, setquotuniv R Y f is (setquotpr R x) = f x.
+  ∏ x : X, setquotuniv R Y f is (setquotpr R x) = f x.
 Proof.
   intros. unfold setquotuniv. unfold setquotpr.
   simpl. apply idpath.
@@ -1709,7 +1709,7 @@ Defined.
 
 
 Definition iscomprelrelfun {X Y : UU} (RX : hrel X) (RY : hrel Y) (f : X -> Y)
-  : UU := Π x x' : X, RX x x' -> RY (f x) (f x').
+  : UU := ∏ x x' : X, RX x x' -> RY (f x) (f x').
 
 Lemma iscomprelfunlogeqf1 {X Y : UU} {LX RX : hrel X} (RY : hrel Y)
       (lg : hrellogeq LX RX) (f : X -> Y) (is : iscomprelrelfun LX RY f) :
@@ -1737,7 +1737,7 @@ Defined.
 
 Definition setquotfuncomm {X Y : UU} (RX : eqrel X) (RY : eqrel Y)
            (f : X -> Y) (is : iscomprelrelfun RX RY f) :
-  Π x : X, setquotfun RX RY f is (setquotpr RX x) = setquotpr RY (f x).
+  ∏ x : X, setquotfun RX RY f is (setquotpr RX x) = setquotpr RY (f x).
 Proof. intros. simpl. apply idpath. Defined.
 
 
@@ -1745,7 +1745,7 @@ Proof. intros. simpl. apply idpath. Defined.
 (** *** Universal property of [setquot] for predicates of one and several variables *)
 
 Theorem setquotunivprop {X : UU} (R : eqrel X) (P : setquot (pr1 R) -> hProp)
-  (ps : Π x : X, pr1 (P (setquotpr R x))) : Π c : setquot (pr1 R), pr1 (P c).
+  (ps : ∏ x : X, pr1 (P (setquotpr R x))) : ∏ c : setquot (pr1 R), pr1 (P c).
 Proof.
 intros X R P ps c.
 apply (@hinhuniv (carrier (pr1 c)) (P c)).
@@ -1758,11 +1758,11 @@ Defined.
 
 Theorem setquotuniv2prop {X : UU} (R : eqrel X)
         (P : setquot R -> setquot R -> hProp)
-        (is : Π x x' : X, P (setquotpr R x) (setquotpr R x')) :
-  Π c c' : setquot R, P c c'.
+        (is : ∏ x x' : X, P (setquotpr R x) (setquotpr R x')) :
+  ∏ c c' : setquot R, P c c'.
 Proof.
   intros.
-  assert (int1 : Π c0' : _, P c c0').
+  assert (int1 : ∏ c0' : _, P c c0').
   {
     apply (setquotunivprop R (fun c0' => P c c0')).
     intro x. apply (setquotunivprop R (fun c0 : _ => P c0 (setquotpr R x))).
@@ -1773,12 +1773,12 @@ Defined.
 
 Theorem setquotuniv3prop {X : UU} (R : eqrel X)
         (P : setquot R -> setquot R -> setquot R -> hProp)
-        (is : Π x x' x'' : X, P (setquotpr R x) (setquotpr R x')
+        (is : ∏ x x' x'' : X, P (setquotpr R x) (setquotpr R x')
                                 (setquotpr R x'')) :
-  Π c c' c'' : setquot R, P c c' c''.
+  ∏ c c' c'' : setquot R, P c c' c''.
 Proof.
   intros.
-  assert (int1 : Π c0' c0'' : _, P c c0' c0'').
+  assert (int1 : ∏ c0' c0'' : _, P c c0' c0'').
   {
     apply (setquotuniv2prop R (fun c0' c0'' => P c c0' c0'')).
     intros x x'.
@@ -1791,12 +1791,12 @@ Defined.
 
 Theorem setquotuniv4prop {X : UU} (R : eqrel X)
         (P : setquot R -> setquot R ->  setquot R -> setquot R -> hProp)
-        (is : Π x x' x'' x''' : X, P (setquotpr R x) (setquotpr R x')
+        (is : ∏ x x' x'' x''' : X, P (setquotpr R x) (setquotpr R x')
                                      (setquotpr R x'') (setquotpr R x''')) :
-  Π c c' c'' c''' : setquot R, P c c' c'' c'''.
+  ∏ c c' c'' c''' : setquot R, P c c' c'' c'''.
 Proof.
   intros.
-  assert (int1 : Π c0 c0' c0'' : _, P c c0 c0' c0'').
+  assert (int1 : ∏ c0 c0' c0'' : _, P c c0 c0' c0'').
   {
     apply (setquotuniv3prop R (fun c0 c0' c0'' => P c c0 c0' c0'')).
     intros x x' x''.
@@ -1841,13 +1841,13 @@ Defined.
 
 Lemma isinclsetquotfun {X Y : UU} (RX : eqrel X) (RY : eqrel Y) (f : X -> Y)
       (is1 : iscomprelrelfun RX RY f)
-      (is2 : Π x x' : X, RY (f x) (f x') -> RX x x') :
+      (is2 : ∏ x x' : X, RY (f x) (f x') -> RX x x') :
   isincl (setquotfun RX RY f is1).
 Proof.
   intros. apply isinclbetweensets.
   - apply isasetsetquot.
   - apply isasetsetquot.
-  - assert (is : Π (x x' : setquot RX),
+  - assert (is : ∏ (x x' : setquot RX),
                  isaprop (paths (setquotfun RX RY f is1 x)
                                 (setquotfun RX RY f is1 x') -> paths x x')).
     {
@@ -1863,32 +1863,32 @@ Defined.
 
 Definition setquotincl {X Y : UU} (RX : eqrel X) (RY : eqrel Y) (f : X -> Y)
            (is1 : iscomprelrelfun RX RY f)
-           (is2 : Π x x' : X, RY (f x) (f x') -> RX x x') :
+           (is2 : ∏ x x' : X, RY (f x) (f x') -> RX x x') :
   incl (setquot RX) (setquot RY)
   := inclpair (setquotfun RX RY f is1) (isinclsetquotfun RX RY f is1 is2).
 
 Definition  weqsetquotweq {X Y : UU} (RX : eqrel X) (RY : eqrel Y) (f : weq X Y)
             (is1 : iscomprelrelfun RX RY f)
-            (is2 : Π x x' : X, RY (f x) (f x') -> RX x x') :
+            (is2 : ∏ x x' : X, RY (f x) (f x') -> RX x x') :
   weq (setquot RX) (setquot RY).
 Proof.
   intros.
   set (ff := setquotfun RX RY f is1). split with ff.
-  assert (is2' : Π y y' : Y, RY y y' -> RX (invmap f y) (invmap f y')).
+  assert (is2' : ∏ y y' : Y, RY y y' -> RX (invmap f y) (invmap f y')).
   intros y y'.
   rewrite (pathsinv0 (homotweqinvweq f y)).
   rewrite (pathsinv0 (homotweqinvweq f y')).
   rewrite (homotinvweqweq f (invmap f y)).
   rewrite (homotinvweqweq f (invmap f y')).
   apply (is2 _ _). set (gg := setquotfun RY RX (invmap f) is2').
-  assert (egf : Π a, paths (gg (ff a)) a).
+  assert (egf : ∏ a, paths (gg (ff a)) a).
   {
     apply (setquotunivprop
              RX (fun a0 => hProppair _ (isasetsetquot RX (gg (ff a0)) a0))).
     simpl. intro x. unfold ff. unfold gg.
     apply (maponpaths (setquotpr RX) (homotinvweqweq f x)).
   }
-  assert (efg : Π a, paths (ff (gg a)) a).
+  assert (efg : ∏ a, paths (ff (gg a)) a).
   {
     apply (setquotunivprop
              RY (fun a0 => hProppair _ (isasetsetquot RY (ff (gg a0)) a0))).
@@ -1900,7 +1900,7 @@ Defined.
 
 Definition weqsetquotsurj {X Y : UU} (RX : eqrel X) (RY : eqrel Y) (f : X -> Y)
            (is : issurjective f) (is1 : iscomprelrelfun RX RY f)
-           (is2 : Π x x' : X, RY (f x) (f x') -> RX x x') :
+           (is2 : ∏ x x' : X, RY (f x) (f x') -> RX x x') :
   weq (setquot RX) (setquot RY).
 Proof.
   intros.
@@ -1949,7 +1949,7 @@ Proof.
   set (f := setquottodirprod RX RY).
   set (g := dirprodtosetquot RX RY).
   split with f.
-  assert (egf : Π a : _, paths (g (f a)) a).
+  assert (egf : ∏ a : _, paths (g (f a)) a).
   {
     apply (setquotunivprop _ (fun a : _ => (hProppair _ (isasetsetquot _ (g (f a))
                                                                     a)))).
@@ -1958,7 +1958,7 @@ Proof.
     simpl. apply funextsec. intro xy'.
     destruct xy' as [ x' y' ]. apply idpath.
   }
-  assert (efg : Π a : _, paths (f (g a)) a).
+  assert (efg : ∏ a : _, paths (f (g a)) a).
   {
     intro a. destruct a as [ ax ay ]. apply pathsdirprod.
     generalize ax. clear ax.
@@ -1983,11 +1983,11 @@ Defined.
 (** *** Universal property of [setquot] for functions of two variables *)
 
 Definition iscomprelfun2 {X Y : UU} (R : hrel X) (f : X -> X -> Y) : UU
-  := Π x x' x0 x0' : X, R x x' -> R x0 x0' -> f x x0 = f x' x0'.
+  := ∏ x x' x0 x0' : X, R x x' -> R x0 x0' -> f x x0 = f x' x0'.
 
 Lemma iscomprelfun2if {X Y : UU} (R : hrel X) (f : X -> X -> Y)
-      (is1 : Π x x' x0 : X, R x x' -> f x x0 = f x' x0)
-      (is2 : Π x x0 x0' : X, R x0 x0' -> f x x0 = f x x0') : iscomprelfun2 R f.
+      (is1 : ∏ x x' x0 : X, R x x' -> f x x0 = f x' x0)
+      (is2 : ∏ x x0 x0' : X, R x0 x0' -> f x x0 = f x x0') : iscomprelfun2 R f.
 Proof.
   intros. intros x x' x0 x0'. intros r r'.
   set (e := is1 x x' x0 r).
@@ -2018,7 +2018,7 @@ Defined.
 
 Theorem setquotuniv2comm {X : UU} (R : eqrel X) (Y : hSet) (f : X -> X -> Y)
         (is : iscomprelfun2 R f) :
-  Π x x' : X, setquotuniv2 R Y f is (setquotpr R x) (setquotpr R x') = f x x'.
+  ∏ x x' : X, setquotuniv2 R Y f is (setquotpr R x) (setquotpr R x') = f x x'.
 Proof. intros. apply idpath. Defined.
 
 
@@ -2028,12 +2028,12 @@ Proof. intros. apply idpath. Defined.
 
 Definition iscomprelrelfun2 {X Y : UU} (RX : hrel X) (RY : hrel Y)
            (f : X -> X -> Y) : UU
-  := Π x x' x0 x0' : X, RX x x' -> RX x0 x0' -> RY (f x x0) (f x' x0').
+  := ∏ x x' x0 x0' : X, RX x x' -> RX x0 x0' -> RY (f x x0) (f x' x0').
 
 Lemma iscomprelrelfun2if {X Y : UU} (RX : hrel X) (RY : eqrel Y)
       (f : X -> X -> Y)
-      (is1 : Π x x' x0 : X, RX x x' -> RY (f x x0) (f x' x0))
-      (is2 : Π x x0 x0' : X, RX x0 x0' -> RY (f x x0) (f x x0')) :
+      (is1 : ∏ x x' x0 : X, RX x x' -> RY (f x x0) (f x' x0))
+      (is2 : ∏ x x0 x0' : X, RX x0 x0' -> RY (f x x0) (f x x0')) :
   iscomprelrelfun2 RX RY f.
 Proof.
   intros. intros x x' x0 x0'. intros r r'.
@@ -2074,7 +2074,7 @@ Defined.
 
 Theorem setquotfun2comm {X Y : UU} (RX : eqrel X) (RY : eqrel Y)
         (f : X -> X -> Y) (is : iscomprelrelfun2 RX RY f) :
-  Π (x x' : X), setquotfun2 RX RY f is (setquotpr RX x) (setquotpr RX x')
+  ∏ (x x' : X), setquotfun2 RX RY f is (setquotpr RX x) (setquotpr RX x')
                 = setquotpr RY (f x x').
 Proof. intros. apply idpath. Defined.
 
@@ -2084,7 +2084,7 @@ Proof. intros. apply idpath. Defined.
 
 
 Theorem isdeceqsetquot_non_constr {X : UU} (R : eqrel X)
-        (is : Π x x' : X, isdecprop (R x x')) : isdeceq (setquot R).
+        (is : ∏ x x' : X, isdecprop (R x x')) : isdeceq (setquot R).
 Proof.
   intros. apply isdeceqif. intros x x'.
   apply (setquotuniv2prop
@@ -2094,11 +2094,11 @@ Proof.
 Defined.
 
 Definition setquotbooleqint {X : UU} (R : eqrel X)
-           (is : Π x x' : X, isdecprop (R x x')) (x x' : X) : bool.
+           (is : ∏ x x' : X, isdecprop (R x x')) (x x' : X) : bool.
 Proof. intros. destruct (pr1 (is x x')). apply true. apply false. Defined.
 
 Lemma setquotbooleqintcomp {X : UU} (R : eqrel X)
-      (is : Π x x' : X, isdecprop (R x x')) :
+      (is : ∏ x x' : X, isdecprop (R x x')) :
   iscomprelfun2 R (setquotbooleqint R is).
 Proof.
   intros. unfold iscomprelfun2.
@@ -2118,17 +2118,17 @@ Defined.
 
 
 Definition setquotbooleq {X : UU} (R : eqrel X)
-           (is : Π x x' : X, isdecprop (R x x')) :
+           (is : ∏ x x' : X, isdecprop (R x x')) :
   setquot R -> setquot R -> bool
   := setquotuniv2 R (hSetpair _ (isasetbool)) (setquotbooleqint R is)
                   (setquotbooleqintcomp R is).
 
 Lemma setquotbooleqtopaths {X : UU} (R : eqrel X)
-      (is : Π x x' : X, isdecprop (R x x')) (x x' : setquot R) :
+      (is : ∏ x x' : X, isdecprop (R x x')) (x x' : setquot R) :
   setquotbooleq R is x x' = true  -> x = x'.
 Proof.
   intros X R is.
-  assert (isp : Π (x x' : setquot R),
+  assert (isp : ∏ (x x' : setquot R),
                 isaprop (paths (setquotbooleq R is x x') true  -> paths x x')).
   {
     intros x x'. apply impred. intro. apply (isasetsetquot R x x').
@@ -2143,7 +2143,7 @@ Proof.
 Defined.
 
 Lemma setquotpathstobooleq {X : UU} (R : eqrel X)
-      (is : Π x x' : X, isdecprop (R x x')) (x x' : setquot R) :
+      (is : ∏ x x' : X, isdecprop (R x x')) (x x' : setquot R) :
   x = x' -> setquotbooleq R is x x' = true.
 Proof.
   intros X R is x x' e. destruct e. generalize x.
@@ -2157,7 +2157,7 @@ Proof.
 Defined.
 
 Definition isdeceqsetquot {X : UU} (R : eqrel X)
-           (is : Π x x' : X, isdecprop (R x x')) : isdeceq (setquot R).
+           (is : ∏ x x' : X, isdecprop (R x x')) : isdeceq (setquot R).
 Proof.
   intros. intros x x'.
   destruct (boolchoice (setquotbooleq R is x x')) as [ i | ni ].
@@ -2178,8 +2178,8 @@ Definition iscomprelrel {X : UU} (R : hrel X) (L : hrel X) : UU
   := iscomprelfun2 R L.
 
 Lemma iscomprelrelif {X : UU} {R : hrel X} (L : hrel X) (isr : issymm R)
-      (i1 : Π x x' y, R x x' -> L x y -> L x' y)
-      (i2 : Π x y y', R y y' -> L x y -> L x y') : iscomprelrel R L.
+      (i1 : ∏ x x' y, R x x' -> L x y -> L x' y)
+      (i2 : ∏ x y y', R y y' -> L x y -> L x y') : iscomprelrel R L.
 Proof.
   intros. intros x x' y y' rx ry.
   set (rx' := isr _ _ rx). set (ry' := isr _ _ ry).
@@ -2219,7 +2219,7 @@ Lemma istransquotrel {X : UU} {R : eqrel X} {L : hrel X}
       (is : iscomprelrel R L) (isl : istrans L) : istrans (quotrel is).
 Proof.
   intros. unfold istrans.
-  assert (int : Π (x1 x2 x3 : setquot R),
+  assert (int : ∏ (x1 x2 x3 : setquot R),
                 isaprop (quotrel is x1 x2 -> quotrel is x2 x3
                          -> quotrel is x1 x3)).
   {
@@ -2237,7 +2237,7 @@ Lemma issymmquotrel {X : UU} {R : eqrel X} {L : hrel X} (is : iscomprelrel R L)
       (isl : issymm L) : issymm (quotrel is).
 Proof.
   intros. unfold issymm.
-  assert (int : Π (x1 x2 : setquot R),
+  assert (int : ∏ (x1 x2 : setquot R),
                 isaprop (quotrel is x1 x2 -> quotrel is x2 x1)).
   {
     intros x1 x2.
@@ -2282,7 +2282,7 @@ Lemma isasymmquotrel {X : UU} {R : eqrel X} {L : hrel X} (is : iscomprelrel R L)
       (isl : isasymm L) : isasymm (quotrel is).
 Proof.
   intros. unfold isasymm.
-  assert (int : Π (x1 x2 : setquot R),
+  assert (int : ∏ (x1 x2 : setquot R),
                 isaprop (quotrel is x1 x2 -> quotrel is x2 x1 -> empty)).
   {
     intros x1 x2.
@@ -2299,7 +2299,7 @@ Lemma iscoasymmquotrel {X : UU} {R : eqrel X} {L : hrel X}
       (is : iscomprelrel R L) (isl : iscoasymm L) : iscoasymm (quotrel is).
 Proof.
   intros. unfold iscoasymm.
-  assert (int : Π (x1 x2 : setquot R),
+  assert (int : ∏ (x1 x2 : setquot R),
                 isaprop (neg (quotrel is x1 x2) -> quotrel is x2 x1)).
   {
     intros x1 x2.
@@ -2324,7 +2324,7 @@ Lemma iscotransquotrel {X : UU} {R : eqrel X} {L : hrel X}
       (is : iscomprelrel R L) (isl : iscotrans L) : iscotrans (quotrel is).
 Proof.
   intros. unfold iscotrans.
-  assert (int : Π (x1 x2 x3 : setquot R),
+  assert (int : ∏ (x1 x2 x3 : setquot R),
                 isaprop (quotrel is x1 x3 -> hdisj (quotrel is x1 x2)
                                                   (quotrel is x2 x3))).
   {
@@ -2341,7 +2341,7 @@ Lemma isantisymmquotrel {X : UU} {R : eqrel X} {L : hrel X}
       (is : iscomprelrel R L) (isl : isantisymm L) : isantisymm (quotrel is).
 Proof.
   intros. unfold isantisymm.
-  assert (int : Π (x1 x2 : setquot R),
+  assert (int : ∏ (x1 x2 : setquot R),
                 isaprop (quotrel is x1 x2 -> quotrel is x2 x1 -> paths x1 x2)).
   {
     intros x1 x2.
@@ -2359,7 +2359,7 @@ Lemma isantisymmnegquotrel {X : UU} {R : eqrel X} {L : hrel X}
   isantisymmneg (quotrel is).
 Proof.
   intros. unfold isantisymmneg.
-  assert (int : Π (x1 x2 : setquot R),
+  assert (int : ∏ (x1 x2 : setquot R),
                 isaprop (neg (quotrel is x1 x2) -> neg (quotrel is x2 x1)
                          -> paths x1 x2)).
   {
@@ -2382,11 +2382,11 @@ question.*)
 
 
 Lemma quotrelimpl {X : UU} {R : eqrel X} {L L' : hrel X} (is : iscomprelrel R L)
-      (is' : iscomprelrel R L') (impl : Π x x', L x x' -> L' x x')
+      (is' : iscomprelrel R L') (impl : ∏ x x', L x x' -> L' x x')
       (x x' : setquot R) (ql : quotrel is x x') : quotrel is' x x'.
 Proof.
   intros. generalize x x' ql.
-  assert (int : Π (x0 x0' : setquot R),
+  assert (int : ∏ (x0 x0' : setquot R),
                 isaprop (quotrel is x0 x0' -> quotrel is' x0 x0')).
   {
     intros x0 x0'.
@@ -2400,7 +2400,7 @@ Defined.
 
 Lemma quotrellogeq {X : UU} {R : eqrel X} {L L' : hrel X}
       (is : iscomprelrel R L) (is' : iscomprelrel R L')
-      (lg : Π x x', L x x' <-> L' x x') (x x' : setquot R) :
+      (lg : ∏ x x', L x x' <-> L' x x') (x x' : setquot R) :
   (quotrel is x x') <-> (quotrel is' x x').
 Proof.
   intros. split.
@@ -2442,7 +2442,7 @@ Definition quotdecrelintlogeq {X : UU} {R : eqrel X} (L : decrel X)
   breltodecrel (quotdecrelint L is) x x' <-> quotrel is x x'.
 Proof.
   intros X R L is.
-  assert (int : Π (x x' : setquot R),
+  assert (int : ∏ (x x' : setquot R),
                 isaprop (paths (quotdecrelint L is x x') true
                          <-> (quotrel is x x'))).
   {
@@ -2478,7 +2478,7 @@ Definition reseqrel {X : UU} (R : eqrel X) (P : hsubtype X) : eqrel P :=
   eqrelpair _ (iseqrelresrel R P (pr2 R)).
 
 Lemma iseqclassresrel {X : UU} (R : hrel X) (P Q : hsubtype X)
-      (is : iseqclass R Q) (is' : Π x, Q x -> P x) :
+      (is : iseqclass R Q) (is' : ∏ x, Q x -> P x) :
   iseqclass (resrel R P) (fun x : P => Q (pr1 x)).
 Proof.
   intros. split.
@@ -2529,12 +2529,12 @@ Proof.
     - apply (setproperty (setquotinset R)).
     - refine (isinclpr1carrier _).
   }
-  assert (egf : Π (a : P), paths (g (f a)) a).
+  assert (egf : ∏ (a : P), paths (g (f a)) a).
   {
     intros a. destruct a as [ p isp ].
     generalize isp. generalize p. clear isp. clear p.
-    assert (int : Π (p : setquot R),
-                  isaprop (Π isp : P p, paths (g (f (tpair _ p isp)))
+    assert (int : ∏ (p : setquot R),
+                  isaprop (∏ isp : P p, paths (g (f (tpair _ p isp)))
                                               (tpair _ p isp))).
     {
       intro p.
@@ -2545,10 +2545,10 @@ Proof.
     simpl. intros x isp. apply (invmaponpathsincl _ (isinclpr1carrier P) _ _).
     apply idpath.
   }
-  assert (efg : Π (a : setquot (resrel R (P ∘ setquotpr R))),
+  assert (efg : ∏ (a : setquot (resrel R (P ∘ setquotpr R))),
                 paths (f (g a)) a).
   {
-    assert (int : Π a, isaprop (paths (f (g a)) a)).
+    assert (int : ∏ a, isaprop (paths (f (g a)) a)).
     {
       intro a.
       apply (setproperty (setquotinset (resrel R (funcomp (setquotpr R) P)))).
@@ -2584,14 +2584,14 @@ Defined.
   places in the work with quotients. It can be traced back first to the failure
   of [invmaponpathsincl] to map [idpath] to [idpath] and then to the fact that
   for [(X : UU) (is : isaprop X)] the term
-  [t := proofirrelevance is : Π x1 x2 : X, paths x1 x2] does not satisfy
+  [t := proofirrelevance is : ∏ x1 x2 : X, paths x1 x2] does not satisfy
   (definitionally) the condition [t x x == idpath x].
 
   It can and probably should be fixed by the addition of a new componenet to
   CIC in the form of a term constructor:
 
-  tfc (X : UU) (E : X -> UU) (is : Π x, iscontr (E x)) (x0 : X) (e0 : E x0) :
-     Π x : X, E x.
+  tfc (X : UU) (E : X -> UU) (is : ∏ x, iscontr (E x)) (x0 : X) (e0 : E x0) :
+     ∏ x : X, E x.
 
   and a computation rule
 
@@ -2603,9 +2603,9 @@ Defined.
   as far as I can see, provide any problems for normalization or for the
   decidability of typing. Using tfc one can give a construction of
   [proofirrelevance] as follows (recall that
-  [isaprop := Π x1 x2, iscontr (paths x1 x2)]) :
+  [isaprop := ∏ x1 x2, iscontr (paths x1 x2)]) :
 
-  Lemma proofirrelevance {X : UU} (is : isaprop X) : Π x1 x2, paths x1 x2.
+  Lemma proofirrelevance {X : UU} (is : isaprop X) : ∏ x1 x2, paths x1 x2.
   Proof.
    intros X is x1.
    apply (tfc X (fun x2 => paths x1 x2) is x1 (idpath x1)).
@@ -2691,7 +2691,7 @@ Definition pr1compfun (X : UU) (R : hrel X) (S : UU) :
 Coercion pr1compfun : compfun >-> Funclass.
 
 Definition compevmapset {X : UU} (R : hrel X) :
-  X -> Π S : hSet, (compfun R S) -> S
+  X -> ∏ S : hSet, (compfun R S) -> S
   := fun x : X => fun S : _ => fun f : compfun R S => pr1 f x.
 
 Definition compfuncomp {X : UU} (R : hrel X) {S S' : UU} (f : compfun R S)
@@ -2719,7 +2719,7 @@ Definition Fv {X Y : UU} (R : hrel X) (f : compfun R Y) (phi : F X Y R) : Y
 
 Definition qeq {X Y : UU} (R : hrel X)
 := total2 (fun phi : F X Y R =>
-                     Π psi : F X Y R -> Y,
+                     ∏ psi : F X Y R -> Y,
                              paths (psi phi)
                                    (Fv R (compfuncomp
                                            R (compfunpair R _ (iscompFi R)) psi)
@@ -2727,7 +2727,7 @@ Definition qeq {X Y : UU} (R : hrel X)
 
 Lemma isinclpr1qeq {X : UU} (R : hrel X) (Y : hSet) :
     isincl (@pr1 _ (fun phi : F X Y R =>
-                            Π psi : F X Y R -> Y,
+                            ∏ psi : F X Y R -> Y,
                                   paths
                                     (psi phi)
                                      (Fv R (compfuncomp
@@ -2825,8 +2825,8 @@ Proof.
 Defined.
 
 Inductive try0 (T : UU) (t : T) :
-   Π (t1 t2 : T) (e1 : paths t t1) (e2 : paths t t2), UU
-   := idconstr : Π (t' : T) (e' : paths t t'), try0 T t t' t' e' e'.
+   ∏ (t1 t2 : T) (e1 : paths t t1) (e2 : paths t t2), UU
+   := idconstr : ∏ (t' : T) (e' : paths t t'), try0 T t t' t' e' e'.
 
 Definition try0map1 (T : UU) (t : T) (t1 t2 : T) (e1 : paths t t1)
    (e2 : paths t t2) (X : try0 T t t1 t2 e1 e2) : paths t1 t2.
@@ -2869,7 +2869,7 @@ Definition setquot2 {X : UU} (R : hrel X) : UU := image (compevmapset R).
 Theorem isasetsetquot2 {X : UU} (R : hrel X) : isaset (setquot2 R).
 Proof.
   intros.
-  assert (is1: isofhlevel 2 (Π S : hSet, (compfun R S) -> S)).
+  assert (is1: isofhlevel 2 (∏ S : hSet, (compfun R S) -> S)).
   {
     apply impred. intro.
     apply impred. intro X0.

--- a/UniMath/Foundations/Tests.v
+++ b/UniMath/Foundations/Tests.v
@@ -1,17 +1,17 @@
 Unset Automatic Introduction.
 Require Export UniMath.Foundations.PartD.
 
-Goal Σ (_:nat) (_:nat) (_:nat) (_:nat), nat. exact (2,,3,,4,,5,,6). Defined.
-Goal Π i j k, i+j+k = (i+j)+k. reflexivity. Defined.
-Goal Π n, 1+n = S n. reflexivity. Defined.
-Goal Π i j k, i*j*k = (i*j)*k. reflexivity. Defined.
-Goal Π n, 0*n = 0. reflexivity. Defined.
-Goal Π n, 0+n = n. reflexivity. Defined.
-Goal Π n, 0*n = 0. reflexivity. Defined.
-Goal Π n m, S n * m = n*m + m. reflexivity. Defined.
-Goal Π n, 1*n = n. reflexivity. Defined.
-Goal Π n, 4*n = n+n+n+n. reflexivity. Defined.
-Goal Π X x, idweq X x = x. reflexivity. Defined.
+Goal ∑ (_:nat) (_:nat) (_:nat) (_:nat), nat. exact (2,,3,,4,,5,,6). Defined.
+Goal ∏ i j k, i+j+k = (i+j)+k. reflexivity. Defined.
+Goal ∏ n, 1+n = S n. reflexivity. Defined.
+Goal ∏ i j k, i*j*k = (i*j)*k. reflexivity. Defined.
+Goal ∏ n, 0*n = 0. reflexivity. Defined.
+Goal ∏ n, 0+n = n. reflexivity. Defined.
+Goal ∏ n, 0*n = 0. reflexivity. Defined.
+Goal ∏ n m, S n * m = n*m + m. reflexivity. Defined.
+Goal ∏ n, 1*n = n. reflexivity. Defined.
+Goal ∏ n, 4*n = n+n+n+n. reflexivity. Defined.
+Goal ∏ X x, idweq X x = x. reflexivity. Defined.
 
 Module Test_gradth.
   Let f := idfun nat.
@@ -27,7 +27,7 @@ Module Test_gradth.
   Goal homotweqinvweqweq v true = idpath _. reflexivity. Defined.
 End Test_gradth.
 
-Goal Π X x, invweq (idweq X) x = x. reflexivity. Defined.
+Goal ∏ X x, invweq (idweq X) x = x. reflexivity. Defined.
 
 Module Test_weqtotal2overcoprod.
   Let P (t : bool ⨿ bool) := nat.
@@ -69,11 +69,11 @@ Module Test_sets.
 
   Require Import UniMath.Foundations.Sets.
 
-  Goal Π Y (is:isaset Y) (F:Y->UU) (e :Π y y', F y -> F y' -> y=y')
+  Goal ∏ Y (is:isaset Y) (F:Y->UU) (e :∏ y y', F y -> F y' -> y=y')
          y (f:F y), squash_pairs_to_set F is e (hinhpr (y,,f)) = y.
   Proof. reflexivity. Qed.
 
-  Goal Π X Y (is:isaset Y) (f:X->Y) (e:Π x x', f x = f x'),
+  Goal ∏ X Y (is:isaset Y) (f:X->Y) (e:∏ x x', f x = f x'),
          f = funcomp hinhpr (squash_to_set is f e).
   Proof. reflexivity. Qed.
 

--- a/UniMath/Foundations/UnivalenceAxiom.v
+++ b/UniMath/Foundations/UnivalenceAxiom.v
@@ -37,14 +37,14 @@ Require Export UniMath.Foundations.PartB.
 Definition eqweqmap { T1 T2 : UU } : T1 = T2 -> T1 ≃ T2.
 Proof. intro e. induction e. apply idweq. Defined.
 
-Definition sectohfiber { X : UU } (P:X -> UU): (Π x:X, P x) -> (hfiber (fun f:_ => fun x:_ => pr1  (f x)) (fun x:X => x)) := (fun a : Π x:X, P x => tpair _ (fun x:_ => tpair _ x (a x)) (idpath (fun x:X => x))).
+Definition sectohfiber { X : UU } (P:X -> UU): (∏ x:X, P x) -> (hfiber (fun f:_ => fun x:_ => pr1  (f x)) (fun x:X => x)) := (fun a : ∏ x:X, P x => tpair _ (fun x:_ => tpair _ x (a x)) (idpath (fun x:X => x))).
 
 Definition hfibertosec { X : UU } (P:X -> UU):
-  (hfiber (fun f x => pr1 (f x)) (fun x:X => x)) -> (Π x:X, P x)
+  (hfiber (fun f x => pr1 (f x)) (fun x:X => x)) -> (∏ x:X, P x)
   := fun se:_  => fun x:X => match se as se' return P x with tpair _ s e => (transportf P (toforallpaths _ (fun x:X => pr1 (s x)) (fun x:X => x) e x) (pr2  (s x))) end.
 
 Definition sectohfibertosec { X : UU } (P:X -> UU):
-  Π a : (Π x:X, P x), hfibertosec _ (sectohfiber _ a) = a.
+  ∏ a : (∏ x:X, P x), hfibertosec _ (sectohfiber _ a) = a.
 Proof.
   reflexivity.
 Defined.
@@ -55,43 +55,43 @@ Proof. intros. destruct e.  apply idisweq. Defined.
 Lemma isweqtransportb10 { X : UU } ( P : X -> UU ) { x x' : X } ( e :  paths x x' ) : isweq ( transportb P e ).
 Proof. intros. apply ( isweqtransportf10 _ ( pathsinv0 e ) ). Defined.
 
-Lemma l1  { X0 X0' : UU } ( ee : paths X0 X0' ) ( P : UU -> UU ) ( pp' : P X0' ) ( R : Π X X' : UU , Π w : weq X X' , P X' -> P X ) ( r : Π X : UU , Π p : P X , paths ( R X X ( idweq X ) p ) p ) : paths ( R X0 X0' ( eqweqmap ee ) pp' ) (  transportb P ee pp' ).
+Lemma l1  { X0 X0' : UU } ( ee : paths X0 X0' ) ( P : UU -> UU ) ( pp' : P X0' ) ( R : ∏ X X' : UU , ∏ w : weq X X' , P X' -> P X ) ( r : ∏ X : UU , ∏ p : P X , paths ( R X X ( idweq X ) p ) p ) : paths ( R X0 X0' ( eqweqmap ee ) pp' ) (  transportb P ee pp' ).
 Proof. destruct ee. simpl. apply r. Defined.
 
 (** Axiom statements (propositions) *)
 
-Definition univalenceStatement := Π X Y:UU, isweq (@eqweqmap X Y).
+Definition univalenceStatement := ∏ X Y:UU, isweq (@eqweqmap X Y).
 
-Definition funextemptyStatement := Π (X:UU) (f g : X->empty), f = g.
+Definition funextemptyStatement := ∏ (X:UU) (f g : X->empty), f = g.
 
 Definition propositionalUnivalenceStatement :=
-  Π (P Q:UU), isaprop P -> isaprop Q -> (P -> Q) -> (Q -> P) -> P=Q.
+  ∏ (P Q:UU), isaprop P -> isaprop Q -> (P -> Q) -> (Q -> P) -> P=Q.
 
 Definition funcontrStatement :=
-  Π (X : UU) (P:X -> UU),
-    (Π x:X, iscontr (P x)) -> iscontr (Π x:X, P x).
+  ∏ (X : UU) (P:X -> UU),
+    (∏ x:X, iscontr (P x)) -> iscontr (∏ x:X, P x).
 
 Definition funextcontrStatement :=
-  Π (T:UU) (P:T -> UU) (g: Π t, P t), ∃! (f:Π t, P t), Π t:T, f t = g t.
+  ∏ (T:UU) (P:T -> UU) (g: ∏ t, P t), ∃! (f:∏ t, P t), ∏ t:T, f t = g t.
 
 Definition isweqtoforallpathsStatement :=
-  Π (T:UU) (P:T -> UU) (f g :Π t:T, P t), isweq (toforallpaths _ f g).
+  ∏ (T:UU) (P:T -> UU) (f g :∏ t:T, P t), isweq (toforallpaths _ f g).
 
 (** Axiom consequence statements (not propositions) *)
 
 Definition funextsecStatement :=
-  Π (T:UU) (P:T -> UU) (f g :Π t:T, P t), f ~ g -> f = g.
+  ∏ (T:UU) (P:T -> UU) (f g :∏ t:T, P t), f ~ g -> f = g.
 
 Definition funextfunStatement :=
-  Π (X Y:UU) (f g : X -> Y), f ~ g -> f = g.
+  ∏ (X Y:UU) (f g : X -> Y), f ~ g -> f = g.
 
-Definition weqtopathsStatement := Π ( T1 T2 : UU ), T1 ≃ T2 -> T1 = T2.
+Definition weqtopathsStatement := ∏ ( T1 T2 : UU ), T1 ≃ T2 -> T1 = T2.
 
 Definition weqpathsweqStatement (weqtopaths:weqtopathsStatement) :=
-  Π ( T1 T2 : UU ) ( w : T1 ≃ T2 ), eqweqmap (weqtopaths _ _ w) = w.
+  ∏ ( T1 T2 : UU ) ( w : T1 ≃ T2 ), eqweqmap (weqtopaths _ _ w) = w.
 
 Definition weqtoforallpathsStatement :=
-  Π (T:UU) (P:T -> UU) (f g :Π t:T, P t), (f = g) ≃ (f ~ g).
+  ∏ (T:UU) (P:T -> UU) (f g :∏ t:T, P t), (f = g) ≃ (f ~ g).
 
 (** Implications between statements and consequences of them *)
 
@@ -108,7 +108,7 @@ Defined.
 (** We show that [ univalenceAxiom ] is equivalent to the axioms [ weqtopathsStatement ] and [ weqpathsweqStatement ] stated below . *)
 
 Theorem univfromtwoaxioms :
-  (Σ weqtopaths: weqtopathsStatement, weqpathsweqStatement weqtopaths)
+  (∑ weqtopaths: weqtopathsStatement, weqpathsweqStatement weqtopaths)
   <-> univalenceStatement.
 Proof.
   split.
@@ -124,9 +124,9 @@ Proof.
       apply ( maponpaths ( fun w : weq ( pr1 XY) (pr2 XY) =>  tpair P2 XY w )
                        ( weqpathsweq ( pr1 XY ) ( pr2 XY ) e )) .
     - set ( h := fun a1 : Z1 =>  pr1 ( pr1 a1 ) ) .
-      assert ( egf0 : Π a1 : Z1 ,  pr1 ( g ( f a1 ) ) = pr1 a1 ).
+      assert ( egf0 : ∏ a1 : Z1 ,  pr1 ( g ( f a1 ) ) = pr1 a1 ).
       + intro. apply idpath.
-      + assert ( egf1 : Π a1 a1' : Z1 ,  paths ( pr1 a1' ) (  pr1 a1 ) ->  paths a1' a1 ).
+      + assert ( egf1 : ∏ a1 a1' : Z1 ,  paths ( pr1 a1' ) (  pr1 a1 ) ->  paths a1' a1 ).
         * intros.
           set ( X' :=  maponpaths pr1 X ).
           assert ( is : isweq h ).
@@ -191,9 +191,9 @@ Section UnivalenceImplications.
     of structures are weak equivalences. *)
 
   Theorem weqtransportbUAH ( P : UU -> UU )
-          ( R : Π ( X X' : UU ) ( w :  weq X X' ) , P X' -> P X )
-          ( r : Π X : UU , Π p : P X , R X X ( idweq X ) p = p ) :
-    Π ( X X' : UU ) ( w :  weq X X' ) ( p' : P X' ),
+          ( R : ∏ ( X X' : UU ) ( w :  weq X X' ) , P X' -> P X )
+          ( r : ∏ X : UU , ∏ p : P X , R X X ( idweq X ) p = p ) :
+    ∏ ( X X' : UU ) ( w :  weq X X' ) ( p' : P X' ),
       R X X' w p' = transportb P ( weqtopathsUAH w ) p'.
   Proof.
     intros.
@@ -212,9 +212,9 @@ Section UnivalenceImplications.
 
   Corollary isweqweqtransportbUAH
             ( P : UU -> UU )
-            ( R :  Π ( X X' : UU ) ( w : X ≃ X' ) , P X' -> P X )
-            ( r :  Π X : UU , Π p : P X , R X X ( idweq X ) p  = p ) :
-    Π ( X X' : UU ) ( w : X ≃ X' ),
+            ( R :  ∏ ( X X' : UU ) ( w : X ≃ X' ) , P X' -> P X )
+            ( r :  ∏ X : UU , ∏ p : P X , R X X ( idweq X ) p  = p ) :
+    ∏ ( X X' : UU ) ( w : X ≃ X' ),
       isweq ( fun p' :  P X' => R X X' w p' ).
   Proof.
     intros.
@@ -289,7 +289,7 @@ Section UnivalenceImplications.
   Proof.
     unfold funcontrStatement.
     intros ? ? X0.
-    set (T1 := Π x:X, P x).
+    set (T1 := ∏ x:X, P x).
     set (T2 := (hfiber (fun f: (X -> total2 P)  => fun x: X => pr1  (f x)) (fun x:X => x))).
     assert (is1:isweq (@pr1 X P)).
     - apply isweqpr1. assumption.
@@ -300,7 +300,7 @@ Section UnivalenceImplications.
   Defined.
 
   (** Proof of the fact that the [ toforallpaths ] from [paths s1 s2] to
-  [Π t:T, paths (s1 t) (s2 t)] is a weak equivalence - a strong form of
+  [∏ t:T, paths (s1 t) (s2 t)] is a weak equivalence - a strong form of
   functional extensionality for sections of general families. The proof uses
   only [funcontrUAH] which is an element of a proposition.  *)
 
@@ -308,7 +308,7 @@ Section UnivalenceImplications.
   Proof.
     unfold funextcontrStatement.
     intros.
-    unshelve refine (iscontrretract (X := Π t, Σ p, p = g t) _ _ _ _).
+    unshelve refine (iscontrretract (X := ∏ t, ∑ p, p = g t) _ _ _ _).
     - intros x. unshelve refine (_,,_).
       + intro t. exact (pr1 (x t)).
       + intro t; simpl. exact (pr2 (x t)).
@@ -322,8 +322,8 @@ Section UnivalenceImplications.
   Proof.
     unfold isweqtoforallpathsStatement.
     intros.
-    refine (isweqtotaltofib _ _ (λ (h:Π t, P t), toforallpaths _ h g) _ f).
-    refine (isweqcontrcontr (X := Σ (h: Π t, P t), h = g)
+    refine (isweqtotaltofib _ _ (λ (h:∏ t, P t), toforallpaths _ h g) _ f).
+    refine (isweqcontrcontr (X := ∑ (h: ∏ t, P t), h = g)
               (λ ff, tpair _ (pr1 ff) (toforallpaths P (pr1 ff) g (pr2 ff))) _ _).
     { exact (iscontrcoconustot _ g). }
     { apply funextcontrUAH. }
@@ -396,29 +396,29 @@ Definition funextfun := funextfunImplication (@funextsec).
 Arguments funextfun {_ _} _ _ _.
 (* Print Assumptions funextfun.    (* isweqtoforallpathsAxiom *) *)
 
-Definition weqfunextsec { T : UU } (P:T -> UU) (f g : Π t:T, P t) :
+Definition weqfunextsec { T : UU } (P:T -> UU) (f g : ∏ t:T, P t) :
   (f ~ g) ≃ (f = g)
   := invweq (weqtoforallpaths P f g).
 (* Print Assumptions weqfunextsec. (* isweqtoforallpathsAxiom *) *)
 
-Corollary funcontrtwice { X : UU } (P: X-> X -> UU) (is: Π (x x':X), iscontr (P x x')) :
-  iscontr (Π (x x':X), P x x').
+Corollary funcontrtwice { X : UU } (P: X-> X -> UU) (is: ∏ (x x':X), iscontr (P x x')) :
+  iscontr (∏ (x x':X), P x x').
 Proof.
   intros.
-  assert (is1: Π x:X, iscontr (Π x':X, P x x')).
+  assert (is1: ∏ x:X, iscontr (∏ x':X, P x x')).
   - intro. apply (funcontr _ (is x)).
   - apply (funcontr _ is1).
 Defined.
 
 (** Check assumptions *)
 
-Lemma toforallpaths_induction (X Y : UU) (f g : X -> Y) (P : (Π x, f x = g x) -> UU)
-      (H : Π e : f = g, P (toforallpaths _ _ _ e)) : Π i : (Π x, f x = g x), P i.
+Lemma toforallpaths_induction (X Y : UU) (f g : X -> Y) (P : (∏ x, f x = g x) -> UU)
+      (H : ∏ e : f = g, P (toforallpaths _ _ _ e)) : ∏ i : (∏ x, f x = g x), P i.
 Proof.
   intros i. rewrite <- (homotweqinvweq (weqtoforallpaths _ f g)). apply H.
 Defined.
 
-Definition transportf_funextfun {X Y : UU} (P : Y -> UU) (F F' : X -> Y) (H : Π (x : X), F x = F' x)
+Definition transportf_funextfun {X Y : UU} (P : Y -> UU) (F F' : X -> Y) (H : ∏ (x : X), F x = F' x)
            (x : X) (f : P (F x)) :
   transportf (λ x0 : X → Y, P (x0 x)) (funextsec _ F F' H) f = transportf (λ x0 : Y, P x0) (H x) f.
 Proof.

--- a/UniMath/HomologicalAlgebra/CohomologyComplex.v
+++ b/UniMath/HomologicalAlgebra/CohomologyComplex.v
@@ -1116,9 +1116,9 @@ Section def_cohomology_homotopy.
 
   Definition CohomologyFunctorHIm {C1 C2 : ComplexHomot_Additive (AbelianToAdditive A hs)}
              (f : ComplexHomot_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧) : UU :=
-    Σ (h : (ComplexPreCat_Additive (AbelianToAdditive A hs))⟦CohomologyComplex A hs C1,
+    ∑ (h : (ComplexPreCat_Additive (AbelianToAdditive A hs))⟦CohomologyComplex A hs C1,
                                                              CohomologyComplex A hs C2⟧),
-    Π (f' : ComplexPreCat_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧)
+    ∏ (f' : ComplexPreCat_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧)
       (H : # (ComplexHomotFunctor (AbelianToAdditive A hs)) f' = f),
     h = # (CohomologyFunctor A hs) f'.
 
@@ -1139,7 +1139,7 @@ Section def_cohomology_homotopy.
              (f : (ComplexHomot_Additive (AbelianToAdditive A hs))⟦C1, C2⟧)
              (h : (ComplexPreCat_Additive (AbelianToAdditive A hs))⟦CohomologyComplex A hs C1,
                                                                     CohomologyComplex A hs C2⟧)
-             (HH : Π (f' : ComplexPreCat_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧)
+             (HH : ∏ (f' : ComplexPreCat_Additive (AbelianToAdditive A hs) ⟦C1, C2⟧)
                      (H : # (ComplexHomotFunctor (AbelianToAdditive A hs)) f' = f),
                    h = # (CohomologyFunctor A hs) f') : CohomologyFunctorHIm f :=
     tpair _ h HH.
@@ -1579,7 +1579,7 @@ Section def_kernel_cokernel_complex.
   Qed.
 
   Local Lemma CokernelKernelMorphism_uni (C : Complex (AbelianToAdditive A hs)) (i : hz) :
-    Π t : Σ f : A ⟦Cokernel (Diff C (i - 1)), Kernel (Diff C (i + 1))⟧,
+    ∏ t : ∑ f : A ⟦Cokernel (Diff C (i - 1)), Kernel (Diff C (i + 1))⟧,
                 (KernelIn to_Zero (Kernel (Diff C (i + 1))) (C i) (Diff C i)
                           (DSq (AbelianToAdditive A hs) C i) =
                  transportf (λ i0 : pr1 hz, A ⟦ C i0, Cokernel (Diff C (i - 1)) ⟧)
@@ -1619,7 +1619,7 @@ Section def_kernel_cokernel_complex.
   Qed.
 
   Definition CokernelKernelMorphism (C : Complex (AbelianToAdditive A hs)) (i : hz) :
-    iscontr (Σ f : A⟦(CokernelComplex C) i, (KernelComplex C) i⟧,
+    iscontr (∑ f : A⟦(CokernelComplex C) i, (KernelComplex C) i⟧,
                    ((KernelIn to_Zero (Kernel (Diff C (i + 1))) (C i) (Diff C i) (DSq _ C i)) =
                     (transportf (fun (i0 : hz) => A⟦C i0, (Cokernel (Diff C (i - 1)))⟧)
                                 (hzrminusplus i 1)

--- a/UniMath/HomologicalAlgebra/Complexes.v
+++ b/UniMath/HomologicalAlgebra/Complexes.v
@@ -88,11 +88,11 @@ Section def_complexes.
 
   (** Complex *)
   Definition Complex : UU :=
-    Σ D' : (Σ D : (Π i : hz, ob A), (Π i : hz, A⟦D i, D (i + 1)⟧)),
-           Π i : hz, (pr2 D' i) ;; (pr2 D' (i + 1)) = ZeroArrow (Additive.to_Zero A) _ _.
+    ∑ D' : (∑ D : (∏ i : hz, ob A), (∏ i : hz, A⟦D i, D (i + 1)⟧)),
+           ∏ i : hz, (pr2 D' i) ;; (pr2 D' (i + 1)) = ZeroArrow (Additive.to_Zero A) _ _.
 
-  Definition mk_Complex (D : Π i : hz, ob A) (D' : Π i : hz, A⟦D i, D (i + 1)⟧)
-             (D'' : Π i : hz, (D' i) ;; (D' (i + 1)) = ZeroArrow (Additive.to_Zero A) _ _) :
+  Definition mk_Complex (D : ∏ i : hz, ob A) (D' : ∏ i : hz, A⟦D i, D (i + 1)⟧)
+             (D'' : ∏ i : hz, (D' i) ;; (D' (i + 1)) = ZeroArrow (Additive.to_Zero A) _ _) :
     Complex := ((D,,D'),,D'').
 
   (** Accessor functions *)
@@ -104,17 +104,17 @@ Section def_complexes.
   Definition DSq (C : Complex) (i : hz) :
     (Diff C i) ;; (Diff C (i + 1)) = ZeroArrow (Additive.to_Zero A) _ _ := pr2 C i.
 
-  Local Lemma ComplexEq' (C1 C2 : Complex) (H : Π (i : hz), C1 i = C2 i)
-        (H1 : Π (i : hz),
+  Local Lemma ComplexEq' (C1 C2 : Complex) (H : ∏ (i : hz), C1 i = C2 i)
+        (H1 : ∏ (i : hz),
               transportf (λ x : A, C2 i --> x) (H (i + 1))
                          (transportf (λ x : A, x --> C1 (i + 1)) (H i) (Diff C1 i)) =
               Diff C2 i) :
-    transportf (λ x : hz → A, Π i : hz, A ⟦ x i, x (i + 1) ⟧)
+    transportf (λ x : hz → A, ∏ i : hz, A ⟦ x i, x (i + 1) ⟧)
                (funextfun (pr1 (pr1 C1)) (pr1 (pr1 C2)) (λ i : hz, H i)) (pr2 (pr1 C1)) =
     pr2 (pr1 C2).
   Proof.
     use funextsec. intros i.
-    assert (e : transportf (λ x : hz → A, Π i0 : hz, A ⟦ x i0, x (i0 + 1) ⟧)
+    assert (e : transportf (λ x : hz → A, ∏ i0 : hz, A ⟦ x i0, x (i0 + 1) ⟧)
                            (funextfun (pr1 (pr1 C1)) (pr1 (pr1 C2)) (λ i0 : hz, H i0))
                            (pr2 (pr1 C1)) i =
                 transportf (λ x : hz → A, A ⟦ x i, x (i + 1) ⟧)
@@ -130,14 +130,14 @@ Section def_complexes.
     exact (H1 i).
   Qed.
 
-  Local Lemma ComplexEq'' (C1 C2 : Complex) (H : Π (i : hz), C1 i = C2 i)
-        (H1 : Π (i : hz),
+  Local Lemma ComplexEq'' (C1 C2 : Complex) (H : ∏ (i : hz), C1 i = C2 i)
+        (H1 : ∏ (i : hz),
               transportf (λ x : A, C2 i --> x) (H (i + 1))
                          (transportf (λ x : A, x --> C1 (i + 1)) (H i) (Diff C1 i)) =
               Diff C2 i) :
     transportf
-      (λ x : Σ D : hz → A, Π i : hz, A ⟦ D i, D (i + 1) ⟧,
-                                 Π i : hz, pr2 x i ;; pr2 x (i + 1) =
+      (λ x : ∑ D : hz → A, ∏ i : hz, A ⟦ D i, D (i + 1) ⟧,
+                                 ∏ i : hz, pr2 x i ;; pr2 x (i + 1) =
                                            ZeroArrow (Additive.to_Zero A) _ _)
       (total2_paths (funextfun (pr1 (pr1 C1)) (pr1 (pr1 C2)) (λ i : hz, H i))
                     (ComplexEq' C1 C2 H H1)) (pr2 C1) = pr2 C2.
@@ -145,8 +145,8 @@ Section def_complexes.
     apply proofirrelevance. apply impred_isaprop. intros t. apply to_has_homsets.
   Qed.
 
-  Lemma ComplexEq (C1 C2 : Complex) (H : Π (i : hz), C1 i = C2 i)
-        (H1 : Π (i : hz),
+  Lemma ComplexEq (C1 C2 : Complex) (H : ∏ (i : hz), C1 i = C2 i)
+        (H1 : ∏ (i : hz),
               transportf (λ x : A, C2 i --> x) (H (i + 1))
                          (transportf (λ x : A, x --> C1 (i + 1)) (H i) (Diff C1 i)) =
               Diff C2 i) : C1 = C2.
@@ -198,10 +198,10 @@ Section def_complexes.
 
   (** Morphism of complexes *)
   Definition Morphism (C1 C2 : Complex) : UU :=
-    Σ D : (Π i : hz, A⟦C1 i, C2 i⟧), Π i : hz, (D i) ;; (Diff C2 i) = (Diff C1 i) ;; (D (i + 1)).
+    ∑ D : (∏ i : hz, A⟦C1 i, C2 i⟧), ∏ i : hz, (D i) ;; (Diff C2 i) = (Diff C1 i) ;; (D (i + 1)).
 
-  Definition mk_Morphism (C1 C2 : Complex) (Mors : Π i : hz, A⟦C1 i, C2 i⟧)
-             (Comm : Π i : hz, (Mors i) ;; (Diff C2 i) = (Diff C1 i) ;; (Mors (i + 1))) :
+  Definition mk_Morphism (C1 C2 : Complex) (Mors : ∏ i : hz, A⟦C1 i, C2 i⟧)
+             (Comm : ∏ i : hz, (Mors i) ;; (Diff C2 i) = (Diff C1 i) ;; (Mors (i + 1))) :
     Morphism C1 C2 := tpair _ Mors Comm.
 
   (** Accessor functions *)
@@ -212,7 +212,7 @@ Section def_complexes.
     (M i) ;; (Diff C2 i) = (Diff C1 i) ;; (M (i + 1)) := pr2 M i.
 
   (** A lemma to show that two morphisms are the same *)
-  Lemma MorphismEq {C1 C2 : Complex} (M1 M2 : Morphism C1 C2) (H : Π i : hz, M1 i = M2 i) :
+  Lemma MorphismEq {C1 C2 : Complex} (M1 M2 : Morphism C1 C2) (H : ∏ i : hz, M1 i = M2 i) :
     M1 = M2.
   Proof.
     use total2_paths.
@@ -221,7 +221,7 @@ Section def_complexes.
   Qed.
 
   Lemma MorphismEq' {C1 C2 : Complex} (M1 M2 : Morphism C1 C2) (H : M1 = M2) :
-    Π i : hz, M1 i = M2 i.
+    ∏ i : hz, M1 i = M2 i.
   Proof.
     induction H.
     intros i.
@@ -663,7 +663,7 @@ Section def_complexes.
   Defined.
 
   Definition ComplexFromObject_mors (X : ob A) (i : hz) :
-    Π i0 : hz, A ⟦ComplexFromObject_obs X i i0, ComplexFromObject_obs X i (i0 + 1)⟧.
+    ∏ i0 : hz, A ⟦ComplexFromObject_obs X i i0, ComplexFromObject_obs X i (i0 + 1)⟧.
   Proof.
     intros i0.
     unfold ComplexFromObject_obs. unfold coprod_rect.
@@ -677,7 +677,7 @@ Section def_complexes.
   Defined.
 
   Local Lemma ComplexFromObject_comm (X : ob A) (i : hz) :
-    Π i0 : hz, (ComplexFromObject_mors X i i0) ;; (ComplexFromObject_mors X i (i0 + 1)) =
+    ∏ i0 : hz, (ComplexFromObject_mors X i i0) ;; (ComplexFromObject_mors X i (i0 + 1)) =
                ZeroArrow (Additive.to_Zero A) _ _.
   Proof.
     intros i0.
@@ -701,7 +701,7 @@ Section def_complexes.
 
   (** A morphisms in A induces a morphisms of ComplexFromObjects *)
   Definition ObjectMorToComplexMor_mors {a b : ob A} (f : a --> b) (i : hz) :
-    Π i0 : hz, A ⟦(ComplexFromObject a i) i0, (ComplexFromObject b i) i0⟧.
+    ∏ i0 : hz, A ⟦(ComplexFromObject a i) i0, (ComplexFromObject b i) i0⟧.
   Proof.
     intros i0.
     unfold ComplexFromObject. cbn. unfold ComplexFromObject_obs. cbn. unfold coprod_rect.
@@ -711,7 +711,7 @@ Section def_complexes.
   Defined.
 
   Local Lemma ObjectMorToComplexMor_comm {a b : ob A} (f : a --> b) (i : hz) :
-    Π i0 : hz, (ObjectMorToComplexMor_mors f i i0) ;; (Diff (ComplexFromObject b i) i0) =
+    ∏ i0 : hz, (ObjectMorToComplexMor_mors f i i0) ;; (Diff (ComplexFromObject b i) i0) =
                (Diff (ComplexFromObject a i) i0) ;; (ObjectMorToComplexMor_mors f i (i0 + 1)).
   Proof.
     intros i0.
@@ -748,7 +748,7 @@ Section def_complexes.
   Defined.
 
   Definition Complex2FromObject_mors (a : ob A) (i : hz) :
-    Π i0 : hz, A ⟦Complex2FromObject_obs a i i0, Complex2FromObject_obs a i (i0 + 1)⟧.
+    ∏ i0 : hz, A ⟦Complex2FromObject_obs a i i0, Complex2FromObject_obs a i (i0 + 1)⟧.
   Proof.
     intros i0. unfold Complex2FromObject_obs. cbn. unfold coprod_rect.
     induction (isdecrelhzeq i i0) as [e | n].
@@ -772,7 +772,7 @@ Section def_complexes.
   Defined.
 
   Local Lemma Complex2FromObject_comm (a : ob A) (i : hz) :
-    Π i0 : hz, (Complex2FromObject_mors a i i0) ;; (Complex2FromObject_mors a i (i0 + 1)) =
+    ∏ i0 : hz, (Complex2FromObject_mors a i i0) ;; (Complex2FromObject_mors a i (i0 + 1)) =
                ZeroArrow (Additive.to_Zero A) _ _.
   Proof.
     intros i0.
@@ -825,7 +825,7 @@ Section def_complexes.
   (** *** Morphism from Complex2FromObject to complex *)
 
   Definition FromComplex2FromObject_mors {a : ob A} {C : Complex} {i : hz} (f : a --> (C i)) :
-    Π i0 : hz, A ⟦(Complex2FromObject a i) i0, C i0⟧.
+    ∏ i0 : hz, A ⟦(Complex2FromObject a i) i0, C i0⟧.
   Proof.
     intros i0.
     unfold Complex2FromObject. unfold Complex2FromObject_obs. unfold Complex2FromObject_mors. cbn.
@@ -838,7 +838,7 @@ Section def_complexes.
   Defined.
 
   Local Lemma FromComplex2FromObject_comm {a : ob A} {C : Complex} {i : hz} (f : a --> (C i)) :
-    Π i0 : hz, (FromComplex2FromObject_mors f i0) ;; (Diff C i0) =
+    ∏ i0 : hz, (FromComplex2FromObject_mors f i0) ;; (Diff C i0) =
                (Diff (Complex2FromObject a i) i0) ;; (FromComplex2FromObject_mors f (i0 + 1)).
   Proof.
     intros i0.
@@ -886,7 +886,7 @@ Section def_complexes.
   (** *** Morphism from complex to Complex2FromObject *)
 
   Definition ToComplex2FromObject_mors {a : ob A} {C : Complex} {i : hz} (f : (C i) --> a) :
-    Π i0 : hz, A ⟦C i0, (Complex2FromObject a (i - 1)) i0⟧.
+    ∏ i0 : hz, A ⟦C i0, (Complex2FromObject a (i - 1)) i0⟧.
   Proof.
     intros i0. unfold Complex2FromObject. unfold Complex2FromObject_obs. cbn. unfold coprod_rect.
     induction (isdecrelhzeq (i - 1) i0) as [e | n].
@@ -904,7 +904,7 @@ Section def_complexes.
   Defined.
 
   Local Lemma ToComplex2FromObject_comm {a : ob A} {C : Complex} {i : hz} (f : (C i) --> a) :
-    Π i0 : hz, (ToComplex2FromObject_mors f i0) ;; (Diff (Complex2FromObject a (i - 1)) i0) =
+    ∏ i0 : hz, (ToComplex2FromObject_mors f i0) ;; (Diff (Complex2FromObject a (i - 1)) i0) =
                (Diff C i0) ;; (ToComplex2FromObject_mors f (i0 + 1)).
   Proof.
     intros i0.
@@ -1058,7 +1058,7 @@ Section complexes_precat.
   Qed.
 
   Lemma ComplexMonicIndexMonic {C1 C2 : Complex A} (M : Monic ComplexPreCat C1 C2) :
-    Π i : hz, isMonic (@MMor A C1 C2 (MonicArrow _ M) i).
+    ∏ i : hz, isMonic (@MMor A C1 C2 (MonicArrow _ M) i).
   Proof.
     intros i a g h H.
     set (tmp := ComplexMonicIndexMonic_eq M i g h H).
@@ -1100,7 +1100,7 @@ Section complexes_precat.
   Qed.
 
   Lemma ComplexEpiIndexEpi {C1 C2 : Complex A} (E : Epi ComplexPreCat C1 C2) :
-    Π i : hz, isEpi (@MMor A C1 C2 (EpiArrow _ E) i).
+    ∏ i : hz, isEpi (@MMor A C1 C2 (EpiArrow _ E) i).
   Proof.
     intros i a g h H.
     set (tmp := ComplexEpiIndexEpi_eq E i g h H).
@@ -1119,7 +1119,7 @@ Section complexes_precat.
   (** ** An morphism in complexes is an isomorphism if it is so indexwise *)
 
   Lemma ComplexIsoIndexIso {C1 C2 : Complex A} (f : ComplexPreCat⟦C1, C2⟧)
-        (H : Π (i : hz), is_iso (MMor f i)) : is_iso f.
+        (H : ∏ (i : hz), is_iso (MMor f i)) : is_iso f.
   Proof.
     use is_iso_qinv.
     - use mk_Morphism.
@@ -2020,7 +2020,7 @@ Section transport_section'.
 
   Variable C : precategory.
 
-  Lemma transport_hz_source_target (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f i, f (i + n)⟧)
+  Lemma transport_hz_source_target (f : hz -> ob C) (n : hz) (H : ∏ (i : hz), C⟦f i, f (i + n)⟧)
         (i i' : hz) (e1 : i = i') :
     H i' = transportf (fun (x : ob C) => C⟦x, f (i' + n)⟧) (maponpaths f e1)
                       (transportf (precategory_morphisms (f i))
@@ -2029,7 +2029,7 @@ Section transport_section'.
     induction e1. apply idpath.
   Qed.
 
-  Lemma transport_hz_target_source (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f i, f (i + n)⟧)
+  Lemma transport_hz_target_source (f : hz -> ob C) (n : hz) (H : ∏ (i : hz), C⟦f i, f (i + n)⟧)
         (i i' : hz) (e1 : i = i') :
     H i' = transportf (precategory_morphisms (f i'))
                       (maponpaths f (hzplusradd i i' n e1))
@@ -2038,7 +2038,7 @@ Section transport_section'.
     induction e1. apply idpath.
   Qed.
 
-  Lemma transport_hz_section (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f i, f (i + n)⟧)
+  Lemma transport_hz_section (f : hz -> ob C) (n : hz) (H : ∏ (i : hz), C⟦f i, f (i + n)⟧)
         (i i' : hz) (e1 : i = i') :
     transportf (precategory_morphisms (f i)) (maponpaths f (hzplusradd i i' n e1)) (H i) =
     transportf (fun (x : ob C) => C⟦x, f (i' + n)⟧) (maponpaths f (! e1)) (H i').
@@ -2046,7 +2046,7 @@ Section transport_section'.
     induction e1. apply idpath.
   Qed.
 
-  Lemma transport_hz_section' (f : hz -> ob C) (n : hz) (H : Π (i : hz), C⟦f (i + n), f i⟧)
+  Lemma transport_hz_section' (f : hz -> ob C) (n : hz) (H : ∏ (i : hz), C⟦f (i + n), f i⟧)
         (i i' : hz) (e1 : i + n = i' + n) (e2 : i = i') :
     transportf (precategory_morphisms (f (i + n))) (maponpaths f e2) (H i) =
     transportf (fun (x : ob C) => C⟦x, f i'⟧) (maponpaths f (! e1)) (H i').
@@ -2054,7 +2054,7 @@ Section transport_section'.
     induction e2. assert (e : e1 = idpath _) by apply isasethz. rewrite e. clear e. apply idpath.
   Qed.
 
-  Lemma transport_hz_double_section (f f' : hz -> ob C) (H : Π (i : hz), C⟦f i, f' i⟧)
+  Lemma transport_hz_double_section (f f' : hz -> ob C) (H : ∏ (i : hz), C⟦f i, f' i⟧)
         (i i' : hz) (e : i = i') :
     transportf (precategory_morphisms (f i)) (maponpaths f' e) (H i) =
     transportf (fun (x : ob C) => C⟦x, f' i'⟧) (maponpaths f (! e)) (H i').
@@ -2062,7 +2062,7 @@ Section transport_section'.
     induction e. apply idpath.
   Qed.
 
-  Lemma transport_hz_double_section_source_target (f f' : hz -> ob C) (H : Π (i : hz), C⟦f i, f' i⟧)
+  Lemma transport_hz_double_section_source_target (f f' : hz -> ob C) (H : ∏ (i : hz), C⟦f i, f' i⟧)
         (i i' : hz) (e : i = i') :
     H i' = transportf (precategory_morphisms (f i')) (maponpaths f' e)
                       (transportf (fun (x : ob C) => C⟦x, f' i⟧) (maponpaths f e) (H i)).
@@ -2101,7 +2101,7 @@ Section complexes_homotopies.
 
   Variable A : Additive.
 
-  Definition ComplexHomot (C1 C2 : Complex A) : UU := Π (i : hz), A⟦C1 i, C2 (i - 1)⟧.
+  Definition ComplexHomot (C1 C2 : Complex A) : UU := ∏ (i : hz), A⟦C1 i, C2 (i - 1)⟧.
 
   (** This lemma shows that the squares of the morphism map, defined by the homotopy H, commute. *)
   Local Lemma ComplexHomotMorphism_comm {C1 C2 : Complex A} (H : ComplexHomot C1 C2) (i : hz) :
@@ -2169,7 +2169,7 @@ Section complexes_homotopies.
        ∃ (H : ComplexHomot C1 C2), ComplexHomotMorphism H = f).
 
   Local Lemma grinvop (Y : gr) :
-    Π y1 y2 : Y, grinv Y (@op Y y1 y2) = @op Y (grinv Y y2) (grinv Y y1).
+    ∏ y1 y2 : Y, grinv Y (@op Y y1 y2) = @op Y (grinv Y y2) (grinv Y y1).
   Proof.
     intros y1 y2.
     apply (grrcan Y y1).
@@ -2296,7 +2296,7 @@ Section complexes_homotopies.
   (** Pre- and postcomposition with morphisms in ComplexHomotSubset is in ComplexHomotSubset. *)
   Lemma ComplexHomotSubgrop_comp_left (C1 : Complex A) {C2 C3 : Complex A}
         (f : ((ComplexPreCat_Additive A)⟦C2, C3⟧)) (H : ComplexHomotSubset C2 C3 f) :
-    Π (g : ((ComplexPreCat_Additive A)⟦C1, C2⟧)), ComplexHomotSubset C1 C3 (g ;; f).
+    ∏ (g : ((ComplexPreCat_Additive A)⟦C1, C2⟧)), ComplexHomotSubset C1 C3 (g ;; f).
   Proof.
     intros g P X.
     use (squash_to_prop H). apply propproperty. intros HH.
@@ -2314,7 +2314,7 @@ Section complexes_homotopies.
 
   Lemma ComplexHomotSubgrop_comp_right {C1 C2 : Complex A} (C3 : Complex A)
         (f : ((ComplexPreCat_Additive A)⟦C1, C2⟧)) (H : ComplexHomotSubset C1 C2 f) :
-    Π (g : ((ComplexPreCat_Additive A)⟦C2, C3⟧)), ComplexHomotSubset C1 C3 (f ;; g).
+    ∏ (g : ((ComplexPreCat_Additive A)⟦C2, C3⟧)), ComplexHomotSubset C1 C3 (f ;; g).
   Proof.
     intros g P X.
     use (squash_to_prop H). apply propproperty. intros HH.
@@ -2821,17 +2821,17 @@ Section translation_functor.
 
   (** ** Translation functor is an isomorphism, with inverse the inverse translation. *)
 
-  Lemma transportf_total2_base {AA : UU} {B : AA -> UU} {BB : AA -> UU} (s s' : Σ x : AA, B x)
+  Lemma transportf_total2_base {AA : UU} {B : AA -> UU} {BB : AA -> UU} (s s' : ∑ x : AA, B x)
         (p : pr1 s = pr1 s') (q : transportf B p (pr2 s) = pr2 s') (x : BB (pr1 s)) :
-    transportf (λ x' : Σ x : AA, B x, BB (pr1 x')) (total2_paths p q) x =
+    transportf (λ x' : ∑ x : AA, B x, BB (pr1 x')) (total2_paths p q) x =
     transportf (λ x : AA, BB x) p x.
   Proof.
     induction s as [s1 s2]. induction s' as [s1' s2']. cbn in *.
     induction p. induction q. apply idpath.
   Qed.
 
-  Lemma ComplexEq_transport_target {C1 C2 C2' : Complex A} (H : Π (i : hz), C2 i = C2' i)
-        (H1 : Π (i : hz),
+  Lemma ComplexEq_transport_target {C1 C2 C2' : Complex A} (H : ∏ (i : hz), C2 i = C2' i)
+        (H1 : ∏ (i : hz),
               transportf (λ x : A, C2' i --> x) (H (i + 1))
                          (transportf (λ x : A, x --> C2 (i + 1)) (H i) (Diff C2 i)) =
               Diff C2' i) (f : Morphism C1 C2) (i : hz) :
@@ -2856,8 +2856,8 @@ Section translation_functor.
     use transportf_total2_base.
   Qed.
 
-  Lemma ComplexEq_transport_source {C1 C1' C2 : Complex A} (H : Π (i : hz), C1' i = C1 i)
-        (H1 : Π (i : hz),
+  Lemma ComplexEq_transport_source {C1 C1' C2 : Complex A} (H : ∏ (i : hz), C1' i = C1 i)
+        (H1 : ∏ (i : hz),
               transportf (λ x : A, C1 i --> x) (H (i + 1))
                          (transportf (λ x : A, x --> C1' (i + 1)) (H i) (Diff C1' i)) =
               Diff C1 i) (f : Morphism C1' C2) (i : hz) :
@@ -2996,8 +2996,8 @@ Section translation_functor.
 
   Definition TranslationFunctorHIm {C1 C2 : ComplexHomot_Additive A}
              (f : (ComplexHomot_Additive A)⟦C1, C2⟧) : UU :=
-    Σ (h : (ComplexHomot_Additive A)⟦TranslationComplex C1, TranslationComplex C2⟧),
-    Π (f' : (ComplexPreCat_Additive A)⟦C1, C2⟧) (H : # (ComplexHomotFunctor A) f' = f),
+    ∑ (h : (ComplexHomot_Additive A)⟦TranslationComplex C1, TranslationComplex C2⟧),
+    ∏ (f' : (ComplexPreCat_Additive A)⟦C1, C2⟧) (H : # (ComplexHomotFunctor A) f' = f),
     h = # (ComplexHomotFunctor A) (# TranslationFunctor f').
 
 
@@ -3013,7 +3013,7 @@ Section translation_functor.
   Definition mk_TranslationFunctorHIm {C1 C2 : ComplexHomot_Additive A}
              {f : (ComplexHomot_Additive A)⟦C1, C2⟧}
              (h : (ComplexHomot_Additive A)⟦TranslationComplex C1, TranslationComplex C2⟧)
-             (HH : Π (f' : (ComplexPreCat_Additive A)⟦C1, C2⟧)
+             (HH : ∏ (f' : (ComplexPreCat_Additive A)⟦C1, C2⟧)
                      (H : # (ComplexHomotFunctor A) f' = f),
                    h = # (ComplexHomotFunctor A) (# TranslationFunctor f')) :
     TranslationFunctorHIm f := tpair _ h HH.
@@ -3212,8 +3212,8 @@ Section translation_functor.
 
   Definition InvTranslationFunctorHIm {C1 C2 : ComplexHomot_Additive A}
              (f : (ComplexHomot_Additive A)⟦C1, C2⟧) : UU :=
-    Σ (h : (ComplexHomot_Additive A)⟦InvTranslationComplex C1, InvTranslationComplex C2⟧),
-    Π (f' : (ComplexPreCat_Additive A)⟦C1, C2⟧) (H : # (ComplexHomotFunctor A) f' = f),
+    ∑ (h : (ComplexHomot_Additive A)⟦InvTranslationComplex C1, InvTranslationComplex C2⟧),
+    ∏ (f' : (ComplexPreCat_Additive A)⟦C1, C2⟧) (H : # (ComplexHomotFunctor A) f' = f),
     h = # (ComplexHomotFunctor A) (# InvTranslationFunctor f').
 
   Definition InvTranslationFunctorHImMor {C1 C2 : ComplexHomot_Additive A}
@@ -3229,7 +3229,7 @@ Section translation_functor.
   Definition mk_InvTranslationFunctorHIm {C1 C2 : ComplexHomot_Additive A}
              {f : (ComplexHomot_Additive A)⟦C1, C2⟧}
              (h : (ComplexHomot_Additive A)⟦InvTranslationComplex C1, InvTranslationComplex C2⟧)
-             (HH : Π (f' : (ComplexPreCat_Additive A)⟦C1, C2⟧)
+             (HH : ∏ (f' : (ComplexPreCat_Additive A)⟦C1, C2⟧)
                      (H : # (ComplexHomotFunctor A) f' = f),
                    h = # (ComplexHomotFunctor A) (# InvTranslationFunctor f')) :
     InvTranslationFunctorHIm f := tpair _ h HH.

--- a/UniMath/Ktheory/AbelianGroup.v
+++ b/UniMath/Ktheory/AbelianGroup.v
@@ -87,19 +87,19 @@ Module Presentation.
 
   Record AdequateRelation {X I} (R:I->reln X) (r : hrel (word X)) :=
     make_AdequateRelation {
-        base: Π i, r (lhs (R i)) (rhs (R i));
-        reflex : Π w, r w w;
-        symm : Π v w, r v w -> r w v;
-        trans : Π u v w, r u v -> r v w -> r u w;
-        left_compat : Π u v w, r v w -> r (word_op u v) (word_op u w);
-        right_compat: Π u v w, r u v -> r (word_op u w) (word_op v w);
-        left_unit : Π w, r (word_op word_unit w) w;
-        right_unit : Π w, r (word_op w word_unit) w;
-        assoc : Π u v w, r (word_op (word_op u v) w) (word_op u (word_op v w));
-        inverse_compat : Π v w, r v w -> r (word_inv v) (word_inv w);
-        left_inverse : Π w, r (word_op (word_inv w) w) word_unit;
-        right_inverse: Π w, r (word_op w (word_inv w)) word_unit;
-        comm : Π v w, r (word_op v w) (word_op w v)
+        base: ∏ i, r (lhs (R i)) (rhs (R i));
+        reflex : ∏ w, r w w;
+        symm : ∏ v w, r v w -> r w v;
+        trans : ∏ u v w, r u v -> r v w -> r u w;
+        left_compat : ∏ u v w, r v w -> r (word_op u v) (word_op u w);
+        right_compat: ∏ u v w, r u v -> r (word_op u w) (word_op v w);
+        left_unit : ∏ w, r (word_op word_unit w) w;
+        right_unit : ∏ w, r (word_op w word_unit) w;
+        assoc : ∏ u v w, r (word_op (word_op u v) w) (word_op u (word_op v w));
+        inverse_compat : ∏ v w, r v w -> r (word_inv v) (word_inv w);
+        left_inverse : ∏ w, r (word_op (word_inv w) w) word_unit;
+        right_inverse: ∏ w, r (word_op w (word_inv w)) word_unit;
+        comm : ∏ v w, r (word_op v w) (word_op w v)
       }.
   Arguments make_AdequateRelation {X I} R r _ _ _ _ _ _ _ _ _ _ _ _ _.
   Arguments base {X I R r} _ _.
@@ -116,7 +116,7 @@ Module Presentation.
 
   Definition smallestAdequateRelation0 {X I} (R:I->reln X) : hrel (word X).
     intros ? ? ? v w.
-    exists (Π r: hrel (word X), AdequateRelation R r -> r v w).
+    exists (∏ r: hrel (word X), AdequateRelation R r -> r v w).
     abstract (apply impred; intro r; apply impred_prop).
   Defined.
   Lemma adequacy {X I} (R:I->reln X) :
@@ -197,7 +197,7 @@ Module Presentation.
          apply (squash_to_prop (lift R w') ig); intros [w []].
          exact (iscompsetquotpr e _ _ (fun r ra => assoc R r ra u v w)). Qed.
   Lemma is_left_inverse_univ_binop {X I} (R:I->reln X) :
-    Π w:setquot (smallestAdequateRelation0 R),
+    ∏ w:setquot (smallestAdequateRelation0 R),
       univ_binop R (univ_inverse R w) w =
       setquotpr (smallestAdequateRelation R) word_unit.
   Proof. intros. isaprop_goal ig. { apply setproperty. }
@@ -205,7 +205,7 @@ Module Presentation.
     exact (iscompsetquotpr (smallestAdequateRelation R) _ _
                            (fun r ra => left_inverse R r ra v)). Qed.
   Lemma is_right_inverse_univ_binop {X I} (R:I->reln X) :
-    Π w:setquot (smallestAdequateRelation0 R),
+    ∏ w:setquot (smallestAdequateRelation0 R),
       univ_binop R w (univ_inverse R w) =
       setquotpr (smallestAdequateRelation R) word_unit.
   Proof. intros. isaprop_goal ig. { apply setproperty. }
@@ -244,7 +244,7 @@ Module Presentation.
     make_MarkedAbelianGroup {
         m_base :> abgr;
         m_mark : X -> m_base;
-        m_reln : Π i, evalword (toMarkedPreAbelianGroup R m_base m_mark) (lhs (R i)) =
+        m_reln : ∏ i, evalword (toMarkedPreAbelianGroup R m_base m_mark) (lhs (R i)) =
                            evalword (toMarkedPreAbelianGroup R m_base m_mark) (rhs (R i)) }.
   Arguments make_MarkedAbelianGroup {X I} R _ _ _.
   Arguments m_base {X I R} _.
@@ -272,7 +272,7 @@ Module Presentation.
   Record MarkedAbelianGroupMap {X I} {R:I->reln X} (M N:MarkedAbelianGroup R) :=
     make_MarkedAbelianGroupMap {
         map_base :> Hom_abgr M N;
-        map_mark : Π x, map_base (m_mark M x) = m_mark N x }.
+        map_mark : ∏ x, map_base (m_mark M x) = m_mark N x }.
   Arguments map_base {X I R M N} m.
   Arguments map_mark {X I R M N} m x.
   Lemma MarkedAbelianGroupMapEquality {X I} {R:I->reln X} {M N:MarkedAbelianGroup R}
@@ -339,7 +339,7 @@ Module Presentation.
                 (universalMarkedAbelianGroup3 R).
   Fixpoint agreement_on_gens0 {X I} {R:I->reln X} {M:abgr}
         (f g:Hom_abgr (universalMarkedAbelianGroup R) M)
-        (p:Π i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
+        (p:∏ i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
                    g (setquotpr (smallestAdequateRelation R) (word_gen i)))
         (w:word X) :
           pr1 f (setquotpr (smallestAdequateRelation R) w) =
@@ -362,7 +362,7 @@ Module Presentation.
            { apply agreement_on_gens0. assumption. } } Qed.
   Lemma agreement_on_gens {X I} {R:I->reln X} {M:abgr}
         (f g:Hom_abgr (universalMarkedAbelianGroup R) M) :
-        (Π i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
+        (∏ i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
                    g (setquotpr (smallestAdequateRelation R) (word_gen i)))
           -> f = g.
     intros ? ? ? ? ? ? p. apply Monoid.funEquality.
@@ -416,14 +416,14 @@ Module Product.
     intros a b. apply funextsec; intro i. apply commax. Defined.
   Definition Proj {I} (G:I->abgr) (i:I) : Hom_abgr (make G) (G i).
     exact @Group.Product.Proj. Defined.
-  Definition Map {I} (G:I->abgr) (T:abgr) (g: Π i, Hom_abgr T (G i)) :
+  Definition Map {I} (G:I->abgr) (T:abgr) (g: ∏ i, Hom_abgr T (G i)) :
     Hom_abgr T (make G).
     exact @Group.Product.Fun. Defined.
-  Lemma Eqn {I} (G:I->abgr) (T:abgr) (g: Π i, Hom_abgr T (G i))
-           : Π i, Proj G i ∘ Map G T g = g i.
+  Lemma Eqn {I} (G:I->abgr) (T:abgr) (g: ∏ i, Hom_abgr T (G i))
+           : ∏ i, Proj G i ∘ Map G T g = g i.
     exact @Group.Product.Eqn. Qed.
   Definition UniqueMap {I} (G:I->abgr) (T:abgr) (h h' : Hom_abgr T (make G)) :
-       (Π i, Proj G i ∘ h = Proj G i ∘ h') -> h = h'.
+       (∏ i, Proj G i ∘ h = Proj G i ∘ h') -> h = h'.
     intros ? ? ? ? ? e. apply Monoid.funEquality.
     apply funextsec; intro t. apply funextsec; intro i.
     exact (eqtohomot (ap pr1 (e i)) t). Qed.
@@ -433,7 +433,7 @@ Module Sum.                   (* coproducts *)
   Definition X {I} (G:I->abgr) := total2 G. (* the generators *)
   Inductive J {I} (G:I->abgr) : Type := (* index set for the relations *)
     | J_zero : I -> J G                 (* (i,0) ~  ; redundant relation *)
-    | J_sum : (Σ i, G i × G i) -> J G.  (* (i,g)+(i,h) ~ (i,g+h) *)
+    | J_sum : (∑ i, G i × G i) -> J G.  (* (i,g)+(i,h) ~ (i,g+h) *)
   Definition R {I} (G:I->abgr) : J G -> reln (X G).
     intros ? ? [i|[i [g h]]].
     { exact (make_reln (word_gen (i,,0)) (word_unit)). }
@@ -446,21 +446,21 @@ Module Sum.                   (* coproducts *)
     { intro g. apply setquotpr. apply word_gen. exact (i,,g). } { split.
       { intros g h. apply iscompsetquotpr. exact (base (adequacy _) (J_sum _ (i,,(g,,h)))). }
       { apply iscompsetquotpr. exact (base (adequacy _) (J_zero _ i)). } } Defined.
-  Definition Map0 {I} {G:I->abgr} {T:abgr} (f: Π i, Hom_abgr (G i) T) :
+  Definition Map0 {I} {G:I->abgr} {T:abgr} (f: ∏ i, Hom_abgr (G i) T) :
       MarkedAbelianGroup (R G).
     intros. simple refine (make_MarkedAbelianGroup (R G) T _ _).
     { intros [i g]. exact (f i g). }
     { intros [i|[i [g h]]].
       { simpl. apply unitproperty. }
       { simpl. apply addproperty. } } Defined.
-  Definition Map {I} (G:I->abgr) (T:abgr) (f: Π i, Hom_abgr (G i) T) :
+  Definition Map {I} (G:I->abgr) (T:abgr) (f: ∏ i, Hom_abgr (G i) T) :
       Hom_abgr (make G) T.
     intros. exact (thePoint (iscontrMarkedAbelianGroupMap (Map0 f))). Defined.
-  Lemma Eqn {I} (G:I->abgr) (T:abgr) (f: Π i, Hom_abgr (G i) T)
-           : Π i, Map G T f ∘ Incl G i = f i.
+  Lemma Eqn {I} (G:I->abgr) (T:abgr) (f: ∏ i, Hom_abgr (G i) T)
+           : ∏ i, Map G T f ∘ Incl G i = f i.
     intros. apply Monoid.funEquality. reflexivity. Qed.
   Definition UniqueMap {I} (G:I->abgr) (T:abgr) (h h' : Hom_abgr (make G) T) :
-       (Π i, h ∘ Incl G i = h' ∘ Incl G i) -> h = h'.
+       (∏ i, h ∘ Incl G i = h' ∘ Incl G i) -> h = h'.
     intros ? ? ? ? ? e. apply (agreement_on_gens h h').
     { intros [i g]. exact (ap (evalat g) (ap pr1 (e i))). }
   Qed.

--- a/UniMath/Ktheory/AbelianMonoid.v
+++ b/UniMath/Ktheory/AbelianMonoid.v
@@ -14,7 +14,7 @@ Definition finiteOperation0 (X:abmonoid) n (x:stn n->X) : X.
 Proof. (* return (...((x0*x1)*x2)*...)  *)
   intros. induction n as [|n x'].
   { exact (unel _). } { exact ((x' (funcomp (dni_last n) x)) + x (lastelement n)). } Defined.
-Goal Π (X:abmonoid) n (x:stn (S n)->X),
+Goal ∏ (X:abmonoid) n (x:stn (S n)->X),
      finiteOperation0 X (S n) x
   = finiteOperation0 X n (funcomp (dni_last n) x) + x (lastelement n).
 Proof. reflexivity. Qed.
@@ -284,7 +284,7 @@ Abort.
 
 Definition decidable_type (X:UU) := X ⨿ ¬X.
 
-Lemma uniqueness0 (X:abmonoid) n : Π I (f g:nelstruct n I) (x:I->X),
+Lemma uniqueness0 (X:abmonoid) n : ∏ I (f g:nelstruct n I) (x:I->X),
      finiteOperation0 X n (funcomp (pr1 f) x)
   = finiteOperation0 X n (funcomp (pr1 g) x).
 Proof.
@@ -368,16 +368,16 @@ Module Presentation.
 
   Record AdequateRelation {X I} (R:I->reln X) (r : hrel (word X)) :=
     make_AdequateRelation {
-        base: Π i, r (lhs (R i)) (rhs (R i));
-        reflex : Π w, r w w;
-        symm : Π v w, r v w -> r w v;
-        trans : Π u v w, r u v -> r v w -> r u w;
-        left_compat : Π u v w, r v w -> r (word_op u v) (word_op u w);
-        right_compat: Π u v w, r u v -> r (word_op u w) (word_op v w);
-        left_unit : Π w, r (word_op word_unit w) w;
-        right_unit : Π w, r (word_op w word_unit) w;
-        assoc : Π u v w, r (word_op (word_op u v) w) (word_op u (word_op v w));
-        comm : Π v w, r (word_op v w) (word_op w v)
+        base: ∏ i, r (lhs (R i)) (rhs (R i));
+        reflex : ∏ w, r w w;
+        symm : ∏ v w, r v w -> r w v;
+        trans : ∏ u v w, r u v -> r v w -> r u w;
+        left_compat : ∏ u v w, r v w -> r (word_op u v) (word_op u w);
+        right_compat: ∏ u v w, r u v -> r (word_op u w) (word_op v w);
+        left_unit : ∏ w, r (word_op word_unit w) w;
+        right_unit : ∏ w, r (word_op w word_unit) w;
+        assoc : ∏ u v w, r (word_op (word_op u v) w) (word_op u (word_op v w));
+        comm : ∏ v w, r (word_op v w) (word_op w v)
       }.
   Arguments make_AdequateRelation {X I} R r _ _ _ _ _ _ _ _ _ _.
   Arguments base {X I R r} _ _.
@@ -394,7 +394,7 @@ Module Presentation.
 
   Definition smallestAdequateRelation0 {X I} (R:I->reln X) : hrel (word X).
     intros ? ? ? v w.
-    exists (Π r: hrel (word X), AdequateRelation R r -> r v w).
+    exists (∏ r: hrel (word X), AdequateRelation R r -> r v w).
     abstract (apply impred; intro r; apply impred_prop).
   Defined.
   Lemma adequacy {X I} (R:I->reln X) :
@@ -493,7 +493,7 @@ Module Presentation.
     make_MarkedAbelianMonoid {
         m_base :> abmonoid;
         m_mark : X -> m_base;
-        m_reln : Π i, evalword (toMarkedPreAbelianMonoid R m_base m_mark) (lhs (R i)) =
+        m_reln : ∏ i, evalword (toMarkedPreAbelianMonoid R m_base m_mark) (lhs (R i)) =
                            evalword (toMarkedPreAbelianMonoid R m_base m_mark) (rhs (R i)) }.
   Arguments make_MarkedAbelianMonoid {X I} R _ _ _.
   Arguments m_base {X I R} _.
@@ -521,7 +521,7 @@ Module Presentation.
   Record MarkedAbelianMonoidMap {X I} {R:I->reln X} (M N:MarkedAbelianMonoid R) :=
     make_MarkedAbelianMonoidMap {
         map_base :> Hom M N;
-        map_mark : Π x, map_base (m_mark M x) = m_mark N x }.
+        map_mark : ∏ x, map_base (m_mark M x) = m_mark N x }.
   Arguments map_base {X I R M N} m.
   Arguments map_mark {X I R M N} m x.
   Lemma MarkedAbelianMonoidMapEquality {X I} {R:I->reln X} {M N:MarkedAbelianMonoid R}
@@ -579,7 +579,7 @@ Module Presentation.
                 (universalMarkedAbelianMonoid3 R).
   Fixpoint agreement_on_gens0 {X I} {R:I->reln X} {M:abmonoid}
         (f g:Hom (universalMarkedAbelianMonoid R) M)
-        (p:Π i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
+        (p:∏ i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
                    g (setquotpr (smallestAdequateRelation R) (word_gen i)))
         (w:word X) :
           pr1 f (setquotpr (smallestAdequateRelation R) w) =
@@ -599,7 +599,7 @@ Module Presentation.
            { apply agreement_on_gens0. assumption. } } Qed.
   Lemma agreement_on_gens {X I} {R:I->reln X} {M:abmonoid}
         (f g:Hom (universalMarkedAbelianMonoid R) M) :
-        (Π i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
+        (∏ i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
                    g (setquotpr (smallestAdequateRelation R) (word_gen i)))
           -> f = g.
     intros ? ? ? ? ? ? p. apply Monoid.funEquality.

--- a/UniMath/Ktheory/AffineLine.v
+++ b/UniMath/Ktheory/AffineLine.v
@@ -28,33 +28,33 @@ Open Scope hz_scope.
 (** ** Recursion for ℤ *)
 
 Definition ℤRecursionData0 (P:ℤ->Type) (p0:P zero)
-      (IH :Π n, P(  toℤ n) -> P(  toℤ (S n)))
-      (IH':Π n, P(- toℤ n) -> P(- toℤ (S n))) := fun
-          f:Π i, P i =>
+      (IH :∏ n, P(  toℤ n) -> P(  toℤ (S n)))
+      (IH':∏ n, P(- toℤ n) -> P(- toℤ (S n))) := fun
+          f:∏ i, P i =>
             (f zero = p0) ×
-            (Π n, f(  toℤ (S n)) = IH  n (f (  toℤ n))) ×
-            (Π n, f(- toℤ (S n)) = IH' n (f (- toℤ n))).
+            (∏ n, f(  toℤ (S n)) = IH  n (f (  toℤ n))) ×
+            (∏ n, f(- toℤ (S n)) = IH' n (f (- toℤ n))).
 
 Definition ℤRecursionData (P:ℤ->Type)
-      (IH :Π n, P(  toℤ n) -> P(  toℤ (S n)))
-      (IH':Π n, P(- toℤ n) -> P(- toℤ (S n))) := fun
-             f:Π i, P i =>
-               (Π n, f(  toℤ (S n)) = IH  n (f (  toℤ n))) ×
-               (Π n, f(- toℤ (S n)) = IH' n (f (- toℤ n))).
+      (IH :∏ n, P(  toℤ n) -> P(  toℤ (S n)))
+      (IH':∏ n, P(- toℤ n) -> P(- toℤ (S n))) := fun
+             f:∏ i, P i =>
+               (∏ n, f(  toℤ (S n)) = IH  n (f (  toℤ n))) ×
+               (∏ n, f(- toℤ (S n)) = IH' n (f (- toℤ n))).
 
 Lemma ℤRecursionUniq (P:ℤ->Type) (p0:P zero)
-      (IH :Π n, P(  toℤ n) -> P(  toℤ (S n)))
-      (IH':Π n, P(- toℤ n) -> P(- toℤ (S n))) :
+      (IH :∏ n, P(  toℤ n) -> P(  toℤ (S n)))
+      (IH':∏ n, P(- toℤ n) -> P(- toℤ (S n))) :
   iscontr (total2 (ℤRecursionData0 P p0 IH IH')).
 Proof. intros.
        unfold ℤRecursionData0.
        (* use hNatRecursion_weq *)
        apply (iscontrweqb (Y :=
-            Σ f:Π w, P (negpos w),
+            ∑ f:∏ w, P (negpos w),
               (f (ii2 O) = p0) ×
-              (Π n : nat, f (ii2 (S n)) = IH n (f (ii2 n))) ×
+              (∏ n : nat, f (ii2 (S n)) = IH n (f (ii2 n))) ×
               (f (ii1 O) = IH' O (f (ii2 O))) ×
-              (Π n : nat, f (ii1 (S n)) = IH' (S n) (f (ii1 n))))).
+              (∏ n : nat, f (ii1 (S n)) = IH' (S n) (f (ii1 n))))).
        { apply (weqbandf (weqonsecbase _ negpos)). intro f.
          simple refine (weqpair _ (gradth _ _ _ _)).
          { intros [h0 [hp hn]]. simple refine (_,,_,,_,,_).
@@ -68,51 +68,51 @@ Proof. intros.
            { apply funextsec; intros [|n']; reflexivity; reflexivity. } }
          { intros [h0 [h1' [hp hn]]]. reflexivity. } }
        intermediate_iscontr (
-             Σ f : (Π n, P (negpos (ii1 n))) ×
-                 (Π n, P (negpos (ii2 n))),
+             ∑ f : (∏ n, P (negpos (ii1 n))) ×
+                 (∏ n, P (negpos (ii2 n))),
                 (pr2 f O = p0) ×
-                (Π n : nat, pr2 f (S n) = IH n (pr2 f n)) ×
+                (∏ n : nat, pr2 f (S n) = IH n (pr2 f n)) ×
                 (pr1 f O = IH' O (pr2 f O)) ×
-                (Π n : nat, pr1 f (S n) = IH' (S n) (pr1 f n))).
+                (∏ n : nat, pr1 f (S n) = IH' (S n) (pr1 f n))).
        { apply (weqbandf (weqsecovercoprodtoprod (fun w => P (negpos w)))).
          intro f. apply idweq. }
        intermediate_iscontr (
-              Σ f : (Π n, P (negpos (ii2 n))) ×
-                    (Π n, P (negpos (ii1 n))),
+              ∑ f : (∏ n, P (negpos (ii2 n))) ×
+                    (∏ n, P (negpos (ii1 n))),
                 (pr1 f O = p0) ×
-                (Π n : nat, pr1 f (S n) = IH n (pr1 f n)) ×
+                (∏ n : nat, pr1 f (S n) = IH n (pr1 f n)) ×
                 (pr2 f O = IH' O (pr1 f O)) ×
-                (Π n : nat, pr2 f (S n) = IH' (S n) (pr2 f n))).
+                (∏ n : nat, pr2 f (S n) = IH' (S n) (pr2 f n))).
        { apply (weqbandf (weqdirprodcomm _ _)). intro f. apply idweq. }
        intermediate_iscontr (
-                Σ (f2 : Π n : nat, P (negpos (ii2 n)))
-                  (f1 : Π n : nat, P (negpos (ii1 n))),
+                ∑ (f2 : ∏ n : nat, P (negpos (ii2 n)))
+                  (f1 : ∏ n : nat, P (negpos (ii1 n))),
                      (f2 O = p0) ×
-                     (Π n : nat, f2 (S n) = IH n (f2 n)) ×
+                     (∏ n : nat, f2 (S n) = IH n (f2 n)) ×
                      (f1 O = IH' O (f2 O)) ×
-                     (Π n : nat, f1 (S n) = IH' (S n) (f1 n))).
+                     (∏ n : nat, f1 (S n) = IH' (S n) (f1 n))).
        { apply weqtotal2asstor. }
        intermediate_iscontr (
-            Σ f2 : Π n : nat, P (negpos (ii2 n)),
+            ∑ f2 : ∏ n : nat, P (negpos (ii2 n)),
                  (f2 O = p0) ×
-            Σ f1 : Π n : nat, P (negpos (ii1 n)),
-                 (Π n : nat, f2 (S n) = IH n (f2 n)) ×
+            ∑ f1 : ∏ n : nat, P (negpos (ii1 n)),
+                 (∏ n : nat, f2 (S n) = IH n (f2 n)) ×
                  (f1 O = IH' O (f2 O)) ×
-                 (Π n : nat, f1 (S n) = IH' (S n) (f1 n))).
+                 (∏ n : nat, f1 (S n) = IH' (S n) (f1 n))).
        { apply weqfibtototal; intro f2. apply weq_total2_prod. }
        intermediate_iscontr (
-            Σ f2 : Π n : nat, P (negpos (ii2 n)),
+            ∑ f2 : ∏ n : nat, P (negpos (ii2 n)),
                  (f2 O = p0) ×
-                 (Π n : nat, f2 (S n) = IH n (f2 n)) ×
-            Σ f1 : Π n : nat, P (negpos (ii1 n)),
+                 (∏ n : nat, f2 (S n) = IH n (f2 n)) ×
+            ∑ f1 : ∏ n : nat, P (negpos (ii1 n)),
                  (f1 O = IH' O (f2 O)) ×
-                 (Π n : nat, f1 (S n) = IH' (S n) (f1 n))).
+                 (∏ n : nat, f1 (S n) = IH' (S n) (f1 n))).
        { apply weqfibtototal; intro f2. apply weqfibtototal; intro.
          apply weq_total2_prod. }
        intermediate_iscontr (
-            Σ f2 : Π n : nat, P (negpos (ii2 n)),
+            ∑ f2 : ∏ n : nat, P (negpos (ii2 n)),
                  (f2 O = p0) ×
-                 (Π n : nat, f2 (S n) = IH n (f2 n))).
+                 (∏ n : nat, f2 (S n) = IH n (f2 n))).
        { apply weqfibtototal; intro f2. apply weqfibtototal; intro h0.
          apply weqpr1; intro ih2.
          exact (Nat.Uniqueness.hNatRecursionUniq
@@ -123,8 +123,8 @@ Proof. intros.
 Defined.
 
 Lemma A (P:ℤ->Type) (p0:P zero)
-      (IH :Π n, P(  toℤ n) -> P(  toℤ (S n)))
-      (IH':Π n, P(- toℤ n) -> P(- toℤ (S n))) :
+      (IH :∏ n, P(  toℤ n) -> P(  toℤ (S n)))
+      (IH':∏ n, P(- toℤ n) -> P(- toℤ (S n))) :
   weq (total2 (ℤRecursionData0 P p0 IH IH'))
       (@hfiber
          (total2 (ℤRecursionData P IH IH'))
@@ -139,15 +139,15 @@ Proof. intros.
        { intros [[f h] h0]. reflexivity. } Defined.
 
 Lemma ℤRecursion_weq (P:ℤ->Type)
-      (IH :Π n, P(  toℤ n) -> P(  toℤ (S n)))
-      (IH':Π n, P(- toℤ n) -> P(- toℤ (S n))) :
+      (IH :∏ n, P(  toℤ n) -> P(  toℤ (S n)))
+      (IH':∏ n, P(- toℤ n) -> P(- toℤ (S n))) :
   weq (total2 (ℤRecursionData P IH IH')) (P 0).
 Proof. intros. exists (fun f => pr1 f zero). intro p0.
        apply (iscontrweqf (A _ _ _ _)). apply ℤRecursionUniq. Defined.
 
 Lemma ℤRecursion_weq_compute (P:ℤ->Type)
-      (IH :Π n, P(  toℤ n) -> P(  toℤ (S n)))
-      (IH':Π n, P(- toℤ n) -> P(- toℤ (S n)))
+      (IH :∏ n, P(  toℤ n) -> P(  toℤ (S n)))
+      (IH':∏ n, P(- toℤ n) -> P(- toℤ (S n)))
       (fh : total2 (ℤRecursionData P IH IH')) :
   ℤRecursion_weq P IH IH' fh = pr1 fh zero.
 Proof. reflexivity.             (* don't change the proof *)
@@ -155,16 +155,16 @@ Defined.
 
 (** ** Bidirectional recursion for ℤ *)
 
-Definition ℤBiRecursionData (P:ℤ->Type) (IH :Π i, P(i) -> P(1+i)) :=
-  fun f:Π i, P i => Π i, f(1+i)=IH i (f i).
+Definition ℤBiRecursionData (P:ℤ->Type) (IH :∏ i, P(i) -> P(1+i)) :=
+  fun f:∏ i, P i => ∏ i, f(1+i)=IH i (f i).
 
-Definition ℤBiRecursion_weq (P:ℤ->Type) (IH :Π i, weq (P i) (P(1+i))) :
+Definition ℤBiRecursion_weq (P:ℤ->Type) (IH :∏ i, weq (P i) (P(1+i))) :
   weq (total2 (ℤBiRecursionData P IH)) (P 0).
 Proof. intros.
-       assert (k : Π n, one + toℤ n = toℤ (S n)).
+       assert (k : ∏ n, one + toℤ n = toℤ (S n)).
        { intro. rewrite nattohzandS. reflexivity. }
        set (l := fun n : nat => weq_transportf P (k n)).
-       assert (k' : Π n, - toℤ n = one + (- toℤ (S n))).
+       assert (k' : ∏ n, - toℤ n = one + (- toℤ (S n))).
        { intros. unfold one, toℤ. rewrite nattohzand1.
          rewrite nattohzandS. rewrite hzminusplus. rewrite <- (hzplusassoc one).
          rewrite (hzpluscomm one). rewrite hzlminus. rewrite hzplusl0.
@@ -191,7 +191,7 @@ Proof. intros.
            reflexivity. } } Defined.
 
 Definition ℤBiRecursion_weq_compute (P:ℤ->Type)
-           (IH :Π i, weq (P i) (P(1+i)))
+           (IH :∏ i, weq (P i) (P(1+i)))
       (fh : total2 (ℤBiRecursionData P IH)) :
   ℤBiRecursion_weq P IH fh = pr1 fh 0.
 Proof. reflexivity.             (* don't change the proof *)
@@ -204,25 +204,25 @@ Open Scope action_scope.
 (** ** Bidirectional recursion for ℤ-torsors *)
 
 Definition GuidedSection {T:Torsor ℤ}
-           (P:T->Type) (IH:Π t, weq (P t) (P (one + t))) := fun
+           (P:T->Type) (IH:∏ t, weq (P t) (P (one + t))) := fun
      f:Section P =>
-       Π t, f (one + t) = IH t (f t).
+       ∏ t, f (one + t) = IH t (f t).
 
 Definition ℤTorsorRecursion_weq {T:Torsor ℤ} (P:T->Type)
-      (IH:Π t, weq (P t) (P (one + t))) (t0:T) :
+      (IH:∏ t, weq (P t) (P (one + t))) (t0:T) :
   weq (total2 (GuidedSection P IH)) (P t0).
 Proof. intros. exists (fun fh => pr1 fh t0). intro q.
        set (w := triviality_isomorphism T t0).
-       assert (k0 : Π i, one + w i = w (1+i)%hz).
+       assert (k0 : ∏ i, one + w i = w (1+i)%hz).
        { intros. simpl. unfold right_mult, ac_mult. rewrite act_assoc.
          reflexivity. }
        set (l0 := (fun i => eqweqmap (ap P (k0 i)))
-               : Π i, weq (P(one + w i)) (P(w(1+i)%hz))).
+               : ∏ i, weq (P(one + w i)) (P(w(1+i)%hz))).
        assert( e : right_mult t0 zero = t0 ). { apply act_unit. }
-       set (H := fun f => Π t : T, f (one + t) = (IH t) (f t)).
+       set (H := fun f => ∏ t : T, f (one + t) = (IH t) (f t)).
        set ( IH' := (fun i => weqcomp (IH (w i)) (l0 i))
-                    : Π i:ℤ, weq (P (w i)) (P (w(1+i)%hz))).
-       set (J := fun f => Π i : ℤ, f (1 + i)%hz = (IH' i) (f i)).
+                    : ∏ i:ℤ, weq (P (w i)) (P (w(1+i)%hz))).
+       set (J := fun f => ∏ i : ℤ, f (1 + i)%hz = (IH' i) (f i)).
        simple refine (iscontrweqb (@weq_over_sections ℤ T w 0 t0 e P q (e#'q) _ H J _) _).
        { apply transportfbinv. }
        { intro. apply invweq. unfold H,J,maponsec1. simple refine (weqonsec _ _ w _).
@@ -235,13 +235,13 @@ Proof. intros. exists (fun fh => pr1 fh t0). intro q.
 Defined.
 
 Definition ℤTorsorRecursion_compute {T:Torsor ℤ} (P:T->Type)
-      (IH:Π t, weq (P t) (P (one + t))) t h :
+      (IH:∏ t, weq (P t) (P (one + t))) t h :
   ℤTorsorRecursion_weq P IH t h = pr1 h t.
 Proof. reflexivity.             (* don't change the proof *)
 Defined.
 
 Definition ℤTorsorRecursion_inv_compute {T:Torsor ℤ} (P:T->Type)
-      (IH:Π t, weq (P t) (P (one + t)))
+      (IH:∏ t, weq (P t) (P (one + t)))
       (t0:T) (h0:P t0) :
   pr1 (invmap (ℤTorsorRecursion_weq P IH t0) h0) t0 = h0.
 Proof. intros.
@@ -251,7 +251,7 @@ Proof. intros.
                 homotweqinvweq (ℤTorsorRecursion_weq P IH t0) h0). Defined.
 
 Definition ℤTorsorRecursion_transition {T:Torsor ℤ} (P:T->Type)
-      (IH:Π t, weq (P t) (P (one + t)))
+      (IH:∏ t, weq (P t) (P (one + t)))
       (t:T)
       (h:total2 (GuidedSection P IH)) :
   ℤTorsorRecursion_weq P IH (one+t) h
@@ -260,9 +260,9 @@ Definition ℤTorsorRecursion_transition {T:Torsor ℤ} (P:T->Type)
 Proof. intros. rewrite 2!ℤTorsorRecursion_compute. exact (pr2 h t). Defined.
 
 Definition ℤTorsorRecursion_transition_inv {T:Torsor ℤ} (P:T->Type)
-      (IH:Π t, weq (P t) (P (one + t)))
+      (IH:∏ t, weq (P t) (P (one + t)))
       (t:T) :
-  Π h0,
+  ∏ h0,
   invmap (ℤTorsorRecursion_weq P IH t) h0
   =
   invmap (ℤTorsorRecursion_weq P IH (one+t)) (IH t h0).
@@ -273,7 +273,7 @@ Proof. intros.
        rewrite homotinvweqweq. reflexivity. Defined.
 
 Definition ℤTorsorRecursion {T:Torsor ℤ} (P:T->Type)
-      (IH:Π t, weq (P t) (P (one + t)))
+      (IH:∏ t, weq (P t) (P (one + t)))
       (t t':T) :
   weq (P t) (P t').
 Proof. intros.
@@ -294,10 +294,10 @@ Proof. intros.
 
  *)
 
-Definition target_paths {Y} {T:Torsor ℤ} (f:T->Y) := Π t, f t=f(one + t).
+Definition target_paths {Y} {T:Torsor ℤ} (f:T->Y) := ∏ t, f t=f(one + t).
 
 Definition GHomotopy {Y} {T:Torsor ℤ} (f:T->Y) (s:target_paths f) := fun
-        y:Y => Σ h:nullHomotopyFrom f y, Π n, h(one + n) = h n @ s n.
+        y:Y => ∑ h:nullHomotopyFrom f y, ∏ n, h(one + n) = h n @ s n.
 
 Definition GuidedHomotopy {Y} {T:Torsor ℤ} (f:T->Y) (s:target_paths f) :=
   total2 (GHomotopy f s).
@@ -319,7 +319,7 @@ Definition GH_equations {Y} {T:Torsor ℤ} (f:T->Y) (s:target_paths f)
            (yhp : GuidedHomotopy f s)
      := pr2 (pr2 yhp)
      : let h := GH_homotopy yhp in
-       Π n, h(one + n) = h n @ s n.
+       ∏ n, h(one + n) = h n @ s n.
 
 Theorem iscontrGuidedHomotopy {Y} (T:Torsor ℤ) (f:T->Y) (s:target_paths f) :
   iscontr (GuidedHomotopy f s).
@@ -328,20 +328,20 @@ Proof. intros. apply (squash_to_prop (torsor_nonempty T)).
        (* A better proof would construct the center explicitly now
           using [makeGuidedHomotopy] below.  Or we could replace this theorem
           by a corollary of it, with the new center. *)
-       apply ( iscontrweqb (Y := Σ y:Y, y = f t0)).
+       apply ( iscontrweqb (Y := ∑ y:Y, y = f t0)).
        { apply weqfibtototal; intro y.
          exact (ℤTorsorRecursion_weq _ (fun t => weq_pathscomp0r _ _) t0). }
        apply iscontrcoconustot. Defined.
 
 Corollary proofirrGuidedHomotopy {Y} (T:Torsor ℤ) (f:T->Y) (s:target_paths f) :
-  Π v w : GuidedHomotopy f s, v=w.
+  ∏ v w : GuidedHomotopy f s, v=w.
 Proof. (* later give a more direct proof *)
        intros. apply proofirrelevancecontr. apply iscontrGuidedHomotopy. Defined.
 
 Definition iscontrGuidedHomotopy_comp_1 {Y} :
   let T := trivialTorsor ℤ in
   let t0 := 0 : T in
-    Π (f:T->Y) (s:target_paths f),
+    ∏ (f:T->Y) (s:target_paths f),
       GH_point (thePoint (iscontrGuidedHomotopy T f s)) = f t0.
 Proof. reflexivity.             (* don't change the proof *)
 Defined.
@@ -349,7 +349,7 @@ Defined.
 Definition iscontrGuidedHomotopy_comp_2 {Y} :
   let T := trivialTorsor ℤ in
   let t0 := 0 : T in
-    Π (f:T->Y) (s:target_paths f),
+    ∏ (f:T->Y) (s:target_paths f),
         (GH_homotopy (thePoint (iscontrGuidedHomotopy T f s)) t0) =
         (idpath (f t0)).
 Proof. intros.
@@ -386,7 +386,7 @@ Defined.
 (* Definition iscontrGuidedHomotopy_comp_3 {Y} : *)
 (*   let T := trivialTorsor ℤ in  *)
 (*   let t0 := 0 : T in *)
-(*     Π (f:T->Y) (s:target_paths f), *)
+(*     ∏ (f:T->Y) (s:target_paths f), *)
 (*       GH_to_cone t0 (thePoint (iscontrGuidedHomotopy T f s)) = f t0,, idpath (f t0). *)
 (* Proof. intros. *)
 
@@ -477,11 +477,11 @@ Proof. intros ? ? ? ? t'.
        exact (makeGuidedHomotopy1 f s t). Defined.
 
 Definition map_path {T:Torsor ℤ} {Y} (f:T->Y) (s:target_paths f) :
-  Π t, map f s (squash_element t) = map f s (squash_element (one + t)).
+  ∏ t, map f s (squash_element t) = map f s (squash_element (one + t)).
 Proof. intros. exact (makeGuidedHomotopy_diagonalPath f s t). Defined.
 
 Definition map_path_check {T:Torsor ℤ} {Y} (f:T->Y) (s:target_paths f) :
-  Π t, Π p : map f s (squash_element t) =
+  ∏ t, ∏ p : map f s (squash_element t) =
                        map f s (squash_element (one + t)),
     ap pr1 p = s t.
 Proof. intros. set (q := map_path f s t). assert (k : q=p).

--- a/UniMath/Ktheory/Bifunctor.v
+++ b/UniMath/Ktheory/Bifunctor.v
@@ -23,7 +23,7 @@ Definition comm_functor_data {I A B:Precategory} :
   := λ D a, functor_data_constr I B (λ i, D ◾ i ◾ a) (λ i j e, D ▭ e ◽ a).
 
 Lemma isfunctor_comm_functor_data {I A B:Precategory} :
-  Π (D:[I,[A,B]]) (a:A), is_functor (comm_functor_data D a).
+  ∏ (D:[I,[A,B]]) (a:A), is_functor (comm_functor_data D a).
 Proof.
   split.
   { unfold functor_idax. intro i; simpl. unfold functor_mor_application.
@@ -115,14 +115,14 @@ Proof.
                 | intro b; simpl; now rewrite id_right, id_left]]) using _N_. }
 Defined.
 
-Lemma transport_along_funextsec {X:UU} {Y:X->UU} {f g:Π x, Y x}
+Lemma transport_along_funextsec {X:UU} {Y:X->UU} {f g:∏ x, Y x}
       (e:f~g) (x:X) : transportf _ (funextsec _ _ _ e) (f x) = g x.
 Proof. now induction (funextsec _ _ _ e). Defined.
 
 Definition Functor_eq_map {A B: Precategory} (F G:[A,B]) :
   F = G ->
-  Σ (ob : Π a, F ◾ a = G ◾ a),
-  Π a a' f, transportf (λ k, k --> G ◾ a')
+  ∑ (ob : ∏ a, F ◾ a = G ◾ a),
+  ∏ a a' f, transportf (λ k, k --> G ◾ a')
                        (ob a)
                        (transportf (λ k, F ◾ a --> k)
                                    (ob a')
@@ -142,13 +142,13 @@ Proof.
 Abort.
 
 Hypothesis Functor_eq_map_isweq :
-  Π (A B: Precategory) (F G:[A,B]), isweq (Functor_eq_map F G).
+  ∏ (A B: Precategory) (F G:[A,B]), isweq (Functor_eq_map F G).
 Arguments Functor_eq_map_isweq {_ _ _ _} _.
 
 Lemma Functor_eq_weq {A B: Precategory} (F G:[A,B]) :
   F = G ≃
-  Σ (ob : Π a, F ◾ a = G ◾ a),
-  Π a a' f, transportf (λ k, k --> G ◾ a')
+  ∑ (ob : ∏ a, F ◾ a = G ◾ a),
+  ∏ a a' f, transportf (λ k, k --> G ◾ a')
                        (ob a)
                        (transportf (λ k, F ◾ a --> k)
                                    (ob a')
@@ -158,8 +158,8 @@ Proof.
 Defined.
 
 Lemma Functor_eq {A B: Precategory} {F G:[A,B]}
-      (ob : Π a, F ◾ a = G ◾ a)
-      (mor : Π a a' f, transportf (λ k, k --> G ◾ a')
+      (ob : ∏ a, F ◾ a = G ◾ a)
+      (mor : ∏ a a' f, transportf (λ k, k --> G ◾ a')
                                   (ob a)
                                   (transportf (λ k, F ◾ a --> k)
                                               (ob a')
@@ -188,14 +188,14 @@ End Working.
 (** bifunctors related to representable functors  *)
 
 Definition θ_1 {B C:Precategory} (F : [B, C]) (X : [B, [C^op, SET]]) : hSet
-  := (Π b, F ◾ b ⇒ X ◾ b) % set.
+  := (∏ b, F ◾ b ⇒ X ◾ b) % set.
 
 Definition θ_2 {B C:Precategory} (F : [B, C]) (X : [B, [C^op, SET]])
            (x : θ_1 F X) : hSet
-  := (Π (b' b:B) (f:b'-->b), x b ⟲ F ▭ f = X ▭ f ⟳ x b' ) % set.
+  := (∏ (b' b:B) (f:b'-->b), x b ⟲ F ▭ f = X ▭ f ⟳ x b' ) % set.
 
 Definition θ {B C:Precategory} (F : [B, C]) (X : [B, [C^op, SET]]) : hSet
-  := ( Σ x : θ_1 F X, θ_2 F X x ) % set.
+  := ( ∑ x : θ_1 F X, θ_2 F X x ) % set.
 
 Notation "F ⟹ X" := (θ F X) (at level 50) : cat.
 

--- a/UniMath/Ktheory/Circle.v
+++ b/UniMath/Ktheory/Circle.v
@@ -35,7 +35,7 @@ Proof. intros. unfold circle_loop. rewrite pathsinv0inv0.
 Definition ZGuidedHomotopy {Y} {y:Y} (l:y = y) (T:Torsor ℤ) :=
   GuidedHomotopy (confun T y) (confun T l).
 
-Definition GH {Y} {y:Y} (l:y = y) := Σ T:Torsor ℤ, ZGuidedHomotopy l T.
+Definition GH {Y} {y:Y} (l:y = y) := ∑ T:Torsor ℤ, ZGuidedHomotopy l T.
 
 Definition GHpair {Y} {y:Y} (l:y = y) (T:Torsor ℤ) (g:ZGuidedHomotopy l T) :=
   T,,g : GH l.
@@ -254,7 +254,7 @@ Proof. intros. assert (p := pr1_GH_weq_compute l).
 
 
 Definition circle_map' {Y:circle->Type} {y:Y(basepoint circle)}
-           (l:circle_loop#y = y) : Π c:circle, Y c.
+           (l:circle_loop#y = y) : ∏ c:circle, Y c.
 Proof. (** (not proved yet) *)
 Abort.
 
@@ -263,7 +263,7 @@ Abort.
  http://arxiv.org/abs/1402.0761 *)
 
 Lemma circle_map_check_paths'
-      (circle_map': Π (Y:circle->UU) (y:Y(basepoint circle))
+      (circle_map': ∏ (Y:circle->UU) (y:Y(basepoint circle))
            (l:circle_loop#y = y) (c:circle), Y c)
       {Y} (f:circle->Y) :
   circle_map (ap f circle_loop) = f .

--- a/UniMath/Ktheory/DirectSum.v
+++ b/UniMath/Ktheory/DirectSum.v
@@ -15,7 +15,7 @@ Require UniMath.Ktheory.RawMatrix.
 Local Open Scope cat.
 
 Definition identity_matrix {C:Precategory} (h:hasZeroMaps C)
-           {I} (d:I -> ob C) (dec : isdeceq I) : Π i j, Hom C (d j) (d i).
+           {I} (d:I -> ob C) (dec : isdeceq I) : ∏ i j, Hom C (d j) (d i).
 Proof. intros. induction (dec i j) as [ eq | ne ].
        { induction eq. apply identity. }
        { apply h. }
@@ -31,11 +31,11 @@ Proof. intros. apply RawMatrix.from_matrix. apply identity_matrix.
 Record DirectSum {C:Precategory} (h:hasZeroMaps C) I (dec : isdeceq I) (c : I -> ob C) :=
   make_DirectSum {
       ds : C;
-      ds_pr : Π i, Hom C ds (c i);
-      ds_in : Π i, Hom C (c i) ds;
-      ds_id : Π i j, ds_pr i ∘ ds_in j = identity_matrix h c dec i j;
-      ds_isprod : Π c, isweq (λ f : Hom C c ds, λ i, ds_pr i ∘ f);
-      ds_issum  : Π c, isweq (λ f : Hom C ds c, λ i, f ∘ ds_in i) }.
+      ds_pr : ∏ i, Hom C ds (c i);
+      ds_in : ∏ i, Hom C (c i) ds;
+      ds_id : ∏ i j, ds_pr i ∘ ds_in j = identity_matrix h c dec i j;
+      ds_isprod : ∏ c, isweq (λ f : Hom C c ds, λ i, ds_pr i ∘ f);
+      ds_issum  : ∏ c, isweq (λ f : Hom C ds c, λ i, f ∘ ds_in i) }.
 Definition toDirectSum {C:Precategory} (h:hasZeroMaps C) {I} (dec : isdeceq I) (d:I -> ob C)
            (B:Sum d) (D:Product d)
            (is: is_isomorphism (identity_map h dec B D)) : DirectSum h I dec d.
@@ -56,7 +56,7 @@ Proof. intros. set (id := identity_map h dec B D).
                       (pr2 (universalProperty B c))). }
 Defined.
 Definition FiniteDirectSums (C:Precategory) :=
-             Σ h : hasZeroMaps C,
-             Π I : FiniteSet,
-             Π d : I -> ob C,
+             ∑ h : hasZeroMaps C,
+             ∏ I : FiniteSet,
+             ∏ d : I -> ob C,
                DirectSum h I (isfinite_isdeceq I (pr2 I)) d.

--- a/UniMath/Ktheory/Elements.v
+++ b/UniMath/Ktheory/Elements.v
@@ -8,9 +8,9 @@ Require Export UniMath.Ktheory.Precategories.
 Local Open Scope cat.
 
 Definition cat_ob_mor {C} (X:C==>SET) : precategory_ob_mor.
-  intros. exists (Σ c:ob C, X c : hSet).
+  intros. exists (∑ c:ob C, X c : hSet).
   intros a b.
-  exact (Σ f : pr1 a --> pr1 b, #X f (pr2 a) = (pr2 b)).
+  exact (∑ f : pr1 a --> pr1 b, #X f (pr2 a) = (pr2 b)).
 Defined.
 
 Definition cat_data {C} (X:C==>SET) : precategory_data.

--- a/UniMath/Ktheory/ElementsOp.v
+++ b/UniMath/Ktheory/ElementsOp.v
@@ -10,9 +10,9 @@ Require Export UniMath.Ktheory.Precategories.
 Local Open Scope cat.
 
 Definition cat_ob_mor {C} (X:C^op==>SET) : precategory_ob_mor.
-  intros. exists (Σ c:ob C, X c : hSet).
+  intros. exists (∑ c:ob C, X c : hSet).
   intros a b.
-  exact (Σ f : pr1 a --> pr1 b, (pr2 a) = #X f (pr2 b)).
+  exact (∑ f : pr1 a --> pr1 b, (pr2 a) = #X f (pr2 b)).
 Defined.
 
 

--- a/UniMath/Ktheory/Equivalences.v
+++ b/UniMath/Ktheory/Equivalences.v
@@ -7,8 +7,8 @@ Require Import UniMath.Foundations.UnivalenceAxiom.
 Require Import UniMath.Ktheory.Tactics.
 
 Definition Equivalence X Y :=
-  Σ (f:X->Y) (g:Y->X) (p:Π y, f(g y) = y) (q:Π x, g(f x) = x),
-      Π x, ap f (q x) = p(f x).
+  ∑ (f:X->Y) (g:Y->X) (p:∏ y, f(g y) = y) (q:∏ x, g(f x) = x),
+      ∏ x, ap f (q x) = p(f x).
 
 Notation "X ≅ Y" := (Equivalence X Y) (at level 60, no associativity) : type_scope.
 
@@ -21,14 +21,14 @@ Coercion Equivalence_toFunction : Equivalence >-> Funclass.
 Definition Equivalence_toInverseFunction {X Y} : X≅Y -> Y->X.
 Proof. intros ? ? f. exact (pr1 (pr2 f)). Defined.
 
-Definition Equivalence_toTargetHomotopy {X Y} (f:Equivalence X Y) : Π y, f (Equivalence_toInverseFunction f y) = y
+Definition Equivalence_toTargetHomotopy {X Y} (f:Equivalence X Y) : ∏ y, f (Equivalence_toInverseFunction f y) = y
   := pr1 (pr2 (pr2 f)).
 
-Definition Equivalence_toSourceHomotopy {X Y} (f:Equivalence X Y) : Π x, Equivalence_toInverseFunction f (f x) = x
+Definition Equivalence_toSourceHomotopy {X Y} (f:Equivalence X Y) : ∏ x, Equivalence_toInverseFunction f (f x) = x
   := pr1 (pr2 (pr2 (pr2 f))).
 
 Definition Equivalence_toAdjointness {X Y} (f:Equivalence X Y)
-  : Π x, ap f (Equivalence_toSourceHomotopy f x) = Equivalence_toTargetHomotopy f (f x)
+  : ∏ x, ap f (Equivalence_toSourceHomotopy f x) = Equivalence_toTargetHomotopy f (f x)
   := pr2 (pr2 (pr2 (pr2 f))).
 
 Lemma transportf_fun_idpath {X Y} {f:X->Y} x x' (w:x = x') (t:f x = f x) :
@@ -145,10 +145,10 @@ Local Notation "p @' q" := (pathscomp0 p q) (only parsing, at level 61, left ass
 Local Arguments idpath {_ _}.
 
 Lemma other_adjoint {X Y} (f : X -> Y) (g : Y -> X)
-      (p : Π y : Y, f (g y) = y)
-      (q : Π x : X, g (f x) = x)
-      (h : Π x : X, ap f (q x) = p (f x)) :
- Π y : Y, ap g (p y) = q (g y).
+      (p : ∏ y : Y, f (g y) = y)
+      (q : ∏ x : X, g (f x) = x)
+      (h : ∏ x : X, ap f (q x) = p (f x)) :
+ ∏ y : Y, ap g (p y) = q (g y).
 Proof. intros. apply pathsinv0.
        intermediate_path (
             !(ap g (p (f (g y))))

--- a/UniMath/Ktheory/Group.v
+++ b/UniMath/Ktheory/Group.v
@@ -60,18 +60,18 @@ Module Presentation.
 
   Record AdequateRelation {X I} (R:I->reln X) (r : hrel (word X)) :=
     make_AdequateRelation {
-        base: Π i, r (lhs (R i)) (rhs (R i));
-        reflex : Π w, r w w;
-        symm : Π v w, r v w -> r w v;
-        trans : Π u v w, r u v -> r v w -> r u w;
-        left_compat : Π u v w, r v w -> r (word_op u v) (word_op u w);
-        right_compat: Π u v w, r u v -> r (word_op u w) (word_op v w);
-        left_unit : Π w, r (word_op word_unit w) w;
-        right_unit : Π w, r (word_op w word_unit) w;
-        assoc : Π u v w, r (word_op (word_op u v) w) (word_op u (word_op v w));
-        inverse_compat : Π v w, r v w -> r (word_inv v) (word_inv w);
-        left_inverse : Π w, r (word_op (word_inv w) w) word_unit;
-        right_inverse: Π w, r (word_op w (word_inv w)) word_unit
+        base: ∏ i, r (lhs (R i)) (rhs (R i));
+        reflex : ∏ w, r w w;
+        symm : ∏ v w, r v w -> r w v;
+        trans : ∏ u v w, r u v -> r v w -> r u w;
+        left_compat : ∏ u v w, r v w -> r (word_op u v) (word_op u w);
+        right_compat: ∏ u v w, r u v -> r (word_op u w) (word_op v w);
+        left_unit : ∏ w, r (word_op word_unit w) w;
+        right_unit : ∏ w, r (word_op w word_unit) w;
+        assoc : ∏ u v w, r (word_op (word_op u v) w) (word_op u (word_op v w));
+        inverse_compat : ∏ v w, r v w -> r (word_inv v) (word_inv w);
+        left_inverse : ∏ w, r (word_op (word_inv w) w) word_unit;
+        right_inverse: ∏ w, r (word_op w (word_inv w)) word_unit
       }.
   Arguments make_AdequateRelation {X I} R r _ _ _ _ _ _ _ _ _ _ _ _.
   Arguments base {X I R r} _ _.
@@ -88,7 +88,7 @@ Module Presentation.
 
   Definition smallestAdequateRelation0 {X I} (R:I->reln X) : hrel (word X).
     intros ? ? ? v w.
-    exists (Π r: hrel (word X), AdequateRelation R r -> r v w).
+    exists (∏ r: hrel (word X), AdequateRelation R r -> r v w).
     abstract (apply impred; intro r; apply impred_prop).
   Defined.
   Lemma adequacy {X I} (R:I->reln X) :
@@ -168,7 +168,7 @@ Module Presentation.
          apply (squash_to_prop (lift R w') ig); intros [w []].
          exact (iscompsetquotpr e _ _ (fun r ra => assoc R r ra u v w)). Qed.
   Lemma is_left_inverse_univ_binop {X I} (R:I->reln X) :
-    Π w:setquot (smallestAdequateRelation0 R),
+    ∏ w:setquot (smallestAdequateRelation0 R),
       univ_binop R (univ_inverse R w) w =
       setquotpr (smallestAdequateRelation R) word_unit.
   Proof. intros. isaprop_goal ig. { apply setproperty. }
@@ -176,7 +176,7 @@ Module Presentation.
     exact (iscompsetquotpr (smallestAdequateRelation R) _ _
                            (fun r ra => left_inverse R r ra v)). Qed.
   Lemma is_right_inverse_univ_binop {X I} (R:I->reln X) :
-    Π w:setquot (smallestAdequateRelation0 R),
+    ∏ w:setquot (smallestAdequateRelation0 R),
       univ_binop R w (univ_inverse R w) =
       setquotpr (smallestAdequateRelation R) word_unit.
   Proof. intros. isaprop_goal ig. { apply setproperty. }
@@ -209,7 +209,7 @@ Module Presentation.
     make_MarkedGroup {
         m_base :> gr;
         m_mark : X -> m_base;
-        m_reln : Π i, evalword (toMarkedPreGroup R m_base m_mark) (lhs (R i)) =
+        m_reln : ∏ i, evalword (toMarkedPreGroup R m_base m_mark) (lhs (R i)) =
                            evalword (toMarkedPreGroup R m_base m_mark) (rhs (R i)) }.
   Arguments make_MarkedGroup {X I} R _ _ _.
   Arguments m_base {X I R} _.
@@ -237,7 +237,7 @@ Module Presentation.
   Record MarkedGroupMap {X I} {R:I->reln X} (M N:MarkedGroup R) :=
     make_MarkedGroupMap {
         map_base :> Hom M N;
-        map_mark : Π x, map_base (m_mark M x) = m_mark N x }.
+        map_mark : ∏ x, map_base (m_mark M x) = m_mark N x }.
   Arguments map_base {X I R M N} m.
   Arguments map_mark {X I R M N} m x.
   Lemma MarkedGroupMapEquality {X I} {R:I->reln X} {M N:MarkedGroup R}
@@ -303,7 +303,7 @@ Module Presentation.
                 (universalMarkedGroup3 R).
   Fixpoint agreement_on_gens0 {X I} {R:I->reln X} {M:gr}
         (f g:Hom (universalMarkedGroup R) M)
-        (p:Π i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
+        (p:∏ i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
                    g (setquotpr (smallestAdequateRelation R) (word_gen i)))
         (w:word X) :
           pr1 f (setquotpr (smallestAdequateRelation R) w) =
@@ -326,7 +326,7 @@ Module Presentation.
            { apply agreement_on_gens0. assumption. } } Qed.
   Lemma agreement_on_gens {X I} {R:I->reln X} {M:gr}
         (f g:Hom (universalMarkedGroup R) M) :
-        (Π i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
+        (∏ i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
                    g (setquotpr (smallestAdequateRelation R) (word_gen i)))
           -> f = g.
     intros ? ? ? ? ? ? p. apply Monoid.funEquality.
@@ -376,10 +376,10 @@ Module Product.
     - intro y. apply funextsec; intro i. apply grrinvax. Defined.
   Definition Proj {I} (X:I->gr) (i:I) : Hom (make X) (X i).
     intros. exact (Monoid.Product.Proj X i). Defined.
-  Definition Fun {I} (X:I->gr) (T:gr) (g: Π i, Hom T (X i)) : Hom T (make X).
+  Definition Fun {I} (X:I->gr) (T:gr) (g: ∏ i, Hom T (X i)) : Hom T (make X).
     intros. exact (Monoid.Product.Fun X T g). Defined.
-  Definition Eqn {I} (X:I->gr) (T:gr) (g: Π i, Hom T (X i))
-             : Π i, Proj X i ∘ Fun X T g = g i.
+  Definition Eqn {I} (X:I->gr) (T:gr) (g: ∏ i, Hom T (X i))
+             : ∏ i, Proj X i ∘ Fun X T g = g i.
     intros. apply Monoid.funEquality. reflexivity. Qed.
 End Product.
 Module Free.

--- a/UniMath/Ktheory/GroupAction.v
+++ b/UniMath/Ktheory/GroupAction.v
@@ -78,16 +78,16 @@ Definition action_op G X := G -> X -> X.
 Record ActionStructure (G:gr) (X:hSet) :=
   make {
       act_mult : action_op G X;
-      act_unit : Π x, act_mult (unel _) x = x;
-      act_assoc : Π g h x, act_mult (op g h) x = act_mult g (act_mult h x)
+      act_unit : ∏ x, act_mult (unel _) x = x;
+      act_assoc : ∏ g h x, act_mult (op g h) x = act_mult g (act_mult h x)
     }.
 Arguments act_mult {G _} _ g x.
 
 Module Pack.
   Definition ActionStructure' (G:gr) (X:hSet) :=
-         Σ act_mult : action_op G X,
-         Σ act_unit : Π x, act_mult (unel _) x = x,
-      (* act_assoc : *) Π g h x, act_mult (op g h) x = act_mult g (act_mult h x).
+         ∑ act_mult : action_op G X,
+         ∑ act_unit : ∏ x, act_mult (unel _) x = x,
+      (* act_assoc : *) ∏ g h x, act_mult (op g h) x = act_mult g (act_mult h x).
   Definition pack {G:gr} {X:hSet} : ActionStructure' G X -> ActionStructure G X
     := fun ac => make G X (pr1 ac) (pr1 (pr2 ac)) (pr2 (pr2 ac)).
   Definition unpack {G:gr} {X:hSet} : ActionStructure G X -> ActionStructure' G X
@@ -124,13 +124,13 @@ Definition ac_mult {G:gr} (X:Action G) := act_mult (pr2 X).
 Delimit Scope action_scope with action.
 Local Notation "g * x" := (ac_mult _ g x) : action_scope.
 Open Scope action_scope.
-Definition ac_assoc {G:gr} (X:Action G) := act_assoc _ _ (pr2 X) : Π g h x, (op g h)*x = g*(h*x).
+Definition ac_assoc {G:gr} (X:Action G) := act_assoc _ _ (pr2 X) : ∏ g h x, (op g h)*x = g*(h*x).
 
 Definition right_mult {G:gr} {X:Action G} (x:X) := fun g => g*x.
 Definition left_mult {G:gr} {X:Action G} (g:G) := fun x:X => g*x.
 
 Definition is_equivariant {G:gr} {X Y:Action G} (f:X->Y) :=
-  Π g x, f (g*x) = g*(f x).
+  ∏ g x, f (g*x) = g*(f x).
 
 Definition is_equivariant_isaprop {G:gr} {X Y:Action G} (f:X->Y) :
   isaprop (is_equivariant f).
@@ -187,7 +187,7 @@ Proof. intros ? ? ? ? [p i] [q j]. exists (funcomp p q).
        apply is_equivariant_comp. assumption. assumption. Defined.
 
 Definition ActionIso {G:gr} (X Y:Action G) :=
-  Σ f:weq (ac_set X) (ac_set Y), is_equivariant f.
+  ∑ f:weq (ac_set X) (ac_set Y), is_equivariant f.
 
 Definition underlyingIso {G:gr} {X Y:Action G} (e:ActionIso X Y) := pr1 e : X ≃ Y.
 
@@ -272,7 +272,7 @@ Proof. intros. exact (eqtohomot
 (** ** Torsors *)
 
 Definition is_torsor {G:gr} (X:Action G) :=
-  nonempty X × Π x:X, isweq (right_mult x).
+  nonempty X × ∏ x:X, isweq (right_mult x).
 
 Lemma is_torsor_isaprop {G:gr} (X:Action G) : isaprop (is_torsor X).
 Proof. intros. apply isapropdirprod. { apply propproperty. }
@@ -315,7 +315,7 @@ Definition underlyingAction_injectivity_inv_comp {G:gr} {X Y:Torsor G}
   ap underlyingAction (invmap underlyingAction_injectivity f) = f.
 Proof. intros. apply (homotweqinvweq underlyingAction_injectivity f). Defined.
 
-Definition PointedTorsor (G:gr) := Σ X:Torsor G, X.
+Definition PointedTorsor (G:gr) := ∑ X:Torsor G, X.
 Definition underlyingTorsor {G} (X:PointedTorsor G) := pr1 X : Torsor G.
 Coercion underlyingTorsor : PointedTorsor >-> Torsor.
 Definition underlyingPoint {G} (X:PointedTorsor G) := pr2 X : X.
@@ -449,7 +449,7 @@ Definition torsor_eqweq_to_path {G:gr} {X Y:Torsor G} : ActionIso X Y -> X = Y.
 Proof. intros ? ? ? f. exact ((invweq Torsor_univalence) f). Defined.
 
 Definition PointedActionIso {G:gr} (X Y:PointedTorsor G)
-    := Σ f:ActionIso X Y, f (underlyingPoint X) = underlyingPoint Y.
+    := ∑ f:ActionIso X Y, f (underlyingPoint X) = underlyingPoint Y.
 
 Definition pointed_triviality_isomorphism {G:gr} (X:PointedTorsor G) :
   PointedActionIso (pointedTrivialTorsor G) X.

--- a/UniMath/Ktheory/Halfline.v
+++ b/UniMath/Ktheory/Halfline.v
@@ -6,10 +6,10 @@ Require UniMath.CategoryTheory.precategories.
 Require UniMath.Ktheory.Nat.
 Notation ℕ := nat.
 
-Definition target_paths {Y} (f:ℕ->Y) := Π n, f n=f(S n).
+Definition target_paths {Y} (f:ℕ->Y) := ∏ n, f n=f(S n).
 
 Definition gHomotopy {Y} (f:ℕ->Y) (s:target_paths f) := fun
-     y:Y => Σ (h:nullHomotopyFrom f y), Π n, h(S n) = h n @ s n.
+     y:Y => ∑ (h:nullHomotopyFrom f y), ∏ n, h(S n) = h n @ s n.
 
 Definition GuidedHomotopy {Y} (f:ℕ->Y) (s:target_paths f) :=
   total2 (gHomotopy f s).
@@ -17,7 +17,7 @@ Definition GuidedHomotopy {Y} (f:ℕ->Y) (s:target_paths f) :=
 Theorem iscontrGuidedHomotopy {Y} {f:ℕ->Y} (s:target_paths f) :
   iscontr (GuidedHomotopy f s).
 Proof. intros. unfold GuidedHomotopy, nullHomotopyFrom.
-       refine (@iscontrweqb _ (Σ y, y=f 0) _ _).
+       refine (@iscontrweqb _ (∑ y, y=f 0) _ _).
        { apply weqfibtototal. intro y.
          exact (Nat.Uniqueness.hNatRecursion_weq
                   (fun n => y = f n) (fun n hn => hn @ s n)). }
@@ -38,12 +38,12 @@ Proof. intros ? ? ? r. apply (squash_to_prop r).
          { exact (transportf (gHomotopy f s) (s n) IHn). } } Defined.
 
 Definition map_path {Y} {f:ℕ->Y} (s:target_paths f) :
-  Π n, map s (squash_element n) = map s (squash_element (S n)).
+  ∏ n, map s (squash_element n) = map s (squash_element (S n)).
 Proof. intros. apply (total2_paths2 (s n)).
        simpl. reflexivity. Defined.
 
 Definition map_path_check {Y} {f:ℕ->Y} (s:target_paths f) (n:ℕ) :
-  Π p : map s (squash_element n) = map s (squash_element (S n)),
+  ∏ p : map s (squash_element n) = map s (squash_element (S n)),
     ap pr1 p = s n.
 Proof. intros. set (q := map_path s n).
        assert (path_inverse_to_right : q=p).

--- a/UniMath/Ktheory/Integers.v
+++ b/UniMath/Ktheory/Integers.v
@@ -39,8 +39,8 @@ Lemma hzsign_hzsign (i:hz) : - - i = i.
 Proof. apply (grinvinv ℤ). Defined.
 
 Definition hz_normal_form (i:ℤ) :=
-  coprod (Σ n, natnattohz n 0 = i)
-         (Σ n, natnattohz 0 (S n) = i).
+  coprod (∑ n, natnattohz n 0 = i)
+         (∑ n, natnattohz 0 (S n) = i).
 
 Definition hznf_pos n := _,, inl (n,,idpath _) : total2 hz_normal_form.
 
@@ -76,13 +76,13 @@ Proof. apply isweqpr1; intro i.
        exists (hz_to_normal_form i).
        generalize (hz_to_normal_form i) as s.
        intros [[m p]|[m p]] [[n q]|[n q]].
-       { apply (ap (@ii1 (Σ n, natnattohz n 0 = i)
-                         (Σ n, natnattohz 0 (S n) = i))).
+       { apply (ap (@ii1 (∑ n, natnattohz n 0 = i)
+                         (∑ n, natnattohz 0 (S n) = i))).
          apply (proofirrelevance _ (isinclnattohz i)). }
        { apply fromempty. assert (r := p@!q); clear p q. apply (hzdichot r). }
        { apply fromempty. assert (r := q@!p); clear p q. apply (hzdichot r). }
-       { apply (ap (@ii2 (Σ n, natnattohz n 0 = i)
-                         (Σ n, natnattohz 0 (S n) = i))).
+       { apply (ap (@ii2 (∑ n, natnattohz n 0 = i)
+                         (∑ n, natnattohz 0 (S n) = i))).
          assert (p' := ap hzsign p). assert (q' := ap hzsign q).
          change (- natnattohz O (S m)) with  (nattohz (S m)) in p'.
          change (- natnattohz O (S n)) with  (nattohz (S n)) in q'.

--- a/UniMath/Ktheory/Interval.v
+++ b/UniMath/Ktheory/Interval.v
@@ -16,8 +16,8 @@ Proof. intros ? ? ? e. set (f := fun t:bool => if t then y else y').
        truncation, but notice that propositional truncation uses functional
        extensionality for functions, already. *)
 
-Definition funextsec2 X (Y:X->Type) (f g:Π x,Y x) :
-           (Π x, f x = g x) -> f = g.
+Definition funextsec2 X (Y:X->Type) (f g:∏ x,Y x) :
+           (∏ x, f x = g x) -> f = g.
 Proof. intros ? ? ? ? e.
        exact (maponpaths (fun h x => interval_map (e x) h) interval_path).
 Defined.

--- a/UniMath/Ktheory/Magma.v
+++ b/UniMath/Ktheory/Magma.v
@@ -25,15 +25,15 @@ Module Product.
     intros.
     exists (Section X,,i1 X). exact (fun v w i => v i * w i). Defined.
   (** the projection maps *)
-  Definition Proj {I} (X:I->setwithbinop) : Π i:I, Hom (make X) (X i).
+  Definition Proj {I} (X:I->setwithbinop) : ∏ i:I, Hom (make X) (X i).
     intros. exists (fun y => y i). intros a b. reflexivity. Defined.
   (** the universal map *)
   Definition Fun {I} (X:I->setwithbinop) (T:setwithbinop)
-             (g: Π i, Hom T (X i))
+             (g: ∏ i, Hom T (X i))
              : Hom T (make X).
     intros. exists (fun t i => g i t).
     intros t u. apply funextsec; intro i. apply (pr2 (g i)). Defined.
-  Definition Eqn {I} (X:I->setwithbinop) (T:setwithbinop) (g: Π i, Hom T (X i))
-             : Π i, Proj X i ∘ Fun X T g = g i.
+  Definition Eqn {I} (X:I->setwithbinop) (T:setwithbinop) (g: ∏ i, Hom T (X i))
+             : ∏ i, Proj X i ∘ Fun X T g = g i.
     intros. apply funEquality. reflexivity. Qed.
 End Product.

--- a/UniMath/Ktheory/MetricTree.v
+++ b/UniMath/Ktheory/MetricTree.v
@@ -14,12 +14,12 @@ Record Tree :=
   make {
       mt_set:> Type;
       mt_dist: mt_set -> mt_set -> nat;
-      mt_refl: Π x, mt_dist x x = 0;
-      mt_anti: Π x y, mt_dist x y = 0 -> x = y;
-      mt_symm: Π x y, mt_dist x y = mt_dist y x;
-      mt_trans: Π x y z, mt_dist x z <= mt_dist x y + mt_dist y z;
-      mt_step: Π x z, x != z ->
-                      Σ y, (S (mt_dist x y) = mt_dist x z) × (mt_dist y z = 1)
+      mt_refl: ∏ x, mt_dist x x = 0;
+      mt_anti: ∏ x y, mt_dist x y = 0 -> x = y;
+      mt_symm: ∏ x y, mt_dist x y = mt_dist y x;
+      mt_trans: ∏ x y z, mt_dist x z <= mt_dist x y + mt_dist y z;
+      mt_step: ∏ x z, x != z ->
+                      ∑ y, (S (mt_dist x y) = mt_dist x z) × (mt_dist y z = 1)
     }.
 
 Lemma mt_path_refl (T:Tree) (x y:T) : x = y -> mt_dist _ x y = 0.
@@ -37,10 +37,10 @@ Definition step (T:Tree) {x z:T} (ne:x != z) : T := pr1 (mt_step _ x z ne).
 
 Definition tree_induction (T:Tree) (x:T) (P:T->Type)
            (p0 : P x)
-           (pn : Π z (ne:x != z), P (step T ne) -> P z) :
-  Π z, P z.
+           (pn : ∏ z (ne:x != z), P (step T ne) -> P z) :
+  ∏ z, P z.
 Proof. intros ? ? ? ? ?.
-       assert(d_ind : Π n z, mt_dist _ x z = n -> P z).
+       assert(d_ind : ∏ n z, mt_dist _ x z = n -> P z).
        { intros ?.
          induction n as [|n IH].
          { intros. assert (k:x=z).

--- a/UniMath/Ktheory/Monoid.v
+++ b/UniMath/Ktheory/Monoid.v
@@ -62,14 +62,14 @@ Module Presentation'.
   Definition make_reln {X} : word X -> word X -> reln X := fun v w => v,,w.
 
   Definition isAdequateRelation {X I} (R:I->reln X) (r : eqrel (word X)) :=
-        (* base         *) (Π i, r (lhs (R i)) (rhs (R i))) ×
-        (* left_compat  *) (Π u v w, r v w -> r (word_op u v) (word_op u w)) ×
-        (* right_compat *) (Π u v w, r u v -> r (word_op u w) (word_op v w)).
+        (* base         *) (∏ i, r (lhs (R i)) (rhs (R i))) ×
+        (* left_compat  *) (∏ u v w, r v w -> r (word_op u v) (word_op u w)) ×
+        (* right_compat *) (∏ u v w, r u v -> r (word_op u w) (word_op v w)).
   Definition base         {X I} {R:I->reln X} {r} (ad : isAdequateRelation R r) := pr1 ad.
   Definition left_compat  {X I} {R:I->reln X} {r} (ad : isAdequateRelation R r) := pr1(pr2 ad).
   Definition right_compat {X I} {R:I->reln X} {r} (ad : isAdequateRelation R r) := pr2(pr2 ad).
 
-  Definition AdequateRelation {X I} (R:I->reln X) := Σ r, isAdequateRelation R r.
+  Definition AdequateRelation {X I} (R:I->reln X) := ∑ r, isAdequateRelation R r.
   Definition toeqrel {X I} (R:I->reln X) : AdequateRelation R -> eqrel (word X) := pr1.
   Coercion toeqrel : AdequateRelation >-> eqrel.
 
@@ -79,7 +79,7 @@ Module Presentation'.
     simple refine (_,,_).
     { simple refine (_,,_).
       { intros v w.
-        exists (Π r, isAdequateRelation R r -> r v w).
+        exists (∏ r, isAdequateRelation R r -> r v w).
         apply impred; intros r; apply impred_prop. }
       { simple refine (_,,_).
         { simple refine (_,,_).
@@ -229,15 +229,15 @@ Module Presentation.
 
   Record AdequateRelation {X I} (R:I->reln X) (r : hrel (word X)) :=
     make_AdequateRelation {
-        base: Π i, r (lhs (R i)) (rhs (R i));
-        reflex : Π w, r w w;
-        symm : Π v w, r v w -> r w v;
-        trans : Π u v w, r u v -> r v w -> r u w;
-        left_compat : Π u v w, r v w -> r (word_op u v) (word_op u w);
-        right_compat: Π u v w, r u v -> r (word_op u w) (word_op v w);
-        left_unit : Π w, r (word_op word_unit w) w;
-        right_unit : Π w, r (word_op w word_unit) w;
-        assoc : Π u v w, r (word_op (word_op u v) w) (word_op u (word_op v w))
+        base: ∏ i, r (lhs (R i)) (rhs (R i));
+        reflex : ∏ w, r w w;
+        symm : ∏ v w, r v w -> r w v;
+        trans : ∏ u v w, r u v -> r v w -> r u w;
+        left_compat : ∏ u v w, r v w -> r (word_op u v) (word_op u w);
+        right_compat: ∏ u v w, r u v -> r (word_op u w) (word_op v w);
+        left_unit : ∏ w, r (word_op word_unit w) w;
+        right_unit : ∏ w, r (word_op w word_unit) w;
+        assoc : ∏ u v w, r (word_op (word_op u v) w) (word_op u (word_op v w))
       }.
   Arguments make_AdequateRelation {X I} R r _ _ _ _ _ _ _ _ _.
   Arguments base {X I R r} _ _.
@@ -254,7 +254,7 @@ Module Presentation.
 
   Definition smallestAdequateRelation0 {X I} (R:I->reln X) : hrel (word X).
     intros ? ? ? v w.
-    exists (Π r: hrel (word X), AdequateRelation R r -> r v w).
+    exists (∏ r: hrel (word X), AdequateRelation R r -> r v w).
     abstract (apply impred; intro r; apply impred_prop).
   Defined.
   Lemma adequacy {X I} (R:I->reln X) :
@@ -346,7 +346,7 @@ Module Presentation.
     make_MarkedMonoid {
         m_base :> monoid;
         m_mark : X -> m_base;
-        m_reln : Π i, evalword (toMarkedPreMonoid R m_base m_mark) (lhs (R i)) =
+        m_reln : ∏ i, evalword (toMarkedPreMonoid R m_base m_mark) (lhs (R i)) =
                            evalword (toMarkedPreMonoid R m_base m_mark) (rhs (R i)) }.
   Arguments make_MarkedMonoid {X I} R _ _ _.
   Arguments m_base {X I R} _.
@@ -371,7 +371,7 @@ Module Presentation.
   Record MarkedMonoidMap {X I} {R:I->reln X} (M N:MarkedMonoid R) :=
     make_MarkedMonoidMap {
         map_base :> Hom M N;
-        map_mark : Π x, map_base (m_mark M x) = m_mark N x }.
+        map_mark : ∏ x, map_base (m_mark M x) = m_mark N x }.
   Arguments map_base {X I R M N} m.
   Arguments map_mark {X I R M N} m x.
   Lemma MarkedMonoidMapEquality {X I} {R:I->reln X} {M N:MarkedMonoid R}
@@ -429,7 +429,7 @@ Defined.
                 (universalMarkedMonoid3 R).
   Fixpoint agreement_on_gens0 {X I} {R:I->reln X} {M:monoid}
         (f g:Hom (universalMarkedMonoid R) M)
-        (p:Π i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
+        (p:∏ i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
                    g (setquotpr (smallestAdequateRelation R) (word_gen i)))
         (w:word X) :
           pr1 f (setquotpr (smallestAdequateRelation R) w) =
@@ -449,7 +449,7 @@ Defined.
            { apply agreement_on_gens0. assumption. } } Qed.
   Lemma agreement_on_gens {X I} {R:I->reln X} {M:monoid}
         (f g:Hom (universalMarkedMonoid R) M) :
-        (Π i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
+        (∏ i, f (setquotpr (smallestAdequateRelation R) (word_gen i)) =
                    g (setquotpr (smallestAdequateRelation R) (word_gen i)))
           -> f = g.
     intros ? ? ? ? ? ? p. apply funEquality.
@@ -506,13 +506,13 @@ Module Product.
   Definition Proj {I} (X:I->monoid) (i:I) : Hom (make X) (X i).
     intros. exists (pr1 (Magma.Product.Proj X i)). split.
     exact (pr2 (Magma.Product.Proj X i)). simpl. reflexivity. Defined.
-  Definition Fun {I} (X:I->monoid) (T:monoid) (g: Π i, Hom T (X i))
+  Definition Fun {I} (X:I->monoid) (T:monoid) (g: ∏ i, Hom T (X i))
              : Hom T (make X).
     intros.  exists (pr1 (Magma.Product.Fun X T g)).
     exists (pr2 (Magma.Product.Fun X T g)). apply funextsec; intro i.
     exact (pr2 (pr2 (g i))). Defined.
-  Definition Eqn {I} (X:I->monoid) (T:monoid) (g: Π i, Hom T (X i))
-             : Π i, Proj X i ∘ Fun X T g = g i.
+  Definition Eqn {I} (X:I->monoid) (T:monoid) (g: ∏ i, Hom T (X i))
+             : ∏ i, Proj X i ∘ Fun X T g = g i.
     intros. apply funEquality. reflexivity. Qed.
   Lemma issurjective_projection {I} (X:I->monoid) (i:I) :
     isdeceq I -> issurjective (Proj X i).

--- a/UniMath/Ktheory/MoreEquivalences.v
+++ b/UniMath/Ktheory/MoreEquivalences.v
@@ -29,7 +29,7 @@ Definition weq_pathscomp0r {X} x {y z:X} (p:y = z) : weq (x = y) (x = z).
 Proof. intros. exact (weqpair _ (isweqpathscomp0r _ p)). Defined.
 
 Definition iscontrretract_compute {X Y} (p:X->Y) (s:Y->X)
-           (eps:Π y : Y, p (s y) = y) (is:iscontr X) :
+           (eps:∏ y : Y, p (s y) = y) (is:iscontr X) :
   thePoint (iscontrretract p s eps is) = p (thePoint is).
 Proof. intros. unfold iscontrretract. destruct is as [ctr uni].
        simpl. reflexivity. Defined.
@@ -40,25 +40,25 @@ Proof. intros. unfold iscontrweqb. rewrite iscontrretract_compute.
        reflexivity. Defined.
 
 Definition compute_iscontrweqb_weqfibtototal_1 {T} {P Q:T->Type}
-           (f:Π t, weq (P t) (Q t))
+           (f:∏ t, weq (P t) (Q t))
            (is:iscontr (total2 Q)) :
   pr1 (thePoint (iscontrweqb (weqfibtototal P Q f) is)) = pr1 (thePoint is).
 Proof. intros. destruct is as [ctr uni]. reflexivity. Defined.
 
 Definition compute_pr1_invmap_weqfibtototal {T} {P Q:T->Type}
-           (f:Π t, weq (P t) (Q t))
+           (f:∏ t, weq (P t) (Q t))
            (w:total2 Q) :
   pr1 (invmap (weqfibtototal P Q f) w) = pr1 w.
 Proof. intros. reflexivity. Defined.
 
 Definition compute_pr2_invmap_weqfibtototal {T} {P Q:T->Type}
-           (f:Π t, weq (P t) (Q t))
+           (f:∏ t, weq (P t) (Q t))
            (w:total2 Q) :
   pr2 (invmap (weqfibtototal P Q f) w) = invmap (f (pr1 w)) (pr2 w).
 Proof. intros. reflexivity. Defined.
 
 Definition compute_iscontrweqb_weqfibtototal_3 {T} {P Q:T->Type}
-           (f:Π t, weq (P t) (Q t))
+           (f:∏ t, weq (P t) (Q t))
            (is:iscontr (total2 Q)) :
   ap pr1 (iscontrweqb_compute (weqfibtototal P Q f) is)
   =
@@ -69,11 +69,11 @@ Definition iscontrcoconustot_comp {X} {x:X} :
   thePoint (iscontrcoconustot X x) = x,,idpath x.
 Proof. reflexivity. Defined.
 
-Definition funfibtototal {X} (P Q:X->Type) (f:Π x:X, P x -> Q x) :
+Definition funfibtototal {X} (P Q:X->Type) (f:∏ x:X, P x -> Q x) :
   total2 P -> total2 Q.
 Proof. intros ? ? ? ? [x p]. exact (x,,f x p). Defined.
 
-Definition weqfibtototal_comp {X} (P Q:X->Type) (f:Π x:X, weq (P x) (Q x)) :
+Definition weqfibtototal_comp {X} (P Q:X->Type) (f:∏ x:X, weq (P x) (Q x)) :
   invmap (weqfibtototal P Q f) = funfibtototal Q P (fun x => invmap (f x)).
 Proof. intros. apply funextsec; intros [x q]. reflexivity. Defined.
 
@@ -86,7 +86,7 @@ Definition eqweqmapap_inv' {T} (P:T->Type) {t u:T} (e:t = u) (p:P t) :
 Proof. intros. destruct e. reflexivity. Defined.
 
 Definition weqpr1_irr_sec {X} {P:X->Type}
-           (irr:Π x (p q:P x), p = q) (sec:Section P) : weq (total2 P) X.
+           (irr:∏ x (p q:P x), p = q) (sec:Section P) : weq (total2 P) X.
 (* compare with weqpr1 *)
 Proof. intros.
        set (isc := fun x => iscontraprop1 (invproofirrelevance _ (irr x)) (sec x)).
@@ -97,7 +97,7 @@ Proof. intros.
        { intros [x p]. simpl. apply pair_path_in2_comp1. } Defined.
 
 Definition invweqpr1_irr_sec {X} {P:X->Type}
-           (irr:Π x (p q:P x), p = q) (sec:Section P) : X ≃ (total2 P).
+           (irr:∏ x (p q:P x), p = q) (sec:Section P) : X ≃ (total2 P).
 (* compare with weqpr1 *)
 Proof. intros.
        set (isc := fun x => iscontraprop1 (invproofirrelevance _ (irr x)) (sec x)).
@@ -110,12 +110,12 @@ Proof. intros.
          reflexivity. } Defined.
 
 Definition homotinvweqweq' {X} {P:X->Type}
-           (irr:Π x (p q:P x), p = q) (s:Section P) (w:total2 P) :
+           (irr:∏ x (p q:P x), p = q) (s:Section P) (w:total2 P) :
   invmap (weqpr1_irr_sec irr s) (weqpr1_irr_sec irr s w) = w.
 Proof. intros ? ? ? ? [x p]. apply pair_path_in2. apply irr. Defined.
 
 Definition homotinvweqweq'_comp {X} {P:X->Type}
-           (irr:Π x (p q:P x), p = q) (sec:Section P)
+           (irr:∏ x (p q:P x), p = q) (sec:Section P)
            (x:X) (p:P x) :
   let f := weqpr1_irr_sec irr sec in
   let w := x,,p in
@@ -127,7 +127,7 @@ Proof. reflexivity.             (* don't change the proof *)
 Defined.
 
 Definition homotinvweqweq_comp {X} {P:X->Type}
-           (irr:Π x (p q:P x), p = q) (sec:Section P)
+           (irr:∏ x (p q:P x), p = q) (sec:Section P)
            (x:X) (p:P x) :
   let f := weqpr1_irr_sec irr sec in
   let w := x,,p in
@@ -140,7 +140,7 @@ Proof.
 Abort.
 
 Definition homotinvweqweq_comp_3 {X} {P:X->Type}
-           (irr:Π x (p q:P x), p = q) (sec:Section P)
+           (irr:∏ x (p q:P x), p = q) (sec:Section P)
            (x:X) (p:P x) :
   let f := weqpr1_irr_sec irr sec in
   let g := invweqpr1_irr_sec irr sec in
@@ -162,7 +162,7 @@ Proof. intros. destruct ni, mi, l. simpl. rewrite pathscomp0rid. reflexivity.
 Defined.
 
 Definition loop_correspondence' {X Y} {P:X->Type}
-           (irr:Π x (p q:P x), p = q) (sec:Section P)
+           (irr:∏ x (p q:P x), p = q) (sec:Section P)
            (g:total2 P->Y)
            {w w':total2 P} {l:w = w'}
            {m:weqpr1_irr_sec irr sec w = weqpr1_irr_sec irr sec w'} (mi:ap (weqpr1_irr_sec irr sec) l = m)

--- a/UniMath/Ktheory/Nat.v
+++ b/UniMath/Ktheory/Nat.v
@@ -14,10 +14,10 @@ Definition ℕ := nat.
 
 Module Uniqueness.
 
-  Lemma helper_A (P:nat->Type) (p0:P 0) (IH:Π n, P n->P(S n))
-        (f:Π n, P n) :
-    weq (Π n, f n = nat_rect P p0 IH n)
-        (f 0=p0 × Π n, f(S n)=IH n (f n)).
+  Lemma helper_A (P:nat->Type) (p0:P 0) (IH:∏ n, P n->P(S n))
+        (f:∏ n, P n) :
+    weq (∏ n, f n = nat_rect P p0 IH n)
+        (f 0=p0 × ∏ n, f(S n)=IH n (f n)).
   Proof. intros. simple refine (_,,gradth _ _ _ _).
          { intros h. split.
            { exact (h 0). } { intros. exact (h (S n) @ ap (IH n) (! h n)). } }
@@ -32,29 +32,29 @@ Module Uniqueness.
            rewrite <- path_assoc. rewrite <- maponpathscomp0. rewrite pathsinv0r.
            apply pathscomp0rid. } Defined.
 
-  Lemma helper_B (P:nat->Type) (p0:P 0) (IH:Π n, P n->P(S n))
-        (f:Π n, P n) :
+  Lemma helper_B (P:nat->Type) (p0:P 0) (IH:∏ n, P n->P(S n))
+        (f:∏ n, P n) :
     weq (f = nat_rect P p0 IH)
-        ((f 0=p0) × (Π n, f(S n)=IH n (f n))).
+        ((f 0=p0) × (∏ n, f(S n)=IH n (f n))).
   Proof. intros.
          exact (weqcomp (weqtoforallpaths _ _ _) (helper_A _ _ _ _)). Defined.
 
-  Lemma helper_C (P:nat->Type) (p0:P 0) (IH:Π n, P n->P(S n)) :
-    (Σ f:Π n, P n, f = nat_rect P p0 IH)
+  Lemma helper_C (P:nat->Type) (p0:P 0) (IH:∏ n, P n->P(S n)) :
+    (∑ f:∏ n, P n, f = nat_rect P p0 IH)
       ≃
-    (Σ f:Π n, P n, f 0=p0 × Π n, f(S n)=IH n (f n)).
+    (∑ f:∏ n, P n, f 0=p0 × ∏ n, f(S n)=IH n (f n)).
   Proof. intros. apply weqfibtototal. intros f. apply helper_B. Defined.
 
-  Lemma hNatRecursionUniq (P:nat->Type) (p0:P 0) (IH:Π n, P n->P(S n)) :
-    ∃! (f:Π n, P n), f 0=p0 × Π n, f(S n) = IH n (f n).
+  Lemma hNatRecursionUniq (P:nat->Type) (p0:P 0) (IH:∏ n, P n->P(S n)) :
+    ∃! (f:∏ n, P n), f 0=p0 × ∏ n, f(S n) = IH n (f n).
   Proof. intros. exact (iscontrweqf (helper_C _ _ _) (iscontrcoconustot _ _)).
   Defined.
 
-  Lemma helper_D (P:nat->Type) (p0:P 0) (IH:Π n, P n->P(S n)) :
-     (Σ f:Π n, P n, (f 0=p0) × (Π n, f(S n)=IH n (f n)))
+  Lemma helper_D (P:nat->Type) (p0:P 0) (IH:∏ n, P n->P(S n)) :
+     (∑ f:∏ n, P n, (f 0=p0) × (∏ n, f(S n)=IH n (f n)))
        ≃
         (@hfiber
-           (Σ (f:Π n, P n), Π n, f(S n)=IH n (f n))
+           (∑ (f:∏ n, P n), ∏ n, f(S n)=IH n (f n))
            (P 0)
            (fun fh => pr1 fh 0)
            p0).
@@ -65,8 +65,8 @@ Module Uniqueness.
          { intros [[f h'] h0]. reflexivity. }
   Defined.
 
-  Lemma hNatRecursion_weq (P:nat->Type) (IH:Π n, P n->P(S n)) :
-    weq (total2 (fun f:Π n, P n => Π n, f(S n)=IH n (f n))) (P 0).
+  Lemma hNatRecursion_weq (P:nat->Type) (IH:∏ n, P n->P(S n)) :
+    weq (total2 (fun f:∏ n, P n => ∏ n, f(S n)=IH n (f n))) (P 0).
   Proof. intros. exists (fun f => pr1 f 0). intro p0.
          apply (iscontrweqf (helper_D _ _ _)). apply hNatRecursionUniq.
   Defined.
@@ -88,7 +88,7 @@ Module Discern.
       | S m, 0 => empty
       | 0, 0 => unit end.
 
-  Goal Π m n, nat_discern m n -> nat_discern (S m) (S n).
+  Goal ∏ m n, nat_discern m n -> nat_discern (S m) (S n).
   Proof. intros ? ? e. exact e. Defined.
 
   Lemma nat_discern_inj m n : nat_discern (S m) (S n) -> nat_discern m n.
@@ -130,7 +130,7 @@ Module Discern.
            { simpl. intro i. assert(b := helper_B _ _ i); clear i.
              destruct b. reflexivity. } } Defined.
 
-  Goal Π m n (e:nat_discern m n), ap S (helper_B m n e) = helper_B (S m) (S n) e.
+  Goal ∏ m n (e:nat_discern m n), ap S (helper_B m n e) = helper_B (S m) (S n) e.
   Proof. reflexivity. Defined.
 
   Fixpoint helper_C m n : m = n -> nat_discern m n.
@@ -215,7 +215,7 @@ Proof. intros ? ? ? i j.
        rewrite <- (minusplusnmm _ _ i). rewrite j. reflexivity. Defined.
 
 Definition nat_dist_between_le m n a b : m ≤ n -> nat_dist m n = a + b ->
-  Σ x, nat_dist x m = a × nat_dist x n = b.
+  ∑ x, nat_dist x m = a × nat_dist x n = b.
 Proof. intros ? ? ? ? i j. exists (m+a). split.
        { apply nat_dist_plus. }
        { rewrite (nat_dist_le m n i) in j.
@@ -225,7 +225,7 @@ Proof. intros ? ? ? ? i j. exists (m+a). split.
          rewrite (natplusassoc m a b) in l. rewrite <- k in l. exact l. } Defined.
 
 Definition nat_dist_between_ge m n a b :
-  n ≤ m -> nat_dist m n = a + b -> Σ x:nat, nat_dist x m = a × nat_dist x n = b.
+  n ≤ m -> nat_dist m n = a + b -> ∑ x:nat, nat_dist x m = a × nat_dist x n = b.
 Proof. intros ? ? ? ? i j.
        rewrite nat_dist_symm in j.
        rewrite natpluscomm in j.
@@ -235,7 +235,7 @@ Proof. intros ? ? ? ? i j.
 Defined.
 
 Definition nat_dist_between m n a b :
-  nat_dist m n = a + b -> Σ x:nat, nat_dist x m = a × nat_dist x n = b.
+  nat_dist m n = a + b -> ∑ x:nat, nat_dist x m = a × nat_dist x n = b.
 Proof. intros ? ? ? ? j.
        induction (natgthorleh m n) as [r|s].
        { apply nat_dist_between_ge. apply natlthtoleh. exact r. exact j. }

--- a/UniMath/Ktheory/Precategories.v
+++ b/UniMath/Ktheory/Precategories.v
@@ -105,7 +105,7 @@ Definition category_pair (C:precategory) (i:is_category C) : category := C,,i.
 Definition theUnivalenceProperty (C:category) := pr2 C : is_category C.
 
 Definition reflects_isos {C D} (X:C==>D) :=
-  Π c c' (f : c --> c'), is_isomorphism (#X f) -> is_isomorphism f.
+  ∏ c c' (f : c --> c'), is_isomorphism (#X f) -> is_isomorphism f.
 
 Lemma isaprop_reflects_isos {C D} (X:C==>D) : isaprop (reflects_isos X).
 Proof.
@@ -124,7 +124,7 @@ Defined.
 
 (** embeddings and isomorphism of categories  *)
 
-Definition PrecategoryEmbedding (B C:Precategory) := Σ F:[B,C], fully_faithful F.
+Definition PrecategoryEmbedding (B C:Precategory) := ∑ F:[B,C], fully_faithful F.
 
 Definition embeddingToFunctor (B C:Precategory) :
   PrecategoryEmbedding B C -> B ==> C
@@ -133,7 +133,7 @@ Definition embeddingToFunctor (B C:Precategory) :
 Coercion embeddingToFunctor : PrecategoryEmbedding >-> functor.
 
 Definition PrecategoryIsomorphism (B C:Precategory) :=
-  Σ F:PrecategoryEmbedding B C, isweq ((pr1 F : B ==> C) : ob B -> ob C).
+  ∑ F:PrecategoryEmbedding B C, isweq ((pr1 F : B ==> C) : ob B -> ob C).
 
 Definition isomorphismToEmbedding (B C:Precategory) :
   PrecategoryIsomorphism B C -> PrecategoryEmbedding B C
@@ -155,20 +155,20 @@ Definition makePrecategory_ob_mor
 Definition makePrecategory_data
     (obj : UU)
     (mor : obj -> obj -> UU)
-    (identity : Π i, mor i i)
-    (compose : Π i j k (f:mor i j) (g:mor j k), mor i k)
+    (identity : ∏ i, mor i i)
+    (compose : ∏ i j k (f:mor i j) (g:mor j k), mor i k)
     : precategory_data
   := precategory_data_pair (makePrecategory_ob_mor obj mor) identity compose.
 
 Definition makePrecategory
     (obj : UU)
     (mor : obj -> obj -> UU)
-    (homsets : Π a b, isaset (mor a b))
-    (identity : Π i, mor i i)
-    (compose : Π i j k (f:mor i j) (g:mor j k), mor i k)
-    (right : Π i j (f:mor i j), compose _ _ _ (identity i) f = f)
-    (left  : Π i j (f:mor i j), compose _ _ _ f (identity j) = f)
-    (associativity : Π a b c d (f:mor a b) (g:mor b c) (h:mor c d),
+    (homsets : ∏ a b, isaset (mor a b))
+    (identity : ∏ i, mor i i)
+    (compose : ∏ i j k (f:mor i j) (g:mor j k), mor i k)
+    (right : ∏ i j (f:mor i j), compose _ _ _ (identity i) f = f)
+    (left  : ∏ i j (f:mor i j), compose _ _ _ f (identity j) = f)
+    (associativity : ∏ a b c d (f:mor a b) (g:mor b c) (h:mor c d),
         compose _ _ _ f (compose _ _ _ g h) = compose _ _ _ (compose _ _ _ f g) h)
   : Precategory
   := (precategory_pair
@@ -181,9 +181,9 @@ Definition makePrecategory
 
 Definition makeFunctor {C D:Precategory}
            (obj : C -> D)
-           (mor : Π c c' : C, c --> c' -> obj c --> obj c')
-           (identity : Π c, mor c c (identity c) = identity (obj c))
-           (compax : Π (a b c : C) (f : a --> b) (g : b --> c),
+           (mor : ∏ c c' : C, c --> c' -> obj c --> obj c')
+           (identity : ∏ c, mor c c (identity c) = identity (obj c))
+           (compax : ∏ (a b c : C) (f : a --> b) (g : b --> c),
                        mor a c (g ∘ f) = mor b c g ∘ mor a b f) :
   C ==> D
   := (obj,, mor),, identity,, compax.
@@ -280,28 +280,28 @@ Proof. exact (functor_comp F _ _ _ f g). Defined.
 Definition nat_iso {B C:Precategory} (F G:[B,C]) := iso F G.
 
 Definition makeNattrans {C D:Precategory} {F G:[C,D]}
-           (mor : Π x : C, F ◾ x --> G ◾ x)
-           (eqn : Π c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
+           (mor : ∏ x : C, F ◾ x --> G ◾ x)
+           (eqn : ∏ c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
   F --> G
   := (mor,,eqn).
 
 Definition makeNattrans_op {C D:Precategory} {F G:[C^op,D]}
-           (mor : Π x : C, F ◾ x --> G ◾ x)
-           (eqn : Π c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
+           (mor : ∏ x : C, F ◾ x --> G ◾ x)
+           (eqn : ∏ c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
   F --> G
   := (mor,,eqn).
 
 Definition makeNatiso {C D:Precategory} {F G:[C,D]}
-           (mor : Π x : C, iso (F ◾ x) (G ◾ x))
-           (eqn : Π c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
+           (mor : ∏ x : C, iso (F ◾ x) (G ◾ x))
+           (eqn : ∏ c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
   nat_iso F G.
 Proof.
   refine (makeNattrans mor eqn,,_). apply functor_iso_if_pointwise_iso; intro c. apply pr2.
 Defined.
 
 Definition makeNatiso_op {C D:Precategory} {F G:[C^op,D]}
-           (mor : Π x : C, iso (F ◾ x) (G ◾ x))
-           (eqn : Π c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
+           (mor : ∏ x : C, iso (F ◾ x) (G ◾ x))
+           (eqn : ∏ c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
   nat_iso F G.
 Proof.
   refine (makeNattrans_op mor eqn,,_). apply functor_iso_if_pointwise_iso; intro c. apply pr2.
@@ -343,9 +343,9 @@ Definition functor_to_opp_opp {C:Precategory} : C ==> C^op^op
 
 Definition makeFunctor_op {C D:Precategory}
            (obj : ob C -> ob D)
-           (mor : Π a b : C, b --> a -> obj a --> obj b)
-           (identity : Π c, mor c c (identity c) = identity (obj c))
-           (compax : Π (a b c : C) (f : b --> a) (g : c --> b),
+           (mor : ∏ a b : C, b --> a -> obj a --> obj b)
+           (identity : ∏ c, mor c c (identity c) = identity (obj c))
+           (compax : ∏ (a b c : C) (f : b --> a) (g : c --> b),
                        mor a c (f ∘ g) = mor b c g ∘ mor a b f) :
   C^op ==> D
   := (obj,, mor),, identity,, compax.
@@ -475,10 +475,10 @@ Lemma total2_paths1 {A : UU} {B : A -> UU} (a:A) {b b':B a} :
   b=b' -> tpair B a b = tpair B a b'.
 Proof. intro e. induction e. reflexivity. Defined.
 
-Goal Π A : UU, Π B : A -> UU, Π p : (Σ a, B a), p = tpair B (pr1 p) (pr2 p).
+Goal ∏ A : UU, ∏ B : A -> UU, ∏ p : (∑ a, B a), p = tpair B (pr1 p) (pr2 p).
   induction p as [a b]. reflexivity. Defined.
 
-Goal Π X Y (f:X->Y), f = λ x, f x.
+Goal ∏ X Y (f:X->Y), f = λ x, f x.
   reflexivity. Defined.
 
 (* new categories from old *)
@@ -487,7 +487,7 @@ Definition categoryWithStructure (C:Precategory) (P:ob C -> UU) : Precategory.
 Proof.
   unshelve refine (makePrecategory _ _ _ _ _ _ _ _).
   (* add a new component to each object: *)
-  - exact (Σ c:C, P c).
+  - exact (∑ c:C, P c).
   (* the homsets ignore the extra structure: *)
   - intros x y. exact (pr1 x --> pr1 y).
   (* the rest is the same: *)
@@ -500,7 +500,7 @@ Proof.
 Defined.
 
 Definition functorWithStructures {C:Precategory} {P Q:ob C -> UU}
-           (F : Π c, P c -> Q c) : categoryWithStructure C P ==> categoryWithStructure C Q.
+           (F : ∏ c, P c -> Q c) : categoryWithStructure C P ==> categoryWithStructure C Q.
 Proof.
   unshelve refine (makeFunctor _ _ _ _).
   (* transport the structure: *)
@@ -512,7 +512,7 @@ Proof.
 Defined.
 
 Definition addStructure {B C:Precategory} {P:ob C -> UU}
-           (F:B==>C) (h : Π b, P(F b)) : B ==> categoryWithStructure C P.
+           (F:B==>C) (h : ∏ b, P(F b)) : B ==> categoryWithStructure C P.
 Proof.
   unshelve refine (makeFunctor _ _ _ _).
   - intros b. exact (F b,,h b).
@@ -521,10 +521,10 @@ Proof.
   - abstract (intros b b' b'' f g; simpl; apply functor_comp) using _L_.
 Defined.
 
-Lemma identityFunction : Π (T:SET) (f:T-->T) (t:T:hSet), f = identity T -> f t = t.
+Lemma identityFunction : ∏ (T:SET) (f:T-->T) (t:T:hSet), f = identity T -> f t = t.
 Proof. intros ? ? ? e. exact (eqtohomot e t). Defined.
 
-Lemma identityFunction' : Π (T:SET) (t:T:hSet), identity T t = t.
+Lemma identityFunction' : ∏ (T:SET) (t:T:hSet), identity T t = t.
 Proof. reflexivity. Defined.
 
 (*  *)
@@ -565,10 +565,10 @@ Defined.
 (* zero maps, definition: *)
 
 Definition hasZeroMaps (C:Precategory) :=
-  Σ (zero : Π a b:C, a --> b),
-  (Π a b c, Π f:b --> c, f ∘ zero a b = zero a c)
+  ∑ (zero : ∏ a b:C, a --> b),
+  (∏ a b c, ∏ f:b --> c, f ∘ zero a b = zero a c)
     ×
-    (Π a b c, Π f:c --> b, zero b a ∘ f = zero c a).
+    (∏ a b c, ∏ f:c --> b, zero b a ∘ f = zero c a).
 
 Definition is {C:Precategory} (zero: hasZeroMaps C) {a b:C} (f:a-->b)
   := f = pr1 zero _ _.

--- a/UniMath/Ktheory/QuotientSet.v
+++ b/UniMath/Ktheory/QuotientSet.v
@@ -5,12 +5,12 @@ Require Import
         UniMath.Ktheory.Utilities.
 Definition iscomprelfun2 {X Y Z} (RX:hrel X) (RY:hrel Y)
            (f:X->Y->Z) : Type
-  := (Π x x', RX x x' -> Π y, f x y = f x' y) ×
-     (Π y y', RY y y' -> Π x, f x y = f x y').
+  := (∏ x x', RX x x' -> ∏ y, f x y = f x' y) ×
+     (∏ y y', RY y y' -> ∏ x, f x y = f x y').
 Definition iscomprelrelfun2 {X Y Z} (RX:hrel X) (RY:hrel Y) (RZ:eqrel Z)
            (f:X->Y->Z) : Type
-  := (Π x x' y, RX x x' -> RZ (f x y) (f x' y)) ×
-     (Π x y y', RY y y' -> RZ (f x y) (f x y')).
+  := (∏ x x' y, RX x x' -> RZ (f x y) (f x' y)) ×
+     (∏ x y y', RY y y' -> RZ (f x y) (f x y')).
 Lemma setquotuniv_equal { X : UU } ( R : hrel X ) ( Y : hSet )
       ( f f' : X -> Y ) (p : f = f')
       ( is : iscomprelfun R f ) ( is' : iscomprelfun R f' )

--- a/UniMath/Ktheory/RawMatrix.v
+++ b/UniMath/Ktheory/RawMatrix.v
@@ -16,31 +16,31 @@ Local Open Scope cat.
 
 Definition to_row {C:Precategory} {I} {b:I -> ob C}
            (B:Sum b) {d:ob C} :
-  weq (Hom C (universalObject B) d) (Π j, Hom C (b j) d).
+  weq (Hom C (universalObject B) d) (∏ j, Hom C (b j) d).
 Proof. intros. exact (universalProperty B d). Defined.
 
 Definition from_row {C:Precategory}  {I} {b:I -> ob C}
            (B:Sum b) {d:ob C} :
-  weq (Π j, Hom C (b j) d) (Hom C (universalObject B) d).
+  weq (∏ j, Hom C (b j) d) (Hom C (universalObject B) d).
 Proof. intros. apply invweq. apply to_row. Defined.
 
 Lemma from_row_entry {C:Precategory} {I} {b:I -> ob C}
-           (B:Sum b) {d:ob C} (f : Π j, Hom C (b j) d) :
-  Π j, from_row B f ∘ opp_mor (universalElement B j) = f j.
+           (B:Sum b) {d:ob C} (f : ∏ j, Hom C (b j) d) :
+  ∏ j, from_row B f ∘ opp_mor (universalElement B j) = f j.
 Proof. intros. exact (eqtohomot (homotweqinvweq (to_row B) f) j). Qed.
 
 Definition to_col {C:Precategory} {I} {d:I -> ob C} (D:Product d) {b:ob C} :
-  (Hom C b (universalObject D)) ≃ (Π i, Hom C b (d i)).
+  (Hom C b (universalObject D)) ≃ (∏ i, Hom C b (d i)).
 Proof. intros. exact (universalProperty D b). Defined.
 
 Definition from_col {C:Precategory} {I} {d:I -> ob C}
            (D:Product d) {b:ob C} :
- (Π i, Hom C b (d i)) ≃ (Hom C b (universalObject D)).
+ (∏ i, Hom C b (d i)) ≃ (Hom C b (universalObject D)).
 Proof. intros. apply invweq. apply to_col. Defined.
 
 Lemma from_col_entry {C:Precategory} {I} {b:I -> ob C}
-           (D:Product b) {d:ob C} (f : Π i, Hom C d (b i)) :
-  Π i, universalElement D i ∘ from_col D f = f i.
+           (D:Product b) {d:ob C} (f : ∏ i, Hom C d (b i)) :
+  ∏ i, universalElement D i ∘ from_col D f = f i.
 Proof. intros.
   apply (eqtohomot (homotweqinvweq (to_col D) f ) i). Qed.
 
@@ -49,9 +49,9 @@ Definition to_matrix {C:Precategory}
            {J} {b:J -> ob C} (B:Sum b) :
   (Hom C (universalObject B) (universalObject D))
     ≃
-    (Π i j, Hom C (b j) (d i)).
+    (∏ i j, Hom C (b j) (d i)).
 Proof.
-  intros. apply @weqcomp with (Y := Π i, Hom C (universalObject B) (d i)).
+  intros. apply @weqcomp with (Y := ∏ i, Hom C (universalObject B) (d i)).
   { apply to_col. }
   { apply weqonsecfibers; intro i. apply to_row. }
 Defined.
@@ -59,19 +59,19 @@ Defined.
 Definition from_matrix {C:Precategory}
            {I} {d:I -> ob C} (D:Product d)
            {J} {b:J -> ob C} (B:Sum b) :
-           weq (Π i j, Hom C (b j) (d i)) (Hom C (universalObject B) (universalObject D)).
+           weq (∏ i j, Hom C (b j) (d i)) (Hom C (universalObject B) (universalObject D)).
 Proof. intros. apply invweq. apply to_matrix. Defined.
 
 Lemma from_matrix_entry {C:Precategory}
            {I} {d:I -> ob C} (D:Product d)
            {J} {b:J -> ob C} (B:Sum b)
-           (f : Π i j, Hom C (b j) (d i)) :
-  Π i j, (universalElement D i ∘ from_matrix D B f) ∘ opp_mor (universalElement B j) = f i j.
+           (f : ∏ i j, Hom C (b j) (d i)) :
+  ∏ i j, (universalElement D i ∘ from_matrix D B f) ∘ opp_mor (universalElement B j) = f i j.
 Proof. intros. exact (eqtohomot (eqtohomot (homotweqinvweq (to_matrix D B) f) i) j). Qed.
 
 Lemma from_matrix_entry_assoc {C:Precategory}
            {I} {d:I -> ob C} (D:Product d)
            {J} {b:J -> ob C} (B:Sum b)
-           (f : Π i j, Hom C (b j) (d i)) :
-  Π i j, universalElement D i ∘ (from_matrix D B f ∘ opp_mor(universalElement B j)) = f i j.
+           (f : ∏ i j, Hom C (b j) (d i)) :
+  ∏ i j, universalElement D i ∘ (from_matrix D B f ∘ opp_mor(universalElement B j)) = f i j.
 Proof. intros. rewrite <- assoc. exact (from_matrix_entry D B f i j). Qed.

--- a/UniMath/Ktheory/Representation.v
+++ b/UniMath/Ktheory/Representation.v
@@ -12,10 +12,10 @@ Set Automatic Introduction.
 Local Open Scope cat.
 
 Definition isUniversal {C:Precategory} {X:[C^op,SET]} {c:C} (x:c ⇒ X)
-  := Π (c':C), isweq (λ f : c' --> c, x ⟲ f).
+  := ∏ (c':C), isweq (λ f : c' --> c, x ⟲ f).
 
 Definition Universal {C:Precategory} (X:[C^op,SET]) (c:C)
-  := Σ (x:c ⇒ X), isUniversal x.
+  := ∑ (x:c ⇒ X), isUniversal x.
 
 Lemma iso_Universal_weq {C:Precategory} {X Y:[C^op,SET]} (c:C) :
   iso X Y -> Universal X c ≃ Universal Y c.
@@ -36,7 +36,7 @@ Proof.
 Defined.
 
 Definition Representation {C:Precategory} (X:[C^op,SET]) : UU
-  := Σ (c:C), Universal X c.
+  := ∑ (c:C), Universal X c.
 
 Definition isRepresentable {C:Precategory} (X:[C^op,SET]) := ∥ Representation X ∥.
 
@@ -71,7 +71,7 @@ Definition toRepresentableFunctor {C:Precategory} :
 (* make a representation of a functor *)
 
 Definition makeRepresentation {C:Precategory} {c:C} {X:[C^op,SET]} (x:c ⇒ X) :
-  (Π (c':C), bijective (λ f : c' --> c, x ⟲ f)) -> Representation X.
+  (∏ (c':C), bijective (λ f : c' --> c, x ⟲ f)) -> Representation X.
 Proof.
   intros bij. exists c. exists x. intros c'. apply set_bijection_to_weq.
   - exact (bij c').
@@ -203,7 +203,7 @@ Definition embeddingRepresentability {C D:Precategory}
            (s:Representation Y)
            (i:PrecategoryEmbedding C D) :
   iso (Y □ functorOp (opp_ob (pr1 i))) X ->
-  (Σ c, i c = universalObject s) -> Representation X.
+  (∑ c, i c = universalObject s) -> Representation X.
 Proof.
   intros j ce.
   apply (iso_Representation_weq j).
@@ -300,7 +300,7 @@ Proof. intros. unfold InitialObject. now induction (opp_opp_precat C). Defined.
 (** zero objects, as an alternative to ZeroObject.v *)
 
 Definition ZeroObject (C:Precategory)
-  := Σ z:ob C, Universal (UnitFunctor C^op) z × Universal (UnitFunctor C^op^op) z.
+  := ∑ z:ob C, Universal (UnitFunctor C^op) z × Universal (UnitFunctor C^op^op) z.
 
 Definition zero_to_terminal (C:Precategory) : ZeroObject C -> TerminalObject C
   := λ z, pr1 z ,, pr1 (pr2 z).
@@ -359,7 +359,7 @@ Definition HomPair_2 {C:Precategory} (a b c:C) :
 Definition BinaryProduct {C:Precategory} (a b:C) :=
   Representation (HomPair a b).
 
-Definition hasBinaryProducts (C:Precategory) := Π (a b:C), BinaryProduct a b.
+Definition hasBinaryProducts (C:Precategory) := ∏ (a b:C), BinaryProduct a b.
 
 Definition pr_1 {C:Precategory} {a b:C} (prod : BinaryProduct a b) :
   universalObject prod --> a
@@ -406,7 +406,7 @@ Defined.
 Definition BinarySum {C:Precategory} (a b:C) :=
   BinaryProduct (opp_ob a) (opp_ob b).
 
-Definition hasBinarySums (C:Precategory) := Π (a b:C), BinarySum a b.
+Definition hasBinarySums (C:Precategory) := ∏ (a b:C), BinarySum a b.
 
 Lemma binarySumsToProducts {C:Precategory} :
   hasBinarySums C -> hasBinaryProducts C^op.
@@ -465,7 +465,7 @@ Definition HomFamily (C:Precategory) {I} (c:I -> ob C) : C^op ==> SET.
 Proof.
   unshelve refine (_,,_).
   - unshelve refine (_,,_).
-    + intros x. exact (Π i, Hom C x (c i)) % set.
+    + intros x. exact (∏ i, Hom C x (c i)) % set.
     + intros x y f p i; simpl; simpl in p.
       exact (compose (C:=C) f (p i)).
   - abstract (split;
@@ -485,12 +485,12 @@ Definition pr_ {C:Precategory} {I} {c:I -> ob C} (prod : Product c) (i:I) :
 
 Definition productMapExistence {C:Precategory} {I} {c:I -> ob C} (prod : Product c)
       {a:C} :
-  (Π i, Hom C a (c i)) -> Hom C a (universalObject prod)
+  (∏ i, Hom C a (c i)) -> Hom C a (universalObject prod)
   := λ f, prod \\ f.
 
 Lemma productMapUniqueness {C:Precategory} {I} {c:I -> ob C} (prod : Product c)
       {a:C} (f g : Hom C a (universalObject prod)) :
-  (Π i, pr_ prod i ∘ f = pr_ prod i ∘ g) -> f = g.
+  (∏ i, pr_ prod i ∘ f = pr_ prod i ∘ g) -> f = g.
 Proof.
   intro e. apply mapUniqueness. apply funextsec; intro i. apply e.
 Defined.
@@ -504,12 +504,12 @@ Definition in_ {C:Precategory} {I} {c:I -> ob C} (sum : Sum c) (i:I) :
 
 Definition sumMapExistence {C:Precategory} {I} {c:I -> ob C} (sum : Sum c)
       {a:C} :
-  (Π i, Hom C (c i) a) -> Hom C (universalObject sum) a
+  (∏ i, Hom C (c i) a) -> Hom C (universalObject sum) a
   := λ f, f // sum.
 
 Lemma sumMapUniqueness {C:Precategory} {I} {c:I -> ob C} (sum : Sum c)
       {a:C} (f g : Hom C (universalObject sum) a) :
-  (Π i, f ∘ in_ sum i = g ∘ in_ sum i) -> f = g.
+  (∏ i, f ∘ in_ sum i = g ∘ in_ sum i) -> f = g.
 Proof.
   intro e. apply opp_mor_eq, mapUniqueness. apply funextsec; intro i. apply e.
 Defined.
@@ -523,7 +523,7 @@ Definition Equalization {C:Precategory} {c d:C} (f g:c-->d) :
 Proof.
   unshelve refine (makeFunctor_op _ _ _ _).
   - intro b. unshelve refine (_,,_).
-    + exact (Σ p:b --> c, f∘p = g∘p).
+    + exact (∑ p:b --> c, f∘p = g∘p).
     + abstract (apply isaset_total2;
       [ apply homset_property
       | intro; apply isasetaprop; apply homset_property]) using _L_.
@@ -570,7 +570,7 @@ Proof.
   intros.
   unshelve refine (makeFunctor_op _ _ _ _).
   - intros t. unshelve refine (_,,_).
-    + exact (Σ (p: t --> a × t --> b), f ∘ pr1 p = g ∘ pr2 p).
+    + exact (∑ (p: t --> a × t --> b), f ∘ pr1 p = g ∘ pr2 p).
     + abstract (apply isaset_total2;
       [ apply isasetdirprod; apply homset_property
       | intro; apply isasetaprop; apply homset_property]) using _L_.
@@ -629,7 +629,7 @@ Definition Annihilator (C:Precategory) (zero:hasZeroMaps C) {c d:C} (f:c --> d) 
 Proof.
   unshelve refine (_,,_).
   { unshelve refine (_,,_).
-    { intro b. exists (Σ g:Hom C b c, f ∘ g = pr1 zero b d).
+    { intro b. exists (∑ g:Hom C b c, f ∘ g = pr1 zero b d).
       abstract (apply isaset_total2; [ apply setproperty |
       intro g; apply isasetaprop; apply homset_property ]) using _L_. }
     { intros a b p ge; simpl.
@@ -679,7 +679,7 @@ Definition fiber {C:Precategory} {X Y:[C^op,SET]} (p : X --> Y) {c:C} (y : c ⇒
 Proof.
   unshelve refine (makeFunctor_op _ _ _ _).
   - intro b.
-    exists (Σ fx : (b --> c) × (b ⇒ X), p ⟳ pr2 fx = y ⟲ pr1 fx).
+    exists (∑ fx : (b --> c) × (b ⇒ X), p ⟳ pr2 fx = y ⟲ pr1 fx).
     abstract (apply isaset_total2;
         [ apply isaset_dirprod, setproperty; apply homset_property
         | intros [f x]; apply isasetaprop; apply setproperty ]) using _K_.
@@ -704,16 +704,16 @@ Defined.
    Grothendieck.  See EGA Chapter 0. *)
 
 Definition Representation_Map {C:Precategory} {X Y:[C^op,SET]} (p : X --> Y) :=
-  Π (c : C) (y : c ⇒ Y), Representation (fiber p y).
+  ∏ (c : C) (y : c ⇒ Y), Representation (fiber p y).
 
 Definition isRepresentable_Map {C:Precategory} {X Y:[C^op,SET]} (p : X --> Y) :=
-  Π (c : C) (y : c ⇒ Y), isRepresentable (fiber p y).
+  ∏ (c : C) (y : c ⇒ Y), isRepresentable (fiber p y).
 
 (** limits and colimits  *)
 
 Definition cone {I C:Precategory} (c:C) (D: [I,C]) : UU
-  := Σ (φ : Π i, Hom C c (D ◾ i)),
-     Π i j (e : i --> j), D ▭ e ∘ φ i = φ j.
+  := ∑ (φ : ∏ i, Hom C c (D ◾ i)),
+     ∏ i j (e : i --> j), D ▭ e ∘ φ i = φ j.
 
 Lemma cone_eq {C I:Precategory} (c:C^op) (D: I==>C) (p q:cone (C:=C) c D) :
   pr1 p ~ pr1 q -> p = q.
@@ -802,9 +802,9 @@ Definition inj_comm {C I:Precategory} {D: I==>C} (colim:Colimit D) {i j:I} (f:i-
   inj_ colim j ∘ # D f = inj_ colim i.
 Proof. intros. exact (pr2 (universalElement colim) _ _ f). Defined.
 
-Definition hasLimits (C:Precategory) := Π (I:Precategory) (D: I==>C), Limit D.
+Definition hasLimits (C:Precategory) := ∏ (I:Precategory) (D: I==>C), Limit D.
 
-Definition hasColimits (C:Precategory) := Π (I:Precategory) (D: I==>C), Colimit D.
+Definition hasColimits (C:Precategory) := ∏ (I:Precategory) (D: I==>C), Colimit D.
 
 Definition lim_functor (C:Precategory) (lim:hasLimits C) (I:Precategory) :
   [I,C] ==> C
@@ -816,7 +816,7 @@ Definition colim_functor (C:Precategory) (colim:hasColimits C) (I:Precategory) :
          universalObjectFunctor C^op □ addStructure cocone_functor (colim I)).
 
 Lemma bifunctor_assoc_repn {B C:Precategory} (X : [B, [C^op,SET]]) :
-  (Π b, Representation (X ◾ b)) -> Representation (bifunctor_assoc X).
+  (∏ b, Representation (X ◾ b)) -> Representation (bifunctor_assoc X).
 Proof.
   intro r. set (X' := addStructure X r).
   change (categoryWithStructure [C ^op, SET] Representation) with (RepresentedFunctor C) in X'.
@@ -879,7 +879,7 @@ Proof.
   { apply bifunctor_assoc_repn; intro b. exact t. }
 Defined.
 
-Goal Π B C t b,
+Goal ∏ B C t b,
        universalObject(functorPrecategoryTerminalObject B C t) ◾ b = universalObject t.
   reflexivity.
 Defined.

--- a/UniMath/Ktheory/StandardCategories.v
+++ b/UniMath/Ktheory/StandardCategories.v
@@ -12,7 +12,7 @@ Proof. intros. exact (compose f g). Defined.
 (** *** the path groupoid *)
 
 Definition is_groupoid (C : Precategory) :=
-  Π a b : ob C, isweq (fun p : a = b => idtomor a b p).
+  ∏ a b : ob C, isweq (fun p : a = b => idtomor a b p).
 
 Lemma isaprop_is_groupoid (C : Precategory) : isaprop (is_groupoid C).
 Proof. intro. apply impred.

--- a/UniMath/Ktheory/Test.v
+++ b/UniMath/Ktheory/Test.v
@@ -27,7 +27,7 @@ Definition isCoproductCocone (a b co : C) (ia : a --> co) (ib : b --> co) :=
   binarySumProperty ia ib.
 
 Definition mk_isCoproductCocone (a b co : C) (ia : a --> co) (ib : b --> co) :
-   (Π (c : C) (f : a --> c) (g : b --> c),
+   (∏ (c : C) (f : a --> c) (g : b --> c),
     ∃! k : C ⟦co, c⟧,
       ia ;; k = f ×
       ib ;; k = g)
@@ -50,7 +50,7 @@ Defined.
 Definition CoproductCocone (a b : C) := BinarySum a b.
 
 Definition mk_CoproductCocone (a b : C) :
-  Π (c : C) (f : a --> c) (g : b --> c),
+  ∏ (c : C) (f : a --> c) (g : b --> c),
     isCoproductCocone _ _ _ f g -> CoproductCocone a b
   := λ c f g i, c,,(f,,g),,i.
 
@@ -71,14 +71,14 @@ Definition CoproductArrow {a b : C} (CC : CoproductCocone a b) {c : C} (f : a --
   := binarySumMap CC f g.
 
 Lemma CoproductIn1Commutes (a b : C) (CC : CoproductCocone a b):
-     Π (c : C) (f : a --> c) g, CoproductIn1 CC ;; CoproductArrow CC f g  = f.
+     ∏ (c : C) (f : a --> c) g, CoproductIn1 CC ;; CoproductArrow CC f g  = f.
 Proof.
   intros c f g.
   exact (binarySum_in_1_eqn CC f g).
 Qed.
 
 Lemma CoproductIn2Commutes (a b : C) (CC : CoproductCocone a b):
-     Π (c : C) (f : a --> c) g, CoproductIn2 CC ;; CoproductArrow CC f g = g.
+     ∏ (c : C) (f : a --> c) g, CoproductIn2 CC ;; CoproductArrow CC f g = g.
 Proof.
   intros c f g.
   exact (binarySum_in_2_eqn CC f g).

--- a/UniMath/Ktheory/Utilities.v
+++ b/UniMath/Ktheory/Utilities.v
@@ -10,12 +10,12 @@ Require Export UniMath.Ktheory.Tactics.
 
 Open Scope transport.
 
-Definition nullHomotopyTo {X Y} (f:X->Y) (y:Y) := Π x:X, f x = y.
+Definition nullHomotopyTo {X Y} (f:X->Y) (y:Y) := ∏ x:X, f x = y.
 Definition NullHomotopyTo {X Y} (f:X->Y) := total2 (nullHomotopyTo f).
 Definition NullHomotopyTo_center {X Y} (f:X->Y) : NullHomotopyTo f -> Y := pr1.
 Definition NullHomotopyTo_path {X Y} {f:X->Y} (r:NullHomotopyTo f) := pr2 r.
 
-Definition nullHomotopyFrom {X Y} (f:X->Y) (y:Y) := Π x:X, y = f x.
+Definition nullHomotopyFrom {X Y} (f:X->Y) (y:Y) := ∏ x:X, y = f x.
 Definition NullHomotopyFrom {X Y} (f:X->Y) := total2 (nullHomotopyFrom f).
 Definition NullHomotopyFrom_center {X Y} (f:X->Y) : NullHomotopyFrom f -> Y := pr1.
 Definition NullHomotopyFrom_path {X Y} {f:X->Y} (r:NullHomotopyFrom f) := pr2 r.
@@ -86,7 +86,7 @@ Definition cone_squash_map {X Y} (f:X->Y) (y:Y) :
 Proof. intros ? ? ? ? e h.
        exact (point_from (h (paths_to_prop y) (fun x => f x,,e x))). Defined.
 
-Goal Π X Y (y:Y) (f:X->Y) (e:Π m:X, f m = y),
+Goal ∏ X Y (y:Y) (f:X->Y) (e:∏ m:X, f m = y),
        f = funcomp squash_element (cone_squash_map f y e).
 Proof. reflexivity. Qed.
 
@@ -95,20 +95,20 @@ Proof. reflexivity. Qed.
 Lemma squash_uniqueness {X} (x:X) (h:∥ X ∥) : squash_element x = h.
 Proof. intros. apply propproperty. Qed.
 
-Goal Π X Q (i:isaprop Q) (f:X -> Q) (x:X),
+Goal ∏ X Q (i:isaprop Q) (f:X -> Q) (x:X),
    factor_through_squash i f (squash_element x) = f x.
 Proof. reflexivity. Defined.
 
 Lemma factor_dep_through_squash {X} {Q:∥ X ∥->UU} :
-  (Π h, isaprop (Q h)) ->
-  (Π x, Q(squash_element x)) ->
-  (Π h, Q h).
+  (∏ h, isaprop (Q h)) ->
+  (∏ x, Q(squash_element x)) ->
+  (∏ h, Q h).
 Proof.
   intros ? ? i f ?.  apply (h (hProppair (Q h) (i h))).
   intro x. simpl. destruct (squash_uniqueness x h). exact (f x).
 Defined.
 
-Lemma factor_through_squash_hProp {X} : Π hQ:hProp, (X -> hQ) -> ∥ X ∥ -> hQ.
+Lemma factor_through_squash_hProp {X} : ∏ hQ:hProp, (X -> hQ) -> ∥ X ∥ -> hQ.
 Proof. intros ? [Q i] f h. refine (h _ _). assumption. Defined.
 
 Lemma funspace_isaset {X Y} : isaset Y -> isaset (X -> Y).
@@ -143,10 +143,10 @@ Definition funcomp' { X Y Z : UU } ( g : Y -> Z ) ( f : X -> Y ) := fun x : X =>
 Open Scope transport.
 
 (* some jargon reminders: *)
-Goal Π X (i:isaprop X) (x x':X), x = x'.
+Goal ∏ X (i:isaprop X) (x x':X), x = x'.
 Proof. apply proofirrelevance. Defined.
 
-Goal Π X (i:iscontr X) (x x':X), x = x'.
+Goal ∏ X (i:iscontr X) (x x':X), x = x'.
 Proof. intros. apply proofirrelevancecontr. assumption. Defined.
 
 (* *)
@@ -208,9 +208,9 @@ Definition pathscomp0_rinj {X} {x y z:X} {p p':x = y} {q:y = z} (r:p@q = p'@q) :
 Proof. intros. destruct q. exact (! pathscomp0rid p @ r @ pathscomp0rid p').
 Defined.
 
-Lemma irrel_paths {X} (irr:Π x y:X, x = y) {x y:X} (p q:x = y) : p = q.
+Lemma irrel_paths {X} (irr:∏ x y:X, x = y) {x y:X} (p q:x = y) : p = q.
 Proof. intros.
-       assert (k : Π z:X, Π r:x = z, r @ irr z z = irr x z).
+       assert (k : ∏ z:X, ∏ r:x = z, r @ irr z z = irr x z).
        { intros. destruct r. reflexivity. }
        exact (pathscomp0_rinj (k y p @ !k y q)). Defined.
 
@@ -254,7 +254,7 @@ Proof. reflexivity. Defined.
 
 (* replace all uses of this by uses of subtypePairEquality *)
 Definition pair_path_props {X} {P:X->Type} {x y:X} {p:P x} {q:P y} :
-  x = y -> (Π z, isaprop (P z)) -> x,,p = y,,q.
+  x = y -> (∏ z, isaprop (P z)) -> x,,p = y,,q.
 Proof. intros ? ? ? ? ? ? e is. now apply subtypePairEquality. Abort.
 
 Definition pair_path2 {A} {B:A->UU} {a a1 a2} {b1:B a1} {b2:B a2}
@@ -282,14 +282,14 @@ Proof. intros. destruct p, q. reflexivity. Defined.
 
 (** ** Maps from pair types *)
 
-Definition from_total2 {X} {P:X->Type} {Y} : (Π x, P x->Y) -> total2 P -> Y.
+Definition from_total2 {X} {P:X->Type} {Y} : (∏ x, P x->Y) -> total2 P -> Y.
 Proof. intros ? ? ? f [x p]. exact (f x p). Defined.
 
 (** ** Sections and functions *)
 
-Definition Section {T} (P:T->UU) := Π t:T, P t.
+Definition Section {T} (P:T->UU) := ∏ t:T, P t.
 
-Definition homotsec {T} {P:T->UU} (f g:Section P) := Π t, f t = g t.
+Definition homotsec {T} {P:T->UU} (f g:Section P) := ∏ t, f t = g t.
 
 (* compare with [adjev] *)
 Definition evalat {T} {P:T->UU} (t:T) (f:Section P) := f t.
@@ -332,39 +332,39 @@ Lemma transport_idfun {X} (P:X->UU) {x y:X} (p:x = y) (u:P x) :
 (* same as HoTT.PathGroupoids.transport_idmap_ap *)
 Proof. intros. destruct p. reflexivity. Defined.
 
-Lemma transport_functions {X} {Y:X->Type} {Z:Π x (y:Y x), Type}
-      {f f':Section Y} (p:f = f') (z:Π x, Z x (f x)) x :
-    transportf (fun f => Π x, Z x (f x)) p z x =
+Lemma transport_functions {X} {Y:X->Type} {Z:∏ x (y:Y x), Type}
+      {f f':Section Y} (p:f = f') (z:∏ x, Z x (f x)) x :
+    transportf (fun f => ∏ x, Z x (f x)) p z x =
     transportf (Z x) (toforallpaths _ _ _ p x) (z x).
 Proof. intros. destruct p. reflexivity. Defined.
 
 Definition transport_funapp {T} {X Y:T->Type}
-           (f:Π t, X t -> Y t) (x:Π t, X t)
+           (f:∏ t, X t -> Y t) (x:∏ t, X t)
            {t t':T} (p:t = t') :
   transportf _ p ((f t)(x t))
   = (transportf (fun t => X t -> Y t) p (f t)) (transportf _ p (x t)).
 Proof. intros. destruct p. reflexivity. Defined.
 
-Definition helper_A {T} {Y} (P:T->Y->Type) {y y':Y} (k:Π t, P t y) (e:y = y') t :
+Definition helper_A {T} {Y} (P:T->Y->Type) {y y':Y} (k:∏ t, P t y) (e:y = y') t :
   transportf (fun y => P t y) e (k t)
   =
-  (transportf (fun y => Π t, P t y) e k) t.
+  (transportf (fun y => ∏ t, P t y) e k) t.
 Proof. intros. destruct e. reflexivity. Defined.
 
-Definition helper_B {T} {Y} (f:T->Y) {y y':Y} (k:Π t, y = f t) (e:y = y') t :
+Definition helper_B {T} {Y} (f:T->Y) {y y':Y} (k:∏ t, y = f t) (e:y = y') t :
   transportf (fun y => y = f t) e (k t)
   =
-  (transportf (fun y => Π t, y = f t) e k) t.
+  (transportf (fun y => ∏ t, y = f t) e k) t.
 Proof. intros. exact (helper_A _ k e t). Defined.
 
-Definition transport_invweq {T} {X Y:T->Type} (f:Π t, weq (X t) (Y t))
+Definition transport_invweq {T} {X Y:T->Type} (f:∏ t, weq (X t) (Y t))
            {t t':T} (p:t = t') :
   transportf (fun t => weq (Y t) (X t)) p (invweq (f t))
   =
   invweq (transportf (fun t => weq (X t) (Y t)) p (f t)).
 Proof. intros. destruct p. reflexivity. Defined.
 
-Definition transport_invmap {T} {X Y:T->Type} (f:Π t, weq (X t) (Y t))
+Definition transport_invmap {T} {X Y:T->Type} (f:∏ t, weq (X t) (Y t))
            {t t':T} (p:t=t') :
   transportf (fun t => Y t -> X t) p (invmap (f t))
   =
@@ -373,18 +373,18 @@ Proof. intros. destruct p. reflexivity. Defined.
 
   (** *** Double transport *)
 
-  Definition transportf2 {X} {Y:X->Type} (Z:Π x, Y x->Type)
+  Definition transportf2 {X} {Y:X->Type} (Z:∏ x, Y x->Type)
              {x x'} (p:x = x')
              (y:Y x) (z:Z x y) : Z x' (p#y).
   Proof. intros. destruct p. exact z. Defined.
 
-  Definition transportb2 {X} {Y:X->Type} (Z:Π x, Y x->Type)
+  Definition transportb2 {X} {Y:X->Type} (Z:∏ x, Y x->Type)
              {x x'} (p:x=x')
              (y':Y x') (z':Z x' y') : Z x (p#'y').
   Proof. intros. destruct p. exact z'. Defined.
 
-  Definition maponpaths_pr1_pr2 {X} {P:X->UU} {Q:Π x, P x->Type}
-             {w w': Σ x p, Q x p}
+  Definition maponpaths_pr1_pr2 {X} {P:X->UU} {Q:∏ x, P x->Type}
+             {w w': ∑ x p, Q x p}
              (p : w = w') :
     transportf P (ap pr1 p) (pr1 (pr2 w)) = pr1 (pr2 w').
   Proof. intros. destruct p. reflexivity. Defined.
@@ -392,14 +392,14 @@ Proof. intros. destruct p. reflexivity. Defined.
   (** *** Transport a pair *)
 
   (* replace this with transportf_total2 (?) : *)
-  Definition transportf_pair X (Y:X->Type) (Z:Π x, Y x->Type)
+  Definition transportf_pair X (Y:X->Type) (Z:∏ x, Y x->Type)
              x x' (p:x = x') (y:Y x) (z:Z x y) :
     transportf (fun x => total2 (Z x)) p (tpair (Z x) y z)
     =
     tpair (Z x') (transportf Y p y) (transportf2 _ p y z).
   Proof. intros. destruct p. reflexivity. Defined.
 
-  Definition transportb_pair X (Y:X->Type) (Z:Π x, Y x->Type)
+  Definition transportb_pair X (Y:X->Type) (Z:∏ x, Y x->Type)
              x x' (p:x = x')
              (y':Y x') (z':Z x' y')
              (z' : (Z x' y')) :
@@ -417,10 +417,10 @@ Lemma isaprop_wma_inhab' X : (X -> iscontr X) -> isaprop X.
 Proof. intros ? f. apply isaprop_wma_inhab. intro x. apply isapropifcontr.
        apply (f x). Qed.
 
-Goal Π (X:hSet) (x y:X) (p q:x = y), p = q.
+Goal ∏ (X:hSet) (x y:X) (p q:x = y), p = q.
 Proof. intros. apply setproperty. Defined.
 
-Goal Π (X:Type) (x y:X) (p q:x = y), isaset X -> p = q.
+Goal ∏ (X:Type) (x y:X) (p q:x = y), isaset X -> p = q.
 Proof. intros ? ? ? ? ? is. apply is. Defined.
 
 Definition funset X (Y:hSet) : hSet
@@ -428,9 +428,9 @@ Definition funset X (Y:hSet) : hSet
 
 (** ** Connected types *)
 
-Definition isconnected X := Π (x y:X), nonempty (x = y).
+Definition isconnected X := ∏ (x y:X), nonempty (x = y).
 
-Lemma base_connected {X} (t:X) : (Π y:X, nonempty (t = y)) -> isconnected X.
+Lemma base_connected {X} (t:X) : (∏ y:X, nonempty (t = y)) -> isconnected X.
 Proof. intros ? ? p x y. assert (a := p x). assert (b := p y). clear p.
        apply (squash_to_prop a). apply propproperty. clear a. intros a.
        apply (squash_to_prop b). apply propproperty. clear b. intros b.
@@ -450,7 +450,7 @@ Definition pr1_eqweqmap2 { X Y } ( e: X = Y ) :
 Proof. intros. destruct e. reflexivity. Defined.
 
 Definition weqonsec {X Y} (P:X->Type) (Q:Y->Type)
-           (f:X ≃ Y) (g:Π x, weq (P x) (Q (f x))) :
+           (f:X ≃ Y) (g:∏ x, weq (P x) (Q (f x))) :
   weq (Section P) (Section Q).
 Proof. intros.
        exact (weqcomp (weqonsecfibers P (fun x => Q(f x)) g)
@@ -491,7 +491,7 @@ Proof. intros ? ? ? ? ? p. exact (! homotweqinvweq f y @ ap f p). Defined.
 Definition weqbandfrel {X Y T}
            (e:Y->T) (t:T) (f : X ≃ Y)
            (P:X -> Type) (Q: Y -> Type)
-           (g:Π x:X, weq (P x) (Q (f x))) :
+           (g:∏ x:X, weq (P x) (Q (f x))) :
   weq (hfiber (fun xp:total2 P => e(f(pr1 xp))) t)
       (hfiber (fun yq:total2 Q => e(  pr1 yq )) t).
 Proof. intros. refine (weqbandf (weqbandf f _ _ g) _ _ _).
@@ -503,7 +503,7 @@ Definition weq_over_sections {S T} (w:S ≃ T)
            (p0:P t0) (pw0:P(w s0)) (l:k#pw0 = p0)
            (H:Section P -> Type)
            (J:Section (funcomp w P) -> Type)
-           (g:Π f:Section P, weq (H f) (J (maponsec1 P w f))) :
+           (g:∏ f:Section P, weq (H f) (J (maponsec1 P w f))) :
   weq (hfiber (fun fh:total2 H => pr1 fh t0) p0 )
       (hfiber (fun fh:total2 J => pr1 fh s0) pw0).
 Proof. intros. simple refine (weqbandf _ _ _ _).
@@ -514,7 +514,7 @@ Proof. intros. simple refine (weqbandf _ _ _ _).
          destruct k, l; simpl. unfold transportf; simpl.
          unfold idfun; simpl. apply idweq. } Defined.
 
-Definition weq_total2_prod {X Y} (Z:Y->Type) : (Σ y, X × Z y) ≃ (X × Σ y, Z y).
+Definition weq_total2_prod {X Y} (Z:Y->Type) : (∑ y, X × Z y) ≃ (X × ∑ y, Z y).
 Proof.                          (* move upstream *)
        intros. simple refine (weqpair _ (gradth _ _ _ _)).
        { intros [y [x z]]. exact (x,,y,,z). }
@@ -522,8 +522,8 @@ Proof.                          (* move upstream *)
        { intros [y [x z]]. reflexivity. }
        { intros [x [y z]]. reflexivity. } Defined.
 
-(* associativity of Σ *)
-Definition totalAssociativity {X:UU} {Y: Π (x:X), UU} (Z: Π (x:X) (y:Y x), UU) : (Σ (x:X) (y:Y x), Z x y) ≃ (Σ (p:Σ (x:X), Y x), Z (pr1 p) (pr2 p)).
+(* associativity of ∑ *)
+Definition totalAssociativity {X:UU} {Y: ∏ (x:X), UU} (Z: ∏ (x:X) (y:Y x), UU) : (∑ (x:X) (y:Y x), Z x y) ≃ (∑ (p:∑ (x:X), Y x), Z (pr1 p) (pr2 p)).
 Proof.                          (* move upstream *)
   intros. simple refine (_,,gradth _ _ _ _).
   { intros [x [y z]]. exact ((x,,y),,z). }
@@ -533,7 +533,7 @@ Proof.                          (* move upstream *)
 
 (** ** Pointed types *)
 
-Definition PointedType := Σ X, X.
+Definition PointedType := ∑ X, X.
 
 Definition pointedType X x := X,,x : PointedType.
 

--- a/UniMath/NumberSystems/Integers.v
+++ b/UniMath/NumberSystems/Integers.v
@@ -715,7 +715,7 @@ Definition hzgehtogehs ( n m : hz ) : hzgeh n m -> hzgeh ( n + 1 ) m := hzlehtol
 (** *** Two comparisons and [ n -> n + 1 ] *)
 
 Lemma hzgthtogehsn ( n m : hz ) : hzgth n m -> hzgeh n ( m + 1 ) .
-Proof. assert ( int : Π n m , isaprop ( hzgth n m -> hzgeh n ( m + 1 )  ) ) .
+Proof. assert ( int : ∏ n m , isaprop ( hzgth n m -> hzgeh n ( m + 1 )  ) ) .
        { intros . apply impred . intro . apply ( pr2 _ ) . }
        unfold hzgth in * .  apply ( setquotuniv2prop _ ( fun n m => hProppair _ ( int n m ) ) ) . set ( R := abgrdiffrelint nataddabmonoid natgth ) .
        intros x x' .  change ( R x x' -> ( neg ( R ( @op ( abmonoiddirprod (rigaddabmonoid natcommrig) (rigaddabmonoid natcommrig) ) x' ( dirprodpair 1%nat 0%nat ) ) x ) ) ) .
@@ -798,7 +798,7 @@ Definition nattohzandS ( n : nat ) : ( nattohz ( S n ) ) = ( 1 + nattohz n ) := 
 Definition nattohzand1 : ( nattohz 1%nat ) = 1 := idpath _ .
 
 Lemma nattorig_nattohz :
-  Π n : nat, nattorig (X := hz) n = nattohz n.
+  ∏ n : nat, nattorig (X := hz) n = nattohz n.
 Proof.
   induction n as [|n IHn].
   - unfold nattorig, nattohz ; simpl.
@@ -857,7 +857,7 @@ Lemma hzabsval0 : ( hzabsval 0 ) = 0%nat .
 Proof .  apply idpath .  Defined .
 
 Lemma hzabsvalgth0 { x : hz } ( is : hzgth x 0 ) : ( nattohz ( hzabsval x ) ) = x .
-Proof . assert ( int : Π x : hz , isaprop ( hzgth x 0 -> ( nattohz ( hzabsval x ) ) = x ) ) . intro . apply impred . intro . apply ( setproperty hz ) .  apply ( setquotunivprop _ ( fun x => hProppair _ ( int x ) ) ) . intros xa g . simpl in xa . assert ( g' := natnattohzandgth _ _ g ) . simpl in g' .  simpl .  change (( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) ( dirprodpair ( hzabsvalint xa ) 0%nat ) ) = ( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) xa ) ) . apply weqpathsinsetquot . simpl . apply hinhpr . split with 0%nat .  change ( pr1 ( natgth ( pr1 xa + 0%nat ) ( pr2 xa ) ) ) in g' . rewrite ( natplusr0 _ ) in g' .  change ((hzabsvalint xa + pr2 xa + 0)%nat = (pr1 xa + 0 + 0)%nat ) . rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) . unfold hzabsvalint .   destruct ( natgthorleh (pr1 xa) (pr2 xa)  ) as [ g'' | l ] .
+Proof . assert ( int : ∏ x : hz , isaprop ( hzgth x 0 -> ( nattohz ( hzabsval x ) ) = x ) ) . intro . apply impred . intro . apply ( setproperty hz ) .  apply ( setquotunivprop _ ( fun x => hProppair _ ( int x ) ) ) . intros xa g . simpl in xa . assert ( g' := natnattohzandgth _ _ g ) . simpl in g' .  simpl .  change (( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) ( dirprodpair ( hzabsvalint xa ) 0%nat ) ) = ( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) xa ) ) . apply weqpathsinsetquot . simpl . apply hinhpr . split with 0%nat .  change ( pr1 ( natgth ( pr1 xa + 0%nat ) ( pr2 xa ) ) ) in g' . rewrite ( natplusr0 _ ) in g' .  change ((hzabsvalint xa + pr2 xa + 0)%nat = (pr1 xa + 0 + 0)%nat ) . rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) . unfold hzabsvalint .   destruct ( natgthorleh (pr1 xa) (pr2 xa)  ) as [ g'' | l ] .
 
 rewrite ( minusplusnmm _ _ ( natlthtoleh _ _ g'' ) ) . apply idpath .
 
@@ -870,7 +870,7 @@ Lemma hzabsvalgeh0 { x : hz } ( is : hzgeh x 0 ) : ( nattohz ( hzabsval x ) ) = 
 Proof .  intros . destruct ( hzgehchoice _ _ is ) as [ g | e ] .  apply ( hzabsvalgth0 g ) . rewrite e .  apply idpath .  Defined .
 
 Lemma hzabsvallth0 { x : hz } ( is : hzlth x 0 ) : ( nattohz ( hzabsval x ) ) = ( - x ) .
-Proof . assert ( int : Π x : hz , isaprop ( hzlth x 0 -> ( nattohz ( hzabsval x ) ) = ( - x ) ) ) . intro . apply impred . intro . apply ( setproperty hz ) .  apply ( setquotunivprop _ ( fun x => hProppair _ ( int x ) ) ) . intros xa l . simpl in xa . assert ( l' := natnattohzandlth _ _ l ) . simpl in l' .  simpl .  change (( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) ( dirprodpair ( hzabsvalint xa ) 0%nat ) ) = ( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) ( dirprodpair ( pr2 xa ) ( pr1 xa ) ) ) ) . apply weqpathsinsetquot . simpl . apply hinhpr . split with 0%nat .  change ( pr1 ( natlth ( pr1 xa + 0%nat ) ( pr2 xa ) ) ) in l' . rewrite ( natplusr0 _ ) in l' .  change ((hzabsvalint xa + pr1 xa + 0)%nat = (pr2 xa + 0 + 0)%nat). rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) . unfold hzabsvalint .   destruct ( natgthorleh (pr1 xa) (pr2 xa)  ) as [ g | l'' ] .
+Proof . assert ( int : ∏ x : hz , isaprop ( hzlth x 0 -> ( nattohz ( hzabsval x ) ) = ( - x ) ) ) . intro . apply impred . intro . apply ( setproperty hz ) .  apply ( setquotunivprop _ ( fun x => hProppair _ ( int x ) ) ) . intros xa l . simpl in xa . assert ( l' := natnattohzandlth _ _ l ) . simpl in l' .  simpl .  change (( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) ( dirprodpair ( hzabsvalint xa ) 0%nat ) ) = ( setquotpr (eqrelabgrdiff (rigaddabmonoid natcommrig)) ( dirprodpair ( pr2 xa ) ( pr1 xa ) ) ) ) . apply weqpathsinsetquot . simpl . apply hinhpr . split with 0%nat .  change ( pr1 ( natlth ( pr1 xa + 0%nat ) ( pr2 xa ) ) ) in l' . rewrite ( natplusr0 _ ) in l' .  change ((hzabsvalint xa + pr1 xa + 0)%nat = (pr2 xa + 0 + 0)%nat). rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) .  rewrite ( natplusr0 _ ) . unfold hzabsvalint .   destruct ( natgthorleh (pr1 xa) (pr2 xa)  ) as [ g | l'' ] .
 
 destruct ( isasymmnatgth _ _ g l' ) .
 
@@ -1036,7 +1036,7 @@ Proof.
 Qed.
 
 Lemma isarchhz_one :
-  Π x : hz, hzgth x 0 → ∃ n : nat, hzgth (nattohz n * x) 1.
+  ∏ x : hz, hzgth x 0 → ∃ n : nat, hzgth (nattohz n * x) 1.
 Proof.
   intros x Hx.
   generalize (isarchrng_1 _ isarchhz x Hx).
@@ -1048,7 +1048,7 @@ Proof.
 Qed.
 
 Lemma isarchhz_gt :
-  Π x : hz, ∃ n : nat, hzgth (nattohz n) x.
+  ∏ x : hz, ∃ n : nat, hzgth (nattohz n) x.
 Proof.
   intros x.
   generalize (isarchrng_2 _ isarchhz x).

--- a/UniMath/NumberSystems/NaturalNumbersAlgebra.v
+++ b/UniMath/NumberSystems/NaturalNumbersAlgebra.v
@@ -56,7 +56,7 @@ Proof.
 Defined.
 
 Lemma nattorig_nat :
-  Π n : nat, nattorig (X := natcommrig) n = n.
+  ∏ n : nat, nattorig (X := natcommrig) n = n.
 Proof.
   induction n as [|n IHn].
   reflexivity.
@@ -201,7 +201,7 @@ Defined.
 (** *** [nat] is an archimedean rig *)
 
 Lemma isarchnat_diff :
-  Π (y1 y2 : nat),
+  ∏ (y1 y2 : nat),
   y1 > y2 → ∃ n : nat, n * y1 > 1 + n * y2.
 Proof.
   intros y1 y2 Hy.
@@ -218,7 +218,7 @@ Proof.
 Defined.
 
 Lemma isarchnat_gth :
-  Π x : nat, ∃ n : nat, n > x.
+  ∏ x : nat, ∃ n : nat, n > x.
 Proof.
   intros n.
   apply hinhpr.
@@ -227,7 +227,7 @@ Proof.
 Defined.
 
 Lemma isarchnat_pos :
-  Π x : nat, ∃ n : nat, n + x > 0.
+  ∏ x : nat, ∃ n : nat, n + x > 0.
 Proof.
   intros n.
   apply hinhpr.

--- a/UniMath/NumberSystems/NaturalNumbers_le_Inductive.v
+++ b/UniMath/NumberSystems/NaturalNumbers_le_Inductive.v
@@ -36,7 +36,7 @@ to work with [natleh] than with [le].
 
 Inductive leF {T : UU} (F : T -> T) (t : T) : T -> UU :=
 | leF_O : leF F t t
-| leF_S : Π t' : T, leF F t t' -> leF F t (F t').
+| leF_S : ∏ t' : T, leF F t t' -> leF F t (F t').
 
 Lemma leFiter {T : UU} (F : T -> T) (t : T) (n : nat) : leF F t (iteration F n t).
 Proof.
@@ -78,7 +78,7 @@ Proof.
   intros.
   set (f := leFtototal2withnat F t t').
   set (g := total2withnattoleF  F t t').
-  assert (egf : Π x : _, paths (g (f x)) x).
+  assert (egf : ∏ x : _, paths (g (f x)) x).
   {
     intro x. induction x as [ | y H0 IHH0 ].
     - apply idpath.
@@ -87,7 +87,7 @@ Proof.
       destruct e. simpl. simpl in IHH0.
       apply (@maponpaths _ _ (leF_S F t (iteration F m t)) _ _ IHH0).
   }
-  assert (efg : Π x : _, paths (f (g x)) x).
+  assert (efg : ∏ x : _, paths (f (g x)) x).
   {
     intro x. destruct x as [ n e ]. destruct e. simpl.
     apply leFtototal2withnat_l0.
@@ -104,9 +104,9 @@ Definition weqleFtototalwithnat { T : UU } (F : T -> T) (t t' : T) :
 
 Definition le (n : nat) : nat -> UU := leF S n.
 
-Definition le_n : Π t : nat, leF S t t := leF_O S.
+Definition le_n : ∏ t : nat, leF S t t := leF_O S.
 
-Definition le_S : Π t t' : nat, leF S t t' → leF S t (S t') := leF_S S.
+Definition le_S : ∏ t t' : nat, leF S t t' → leF S t (S t') := leF_S S.
 
 Theorem isaprople (n m : nat) : isaprop (le n m).
 Proof.

--- a/UniMath/RealNumbers/DecidableDedekindCuts.v
+++ b/UniMath/RealNumbers/DecidableDedekindCuts.v
@@ -13,7 +13,7 @@ Open Scope Dcuts_scope.
 (** ** Definition *)
 
 Lemma isboolDcuts_isaprop (x : Dcuts) :
-  isaprop (Π r, (r ∈ x) ∨ (neg (r ∈ x))).
+  isaprop (∏ r, (r ∈ x) ∨ (neg (r ∈ x))).
 Proof.
   intros x.
   apply impred_isaprop.
@@ -36,11 +36,11 @@ Proof.
   apply (hSetpair (carrier isboolDcuts)).
   exact isaset_boolDcuts.
 Defined.
-Definition mk_boolDcuts (x : Dcuts) (Hdec : Π r : NonnegativeRationals, (r ∈ x) ⨿ ¬ (r ∈ x)) : boolDcuts :=
+Definition mk_boolDcuts (x : Dcuts) (Hdec : ∏ r : NonnegativeRationals, (r ∈ x) ⨿ ¬ (r ∈ x)) : boolDcuts :=
   x,, (λ r : NonnegativeRationals, hinhpr (Hdec r)).
 
 Lemma is_zero_dec :
-  Π x : Dcuts, isboolDcuts x -> (x = 0) ∨ (¬ (x = 0)).
+  ∏ x : Dcuts, isboolDcuts x -> (x = 0) ∨ (¬ (x = 0)).
 Proof.
   intros x Hx.
   generalize (Hx 0%NRat) ; apply hinhfun ; apply sumofmaps ; intros Hx0.

--- a/UniMath/RealNumbers/Fields.v
+++ b/UniMath/RealNumbers/Fields.v
@@ -3,7 +3,7 @@
 Require Export UniMath.Algebra.Domains_and_Fields.
 
 Lemma isapropmultinvpair :
-  Π (X : rig) (x : X), isaprop (multinvpair X x).
+  ∏ (X : rig) (x : X), isaprop (multinvpair X x).
 Proof.
   intros X x.
   apply isapropinvpair.

--- a/UniMath/RealNumbers/NonnegativeRationals.v
+++ b/UniMath/RealNumbers/NonnegativeRationals.v
@@ -345,7 +345,7 @@ Proof.
   reflexivity.
 Qed.
 Lemma plusNonnegativeRationals_correct :
-  Π (x y : NonnegativeRationals),
+  ∏ (x y : NonnegativeRationals),
     x + y = Rationals_to_NonnegativeRationals (pr1 x + pr1 y)%hq (hq0lehandplus _ _ (pr2 x) (pr2 y)).
 Proof.
   intros x y.
@@ -353,7 +353,7 @@ Proof.
   reflexivity.
 Qed.
 Lemma minusNonnegativeRationals_correct :
-  Π (x y : NonnegativeRationals) (Hminus : y <= x),
+  ∏ (x y : NonnegativeRationals) (Hminus : y <= x),
     x - y = Rationals_to_NonnegativeRationals (pr1 x - pr1 y)%hq (hq0leminus _ _ Hminus).
 Proof.
   intros x y H.
@@ -370,7 +370,7 @@ Proof.
     reflexivity.
 Qed.
 Lemma multNonnegativeRationals_correct :
-  Π (x y : NonnegativeRationals),
+  ∏ (x y : NonnegativeRationals),
     x * y = Rationals_to_NonnegativeRationals (pr1 x * pr1 y)%hq ( hq0lehandmult _ _ (pr2 x) (pr2 y)).
 Proof.
   intros x y.
@@ -378,7 +378,7 @@ Proof.
   reflexivity.
 Qed.
 Lemma invNonnegativeRationals_correct :
-  Π (x : NonnegativeRationals) (Hx : 0 < x),
+  ∏ (x : NonnegativeRationals) (Hx : 0 < x),
     / x = Rationals_to_NonnegativeRationals (/ pr1 x)%hq (hqlthtoleh _ _ (hqinv_gt0 _ Hx)).
 Proof.
   intros x Hx0.
@@ -395,25 +395,25 @@ Proof.
 Qed.
 
 Lemma leNonnegativeRationals_correct :
-  Π x y : NonnegativeRationals, (x <= y) = (pr1 x <= pr1 y)%hq.
+  ∏ x y : NonnegativeRationals, (x <= y) = (pr1 x <= pr1 y)%hq.
 Proof.
   intros x y.
   reflexivity.
 Qed.
 Lemma geNonnegativeRationals_correct :
-  Π x y : NonnegativeRationals, (x >= y) = (pr1 x >= pr1 y)%hq.
+  ∏ x y : NonnegativeRationals, (x >= y) = (pr1 x >= pr1 y)%hq.
 Proof.
   intros x y.
   reflexivity.
 Qed.
 Lemma ltNonnegativeRationals_correct :
-  Π x y : NonnegativeRationals, (x < y) = (pr1 x < pr1 y)%hq.
+  ∏ x y : NonnegativeRationals, (x < y) = (pr1 x < pr1 y)%hq.
 Proof.
   intros x y.
   reflexivity.
 Qed.
 Lemma gtNonnegativeRationals_correct :
-  Π x y : NonnegativeRationals, (x > y) = (pr1 x > pr1 y)%hq.
+  ∏ x y : NonnegativeRationals, (x > y) = (pr1 x > pr1 y)%hq.
 Proof.
   intros x y.
   reflexivity.
@@ -424,7 +424,7 @@ Qed.
 (** *** Decidability *)
 
 Lemma isdeceq_NonnegativeRationals :
-  Π x y : NonnegativeRationals, (x = y) ⨿ (x != y).
+  ∏ x y : NonnegativeRationals, (x = y) ⨿ (x != y).
 Proof.
   intros x y.
   generalize (isdeceqhq (pr1 x) (pr1 y)) ;
@@ -438,20 +438,20 @@ Proof.
     apply base_paths.
 Qed.
 Lemma isdecrel_leNonnegativeRationals :
-  Π x y : NonnegativeRationals, (x <= y) ⨿ ¬ (x <= y).
+  ∏ x y : NonnegativeRationals, (x <= y) ⨿ ¬ (x <= y).
 Proof.
   intros x y.
   apply isdecrelhqleh.
 Qed.
 Lemma isdecrel_ltNonnegativeRationals :
-  Π x y : NonnegativeRationals, (x < y) ⨿ ¬ (x < y).
+  ∏ x y : NonnegativeRationals, (x < y) ⨿ ¬ (x < y).
 Proof.
   intros x y.
   apply isdecrelhqlth.
 Qed.
 
 Lemma le_eqorltNonnegativeRationals :
-  Π x y : NonnegativeRationals, x <= y -> (x = y) ⨿ (x < y).
+  ∏ x y : NonnegativeRationals, x <= y -> (x = y) ⨿ (x < y).
 Proof.
   intros x y Hle.
   generalize (hqlehchoice (pr1 x) (pr1 y) Hle) ;
@@ -461,7 +461,7 @@ Proof.
     now apply subtypeEquality_prop, Heq.
 Qed.
 Lemma noteq_ltorgtNonnegativeRationals :
-  Π x y : NonnegativeRationals, x != y -> (x < y) ⨿ (x > y).
+  ∏ x y : NonnegativeRationals, x != y -> (x < y) ⨿ (x > y).
 Proof.
   intros x y Hneq.
   generalize (isdecrel_leNonnegativeRationals x y) ;
@@ -476,7 +476,7 @@ Proof.
     exact Hlt.
 Qed.
 Lemma eq0orgt0NonnegativeRationals :
-  Π x : NonnegativeRationals, (x = 0) ⨿ (0 < x).
+  ∏ x : NonnegativeRationals, (x = 0) ⨿ (0 < x).
 Proof.
   intros x.
   generalize (le_eqorltNonnegativeRationals 0 x (pr2 x)) ; apply sumofmaps ; intros Hx.
@@ -487,30 +487,30 @@ Qed.
 (** *** Basic theorems about order *)
 
 Definition lt_leNonnegativeRationals :
-  Π x y : NonnegativeRationals, x < y -> x <= y
+  ∏ x y : NonnegativeRationals, x < y -> x <= y
   := EOlt_le (X := NonnegativeRationals_EffectivelyOrderedSet).
 
 Definition isrefl_leNonnegativeRationals:
-  Π x : NonnegativeRationals, x <= x :=
+  ∏ x : NonnegativeRationals, x <= x :=
   isrefl_EOle (X := NonnegativeRationals_EffectivelyOrderedSet).
 Definition istrans_leNonnegativeRationals:
-  Π x y z : NonnegativeRationals, x <= y -> y <= z -> x <= z :=
+  ∏ x y z : NonnegativeRationals, x <= y -> y <= z -> x <= z :=
   istrans_EOle (X := NonnegativeRationals_EffectivelyOrderedSet).
 Definition isirrefl_ltNonnegativeRationals:
-  Π x : NonnegativeRationals, ¬ (x < x) :=
+  ∏ x : NonnegativeRationals, ¬ (x < x) :=
   isirrefl_EOlt (X := NonnegativeRationals_EffectivelyOrderedSet).
 Definition istrans_ltNonnegativeRationals :
-  Π x y z : NonnegativeRationals, x < y -> y < z -> x < z
+  ∏ x y z : NonnegativeRationals, x < y -> y < z -> x < z
   := istrans_EOlt (X := NonnegativeRationals_EffectivelyOrderedSet).
 Definition istrans_lt_le_ltNonnegativeRationals:
-  Π x y z : NonnegativeRationals, x < y -> y <= z -> x < z
+  ∏ x y z : NonnegativeRationals, x < y -> y <= z -> x < z
   := istrans_EOlt_le (X := NonnegativeRationals_EffectivelyOrderedSet).
 Definition istrans_le_lt_ltNonnegativeRationals :
-  Π x y z : NonnegativeRationals, x <= y -> y < z -> x < z
+  ∏ x y z : NonnegativeRationals, x <= y -> y < z -> x < z
   := istrans_EOle_lt (X := NonnegativeRationals_EffectivelyOrderedSet).
 
 Lemma isantisymm_leNonnegativeRationals :
-  Π x y : NonnegativeRationals, x <= y -> y <= x -> x = y.
+  ∏ x y : NonnegativeRationals, x <= y -> y <= x -> x = y.
 Proof.
   intros x y Hle Hge.
   apply subtypeEquality_prop.
@@ -518,16 +518,16 @@ Proof.
 Qed.
 
 Definition ge_leNonnegativeRationals:
-  Π x y : NonnegativeRationals, (x >= y) <-> (y <= x)
+  ∏ x y : NonnegativeRationals, (x >= y) <-> (y <= x)
   := EOge_le (X := NonnegativeRationals_EffectivelyOrderedSet).
 Definition lt_gtNonnegativeRationals:
-  Π x y : NonnegativeRationals, (x > y) <-> (y < x)
+  ∏ x y : NonnegativeRationals, (x > y) <-> (y < x)
   := EOgt_lt (X := NonnegativeRationals_EffectivelyOrderedSet).
 Definition notlt_geNonnegativeRationals:
-  Π x y : NonnegativeRationals, (¬ (x < y)) <-> (y <= x)
+  ∏ x y : NonnegativeRationals, (¬ (x < y)) <-> (y <= x)
   := not_EOlt_le (X := NonnegativeRationals_EffectivelyOrderedSet).
 Lemma notge_ltNonnegativeRationals :
-  Π x y : NonnegativeRationals, (¬ (y <= x)) <-> (x < y).
+  ∏ x y : NonnegativeRationals, (¬ (y <= x)) <-> (x < y).
 Proof.
   intros x y.
   split.
@@ -536,15 +536,15 @@ Proof.
 Qed.
 
 Definition ltNonnegativeRationals_noteq :
-  Π x y, x < y -> x != y
+  ∏ x y, x < y -> x != y
   := EOlt_noteq (X := NonnegativeRationals_EffectivelyOrderedSet).
 Definition gtNonnegativeRationals_noteq :
-  Π x y, x > y -> x != y
+  ∏ x y, x > y -> x != y
   := EOgt_noteq (X := NonnegativeRationals_EffectivelyOrderedSet).
 
 Lemma between_ltNonnegativeRationals :
-  Π x y : NonnegativeRationals,
-    x < y -> Σ t : NonnegativeRationals, x < t × t < y.
+  ∏ x y : NonnegativeRationals,
+    x < y -> ∑ t : NonnegativeRationals, x < t × t < y.
 Proof.
   intros x y H.
   set (z := hqlth_between (pr1 x) (pr1 y) H).
@@ -559,20 +559,20 @@ Qed.
 (** *** Order and 0 *)
 
 Lemma isnonnegative_NonnegativeRationals :
-  Π x : NonnegativeRationals , 0 <= x.
+  ∏ x : NonnegativeRationals , 0 <= x.
 Proof.
   intros x.
   apply (pr2 x).
 Qed.
 Lemma isnonnegative_NonnegativeRationals' :
-  Π x : NonnegativeRationals , ¬ (x < 0).
+  ∏ x : NonnegativeRationals , ¬ (x < 0).
 Proof.
   intros x.
   apply (pr2 x).
 Qed.
 
 Lemma NonnegativeRationals_eq0_le0 :
-  Π r : NonnegativeRationals, (r <= 0) -> (r = 0).
+  ∏ r : NonnegativeRationals, (r <= 0) -> (r = 0).
 Proof.
   intros r Hr0.
   apply subtypeEquality_prop.
@@ -581,7 +581,7 @@ Proof.
   apply (pr2 r).
 Qed.
 Lemma NonnegativeRationals_neq0_gt0 :
-  Π r : NonnegativeRationals, (r != 0) -> (0 < r).
+  ∏ r : NonnegativeRationals, (r != 0) -> (0 < r).
 Proof.
   intros r Hr0.
   apply neghqlehtogth.
@@ -610,25 +610,25 @@ Qed.
 (** Rewritings *)
 
 Definition isassoc_plusNonnegativeRationals:
-  Π x y z : NonnegativeRationals, x + y + z = x + (y + z) :=
+  ∏ x y z : NonnegativeRationals, x + y + z = x + (y + z) :=
   CommDivRig_isassoc_plus.
 
 Definition islunit_zeroNonnegativeRationals:
-  Π r : NonnegativeRationals, 0 + r = r :=
+  ∏ r : NonnegativeRationals, 0 + r = r :=
   CommDivRig_islunit_zero.
 
 Definition isrunit_zeroNonnegativeRationals:
-  Π r : NonnegativeRationals, r + 0 = r :=
+  ∏ r : NonnegativeRationals, r + 0 = r :=
   CommDivRig_isrunit_zero.
 
 Definition iscomm_plusNonnegativeRationals:
-  Π x y : NonnegativeRationals, x + y = y + x :=
+  ∏ x y : NonnegativeRationals, x + y = y + x :=
   CommDivRig_iscomm_plus.
 
 (** Order *)
 
 Lemma plusNonnegativeRationals_ltcompat_r :
-  Π x y z : NonnegativeRationals, (y < z) <-> (y + x < z + x).
+  ∏ x y z : NonnegativeRationals, (y < z) <-> (y + x < z + x).
 Proof.
   intros x y z.
   split.
@@ -636,7 +636,7 @@ Proof.
   now apply hqlthandplusrinv.
 Qed.
 Lemma plusNonnegativeRationals_ltcompat_l :
-  Π x y z : NonnegativeRationals, (y < z) <-> (x + y < x + z).
+  ∏ x y z : NonnegativeRationals, (y < z) <-> (x + y < x + z).
 Proof.
   intros x y z.
   rewrite !(iscomm_plusNonnegativeRationals x).
@@ -644,7 +644,7 @@ Proof.
 Qed.
 
 Lemma plusNonnegativeRationals_lecompat_r :
-  Π r q n : NonnegativeRationals, (q <= n) <-> (q + r <= n + r).
+  ∏ r q n : NonnegativeRationals, (q <= n) <-> (q + r <= n + r).
 Proof.
   intros r q n.
   split.
@@ -652,7 +652,7 @@ Proof.
   - now apply hqlehandplusrinv.
 Qed.
 Lemma plusNonnegativeRationals_lecompat_l :
-  Π r q n : NonnegativeRationals, (q <= n) <-> (r + q <= r + n).
+  ∏ r q n : NonnegativeRationals, (q <= n) <-> (r + q <= r + n).
 Proof.
   intros r q n.
   rewrite ! (iscomm_plusNonnegativeRationals r).
@@ -660,7 +660,7 @@ Proof.
 Qed.
 
 Lemma plusNonnegativeRationals_eqcompat_l:
-  Π k x y : NonnegativeRationals,
+  ∏ k x y : NonnegativeRationals,
     (k + x = k + y) -> (x = y).
 Proof.
   intros k x y H.
@@ -670,7 +670,7 @@ Proof.
     apply isrefl_leNonnegativeRationals.
 Qed.
 Lemma plusNonnegativeRationals_eqcompat_r:
-  Π k x y : NonnegativeRationals,
+  ∏ k x y : NonnegativeRationals,
     (x + k = y + k) -> (x = y).
 Proof.
   intros k x y.
@@ -679,7 +679,7 @@ Proof.
 Qed.
 
 Lemma plusNonnegativeRationals_ltcompat :
-  Π x x' y y' : NonnegativeRationals,
+  ∏ x x' y y' : NonnegativeRationals,
     x < x' -> y < y' -> x + y < x' + y'.
 Proof.
   intros x x' y y' Hx Hy.
@@ -688,7 +688,7 @@ Proof.
   now apply hqlthandplusr, Hx.
 Qed.
 Lemma plusNonnegativeRationals_le_lt_ltcompat :
-  Π x x' y y' : NonnegativeRationals,
+  ∏ x x' y y' : NonnegativeRationals,
     x <= x' -> y < y' -> x + y < x' + y'.
 Proof.
   intros x x' y y' Hx Hy.
@@ -697,7 +697,7 @@ Proof.
   now apply hqlehandplusr, Hx.
 Qed.
 Lemma plusNonnegativeRationals_lt_le_ltcompat :
-  Π x x' y y' : NonnegativeRationals,
+  ∏ x x' y y' : NonnegativeRationals,
     x < x' -> y <= y' -> x + y < x' + y'.
 Proof.
   intros x x' y y' Hx Hy.
@@ -707,7 +707,7 @@ Proof.
 Qed.
 
 Lemma plusNonnegativeRationals_le_r :
-  Π r q : NonnegativeRationals, r <= r + q.
+  ∏ r q : NonnegativeRationals, r <= r + q.
 Proof.
   intros r q.
   pattern r at 1.
@@ -716,7 +716,7 @@ Proof.
   apply (pr2 q).
 Qed.
 Lemma plusNonnegativeRationals_le_l :
-  Π r q : NonnegativeRationals, r <= q + r.
+  ∏ r q : NonnegativeRationals, r <= q + r.
 Proof.
   intros r q.
   rewrite iscomm_plusNonnegativeRationals.
@@ -724,7 +724,7 @@ Proof.
 Qed.
 
 Lemma ispositive_plusNonnegativeRationals_l :
-  Π x y : NonnegativeRationals, 0 < x -> 0 < x + y.
+  ∏ x y : NonnegativeRationals, 0 < x -> 0 < x + y.
 Proof.
   intros x y Hx.
   apply istrans_lt_le_ltNonnegativeRationals with x.
@@ -732,7 +732,7 @@ Proof.
   now apply plusNonnegativeRationals_le_r.
 Qed.
 Lemma ispositive_plusNonnegativeRationals_r :
-  Π x y : NonnegativeRationals, 0 < y -> 0 < x + y.
+  ∏ x y : NonnegativeRationals, 0 < y -> 0 < x + y.
 Proof.
   intros x y Hy.
   apply istrans_lt_le_ltNonnegativeRationals with y.
@@ -741,7 +741,7 @@ Proof.
 Qed.
 
 Lemma plusNonnegativeRationals_lt_r :
-  Π r q : NonnegativeRationals, 0 < q -> r < r + q.
+  ∏ r q : NonnegativeRationals, 0 < q -> r < r + q.
 Proof.
   intros x y Hy0.
   pattern x at 1.
@@ -750,7 +750,7 @@ Proof.
   exact Hy0.
 Qed.
 Lemma plusNonnegativeRationals_lt_l :
-  Π r q : NonnegativeRationals, 0 < r -> q < r + q.
+  ∏ r q : NonnegativeRationals, 0 < r -> q < r + q.
 Proof.
   intros x y.
   rewrite iscomm_plusNonnegativeRationals.
@@ -761,7 +761,7 @@ Qed.
 (** Rewriting *)
 
 Lemma minusNonnegativeRationals_eq_zero:
-  Π x y : NonnegativeRationals, x <= y -> x - y = 0.
+  ∏ x y : NonnegativeRationals, x <= y -> x - y = 0.
 Proof.
   intros x y Hle.
   unfold minusNonnegativeRationals, hnnq_minus.
@@ -772,7 +772,7 @@ Proof.
   - reflexivity.
 Qed.
 Lemma minusNonnegativeRationals_plus_r :
-  Π r q : NonnegativeRationals,
+  ∏ r q : NonnegativeRationals,
     r <= q -> (q - r) + r = q.
 Proof.
   intros r q H.
@@ -797,7 +797,7 @@ Proof.
 Qed.
 
 Lemma plusNonnegativeRationals_minus_r :
-  Π q r : NonnegativeRationals, (r + q) - q = r.
+  ∏ q r : NonnegativeRationals, (r + q) - q = r.
 Proof.
   intros q r.
   rewrite (tppr r), (tppr q).
@@ -809,7 +809,7 @@ Proof.
   now rewrite hqplusassoc, (hqpluscomm q'), (hqlminus q'), hqplusr0.
 Qed.
 Lemma plusNonnegativeRationals_minus_l :
-  Π q r : NonnegativeRationals, (q + r) - q = r.
+  ∏ q r : NonnegativeRationals, (q + r) - q = r.
 Proof.
   intros q r.
   rewrite iscomm_plusNonnegativeRationals.
@@ -817,27 +817,27 @@ Proof.
 Qed.
 
 Lemma minusNonnegativeRationals_correct_l :
-  Π x y z : NonnegativeRationals, x = y + z -> z = x - y.
+  ∏ x y z : NonnegativeRationals, x = y + z -> z = x - y.
 Proof.
   intros x y z ->.
   now rewrite plusNonnegativeRationals_minus_l.
 Qed.
 Lemma minusNonnegativeRationals_correct_r :
-  Π x y z : NonnegativeRationals, x = y + z -> y = x - z.
+  ∏ x y z : NonnegativeRationals, x = y + z -> y = x - z.
 Proof.
   intros x y z ->.
   now rewrite plusNonnegativeRationals_minus_r.
 Qed.
 
 Lemma minusNonnegativeRationals_zero_l :
-  Π x : NonnegativeRationals, 0 - x = 0.
+  ∏ x : NonnegativeRationals, 0 - x = 0.
 Proof.
   intros x.
   apply minusNonnegativeRationals_eq_zero.
   now apply isnonnegative_NonnegativeRationals.
 Qed.
 Lemma minusNonnegativeRationals_zero_r :
-  Π x : NonnegativeRationals, x - 0 = x.
+  ∏ x : NonnegativeRationals, x - 0 = x.
 Proof.
   intros x.
   rewrite <- (isrunit_zeroNonnegativeRationals (x - 0)).
@@ -846,7 +846,7 @@ Proof.
 Qed.
 
 Lemma minusNonnegativeRationals_plus_exchange :
-  Π x y z : NonnegativeRationals, y <= x -> x - y + z = (x + z) - y.
+  ∏ x y z : NonnegativeRationals, y <= x -> x - y + z = (x + z) - y.
 Proof.
   intros x y z Hxy.
   assert (Hxzy : y <= x + z).
@@ -865,7 +865,7 @@ Qed.
 (** Order *)
 
 Lemma ispositive_minusNonnegativeRationals :
-  Π x y : NonnegativeRationals, (x < y) <-> (0 < y - x).
+  ∏ x y : NonnegativeRationals, (x < y) <-> (0 < y - x).
 Proof.
   intros x y.
   split ; intro Hlt.
@@ -882,7 +882,7 @@ Proof.
 Qed.
 
 Lemma minusNonnegativeRationals_le :
-  Π x y : NonnegativeRationals, x - y <= x.
+  ∏ x y : NonnegativeRationals, x - y <= x.
 Proof.
   intros x y.
   apply_pr2 (plusNonnegativeRationals_lecompat_r y).
@@ -899,7 +899,7 @@ Proof.
 Qed.
 
 Lemma minusNonnegativeRationals_lecompat_l :
-  Π k x y : NonnegativeRationals, x <= y -> x - k <= y - k.
+  ∏ k x y : NonnegativeRationals, x <= y -> x - k <= y - k.
 Proof.
   intros k x y Hxy.
   generalize (isdecrel_leNonnegativeRationals k x) ;
@@ -914,7 +914,7 @@ Proof.
     now apply lt_leNonnegativeRationals, notge_ltNonnegativeRationals.
 Qed.
 Lemma minusNonnegativeRationals_lecompat_l' :
-  Π k x y : NonnegativeRationals, k <= y -> x - k <= y - k -> x <= y.
+  ∏ k x y : NonnegativeRationals, k <= y -> x - k <= y - k -> x <= y.
 Proof.
   intros k x y Hky H.
   generalize (isdecrel_leNonnegativeRationals k x) ;
@@ -929,7 +929,7 @@ Proof.
 Qed.
 
 Lemma minusNonnegativeRationals_lecompat_r :
-  Π k x y : NonnegativeRationals, x <= y -> k - y <= k - x.
+  ∏ k x y : NonnegativeRationals, x <= y -> k - y <= k - x.
 Proof.
   intros k x y Hxy.
   generalize (isdecrel_leNonnegativeRationals y k) ;
@@ -947,7 +947,7 @@ Proof.
     now apply lt_leNonnegativeRationals, notge_ltNonnegativeRationals.
 Qed.
 Lemma minusNonnegativeRationals_lecompat_r' :
-  Π k x y : NonnegativeRationals, x <= k -> k - y <= k - x -> x <= y.
+  ∏ k x y : NonnegativeRationals, x <= k -> k - y <= k - x -> x <= y.
 Proof.
   intros k x y Hkx H.
   generalize (isdecrel_leNonnegativeRationals y k) ;
@@ -965,7 +965,7 @@ Proof.
 Qed.
 
 Lemma minusNonnegativeRationals_ltcompat_l:
-  Π x y z : NonnegativeRationals, x < y -> z < y -> x - z < y - z.
+  ∏ x y z : NonnegativeRationals, x < y -> z < y -> x - z < y - z.
 Proof.
   intros x y z Hxy Hyz.
   generalize (isdecrel_leNonnegativeRationals x z) ;
@@ -981,7 +981,7 @@ Proof.
     now apply lt_leNonnegativeRationals, Hxz.
 Qed.
 Lemma minusNonnegativeRationals_ltcompat_l' :
-  Π x y z : NonnegativeRationals, x - z < y - z -> x < y.
+  ∏ x y z : NonnegativeRationals, x - z < y - z -> x < y.
 Proof.
   intros x y z Hlt.
   assert (Hyz : (z < y)%NRat).
@@ -1001,7 +1001,7 @@ Proof.
     exact Hlt.
 Qed.
 Lemma minusNonnegativeRationals_ltcompat_r:
-  Π x y z : NonnegativeRationals, x < y -> x < z -> z - y < z - x.
+  ∏ x y z : NonnegativeRationals, x < y -> x < z -> z - y < z - x.
 Proof.
   intros x y z Hxy Hxz.
   generalize (isdecrel_leNonnegativeRationals y z) ;
@@ -1019,7 +1019,7 @@ Proof.
     now apply lt_leNonnegativeRationals, notge_ltNonnegativeRationals, Hky.
 Qed.
 Lemma minusNonnegativeRationals_ltcompat_r':
-  Π x y z : NonnegativeRationals, z - y < z - x -> x < y.
+  ∏ x y z : NonnegativeRationals, z - y < z - x -> x < y.
 Proof.
   intros x y z H.
   apply notge_ltNonnegativeRationals.
@@ -1033,34 +1033,34 @@ Qed.
 (** Rewritings *)
 
 Definition isassoc_multNonnegativeRationals:
-  Π x y z : NonnegativeRationals, x * y * z = x * (y * z) :=
+  ∏ x y z : NonnegativeRationals, x * y * z = x * (y * z) :=
   CommDivRig_isassoc_mult.
 Definition islunit_oneNonnegativeRationals:
-  Π x : NonnegativeRationals, 1 * x = x :=
+  ∏ x : NonnegativeRationals, 1 * x = x :=
   CommDivRig_islunit_one.
 Definition isrunit_oneNonnegativeRationals:
-  Π x : NonnegativeRationals, x * 1 = x :=
+  ∏ x : NonnegativeRationals, x * 1 = x :=
   CommDivRig_isrunit_one.
 Definition iscomm_multNonnegativeRationals:
-  Π x y : NonnegativeRationals, x * y = y * x :=
+  ∏ x y : NonnegativeRationals, x * y = y * x :=
   CommDivRig_iscomm_mult.
 Definition isldistr_mult_plusNonnegativeRationals:
-  Π x y z : NonnegativeRationals, z * (x + y) = z * x + z * y :=
+  ∏ x y z : NonnegativeRationals, z * (x + y) = z * x + z * y :=
   CommDivRig_isldistr.
 Definition isrdistr_mult_plusNonnegativeRationals:
-  Π x y z : NonnegativeRationals, (x + y) * z = x * z + y * z :=
+  ∏ x y z : NonnegativeRationals, (x + y) * z = x * z + y * z :=
   CommDivRig_isrdistr.
 Definition islabsorb_zero_multNonnegativeRationals:
-  Π x : NonnegativeRationals, 0 * x = 0 :=
+  ∏ x : NonnegativeRationals, 0 * x = 0 :=
   rigmult0x _.
 Definition israbsorb_zero_multNonnegativeRationals:
-  Π x : NonnegativeRationals, x * 0 = 0 :=
+  ∏ x : NonnegativeRationals, x * 0 = 0 :=
   rigmultx0 _.
 
 (** Order *)
 
 Lemma multNonnegativeRationals_ltcompat_l :
-  Π k x y : NonnegativeRationals, 0 < k -> (x < y) <->  (k * x < k * y).
+  ∏ k x y : NonnegativeRationals, 0 < k -> (x < y) <->  (k * x < k * y).
 Proof.
   intros k x y Hk.
   split ; intro H.
@@ -1072,7 +1072,7 @@ Proof.
     exact H.
 Qed.
 Lemma multNonnegativeRationals_ltcompat_r :
-  Π k x y : NonnegativeRationals, 0 < k -> (x < y) <-> (x * k < y * k).
+  ∏ k x y : NonnegativeRationals, 0 < k -> (x < y) <-> (x * k < y * k).
 Proof.
   intros k x y Hk.
   rewrite !(iscomm_multNonnegativeRationals _ k).
@@ -1080,7 +1080,7 @@ Proof.
 Qed.
 
 Lemma multNonnegativeRationals_lecompat_l :
-  Π k x y : NonnegativeRationals, x <= y -> k * x <= k * y.
+  ∏ k x y : NonnegativeRationals, x <= y -> k * x <= k * y.
 Proof.
   intros k x y Hle.
   generalize (eq0orgt0NonnegativeRationals k) ;
@@ -1092,21 +1092,21 @@ Proof.
     exact Hk0.
 Qed.
 Lemma multNonnegativeRationals_lecompat_l' :
-  Π k x y : NonnegativeRationals, 0 < k -> k * x <= k * y -> x <= y.
+  ∏ k x y : NonnegativeRationals, 0 < k -> k * x <= k * y -> x <= y.
 Proof.
   intros k x y Hk0.
   apply (hqlehandmultlinv (pr1 x) (pr1 y) (pr1 k)).
   exact Hk0.
 Qed.
 Lemma multNonnegativeRationals_lecompat_r :
-  Π k x y : NonnegativeRationals, x <= y -> x * k <= y * k.
+  ∏ k x y : NonnegativeRationals, x <= y -> x * k <= y * k.
 Proof.
   intros k x y Hk.
   rewrite !(iscomm_multNonnegativeRationals _ k).
   now apply multNonnegativeRationals_lecompat_l.
 Qed.
 Lemma multNonnegativeRationals_lecompat_r' :
-  Π k x y : NonnegativeRationals, 0 < k -> x * k <= y * k -> x <= y.
+  ∏ k x y : NonnegativeRationals, 0 < k -> x * k <= y * k -> x <= y.
 Proof.
   intros k x y Hk.
   rewrite !(iscomm_multNonnegativeRationals _ k).
@@ -1114,7 +1114,7 @@ Proof.
 Qed.
 
 Lemma multNonnegativeRationals_eqcompat_l:
-  Π k x y : NonnegativeRationals,
+  ∏ k x y : NonnegativeRationals,
     0 < k -> k * x = k * y -> x = y.
 Proof.
   intros k x y Hk0 H.
@@ -1131,7 +1131,7 @@ Proof.
   now apply islunit_oneNonnegativeRationals.
 Qed.
 Lemma multNonnegativeRationals_eqcompat_r:
-  Π k x y : NonnegativeRationals,
+  ∏ k x y : NonnegativeRationals,
     0 < k -> x * k = y * k -> x = y.
 Proof.
   intros k x y.
@@ -1140,7 +1140,7 @@ Proof.
 Qed.
 
 Lemma ispositive_multNonnegativeRationals:
-  Π x y : NonnegativeRationals,
+  ∏ x y : NonnegativeRationals,
     0 < x -> 0 < y -> 0 < x * y.
 Proof.
   intros x y Hx Hy.
@@ -1150,7 +1150,7 @@ Proof.
   exact Hy.
 Qed.
 Lemma multNonnegativeRationals_ltcompat:
-  Π x x' y y' : NonnegativeRationals,
+  ∏ x x' y y' : NonnegativeRationals,
     x < x' -> y < y' -> x * y < x' * y'.
 Proof.
   intros x x' y y' Hx Hy.
@@ -1170,7 +1170,7 @@ Proof.
     now apply lt_leNonnegativeRationals.
 Qed.
 Lemma multNonnegativeRationals_le_lt:
-  Π x x' y y' : NonnegativeRationals,
+  ∏ x x' y y' : NonnegativeRationals,
     0 < x -> x <= x' -> y < y' -> x * y < x' * y'.
 Proof.
   intros x x' y y' Hx0 Hx Hy.
@@ -1181,7 +1181,7 @@ Proof.
   - now apply multNonnegativeRationals_lecompat_r, Hx.
 Qed.
 Lemma multNonnegativeRationals_lt_le:
-  Π x x' y y' : NonnegativeRationals,
+  ∏ x x' y y' : NonnegativeRationals,
     0 < y -> x < x' -> y <= y' -> x * y < x' * y'.
 Proof.
   intros x x' y y' Hy0 Hx Hy.
@@ -1193,14 +1193,14 @@ Proof.
 Qed.
 
 Lemma multNonnegativeRationals_le1_r :
-  Π q r : NonnegativeRationals, q <= 1 -> r * q <= r.
+  ∏ q r : NonnegativeRationals, q <= 1 -> r * q <= r.
 Proof.
   intros q r Hq.
   pattern r at 2 ; rewrite <- isrunit_oneNonnegativeRationals.
   now apply multNonnegativeRationals_lecompat_l.
 Qed.
 Lemma multNonnegativeRationals_le1_l :
-  Π q r : NonnegativeRationals, q <= 1 -> q * r <= r.
+  ∏ q r : NonnegativeRationals, q <= 1 -> q * r <= r.
 Proof.
   intros q r Hq.
   pattern r at 2 ; rewrite <- islunit_oneNonnegativeRationals.
@@ -1208,7 +1208,7 @@ Proof.
 Qed.
 
 Lemma isldistr_mult_minusNonnegativeRationals:
-  Π x y z : NonnegativeRationals, z * (x - y) = z * x - z * y.
+  ∏ x y z : NonnegativeRationals, z * (x - y) = z * x - z * y.
 Proof.
   intros x y z.
   generalize (isdecrel_leNonnegativeRationals x y) ;
@@ -1227,7 +1227,7 @@ Proof.
     exact Hlt.
 Qed.
 Lemma isrdistr_mult_minusNonnegativeRationals:
-  Π x y z : NonnegativeRationals, (x - y) * z = x * z - y * z.
+  ∏ x y z : NonnegativeRationals, (x - y) * z = x * z - y * z.
 Proof.
   intros x y z.
   rewrite !(iscomm_multNonnegativeRationals _ z).
@@ -1238,7 +1238,7 @@ Qed.
 (** Rewritings *)
 
 Definition islinv_NonnegativeRationals:
-  Π x : NonnegativeRationals, 0 < x -> / x * x = 1.
+  ∏ x : NonnegativeRationals, 0 < x -> / x * x = 1.
 Proof.
   intros x Hx0.
   assert (Hx : x != 0).
@@ -1248,7 +1248,7 @@ Proof.
   apply @CommDivRig_islinv.
 Qed.
 Definition isrinv_NonnegativeRationals:
-  Π x : NonnegativeRationals, 0 < x -> x * / x = 1.
+  ∏ x : NonnegativeRationals, 0 < x -> x * / x = 1.
 Proof.
   intros x.
   rewrite iscomm_multNonnegativeRationals.
@@ -1266,7 +1266,7 @@ Proof.
 Qed.
 
 Lemma ispositive_invNonnegativeRationals :
-  Π x, (0 < x) <-> (0 < / x).
+  ∏ x, (0 < x) <-> (0 < / x).
 Proof.
   intros x.
   split ; intro Hx.
@@ -1294,7 +1294,7 @@ Proof.
 Qed.
 
 Lemma isinvolutive_invNonnegativeRationals :
-  Π x, / / x = x.
+  ∏ x, / / x = x.
 Proof.
   intros x.
   generalize (eq0orgt0NonnegativeRationals x) ;
@@ -1311,7 +1311,7 @@ Qed.
 (** Order *)
 
 Lemma invNonnegativeRationals_lecompat :
-  Π x y : NonnegativeRationals, 0 < x -> x <= y -> / y <= / x.
+  ∏ x y : NonnegativeRationals, 0 < x -> x <= y -> / y <= / x.
 Proof.
   intros x y Hx0 Hxy.
   assert (Hy0 : 0 < y).
@@ -1329,7 +1329,7 @@ Proof.
   exact Hx0.
 Qed.
 Lemma invNonnegativeRationals_lecompat' :
-  Π x y : NonnegativeRationals, 0 < y -> / y <= / x -> x <= y.
+  ∏ x y : NonnegativeRationals, 0 < y -> / y <= / x -> x <= y.
 Proof.
   intros x y Hy0 Hxy.
   rewrite <- (isinvolutive_invNonnegativeRationals x), <- (isinvolutive_invNonnegativeRationals y).
@@ -1339,7 +1339,7 @@ Proof.
 Qed.
 
 Lemma invNonnegativeRationals_ltcompat :
-  Π x y : NonnegativeRationals, 0 < x -> x < y -> / y < / x.
+  ∏ x y : NonnegativeRationals, 0 < x -> x < y -> / y < / x.
 Proof.
   intros x y Hx0 Hxy.
   apply notge_ltNonnegativeRationals.
@@ -1351,7 +1351,7 @@ Proof.
   exact H.
 Qed.
 Lemma invNonnegativeRationals_ltcompat' :
-  Π x y : NonnegativeRationals, 0 < y -> / y < / x -> x < y.
+  ∏ x y : NonnegativeRationals, 0 < y -> / y < / x -> x < y.
 Proof.
   intros x y Hy0 Hxy.
   rewrite <- (isinvolutive_invNonnegativeRationals x), <- (isinvolutive_invNonnegativeRationals y).
@@ -1362,7 +1362,7 @@ Proof.
 Qed.
 
 Lemma issublinear_invNonnegativeRationals :
-  Π x y : NonnegativeRationals, / (x + y) <= / x + / y.
+  ∏ x y : NonnegativeRationals, / (x + y) <= / x + / y.
 Proof.
   intros x y.
   generalize (eq0orgt0NonnegativeRationals x) ;
@@ -1384,7 +1384,7 @@ Proof.
   now apply ispositive_plusNonnegativeRationals_l, Hx0.
 Qed.
 Lemma issublinear_invNonnegativeRationals_lt :
-  Π x y : NonnegativeRationals, (0 < x)%NRat -> (0 < y)%NRat -> (/ (x + y) < / x + / y)%NRat.
+  ∏ x y : NonnegativeRationals, (0 < x)%NRat -> (0 < y)%NRat -> (/ (x + y) < / x + / y)%NRat.
 Proof.
   intros x y Hx0 Hy0.
   apply_pr2 (multNonnegativeRationals_ltcompat_l x).
@@ -1407,7 +1407,7 @@ Qed.
 (** Rewritings *)
 
 Lemma multdivNonnegativeRationals :
-  Π q r : NonnegativeRationals, 0 < r -> r * (q / r) = q.
+  ∏ q r : NonnegativeRationals, 0 < r -> r * (q / r) = q.
 Proof.
   intros q r Hr0.
   unfold divNonnegativeRationals.
@@ -1418,7 +1418,7 @@ Proof.
 Qed.
 
 Lemma minus_divNonnegativeRationals :
-  Π x y : NonnegativeRationals, 0 < y -> / x - / y = (y - x) / (x * y).
+  ∏ x y : NonnegativeRationals, 0 < y -> / x - / y = (y - x) / (x * y).
 Proof.
   intros x y Hy0.
   generalize (eq0orgt0NonnegativeRationals x) ;
@@ -1443,7 +1443,7 @@ Qed.
 (** Order *)
 
 Lemma ispositive_divNonnegativeRationals :
-  Π x y, 0 < x -> 0 < y -> 0 < x / y.
+  ∏ x y, 0 < x -> 0 < y -> 0 < x / y.
 Proof.
   intros x y Hx Hy.
   apply ispositive_multNonnegativeRationals.
@@ -1453,7 +1453,7 @@ Proof.
 Qed.
 
 Lemma divNonnegativeRationals_le1 :
-  Π q r : NonnegativeRationals, q <= r -> q / r <= 1.
+  ∏ q r : NonnegativeRationals, q <= r -> q / r <= 1.
 Proof.
   intros q r Hrq.
   generalize (eq0orgt0NonnegativeRationals r) ;
@@ -1473,7 +1473,7 @@ Qed.
 
 (** ** NQhalf *)
 
-Lemma NQhalf_double : Π x, x = x / 2 + x / 2.
+Lemma NQhalf_double : ∏ x, x = x / 2 + x / 2.
 Proof.
   intros x.
   rewrite (tppr x) ; generalize (pr1 x) (pr2 x) ; clear x ; intros x Hx.
@@ -1488,7 +1488,7 @@ Proof.
   now apply (isirreflhqlth 2%hq).
 Qed.
 
-Lemma ispositive_NQhalf : Π x, (0 < x) <-> (0 < x / 2).
+Lemma ispositive_NQhalf : ∏ x, (0 < x) <-> (0 < x / 2).
 Proof.
   intro x.
   split ; intro Hx.
@@ -1516,7 +1516,7 @@ Proof.
   exact x.
 Defined.
 Lemma NQmax_eq_zero :
-  Π x y : NonnegativeRationals, NQmax x y = 0 -> (x = 0) × (y = 0).
+  ∏ x y : NonnegativeRationals, NQmax x y = 0 -> (x = 0) × (y = 0).
 Proof.
   intros x y.
   unfold NQmax.
@@ -1531,8 +1531,8 @@ Proof.
     now apply lt_leNonnegativeRationals, notge_ltNonnegativeRationals.
 Qed.
 Lemma NQmax_case :
-  Π (P : NonnegativeRationals -> UU),
-  Π x y : NonnegativeRationals, P x -> P y -> P (NQmax x y).
+  ∏ (P : NonnegativeRationals -> UU),
+  ∏ x y : NonnegativeRationals, P x -> P y -> P (NQmax x y).
 Proof.
   intros P x y Hx Hy.
   unfold NQmax.
@@ -1540,8 +1540,8 @@ Proof.
   now apply coprod_rect.
 Qed.
 Lemma NQmax_case_strong :
-  Π (P : NonnegativeRationals -> UU),
-  Π x y : NonnegativeRationals, (y <= x -> P x) -> (x <= y -> P y) -> P (NQmax x y).
+  ∏ (P : NonnegativeRationals -> UU),
+  ∏ x y : NonnegativeRationals, (y <= x -> P x) -> (x <= y -> P y) -> P (NQmax x y).
 Proof.
   intros P x y Hx Hy.
   unfold NQmax.
@@ -1552,7 +1552,7 @@ Proof.
     now apply lt_leNonnegativeRationals, notge_ltNonnegativeRationals.
 Qed.
 Lemma iscomm_NQmax :
-  Π x y, NQmax x y = NQmax y x.
+  ∏ x y, NQmax x y = NQmax y x.
 Proof.
   intros x y.
   apply NQmax_case_strong ; intro Hle ;
@@ -1563,7 +1563,7 @@ Proof.
   - now apply isantisymm_leNonnegativeRationals.
 Qed.
 Lemma NQmax_le_l :
-  Π x y : NonnegativeRationals, x <= NQmax x y.
+  ∏ x y : NonnegativeRationals, x <= NQmax x y.
 Proof.
   intros x y.
   apply NQmax_case_strong ; intro Hle.
@@ -1571,7 +1571,7 @@ Proof.
   - exact Hle.
 Qed.
 Lemma NQmax_le_r :
-  Π x y : NonnegativeRationals, y <= NQmax x y.
+  ∏ x y : NonnegativeRationals, y <= NQmax x y.
 Proof.
   intros x y.
   rewrite iscomm_NQmax.
@@ -1597,7 +1597,7 @@ Proof.
   reflexivity.
 Qed.
 Lemma nat_to_NonnegativeRationals_Sn :
-  Π n : nat, nat_to_NonnegativeRationals (S n) = nat_to_NonnegativeRationals n + 1.
+  ∏ n : nat, nat_to_NonnegativeRationals (S n) = nat_to_NonnegativeRationals n + 1.
 Proof.
   intro n.
   apply subtypeEquality_prop.
@@ -1612,7 +1612,7 @@ Proof.
   set (H := isarchhq).
   apply isarchfld_isarchrng in H.
   apply isarchrng_isarchrig in H.
-  assert (Π n, pr1 (nattorig (X := pr1 (CommDivRig_DivRig NonnegativeRationals)) n) = nattorig (X := pr1fld hq) n).
+  assert (∏ n, pr1 (nattorig (X := pr1 (CommDivRig_DivRig NonnegativeRationals)) n) = nattorig (X := pr1fld hq) n).
   { induction n as [|n IHn].
     - reflexivity.
     - rewrite !nattorigS, <- IHn.

--- a/UniMath/RealNumbers/NonnegativeReals.v
+++ b/UniMath/RealNumbers/NonnegativeReals.v
@@ -14,15 +14,15 @@ Local Open Scope tap_scope.
 (** ** Definition of Dedekind cuts *)
 
 Definition Dcuts_def_bot (X : hsubtype NonnegativeRationals) : UU :=
-  Π x : NonnegativeRationals,
-        X x -> Π y : NonnegativeRationals, y <= x -> X y.
+  ∏ x : NonnegativeRationals,
+        X x -> ∏ y : NonnegativeRationals, y <= x -> X y.
 Definition Dcuts_def_open (X : hsubtype NonnegativeRationals) : UU :=
-  Π x : NonnegativeRationals,
+  ∏ x : NonnegativeRationals,
         X x -> ∃ y : NonnegativeRationals, (X y) × (x < y).
 Definition Dcuts_def_finite (X : hsubtype NonnegativeRationals) : hProp :=
   ∃ ub : NonnegativeRationals, ¬ (X ub).
 Definition Dcuts_def_corr (X : hsubtype NonnegativeRationals) : UU :=
-  Π r : NonnegativeRationals, 0 < r -> (¬ (X r)) ∨ Σ q : NonnegativeRationals, (X q) × (¬ (X (q + r))).
+  ∏ r : NonnegativeRationals, 0 < r -> (¬ (X r)) ∨ ∑ q : NonnegativeRationals, (X q) × (¬ (X (q + r))).
 
 Lemma Dcuts_def_corr_finite (X : hsubtype NonnegativeRationals) :
   Dcuts_def_corr X → Dcuts_def_finite X.
@@ -37,7 +37,7 @@ Qed.
 
 Lemma Dcuts_def_corr_not_empty (X : hsubtype NonnegativeRationals) :
   X 0 -> Dcuts_def_corr X ->
-  Π c : NonnegativeRationals,
+  ∏ c : NonnegativeRationals,
     (0 < c)%NRat -> ∃ x : NonnegativeRationals, X x × ¬ X (x + c).
 Proof.
   intros X X0 Hx c Hc.
@@ -124,8 +124,8 @@ Proof.
 Defined.
 
 Lemma Dcuts_finite :
-  Π X : Dcuts_set, Π r : NonnegativeRationals,
-    neg (r ∈ X) -> Π n : NonnegativeRationals, n ∈ X -> n < r.
+  ∏ X : Dcuts_set, ∏ r : NonnegativeRationals,
+    neg (r ∈ X) -> ∏ n : NonnegativeRationals, n ∈ X -> n < r.
 Proof.
   intros X r Hr n Hn.
   apply notge_ltNonnegativeRationals ; intro Hn'.
@@ -141,7 +141,7 @@ Qed.
 
 Definition Dcuts_le_rel : hrel Dcuts_set :=
   λ X Y : Dcuts_set,
-          hProppair (Π x : NonnegativeRationals, x ∈ X -> x ∈ Y)
+          hProppair (∏ x : NonnegativeRationals, x ∈ X -> x ∈ Y)
                     (impred_isaprop _ (λ _, isapropimpl _ _ (pr2 _))).
 
 Lemma istrans_Dcuts_le_rel : istrans Dcuts_le_rel.
@@ -241,7 +241,7 @@ Qed.
 (** Effectively Ordered Set *)
 
 Lemma Dcuts_lt_le_rel :
-  Π x y : Dcuts_set, Dcuts_lt_rel x y -> Dcuts_le_rel x y.
+  ∏ x y : Dcuts_set, Dcuts_lt_rel x y -> Dcuts_le_rel x y.
 Proof.
   intros x y ; apply hinhuniv ; intros r.
   intros n Xn.
@@ -254,7 +254,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_le_ngt_rel :
-  Π x y : Dcuts_set, ¬ Dcuts_lt_rel x y <-> Dcuts_le_rel y x.
+  ∏ x y : Dcuts_set, ¬ Dcuts_lt_rel x y <-> Dcuts_le_rel y x.
 Proof.
   intros X Y.
   split.
@@ -296,7 +296,7 @@ Proof.
 Qed.
 
 Lemma istrans_Dcuts_lt_le_rel :
-  Π x y z : Dcuts_set, Dcuts_lt_rel x y -> Dcuts_le_rel y z -> Dcuts_lt_rel x z.
+  ∏ x y z : Dcuts_set, Dcuts_lt_rel x y -> Dcuts_le_rel y z -> Dcuts_lt_rel x z.
 Proof.
   intros x y z Hlt Hle.
   revert Hlt ; apply hinhfun ; intros r.
@@ -306,7 +306,7 @@ Proof.
     exact (pr2 (pr2 r)).
 Qed.
 Lemma istrans_Dcuts_le_lt_rel :
-  Π x y z : Dcuts_set, Dcuts_le_rel x y -> Dcuts_lt_rel y z -> Dcuts_lt_rel x z.
+  ∏ x y z : Dcuts_set, Dcuts_le_rel x y -> Dcuts_lt_rel y z -> Dcuts_lt_rel x z.
 Proof.
   intros x y z Hle.
   apply hinhfun ; intros r.
@@ -349,8 +349,8 @@ Notation "x > y" := (@EOgt_rel eo_Dcuts x y) : Dcuts_scope.
 (** ** Equivalence on [Dcuts] *)
 
 Definition Dcuts_eq_rel :=
-  λ X Y : Dcuts_set, Π r : NonnegativeRationals, (r ∈ X -> r ∈ Y) × (r ∈ Y -> r ∈ X).
-Lemma isaprop_Dcuts_eq_rel : Π X Y : Dcuts_set, isaprop (Dcuts_eq_rel X Y).
+  λ X Y : Dcuts_set, ∏ r : NonnegativeRationals, (r ∈ X -> r ∈ Y) × (r ∈ Y -> r ∈ X).
+Lemma isaprop_Dcuts_eq_rel : ∏ X Y : Dcuts_set, isaprop (Dcuts_eq_rel X Y).
 Proof.
   intros X Y.
   apply impred_isaprop ; intro r.
@@ -359,7 +359,7 @@ Proof.
   - now apply isapropimpl, pr2.
 Qed.
 Definition Dcuts_eq : hrel Dcuts_set :=
-  λ X Y : Dcuts_set, hProppair (Π r, dirprod (r ∈ X -> r ∈ Y) (r ∈ Y -> r ∈ X)) (isaprop_Dcuts_eq_rel X Y).
+  λ X Y : Dcuts_set, hProppair (∏ r, dirprod (r ∈ X -> r ∈ Y) (r ∈ Y -> r ∈ X)) (isaprop_Dcuts_eq_rel X Y).
 
 Lemma istrans_Dcuts_eq : istrans Dcuts_eq.
 Proof.
@@ -398,7 +398,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_eq_is_eq :
-  Π x y : Dcuts_set,
+  ∏ x y : Dcuts_set,
     Dcuts_eq x y -> x = y.
 Proof.
   intros x y Heq.
@@ -472,7 +472,7 @@ Definition Dcuts : tightapSet :=
     istight_Dcuts_ap_rel.
 
 Lemma not_Dcuts_ap_eq :
-  Π x y : Dcuts, ¬ (x ≠ y) -> (x = y).
+  ∏ x y : Dcuts, ¬ (x ≠ y) -> (x = y).
 Proof.
   intros x y.
   now apply istight_Dcuts_ap_rel.
@@ -481,31 +481,31 @@ Qed.
 (** *** Various theorems about order *)
 
 Lemma Dcuts_ge_le :
-  Π x y : Dcuts, x >= y -> y <= x.
+  ∏ x y : Dcuts, x >= y -> y <= x.
 Proof.
   easy.
 Qed.
 Lemma Dcuts_le_ge :
-  Π x y : Dcuts, x <= y -> y >= x.
+  ∏ x y : Dcuts, x <= y -> y >= x.
 Proof.
   easy.
 Qed.
 Lemma Dcuts_eq_le :
-  Π x y : Dcuts, Dcuts_eq x y -> x <= y.
+  ∏ x y : Dcuts, Dcuts_eq x y -> x <= y.
 Proof.
   intros x y Heq.
   intro r ;
     now apply (pr1 (Heq _)).
 Qed.
 Lemma Dcuts_eq_ge :
-  Π x y : Dcuts, Dcuts_eq x y -> x >= y.
+  ∏ x y : Dcuts, Dcuts_eq x y -> x >= y.
 Proof.
   intros x y Heq.
   apply Dcuts_eq_le.
   now apply issymm_Dcuts_eq.
 Qed.
 Lemma Dcuts_le_ge_eq :
-  Π x y : Dcuts, x <= y -> x >= y -> x = y.
+  ∏ x y : Dcuts, x <= y -> x >= y -> x = y.
 Proof.
   intros x y le_xy ge_xy.
   apply Dcuts_eq_is_eq.
@@ -515,31 +515,31 @@ Proof.
 Qed.
 
 Lemma Dcuts_gt_lt :
-  Π x y : Dcuts, (x > y) <-> (y < x).
+  ∏ x y : Dcuts, (x > y) <-> (y < x).
 Proof.
   now split.
 Qed.
 Lemma Dcuts_gt_ge :
-  Π x y : Dcuts, x > y -> x >= y.
+  ∏ x y : Dcuts, x > y -> x >= y.
 Proof.
   intros x y.
   now apply Dcuts_lt_le_rel.
 Qed.
 
 Lemma Dcuts_gt_nle :
-  Π x y : Dcuts, x > y -> neg (x <= y).
+  ∏ x y : Dcuts, x > y -> neg (x <= y).
 Proof.
   intros x y Hlt Hle.
   now apply (pr2 (Dcuts_le_ngt_rel _ _)) in Hle.
 Qed.
 Lemma Dcuts_nlt_ge :
-  Π x y : Dcuts, neg (x < y) <-> (x >= y).
+  ∏ x y : Dcuts, neg (x < y) <-> (x >= y).
 Proof.
   intros X Y.
   now apply Dcuts_le_ngt_rel.
 Qed.
 Lemma Dcuts_lt_nge :
-  Π x y : Dcuts, x < y -> neg (x >= y).
+  ∏ x y : Dcuts, x < y -> neg (x >= y).
 Proof.
   intros x y.
   now apply Dcuts_gt_nle.
@@ -598,7 +598,7 @@ Definition NonnegativeRationals_to_Dcuts (q : NonnegativeRationals) : Dcuts :=
 
 
 Lemma isapfun_NonnegativeRationals_to_Dcuts_aux :
-  Π q q' : NonnegativeRationals,
+  ∏ q q' : NonnegativeRationals,
     NonnegativeRationals_to_Dcuts q < NonnegativeRationals_to_Dcuts q'
     <-> (q < q')%NRat.
 Proof.
@@ -617,7 +617,7 @@ Proof.
     exact H.
 Qed.
 Lemma isapfun_NonnegativeRationals_to_Dcuts :
-  Π q q' : NonnegativeRationals,
+  ∏ q q' : NonnegativeRationals,
     NonnegativeRationals_to_Dcuts q ≠ NonnegativeRationals_to_Dcuts q'
     → q != q'.
 Proof.
@@ -627,7 +627,7 @@ Proof.
   now apply gtNonnegativeRationals_noteq, isapfun_NonnegativeRationals_to_Dcuts_aux.
 Qed.
 Lemma isapfun_NonnegativeRationals_to_Dcuts' :
-  Π q q' : NonnegativeRationals,
+  ∏ q q' : NonnegativeRationals,
     q != q'
     → NonnegativeRationals_to_Dcuts q ≠ NonnegativeRationals_to_Dcuts q'.
 Proof.
@@ -649,14 +649,14 @@ Notation "2" := Dcuts_two : Dcuts_scope.
 (** Various usefull theorems *)
 
 Lemma Dcuts_zero_empty :
-  Π r : NonnegativeRationals, neg (r ∈ 0).
+  ∏ r : NonnegativeRationals, neg (r ∈ 0).
 Proof.
   intros r ; simpl.
   change (neg (r < 0)%NRat).
   now apply isnonnegative_NonnegativeRationals'.
 Qed.
 Lemma Dcuts_notempty_notzero :
-  Π (x : Dcuts) (r : NonnegativeRationals), r ∈ x -> x ≠ 0.
+  ∏ (x : Dcuts) (r : NonnegativeRationals), r ∈ x -> x ≠ 0.
 Proof.
   intros x r Hx.
   right.
@@ -668,7 +668,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_ge_0 :
-  Π x : Dcuts, Dcuts_zero <= x.
+  ∏ x : Dcuts, Dcuts_zero <= x.
 Proof.
   intros x r Hr.
   apply fromempty.
@@ -676,7 +676,7 @@ Proof.
   now apply Dcuts_zero_empty.
 Qed.
 Lemma Dcuts_notlt_0 :
-  Π x : Dcuts, ¬ (x < Dcuts_zero).
+  ∏ x : Dcuts, ¬ (x < Dcuts_zero).
 Proof.
   intros x.
   unfold neg.
@@ -687,7 +687,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_apzero_notempty :
-  Π (x : Dcuts), (0%NRat ∈ x) <-> x ≠ 0.
+  ∏ (x : Dcuts), (0%NRat ∈ x) <-> x ≠ 0.
 Proof.
   intros x ; split.
   - now apply Dcuts_notempty_notzero.
@@ -701,7 +701,7 @@ Proof.
 Qed.
 
 Lemma NonnegativeRationals_to_Dcuts_notin_le :
-  Π (x : Dcuts) (r : NonnegativeRationals),
+  ∏ (x : Dcuts) (r : NonnegativeRationals),
     ¬ (r ∈ x) -> x <= NonnegativeRationals_to_Dcuts r.
 Proof.
   intros x r Hr q Hq.
@@ -725,7 +725,7 @@ Section Dcuts_plus.
 Definition Dcuts_plus_val : hsubtype NonnegativeRationals :=
   λ r : NonnegativeRationals,
         ((X r) ⨿ (Y r)) ∨
-        (Σ xy : NonnegativeRationals × NonnegativeRationals, (r = (pr1 xy + pr2 xy)%NRat) × ((X (pr1 xy)) × (Y (pr2 xy)))).
+        (∑ xy : NonnegativeRationals × NonnegativeRationals, (r = (pr1 xy + pr2 xy)%NRat) × ((X (pr1 xy)) × (Y (pr2 xy)))).
 
 Lemma Dcuts_plus_bot : Dcuts_def_bot Dcuts_plus_val.
 Proof.
@@ -1375,11 +1375,11 @@ Context (X_0 : X 0%NRat).
 
 Definition Dcuts_inv_val : hsubtype NonnegativeRationals :=
   λ r : NonnegativeRationals,
-        hexists (λ l : NonnegativeRationals, (Π rx : NonnegativeRationals, X rx -> (r * rx <= l)%NRat)
+        hexists (λ l : NonnegativeRationals, (∏ rx : NonnegativeRationals, X rx -> (r * rx <= l)%NRat)
                                                × (0 < l)%NRat × (l < 1)%NRat).
 
 Lemma Dcuts_inv_in :
-  Π x, (0 < x)%NRat -> X x -> (Dcuts_inv_val (/ x)%NRat) -> empty.
+  ∏ x, (0 < x)%NRat -> X x -> (Dcuts_inv_val (/ x)%NRat) -> empty.
 Proof.
   intros x Hx0 Xx.
   unfold neg ; apply (hinhuniv (P := hProppair _ isapropempty)) ; intros l.
@@ -1390,7 +1390,7 @@ Proof.
   exact Hx0.
 Qed.
 Lemma Dcuts_inv_out :
-  Π x, ¬ (X x) -> Π y, (x < y)%NRat -> Dcuts_inv_val (/ y)%NRat.
+  ∏ x, ¬ (X x) -> ∏ y, (x < y)%NRat -> Dcuts_inv_val (/ y)%NRat.
 Proof.
   intros x nXx y Hy.
   apply hinhpr.
@@ -1497,7 +1497,7 @@ Context (X_1 : X 1%NRat).
 
 Lemma Dcuts_inv_corr_aux : Dcuts_def_corr Dcuts_inv_val.
 Proof.
-  assert (Π c, (0 < c)%NRat -> hexists (λ q : NonnegativeRationals, X q × ¬ X (q + c))).
+  assert (∏ c, (0 < c)%NRat -> hexists (λ q : NonnegativeRationals, X q × ¬ X (q + c))).
   { intros c Hc0.
     generalize (X_corr c Hc0) ; apply hinhuniv ; apply sumofmaps ; [ intros nXc | intros H].
     - apply hinhpr.
@@ -1645,7 +1645,7 @@ Defined.
 (** ** Algebraic properties *)
 
 Lemma Dcuts_NQmult_mult :
-  Π (x : NonnegativeRationals) (y : Dcuts) (Hx0 : (0 < x)%NRat), Dcuts_NQmult x y Hx0 = Dcuts_mult (NonnegativeRationals_to_Dcuts x) y.
+  ∏ (x : NonnegativeRationals) (y : Dcuts) (Hx0 : (0 < x)%NRat), Dcuts_NQmult x y Hx0 = Dcuts_mult (NonnegativeRationals_to_Dcuts x) y.
 Proof.
   intros x y Hx0.
   apply Dcuts_eq_is_eq.
@@ -1701,7 +1701,7 @@ Qed.
 
 Lemma iscomm_Dcuts_plus : iscomm Dcuts_plus.
 Proof.
-  assert (H : Π x y, Π x0 : NonnegativeRationals, x0 ∈ Dcuts_plus x y -> x0 ∈ Dcuts_plus y x).
+  assert (H : ∏ x y, ∏ x0 : NonnegativeRationals, x0 ∈ Dcuts_plus x y -> x0 ∈ Dcuts_plus y x).
   { intros x y r.
     apply hinhuniv, sumofmaps ; simpl pr1.
     - apply sumofmaps ; intros Hr.
@@ -1722,7 +1722,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_plus_lt_l :
-  Π x x' y : Dcuts, Dcuts_plus x y < Dcuts_plus x' y -> x < x'.
+  ∏ x x' y : Dcuts, Dcuts_plus x y < Dcuts_plus x' y -> x < x'.
 Proof.
   intros x x' y.
   apply hinhuniv ; intros r.
@@ -1779,7 +1779,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_mult_lt_l :
-  Π x x' y : Dcuts, Dcuts_mult x y < Dcuts_mult x' y -> x < x'.
+  ∏ x x' y : Dcuts, Dcuts_mult x y < Dcuts_mult x' y -> x < x'.
 Proof.
   intros x x' y.
   apply hinhuniv ; intros r.
@@ -1980,7 +1980,7 @@ Proof.
   now apply islunit_Dcuts_mult_one.
 Qed.
 Lemma islabsorb_Dcuts_mult_zero :
-  Π x : Dcuts, Dcuts_mult Dcuts_zero x = Dcuts_zero.
+  ∏ x : Dcuts, Dcuts_mult Dcuts_zero x = Dcuts_zero.
 Proof.
   intros x.
   apply Dcuts_eq_is_eq ; intro r ; split.
@@ -1991,7 +1991,7 @@ Proof.
     now apply Dcuts_zero_empty in Hr.
 Qed.
 Lemma israbsorb_Dcuts_mult_zero :
-  Π x : Dcuts, Dcuts_mult x Dcuts_zero = Dcuts_zero.
+  ∏ x : Dcuts, Dcuts_mult x Dcuts_zero = Dcuts_zero.
 Proof.
   intros x.
   rewrite iscomm_Dcuts_mult.
@@ -2095,7 +2095,7 @@ Proof.
   exact ispositive_oneNonnegativeRationals.
 Qed.
 Definition islinv_Dcuts_inv :
-  Π x : Dcuts, Π Hx0 : x ≠ 0, Dcuts_mult (Dcuts_inv x Hx0) x = 1.
+  ∏ x : Dcuts, ∏ Hx0 : x ≠ 0, Dcuts_mult (Dcuts_inv x Hx0) x = 1.
 Proof.
   intros x Hx0.
   apply Dcuts_eq_is_eq ; intros q ; split.
@@ -2224,7 +2224,7 @@ Proof.
         exact (pr1 (pr2 r')).
 Qed.
 Lemma isrinv_Dcuts_inv :
-  Π x : Dcuts, Π Hx0 : x ≠ 0, Dcuts_mult x (Dcuts_inv x Hx0) = 1.
+  ∏ x : Dcuts, ∏ Hx0 : x ≠ 0, Dcuts_mult x (Dcuts_inv x Hx0) = 1.
 Proof.
   intros x Hx0.
   rewrite iscomm_Dcuts_mult.
@@ -2232,7 +2232,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_plus_ltcompat_l :
-  Π x y z: Dcuts, (y < z) <-> (Dcuts_plus y x < Dcuts_plus z x).
+  ∏ x y z: Dcuts, (y < z) <-> (Dcuts_plus y x < Dcuts_plus z x).
 Proof.
   intros x y z.
   split.
@@ -2296,7 +2296,7 @@ Proof.
   - now apply Dcuts_plus_lt_l.
 Qed.
 Lemma Dcuts_plus_lecompat_l :
-  Π x y z: Dcuts, (y <= z) <-> (Dcuts_plus y x <= Dcuts_plus z x).
+  ∏ x y z: Dcuts, (y <= z) <-> (Dcuts_plus y x <= Dcuts_plus z x).
 Proof.
   intros x y z.
   split.
@@ -2306,14 +2306,14 @@ Proof.
     now apply Dcuts_plus_ltcompat_l.
 Qed.
 Lemma Dcuts_plus_ltcompat_r :
-  Π x y z: Dcuts, (y < z) <-> (Dcuts_plus x y < Dcuts_plus x z).
+  ∏ x y z: Dcuts, (y < z) <-> (Dcuts_plus x y < Dcuts_plus x z).
 Proof.
   intros x y z.
   rewrite ! (iscomm_Dcuts_plus x).
   now apply Dcuts_plus_ltcompat_l.
 Qed.
 Lemma Dcuts_plus_lecompat_r :
-  Π x y z: Dcuts, (y <= z) <-> (Dcuts_plus x y <= Dcuts_plus x z).
+  ∏ x y z: Dcuts, (y <= z) <-> (Dcuts_plus x y <= Dcuts_plus x z).
 Proof.
   intros x y z.
   rewrite ! (iscomm_Dcuts_plus x).
@@ -2321,20 +2321,20 @@ Proof.
 Qed.
 
 Lemma Dcuts_plus_le_l :
-  Π x y, x <= Dcuts_plus x y.
+  ∏ x y, x <= Dcuts_plus x y.
 Proof.
   intros x y r Xr.
   now apply hinhpr ; left ; left.
 Qed.
 Lemma Dcuts_plus_le_r :
-  Π x y, y <= Dcuts_plus x y.
+  ∏ x y, y <= Dcuts_plus x y.
 Proof.
   intros x y r Xr.
   now apply hinhpr ; left ; right.
 Qed.
 
 Lemma Dcuts_mult_ltcompat_l :
-  Π x y z: Dcuts, (0 < x) -> (y < z) -> (Dcuts_mult y x < Dcuts_mult z x).
+  ∏ x y z: Dcuts, (0 < x) -> (y < z) -> (Dcuts_mult y x < Dcuts_mult z x).
 Proof.
   intros X Y Z.
   apply hinhuniv2 ; intros x r.
@@ -2408,20 +2408,20 @@ Proof.
         exact (pr2 (pr2 r')).
 Qed.
 Lemma Dcuts_mult_ltcompat_l' :
-  Π x y z: Dcuts, (Dcuts_mult y x < Dcuts_mult z x) -> (y < z).
+  ∏ x y z: Dcuts, (Dcuts_mult y x < Dcuts_mult z x) -> (y < z).
 Proof.
   intros x y z.
   now apply Dcuts_mult_lt_l.
 Qed.
 Lemma Dcuts_mult_lecompat_l :
-  Π x y z: Dcuts, (0 < x) -> (Dcuts_mult y x <= Dcuts_mult z x) -> (y <= z).
+  ∏ x y z: Dcuts, (0 < x) -> (Dcuts_mult y x <= Dcuts_mult z x) -> (y <= z).
 Proof.
   intros x y z Hx0.
   intros H ; apply Dcuts_nlt_ge ; intro H0 ; apply (pr2 (Dcuts_nlt_ge _ _) H).
   now apply Dcuts_mult_ltcompat_l.
 Qed.
 Lemma Dcuts_mult_lecompat_l' :
-  Π x y z: Dcuts, (y <= z) -> (Dcuts_mult y x <= Dcuts_mult z x).
+  ∏ x y z: Dcuts, (y <= z) -> (Dcuts_mult y x <= Dcuts_mult z x).
 Proof.
   intros x y z.
   intros H ; apply Dcuts_nlt_ge ; intro H0 ; apply (pr2 (Dcuts_nlt_ge _ _) H).
@@ -2429,28 +2429,28 @@ Proof.
 Qed.
 
 Lemma Dcuts_mult_ltcompat_r :
-  Π x y z: Dcuts, (0 < x) -> (y < z) -> (Dcuts_mult x y < Dcuts_mult x z).
+  ∏ x y z: Dcuts, (0 < x) -> (y < z) -> (Dcuts_mult x y < Dcuts_mult x z).
 Proof.
   intros x y z.
   rewrite ! (iscomm_Dcuts_mult x).
   now apply Dcuts_mult_ltcompat_l.
 Qed.
 Lemma Dcuts_mult_ltcompat_r' :
-  Π x y z: Dcuts, (Dcuts_mult x y < Dcuts_mult x z) -> (y < z).
+  ∏ x y z: Dcuts, (Dcuts_mult x y < Dcuts_mult x z) -> (y < z).
 Proof.
   intros x y z.
   rewrite ! (iscomm_Dcuts_mult x).
   now apply Dcuts_mult_ltcompat_l'.
 Qed.
 Lemma Dcuts_mult_lecompat_r :
-  Π x y z: Dcuts, (0 < x) -> (Dcuts_mult x y <= Dcuts_mult x z) -> (y <= z).
+  ∏ x y z: Dcuts, (0 < x) -> (Dcuts_mult x y <= Dcuts_mult x z) -> (y <= z).
 Proof.
   intros x y z.
   rewrite ! (iscomm_Dcuts_mult x).
   now apply Dcuts_mult_lecompat_l.
 Qed.
 Lemma Dcuts_mult_lecompat_r' :
-  Π x y z: Dcuts, (y <= z) -> (Dcuts_mult x y <= Dcuts_mult x z).
+  ∏ x y z: Dcuts, (y <= z) -> (Dcuts_mult x y <= Dcuts_mult x z).
 Proof.
   intros x y z.
   rewrite ! (iscomm_Dcuts_mult x).
@@ -2458,7 +2458,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_plus_double :
-  Π x : Dcuts, Dcuts_plus x x = Dcuts_mult Dcuts_two x.
+  ∏ x : Dcuts, Dcuts_plus x x = Dcuts_mult Dcuts_two x.
 Proof.
   intros x.
   rewrite <- (Dcuts_NQmult_mult _ _ ispositive_twoNonnegativeRationals).
@@ -2587,7 +2587,7 @@ Section Dcuts_minus.
   Context (Y_corr : Dcuts_def_corr Y).
 
 Definition Dcuts_minus_val : hsubtype NonnegativeRationals :=
-  fun r => ∃ x, X x × Π y, (Y y) ⨿ (y = 0%NRat) -> (r + y < x)%NRat.
+  fun r => ∃ x, X x × ∏ y, (Y y) ⨿ (y = 0%NRat) -> (r + y < x)%NRat.
 
 Lemma Dcuts_minus_bot : Dcuts_def_bot Dcuts_minus_val.
 Proof.
@@ -2666,7 +2666,7 @@ Proof.
     apply (pr2 (pr2 x)).
     now right.
   - generalize (isdecrel_leNonnegativeRationals (pr1 y + c / 2)%NRat (pr1 x)) ; apply sumofmaps ; intro Hxy.
-    + assert (HY : Π y', coprod (Y y') (y' = 0%NRat) -> (y' < pr1 y + c / 2)%NRat).
+    + assert (HY : ∏ y', coprod (Y y') (y' = 0%NRat) -> (y' < pr1 y + c / 2)%NRat).
       { intros y' ; apply sumofmaps ; intros Yy'.
         apply notge_ltNonnegativeRationals ; intro H ; apply nYy.
         now apply Y_bot with (1 := Yy').
@@ -2727,7 +2727,7 @@ Definition Dcuts_minus (X Y : Dcuts) : Dcuts :=
                               (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_corr Y)).
 
 Lemma Dcuts_minus_correct_l:
-  Π x y z : Dcuts, x = Dcuts_plus y z -> z = Dcuts_minus x y.
+  ∏ x y z : Dcuts, x = Dcuts_plus y z -> z = Dcuts_minus x y.
 Proof.
   intros _ Y Z ->.
   apply Dcuts_eq_is_eq ; intro r ; split.
@@ -2782,7 +2782,7 @@ Proof.
       exact (pr1 (pr2 (pr2 yz))).
 Qed.
 Lemma Dcuts_minus_correct_r:
-  Π x y z : Dcuts, x = Dcuts_plus y z -> y = Dcuts_minus x z.
+  ∏ x y z : Dcuts, x = Dcuts_plus y z -> y = Dcuts_minus x z.
 Proof.
   intros x y z Hx.
   apply Dcuts_minus_correct_l.
@@ -2790,7 +2790,7 @@ Proof.
   now apply iscomm_Dcuts_plus.
 Qed.
 Lemma Dcuts_minus_eq_zero:
-  Π x y : Dcuts, x <= y -> Dcuts_minus x y = 0.
+  ∏ x y : Dcuts, x <= y -> Dcuts_minus x y = 0.
 Proof.
   intros X Y Hxy.
   apply Dcuts_eq_is_eq ; intros r ; split.
@@ -2804,7 +2804,7 @@ Proof.
     now apply fromempty ; apply (Dcuts_zero_empty r).
 Qed.
 Lemma Dcuts_minus_plus_r:
-  Π x y z : Dcuts, z <= y -> x = Dcuts_minus y z -> y = Dcuts_plus x z.
+  ∏ x y z : Dcuts, z <= y -> x = Dcuts_minus y z -> y = Dcuts_plus x z.
 Proof.
   intros _ Y Z Hyz ->.
   apply Dcuts_eq_is_eq ; intro r ; split.
@@ -2868,7 +2868,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_minus_le :
-  Π x y, Dcuts_minus x y <= x.
+  ∏ x y, Dcuts_minus x y <= x.
 Proof.
   intros X Y r.
   apply hinhuniv ; intros x.
@@ -2881,7 +2881,7 @@ Proof.
 Qed.
 
 Lemma ispositive_Dcuts_minus :
-  Π x y : Dcuts, (y < x) <-> (0 < Dcuts_minus x y).
+  ∏ x y : Dcuts, (y < x) <-> (0 < Dcuts_minus x y).
 Proof.
   intros X Y.
   split.
@@ -3008,14 +3008,14 @@ Definition Dcuts_max (X Y : Dcuts) : Dcuts :=
                             (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_corr Y)).
 
 Lemma iscomm_Dcuts_max :
-  Π x y : Dcuts, Dcuts_max x y = Dcuts_max y x.
+  ∏ x y : Dcuts, Dcuts_max x y = Dcuts_max y x.
 Proof.
   intros x y.
   apply Dcuts_eq_is_eq ; intros r.
   split ; apply islogeqcommhdisj.
 Qed.
 Lemma isassoc_Dcuts_max :
-  Π x y z : Dcuts, Dcuts_max (Dcuts_max x y) z = Dcuts_max x (Dcuts_max y z).
+  ∏ x y z : Dcuts, Dcuts_max (Dcuts_max x y) z = Dcuts_max x (Dcuts_max y z).
 Proof.
   intros x y z.
   apply Dcuts_eq_is_eq ; intros r.
@@ -3039,14 +3039,14 @@ Proof.
 Qed.
 
 Lemma Dcuts_max_le_l :
-  Π x y : Dcuts, x <= Dcuts_max x y.
+  ∏ x y : Dcuts, x <= Dcuts_max x y.
 Proof.
   intros x y r Xr.
   apply hinhpr.
   now left.
 Qed.
 Lemma Dcuts_max_le_r :
-  Π x y : Dcuts, y <= Dcuts_max x y.
+  ∏ x y : Dcuts, y <= Dcuts_max x y.
 Proof.
   intros x y r Xr.
   apply hinhpr.
@@ -3054,7 +3054,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_max_carac_l :
-  Π x y : Dcuts, y <= x -> Dcuts_max x y = x.
+  ∏ x y : Dcuts, y <= x -> Dcuts_max x y = x.
 Proof.
   intros x y Hxy.
   apply Dcuts_eq_is_eq ; intros r ; split.
@@ -3065,7 +3065,7 @@ Proof.
     now apply hinhpr ; left.
 Qed.
 Lemma Dcuts_max_carac_r :
-  Π x y : Dcuts, x <= y -> Dcuts_max x y = y.
+  ∏ x y : Dcuts, x <= y -> Dcuts_max x y = y.
 Proof.
   intros x y Hxy.
   rewrite iscomm_Dcuts_max.
@@ -3073,7 +3073,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_minus_plus_max :
-  Π x y : Dcuts, Dcuts_plus (Dcuts_minus x y) y = Dcuts_max x y.
+  ∏ x y : Dcuts, Dcuts_plus (Dcuts_minus x y) y = Dcuts_max x y.
 Proof.
   intros X Y.
   apply Dcuts_eq_is_eq ; intros r ; split.
@@ -3126,7 +3126,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_max_le :
-  Π x y z, x <= z -> y <= z -> Dcuts_max x y <= z.
+  ∏ x y z, x <= z -> y <= z -> Dcuts_max x y <= z.
 Proof.
   intros x y z Hx Hy r.
   apply hinhuniv ; apply sumofmaps ; [intros Xr|intros Yr].
@@ -3134,7 +3134,7 @@ Proof.
   now refine (Hy _ _).
 Qed.
 Lemma Dcuts_max_lt :
-  Π x y z : Dcuts, x < z -> y < z -> Dcuts_max x y < z.
+  ∏ x y z : Dcuts, x < z -> y < z -> Dcuts_max x y < z.
 Proof.
   intros x y z.
   apply hinhfun2 ; intros rx ry.
@@ -3277,7 +3277,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_max_plus :
-  Π x y : Dcuts,
+  ∏ x y : Dcuts,
     (0 < x -> y = 0) ->
     Dcuts_max x y = Dcuts_plus x y.
 Proof.
@@ -3388,7 +3388,7 @@ Definition Dcuts_min (X Y : Dcuts) : Dcuts :=
                             (pr1 Y) (is_Dcuts_bot Y) (is_Dcuts_corr Y)).
 
 Lemma iscomm_Dcuts_min :
-  Π x y : Dcuts, Dcuts_min x y = Dcuts_min y x.
+  ∏ x y : Dcuts, Dcuts_min x y = Dcuts_min y x.
 Proof.
   intros x y.
   apply Dcuts_eq_is_eq ; intros r.
@@ -3396,7 +3396,7 @@ Proof.
 Qed.
 
 Lemma isassoc_Dcuts_min :
-  Π x y z : Dcuts, Dcuts_min (Dcuts_min x y) z = Dcuts_min x (Dcuts_min y z).
+  ∏ x y z : Dcuts, Dcuts_min (Dcuts_min x y) z = Dcuts_min x (Dcuts_min y z).
 Proof.
   intros x y z.
   apply Dcuts_eq_is_eq ; intros r.
@@ -3410,20 +3410,20 @@ Proof.
 Qed.
 
 Lemma Dcuts_min_le_l :
-  Π x y : Dcuts, Dcuts_min x y <= x.
+  ∏ x y : Dcuts, Dcuts_min x y <= x.
 Proof.
   intros x y r Hr.
   exact (pr1 Hr).
 Qed.
 Lemma Dcuts_min_le_r :
-  Π x y : Dcuts, Dcuts_min x y <= y.
+  ∏ x y : Dcuts, Dcuts_min x y <= y.
 Proof.
   intros x y r Hr.
   exact (pr2 Hr).
 Qed.
 
 Lemma Dcuts_min_carac_r :
-  Π x y : Dcuts, y <= x -> Dcuts_min x y = y.
+  ∏ x y : Dcuts, y <= x -> Dcuts_min x y = y.
 Proof.
   intros x y Hxy.
   apply Dcuts_eq_is_eq ; intros r ; split.
@@ -3435,7 +3435,7 @@ Proof.
     exact Yr.
 Qed.
 Lemma Dcuts_min_carac_l :
-  Π x y : Dcuts, x <= y -> Dcuts_min x y = x.
+  ∏ x y : Dcuts, x <= y -> Dcuts_min x y = x.
 Proof.
   intros x y Hxy.
   rewrite iscomm_Dcuts_min.
@@ -3443,7 +3443,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_min_max :
-  Π x y : Dcuts,
+  ∏ x y : Dcuts,
     Dcuts_min x (Dcuts_max x y) = x.
 Proof.
   intros x y.
@@ -3458,7 +3458,7 @@ Proof.
     now left.
 Qed.
 Lemma Dcuts_max_min :
-  Π x y : Dcuts,
+  ∏ x y : Dcuts,
     Dcuts_max x (Dcuts_min x y) = x.
 Proof.
   intros x y.
@@ -3473,7 +3473,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_min_gt :
-  Π x y z : Dcuts,
+  ∏ x y z : Dcuts,
     z < x → z < y → z < (Dcuts_min x y).
 Proof.
   intros x y z.
@@ -3565,7 +3565,7 @@ Definition Dcuts_half (x : Dcuts) : Dcuts :=
            (Dcuts_half_corr (pr1 x) (is_Dcuts_bot x) (is_Dcuts_corr x)).
 
 Lemma Dcuts_half_le :
-  Π x : Dcuts, Dcuts_half x <= x.
+  ∏ x : Dcuts, Dcuts_half x <= x.
 Proof.
   intros x.
   intros r Hr.
@@ -3574,7 +3574,7 @@ Proof.
 Qed.
 
 Lemma isdistr_Dcuts_half_plus :
-  Π x y : Dcuts, Dcuts_half (Dcuts_plus x y) = Dcuts_plus (Dcuts_half x) (Dcuts_half y).
+  ∏ x y : Dcuts, Dcuts_half (Dcuts_plus x y) = Dcuts_plus (Dcuts_half x) (Dcuts_half y).
 Proof.
   intros x y.
   apply Dcuts_eq_is_eq.
@@ -3618,7 +3618,7 @@ Proof.
       * exact (pr2 (pr2 (pr2 xy))).
 Qed.
 Lemma Dcuts_half_double :
-  Π x : Dcuts, x = Dcuts_plus (Dcuts_half x) (Dcuts_half x).
+  ∏ x : Dcuts, x = Dcuts_plus (Dcuts_half x) (Dcuts_half x).
 Proof.
   intros x.
   rewrite  <- isdistr_Dcuts_half_plus.
@@ -3641,7 +3641,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_half_correct :
-  Π x, Dcuts_half x = Dcuts_mult x (Dcuts_inv Dcuts_two Dcuts_two_ap_zero).
+  ∏ x, Dcuts_half x = Dcuts_mult x (Dcuts_inv Dcuts_two Dcuts_two_ap_zero).
 Proof.
   intros x.
   pattern x at 2 ; rewrite (Dcuts_half_double x).
@@ -3650,7 +3650,7 @@ Proof.
 Qed.
 
 Lemma ispositive_Dcuts_half:
-  Π x : Dcuts, (0 < x) <-> (0 < Dcuts_half x).
+  ∏ x : Dcuts, (0 < x) <-> (0 < Dcuts_half x).
 Proof.
   intros.
   rewrite Dcuts_half_correct.
@@ -3670,7 +3670,7 @@ Qed.
 (** ** Locatedness *)
 
 Lemma Dcuts_locatedness :
-  Π X : Dcuts, Π p q : NonnegativeRationals, (p < q)%NRat -> p ∈ X ∨ ¬ (q ∈ X).
+  ∏ X : Dcuts, ∏ p q : NonnegativeRationals, (p < q)%NRat -> p ∈ X ∨ ¬ (q ∈ X).
 Proof.
   intros X p q Hlt.
   apply ispositive_minusNonnegativeRationals in Hlt.
@@ -3701,19 +3701,19 @@ Qed.
 Section Dcuts_lim.
 
 Context (U : nat -> hsubtype NonnegativeRationals)
-        (U_bot : Π n : nat, Dcuts_def_bot (U n))
-        (U_open : Π n : nat, Dcuts_def_open (U n))
-        (U_corr : Π n : nat, Dcuts_def_corr (U n)).
+        (U_bot : ∏ n : nat, Dcuts_def_bot (U n))
+        (U_open : ∏ n : nat, Dcuts_def_open (U n))
+        (U_corr : ∏ n : nat, Dcuts_def_corr (U n)).
 
 Context (U_cauchy :
-           Π eps : NonnegativeRationals,
+           ∏ eps : NonnegativeRationals,
                    (0 < eps)%NRat ->
                    hexists
                      (λ N : nat,
-                            Π n m : nat, N ≤ n -> N ≤ m -> (Π r, U n r -> Dcuts_plus_val (U m) (λ q, (q < eps)%NRat) r) × (Π r, U m r -> Dcuts_plus_val (U n) (λ q, (q < eps)%NRat) r))).
+                            ∏ n m : nat, N ≤ n -> N ≤ m -> (∏ r, U n r -> Dcuts_plus_val (U m) (λ q, (q < eps)%NRat) r) × (∏ r, U m r -> Dcuts_plus_val (U n) (λ q, (q < eps)%NRat) r))).
 
 Definition Dcuts_lim_cauchy_val : hsubtype NonnegativeRationals :=
-λ r : NonnegativeRationals, hexists (λ c : NonnegativeRationals, (0 < c)%NRat × Σ N : nat, Π n : nat, N ≤ n -> U n (r + c)).
+λ r : NonnegativeRationals, hexists (λ c : NonnegativeRationals, (0 < c)%NRat × ∑ N : nat, ∏ n : nat, N ≤ n -> U n (r + c)).
 
 Lemma Dcuts_lim_cauchy_bot : Dcuts_def_bot Dcuts_lim_cauchy_val.
 Proof.
@@ -3968,18 +3968,18 @@ Qed.
 End Dcuts_lim.
 
 Definition Dcuts_Cauchy_seq (u : nat -> Dcuts) : hProp
-  := hProppair (Π eps : Dcuts,
+  := hProppair (∏ eps : Dcuts,
                    0 < eps ->
                    hexists
                      (λ N : nat,
-                            Π n m : nat, N ≤ n -> N ≤ m -> u n < Dcuts_plus (u m) eps × u m < Dcuts_plus (u n) eps))
+                            ∏ n m : nat, N ≤ n -> N ≤ m -> u n < Dcuts_plus (u m) eps × u m < Dcuts_plus (u n) eps))
                (impred_isaprop _ (λ _, isapropimpl _ _ (pr2 _))).
 Definition is_Dcuts_lim_seq (u : nat -> Dcuts) (l : Dcuts) : hProp
-  := hProppair (Π eps : Dcuts,
+  := hProppair (∏ eps : Dcuts,
                    0 < eps ->
                    hexists
                      (λ N : nat,
-                            Π n : nat, N ≤ n -> u n < Dcuts_plus l eps × l < Dcuts_plus (u n) eps))
+                            ∏ n : nat, N ≤ n -> u n < Dcuts_plus l eps × l < Dcuts_plus (u n) eps))
                (impred_isaprop _ (λ _, isapropimpl _ _ (pr2 _))).
 
 Definition Dcuts_lim_cauchy_seq (u : nat → Dcuts) (Hu : Dcuts_Cauchy_seq u) : Dcuts.
@@ -4137,16 +4137,16 @@ Qed.
 Section Dcuts_of_Dcuts.
 
 Context (E : hsubtype Dcuts).
-Context (E_bot : Π x : Dcuts, E x -> Π y : Dcuts, y <= x -> E y).
-Context (E_open : Π x : Dcuts, E x -> ∃ y : Dcuts, x < y × E y).
-Context (E_corr: Π c : Dcuts, 0 < c -> (¬ E c) ∨ (hexists (λ P, E P × ¬ E (Dcuts_plus P c)))).
+Context (E_bot : ∏ x : Dcuts, E x -> ∏ y : Dcuts, y <= x -> E y).
+Context (E_open : ∏ x : Dcuts, E x -> ∃ y : Dcuts, x < y × E y).
+Context (E_corr: ∏ c : Dcuts, 0 < c -> (¬ E c) ∨ (hexists (λ P, E P × ¬ E (Dcuts_plus P c)))).
 
 Definition Dcuts_of_Dcuts_val : NonnegativeRationals → hProp :=
   λ r : NonnegativeRationals, ∃ X : Dcuts, (E X) × (r ∈ X).
 
 Lemma Dcuts_of_Dcuts_bot :
-  Π (x : NonnegativeRationals),
-    Dcuts_of_Dcuts_val x -> Π y : NonnegativeRationals, (y <= x)%NRat -> Dcuts_of_Dcuts_val y.
+  ∏ (x : NonnegativeRationals),
+    Dcuts_of_Dcuts_val x -> ∏ y : NonnegativeRationals, (y <= x)%NRat -> Dcuts_of_Dcuts_val y.
 Proof.
   intros r Xr n Xn.
   revert Xr ; apply hinhfun ; intros X.
@@ -4158,7 +4158,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_of_Dcuts_open :
-  Π (x : NonnegativeRationals),
+  ∏ (x : NonnegativeRationals),
     Dcuts_of_Dcuts_val x ->
     hexists (fun y : NonnegativeRationals => dirprod (Dcuts_of_Dcuts_val y) (x < y)%NRat).
 Proof.
@@ -4302,8 +4302,8 @@ Definition Dcuts_of_Dcuts'_val : hsubtype Dcuts :=
   λ x : Dcuts, ∃ r : NonnegativeRationals, (¬ (r ∈ x)) × E r.
 
 Lemma Dcuts_of_Dcuts'_bot :
-  Π (x : Dcuts),
-    Dcuts_of_Dcuts'_val x -> Π y : Dcuts, (y <= x) -> Dcuts_of_Dcuts'_val y.
+  ∏ (x : Dcuts),
+    Dcuts_of_Dcuts'_val x -> ∏ y : Dcuts, (y <= x) -> Dcuts_of_Dcuts'_val y.
 Proof.
   intros r Xr n Xn.
   revert Xr.
@@ -4318,7 +4318,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_of_Dcuts'_open :
-  Π (x : Dcuts),
+  ∏ (x : Dcuts),
     Dcuts_of_Dcuts'_val x ->
     hexists (fun y : Dcuts => dirprod (Dcuts_of_Dcuts'_val y) (x < y)).
 Proof.
@@ -4345,7 +4345,7 @@ Proof.
 Qed.
 
 Lemma Dcuts_of_Dcuts'_corr:
-  Π c : Dcuts, 0 < c -> (¬ Dcuts_of_Dcuts'_val c) ∨ (hexists (λ P, Dcuts_of_Dcuts'_val P × ¬ Dcuts_of_Dcuts'_val (Dcuts_plus P c))).
+  ∏ c : Dcuts, 0 < c -> (¬ Dcuts_of_Dcuts'_val c) ∨ (hexists (λ P, Dcuts_of_Dcuts'_val P × ¬ Dcuts_of_Dcuts'_val (Dcuts_plus P c))).
 Proof.
   intros C HC.
   assert (∃ c : NonnegativeRationals, c ∈ C × (0 < c)%NRat).
@@ -4410,7 +4410,7 @@ Qed.
 End Dcuts_of_Dcuts'.
 
 Lemma Dcuts_of_Dcuts_bij :
-  Π x : Dcuts, Dcuts_of_Dcuts (Dcuts_of_Dcuts'_val (pr1 x)) (Dcuts_of_Dcuts'_bot (pr1 x)) (Dcuts_of_Dcuts'_corr (pr1 x) (is_Dcuts_bot x) (is_Dcuts_corr x)) = x.
+  ∏ x : Dcuts, Dcuts_of_Dcuts (Dcuts_of_Dcuts'_val (pr1 x)) (Dcuts_of_Dcuts'_bot (pr1 x)) (Dcuts_of_Dcuts'_corr (pr1 x) (is_Dcuts_bot x) (is_Dcuts_corr x)) = x.
 Proof.
   intros x.
   apply Dcuts_eq_is_eq.
@@ -4442,7 +4442,7 @@ Proof.
       exact (pr2 (pr2 q)).
 Qed.
 Lemma Dcuts_of_Dcuts_bij' :
-  Π E : hsubtype Dcuts, Π (E_bot : Π x : Dcuts, E x -> Π y : Dcuts, y <= x -> E y) (E_open : Π x : Dcuts, E x -> ∃ y : Dcuts, x < y × E y),
+  ∏ E : hsubtype Dcuts, ∏ (E_bot : ∏ x : Dcuts, E x -> ∏ y : Dcuts, y <= x -> E y) (E_open : ∏ x : Dcuts, E x -> ∃ y : Dcuts, x < y × E y),
     Dcuts_of_Dcuts'_val (Dcuts_of_Dcuts_val E) = E.
 Proof.
   intros.
@@ -4580,9 +4580,9 @@ Definition NonnegativeReals_to_hsubtypeNonnegativeRationals :
   NonnegativeReals → (hsubtype NonnegativeRationals) := pr1.
 Definition hsubtypeNonnegativeRationals_to_NonnegativeReals
   (X : NonnegativeRationals -> hProp)
-  (Xbot : Π x : NonnegativeRationals,
-            X x -> Π y : NonnegativeRationals, (y <= x)%NRat -> X y)
-  (Xopen : Π x : NonnegativeRationals,
+  (Xbot : ∏ x : NonnegativeRationals,
+            X x -> ∏ y : NonnegativeRationals, (y <= x)%NRat -> X y)
+  (Xopen : ∏ x : NonnegativeRationals,
              X x ->
              hexists (fun y : NonnegativeRationals => dirprod (X y) (x < y)%NRat))
   (Xtop : Dcuts_def_corr X) : NonnegativeReals :=
@@ -4601,7 +4601,7 @@ Notation "x / 2" := (halfNonnegativeReals x) (at level 35, no associativity) : N
 (** ** Compatibility with NonnegativeRationals *)
 
 Lemma NonnegativeRationals_to_NonnegativeReals_lt :
-  Π x y : NonnegativeRationals,
+  ∏ x y : NonnegativeRationals,
     (x < y)%NRat <->
     NonnegativeRationals_to_NonnegativeReals x < NonnegativeRationals_to_NonnegativeReals y.
 Proof.
@@ -4619,7 +4619,7 @@ Proof.
 Qed.
 
 Lemma NonnegativeRationals_to_NonnegativeReals_le :
-  Π x y : NonnegativeRationals,
+  ∏ x y : NonnegativeRationals,
     (x <= y)%NRat <->
     NonnegativeRationals_to_NonnegativeReals x <= NonnegativeRationals_to_NonnegativeReals y.
 Proof.
@@ -4651,7 +4651,7 @@ Proof.
   reflexivity.
 Qed.
 Lemma NonnegativeRationals_to_NonnegativeReals_plus :
-  Π x y : NonnegativeRationals, NonnegativeRationals_to_NonnegativeReals (x + y)%NRat = NonnegativeRationals_to_NonnegativeReals x + NonnegativeRationals_to_NonnegativeReals y.
+  ∏ x y : NonnegativeRationals, NonnegativeRationals_to_NonnegativeReals (x + y)%NRat = NonnegativeRationals_to_NonnegativeReals x + NonnegativeRationals_to_NonnegativeReals y.
 Proof.
   intros x y.
   apply Dcuts_eq_is_eq.
@@ -4714,7 +4714,7 @@ Proof.
 Qed.
 
 Lemma NonnegativeRationals_to_NonnegativeReals_minus :
-  Π x y : NonnegativeRationals, NonnegativeRationals_to_NonnegativeReals (x - y)%NRat = NonnegativeRationals_to_NonnegativeReals x - NonnegativeRationals_to_NonnegativeReals y.
+  ∏ x y : NonnegativeRationals, NonnegativeRationals_to_NonnegativeReals (x - y)%NRat = NonnegativeRationals_to_NonnegativeReals x - NonnegativeRationals_to_NonnegativeReals y.
 Proof.
   intros x y.
   generalize (isdecrel_leNonnegativeRationals x y) ; apply sumofmaps ; intros Hxy.
@@ -4731,7 +4731,7 @@ Proof.
     exact Hxy.
 Qed.
 Lemma NonnegativeRationals_to_NonnegativeReals_mult :
-  Π x y : NonnegativeRationals, NonnegativeRationals_to_NonnegativeReals (x * y)%NRat = NonnegativeRationals_to_NonnegativeReals x * NonnegativeRationals_to_NonnegativeReals y.
+  ∏ x y : NonnegativeRationals, NonnegativeRationals_to_NonnegativeReals (x * y)%NRat = NonnegativeRationals_to_NonnegativeReals x * NonnegativeRationals_to_NonnegativeReals y.
 Proof.
   intros x y.
   generalize (eq0orgt0NonnegativeRationals x) ; apply sumofmaps ; [intros -> | intros Hx].
@@ -4763,7 +4763,7 @@ Proof.
 Qed.
 
 Lemma NonnegativeRationals_to_NonnegativeReals_nattorig :
-  Π n : nat, NonnegativeRationals_to_NonnegativeReals (nattorig n) = nattorig n.
+  ∏ n : nat, NonnegativeRationals_to_NonnegativeReals (nattorig n) = nattorig n.
 Proof.
   induction n as [|n IHn].
   - reflexivity.
@@ -4780,7 +4780,7 @@ Proof.
   reflexivity.
 Qed.
 Lemma nat_to_NonnegativeReals_Sn :
-  Π n : nat, nat_to_NonnegativeReals (S n) = nat_to_NonnegativeReals n + 1.
+  ∏ n : nat, nat_to_NonnegativeReals (S n) = nat_to_NonnegativeReals n + 1.
 Proof.
   intros n.
   unfold nat_to_NonnegativeReals.
@@ -4792,13 +4792,13 @@ Qed.
 (** Order, apartness, and equality *)
 
 Definition istrans_leNonnegativeReals :
-  Π x y z : NonnegativeReals, x <= y -> y <= z -> x <= z
+  ∏ x y z : NonnegativeReals, x <= y -> y <= z -> x <= z
   := istrans_EOle (X := EffectivelyOrdered_NonnegativeReals).
 Definition isrefl_leNonnegativeReals :
-  Π x : NonnegativeReals, x <= x
+  ∏ x : NonnegativeReals, x <= x
   := isrefl_EOle (X := EffectivelyOrdered_NonnegativeReals).
 Lemma isantisymm_leNonnegativeReals :
-  Π x y : NonnegativeReals, x <= y × y <= x <-> x = y.
+  ∏ x y : NonnegativeReals, x <= y × y <= x <-> x = y.
 Proof.
   intros x y ; split.
   - intros H.
@@ -4809,54 +4809,54 @@ Proof.
      split ; apply isrefl_leNonnegativeReals.
 Qed.
 Lemma eqNonnegativeReals_le :
-  Π x y : NonnegativeReals, x = y -> x <= y.
+  ∏ x y : NonnegativeReals, x = y -> x <= y.
 Proof.
   intros x y ->.
   apply isrefl_leNonnegativeReals.
 Qed.
 
 Definition istrans_ltNonnegativeReals :
-  Π x y z : NonnegativeReals, x < y -> y < z -> x < z
+  ∏ x y z : NonnegativeReals, x < y -> y < z -> x < z
   := istrans_EOlt (X := EffectivelyOrdered_NonnegativeReals).
 Definition iscotrans_ltNonnegativeReals :
-  Π x y z : NonnegativeReals, x < z -> x < y ∨ y < z
+  ∏ x y z : NonnegativeReals, x < z -> x < y ∨ y < z
   := iscotrans_Dcuts_lt_rel.
 Definition isirrefl_ltNonnegativeReals :
-  Π x : NonnegativeReals, ¬ (x < x)
+  ∏ x : NonnegativeReals, ¬ (x < x)
   := isirrefl_EOlt (X := EffectivelyOrdered_NonnegativeReals).
 
 Definition istrans_lt_le_ltNonnegativeReals :
-  Π x y z : NonnegativeReals, x < y -> y <= z -> x < z
+  ∏ x y z : NonnegativeReals, x < y -> y <= z -> x < z
   := istrans_EOlt_le (X := EffectivelyOrdered_NonnegativeReals).
 Definition istrans_le_lt_ltNonnegativeReals :
-  Π x y z : NonnegativeReals, x <= y -> y < z -> x < z
+  ∏ x y z : NonnegativeReals, x <= y -> y < z -> x < z
   := istrans_EOle_lt (X := EffectivelyOrdered_NonnegativeReals).
 
 Lemma lt_leNonnegativeReals :
-  Π x y : NonnegativeReals, x < y -> x <= y.
+  ∏ x y : NonnegativeReals, x < y -> x <= y.
 Proof.
   exact Dcuts_lt_le_rel.
 Qed.
 Lemma notlt_leNonnegativeReals :
-  Π x y : NonnegativeReals, ¬ (x < y) <-> (y <= x).
+  ∏ x y : NonnegativeReals, ¬ (x < y) <-> (y <= x).
 Proof.
   exact Dcuts_nlt_ge.
 Qed.
 
 Lemma isnonnegative_NonnegativeReals :
-  Π x : NonnegativeReals, 0 <= x.
+  ∏ x : NonnegativeReals, 0 <= x.
 Proof.
   intros x.
   now apply Dcuts_ge_0.
 Qed.
 Lemma isnonnegative_NonnegativeReals' :
-  Π x : NonnegativeReals, ¬ (x < 0).
+  ∏ x : NonnegativeReals, ¬ (x < 0).
 Proof.
   intros x.
   now apply Dcuts_notlt_0.
 Qed.
 Lemma le0_NonnegativeReals :
-  Π x : NonnegativeReals, (x <= 0) <-> (x = 0).
+  ∏ x : NonnegativeReals, (x <= 0) <-> (x = 0).
 Proof.
   intros x ; split ; intros Hx.
   apply isantisymm_leNonnegativeReals.
@@ -4868,21 +4868,21 @@ Proof.
 Qed.
 
 Lemma ap_ltNonnegativeReals :
-  Π x y : NonnegativeReals, x ≠ y <-> (x < y) ⨿  (y < x).
+  ∏ x y : NonnegativeReals, x ≠ y <-> (x < y) ⨿  (y < x).
 Proof.
   now intros x y ; split.
 Qed.
 Definition isirrefl_apNonnegativeReals :
-  Π x : NonnegativeReals, ¬ (x ≠ x)
+  ∏ x : NonnegativeReals, ¬ (x ≠ x)
   := isirrefl_Dcuts_ap_rel.
 Definition issymm_apNonnegativeReals :
-  Π x y : NonnegativeReals, x ≠ y -> y ≠ x
+  ∏ x y : NonnegativeReals, x ≠ y -> y ≠ x
   := issymm_Dcuts_ap_rel.
 Definition iscotrans_apNonnegativeReals :
-  Π x y z : NonnegativeReals, x ≠ z -> x ≠ y ∨ y ≠ z
+  ∏ x y z : NonnegativeReals, x ≠ z -> x ≠ y ∨ y ≠ z
   := iscotrans_Dcuts_ap_rel.
 Lemma istight_apNonnegativeReals:
-  Π x y : NonnegativeReals, (¬ (x ≠ y)) <-> (x = y).
+  ∏ x y : NonnegativeReals, (¬ (x ≠ y)) <-> (x = y).
 Proof.
   intros x y.
   split.
@@ -4892,7 +4892,7 @@ Proof.
 Qed.
 
 Lemma ispositive_apNonnegativeReals :
-  Π x : NonnegativeReals, x ≠ 0 <-> 0 < x.
+  ∏ x : NonnegativeReals, x ≠ 0 <-> 0 < x.
 Proof.
   intros X ; split.
   - apply sumofmaps ; [ | intros Hlt ].
@@ -4916,32 +4916,32 @@ Qed.
 (** addition *)
 
 Definition ap_plusNonnegativeReals:
-  Π x x' y y' : NonnegativeReals,
+  ∏ x x' y y' : NonnegativeReals,
     x + y ≠ x' + y' -> x ≠ x' ∨ y ≠ y'
   := apCCDRplus (X := NonnegativeReals).
 
 Definition islunit_zero_plusNonnegativeReals:
-  Π x : NonnegativeReals, 0 + x = x
+  ∏ x : NonnegativeReals, 0 + x = x
   := islunit_CCDRzero_CCDRplus (X := NonnegativeReals).
 Definition isrunit_zero_plusNonnegativeReals:
-  Π x : NonnegativeReals, x + 0 = x
+  ∏ x : NonnegativeReals, x + 0 = x
   := isrunit_CCDRzero_CCDRplus (X := NonnegativeReals).
 Definition isassoc_plusNonnegativeReals:
-  Π x y z : NonnegativeReals, x + y + z = x + (y + z)
+  ∏ x y z : NonnegativeReals, x + y + z = x + (y + z)
   := isassoc_CCDRplus (X := NonnegativeReals).
 Definition iscomm_plusNonnegativeReals:
-  Π x y : NonnegativeReals, x + y = y + x
+  ∏ x y : NonnegativeReals, x + y = y + x
   := iscomm_CCDRplus (X := NonnegativeReals).
 
 Definition plusNonnegativeReals_ltcompat_l :
-  Π x y z: NonnegativeReals, (y < z) <-> (y + x < z + x)
+  ∏ x y z: NonnegativeReals, (y < z) <-> (y + x < z + x)
   := Dcuts_plus_ltcompat_l.
 Definition plusNonnegativeReals_ltcompat_r :
-  Π x y z: NonnegativeReals, (y < z) <-> (x + y < x + z)
+  ∏ x y z: NonnegativeReals, (y < z) <-> (x + y < x + z)
   := Dcuts_plus_ltcompat_r.
 
 Lemma plusNonnegativeReals_ltcompat :
-  Π x y z t : NonnegativeReals, x < y -> z < t -> x + z < y + t.
+  ∏ x y z t : NonnegativeReals, x < y -> z < t -> x + z < y + t.
 Proof.
   intros x y z t Hxy Hzt.
   eapply istrans_ltNonnegativeReals, plusNonnegativeReals_ltcompat_l.
@@ -4949,7 +4949,7 @@ Proof.
   exact Hxy.
 Qed.
 Lemma plusNonnegativeReals_lt_l:
-  Π x y : NonnegativeReals, 0 < x <-> y < x + y.
+  ∏ x y : NonnegativeReals, 0 < x <-> y < x + y.
 Proof.
   intros x y.
   pattern y at 1.
@@ -4957,7 +4957,7 @@ Proof.
   now apply plusNonnegativeReals_ltcompat_l.
 Qed.
 Lemma plusNonnegativeReals_lt_r:
-  Π x y : NonnegativeReals, 0 < y <-> x < x + y.
+  ∏ x y : NonnegativeReals, 0 < y <-> x < x + y.
 Proof.
   intros x y.
   pattern x at 1.
@@ -4966,13 +4966,13 @@ Proof.
 Qed.
 
 Definition plusNonnegativeReals_lecompat_l :
-  Π x y z: NonnegativeReals, (y <= z) <-> (y + x <= z + x)
+  ∏ x y z: NonnegativeReals, (y <= z) <-> (y + x <= z + x)
   := Dcuts_plus_lecompat_l.
 Definition plusNonnegativeReals_lecompat_r :
-  Π x y z: NonnegativeReals, (y <= z) <-> (x + y <= x + z)
+  ∏ x y z: NonnegativeReals, (y <= z) <-> (x + y <= x + z)
   := Dcuts_plus_lecompat_r.
 Lemma plusNonnegativeReals_lecompat :
-  Π x y x' y' : NonnegativeReals,
+  ∏ x y x' y' : NonnegativeReals,
     x <= y -> x' <= y' -> x + x' <= y + y'.
 Proof.
   intros x y x' y' H H'.
@@ -4984,18 +4984,18 @@ Proof.
 Qed.
 
 Lemma plusNonnegativeReals_le_l :
-  Π (x y : NonnegativeReals), x <= x + y.
+  ∏ (x y : NonnegativeReals), x <= x + y.
 Proof.
   exact Dcuts_plus_le_l.
 Qed.
 Lemma plusNonnegativeReals_le_r :
-  Π (x y : NonnegativeReals), y <= x + y.
+  ∏ (x y : NonnegativeReals), y <= x + y.
 Proof.
   exact Dcuts_plus_le_r.
 Qed.
 
 Lemma plusNonnegativeReals_le_ltcompat :
-  Π x y z t : NonnegativeReals,
+  ∏ x y z t : NonnegativeReals,
     x <= y -> z < t -> x + z < y + t.
 Proof.
   intros x y z t Hxy Hzt.
@@ -5004,7 +5004,7 @@ Proof.
 Qed.
 
 Lemma plusNonnegativeReals_eqcompat_l :
-  Π x y z: NonnegativeReals, (y + x = z + x) <-> (y = z).
+  ∏ x y z: NonnegativeReals, (y + x = z + x) <-> (y = z).
 Proof.
   intros x y z ; split.
   - intro H ;
@@ -5016,7 +5016,7 @@ Proof.
   - now intros ->.
 Qed.
 Lemma plusNonnegativeReals_eqcompat_r :
-  Π x y z: NonnegativeReals, (x + y = x + z) <-> (y = z).
+  ∏ x y z: NonnegativeReals, (x + y = x + z) <-> (y = z).
 Proof.
   intros x y z.
   rewrite ! (iscomm_plusNonnegativeReals x).
@@ -5024,7 +5024,7 @@ Proof.
 Qed.
 
 Lemma plusNonnegativeReals_apcompat_l :
-  Π x y z: NonnegativeReals, (y ≠ z) <-> (y + x ≠ z + x).
+  ∏ x y z: NonnegativeReals, (y ≠ z) <-> (y + x ≠ z + x).
 Proof.
   intros a b c.
   split.
@@ -5039,7 +5039,7 @@ Proof.
   - now apply islapbinop_Dcuts_plus.
 Qed.
 Lemma plusNonnegativeReals_apcompat_r :
-  Π x y z: NonnegativeReals, (y ≠ z) <-> (x + y ≠ x + z).
+  ∏ x y z: NonnegativeReals, (y ≠ z) <-> (x + y ≠ x + z).
 Proof.
   intros x y z.
   rewrite ! (iscomm_plusNonnegativeReals x).
@@ -5049,102 +5049,102 @@ Qed.
 (** Subtraction *)
 
 Definition minusNonnegativeReals_plus_r :
-  Π x y z : NonnegativeReals, z <= y -> x = y - z -> y = x + z
+  ∏ x y z : NonnegativeReals, z <= y -> x = y - z -> y = x + z
   := Dcuts_minus_plus_r.
 Definition minusNonnegativeReals_eq_zero :
-  Π x y : NonnegativeReals, x <= y -> x - y = 0
+  ∏ x y : NonnegativeReals, x <= y -> x - y = 0
   := Dcuts_minus_eq_zero.
 Definition minusNonnegativeReals_correct_r :
-  Π x y z : NonnegativeReals, x = y + z -> y = x - z
+  ∏ x y z : NonnegativeReals, x = y + z -> y = x - z
   := Dcuts_minus_correct_r.
 Definition minusNonnegativeReals_correct_l :
-  Π x y z : NonnegativeReals, x = y + z -> z = x - y
+  ∏ x y z : NonnegativeReals, x = y + z -> z = x - y
   := Dcuts_minus_correct_l.
 Definition ispositive_minusNonnegativeReals :
-  Π x y : NonnegativeReals, (y < x) <-> (0 < x - y)
+  ∏ x y : NonnegativeReals, (y < x) <-> (0 < x - y)
   := ispositive_Dcuts_minus.
 Definition minusNonnegativeReals_le :
-  Π x y : NonnegativeReals, x - y <= x
+  ∏ x y : NonnegativeReals, x - y <= x
   := Dcuts_minus_le.
 
 (** Multiplication *)
 
 Definition ap_multNonnegativeReals:
-  Π x x' y y' : NonnegativeReals,
+  ∏ x x' y y' : NonnegativeReals,
     x * y ≠ x' * y' -> x ≠ x' ∨ y ≠ y'
   := apCCDRmult (X := NonnegativeReals).
 
 Definition islunit_one_multNonnegativeReals:
-  Π x : NonnegativeReals, 1 * x = x
+  ∏ x : NonnegativeReals, 1 * x = x
   := islunit_CCDRone_CCDRmult (X := NonnegativeReals).
 Definition isrunit_one_multNonnegativeReals:
-  Π x : NonnegativeReals, x * 1 = x
+  ∏ x : NonnegativeReals, x * 1 = x
   := isrunit_CCDRone_CCDRmult (X := NonnegativeReals).
 Definition isassoc_multNonnegativeReals:
-  Π x y z : NonnegativeReals, x * y * z = x * (y * z)
+  ∏ x y z : NonnegativeReals, x * y * z = x * (y * z)
   := isassoc_CCDRmult (X := NonnegativeReals).
 Definition iscomm_multNonnegativeReals:
-  Π x y : NonnegativeReals, x * y = y * x
+  ∏ x y : NonnegativeReals, x * y = y * x
   := iscomm_CCDRmult (X := NonnegativeReals).
 Definition islabsorb_zero_multNonnegativeReals:
-  Π x : NonnegativeReals, 0 * x = 0
+  ∏ x : NonnegativeReals, 0 * x = 0
   := islabsorb_CCDRzero_CCDRmult (X := NonnegativeReals).
 Definition israbsorb_zero_multNonnegativeReals:
-  Π x : NonnegativeReals, x * 0 = 0
+  ∏ x : NonnegativeReals, x * 0 = 0
   := israbsorb_CCDRzero_CCDRmult (X := NonnegativeReals).
 
 Definition multNonnegativeReals_ltcompat_l :
-  Π x y z: NonnegativeReals, (0 < x) -> (y < z) -> (y * x < z * x)
+  ∏ x y z: NonnegativeReals, (0 < x) -> (y < z) -> (y * x < z * x)
   := Dcuts_mult_ltcompat_l.
 Definition multNonnegativeReals_ltcompat_l' :
-  Π x y z: NonnegativeReals, (y * x < z * x) -> (y < z)
+  ∏ x y z: NonnegativeReals, (y * x < z * x) -> (y < z)
   := Dcuts_mult_ltcompat_l'.
 Definition multNonnegativeReals_lecompat_l :
-  Π x y z: NonnegativeReals, (0 < x) -> (y * x <= z * x) -> (y <= z)
+  ∏ x y z: NonnegativeReals, (0 < x) -> (y * x <= z * x) -> (y <= z)
   := Dcuts_mult_lecompat_l.
 Definition multNonnegativeReals_lecompat_l' :
-  Π x y z: NonnegativeReals, (y <= z) -> (y * x <= z * x)
+  ∏ x y z: NonnegativeReals, (y <= z) -> (y * x <= z * x)
   := Dcuts_mult_lecompat_l'.
 
 Definition multNonnegativeReals_ltcompat_r :
-  Π x y z: NonnegativeReals, (0 < x) -> (y < z) -> (x * y < x * z)
+  ∏ x y z: NonnegativeReals, (0 < x) -> (y < z) -> (x * y < x * z)
   := Dcuts_mult_ltcompat_r.
 Definition multNonnegativeReals_ltcompat_r' :
-  Π x y z: NonnegativeReals, (x * y < x *  z) -> (y < z)
+  ∏ x y z: NonnegativeReals, (x * y < x *  z) -> (y < z)
   := Dcuts_mult_ltcompat_r'.
 Definition multNonnegativeReals_lecompat_r :
-  Π x y z: NonnegativeReals, (0 < x) -> (x * y <= x * z) -> (y <= z)
+  ∏ x y z: NonnegativeReals, (0 < x) -> (x * y <= x * z) -> (y <= z)
   := Dcuts_mult_lecompat_r.
 Definition multNonnegativeReals_lecompat_r' :
-  Π x y z: NonnegativeReals, (y <= z) -> (x * y <= x * z)
+  ∏ x y z: NonnegativeReals, (y <= z) -> (x * y <= x * z)
   := Dcuts_mult_lecompat_r'.
 
 (** Multiplicative Inverse *)
 
 Definition islinv_invNonnegativeReals:
-  Π (x : NonnegativeReals) (Hx0 : x ≠ 0), invNonnegativeReals x Hx0 * x = 1
+  ∏ (x : NonnegativeReals) (Hx0 : x ≠ 0), invNonnegativeReals x Hx0 * x = 1
   := islinv_CCDRinv (X := NonnegativeReals).
 Definition isrinv_invNonnegativeReals:
-  Π (x : NonnegativeReals) (Hx0 : x ≠ 0), x * invNonnegativeReals x Hx0 = 1
+  ∏ (x : NonnegativeReals) (Hx0 : x ≠ 0), x * invNonnegativeReals x Hx0 = 1
   := isrinv_CCDRinv (X := NonnegativeReals).
 
 Definition isldistr_plus_multNonnegativeReals:
-  Π x y z : NonnegativeReals, z * (x + y) = z * x + z * y
+  ∏ x y z : NonnegativeReals, z * (x + y) = z * x + z * y
   := isldistr_CCDRplus_CCDRmult (X := NonnegativeReals).
 Definition isrdistr_plus_multNonnegativeReals:
-  Π x y z : NonnegativeReals, (x + y) * z = x * z + y * z
+  ∏ x y z : NonnegativeReals, (x + y) * z = x * z + y * z
   := isrdistr_CCDRplus_CCDRmult (X := NonnegativeReals).
 
 (** maximum *)
 
 Lemma iscomm_maxNonnegativeReals :
-  Π x y : NonnegativeReals,
+  ∏ x y : NonnegativeReals,
     maxNonnegativeReals x y = maxNonnegativeReals y x.
 Proof.
   exact iscomm_Dcuts_max.
 Qed.
 Lemma isassoc_maxNonnegativeReals :
-  Π x y z : NonnegativeReals,
+  ∏ x y z : NonnegativeReals,
     maxNonnegativeReals (maxNonnegativeReals x y) z =
     maxNonnegativeReals x (maxNonnegativeReals y z).
 Proof.
@@ -5152,13 +5152,13 @@ Proof.
 Qed.
 
 Lemma isldistr_max_plusNonnegativeReals :
-  Π x y z : NonnegativeReals,
+  ∏ x y z : NonnegativeReals,
     z + maxNonnegativeReals x y = maxNonnegativeReals (z + x) (z + y).
 Proof.
   exact isldistr_Dcuts_max_plus.
 Qed.
 Lemma isrdistr_max_plusNonnegativeReals :
-  Π x y z : NonnegativeReals,
+  ∏ x y z : NonnegativeReals,
     maxNonnegativeReals x y + z = maxNonnegativeReals (x + z) (y + z).
 Proof.
   intros x y z.
@@ -5167,13 +5167,13 @@ Proof.
 Qed.
 
 Lemma isldistr_max_multNonnegativeReals :
-  Π x y z : NonnegativeReals,
+  ∏ x y z : NonnegativeReals,
     z * maxNonnegativeReals x y = maxNonnegativeReals (z * x) (z * y).
 Proof.
   exact isldistr_Dcuts_max_mult.
 Qed.
 Lemma isrdistr_max_multNonnegativeReals :
-  Π x y z : NonnegativeReals,
+  ∏ x y z : NonnegativeReals,
     maxNonnegativeReals x y * z = maxNonnegativeReals (x * z) (y * z).
 Proof.
   intros x y z.
@@ -5182,40 +5182,40 @@ Proof.
 Qed.
 
 Lemma maxNonnegativeReals_carac_l :
-  Π x y : NonnegativeReals,
+  ∏ x y : NonnegativeReals,
     y <= x -> maxNonnegativeReals x y = x.
 Proof.
   exact Dcuts_max_carac_l.
 Qed.
 Lemma maxNonnegativeReals_carac_r :
-  Π x y : NonnegativeReals,
+  ∏ x y : NonnegativeReals,
     x <= y -> maxNonnegativeReals x y = y.
 Proof.
   exact Dcuts_max_carac_r.
 Qed.
 
 Lemma maxNonnegativeReals_le_l :
-  Π x y : NonnegativeReals,
+  ∏ x y : NonnegativeReals,
     x <= maxNonnegativeReals x y.
 Proof.
   exact Dcuts_max_le_l.
 Qed.
 Lemma maxNonnegativeReals_le_r :
-  Π x y : NonnegativeReals,
+  ∏ x y : NonnegativeReals,
     y <= maxNonnegativeReals x y.
 Proof.
   exact Dcuts_max_le_r.
 Qed.
 
 Lemma maxNonnegativeReals_lt :
-  Π x y z : NonnegativeReals,
+  ∏ x y z : NonnegativeReals,
     x < z -> y < z
     -> maxNonnegativeReals x y < z.
 Proof.
   exact Dcuts_max_lt.
 Qed.
 Lemma maxNonnegativeReals_le :
-  Π x y z : NonnegativeReals,
+  ∏ x y z : NonnegativeReals,
     x <= z -> y <= z
     -> maxNonnegativeReals x y <= z.
 Proof.
@@ -5223,7 +5223,7 @@ Proof.
 Qed.
 
 Lemma maxNonnegativeReals_minus_plus:
-  Π x y : NonnegativeReals,
+  ∏ x y : NonnegativeReals,
     maxNonnegativeReals x y = (x - y) + y.
 Proof.
   intros x y.
@@ -5232,7 +5232,7 @@ Proof.
 Qed.
 
 Lemma isldistr_minus_multNonnegativeReals :
-  Π x y z : NonnegativeReals, z * (x - y) = z * x - z * y.
+  ∏ x y z : NonnegativeReals, z * (x - y) = z * x - z * y.
 Proof.
   intros x y z.
   apply plusNonnegativeReals_eqcompat_l with (Dcuts_mult z y).
@@ -5240,7 +5240,7 @@ Proof.
   apply isldistr_max_multNonnegativeReals.
 Qed.
 Lemma isrdistr_minus_multNonnegativeReals :
-   Π x y z : NonnegativeReals, (x - y) * z = x * z - y * z.
+   ∏ x y z : NonnegativeReals, (x - y) * z = x * z - y * z.
 Proof.
   intros x y z.
   rewrite !(iscomm_multNonnegativeReals _ z).
@@ -5248,7 +5248,7 @@ Proof.
 Qed.
 
 Lemma isassoc_minusNonnegativeReals :
-  Π x y z : NonnegativeReals,
+  ∏ x y z : NonnegativeReals,
     (x - y) - z = x - (y + z).
 Proof.
   intros x y z.
@@ -5265,7 +5265,7 @@ Proof.
   now apply plusNonnegativeReals_le_r.
 Qed.
 Lemma iscomm_minusNonnegativeReals :
-  Π x y z : NonnegativeReals,
+  ∏ x y z : NonnegativeReals,
     x - y - z = x - z - y.
 Proof.
   intros x y z.
@@ -5275,7 +5275,7 @@ Proof.
 Qed.
 
 Lemma max_plusNonnegativeReals :
-  Π x y : NonnegativeReals,
+  ∏ x y : NonnegativeReals,
     (0 < x -> y = 0) ->
     maxNonnegativeReals x y = x + y.
 Proof.
@@ -5285,18 +5285,18 @@ Qed.
 (** half of a non-negative real numbers *)
 
 Lemma double_halfNonnegativeReals :
-  Π x : NonnegativeReals, x = (x / 2) + (x / 2).
+  ∏ x : NonnegativeReals, x = (x / 2) + (x / 2).
 Proof.
   exact Dcuts_half_double.
 Qed.
 Lemma isdistr_plus_halfNonnegativeReals:
-  Π x y : NonnegativeReals,
+  ∏ x y : NonnegativeReals,
     (x + y) / 2 = (x / 2) + (y / 2).
 Proof.
   exact isdistr_Dcuts_half_plus.
 Qed.
 Lemma ispositive_halfNonnegativeReals:
-  Π x : NonnegativeReals,
+  ∏ x : NonnegativeReals,
     (0 < x) <-> (0 < x / 2).
 Proof.
   exact ispositive_Dcuts_half.
@@ -5305,7 +5305,7 @@ Qed.
 (** ** NonnegativeRationals is dense in NonnegativeReals *)
 
 Lemma NonnegativeReals_dense :
-  Π x y : NonnegativeReals, x < y -> ∃ r : NonnegativeRationals, x < NonnegativeRationals_to_NonnegativeReals r × NonnegativeRationals_to_NonnegativeReals r < y.
+  ∏ x y : NonnegativeReals, x < y -> ∃ r : NonnegativeRationals, x < NonnegativeRationals_to_NonnegativeReals r × NonnegativeRationals_to_NonnegativeReals r < y.
 Proof.
   intros x y.
   apply hinhuniv ; intros q.
@@ -5370,18 +5370,18 @@ Qed.
 (** ** Completeness *)
 
 Definition Cauchy_seq (u : nat -> NonnegativeReals) : hProp
-  := hProppair (Π eps : NonnegativeReals,
+  := hProppair (∏ eps : NonnegativeReals,
                    0 < eps ->
                    hexists
                      (λ N : nat,
-                            Π n m : nat, N ≤ n -> N ≤ m -> u n < u m + eps × u m < u n + eps))
+                            ∏ n m : nat, N ≤ n -> N ≤ m -> u n < u m + eps × u m < u n + eps))
                (impred_isaprop _ (λ _, isapropimpl _ _ (pr2 _))).
 Definition is_lim_seq (u : nat -> NonnegativeReals) (l : NonnegativeReals) : hProp
-  := hProppair (Π eps : NonnegativeReals,
+  := hProppair (∏ eps : NonnegativeReals,
                    0 < eps ->
                    hexists
                      (λ N : nat,
-                            Π n : nat, N ≤ n -> u n < l + eps × l < u n + eps))
+                            ∏ n : nat, N ≤ n -> u n < l + eps × l < u n + eps))
                (impred_isaprop _ (λ _, isapropimpl _ _ (pr2 _))).
 
 Definition Cauchy_lim_seq (u : nat → NonnegativeReals) (Cu : Cauchy_seq u) : NonnegativeReals
@@ -5432,7 +5432,7 @@ Proof.
   - now apply (is_lim_seq_unique_aux u).
 Qed.
 Lemma isaprop_ex_lim_seq :
-  Π u : nat -> NonnegativeReals, isaprop (Σ l : NonnegativeReals, is_lim_seq u l).
+  ∏ u : nat -> NonnegativeReals, isaprop (∑ l : NonnegativeReals, is_lim_seq u l).
 Proof.
   intros u l l'.
   apply (iscontrweqf (X := (pr1 l = pr1 l'))).
@@ -5442,7 +5442,7 @@ Proof.
   apply pr2.
 Qed.
 Definition ex_lim_seq  (u : nat → NonnegativeReals) : hProp
-  := hProppair (Σ l : NonnegativeReals, is_lim_seq u l) (isaprop_ex_lim_seq u).
+  := hProppair (∑ l : NonnegativeReals, is_lim_seq u l) (isaprop_ex_lim_seq u).
 Definition Lim_seq (u : nat → NonnegativeReals) (Lu : ex_lim_seq u) : NonnegativeReals
   := pr1 Lu.
 

--- a/UniMath/RealNumbers/Prelim.v
+++ b/UniMath/RealNumbers/Prelim.v
@@ -53,7 +53,7 @@ Proof.
 Qed.
 
 Lemma hqgth_hqneq :
-  Π x y : hq, x > y -> hqneq x y.
+  ∏ x y : hq, x > y -> hqneq x y.
 Proof.
   intros x y Hlt Heq.
   rewrite Heq in Hlt.
@@ -61,20 +61,20 @@ Proof.
 Qed.
 
 Lemma hqldistr :
-  Π x y z, x * (y + z) = x * y + x * z.
+  ∏ x y z, x * (y + z) = x * y + x * z.
 Proof.
   intros x y z.
   now apply rngldistr.
 Qed.
 
 Lemma hqmult2r :
-  Π x : hq, x * 2 = x + x.
+  ∏ x : hq, x * 2 = x + x.
 Proof.
   intros x.
   now rewrite hq2eq1plus1, hqldistr, (hqmultr1 x).
 Qed.
 
-Lemma hqplusdiv2 : Π x : hq, x = (x + x) / 2.
+Lemma hqplusdiv2 : ∏ x : hq, x = (x + x) / 2.
   intros x.
   apply hqmultrcan with 2.
   now apply hqgth_hqneq, hq2_gt0.
@@ -87,7 +87,7 @@ Lemma hqplusdiv2 : Π x : hq, x = (x + x) / 2.
 Qed.
 
 Lemma hqlth_between :
-  Π x y : hq, x < y -> total2 (fun z => dirprod (x < z) (z < y)).
+  ∏ x y : hq, x < y -> total2 (fun z => dirprod (x < z) (z < y)).
 Proof.
   assert (H0 : / 2 > 0).
   { apply hqgthandmultlinv with 2.
@@ -114,7 +114,7 @@ Proof.
 Qed.
 
 Lemma hq0lehandplus:
-  Π n m : hq,
+  ∏ n m : hq,
     0 <= n -> 0 <= m -> 0 <= (n + m).
 Proof.
   intros n m Hn Hm.
@@ -123,14 +123,14 @@ Proof.
 Qed.
 
 Lemma hq0lehandmult:
-  Π n m : hq, 0 <= n -> 0 <= m -> 0 <= n * m.
+  ∏ n m : hq, 0 <= n -> 0 <= m -> 0 <= n * m.
 Proof.
   intros n m.
   exact hqmultgeh0geh0.
 Qed.
 
 Lemma hq0leminus :
-  Π r q : hq, r <= q -> 0 <= q - r.
+  ∏ r q : hq, r <= q -> 0 <= q - r.
 Proof.
   intros r q Hr.
   apply hqlehandplusrinv with r.
@@ -153,7 +153,7 @@ Proof.
 Qed.
 
 Lemma hztohqandleh':
-  Π n m : hz, (hztohq n <= hztohq m)%hq → hzleh n m.
+  ∏ n m : hz, (hztohq n <= hztohq m)%hq → hzleh n m.
 Proof.
   intros n m Hle Hlt.
   simple refine (Hle _).
@@ -161,7 +161,7 @@ Proof.
   exact Hlt.
 Qed.
 Lemma hztohqandlth':
-  Π n m : hz, (hztohq n < hztohq m)%hq -> hzlth n m.
+  ∏ n m : hz, (hztohq n < hztohq m)%hq -> hzlth n m.
 Proof.
   intros n m Hlt.
   apply neghzgehtolth.

--- a/UniMath/RealNumbers/Reals.v
+++ b/UniMath/RealNumbers/Reals.v
@@ -21,7 +21,7 @@ Definition nat_to_hr (n : nat) : hr_commrng :=
   NR_to_hr (nat_to_NonnegativeReals n,,0).
 
 Lemma NR_to_hr_inside :
-  Π x : NonnegativeReals × NonnegativeReals, pr1 (NR_to_hr x) x.
+  ∏ x : NonnegativeReals × NonnegativeReals, pr1 (NR_to_hr x) x.
 Proof.
   intros x.
   apply hinhpr ; simpl.
@@ -29,7 +29,7 @@ Proof.
 Qed.
 
 Local Lemma iscomprelfun_NRminus :
-  Π x y : NonnegativeReals × NonnegativeReals,
+  ∏ x y : NonnegativeReals × NonnegativeReals,
     pr1 x + pr2 y = pr1 y + pr2 x
     → pr1 x - pr2 x = pr1 y - pr2 y.
 Proof.
@@ -77,7 +77,7 @@ Definition hr_to_NRpos (x : hr_commrng) : NonnegativeReals := pr1 (hr_to_NR x).
 Definition hr_to_NRneg (x : hr_commrng) : NonnegativeReals := pr2 (hr_to_NR x).
 
 Lemma hr_to_NR_correct :
-  Π (x : hr_commrng), pr1 x (hr_to_NR x).
+  ∏ (x : hr_commrng), pr1 x (hr_to_NR x).
 Proof.
   intros X.
   generalize (pr1 (pr2 X)).
@@ -99,7 +99,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NRpos_NR_to_hr :
-  Π (x : NonnegativeReals × NonnegativeReals),
+  ∏ (x : NonnegativeReals × NonnegativeReals),
     hr_to_NRpos (NR_to_hr x) = pr1 x - pr2 x.
 Proof.
   intros x.
@@ -107,7 +107,7 @@ Proof.
   now rewrite setquotunivcomm.
 Qed.
 Lemma hr_to_NRneg_NR_to_hr :
-  Π (x : NonnegativeReals × NonnegativeReals),
+  ∏ (x : NonnegativeReals × NonnegativeReals),
     hr_to_NRneg (NR_to_hr x) = pr2 x - pr1 x.
 Proof.
   intros x.
@@ -116,7 +116,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NR_bij :
-  Π x : hr_commrng, NR_to_hr (hr_to_NR x) = x.
+  ∏ x : hr_commrng, NR_to_hr (hr_to_NR x) = x.
 Proof.
   intros x.
   unfold NR_to_hr.
@@ -125,7 +125,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NRposneg_zero :
-  Π x : hr_commrng, 0 < hr_to_NRpos x -> hr_to_NRneg x = 0.
+  ∏ x : hr_commrng, 0 < hr_to_NRpos x -> hr_to_NRneg x = 0.
 Proof.
   intros x.
   rewrite <- (hr_to_NR_bij x).
@@ -138,7 +138,7 @@ Proof.
   exact Hx.
 Qed.
 Lemma hr_to_NRnegpos_zero :
-  Π x : hr_commrng, 0 < hr_to_NRneg x -> hr_to_NRpos x = 0.
+  ∏ x : hr_commrng, 0 < hr_to_NRneg x -> hr_to_NRpos x = 0.
 Proof.
   intros x.
   rewrite <- (hr_to_NR_bij x).
@@ -152,7 +152,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NRpos_NR_to_hr_std :
-  Π (x : NonnegativeReals × NonnegativeReals),
+  ∏ (x : NonnegativeReals × NonnegativeReals),
     (0 < pr1 x -> pr2 x = 0) ->
     hr_to_NRpos (NR_to_hr x) = pr1 x.
 Proof.
@@ -163,7 +163,7 @@ Proof.
   now apply max_plusNonnegativeReals.
 Qed.
 Lemma hr_to_NRneg_NR_to_hr_std :
-  Π (x : NonnegativeReals × NonnegativeReals),
+  ∏ (x : NonnegativeReals × NonnegativeReals),
     (0 < pr1 x -> pr2 x = 0) ->
     hr_to_NRneg (NR_to_hr x) = pr2 x.
 Proof.
@@ -178,7 +178,7 @@ Qed.
 (** Caracterisation of equality *)
 
 Lemma NR_to_hr_eq :
-  Π x y : NonnegativeReals × NonnegativeReals,
+  ∏ x y : NonnegativeReals × NonnegativeReals,
     pr1 x + pr2 y = pr1 y + pr2 x <-> NR_to_hr x = NR_to_hr y.
 Proof.
   intros x y.
@@ -228,7 +228,7 @@ Qed.
 (** plus *)
 
 Lemma NR_to_hr_plus :
-  Π x y : NonnegativeReals × NonnegativeReals,
+  ∏ x y : NonnegativeReals × NonnegativeReals,
     (NR_to_hr x + NR_to_hr y)%rng = NR_to_hr (pr1 x + pr1 y ,, pr2 x + pr2 y).
 Proof.
   intros x y.
@@ -241,7 +241,7 @@ Qed.
 (** opp *)
 
 Lemma NR_to_hr_opp :
-  Π x : NonnegativeReals × NonnegativeReals,
+  ∏ x : NonnegativeReals × NonnegativeReals,
     (- NR_to_hr x)%rng = NR_to_hr (pr2 x ,, pr1 x).
 Proof.
   intros x.
@@ -252,7 +252,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NR_opp :
-  Π x : hr_commrng,
+  ∏ x : hr_commrng,
     hr_to_NR (- x)%rng = (hr_to_NRneg x ,, hr_to_NRpos x).
 Proof.
   intros x.
@@ -264,7 +264,7 @@ Proof.
   reflexivity.
 Qed.
 Lemma hr_to_NRpos_opp :
-  Π x : hr_commrng,
+  ∏ x : hr_commrng,
     hr_to_NRpos (- x)%rng = hr_to_NRneg x.
 Proof.
   intros x.
@@ -272,7 +272,7 @@ Proof.
   now rewrite hr_to_NR_opp.
 Qed.
 Lemma hr_to_NRneg_opp :
-  Π x : hr_commrng,
+  ∏ x : hr_commrng,
     hr_to_NRneg (- x)%rng = hr_to_NRpos x.
 Proof.
   intros x.
@@ -283,7 +283,7 @@ Qed.
 (** minus *)
 
 Lemma NR_to_hr_minus :
-  Π x y : NonnegativeReals × NonnegativeReals,
+  ∏ x y : NonnegativeReals × NonnegativeReals,
     (NR_to_hr x - NR_to_hr y)%rng = NR_to_hr (pr1 x + pr2 y ,, pr2 x + pr1 y).
 Proof.
   intros x y.
@@ -292,7 +292,7 @@ Proof.
 Qed.
 
 Lemma hr_opp_minus :
-  Π x y : hr_commrng,
+  ∏ x y : hr_commrng,
     (x - y = - ((- x) - (- y)))%rng.
 Proof.
   intros x y.
@@ -302,7 +302,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NRpos_minus :
-  Π x y : hr_commrng,
+  ∏ x y : hr_commrng,
     hr_to_NRpos x - hr_to_NRpos y <= hr_to_NRpos (x - y)%rng.
 Proof.
   intros X Y.
@@ -331,7 +331,7 @@ Proof.
   apply maxNonnegativeReals_le_r.
 Qed.
 Lemma hr_to_NRneg_minus :
-  Π x y : hr_commrng,
+  ∏ x y : hr_commrng,
     hr_to_NRneg x - hr_to_NRneg y <= hr_to_NRneg (x - y)%rng.
 Proof.
   intros x y.
@@ -349,7 +349,7 @@ Qed.
 (** mult *)
 
 Lemma NR_to_hr_mult :
-  Π x y : NonnegativeReals × NonnegativeReals,
+  ∏ x y : NonnegativeReals × NonnegativeReals,
     (NR_to_hr x * NR_to_hr y)%rng = NR_to_hr (pr1 x * pr1 y + pr2 x * pr2 y ,, pr1 x * pr2 y + pr2 x * pr1 y).
 Proof.
   intros x y.
@@ -375,7 +375,7 @@ Definition hr_lt_rel : hrel hr_commrng
   := rigtorngrel NonnegativeReals isbinophrel_ltNonnegativeReals.
 
 Lemma NR_to_hr_lt :
-  Π x y : NonnegativeReals × NonnegativeReals,
+  ∏ x y : NonnegativeReals × NonnegativeReals,
     pr1 x + pr2 y < pr1 y + pr2 x
     <-> hr_lt_rel (NR_to_hr x) (NR_to_hr y).
 Proof.
@@ -404,7 +404,7 @@ Definition hr_le_rel : hrel hr_commrng
   := rigtorngrel NonnegativeReals isbinophrel_leNonnegativeReals.
 
 Lemma NR_to_hr_le :
-  Π x y : NonnegativeReals × NonnegativeReals,
+  ∏ x y : NonnegativeReals × NonnegativeReals,
     pr1 x + pr2 y <= pr1 y + pr2 x
     <-> hr_le_rel (NR_to_hr x) (NR_to_hr y).
 Proof.
@@ -421,7 +421,7 @@ Qed.
 (** Theorems about order *)
 
 Lemma hr_notlt_le :
-  Π X Y, ¬ hr_lt_rel X Y <-> hr_le_rel Y X.
+  ∏ X Y, ¬ hr_lt_rel X Y <-> hr_le_rel Y X.
 Proof.
   intros x y.
   rewrite <- (hr_to_NR_bij x), <- (hr_to_NR_bij y).
@@ -440,7 +440,7 @@ Proof.
 Qed.
 
 Lemma hr_lt_le :
-  Π X Y, hr_lt_rel X Y -> hr_le_rel X Y.
+  ∏ X Y, hr_lt_rel X Y -> hr_le_rel X Y.
 Proof.
   intros x y.
   rewrite <- (hr_to_NR_bij x), <- (hr_to_NR_bij y).
@@ -478,7 +478,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NR_nonnegative :
-  Π x : hr_commrng,
+  ∏ x : hr_commrng,
     (hr_to_NRneg x = 0) <-> hr_le_rel 0%rng x.
 Proof.
   intros x.
@@ -501,7 +501,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NR_positive :
-  Π x : hr_commrng,
+  ∏ x : hr_commrng,
     (hr_to_NRpos x ≠ 0 × hr_to_NRneg x = 0) <-> hr_lt_rel 0%rng x.
 Proof.
   intros x.
@@ -526,7 +526,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NR_nonpositive :
-  Π x : hr_commrng,
+  ∏ x : hr_commrng,
     (hr_to_NRpos x = 0) <-> hr_le_rel x 0%rng.
 Proof.
   intros x.
@@ -550,7 +550,7 @@ Proof.
 Qed.
 
 Lemma hr_to_NR_negative :
-  Π x : hr_commrng,
+  ∏ x : hr_commrng,
     (hr_to_NRpos x = 0 × hr_to_NRneg x ≠ 0) <-> hr_lt_rel x 0%rng.
 Proof.
   intros x.
@@ -573,7 +573,7 @@ Proof.
 Qed.
 
 Lemma hr_plus_ltcompat_l :
-  Π x y z : hr_commrng, hr_lt_rel y z <-> hr_lt_rel (y+x)%rng (z+x)%rng.
+  ∏ x y z : hr_commrng, hr_lt_rel y z <-> hr_lt_rel (y+x)%rng (z+x)%rng.
 Proof.
   intros X Y Z.
   rewrite <- (hr_to_NR_bij X), <- (hr_to_NR_bij Y), <- (hr_to_NR_bij Z).
@@ -593,7 +593,7 @@ Proof.
     now apply_pr2_in NR_to_hr_lt Hlt.
 Qed.
 Lemma hr_plus_ltcompat_r :
-  Π x y z : hr_commrng, hr_lt_rel y z <-> hr_lt_rel (x + y)%rng (x + z)%rng.
+  ∏ x y z : hr_commrng, hr_lt_rel y z <-> hr_lt_rel (x + y)%rng (x + z)%rng.
 Proof.
   intros x y z.
   rewrite !(rngcomm1 _ x).
@@ -601,7 +601,7 @@ Proof.
 Qed.
 
 Lemma hr_plus_lecompat_l :
-  Π x y z : hr_commrng, hr_le_rel y z <-> hr_le_rel (y + x)%rng (z + x)%rng.
+  ∏ x y z : hr_commrng, hr_le_rel y z <-> hr_le_rel (y + x)%rng (z + x)%rng.
 Proof.
   intros x y z ; split ; intro Hle.
   - apply hr_notlt_le.
@@ -616,7 +616,7 @@ Proof.
     exact Hlt.
 Qed.
 Lemma hr_plus_lecompat_r :
-  Π x y z : hr_commrng, hr_le_rel y z <-> hr_le_rel (x + y)%rng (x + z)%rng.
+  ∏ x y z : hr_commrng, hr_le_rel y z <-> hr_le_rel (x + y)%rng (x + z)%rng.
 Proof.
   intros x y z.
   rewrite !(rngcomm1 _ x).
@@ -624,7 +624,7 @@ Proof.
 Qed.
 
 Lemma hr_mult_ltcompat_l :
-  Π x y z : hr_commrng, hr_lt_rel 0%rng x -> hr_lt_rel y z -> hr_lt_rel (y * x)%rng (z * x)%rng.
+  ∏ x y z : hr_commrng, hr_lt_rel 0%rng x -> hr_lt_rel y z -> hr_lt_rel (y * x)%rng (z * x)%rng.
 Proof.
   intros X Y Z Hx0 Hlt.
   apply_pr2_in hr_to_NR_positive Hx0.
@@ -642,7 +642,7 @@ Proof.
   now rewrite !hr_to_NR_bij.
 Qed.
 Lemma hr_mult_ltcompat_l' :
-  Π x y z : hr_commrng, hr_le_rel 0%rng x -> hr_lt_rel (y * x)%rng (z * x)%rng -> hr_lt_rel y z.
+  ∏ x y z : hr_commrng, hr_le_rel 0%rng x -> hr_lt_rel (y * x)%rng (z * x)%rng -> hr_lt_rel y z.
 Proof.
   intros X Y Z Hx0.
   apply_pr2_in hr_to_NR_nonnegative Hx0.
@@ -658,7 +658,7 @@ Proof.
   now apply_pr2_in NR_to_hr_lt Hlt.
 Qed.
 Lemma hr_mult_ltcompat_r' :
-  Π x y z : hr_commrng, hr_le_rel 0%rng x -> hr_lt_rel (x * y)%rng (x * z)%rng -> hr_lt_rel y z.
+  ∏ x y z : hr_commrng, hr_le_rel 0%rng x -> hr_lt_rel (x * y)%rng (x * z)%rng -> hr_lt_rel y z.
 Proof.
   intros x y z.
   rewrite !(rngcomm2 _ x).
@@ -666,7 +666,7 @@ Proof.
 Qed.
 
 Lemma hr_mult_lecompat_l :
-  Π x y z : hr_commrng, hr_le_rel 0%rng x -> hr_le_rel y z -> hr_le_rel (y * x)%rng (z * x)%rng.
+  ∏ x y z : hr_commrng, hr_le_rel 0%rng x -> hr_le_rel y z -> hr_le_rel (y * x)%rng (z * x)%rng.
 Proof.
   intros x y z Hx0 Hle.
   apply hr_notlt_le.
@@ -677,7 +677,7 @@ Proof.
   exact Hlt.
 Qed.
 Lemma hr_mult_lecompat_l' :
-  Π x y z : hr_commrng, hr_lt_rel 0%rng x -> hr_le_rel (y * x)%rng (z * x)%rng -> hr_le_rel y z.
+  ∏ x y z : hr_commrng, hr_lt_rel 0%rng x -> hr_le_rel (y * x)%rng (z * x)%rng -> hr_le_rel y z.
 Proof.
   intros x y z Hx0 Hle.
   apply hr_notlt_le.
@@ -688,14 +688,14 @@ Proof.
   exact Hlt.
 Qed.
 Lemma hr_mult_lecompat_r :
-  Π x y z : hr_commrng, hr_le_rel 0%rng x -> hr_le_rel y z -> hr_le_rel (x * y)%rng (x * z)%rng.
+  ∏ x y z : hr_commrng, hr_le_rel 0%rng x -> hr_le_rel y z -> hr_le_rel (x * y)%rng (x * z)%rng.
 Proof.
   intros x y z.
   rewrite !(rngcomm2 _ x).
   apply hr_mult_lecompat_l.
 Qed.
 Lemma hr_mult_lecompat_r' :
-  Π x y z : hr_commrng, hr_lt_rel 0%rng x -> hr_le_rel (x * y)%rng (x * z)%rng -> hr_le_rel y z.
+  ∏ x y z : hr_commrng, hr_lt_rel 0%rng x -> hr_le_rel (x * y)%rng (x * z)%rng -> hr_le_rel y z.
 Proof.
   intros x y z.
   rewrite !(rngcomm2 _ x).
@@ -717,7 +717,7 @@ Definition hr_ap_rel : hrel hr_commrng
   := rigtorngrel NonnegativeReals isbinophrel_apNonnegativeReals.
 
 Lemma NR_to_hr_ap :
-  Π x y : NonnegativeReals × NonnegativeReals,
+  ∏ x y : NonnegativeReals × NonnegativeReals,
     pr1 x + pr2 y ≠ pr1 y + pr2 x
     <-> hr_ap_rel (NR_to_hr x) (NR_to_hr y).
 Proof.
@@ -734,7 +734,7 @@ Qed.
 (** Theorems about apartness *)
 
 Lemma hr_ap_lt :
-  Π X Y : hr_commrng, hr_ap_rel X Y <-> (hr_lt_rel X Y) ⨿ (hr_lt_rel Y X).
+  ∏ X Y : hr_commrng, hr_ap_rel X Y <-> (hr_lt_rel X Y) ⨿ (hr_lt_rel Y X).
 Proof.
   intros X Y.
   rewrite <-  (hr_to_NR_bij X), <- (hr_to_NR_bij Y).
@@ -823,7 +823,7 @@ Proof.
   rewrite <- (hr_to_NR_bij X), <- (hr_to_NR_bij Y), <- (hr_to_NR_bij Z), !NR_to_hr_mult.
   intros Hap.
   apply_pr2_in NR_to_hr_ap Hap ; simpl in Hap.
-  cut (Π Y Z, (pr1 (hr_to_NR Z) * pr1 (hr_to_NR X) + pr2 (hr_to_NR Z) * pr2 (hr_to_NR X) + (pr1 (hr_to_NR Y) * pr2 (hr_to_NR X) + pr2 (hr_to_NR Y) * pr1 (hr_to_NR X)))
+  cut (∏ Y Z, (pr1 (hr_to_NR Z) * pr1 (hr_to_NR X) + pr2 (hr_to_NR Z) * pr2 (hr_to_NR X) + (pr1 (hr_to_NR Y) * pr2 (hr_to_NR X) + pr2 (hr_to_NR Y) * pr1 (hr_to_NR X)))
        = (pr1 (hr_to_NR Z) + pr2 (hr_to_NR Y)) * pr1 (hr_to_NR X) + (pr2 (hr_to_NR Z) + pr1 (hr_to_NR Y)) * pr2 (hr_to_NR X)).
   intro H ; simpl in H,Hap ; rewrite !H in Hap ; clear H.
   apply ap_plusNonnegativeReals in Hap.
@@ -864,7 +864,7 @@ Proof.
 Qed.
 
 Lemma hr_islinv_neg :
-  Π (x : hr_commrng) (Hap : hr_lt_rel x 0%rng),
+  ∏ (x : hr_commrng) (Hap : hr_lt_rel x 0%rng),
    (NR_to_hr (0%NR,, invNonnegativeReals (hr_to_NRneg x) (pr2 (pr2 (hr_to_NR_negative _) Hap))) * x)%rng = 1%rng.
 Proof.
   intros x Hap.
@@ -883,7 +883,7 @@ Proof.
   apply (pr1 (pr2 (hr_to_NR_negative x) Hap)).
 Qed.
 Lemma hr_isrinv_neg :
-  Π (x : hr_commrng) (Hap : hr_lt_rel x 0%rng),
+  ∏ (x : hr_commrng) (Hap : hr_lt_rel x 0%rng),
    (x * NR_to_hr (0%NR,, invNonnegativeReals (hr_to_NRneg x) (pr2 (pr2 (hr_to_NR_negative _) Hap))))%rng = 1%rng.
 Proof.
   intros x Hap.
@@ -892,7 +892,7 @@ Proof.
 Qed.
 
 Lemma hr_islinv_pos :
-  Π (x : hr_commrng) (Hap : hr_lt_rel 0%rng x),
+  ∏ (x : hr_commrng) (Hap : hr_lt_rel 0%rng x),
    (NR_to_hr (invNonnegativeReals (hr_to_NRpos x) (pr1 (pr2 (hr_to_NR_positive _) Hap)) ,, 0%NR) * x)%rng = 1%rng.
 Proof.
   intros x Hap.
@@ -911,7 +911,7 @@ Proof.
   apply (pr2 (pr2 (hr_to_NR_positive x) Hap)).
 Qed.
 Lemma hr_isrinv_pos :
-  Π (x : hr_commrng) (Hap : hr_lt_rel 0%rng x),
+  ∏ (x : hr_commrng) (Hap : hr_lt_rel 0%rng x),
    (x * NR_to_hr (invNonnegativeReals (hr_to_NRpos x) (pr1 (pr2 (hr_to_NR_positive _) Hap)) ,, 0%NR))%rng = 1%rng.
 Proof.
   intros x Hap.
@@ -920,7 +920,7 @@ Proof.
 Qed.
 
 Lemma hr_ex_inv :
-  Π x : hr_commrng,
+  ∏ x : hr_commrng,
     hr_ap_rel x 0%rng -> multinvpair hr_commrng x.
 Proof.
   intros x Hap.
@@ -955,7 +955,7 @@ Definition hr_abs (x : hr_ConstructiveField) : NonnegativeReals :=
   maxNonnegativeReals (hr_to_NRpos x) (hr_to_NRneg x).
 
 Lemma NR_to_hr_abs :
-  Π x : NonnegativeReals × NonnegativeReals,
+  ∏ x : NonnegativeReals × NonnegativeReals,
     hr_abs (NR_to_hr x) <= maxNonnegativeReals (pr1 x) (pr2 x).
 Proof.
   intros x.
@@ -969,7 +969,7 @@ Proof.
 Qed.
 
 Lemma hr_abs_opp :
-  Π x : hr_ConstructiveField, hr_abs (- x)%rng = hr_abs x.
+  ∏ x : hr_ConstructiveField, hr_abs (- x)%rng = hr_abs x.
 Proof.
   intros x.
   unfold hr_abs.
@@ -978,7 +978,7 @@ Proof.
 Qed.
 
 Lemma istriangle_hr_abs :
-  Π x y : hr_ConstructiveField,
+  ∏ x y : hr_ConstructiveField,
     hr_abs (x + y)%rng <= hr_abs x + hr_abs y.
 Proof.
   intros x y.
@@ -995,7 +995,7 @@ Proof.
 Qed.
 
 Lemma istriangle_hr_abs' :
-  Π x y : hr_ConstructiveField,
+  ∏ x y : hr_ConstructiveField,
     hr_abs x - hr_abs y <= hr_abs (x + y)%rng.
 Proof.
   intros x y.
@@ -1011,7 +1011,7 @@ Proof.
 Qed.
 
 Lemma hr_abs_minus :
-  Π x y : hr_ConstructiveField,
+  ∏ x y : hr_ConstructiveField,
     hr_abs x - hr_abs y <= hr_abs (x - y)%rng.
 Proof.
   intros x y.
@@ -1020,14 +1020,14 @@ Proof.
 Qed.
 
 Lemma multNonnegativeReals_lecompat :
-  Π x y z t : NonnegativeReals, x <= y -> z <= t -> x * z <= y * t.
+  ∏ x y z t : NonnegativeReals, x <= y -> z <= t -> x * z <= y * t.
 Proof.
   intros x y z t H H0.
   eapply istrans_leNonnegativeReals, multNonnegativeReals_lecompat_l', H.
   apply multNonnegativeReals_lecompat_r', H0.
 Qed.
 Lemma ispositive_multNonnegativeReals :
-  Π x y : NonnegativeReals, 0 < x ∧ 0 < y <-> 0 < x * y.
+  ∏ x y : NonnegativeReals, 0 < x ∧ 0 < y <-> 0 < x * y.
 Proof.
   intros x y.
   split.
@@ -1045,7 +1045,7 @@ Proof.
     exact H.
 Qed.
 Lemma maxNonnegativeReals_lt' :
-  Π x y z : NonnegativeReals,
+  ∏ x y z : NonnegativeReals,
     z < maxNonnegativeReals x y -> z < x ∨ z < y.
 Proof.
   intros x y z.
@@ -1066,7 +1066,7 @@ Proof.
 Qed.
 
 Lemma hr_abs_mult :
-  Π x y : hr_ConstructiveField, hr_abs (x * y)%rng = hr_abs x * hr_abs y.
+  ∏ x y : hr_ConstructiveField, hr_abs (x * y)%rng = hr_abs x * hr_abs y.
 Proof.
   intros x y.
   pattern x at 1 ; rewrite <- (hr_to_NR_bij x) ;
@@ -1131,7 +1131,7 @@ Proof.
 Qed.
 
 Lemma nat_to_hr_S :
-  Π n : nat, nat_to_hr (S n) = (1 + nat_to_hr n)%rng.
+  ∏ n : nat, nat_to_hr (S n) = (1 + nat_to_hr n)%rng.
 Proof.
   intros n.
   unfold nat_to_hr.
@@ -1204,7 +1204,7 @@ Qed.
 Definition Cauchy_seq (u : nat → hr_ConstructiveField) : hProp.
 Proof.
   intro u.
-  apply (hProppair (Π c : NonnegativeReals, 0 < c -> ∃ N : nat, Π n m : nat, N ≤ n -> N ≤ m -> hr_abs (u m - u n)%rng < c)).
+  apply (hProppair (∏ c : NonnegativeReals, 0 < c -> ∃ N : nat, ∏ n m : nat, N ≤ n -> N ≤ m -> hr_abs (u m - u n)%rng < c)).
   apply impred_isaprop ; intro.
   apply isapropimpl.
   apply pr2.
@@ -1216,7 +1216,7 @@ Lemma Cauchy_seq_pr1 (u : nat → hr_ConstructiveField) :
 Proof.
   intros u x.
   set (y := λ n : nat, hr_to_NRneg (u n)).
-  assert (Hxy : Π n, NR_to_hr (x n ,, y n) = u n).
+  assert (Hxy : ∏ n, NR_to_hr (x n ,, y n) = u n).
   { intros n.
     unfold x, y, hr_to_NRpos, hr_to_NRneg.
     tryif primitive_projections then idtac else rewrite <- tppr.
@@ -1253,7 +1253,7 @@ Lemma Cauchy_seq_pr2 (u : nat → hr_ConstructiveField) :
 Proof.
   intros u y.
   set (x := λ n : nat, hr_to_NRpos (u n)).
-  assert (Hxy : Π n, NR_to_hr (x n ,, y n) = u n).
+  assert (Hxy : ∏ n, NR_to_hr (x n ,, y n) = u n).
   { intros n.
     unfold x, y, hr_to_NRpos, hr_to_NRneg.
     tryif primitive_projections then idtac else rewrite <- tppr.
@@ -1288,12 +1288,12 @@ Qed.
 Definition is_lim_seq (u : nat → hr_ConstructiveField) (l : hr_ConstructiveField) : hProp.
 Proof.
   intros u l.
-  apply (hProppair (Π c : NonnegativeReals, 0 < c -> ∃ N : nat, Π n : nat, N ≤ n -> hr_abs (u n - l)%rng < c)).
+  apply (hProppair (∏ c : NonnegativeReals, 0 < c -> ∃ N : nat, ∏ n : nat, N ≤ n -> hr_abs (u n - l)%rng < c)).
   apply impred_isaprop ; intro.
   apply isapropimpl.
   apply pr2.
 Defined.
-Definition ex_lim_seq (u : nat → hr_ConstructiveField) := Σ l, is_lim_seq u l.
+Definition ex_lim_seq (u : nat → hr_ConstructiveField) := ∑ l, is_lim_seq u l.
 
 Lemma Cauchy_seq_impl_ex_lim_seq (u : nat → hr_ConstructiveField) :
   Cauchy_seq u → ex_lim_seq u.
@@ -1301,7 +1301,7 @@ Proof.
   intros u Cu.
   set (x := λ n, hr_to_NRpos (u n)).
   set (y := λ n, hr_to_NRneg (u n)).
-  assert (Hxy : Π n, NR_to_hr (x n ,, y n) = u n).
+  assert (Hxy : ∏ n, NR_to_hr (x n ,, y n) = u n).
   { intros n.
     unfold x, y, hr_to_NRpos, hr_to_NRneg.
     tryif primitive_projections then idtac else rewrite <- tppr.
@@ -1369,8 +1369,8 @@ Definition Rminus : binop Reals := CFminus.
 
 Definition Rone : Reals := CFone.
 Definition Rmult : binop Reals := CFmult.
-Definition Rinv : Π x : Reals, (Rap x Rzero) -> Reals := CFinv.
-Definition Rdiv : Reals -> Π y : Reals, (Rap y Rzero) -> Reals := CFdiv.
+Definition Rinv : ∏ x : Reals, (Rap x Rzero) -> Reals := CFinv.
+Definition Rdiv : Reals -> ∏ y : Reals, (Rap y Rzero) -> Reals := CFdiv.
 
 Definition Rtwo : Reals := Rplus Rone Rone.
 Definition Rabs : Reals → NonnegativeReals := hr_abs.
@@ -1400,7 +1400,7 @@ Notation "x / y" := (Rdiv x (pr1 y) (pr2 y)) : R_scope.
 (** ** NRNRtoR and RtoNRNR *)
 
 Lemma NRNRtoR_RtoNRNR :
-  Π x : Reals, NRNRtoR (pr1 (RtoNRNR x)) (pr2 (RtoNRNR x)) = x.
+  ∏ x : Reals, NRNRtoR (pr1 (RtoNRNR x)) (pr2 (RtoNRNR x)) = x.
 Proof.
   intros X.
   unfold NRNRtoR.
@@ -1409,7 +1409,7 @@ Proof.
 Qed.
 
 Lemma RtoNRNR_NRNRtoR :
-  Π x y : NonnegativeReals,
+  ∏ x y : NonnegativeReals,
     (RtoNRNR (NRNRtoR x y)) = ((x - y)%NR ,, (y - x)%NR).
 Proof.
   intros X Y.
@@ -1419,7 +1419,7 @@ Proof.
 Qed.
 
 Lemma NRNRtoR_inside :
-  Π x y : NonnegativeReals, pr1 (NRNRtoR x y) (x,,y).
+  ∏ x y : NonnegativeReals, pr1 (NRNRtoR x y) (x,,y).
 Proof.
   intros x y.
   apply hinhpr.
@@ -1447,7 +1447,7 @@ Proof.
 Qed.
 
 Lemma NRNRtoR_eq :
-  Π x x' y y' : NonnegativeReals,
+  ∏ x x' y y' : NonnegativeReals,
     (x + y' = x' + y)%NR <->
     NRNRtoR x y = NRNRtoR x' y'.
 Proof.
@@ -1455,7 +1455,7 @@ Proof.
   apply (NR_to_hr_eq (x,,y) (x' ,, y')).
 Qed.
 Lemma NRNRtoR_ap :
-  Π x x' y y' : NonnegativeReals,
+  ∏ x x' y y' : NonnegativeReals,
     (x + y' ≠ x' + y)%NR <->
     NRNRtoR x y ≠ NRNRtoR x' y'.
 Proof.
@@ -1463,7 +1463,7 @@ Proof.
   apply (NR_to_hr_ap (x,,y) (x' ,, y')).
 Qed.
 Lemma NRNRtoR_lt :
-  Π x x' y y' : NonnegativeReals,
+  ∏ x x' y y' : NonnegativeReals,
     (x + y' < x' + y)%NR <->
     NRNRtoR x y < NRNRtoR x' y'.
 Proof.
@@ -1471,7 +1471,7 @@ Proof.
   apply (NR_to_hr_lt (x,,y) (x' ,, y')).
 Qed.
 Lemma NRNRtoR_le :
-  Π x x' y y' : NonnegativeReals,
+  ∏ x x' y y' : NonnegativeReals,
     (x + y' <= x' + y)%NR <->
     NRNRtoR x y <= NRNRtoR x' y'.
 Proof.
@@ -1480,31 +1480,31 @@ Proof.
 Qed.
 
 Lemma NRNRtoR_plus :
-  Π x x' y y' : NonnegativeReals, NRNRtoR (x + x')%NR (y + y')%NR = NRNRtoR x y + NRNRtoR x' y'.
+  ∏ x x' y y' : NonnegativeReals, NRNRtoR (x + x')%NR (y + y')%NR = NRNRtoR x y + NRNRtoR x' y'.
 Proof.
   intros x x' y y'.
   apply pathsinv0, NR_to_hr_plus.
 Qed.
 Lemma NRNRtoR_opp :
-  Π x y : NonnegativeReals, NRNRtoR y x = - NRNRtoR x y.
+  ∏ x y : NonnegativeReals, NRNRtoR y x = - NRNRtoR x y.
 Proof.
   intros x y.
   apply pathsinv0, NR_to_hr_opp.
 Qed.
 Lemma NRNRtoR_minus :
-  Π x x' y y' : NonnegativeReals, NRNRtoR (x + y')%NR (y + x')%NR = NRNRtoR x y - NRNRtoR x' y'.
+  ∏ x x' y y' : NonnegativeReals, NRNRtoR (x + y')%NR (y + x')%NR = NRNRtoR x y - NRNRtoR x' y'.
 Proof.
   intros x x' y y'.
   apply pathsinv0, NR_to_hr_minus.
 Qed.
 Lemma NRNRtoR_mult :
-  Π x x' y y' : NonnegativeReals, NRNRtoR (x * x' + y * y')%NR (x * y' + y * x')%NR = NRNRtoR x y * NRNRtoR x' y'.
+  ∏ x x' y y' : NonnegativeReals, NRNRtoR (x * x' + y * y')%NR (x * y' + y * x')%NR = NRNRtoR x y * NRNRtoR x' y'.
 Proof.
   intros x x' y y'.
   apply pathsinv0, NR_to_hr_mult.
 Qed.
 Lemma NRNRtoR_inv_pos :
-  Π (x : NonnegativeReals) Hrn Hr,
+  ∏ (x : NonnegativeReals) Hrn Hr,
     NRNRtoR (invNonnegativeReals x Hrn) 0%NR = Rinv (NRNRtoR x 0%NR) Hr.
 Proof.
   intros x Hrn Hr.
@@ -1521,7 +1521,7 @@ Proof.
   apply NRNRtoR_one.
 Qed.
 Lemma NRNRtoR_inv_neg :
-  Π (x : NonnegativeReals) Hrn Hr,
+  ∏ (x : NonnegativeReals) Hrn Hr,
     NRNRtoR 0%NR (invNonnegativeReals x Hrn) = Rinv (NRNRtoR 0%NR x) Hr.
 Proof.
   intros x Hrn Hr.
@@ -1539,7 +1539,7 @@ Proof.
 Qed.
 
 Lemma Rabs_pr1RtoNRNR :
-  Π x : Reals,
+  ∏ x : Reals,
     (pr1 (RtoNRNR x) <= Rabs x)%NR.
 Proof.
   intros x.
@@ -1548,7 +1548,7 @@ Proof.
   apply maxNonnegativeReals_le_l.
 Qed.
 Lemma Rabs_pr2RtoNRNR :
-  Π x : Reals,
+  ∏ x : Reals,
     (pr2 (RtoNRNR x) <= Rabs x)%NR.
 Proof.
   intros x.
@@ -1569,45 +1569,45 @@ Proof.
 Qed.
 
 Lemma isirrefl_Rlt :
-  Π x : Reals, ¬ (x < x).
+  ∏ x : Reals, ¬ (x < x).
 Proof.
   exact (pr2 (pr2 isStrongOrder_hr_lt)).
 Qed.
 Lemma istrans_Rlt :
-  Π x y z : Reals, x < y -> y < z -> x < z.
+  ∏ x y z : Reals, x < y -> y < z -> x < z.
 Proof.
   exact (pr1 isStrongOrder_hr_lt).
 Qed.
 Lemma iscotrans_Rlt :
-  Π (x y z : Reals), (x < z) -> (x < y) ∨ (y < z).
+  ∏ (x y z : Reals), (x < z) -> (x < y) ∨ (y < z).
 Proof.
   exact iscotrans_hr_lt.
 Qed.
 
 Lemma Rplus_ltcompat_l:
-  Π x y z : Reals, y < z <-> (y + x) < (z + x).
+  ∏ x y z : Reals, y < z <-> (y + x) < (z + x).
 Proof.
   exact hr_plus_ltcompat_l.
 Qed.
 Lemma Rplus_ltcompat_r:
-  Π x y z : Reals, y < z <-> (x + y) < (x + z).
+  ∏ x y z : Reals, y < z <-> (x + y) < (x + z).
 Proof.
   exact hr_plus_ltcompat_r.
 Qed.
 Lemma Rmult_ltcompat_l:
-  Π x y z : Reals,
+  ∏ x y z : Reals,
     0 < x -> y < z -> (y * x) < (z * x).
 Proof.
   exact hr_mult_ltcompat_l.
 Qed.
 Lemma Rmult_ltcompat_l':
-  Π x y z : Reals,
+  ∏ x y z : Reals,
     0 <= x -> (y * x) < (z * x) -> y < z.
 Proof.
   exact hr_mult_ltcompat_l'.
 Qed.
 Lemma Rmult_ltcompat_r:
-  Π x y z : Reals,
+  ∏ x y z : Reals,
     0 < x -> y < z -> (x * y) < (x * z).
 Proof.
   intros x y z.
@@ -1615,25 +1615,25 @@ Proof.
   now apply Rmult_ltcompat_l.
 Qed.
 Lemma Rmult_ltcompat_r':
-  Π x y z : Reals,
+  ∏ x y z : Reals,
     0 <= x -> (x * y) < (x * z) -> y < z.
 Proof.
   exact hr_mult_ltcompat_r'.
 Qed.
 
 Lemma Rarchimedean:
-  Π x : Reals, ∃ n : nat, x < nattorng n.
+  ∏ x : Reals, ∃ n : nat, x < nattorng n.
 Proof.
   exact hr_archimedean.
 Qed.
 
 Lemma notRlt_Rle :
-  Π x y : Reals, ¬ (x < y) <-> (y <= x).
+  ∏ x y : Reals, ¬ (x < y) <-> (y <= x).
 Proof.
   exact hr_notlt_le.
 Qed.
 Lemma Rlt_Rle :
-  Π x y : Reals, x < y -> x <= y.
+  ∏ x y : Reals, x < y -> x <= y.
 Proof.
   intros x y H.
   apply notRlt_Rle.
@@ -1644,12 +1644,12 @@ Proof.
   exact H0.
 Qed.
 Lemma isantisymm_Rle :
-  Π x y : Reals, x <= y -> y <= x -> x = y.
+  ∏ x y : Reals, x <= y -> y <= x -> x = y.
 Proof.
   exact isantisymm_hr_le.
 Qed.
 Lemma istrans_Rle :
-  Π x y z : Reals, x <= y -> y <= z -> x <= z.
+  ∏ x y z : Reals, x <= y -> y <= z -> x <= z.
 Proof.
   intros x y z Hxy Hyz.
   apply notRlt_Rle ; intro H.
@@ -1663,7 +1663,7 @@ Proof.
     exact Hxy.
 Qed.
 Lemma istrans_Rle_lt :
-  Π x y z : Reals, x <= y -> y < z -> x < z.
+  ∏ x y z : Reals, x <= y -> y < z -> x < z.
 Proof.
   intros x y z Hxy Hyz.
   generalize (iscotrans_Rlt _ x _ Hyz).
@@ -1676,7 +1676,7 @@ Proof.
   exact H.
 Qed.
 Lemma istrans_Rlt_le :
-  Π x y z : Reals, x < y -> y <= z -> x < z.
+  ∏ x y z : Reals, x < y -> y <= z -> x < z.
 Proof.
   intros x y z Hxy Hyz.
   generalize (iscotrans_Rlt _ z _ Hxy).
@@ -1690,42 +1690,42 @@ Proof.
 Qed.
 
 Lemma Rplus_lecompat_l:
-  Π x y z : Reals, y <= z <-> (y + x) <= (z + x).
+  ∏ x y z : Reals, y <= z <-> (y + x) <= (z + x).
 Proof.
   exact hr_plus_lecompat_l.
 Qed.
 Lemma Rplus_lecompat_r:
-  Π x y z : Reals, y <= z <-> (x + y) <= (x + z).
+  ∏ x y z : Reals, y <= z <-> (x + y) <= (x + z).
 Proof.
   exact hr_plus_lecompat_r.
 Qed.
 Lemma Rmult_lecompat_l:
-  Π x y z : Reals,
+  ∏ x y z : Reals,
     0 <= x -> y <= z -> (y * x) <= (z * x).
 Proof.
   exact hr_mult_lecompat_l.
 Qed.
 Lemma Rmult_lecompat_l':
-  Π x y z : Reals,
+  ∏ x y z : Reals,
     0 < x -> (y * x) <= (z * x) -> y <= z.
 Proof.
   exact hr_mult_lecompat_l'.
 Qed.
 Lemma Rmult_lecompat_r:
-  Π x y z : Reals,
+  ∏ x y z : Reals,
     0 <= x -> y <= z -> (x * y) <= (x * z).
 Proof.
   exact hr_mult_lecompat_r.
 Qed.
 Lemma Rmult_lecompat_r':
-  Π x y z : Reals,
+  ∏ x y z : Reals,
     0 < x -> (x * y) <= (x * z) -> y <= z.
 Proof.
   exact hr_mult_lecompat_r'.
 Qed.
 
 Lemma Rap_Rlt:
-  Π x y : Reals, x ≠ y <-> (x < y) ⨿ (y < x).
+  ∏ x y : Reals, x ≠ y <-> (x < y) ⨿ (y < x).
 Proof.
   exact hr_ap_lt.
 Qed.
@@ -1736,75 +1736,75 @@ Proof.
 Qed.
 
 Lemma isirrefl_Rap :
-  Π x : Reals, ¬ (x ≠ x).
+  ∏ x : Reals, ¬ (x ≠ x).
 Proof.
   exact isirrefl_CFap.
 Qed.
 Lemma issymm_Rap :
-  Π (x y : Reals), (x ≠ y) -> (y ≠ x).
+  ∏ (x y : Reals), (x ≠ y) -> (y ≠ x).
 Proof.
   exact issymm_CFap.
 Qed.
 Lemma iscotrans_Rap :
-  Π (x y z : Reals), (x ≠ z) -> (x ≠ y) ∨ (y ≠ z).
+  ∏ (x y z : Reals), (x ≠ z) -> (x ≠ y) ∨ (y ≠ z).
 Proof.
   exact iscotrans_CFap.
 Qed.
 Lemma istight_Rap :
-  Π (x y : Reals), ¬ (x ≠ y) -> x = y.
+  ∏ (x y : Reals), ¬ (x ≠ y) -> x = y.
 Proof.
   exact istight_CFap.
 Qed.
 
 Lemma apRplus :
-  Π (x x' y y' : Reals),
+  ∏ (x x' y y' : Reals),
     (x + y ≠ x' + y') -> (x ≠ x') ∨ (y ≠ y').
 Proof.
   exact apCFplus.
 Qed.
 Lemma Rplus_apcompat_l :
-  Π x y z : Reals,
+  ∏ x y z : Reals,
     y + x ≠ z + x <-> y ≠ z.
 Proof.
   exact CFplus_apcompat_l.
 Qed.
 Lemma Rplus_apcompat_r :
-  Π x y z : Reals,
+  ∏ x y z : Reals,
     x + y ≠ x + z <-> y ≠ z.
 Proof.
   exact CFplus_apcompat_r.
 Qed.
 
 Lemma apRmult:
-  Π (x x' y y' : Reals),
+  ∏ (x x' y y' : Reals),
   (x * y ≠ x' * y') -> (x ≠ x') ∨ (y ≠ y').
 Proof.
   apply apCFmult.
 Qed.
 Lemma Rmult_apcompat_l:
-  Π (x y z : Reals), (y * x ≠ z * x) -> (y ≠ z).
+  ∏ (x y z : Reals), (y * x ≠ z * x) -> (y ≠ z).
 Proof.
   exact CFmult_apcompat_l.
 Qed.
 Lemma Rmult_apcompat_l':
-  Π (x y z : Reals),
+  ∏ (x y z : Reals),
     (x ≠ 0) -> (y ≠ z) -> (y * x ≠ z * x).
 Proof.
   exact CFmult_apcompat_l'.
 Qed.
 Lemma Rmult_apcompat_r:
-  Π (x y z : Reals), (x * y ≠ x * z) -> (y ≠ z).
+  ∏ (x y z : Reals), (x * y ≠ x * z) -> (y ≠ z).
 Proof.
   exact CFmult_apcompat_r.
 Qed.
 Lemma Rmult_apcompat_r':
-  Π (x y z : Reals),
+  ∏ (x y z : Reals),
     (x ≠ 0) -> (y ≠ z) -> (x * y ≠ x * z).
 Proof.
   exact CFmult_apcompat_r'.
 Qed.
 Lemma RmultapRzero:
-  Π (x y : Reals),
+  ∏ (x y : Reals),
     (x * y ≠ 0) -> (x ≠ 0) ∧ (y ≠ 0).
 Proof.
   exact CFmultapCFzero.
@@ -1813,85 +1813,85 @@ Qed.
 (** ** Algrebra *)
 
 Lemma islunit_Rzero_Rplus :
-  Π x : Reals, 0 + x = x.
+  ∏ x : Reals, 0 + x = x.
 Proof.
   exact islunit_CFzero_CFplus.
 Qed.
 Lemma isrunit_Rzero_Rplus :
-  Π x : Reals, x + 0 = x.
+  ∏ x : Reals, x + 0 = x.
 Proof.
   exact isrunit_CFzero_CFplus.
 Qed.
 Lemma isassoc_Rplus :
-  Π x y z : Reals, x + y + z = x + (y + z).
+  ∏ x y z : Reals, x + y + z = x + (y + z).
 Proof.
   exact isassoc_CFplus.
 Qed.
 Lemma islinv_Ropp :
-  Π x : Reals, - x + x = 0.
+  ∏ x : Reals, - x + x = 0.
 Proof.
   exact islinv_CFopp.
 Qed.
 Lemma isrinv_Ropp :
-  Π x : Reals, x + - x = 0.
+  ∏ x : Reals, x + - x = 0.
 Proof.
   exact isrinv_CFopp.
 Qed.
 
 Lemma iscomm_Rplus :
-  Π x y : Reals, x + y = y + x.
+  ∏ x y : Reals, x + y = y + x.
 Proof.
   exact iscomm_CFplus.
 Qed.
 Lemma islunit_Rone_Rmult :
-  Π x : Reals, 1 * x = x.
+  ∏ x : Reals, 1 * x = x.
 Proof.
   exact islunit_CFone_CFmult.
 Qed.
 Lemma isrunit_Rone_Rmult :
-  Π x : Reals, x * 1 = x.
+  ∏ x : Reals, x * 1 = x.
 Proof.
   exact isrunit_CFone_CFmult.
 Qed.
 Lemma isassoc_Rmult :
-  Π x y z : Reals, x * y * z = x * (y * z).
+  ∏ x y z : Reals, x * y * z = x * (y * z).
 Proof.
   exact isassoc_CFmult.
 Qed.
 Lemma iscomm_Rmult :
-  Π x y : Reals, x * y = y * x.
+  ∏ x y : Reals, x * y = y * x.
 Proof.
   exact iscomm_CFmult.
 Qed.
 Lemma islinv_Rinv :
-  Π (x : Reals) (Hx0 : x ≠ 0),
+  ∏ (x : Reals) (Hx0 : x ≠ 0),
     (Rinv x Hx0) * x = 1.
 Proof.
   exact islinv_CFinv.
 Qed.
 Lemma isrinv_Rinv :
-  Π (x : Reals) (Hx0 : x ≠ 0),
+  ∏ (x : Reals) (Hx0 : x ≠ 0),
     x * (Rinv x Hx0) = 1.
 Proof.
   exact isrinv_CFinv.
 Qed.
 Lemma islabsorb_Rzero_Rmult :
-  Π x : Reals, 0 * x = 0.
+  ∏ x : Reals, 0 * x = 0.
 Proof.
   exact islabsorb_CFzero_CFmult.
 Qed.
 Lemma israbsorb_Rzero_Rmult :
-  Π x : Reals, x * 0 = 0.
+  ∏ x : Reals, x * 0 = 0.
 Proof.
   exact israbsorb_CFzero_CFmult.
 Qed.
 Lemma isldistr_Rplus_Rmult :
-  Π x y z : Reals, z * (x + y) = z * x + z * y.
+  ∏ x y z : Reals, z * (x + y) = z * x + z * y.
 Proof.
   exact isldistr_CFplus_CFmult.
 Qed.
 Lemma isrdistr_Rplus_Rmult :
-  Π x y z : Reals, (x + y) * z = x * z + y * z.
+  ∏ x y z : Reals, (x + y) * z = x * z + y * z.
 Proof.
   exact isrdistr_CFplus_CFmult.
 Qed.
@@ -1899,24 +1899,24 @@ Qed.
 (** ** Rabs *)
 
 Lemma istriangle_Rabs :
-  Π x y : Reals, (Rabs (x + y)%R <= Rabs x + Rabs y)%NR.
+  ∏ x y : Reals, (Rabs (x + y)%R <= Rabs x + Rabs y)%NR.
 Proof.
   exact istriangle_hr_abs.
 Qed.
 Lemma istriangle_Rabs' :
-  Π x y : Reals, (Rabs x - Rabs y <= Rabs (x + y)%R)%NR.
+  ∏ x y : Reals, (Rabs x - Rabs y <= Rabs (x + y)%R)%NR.
 Proof.
   exact istriangle_hr_abs'.
 Qed.
 
 Lemma Rabs_Rmult :
-  Π x y : Reals, (Rabs (x * y)%R = Rabs x * Rabs y)%NR.
+  ∏ x y : Reals, (Rabs (x * y)%R = Rabs x * Rabs y)%NR.
 Proof.
   exact hr_abs_mult.
 Qed.
 
 Lemma Rabs_Ropp :
-  Π x : Reals, (Rabs (- x)%R = Rabs x).
+  ∏ x : Reals, (Rabs (- x)%R = Rabs x).
 Proof.
   intros x.
   rewrite <- (NRNRtoR_RtoNRNR x).

--- a/UniMath/RealNumbers/Sets.v
+++ b/UniMath/RealNumbers/Sets.v
@@ -24,9 +24,9 @@ Definition makeSubset {X : hSet} {Hsub : hsubtype X} (x : X) (Hx : Hsub x) : sub
 Definition unop (X : UU) := X → X.
 
 Definition islinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtype X) (inv : subset exinv -> X) :=
-  Π (x : X) (Hx : exinv x), op (inv (x ,, Hx)) x = x1.
+  ∏ (x : X) (Hx : exinv x), op (inv (x ,, Hx)) x = x1.
 Definition isrinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtype X) (inv : subset exinv -> X) :=
-  Π (x : X) (Hx : exinv x), op x (inv (x ,, Hx)) = x1.
+  ∏ (x : X) (Hx : exinv x), op x (inv (x ,, Hx)) = x1.
 Definition isinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtype X) (inv : subset exinv -> X)  :=
   islinv' x1 op exinv inv × isrinv' x1 op exinv inv.
 
@@ -47,7 +47,7 @@ End po_pty.
 (** ** Strong Order *)
 
 Definition isStrongOrder {X : UU} (R : hrel X) := istrans R × iscotrans R × isirrefl R.
-Definition StrongOrder (X : UU) := Σ R : hrel X, isStrongOrder R.
+Definition StrongOrder (X : UU) := ∑ R : hrel X, isStrongOrder R.
 Definition pairStrongOrder {X : UU} (R : hrel X) (is : isStrongOrder R) : StrongOrder X :=
   tpair (fun R : hrel X => isStrongOrder R ) R is.
 Definition pr1StrongOrder {X : UU} : StrongOrder X → hrel X := pr1.
@@ -107,7 +107,7 @@ Qed.
 Definition po_reverse {X : UU} (l : po X) :=
   popair (hrel_reverse l) (ispreorder_reverse l (pr2 l)).
 Lemma po_reverse_correct {X : UU} (l : po X) :
-  Π x y : X, po_reverse l x y = l y x.
+  ∏ x y : X, po_reverse l x y = l y x.
 Proof.
   intros X l x y.
   now apply paths_refl.
@@ -131,7 +131,7 @@ Qed.
 Definition eqrel_reverse {X : UU} (l : eqrel X) :=
   eqrelpair (hrel_reverse l) (iseqrel_reverse l (pr2 l)).
 Lemma eqrel_reverse_correct {X : UU} (l : eqrel X) :
-  Π x y : X, eqrel_reverse l x y = l y x.
+  ∏ x y : X, eqrel_reverse l x y = l y x.
 Proof.
   intros X l x y.
   now apply paths_refl.
@@ -162,7 +162,7 @@ Qed.
 Definition StrongOrder_reverse {X : UU} (l : StrongOrder X) :=
   pairStrongOrder (hrel_reverse l) (isStrongOrder_reverse l (pr2 l)).
 Lemma StrongOrder_reverse_correct {X : UU} (l : StrongOrder X) :
-  Π x y : X, StrongOrder_reverse l x y = l y x.
+  ∏ x y : X, StrongOrder_reverse l x y = l y x.
 Proof.
   intros X l x y.
   now apply paths_refl.
@@ -194,16 +194,16 @@ Qed.
 
 Definition isEffectiveOrder {X : UU} (le lt : hrel X) :=
   dirprod ((ispreorder le) × (isStrongOrder lt))
-          ((Π x y : X, (¬ lt x y) <-> (le y x))
-          × (Π x y z : X, lt x y -> le y z -> lt x z)
-          × (Π x y z : X, le x y -> lt y z -> lt x z)).
+          ((∏ x y : X, (¬ lt x y) <-> (le y x))
+          × (∏ x y z : X, lt x y -> le y z -> lt x z)
+          × (∏ x y z : X, le x y -> lt y z -> lt x z)).
 Definition EffectiveOrder (X : UU) :=
-  Σ le lt : hrel X, isEffectiveOrder le lt.
+  ∑ le lt : hrel X, isEffectiveOrder le lt.
 Definition pairEffectiveOrder {X : UU} (le lt : hrel X) (is : isEffectiveOrder le lt) : EffectiveOrder X :=
   (le,,lt,,is).
 
 Definition EffectivelyOrderedSet :=
-  Σ X : hSet, EffectiveOrder X.
+  ∑ X : hSet, EffectiveOrder X.
 Definition pairEffectivelyOrderedSet {X : hSet} (is : EffectiveOrder X) : EffectivelyOrderedSet
   := tpair _ X is.
 Definition pr1EffectivelyOrderedSet : EffectivelyOrderedSet → hSet := pr1.
@@ -250,44 +250,44 @@ Context {X : EffectivelyOrderedSet}.
 Open Scope eo_scope.
 
 Lemma not_EOlt_le :
-  Π x y : X, (¬ (x < y)) <-> (y <= x).
+  ∏ x y : X, (¬ (x < y)) <-> (y <= x).
 Proof.
   exact (pr1 (pr2 (pr2 (pr2 (pr2 X))))).
 Qed.
 Lemma EOge_le:
-  Π x y : X, (x >= y) <-> (y <= x).
+  ∏ x y : X, (x >= y) <-> (y <= x).
 Proof.
   now split.
 Qed.
 Lemma EOgt_lt:
-  Π x y : X, (x > y) <-> (y < x).
+  ∏ x y : X, (x > y) <-> (y < x).
 Proof.
   now split.
 Qed.
 
 Definition isrefl_EOle:
-  Π x : X, x <= x
+  ∏ x : X, x <= x
   := isrefl_po EOle.
 Definition istrans_EOle:
-  Π x y z : X, x <= y -> y <= z -> x <= z
+  ∏ x y z : X, x <= y -> y <= z -> x <= z
   := istrans_po EOle.
 
 Definition isirrefl_EOgt:
-  Π x : X, ¬ (x > x)
+  ∏ x : X, ¬ (x > x)
   := isirrefl_StrongOrder EOgt.
 Definition istrans_EOgt:
-  Π x y z : X, x > y -> y > z -> x > z
+  ∏ x y z : X, x > y -> y > z -> x > z
   := istrans_StrongOrder EOgt.
 
 Definition isirrefl_EOlt:
-  Π x : X, ¬ (x < x)
+  ∏ x : X, ¬ (x < x)
   := isirrefl_StrongOrder EOlt.
 Definition istrans_EOlt:
-  Π x y z : X, x < y -> y < z -> x < z
+  ∏ x y z : X, x < y -> y < z -> x < z
   := istrans_StrongOrder EOlt.
 
 Lemma EOlt_le :
-  Π x y : X, x < y -> x <= y.
+  ∏ x y : X, x < y -> x <= y.
 Proof.
   intros x y Hxy.
   apply not_EOlt_le.
@@ -299,25 +299,25 @@ Proof.
 Qed.
 
 Lemma istrans_EOlt_le:
-  Π x y z : X, x < y -> y <= z -> x < z.
+  ∏ x y z : X, x < y -> y <= z -> x < z.
 Proof.
   exact (pr1 (pr2 (pr2 (pr2 (pr2 (pr2 X)))))).
 Qed.
 Lemma istrans_EOle_lt:
-  Π x y z : X, x <= y -> y < z -> x < z.
+  ∏ x y z : X, x <= y -> y < z -> x < z.
 Proof.
   exact (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 X)))))).
 Qed.
 
 Lemma EOlt_noteq :
-  Π x y : X, x < y -> x != y.
+  ∏ x y : X, x < y -> x != y.
 Proof.
   intros x y Hgt Heq.
   rewrite Heq in Hgt.
   now apply isirrefl_EOgt in Hgt.
 Qed.
 Lemma EOgt_noteq :
-  Π x y : X, x > y -> x != y.
+  ∏ x y : X, x > y -> x != y.
 Proof.
   intros x y Hgt Heq.
   rewrite Heq in Hgt.
@@ -334,11 +334,11 @@ Definition isConstructiveTotalEffectiveOrder {X : UU} (ap le lt : hrel X) :=
   istightap ap
   × isEffectiveOrder le lt
   × (isantisymm le)
-  × (Π x y : X, ap x y <-> (lt x y) ⨿ (lt y x)).
+  × (∏ x y : X, ap x y <-> (lt x y) ⨿ (lt y x)).
 Definition ConstructiveTotalEffectiveOrder X :=
-  Σ ap lt le : hrel X, isConstructiveTotalEffectiveOrder ap lt le.
+  ∑ ap lt le : hrel X, isConstructiveTotalEffectiveOrder ap lt le.
 Definition ConstructiveTotalEffectivellyOrderedSet :=
-  Σ X : hSet, ConstructiveTotalEffectiveOrder X.
+  ∑ X : hSet, ConstructiveTotalEffectiveOrder X.
 
 (** ** Complete Ordered Space *)
 
@@ -348,14 +348,14 @@ Context {X : PreorderedSet}.
 Local Notation "x <= y" := (pr1 (pr2 X) x y).
 
 Definition isUpperBound (E : hsubtype X) (ub : X) : UU :=
-  Π x : X, E x -> x <= ub.
+  ∏ x : X, E x -> x <= ub.
 Definition isSmallerThanUpperBounds (E : hsubtype X) (lub : X) : UU :=
-  Π ub : X, isUpperBound E ub -> lub <= ub.
+  ∏ ub : X, isUpperBound E ub -> lub <= ub.
 
 Definition isLeastUpperBound (E : hsubtype X) (lub : X) : UU :=
   dirprod (isUpperBound E lub) (isSmallerThanUpperBounds E lub).
 Definition LeastUpperBound (E : hsubtype X) : UU :=
-  Σ lub : X, isLeastUpperBound E lub.
+  ∑ lub : X, isLeastUpperBound E lub.
 Definition pairLeastUpperBound (E : hsubtype X) (lub : X)
            (is : isLeastUpperBound E lub) : LeastUpperBound E :=
   tpair (isLeastUpperBound E) lub is.
@@ -393,14 +393,14 @@ Context {X : PreorderedSet}.
 Local Notation "x >= y" := (pr1 (pr2 X) y x).
 
 Definition isLowerBound (E : hsubtype X) (ub : X) : UU :=
-  Π x : X, E x -> x >= ub.
+  ∏ x : X, E x -> x >= ub.
 Definition isBiggerThanLowerBounds (E : hsubtype X) (lub : X) : UU :=
-  Π ub : X, isLowerBound E ub -> lub >= ub.
+  ∏ ub : X, isLowerBound E ub -> lub >= ub.
 
 Definition isGreatestLowerBound (E : hsubtype X) (glb : X) : UU :=
   dirprod (isLowerBound E glb) (isBiggerThanLowerBounds E glb).
 Definition GreatestLowerBound (E : hsubtype X) : UU :=
-  Σ glb : X, isGreatestLowerBound E glb.
+  ∑ glb : X, isGreatestLowerBound E glb.
 Definition pairGreatestLowerBound (E : hsubtype X) (glb : X)
            (is : isGreatestLowerBound E glb) : GreatestLowerBound E :=
   tpair (isGreatestLowerBound E) glb is.
@@ -433,9 +433,9 @@ Qed.
 End GreatestLowerBound.
 
 Definition isCompleteSpace (X : PreorderedSet) :=
-  Π E : hsubtype X,
+  ∏ E : hsubtype X,
     hexists (isUpperBound E) -> hexists E -> LeastUpperBound E.
 Definition CompleteSpace  :=
-  Σ X : PreorderedSet, isCompleteSpace X.
+  ∑ X : PreorderedSet, isCompleteSpace X.
 Definition pr1CompleteSpace : CompleteSpace → UU := pr1.
 Coercion pr1CompleteSpace : CompleteSpace >-> UU.

--- a/UniMath/SubstitutionSystems/BinProductOfSignatures.v
+++ b/UniMath/SubstitutionSystems/BinProductOfSignatures.v
@@ -63,7 +63,7 @@ Definition H : functor [C, C, hsC] [C, C, hsC] :=
   BinProduct_of_functors _ _ CCC H1 H2.
 
 Local Definition θ_ob_fun (X : [C, C, hsC]) (Z : precategory_Ptd C hsC) :
-   Π c : C,
+   ∏ c : C,
     (functor_composite_data (pr1 Z)
      (BinProduct_of_functors_data C C PC (H1 X) (H2 X))) c
    --> (BinProduct_of_functors_data C C PC (H1 (functor_composite (pr1 Z) X))
@@ -86,7 +86,7 @@ Proof.
   * apply (nat_trans_ax (θ2 (X ⊗ Z))).
 Qed.
 
-Definition θ_ob : Π XZ, θ_source H XZ --> θ_target H XZ.
+Definition θ_ob : ∏ XZ, θ_source H XZ --> θ_target H XZ.
 Proof.
   intro XZ.
   exists (θ_ob_fun (pr1 XZ) (pr2 XZ)).
@@ -196,7 +196,7 @@ Defined.
 
 Lemma is_omega_cocont_BinProduct_of_Signatures (S1 S2 : Signature C hsC)
   (h1 : is_omega_cocont S1) (h2 : is_omega_cocont S2)
-  (hE : Π x, is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C PC hsC) x)) :
+  (hE : ∏ x, is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C PC hsC) x)) :
   is_omega_cocont (BinProduct_of_Signatures S1 S2).
 Proof.
 destruct S1 as [F1 [F2 [F3 F4]]]; simpl in *.

--- a/UniMath/SubstitutionSystems/BinSumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/BinSumOfSignatures.v
@@ -72,7 +72,7 @@ Definition H : functor [C, C, hs] [C, C, hs] := BinCoproduct_of_functors _ _ CCC
 (* Definition H : functor [C, C, hs] [C, C, hs] := BinCoproduct_of_functors_alt CCC H1 H2. *)
 
 Local Definition θ_ob_fun (X : [C, C, hs]) (Z : precategory_Ptd C hs) :
-   Π c : C,
+   ∏ c : C,
     (functor_composite_data (pr1 Z)
      (BinCoproduct_of_functors_data C C CC (H1 X) (H2 X))) c
    --> (BinCoproduct_of_functors_data C C CC (H1 (functor_composite (pr1 Z) X))
@@ -95,7 +95,7 @@ Proof.
   * apply (nat_trans_ax (θ2 (X ⊗ Z))).
 Qed.
 
-Definition θ_ob : Π XF, θ_source H XF --> θ_target H XF.
+Definition θ_ob : ∏ XF, θ_source H XF --> θ_target H XF.
 Proof.
   intros [X Z].
   exists (θ_ob_fun X Z).

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -50,7 +50,7 @@ Local Notation "'chain'" := (diagram nat_graph).
 Section BindingSig.
 
 (** A binding signature is a collection of lists of natural numbers indexed by types I *)
-Definition BindingSig : UU := Σ (I : UU) (h : isdeceq I), I → list nat.
+Definition BindingSig : UU := ∑ (I : UU) (h : isdeceq I), I → list nat.
 
 Definition BindingSigIndex : BindingSig -> UU := pr1.
 Definition BindingSigIsdeceq (s : BindingSig) : isdeceq (BindingSigIndex s) :=
@@ -138,7 +138,7 @@ Let constprod_functor1 := constprod_functor1 (BPC2 BPC).
 (** The H assumption follows directly if [C,C] has exponentials *)
 Lemma is_omega_cocont_Arity_to_Signature
   (TC : Terminal C) (CLC : Colims_of_shape nat_graph C)
-  (H : Π (F : [C,C]), is_omega_cocont (constprod_functor1 F))
+  (H : ∏ (F : [C,C]), is_omega_cocont (constprod_functor1 F))
   (xs : list nat) :
   is_omega_cocont (Arity_to_Signature TC xs).
 Proof.
@@ -166,7 +166,7 @@ Defined.
 
 Lemma is_omega_cocont_BindingSigToSignature
   (TC : Terminal C) (CLC : Colims_of_shape nat_graph C)
-  (HF : Π (F : [C,C]), is_omega_cocont (constprod_functor1 F))
+  (HF : ∏ (F : [C,C]), is_omega_cocont (constprod_functor1 F))
   (sig : BindingSig)
   (CC : Coproducts (BindingSigIndex sig) C) (PC : Products (BindingSigIndex sig) C) :
   is_omega_cocont (BindingSigToSignature TC sig CC).
@@ -229,7 +229,7 @@ Defined.
 (** ** Function from binding signatures to monads *)
 Definition BindingSigToMonad
   (TC : Terminal C) (IC : Initial C) (CLC : Colims_of_shape nat_graph C)
-  (HF : Π (F : [C,C]), is_omega_cocont (constprod_functor1 F))
+  (HF : ∏ (F : [C,C]), is_omega_cocont (constprod_functor1 F))
   (sig : BindingSig)
   (PC : Products (BindingSigIndex sig) C)
   (CC : Coproducts (BindingSigIndex sig) C) :

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -58,30 +58,30 @@ Definition BindingSig : UU :=
   @UniMath.SubstitutionSystems.BindingSigToMonad.BindingSig.
 
 (** Definition 4: Signatures with strength *)
-Definition Signature : Π C : precategory, has_homsets C → UU :=
+Definition Signature : ∏ C : precategory, has_homsets C → UU :=
   @UniMath.SubstitutionSystems.Signatures.Signature.
 
 (** Definition 5: Morphism of signatures with strength *)
 Definition SignatureMor :
-  Π C : Precategory, Signature C (homset_property C) → Signature C (homset_property C) → UU :=
+  ∏ C : Precategory, Signature C (homset_property C) → Signature C (homset_property C) → UU :=
   @UniMath.SubstitutionSystems.SignatureCategory.SignatureMor.
 
 (** Definition 6: Coproduct of signatures with strength *)
 Definition Sum_of_Signatures :
-  Π (I : UU) (C : precategory) (hsC : has_homsets C), Coproducts I C
+  ∏ (I : UU) (C : precategory) (hsC : has_homsets C), Coproducts I C
   → (I → Signature C hsC) → Signature C hsC :=
     @UniMath.SubstitutionSystems.SumOfSignatures.Sum_of_Signatures.
 
 (** Definition 7: Binary product of signatures with strength *)
 Definition BinProduct_of_Signatures :
-  Π (C : precategory) (hsC : has_homsets C), BinProducts C
+  ∏ (C : precategory) (hsC : has_homsets C), BinProducts C
   → Signature C hsC → Signature C hsC → Signature C hsC :=
     @UniMath.SubstitutionSystems.BinProductOfSignatures.BinProduct_of_Signatures.
 
 (** Problem 8: Signatures with strength from binding signatures *)
 Definition BindingSigToSignature :
-  Π {C : precategory} (hsC : has_homsets C), BinProducts C → BinCoproducts C → Terminal C
-  → Π sig : BindingSig, Coproducts (BindingSigIndex sig) C → Signature C hsC :=
+  ∏ {C : precategory} (hsC : has_homsets C), BinProducts C → BinCoproducts C → Terminal C
+  → ∏ sig : BindingSig, Coproducts (BindingSigIndex sig) C → Signature C hsC :=
     @UniMath.SubstitutionSystems.BindingSigToMonad.BindingSigToSignature.
 
 (** Definition 10 and Lemma 11 and 12: see UniMath/SubstitutionSystems/SignatureExamples.v *)
@@ -94,11 +94,11 @@ Definition diagram : graph → precategory → UU :=
   @UniMath.CategoryTheory.limits.graphs.colimits.diagram.
 
 (** Definition 18: Cocone *)
-Definition cocone : Π {C : precategory} {g : graph}, diagram g C → C → UU :=
+Definition cocone : ∏ {C : precategory} {g : graph}, diagram g C → C → UU :=
   @UniMath.CategoryTheory.limits.graphs.colimits.cocone.
 
 (** Definition 19: Colimiting cocone *)
-Definition isColimCocone : Π {C : precategory} {g : graph} (d : diagram g C)
+Definition isColimCocone : ∏ {C : precategory} {g : graph} (d : diagram g C)
   (c0 : C), cocone d c0 → UU :=
     @UniMath.CategoryTheory.limits.graphs.colimits.isColimCocone.
 
@@ -111,25 +111,25 @@ Definition Colims : precategory → UU :=
   @UniMath.CategoryTheory.limits.graphs.colimits.Colims.
 
 (** Remark 20: Uniqueness of colimits *)
-Lemma isaprop_Colims : Π C : category, isaprop (Colims C).
+Lemma isaprop_Colims : ∏ C : category, isaprop (Colims C).
 Proof.
 exact @UniMath.CategoryTheory.limits.graphs.colimits.isaprop_Colims.
 Defined.
 
 (** Definition 21: Preservation of colimits *)
-Definition preserves_colimit : Π {C D : precategory}, functor C D
-  → Π {g : graph} (d : diagram g C) (L : C), cocone d L → UU :=
+Definition preserves_colimit : ∏ {C D : precategory}, functor C D
+  → ∏ {g : graph} (d : diagram g C) (L : C), cocone d L → UU :=
     @UniMath.CategoryTheory.limits.graphs.colimits.preserves_colimit.
 
-Definition is_cocont : Π {C D : precategory}, functor C D → UU :=
+Definition is_cocont : ∏ {C D : precategory}, functor C D → UU :=
   @UniMath.CategoryTheory.CocontFunctors.is_cocont.
 
-Definition is_omega_cocont : Π {C D : precategory}, functor C D → UU :=
+Definition is_omega_cocont : ∏ {C D : precategory}, functor C D → UU :=
   @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont.
 
 (** Lemma 22: Invariance of cocontinuity under isomorphism *)
 Lemma preserves_colimit_iso :
-  Π (C D : precategory) (hsD : has_homsets D) (F G : functor C D) (α : @iso [C,D,hsD] F G)
+  ∏ (C D : precategory) (hsD : has_homsets D) (F G : functor C D) (α : @iso [C,D,hsD] F G)
     (g : graph) (d : diagram g C) (L : C) (cc : cocone d L),
   preserves_colimit F d L cc → preserves_colimit G d L cc.
 Proof.
@@ -138,34 +138,34 @@ Defined.
 
 (** Problem 23: Colimits in functor categories *)
 Definition ColimsFunctorCategory_of_shape :
-  Π (g : graph) (A C : precategory) (hsC : has_homsets C),
+  ∏ (g : graph) (A C : precategory) (hsC : has_homsets C),
   Colims_of_shape g C → Colims_of_shape g [A,C,hsC] :=
     @UniMath.CategoryTheory.limits.graphs.colimits.ColimsFunctorCategory_of_shape.
 
 (** Problem 25: Initial algebras of ω-cocontinuous functors *)
 Definition colimAlgInitial :
-  Π (C : precategory) (hsC : has_homsets C) (InitC : Initial C)
+  ∏ (C : precategory) (hsC : has_homsets C) (InitC : Initial C)
     (F : functor C C), is_omega_cocont F → ColimCocone (initChain InitC F) →
   Initial (FunctorAlg F hsC) :=
     @UniMath.CategoryTheory.CocontFunctors.colimAlgInitial.
 
 (** Lemma 26: Lambek's lemma *)
 Lemma initialAlg_is_iso :
-  Π (C : precategory) (hsC : has_homsets C) (F : functor C C)
+  ∏ (C : precategory) (hsC : has_homsets C) (F : functor C C)
     (Aa : algebra_ob F), isInitial (FunctorAlg F hsC) Aa → is_iso (alg_map F Aa).
 Proof.
 exact @UniMath.CategoryTheory.FunctorAlgebras.initialAlg_is_iso.
 Defined.
 
 (** Problem 28: Colimits in Set *)
-Lemma ColimsHSET_of_shape : Π (g : graph), Colims_of_shape g HSET.
+Lemma ColimsHSET_of_shape : ∏ (g : graph), Colims_of_shape g HSET.
 Proof.
 exact @UniMath.CategoryTheory.category_hset_structures.ColimsHSET_of_shape.
 Defined.
 
 (** Lemma 32: Left adjoints preserve colimits *)
 Lemma left_adjoint_cocont :
-  Π (C D : precategory) (F : functor C D), is_left_adjoint F
+  ∏ (C D : precategory) (F : functor C D), is_left_adjoint F
   → has_homsets C → has_homsets D → is_cocont F.
 Proof.
 exact @UniMath.CategoryTheory.CocontFunctors.left_adjoint_cocont.
@@ -173,8 +173,8 @@ Defined.
 
 (** Lemma 33: Examples of preservation of colimits *)
 (** (i): Identity functor *)
-Lemma preserves_colimit_identity : Π C : precategory, has_homsets C
-  → Π (g : colimits.graph) (d : colimits.diagram g C)
+Lemma preserves_colimit_identity : ∏ C : precategory, has_homsets C
+  → ∏ (g : colimits.graph) (d : colimits.diagram g C)
     (L : C) (cc : colimits.cocone d L),
   preserves_colimit (functor_identity C) d L cc.
 Proof.
@@ -182,20 +182,20 @@ exact @UniMath.CategoryTheory.CocontFunctors.preserves_colimit_identity.
 Defined.
 
 (** (ii): Constant functor *)
-Lemma is_omega_cocont_constant_functor : Π C D : precategory, has_homsets D
-  → Π x : D, CocontFunctors.is_omega_cocont (constant_functor C D x).
+Lemma is_omega_cocont_constant_functor : ∏ C D : precategory, has_homsets D
+  → ∏ x : D, CocontFunctors.is_omega_cocont (constant_functor C D x).
 Proof.
 exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_constant_functor.
 Defined.
 
 (** (iii): Diagonal functor *)
-Lemma is_cocont_delta_functor : Π (I : UU) (C : precategory),
+Lemma is_cocont_delta_functor : ∏ (I : UU) (C : precategory),
   Products I C → has_homsets C → is_cocont (delta_functor I C).
 Proof.
 exact @UniMath.CategoryTheory.CocontFunctors.is_cocont_delta_functor.
 Defined.
 
-Lemma is_omega_cocont_delta_functor : Π (I : UU) (C : precategory),
+Lemma is_omega_cocont_delta_functor : ∏ (I : UU) (C : precategory),
   Products I C → has_homsets C → is_omega_cocont (delta_functor I C).
 Proof.
 exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_delta_functor.
@@ -203,14 +203,14 @@ Defined.
 
 (** (iv): Coproduct functor *)
 Lemma is_cocont_coproduct_functor :
-  Π (I : UU) (C : precategory) (PC : Coproducts I C),
+  ∏ (I : UU) (C : precategory) (PC : Coproducts I C),
   has_homsets C → is_cocont (coproduct_functor I PC).
 Proof.
 exact @UniMath.CategoryTheory.CocontFunctors.is_cocont_coproduct_functor.
 Defined.
 
 Lemma is_omega_cocont_coproduct_functor :
-  Π (I : UU) (C : precategory) (PC : Coproducts I C),
+  ∏ (I : UU) (C : precategory) (PC : Coproducts I C),
   has_homsets C → is_omega_cocont (coproduct_functor I PC).
 Proof.
 exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_coproduct_functor.
@@ -219,8 +219,8 @@ Defined.
 (** Lemma 34: Examples of preservation of cocontinuity *)
 (** (i): Composition of functors *)
 Lemma preserves_colimit_functor_composite :
-  Π C D E : precategory, has_homsets E
-  → Π (F : functor C D) (G : functor D E) (g : graph)
+  ∏ C D E : precategory, has_homsets E
+  → ∏ (F : functor C D) (G : functor D E) (g : graph)
       (d : diagram g C) (L : C) (cc : cocone d L),
       preserves_colimit F d L cc
   → preserves_colimit G (mapdiagram F d) (F L) (mapcocone F d cc)
@@ -230,16 +230,16 @@ exact @UniMath.CategoryTheory.CocontFunctors.preserves_colimit_functor_composite
 Defined.
 
 Lemma is_cocont_functor_composite :
-  Π C D E : precategory, has_homsets E
-  → Π (F : functor C D) (G : functor D E), is_cocont F → is_cocont G
+  ∏ C D E : precategory, has_homsets E
+  → ∏ (F : functor C D) (G : functor D E), is_cocont F → is_cocont G
   → is_cocont (functor_composite F G).
 Proof.
 exact @UniMath.CategoryTheory.CocontFunctors.is_cocont_functor_composite.
 Defined.
 
 Lemma is_omega_cocont_functor_composite :
-  Π C D E : precategory, has_homsets E
-  → Π (F : functor C D) (G : functor D E), is_omega_cocont F → is_omega_cocont G
+  ∏ C D E : precategory, has_homsets E
+  → ∏ (F : functor C D) (G : functor D E), is_omega_cocont F → is_omega_cocont G
   → is_omega_cocont (functor_composite F G).
 Proof.
 exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_functor_composite.
@@ -247,16 +247,16 @@ Defined.
 
 (** (ii): Families of functors *)
 Lemma is_cocont_family_functor :
-  Π (I : UU) (A B : precategory), has_homsets A → has_homsets B → isdeceq I
-  → Π F : I → functor A B, (Π i : I, is_cocont (F i))
+  ∏ (I : UU) (A B : precategory), has_homsets A → has_homsets B → isdeceq I
+  → ∏ F : I → functor A B, (∏ i : I, is_cocont (F i))
   → is_cocont (family_functor I F).
 Proof.
 exact @UniMath.CategoryTheory.CocontFunctors.is_cocont_family_functor.
 Defined.
 
 Lemma is_omega_cocont_family_functor :
-  Π (I : UU) (A B : precategory), has_homsets A → has_homsets B → isdeceq I
-  → Π F : I → functor A B, (Π i : I, is_omega_cocont (F i))
+  ∏ (I : UU) (A B : precategory), has_homsets A → has_homsets B → isdeceq I
+  → ∏ F : I → functor A B, (∏ i : I, is_omega_cocont (F i))
   → is_omega_cocont (family_functor I F).
 Proof.
 exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_family_functor.
@@ -268,37 +268,37 @@ Definition has_exponentials_HSET : has_exponentials BinProductsHSET :=
 
 (** Lemma 37: Left and right product functors preserves colimits *)
 Lemma is_cocont_constprod_functor1 :
-  Π (C : precategory) (PC : BinProducts C), has_homsets C → has_exponentials PC
-  → Π x : C, is_cocont (constprod_functor1 PC x).
+  ∏ (C : precategory) (PC : BinProducts C), has_homsets C → has_exponentials PC
+  → ∏ x : C, is_cocont (constprod_functor1 PC x).
 Proof.
 exact @UniMath.CategoryTheory.CocontFunctors.is_cocont_constprod_functor1.
 Defined.
 
 Lemma is_omega_cocont_constprod_functor1 :
-  Π (C : precategory) (PC : BinProducts C), has_homsets C → has_exponentials PC
-  → Π x : C, is_omega_cocont (constprod_functor1 PC x).
+  ∏ (C : precategory) (PC : BinProducts C), has_homsets C → has_exponentials PC
+  → ∏ x : C, is_omega_cocont (constprod_functor1 PC x).
 Proof.
 exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_constprod_functor1.
 Defined.
 
 Lemma is_cocont_constprod_functor2 :
-  Π (C : precategory) (PC : BinProducts C), has_homsets C → has_exponentials PC
-  → Π x : C, is_cocont (constprod_functor2 PC x).
+  ∏ (C : precategory) (PC : BinProducts C), has_homsets C → has_exponentials PC
+  → ∏ x : C, is_cocont (constprod_functor2 PC x).
 Proof.
 exact @UniMath.CategoryTheory.CocontFunctors.is_cocont_constprod_functor2.
 Defined.
 
 Lemma is_omega_cocont_constprod_functor2 :
-  Π (C : precategory) (PC : BinProducts C), has_homsets C → has_exponentials PC
-  → Π x : C, is_omega_cocont (constprod_functor2 PC x).
+  ∏ (C : precategory) (PC : BinProducts C), has_homsets C → has_exponentials PC
+  → ∏ x : C, is_omega_cocont (constprod_functor2 PC x).
 Proof.
 exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_constprod_functor2.
 Defined.
 
 (** Theorem 38: Binary product functor is ω-cocontinuous *)
 Lemma is_omega_cocont_binproduct_functor :
-  Π (C : precategory) (PC : BinProducts C), has_homsets C
-  → (Π x : C, is_omega_cocont (constprod_functor1 PC x))
+  ∏ (C : precategory) (PC : BinProducts C), has_homsets C
+  → (∏ x : C, is_omega_cocont (constprod_functor1 PC x))
   → is_omega_cocont (binproduct_functor PC).
 Proof.
 exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_binproduct_functor.
@@ -309,16 +309,16 @@ Defined.
 
 (** Theorem 42: Precomposition functor preserves colimits *)
 Lemma preserves_colimit_pre_composition_functor :
-  Π (A B C : precategory) (F : functor A B) (hsB : has_homsets B) (hsC : has_homsets C)
+  ∏ (A B C : precategory) (F : functor A B) (hsB : has_homsets B) (hsC : has_homsets C)
     (g : graph) (d : diagram g [B, C, hsC]) (G : [B, C, hsC]) (ccG : cocone d G),
-    (Π b : B, ColimCocone (diagram_pointwise hsC d b))
+    (∏ b : B, ColimCocone (diagram_pointwise hsC d b))
   → preserves_colimit (pre_composition_functor A B C hsB hsC F) d G ccG.
 Proof.
 exact @UniMath.CategoryTheory.CocontFunctors.preserves_colimit_pre_composition_functor.
 Defined.
 
 Lemma is_omega_cocont_pre_composition_functor :
-  Π (A B C : precategory) (F : functor A B) (hsB : has_homsets B) (hsC : has_homsets C),
+  ∏ (A B C : precategory) (F : functor A B) (hsB : has_homsets B) (hsC : has_homsets C),
   Colims_of_shape nat_graph C → is_omega_cocont (pre_composition_functor A B C hsB hsC F).
 Proof.
 exact @UniMath.CategoryTheory.CocontFunctors.is_omega_cocont_pre_composition_functor.
@@ -326,12 +326,12 @@ Defined.
 
 (** Theorem 44: Signature functor associated to a binding signature is ω-cocontinuous *)
 Lemma is_omega_cocont_BindingSigToSignature :
-  Π (C : precategory) (hsC : has_homsets C)
+  ∏ (C : precategory) (hsC : has_homsets C)
   (BPC : BinProducts C) (BCC : BinCoproducts C) (TC : Terminal C),
   Colims_of_shape nat_graph C →
-  (Π F : functor_precategory C C hsC, is_omega_cocont
+  (∏ F : functor_precategory C C hsC, is_omega_cocont
        (constprod_functor1 (BinProducts_functor_precat C C BPC hsC) F))
-  → Π (sig : BindingSig) (CC : Coproducts (BindingSigIndex sig) C),
+  → ∏ (sig : BindingSig) (CC : Coproducts (BindingSigIndex sig) C),
                           Products (BindingSigIndex sig) C →
   is_omega_cocont (pr1 (BindingSigToSignature hsC BPC BCC TC sig CC)).
 Proof.
@@ -340,9 +340,9 @@ Defined.
 
 (** Construction 46: Datatypes specified by binding signatures (initial algebra of Id_H + H) *)
 Definition SignatureInitialAlgebra :
-  Π {C : precategory} (hsC : has_homsets C) (BPC : BinProducts C) (BCC : BinCoproducts C),
+  ∏ {C : precategory} (hsC : has_homsets C) (BPC : BinProducts C) (BCC : BinCoproducts C),
   Initial C → Colims_of_shape nat_graph C
-  → Π s : Signature C hsC, is_omega_cocont (Signature_Functor C hsC s)
+  → ∏ s : Signature C hsC, is_omega_cocont (Signature_Functor C hsC s)
   → Initial (FunctorAlg (Id_H C hsC BCC s) (BindingSigToMonad.has_homsets_C2 hsC)).
 Proof.
 exact @UniMath.SubstitutionSystems.BindingSigToMonad.SignatureInitialAlgebra.
@@ -350,15 +350,15 @@ Defined.
 
 (** Theorem 48: Construction of a substitution operation on an initial algebra *)
 Definition InitHSS :
-  Π (C : precategory) (hsC : has_homsets C) (CP : BinCoproducts C),
+  ∏ (C : precategory) (hsC : has_homsets C) (CP : BinCoproducts C),
   BinProducts C → Initial C → Colims_of_shape nat_graph C →
-  Π H : Signature C hsC, is_omega_cocont (pr1 H) → hss_precategory CP H.
+  ∏ H : Signature C hsC, is_omega_cocont (pr1 H) → hss_precategory CP H.
 Proof.
 exact @UniMath.SubstitutionSystems.LiftingInitial_alt.InitHSS.
 Defined.
 
 Lemma isInitial_InitHSS :
-  Π (C : precategory) (hsC : has_homsets C) (CP : BinCoproducts C)
+  ∏ (C : precategory) (hsC : has_homsets C) (CP : BinCoproducts C)
   (BPC : BinProducts C) (IC : Initial C)
   (CC : Colims_of_shape nat_graph C) (H : Signature C hsC)
   (HH : is_omega_cocont (pr1 H)),
@@ -369,10 +369,10 @@ Defined.
 
 (** Section 4.2: Binding signatures to monads *)
 Definition BindingSigToMonad :
-  Π (C : precategory) (hsC : has_homsets C) (BPC : BinProducts C),
+  ∏ (C : precategory) (hsC : has_homsets C) (BPC : BinProducts C),
   BinCoproducts C → Terminal C → Initial C → Colims_of_shape nat_graph C
-  → (Π F, is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C BPC hsC) F))
-  → Π sig : BindingSig, Products (BindingSigIndex sig) C
+  → (∏ F, is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C BPC hsC) F))
+  → ∏ sig : BindingSig, Products (BindingSigIndex sig) C
   → Coproducts (BindingSigIndex sig) C
   → Monad C.
 Proof.

--- a/UniMath/SubstitutionSystems/GenMendlerIteration.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration.v
@@ -173,7 +173,7 @@ Proof.
     exact iter_eq.
 Qed.
 
-Lemma preIt_uniq (t : Σ h : L μF --> X, # L inF;; h = ψ μF h):
+Lemma preIt_uniq (t : ∑ h : L μF --> X, # L inF;; h = ψ μF h):
     t = tpair (λ h : L μF --> X, # L inF;; h = ψ μF h) preIt preIt_ok.
 Proof.
     destruct t as [h h_rec_eq]; simpl.
@@ -205,7 +205,7 @@ Focus 2.
        * apply (maponpaths pr1 (InitialArrowUnique _ _ X0)).
 Qed.
 
-Theorem GenMendlerIteration : iscontr (Σ h : L μF --> X, #L inF ;; h = ψ μF h).
+Theorem GenMendlerIteration : iscontr (∑ h : L μF --> X, #L inF ;; h = ψ μF h).
 Proof.
   simple refine (tpair _ _ _ ).
   - exists preIt.
@@ -260,7 +260,7 @@ Section special_case.
 
   Definition SpecialGenMendlerIteration :
     iscontr
-      (Σ h : L μF --> X, # L inF ;; h = θ μF ;; #G h ;; ρ)
+      (∑ h : L μF --> X, # L inF ;; h = θ μF ;; #G h ;; ρ)
     := GenMendlerIteration ψ_from_comps.
 
 End special_case.

--- a/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
@@ -57,7 +57,7 @@ Let chnF := initChain IC F.
 Let μF_Initial : Initial AF := colimAlgInitial hsC IC HF (CC chnF).
 Let μF : C := alg_carrier _ (InitialObject μF_Initial).
 Let inF : C⟦F μF,μF⟧ := alg_map _ (InitialObject μF_Initial).
-Let e : Π (n : nat), C⟦iter_functor F n IC,μF⟧ := colimIn (CC chnF).
+Let e : ∏ (n : nat), C⟦iter_functor F n IC,μF⟧ := colimIn (CC chnF).
 Let cocone_μF : cocone chnF μF := colimCocone (CC chnF).
 
 Local Lemma e_comm (n : nat) : e (S n) = # F (e n) ;; inF.
@@ -158,12 +158,12 @@ induction n.
 Qed.
 
 (* The direction ** -> * *)
-Local Lemma SS_imp_S (H : Π n, # L (e n) ;; preIt = Pow n IC z) : # L inF ;; preIt = ψ μF preIt.
+Local Lemma SS_imp_S (H : ∏ n, # L (e n) ;; preIt = Pow n IC z) : # L inF ;; preIt = ψ μF preIt.
 Proof.
 assert (H'' : # L inF ;; # L inF_inv = identity _).
 { rewrite <- functor_comp,  <- functor_id.
    apply maponpaths, (iso_inv_after_iso inF_iso). }
-assert (H' : Π n, # L (e (S n)) ;; # L inF_inv ;; ψ μF preIt = pr1 (Pow (S n)) _ z).
+assert (H' : ∏ n, # L (e (S n)) ;; # L inF_inv ;; ψ μF preIt = pr1 (Pow (S n)) _ z).
 { intro n.
   rewrite e_comm, functor_comp.
   eapply pathscomp0;
@@ -190,7 +190,7 @@ Proof.
 now apply SS_imp_S; intro n; apply eqSS.
 Qed.
 
-Lemma preIt_uniq (t : Σ h, # L inF ;; h = ψ μF h) : t = (preIt,,preIt_ok).
+Lemma preIt_uniq (t : ∑ h, # L inF ;; h = ψ μF h) : t = (preIt,,preIt_ok).
 Proof.
 apply subtypeEquality; [intros f; apply hsD|]; simpl.
 destruct t as [f Hf]; simpl.

--- a/UniMath/SubstitutionSystems/Lam.v
+++ b/UniMath/SubstitutionSystems/Lam.v
@@ -77,7 +77,7 @@ Let CPEndEndC:= BinCoproducts_functor_precat _ _ CPEndC hsEndC: BinCoproducts En
 
 Let one : C :=  @TerminalObject C terminal.
 
-Variable KanExt : Π Z : precategory_Ptd C hs,
+Variable KanExt : ∏ Z : precategory_Ptd C hs,
    RightKanExtension.GlobalRightKanExtensionExists C C
      (U Z) C hs hs.
 
@@ -415,8 +415,8 @@ Qed.
 Lemma bracket_for_LamE_algebra_on_Lam_unique (Z : Ptd)
   (f : Ptd ⟦ Z, ptd_from_alg LamE_algebra_on_Lam ⟧)
  :
-   Π
-   t : Σ
+   ∏
+   t : ∑
        h : [C, C, hs]
            ⟦ functor_composite (U Z)
                (` LamE_algebra_on_Lam),

--- a/UniMath/SubstitutionSystems/LamHSET.v
+++ b/UniMath/SubstitutionSystems/LamHSET.v
@@ -68,7 +68,7 @@ use colimAlgInitial.
 - apply ColimsFunctorCategory_of_shape; apply ColimsHSET_of_shape.
 Defined.
 
-(* Lemma KanExt_HSET : Π Z : precategory_Ptd HSET has_homsets_HSET, *)
+(* Lemma KanExt_HSET : ∏ Z : precategory_Ptd HSET has_homsets_HSET, *)
 (*    RightKanExtension.GlobalRightKanExtensionExists HSET HSET *)
 (*      (U Z) HSET has_homsets_HSET has_homsets_HSET. *)
 (* Proof. *)

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -84,7 +84,7 @@ Proof.
 Defined.
 
 Lemma is_omega_cocont_App_H
-  (hE : Π x, is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C CP hs) x)) :
+  (hE : ∏ x, is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C CP hs) x)) :
   is_omega_cocont App_H.
 Proof.
 unfold App_H, square_functor.
@@ -103,7 +103,7 @@ Defined.
 (* Definition Abs_H_ob (X: EndC): functor C C := functor_composite (option_functor _ CC terminal) X. *)
 
 (* (* works only with -type-in-type: *)
-(* Definition Abs_H_mor_nat_trans_data (X X': EndC)(α: X --> X'): Π c, Abs_H_ob X c --> Abs_H_ob X' c. *)
+(* Definition Abs_H_mor_nat_trans_data (X X': EndC)(α: X --> X'): ∏ c, Abs_H_ob X c --> Abs_H_ob X' c. *)
 (* Proof. *)
 (*   intro. *)
 (*   unfold Abs_H_ob. *)
@@ -111,7 +111,7 @@ Defined.
 (* Defined. *)
 (* *) *)
 
-(* Definition Abs_H_mor_nat_trans_data (X X': functor C C)(α: nat_trans X X'): Π c, Abs_H_ob X c --> Abs_H_ob X' c. *)
+(* Definition Abs_H_mor_nat_trans_data (X X': functor C C)(α: nat_trans X X'): ∏ c, Abs_H_ob X c --> Abs_H_ob X' c. *)
 (* Proof. *)
 (*   intro. *)
 (*   apply α. *)
@@ -225,7 +225,7 @@ Definition Flat_H : functor [C, C, hs] [C, C, hs] := tpair _ _ is_functor_Flat_H
 (** here definition of suitable θ's together with their strength laws  *)
 
 
-Definition App_θ_data: Π XZ, (θ_source App_H)XZ --> (θ_target App_H)XZ.
+Definition App_θ_data: ∏ XZ, (θ_source App_H)XZ --> (θ_target App_H)XZ.
 Proof.
   intro XZ.
   apply nat_trans_id.
@@ -323,7 +323,7 @@ Proof.
 Qed.
 
 
-Definition Abs_θ_data_data: Π XZ A, ((θ_source Abs_H)XZ: functor C C) A --> ((θ_target Abs_H)XZ: functor C C) A.
+Definition Abs_θ_data_data: ∏ XZ A, ((θ_source Abs_H)XZ: functor C C) A --> ((θ_target Abs_H)XZ: functor C C) A.
 Proof.
   intro XZ.
 (*
@@ -345,7 +345,7 @@ Proof.
   + exact (# (pr1 (pr2 XZ)) (BinCoproductIn2 _ (CC (TerminalObject terminal) A))).
 Defined.
 
-Lemma is_nat_trans_Abs_θ_data_data: Π XZ, is_nat_trans _ _ (Abs_θ_data_data XZ).
+Lemma is_nat_trans_Abs_θ_data_data: ∏ XZ, is_nat_trans _ _ (Abs_θ_data_data XZ).
 Proof.
 
   intro XZ.
@@ -431,7 +431,7 @@ Focus 2.
 Qed.
 
 
-Definition Abs_θ_data: Π XZ, (θ_source Abs_H)XZ --> (θ_target Abs_H)XZ.
+Definition Abs_θ_data: ∏ XZ, (θ_source Abs_H)XZ --> (θ_target Abs_H)XZ.
 Proof.
   intro XZ.
   exact (tpair _ _ (is_nat_trans_Abs_θ_data_data XZ)).
@@ -556,7 +556,7 @@ Focus 2.
 Qed.
 
 
-Definition Flat_θ_data: Π XZ, (θ_source Flat_H)XZ --> (θ_target Flat_H)XZ.
+Definition Flat_θ_data: ∏ XZ, (θ_source Flat_H)XZ --> (θ_target Flat_H)XZ.
 Proof.
   intro XZ.
 (*  destruct XZ as [X [Z e]].
@@ -668,7 +668,7 @@ Definition Lam_Sig: Signature C hs :=
   BinSum_of_Signatures C hs CC App_Sig Abs_Sig.
 
 Lemma is_omega_cocont_Lam
-  (hE : Π x, is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C CP hs) x))
+  (hE : ∏ x, is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C CP hs) x))
   (LC : Colims_of_shape nat_graph C) : is_omega_cocont (Signature_Functor _ _ Lam_Sig).
 Proof.
 apply is_omega_cocont_BinCoproduct_of_functors.

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -78,7 +78,7 @@ Let EndEndC := [EndC, EndC, hsEndC].
 Let CPEndEndC:= BinCoproducts_functor_precat _ _ CPEndC hsEndC: BinCoproducts EndEndC.
 
 
-Variable KanExt : Π Z : Ptd, GlobalRightKanExtensionExists _ _ (U Z) _ hs hs.
+Variable KanExt : ∏ Z : Ptd, GlobalRightKanExtensionExists _ _ (U Z) _ hs hs.
 
 Variable H : Signature C hs.
 Let θ := theta H.
@@ -95,7 +95,7 @@ Let Alg : precategory := FunctorAlg Id_H hsEndC.
 
 Variable IA : Initial Alg.
 Definition SpecializedGMIt (Z : Ptd) (X : EndC)
-  :  Π (G : functor [C, C, hs] [C, C, hs])
+  :  ∏ (G : functor [C, C, hs] [C, C, hs])
        (ρ : [C, C, hs] ⟦ G X, X ⟧)
        (θ : functor_composite Id_H (ℓ (U Z)) ⟶ functor_composite (ℓ (U Z)) G),
      ∃! h : [C, C, hs] ⟦ ℓ (U Z) (` (InitialObject IA)), X ⟧,
@@ -428,7 +428,7 @@ Proof.
 Qed.
 
 Local Lemma foo' (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
- Π t : Σ h : [C, C, hs] ⟦ functor_composite (U Z) (pr1  InitAlg),
+ ∏ t : ∑ h : [C, C, hs] ⟦ functor_composite (U Z) (pr1  InitAlg),
                          pr1 InitAlg ⟧,
        bracket_property f h,
    t
@@ -858,7 +858,7 @@ Proof.
       apply (nat_trans_eq_pointwise Hyp c).
 Qed.
 
-Definition hss_InitMor : Π T' : hss CP H, hssMor InitHSS T'.
+Definition hss_InitMor : ∏ T' : hss CP H, hssMor InitHSS T'.
 Proof.
   intro T'.
   exists (InitialArrow IA (pr1 T')).
@@ -866,7 +866,7 @@ Proof.
 Defined.
 
 Lemma hss_InitMor_unique (T' : hss_precategory CP H):
-  Π t : hss_precategory CP H ⟦ InitHSS, T' ⟧, t = hss_InitMor T'.
+  ∏ t : hss_precategory CP H ⟦ InitHSS, T' ⟧, t = hss_InitMor T'.
 Proof.
   intro t.
   apply (invmap (hssMor_eq1 _ _ _ _ _ _ _ _ )).

--- a/UniMath/SubstitutionSystems/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial_alt.v
@@ -109,7 +109,7 @@ apply is_omega_cocont_pre_composition_functor, CC.
 Defined.
 
 Definition SpecializedGMIt (Z : Ptd) (X : EndC) :
-  Π (G : functor [C, C, hsC] [C, C, hsC]) (ρ : [C, C, hsC] ⟦ G X, X ⟧)
+  ∏ (G : functor [C, C, hsC] [C, C, hsC]) (ρ : [C, C, hsC] ⟦ G X, X ⟧)
     (θ : functor_composite Id_H (ℓ (U Z)) ⟶ functor_composite (ℓ (U Z)) G),
   ∃! h : [C, C, hsC] ⟦ ℓ (U Z) (alg_carrier _ InitAlg), X ⟧,
     # (ℓ (U Z)) (alg_map Id_H InitAlg) ;; h =
@@ -339,7 +339,7 @@ now apply whole_from_parts, bracket_Thm15_ok.
 Qed.
 
 Local Lemma bracket_unique (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
- Π t : Σ h : [C, C, hsC] ⟦ functor_composite (U Z) (pr1  InitAlg),
+ ∏ t : ∑ h : [C, C, hsC] ⟦ functor_composite (U Z) (pr1  InitAlg),
                             pr1 InitAlg ⟧, bracket_property f h,
    t = tpair _ ⦃f⦄ (bracket_Thm15_ok_cor Z f).
 Proof.
@@ -640,7 +640,7 @@ pathvia (pr1 (pr1 X)).
       now apply (nat_trans_eq_pointwise Hyp c).
 Qed.
 
-Definition hss_InitMor : Π T' : hss CP H, hssMor InitHSS T'.
+Definition hss_InitMor : ∏ T' : hss CP H, hssMor InitHSS T'.
 Proof.
 intro T'.
 exists (InitialArrow IA (pr1 T')).
@@ -648,7 +648,7 @@ apply ishssMor_InitAlg.
 Defined.
 
 Lemma hss_InitMor_unique (T' : hss_precategory CP H):
-  Π t : hss_precategory CP H ⟦ InitHSS, T' ⟧, t = hss_InitMor T'.
+  ∏ t : hss_precategory CP H ⟦ InitHSS, T' ⟧, t = hss_InitMor T'.
 Proof.
 intro t.
 apply (invmap (hssMor_eq1 _ _ _ _ _ _ _ _ )).

--- a/UniMath/SubstitutionSystems/MLTT79.v
+++ b/UniMath/SubstitutionSystems/MLTT79.v
@@ -69,11 +69,11 @@ Section MLTT79.
 
 (** This is the syntax as presented on page 158:
 <<
-Pi types           (Πx:A)B                     [0,1]
+Pi types           (∏x:A)B                     [0,1]
 lambda             (λx)b                       [1]
 application        (c)a                        [0,0]
 
-Sigma types        (Σx:A)B                     [0,1]
+Sigma types        (∑x:A)B                     [0,1]
 pair               (a,b)                       [0,0]
 pair-elim          (Ex,y)(c,d)                 [0,2]
 
@@ -149,7 +149,7 @@ Definition FinSigConstructors (n : nat) : stn n -> list nat := fun _ => [].
 (* Defined. *)
 
 (** Uncurried version of the FinSig family *)
-Definition FinSigFun : (Σ n : nat, unit ⨿ (stn n ⨿ unit)) → list nat.
+Definition FinSigFun : (∑ n : nat, unit ⨿ (stn n ⨿ unit)) → list nat.
 Proof.
 induction 1 as [n p].
 induction p as [_|p].
@@ -159,7 +159,7 @@ induction p as [_|p].
   + apply (FinSigElim n).
 Defined.
 
-Lemma isdeceqFinSig : isdeceq (Σ n, unit ⨿ (stn n ⨿ unit)).
+Lemma isdeceqFinSig : isdeceq (∑ n, unit ⨿ (stn n ⨿ unit)).
 Proof.
 intros [n p] [m q].
 induction (isdeceqnat n m) as [h|h].

--- a/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
@@ -130,7 +130,7 @@ Proof.
 Qed.
 
 
-Lemma μ_1_identity' : Π c : C, μ_1 c = identity _.
+Lemma μ_1_identity' : ∏ c : C, μ_1 c = identity _.
 Proof.
   intros c.
   assert (HA:= nat_trans_eq_pointwise μ_1_identity).
@@ -175,7 +175,7 @@ Defined.
 (** *** Proof of the first monad law *)
 
 Lemma Monad_law_1_from_hss :
-  Π c : C, μ_0 (pr1 (`T) c);; μ_2 c = identity ((pr1 (`T)) c).
+  ∏ c : C, μ_0 (pr1 (`T) c);; μ_2 c = identity ((pr1 (`T)) c).
 Proof.
   intro c.
   unfold μ_2. simpl.
@@ -190,7 +190,7 @@ Qed.
 (** *** Proof of the second monad law *)
 
 Lemma Monad_law_2_from_hss:
-  Π c : C, # (pr1 (`T)) (μ_0 c);; μ_2 c = identity ((pr1 (`T)) c).
+  ∏ c : C, # (pr1 (`T)) (μ_0 c);; μ_2 c = identity ((pr1 (`T)) c).
 Proof.
   intro c.
   pathvia (μ_1 c).
@@ -274,7 +274,7 @@ Defined.
     the pointed structure given by [η] *)
 
 Lemma μ_2_is_ptd_mor :
-  Π c : C, (ptd_pt C T_squared) c;; μ_2 c = pr1 (η T) c.
+  ∏ c : C, (ptd_pt C T_squared) c;; μ_2 c = pr1 (η T) c.
 Proof.
   intro c.
   unfold μ_2.
@@ -441,7 +441,7 @@ Lemma μ_3_μ_2_T_μ_2 :  (
       eapply pathscomp0. Focus 2. apply assoc.
       eapply pathscomp0. Focus 2. apply maponpaths. apply (!HXX).
       clear HXX.
-      assert (Strength_2 : Π α : functor_compose hs hs (functor_composite (`T) (`T))(`T) --> functor_composite (` T) (`T),
+      assert (Strength_2 : ∏ α : functor_compose hs hs (functor_composite (`T) (`T))(`T) --> functor_composite (` T) (`T),
 
                     pr1 (θ (`T ⊗ T_squared)) c ;; pr1 (# H α) c =
                      pr1 (θ ((`T) ⊗ (ptd_from_alg T))) ((pr1 (pr1 (pr1 T))) c);;

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -74,7 +74,7 @@ Let post_comp := post_composition_functor (SET / sort) _ _
 
 (** Definition of multi sorted signatures *)
 Definition MultiSortedSig : UU :=
-  Σ (I : hSet), I → list (list sort × sort) × sort.
+  ∑ (I : hSet), I → list (list sort × sort) × sort.
 
 Definition ops (M : MultiSortedSig) : hSet := pr1 M.
 Definition arity (M : MultiSortedSig) : ops M → list (list sort × sort) × sort :=
@@ -422,7 +422,7 @@ Defined.
 
 (** Definition of multi sorted signatures *)
 Definition MultiSortedSig : UU :=
-  Π (s : sort), Σ (I : UU), (I → list (list sort × sort)). (* × (isaset I). *)
+  ∏ (s : sort), ∑ (I : UU), (I → list (list sort × sort)). (* × (isaset I). *)
 
 Definition indices (M : MultiSortedSig) : sort → UU := fun s => pr1 (M s).
 
@@ -519,7 +519,7 @@ Defined.
 
 (* H follows if C has exponentials? *)
 (* Lemma is_omega_cocont_exp_functors (xs : list (list sort × sort)) *)
-(*   (H : Π x : [sortToC, C], is_omega_cocont (constprod_functor1 BinProductsSortToCToC x)) *)
+(*   (H : ∏ x : [sortToC, C], is_omega_cocont (constprod_functor1 BinProductsSortToCToC x)) *)
 (*   (H2 : Colims_of_shape nat_graph sortToC) : *)
 (*   is_omega_cocont (exp_functors xs). *)
 (* Proof. *)
@@ -567,7 +567,7 @@ Defined.
 
 
 (* Lemma is_omega_cocont_MultiSortedSigToFunctor_helper (C1 D E1 : precategory) (E2 : Precategory) *)
-(*   (F : functor E1 [C1,[D,E2]]) (HF : Π s, is_omega_cocont (F s)) : *)
+(*   (F : functor E1 [C1,[D,E2]]) (HF : ∏ s, is_omega_cocont (F s)) : *)
 (*   is_omega_cocont (MultiSortedSigToFunctor_helper C1 D E1 E2 F). *)
 (* Proof. *)
 (* apply is_omega_cocont_functor_composite. *)
@@ -585,7 +585,7 @@ Defined.
 (* apply functor_identity. *)
 (* Defined. *)
 
-Local Definition MultiSortedSigToFunctor_fun (M : MultiSortedSig) (CC : Π s, Coproducts (indices M s) C)
+Local Definition MultiSortedSigToFunctor_fun (M : MultiSortedSig) (CC : ∏ s, Coproducts (indices M s) C)
   : [sort_cat, [[sortToC, sortToC], [sortToC, C]]].
 Proof.
 (* As we're defining a functor out of a discrete category it suffices to give a function: *)
@@ -596,12 +596,12 @@ use (coproduct_of_functors (indices M s)).
 Defined.
 
 (* Lemma is_omega_cocont_MultiSortedSigToFunctor_fun *)
-(*   (M : MultiSortedSig) (CC : Π s, Coproducts (indices M s) C) *)
-(*   (CP : Π s, Products (indices M s) C) *)
-(*   (hs : Π s, isdeceq (indices M s)) *)
-(*   (H : Π x : [sortToC, C], is_omega_cocont (constprod_functor1 BinProductsSortToCToC x)) *)
+(*   (M : MultiSortedSig) (CC : ∏ s, Coproducts (indices M s) C) *)
+(*   (CP : ∏ s, Products (indices M s) C) *)
+(*   (hs : ∏ s, isdeceq (indices M s)) *)
+(*   (H : ∏ x : [sortToC, C], is_omega_cocont (constprod_functor1 BinProductsSortToCToC x)) *)
 (*   (H2 : Colims_of_shape nat_graph sortToC) : *)
-(*   Π s, is_omega_cocont (pr1 (MultiSortedSigToFunctor_fun M CC) s). *)
+(*   ∏ s, is_omega_cocont (pr1 (MultiSortedSigToFunctor_fun M CC) s). *)
 (* Proof. *)
 (* intros s. *)
 (* apply is_omega_cocont_coproduct_of_functors; try apply homset_property. *)
@@ -613,7 +613,7 @@ Defined.
 (* Defined. *)
 
 (** * The functor constructed from a multisorted binding signature *)
-Definition MultiSortedSigToFunctor (M : MultiSortedSig) (CC : Π s, Coproducts (indices M s) C) :
+Definition MultiSortedSigToFunctor (M : MultiSortedSig) (CC : ∏ s, Coproducts (indices M s) C) :
   functor [sortToC,sortToC] [sortToC,sortToC].
 Proof.
 (* First reorganize so that the last sort argument is first: *)
@@ -623,10 +623,10 @@ apply (F x).
 Defined.
 
 (* Lemma is_omega_cocont_MultiSortedSigToFunctor (M : MultiSortedSig) *)
-(*   (CC : Π s, Coproducts (indices M s) C) *)
-(*   (PC : Π s, Products (indices M s) C) *)
-(*   (Hi : Π s, isdeceq (indices M s)) *)
-(*   (H : Π x : [sortToC, C], is_omega_cocont (constprod_functor1 BinProductsSortToCToC x)) : *)
+(*   (CC : ∏ s, Coproducts (indices M s) C) *)
+(*   (PC : ∏ s, Products (indices M s) C) *)
+(*   (Hi : ∏ s, isdeceq (indices M s)) *)
+(*   (H : ∏ x : [sortToC, C], is_omega_cocont (constprod_functor1 BinProductsSortToCToC x)) : *)
 (*    is_omega_cocont (MultiSortedSigToFunctor M CC). *)
 (* Proof. *)
 (* apply is_omega_cocont_functor_composite. *)

--- a/UniMath/SubstitutionSystems/SignatureCategory.v
+++ b/UniMath/SubstitutionSystems/SignatureCategory.v
@@ -62,7 +62,7 @@ Definition Signature_category_mor_diagram : UU := f1 ;; f2 = g1 ;; g2.
 
 (** Special comparison lemma that speeds things up a lot *)
 Lemma Signature_category_mor_diagram_pointwise
-  (Hc : Π c, pr1 f1 c ;; pr1 f2 c = pr1 (α X) ((pr1 Y) c) ;; pr1 g2 c) :
+  (Hc : ∏ c, pr1 f1 c ;; pr1 f2 c = pr1 (α X) ((pr1 Y) c) ;; pr1 g2 c) :
    Signature_category_mor_diagram.
 Proof.
 apply (nat_trans_eq hsC); intro c; simpl.
@@ -76,7 +76,7 @@ Proof.
 intros Ht Ht'.
 use total2.
 + apply (nat_trans Ht Ht').
-+ intros α; apply (Π X Y, Signature_category_mor_diagram Ht Ht' α X Y).
++ intros α; apply (∏ X Y, Signature_category_mor_diagram Ht Ht' α X Y).
 Defined.
 
 Lemma SignatureMor_eq (Ht Ht' : Signature C hsC) (f g : SignatureMor Ht Ht') :
@@ -289,7 +289,7 @@ mkpair.
 Defined.
 
 Lemma CoproductArrow_diagram (Hti : I → Signature_precategory C)
-  (Ht : Signature C hsC) (F : Π i : I, SignatureMor C (Hti i) Ht) X Y :
+  (Ht : Signature C hsC) (F : ∏ i : I, SignatureMor C (Hti i) Ht) X Y :
   Signature_category_mor_diagram C (Sum_of_Signatures I C hsC CC Hti) Ht
     (CoproductArrow I _ (CCC _) (λ i, pr1 (F i))) X Y.
 Proof.

--- a/UniMath/SubstitutionSystems/SignatureExamples.v
+++ b/UniMath/SubstitutionSystems/SignatureExamples.v
@@ -141,7 +141,7 @@ Let D' Ze Ze' :=
  (nat_trans_comp (post_whisker (δ Ze) (pr1 Ze'))
                  (α_functor G (pr1 Ze) (pr1 Ze'))))).
 
-Definition δ_law2 : UU := Π Ze Ze', δ (Ze p• Ze') = D' Ze Ze'.
+Definition δ_law2 : UU := ∏ Ze Ze', δ (Ze p• Ze') = D' Ze Ze'.
 Hypothesis H2 : δ_law2.
 
 Lemma θ_Strength2_int_from_δ : θ_Strength2_int θ_from_δ.
@@ -156,7 +156,7 @@ eapply pathscomp0;
 apply functor_comp.
 Qed.
 
-Definition θ_precompG : Σ θ : θ_source precompG ⟶ θ_target precompG,
+Definition θ_precompG : ∑ θ : θ_source precompG ⟶ θ_target precompG,
                               θ_Strength1_int θ × θ_Strength2_int θ :=
   tpair _ θ_from_δ (θ_Strength1_int_from_δ,,θ_Strength2_int_from_δ).
 
@@ -406,7 +406,7 @@ Section id_signature.
 
 Variable (C : precategory) (hsC : has_homsets C).
 
-Definition θ_functor_identity : Σ
+Definition θ_functor_identity : ∑
   θ : θ_source (functor_identity [C,C,hsC]) ⟶ θ_target (functor_identity [C,C,hsC]),
   θ_Strength1_int θ × θ_Strength2_int θ.
 Proof.

--- a/UniMath/SubstitutionSystems/Signatures.v
+++ b/UniMath/SubstitutionSystems/Signatures.v
@@ -186,14 +186,14 @@ Hypothesis θ : θ_source ⟶ θ_target.
 
 (** [θ] is supposed to satisfy two strength laws *)
 
-Definition θ_Strength1 : UU := Π X : EndC,
+Definition θ_Strength1 : UU := ∏ X : EndC,
   (θ (X ⊗ (id_Ptd C hs))) ;; # H (identity X : functor_composite (functor_identity C) X ⟶ pr1 X)
           = nat_trans_id _ .
 
 Section Strength_law_1_intensional.
 
 Definition θ_Strength1_int : UU
-  := Π X : EndC,
+  := ∏ X : EndC,
      θ (X ⊗ (id_Ptd C hs)) ;; # H (λ_functor _) = λ_functor _.
 
 Lemma θ_Strength1_int_implies_θ_Strength1 : θ_Strength1_int → θ_Strength1.
@@ -234,7 +234,7 @@ End Strength_law_1_intensional.
 Hypothesis θ_strength1 : θ_Strength1.
 *)
 
-Definition θ_Strength2 : UU := Π (X : EndC) (Z Z' : Ptd) (Y : EndC)
+Definition θ_Strength2 : UU := ∏ (X : EndC) (Z Z' : Ptd) (Y : EndC)
            (α : functor_compose hs hs (functor_composite (U Z) (U Z')) X --> Y),
     θ (X ⊗ (Z p• Z' : Ptd)) ;; # H α =
     θ (X ⊗ Z') •• (U Z) ;; θ ((functor_compose hs hs (U Z') X) ⊗ Z) ;;
@@ -243,7 +243,7 @@ Definition θ_Strength2 : UU := Π (X : EndC) (Z Z' : Ptd) (Y : EndC)
 Section Strength_law_2_intensional.
 
 Definition θ_Strength2_int : UU
-  := Π (X : EndC) (Z Z' : Ptd),
+  := ∏ (X : EndC) (Z Z' : Ptd),
       θ (X ⊗ (Z p• Z'))  ;; #H (α_functor (U Z) (U Z') X )  =
       (α_functor (U Z) (U Z') (H X) : functor_compose hs hs _ _  --> _ ) ;;
       θ (X ⊗ Z') •• (U Z) ;; θ ((functor_compose hs hs (U Z') X) ⊗ Z) .
@@ -395,8 +395,8 @@ End Strength_laws.
 
 Definition Signature (*C : precategory) (hs : has_homsets C*) : UU
   :=
-  Σ H : functor [C, C, hs] [C, C, hs] ,
-     Σ θ : nat_trans (θ_source H) (θ_target H) , θ_Strength1_int H θ × θ_Strength2_int H θ.
+  ∑ H : functor [C, C, hs] [C, C, hs] ,
+     ∑ θ : nat_trans (θ_source H) (θ_target H) , θ_Strength1_int H θ × θ_Strength2_int H θ.
 
 Coercion Signature_Functor (S : Signature) : functor _ _ := pr1 S.
 

--- a/UniMath/SubstitutionSystems/SubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/SubstitutionSystems.v
@@ -119,7 +119,7 @@ Definition bracket_at (T : algebra_ob Id_H) {Z : Ptd} (f : Z --> ptd_from_alg T)
   ∃! h : `T • (U Z)  --> `T, bracket_property T f h.
 
 Definition bracket (T : algebra_ob Id_H) : UU
-  := Π (Z : Ptd) (f : Z --> ptd_from_alg T), bracket_at T f.
+  := ∏ (Z : Ptd) (f : Z --> ptd_from_alg T), bracket_at T f.
 
 Lemma isaprop_bracket (T : algebra_ob Id_H) : isaprop (bracket T).
 Proof.
@@ -138,7 +138,7 @@ Definition bracket_parts_at (T : algebra_ob Id_H) {Z : Ptd} (f : Z --> ptd_from_
    ∃! h : `T • (U Z)  --> `T, bracket_property_parts T f h.
 
 Definition bracket_parts (T : algebra_ob Id_H) : UU
-  := Π (Z : Ptd) (f : Z --> ptd_from_alg T), bracket_parts_at T f.
+  := ∏ (Z : Ptd) (f : Z --> ptd_from_alg T), bracket_parts_at T f.
 
 (* show that for any h of suitable type, the following are equivalent *)
 
@@ -241,11 +241,11 @@ Qed.
 
 (* show bracket_parts_point is logically equivalent to bracket_point, then
    use it to show that bracket_parts is equivalent to bracket using [weqonsecfibers:
-  Π (X : UU) (P Q : X → UU),
-  (Π x : X, P x ≃ Q x) → (Π x : X, P x) ≃ (Π x : X, Q x)] *)
+  ∏ (X : UU) (P Q : X → UU),
+  (∏ x : X, P x ≃ Q x) → (∏ x : X, P x) ≃ (∏ x : X, Q x)] *)
 
 
-Definition hss : UU := Σ T, bracket T.
+Definition hss : UU := ∑ T, bracket T.
 
 Coercion alg_from_hss (T : hss) : algebra_ob Id_H := pr1 T.
 
@@ -259,9 +259,9 @@ Notation "⦃ f ⦄" := (fbracket _ f)(at level 0).
 (** The bracket operation [fbracket] is unique *)
 
 Definition fbracket_unique_pointwise (T : hss) {Z : Ptd} (f : Z --> ptd_from_alg T)
-  : Π (α : functor_composite (U Z) `T ⟶ pr1 `T),
-     (Π c : C, pr1 (#U f) c = pr1 (η T) (pr1 (U Z) c) ;; α c) →
-     (Π c : C, pr1 (θ (`T ⊗ Z))  c ;; pr1 (#H α) c ;; pr1 (τ T) c =
+  : ∏ (α : functor_composite (U Z) `T ⟶ pr1 `T),
+     (∏ c : C, pr1 (#U f) c = pr1 (η T) (pr1 (U Z) c) ;; α c) →
+     (∏ c : C, pr1 (θ (`T ⊗ Z))  c ;; pr1 (#H α) c ;; pr1 (τ T) c =
         pr1 (τ T) (pr1 (U Z) c) ;; α c)
      →
      α = ⦃f⦄.
@@ -275,7 +275,7 @@ Proof.
 Qed.
 
 Definition fbracket_unique (T : hss) {Z : Ptd} (f : Z --> ptd_from_alg T)
-: Π α : (*functor_composite (C:=C)*) `T • (U Z)  --> `T,
+: ∏ α : (*functor_composite (C:=C)*) `T • (U Z)  --> `T,
     bracket_property_parts T f α
    →
    α = ⦃f⦄.
@@ -287,10 +287,10 @@ Proof.
 Qed.
 
 Definition fbracket_unique_target_pointwise (T : hss) {Z : Ptd} (f : Z --> ptd_from_alg T)
-  : Π α : `T • U Z --> `T,
+  : ∏ α : `T • U Z --> `T,
         bracket_property_parts T f α
    →
-   Π c, pr1 α c =  pr1 ⦃ f ⦄ c.
+   ∏ c, pr1 α c =  pr1 ⦃ f ⦄ c.
 Proof.
   intros α H12.
   set (t:= fbracket_unique _ _ α H12).
@@ -299,7 +299,7 @@ Qed.
 
 (** Properties of [fbracket] by definition: commutative diagrams *)
 
-Lemma fbracket_η (T : hss) : Π {Z : Ptd} (f : Z --> ptd_from_alg T),
+Lemma fbracket_η (T : hss) : ∏ {Z : Ptd} (f : Z --> ptd_from_alg T),
    #U f = η T •• U Z ;; ⦃f⦄.
 Proof.
   intros Z f.
@@ -307,7 +307,7 @@ Proof.
   exact (pr1 (parts_from_whole _ _ _ _  (pr2 (pr1 (pr2 T Z f))))).
 Qed.
 
-Lemma fbracket_τ (T : hss) : Π {Z : Ptd} (f : Z --> ptd_from_alg T),
+Lemma fbracket_τ (T : hss) : ∏ {Z : Ptd} (f : Z --> ptd_from_alg T),
     θ (`T ⊗ Z) ;; #H ⦃f⦄ ;; τ T
     =
     τ T •• U Z ;; ⦃f⦄.
@@ -376,7 +376,7 @@ Qed.
 
 (** As a consequence of naturality, we can compute [fbracket f] from [fbracket identity] *)
 
-Lemma compute_fbracket (T : hss) : Π {Z : Ptd} (f : Z --> ptd_from_alg T),
+Lemma compute_fbracket (T : hss) : ∏ {Z : Ptd} (f : Z --> ptd_from_alg T),
     ⦃ f ⦄ = (` T ∘ # U f : EndC ⟦ `T • U Z , `T • U (p T) ⟧) ;; ⦃ identity p T ⦄.
 Proof.
   intros Z f.
@@ -494,7 +494,7 @@ Definition ptd_from_alg_functor: functor (precategory_FunctorAlg Id_H hsEndC) Pt
 
 
 Definition isbracketMor {T T' : hss} (β : algebra_mor _ T T') : UU :=
-    Π (Z : Ptd) (f : Z --> ptd_from_alg T),
+    ∏ (Z : Ptd) (f : Z --> ptd_from_alg T),
       ⦃ f ⦄ ;; β = β •• U Z ;; ⦃ f ;; # ptd_from_alg_functor β ⦄.
 
 
@@ -512,7 +512,7 @@ Definition ishssMor {T T' : hss} (β : algebra_mor _ T T') : UU
   :=   isbracketMor β.
 
 Definition hssMor (T T' : hss) : UU
-  := Σ β : algebra_mor _ T T', ishssMor β.
+  := ∑ β : algebra_mor _ T T', ishssMor β.
 
 Coercion ptd_mor_from_hssMor (T T' : hss) (β : hssMor T T') : algebra_mor _ T T' := pr1 β.
 

--- a/UniMath/SubstitutionSystems/SubstitutionSystems_Summary.v
+++ b/UniMath/SubstitutionSystems/SubstitutionSystems_Summary.v
@@ -54,11 +54,11 @@ Notation "G • F" := (functor_composite F G).
 (** Lemma 8 *)
 
 Definition GenMendlerIteration :
-   Π (C : precategory) (hsC : has_homsets C) (F : functor C C)
+   ∏ (C : precategory) (hsC : has_homsets C) (F : functor C C)
    (μF_Initial : Initial (FunctorAlg F hsC)) (C' : precategory)
    (hsC' : has_homsets C') (X : C') (L : functor C C'),
    equivalences.is_left_adjoint L
-   → Π ψ : ψ_source C C' hsC' X L ⟶ ψ_target C F C' hsC' X L,
+   → ∏ ψ : ψ_source C C' hsC' X L ⟶ ψ_target C F C' hsC' X L,
      ∃! h : C' ⟦ L ` (InitialObject μF_Initial), X ⟧,
      # L (alg_map F (InitialObject μF_Initial)) ;; h =
      ψ ` (InitialObject μF_Initial) h.
@@ -72,7 +72,7 @@ Arguments It {_ _ _} _ {_} _ _ _ _ _ .
 (** Lemma 9 *)
 
 Theorem fusion_law
-     : Π (C : precategory) (hsC : has_homsets C)
+     : ∏ (C : precategory) (hsC : has_homsets C)
        (F : functor C C)
        (μF_Initial : Initial (precategory_FunctorAlg F hsC))
        (C' : precategory) (hsC' : has_homsets C')
@@ -100,7 +100,7 @@ Qed.
 (** Lemma 15 *)
 
 Lemma fbracket_natural
-     : Π (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
+     : ∏ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
        (H : Signature C hs) (T : hss CP H) (Z Z' : precategory_Ptd C hs)
        (f : precategory_Ptd C hs ⟦ Z, Z' ⟧)
        (g : precategory_Ptd C hs ⟦ Z', ptd_from_alg T ⟧),
@@ -110,7 +110,7 @@ Proof.
 Qed.
 
 Lemma compute_fbracket
-     : Π (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
+     : ∏ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
        (H : Signature C hs) (T : hss CP H) (Z : precategory_Ptd C hs)
        (f : precategory_Ptd C hs ⟦ Z, ptd_from_alg T ⟧),
        ⦃ f ⦄ = (`T ∘ # U f : [C,C,hs] ⟦ `T • U Z , `T • U _ ⟧) ;; ⦃ identity (ptd_from_alg T) ⦄.
@@ -124,7 +124,7 @@ Qed.
 (** Theorem 24 *)
 
 Definition Monad_from_hss
-     : Π (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
+     : ∏ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
        (H : Signature C hs), hss CP H → Monad C.
 Proof.
   apply Monad_from_hss.
@@ -133,7 +133,7 @@ Defined.
 (** Theorem 25 *)
 
 Definition hss_to_monad_functor
-     : Π (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
+     : ∏ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
        (H : Signature C hs),
        functor (hss_precategory CP H) (precategory_Monad C hs).
 Proof.
@@ -143,7 +143,7 @@ Defined.
 (** Lemma 26 *)
 
 Lemma faithful_hss_to_monad
-     : Π (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
+     : ∏ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
        (H : Signature C hs), faithful (hss_to_monad_functor C hs CP H).
 Proof.
   apply faithful_hss_to_monad.
@@ -159,9 +159,9 @@ Defined.
 *)
 
 Definition bracket_for_initial_algebra
- : Π (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C),
-     (Π Z : precategory_Ptd C hs, GlobalRightKanExtensionExists C C (U Z) C hs hs)
-       → Π (H : Signature C hs)
+ : ∏ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C),
+     (∏ Z : precategory_Ptd C hs, GlobalRightKanExtensionExists C C (U Z) C hs hs)
+       → ∏ (H : Signature C hs)
            (IA : Initial (FunctorAlg (Id_H C hs CP H) (functor_category_has_homsets C C hs)))
            (Z : precategory_Ptd C hs),
            precategory_Ptd C hs ⟦ Z, ptd_from_alg (InitAlg C hs CP H IA) ⟧
@@ -172,8 +172,8 @@ Proof.
 Defined.
 
 Lemma bracket_Thm15_ok_η
-     : Π (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
-       (KanExt : Π Z : precategory_Ptd C hs,
+     : ∏ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
+       (KanExt : ∏ Z : precategory_Ptd C hs,
                  GlobalRightKanExtensionExists C C (U Z) C hs hs)
        (H : Signature C hs)
        (IA : Initial (FunctorAlg (Id_H C hs CP H) (functor_category_has_homsets C C hs)))
@@ -187,8 +187,8 @@ Proof.
 Qed.
 
 Lemma bracket_Thm15_ok_τ
-  : Π (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
-      (KanExt : Π Z : precategory_Ptd C hs, GlobalRightKanExtensionExists C C (U Z) C hs hs)
+  : ∏ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
+      (KanExt : ∏ Z : precategory_Ptd C hs, GlobalRightKanExtensionExists C C (U Z) C hs hs)
       (H : Signature C hs)
       (IA : Initial (FunctorAlg (Id_H C hs CP H) (functor_category_has_homsets C C hs)))
       (Z : precategory_Ptd C hs)
@@ -206,10 +206,10 @@ Qed.
 (** Theorem 29 *)
 
 Definition Initial_HSS :
-   Π (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C),
-     (Π Z : precategory_Ptd C hs,
+   ∏ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C),
+     (∏ Z : precategory_Ptd C hs,
          GlobalRightKanExtensionExists C C (U Z) C hs hs)
-     → Π H : Signature C hs,
+     → ∏ H : Signature C hs,
        Initial (FunctorAlg (Id_H C hs CP H) (functor_category_has_homsets C C hs))
        → Initial (hss_precategory CP H).
 Proof.
@@ -222,7 +222,7 @@ Defined.
 (** Lemma 30 *)
 
 Definition Sum_of_Signatures
-  : Π (C : precategory) (hs : has_homsets C),
+  : ∏ (C : precategory) (hs : has_homsets C),
        BinCoproducts C → Signature C hs → Signature C hs → Signature C hs.
 Proof.
   apply BinSum_of_Signatures.
@@ -234,7 +234,7 @@ Defined.
 (** Definition 31 *)
 
 Definition App_Sig
-  : Π (C : precategory) (hs : has_homsets C), BinProducts C → Signature C hs.
+  : ∏ (C : precategory) (hs : has_homsets C), BinProducts C → Signature C hs.
 Proof.
   apply App_Sig.
 Defined.
@@ -242,7 +242,7 @@ Defined.
 (** Definition 32 *)
 
 Definition Lam_Sig
-  : Π (C : precategory) (hs : has_homsets C),
+  : ∏ (C : precategory) (hs : has_homsets C),
     Terminal C → BinCoproducts C → BinProducts C → Signature C hs.
 Proof.
   apply Lam_Sig.
@@ -251,7 +251,7 @@ Defined.
 (** Definition 33 *)
 
 Definition Flat_Sig
-  : Π (C : precategory) (hs : has_homsets C), Signature C hs.
+  : ∏ (C : precategory) (hs : has_homsets C), Signature C hs.
 Proof.
   apply Flat_Sig.
 Defined.
@@ -261,12 +261,12 @@ Defined.
 (** Definition 36 *)
 
 Definition Lam_Flatten
-  :  Π (C : precategory) (hs : has_homsets C)
+  :  ∏ (C : precategory) (hs : has_homsets C)
        (terminal : Terminal C)
        (CC : BinCoproducts C) (CP : BinProducts C),
-    (Π Z : precategory_Ptd C hs,
+    (∏ Z : precategory_Ptd C hs,
         GlobalRightKanExtensionExists C C (U Z) C hs hs)
-    → Π Lam_Initial : Initial (FunctorAlg (Id_H C hs CC (Lam_Sig C hs terminal CC CP))
+    → ∏ Lam_Initial : Initial (FunctorAlg (Id_H C hs CC (Lam_Sig C hs terminal CC CP))
                                           (functor_category_has_homsets C C hs)),
   [C, C, hs] ⟦ (Flat_H C hs) ` (InitialObject Lam_Initial), ` (InitialObject Lam_Initial) ⟧.
 Proof.
@@ -276,9 +276,9 @@ Defined.
 (** Lemma 37, construction of the bracket *)
 
 Definition fbracket_for_LamE_algebra_on_Lam
-  : Π (C : precategory) (hs : has_homsets C) (terminal : Terminal C)
+  : ∏ (C : precategory) (hs : has_homsets C) (terminal : Terminal C)
       (CC : BinCoproducts C) (CP : BinProducts C)
-      (KanExt : Π Z : precategory_Ptd C hs, GlobalRightKanExtensionExists C C (U Z) C hs hs)
+      (KanExt : ∏ Z : precategory_Ptd C hs, GlobalRightKanExtensionExists C C (U Z) C hs hs)
       (Lam_Initial : Initial (FunctorAlg (Id_H C hs CC (Lam_Sig C hs terminal CC CP))
                                          (functor_category_has_homsets C C hs)))
       (Z : precategory_Ptd C hs),
@@ -296,9 +296,9 @@ Defined.
 (** Morphism from initial hss to construed hss, consequence of Lemma 37 *)
 
 Definition EVAL
-  : Π (C : precategory) (hs : has_homsets C) (terminal : Terminal C)
+  : ∏ (C : precategory) (hs : has_homsets C) (terminal : Terminal C)
       (CC : BinCoproducts C) (CP : BinProducts C)
-      (KanExt : Π Z : precategory_Ptd C hs, GlobalRightKanExtensionExists C C (U Z) C hs hs)
+      (KanExt : ∏ Z : precategory_Ptd C hs, GlobalRightKanExtensionExists C C (U Z) C hs hs)
        (Lam_Initial : Initial
                         (FunctorAlg
                            (Id_H C hs CC

--- a/UniMath/SubstitutionSystems/SumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/SumOfSignatures.v
@@ -51,7 +51,7 @@ Local Notation "'CCC'" := (Coproducts_functor_precat I C C CC hsC : Coproducts I
 
 Variables H1 : I -> functor [C, C, hsC] [C, C, hsC].
 
-Variable θ1 : Π i, θ_source (H1 i) ⟶ θ_target (H1 i).
+Variable θ1 : ∏ i, θ_source (H1 i) ⟶ θ_target (H1 i).
 
 (** * Definition of the data of the sum of two signatures *)
 
@@ -78,7 +78,7 @@ apply CoproductOfArrows_eq, funextsec; intro i.
 apply (nat_trans_ax (θ1 i (X ⊗ Z))).
 Qed.
 
-Definition θ_ob : Π XF, θ_source H XF --> θ_target H XF.
+Definition θ_ob : ∏ XF, θ_source H XF --> θ_target H XF.
 Proof.
 intros [X Z]; exists (θ_ob_fun X Z); apply is_nat_trans_θ_ob_fun.
 Defined.
@@ -99,8 +99,8 @@ Local Definition θ : θ_source H ⟶ θ_target H := tpair _ _ is_nat_trans_θ_o
 
 (** * Proof of the strength laws of the sum of two signatures *)
 
-Variable S11' : Π i, θ_Strength1_int (θ1 i).
-Variable S12' : Π i, θ_Strength2_int (θ1 i).
+Variable S11' : ∏ i, θ_Strength1_int (θ1 i).
+Variable S12' : ∏ i, θ_Strength2_int (θ1 i).
 
 Lemma SumStrength1' : θ_Strength1_int θ.
 Proof.
@@ -140,7 +140,7 @@ mkpair.
 Defined.
 
 Lemma is_omega_cocont_Sum_of_Signatures (S : I -> Signature C hsC)
-  (h : Π i, is_omega_cocont (S i)) (PC : Products I C) :
+  (h : ∏ i, is_omega_cocont (S i)) (PC : Products I C) :
   is_omega_cocont (Sum_of_Signatures S).
 Proof.
 apply is_omega_cocont_coproduct_of_functors; try assumption.

--- a/UniMath/Tactics/Abmonoids_Tactics.v
+++ b/UniMath/Tactics/Abmonoids_Tactics.v
@@ -17,8 +17,8 @@ Definition abmonoid_to_absemigr (M : abmonoid) : isabsemigrop (@op M) :=
   dirprodpair (@assocax M) (@commax M).
 
 Definition absemigr_perm021 :
-  Π X : hSet, Π opp : binop X, Π is : isabsemigrop opp,
-  Π n0 n1 n2,
+  ∏ X : hSet, ∏ opp : binop X, ∏ is : isabsemigrop opp,
+  ∏ n0 n1 n2,
     opp (opp n0 n1) n2 = opp (opp n0 n2) n1 :=
   fun X opp is n0 n1 n2 =>
     pathscomp0
@@ -31,8 +31,8 @@ Definition abmonoid_perm021 :=
   fun M : abmonoid => absemigr_perm021 M (@op M) (abmonoid_to_absemigr M).
 
 Definition absemigr_perm102 :
-  Π X : hSet, Π opp : binop X, Π is : isabsemigrop opp,
-  Π n0 n1 n2,
+  ∏ X : hSet, ∏ opp : binop X, ∏ is : isabsemigrop opp,
+  ∏ n0 n1 n2,
     opp (opp n0 n1) n2 = opp (opp n1 n0) n2 :=
   fun X opp is n0 n1 n2 => maponpaths (fun z => opp z n2) ((pr2 is) n0 n1).
 
@@ -40,8 +40,8 @@ Definition abmonoid_perm102 :=
   fun M : abmonoid => absemigr_perm102 M (@op M) (abmonoid_to_absemigr M).
 
 Definition absemigr_perm120 :
-  Π X : hSet, Π opp : binop X, Π is : isabsemigrop opp,
-  Π n0 n1 n2,
+  ∏ X : hSet, ∏ opp : binop X, ∏ is : isabsemigrop opp,
+  ∏ n0 n1 n2,
     opp (opp n0 n1) n2 = opp (opp n2 n0) n1 :=
   fun X opp is n0 n1 n2 =>
     pathscomp0 ((pr2 is) (opp n0 n1) n2) (pathsinv0 ((pr1 is) n2 n0 n1)).
@@ -50,8 +50,8 @@ Definition abmonoid_perm120 :=
   fun M : abmonoid => absemigr_perm120 M (@op M) (abmonoid_to_absemigr M).
 
 Definition absemigr_perm201 :
-  Π X : hSet, Π opp : binop X, Π is : isabsemigrop opp,
-  Π n0 n1 n2,
+  ∏ X : hSet, ∏ opp : binop X, ∏ is : isabsemigrop opp,
+  ∏ n0 n1 n2,
     opp (opp n0 n1) n2 = opp (opp n1 n2) n0 :=
   fun X opp is n0 n1 n2 =>
     pathscomp0 ((pr1 is) n0 n1 n2) ((pr2 is) n0 (opp n1 n2)).
@@ -60,8 +60,8 @@ Definition abmonoid_perm201 :=
   fun M : abmonoid => absemigr_perm201 M (@op M) (abmonoid_to_absemigr M).
 
 Definition absemigr_perm210 :
-  Π X : hSet, Π opp : binop X, Π is : isabsemigrop opp,
-  Π n0 n1 n2,
+  ∏ X : hSet, ∏ opp : binop X, ∏ is : isabsemigrop opp,
+  ∏ n0 n1 n2,
     opp (opp n0 n1) n2 = opp (opp n2 n1) n0 :=
   fun X opp is n0 n1 n2 =>
     pathscomp0 (absemigr_perm102 X opp is n0 n1 n2)

--- a/UniMath/Tactics/Nat_Tactics.v
+++ b/UniMath/Tactics/Nat_Tactics.v
@@ -22,7 +22,7 @@ Definition natneqtwist n (p : ¬ (0 = n)) : ¬ (n = 0) :=
   fun f => p (pathsinv0 f).
 
 Definition nat_plus_perm021 :
-  Π n0 n1 n2,
+  ∏ n0 n1 n2,
     n0 + n1 + n2 = n0 + n2 + n1 :=
   fun n0 n1 n2 =>
     pathscomp0
@@ -32,30 +32,30 @@ Definition nat_plus_perm021 :
       (pathsinv0 (natplusassoc n0 n2 n1)).
 
 Definition nat_plus_perm102 :
-  Π n0 n1 n2,
+  ∏ n0 n1 n2,
     n0 + n1 + n2 = n1 + n0 + n2 :=
   fun n0 n1 n2 => maponpaths (fun z => z + n2) (natpluscomm n0 n1).
 
 Definition nat_plus_perm120 :
-  Π n0 n1 n2,
+  ∏ n0 n1 n2,
     n0 + n1 + n2 = n2 + n0 + n1 :=
   fun n0 n1 n2 =>
     pathscomp0 (natpluscomm (n0 + n1) n2) (pathsinv0 (natplusassoc n2 n0 n1)).
 
 Definition nat_plus_perm201 :
-  Π n0 n1 n2,
+  ∏ n0 n1 n2,
     n0 + n1 + n2 = n1 + n2 + n0 :=
   fun n0 n1 n2 =>
     pathscomp0 (natplusassoc n0 n1 n2) (natpluscomm n0 (n1 + n2)).
 
 Definition nat_plus_perm210 :
-  Π n0 n1 n2,
+  ∏ n0 n1 n2,
     n0 + n1 + n2 = n2 + n1 + n0 :=
   fun n0 n1 n2 =>
     pathscomp0 (nat_plus_perm102 n0 n1 n2) (nat_plus_perm120 n1 n0 n2).
 
 Definition nat_mult_perm021 :
-  Π n0 n1 n2,
+  ∏ n0 n1 n2,
     n0 * n1 * n2 = n0 * n2 * n1 :=
   fun n0 n1 n2 =>
     pathscomp0
@@ -65,29 +65,29 @@ Definition nat_mult_perm021 :
       (pathsinv0 (natmultassoc n0 n2 n1)).
 
 Definition nat_mult_perm102 :
-  Π n0 n1 n2,
+  ∏ n0 n1 n2,
     n0 * n1 * n2 = n1 * n0 * n2 :=
   fun n0 n1 n2 => maponpaths (fun z => z * n2) (natmultcomm n0 n1).
 
 Definition nat_mult_perm120 :
-  Π n0 n1 n2,
+  ∏ n0 n1 n2,
     n0 * n1 * n2 = n2 * n0 * n1 :=
   fun n0 n1 n2 =>
     pathscomp0 (natmultcomm (n0 * n1) n2) (pathsinv0 (natmultassoc n2 n0 n1)).
 
 Definition nat_mult_perm201 :
-  Π n0 n1 n2,
+  ∏ n0 n1 n2,
     n0 * n1 * n2 = n1 * n2 * n0 :=
   fun n0 n1 n2 =>
     pathscomp0 (natmultassoc n0 n1 n2) (natmultcomm n0 (n1 * n2)).
 
 Definition nat_mult_perm210 :
-  Π n0 n1 n2,
+  ∏ n0 n1 n2,
     n0 * n1 * n2 = n2 * n1 * n0 :=
   fun n0 n1 n2 =>
     pathscomp0 (nat_mult_perm102 n0 n1 n2) (nat_mult_perm120 n1 n0 n2).
 
-Definition minus0r : Π n, n - 0 = n :=
+Definition minus0r : ∏ n, n - 0 = n :=
   fun n => match n with
              | 0 => (idpath _)
              | S _ => (idpath _)
@@ -911,7 +911,7 @@ Ltac nat_simple :=
 Ltac nat_intros :=
   repeat match goal with
            | |- ?x -> ?y => intro
-           | |- Π _, _ => intro
+           | |- ∏ _, _ => intro
          end.
 
 Ltac nat_try :=

--- a/UniMath/Topology/Filters.v
+++ b/UniMath/Topology/Filters.v
@@ -14,7 +14,7 @@ Context {X : UU}.
 Context (F : (X → hProp) → hProp).
 
 Definition isfilter_imply :=
-  Π A B : X → hProp, (Π x : X, A x → B x) → F A → F B.
+  ∏ A B : X → hProp, (∏ x : X, A x → B x) → F A → F B.
 Lemma isaprop_isfilter_imply : isaprop isfilter_imply.
 Proof.
   apply impred_isaprop ; intro A.
@@ -25,7 +25,7 @@ Proof.
 Qed.
 
 Definition isfilter_finite_intersection :=
-  Π (L : Sequence (X → hProp)), (Π n, F (L n)) → F (finite_intersection L).
+  ∏ (L : Sequence (X → hProp)), (∏ n, F (L n)) → F (finite_intersection L).
 Lemma isaprop_isfilter_finite_intersection :
   isaprop isfilter_finite_intersection.
 Proof.
@@ -38,7 +38,7 @@ Definition isfilter_htrue : hProp :=
   F (λ _ : X, htrue).
 
 Definition isfilter_and :=
-  Π A B : X → hProp, F A → F B → F (λ x : X, A x ∧ B x).
+  ∏ A B : X → hProp, F A → F B → F (λ x : X, A x ∧ B x).
 Lemma isaprop_isfilter_and : isaprop isfilter_and.
 Proof.
   apply impred_isaprop ; intro A.
@@ -49,7 +49,7 @@ Proof.
 Qed.
 
 Definition isfilter_notempty :=
-  Π A : X → hProp, F A → ∃ x : X, A x.
+  ∏ A : X → hProp, F A → ∃ x : X, A x.
 Lemma isaprop_isfilter_notempty :
   isaprop isfilter_notempty.
 Proof.
@@ -100,7 +100,7 @@ End Filter_def.
 Definition isPreFilter {X : UU} (F : (X → hProp) → hProp) :=
   isfilter_imply F × isfilter_finite_intersection F.
 Definition PreFilter (X : UU) :=
-  Σ (F : (X → hProp) → hProp), isPreFilter F.
+  ∑ (F : (X → hProp) → hProp), isPreFilter F.
 Definition mkPreFilter {X : UU} (F : (X → hProp) → hProp)
            (Himpl : isfilter_imply F)
            (Htrue : isfilter_htrue F)
@@ -112,7 +112,7 @@ Coercion pr1PreFilter : PreFilter >-> Funclass.
 
 Definition isFilter {X : UU} (F : (X → hProp) → hProp) :=
   isPreFilter F × isfilter_notempty F.
-Definition Filter (X : UU) := Σ F : (X → hProp) → hProp, isFilter F.
+Definition Filter (X : UU) := ∑ F : (X → hProp) → hProp, isFilter F.
 Definition pr1Filter (X : UU) (F : Filter X) : PreFilter X :=
   pr1 F,, pr1 (pr2 F).
 Coercion pr1Filter : Filter >-> PreFilter.
@@ -124,7 +124,7 @@ Definition mkFilter {X : UU} (F : (X → hProp) → hProp)
   F ,, (Himp ,, (isfilter_finite_intersection_carac F Htrue Hand)) ,, Hempty.
 
 Lemma emptynofilter :
-  Π F : (empty → hProp) → hProp,
+  ∏ F : (empty → hProp) → hProp,
     ¬ isFilter F.
 Proof.
   intros F Hf.
@@ -165,7 +165,7 @@ Proof.
 Qed.
 
 Lemma filter_forall :
-  Π A : X → hProp, (Π x : X, A x) → F A.
+  ∏ A : X → hProp, (∏ x : X, A x) → F A.
 Proof.
   intros A Ha.
   generalize filter_htrue.
@@ -188,7 +188,7 @@ Proof.
 Qed.
 
 Lemma filter_const :
-  Π A : hProp, F (λ _ : X, A) → ¬ (¬ A).
+  ∏ A : hProp, F (λ _ : X, A) → ¬ (¬ A).
 Proof.
   intros A Fa Ha.
   generalize (filter_notempty _ Fa).
@@ -227,10 +227,10 @@ Qed.
 (** *** Order on filters *)
 
 Definition filter_le {X : UU} (F G : PreFilter X) :=
-  Π A : X → hProp, G A → F A.
+  ∏ A : X → hProp, G A → F A.
 
 Lemma istrans_filter_le {X : UU} :
-  Π F G H : PreFilter X,
+  ∏ F G H : PreFilter X,
     filter_le F G → filter_le G H → filter_le F H.
 Proof.
   intros X.
@@ -238,13 +238,13 @@ Proof.
   apply Hfg, Hgh, Fa.
 Qed.
 Lemma isrefl_filter_le {X : UU} :
-  Π F : PreFilter X, filter_le F F.
+  ∏ F : PreFilter X, filter_le F F.
 Proof.
   intros X F A Fa.
   exact Fa.
 Qed.
 Lemma isantisymm_filter_le {X : UU} :
-  Π F G : PreFilter X, filter_le F G → filter_le G F → F = G.
+  ∏ F G : PreFilter X, filter_le F G → filter_le G F → F = G.
 Proof.
   intros X F G Hle Hge.
   simple refine (subtypeEquality_prop (B := λ _, hProppair _ _) _).
@@ -342,7 +342,7 @@ Proof.
 Defined.
 
 Lemma PreFilterIm_incr {X Y : UU} :
-  Π (f : X → Y) (F G : PreFilter X),
+  ∏ (f : X → Y) (F G : PreFilter X),
     filter_le F G → filter_le (PreFilterIm f F) (PreFilterIm f G).
 Proof.
   intros X Y.
@@ -350,7 +350,7 @@ Proof.
   apply Hle.
 Qed.
 Lemma FilterIm_incr {X Y : UU} :
-  Π (f : X → Y) (F G : Filter X),
+  ∏ (f : X → Y) (F G : Filter X),
     filter_le F G → filter_le (FilterIm f F) (FilterIm f G).
 Proof.
   intros X Y.
@@ -364,7 +364,7 @@ Definition filterlim {X Y : UU} (f : X → Y) (F : PreFilter X) (G : PreFilter Y
   filter_le (PreFilterIm f F) G.
 
 Lemma filterlim_comp {X Y Z : UU} :
-  Π (f : X → Y) (g : Y → Z)
+  ∏ (f : X → Y) (g : Y → Z)
     (F : PreFilter X) (G : PreFilter Y) (H : PreFilter Z),
     filterlim f F G → filterlim g G H → filterlim (funcomp f g) F H.
 Proof.
@@ -376,7 +376,7 @@ Proof.
 Qed.
 
 Lemma filterlim_decr_1 {X Y : UU} :
-  Π (f : X → Y) (F F' : PreFilter X) (G : PreFilter Y),
+  ∏ (f : X → Y) (F F' : PreFilter X) (G : PreFilter Y),
     filter_le F' F → filterlim f F G → filterlim f F' G.
 Proof.
   intros X Y.
@@ -387,7 +387,7 @@ Proof.
 Qed.
 
 Lemma filterlim_incr_2 {X Y : UU} :
-  Π (f : X → Y) (F : PreFilter X) (G G' : PreFilter Y),
+  ∏ (f : X → Y) (F : PreFilter X) (G G' : PreFilter Y),
     filter_le G G' → filterlim f F G → filterlim f F G'.
 Proof.
   intros X Y.
@@ -410,7 +410,7 @@ Context (F : (X → hProp) → hProp)
         (Hand : isfilter_and F)
         (Hempty : isfilter_notempty F).
 Context (dom : X → hProp)
-        (Hdom : Π P, F P → ∃ x, dom x ∧ P x).
+        (Hdom : ∏ P, F P → ∃ x, dom x ∧ P x).
 
 Definition filterdom : (X → hProp) → hProp
   := λ A : X → hProp, F (λ x : X, hProppair (dom x → A x) (isapropimpl _ _ (propproperty _))).
@@ -470,7 +470,7 @@ Proof.
 Defined.
 
 Definition FilterDom {X : UU} (F : Filter X) (dom : X → hProp)
-           (Hdom : Π P, F P → ∃ x, dom x ∧ P x) : Filter X.
+           (Hdom : ∏ P, F P → ∃ x, dom x ∧ P x) : Filter X.
 Proof.
   intros X F dom Hdom.
   refine (tpair _ _ _).
@@ -491,11 +491,11 @@ Context (F : (X → hProp) → hProp)
         (Hand : isfilter_and F)
         (Hempty : isfilter_notempty F).
 Context (dom : X → hProp)
-        (Hdom : Π P, F P → ∃ x, dom x ∧ P x).
+        (Hdom : ∏ P, F P → ∃ x, dom x ∧ P x).
 
-Definition filtersubtype : ((Σ x : X, dom x) → hProp) → hProp :=
-  λ A : (Σ x : X, dom x) → hProp,
-        F (λ x : X, hProppair (Π Hx : dom x, A (x,, Hx)) (impred_isaprop _ (λ _, propproperty _))).
+Definition filtersubtype : ((∑ x : X, dom x) → hProp) → hProp :=
+  λ A : (∑ x : X, dom x) → hProp,
+        F (λ x : X, hProppair (∏ Hx : dom x, A (x,, Hx)) (impred_isaprop _ (λ _, propproperty _))).
 
 Lemma filtersubtype_imply :
   isfilter_imply filtersubtype.
@@ -536,7 +536,7 @@ Qed.
 
 End filtersubtype.
 
-Definition PreFilterSubtype {X : UU} (F : PreFilter X) (dom : X → hProp) : PreFilter (Σ x : X, dom x).
+Definition PreFilterSubtype {X : UU} (F : PreFilter X) (dom : X → hProp) : PreFilter (∑ x : X, dom x).
 Proof.
   intros X F dom.
   simple refine (mkPreFilter _ _ _ _).
@@ -551,7 +551,7 @@ Proof.
 Defined.
 
 Definition FilterSubtype {X : UU} (F : Filter X) (dom : X → hProp)
-           (Hdom : Π P, F P → ∃ x, dom x ∧ P x) : Filter (Σ x : X, dom x).
+           (Hdom : ∏ P, F P → ∃ x, dom x ∧ P x) : Filter (∑ x : X, dom x).
 Proof.
   intros X F dom Hdom.
   refine (tpair _ _ _).
@@ -580,7 +580,7 @@ Context (Fy : (Y → hProp) → hProp)
 Definition filterdirprod : (X × Y → hProp) → hProp :=
   λ A : (X × Y) → hProp,
         ∃ (Ax : X → hProp) (Ay : Y → hProp),
-          Fx Ax × Fy Ay × (Π (x : X) (y : Y), Ax x → Ay y → A (x,,y)).
+          Fx Ax × Fy Ay × (∏ (x : X) (y : Y), Ax x → Ay y → A (x,,y)).
 
 Lemma filterdirprod_imply :
   isfilter_imply filterdirprod.
@@ -680,7 +680,7 @@ Definition PreFilterPr2 {X Y : UU} (F : PreFilter (X × Y)) : PreFilter Y :=
 Definition FilterPr2 {X Y : UU} (F : Filter (X × Y)) : Filter Y :=
   (FilterIm (@pr2 X (λ _ : X, Y)) F).
 
-Goal Π {X Y : UU} (F : PreFilter (X × Y)),
+Goal ∏ {X Y : UU} (F : PreFilter (X × Y)),
     filter_le F (PreFilterDirprod (PreFilterPr1 F) (PreFilterPr2 F)).
 Proof.
   intros X Y F.
@@ -699,7 +699,7 @@ Proof.
   exact (pr2 Fxy).
 Qed.
 
-Goal Π {X Y : UU} (F : PreFilter X) (G : PreFilter Y),
+Goal ∏ {X Y : UU} (F : PreFilter X) (G : PreFilter Y),
     filter_le (PreFilterPr1 (PreFilterDirprod F G)) F.
 Proof.
   intros X Y F G.
@@ -711,7 +711,7 @@ Proof.
   - now apply filter_htrue.
   - easy.
 Qed.
-Goal Π {X Y : UU} (F : PreFilter X) (G : PreFilter Y),
+Goal ∏ {X Y : UU} (F : PreFilter X) (G : PreFilter Y),
     filter_le (PreFilterPr2 (PreFilterDirprod F G)) G.
 Proof.
   intros X Y F G.
@@ -731,7 +731,7 @@ Qed.
 Section filternat.
 
 Definition filternat : (nat → hProp) → hProp :=
-  λ P : nat → hProp, ∃ N : nat, Π n : nat, N ≤ n → P n.
+  λ P : nat → hProp, ∃ N : nat, ∏ n : nat, N ≤ n → P n.
 
 Lemma filternat_imply :
   isfilter_imply filternat.
@@ -795,7 +795,7 @@ Section filtertop.
 Context  {X : UU} (x0 : ∥ X ∥).
 
 Definition filtertop : (X → hProp) → hProp :=
-  λ A : X → hProp, hProppair (Π x : X, A x) (impred_isaprop _ (λ _, propproperty _)).
+  λ A : X → hProp, hProppair (∏ x : X, A x) (impred_isaprop _ (λ _, propproperty _)).
 
 Lemma filtertop_imply :
   isfilter_imply filtertop.
@@ -851,13 +851,13 @@ Proof.
 Defined.
 
 Lemma PreFilterTop_correct {X : UU} :
-  Π (F : PreFilter X), filter_le F PreFilterTop.
+  ∏ (F : PreFilter X), filter_le F PreFilterTop.
 Proof.
   intros X F A Ha.
   apply filter_forall, Ha.
 Qed.
 Lemma FilterTop_correct {X : UU} :
-  Π (x0 : ∥ X ∥) (F : Filter X), filter_le F (FilterTop x0).
+  ∏ (x0 : ∥ X ∥) (F : Filter X), filter_le F (FilterTop x0).
 Proof.
   intros X x0 F A Ha.
   apply PreFilterTop_correct, Ha.
@@ -869,15 +869,15 @@ Section filterintersection.
 
 Context {X : UU}.
 Context (is : ((X → hProp) → hProp) → UU).
-Context (FF : (Σ F : ((X → hProp) → hProp), is F) → hProp)
-        (Himp : Π F, FF F → isfilter_imply (pr1 F))
-        (Htrue : Π F, FF F → isfilter_htrue (pr1 F))
-        (Hand : Π F, FF F → isfilter_and (pr1 F))
-        (Hempty : Π F, FF F → isfilter_notempty (pr1 F)).
+Context (FF : (∑ F : ((X → hProp) → hProp), is F) → hProp)
+        (Himp : ∏ F, FF F → isfilter_imply (pr1 F))
+        (Htrue : ∏ F, FF F → isfilter_htrue (pr1 F))
+        (Hand : ∏ F, FF F → isfilter_and (pr1 F))
+        (Hempty : ∏ F, FF F → isfilter_notempty (pr1 F)).
 Context (His : ∃ F, FF F).
 
 Definition filterintersection : (X → hProp) → hProp :=
-  λ A : X → hProp, hProppair (Π F, FF F → (pr1 F) A)
+  λ A : X → hProp, hProppair (∏ F, FF F → (pr1 F) A)
                              (impred_isaprop _ (λ _, isapropimpl _ _ (propproperty _))).
 
 Lemma filterintersection_imply :
@@ -956,8 +956,8 @@ Proof.
 Defined.
 
 Lemma PreFilterIntersection_glb {X : UU} (FF : PreFilter X → hProp) :
-  (Π F : PreFilter X, FF F → filter_le F (PreFilterIntersection FF))
-    × (Π F : PreFilter X, (Π G : PreFilter X, FF G → filter_le G F)
+  (∏ F : PreFilter X, FF F → filter_le F (PreFilterIntersection FF))
+    × (∏ F : PreFilter X, (∏ G : PreFilter X, FF G → filter_le G F)
                           → filter_le (PreFilterIntersection FF) F).
 Proof.
   split.
@@ -968,8 +968,8 @@ Proof.
     apply Fa.
 Qed.
 Lemma FilterIntersection_glb {X : UU} (FF : Filter X → hProp) Hff :
-  (Π F : Filter X, FF F → filter_le F (FilterIntersection FF Hff))
-    × (Π F : Filter X, (Π G : Filter X, FF G → filter_le G F)
+  (∏ F : Filter X, FF F → filter_le F (FilterIntersection FF Hff))
+    × (∏ F : Filter X, (∏ G : Filter X, FF G → filter_le G F)
                        → filter_le (FilterIntersection FF Hff) F).
 Proof.
   split.
@@ -986,11 +986,11 @@ Section filtergenerated.
 
 Context {X : UU}.
 Context (L : (X → hProp) → hProp).
-Context (Hl : Π (L' : Sequence (X → hProp)), (Π m, L (L' m)) → ∃ x : X, Π m, L' m x).
+Context (Hl : ∏ (L' : Sequence (X → hProp)), (∏ m, L (L' m)) → ∃ x : X, ∏ m, L' m x).
 
 Definition filtergenerated : (X → hProp) → hProp :=
   λ A : X → hProp,
-        ∃ (L' : Sequence (X → hProp)), (Π m, L (L' m)) × (Π x : X, finite_intersection L' x → A x).
+        ∃ (L' : Sequence (X → hProp)), (∏ m, L (L' m)) × (∏ x : X, finite_intersection L' x → A x).
 
 Lemma filtergenerated_imply :
   isfilter_imply filtergenerated.
@@ -1068,8 +1068,8 @@ Proof.
 Defined.
 
 Definition FilterGenerated {X : UU} (L : (X → hProp) → hProp)
-           (Hl : Π L' : Sequence (X → hProp),
-  (Π m : stn (length L'), L (L' m)) → ∃ x : X, finite_intersection L' x) : Filter X.
+           (Hl : ∏ L' : Sequence (X → hProp),
+  (∏ m : stn (length L'), L (L' m)) → ∃ x : X, finite_intersection L' x) : Filter X.
 Proof.
   intros X L Hl.
   exists (PreFilterGenerated L).
@@ -1080,10 +1080,10 @@ Proof.
 Defined.
 
 Lemma PreFilterGenerated_correct {X : UU} :
-   Π (L : (X → hProp) → hProp),
-   (Π A : X → hProp, L A → (PreFilterGenerated L) A)
-   × (Π F : PreFilter X,
-      (Π A : X → hProp, L A → F A) → filter_le F (PreFilterGenerated L)).
+   ∏ (L : (X → hProp) → hProp),
+   (∏ A : X → hProp, L A → (PreFilterGenerated L) A)
+   × (∏ F : PreFilter X,
+      (∏ A : X → hProp, L A → F A) → filter_le F (PreFilterGenerated L)).
 Proof.
   intros X L.
   split.
@@ -1105,13 +1105,13 @@ Proof.
     apply (pr1 (pr2 Ha)).
 Qed.
 Lemma FilterGenerated_correct {X : UU} :
-   Π (L : (X → hProp) → hProp)
-   (Hl : Π L' : Sequence (X → hProp),
-         (Π m, L (L' m)) →
+   ∏ (L : (X → hProp) → hProp)
+   (Hl : ∏ L' : Sequence (X → hProp),
+         (∏ m, L (L' m)) →
          (∃ x : X, finite_intersection L' x)),
-   (Π A : X → hProp, L A → (FilterGenerated L Hl) A)
-   × (Π F : Filter X,
-      (Π A : X → hProp, L A → F A) → filter_le F (FilterGenerated L Hl)).
+   (∏ A : X → hProp, L A → (FilterGenerated L Hl) A)
+   × (∏ F : Filter X,
+      (∏ A : X → hProp, L A → F A) → filter_le F (FilterGenerated L Hl)).
 Proof.
   intros X L Hl.
   split.
@@ -1134,10 +1134,10 @@ Proof.
 Qed.
 
 Lemma FilterGenerated_inv {X : UU} :
-   Π (L : (X → hProp) → hProp) (F : Filter X),
-   (Π A : X → hProp, L A → F A) →
-   Π (L' : Sequence (X → hProp)),
-   (Π m, L (L' m)) →
+   ∏ (L : (X → hProp) → hProp) (F : Filter X),
+   (∏ A : X → hProp, L A → F A) →
+   ∏ (L' : Sequence (X → hProp)),
+   (∏ m, L (L' m)) →
    (∃ x : X, finite_intersection L' x).
 Proof.
   intros X.
@@ -1149,9 +1149,9 @@ Proof.
 Qed.
 
 Lemma ex_filter_le {X : UU} :
-  Π (F : Filter X) (A : X → hProp),
-    (Σ G : Filter X, filter_le G F × G A)
-    <-> (Π B : X → hProp, F B → (∃ x : X, A x ∧ B x)).
+  ∏ (F : Filter X) (A : X → hProp),
+    (∑ G : Filter X, filter_le G F × G A)
+    <-> (∏ B : X → hProp, F B → (∃ x : X, A x ∧ B x)).
 Proof.
   intros X.
   intros F A.
@@ -1167,12 +1167,12 @@ Proof.
     + intros B.
       apply (F B ∨ B = A).
     + intros L Hl.
-      assert (B : ∃ B : X → hProp, F B × (Π x, (A x ∧ B x → A x ∧ finite_intersection L x))).
+      assert (B : ∃ B : X → hProp, F B × (∏ x, (A x ∧ B x → A x ∧ finite_intersection L x))).
       { revert L Hl.
         apply (Sequence_rect (P := λ L : Sequence (X → hProp),
-                                    (Π m : stn (length L), (λ B : X → hProp, F B ∨ B = A) (L m)) →
+                                    (∏ m : stn (length L), (λ B : X → hProp, F B ∨ B = A) (L m)) →
                                     ∃ B : X → hProp,
-                                      F B × (Π x : X, A x ∧ B x → A x ∧ finite_intersection L x))).
+                                      F B × (∏ x : X, A x ∧ B x → A x ∧ finite_intersection L x))).
         - intros Hl.
           apply hinhpr.
           rewrite finite_intersection_htrue.
@@ -1248,11 +1248,11 @@ Context {X : UU}.
 Context (base : (X → hProp) → hProp).
 
 Definition isbase_and :=
-  Π A B : X → hProp, base A → base B → ∃ C : X → hProp, base C × (Π x, C x → A x ∧ B x).
+  ∏ A B : X → hProp, base A → base B → ∃ C : X → hProp, base C × (∏ x, C x → A x ∧ B x).
 Definition isbase_notempty :=
   ∃ A : X → hProp, base A.
 Definition isbase_notfalse :=
-  Π A, base A → ∃ x, A x.
+  ∏ A, base A → ∃ x, A x.
 
 Definition isBaseOfPreFilter :=
   isbase_and × isbase_notempty.
@@ -1262,12 +1262,12 @@ Definition isBaseOfFilter :=
 End base.
 
 Definition BaseOfPreFilter (X : UU) :=
-  Σ (base : (X → hProp) → hProp), isBaseOfPreFilter base.
+  ∑ (base : (X → hProp) → hProp), isBaseOfPreFilter base.
 Definition pr1BaseOfPreFilter {X : UU} : BaseOfPreFilter X → ((X → hProp) → hProp) := pr1.
 Coercion pr1BaseOfPreFilter : BaseOfPreFilter >-> Funclass.
 
 Definition BaseOfFilter (X : UU) :=
-  Σ (base : (X → hProp) → hProp), isBaseOfFilter base.
+  ∑ (base : (X → hProp) → hProp), isBaseOfFilter base.
 Definition pr1BaseOfFilter {X : UU} : BaseOfFilter X → BaseOfPreFilter X.
 Proof.
   intros X base.
@@ -1279,7 +1279,7 @@ Defined.
 Coercion pr1BaseOfFilter : BaseOfFilter >-> BaseOfPreFilter.
 
   Lemma BaseOfPreFilter_and {X : UU} (base : BaseOfPreFilter X) :
-  Π A B : X → hProp, base A → base B → ∃ C : X → hProp, base C × (Π x, C x → A x ∧ B x).
+  ∏ A B : X → hProp, base A → base B → ∃ C : X → hProp, base C × (∏ x, C x → A x ∧ B x).
 Proof.
   intros X base.
   apply (pr1 (pr2 base)).
@@ -1292,7 +1292,7 @@ Proof.
 Qed.
 
 Lemma BaseOfFilter_and {X : UU} (base : BaseOfFilter X) :
-  Π A B : X → hProp, base A → base B → ∃ C : X → hProp, base C × (Π x, C x → A x ∧ B x).
+  ∏ A B : X → hProp, base A → base B → ∃ C : X → hProp, base C × (∏ x, C x → A x ∧ B x).
 Proof.
   intros X base.
   apply (pr1 (pr2 base)).
@@ -1304,7 +1304,7 @@ Proof.
   apply (pr1 (pr2 (pr2 base))).
 Qed.
 Lemma BaseOfFilter_notfalse {X : UU} (base : BaseOfFilter X) :
-  Π A, base A → ∃ x, A x.
+  ∏ A, base A → ∃ x, A x.
 Proof.
   intros X base.
   apply (pr2 (pr2 (pr2 base))).
@@ -1319,7 +1319,7 @@ Context (base : (X → hProp) → hProp)
         (Hfalse : isbase_notfalse base).
 
 Definition filterbase : (X → hProp) → hProp :=
-  λ A : X → hProp, (∃ B : X → hProp, base B × Π x, B x → A x).
+  λ A : X → hProp, (∃ B : X → hProp, base B × ∏ x, B x → A x).
 
 Lemma filterbase_imply :
   isfilter_imply filterbase.
@@ -1379,11 +1379,11 @@ Proof.
 Qed.
 
 Lemma base_finite_intersection :
-  Π L : Sequence (X → hProp),
-    (Π n, base (L n)) → ∃ A, base A × (Π x, A x → finite_intersection L x).
+  ∏ L : Sequence (X → hProp),
+    (∏ n, base (L n)) → ∃ A, base A × (∏ x, A x → finite_intersection L x).
 Proof.
   intros L Hbase.
-  apply (pr2 (finite_intersection_hProp (λ B, ∃ A : X → hProp, base A × (Π x : X, A x → B x)))).
+  apply (pr2 (finite_intersection_hProp (λ B, ∃ A : X → hProp, base A × (∏ x : X, A x → B x)))).
   split.
   - revert Hempty.
     apply hinhfun.
@@ -1437,8 +1437,8 @@ Proof.
 Qed.
 
 Lemma filterbase_generated_hypothesis :
-  Π L' : Sequence (X → hProp),
-    (Π m : stn (length L'), base (L' m))
+  ∏ L' : Sequence (X → hProp),
+    (∏ m : stn (length L'), base (L' m))
     → ∃ x : X, finite_intersection L' x.
 Proof.
   intros L Hbase.
@@ -1513,8 +1513,8 @@ Proof.
 Qed.
 
 Lemma FilterBase_Generated_hypothesis {X : UU} (base : BaseOfFilter X) :
-  Π L' : Sequence (X → hProp),
-    (Π m : stn (length L'), base (L' m))
+  ∏ L' : Sequence (X → hProp),
+    (∏ m : stn (length L'), base (L' m))
     → ∃ x : X, finite_intersection L' x.
 Proof.
   intros X base.
@@ -1527,8 +1527,8 @@ Proof.
 Qed.
 
 Lemma filterbase_le {X : UU} (base base' : (X → hProp) → hProp) :
-  (Π P : X → hProp, base P → ∃ Q : X → hProp, base' Q × (Π x, Q x → P x))
-  <-> (Π P : X → hProp, filterbase base P → filterbase base' P).
+  (∏ P : X → hProp, base P → ∃ Q : X → hProp, base' Q × (∏ x, Q x → P x))
+  <-> (∏ P : X → hProp, filterbase base P → filterbase base' P).
 Proof.
   intros X base base'.
   split.
@@ -1550,7 +1550,7 @@ Proof.
 Qed.
 
 Lemma PreFilterBase_le {X : UU} (base base' : BaseOfPreFilter X) :
-  (Π P : X → hProp, base P → ∃ Q : X → hProp, base' Q × (Π x, Q x → P x))
+  (∏ P : X → hProp, base P → ∃ Q : X → hProp, base' Q × (∏ x, Q x → P x))
   <-> filter_le (PreFilterBase base') (PreFilterBase base).
 Proof.
   intros X base base'.
@@ -1560,7 +1560,7 @@ Proof.
   - apply (pr2 (filterbase_le base base')).
 Qed.
 Lemma FilterBase_le {X : UU} (base base' : BaseOfFilter X) :
-  (Π P : X → hProp, base P → ∃ Q : X → hProp, base' Q × (Π x, Q x → P x))
+  (∏ P : X → hProp, base P → ∃ Q : X → hProp, base' Q × (∏ x, Q x → P x))
   <-> filter_le (FilterBase base') (FilterBase base).
 Proof.
   intros X base base'.

--- a/UniMath/Topology/Prelim.v
+++ b/UniMath/Topology/Prelim.v
@@ -12,8 +12,8 @@ Unset Automatic Introduction. (* This line has to be removed for the file to com
 Lemma isaproptotal2' {X : UU} (P : X → UU) :
   isaset X →
   isPredicate P →
-  (Π x y : X, P x → P y → x = y) →
-  isaprop (Σ x : X, P x).
+  (∏ x y : X, P x → P y → x = y) →
+  isaprop (∑ x : X, P x).
 Proof.
   intros X P HX HP Heq x y ; simpl.
   eapply iscontrweqb.
@@ -67,7 +67,7 @@ Ltac apply_pr2_in T H :=
 
 (** ** About nat *)
 
-Lemma max_le_l : Π n m : nat, (n ≤ max n m)%nat.
+Lemma max_le_l : ∏ n m : nat, (n ≤ max n m)%nat.
 Proof.
   induction n as [ | n IHn] ; simpl max.
   - intros m ; reflexivity.
@@ -75,7 +75,7 @@ Proof.
     + now apply isreflnatleh.
     + now apply IHn.
 Qed.
-Lemma max_le_r : Π n m : nat, (m ≤ max n m)%nat.
+Lemma max_le_r : ∏ n m : nat, (m ≤ max n m)%nat.
 Proof.
   induction n as [ | n IHn] ; simpl max.
   - intros m ; now apply isreflnatleh.
@@ -117,7 +117,7 @@ Proof.
 Qed.
 
 Lemma union_or {X : UU} :
-  Π A B : X → hProp,
+  ∏ A B : X → hProp,
     union (λ C : X → hProp, C = A ∨ C = B)
     = (λ x : X, A x ∨ B x).
 Proof.
@@ -151,9 +151,9 @@ Proof.
 Qed.
 
 Lemma union_hProp {X : UU} :
-  Π (P : (X → hProp) → hProp),
-    (Π (L : (X → hProp) → hProp), (Π A, L A → P A) → P (union L))
-    → (Π A B, P A → P B → P (λ x : X, A x ∨ B x)).
+  ∏ (P : (X → hProp) → hProp),
+    (∏ (L : (X → hProp) → hProp), (∏ A, L A → P A) → P (union L))
+    → (∏ A B, P A → P B → P (λ x : X, A x ∨ B x)).
 Proof.
   intros X.
   intros P Hp A B Pa Pb.
@@ -171,7 +171,7 @@ Proof.
   intros X P.
   intros x.
   simple refine (hProppair _ _).
-  apply (Π n, P n x).
+  apply (∏ n, P n x).
   apply (impred_isaprop _ (λ _, propproperty _)).
 Defined.
 
@@ -193,7 +193,7 @@ Proof.
 Qed.
 
 Lemma finite_intersection_1 {X : UU} :
-  Π (A : X → hProp),
+  ∏ (A : X → hProp),
     finite_intersection (singletonSequence A) = A.
 Proof.
   intros X.
@@ -208,7 +208,7 @@ Proof.
 Qed.
 
 Lemma finite_intersection_and {X : UU} :
-  Π A B : X → hProp,
+  ∏ A B : X → hProp,
     finite_intersection (pairSequence A B)
     = (λ x : X, A x ∧ B x).
 Proof.
@@ -232,7 +232,7 @@ Proof.
 Qed.
 
 Lemma finite_intersection_case {X : UU} :
-  Π (L : Sequence (X → hProp)),
+  ∏ (L : Sequence (X → hProp)),
   finite_intersection L =
   sumofmaps (λ _ _, htrue)
             (λ (AB : (X → hProp) × Sequence (X → hProp)) (x : X), pr1 AB x ∧ finite_intersection (pr2 AB) x)
@@ -272,7 +272,7 @@ Proof.
       exact (pr1 Hx).
 Qed.
 Lemma finite_intersection_append {X : UU} :
-  Π (A : X → hProp) (L : Sequence (X → hProp)),
+  ∏ (A : X → hProp) (L : Sequence (X → hProp)),
     finite_intersection (append L A) = (λ x : X, A x ∧ finite_intersection L x).
 Proof.
   intros X A L.
@@ -290,9 +290,9 @@ Proof.
 Qed.
 
 Lemma finite_intersection_hProp {X : UU} :
-  Π (P : (X → hProp) → hProp),
-    (Π (L : Sequence (X → hProp)), (Π n, P (L n)) → P (finite_intersection L))
-    <-> (P (λ _, htrue) × (Π A B, P A → P B → P (λ x : X, A x ∧ B x))).
+  ∏ (P : (X → hProp) → hProp),
+    (∏ (L : Sequence (X → hProp)), (∏ n, P (L n)) → P (finite_intersection L))
+    <-> (P (λ _, htrue) × (∏ A B, P A → P B → P (λ x : X, A x ∧ B x))).
 Proof.
   intros X P.
   split.
@@ -312,7 +312,7 @@ Proof.
       now induction n as [ | n _] ; simpl.
   - intros Hp.
     apply (Sequence_rect (P := λ L : Sequence (X → hProp),
-                                     (Π n : stn (length L), P (L n)) → P (finite_intersection L))).
+                                     (∏ n : stn (length L), P (L n)) → P (finite_intersection L))).
     + intros _.
       rewrite finite_intersection_htrue.
       exact (pr1 Hp).

--- a/UniMath/Topology/Topology.v
+++ b/UniMath/Topology/Topology.v
@@ -12,15 +12,15 @@ Context {X : UU}.
 Context (O : (X → hProp) → hProp).
 
 Definition isSetOfOpen_union :=
-  Π P : (X → hProp) → hProp,
-    (Π A : X → hProp, P A → O A) → O (union P).
+  ∏ P : (X → hProp) → hProp,
+    (∏ A : X → hProp, P A → O A) → O (union P).
 Lemma isaprop_isSetOfOpen_union :
   isaprop isSetOfOpen_union.
 Proof.
   apply (impred_isaprop _ (λ _, isapropimpl _ _ (propproperty _))).
 Qed.
 Definition isSetOfOpen_finite_intersection :=
-  Π (P : Sequence (X → hProp)), (Π m, O (P m)) → O (finite_intersection P).
+  ∏ (P : Sequence (X → hProp)), (∏ m, O (P m)) → O (finite_intersection P).
 Lemma isaprop_isSetOfOpen_finite_intersection :
   isaprop isSetOfOpen_finite_intersection.
 Proof.
@@ -31,7 +31,7 @@ Definition isSetOfOpen_htrue :=
   O (λ _, htrue).
 
 Definition isSetOfOpen_and :=
-  Π A B, O A → O B → O (λ x, A x ∧ B x).
+  ∏ A B, O A → O B → O (λ x, A x ∧ B x).
 Lemma isaprop_isSetOfOpen_and :
   isaprop isSetOfOpen_and.
 Proof.
@@ -92,8 +92,8 @@ Definition isSetOfOpen :=
 End Open.
 
 Definition isTopologicalSet (X : UU) :=
-  Σ O : (X → hProp) → hProp, isSetOfOpen O.
-Definition TopologicalSet := Σ X : UU, isTopologicalSet X.
+  ∑ O : (X → hProp) → hProp, isSetOfOpen O.
+Definition TopologicalSet := ∑ X : UU, isTopologicalSet X.
 
 Definition mkTopologicalSet (X : UU) (O : (X → hProp) → hProp)
            (is : isSetOfOpen_union O)
@@ -106,7 +106,7 @@ Coercion pr1TopologicatSet : TopologicalSet >-> UU.
 
 Definition isOpen {T : TopologicalSet} : (T → hProp) → hProp := pr1 (pr2 T).
 Definition Open {T : TopologicalSet} :=
-  Σ O : T → hProp, isOpen O.
+  ∑ O : T → hProp, isOpen O.
 Definition pr1Open {T : TopologicalSet} : Open → (T → hProp) := pr1.
 Coercion pr1Open : Open >-> Funclass.
 
@@ -115,15 +115,15 @@ Section Topology_pty.
 Context {T : TopologicalSet}.
 
 Lemma isOpen_union :
-  Π P : (T → hProp) → hProp,
-    (Π A : T → hProp, P A → isOpen A)
+  ∏ P : (T → hProp) → hProp,
+    (∏ A : T → hProp, P A → isOpen A)
     → isOpen (union P).
 Proof.
   apply (pr1 (pr2 (pr2 T))).
 Qed.
 Lemma isOpen_finite_intersection :
-  Π (P : Sequence (T → hProp)),
-    (Π m , isOpen (P m))
+  ∏ (P : Sequence (T → hProp)),
+    (∏ m , isOpen (P m))
     → isOpen (finite_intersection P).
 Proof.
   apply (pr2 (pr2 (pr2 T))).
@@ -145,7 +145,7 @@ Proof.
   now generalize (pr2 m).
 Qed.
 Lemma isOpen_and :
-  Π A B : T → hProp,
+  ∏ A B : T → hProp,
     isOpen A → isOpen B → isOpen (λ x : T, A x ∧ B x).
 Proof.
   apply isSetOfOpen_finite_intersection_and.
@@ -154,7 +154,7 @@ Proof.
   apply Hp.
 Qed.
 Lemma isOpen_or :
-  Π A B : T → hProp,
+  ∏ A B : T → hProp,
     isOpen A → isOpen B → isOpen (λ x : T, A x ∨ B x).
 Proof.
   intros A B Ha Hb.
@@ -176,20 +176,20 @@ Section Neighborhood.
 Context {T : TopologicalSet}.
 
 Definition neighborhood (x : T) : (T → hProp) → hProp :=
-  λ P : T → hProp, ∃ O : Open, O x × (Π y : T, O y → P y).
+  λ P : T → hProp, ∃ O : Open, O x × (∏ y : T, O y → P y).
 
 Lemma neighborhood_isOpen (P : T → hProp) :
-  (Π x, P x → neighborhood x P) <-> isOpen P.
+  (∏ x, P x → neighborhood x P) <-> isOpen P.
 Proof.
   split.
   - intros Hp.
-    assert (H : Π A : T → hProp, isaprop (Π y : T, A y → P y)).
+    assert (H : ∏ A : T → hProp, isaprop (∏ y : T, A y → P y)).
     { intros A.
       apply impred_isaprop.
       intro y.
       apply isapropimpl.
       apply propproperty. }
-    set (Q := λ A : T → hProp, isOpen A ∧ (hProppair (Π y : T, A y → P y) (H A))).
+    set (Q := λ A : T → hProp, isOpen A ∧ (hProppair (∏ y : T, A y → P y) (H A))).
     assert (P = (union Q)).
     { apply funextfun.
       intros x.
@@ -221,8 +221,8 @@ Proof.
 Qed.
 
 Lemma neighborhood_imply :
-  Π (x : T) (P Q : T → hProp),
-    (Π y : T, P y → Q y) → neighborhood x P → neighborhood x Q.
+  ∏ (x : T) (P Q : T → hProp),
+    (∏ y : T, P y → Q y) → neighborhood x P → neighborhood x Q.
 Proof.
   intros x P Q H.
   apply hinhfun.
@@ -236,8 +236,8 @@ Proof.
     exact Hy.
 Qed.
 Lemma neighborhood_forall :
-  Π (x : T) (P : T → hProp),
-    (Π y, P y) → neighborhood x P.
+  ∏ (x : T) (P : T → hProp),
+    (∏ y, P y) → neighborhood x P.
 Proof.
   intros x P H.
   apply hinhpr.
@@ -248,7 +248,7 @@ Proof.
   now apply H.
 Qed.
 Lemma neighborhood_and :
-  Π (x : T) (A B : T → hProp),
+  ∏ (x : T) (A B : T → hProp),
     neighborhood x A → neighborhood x B → neighborhood x (λ y, A y ∧ B y).
 Proof.
   intros x A B.
@@ -268,7 +268,7 @@ Proof.
       apply (pr2 Hy).
 Qed.
 Lemma neighborhood_point :
-  Π (x : T) (P : T → hProp),
+  ∏ (x : T) (P : T → hProp),
     neighborhood x P → P x.
 Proof.
   intros x P.
@@ -279,10 +279,10 @@ Proof.
 Qed.
 
 Lemma neighborhood_neighborhood :
-  Π (x : T) (P : T → hProp),
+  ∏ (x : T) (P : T → hProp),
     neighborhood x P
     → ∃ Q : T → hProp, neighborhood x Q
-                        × Π y : T, Q y → neighborhood y P.
+                        × ∏ y : T, Q y → neighborhood y P.
 Proof.
   intros x P.
   apply hinhfun.
@@ -323,11 +323,11 @@ Defined.
 (** ** Base of Neighborhood *)
 
 Definition is_base_of_neighborhood {T : TopologicalSet} (x : T) (B : (T → hProp) → hProp) :=
-  (Π P : T → hProp, B P → neighborhood x P)
-    × (Π P : T → hProp, neighborhood x P → ∃ Q : T → hProp, B Q × (Π t : T, Q t → P t)).
+  (∏ P : T → hProp, B P → neighborhood x P)
+    × (∏ P : T → hProp, neighborhood x P → ∃ Q : T → hProp, B Q × (∏ t : T, Q t → P t)).
 
 Definition base_of_neighborhood {T : TopologicalSet} (x : T) :=
-  Σ (B : (T → hProp) → hProp), is_base_of_neighborhood x B.
+  ∑ (B : (T → hProp) → hProp), is_base_of_neighborhood x B.
 Definition pr1base_of_neighborhood {T : TopologicalSet} (x : T) :
   base_of_neighborhood x → ((T → hProp) → hProp) := pr1.
 Coercion pr1base_of_neighborhood : base_of_neighborhood >-> Funclass.
@@ -340,7 +340,7 @@ Definition base_default : (T → hProp) → hProp :=
   λ P : T → hProp, isOpen P ∧ P x.
 
 Lemma base_default_1 :
-  Π P : T → hProp, base_default P → neighborhood x P.
+  ∏ P : T → hProp, base_default P → neighborhood x P.
 Proof.
   intros P Hp.
   apply hinhpr.
@@ -349,7 +349,7 @@ Proof.
   easy.
 Qed.
 Lemma base_default_2 :
-  Π P : T → hProp, neighborhood x P → ∃ Q : T → hProp, base_default Q × (Π t : T, Q t → P t).
+  ∏ P : T → hProp, neighborhood x P → ∃ Q : T → hProp, base_default Q × (∏ t : T, Q t → P t).
 Proof.
   intros P.
   apply hinhfun.
@@ -373,10 +373,10 @@ Proof.
 Defined.
 
 Definition neighborhood' {T : TopologicalSet} (x : T) (B : base_of_neighborhood x) : (T → hProp) → hProp :=
-  λ P : T → hProp, ∃ O : T → hProp, B O × (Π t : T, O t → P t).
+  λ P : T → hProp, ∃ O : T → hProp, B O × (∏ t : T, O t → P t).
 
 Lemma neighborhood_equiv {T : TopologicalSet} (x : T) (B : base_of_neighborhood x) :
-  Π P, neighborhood' x B P <-> neighborhood x P.
+  ∏ P, neighborhood' x B P <-> neighborhood x P.
 Proof.
   intros T x B P.
   split.
@@ -398,11 +398,11 @@ Qed.
 (** *** Topology from neighborhood *)
 
 Definition isNeighborhood {X : UU} (B : X → (X → hProp) → hProp) :=
-  (Π x, isfilter_imply (B x))
-    × (Π x, isfilter_htrue (B x))
-    × (Π x, isfilter_and (B x))
-    × (Π x P, B x P → P x)
-    × (Π x P, B x P → ∃ Q, B x Q × Π y, Q y → B y P).
+  (∏ x, isfilter_imply (B x))
+    × (∏ x, isfilter_htrue (B x))
+    × (∏ x, isfilter_and (B x))
+    × (∏ x P, B x P → P x)
+    × (∏ x P, B x P → ∃ Q, B x Q × ∏ y, Q y → B y P).
 
 Lemma isNeighborhood_neighborhood {T : TopologicalSet} :
   isNeighborhood (neighborhood (T := T)).
@@ -427,16 +427,16 @@ Section TopologyFromNeighborhood.
 
 Context {X : UU}.
 Context (N : X → (X → hProp) → hProp).
-Context (Himpl : Π x, isfilter_imply (N x))
-        (Htrue : Π x, isfilter_htrue (N x))
-        (Hand : Π x, isfilter_and (N x))
-        (Hpt : Π x P, N x P → P x)
-        (H : Π x P, N x P → ∃ Q, N x Q × Π y, Q y → N y P).
+Context (Himpl : ∏ x, isfilter_imply (N x))
+        (Htrue : ∏ x, isfilter_htrue (N x))
+        (Hand : ∏ x, isfilter_and (N x))
+        (Hpt : ∏ x P, N x P → P x)
+        (H : ∏ x P, N x P → ∃ Q, N x Q × ∏ y, Q y → N y P).
 
 Definition topologyfromneighborhood (A : X → hProp) :=
-  Π x : X, A x → N x A.
+  ∏ x : X, A x → N x A.
 Lemma isaprop_topologyfromneighborhood :
-  Π A, isaprop (topologyfromneighborhood A).
+  ∏ A, isaprop (topologyfromneighborhood A).
 Proof.
   intros A.
   apply impred_isaprop ; intros x ;
@@ -483,7 +483,7 @@ Proof.
 Defined.
 
 Lemma TopologyFromNeighborhood_correct {X : UU} (N : X → (X → hProp) → hProp) (H : isNeighborhood N) :
-  Π (x : X) (P : X → hProp),
+  ∏ (x : X) (P : X → hProp),
     N x P <-> neighborhood (T := TopologyFromNeighborhood N H) x P.
 Proof.
   intros X N H.
@@ -514,7 +514,7 @@ Proof.
 Qed.
 
 Lemma isNeighborhood_isPreFilter {X : UU} N :
-  isNeighborhood N -> Π x : X, isPreFilter (N x).
+  isNeighborhood N -> ∏ x : X, isPreFilter (N x).
 Proof.
   intros X N Hn x.
   split.
@@ -524,7 +524,7 @@ Proof.
     + apply (pr1 (pr2 (pr2 Hn))).
 Qed.
 Lemma isNeighborhood_isFilter {X : UU} N :
-  isNeighborhood N -> Π x : X, isFilter (N x).
+  isNeighborhood N -> ∏ x : X, isFilter (N x).
 Proof.
   intros X N Hn x.
   split.
@@ -543,10 +543,10 @@ Context {X : UU} (O : (X → hProp) → hProp).
 
 Definition topologygenerated :=
   λ (x : X) (A : X → hProp),
-  (∃ L : Sequence (X → hProp), (Π n, O (L n)) × (finite_intersection L x) × (Π y, finite_intersection L y → A y)).
+  (∃ L : Sequence (X → hProp), (∏ n, O (L n)) × (finite_intersection L x) × (∏ y, finite_intersection L y → A y)).
 
 Lemma topologygenerated_imply :
-  Π x : X, isfilter_imply (topologygenerated x).
+  ∏ x : X, isfilter_imply (topologygenerated x).
 Proof.
   intros x A B H.
   apply hinhfun.
@@ -560,7 +560,7 @@ Proof.
 Qed.
 
 Lemma topologygenerated_htrue :
-  Π x : X, isfilter_htrue (topologygenerated x).
+  ∏ x : X, isfilter_htrue (topologygenerated x).
 Proof.
   intros x.
   apply hinhpr.
@@ -573,7 +573,7 @@ Proof.
 Qed.
 
 Lemma topologygenerated_and :
-  Π x : X, isfilter_and (topologygenerated x).
+  ∏ x : X, isfilter_and (topologygenerated x).
 Proof.
   intros x A B.
   apply hinhfun2.
@@ -606,7 +606,7 @@ Proof.
 Qed.
 
 Lemma topologygenerated_point :
-  Π (x : X) (P : X → hProp), topologygenerated x P → P x.
+  ∏ (x : X) (P : X → hProp), topologygenerated x P → P x.
 Proof.
   intros x P.
   apply hinhuniv.
@@ -616,10 +616,10 @@ Proof.
 Qed.
 
 Lemma topologygenerated_neighborhood :
-Π (x : X) (P : X → hProp),
+∏ (x : X) (P : X → hProp),
  topologygenerated x P
  → ∃ Q : X → hProp,
-    topologygenerated x Q × (Π y : X, Q y → topologygenerated y P).
+    topologygenerated x Q × (∏ y : X, Q y → topologygenerated y P).
 Proof.
   intros x P.
   apply hinhfun.
@@ -658,7 +658,7 @@ Proof.
 Defined.
 
 Lemma TopologyGenerated_included {X : UU} :
-  Π (O : (X → hProp) → hProp) (P : X → hProp),
+  ∏ (O : (X → hProp) → hProp) (P : X → hProp),
     O P → isOpen (T := TopologyGenerated O) P.
 Proof.
   intros X O P Op.
@@ -677,9 +677,9 @@ Proof.
     now apply (Hy (0%nat,,paths_refl _)).
 Qed.
 Lemma TopologyGenerated_smallest {X : UU} :
-  Π (O : (X → hProp) → hProp) (T : isTopologicalSet X),
-    (Π P : X → hProp, O P → pr1 T P)
-    → Π P : X → hProp, isOpen (T := TopologyGenerated O) P → pr1 T P.
+  ∏ (O : (X → hProp) → hProp) (T : isTopologicalSet X),
+    (∏ P : X → hProp, O P → pr1 T P)
+    → ∏ P : X → hProp, isOpen (T := TopologyGenerated O) P → pr1 T P.
 Proof.
   intros X O T Ht P Hp.
   apply (neighborhood_isOpen (T := (X,,T))).
@@ -710,10 +710,10 @@ Definition topologydirprod :=
   (∃ (Ax : U → hProp) (Ay : V → hProp),
       (Ax (pr1 z) × isOpen Ax)
         × (Ay (pr2 z) × isOpen Ay)
-        × (Π x y, Ax x → Ay y → A (x,,y))).
+        × (∏ x y, Ax x → Ay y → A (x,,y))).
 
 Lemma topologydirprod_imply :
-  Π x : U × V, isfilter_imply (topologydirprod x).
+  ∏ x : U × V, isfilter_imply (topologydirprod x).
 Proof.
   intros x A B H.
   apply hinhfun.
@@ -726,7 +726,7 @@ Proof.
 Qed.
 
 Lemma topologydirprod_htrue :
-  Π x : U × V, isfilter_htrue (topologydirprod x).
+  ∏ x : U × V, isfilter_htrue (topologydirprod x).
 Proof.
   intros z.
   apply hinhpr.
@@ -737,7 +737,7 @@ Proof.
 Qed.
 
 Lemma topologydirprod_and :
-  Π x : U × V, isfilter_and (topologydirprod x).
+  ∏ x : U × V, isfilter_and (topologydirprod x).
 Proof.
   intros z A B.
   apply hinhfun2.
@@ -763,7 +763,7 @@ Proof.
 Qed.
 
 Lemma topologydirprod_point :
-  Π (x : U × V) (P : U × V → hProp), topologydirprod x P → P x.
+  ∏ (x : U × V) (P : U × V → hProp), topologydirprod x P → P x.
 Proof.
   intros xy A.
   apply hinhuniv.
@@ -775,11 +775,11 @@ Proof.
 Qed.
 
 Lemma topologydirprod_neighborhood :
-  Π (x : U × V) (P : U × V → hProp),
+  ∏ (x : U × V) (P : U × V → hProp),
     topologydirprod x P
     → ∃ Q : U × V → hProp,
       topologydirprod x Q
-                      × (Π y : U × V, Q y → topologydirprod y P).
+                      × (∏ y : U × V, Q y → topologydirprod y P).
 Proof.
   intros xy P.
   apply hinhfun.
@@ -825,7 +825,7 @@ Definition locally2d {T S : TopologicalSet} (x : T) (y : S) : Filter (T × S) :=
   FilterDirprod (locally x) (locally y).
 
 Lemma locally2d_correct {T S : TopologicalSet} (x : T) (y : S) :
-  Π P : T × S → hProp, locally2d x y P <-> locally (T := TopologyDirprod T S) (x,,y) P.
+  ∏ P : T × S → hProp, locally2d x y P <-> locally (T := TopologyDirprod T S) (x,,y) P.
 Proof.
   intros T S x y P.
   split ; apply hinhuniv.
@@ -868,12 +868,12 @@ Section topologysubtype.
 Context {T : TopologicalSet} (dom : T → hProp).
 
 Definition topologysubtype :=
-  λ (x : Σ x : T, dom x) (A : (Σ x0 : T, dom x0) → hProp),
+  λ (x : ∑ x : T, dom x) (A : (∑ x0 : T, dom x0) → hProp),
   ∃ B : T → hProp,
-    (B (pr1 x) × isOpen B) × (Π y : Σ x0 : T, dom x0, B (pr1 y) → A y).
+    (B (pr1 x) × isOpen B) × (∏ y : ∑ x0 : T, dom x0, B (pr1 y) → A y).
 
 Lemma topologysubtype_imply :
-  Π x : Σ x : T, dom x, isfilter_imply (topologysubtype x).
+  ∏ x : ∑ x : T, dom x, isfilter_imply (topologysubtype x).
 Proof.
   intros x A B H.
   apply hinhfun.
@@ -886,7 +886,7 @@ Proof.
 Qed.
 
 Lemma topologysubtype_htrue :
-  Π x : Σ x : T, dom x, isfilter_htrue (topologysubtype x).
+  ∏ x : ∑ x : T, dom x, isfilter_htrue (topologysubtype x).
 Proof.
   intros x.
   apply hinhpr.
@@ -896,7 +896,7 @@ Proof.
 Qed.
 
 Lemma topologysubtype_and :
-  Π x : Σ x : T, dom x, isfilter_and (topologysubtype x).
+  ∏ x : ∑ x : T, dom x, isfilter_and (topologysubtype x).
 Proof.
   intros x A B.
   apply hinhfun2.
@@ -913,7 +913,7 @@ Proof.
 Qed.
 
 Lemma topologysubtype_point :
-  Π (x : Σ x : T, dom x) (P : (Σ x0 : T, dom x0) → hProp),
+  ∏ (x : ∑ x : T, dom x) (P : (∑ x0 : T, dom x0) → hProp),
     topologysubtype x P → P x.
 Proof.
   intros x A.
@@ -923,16 +923,16 @@ Proof.
 Qed.
 
 Lemma topologysubtype_neighborhood :
-  Π (x : Σ x : T, dom x) (P : (Σ x0 : T, dom x0) → hProp),
+  ∏ (x : ∑ x : T, dom x) (P : (∑ x0 : T, dom x0) → hProp),
     topologysubtype x P
-    → ∃ Q : (Σ x0 : T, dom x0) → hProp,
+    → ∃ Q : (∑ x0 : T, dom x0) → hProp,
       topologysubtype x Q
-       × (Π y : Σ x0 : T, dom x0, Q y → topologysubtype y P).
+       × (∏ y : ∑ x0 : T, dom x0, Q y → topologysubtype y P).
 Proof.
   intros x A.
   apply hinhfun.
   intros B.
-  exists (λ y : Σ x : T, dom x, pr1 B (pr1 y)).
+  exists (λ y : ∑ x : T, dom x, pr1 B (pr1 y)).
   split.
   - apply hinhpr.
     exists (pr1 B).
@@ -954,7 +954,7 @@ Definition TopologySubtype {T : TopologicalSet} (dom : T → hProp) : Topologica
 Proof.
   intros T dom.
   simple refine (TopologyFromNeighborhood _ _).
-  - exact (Σ x : T, dom x).
+  - exact (∑ x : T, dom x).
   - apply topologysubtype.
   - repeat split.
     + apply topologysubtype_imply.
@@ -1104,12 +1104,12 @@ Qed.
 Definition continuous_at {U V : TopologicalSet} (f : U → V) (x : U) :=
   is_lim f (locally x) (f x).
 
-Definition continuous_on {U V : TopologicalSet} (dom : U → hProp) (f : Π (x : U), dom x → V) :=
-  Π (x : U) (Hx : dom x),
+Definition continuous_on {U V : TopologicalSet} (dom : U → hProp) (f : ∏ (x : U), dom x → V) :=
+  ∏ (x : U) (Hx : dom x),
     ∃ H,
-      is_lim (λ y : (Σ x : U, dom x), f (pr1 y) (pr2 y)) (FilterSubtype (locally x) dom H) (f x Hx).
+      is_lim (λ y : (∑ x : U, dom x), f (pr1 y) (pr2 y)) (FilterSubtype (locally x) dom H) (f x Hx).
 Definition continuous {U V : TopologicalSet} (f : U → V) :=
-  Π x : U, continuous_at f x.
+  ∏ x : U, continuous_at f x.
 
 Definition continuous_base_at {U V : TopologicalSet} (f : U → V) (x : U) base_x base_fx :=
   is_lim_base f (locally_base x base_x) (f x) base_fx.
@@ -1119,7 +1119,7 @@ Definition continuous_base_at {U V : TopologicalSet} (f : U → V) (x : U) base_
 Definition continuous2d_at {U V W : TopologicalSet} (f : U → V → W) (x : U) (y : V) :=
   is_lim (λ z : U × V, f (pr1 z) (pr2 z)) (FilterDirprod (locally x) (locally y)) (f x y).
 Definition continuous2d {U V W : TopologicalSet} (f : U → V → W) :=
-  Π (x : U) (y : V), continuous2d_at f x y.
+  ∏ (x : U) (y : V), continuous2d_at f x y.
 
 Definition continuous2d_base_at {U V W : TopologicalSet} (f : U → V → W)
            (x : U) (y : V) base_x base_y base_fxy :=
@@ -1233,25 +1233,25 @@ Definition isTopological_monoid (X : monoid) (is : isTopologicalSet X) :=
                (V := ((pr1 (pr1 (pr1 X))) ,, is))
                (W := ((pr1 (pr1 (pr1 X))) ,, is)) BinaryOperations.op.
 Definition Topological_monoid :=
-  Σ (X : monoid) (is : isTopologicalSet X), isTopological_monoid X is.
+  ∑ (X : monoid) (is : isTopologicalSet X), isTopological_monoid X is.
 
 Definition isTopological_gr (X : gr) (is : isTopologicalSet X) :=
   isTopological_monoid X is
   × continuous (U := ((pr1 (pr1 (pr1 X))) ,, is)) (V := ((pr1 (pr1 (pr1 X))) ,, is)) (grinv X).
 Definition Topological_gr :=
-  Σ (X : gr) is, isTopological_gr X is.
+  ∑ (X : gr) is, isTopological_gr X is.
 
 Definition isTopological_rig (X : rig) (is : isTopologicalSet X) :=
   isTopological_monoid (rigaddabmonoid X) is
   × isTopological_monoid (rigmultmonoid X) is.
 Definition Topological_rig :=
-  Σ (X : rig) is, isTopological_rig X is.
+  ∑ (X : rig) is, isTopological_rig X is.
 
 Definition isTopological_rng (X : rng) (is : isTopologicalSet X) :=
   isTopological_gr (rngaddabgr X) is
   × isTopological_monoid (rigmultmonoid X) is.
 Definition Topological_rng :=
-  Σ (X : rng) is, isTopological_rng X is.
+  ∑ (X : rng) is, isTopological_rng X is.
 
 Definition isTopological_DivRig (X : DivRig) (is : isTopologicalSet X) :=
   isTopological_rig (pr1 X) is
@@ -1259,7 +1259,7 @@ Definition isTopological_DivRig (X : DivRig) (is : isTopologicalSet X) :=
                   (V := ((pr1 (pr1 (pr1 (pr1 X)))) ,, is))
                   (λ x : X, hProppair (x != 0%dr) (isapropneg _)) (λ x Hx, invDivRig (x,,Hx)).
 Definition Topological_DivRig :=
-  Σ (X : DivRig) is, isTopological_DivRig X is.
+  ∑ (X : DivRig) is, isTopological_DivRig X is.
 
 Definition isTopological_fld (X : fld) (is : isTopologicalSet X) :=
   isTopological_rng (pr1 X) is
@@ -1268,7 +1268,7 @@ Definition isTopological_fld (X : fld) (is : isTopologicalSet X) :=
                   (λ x : X, hProppair (x != 0%rng) (isapropneg _))
                   fldmultinv.
 Definition Topological_fld :=
-  Σ (X : fld) is, isTopological_fld X is.
+  ∑ (X : fld) is, isTopological_fld X is.
 
 Definition isTopological_ConstructiveDivisionRig (X : ConstructiveDivisionRig) (is : isTopologicalSet X) :=
   isTopological_rig (pr1 X) is
@@ -1276,7 +1276,7 @@ Definition isTopological_ConstructiveDivisionRig (X : ConstructiveDivisionRig) (
                         (V := ((pr1 (pr1 (pr1 (pr1 X)))) ,, is))
                         (λ x : X, (x ≠ 0)%CDR) CDRinv.
 Definition Topological_ConstructiveDivisionRig :=
-  Σ (X : ConstructiveDivisionRig) is, isTopological_ConstructiveDivisionRig X is.
+  ∑ (X : ConstructiveDivisionRig) is, isTopological_ConstructiveDivisionRig X is.
 
 Definition isTopological_ConstructiveField (X : ConstructiveField) (is : isTopologicalSet X) :=
   isTopological_rng (pr1 X) is
@@ -1284,4 +1284,4 @@ Definition isTopological_ConstructiveField (X : ConstructiveField) (is : isTopol
                   (V := ((pr1 (pr1 (pr1 (pr1 X)))) ,, is))
                   (λ x : X, (x ≠ 0)%CF) CFinv.
 Definition Topological_ConstructiveField :=
-  Σ (X : ConstructiveField) is, isTopological_ConstructiveField X is.
+  ∑ (X : ConstructiveField) is, isTopological_ConstructiveField X is.


### PR DESCRIPTION
because we should use the unicode math symbols, not the unicode Greek letters.

This resolves #560.