### PR TITLE
Proof that Omega in PreShv(C) is a bounded lattice

### DIFF
--- a/UniMath/Algebra/Lattice.v
+++ b/UniMath/Algebra/Lattice.v
@@ -90,6 +90,23 @@ Definition mklattice {X : hSet} {min max : binop X} : latticeop min max → latt
 Definition Lmin {X : hSet} (is : lattice X) : binop X := pr1 is.
 Definition Lmax {X : hSet} (is : lattice X) : binop X := pr1 (pr2 is).
 
+(** Bounded lattices *)
+
+Definition bounded_latticeop {X : hSet} (l : lattice X) (bot top : X) :=
+  (islunit (Lmax l) bot) × (islunit (Lmin l) top).
+
+Definition bounded_lattice (X : hSet) :=
+  ∑ (l : lattice X) (bot top : X), bounded_latticeop l bot top.
+
+Definition mkbounded_lattice {X : hSet} {l : lattice X} {bot top : X} :
+  bounded_latticeop l bot top → bounded_lattice X := λ bl, l,, bot,, top,, bl.
+
+Definition bounded_lattice_to_lattice X : bounded_lattice X → lattice X := pr1.
+Coercion bounded_lattice_to_lattice : bounded_lattice >-> lattice.
+
+Definition Lbot {X : hSet} (is : bounded_lattice X) : X := pr1 (pr2 is).
+Definition Ltop {X : hSet} (is : bounded_lattice X) : X := pr1 (pr2 (pr2 is)).
+
 Section lattice_pty.
 
 Context {X : hSet}
@@ -128,6 +145,30 @@ Proof.
 Qed.
 
 End lattice_pty.
+
+Section bounded_lattice_pty.
+
+Context {X : hSet} (l : bounded_lattice X).
+
+Definition islunit_Lmax_Lbot : islunit (Lmax l) (Lbot l) :=
+  pr1 (pr2 (pr2 (pr2 l))).
+
+Definition islunit_Lmin_Ltop : islunit (Lmin l) (Ltop l) :=
+  pr2 (pr2 (pr2 (pr2 l))).
+
+Lemma Lmin_Lbot (x : X) : Lmin l (Lbot l) x = Lbot l.
+Proof.
+intros x.
+now rewrite <- (islunit_Lmax_Lbot x), Lmin_absorb.
+Qed.
+
+Lemma Lmax_Ltop (x : X) : Lmax l (Ltop l) x = Ltop l.
+Proof.
+intros x.
+now rewrite <- (islunit_Lmin_Ltop x), Lmax_absorb.
+Qed.
+
+End bounded_lattice_pty.
 
 (** ** Partial order in a lattice *)
 

--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -100,3 +100,4 @@ set_slice_fam_equiv.v
 Elements.v
 ElementsOp.v
 Presheaf.v
+LatticeObject.v

--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -99,5 +99,5 @@ FiveLemma.v
 set_slice_fam_equiv.v
 Elements.v
 ElementsOp.v
-Presheaf.v
 LatticeObject.v
+Presheaf.v

--- a/UniMath/CategoryTheory/LatticeObject.v
+++ b/UniMath/CategoryTheory/LatticeObject.v
@@ -20,6 +20,7 @@ Require Import UniMath.Algebra.Lattice.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.Monics.
 Require Import UniMath.CategoryTheory.limits.binproducts.
+Require Import UniMath.CategoryTheory.limits.terminal.
 
 Local Open Scope cat.
 
@@ -114,6 +115,46 @@ Definition mklatticeob {L : C} {meet_mor join_mor : C⟦L ⊗ L,L⟧} :
 
 Definition meet_mor {L : C} (isL : latticeob L) : C⟦L ⊗ L,L⟧ := pr1 isL.
 Definition join_mor {L : C} (isL : latticeob L) : C⟦L ⊗ L,L⟧ := pr1 (pr2 isL).
+
+(** Bounded lattice objects *)
+
+Context {TC : Terminal C}.
+
+Definition ι_1 {x : C} : C⟦x,TC ⊗ x⟧ :=
+  BinProductArrow _ _ (TerminalArrow _) (identity x).
+
+(** Given u : C⟦TC,L⟧ the equation witnessing the left unit law is given by the diagram:
+<<
+         ι_1
+     L ------> 1 ⊗ L
+     |           |
+   1 |           | u×1
+     V           V
+     L <------ L ⊗ L
+          f
+>>
+
+ *)
+
+Definition islunit_cat {L} (f : C⟦L ⊗ L,L⟧) (u : C⟦TC,L⟧) : UU := ι_1 · (u ×× 1) · f = 1.
+
+
+Definition bounded_latticeop {X : hSet} (l : lattice X) (bot top : X) :=
+  (islunit (Lmax l) bot) × (islunit (Lmin l) top).
+
+Definition bounded_lattice (X : hSet) :=
+  ∑ (l : lattice X) (bot top : X), bounded_latticeop l bot top.
+
+Definition mkbounded_lattice {X : hSet} {l : lattice X} {bot top : X} :
+  bounded_latticeop l bot top → bounded_lattice X := λ bl, l,, bot,, top,, bl.
+
+Definition bounded_lattice_to_lattice X : bounded_lattice X → lattice X := pr1.
+Coercion bounded_lattice_to_lattice : bounded_lattice >-> lattice.
+
+Definition Lbot {X : hSet} (is : bounded_lattice X) : X := pr1 (pr2 is).
+Definition Ltop {X : hSet} (is : bounded_lattice X) : X := pr1 (pr2 (pr2 is)).
+
+
 
 End LatticeObject_def.
 

--- a/UniMath/CategoryTheory/LatticeObject.v
+++ b/UniMath/CategoryTheory/LatticeObject.v
@@ -109,7 +109,7 @@ Definition latticeop_cat {L} (meet_mor join_mor : C⟦L ⊗ L,L⟧) :=
 Definition latticeob (L : C) : UU :=
   ∑ (meet_mor join_mor : C⟦L ⊗ L,L⟧), latticeop_cat meet_mor join_mor.
 
-Definition mklatticeob {L : C} {meet_mor join_mor : C⟦L ⊗ L,L⟧} :
+Definition mk_latticeob {L : C} {meet_mor join_mor : C⟦L ⊗ L,L⟧} :
   latticeop_cat meet_mor join_mor → latticeob L :=
     λ (isL : latticeop_cat meet_mor join_mor), meet_mor,, join_mor ,, isL.
 
@@ -145,7 +145,7 @@ Definition bounded_latticeop_cat {L} (l : latticeob L) (bot top : C⟦TC,L⟧) :
 Definition bounded_latticeob (L : C) : UU :=
   ∑ (l : latticeob L) (bot top : C⟦TC,L⟧), bounded_latticeop_cat l bot top.
 
-Definition mkbounded_latticeob {L} {l : latticeob L} {bot top : C⟦TC,L⟧} :
+Definition mk_bounded_latticeob {L} {l : latticeob L} {bot top : C⟦TC,L⟧} :
   bounded_latticeop_cat l bot top → bounded_latticeob L := λ bl, l,, bot,, top,, bl.
 
 Definition bounded_latticeob_to_latticeob X : bounded_latticeob X → latticeob X := pr1.
@@ -281,7 +281,7 @@ Qed.
 
 Definition sub_latticeob : latticeob BPC M.
 Proof.
-use mklatticeob.
+use mk_latticeob.
 - apply meet_mor_M.
 - apply join_mor_M.
 - repeat split.
@@ -327,7 +327,7 @@ Qed.
 
 Definition sub_bounded_latticeob : bounded_latticeob BPC TC M.
 Proof.
-use mkbounded_latticeob.
+use mk_bounded_latticeob.
 - exact (sub_latticeob BPC Hi l Hmeet Hjoin).
 - exact bot_mor_M.
 - exact top_mor_M.

--- a/UniMath/CategoryTheory/LatticeObject.v
+++ b/UniMath/CategoryTheory/LatticeObject.v
@@ -26,6 +26,7 @@ Require Import UniMath.CategoryTheory.limits.terminal.
 
 Local Open Scope cat.
 
+(** * Definition of lattice objects and bounded lattice objects *)
 Section LatticeObject_def.
 
 Context {C : precategory} {BPC : BinProducts C}.
@@ -192,6 +193,8 @@ Definition islunit_meet_mor_top_mor : islunit_cat (meet_mor l) (top_mor l) :=
 
 End BoundedLatticeObject_accessors.
 
+
+(** * Definition of sublattice objects  *)
 Section SublatticeObject.
 
 Context {C : precategory} (BPC : BinProducts C) {M L : C}.

--- a/UniMath/CategoryTheory/LatticeObject.v
+++ b/UniMath/CategoryTheory/LatticeObject.v
@@ -5,7 +5,9 @@ Internal lattice objects in a category
 Contents:
 
 - Lattice objects ([latticeob])
-- Proof that a subobject of a lattice object is a lattice object ([sublatticeob])
+- Bounded lattice objects ([bounded_latticeob])
+- Proof that a subobject of a (bounded) lattice object is a lattice object
+  ([sublatticeob], [sub_bounded_latticeob])
 
 Written by: Anders Mörtberg, 2017
 
@@ -199,8 +201,7 @@ Context {i : C⟦M,L⟧} (Hi : isMonic i) (l : latticeob BPC L).
 Local Notation "c '⊗' d" := (BinProductObject C (BPC c d)) (at level 75) : cat.
 Local Notation "f '××' g" := (BinProductOfArrows _ _ _ f g) (at level 90) : cat.
 
-(* Is this the correct way of expressing this or is too strong? *)
-(* I think this asserts that i is a lattice morphism internally *)
+(** This asserts that i is a lattice homomorphism internally *)
 Context {meet_mor_M : C⟦M ⊗ M,M⟧} (Hmeet : meet_mor_M · i = (i ×× i) · meet_mor l).
 Context {join_mor_M : C⟦M ⊗ M,M⟧} (Hjoin : join_mor_M · i = (i ×× i) · join_mor l).
 

--- a/UniMath/CategoryTheory/LatticeObject.v
+++ b/UniMath/CategoryTheory/LatticeObject.v
@@ -9,6 +9,8 @@ Contents:
 - Proof that a subobject of a (bounded) lattice object is a lattice object
   ([sublatticeob], [sub_bounded_latticeob])
 
+Based on "Sheaves in Geometry and Logic" by Mac Lane and Moerdijk (Section IV.8, page 198)
+
 Written by: Anders Mörtberg, 2017
 
 *********************************************************************************)

--- a/UniMath/CategoryTheory/LatticeObject.v
+++ b/UniMath/CategoryTheory/LatticeObject.v
@@ -146,94 +146,94 @@ Definition meet_mor_absorb_join_mor : isabsorb_cat (meet_mor isL) (join_mor isL)
 Definition join_mor_absorb_meet_mor : isabsorb_cat (join_mor isL) (meet_mor isL) :=
   pr2 (pr2 (pr2 (pr2 (pr2 isL)))).
 
-(** This corresponds to the equation: x ∧ x = x *)
-Lemma meet_mor_id : δ · meet_mor isL = 1.
-Proof.
-generalize isassoc_meet_mor.
-generalize iscomm_meet_mor.
-generalize isassoc_join_mor.
-generalize iscomm_join_mor.
-generalize meet_mor_absorb_join_mor.
-generalize join_mor_absorb_meet_mor.
-unfold isassoc_cat, iscomm_cat, isabsorb_cat.
-intros h1 h2 h3 h4 h5 h6.
-assert (H : δ · π1 = identity L).
-admit.
-rewrite <- H.
-Abort.
-
 End LatticeObject_theory.
 
 Section SublatticeObject.
 
