### PR TITLE
Speed up some files on limits

### DIFF
--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -36,7 +36,6 @@ Require Import UniMath.Foundations.Sets.
 
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.category_hset.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
@@ -52,8 +51,9 @@ Require Import UniMath.CategoryTheory.Adjunctions.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.covyoneda.
 Require Import UniMath.CategoryTheory.slicecat.
-
 Require Import UniMath.CategoryTheory.EpiFacts.
+
+Local Open Scope cat.
 
 (* This should be moved upstream. Constructs the smallest eqrel
    containing a given relation *)

--- a/UniMath/CategoryTheory/limits/graphs/coequalizers.v
+++ b/UniMath/CategoryTheory/limits/graphs/coequalizers.v
@@ -12,9 +12,9 @@ Require Import UniMath.Combinatorics.StandardFiniteSets.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.limits.coequalizers.
 
+Local Open Scope cat.
 
 (** * Definition of coequalizers in terms of colimits *)
 Section def_coequalizers.
@@ -39,8 +39,8 @@ Section def_coequalizers.
   Definition Coequalizer_diagram {a b : C} (f g : C⟦a, b⟧) : diagram Coequalizer_graph C.
   Proof.
     exists (two_rec a b).
-    use two_rec_dep; cbn.
-    - use two_rec_dep; cbn.
+    use two_rec_dep.
+    - use two_rec_dep; simpl.
       + apply fromempty.
       + intro x. induction x.
         exact f. exact g.
@@ -51,12 +51,12 @@ Section def_coequalizers.
              (H : f · h = g · h) : cocone (Coequalizer_diagram f g) d.
   Proof.
     use mk_cocone.
-    - use two_rec_dep; cbn.
+    - use two_rec_dep.
       + exact (f · h).
       + exact h.
-    - use two_rec_dep; cbn; use two_rec_dep; cbn.
+    - use two_rec_dep; use two_rec_dep.
       + exact (Empty_set_rect _).
-      + intro e. unfold idfun. induction e.
+      + intro e. induction e.
         * apply idpath.
         * apply (! H).
       + exact (Empty_set_rect _).
