### PR TITLE
Some theory about presheaf categories

### DIFF
--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -99,3 +99,4 @@ FiveLemma.v
 set_slice_fam_equiv.v
 Elements.v
 ElementsOp.v
+Presheaf.v

--- a/UniMath/CategoryTheory/Epis.v
+++ b/UniMath/CategoryTheory/Epis.v
@@ -17,8 +17,6 @@ Local Open Scope cat.
 Require Import UniMath.CategoryTheory.sub_precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 
-
-
 (** * Definition of Epis *)
 Section def_epi.
 

--- a/UniMath/CategoryTheory/Monics.v
+++ b/UniMath/CategoryTheory/Monics.v
@@ -14,7 +14,6 @@ Local Open Scope cat.
 Require Import UniMath.CategoryTheory.sub_precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 
-
 (** * Definition of Monics *)
 Section def_monic.
 

--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -14,7 +14,7 @@ Contents:
 - Terminal object ([Terminal_Psh])
 - Pullbacks ([Pullbacks_Psh])
 - Exponentials ([has_exponentials_Psh])
-- Definition of the subobject classifier (without proof) ([Ω_Psh])
+- Definition of the subobject classifier (without proof) ([Ω_Psh], [Ω_mor])
 
 
 Written by: Anders Mörtberg, 2017
@@ -42,6 +42,7 @@ Require Import UniMath.CategoryTheory.limits.initial.
 Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import UniMath.CategoryTheory.exponentials.
+Require Import UniMath.CategoryTheory.Monics.
 
 Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
 Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
@@ -137,7 +138,21 @@ use isaset_total2.
 - intros S; simpl; repeat (apply impred_isaset; intro); apply isasetaprop, propproperty.
 Qed.
 
