### PR TITLE
Introduce vocabulary "univalence" for categories

### DIFF
--- a/UniMath/CategoryTheory/FunctorAlgebras.v
+++ b/UniMath/CategoryTheory/FunctorAlgebras.v
@@ -143,7 +143,7 @@ Qed.
 
 Section FunctorAlg_saturated.
 
-Hypothesis H : is_category C.
+Hypothesis H : is_univalent C.
 
 Definition algebra_eq_type (X Y : FunctorAlg (pr2 H)) : UU
   := ∑ p : iso (pr1 X) (pr1 Y), pr2 X · p = #F p · pr2 Y.
@@ -281,7 +281,7 @@ Proof.
   - apply (pr2 _ ).
 Defined.
 
-Lemma is_category_FunctorAlg : is_category (FunctorAlg (pr2 H)).
+Lemma is_univalent_FunctorAlg : is_univalent (FunctorAlg (pr2 H)).
 Proof.
   split.
   - apply isweq_idtoiso_FunctorAlg.

--- a/UniMath/CategoryTheory/SimplicialSets.v
+++ b/UniMath/CategoryTheory/SimplicialSets.v
@@ -76,7 +76,7 @@ Defined.
 
 Local Open Scope cat.
 
-Definition sSet := [ precatDelta^op , HSET, pr2 is_category_HSET ] .
+Definition sSet := [ precatDelta^op , HSET, pr2 is_univalent_HSET ] .
 (* V.V. with Sasha Vishik, Nov. 23, 2014 *)
 
 

--- a/UniMath/CategoryTheory/bicategories/Cat.v
+++ b/UniMath/CategoryTheory/bicategories/Cat.v
@@ -395,7 +395,7 @@ Definition Cat_has_homcats : has_homcats Cat_prebicategory.
 Proof.
   unfold has_homcats.
   intros a b.
-  apply is_category_functor_category.
+  apply is_univalent_functor_category.
 Defined.
 
 (* TODO: "Should be easy" *)

--- a/UniMath/CategoryTheory/bicategories/Cat.v
+++ b/UniMath/CategoryTheory/bicategories/Cat.v
@@ -315,9 +315,9 @@ Defined.
 
 Definition Cat_1mor_2mor : prebicategory_ob_1mor_2mor.
 Proof.
-  exists category.
+  exists univalent_category.
   intros a b.
-  exact (functor_precategory a b (category_has_homsets b)).
+  exact (functor_precategory a b (univalent_category_has_homsets b)).
 Defined.
 
 Definition Cat_id_comp : prebicategory_id_comp.
@@ -328,8 +328,8 @@ Proof.
     exact functor_identity.
   - simpl.
     intros a b c.
-    exact (functorial_composition a b c (category_has_homsets b)
-                                        (category_has_homsets c)).
+    exact (functorial_composition a b c (univalent_category_has_homsets b)
+                                        (univalent_category_has_homsets c)).
 Defined.
 
 Definition Cat_data : prebicategory_data.
@@ -339,16 +339,16 @@ Proof.
   repeat split.
   - intros.
     simpl in a,b,c,d.
-    exact (Catlike_associator a b c d (category_has_homsets b)
-                                      (category_has_homsets c)
-                                      (category_has_homsets d)).
+    exact (Catlike_associator a b c d (univalent_category_has_homsets b)
+                                      (univalent_category_has_homsets c)
+                                      (univalent_category_has_homsets d)).
   - intros.
     simpl in a, b.
-    exact (Catlike_left_unitor a b (category_has_homsets a)
-                                   (category_has_homsets b)).
+    exact (Catlike_left_unitor a b (univalent_category_has_homsets a)
+                                   (univalent_category_has_homsets b)).
   - intros.
     simpl in a, b.
-    exact (Catlike_right_unitor a b (category_has_homsets b)).
+    exact (Catlike_right_unitor a b (univalent_category_has_homsets b)).
 Defined.
 
 Definition Cat_has_2mor_set : has_2mor_sets Cat_data.
@@ -356,7 +356,7 @@ Proof.
   unfold has_2mor_sets.
   intros a b f g.
   apply isaset_nat_trans.
-  exact (category_has_homsets b).
+  exact (univalent_category_has_homsets b).
 Defined.
 
 Definition Cat_associator_and_unitors_are_iso : associator_and_unitors_are_iso Cat_data.

--- a/UniMath/CategoryTheory/bicategories/bicategory.v
+++ b/UniMath/CategoryTheory/bicategories/bicategory.v
@@ -28,7 +28,7 @@ Proof.
   intro a.
   apply impred.
   intro b.
-  apply (isaprop_is_category (a -1-> b)).
+  apply (isaprop_is_univalent (a -1-> b)).
 Qed.
 
 (* Definition isaprop_is_bicategory { C : prebicategory } *)

--- a/UniMath/CategoryTheory/bicategories/prebicategory.v
+++ b/UniMath/CategoryTheory/bicategories/prebicategory.v
@@ -269,7 +269,7 @@ Definition prebicategory_has_2mor_sets {C : prebicategory} (a b : C)
   := (pr1 (pr2 C)) a b.
 
 Definition has_homcats (C : prebicategory)
-  := forall a b : C, is_category (a -1-> b).
+  := forall a b : C, is_univalent (a -1-> b).
 
 Definition associator {C : prebicategory} { a b c d : C }
            (f : a -1-> b)

--- a/UniMath/CategoryTheory/categories/StandardCategories.v
+++ b/UniMath/CategoryTheory/categories/StandardCategories.v
@@ -24,7 +24,7 @@ Lemma morphism_from_iso_is_incl (C : Precategory) (a b : ob C) :
 Proof. intro g.
   apply (isofhlevelweqf _ (ezweqpr1 _ _)). apply isaprop_is_iso. Qed.
 
