### PR TITLE
Use -arg to pass arguments to COQC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ describe:; git describe --dirty --long --always --abbrev=40 --all
 	echo '# It is made by automatically (by code in Makefile)' ;\
 	echo ;\
 	echo '-Q UniMath UniMath' ;\
+	echo '-arg "$(OTHERFLAGS)"' ;\
 	echo ;\
 	for i in $(PACKAGES) ;\
 	do <UniMath/$$i/.package/files $(FILES_FILTER) |sed "s=^=UniMath/$$i/="  ;\


### PR DESCRIPTION
This patch makes it work with https://github.com/coq/coq/pull/406

BTW, this is the recommended way of passing arguments to COQC (that I discovered not being documented... but is there since, at least, 8.4).

Note that I discourage including a generated Makefile because no matter what we change in such file we break users (i.e. renaming variables for example).  I try to recommend alternatives here https://github.com/coq/coq/pull/406/files#diff-aaaca1f91738f8f7dc4afb4f7e249dbd

In this specific case one can use `-arg` (as in this PR), or do the `+=` magic in the `.local` file (see the link above).
Also note that the `.conf` file (again see the link above) contains all variable (and only that) with names that live in the `COQMF_` name space and is hence safe to include that file in other Makefiles.