### PR TITLE
Univalence for abmonoids, rigs, commrigs, rngs, ...

### DIFF
--- a/UniMath/Algebra/BinaryOperations.v
+++ b/UniMath/Algebra/BinaryOperations.v
@@ -193,6 +193,9 @@ Definition invstruct {X : hSet} (opp : binop X) (is : ismonoidop opp) : UU :=
 Definition isgrop {X : hSet} (opp : binop X) : UU :=
   total2 (fun is : ismonoidop opp => invstruct opp is).
 
+Definition mk_isgrop {X : hSet} {opp : binop X} (H1 : ismonoidop opp) (H2 : invstruct opp H1) :
+  isgrop opp := tpair _ H1 H2.
+
 Definition isgroppair {X : hSet} {opp : binop X} (is1 : ismonoidop opp) (is2 : invstruct opp is1) :
   isgrop opp := tpair (fun is : ismonoidop opp => invstruct opp is) is1 is2.
 
@@ -380,6 +383,9 @@ Defined.
 
 Definition isabmonoidop {X : hSet} (opp : binop X) : UU := dirprod (ismonoidop opp) (iscomm opp).
 
+Definition mk_isabmonoidop {X : hSet} {opp : binop X} (H1 : ismonoidop opp) (H2 : iscomm opp) :
+  isabmonoidop opp := dirprodpair H1 H2.
+
 Definition pr1isabmonoidop (X : hSet) (opp : binop X) : isabmonoidop opp -> ismonoidop opp :=
   @pr1 _ _.
 Coercion pr1isabmonoidop : isabmonoidop >-> ismonoidop.
@@ -491,6 +497,9 @@ Opaque abmonoidoprer.
 
 Definition isabgrop {X : hSet} (opp : binop X) : UU := dirprod (isgrop opp) (iscomm opp).
 
+Definition mk_isabgrop {X : hSet} {opp : binop X} (H1 : isgrop opp) (H2 : iscomm opp) :
+  isabgrop opp := dirprodpair H1 H2.
+
 Definition pr1isabgrop (X : hSet) (opp : binop X) : isabgrop opp -> isgrop opp := @pr1 _ _.
 Coercion pr1isabgrop : isabgrop >-> isgrop.
 
@@ -582,11 +591,16 @@ Defined.
 (** *)
 
 Definition isrigops {X : hSet} (opp1 opp2 : binop X) : UU :=
-  dirprod (total2
-             (fun (axs : dirprod (isabmonoidop opp1) (ismonoidop opp2)) =>
-                (dirprod (∏ x : X, paths (opp2 (unel_is (pr1 axs)) x) (unel_is (pr1 axs))))
-                  (∏ x : X, paths (opp2 x (unel_is (pr1 axs))) (unel_is (pr1 axs)))))
-          (isdistr opp1 opp2).
+  (∑ axs : (isabmonoidop opp1) × (ismonoidop opp2),
+           (∏ x : X, (opp2 (unel_is (pr1 axs)) x) = (unel_is (pr1 axs)))
+             × (∏ x : X, (opp2 x (unel_is (pr1 axs))) = (unel_is (pr1 axs))))
+    × (isdistr opp1 opp2).
+
+Definition mk_isrigops {X : hSet} {opp1 opp2 : binop X} (H1 : isabmonoidop opp1)
+           (H2 : ismonoidop opp2) (H3 : ∏ x : X, (opp2 (unel_is H1) x) = (unel_is H1))
+           (H4 : ∏ x : X, (opp2 x (unel_is H1)) = (unel_is H1))
+           (H5 : isdistr opp1 opp2) : isrigops opp1 opp2 :=
+  tpair _ (tpair _ (dirprodpair H1 H2) (dirprodpair H3 H4)) H5.
 
 Definition rigop1axs_is {X : hSet} {opp1 opp2 : binop X} :
   isrigops opp1 opp2 -> isabmonoidop opp1 := fun is : _ => pr1 (pr1 (pr1 is)).
@@ -635,6 +649,10 @@ Defined.
 
 Definition isrngops {X : hSet} (opp1 opp2 : binop X) : UU :=
   dirprod (dirprod (isabgrop opp1) (ismonoidop opp2)) (isdistr opp1 opp2).
+
+Definition mk_isrngops {X : hSet} {opp1 opp2 : binop X} (H1 : isabgrop opp1) (H2 : ismonoidop opp2)
+           (H3 : isdistr opp1 opp2) : isrngops opp1 opp2 :=
+  dirprodpair (dirprodpair H1 H2) H3.
 
 Definition rngop1axs_is {X : hSet} {opp1 opp2 : binop X} : isrngops opp1 opp2 -> isabgrop opp1 :=
   fun is : _ => pr1 (pr1 is).
