### PR TITLE
fix latex errors

### DIFF
--- a/UniMath/CategoryTheory/SetValuedFunctors.v
+++ b/UniMath/CategoryTheory/SetValuedFunctors.v
@@ -3,7 +3,7 @@ Facts about set valued functors
 
 - epimorphic natural transformations are pointwise epimorphic
 - epimorphic natural transformations enjoy a universal property similar to
-surjections (univ_surj_nt)
+surjections [univ_surj_nt]
 - Definition of a quotient functor
 
 Ambroise LAFONT January 2017
@@ -50,7 +50,7 @@ Given the following diagram :
  B
 >>>
 there exists a unique natural transformation from B to C that makes the diagram
-commute provided that for any set X, any x,y in X, if p_X x = p_X y then f_X x = f_X y
+commute provided that for any set X, any x,y in X, if [p x = p y] then [f x = f y]
 
 This property comes from the fact that p is an effective epimorphism.
 *)
@@ -134,11 +134,11 @@ Let C be a category
 Let R be a functor from C to Set.
 
 Let X be an object of C
-Let ~_X a family of equivalence relations on RX satisfying
-if x ~_X y and f : X -> Y, then f(x) ~_Y f(y).
+Let tilde a family of equivalence relations on RX satisfying
+if [x tilde y] and [f : X -> Y], then [f(x) tilde f(y)].
 
-Then we can define R' := R/~ as a functor which to any X associates R'X := RX / ~_X
-Moreover, there is an epimorphism pr_quot_functor : R -> R'
+Then we can define [R'] as a functor which to any X associates [R'X = RX mod tilde]
+Moreover, there is an epimorphism [pr_quot_functor : R -> R']
 
  *)
 Section QuotientFunctor.
@@ -146,15 +146,15 @@ Section QuotientFunctor.
   Context { D:precategory}.
   Variable (R:functor D HSET).
 
-  (** This is ~_X *)
+  (** This is [tilde] *)
   Variable (hequiv : ∏ (d:D),eqrel (pr1hSet (R d))).
 
-  (** The relations satisfied by hequiv (~_X) *)
+  (** The relations satisfied by [hequiv (tilde)] *)
   Hypothesis (congru: ∏ (x y:D) (f:D⟦ x,  y⟧), iscomprelrelfun (hequiv x) (hequiv y) (#R f)).
 
   (** Definition of the quotient functor *)
   (* not using setquotinset directly because as isasetsetquot is not opaque it would make
-     computation slow in some cases (see issue #548) *)
+     computation slow in some cases (see issue 548) *)
   Definition quot_functor_ob (d:D) :hSet.
   Proof.
     mkpair.

--- a/UniMath/Foundations/Preamble.v
+++ b/UniMath/Foundations/Preamble.v
@@ -120,7 +120,7 @@ definitions in Coq.
 
 We use "Record", which is equivalent to "Structure", instead of "Inductive" here, so we can take
 advantage of the "primitive projections" feature of Coq, which introduces η-reduction for pairs, by
-adding the option "Set Primitive Projections".  It also speeds up compilation by 56%.
+adding the option "Set Primitive Projections".  It also speeds up compilation by 56 percent.
 
 The terms produced by the "induction" tactic, when we define "total2" as a record, contain the
 "match" construction instead appealing to the eliminator.  However, assuming the eliminator will be
@@ -130,11 +130,11 @@ parameters (X:Type) and (Y:X->Type).
 
 I.e., whenever you see
 
-       match w as t0 return TYPE with | tpair _ _ x y => BODY end
+       [match w as t0 return TYPE with | tpair _ _ x y => BODY end]
 
 in a proof term, just mentally replace it by
 
-       @total2_rect _ _ (λ t0, TYPE) (λ x y, BODY) w
+       [@total2_rect _ _ (λ t0, TYPE) (λ x y, BODY) w]
 
 *)
 

--- a/latex/latex-preamble.txt
+++ b/latex/latex-preamble.txt
@@ -31,7 +31,7 @@
 \DeclareUnicodeCharacter{9645}{{\(\boxdot\)}}
 \DeclareUnicodeCharacter{981}{{\(\phi\)}}
 \DeclareUnicodeCharacter{9565}{{\textSFxxvi}}
-\DeclareUnicodeCharacter{8803}{{\(\triplesim\)}} % TODO: this latex symbol does not adequately represent the Unicode symbol
+\DeclareUnicodeCharacter{8803}{{\(\mathop {\vbox {{\rlap =} \kern 3.9pt} {\rlap =} \phantom =} \)}}
 \hypersetup{linkcolor=blue}
 
 \begin{document}

--- a/latex/latex-preamble.txt
+++ b/latex/latex-preamble.txt
@@ -19,6 +19,7 @@
 \usepackage{textgreek}
 \usepackage{stmaryrd}
 \usepackage{pmboxdraw}
+\usepackage{fdsymbol}
 \DeclareUnicodeCharacter{10627}{{\(\llparenthesis\)}}
 \DeclareUnicodeCharacter{10628}{{\(\rrparenthesis\)}}
 \DeclareUnicodeCharacter{10815}{{\(\amalg\)}}
@@ -30,6 +31,7 @@
 \DeclareUnicodeCharacter{9645}{{\(\boxdot\)}}
 \DeclareUnicodeCharacter{981}{{\(\phi\)}}
 \DeclareUnicodeCharacter{9565}{{\textSFxxvi}}
+\DeclareUnicodeCharacter{8803}{{\(\triplesim\)}} % TODO: this latex symbol does not adequately represent the Unicode symbol
 \hypersetup{linkcolor=blue}
 
 \begin{document}


### PR DESCRIPTION
This PR fixes LaTeX errors occurring during the compilation of the LaTeX documention of UniMath/UniMath:

- In SetValuedFunctors.v there were a few runaway arguments. I fixed them by replacing symbols by text in the comments.
- I put in a temporary fix for #696 , but the LaTeX symbol does not look like the Unicode symbol. A proper solution is hence still missing.

The fixes are not perfect, but I don't know a better solution for the moment.

A few numbers: the resulting PDF has 3130 pages. Its TOC has 37 pages.