-Context {C : precategory} (BPC : BinProducts C) (M L : C) (i : Monic _ M L)
+Context {C : precategory} (BPC : BinProducts C) (M L : C) (i : C⟦M,L⟧) (Hi : isMonic i)
         (isL : latticeob BPC L).
 
 Local Notation "c '⊗' d" := (BinProductObject C (BPC c d)) (at level 75) : cat.
 Local Notation "f '××' g" := (BinProductOfArrows _ _ _ f g) (at level 90) : cat.
 
-Let j : C⟦M,L⟧ := pr1 i.
-Let Hj : isMonic j := pr2 i.
-
 (* Is this the correct way of expressing this or is too strong? *)
 (* I think this asserts that i is a lattice morphism internally *)
-Variables (meet_mor_M : C⟦M ⊗ M,M⟧) (Hmeet : meet_mor_M · j = (j ×× j) · meet_mor isL).
-Variables (join_mor_M : C⟦M ⊗ M,M⟧) (Hjoin : join_mor_M · j = (j ×× j) · join_mor isL).
+Variables (meet_mor_M : C⟦M ⊗ M,M⟧) (Hmeet : meet_mor_M · i = (i ×× i) · meet_mor isL).
+Variables (join_mor_M : C⟦M ⊗ M,M⟧) (Hjoin : join_mor_M · i = (i ×× i) · join_mor isL).
 
-(* Notation "C ⟦ a ,, b ⟧" := (precategory_morphisms (C:=C) a b) (format "C ⟦ a ,, b ⟧", at level 50). *)
-
-Lemma Hid : identity M · j = j · identity L.
+Local Lemma identity_comm : identity M · i = i · identity L.
 Proof.
 now rewrite id_left, id_right.
 Qed.
 
-Lemma Hbinprod_assoc : ((j ×× j) ×× j) · @binprod_assoc _ BPC L L L =
-                       @binprod_assoc _ BPC M M M · (j ×× (j ×× j)).
+Local Lemma binprod_assoc_comm :
+  ((i ×× i) ×× i) · @binprod_assoc _ BPC L L L =
+  @binprod_assoc _ BPC M M M · (i ×× (i ×× i)).
 Proof.
-apply pathsinv0.
-etrans.
-    apply postcompWithBinProductArrow.
-    apply pathsinv0.
-    apply BinProductArrowUnique.
-    *
-    rewrite <-assoc.
-    etrans.
-    apply maponpaths.
-    apply BinProductPr1Commutes.
-    simpl.
-    now rewrite assoc, BinProductOfArrowsPr1, <- assoc, BinProductOfArrowsPr1, assoc.
-    * rewrite postcompWithBinProductArrow.
-      apply BinProductArrowUnique.
-      **
-        etrans.
-        apply cancel_postcomposition.
-        rewrite <-assoc.
-        apply maponpaths.
-        apply BinProductPr2Commutes.
-        rewrite <-assoc.
-        etrans.
-        apply maponpaths.
-        apply BinProductPr1Commutes.
-        now rewrite assoc, BinProductOfArrowsPr1, <- assoc, BinProductOfArrowsPr2, assoc.
-      ** etrans.
-         apply cancel_postcomposition.
-         rewrite <-assoc.
-         apply maponpaths.
-        apply BinProductPr2Commutes.
-        rewrite <-assoc.
-        etrans.
-        apply maponpaths.
-        apply BinProductPr2Commutes.
-        now rewrite BinProductOfArrowsPr2.
+unfold binprod_assoc; rewrite postcompWithBinProductArrow.
+apply BinProductArrowUnique.
+- rewrite <-assoc, BinProductPr1Commutes.
+  now rewrite assoc, BinProductOfArrowsPr1, <- assoc, BinProductOfArrowsPr1, assoc.
+- rewrite postcompWithBinProductArrow.
+  apply BinProductArrowUnique.
+  + etrans; [ apply cancel_postcomposition; rewrite <-assoc;
+              apply maponpaths, BinProductPr2Commutes |].
+    rewrite <- assoc, BinProductPr1Commutes.
+    now rewrite assoc, BinProductOfArrowsPr1, <- assoc, BinProductOfArrowsPr2, assoc.
+  + etrans; [ apply cancel_postcomposition; rewrite <-assoc;
+              apply maponpaths, BinProductPr2Commutes |].
+    now rewrite <- assoc, BinProductPr2Commutes, BinProductOfArrowsPr2.
 Qed.
 
-Lemma binprod_delta_comm : j · @binprod_delta _ BPC L = @binprod_delta _ BPC M · (j ×× j).
+Local Lemma binprod_delta_comm :
+  i · @binprod_delta _ BPC L = @binprod_delta _ BPC M · (i ×× i).
 Proof.
-unfold binprod_delta.
-rewrite postcompWithBinProductArrow.
+unfold binprod_delta; rewrite postcompWithBinProductArrow.
 apply BinProductArrowUnique.
-now rewrite <-assoc, BinProductPr1Commutes, Hid.
-now rewrite <-assoc, BinProductPr2Commutes, Hid.
+now rewrite <-assoc, BinProductPr1Commutes, identity_comm.
+now rewrite <-assoc, BinProductPr2Commutes, identity_comm.
+Qed.
+
+Local Lemma isassoc_cat_comm {f : C⟦M ⊗ M,M⟧} {g : C⟦L ⊗ L,L⟧} (Hfg : f · i = (i ×× i) · g) :
+  isassoc_cat g → isassoc_cat f.
+Proof.
+unfold isassoc_cat; intros H; apply Hi.
+rewrite <-!assoc, !Hfg, !assoc, BinProductOfArrows_comp, Hfg, <- !assoc, identity_comm.
+rewrite <- BinProductOfArrows_comp, <- assoc, H, !assoc.
+apply cancel_postcomposition.
+rewrite <-!assoc, BinProductOfArrows_comp, Hfg, identity_comm.
+now rewrite <- BinProductOfArrows_comp, !assoc, binprod_assoc_comm.
+Qed.
+
+Local Lemma iscomm_cat_comm {f : C⟦M ⊗ M,M⟧} {g : C⟦L ⊗ L,L⟧} (Hfg : f · i = (i ×× i) · g) :
+  iscomm_cat g → iscomm_cat f.
+Proof.
+unfold iscomm_cat; intros H; apply Hi.
+rewrite <- !assoc, !Hfg.
+etrans; [eapply maponpaths, H|].
+rewrite !assoc; apply cancel_postcomposition.
+unfold binprod_swap; rewrite postcompWithBinProductArrow.
+apply BinProductArrowUnique; rewrite <- assoc.
+* now rewrite BinProductPr1Commutes, BinProductOfArrowsPr2.
+* now rewrite BinProductPr2Commutes, BinProductOfArrowsPr1.
+Qed.
+
+Local Lemma isabsorb_cat_comm {f1 f2 : C⟦M ⊗ M,M⟧} {g1 g2 : C⟦L ⊗ L,L⟧}
+  (Hfg1 : f1 · i = (i ×× i) · g1) (Hfg2 : f2 · i = (i ×× i) · g2) :
+  isabsorb_cat g1 g2  → isabsorb_cat f1 f2.
+Proof.
+unfold isabsorb_cat; intros H; apply Hi.
+assert (HH : BinProductPr1 C (BPC M M) · i = (i ×× i) · BinProductPr1 C (BPC L L)).
+{ now rewrite BinProductOfArrowsPr1. }
+rewrite HH, <- H, <-!assoc, Hfg1, !assoc.
+apply cancel_postcomposition.
+rewrite <-!assoc, BinProductOfArrows_comp, Hfg2, identity_comm, !assoc.
+rewrite BinProductOfArrows_comp, <-identity_comm, binprod_delta_comm.
+etrans; [| eapply pathsinv0; do 2 apply cancel_postcomposition;
+           now rewrite <-BinProductOfArrows_comp].
+rewrite <-!assoc; apply maponpaths.
+rewrite assoc, binprod_assoc_comm, <-assoc; apply maponpaths.
+now rewrite identity_comm, BinProductOfArrows_comp.
 Qed.
 
 Definition sublatticeob : latticeob BPC M.
@@ -241,118 +241,13 @@ Proof.
 use mklatticeob.
 - apply meet_mor_M.
 - apply join_mor_M.
