### PR TITLE
Capitalize Kleisli

### DIFF
--- a/UniMath/CategoryTheory/Kleisli.v
+++ b/UniMath/CategoryTheory/Kleisli.v
@@ -1,7 +1,7 @@
 (** **********************************************************
 Contents:
-        - "Kleisli" definition of monad [kleisli]
-        - equivalence of this definition and the "monoidal" definition [weq_kleisli_monad]
+        - "Kleisli" definition of monad [Kleisli]
+        - equivalence of this definition and the "monoidal" definition [weq_Kleisli_Monad]
 
 Written by: Joseph Helfer, Matthew Weaver, 2017
 
@@ -15,48 +15,48 @@ Require Import UniMath.CategoryTheory.Monads.
 Local Open Scope cat.
 
 (** * Definition of "Kleisli style" monad *)
-Section kleisli_def.
+Section Kleisli_def.
 
-  Definition kleisli_data (C : precategory) : UU :=
+  Definition Kleisli_data (C : precategory) : UU :=
     ∑ T : C -> C, ((∏ a : C, a --> T a) × (∏ a b : C, a --> T b -> T a --> T b)).
 
-  Definition ob_function_from_kleisli_data {C : precategory} (T : kleisli_data C) := pr1 T.
-  Coercion ob_function_from_kleisli_data : kleisli_data >-> Funclass.
+  Definition ob_function_from_Kleisli_data {C : precategory} (T : Kleisli_data C) := pr1 T.
+  Coercion ob_function_from_Kleisli_data : Kleisli_data >-> Funclass.
 
-  Definition unit {C : precategory} (T : kleisli_data C) := pr1 (pr2 T).
-  Definition bind {C : precategory} (T : kleisli_data C) {a b : C} := pr2 (pr2 T) a b.
+  Definition unit {C : precategory} (T : Kleisli_data C) := pr1 (pr2 T).
+  Definition bind {C : precategory} (T : Kleisli_data C) {a b : C} := pr2 (pr2 T) a b.
 
-  Definition kleisli_laws {C : precategory} (T : kleisli_data C) : UU :=
+  Definition Kleisli_laws {C : precategory} (T : Kleisli_data C) : UU :=
     ((∏ a : C, bind T (unit T a) = identity (T a)) ×
      (∏ (a b : C) (f : a --> T b), unit T a · bind T f = f)) ×
     (∏ (a b c : C) (f : a --> T b) (g : b --> T c), bind T f · bind T g = bind T (f · bind T g)).
 
-  Lemma isaprop_kleisli_laws {C : precategory} (hs : has_homsets C) (T : kleisli_data C) :
-    isaprop (kleisli_laws T).
+  Lemma isaprop_Kleisli_laws {C : precategory} (hs : has_homsets C) (T : Kleisli_data C) :
+    isaprop (Kleisli_laws T).
   Proof.
     do 2 try apply isapropdirprod;
     do 5 try (apply impred; intro);
     apply hs.
   Defined.
 
-  Definition kleisli (C : precategory) : UU := ∑ T : kleisli_data C, kleisli_laws T.
+  Definition Kleisli (C : precategory) : UU := ∑ T : Kleisli_data C, Kleisli_laws T.
 
-  Definition kleisli_data_from_kleisli {C : precategory} (T : kleisli C) : kleisli_data C := pr1 T.
-  Coercion kleisli_data_from_kleisli : kleisli >-> kleisli_data.
+  Definition Kleisli_data_from_Kleisli {C : precategory} (T : Kleisli C) : Kleisli_data C := pr1 T.
+  Coercion Kleisli_data_from_Kleisli : Kleisli >-> Kleisli_data.
 
-  Definition kleisli_law1 {C : precategory} (T : kleisli C) := pr1 (pr1 (pr2 T)).
-  Definition kleisli_law2 {C : precategory} (T : kleisli C) := pr2 (pr1 (pr2 T)).
-  Definition kleisli_law3 {C : precategory} (T : kleisli C) := pr2 (pr2 T).
+  Definition Kleisli_law1 {C : precategory} (T : Kleisli C) := pr1 (pr1 (pr2 T)).
+  Definition Kleisli_law2 {C : precategory} (T : Kleisli C) := pr2 (pr1 (pr2 T)).
+  Definition Kleisli_law3 {C : precategory} (T : Kleisli C) := pr2 (pr2 T).
 
-End kleisli_def.
+End Kleisli_def.
 
 (** * Equivalence of the types of Kleisli monads and "monoidal" monads *)
 Section monad_types_equiv.
-  Definition Monad_to_kleisli {C : precategory} : Monad C → kleisli C :=
+  Definition Monad_to_Kleisli {C : precategory} : Monad C → Kleisli C :=
     fun T => (functor_on_objects T ,, (pr1 (η T) ,, @Monads.bind C T))
                ,, (@Monad_law2 C T ,, @η_bind C T) ,, @bind_bind C T.
 
-  Definition kleisli_to_functor {C : precategory} (T: kleisli C) : C ⟶ C.
+  Definition Kleisli_to_functor {C : precategory} (T: Kleisli C) : C ⟶ C.
   Proof.
     use mk_functor.
     - use mk_functor_data.
@@ -64,40 +64,40 @@ Section monad_types_equiv.
       + exact (fun (a b : C) (f : a --> b) => bind T (f · unit T b)).
     - apply tpair.
       + intro a; simpl.
-        now rewrite id_left, (kleisli_law1 T).
+        now rewrite id_left, (Kleisli_law1 T).
       + intros a b c f g; simpl.
-        now rewrite (kleisli_law3 T), <- !assoc, (kleisli_law2 T).
+        now rewrite (Kleisli_law3 T), <- !assoc, (Kleisli_law2 T).
   Defined.
 
-  Definition kleisli_to_μ {C : precategory} (T: kleisli C) :
-    kleisli_to_functor T ∙ kleisli_to_functor T ⟹ kleisli_to_functor T.
+  Definition Kleisli_to_μ {C : precategory} (T: Kleisli C) :
+    Kleisli_to_functor T ∙ Kleisli_to_functor T ⟹ Kleisli_to_functor T.
   Proof.
     mkpair.
     - exact (fun (x : C) => bind T (identity (T x))).
     - intros x x' f; simpl.
-      now rewrite (kleisli_law3 T), <- assoc, (kleisli_law2 T), id_right, (kleisli_law3 T), id_left.
+      now rewrite (Kleisli_law3 T), <- assoc, (Kleisli_law2 T), id_right, (Kleisli_law3 T), id_left.
   Defined.
 
-  Definition kleisli_to_η {C : precategory} (T: kleisli C) :
-    functor_identity C ⟹ kleisli_to_functor T.
+  Definition Kleisli_to_η {C : precategory} (T: Kleisli C) :
+    functor_identity C ⟹ Kleisli_to_functor T.
   Proof.
     mkpair.
     - exact (unit T).
     - intros x x' f; simpl.
-      now rewrite (kleisli_law2 T).
+      now rewrite (Kleisli_law2 T).
   Defined.
 
-  Definition kleisli_to_Monad {C : precategory} (T : kleisli C) : Monad C.
+  Definition Kleisli_to_Monad {C : precategory} (T : Kleisli C) : Monad C.
   Proof.
-    refine (((kleisli_to_functor T,, kleisli_to_μ T) ,, kleisli_to_η T) ,, _).
+    refine (((Kleisli_to_functor T,, Kleisli_to_μ T) ,, Kleisli_to_η T) ,, _).
     do 2 try apply tpair; intros; simpl.
-    - apply kleisli_law2.
-    - now rewrite (kleisli_law3 T), <- assoc, (kleisli_law2 T), id_right, (kleisli_law1 T).
-    - now rewrite !(kleisli_law3 T), id_left, <- assoc, (kleisli_law2 T), id_right.
+    - apply Kleisli_law2.
+    - now rewrite (Kleisli_law3 T), <- assoc, (Kleisli_law2 T), id_right, (Kleisli_law1 T).
+    - now rewrite !(Kleisli_law3 T), id_left, <- assoc, (Kleisli_law2 T), id_right.
   Defined.
 
-  Proposition kleisli_to_Monad_to_kleisli {C : precategory} (hs : has_homsets C) (T : kleisli C) :
-    Monad_to_kleisli (kleisli_to_Monad T) = T.
+  Proposition Kleisli_to_Monad_to_Kleisli {C : precategory} (hs : has_homsets C) (T : Kleisli C) :
+    Monad_to_Kleisli (Kleisli_to_Monad T) = T.
   Proof.
     apply subtypeEquality'.
     - use total2_paths_f.
@@ -107,12 +107,12 @@ Section monad_types_equiv.
         * apply idpath.
         * repeat (apply funextsec; unfold homot; intro).
           simpl; unfold Monads.bind; simpl.
-          now rewrite (kleisli_law3 T), <- assoc, (kleisli_law2 T), id_right.
-    - apply (isaprop_kleisli_laws hs).
+          now rewrite (Kleisli_law3 T), <- assoc, (Kleisli_law2 T), id_right.
+    - apply (isaprop_Kleisli_laws hs).
   Defined.
 
-  Lemma Monad_to_kleisli_to_Monad_raw_data {C : precategory} (T : Monad C) :
-    Monad_to_raw_data (kleisli_to_Monad (Monad_to_kleisli T)) = Monad_to_raw_data T.
+  Lemma Monad_to_Kleisli_to_Monad_raw_data {C : precategory} (T : Monad C) :
+    Monad_to_raw_data (Kleisli_to_Monad (Monad_to_Kleisli T)) = Monad_to_raw_data T.
   Proof.
     use total2_paths_f.
     - apply idpath.
@@ -130,18 +130,18 @@ Section monad_types_equiv.
       + apply idpath.
   Defined.
 
-  Definition Monad_to_kleisli_to_Monad {C : precategory} (hs : has_homsets C) (T : Monad C) :
-    kleisli_to_Monad (Monad_to_kleisli T) = T.
+  Definition Monad_to_Kleisli_to_Monad {C : precategory} (hs : has_homsets C) (T : Monad C) :
+    Kleisli_to_Monad (Monad_to_Kleisli T) = T.
   Proof.
     apply (Monad_eq_raw_data hs).
-    apply Monad_to_kleisli_to_Monad_raw_data.
+    apply Monad_to_Kleisli_to_Monad_raw_data.
   Defined.
 
-  Definition isweq_Monad_to_kleisli {C : precategory} (hs: has_homsets C) :
-    isweq Monad_to_kleisli :=
-    gradth _ _ (Monad_to_kleisli_to_Monad hs) (kleisli_to_Monad_to_kleisli hs).
+  Definition isweq_Monad_to_Kleisli {C : precategory} (hs: has_homsets C) :
+    isweq Monad_to_Kleisli :=
+    gradth _ _ (Monad_to_Kleisli_to_Monad hs) (Kleisli_to_Monad_to_Kleisli hs).
 
-  Definition weq_kleisli_monad {C : precategory} (hs : has_homsets C) :
-    weq (Monad C) (kleisli C) := _,, (isweq_Monad_to_kleisli hs).
+  Definition weq_Kleisli_Monad {C : precategory} (hs : has_homsets C) :
+    weq (Monad C) (Kleisli C) := _,, (isweq_Monad_to_Kleisli hs).
 
 End monad_types_equiv.

--- a/UniMath/CategoryTheory/README.md
+++ b/UniMath/CategoryTheory/README.md
@@ -85,7 +85,7 @@ For any question about this library, send an email to Benedikt Ahrens.
 * *GrothendieckTopos.v*
 * *HorizontalComposition.v*
   * Definition of horizontal composition for natural transformations
-* *Kleisli.v* --- the "kleisli" definition of monad and its equivalence to the "monoidal" definition
+* *Kleisli.v* --- the "Kleisli" definition of monad and its equivalence to the "monoidal" definition
 * *LocalizingClass.v* --- localizing class and localization of categories
 * *Monads.v* --- monads, bind operation and substitution
 * *Monics.v* --- monics, their subcategory and their construction in functor categories


### PR DESCRIPTION
As @vladimirias pointed out, there is at least as much reason to capitalize Kleisli as there is to capitalize Monad, given that the former is a proper noun.