### PR TITLE
stop ignoring all warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ $(VFILES:.v=.vo) : $(COQBIN)coqc
 endif
 
 OTHERFLAGS += $(MOREFLAGS)
-OTHERFLAGS += -indices-matter -type-in-type -w none
+OTHERFLAGS += -indices-matter -type-in-type -w '-notation-overridden,-local-declaration,+uniform-inheritance'
 ifeq ($(VERBOSE),yes)
 OTHERFLAGS += -verbose
 endif

--- a/UniMath/Algebra/Domains_and_Fields.v
+++ b/UniMath/Algebra/Domains_and_Fields.v
@@ -60,7 +60,7 @@ Definition iscancelableif {X : hSet} (opp : binop X) (x : X)
 
 (** To monoids *)
 
-Open Local Scope  multmonoid_scope.
+Local Open Scope multmonoid_scope.
 
 Definition linvpair (X : monoid) (x : X) : UU := total2 (fun x' : X => paths (x' * x) 1).
 

--- a/UniMath/Algebra/Tests.v
+++ b/UniMath/Algebra/Tests.v
@@ -1,9 +1,14 @@
 Unset Automatic Introduction.
 
+Require UniMath.Algebra.IteratedBinaryOperations.
+Require UniMath.Foundations.NaturalNumbers.
+Require UniMath.Algebra.IteratedBinaryOperations.
+Require UniMath.Combinatorics.FiniteSets.
+
 Module Test_assoc.
 
-  Require Import UniMath.Algebra.IteratedBinaryOperations.
-  Require Import UniMath.Foundations.NaturalNumbers.
+  Import UniMath.Algebra.IteratedBinaryOperations.
+  Import UniMath.Foundations.NaturalNumbers.
 
   (* verify that our associativity matches that of the parser, without an extra "1" *)
 
@@ -46,8 +51,8 @@ End Test_assoc.
 
 Module Test_finsum.
 
-  Require Import UniMath.Algebra.IteratedBinaryOperations.
-  Require Import UniMath.Combinatorics.FiniteSets.
+  Import UniMath.Algebra.IteratedBinaryOperations.
+  Import UniMath.Combinatorics.FiniteSets.
 
   Goal ∏ X (fin : finstruct X) (f : X -> nat),
     finsum (hinhpr fin) f = stnsum (f ∘ pr1weq (pr2 fin)).

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -1683,7 +1683,7 @@ End functor_swap.
 (** * The forgetful functor from Set/X to Set preserves colimits *)
 Section cocont_slicecat_to_cat_HSET.
 
-Local Notation "HSET / X" := (slice_precat HSET X has_homsets_HSET).
+Local Notation "HSET / X" := (slice_precat HSET X has_homsets_HSET) (only parsing).
 
 Lemma preserves_colimit_slicecat_to_cat_HSET (X : HSET)
   (g : graph) (d : diagram g (HSET / X)) (L : HSET / X) (ccL : cocone d L) :

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -754,7 +754,7 @@ End exponentials_functor_cat.
 (** * Various results on Set/X *)
 Section set_slicecat.
 
-Local Notation "HSET / X" := (slice_precat HSET X has_homsets_HSET).
+Local Notation "HSET / X" := (slice_precat HSET X has_homsets_HSET) (only parsing).
 
 Lemma Terminal_HSET_slice X : Terminal (HSET / X).
 Proof.

--- a/UniMath/CategoryTheory/limits/cones.v
+++ b/UniMath/CategoryTheory/limits/cones.v
@@ -331,5 +331,5 @@ End CONE_category.
 
 End Cone.
 
-Implicit Arguments CONE [J C].
-Implicit Arguments ConeConnect [J C].
+Arguments CONE [J C].
+Arguments ConeConnect [J C].

--- a/UniMath/CategoryTheory/limits/graphs/limits.v
+++ b/UniMath/CategoryTheory/limits/graphs/limits.v
@@ -534,10 +534,11 @@ End map.
 
 (** Put in a module for namespace reasons *)
 
+Require UniMath.CategoryTheory.opp_precat.
 
 Module co.
 
-Require Import UniMath.CategoryTheory.opp_precat.
+Import UniMath.CategoryTheory.opp_precat.
 
 Section lim_def.
 

--- a/UniMath/Combinatorics/Tests.v
+++ b/UniMath/Combinatorics/Tests.v
@@ -1,8 +1,16 @@
 Unset Automatic Introduction.
 
+Require UniMath.Combinatorics.Lists.
+Require UniMath.Combinatorics.StandardFiniteSets.
+Require UniMath.Combinatorics.FiniteSets.
+Require UniMath.Combinatorics.FiniteSequences.
+Require UniMath.Combinatorics.FiniteSets.
+Require UniMath.Combinatorics.OrderedSets.
+Require UniMath.Combinatorics.StandardFiniteSets.
+
 Module Test_list.
 
