### PR TITLE
check for changes to Foundations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,9 @@ env:
   - PACKAGES=Tactics BUILD_COQIDE=yes BUILD_ALSO=TAGS
   - PACKAGES=Folds
   - PACKAGES=HomologicalAlgebra
+  - PACKAGES= FOUNDATIONS_CHANGE_ERROR=yes
 # building Coq in a separate stage folds up the output in the log:
 before_script:
   - time make build-coq
 script:
-  - time make TIMECMD=time $PACKAGES $BUILD_ALSO
+  - time make TIMECMD=time $PACKAGES $BUILD_ALSO FOUNDATIONS_CHANGE_ERROR=$FOUNDATIONS_CHANGE_ERROR

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
   - PACKAGES=Tactics BUILD_COQIDE=yes BUILD_ALSO=TAGS
   - PACKAGES=Folds
   - PACKAGES=HomologicalAlgebra
-  - PACKAGES= FOUNDATIONS_CHANGE_ERROR=yes
+  - FOUNDATIONS_CHANGE_ERROR=yes BUILD_ALSO=check-for-change-to-Foundations
 # building Coq in a separate stage folds up the output in the log:
 before_script:
   - time make build-coq

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ COQBIN ?=
 
 .PHONY: all everything install lc lcp wc describe clean distclean build-coq doc build-coqide
 all: check-first
+all: check-for-change-to-Foundations
 everything: TAGS all html install
 check-first: enforce-prescribed-ordering check-travis enforce-listing-of-proof-files
 
@@ -64,7 +65,7 @@ $(VFILES:.v=.vo) : $(COQBIN)coqc
 endif
 
 OTHERFLAGS += $(MOREFLAGS)
-OTHERFLAGS += -indices-matter -type-in-type -w '-notation-overridden,-local-declaration,+uniform-inheritance'
+OTHERFLAGS += -indices-matter -type-in-type -w '-notation-overridden,-local-declaration,+uniform-inheritance,-deprecated-option'
 ifeq ($(VERBOSE),yes)
 OTHERFLAGS += -verbose
 endif
@@ -301,6 +302,14 @@ enforce-listing-of-proof-files:
 	       fi ;													\
 	  else echo "make: *** skipping enforcement of listing of proof files, because 'bash' is too old" ;		\
 	  fi
+
+# Here we check for changes to UniMath/Foundations, which normally does not change.
+# One step of the travis job will fail, if a change is made, see .travis.yml
+ifneq ($(FOUNDATIONS_CHANGE_ERROR),yes)
+FOUNDATIONS_CHANGE_ERROR0 = -
+endif
+check-for-change-to-Foundations:
+	$(FOUNDATIONS_CHANGE_ERROR0) ! ( git diff --stat master -- UniMath/Foundations | grep . )
 
 #################################
 # targets best used with INCLUDE=no

--- a/UniMath/Foundations/Sets.v
+++ b/UniMath/Foundations/Sets.v
@@ -1,6 +1,6 @@
 (** * Generalities on [hSet].  Vladimir Voevodsky. Feb. - Sep. 2011
 
-In this file we introduce the type [hSet] of h-sets i.e. of types of h-level 2
+In this file we introduce the type [hSet] of h-sets, i.e., of types of h-level 2
 as well as a number of constructions such as type of (monic) subtypes, images,
 surjectivity etc. which, while they formally apply to functions between
 arbitrary types actually only depend on the behavior of the function on the sets


### PR DESCRIPTION
Here we arrange for one step of the travis job to fail if any changes
have been made to Foundations.

We also fix some punctuation in Foundations, to demonstrate how the
travis failure appears.

We also suppress some warning messages about deprecated options, such as
"Automatic Introduction".  At some point we may have to fix the files
that use "Unset Automatic Introduction", but that can wait.