@@ -1345,6 +1363,9 @@ Notation "x * y" := (op x y) : multoperation_scope.
 
 Definition isbinopfun {X Y : setwithbinop} (f : X -> Y) : UU :=
   ∏ x x' : X, paths (f (op x x')) (op (f x) (f x')).
+
+Definition mk_isbinopfun {X Y : setwithbinop} {f : X -> Y}
+           (H : ∏ x x' : X, f (op x x') = op (f x) (f x')) : isbinopfun f := H.
 
 Lemma isapropisbinopfun {X Y : setwithbinop} (f : X -> Y) : isaprop (isbinopfun f).
 Proof.

--- a/UniMath/Algebra/BinaryOperations.v
+++ b/UniMath/Algebra/BinaryOperations.v
@@ -1509,7 +1509,7 @@ Proof.
   intros X Y.
   use isweqhomot.
   - exact (weqcomp (setwithbinop_univalence_weq1 X Y) (setwithbinop_univalence_weq2 X Y)).
-  - intros e. induction e. use (pathscomp0 weqcomp_to_funcomp_app). use idpath.
+  - intros e. induction e. use weqcomp_to_funcomp_app.
   - use weqproperty.
 Defined.
 Opaque setwithbinop_univalence_isweq.
@@ -2300,7 +2300,7 @@ Proof.
   intros X Y.
   use isweqhomot.
   - exact (weqcomp (setwith2binop_univalence_weq1 X Y) (setwith2binop_univalence_weq2 X Y)).
-  - intros e. induction e. use (pathscomp0 weqcomp_to_funcomp_app). use idpath.
+  - intros e. induction e. use weqcomp_to_funcomp_app.
   - use weqproperty.
 Defined.
 Opaque setwith2binop_univalence_isweq.

--- a/UniMath/Algebra/Domains_and_Fields.v
+++ b/UniMath/Algebra/Domains_and_Fields.v
@@ -514,7 +514,7 @@ Defined.
 (** **** Main definitions *)
 
 Definition isafield (X : commrng) : UU :=
-  ∑ H : isnonzerorng X, (∏ x : X, coprod (multinvpair X x) (paths x 0)).
+  (isnonzerorng X) × (∏ x : X, coprod (multinvpair X x) (paths x 0)).
 
 Lemma isapropisafield (X : commrng) : isaprop (isafield X).
 Proof.

--- a/UniMath/Algebra/Domains_and_Fields.v
+++ b/UniMath/Algebra/Domains_and_Fields.v
@@ -343,7 +343,6 @@ Definition intdomax (X : intdom) :
    We use the following composition
 
                             (X = Y) ≃ (pr1 X = pr1 Y)
-                                    ≃ (rngiso (pr1 X) (pr1 Y))
                                     ≃ (rngiso X Y)
 
   where the second weak equivalence is given by univalence for commrngs, [commrng_univalence].
@@ -357,11 +356,8 @@ Proof.
 Defined.
 Opaque intdom_univalence_weq1.
 
-Definition intdom_univalence_weq2 (X Y : intdom) : (pr1 X = pr1 Y) ≃ (rngiso (pr1 X) (pr1 Y)) :=
+Definition intdom_univalence_weq2 (X Y : intdom) : (pr1 X = pr1 Y) ≃ (rngiso X Y) :=
   commrng_univalence (pr1 X) (pr1 Y).
-
-Definition intdom_univalence_weq3 (X Y : intdom) : (rngiso (pr1 X) (pr1 Y)) ≃ (rngiso X Y) :=
-  idweq (rngiso X Y).
 
 Definition intdom_univalence_map (X Y : intdom) : (X = Y) -> (rngiso X Y).
 Proof.
@@ -372,10 +368,8 @@ Lemma intdom_univalence_isweq (X Y : intdom) : isweq (intdom_univalence_map X Y)
 Proof.
   intros X Y.
   use isweqhomot.
-  - exact (weqcomp (intdom_univalence_weq1 X Y)
-                   (weqcomp (intdom_univalence_weq2 X Y) (intdom_univalence_weq3 X Y))).
+  - exact (weqcomp (intdom_univalence_weq1 X Y) (intdom_univalence_weq2 X Y)).
   - intros e. induction e.
-    use (pathscomp0 weqcomp_to_funcomp_app).
     use (pathscomp0 weqcomp_to_funcomp_app).
     use idpath.
   - use weqproperty.
@@ -567,7 +561,6 @@ Definition fldmultinv {X : fld} (x : X) (ne : neg (paths x 0)) : X := pr1 (fldmu
    We use the following composition
 
                                 (X = Y) ≃ (pr1 X = pr1 Y)
-                                        ≃ (rngiso (pr1 X) (pr1 Y))
                                         ≃ (rngiso X Y)
 
    where the second weak equivalence is given by univalence for commrngs, [commrng_univalence].
@@ -581,11 +574,8 @@ Proof.
 Defined.
 Opaque fld_univalence_weq1.
 
-Definition fld_univalence_weq2 (X Y : fld) : (pr1 X = pr1 Y) ≃ (rngiso (pr1 X) (pr1 Y)) :=
+Definition fld_univalence_weq2 (X Y : fld) : (pr1 X = pr1 Y) ≃ (rngiso X Y) :=
   commrng_univalence (pr1 X) (pr1 Y).
-
-Definition fld_univalence_weq3 (X Y : fld) : (rngiso (pr1 X) (pr1 Y)) ≃ (rngiso X Y) :=
-  idweq (rngiso X Y).
 
 Definition fld_univalence_map (X Y : fld) : (X = Y) -> (rngiso X Y).
 Proof.
@@ -596,10 +586,8 @@ Lemma fld_univalence_isweq (X Y : fld) : isweq (fld_univalence_map X Y).
 Proof.
   intros X Y.
   use isweqhomot.
-  - exact (weqcomp (fld_univalence_weq1 X Y)
-                   (weqcomp (fld_univalence_weq2 X Y) (fld_univalence_weq3 X Y))).
+  - exact (weqcomp (fld_univalence_weq1 X Y) (fld_univalence_weq2 X Y)).
   - intros e. induction e.
-    use (pathscomp0 weqcomp_to_funcomp_app).
     use (pathscomp0 weqcomp_to_funcomp_app).
     use idpath.
   - use weqproperty.

--- a/UniMath/Algebra/Domains_and_Fields.v
+++ b/UniMath/Algebra/Domains_and_Fields.v
@@ -339,7 +339,15 @@ Definition intdomax (X : intdom) :
   ∏ (a1 a2 : X), paths (a1 * a2) 0 -> hdisj (eqset a1 0) (eqset a2 0) := pr2 (pr2 X).
 
 
-(** **** (X = Y) ≃ (rngiso X Y) *)
+(** **** (X = Y) ≃ (rngiso X Y)
+   We use the following composition
+
+                            (X = Y) ≃ (pr1 X = pr1 Y)
+                                    ≃ (rngiso (pr1 X) (pr1 Y))
+                                    ≃ (rngiso X Y)
+
+  where the second weak equivalence is given by univalence for commrngs, [commrng_univalence].
+*)
 
 Definition intdom_univalence_weq1 (X Y : intdom) : (X = Y) ≃ (pr1 X = pr1 Y).
 Proof.
@@ -347,7 +355,7 @@ Proof.
   use subtypeInjectivity.
   intros w. use isapropisintdom.
 Defined.
-Opaque commrig_univalence_weq1.
+Opaque intdom_univalence_weq1.
 
 Definition intdom_univalence_weq2 (X Y : intdom) : (pr1 X = pr1 Y) ≃ (rngiso (pr1 X) (pr1 Y)) :=
   commrng_univalence (pr1 X) (pr1 Y).
@@ -528,14 +536,12 @@ Proof.
         -- use setproperty.
         -- use setproperty.
     + use setproperty.
-    + intros H' e.
-      use H.
-      set (tmp := dirprod_pr1 (pr2 H')). cbn in tmp. rewrite e in tmp.
-      set (t := @multx0_is_l
-                  X (@op1 X) (@op2 X) (dirprod_pr1 (rngop1axs X)) (rngop2axs X)
-                  (rngdistraxs X) (pr1 H')).
-      use (pathscomp0 _ t). clear t.
-      use pathsinv0. exact tmp.
+    + intros H' e. use H.
+      use (pathscomp0
+             _ (@multx0_is_l X (@op1 X) (@op2 X) (dirprod_pr1 (rngop1axs X)) (rngop2axs X)
+                             (rngdistraxs X) (pr1 H'))).
+      use (pathscomp0 _ (maponpaths (fun y : X  => op2 (pr1 H') y) e)).
+      exact (! dirprod_pr1 (pr2 H')).
 Defined.
 Opaque isapropisafield.
 
@@ -568,7 +574,15 @@ Defined.
 Definition fldmultinv {X : fld} (x : X) (ne : neg (paths x 0)) : X := pr1 (fldmultinvpair X x ne).
 
 
-(** **** (X = Y) ≃ (rngiso X Y) *)
+(** **** (X = Y) ≃ (rngiso X Y)
+   We use the following composition
+
+                                (X = Y) ≃ (pr1 X = pr1 Y)
+                                        ≃ (rngiso (pr1 X) (pr1 Y))
+                                        ≃ (rngiso X Y)
+
+   where the second weak equivalence is given by univalence for commrngs, [commrng_univalence].
+*)
 
 Definition fld_univalence_weq1 (X Y : fld) : (X = Y) ≃ (pr1 X = pr1 Y).
 Proof.

--- a/UniMath/Algebra/Domains_and_Fields.v
+++ b/UniMath/Algebra/Domains_and_Fields.v
@@ -523,18 +523,7 @@ Proof.
   - use isapropisnonzerorng.
   - intros H.
     use impred. intros x. use isapropcoprod.
-    + use invproofirrelevance. intros m1 m2.
-      use total2_paths_f.
-      * use (pathscomp0 (! (rigrunax2 X (pr1 m1)))).
-        use (pathscomp0 _ (riglunax2 X (pr1 m2))).
-        use (pathscomp0 _ (maponpaths (fun y : X => op2 y (pr1 m2)) (dirprod_pr2 (pr2 m1)))).
-        use (pathscomp0 (maponpaths (fun y : X => op2 (pr1 m1) y) (! dirprod_pr1 (pr2 m2)))).
-        use (pathscomp0 (! @rigassoc2 X (pr1 m1) (pr1 m2) x)).
-        use (pathscomp0 (@rigcomm2 X (op2 (pr1 m1) (pr1 m2)) x)).
-        exact (! @rigassoc2 X x (pr1 m1) (pr1 m2)).
-      * use proofirrelevance. use isapropdirprod.
-        -- use setproperty.
-        -- use setproperty.
+    + use isapropinvpair.
     + use setproperty.
     + intros H' e. use H.
       use (pathscomp0

--- a/UniMath/Algebra/Domains_and_Fields.v
+++ b/UniMath/Algebra/Domains_and_Fields.v
@@ -369,9 +369,7 @@ Proof.
   intros X Y.
   use isweqhomot.
   - exact (weqcomp (intdom_univalence_weq1 X Y) (intdom_univalence_weq2 X Y)).
-  - intros e. induction e.
-    use (pathscomp0 weqcomp_to_funcomp_app).
-    use idpath.
+  - intros e. induction e. use weqcomp_to_funcomp_app.
   - use weqproperty.
 Defined.
 Opaque intdom_univalence_isweq.
@@ -587,9 +585,7 @@ Proof.
   intros X Y.
   use isweqhomot.
   - exact (weqcomp (fld_univalence_weq1 X Y) (fld_univalence_weq2 X Y)).
-  - intros e. induction e.
-    use (pathscomp0 weqcomp_to_funcomp_app).
-    use idpath.
+  - intros e. induction e. use weqcomp_to_funcomp_app.
   - use weqproperty.
 Defined.
 Opaque fld_univalence_isweq.

--- a/UniMath/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Algebra/Monoids_and_Groups.v
@@ -261,8 +261,7 @@ Proof.
                    (weqcomp (monoid_univalence_weq2 X Y) (monoid_univalence_weq3 X Y))).
   - intros e. induction e.
     use (pathscomp0 weqcomp_to_funcomp_app).
-    use (pathscomp0 weqcomp_to_funcomp_app).
-    use idpath.
+    use weqcomp_to_funcomp_app.
   - use weqproperty.
 Defined.
 Opaque monoid_univalence_isweq.
@@ -472,8 +471,7 @@ Proof.
                    (weqcomp (abmonoid_univalence_weq2 X Y) (abmonoid_univalence_weq3 X Y))).
   - intros e. induction e.
     use (pathscomp0 weqcomp_to_funcomp_app).
-    use (pathscomp0 weqcomp_to_funcomp_app).
-    use idpath.
+    use weqcomp_to_funcomp_app.
   - use weqproperty.
 Defined.
 Opaque abmonoid_univalence_isweq.
@@ -1462,8 +1460,7 @@ Proof.
                    (weqcomp (gr_univalence_weq2 X Y) (gr_univalence_weq3 X Y))).
   - intros e. induction e.
     use (pathscomp0 weqcomp_to_funcomp_app).
-    use (pathscomp0 weqcomp_to_funcomp_app).
-    use idpath.
+    use weqcomp_to_funcomp_app.
   - use weqproperty.
 Defined.
 Opaque gr_univalence_isweq.
@@ -1799,8 +1796,7 @@ Proof.
                    (weqcomp (abgr_univalence_weq2 X Y) (abgr_univalence_weq3 X Y))).
   - intros e. induction e.
     use (pathscomp0 weqcomp_to_funcomp_app).
-    use (pathscomp0 weqcomp_to_funcomp_app).
-    use idpath.
+    use weqcomp_to_funcomp_app.
   - use weqproperty.
 Defined.
 Opaque abgr_univalence_isweq.

--- a/UniMath/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Algebra/Monoids_and_Groups.v
@@ -428,7 +428,6 @@ Definition abmonoidrer (X : abmonoid) (a b c d : X) :
 
                       (X = Y) ≃ ((mk_abmonoid' X) = (mk_abmonoid' Y))
                               ≃ ((pr1 (mk_abmonoid' X)) = (pr1 (mk_abmonoid' Y)))
-                              ≃ (monoidiso (pr1 (mk_abmonoid' X)) (pr1 (mk_abmonoid' Y)))
                               ≃ (monoidiso X Y)
 
     where the third weak equivalence is given by univalence for monoids, [monoid_univalence].
@@ -457,13 +456,8 @@ Defined.
 Opaque abmonoid_univalence_weq2.
 
 Definition abmonoid_univalence_weq3 (X Y : abmonoid) :
-  ((pr1 (mk_abmonoid' X)) = (pr1 (mk_abmonoid' Y)))
-    ≃ (monoidiso (pr1 (mk_abmonoid' X)) (pr1 (mk_abmonoid' Y))) :=
+  ((pr1 (mk_abmonoid' X)) = (pr1 (mk_abmonoid' Y))) ≃ (monoidiso X Y) :=
   monoid_univalence (pr1 (mk_abmonoid' X)) (pr1 (mk_abmonoid' Y)).
-
-Definition abmonoid_univalence_weq4 (X Y : abmonoid) :
-  (monoidiso (pr1 (mk_abmonoid' X)) (pr1 (mk_abmonoid' Y))) ≃ (monoidiso X Y) :=
-  idweq (monoidiso X Y).
 
 Definition abmonoid_univalence_map (X Y : abmonoid) : (X = Y) -> (monoidiso X Y).
 Proof.
@@ -475,11 +469,8 @@ Proof.
   intros X Y.
   use isweqhomot.
   - exact (weqcomp (abmonoid_univalence_weq1' X Y)
-                   (weqcomp (abmonoid_univalence_weq2 X Y)
-                            (weqcomp (abmonoid_univalence_weq3 X Y)
-                                     (abmonoid_univalence_weq4 X Y)))).
+                   (weqcomp (abmonoid_univalence_weq2 X Y) (abmonoid_univalence_weq3 X Y))).
   - intros e. induction e.
-    use (pathscomp0 weqcomp_to_funcomp_app).
     use (pathscomp0 weqcomp_to_funcomp_app).
     use (pathscomp0 weqcomp_to_funcomp_app).
     use idpath.
@@ -1424,7 +1415,6 @@ Defined.
 
             (X = Y) ≃ (mk_gr' X = mk_gr' Y)
                     ≃ ((gr'_to_monoid (mk_gr' X)) = (gr'_to_monoid (mk_gr' Y)))
-                    ≃ (monoidiso (gr'_to_monoid (mk_gr' X)) ((gr'_to_monoid (mk_gr' Y))))
                     ≃ (monoidiso X Y).
 
    The reason why we use gr' is that then we can use univalence for monoids. See
@@ -1456,13 +1446,8 @@ Defined.
 Opaque gr_univalence_weq2.
 
 Definition gr_univalence_weq3 (X Y : gr) :
-  ((gr'_to_monoid (mk_gr' X)) = (gr'_to_monoid (mk_gr' Y)))
-    ≃ (monoidiso (gr'_to_monoid (mk_gr' X)) ((gr'_to_monoid (mk_gr' Y)))) :=
+  ((gr'_to_monoid (mk_gr' X)) = (gr'_to_monoid (mk_gr' Y))) ≃ (monoidiso X Y) :=
   monoid_univalence (gr'_to_monoid (mk_gr' X)) (gr'_to_monoid (mk_gr' Y)).
-
-Definition gr_univalence_weq4 (X Y : gr) :
-  (monoidiso (gr'_to_monoid (mk_gr' X)) ((gr'_to_monoid (mk_gr' Y)))) ≃ (monoidiso X Y) :=
-  idweq (monoidiso X Y).
 
 Definition gr_univalence_map (X Y : gr) : (X = Y) -> (monoidiso X Y).
 Proof.
