### PR TITLE
Simplified now tactic

### DIFF
--- a/UniMath/Algebra/Apartness.v
+++ b/UniMath/Algebra/Apartness.v
@@ -8,6 +8,8 @@ Unset Kernel Term Sharing.
 Require Export UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Foundations.Propositions.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 (** ** Additionals theorems about relations *)
 
 Lemma isapropisirrefl {X : UU} (rel : hrel X) :

--- a/UniMath/Algebra/Archimedean.v
+++ b/UniMath/Algebra/Archimedean.v
@@ -17,6 +17,8 @@ Require Import UniMath.Algebra.DivisionRig .
 Require Import UniMath.Algebra.Domains_and_Fields .
 Require Import UniMath.Algebra.ConstructiveStructures.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 (** ** The standard function from the natural numbers to a monoid *)
 
 Fixpoint natmult {X : monoid} (n : nat) (x : X) : X :=

--- a/UniMath/Algebra/ConstructiveStructures.v
+++ b/UniMath/Algebra/ConstructiveStructures.v
@@ -9,6 +9,8 @@ Require Export UniMath.Algebra.Apartness.
 Require Export UniMath.Algebra.DivisionRig.
 Require Export UniMath.Algebra.Domains_and_Fields.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 (** ** Predicats in a rig with a tight appartness relation *)
 
 Definition isnonzeroCR (X : rig) (R : tightap X) := R 1%rig 0%rig.

--- a/UniMath/Algebra/DivisionRig.v
+++ b/UniMath/Algebra/DivisionRig.v
@@ -15,6 +15,8 @@ Require Export UniMath.Foundations.Sets.
 Require Export UniMath.Algebra.Rigs_and_Rings.
 Require Export UniMath.Algebra.Domains_and_Fields.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 (** ** Definition of a DivRig *)
 
 Definition isnonzerorig (X : rig) : UU := (1%rig : X) != 0%rig.

--- a/UniMath/Algebra/IteratedBinaryOperations.v
+++ b/UniMath/Algebra/IteratedBinaryOperations.v
@@ -2,6 +2,9 @@ Require Export UniMath.Combinatorics.Lists.
 Require Export UniMath.Combinatorics.FiniteSequences.
 Require Export UniMath.Algebra.Rigs_and_Rings.
 Require Export UniMath.Foundations.UnivalenceAxiom.
+
+Require Import UniMath.MoreFoundations.Tactics.
+
 Unset Automatic Introduction.
 
 (* move upstream *)

--- a/UniMath/Algebra/Lattice.v
+++ b/UniMath/Algebra/Lattice.v
@@ -31,6 +31,8 @@ Truncated minus is a lattice:
 
 Require Export UniMath.Algebra.Monoids_and_Groups.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Unset Automatic Introduction.
 
 (** ** Strong Order *)

--- a/UniMath/CategoryTheory/Adjunctions.v
+++ b/UniMath/CategoryTheory/Adjunctions.v
@@ -24,10 +24,13 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.whiskering.
+
+Local Open Scope cat.
 
 (** * Adjunctions *)
 Section adjunctions.

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -60,10 +60,11 @@ Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.NaturalNumbers.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.category_hset.
 Require Import UniMath.CategoryTheory.category_hset_structures.
@@ -83,6 +84,8 @@ Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.RightKanExtension.
 Require Import UniMath.CategoryTheory.slicecat.
+
+Local Open Scope cat.
 
 (** * Definition of cocontinuous functors *)
 Section cocont.

--- a/UniMath/CategoryTheory/DiscretePrecategory.v
+++ b/UniMath/CategoryTheory/DiscretePrecategory.v
@@ -12,8 +12,11 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
+
 Local Open Scope cat.
 
 (** * Discrete precategories *)

--- a/UniMath/CategoryTheory/Elements.v
+++ b/UniMath/CategoryTheory/Elements.v
@@ -19,6 +19,8 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.category_hset.

--- a/UniMath/CategoryTheory/ElementsOp.v
+++ b/UniMath/CategoryTheory/ElementsOp.v
@@ -19,6 +19,8 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.category_hset.

--- a/UniMath/CategoryTheory/EndofunctorsMonoidal.v
+++ b/UniMath/CategoryTheory/EndofunctorsMonoidal.v
@@ -24,8 +24,11 @@ Contents :
 
 Require Import UniMath.Foundations.PartD.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
+
 Local Open Scope cat.
 
 (** There is a monoidal structure on endofunctors, given by composition. While

--- a/UniMath/CategoryTheory/EpiFacts.v
+++ b/UniMath/CategoryTheory/EpiFacts.v
@@ -9,28 +9,26 @@
 Ambroise LAFONT January 2017
 *)
 
-
-Require Import UniMath.CategoryTheory.precategories.
-Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
-Local Open Scope cat.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.Epis.
 Require Import UniMath.CategoryTheory.limits.graphs.pullbacks.
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.limits.graphs.coequalizers.
 Require Import UniMath.CategoryTheory.limits.pullbacks.
-
 Require Import UniMath.CategoryTheory.limits.graphs.pushouts.
 Require Import UniMath.CategoryTheory.limits.graphs.eqdiag.
-
 Require Import UniMath.CategoryTheory.limits.pushouts.
 Require Import UniMath.CategoryTheory.limits.coequalizers.
 
-
-Require Import UniMath.CategoryTheory.Epis.
+Local Open Scope cat.
 
 (** Definition of an effective epimorphism.
 An effective epimorphism p: A -> B is a morphism which has a kernel pair and which

--- a/UniMath/CategoryTheory/EquivalencesExamples.v
+++ b/UniMath/CategoryTheory/EquivalencesExamples.v
@@ -21,17 +21,20 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
 Require Import UniMath.CategoryTheory.ProductPrecategory.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.Adjunctions.
 Require Import UniMath.CategoryTheory.equivalences.
 Require Import UniMath.CategoryTheory.limits.binproducts.
 Require Import UniMath.CategoryTheory.limits.products.
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
 Require Import UniMath.CategoryTheory.limits.coproducts.
+
+Local Open Scope cat.
 
 Section bindelta_functor_adjunction.
 

--- a/UniMath/CategoryTheory/FunctorAlgebras.v
+++ b/UniMath/CategoryTheory/FunctorAlgebras.v
@@ -23,11 +23,14 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.limits.initial.
+
+Local Open Scope cat.
 
 Section Algebra_Definition.
 

--- a/UniMath/CategoryTheory/HorizontalComposition.v
+++ b/UniMath/CategoryTheory/HorizontalComposition.v
@@ -10,10 +10,13 @@ Written by: Benedikt Ahrens, Ralph Matthes (2015)
 
 Require Import UniMath.Foundations.PartD.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
+
 Local Open Scope cat.
 
 Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).

