### PR TITLE
Remove deceq assumption from Cocont and hence from SubstSys

### DIFF
--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -776,12 +776,150 @@ Defined.
 
 End pair_functor.
 
+(** TODO: upstream, to with [mapcocone]? *)
+Section mapcocone_functor_composite.
+
+Context {A B C : precategory}
+  (hsA : has_homsets A) (hsB : has_homsets B) (hsC : has_homsets C)
+  (F : functor A B) (G : functor B C).
+
+Lemma mapcocone_functor_composite
+  {g : graph} {D : diagram g A} {a : A} (cc : cocone D a)
+  : mapcocone (functor_composite F G) _ cc
+  = mapcocone G _ (mapcocone F _ cc).
+Proof.
+  apply subtypeEquality.
+  - intros x. repeat (apply impred_isaprop; intro). apply hsC.
+  - reflexivity.
+Qed.
+
+End mapcocone_functor_composite.
+
+(** ** A functor F : A -> product_precategory I B is (omega-)cocontinuous if each F_i : A -> B_i is *)
+Section functor_into_product_precategory.
+(* NOTE: section below on [power_precategory] may be easily(?) generalised to [product_precategory]. *)
+(* NOTE: binary analogue for this section. *)
+
+Context {I : UU} {A : precategory} (hsA : has_homsets A)
+  {B : I -> precategory} (hsB : forall i, has_homsets (B i)).
+
+(* A cocone in the [product_precategory] is a colimit cocone if each of its components is.
+
+Cf. the converse [isColimCocone_functor_into_power] below (currently only for special case of power, not product), which seems to require some additional assumption (e.g. decidable equality on [I]; perhaps other conditions might also suffice. *)
+(* NOTE: other lemmas in below on cocones in [power_precategory] may be able to be simplified using this. *)
+Lemma isColimCocone_in_product_precategory
+  {g : graph} (c : diagram g (product_precategory I B))
+  (b : product_precategory I B) (cc : cocone c b)
+  (M : ∏ i, isColimCocone _ _ (mapcocone (pr_functor I B i) _ cc))
+  : isColimCocone c b cc.
+Proof.
+  intros b' cc'.
+  apply iscontraprop1.
+  - apply invproofirrelevance; intros f1 f2.
+    apply subtypeEquality.
+      intros f; apply impred_isaprop; intros v.
+      apply has_homsets_product_precategory, hsB.
+    apply funextsec; intros i.
+    assert (MM := M i _ (mapcocone (pr_functor I B i) _ cc')).
+    assert (H := proofirrelevance _ (isapropifcontr MM)).
+    refine (maponpaths pr1 (H (pr1 f1 i,,_) (pr1 f2 i,,_)));
+      clear MM H; intros v.
+    + exact (toforallpaths _ _ _ (pr2 f1 v) i).
+    + exact (toforallpaths _ _ _ (pr2 f2 v) i).
+  - mkpair.
+    + intros i.
+      refine (pr1 (pr1 (M i _ (mapcocone (pr_functor I B i) _ cc')))).
+    + intros v. apply funextsec; intros i.
+      refine (pr2 (pr1 (M i _ (mapcocone (pr_functor I B i) _ cc'))) v).
+Defined.
+
+Lemma is_cocont_functor_into_product_precategory
+  {F : functor A (product_precategory I B)}
+  (HF : ∏ (i : I), is_cocont (functor_composite F (pr_functor I B i))) :
+  is_cocont F.
+Proof.
+  intros gr cA a cc Hcc.
+  apply isColimCocone_in_product_precategory.
+  intros i.
+  rewrite <- mapcocone_functor_composite; try apply hsB.
+  now apply HF, Hcc.
+Defined.
+
+Lemma is_omega_cocont_functor_into_product_precategory
+  {F : functor A (product_precategory I B)}
+  (HF : ∏ (i : I), is_omega_cocont (functor_composite F (pr_functor I B i))) :
+  is_omega_cocont F.
+Proof.
+  intros cA a cc Hcc.
+  apply isColimCocone_in_product_precategory.
+  intros i.
+  rewrite <- mapcocone_functor_composite; try apply hsB.
+  now apply HF, Hcc.
+Defined.
+
+End functor_into_product_precategory.
+
+Section tuple_functor.
+
+Context {I : UU} {A : precategory} (hsA : has_homsets A)
+  {B : I -> precategory} (hsB : forall i, has_homsets (B i)).
+
+(** TODO: upstream definitions of [tuple_functor], [pr_tuple_functor] to with [product_precategory]/[family_functor]? Indeed: both of those could be defined as instances of [tuple_functor]. TODO: try! *)
+Definition tuple_functor_data (F : forall i, functor A (B i))
+  : functor_data A (product_precategory I B).
+Proof.
+  mkpair.
+  - intros a i; exact (F i a).
+  - intros a b f i; exact (#(F i) f).
+Defined.
+
+Definition tuple_functor_axioms (F : forall i, functor A (B i))
+  : is_functor (tuple_functor_data F).
+Proof.
+  split.
+  - intros a. apply funextsec; intro i. apply functor_id.
+  - intros ? ? ? ? ?. apply funextsec; intro i. apply functor_comp.
+Qed.
+
+Definition tuple_functor (F : forall i, functor A (B i))
+  : functor A (product_precategory I B)
+:= (tuple_functor_data F,, tuple_functor_axioms F).
+
+Definition pr_tuple_functor (F : forall i, functor A (B i)) (i : I)
+  : functor_composite (tuple_functor F) (pr_functor _ B i) = F i.
+Proof.
+  apply subtypeEquality.
+  - intro. apply isaprop_is_functor, hsB.
+  - apply pathsinv0, tppr.
+Defined.
+
+Definition is_cocont_tuple_functor
+  {F : forall i, functor A (B i)}
+  (HF : forall i, is_cocont (F i))
+  : is_cocont (tuple_functor F).
+Proof.
+  apply is_cocont_functor_into_product_precategory; try apply hsB.
+  intro i. rewrite pr_tuple_functor. apply HF.
+Defined.
+
+Definition is_omega_cocont_tuple_functor
+  {F : forall i, functor A (B i)}
+  (HF : forall i, is_omega_cocont (F i))
+  : is_omega_cocont (tuple_functor F).
+Proof.
+  apply is_omega_cocont_functor_into_product_precategory; try apply hsB.
+  intro i. rewrite pr_tuple_functor. apply HF.
+Defined.
+
+End tuple_functor.
+
 (** ** A family of functor F^I : A^I -> B^I is omega cocontinuous if each F_i is *)
+(** TODO: split out section [pr_functor], and then factor results on [family_functor] using that together with [tuple_functor] (maybe after redefining [family_functor] using [tuple_functor]. *)
 Section family_functor.
 
 Context {I : UU} {A B : precategory} (hsA : has_homsets A) (hsB : has_homsets B).
 
-(* I needs to have decidable equality for pr_functor to be omega cocont *)
+(* The index set I needs decidable equality for pr_functor to be cocont *)
 Hypothesis (HI : isdeceq I).
 
 Local Definition ifI (i j : I) (a b : A) : A :=
@@ -893,6 +1031,7 @@ Defined.
 
 End family_functor.
 
+
 (** ** The bindelta functor C -> C^2 mapping x to (x,x) is omega cocontinuous *)
 Section bindelta_functor.
 
@@ -913,6 +1052,7 @@ End bindelta_functor.
 
 (** ** The generalized delta functor C -> C^I is omega cocontinuous *)
 Section delta_functor.
+(* TODO: factor this using [tuple_functor] results above, after redefining [delta_functor] in terms of [tuple_functor]. *)
 
 Context {I : UU} {C : precategory} (PC : Products I C) (hsC : has_homsets C).
 
@@ -1032,58 +1172,53 @@ End BinCoproduct_of_functors.
 (** ** Coproduct of families of functors: + F_i : C -> D is omega cocontinuous *)
 Section coproduct_of_functors.
 
-Context {I : UU} {C D : precategory} (PC : Products I C) (HD : Coproducts I D)
-        (hsC : has_homsets C) (hsD : has_homsets D) (HI : isdeceq I).
+Context {I : UU} {C D : precategory} (HD : Coproducts I D)
+        (hsC : has_homsets C) (hsD : has_homsets D).
 
-Lemma is_cocont_coproduct_of_functors_alt (F : ∏ i, functor C D)
-  (HF : ∏ i, is_cocont (F i)) :
-  is_cocont (coproduct_of_functors_alt _ HD F).
+(** todo: upstream? *)
+Local Definition coproduct_of_functors_alt2 (F : ∏ (i : I), functor C D)
+  := functor_composite (tuple_functor F) (coproduct_functor _ HD).
+
+Local Lemma coproduct_of_functors_alt2_eq_coproduct_of_functors
+  (F : ∏ (i : I), functor C D)
+  : coproduct_of_functors_alt2 F
+  = coproduct_of_functors I C D HD F.
 Proof.
-apply (is_cocont_functor_composite hsD).
-  apply (is_cocont_delta_functor PC hsC).
-apply (is_cocont_functor_composite hsD).
-  apply (is_cocont_family_functor hsC hsD HI HF).
-apply (is_cocont_coproduct_functor _ hsD).
+  apply subtypeEquality.
+  - intro; apply isaprop_is_functor, hsD.
+  - reflexivity.
 Defined.
 
-Lemma is_omega_cocont_coproduct_of_functors_alt (F : ∏ i, functor C D)
-  (HF : ∏ i, is_omega_cocont (F i)) :
-  is_omega_cocont (coproduct_of_functors_alt _ HD F).
-Proof.
-apply (is_omega_cocont_functor_composite hsD).
-  apply (is_omega_cocont_delta_functor PC hsC).
-apply (is_omega_cocont_functor_composite hsD).
-  apply (is_omega_cocont_family_functor hsC hsD HI HF).
-apply (is_omega_cocont_coproduct_functor _ hsD).
-Defined.
-
-Definition omega_cocont_coproduct_of_functors_alt
-  (F : ∏ i, omega_cocont_functor C D) :
-  omega_cocont_functor C D :=
-    tpair _ _ (is_omega_cocont_coproduct_of_functors_alt _ (fun i => pr2 (F i))).
-
-Lemma is_cocont_coproduct_of_functors (F : ∏ (i : I), functor C D)
-  (HF : ∏ i, is_cocont (F i)) :
+Lemma is_cocont_coproduct_of_functors
+  {F : ∏ (i : I), functor C D} (HF : ∏ i, is_cocont (F i)) :
   is_cocont (coproduct_of_functors I _ _ HD F).
 Proof.
-exact (transportf _
-        (coproduct_of_functors_alt_eq_coproduct_of_functors I C D HD hsD F)
-        (is_cocont_coproduct_of_functors_alt _ HF)).
+  refine (transportf _
+        (coproduct_of_functors_alt2_eq_coproduct_of_functors F)
+        _).
+  apply is_cocont_functor_composite; try apply hsD.
+  - apply is_cocont_tuple_functor; try (intro; apply hsD).
+    apply HF.
+  - apply is_cocont_coproduct_functor; try apply hsD.
 Defined.
 
-Lemma is_omega_cocont_coproduct_of_functors (F : ∏ (i : I), functor C D)
-  (HF : ∏ i, is_omega_cocont (F i)) :
+Lemma is_omega_cocont_coproduct_of_functors
+  {F : ∏ (i : I), functor C D} (HF : ∏ i, is_omega_cocont (F i)) :
   is_omega_cocont (coproduct_of_functors I _ _ HD F).
 Proof.
-exact (transportf _
-        (coproduct_of_functors_alt_eq_coproduct_of_functors I C D HD hsD F)
-        (is_omega_cocont_coproduct_of_functors_alt _ HF)).
+  refine (transportf _
+        (coproduct_of_functors_alt2_eq_coproduct_of_functors F)
+        _).
+  apply is_omega_cocont_functor_composite; try apply hsD.
+  - apply is_omega_cocont_tuple_functor; try (intro; apply hsD).
+    apply HF.
+  - apply is_omega_cocont_coproduct_functor; try apply hsD.
 Defined.
 
 Definition omega_cocont_coproduct_of_functors
   (F : ∏ i, omega_cocont_functor C D) :
   omega_cocont_functor C D :=
-    tpair _ _ (is_omega_cocont_coproduct_of_functors _ (fun i => pr2 (F i))).
+    tpair _ _ (is_omega_cocont_coproduct_of_functors (fun i => pr2 (F i))).
 
 End coproduct_of_functors.
 

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -171,7 +171,7 @@ Lemma is_omega_cocont_BindingSigToSignature
   (CC : Coproducts (BindingSigIndex sig) C) (PC : Products (BindingSigIndex sig) C) :
   is_omega_cocont (BindingSigToSignature TC sig CC).
 Proof.
-apply (is_omega_cocont_Sum_of_Signatures _ (BindingSigIsdeceq sig)).
+apply is_omega_cocont_Sum_of_Signatures.
 - intro i; apply is_omega_cocont_Arity_to_Signature, HF; assumption.
 - apply PC.
 Defined.
@@ -265,7 +265,7 @@ Defined.
 Lemma is_omega_cocont_BindingSigToSignatureHSET (sig : BindingSig) :
   is_omega_cocont (BindingSigToSignatureHSET sig).
 Proof.
-apply (is_omega_cocont_Sum_of_Signatures _ (BindingSigIsdeceq sig)).
+apply is_omega_cocont_Sum_of_Signatures.
 - intro i; apply is_omega_cocont_Arity_to_Signature.
   + apply ColimsHSET_of_shape.
   + intros F.

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -50,15 +50,15 @@ Local Notation "'chain'" := (diagram nat_graph).
 Section BindingSig.
 
 (** A binding signature is a collection of lists of natural numbers indexed by types I *)
-Definition BindingSig : UU := ∑ (I : UU) (h : isdeceq I), I → list nat.
+Definition BindingSig : UU := ∑ (I : UU) (h : isaset I), I → list nat.
 
 Definition BindingSigIndex : BindingSig -> UU := pr1.
-Definition BindingSigIsdeceq (s : BindingSig) : isdeceq (BindingSigIndex s) :=
+Definition BindingSigIsaset (s : BindingSig) : isaset (BindingSigIndex s) :=
   pr1 (pr2 s).
 Definition BindingSigMap (s : BindingSig) : BindingSigIndex s -> list nat :=
   pr2 (pr2 s).
 
-Definition mkBindingSig {I : UU} (h : isdeceq I) (f : I -> list nat) : BindingSig := (I,,h,,f).
+Definition mkBindingSig {I : UU} (h : isaset I) (f : I -> list nat) : BindingSig := (I,,h,,f).
 
 (** Sum of binding signatures *)
 Definition SumBindingSig : BindingSig -> BindingSig -> BindingSig.
@@ -67,7 +67,7 @@ intros s1 s2.
 mkpair.
 - apply (BindingSigIndex s1 ⨿ BindingSigIndex s2).
 - mkpair.
-  + apply (isdeceqcoprod (BindingSigIsdeceq s1) (BindingSigIsdeceq s2)).
+  + apply (isasetcoprod _ _ (BindingSigIsaset s1) (BindingSigIsaset s2)).
   + induction 1 as [i|i]; [ apply (BindingSigMap s1 i) | apply (BindingSigMap s2 i) ].
 Defined.
 
@@ -259,7 +259,7 @@ use BindingSigToSignature.
 - apply BinCoproductsHSET.
 - apply TerminalHSET.
 - apply sig.
-- apply CoproductsHSET, (isasetifdeceq _ (BindingSigIsdeceq sig)).
+- apply CoproductsHSET, (BindingSigIsaset sig).
 Defined.
 
 Lemma is_omega_cocont_BindingSigToSignatureHSET (sig : BindingSig) :
@@ -299,7 +299,7 @@ intros sig; use (BindingSigToMonad _ _ _ _ _ _ _ sig).
   apply has_exponentials_functor_HSET, has_homsets_HSET.
 - apply ProductsHSET.
 - apply CoproductsHSET.
-  exact (isasetifdeceq _ (BindingSigIsdeceq sig)).
+  apply BindingSigIsaset.
 Defined.
 
 End BindingSigToMonadHSET.

--- a/UniMath/SubstitutionSystems/LamFromBindingSig.v
+++ b/UniMath/SubstitutionSystems/LamFromBindingSig.v
@@ -72,7 +72,7 @@ Local Notation "'1'" := (functor_identity HSET).
 
 (** The signature of the lambda calculus: { [0,0], [1] } *)
 Definition LamSig : BindingSig :=
-  mkBindingSig isdeceqbool (fun b => if b then 0 :: 0 :: [] else 1 :: [])%nat.
+  mkBindingSig isasetbool (fun b => if b then 0 :: 0 :: [] else 1 :: [])%nat.
 
 (** The signature with strength for the lambda calculus *)
 Definition LamSignature : Signature HSET has_homsets_HSET :=

--- a/UniMath/SubstitutionSystems/LamFromBindingSig.v
+++ b/UniMath/SubstitutionSystems/LamFromBindingSig.v
@@ -172,7 +172,7 @@ rewrite assoc.
 eapply pathscomp0.
   eapply cancel_postcomposition, cancel_postcomposition.
   apply (CoproductOfArrowsIn _ _ (Coproducts_functor_precat _ _ _
-          (CoproductsHSET _ (isasetifdeceq _ isdeceqbool))
+          (CoproductsHSET _ isasetbool)
           _ (λ i, pr1 (Arity_to_Signature has_homsets_HSET BinProductsHSET
                          BinCoproductsHSET TerminalHSET (BindingSigMap LamSig i)) `LC_alg))).
 rewrite <- assoc.
@@ -202,7 +202,7 @@ rewrite assoc.
 eapply pathscomp0.
   eapply cancel_postcomposition, cancel_postcomposition.
   apply (CoproductOfArrowsIn _ _ (Coproducts_functor_precat _ _ _
-          (CoproductsHSET _ (isasetifdeceq _ isdeceqbool))
+          (CoproductsHSET _ isasetbool)
           _ (λ i, pr1 (Arity_to_Signature has_homsets_HSET BinProductsHSET
                          BinCoproductsHSET TerminalHSET (BindingSigMap LamSig i)) `LC_alg))).
 rewrite <- assoc.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -342,7 +342,7 @@ Defined.
 
 (** The functor obtained from a multisorted binding signature is omega-cocontinuous *)
 Lemma is_omega_cocont_MultiSortedSigToFunctor (M : MultiSortedSig)
-  (Heq : isdeceq (ops M)) (H : Colims_of_shape nat_graph SET_over_sort) :
+  (H : Colims_of_shape nat_graph SET_over_sort) :
   is_omega_cocont (MultiSortedSigToFunctor M).
 Proof.
 apply is_omega_cocont_coproduct_of_functors; try apply homset_property.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -346,8 +346,6 @@ Lemma is_omega_cocont_MultiSortedSigToFunctor (M : MultiSortedSig)
   is_omega_cocont (MultiSortedSigToFunctor M).
 Proof.
 apply is_omega_cocont_coproduct_of_functors; try apply homset_property.
-+ apply Products_functor_precat, Products_HSET_slice.
-+ apply Heq.
 + intros op; apply is_omega_cocont_hat_exp_functor_list, H.
 Defined.
 

--- a/UniMath/SubstitutionSystems/SignatureCategory.v
+++ b/UniMath/SubstitutionSystems/SignatureCategory.v
@@ -259,7 +259,7 @@ End BinProducts.
 (** * Coproducts in the category of signatures *)
 Section Coproducts.
 
-Variables (I : UU) (HI : isdeceq I).
+Variables (I : UU).
 Variables (C : Precategory) (CC : Coproducts I C).
 
 Let hsC : has_homsets C := homset_property C.

--- a/UniMath/SubstitutionSystems/SumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/SumOfSignatures.v
@@ -42,7 +42,7 @@ Arguments θ_Strength2_int {_ _ _} _ .
 
 Section sum_of_signatures.
 
-Variables (I : UU) (HI : isdeceq I) (C : precategory) (hsC : has_homsets C).
+Variables (I : UU) (C : precategory) (hsC : has_homsets C).
 Variables (CC : Coproducts I C).
 
 Section construction.
@@ -144,8 +144,6 @@ Lemma is_omega_cocont_Sum_of_Signatures (S : I -> Signature C hsC)
   is_omega_cocont (Sum_of_Signatures S).
 Proof.
 apply is_omega_cocont_coproduct_of_functors; try assumption.
-- apply (Products_functor_precat _ _ _ PC).
-- apply functor_category_has_homsets.
 - apply functor_category_has_homsets.
 Defined.
 


### PR DESCRIPTION
Assumption was used in proof of cocontinuity of an ingredient of a signature functor, turns out it is not needed