@@ -1474,11 +1459,8 @@ Proof.
   intros X Y.
   use isweqhomot.
   - exact (weqcomp (gr_univalence_weq1' X Y)
-                   (weqcomp (gr_univalence_weq2 X Y)
-                            (weqcomp (gr_univalence_weq3 X Y)
-                                     (gr_univalence_weq4 X Y)))).
+                   (weqcomp (gr_univalence_weq2 X Y) (gr_univalence_weq3 X Y))).
   - intros e. induction e.
-    use (pathscomp0 weqcomp_to_funcomp_app).
     use (pathscomp0 weqcomp_to_funcomp_app).
     use (pathscomp0 weqcomp_to_funcomp_app).
     use idpath.
@@ -1772,7 +1754,6 @@ Coercion abgrtoabmonoid : abgr >-> abmonoid.
 
         (X = Y) ≃ (mk_abgr' X = mk_abgr' Y)
                 ≃ (pr1 (mk_abgr' X) = pr1 (mk_abgr' Y))
-                ≃ (monoidiso (grtomonoid (pr1 (mk_abgr' X))) (grtomonoid (pr1 (mk_abgr' Y))))
                 ≃ (monoidiso X Y)
 
     We use abgr' so that we can use univalence for groups, [gr_univalence]. See
@@ -1802,13 +1783,8 @@ Defined.
 Opaque abgr_univalence_weq2.
 
 Definition abgr_univalence_weq3 (X Y : abgr) :