--- a/UniMath/CategoryTheory/Inductives/LambdaCalculus.v
+++ b/UniMath/CategoryTheory/Inductives/LambdaCalculus.v
@@ -8,15 +8,17 @@ SubstitutionSystems/LamFromBindingSig.v.
 Written by: Anders Mörtberg, 2016
 
 *)
+
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.NaturalNumbers.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.category_hset.
 Require Import UniMath.CategoryTheory.category_hset_structures.
@@ -32,6 +34,8 @@ Require Import UniMath.CategoryTheory.EquivalencesExamples.
 Require Import UniMath.CategoryTheory.CocontFunctors.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.whiskering.
+
+Local Open Scope cat.
 
 Local Notation "'chain'" := (diagram nat_graph).
 

--- a/UniMath/CategoryTheory/Inductives/Lists.v
+++ b/UniMath/CategoryTheory/Inductives/Lists.v
@@ -10,12 +10,14 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.NaturalNumbers.
+
 Require Import UniMath.Combinatorics.Lists.
+
+Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.category_hset.
 Require Import UniMath.CategoryTheory.category_hset_structures.
@@ -26,6 +28,8 @@ Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.CocontFunctors.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
+
+Local Open Scope cat.
 
 (** * Lists as the colimit of a chain given by the list functor: F(X) = 1 + A * X *)
 Section lists.

--- a/UniMath/CategoryTheory/Inductives/Trees.v
+++ b/UniMath/CategoryTheory/Inductives/Trees.v
@@ -6,15 +6,17 @@ tree functor.
 Written by: Anders Mörtberg (2016)
 
 *)
+
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.NaturalNumbers.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.category_hset.
 Require Import UniMath.CategoryTheory.category_hset_structures.
@@ -26,6 +28,8 @@ Require Import UniMath.CategoryTheory.CocontFunctors.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
 Require Import UniMath.CategoryTheory.Inductives.Lists.
+
+Local Open Scope cat.
 
 (** * Binary trees *)
 Section bintrees.

--- a/UniMath/CategoryTheory/Monads.v
+++ b/UniMath/CategoryTheory/Monads.v
@@ -22,12 +22,15 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
+
+Local Open Scope cat.
 
 Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 

--- a/UniMath/CategoryTheory/RModules.v
+++ b/UniMath/CategoryTheory/RModules.v
@@ -12,19 +12,20 @@ Written by: Ambroise Lafont (November 2016)
 
 ************************************************************)
 
-
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
-
 Require Import UniMath.CategoryTheory.Monads.
+
+Local Open Scope cat.
 
 Local Notation "F ;;; G" := (nat_trans_comp _ _ _ F G) (at level 35).
 

--- a/UniMath/CategoryTheory/RightKanExtension.v
+++ b/UniMath/CategoryTheory/RightKanExtension.v
@@ -26,14 +26,17 @@ Contents:
 
 Require Import UniMath.Foundations.PartD.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.Adjunctions.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
 Require Import UniMath.CategoryTheory.CommaCategories.
+
+Local Open Scope cat.
 
 (** * Definition of global right Kan extension as right adjoint to precomposition *)
 Section RightKanExtension.

--- a/UniMath/CategoryTheory/SetValuedFunctors.v
+++ b/UniMath/CategoryTheory/SetValuedFunctors.v
@@ -13,16 +13,17 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.category_hset.
 Require Import UniMath.CategoryTheory.category_hset_structures.
-
 Require Import UniMath.CategoryTheory.Epis.
 Require Import UniMath.CategoryTheory.EpiFacts.
-
 Require Import UniMath.CategoryTheory.limits.coequalizers.
+
+Local Open Scope cat.
 
 
 Lemma is_pointwise_epi_from_set_nat_trans_epi (C:precategory)

--- a/UniMath/CategoryTheory/ShortExactSequences.v
+++ b/UniMath/CategoryTheory/ShortExactSequences.v
@@ -19,6 +19,8 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.limits.zero.
 Require Import UniMath.CategoryTheory.limits.equalizers.
 Require Import UniMath.CategoryTheory.limits.coequalizers.
@@ -26,7 +28,6 @@ Require Import UniMath.CategoryTheory.limits.Opp.
 
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.opp_precat.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.Monics.
 Require Import UniMath.CategoryTheory.Epis.
 Require Import UniMath.CategoryTheory.Morphisms.
@@ -41,6 +42,7 @@ Require Import UniMath.CategoryTheory.limits.kernels.
 Require Import UniMath.CategoryTheory.limits.cokernels.
 Require Import UniMath.CategoryTheory.limits.BinDirectSums.
 
+Local Open Scope cat.
 
 
 (** * Introduction

--- a/UniMath/CategoryTheory/SimplicialSets.v
+++ b/UniMath/CategoryTheory/SimplicialSets.v
@@ -10,6 +10,8 @@ Unset Automatic Introduction.
 
 (* Preamble *)
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Export UniMath.Combinatorics.FiniteSets.
 (* Require Export UniMath.Combinatorics.OrderedSets. *)
 Require Export UniMath.CategoryTheory.precategories.

--- a/UniMath/CategoryTheory/Subobjects.v
+++ b/UniMath/CategoryTheory/Subobjects.v
@@ -16,6 +16,8 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.slicecat.

--- a/UniMath/CategoryTheory/bicategories/whiskering.v
+++ b/UniMath/CategoryTheory/bicategories/whiskering.v
@@ -1,4 +1,7 @@
 Require Import UniMath.Foundations.PartD.
+
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -34,6 +34,8 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.category_hset.

--- a/UniMath/CategoryTheory/equivalences.v
+++ b/UniMath/CategoryTheory/equivalences.v
@@ -21,12 +21,14 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.Adjunctions.
 
+Local Open Scope cat.
 
 (** * Sloppy equivalence of (pre)categories *)
 

--- a/UniMath/CategoryTheory/exponentials.v
+++ b/UniMath/CategoryTheory/exponentials.v
@@ -17,10 +17,11 @@ Contents:
 
 ************************************************************)
 
-
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
+
+Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
@@ -28,6 +29,7 @@ Require Import UniMath.CategoryTheory.Adjunctions.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
 Require Import UniMath.CategoryTheory.limits.binproducts.
+
 Local Open Scope cat.
 
 Section exponentials.

--- a/UniMath/CategoryTheory/functor_categories.v
+++ b/UniMath/CategoryTheory/functor_categories.v
@@ -52,12 +52,13 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
+
 Local Open Scope cat.
+
 Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
-
-
-
 
 (** * Functors : Morphisms of precategories *)
 Section functors.

--- a/UniMath/CategoryTheory/limits/BinDirectSums.v
+++ b/UniMath/CategoryTheory/limits/BinDirectSums.v
@@ -9,23 +9,24 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids_and_Groups.
 
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
 Require Import UniMath.CategoryTheory.limits.binproducts.
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
 Require Import UniMath.CategoryTheory.limits.zero.