-Lemma is_category_groupoid {C : Precategory}: is_groupoid C -> is_category C.
+Lemma is_univalent_groupoid {C : Precategory}: is_groupoid C -> is_univalent C.
 Proof. intros ig  .
   split.
   { intros a b.
@@ -57,17 +57,17 @@ Proof. intros a b.
   assert (k : idfun (a = b) ~ idtomor a b). { intro p. destruct p. reflexivity. }
   apply (isweqhomot _ _ k). apply idisweq. Qed.
 
-Lemma is_category_path_pregroupoid (X:UU) (i:isofhlevel 3 X) :
-  is_category (path_pregroupoid X i).
+Lemma is_univalent_path_pregroupoid (X:UU) (i:isofhlevel 3 X) :
+  is_univalent (path_pregroupoid X i).
 Proof.
   intros; split.
-  - apply is_category_groupoid. apply is_groupoid_path_pregroupoid.
+  - apply is_univalent_groupoid. apply is_groupoid_path_pregroupoid.
   - apply i.
 Qed.
 
 Definition path_groupoid (X:UU) : isofhlevel 3 X -> category.
 Proof. intros iobj. apply (category_pair (path_pregroupoid X iobj)).
-  apply is_category_path_pregroupoid. Defined.
+  apply is_univalent_path_pregroupoid. Defined.
 
 (** *** the discrete category on n objects *)
 

--- a/UniMath/CategoryTheory/categories/StandardCategories.v
+++ b/UniMath/CategoryTheory/categories/StandardCategories.v
@@ -65,14 +65,14 @@ Proof.
   - apply i.
 Qed.
 
-Definition path_groupoid (X:UU) : isofhlevel 3 X -> category.
-Proof. intros iobj. apply (category_pair (path_pregroupoid X iobj)).
+Definition path_groupoid (X:UU) : isofhlevel 3 X -> univalent_category.
+Proof. intros iobj. apply (univalent_category_pair (path_pregroupoid X iobj)).
   apply is_univalent_path_pregroupoid. Defined.
 
-(** *** the discrete category on n objects *)
+(** *** the discrete univalent_category on n objects *)
 
 Require Import UniMath.Combinatorics.StandardFiniteSets.
-Definition cat_n (n:nat):category.
+Definition cat_n (n:nat): univalent_category.
   apply (path_groupoid (stn n)). apply hlevelntosn.
   apply isasetstn. Defined.
 Definition is_discrete (C:Precategory) := isaset (ob C) × is_groupoid C.
@@ -86,7 +86,7 @@ Lemma is_discrete_cat_n (n:nat) : is_discrete (cat_n n).
 Proof. split. apply isasetstn. apply is_groupoid_path_pregroupoid. Qed.
 
 
-Definition unit_category : category.
+Definition unit_category : univalent_category.
 Proof.
   use path_groupoid.
   - exact unit.

--- a/UniMath/CategoryTheory/categories/abgrs.v
+++ b/UniMath/CategoryTheory/categories/abgrs.v
@@ -193,7 +193,7 @@ Section def_abgr_category.
     - use proofirrelevance. use isaprop_is_iso.
   Qed.
 
-  Definition abgr_Precategory_is_category : is_category abgr_Precategory.
+  Definition abgr_Precategory_is_univalent : is_univalent abgr_Precategory.
   Proof.
     use dirprodpair.
     - intros a b. exact (abgr_Precategory_isweq a b).
@@ -201,7 +201,7 @@ Section def_abgr_category.
   Defined.
 
   Definition abgr_category : category :=
-    mk_category abgr_Precategory abgr_Precategory_is_category.
+    mk_category abgr_Precategory abgr_Precategory_is_univalent.
 
 End def_abgr_category.
 

--- a/UniMath/CategoryTheory/categories/abgrs.v
+++ b/UniMath/CategoryTheory/categories/abgrs.v
@@ -200,7 +200,7 @@ Section def_abgr_category.
     - exact has_homsets_abgr.
   Defined.
 
-  Definition abgr_category : category :=
+  Definition abgr_category : univalent_category :=
     mk_category abgr_Precategory abgr_Precategory_is_univalent.
 
 End def_abgr_category.

--- a/UniMath/CategoryTheory/categories/abmonoids.v
+++ b/UniMath/CategoryTheory/categories/abmonoids.v
@@ -175,14 +175,14 @@ Section def_abmonoid_category.
   Defined.
   Opaque abmonoid_precategory_isweq.
 
-  Definition abmonoid_precategory_is_category : is_category abmonoid_precategory.
+  Definition abmonoid_precategory_is_univalent : is_univalent abmonoid_precategory.
   Proof.
-    use mk_is_category.
+    use mk_is_univalent.
     - intros X Y. exact (abmonoid_precategory_isweq X Y).
     - exact has_homsets_abmonoid_precategory.
   Defined.
 
   Definition abmonoid_category : category :=
-    mk_category abmonoid_precategory abmonoid_precategory_is_category.
+    mk_category abmonoid_precategory abmonoid_precategory_is_univalent.
 
 End def_abmonoid_category.

--- a/UniMath/CategoryTheory/categories/abmonoids.v
+++ b/UniMath/CategoryTheory/categories/abmonoids.v
@@ -182,7 +182,7 @@ Section def_abmonoid_category.
     - exact has_homsets_abmonoid_precategory.
   Defined.
 
-  Definition abmonoid_category : category :=
+  Definition abmonoid_category : univalent_category :=
     mk_category abmonoid_precategory abmonoid_precategory_is_univalent.
 
 End def_abmonoid_category.

--- a/UniMath/CategoryTheory/categories/commrigs.v
+++ b/UniMath/CategoryTheory/categories/commrigs.v
@@ -178,7 +178,7 @@ Section def_commrig_category.
     - exact has_homsets_commrig_precategory.
   Defined.
 
-  Definition commrig_category : category :=
+  Definition commrig_category : univalent_category :=
     mk_category commrig_precategory commrig_precategory_is_univalent.
 
 End def_commrig_category.

--- a/UniMath/CategoryTheory/categories/commrigs.v
+++ b/UniMath/CategoryTheory/categories/commrigs.v
@@ -171,14 +171,14 @@ Section def_commrig_category.
   Defined.
   Opaque commrig_precategory_isweq.
 
-  Definition commrig_precategory_is_category : is_category commrig_precategory.
+  Definition commrig_precategory_is_univalent : is_univalent commrig_precategory.
   Proof.
-    use mk_is_category.
+    use mk_is_univalent.
     - intros X Y. exact (commrig_precategory_isweq X Y).
     - exact has_homsets_commrig_precategory.
   Defined.
 
   Definition commrig_category : category :=
-    mk_category commrig_precategory commrig_precategory_is_category.
+    mk_category commrig_precategory commrig_precategory_is_univalent.
 
 End def_commrig_category.

--- a/UniMath/CategoryTheory/categories/commrngs.v
+++ b/UniMath/CategoryTheory/categories/commrngs.v
@@ -172,14 +172,14 @@ Section def_commrng_category.
   Defined.
   Opaque commrng_precategory_isweq.
 
-  Definition commrng_precategory_is_category : is_category commrng_precategory.
+  Definition commrng_precategory_is_univalent : is_univalent commrng_precategory.
   Proof.
-    use mk_is_category.
+    use mk_is_univalent.
     - intros X Y. exact (commrng_precategory_isweq X Y).
     - exact has_homsets_commrng_precategory.
   Defined.
 
   Definition commrng_category : category :=
-    mk_category commrng_precategory commrng_precategory_is_category.
+    mk_category commrng_precategory commrng_precategory_is_univalent.
 
 End def_commrng_category.

--- a/UniMath/CategoryTheory/categories/commrngs.v
+++ b/UniMath/CategoryTheory/categories/commrngs.v
@@ -179,7 +179,7 @@ Section def_commrng_category.
     - exact has_homsets_commrng_precategory.
   Defined.
 
-  Definition commrng_category : category :=
+  Definition commrng_category : univalent_category :=
     mk_category commrng_precategory commrng_precategory_is_univalent.
 
 End def_commrng_category.

--- a/UniMath/CategoryTheory/categories/flds.v
+++ b/UniMath/CategoryTheory/categories/flds.v
@@ -175,6 +175,6 @@ Section def_fld_category.
     - exact has_homsets_fld_precategory.
   Defined.
 
-  Definition fld_category : category := mk_category fld_precategory fld_precategory_is_univalent.
+  Definition fld_category : univalent_category := mk_category fld_precategory fld_precategory_is_univalent.
 
 End def_fld_category.

--- a/UniMath/CategoryTheory/categories/flds.v
+++ b/UniMath/CategoryTheory/categories/flds.v
@@ -168,13 +168,13 @@ Section def_fld_category.
   Defined.
   Opaque fld_precategory_isweq.
 
-  Definition fld_precategory_is_category : is_category fld_precategory.
+  Definition fld_precategory_is_univalent : is_univalent fld_precategory.
   Proof.
-    use mk_is_category.
+    use mk_is_univalent.
     - intros X Y. exact (fld_precategory_isweq X Y).
     - exact has_homsets_fld_precategory.
   Defined.
 
-  Definition fld_category : category := mk_category fld_precategory fld_precategory_is_category.
+  Definition fld_category : category := mk_category fld_precategory fld_precategory_is_univalent.
 
 End def_fld_category.

--- a/UniMath/CategoryTheory/categories/grs.v
+++ b/UniMath/CategoryTheory/categories/grs.v
@@ -166,13 +166,13 @@ Section def_gr_category.
   Defined.
   Opaque gr_precategory_isweq.
 
-  Definition gr_precategory_is_category : is_category gr_precategory.
+  Definition gr_precategory_is_univalent : is_univalent gr_precategory.
   Proof.
-    use mk_is_category.
+    use mk_is_univalent.
     - intros X Y. exact (gr_precategory_isweq X Y).
     - exact has_homsets_gr_precategory.
   Defined.
 
-  Definition gr_category : category := mk_category gr_precategory gr_precategory_is_category.
+  Definition gr_category : category := mk_category gr_precategory gr_precategory_is_univalent.
 
 End def_gr_category.

--- a/UniMath/CategoryTheory/categories/grs.v
+++ b/UniMath/CategoryTheory/categories/grs.v
@@ -173,6 +173,6 @@ Section def_gr_category.
     - exact has_homsets_gr_precategory.
   Defined.
 
-  Definition gr_category : category := mk_category gr_precategory gr_precategory_is_univalent.
+  Definition gr_category : univalent_category := mk_category gr_precategory gr_precategory_is_univalent.
 
 End def_gr_category.

--- a/UniMath/CategoryTheory/categories/intdoms.v
+++ b/UniMath/CategoryTheory/categories/intdoms.v
@@ -171,14 +171,14 @@ Section def_intdom_category.
   Defined.
   Opaque intdom_precategory_isweq.
 
-  Definition intdom_precategory_is_category : is_category intdom_precategory.
+  Definition intdom_precategory_is_univalent : is_univalent intdom_precategory.
   Proof.
-    use mk_is_category.
+    use mk_is_univalent.
     - intros X Y. exact (intdom_precategory_isweq X Y).
     - exact has_homsets_intdom_precategory.
   Defined.
 
   Definition intdom_category : category :=
-    mk_category intdom_precategory intdom_precategory_is_category.
+    mk_category intdom_precategory intdom_precategory_is_univalent.
 
 End def_intdom_category.

--- a/UniMath/CategoryTheory/categories/intdoms.v
+++ b/UniMath/CategoryTheory/categories/intdoms.v
@@ -178,7 +178,7 @@ Section def_intdom_category.
     - exact has_homsets_intdom_precategory.
   Defined.
 
-  Definition intdom_category : category :=
+  Definition intdom_category : univalent_category :=
     mk_category intdom_precategory intdom_precategory_is_univalent.
 
 End def_intdom_category.

--- a/UniMath/CategoryTheory/categories/monoids.v
+++ b/UniMath/CategoryTheory/categories/monoids.v
@@ -175,7 +175,7 @@ Section def_monoid_category.
     - exact has_homsets_monoid_precategory.
   Defined.
 
-  Definition monoid_category : category :=
+  Definition monoid_category : univalent_category :=
     mk_category monoid_precategory monoid_precategory_is_univalent.
 
 End def_monoid_category.

--- a/UniMath/CategoryTheory/categories/monoids.v
+++ b/UniMath/CategoryTheory/categories/monoids.v
@@ -168,14 +168,14 @@ Section def_monoid_category.
   Defined.
   Opaque monoid_precategory_isweq.
 
-  Definition monoid_precategory_is_category : is_category monoid_precategory.
+  Definition monoid_precategory_is_univalent : is_univalent monoid_precategory.
   Proof.
-    use mk_is_category.
+    use mk_is_univalent.
     - intros X Y. exact (monoid_precategory_isweq X Y).
     - exact has_homsets_monoid_precategory.
   Defined.
 
   Definition monoid_category : category :=
-    mk_category monoid_precategory monoid_precategory_is_category.
+    mk_category monoid_precategory monoid_precategory_is_univalent.
 
 End def_monoid_category.

--- a/UniMath/CategoryTheory/categories/rigs.v
+++ b/UniMath/CategoryTheory/categories/rigs.v
@@ -176,7 +176,7 @@ Section def_rig_category.
     - exact has_homsets_rig_precategory.
   Defined.
 
-  Definition rig_category : category :=
+  Definition rig_category : univalent_category :=
     mk_category rig_precategory rig_precategory_is_univalent.
 
 End def_rig_category.

--- a/UniMath/CategoryTheory/categories/rigs.v
+++ b/UniMath/CategoryTheory/categories/rigs.v
@@ -169,14 +169,14 @@ Section def_rig_category.
   Defined.
   Opaque rig_precategory_isweq.
 
-  Definition rig_precategory_is_category : is_category rig_precategory.
+  Definition rig_precategory_is_univalent : is_univalent rig_precategory.
   Proof.
-    use mk_is_category.
+    use mk_is_univalent.
     - intros X Y. exact (rig_precategory_isweq X Y).
     - exact has_homsets_rig_precategory.
   Defined.
 
   Definition rig_category : category :=
-    mk_category rig_precategory rig_precategory_is_category.
+    mk_category rig_precategory rig_precategory_is_univalent.
 
 End def_rig_category.

--- a/UniMath/CategoryTheory/categories/rngs.v
+++ b/UniMath/CategoryTheory/categories/rngs.v
@@ -175,7 +175,7 @@ Section def_rng_category.
     - exact has_homsets_rng_precategory.
   Defined.
 
-  Definition rng_category : category :=
+  Definition rng_category : univalent_category :=
     mk_category rng_precategory rng_precategory_is_univalent.
 
 End def_rng_category.

--- a/UniMath/CategoryTheory/categories/rngs.v
+++ b/UniMath/CategoryTheory/categories/rngs.v
@@ -168,14 +168,14 @@ Section def_rng_category.
   Defined.
   Opaque rng_precategory_isweq.
 
-  Definition rng_precategory_is_category : is_category rng_precategory.
+  Definition rng_precategory_is_univalent : is_univalent rng_precategory.
   Proof.
-    use mk_is_category.
+    use mk_is_univalent.
     - intros X Y. exact (rng_precategory_isweq X Y).
     - exact has_homsets_rng_precategory.
   Defined.
 
   Definition rng_category : category :=
-    mk_category rng_precategory rng_precategory_is_category.
+    mk_category rng_precategory rng_precategory_is_univalent.
 
 End def_rng_category.

--- a/UniMath/CategoryTheory/categories/setwith2binops.v
+++ b/UniMath/CategoryTheory/categories/setwith2binops.v
@@ -184,7 +184,7 @@ Section def_setwith2binop_category.
     - exact has_homsets_setwith2binop_precategory.
   Defined.
 
-  Definition setwith2binop_category : category :=
+  Definition setwith2binop_category : univalent_category :=
     mk_category setwith2binop_precategory setwith2binop_precategory_is_univalent.
 
 End def_setwith2binop_category.

--- a/UniMath/CategoryTheory/categories/setwith2binops.v
+++ b/UniMath/CategoryTheory/categories/setwith2binops.v
@@ -177,14 +177,14 @@ Section def_setwith2binop_category.
   Defined.
   Opaque setwith2binop_precategory_isweq.
 
-  Definition setwith2binop_precategory_is_category : is_category setwith2binop_precategory.
+  Definition setwith2binop_precategory_is_univalent : is_univalent setwith2binop_precategory.
   Proof.
-    use mk_is_category.
+    use mk_is_univalent.
     - intros X Y. exact (setwith2binop_precategory_isweq X Y).
     - exact has_homsets_setwith2binop_precategory.
   Defined.
 
   Definition setwith2binop_category : category :=
-    mk_category setwith2binop_precategory setwith2binop_precategory_is_category.
+    mk_category setwith2binop_precategory setwith2binop_precategory_is_univalent.
 
 End def_setwith2binop_category.

--- a/UniMath/CategoryTheory/category_binops.v
+++ b/UniMath/CategoryTheory/category_binops.v
@@ -207,7 +207,7 @@ Section BINOP_category.
   Defined.
   Opaque binop_precategory_isweq.
 
-  Definition binop_precategory_is_category : is_category binop_precategory.
+  Definition binop_precategory_is_univalent : is_univalent binop_precategory.
   Proof.
     use dirprodpair.
     - intros a b. exact (binop_precategory_isweq a b).

--- a/UniMath/CategoryTheory/category_hset.v
+++ b/UniMath/CategoryTheory/category_hset.v
@@ -15,7 +15,7 @@ Contents :
 
             Precategory HSET of hSets
 
-	    HSET is a category
+	    HSET is a univalent_category
 
 	    Colimits in HSET
 
@@ -74,7 +74,7 @@ End HSET_precategory.
 Notation "'HSET'" := hset_precategory : cat.
 Notation "'SET'" := hset_Precategory : cat.
 
-(** * The precategory of hSets is a category. *)
+(** * The precategory of hSets is a univalent_category. *)
 
 Section HSET_category.
 
@@ -167,7 +167,7 @@ Proof.
   apply hset_equiv_iso_is_equiv.
 Defined.
 
-(** ** HSET is a category. *)
+(** ** HSET is a univalent_category. *)
 
 Definition univalenceweq (X X' : UU) : weq (X = X') (weq X X') :=
    tpair _ _ (univalenceAxiom X X').

--- a/UniMath/CategoryTheory/category_hset.v
+++ b/UniMath/CategoryTheory/category_hset.v
@@ -204,7 +204,7 @@ Proof.
   apply (pr2 (hset_id_iso_weq A B)).
 Defined.
 
-Lemma is_category_HSET : is_category HSET.
+Lemma is_univalent_HSET : is_univalent HSET.
 Proof.
   split.
   - apply is_weq_precat_paths_to_iso_hset.

--- a/UniMath/CategoryTheory/equivalences.v
+++ b/UniMath/CategoryTheory/equivalences.v
@@ -279,14 +279,14 @@ Defined.
 (**  Fundamentally needed that both source and target are categories *)
 
 Lemma adj_equiv_of_cats_is_weq_of_objects (A B : precategory)
-   (HA : is_category A) (HB : is_category B) (F : [A, B, pr2 HB ])
+   (HA : is_univalent A) (HB : is_univalent B) (F : [A, B, pr2 HB ])
    (HF : adj_equivalence_of_precats F) : isweq (pr1 (pr1 F)).
 Proof.
   set (G := right_adjoint (pr1 HF)).
   set (et := unit_iso_from_adj_equivalence_of_precats (pr2 HA)  HF).
   set (ep := counit_iso_from_adj_equivalence_of_precats _ HF).
-  set (AAcat := is_category_functor_category A _ HA).
-  set (BBcat := is_category_functor_category B _ HB).
+  set (AAcat := is_univalent_functor_category A _ HA).
+  set (BBcat := is_univalent_functor_category B _ HB).
   set (Et := isotoid _ AAcat et).
   set (Ep := isotoid _ BBcat ep).
   apply (gradth _ (fun b => pr1 (right_adjoint (pr1 HF)) b)); intro a.
@@ -295,7 +295,7 @@ Proof.
 Defined.
 
 Definition weq_on_objects_from_adj_equiv_of_cats (A B : precategory)
-   (HA : is_category A) (HB : is_category B) (F : ob [A, B, pr2 HB])
+   (HA : is_univalent A) (HB : is_univalent B) (F : ob [A, B, pr2 HB])
    (HF : adj_equivalence_of_precats F) : weq
           (ob A) (ob B).
 Proof.
@@ -308,7 +308,7 @@ Defined.
      is a proposition *)
 
 
-Lemma isaprop_sigma_iso (A B : precategory) (HA : is_category A) (*hsB: has_homsets B*)
+Lemma isaprop_sigma_iso (A B : precategory) (HA : is_univalent A) (*hsB: has_homsets B*)
      (F : functor A B) (HF : fully_faithful F) :
       ∏ b : ob B,
   isaprop (total2 (fun a : ob A => iso (pr1 F a) b)).
@@ -356,7 +356,7 @@ Proof.
 Qed.
 
 
-Lemma isaprop_pi_sigma_iso (A B : precategory) (HA : is_category A) (hsB: has_homsets B)
+Lemma isaprop_pi_sigma_iso (A B : precategory) (HA : is_univalent A) (hsB: has_homsets B)
      (F : ob [A, B, hsB]) (HF : fully_faithful F) :
   isaprop (∏ b : ob B,
              total2 (fun a : ob A => iso (pr1 F a) b)).
@@ -376,7 +376,7 @@ Qed.
 Section from_fully_faithful_and_ess_surj_to_equivalence.
 
 Variables A B : precategory.
-Hypothesis HA : is_category A.
+Hypothesis HA : is_univalent A.
 Variable F : functor A B.
 Hypothesis HF : fully_faithful F.
 Hypothesis HS : essentially_surjective F.

--- a/UniMath/CategoryTheory/equivalences.v
+++ b/UniMath/CategoryTheory/equivalences.v
@@ -12,7 +12,7 @@ Contents:
 
 - Definition of equivalence of precategories
 - Equivalence of categories yields weak equivalence of object types
-- A fully faithful and ess. surjective functor induces equivalence of precategories, if the source is a category.
+- A fully faithful and ess. surjective functor induces equivalence of precategories, if the source is a univalent_category.
 
 ************************************************************)
 
@@ -304,7 +304,7 @@ Proof.
 Defined.
 
 
-(** If the source precategory is a category, then being split essentially surjective
+(** If the source precategory is a univalent_category, then being split essentially surjective
      is a proposition *)
 
 
@@ -370,7 +370,7 @@ Qed.
 
 (** A fully faithful and ess. surjective functor induces an
    equivalence of precategories, if the source is a
-    category.
+    univalent_category.
 *)
 
 Section from_fully_faithful_and_ess_surj_to_equivalence.

--- a/UniMath/CategoryTheory/functor_categories.v
+++ b/UniMath/CategoryTheory/functor_categories.v
@@ -37,10 +37,10 @@ Contents :
                          isomorphisms
 
                 - Isomorphic Functors are equal
-                   if target precategory is category
+                   if target precategory is univalent_category
                    [functor_eq_from_functor_iso]
 
-                - Functor precategory is category if
+                - Functor precategory is univalent_category if
                    target precategory is
                    [is_univalent_functor_category]
 

--- a/UniMath/CategoryTheory/functor_categories.v
+++ b/UniMath/CategoryTheory/functor_categories.v
@@ -42,7 +42,7 @@ Contents :
 
                 - Functor precategory is category if
                    target precategory is
-                   [is_category_functor_category]
+                   [is_univalent_functor_category]
 
 
 ************************************************************)
@@ -296,8 +296,8 @@ Proof.
   apply (! functor_id _ _ ).
 Qed.
 
-Hypothesis HC : is_category C.
-Hypothesis HD : is_category D.
+Hypothesis HC : is_univalent C.
+Hypothesis HD : is_univalent D.
 
 Lemma maponpaths_isotoid (a b : C) (i : iso a b)
 : maponpaths (functor_on_objects F) (isotoid _ HC i)
@@ -545,7 +545,7 @@ Proof.
 Defined.
 
 Lemma ff_is_inclusion_on_objects {C D : precategory}
-      (HC : is_category C) (HD : is_category D)
+      (HC : is_univalent C) (HD : is_univalent D)
       (F : functor C D) (HF : fully_faithful F)
       : isofhlevelf 1 (functor_on_objects F).
 Proof.
@@ -1104,7 +1104,7 @@ Defined.
 
 Definition pr1_pr1_functor_eq_from_functor_iso (C : precategory_data) (D : precategory)
   (hs: has_homsets D)
-    (H : is_category D) (F G : ob [C , D, hs]) :
+    (H : is_univalent D) (F G : ob [C , D, hs]) :
    iso F G -> pr1 (pr1 F) = pr1 (pr1 G).
 Proof.
   intro A.
@@ -1145,7 +1145,7 @@ Proof.
 Qed.
 
 Definition pr1_functor_eq_from_functor_iso (C : precategory_data) (D : precategory)(hs: has_homsets D)
-    (H : is_category D) (F G : ob [C , D, hs]) :
+    (H : is_univalent D) (F G : ob [C , D, hs]) :
    iso F G -> pr1 F = pr1 G.
 Proof.
   intro A.
@@ -1194,7 +1194,7 @@ Defined.
 
 Definition functor_eq_from_functor_iso {C : precategory_data} {D : precategory}
   (hs: has_homsets D)
-    (H : is_category D) (F G : ob [C , D, hs])
+    (H : is_univalent D) (F G : ob [C , D, hs])
     (H' : iso F G) : F = G.
 Proof.
   apply (functor_eq _ _ hs F G).
@@ -1218,7 +1218,7 @@ Qed.
 
 Lemma functor_eq_from_functor_iso_idtoiso (C : precategory_data) (D : precategory)
   (hs: has_homsets D)
-    (H : is_category D)
+    (H : is_univalent D)
     (F G : ob [C, D, hs]) (p : F = G) :
   functor_eq_from_functor_iso _ H F G (idtoiso p) = p.
 Proof.
@@ -1239,7 +1239,7 @@ Qed.
 
 Lemma idtoiso_functor_eq_from_functor_iso (C : precategory_data) (D : precategory)
   (hs: has_homsets D)
-    (H : is_category D)
+    (H : is_univalent D)
     (F G : ob [C, D, hs]) (gamma : iso F G) :
         idtoiso (functor_eq_from_functor_iso _ H F G gamma) = gamma.
 Proof.
@@ -1271,7 +1271,7 @@ Proof.
   apply idpath.
 Qed.
 
-Lemma isweq_idtoiso_functorcat (C : precategory_data) (D : precategory) (H : is_category D)
+Lemma isweq_idtoiso_functorcat (C : precategory_data) (D : precategory) (H : is_univalent D)
     (F G : ob [C, D, (pr2 H)]) :
    isweq (@idtoiso _ F G).
 Proof.
@@ -1280,8 +1280,8 @@ Proof.
   apply idtoiso_functor_eq_from_functor_iso.
 Defined.
 
-Lemma is_category_functor_category (C : precategory_data) (D : precategory) (H : is_category D) :
-   is_category [C, D, (pr2 H)].
+Lemma is_univalent_functor_category (C : precategory_data) (D : precategory) (H : is_univalent D) :
+   is_univalent [C, D, (pr2 H)].
 Proof.
   split.
   - intros F G.

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -210,7 +210,7 @@ Qed.
 
 Section coproduct_unique.
 
-Hypothesis H : is_category C.
+Hypothesis H : is_univalent C.
 
 Variables a b : C.
 

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -2,7 +2,7 @@
 
 Direct implementation of binary coproducts togther with:
 
-- Proof that binary coproduct(cocone) is a property in a category ([isaprop_BinCoproductCocone])
+- Proof that binary coproduct(cocone) is a property in a univalent_category ([isaprop_BinCoproductCocone])
 - Specialized versions of beta rules for coproducts
 - Definition of binary coproduct functor ([bincoproduct_functor])
 - Definition of a coproduct structure on a functor category by taking pointwise coproducts in the
@@ -206,7 +206,7 @@ Proof.
 Qed.
 
 
-(** * Proof that coproducts are unique when the precategory [C] is a category *)
+(** * Proof that coproducts are unique when the precategory [C] is a univalent_category *)
 
 Section coproduct_unique.
 

--- a/UniMath/CategoryTheory/limits/cats/limits.v
+++ b/UniMath/CategoryTheory/limits/cats/limits.v
@@ -284,7 +284,7 @@ Definition Lims_of_shape (J C : precategory) : UU := ∏ (F : functor J C), LimC
 
 Section Universal_Unique.
 
-Context (C : category).
+Context (C : univalent_category).
 
 Let H : is_univalent C := pr2 C.
 

--- a/UniMath/CategoryTheory/limits/cats/limits.v
+++ b/UniMath/CategoryTheory/limits/cats/limits.v
@@ -286,7 +286,7 @@ Section Universal_Unique.
 
 Context (C : category).
 
-Let H : is_category C := pr2 C.
+Let H : is_univalent C := pr2 C.
 
 Lemma isaprop_Lims: isaprop (Lims C).
 Proof.

--- a/UniMath/CategoryTheory/limits/cones.v
+++ b/UniMath/CategoryTheory/limits/cones.v
@@ -1,7 +1,7 @@
 (**
 
 Definition of the precategory of cones over a precategory C together with a proof that that
-precategory is a category if C is ([is_category_CONE]).
+precategory is a category if C is ([is_univalent_CONE]).
 
 Written by Benedikt Ahrens, following discussions with J. Gross, D. Grayson and V. Voevodsky
 *)
@@ -215,7 +215,7 @@ Defined.
 
 Section CONE_category.
 
-Hypothesis is_cat_C : is_category C.
+Hypothesis is_cat_C : is_univalent C.
 
 
 Definition isotoid_CONE_pr1 (a b : CONE) : iso a b -> pr1 a = pr1 b.
@@ -317,7 +317,7 @@ Proof.
 Qed.
 
 
-Lemma is_category_CONE : is_category CONE.
+Lemma is_univalent_CONE : is_univalent CONE.
 Proof.
   split.
   - intros a b.

--- a/UniMath/CategoryTheory/limits/cones.v
+++ b/UniMath/CategoryTheory/limits/cones.v
@@ -1,7 +1,7 @@
 (**
 
 Definition of the precategory of cones over a precategory C together with a proof that that
-precategory is a category if C is ([is_univalent_CONE]).
+precategory is a univalent_category if C is ([is_univalent_CONE]).
 
 Written by Benedikt Ahrens, following discussions with J. Gross, D. Grayson and V. Voevodsky
 *)

--- a/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
@@ -196,7 +196,7 @@ Proof.
 Qed.
 
 
-(** * Proof that coproducts are unique when the precategory [C] is a category *)
+(** * Proof that coproducts are unique when the precategory [C] is a univalent_category *)
 
 Section coproduct_unique.
 

--- a/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
@@ -200,7 +200,7 @@ Qed.
 
 Section coproduct_unique.
 
-Hypothesis H : is_category C.
+Hypothesis H : is_univalent C.
 
 Variables a b : C.
 

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -383,7 +383,7 @@ Section Universal_Unique.
 
 Variables (C : category).
 
-Let H : is_category C := pr2 C.
+Let H : is_univalent C := pr2 C.
 
 Lemma isaprop_Colims: isaprop (Colims C).
 Proof.

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -378,10 +378,10 @@ Definition hasColims (C : precategory) : UU  :=
 Definition Colims_of_shape (g : graph) (C : precategory) : UU :=
   ∏ (d : diagram g C), ColimCocone d.
 
-(** If C is a category then Colims is a prop *)
+(** If C is a univalent_category then Colims is a prop *)
 Section Universal_Unique.
 
-Variables (C : category).
+Variables (C : univalent_category).
 
 Let H : is_univalent C := pr2 C.
 
@@ -396,7 +396,7 @@ apply subtypeEquality.
   set (C' (c : C) f := ∏ u v (e : edge u v), @compose _ _ _ c (dmor cc e) (f v) = f u).
   rewrite (@transportf_total2 _ B C').
   apply subtypeEquality.
-  + intro; repeat (apply impred; intro); apply category_has_homsets.
+  + intro; repeat (apply impred; intro); apply univalent_category_has_homsets.
   + simpl; eapply pathscomp0; [apply transportf_isotoid_dep''|].
     apply funextsec; intro v.
     now rewrite idtoiso_isotoid; apply colimArrowCommutes.

--- a/UniMath/CategoryTheory/limits/graphs/initial.v
+++ b/UniMath/CategoryTheory/limits/graphs/initial.v
@@ -104,7 +104,7 @@ Definition hasInitial := ishinh Initial.
 (* TODO: This should be an instance of a general result for colimits *)
 (* Section Initial_Unique. *)
 
-(* Hypothesis H : is_category C. *)
+(* Hypothesis H : is_univalent C. *)
 
 (* Lemma isaprop_Initial : isaprop Initial. *)
 (* Proof. *)

--- a/UniMath/CategoryTheory/limits/graphs/limits.v
+++ b/UniMath/CategoryTheory/limits/graphs/limits.v
@@ -339,7 +339,7 @@ Section Universal_Unique.
 
 Variable (C : category).
 
-Let H : is_category C := pr2 C.
+Let H : is_univalent C := pr2 C.
 
 Lemma isaprop_Lims : isaprop (Lims C).
 Proof.

--- a/UniMath/CategoryTheory/limits/graphs/limits.v
+++ b/UniMath/CategoryTheory/limits/graphs/limits.v
@@ -337,7 +337,7 @@ Definition Lims_of_shape (g : graph) (C : precategory) : UU :=
 
 Section Universal_Unique.
 
-Variable (C : category).
+Variable (C : univalent_category).
 
 Let H : is_univalent C := pr2 C.
 
@@ -352,7 +352,7 @@ apply subtypeEquality.
   set (C' (c : C) f := ∏ u v (e : edge u v), @compose _ c _ _ (f u) (dmor cc e) = f v).
   rewrite (@transportf_total2 _ B C').
   apply subtypeEquality.
-  + intro; repeat (apply impred; intro); apply category_has_homsets.
+  + intro; repeat (apply impred; intro); apply univalent_category_has_homsets.
   + abstract (now simpl; eapply pathscomp0; [apply transportf_isotoid_dep'|];
               apply funextsec; intro v; rewrite inv_isotoid, idtoiso_isotoid;
               cbn; unfold precomp_with; rewrite id_right; apply limArrowCommutes).

--- a/UniMath/CategoryTheory/limits/graphs/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/graphs/pullbacks.v
@@ -489,7 +489,7 @@ End pullback_lemma.
 
 Section Universal_Unique.
 
-Hypothesis H : is_category C.
+Hypothesis H : is_univalent C.
 
 
 Lemma inv_from_iso_iso_from_Pullback (a b c : C) (f : C⟦b, a⟧) (g : C⟦c, a⟧)

--- a/UniMath/CategoryTheory/limits/graphs/pushouts.v
+++ b/UniMath/CategoryTheory/limits/graphs/pushouts.v
@@ -293,7 +293,7 @@ Section def_po.
 
   Section Universal_Unique.
 
-    Hypothesis H : is_category C.
+    Hypothesis H : is_univalent C.
 
     Lemma inv_from_iso_iso_from_Pushout (a b c : C) (f : C⟦a, b⟧) (g : C⟦a, c⟧)
           (Po : Pushout f g) (Po' : Pushout f g):

--- a/UniMath/CategoryTheory/limits/graphs/terminal.v
+++ b/UniMath/CategoryTheory/limits/graphs/terminal.v
@@ -105,7 +105,7 @@ Definition hasTerminal := ishinh Terminal.
 (* TODO: This should be an instance of a general result for limits *)
 (* Section Terminal_Unique. *)
 
-(* Hypothesis H : is_category C. *)
+(* Hypothesis H : is_univalent C. *)
 
 (* Lemma isaprop_Terminal : isaprop Terminal. *)
 (* Proof. *)

--- a/UniMath/CategoryTheory/limits/initial.v
+++ b/UniMath/CategoryTheory/limits/initial.v
@@ -78,7 +78,7 @@ Definition hasInitial := ishinh Initial.
 (** * Being initial is a property in a (saturated/univalent) category *)
 Section Initial_Unique.
 
-Hypothesis H : is_category C.
+Hypothesis H : is_univalent C.
 
 Lemma isaprop_Initial : isaprop Initial.
 Proof.

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -316,7 +316,7 @@ End pullback_lemma.
 
 Section Universal_Unique.
 
-Hypothesis H : is_category C.
+Hypothesis H : is_univalent C.
 
 Lemma inv_from_iso_iso_from_Pullback (a b c : C) (f : b --> a) (g : c --> a)
   (Pb : Pullback f g) (Pb' : Pullback f g):

--- a/UniMath/CategoryTheory/limits/pushouts.v
+++ b/UniMath/CategoryTheory/limits/pushouts.v
@@ -246,7 +246,7 @@ Section def_po.
 
   Section Universal_Unique.
 
-    Hypothesis H : is_category C.
+    Hypothesis H : is_univalent C.
 
 
     Lemma inv_from_iso_iso_from_Pushout (a b c : C) (f : a --> b) (g : a --> c)

--- a/UniMath/CategoryTheory/limits/terminal.v
+++ b/UniMath/CategoryTheory/limits/terminal.v
@@ -73,7 +73,7 @@ Definition hasTerminal := ishinh Terminal.
 
 Section Terminal_Unique.
 
-Hypothesis H : is_category C.
+Hypothesis H : is_univalent C.
 
 Lemma isaprop_Terminal : isaprop Terminal.
 Proof.

--- a/UniMath/CategoryTheory/limits/zero.v
+++ b/UniMath/CategoryTheory/limits/zero.v
@@ -126,7 +126,7 @@ Section def_zero.
   Definition hasZero := ishinh Zero.
 
   Section Zero_Unique.
-    Hypothesis H : is_category C.
+    Hypothesis H : is_univalent C.
 
     Lemma isaprop_Zero : isaprop Zero.
     Proof.

--- a/UniMath/CategoryTheory/precategories.v
+++ b/UniMath/CategoryTheory/precategories.v
@@ -1187,25 +1187,25 @@ Proof.
     apply isapropisaset.
 Qed.
 
-Definition category : UU := total2 (fun C : precategory => is_univalent C).
+Definition univalent_category : UU := total2 (fun C : precategory => is_univalent C).
 
-Definition mk_category (C : precategory) (H : is_univalent C) : category := tpair _ C H.
+Definition mk_category (C : precategory) (H : is_univalent C) : univalent_category := tpair _ C H.
 
-Definition category_to_Precategory (C : category) : Precategory.
+Definition univalent_category_to_Precategory (C : univalent_category) : Precategory.
 Proof.
   exists (pr1 C).
   exact (pr2 (pr2 C)).
 Defined.
-Coercion category_to_Precategory : category >-> Precategory.
+Coercion univalent_category_to_Precategory : univalent_category >-> Precategory.
 
-Definition category_pair (C:precategory) (i:is_univalent C) : category := C,,i.
+Definition univalent_category_pair (C:precategory) (i:is_univalent C) : univalent_category := C,,i.
 
 
-Definition category_has_homsets (C : category) := pr2 (pr2 C).
+Definition univalent_category_has_homsets (C : univalent_category) := pr2 (pr2 C).
 
-Definition category_is_univalent (C : category) : is_univalent C := pr2 C.
+Definition univalent_category_is_univalent (C : univalent_category) : is_univalent C := pr2 C.
 
-Lemma category_has_groupoid_ob (C : category): isofhlevel 3 (ob C).
+Lemma univalent_category_has_groupoid_ob (C : univalent_category): isofhlevel 3 (ob C).
 Proof.
   change (isofhlevel 3 C) with
         (∏ a b : C, isofhlevel 2 (a = b)).

--- a/UniMath/CategoryTheory/precategories.v
+++ b/UniMath/CategoryTheory/precategories.v
@@ -1160,11 +1160,11 @@ Proof.
 Defined.
 
 (* use eta expanded version to force printing of object arguments *)
-Definition is_category (C : precategory) :=
+Definition is_univalent (C : precategory) :=
   (∏ (a b : ob C), isweq (fun p : a = b => idtoiso p)) × (has_homsets C).
 
-Definition mk_is_category {C : precategory} (H1 : ∏ (a b : ob C), isweq (fun p : a = b => idtoiso p))
-           (H2 : has_homsets C) : is_category C := dirprodpair H1 H2.
+Definition mk_is_univalent {C : precategory} (H1 : ∏ (a b : ob C), isweq (fun p : a = b => idtoiso p))
+           (H2 : has_homsets C) : is_univalent C := dirprodpair H1 H2.
 
 Lemma eq_idtoiso_idtomor {C:precategory} (a b:ob C) (e:a = b) :
     pr1 (idtoiso e) = idtomor _ _ e.
@@ -1172,7 +1172,7 @@ Proof.
   destruct e; reflexivity.
 Defined.
 
-Lemma isaprop_is_category (C : precategory) : isaprop (is_category C).
+Lemma isaprop_is_univalent (C : precategory) : isaprop (is_univalent C).
 Proof.
   apply isapropdirprod.
   - apply impred.
@@ -1187,9 +1187,9 @@ Proof.
     apply isapropisaset.
 Qed.
 
-Definition category : UU := total2 (fun C : precategory => is_category C).
+Definition category : UU := total2 (fun C : precategory => is_univalent C).
 
-Definition mk_category (C : precategory) (H : is_category C) : category := tpair _ C H.
+Definition mk_category (C : precategory) (H : is_univalent C) : category := tpair _ C H.
 
 Definition category_to_Precategory (C : category) : Precategory.
 Proof.
@@ -1198,12 +1198,12 @@ Proof.
 Defined.
 Coercion category_to_Precategory : category >-> Precategory.
 
-Definition category_pair (C:precategory) (i:is_category C) : category := C,,i.
+Definition category_pair (C:precategory) (i:is_univalent C) : category := C,,i.
 
 
 Definition category_has_homsets (C : category) := pr2 (pr2 C).
 
-Definition category_is_category (C : category) : is_category C := pr2 C.
+Definition category_is_univalent (C : category) : is_univalent C := pr2 C.
 
 Lemma category_has_groupoid_ob (C : category): isofhlevel 3 (ob C).
 Proof.
@@ -1217,10 +1217,10 @@ Qed.
 
 (** ** Definition of [isotoid] *)
 
-Definition isotoid (C : precategory) (H : is_category C) {a b : ob C}:
+Definition isotoid (C : precategory) (H : is_univalent C) {a b : ob C}:
       iso a b -> a = b := invmap (weqpair _ (pr1 H a b)).
 
-Lemma idtoiso_isotoid (C : precategory) (H : is_category C) (a b : ob C)
+Lemma idtoiso_isotoid (C : precategory) (H : is_univalent C) (a b : ob C)
     (f : iso a b) : idtoiso (isotoid _ H f) = f.
 Proof.
   unfold isotoid.
@@ -1229,7 +1229,7 @@ Proof.
   apply Hw.
 Qed.
 
-Lemma isotoid_idtoiso (C : precategory) (H : is_category C) (a b : ob C)
+Lemma isotoid_idtoiso (C : precategory) (H : is_univalent C) (a b : ob C)
     (p : a = b) : isotoid _ H (idtoiso p) = p.
 Proof.
   unfold isotoid.
@@ -1307,7 +1307,7 @@ Proof.
   simpl; apply pathsinv0, id_left.
 Qed.
 
-Lemma idtoiso_inj (C : precategory) (H : is_category C) (a a' : ob C)
+Lemma idtoiso_inj (C : precategory) (H : is_univalent C) (a a' : ob C)
    (p p' : a = a') : idtoiso p = idtoiso p' -> p = p'.
 Proof.
   apply invmaponpathsincl.
@@ -1315,7 +1315,7 @@ Proof.
   apply H.
 Qed.
 
-Lemma isotoid_inj (C : precategory) (H : is_category C) (a a' : ob C)
+Lemma isotoid_inj (C : precategory) (H : is_univalent C) (a a' : ob C)
    (f f' : iso a a') : isotoid _ H f = isotoid _ H f' -> f = f'.
 Proof.
   apply invmaponpathsincl.
@@ -1323,7 +1323,7 @@ Proof.
   apply isweqinvmap.
 Qed.
 
-Lemma isotoid_comp (C : precategory) (H : is_category C) (a b c : ob C)
+Lemma isotoid_comp (C : precategory) (H : is_univalent C) (a b c : ob C)
   (e : iso a b) (f : iso b c) :
   isotoid _ H (iso_comp e f) = isotoid _ H e @ isotoid _ H f.
 Proof.
@@ -1334,7 +1334,7 @@ Proof.
   apply idpath.
 Qed.
 
-Lemma isotoid_identity_iso (C : precategory) (H : is_category C) (a : C) :
+Lemma isotoid_identity_iso (C : precategory) (H : is_univalent C) (a : C) :
   isotoid _ H (identity_iso a) = idpath _ .
 Proof.
   apply idtoiso_inj; try assumption.
@@ -1342,7 +1342,7 @@ Proof.
   apply idpath.
 Qed.
 
-Lemma inv_isotoid (C : precategory) (H : is_category C) (a b : C)
+Lemma inv_isotoid (C : precategory) (H : is_univalent C) (a b : C)
     (f : iso a b) : ! isotoid _ H f = isotoid _ H (iso_inv_from_iso f).
 Proof.
   apply idtoiso_inj; try assumption.
@@ -1352,7 +1352,7 @@ Proof.
   apply idpath.
 Qed.
 
-Lemma transportf_isotoid (C : precategory) (H : is_category C)
+Lemma transportf_isotoid (C : precategory) (H : is_univalent C)
    (a a' b : ob C) (p : iso a a') (f : a --> b) :
  transportf (fun a0 : C => a0 --> b) (isotoid C H p) f = inv_from_iso p · f.
 Proof.
@@ -1362,7 +1362,7 @@ Proof.
   apply idpath.
 Qed.
 
-Lemma transportf_isotoid' (C : precategory) (H : is_category C)
+Lemma transportf_isotoid' (C : precategory) (H : is_univalent C)
    (a b b' : ob C) (p : iso b b') (f : a --> b) :
  transportf (fun a0 : C => a --> a0) (isotoid C H p) f = f · p.
 Proof.

--- a/UniMath/CategoryTheory/precomp_ess_surj.v
+++ b/UniMath/CategoryTheory/precomp_ess_surj.v
@@ -55,7 +55,7 @@ Section precomp_w_ess_surj_ff_is_ess_surj.
 (** ** Section variables *)
 
 Variables A B C : precategory.
-Hypothesis Ccat : is_category C.
+Hypothesis Ccat : is_univalent C.
 Variable H : functor A B.
 Hypothesis p : essentially_surjective H.
 Hypothesis fH : fully_faithful H.

--- a/UniMath/CategoryTheory/rezk_completion.v
+++ b/UniMath/CategoryTheory/rezk_completion.v
@@ -45,7 +45,7 @@ Section rezk.
 Variable A : precategory.
 Hypothesis hsA: has_homsets A.
 
-Definition Rezk_completion : category.
+Definition Rezk_completion : univalent_category.
 Proof.
   exists (full_img_sub_precategory (yoneda A hsA)).
   apply is_univalent_full_subcat.
@@ -73,9 +73,9 @@ End rezk.
 (** * Universal property of the Rezk completion *)
 
 Definition functor_from (C : precategory) : UU
-  := ∑ D : category, functor C D.
+  := ∑ D : univalent_category, functor C D.
 
-Coercion target_category (C : precategory) (X : functor_from C) : category := pr1 X.
+Coercion target_category (C : precategory) (X : functor_from C) : univalent_category := pr1 X.
 Definition func_functor_from {C : precategory} (X : functor_from C) : functor C X := pr2 X.
 
 Definition is_initial_functor_from (C : precategory) (X : functor_from C) : UU

--- a/UniMath/CategoryTheory/rezk_completion.v
+++ b/UniMath/CategoryTheory/rezk_completion.v
@@ -48,8 +48,8 @@ Hypothesis hsA: has_homsets A.
 Definition Rezk_completion : category.
 Proof.
   exists (full_img_sub_precategory (yoneda A hsA)).
-  apply is_category_full_subcat.
-  apply (is_category_functor_category _ _ is_category_HSET).
+  apply is_univalent_full_subcat.
+  apply (is_univalent_functor_category _ _ is_univalent_HSET).
 Defined.
 
 Definition Rezk_eta : functor A Rezk_completion.
@@ -91,7 +91,7 @@ Hypothesis hsA: has_homsets A.
 Section fix_a_category.
 
 Variable C : precategory.
-Hypothesis Ccat : is_category C.
+Hypothesis Ccat : is_univalent C.
 
 Lemma pre_comp_rezk_eta_is_fully_faithful :
     fully_faithful (pre_composition_functor A (Rezk_completion A hsA) C
@@ -120,7 +120,7 @@ Proof.
   apply (@rad_equivalence_of_precats
            [Rezk_completion A hsA, C, pr2 Ccat]
            [A, C, pr2 Ccat]
-           (is_category_functor_category _ _ _ )
+           (is_univalent_functor_category _ _ _ )
            _
            (pre_comp_rezk_eta_is_fully_faithful)
            (pre_comp_rezk_eta_is_ess_surj)).
@@ -131,9 +131,9 @@ Theorem Rezk_eta_Universal_Property :
    (pr2 (pr2 (Rezk_completion A hsA))) (pr2 Ccat) (Rezk_eta A hsA)).
 Proof.
   apply adj_equiv_of_cats_is_weq_of_objects.
-  - apply is_category_functor_category;
+  - apply is_univalent_functor_category;
     assumption.
-  - apply is_category_functor_category;
+  - apply is_univalent_functor_category;
     assumption.
   - apply Rezk_adj_equiv.
 Defined.
@@ -189,7 +189,7 @@ Let hsRAop : has_homsets (Rezk_completion A hsA)^op :=
 Section fix_a_category.
 
 Variable C : precategory.
-Hypothesis Ccat : is_category C.
+Hypothesis Ccat : is_univalent C.
 
 Lemma pre_comp_rezk_eta_opp_is_fully_faithful :
     fully_faithful
@@ -223,7 +223,7 @@ Proof.
   apply (@rad_equivalence_of_precats
            [(Rezk_completion A hsA)^op, C, pr2 Ccat]
            [A^op, C, pr2 Ccat]
-           (is_category_functor_category _ _ _ )
+           (is_univalent_functor_category _ _ _ )
            _
            (pre_comp_rezk_eta_opp_is_fully_faithful)
            (pre_comp_rezk_eta_opp_is_ess_surj)).
@@ -234,9 +234,9 @@ Theorem Rezk_eta_opp_Universal_Property :
           hsRAop (pr2 Ccat) (functor_opp (Rezk_eta A hsA))).
 Proof.
   apply adj_equiv_of_cats_is_weq_of_objects.
-  - apply is_category_functor_category;
+  - apply is_univalent_functor_category;
     assumption.
-  - apply is_category_functor_category;
+  - apply is_univalent_functor_category;
     assumption.
   - apply Rezk_op_adj_equiv.
 Defined.

--- a/UniMath/CategoryTheory/slicecat.v
+++ b/UniMath/CategoryTheory/slicecat.v
@@ -263,7 +263,7 @@ End slice_precat_theory.
 (** This is exercise 9.1 in the HoTT book *)
 Section slicecat_theory.
 
-Context {C : precategory} (is_catC : is_category C) (x : C).
+Context {C : precategory} (is_catC : is_univalent C) (x : C).
 
 Local Notation "C / x" := (slice_precat C x (pr2 is_catC)).
 
@@ -295,7 +295,7 @@ assert (weq4 : weq (total2 (fun h : iso a b => f = h · g)) (iso af bg)).
 apply (weqcomp weq1 (weqcomp weq2 (weqcomp weq3 weq4))).
 Defined.
 
-Lemma is_category_slicecat : is_category (C / x).
+Lemma is_univalent_slicecat : is_univalent (C / x).
 Proof.
 split; [| apply has_homsets_slice_precat]; simpl; intros a b.
 set (h := id_weq_iso_slicecat a b).

--- a/UniMath/CategoryTheory/slicecat.v
+++ b/UniMath/CategoryTheory/slicecat.v
@@ -13,7 +13,7 @@ Contents:
 - Proof that the forgetful functor [slicecat_to_cat] : C/x → C is
   a left adjoint if C has binary products ([is_left_adjoint_slicecat_to_cat])
 
-- Proof that C/x is a category if C is
+- Proof that C/x is a univalent_category if C is
 
 - Proof that any morphism C[x,y] induces a functor from C/x to C/y
   ([slicecat_functor])
@@ -259,7 +259,7 @@ Defined.
 
 End slice_precat_theory.
 
-(** * Proof that C/x is a category if C is. *)
+(** * Proof that C/x is a univalent_category if C is. *)
 (** This is exercise 9.1 in the HoTT book *)
 Section slicecat_theory.
 

--- a/UniMath/CategoryTheory/sub_precategories.v
+++ b/UniMath/CategoryTheory/sub_precategories.v
@@ -31,7 +31,7 @@ Contents :
 
                     Full subcategory of a category is
                       a category
-                      [is_category_full_subcat]
+                      [is_univalent_full_subcat]
 
 
 
@@ -466,7 +466,7 @@ Proof.
 Section full_sub_cat.
 
 Variable C : precategory.
-Hypothesis H : is_category C.
+Hypothesis H : is_univalent C.
 
 Variable C' : hsubtype (ob C).
 
@@ -586,9 +586,9 @@ Defined.
 
 (** ** Proof of the targeted theorem: full subcats of cats are cats *)
 
-Lemma is_category_full_subcat: is_category (full_sub_precategory C').
+Lemma is_univalent_full_subcat: is_univalent (full_sub_precategory C').
 Proof.
-  unfold is_category.
+  unfold is_univalent.
   split.
   - apply isweq_sub_precat_paths_to_iso.
   - intros x y. apply is_set_sub_precategory_morphisms. apply (pr2 H).

--- a/UniMath/CategoryTheory/sub_precategories.v
+++ b/UniMath/CategoryTheory/sub_precategories.v
@@ -29,8 +29,8 @@ Contents :
                     Isos in full subcategory are equiv
                       to isos in the precategory
 
-                    Full subcategory of a category is
-                      a category
+                    Full subcategory of a univalent_category is
+                      a univalent_category
                       [is_univalent_full_subcat]
 
 
@@ -316,7 +316,7 @@ Definition functor_full_img {C D: precategory}
 
 
 (** *** Morphisms in the full subprecat are equiv to morphisms in the precategory *)
-(** does of course not need the category hypothesis *)
+(** does of course not need the univalent_category hypothesis *)
 
 Definition hom_in_subcat_from_hom_in_precat (C : precategory)
  (C' : hsubtype (ob C))
@@ -460,7 +460,7 @@ Proof.
 *)
 
 
-(** ** Any full subprecategory of a category is a category. *)
+(** ** Any full subprecategory of a univalent_category is a univalent_category. *)
 
 
 Section full_sub_cat.

--- a/UniMath/Ktheory/Precategories.v
+++ b/UniMath/Ktheory/Precategories.v
@@ -77,7 +77,7 @@ Definition Functor_identity {C D} (F:functor C D) := functor_id F.
 Definition Functor_compose {C D} (F:functor C D) := @functor_comp _ _ F.
 
 
-Definition theUnivalenceProperty (C:category) := pr2 C : is_univalent C.
+Definition theUnivalenceProperty (C: univalent_category) := pr2 C : is_univalent C.
 
 Lemma Precategory_eq (C D:Precategory) :
   (C:precategory_data) = (D:precategory_data) -> C=D.

--- a/UniMath/Ktheory/Precategories.v
+++ b/UniMath/Ktheory/Precategories.v
@@ -77,7 +77,7 @@ Definition Functor_identity {C D} (F:functor C D) := functor_id F.
 Definition Functor_compose {C D} (F:functor C D) := @functor_comp _ _ F.
 
 
-Definition theUnivalenceProperty (C:category) := pr2 C : is_category C.
+Definition theUnivalenceProperty (C:category) := pr2 C : is_univalent C.
 
 Lemma Precategory_eq (C D:Precategory) :
   (C:precategory_data) = (D:precategory_data) -> C=D.

--- a/UniMath/Ktheory/Representation.v
+++ b/UniMath/Ktheory/Representation.v
@@ -42,7 +42,7 @@ Definition Representation {C:Precategory} (X:[C^op,SET]) : UU
 
 Definition isRepresentable {C:Precategory} (X:[C^op,SET]) := ∥ Representation X ∥.
 
-Lemma isaprop_Representation {C:category} (X:[C^op,SET]) :
+Lemma isaprop_Representation {C: univalent_category} (X:[C^op,SET]) :
   isaprop (@Representation C X).
 Proof.
 

--- a/UniMath/Ktheory/Test.v
+++ b/UniMath/Ktheory/Test.v
@@ -156,7 +156,7 @@ Qed.
 
 Section coproduct_unique.
 
-Hypothesis H : is_category C.
+Hypothesis H : is_univalent C.
 
 Variables a b : C.
 

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -117,7 +117,7 @@ Definition Colims : precategory → UU :=
   @UniMath.CategoryTheory.limits.graphs.colimits.Colims.
 
 (** Remark 20: Uniqueness of colimits *)
-Lemma isaprop_Colims : ∏ C : category, isaprop (Colims C).
+Lemma isaprop_Colims : ∏ C : univalent_category, isaprop (Colims C).
 Proof.
 exact @UniMath.CategoryTheory.limits.graphs.colimits.isaprop_Colims.
 Defined.


### PR DESCRIPTION
Rename
- `is_category` -> `is_univalent`
- `category` -> `univalent_category`