### PR TITLE
rename Precategory -> category

### DIFF
--- a/UniMath/CategoryTheory/AbelianToAdditive.v
+++ b/UniMath/CategoryTheory/AbelianToAdditive.v
@@ -709,10 +709,10 @@ Section abelian_is_additive.
     apply idpath.
   Qed.
 
-  Definition AbelianToPrecategoryWithAbgropsData :
-    PrecategoryWithAbgropsData AbelianToprecategoryWithBinops hs.
+  Definition AbelianTocategoryWithAbgropsData :
+    categoryWithAbgropsData AbelianToprecategoryWithBinops hs.
   Proof.
-    unfold PrecategoryWithAbgropsData.
+    unfold categoryWithAbgropsData.
     intros x y.
     split.
     - use isgroppair.
@@ -732,14 +732,14 @@ Section abelian_is_additive.
   Defined.
 
   (** We prove that Abelian_precategories are PrecategoriesWithAbgrops. *)
-  Definition AbelianToPrecategoryWithAbgrops :
-    PrecategoryWithAbgrops := mk_PrecategoryWithAbgrops
+  Definition AbelianTocategoryWithAbgrops :
+    categoryWithAbgrops := mk_categoryWithAbgrops
                                 AbelianToprecategoryWithBinops  hs
-                                AbelianToPrecategoryWithAbgropsData.
+                                AbelianTocategoryWithAbgropsData.
 
   (** Hide isPreAdditive behind Qed. *)
   Lemma AbelianToisPreAdditive :
-    isPreAdditive AbelianToPrecategoryWithAbgrops.
+    isPreAdditive AbelianTocategoryWithAbgrops.
   Proof.
     use mk_isPreAdditive.
     (* precomposition ismonoidfun *)
@@ -815,7 +815,7 @@ Section abelian_is_additive.
 
   (** We prove that Abelian_precategories are PreAddtitive. *)
   Definition AbelianToPreAdditive :
-    PreAdditive := mk_PreAdditive AbelianToPrecategoryWithAbgrops AbelianToisPreAdditive.
+    PreAdditive := mk_PreAdditive AbelianTocategoryWithAbgrops AbelianToisPreAdditive.
 
   (** Finally, we show that Abelian_precategories are Additive. *)
   Definition AbelianToAdditive : Additive.

--- a/UniMath/CategoryTheory/Additive.v
+++ b/UniMath/CategoryTheory/Additive.v
@@ -100,13 +100,13 @@ Section additive_quot_additive.
   Hypothesis PAS : PreAdditiveSubabgrs A.
   Hypothesis PAC : PreAdditiveComps A PAS.
 
-  Definition QuotPrecategory_Additive : Additive.
+  Definition Quotcategory_Additive : Additive.
   Proof.
     use mk_Additive.
-    - exact (QuotPrecategory_PreAdditive A PAS PAC).
+    - exact (Quotcategory_PreAdditive A PAS PAC).
     - use mk_isAdditive.
-      + exact (QuotPrecategory_Zero A PAS PAC (to_Zero A)).
-      + exact (QuotPrecategory_BinDirectSums A (to_BinDirectSums A) PAS PAC).
+      + exact (Quotcategory_Zero A PAS PAC (to_Zero A)).
+      + exact (Quotcategory_BinDirectSums A (to_BinDirectSums A) PAS PAC).
   Defined.
 
 End additive_quot_additive.

--- a/UniMath/CategoryTheory/AdditiveFunctors.v
+++ b/UniMath/CategoryTheory/AdditiveFunctors.v
@@ -688,16 +688,16 @@ Section additivefunctor_criteria.
 End additivefunctor_criteria.
 
 
-(** * The functor [QuotPrecategoryFunctor] is additive *)
+(** * The functor [QuotcategoryFunctor] is additive *)
 Section def_additive_quot_functor.
 
   Variable A : Additive.
   Variable PAS : PreAdditiveSubabgrs A.
   Variable PAC : PreAdditiveComps A PAS.
 
-  Local Lemma QuotPrecategoryAdditiveFunctor_isAdditiveFunctor :
-    @isAdditiveFunctor A (QuotPrecategory_Additive A PAS PAC)
-                       (QuotPrecategoryFunctor (Additive_PreAdditive A) PAS PAC).
+  Local Lemma QuotcategoryAdditiveFunctor_isAdditiveFunctor :
+    @isAdditiveFunctor A (Quotcategory_Additive A PAS PAC)
+                       (QuotcategoryFunctor (Additive_PreAdditive A) PAS PAC).
   Proof.
     use mk_isAdditiveFunctor.
     intros X Y.
@@ -706,12 +706,12 @@ Section def_additive_quot_functor.
     - apply idpath.
   Qed.
 
-  Definition QuotPrecategoryAdditiveFunctor :
-    AdditiveFunctor A (QuotPrecategory_Additive A PAS PAC).
+  Definition QuotcategoryAdditiveFunctor :
+    AdditiveFunctor A (Quotcategory_Additive A PAS PAC).
   Proof.
     use mk_AdditiveFunctor.
-    - exact (QuotPrecategoryFunctor A PAS PAC).
-    - exact QuotPrecategoryAdditiveFunctor_isAdditiveFunctor.
+    - exact (QuotcategoryFunctor A PAS PAC).
+    - exact QuotcategoryAdditiveFunctor_isAdditiveFunctor.
   Defined.
 
 End def_additive_quot_functor.

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -1664,14 +1664,14 @@ End post_composition_functor.
 (** * Swapping of functor category arguments *)
 Section functor_swap.
 
-Lemma is_cocont_functor_cat_swap (C D : precategory) (E : Precategory) :
+Lemma is_cocont_functor_cat_swap (C D : precategory) (E : category) :
   is_cocont (functor_cat_swap C D E).
 Proof.
 apply left_adjoint_cocont; try apply homset_property.
 apply is_left_adjoint_functor_cat_swap.
 Defined.
 
-Lemma is_omega_cocont_functor_cat_swap (C D : precategory) (E : Precategory) :
+Lemma is_omega_cocont_functor_cat_swap (C D : precategory) (E : category) :
   is_omega_cocont (functor_cat_swap C D E).
 Proof.
 intros d L ccL HccL.

--- a/UniMath/CategoryTheory/DiscretePrecategory.v
+++ b/UniMath/CategoryTheory/DiscretePrecategory.v
@@ -20,7 +20,7 @@ Require Import UniMath.CategoryTheory.functor_categories.
 Local Open Scope cat.
 
 (** * Discrete precategories *)
-Section DiscretePrecategory.
+Section Discretecategory.
 
 Variable (A : UU).
 
@@ -70,4 +70,4 @@ Proof.
   reflexivity.
 Defined.
 
-End DiscretePrecategory.
+End Discretecategory.

--- a/UniMath/CategoryTheory/EpiFacts.v
+++ b/UniMath/CategoryTheory/EpiFacts.v
@@ -55,9 +55,9 @@ Definition EpisAreEffective (C:precategory) :=
 (** Let f be a natural transformation. If f is pointwise effective, then f is effective *)
 Section IsEffectivePw.
 
-  Context { C :precategory} {D:Precategory} .
+  Context {C : precategory} {D : category} .
 
-  Local Notation CD := (@functor_Precategory C D).
+  Local Notation CD := (functor_category C D).
 
   Lemma eq_pb_pw {X Y Z:functor C D}
         (a: X ⟹ Z) (b: Y ⟹ Z)
@@ -136,9 +136,9 @@ Set Automatic Introduction.
   an epimorphism is pointwise epimorphic *)
 Section PointwiseEpi.
 
-  Context { C :precategory} {D:Precategory} .
+  Context {C : precategory} {D : category}.
 
-  Local Notation CD := (functor_Precategory C D).
+  Local Notation CD := (functor_category C D).
 
   Lemma eq_po_pw {X Y Z :functor C D} {a: X ⟹ Y } {b: X ⟹ Z} x  :
     eq_diag

--- a/UniMath/CategoryTheory/EquivalencesExamples.v
+++ b/UniMath/CategoryTheory/EquivalencesExamples.v
@@ -160,9 +160,9 @@ End coproduct_functor_adjunction.
 (** * Swapping of arguments in functor categories *)
 Section functor_swap.
 
-Local Notation "[ C , D ]" := (functor_Precategory C D).
+Local Notation "[ C , D ]" := (functor_category C D).
 
-Lemma functor_swap {C D : precategory} {E : Precategory} : functor C [D,E] → functor D [C,E].
+Lemma functor_swap {C D : precategory} {E : category} : functor C [D,E] → functor D [C,E].
 Proof.
 intros F.
 mkpair.
@@ -187,7 +187,7 @@ mkpair.
   | intros a b c f g; apply (nat_trans_eq (homset_property E)); intro x; simpl; apply functor_comp]).
 Defined.
 
-Lemma functor_cat_swap_nat_trans {C D : precategory} {E : Precategory}
+Lemma functor_cat_swap_nat_trans {C D : precategory} {E : category}
   (F G : functor C [D, E]) (α : nat_trans F G) :
   nat_trans (functor_swap F) (functor_swap G).
 Proof.
@@ -199,7 +199,7 @@ mkpair.
 + abstract (intros a b f; apply (nat_trans_eq (homset_property E)); intro c; simpl; apply nat_trans_ax).
 Defined.
 
-Lemma functor_cat_swap (C D : precategory) (E : Precategory) : functor [C, [D, E]] [D, [C, E]].
+Lemma functor_cat_swap (C D : precategory) (E : category) : functor [C, [D, E]] [D, [C, E]].
 Proof.
 mkpair.
 - mkpair.
@@ -212,7 +212,7 @@ mkpair.
     now apply (nat_trans_eq (homset_property E))]).
 Defined.
 
-Definition id_functor_cat_swap (C D : precategory) (E : Precategory) :
+Definition id_functor_cat_swap (C D : precategory) (E : category) :
   nat_trans (functor_identity [C,[D,E]])
             (functor_composite (functor_cat_swap C D E) (functor_cat_swap D C E)).
 Proof.
@@ -229,7 +229,7 @@ mkpair.
             apply (nat_trans_eq hsE); intro d; simpl; rewrite id_left, id_right).
 Defined.
 
-Definition functor_cat_swap_id (C D : precategory) (E : Precategory) :
+Definition functor_cat_swap_id (C D : precategory) (E : category) :
   nat_trans (functor_composite (functor_cat_swap D C E) (functor_cat_swap C D E))
             (functor_identity [D,[C,E]]).
 Proof.
@@ -246,7 +246,7 @@ mkpair.
             apply (nat_trans_eq hsE); intro d; simpl; rewrite id_left, id_right).
 Defined.
 
-Lemma form_adjunction_functor_cat_swap (C D : precategory) (E : Precategory) :
+Lemma form_adjunction_functor_cat_swap (C D : precategory) (E : category) :
   form_adjunction _ _ (id_functor_cat_swap C D E) (functor_cat_swap_id C D E).
 Proof.
 set (hsE := homset_property E).
@@ -261,7 +261,7 @@ split; intro F.
   now intro d; apply (nat_trans_eq hsE); intro c; apply id_left.
 Qed. (* This Qed is very slow... I don't see how to make it faster *)
 
-Lemma are_adjoint_functor_cat_swap (C D : precategory) (E : Precategory) :
+Lemma are_adjoint_functor_cat_swap (C D : precategory) (E : category) :
   are_adjoints (@functor_cat_swap C D E) (@functor_cat_swap D C E).
 Proof.
 mkpair.
@@ -269,7 +269,7 @@ mkpair.
 - apply form_adjunction_functor_cat_swap.
 Defined.
 
-Lemma is_left_adjoint_functor_cat_swap (C D : precategory) (E : Precategory) :
+Lemma is_left_adjoint_functor_cat_swap (C D : precategory) (E : category) :
   is_left_adjoint (functor_cat_swap C D E).
 Proof.
 mkpair.

--- a/UniMath/CategoryTheory/FunctorAlgebras.v
+++ b/UniMath/CategoryTheory/FunctorAlgebras.v
@@ -11,7 +11,7 @@ Extended by: Anders Mörtberg. October 2015
 
 Contents :
 
-- Precategory of algebras of an endofunctor
+- category of algebras of an endofunctor
 
 - Saturated if base precategory is
 

--- a/UniMath/CategoryTheory/GrothendieckTopos.v
+++ b/UniMath/CategoryTheory/GrothendieckTopos.v
@@ -57,7 +57,7 @@ Section def_grothendiecktopology.
 
   (** A sieve on c is a subobject of the yoneda functor. *)
   Definition sieve (c : C) : UU :=
-    SubobjectsPrecategory
+    Subobjectscategory
       (functor_category_has_homsets (opp_precat C) HSET has_homsets_HSET)
       (yoneda C hs c).
 
@@ -83,7 +83,7 @@ Section def_grothendiecktopology.
   Definition collection_of_sieves : UU := ∏ (c : C), hsubtype (sieve c).
 
   Definition isGrothendieckTopology_maximal_sieve (COS : collection_of_sieves) : UU :=
-    ∏ (c : C), COS c (SubobjectsPrecategory_ob
+    ∏ (c : C), COS c (Subobjectscategory_ob
                         (functor_category_has_homsets (opp_precat C) HSET has_homsets_HSET)
                         (identity (yoneda C hs c)) (identity_isMonic _)).
 
@@ -92,7 +92,7 @@ Section def_grothendiecktopology.
     COS c s ->
     COS c' (PullbackSubobject
               _
-              (FunctorPrecategoryPullbacks (opp_precat C) HSET has_homsets_HSET HSET_Pullbacks)
+              (FunctorcategoryPullbacks (opp_precat C) HSET has_homsets_HSET HSET_Pullbacks)
               s (yoneda_morphisms C hs _ _ h)).
 
   Definition isGrothendieckTopology_transitivity (COS : collection_of_sieves) : UU :=
@@ -100,7 +100,7 @@ Section def_grothendiecktopology.
     (∏ (c' : C) (h : c' --> c),
      COS c' (PullbackSubobject
                _
-               (FunctorPrecategoryPullbacks (opp_precat C) HSET has_homsets_HSET HSET_Pullbacks)
+               (FunctorcategoryPullbacks (opp_precat C) HSET has_homsets_HSET HSET_Pullbacks)
                s (yoneda_morphisms C hs _ _ h))
      -> COS c s).
 
@@ -151,7 +151,7 @@ Section def_grothendiecktopology.
     (fun P : functor_precategory (opp_precat C) HSET has_homsets_HSET =>
        hProppair _ (isaprop_isSheaf GT (mk_Presheaf P))).
 
-  Definition PrecategoryOfSheaves (GT : GrothendieckTopology) :
+  Definition categoryOfSheaves (GT : GrothendieckTopology) :
     sub_precategories (functor_precategory (opp_precat C) HSET has_homsets_HSET) :=
     full_sub_precategory (hsubtype_obs_isSheaf GT).
 
@@ -170,7 +170,7 @@ Section def_grothendiecktopos.
       Grothendieck topology (pr2 D). *)
   Definition GrothendieckTopos : UU :=
     ∑ D' : (∑ D : precategory × (GrothendieckTopology C hs),