-
 Require Import UniMath.CategoryTheory.precategoriesWithBinOps.
 Require Import UniMath.CategoryTheory.PrecategoriesWithAbgrops.
 Require Import UniMath.CategoryTheory.PreAdditive.
 Require Import UniMath.CategoryTheory.Monics.
 Require Import UniMath.CategoryTheory.Epis.
 
+Local Open Scope cat.
 
 (** BinDirectSumCone is at the same time product and coproduct of the underlying objects together
     with the following equalities

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -19,14 +19,17 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories
-               UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
+Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
 Require Import UniMath.CategoryTheory.limits.zero.
 Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+
+Local Open Scope cat.
 
 (** * Definition of binary coproduct of objects in a precategory *)
 Section coproduct_def.

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -22,7 +22,7 @@ Require Import UniMath.Foundations.Sets.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.total2_paths.
-Require Import UniMath.CategoryTheory.precategories
+Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
 Require Import UniMath.CategoryTheory.limits.zero.

--- a/UniMath/CategoryTheory/limits/binproducts.v
+++ b/UniMath/CategoryTheory/limits/binproducts.v
@@ -11,18 +11,22 @@ Written by: Benedikt Ahrens, Ralph Matthes
 Extended by: Anders Mörtberg and Tomi Pannila
 
 *)
+
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories
-               UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
+Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
 Require Import UniMath.CategoryTheory.limits.zero.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
+
+Local Open Scope cat.
 
 (** Definition of binary products *)
 Section binproduct_def.

--- a/UniMath/CategoryTheory/limits/binproducts.v
+++ b/UniMath/CategoryTheory/limits/binproducts.v
@@ -19,7 +19,7 @@ Require Import UniMath.Foundations.Sets.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.total2_paths.
-Require Import UniMath.CategoryTheory.precategories
+Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
 Require Import UniMath.CategoryTheory.limits.zero.

--- a/UniMath/CategoryTheory/limits/cats/limits.v
+++ b/UniMath/CategoryTheory/limits/cats/limits.v
@@ -14,9 +14,12 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
+
 Local Open Scope cat.
 
 Section move_upstream.

--- a/UniMath/CategoryTheory/limits/coproducts.v
+++ b/UniMath/CategoryTheory/limits/coproducts.v
@@ -10,16 +10,20 @@ Direct implementation of indexed coproducts together with:
 Written by: Anders Mörtberg 2016
 
 *)
+
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.ProductPrecategory.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+
+Local Open Scope cat.
 
 (** * Definition of indexed coproducts of objects in a precategory *)
 Section coproduct_def.

--- a/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
@@ -10,10 +10,13 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+
+Local Open Scope cat.
 
 (** * Definition of binary coproduct of objects in a precategory *)
 

--- a/UniMath/CategoryTheory/limits/graphs/binproducts.v
+++ b/UniMath/CategoryTheory/limits/graphs/binproducts.v
@@ -1,12 +1,16 @@
 (** Binary products via limits *)
+
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
+
+Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
+
 Local Open Scope cat.
 
 Section binproduct_def.

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -17,11 +17,14 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.Adjunctions.
+
+Local Open Scope cat.
 
 Section move_upstream.
 

--- a/UniMath/CategoryTheory/limits/graphs/eqdiag.v
+++ b/UniMath/CategoryTheory/limits/graphs/eqdiag.v
@@ -42,13 +42,15 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.whiskering.
-
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
+
+Local Open Scope cat.
 
 Set Automatic Introduction.
 

--- a/UniMath/CategoryTheory/limits/graphs/initial.v
+++ b/UniMath/CategoryTheory/limits/graphs/initial.v
@@ -1,13 +1,17 @@
 (** Definition of initial object as a colimit *)
+
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.limits.initial.
+
+Local Open Scope cat.
 
 Section def_initial.
 

--- a/UniMath/CategoryTheory/limits/graphs/limits.v
+++ b/UniMath/CategoryTheory/limits/graphs/limits.v
@@ -15,12 +15,15 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.Adjunctions.
+
+Local Open Scope cat.
 
 (** * Definition of limits *)
 Section lim_def.

--- a/UniMath/CategoryTheory/limits/graphs/terminal.v
+++ b/UniMath/CategoryTheory/limits/graphs/terminal.v
@@ -1,14 +1,18 @@
 (** Terminal object defined as a limit *)
+
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
+
+Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.limits.terminal.
+
+Local Open Scope cat.
 
 Section def_terminal.
 

--- a/UniMath/CategoryTheory/limits/products.v
+++ b/UniMath/CategoryTheory/limits/products.v
@@ -11,17 +11,21 @@ Written by: Anders Mörtberg 2016
 
 
 *)
+
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories
-               UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
+Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.ProductPrecategory.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
+
+Local Open Scope cat.
 
 (** * Definition of indexed products of objects in a precategory *)
 Section product_def.

--- a/UniMath/CategoryTheory/limits/products.v
+++ b/UniMath/CategoryTheory/limits/products.v
@@ -19,7 +19,7 @@ Require Import UniMath.Foundations.Sets.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.total2_paths.
-Require Import UniMath.CategoryTheory.precategories
+Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.ProductPrecategory.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -14,16 +14,20 @@ Direct implementation of pullbacks together with:
 - Construction of binary products from pullbacks ([BinProductsFromPullbacks])
 
 *)
+
 Require Import UniMath.Foundations.PartD.
+Require Import UniMath.Foundations.Propositions.
+
+Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.limits.binproducts.
 Require Import UniMath.CategoryTheory.limits.equalizers.
 Require Import UniMath.CategoryTheory.Monics.
-Require Import UniMath.Foundations.Propositions.
+
+Local Open Scope cat.
 
 (** Definition of pullbacks *)
 Section def_pb.