@@ -83,16 +83,16 @@ Section def_coequalizers.
     set (H2 := (H' x (coconeIn cx Two) H1)).
     use tpair.
     - use (tpair _ (pr1 (pr1 H2)) _).
-      use two_rec_dep; cbn; unfold idfun.
+      use two_rec_dep.
       + use (pathscomp0 _ (coconeInCommutes cx One Two (ii1 tt))).
-        rewrite <- assoc. cbn. apply cancel_precomposition.
-        apply (pr2 (pr1 H2)).
+        change (coconeIn (Coequalizer_cocone f g d h H) _) with (f · h).
+        change (dmor _ _) with f.
+        rewrite <- assoc.
+        apply cancel_precomposition, (pr2 (pr1 H2)).
       + apply (pr2 (pr1 H2)).
-    - intro t. apply subtypeEquality.
-      intros y. apply impred. intros t0. apply hs.
-      induction t as [t p]. cbn.
-      apply path_to_ctr.
-      apply (p Two).
+    - abstract (intro t; apply subtypeEquality;
+               [intros y; apply impred; intros t0; apply hs
+               |induction t as [t p]; apply path_to_ctr, (p Two)]).
   Defined.
 
   Definition Coequalizer {a b : C} (f g : C⟦a, b⟧) : UU := ColimCocone (Coequalizer_diagram f g).
@@ -130,18 +130,7 @@ Section def_coequalizers.
   Definition CoequalizerOut {a b : C} {f g : C⟦a, b⟧} (E : Coequalizer f g) e (h : C⟦b, e⟧)
              (H : f · h = g · h) : C⟦colim E, e⟧.
   Proof.
-    use colimArrow.
-    use mk_cocone.
-    - use two_rec_dep; cbn.
-      + exact (f · h).
-      + exact h.
-    - use two_rec_dep; cbn; use two_rec_dep; cbn.
-      + exact (Empty_set_rect _).
-      + intro e0. unfold idfun. induction e0.
-        * apply idpath.
-        * apply (! H).
-      + exact (Empty_set_rect _).
-      + exact (Empty_set_rect _).
+    now use colimArrow; use Coequalizer_cocone.
   Defined.
 
   Lemma CoequalizerArrowComm {a b : C} {f g : C⟦a, b⟧} (E : Coequalizer f g) (e : C) (h : C⟦b, e⟧)
@@ -155,12 +144,13 @@ Section def_coequalizers.
     w = CoequalizerOut E e h H.
   Proof.
     apply path_to_ctr.
-    use two_rec_dep; cbn.
+    use two_rec_dep.
     - set (X := colimInCommutes E One Two (ii1 tt)).
       apply (maponpaths (fun h : _ => h · w)) in X.
-      use (pathscomp0 (!X)). cbn. rewrite <- assoc.
-      unfold idfun. apply cancel_precomposition.
-      apply H'.
+      use (pathscomp0 (!X)); rewrite <- assoc.
+      change (dmor _ _) with f.
+      change (coconeIn _ _) with (f · h).
+      apply cancel_precomposition, H'.
     - apply H'.
   Qed.
 

--- a/UniMath/CategoryTheory/limits/graphs/equalizers.v
+++ b/UniMath/CategoryTheory/limits/graphs/equalizers.v
@@ -13,9 +13,9 @@ Require Import UniMath.Combinatorics.StandardFiniteSets.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.limits.equalizers.
 
+Local Open Scope cat.
 
 (** * Definition of equalizers in terms of limits *)
 Section def_equalizers.
@@ -41,8 +41,8 @@ Section def_equalizers.
   Definition Equalizer_diagram {a b : C} (f g : C⟦a, b⟧) : diagram Equalizer_graph C.
   Proof.
     exists (two_rec a b).
-    use two_rec_dep; cbn.
-    - use two_rec_dep; cbn.
+    use two_rec_dep.
+    - use two_rec_dep; simpl.
       + apply fromempty.
       + intro x. induction x.
         exact f. exact g.
@@ -53,10 +53,10 @@ Section def_equalizers.
     cone (Equalizer_diagram f g) d.
   Proof.
     use mk_cone.
-    - use two_rec_dep; cbn.
+    - use two_rec_dep.
       + exact h.
       + exact (h · f).
-    - use two_rec_dep; cbn; use two_rec_dep; cbn.
+    - use two_rec_dep; use two_rec_dep.
       + exact (Empty_set_rect _).
       + intro e. unfold idfun. induction e.
         * apply idpath.
@@ -73,7 +73,6 @@ Section def_equalizers.
      iscontr (total2 (fun hk : C⟦e, d⟧ => hk · h = h'))) -> isEqualizer f g d h H.
   Proof.
     intros H' x cx.
-
     assert (H1 : coneOut cx One · f = coneOut cx One · g).
     {
       use (pathscomp0 (coneOutCommutes cx One Two (ii1 tt))).
@@ -83,16 +82,15 @@ Section def_equalizers.
     set (H2 := (H' x (coneOut cx One) H1)).
     use tpair.
     - use (tpair _ (pr1 (pr1 H2)) _).
-      use two_rec_dep; cbn; unfold idfun.
+      use two_rec_dep.
       + apply (pr2 (pr1 H2)).
-      +  use (pathscomp0 _ (coneOutCommutes cx One Two (ii1 tt))).
-         cbn. rewrite assoc. apply cancel_postcomposition.
-         apply (pr2 (pr1 H2)).
-    - intro t. apply subtypeEquality.
-      intros y. apply impred. intros t0. apply hs.
-      induction t as [t p]. cbn.
-      apply path_to_ctr.
-      apply (p One).
+      + use (pathscomp0 _ (coneOutCommutes cx One Two (ii1 tt))).
+        change (coneOut (Equalizer_cone f g d h H) (● 1)%stn) with (h · f).
+        rewrite assoc.
+        apply cancel_postcomposition, (pr2 (pr1 H2)).
+    - abstract (intro t; apply subtypeEquality;
+                [ intros y; apply impred; intros t0; apply hs
+                | induction t as [t p]; apply path_to_ctr, (p One)]).
   Defined.
 
   Definition Equalizer {a b : C} (f g : C⟦a, b⟧) := LimCone (Equalizer_diagram f g).
@@ -130,18 +128,7 @@ Section def_equalizers.
   Definition EqualizerIn {a b : C} {f g : C⟦a, b⟧} (E : Equalizer f g) (e : C) (h : C⟦e, a⟧)
              (H : h · f = h · g) : C⟦e, lim E⟧.
   Proof.
-    use limArrow.
-    use mk_cone.
-    - use two_rec_dep; cbn.
-      + exact h.
-      + exact (h · f).
-    - use two_rec_dep; cbn; use two_rec_dep; cbn.
-      + exact (Empty_set_rect _).
-      + intros e0. unfold idfun. induction e0.
-        * apply idpath.
-        * apply (! H).
-      + exact (Empty_set_rect _).
-      + exact (Empty_set_rect _).
+    now use limArrow; use Equalizer_cone.
   Defined.
 
   Lemma EqualizerArrowComm {a b : C} {f g : C⟦a, b⟧} (E : Equalizer f g) (e : C) (h : C⟦e, a⟧)
@@ -155,13 +142,14 @@ Section def_equalizers.
     w = EqualizerIn E e h H.
   Proof.
     apply path_to_ctr.
-    use two_rec_dep; cbn.
+    use two_rec_dep.
     - apply H'.
     - set (X := limOutCommutes E One Two (ii1 tt)).
       apply (maponpaths (fun h : _ => w · h)) in X.
-      use (pathscomp0 (!X)). cbn. rewrite assoc.
-      apply cancel_postcomposition.
-      apply H'.
+      use (pathscomp0 (!X)); rewrite assoc.
+      change (dmor _ _) with f.
+      change (coneOut _ _) with (h · f).
+      apply cancel_postcomposition, H'.
   Qed.
 
   Definition isEqualizer_Equalizer {a b : C} {f g : C⟦a, b⟧} (E : Equalizer f g) :
@@ -201,8 +189,8 @@ Section def_equalizers.
     + set (X := (coneOutCommutes (limCone E) One Two (ii1 tt))).
       use (pathscomp0 (! (maponpaths (fun h' : _ => k · h') X))).
       use (pathscomp0 _ X).
-      rewrite assoc. cbn. apply cancel_postcomposition.
-      apply kH.
+      rewrite assoc; change (dmor _ _) with f.
+      apply cancel_postcomposition, kH.
   Qed.
 
   Definition from_Equalizer_to_Equalizer {a b : C} {f g : C⟦a, b⟧} (E1 E2 : Equalizer f g) :

--- a/UniMath/CategoryTheory/limits/graphs/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/graphs/pullbacks.v
@@ -7,8 +7,9 @@ Require Import UniMath.CategoryTheory.precategories.
 
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
-Local Open Scope cat.
 Require        UniMath.CategoryTheory.limits.pullbacks.
+
+Local Open Scope cat.
 
 Section def_pb.
 
@@ -20,15 +21,15 @@ Definition One : three := ● 0.
 Definition Two : three := ● 1.
 Definition Three : three := ● 2.
 
-Definition pushout_graph : graph.
+Definition pullback_graph : graph.
 Proof.
   exists three.
-  apply (@three_rec (three -> UU)).
+  use three_rec.
   - apply three_rec.
     + apply empty.
     + apply unit.
     + apply empty.
-  - apply (fun _ => empty).
+  - apply (λ _, empty).
   - apply three_rec.
     + apply empty.
     + apply unit.
@@ -36,18 +37,18 @@ Proof.
 Defined.
 
 Definition pullback_diagram {a b c : C} (f : C ⟦b,a⟧) (g : C⟦c,a⟧) :
-  diagram pushout_graph C.
+  diagram pullback_graph C.
 Proof.
   exists (three_rec b a c).
-  use (three_rec_dep); cbn.
-  - use three_rec_dep; cbn.
+  use three_rec_dep.
+  - use three_rec_dep; simpl.
     + apply fromempty.
-    + intro; assumption.
+    + intro x; assumption.
     + apply fromempty.
-  - intro; apply fromempty.
-  - use three_rec_dep; cbn.
+  - intro x; apply fromempty.
+  - use three_rec_dep; simpl.
     + apply fromempty.
-    + intro; assumption.
+    + intro x; assumption.
     + apply fromempty.
 Defined.
 
@@ -56,18 +57,18 @@ Definition PullbCone {a b c : C} (f : C ⟦b,a⟧) (g : C⟦c,a⟧)
            (H : f' · f = g'· g)
   : cone (pullback_diagram f g) d.
 Proof.
-  simple refine (mk_cone _ _  ).
-  - use three_rec_dep; cbn; try assumption.
+  use mk_cone.
+  - use three_rec_dep; try assumption.
     apply (f' · f).
-  - use three_rec_dep; cbn; use three_rec_dep; cbn.
+  - use three_rec_dep; use three_rec_dep.
     + exact (Empty_set_rect _ ).
-    + intro. apply idpath.
-    + exact (Empty_set_rect _ ).
-    + exact (Empty_set_rect _ ).
+    + intro x; apply idpath.
     + exact (Empty_set_rect _ ).
     + exact (Empty_set_rect _ ).
     + exact (Empty_set_rect _ ).
-    + intro; apply (!H).
+    + exact (Empty_set_rect _ ).
+    + exact (Empty_set_rect _ ).
+    + intro x; apply (!H).
     + exact (Empty_set_rect _ ).
 Defined.
 
@@ -89,35 +90,24 @@ Proof.
   intros H' x cx; simpl in *.
   set (H1 := H' x (coneOut cx One) (coneOut cx Three) ).
   simple refine (let p : coneOut cx One · f = coneOut cx Three · g := _ in _ ).
-  - set (H2 := coneOutCommutes cx One Two tt).
-    eapply pathscomp0. apply H2.
-    clear H2.
-    apply pathsinv0.
-    apply (coneOutCommutes cx Three Two tt).
-  - set (H2 := H1 p).
-    simple refine (tpair _ _ _ ).
-    + exists (pr1 (pr1 H2)).
-      use three_rec_dep; cbn.
-      * apply (pr1 (pr2 (pr1 H2))).
-      * unfold compose.
-        simpl.
-        eapply pathscomp0.
-        apply assoc.
-        eapply pathscomp0.
-        eapply cancel_postcomposition.
-        apply (pr2 (pr1 H2)).
-        apply (coneOutCommutes cx One Two tt ).
-      * unfold compose. simpl.
-        set (X := pr2 (pr2 (pr1 H2))). simpl in *. apply X.
-    +  intro t.
-       apply subtypeEquality.
-       * simpl.
-         intro; apply impred; intro. apply hs.
-       * destruct t as [t p0]; simpl.
-         apply path_to_ctr.
-         { split.
-           - apply (p0 One).
-           - apply (p0 Three). }
+  { eapply pathscomp0; [apply (coneOutCommutes cx One Two tt)|].
+    apply pathsinv0, (coneOutCommutes cx Three Two tt). }
+  set (H2 := H1 p).
+  mkpair.
+  + exists (pr1 (pr1 H2)).
+    use three_rec_dep.
+    * apply (pr1 (pr2 (pr1 H2))).
+    * simpl.
+      change (three_rec_dep (λ n, C⟦d,_⟧) _ _ _ _) with (p1 · f).
+      rewrite assoc.
+      eapply pathscomp0.
+        eapply cancel_postcomposition, (pr2 (pr1 H2)).
+      apply (coneOutCommutes cx One Two tt).
+    * apply (pr2 (pr2 (pr1 H2))).
+  + abstract (intro t; apply subtypeEquality;
+              [ intro; apply impred; intro; apply hs
+              | destruct t as [t p0];
+                apply path_to_ctr; split; [ apply (p0 One) | apply (p0 Three) ]]).
 Defined.
 
 (*
@@ -139,10 +129,10 @@ Definition mk_Pullback {a b c : C} (f : C⟦b, a⟧)(g : C⟦c, a⟧)
     (ispb : isPullback f g p1 p2 H)
   : Pullback f g.
 Proof.
-  simple refine (tpair _ _ _ ).
-  - simple refine (tpair _ _ _ ).
+  mkpair.
+  - mkpair.
     + apply d.
-    + simple refine (PullbCone _ _ _ _ _ _ ); assumption.
+    + use PullbCone; assumption.
   - apply ispb.
 Defined.
 
@@ -179,27 +169,11 @@ Proof.
   apply (!limOutCommutes Pb Three Two tt) .
 Qed.
 
-
-
-
 Definition PullbackArrow {a b c : C} {f : C⟦b, a⟧} {g : C⟦c, a⟧}
            (Pb : Pullback f g) e (h : C⟦e, b⟧) (k : C⟦e, c⟧)(H : h · f = k · g)
   : C⟦e, lim Pb⟧.
 Proof.
-  simple refine (limArrow _ _ _ ).
-  simple refine (mk_cone _ _ ).
-  - use three_rec_dep; cbn; try assumption.
-    apply (h · f).
-  - use three_rec_dep; cbn; use three_rec_dep; cbn.
-    + exact (Empty_set_rect _ ).
-    + intro. apply idpath.
-    + exact (Empty_set_rect _ ).
-    + exact (Empty_set_rect _ ).
-    + exact (Empty_set_rect _ ).
-    + exact (Empty_set_rect _ ).
-    + exact (Empty_set_rect _ ).
-    + intro; apply (!H).
-    + exact (Empty_set_rect _ ).
+  now use limArrow; use PullbCone.
 Defined.
 
 Lemma PullbackArrow_PullbackPr1 {a b c : C} {f : C⟦b, a⟧} {g : C⟦c, a⟧}
@@ -225,14 +199,14 @@ Lemma PullbackArrowUnique {a b c d : C} (f : C⟦b, a⟧) (g : C⟦c, a⟧)
   w = PullbackArrow Pb _ h k Hcomm.
 Proof.
   apply path_to_ctr.
-  use three_rec_dep; cbn; try assumption.
+  use three_rec_dep; try assumption.
   set (X:= limOutCommutes Pb Three Two tt).
-  eapply pathscomp0. apply maponpaths.
-   eapply pathsinv0.
-   apply X.
+  eapply pathscomp0.
+    eapply maponpaths, pathsinv0, X.
   simpl.
   rewrite assoc.
-  eapply pathscomp0. apply cancel_postcomposition. apply H2.
+  eapply pathscomp0.
+    apply cancel_postcomposition, H2.
   apply (!Hcomm).
 Qed.
 
@@ -242,8 +216,8 @@ Definition isPullback_Pullback {a b c : C} {f : C⟦b, a⟧}{g : C⟦c, a⟧}
 Proof.
   apply mk_isPullback.
   intros e h k HK.
-  simple refine (tpair _ _ _ ).
-  - simple refine (tpair _ _ _ ).
+  mkpair.
+  - mkpair.
     + apply (PullbackArrow P _ h k HK).
     + split.
       * apply PullbackArrow_PullbackPr1.
@@ -281,15 +255,14 @@ Proof.
         assert (XRT := coneOutCommutes cc One Two tt); simpl in XRT;
         eapply pathscomp0; [| apply (XRT)]; apply idpath
          ).
-    + use three_rec_dep; cbn.
+    + use three_rec_dep.
       * abstract (apply (pullbacks.PullbackArrow_PullbackPr1 XR)).
-      * abstract (
-        simpl; cbn; unfold idfun;
+      * abstract (simpl;
+        change (three_rec_dep (λ n, C⟦d,_⟧) _ _ _ _) with (p1 · f);
         rewrite assoc;
         rewrite  (limits.pullbacks.PullbackArrow_PullbackPr1 XR);
         assert (XRT := coneOutCommutes cc One Two tt); simpl in XRT;
-        eapply pathscomp0; [| apply (XRT)]; apply idpath
-        ).
+        eapply pathscomp0; [| apply (XRT)]; apply idpath).
       * abstract (apply (limits.pullbacks.PullbackArrow_PullbackPr2 XR)).
   - abstract (
     intro t;
@@ -372,10 +345,6 @@ Proof.
            (equiv_isPullback_2 _ _ _ _ _ (isPullback_Pullback X))).
 Defined.
 
-
-
-
-
 Definition identity_is_Pullback_input {a b c : C}{f : C⟦b, a⟧} {g : C⟦c, a⟧} (Pb : Pullback f g) :
  total2 (fun hk : C⟦lim Pb, lim Pb⟧ =>
    dirprod (hk · PullbackPr1 Pb = PullbackPr1 Pb)(hk · PullbackPr2 Pb = PullbackPr2 Pb)).
@@ -383,9 +352,6 @@ Proof.
   exists (identity (lim Pb)).
   apply dirprodpair; apply id_left.
 Defined.
-
-
-
 
 (* was PullbackArrowUnique *)
 Lemma PullbackArrowUnique' {a b c d : C} (f : C⟦b, a⟧) (g : C⟦c, a⟧)
@@ -395,13 +361,10 @@ Lemma PullbackArrowUnique' {a b c d : C} (f : C⟦b, a⟧) (g : C⟦c, a⟧)
   w =  (pr1 (pr1 (P e (PullbCone f g _ h k Hcomm)))).
 Proof.
   apply path_to_ctr.
-  use three_rec_dep; cbn.
-  - assumption.
-  - unfold compose; simpl.
-    eapply pathscomp0. apply assoc.
-    rewrite H1.
-    apply idpath.
-  - assumption.
+  use three_rec_dep; try assumption; simpl.
+  change (three_rec_dep (λ n, C⟦d,_⟧) _ _ _ _) with (p1 · f).
+  change (three_rec_dep (λ n, C⟦e,_⟧) _ _ _ _) with (h · f).
+  now rewrite <- H1, assoc.
 Qed.
 
 

--- a/UniMath/CategoryTheory/limits/graphs/pushouts.v
+++ b/UniMath/CategoryTheory/limits/graphs/pushouts.v
@@ -12,9 +12,9 @@ Require Import UniMath.Combinatorics.StandardFiniteSets.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.limits.pushouts.
 
+Local Open Scope cat.
 
 (** * Definition of pushouts in terms of colimits *)
 Section def_po.
@@ -30,12 +30,12 @@ Section def_po.
   Definition pushout_graph : graph.
   Proof.
     exists three.
-    apply (@three_rec (three -> UU)).
+    use three_rec.
     - apply three_rec.
       + apply empty.
       + apply unit.
       + apply unit.
-    - apply (fun _ => empty).
+    - apply (λ _, empty).
     - apply three_rec.
       + apply empty.
       + apply empty.
@@ -46,29 +46,26 @@ Section def_po.
     diagram pushout_graph C.
   Proof.
     exists (three_rec a b c).
-    use (three_rec_dep); cbn.
+    use three_rec_dep; cbn.
     - use three_rec_dep; cbn.
       + apply fromempty.
-      + intro; assumption.
-      + intro; assumption.
-    - intro; apply fromempty.
-    - use three_rec_dep; cbn.
-      + apply fromempty.
-      + apply fromempty.
-      + apply fromempty.
+      + intros _; exact f.
+      + intros _; exact g.
+    - intros x; apply fromempty.
+    - use three_rec_dep; cbn; apply fromempty.
   Defined.
 
   Definition PushoutCocone {a b c : C} (f : C ⟦a, b⟧) (g : C⟦a, c⟧) (d : C)
              (f' : C ⟦b, d⟧) (g' : C ⟦c, d⟧) (H : f · f' = g · g') :
     cocone (pushout_diagram f g) d.
   Proof.
-    simple refine (mk_cocone _ _  ).
-    - use three_rec_dep; cbn; try assumption.
+    use mk_cocone.
+    - use three_rec_dep; try assumption.
       apply (f · f').
-    - use three_rec_dep; cbn; use three_rec_dep; cbn.
+    - use three_rec_dep; use three_rec_dep.
       + exact (Empty_set_rect _).
-      + intro. apply idpath.
-      + intro. apply (! H).
+      + intros x; apply idpath.
+      + intros x; apply (! H).
       + exact (Empty_set_rect _).
       + exact (Empty_set_rect _).
       + exact (Empty_set_rect _).
@@ -91,30 +88,22 @@ Section def_po.
     set (H1 := H' x (coconeIn cx Two) (coconeIn cx Three)).
     simple refine (let p : f · coconeIn cx Two = g · coconeIn cx Three
                        := _ in _ ).
-    - set (H2 := coconeInCommutes cx One Two tt).
-    eapply pathscomp0. apply H2.
-    clear H2.
-    apply pathsinv0.
-    apply (coconeInCommutes cx One Three tt).
-  - set (H2 := H1 p).
-    simple refine (tpair _ _ _ ).
+    { eapply pathscomp0; [apply (coconeInCommutes cx One Two tt)|].
+      apply pathsinv0, (coconeInCommutes cx One Three tt). }
+    set (H2 := H1 p).
+    mkpair.
     + exists (pr1 (pr1 H2)).
-      use (three_rec_dep); cbn.
-      * use (pathscomp0 _ (coconeInCommutes cx One Two tt)).
-        cbn. unfold idfun.
-        rewrite <- assoc.
-        apply cancel_precomposition.
-        apply (pr1 (pr2 (pr1 H2))).
-      * unfold idfun. apply (pr1 (pr2 (pr1 H2))).
-      * use (pathscomp0 _ (pr2 (pr2 (pr1 H2)))). apply idpath.
-    + intro t.
-       apply subtypeEquality.
-       * intro; apply impred; intro. apply hs.
-       * destruct t as [t p0]; simpl.
-         apply path_to_ctr.
-         { split.
-           - apply (p0 Two).
-           - apply (p0 Three). }
+      use three_rec_dep.
+      * abstract (use (pathscomp0 _ (coconeInCommutes cx One Two tt));
+        change (three_rec_dep _ _ _ _ _) with (f · i1);
+        change (dmor _ _) with f; rewrite <- assoc;
+        apply cancel_precomposition, (pr1 (pr2 (pr1 H2)))).
+      * abstract ( apply (pr1 (pr2 (pr1 H2)))).
+      * abstract (now use (pathscomp0 _ (pr2 (pr2 (pr1 H2))))).
+    + abstract (intro t; apply subtypeEquality;
+               [ intro; apply impred; intro; apply hs
+               | destruct t as [t p0];
+                 apply path_to_ctr; split; [ apply (p0 Two) | apply (p0 Three) ]]).
   Defined.
 
   Definition Pushout {a b c : C} (f : C⟦a, b⟧) (g : C⟦a, c⟧) : UU :=
@@ -124,10 +113,9 @@ Section def_po.
              (i1 : C⟦b,d⟧) (i2 : C ⟦c,d⟧) (H : f · i1 = g · i2)
              (ispo : isPushout f g i1 i2 H) : Pushout f g.
   Proof.
-    simple refine (tpair _ _ _ ).
-    - simple refine (tpair _ _ _ ).
-      + apply d.
-      + simple refine (PushoutCocone _ _ _ _ _ _ ); assumption.
+    mkpair.
+    - exists d.
+      use PushoutCocone; assumption.
     - apply ispo.
   Defined.
 
@@ -155,20 +143,7 @@ Section def_po.
   Definition PushoutArrow {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧} (Po : Pushout f g) (e : C)
              (h : C⟦b, e⟧) (k : C⟦c, e⟧) (H : f · h = g · k) : C⟦colim Po, e⟧.
   Proof.
-    simple refine (colimArrow _ _ _ ).
-    simple refine (mk_cocone _ _ ).
-    - apply three_rec_dep; cbn; try assumption.
-      + apply (f · h).
-    - use three_rec_dep; cbn; use three_rec_dep; cbn.
-      + exact (Empty_set_rect _).
-      + intro. apply idpath.
-      + intro. apply (! H).
-      + exact (Empty_set_rect _).
-      + exact (Empty_set_rect _).
-      + exact (Empty_set_rect _).
-      + exact (Empty_set_rect _).
-      + exact (Empty_set_rect _).
-      + exact (Empty_set_rect _).
+    now use colimArrow; use PushoutCocone.
   Defined.
 
   Lemma PushoutArrow_PushoutIn1 {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧}  (Po : Pushout f g)
@@ -191,11 +166,10 @@ Section def_po.
     w = PushoutArrow Po _ h k Hcomm.
   Proof.
     apply path_to_ctr.
-    use three_rec_dep; cbn; try assumption.
+    use three_rec_dep; try assumption.
     set (X := colimInCommutes Po One Two tt).
     use (pathscomp0 (! (maponpaths (fun h' : _ => h' · w) X))).
-    cbn. unfold idfun. rewrite <- assoc. apply cancel_precomposition.
-    apply H1.
+    now rewrite <- assoc; simpl; rewrite <- H1.
   Qed.
 
   Definition isPushout_Pushout {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧} (P : Pushout f g) :
@@ -203,8 +177,8 @@ Section def_po.
   Proof.
     apply mk_isPushout.
     intros e h k HK.
-    simple refine (tpair _ _ _ ).
-    - simple refine (tpair _ _ _ ).
+    mkpair.
+    - mkpair.
       + apply (PushoutArrow P _ h k HK).
       + split.
         * apply PushoutArrow_PushoutIn1.
@@ -237,9 +211,10 @@ Section def_po.
     w =  (pr1 (pr1 (P e (PushoutCocone f g _ h k Hcomm)))).
   Proof.
     apply path_to_ctr.
-    use three_rec_dep; cbn; try assumption.
-    unfold idfun. rewrite <- assoc. apply cancel_precomposition.
-    apply H1.
+    use three_rec_dep; try assumption; simpl.
+    change (three_rec_dep (λ n, C⟦three_rec a b c n, d⟧) _ _ _ _) with (f · i1).
+    change (three_rec_dep (λ n, C⟦three_rec a b c n, e⟧) _ _ _ _) with (f · h).
+    now rewrite <- assoc, H1.
   Qed.
 
   Lemma PushoutEndo_is_identity {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧} (Po : Pushout f g)
@@ -361,27 +336,22 @@ Section pushout_coincide.
     intros X R cc.
     set (XR := limits.pushouts.mk_Pushout f g d i1 i2 H X).
     use unique_exists.
-
-    use (limits.pushouts.PushoutArrow XR).
-    exact (coconeIn cc Two).
-    exact (coconeIn cc Three).
-    use (pathscomp0 ((coconeInCommutes cc One Two tt))).
-    apply (!(coconeInCommutes cc One Three tt)).
-
-    use three_rec_dep; cbn; unfold idfun.
-    rewrite <- assoc.
-    rewrite (limits.pushouts.PushoutArrow_PushoutIn1 XR).
-    apply (coconeInCommutes cc One Two tt).
-    apply (limits.pushouts.PushoutArrow_PushoutIn1 XR).
-
-    apply (limits.pushouts.PushoutArrow_PushoutIn2 XR).
-
-    intros y. cbn beta. apply impred_isaprop. intros t. apply hs.
-
-    intros y T. cbn in T.
-    use limits.pushouts.PushoutArrowUnique.
-    apply (T Two).
-    apply (T Three).
+    + use (limits.pushouts.PushoutArrow XR).
+      - exact (coconeIn cc Two).
+      - exact (coconeIn cc Three).
+      - use (pathscomp0 ((coconeInCommutes cc One Two tt))).
+        apply (!(coconeInCommutes cc One Three tt)).
+    + use three_rec_dep; simpl.
+      - change (three_rec_dep (λ n, C⟦three_rec a b c n, d⟧) _ _ _ _) with (f · i1).
+        rewrite <- assoc, (limits.pushouts.PushoutArrow_PushoutIn1 XR).
+        apply (coconeInCommutes cc One Two tt).
+      - apply (limits.pushouts.PushoutArrow_PushoutIn1 XR).
+      - apply (limits.pushouts.PushoutArrow_PushoutIn2 XR).
+    + intros y; apply impred_isaprop; intros t; apply hs.
+    + intros y T.
+      use limits.pushouts.PushoutArrowUnique.
+      - apply (T Two).
+      - apply (T Three).
   Qed.
 
   Lemma equiv_isPushout2 {a b c d : C} (f : C⟦a, b⟧) (g : C⟦a, c⟧)
@@ -391,17 +361,19 @@ Section pushout_coincide.
     intros X R k h HH.
     set (XR := mk_Pushout C f g d i1 i2 H X).
     use unique_exists.
-
-    use (PushoutArrow C XR).
-    exact k. exact h. exact HH.
-    split.
-    exact (PushoutArrow_PushoutIn1 C XR R k h HH).
-    exact (PushoutArrow_PushoutIn2 C XR R k h HH).
-    intros y. cbn beta. apply isapropdirprod; apply hs.
-
-    intros y T. cbn in T.
-    use (PushoutArrowUnique C _ _ XR).
-    exact R. exact (pr1 T). exact (pr2 T).
+    + use (PushoutArrow C XR).
+      - exact k.
+      - exact h.
+      - exact HH.
+    + split.
+      - exact (PushoutArrow_PushoutIn1 C XR R k h HH).
+      - exact (PushoutArrow_PushoutIn2 C XR R k h HH).
+    + intros y; apply isapropdirprod; apply hs.
+    + intros y T.
+      use (PushoutArrowUnique C _ _ XR).
+      - exact R.
+      - exact (pr1 T).
+      - exact (pr2 T).
   Qed.
 
 


### PR DESCRIPTION
This PR speed up the compilation time of some files on limits by a lot. This was achieved by removing calls to `cbn` that got very slow recently. While doing this I also cleaned the files a bit (adding bullets and indentation, shorten some proofs, etc.), but there are no new results in this PR.

Before this PR my benchmarks for CT looked like this:
```
user time 200.03: UniMath/CategoryTheory/limits/graphs/pushouts
user time 160.01: UniMath/CategoryTheory/limits/graphs/pullbacks
user time 113.19: UniMath/CategoryTheory/LocalizingClass
user time 77.86: UniMath/CategoryTheory/limits/graphs/equalizers
user time 66.72: UniMath/CategoryTheory/limits/graphs/coequalizers
user time 17.46: UniMath/CategoryTheory/category_hset_structures
user time 16.15: UniMath/CategoryTheory/Subobjects
user time 14.30: UniMath/CategoryTheory/AdditiveFunctors
user time 8.79: UniMath/CategoryTheory/functor_categories
user time 8.52: UniMath/CategoryTheory/EquivalencesExamples
```
after it looks like this:
```
user time 108.40: UniMath/CategoryTheory/LocalizingClass
user time 18.91: UniMath/CategoryTheory/category_hset_structures
user time 13.81: UniMath/CategoryTheory/Subobjects
user time 11.70: UniMath/CategoryTheory/AdditiveFunctors
user time 8.45: UniMath/CategoryTheory/functor_categories
user time 8.32: UniMath/CategoryTheory/Inductives/Lists
user time 7.16: UniMath/CategoryTheory/Adjunctions
user time 7.11: UniMath/CategoryTheory/EquivalencesExamples
user time 5.36: UniMath/CategoryTheory/Inductives/LambdaCalculus
user time 4.89: UniMath/Algebra/Archimedean
```

(I'm running the benchmarks on a shared server with 24 cores and the compilation times might differ a little because of other jobs on it)

The files I changed in this PR now have the following compilation times:
```
user time 1.11: UniMath/CategoryTheory/limits/graphs/pushouts
user time 1.02: UniMath/CategoryTheory/limits/graphs/pullbacks
user time 0.60: UniMath/CategoryTheory/limits/graphs/equalizers
user time 0.59: UniMath/CategoryTheory/limits/graphs/coequalizers
```

So the speed-up is massive.

I'm not sure what to do about LocalizingClass, I had a look at it and removing `cbn` doesn't make a difference. 
