### PR TITLE
Alternative definition of binary coproduct of functors and new proofs that this is omega cocont

### DIFF
--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -28,10 +28,10 @@ This file also contains proofs that the following functors are (omega-)cocontinu
   [is_cocont_bincoproduct_functor] [is_omega_cocont_bincoproduct_functor]
 - General coproduct functor: C^I -> C
   [is_cocont_coproduct_functor] [is_omega_cocont_coproduct_functor]
-- Binary coproduct of functors: F + G : C -> D, x |-> (x,x) |-> (F x,G x) |-> F x
- + G x
-  [is_cocont_BinCoproduct_of_functors_alt] [is_cocont_BinCoproduct_of_functors]
-  [is_omega_cocont_BinCoproduct_of_functors_alt] [is_omega_cocont_BinCoproduct_of_functors]
+- Binary coproduct of functors: F + G : C -> D, x |-> F x + G x
+  [is_cocont_BinCoproduct_of_functors_alt] [is_omega_cocont_BinCoproduct_of_functors_alt]
+  [is_cocont_BinCoproduct_of_functors_alt2] [is_omega_cocont_BinCoproduct_of_functors_alt2]
+  [is_cocont_BinCoproduct_of_functors] [is_omega_cocont_BinCoproduct_of_functors]
 - Coproduct of families of functors: + F_i : C -> D  (generalization of coproduct of functors)
   [is_cocont_coproduct_of_functors_alt] [is_cocont_coproduct_of_functors]
   [is_omega_cocont_coproduct_of_functors_alt] [is_omega_cocont_coproduct_of_functors]
@@ -1089,7 +1089,7 @@ Defined.
 
 Definition omega_cocont_BinCoproduct_of_functors_alt (F G : omega_cocont_functor C D) :
   omega_cocont_functor C D :=
-  tpair _ _ (is_omega_cocont_BinCoproduct_of_functors_alt (pr2 F) (pr2 G)).
+    tpair _ _ (is_omega_cocont_BinCoproduct_of_functors_alt (pr2 F) (pr2 G)).
 
 Lemma is_cocont_BinCoproduct_of_functors (F G : functor C D)
   (HF : is_cocont F) (HG : is_cocont G) :

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -1114,28 +1114,35 @@ Definition omega_cocont_BinCoproduct_of_functors
   omega_cocont_functor C D :=
     tpair _ _ (is_omega_cocont_BinCoproduct_of_functors _ _ (pr2 F) (pr2 G)).
 
-(* Lemma is_cocont_BinCoproduct_of_functors_alt_old (F G : functor C D) *)
-(*   (HF : is_cocont F) (HG : is_cocont G) : *)
-(*   is_cocont (BinCoproduct_of_functors_alt_old HD F G). *)
-(* Proof. *)
-(* exact (transportf _ *)
-(*          (BinCoproduct_of_functors_alt_eq_BinCoproduct_of_functors_alt_old _ _ _ _ F G) *)
-(*          (is_cocont_BinCoproduct_of_functors_alt HF HG)). *)
-(* Defined. *)
+(* Keep these as they have better computational behavior than the one for _alt above *)
+Lemma is_cocont_BinCoproduct_of_functors_alt2 {hsC : has_homsets C}
+  (PC : BinProducts C) (F G : functor C D)
+  (HF : is_cocont F) (HG : is_cocont G) :
+  is_cocont (BinCoproduct_of_functors_alt2 HD F G).
+Proof.
+apply (is_cocont_functor_composite hsD).
+  apply (is_cocont_bindelta_functor PC hsC).
+apply (is_cocont_functor_composite hsD).
+  apply (is_cocont_pair_functor _ _ hsC hsC hsD hsD HF HG).
+apply (is_cocont_bincoproduct_functor _ hsD).
+Defined.
 