--- a/UniMath/CategoryTheory/limits/pushouts.v
+++ b/UniMath/CategoryTheory/limits/pushouts.v
@@ -1,17 +1,21 @@
-(* Direct implementation of pushouts
+(** Direct implementation of pushouts
 
 Definition of Epi in terms of a pushout diagram
+
 *)
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.limits.initial.
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
 Require Import UniMath.CategoryTheory.limits.coequalizers.
 Require Import UniMath.CategoryTheory.Epis.
+
+Local Open Scope cat.
 
 Section def_po.
 

--- a/UniMath/CategoryTheory/opp_precat.v
+++ b/UniMath/CategoryTheory/opp_precat.v
@@ -18,6 +18,8 @@ Contents : Definition of opposite category and functor
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 

--- a/UniMath/CategoryTheory/precategories.v
+++ b/UniMath/CategoryTheory/precategories.v
@@ -38,6 +38,8 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 
 Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 

--- a/UniMath/CategoryTheory/precomp_ess_surj.v
+++ b/UniMath/CategoryTheory/precomp_ess_surj.v
@@ -22,10 +22,13 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.whiskering.
+
+Local Open Scope cat.
 
 Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 

--- a/UniMath/CategoryTheory/slicecat.v
+++ b/UniMath/CategoryTheory/slicecat.v
@@ -40,6 +40,8 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
@@ -52,6 +54,7 @@ Require Import UniMath.CategoryTheory.limits.initial.
 Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.Adjunctions.
 Require Import UniMath.CategoryTheory.exponentials.
+
 Local Open Scope cat.
 
 (** * Definition of slice categories *)

--- a/UniMath/Combinatorics/FiniteSequences.v
+++ b/UniMath/Combinatorics/FiniteSequences.v
@@ -1,5 +1,8 @@
 Require Export UniMath.Combinatorics.FiniteSets.
 Require Export UniMath.Combinatorics.Lists.
+
+Require Import UniMath.MoreFoundations.Tactics.
+
 Unset Automatic Introduction.
 
 Local Open Scope transport.

--- a/UniMath/Combinatorics/FiniteSets.v
+++ b/UniMath/Combinatorics/FiniteSets.v
@@ -18,6 +18,8 @@ Unset Automatic Introduction. (* This line has to be removed for the file to com
 
 (** Imports. *)
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Export UniMath.Combinatorics.StandardFiniteSets .
 
 

--- a/UniMath/Combinatorics/Lists.v
+++ b/UniMath/Combinatorics/Lists.v
@@ -5,6 +5,9 @@ This file contains a formalization of lists define as iterated products ([list])
 Written by: Anders Mörtberg, 2016 (inspired by a remark of Vladimir Voevodsky)
 
 *)
+
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.Combinatorics.StandardFiniteSets.
 
 Section preamble.

--- a/UniMath/Combinatorics/OrderedSets.v
+++ b/UniMath/Combinatorics/OrderedSets.v
@@ -3,6 +3,7 @@
 Require Import UniMath.Combinatorics.FiniteSets.
 Unset Automatic Introduction.
 Require Import UniMath.Foundations.UnivalenceAxiom.
+Require Import UniMath.MoreFoundations.Tactics.
 Local Open Scope poset.
 
 (** partially ordered sets and ordered sets *)

--- a/UniMath/Combinatorics/StandardFiniteSets.v
+++ b/UniMath/Combinatorics/StandardFiniteSets.v
@@ -16,6 +16,7 @@ Unset Automatic Introduction. (* This line has to be removed for the file to com
 (** Imports. *)
 
 Require Export UniMath.Foundations.NaturalNumbers .
+Require Import UniMath.MoreFoundations.Tactics.
 
 (** ** Standard finite sets [ stn ] . *)
 

--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -375,8 +375,12 @@ Hint Resolve @pathsinv0 : pathshints.
 Ltac unimath_easy :=
   trivial; intros; solve
    [ repeat (solve [trivial | apply pathsinv0; trivial] || split)
-   | match goal with H : ¬ _ |- _ => solve [induction H; trivial] end
-   | match goal with H : ∅ |- _ => induction H end ].
+   | match goal with
+       | H : ¬ _ |- _ => induction H; trivial
+       | H : _ → ∅ |- _ => induction H; trivial
+       | H : _ → _ → ∅ |- _ => induction H; trivial
+       | H : ∅ |- _ => induction H
+     end ].
 
 Tactic Notation "now" tactic(t) := t; unimath_easy.
 

--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -139,6 +139,7 @@ Require Export UniMath.Foundations.Preamble.
 
 (* end of "Preamble" *)
 
+
 (** ** Some standard constructions not using identity types (paths) *)
 
 (** *** Canonical functions from [ empty ] and to [ unit ] *)

--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -373,9 +373,10 @@ Defined.
 Hint Resolve @pathsinv0 : pathshints.
 
 Ltac unimath_easy :=
-  trivial; hnf; intros; solve
-   [ repeat (solve [trivial | apply pathsinv0; trivial] || discriminate || contradiction || split)
-   | match goal with H : ¬ _ |- _ => solve [induction H; trivial] end ].
+  trivial; intros; solve
+   [ repeat (solve [trivial | apply pathsinv0; trivial] || split)
+   | match goal with H : ¬ _ |- _ => solve [induction H; trivial] end
+   | match goal with H : ∅ |- _ => induction H end ].
 
 Tactic Notation "now" tactic(t) := t; unimath_easy.
 

--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -375,12 +375,10 @@ Hint Resolve @pathsinv0 : pathshints.
 Ltac unimath_easy :=
   trivial; intros; solve
    [ repeat (solve [trivial | apply pathsinv0; trivial] || split)
-   | match goal with
-       | H : ¬ _ |- _ => induction H; trivial
-       | H : _ → ∅ |- _ => induction H; trivial
-       | H : _ → _ → ∅ |- _ => induction H; trivial
-       | H : ∅ |- _ => induction H
-     end ].
+   | match goal with | H : ∅ |- _ => induction H end
+   | match goal with | H : ¬ _ |- _ => induction H; trivial end
+   | match goal with | H : _ → ∅ |- _ => induction H; trivial end
+   | match goal with | H : _ → _ → ∅ |- _ => induction H; trivial end ].
 
 Tactic Notation "now" tactic(t) := t; unimath_easy.
 

--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -139,7 +139,6 @@ Require Export UniMath.Foundations.Preamble.
 
 (* end of "Preamble" *)
 
-
 (** ** Some standard constructions not using identity types (paths) *)
 
 (** *** Canonical functions from [ empty ] and to [ unit ] *)
@@ -372,6 +371,13 @@ Proof.
 Defined.
 
 Hint Resolve @pathsinv0 : pathshints.
+
+Ltac unimath_easy :=
+  trivial; hnf; intros; solve
+   [ repeat (solve [trivial | apply pathsinv0; trivial] || discriminate || contradiction || split)
+   | match goal with H : ¬ _ |- _ => solve [induction H; trivial] end ].
+
+Tactic Notation "now" tactic(t) := t; unimath_easy.
 
 Definition path_assoc {X} {a b c d:X}
            (f : a = b) (g : b = c) (h : c = d)

--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -372,16 +372,6 @@ Defined.
 
 Hint Resolve @pathsinv0 : pathshints.
 
-Ltac unimath_easy :=
-  trivial; intros; solve
-   [ repeat (solve [trivial | apply pathsinv0; trivial] || split)
-   | match goal with | H : ∅ |- _ => induction H end
-   | match goal with | H : ¬ _ |- _ => induction H; trivial end
-   | match goal with | H : _ → ∅ |- _ => induction H; trivial end
-   | match goal with | H : _ → _ → ∅ |- _ => induction H; trivial end ].
-
-Tactic Notation "now" tactic(t) := t; unimath_easy.
-
 Definition path_assoc {X} {a b c d:X}
            (f : a = b) (g : b = c) (h : c = d)
   : f @ (g @ h) = (f @ g) @ h.