-                  functor (pr1 D) (PrecategoryOfSheaves C hs (pr2 D))),
+                  functor (pr1 D) (categoryOfSheaves C hs (pr2 D))),
            (adj_equivalence_of_precats (pr2 D')).
 
   (** Accessor functions *)
@@ -183,7 +183,7 @@ Section def_grothendiecktopos.
 
   Definition GrothendieckTopos_functor (GT : GrothendieckTopos) :
     functor (GrothendieckTopos_precategory GT)
-            (PrecategoryOfSheaves C hs (GrothendieckTopos_GrothendieckTopology GT)) :=
+            (categoryOfSheaves C hs (GrothendieckTopos_GrothendieckTopology GT)) :=
     pr2 (pr1 GT).
 
   Definition GrothendieckTopos_equivalence (GT : GrothendieckTopos) :

--- a/UniMath/CategoryTheory/Monads.v
+++ b/UniMath/CategoryTheory/Monads.v
@@ -3,7 +3,7 @@
 Contents:
 
         - Definition of monads ([Monad])
-        - Precategory of monads [Precategory_Monad C] on [C]
+        - category of monads [category_Monad C] on [C]
         - Forgetful functor [forgetfunctor_Monad] from monads
              to endofunctors on [C]
         - Haskell style bind operation ([bind])
@@ -193,7 +193,7 @@ Definition precategory_Monad (C : precategory) (hs : has_homsets C) : precategor
   := tpair _ _ (precategory_Monad_axioms C hs).
 
 
-Lemma has_homsets_Monad (C:Precategory) : has_homsets (precategory_Monad C (homset_property C)).
+Lemma has_homsets_Monad (C : category) : has_homsets (precategory_Monad C (homset_property C)).
 Proof.
   intros F G.
   simpl.
@@ -207,12 +207,12 @@ Proof.
   apply homset_property.
 Qed.
 
-Definition Precategory_Monad (C:Precategory) : Precategory :=
+Definition category_Monad (C : category) : category :=
   (precategory_Monad C (homset_property C) ,, has_homsets_Monad C ).
 
 
-Definition forgetfunctor_Monad (C:Precategory) :
-  functor (Precategory_Monad C) (functor_Precategory C C).
+Definition forgetfunctor_Monad (C : category) :
+  functor (category_Monad C) (functor_category C C).
 Proof.
   use mk_functor.
   - use mk_functor_data.

--- a/UniMath/CategoryTheory/PreAdditive.v
+++ b/UniMath/CategoryTheory/PreAdditive.v
@@ -37,11 +37,11 @@ Section def_preadditive.
   (** In preadditive category precomposition and postcomposition for any
       morphism yields a morphism of abelian groups. Classically one says that
       composition is bilinear with respect to the abelian groups? *)
-  Definition isPreAdditive (PA : PrecategoryWithAbgrops) : UU :=
+  Definition isPreAdditive (PA : categoryWithAbgrops) : UU :=
     (∏ (x y z : PA) (f : x --> y), ismonoidfun (to_premor z f))
       × (∏ (x y z : PA) (f : y --> z), ismonoidfun (to_postmor x f)).
 
-  Definition mk_isPreAdditive (PA : PrecategoryWithAbgrops)
+  Definition mk_isPreAdditive (PA : categoryWithAbgrops)
              (H1 : ∏ (x y z : PA) (f : x --> y), ismonoidfun (to_premor z f))
              (H2 : ∏ (x y z : PA) (f : y --> z), ismonoidfun (to_postmor x f)) :
     isPreAdditive PA.
@@ -49,7 +49,7 @@ Section def_preadditive.
     exact (H1,,H2).
   Defined.
 
-  Definition mk_isPreAdditive' (PA : PrecategoryWithAbgrops)
+  Definition mk_isPreAdditive' (PA : categoryWithAbgrops)
              (H1 : ∏ (x y z : PA) (f : x --> y) (g h : y --> z),
                    f · (to_binop _ _ g h) = to_binop _ _ (f · g) (f · h))
              (H1' : ∏ (x y z : PA) (f : x --> y), to_premor z f (to_unel y z) = to_unel x z)
@@ -69,27 +69,27 @@ Section def_preadditive.
       + exact (H2' x y z f).
   Qed.
 
-  Definition to_premor_monoid {PWA : PrecategoryWithAbgrops} (iPA : isPreAdditive PWA) :
+  Definition to_premor_monoid {PWA : categoryWithAbgrops} (iPA : isPreAdditive PWA) :
     ∏ (x y z : PWA) (f : x --> y), ismonoidfun (to_premor z f) := dirprod_pr1 iPA.
 
-  Definition to_postmor_monoid {PWA : PrecategoryWithAbgrops} (iPA : isPreAdditive PWA) :
+  Definition to_postmor_monoid {PWA : categoryWithAbgrops} (iPA : isPreAdditive PWA) :
     ∏ (x y z : PWA) (f : y --> z), ismonoidfun (to_postmor x f) := dirprod_pr2 iPA.
 
-  Definition to_premor_monoidfun {PWA : PrecategoryWithAbgrops} (iPA : isPreAdditive PWA)
+  Definition to_premor_monoidfun {PWA : categoryWithAbgrops} (iPA : isPreAdditive PWA)
              (x y z : PWA) (f : x --> y) : monoidfun (to_abgrop y z) (to_abgrop x z) :=
     monoidfunconstr (to_premor_monoid iPA x y z f).
 
-  Definition to_postmor_monoidfun {PWA : PrecategoryWithAbgrops} (iPA : isPreAdditive PWA)
+  Definition to_postmor_monoidfun {PWA : categoryWithAbgrops} (iPA : isPreAdditive PWA)
              (x y z : PWA) (f : y --> z) : monoidfun (to_abgrop x y) (to_abgrop x z) :=
     monoidfunconstr (to_postmor_monoid iPA x y z f).
 
   (** Definition of preadditive categories *)
-  Definition PreAdditive : UU := ∑ PA : PrecategoryWithAbgrops, isPreAdditive PA.
+  Definition PreAdditive : UU := ∑ PA : categoryWithAbgrops, isPreAdditive PA.
 
-  Definition PreAdditive_PrecategoryWithAbgrops (A : PreAdditive) : PrecategoryWithAbgrops := pr1 A.
-  Coercion PreAdditive_PrecategoryWithAbgrops : PreAdditive >-> PrecategoryWithAbgrops.
+  Definition PreAdditive_categoryWithAbgrops (A : PreAdditive) : categoryWithAbgrops := pr1 A.
+  Coercion PreAdditive_categoryWithAbgrops : PreAdditive >-> categoryWithAbgrops.
 
-  Definition mk_PreAdditive (PA : PrecategoryWithAbgrops) (H : isPreAdditive PA) : PreAdditive.
+  Definition mk_PreAdditive (PA : categoryWithAbgrops) (H : isPreAdditive PA) : PreAdditive.
   Proof.
     exact (tpair _ PA H).
   Defined.
@@ -455,12 +455,12 @@ Section preadditive_quotient.
   Definition subabgr_quot {A : abgr} (B : @subabgr A) : abgr :=
     abgrquot (binopeqrel_subgr_eqrel B).
 
-  Definition QuotPrecategory_homsets (c d : ob PA) : abgr := subabgr_quot (PAS c d).
+  Definition Quotcategory_homsets (c d : ob PA) : abgr := subabgr_quot (PAS c d).
 
-  Definition QuotPrecategory_ob_mor : precategory_ob_mor :=
-    tpair (fun ob : UU => ob -> ob -> UU) (ob PA) (fun A B : ob PA => QuotPrecategory_homsets A B).
+  Definition Quotcategory_ob_mor : precategory_ob_mor :=
+    tpair (fun ob : UU => ob -> ob -> UU) (ob PA) (fun A B : ob PA => Quotcategory_homsets A B).
 
-  Lemma QuotPrecategory_surj {c d : QuotPrecategory_ob_mor} (f : QuotPrecategory_ob_mor⟦c, d⟧) :
+  Lemma Quotcategory_surj {c d : Quotcategory_ob_mor} (f : Quotcategory_ob_mor⟦c, d⟧) :
     ∥ hfiber (setquotpr (binopeqrel_subgr_eqrel (PAS c d))) f ∥.
   Proof.
     use issurjsetquotpr.
@@ -528,44 +528,44 @@ Section preadditive_quotient.
 
   (** **** Structure for composition *)
 
-  Definition QuotPrecategoryComp {A B C : ob PA} (f : QuotPrecategory_ob_mor⟦A, B⟧)
-             (g : QuotPrecategory_ob_mor⟦B, C⟧) : UU :=
-    ∑ h : QuotPrecategory_ob_mor⟦A, C⟧,
+  Definition QuotcategoryComp {A B C : ob PA} (f : Quotcategory_ob_mor⟦A, B⟧)
+             (g : Quotcategory_ob_mor⟦B, C⟧) : UU :=
+    ∑ h : Quotcategory_ob_mor⟦A, C⟧,
           (∏ (f' : PA⟦A, B⟧) (e1 : setquotpr _ f' = f)
              (g' : PA⟦B, C⟧) (e2 : setquotpr _ g' = g), setquotpr _ (f' · g') = h).
 
-  Definition mk_QuotPrecategoryComp {A B C : ob PA} {f : QuotPrecategory_ob_mor⟦A, B⟧}
-             {g : QuotPrecategory_ob_mor⟦B, C⟧} (h : QuotPrecategory_ob_mor⟦A, C⟧)
+  Definition mk_QuotcategoryComp {A B C : ob PA} {f : Quotcategory_ob_mor⟦A, B⟧}
+             {g : Quotcategory_ob_mor⟦B, C⟧} (h : Quotcategory_ob_mor⟦A, C⟧)
              (H : ∏ (f' : PA⟦A, B⟧) (e1 : setquotpr _ f' = f)
                     (g' : PA⟦B, C⟧) (e2 : setquotpr _ g' = g), setquotpr _ (f' · g') = h) :
-    QuotPrecategoryComp f g := tpair _ h H.
+    QuotcategoryComp f g := tpair _ h H.
 
-  Definition QuotPrecategoryCompMor {A B C : ob PA} {f : QuotPrecategory_ob_mor⟦A, B⟧}
-             {g : QuotPrecategory_ob_mor⟦B, C⟧} (QPC : QuotPrecategoryComp f g) :
-    QuotPrecategory_ob_mor⟦A, C⟧ := pr1 QPC.
+  Definition QuotcategoryCompMor {A B C : ob PA} {f : Quotcategory_ob_mor⟦A, B⟧}
+             {g : Quotcategory_ob_mor⟦B, C⟧} (QPC : QuotcategoryComp f g) :
+    Quotcategory_ob_mor⟦A, C⟧ := pr1 QPC.
 
-  Definition QuotPrecategoryCompEq {A B C : ob PA} {f : QuotPrecategory_ob_mor⟦A, B⟧}
-             {g : QuotPrecategory_ob_mor⟦B, C⟧} (QPC : QuotPrecategoryComp f g) :
+  Definition QuotcategoryCompEq {A B C : ob PA} {f : Quotcategory_ob_mor⟦A, B⟧}
+             {g : Quotcategory_ob_mor⟦B, C⟧} (QPC : QuotcategoryComp f g) :
     ∏ (f' : PA⟦A, B⟧) (e1 : setquotpr _ f' = f) (g' : PA⟦B, C⟧) (e2 : setquotpr _ g' = g),
-    setquotpr _ (f' · g') = QuotPrecategoryCompMor QPC := pr2 QPC.
+    setquotpr _ (f' · g') = QuotcategoryCompMor QPC := pr2 QPC.
 
 
   (** **** Composition for quotient category *)
 
-  Local Lemma QuotPrecategory_comp_iscontr_PAS_eq {A : abgr} {a b c : A}
+  Local Lemma Quotcategory_comp_iscontr_PAS_eq {A : abgr} {a b c : A}
         (e : a = (b * (grinv A c))%multmonoid) : b = (a * c)%multmonoid.
   Proof.
     rewrite e. rewrite assocax. rewrite grlinvax. rewrite runax. apply idpath.
   Qed.
 
-  Lemma QuotPrecategory_comp_iscontr_PAS {A B C : PA} {t : pr1 (PAS A B)} {t' : pr1 (PAS B C)}
+  Lemma Quotcategory_comp_iscontr_PAS {A B C : PA} {t : pr1 (PAS A B)} {t' : pr1 (PAS B C)}
         {f1 f'1 : PA⟦A, B⟧} {g1 g'1 : PA⟦B, C⟧}
         (p : pr1 t = to_binop A B f'1 (grinv (to_abgrop A B) f1))
         (p' : pr1 t' = to_binop B C g'1 (grinv (to_abgrop B C) g1)) :
     pr1 (PAS A C) (to_binop A C (f1 · g1) (grinv (to_abgrop A C) (f'1 · g'1))).
   Proof.
-    set (e1 := QuotPrecategory_comp_iscontr_PAS_eq p).
-    set (e2 := QuotPrecategory_comp_iscontr_PAS_eq p').
+    set (e1 := Quotcategory_comp_iscontr_PAS_eq p).
+    set (e2 := Quotcategory_comp_iscontr_PAS_eq p').
     rewrite e1. rewrite e2. clear e1 e2 p p'. cbn.
     rewrite to_premor_linear'. rewrite to_postmor_linear'. rewrite to_postmor_linear'.
     set (ac := assocax (to_abgrop A C)). unfold isassoc in ac. cbn in ac.
@@ -584,8 +584,8 @@ Section preadditive_quotient.
     - apply (dirprod_pr1 (PAC A B) C (pr1 t) (pr2 t) g1).
   Qed.
 
-  Local Lemma QuotPrecategory_comp_iscontr_eq {A B C : ob PA} (f : QuotPrecategory_ob_mor⟦A, B⟧)
-        (g : QuotPrecategory_ob_mor⟦B, C⟧)  (f'1 : PA ⟦ A, B ⟧) (f''1 : setquotpr _ f'1 = f)
+  Local Lemma Quotcategory_comp_iscontr_eq {A B C : ob PA} (f : Quotcategory_ob_mor⟦A, B⟧)
+        (g : Quotcategory_ob_mor⟦B, C⟧)  (f'1 : PA ⟦ A, B ⟧) (f''1 : setquotpr _ f'1 = f)
         (g'1 : PA ⟦ B, C ⟧) (g''1 : setquotpr _ g'1 = g) :
     ∏ (f' : PA⟦A, B⟧) (e1 : setquotpr _ f' = f) (g' : PA⟦B, C⟧) (e2 : setquotpr _ g' = g),
     setquotpr _ (f' · g') = setquotpr (binopeqrel_subgr_eqrel (PAS A C)) (f'1 · g'1).
@@ -607,19 +607,19 @@ Section preadditive_quotient.
     use tpair.
     + use tpair.
       * exact (to_binop A C (f1 · g1) (grinv (to_abgrop A C) (f'1 · g'1))).
-      * apply (QuotPrecategory_comp_iscontr_PAS p p').
+      * apply (Quotcategory_comp_iscontr_PAS p p').
     + apply idpath.
   Qed.
 
-  Local Lemma QuotPrecatetgory_comp_iscontr_univ {A B C : ob PA} (f : QuotPrecategory_ob_mor⟦A, B⟧)
-             (g : QuotPrecategory_ob_mor⟦B, C⟧)
+  Local Lemma QuotPrecatetgory_comp_iscontr_univ {A B C : ob PA} (f : Quotcategory_ob_mor⟦A, B⟧)
+             (g : Quotcategory_ob_mor⟦B, C⟧)
              (f' : hfiber (setquotpr (binopeqrel_subgr_eqrel (PAS A B))) f)
              (g' : hfiber (setquotpr (binopeqrel_subgr_eqrel (PAS B C))) g) :
-    ∏ t : QuotPrecategoryComp f g,
-          t = mk_QuotPrecategoryComp
+    ∏ t : QuotcategoryComp f g,
+          t = mk_QuotcategoryComp
                 (setquotpr (binopeqrel_subgr_eqrel (PAS A C))
                            (hfiberpr1 _ _ f' · hfiberpr1 _ _ g'))
-                (QuotPrecategory_comp_iscontr_eq
+                (Quotcategory_comp_iscontr_eq
                    f g (hfiberpr1 (setquotpr (binopeqrel_subgr_eqrel (PAS A B))) f f')
                    (hfiberpr2 (setquotpr (binopeqrel_subgr_eqrel (PAS A B))) f f')
                    (hfiberpr1 (setquotpr (binopeqrel_subgr_eqrel (PAS B C))) g g')
@@ -636,27 +636,27 @@ Section preadditive_quotient.
       apply isasetsetquot.
   Qed.
 
-  Lemma QuotPrecategory_comp_iscontr {A B C : ob PA} (f : QuotPrecategory_ob_mor⟦A, B⟧)
-             (g : QuotPrecategory_ob_mor⟦B, C⟧) : iscontr (QuotPrecategoryComp f g).
+  Lemma Quotcategory_comp_iscontr {A B C : ob PA} (f : Quotcategory_ob_mor⟦A, B⟧)
+             (g : Quotcategory_ob_mor⟦B, C⟧) : iscontr (QuotcategoryComp f g).
   Proof.
-    use (squash_to_prop (QuotPrecategory_surj f) (isapropiscontr _)). intros f'.
-    use (squash_to_prop (QuotPrecategory_surj g) (isapropiscontr _)). intros g'.
+    use (squash_to_prop (Quotcategory_surj f) (isapropiscontr _)). intros f'.
+    use (squash_to_prop (Quotcategory_surj g) (isapropiscontr _)). intros g'.
     use iscontrpair.
-    - use mk_QuotPrecategoryComp.
+    - use mk_QuotcategoryComp.
       + exact (setquotpr
                  (binopeqrel_subgr_eqrel (PAS A C)) ((hfiberpr1 _ _ f') · (hfiberpr1 _ _ g'))).
-      + exact (QuotPrecategory_comp_iscontr_eq
+      + exact (Quotcategory_comp_iscontr_eq
                  f g (hfiberpr1 _ _ f') (hfiberpr2 _ _ f') (hfiberpr1 _ _ g') (hfiberpr2 _ _ g')).
     - exact (QuotPrecatetgory_comp_iscontr_univ f g f' g').
   Defined.
 
-  Definition QuotPrecategory_comp {A B C : ob PA} (f : QuotPrecategory_ob_mor⟦A, B⟧)
-             (g : QuotPrecategory_ob_mor⟦B, C⟧) : QuotPrecategory_ob_mor⟦A, C⟧.
+  Definition Quotcategory_comp {A B C : ob PA} (f : Quotcategory_ob_mor⟦A, B⟧)
+             (g : Quotcategory_ob_mor⟦B, C⟧) : Quotcategory_ob_mor⟦A, C⟧.
   Proof.
-    exact (QuotPrecategoryCompMor (iscontrpr1 (QuotPrecategory_comp_iscontr f g))).
+    exact (QuotcategoryCompMor (iscontrpr1 (Quotcategory_comp_iscontr f g))).
   Defined.
 
-  Definition to_quot_mor {x y : ob PA} (f : PA⟦x, y⟧) : QuotPrecategory_ob_mor⟦x, y⟧.
+  Definition to_quot_mor {x y : ob PA} (f : PA⟦x, y⟧) : Quotcategory_ob_mor⟦x, y⟧.
   Proof.
     use setquotpr. exact f.
   Defined.
@@ -664,12 +664,12 @@ Section preadditive_quotient.
 
   (** ** Some equations on linearity, compositions, and binops *)
 
-  Lemma QuotPrecategory_comp_linear {x y z : ob PA} (f : PA⟦x, y⟧) (g : PA⟦y, z⟧) :
-    QuotPrecategory_comp (to_quot_mor f) (to_quot_mor g) = to_quot_mor (f · g).
+  Lemma Quotcategory_comp_linear {x y z : ob PA} (f : PA⟦x, y⟧) (g : PA⟦y, z⟧) :
+    Quotcategory_comp (to_quot_mor f) (to_quot_mor g) = to_quot_mor (f · g).
   Proof.
-    unfold to_quot_mor. unfold QuotPrecategory_comp.
+    unfold to_quot_mor. unfold Quotcategory_comp.
     apply pathsinv0.
-    use (pr2 (pr1 (QuotPrecategory_comp_iscontr
+    use (pr2 (pr1 (Quotcategory_comp_iscontr
                            (setquotpr (binopeqrel_subgr_eqrel (PAS x y)) f)
                            (setquotpr (binopeqrel_subgr_eqrel (PAS y z)) g)))).
     - apply idpath.
@@ -677,15 +677,15 @@ Section preadditive_quotient.
   Qed.
 
   (** Pre- and postcomposition respect binop. *)
-  Local Lemma QuotPrecategory_premor {x y z : PA} (f : PA⟦x, y⟧) (g h : PA⟦y, z⟧) :
-    QuotPrecategory_comp (to_quot_mor f) ((to_quot_mor g * to_quot_mor h)%multmonoid) =
-    ((QuotPrecategory_comp (to_quot_mor f) (to_quot_mor g)) *
-     (QuotPrecategory_comp (to_quot_mor f) (to_quot_mor h)))%multmonoid.
+  Local Lemma Quotcategory_premor {x y z : PA} (f : PA⟦x, y⟧) (g h : PA⟦y, z⟧) :
+    Quotcategory_comp (to_quot_mor f) ((to_quot_mor g * to_quot_mor h)%multmonoid) =
+    ((Quotcategory_comp (to_quot_mor f) (to_quot_mor g)) *
+     (Quotcategory_comp (to_quot_mor f) (to_quot_mor h)))%multmonoid.
   Proof.
-    Local Opaque binopeqrel_subgr_eqrel isabgrquot setquotfun2 QuotPrecategory_comp.
+    Local Opaque binopeqrel_subgr_eqrel isabgrquot setquotfun2 Quotcategory_comp.
     apply pathsinv0. cbn.
     eapply pathscomp0.
-    - rewrite QuotPrecategory_comp_linear. rewrite QuotPrecategory_comp_linear.
+    - rewrite Quotcategory_comp_linear. rewrite Quotcategory_comp_linear.
       use setquotfun2comm.
     - apply pathsinv0.
       unfold to_quot_mor.
@@ -699,29 +699,29 @@ Section preadditive_quotient.
       rewrite tmp. clear tmp.
       rewrite <- to_premor_linear'.
       apply pathsinv0.
-      Local Transparent QuotPrecategory_comp. unfold QuotPrecategory_comp.
-      apply (pr2 (pr1 (QuotPrecategory_comp_iscontr
+      Local Transparent Quotcategory_comp. unfold Quotcategory_comp.
+      apply (pr2 (pr1 (Quotcategory_comp_iscontr
                          (setquotpr (binopeqrel_subgr_eqrel (PAS x y)) f)
                          (setquotpr (binopeqrel_subgr_eqrel (PAS y z)) (to_binop y z g h))))).
       + apply idpath.
       + apply idpath.
   Qed.
 
-  Local Lemma QuotPrecategory_postmor {x y z : PA} (f : PA⟦y, z⟧) (g h : PA⟦x, y⟧) :
-    QuotPrecategory_comp (to_quot_mor g * to_quot_mor h)%multmonoid (to_quot_mor f) =
-    ((QuotPrecategory_comp (to_quot_mor g) (to_quot_mor f)) *
-     (QuotPrecategory_comp (to_quot_mor h) (to_quot_mor f)))%multmonoid.
+  Local Lemma Quotcategory_postmor {x y z : PA} (f : PA⟦y, z⟧) (g h : PA⟦x, y⟧) :
+    Quotcategory_comp (to_quot_mor g * to_quot_mor h)%multmonoid (to_quot_mor f) =
+    ((Quotcategory_comp (to_quot_mor g) (to_quot_mor f)) *
+     (Quotcategory_comp (to_quot_mor h) (to_quot_mor f)))%multmonoid.
   Proof.
-    Local Opaque QuotPrecategory_comp.
+    Local Opaque Quotcategory_comp.
     apply pathsinv0. cbn.
     eapply pathscomp0.
-    - rewrite QuotPrecategory_comp_linear. rewrite QuotPrecategory_comp_linear.
+    - rewrite Quotcategory_comp_linear. rewrite Quotcategory_comp_linear.
       use setquotfun2comm.
     - unfold to_quot_mor. rewrite setquotfun2comm.
-      Local Transparent QuotPrecategory_comp.
-      unfold QuotPrecategory_comp.
+      Local Transparent Quotcategory_comp.
+      unfold Quotcategory_comp.
       rewrite <- to_postmor_linear'.
-      apply (pr2 (pr1 (QuotPrecategory_comp_iscontr
+      apply (pr2 (pr1 (Quotcategory_comp_iscontr
                          (setquotpr (binopeqrel_subgr_eqrel (PAS x y)) (to_binop x y g h))
                          (setquotpr (binopeqrel_subgr_eqrel (PAS y z)) f)))).
       + apply idpath.
@@ -730,13 +730,13 @@ Section preadditive_quotient.
 
   (** Composing with the unit element gives the unit element. *)
   Local Lemma quot_comp_unel_left {x y z : PA} (f : PA⟦x, y⟧) :
-    QuotPrecategory_comp (setquotpr (binopeqrel_subgr_eqrel (PAS x y)) f)
+    Quotcategory_comp (setquotpr (binopeqrel_subgr_eqrel (PAS x y)) f)
                          (setquotpr (binopeqrel_subgr_eqrel (PAS y z)) (@to_unel PA y z)) =
     (setquotpr (binopeqrel_subgr_eqrel (PAS x z)) (@to_unel PA x z)).
   Proof.
     rewrite <- (to_premor_unel' _ _ f). apply pathsinv0.
-    unfold QuotPrecategory_comp.
-    apply (pr2 (pr1 (QuotPrecategory_comp_iscontr
+    unfold Quotcategory_comp.
+    apply (pr2 (pr1 (Quotcategory_comp_iscontr
                        (setquotpr (binopeqrel_subgr_eqrel (PAS x y)) f)
                        (setquotpr (binopeqrel_subgr_eqrel (PAS y z)) (to_unel y z))))).
     - apply idpath.
@@ -744,13 +744,13 @@ Section preadditive_quotient.
   Qed.
 
   Local Lemma quot_comp_unel_right {x y z : PA} (f : PA⟦y, z⟧) :
-    QuotPrecategory_comp (setquotpr (binopeqrel_subgr_eqrel (PAS x y)) (to_unel x y))
+    Quotcategory_comp (setquotpr (binopeqrel_subgr_eqrel (PAS x y)) (to_unel x y))
                          (setquotpr (binopeqrel_subgr_eqrel (PAS y z)) f) =
     (setquotpr (binopeqrel_subgr_eqrel (PAS x z)) (to_unel x z)).
   Proof.
     rewrite <- (to_postmor_unel' _ _ f). apply pathsinv0.
-    unfold QuotPrecategory_comp.
-    apply (pr2 (pr1 (QuotPrecategory_comp_iscontr
+    unfold Quotcategory_comp.
+    apply (pr2 (pr1 (Quotcategory_comp_iscontr
                        (setquotpr (binopeqrel_subgr_eqrel (PAS x y)) (to_unel x y))
                        (setquotpr (binopeqrel_subgr_eqrel (PAS y z)) f)))).
     - apply idpath.
@@ -758,29 +758,29 @@ Section preadditive_quotient.
   Qed.
 
 
-  (** ** Construction of the QuotPrecategory *)
+  (** ** Construction of the Quotcategory *)
 
-  Definition QuotPrecategory_data : precategory_data :=
+  Definition Quotcategory_data : precategory_data :=
     precategory_data_pair
-      QuotPrecategory_ob_mor
+      Quotcategory_ob_mor
       (fun (A : ob PA) => setquotpr (binopeqrel_subgr_eqrel (PAS A A)) (identity A))
-      (fun (A B C : ob PA) (f : QuotPrecategory_ob_mor⟦A, B⟧)
-         (g : QuotPrecategory_ob_mor⟦B, C⟧) => QuotPrecategory_comp f g).
+      (fun (A B C : ob PA) (f : Quotcategory_ob_mor⟦A, B⟧)
+         (g : Quotcategory_ob_mor⟦B, C⟧) => Quotcategory_comp f g).
 
   (** The following two lemmas are used to show associaticity of composition in
-      QuotPrecategory. *)
-  Local Lemma Quot_assoc1 {a b c d : QuotPrecategory_data} (f : QuotPrecategory_data ⟦a, b⟧)
-        (g : QuotPrecategory_data ⟦b, c⟧) (h : QuotPrecategory_data ⟦c, d⟧)
+      Quotcategory. *)
+  Local Lemma Quot_assoc1 {a b c d : Quotcategory_data} (f : Quotcategory_data ⟦a, b⟧)
+        (g : Quotcategory_data ⟦b, c⟧) (h : Quotcategory_data ⟦c, d⟧)
         (f1 : PA⟦a, b⟧) (f2 : setquotpr (binopeqrel_subgr_eqrel (PAS a b)) f1 = f)
         (g1 : PA⟦b, c⟧) (g2 : setquotpr (binopeqrel_subgr_eqrel (PAS b c)) g1 = g)
         (h1 : PA⟦c, d⟧) (h2 : setquotpr (binopeqrel_subgr_eqrel (PAS c d)) h1 = h) :
-    QuotPrecategory_comp f (QuotPrecategory_comp g h) =
+    Quotcategory_comp f (Quotcategory_comp g h) =
     setquotpr (binopeqrel_subgr_eqrel (PAS a d)) (f1 · (g1 · h1)).
   Proof.
     apply pathsinv0.
-    set (ic2 := QuotPrecategory_comp_iscontr g h).
-    set (ic3 := QuotPrecategory_comp_iscontr f (pr1 (pr1 ic2))).
-    set (tmp := pr2 (pr1 ic3)). cbn beta in tmp. unfold QuotPrecategory_comp.
+    set (ic2 := Quotcategory_comp_iscontr g h).
+    set (ic3 := Quotcategory_comp_iscontr f (pr1 (pr1 ic2))).
+    set (tmp := pr2 (pr1 ic3)). cbn beta in tmp. unfold Quotcategory_comp.
     fold ic2. fold ic3. use tmp.
     - exact f2.
     - use (pr2 (pr1 ic2)).
@@ -788,17 +788,17 @@ Section preadditive_quotient.
       + exact h2.
   Qed.
 
-  Local Lemma Quot_assoc2 {a b c d : QuotPrecategory_data} (f : QuotPrecategory_data ⟦a, b⟧)
-        (g : QuotPrecategory_data ⟦b, c⟧) (h : QuotPrecategory_data ⟦c, d⟧)
+  Local Lemma Quot_assoc2 {a b c d : Quotcategory_data} (f : Quotcategory_data ⟦a, b⟧)
+        (g : Quotcategory_data ⟦b, c⟧) (h : Quotcategory_data ⟦c, d⟧)
         (f1 : PA⟦a, b⟧) (f2 : setquotpr (binopeqrel_subgr_eqrel (PAS a b)) f1 = f)
         (g1 : PA⟦b, c⟧) (g2 : setquotpr (binopeqrel_subgr_eqrel (PAS b c)) g1 = g)
         (h1 : PA⟦c, d⟧) (h2 : setquotpr (binopeqrel_subgr_eqrel (PAS c d)) h1 = h) :
     setquotpr (binopeqrel_subgr_eqrel (PAS a d)) ((f1 · g1) · h1) =
-    QuotPrecategory_comp (QuotPrecategory_comp f g) h.
+    Quotcategory_comp (Quotcategory_comp f g) h.
   Proof.
-    set (ic1 := QuotPrecategory_comp_iscontr f g).
-    set (ic4 := QuotPrecategory_comp_iscontr (pr1 (pr1 ic1)) h).
-    set (tmp := pr2 (pr1 ic4)). cbn beta in tmp. unfold QuotPrecategory_comp.
+    set (ic1 := Quotcategory_comp_iscontr f g).
+    set (ic4 := Quotcategory_comp_iscontr (pr1 (pr1 ic1)) h).
+    set (tmp := pr2 (pr1 ic4)). cbn beta in tmp. unfold Quotcategory_comp.
     fold ic1. fold ic4. use tmp.
     - use (pr2 (pr1 ic1)).
       + exact f2.
@@ -806,31 +806,31 @@ Section preadditive_quotient.
     - exact h2.
   Qed.
 
-  (** QuotPrecategory is a precategory *)
-  Lemma is_precategory_QuotPrecategory_data : is_precategory QuotPrecategory_data.
+  (** Quotcategory is a precategory *)
+  Lemma is_precategory_Quotcategory_data : is_precategory Quotcategory_data.
   Proof.
     split.
     - split.
       (* id left *)
-      + intros a b f. apply pathsinv0. cbn. unfold QuotPrecategory_comp.
+      + intros a b f. apply pathsinv0. cbn. unfold Quotcategory_comp.
         set (f'' := @issurjsetquotpr (to_abgrop a b) (binopeqrel_subgr_eqrel (PAS a b)) f).
         use (squash_to_prop f''). apply isasetsetquot. intros f'. clear f''.
         induction f' as [f1 f2]. rewrite <- f2. cbn in f1, a, b.
         eapply pathscomp0.
         * apply maponpaths. exact (! (id_left f1)).
-        * apply (pr2 (pr1 (QuotPrecategory_comp_iscontr
+        * apply (pr2 (pr1 (Quotcategory_comp_iscontr
                              (setquotpr (binopeqrel_subgr_eqrel (PAS a a)) (@identity PA a))
                              (setquotpr (binopeqrel_subgr_eqrel (PAS a b)) f1)))).
           -- apply idpath.
           -- apply idpath.
       (* id right *)
-      + intros a b f. apply pathsinv0. cbn. unfold QuotPrecategory_comp.
+      + intros a b f. apply pathsinv0. cbn. unfold Quotcategory_comp.
         set (f'' := @issurjsetquotpr (to_abgrop a b) (binopeqrel_subgr_eqrel (PAS a b)) f).
         use (squash_to_prop f''). apply isasetsetquot. intros f'. clear f''.
         induction f' as [f1 f2]. rewrite <- f2. cbn in f1, a, b.
         eapply pathscomp0.
         * apply maponpaths. exact (! (id_right f1)).
-        * apply (pr2 (pr1 (QuotPrecategory_comp_iscontr
+        * apply (pr2 (pr1 (Quotcategory_comp_iscontr
                              (setquotpr (binopeqrel_subgr_eqrel (PAS a b)) f1)
                              (setquotpr (binopeqrel_subgr_eqrel (PAS b b)) (@identity PA b))))).
           -- apply idpath.
@@ -850,10 +850,10 @@ Section preadditive_quotient.
       rewrite assoc. apply idpath.
   Qed.
 
-  Definition QuotPrecategory : precategory :=
-    tpair _ _ is_precategory_QuotPrecategory_data.
+  Definition Quotcategory : precategory :=
+    tpair _ _ is_precategory_Quotcategory_data.
 
-  Lemma has_homsets_QuotPrecategory : has_homsets QuotPrecategory.
+  Lemma has_homsets_Quotcategory : has_homsets Quotcategory.
   Proof.
     intros a b. apply isasetsetquot.
   Qed.
@@ -861,72 +861,72 @@ Section preadditive_quotient.
 
   (** ** Quotient precategory of PreAdditive is PreAdditive *)
 
-  Definition QuotPrecategory_binops : precategoryWithBinOps.
+  Definition Quotcategory_binops : precategoryWithBinOps.
   Proof.
     use mk_precategoryWithBinOps.
-    - exact QuotPrecategory.
+    - exact Quotcategory.
     - intros x y. exact (@op (subabgr_quot (PAS x y))).
   Defined.
 
   Unset Kernel Term Sharing.
-  Definition QuotPrecategory_abgrops : PrecategoryWithAbgrops.
+  Definition Quotcategory_abgrops : categoryWithAbgrops.
   Proof.
-    use mk_PrecategoryWithAbgrops.
-    - exact QuotPrecategory_binops.
-    - exact has_homsets_QuotPrecategory.
+    use mk_categoryWithAbgrops.
+    - exact Quotcategory_binops.
+    - exact has_homsets_Quotcategory.
     - intros x y. exact (pr2 (subabgr_quot (PAS x y))).
   Defined.
   Set Kernel Term Sharing.
 
   Local Lemma quot_unel {x y : PA} :
     setquotpr (binopeqrel_subgr_eqrel (PAS x y)) (@to_unel PA x y) =
-    unel (@to_abgrop QuotPrecategory_abgrops x y).
+    unel (@to_abgrop Quotcategory_abgrops x y).
   Proof.
     apply idpath.
   Qed.
 
   Local Opaque to_abgrop.
-  Local Lemma PreAdditive_pre_linear (x y z : ob QuotPrecategory_abgrops)
-    (f : QuotPrecategory_abgrops⟦x, y⟧) (g h : QuotPrecategory_abgrops ⟦y, z⟧):
+  Local Lemma PreAdditive_pre_linear (x y z : ob Quotcategory_abgrops)
+    (f : Quotcategory_abgrops⟦x, y⟧) (g h : Quotcategory_abgrops ⟦y, z⟧):
     f · to_binop y z g h = to_binop x z (f · g) (f · h).
   Proof.
-    use (squash_to_prop (QuotPrecategory_surj f)). apply to_has_homsets. intros f'.
-    use (squash_to_prop (QuotPrecategory_surj g)). apply to_has_homsets. intros g'.
-    use (squash_to_prop (QuotPrecategory_surj h)). apply to_has_homsets. intros h'.
+    use (squash_to_prop (Quotcategory_surj f)). apply to_has_homsets. intros f'.
+    use (squash_to_prop (Quotcategory_surj g)). apply to_has_homsets. intros g'.
+    use (squash_to_prop (Quotcategory_surj h)). apply to_has_homsets. intros h'.
     rewrite <- (hfiberpr2 _ _ f'). rewrite <- (hfiberpr2 _ _ g'). rewrite <- (hfiberpr2 _ _ h').
-    exact (QuotPrecategory_premor (hfiberpr1 _ _ f') (hfiberpr1 _ _ g') (hfiberpr1 _ _ h')).
+    exact (Quotcategory_premor (hfiberpr1 _ _ f') (hfiberpr1 _ _ g') (hfiberpr1 _ _ h')).
   Qed.
 
-  Local Lemma PreAdditive_pre_unel (x y z : ob QuotPrecategory_abgrops)
-        (f : QuotPrecategory_abgrops⟦x, y⟧) : f · (@to_unel QuotPrecategory_abgrops y z) =
-                                              @to_unel QuotPrecategory_abgrops x z.
+  Local Lemma PreAdditive_pre_unel (x y z : ob Quotcategory_abgrops)
+        (f : Quotcategory_abgrops⟦x, y⟧) : f · (@to_unel Quotcategory_abgrops y z) =
+                                              @to_unel Quotcategory_abgrops x z.
   Proof.
-    use (squash_to_prop (QuotPrecategory_surj f)). apply (@to_has_homsets QuotPrecategory_abgrops).
+    use (squash_to_prop (Quotcategory_surj f)). apply (@to_has_homsets Quotcategory_abgrops).
     intros f'. rewrite <- (hfiberpr2 _ _ f').
     exact (@quot_comp_unel_left x y z (hfiberpr1 _ _ f')).
   Qed.
 
-  Local Lemma PreAdditive_post_linear (x y z : ob QuotPrecategory_abgrops)
-    (f : QuotPrecategory_abgrops⟦y, z⟧) (g h : QuotPrecategory_abgrops ⟦x, y⟧):
+  Local Lemma PreAdditive_post_linear (x y z : ob Quotcategory_abgrops)
+    (f : Quotcategory_abgrops⟦y, z⟧) (g h : Quotcategory_abgrops ⟦x, y⟧):
     to_binop x y g h · f = to_binop x z (g · f) (h · f).
   Proof.
-    use (squash_to_prop (QuotPrecategory_surj f)). apply to_has_homsets. intros f'.
-    use (squash_to_prop (QuotPrecategory_surj g)). apply to_has_homsets. intros g'.
-    use (squash_to_prop (QuotPrecategory_surj h)). apply to_has_homsets. intros h'.
+    use (squash_to_prop (Quotcategory_surj f)). apply to_has_homsets. intros f'.
+    use (squash_to_prop (Quotcategory_surj g)). apply to_has_homsets. intros g'.
+    use (squash_to_prop (Quotcategory_surj h)). apply to_has_homsets. intros h'.
     rewrite <- (hfiberpr2 _ _ f'). rewrite <- (hfiberpr2 _ _ g'). rewrite <- (hfiberpr2 _ _ h').
-    exact (QuotPrecategory_postmor (hfiberpr1 _ _ f') (hfiberpr1 _ _ g') (hfiberpr1 _ _ h')).
+    exact (Quotcategory_postmor (hfiberpr1 _ _ f') (hfiberpr1 _ _ g') (hfiberpr1 _ _ h')).
   Qed.
 
-  Local Lemma PreAdditive_post_unel (x y z : ob QuotPrecategory_abgrops)
-        (f : QuotPrecategory_abgrops⟦y, z⟧) : (@to_unel QuotPrecategory_abgrops x y) · f =
-                                              @to_unel QuotPrecategory_abgrops x z.
+  Local Lemma PreAdditive_post_unel (x y z : ob Quotcategory_abgrops)
+        (f : Quotcategory_abgrops⟦y, z⟧) : (@to_unel Quotcategory_abgrops x y) · f =
+                                              @to_unel Quotcategory_abgrops x z.
   Proof.
-    use (squash_to_prop (QuotPrecategory_surj f)). apply (@to_has_homsets QuotPrecategory_abgrops).
+    use (squash_to_prop (Quotcategory_surj f)). apply (@to_has_homsets Quotcategory_abgrops).
     intros f'. rewrite <- (hfiberpr2 _ _ f').
     exact (@quot_comp_unel_right x y z (hfiberpr1 _ _ f')).
   Qed.
 
-  Lemma QuotPrecategory_isPreAdditive : isPreAdditive QuotPrecategory_abgrops.
+  Lemma Quotcategory_isPreAdditive : isPreAdditive Quotcategory_abgrops.
   Proof.
     use mk_isPreAdditive'.
     - intros x y z f g h. exact (PreAdditive_pre_linear x y z f g h).
@@ -935,58 +935,58 @@ Section preadditive_quotient.
     - intros x y z f. exact (PreAdditive_post_unel x y z f).
   Qed.
 
-  Definition QuotPrecategory_PreAdditive : PreAdditive.
+  Definition Quotcategory_PreAdditive : PreAdditive.
   Proof.
     use mk_PreAdditive.
-    - exact QuotPrecategory_abgrops.
-    - exact QuotPrecategory_isPreAdditive.
+    - exact Quotcategory_abgrops.
+    - exact Quotcategory_isPreAdditive.
   Defined.
 
   Lemma setquotpr_linear {x y : PA} (f g : PA⟦x, y⟧) :
     to_quot_mor (@to_binop PA _ _ f g) =
-    @to_binop QuotPrecategory_PreAdditive _ _ (to_quot_mor f) (to_quot_mor g).
+    @to_binop Quotcategory_PreAdditive _ _ (to_quot_mor f) (to_quot_mor g).
   Proof.
     exact (pr1 (abgrquotpr_ismonoidfun (binopeqrel_subgr_eqrel (PAS x y))) f g).
   Qed.
 
-  Lemma comp_eq {x y z : PA} (f : QuotPrecategory_PreAdditive⟦x, y⟧)
-        (g : QuotPrecategory_PreAdditive⟦y, z⟧) : QuotPrecategory_comp f g = f · g.
+  Lemma comp_eq {x y z : PA} (f : Quotcategory_PreAdditive⟦x, y⟧)
+        (g : Quotcategory_PreAdditive⟦y, z⟧) : Quotcategory_comp f g = f · g.
   Proof.
     apply idpath.
   Qed.
 
 
-  (** ** The canonical functor to QuotPrecategory *)
+  (** ** The canonical functor to Quotcategory *)
   (** This functor is identity on objects and sends morphisms to the equivalence class they
       represent. *)
 
-  Definition QuotPrecategoryFunctor_data : functor_data PA QuotPrecategory_PreAdditive.
+  Definition QuotcategoryFunctor_data : functor_data PA Quotcategory_PreAdditive.
   Proof.
     use tpair.
     - intros X. exact X.
     - intros X Y f. exact (setquotpr (binopeqrel_subgr_eqrel (PAS X Y)) f).
   Defined.
 
-  Local Lemma QuotPrecategoryFunctor_isfunctor : is_functor QuotPrecategoryFunctor_data.
+  Local Lemma QuotcategoryFunctor_isfunctor : is_functor QuotcategoryFunctor_data.
   Proof.
     split.
     - intros X. apply idpath.
-    - intros x Y Z f g. exact (! (QuotPrecategory_comp_linear f g)).
+    - intros x Y Z f g. exact (! (Quotcategory_comp_linear f g)).
   Qed.
 
-  Definition QuotPrecategoryFunctor : functor PA QuotPrecategory_PreAdditive.
+  Definition QuotcategoryFunctor : functor PA Quotcategory_PreAdditive.
   Proof.
     use tpair.
-    - exact QuotPrecategoryFunctor_data.
-    - exact QuotPrecategoryFunctor_isfunctor.
+    - exact QuotcategoryFunctor_data.
+    - exact QuotcategoryFunctor_isfunctor.
   Defined.
 
 
-  (** ** If PA has a zero object, then so does QuotPrecategory of PA *)
+  (** ** If PA has a zero object, then so does Quotcategory of PA *)
 
   Variable Z : Zero PA.
 
-  Lemma QuotPrecategory_isZero : isZero QuotPrecategory Z.
+  Lemma Quotcategory_isZero : isZero Quotcategory Z.
   Proof.
     use mk_isZero.
     - intros a.
@@ -994,7 +994,7 @@ Section preadditive_quotient.
       + exact (to_quot_mor (@ZeroArrowFrom PA Z a)).
       + cbn beta. intros t.
         set (t'1 := @issurjsetquotpr (to_abgrop Z a) (binopeqrel_subgr_eqrel (PAS Z a)) t).
-        use (squash_to_prop t'1). apply has_homsets_QuotPrecategory. intros t1. clear t'1.
+        use (squash_to_prop t'1). apply has_homsets_Quotcategory. intros t1. clear t'1.
         induction t1 as [t1 t2]. rewrite <- t2. unfold to_quot_mor. apply maponpaths.
         apply ArrowsFromZero.
     - intros a.
@@ -1002,16 +1002,16 @@ Section preadditive_quotient.
       + exact (to_quot_mor (@ZeroArrowTo PA Z a)).
       + cbn beta. intros t.
         set (t'1 := @issurjsetquotpr (to_abgrop a Z) (binopeqrel_subgr_eqrel (PAS a Z)) t).
-        use (squash_to_prop t'1). apply has_homsets_QuotPrecategory. intros t1. clear t'1.
+        use (squash_to_prop t'1). apply has_homsets_Quotcategory. intros t1. clear t'1.
         induction t1 as [t1 t2]. rewrite <- t2. unfold to_quot_mor. apply maponpaths.
         apply ArrowsToZero.
   Qed.
 
-  Definition QuotPrecategory_Zero : @Zero QuotPrecategory.
+  Definition Quotcategory_Zero : @Zero Quotcategory.
   Proof.
     use mk_Zero.
     - exact Z.
-    - exact QuotPrecategory_isZero.
+    - exact Quotcategory_isZero.
   Defined.
 
 End preadditive_quotient.

--- a/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
+++ b/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
@@ -16,39 +16,40 @@ Require Import UniMath.CategoryTheory.precategoriesWithBinOps.
 Section def_precategory_with_abgrops.
 
   (** Definition of precategories such that homsets are abgrops. *)
-  Definition PrecategoryWithAbgropsData (PB : precategoryWithBinOps) (hs : has_homsets PB) : UU :=
+  Definition categoryWithAbgropsData (PB : precategoryWithBinOps) (hs : has_homsets PB) : UU :=
     ∏ (x y : PB), @isabgrop (hSetpair (PB⟦x,y⟧) (hs x y)) (to_binop x y).
 
-  Definition mk_PrecategoryWithAbgropsData {PB : precategoryWithBinOps} (hs : has_homsets PB)
+  Definition mk_categoryWithAbgropsData {PB : precategoryWithBinOps} (hs : has_homsets PB)
              (H : ∏ (x y : PB), @isabgrop (hSetpair (PB⟦x,y⟧) (hs x y)) (to_binop x y)) :
-    PrecategoryWithAbgropsData PB hs := H.
+    categoryWithAbgropsData PB hs := H.
 
-  Definition PrecategoryWithAbgrops : UU :=
+  Definition categoryWithAbgrops : UU :=
     ∑ PA : (∑ PB : precategoryWithBinOps, has_homsets PB),
-           PrecategoryWithAbgropsData (pr1 PA) (pr2 PA).
+           categoryWithAbgropsData (pr1 PA) (pr2 PA).
 
-  Definition PrecategoryWithAbgrops_precategoryWithBinOps (PB : PrecategoryWithAbgrops) :
+  Definition categoryWithAbgrops_precategoryWithBinOps (PB : categoryWithAbgrops) :
     precategoryWithBinOps := pr1 (pr1 PB).
-  Coercion PrecategoryWithAbgrops_precategoryWithBinOps :
-    PrecategoryWithAbgrops >-> precategoryWithBinOps.
+  Coercion categoryWithAbgrops_precategoryWithBinOps :
+    categoryWithAbgrops >-> precategoryWithBinOps.
 
-  (* Precategory with abgrops to Precategory *)
-  Definition PrecategoryWithAbgrops_Precategory (PWA : PrecategoryWithAbgrops) : Precategory.
+  (* category with abgrops to category *)
+  Definition categoryWithAbgrops_category (PWA : categoryWithAbgrops) : category.
   Proof.
     use tpair.
     - exact PWA.
     - exact (pr2 (pr1 PWA)).
   Defined.
-  Coercion PrecategoryWithAbgrops_Precategory : PrecategoryWithAbgrops >-> Precategory.
+  Coercion categoryWithAbgrops_category : categoryWithAbgrops >-> category.
 
-  Definition mk_PrecategoryWithAbgrops (PB : precategoryWithBinOps) (hs : has_homsets PB)
-             (H : PrecategoryWithAbgropsData PB hs) : PrecategoryWithAbgrops.
+
+  Definition mk_categoryWithAbgrops (PB : precategoryWithBinOps) (hs : has_homsets PB)
+             (H : categoryWithAbgropsData PB hs) : categoryWithAbgrops.
   Proof.
     exact (tpair _ (tpair _ PB hs) H).
   Defined.
 
 
-  Variable PA : PrecategoryWithAbgrops.
+  Variable PA : categoryWithAbgrops.
 
   (** Definitions to access the structure of a precategory with abelian groups. *)
   Definition to_has_homsets : has_homsets PA := pr2 (pr1 PA).
@@ -200,7 +201,7 @@ Arguments cancel_inv [PA] [x] [y] _ _ _.
 
 Section transport_morphisms.
 
-  Variable PA : PrecategoryWithAbgrops.
+  Variable PA : categoryWithAbgrops.
 
   Lemma transport_target_to_inv {x y z : ob PA} (f : x --> y) (e : y = z) :
     to_inv (transportf (precategory_morphisms x) e f) =

--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -227,7 +227,7 @@ Defined.
 
 Lemma Pullbacks_PreShv : Pullbacks (PreShv C).
 Proof.
-now apply FunctorPrecategoryPullbacks, PullbacksHSET.
+now apply FunctorcategoryPullbacks, PullbacksHSET.
 Defined.
 
 Lemma has_exponentials_PreShv (hsC : has_homsets C) :

--- a/UniMath/CategoryTheory/Quotobjects.v
+++ b/UniMath/CategoryTheory/Quotobjects.v
@@ -20,24 +20,24 @@ Section def_quotobjects.
   Variable C : precategory.
   Hypothesis hs : has_homsets C.
 
-  Definition QuotobjectsPrecategory (c : C) : UU :=
-    UnderPrecategory (subprecategory_of_epis C hs)
+  Definition Quotobjectscategory (c : C) : UU :=
+    Undercategory (subprecategory_of_epis C hs)
                      (has_homsets_subprecategory_of_epis C hs)
                      (subprecategory_of_epis_ob C hs c).
 
   (** Construction of a quotient object from an epi *)
-  Definition QuotobjectsPrecategory_ob {c c' : C} (h : C⟦c, c'⟧) (isE : isEpi h) :
-    QuotobjectsPrecategory c := tpair _ (subprecategory_of_epis_ob C hs c') (tpair _ h isE).
+  Definition Quotobjectscategory_ob {c c' : C} (h : C⟦c, c'⟧) (isE : isEpi h) :
+    Quotobjectscategory c := tpair _ (subprecategory_of_epis_ob C hs c') (tpair _ h isE).
 
   Hypothesis hpo : @Pushouts C.
 
   (** Given any quotient object Q of c and a morphism h : c -> c', by taking then pushout of Q by h
       we obtain a quotient object of c'. *)
-  Definition PushoutQuotobject {c : C} (Q : QuotobjectsPrecategory c) {c' : C} (h : C⟦c, c'⟧) :
-    QuotobjectsPrecategory c'.
+  Definition PushoutQuotobject {c : C} (Q : Quotobjectscategory c) {c' : C} (h : C⟦c, c'⟧) :
+    Quotobjectscategory c'.
   Proof.
     set (po := hpo _ _ _ h (pr1 (pr2 Q))).
-    use QuotobjectsPrecategory_ob.
+    use Quotobjectscategory_ob.
     - exact po.
     - exact (limits.pushouts.PushoutIn1 po).
     - use EpiPushoutisEpi'.

--- a/UniMath/CategoryTheory/RModules.v
+++ b/UniMath/CategoryTheory/RModules.v
@@ -1,7 +1,7 @@
 (** **********************************************************
 Contents:
         - Definition of right modules ([RModule R]) over a monad [R] on [C]
-        - Precategory of right modules [Precategory_RModule R D] of range [D] over a monad [R] on [C]
+        - category of right modules [category_RModule R D] of range [D] over a monad [R] on [C]
         - Tautological right module [tautological_RModule] : a monad is a module over itself
         - Pullback of a module along a monad morphism [pb_RModule]
         - Pullback of a module morphism along a monad morphism [pb_RModule_Mor]
@@ -167,10 +167,10 @@ Proof.
     apply (@assoc (functor_precategory B C hs)).
 Qed.
 
-Definition precategory_RModule (C : Precategory) : precategory
+Definition precategory_RModule (C : category) : precategory
   := tpair _ _ (precategory_RModule_axioms C (homset_property C)).
 
-Lemma has_homsets_RModule (C:Precategory) :
+Lemma has_homsets_RModule (C : category) :
   has_homsets (precategory_RModule C).
 Proof.
   intros F G.
@@ -183,7 +183,7 @@ Proof.
     apply homset_property.
 Qed.
 
-Definition Precategory_RModule (C:Precategory) : Precategory :=
+Definition category_RModule (C : category) : category :=
   (precategory_RModule C,, has_homsets_RModule C).
 
 

--- a/UniMath/CategoryTheory/SetValuedFunctors.v
+++ b/UniMath/CategoryTheory/SetValuedFunctors.v
@@ -31,7 +31,7 @@ Lemma is_pointwise_epi_from_set_nat_trans_epi (C:precategory)
       (h:isEpi (C:=functor_precategory C _ has_homsets_HSET) f)
   : ∏ (x:C), isEpi (f x).
 Proof.
-  apply (Pushouts_pw_epi (D:=hset_Precategory)).
+  apply (Pushouts_pw_epi (D:=hset_category)).
   apply PushoutsHSET_from_Colims.
   apply h.
 Qed.
@@ -71,10 +71,10 @@ Section LiftEpiNatTrans.
   Lemma EffectiveEpis_Functor_HSET : EpisAreEffective C_SET.
   Proof.
     intros F G m isepim.
-    apply (isEffectivePw (D:=hset_Precategory)).
+    apply (isEffectivePw (D:=hset_category)).
     intro x.
     apply EffectiveEpis_HSET.
-    apply (Pushouts_pw_epi (D:=hset_Precategory)
+    apply (Pushouts_pw_epi (D:=hset_category)
                            PushoutsHSET_from_Colims).
     assumption.
   Qed.

--- a/UniMath/CategoryTheory/Subobjects.v
+++ b/UniMath/CategoryTheory/Subobjects.v
@@ -4,7 +4,7 @@ Definition and theory about subobjects of an object c
 
 Contents:
 
-- Category of subobjects (monos) of c ([SubobjectsPrecategory])
+- Category of subobjects (monos) of c ([Subobjectscategory])
 - Set of subobjects as equivalence classes of monos ([SubObj])
 - Proof that the set of subobjects of an object is a poset ([SubObjPoset])
 
@@ -33,28 +33,28 @@ Section def_subobjects.
 
   Context {C : precategory} (hsC : has_homsets C).
 
-  Definition SubobjectsPrecategory (c : C) : precategory :=
+  Definition Subobjectscategory (c : C) : precategory :=
     slice_precat (subprecategory_of_monics C hsC)
                  (subprecategory_of_monics_ob C hsC c)
                  (has_homsets_subprecategory_of_monics C hsC).
 
-  Lemma has_homsets_SubobjectsPrecategory (c : C) :
-    has_homsets (SubobjectsPrecategory c).
+  Lemma has_homsets_Subobjectscategory (c : C) :
+    has_homsets (Subobjectscategory c).
   Proof.
   apply has_homsets_slice_precat.
   Qed.
 
   (** Construction of a subobject from a monic *)
-  Definition SubobjectsPrecategory_ob {c c' : C} (h : C⟦c', c⟧) (isM : isMonic h) :
-    SubobjectsPrecategory c := (subprecategory_of_monics_ob C hsC c',,(h,,isM)).
+  Definition Subobjectscategory_ob {c c' : C} (h : C⟦c', c⟧) (isM : isMonic h) :
+    Subobjectscategory c := (subprecategory_of_monics_ob C hsC c',,(h,,isM)).
 
   (** Given any subobject S of c and a morphism h : c' -> c, by taking then pullback of S by h we
       obtain a subobject of c'. *)
-  Definition PullbackSubobject (PB : Pullbacks C) {c : C} (S : SubobjectsPrecategory c) {c' : C} (h : C⟦c', c⟧) :
-    SubobjectsPrecategory c'.
+  Definition PullbackSubobject (PB : Pullbacks C) {c : C} (S : Subobjectscategory c) {c' : C} (h : C⟦c', c⟧) :
+    Subobjectscategory c'.
   Proof.
     set (pb := PB _ _ _ h (pr1 (pr2 S))).
-    use SubobjectsPrecategory_ob.
+    use Subobjectscategory_ob.
     - exact pb.
     - exact (PullbackPr1 pb).
     - use MonicPullbackisMonic'.
@@ -70,10 +70,10 @@ Context {C : precategory} (hsC : has_homsets C).
 (** Equivalence classes of subobjects defined by identifying monos into c
     with isomorphic source *)
 Definition SubObj (c : C) : HSET :=
-  hSetpair (setquot (iso_eqrel (SubobjectsPrecategory hsC c))) (isasetsetquot _).
+  hSetpair (setquot (iso_eqrel (Subobjectscategory hsC c))) (isasetsetquot _).
 
 (* For f and g monics into c: f <= g := ∃ h, f = h · g *)
-Definition monorel c : hrel (SubobjectsPrecategory hsC c) :=
+Definition monorel c : hrel (Subobjectscategory hsC c) :=
   λ f g, ∃ h, pr1 (pr2 f) = h · pr1 (pr2 g).
 
 Lemma isrefl_monorel (c : C) : isrefl (monorel c).
@@ -97,7 +97,7 @@ Proof.
 exact (istrans_monorel c,,isrefl_monorel c).
 Qed.
 
-Lemma are_isomorphic_monorel {c : C} {x1 y1 x2 y2 : SubobjectsPrecategory hsC c}
+Lemma are_isomorphic_monorel {c : C} {x1 y1 x2 y2 : Subobjectscategory hsC c}
   (h1 : are_isomorphic _ x1 y1) (h2 : are_isomorphic _ x2 y2) :
   monorel c x1 x2 → monorel c y1 y2.
 Proof.
@@ -159,7 +159,7 @@ assert (int : ∏ x1 x2, isaprop (SubObj_rel c x1 x2 → SubObj_rel c x2 x1 -> x
 apply (setquotuniv2prop _ (λ x1 x2, hProppair _ (int x1 x2))).
 intros x y h1 h2.
 simpl in *. (* This is slow *)
-apply (iscompsetquotpr (iso_eqrel (SubobjectsPrecategory hsC c))).
+apply (iscompsetquotpr (iso_eqrel (Subobjectscategory hsC c))).
 generalize h1; clear h1; apply hinhuniv; intros [h1 Hh1].
 generalize h2; clear h2; apply hinhuniv; intros [h2 Hh2].
 apply hinhpr, (invmap (iso_weq _ (subprecategory_of_monics_ob C hsC c) _ _)).

--- a/UniMath/CategoryTheory/UnderPrecategories.v
+++ b/UniMath/CategoryTheory/UnderPrecategories.v
@@ -72,21 +72,21 @@ Section def_underprecategories.
     exact (mk_Under_mor X Z (Under_mor_mor f · Under_mor_mor g) (Under_comp_eq f g)).
   Defined.
 
-  Definition UnderPrecategory_ob_mor : precategory_ob_mor.
+  Definition Undercategory_ob_mor : precategory_ob_mor.
   Proof.
     exists Under_ob.
     exact Under_mor.
   Defined.
 
-  Definition UnderPrecategory_data : precategory_data.
+  Definition Undercategory_data : precategory_data.
   Proof.
-    exists UnderPrecategory_ob_mor.
+    exists Undercategory_ob_mor.
     split.
     - exact Under_id.
     - exact Under_comp.
   Defined.
 
-  Definition is_precategory_UnderPrecategory_data : is_precategory UnderPrecategory_data.
+  Definition is_precategory_Undercategory_data : is_precategory Undercategory_data.
   Proof.
     repeat split.
     - intros. apply Under_mor_equality. apply id_left.
@@ -94,13 +94,13 @@ Section def_underprecategories.
     - intros. apply Under_mor_equality. apply assoc.
   Defined.
 
-  Definition UnderPrecategory : precategory.
+  Definition Undercategory : precategory.
   Proof.
-    exists UnderPrecategory_data.
-    exact is_precategory_UnderPrecategory_data.
+    exists Undercategory_data.
+    exact is_precategory_Undercategory_data.
   Defined.
 
-  Lemma has_homsets_Under : has_homsets UnderPrecategory.
+  Lemma has_homsets_Under : has_homsets Undercategory.
   Proof.
     intros X Y.
     apply (isaset_Under_mor X Y).
@@ -115,7 +115,7 @@ Section undercategories_morphisms.
   Variable C : precategory.
   Hypothesis hs : has_homsets C.
 
-  Local Notation "c / C" := (@UnderPrecategory C hs c).
+  Local Notation "c / C" := (@Undercategory C hs c).
 
   Definition Under_precategories_mor_ob {c c' : C} (h : C⟦c, c'⟧) : c' / C → c / C.
   Proof.

--- a/UniMath/CategoryTheory/categories/StandardCategories.v
+++ b/UniMath/CategoryTheory/categories/StandardCategories.v
@@ -12,19 +12,19 @@ Proof. intros. exact (compose f g). Defined.
 
 (** *** the path groupoid *)
 
-Definition is_groupoid (C : Precategory) :=
+Definition is_groupoid (C : category) :=
   ∏ a b : ob C, isweq (fun p : a = b => idtomor a b p).
 
-Lemma isaprop_is_groupoid (C : Precategory) : isaprop (is_groupoid C).
+Lemma isaprop_is_groupoid (C : category) : isaprop (is_groupoid C).
 Proof. apply impred.
   intro a. apply impred. intro b. apply isapropisweq. Qed.
 
-Lemma morphism_from_iso_is_incl (C : Precategory) (a b : ob C) :
+Lemma morphism_from_iso_is_incl (C : category) (a b : ob C) :
   isincl (morphism_from_iso C a b).
 Proof. intro g.
   apply (isofhlevelweqf _ (ezweqpr1 _ _)). apply isaprop_is_iso. Qed.
 
-Lemma is_univalent_groupoid {C : Precategory}: is_groupoid C -> is_univalent C.
+Lemma is_univalent_groupoid {C : category}: is_groupoid C -> is_univalent C.
 Proof. intros ig  .
   split.
   { intros a b.
@@ -36,13 +36,13 @@ Proof. intros ig  .
   { apply homset_property. }
 Qed.
 
-Definition path_pregroupoid (X:UU) : isofhlevel 3 X -> Precategory.
+Definition path_pregroupoid (X:UU) : isofhlevel 3 X -> category.
   (* Later we'll define a version of this with no hlevel assumption on X,
      where [mor i j] will be defined with [pi0].  This version will still
      be useful, because in it, each arrow is a path, rather than an
      equivalence class of paths. *)
   intros iobj.
-  unshelve refine (makePrecategory X (fun x y => x = y) _ _ _ _ _ _).
+  unshelve refine (makecategory X (fun x y => x = y) _ _ _ _ _ _).
   { reflexivity. }
   { intros. exact (f @ g). }
   { intros. exact (iobj _ _). }
@@ -75,9 +75,9 @@ Require Import UniMath.Combinatorics.StandardFiniteSets.
 Definition cat_n (n:nat): univalent_category.
   apply (path_groupoid (stn n)). apply hlevelntosn.
   apply isasetstn. Defined.
-Definition is_discrete (C:Precategory) := isaset (ob C) × is_groupoid C.
+Definition is_discrete (C : category) := isaset (ob C) × is_groupoid C.
 
-Lemma isaprop_is_discrete (C:Precategory) :
+Lemma isaprop_is_discrete (C : category) :
   isaprop (is_discrete C).
 Proof. apply isofhleveltotal2. apply isapropisaset.
   intro is. apply isaprop_is_groupoid. Qed.

--- a/UniMath/CategoryTheory/categories/abgrs.v
+++ b/UniMath/CategoryTheory/categories/abgrs.v
@@ -83,7 +83,7 @@ Section def_abgr_precategory.
     - intros a b c d f g h. use monoidfunassoc.
   Qed.
 
-  (** ** precategory and Precategory *)
+  (** ** precategory and category *)
 
   Definition abgr_precategory : precategory :=
     mk_precategory abgr_precategory_data is_precategory_abgr_precategory_data.
@@ -93,7 +93,7 @@ Section def_abgr_precategory.
     intros a b. use isasetmonoidfun.
   Qed.
 
-  Definition abgr_Precategory : Precategory := Precategory_pair abgr_precategory has_homsets_abgr.
+  Definition abgr_category : category := category_pair abgr_precategory has_homsets_abgr.
 
 End def_abgr_precategory.
 
@@ -106,7 +106,7 @@ Section def_abgr_category.
 
   (** ** (monoidiso X Y) ≃ (iso X Y) *)
 
-  Lemma abgr_iso_is_equiv (A B : ob abgr_Precategory) (f : iso A B) : isweq (pr1 (pr1 f)).
+  Lemma abgr_iso_is_equiv (A B : ob abgr_category) (f : iso A B) : isweq (pr1 (pr1 f)).
   Proof.
     use gradth.
     - exact (pr1monoidfun _ _ (inv_from_iso f)).
@@ -118,7 +118,7 @@ Section def_abgr_category.
       intros x0. use isapropismonoidfun.
   Qed.
 
-  Lemma abgr_iso_equiv (X Y : ob abgr_Precategory) : iso X Y -> monoidiso (X : abgr) (Y : abgr).
+  Lemma abgr_iso_equiv (X Y : ob abgr_category) : iso X Y -> monoidiso (X : abgr) (Y : abgr).
   Proof.
     intro f.
     use monoidisopair.
@@ -126,8 +126,8 @@ Section def_abgr_category.
     - exact (pr2 (pr1 f)).
   Defined.
 
-  Lemma abgr_equiv_is_iso (X Y : ob abgr_Precategory) (f : monoidiso (X : abgr) (Y : abgr)) :
-    @is_iso abgr_Precategory X Y (monoidfunconstr (pr2 f)).
+  Lemma abgr_equiv_is_iso (X Y : ob abgr_category) (f : monoidiso (X : abgr) (Y : abgr)) :
+    @is_iso abgr_category X Y (monoidfunconstr (pr2 f)).
   Proof.
     use is_iso_qinv.
     - exact (monoidfunconstr (pr2 (invmonoidiso f))).
@@ -136,10 +136,10 @@ Section def_abgr_category.
       + use monoidfun_paths. use funextfun. intros y. use homotweqinvweq.
   Qed.
 
-  Definition abgr_equiv_iso (X Y : ob abgr_Precategory) (f : monoidiso (X : abgr) (Y : abgr)) :
-    iso X Y := @isopair abgr_Precategory X Y (monoidfunconstr (pr2 f)) (abgr_equiv_is_iso X Y f).
+  Definition abgr_equiv_iso (X Y : ob abgr_category) (f : monoidiso (X : abgr) (Y : abgr)) :
+    iso X Y := @isopair abgr_category X Y (monoidfunconstr (pr2 f)) (abgr_equiv_is_iso X Y f).
 
-  Lemma abgr_iso_equiv_is_equiv (X Y : abgr_Precategory) : isweq (abgr_iso_equiv X Y).
+  Lemma abgr_iso_equiv_is_equiv (X Y : abgr_category) : isweq (abgr_iso_equiv X Y).
   Proof.
     use gradth.
     - exact (abgr_equiv_iso X Y).
@@ -149,7 +149,7 @@ Section def_abgr_category.
       + use idpath.
   Qed.
 
-  Definition abgr_iso_equiv_weq (X Y : ob abgr_Precategory) :
+  Definition abgr_iso_equiv_weq (X Y : ob abgr_category) :
     weq (iso X Y) (monoidiso (X : abgr) (Y : abgr)).
   Proof.
     use weqpair.
@@ -157,7 +157,7 @@ Section def_abgr_category.
     - exact (abgr_iso_equiv_is_equiv X Y).
   Defined.
 
-  Lemma abgr_equiv_iso_is_equiv (X Y : ob abgr_Precategory) : isweq (abgr_equiv_iso X Y).
+  Lemma abgr_equiv_iso_is_equiv (X Y : ob abgr_category) : isweq (abgr_equiv_iso X Y).
   Proof.
     use gradth.
     - exact (abgr_iso_equiv X Y).
@@ -167,7 +167,7 @@ Section def_abgr_category.
     - intros x. use eq_iso. use monoidfun_paths. use idpath.
   Qed.
 
-  Definition abgr_equiv_iso_weq (X Y : ob abgr_Precategory) :
+  Definition abgr_equiv_iso_weq (X Y : ob abgr_category) :
     (monoidiso (X : abgr) (Y : abgr)) ≃ (iso X Y).
   Proof.
     use weqpair.
@@ -178,7 +178,7 @@ Section def_abgr_category.
 
   (** ** Category of abelian groups *)
 
-  Definition abgr_Precategory_isweq (a b : ob abgr_Precategory) : isweq (λ p : a = b, idtoiso p).
+  Definition abgr_category_isweq (a b : ob abgr_category) : isweq (λ p : a = b, idtoiso p).
   Proof.
     use (@isweqhomot
            (a = b) (iso a b)
@@ -193,15 +193,15 @@ Section def_abgr_category.
     - use proofirrelevance. use isaprop_is_iso.
   Qed.
 
-  Definition abgr_Precategory_is_univalent : is_univalent abgr_Precategory.
+  Definition abgr_category_is_univalent : is_univalent abgr_category.
   Proof.
     use dirprodpair.
-    - intros a b. exact (abgr_Precategory_isweq a b).
+    - intros a b. exact (abgr_category_isweq a b).
     - exact has_homsets_abgr.
   Defined.
 
-  Definition abgr_category : univalent_category :=
-    mk_category abgr_Precategory abgr_Precategory_is_univalent.
+  Definition abgr_univalent_category : univalent_category :=
+    mk_category abgr_category abgr_category_is_univalent.
 
 End def_abgr_category.
 
@@ -286,22 +286,22 @@ Section abgr_preadditive.
       category.
   *)
 
-  Definition abgr_WithBinOpsData : precategoryWithBinOpsData abgr_Precategory.
+  Definition abgr_WithBinOpsData : precategoryWithBinOpsData abgr_category.
   Proof.
     intros X Y. exact (@abmonoidshombinop (X : abgr) (Y : abgr)).
   Defined.
 
   Definition abgr_WithBinOps : precategoryWithBinOps :=
-    mk_precategoryWithBinOps abgr_Precategory abgr_WithBinOpsData.
+    mk_precategoryWithBinOps abgr_category abgr_WithBinOpsData.
 
-  (** ** [PrecategoryWithAbgrops] structure on the category of abelian groups *)
+  (** ** [categoryWithAbgrops] structure on the category of abelian groups *)
 
-  Definition abgr_WithAbGrops : PrecategoryWithAbgrops.
+  Definition abgr_WithAbGrops : categoryWithAbgrops.
   Proof.
-    use mk_PrecategoryWithAbgrops.
+    use mk_categoryWithAbgrops.
     - exact abgr_WithBinOps.
     - use homset_property.
-    - use mk_PrecategoryWithAbgropsData.
+    - use mk_categoryWithAbgropsData.
       intros X Y. exact (@abgrshomabgr_isabgrop X Y).
   Defined.
 
@@ -363,7 +363,7 @@ Section abgr_additive.
     - use idpath.
   Qed.
 
-  Definition abgr_DirectSumPr2 (A B : abgr) : abgr_Precategory⟦abgrdirprod A B, B⟧ :=
+  Definition abgr_DirectSumPr2 (A B : abgr) : abgr_category⟦abgrdirprod A B, B⟧ :=
     monoidfunconstr (abgr_DirectSumPr2_ismonoidfun A B).
 
   Lemma abgr_DirectSumIn1_ismonoidfun (A B : abgr) :
@@ -678,7 +678,7 @@ Section abgr_kernels_and_cokernels.
   Qed.
 
   Definition abgr_Kernel_monoidfun {A B : abgr} (f : monoidfun A B) :
-    abgr_Precategory⟦carrierofasubabgr (abgr_Kernel_subabgr f), A⟧ :=
+    abgr_category⟦carrierofasubabgr (abgr_Kernel_subabgr f), A⟧ :=
     monoidincltomonoidfun
       (abgr_Kernel_subabgr f) A
       (@monoidmonopair (abgr_Kernel_subabgr f) A
@@ -698,14 +698,14 @@ Section abgr_kernels_and_cokernels.
 
   (** *** KernelIn morphism *)
 
-  Lemma abgr_KernelArrowIn_map_property {A B C : abgr_Precategory} (h : C --> A) (f : A --> B)
+  Lemma abgr_KernelArrowIn_map_property {A B C : abgr_category} (h : C --> A) (f : A --> B)
              (H : h · f = ZeroArrow abgr_Zero C B) (c : (C : abgr)) :
     ishinh_UU (pr1 f (pr1 h c) = 1%multmonoid).
   Proof.
     use hinhpr. use (pathscomp0 (toforallpaths _ _ _ (base_paths _ _ H) c)). use idpath.
   Qed.
 
-  Definition abgr_KernelArrowIn_map {A B C : abgr_Precategory} (h : C --> A) (f : A --> B)
+  Definition abgr_KernelArrowIn_map {A B C : abgr_category} (h : C --> A) (f : A --> B)
              (H : h · f = ZeroArrow abgr_Zero C B) (c : (C : abgr)) : abgr_Kernel_subabgr f.
   Proof.
     use tpair.
@@ -713,7 +713,7 @@ Section abgr_kernels_and_cokernels.
     - exact (abgr_KernelArrowIn_map_property h f H c).
   Defined.
 
-  Lemma abgr_KernelArrowIn_ismonoidfun {A B C : abgr_Precategory} (h : C --> A)
+  Lemma abgr_KernelArrowIn_ismonoidfun {A B C : abgr_category} (h : C --> A)
         (f : A --> B) (H : h · f = ZeroArrow abgr_Zero C B) :
     @ismonoidfun (C : abgr) (@abgr_Kernel_subabgr A B f) (@abgr_KernelArrowIn_map A B C h f H).
   Proof.
@@ -726,9 +726,9 @@ Section abgr_kernels_and_cokernels.
       + use proofirrelevance. use propproperty.
   Qed.
 
-  Definition abgr_KernelArrowIn {A B C : abgr_Precategory} (h : C --> A) (f : A --> B)
+  Definition abgr_KernelArrowIn {A B C : abgr_category} (h : C --> A) (f : A --> B)
              (H : h · f = ZeroArrow abgr_Zero C B) :
-    abgr_Precategory⟦C, carrierofasubabgr (abgr_Kernel_subabgr f)⟧.
+    abgr_category⟦C, carrierofasubabgr (abgr_Kernel_subabgr f)⟧.
   Proof.
     use monoidfunconstr.
     - exact (abgr_KernelArrowIn_map h f H).
@@ -738,8 +738,8 @@ Section abgr_kernels_and_cokernels.
   (** *** Kernels *)
 
   Definition abgr_Kernel_isKernel_KernelArrrow {A B C : abgr} (f : abgr_category ⟦A, B⟧)
-             (h : abgr_Precategory ⟦C, A⟧) (H' : h · f = ZeroArrow abgr_Zero C B) :
-    ∑ ψ : abgr_Precategory ⟦C, carrierofasubabgr (abgr_Kernel_subabgr f)⟧,
+             (h : abgr_category ⟦C, A⟧) (H' : h · f = ZeroArrow abgr_Zero C B) :
+    ∑ ψ : abgr_category ⟦C, carrierofasubabgr (abgr_Kernel_subabgr f)⟧,
           ψ · abgr_Kernel_monoidfun f = h.
   Proof.
     use tpair.
@@ -749,7 +749,7 @@ Section abgr_kernels_and_cokernels.
 
   Definition abgr_Kernel_isKernel_uniqueness {A B C : abgr} (f : abgr_category ⟦A, B⟧)
              (h : abgr_category ⟦C, A⟧) (H' : h · f = ZeroArrow abgr_Zero C B)
-             (t : ∑ (t1 : abgr_Precategory ⟦C, carrierofasubabgr (abgr_Kernel_subabgr f)⟧),
+             (t : ∑ (t1 : abgr_category ⟦C, carrierofasubabgr (abgr_Kernel_subabgr f)⟧),
                   t1 · abgr_Kernel_monoidfun f = h) :
     t = abgr_Kernel_isKernel_KernelArrrow f h H'.
   Proof.
@@ -1004,7 +1004,7 @@ Section abgr_kernels_and_cokernels.
       + intros t. exact (abgr_isCokernel_uniquenss f h H t).
   Defined.
 
-  Definition abgr_Cokernel {A B : abgr} (f : abgr_Precategory⟦A, B⟧) : Cokernel abgr_Zero f :=
+  Definition abgr_Cokernel {A B : abgr} (f : abgr_category⟦A, B⟧) : Cokernel abgr_Zero f :=
     mk_Cokernel abgr_Zero f (abgr_CokernelArrow f) (abgr_Cokernel_eq f) (abgr_isCokernel f).
 
   Corollary abgr_Cokernels : Cokernels abgr_Zero.
@@ -1034,7 +1034,7 @@ Section abgr_monics_and_epis.
     exact (hfiberpair (pr1 f) t p).
   Qed.
 
-  Definition abgr_epi_issurjective {A B : abgr} (f : abgr_Precategory⟦A, B⟧) (isE : isEpi f) :
+  Definition abgr_epi_issurjective {A B : abgr} (f : abgr_category⟦A, B⟧) (isE : isEpi f) :
     issurjective (pr1 f).
   Proof.
     intros x. use abgr_epi_hfiber_inhabited.
@@ -1125,13 +1125,13 @@ Section abgr_monics_and_epis.
       + use setproperty.
   Qed.
 
-  Definition abgr_monic_isInjective {A B : abgr} (f : abgr_Precategory⟦A, B⟧) (isM : isMonic f) :
+  Definition abgr_monic_isInjective {A B : abgr} (f : abgr_category⟦A, B⟧) (isM : isMonic f) :
     isInjective (pr1 f).
   Proof.
     exact (isweqonpathsincl (pr1 f) (abgr_monic_isincl f isM)).
   Qed.
 
-  Lemma abgr_monic_paths {A B : abgr} (f : abgr_Precategory⟦A, B⟧) (isM : isMonic f) (a1 a2 : A) :
+  Lemma abgr_monic_paths {A B : abgr} (f : abgr_category⟦A, B⟧) (isM : isMonic f) (a1 a2 : A) :
     pr1 f a1 = pr1 f a2 -> a1 = a2.
   Proof.
     exact (invweq (weqpair _ (abgr_monic_isInjective f isM a1 a2))).
@@ -1156,7 +1156,7 @@ Section abgr_monic_kernels_epi_cokernels.
   (** ** Monics are kernels of their cokernels *)
 
   Definition abgr_monic_kernel_in_hfiber_iscontr {A B C : abgr} (f : abgr_category⟦A, B⟧)
-             (isM : isMonic f) (h : abgr_Precategory⟦C, B⟧)
+             (isM : isMonic f) (h : abgr_category⟦C, B⟧)
              (H : h · CokernelArrow (abgr_Cokernel f) =
                   ZeroArrow abgr_Zero C (abgr_Cokernel f)) (c : C) :
     iscontr (hfiber (pr1 f) (pr1 h c)).
@@ -1189,7 +1189,7 @@ Section abgr_monic_kernels_epi_cokernels.
   Qed.
 
   Definition abgr_monic_kernel_in_hfiber_mult {A B : abgr} (f : abgr_category⟦A, B⟧)
-             (w : abgr) (x x' : w) (h : abgr_Precategory⟦w, B⟧) :
+             (w : abgr) (x x' : w) (h : abgr_category⟦w, B⟧) :
     hfiber (pr1 f) (pr1 h x) -> hfiber (pr1 f) (pr1 h x')
     -> hfiber (pr1 f) (pr1 h (x * x')%multmonoid).
   Proof.
@@ -1199,7 +1199,7 @@ Section abgr_monic_kernels_epi_cokernels.
   Defined.
 
   Lemma abgr_monic_kernel_in_hfiber_unel_eq {A B C : abgr} (f : abgr_category⟦A, B⟧)
-        (h : abgr_Precategory⟦C, B⟧) : pr1 f 1%multmonoid = pr1 h 1%multmonoid.
+        (h : abgr_category⟦C, B⟧) : pr1 f 1%multmonoid = pr1 h 1%multmonoid.
   Proof.
     rewrite (pr2 (pr2 h)). use (pr2 (pr2 f)).
   Qed.
@@ -1274,7 +1274,7 @@ Section abgr_monic_kernels_epi_cokernels.
   Definition abgr_monic_Kernel_isKernel_pair {A B C : abgr} (f : abgr_category⟦A, B⟧)
              (isM : isMonic f) (h : abgr_category⟦C, B⟧)
              (H : h · CokernelArrow (abgr_Cokernel f) = ZeroArrow abgr_Zero C (abgr_Cokernel f)) :
-    ∑ ψ : abgr_Precategory ⟦C, A⟧, ψ · f = h.
+    ∑ ψ : abgr_category ⟦C, A⟧, ψ · f = h.
   Proof.
     use tpair.
     - exact (abgr_monic_kernel_in_monoidfun f isM C h H).
@@ -1284,7 +1284,7 @@ Section abgr_monic_kernels_epi_cokernels.
   Definition abgr_monic_Kernel_isKernel_uniqueness {A B C : abgr} (f : abgr_category⟦A, B⟧)
              (isM : isMonic f) (h : abgr_category⟦C, B⟧)
              (H : h · CokernelArrow (abgr_Cokernel f) = ZeroArrow abgr_Zero C (abgr_Cokernel f))
-             (t : ∑ ψ : abgr_Precategory ⟦C, A⟧, ψ · f = h) :
+             (t : ∑ ψ : abgr_category ⟦C, A⟧, ψ · f = h) :
     t = abgr_monic_Kernel_isKernel_pair f isM h H.
   Proof.
     use total2_paths_f.
@@ -1330,8 +1330,8 @@ Section abgr_monic_kernels_epi_cokernels.
     - use hinhpr. exact H.
   Defined.
 
-  Lemma abgr_epi_cokernel_out_data_eq {A B C : abgr} (f : abgr_Precategory⟦A, B⟧)
-        (isE : isEpi f) (h : abgr_Precategory⟦A, C⟧)
+  Lemma abgr_epi_cokernel_out_data_eq {A B C : abgr} (f : abgr_category⟦A, B⟧)
+        (isE : isEpi f) (h : abgr_category⟦A, C⟧)
         (H : KernelArrow (abgr_Kernel f) · h = ZeroArrow abgr_Zero (abgr_Kernel f) C) :
     ∏ x : abgr_kernel_hsubtype f, pr1 h (pr1carrier (abgr_kernel_hsubtype f) x) = 1%multmonoid.
   Proof.
@@ -1369,8 +1369,8 @@ Section abgr_monic_kernels_epi_cokernels.
     set (tmp4 := tmp2 tmp3). cbn in tmp4. exact tmp4.
   Qed.
 
-  Lemma abgr_epi_CokernelOut_iscontr {A B C : abgr} (f : abgr_Precategory⟦A, B⟧)
-        (isE : isEpi f) (h : abgr_Precategory⟦A, C⟧)
+  Lemma abgr_epi_CokernelOut_iscontr {A B C : abgr} (f : abgr_category⟦A, B⟧)
+        (isE : isEpi f) (h : abgr_category⟦A, C⟧)
         (H : KernelArrow (abgr_Kernel f) · h = ZeroArrow abgr_Zero _ _) (b : B) :
     iscontr (∑ x : C, ∏ (hfib : hfiber (pr1 f) b), pr1 h (pr1 hfib) = x).
   Proof.
@@ -1400,7 +1400,7 @@ Section abgr_monic_kernels_epi_cokernels.
   Qed.
 
   Definition abgr_epi_cokernel_out_data_mult {A B C : abgr} (b1 b2 : B)
-             (f : abgr_Precategory⟦A, B⟧) (isE : isEpi f) (h : abgr_Precategory⟦A, C⟧)
+             (f : abgr_category⟦A, B⟧) (isE : isEpi f) (h : abgr_category⟦A, C⟧)
              (H : KernelArrow (abgr_Kernel f) · h = ZeroArrow abgr_Zero _ _) :
     (∑ x : C, ∏ (hfib : hfiber (pr1 f) b1), pr1 h (pr1 hfib) = x) ->
     (∑ x : C, ∏ (hfib : hfiber (pr1 f) b2), pr1 h (pr1 hfib) = x) ->
@@ -1428,8 +1428,8 @@ Section abgr_monic_kernels_epi_cokernels.
     ( ∑ x : C, ∏ (hfib : hfiber (pr1 f) 1%multmonoid),  pr1 h (pr1 hfib) = x) :=
     tpair _ 1%multmonoid (abgr_epi_cokernel_out_data_unel_eq f isE h H).
 
-  Lemma abgr_epi_cokernel_out_ismonoidfun {A B C : abgr} (f : abgr_Precategory⟦A, B⟧)
-        (isE : isEpi f) (h : abgr_Precategory⟦A, C⟧)
+  Lemma abgr_epi_cokernel_out_ismonoidfun {A B C : abgr} (f : abgr_category⟦A, B⟧)
+        (isE : isEpi f) (h : abgr_category⟦A, C⟧)
         (H : KernelArrow (abgr_Kernel f) · h = ZeroArrow abgr_Zero _ _) :
     ismonoidfun (fun b : B => (pr1 (iscontrpr1 (abgr_epi_CokernelOut_iscontr f isE h H b)))).
   Proof.
@@ -1546,7 +1546,7 @@ Section abgr_abelian.
         exact (KernelisKernel abgr_Zero (abgr_monic_kernel M (MonicisMonic abgr_category M))).
       + use mk_EpisAreCokernels.
         intros x y E.
-        exact (CokernelisCokernel abgr_Zero (abgr_epi_cokernel E (EpiisEpi abgr_Precategory E))).
+        exact (CokernelisCokernel abgr_Zero (abgr_epi_cokernel E (EpiisEpi abgr_category E))).
   Defined.
 
 End abgr_abelian.

--- a/UniMath/CategoryTheory/category_hset.v
+++ b/UniMath/CategoryTheory/category_hset.v
@@ -13,7 +13,7 @@ Extended by: Anders Mörtberg (October 2015)
 
 Contents :
 
-            Precategory HSET of hSets
+            category HSET of hSets
 
 	    HSET is a univalent_category
 
@@ -33,7 +33,7 @@ Require Import UniMath.CategoryTheory.functor_categories.
 
 Local Open Scope cat.
 
-(** * Precategory of hSets *)
+(** * category of hSets *)
 Section HSET_precategory.
 
 Definition hset_fun_space (A B : hSet) : hSet :=
@@ -67,12 +67,12 @@ Qed.
   Canonical Structure hset_precategory. :-)
  *)
 
-Definition hset_Precategory : Precategory := (HSET ,, has_homsets_HSET).
+Definition hset_category : category := (HSET ,, has_homsets_HSET).
 
 End HSET_precategory.
 
 Notation "'HSET'" := hset_precategory : cat.
-Notation "'SET'" := hset_Precategory : cat.
+Notation "'SET'" := hset_category : cat.
 
 (** * The precategory of hSets is a univalent_category. *)
 

--- a/UniMath/CategoryTheory/elems_slice_equiv.v
+++ b/UniMath/CategoryTheory/elems_slice_equiv.v
@@ -23,7 +23,7 @@ Section elems_slice_equiv.
 
   Local Open Scope cat.
 
-  Local Definition pshf (C : precategory) : Precategory := [C^op, SET].
+  Local Definition pshf (C : precategory) : category := [C^op, SET].
   Local Notation "C / X" := (slice_precat C X (pr2 C)).
   Local Definition ap_pshf {X : precategory} := fun (P : pshf X) (x : X) => pr1hSet ((pr1 P) x).
   Local Notation "##" := ap_pshf.

--- a/UniMath/CategoryTheory/equivalences.v
+++ b/UniMath/CategoryTheory/equivalences.v
@@ -172,7 +172,7 @@ Defined.
 
 Section adjointification.
 
-Context {C D : Precategory} (E : equivalence_of_precats C D).
+Context {C D : category} (E : equivalence_of_precats C D).
 Let F : functor C D := left_functor E.
 Let G : functor D C := right_functor E.
 

--- a/UniMath/CategoryTheory/functor_categories.v
+++ b/UniMath/CategoryTheory/functor_categories.v
@@ -1301,7 +1301,7 @@ Proof.
 Qed.
 
 
-Definition functor_Precategory (C : precategory) (D : Precategory) : Precategory.
+Definition functor_category (C : precategory) (D : category) : category.
 Proof.
   exists (functor_precategory C D (homset_property D)).
   apply functor_category_has_homsets.
@@ -1466,7 +1466,7 @@ End functors_on_iso_with_inv.
 
 Notation "[ C , D , hs ]" := (functor_precategory C D hs) : cat.
 
-Notation "[ C , D ]" := (functor_Precategory C D) : cat.
+Notation "[ C , D ]" := (functor_category C D) : cat.
 
 Notation "F ⟹ G" := (nat_trans F G) (at level 39) : cat.
 (* to input: type "\==>" with Agda input method *)

--- a/UniMath/CategoryTheory/limits/BinDirectSums.v
+++ b/UniMath/CategoryTheory/limits/BinDirectSums.v
@@ -569,13 +569,13 @@ Section bindirectsums_in_quot.
   Hypothesis PAS : PreAdditiveSubabgrs A.
   Hypothesis PAC : PreAdditiveComps A PAS.
 
-  Lemma QuotPrecategory_isBinCoproductCocone (x y : A) :
-    isBinCoproductCocone (QuotPrecategory_PreAdditive A PAS PAC) x y (BD x y)
+  Lemma Quotcategory_isBinCoproductCocone (x y : A) :
+    isBinCoproductCocone (Quotcategory_PreAdditive A PAS PAC) x y (BD x y)
                          (to_quot_mor A PAS (to_In1 A (BD x y)))
                          (to_quot_mor A PAS (to_In2 A (BD x y))).
   Proof.
     use mk_isBinCoproductCocone.
-    - apply has_homsets_QuotPrecategory.
+    - apply has_homsets_Quotcategory.
     - intros c f g.
       set (f'' := @issurjsetquotpr (@to_abgrop A x c) (binopeqrel_subgr_eqrel (PAS x c)) f).
       use (squash_to_prop f''). apply isapropiscontr. intros f'. clear f''.
@@ -585,18 +585,18 @@ Section bindirectsums_in_quot.
       use unique_exists.
       + exact (to_quot_mor A PAS (FromBinDirectSum A (BD x y) f1 g1)).
       + cbn beta. split.
-        * use (pathscomp0 (QuotPrecategory_comp_linear A PAS PAC _ _)).
+        * use (pathscomp0 (Quotcategory_comp_linear A PAS PAC _ _)).
           rewrite BinDirectSumIn1Commutes. exact f2.
-        * use (pathscomp0 (QuotPrecategory_comp_linear A PAS PAC _ _)).
+        * use (pathscomp0 (Quotcategory_comp_linear A PAS PAC _ _)).
           rewrite BinDirectSumIn2Commutes. exact g2.
-      + intros y0. apply isapropdirprod; apply has_homsets_QuotPrecategory.
+      + intros y0. apply isapropdirprod; apply has_homsets_Quotcategory.
       + intros y0 T. cbn beta in T. induction T as [T1 T2].
         * set (y'' := @issurjsetquotpr (@to_abgrop A (BD x y) c)
                                        (binopeqrel_subgr_eqrel (PAS (BD x y) c)) y0).
-          use (squash_to_prop y''). apply has_homsets_QuotPrecategory. intros y'. clear y''.
+          use (squash_to_prop y''). apply has_homsets_Quotcategory. intros y'. clear y''.
           induction y' as [y1 y2]. rewrite <- y2. rewrite <- y2 in T1. rewrite <- y2 in T2.
           cbn in y1.
-          rewrite <- (@id_left (QuotPrecategory_PreAdditive A PAS PAC) _ _
+          rewrite <- (@id_left (Quotcategory_PreAdditive A PAS PAC) _ _
                               (setquotpr (binopeqrel_subgr_eqrel (PAS (BD x y) c)) y1)).
           rewrite <- (@id_left A _ _ (FromBinDirectSum A (BD x y) f1 g1)).
           rewrite <- (to_BinOpId A (BD x y)). rewrite to_postmor_linear'.
@@ -606,18 +606,18 @@ Section bindirectsums_in_quot.
           rewrite <- f2 in T1. rewrite <- g2 in T2. unfold to_quot_mor.
           set (tmp := @setquotpr_linear A PAS PAC (BD x y) c). unfold to_quot_mor in tmp.
           rewrite tmp. clear tmp.
-          set (tmp := @QuotPrecategory_comp_linear A PAS PAC (BD x y) x c).
+          set (tmp := @Quotcategory_comp_linear A PAS PAC (BD x y) x c).
           unfold to_quot_mor in tmp. rewrite <- tmp. clear tmp.
           rewrite <- T1.
-          set (tmp := @QuotPrecategory_comp_linear A PAS PAC (BD x y) y c).
+          set (tmp := @Quotcategory_comp_linear A PAS PAC (BD x y) y c).
           unfold to_quot_mor in tmp. rewrite <- tmp. clear tmp.
           rewrite <- T2. unfold to_quot_mor. rewrite comp_eq. rewrite comp_eq.
           rewrite assoc. rewrite assoc.
           rewrite <- to_postmor_linear'.
           repeat rewrite <- comp_eq.
-          set (tmp := @QuotPrecategory_comp_linear A PAS PAC (BD x y) x (BD x y)).
+          set (tmp := @Quotcategory_comp_linear A PAS PAC (BD x y) x (BD x y)).
           unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
-          set (tmp := @QuotPrecategory_comp_linear A PAS PAC (BD x y) y (BD x y)).
+          set (tmp := @Quotcategory_comp_linear A PAS PAC (BD x y) y (BD x y)).
           unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
           set (tmp := @setquotpr_linear A PAS PAC (BD x y) (BD x y)). unfold to_quot_mor in tmp.
           rewrite <- tmp. clear tmp.
@@ -627,13 +627,13 @@ Section bindirectsums_in_quot.
           apply idpath.
   Qed.
 
-  Lemma QuotPrecategory_isBinProductCone (x y : A) :
-    isBinProductCone (QuotPrecategory_PreAdditive A PAS PAC) x y (BD x y)
+  Lemma Quotcategory_isBinProductCone (x y : A) :
+    isBinProductCone (Quotcategory_PreAdditive A PAS PAC) x y (BD x y)
                      (to_quot_mor A PAS (to_Pr1 A (BD x y)))
                      (to_quot_mor A PAS (to_Pr2 A (BD x y))).
   Proof.
     use mk_isBinProductCone.
-    - apply has_homsets_QuotPrecategory.
+    - apply has_homsets_Quotcategory.
     - intros c f g.
       set (f'' := @issurjsetquotpr (@to_abgrop A c x) (binopeqrel_subgr_eqrel (PAS c x)) f).
       use (squash_to_prop f''). apply isapropiscontr. intros f'. clear f''.
@@ -643,18 +643,18 @@ Section bindirectsums_in_quot.
       use unique_exists.
       + exact (to_quot_mor A PAS (ToBinDirectSum A (BD x y) f1 g1)).
       + cbn beta. split.
-        * use (pathscomp0 (QuotPrecategory_comp_linear A PAS PAC _ _)).
+        * use (pathscomp0 (Quotcategory_comp_linear A PAS PAC _ _)).
           rewrite BinDirectSumPr1Commutes. exact f2.
-        * use (pathscomp0 (QuotPrecategory_comp_linear A PAS PAC _ _)).
+        * use (pathscomp0 (Quotcategory_comp_linear A PAS PAC _ _)).
           rewrite BinDirectSumPr2Commutes. exact g2.
-      + intros y0. apply isapropdirprod; apply has_homsets_QuotPrecategory.
+      + intros y0. apply isapropdirprod; apply has_homsets_Quotcategory.
       + intros y0 T. cbn beta in T. induction T as [T1 T2].
         * set (y'' := @issurjsetquotpr (@to_abgrop A c (BD x y))
                                        (binopeqrel_subgr_eqrel (PAS c (BD x y))) y0).
-          use (squash_to_prop y''). apply has_homsets_QuotPrecategory. intros y'. clear y''.
+          use (squash_to_prop y''). apply has_homsets_Quotcategory. intros y'. clear y''.
           induction y' as [y1 y2]. rewrite <- y2. rewrite <- y2 in T1. rewrite <- y2 in T2.
           cbn in y1.
-          rewrite <- (@id_right (QuotPrecategory_PreAdditive A PAS PAC) _ _
+          rewrite <- (@id_right (Quotcategory_PreAdditive A PAS PAC) _ _
                                (setquotpr (binopeqrel_subgr_eqrel (PAS c (BD x y))) y1)).
           rewrite <- (@id_right A _ _ (ToBinDirectSum A (BD x y) f1 g1)).
           rewrite <- (to_BinOpId A (BD x y)). rewrite to_premor_linear'.
@@ -664,18 +664,18 @@ Section bindirectsums_in_quot.
           rewrite <- f2 in T1. rewrite <- g2 in T2. unfold to_quot_mor.
           set (tmp := @setquotpr_linear A PAS PAC c (BD x y)). unfold to_quot_mor in tmp.
           rewrite tmp. clear tmp.
-          set (tmp := @QuotPrecategory_comp_linear A PAS PAC c x (BD x y)).
+          set (tmp := @Quotcategory_comp_linear A PAS PAC c x (BD x y)).
           unfold to_quot_mor in tmp. rewrite <- tmp. clear tmp.
           rewrite <- T1.
-          set (tmp := @QuotPrecategory_comp_linear A PAS PAC c y (BD x y)).
+          set (tmp := @Quotcategory_comp_linear A PAS PAC c y (BD x y)).
           unfold to_quot_mor in tmp. rewrite <- tmp. clear tmp.
           rewrite <- T2. unfold to_quot_mor. rewrite comp_eq. rewrite comp_eq.
           rewrite <- assoc. rewrite <- assoc.
           rewrite <- to_premor_linear'.
           repeat rewrite <- comp_eq.
-          set (tmp := @QuotPrecategory_comp_linear A PAS PAC (BD x y) x (BD x y)).
+          set (tmp := @Quotcategory_comp_linear A PAS PAC (BD x y) x (BD x y)).
           unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
-          set (tmp := @QuotPrecategory_comp_linear A PAS PAC (BD x y) y (BD x y)).
+          set (tmp := @Quotcategory_comp_linear A PAS PAC (BD x y) y (BD x y)).
           unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
           set (tmp := @setquotpr_linear A PAS PAC (BD x y) (BD x y)). unfold to_quot_mor in tmp.
           rewrite <- tmp. clear tmp.
@@ -685,54 +685,54 @@ Section bindirectsums_in_quot.
           apply idpath.
   Qed.
 
-  Opaque QuotPrecategory_PreAdditive. (* This speeds up the following proof significantly. *)
-  Lemma QuotPrecategory_isBinDirectSumCone (x y : A) :
+  Opaque Quotcategory_PreAdditive. (* This speeds up the following proof significantly. *)
+  Lemma Quotcategory_isBinDirectSumCone (x y : A) :
     isBinDirectSumCone
-      (QuotPrecategory_PreAdditive A PAS PAC) x y (BD x y)
+      (Quotcategory_PreAdditive A PAS PAC) x y (BD x y)
       (to_quot_mor A PAS (to_In1 A (BD x y))) (to_quot_mor A PAS (to_In2 A (BD x y)))
       (to_quot_mor A PAS (to_Pr1 A (BD x y))) (to_quot_mor A PAS (to_Pr2 A (BD x y))).
   Proof.
     use mk_isBinDirectSumCone.
-    - exact (QuotPrecategory_isBinCoproductCocone x y).
-    - exact (QuotPrecategory_isBinProductCone x y).
+    - exact (Quotcategory_isBinCoproductCocone x y).
+    - exact (Quotcategory_isBinProductCone x y).
     - unfold to_quot_mor.
       rewrite <- comp_eq.
-      set (tmp := @QuotPrecategory_comp_linear A PAS PAC x (BD x y) x).
+      set (tmp := @Quotcategory_comp_linear A PAS PAC x (BD x y) x).
       unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
       rewrite (to_IdIn1 A (BD x y)).
       apply idpath.
     - unfold to_quot_mor.
       rewrite <- comp_eq.
-      set (tmp := @QuotPrecategory_comp_linear A PAS PAC y (BD x y) y).
+      set (tmp := @Quotcategory_comp_linear A PAS PAC y (BD x y) y).
       unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
       rewrite (to_IdIn2 A (BD x y)).
       apply idpath.
     - unfold to_quot_mor.
       rewrite <- comp_eq.
-      set (tmp := @QuotPrecategory_comp_linear A PAS PAC x (BD x y) y).
+      set (tmp := @Quotcategory_comp_linear A PAS PAC x (BD x y) y).
       unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
       rewrite (to_Unel1 A (BD x y)).
       apply idpath.
     - unfold to_quot_mor.
       rewrite <- comp_eq.
-      set (tmp := @QuotPrecategory_comp_linear A PAS PAC y (BD x y) x).
+      set (tmp := @Quotcategory_comp_linear A PAS PAC y (BD x y) x).
       unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
       rewrite (to_Unel2 A (BD x y)).
       apply idpath.
     - unfold to_quot_mor.
       repeat rewrite <- comp_eq.
-      set (tmp := @QuotPrecategory_comp_linear A PAS PAC (BD x y) x (BD x y)).
+      set (tmp := @Quotcategory_comp_linear A PAS PAC (BD x y) x (BD x y)).
       unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
-      set (tmp := @QuotPrecategory_comp_linear A PAS PAC (BD x y) y (BD x y)).
+      set (tmp := @Quotcategory_comp_linear A PAS PAC (BD x y) y (BD x y)).
       unfold to_quot_mor in tmp. rewrite tmp. clear tmp.
       set (tmp := @setquotpr_linear A PAS PAC (BD x y) (BD x y)). unfold to_quot_mor in tmp.
       rewrite <- tmp. clear tmp.
       rewrite (to_BinOpId A (BD x y)).
       apply idpath.
   Qed.
-  Transparent QuotPrecategory_PreAdditive. (* Transparent again *)
+  Transparent Quotcategory_PreAdditive. (* Transparent again *)
 
-  Definition QuotPrecategory_BinDirectSums : BinDirectSums (QuotPrecategory_PreAdditive A PAS PAC).
+  Definition Quotcategory_BinDirectSums : BinDirectSums (Quotcategory_PreAdditive A PAS PAC).
   Proof.
     intros x y.
     use mk_BinDirectSumCone.
@@ -741,7 +741,7 @@ Section bindirectsums_in_quot.
     - exact (to_quot_mor A PAS (to_In2 A (BD x y))).
     - exact (to_quot_mor A PAS (to_Pr1 A (BD x y))).
     - exact (to_quot_mor A PAS (to_Pr2 A (BD x y))).
-    - exact (QuotPrecategory_isBinDirectSumCone x y).
+    - exact (Quotcategory_isBinDirectSumCone x y).
   Defined.
 
 End bindirectsums_in_quot.

--- a/UniMath/CategoryTheory/limits/graphs/eqdiag.v
+++ b/UniMath/CategoryTheory/limits/graphs/eqdiag.v
@@ -97,12 +97,12 @@ Proof.
   now induction ex.
 Qed.
 
-Definition eq_diag  {C : Precategory} {g : graph} (d d' : diagram g C) :=
+Definition eq_diag  {C : category} {g : graph} (d d' : diagram g C) :=
   ∑ (eq_v : ∏ v: vertex g, dob d v = dob d' v), ∏ (v v':vertex g) (f:edge v v'),
   transportf (fun obj => C⟦obj, dob d v'⟧)  (eq_v v) (dmor d f) =
   transportb (fun obj => C⟦_, obj⟧) (eq_v v') (dmor d' f).
 
-Lemma eq_is_eq_diag {C : Precategory} {g : graph} (d d' : diagram g C)  :
+Lemma eq_is_eq_diag {C : category} {g : graph} (d d' : diagram g C)  :
   d = d' -> eq_diag d d'.
 Proof.
   intro e.
@@ -111,7 +111,7 @@ Proof.
   exact (fun x y z => idpath _).
 Qed.
 
-Lemma eq_diag_is_eq {C : Precategory} {g : graph} (d d' : diagram g C) :
+Lemma eq_diag_is_eq {C : category} {g : graph} (d d' : diagram g C) :
   eq_diag d d' -> d = d'.
 Proof.
   intros [eqv autreq].
@@ -156,7 +156,7 @@ Qed.
 (* We don't want to use the equivalence with bare identity to show the
 apply pathsinv0 because we want computation (Defined)
  *)
-Lemma sym_eq_diag  {C : Precategory} {g : graph} (d d' : diagram g C) :
+Lemma sym_eq_diag  {C : category} {g : graph} (d d' : diagram g C) :
   eq_diag d d' -> eq_diag d' d.
 Proof.
   intros eq_d.
@@ -190,7 +190,7 @@ Proof.
 Defined.
 
 Lemma eq_diag_mkcocone  :
-  ∏ {C : Precategory} {g : graph} {d : diagram g C}
+  ∏ {C : category} {g : graph} {d : diagram g C}
     (d' : diagram g C)
     (heq_d: eq_diag d d')
     {c : C} (cc:cocone d c),
@@ -223,7 +223,7 @@ Defined.
 
 (* The dual proof *)
 Lemma eq_diag_mkcone  :
-  ∏ {C : Precategory} {g : graph} {d : diagram g C}
+  ∏ {C : category} {g : graph} {d : diagram g C}
     (d' : diagram g C)
     (heq_d: eq_diag d d')
     {c : C} (cc:cone d c),
@@ -258,7 +258,7 @@ Defined.
 
 
 Lemma eq_diag_islimcone:
-  ∏ {C : Precategory} {g : graph} {d : diagram g C}
+  ∏ {C : category} {g : graph} {d : diagram g C}
     (d' : diagram g C)
     (eq_d : eq_diag d d')
     {c : C} {cc:cone d c}
@@ -310,7 +310,7 @@ This proof could be deduced from the previous if there was a lemma
 stating that colimits are limits in the dual category.
  *)
 Lemma eq_diag_iscolimcocone:
-  ∏ {C : Precategory} {g : graph} {d : diagram g C}
+  ∏ {C : category} {g : graph} {d : diagram g C}
     (d' : diagram g C)
     (eq_d : eq_diag d d')
     {c : C} {cc:cocone d c}
@@ -362,7 +362,7 @@ Qed.
 
 
 Definition eq_diag_liftcolimcocone
-           {C : Precategory} {g : graph} {d : diagram g C}
+           {C : category} {g : graph} {d : diagram g C}
            (d' : diagram g C)
            (eq_d : eq_diag d d')
            (cc:ColimCocone d ) : ColimCocone d'
@@ -370,7 +370,7 @@ Definition eq_diag_liftcolimcocone
                                                  (isColimCocone_ColimCocone cc)).
 
 Definition eq_diag_liftlimcone
-           {C : Precategory} {g : graph} {d : diagram g C}
+           {C : category} {g : graph} {d : diagram g C}
            (d' : diagram g C)
            (eq_d : eq_diag d d')
            (cc:LimCone d ) : LimCone d'

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -10,7 +10,7 @@ Direct implementation of pullbacks together with:
   ([Pullbacks_from_Equalizers_BinProducts])
 - A fully faithful functor reflects limits ([isPullback_preimage_square])
 - A fully faithfull and essentially surjects functor preserves pullbacks ([isPullback_image_square])
-- Pullbacks in functor categories ([FunctorPrecategoryPullbacks])
+- Pullbacks in functor categories ([FunctorcategoryPullbacks])
 - Construction of binary products from pullbacks ([BinProductsFromPullbacks])
 
 *)
@@ -1036,7 +1036,7 @@ Section pullbacks_functor_category.
   Hypothesis hs : has_homsets C.
   Hypothesis hpb : @Pullbacks C.
 
-  Local Lemma FunctorPrecategoryPullbacks_eq (F G H : functor D C) (α : nat_trans G F)
+  Local Lemma FunctorcategoryPullbacks_eq (F G H : functor D C) (α : nat_trans G F)
         (β : nat_trans H F) (a b : D) (f : D ⟦a, b⟧) :
     PullbackPr1 (hpb _ _ _ (α a) (β a)) · # G f · α b =
     PullbackPr2 (hpb _ _ _ (α a) (β a)) · # H f · β b.
@@ -1050,7 +1050,7 @@ Section pullbacks_functor_category.
     exact (PullbackSqrCommutes pba).
   Qed.
 
-  Local Lemma FunctorPrecategoryPullbacks_isfunctor (F G H : functor D C) (α : nat_trans G F)
+  Local Lemma FunctorcategoryPullbacks_isfunctor (F G H : functor D C) (α : nat_trans G F)
         (β : nat_trans H F) :
     is_functor
       (mk_functor_data
@@ -1061,7 +1061,7 @@ Section pullbacks_functor_category.
             (hpb (F a) (G a) (H a) (α a) (β a))
             (PullbackPr1 (hpb (F a) (G a) (H a) (α a) (β a)) · # G f)
             (PullbackPr2 (hpb (F a) (G a) (H a) (α a) (β a)) · # H f)
-            (FunctorPrecategoryPullbacks_eq F G H α β a b f))).
+            (FunctorcategoryPullbacks_eq F G H α β a b f))).
   Proof.
     split.
     intros x. apply pathsinv0. cbn.
@@ -1074,19 +1074,19 @@ Section pullbacks_functor_category.
     set (pz := hpb (F z) (G z) (H z) (α z) (β z)).
     set (pz1 := PullbackArrow_PullbackPr1 pz py (PullbackPr1 py · # G g)
                                           (PullbackPr2 py · # H g)
-                                          (FunctorPrecategoryPullbacks_eq
+                                          (FunctorcategoryPullbacks_eq
                                              F G H α β y z g)).
     set (pz2 := PullbackArrow_PullbackPr2 pz py (PullbackPr1 py · # G g)
                                           (PullbackPr2 py · # H g)
-                                          (FunctorPrecategoryPullbacks_eq
+                                          (FunctorcategoryPullbacks_eq
                                              F G H α β y z g)).
     set (py1 := PullbackArrow_PullbackPr1 py px (PullbackPr1 px · # G f)
                                           (PullbackPr2 px · # H f)
-                                          (FunctorPrecategoryPullbacks_eq
+                                          (FunctorcategoryPullbacks_eq
                                              F G H α β x y f)).
     set (py2 := PullbackArrow_PullbackPr2 py px (PullbackPr1 px · # G f)
                                           (PullbackPr2 px · # H f)
-                                          (FunctorPrecategoryPullbacks_eq
+                                          (FunctorcategoryPullbacks_eq
                                              F G H α β x y f)).
     apply pathsinv0. cbn. fold px. fold py. fold pz.
     use PullbackArrowUnique.
@@ -1101,7 +1101,7 @@ Section pullbacks_functor_category.
     apply py2.
   Qed.
 
-  Local Definition FunctorPrecategoryPullbacks_functor (F G H : functor D C) (α : nat_trans G F)
+  Local Definition FunctorcategoryPullbacks_functor (F G H : functor D C) (α : nat_trans G F)
         (β : nat_trans H F) : functor D C.
   Proof.
     use mk_functor.
@@ -1112,13 +1112,13 @@ Section pullbacks_functor_category.
         use (PullbackArrow (hpb _ _ _ (α b) (β b)) _
                            (PullbackPr1 (hpb _ _ _ (α a) (β a)) · (# G f))
                            (PullbackPr2 (hpb _ _ _ (α a) (β a)) · (# H f))
-                           (FunctorPrecategoryPullbacks_eq F G H α β a b f)).
-    - exact (FunctorPrecategoryPullbacks_isfunctor F G H α β).
+                           (FunctorcategoryPullbacks_eq F G H α β a b f)).
+    - exact (FunctorcategoryPullbacks_isfunctor F G H α β).
   Defined.
 
-  Local Lemma FunctorPrecategoryPullbacks_is_nat_trans1 (F G H : functor D C) (α : nat_trans G F)
+  Local Lemma FunctorcategoryPullbacks_is_nat_trans1 (F G H : functor D C) (α : nat_trans G F)
         (β : nat_trans H F) :
-    is_nat_trans (FunctorPrecategoryPullbacks_functor F G H α β) G
+    is_nat_trans (FunctorcategoryPullbacks_functor F G H α β) G
                  (λ x : D, PullbackPr1 (hpb (F x) (G x) (H x) (α x) (β x))).
   Proof.
     intros x x' f. cbn.
@@ -1126,21 +1126,21 @@ Section pullbacks_functor_category.
     set (px' := hpb (F x') (G x') (H x') (α x') (β x')).
     apply (PullbackArrow_PullbackPr1 px' px (PullbackPr1 px · # G f)
                                      (PullbackPr2 px · # H f)
-                                     (FunctorPrecategoryPullbacks_eq
+                                     (FunctorcategoryPullbacks_eq
                                         F G H α β x x' f)).
   Qed.
 
-  Local Definition FunctorPrecategoryPullbacks_nat_trans1 (F G H : functor D C) (α : nat_trans G F)
-        (β : nat_trans H F) : nat_trans (FunctorPrecategoryPullbacks_functor F G H α β) G.
+  Local Definition FunctorcategoryPullbacks_nat_trans1 (F G H : functor D C) (α : nat_trans G F)
+        (β : nat_trans H F) : nat_trans (FunctorcategoryPullbacks_functor F G H α β) G.
   Proof.
     use mk_nat_trans.
     - intros x. exact (PullbackPr1 (hpb (F x) (G x) (H x) (α x) (β x))).
-    - exact (FunctorPrecategoryPullbacks_is_nat_trans1 F G H α β).
+    - exact (FunctorcategoryPullbacks_is_nat_trans1 F G H α β).
   Defined.
 
-  Local Lemma FunctorPrecategoryPullbacks_is_nat_trans2 (F G H : functor D C) (α : nat_trans G F)
+  Local Lemma FunctorcategoryPullbacks_is_nat_trans2 (F G H : functor D C) (α : nat_trans G F)
         (β : nat_trans H F) :
-    is_nat_trans (FunctorPrecategoryPullbacks_functor F G H α β) H
+    is_nat_trans (FunctorcategoryPullbacks_functor F G H α β) H
                  (λ x : D, PullbackPr2 (hpb (F x) (G x) (H x) (α x) (β x))).
   Proof.
     intros x x' f. cbn.
@@ -1148,40 +1148,40 @@ Section pullbacks_functor_category.
     set (px' := hpb (F x') (G x') (H x') (α x') (β x')).
     apply (PullbackArrow_PullbackPr2 px' px (PullbackPr1 px · # G f)
                                      (PullbackPr2 px · # H f)
-                                     (FunctorPrecategoryPullbacks_eq
+                                     (FunctorcategoryPullbacks_eq
                                         F G H α β x x' f)).
   Qed.
 
 
-  Local Definition FunctorPrecategoryPullbacks_nat_trans2 (F G H : functor D C) (α : nat_trans G F)
-        (β : nat_trans H F) : nat_trans (FunctorPrecategoryPullbacks_functor F G H α β) H.
+  Local Definition FunctorcategoryPullbacks_nat_trans2 (F G H : functor D C) (α : nat_trans G F)
+        (β : nat_trans H F) : nat_trans (FunctorcategoryPullbacks_functor F G H α β) H.
   Proof.
     use mk_nat_trans.
     - intros x. exact (PullbackPr2 (hpb (F x) (G x) (H x) (α x) (β x))).
-    - exact (FunctorPrecategoryPullbacks_is_nat_trans2 F G H α β).
+    - exact (FunctorcategoryPullbacks_is_nat_trans2 F G H α β).
   Defined.
 
-  Local Lemma FunctorPrecategoryPullbacks_comm (F G H : functor D C) (α : nat_trans G F)
+  Local Lemma FunctorcategoryPullbacks_comm (F G H : functor D C) (α : nat_trans G F)
         (β : nat_trans H F) :
-    nat_trans_comp _ _ _ (FunctorPrecategoryPullbacks_nat_trans1 F G H α β) α =
-    nat_trans_comp _ _ _ (FunctorPrecategoryPullbacks_nat_trans2 F G H α β) β.
+    nat_trans_comp _ _ _ (FunctorcategoryPullbacks_nat_trans1 F G H α β) α =
+    nat_trans_comp _ _ _ (FunctorcategoryPullbacks_nat_trans2 F G H α β) β.
   Proof.
     use (nat_trans_eq hs). intros x.
     apply (PullbackSqrCommutes (hpb (F x) (G x) (H x) (α x) (β x))).
   Qed.
 
-  Definition FunctorPrecategoryPullbacks : @Pullbacks (functor_precategory D C hs).
+  Definition FunctorcategoryPullbacks : @Pullbacks (functor_precategory D C hs).
   Proof.
     intros F G H α β. cbn in F, G, H, α, β.
     use mk_Pullback.
     (* Pullback object *)
-    - exact (FunctorPrecategoryPullbacks_functor F G H α β).
+    - exact (FunctorcategoryPullbacks_functor F G H α β).
     (* Pr1 *)
-    - exact (FunctorPrecategoryPullbacks_nat_trans1 F G H α β).
+    - exact (FunctorcategoryPullbacks_nat_trans1 F G H α β).
     (* Pr2 *)
-    - exact (FunctorPrecategoryPullbacks_nat_trans2 F G H α β).
+    - exact (FunctorcategoryPullbacks_nat_trans2 F G H α β).
     (* Commutativity of the square *)
-    - exact (FunctorPrecategoryPullbacks_comm F G H α β).
+    - exact (FunctorcategoryPullbacks_comm F G H α β).
     (* isPullback *)
     - apply pb_if_pointwise_pb. intros x. cbn. apply isPullback_Pullback.
   Defined.

--- a/UniMath/CategoryTheory/limits/pushouts.v
+++ b/UniMath/CategoryTheory/limits/pushouts.v
@@ -527,7 +527,7 @@ is a pushout
 *)
 Section EpiPushoutId.
 
-  Context {C:Precategory} {A B:C} (f:C⟦A,B ⟧).
+  Context {C : category} {A B : C} (f : C⟦A,B ⟧).
 
   Lemma epi_to_pushout : isEpi f -> isPushout f f (identity _) (identity _) (idpath _).
   Proof.

--- a/UniMath/CategoryTheory/precategories.v
+++ b/UniMath/CategoryTheory/precategories.v
@@ -63,7 +63,7 @@ Definition precategory_morphisms { C : precategory_ob_mor } :
 
 Delimit Scope cat with cat.     (* for precategories *)
 
-Delimit Scope cat with Cat.     (* a slight enhancement for Precategories *)
+Delimit Scope cat with Cat.     (* a slight enhancement for categories *)
 
 Delimit Scope cat_deprecated with cat_deprecated.
 
@@ -180,17 +180,17 @@ Proof.
   apply isapropisaset.
 Qed.
 
-Definition Precategory := ∑ C:precategory, has_homsets C.
-Definition Precategory_pair C h : Precategory := C,,h.
-Definition Precategory_to_precategory : Precategory -> precategory := pr1.
-Coercion Precategory_to_precategory : Precategory >-> precategory.
-Definition homset_property (C : Precategory) : has_homsets C := pr2 C.
+Definition category := ∑ C:precategory, has_homsets C.
+Definition category_pair C h : category := C,,h.
+Definition category_to_precategory : category -> precategory := pr1.
+Coercion category_to_precategory : category >-> precategory.
+Definition homset_property (C : category) : has_homsets C := pr2 C.
 
 
 Definition precategory_pair (C:precategory_data) (i:is_precategory C)
   : precategory := C,,i.
 
-Definition makePrecategory
+Definition makecategory
     (obj : UU)
     (mor : obj -> obj -> UU)
     (homsets : ∏ a b, isaset (mor a b))
@@ -200,7 +200,7 @@ Definition makePrecategory
     (left  : ∏ i j (f:mor i j), compose _ _ _ f (identity j) = f)
     (associativity : ∏ a b c d (f:mor a b) (g:mor b c) (h:mor c d),
         compose _ _ _ f (compose _ _ _ g h) = compose _ _ _ (compose _ _ _ f g) h)
-  : Precategory
+  : category
   := (precategory_pair
            (precategory_data_pair
               (precategory_ob_mor_pair
@@ -893,7 +893,7 @@ Proof.
   exact H.
 Qed.
 
-Lemma z_iso_eq {C : Precategory} {a b : C} (i i' : z_iso a b) (e : z_iso_mor i = z_iso_mor i') :
+Lemma z_iso_eq {C : category} {a b : C} (i i' : z_iso a b) (e : z_iso_mor i = z_iso_mor i') :
   i = i'.
 Proof.
   use total2_paths_f.
@@ -901,7 +901,7 @@ Proof.
   - use proofirrelevance. apply isaprop_is_z_isomorphism. apply homset_property.
 Qed.
 
-Lemma z_iso_eq_inv {C : Precategory} {a b : C} (i i' : z_iso a b)
+Lemma z_iso_eq_inv {C : category} {a b : C} (i i' : z_iso a b)
       (e2 : z_iso_inv_mor i = z_iso_inv_mor i') : i = i'.
 Proof.
   use z_iso_eq.
@@ -1191,12 +1191,12 @@ Definition univalent_category : UU := total2 (fun C : precategory => is_univalen
 
 Definition mk_category (C : precategory) (H : is_univalent C) : univalent_category := tpair _ C H.
 
-Definition univalent_category_to_Precategory (C : univalent_category) : Precategory.
+Definition univalent_category_to_category (C : univalent_category) : category.
 Proof.
   exists (pr1 C).
   exact (pr2 (pr2 C)).
 Defined.
-Coercion univalent_category_to_Precategory : univalent_category >-> Precategory.
+Coercion univalent_category_to_category : univalent_category >-> category.
 
 Definition univalent_category_pair (C:precategory) (i:is_univalent C) : univalent_category := C,,i.
 

--- a/UniMath/HomologicalAlgebra/Complexes.v
+++ b/UniMath/HomologicalAlgebra/Complexes.v
@@ -1313,15 +1313,15 @@ Section complexes_additive.
     - intros x y. exact (MorphismOp A).
   Defined.
 
-  Definition ComplexPreCat_PrecategoryWithAbgrops : PrecategoryWithAbgrops.
+  Definition ComplexPreCat_categoryWithAbgrops : categoryWithAbgrops.
   Proof.
-    use mk_PrecategoryWithAbgrops.
+    use mk_categoryWithAbgrops.
     - exact ComplexPreCat_precategoryWithBinOps.
     - exact (has_homsets_ComplexPreCat A).
     - intros x y. exact (MorphismOp_isabgrop A x y).
   Defined.
 
-  Lemma ComplexPreCat_isPreAdditive : isPreAdditive ComplexPreCat_PrecategoryWithAbgrops.
+  Lemma ComplexPreCat_isPreAdditive : isPreAdditive ComplexPreCat_categoryWithAbgrops.
   Proof.
     split.
     - intros x y z f.
@@ -1347,7 +1347,7 @@ Section complexes_additive.
   Lemma ComplexPreCat_PreAdditive : PreAdditive.
   Proof.
     use mk_PreAdditive.
-    - exact ComplexPreCat_PrecategoryWithAbgrops.
+    - exact ComplexPreCat_categoryWithAbgrops.
     - exact ComplexPreCat_isPreAdditive.
   Defined.
 

--- a/UniMath/HomologicalAlgebra/KA.v
+++ b/UniMath/HomologicalAlgebra/KA.v
@@ -63,7 +63,7 @@ Opaque hz isdecrelhzeq hzplus hzminus hzone hzzero iscommrngops ZeroArrow ishinh
    (χ^i · g^{i-1}), respectively.
 
    These are the properties that are enough to form the quotient category of C(A) using
-   [QuotPrecategory_Additive]. We call the resulting category the naive homotopy category of A, and
+   [Quotcategory_Additive]. We call the resulting category the naive homotopy category of A, and
    denote it by K(A). The objects of K(A) are objects of C(A) and Mor_{K(A)}(X, Y) =
    Mor_{C(A)}(X, Y) / (the subgroup of null-homotopic morphisms, [ComplexHomotSubgrp]).
 
@@ -318,7 +318,7 @@ Section complexes_homotopies.
      morphisms from C1 to C2, by [ComplexHomotSubgrp]. We also know that composition of a morphism
      with a morphism coming from a homotopy, is a morphism which comes from a homotopy, by
      [ComplexHomotSubgrop_comp_left] and [ComplexHomotSubgrop_comp_right]. This is enough to
-     invoke our abstract construction QuotPrecategory_Additive, to construct the naive homotopy
+     invoke our abstract construction Quotcategory_Additive, to construct the naive homotopy
      category. *)
   Local Lemma ComplexHomot_Additive_Comp :
     PreAdditiveComps (ComplexPreCat_Additive A)
@@ -333,12 +333,12 @@ Section complexes_homotopies.
 
   (** Here we construct K(A). *)
   Definition ComplexHomot_Additive : Additive :=
-    QuotPrecategory_Additive
+    Quotcategory_Additive
       (ComplexPreCat_Additive A) ComplexHomotSubgrp ComplexHomot_Additive_Comp.
 
   Definition ComplexHomotFunctor :
     AdditiveFunctor (ComplexPreCat_Additive A) ComplexHomot_Additive :=
-    QuotPrecategoryAdditiveFunctor
+    QuotcategoryAdditiveFunctor
       (ComplexPreCat_Additive A) ComplexHomotSubgrp ComplexHomot_Additive_Comp.
   Arguments ComplexHomotFunctor : simpl never.
 

--- a/UniMath/HomologicalAlgebra/KAPreTriangulated.v
+++ b/UniMath/HomologicalAlgebra/KAPreTriangulated.v
@@ -104,7 +104,7 @@ Section KAPreTriangulated.
 
   Context {A : Additive}.
 
-  Local Opaque ComplexHomotFunctor ComplexHomotSubset QuotPrecategory identity
+  Local Opaque ComplexHomotFunctor ComplexHomotSubset Quotcategory identity
         MappingConePr1 MappingConeIn2 RotMorphism RotMorphismInv InvRotMorphism InvRotMorphismInv
         to_inv compose pathsinv0 pathscomp0 ishinh to_abgrop.
 

--- a/UniMath/HomologicalAlgebra/KATriangulated.v
+++ b/UniMath/HomologicalAlgebra/KATriangulated.v
@@ -62,7 +62,7 @@ Section KATriangulated.
 
   Context {A : Additive}.
 
-  Local Opaque ComplexHomotFunctor ComplexHomotSubset QuotPrecategory identity
+  Local Opaque ComplexHomotFunctor ComplexHomotSubset Quotcategory identity
         MappingConePr1 MappingConeIn2 RotMorphism RotMorphismInv InvRotMorphism InvRotMorphismInv
         to_inv compose to_abgrop pathsinv0 pathscomp0 ishinh.
 

--- a/UniMath/Ktheory/AbelianGroup.v
+++ b/UniMath/Ktheory/AbelianGroup.v
@@ -491,7 +491,7 @@ Module Category.
   Definition MorEquality G H (p q : Mor G H) : pr1 p = pr1 q -> p = q.
     intros. apply Monoid.funEquality. assumption. Qed.
 
-  Definition Precat : Precategory.
+  Definition Precat : category.
     unshelve refine (_,,_).
     { exists Data. split.
       { simpl. split.

--- a/UniMath/Ktheory/Bifunctor.v
+++ b/UniMath/Ktheory/Bifunctor.v
@@ -20,11 +20,11 @@ Set Automatic Introduction.
 
 (** bifunctor commutativity *)
 
-Definition comm_functor_data {I A B:Precategory} :
+Definition comm_functor_data {I A B : category} :
   [I, [A, B] ] -> A -> functor_data I B
   := λ D a, functor_data_constr I B (λ i, D ◾ i ◾ a) (λ i j e, D ▭ e ◽ a).
 
-Lemma isfunctor_comm_functor_data {I A B:Precategory} :
+Lemma isfunctor_comm_functor_data {I A B : category} :
   ∏ (D:[I,[A,B]]) (a:A), is_functor (comm_functor_data D a).
 Proof.
   split.
@@ -34,7 +34,7 @@ Proof.
     now rewrite functor_comp. }
 Qed.
 
-Definition comm_functor {I A B:Precategory} :
+Definition comm_functor {I A B : category} :
   [I, [A, B] ] -> A -> [I,B].
 Proof.
   intros D a.
@@ -42,7 +42,7 @@ Proof.
   exact (isfunctor_comm_functor_data D a).
 Defined.
 
-Definition comm_functor_data_2 (I A B:Precategory) : functor_data [I,[A,B]] [A,[I,B]].
+Definition comm_functor_data_2 (I A B:category) : functor_data [I,[A,B]] [A,[I,B]].
 Proof.
   unshelve refine (_,,_).
   { intros D.
@@ -71,7 +71,7 @@ Proof.
                 | intros i; simpl; apply nat_trans_ax]. } }
 Defined.
 
-Definition isfunctor_comm_functor_data_2 {I A B:Precategory} :
+Definition isfunctor_comm_functor_data_2 {I A B:category} :
   is_functor (comm_functor_data_2 I A B).
 Proof.
   split.
@@ -86,7 +86,7 @@ Proof.
     intros i; simpl. eqn_logic. }
 Qed.
 
-Definition bifunctor_comm (A B C:Precategory) : [A,[B,C]] ⟶ [B,[A,C]].
+Definition bifunctor_comm (A B C:category) : [A,[B,C]] ⟶ [B,[A,C]].
 Proof.
   exists (comm_functor_data_2 A B C).
   apply isfunctor_comm_functor_data_2.
@@ -98,7 +98,7 @@ Proof.
   exact ((transportf (λ k, transportf Y k y = y) (pr1 (i x x (idpath x) e))) (idpath y)).
 Defined.
 
-Lemma comm_comm_iso_id (A B C:Precategory) :
+Lemma comm_comm_iso_id (A B C:category) :
   nat_iso (bifunctor_comm B A C □ bifunctor_comm A B C) (functor_identity _).
 Proof.
   intros. unshelve refine (makeNatiso _ _).
@@ -121,7 +121,7 @@ Lemma transport_along_funextsec {X:UU} {Y:X->UU} {f g:∏ x, Y x}
       (e:f~g) (x:X) : transportf _ (funextsec _ _ _ e) (f x) = g x.
 Proof. now induction (funextsec _ _ _ e). Defined.
 
-Definition Functor_eq_map {A B: Precategory} (F G:[A,B]) :
+Definition Functor_eq_map {A B: category} (F G:[A,B]) :
   F = G ->
   ∑ (ob : ∏ a, F ◾ a = G ◾ a),
   ∏ a a' f, transportf (λ k, k --> G ◾ a')
@@ -138,16 +138,16 @@ Defined.
 
 Section Working.
 
-Lemma Functor_eq_map_isweq {A B: Precategory} {F G:[A,B]} : isweq (Functor_eq_map F G).
+Lemma Functor_eq_map_isweq {A B: category} {F G:[A,B]} : isweq (Functor_eq_map F G).
 Proof.
   (* should be provable using the ideas in isweqtoforallpaths *)
 Abort.
 
 Hypothesis Functor_eq_map_isweq :
-  ∏ (A B: Precategory) (F G:[A,B]), isweq (Functor_eq_map F G).
+  ∏ (A B: category) (F G:[A,B]), isweq (Functor_eq_map F G).
 Arguments Functor_eq_map_isweq {_ _ _ _} _.
 
-Lemma Functor_eq_weq {A B: Precategory} (F G:[A,B]) :
+Lemma Functor_eq_weq {A B: category} (F G:[A,B]) :
   F = G ≃
   ∑ (ob : ∏ a, F ◾ a = G ◾ a),
   ∏ a a' f, transportf (λ k, k --> G ◾ a')
@@ -159,7 +159,7 @@ Proof.
   exact (weqpair _ Functor_eq_map_isweq).
 Defined.
 
-Lemma Functor_eq {A B: Precategory} {F G:[A,B]}
+Lemma Functor_eq {A B: category} {F G:[A,B]}
       (ob : ∏ a, F ◾ a = G ◾ a)
       (mor : ∏ a a' f, transportf (λ k, k --> G ◾ a')
                                   (ob a)
@@ -173,7 +173,7 @@ Proof.
   exact mor.
 Defined.
 
-Lemma comm_comm_eq_id (A B C:Precategory) :
+Lemma comm_comm_eq_id (A B C:category) :
   bifunctor_comm B A C □ bifunctor_comm A B C = functor_identity _.
 Proof.
   intros. unshelve refine (Functor_eq _ _).
@@ -189,20 +189,20 @@ End Working.
 
 (** bifunctors related to representable functors  *)
 
-Definition θ_1 {B C:Precategory} (F : [B, C]) (X : [B, [C^op, SET]]) : hSet
+Definition θ_1 {B C:category} (F : [B, C]) (X : [B, [C^op, SET]]) : hSet
   := (∏ b, F ◾ b ⇒ X ◾ b) % set.
 
-Definition θ_2 {B C:Precategory} (F : [B, C]) (X : [B, [C^op, SET]])
+Definition θ_2 {B C:category} (F : [B, C]) (X : [B, [C^op, SET]])
            (x : θ_1 F X) : hSet
   := (∏ (b' b:B) (f:b'-->b), x b ⟲ F ▭ f = X ▭ f ⟳ x b' ) % set.
 
-Definition θ {B C:Precategory} (F : [B, C]) (X : [B, [C^op, SET]]) : hSet
+Definition θ {B C:category} (F : [B, C]) (X : [B, [C^op, SET]]) : hSet
   := ( ∑ x : θ_1 F X, θ_2 F X x ) % set.
 
 Local Notation "F ⟹ X" := (θ F X) (at level 39) : cat.
 (* to input: type "\==>" with Agda input method *)
 
-Definition θ_subset {B C:Precategory} {F : [B, C]} {X : [B, [C^op, SET]]}
+Definition θ_subset {B C:category} {F : [B, C]} {X : [B, [C^op, SET]]}
            (t u : F ⟹ X) :
   pr1 t = pr1 u -> t = u.
 Proof.
@@ -211,11 +211,11 @@ Proof.
   apply setproperty.
 Defined.
 
-Definition θ_map_1 {B C:Precategory} {F' F:[B, C]} {X : [B, [C^op, SET]]} :
+Definition θ_map_1 {B C:category} {F' F:[B, C]} {X : [B, [C^op, SET]]} :
   F' --> F -> F ⟹ X -> θ_1 F' X
   := λ p xe b, pr1 xe b ⟲ p ◽ b.
 
-Definition θ_map_2 {B C:Precategory} {F' F:[B, C]} {X : [B, [C^op, SET]]}
+Definition θ_map_2 {B C:category} {F' F:[B, C]} {X : [B, [C^op, SET]]}
   (p : F' --> F) (xe : F ⟹ X) : θ_2 F' X (θ_map_1 p xe).
 Proof.
   induction xe as [x e]. unfold θ_map_1; unfold θ_1 in x; unfold θ_2 in e.
@@ -228,17 +228,17 @@ Proof.
   reflexivity.
 Qed.
 
-Definition θ_map {B C:Precategory} {F' F:[B, C]} {X : [B, [C^op, SET]]} :
+Definition θ_map {B C:category} {F' F:[B, C]} {X : [B, [C^op, SET]]} :
   F' --> F -> F ⟹ X -> F' ⟹ X
   := λ p xe, θ_map_1 p xe ,, θ_map_2 p xe.
 
 Notation "xe ⟲⟲ p" := (θ_map p xe) (at level 50) : cat.
 
-Definition φ_map_1 {B C:Precategory} {F:[B, C]} {X' X: [B, [C^op, SET]]} :
+Definition φ_map_1 {B C:category} {F:[B, C]} {X' X: [B, [C^op, SET]]} :
   F ⟹ X -> X --> X' -> θ_1 F X'
   := λ x p b, p ◽ b ⟳ pr1 x b.
 
-Definition φ_map_2 {B C:Precategory} {F:[B, C]} {X' X: [B, [C^op, SET]]}
+Definition φ_map_2 {B C:category} {F:[B, C]} {X' X: [B, [C^op, SET]]}
   (x : F ⟹ X) (p : X --> X') : θ_2 F X' (φ_map_1 x p).
 Proof.
   induction x as [x e]. unfold φ_map_1; unfold θ_1 in x; unfold θ_2 in e; unfold θ_2.
@@ -249,11 +249,11 @@ Proof.
   exact (maponpaths (λ k, k ⟳ x b) (nattrans_naturality p f)).
 Qed.
 
-Definition φ_map {B C:Precategory} {F:[B, C]} {X' X: [B, [C^op, SET]]} :
+Definition φ_map {B C:category} {F:[B, C]} {X' X: [B, [C^op, SET]]} :
   F ⟹ X -> X --> X' -> F ⟹ X'
   := λ x p, φ_map_1 x p,, φ_map_2 x p.
 
-Definition bifunctor_assoc {B C:Precategory} : [B, [C^op,SET]] ⟶ [[B,C]^op,SET].
+Definition bifunctor_assoc {B C:category} : [B, [C^op,SET]] ⟶ [[B,C]^op,SET].
 Proof.
   unshelve refine (makeFunctor _ _ _ _).
   { intros X.

--- a/UniMath/Ktheory/DirectSum.v
+++ b/UniMath/Ktheory/DirectSum.v
@@ -14,21 +14,21 @@ Require Import
 Require UniMath.Ktheory.RawMatrix.
 Local Open Scope cat.
 
-Definition identity_matrix {C:Precategory} (h:hasZeroMaps C)
+Definition identity_matrix {C:category} (h:hasZeroMaps C)
            {I} (d:I -> ob C) (dec : isdeceq I) : ∏ i j, Hom C (d j) (d i).
 Proof. intros. induction (dec i j) as [ eq | ne ].
        { induction eq. apply identity. }
        { apply h. }
 Defined.
 
-Definition identity_map {C:Precategory} (h:hasZeroMaps C)
+Definition identity_map {C:category} (h:hasZeroMaps C)
            {I} {d:I -> ob C} (dec : isdeceq I)
            (B:Sum d) (D:Product d)
       : Hom C (universalObject B) (universalObject D).
 Proof. intros. apply RawMatrix.from_matrix. apply identity_matrix.
        assumption. assumption. Defined.
 
-Record DirectSum {C:Precategory} (h:hasZeroMaps C) I (dec : isdeceq I) (c : I -> ob C) :=
+Record DirectSum {C:category} (h:hasZeroMaps C) I (dec : isdeceq I) (c : I -> ob C) :=
   make_DirectSum {
       ds : C;
       ds_pr : ∏ i, Hom C ds (c i);
@@ -36,7 +36,7 @@ Record DirectSum {C:Precategory} (h:hasZeroMaps C) I (dec : isdeceq I) (c : I ->
       ds_id : ∏ i j, ds_pr i ∘ ds_in j = identity_matrix h c dec i j;
       ds_isprod : ∏ c, isweq (λ f : Hom C c ds, λ i, ds_pr i ∘ f);
       ds_issum  : ∏ c, isweq (λ f : Hom C ds c, λ i, f ∘ ds_in i) }.
-Definition toDirectSum {C:Precategory} (h:hasZeroMaps C) {I} (dec : isdeceq I) (d:I -> ob C)
+Definition toDirectSum {C:category} (h:hasZeroMaps C) {I} (dec : isdeceq I) (d:I -> ob C)
            (B:Sum d) (D:Product d)
            (is: is_iso (identity_map h dec B D)) : DirectSum h I dec d.
 Proof. intros. set (id := identity_map h dec B D).
@@ -55,7 +55,7 @@ Proof. intros. set (id := identity_map h dec B D).
                       (iso_comp_right_isweq (id,,is) c)
                       (pr2 (universalProperty B c))). }
 Defined.
-Definition FiniteDirectSums (C:Precategory) :=
+Definition FiniteDirectSums (C:category) :=
              ∑ h : hasZeroMaps C,
              ∏ I : FiniteSet,
              ∏ d : I -> ob C,

--- a/UniMath/Ktheory/Precategories.v
+++ b/UniMath/Ktheory/Precategories.v
@@ -23,7 +23,7 @@ Definition tar {C:precategory} {a b:C} (f:a-->b) : C := b.
 Definition hom (C:precategory_data) : ob C -> ob C -> UU :=
   λ c c', c --> c'.
 
-Definition Hom (C:Precategory) : ob C -> ob C -> hSet :=
+Definition Hom (C : category) : ob C -> ob C -> hSet :=
   λ c c', hSetpair (c --> c') (homset_property C _ _ ).
 
 Ltac eqn_logic :=
@@ -54,19 +54,19 @@ Ltac set_logic :=
                 try apply impred_isaset;
                 try apply isasetaprop)) using _M_.
 
-Notation "[ C , D ]" := (functor_Precategory C D) : cat.
+Notation "[ C , D ]" := (functor_category C D) : cat.
 
-Definition oppositePrecategory (C:Precategory) : Precategory.
+Definition oppositecategory (C : category) : category.
 Proof.
   exists (opp_precat C).
-  unfold Precategory in C.
+  unfold category in C.
   exact (λ a b, pr2 C b a).
 Defined.
 
-Notation "C '^op'" := (oppositePrecategory C) (at level 3) : cat. (* this overwrites the previous definition *)
+Notation "C '^op'" := (oppositecategory C) (at level 3) : cat. (* this overwrites the previous definition *)
 
 
-Definition Precategory_obmor (C:precategory) : precategory_ob_mor :=
+Definition precategory_obmor (C:precategory) : precategory_ob_mor :=
       precategory_ob_mor_from_precategory_data (
           precategory_data_from_precategory C).
 
@@ -79,7 +79,7 @@ Definition Functor_compose {C D} (F:functor C D) := @functor_comp _ _ F.
 
 Definition theUnivalenceProperty (C: univalent_category) := pr2 C : is_univalent C.
 
-Lemma Precategory_eq (C D:Precategory) :
+Lemma category_eq (C D : category) :
   (C:precategory_data) = (D:precategory_data) -> C=D.
 Proof.
   intro e. apply subtypeEquality. intro. apply isaprop_has_homsets.
@@ -91,46 +91,46 @@ Defined.
 
 (** embeddings and isomorphism of categories  *)
 
-Definition PrecategoryEmbedding (B C:Precategory) := ∑ F:[B,C], fully_faithful F.
+Definition categoryEmbedding (B C : category) := ∑ F:[B,C], fully_faithful F.
 
-Definition embeddingToFunctor (B C:Precategory) :
-  PrecategoryEmbedding B C -> B ⟶ C
+Definition embeddingToFunctor (B C : category) :
+  categoryEmbedding B C -> B ⟶ C
   := pr1.
 
-Coercion embeddingToFunctor : PrecategoryEmbedding >-> functor.
+Coercion embeddingToFunctor : categoryEmbedding >-> functor.
 
-Definition PrecategoryIsomorphism (B C:Precategory) :=
-  ∑ F:PrecategoryEmbedding B C, isweq ((pr1 F : B ⟶ C) : ob B -> ob C).
+Definition categoryIsomorphism (B C : category) :=
+  ∑ F:categoryEmbedding B C, isweq ((pr1 F : B ⟶ C) : ob B -> ob C).
 
-Definition isomorphismToEmbedding (B C:Precategory) :
-  PrecategoryIsomorphism B C -> PrecategoryEmbedding B C
+Definition isomorphismToEmbedding (B C:category) :
+  categoryIsomorphism B C -> categoryEmbedding B C
   := pr1.
 
-Coercion isomorphismToEmbedding : PrecategoryIsomorphism >-> PrecategoryEmbedding.
+Coercion isomorphismToEmbedding : categoryIsomorphism >-> categoryEmbedding.
 
-Definition isomorphismOnMor {B C:Precategory} (F:PrecategoryIsomorphism B C)
+Definition isomorphismOnMor {B C:category} (F:categoryIsomorphism B C)
            (b b':B) : Hom B b b'  ≃  Hom C (F b) (F b')
   := weqpair _ (pr2 (pr1 F) b b').
 
 (** *** make a precategory *)
 
-Definition makePrecategory_ob_mor
+Definition makecategory_ob_mor
     (obj : UU)
     (mor : obj -> obj -> UU) : precategory_ob_mor
   := precategory_ob_mor_pair obj (fun i j:obj => mor i j).
 
-Definition makePrecategory_data
+Definition makecategory_data
     (obj : UU)
     (mor : obj -> obj -> UU)
     (identity : ∏ i, mor i i)
     (compose : ∏ i j k (f:mor i j) (g:mor j k), mor i k)
     : precategory_data
-  := precategory_data_pair (makePrecategory_ob_mor obj mor) identity compose.
+  := precategory_data_pair (makecategory_ob_mor obj mor) identity compose.
 
 
 Local Open Scope cat_deprecated.
 
-Definition makeFunctor {C D:Precategory}
+Definition makeFunctor {C D:category}
            (obj : C -> D)
            (mor : ∏ c c' : C, c --> c' -> obj c --> obj c')
            (identity : ∏ c, mor c c (identity c) = identity (obj c))
@@ -141,23 +141,23 @@ Definition makeFunctor {C D:Precategory}
 
 (** notation for dealing with functors, natural transformations, etc.  *)
 
-Definition functor_object_application {B C:Precategory} (F : [B,C]) (b:B) : C
+Definition functor_object_application {B C:category} (F : [B,C]) (b:B) : C
   := (F:_⟶_) b.
 Notation "F ◾ b" := (functor_object_application F b) (at level 40, left associativity) : cat.
 (* \sqb3 *)
 
-Definition functor_mor_application {B C:Precategory} {b b':B} (F:[B,C]) :
+Definition functor_mor_application {B C:category} {b b':B} (F:[B,C]) :
   b --> b'  ->  F ◾ b --> F ◾ b'
   := λ f, # (F:_⟶_) f.
 Notation "F ▭ f" := (functor_mor_application F f) (at level 40, left associativity) : cat. (* \rew1 *)
 
-Definition arrow {C:Precategory} (c : C) (X : [C^op,SET]) : hSet := X ◾ c.
+Definition arrow {C:category} (c : C) (X : [C^op,SET]) : hSet := X ◾ c.
 Notation "c ⇒ X" := (arrow c X)  (at level 50) : cat. (* \r= *)
 
-Definition arrow' {C:Precategory} (c : C) (X : [C^op^op,SET]) : hSet := X ◾ c.
+Definition arrow' {C:category} (c : C) (X : [C^op^op,SET]) : hSet := X ◾ c.
 Notation "X ⇐ c" := (arrow' c X)  (at level 50) : cat. (* \l= *)
 
-Definition arrow_morphism_composition {C:Precategory} {c' c:C} {X:[C^op,SET]} :
+Definition arrow_morphism_composition {C:category} {c' c:C} {X:[C^op,SET]} :
   c'-->c -> c⇒X -> c'⇒X
   := λ f x, # (X:_⟶_) f x.
 Notation "x ⟲ f" := (arrow_morphism_composition f x) (at level 50, left associativity) : cat.
@@ -165,7 +165,7 @@ Notation "x ⟲ f" := (arrow_morphism_composition f x) (at level 50, left associ
 (* motivation for the notation:
    the morphisms of C act on the right of the elements of X *)
 
-Definition nattrans_arrow_composition {C:Precategory} {X X':[C^op,SET]} {c:C} :
+Definition nattrans_arrow_composition {C:category} {X X':[C^op,SET]} {c:C} :
   c⇒X -> X-->X' -> c⇒X'
   := λ x q, (q:_ ⟹ _) c (x:(X:_⟶_) c:hSet).
 Notation "q ⟳ x" := (nattrans_arrow_composition x q) (at level 50, left associativity) : cat.
@@ -174,53 +174,53 @@ Notation "q ⟳ x" := (nattrans_arrow_composition x q) (at level 50, left associ
    the natural transformations between functors act on the
    left of the elements of the functors *)
 
-Definition nattrans_object_application {B C:Precategory} {F F' : [B,C]} (b:B) :
+Definition nattrans_object_application {B C:category} {F F' : [B,C]} (b:B) :
   F --> F'  ->  F ◾ b --> F' ◾ b
   := λ p, (p:_ ⟹ _) b.
 Notation "p ◽ b" := (nattrans_object_application b p) (at level 40) : cat.
 (* agda input : \sqw3 *)
 
-Definition arrow_mor_id {C:Precategory} {c:C} {X:[C^op,SET]} (x:c⇒X) :
+Definition arrow_mor_id {C:category} {c:C} {X:[C^op,SET]} (x:c⇒X) :
   x ⟲ identity c = x
   := eqtohomot (functor_id X c) x.
 
-Definition arrow_mor_mor_assoc {C:Precategory} {c c' c'':C} {X:[C^op,SET]}
+Definition arrow_mor_mor_assoc {C:category} {c c' c'':C} {X:[C^op,SET]}
            (g:c''-->c') (f:c'-->c) (x:c⇒X) :
   x ⟲ (f ∘ g) = (x ⟲ f) ⟲ g
   := eqtohomot (functor_comp X f g) x.
 
-Definition nattrans_naturality {B C:Precategory} {F F':[B, C]} {b b':B}
+Definition nattrans_naturality {B C:category} {F F':[B, C]} {b b':B}
            (p : F --> F') (f : b --> b') :
   p ◽ b'  ∘  F ▭ f  =  F' ▭ f  ∘  p ◽ b
   := nat_trans_ax p _ _ f.
 
-Definition comp_func_on_mor {A B C:Precategory} (F:[A,B]) (G:[B,C]) {a a':A} (f:a-->a') :
+Definition comp_func_on_mor {A B C:category} (F:[A,B]) (G:[B,C]) {a a':A} (f:a-->a') :
   G □ F ▭ f = G ▭ (F ▭ f).
 Proof. reflexivity. Defined.
 
-Definition nattrans_arrow_mor_assoc {C:Precategory} {c' c:C} {X X':[C^op,SET]}
+Definition nattrans_arrow_mor_assoc {C:category} {c' c:C} {X X':[C^op,SET]}
            (g:c'-->c) (x:c⇒X) (p:X-->X') :
   p ⟳ (x ⟲ g) = (p ⟳ x) ⟲ g
   := eqtohomot (nat_trans_ax p _ _ g) x.
 
-Definition nattrans_arrow_id {C:Precategory} {c:C} {X:[C^op,SET]} (x:c⇒X) :
+Definition nattrans_arrow_id {C:category} {c:C} {X:[C^op,SET]} (x:c⇒X) :
   nat_trans_id _ ⟳ x = x
   := idpath _.
 
-Definition nattrans_nattrans_arrow_assoc {C:Precategory} {c:C} {X X' X'':[C^op,SET]}
+Definition nattrans_nattrans_arrow_assoc {C:category} {c:C} {X X' X'':[C^op,SET]}
            (x:c⇒X) (p:X-->X') (q:X'-->X'') :
   q ⟳ (p ⟳ x) = (q ∘ p) ⟳ x
   := idpath _.
 
-Definition nattrans_nattrans_object_assoc {A B C:Precategory}
+Definition nattrans_nattrans_object_assoc {A B C:category}
            (F:[A,B]) (G:[B, C]) {a a' : A} (f : a --> a') :
   G □ F ▭ f = G ▭ (F ▭ f)
   := idpath _.
 
-Lemma functor_on_id {B C:Precategory} (F:[B,C]) (b:B) : F ▭ identity b = identity (F ◾ b).
+Lemma functor_on_id {B C:category} (F:[B,C]) (b:B) : F ▭ identity b = identity (F ◾ b).
 Proof. exact (functor_id F b). Defined.
 
-Lemma functor_on_comp {B C:Precategory} (F:[B,C]) {b b' b'':B} (g:b'-->b'') (f:b-->b') :
+Lemma functor_on_comp {B C:category} (F:[B,C]) {b b' b'':B} (g:b'-->b'') (f:b-->b') :
   F ▭ (g ∘ f) = F ▭ g ∘ F ▭ f.
 Proof. exact (functor_comp F f g). Defined.
 
@@ -228,21 +228,21 @@ Proof. exact (functor_comp F f g). Defined.
 
 (** natural transformations and isomorphisms *)
 
-Definition nat_iso {B C:Precategory} (F G:[B,C]) := iso F G.
+Definition nat_iso {B C:category} (F G:[B,C]) := iso F G.
 
-Definition makeNattrans {C D:Precategory} {F G:[C,D]}
+Definition makeNattrans {C D:category} {F G:[C,D]}
            (mor : ∏ x : C, F ◾ x --> G ◾ x)
            (eqn : ∏ c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
   F --> G
   := (mor,,eqn).
 
-Definition makeNattrans_op {C D:Precategory} {F G:[C^op,D]}
+Definition makeNattrans_op {C D:category} {F G:[C^op,D]}
            (mor : ∏ x : C, F ◾ x --> G ◾ x)
            (eqn : ∏ c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
   F --> G
   := (mor,,eqn).
 
-Definition makeNatiso {C D:Precategory} {F G:[C,D]}
+Definition makeNatiso {C D:category} {F G:[C,D]}
            (mor : ∏ x : C, iso (F ◾ x) (G ◾ x))
            (eqn : ∏ c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
   nat_iso F G.
@@ -250,7 +250,7 @@ Proof.
   refine (makeNattrans mor eqn,,_). apply functor_iso_if_pointwise_iso; intro c. apply pr2.
 Defined.
 
-Definition makeNatiso_op {C D:Precategory} {F G:[C^op,D]}
+Definition makeNatiso_op {C D:category} {F G:[C^op,D]}
            (mor : ∏ x : C, iso (F ◾ x) (G ◾ x))
            (eqn : ∏ c c' f, mor c' ∘ F ▭ f = G ▭ f ∘ mor c) :
   nat_iso F G.
@@ -258,7 +258,7 @@ Proof.
   refine (makeNattrans_op mor eqn,,_). apply functor_iso_if_pointwise_iso; intro c. apply pr2.
 Defined.
 
-Lemma move_inv {C:Precategory} {a a' b' b:C} {f : a --> b} {f' : a' --> b'}
+Lemma move_inv {C:category} {a a' b' b:C} {f : a --> b} {f' : a' --> b'}
       {i : a --> a'} {i' : a' --> a} {j : b --> b'} {j' : b' --> b} :
   is_inverse_in_precat i i' -> is_inverse_in_precat j j' ->
   j ∘ f = f' ∘ i -> j' ∘ f' = f ∘ i'.
@@ -289,10 +289,10 @@ Defined.
 
 (* opposite categories *)
 
-Definition functor_to_opp_opp {C:Precategory} : C ⟶ C^op^op
+Definition functor_to_opp_opp {C:category} : C ⟶ C^op^op
   := makeFunctor (λ c,c) (λ a b f,f) (λ c, idpath _) (λ a b c f g, idpath _).
 
-Definition makeFunctor_op {C D:Precategory}
+Definition makeFunctor_op {C D:category}
            (obj : ob C -> ob D)
            (mor : ∏ a b : C, b --> a -> obj a --> obj b)
            (identity : ∏ c, mor c c (identity c) = identity (obj c))
@@ -301,19 +301,19 @@ Definition makeFunctor_op {C D:Precategory}
   C^op ⟶ D
   := (obj,, mor),, identity,, compax.
 
-Definition opp_ob {C:Precategory} : ob C -> ob C^op
+Definition opp_ob {C:category} : ob C -> ob C^op
   := λ c, c.
 
-Definition rm_opp_ob {C:Precategory} : ob C^op -> ob C
+Definition rm_opp_ob {C:category} : ob C^op -> ob C
   := λ c, c.
 
-Definition opp_mor {C:Precategory} {b c:C} : Hom C b c -> Hom C^op c b
+Definition opp_mor {C:category} {b c:C} : Hom C b c -> Hom C^op c b
   := λ f, f.
 
-Definition rm_opp_mor {C:Precategory} {b c:C} : Hom C^op b c -> Hom C c b
+Definition rm_opp_mor {C:category} {b c:C} : Hom C^op b c -> Hom C c b
   := λ f, f.
 
-Definition opp_mor_eq {C:Precategory} {a b:C} (f g:a --> b) :
+Definition opp_mor_eq {C:category} {a b:C} (f g:a --> b) :
   opp_mor f = opp_mor g -> f = g
   := idfun _.
 
@@ -328,15 +328,15 @@ Lemma opp_opp_precat_data (C : precategory_data)
    : C = opp_precat_data (opp_precat_data C).
 Proof. induction C as [[ob mor] [id co]]. reflexivity. Defined.
 
-Lemma opp_opp_precat (C:Precategory) : C = C^op^op.
+Lemma opp_opp_precat (C:category) : C = C^op^op.
 Proof.
-  apply Precategory_eq.         (* we need both associativity axioms to avoid this *)
+  apply category_eq.         (* we need both associativity axioms to avoid this *)
   tryif primitive_projections
   then reflexivity
   else induction C as [[[[obj mor] [id comp]] p] h]; reflexivity.
 Qed.
 
-Definition functorOp {B C : Precategory} : [B, C] ^op ⟶ [B ^op, C ^op].
+Definition functorOp {B C : category} : [B, C] ^op ⟶ [B ^op, C ^op].
 Proof.
   unshelve refine (makeFunctor _ _ _ _).
   { exact functor_opp. }
@@ -346,12 +346,12 @@ Proof.
   { abstract (intros H J K p q; now apply (nat_trans_eq (homset_property _))). }
 Defined.
 
-Definition functorOp' {B C:Precategory} : [B,C] ⟶ [B^op,C^op]^op.
+Definition functorOp' {B C:category} : [B,C] ⟶ [B^op,C^op]^op.
 Proof.
   exact (functorOp functorOp).
 Defined.
 
-Definition functorRmOp {B C : Precategory} : [B ^op, C ^op] ⟶ [B, C] ^op.
+Definition functorRmOp {B C : category} : [B ^op, C ^op] ⟶ [B, C] ^op.
 Proof.
   unshelve refine (makeFunctor _ _ _ _).
   { exact functor_opp. }
@@ -361,7 +361,7 @@ Proof.
   { abstract (intros H J K p q; now apply (nat_trans_eq (homset_property _))). }
 Defined.
 
-Definition functorMvOp {B C:Precategory} : [B,C^op] ⟶ [B^op,C]^op.
+Definition functorMvOp {B C:category} : [B,C^op] ⟶ [B^op,C]^op.
 Proof.
   unshelve refine (makeFunctor _ _ _ _).
   { exact functor_opp. }
@@ -371,7 +371,7 @@ Proof.
   { abstract (intros H J K p q; now apply (nat_trans_eq (homset_property _))). }
 Defined.
 
-Lemma functorOpIso {B C:Precategory} : PrecategoryIsomorphism [B, C]^op [B^op, C^op].
+Lemma functorOpIso {B C:category} : categoryIsomorphism [B, C]^op [B^op, C^op].
 Proof.
   unshelve refine (_,,_).
   { unshelve refine (_,,_).
@@ -395,10 +395,10 @@ Proof.
                 | unshelve refine (total2_paths_f _ _); reflexivity]). } }
 Defined.
 
-Definition functorOpEmb {B C:Precategory} : PrecategoryEmbedding [B, C]^op [B^op, C^op]
+Definition functorOpEmb {B C:category} : categoryEmbedding [B, C]^op [B^op, C^op]
   := pr1 functorOpIso.
 
-Lemma functor_op_rm_op_eq {C D:Precategory} (F : C^op ⟶ D^op) :
+Lemma functor_op_rm_op_eq {C D:category} (F : C^op ⟶ D^op) :
   functorOp (functorRmOp F) = F.
 Proof.
   apply functor_eq.
@@ -406,7 +406,7 @@ Proof.
   unshelve refine (total2_paths_f _ _); reflexivity.
 Qed.
 
-Lemma functor_rm_op_op_eq {C D:Precategory} (F : C ⟶ D) :
+Lemma functor_rm_op_op_eq {C D:category} (F : C ⟶ D) :
   functorRmOp (functorOp F) = F.
 Proof.
   apply functor_eq.
@@ -414,7 +414,7 @@ Proof.
   unshelve refine (total2_paths_f _ _); reflexivity.
 Qed.
 
-Lemma functor_op_op_eq {C D:Precategory} (F : C ⟶ D) :
+Lemma functor_op_op_eq {C D:category} (F : C ⟶ D) :
   functorOp (functorOp F) = F.
 Proof.
   apply functor_eq.
@@ -436,9 +436,9 @@ Goal ∏ X Y (f:X->Y), f = λ x, f x.
 
 (* new categories from old *)
 
-Definition categoryWithStructure (C:Precategory) (P:ob C -> UU) : Precategory.
+Definition categoryWithStructure (C:category) (P:ob C -> UU) : category.
 Proof.
-  unshelve refine (makePrecategory _ _ _ _ _ _ _ _).
+  unshelve refine (makecategory _ _ _ _ _ _ _ _).
   (* add a new component to each object: *)
   - exact (∑ c:C, P c).
   (* the homsets ignore the extra structure: *)
@@ -452,7 +452,7 @@ Proof.
   - intros. apply assoc.
 Defined.
 
-Definition functorWithStructures {C:Precategory} {P Q:ob C -> UU}
+Definition functorWithStructures {C:category} {P Q:ob C -> UU}
            (F : ∏ c, P c -> Q c) : categoryWithStructure C P ⟶ categoryWithStructure C Q.
 Proof.
   unshelve refine (makeFunctor _ _ _ _).
@@ -464,7 +464,7 @@ Proof.
   - reflexivity.
 Defined.
 
-Definition addStructure {B C:Precategory} {P:ob C -> UU}
+Definition addStructure {B C:category} {P:ob C -> UU}
            (F:B⟶C) (h : ∏ b, P(F b)) : B ⟶ categoryWithStructure C P.
 Proof.
   unshelve refine (makeFunctor _ _ _ _).
@@ -482,13 +482,13 @@ Proof. reflexivity. Defined.
 
 (*  *)
 
-Lemma functor_identity_object {C:Precategory} (c:C) : functor_identity C ◾ c = c.
+Lemma functor_identity_object {C:category} (c:C) : functor_identity C ◾ c = c.
 Proof. reflexivity. Defined.
 
-Lemma functor_identity_arrow {C:Precategory} {c c':C} (f:c-->c') : functor_identity C ▭ f = f.
+Lemma functor_identity_arrow {C:category} {c c':C} (f:c-->c') : functor_identity C ▭ f = f.
 Proof. reflexivity. Defined.
 
-Definition constantFunctor (C:Precategory) {D:Precategory} (d:D) : [C,D].
+Definition constantFunctor (C:category) {D:category} (d:D) : [C,D].
 Proof.
   unshelve refine (makeFunctor _ _ _ _).
   - exact (λ _, d).
@@ -499,7 +499,7 @@ Defined.
 
 (*  *)
 
-Definition functor_composite_functor {A B C:Precategory} (F:A⟶B) :
+Definition functor_composite_functor {A B C:category} (F:A⟶B) :
   [B,C] ⟶ [A,C].
 Proof.
   unshelve refine (makeFunctor _ _ _ _).
@@ -517,19 +517,19 @@ Defined.
 
 (* zero maps, definition: *)
 
-Definition hasZeroMaps (C:Precategory) :=
+Definition hasZeroMaps (C:category) :=
   ∑ (zero : ∏ a b:C, a --> b),
   (∏ a b c, ∏ f:b --> c, f ∘ zero a b = zero a c)
     ×
     (∏ a b c, ∏ f:c --> b, zero b a ∘ f = zero c a).
 
-Definition is {C:Precategory} (zero: hasZeroMaps C) {a b:C} (f:a-->b)
+Definition is {C:category} (zero: hasZeroMaps C) {a b:C} (f:a-->b)
   := f = pr1 zero _ _.
 
-Definition hasZeroMaps_opp (C:Precategory) : hasZeroMaps C -> hasZeroMaps C^op
+Definition hasZeroMaps_opp (C:category) : hasZeroMaps C -> hasZeroMaps C^op
   := λ z, (λ a b, pr1 z b a) ,, pr2 (pr2 z) ,, pr1 (pr2 z).
 
-Definition hasZeroMaps_opp_opp (C:Precategory) (zero:hasZeroMaps C) :
+Definition hasZeroMaps_opp_opp (C:category) (zero:hasZeroMaps C) :
   hasZeroMaps_opp C^op (hasZeroMaps_opp C zero) = zero.
 Proof.
   unshelve refine (total2_paths_f _ _).

--- a/UniMath/Ktheory/RawMatrix.v
+++ b/UniMath/Ktheory/RawMatrix.v
@@ -14,37 +14,37 @@ Require Import
         UniMath.Ktheory.Precategories.
 Local Open Scope cat.
 
-Definition to_row {C:Precategory} {I} {b:I -> ob C}
+Definition to_row {C:category} {I} {b:I -> ob C}
            (B:Sum b) {d:ob C} :
   weq (Hom C (universalObject B) d) (∏ j, Hom C (b j) d).
 Proof. intros. exact (universalProperty B d). Defined.
 
-Definition from_row {C:Precategory}  {I} {b:I -> ob C}
+Definition from_row {C:category}  {I} {b:I -> ob C}
            (B:Sum b) {d:ob C} :
   weq (∏ j, Hom C (b j) d) (Hom C (universalObject B) d).
 Proof. intros. apply invweq. apply to_row. Defined.
 
-Lemma from_row_entry {C:Precategory} {I} {b:I -> ob C}
+Lemma from_row_entry {C:category} {I} {b:I -> ob C}
            (B:Sum b) {d:ob C} (f : ∏ j, Hom C (b j) d) :
   ∏ j, from_row B f ∘ opp_mor (universalElement B j) = f j.
 Proof. intros. exact (eqtohomot (homotweqinvweq (to_row B) f) j). Qed.
 
-Definition to_col {C:Precategory} {I} {d:I -> ob C} (D:Product d) {b:ob C} :
+Definition to_col {C:category} {I} {d:I -> ob C} (D:Product d) {b:ob C} :
   (Hom C b (universalObject D)) ≃ (∏ i, Hom C b (d i)).
 Proof. intros. exact (universalProperty D b). Defined.
 
-Definition from_col {C:Precategory} {I} {d:I -> ob C}
+Definition from_col {C:category} {I} {d:I -> ob C}
            (D:Product d) {b:ob C} :
  (∏ i, Hom C b (d i)) ≃ (Hom C b (universalObject D)).
 Proof. intros. apply invweq. apply to_col. Defined.
 
-Lemma from_col_entry {C:Precategory} {I} {b:I -> ob C}
+Lemma from_col_entry {C:category} {I} {b:I -> ob C}
            (D:Product b) {d:ob C} (f : ∏ i, Hom C d (b i)) :
   ∏ i, universalElement D i ∘ from_col D f = f i.
 Proof. intros.
   apply (eqtohomot (homotweqinvweq (to_col D) f ) i). Qed.
 
-Definition to_matrix {C:Precategory}
+Definition to_matrix {C:category}
            {I} {d:I -> ob C} (D:Product d)
            {J} {b:J -> ob C} (B:Sum b) :
   (Hom C (universalObject B) (universalObject D))
@@ -56,20 +56,20 @@ Proof.
   { apply weqonsecfibers; intro i. apply to_row. }
 Defined.
 
-Definition from_matrix {C:Precategory}
+Definition from_matrix {C:category}
            {I} {d:I -> ob C} (D:Product d)
            {J} {b:J -> ob C} (B:Sum b) :
            weq (∏ i j, Hom C (b j) (d i)) (Hom C (universalObject B) (universalObject D)).
 Proof. intros. apply invweq. apply to_matrix. Defined.
 
-Lemma from_matrix_entry {C:Precategory}
+Lemma from_matrix_entry {C:category}
            {I} {d:I -> ob C} (D:Product d)
            {J} {b:J -> ob C} (B:Sum b)
            (f : ∏ i j, Hom C (b j) (d i)) :
   ∏ i j, (universalElement D i ∘ from_matrix D B f) ∘ opp_mor (universalElement B j) = f i j.
 Proof. intros. exact (eqtohomot (eqtohomot (homotweqinvweq (to_matrix D B) f) i) j). Qed.
 
-Lemma from_matrix_entry_assoc {C:Precategory}
+Lemma from_matrix_entry_assoc {C:category}
            {I} {d:I -> ob C} (D:Product d)
            {J} {b:J -> ob C} (B:Sum b)
            (f : ∏ i j, Hom C (b j) (d i)) :

--- a/UniMath/Ktheory/Representation.v
+++ b/UniMath/Ktheory/Representation.v
@@ -13,13 +13,13 @@ Set Automatic Introduction.
 Local Open Scope cat.
 Local Open Scope Cat.
 
-Definition isUniversal {C:Precategory} {X:[C^op,SET]} {c:C} (x:c ⇒ X)
+Definition isUniversal {C:category} {X:[C^op,SET]} {c:C} (x:c ⇒ X)
   := ∏ (c':C), isweq (λ f : c' --> c, x ⟲ f).
 
-Definition Universal {C:Precategory} (X:[C^op,SET]) (c:C)
+Definition Universal {C:category} (X:[C^op,SET]) (c:C)
   := ∑ (x:c ⇒ X), isUniversal x.
 
-Lemma iso_Universal_weq {C:Precategory} {X Y:[C^op,SET]} (c:C) :
+Lemma iso_Universal_weq {C:category} {X Y:[C^op,SET]} (c:C) :
   iso X Y -> Universal X c ≃ Universal Y c.
 Proof.
   intro i.
@@ -37,10 +37,10 @@ Proof.
     + apply isapropisweq.
 Defined.
 
-Definition Representation {C:Precategory} (X:[C^op,SET]) : UU
+Definition Representation {C:category} (X:[C^op,SET]) : UU
   := ∑ (c:C), Universal X c.
 
-Definition isRepresentable {C:Precategory} (X:[C^op,SET]) := ∥ Representation X ∥.
+Definition isRepresentable {C:category} (X:[C^op,SET]) := ∥ Representation X ∥.
 
 Lemma isaprop_Representation {C: univalent_category} (X:[C^op,SET]) :
   isaprop (@Representation C X).
@@ -48,7 +48,7 @@ Proof.
 
 Abort.
 
-Definition iso_Representation_weq {C:Precategory} {X Y:[C^op,SET]} :
+Definition iso_Representation_weq {C:category} {X Y:[C^op,SET]} :
   iso X Y -> Representation X ≃ Representation Y.
 Proof.
   intros i. apply weqfibtototal; intro c. apply iso_Universal_weq; assumption.
@@ -56,23 +56,23 @@ Defined.
 
 (* categories of functors with representations *)
 
-Definition RepresentedFunctor (C:Precategory) : Precategory
+Definition RepresentedFunctor (C:category) : category
   := categoryWithStructure [C^op,SET] Representation.
 
-Definition toRepresentation {C:Precategory} (X : RepresentedFunctor C) :
+Definition toRepresentation {C:category} (X : RepresentedFunctor C) :
   Representation (pr1 X)
   := pr2 X.
 
-Definition RepresentableFunctor (C:Precategory) : Precategory
+Definition RepresentableFunctor (C:category) : category
   := categoryWithStructure [C^op,SET] isRepresentable.
 
-Definition toRepresentableFunctor {C:Precategory} :
+Definition toRepresentableFunctor {C:category} :
   RepresentedFunctor C ⟶ RepresentableFunctor C :=
   functorWithStructures (λ c, hinhpr).
 
 (* make a representation of a functor *)
 
-Definition makeRepresentation {C:Precategory} {c:C} {X:[C^op,SET]} (x:c ⇒ X) :
+Definition makeRepresentation {C:category} {c:C} {X:[C^op,SET]} (x:c ⇒ X) :
   (∏ (c':C), UniqueConstruction (λ f : c' --> c, x ⟲ f)) -> Representation X.
 Proof.
   intros bij. exists c. exists x. intros c'. apply set_bijection_to_weq.
@@ -82,57 +82,57 @@ Defined.
 
 (* universal aspects of represented functors *)
 
-Definition universalObject {C:Precategory} {X:[C^op,SET]} (r:Representation X) : C
+Definition universalObject {C:category} {X:[C^op,SET]} (r:Representation X) : C
   := pr1 r.
 
-Definition universalElement {C:Precategory} {X:[C^op,SET]} (r:Representation X) :
+Definition universalElement {C:category} {X:[C^op,SET]} (r:Representation X) :
   universalObject r ⇒ X
   := pr1 (pr2 r).
 
 Coercion universalElement : Representation >-> pr1hSet.
 
-Definition universalProperty {C:Precategory} {X:[C^op,SET]} (r:Representation X) (c:C) :
+Definition universalProperty {C:category} {X:[C^op,SET]} (r:Representation X) (c:C) :
   c --> universalObject r ≃ c ⇒ X
   := weqpair (λ f : c --> universalObject r, r ⟲ f)
              (pr2 (pr2 r) c).
 
-Definition universalMap {C:Precategory} {X:[C^op,SET]} (r:Representation X) {c:C} :
+Definition universalMap {C:category} {X:[C^op,SET]} (r:Representation X) {c:C} :
   c ⇒ X -> c --> universalObject r
   := invmap (universalProperty _ _).
 
 Notation "r \\ x" := (universalMap r x) (at level 50, left associativity) : cat.
 
-Definition universalMap' {C:Precategory} {X:[C^op^op,SET]} (r:Representation X) {c:C} :
+Definition universalMap' {C:category} {X:[C^op^op,SET]} (r:Representation X) {c:C} :
   X ⇐ c -> c <-- universalObject r
   := invmap (universalProperty _ _).
 
 Notation "x // r" := (universalMap' r x) (at level 50, left associativity) : cat.
 
-Definition universalMapProperty {C:Precategory} {X:[C^op,SET]} (r:Representation X)
+Definition universalMapProperty {C:category} {X:[C^op,SET]} (r:Representation X)
       {c:C} (x : c ⇒ X) :
   r ⟲ (r \\ x) = x
   := homotweqinvweq (universalProperty r c) x.
 
-Definition mapUniqueness {C:Precategory} (X:[C^op,SET]) (r : Representation X) (c:C)
+Definition mapUniqueness {C:category} (X:[C^op,SET]) (r : Representation X) (c:C)
            (f g: c --> universalObject r) :
   r ⟲ f = r ⟲ g -> f = g
   := invmaponpathsweq (universalProperty _ _) _ _.
 
-Definition universalMapUniqueness {C:Precategory} {X:[C^op,SET]} {r:Representation X}
+Definition universalMapUniqueness {C:category} {X:[C^op,SET]} {r:Representation X}
       {c:C} (x : c ⇒ X) (f : c --> universalObject r) :
   r ⟲ f = x -> f = r \\ x
   := pathsweq1 (universalProperty r c) f x.
 
-Definition universalMapIdentity {C:Precategory} {X:[C^op,SET]} (r:Representation X) :
+Definition universalMapIdentity {C:category} {X:[C^op,SET]} (r:Representation X) :
   r \\ r = identity _.
 Proof. apply pathsinv0. apply universalMapUniqueness. apply arrow_mor_id. Qed.
 
-Definition universalMapUniqueness' {C:Precategory} {X:[C^op,SET]} {r:Representation X}
+Definition universalMapUniqueness' {C:category} {X:[C^op,SET]} {r:Representation X}
       {c:C} (x : c ⇒ X) (f : c --> universalObject r) :
   f = r \\ x -> r ⟲ f = x
   := pathsweq1' (universalProperty r c) f x.
 
-Lemma univ_arrow_mor_assoc {C:Precategory} {a b:C} {Z:[C^op,SET]}
+Lemma univ_arrow_mor_assoc {C:category} {a b:C} {Z:[C^op,SET]}
       (f : a --> b) (z : b ⇒ Z) (t : Representation Z) :
   (t \\ z) ∘ f = t \\ (z ⟲ f).
 Proof.
@@ -144,7 +144,7 @@ Qed.
 
 (*  *)
 
-Lemma uOF_identity {C:Precategory} {X:[C^op,SET]} (r:Representation X) :
+Lemma uOF_identity {C:category} {X:[C^op,SET]} (r:Representation X) :
   r \\ (identity X ⟳ r) = identity _.
 Proof.
   unfold nat_trans_id; simpl.
@@ -152,7 +152,7 @@ Proof.
   apply universalMapIdentity.
 Qed.
 
-Lemma uOF_comp {C:Precategory} {X Y Z:[C^op,SET]}
+Lemma uOF_comp {C:category} {X Y Z:[C^op,SET]}
       (r:Representation X)
       (s:Representation Y)
       (t:Representation Z)
@@ -168,7 +168,7 @@ Proof.
   apply universalMapProperty.
 Qed.
 
-Definition universalObjectFunctor (C:Precategory) : RepresentedFunctor C ⟶ C.
+Definition universalObjectFunctor (C:category) : RepresentedFunctor C ⟶ C.
 Proof.
   unshelve refine (makeFunctor _ _ _ _).
   - intro X. exact (universalObject (pr2 X)).
@@ -177,11 +177,11 @@ Proof.
   - intros X Y Z p q; simpl. apply uOF_comp.
 Defined.
 
-Definition universalObjectFunctor_on_map (C:Precategory) {X Y:RepresentedFunctor C} (p:X-->Y) :
+Definition universalObjectFunctor_on_map (C:category) {X Y:RepresentedFunctor C} (p:X-->Y) :
   universalObjectFunctor C ▭ p = pr2 Y \\ (p ⟳ pr2 X).
 Proof. reflexivity. Defined.
 
-Lemma universalObjectFunctor_comm (C:Precategory) {X Y:RepresentedFunctor C} (p:X-->Y) :
+Lemma universalObjectFunctor_comm (C:category) {X Y:RepresentedFunctor C} (p:X-->Y) :
   p ⟳ universalElement (pr2 X) = universalElement (pr2 Y) ⟲ universalObjectFunctor C ▭ p.
 Proof.
   change (universalObjectFunctor C ▭ p) with (pr2 Y \\ (p ⟳ pr2 X)).
@@ -190,7 +190,7 @@ Defined.
 
 (** transferring universal properties between isomorphic objects *)
 
-Definition isUniversal_isom {C:Precategory} {X:[C^op,SET]} {c c':C}
+Definition isUniversal_isom {C:category} {X:[C^op,SET]} {c c':C}
            (x:c ⇒ X) (f : iso c' c) :
   isUniversal x <-> isUniversal (x ⟲ f).
 Proof.
@@ -200,10 +200,10 @@ Abort.
 
 (** transferring representability via embeddings and isomorphisms of categories  *)
 
-Definition embeddingRepresentability {C D:Precategory}
+Definition embeddingRepresentability {C D:category}
            {X:[C^op,SET]} {Y:[D^op,SET]}
            (s:Representation Y)
-           (i:PrecategoryEmbedding C D) :
+           (i:categoryEmbedding C D) :
   iso (Y □ functorOp (opp_ob (pr1 i))) X ->
   (∑ c, i c = universalObject s) -> Representation X.
 Proof.
@@ -216,10 +216,10 @@ Proof.
   - induction (! pr2 ce). exact (weqproperty (universalProperty _ _)).
 Defined.
 
-Definition isomorphismRepresentability {C D:Precategory}
+Definition isomorphismRepresentability {C D:category}
            {X:[C^op,SET]} {Y:[D^op,SET]}
            (s:Representation Y)
-           (i:PrecategoryIsomorphism C D) :
+           (i:categoryIsomorphism C D) :
   iso (Y □ functorOp (opp_ob (pr1 (pr1 i)))) X -> Representation X
   := λ j, embeddingRepresentability s i j (iscontrpr1 (pr2 i (universalObject s))).
 
@@ -227,7 +227,7 @@ Definition isomorphismRepresentability {C D:Precategory}
 
 (** the functor represented by an object *)
 
-Definition Hom1 {C:Precategory} (c:C) : [C^op,SET].
+Definition Hom1 {C:category} (c:C) : [C^op,SET].
 Proof.
   unshelve refine (makeFunctor_op _ _ _ _).
   - intro b. exact (Hom C b c).
@@ -237,7 +237,7 @@ Proof.
               rewrite <- assoc; reflexivity) using _L_.
 Defined.
 
-Lemma Hom1_Representation {C:Precategory} (c:C) : Representation (Hom1 c).
+Lemma Hom1_Representation {C:category} (c:C) : Representation (Hom1 c).
 Proof.
   exists c. exists (identity c). intro b. apply (isweqhomot (idweq _)).
   - abstract (intro f; unfold arrow_morphism_composition; unfold Hom1, idfun; simpl;
@@ -250,7 +250,7 @@ Defined.
 Lemma compose_SET {X Y Z:SET} (f:X-->Y) (g:Y-->Z) : g∘f = λ x, g(f x).
 Proof. reflexivity. Defined.
 
-Definition element_to_nattrans {C:Precategory} (X:[C^op,SET]) (c:C) :
+Definition element_to_nattrans {C:category} (X:[C^op,SET]) (c:C) :
   c ⇒ X -> Hom1 c --> X.
 Proof.
   intros x. unshelve refine (makeNattrans_op _ _).
@@ -260,7 +260,7 @@ Defined.
 
 (** representable functors are isomorphic to one represented by an object  *)
 
-Theorem Representation_to_iso {C:Precategory} (X:[C^op,SET]) (r:Representation X) :
+Theorem Representation_to_iso {C:category} (X:[C^op,SET]) (r:Representation X) :
   iso (Hom1 (universalObject r)) X.
 Proof.
   apply (functor_iso_from_pointwise_iso _ _ _ _ _ (element_to_nattrans X (universalObject r) (universalElement r))).
@@ -269,7 +269,7 @@ Defined.
 
 (** initial and final objects and zero maps  *)
 
-Definition UnitFunctor (C:Precategory) : [C,SET].
+Definition UnitFunctor (C:category) : [C,SET].
   unshelve refine (_,,_).
   { exists (λ c, unitset). exact (λ a b f t, t). }
   { split.
@@ -277,7 +277,7 @@ Definition UnitFunctor (C:Precategory) : [C,SET].
     { intros a b c f g. reflexivity. } }
 Defined.
 
-Definition TerminalObject (C:Precategory) := Representation (UnitFunctor C^op).
+Definition TerminalObject (C:category) := Representation (UnitFunctor C^op).
 
 Definition terminalObject {C} (t:TerminalObject C) : ob C := universalObject t.
 
@@ -285,7 +285,7 @@ Definition terminalArrow {C} (t:TerminalObject C) (c:ob C) :
   Hom C c (terminalObject t)
   := t \\ tt.
 
-Definition InitialObject (C:Precategory) := TerminalObject C^op.
+Definition InitialObject (C:category) := TerminalObject C^op.
 
 Definition initialObject {C} (i:InitialObject C) : ob C := universalObject i.
 
@@ -293,39 +293,39 @@ Definition initialArrow {C} (i:InitialObject C) (c:ob C) :
   Hom C (initialObject i) c
   := rm_opp_mor (tt // i).
 
-Definition init_to_opp {C:Precategory} : InitialObject C -> TerminalObject C^op
+Definition init_to_opp {C:category} : InitialObject C -> TerminalObject C^op
   := λ i, i.
 
-Definition term_to_opp {C:Precategory} : TerminalObject C -> InitialObject C^op.
+Definition term_to_opp {C:category} : TerminalObject C -> InitialObject C^op.
 Proof. intros. unfold InitialObject. now induction (opp_opp_precat C). Defined.
 
 (** zero objects, as an alternative to ZeroObject.v *)
 
-Definition ZeroObject (C:Precategory)
+Definition ZeroObject (C:category)
   := ∑ z:ob C, Universal (UnitFunctor C^op) z × Universal (UnitFunctor C^op^op) z.
 
-Definition zero_to_terminal (C:Precategory) : ZeroObject C -> TerminalObject C
+Definition zero_to_terminal (C:category) : ZeroObject C -> TerminalObject C
   := λ z, pr1 z ,, pr1 (pr2 z).
 
-Definition zero_to_initial (C:Precategory) : ZeroObject C -> InitialObject C
+Definition zero_to_initial (C:category) : ZeroObject C -> InitialObject C
   := λ z, pr1 z ,, pr2 (pr2 z).
 
-Definition zero_opp (C:Precategory) : ZeroObject C -> ZeroObject C^op.
+Definition zero_opp (C:category) : ZeroObject C -> ZeroObject C^op.
 Proof.
   intro z. induction z as [z k]. exists z.
   induction (opp_opp_precat C).
   exact (pr2 k,,pr1 k).
 Defined.
 
-Definition hasZeroObject (C:Precategory) := ∥ ZeroObject C ∥.
+Definition hasZeroObject (C:category) := ∥ ZeroObject C ∥.
 
-Definition haszero_opp (C:Precategory) : hasZeroObject C -> hasZeroObject C^op
+Definition haszero_opp (C:category) : hasZeroObject C -> hasZeroObject C^op
   := hinhfun (zero_opp C).
 
-Definition zeroMap' (C:Precategory) (a b:ob C) (o:ZeroObject C) : Hom C a b
+Definition zeroMap' (C:category) (a b:ob C) (o:ZeroObject C) : Hom C a b
   := (zero_to_initial C o \\ tt) ∘ (zero_to_terminal C o \\ tt).
 
-Lemma zero_eq_zero_opp (C:Precategory) (a b:ob C) (o:ZeroObject C) :
+Lemma zero_eq_zero_opp (C:category) (a b:ob C) (o:ZeroObject C) :
   zeroMap' C^op (opp_ob b) (opp_ob a) (zero_opp C o)
   =
   opp_mor (zeroMap' C a b o).
@@ -338,7 +338,7 @@ Abort.
 
 (** binary products and coproducts *)
 
-Definition HomPair {C:Precategory} (a b:C) : [C^op,SET].
+Definition HomPair {C:category} (a b:C) : [C^op,SET].
 Proof.
   unshelve refine (makeFunctor_op _ _ _ _).
   - intro c. exact (Hom C c a × Hom C c b) % set.
@@ -350,42 +350,42 @@ Proof.
               apply dirprodeq; apply pathsinv0, assoc) using _C_.
 Defined.
 
-Definition HomPair_1 {C:Precategory} (a b c:C) :
+Definition HomPair_1 {C:category} (a b c:C) :
   (((HomPair a b : C^op ⟶ SET) c : hSet) -> Hom C c a)
   := pr1.
 
-Definition HomPair_2 {C:Precategory} (a b c:C) :
+Definition HomPair_2 {C:category} (a b c:C) :
   (((HomPair a b : C^op ⟶ SET) c : hSet) -> Hom C c b)
   := pr2.
 
-Definition BinaryProduct {C:Precategory} (a b:C) :=
+Definition BinaryProduct {C:category} (a b:C) :=
   Representation (HomPair a b).
 
-Definition hasBinaryProducts (C:Precategory) := ∏ (a b:C), BinaryProduct a b.
+Definition hasBinaryProducts (C:category) := ∏ (a b:C), BinaryProduct a b.
 
-Definition pr_1 {C:Precategory} {a b:C} (prod : BinaryProduct a b) :
+Definition pr_1 {C:category} {a b:C} (prod : BinaryProduct a b) :
   universalObject prod --> a
   := pr1 (universalElement prod).
 
-Definition pr_2 {C:Precategory} {a b:C} (prod : BinaryProduct a b) :
+Definition pr_2 {C:category} {a b:C} (prod : BinaryProduct a b) :
   universalObject prod --> b
   := pr2 (universalElement prod).
 
-Definition binaryProductMap {C:Precategory} {a b:C} (prod : BinaryProduct a b)
+Definition binaryProductMap {C:category} {a b:C} (prod : BinaryProduct a b)
            {c:C} : c --> a -> c --> b -> c --> universalObject prod
   := λ f g, prod \\ (f,,g).
 
-Definition binaryProduct_pr_1_eqn {C:Precategory} {a b:C} (prod : BinaryProduct a b)
+Definition binaryProduct_pr_1_eqn {C:category} {a b:C} (prod : BinaryProduct a b)
       {c:C} (f : c --> a) (g : c --> b) :
   pr_1 prod ∘ binaryProductMap prod f g = f
   := maponpaths (HomPair_1 a b (opp_ob c)) (pr2 (pr1 (pr2 (pr2 prod) c (f,,g)))).
 
-Definition binaryProduct_pr_2_eqn {C:Precategory} {a b:C} (prod : BinaryProduct a b)
+Definition binaryProduct_pr_2_eqn {C:category} {a b:C} (prod : BinaryProduct a b)
       {c:C} (f : c --> a) (g : c --> b) :
   pr_2 prod ∘ binaryProductMap prod f g = g
   := maponpaths (HomPair_2 a b (opp_ob c)) (pr2 (pr1 (pr2 (pr2 prod) c (f,,g)))).
 
-Lemma binaryProductMapUniqueness {C:Precategory} {a b:C} (prod : BinaryProduct a b)
+Lemma binaryProductMapUniqueness {C:category} {a b:C} (prod : BinaryProduct a b)
       {c:C} (f g : Hom C c (universalObject prod)) :
   pr_1 prod ∘ f = pr_1 prod ∘ g ->
   pr_2 prod ∘ f = pr_2 prod ∘ g -> f = g.
@@ -393,7 +393,7 @@ Proof. intros r s. apply mapUniqueness. apply dirprodeq.
        exact r. exact s.
 Defined.
 
-Definition binaryProductMap_2 {C:Precategory} {a b a' b':C}
+Definition binaryProductMap_2 {C:category} {a b a' b':C}
            (prod : BinaryProduct a b)
            (prod' : BinaryProduct a' b')
            (f : a --> a')
@@ -405,51 +405,51 @@ Proof.
   { exact (g ∘ pr_2 prod). }
 Defined.
 
-Definition BinarySum {C:Precategory} (a b:C) :=
+Definition BinarySum {C:category} (a b:C) :=
   BinaryProduct (opp_ob a) (opp_ob b).
 
-Definition hasBinarySums (C:Precategory) := ∏ (a b:C), BinarySum a b.
+Definition hasBinarySums (C:category) := ∏ (a b:C), BinarySum a b.
 
-Lemma binarySumsToProducts {C:Precategory} :
+Lemma binarySumsToProducts {C:category} :
   hasBinarySums C -> hasBinaryProducts C^op.
 Proof. intros sum. exact sum. Defined.
 
-Lemma binaryProductToSums {C:Precategory} :
+Lemma binaryProductToSums {C:category} :
   hasBinaryProducts C -> hasBinarySums C^op.
 Proof. intro prod. exact prod. Defined.
 
-Definition in_1 {C:Precategory} {a b:C} (sum : BinarySum a b) :
+Definition in_1 {C:category} {a b:C} (sum : BinarySum a b) :
   Hom C a (universalObject sum)
   := pr_1 sum.
 
-Definition in_2 {C:Precategory} {a b:C} (sum : BinarySum a b) :
+Definition in_2 {C:category} {a b:C} (sum : BinarySum a b) :
   Hom C b (universalObject sum)
   := pr_2 sum.
 
-Definition binarySumProperty {C:Precategory} {a b c:C} (f:a-->c) (g:b-->c) :=
+Definition binarySumProperty {C:category} {a b c:C} (f:a-->c) (g:b-->c) :=
   isUniversal ((f ,, g) : HomPair (opp_ob a) (opp_ob b) ◾ c : hSet).
 
-Definition binarySumMap {C:Precategory} {a b:C} (sum : BinarySum a b)
+Definition binarySumMap {C:category} {a b:C} (sum : BinarySum a b)
            {c:C} : a --> c -> b --> c -> rm_opp_ob (universalObject sum) --> c
   := λ f g, rm_opp_mor (sum \\ (opp_mor f,,opp_mor g)).
 
-Definition binarySum_in_1_eqn {C:Precategory} {a b:C} (sum : BinarySum a b)
+Definition binarySum_in_1_eqn {C:category} {a b:C} (sum : BinarySum a b)
       {c:C} (f : a --> c) (g : b --> c) :
   binarySumMap sum f g ∘ in_1 sum = f
   := maponpaths (HomPair_1 (opp_ob a) (opp_ob b) c) ((pr2 (pr1 (pr2 (pr2 sum) c (f,,g))))).
 
-Definition binarySum_in_2_eqn {C:Precategory} {a b:C} (sum : BinarySum a b)
+Definition binarySum_in_2_eqn {C:category} {a b:C} (sum : BinarySum a b)
       {c:C} (f : a --> c) (g : b --> c) :
   binarySumMap sum f g ∘ in_2 sum = g
   := maponpaths (HomPair_2 (opp_ob a) (opp_ob b) c) ((pr2 (pr1 (pr2 (pr2 sum) c (f,,g))))).
 
-Lemma binarySumMapUniqueness {C:Precategory} {a b:C} (sum : BinarySum a b)
+Lemma binarySumMapUniqueness {C:category} {a b:C} (sum : BinarySum a b)
       {c:C} (f g : Hom C (rm_opp_ob (universalObject sum)) c) :
   f ∘ in_1 sum = g ∘ in_1 sum ->
   f ∘ in_2 sum = g ∘ in_2 sum -> f = g.
 Proof. intros r s. apply opp_mor_eq, mapUniqueness, dirprodeq; assumption. Defined.
 
-Definition binarySumMap_2 {C:Precategory} {a b a' b':C}
+Definition binarySumMap_2 {C:category} {a b a' b':C}
            (sum : BinarySum a b)
            (sum' : BinarySum a' b')
            (f : a --> a')
@@ -463,7 +463,7 @@ Defined.
 
 (** products and coproducts *)
 
-Definition HomFamily (C:Precategory) {I} (c:I -> ob C) : C^op ⟶ SET.
+Definition HomFamily (C:category) {I} (c:I -> ob C) : C^op ⟶ SET.
 Proof.
   unshelve refine (_,,_).
   - unshelve refine (_,,_).
@@ -478,38 +478,38 @@ Proof.
       apply pathsinv0, assoc]) using _L_.
 Defined.
 
-Definition Product {C:Precategory} {I} (c:I -> ob C)
+Definition Product {C:category} {I} (c:I -> ob C)
   := Representation (HomFamily C c).
 
-Definition pr_ {C:Precategory} {I} {c:I -> ob C} (prod : Product c) (i:I) :
+Definition pr_ {C:category} {I} {c:I -> ob C} (prod : Product c) (i:I) :
   universalObject prod --> c i
   := universalElement prod i.
 
-Definition productMapExistence {C:Precategory} {I} {c:I -> ob C} (prod : Product c)
+Definition productMapExistence {C:category} {I} {c:I -> ob C} (prod : Product c)
       {a:C} :
   (∏ i, Hom C a (c i)) -> Hom C a (universalObject prod)
   := λ f, prod \\ f.
 
-Lemma productMapUniqueness {C:Precategory} {I} {c:I -> ob C} (prod : Product c)
+Lemma productMapUniqueness {C:category} {I} {c:I -> ob C} (prod : Product c)
       {a:C} (f g : Hom C a (universalObject prod)) :
   (∏ i, pr_ prod i ∘ f = pr_ prod i ∘ g) -> f = g.
 Proof.
   intro e. apply mapUniqueness. apply funextsec; intro i. apply e.
 Defined.
 
-Definition Sum {C:Precategory} {I} (c:I -> ob C)
+Definition Sum {C:category} {I} (c:I -> ob C)
   := Representation (HomFamily C^op c).
 
-Definition in_ {C:Precategory} {I} {c:I -> ob C} (sum : Sum c) (i:I) :
+Definition in_ {C:category} {I} {c:I -> ob C} (sum : Sum c) (i:I) :
   c i --> universalObject sum
   := rm_opp_mor (universalElement sum i).
 
-Definition sumMapExistence {C:Precategory} {I} {c:I -> ob C} (sum : Sum c)
+Definition sumMapExistence {C:category} {I} {c:I -> ob C} (sum : Sum c)
       {a:C} :
   (∏ i, Hom C (c i) a) -> Hom C (universalObject sum) a
   := λ f, f // sum.
 
-Lemma sumMapUniqueness {C:Precategory} {I} {c:I -> ob C} (sum : Sum c)
+Lemma sumMapUniqueness {C:category} {I} {c:I -> ob C} (sum : Sum c)
       {a:C} (f g : Hom C (universalObject sum) a) :
   (∏ i, f ∘ in_ sum i = g ∘ in_ sum i) -> f = g.
 Proof.
@@ -518,7 +518,7 @@ Defined.
 
 (** equalizers and coequalizers *)
 
-Definition Equalization {C:Precategory} {c d:C} (f g:c-->d) :
+Definition Equalization {C:category} {c d:C} (f g:c-->d) :
   C^op ⟶ SET.
 Proof.
   unshelve refine (makeFunctor_op _ _ _ _).
@@ -540,31 +540,31 @@ Proof.
         | apply pathsinv0, assoc ]) using _O_.
 Defined.
 
-Definition Equalizer {C:Precategory} {c d:C} (f g:c-->d) :=
+Definition Equalizer {C:category} {c d:C} (f g:c-->d) :=
   Representation (Equalization f g).
 
-Definition equalizerMap {C:Precategory} {c d:C} {f g:c-->d} (eq : Equalizer f g) :
+Definition equalizerMap {C:category} {c d:C} {f g:c-->d} (eq : Equalizer f g) :
   universalObject eq --> c
   := pr1 (universalElement eq).
 
-Definition equalizerEquation {C:Precategory} {c d:C} {f g:c-->d} (eq : Equalizer f g) :
+Definition equalizerEquation {C:category} {c d:C} {f g:c-->d} (eq : Equalizer f g) :
   f ∘ equalizerMap eq = g ∘ equalizerMap eq
   := pr2 (universalElement eq).
 
-Definition Coequalizer {C:Precategory} {c d:C} (f g:c-->d) :=
+Definition Coequalizer {C:category} {c d:C} (f g:c-->d) :=
   Representation (Equalization (opp_mor f) (opp_mor g)).
 
-Definition coequalizerMap {C:Precategory} {c d:C} {f g:c-->d} (coeq : Coequalizer f g) :
+Definition coequalizerMap {C:category} {c d:C} {f g:c-->d} (coeq : Coequalizer f g) :
   d --> universalObject coeq
   := pr1 (universalElement coeq).
 
-Definition coequalizerEquation {C:Precategory} {c d:C} {f g:c-->d} (coeq : Coequalizer f g) :
+Definition coequalizerEquation {C:category} {c d:C} {f g:c-->d} (coeq : Coequalizer f g) :
   coequalizerMap coeq ∘ f = coequalizerMap coeq ∘ g
   := pr2 (universalElement coeq).
 
 (** pullbacks and pushouts  *)
 
-Definition PullbackCone {C:Precategory} {a b c:C} (f:a-->c) (g:b-->c) :
+Definition PullbackCone {C:category} {a b c:C} (f:a-->c) (g:b-->c) :
   C^op ⟶ SET.
 Proof.
   intros.
@@ -590,39 +590,39 @@ Proof.
         | apply proofirrelevance; apply homset_property]) using _P_.
 Defined.
 
-Definition Pullback {C:Precategory} {a b c:C} (f:a-->c) (g:b-->c) :=
+Definition Pullback {C:category} {a b c:C} (f:a-->c) (g:b-->c) :=
   Representation (PullbackCone f g).
 
-Definition pb_1 {C:Precategory} {a b c:C} {f:a-->c} {g:b-->c} (pb : Pullback f g) :
+Definition pb_1 {C:category} {a b c:C} {f:a-->c} {g:b-->c} (pb : Pullback f g) :
   universalObject pb --> a
   := pr1 (pr1 (universalElement pb)).
 
-Definition pb_2 {C:Precategory} {a b c:C} {f:a-->c} {g:b-->c} (pb : Pullback f g) :
+Definition pb_2 {C:category} {a b c:C} {f:a-->c} {g:b-->c} (pb : Pullback f g) :
   universalObject pb --> b
   := pr2 (pr1 (universalElement pb)).
 
-Definition pb_eqn {C:Precategory} {a b c:C} {f:a-->c} {g:b-->c} (pb : Pullback f g) :
+Definition pb_eqn {C:category} {a b c:C} {f:a-->c} {g:b-->c} (pb : Pullback f g) :
   f ∘ pb_1 pb = g ∘ pb_2 pb
   := pr2 (universalElement pb).
 
-Definition Pushout {C:Precategory} {a b c:C} (f:a-->b) (g:a-->c) :=
+Definition Pushout {C:category} {a b c:C} (f:a-->b) (g:a-->c) :=
   Representation (PullbackCone (opp_mor f) (opp_mor g)).
 
-Definition po_1 {C:Precategory} {a b c:C} {f:a-->b} {g:a-->c} (po : Pushout f g) :
+Definition po_1 {C:category} {a b c:C} {f:a-->b} {g:a-->c} (po : Pushout f g) :
   b --> universalObject po
   := pr1 (pr1 (universalElement po)).
 
-Definition po_2 {C:Precategory} {a b c:C} {f:a-->b} {g:a-->c} (po : Pushout f g) :
+Definition po_2 {C:category} {a b c:C} {f:a-->b} {g:a-->c} (po : Pushout f g) :
   c --> universalObject po
   := pr2 (pr1 (universalElement po)).
 
-Definition po_eqn {C:Precategory} {a b c:C} {f:a-->c} {g:a-->c} (po : Pushout f g) :
+Definition po_eqn {C:category} {a b c:C} {f:a-->c} {g:a-->c} (po : Pushout f g) :
   po_1 po ∘ f = po_2 po ∘ g
   := pr2 (universalElement po).
 
 (** kernels and cokernels *)
 
-Definition Annihilator (C:Precategory) (zero:hasZeroMaps C) {c d:C} (f:c --> d) :
+Definition Annihilator (C:category) (zero:hasZeroMaps C) {c d:C} (f:c --> d) :
   C^op ⟶ SET.
 Proof.
   unshelve refine (_,,_).
@@ -646,33 +646,33 @@ Proof.
       | simpl; unfold opp_mor; apply pathsinv0, assoc ] ]) using _N_. }
 Defined.
 
-Definition Kernel {C:Precategory} (zero:hasZeroMaps C) {c d:ob C} (f:c --> d) :=
+Definition Kernel {C:category} (zero:hasZeroMaps C) {c d:ob C} (f:c --> d) :=
   Representation (Annihilator C zero f).
 
-Definition Cokernel {C:Precategory} (zero:hasZeroMaps C) {c d:ob C} (f:c --> d) :=
+Definition Cokernel {C:category} (zero:hasZeroMaps C) {c d:ob C} (f:c --> d) :=
   Representation (Annihilator C^op (hasZeroMaps_opp C zero) f).
 
-Definition kernelMap {C:Precategory} {zero:hasZeroMaps C} {c d:ob C} {f:c --> d}
+Definition kernelMap {C:category} {zero:hasZeroMaps C} {c d:ob C} {f:c --> d}
            (r : Kernel zero f) : universalObject r --> c
   := pr1 (universalElement r).
 
-Definition kernelEquation {C:Precategory} {zero:hasZeroMaps C} {c d:ob C} {f:c --> d}
+Definition kernelEquation {C:category} {zero:hasZeroMaps C} {c d:ob C} {f:c --> d}
            (ker : Kernel zero f) :
   f ∘ kernelMap ker = pr1 zero _ _
   := pr2 (universalElement ker).
 
-Definition cokernelMap {C:Precategory} {zero:hasZeroMaps C} {c d:ob C} {f:c --> d}
+Definition cokernelMap {C:category} {zero:hasZeroMaps C} {c d:ob C} {f:c --> d}
            (r : Cokernel zero f) : d --> universalObject r
   := pr1 (universalElement r).
 
-Definition cokernelEquation {C:Precategory} {zero:hasZeroMaps C} {c d:ob C} {f:c --> d}
+Definition cokernelEquation {C:category} {zero:hasZeroMaps C} {c d:ob C} {f:c --> d}
            (coker : Cokernel zero f) :
   cokernelMap coker ∘ f = pr1 zero _ _
   := pr2 (universalElement coker).
 
 (** fibers of maps between functors *)
 
-Definition fiber {C:Precategory} {X Y:[C^op,SET]} (p : X --> Y) {c:C} (y : c ⇒ Y) :
+Definition fiber {C:category} {X Y:[C^op,SET]} (p : X --> Y) {c:C} (y : c ⇒ Y) :
   C^op ⟶ SET.
 Proof.
   unshelve refine (makeFunctor_op _ _ _ _).
@@ -701,19 +701,19 @@ Defined.
 (* this is representability of a map between two functors, in the sense of
    Grothendieck.  See EGA Chapter 0. *)
 
-Definition Representation_Map {C:Precategory} {X Y:[C^op,SET]} (p : X --> Y) :=
+Definition Representation_Map {C:category} {X Y:[C^op,SET]} (p : X --> Y) :=
   ∏ (c : C) (y : c ⇒ Y), Representation (fiber p y).
 
-Definition isRepresentable_Map {C:Precategory} {X Y:[C^op,SET]} (p : X --> Y) :=
+Definition isRepresentable_Map {C:category} {X Y:[C^op,SET]} (p : X --> Y) :=
   ∏ (c : C) (y : c ⇒ Y), isRepresentable (fiber p y).
 
 (** limits and colimits  *)
 
-Definition cone {I C:Precategory} (c:C) (D: [I,C]) : UU
+Definition cone {I C:category} (c:C) (D: [I,C]) : UU
   := ∑ (φ : ∏ i, Hom C c (D ◾ i)),
      ∏ i j (e : i --> j), D ▭ e ∘ φ i = φ j.
 
-Lemma cone_eq {C I:Precategory} (c:C^op) (D: I⟶C) (p q:cone (C:=C) c D) :
+Lemma cone_eq {C I:category} (c:C^op) (D: I⟶C) (p q:cone (C:=C) c D) :
   pr1 p ~ pr1 q -> p = q.
 Proof.
   intros h. apply subtypeEquality.
@@ -725,7 +725,7 @@ Proof.
   apply funextsec; intro i; apply h.
 Qed.
 
-Definition cone_functor {I C:Precategory} : [I,C] ⟶ [C^op,SET].
+Definition cone_functor {I C:category} : [I,C] ⟶ [C^op,SET].
 Proof.
   intros.
   unshelve refine (_,,_).
@@ -779,41 +779,41 @@ Proof.
       | intro c; apply funextsec; intro K; apply cone_eq; intros i; apply assoc ]]). }
 Defined.
 
-Definition cocone_functor {I C:Precategory} : [I,C]^op ⟶ [C^op^op,SET] :=
+Definition cocone_functor {I C:category} : [I,C]^op ⟶ [C^op^op,SET] :=
   cone_functor □ functorOp.
 
-Definition Limit {C I:Precategory} (D: I⟶C) := Representation (cone_functor D).
+Definition Limit {C I:category} (D: I⟶C) := Representation (cone_functor D).
 
-Definition Colimit {C I:Precategory} (D: I⟶C) := Representation (cocone_functor D).
+Definition Colimit {C I:category} (D: I⟶C) := Representation (cocone_functor D).
 
-Definition proj_ {C I:Precategory} {D: I⟶C} (lim:Limit D) (i:I) : universalObject lim --> D i.
+Definition proj_ {C I:category} {D: I⟶C} (lim:Limit D) (i:I) : universalObject lim --> D i.
 Proof. intros. exact ((pr1 (universalElement lim) i)). Defined.
 
-Definition inj_ {C I:Precategory} {D: I⟶C} (colim:Colimit D) (i:I) : D i --> universalObject colim.
+Definition inj_ {C I:category} {D: I⟶C} (colim:Colimit D) (i:I) : D i --> universalObject colim.
 Proof. intros. exact ((pr1 (universalElement colim) i)). Defined.
 
-Definition proj_comm {C I:Precategory} {D: I⟶C} (lim:Limit D) {i j:I} (f:i-->j) :
+Definition proj_comm {C I:category} {D: I⟶C} (lim:Limit D) {i j:I} (f:i-->j) :
   # D f ∘ proj_ lim i = proj_ lim j.
 Proof. intros. exact (pr2 (universalElement lim) _ _ f). Defined.
 
-Definition inj_comm {C I:Precategory} {D: I⟶C} (colim:Colimit D) {i j:I} (f:i-->j) :
+Definition inj_comm {C I:category} {D: I⟶C} (colim:Colimit D) {i j:I} (f:i-->j) :
   inj_ colim j ∘ # D f = inj_ colim i.
 Proof. intros. exact (pr2 (universalElement colim) _ _ f). Defined.
 
-Definition hasLimits (C:Precategory) := ∏ (I:Precategory) (D: I⟶C), Limit D.
+Definition hasLimits (C:category) := ∏ (I:category) (D: I⟶C), Limit D.
 
-Definition hasColimits (C:Precategory) := ∏ (I:Precategory) (D: I⟶C), Colimit D.
+Definition hasColimits (C:category) := ∏ (I:category) (D: I⟶C), Colimit D.
 
-Definition lim_functor (C:Precategory) (lim:hasLimits C) (I:Precategory) :
+Definition lim_functor (C:category) (lim:hasLimits C) (I:category) :
   [I,C] ⟶ C
   := universalObjectFunctor C □ addStructure cone_functor (lim I).
 
-Definition colim_functor (C:Precategory) (colim:hasColimits C) (I:Precategory) :
+Definition colim_functor (C:category) (colim:hasColimits C) (I:category) :
   [I,C] ⟶ C
   := functorRmOp (
          universalObjectFunctor C^op □ addStructure cocone_functor (colim I)).
 
-Lemma bifunctor_assoc_repn {B C:Precategory} (X : [B, [C^op,SET]]) :
+Lemma bifunctor_assoc_repn {B C:category} (X : [B, [C^op,SET]]) :
   (∏ b, Representation (X ◾ b)) -> Representation (bifunctor_assoc X).
 Proof.
   intro r. set (X' := addStructure X r).
@@ -856,7 +856,7 @@ Proof.
                   exact (maponpaths (λ k, pr1 k b) e)]) using _M_. } }
 Defined.
 
-Theorem functorPrecategoryTerminalObject (B C:Precategory) :
+Theorem functorcategoryTerminalObject (B C:category) :
   TerminalObject C -> TerminalObject [B,C].
 Proof.
   intro t.
@@ -878,11 +878,11 @@ Proof.
 Defined.
 
 Goal ∏ B C t b,
-       universalObject(functorPrecategoryTerminalObject B C t) ◾ b = universalObject t.
+       universalObject(functorcategoryTerminalObject B C t) ◾ b = universalObject t.
   reflexivity.
 Defined.
 
-Definition binaryProductFunctor {B C:Precategory} (F G:[B,C]) : [B,[C^op,SET]].
+Definition binaryProductFunctor {B C:category} (F G:[B,C]) : [B,[C^op,SET]].
 Proof.
   unshelve refine (makeFunctor _ _ _ _).
   - intro b. exact (HomPair (F ◾ b) (G ◾ b)).
@@ -903,7 +903,7 @@ Proof.
       ( simpl; rewrite functor_on_comp; rewrite assoc; reflexivity) ]) using _L_.
 Defined.
 
-Lemma BinaryProductFunctorAssoc {B C : Precategory}
+Lemma BinaryProductFunctorAssoc {B C : category}
       (prod : hasBinaryProducts C)
       (F G : [B, C]) :
   iso (bifunctor_assoc (binaryProductFunctor F G)) (HomPair F G).
@@ -943,7 +943,7 @@ Proof.
                 | intros b; unfold makeNattrans; simpl; reflexivity ] )) using _L_. }
 Defined.
 
-Theorem functorBinaryProduct {B C:Precategory} :
+Theorem functorBinaryProduct {B C:category} :
   hasBinaryProducts C -> hasBinaryProducts [B,C].
 Proof.
   intros prod F G. unshelve refine (iso_Representation_weq _ _).
@@ -952,21 +952,21 @@ Proof.
   { apply bifunctor_assoc_repn. intro b. apply prod. }
 Defined.
 
-Lemma functorBinaryProduct_eqn {B C:Precategory} (prod : hasBinaryProducts C)
+Lemma functorBinaryProduct_eqn {B C:category} (prod : hasBinaryProducts C)
       (F G : [B,C]) (b:B) :
   universalObject (functorBinaryProduct prod F G) ◾ b
   =
   universalObject (prod (F ◾ b) (G ◾ b)).
 Proof. reflexivity. Defined.
 
-Lemma functorBinaryProduct_map_eqn {B C:Precategory} (prod : hasBinaryProducts C)
+Lemma functorBinaryProduct_map_eqn {B C:category} (prod : hasBinaryProducts C)
       (F G F' G' : [B,C]) (p:F-->F') (q:G-->G') (b:B) :
   binaryProductMap_2 (functorBinaryProduct prod F G) (functorBinaryProduct prod F' G') p q ◽ b
   =
   binaryProductMap_2 (prod (F ◾ b) (G ◾ b)) (prod (F' ◾ b) (G' ◾ b)) (p ◽ b) (q ◽ b).
 Proof. reflexivity. Defined.
 
-Lemma HomPairOp {B C : Precategory} (F G : [B, C]) :
+Lemma HomPairOp {B C : category} (F G : [B, C]) :
   iso (HomPair (functorOp F) (functorOp G) □ functorOp')
       (HomPair (opp_ob F) (opp_ob G)).
 (* This should be replaced by a general statement where [B,C]^op and
@@ -982,7 +982,7 @@ Proof.
               ( apply nat_trans_eq; [ apply homset_property | reflexivity ] )). }
 Defined.
 
-Theorem functorBinarySum {B C:Precategory} :
+Theorem functorBinarySum {B C:category} :
   hasBinarySums C -> hasBinarySums [B,C].
 Proof.
   intros sum F G.
@@ -993,14 +993,14 @@ Proof.
            (HomPairOp F G)).
 Defined.
 
-Lemma functorBinarySum_eqn {B C:Precategory} (sum : hasBinarySums C)
+Lemma functorBinarySum_eqn {B C:category} (sum : hasBinarySums C)
       (F G : [B,C]) (b:B) :
   universalObject (functorBinarySum sum F G) ◾ b
   =
   universalObject (sum (F ◾ b) (G ◾ b)).
 Proof. reflexivity. Defined.
 
-Lemma functorBinarySum_map_eqn {B C:Precategory} (sum : hasBinarySums C)
+Lemma functorBinarySum_map_eqn {B C:category} (sum : hasBinarySums C)
       (F G F' G' : [B,C]) (p:F-->F') (q:G-->G') (b:B) :
   binarySumMap_2 (functorBinarySum sum F G) (functorBinarySum sum F' G') p q ◽ b
   =
@@ -1016,7 +1016,7 @@ Proof.
      (universalObject sum)] *)
 Abort.
 
-Theorem functorLimits (B C:Precategory) : hasLimits C -> hasLimits [B,C].
+Theorem functorLimits (B C:category) : hasLimits C -> hasLimits [B,C].
 Proof.
   intros lim I D.
   unfold hasLimits, Limit in lim.
@@ -1028,7 +1028,7 @@ Proof.
 
 Abort.
 
-Theorem functorColimits (B C:Precategory) : hasColimits C -> hasColimits [B,C].
+Theorem functorColimits (B C:category) : hasColimits C -> hasColimits [B,C].
 Proof.
 Abort.
 

--- a/UniMath/Ktheory/Test.v
+++ b/UniMath/Ktheory/Test.v
@@ -20,7 +20,7 @@ Require UniMath.Ktheory.Precategories.
 
 Section interface.
 
-Variable C : Precategory.
+Variable C : category.
 
 Set Automatic Introduction.
 
@@ -186,7 +186,7 @@ End interface.
 
 Section def_functor_pointwise_coprod.
 
-Variable C D : Precategory.
+Variable C D : category.
 Variable HD : Coproducts D.
 
 Definition hsD := homset_property D.
@@ -195,7 +195,7 @@ Section coproduct_functor.
 
 Variables F G : functor C D.
 
-Definition Coproducts_functor_precat : Coproducts (functor_Precategory C D).
+Definition Coproducts_functor_precat : Coproducts (functor_category C D).
 Proof.
   apply functorBinarySum.
   exact HD.

--- a/UniMath/SubstitutionSystems/CCS.v
+++ b/UniMath/SubstitutionSystems/CCS.v
@@ -76,7 +76,7 @@ Definition sort : hSet := @tpair _ (λ X, isaset X) bool isasetbool.
 Definition ty : sort := true.
 Definition el : sort := false.
 
-Local Definition SET_over_sort : Precategory.
+Local Definition SET_over_sort : category.
 Proof.
 exists (SET / sort).
 now apply has_homsets_slice_precat.

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -62,7 +62,7 @@ Definition Signature : ∏ C : precategory, has_homsets C → ∏ D : precategor
 
 (** Definition 5: Morphism of signatures with strength *)
 Definition SignatureMor :
-  ∏ C D : Precategory,
+  ∏ C D : category,
        Signatures.Signature C (homset_property C) D (homset_property D)
        → Signatures.Signature C (homset_property C) D (homset_property D) → UU :=
   @UniMath.SubstitutionSystems.SignatureCategory.SignatureMor.

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -55,7 +55,7 @@ Local Open Scope cat.
 
 Local Coercion alg_carrier : algebra_ob >-> ob.
 
-Section Precategory_Algebra.
+Section category_Algebra.
 
 Variable C : precategory.
 Variable hs : has_homsets C.
@@ -882,4 +882,4 @@ Proof.
 Defined.
 
 
-End Precategory_Algebra.
+End category_Algebra.

--- a/UniMath/SubstitutionSystems/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial_alt.v
@@ -45,7 +45,7 @@ Local Open Scope cat.
 
 Local Coercion alg_carrier : algebra_ob >-> ob.
 
-Section Precategory_Algebra.
+Section category_Algebra.
 
 Variables (C : precategory) (hsC : has_homsets C) (CP : BinCoproducts C).
 Variables (IC : Initial C) (CC : Colims_of_shape nat_graph C).
@@ -665,4 +665,4 @@ Proof.
 apply (mk_Initial InitHSS), isInitial_InitHSS.
 Defined.
 
-End Precategory_Algebra.
+End category_Algebra.

--- a/UniMath/SubstitutionSystems/MonadsMultiSorted.v
+++ b/UniMath/SubstitutionSystems/MonadsMultiSorted.v
@@ -35,7 +35,7 @@ Section MonadsInSET_over_sort.
 
 Variables (sort : hSet).
 
-Definition SET_over_sort : Precategory.
+Definition SET_over_sort : category.
 Proof.
 exists (SET / sort).
 now apply has_homsets_slice_precat.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -89,7 +89,7 @@ Section MBindingSig.
 
 Variables (sort : hSet).
 
-Local Definition SET_over_sort : Precategory.
+Local Definition SET_over_sort : category.
 Proof.
 exists (SET / sort).
 now apply has_homsets_slice_precat.
@@ -545,7 +545,7 @@ Require Import UniMath.CategoryTheory.EquivalencesExamples.
 Section MBindingSig.
 
 Variables (sort : UU) (eq : isdeceq sort). (* Can we eliminate this assumption? *)
-Variables (C : Precategory) (BP : BinProducts C) (BC : BinCoproducts C) (TC : Terminal C).
+Variables (C : category) (BP : BinProducts C) (BC : BinCoproducts C) (TC : Terminal C).
 
 (** Define the discrete category of sorts *)
 Let sort_cat : precategory := discrete_precategory sort.
@@ -553,7 +553,7 @@ Let sort_cat : precategory := discrete_precategory sort.
 Let hsC : has_homsets C := homset_property C.
 
 (** This represents "sort → C" *)
-Let sortToC : Precategory := [sort_cat,C].
+Let sortToC : category := [sort_cat,C].
 
 Local Lemma has_homsets_sortToC : has_homsets sortToC.
 Proof.
@@ -568,7 +568,7 @@ Defined.
 Local Definition mk_sortToC (f : sort → C) : sortToC :=
   functor_discrete_precategory _ _ f.
 
-Local Definition proj_gen_fun (D : precategory) (E : Precategory) (d : D) : functor [D,E] E.
+Local Definition proj_gen_fun (D : precategory) (E : category) (d : D) : functor [D,E] E.
 Proof.
 mkpair.
 + mkpair.
@@ -577,7 +577,7 @@ mkpair.
 + abstract (split; [intro f; apply idpath|intros f g h fg gh; apply idpath]).
 Defined.
 
-Local Definition proj_gen {D : precategory} {E : Precategory} : functor D [[D,E],E].
+Local Definition proj_gen {D : precategory} {E : category} : functor D [[D,E],E].
 Proof.
 mkpair.
 + mkpair.
@@ -719,7 +719,7 @@ Defined.
 
 
 (* From here on things are not so nice: *)
-Local Definition MultiSortedSigToFunctor_helper1 (C1 D E1 : precategory) (E2 : Precategory)
+Local Definition MultiSortedSigToFunctor_helper1 (C1 D E1 : precategory) (E2 : category)
   : functor [E1,[C1,[D,E2]]] [E1,[D,[C1,E2]]].
 Proof.
 eapply post_composition_functor.
@@ -728,7 +728,7 @@ Defined.
 
 (* This lemma is just here to check that the correct sort_cat gets pulled out when reorganizing *)
 (*    arguments *)
-Local Definition MultiSortedSigToFunctor_helper (C1 D E1 : precategory) (E2 : Precategory) :
+Local Definition MultiSortedSigToFunctor_helper (C1 D E1 : precategory) (E2 : category) :
   functor [E1,[C1,[D,E2]]] [C1,[D,[E1,E2]]].
 Proof.
 eapply (functor_composite (functor_cat_swap _ _ _)).
@@ -740,12 +740,12 @@ Defined.
 (* The above definition might be the same as: *)
 (* functor_composite (functor_cat_swap F) functor_cat_swap. *)
 
-(* Local Definition MultiSortedSigToFunctor_helper (C1 D E1 : precategory) (E2 : Precategory) *)
+(* Local Definition MultiSortedSigToFunctor_helper (C1 D E1 : precategory) (E2 : category) *)
 (*   (F : functor E1 [C1,[D,E2]]) : functor C1 [D,[E1,E2]]. *)
 (*     functor_composite (functor_cat_swap F) functor_cat_swap. *)
 
 
-(* Lemma is_omega_cocont_MultiSortedSigToFunctor_helper (C1 D E1 : precategory) (E2 : Precategory) *)
+(* Lemma is_omega_cocont_MultiSortedSigToFunctor_helper (C1 D E1 : precategory) (E2 : category) *)
 (*   (F : functor E1 [C1,[D,E2]]) (HF : ∏ s, is_omega_cocont (F s)) : *)
 (*   is_omega_cocont (MultiSortedSigToFunctor_helper C1 D E1 E2 F). *)
 (* Proof. *)
@@ -755,7 +755,7 @@ Defined.
 (* + apply is_omega_cocont_functor_cat_swap. *)
 (* Admitted. *)
 
-(* Local Definition MultiSortedSigToFunctor_helper2 (C1 D E1 : precategory) (E2 : Precategory) : *)
+(* Local Definition MultiSortedSigToFunctor_helper2 (C1 D E1 : precategory) (E2 : category) : *)
 (*   functor [E1,[D,[C1,E2]]] [C1,[D,[E1,E2]]]. *)
 (* Proof. *)
 (* eapply functor_composite;[apply functor_cat_swap|]. *)

--- a/UniMath/SubstitutionSystems/STLC.v
+++ b/UniMath/SubstitutionSystems/STLC.v
@@ -57,7 +57,7 @@ Local Notation "[]" := (@nil _) (at level 0, format "[]").
 Local Notation "C / X" := (slice_precat C X (homset_property C)).
 Local Notation "a + b" := (setcoprod a b) : set.
 
-Local Definition SET_over_sort : Precategory.
+Local Definition SET_over_sort : category.
 Proof.
 exists (SET / sort).
 now apply has_homsets_slice_precat.

--- a/UniMath/SubstitutionSystems/SignatureCategory.v
+++ b/UniMath/SubstitutionSystems/SignatureCategory.v
@@ -31,12 +31,12 @@ Require Import UniMath.SubstitutionSystems.SumOfSignatures.
 
 Local Open Scope cat.
 
-Local Notation "[ C , D ]" := (functor_Precategory C D).
+Local Notation "[ C , D ]" := (functor_category C D).
 
 (** * The category of signatures with strength *)
 Section SignatureCategory.
 
-Variables (C D : Precategory).
+Variables (C D : category).
 
 Let hsC : has_homsets C := homset_property C.
 Let hsD : has_homsets D := homset_property D.
@@ -174,7 +174,7 @@ End SignatureCategory.
 (** * Binary products in the category of signatures *)
 Section BinProducts.
 
-Variables (C : Precategory) (BC : BinProducts C) (D : Precategory) (BD : BinProducts D).
+Variables (C : category) (BC : BinProducts C) (D : category) (BD : BinProducts D).
 
 Let hsC : has_homsets C := homset_property C.
 Let hsD : has_homsets D := homset_property D.
@@ -266,7 +266,7 @@ End BinProducts.
 Section Coproducts.
 
 Variables (I : UU).
-Variables (C D : Precategory) (CD : Coproducts I D).
+Variables (C D : category) (CD : Coproducts I D).
 
 Let hsC : has_homsets C := homset_property C.
 Let hsD : has_homsets D := homset_property D.

--- a/UniMath/SubstitutionSystems/SignatureExamples.v
+++ b/UniMath/SubstitutionSystems/SignatureExamples.v
@@ -502,10 +502,10 @@ End id_signature.
 
 Section constantly_constant_signature.
 
-  Variable (C D : Precategory).
+  Variable (C D : category).
   Variable (d : D).
 
-  Let H := constant_functor (functor_Precategory C C) (functor_Precategory C D) (constant_functor C D d).
+  Let H := constant_functor (functor_category C C) (functor_category C D) (constant_functor C D d).
 
   Definition θ_const_const : ∑
   θ : θ_source H  ⟹ θ_target H, θ_Strength1_int θ × θ_Strength2_int θ.


### PR DESCRIPTION
This PR renames `Precategory` to `category`.

The renaming destroyed some CamlCase where "Precategory" occurred in the middle of a word and I replaced it by "category" for uniformity.

I did not rename section titles of the form "Precategory of foo", since it seemed to me that capitalization here stems from the fact that it is the first word of a section title.

I have not renamed files that carry "Precategory" in their names.