### PR TITLE
generalize total2_paths2

### DIFF
--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -1634,7 +1634,7 @@ transparent assert (cc : (cocone d c)).
     + abstract (now apply funextsec; intro z;
                 apply (toforallpaths _ _ _ (pr2 (coconeIn ccL n)) z)).
   - abstract (intros m n e; apply eq_mor_slicecat, funextsec; intro z;
-    use total2_paths;
+    use total2_paths_f;
       [ apply (maponpaths _ (toforallpaths _ _ _
                  (maponpaths pr1 (coconeInCommutes ccL m n e)) z))|];
     cbn in *; induction (maponpaths _ _);
@@ -1660,7 +1660,7 @@ assert (Hk : (∏ n, colimIn CC n ;; k = coconeIn cc n)).
 { intros n.
   apply subtypeEquality; [intros x; apply setproperty|].
   apply funextsec; intro z.
-  use total2_paths; [apply idpath|].
+  use total2_paths_f; [apply idpath|].
   now rewrite idpath_transportf; cbn; rewrite <- (toforallpaths _ _ _ (Hf n) z).
 }
 apply (maponpaths dirprod_pr2

--- a/UniMath/CategoryTheory/HLevel_n_is_of_hlevel_Sn.v
+++ b/UniMath/CategoryTheory/HLevel_n_is_of_hlevel_Sn.v
@@ -126,7 +126,7 @@ Proof.
     apply funextfun.
     simpl. intro x.
     apply (pr2 pY).
-  apply (total2_paths H').
+  apply (total2_paths_f H').
   apply proofirrelevance.
   apply isapropisweq.
 Defined.

--- a/UniMath/CategoryTheory/LocalizingClass.v
+++ b/UniMath/CategoryTheory/LocalizingClass.v
@@ -362,7 +362,7 @@ Section def_roofs.
              (H1 : ∏ (R : Roof x y) (H : (pr1 RE1) R), (pr1 RE2) R)
              (H2 : ∏ (R : Roof x y) (H : (pr1 RE2) R), (pr1 RE1) R) : RE1 = RE2.
   Proof.
-    use total2_paths.
+    use total2_paths_f.
     - use funextfun. intros g.
       apply hPropUnivalence.
       + apply H1.
@@ -689,7 +689,7 @@ Section def_roofs.
         exact X.
     (* Uniqueness *)
     - intros t.
-      use total2_paths.
+      use total2_paths_f.
       + use RoofEqclassEq.
         * intros R HR. cbn.
           set (tmp1 := eqax2 (pr2 (pr1 t))). apply tmp1.
@@ -1619,7 +1619,7 @@ Section def_roofs.
     functor_composite FunctorToLocalization (LocalizationUniversalFunctor D hsD F H') = F.
   Proof.
     use (functor_eq _ _ hsD).
-    use total2_paths.
+    use total2_paths_f.
     - apply idpath.
     - cbn.
       use funextsec. intros a.
@@ -1645,7 +1645,7 @@ Section def_roofs.
     y = (LocalizationUniversalFunctor D hsD F H').
   Proof.
     use (functor_eq _ _ hsD).
-    use total2_paths.
+    use total2_paths_f.
     - induction T. apply idpath.
     - use funextsec. intros a.
       use funextsec. intros b.

--- a/UniMath/CategoryTheory/category_abgr.v
+++ b/UniMath/CategoryTheory/category_abgr.v
@@ -77,7 +77,7 @@ Section ABGR_precategory.
   Definition idabgrfun_left (A B : abgr) (f : monoidfun A B) : monoidfuncomp (idabgrfun A) f = f.
   Proof.
     unfold monoidfuncomp. unfold idabgrfun.
-    use total2_paths.
+    use total2_paths_f.
     - cbn. unfold funcomp. apply maponpaths. apply idpath.
     - apply proofirrelevance. apply isapropismonoidfun.
   Qed.
@@ -85,7 +85,7 @@ Section ABGR_precategory.
   Definition idabgrfun_right (A B : abgr) (f : monoidfun A B) : monoidfuncomp f (idabgrfun B) = f.
   Proof.
     unfold monoidfuncomp, idabgrfun.
-    use total2_paths.
+    use total2_paths_f.
     - cbn. unfold funcomp. apply idpath.
     - apply proofirrelevance. apply isapropismonoidfun.
   Qed.
@@ -95,7 +95,7 @@ Section ABGR_precategory.
              (h : monoidfun C D) :
     monoidfuncomp (monoidfuncomp f g) h = monoidfuncomp f (monoidfuncomp g h).
   Proof.
-    use total2_paths.
+    use total2_paths_f.
     - cbn. unfold funcomp. apply funextfun. intros x. apply idpath.
     - apply proofirrelevance. apply isapropismonoidfun.
   Qed.
@@ -173,13 +173,13 @@ Section ABGR_category.
     apply (is_iso_qinv (C:=ABGR) _ (monoidfunconstr (pr2 (invmonoidiso f)))).
     split; cbn.
     - unfold monoidfuncomp, compose, idabgrfun, identity.
-      use total2_paths.
+      use total2_paths_f.
       + cbn. apply funextfun. intros x.
         apply homotinvweqweq.
-      + cbn. use total2_paths.
+      + cbn. use total2_paths_f.
         * apply proofirrelevance. apply isapropisbinopfun.
         * apply proofirrelevance. apply (setproperty A).
-    - use total2_paths.
+    - use total2_paths_f.
       + apply funextfun. intros x. apply homotweqinvweq.
       + apply proofirrelevance. apply isapropismonoidfun.
   Qed.
@@ -198,7 +198,7 @@ Section ABGR_category.
     apply (gradth _ (abgr_equiv_iso A B)).
     - intro; apply eq_iso. apply maponpaths.
       unfold abgr_equiv_iso, abgrp_iso_equiv. cbn.
-      use total2_paths.
+      use total2_paths_f.
       + cbn. unfold monoidfunconstr.
         apply subtypeEquality. intros y. apply isapropismonoidfun.
         apply maponpaths. apply subtypeEquality.
@@ -206,7 +206,7 @@ Section ABGR_category.
         * apply idpath.
       + apply proofirrelevance. apply isaprop_is_iso.
     - intros y. unfold abgrp_iso_equiv, abgr_equiv_iso. cbn.
-      use total2_paths.
+      use total2_paths_f.
       + unfold monoidfunconstr. apply subtypeEquality.
         intros x. apply isapropisweq. apply idpath.
       + apply proofirrelevance. apply isapropismonoidfun.
@@ -225,11 +225,11 @@ Section ABGR_category.
     - intros x. apply subtypeEquality.
       + intros y. apply isapropismonoidfun.
       + unfold abgr_equiv_iso, abgrp_iso_equiv. cbn.
-        use total2_paths.
+        use total2_paths_f.
         * apply idpath.
         * apply isapropisweq.
     - intros y. unfold abgr_equiv_iso, abgrp_iso_equiv. cbn.
-      use total2_paths.
+      use total2_paths_f.
       + unfold monoidfunconstr. cbn. apply subtypeEquality.
         * intros x. apply isapropismonoidfun.
         * apply idpath.
@@ -400,14 +400,14 @@ Section ABGR_zero.
     use mk_isZero.
     - intros a. use iscontrpair.
       + exact (ABGR_zero_to a).
-      + intros t. use total2_paths.
+      + intros t. use total2_paths_f.
         * apply funextfun. intros x.
           unfold ABGR_zero_to. cbn.
           rewrite (isconnectedunit x (unel ABGR_zero)). apply (pr2 (pr2 t)).
         * apply proofirrelevance. apply isapropismonoidfun.
     - intros a. use iscontrpair.
       + exact (ABGR_zero_from a).
-      + intros t. use total2_paths.
+      + intros t. use total2_paths_f.
         * apply funextfun. intros x. apply isconnectedunit.
         * apply proofirrelevance. apply isapropismonoidfun.
   Qed.
@@ -438,7 +438,7 @@ Section ABGR_zero.
     unfold ZeroArrow.
     rewrite ABGR_has_zero_from.
     rewrite ABGR_has_zero_to.
-    use total2_paths.
+    use total2_paths_f.
     - cbn. unfold funcomp. apply idpath.
     - apply proofirrelevance. apply isapropismonoidfun.
   Qed.
@@ -479,7 +479,7 @@ Section ABGR_preadditive.
   Definition ABGR_hombinop_runax (X Y : ABGR) (f : ABGR⟦X, Y⟧) :
     ABGR_hombinop X Y f (ABGR_zero_arrow X Y) = f.
   Proof.
-    use total2_paths.
+    use total2_paths_f.
     - cbn. apply funextfun. intros x.
       rewrite (runax (abgrtoabmonoid Y)). apply idpath.
     - apply proofirrelevance. apply isapropismonoidfun.
@@ -488,7 +488,7 @@ Section ABGR_preadditive.
   Definition ABGR_hombinop_lunax (X Y : ABGR) (f : ABGR⟦X, Y⟧) :
     ABGR_hombinop X Y (ABGR_zero_arrow X Y) f = f.
   Proof.
-    use total2_paths.
+    use total2_paths_f.
     - cbn. apply funextfun. intros x.
       rewrite (lunax (abgrtoabmonoid Y)). apply idpath.
     - apply proofirrelevance. apply isapropismonoidfun.
@@ -498,7 +498,7 @@ Section ABGR_preadditive.
   Definition ABGR_hombinop_comm (X Y : ABGR) :
     ∏ (f g : ABGR⟦X, Y⟧), @ABGR_hombinop X Y f g = @ABGR_hombinop X Y g f.
   Proof.
-    intros f g. use total2_paths.
+    intros f g. use total2_paths_f.
     - cbn. apply funextfun. intros x. rewrite (pr2 (pr2 Y)). apply idpath.
     - apply proofirrelevance. apply isapropismonoidfun.
   Qed.
@@ -528,7 +528,7 @@ Section ABGR_preadditive.
   Definition ABGR_hombinop_linvax (X Y : ABGR) :
     ∏ f : ABGR⟦X, Y⟧, ABGR_hombinop X Y (ABGR_hombinop_inv X Y f) f  = ABGR_zero_arrow X Y.
   Proof.
-    intros f. use total2_paths.
+    intros f. use total2_paths_f.
     - cbn. apply funextfun. intros x. apply (grlinvax (abgrtogr Y)).
     - apply proofirrelevance. apply isapropismonoidfun.
   Qed.
@@ -536,7 +536,7 @@ Section ABGR_preadditive.
   Definition ABGR_hombinop_rinvax (X Y : ABGR) :
     ∏ f : ABGR⟦X, Y⟧, ABGR_hombinop X Y f (ABGR_hombinop_inv X Y f) = ABGR_zero_arrow X Y.
   Proof.
-    intros f. use total2_paths.
+    intros f. use total2_paths_f.
     - cbn. apply funextfun. intros x. apply (grrinvax (abgrtogr Y)).
     - apply proofirrelevance. apply isapropismonoidfun.
   Qed.
@@ -545,7 +545,7 @@ Section ABGR_preadditive.
   Definition ABGR_hombinop_assoc (X Y : ABGR) (f g h : ABGR⟦X, Y⟧) :
     ABGR_hombinop X Y f (ABGR_hombinop X Y g h) = ABGR_hombinop X Y (ABGR_hombinop X Y f g) h.
   Proof.
-    use total2_paths.
+    use total2_paths_f.
     - cbn. apply funextfun. intros x. rewrite (assocax (abgrtoabmonoid Y)). apply idpath.
     - apply proofirrelevance. apply isapropismonoidfun.
   Qed.
@@ -595,12 +595,12 @@ Section ABGR_preadditive.
       split.
       + intros g h.
         unfold to_premor.
-        use total2_paths.
+        use total2_paths_f.
         * cbn. apply funextfun.
           intros x. unfold funcomp. apply idpath.
         * apply proofirrelevance. apply isapropismonoidfun.
       + unfold to_premor.
-        use total2_paths.
+        use total2_paths_f.
         * cbn. apply funextfun.
           intros x. unfold funcomp. apply idpath.
         * apply proofirrelevance. apply isapropismonoidfun.
@@ -609,12 +609,12 @@ Section ABGR_preadditive.
       split.
       + intros g h.
         unfold to_premor.
-        use total2_paths.
+        use total2_paths_f.
         * cbn. apply funextfun.
           intros x. unfold funcomp. rewrite (pr1 (pr2 f)). apply idpath.
         * apply proofirrelevance. apply isapropismonoidfun.
       + unfold to_premor.
-        use total2_paths.
+        use total2_paths_f.
         * cbn. apply funextfun.
           intros x. unfold funcomp. apply (pr2 (pr2 f)).
         * apply proofirrelevance. apply isapropismonoidfun.
@@ -660,7 +660,7 @@ Section ABGR_Additive.
     - intros x x'. use dirprodeq.
       + apply idpath.
       + apply pathsinv0. apply (runax B).
-    - unfold dirprodpair. use total2_paths; apply idpath.
+    - unfold dirprodpair. use total2_paths_f; apply idpath.
   Qed.
 
   Definition ABGR_DirectSumIn1 (A B : abgr) : ABGR⟦A, abgrdirprod A B⟧ :=
@@ -673,7 +673,7 @@ Section ABGR_Additive.
     - intros x x'. use dirprodeq.
       + apply pathsinv0. apply (runax A).
       + apply idpath.
-    - unfold dirprodpair. use total2_paths; apply idpath.
+    - unfold dirprodpair. use total2_paths_f; apply idpath.
   Qed.
 
   Definition ABGR_DirectSumIn2 (A B : abgr) : ABGR⟦B, abgrdirprod A B⟧ :=
@@ -682,7 +682,7 @@ Section ABGR_Additive.
   Lemma ABGR_DirectSumIdIn1 (A B : abgr) :
     ABGR_DirectSumIn1 A B ;; ABGR_DirectSumPr1 A B = idabgrfun A.
   Proof.
-    use total2_paths.
+    use total2_paths_f.
     - cbn. use funextfun. intros x. apply idpath.
     - apply proofirrelevance. apply isapropismonoidfun.
   Qed.
@@ -690,7 +690,7 @@ Section ABGR_Additive.
   Lemma ABGR_DirectSumIdIn2 (A B : abgr) :
     ABGR_DirectSumIn2 A B ;; ABGR_DirectSumPr2 A B = idabgrfun B.
   Proof.
-    use total2_paths.
+    use total2_paths_f.
     - cbn. use funextfun. intros x. apply idpath.
     - apply proofirrelevance. apply isapropismonoidfun.
   Qed.
@@ -698,7 +698,7 @@ Section ABGR_Additive.
   Lemma ABGR_DirectSumUnel1 (A B : abgr) :
     ABGR_DirectSumIn1 A B ;; ABGR_DirectSumPr2 A B = ABGR_zero_arrow A B.
   Proof.
-    use total2_paths.
+    use total2_paths_f.
     - cbn. use funextfun. intros x. apply idpath.
     - apply proofirrelevance. apply isapropismonoidfun.
   Qed.
@@ -706,7 +706,7 @@ Section ABGR_Additive.
   Lemma ABGR_DirectSumUnel2 (A B : abgr) :
     ABGR_DirectSumIn2 A B ;; ABGR_DirectSumPr1 A B = ABGR_zero_arrow B A.
   Proof.
-    use total2_paths.
+    use total2_paths_f.
     - cbn. use funextfun. intros x. apply idpath.
     - apply proofirrelevance. apply isapropismonoidfun.
   Qed.
@@ -715,7 +715,7 @@ Section ABGR_Additive.
     ABGR_hombinop _ _ (ABGR_DirectSumPr1 A B ;; ABGR_DirectSumIn1 A B)
                   (ABGR_DirectSumPr2 A B ;; ABGR_DirectSumIn2 A B) = idabgrfun _.
   Proof.
-    use total2_paths.
+    use total2_paths_f.
     - cbn. use funextfun. intros x.
       apply dirprodeq.
       + apply (runax A).
@@ -754,12 +754,12 @@ Section ABGR_Additive.
              apply (runax (abgrtoabmonoid Z)).
         (* Commutativity of the morphism. *)
         * split.
-          -- use total2_paths.
+          -- use total2_paths_f.
              ++ cbn. apply funextfun. intros x.
                 unfold funcomp. cbn. set (HHg := pr2 (pr2 g)). cbn in HHg. rewrite HHg.
                 apply (runax (abgrtoabmonoid Z)).
              ++ apply proofirrelevance. apply isapropismonoidfun.
-          -- use total2_paths.
+          -- use total2_paths_f.
              ++ cbn. apply funextfun. intros x.
                 unfold funcomp. cbn. set (HHf := pr2 (pr2 f)). cbn in HHf. rewrite HHf.
                 apply (lunax (abgrtoabmonoid Z)).
@@ -767,7 +767,7 @@ Section ABGR_Additive.
         (* Equality on equality of homsets *)
         * intros y. apply isapropdirprod; apply has_homsets_ABGR.
         (* Uniqueness *)
-        * intros y z. use total2_paths.
+        * intros y z. use total2_paths_f.
           -- cbn. apply funextfun. intros x.
              unfold funcomp. rewrite <- (idabgrfun_left _ _ y).
              rewrite <- (ABGR_DirectSumId X Y). cbn. unfold funcomp.
@@ -799,18 +799,18 @@ Section ABGR_Additive.
                    apply (lunax (abgrtoabmonoid Y)).
         (* Commutativity of the morphism. *)
         * split.
-          -- use total2_paths.
+          -- use total2_paths_f.
              ++ cbn. apply funextfun. intros x.
                 unfold funcomp. cbn. rewrite (runax (abgrtoabmonoid X)). apply idpath.
              ++ apply proofirrelevance. apply isapropismonoidfun.
-          -- use total2_paths.
+          -- use total2_paths_f.
              ++ cbn. apply funextfun. intros x.
                 unfold funcomp. cbn. rewrite (lunax (abgrtoabmonoid Y)). apply idpath.
              ++ apply proofirrelevance. apply isapropismonoidfun.
         (* Equality on equality of homsets *)
         * intros y. apply isapropdirprod; apply has_homsets_ABGR.
         (* Uniqueness *)
-        * intros y z. use total2_paths.
+        * intros y z. use total2_paths_f.
           -- cbn. apply funextfun. intros x.
              rewrite <- (idabgrfun_right _ _ y).
              rewrite <- (ABGR_DirectSumId X Y). cbn.
@@ -818,23 +818,23 @@ Section ABGR_Additive.
              apply idpath.
           -- apply proofirrelevance. apply isapropismonoidfun.
       (* Id1 *)
-      + use total2_paths.
+      + use total2_paths_f.
         * apply funextfun. intros x. cbn. apply idpath.
         * apply proofirrelevance. apply isapropismonoidfun.
       (* Id2 *)
-      + use total2_paths.
+      + use total2_paths_f.
         * apply funextfun. intros x. cbn. apply idpath.
         * apply proofirrelevance. apply isapropismonoidfun.
       (* Unit1 *)
-      + use total2_paths.
+      + use total2_paths_f.
         * apply funextfun. intros x. cbn. apply idpath.
         * apply proofirrelevance. apply isapropismonoidfun.
       (* Unit2 *)
-      + use total2_paths.
+      + use total2_paths_f.
         * apply funextfun. intros x. cbn. apply idpath.
         * apply proofirrelevance. apply isapropismonoidfun.
       (* Id *)
-      + use total2_paths.
+      + use total2_paths_f.
         * apply funextfun. intros x. induction x.
           cbn. apply dirprodeq.
           -- cbn. apply (runax (abgrtoabmonoid X)).
@@ -902,7 +902,7 @@ Section ABGR_kernels.
   Definition ABGR_Kernel_eq {A B : abgr} (f : monoidfun A B) :
     ABGR_kernel_monoidfun f ;; f = ZeroArrow ABGR_has_zero _ _.
   Proof.
-    use total2_paths.
+    use total2_paths_f.
     - apply funextfun. intros x. induction x as [t p]. cbn.
       unfold funcomp, pr1carrier. cbn in p. cbn.
       use (squash_to_prop p).
@@ -926,10 +926,10 @@ Section ABGR_kernels.
       apply (funeqpaths H c).
     (* ismonoidfun *)
     - split.
-      + intros y y'. cbn. use total2_paths.
+      + intros y y'. cbn. use total2_paths_f.
         * cbn. rewrite (pr1 (pr2 h)). apply idpath.
         * apply proofirrelevance. cbn. apply isapropishinh.
-      + use total2_paths.
+      + use total2_paths_f.
         * cbn. apply (pr2 (pr2 h)).
         * apply proofirrelevance. cbn. apply isapropishinh.
   Defined.
@@ -946,15 +946,15 @@ Section ABGR_kernels.
     - rewrite (ABGR_has_zero_arrow_eq _ _) in H'.
       apply (ABGR_KernelArrowIn _ f H').
     (* Commutativity of the kernel arrow *)
-    - use total2_paths.
+    - use total2_paths_f.
       + apply funextfun. intros x. cbn. apply idpath.
       + apply proofirrelevance. apply isapropismonoidfun.
     (* Equality of equalities of morphisms *)
     - intros y. apply has_homsets_ABGR.
     (* Uniqueness *)
     - intros y t3. induction y as [t1 p1]. apply base_paths in t3. cbn in *.
-      unfold pr1carrier, funcomp in t3. cbn in t3. use total2_paths.
-      + cbn. apply funextfun. intros x. use total2_paths.
+      unfold pr1carrier, funcomp in t3. cbn in t3. use total2_paths_f.
+      + cbn. apply funextfun. intros x. use total2_paths_f.
         * cbn. exact (funeqpaths t3 x).
         * apply proofirrelevance. apply isapropishinh.
       + apply proofirrelevance. apply isapropismonoidfun.
@@ -1083,7 +1083,7 @@ Section ABGR_kernels.
     f ;; ABGR_cokernel_monoidfun f = ZeroArrow ABGR_has_zero A (ABGR_cokernel_abgr f).
   Proof.
     rewrite ABGR_has_zero_arrow_eq.
-    use total2_paths.
+    use total2_paths_f.
     - apply funextfun. intros a. apply (iscompsetquotpr (ABGR_cokernel_eqrel f)).
       unfold ABGR_cokernel_eqrel.
       intros P X. cbn in *. apply X. refine (tpair _ a _).
@@ -1170,14 +1170,14 @@ Section ABGR_kernels.
         * cbn. set (XXh := pr2 (pr2 h)). cbn in XXh. rewrite <- XXh.
           apply maponpaths. apply idpath.
       (* Commutativity *)
-    - use total2_paths.
+    - use total2_paths_f.
       + cbn. apply funextfun. intros b. apply idpath.
       + apply proofirrelevance. apply isapropismonoidfun.
     (* Equality on equality of morphisms *)
     - intros y. cbn. intros x x'. apply (has_homsets_ABGR).
     (* Uniqueness *)
     - intros y. induction y as [t p]. intros  t0. cbn in t0.
-      use total2_paths.
+      use total2_paths_f.
       + cbn. apply funextfun. intros z. cbn in *.
         set (surj := issurjsetquotpr (ABGR_cokernel_eqrel f)).
         unfold issurjective in surj. cbn in surj.
@@ -1438,7 +1438,7 @@ Section ABGR_monics.
         (H : f a1 = f a2) : monoidfuncomp (ABGR_natset_dirprod_map_monoidfun a1) f =
                             monoidfuncomp (ABGR_natset_dirprod_map_monoidfun a2) f.
   Proof.
-    use total2_paths.
+    use total2_paths_f.
     - cbn. unfold funcomp. apply funextfun.
       intros x. induction x as [t p]. induction t as [|t IHt].
       + induction p as [|p IHp].
@@ -1471,7 +1471,7 @@ Section ABGR_monics.
     monoidfuncomp g f1 = monoidfuncomp g f2 -> f1 = f2.
   Proof.
     intros X.
-    use total2_paths.
+    use total2_paths_f.
     - apply funextfun. intros x. apply base_paths in X. cbn in X. unfold funcomp in X.
       unfold issurjective in H.
       use (squash_to_prop (H x)). use (setproperty C).
@@ -1485,7 +1485,7 @@ Section ABGR_monics.
     monoidfuncomp ABGR_natset_to_Z_monoidfun (ABGR_integer_map_monoidfun a) =
     ABGR_natset_dirprod_map_monoidfun a.
   Proof.
-    use total2_paths.
+    use total2_paths_f.
     - cbn. apply funextfun. intros x. unfold funcomp. use setquotunivcomm.
     - apply proofirrelevance. apply isapropismonoidfun.
   Qed.
@@ -1530,7 +1530,7 @@ Section ABGR_monics.
   Proof.
     intros b h1 h2.
     use iscontrpair.
-    - use total2_paths.
+    - use total2_paths_f.
       + unfold isMonic in isM. cbn in *.
         set (p := pr2 h1). cbn in p.
         set (p' := pr2 h2). cbn in p'.
@@ -1603,7 +1603,7 @@ Section ABGR_monic_kernels.
     apply (iscontrpair (hfiberpair (pr1 f) (pr1 X) (pr2 X))).
     (* Equality in hfibers *)
     intros t.
-    use total2_paths.
+    use total2_paths_f.
     - cbn.
       assert (e : pr1 f (pr1 t) = pr1 f (pr1 X)).
       {
@@ -1734,7 +1734,7 @@ Section ABGR_monic_kernels.
     (* KernelIn *)
     - apply (ABGR_monic_kernel_in_monoidfun f isM w h H').
     (* Commutativity *)
-    - cbn. use total2_paths.
+    - cbn. use total2_paths_f.
       + cbn. unfold funcomp. apply funextfun.
         intros x. cbn. unfold ABGR_monic_kernel_in.
         set (tmp := pr2 ((ABGR_monic_kernel_in_hfiber f isM w x h H'))).
@@ -1745,7 +1745,7 @@ Section ABGR_monic_kernels.
     (* Uniqueness *)
     - intros y H. cbn in H.
       unfold isMonic in isM. apply isM. cbn. rewrite H.
-      use total2_paths.
+      use total2_paths_f.
       + cbn. apply funextfun. intros x.
         apply pathsinv0. unfold funcomp. unfold ABGR_monic_kernel_in.
         apply (pr2 ((ABGR_monic_kernel_in_hfiber f isM w x h H'))).
@@ -1989,7 +1989,7 @@ Section ABGR_monic_kernels.
     (* Arrow *)
     - exact (ABGR_epi_cokernel_out_monoidfun f isE w h H).
     (* Commutativity *)
-    - cbn. use total2_paths.
+    - cbn. use total2_paths_f.
       + cbn. unfold funcomp. apply funextfun.
         intros x. apply pathsinv0. unfold ABGR_epi_cokernel_out_map.
         apply (pr2 ((ABGR_epi_cokernel_out_data (pr1 f x) f isE w h H))
@@ -1999,7 +1999,7 @@ Section ABGR_monic_kernels.
     - intros y. apply has_homsets_ABGR.
     (* Uniqueness *)
     - intros y T. cbn in T. unfold isEpi in isE. apply isE. cbn. rewrite T.
-      use total2_paths.
+      use total2_paths_f.
       + cbn. unfold funcomp. apply funextfun. intros x. unfold ABGR_epi_cokernel_out_map.
         apply (pr2 ((ABGR_epi_cokernel_out_data (pr1 f x) f isE w h H))
                    (@hfiberpair _ _ (pr1 f) (pr1 f x) x (idpath _))).

--- a/UniMath/CategoryTheory/category_binops.v
+++ b/UniMath/CategoryTheory/category_binops.v
@@ -32,7 +32,7 @@ Section BINOPS_precategory.
     binopfuncomp (idbinopfun A) f = f.
   Proof.
     unfold binopfuncomp. unfold idbinopfun.
-    use total2_paths. cbn. unfold funcomp. apply maponpaths.
+    use total2_paths_f. cbn. unfold funcomp. apply maponpaths.
     apply idpath. apply proofirrelevance. apply isapropisbinopfun.
   Defined.
 
@@ -41,7 +41,7 @@ Section BINOPS_precategory.
     binopfuncomp f (idbinopfun B) = f.
   Proof.
     unfold binopfuncomp. unfold idbinopfun.
-    use total2_paths. cbn. unfold funcomp. apply maponpaths.
+    use total2_paths_f. cbn. unfold funcomp. apply maponpaths.
     apply idpath. apply proofirrelevance. apply isapropisbinopfun.
   Defined.
 
@@ -121,11 +121,11 @@ Section BINOP_category.
     apply (is_iso_qinv (C:=BINOP) _ (binopfunpair (pr1 (pr1 (invbinopiso f)))
                                                   (pr2 (invbinopiso f)))).
     split; cbn. unfold compose, identity. cbn. unfold binopfuncomp, idbinopfun.
-    cbn. use total2_paths. cbn. apply funextfun. intros x.
+    cbn. use total2_paths_f. cbn. apply funextfun. intros x.
     apply homotinvweqweq. cbn. apply impred_isaprop. intros t.
     apply impred_isaprop. intros t0. apply (pr2 (pr1 A)).
 
-    use total2_paths. cbn. apply funextfun. intros x.
+    use total2_paths_f. cbn. apply funextfun. intros x.
     apply homotweqinvweq. cbn. apply impred_isaprop. intros yt.
     apply impred_isaprop. intros t0. apply (pr2 (pr1 B)).
   Defined.
@@ -144,7 +144,7 @@ Section BINOP_category.
     apply (gradth _ (binop_equiv_iso A B)).
     intro; apply eq_iso. apply maponpaths.
     unfold binop_equiv_iso, binop_iso_equiv. cbn.
-    use total2_paths. cbn. unfold binopfunpair.
+    use total2_paths_f. cbn. unfold binopfunpair.
     apply subtypeEquality. intros y. apply isapropisbinopfun.
     apply maponpaths. apply subtypeEquality.
     unfold isPredicate.
@@ -156,7 +156,7 @@ Section BINOP_category.
     apply isaprop_is_iso.
 
     intros y. unfold binop_iso_equiv, binop_equiv_iso. cbn.
-    use total2_paths. cbn. unfold binopfunpair.
+    use total2_paths_f. cbn. unfold binopfunpair.
     apply subtypeEquality. intros x. apply isapropisweq.
     apply idpath.
 
@@ -177,11 +177,11 @@ Section BINOP_category.
     intros y. apply isapropisbinopfun.
 
     unfold binop_equiv_iso, binop_iso_equiv. cbn.
-    use total2_paths. cbn. apply idpath.
+    use total2_paths_f. cbn. apply idpath.
     apply isapropisweq.
 
     intros y. unfold binop_equiv_iso, binop_iso_equiv. cbn.
-    use total2_paths. cbn. unfold binopfunpair. cbn.
+    use total2_paths_f. cbn. unfold binopfunpair. cbn.
     apply subtypeEquality. intros x. apply isapropisbinopfun.
     apply idpath. apply proofirrelevance.
     apply isaprop_is_iso.

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -905,7 +905,7 @@ mkpair.
       abstract (now apply funextsec).
     * abstract (intros Y Z F; apply (eq_mor_slicecat has_homsets_HSET);
                 apply funextsec; intro y;
-                use total2_paths2; [apply (toforallpaths _ _ _ (!pr2 F) y)|];
+                use (two_arg_paths_f (f:=tpair _)); [apply (toforallpaths _ _ _ (!pr2 F) y)|];
                 cbn in *; induction (toforallpaths _ _ _ _ _);
                 now rewrite idpath_transportf).
   + use mk_nat_trans.

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -766,12 +766,12 @@ use mk_functor.
 + split.
   - intros x; apply (eq_mor_slicecat has_homsets_HSET); simpl.
     apply funextsec; intros [y hy].
-    use total2_paths; [ apply idpath |].
+    use total2_paths_f; [ apply idpath |].
     apply funextsec; intros w; apply subtypeEquality; [|apply idpath].
     now intros XX; apply setproperty.
   - intros x y z g h; apply (eq_mor_slicecat has_homsets_HSET); simpl.
     apply funextsec; intros [w hw].
-    use total2_paths; [ apply idpath |].
+    use total2_paths_f; [ apply idpath |].
     apply funextsec; intros w'.
     apply subtypeEquality; [|apply idpath].
     now intros XX; apply setproperty.
@@ -822,7 +822,7 @@ use mk_are_adjoints.
   + intros x; apply eq_mor_slicecat, funextsec; intro x1.
     now apply subtypeEquality; [intro y; apply setproperty|]; rewrite tppr.
   + intros x; apply eq_mor_slicecat, funextsec; intro x1; simpl.
-    use total2_paths; [apply idpath|]; cbn.
+    use total2_paths_f; [apply idpath|]; cbn.
     apply funextsec; intro y.
     now apply subtypeEquality; [intro z; apply setproperty|]; simpl; rewrite <- tppr.
 Defined.
@@ -872,7 +872,7 @@ use mk_ProductCone.
   - abstract (now intros i; apply eq_mor_slicecat, funextsec).
   - abstract (now intros g; apply impred_isaprop; intro i; apply has_homsets_slice_precat).
   - abstract (simpl; intros [y1 y2] Hy; apply eq_mor_slicecat, funextsec; intro x;
-    use total2_paths; [apply (toforallpaths _ _ _ (!y2) x)|];
+    use total2_paths_f; [apply (toforallpaths _ _ _ (!y2) x)|];
     apply funextsec; intro i; apply subtypeEquality; [intros w; apply setproperty|];
     destruct f as [f Hf]; cbn in *;
     induction (toforallpaths (λ _ : f, X) (λ x0 : f, pr1 (y1 x0)) Hf (! y2) x);
@@ -905,7 +905,7 @@ mkpair.
       abstract (now apply funextsec).
     * abstract (intros Y Z F; apply (eq_mor_slicecat has_homsets_HSET);
                 apply funextsec; intro y;
-                use (two_arg_paths_f (f:=tpair _)); [apply (toforallpaths _ _ _ (!pr2 F) y)|];
+                use total2_paths2_f; [apply (toforallpaths _ _ _ (!pr2 F) y)|];
                 cbn in *; induction (toforallpaths _ _ _ _ _);
                 now rewrite idpath_transportf).
   + use mk_nat_trans.

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -791,7 +791,7 @@ use mk_nat_trans.
   * abstract (now apply funextsec).
 + intros [g Hg] [h Hh] [w Hw].
   apply (eq_mor_slicecat has_homsets_HSET), funextsec; intro x1.
-  apply (total2_paths2 (!toforallpaths _ _ _ Hw x1)), funextsec; intro y.
+  apply (two_arg_paths_f (!toforallpaths _ _ _ Hw x1)), funextsec; intro y.
   repeat (apply subtypeEquality; [intros x; apply setproperty|]); cbn in *.
   now induction (! toforallpaths _ _ (λ x : g, Hh (w x)) _ _).
 Defined.

--- a/UniMath/CategoryTheory/catiso.v
+++ b/UniMath/CategoryTheory/catiso.v
@@ -222,7 +222,7 @@ Lemma transport_id {A0 B0 : UU} (p0 : A0 = B0)
   : forall a : A0,
     (transportb (X := total2 (fun T => T -> T -> UU))
                 (fun T => forall a, (pr2 T) a a)
-                (two_arg_paths_b (f:=tpair _) p0 p1) idB) a
+                (total2_paths2_b p0 p1) idB) a
   = (eqweqmap (  (transport_mor B1 p0 _ _)
                @ !weqtoforallpaths _ _ _ (weqtoforallpaths _ _ _ p1 a) a))
     (idB (eqweqmap p0 a)).
@@ -254,8 +254,7 @@ Lemma catiso_to_precategory_id_path {A B : precategory}
   : forall a : A,
     (transportb (X := total2 (fun T => T -> T -> UU))
                 (fun T => forall a, (pr2 T) a a)
-                (two_arg_paths_b (f:=tpair _)
-                                 (catiso_to_precategory_ob_path F)
+                (total2_paths2_b (catiso_to_precategory_ob_path F)
                                  (catiso_to_precategory_mor_path_funext F))
      identity) a
    = identity a.
@@ -328,7 +327,7 @@ Lemma transport_comp {A0 B0 : UU} (p0 : A0 = B0)
   : forall a a' a'' : A0,
       (transportb (X := total2 (fun T => T -> T -> UU))
                   (fun T => forall a b c, (pr2 T) a b -> (pr2 T) b c -> (pr2 T) a c)
-                  (two_arg_paths_b (f:=tpair _) p0 p1) compB)
+                  (total2_paths2_b p0 p1) compB)
         a a' a''
     = transport_comp_target p0 A1 B1 p1 a a' a''
         (compB (eqweqmap p0 a) (eqweqmap p0 a') (eqweqmap p0 a'')).
@@ -360,8 +359,7 @@ Lemma catiso_to_precategory_comp_path {A B : precategory}
   : forall a a' a'' : A,
     (transportb (X := total2 (fun T => T -> T -> UU))
                 (fun T => forall a b c : (pr1 T), (pr2 T) a b -> (pr2 T) b c -> (pr2 T) a c)
-                (two_arg_paths_b (f:=tpair _)
-                                 (catiso_to_precategory_ob_path F)
+                (total2_paths2_b (catiso_to_precategory_ob_path F)
                                  (catiso_to_precategory_mor_path_funext F))
      (@compose B)) a a' a''
    = (@compose A a a' a'').

--- a/UniMath/CategoryTheory/catiso.v
+++ b/UniMath/CategoryTheory/catiso.v
@@ -222,7 +222,7 @@ Lemma transport_id {A0 B0 : UU} (p0 : A0 = B0)
   : forall a : A0,
     (transportb (X := total2 (fun T => T -> T -> UU))
                 (fun T => forall a, (pr2 T) a a)
-                (total2_paths2_b p0 p1) idB) a
+                (two_arg_paths_b (f:=tpair _) p0 p1) idB) a
   = (eqweqmap (  (transport_mor B1 p0 _ _)
                @ !weqtoforallpaths _ _ _ (weqtoforallpaths _ _ _ p1 a) a))
     (idB (eqweqmap p0 a)).
@@ -254,7 +254,8 @@ Lemma catiso_to_precategory_id_path {A B : precategory}
   : forall a : A,
     (transportb (X := total2 (fun T => T -> T -> UU))
                 (fun T => forall a, (pr2 T) a a)
-                (total2_paths2_b (catiso_to_precategory_ob_path F)
+                (two_arg_paths_b (f:=tpair _)
+                                 (catiso_to_precategory_ob_path F)
                                  (catiso_to_precategory_mor_path_funext F))
      identity) a
    = identity a.
@@ -327,7 +328,7 @@ Lemma transport_comp {A0 B0 : UU} (p0 : A0 = B0)
   : forall a a' a'' : A0,
       (transportb (X := total2 (fun T => T -> T -> UU))
                   (fun T => forall a b c, (pr2 T) a b -> (pr2 T) b c -> (pr2 T) a c)
-                  (total2_paths2_b p0 p1) compB)
+                  (two_arg_paths_b (f:=tpair _) p0 p1) compB)
         a a' a''
     = transport_comp_target p0 A1 B1 p1 a a' a''
         (compB (eqweqmap p0 a) (eqweqmap p0 a') (eqweqmap p0 a'')).
@@ -359,7 +360,8 @@ Lemma catiso_to_precategory_comp_path {A B : precategory}
   : forall a a' a'' : A,
     (transportb (X := total2 (fun T => T -> T -> UU))
                 (fun T => forall a b c : (pr1 T), (pr2 T) a b -> (pr2 T) b c -> (pr2 T) a c)
-                (total2_paths2_b (catiso_to_precategory_ob_path F)
+                (two_arg_paths_b (f:=tpair _)
+                                 (catiso_to_precategory_ob_path F)
                                  (catiso_to_precategory_mor_path_funext F))
      (@compose B)) a a' a''
    = (@compose A a a' a'').

--- a/UniMath/CategoryTheory/equivalences.v
+++ b/UniMath/CategoryTheory/equivalences.v
@@ -335,7 +335,7 @@ Proof.
   destruct x' as [a' f'].
   set (fminusf := iso_comp f (iso_inv_from_iso f')).
   set (g := iso_from_fully_faithful_reflection HF fminusf).
-  apply (total2_paths2 (B:=fun a' => iso ((pr1 F) a') b) (isotoid _ HA g)).
+  apply (two_arg_paths_f (B:=fun a' => iso ((pr1 F) a') b) (isotoid _ HA g)).
   pathvia (iso_comp (iso_inv_from_iso
     (functor_on_iso F (idtoiso (isotoid _ HA g)))) f).
     generalize (isotoid _ HA g).

--- a/UniMath/CategoryTheory/functor_categories.v
+++ b/UniMath/CategoryTheory/functor_categories.v
@@ -189,11 +189,11 @@ Proof.
   apply (invmaponpathsweq (total2_paths_equiv _ _ _ )); simpl.
   assert (H' : base_paths _ _ p = base_paths _ _ q).
   { apply (invmaponpathsweq (total2_paths_equiv _ _ _ )); simpl.
-    apply (total2_paths2 H), uip.
+    apply (two_arg_paths_f H), uip.
     apply impred_isaset; intro a; apply impred_isaset; intro b; apply impred_isaset; intro f.
     apply hs.
   }
-  apply (total2_paths2 H'), uip, isasetaprop, isaprop_is_functor, hs.
+  apply (two_arg_paths_f H'), uip, isasetaprop, isaprop_is_functor, hs.
 Defined.
 
 Definition functor_id {C C' : precategory_data}(F : functor C C'):

--- a/UniMath/CategoryTheory/functor_categories.v
+++ b/UniMath/CategoryTheory/functor_categories.v
@@ -92,7 +92,7 @@ Lemma functor_data_eq {C C' : precategory_ob_mor} (F F' : functor_data C C')
                        (transportf (λ x : C', x --> pr1 F C2) (H C1) (pr2 F C1 C2 f)) =
             pr2 F' C1 C2 f) : F = F'.
 Proof.
-  use total2_paths.
+  use total2_paths_f.
   - use funextfun. intros c. exact (H c).
   - use funextsec. intros C1. use funextsec. intros C2. use funextsec. intros f.
     assert (e : transportf (λ x : C → C', ∏ a b : C, a --> b → x a --> x b)
@@ -158,7 +158,7 @@ Lemma functor_eq (C C' : precategory_data) (hs: has_homsets C') (F F': functor C
     pr1 F = pr1 F' -> F = F'.
 Proof.
   intro H.
-  apply (total2_paths H).
+  apply (total2_paths_f H).
   apply proofirrelevance.
   apply isaprop_is_functor.
   apply hs.
@@ -528,7 +528,7 @@ Proof.
   intro d.
   apply invproofirrelevance.
   intros [c e] [c' e'].
-  simple refine (total2_paths _ _ ).
+  simple refine (total2_paths_f _ _ ).
   - simpl.
     set (X := idtoiso (e @ ! e')).
     (* set (X' := invmap (@weq_ff_functor_on_iso _ _ _ HF _ _ ) X). *)
@@ -788,7 +788,7 @@ Proof.
   intro H.
   assert (H' : pr1 a = pr1 a').
   { now apply funextsec. }
-  apply (total2_paths H'), proofirrelevance, isaprop_is_nat_trans, hs.
+  apply (total2_paths_f H'), proofirrelevance, isaprop_is_nat_trans, hs.
 Qed.
 
 Definition nat_trans_eq_pointwise {C C' : precategory_data}
@@ -1124,7 +1124,7 @@ Definition pr1_functor_eq_from_functor_iso (C : precategory_data) (D : precatego
    iso F G -> pr1 F = pr1 G.
 Proof.
   intro A.
-  apply (total2_paths (pr1_pr1_functor_eq_from_functor_iso C D _ H F G A)).
+  apply (total2_paths_f (pr1_pr1_functor_eq_from_functor_iso C D _ H F G A)).
   unfold pr1_pr1_functor_eq_from_functor_iso.
   apply funextsec; intro a.
   apply funextsec; intro b.

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -282,7 +282,7 @@ Proof.
   apply subtypeEquality.
   + intros.
     intro. do 3 (apply impred; intro); apply isapropiscontr.
-  + apply (total2_paths (isotoid _ H (iso_from_BinCoproduct_to_BinCoproduct CC CC'))).
+  + apply (total2_paths_f (isotoid _ H (iso_from_BinCoproduct_to_BinCoproduct CC CC'))).
     rewrite transportf_dirprod.
     rewrite transportf_isotoid'. simpl.
     rewrite transportf_isotoid'.

--- a/UniMath/CategoryTheory/limits/cats/limits.v
+++ b/UniMath/CategoryTheory/limits/cats/limits.v
@@ -293,7 +293,7 @@ apply impred; intro J; apply impred; intro F.
 apply invproofirrelevance; intros Hccx Hccy.
 apply subtypeEquality.
 - intro; apply isaprop_isLimCone.
-- apply (total2_paths (isotoid _ H (iso_from_lim_to_lim Hccx Hccy))).
+- apply (total2_paths_f (isotoid _ H (iso_from_lim_to_lim Hccx Hccy))).
   set (B c := ∏ v, C⟦c,F v⟧).
   set (C' (c : C) f := ∏ u v (e : J⟦u,v⟧), @compose _ c _ _ (f u) (# F e) = f v).
   rewrite (@transportf_total2 _ B C').

--- a/UniMath/CategoryTheory/limits/cones.v
+++ b/UniMath/CategoryTheory/limits/cones.v
@@ -83,7 +83,7 @@ Qed.
 Definition Cone_eq (a b : Cone) : pr1 a = pr1 b -> a = b.
 Proof.
   intro H.
-  apply (total2_paths H).
+  apply (total2_paths_f H).
   apply proofirrelevance.
   apply isaprop_ConeProp.
 Defined.
@@ -111,7 +111,7 @@ Lemma Cone_Mor_eq (M N : Cone) (f g : Cone_Mor M N) :
    ConeConnect f = ConeConnect g -> f = g.
 Proof.
   intro H.
-  apply (total2_paths H).
+  apply (total2_paths_f H).
   apply proofirrelevance.
   apply impred; intro; apply hs.
 Qed.
@@ -224,7 +224,7 @@ Hypothesis is_cat_C : is_category C.
 Definition isotoid_CONE_pr1 (a b : CONE) : iso a b -> pr1 a = pr1 b.
 Proof.
   intro f.
-  apply (total2_paths (isotoid _ is_cat_C (ConeConnectIso f))).
+  apply (total2_paths_f (isotoid _ is_cat_C (ConeConnectIso f))).
   pathvia ((fun c : J =>
      idtoiso (!isotoid C is_cat_C (ConeConnectIso f));; pr2 (pr1 a) c)).
   apply transportf_isotoid_dep'.

--- a/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
@@ -267,7 +267,7 @@ Proof.
   + intros.
     unfold isColimCocone.
     do 2 (apply impred; intro); apply isapropiscontr.
-  + apply (total2_paths (isotoid _ H (iso_from_BinCoproduct_to_BinCoproduct CC CC'))).
+  + apply (total2_paths_f (isotoid _ H (iso_from_BinCoproduct_to_BinCoproduct CC CC'))).
     rewrite transportf_dirprod.
     rewrite transportf_isotoid'. simpl.
     rewrite transportf_isotoid'.

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -391,7 +391,7 @@ apply impred; intro g; apply impred; intro cc.
 apply invproofirrelevance; intros Hccx Hccy.
 apply subtypeEquality.
 - intro; apply isaprop_isColimCocone.
-- apply (total2_paths (isotoid _ H (iso_from_colim_to_colim Hccx Hccy))).
+- apply (total2_paths_f (isotoid _ H (iso_from_colim_to_colim Hccx Hccy))).
   set (B c := ∏ v, C⟦dob cc v,c⟧).
   set (C' (c : C) f := ∏ u v (e : edge u v), @compose _ _ _ c (dmor cc e) (f v) = f u).
   rewrite (@transportf_total2 _ B C').

--- a/UniMath/CategoryTheory/limits/graphs/eqdiag.v
+++ b/UniMath/CategoryTheory/limits/graphs/eqdiag.v
@@ -113,7 +113,7 @@ Lemma eq_diag_is_eq {C : Precategory} {g : graph} (d d' : diagram g C) :
   eq_diag d d' -> d = d'.
 Proof.
   intros [eqv autreq].
-  use total2_paths.
+  use total2_paths_f.
   - apply funextfun.
     intro v.
     apply eqv.

--- a/UniMath/CategoryTheory/limits/graphs/initial.v
+++ b/UniMath/CategoryTheory/limits/graphs/initial.v
@@ -106,7 +106,7 @@ Definition hasInitial := ishinh Initial.
 (* Proof. *)
 (*   apply invproofirrelevance. *)
 (*   intros O O'. *)
-(*   apply (total2_paths (isotoid _ H (iso_Initials O O')) ). *)
+(*   apply (total2_paths_f (isotoid _ H (iso_Initials O O')) ). *)
 (*   apply proofirrelevance. *)
 (*   unfold isInitial. *)
 (*   apply impred. *)

--- a/UniMath/CategoryTheory/limits/graphs/limits.v
+++ b/UniMath/CategoryTheory/limits/graphs/limits.v
@@ -347,7 +347,7 @@ apply impred; intro g; apply impred; intro cc.
 apply invproofirrelevance; intros Hccx Hccy.
 apply subtypeEquality.
 - intro; apply isaprop_isLimCone.
-- apply (total2_paths (isotoid _ H (iso_from_lim_to_lim Hccx Hccy))).
+- apply (total2_paths_f (isotoid _ H (iso_from_lim_to_lim Hccx Hccy))).
   set (B c := ∏ v, C⟦c,dob cc v⟧).
   set (C' (c : C) f := ∏ u v (e : edge u v), @compose _ c _ _ (f u) (dmor cc e) = f v).
   rewrite (@transportf_total2 _ B C').

--- a/UniMath/CategoryTheory/limits/graphs/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/graphs/pullbacks.v
@@ -553,7 +553,7 @@ Proof.
   - intro; apply isofhleveltotal2.
     + apply hs.
     + intros; apply isaprop_isPullback.
-  - apply (total2_paths  (isotoid _ H (iso_from_Pullback_to_Pullback Pb Pb' ))).
+  - apply (total2_paths_f  (isotoid _ H (iso_from_Pullback_to_Pullback Pb Pb' ))).
     rewrite transportf_dirprod, transportf_isotoid.
     rewrite inv_from_iso_iso_from_Pullback.
     rewrite transportf_isotoid.

--- a/UniMath/CategoryTheory/limits/graphs/terminal.v
+++ b/UniMath/CategoryTheory/limits/graphs/terminal.v
@@ -107,7 +107,7 @@ Definition hasTerminal := ishinh Terminal.
 (* Proof. *)
 (*   apply invproofirrelevance. *)
 (*   intros T T'. *)
-(*   apply (total2_paths (isotoid _ H (iso_Terminals T T')) ). *)
+(*   apply (total2_paths_f (isotoid _ H (iso_Terminals T T')) ). *)
 (*   apply proofirrelevance. *)
 (*   unfold isTerminal. *)
 (*   apply impred. *)

--- a/UniMath/CategoryTheory/limits/initial.v
+++ b/UniMath/CategoryTheory/limits/initial.v
@@ -83,7 +83,7 @@ Lemma isaprop_Initial : isaprop Initial.
 Proof.
   apply invproofirrelevance.
   intros O O'.
-  apply (total2_paths (isotoid _ H (iso_Initials O O')) ).
+  apply (total2_paths_f (isotoid _ H (iso_Initials O O')) ).
   apply proofirrelevance.
   unfold isInitial.
   apply impred.

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -338,7 +338,7 @@ Proof.
   - intro; apply isofhleveltotal2.
     + apply hsC.
     + intros; apply isaprop_isPullback.
-  - apply (total2_paths  (isotoid _ H (iso_from_Pullback_to_Pullback Pb Pb' ))).
+  - apply (total2_paths_f  (isotoid _ H (iso_from_Pullback_to_Pullback Pb Pb' ))).
     rewrite transportf_dirprod, transportf_isotoid.
     rewrite inv_from_iso_iso_from_Pullback.
     rewrite transportf_isotoid.

--- a/UniMath/CategoryTheory/limits/pushouts.v
+++ b/UniMath/CategoryTheory/limits/pushouts.v
@@ -270,7 +270,7 @@ Section def_po.
       - intro; apply isofhleveltotal2.
         + apply hsC.
         + intros; apply isaprop_isPushout.
-      - apply (total2_paths
+      - apply (total2_paths_f
                  (isotoid _ H (iso_from_Pushout_to_Pushout Pb Pb' ))).
         rewrite transportf_dirprod, transportf_isotoid', transportf_isotoid'.
         fold (PushoutIn1 Pb). fold (PushoutIn2 Pb).

--- a/UniMath/CategoryTheory/limits/terminal.v
+++ b/UniMath/CategoryTheory/limits/terminal.v
@@ -75,7 +75,7 @@ Lemma isaprop_Terminal : isaprop Terminal.
 Proof.
   apply invproofirrelevance.
   intros T T'.
-  apply (total2_paths (isotoid _ H (iso_Terminals T T')) ).
+  apply (total2_paths_f (isotoid _ H (iso_Terminals T T')) ).
   apply proofirrelevance.
   unfold isTerminal.
   apply impred.

--- a/UniMath/CategoryTheory/limits/zero.v
+++ b/UniMath/CategoryTheory/limits/zero.v
@@ -117,7 +117,7 @@ Section def_zero.
     Proof.
       apply invproofirrelevance.
       intros Z Z'.
-      apply (total2_paths (isotoid _ H (iso_Zeros Z Z'))).
+      apply (total2_paths_f (isotoid _ H (iso_Zeros Z Z'))).
       apply proofirrelevance.
       unfold isZero.
       apply isapropdirprod; apply impred; intros t; apply isapropiscontr.

--- a/UniMath/CategoryTheory/opp_precat.v
+++ b/UniMath/CategoryTheory/opp_precat.v
@@ -79,7 +79,7 @@ Defined.
 
 Lemma opp_opp_precat (C : precategory) (hs : has_homsets C) : C = C^op^op.
 Proof.
-  use total2_paths.
+  use total2_paths_f.
   - apply opp_opp_precat_data.
   - apply (isaprop_is_precategory _ hs).
 Qed.

--- a/UniMath/CategoryTheory/precategories.v
+++ b/UniMath/CategoryTheory/precategories.v
@@ -630,7 +630,7 @@ Proof.
   apply invproofirrelevance.
   intros g g'.
   set (Hpr1 := inverse_unique_precat _ _ _ _ _ _ (pr2 g) (pr2 g')).
-  apply (total2_paths Hpr1).
+  apply (total2_paths_f Hpr1).
   destruct g as [g [eta eps]].
   destruct g' as [g' [eta' eps']].
   simpl in *.
@@ -644,7 +644,7 @@ Lemma eq_z_iso (C : precategory)(hs: has_homsets C) (a b : ob C)
    (f g : z_iso a b) : pr1 f = pr1 g -> f = g.
 Proof.
   intro H.
-  apply (total2_paths H).
+  apply (total2_paths_f H).
   apply proofirrelevance.
   apply isaprop_is_z_isomorphism, hs.
 Defined.

--- a/UniMath/CategoryTheory/precomp_ess_surj.v
+++ b/UniMath/CategoryTheory/precomp_ess_surj.v
@@ -143,7 +143,7 @@ Proof.
   assert (Hpr1 : pr1 (X_aux_type_center_of_contr b anot hnot) = pr1 t).
   set (w := isotoid _ Ccat ((pr2 (pr1 t)) anot hnot) :
           pr1 (pr1 (X_aux_type_center_of_contr b anot hnot)) = pr1 (pr1 t)).
-  apply (total2_paths w).
+  apply (total2_paths_f w).
   simpl.
   destruct t as [[c1 k1] q1].
   simpl in *.
@@ -176,7 +176,7 @@ Proof.
   apply quack.
 
   apply pathsinv0.
-  apply (total2_paths Hpr1).
+  apply (total2_paths_f Hpr1).
   apply proofirrelevance.
 
   repeat (apply impred; intro).
@@ -388,7 +388,7 @@ Proof.
     repeat rewrite <- assoc.
     rewrite iso_after_iso_inv, id_right.
     apply idpath.
-  apply (total2_paths Hpr).
+  apply (total2_paths_f Hpr).
   apply proofirrelevance.
   repeat (apply impred; intro).
   apply (pr2 Ccat).
@@ -803,7 +803,7 @@ Defined.
 Lemma is_preimage_for_pre_composition : functor_composite H GG = F.
 Proof.
   apply (functor_eq _ _  (pr2 Ccat) (functor_composite H GG) F).
-  apply (total2_paths extphi).
+  apply (total2_paths_f extphi).
   apply funextsec; intro a0;
   apply funextsec; intro a0';
   apply funextsec; intro f.

--- a/UniMath/CategoryTheory/slicecat.v
+++ b/UniMath/CategoryTheory/slicecat.v
@@ -143,7 +143,7 @@ Qed.
 
 Lemma eq_mor_slicecat (af bg : C / x) (f g : C/x⟦af,bg⟧) : pr1 f = pr1 g -> f = g.
 Proof.
-now intro heq; apply (total2_paths heq); apply hsC.
+now intro heq; apply (total2_paths_f heq); apply hsC.
 Qed.
 
 Lemma eq_iso_slicecat (af bg : C / x) (f g : iso af bg) : pr1 f = pr1 g -> f = g.

--- a/UniMath/CategoryTheory/slicecat.v
+++ b/UniMath/CategoryTheory/slicecat.v
@@ -300,7 +300,7 @@ Lemma slicecat_functor_identity (x : C) :
   slicecat_functor _ (identity x) = functor_identity (C / x).
 Proof.
 apply (functor_eq _ _ (has_homsets_slice_precat _ _)); simpl.
-apply (total2_paths2 (slicecat_functor_identity_ob _)).
+apply (two_arg_paths_f (slicecat_functor_identity_ob _)).
 apply funextsec; intros [a f].
 apply funextsec; intros [b g].
 apply funextsec; intros [h hh].
@@ -331,7 +331,7 @@ Proof.
 apply (functor_eq _ _ (has_homsets_slice_precat _ _)); simpl.
 unfold slicecat_functor_data; simpl.
 unfold functor_composite_data; simpl.
-apply (total2_paths2 (slicecat_functor_comp_ob _ _)).
+apply (two_arg_paths_f (slicecat_functor_comp_ob _ _)).
 apply funextsec; intros [a fax].
 apply funextsec; intros [b fbx].
 apply funextsec; intros [h hh].

--- a/UniMath/CategoryTheory/sub_precategories.v
+++ b/UniMath/CategoryTheory/sub_precategories.v
@@ -213,9 +213,9 @@ Lemma eq_in_sub_precategory2 (C : precategory)(C':sub_precategories C)
       (tpair (fun f => sub_precategory_predicate_morphisms _ _ _ f) g pg).
 Proof.
   intro H.
-  apply (total2_paths2 H).
+  apply (two_arg_paths_f H).
   destruct H.
-  apply (total2_paths2 (idpath _ )).
+  apply (two_arg_paths_f (idpath _ )).
 *)
 
 Definition is_precategory_sub_category (C : precategory)(C':sub_precategories C) :
@@ -434,7 +434,7 @@ Proof.
   destruct F as [F Fax].
   simpl.
   destruct F as [Fob Fmor]; simpl in *.
-  apply (total2_paths2 (H)).
+  apply (two_arg_paths_f (H)).
   unfold functor_full_img_factorization_ob in H.
   simpl in *.
   apply dep_funextfun.

--- a/UniMath/CategoryTheory/sub_precategories.v
+++ b/UniMath/CategoryTheory/sub_precategories.v
@@ -199,7 +199,7 @@ Proof.
   intro H.
   destruct f as [f p].
   destruct g as [g p'].
-  apply (total2_paths H).
+  apply (total2_paths_f H).
   apply proofirrelevance.
   apply pr2.
 Qed.

--- a/UniMath/CategoryTheory/total2_paths.v
+++ b/UniMath/CategoryTheory/total2_paths.v
@@ -33,7 +33,7 @@ Lemma total2_paths2_UU {B : UU -> UU} {A A': UU} {b : B A}
      {b' : B A'} (p : A = A') (q : transportf (fun x => B x) p b = b') :
     tpair (fun x => B x) A b = tpair (fun x => B x) A' b'.
 Proof.
-  apply (@total2_paths _ _
+  apply (@total2_paths_f _ _
      (tpair (fun x => B x) A b)(tpair (fun x => B x) A' b') p q).
 Defined.
 
@@ -94,7 +94,7 @@ Lemma eq_equalities_between_pairs (A : UU)(B : A -> UU)(x y : total2 (fun x => B
          H (fiber_paths p) = fiber_paths q) :  p = q.
 Proof.
   apply (invmaponpathsweq (total2_paths_equiv _ _ _ )).
-  apply (total2_paths (B:=(fun p : pr1 x = pr1 y =>
+  apply (total2_paths_f (B:=(fun p : pr1 x = pr1 y =>
           transportf (fun x : A => B x) p (pr2 x) = pr2 y))
           (s:=(total2_paths_equiv B x y) p)
           (s':=(total2_paths_equiv B x y) q) H).

--- a/UniMath/Combinatorics/FiniteSequences.v
+++ b/UniMath/Combinatorics/FiniteSequences.v
@@ -136,7 +136,7 @@ Defined.
 
 Definition nil_unique {X} (x : stn 0 -> X) : nil = (0,,x).
 Proof.
-  intros. apply pair_path_in2. apply isapropifcontr. apply stn0_fun_iscontr.
+  intros. unfold nil. apply maponpaths. apply isapropifcontr. apply stn0_fun_iscontr.
 Defined.
 
 Definition isaset_transportf {X : hSet} (P : X ->UU) {x : X} (e : x = x) (p : P x) :
@@ -450,13 +450,13 @@ Proof.
   unfold total2_step_b, total2_step_f.
   induction (natlehchoice4 j n J) as [J'|K].
   + simpl.
-    simple refine (total2_paths _ _).
+    simple refine (total2_paths_f _ _).
     * simpl. rewrite replace_dni_last. apply isinjstntonat. reflexivity.
     * rewrite replace_dni_last. unfold dni_lastelement.  simpl.
       change (λ x0 : stn (S n), X x0) with X.
       rewrite transport_f_b. apply (isaset_transportf X).
   + induction (!K). simpl.
-    simple refine (total2_paths _ _).
+    simple refine (total2_paths_f _ _).
     * simpl. now apply isinjstntonat.
     * simpl. assert (d : idpath n = K).
       { apply isasetnat. }
@@ -593,7 +593,7 @@ Definition isassoc_concatenate {X} (x y z:Sequence X) :
   concatenate (concatenate x y) z = concatenate x (concatenate y z).
 Proof.
   intros.
-  simple refine (total2_paths _ _).
+  simple refine (total2_paths_f _ _).
   - simpl. apply natplusassoc.
   - apply sequenceEquality; intros i.
 

--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -766,31 +766,15 @@ Proof.
   induction s as [a b].
   induction s' as [a' b']; simpl in *.
   induction p.
-  induction (!q).
+  change _ with (b=b') in q.
+  induction q.
   reflexivity.
-Defined.
-
-Lemma total2_paths2 {A : UU} {B : A -> UU} {a1 : A} {b1 : B a1}
-      {a2 : A} {b2 : B a2} (p : a1 = a2)
-      (q : transportf B p b1 = b2) : a1,,b1 = a2,,b2.
-Proof.
-  intros.
-  apply (@total2_paths _ _ (tpair (fun x => B x) a1 b1)
-                       (tpair (fun x => B x) a2 b2) p q).
-Defined.
-
-Lemma total2_paths2_b {A : UU} {B : A -> UU} {a1 : A} {b1 : B a1}
-  {a2 : A} {b2 : B a2} (p : a1 = a2)
-  (q : b1 = transportb B p b2) : a1,,b1 = a2,,b2.
-Proof.
-  intros.
-  apply (@total2_paths_b _ _
-    (tpair (fun x => B x) a1 b1) (tpair (fun x => B x) a2 b2) p q).
 Defined.
 
 Lemma two_arg_paths_f {A : UU} {B : A -> UU} {C:UU} {f : ∏ a, B a -> C} {a1 : A} {b1 : B a1}
       {a2 : A} {b2 : B a2} (p : a1 = a2)
       (q : transportf B p b1 = b2) : f a1 b1 = f a2 b2.
+(* This lemma replaced [total2_paths2], which is the special case f := tpair _ *)
 Proof.
   intros. induction p. induction q. reflexivity.
 Defined.
@@ -798,6 +782,7 @@ Defined.
 Lemma two_arg_paths_b {A : UU} {B : A -> UU} {C:UU} {f : ∏ a, B a -> C} {a1 : A} {b1 : B a1}
   {a2 : A} {b2 : B a2} (p : a1 = a2)
   (q : b1 = transportb B p b2) : f a1 b1 = f a2 b2.
+(* This lemma replaced [total2_paths2_b], which is the special case f := tpair _ *)
 Proof.
   intros. induction p. change _ with (b1 = b2) in q. induction q. reflexivity.
 Defined.

--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -748,20 +748,26 @@ Defined.
 
 Lemma two_arg_paths {A B C:UU} {f : A -> B -> C} {a1 b1 a2 b2} (p : a1 = a2)
       (q : b1 = b2) : f a1 b1 = f a2 b2.
+(* This lemma is an analogue of [maponpaths] for functions of two arguments. *)
 Proof.
   intros. induction p. induction q. reflexivity.
 Defined.
 
 Lemma two_arg_paths_f {A : UU} {B : A -> UU} {C:UU} {f : ∏ a, B a -> C} {a1 b1 a2  b2}
       (p : a1 = a2) (q : transportf B p b1 = b2) : f a1 b1 = f a2 b2.
-(* This lemma generalizes [total2_paths2_f], which is the special case f := tpair _ *)
+(* This lemma is a replacement for and a generalization of [total2_paths2_f], formerly called
+   [total2_paths2], which does not refer to [total2].  The lemma [total2_paths2_f] can be obtained
+   as the special case [f := tpair _], and Coq can often infer the value for [f], which is declared
+   as an implicit argument. *)
 Proof.
   intros. induction p. induction q. reflexivity.
 Defined.
 
 Lemma two_arg_paths_b {A : UU} {B : A -> UU} {C:UU} {f : ∏ a, B a -> C} {a1 b1 a2 b2}
       (p : a1 = a2) (q : b1 = transportb B p b2) : f a1 b1 = f a2 b2.
-(* This lemma generalizes [total2_paths2_b], which is the special case f := tpair _ *)
+(* This lemma is a replacement for and a generalization of [total2_paths2_b], which does not refer
+   to [total2].  The lemma [total2_paths2_b] can be obtained as the special case [f := tpair _],
+   and Coq can often infer the value for [f], which is declared as an implicit argument. *)
 Proof.
   intros. induction p. change _ with (b1 = b2) in q. induction q. reflexivity.
 Defined.

--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -788,8 +788,23 @@ Proof.
     (tpair (fun x => B x) a1 b1) (tpair (fun x => B x) a2 b2) p q).
 Defined.
 
+Lemma two_arg_paths_f {A : UU} {B : A -> UU} {C:UU} {f : ∏ a, B a -> C} {a1 : A} {b1 : B a1}
+      {a2 : A} {b2 : B a2} (p : a1 = a2)
+      (q : transportf B p b1 = b2) : f a1 b1 = f a2 b2.
+Proof.
+  intros. induction p. induction q. reflexivity.
+Defined.
+
+Lemma two_arg_paths_b {A : UU} {B : A -> UU} {C:UU} {f : ∏ a, B a -> C} {a1 : A} {b1 : B a1}
+  {a2 : A} {b2 : B a2} (p : a1 = a2)
+  (q : b1 = transportb B p b2) : f a1 b1 = f a2 b2.
+Proof.
+  intros. induction p. change _ with (b1 = b2) in q. induction q. reflexivity.
+Defined.
+
 Definition pair_path_in2 {X : UU} (P : X -> UU) {x : X} {p q : P x} (e : p = q) :
   x,,p = x,,q.
+(* this function is probably not needed *)
 Proof.
   intros. now apply maponpaths.
 Defined.
@@ -1462,7 +1477,7 @@ Proof.
   induction ha as [x e].
   unfold hc. unfold hfiberpair. unfold isconnectedunit.
   simpl.
-  apply (fun q => total2_paths2 (h x) q).
+  apply (fun q => two_arg_paths_f (h x) q).
   apply ifcontrthenunitl0.
 Defined.
 
@@ -1494,7 +1509,7 @@ Proof.
   unfold hfibersgftog.
   unfold hfiberpair.
   simpl.
-  apply (total2_paths2 eint).
+  apply (two_arg_paths_f eint).
   induction eint.
   apply idpath.
 Defined.
@@ -1671,7 +1686,7 @@ Proof.
   - intro p.
     apply total2_fiber_paths.
   - intros [p q]. simpl in *.
-    apply (total2_paths2 (base_total2_paths q)).
+    apply (two_arg_paths_f (base_total2_paths q)).
     apply transportf_fiber_total2_paths.
 Defined.
 

--- a/UniMath/Foundations/PartB.v
+++ b/UniMath/Foundations/PartB.v
@@ -576,7 +576,7 @@ Proof.
   intros. simple refine (weqgradth _ _ _ _).
   + intros [x [t e]]. exact (x,,!e).
   + intros [x e]. exact (x,,tt,,!e).
-  + intros [x [t e]]. apply maponpaths. simple refine (total2_paths2 _ _).
+  + intros [x [t e]]. apply maponpaths. simple refine (two_arg_paths_f _ _).
     * apply isapropunit.
     * simpl. induction e. rewrite pathsinv0inv0. induction t. reflexivity.
   + intros [x e]. apply maponpaths. apply pathsinv0inv0.
@@ -823,13 +823,13 @@ Defined.
 Definition subtypePairEquality {X : UU} {P : X -> UU} (is : isPredicate P)
            {x y : X} {p : P x} {q : P y} :
   x = y -> (x,,p) = (y,,q).
-Proof. intros X P is x y p q e. apply (total2_paths2 e). apply is. Defined.
+Proof. intros X P is x y p q e. apply (two_arg_paths_f e). apply is. Defined.
 
 Definition subtypePairEquality' {X : UU} {P : X -> UU}
            {x y : X} {p : P x} {q : P y} :
   x = y -> isaprop(P y) -> (x,,p) = (y,,q).
 (* This variant of subtypePairEquality is never needed. *)
-Proof. intros X P x y p q e is. apply (total2_paths2 e). apply is. Defined.
+Proof. intros X P x y p q e is. apply (two_arg_paths_f e). apply is. Defined.
 
 Theorem samehfibers {X Y Z : UU} (f : X -> Y) (g : Y -> Z) (is1 : isincl g)
         (y : Y) :  hfiber f y ≃ hfiber (g ∘ f) (g y).

--- a/UniMath/Foundations/PartB.v
+++ b/UniMath/Foundations/PartB.v
@@ -804,7 +804,7 @@ Defined.
 Corollary subtypeEquality' {A : UU} {B : A -> UU}
    {s s' : total2 (fun x => B x)} : pr1 s = pr1 s' -> isaprop (B (pr1 s')) -> s = s'.
 (* This variant of subtypeEquality is not often needed. *)
-Proof. intros ? ? ? ? e is. apply (total2_paths e). apply is. Defined.
+Proof. intros ? ? ? ? e is. apply (total2_paths_f e). apply is. Defined.
 
 (* This corollary of subtypeEquality is used for categories. *)
 Corollary unique_exists {A : UU} {B : A -> UU} (x : A) (b : B x)
@@ -956,7 +956,7 @@ Proof.
   unshelve refine (_,,_).
   - exists (pr1 (sur y)). exact (pr2 (sur y)).
   - intro w.
-    unshelve refine (total2_paths _ _).
+    unshelve refine (total2_paths_f _ _).
     + simpl. apply inj. intermediate_path y.
       * exact (pr2 w).
       * exact (! pr2 (sur y)).

--- a/UniMath/Foundations/PartD.v
+++ b/UniMath/Foundations/PartD.v
@@ -882,7 +882,7 @@ Lemma eqweqmap_pathscomp0 {A B C : UU} (p : A = B) (q : B = C)
 Proof.
   induction p.
   induction q.
-  eapply total2_paths.
+  eapply total2_paths_f.
     apply isapropisweq.
     Unshelve.
   reflexivity.
@@ -892,7 +892,7 @@ Lemma inv_idweq_is_idweq {A : UU} :
   idweq A = invweq (idweq A).
 Proof.
   intros A.
-  eapply total2_paths.
+  eapply total2_paths_f.
   apply isapropisweq.
   Unshelve.
   reflexivity.

--- a/UniMath/HomologicalAlgebra/CohomologyComplex.v
+++ b/UniMath/HomologicalAlgebra/CohomologyComplex.v
@@ -1149,7 +1149,7 @@ Section def_cohomology_homotopy.
              (h : CohomologyFunctorHIm f) (h' : CohomologyFunctorHIm f)
              (e : CohomologyFunctorHImMor h = CohomologyFunctorHImMor h') : h = h'.
   Proof.
-    use total2_paths.
+    use total2_paths_f.
     - exact e.
     - apply proofirrelevance. apply impred_isaprop. intros t0.
       apply impred_isaprop. intros H0. apply has_homsets_ComplexPreCat.
@@ -1243,8 +1243,8 @@ Section def_cohomology_homotopy.
     functor_composite (ComplexHomotFunctor (AbelianToAdditive A hs)) CohomologyFunctorH =
     (CohomologyFunctor A hs).
   Proof.
-    use total2_paths.
-    - use total2_paths.
+    use total2_paths_f.
+    - use total2_paths_f.
       + apply idpath.
       + rewrite idpath_transportf.
         use funextsec. intros C1.
@@ -1597,7 +1597,7 @@ Section def_kernel_cokernel_complex.
     CokernelKernelMorphism_comm3 C i,, CokernelKernelMorphism_comm2' C i.
   Proof.
     intros t. induction t as [t1 t2]. induction t2 as [t21 t22].
-    use total2_paths.
+    use total2_paths_f.
     - cbn. use KernelInsEq. rewrite KernelCommutes.
       use CokernelOutsEq. rewrite CokernelCommutes.
       rewrite assoc.

--- a/UniMath/HomologicalAlgebra/Complexes.v
+++ b/UniMath/HomologicalAlgebra/Complexes.v
@@ -139,7 +139,7 @@ Section def_complexes.
       (λ x : ∑ D : hz → A, ∏ i : hz, A ⟦ D i, D (i + 1) ⟧,
                                  ∏ i : hz, pr2 x i ;; pr2 x (i + 1) =
                                            ZeroArrow (Additive.to_Zero A) _ _)
-      (total2_paths (funextfun (pr1 (pr1 C1)) (pr1 (pr1 C2)) (λ i : hz, H i))
+      (total2_paths_f (funextfun (pr1 (pr1 C1)) (pr1 (pr1 C2)) (λ i : hz, H i))
                     (ComplexEq' C1 C2 H H1)) (pr2 C1) = pr2 C2.
   Proof.
     apply proofirrelevance. apply impred_isaprop. intros t. apply to_has_homsets.
@@ -151,8 +151,8 @@ Section def_complexes.
                          (transportf (λ x : A, x --> C1 (i + 1)) (H i) (Diff C1 i)) =
               Diff C2 i) : C1 = C2.
   Proof.
-    use total2_paths.
-    - use total2_paths.
+    use total2_paths_f.
+    - use total2_paths_f.
       + use funextfun. intros i. exact (H i).
       + exact (ComplexEq' C1 C2 H H1).
     - exact (ComplexEq'' C1 C2 H H1).
@@ -215,7 +215,7 @@ Section def_complexes.
   Lemma MorphismEq {C1 C2 : Complex} (M1 M2 : Morphism C1 C2) (H : ∏ i : hz, M1 i = M2 i) :
     M1 = M2.
   Proof.
-    use total2_paths.
+    use total2_paths_f.
     - use funextsec. intros i. exact (H i).
     - use proofirrelevance. apply impred_isaprop. intros t. apply to_has_homsets.
   Qed.
@@ -2823,7 +2823,7 @@ Section translation_functor.
 
   Lemma transportf_total2_base {AA : UU} {B : AA -> UU} {BB : AA -> UU} (s s' : ∑ x : AA, B x)
         (p : pr1 s = pr1 s') (q : transportf B p (pr2 s) = pr2 s') (x : BB (pr1 s)) :
-    transportf (λ x' : ∑ x : AA, B x, BB (pr1 x')) (total2_paths p q) x =
+    transportf (λ x' : ∑ x : AA, B x, BB (pr1 x')) (total2_paths_f p q) x =
     transportf (λ x : AA, BB x) p x.
   Proof.
     induction s as [s1 s2]. induction s' as [s1' s2']. cbn in *.
@@ -2849,7 +2849,7 @@ Section translation_functor.
     set (e := (funextfun (pr1 (pr1 C2)) (pr1 (pr1 C2')) (λ x0 : pr1 hz, H x0))).
     cbn. cbn in e. fold e.
     set (tmp := @transportf_total2_base _ _ (λ x0 : _ , A ⟦ pr1 (pr1 C1) i, (pr1 x0) i ⟧) C2 C2'
-                                        (total2_paths e (ComplexEq' A C2 C2' H H1))
+                                        (total2_paths_f e (ComplexEq' A C2 C2' H H1))
                                         (ComplexEq'' A C2 C2' H H1) (f i)).
     cbn beta in tmp.
     use (pathscomp0 tmp). clear tmp.
@@ -3022,7 +3022,7 @@ Section translation_functor.
              {f : (ComplexHomot_Additive A)⟦C1, C2⟧} (h h' : TranslationFunctorHIm f)
              (e : TranslationFunctorHImMor h = TranslationFunctorHImMor h') : h = h'.
   Proof.
-    use total2_paths.
+    use total2_paths_f.
     - exact e.
     - apply proofirrelevance. apply impred_isaprop. intros t0.
       apply impred_isaprop. intros H0. apply has_homsets_ComplexHomot_Additive.
@@ -3238,7 +3238,7 @@ Section translation_functor.
              {f : (ComplexHomot_Additive A)⟦C1, C2⟧} (h h' : InvTranslationFunctorHIm f)
              (e : InvTranslationFunctorHImMor h = InvTranslationFunctorHImMor h') : h = h'.
   Proof.
-    use total2_paths.
+    use total2_paths_f.
     - exact e.
     - apply proofirrelevance. apply impred_isaprop. intros t0.
       apply impred_isaprop. intros H0. apply has_homsets_ComplexHomot_Additive.

--- a/UniMath/Ktheory/AffineLine.v
+++ b/UniMath/Ktheory/AffineLine.v
@@ -420,7 +420,7 @@ Definition makeGuidedHomotopy_verticalPath {T:Torsor ℤ} {Y} (f:T->Y)
            (s:target_paths f) {y:Y} t0 (h0:y=f t0)
            {y':Y} (p:y' = y) :
   makeGuidedHomotopy f s t0 (p@h0) = makeGuidedHomotopy f s t0 h0.
-Proof. intros. apply (total2_paths2 p). destruct p. reflexivity. Defined.
+Proof. intros. apply (two_arg_paths_f p). destruct p. reflexivity. Defined.
 
 Definition makeGuidedHomotopy_verticalPath_comp {T:Torsor ℤ} {Y} (f:T->Y)
            (s:target_paths f) {y:Y} t0 (h0:y=f t0)

--- a/UniMath/Ktheory/AffineLine.v
+++ b/UniMath/Ktheory/AffineLine.v
@@ -431,7 +431,7 @@ Proof. intros. apply total2_paths2_comp1. Defined.
 Definition makeGuidedHomotopy_transPath {T:Torsor ℤ} {Y} (f:T->Y)
            (s:target_paths f) {y:Y} t0 (h0:y=f t0) :
   makeGuidedHomotopy f s t0 h0 = makeGuidedHomotopy f s (one+t0) (h0 @ s t0).
-Proof. intros. apply pair_path_in2.
+Proof. intros. apply (maponpaths (tpair _ _)).
        exact (ℤTorsorRecursion_transition_inv
                 _ (fun t => weq_pathscomp0r y (s t)) _ _). Defined.
 

--- a/UniMath/Ktheory/Bifunctor.v
+++ b/UniMath/Ktheory/Bifunctor.v
@@ -270,7 +270,7 @@ Proof.
     { abstract (
           intros F G q; simpl in F, G; simpl;
           apply funextsec; intro w;
-          unshelve refine (two_arg_paths_f (f := tpair _) _ _);
+          unshelve refine (total2_paths2_f _ _);
           [ apply funextsec; intro b;
             unfold φ_map, φ_map_1, θ_map_1; simpl;
             unfold θ_map_1; simpl;
@@ -288,7 +288,7 @@ Proof.
       unfold φ_map; simpl; unfold φ_map_1; simpl;
       apply funextsec; intro w;
       simpl;
-      unshelve refine (total2_paths _ _);
+      unshelve refine (total2_paths_f _ _);
       [ simpl; apply funextsec; intro b; reflexivity
       | apply funextsec; intro b;
         apply funextsec; intro b';
@@ -302,7 +302,7 @@ Proof.
               | intro G;
                 simpl;
                 apply funextsec; intro w;
-                unshelve refine (two_arg_paths_f (f := tpair _) _ _);
+                unshelve refine (total2_paths2_f _ _);
                 [ unfold φ_map, φ_map_1; simpl;
                   apply funextsec; intro b;
                   apply pathsinv0, nattrans_nattrans_arrow_assoc

--- a/UniMath/Ktheory/Bifunctor.v
+++ b/UniMath/Ktheory/Bifunctor.v
@@ -270,7 +270,7 @@ Proof.
     { abstract (
           intros F G q; simpl in F, G; simpl;
           apply funextsec; intro w;
-          unshelve refine (total2_paths2 _ _);
+          unshelve refine (two_arg_paths_f (f := tpair _) _ _);
           [ apply funextsec; intro b;
             unfold φ_map, φ_map_1, θ_map_1; simpl;
             unfold θ_map_1; simpl;
@@ -302,7 +302,7 @@ Proof.
               | intro G;
                 simpl;
                 apply funextsec; intro w;
-                unshelve refine (total2_paths2 _ _);
+                unshelve refine (two_arg_paths_f (f := tpair _) _ _);
                 [ unfold φ_map, φ_map_1; simpl;
                   apply funextsec; intro b;
                   apply pathsinv0, nattrans_nattrans_arrow_assoc

--- a/UniMath/Ktheory/GroupAction.v
+++ b/UniMath/Ktheory/GroupAction.v
@@ -234,7 +234,7 @@ Defined.
 
 Definition Action_univalence_prelim_comp {G:gr} {X Y:Action G} (p:X = Y) :
    Action_univalence_prelim p = path_to_ActionIso p.
-Proof. intros. destruct p. apply pair_path_in2. apply funextsec; intro g.
+Proof. intros. destruct p. apply (maponpaths (tpair _ _)). apply funextsec; intro g.
        apply funextsec; intro x. apply setproperty. Defined.
 
 Lemma path_to_ActionIso_isweq {G:gr} {X Y:Action G}  :

--- a/UniMath/Ktheory/Halfline.v
+++ b/UniMath/Ktheory/Halfline.v
@@ -39,7 +39,7 @@ Proof. intros ? ? ? r. apply (squash_to_prop r).
 
 Definition map_path {Y} {f:ℕ->Y} (s:target_paths f) :
   ∏ n, map s (squash_element n) = map s (squash_element (S n)).
-Proof. intros. apply (total2_paths2 (s n)).
+Proof. intros. apply (two_arg_paths_f (s n)).
        simpl. reflexivity. Defined.
 
 Definition map_path_check {Y} {f:ℕ->Y} (s:target_paths f) (n:ℕ) :

--- a/UniMath/Ktheory/MoreEquivalences.v
+++ b/UniMath/Ktheory/MoreEquivalences.v
@@ -93,7 +93,7 @@ Proof. intros.
        apply Equivalence_to_weq.
        simple refine (makeEquivalence _ _ _ _ _ _ _).
        { exact pr1. } { intro x. exact (x,,sec x). } { intro x. reflexivity. }
-       { intros [x p]. simpl. apply pair_path_in2. apply irr. }
+       { intros [x p]. simpl. apply maponpaths. apply irr. }
        { intros [x p]. simpl. apply pair_path_in2_comp1. } Defined.
 
 Definition invweqpr1_irr_sec {X} {P:X->Type}
@@ -104,7 +104,7 @@ Proof. intros.
        apply Equivalence_to_weq.
        simple refine (makeEquivalence _ _ _ _ _ _ _).
        { intro x. exact (x,,sec x). } { exact pr1. }
-       { intros [x p]. simpl. apply pair_path_in2. apply irr. }
+       { intros [x p]. simpl. apply maponpaths. apply irr. }
        { intro x. reflexivity. }
        { intro x'. simpl. rewrite (irrel_paths (irr _) (irr _ _ _) (idpath (sec x'))).
          reflexivity. } Defined.
@@ -122,7 +122,7 @@ Definition homotinvweqweq'_comp {X} {P:X->Type}
   let w' := invweq f x in
   @identity (w' = w)
             (homotinvweqweq' irr sec w)
-            (pair_path_in2 P (irr x (sec x) (pr2 w))).
+            (maponpaths _ (irr x (sec x) (pr2 w))).
 Proof. reflexivity.             (* don't change the proof *)
 Defined.
 
@@ -134,7 +134,7 @@ Definition homotinvweqweq_comp {X} {P:X->Type}
   let w' := invweq f x in
   @identity (w' = w)
             (homotinvweqweq f w)
-            (pair_path_in2 P (irr x (sec x) (pr2 w))).
+            (maponpaths _ (irr x (sec x) (pr2 w))).
 Proof.
   try reflexivity.              (* this worked above but doesn't work here *)
 Abort.
@@ -148,7 +148,7 @@ Definition homotinvweqweq_comp_3 {X} {P:X->Type}
   let w' := g x in
   @identity (w' = w)
             (homotweqinvweq g w)    (* !! *)
-            (pair_path_in2 P (irr x (sec x) (pr2 w))).
+            (maponpaths _ (irr x (sec x) (pr2 w))).
 Proof. reflexivity. Defined.
 
 Definition loop_correspondence {T X Y}

--- a/UniMath/Ktheory/MoreEquivalences.v
+++ b/UniMath/Ktheory/MoreEquivalences.v
@@ -21,7 +21,7 @@ Abort.
 
 Definition Equivalence_to_invweq X Y : Equivalence X Y -> Y ≃ X.
 Proof. intros ? ? [f [g [p [q h]]]]. exists g. unfold isweq. intro x.
-       exists (f x,,q x). intros [y []]. apply (total2_paths2 (!p y)).
+       exists (f x,,q x). intros [y []]. apply (two_arg_paths_f (!p y)).
        admit.
 Abort.
 

--- a/UniMath/Ktheory/Nat.v
+++ b/UniMath/Ktheory/Nat.v
@@ -28,7 +28,7 @@ Module Uniqueness.
            { simpl. rewrite <- path_assoc. simple refine (_ @ pathscomp0rid _).
              rewrite <- maponpathscomp0. rewrite IHn. rewrite pathsinv0l.
              simpl. reflexivity. } }
-         { intros [h0 h']. apply pair_path_in2. apply funextsec; intro n; simpl.
+         { intros [h0 h']. apply maponpaths. apply funextsec; intro n; simpl.
            rewrite <- path_assoc. rewrite <- maponpathscomp0. rewrite pathsinv0r.
            apply pathscomp0rid. } Defined.
 

--- a/UniMath/Ktheory/Precategories.v
+++ b/UniMath/Ktheory/Precategories.v
@@ -42,7 +42,7 @@ Ltac eqn_logic :=
           try apply isasetunit;
           try apply isapropunit;
           try refine (two_arg_paths_f _ _);
-          try refine (total2_paths _ _);
+          try refine (total2_paths_f _ _);
           try refine (nat_trans_ax _ _ _ _);
           try refine (! nat_trans_ax _ _ _ _);
           try apply functor_id;
@@ -436,10 +436,10 @@ Proof.
   { simpl. unshelve refine (gradth _ _ _ _).
     { exact (functor_opp : B^op ==> C^op -> B ==> C). }
     { abstract (intros H; simpl; apply (functor_eq _ _ (homset_property C));
-                unshelve refine (total2_paths _ _); reflexivity) using _L_. }
+                unshelve refine (total2_paths_f _ _); reflexivity) using _L_. }
     { abstract (intros H; simpl; apply functor_eq;
                 [ exact (homset_property C^op)
-                | unshelve refine (total2_paths _ _); reflexivity]). } }
+                | unshelve refine (total2_paths_f _ _); reflexivity]). } }
 Defined.
 
 Definition functorOpEmb {B C:Precategory} : PrecategoryEmbedding [B, C]^op [B^op, C^op]
@@ -450,7 +450,7 @@ Lemma functor_op_rm_op_eq {C D:Precategory} (F : C^op ==> D^op) :
 Proof.
   apply functor_eq.
   { apply homset_property. }
-  unshelve refine (total2_paths _ _); reflexivity.
+  unshelve refine (total2_paths_f _ _); reflexivity.
 Qed.
 
 Lemma functor_rm_op_op_eq {C D:Precategory} (F : C ==> D) :
@@ -458,7 +458,7 @@ Lemma functor_rm_op_op_eq {C D:Precategory} (F : C ==> D) :
 Proof.
   apply functor_eq.
   { apply homset_property. }
-  unshelve refine (total2_paths _ _); reflexivity.
+  unshelve refine (total2_paths_f _ _); reflexivity.
 Qed.
 
 Lemma functor_op_op_eq {C D:Precategory} (F : C ==> D) :
@@ -466,7 +466,7 @@ Lemma functor_op_op_eq {C D:Precategory} (F : C ==> D) :
 Proof.
   apply functor_eq.
   { apply homset_property. }
-  unshelve refine (total2_paths _ _); reflexivity.
+  unshelve refine (total2_paths_f _ _); reflexivity.
 Qed.
 
 (*  *)
@@ -579,9 +579,9 @@ Definition hasZeroMaps_opp (C:Precategory) : hasZeroMaps C -> hasZeroMaps C^op
 Definition hasZeroMaps_opp_opp (C:Precategory) (zero:hasZeroMaps C) :
   hasZeroMaps_opp C^op (hasZeroMaps_opp C zero) = zero.
 Proof.
-  unshelve refine (total2_paths _ _).
+  unshelve refine (total2_paths_f _ _).
   - reflexivity.
-  - unshelve refine (total2_paths _ _); reflexivity.
+  - unshelve refine (total2_paths_f _ _); reflexivity.
 Defined.
 
       (*  *)

--- a/UniMath/Ktheory/Precategories.v
+++ b/UniMath/Ktheory/Precategories.v
@@ -41,7 +41,7 @@ Ltac eqn_logic :=
           try apply homset_property;
           try apply isasetunit;
           try apply isapropunit;
-          try refine (total2_paths2 _ _);
+          try refine (two_arg_paths_f _ _);
           try refine (total2_paths _ _);
           try refine (nat_trans_ax _ _ _ _);
           try refine (! nat_trans_ax _ _ _ _);

--- a/UniMath/Ktheory/Representation.v
+++ b/UniMath/Ktheory/Representation.v
@@ -585,7 +585,7 @@ Proof.
               | apply proofirrelevance; apply homset_property]) using _N_.
   - abstract (
         intros r s t p q; simpl in *; apply funextsec; intro w;
-        unshelve refine (two_arg_paths_f (f := tpair _) _ _);
+        unshelve refine (total2_paths2_f _ _);
         [ simpl; rewrite 2? assoc; reflexivity
         | apply proofirrelevance; apply homset_property]) using _P_.
 Defined.
@@ -694,7 +694,7 @@ Proof.
               | apply setproperty]) using _R_.
   - abstract (intros b b' b'' g g''; apply funextsec; intro w;
               induction w as [w e]; induction w as [f x]; simpl;
-              unshelve refine (two_arg_paths_f (f := tpair _) _ _);
+              unshelve refine (total2_paths2_f _ _);
               [ apply dirprodeq;
                 [ apply pathsinv0, assoc | apply arrow_mor_mor_assoc ]
               | apply setproperty ]) using _T_.
@@ -847,7 +847,7 @@ Proof.
                       apply (maponpaths (λ k, X ▭ f ⟳ k));
                       apply pathsinv0;
                       exact (universalMapProperty (r b) (pr1 x' b)) ]) using _R_. } }
-      { abstract (unshelve refine (total2_paths _ _);
+      { abstract (unshelve refine (total2_paths_f _ _);
         [ simpl; apply funextsec; intro b; unshelve refine (universalMapProperty _ _)
         | apply funextsec; intro b;
           apply funextsec; intro b';
@@ -927,7 +927,7 @@ Proof.
       { abstract (intros b b' f; simpl;
                   apply dirprodeq; ( simpl; apply nattrans_naturality )) using _L_. } }
     { abstract (intros w;
-                unshelve refine (total2_paths _ _);
+                unshelve refine (total2_paths_f _ _);
                 [ apply funextsec; intro b; apply pathsinv0, tppr
                 | (apply funextsec; intro b;
                    apply funextsec; intro b';

--- a/UniMath/Ktheory/Representation.v
+++ b/UniMath/Ktheory/Representation.v
@@ -580,12 +580,12 @@ Proof.
         simpl; rewrite <- 2? assoc; apply maponpaths; exact (pr2 w)) using _M_.
   - abstract (intros t; simpl; apply funextsec; intro w;
               induction w as [w eq]; induction w as [p q];
-              simpl in *; unshelve refine (total2_paths2 _ _);
+              simpl in *; unshelve refine (two_arg_paths_f _ _);
               [ rewrite 2? id_left; reflexivity
               | apply proofirrelevance; apply homset_property]) using _N_.
   - abstract (
         intros r s t p q; simpl in *; apply funextsec; intro w;
-        unshelve refine (total2_paths2 _ _);
+        unshelve refine (two_arg_paths_f (f := tpair _) _ _);
         [ simpl; rewrite 2? assoc; reflexivity
         | apply proofirrelevance; apply homset_property]) using _P_.
 Defined.
@@ -689,12 +689,12 @@ Proof.
               apply maponpaths; exact (pr2 fxe)) using _M_.
   - abstract (intro b; apply funextsec; intro w;
               induction w as [w e]; induction w as [f x]; simpl;
-              unshelve refine (total2_paths2 _ _);
+              unshelve refine (two_arg_paths_f _ _);
               [ apply dirprodeq; [ apply id_left | apply arrow_mor_id ]
               | apply setproperty]) using _R_.
   - abstract (intros b b' b'' g g''; apply funextsec; intro w;
               induction w as [w e]; induction w as [f x]; simpl;
-              unshelve refine (total2_paths2 _ _);
+              unshelve refine (two_arg_paths_f (f := tpair _) _ _);
               [ apply dirprodeq;
                 [ apply pathsinv0, assoc | apply arrow_mor_mor_assoc ]
               | apply setproperty ]) using _T_.

--- a/UniMath/Ktheory/Utilities.v
+++ b/UniMath/Ktheory/Utilities.v
@@ -272,12 +272,12 @@ Definition pair_path_in2_comp1 {X} (P:X->Type) {x:X} {p q:P x} (e:p = q) :
 Proof. intros. destruct e. reflexivity. Defined.
 
 Definition total2_paths2_comp1 {X} {Y:X->Type} {x} {y:Y x} {x'} {y':Y x'}
-           (p:x = x') (q:p#y = y') : ap pr1 (total2_paths2 p q) = p.
+           (p:x = x') (q:p#y = y') : ap pr1 (two_arg_paths_f (f := tpair Y) p q) = p.
 Proof. intros. destruct p. destruct q. reflexivity. Defined.
 
 Definition total2_paths2_comp2 {X} {Y:X->Type} {x} {y:Y x} {x'} {y':Y x'}
            (p:x = x') (q:p#y = y') :
-  ! app (total2_paths2_comp1 p q) y @ fiber_paths (total2_paths2 p q) = q.
+  ! app (total2_paths2_comp1 p q) y @ fiber_paths (two_arg_paths_f p q) = q.
 Proof. intros. destruct p, q. reflexivity. Defined.
 
 (** ** Maps from pair types *)

--- a/UniMath/Ktheory/Utilities.v
+++ b/UniMath/Ktheory/Utilities.v
@@ -268,7 +268,7 @@ Proof. intros. destruct p. destruct q. apply idpath. Defined.
 (** ** Projections from pair types *)
 
 Definition pair_path_in2_comp1 {X} (P:X->Type) {x:X} {p q:P x} (e:p = q) :
-  ap pr1 (pair_path_in2 P e) = idpath x.
+  ap pr1 (maponpaths (tpair P _) e) = idpath x.
 Proof. intros. destruct e. reflexivity. Defined.
 
 Definition total2_paths2_comp1 {X} {Y:X->Type} {x} {y:Y x} {x'} {y':Y x'}


### PR DESCRIPTION
```
    Lemma total2_paths2 {A : UU} {B : A -> UU} {a1 : A} {b1 : B a1}
	  {a2 : A} {b2 : B a2} (p : a1 = a2)
	  (q : transportf B p b1 = b2) : a1,,b1 = a2,,b2.
```
turns out to be a special case of this:
```
    Lemma two_arg_paths_f {A : UU} {B : A -> UU} {C:UU} {f : ∏ a, B a -> C} {a1 : A} {b1 : B a1}
	  {a2 : A} {b2 : B a2} (p : a1 = a2)
	  (q : transportf B p b1 = b2) : f a1 b1 = f a2 b2.
    Proof.
      intros. induction p. induction q. reflexivity.
    Defined.
```
, and similarly for the backwards version.  We introduce the
generalizations and use it, where possible.