--
-  repeat split; apply Hj.
-  + set (H := isassoc_meet_mor _ isL).
-    unfold isassoc_cat in *.
-    simpl in *.
-    rewrite <-!assoc, !Hmeet.
-    rewrite !assoc.
-    rewrite !BinProductOfArrows_comp.
-    rewrite Hmeet.
-    rewrite <- !assoc.
-    rewrite Hid.
-    rewrite <- BinProductOfArrows_comp, <- assoc, H.
-    rewrite !assoc.
-    apply cancel_postcomposition.
-    rewrite <-!assoc.
-    rewrite BinProductOfArrows_comp, Hmeet, Hid.
-    rewrite <- BinProductOfArrows_comp.
-    rewrite !assoc.
-    apply cancel_postcomposition.
-    apply Hbinprod_assoc.
-  + rewrite <- !assoc, !Hmeet.
-    etrans; [eapply maponpaths, (iscomm_meet_mor _ isL)|].
-    rewrite !assoc; apply cancel_postcomposition.
-    unfold binprod_swap.
-    rewrite postcompWithBinProductArrow.
-    apply BinProductArrowUnique; rewrite <- assoc.
-    * now rewrite BinProductPr1Commutes, BinProductOfArrowsPr2.
-    * now rewrite BinProductPr2Commutes, BinProductOfArrowsPr1.
-  + set (H := isassoc_join_mor _ isL).
-    unfold isassoc_cat in *.
-    simpl in *.
-    rewrite <-!assoc, !Hjoin.
-    rewrite !assoc.
-    rewrite !BinProductOfArrows_comp.
-    rewrite Hjoin.
-    rewrite <- !assoc.
-    assert (HH : identity M · j = j · identity L).
-    { now rewrite id_left, id_right. }
-    rewrite HH.
-    rewrite <- BinProductOfArrows_comp, <- assoc, H.
-    rewrite !assoc.
-    apply cancel_postcomposition.
-    rewrite <-!assoc.
-    rewrite BinProductOfArrows_comp, Hjoin, HH.
-    rewrite <- BinProductOfArrows_comp.
-    rewrite !assoc.
-    apply cancel_postcomposition.
-    apply Hbinprod_assoc.
-  + rewrite <- !assoc, !Hjoin.
-    etrans; [eapply maponpaths, (iscomm_join_mor _ isL)|].
-    rewrite !assoc; apply cancel_postcomposition.
-    unfold binprod_swap.
-    rewrite postcompWithBinProductArrow.
-    apply BinProductArrowUnique; rewrite <- assoc.
-    * now rewrite BinProductPr1Commutes, BinProductOfArrowsPr2.
-    * now rewrite BinProductPr2Commutes, BinProductOfArrowsPr1.
-  + set (H := meet_mor_absorb_join_mor _ isL).
-    unfold isabsorb_cat in *.
-    assert (HH :  BinProductPr1 C (BPC M M) · j = (j ×× j) · BinProductPr1 C (BPC L L)).
-    { now rewrite BinProductOfArrowsPr1. }
-    rewrite HH.
-    rewrite <- H, <-!assoc.
-    rewrite Hmeet, !assoc.
-    apply cancel_postcomposition.
-    rewrite <-!assoc.
-    rewrite BinProductOfArrows_comp, Hjoin.
-    rewrite Hid.
-    rewrite !assoc.
-    rewrite BinProductOfArrows_comp.
-    rewrite <-Hid.
-    rewrite binprod_delta_comm.
-    etrans.
-    Focus 2.
-    eapply pathsinv0.
-    do 2apply cancel_postcomposition.
-    rewrite <-BinProductOfArrows_comp.
-    apply idpath.
-    rewrite <-!assoc.
-    apply maponpaths.
-    rewrite assoc.
-    rewrite Hbinprod_assoc, <-assoc.
-    apply maponpaths.
-    rewrite Hid.
-    now rewrite BinProductOfArrows_comp.
-  + set (H := join_mor_absorb_meet_mor _ isL).
-    unfold isabsorb_cat in *.
-    assert (HH :  BinProductPr1 C (BPC M M) · j = (j ×× j) · BinProductPr1 C (BPC L L)).
-    { now rewrite BinProductOfArrowsPr1. }
-    rewrite HH.
-    rewrite <- H, <-!assoc.
-    rewrite Hjoin, !assoc.
-    apply cancel_postcomposition.
-    rewrite <-!assoc.
-    rewrite BinProductOfArrows_comp, Hmeet.
-    rewrite Hid.
-    rewrite !assoc.
-    rewrite BinProductOfArrows_comp.
-    rewrite <-Hid.
-    rewrite binprod_delta_comm.
-    etrans.
-    Focus 2.
-    eapply pathsinv0.
-    do 2apply cancel_postcomposition.
-    rewrite <-BinProductOfArrows_comp.
-    apply idpath.
-    rewrite <-!assoc.
-    apply maponpaths.
-    rewrite assoc.
-    rewrite Hbinprod_assoc, <-assoc.
-    apply maponpaths.
-    rewrite Hid.
-    now rewrite BinProductOfArrows_comp.
+- repeat split.
+  + now apply (isassoc_cat_comm Hmeet), (isassoc_meet_mor _ isL).
+  + now apply (iscomm_cat_comm Hmeet), (iscomm_meet_mor _ isL).
+  + now apply (isassoc_cat_comm Hjoin), (isassoc_join_mor _ isL).
+  + now apply (iscomm_cat_comm Hjoin), (iscomm_join_mor _ isL).
+  + now apply (isabsorb_cat_comm Hmeet Hjoin), (meet_mor_absorb_join_mor _ isL).
+  + now apply (isabsorb_cat_comm Hjoin Hmeet), (join_mor_absorb_meet_mor _ isL).
 Qed.
 
 End SublatticeObject.

--- a/UniMath/CategoryTheory/LatticeObject.v
+++ b/UniMath/CategoryTheory/LatticeObject.v
@@ -19,6 +19,13 @@ Context {C : precategory} {BPC : BinProducts C}.
 Local Notation "c '⊗' d" := (BinProductObject C (BPC c d)) (at level 75) : cat.
 Local Notation "f '××' g" := (BinProductOfArrows _ _ _ f g) (at level 80) : cat.
 
+Let π1 {x y} : C⟦x ⊗ y,x⟧ := BinProductPr1 _ (BPC x y).
+Let π2 {x y} : C⟦x ⊗ y,y⟧ := BinProductPr2 _ (BPC x y).
+
+Definition binprod_assoc (x y z : C) : C⟦(x ⊗ y) ⊗ z,x ⊗ (y ⊗ z)⟧ :=
+  BinProductArrow _ _ (π1 · π1) (BinProductArrow _ _ (π1 · π2) π2).
+Let α {x y z} : C⟦(x ⊗ y) ⊗ z,x ⊗ (y ⊗ z)⟧ := binprod_assoc x y z.
+
 Definition binprod_delta (x : C) : C⟦x,x ⊗ x⟧ :=
   BinProductArrow _ _ (identity x) (identity x).
 Let δ {x} : C⟦x,x ⊗ x⟧ := binprod_delta x.
@@ -27,28 +34,27 @@ Definition binprod_swap (x y : C) : C⟦x ⊗ y,y ⊗ x⟧ :=
   BinProductArrow _ _ (BinProductPr2 _ _) (BinProductPr1 _ _).
 Let τ {x y} : C⟦x ⊗ y,y ⊗ x⟧ := binprod_swap x y.
 
-Let π1 {x y} : C⟦x ⊗ y,x⟧ := BinProductPr1 _ (BPC x y).
 
 Local Notation "1" := (identity _) : cat.
 
 
 (** Equation witnessing that a morphism is associative as illustrated by diagram:
 <<
-               1×f
- L ⊗ (L ⊗ L) -------> L ⊗ L
+               f×1
+ (L ⊗ L) ⊗ L -------> L ⊗ L
      |                  |
-   τ |                  |
+   α |                  |
      V                  |
- (L ⊗ L) ⊗ L            | f
+ L ⊗ (L ⊗ L)            | f
      |                  |
- f×1 |                  |
+ 1×f |                  |
      V                  V
    L ⊗ L ----------->   L
               f
 >>
 *)
 