-  Require Import UniMath.Combinatorics.Lists.
+  Import UniMath.Combinatorics.Lists.
 
   Local Notation "[]" := nil (at level 0, format "[]").
   Local Infix "::" := cons.
@@ -19,7 +27,7 @@ End Test_list.
 
 Module Test_stn.
 
-  Require Import UniMath.Combinatorics.StandardFiniteSets.
+  Import UniMath.Combinatorics.StandardFiniteSets.
 
   Local Open Scope stn.
 
@@ -233,7 +241,7 @@ End Test_stn.
 
 Module Test_fin.
 
-  Require Import UniMath.Combinatorics.FiniteSets.
+  Import UniMath.Combinatorics.FiniteSets.
 
   (** ** Test computations. *)
   Goal fincard (isfiniteempty) = 0. reflexivity. Qed.
@@ -333,14 +341,14 @@ End Test_fin.
 
 Module Test_seq.
 
-  Require Import UniMath.Combinatorics.FiniteSequences.
+  Import UniMath.Combinatorics.FiniteSequences.
 
   Local Open Scope stn.
 
 End Test_seq.
 
 Module Test_finite_sets.
-  Require Import UniMath.Combinatorics.FiniteSets.
+  Import UniMath.Combinatorics.FiniteSets.
   Local Open Scope stn.
 
   Goal 3 = fincard_standardSubset (λ i:stn 10, 2*i < 6)%dnat. Proof. reflexivity. Defined.
@@ -353,8 +361,8 @@ End Test_finite_sets.
 
 Module Test_ord.
 
-  Require Import UniMath.Combinatorics.OrderedSets.
-  Require Import UniMath.Combinatorics.StandardFiniteSets.
+  Import UniMath.Combinatorics.OrderedSets.
+  Import UniMath.Combinatorics.StandardFiniteSets.
 
   Local Open Scope stn.
 

--- a/UniMath/Foundations/Tests.v
+++ b/UniMath/Foundations/Tests.v
@@ -65,9 +65,11 @@ Goal invmap (weqtotal2overunit (λ _,nat)) 3 = (tt,,3). reflexivity. Defined.
 Goal iscontr = isofhlevel 0. reflexivity. Defined.
 Goal isaset = isofhlevel 2.  reflexivity. Defined.
 
+Require UniMath.Foundations.Sets.
+
 Module Test_sets.
 