--- a/UniMath/HomologicalAlgebra/KA.v
+++ b/UniMath/HomologicalAlgebra/KA.v
@@ -8,6 +8,8 @@ Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.NaturalNumbers.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids_and_Groups.
 
@@ -15,8 +17,6 @@ Require Import UniMath.NumberSystems.Integers.
 
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
-Local Open Scope cat.
-
 Require Import UniMath.CategoryTheory.limits.zero.
 Require Import UniMath.CategoryTheory.limits.binproducts.
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
@@ -41,6 +41,8 @@ Require Import UniMath.CategoryTheory.AbelianToAdditive.
 Require Import UniMath.CategoryTheory.AdditiveFunctors.
 
 Require Import UniMath.HomologicalAlgebra.Complexes.
+
+Local Open Scope cat.
 
 Unset Kernel Term Sharing.
 Global Opaque hz.

--- a/UniMath/Ktheory/AffineLine.v
+++ b/UniMath/Ktheory/AffineLine.v
@@ -13,6 +13,9 @@ Unset Kernel Term Sharing.
 
 Require UniMath.Ktheory.Nat.
 Require Export UniMath.Foundations.Sets.
+
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.Ktheory.Utilities
                UniMath.Algebra.Monoids_and_Groups
                UniMath.Foundations.UnivalenceAxiom

--- a/UniMath/Ktheory/Bifunctor.v
+++ b/UniMath/Ktheory/Bifunctor.v
@@ -4,6 +4,8 @@ Require Import
         UniMath.Ktheory.Utilities
         UniMath.Ktheory.Precategories.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Export UniMath.CategoryTheory.precategories.
 Require Export UniMath.CategoryTheory.opp_precat
                UniMath.CategoryTheory.yoneda

--- a/UniMath/Ktheory/Equivalences.v
+++ b/UniMath/Ktheory/Equivalences.v
@@ -4,6 +4,7 @@ Unset Automatic Introduction.
 
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.UnivalenceAxiom.
+Require Import UniMath.MoreFoundations.Tactics.
 Require Import UniMath.Ktheory.Tactics.
 
 Definition Equivalence X Y :=

--- a/UniMath/Ktheory/Nat.v
+++ b/UniMath/Ktheory/Nat.v
@@ -2,6 +2,7 @@
 
 (** * Natural numbers *)
 
+Require Import UniMath.MoreFoundations.Tactics.
 Require Import UniMath.Algebra.Monoids_and_Groups
                UniMath.Foundations.NaturalNumbers
                UniMath.Foundations.UnivalenceAxiom

--- a/UniMath/Ktheory/Precategories.v
+++ b/UniMath/Ktheory/Precategories.v
@@ -9,6 +9,7 @@ Require Export UniMath.CategoryTheory.functor_categories.
 Require Export UniMath.Foundations.Preamble.
 Require Export UniMath.Foundations.Sets.
 Require Export UniMath.CategoryTheory.category_hset.
+Require Import UniMath.MoreFoundations.Tactics.
 
 Local Open Scope cat.
 

--- a/UniMath/Ktheory/Representation.v
+++ b/UniMath/Ktheory/Representation.v
@@ -8,6 +8,7 @@ Require Import
         UniMath.Ktheory.Tactics
         UniMath.Ktheory.Precategories
         UniMath.Ktheory.Bifunctor.
+Require Import UniMath.MoreFoundations.Tactics.
 Set Automatic Introduction.
 Local Open Scope cat.
 Local Open Scope Cat.

--- a/UniMath/Ktheory/Utilities.v
+++ b/UniMath/Ktheory/Utilities.v
@@ -5,6 +5,7 @@ Require Export UniMath.Foundations.PartD.
 Require Export UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.UnivalenceAxiom.
 Require Export UniMath.Ktheory.Tactics.
+Require Import UniMath.MoreFoundations.Tactics.
 
 (** ** Null homotopies, an aid for proving things about propositional truncation *)
 

--- a/UniMath/MoreFoundations/.package/files
+++ b/UniMath/MoreFoundations/.package/files
@@ -1,6 +1,6 @@
 Foundations.v
+Tactics.v
 Notations.v
 DecidablePropositions.v
 AxiomOfChoice.v
-Tactics.v
 All.v

--- a/UniMath/MoreFoundations/.package/files
+++ b/UniMath/MoreFoundations/.package/files
@@ -2,4 +2,5 @@ Foundations.v
 Notations.v
 DecidablePropositions.v
 AxiomOfChoice.v
+Tactics.v
 All.v

--- a/UniMath/MoreFoundations/All.v
+++ b/UniMath/MoreFoundations/All.v
@@ -7,4 +7,5 @@ Require Export
         UniMath.MoreFoundations.Notations
         UniMath.MoreFoundations.DecidablePropositions
         UniMath.MoreFoundations.AxiomOfChoice
+        UniMath.MoreFoundations.Tactics
 .

--- a/UniMath/MoreFoundations/DecidablePropositions.v
+++ b/UniMath/MoreFoundations/DecidablePropositions.v
@@ -1,4 +1,5 @@
 Require Export UniMath.MoreFoundations.Notations.
+Require Import UniMath.MoreFoundations.Tactics.
 
 Lemma retract_dec {X Y} (f : X -> Y) (g : Y -> X) (h : f ∘ g ~ idfun Y) : isdeceq X -> isdeceq Y.
 Proof.

--- a/UniMath/MoreFoundations/Tactics.v
+++ b/UniMath/MoreFoundations/Tactics.v
@@ -1,0 +1,21 @@
+(************************************************************************
+
+This file contains various useful tactics
+
+************************************************************************)
+
+Require Import UniMath.MoreFoundations.Foundations.
+
+(** A version of "easy" specialized for the needs of UniMath.
+This tactic is supposed to be simple and predictable. The goal
+is to use it to finish of "trivial" goals *)
+Ltac unimath_easy :=
+  trivial; intros; solve
+   [ repeat (solve [trivial | apply pathsinv0; trivial] || split)
+   | match goal with | H : ∅ |- _ => induction H end
+   | match goal with | H : ¬ _ |- _ => induction H; trivial end
+   | match goal with | H : _ → ∅ |- _ => induction H; trivial end
+   | match goal with | H : _ → _ → ∅ |- _ => induction H; trivial end ].
+
+(** Override the Coq now tactic so that it uses unimath_easy instead *)
+Tactic Notation "now" tactic(t) := t; unimath_easy.

--- a/UniMath/NumberSystems/NaturalNumbersAlgebra.v
+++ b/UniMath/NumberSystems/NaturalNumbersAlgebra.v
@@ -3,6 +3,7 @@
 Require Export UniMath.Algebra.Archimedean.
 Require Export UniMath.Algebra.Domains_and_Fields.
 Require Export UniMath.Foundations.NaturalNumbers.