-  (pr1 (mk_abgr' X) = pr1 (mk_abgr' Y))
-    ≃ (monoidiso (grtomonoid (pr1 (mk_abgr' X))) (grtomonoid (pr1 (mk_abgr' Y)))) :=
+  (pr1 (mk_abgr' X) = pr1 (mk_abgr' Y)) ≃ (monoidiso X Y) :=
   gr_univalence (pr1 (mk_abgr' X)) (pr1 (mk_abgr' Y)).
-
-Definition abgr_univalence_weq4 (X Y : abgr) :
-  (monoidiso (grtomonoid (pr1 (mk_abgr' X))) (grtomonoid (pr1 (mk_abgr' Y)))) ≃ (monoidiso X Y) :=
-  idweq (monoidiso X Y).
 
 Definition abgr_univalence_map (X Y : abgr) : (X = Y) -> (monoidiso X Y).
 Proof.
@@ -1820,11 +1796,8 @@ Proof.
   intros X Y.
   use isweqhomot.
   - exact (weqcomp (abgr_univalence_weq1' X Y)
-                   (weqcomp (abgr_univalence_weq2 X Y)
-                            (weqcomp (abgr_univalence_weq3 X Y)
-                                     (abgr_univalence_weq4 X Y)))).
+                   (weqcomp (abgr_univalence_weq2 X Y) (abgr_univalence_weq3 X Y))).
   - intros e. induction e.
-    use (pathscomp0 weqcomp_to_funcomp_app).
     use (pathscomp0 weqcomp_to_funcomp_app).
     use (pathscomp0 weqcomp_to_funcomp_app).
     use idpath.

--- a/UniMath/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Algebra/Monoids_and_Groups.v
@@ -416,7 +416,18 @@ Definition commax (X : abmonoid) : iscomm (@op X) := pr2 (pr2 X).
 Definition abmonoidrer (X : abmonoid) (a b c d : X) :
   paths (op (op a b) (op c d)) (op (op a c) (op b d)) := abmonoidoprer (pr2 X) a b c d.
 
-(** **** (X = Y) ≃ (monoidiso X Y) *)
+
+(** **** (X = Y) ≃ (monoidiso X Y)
+    We use the following composition
+
+                      (X = Y) ≃ ((mk_abmonoid' X) = (mk_abmonoid' Y))
+                              ≃ ((pr1 (mk_abmonoid' X)) = (pr1 (mk_abmonoid' Y)))
+                              ≃ (monoidiso (pr1 (mk_abmonoid' X)) (pr1 (mk_abmonoid' Y)))
+                              ≃ (monoidiso X Y)
+
+    where the third weak equivalence is given by univalence for monoids, [monoid_univalence].
+*)
+
 Local Definition abmonoid' : UU := ∑ m : monoid, iscomm (@op m).
 
 Local Definition mk_abmonoid' (X : abmonoid) : abmonoid' :=

--- a/UniMath/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Algebra/Monoids_and_Groups.v
@@ -1349,7 +1349,7 @@ Defined.
 *)
 
 Local Definition gr' : UU :=
-  ∑ g : (∑ X : setwithbinop, ismonoidop (@op X)), invstruct (pr2 (pr1 g)) (pr2 g).
+  ∑ g : (∑ X : setwithbinop, ismonoidop (@op X)), invstruct (@op (pr1 g)) (pr2 g).
 
 Local Definition mk_gr' (X : gr) : gr' := tpair _ (tpair _ (pr1 X) (pr1 (pr2 X))) (pr2 (pr2 X)).
 
@@ -1357,8 +1357,8 @@ Local Definition gr'_to_monoid (X : gr') : monoid := pr1 X.
 
 Definition gr_univalence_weq1 : gr ≃ gr' :=
   weqtotal2asstol
