### PR TITLE
add a little lemma, potentially useful

### DIFF
--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -869,6 +869,12 @@ Proof.
   apply idpath.
 Defined.
 
+Lemma total2_section_path {X:UU} {Y:X->UU} (a:X) (b:Y a) (e:∏ x, Y x) : (a,,e a) = (a,,b) -> e a = b.
+(* this is called "Voldemort's theorem" by David McAllester, https://arxiv.org/pdf/1407.7274.pdf *)
+Proof.
+  intros ? ? ? ? ? p. simple refine (_ @ fiber_paths p). unfold base_paths. simpl.
+  apply pathsinv0, transport_section.
+Defined.
 
 (** *** Lemmas about transport adapted from the HoTT library and the HoTT book *)
 


### PR DESCRIPTION
He explains the reason for the name:

" ... and “Voldemort’s theorem” stating that certain objects exist but cannot be named. For example, there is no natural point on a geometric circle — no point on a geometric circle can be named by a well-typed expression.  Similarly it is not possible to name any particular basis for a vector space or any particular isomorphism of a finite dimensional vector space with its dual. "

Well, it doesn't state that, but it does imply it.