+Require Import UniMath.MoreFoundations.Tactics.
 
 Definition nataddabmonoid : abmonoid :=
   abmonoidpair (setwithbinoppair natset (fun n m : nat => n + m))

--- a/UniMath/PAdics/frac.v
+++ b/UniMath/PAdics/frac.v
@@ -48,7 +48,7 @@ pr1 ( pr2 ef ) ) ) ~> ( @op2 A ( pr1 ef ) ( pr1 ( pr2 cd ) ) ) ) in p.
 assert ( ( @op2 A ( pr1 cd ) ( pr1 ( pr2 ef ) ) ) # 0 ) as v. apply
 A. assumption. apply ( pr2 ( pr2 ef ) ). rewrite p in v. apply ( pr1 (
 timesazero v ) ).  Defined.
- 
+
 Lemma azerolmultcomp { a b c : A } ( p : a # 0 ) ( q : b # c ) : a * b
 # a * c.  Proof.  intros. apply aminuszeroa. rewrite <-
 rngminusdistr. apply ( pr2 A ). assumption.  apply
@@ -68,11 +68,11 @@ ab cd ef gh p q. unfold afldfracapartrelpre.  destruct ab as [ a b
 ]. destruct b as [ b b' ].  destruct cd as [ c d ]. destruct d as [ d
 d' ].  destruct ef as [ e f ]. destruct f as [ f f' ].  destruct gh as
 [ g h ]. destruct h as [ h h' ].  simpl in *.
-  
+
   apply uahp. intro u. apply p. intro p'. apply q. intro q'.  destruct
   p' as [ p' j ]. destruct p' as [ i p' ]. destruct q' as [ q' j'
   ]. destruct q' as [ i' q' ].  simpl in *.
-  
+
   assert ( a * f * d * i * h * i' # e * b * d * i * h * i') as v0.
   assert ( a * f * d # e * b * d ) as v0. apply azerormultcomp. apply
   d'.  assumption.  assert ( a * f * d * i # e * b * d * i ) as
@@ -98,7 +98,7 @@ d' ].  destruct ef as [ e f ]. destruct f as [ f f' ].  destruct gh as
   @op2 A ( @op2 A g d ) b ) f ) i ) i' ). rewrite k0.  assert ( @op2 A
   ( @op2 A e h ) i' ~> @op2 A ( @op2 A g f ) i' ) as j''. assumption.
   rewrite j''. permute. rewrite k in v0. assumption.
-  
+
   intro u. apply p. intro p'. apply q. intro q'.  destruct p' as [ p'
   j ]. destruct p' as [ i p' ]. destruct q' as [ q' j' ]. destruct q'
   as [ i' q' ].  simpl in *.
@@ -230,11 +230,11 @@ commrngfracop2 A ( aintdomazerosubmonoid A ) a c) -> pr1
 (afldfracapart ) b c) ) as int.  intros a b c. apply impred. intro
 p. apply ( pr1 ( afldfracapart ) b c ).  apply ( setquotuniv3prop _ (
 fun a b c => hProppair _ ( int a b c ) ) ).  intros ab cd ef p.
