### PR TITLE
avoid warnings on ignored implicit arguments

### DIFF
--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -92,7 +92,7 @@ Section cocont.
 
 Context {C D : precategory} (F : functor C D).
 
-Definition is_cocont : UU := ∏ {g : graph} (d : diagram g C) (L : C)
+Definition is_cocont : UU := ∏ (g : graph) (d : diagram g C) (L : C)
   (cc : cocone d L), preserves_colimit F d L cc.
 
 End cocont.

--- a/UniMath/CategoryTheory/limits/cats/limits.v
+++ b/UniMath/CategoryTheory/limits/cats/limits.v
@@ -277,9 +277,9 @@ End lim_def.
 
 Section Lims.
 
-Definition Lims (C : precategory) : UU := ∏ {J : precategory} (F : functor J C), LimCone F.
+Definition Lims (C : precategory) : UU := ∏ (J : precategory) (F : functor J C), LimCone F.
 Definition hasLims : UU  :=
-  ∏ {J C : precategory} (F : functor J C), ishinh (LimCone F).
+  ∏ (J C : precategory) (F : functor J C), ishinh (LimCone F).
 Definition Lims_of_shape (J C : precategory) : UU := ∏ (F : functor J C), LimCone F.
 
 Section Universal_Unique.

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -370,9 +370,9 @@ End colim_def.
 
 Section Colims.
 
-Definition Colims (C : precategory) : UU := ∏ {g : graph} (d : diagram g C), ColimCocone d.
+Definition Colims (C : precategory) : UU := ∏ (g : graph) (d : diagram g C), ColimCocone d.
 Definition hasColims (C : precategory) : UU  :=
-  ∏ {g : graph} (d : diagram g C), ishinh (ColimCocone d).
+  ∏ (g : graph) (d : diagram g C), ishinh (ColimCocone d).
 
 (** Colimits of a specific shape *)
 Definition Colims_of_shape (g : graph) (C : precategory) : UU :=

--- a/UniMath/CategoryTheory/limits/graphs/limits.v
+++ b/UniMath/CategoryTheory/limits/graphs/limits.v
@@ -327,9 +327,9 @@ End lim_def.
 
 Section Lims.
 
-Definition Lims (C : precategory) : UU := ∏ {g : graph} (d : diagram g C), LimCone d.
+Definition Lims (C : precategory) : UU := ∏ (g : graph) (d : diagram g C), LimCone d.
 Definition hasLims (C : precategory) : UU  :=
-  ∏ {g : graph} (d : diagram g C), ishinh (LimCone d).
+  ∏ (g : graph) (d : diagram g C), ishinh (LimCone d).
 
 (** Limits of a specific shape *)
 Definition Lims_of_shape (g : graph) (C : precategory) : UU :=
@@ -601,9 +601,9 @@ simple refine (mk_ColimCocone _ _ _ _  ).
 - apply isCC.
 Defined.
 
-Definition Lims : UU := ∏ {g : graph} (d : diagram g C^op), LimCone d.
+Definition Lims : UU := ∏ (g : graph) (d : diagram g C^op), LimCone d.
 Definition hasLims : UU  :=
-  ∏ {g : graph} (d : diagram g C^op), ishinh (LimCone d).
+  ∏ (g : graph) (d : diagram g C^op), ishinh (LimCone d).
 
 (* lim is the tip of the lim cone *)
 Definition lim {g : graph} {d : diagram g C^op} (CC : LimCone d) : C

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -907,7 +907,7 @@ Definition maps_pb_square_to_pb_square
   isPullback _ _ _ _ H -> isPullback _ _ _ _ (functor_on_square H).
 
 Definition maps_pb_squares_to_pb_squares :=
-   ∏ {a b c d : C}
+   ∏ (a b c d : C)
      {f : C ⟦b, a⟧} {g : C ⟦c, a⟧} {h : C⟦d, b⟧} {k : C⟦d,c⟧}
      (H : h · f = k · g),
      maps_pb_square_to_pb_square H.


### PR DESCRIPTION
by no longer declaring them as implicit