-  Require Import UniMath.Foundations.Sets.
+  Import UniMath.Foundations.Sets.
 
   Goal ∏ Y (is:isaset Y) (F:Y->UU) (e :∏ y y', F y -> F y' -> y=y')
          y (f:F y), squash_pairs_to_set F is e (hinhpr (y,,f)) = y.

--- a/UniMath/Ktheory/AbelianGroup.v
+++ b/UniMath/Ktheory/AbelianGroup.v
@@ -470,9 +470,12 @@ Definition power (I:Type) (X:abgr) : abgr.
 
 (** ** the category of abelian groups *)
 
+Require UniMath.Algebra.Monoids_and_Groups
+        UniMath.CategoryTheory.Categories.
+
 Module Category.
-  Require Import UniMath.Algebra.Monoids_and_Groups
-                 UniMath.CategoryTheory.Categories.
+  Import UniMath.Algebra.Monoids_and_Groups
+         UniMath.CategoryTheory.Categories.
 
   Definition Ob := abgr.
 

--- a/UniMath/Ktheory/Monoid.v
+++ b/UniMath/Ktheory/Monoid.v
@@ -32,9 +32,11 @@ Proof. intros. exists (zero_map A zero).
        intros [f e]. apply funEquality; simpl.
        apply funextsec; intro a. induction (f a). reflexivity. Defined.
 
+Require UniMath.Combinatorics.FiniteSequences.
+
 Module Presentation'.
 
-  Require Import UniMath.Combinatorics.FiniteSequences.
+  Import UniMath.Combinatorics.FiniteSequences.
 
   Definition word X := Sequence X.
   Definition word_length {X} : word X -> nat := length.

--- a/UniMath/MoreFoundations/Subtypes.v
+++ b/UniMath/MoreFoundations/Subtypes.v
@@ -104,8 +104,6 @@ Notation "⋃ S" := (subtype_union S) (at level 100, no associativity) : subtype
 Definition carrier_set {X : hSet} (S : hsubtype X) : hSet :=
   hSetpair (carrier S) (isaset_carrier_subset _ S).
 
-Coercion carrier_set : hsubtype >-> hSet.
-
 Definition subtype_union_containedIn {X:hSet} {I:UU} (S : I -> hsubtype X) i : S i ⊆ ⋃ S
   := λ x s, hinhpr (i,,s).
 

--- a/UniMath/NumberSystems/Integers.v
+++ b/UniMath/NumberSystems/Integers.v
@@ -84,7 +84,7 @@ Definition hzdecneq : decrel hz := decrelpair isdecrelhzneq .
 Definition hzboolneq := decreltobrel hzdecneq .
 
 
-Open Local Scope hz_scope .
+Local Open Scope hz_scope .
 
 
 (** *** [ hz ] is a non-zero ring *)
@@ -1034,7 +1034,7 @@ Local Transparent hz isdecrelhzeq iscommrngops.
 
 (** *** [hz] is an archimedean ring *)
 
-Open Local Scope hz_scope .
+Local Open Scope hz_scope .
 
 Lemma isarchhz : isarchrng (X := hz) hzgth.
 Proof.

--- a/UniMath/NumberSystems/RationalNumbers.v
+++ b/UniMath/NumberSystems/RationalNumbers.v
@@ -79,11 +79,11 @@ Definition hqdecneq : decrel hq := decrelpair isdecrelhqneq .
 
 Definition hqboolneq := decreltobrel hqdecneq .
 
-Open Local Scope hz_scope .
+Local Open Scope hz_scope .
 
 (** *** Properties of addition and subtraction on [ hq ] *)
 
-Open Local Scope hq_scope .
+Local Open Scope hq_scope .
 
 Lemma hqplusr0 ( x : hq ) : paths ( x + 0 ) x .
 Proof . intro . apply ( rngrunax1 _ x ) .  Defined .

--- a/UniMath/NumberSystems/Tests.v
+++ b/UniMath/NumberSystems/Tests.v
@@ -1,10 +1,12 @@
 Unset Automatic Introduction.
 
+Require UniMath.Foundations.NaturalNumbers.
+
 Module Test_nat.
 
-  Local Open Scope nat_scope.
+  Import UniMath.Foundations.NaturalNumbers.
 
-  Require Import UniMath.Foundations.NaturalNumbers.
+  Local Open Scope nat_scope.
 
   Goal 3 ≠ 5. easy. Defined.
   Goal ¬ (3 ≠ 3). easy. Defined.
@@ -64,9 +66,11 @@ Module Test_nat.
 
 End Test_nat.
 
+Require UniMath.NumberSystems.Integers.
+
 Module Test_int.
 
-  Require Import UniMath.NumberSystems.Integers.
+  Import UniMath.NumberSystems.Integers.
 
   Goal true = (hzbooleq (natnattohz 3 4) (natnattohz 17 18)) . reflexivity. Qed.
   Goal false = (hzbooleq (natnattohz 3 4) (natnattohz 17 19)) . reflexivity. Qed.
@@ -77,9 +81,11 @@ Module Test_int.
 
 End Test_int.
 
+Require UniMath.NumberSystems.RationalNumbers.
+
 Module Test_rat.
 
-  Require Import UniMath.NumberSystems.RationalNumbers.
+  Import UniMath.NumberSystems.RationalNumbers.
 
   Open Scope hz_scope .
 

--- a/UniMath/RealNumbers/NonnegativeRationals.v
+++ b/UniMath/RealNumbers/NonnegativeRationals.v
@@ -20,7 +20,7 @@ Open Scope hq_scope.
 Definition hnnq_set := subset (hqleh 0).
 
 Local Definition hnnq_set_to_hq (r : hnnq_set) : hq := pr1 r.
-Coercion hnnq_set_to_hq : pr1hSet >-> pr1hSet.
+
 Local Definition hq_to_hnnq_set (r : hq) (Hr : hqleh 0 r) : hnnq_set :=
   r ,, Hr.
 

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -536,10 +536,13 @@ End MBindingSig.
 
 (** Alternative version using [X,SET] instead of SET/X below. There is no proof that the
     functor we obtain using this approach is omega-cocontinuous yet. *)
+Require UniMath.CategoryTheory.DiscreteCategory.
+Require UniMath.CategoryTheory.EquivalencesExamples.
+
 Module alt.
 
-Require Import UniMath.CategoryTheory.DiscreteCategory.
-Require Import UniMath.CategoryTheory.EquivalencesExamples.
+Import UniMath.CategoryTheory.DiscreteCategory.
+Import UniMath.CategoryTheory.EquivalencesExamples.
 
 (** * Definition of multisorted binding signatures *)
 Section MBindingSig.


### PR DESCRIPTION
Now we ignore just two warnings, and we convert one into an error, in
the makefile.  We also fixed some of the code to remove some warnings.

Note: two non-functional coercions were removed:

```
Coercion carrier_set : hsubtype >-> hSet.

Coercion hnnq_set_to_hq : pr1hSet >-> pr1hSet.
```

Resolves #713.