### PR TITLE
fix an unused variable name warning

### DIFF
--- a/UniMath/Foundations/NaturalNumbers.v
+++ b/UniMath/Foundations/NaturalNumbers.v
@@ -852,7 +852,7 @@ Defined.
 
 Lemma natplusr0 (n : nat) : (n + 0) = n.
 Proof.
-  intro. induction n as [ | n IH n ].
+  intro. induction n as [ | n IH].
   - apply idpath.
   - simpl. apply (maponpaths S IH).
 Defined.


### PR DESCRIPTION
This removes a spurious `n` which was not used and warned as such.
This warning is going to be transformed into an error when https://github.com/coq/coq/pull/474 gets merged so this fix is needed.