+(* If I use HSET here the coercion isn't triggered later and I need to insert pr1 explicitly *)
 Definition sieve (c : C) : hSet := (sieve_def c,,isaset_sieve c).
+
+Lemma sieve_eq (c : C) (s t : sieve c) (H : pr1 s = pr1 t) : s = t.
+Proof.
+apply subtypeEquality; try assumption.
+now intros x; repeat (apply impred; intros); apply propproperty.
+Qed.
+
+Definition maximal_sieve (c : C) : sieve c.
+Proof.
+mkpair.
+- apply (λ _ _, htrue).
+- apply (λ _ _ _ _ _, tt).
+Defined.
 
 Definition sieve_mor a b (f : C⟦b,a⟧) : sieve a → sieve b.
 Proof.
@@ -164,5 +179,19 @@ split.
 Qed.
 
 Definition Ω_Psh : Psh C := (Ω_Psh_data,,is_functor_Ω_Psh_data).
+
+Definition Ω_mor : (Psh C)⟦Terminal_Psh,Ω_Psh⟧.
+Proof.
+use mk_nat_trans.
+- simpl; apply (λ c _, maximal_sieve c).
+- intros x y f; simpl in *; apply funextfun; cbn; intros _.
+  apply sieve_eq; simpl.
+  now repeat (apply funextsec; intros).
+Defined.
+
+Lemma isMonic_Ω_mor : isMonic Ω_mor.
+Proof.
+now apply from_terminal_isMonic.
+Qed.
 
 End Ω_Psh.

--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -1,20 +1,20 @@
 (** **********************************************************
 
-Theory about set-valued presheafs. We write Psh C for [C^op,HSET].
+Theory about set-valued presheaves. We write PreShv C for [C^op,HSET].
 
 Contents:
 
-- Limits ([Lims_Psh], [Lims_Psh_of_shape])
-- Colimits ([Colims_Psh], [Colims_Psh_of_shape])
-- Binary products ([BinProducts_Psh])
-- Indexed products ([Products_Psh])
-- Binary coproducts ([BinCoproducts_Psh])
-- Indexed coproducts ([Coproducts_Psh])
-- Initial object ([Initial_Psh])
-- Terminal object ([Terminal_Psh])
-- Pullbacks ([Pullbacks_Psh])
-- Exponentials ([has_exponentials_Psh])
-- Definition of the subobject classifier (without proof) ([Ω_Psh], [Ω_mor])
+- Limits ([Lims_PreShv], [Lims_PreShv_of_shape])
+- Colimits ([Colims_PreShv], [Colims_PreShv_of_shape])
+- Binary products ([BinProducts_PreShv])
+- Indexed products ([Products_PreShv])
+- Binary coproducts ([BinCoproducts_PreShv])
+- Indexed coproducts ([Coproducts_PreShv])
+- Initial object ([Initial_PreShv])
+- Terminal object ([Terminal_PreShv])
+- Pullbacks ([Pullbacks_PreShv])
+- Exponentials ([has_exponentials_PreShv])
+- Definition of the subobject classifier (without proof) ([Ω_PreShv], [Ω_mor])
 
 
 Written by: Anders Mörtberg, 2017
@@ -28,7 +28,6 @@ Require Import UniMath.Foundations.Sets.
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.category_hset.
 Require Import UniMath.CategoryTheory.category_hset_structures.
 Require Import UniMath.CategoryTheory.opp_precat.
@@ -44,73 +43,72 @@ Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.Monics.
 
-Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
-Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
-Local Notation "'Psh' C" := [C^op,HSET,has_homsets_HSET] (at level 3).
-Arguments nat_trans_comp {_ _ _ _ _} _ _.
+Local Open Scope cat.
 
-(** Various limits and colimits in Psh C *)
+Notation "'PreShv' C" := [C^op,HSET,has_homsets_HSET] (at level 3) : cat.
+
+(** Various limits and colimits in PreShv C *)
 Section limits.
 
 Context {C : precategory}.
 
-Lemma Lims_Psh : Lims (Psh C).
+Lemma Lims_PreShv : Lims (PreShv C).
 Proof.
 now apply LimsFunctorCategory, LimsHSET.
 Defined.
 
-Lemma Lims_Psh_of_shape (g : graph) : Lims_of_shape g (Psh C).
+Lemma Lims_PreShv_of_shape (g : graph) : Lims_of_shape g (PreShv C).
 Proof.
 now apply LimsFunctorCategory_of_shape, LimsHSET_of_shape.
 Defined.
 
-Lemma Colims_Psh : Colims (Psh C).
+Lemma Colims_PreShv : Colims (PreShv C).
 Proof.
 now apply ColimsFunctorCategory, ColimsHSET.
 Defined.
 
-Lemma Colims_Psh_of_shape (g : graph) : Colims_of_shape g (Psh C).
+Lemma Colims_PreShv_of_shape (g : graph) : Colims_of_shape g (PreShv C).
 Proof.
 now apply ColimsFunctorCategory_of_shape, ColimsHSET_of_shape.
 Defined.
 
-Lemma BinProducts_Psh : BinProducts (Psh C).
+Lemma BinProducts_PreShv : BinProducts (PreShv C).
 Proof.
 now apply BinProducts_functor_precat, BinProductsHSET.
 Defined.
 
-Lemma Products_Psh I : Products I (Psh C).
+Lemma Products_PreShv I : Products I (PreShv C).
 Proof.
 now apply Products_functor_precat, ProductsHSET.
 Defined.
 
-Lemma BinCoproducts_Psh : BinCoproducts (Psh C).
+Lemma BinCoproducts_PreShv : BinCoproducts (PreShv C).
 Proof.
 now apply BinCoproducts_functor_precat, BinCoproductsHSET.
 Defined.
 
-Lemma Coproducts_Psh I (HI : isaset I) : Coproducts I (Psh C).
+Lemma Coproducts_PreShv I (HI : isaset I) : Coproducts I (PreShv C).
 Proof.
 now apply Coproducts_functor_precat, CoproductsHSET, HI.
 Defined.
 
-Lemma Initial_Psh : Initial (Psh C).
+Lemma Initial_PreShv : Initial (PreShv C).
 Proof.
 now apply Initial_functor_precat, InitialHSET.
 Defined.
 
-Lemma Terminal_Psh : Terminal (Psh C).
+Lemma Terminal_PreShv : Terminal (PreShv C).
 Proof.
 now apply Terminal_functor_precat, TerminalHSET.
 Defined.
 
-Lemma Pullbacks_Psh : Pullbacks (Psh C).
+Lemma Pullbacks_PreShv : Pullbacks (PreShv C).
 Proof.
 now apply FunctorPrecategoryPullbacks, PullbacksHSET.
 Defined.
 
-Lemma has_exponentials_Psh (hsC : has_homsets C) :
-  has_exponentials BinProducts_Psh.
+Lemma has_exponentials_PreShv (hsC : has_homsets C) :
+  has_exponentials BinProducts_PreShv.
 Proof.
 now apply has_exponentials_functor_HSET, has_homsets_opp, hsC.
 Defined.
@@ -119,7 +117,7 @@ End limits.
 
 (** Definition of the subobject classifier in a presheaf
     TODO: Prove that Ω actually is the subobject classifier  *)
-Section Ω_Psh.
+Section Ω_PreShv.
 
 Context {C : precategory}.
 
@@ -128,7 +126,7 @@ Proof.
 use total2.
 - apply (∏ (x : C) (f : C⟦x,c⟧), hProp).
 - intros S.
-  apply (∏ (x : C) (f : C⟦x,c⟧), S x f → ∏ (y : C) (f' : C⟦y,x⟧), S y (f' ;; f)).
+  apply (∏ (x : C) (f : C⟦x,c⟧), S x f → ∏ (y : C) (f' : C⟦y,x⟧), S y (f' · f)).
 Defined.
 
 Lemma isaset_sieve (c : C) : isaset (sieve_def c).
@@ -159,13 +157,13 @@ Proof.
 intros S.
 mkpair.
 - intros y g.
-  apply (pr1 S y (g ;; f)).
+  apply (pr1 S y (g · f)).
 - abstract (intros y g H z h; simpl; rewrite <- assoc; apply (pr2 S), H).
 Defined.
 
-Local Definition Ω_Psh_data : functor_data C^op HSET := (sieve,,sieve_mor).
+Local Definition Ω_PreShv_data : functor_data C^op HSET := (sieve,,sieve_mor).
 
-Local Lemma is_functor_Ω_Psh_data : is_functor Ω_Psh_data.
+Local Lemma is_functor_Ω_PreShv_data : is_functor Ω_PreShv_data.
 Proof.
 split.
 - intros x; apply funextfun; intros [S hS]; simpl.
@@ -178,9 +176,9 @@ split.
   + now repeat (apply funextsec; intro); rewrite <- assoc.
 Qed.
 
-Definition Ω_Psh : Psh C := (Ω_Psh_data,,is_functor_Ω_Psh_data).
+Definition Ω_PreShv : PreShv C := (Ω_PreShv_data,,is_functor_Ω_PreShv_data).
 
-Definition Ω_mor : (Psh C)⟦Terminal_Psh,Ω_Psh⟧.
+Definition Ω_mor : (PreShv C)⟦Terminal_PreShv,Ω_PreShv⟧.
 Proof.
 use mk_nat_trans.
 - simpl; apply (λ c _, maximal_sieve c).
@@ -194,4 +192,4 @@ Proof.
 now apply from_terminal_isMonic.
 Qed.
 
-End Ω_Psh.
+End Ω_PreShv.

--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -1,0 +1,168 @@
+(** **********************************************************
+
+Theory about set-valued presheafs. We write Psh C for [C^op,HSET].
+
+Contents:
+
+- Limits ([Lims_Psh], [Lims_Psh_of_shape])
+- Colimits ([Colims_Psh], [Colims_Psh_of_shape])
+- Binary products ([BinProducts_Psh])
+- Indexed products ([Products_Psh])
+- Binary coproducts ([BinCoproducts_Psh])
+- Indexed coproducts ([Coproducts_Psh])
+- Initial object ([Initial_Psh])
+- Terminal object ([Terminal_Psh])
+- Pullbacks ([Pullbacks_Psh])
+- Exponentials ([has_exponentials_Psh])
+- Definition of the subobject classifier (without proof) ([Ω_Psh])
+
+
+Written by: Anders Mörtberg, 2017
+
+************************************************************)
+
+Require Import UniMath.Foundations.PartD.
+Require Import UniMath.Foundations.Propositions.
+Require Import UniMath.Foundations.Sets.
+
+Require Import UniMath.CategoryTheory.total2_paths.
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.UnicodeNotations.
+Require Import UniMath.CategoryTheory.category_hset.
+Require Import UniMath.CategoryTheory.category_hset_structures.
+Require Import UniMath.CategoryTheory.opp_precat.
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.limits.graphs.limits.
+Require Import UniMath.CategoryTheory.limits.binproducts.
+Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.limits.bincoproducts.
+Require Import UniMath.CategoryTheory.limits.coproducts.
+Require Import UniMath.CategoryTheory.limits.initial.
+Require Import UniMath.CategoryTheory.limits.terminal.
+Require Import UniMath.CategoryTheory.limits.pullbacks.
+Require Import UniMath.CategoryTheory.exponentials.
+
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
+Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
+Local Notation "'Psh' C" := [C^op,HSET,has_homsets_HSET] (at level 3).
+Arguments nat_trans_comp {_ _ _ _ _} _ _.
+
+(** Various limits and colimits in Psh C *)
+Section limits.
+
+Context {C : precategory}.
+
+Lemma Lims_Psh : Lims (Psh C).
+Proof.
+now apply LimsFunctorCategory, LimsHSET.
+Defined.
+
+Lemma Lims_Psh_of_shape (g : graph) : Lims_of_shape g (Psh C).
+Proof.
+now apply LimsFunctorCategory_of_shape, LimsHSET_of_shape.
+Defined.
+
+Lemma Colims_Psh : Colims (Psh C).
+Proof.
+now apply ColimsFunctorCategory, ColimsHSET.
+Defined.
+
+Lemma Colims_Psh_of_shape (g : graph) : Colims_of_shape g (Psh C).
+Proof.
+now apply ColimsFunctorCategory_of_shape, ColimsHSET_of_shape.
+Defined.
+
+Lemma BinProducts_Psh : BinProducts (Psh C).
+Proof.
+now apply BinProducts_functor_precat, BinProductsHSET.
+Defined.
+
+Lemma Products_Psh I : Products I (Psh C).
+Proof.
+now apply Products_functor_precat, ProductsHSET.
+Defined.
+
+Lemma BinCoproducts_Psh : BinCoproducts (Psh C).
+Proof.
+now apply BinCoproducts_functor_precat, BinCoproductsHSET.
+Defined.
+
+Lemma Coproducts_Psh I (HI : isaset I) : Coproducts I (Psh C).
+Proof.
+now apply Coproducts_functor_precat, CoproductsHSET, HI.
+Defined.
+
+Lemma Initial_Psh : Initial (Psh C).
+Proof.
+now apply Initial_functor_precat, InitialHSET.
+Defined.
+
+Lemma Terminal_Psh : Terminal (Psh C).
+Proof.
+now apply Terminal_functor_precat, TerminalHSET.
+Defined.
+
+Lemma Pullbacks_Psh : Pullbacks (Psh C).
+Proof.
+now apply FunctorPrecategoryPullbacks, PullbacksHSET.
+Defined.
+
+Lemma has_exponentials_Psh (hsC : has_homsets C) :
+  has_exponentials BinProducts_Psh.
+Proof.
+now apply has_exponentials_functor_HSET, has_homsets_opp, hsC.
+Defined.
+
+End limits.
+
+(** Definition of the subobject classifier in a presheaf
+    TODO: Prove that Ω actually is the subobject classifier  *)
+Section Ω_Psh.
+
+Context {C : precategory}.
+
+Definition sieve_def (c : C) : UU.
+Proof.
+use total2.
+- apply (∏ (x : C) (f : C⟦x,c⟧), hProp).
+- intros S.
+  apply (∏ (x : C) (f : C⟦x,c⟧), S x f → ∏ (y : C) (f' : C⟦y,x⟧), S y (f' ;; f)).
+Defined.
+
+Lemma isaset_sieve (c : C) : isaset (sieve_def c).
+Proof.
+use isaset_total2.
+- repeat (apply impred_isaset; intro); apply isasethProp.
+- intros S; simpl; repeat (apply impred_isaset; intro); apply isasetaprop, propproperty.
+Qed.
+
+Definition sieve (c : C) : hSet := (sieve_def c,,isaset_sieve c).
+
+Definition sieve_mor a b (f : C⟦b,a⟧) : sieve a → sieve b.
+Proof.
+intros S.
+mkpair.
+- intros y g.
+  apply (pr1 S y (g ;; f)).
+- abstract (intros y g H z h; simpl; rewrite <- assoc; apply (pr2 S), H).
+Defined.
+
+Local Definition Ω_Psh_data : functor_data C^op HSET := (sieve,,sieve_mor).
+
+Local Lemma is_functor_Ω_Psh_data : is_functor Ω_Psh_data.
+Proof.
+split.
+- intros x; apply funextfun; intros [S hS]; simpl.
+  apply subtypeEquality; simpl.
+  + intros X; repeat (apply impred; intro); apply propproperty.
+  + now repeat (apply funextsec; intro); rewrite id_right.
+- intros x y z f g; apply funextfun; intros [S hS]; simpl.
+  apply subtypeEquality; simpl.
+  + intros X; repeat (apply impred; intro); apply propproperty.
+  + now repeat (apply funextsec; intro); rewrite <- assoc.
+Qed.
+
+Definition Ω_Psh : Psh C := (Ω_Psh_data,,is_functor_Ω_Psh_data).
+
+End Ω_Psh.

--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -14,7 +14,7 @@ Contents:
 - Terminal object ([Terminal_PreShv])
 - Pullbacks ([Pullbacks_PreShv])
 - Exponentials ([has_exponentials_PreShv])
-- Discrete presheaf ([discrete_PreShv])
+- Constant presheaf ([constant_PreShv])
 - Definition of the subobject classifier (without proof) ([Ω_PreShv], [Ω_mor])
 
 
@@ -121,7 +121,7 @@ Section presheaves.
 
 Context {C : precategory}.
 
-Definition discrete_PreShv (A : HSET) : PreShv C.
+Definition constant_PreShv (A : HSET) : PreShv C.
 Proof.
 use mk_functor.
 + mkpair.
@@ -130,7 +130,7 @@ use mk_functor.
 + now split.
 Defined.
 
-Definition empty_PreShv : PreShv C := discrete_PreShv emptyHSET.
+Definition empty_PreShv : PreShv C := constant_PreShv emptyHSET.
 
 End presheaves.
 

--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -14,6 +14,7 @@ Contents:
 - Terminal object ([Terminal_PreShv])
 - Pullbacks ([Pullbacks_PreShv])
 - Exponentials ([has_exponentials_PreShv])
+- Discrete presheaf ([discrete_PreShv])
 - Definition of the subobject classifier (without proof) ([Ω_PreShv], [Ω_mor])
 
 
@@ -114,6 +115,24 @@ now apply has_exponentials_functor_HSET, has_homsets_opp, hsC.
 Defined.
 
 End limits.
+
+(** * Define some standard presheaves *)
+Section presheaves.
+
+Context {C : precategory}.
+
+Definition discrete_PreShv (A : HSET) : PreShv C.
+Proof.
+use mk_functor.
++ mkpair.
+  - intros _; apply A.
+  - intros a b f; apply idfun.
++ now split.
+Defined.
+
+Definition empty_PreShv : PreShv C := discrete_PreShv emptyHSET.
+
+End presheaves.
 
 (** Definition of the subobject classifier in a presheaf
     TODO: Prove that Ω actually is the subobject classifier  *)

--- a/UniMath/CategoryTheory/limits/initial.v
+++ b/UniMath/CategoryTheory/limits/initial.v
@@ -12,7 +12,7 @@ Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
 Require Import UniMath.CategoryTheory.total2_paths.
-Require Import UniMath.CategoryTheory.precategories
+Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.Epis.
 

--- a/UniMath/CategoryTheory/limits/initial.v
+++ b/UniMath/CategoryTheory/limits/initial.v
@@ -13,7 +13,9 @@ Require Import UniMath.Foundations.Sets.
 
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories
-               UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.Epis.
+
 Local Open Scope cat.
 
 Section def_initial.
@@ -183,3 +185,16 @@ use mk_Initial.
 Defined.
 
 End InitialFunctorCat.
+
+(** Morphisms to the initial object are epis *)
+Section epis_initial.
+
+Context {C : precategory} (IC : Initial C).
+
+Lemma to_initial_isEpi (a : C) (f : C⟦a,IC⟧) : isEpi f.
+Proof.
+apply mk_isEpi; intros b g h H.
+now apply InitialArrowEq.
+Qed.
+
+End epis_initial.

--- a/UniMath/CategoryTheory/limits/initial.v
+++ b/UniMath/CategoryTheory/limits/initial.v
@@ -160,28 +160,25 @@ End Initial_and_EmptyCoprod.
 (** * Construction of initial object in a functor category *)
 Section InitialFunctorCat.
 
-Variable C D : precategory.
-Variable ID : Initial D.
-Variable hsD : has_homsets D.
+Variables (C D : precategory) (ID : Initial D) (hsD : has_homsets D).
 
 Definition Initial_functor_precat : Initial [C, D, hsD].
 Proof.
 use mk_Initial.
-- mkpair.
+- use mk_functor.
   + mkpair.
     * intros c; apply (InitialObject ID).
     * simpl; intros a b f; apply (InitialArrow ID).
-  + abstract (split;
-               [ intro a; apply pathsinv0, InitialEndo_is_identity
-               | intros a b c f g; apply pathsinv0, InitialArrowUnique]).
+  + split.
+    * intro a; apply pathsinv0, InitialEndo_is_identity.
+    * intros a b c f g; apply pathsinv0, InitialArrowUnique.
 - intros F.
   mkpair.
-  + simpl.
-    mkpair.
+  + use mk_nat_trans; simpl.
     * intro a; apply InitialArrow.
-    * abstract (intros a b f; simpl;
-                rewrite <- (InitialEndo_is_identity _ ID (InitialArrow ID ID)), id_left;
-                apply pathsinv0, InitialArrowUnique).
+    * intros a b f; simpl.
+      rewrite <- (InitialEndo_is_identity _ ID (InitialArrow ID ID)), id_left.
+      now apply pathsinv0, InitialArrowUnique.
   + abstract (intros α; apply (nat_trans_eq hsD); intro a; apply InitialArrowUnique).
 Defined.
 

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -10,7 +10,7 @@ Direct implementation of pullbacks together with:
   ([Pullbacks_from_Equalizers_BinProducts])
 - A fully faithful functor reflects limits ([isPullback_preimage_square])
 - A fully faithfull and essentially surjects functor preserves pullbacks ([isPullback_image_square])
-- Pullbacks in functor categories ([pb_if_pointwise_pb])
+- Pullbacks in functor categories ([FunctorPrecategoryPullbacks])
 - Construction of binary products from pullbacks ([BinProductsFromPullbacks])
 
 *)

--- a/UniMath/CategoryTheory/limits/terminal.v
+++ b/UniMath/CategoryTheory/limits/terminal.v
@@ -13,6 +13,7 @@ Require Import UniMath.Foundations.Sets.
 
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.limits.products.
 Require Import UniMath.CategoryTheory.Monics.
 
@@ -166,15 +167,12 @@ End Terminal_and_EmptyProd.
 
 (* End Terminal_from_Lims. *)
 
-
-Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
-
 (** * Construction of terminal object in a functor category *)
 Section TerminalFunctorCat.
 
 Variables (C D : precategory) (ID : Terminal D) (hsD : has_homsets D).
 
-Definition Terminal_functor_precat : Terminal [C, D, hsD].
+Definition Terminal_functor_precat : Terminal [C,D,hsD].
 Proof.
 use mk_Terminal.
 - use mk_functor.

--- a/UniMath/CategoryTheory/limits/terminal.v
+++ b/UniMath/CategoryTheory/limits/terminal.v
@@ -14,6 +14,7 @@ Require Import UniMath.Foundations.Sets.
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.Monics.
 
 Local Open Scope cat.
 
@@ -194,3 +195,16 @@ use mk_Terminal.
 Defined.
 
 End TerminalFunctorCat.
+
+(** Morphisms from the terminal object are monic *)
+Section monics_terminal.
+
+Context {C : precategory} (TC : Terminal C).
+
+Lemma from_terminal_isMonic (a : C) (f : C⟦TC,a⟧) : isMonic f.
+Proof.
+apply mk_isMonic; intros b g h H.
+now apply ArrowsToTerminal.
+Qed.
+
+End monics_terminal.

--- a/UniMath/CategoryTheory/limits/terminal.v
+++ b/UniMath/CategoryTheory/limits/terminal.v
@@ -13,6 +13,8 @@ Require Import UniMath.Foundations.Sets.
 
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.limits.products.
+
 Local Open Scope cat.
 
 Section def_terminal.
@@ -26,6 +28,24 @@ Definition Terminal : UU := total2 (fun a => isTerminal a).
 Definition TerminalObject (T : Terminal) : C := pr1 T.
 Coercion TerminalObject : Terminal >-> ob.
 
+Definition TerminalArrow (T : Terminal) (b : C) : b --> T :=  pr1 (pr2 T b).
+
+Lemma TerminalEndo_is_identity (T : Terminal) (f : T --> T) : identity T = f.
+Proof.
+now apply proofirrelevance, isapropifcontr, (pr2 T T).
+Qed.
+
+Lemma TerminalArrowUnique (T : Terminal) (a : C)
+  (f : C⟦a,TerminalObject T⟧) : f = TerminalArrow T _.
+Proof.
+exact (pr2 (pr2 T _ ) _ ).
+Defined.
+
+Lemma ArrowsToTerminal (T : Terminal) (a : C) (f g : a --> T) : f = g.
+Proof.
+now rewrite (TerminalArrowUnique _ _ f), (TerminalArrowUnique _ _ g).
+Qed.
+
 Definition mk_Terminal (b : C) (H : isTerminal b) : Terminal.
 Proof.
   exists b; exact H.
@@ -37,27 +57,11 @@ Proof.
   exact H.
 Defined.
 
-Definition TerminalArrow (T : Terminal) (b : C) : b --> T :=  pr1 (pr2 T b).
-
-Lemma ArrowsToTerminal (T : Terminal) (b : C) (f g : b --> T) : f = g.
-Proof.
-  apply proofirrelevance.
-  apply isapropifcontr.
-  apply (pr2 T _).
-Qed.
-
-Lemma TerminalEndo_is_identity (T : Terminal) (f : T --> T) : identity T = f.
-Proof.
-  apply ArrowsToTerminal.
-Qed.
-
 Lemma isiso_from_Terminal_to_Terminal (T T' : Terminal) :
    is_iso (TerminalArrow T T').
 Proof.
-  apply (is_iso_qinv _ (TerminalArrow T' T)).
-  split.
-  - apply pathsinv0. apply TerminalEndo_is_identity.
-  - apply pathsinv0. apply TerminalEndo_is_identity.
+apply (is_iso_qinv _ (TerminalArrow T' T)).
+now split; apply pathsinv0, TerminalEndo_is_identity.
 Defined.
 
 Definition iso_Terminals (T T' : Terminal) : iso T T' :=
@@ -102,7 +106,6 @@ Arguments mk_Terminal {_} _ _.
 
 
 Section Terminal_and_EmptyProd.
-  Require Import UniMath.CategoryTheory.limits.products.
 
   (** Construct Terminal from empty arbitrary product. *)
   Definition terminal_from_empty_product (C : precategory) :
@@ -117,6 +120,7 @@ Section Terminal_and_EmptyProd.
     apply (iscontrpair (ProductArrow _ _ X H)); intros t.
     apply ProductArrowUnique; intros i; apply (fromempty i).
   Defined.
+
 End Terminal_and_EmptyProd.
 
 (* Section Terminal_from_Lims. *)
@@ -160,3 +164,33 @@ End Terminal_and_EmptyProd.
 (* Defined. *)
 
 (* End Terminal_from_Lims. *)
+
+
+Local Notation "[ C , D , hs ]" := (functor_precategory C D hs).
+
+(** * Construction of terminal object in a functor category *)
+Section TerminalFunctorCat.
+
+Variables (C D : precategory) (ID : Terminal D) (hsD : has_homsets D).
+
+Definition Terminal_functor_precat : Terminal [C, D, hsD].
+Proof.
+use mk_Terminal.
+- use mk_functor.
+  + mkpair.
+    * intros c; apply (TerminalObject ID).
+    * simpl; intros a b f; apply (TerminalArrow ID).
+  + split.
+    * intro a; apply pathsinv0, TerminalEndo_is_identity.
+    * intros a b c f g; apply pathsinv0, TerminalArrowUnique.
+- intros F.
+  mkpair.
+  + use mk_nat_trans; simpl.
+    * intro a; apply TerminalArrow.
+    * intros a b f; simpl.
+      rewrite <- (TerminalEndo_is_identity _ ID (TerminalArrow ID)), id_right.
+      apply TerminalArrowUnique.
+  + abstract (intros α; apply (nat_trans_eq hsD); intro a; apply TerminalArrowUnique).
+Defined.
+
+End TerminalFunctorCat.


### PR DESCRIPTION
Define the (set-valued) presheaf category Psh C as [C^op,HSET] and prove various things:

- Construction of some (co)limits (all of these are lifted from HSET to the functor category)
- Definition of the subobject classifier in Psh C as the set of sieves (there is no proof yet that this actually is the subobject classifier as this notion hasn't been defined in UniMath yet)
- Various minor results (morphisms from the terminal object are monic, morphisms to the initial object are epi and construction of the terminal object in functor categories from the target category)