### PR TITLE
simplify intro patterns that give rise to a warning

### DIFF
--- a/UniMath/Combinatorics/StandardFiniteSets.v
+++ b/UniMath/Combinatorics/StandardFiniteSets.v
@@ -1386,8 +1386,8 @@ Definition two_rec {A : UU} (a b : A) : stn 2 -> A.
 Proof.
   intros A a b.
   induction 1 as [n p].
-  induction n as [_|n _]; [apply a|].
-  induction n as [_|n _]; [apply b|].
+  induction n as [|n _]; [apply a|].
+  induction n as [|n _]; [apply b|].
   induction (nopathsfalsetotrue p).
 Defined.
 
@@ -1396,8 +1396,8 @@ Definition two_rec_dep (P : two -> UU):
 Proof.
   intros P a b n.
   induction n as [n p].
-  induction n as [_|n _]. eapply stn_predicate. apply a.
-  induction n as [_|n _]. eapply stn_predicate. apply b.
+  induction n as [|n _]. eapply stn_predicate. apply a.
+  induction n as [|n _]. eapply stn_predicate. apply b.
   induction (nopathsfalsetotrue p).
 Defined.
 
@@ -1407,9 +1407,9 @@ Definition three_rec {A : UU} (a b c : A) : stn 3 -> A.
 Proof.
   intros A a b c.
   induction 1 as [n p].
-  induction n as [_|n _]; [apply a|].
-  induction n as [_|n _]; [apply b|].
-  induction n as [_|n _]; [apply c|].
+  induction n as [|n _]; [apply a|].
+  induction n as [|n _]; [apply b|].
+  induction n as [|n _]; [apply c|].
   induction (nopathsfalsetotrue p).
 Defined.
 
@@ -1418,9 +1418,9 @@ Definition three_rec_dep (P : three -> UU):
 Proof.
   intros P a b c n.
   induction n as [n p].
-  induction n as [_|n _]. eapply stn_predicate. apply a.
-  induction n as [_|n _]. eapply stn_predicate. apply b.
-  induction n as [_|n _]. eapply stn_predicate. apply c.
+  induction n as [|n _]. eapply stn_predicate. apply a.
+  induction n as [|n _]. eapply stn_predicate. apply b.
+  induction n as [|n _]. eapply stn_predicate. apply c.
   induction (nopathsfalsetotrue p).
 Defined.
 

--- a/UniMath/SubstitutionSystems/CCS.v
+++ b/UniMath/SubstitutionSystems/CCS.v
@@ -61,12 +61,12 @@ Local Notation "a + b" := (setcoprod a b) : set.
 Definition six_rec {A : UU} (a b c d e f : A) : stn 6 -> A.
 Proof.
 induction 1 as [n p].
-induction n as [_|n _]; [apply a|].
-induction n as [_|n _]; [apply b|].
-induction n as [_|n _]; [apply c|].
-induction n as [_|n _]; [apply d|].
-induction n as [_|n _]; [apply e|].
-induction n as [_|n _]; [apply f|].
+induction n as [|n _]; [apply a|].
+induction n as [|n _]; [apply b|].
+induction n as [|n _]; [apply c|].
+induction n as [|n _]; [apply d|].
+induction n as [|n _]; [apply e|].
+induction n as [|n _]; [apply f|].
 induction (nopathsfalsetotrue p).
 Defined.
 

--- a/UniMath/SubstitutionSystems/MLTT79.v
+++ b/UniMath/SubstitutionSystems/MLTT79.v
@@ -50,10 +50,10 @@ Section preamble.
 Definition four_rec {A : UU} (a b c d : A) : stn 4 -> A.
 Proof.
 induction 1 as [n p].
-induction n as [_|n _]; [apply a|].
-induction n as [_|n _]; [apply b|].
-induction n as [_|n _]; [apply c|].
-induction n as [_|n _]; [apply d|].
+induction n as [|n _]; [apply a|].
+induction n as [|n _]; [apply b|].
+induction n as [|n _]; [apply c|].
+induction n as [|n _]; [apply d|].
 induction (nopathsfalsetotrue p).
 Defined.
 


### PR DESCRIPTION
this concerns the definitions of four_rec and six_rec, the warning message used to be "Warning: Unused introduction pattern: _ [unused-intro-pattern,tactics]"