-Definition isassoc_cat {L} (f : C⟦L ⊗ L,L⟧) : UU := (1 ×× f) · f = τ · (f ×× 1) · f.
+Definition isassoc_cat {L} (f : C⟦L ⊗ L,L⟧) : UU := (f ×× 1) · f = α · (1 ×× f) · f.
 
 
 (** Equation witnessing that a morphism is commutative as illustrated by diagram:
@@ -67,12 +73,12 @@ Definition iscomm_cat {L} (f : C⟦L ⊗ L,L⟧) : UU := 1 · f = τ · f.
 
 (** Equation witnessing the absorbtion law as illustrated by diagram:
 <<
-           δ×1                  τ
-   L ⊗ L ------> (L ⊗ L) ⊗ L ------> L ⊗ (L ⊗ L)
-     |                                   |
-  π1 |                                   | 1×g
-     V                                   V
-     L <------------------------------ L ⊗ L
+           δ×1                   α
+   L ⊗ L ------> (L ⊗ L) ⊗ L -------> L ⊗ (L ⊗ L)
+     |                                    |
+  π1 |                                    | 1×g
+     V                                    V
+     L <------------------------------- L ⊗ L
                        f
 >>
 
@@ -81,8 +87,7 @@ If f is ∧ and g is ∨ this expresses: x ∧ (x ∨ y) = x
 *)
 
 Definition isabsorb_cat {L} (f g : C⟦L ⊗ L,L⟧) : UU :=
-  (δ ×× 1) · τ · (1 ×× g) · f = π1.
-
+  (δ ×× 1) · α · (1 ×× g) · f = π1.
 
 Definition latticeop_cat {L} (meet_mor join_mor : C⟦L ⊗ L,L⟧) :=
     (isassoc_cat meet_mor × iscomm_cat meet_mor)

--- a/UniMath/CategoryTheory/LatticeObject.v
+++ b/UniMath/CategoryTheory/LatticeObject.v
@@ -1,4 +1,15 @@
-(** Internal lattice objects in a category *)
+(** *****************************************************************************
+
+Internal lattice objects in a category
+
+Contents:
+
+- Lattice objects ([latticeob])
+- Proof that a subobject of a lattice object is a lattice object ([sublatticeob])
+
+Written by: Anders Mörtberg, 2017
+
+*********************************************************************************)
 
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
@@ -38,7 +49,8 @@ Let τ {x y} : C⟦x ⊗ y,y ⊗ x⟧ := binprod_swap x y.
 Local Notation "1" := (identity _) : cat.
 
 
-(** Equation witnessing that a morphism is associative as illustrated by diagram:
+(** Equation witnessing that a morphism representing a binary operation is
+    associative as illustrated by diagram:
 <<
                f×1
  (L ⊗ L) ⊗ L -------> L ⊗ L
@@ -53,22 +65,23 @@ Local Notation "1" := (identity _) : cat.
               f
 >>
 *)
-
 Definition isassoc_cat {L} (f : C⟦L ⊗ L,L⟧) : UU := (f ×× 1) · f = α · (1 ×× f) · f.
 
 
-(** Equation witnessing that a morphism is commutative as illustrated by diagram:
+(** Equation witnessing that a morphism representing a binary operation is
+    commutative as illustrated by diagram:
 <<
-             1
-   L ⊗ L -------> L ⊗ L
-     |              |
-   τ |              | f
-     V              V
-   L ⊗ L ---------> L
-             f
+   L ⊗ L
+     |   \
+     |     \
+   τ |       \ f
+     |         \
+     |          V
+   L ⊗ L -----> L
+           f
 >>
 *)
-Definition iscomm_cat {L} (f : C⟦L ⊗ L,L⟧) : UU := 1 · f = τ · f.
+Definition iscomm_cat {L} (f : C⟦L ⊗ L,L⟧) : UU := f = τ · f.
 
 
 (** Equation witnessing the absorbtion law as illustrated by diagram:
@@ -85,7 +98,6 @@ Definition iscomm_cat {L} (f : C⟦L ⊗ L,L⟧) : UU := 1 · f = τ · f.
 If f is ∧ and g is ∨ this expresses: x ∧ (x ∨ y) = x
 
 *)
-
 Definition isabsorb_cat {L} (f g : C⟦L ⊗ L,L⟧) : UU :=
   (δ ×× 1) · α · (1 ×× g) · f = π1.
 
@@ -94,6 +106,7 @@ Definition latticeop_cat {L} (meet_mor join_mor : C⟦L ⊗ L,L⟧) :=
   × (isassoc_cat join_mor × iscomm_cat join_mor)
   × (isabsorb_cat meet_mor join_mor × isabsorb_cat join_mor meet_mor).
 
+(** A lattice object L has operation meet and join satisfying the above laws *)
 Definition latticeob (L : C) : UU :=
   ∑ (meet_mor join_mor : C⟦L ⊗ L,L⟧), latticeop_cat meet_mor join_mor.
 
@@ -157,48 +170,189 @@ Context {C : precategory} (BPC : BinProducts C) (M L : C) (i : Monic _ M L)
         (isL : latticeob BPC L).
 
 Local Notation "c '⊗' d" := (BinProductObject C (BPC c d)) (at level 75) : cat.
-Local Notation "f '××' g" := (BinProductOfArrows _ _ _ f g) (at level 80) : cat.
+Local Notation "f '××' g" := (BinProductOfArrows _ _ _ f g) (at level 90) : cat.
+
+Let j : C⟦M,L⟧ := pr1 i.
+Let Hj : isMonic j := pr2 i.
 
 (* Is this the correct way of expressing this or is too strong? *)
 (* I think this asserts that i is a lattice morphism internally *)
-Variables (meet_mor_M : C⟦M ⊗ M,M⟧) (Hmeet : meet_mor_M · i = (i ×× i) · meet_mor isL).
+Variables (meet_mor_M : C⟦M ⊗ M,M⟧) (Hmeet : meet_mor_M · j = (j ×× j) · meet_mor isL).
+Variables (join_mor_M : C⟦M ⊗ M,M⟧) (Hjoin : join_mor_M · j = (j ×× j) · join_mor isL).
+
+(* Notation "C ⟦ a ,, b ⟧" := (precategory_morphisms (C:=C) a b) (format "C ⟦ a ,, b ⟧", at level 50). *)
+
+Lemma Hid : identity M · j = j · identity L.
+Proof.
+now rewrite id_left, id_right.
+Qed.
+
+Lemma Hbinprod_assoc : ((j ×× j) ×× j) · @binprod_assoc _ BPC L L L =
+                       @binprod_assoc _ BPC M M M · (j ×× (j ×× j)).
+Proof.
+apply pathsinv0.
+etrans.
+    apply postcompWithBinProductArrow.
+    apply pathsinv0.
+    apply BinProductArrowUnique.
+    *
+    rewrite <-assoc.
+    etrans.
+    apply maponpaths.
+    apply BinProductPr1Commutes.
+    simpl.
+    now rewrite assoc, BinProductOfArrowsPr1, <- assoc, BinProductOfArrowsPr1, assoc.
+    * rewrite postcompWithBinProductArrow.
+      apply BinProductArrowUnique.
+      **
+        etrans.
+        apply cancel_postcomposition.
+        rewrite <-assoc.
+        apply maponpaths.
+        apply BinProductPr2Commutes.
+        rewrite <-assoc.
+        etrans.
+        apply maponpaths.
+        apply BinProductPr1Commutes.
+        now rewrite assoc, BinProductOfArrowsPr1, <- assoc, BinProductOfArrowsPr2, assoc.
+      ** etrans.
+         apply cancel_postcomposition.
+         rewrite <-assoc.
+         apply maponpaths.
+        apply BinProductPr2Commutes.
+        rewrite <-assoc.
+        etrans.
+        apply maponpaths.
+        apply BinProductPr2Commutes.
+        now rewrite BinProductOfArrowsPr2.
+Qed.
+
+Lemma binprod_delta_comm : j · @binprod_delta _ BPC L = @binprod_delta _ BPC M · (j ×× j).
+Proof.
+unfold binprod_delta.
+rewrite postcompWithBinProductArrow.
+apply BinProductArrowUnique.
+now rewrite <-assoc, BinProductPr1Commutes, Hid.
+now rewrite <-assoc, BinProductPr2Commutes, Hid.
+Qed.
 
 Definition sublatticeob : latticeob BPC M.
 Proof.
 use mklatticeob.
 - apply meet_mor_M.
-- admit.
-- repeat split.
-  + admit.
-  + unfold iscomm_cat.
-    set (Hcomm := iscomm_meet_mor _ isL).
-    destruct i as [j Hj].
+- apply join_mor_M.
+-
+  repeat split; apply Hj.
+  + set (H := isassoc_meet_mor _ isL).
+    unfold isassoc_cat in *.
     simpl in *.
-    unfold isMonic in *.
-    rewrite id_left.
-    apply Hj.
+    rewrite <-!assoc, !Hmeet.
+    rewrite !assoc.
+    rewrite !BinProductOfArrows_comp.
+    rewrite Hmeet.
     rewrite <- !assoc.
-    rewrite !Hmeet.
-    unfold iscomm_cat in *.
-    rewrite id_left in Hcomm.
-    etrans.
-    eapply maponpaths.
-    apply Hcomm.
+    rewrite Hid.
+    rewrite <- BinProductOfArrows_comp, <- assoc, H.
     rewrite !assoc.
     apply cancel_postcomposition.
+    rewrite <-!assoc.
+    rewrite BinProductOfArrows_comp, Hmeet, Hid.
+    rewrite <- BinProductOfArrows_comp.
+    rewrite !assoc.
+    apply cancel_postcomposition.
+    apply Hbinprod_assoc.
+  + rewrite <- !assoc, !Hmeet.
+    etrans; [eapply maponpaths, (iscomm_meet_mor _ isL)|].
+    rewrite !assoc; apply cancel_postcomposition.
     unfold binprod_swap.
     rewrite postcompWithBinProductArrow.
-    apply BinProductArrowUnique.
-    rewrite <- assoc.
-    rewrite BinProductPr1Commutes.
-    now rewrite BinProductOfArrowsPr2.
-    rewrite <- assoc.
-    rewrite BinProductPr2Commutes.
-    now rewrite BinProductOfArrowsPr1.
-  + admit.
-  + admit.
-  + admit.
-  + admit.
-Admitted.
+    apply BinProductArrowUnique; rewrite <- assoc.
+    * now rewrite BinProductPr1Commutes, BinProductOfArrowsPr2.
+    * now rewrite BinProductPr2Commutes, BinProductOfArrowsPr1.
+  + set (H := isassoc_join_mor _ isL).
+    unfold isassoc_cat in *.
+    simpl in *.
+    rewrite <-!assoc, !Hjoin.
+    rewrite !assoc.
+    rewrite !BinProductOfArrows_comp.
+    rewrite Hjoin.
+    rewrite <- !assoc.
+    assert (HH : identity M · j = j · identity L).
+    { now rewrite id_left, id_right. }
+    rewrite HH.
+    rewrite <- BinProductOfArrows_comp, <- assoc, H.
+    rewrite !assoc.
+    apply cancel_postcomposition.
+    rewrite <-!assoc.
+    rewrite BinProductOfArrows_comp, Hjoin, HH.
+    rewrite <- BinProductOfArrows_comp.
+    rewrite !assoc.
+    apply cancel_postcomposition.
+    apply Hbinprod_assoc.
+  + rewrite <- !assoc, !Hjoin.
+    etrans; [eapply maponpaths, (iscomm_join_mor _ isL)|].
+    rewrite !assoc; apply cancel_postcomposition.
+    unfold binprod_swap.
+    rewrite postcompWithBinProductArrow.
+    apply BinProductArrowUnique; rewrite <- assoc.
+    * now rewrite BinProductPr1Commutes, BinProductOfArrowsPr2.
+    * now rewrite BinProductPr2Commutes, BinProductOfArrowsPr1.
+  + set (H := meet_mor_absorb_join_mor _ isL).
+    unfold isabsorb_cat in *.
+    assert (HH :  BinProductPr1 C (BPC M M) · j = (j ×× j) · BinProductPr1 C (BPC L L)).
+    { now rewrite BinProductOfArrowsPr1. }
+    rewrite HH.
+    rewrite <- H, <-!assoc.
+    rewrite Hmeet, !assoc.
+    apply cancel_postcomposition.
+    rewrite <-!assoc.
+    rewrite BinProductOfArrows_comp, Hjoin.
+    rewrite Hid.
+    rewrite !assoc.
+    rewrite BinProductOfArrows_comp.
+    rewrite <-Hid.
+    rewrite binprod_delta_comm.
+    etrans.
+    Focus 2.
+    eapply pathsinv0.
+    do 2apply cancel_postcomposition.
+    rewrite <-BinProductOfArrows_comp.
+    apply idpath.
+    rewrite <-!assoc.
+    apply maponpaths.
+    rewrite assoc.
+    rewrite Hbinprod_assoc, <-assoc.
+    apply maponpaths.
+    rewrite Hid.
+    now rewrite BinProductOfArrows_comp.
+  + set (H := join_mor_absorb_meet_mor _ isL).
+    unfold isabsorb_cat in *.
+    assert (HH :  BinProductPr1 C (BPC M M) · j = (j ×× j) · BinProductPr1 C (BPC L L)).
+    { now rewrite BinProductOfArrowsPr1. }
+    rewrite HH.
+    rewrite <- H, <-!assoc.
+    rewrite Hjoin, !assoc.
+    apply cancel_postcomposition.
+    rewrite <-!assoc.
+    rewrite BinProductOfArrows_comp, Hmeet.
+    rewrite Hid.
+    rewrite !assoc.
+    rewrite BinProductOfArrows_comp.
+    rewrite <-Hid.
+    rewrite binprod_delta_comm.
+    etrans.
+    Focus 2.
+    eapply pathsinv0.
+    do 2apply cancel_postcomposition.
+    rewrite <-BinProductOfArrows_comp.
+    apply idpath.
+    rewrite <-!assoc.
+    apply maponpaths.
+    rewrite assoc.
+    rewrite Hbinprod_assoc, <-assoc.
+    apply maponpaths.
+    rewrite Hid.
+    now rewrite BinProductOfArrows_comp.
+Qed.
 
 End SublatticeObject.

--- a/UniMath/CategoryTheory/LatticeObject.v
+++ b/UniMath/CategoryTheory/LatticeObject.v
@@ -51,7 +51,7 @@ Let τ {x y} : C⟦x ⊗ y,y ⊗ x⟧ := binprod_swap x y.
 
 
 (** Equation witnessing that a morphism representing a binary operation is
-    associative as illustrated by diagram:
+    associative as illustrated by the diagram:
 <<
                f×1
  (L ⊗ L) ⊗ L -------> L ⊗ L
@@ -70,7 +70,7 @@ Definition isassoc_cat {L} (f : C⟦L ⊗ L,L⟧) : UU := (f ×× 1) · f = α �
 
 
 (** Equation witnessing that a morphism representing a binary operation is
-    commutative as illustrated by diagram:
+    commutative as illustrated by the diagram:
 <<
    L ⊗ L
      |   \
@@ -85,7 +85,7 @@ Definition isassoc_cat {L} (f : C⟦L ⊗ L,L⟧) : UU := (f ×× 1) · f = α �
 Definition iscomm_cat {L} (f : C⟦L ⊗ L,L⟧) : UU := f = τ · f.
 
 
-(** Equation witnessing the absorbtion law as illustrated by diagram:
+(** Equation witnessing the absorbtion law as illustrated by the diagram:
 <<
            δ×1                   α
    L ⊗ L ------> (L ⊗ L) ⊗ L -------> L ⊗ (L ⊗ L)
@@ -125,7 +125,8 @@ Context {TC : Terminal C}.
 Let ι {x : C} : C⟦x,TC ⊗ x⟧ :=
   BinProductArrow _ _ (TerminalArrow _) (identity x).
 
-(** Given u : C⟦TC,L⟧ the equation witnessing the left unit law is given by the diagram:
+(** Given u : C⟦TC,L⟧ the equation witnessing the left unit law is given
+    by the diagram:
 <<
           ι
      L ------> 1 ⊗ L
@@ -135,9 +136,7 @@ Let ι {x : C} : C⟦x,TC ⊗ x⟧ :=
      L <------ L ⊗ L
           f
 >>
-
- *)
-
+*)
 Definition islunit_cat {L} (f : C⟦L ⊗ L,L⟧) (u : C⟦TC,L⟧) : UU :=
   ι · (u ×× 1) · f = 1.
 

--- a/UniMath/CategoryTheory/LatticeObject.v
+++ b/UniMath/CategoryTheory/LatticeObject.v
@@ -1,0 +1,199 @@
+(** Internal lattice objects in a category *)
+
+Require Import UniMath.Foundations.PartD.
+Require Import UniMath.Foundations.Propositions.
+Require Import UniMath.Foundations.Sets.
+
+Require Import UniMath.Algebra.Lattice.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.Monics.
+Require Import UniMath.CategoryTheory.limits.binproducts.
+
+Local Open Scope cat.
+
+Section LatticeObject_def.
+
+Context {C : precategory} {BPC : BinProducts C}.
+
+Local Notation "c '⊗' d" := (BinProductObject C (BPC c d)) (at level 75) : cat.
+Local Notation "f '××' g" := (BinProductOfArrows _ _ _ f g) (at level 80) : cat.
+
+Definition binprod_delta (x : C) : C⟦x,x ⊗ x⟧ :=
+  BinProductArrow _ _ (identity x) (identity x).
+Let δ {x} : C⟦x,x ⊗ x⟧ := binprod_delta x.
+
+Definition binprod_swap (x y : C) : C⟦x ⊗ y,y ⊗ x⟧ :=
+  BinProductArrow _ _ (BinProductPr2 _ _) (BinProductPr1 _ _).
+Let τ {x y} : C⟦x ⊗ y,y ⊗ x⟧ := binprod_swap x y.
+
+Let π1 {x y} : C⟦x ⊗ y,x⟧ := BinProductPr1 _ (BPC x y).
+
+Local Notation "1" := (identity _) : cat.
+
+
+(** Equation witnessing that a morphism is associative as illustrated by diagram:
+<<
+               1×f
+ L ⊗ (L ⊗ L) -------> L ⊗ L
+     |                  |
+   τ |                  |
+     V                  |
+ (L ⊗ L) ⊗ L            | f
+     |                  |
+ f×1 |                  |
+     V                  V
+   L ⊗ L ----------->   L
+              f
+>>
+*)
+
+Definition isassoc_cat {L} (f : C⟦L ⊗ L,L⟧) : UU := (1 ×× f) · f = τ · (f ×× 1) · f.
+
+
+(** Equation witnessing that a morphism is commutative as illustrated by diagram:
+<<
+             1
+   L ⊗ L -------> L ⊗ L
+     |              |
+   τ |              | f
+     V              V
+   L ⊗ L ---------> L
+             f
+>>
+*)
+Definition iscomm_cat {L} (f : C⟦L ⊗ L,L⟧) : UU := 1 · f = τ · f.
+
+
+(** Equation witnessing the absorbtion law as illustrated by diagram:
+<<
+           δ×1                  τ
+   L ⊗ L ------> (L ⊗ L) ⊗ L ------> L ⊗ (L ⊗ L)
+     |                                   |
+  π1 |                                   | 1×g
+     V                                   V
+     L <------------------------------ L ⊗ L
+                       f
+>>
+
+If f is ∧ and g is ∨ this expresses: x ∧ (x ∨ y) = x
+
+*)
+
+Definition isabsorb_cat {L} (f g : C⟦L ⊗ L,L⟧) : UU :=
+  (δ ×× 1) · τ · (1 ×× g) · f = π1.
+
+
+Definition latticeop_cat {L} (meet_mor join_mor : C⟦L ⊗ L,L⟧) :=
+    (isassoc_cat meet_mor × iscomm_cat meet_mor)
+  × (isassoc_cat join_mor × iscomm_cat join_mor)
+  × (isabsorb_cat meet_mor join_mor × isabsorb_cat join_mor meet_mor).
+
+Definition latticeob (L : C) : UU :=
+  ∑ (meet_mor join_mor : C⟦L ⊗ L,L⟧), latticeop_cat meet_mor join_mor.
+
+Definition mklatticeob {L : C} {meet_mor join_mor : C⟦L ⊗ L,L⟧} :
+  latticeop_cat meet_mor join_mor → latticeob L :=
+    λ (isL : latticeop_cat meet_mor join_mor), meet_mor,, join_mor ,, isL.
+
+Definition meet_mor {L : C} (isL : latticeob L) : C⟦L ⊗ L,L⟧ := pr1 isL.
+Definition join_mor {L : C} (isL : latticeob L) : C⟦L ⊗ L,L⟧ := pr1 (pr2 isL).
+
+End LatticeObject_def.
+
+Arguments latticeob {_} _ _.
+
+Section LatticeObject_theory.
+
+Context {C : precategory} (BPC : BinProducts C) {L : C} (isL : latticeob BPC L).
+
+Local Notation "c '⊗' d" := (BinProductObject C (BPC c d)) (at level 75) : cat.
+Local Notation "f '××' g" := (BinProductOfArrows _ _ _ f g) (at level 80) : cat.
+Let δ {x} : C⟦x,x ⊗ x⟧ := binprod_delta x.
+Let τ {x y} : C⟦x ⊗ y,y ⊗ x⟧ := binprod_swap x y.
+Let π1 {x y} : C⟦x ⊗ y,x⟧ := BinProductPr1 _ (BPC x y).
+
+Local Notation "1" := (identity _) : cat.
+
+Definition isassoc_meet_mor : isassoc_cat (meet_mor isL) :=
+  pr1 (pr1 (pr2 (pr2 isL))).
+Definition iscomm_meet_mor : iscomm_cat (meet_mor isL) :=
+  pr2 (pr1 (pr2 (pr2 isL))).
+Definition isassoc_join_mor : isassoc_cat (join_mor isL) :=
+  pr1 (pr1 (pr2 (pr2 (pr2 isL)))).
+Definition iscomm_join_mor : iscomm_cat (join_mor isL) :=
+  pr2 (pr1 (pr2 (pr2 (pr2 isL)))).
+Definition meet_mor_absorb_join_mor : isabsorb_cat (meet_mor isL) (join_mor isL) :=
+  pr1 (pr2 (pr2 (pr2 (pr2 isL)))).
+Definition join_mor_absorb_meet_mor : isabsorb_cat (join_mor isL) (meet_mor isL) :=
+  pr2 (pr2 (pr2 (pr2 (pr2 isL)))).
+
+(** This corresponds to the equation: x ∧ x = x *)
+Lemma meet_mor_id : δ · meet_mor isL = 1.
+Proof.
+generalize isassoc_meet_mor.
+generalize iscomm_meet_mor.
+generalize isassoc_join_mor.
+generalize iscomm_join_mor.
+generalize meet_mor_absorb_join_mor.
+generalize join_mor_absorb_meet_mor.
+unfold isassoc_cat, iscomm_cat, isabsorb_cat.
+intros h1 h2 h3 h4 h5 h6.
+assert (H : δ · π1 = identity L).
+admit.
+rewrite <- H.
+Abort.
+
+End LatticeObject_theory.
+
+Section SublatticeObject.
+
+Context {C : precategory} (BPC : BinProducts C) (M L : C) (i : Monic _ M L)
+        (isL : latticeob BPC L).
+
+Local Notation "c '⊗' d" := (BinProductObject C (BPC c d)) (at level 75) : cat.
+Local Notation "f '××' g" := (BinProductOfArrows _ _ _ f g) (at level 80) : cat.
+
+(* Is this the correct way of expressing this or is too strong? *)
+(* I think this asserts that i is a lattice morphism internally *)
+Variables (meet_mor_M : C⟦M ⊗ M,M⟧) (Hmeet : meet_mor_M · i = (i ×× i) · meet_mor isL).
+
+Definition sublatticeob : latticeob BPC M.
+Proof.
+use mklatticeob.
+- apply meet_mor_M.
+- admit.
+- repeat split.
+  + admit.
+  + unfold iscomm_cat.
+    set (Hcomm := iscomm_meet_mor _ isL).
+    destruct i as [j Hj].
+    simpl in *.
+    unfold isMonic in *.
+    rewrite id_left.
+    apply Hj.
+    rewrite <- !assoc.
+    rewrite !Hmeet.
+    unfold iscomm_cat in *.
+    rewrite id_left in Hcomm.
+    etrans.
+    eapply maponpaths.
+    apply Hcomm.
+    rewrite !assoc.
+    apply cancel_postcomposition.
+    unfold binprod_swap.
+    rewrite postcompWithBinProductArrow.
+    apply BinProductArrowUnique.
+    rewrite <- assoc.
+    rewrite BinProductPr1Commutes.
+    now rewrite BinProductOfArrowsPr2.
+    rewrite <- assoc.
+    rewrite BinProductPr2Commutes.
+    now rewrite BinProductOfArrowsPr1.
+  + admit.
+  + admit.
+  + admit.
+  + admit.
+Admitted.
+
+End SublatticeObject.

--- a/UniMath/CategoryTheory/LatticeObject.v
+++ b/UniMath/CategoryTheory/LatticeObject.v
@@ -29,6 +29,7 @@ Context {C : precategory} {BPC : BinProducts C}.
 
 Local Notation "c '⊗' d" := (BinProductObject C (BPC c d)) (at level 75) : cat.
 Local Notation "f '××' g" := (BinProductOfArrows _ _ _ f g) (at level 80) : cat.
+Local Notation "1" := (identity _) : cat.
 
 Let π1 {x y} : C⟦x ⊗ y,x⟧ := BinProductPr1 _ (BPC x y).
 Let π2 {x y} : C⟦x ⊗ y,y⟧ := BinProductPr2 _ (BPC x y).
@@ -44,9 +45,6 @@ Let δ {x} : C⟦x,x ⊗ x⟧ := binprod_delta x.
 Definition binprod_swap (x y : C) : C⟦x ⊗ y,y ⊗ x⟧ :=
   BinProductArrow _ _ (BinProductPr2 _ _) (BinProductPr1 _ _).
 Let τ {x y} : C⟦x ⊗ y,y ⊗ x⟧ := binprod_swap x y.
-
-
-Local Notation "1" := (identity _) : cat.
 
 
 (** Equation witnessing that a morphism representing a binary operation is
@@ -127,10 +125,6 @@ Context {C : precategory} (BPC : BinProducts C) {L : C} (isL : latticeob BPC L).
 
 Local Notation "c '⊗' d" := (BinProductObject C (BPC c d)) (at level 75) : cat.
 Local Notation "f '××' g" := (BinProductOfArrows _ _ _ f g) (at level 80) : cat.
-Let δ {x} : C⟦x,x ⊗ x⟧ := binprod_delta x.
-Let τ {x y} : C⟦x ⊗ y,y ⊗ x⟧ := binprod_swap x y.
-Let π1 {x y} : C⟦x ⊗ y,x⟧ := BinProductPr1 _ (BPC x y).
-
 Local Notation "1" := (identity _) : cat.
 
 Definition isassoc_meet_mor : isassoc_cat (meet_mor isL) :=

--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -275,6 +275,24 @@ apply hPropUnivalence.
 - intros hP; apply (hinhpr (ii1 hP)).
 Qed.
 
+Lemma hdisj_hfalse (P : hProp) : (∅ ∨ P) = P.
+Proof.
+apply hPropUnivalence.
+- apply hinhuniv; intros hPPQ.
+  induction hPPQ as [hF|hP].
+  + induction hF.
+  + exact hP.
+- intros hP; apply (hinhpr (ii2 hP)).
+Qed.
+
+Lemma hconj_htrue (P : hProp) : (htrue ∧ P) = P.
+Proof.
+apply hPropUnivalence.
+- intros hP; apply (pr2 hP).
+- intros hP.
+  split; [ apply tt | apply hP ].
+Qed.
+
 Definition sieve_lattice (c : C) : lattice (sieve c).
 Proof.
 use mklattice.
@@ -301,7 +319,20 @@ use mklattice.
     apply hdisj_absorb.
 Defined.
 
-(* TODO: Define the bounded lattice *)
+Definition sieve_bounded_lattice (c : C) : bounded_lattice (sieve c).
+Proof.
+use mkbounded_lattice.
+- apply sieve_lattice.
+- apply empty_sieve.
+- apply maximal_sieve.
+- split.
+  + intros S.
+    apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
+    apply hdisj_hfalse.
+  + intros S.
+    apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
+    apply hconj_htrue.
+Defined.
 
 Definition sieve_mor a b (f : C⟦b,a⟧) : sieve a → sieve b.
 Proof.

--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -1,4 +1,4 @@
-(** **********************************************************
+(** ****************************************************************************
 
 Theory about set-valued presheaves. We write PreShv C for [C^op,HSET].
 
@@ -16,11 +16,12 @@ Contents:
 - Exponentials ([has_exponentials_PreShv])
 - Constant presheaf ([constant_PreShv])
 - Definition of the subobject classifier (without proof) ([Ω_PreShv], [Ω_mor])
-
+- Proof that Ω_PreShv is a bounded lattice object ([Ω_PreShv_lattice],
+  [Ω_PreShv_bounded_lattice])
 
 Written by: Anders Mörtberg, 2017
 
-************************************************************)
+********************************************************************************)
 
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.

--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -318,25 +318,14 @@ Proof.
 use mklattice.
 - apply intersection_sieve.
 - apply union_sieve.
-- repeat split.
-  + intros S1 S2 S3.
-    apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
-    apply isassoc_hconj.
-  + intros S1 S2.
-    apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
-    apply iscomm_hconj.
-  + intros S1 S2 S3.
-    apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
-    apply isassoc_hdisj.
-  + intros S1 S2.
-    apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
-    apply iscomm_hdisj.
-  + intros S1 S2.
-    apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
-    apply hconj_absorb_hdisj.
-  + intros S1 S2.
-    apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
-    apply hdisj_absorb_hconj.
+- repeat split; intros S1; intros;
+  apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
+  + apply isassoc_hconj.
+  + apply iscomm_hconj.
+  + apply isassoc_hdisj.
+  + apply iscomm_hdisj.
+  + apply hconj_absorb_hdisj.
+  + apply hdisj_absorb_hconj.
 Defined.
 
 Definition sieve_bounded_lattice (c : C) : bounded_lattice (sieve c).
@@ -423,25 +412,14 @@ Proof.
 use mklatticeob.
 + apply Ω_meet.
 + apply Ω_join.
-+ repeat split.
-  - apply (nat_trans_eq has_homsets_HSET); intro c.
-    apply funextsec; intros S.
-    apply (isassoc_Lmin (sieve_lattice c)).
-  - apply (nat_trans_eq has_homsets_HSET); intro c.
-    apply funextsec; intros S.
-    apply (iscomm_Lmin (sieve_lattice c)).
-  - apply (nat_trans_eq has_homsets_HSET); intro c.
-    apply funextsec; intros S.
-    apply (isassoc_Lmax (sieve_lattice c)).
-  - apply (nat_trans_eq has_homsets_HSET); intro c.
-    apply funextsec; intros S.
-    apply (iscomm_Lmax (sieve_lattice c)).
-  - apply (nat_trans_eq has_homsets_HSET); intro c.
-    apply funextsec; intros S.
-    apply (Lmin_absorb (sieve_lattice c)).
-  - apply (nat_trans_eq has_homsets_HSET); intro c.
-    apply funextsec; intros S.
-    apply (Lmax_absorb (sieve_lattice c)).
++ repeat split; apply (nat_trans_eq has_homsets_HSET); intro c;
+                apply funextsec; intros S.
+  - apply (isassoc_Lmin (sieve_lattice c)).
+  - apply (iscomm_Lmin (sieve_lattice c)).
+  - apply (isassoc_Lmax (sieve_lattice c)).
+  - apply (iscomm_Lmax (sieve_lattice c)).
+  - apply (Lmin_absorb (sieve_lattice c)).
+  - apply (Lmax_absorb (sieve_lattice c)).
 Defined.
 
 End Ω_PreShv.

--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -45,6 +45,7 @@ Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.Monics.
+Require Import UniMath.CategoryTheory.LatticeObject.
 
 Local Open Scope cat.
 
@@ -360,7 +361,9 @@ Qed.
 
 Definition Ω_PreShv : PreShv C := (Ω_PreShv_data,,is_functor_Ω_PreShv_data).
 
-Definition Ω_mor : (PreShv C)⟦Terminal_PreShv,Ω_PreShv⟧.
+Let Ω := Ω_PreShv.
+
+Definition Ω_mor : (PreShv C)⟦Terminal_PreShv,Ω⟧.
 Proof.
 use mk_nat_trans.
 - simpl; apply (λ c _, maximal_sieve c).
@@ -373,5 +376,57 @@ Lemma isMonic_Ω_mor : isMonic Ω_mor.
 Proof.
 now apply from_terminal_isMonic.
 Qed.
+
+Local Notation "c '⊗' d" := (BinProductObject _ (BinProducts_PreShv c d)) (at level 75) : cat.
+
+Definition Ω_meet : PreShv(C) ⟦Ω ⊗ Ω,Ω⟧.
+Proof.
+use mk_nat_trans.
++ intros c S1S2.
+  apply (intersection_sieve c (pr1 S1S2) (pr2 S1S2)).
++ intros x y f.
+  apply funextsec; cbn; intros [S1 S2].
+  now apply sieve_eq.
+Defined.
+
+Definition Ω_join : PreShv(C) ⟦Ω ⊗ Ω,Ω⟧.
+Proof.
+use mk_nat_trans.
++ intros c S1S2.
+  apply (union_sieve c (pr1 S1S2) (pr2 S1S2)).
++ intros x y f.
+  apply funextsec; cbn; intros [S1 S2].
+  now apply sieve_eq.
+Defined.
+
+Definition Ω_lattice : latticeob BinProducts_PreShv Ω_PreShv.
+Proof.
+use mklatticeob.
++ apply Ω_meet.
++ apply Ω_join.
++ repeat split.
+  - apply (nat_trans_eq has_homsets_HSET); intro c.
+    apply funextsec; intros S.
+    apply (isassoc_Lmin (sieve_lattice c)).
+  - unfold iscomm_cat.
+    rewrite id_left.
+    apply (nat_trans_eq has_homsets_HSET); intro c.
+    apply funextsec; intros S.
+    apply (iscomm_Lmin (sieve_lattice c)).
+  - apply (nat_trans_eq has_homsets_HSET); intro c.
+    apply funextsec; intros S.
+    apply (isassoc_Lmax (sieve_lattice c)).
+  - unfold iscomm_cat.
+    rewrite id_left.
+    apply (nat_trans_eq has_homsets_HSET); intro c.
+    apply funextsec; intros S.
+    apply (iscomm_Lmax (sieve_lattice c)).
+  - apply (nat_trans_eq has_homsets_HSET); intro c.
+    apply funextsec; intros S.
+    apply (Lmin_absorb (sieve_lattice c)).
+  - apply (nat_trans_eq has_homsets_HSET); intro c.
+    apply funextsec; intros S.
+    apply (Lmax_absorb (sieve_lattice c)).
+Defined.
 
 End Ω_PreShv.

--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -4,8 +4,8 @@ Theory about set-valued presheaves. We write PreShv C for [C^op,HSET].
 
 Contents:
 
-- Limits ([Lims_PreShv], [Lims_PreShv_of_shape])
-- Colimits ([Colims_PreShv], [Colims_PreShv_of_shape])
+- Limits ([Lims_PreShv_of_shape])
+- Colimits ([Colims_PreShv_of_shape])
 - Binary products ([BinProducts_PreShv])
 - Indexed products ([Products_PreShv])
 - Binary coproducts ([BinCoproducts_PreShv])
@@ -173,20 +173,22 @@ Section limits.
 
 Context {C : precategory}.
 
-Lemma Lims_PreShv : Lims (PreShv C).
-Proof.
-now apply LimsFunctorCategory, LimsHSET.
-Defined.
+(* This should be only small limits *)
+(* Lemma Lims_PreShv : Lims (PreShv C). *)
+(* Proof. *)
+(* now apply LimsFunctorCategory, LimsHSET. *)
+(* Defined. *)
 
 Lemma Lims_PreShv_of_shape (g : graph) : Lims_of_shape g (PreShv C).
 Proof.
 now apply LimsFunctorCategory_of_shape, LimsHSET_of_shape.
 Defined.
 
-Lemma Colims_PreShv : Colims (PreShv C).
-Proof.
-now apply ColimsFunctorCategory, ColimsHSET.
-Defined.
+(* This should be only small colimits *)
+(* Lemma Colims_PreShv : Colims (PreShv C). *)
+(* Proof. *)
+(* now apply ColimsFunctorCategory, ColimsHSET. *)
+(* Defined. *)
 
 Lemma Colims_PreShv_of_shape (g : graph) : Colims_of_shape g (PreShv C).
 Proof.
@@ -254,8 +256,11 @@ Definition empty_PreShv : PreShv C := constant_PreShv emptyHSET.
 
 End presheaves.
 
-(** Definition of the subobject classifier in a presheaf
-    TODO: Prove that Ω actually is the subobject classifier  *)
+(** * Definition of the subobject classifier in a presheaf. *)
+(**
+See: "Sheaves in Geometry and Logic" by Mac Lane and Moerdijk (page 37)
+*)
+(* TODO: Prove that Ω actually is the subobject classifier  *)
 Section Ω_PreShv.
 
 Context {C : precategory}.

--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -374,9 +374,9 @@ split.
   + now repeat (apply funextsec; intro); rewrite <- assoc.
 Qed.
 
-Definition Ω : PreShv C := (Ω_PreShv_data,,is_functor_Ω_PreShv_data).
+Definition Ω_PreShv : PreShv C := (Ω_PreShv_data,,is_functor_Ω_PreShv_data).
 
-Definition Ω_mor : (PreShv C)⟦Terminal_PreShv,Ω⟧.
+Definition Ω_mor : (PreShv C)⟦Terminal_PreShv,Ω_PreShv⟧.
 Proof.
 use mk_nat_trans.
 - simpl; apply (λ c _, maximal_sieve c).
@@ -392,7 +392,7 @@ Qed.
 
 Local Notation "c '⊗' d" := (BinProductObject _ (BinProducts_PreShv c d)) (at level 75) : cat.
 
-Definition Ω_meet : PreShv(C)⟦Ω ⊗ Ω,Ω⟧.
+Definition Ω_PreShv_meet : PreShv(C)⟦Ω_PreShv ⊗ Ω_PreShv,Ω_PreShv⟧.
 Proof.
 use mk_nat_trans.
 + intros c S1S2.
@@ -402,7 +402,7 @@ use mk_nat_trans.
   now apply sieve_eq.
 Defined.
 
-Definition Ω_join : PreShv(C)⟦Ω ⊗ Ω,Ω⟧.
+Definition Ω_PreShv_join : PreShv(C)⟦Ω_PreShv ⊗ Ω_PreShv,Ω_PreShv⟧.
 Proof.
 use mk_nat_trans.
 + intros c S1S2.
@@ -412,11 +412,11 @@ use mk_nat_trans.
   now apply sieve_eq.
 Defined.
 
-Definition Ω_lattice : latticeob BinProducts_PreShv Ω.
+Definition Ω_PreShv_lattice : latticeob BinProducts_PreShv Ω_PreShv.
 Proof.
 use mk_latticeob.
-+ apply Ω_meet.
-+ apply Ω_join.
++ apply Ω_PreShv_meet.
++ apply Ω_PreShv_join.
 + repeat split; apply (nat_trans_eq has_homsets_HSET); intro c;
                 apply funextsec; intros S.
   - apply (isassoc_Lmin (sieve_lattice c)).
@@ -427,26 +427,27 @@ use mk_latticeob.
   - apply (Lmax_absorb (sieve_lattice c)).
 Defined.
 
-Definition Ω_bottom : PreShv(C)⟦Terminal_PreShv,Ω⟧.
+Definition Ω_PreShv_bottom : PreShv(C)⟦Terminal_PreShv,Ω_PreShv⟧.
 Proof.
 use mk_nat_trans.
 + intros c _; apply empty_sieve.
 + now intros x y f; apply funextsec; intros []; apply sieve_eq.
 Defined.
 
-Definition Ω_top : PreShv(C)⟦Terminal_PreShv,Ω⟧.
+Definition Ω_PreShv_top : PreShv(C)⟦Terminal_PreShv,Ω_PreShv⟧.
 Proof.
 use mk_nat_trans.
 + intros c _; apply maximal_sieve.
 + now intros x y f; apply funextsec; intros []; apply sieve_eq.
 Defined.
 
-Definition Ω_bounded_lattice : bounded_latticeob BinProducts_PreShv Terminal_PreShv Ω.
+Definition Ω_PreShv_bounded_lattice :
+  bounded_latticeob BinProducts_PreShv Terminal_PreShv Ω_PreShv.
 Proof.
 use mk_bounded_latticeob.
-- exact Ω_lattice.
-- exact Ω_bottom.
-- exact Ω_top.
+- exact Ω_PreShv_lattice.
+- exact Ω_PreShv_bottom.
+- exact Ω_PreShv_top.
 - split; apply (nat_trans_eq has_homsets_HSET); intro c;
          apply funextsec; cbn; intros S.
   + apply (islunit_Lmax_Lbot (sieve_bounded_lattice c)).

--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -51,6 +51,111 @@ Local Open Scope cat.
 
 Notation "'PreShv' C" := [C^op,HSET,has_homsets_HSET] (at level 3) : cat.
 
+(* TODO: upstream *)
+Section hProp_lattice.
+
+Lemma isassoc_hconj (P Q R : hProp) : ((P ∧ Q) ∧ R) = (P ∧ (Q ∧ R)).
+Proof.
+apply hPropUnivalence.
+- intros PQR.
+  exact (pr1 (pr1 PQR),,(pr2 (pr1 PQR),,pr2 PQR)).
+- intros PQR.
+  exact ((pr1 PQR,,pr1 (pr2 PQR)),,pr2 (pr2 PQR)).
+Qed.
+
+Lemma iscomm_hconj (P Q : hProp) : (P ∧ Q) = (Q ∧ P).
+Proof.
+apply hPropUnivalence.
+- intros PQ.
+  exact (pr2 PQ,,pr1 PQ).
+- intros QP.
+  exact (pr2 QP,,pr1 QP).
+Qed.
+
+Lemma isassoc_hdisj (P Q R : hProp) : ((P ∨ Q) ∨ R) = (P ∨ (Q ∨ R)).
+Proof.
+apply hPropUnivalence.
+- apply hinhuniv; intros hPQR.
+  induction hPQR as [hPQ|hR].
+  + use (hinhuniv _ hPQ); clear hPQ; intros hPQ.
+    induction hPQ as [hP|hQ].
+    * exact (hinhpr (ii1 hP)).
+    * exact (hinhpr (ii2 (hinhpr (ii1 hQ)))).
+  + exact (hinhpr (ii2 (hinhpr (ii2 hR)))).
+- apply hinhuniv; intros hPQR.
+  induction hPQR as [hP|hQR].
+  + exact (hinhpr (ii1 (hinhpr (ii1 hP)))).
+  + use (hinhuniv _ hQR); clear hQR; intros hQR.
+    induction hQR as [hQ|hR].
+    * exact (hinhpr (ii1 (hinhpr (ii2 hQ)))).
+    * exact (hinhpr (ii2 hR)).
+Qed.
+
+Lemma iscomm_hdisj (P Q : hProp) : (P ∨ Q) = (Q ∨ P).
+Proof.
+apply hPropUnivalence.
+- apply hinhuniv; intros PQ.
+  induction PQ as [hP|hQ].
+  + exact (hinhpr (ii2 hP)).
+  + exact (hinhpr (ii1 hQ)).
+- apply hinhuniv; intros PQ.
+  induction PQ as [hQ|hP].
+  + exact (hinhpr (ii2 hQ)).
+  + exact (hinhpr (ii1 hP)).
+Qed.
+
+Lemma hconj_absorb_hdisj (P Q : hProp) : (P ∧ (P ∨ Q)) = P.
+Proof.
+apply hPropUnivalence.
+- intros hPPQ; apply (pr1 hPPQ).
+- intros hP.
+  split; [ apply hP | apply (hinhpr (ii1 hP)) ].
+Qed.
+
+Lemma hdisj_absorb_hconj (P Q : hProp) : (P ∨ (P ∧ Q)) = P.
+Proof.
+apply hPropUnivalence.
+- apply hinhuniv; intros hPPQ.
+  induction hPPQ as [hP|hPQ].
+  + exact hP.
+  + exact (pr1 hPQ).
+- intros hP; apply (hinhpr (ii1 hP)).
+Qed.
+
+Lemma hfalse_hdisj (P : hProp) : (∅ ∨ P) = P.
+Proof.
+apply hPropUnivalence.
+- apply hinhuniv; intros hPPQ.
+  induction hPPQ as [hF|hP].
+  + induction hF.
+  + exact hP.
+- intros hP; apply (hinhpr (ii2 hP)).
+Qed.
+
+Lemma htrue_hconj (P : hProp) : (htrue ∧ P) = P.
+Proof.
+apply hPropUnivalence.
+- intros hP; apply (pr2 hP).
+- intros hP.
+  split; [ apply tt | apply hP ].
+Qed.
+
+Definition hProp_lattice : lattice (hProp,,isasethProp).
+Proof.
+use mklattice.
+- intros P Q; exact (P ∧ Q).
+- simpl; intros P Q; exact (P ∨ Q).
+- repeat split.
+  + intros P Q R; apply isassoc_hconj.
+  + intros P Q; apply iscomm_hconj.
+  + intros P Q R; apply isassoc_hdisj.
+  + intros P Q; apply iscomm_hdisj.
+  + intros P Q; apply hconj_absorb_hdisj.
+  + intros P Q; apply hdisj_absorb_hconj.
+Defined.
+
+End hProp_lattice.
+
 (** Various limits and colimits in PreShv C *)
 Section limits.
 
@@ -208,92 +313,6 @@ mkpair.
   + apply ii2, (pr2 S2 _ _ S).
 Defined.
 
-Lemma hconj_assoc (P Q R : hProp) : ((P ∧ Q) ∧ R) = (P ∧ (Q ∧ R)).
-Proof.
-apply hPropUnivalence.
-- intros PQR.
-  exact (pr1 (pr1 PQR),,(pr2 (pr1 PQR),,pr2 PQR)).
-- intros PQR.
-  exact ((pr1 PQR,,pr1 (pr2 PQR)),,pr2 (pr2 PQR)).
-Qed.
-
-Lemma hconj_comm (P Q : hProp) : (P ∧ Q) = (Q ∧ P).
-Proof.
-apply hPropUnivalence.
-- intros PQ.
-  exact (pr2 PQ,,pr1 PQ).
-- intros QP.
-  exact (pr2 QP,,pr1 QP).
-Qed.
-
-Lemma hdisj_assoc (P Q R : hProp) : ((P ∨ Q) ∨ R) = (P ∨ (Q ∨ R)).
-Proof.
-apply hPropUnivalence.
-- apply hinhuniv; intros hPQR.
-  induction hPQR as [hPQ|hR].
-  + use (hinhuniv _ hPQ); clear hPQ; intros hPQ.
-    induction hPQ as [hP|hQ].
-    * exact (hinhpr (ii1 hP)).
-    * exact (hinhpr (ii2 (hinhpr (ii1 hQ)))).
-  + exact (hinhpr (ii2 (hinhpr (ii2 hR)))).
-- apply hinhuniv; intros hPQR.
-  induction hPQR as [hP|hQR].
-  + exact (hinhpr (ii1 (hinhpr (ii1 hP)))).
-  + use (hinhuniv _ hQR); clear hQR; intros hQR.
-    induction hQR as [hQ|hR].
-    * exact (hinhpr (ii1 (hinhpr (ii2 hQ)))).
-    * exact (hinhpr (ii2 hR)).
-Qed.
-
-Lemma hdisj_comm (P Q : hProp) : (P ∨ Q) = (Q ∨ P).
-Proof.
-apply hPropUnivalence.
-- apply hinhuniv; intros PQ.
-  induction PQ as [hP|hQ].
-  + exact (hinhpr (ii2 hP)).
-  + exact (hinhpr (ii1 hQ)).
-- apply hinhuniv; intros PQ.
-  induction PQ as [hQ|hP].
-  + exact (hinhpr (ii2 hQ)).
-  + exact (hinhpr (ii1 hP)).
-Qed.
-
-Lemma hconj_absorb (P Q : hProp) : (P ∧ (P ∨ Q)) = P.
-Proof.
-apply hPropUnivalence.
-- intros hPPQ; apply (pr1 hPPQ).
-- intros hP.
-  split; [ apply hP | apply (hinhpr (ii1 hP)) ].
-Qed.
-
-Lemma hdisj_absorb (P Q : hProp) : (P ∨ (P ∧ Q)) = P.
-Proof.
-apply hPropUnivalence.
-- apply hinhuniv; intros hPPQ.
-  induction hPPQ as [hP|hPQ].
-  + exact hP.
-  + exact (pr1 hPQ).
-- intros hP; apply (hinhpr (ii1 hP)).
-Qed.
-
-Lemma hdisj_hfalse (P : hProp) : (∅ ∨ P) = P.
-Proof.
-apply hPropUnivalence.
-- apply hinhuniv; intros hPPQ.
-  induction hPPQ as [hF|hP].
-  + induction hF.
-  + exact hP.
-- intros hP; apply (hinhpr (ii2 hP)).
-Qed.
-
-Lemma hconj_htrue (P : hProp) : (htrue ∧ P) = P.
-Proof.
-apply hPropUnivalence.
-- intros hP; apply (pr2 hP).
-- intros hP.
-  split; [ apply tt | apply hP ].
-Qed.
-
 Definition sieve_lattice (c : C) : lattice (sieve c).
 Proof.
 use mklattice.
@@ -302,22 +321,22 @@ use mklattice.
 - repeat split.
   + intros S1 S2 S3.
     apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
-    apply hconj_assoc.
+    apply isassoc_hconj.
   + intros S1 S2.
     apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
-    apply hconj_comm.
+    apply iscomm_hconj.
   + intros S1 S2 S3.
     apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
-    apply hdisj_assoc.
+    apply isassoc_hdisj.
   + intros S1 S2.
     apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
-    apply hdisj_comm.
+    apply iscomm_hdisj.
   + intros S1 S2.
     apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
-    apply hconj_absorb.
+    apply hconj_absorb_hdisj.
   + intros S1 S2.
     apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
-    apply hdisj_absorb.
+    apply hdisj_absorb_hconj.
 Defined.
 
 Definition sieve_bounded_lattice (c : C) : bounded_lattice (sieve c).
@@ -329,10 +348,10 @@ use mkbounded_lattice.
 - split.
   + intros S.
     apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
-    apply hdisj_hfalse.
+    apply hfalse_hdisj.
   + intros S.
     apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
-    apply hconj_htrue.
+    apply htrue_hconj.
 Defined.
 
 Definition sieve_mor a b (f : C⟦b,a⟧) : sieve a → sieve b.
@@ -408,17 +427,13 @@ use mklatticeob.
   - apply (nat_trans_eq has_homsets_HSET); intro c.
     apply funextsec; intros S.
     apply (isassoc_Lmin (sieve_lattice c)).
-  - unfold iscomm_cat.
-    rewrite id_left.
-    apply (nat_trans_eq has_homsets_HSET); intro c.
+  - apply (nat_trans_eq has_homsets_HSET); intro c.
     apply funextsec; intros S.
     apply (iscomm_Lmin (sieve_lattice c)).
   - apply (nat_trans_eq has_homsets_HSET); intro c.
     apply funextsec; intros S.
     apply (isassoc_Lmax (sieve_lattice c)).
-  - unfold iscomm_cat.
-    rewrite id_left.
-    apply (nat_trans_eq has_homsets_HSET); intro c.
+  - apply (nat_trans_eq has_homsets_HSET); intro c.
     apply funextsec; intros S.
     apply (iscomm_Lmax (sieve_lattice c)).
   - apply (nat_trans_eq has_homsets_HSET); intro c.

--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -154,6 +154,17 @@ use mklattice.
   + intros P Q; apply hdisj_absorb_hconj.
 Defined.
 
+Definition hProp_bounded_lattice : bounded_lattice (hProp,,isasethProp).
+Proof.
+use mkbounded_lattice.
+- exact hProp_lattice.
+- exact hfalse.
+- exact htrue.
+- split.
+  + intros P; apply hfalse_hdisj.
+  + intros P; apply htrue_hconj.
+Defined.
+
 End hProp_lattice.
 
 (** Various limits and colimits in PreShv C *)
@@ -320,12 +331,12 @@ use mklattice.
 - apply union_sieve.
 - repeat split; intros S1; intros;
   apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
-  + apply isassoc_hconj.
-  + apply iscomm_hconj.
-  + apply isassoc_hdisj.
-  + apply iscomm_hdisj.
-  + apply hconj_absorb_hdisj.
-  + apply hdisj_absorb_hconj.
+  + apply (isassoc_Lmin hProp_lattice).
+  + apply (iscomm_Lmin hProp_lattice).
+  + apply (isassoc_Lmax hProp_lattice).
+  + apply (iscomm_Lmax hProp_lattice).
+  + apply (Lmin_absorb hProp_lattice).
+  + apply (Lmax_absorb hProp_lattice).
 Defined.
 
 Definition sieve_bounded_lattice (c : C) : bounded_lattice (sieve c).
@@ -334,13 +345,9 @@ use mkbounded_lattice.
 - apply sieve_lattice.
 - apply empty_sieve.
 - apply maximal_sieve.
-- split.
-  + intros S.
-    apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
-    apply hfalse_hdisj.
-  + intros S.
-    apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
-    apply htrue_hconj.
+- split; intros S; apply sieve_eq, funextsec; intro x; apply funextsec; intro f.
+  + apply (islunit_Lmax_Lbot hProp_bounded_lattice).
+  + apply (islunit_Lmin_Ltop hProp_bounded_lattice).
 Defined.
 
 Definition sieve_mor a b (f : C⟦b,a⟧) : sieve a → sieve b.
@@ -367,9 +374,7 @@ split.
   + now repeat (apply funextsec; intro); rewrite <- assoc.
 Qed.
 
-Definition Ω_PreShv : PreShv C := (Ω_PreShv_data,,is_functor_Ω_PreShv_data).
-
-Let Ω := Ω_PreShv.
+Definition Ω : PreShv C := (Ω_PreShv_data,,is_functor_Ω_PreShv_data).
 
 Definition Ω_mor : (PreShv C)⟦Terminal_PreShv,Ω⟧.
 Proof.
@@ -387,7 +392,7 @@ Qed.
 
 Local Notation "c '⊗' d" := (BinProductObject _ (BinProducts_PreShv c d)) (at level 75) : cat.
 
-Definition Ω_meet : PreShv(C) ⟦Ω ⊗ Ω,Ω⟧.
+Definition Ω_meet : PreShv(C)⟦Ω ⊗ Ω,Ω⟧.
 Proof.
 use mk_nat_trans.
 + intros c S1S2.
@@ -397,7 +402,7 @@ use mk_nat_trans.
   now apply sieve_eq.
 Defined.
 
-Definition Ω_join : PreShv(C) ⟦Ω ⊗ Ω,Ω⟧.
+Definition Ω_join : PreShv(C)⟦Ω ⊗ Ω,Ω⟧.
 Proof.
 use mk_nat_trans.
 + intros c S1S2.
@@ -407,9 +412,9 @@ use mk_nat_trans.
   now apply sieve_eq.
 Defined.
 
-Definition Ω_lattice : latticeob BinProducts_PreShv Ω_PreShv.
+Definition Ω_lattice : latticeob BinProducts_PreShv Ω.
 Proof.
-use mklatticeob.
+use mk_latticeob.
 + apply Ω_meet.
 + apply Ω_join.
 + repeat split; apply (nat_trans_eq has_homsets_HSET); intro c;
@@ -420,6 +425,32 @@ use mklatticeob.
   - apply (iscomm_Lmax (sieve_lattice c)).
   - apply (Lmin_absorb (sieve_lattice c)).
   - apply (Lmax_absorb (sieve_lattice c)).
+Defined.
+
+Definition Ω_bottom : PreShv(C)⟦Terminal_PreShv,Ω⟧.
+Proof.
+use mk_nat_trans.
++ intros c _; apply empty_sieve.
++ now intros x y f; apply funextsec; intros []; apply sieve_eq.
+Defined.
+
+Definition Ω_top : PreShv(C)⟦Terminal_PreShv,Ω⟧.
+Proof.
+use mk_nat_trans.
++ intros c _; apply maximal_sieve.
++ now intros x y f; apply funextsec; intros []; apply sieve_eq.
+Defined.
+
+Definition Ω_bounded_lattice : bounded_latticeob BinProducts_PreShv Terminal_PreShv Ω.
+Proof.
+use mk_bounded_latticeob.
+- exact Ω_lattice.
+- exact Ω_bottom.
+- exact Ω_top.
+- split; apply (nat_trans_eq has_homsets_HSET); intro c;
+         apply funextsec; cbn; intros S.
+  + apply (islunit_Lmax_Lbot (sieve_bounded_lattice c)).
+  + apply (islunit_Lmin_Ltop (sieve_bounded_lattice c)).
 Defined.
 
 End Ω_PreShv.

--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -325,7 +325,7 @@ simpl; intros S1 S2.
 mkpair.
 - intros f.
   apply (S1 f ∨ S2 f).
-- intros f S y f'; apply S; clear S; intros S.
+- intros f S y f'; simpl in S; apply S; clear S; intro S.
   apply hinhpr.
   induction S as [S|S].
   + apply ii1, (pr2 S1 _ S).
@@ -375,7 +375,7 @@ split.
 - intros x; apply funextfun; intros [S hS]; simpl.
   apply subtypeEquality; simpl.
   + intros X; repeat (apply impred; intro); apply propproperty.
-  + now apply funextsec; intro; rewrite id_right, <- tppr.
+  + now apply funextsec; intro; rewrite id_right.
 - intros x y z f g; apply funextfun; intros [S hS]; simpl.
   apply subtypeEquality; simpl.
   + intros X; repeat (apply impred; intro); apply propproperty.
@@ -426,7 +426,7 @@ use mk_latticeob.
 + apply Ω_PreShv_meet.
 + apply Ω_PreShv_join.
 + repeat split; apply (nat_trans_eq has_homsets_HSET); intro c;
-                apply funextsec; intros S.
+                apply funextsec; intros S; simpl.
   - apply (isassoc_Lmin (sieve_lattice c)).
   - apply (iscomm_Lmin (sieve_lattice c)).
   - apply (isassoc_Lmax (sieve_lattice c)).

--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -271,7 +271,7 @@ use total2.
 - apply (hsubtype (∑ (x : C),C⟦x,c⟧)).
 - intros S.
   apply (∏ (s1 : ∑ (x : C),C⟦x,c⟧), S s1 →
-         ∏ (s2 : ∑ (y : C),C⟦y,pr1 s1⟧), S (pr1 s2,,pr2 s2 · pr2 s1)).
+         ∏ y (f : C⟦y,pr1 s1⟧), S (y,, f · pr2 s1)).
 Defined.
 
 Lemma isaset_sieve (c : C) : isaset (sieve_def c).
@@ -304,7 +304,7 @@ Definition empty_sieve (c : C) : sieve c.
 Proof.
 mkpair.
 - intros S; apply hfalse.
-- intros f S g; apply S.
+- intros f S y g; apply S.
 Defined.
 
 Definition intersection_sieve (c : C) : binop (sieve c).
@@ -325,7 +325,7 @@ simpl; intros S1 S2.
 mkpair.
 - intros f.
   apply (S1 f ∨ S2 f).
-- intros f S f'; apply S; clear S; intros S.
+- intros f S y f'; apply S; clear S; intros S.
   apply hinhpr.
   induction S as [S|S].
   + apply ii1, (pr2 S1 _ S).
@@ -364,7 +364,7 @@ simpl; intros S.
 mkpair.
 - intros g.
   apply (S (pr1 g,,pr2 g · f)).
-- abstract (intros g H h; simpl; rewrite <- assoc; apply (pr2 S (pr1 g,,pr2 g · f)), H).
+- abstract (intros g H y h; simpl; rewrite <- assoc; apply (pr2 S (pr1 g,,pr2 g · f)), H).
 Defined.
 
 Local Definition Ω_PreShv_data : functor_data C^op HSET := (sieve,,sieve_mor).


### PR DESCRIPTION
The main result of this PR is that Omega in PreShv(C) is a bounded lattice object (internally in PreShv(C)). To prove this I had to:

- Define bounded lattices
- Define internal lattice objects and bounded lattice objects in a category
- Prove that hProp is a bounded lattice (these results should be upstreamed, but I don't know where)

The lattice structure on hProp then gives a lattice structure on the set of sieves used in the definition of Omega which in turn gives that Omega is a lattice object in PreShv(C).

I also defined sublattice objects of a lattice object. I'm not completely sure that this definition is the right one so it would be great if someone looks at it. Given elements `M` and `L` with lattice operations and a mono `i : C[M,L]` which is a homomorphism for the lattice operations I prove that `M` is a lattice object if `L` is. So to give a sublattice object it suffices to give a mono `i : C[M,L]`, operations on `M`, a lattice object structure on `L` and a proof that `i` is a homomorphism for the lattice operations. I want to use this to construct the "face lattice" used in the cubical set model (in cSet the object |F is a sublattice of Omega with some extra structure).

Note that this PR relies on https://github.com/UniMath/UniMath/pull/607 which means that that PR should be merged first, this is also the reason why the diff is pretty big.