-    (fun Z : setwithbinop => ismonoidop (pr2 Z))
-    (fun y : (∑ (x : setwithbinop), ismonoidop (pr2 x)) => invstruct (pr2 (pr1 y)) (pr2 y)).
+    (fun Z : setwithbinop => ismonoidop (@op Z))
+    (fun y : (∑ (x : setwithbinop), ismonoidop (@op x)) => invstruct (@op (pr1 y)) (pr2 y)).
 
 Definition gr_univalence_weq1' (X Y : gr) : (X = Y) ≃ (mk_gr' X = mk_gr' Y) :=
   weqpair _ (@isweqmaponpaths gr gr' gr_univalence_weq1 X Y).
@@ -1703,8 +1703,8 @@ Local Definition mk_abgr' (X : abgr) : abgr' :=
   tpair _ (tpair _ (pr1 X) (dirprod_pr1 (pr2 X))) (dirprod_pr2 (pr2 X)).
 
 Local Definition abgr_univalence_weq1 : abgr ≃ abgr' :=
-  weqtotal2asstol (fun Z : setwithbinop => isgrop (pr2 Z))
-                  (fun y : (∑ x : setwithbinop, isgrop (pr2 x)) => iscomm (pr2 (pr1 y))).
+  weqtotal2asstol (fun Z : setwithbinop => isgrop (@op Z))
+                  (fun y : (∑ x : setwithbinop, isgrop (@op x)) => iscomm (@op (pr1 y))).
 
 Definition abgr_univalence_weq1' (X Y : abgr) : (X = Y) ≃ (mk_abgr' X = mk_abgr' Y) :=
   weqpair _ (@isweqmaponpaths abgr abgr' abgr_univalence_weq1 X Y).

--- a/UniMath/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Algebra/Monoids_and_Groups.v
@@ -100,10 +100,16 @@ Delimit Scope multmonoid_scope with multmonoid.
 (** **** Functions between monoids compatible with structure (homomorphisms) and their properties *)
 
 Definition ismonoidfun {X Y : monoid} (f : X -> Y) : UU :=
-  dirprod (isbinopfun f) (paths (f (unel X)) (unel Y)).
+  dirprod (isbinopfun f) (f (unel X) = (unel Y)).
 
 Definition mk_ismonoidfun {X Y : monoid} {f : X -> Y} (H1 : isbinopfun f)
            (H2 : f (unel X) = unel Y) : ismonoidfun f := dirprodpair H1 H2.
+
+Definition ismonoidfunisbinopfun {X Y : monoid} {f : X -> Y} (H : ismonoidfun f) : isbinopfun f :=
+  dirprod_pr1 H.
+
+Definition ismonoidfununel {X Y : monoid} {f : X -> Y} (H : ismonoidfun f) : f (unel X) = unel Y :=
+  dirprod_pr2 H.
 
 Lemma isapropismonoidfun {X Y : monoid} (f : X -> Y) : isaprop (ismonoidfun f).
 Proof.

--- a/UniMath/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Algebra/Monoids_and_Groups.v
@@ -102,6 +102,9 @@ Delimit Scope multmonoid_scope with multmonoid.
 Definition ismonoidfun {X Y : monoid} (f : X -> Y) : UU :=
   dirprod (isbinopfun f) (paths (f (unel X)) (unel Y)).
 
+Definition mk_ismonoidfun {X Y : monoid} {f : X -> Y} (H1 : isbinopfun f)
+           (H2 : f (unel X) = unel Y) : ismonoidfun f := dirprodpair H1 H2.
+
 Lemma isapropismonoidfun {X Y : monoid} (f : X -> Y) : isaprop (ismonoidfun f).
 Proof.
   intros. apply isofhleveldirprod.
@@ -228,7 +231,7 @@ Proof.
   - intros e. cbn. use invweq. induction X as [X Xop]. induction Y as [Y Yop]. cbn in e.
     cbn. induction e. use weqimplimpl.
     + intros i. use proofirrelevance. use isapropismonoidop.
-    + intros i. unfold idfun in i. induction i. use idpath.
+    + intros i. induction i. use idpath.
     + use setproperty.
     + use isapropifcontr. exact (@isapropismonoidop X (pr2 X) Xop Yop).
 Defined.
@@ -412,6 +415,69 @@ Definition commax (X : abmonoid) : iscomm (@op X) := pr2 (pr2 X).
 
 Definition abmonoidrer (X : abmonoid) (a b c d : X) :
   paths (op (op a b) (op c d)) (op (op a c) (op b d)) := abmonoidoprer (pr2 X) a b c d.
+
+(** **** (X = Y) ≃ (monoidiso X Y) *)
+Local Definition abmonoid' : UU := ∑ m : monoid, iscomm (@op m).
+
+Local Definition mk_abmonoid' (X : abmonoid) : abmonoid' :=
+  tpair _ (tpair _ (pr1 X) (dirprod_pr1 (pr2 X))) (dirprod_pr2 (pr2 X)).
+
+Definition abmonoid_univalence_weq1 : abmonoid ≃ abmonoid' :=
+  weqtotal2asstol (fun X : setwithbinop => ismonoidop (@op X))
+                  (fun y : (∑ X : setwithbinop, ismonoidop op) => iscomm (@op (pr1 y))).
+
+Definition abmonoid_univalence_weq1' (X Y : abmonoid) :
+  (X = Y) ≃ ((mk_abmonoid' X) = (mk_abmonoid' Y)) :=
+  weqpair _ (@isweqmaponpaths abmonoid abmonoid' abmonoid_univalence_weq1 X Y).
+
+Definition abmonoid_univalence_weq2 (X Y : abmonoid) :
+  ((mk_abmonoid' X) = (mk_abmonoid' Y)) ≃ ((pr1 (mk_abmonoid' X)) = (pr1 (mk_abmonoid' Y))).
+Proof.
+  intros X Y.
+  use subtypeInjectivity.
+  intros w. use isapropiscomm.
+Defined.
+Opaque abmonoid_univalence_weq2.
+
+Definition abmonoid_univalence_weq3 (X Y : abmonoid) :
+  ((pr1 (mk_abmonoid' X)) = (pr1 (mk_abmonoid' Y)))
+    ≃ (monoidiso (pr1 (mk_abmonoid' X)) (pr1 (mk_abmonoid' Y))) :=
+  monoid_univalence (pr1 (mk_abmonoid' X)) (pr1 (mk_abmonoid' Y)).
+
+Definition abmonoid_univalence_weq4 (X Y : abmonoid) :
+  (monoidiso (pr1 (mk_abmonoid' X)) (pr1 (mk_abmonoid' Y))) ≃ (monoidiso X Y) :=
+  idweq (monoidiso X Y).
+
+Definition abmonoid_univalence_map (X Y : abmonoid) : (X = Y) -> (monoidiso X Y).
+Proof.
+  intros X Y e. induction e. exact (idmonoidiso X).
+Defined.
+
+Lemma abmonoid_univalence_isweq (X Y : abmonoid) : isweq (abmonoid_univalence_map X Y).
+Proof.
+  intros X Y.
+  use isweqhomot.
+  - exact (weqcomp (abmonoid_univalence_weq1' X Y)
+                   (weqcomp (abmonoid_univalence_weq2 X Y)
+                            (weqcomp (abmonoid_univalence_weq3 X Y)
+                                     (abmonoid_univalence_weq4 X Y)))).
+  - intros e. induction e.
+    use (pathscomp0 weqcomp_to_funcomp_app).
+    use (pathscomp0 weqcomp_to_funcomp_app).
+    use (pathscomp0 weqcomp_to_funcomp_app).
+    use idpath.
+  - use weqproperty.
+Defined.
+Opaque abmonoid_univalence_isweq.
+
+Definition abmonoid_univalence (X Y : abmonoid) : (X = Y) ≃ (monoidiso X Y).
+Proof.
+  intros X Y.
+  use weqpair.
+  - exact (abmonoid_univalence_map X Y).
+  - exact (abmonoid_univalence_isweq X Y).
+Defined.
+Opaque abmonoid_univalence.
 
 
 (** **** Subobjects *)

--- a/UniMath/Algebra/Rigs_and_Rings.v
+++ b/UniMath/Algebra/Rigs_and_Rings.v
@@ -153,6 +153,12 @@ Definition mk_isrigfun {X Y : rig} {f : X -> Y}
            (H2 : @ismonoidfun (rigmultmonoid X) (rigmultmonoid Y) f) : isrigfun f :=
   dirprodpair H1 H2.
 
+Definition isrigfunisaddmonoidfun {X Y : rig} {f : X -> Y} (H : isrigfun f) :
+  @ismonoidfun (rigaddabmonoid X) (rigaddabmonoid Y) f := dirprod_pr1 H.
+
+Definition isrigfunismultmonoidfun {X Y : rig} {f : X -> Y} (H : isrigfun f) :
+  @ismonoidfun (rigmultmonoid X) (rigmultmonoid Y) f := dirprod_pr2 H.
+
 Definition rigfun (X Y : rig) : UU := total2 (fun f : X -> Y => isrigfun f).
 
 Definition rigfunconstr {X Y : rig} {f : X -> Y} (is : isrigfun f) : rigfun X Y := tpair _ f is.
@@ -172,6 +178,8 @@ Definition rigisopair {X Y : rig} (f : weq X Y) (is : isrigfun f) : rigiso X Y :
 
 Definition pr1rigiso (X Y : rig) : rigiso X Y -> weq X Y := @pr1 _ _.
 Coercion pr1rigiso : rigiso >-> weq.
+
+Definition rigisoisrigfun {X Y : rig} (f : rigiso X Y) : isrigfun f := pr2 f.
 
 Definition rigaddiso {X Y : rig} (f : rigiso X Y) :
   monoidiso (rigaddabmonoid X) (rigaddabmonoid Y) :=
@@ -249,10 +257,6 @@ Opaque rig_univalence_weq2.
 Definition rig_univalence_weq3 (X Y : rig) : (rigiso' X Y) ≃ (rigiso X Y).
 Proof.
   intros X Y.
-  induction X as [X1 X2]. induction X2 as [X2 X3]. induction X2 as [X21 X22].
-  induction X21 as [X211 X212]. induction X22 as [X221 X222].
-  induction Y as [Y1 Y2]. induction Y2 as [Y2 Y3]. induction Y2 as [Y21 Y22].
-  induction Y21 as [Y211 Y212]. induction Y22 as [Y221 Y222]. cbn in *.
   use weqpair.
   - intros i'.
     use rigisopair.
@@ -268,12 +272,12 @@ Proof.
         -- exact (dirprod_pr2 (pr2 i')).
   - use gradth.
     + intros i. use mk_rigiso'.
-      * exact (pr1 i).
+      * exact (pr1rigiso _ _ i).
       * use mk_istwobinopfun.
-        -- exact (pr1 (pr1 (pr2 i))).
-        -- exact (pr1 (pr2 (pr2 i))).
-      * exact (pr2 (pr1 (pr2 i))).
-      * exact (pr2 (pr2 (pr2 i))).
+        -- exact (ismonoidfunisbinopfun (isrigfunisaddmonoidfun (rigisoisrigfun i))).
+        -- exact (ismonoidfunisbinopfun (isrigfunismultmonoidfun (rigisoisrigfun i))).
+      * exact (ismonoidfununel (isrigfunisaddmonoidfun (rigisoisrigfun i))).
+      * exact (ismonoidfununel (isrigfunismultmonoidfun (rigisoisrigfun i))).
     + intros x. use idpath.
     + intros x. use idpath.
 Defined.

--- a/UniMath/Algebra/Rigs_and_Rings.v
+++ b/UniMath/Algebra/Rigs_and_Rings.v
@@ -491,7 +491,6 @@ Definition commrigmultabmonoid (X : commrig) : abmonoid :=
 
                           (X = Y) ≃ (mk_commrig' X = mk_commrig' Y)
                                   ≃ ((pr1 (mk_commrig' X)) = (pr1 (mk_commrig' Y)))
-                                  ≃ (rigiso (pr1 (mk_commrig' X)) (pr1 (mk_commrig' Y)))
                                   ≃ (rigiso X Y)
 
     where the third weak equivalence uses univalence for rigs, [rig_univalence]. We define
@@ -522,12 +521,8 @@ Defined.
 Opaque commrig_univalence_weq2.
 
 Definition commrig_univalence_weq3 (X Y : commrig) :
-  ((pr1 (mk_commrig' X)) = (pr1 (mk_commrig' Y)))
-    ≃ (rigiso (pr1 (mk_commrig' X)) (pr1 (mk_commrig' Y))) :=
+  ((pr1 (mk_commrig' X)) = (pr1 (mk_commrig' Y))) ≃ (rigiso X Y) :=
   rig_univalence (pr1 (mk_commrig' X)) (pr1 (mk_commrig' Y)).
-
-Definition commrig_univalence_weq4 (X Y : commrig) :
-  (rigiso (pr1 (mk_commrig' X)) (pr1 (mk_commrig' Y))) ≃ (rigiso X Y) := idweq (rigiso X Y).
 
 Definition commrig_univalence_map (X Y : commrig) : (X = Y) -> (rigiso X Y).
 Proof.
@@ -539,11 +534,8 @@ Proof.
   intros X Y.
   use isweqhomot.
   - exact (weqcomp (commrig_univalence_weq1' X Y)
-                   (weqcomp (commrig_univalence_weq2 X Y)
-                            (weqcomp (commrig_univalence_weq3 X Y)
-                                     (commrig_univalence_weq4 X Y)))).
+                   (weqcomp (commrig_univalence_weq2 X Y) (commrig_univalence_weq3 X Y))).
   - intros e. induction e.
-    use (pathscomp0 weqcomp_to_funcomp_app).
     use (pathscomp0 weqcomp_to_funcomp_app).
     use (pathscomp0 weqcomp_to_funcomp_app).
     use idpath.
@@ -733,7 +725,6 @@ Definition isrngfuninvmap {X Y : rng} (f : rngiso X Y) : isrngfun (invmap f) := 
 
                            (X = Y) ≃ (mk_rng' X = mk_rng' Y)
                                    ≃ ((pr1 (mk_rng' X)) = (pr1 (mk_rng' Y)))
-                                   ≃ (rigiso (pr1 (mk_rng' X)) (pr1 (mk_rng' Y)))
                                    ≃ (rngiso X Y)
 
     where the third weak equivalence is given by univalence for rigs, [rig_univalence]. We define
@@ -808,11 +799,8 @@ Defined.
 Opaque rng_univalence_weq2.
 
 Definition rng_univalence_weq3 (X Y : rng) :
-  ((pr1 (mk_rng' X)) = (pr1 (mk_rng' Y))) ≃ (rigiso (pr1 (mk_rng' X)) (pr1 (mk_rng' Y))) :=
+  ((pr1 (mk_rng' X)) = (pr1 (mk_rng' Y))) ≃ (rigiso X Y) :=
   rig_univalence (pr1 (mk_rng' X)) (pr1 (mk_rng' Y)).
-
-Definition rng_univalence_weq4 (X Y : rng) :
-  (rigiso (pr1 (mk_rng' X)) (pr1 (mk_rng' Y))) ≃ (rngiso X Y) := idweq (rngiso X Y).
 
 Definition rng_univalence_map (X Y : rng) : (X = Y) -> (rngiso X Y).
 Proof.
@@ -824,11 +812,8 @@ Proof.
   intros X Y.
   use isweqhomot.
   - exact (weqcomp (rng_univalence_weq1' X Y)
-                   (weqcomp (rng_univalence_weq2 X Y)
-                            (weqcomp (rng_univalence_weq3 X Y)
-                                     (rng_univalence_weq4 X Y)))).
+                   (weqcomp (rng_univalence_weq2 X Y) (rng_univalence_weq3 X Y))).
   - intros e. induction e.
-    use (pathscomp0 weqcomp_to_funcomp_app).
     use (pathscomp0 weqcomp_to_funcomp_app).
     use (pathscomp0 weqcomp_to_funcomp_app).
     use idpath.
@@ -1861,7 +1846,6 @@ Coercion commrngtocommrig : commrng >-> commrig.
 
                           (X = Y) ≃ (mk_commrng' X = mk_commrng' Y)
                                   ≃ ((pr1 (mk_commrng' X)) = (pr1 (mk_commrng' Y)))
-                                  ≃ (rngiso (pr1 (mk_commrng' X)) (pr1 (mk_commrng' Y)))
                                   ≃ (rngiso X Y)
 
     where the third weak equivalence is given by univalence for rng, [rng_univalence]. We define
@@ -1892,12 +1876,8 @@ Defined.
 Opaque commrng_univalence_weq2.
 
 Definition commrng_univalence_weq3 (X Y : commrng) :
-  ((pr1 (mk_commrng' X)) = (pr1 (mk_commrng' Y)))
-    ≃ (rngiso (pr1 (mk_commrng' X)) (pr1 (mk_commrng' Y))) :=
+  ((pr1 (mk_commrng' X)) = (pr1 (mk_commrng' Y))) ≃ (rngiso X Y) :=
   rng_univalence (pr1 (mk_commrng' X)) (pr1 (mk_commrng' Y)).
-
-Definition commrng_univalence_weq4 (X Y : commrng) :
-  (rngiso (pr1 (mk_commrng' X)) (pr1 (mk_commrng' Y))) ≃ (rngiso X Y) := idweq (rngiso X Y).
 
 Definition commrng_univalence_map (X Y : commrng) : (X = Y) -> (rngiso X Y).
 Proof.
@@ -1909,11 +1889,8 @@ Proof.
   intros X Y.
   use isweqhomot.
   - exact (weqcomp (commrng_univalence_weq1' X Y)
-                   (weqcomp (commrng_univalence_weq2 X Y)
-                            (weqcomp (commrng_univalence_weq3 X Y)
-                                     (commrng_univalence_weq4 X Y)))).
+                   (weqcomp (commrng_univalence_weq2 X Y) (commrng_univalence_weq3 X Y))).
   - intros e. induction e.
-    use (pathscomp0 weqcomp_to_funcomp_app).
     use (pathscomp0 weqcomp_to_funcomp_app).
     use (pathscomp0 weqcomp_to_funcomp_app).
     use idpath.

--- a/UniMath/Algebra/Rigs_and_Rings.v
+++ b/UniMath/Algebra/Rigs_and_Rings.v
@@ -205,13 +205,23 @@ Proof.
 Defined.
 
 
-(** **** (X = Y) ≃ (rigiso X Y) *)
+(** **** (X = Y) ≃ (rigiso X Y)
+    We use the following composition
 
-Definition rigiso' (X Y : rig) : UU :=
+                              (X = Y) ≃ (X ╝ Y)
+                                      ≃ (rigiso' X Y)
+                                      ≃ (rigiso X Y)
+
+    where the second weak equivalence is given by univalence for setwith2binop,
+    [setwith2binop_univalence]. The reason to define rigiso' is that it allows us to use
+    [setwith2binop_univalence].
+*)
+
+Local Definition rigiso' (X Y : rig) : UU :=
   ∑ D : (∑ w : X ≃ Y, istwobinopfun w),
         ((pr1 D) (@rigunel1 X) = @rigunel1 Y) × ((pr1 D) (@rigunel2 X) = @rigunel2 Y).
 
-Definition mk_rigiso' (X Y : rig) (w : X ≃ Y) (H1 : istwobinopfun w)
+Local Definition mk_rigiso' (X Y : rig) (w : X ≃ Y) (H1 : istwobinopfun w)
            (H2 : w (@rigunel1 X) = @rigunel1 Y) (H3 : w (@rigunel2 X) = @rigunel2 Y) :
   rigiso' X Y := tpair _ (tpair _ w H1) (dirprodpair H2 H3).
 
@@ -234,6 +244,7 @@ Proof.
       * use setproperty.
     + use isapropifcontr. exact (@isapropisrigops X op1 op2 Xop Yop).
 Defined.
+Opaque rig_univalence_weq2.
 
 Definition rig_univalence_weq3 (X Y : rig) : (rigiso' X Y) ≃ (rigiso X Y).
 Proof.
@@ -471,7 +482,17 @@ Definition commrigmultabmonoid (X : commrig) : abmonoid :=
   abmonoidpair (setwithbinoppair X op2) (dirprodpair (rigop2axs X) (rigcomm2 X)).
 
 
-(** **** (X = Y) ≃ (rigiso X Y) *)
+(** **** (X = Y) ≃ (rigiso X Y)
+    We use the following composition
+
+                          (X = Y) ≃ (mk_commrig' X = mk_commrig' Y)
+                                  ≃ ((pr1 (mk_commrig' X)) = (pr1 (mk_commrig' Y)))
+                                  ≃ (rigiso (pr1 (mk_commrig' X)) (pr1 (mk_commrig' Y)))
+                                  ≃ (rigiso X Y)
+
+    where the third weak equivalence uses univalence for rigs, [rig_univalence]. We define
+    [commrig'] to be able to apply it.
+ *)
 
 Local Definition commrig' : UU :=
   ∑ D : (∑ X : setwith2binop, isrigops (@op1 X) (@op2 X)), iscomm (@op2 (pr1 D)).
@@ -502,7 +523,7 @@ Definition commrig_univalence_weq3 (X Y : commrig) :
   rig_univalence (pr1 (mk_commrig' X)) (pr1 (mk_commrig' Y)).
 
 Definition commrig_univalence_weq4 (X Y : commrig) :
-  (rigiso (pr1 (mk_commrig' X)) (pr1 (mk_commrig' Y))) ≃ (rigiso X Y) :=  idweq (rigiso X Y).
+  (rigiso (pr1 (mk_commrig' X)) (pr1 (mk_commrig' Y))) ≃ (rigiso X Y) := idweq (rigiso X Y).
 
 Definition commrig_univalence_map (X Y : commrig) : (X = Y) -> (rigiso X Y).
 Proof.
@@ -703,7 +724,17 @@ Identity Coercion id_rngiso : rngiso >-> rigiso.
 Definition isrngfuninvmap {X Y : rng} (f : rngiso X Y) : isrngfun (invmap f) := isrigfuninvmap f.
 
 
-(** **** (X = Y) ≃ (rngiso X Y) *)
+(** **** (X = Y) ≃ (rngiso X Y)
+    We use the following composition
+
+                           (X = Y) ≃ (mk_rng' X = mk_rng' Y)
+                                   ≃ ((pr1 (mk_rng' X)) = (pr1 (mk_rng' Y)))
+                                   ≃ (rigiso (pr1 (mk_rng' X)) (pr1 (mk_rng' Y)))
+                                   ≃ (rngiso X Y)
+
+    where the third weak equivalence is given by univalence for rigs, [rig_univalence]. We define
+    rng' to be able to apply [rig_univalence].
+ *)
 
 Local Definition rng' : UU :=
   ∑ D : (∑ X : setwith2binop, isrigops (@op1 X) (@op2 X)),
@@ -1821,7 +1852,17 @@ Definition commrngtocommrig (X : commrng) : commrig := commrigpair _ (pr2 X).
 Coercion commrngtocommrig : commrng >-> commrig.
 
 
-(** **** (X = Y) ≃ (rngiso X Y) *)
+(** **** (X = Y) ≃ (rngiso X Y)
+    We use the following composition
+
+                          (X = Y) ≃ (mk_commrng' X = mk_commrng' Y)
+                                  ≃ ((pr1 (mk_commrng' X)) = (pr1 (mk_commrng' Y)))
+                                  ≃ (rngiso (pr1 (mk_commrng' X)) (pr1 (mk_commrng' Y)))
+                                  ≃ (rngiso X Y)
+
+    where the third weak equivalence is given by univalence for rng, [rng_univalence]. We define
+    [commrng'] to be able to use [rng_univalence].
+ *)
 
 Local Definition commrng' : UU :=
   ∑ D : (∑ X : setwith2binop, isrngops (@op1 X) (@op2 X)), iscomm (@op2 (pr1 D)).
@@ -1852,7 +1893,7 @@ Definition commrng_univalence_weq3 (X Y : commrng) :
   rng_univalence (pr1 (mk_commrng' X)) (pr1 (mk_commrng' Y)).
 
 Definition commrng_univalence_weq4 (X Y : commrng) :
-  (rngiso (pr1 (mk_commrng' X)) (pr1 (mk_commrng' Y))) ≃ (rngiso X Y) :=  idweq (rngiso X Y).
+  (rngiso (pr1 (mk_commrng' X)) (pr1 (mk_commrng' Y))) ≃ (rngiso X Y) := idweq (rngiso X Y).
 
 Definition commrng_univalence_map (X Y : commrng) : (X = Y) -> (rngiso X Y).
 Proof.

--- a/UniMath/Algebra/Rigs_and_Rings.v
+++ b/UniMath/Algebra/Rigs_and_Rings.v
@@ -296,8 +296,7 @@ Proof.
                    (weqcomp (rig_univalence_weq2 X Y) (rig_univalence_weq3 X Y))).
   - intros e. induction e.
     use (pathscomp0 weqcomp_to_funcomp_app).
-    use (pathscomp0 weqcomp_to_funcomp_app).
-    use idpath.
+    use weqcomp_to_funcomp_app.
   - use weqproperty.
 Defined.
 Opaque rig_univalence_isweq.
@@ -537,8 +536,7 @@ Proof.
                    (weqcomp (commrig_univalence_weq2 X Y) (commrig_univalence_weq3 X Y))).
   - intros e. induction e.
     use (pathscomp0 weqcomp_to_funcomp_app).
-    use (pathscomp0 weqcomp_to_funcomp_app).
-    use idpath.
+    use weqcomp_to_funcomp_app.
   - use weqproperty.
 Defined.
 Opaque commrig_univalence_isweq.
@@ -815,8 +813,7 @@ Proof.
                    (weqcomp (rng_univalence_weq2 X Y) (rng_univalence_weq3 X Y))).
   - intros e. induction e.
     use (pathscomp0 weqcomp_to_funcomp_app).
-    use (pathscomp0 weqcomp_to_funcomp_app).
-    use idpath.
+    use weqcomp_to_funcomp_app.
   - use weqproperty.
 Defined.
 Opaque rng_univalence_isweq.
@@ -1892,8 +1889,7 @@ Proof.
                    (weqcomp (commrng_univalence_weq2 X Y) (commrng_univalence_weq3 X Y))).
   - intros e. induction e.
     use (pathscomp0 weqcomp_to_funcomp_app).
-    use (pathscomp0 weqcomp_to_funcomp_app).
-    use idpath.
+    use weqcomp_to_funcomp_app.
   - use weqproperty.
 Defined.
 Opaque commrng_univalence_isweq.


### PR DESCRIPTION
This PR contains univalence for
- abmonoids, `abmonoids_univalence`, line 484, Monoids_and_Groups.v
- rigs, `rig_univalence`, line 301, Rigs_and_Rings.v
- commrigs, `commrig_univalence`, line 550, Rigs_and_Rings.v
- rngs, `rng_univalence`, line 835, Rigs_and_Rings.v
- commrngs, `commrng_univalence`, line 1920, Rigs_and_Rings.v
- intdoms, `intdom_univalence`, line 385, Domains_and_Fields.v
- flds, `fld_univalence`, line 620, Domains_and_Fields.v

To show univalence for flds, I needed to change direct product in `isafield` to ∑ .
This change is needed to show that `isaprop(isafield F)`, line 539, Domains_and_Fields.v .