-  
+
   destruct ab as [ a b ]. destruct b as [ b b' ].  destruct cd as [ c
   d ]. destruct d as [ d d' ]. destruct ef as [ e f ].  destruct f as
   [ f f' ].
-  
+
   assert ( afldfracapartrelpre ( dirprodpair ( ( a * c ) ) ( @op (
   aintdomazerosubmonoid A ) ( tpair b b' ) ( tpair d d' ) ) ) (
   dirprodpair ( a * e ) ( @op ( aintdomazerosubmonoid A ) ( tpair b b'
@@ -294,7 +294,7 @@ dirprodpair b c ) ( dirprodpair ( @rngunel1 A ) ( unel (
 aintdomazerosubmonoid A ) ) ) ) as is'.  apply q. split with
 (setquotpr (eqrelcommrngfrac A (aintdomazerosubmonoid A)) (
 afldfracmultinvint ( dirprodpair b c ) is' ) ).
-  
+
   split.  change ( setquotpr ( eqrelcommrngfrac A (
   aintdomazerosubmonoid A ) ) ( dirprodpair ( @op2 A ( pr1 (
   afldfracmultinvint ( dirprodpair b c ) is' ) ) b ) ( @op (
@@ -316,7 +316,7 @@ afldfracmultinvint ( dirprodpair b c ) is' ) ).
  1 ( pr1 ( pr2 A ) ) ).  simpl. rewrite 3! ( @rngrunax2 A ). rewrite (
  @rnglunax2 A ). apply ( @rngcomm2 A ).  apply p. assumption.
  Defined.
- 
+
 Theorem afldfracisafld : isaafield afldfrac0.  Proof.  intros. split.
 change ( ( afldfracapartrel ) ( @rngunel2 ( commrngfrac A (
 aintdomazerosubmonoid A ) ) ) ( @rngunel1 ( commrngfrac A (
@@ -324,9 +324,9 @@ aintdomazerosubmonoid A ) ) ) ).  unfold afldfracapartrel. cut ( (
 @op2 A ( @rngunel2 A ) ( @rngunel2 A ) ) # ( @op2 A ( @rngunel1 A ) (
 @rngunel2 A ) ) ).  intro v. apply v. rewrite 2! ( @rngrunax2 A
 ). apply A.
-  
+
   intros a p. apply afldfracmultinv. assumption.  Defined.
- 
+
 Definition afldfrac := afldpair afldfrac0 afldfracisafld.
 
 End aint.

--- a/UniMath/RealNumbers/DecidableDedekindCuts.v
+++ b/UniMath/RealNumbers/DecidableDedekindCuts.v
@@ -3,6 +3,8 @@
 (** Additional results about Dedekind cuts which cannot be proved *)
 (** without decidability *)
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.RealNumbers.Prelim.
 Require Import UniMath.RealNumbers.Sets.
 Require Import UniMath.RealNumbers.NonnegativeRationals.

--- a/UniMath/RealNumbers/NonnegativeRationals.v
+++ b/UniMath/RealNumbers/NonnegativeRationals.v
@@ -4,6 +4,8 @@ Unset Automatic Introduction. (** This line has to be removed for the file to co
 
 Unset Kernel Term Sharing.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.RealNumbers.Sets.
 Require Import UniMath.RealNumbers.Fields.
 Require Export UniMath.Algebra.DivisionRig.

--- a/UniMath/RealNumbers/NonnegativeReals.v
+++ b/UniMath/RealNumbers/NonnegativeReals.v
@@ -1,6 +1,8 @@
 (** * Definition of Dedekind cuts for non-negative real numbers *)
 (** Catherine Lelay. Sep. 2015 *)
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.RealNumbers.Sets.
 Require Export UniMath.Algebra.ConstructiveStructures.
 Require Import UniMath.RealNumbers.Prelim.

--- a/UniMath/RealNumbers/Prelim.v
+++ b/UniMath/RealNumbers/Prelim.v
@@ -1,5 +1,7 @@
 (** * Additionals theorems and definitions *)
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Export UniMath.Topology.Prelim.
 
 Unset Automatic Introduction. (* This line has to be removed for the file to compile with Coq8.2 *)

--- a/UniMath/RealNumbers/Reals.v
+++ b/UniMath/RealNumbers/Reals.v
@@ -1,6 +1,8 @@
 (** * A library about decidable Real Numbers *)
 (** Author: Catherine LELAY. Oct 2015 - *)
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.RealNumbers.Prelim.
 Require Import UniMath.RealNumbers.Sets.
 Require Import UniMath.RealNumbers.NonnegativeRationals.

--- a/UniMath/RealNumbers/Sets.v
+++ b/UniMath/RealNumbers/Sets.v
@@ -2,6 +2,8 @@
 
 (** Previous theorems about hSet and order *)
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Export UniMath.Foundations.Sets
                UniMath.Ktheory.QuotientSet.
 Require Import UniMath.Algebra.BinaryOperations

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -16,6 +16,8 @@ Written by: Anders Mörtberg, 2016
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Combinatorics.Lists.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.whiskering.

--- a/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
@@ -18,9 +18,10 @@ Based on a note by Ralph Matthes.
 
 Require Import UniMath.Foundations.PartD.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.limits.initial.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.FunctorAlgebras.
@@ -30,6 +31,8 @@ Require Import UniMath.CategoryTheory.CocontFunctors.
 Require Import UniMath.CategoryTheory.yoneda.
 Require Import UniMath.CategoryTheory.HorizontalComposition.
 Require Import UniMath.CategoryTheory.whiskering.
+
+Local Open Scope cat.
 
 Arguments functor_composite {_ _ _} _ _ .
 Arguments nat_trans_comp {_ _ _ _ _} _ _ .

--- a/UniMath/SubstitutionSystems/Lam.v
+++ b/UniMath/SubstitutionSystems/Lam.v
@@ -25,9 +25,10 @@ Set Kernel Term Sharing.
 
 Require Import UniMath.Foundations.PartD.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.limits.binproducts.
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
@@ -45,6 +46,7 @@ Require Import UniMath.SubstitutionSystems.LiftingInitial.
 Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.Notation.
 
+Local Open Scope cat.
 
 Section Lambda.
 

--- a/UniMath/SubstitutionSystems/LamFromBindingSig.v
+++ b/UniMath/SubstitutionSystems/LamFromBindingSig.v
@@ -11,9 +11,10 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Combinatorics.Lists.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.category_hset.
 Require Import UniMath.CategoryTheory.category_hset_structures.
 Require Import UniMath.CategoryTheory.CocontFunctors.
@@ -38,6 +39,8 @@ Require Import UniMath.SubstitutionSystems.LamSignature.
 Require Import UniMath.SubstitutionSystems.Notation.
 Require Import UniMath.SubstitutionSystems.BindingSigToMonad.
 Require Import UniMath.SubstitutionSystems.LiftingInitial_alt.
+
+Local Open Scope cat.
 
 Section Lam.
 

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -26,9 +26,10 @@ Set Kernel Term Sharing.
 
 Require Import UniMath.Foundations.PartD.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.Monads.
 Require Import UniMath.CategoryTheory.limits.binproducts.
@@ -50,7 +51,7 @@ Require Import UniMath.SubstitutionSystems.GenMendlerIteration.
 Require Import UniMath.CategoryTheory.EndofunctorsMonoidal.
 Require Import UniMath.SubstitutionSystems.Notation.
 
-
+Local Open Scope cat.
 
 Local Coercion alg_carrier : algebra_ob >-> ob.
 

--- a/UniMath/SubstitutionSystems/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial_alt.v
@@ -16,9 +16,10 @@ Set Kernel Term Sharing.
 
 Require Import UniMath.Foundations.PartD.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.Monads.
 Require Import UniMath.CategoryTheory.limits.binproducts.
@@ -39,6 +40,8 @@ Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.GenMendlerIteration_alt.
 Require Import UniMath.CategoryTheory.EndofunctorsMonoidal.
 Require Import UniMath.SubstitutionSystems.Notation.
+
+Local Open Scope cat.
 
 Local Coercion alg_carrier : algebra_ob >-> ob.
 

--- a/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
@@ -1,4 +1,3 @@
-
 (** **********************************************************
 
 Benedikt Ahrens, Ralph Matthes
@@ -40,11 +39,12 @@ Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
 Require Import UniMath.CategoryTheory.HorizontalComposition.
 Require Import UniMath.CategoryTheory.PointedFunctorsComposition.
 Require Import UniMath.CategoryTheory.EndofunctorsMonoidal.
+
+Local Open Scope cat.
+
 Require Import UniMath.SubstitutionSystems.Signatures.
 Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.Notation.
-
-Local Open Scope cat.
 
 Section monad_from_hss.
 

--- a/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
@@ -27,9 +27,10 @@ Unset Kernel Term Sharing.
 
 Require Import UniMath.Foundations.PartD.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.Monads.
 Require Import UniMath.CategoryTheory.FunctorAlgebras.
@@ -43,6 +44,7 @@ Require Import UniMath.SubstitutionSystems.Signatures.
 Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.Notation.
 
+Local Open Scope cat.
 
 Section monad_from_hss.
 

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -25,8 +25,12 @@ using [X,SET] instead of SET/X. There is no proof that the
 functor we obtain using this approach is omega-cocontinuous yet.
 
 *)
+
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Sets.
+
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.Combinatorics.Lists.
 
 Require Import UniMath.CategoryTheory.precategories.

--- a/UniMath/SubstitutionSystems/STLC.v
+++ b/UniMath/SubstitutionSystems/STLC.v
@@ -8,6 +8,9 @@ Written by: Anders Mörtberg, 2017
 
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Sets.
+
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.Combinatorics.Lists.
 
 Require Import UniMath.CategoryTheory.precategories.

--- a/UniMath/SubstitutionSystems/SignatureCategory.v
+++ b/UniMath/SubstitutionSystems/SignatureCategory.v
@@ -8,11 +8,13 @@ Definition of the category of signatures with strength ([Signature_precategory])
 Written by: Anders Mörtberg in October 2016 based on a note of Benedikt Ahrens.
 
 *)
+
 Require Import UniMath.Foundations.PartD.
+
+Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.limits.binproducts.
 Require Import UniMath.CategoryTheory.limits.coproducts.
@@ -26,6 +28,8 @@ Require Import UniMath.SubstitutionSystems.Notation.
 Require Import UniMath.SubstitutionSystems.Signatures.
 Require Import UniMath.SubstitutionSystems.BinProductOfSignatures.
 Require Import UniMath.SubstitutionSystems.SumOfSignatures.
+
+Local Open Scope cat.
 
 Local Notation "[ C , D ]" := (functor_Precategory C D).
 

--- a/UniMath/SubstitutionSystems/SignatureExamples.v
+++ b/UniMath/SubstitutionSystems/SignatureExamples.v
@@ -11,9 +11,10 @@ Revised and extended by Ralph Matthes, 2017
 
 Require Import UniMath.Foundations.PartD.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
 Require Import UniMath.CategoryTheory.limits.terminal.
@@ -21,12 +22,11 @@ Require Import UniMath.CategoryTheory.FunctorAlgebras.
 Require Import UniMath.CategoryTheory.PointedFunctors.
 Require Import UniMath.SubstitutionSystems.Signatures.
 Require Import UniMath.CategoryTheory.EndofunctorsMonoidal.
-(*
-Require Import UniMath.SubstitutionSystems.Lam.
-*)
 Require Import UniMath.SubstitutionSystems.Notation.
 Require Import UniMath.CategoryTheory.HorizontalComposition.
 Require Import UniMath.CategoryTheory.PointedFunctorsComposition.
+
+Local Open Scope cat.
 
 Section around_δ.
 

--- a/UniMath/Topology/Filters.v
+++ b/UniMath/Topology/Filters.v
@@ -4,6 +4,8 @@
 
 Require Export UniMath.Topology.Prelim.
 
+Require Import UniMath.MoreFoundations.Tactics.
+
 Unset Automatic Introduction. (* This line has to be removed for the file to compile with Coq8.2 *)
 
 (** ** Definition of a Filter *)

--- a/UniMath/Topology/Filters.v
+++ b/UniMath/Topology/Filters.v
@@ -1008,10 +1008,11 @@ Proof.
   apply hinhpr.
   exists nil.
   split.
-  intros m.
-  now generalize (pr2 m).
-  easy.
+  + intros m.
+    induction (nopathsfalsetotrue (pr2 m)).
+  + unimath_easy.
 Qed.
+
 Lemma filtergenerated_and :
   isfilter_and filtergenerated.
 Proof.

--- a/UniMath/Topology/Prelim.v
+++ b/UniMath/Topology/Prelim.v
@@ -254,7 +254,7 @@ Proof.
     induction n as [ | n _] ; simpl.
     + intros _ n.
       apply fromempty.
-      now generalize (pr2 n).
+      induction (negnatlthn0 _ (pr2 n)).
     + intros Hx m.
       rewrite (tppr m) ;
         generalize (pr1 m) (pr2 m) ;
@@ -302,7 +302,7 @@ Proof.
     + rewrite <- finite_intersection_htrue.
       apply X0.
       intros n.
-      now generalize (pr2 n).
+            induction (negnatlthn0 _ (pr2 n)).
     + intros A B Pa Pb.
       rewrite <- finite_intersection_and.
       apply X0.

--- a/UniMath/Topology/Prelim.v
+++ b/UniMath/Topology/Prelim.v
@@ -1,6 +1,7 @@
 (** * Additionals theorems *)
 
 Require Export UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.Tactics.
 Require Export UniMath.Combinatorics.FiniteSequences.
 Require Export UniMath.Foundations.NaturalNumbers.
 Require Import UniMath.Ktheory.Utilities.

--- a/UniMath/Topology/Topology.v
+++ b/UniMath/Topology/Topology.v
@@ -61,8 +61,9 @@ Proof.
   rewrite <- finite_intersection_htrue.
   apply H0.
   intros m.
-  now generalize (pr2 m).
+  induction (nopathsfalsetotrue (pr2 m)).
 Qed.
+
 Lemma isSetOfOpen_finite_intersection_and :
   isSetOfOpen_finite_intersection
   → isSetOfOpen_and.
@@ -142,7 +143,7 @@ Proof.
   rewrite <- finite_intersection_htrue.
   apply isOpen_finite_intersection.
   intros m.
-  now generalize (pr2 m).
+  induction (nopathsfalsetotrue (pr2 m)).
 Qed.
 Lemma isOpen_and :
   ∏ A B : T → hProp,
@@ -565,11 +566,7 @@ Proof.
   intros x.
   apply hinhpr.
   exists nil.
-  repeat split.
-  intros n.
-  now generalize (pr2 n).
-  intros n.
-  now generalize (pr2 n).
+  repeat split; intros n; induction (nopathsfalsetotrue (pr2 n)).
 Qed.
 
 Lemma topologygenerated_and :

--- a/UniMath/Topology/Topology.v
+++ b/UniMath/Topology/Topology.v
@@ -2,6 +2,7 @@
 (** Author: Catherine LELAY. Jan 2016 - *)
 (** Based on Bourbaky *)
 
+Require Import UniMath.MoreFoundations.Tactics.
 Require Export UniMath.Topology.Filters.
 Require Import UniMath.Algebra.DivisionRig.
 Require Import UniMath.Algebra.ConstructiveStructures.


### PR DESCRIPTION
The goal of this PR is to resolve https://github.com/UniMath/UniMath/issues/621.

Some of us have been using the Coq tactic `now` quite heavily, what we didn't know was that it was doing a lot of complicated things. This tactic is used in just over 1600 times in more or less every package (including Foundations). As pointed out in https://github.com/UniMath/UniMath/issues/609 this has led to some problems with proof maintance.

In this PR I define a very simple tactic called `unimath_easy` which is a replacement for the complicated Coq tactic `easy`, this is then used to define our own `now` tactic which is supposed to be very simple and only try to solve really trivial goals. The new `unimath_easy` tactic works as follows:
1. First try to solve the goal using `trivial` (https://coq.inria.fr/refman/Reference-Manual010.html#hevea_tactic150). This solves things like X=X. 
2. If that didn't work do `intros` and then try to repeatedly decompose the goal using `split` and apply pathsinv0 and try to solve the goal using `trivial`. If that didn't work check if there is a negated type or the empty type in the context and call induction on this hypothesis (this seems better than calling the standard Coq tactic `contradiction` as it is not clear to me if that will use the eliminator or not). 

With this very simple tactic all but 6 uses of `now` still works. The few that failed were very easy to fix. While fixing them I noticed that they were using the Coq tactic `inversion` (https://coq.inria.fr/refman/Reference-Manual010.html#hevea_tactic95) which I think was very bad because this is a very complicated and slow tactic. I have also no idea what kind of proof terms it is generating.

Because `now` is used all over UniMath I had to put this as early as possible in PartA (directly after the definition of `pathsinv0`), so I guess this PR cannot be merged until the lock on the Foundations has been lifted. 