### PR TITLE
improve Makefile message about file ordering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ ifneq "$(INCLUDE)" "no"
 include build/CoqMakefile.make
 endif
 everything: TAGS all html install
-check-first: enforce-linear-ordering check-travis
+check-first: enforce-prescribed-ordering check-travis
 OTHERFLAGS += $(MOREFLAGS)
 OTHERFLAGS += -indices-matter -type-in-type -w none
 ifeq ($(VERBOSE),yes)
@@ -217,10 +217,10 @@ show-long-lines:
 
 # here we assume the shell is bash, which it usually is nowadays:
 SHELL = bash
-enforce-linear-ordering: .enforce-linear-ordering.okay
-clean::; rm -f .enforce-linear-ordering.okay
-.enforce-linear-ordering.okay: Makefile $(VFILES:.v=.v.d)
-	: --- enforce linear ordering ---
+enforce-prescribed-ordering: .enforce-prescribed-ordering.okay
+clean::; rm -f .enforce-prescribed-ordering.okay
+.enforce-prescribed-ordering.okay: Makefile $(VFILES:.v=.v.d)
+	: "--- enforce ordering prescribed by the files UniMath/*/.packages/files ---"
 	@set -e ;\
 	if declare -A seqnum 2>/dev/null ;\
 	then n=0 ;\


### PR DESCRIPTION
Make it clear that we are enforcing the ordering prescribed by
the packages' lists of files, not checking for circularity.