### PR TITLE
Redefine Kleisli in terms of RelMonad

### DIFF
--- a/UniMath/CategoryTheory/Monads/Kleisli.v
+++ b/UniMath/CategoryTheory/Monads/Kleisli.v
@@ -23,10 +23,6 @@ Section Kleisli_def.
   Definition RelMonad_from_Kleisli {C : precategory} (T : Kleisli C) := (T : RelMonad (functor_identity C)).
   Coercion RelMonad_from_Kleisli : Kleisli >-> RelMonad.
 
-  Definition Kleisli_law1 {C : precategory} (T : Kleisli C) := pr1 (pr2 T).
-  Definition Kleisli_law2 {C : precategory} (T : Kleisli C) := pr1 (pr2 (pr2 T)).
-  Definition Kleisli_law3 {C : precategory} (T : Kleisli C) := pr2 (pr2 (pr2 T)).
-
 End Kleisli_def.
 
 (** * Equivalence of the types of Kleisli monads and "monoidal" monads *)
@@ -43,9 +39,9 @@ Section monad_types_equiv.
       + exact (fun (a b : C) (f : a --> b) => r_bind T (f · r_eta T b)).
     - apply tpair.
       + intro a; simpl.
-        now rewrite id_left, (Kleisli_law1 T).
+        now rewrite id_left, (r_bind_r_eta T).
       + intros a b c f g; simpl.
-        now rewrite (Kleisli_law3 T), <- !assoc, (Kleisli_law2 T b).
+        now rewrite (r_bind_r_bind T), <- !assoc, (r_eta_r_bind T b).
   Defined.
 
   Definition Kleisli_to_μ {C : precategory} (T: Kleisli C) :
@@ -54,7 +50,7 @@ Section monad_types_equiv.
     mkpair.
     - exact (fun (x : C) => r_bind T (identity (T x))).
     - intros x x' f; simpl.