-(* Lemma is_omega_cocont_BinCoproduct_of_functors_alt_old (F G : functor C D) *)
-(*   (HF : is_omega_cocont F) (HG : is_omega_cocont G) : *)
-(*   is_omega_cocont (BinCoproduct_of_functors_alt_old HD F G). *)
-(* Proof. *)
-(* exact (transportf _ *)
-(*          (BinCoproduct_of_functors_alt_eq_BinCoproduct_of_functors_alt_old _ _ _ _ F G) *)
-(*          (is_omega_cocont_BinCoproduct_of_functors_alt HF HG)). *)
-(* Defined. *)
+Lemma is_omega_cocont_BinCoproduct_of_functors_alt2 (hsC : has_homsets C)
+  (PC : BinProducts C) (F G : functor C D)
+  (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
+  is_omega_cocont (BinCoproduct_of_functors_alt2 HD F G).
+Proof.
+apply (is_omega_cocont_functor_composite hsD).
+  apply (is_omega_cocont_bindelta_functor PC hsC).
+apply (is_omega_cocont_functor_composite hsD).
+  apply (is_omega_cocont_pair_functor _ _ hsC hsC hsD hsD HF HG).
+apply (is_omega_cocont_bincoproduct_functor _ hsD).
+Defined.
 
-(* Definition omega_cocont_BinCoproduct_of_functors_alt_old *)
-(*  (F G : omega_cocont_functor C D) : *)
-(*   omega_cocont_functor C D := *)
-(*     tpair _ _ (is_omega_cocont_BinCoproduct_of_functors_alt_old _ _ (pr2 F) (pr2 G)). *)
+Definition omega_cocont_BinCoproduct_of_functors_alt2 (hsC : has_homsets C)
+  (PC : BinProducts C) (F G : omega_cocont_functor C D) :
+  omega_cocont_functor C D :=
+    tpair _ _ (is_omega_cocont_BinCoproduct_of_functors_alt2 hsC PC _ _ (pr2 F) (pr2 G)).
 
 End BinCoproduct_of_functors.
 
@@ -1771,14 +1778,14 @@ Notation "'Id'" := (omega_cocont_functor_identity has_homsets_HSET) :
                      cocont_functor_hset_scope.
 
 Notation "F * G" :=
-  (omega_cocont_BinProduct_of_functors BinProductsHSET _
+  (omega_cocont_BinProduct_of_functors_alt BinProductsHSET _
      has_homsets_HSET has_homsets_HSET
      (is_omega_cocont_constprod_functor1 _ has_homsets_HSET has_exponentials_HSET)
      F G) : cocont_functor_hset_scope.
 
 Notation "F + G" :=
-  (omega_cocont_BinCoproduct_of_functors
-     BinCoproductsHSET has_homsets_HSET F G) : cocont_functor_hset_scope.
+  (omega_cocont_BinCoproduct_of_functors_alt2
+     BinCoproductsHSET has_homsets_HSET has_homsets_HSET BinProductsHSET F G) : cocont_functor_hset_scope.
 
 Notation "1" := (unitHSET) : cocont_functor_hset_scope.
 Notation "0" := (emptyHSET) : cocont_functor_hset_scope.

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -1114,28 +1114,28 @@ Definition omega_cocont_BinCoproduct_of_functors
   omega_cocont_functor C D :=
     tpair _ _ (is_omega_cocont_BinCoproduct_of_functors _ _ (pr2 F) (pr2 G)).
 
-Lemma is_cocont_BinCoproduct_of_functors_alt_old (F G : functor C D)
-  (HF : is_cocont F) (HG : is_cocont G) :
-  is_cocont (BinCoproduct_of_functors_alt_old HD F G).
-Proof.
-exact (transportf _
-         (BinCoproduct_of_functors_alt_eq_BinCoproduct_of_functors_alt_old _ _ _ _ F G)
-         (is_cocont_BinCoproduct_of_functors_alt HF HG)).
-Defined.
+(* Lemma is_cocont_BinCoproduct_of_functors_alt_old (F G : functor C D) *)
+(*   (HF : is_cocont F) (HG : is_cocont G) : *)
+(*   is_cocont (BinCoproduct_of_functors_alt_old HD F G). *)
+(* Proof. *)
+(* exact (transportf _ *)
+(*          (BinCoproduct_of_functors_alt_eq_BinCoproduct_of_functors_alt_old _ _ _ _ F G) *)
+(*          (is_cocont_BinCoproduct_of_functors_alt HF HG)). *)
+(* Defined. *)
 
-Lemma is_omega_cocont_BinCoproduct_of_functors_alt_old (F G : functor C D)
-  (HF : is_omega_cocont F) (HG : is_omega_cocont G) :
-  is_omega_cocont (BinCoproduct_of_functors_alt_old HD F G).
-Proof.
-exact (transportf _
-         (BinCoproduct_of_functors_alt_eq_BinCoproduct_of_functors_alt_old _ _ _ _ F G)
-         (is_omega_cocont_BinCoproduct_of_functors_alt HF HG)).
-Defined.
+(* Lemma is_omega_cocont_BinCoproduct_of_functors_alt_old (F G : functor C D) *)
+(*   (HF : is_omega_cocont F) (HG : is_omega_cocont G) : *)
+(*   is_omega_cocont (BinCoproduct_of_functors_alt_old HD F G). *)
+(* Proof. *)
+(* exact (transportf _ *)
+(*          (BinCoproduct_of_functors_alt_eq_BinCoproduct_of_functors_alt_old _ _ _ _ F G) *)
+(*          (is_omega_cocont_BinCoproduct_of_functors_alt HF HG)). *)
+(* Defined. *)
 
-Definition omega_cocont_BinCoproduct_of_functors_alt_old
- (F G : omega_cocont_functor C D) :
-  omega_cocont_functor C D :=
-    tpair _ _ (is_omega_cocont_BinCoproduct_of_functors_alt_old _ _ (pr2 F) (pr2 G)).
+(* Definition omega_cocont_BinCoproduct_of_functors_alt_old *)
+(*  (F G : omega_cocont_functor C D) : *)
+(*   omega_cocont_functor C D := *)
+(*     tpair _ _ (is_omega_cocont_BinCoproduct_of_functors_alt_old _ _ (pr2 F) (pr2 G)). *)
 
 End BinCoproduct_of_functors.
 
@@ -1771,22 +1771,14 @@ Notation "'Id'" := (omega_cocont_functor_identity has_homsets_HSET) :
                      cocont_functor_hset_scope.
 
 Notation "F * G" :=
-  (omega_cocont_BinProduct_of_functors_alt BinProductsHSET _
+  (omega_cocont_BinProduct_of_functors BinProductsHSET _
      has_homsets_HSET has_homsets_HSET
      (is_omega_cocont_constprod_functor1 _ has_homsets_HSET has_exponentials_HSET)
      F G) : cocont_functor_hset_scope.
 
 Notation "F + G" :=
-  (omega_cocont_BinCoproduct_of_functors_alt_old
+  (omega_cocont_BinCoproduct_of_functors
      BinCoproductsHSET has_homsets_HSET F G) : cocont_functor_hset_scope.
-
-(* omega_cocont_coproduct_functor has worse computational behavior
-   than omega_cocont_coproduct_of_functors and breaks
-   isalghom_pr1foldr in lists *)
-(* Notation "F + G" := *)
-(*   (omega_cocont_coproduct_functor _ _ ProductsHSET CoproductsHSET *)
-(*      has_homsets_HSET has_homsets_HSET _ _ (pr2 F) (pr2 G)) : *)
-(*     cocont_functor_hset_scope. *)
 
 Notation "1" := (unitHSET) : cocont_functor_hset_scope.
 Notation "0" := (emptyHSET) : cocont_functor_hset_scope.

--- a/UniMath/CategoryTheory/Inductives/LambdaCalculus.v
+++ b/UniMath/CategoryTheory/Inductives/LambdaCalculus.v
@@ -16,7 +16,6 @@ Require Import UniMath.Foundations.NaturalNumbers.
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.category_hset.
 Require Import UniMath.CategoryTheory.category_hset_structures.
@@ -32,6 +31,8 @@ Require Import UniMath.CategoryTheory.EquivalencesExamples.
 Require Import UniMath.CategoryTheory.CocontFunctors.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.whiskering.
+
+Local Open Scope cat.
 
 Local Notation "'chain'" := (diagram nat_graph).
 
@@ -78,8 +79,7 @@ Local Notation "F * G" :=
      (is_omega_cocont_constprod_functor1 _ has_homsets_HSET2 has_exponentials_HSET2) F G).
 
 Local Notation "F + G" :=
-  (omega_cocont_BinCoproduct_of_functors_alt BinProductsHSET2 BinCoproductsHSET2
-     has_homsets_HSET2 has_homsets_HSET2 F G).
+  (omega_cocont_BinCoproduct_of_functors BinCoproductsHSET2 has_homsets_HSET2 F G).
 
 Local Notation "'_' 'o' 'option'" :=
   (omega_cocont_pre_composition_functor

--- a/UniMath/CategoryTheory/Inductives/Lists.v
+++ b/UniMath/CategoryTheory/Inductives/Lists.v
@@ -237,13 +237,13 @@ Definition sum : List natHSET -> nat :=
 (* Eval vm_compute in sum testlistS. *)
 
 (* All of these compute *)
-(* Eval lazy in length _ (nil natHSET). *)
-(* Eval lazy in length _ testlist. *)
-(* Eval lazy in length _ testlistS. *)
-(* Eval lazy in sum testlist. *)
-(* Eval lazy in sum testlistS. *)
-(* Eval lazy in length _ (concatenate _ testlist testlistS). *)
-(* Eval lazy in sum (concatenate _ testlist testlistS). *)
+Eval lazy in length _ (nil natHSET).
+Eval lazy in length _ testlist.
+Eval lazy in length _ testlistS.
+Eval lazy in sum testlist.
+Eval lazy in sum testlistS.
+Eval lazy in length _ (concatenate _ testlist testlistS).
+Eval lazy in sum (concatenate _ testlist testlistS).
 
 Goal (∏ l, length _ (2 :: l) = S (length _ l)).
 simpl.
@@ -333,7 +333,7 @@ Defined.
 (* Eval compute in (to_list _ testlist). *)
 
 (* This does compute: *)
-(* Eval lazy in (to_list _ testlist). *)
+Eval lazy in (to_list _ testlist).
 
 
 End list.

--- a/UniMath/CategoryTheory/Inductives/Lists.v
+++ b/UniMath/CategoryTheory/Inductives/Lists.v
@@ -236,7 +236,7 @@ Definition sum : List natHSET -> nat :=
 (* Eval vm_compute in sum testlist. *)
 (* Eval vm_compute in sum testlistS. *)
 
-(* None of these compute *)
+(* All of these compute *)
 (* Eval lazy in length _ (nil natHSET). *)
 (* Eval lazy in length _ testlist. *)
 (* Eval lazy in length _ testlistS. *)
@@ -332,7 +332,7 @@ Defined.
 (* This doesn't compute: *)
 (* Eval compute in (to_list _ testlist). *)
 
-(* This doesn't compute: *)
+(* This does compute: *)
 (* Eval lazy in (to_list _ testlist). *)
 
 

--- a/UniMath/CategoryTheory/Inductives/Lists.v
+++ b/UniMath/CategoryTheory/Inductives/Lists.v
@@ -15,7 +15,6 @@ Require Import UniMath.Combinatorics.Lists.
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.category_hset.
 Require Import UniMath.CategoryTheory.category_hset_structures.
@@ -26,6 +25,9 @@ Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.CocontFunctors.
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
+Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
+
+Local Open Scope cat.
 
 (** * Lists as the colimit of a chain given by the list functor: F(X) = 1 + A * X *)
 Section lists.
@@ -60,12 +62,12 @@ Let List_alg : algebra_ob listFunctor :=
   InitialObject listFunctor_Initial.
 
 Definition nil_map : HSET⟦unitHSET,μL_A⟧ :=
-  BinCoproductIn1 HSET _ · List_mor.
+  BinCoproductIn1 _ (BinCoproductsHSET _ _) · List_mor.
 
 Definition nil : List := nil_map tt.
 
 Definition cons_map : HSET⟦(A × μL_A)%set,μL_A⟧ :=
-  BinCoproductIn2 HSET _ · List_mor.
+  BinCoproductIn2 _ (BinCoproductsHSET _ _) · List_mor.
 
 Definition cons : pr1 A → List -> List := λ a l, cons_map (a,,l).
 
@@ -143,8 +145,9 @@ Opaque is_omega_cocont_listFunctor.
 Lemma isalghom_pr1foldr :
   is_algebra_mor _ List_alg List_alg (fun l => pr1 (foldr P'HSET P0' Pc' l)).
 Proof.
-apply BinCoproductArrow_eq_cor.
-- apply funextfun; intro x; destruct x; apply idpath.
+apply (BinCoproductArrow_eq_cor _ BinCoproductsHSET).
+- apply funextfun; intro x; induction x.
+  apply (maponpaths pr1 (foldr_nil P'HSET P0' Pc')).
 - apply funextfun; intro x; destruct x as [a l].
   apply (maponpaths pr1 (foldr_cons P'HSET P0' Pc' a l)).
 Qed.
@@ -200,9 +203,8 @@ Lemma length_map (f : A -> A) : ∏ xs, length (map f xs) = length xs.
 Proof.
 apply listIndProp.
 - intros l; apply isasetnat.
-- apply idpath.
+- now unfold map; rewrite foldr_nil.
 - simpl; unfold map, length; simpl; intros a l Hl.
-  simpl.
   now rewrite !foldr_cons, <- Hl.
 Qed.
 
@@ -234,14 +236,14 @@ Definition sum : List natHSET -> nat :=
 (* Eval vm_compute in sum testlist. *)
 (* Eval vm_compute in sum testlistS. *)
 
-(* All of these compute *)
-Eval lazy in length _ (nil natHSET).
-Eval lazy in length _ testlist.
-Eval lazy in length _ testlistS.
-Eval lazy in sum testlist.
-Eval lazy in sum testlistS.
-Eval lazy in length _ (concatenate _ testlist testlistS).
-Eval lazy in sum (concatenate _ testlist testlistS).
+(* None of these compute *)
+(* Eval lazy in length _ (nil natHSET). *)
+(* Eval lazy in length _ testlist. *)
+(* Eval lazy in length _ testlistS. *)
+(* Eval lazy in sum testlist. *)
+(* Eval lazy in sum testlistS. *)
+(* Eval lazy in length _ (concatenate _ testlist testlistS). *)
+(* Eval lazy in sum (concatenate _ testlist testlistS). *)
 
 Goal (∏ l, length _ (2 :: l) = S (length _ l)).
 simpl.
@@ -330,8 +332,8 @@ Defined.
 (* This doesn't compute: *)
 (* Eval compute in (to_list _ testlist). *)
 
-(* This does compute: *)
-Eval lazy in (to_list _ testlist).
+(* This doesn't compute: *)
+(* Eval lazy in (to_list _ testlist). *)
 
 
 End list.
@@ -536,15 +538,8 @@ Lemma foldr_cons (X : hSet) (x : X) (f : pr1 A × X -> X)
 Proof.
 assert (F := maponpaths (fun x => BinCoproductIn2 _ (BinCoproductsHSET _ _) · x)
                         (algebra_mor_commutes _ _ _ (foldr_map X x f))).
-assert (Fal := toforallpaths _ _ _ F (a,,l)).
-clear F.
-(* apply Fal. *) (* This doesn't work here. why? *)
-unfold compose in Fal.
-simpl in Fal.
-exact Fal.
-Opaque foldr_map.
-Qed. (* This Qed is slow unless one has the Opaque command above *)
-Transparent foldr_map.
+apply (toforallpaths _ _ _ F (a,,l)).
+Qed.
 
 (* This defines the induction principle for lists using foldr *)
 Section list_induction.

--- a/UniMath/CategoryTheory/Inductives/Trees.v
+++ b/UniMath/CategoryTheory/Inductives/Trees.v
@@ -250,6 +250,5 @@ Proof.
   - exact t.
 Defined.
 
-(* These doesn't work any more: *)
-(* Eval lazy in Lists.sum (flatten _ testtree). *)
-(* Eval lazy in sum testtree. *)
+Eval lazy in Lists.sum (flatten _ testtree).
+Eval lazy in sum testtree.

--- a/UniMath/CategoryTheory/Inductives/Trees.v
+++ b/UniMath/CategoryTheory/Inductives/Trees.v
@@ -154,7 +154,8 @@ Lemma isalghom_pr1foldr :
   is_algebra_mor _ Tree_alg Tree_alg (fun l => pr1 (foldr P'HSET P0' Pc' l)).
 Proof.
 apply BinCoproductArrow_eq_cor.
-- apply funextfun; intro x; destruct x; apply idpath.
+- apply funextfun; intro x; destruct x.
+  apply (maponpaths pr1 (foldr_leaf P'HSET P0' Pc')).
 - apply funextfun; intro x; destruct x as [a [l1 l2]].
   apply (maponpaths pr1 (foldr_node P'HSET P0' Pc' a l1 l2)).
 Qed.
@@ -211,9 +212,8 @@ Lemma size_map (f : nat -> nat) : ∏ l, size (map f l) = size l.
 Proof.
 apply treeIndProp.
 - intros l. apply isasetnat.
-- apply idpath.
-- intros a l1 l2 ih1 ih2.
-  unfold map.
+- now unfold map; rewrite foldr_leaf.
+- intros a l1 l2 ih1 ih2; unfold map.
   now rewrite foldr_node, !size_node, <- ih1, <- ih2.
 Qed.
 
@@ -250,5 +250,6 @@ Proof.
   - exact t.
 Defined.
 
-Eval lazy in Lists.sum (flatten _ testtree).
-Eval lazy in sum testtree.
+(* These doesn't work any more: *)
+(* Eval lazy in Lists.sum (flatten _ testtree). *)
+(* Eval lazy in sum testtree. *)

--- a/UniMath/CategoryTheory/ProductPrecategory.v
+++ b/UniMath/CategoryTheory/ProductPrecategory.v
@@ -78,7 +78,7 @@ Qed.
 
 End power_precategory.
 
-
+(* TODO: Some of the functors in this section can be defined in terms of each other *)
 Section functors.
 
 Definition family_functor_data (I : UU) {A B : I -> precategory}
@@ -131,5 +131,31 @@ Proof.
 apply (tpair _ (delta_functor_data I C)).
 abstract (split; intros x *; apply idpath).
 Defined.
+
+Definition tuple_functor_data {I : UU} {A : precategory} {B : I → precategory}
+  (F : ∏ i, functor A (B i)) : functor_data A (product_precategory I B).
+Proof.
+mkpair.
+- intros a i; exact (F i a).
+- intros a b f i; exact (# (F i) f).
+Defined.
+
+Lemma tuple_functor_axioms {I : UU} {A : precategory} {B : I → precategory}
+  (F : ∏ i, functor A (B i)) : is_functor (tuple_functor_data F).
+Proof.
+split.
+- intros a. apply funextsec; intro i. apply functor_id.
+- intros ? ? ? ? ?. apply funextsec; intro i. apply functor_comp.
+Qed.
+
+Definition tuple_functor {I : UU} {A : precategory} {B : I → precategory}
+  (F : ∏ i, functor A (B i)) : functor A (product_precategory I B)
+    := (tuple_functor_data F,, tuple_functor_axioms F).
+
+Definition pr_tuple_functor {I : UU} {A : precategory} {B : I → precategory} (hsB : ∏ i, has_homsets (B i))
+  (F : ∏ i, functor A (B i)) (i : I) : tuple_functor F ∙ pr_functor I B i = F i.
+Proof.
+now apply functor_eq.
+Qed.
 
 End functors.

--- a/UniMath/CategoryTheory/ProductPrecategory.v
+++ b/UniMath/CategoryTheory/ProductPrecategory.v
@@ -5,7 +5,10 @@ Anders Mörtberg
 
 2016
 
-Definition of the general product category
+Contents:
+
+- Definition of the general product category ([product_precategory])
+- Tuple functor ([tuple_functor])
 
 ************************************************************)
 
@@ -13,6 +16,7 @@ Require Import UniMath.Foundations.PartD.
 
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
+
 Local Open Scope cat.
 
 Section dep_product_precategory.
@@ -152,7 +156,7 @@ Definition tuple_functor {I : UU} {A : precategory} {B : I → precategory}
   (F : ∏ i, functor A (B i)) : functor A (product_precategory I B)
     := (tuple_functor_data F,, tuple_functor_axioms F).
 
-Definition pr_tuple_functor {I : UU} {A : precategory} {B : I → precategory} (hsB : ∏ i, has_homsets (B i))
+Lemma pr_tuple_functor {I : UU} {A : precategory} {B : I → precategory} (hsB : ∏ i, has_homsets (B i))
   (F : ∏ i, functor A (B i)) (i : I) : tuple_functor F ∙ pr_functor I B i = F i.
 Proof.
 now apply functor_eq.

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -682,21 +682,22 @@ abstract (split;
   | now intros x y z f g; simpl; rewrite BinCoproductOfArrows_comp ]).
 Defined.
 
+(* Defines the copropuct of two functors *)
+Definition BinCoproduct_of_functors_alt {C D : precategory}
+  (hsD : has_homsets D) (HD : BinCoproducts D) (F G : C ⟶ D) : C ⟶ D :=
+    tuple_functor (λ b, bool_rect (λ _, C ⟶ D) F G b) ∙
+    coproduct_functor bool (CoproductsBool hsD HD).
+
 (* Defines the copropuct of two functors by:
     x -> (x,x) -> (F x,G x) -> F x + G x
 
   For a direct and equal definition see FunctorsPointwiseBinCoproduct.v
 
-  Below follows a slightly simpler definition
+  Above is a slightly simpler definition
 *)
-Definition BinCoproduct_of_functors_alt_old {C D : precategory}
+Definition BinCoproduct_of_functors_alt2 {C D : precategory}
   (HD : BinCoproducts D) (F G : functor C D) : functor C D :=
     bindelta_functor C ∙ (pair_functor F G ∙ bincoproduct_functor HD).
-
-Definition BinCoproduct_of_functors_alt {C D : precategory}
-  (hsD : has_homsets D) (HD : BinCoproducts D) (F G : C ⟶ D) : C ⟶ D :=
-    tuple_functor (λ b, bool_rect (λ _, C ⟶ D) F G b) ∙
-    coproduct_functor bool (CoproductsBool hsD HD).
 
 End functors.
 
@@ -792,8 +793,8 @@ Qed.
 Definition BinCoproduct_of_functors : functor C D :=
   tpair _ _ is_functor_BinCoproduct_of_functors_data.
 
-Lemma BinCoproduct_of_functors_alt_old_eq_BinCoproduct_of_functors :
-  BinCoproduct_of_functors_alt_old HD F G = BinCoproduct_of_functors.
+Lemma BinCoproduct_of_functors_alt2_eq_BinCoproduct_of_functors :
+  BinCoproduct_of_functors_alt2 HD F G = BinCoproduct_of_functors.
 Proof.
 now apply (functor_eq _ _ hsD).
 Defined.
@@ -804,8 +805,8 @@ Proof.
 now apply (functor_eq _ _ hsD).
 Defined.
 
-Lemma BinCoproduct_of_functors_alt_eq_BinCoproduct_of_functors_alt_old :
-  BinCoproduct_of_functors_alt hsD HD F G = BinCoproduct_of_functors_alt_old HD F G.
+Lemma BinCoproduct_of_functors_alt_eq_BinCoproduct_of_functors_alt2 :
+  BinCoproduct_of_functors_alt hsD HD F G = BinCoproduct_of_functors_alt2 HD F G.
 Proof.
 now apply (functor_eq _ _ hsD).
 Defined.

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -20,13 +20,16 @@ Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
 Require Import UniMath.CategoryTheory.total2_paths.
-Require Import UniMath.CategoryTheory.precategories
-               UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
+Require Import UniMath.CategoryTheory.precategories.
+Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
 Require Import UniMath.CategoryTheory.limits.zero.
 Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.limits.coproducts.
+Require Import UniMath.CategoryTheory.ProductPrecategory.
+
+Local Open Scope cat.
 
 (** * Definition of binary coproduct of objects in a precategory *)
 Section coproduct_def.
@@ -632,6 +635,28 @@ Defined.
 
 End BinCoproducts_from_Colims.
 
+(** * Coproducts over bool from binary coproducts *)
+Section CoproductsBool.
+
+Lemma CoproductsBool {C : precategory} (hsC : has_homsets C)
+  (HC : BinCoproducts C) : Coproducts bool C.
+Proof.
+intros H.
+use mk_CoproductCocone.
+- apply (HC (H true) (H false)).
+- induction i; apply (pr1 (HC (H true) (H false))).
+- use (mk_isCoproductCocone _ _ hsC); intros c f.
+  induction (pr2 (HC (H true) (H false)) c (f true) (f false)) as [[x1 [x2 x3]] x4].
+  use unique_exists.
+  + apply x1.
+  + cbn; induction i; assumption.
+  + intros x; apply impred; intros; apply hsC.
+  + intros h1 h2.
+    apply (maponpaths pr1 (x4 (h1,,(h2 true,,h2 false)))).
+Defined.
+
+End CoproductsBool.
+
 Section functors.
 
 Definition bincoproduct_functor_data {C : precategory} (PC : BinCoproducts C) :
@@ -662,11 +687,16 @@ Defined.
 
   For a direct and equal definition see FunctorsPointwiseBinCoproduct.v
 
+  Below follows a slightly simpler definition
 *)
-Definition BinCoproduct_of_functors_alt {C D : precategory}
+Definition BinCoproduct_of_functors_alt_old {C D : precategory}
   (HD : BinCoproducts D) (F G : functor C D) : functor C D :=
-  functor_composite (bindelta_functor C)
-     (functor_composite (pair_functor F G) (bincoproduct_functor HD)).
+    bindelta_functor C ∙ (pair_functor F G ∙ bincoproduct_functor HD).
+
+Definition BinCoproduct_of_functors_alt {C D : precategory}
+  (hsD : has_homsets D) (HD : BinCoproducts D) (F G : C ⟶ D) : C ⟶ D :=
+    tuple_functor (λ b, bool_rect (λ _, C ⟶ D) F G b) ∙
+    coproduct_functor bool (CoproductsBool hsD HD).
 
 End functors.
 
@@ -762,8 +792,20 @@ Qed.
 Definition BinCoproduct_of_functors : functor C D :=
   tpair _ _ is_functor_BinCoproduct_of_functors_data.
 
+Lemma BinCoproduct_of_functors_alt_old_eq_BinCoproduct_of_functors :
+  BinCoproduct_of_functors_alt_old HD F G = BinCoproduct_of_functors.
+Proof.
+now apply (functor_eq _ _ hsD).
+Defined.
+
 Lemma BinCoproduct_of_functors_alt_eq_BinCoproduct_of_functors :
-  BinCoproduct_of_functors_alt HD F G = BinCoproduct_of_functors.
+  BinCoproduct_of_functors_alt hsD HD F G = BinCoproduct_of_functors.
+Proof.
+now apply (functor_eq _ _ hsD).
+Defined.
+
+Lemma BinCoproduct_of_functors_alt_eq_BinCoproduct_of_functors_alt_old :
+  BinCoproduct_of_functors_alt hsD HD F G = BinCoproduct_of_functors_alt_old HD F G.
 Proof.
 now apply (functor_eq _ _ hsD).
 Defined.

--- a/UniMath/CategoryTheory/limits/coproducts.v
+++ b/UniMath/CategoryTheory/limits/coproducts.v
@@ -205,15 +205,16 @@ Defined.
 
 End functors.
 
-(* The arbitrary copropuct of a family of functors *)
-(* This is the old and not so good definition *)
+(* The copropuct of a family of functors *)
+(* This is the old and not so good definition as it is unnecessarily complicated, also the proof
+   that it is omega-cocontinuous requires that C has products *)
 Definition coproduct_of_functors_alt_old (I : UU) {C D : precategory}
   (HD : Coproducts I D) (F : I -> functor C D) : functor C D :=
   functor_composite (delta_functor I C)
      (functor_composite (family_functor _ F)
                         (coproduct_functor _ HD)).
 
-(* The arbitrary copropuct of a family of functors *)
+(** The copropuct of a family of functors *)
 Definition coproduct_of_functors_alt (I : UU) {C D : precategory}
   (HD : Coproducts I D) (F : ∏ (i : I), functor C D)
   := functor_composite (tuple_functor F) (coproduct_functor _ HD).

--- a/UniMath/CategoryTheory/limits/coproducts.v
+++ b/UniMath/CategoryTheory/limits/coproducts.v
@@ -17,9 +17,10 @@ Require Import UniMath.Foundations.Sets.
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.ProductPrecategory.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+
+Local Open Scope cat.
 
 (** * Definition of indexed coproducts of objects in a precategory *)
 Section coproduct_def.

--- a/UniMath/CategoryTheory/limits/coproducts.v
+++ b/UniMath/CategoryTheory/limits/coproducts.v
@@ -204,12 +204,19 @@ Defined.
 
 End functors.
 
-(* Defines the arbitrary copropuct of a family of functors *)
-Definition coproduct_of_functors_alt (I : UU) {C D : precategory}
+(* The arbitrary copropuct of a family of functors *)
+(* This is the old and not so good definition *)
+Definition coproduct_of_functors_alt_old (I : UU) {C D : precategory}
   (HD : Coproducts I D) (F : I -> functor C D) : functor C D :=
   functor_composite (delta_functor I C)
      (functor_composite (family_functor _ F)
                         (coproduct_functor _ HD)).
+
+(* The arbitrary copropuct of a family of functors *)
+Definition coproduct_of_functors_alt (I : UU) {C D : precategory}
+  (HD : Coproducts I D) (F : ∏ (i : I), functor C D)
+  := functor_composite (tuple_functor F) (coproduct_functor _ HD).
+
 
 (** * Coproducts lift to functor categories *)
 Section def_functor_pointwise_coprod.
@@ -256,6 +263,12 @@ Qed.
 
 Definition coproduct_of_functors : functor C D :=
   tpair _ _ is_functor_coproduct_of_functors_data.
+
+Lemma coproduct_of_functors_alt_old_eq_coproduct_of_functors :
+  coproduct_of_functors_alt_old _ HD F = coproduct_of_functors.
+Proof.
+now apply (functor_eq _ _ hsD).
+Defined.
 
 Lemma coproduct_of_functors_alt_eq_coproduct_of_functors :
   coproduct_of_functors_alt _ HD F = coproduct_of_functors.

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -619,3 +619,18 @@ apply (@iscontrweqb _ (∑ y : C ⟦ L, G M ⟧,
 Defined.
 
 End map.
+
+Section mapcocone_functor_composite.
+
+Context {A B C : precategory} (hsC : has_homsets C)
+        (F : functor A B) (G : functor B C).
+
+Lemma mapcocone_functor_composite {g : graph} {D : diagram g A} {a : A} (cc : cocone D a) :
+  mapcocone (functor_composite F G) _ cc = mapcocone G _ (mapcocone F _ cc).
+Proof.
+  apply subtypeEquality.
+  - intros x. repeat (apply impred_isaprop; intro). apply hsC.
+  - reflexivity.
+Qed.
+
+End mapcocone_functor_composite.

--- a/UniMath/SubstitutionSystems/BinSumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/BinSumOfSignatures.v
@@ -22,7 +22,6 @@ Require Import UniMath.Foundations.PartD.
 
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
@@ -32,6 +31,8 @@ Require Import UniMath.SubstitutionSystems.Signatures.
 Require Import UniMath.SubstitutionSystems.Notation.
 Require Import UniMath.CategoryTheory.CocontFunctors.
 Require Import UniMath.CategoryTheory.limits.binproducts.
+
+Local Open Scope cat.
 
 Section binsum_of_signatures.
 
@@ -226,16 +227,14 @@ Proof.
 Defined.
 
 Lemma is_omega_cocont_BinSum_of_Signatures (S1 S2 : Signature C hsC D hs)
-  (h1 : is_omega_cocont S1) (h2 : is_omega_cocont S2) (PC : BinProducts C) :
+  (h1 : is_omega_cocont S1) (h2 : is_omega_cocont S2) :
   is_omega_cocont (BinSum_of_Signatures S1 S2).
 Proof.
 destruct S1 as [F1 [F2 [F3 F4]]]; simpl in *.
 destruct S2 as [G1 [G2 [G3 G4]]]; simpl in *.
 unfold H.
 apply is_omega_cocont_BinCoproduct_of_functors; try assumption.
-- apply (BinProducts_functor_precat _ _ PC).
-- apply functor_category_has_homsets.
-- apply functor_category_has_homsets.
+apply functor_category_has_homsets.
 Defined.
 
 End binsum_of_signatures.

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -195,7 +195,7 @@ Definition SignatureInitialAlgebra
 Proof.
 use colimAlgInitial.
 - apply (Initial_functor_precat _ _ IC).
-- apply (is_omega_cocont_Id_H _ _ _ BPC _ Hs).
+- apply (is_omega_cocont_Id_H _ _ _ _ Hs).
 - apply ColimsFunctorCategory_of_shape, CLC.
 Defined.
 
@@ -287,7 +287,6 @@ Definition SignatureInitialAlgebraHSET (s : Signature HSET has_homsets_HSET _ _)
   Initial (FunctorAlg (Id_H _ _ BinCoproductsHSET s) has_homsets_HSET2).
 Proof.
 apply SignatureInitialAlgebra; try assumption.
-- apply BinProductsHSET.
 - apply InitialHSET.
 - apply ColimsHSET_of_shape.
 Defined.

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -346,7 +346,7 @@ Defined.
 
 (** Construction 46: Datatypes specified by binding signatures (initial algebra of Id_H + H) *)
 Definition SignatureInitialAlgebra :
-  ∏ {C : precategory} (hsC : has_homsets C) (BPC : BinProducts C) (BCC : BinCoproducts C),
+  ∏ {C : precategory} (hsC : has_homsets C) (BCC : BinCoproducts C),
   Initial C → Colims_of_shape nat_graph C
   → ∏ s : Signature C hsC C hsC, is_omega_cocont (Signature_Functor C hsC C hsC s)
   → Initial (FunctorAlg (Id_H C hsC BCC s) (BindingSigToMonad.has_homsets_C2 hsC)).
@@ -357,7 +357,7 @@ Defined.
 (** Theorem 48: Construction of a substitution operation on an initial algebra *)
 Definition InitHSS :
   ∏ (C : precategory) (hsC : has_homsets C) (CP : BinCoproducts C),
-  BinProducts C → Initial C → Colims_of_shape nat_graph C →
+  Initial C → Colims_of_shape nat_graph C →
   ∏ H : Signature C hsC C hsC, is_omega_cocont (pr1 H) → hss_precategory CP H.
 Proof.
 exact @UniMath.SubstitutionSystems.LiftingInitial_alt.InitHSS.
@@ -365,10 +365,9 @@ Defined.
 
 Lemma isInitial_InitHSS :
   ∏ (C : precategory) (hsC : has_homsets C) (CP : BinCoproducts C)
-  (BPC : BinProducts C) (IC : Initial C)
-  (CC : Colims_of_shape nat_graph C) (H : Signature C hsC C hsC)
+  (IC : Initial C) (CC : Colims_of_shape nat_graph C) (H : Signature C hsC C hsC)
   (HH : is_omega_cocont (pr1 H)),
-  isInitial (hss_precategory CP H) (InitHSS C hsC CP BPC IC CC H HH).
+  isInitial (hss_precategory CP H) (InitHSS C hsC CP IC CC H HH).
 Proof.
 exact @UniMath.SubstitutionSystems.LiftingInitial_alt.isInitial_InitHSS.
 Defined.

--- a/UniMath/SubstitutionSystems/LamHSET.v
+++ b/UniMath/SubstitutionSystems/LamHSET.v
@@ -60,8 +60,6 @@ use colimAlgInitial.
 - apply (Initial_functor_precat _ _ InitialHSET).
 - unfold Id_H, Const_plus_H.
   apply is_omega_cocont_BinCoproduct_of_functors.
-  + apply (BinProducts_functor_precat _ _ BinProductsHSET).
-  + apply functor_category_has_homsets.
   + apply functor_category_has_homsets.
   + apply is_omega_cocont_constant_functor; apply functor_category_has_homsets.
   + apply is_omega_cocont_Lam_S.
@@ -79,7 +77,6 @@ Defined.
 Definition LamHSS_Initial_HSET : Initial (hss_precategory BinCoproductsHSET Lam_S).
 Proof.
 apply InitialHSS.
-- apply BinProductsHSET.
 - apply InitialHSET.
 - apply ColimsHSET_of_shape.
 - apply is_omega_cocont_Lam_S.

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -668,8 +668,6 @@ Lemma is_omega_cocont_Lam
   (LC : Colims_of_shape nat_graph C) : is_omega_cocont (Signature_Functor _ _ _ _ Lam_Sig).
 Proof.
 apply is_omega_cocont_BinCoproduct_of_functors.
-- apply (BinProducts_functor_precat _ _ CP).
-- apply functor_category_has_homsets.
 - apply functor_category_has_homsets.
 - apply (is_omega_cocont_App_H hE).
 - apply (is_omega_cocont_Abs_H LC).

--- a/UniMath/SubstitutionSystems/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial_alt.v
@@ -18,7 +18,6 @@ Require Import UniMath.Foundations.PartD.
 
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
-Local Open Scope cat.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.Monads.
 Require Import UniMath.CategoryTheory.limits.binproducts.
@@ -40,11 +39,13 @@ Require Import UniMath.SubstitutionSystems.GenMendlerIteration_alt.
 Require Import UniMath.CategoryTheory.EndofunctorsMonoidal.
 Require Import UniMath.SubstitutionSystems.Notation.
 
+Local Open Scope cat.
+
 Local Coercion alg_carrier : algebra_ob >-> ob.
 
 Section Precategory_Algebra.
 
-Variables (C : precategory) (hsC : has_homsets C) (CP : BinCoproducts C) (BPC : BinProducts C).
+Variables (C : precategory) (hsC : has_homsets C) (CP : BinCoproducts C).
 Variables (IC : Initial C) (CC : Colims_of_shape nat_graph C).
 Variables (H : Signature C hsC C hsC) (HH : is_omega_cocont H).
 
@@ -78,7 +79,6 @@ Defined.
 Lemma is_omega_cocont_Id_H : is_omega_cocont Id_H.
 Proof.
 apply is_omega_cocont_BinCoproduct_of_functors; try apply functor_category_has_homsets.
-- apply (BinProducts_functor_precat _ _ BPC).
 - apply is_omega_cocont_constant_functor, functor_category_has_homsets.
 - apply HH.
 Defined.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -481,9 +481,7 @@ Definition SignatureInitialAlgebraSetSort
 Proof.
 use colimAlgInitial.
 - apply Initial_functor_precat, Initial_slice_precat, InitialHSET.
-- apply (is_omega_cocont_Id_H).
-  + apply BinProducts_HSET_slice.
-  + apply Hs.
+- apply (is_omega_cocont_Id_H), Hs.
 - apply ColimsFunctorCategory_of_shape, slice_precat_colims_of_shape,
         ColimsHSET_of_shape.
 Defined.
@@ -495,7 +493,6 @@ Definition MultiSortedSigToHSS (sig : MultiSortedSig) :
   HSS (MultiSortedSigToSignature sig).
 Proof.
 apply SignatureToHSS.
-+ apply BinProducts_HSET_slice.
 + apply Initial_slice_precat, InitialHSET.
 + apply slice_precat_colims_of_shape, ColimsHSET_of_shape.
 + apply is_omega_cocont_MultiSortedSigToSignature.


### PR DESCRIPTION
In this PR I define a new version the binary coproduct of two functors (called `BinCoproduct_of_functors_alt`). This is defined in the same way as Peter defined `coproduct_of_functors_alt` (i.e. using `tuple_functor`). This gives a more direct proof that this functor is omega cocontinuous if the input functors are which allows me to remove an assumption of the category having binary products in Theorem 48 of our recent paper (see `InitHSS` in FromBindingSigsToMonads_summary.v). 

Note that I had to keep the old version of `BinCoproduct_of_functors_alt`, it is now called `BinCoproduct_of_functors_alt2` and it is still used in CategoryTheory/Inductives/Lists.v. The reason is that the proof that this functor is omega cocontinuous has better computational behavior in the sense that we can compute the length of lists using `lazy`, if I instead use the new `BinCoproduct_of_functors_alt` this doesn't work anymore. 