-      now rewrite (Kleisli_law3 T), <- assoc, (Kleisli_law2 T (T x')), id_right, (Kleisli_law3 T), id_left.
+      now rewrite (r_bind_r_bind T), <- assoc, (r_eta_r_bind T (T x')), id_right, (r_bind_r_bind T), id_left.
   Defined.
 
   Definition Kleisli_to_η {C : precategory} (T: Kleisli C) :
@@ -63,16 +59,16 @@ Section monad_types_equiv.
     mkpair.
     - exact (r_eta T).
     - intros x x' f; simpl.
-      now rewrite (Kleisli_law2 T x).
+      now rewrite (r_eta_r_bind T x).
   Defined.
 
   Definition Kleisli_to_Monad {C : precategory} (T : Kleisli C) : Monad C.
   Proof.
     refine (((Kleisli_to_functor T,, Kleisli_to_μ T) ,, Kleisli_to_η T) ,, _).
     do 2 try apply tpair; intros; simpl.
-    - apply Kleisli_law2.
-    - now rewrite (Kleisli_law3 T), <- assoc, (Kleisli_law2 T (T c)), id_right, (Kleisli_law1 T).
-    - now rewrite !(Kleisli_law3 T), id_left, <- assoc, (Kleisli_law2 T (T c)), id_right.
+    - apply (r_eta_r_bind T).
+    - now rewrite (r_bind_r_bind T), <- assoc, (r_eta_r_bind T (T c)), id_right, (r_bind_r_eta T).
+    - now rewrite !(r_bind_r_bind T), id_left, <- assoc, (r_eta_r_bind T (T c)), id_right.
   Defined.
 
   Proposition Kleisli_to_Monad_to_Kleisli {C : precategory} (hs : has_homsets C) (T : Kleisli C) :
@@ -86,7 +82,7 @@ Section monad_types_equiv.
         * apply idpath.
         * repeat (apply funextsec; unfold homot; intro).
           simpl; unfold Monads.bind; simpl.
-          now rewrite (Kleisli_law3 T), <- assoc, (Kleisli_law2 T (T x0)), id_right.
+          now rewrite (r_bind_r_bind T), <- assoc, (r_eta_r_bind T (T x0)), id_right.
     - do 2 try apply isapropdirprod;
         do 5 try (apply impred; intro);
         apply hs.

--- a/UniMath/CategoryTheory/Monads/Kleisli.v
+++ b/UniMath/CategoryTheory/Monads/Kleisli.v
@@ -11,80 +11,59 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.CategoryTheory.Categories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.Monads.Monads.
+Require Import UniMath.CategoryTheory.Monads.RelativeMonads.
 
 Local Open Scope cat.
 
 (** * Definition of "Kleisli style" monad *)
 Section Kleisli_def.
 
-  Definition Kleisli_data (C : precategory) : UU :=
-    ∑ T : C -> C, ((∏ a : C, a --> T a) × (∏ a b : C, a --> T b -> T a --> T b)).
+  Definition Kleisli (C : precategory) : UU := RelMonad (functor_identity C).
 
-  Definition ob_function_from_Kleisli_data {C : precategory} (T : Kleisli_data C) := pr1 T.
-  Coercion ob_function_from_Kleisli_data : Kleisli_data >-> Funclass.
+  Definition RelMonad_from_Kleisli {C : precategory} (T : Kleisli C) := (T : RelMonad (functor_identity C)).
+  Coercion RelMonad_from_Kleisli : Kleisli >-> RelMonad.
 
-  Definition unit {C : precategory} (T : Kleisli_data C) := pr1 (pr2 T).
-  Definition bind {C : precategory} (T : Kleisli_data C) {a b : C} := pr2 (pr2 T) a b.
-
-  Definition Kleisli_laws {C : precategory} (T : Kleisli_data C) : UU :=
-    ((∏ a : C, bind T (unit T a) = identity (T a)) ×
-     (∏ (a b : C) (f : a --> T b), unit T a · bind T f = f)) ×
-    (∏ (a b c : C) (f : a --> T b) (g : b --> T c), bind T f · bind T g = bind T (f · bind T g)).
-
-  Lemma isaprop_Kleisli_laws {C : precategory} (hs : has_homsets C) (T : Kleisli_data C) :
-    isaprop (Kleisli_laws T).
-  Proof.
-    do 2 try apply isapropdirprod;
-    do 5 try (apply impred; intro);
-    apply hs.
-  Defined.
-
-  Definition Kleisli (C : precategory) : UU := ∑ T : Kleisli_data C, Kleisli_laws T.
-
-  Definition Kleisli_data_from_Kleisli {C : precategory} (T : Kleisli C) : Kleisli_data C := pr1 T.
-  Coercion Kleisli_data_from_Kleisli : Kleisli >-> Kleisli_data.
-
-  Definition Kleisli_law1 {C : precategory} (T : Kleisli C) := pr1 (pr1 (pr2 T)).
-  Definition Kleisli_law2 {C : precategory} (T : Kleisli C) := pr2 (pr1 (pr2 T)).
-  Definition Kleisli_law3 {C : precategory} (T : Kleisli C) := pr2 (pr2 T).
+  Definition Kleisli_law1 {C : precategory} (T : Kleisli C) := pr1 (pr2 T).
+  Definition Kleisli_law2 {C : precategory} (T : Kleisli C) := pr1 (pr2 (pr2 T)).
+  Definition Kleisli_law3 {C : precategory} (T : Kleisli C) := pr2 (pr2 (pr2 T)).
 
 End Kleisli_def.
 
 (** * Equivalence of the types of Kleisli monads and "monoidal" monads *)
 Section monad_types_equiv.
   Definition Monad_to_Kleisli {C : precategory} : Monad C → Kleisli C :=
-    fun T => (functor_on_objects T ,, (pr1 (η T) ,, @Monads.bind C T))
-               ,, (@Monad_law2 C T ,, @η_bind C T) ,, @bind_bind C T.
+    fun T => (functor_on_objects T ,, (pr1 (η T) ,, @bind C T))
+               ,, @Monad_law2 C T ,, (@η_bind C T ,, @bind_bind C T).
 
   Definition Kleisli_to_functor {C : precategory} (T: Kleisli C) : C ⟶ C.
   Proof.
     use mk_functor.
     - use mk_functor_data.
       + exact T.
-      + exact (fun (a b : C) (f : a --> b) => bind T (f · unit T b)).
+      + exact (fun (a b : C) (f : a --> b) => r_bind T (f · r_eta T b)).
     - apply tpair.
       + intro a; simpl.
         now rewrite id_left, (Kleisli_law1 T).
       + intros a b c f g; simpl.
-        now rewrite (Kleisli_law3 T), <- !assoc, (Kleisli_law2 T).
+        now rewrite (Kleisli_law3 T), <- !assoc, (Kleisli_law2 T b).
   Defined.
 
   Definition Kleisli_to_μ {C : precategory} (T: Kleisli C) :
     Kleisli_to_functor T ∙ Kleisli_to_functor T ⟹ Kleisli_to_functor T.
   Proof.
     mkpair.
-    - exact (fun (x : C) => bind T (identity (T x))).
+    - exact (fun (x : C) => r_bind T (identity (T x))).
     - intros x x' f; simpl.
-      now rewrite (Kleisli_law3 T), <- assoc, (Kleisli_law2 T), id_right, (Kleisli_law3 T), id_left.
+      now rewrite (Kleisli_law3 T), <- assoc, (Kleisli_law2 T (T x')), id_right, (Kleisli_law3 T), id_left.
   Defined.
 
   Definition Kleisli_to_η {C : precategory} (T: Kleisli C) :
     functor_identity C ⟹ Kleisli_to_functor T.
   Proof.
     mkpair.
-    - exact (unit T).
+    - exact (r_eta T).
     - intros x x' f; simpl.
-      now rewrite (Kleisli_law2 T).
+      now rewrite (Kleisli_law2 T x).
   Defined.
 
   Definition Kleisli_to_Monad {C : precategory} (T : Kleisli C) : Monad C.
@@ -92,8 +71,8 @@ Section monad_types_equiv.
     refine (((Kleisli_to_functor T,, Kleisli_to_μ T) ,, Kleisli_to_η T) ,, _).
     do 2 try apply tpair; intros; simpl.
     - apply Kleisli_law2.
-    - now rewrite (Kleisli_law3 T), <- assoc, (Kleisli_law2 T), id_right, (Kleisli_law1 T).
-    - now rewrite !(Kleisli_law3 T), id_left, <- assoc, (Kleisli_law2 T), id_right.
+    - now rewrite (Kleisli_law3 T), <- assoc, (Kleisli_law2 T (T c)), id_right, (Kleisli_law1 T).
+    - now rewrite !(Kleisli_law3 T), id_left, <- assoc, (Kleisli_law2 T (T c)), id_right.
   Defined.
 
   Proposition Kleisli_to_Monad_to_Kleisli {C : precategory} (hs : has_homsets C) (T : Kleisli C) :
@@ -107,8 +86,10 @@ Section monad_types_equiv.
         * apply idpath.
         * repeat (apply funextsec; unfold homot; intro).
           simpl; unfold Monads.bind; simpl.
-          now rewrite (Kleisli_law3 T), <- assoc, (Kleisli_law2 T), id_right.
-    - apply (isaprop_Kleisli_laws hs).
+          now rewrite (Kleisli_law3 T), <- assoc, (Kleisli_law2 T (T x0)), id_right.
+    - do 2 try apply isapropdirprod;
+        do 5 try (apply impred; intro);
+        apply hs.
   Defined.
 
   Lemma Monad_to_Kleisli_to_Monad_raw_data {C : precategory} (T : Monad C) :
@@ -121,11 +102,11 @@ Section monad_types_equiv.
       + apply dirprod_paths;
         repeat (apply funextsec; unfold homot; intro);
         simpl.
-        * unfold Monads.bind, bind, unit; simpl.
+        * unfold Monads.bind, r_bind, r_eta; simpl.
           rewrite (functor_comp T), <- assoc.
           change (# T x1 · (# T (η T x0) · μ T x0) = #T x1).
           now rewrite (@Monad_law2 C T x0), id_right.
-        * unfold Monads.bind, bind; simpl.
+        * unfold Monads.bind, r_bind; simpl.
           now rewrite (functor_id T), id_left.
       + apply idpath.
   Defined.

--- a/UniMath/CategoryTheory/Monads/RelativeMonads.v
+++ b/UniMath/CategoryTheory/Monads/RelativeMonads.v
@@ -28,7 +28,7 @@ Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 (** * Definition of relative monads *)
 Section RMonad_def.
 
-Context {C D : precategory} (J : functor C D).
+Context {C D : precategory} {J : functor C D}.
 
 Definition RelMonad_data : UU
   := ∑ F : C -> D, (∏ c, D ⟦J c, F c⟧)
@@ -81,3 +81,7 @@ Proof.
 Defined.
 
 End RMonad_def.
+
+(* Underlying functor argument should be explicit for RelMonad_data and RelMonad *)
+Arguments RelMonad_data {C} {D} J.
+Arguments RelMonad {C} {D} J.

--- a/UniMath/CategoryTheory/Monads/RelativeMonads.v
+++ b/UniMath/CategoryTheory/Monads/RelativeMonads.v
@@ -30,6 +30,7 @@ Section RMonad_def.
 
 Context {C D : precategory} {J : functor C D}.
 
+(* implicitness of arguments for RelMonad_data are set after this section *)
 Definition RelMonad_data : UU
   := ∑ F : C -> D, (∏ c, D ⟦J c, F c⟧)
                  × (∏ c d, D ⟦J c, F d⟧ → D ⟦F c, F d⟧).
@@ -55,6 +56,7 @@ Definition r_bind_r_bind {R : RelMonad_data} (X : RelMonad_axioms R)
          r_bind R f · r_bind R g = r_bind R (f · r_bind R g)
   := pr2 (pr2 X).
 
+(* implicitness of arguments for RelMonad are set after this section *)
 Definition RelMonad : UU := ∑ R : RelMonad_data, RelMonad_axioms R.
 Coercion RelMonad_data_from_RelMonad (R : RelMonad) : RelMonad_data := pr1 R.
 Coercion RelMonad_axioms_from_RelMonad (R : RelMonad) : RelMonad_axioms R := pr2 R.


### PR DESCRIPTION
The definitions of Kleisli and RelMonad were redundant. Here they are unified.