### PR TITLE
clean up Foundations

### DIFF
--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -177,11 +177,17 @@ Notation "g ∘ f" := (funcomp f g) (at level 50, left associativity) : function
 
 Definition curry {X Z : UU} {Y : X -> UU} (f : (∑ x : X, Y x) -> Z) :
   ∏ x, Y x -> Z.
-Proof. intros ? ? ? ? ? y. exact (f (x,,y)). Defined.
+Proof.
+  intros ? ? ? ? ? y.
+  exact (f (x,,y)).
+Defined.
 
 Definition uncurry {X Z : UU} {Y : X -> UU} (g : ∏ x : X, Y x -> Z) :
   (∑ x, Y x) -> Z.
-Proof. intros ? ? ? ? xy. exact (g (pr1 xy) (pr2 xy)). Defined.
+Proof.
+  intros ? ? ? ? xy.
+  exact (g (pr1 xy) (pr2 xy)).
+Defined.
 
 (** *** Definition of binary operation *)
 
@@ -213,7 +219,7 @@ Notation "A × B" := (dirprod A B) (at level 75, right associativity) : type_sco
 Definition dirprod_pr1 {X Y : UU} := pr1 : X × Y -> X.
 Definition dirprod_pr2 {X Y : UU} := pr2 : X × Y -> Y.
 
-Definition dirprodpair {X Y : UU} := tpair (λ _:X, Y).
+Definition dirprodpair {X Y : UU} (x:X) (y:Y) : X × Y := x,,y.
 
 Definition dirprodadj {X Y Z : UU} (f : X × Y -> Z) : X -> Y -> Z :=
   λ x y, f (x,,y).
@@ -239,9 +245,6 @@ Notation "'¬' X" := (neg X) (at level 35, right associativity).
 (* type this in emacs in agda-input method with \neg *)
 
 Notation "x != y" := (neg (x = y)) (at level 70).
-
-(* Apply this tactic to a proof of ([X] and [neg X]), in either order: *)
-Ltac contradicts a b := solve [ induction (a b) | induction (b a) ].
 
 Definition negf {X Y : UU} (f : X -> Y) : ¬ Y -> ¬ X := λ phi x, phi (f x).
 
@@ -276,10 +279,15 @@ Definition logeq (X Y : UU) := (X -> Y) × (Y -> X).
 Notation " X <-> Y " := (logeq X Y) : type_scope.
 
 Lemma isrefl_logeq (X : UU) : X <-> X.
-Proof. intros. split; apply idfun. Defined.
+Proof.
+  intros. split; apply idfun.
+Defined.
 
 Lemma issymm_logeq (X Y : UU) : (X <-> Y) -> (Y <-> X).
-Proof. intros ? ? e. exact (pr2 e,,pr1 e). Defined.
+Proof.
+  intros ? ? e.
+  exact (pr2 e,,pr1 e).
+Defined.
 
 Definition logeqnegs {X Y : UU} (l : X <-> Y) : (¬ X) <-> (¬ Y) :=
   dirprodpair (negf (pr2 l)) (negf (pr1 l)).
@@ -301,9 +309,9 @@ Proof.
 Defined.
 
 Definition logeq_trans {X Y Z : UU} : (X <-> Y) -> (Y <-> Z) -> (X <-> Z).
-Proof. intros ? ? ? i j. exact (pr1 j ∘ pr1 i,, pr2 i ∘ pr2 j). Defined.
-
-Ltac intermediate_logeq Y' := apply (logeq_trans (Y := Y')).
+Proof.
+  intros ? ? ? i j. exact (pr1 j ∘ pr1 i,, pr2 i ∘ pr2 j).
+Defined.
 
 (* end of "Some standard constructions not using identity types (paths)". *)
 
@@ -314,7 +322,7 @@ Ltac intermediate_logeq Y' := apply (logeq_trans (Y := Y')).
 
 (** While the paths in two of the three following lemmas are trivial, having them as
 lemmas turns out to be convenient in some future proofs. They are used to apply a particular
-definitional equalities to modify the syntactic form of the goal in order to make the
+definitional equality to modify the syntactic form of the goal in order to make the
 next tactic, which uses the syntactic form of the goal to guess how to proceed, to work.
 
 The same applies to other lemmas below whose proof is by immediate "reflexivity" or
@@ -329,11 +337,15 @@ Defined.
 
 Lemma uncurry_curry {X Z : UU} {Y : X -> UU} (f : (∑ x : X, Y x) -> Z) :
   ∏ p, uncurry (curry f) p = f p.
-Proof. intros. induction p as [x y]. apply idpath. Defined.
+Proof.
+  intros. induction p as [x y]. apply idpath.
+Defined.
 
 Lemma curry_uncurry {X Z : UU} {Y : X -> UU} (g : ∏ x : X, Y x -> Z) :
   ∏ x y, curry (uncurry g) x y = g x y.
-Proof. intros. apply idpath. Defined.
+Proof.
+  intros. apply idpath.
+Defined.
 
 
 (** *** Composition of paths and inverse paths *)
@@ -518,7 +530,9 @@ Definition homotfun {X Y Z : UU} {f f' : X -> Y} (h : f ~ f')
 (** *** Equality between functions defines a homotopy *)
 
 Definition toforallpaths {T:UU} (P:T->UU) (f g:∏ t:T, P t) : f = g -> f ~ g.
-Proof. intros ? ? ? ? h t. induction h.  apply (idpath _). Defined.
+Proof.
+  intros ? ? ? ? h t. induction h.  apply (idpath _).
+Defined.
 
 Definition eqtohomot     {T:UU} {P:T->UU} {f g:∏ t:T, P t} : f = g -> f ~ g.
 (* the same as toforallpaths, but with different implicit arguments *)
@@ -737,10 +751,14 @@ Opaque transportf_paths.
 Local Open Scope transport.
 
 Definition transportbfinv {T} (P:T->Type) {t u:T} (e:t = u) (p:P t) : e#'e#p = p.
-Proof. intros. destruct e. apply idpath. Defined.
+Proof.
+  intros. destruct e. apply idpath.
+Defined.
 
 Definition transportfbinv {T} (P:T->Type) {t u:T} (e:t = u) (p:P u) : e#e#'p = p.
-Proof. intros. destruct e. apply idpath. Defined.
+Proof.
+  intros. destruct e. apply idpath.
+Defined.
 
 Close Scope transport.
 
@@ -1143,7 +1161,7 @@ Lemma iscontrcoconustot (T : UU) (t : T) : iscontr (coconustot T t).
 Proof.
   intros.
   unfold iscontr.
-  split with (tpair (λ t', t' = t) t (idpath t)).
+  split with (coconustotpair T (idpath t)).
   intros.
   apply connectedcoconustot.
 Defined.
@@ -1162,7 +1180,7 @@ Defined.
 Lemma iscontrcoconusfromt (T : UU) (t : T) : iscontr (coconusfromt T t).
 Proof.
   intros. unfold iscontr.
-  split with (tpair (λ (t' : T), t = t') t (idpath t)).
+  split with (coconusfromtpair T (idpath t)).
   intros.
   apply connectedcoconusfromt.
 Defined.
@@ -1227,7 +1245,7 @@ Lemma idisweq (T : UU) : isweq (idfun T).
 Proof.
   intros. unfold isweq. intro y.
   unfold iscontr.
-  split with (tpair (λ (x : T), idfun T x = y) y (idpath y)).
+  split with (hfiberpair (idfun T) y (idpath y)).
   intro t.
   induction t as [x e].
   induction e.
@@ -1261,12 +1279,12 @@ Definition weqpair {X Y : UU} (f : X -> Y) (is: isweq f) : X ≃ Y :=
 Definition idweq (X : UU) : X ≃ X :=
   tpair (λ f : X -> X, isweq f) (λ (x : X), x) (idisweq X).
 
-Definition isweqtoempty {X : UU} (f : X -> empty) : isweq f.
+Definition isweqtoempty {X : UU} (f : X -> ∅) : isweq f.
 Proof.
   intros. intro y. apply (fromempty y).
 Defined.
 
-Definition weqtoempty {X : UU} (f : X -> empty) :=
+Definition weqtoempty {X : UU} (f : X -> ∅) : X ≃ ∅ :=
   weqpair _ (isweqtoempty f).
 
 Lemma isweqtoempty2 {X Y : UU} (f : X -> Y) (is : ¬ Y) : isweq f.
@@ -1274,8 +1292,8 @@ Proof.
   intros. intro y. induction (is y).
 Defined.
 
-Definition weqtoempty2 {X Y : UU} (f : X -> Y) (is : ¬ Y) :=
-  weqpair _ (isweqtoempty2 f is).
+Definition weqtoempty2 {X Y : UU} (f : X -> Y) (is : ¬ Y) : X ≃ Y
+  := weqpair _ (isweqtoempty2 f is).
 
 Definition weqempty {X Y : UU} : ¬X → ¬Y → X≃Y.
 Proof.
@@ -1353,9 +1371,9 @@ Proof.
   assert (e1 : maponpaths f eee = e).
   {
     assert (e2 : maponpaths (g ∘ f) eee = ee).
-    apply maponpathshomid2.
+    { apply maponpathshomid2. }
     assert (e3 : maponpaths g (maponpaths f eee) = maponpaths g e).
-    apply (maponpathscomp f g eee @ e2).
+    { apply (maponpathscomp f g eee @ e2). }
     set (s := @maponpaths _ _ g (f x) (f x')).
     set (p := @pathssec2 _ _ g f (homotweqinvweq w) (f x) (f x')).
     set (eps := @pathssec3 _ _ g f (homotweqinvweq w) (f x) (f x')).
@@ -1396,16 +1414,20 @@ Proof.
 Defined.
 
 Definition isinjinvmap {X Y} (v w:X≃Y) : invmap v ~ invmap w -> v ~ w.
-Proof. intros ? ? ? ? h x.
+Proof.
+  intros ? ? ? ? h x.
   intermediate_path (w ((invmap w) (v x))).
   { apply pathsinv0. apply homotweqinvweq. }
-  rewrite <- h. rewrite homotinvweqweq. apply idpath. Defined.
+  rewrite <- h. rewrite homotinvweqweq. apply idpath.
+Defined.
 
 Definition isinjinvmap' {X Y} (v w:X->Y) (v' w':Y->X) : w ∘ w' ~ idfun Y -> v' ∘ v ~ idfun X -> v' ~ w' -> v ~ w.
-Proof. intros ? ? ? ? ? ? p q h x .
+Proof.
+  intros ? ? ? ? ? ? p q h x .
   intermediate_path (w (w' (v x))).
   { apply pathsinv0. apply p. }
-  apply maponpaths. rewrite <- h. apply q. Defined.
+  apply maponpaths. rewrite <- h. apply q.
+Defined.
 
 (** *** Adjointness property of a weak equivalence and its inverse *)
 
@@ -1413,7 +1435,7 @@ Lemma diaglemma2 {X Y : UU} (f : X -> Y) {x x' : X}
       (e1 : x = x') (e2 : f x' = f x)
       (ee : idpath (f x) = maponpaths f e1 @ e2) : maponpaths f (! e1) = e2.
 Proof.
-  intros. induction e1. simpl in *. apply ee.
+  intros. induction e1. simpl in *. exact ee.
 Defined.
 
 (* this is the adjointness relation for w and its homotopy inverse: *)
@@ -1473,8 +1495,6 @@ Proof.
   intros. apply (iscontrretract (invmap w) w (homotinvweqweq w) is).
 Defined.
 
-Ltac intermediate_iscontr Y' := apply (iscontrweqb (Y := Y')).
-
 (** *** [ unit ] and contractibility *)
 
 (** [ unit ] is contractible (recall that [ tt ] is the name of the
@@ -1492,7 +1512,7 @@ Defined.
 
 Lemma unitl1: coconustot _ tt -> tt = tt.
 Proof.
-  intro cp. induction cp as [x t]. induction x. apply t.
+  intro cp. induction cp as [x t]. induction x. exact t.
 Defined.
 
 Lemma unitl2: ∏ e : tt = tt, unitl1 (unitl0 e) = e.
@@ -1540,11 +1560,11 @@ Proof.
   apply (iscontrpathsinunit tt tt).
 Defined.
 
-Lemma isweqcontrtounit {T : UU} (is : iscontr T) : isweq (λ (t : T), tt).
+Lemma isweqcontrtounit {T : UU} (is : iscontr T) : isweq (λ (_ : T), tt).
 Proof.
   intros. unfold isweq. intro y. induction y.
   induction is as [c h].
-  set (hc := hfiberpair _ c (isconnectedunit tt tt)).
+  set (hc := hfiberpair _ c (idpath tt)).
   split with hc.
   intros ha.
   induction ha as [x e].
@@ -1780,7 +1800,7 @@ Proof.
   intros ? ? ? bij. assert (sur := pr1 bij). assert (inj := pr2 bij).
   use (gradth f).
   - intros y. exact (pr1 (sur y)).
-  - intros. simpl. apply inj. exact (pr2 (sur (f x))).
+  - intros. simpl. simpl in inj. apply inj. exact (pr2 (sur (f x))).
   - intros. simpl. exact (pr2 (sur y)).
 Defined.
 
@@ -1835,16 +1855,14 @@ Notation "a ╝ b" := (PathPair a b) (at level 70, no associativity) : type_scop
 Theorem total2_paths_equiv {A : UU} (B : A -> UU) (x y : ∑ x, B x) :
   x = y  ≃  x ╝ y.
 Proof.
-  intros A B x y.
+  intros.
   exists (λ r : x = y,
             tpair (λ p : pr1 x = pr1 y, transportf _ p (pr2 x) = pr2 y)
                   (base_paths _ _ r) (fiber_paths r)).
-  apply (gradth _
-                (λ pq : ∑ p : pr1 x = pr1 y, transportf _ p (pr2 x) = pr2 y,
-                   total2_paths_f (pr1 pq) (pr2 pq))).
+  apply (gradth _ (λ pq, total2_paths_f (pr1 pq) (pr2 pq))).
   - intro p.
     apply total2_fiber_paths.
-  - intros [p q]. simpl in *.
+  - intros [p q]. simpl.
     apply (two_arg_paths_f (base_total2_paths q)).
     apply transportf_fiber_total2_paths.
 Defined.
@@ -1854,8 +1872,8 @@ Defined.
 Definition wequnittocontr {X : UU} (is : iscontr X) : unit ≃ X.
 Proof.
   intros.
-  set (f := λ (t : unit), pr1 is).
-  set (g := λ (x : X), tt).
+  set (f := λ (_ : unit), pr1 is).
+  set (g := λ (_ : X), tt).
   split with f.
   assert (egf : ∏ t : unit, g (f t) = t).
   { intro. induction t. apply idpath. }
@@ -1877,8 +1895,8 @@ Proof.
                 (@pathsweq4 _ _ w x x')).
 Defined.
 
-Definition weqonpaths {X Y : UU} (w : X ≃ Y) (x x' : X) :=
-  weqpair _ (isweqmaponpaths w x x').
+Definition weqonpaths {X Y : UU} (w : X ≃ Y) (x x' : X) : x = x' ≃ w x = w x'
+  := weqpair _ (isweqmaponpaths w x x').
 
 (** The inverse path and the composition with a path functions are weak equivalences *)
 
@@ -1891,8 +1909,8 @@ Proof.
                 (@pathsinv0inv0 _ _ _)).
 Defined.
 
-Definition weqpathsinv0 {X : UU} (x x' : X) :=
-  weqpair _ (isweqpathsinv0 x x').
+Definition weqpathsinv0 {X : UU} (x x' : X) : x = x' ≃ x' = x
+  := weqpair _ (isweqpathsinv0 x x').
 
 Corollary isweqpathscomp0r {X : UU} (x : X) {x' x'' : X} (e' : x' = x'') :
   isweq (λ e : x = x', e @ e').
@@ -1964,7 +1982,7 @@ Defined.
 Theorem weqhfibershomot {X Y : UU} (f g : X -> Y)
         (h : f ~ g) (y : Y) : hfiber f y ≃ hfiber g y.
 Proof.
-  intros X Y f g h y.
+  intros.
   set (ff := hfibershomotftog f g h y).
   set (gg := hfibershomotgtof f g h y).
 
@@ -2081,7 +2099,7 @@ Defined.
 Lemma isweql3 {X Y : UU} (f : X -> Y) (g : Y -> X)
       (egf : ∏ x : X, g (f x) = x) : isweq f -> isweq g.
 Proof.
-  intros X Y f g egf w.
+  intros ? ? ? ? ? w.
   assert (int1 : isweq (g ∘ f)).
   {
     apply (isweqhomot (idfun X) (g ∘ f) (λ (x : X), ! (egf x))).
@@ -2177,7 +2195,7 @@ Proof.
 Defined.
 
 Definition weqcontrcontr {X Y : UU} (isx : iscontr X) (isy : iscontr Y) :=
-  weqpair _ (isweqcontrcontr (λ (x : X), pr1 isy) isx isy).
+  weqpair _ (isweqcontrcontr (λ (_ : X), pr1 isy) isx isy).
 
 (** *** Composition of weak equivalences *)
 
@@ -2192,15 +2210,21 @@ Ltac intermediate_weq Y' := apply (weqcomp (Y := Y')).
 
 Definition weqcomp_to_funcomp_app {X Y Z : UU} {x : X} {f : X ≃ Y} {g : Y ≃ Z} :
   (weqcomp f g) x = pr1weq g (pr1weq f x).
-Proof. intros. apply idpath. Defined.
+Proof.
+  intros. apply idpath.
+Defined.
 
 Definition weqcomp_to_funcomp {X Y Z : UU} {f : X ≃ Y} {g : Y ≃ Z} :
   pr1weq (weqcomp f g) = pr1weq g ∘ pr1weq f.
-Proof. intros. apply idpath. Defined.
+Proof.
+  intros. apply idpath.
+Defined.
 
 Definition invmap_weqcomp_expand {X Y Z : UU} {f : X ≃ Y} {g : Y ≃ Z} :
   invmap (weqcomp f g) = invmap f ∘ invmap g.
-Proof. intros. apply idpath. Defined.
+Proof.
+  intros. apply idpath.
+Defined.
 
 (** *** The 2-out-of-6 (two-out-of-six) property of weak equivalences *)
 
@@ -2256,7 +2280,7 @@ Proof.
   apply (gradth _ _ egf efg).
 Defined.
 
-Definition weqdirprodf {X Y X' Y' : UU} (w : X ≃ Y) (w' : X' ≃ Y')
+Definition weqdirprodf {X Y X' Y' : UU} (w : X ≃ Y) (w' : X' ≃ Y') : X × X' ≃ Y × Y'
   := weqpair _ (isweqdirprodf w w').
 
 (** *** Weak equivalence of a type and its direct product with the unit *)
@@ -2440,7 +2464,9 @@ Defined.
 Definition weqrdistrtoprod (X Y Z : UU) := weqpair _ (isweqrdistrtoprod X Y Z).
 
 Corollary isweqrdistrtocoprod (X Y Z : UU) : isweq (rdistrtocoprod X Y Z).
-Proof. intros. apply (isweqinvmap (weqrdistrtoprod X Y Z)). Defined.
+Proof.
+  intros. apply (isweqinvmap (weqrdistrtoprod X Y Z)).
+Defined.
 
 Definition weqrdistrtocoprod (X Y Z : UU)
   := weqpair _ (isweqrdistrtocoprod X Y Z).
@@ -2539,7 +2565,9 @@ Defined.
 Definition weqcoprodasstor (X Y Z : UU) := weqpair _ (isweqcoprodasstor X Y Z).
 
 Corollary isweqcoprodasstol (X Y Z : UU) : isweq (coprodasstol X Y Z).
-Proof. intros. apply (isweqinvmap (weqcoprodasstor X Y Z)). Defined.
+Proof.
+  intros. apply (isweqinvmap (weqcoprodasstor X Y Z)).
+Defined.
 
 Definition weqcoprodasstol (X Y Z : UU) := weqpair _ (isweqcoprodasstol X Y Z).
 
@@ -2670,7 +2698,8 @@ Defined.
 (* Added by D. Grayson, Nov. 2015 *)
 
 Definition equality_cases {P Q : UU} (x x' : P ⨿ Q) : UU.
-Proof.                          (* "codes" *)
+Proof.
+                           (* "codes" *)
   intros. induction x as [p|q].
   - induction x' as [p'|q'].
     + exact (p = p').
@@ -2715,17 +2744,25 @@ Defined.
 
 Lemma ii1_injectivity {P Q : UU} (p p' : P) :
   ii1 (B := Q) p = ii1 (B := Q) p' -> p = p'.
-Proof. intros ? ? ? ?. exact equality_by_case. Defined.
+Proof.
+  intros ? ? ? ?. exact equality_by_case.
+Defined.
 
 Lemma ii2_injectivity {P Q : UU} (q q' : Q) :
   ii2 (A := P) q = ii2 (A := P) q' -> q = q'.
-Proof. intros ? ? ? ?. exact equality_by_case. Defined.
+Proof.
+  intros ? ? ? ?. exact equality_by_case.
+Defined.
 
 Lemma negpathsii1ii2 {X Y : UU} (x : X) (y : Y) : ii1 x != ii2 y.
-Proof. intros ? ? ? ?. exact equality_by_case. Defined.
+Proof.
+  intros ? ? ? ?. exact equality_by_case.
+Defined.
 
 Lemma negpathsii2ii1 {X Y : UU} (x : X) (y : Y) : ii2 y != ii1 x.
-Proof. intros ? ? ? ?. exact equality_by_case. Defined.
+Proof.
+  intros ? ? ? ?. exact equality_by_case.
+Defined.
 
 
 (** *** Bool as coproduct *)
@@ -2788,7 +2825,9 @@ Defined.
 Definition weqcoprodtoboolsum (X Y : UU) := weqpair _ (isweqcoprodtoboolsum X Y).
 
 Corollary isweqboolsumtocoprod (X Y : UU): isweq (boolsumtocoprod X Y).
-Proof. intros. apply (isweqinvmap (weqcoprodtoboolsum X Y)). Defined.
+Proof.
+  intros. apply (isweqinvmap (weqcoprodtoboolsum X Y)).
+Defined.
 
 Definition weqboolsumtocoprod (X Y : UU) := weqpair _ (isweqboolsumtocoprod X Y).
 
@@ -2818,16 +2857,24 @@ Proof.
 Defined.
 
 Theorem nopathstruetofalse : true = false -> empty.
-Proof. intro X. apply (transportf bool_to_type X tt). Defined.
+Proof.
+  intro X. apply (transportf bool_to_type X tt).
+Defined.
 
 Corollary nopathsfalsetotrue : false = true -> empty.
-Proof. intro X. apply (transportb bool_to_type X tt). Defined.
+Proof.
+  intro X. apply (transportb bool_to_type X tt).
+Defined.
 
 Definition truetonegfalse (x : bool) : x = true -> x != false.
-Proof. intros x e. rewrite e. unfold neg. apply nopathstruetofalse. Defined.
+Proof.
+  intros x e. rewrite e. unfold neg. apply nopathstruetofalse.
+Defined.
 
 Definition falsetonegtrue (x : bool) : x = false -> x != true.
-Proof. intros x e. rewrite e. unfold neg. apply nopathsfalsetotrue. Defined.
+Proof.
+  intros x e. rewrite e. unfold neg. apply nopathsfalsetotrue.
+Defined.
 
 Definition negtruetofalse (x : bool) : x != true -> x = false.
 Proof.
@@ -3118,7 +3165,9 @@ Definition ezweqpr1 {Z : UU} (P : Z -> UU) (z : Z)
 
 Lemma isfibseqpr1 {Z : UU} (P : Z -> UU) (z : Z) :
   isfibseq (λ p : P z, tpair _ z p) (@pr1 Z P) z (λ p : P z, idpath z).
-Proof. intros. unfold isfibseq. unfold ezmap. apply isweqezmappr1. Defined.
+Proof.
+  intros. unfold isfibseq. unfold ezmap. apply isweqezmappr1.
+Defined.
 
 Definition fibseqpr1 {Z : UU} (P : Z -> UU) (z : Z) :
   fibseqstr (λ p : P z, tpair _ z p) (@pr1 Z P) z
@@ -3197,7 +3246,9 @@ Definition d3g {Y Z : UU} (g : Y -> Z) {z : Z} (y : Y) (ye' : hfiber g z)
 Lemma homotd3g {Y Z : UU} (g : Y -> Z) {z : Z} (y : Y) (ye' : hfiber g z)
       (e : (g y) = z) (ee : (hfiberpair g y e) = ye') :
   (d3g g y ye' e ee) = (maponpaths (@pr1 _ _) (pathsinv0 ee)).
-Proof. intros. unfold d3g. unfold d2. simpl. apply pathscomp0rid. Defined.
+Proof.
+  intros. unfold d3g. unfold d2. simpl. apply pathscomp0rid.
+Defined.
 
 Definition ezweq3g {Y Z : UU} (g : Y -> Z) {z : Z} (y : Y) (ye' : hfiber g z)
            (e : (g y) = z)
@@ -3666,13 +3717,17 @@ Definition transposcommsqstr {X X' Y Z : UU} (f : X -> Y) (f' : X' -> Y)
 Lemma complxstrtocommsqstr {X Y Z : UU} (f : X -> Y) (g : Y -> Z) (z : Z)
       (h : complxstr f g z) :
   commsqstr f g (λ x : X, tt) (λ t : unit, z).
-Proof. intros. assumption. Defined.
+Proof.
+  intros. assumption.
+Defined.
 
 
 Lemma commsqstrtocomplxstr {X Y Z : UU} (f : X -> Y) (g : Y -> Z) (z : Z)
       (h : commsqstr f g (λ x : X, tt) (λ t : unit, z)) :
   complxstr f g z.
-Proof. intros. assumption. Defined.
+Proof.
+  intros. assumption.
+Defined.
 
 
 (** *** Homotopy fiber products *)
@@ -3780,7 +3835,9 @@ Defined.
 
 Lemma hfp_left {X Y Z : UU} (f : X -> Z) (g : Y -> Z) :
   hfp f g ≃ ∑ x, hfiber g (f x).
-Proof. intros. apply weqtotal2dirprodassoc. Defined.
+Proof.
+  intros. apply weqtotal2dirprodassoc.
+Defined.
 
 Definition hfp_right {X Y Z : UU} (f : X -> Z) (g : Y -> Z) :
   hfp f g ≃ ∑ y, hfiber f (g y).

--- a/UniMath/Foundations/PartB.v
+++ b/UniMath/Foundations/PartB.v
@@ -88,7 +88,9 @@ Defined.
 
 Lemma isofhlevelsn (n : nat) {X : UU} (f : X -> isofhlevel (S n) X) :
   isofhlevel (S n) X.
-Proof. intros. simpl. intros x x'. apply (f x x x'). Defined.
+Proof.
+  intros. simpl. intros x x'. apply (f x x x').
+Defined.
 
 Lemma isofhlevelssn (n : nat) {X : UU}
       (is : ∏ x : X, isofhlevel (S n) (x = x)) : isofhlevel (S (S n)) X.
@@ -265,7 +267,9 @@ Defined.
 
 Corollary isofhlevelfhfiberpr1 (n : nat) {X Y : UU} (f : X -> Y) (y : Y)
           (is : isofhlevel (S n) Y) : isofhlevelf n (hfiberpr1 f y).
-Proof. intros. apply isofhlevelfhfiberpr1y. intro y'. apply (is y' y). Defined.
+Proof.
+  intros. apply isofhlevelfhfiberpr1y. intro y'. apply (is y' y).
+Defined.
 
 
 
@@ -464,7 +468,9 @@ Defined.
 
 Corollary isofhleveldirprod (n : nat) (X Y : UU) (is1 : isofhlevel n X)
           (is2 : isofhlevel n Y) : isofhlevel n (X × Y).
-Proof. intros. apply isofhleveltotal2. assumption. intro. assumption. Defined.
+Proof.
+  intros. apply isofhleveltotal2. assumption. intro. assumption.
+Defined.
 
 
 
@@ -554,7 +560,9 @@ Proof.
 Defined.
 
 Corollary weqhfibertounit (X : UU) : (hfiber (λ x : X, tt) tt) ≃ X.
-Proof. intro. apply (weqhfibertocontr _ tt iscontrunit). Defined.
+Proof.
+  intro. apply (weqhfibertocontr _ tt iscontrunit).
+Defined.
 
 Corollary isofhleveltofun (n : nat) (X : UU) :
   isofhlevel n X -> isofhlevelf n (λ x : X, tt).
@@ -652,7 +660,9 @@ Definition weq_to_iff {X Y : UU} : X ≃ Y -> (X <-> Y)
   := λ f, (pr1weq f ,, invmap f).
 
 Theorem isapropempty: isaprop empty.
-Proof. unfold isaprop. unfold isofhlevel. intros x x'. induction x. Defined.
+Proof.
+  unfold isaprop. unfold isofhlevel. intros x x'. induction x.
+Defined.
 
 Theorem isapropifnegtrue {X : UU} (a : X -> empty) : isaprop X.
 Proof.
@@ -697,7 +707,9 @@ Definition pr1incl (X Y : UU) : incl X Y -> (X -> Y) := @pr1 _ _.
 Coercion pr1incl : incl >-> Funclass.
 
 Lemma isinclweq (X Y : UU) (f : X -> Y) : isweq f -> isincl f.
-Proof. intros X Y f is. apply (isofhlevelfweq 1 (weqpair _ is)). Defined.
+Proof.
+  intros X Y f is. apply (isofhlevelfweq 1 (weqpair _ is)).
+Defined.
 Coercion isinclweq : isweq >-> isincl.
 
 Lemma isofhlevelfsnincl (n : nat) {X Y : UU} (f : X -> Y) (is : isincl f) :
@@ -714,7 +726,9 @@ Coercion weqtoincl : weq >-> incl.
 
 Lemma isinclcomp {X Y Z : UU} (f : incl X Y) (g : incl Y Z) :
   isincl (funcomp (pr1 f) (pr1 g)).
-Proof. intros. apply (isofhlevelfgf 1 f g (pr2 f) (pr2 g)). Defined.
+Proof.
+  intros. apply (isofhlevelfgf 1 f g (pr2 f) (pr2 g)).
+Defined.
 
 Definition inclcomp {X Y Z : UU} (f : incl X Y) (g : incl Y Z) :
   incl X Z := inclpair (funcomp (pr1 f) (pr1 g)) (isinclcomp f g).
@@ -729,16 +743,22 @@ Defined.
 
 Lemma isinclgwtog {X Y Z : UU} (w : X ≃ Y) (g : Y -> Z)
       (is : isincl (funcomp w g)) : isincl g.
-Proof. intros. apply (isofhlevelfgwtog 1 w g is). Defined.
+Proof.
+  intros. apply (isofhlevelfgwtog 1 w g is).
+Defined.
 
 Lemma isinclgtogw {X Y Z : UU}  (w : X ≃ Y) (g : Y -> Z) (is : isincl g) :
   isincl (funcomp w g).
-Proof. intros. apply (isofhlevelfgtogw 1 w g is). Defined.
+Proof.
+  intros. apply (isofhlevelfgtogw 1 w g is).
+Defined.
 
 
 Lemma isinclhomot {X Y : UU} (f g : X -> Y) (h : homot f g) (isf : isincl f) :
   isincl g.
-Proof. intros. apply (isofhlevelfhomot (S O) f g h isf). Defined.
+Proof.
+  intros. apply (isofhlevelfhomot (S O) f g h isf).
+Defined.
 
 
 
@@ -764,10 +784,14 @@ Definition isInjective {X Y : UU} (f : X -> Y)
 
 Definition Injectivity {X Y : UU} (f : X -> Y) :
   isInjective f -> ∏ (x x' : X), x = x'  ≃  f x = f x'.
-Proof. intros ? ? ? i ? ?. exact (weqpair _ (i x x')). Defined.
+Proof.
+  intros ? ? ? i ? ?. exact (weqpair _ (i x x')).
+Defined.
 
 Lemma isweqonpathsincl {X Y : UU} (f : X -> Y) : isincl f -> isInjective f.
-Proof. intros ? ? ? is x x'. apply (isofhlevelfonpaths O f x x' is). Defined.
+Proof.
+  intros ? ? ? is x x'. apply (isofhlevelfonpaths O f x x' is).
+Defined.
 
 Definition weqonpathsincl {X Y : UU} (f : X -> Y) (is : isincl f) (x x' : X)
   := weqpair _ (isweqonpathsincl f is x x').
@@ -780,7 +804,9 @@ Proof.
 Defined.
 
 Lemma isinclweqonpaths {X Y : UU} (f : X -> Y) : isInjective f -> isincl f.
-Proof. intros X Y f X0. apply (isofhlevelfsn O f X0). Defined.
+Proof.
+  intros X Y f X0. apply (isofhlevelfsn O f X0).
+Defined.
 
 Definition isinclpr1 {X : UU} (P : X -> UU) (is : ∏ x : X, isaprop (P x)) :
   isincl (@pr1 X P):= isofhlevelfpr1 (S O) P is.
@@ -800,7 +826,9 @@ Defined.
 Corollary subtypeEquality' {A : UU} {B : A -> UU}
    {s s' : total2 (λ x, B x)} : pr1 s = pr1 s' -> isaprop (B (pr1 s')) -> s = s'.
 (* This variant of subtypeEquality is not often needed. *)
-Proof. intros ? ? ? ? e is. apply (total2_paths_f e). apply is. Defined.
+Proof.
+  intros ? ? ? ? e is. apply (total2_paths_f e). apply is.
+Defined.
 
 (* This corollary of subtypeEquality is used for categories. *)
 Corollary unique_exists {A : UU} {B : A -> UU} (x : A) (b : B x)
@@ -819,13 +847,17 @@ Defined.
 Definition subtypePairEquality {X : UU} {P : X -> UU} (is : isPredicate P)
            {x y : X} {p : P x} {q : P y} :
   x = y -> (x,,p) = (y,,q).
-Proof. intros X P is x y p q e. apply (two_arg_paths_f e). apply is. Defined.
+Proof.
+  intros X P is x y p q e. apply (two_arg_paths_f e). apply is.
+Defined.
 
 Definition subtypePairEquality' {X : UU} {P : X -> UU}
            {x y : X} {p : P x} {q : P y} :
   x = y -> isaprop(P y) -> (x,,p) = (y,,q).
 (* This variant of subtypePairEquality is never needed. *)
-Proof. intros X P x y p q e is. apply (two_arg_paths_f e). apply is. Defined.
+Proof.
+  intros X P x y p q e is. apply (two_arg_paths_f e). apply is.
+Defined.
 
 Theorem samehfibers {X Y Z : UU} (f : X -> Y) (g : Y -> Z) (is1 : isincl g)
         (y : Y) :  hfiber f y ≃ hfiber (g ∘ f) (g y).
@@ -847,32 +879,48 @@ Definition isaset (X : UU) : UU := ∏ x x' : X, isaprop (x = x').
 Notation isasetdirprod := (isofhleveldirprod 2).
 
 Lemma isasetunit : isaset unit.
-Proof. apply (isofhlevelcontr 2 iscontrunit). Defined.
+Proof.
+  apply (isofhlevelcontr 2 iscontrunit).
+Defined.
 
 Lemma isasetempty : isaset empty.
-Proof. apply (isofhlevelsnprop 1 isapropempty). Defined.
+Proof.
+  apply (isofhlevelsnprop 1 isapropempty).
+Defined.
 
 Lemma isasetifcontr {X : UU} (is : iscontr X) : isaset X.
-Proof. intros. apply (isofhlevelcontr 2 is). Defined.
+Proof.
+  intros. apply (isofhlevelcontr 2 is).
+Defined.
 
 Lemma isasetaprop {X : UU} (is : isaprop X) : isaset X.
-Proof. intros. apply (isofhlevelsnprop 1 is). Defined.
+Proof.
+  intros. apply (isofhlevelsnprop 1 is).
+Defined.
 
 Corollary isaset_total2 {X : UU} (P : X->UU) :
   isaset X -> (∏ x, isaset (P x)) -> isaset (∑ x, P x).
-Proof. intros. apply (isofhleveltotal2 2); assumption. Defined.
+Proof.
+  intros. apply (isofhleveltotal2 2); assumption.
+Defined.
 
 Corollary isaset_dirprod {X Y : UU} : isaset X -> isaset Y -> isaset (X × Y).
-Proof. intros. apply isaset_total2. assumption. intro. assumption. Defined.
+Proof.
+  intros. apply isaset_total2. assumption. intro. assumption.
+Defined.
 
 Corollary isaset_hfiber {X Y : UU} (f : X -> Y) (y : Y) : isaset X -> isaset Y -> isaset (hfiber f y).
-Proof. intros X Y f y isX isY. apply isaset_total2. assumption. intro. apply isasetaprop. apply isY. Defined.
+Proof.
+  intros X Y f y isX isY. apply isaset_total2. assumption. intro. apply isasetaprop. apply isY.
+Defined.
 
 (** The following lemma asserts "uniqueness of identity proofs" (uip) for
   sets. *)
 
 Lemma uip {X : UU} (is : isaset X) {x x' : X} (e e' : x = x') : e = e'.
-Proof. intros. apply (proofirrelevance _ (is x x') e e'). Defined.
+Proof.
+  intros. apply (proofirrelevance _ (is x x') e e').
+Defined.
 
 (** For the theorem about the coproduct of two sets see [ isasetcoprod ]
   below. *)
@@ -909,7 +957,9 @@ Defined.
 
 Theorem isasetsubset {X Y : UU} (f : X -> Y) (is1 : isaset Y) (is2 : isincl f) :
   isaset X.
-Proof. intros. apply (isofhlevelsninclb (S O) f is2). apply is1. Defined.
+Proof.
+  intros. apply (isofhlevelsninclb (S O) f is2). apply is1.
+Defined.
 
 
 
@@ -917,7 +967,9 @@ Proof. intros. apply (isofhlevelsninclb (S O) f is2). apply is1. Defined.
 
 Theorem isinclfromhfiber {X Y : UU} (f: X -> Y) (is : isaset Y) (y : Y) :
   @isincl (hfiber f y) X (@pr1 _ _).
-Proof. intros. refine (isofhlevelfhfiberpr1 _ _ _ _). assumption. Defined.
+Proof.
+  intros. refine (isofhlevelfhfiberpr1 _ _ _ _). assumption.
+Defined.
 
 
 (** Criterion for a function between sets being an inclusion.  *)
@@ -975,12 +1027,16 @@ Definition negProp_to_iff {P} (nP : negProp P) : ¬P <-> nP
   := pr2 (pr2 nP).
 
 Definition negProp_to_neg {P} {nP : negProp P} : nP -> ¬P.
-Proof. intros ? ? np. exact (pr2 (negProp_to_iff nP) np). Defined.
+Proof.
+  intros ? ? np. exact (pr2 (negProp_to_iff nP) np).
+Defined.
 
 Coercion negProp_to_neg : negProp >-> Funclass.
 
 Definition neg_to_negProp {P} {nP : negProp P} : ¬P -> nP.
-Proof. intros ? ? np. exact (pr1 (negProp_to_iff nP) np). Defined.
+Proof.
+  intros ? ? np. exact (pr1 (negProp_to_iff nP) np).
+Defined.
 
 Definition negPred {X:UU} (x  :X) (P:∏ y:X, UU)      := ∏ y  , negProp (P y).
 
@@ -1069,7 +1125,9 @@ Definition isdecproptoisaprop ( X : UU ) ( is : isdecprop X ) : isaprop X := pr2
 Coercion isdecproptoisaprop : isdecprop >-> isaprop .
 
 Lemma isdecpropif ( X : UU ) : isaprop X -> X ⨿ ¬ X -> isdecprop X.
-Proof. intros ? i c. exact (c,,i). Defined.
+Proof.
+  intros ? i c. exact (c,,i).
+Defined.
 
 Lemma isdecpropfromiscontr {P} : iscontr P -> isdecprop P.
 Proof.
@@ -1147,7 +1205,9 @@ Proof.
 Defined.
 
 Lemma isdeceqweqb {X Y : UU} (w : X ≃ Y) (is : isdeceq Y) : isdeceq X.
-Proof. intros. apply (isdeceqweqf (invweq w) is). Defined.
+Proof.
+  intros. apply (isdeceqweqf (invweq w) is).
+Defined.
 
 Theorem isdeceqinclb {X Y : UU} (f : X -> Y) (is : isdeceq Y) (is' : isincl f) :
   isdeceq X.
@@ -1165,7 +1225,9 @@ Proof.
 Defined.
 
 Definition booleq {X : UU} (is : isdeceq X) (x x' : X) : bool.
-Proof. intros. induction (is x x'). apply true. apply false. Defined.
+Proof.
+  intros. induction (is x x'). apply true. apply false.
+Defined.
 
 Lemma eqfromdnegeq (X : UU) (is : isdeceq X) (x x' : X) :
   dneg (x = x') -> x = x'.
@@ -1176,7 +1238,9 @@ Proof.
 Defined.
 
 Lemma isdecequnit : isdeceq unit.
-Proof. apply (isdeceqifisaprop _ isapropunit). Defined.
+Proof.
+  apply (isdeceqifisaprop _ isapropunit).
+Defined.
 
 Theorem isdeceqbool: isdeceq bool.
 Proof.
@@ -1381,7 +1445,9 @@ Defined.
 (** **** [ bool ] is a set *)
 
 Theorem isasetbool: isaset bool.
-Proof. apply (isasetifdeceq _ isdeceqbool). Defined.
+Proof.
+  apply (isasetifdeceq _ isdeceqbool).
+Defined.
 
 (** ** Splitting of [ X ] into a coproduct defined by a function [ X -> bool ] *)
 

--- a/UniMath/Foundations/PartC.v
+++ b/UniMath/Foundations/PartC.v
@@ -78,7 +78,9 @@ Defined.
 
 
 Corollary isapropdneg (X : UU) : isaprop (dneg X).
-Proof. intro. apply (isapropneg (neg X)). Defined.
+Proof.
+  intro. apply (isapropneg (neg X)).
+Defined.
 
 
 Definition isaninvprop (X : UU) := isweq (todneg X).
@@ -126,7 +128,9 @@ Definition pr1compl (X : UU) (x : X) := @pr1 _ (λ x' : X, x != x').
 
 
 Lemma isinclpr1compl (X : UU) (x : X) : isincl (pr1compl X x).
-Proof. intros. apply (isinclpr1 _ (λ x' : X, isapropneg _)). Defined.
+Proof.
+  intros. apply (isinclpr1 _ (λ x' : X, isapropneg _)).
+Defined.
 
 Definition compl_ne (X:UU) (x:X) (neq_x : neqPred x) := ∑ y, neq_x y.
 
@@ -139,17 +143,22 @@ Definition pr1compl_ne (X : UU) (x : X) (neq_x : neqPred x)
   X := pr1 c.
 
 Definition make_negProp {P : UU} : negProp P.
-Proof. intros. exists (¬ P). split.
+Proof.
+  intros. exists (¬ P). split.
        - apply isapropneg.  (* uses [funextemptyAxiom] *)
        - apply isrefl_logeq.
 Defined.
 
 Definition make_neqProp {X : UU} (x y : X) : neqProp x y.
-Proof. intros. apply make_negProp. Defined.
+Proof.
+  intros. apply make_negProp.
+Defined.
 
 Lemma isinclpr1compl_ne (X : UU) (x : X) (neq_x : neqPred x) :
   isincl (pr1compl_ne X x neq_x).
-Proof. intros. apply isinclpr1. intro y. apply negProp_to_isaprop. Defined.
+Proof.
+  intros. apply isinclpr1. intro y. apply negProp_to_isaprop.
+Defined.
 
 Lemma compl_ne_weq_compl (X : UU) (x : X) (neq_x : neqPred x) :
   compl X x ≃ compl_ne X x neq_x.
@@ -224,9 +233,9 @@ Proof.
   intros. intermediate_weq (∑ x', neq_wx (w x')).
   - apply weqfibtototal; intro x'.
     apply weqiff.
-    {intermediate_logeq (x != x').
+    {apply (logeq_trans (Y := x != x')).
      {apply issymm_logeq, negProp_to_iff. }
-     intermediate_logeq (w x != w x').
+     apply (logeq_trans (Y := w x != w x')).
      {apply logeqnegs. apply weq_to_iff. apply weqonpaths. }
      apply negProp_to_iff. }
     {apply negProp_to_isaprop. }
@@ -236,12 +245,16 @@ Defined.
 
 Definition weqoncompl_compute {X Y : UU} (w : X ≃ Y) (x : X) :
   ∏ x', pr1 (weqoncompl w x x') = w (pr1 x').
-Proof. intros. induction x' as [x' b]. apply idpath. Defined.
+Proof.
+  intros. induction x' as [x' b]. apply idpath.
+Defined.
 
 Definition weqoncompl_ne_compute {X Y : UU}
            (w : X ≃ Y) (x : X) (neq_x : neqPred x) (neq_wx : neqPred (w x)) x' :
   pr1 (weqoncompl_ne w x neq_x neq_wx x') = w (pr1 x').
-Proof. intros. apply idpath. Defined.
+Proof.
+  intros. apply idpath.
+Defined.
 
 Definition homotweqoncomplcomp {X Y Z : UU} (f : X ≃ Y) (g : Y ≃ Z)
            (x : X) : homot (weqcomp (weqoncompl f x) (weqoncompl g (f x)))
@@ -501,7 +514,8 @@ Definition funtranspos0 {T: UU} (t1 t2 : T) (is2 : isisolated T t2)
 Definition homottranspos0t2t1t1t2 {T : UU} (t1 t2 : T)
            (is1 : isisolated T t1) (is2 : isisolated T t2) :
   funtranspos0 t2 t1 is1 ∘ funtranspos0 t1 t2 is2 ~ idfun _.
-Proof. intros. intro x. unfold funtranspos0. unfold funcomp.
+Proof.
+  intros. intro x. unfold funtranspos0. unfold funcomp.
        induction x as [ t net1 ]; simpl.
        induction (is2 t) as [ et2 | net2 ].
        - induction (is2 t1) as [ et2t1 | net2t1 ].
@@ -625,7 +639,9 @@ Defined.
 
 
 Definition eqbx (X : UU) (x : X) (is : isisolated X x) : X -> bool.
-Proof. intros X x is x'. induction (is x'). apply true. apply false. Defined.
+Proof.
+  intros X x is x'. induction (is x'). apply true. apply false.
+Defined.
 
 Lemma iscontrhfibereqbx (X : UU) (x : X) (is : isisolated X x) :
   iscontr (hfiber (eqbx X x is) true).
@@ -1190,7 +1206,9 @@ Definition weqtocompltodisjoint (X : UU) : X ≃ compl (X ⨿ unit) (ii2 tt)
   := weqpair _ (isweqtocompltodisjoint X).
 
 Corollary isweqfromcompltodisjoint (X : UU) : isweq (fromcompltodisjoint X).
-Proof. intros. apply (isweqinvmap (weqtocompltodisjoint X)). Defined.
+Proof.
+  intros. apply (isweqinvmap (weqtocompltodisjoint X)).
+Defined.
 
 (** ** Decidable propositions and decidable inclusions *)
 
@@ -1212,7 +1230,9 @@ Proof.
 Defined.
 
 Lemma isdeceqif {X : UU} (is : ∏ x x' : X, isdecprop (x = x')) : isdeceq X.
-Proof. intros. intros x x'. apply (pr1 (is x x')). Defined.
+Proof.
+  intros. intros x x'. apply (pr1 (is x x')).
+Defined.
 
 Lemma isaninv1 (X : UU) : isdecprop X -> isaninvprop X.
 Proof.
@@ -1316,7 +1336,9 @@ Defined.
 
 Definition isdecincl {X Y : UU} (f : X -> Y) := ∏ y : Y, isdecprop (hfiber f y).
 Lemma isdecincltoisincl {X Y : UU} (f : X -> Y) : isdecincl f -> isincl f.
-Proof. intros X Y f is. intro y. apply (isdecproptoisaprop _ (is y)). Defined.
+Proof.
+  intros X Y f is. intro y. apply (isdecproptoisaprop _ (is y)).
+Defined.
 Coercion isdecincltoisincl : isdecincl >-> isincl.
 
 Lemma isdecinclfromisweq {X Y : UU} (f : X -> Y) : isweq f -> isdecincl f.

--- a/UniMath/Foundations/PartD.v
+++ b/UniMath/Foundations/PartD.v
@@ -319,7 +319,9 @@ Definition maponsec1l0 {X : UU} (P : X -> UU) (f : X -> X)
 
 Lemma maponsec1l1 {X : UU} (P : X -> UU) (x : X) (s :∏ x : X, P x) :
   paths (maponsec1l0 P (λ x : X, x) (λ x : X, idpath x) s x) (s x).
-Proof. intros. unfold maponsec1l0. apply idpath. Defined.
+Proof.
+  intros. unfold maponsec1l0. apply idpath.
+Defined.
 
 
 Lemma maponsec1l2 {X : UU} (P : X -> UU) (f : X -> X) (h : ∏ x : X, (f x) = x)
@@ -523,7 +525,9 @@ Defined.
 
 
 Definition tosecoverunit (P : unit -> UU) (p : P tt) : ∏ t : unit, P t.
-Proof. intros. induction t. apply p. Defined.
+Proof.
+  intros. induction t. apply p.
+Defined.
 
 Definition weqsecoverunit (P : unit -> UU) : (∏ t : unit, P t) ≃ (P tt).
 Proof.
@@ -550,7 +554,9 @@ Defined.
 Definition tosecovertotal2 {X : UU} (P : X -> UU) (Q : total2 P -> UU)
            (a : ∏ x : X, ∏ p : P x, Q (tpair _ x p)) :
   ∏ xp : total2 P, Q xp.
-Proof. intros. induction xp as [ x p ]. apply (a x p). Defined.
+Proof.
+  intros. induction xp as [ x p ]. apply (a x p).
+Defined.
 
 
 Definition weqsecovertotal2 {X : UU} (P : X -> UU) (Q : total2 P -> UU) :
@@ -633,15 +639,21 @@ Defined.
 
 Corollary impred_iscontr {T : UU} (P : T -> UU) :
   (∏ t : T, iscontr (P t)) -> (iscontr (∏ t : T, P t)).
-Proof. intros. apply (impred 0). assumption. Defined.
+Proof.
+  intros. apply (impred 0). assumption.
+Defined.
 
 Corollary impred_isaprop {T : UU} (P : T -> UU) :
   (∏ t : T, isaprop (P t)) -> (isaprop (∏ t : T, P t)).
-Proof. apply impred. Defined.
+Proof.
+  apply impred.
+Defined.
 
 Corollary impred_isaset {T : UU} (P : T -> UU) :
   (∏ t : T, isaset (P t)) -> (isaset (∏ t : T, P t)).
-Proof. intros. apply (impred 2). assumption. Defined.
+Proof.
+  intros. apply (impred 2). assumption.
+Defined.
 
 Corollary impredtwice  (n : nat) {T T' : UU} (P : T -> T' -> UU) :
   (∏ (t : T) (t': T'), isofhlevel n (P t t'))
@@ -656,7 +668,9 @@ Defined.
 
 Corollary impredfun (n : nat) (X Y : UU) (is : isofhlevel n Y) :
   isofhlevel n (X -> Y).
-Proof. intros. apply (impred n (λ x , Y) (λ x : X, is)). Defined.
+Proof.
+  intros. apply (impred n (λ x , Y) (λ x : X, is)).
+Defined.
 
 
 Theorem impredtech1 (n : nat) (X Y : UU) :
@@ -701,7 +715,9 @@ Defined.
 (** *** Functions to a proposition *)
 
 Lemma isapropimpl (X Y : UU) (isy : isaprop Y) : isaprop (X -> Y).
-Proof. intros. apply impred. intro. assumption. Defined.
+Proof.
+  intros. apply impred. intro. assumption.
+Defined.
 
 
 
@@ -709,7 +725,9 @@ Proof. intros. apply impred. intro. assumption. Defined.
 
 
 Theorem isapropneg2 (X : UU) {Y : UU} (is : neg Y) : isaprop (X -> Y).
-Proof. intros. apply impred. intro. apply (isapropifnegtrue is). Defined.
+Proof.
+  intros. apply impred. intro. apply (isapropifnegtrue is).
+Defined.
 
 
 
@@ -788,7 +806,9 @@ Proof.
 Defined.
 
 Corollary isapropisaprop (X : UU) : isaprop (isaprop X).
-Proof. intro. apply (isapropisofhlevel (S O)). Defined.
+Proof.
+  intro. apply (isapropisofhlevel (S O)).
+Defined.
 
 Definition isapropisdecprop (X : UU) : isaprop (isdecprop X).
 Proof.
@@ -801,7 +821,9 @@ Proof.
 Defined.
 
 Corollary isapropisaset (X : UU) : isaprop (isaset X).
-Proof. intro. apply (isapropisofhlevel (S (S O))). Defined.
+Proof.
+  intro. apply (isapropisofhlevel (S (S O))).
+Defined.
 
 Theorem isapropisofhlevelf (n : nat) {X Y : UU} (f : X -> Y) :
   isaprop (isofhlevelf n f).
@@ -835,13 +857,19 @@ Defined.
 
 
 Theorem isinclpr1weq (X Y : UU) : isincl (pr1weq : X ≃ Y -> X -> Y).
-Proof. intros. refine (isinclpr1 _ _). intro f.   apply isapropisweq.  Defined.
+Proof.
+  intros. refine (isinclpr1 _ _). intro f.   apply isapropisweq.
+Defined.
 
 Corollary isinjpr1weq (X Y : UU) : isInjective (pr1weq : X ≃ Y -> X -> Y).
-Proof. intros. apply isweqonpathsincl. apply isinclpr1weq. Defined.
+Proof.
+  intros. apply isweqonpathsincl. apply isinclpr1weq.
+Defined.
 
 Theorem isinclpr1isolated (T : UU) : isincl (pr1isolated T).
-Proof. intro. apply (isinclpr1 _ (λ t : T, isapropisisolated T t)). Defined.
+Proof.
+  intro. apply (isinclpr1 _ (λ t : T, isapropisisolated T t)).
+Defined.
 
 (** associativity of weqcomp **)
 
@@ -985,57 +1013,81 @@ Defined.
 (** *** Weak equivalences to and from contractible types *)
 
 Theorem isapropweqtocontr (X : UU) {Y : UU} (is : iscontr Y) : isaprop (X ≃ Y).
-Proof. intros. apply (isofhlevelsnweqtohlevelsn 0 _ _ (isapropifcontr is)). Defined.
+Proof.
+  intros. apply (isofhlevelsnweqtohlevelsn 0 _ _ (isapropifcontr is)).
+Defined.
 
 Theorem isapropweqfromcontr (X : UU) {Y : UU} (is : iscontr Y) : isaprop (Y ≃ X).
-Proof. intros. apply (isofhlevelsnweqfromhlevelsn 0 X _ (isapropifcontr is)). Defined.
+Proof.
+  intros. apply (isofhlevelsnweqfromhlevelsn 0 X _ (isapropifcontr is)).
+Defined.
 
 
 (** *** Weak equivalences to and from propositions *)
 
 
 Theorem isapropweqtoprop (X  Y : UU) (is : isaprop Y) : isaprop (X ≃ Y).
-Proof. intros. apply (isofhlevelsnweqtohlevelsn 0 _ _ is). Defined.
+Proof.
+  intros. apply (isofhlevelsnweqtohlevelsn 0 _ _ is).
+Defined.
 
 Theorem isapropweqfromprop (X Y : UU) (is : isaprop Y) : isaprop (Y ≃ X).
-Proof. intros. apply (isofhlevelsnweqfromhlevelsn 0 X _ is). Defined.
+Proof.
+  intros. apply (isofhlevelsnweqfromhlevelsn 0 X _ is).
+Defined.
 
 
 (** *** Weak equivalences to and from sets *)
 
 Theorem isasetweqtoset (X  Y : UU) (is : isaset Y) : isaset (X ≃ Y).
-Proof. intros. apply (isofhlevelsnweqtohlevelsn 1 _ _ is). Defined.
+Proof.
+  intros. apply (isofhlevelsnweqtohlevelsn 1 _ _ is).
+Defined.
 
 Theorem isasetweqfromset (X Y : UU) (is : isaset Y) : isaset (Y ≃ X).
-Proof. intros. apply (isofhlevelsnweqfromhlevelsn 1 X _ is). Defined.
+Proof.
+  intros. apply (isofhlevelsnweqfromhlevelsn 1 X _ is).
+Defined.
 
 
 
 (** *** Weak equivalences to an empty type *)
 
 Theorem isapropweqtoempty (X : UU) : isaprop (X ≃ empty).
-Proof. intro. apply (isofhlevelsnweqtohlevelsn 0 _ _ (isapropempty)). Defined.
+Proof.
+  intro. apply (isofhlevelsnweqtohlevelsn 0 _ _ (isapropempty)).
+Defined.
 
 
 Theorem isapropweqtoempty2 (X : UU) {Y : UU} (is : neg Y) : isaprop (X ≃ Y).
-Proof. intros. apply (isofhlevelsnweqtohlevelsn 0 _ _ (isapropifnegtrue is)). Defined.
+Proof.
+  intros. apply (isofhlevelsnweqtohlevelsn 0 _ _ (isapropifnegtrue is)).
+Defined.
 
 
 (** *** Weak equivalences from an empty type *)
 
 Theorem isapropweqfromempty (X : UU) : isaprop (empty ≃ X).
-Proof. intro. apply (isofhlevelsnweqfromhlevelsn 0 X _ (isapropempty)). Defined.
+Proof.
+  intro. apply (isofhlevelsnweqfromhlevelsn 0 X _ (isapropempty)).
+Defined.
 
 Theorem isapropweqfromempty2 (X : UU) {Y : UU} (is : neg Y) : isaprop (Y ≃ X).
-Proof. intros. apply (isofhlevelsnweqfromhlevelsn 0 X _ (isapropifnegtrue is)). Defined.
+Proof.
+  intros. apply (isofhlevelsnweqfromhlevelsn 0 X _ (isapropifnegtrue is)).
+Defined.
 
 (** *** Weak equivalences to and from [ unit ] *)
 
 Theorem isapropweqtounit (X : UU) : isaprop (X ≃ unit).
-Proof. intro. apply (isofhlevelsnweqtohlevelsn 0 _ _ (isapropunit)). Defined.
+Proof.
+  intro. apply (isofhlevelsnweqtohlevelsn 0 _ _ (isapropunit)).
+Defined.
 
 Theorem isapropweqfromunit (X : UU) : isaprop (unit ≃ X).
-Proof. intros. apply (isofhlevelsnweqfromhlevelsn 0 X _ (isapropunit)). Defined.
+Proof.
+  intros. apply (isofhlevelsnweqfromhlevelsn 0 X _ (isapropunit)).
+Defined.
 
 (** ** Weak auto-equivalences of a type with an isolated point *)
 
@@ -1173,7 +1225,8 @@ end.
 
 Definition locsplitsecissec (X Y : UU) (f : X -> Y) (ls : locsplit f)
 (u:dnegimage  f) : paths (xtodnegimage f (locsplitsec  f ls u)) u.
-Proof. intros. set (p := xtodnegimage f). set (s := locsplitsec f ls).
+Proof.
+  intros. set (p := xtodnegimage f). set (s := locsplitsec f ls).
 assert (paths (pr1 (p (s u))) (pr1  u)). unfold p. unfold xtodnegimage.
 unfold s. unfold locsplitsec. simpl. induction u. set (lst := ls t).
 induction lst.  simpl. apply (pr2  x0). induction (x y).

--- a/UniMath/Foundations/Preamble.v
+++ b/UniMath/Foundations/Preamble.v
@@ -103,14 +103,20 @@ Definition coprod_rect_compute_1
            (f : ∏ (a : A), P (ii1 a))
            (g : ∏ (b : B), P (ii2 b)) (a:A) :
   coprod_rect P f g (ii1 a) = f a.
-Proof. intros. apply idpath. Defined.
+Proof.
+  intros.
+  apply idpath.
+Defined.
 
 Definition coprod_rect_compute_2
            (A B : UU) (P : A ⨿ B -> UU)
            (f : ∏ a : A, P (ii1 a))
            (g : ∏ b : B, P (ii2 b)) (b:B) :
   coprod_rect P f g (ii2 b) = g b.
-Proof. intros. apply idpath. Defined.
+Proof.
+  intros.
+  apply idpath.
+Defined.
 
 (** Dependent sums.
 
@@ -191,9 +197,12 @@ Defined.
 Notation mult := mul.           (* this overrides the notation "mult" defined in Coq's Peano.v *)
 Notation "n * m" := (mul n m) : nat_scope.
 
+(** Some tactics  *)
 
+(* Apply this tactic to a proof of ([X] and [X -> ∅]), in either order: *)
+Ltac contradicts a b := solve [ induction (a b) | induction (b a) ].
 
-(** A few tactics, thanks go to Jason Gross *)
+(** A few more tactics, thanks go to Jason Gross *)
 
 Ltac simple_rapply p :=
   simple refine p ||
@@ -217,6 +226,11 @@ Tactic Notation "use" uconstr(p) := simple_rapply p.
 
 Tactic Notation "transparent" "assert" "(" ident(name) ":" constr(type) ")" :=
   simple refine (let name := (_ : type) in _).
+
+Ltac exact_op x := (* from Jason Gross: same as "exact", but with unification the opposite way *)
+  let T := type of x in
+  let G := match goal with |- ?G => constr:(G) end in
+  exact (((λ g:G, g) : T -> G) x).
 
 (** reserve notations for later use: *)
 

--- a/UniMath/Foundations/Propositions.v
+++ b/UniMath/Foundations/Propositions.v
@@ -96,7 +96,9 @@ Definition tildehProp := total2 (λ P : hProp, P).
 Definition tildehProppair {P : hProp} (p : P) : tildehProp := tpair _ P p.
 
 Definition negProp_to_hProp {P : UU} (Q : negProp P) : hProp.
-Proof. intros. exists (negProp_to_type Q). apply negProp_to_isaprop. Defined.
+Proof.
+  intros. exists (negProp_to_type Q). apply negProp_to_isaprop.
+Defined.
 Coercion negProp_to_hProp : negProp >-> hProp.
 
 (* convenient corollaries of some theorems that take separate isaprop
@@ -104,14 +106,20 @@ Coercion negProp_to_hProp : negProp >-> hProp.
 
 Corollary subtypeInjectivity_prop {A : UU} (B : A -> hProp) :
   ∏ (x y : total2 B), (x = y) ≃ (pr1 x = pr1 y).
-Proof. intros. apply subtypeInjectivity. intro. apply propproperty. Defined.
+Proof.
+  intros. apply subtypeInjectivity. intro. apply propproperty.
+Defined.
 
 Corollary subtypeEquality_prop {A : UU} {B : A -> hProp}
    {s s' : total2 (λ x, B x)} : pr1 s = pr1 s' -> s = s'.
-Proof. intros A B s s'. apply invmap. apply subtypeInjectivity_prop. Defined.
+Proof.
+  intros A B s s'. apply invmap. apply subtypeInjectivity_prop.
+Defined.
 
 Corollary impred_prop {T : UU} (P : T -> hProp) : isaprop (∏ t : T, P t).
-Proof. intros. apply impred; intro. apply propproperty. Defined.
+Proof.
+  intros. apply impred; intro. apply propproperty.
+Defined.
 
 Corollary isaprop_total2 (X : hProp) (Y : X -> hProp) : isaprop (∑ x, Y x).
 Proof.
@@ -122,7 +130,9 @@ Proof.
 Defined.
 
 Lemma isaprop_forall_hProp (X : UU) (Y : X -> hProp) : isaprop (∏ x, Y x).
-Proof. intros. apply impred_isaprop. intro x. apply propproperty. Defined.
+Proof.
+  intros. apply impred_isaprop. intro x. apply propproperty.
+Defined.
 
 Definition forall_hProp {X : UU} (Y : X -> hProp) : hProp
   := hProppair (∏ x, Y x) (isaprop_forall_hProp X Y).
@@ -199,10 +209,14 @@ Definition hinhuniv {X : UU} {P : hProp} (f : X -> P) (wit : ∥ X ∥) : P
   := wit P f.
 
 Corollary factor_through_squash {X Q : UU} : isaprop Q -> (X -> Q) -> ∥ X ∥ -> Q.
-Proof. intros ? ? i f h. exact (@hinhuniv X (Q,,i) f h). Defined.
+Proof.
+  intros ? ? i f h. exact (@hinhuniv X (Q,,i) f h).
+Defined.
 
 Corollary squash_to_prop {X Q : UU} : ∥ X ∥ -> isaprop Q -> (X -> Q) -> Q.
-Proof. intros ? ? h i f. exact (@hinhuniv X (Q,,i) f h). Defined.
+Proof.
+  intros ? ? h i f. exact (@hinhuniv X (Q,,i) f h).
+Defined.
 
 Definition hinhand {X Y : UU} (inx1 : ∥ X ∥) (iny1 : ∥ Y ∥) : ∥ X × Y ∥
   := λ P : _, ddualand (inx1 P) (iny1 P).
@@ -416,7 +430,9 @@ Notation "'¬' X" := (hneg X) (at level 35, right associativity) : logic.
 Delimit Scope logic with logic.
 
 Definition himpl (P : UU) (Q : hProp) : hProp.
-Proof. intros. split with (P -> Q). apply impred. intro. apply (pr2 Q). Defined.
+Proof.
+  intros. split with (P -> Q). apply impred. intro. apply (pr2 Q).
+Defined.
 
 Local Notation "A ⇒ B" := (himpl A B) (at level 95, no associativity) : logic.
   (* precedence same as <-> *)
@@ -665,7 +681,9 @@ Proof.
 Defined.
 
 Definition eqweqmaphProp {P P' : hProp} (e : @paths hProp P P') : P ≃ P'.
-Proof. intros. destruct e. apply idweq. Defined.
+Proof.
+  intros. destruct e. apply idweq.
+Defined.
 
 Definition weqtopathshProp {P P' : hProp} (w : P ≃ P') : P = P'
   := hPropUnivalence P P' w (invweq w).
@@ -726,7 +744,9 @@ Defined.
 
 Definition weqpathsweqhProp' {P P' : hProp} (e : P = P') :
   weqtopathshProp (eqweqmaphProp e) = e.
-Proof. intros. apply isasethProp. Defined.
+Proof.
+  intros. apply isasethProp.
+Defined.
 
 Lemma iscontrtildehProp : iscontr tildehProp.
 Proof.
@@ -736,10 +756,14 @@ Proof.
 Defined.
 
 Lemma isaproptildehProp : isaprop tildehProp.
-Proof. apply (isapropifcontr iscontrtildehProp). Defined.
+Proof.
+  apply (isapropifcontr iscontrtildehProp).
+Defined.
 
 Lemma isasettildehProp : isaset tildehProp.
-Proof. apply (isasetifcontr iscontrtildehProp). Defined.
+Proof.
+  apply (isasetifcontr iscontrtildehProp).
+Defined.
 
 
 (* ** Logical equivalence yields weak equivalence *)

--- a/UniMath/Foundations/Sets.v
+++ b/UniMath/Foundations/Sets.v
@@ -109,7 +109,9 @@ Proof.
 Defined.
 
 Definition setcoprod (X Y : hSet) : hSet.
-Proof. intros. exists (X ⨿ Y). apply isasetcoprod; apply setproperty. Defined.
+Proof.
+  intros. exists (X ⨿ Y). apply isasetcoprod; apply setproperty.
+Defined.
 
 Lemma isaset_total2_hSet (X : hSet) (Y : X -> hSet) : isaset (∑ x, Y x).
 Proof.
@@ -131,7 +133,9 @@ Notation "'∑' x .. y , P" := (total2_hSet (λ x,.. (total2_hSet (λ y, P))..))
   (* type this in emacs in agda-input method with \sum *)
 
 Lemma isaset_forall_hSet (X : UU) (Y : X -> hSet) : isaset (∏ x, Y x).
-Proof. intros. apply impred_isaset. intro x. apply setproperty. Defined.
+Proof.
+  intros. apply impred_isaset. intro x. apply setproperty.
+Defined.
 
 Definition forall_hSet {X : UU} (Y : X -> hSet) : hSet
   := hSetpair (∏ x, Y x) (isaset_forall_hSet X Y).
@@ -225,7 +229,9 @@ Defined.
 
 Lemma ischoicebaseweqb {X Y : UU} (w : X ≃ Y) (is : ischoicebase Y) :
   ischoicebase X.
-Proof. intros. apply (ischoicebaseweqf (invweq w) is). Defined.
+Proof.
+  intros. apply (ischoicebaseweqf (invweq w) is).
+Defined.
 
 Lemma ischoicebaseunit : ischoicebase unit.
 Proof.
@@ -300,7 +306,9 @@ Notation "'∑' x .. y , P"
 Delimit Scope subset with subset.
 
 Lemma isinclpr1carrier {X : UU} (A : hsubtype X) : isincl (@pr1carrier X A).
-Proof. intros. apply (isinclpr1 A (λ x : _, pr2 (A x))). Defined.
+Proof.
+  intros. apply (isinclpr1 A (λ x : _, pr2 (A x))).
+Defined.
 
 Lemma isasethsubtype (X : UU) : isaset (hsubtype X).
 Proof.
@@ -313,7 +321,9 @@ Defined.
 Definition totalsubtype (X : UU) : hsubtype X := λ x, htrue.
 
 Definition weqtotalsubtype (X : UU) : totalsubtype X ≃ X.
-Proof. intro. apply weqpr1. intro. apply iscontrunit. Defined.
+Proof.
+  intro. apply weqpr1. intro. apply iscontrunit.
+Defined.
 
 Definition weq_subtypes {X Y : UU} (w : X ≃ Y)
            (S : hsubtype X) (T : hsubtype Y) :
@@ -602,10 +612,14 @@ Defined.
 
 Lemma istransandirrefltoasymm {X : UU} {R : hrel X}
       (is1 : istrans R) (is2 : isirrefl R) : isasymm R.
-Proof. intros. intros a b rab rba. apply (is2 _ (is1 _ _ _ rab rba)). Defined.
+Proof.
+  intros. intros a b rab rba. apply (is2 _ (is1 _ _ _ rab rba)).
+Defined.
 
 Lemma istotaltoiscoasymm {X : UU} {R : hrel X} (is : istotal R) : iscoasymm R.
-Proof. intros. intros x1 x2. apply (hdisjtoimpl (is _ _)). Defined.
+Proof.
+  intros. intros x1 x2. apply (hdisjtoimpl (is _ _)).
+Defined.
 
 Lemma isdecreltoisnegrel {X : UU} {R : hrel X} (is : isdecrel R) : isnegrel R.
 Proof.
@@ -625,7 +639,9 @@ Defined.
 
 Lemma rtoneq {X : UU} {R : hrel X} (is : isirrefl R) {a b : X} (r : R a b) :
   a != b.
-Proof. intros. intro e. rewrite e in r. apply (is b r). Defined.
+Proof.
+  intros. intro e. rewrite e in r. apply (is b r).
+Defined.
 
 
 (** *** Standard properties of relations and logical equivalences *)
@@ -642,7 +658,9 @@ Defined.
 
 Definition isrefllogeqf {X : UU} {L R : hrel X}
            (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : isrefl L) : isrefl R.
-Proof. intros. intro x. apply (pr1 (lg _ _) (isl x)). Defined.
+Proof.
+  intros. intro x. apply (pr1 (lg _ _) (isl x)).
+Defined.
 
 Definition issymmlogeqf {X : UU} {L R : hrel X}
            (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : issymm L) : issymm R.
@@ -667,7 +685,9 @@ Defined.
 
 Definition isirrefllogeqf {X : UU} {L R : hrel X}
            (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : isirrefl L) : isirrefl R.
-Proof. intros. intros x r. apply (isl _ (pr2 (lg x x) r)). Defined.
+Proof.
+  intros. intros x r. apply (isl _ (pr2 (lg x x) r)).
+Defined.
 
 Definition isasymmlogeqf {X : UU} {L R : hrel X}
            (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : isasymm L) : isasymm R.
@@ -782,13 +802,19 @@ Coercion carrierofposet : Poset >-> hSet.
 Definition posetRelation (X : Poset) : hrel X := pr1 (pr2 X).
 
 Lemma isrefl_posetRelation (X : Poset) : isrefl (posetRelation X).
-Proof. intros ? x. exact (pr2 (pr1 (pr2 (pr2 X))) x). Defined.
+Proof.
+  intros ? x. exact (pr2 (pr1 (pr2 (pr2 X))) x).
+Defined.
 
 Lemma istrans_posetRelation (X : Poset) : istrans (posetRelation X).
-Proof. intros ? x y z l m. exact (pr1 (pr1 (pr2 (pr2 X))) x y z l m). Defined.
+Proof.
+  intros ? x y z l m. exact (pr1 (pr1 (pr2 (pr2 X))) x y z l m).
+Defined.
 
 Lemma isantisymm_posetRelation (X : Poset) : isantisymm (posetRelation X).
-Proof. intros ? x y l m. exact (pr2 (pr2 (pr2 X)) x y l m). Defined.
+Proof.
+  intros ? x y l m. exact (pr2 (pr2 (pr2 X)) x y l m).
+Defined.
 
 Delimit Scope poset with poset.
 Notation "m ≤ n" := (posetRelation _ m n) (no associativity, at level 70) :
@@ -809,7 +835,9 @@ Definition isdec_ordering (X : Poset) : UU
 
 Lemma isaprop_isaposetmorphism {X Y : Poset} (f : X -> Y) :
   isaprop (isaposetmorphism f).
-Proof. intros. apply impredtwice; intros. apply impred_prop. Defined.
+Proof.
+  intros. apply impredtwice; intros. apply impred_prop.
+Defined.
 
 (** the preorders on a set form a set *)
 
@@ -862,10 +890,13 @@ Definition posetUnderlyingEquivalence {X Y : Poset} : X ≅ Y -> X ≃ Y := pr1.
 Coercion posetUnderlyingEquivalence : PosetEquivalence >-> weq.
 
 Definition identityPosetEquivalence (X : Poset) : PosetEquivalence X X.
-Proof. intros. exists (idweq X). apply isPosetEquivalence_idweq. Defined.
+Proof.
+  intros. exists (idweq X). apply isPosetEquivalence_idweq.
+Defined.
 
 Lemma isincl_pr1_PosetEquivalence (X Y : Poset) : isincl (pr1 : X ≅ Y -> X ≃ Y).
-Proof. intros. apply isinclpr1. apply isaprop_isPosetEquivalence.
+Proof.
+  intros. apply isinclpr1. apply isaprop_isPosetEquivalence.
 Defined.
 
 Lemma isinj_pr1_PosetEquivalence (X Y : Poset) :
@@ -975,11 +1006,15 @@ Defined.
 
 Lemma isasymmnegrel {X : UU} (R : hrel X) (isr : iscoasymm R) :
   isasymm (negrel R).
-Proof. intros. intros x1 x2 r12 r21. apply (r21 (isr _ _ r12)). Defined.
+Proof.
+  intros. intros x1 x2 r12 r21. apply (r21 (isr _ _ r12)).
+Defined.
 
 Lemma iscoasymmgenrel {X : UU} (R : hrel X) (isr : isasymm R) :
   iscoasymm (negrel R).
-Proof. intros. intros x1 x2 nr12. apply (negf (isr _ _) nr12). Defined.
+Proof.
+  intros. intros x1 x2 nr12. apply (negf (isr _ _) nr12).
+Defined.
 
 Lemma isdecnegrel {X : UU} (R : hrel X) (isr : isdecrel R) :
   isdecrel (negrel R).
@@ -999,7 +1034,9 @@ Defined.
 
 Lemma isantisymmnegrel {X : UU} (R : hrel X) (isr : isantisymmneg R) :
   isantisymm (negrel R).
-Proof. intros. apply isr. Defined.
+Proof.
+  intros. apply isr.
+Defined.
 
 (** *** Boolean representation of decidable equality *)
 
@@ -1114,7 +1151,8 @@ Defined.
   Definition pathstor_comp {X : UU} (R : decrel X) (x x' : X)
   (e : (decreltobrel R x x') = true) : R x x'.
   Proof. unfold decreltobrel. intros.  destruct (pr2 R x x') as [ e' | ne ].
-  apply e'. destruct (nopathsfalsetotrue e). Defined.
+  apply e'. destruct (nopathsfalsetotrue e).
+Defined.
 
   Notation " 'ct' (R, x, y) " := ((pathstor_comp _ x y (idpath true)) : R x y)
                                  (at level 70).
@@ -1159,7 +1197,8 @@ Notation " 'ct' ( R , is , x , y ) " := (ctlong R is x y (idpath true))
  *)
 
 Definition deceq_to_decrel {X:UU} : isdeceq X -> decrel X.
-Proof. intros ? i. use decrelpair.
+Proof.
+  intros ? i. use decrelpair.
        - intros x y. exists (x=y). apply isasetifdeceq. assumption.
        - exact i.
 Defined.
@@ -1177,11 +1216,6 @@ Proof.
   intros.
   exact (pathstonegr (deceq_to_decrel i) _ _ e).
 Defined.
-
-Ltac exact_op x := (* from Jason Gross: same as "exact", but with unification the opposite way *)
-  let T := type of x in
-  let G := match goal with |- ?G => constr:(G) end in
-  exact ((@idfun G : T -> G) x).
 
 (* I don't know why exact_op works better here, but with "exact", the code in RealNumbers/Prelim.v breaks *)
 Ltac confirm_yes      d x y := exact_op (pathstor d x y (idpath true)).
@@ -1204,11 +1238,15 @@ Defined.
 
 Definition isreflresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : isrefl L) : isrefl (resrel L P).
-Proof. intros. intro x. apply isl. Defined.
+Proof.
+  intros. intro x. apply isl.
+Defined.
 
 Definition issymmresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : issymm L) : issymm (resrel L P).
-Proof. intros. intros x1 x2 r12. apply isl. apply r12. Defined.
+Proof.
+  intros. intros x1 x2 r12. apply isl. apply r12.
+Defined.
 
 Definition isporesrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : ispreorder L) : ispreorder (resrel L P).
@@ -1227,31 +1265,45 @@ Defined.
 
 Definition isirreflresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : isirrefl L) : isirrefl (resrel L P).
-Proof. intros. intros x r. apply (isl _ r). Defined.
+Proof.
+  intros. intros x r. apply (isl _ r).
+Defined.
 
 Definition isasymmresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : isasymm L) : isasymm (resrel L P).
-Proof. intros. intros x1 x2 r12 r21. apply (isl _ _ r12 r21). Defined.
+Proof.
+  intros. intros x1 x2 r12 r21. apply (isl _ _ r12 r21).
+Defined.
 
 Definition iscoasymmresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : iscoasymm L) : iscoasymm (resrel L P).
-Proof. intros. intros x1 x2 r12. apply (isl _ _ r12). Defined.
+Proof.
+  intros. intros x1 x2 r12. apply (isl _ _ r12).
+Defined.
 
 Definition istotalresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : istotal L) : istotal (resrel L P).
-Proof. intros. intros x1 x2. apply isl. Defined.
+Proof.
+  intros. intros x1 x2. apply isl.
+Defined.
 
 Definition iscotransresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : iscotrans L) : iscotrans (resrel L P).
-Proof. intros. intros x1 x2 x3 r13. apply (isl _ _ _ r13). Defined.
+Proof.
+  intros. intros x1 x2 x3 r13. apply (isl _ _ _ r13).
+Defined.
 
 Definition isdecrelresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : isdecrel L) : isdecrel (resrel L P).
-Proof. intros. intros x1 x2. apply isl. Defined.
+Proof.
+  intros. intros x1 x2. apply isl.
+Defined.
 
 Definition isnegrelresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : isnegrel L) : isnegrel (resrel L P).
-Proof. intros. intros x1 x2 nnr. apply (isl _ _ nnr). Defined.
+Proof.
+  intros. intros x1 x2 nnr. apply (isl _ _ nnr).
+Defined.
 
 Definition isantisymmresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : isantisymm L) : isantisymm (resrel L P).
@@ -1630,7 +1682,9 @@ Definition iscomprelfun {X Y : UU} (R : hrel X) (f : X -> Y) : UU
 
 Lemma iscomprelfunlogeqf {X Y : UU} {R L : hrel X} (lg : hrellogeq L R)
       (f : X -> Y) (is : iscomprelfun L f) : iscomprelfun R f.
-Proof. intros. intros x x' r. apply (is _ _ (pr2 (lg  _ _) r)). Defined.
+Proof.
+  intros. intros x x' r. apply (is _ _ (pr2 (lg  _ _) r)).
+Defined.
 
 Lemma isapropimeqclass {X : UU} (R : hrel X) (Y : hSet) (f : X -> Y)
       (is : iscomprelfun R f) (c : setquot R) :
@@ -1701,12 +1755,16 @@ Definition iscomprelrelfun {X Y : UU} (RX : hrel X) (RY : hrel Y) (f : X -> Y)
 Lemma iscomprelfunlogeqf1 {X Y : UU} {LX RX : hrel X} (RY : hrel Y)
       (lg : hrellogeq LX RX) (f : X -> Y) (is : iscomprelrelfun LX RY f) :
   iscomprelrelfun RX RY f.
-Proof. intros. intros x x' r. apply (is _ _ (pr2 (lg  _ _) r)). Defined.
+Proof.
+  intros. intros x x' r. apply (is _ _ (pr2 (lg  _ _) r)).
+Defined.
 
 Lemma iscomprelfunlogeqf2 {X Y : UU} (RX : hrel X) {LY RY : hrel Y}
       (lg : hrellogeq LY RY) (f : X -> Y) (is : iscomprelrelfun RX LY f) :
   iscomprelrelfun RX RY f.
-Proof. intros. intros x x' r. apply ((pr1 (lg _ _)) (is _ _ r)). Defined.
+Proof.
+  intros. intros x x' r. apply ((pr1 (lg _ _)) (is _ _ r)).
+Defined.
 
 Definition setquotfun {X Y : UU} (RX : hrel X) (RY : eqrel Y) (f : X -> Y)
            (is : iscomprelrelfun RX RY f) (cx : setquot RX) : setquot RY.
@@ -1725,7 +1783,9 @@ Defined.
 Definition setquotfuncomm {X Y : UU} (RX : eqrel X) (RY : eqrel Y)
            (f : X -> Y) (is : iscomprelrelfun RX RY f) :
   ∏ x : X, setquotfun RX RY f is (setquotpr RX x) = setquotpr RY (f x).
-Proof. intros. simpl. apply idpath. Defined.
+Proof.
+  intros. simpl. apply idpath.
+Defined.
 
 
 
@@ -2012,7 +2072,9 @@ Defined.
 Theorem setquotuniv2comm {X : UU} (R : eqrel X) (Y : hSet) (f : X -> X -> Y)
         (is : iscomprelfun2 R f) :
   ∏ x x' : X, setquotuniv2 R Y f is (setquotpr R x) (setquotpr R x') = f x x'.
-Proof. intros. apply idpath. Defined.
+Proof.
+  intros. apply idpath.
+Defined.
 
 
 
@@ -2074,7 +2136,9 @@ Theorem setquotfun2comm {X Y : UU} (RX : eqrel X) (RY : eqrel Y)
         (f : X -> X -> Y) (is : iscomprelrelfun2 RX RY f) :
   ∏ (x x' : X), setquotfun2 RX RY f is (setquotpr RX x) (setquotpr RX x')
                 = setquotpr RY (f x x').
-Proof. intros. apply idpath. Defined.
+Proof.
+  intros. apply idpath.
+Defined.
 
 
 
@@ -2093,7 +2157,9 @@ Defined.
 
 Definition setquotbooleqint {X : UU} (R : eqrel X)
            (is : ∏ x x' : X, isdecprop (R x x')) (x x' : X) : bool.
-Proof. intros. destruct (pr1 (is x x')). apply true. apply false. Defined.
+Proof.
+  intros. destruct (pr1 (is x x')). apply true. apply false.
+Defined.
 
 Lemma setquotbooleqintcomp {X : UU} (R : eqrel X)
       (is : ∏ x x' : X, isdecprop (R x x')) :
@@ -2188,7 +2254,9 @@ Defined.
 
 Lemma iscomprelrellogeqf1 {X : UU} {R R' : hrel X} (L : hrel X)
       (lg : hrellogeq R R') (is : iscomprelrel R L) : iscomprelrel R' L.
-Proof. intros. apply (iscomprelfun2logeqf lg L is). Defined.
+Proof.
+  intros. apply (iscomprelfun2logeqf lg L is).
+Defined.
 
 Lemma iscomprelrellogeqf2 {X : UU} (R : hrel X) {L L' : hrel X}
       (lg : hrellogeq L L') (is : iscomprelrel R L) : iscomprelrel R L'.
@@ -2739,7 +2807,9 @@ Proof.
 Defined.
 
 Definition toqeq {X Y : UU} (R : hrel X) (x : X) : @qeq X Y R.
-Proof. intros. split with (Fi X Y R x). intro psi. apply idpath. Defined.
+Proof.
+  intros. split with (Fi X Y R x). intro psi. apply idpath.
+Defined.
 
 Lemma iscomptoqeq {X : UU} (Y : hSet) (R : hrel X) :
       iscomprelfun R (@toqeq X Y R).
@@ -2751,11 +2821,15 @@ Defined.
 
 Definition qequniv {X : UU} (Y : hSet) (R : hrel X) (f : compfun R Y)
        (phi : @qeq X Y R) : Y.
-Proof. intros. apply (Fv R f (pr1 phi)). Defined.
+Proof.
+  intros. apply (Fv R f (pr1 phi)).
+Defined.
 
 Lemma qequnivandpr {X : UU} (Y : hSet) (R : hrel X) (f : compfun R Y)
    (x : X) : paths (qequniv Y R f (toqeq R x)) (f x).
-Proof. intros. apply idpath. Defined.
+Proof.
+  intros. apply idpath.
+Defined.
 
 Lemma etaqeq {X : UU} (Y : hSet) (R : hrel X) (psi : qeq R -> Y)
        (phi : qeq R) : paths (psi phi)
@@ -2781,11 +2855,15 @@ Definition Ffunct {X1 X2 : UU} (f : X1 -> X2) (Y : UU) : F X1 Y -> F X2 Y
 
 Lemma testd1 {X Y : UU} (psi : F X Y -> Y) (phi : F X Y) :
   paths (psi phi) (Fd1 phi psi).
-Proof. intros. apply idpath. Defined.
+Proof.
+  intros. apply idpath.
+Defined.
 
 Lemma testd2 {X Y : UU} (psi : F X Y -> Y) (phi : F X Y) :
    paths (Fv (funcomp (Fi X Y) psi) phi) (Fd2 phi psi).
-Proof. intros. apply idpath. Defined.
+Proof.
+  intros. apply idpath.
+Defined.
 
 Definition F (X Y : UU) := (X -> Y) -> Y.
 
@@ -2802,18 +2880,24 @@ Definition Fv {X Y : UU} (f : X -> Y) (phi : F X Y) : Y := phi f.
 
 Lemma testd1 {X Y : UU} (psi : F X Y -> Y) (phi : F X Y) :
    paths (psi phi) (Fd1 phi psi).
-Proof. intros. apply idpath. Defined.
+Proof.
+  intros. apply idpath.
+Defined.
 
 Lemma testd2 {X Y : UU} (psi : F X Y -> Y) (phi : F X Y) :
    paths (Fv (funcomp (Fi X Y) psi) phi) (Fd2 phi psi).
-Proof. intros. apply idpath. Defined.
+Proof.
+  intros. apply idpath.
+Defined.
 
 
 
 
 
 Lemma Xineq (X Y : UU) (x : X) : paths (Fd1 (Fi X Y x)) (Fd2 (Fi X Y x)).
-Proof. intros. apply idpath. Defined.
+Proof.
+  intros. apply idpath.
+Defined.
 
 Lemma test (X Y : UU) (phi : F X Y) (f : X -> Y) :
    paths (Fd1 phi (Fi (X -> Y) Y f)) (Fd2 phi (Fi (X -> Y) Y f)).
@@ -2828,7 +2912,9 @@ Inductive try0 (T : UU) (t : T) :
 
 Definition try0map1 (T : UU) (t : T) (t1 t2 : T) (e1 : t = t1)
    (e2 : t = t2) (X : try0 T t t1 t2 e1 e2) : t1 = t2.
-Proof. intros. destruct  X. apply idpath. Defined.
+Proof.
+  intros. destruct  X. apply idpath.
+Defined.
 
 Definition try0map2 (T : UU) (t : T) (t1 t2 : T) (e1 : t = t1)
    (e2 : t = t2) : try0 T t t1 t2 e1 e2.
@@ -2838,12 +2924,14 @@ Proof.
 Lemma test (X : UU) (t : X) :
    paths (pr2 (iscontrcoconustot X t) (pr1 (iscontrcoconustot X t)))
          (idpath _).
-Proof. intros. apply idpath.
+Proof.
+  intros. apply idpath.
 
 
 Lemma test {X : UU} (is : iscontr X) :
    paths (pr2 (iscontrcor is) (pr1 (iscontrcor is))) (idpath _).
-Proof. intros. apply idpath.
+Proof.
+  intros. apply idpath.
 
 
 
@@ -2889,7 +2977,9 @@ Definition setquot2pr {X : UU} (R : hrel X) : X -> setquot2 R
                          (hinhpr (hfiberpair (compevmapset R) x (idpath _))).
 
 Lemma issurjsetquot2pr {X : UU} (R : hrel X) : issurjective (setquot2pr R).
-Proof. intros. apply issurjprtoimage. Defined.
+Proof.
+  intros. apply issurjprtoimage.
+Defined.
 
 Lemma iscompsetquot2pr {X : UU} (R : hrel X) : iscomprelfun R (setquot2pr R).
 Proof.
@@ -2915,7 +3005,9 @@ Definition setquot2univ {X : UU} (R : hrel X) (Y : hSet) (F : X -> Y)
 Theorem setquot2univcomm  {X : UU} (R : hrel X) (Y : hSet) (F : X -> Y)
         (iscomp : iscomprelfun R F) (x : X) :
   setquot2univ _ _ F iscomp (setquot2pr R x) = F x.
-Proof. intros. apply idpath. Defined.
+Proof.
+  intros. apply idpath.
+Defined.
 
 (** *** Weak equivalence from [R x x'] to [paths (setquot2pr R x) (setquot2pr R x')] *)
 
@@ -2965,7 +3057,9 @@ Defined.
 Require Import UniMath.Foundations.UnivalenceAxiom.
 
 Definition hSet_univalence_map (X Y : hSet) : (X = Y) -> (pr1 X ≃ pr1 Y).
-Proof. intros ? ? e. exact (eqweqmap (maponpaths pr1hSet e)). Defined.
+Proof.
+  intros ? ? e. exact (eqweqmap (maponpaths pr1hSet e)).
+Defined.
 
 Theorem hSet_univalence (X Y : hSet) : (X = Y) ≃ (X ≃ Y).
 Proof.

--- a/UniMath/Foundations/Tests.v
+++ b/UniMath/Foundations/Tests.v
@@ -73,10 +73,14 @@ Module Test_sets.
 
   Goal ∏ Y (is:isaset Y) (F:Y->UU) (e :∏ y y', F y -> F y' -> y=y')
          y (f:F y), squash_pairs_to_set F is e (hinhpr (y,,f)) = y.
-  Proof. intros. apply idpath. Qed.
+  Proof.
+    intros. apply idpath.
+  Qed.
 
   Goal ∏ X Y (is:isaset Y) (f:X->Y) (e:∏ x x', f x = f x'),
          f = funcomp hinhpr (squash_to_set is f e).
-  Proof. intros. apply idpath. Qed.
+  Proof.
+    intros. apply idpath.
+  Qed.
 
 End Test_sets.

--- a/UniMath/Foundations/UnivalenceAxiom.v
+++ b/UniMath/Foundations/UnivalenceAxiom.v
@@ -35,7 +35,9 @@ Require Export UniMath.Foundations.PartB.
 (* everything related to eta correction is obsolete *)
 
 Definition eqweqmap { T1 T2 : UU } : T1 = T2 -> T1 ≃ T2.
-Proof. intro e. induction e. apply idweq. Defined.
+Proof.
+  intro e. induction e. apply idweq.
+Defined.
 
 Definition sectohfiber { X : UU } (P:X -> UU): (∏ x:X, P x) -> (hfiber (λ f, λ x, pr1  (f x)) (λ x:X, x)) := (fun a : ∏ x:X, P x => tpair _ (λ x, tpair _ x (a x)) (idpath (λ x:X, x))).
 
@@ -50,13 +52,19 @@ Proof.
 Defined.
 
 Lemma isweqtransportf10 { X : UU } ( P : X -> UU ) { x x' : X } ( e :  x = x' ) : isweq ( transportf P e ).
-Proof. intros. destruct e.  apply idisweq. Defined.
+Proof.
+  intros. destruct e.  apply idisweq.
+Defined.
 
 Lemma isweqtransportb10 { X : UU } ( P : X -> UU ) { x x' : X } ( e :  x = x' ) : isweq ( transportb P e ).
-Proof. intros. apply ( isweqtransportf10 _ ( pathsinv0 e ) ). Defined.
+Proof.
+  intros. apply ( isweqtransportf10 _ ( pathsinv0 e ) ).
+Defined.
 
 Lemma l1  { X0 X0' : UU } ( ee : X0 = X0' ) ( P : UU -> UU ) ( pp' : P X0' ) ( R : ∏ X X' : UU , ∏ w : X ≃ X' , P X' -> P X ) ( r : ∏ X : UU , ∏ p : P X , paths ( R X X ( idweq X ) p ) p ) : paths ( R X0 X0' ( eqweqmap ee ) pp' ) (  transportb P ee pp' ).
-Proof. destruct ee. simpl. apply r. Defined.
+Proof.
+  destruct ee. simpl. apply r.
+Defined.
 
 (** Axiom statements (propositions) *)
 
@@ -156,7 +164,9 @@ Section UnivalenceImplications.
   Hypothesis univalenceAxiom : univalenceStatement.
 
   Theorem univalenceUAH (X Y:UU) : (X=Y) ≃ (X≃Y).
-  Proof. exact (weqpair _ (univalenceAxiom X Y)). Defined.
+  Proof.
+    exact (weqpair _ (univalenceAxiom X Y)).
+  Defined.
 
   Definition weqtopathsUAH : weqtopathsStatement.
   Proof.
@@ -240,10 +250,14 @@ Section UnivalenceImplications.
 
   Lemma eqcor0UAH { X X' : UU } ( w :  X ≃ X' ) ( Y : UU ) ( f1 f2 : X' -> Y ) :
     (λ x : X, f1 ( w x )) = (λ x : X, f2 ( w x ) ) -> f1 = f2.
-  Proof. apply ( invmaponpathsweq ( weqpair _ ( isweqcompwithweqUAH w Y ) ) f1 f2 ). Defined.
+  Proof.
+    apply ( invmaponpathsweq ( weqpair _ ( isweqcompwithweqUAH w Y ) ) f1 f2 ).
+  Defined.
 
   Lemma apathpr1toprUAH ( T : UU ) : paths ( λ z :  pathsspace T, pr1 z ) ( λ z : pathsspace T, pr1 ( pr2 z ) ).
-  Proof. apply ( eqcor0UAH ( weqpair _ ( isweqdeltap T ) ) _ ( λ z :  pathsspace T, pr1 z ) ( λ z :  pathsspace T, pr1 ( pr2 z ) ) ( idpath ( idfun T ) ) ) . Defined.
+  Proof.
+    apply ( eqcor0UAH ( weqpair _ ( isweqdeltap T ) ) _ ( λ z :  pathsspace T, pr1 z ) ( λ z :  pathsspace T, pr1 ( pr2 z ) ) ( idpath ( idfun T ) ) ) .
+  Defined.
 
   Theorem funextfunPreliminaryUAH : funextfunStatement.
   Proof.

--- a/UniMath/Ktheory/AffineLine.v
+++ b/UniMath/Ktheory/AffineLine.v
@@ -23,6 +23,7 @@ Require Import UniMath.Ktheory.Utilities
                UniMath.NumberSystems.Integers
                UniMath.Ktheory.Integers
                UniMath.Ktheory.Nat
+               UniMath.Ktheory.Tactics
                UniMath.Ktheory.MoreEquivalences.
 
 Unset Automatic Introduction.

--- a/UniMath/Ktheory/Tactics.v
+++ b/UniMath/Ktheory/Tactics.v
@@ -22,6 +22,7 @@ Ltac prop_logic :=
 Lemma iscontrweqb' {X Y} (is:iscontr Y) (w:X ≃ Y) : iscontr X.
 Proof. intros. apply (iscontrweqb (Y:=Y)). assumption. assumption. Defined.
 
+Ltac intermediate_iscontr  Y' := apply (iscontrweqb (Y := Y')).
 Ltac intermediate_iscontr' Y' := apply (iscontrweqb' (Y := Y')).
 
 Ltac isaprop_goal x :=

--- a/UniMath/MoreFoundations/Tactics.v
+++ b/UniMath/MoreFoundations/Tactics.v
@@ -8,7 +8,7 @@ Require Import UniMath.MoreFoundations.Foundations.
 
 (** A version of "easy" specialized for the needs of UniMath.
 This tactic is supposed to be simple and predictable. The goal
-is to use it to finish of "trivial" goals *)
+is to use it to finish "trivial" goals *)
 Ltac unimath_easy :=
   trivial; intros; solve
    [ repeat (solve [trivial | apply pathsinv0; trivial] || split)

--- a/UniMath/README.md
+++ b/UniMath/README.md
@@ -31,6 +31,8 @@ checking systems, and we follow a style of coding designed to render proofs
 less fragile and to make the files have a more uniform and pleasing appearance.
 
 * Do not use `Admitted` or introduce new axioms.
+* Do not use `apply` with a term that needs no additional arguments filled in,
+  because using `exact` would be clearer.
 * Do not use `Prop` or `Set`, and ensure definitions don't produce
   elements of them.
 * Do not use `Type`, except in `Foundations/Basics/Preamble.v`.


### PR DESCRIPTION
... in time for the workshop, in line with #763.

Incorporates most of Ralph's suggestions in #764.

I also add this to our style guide:

* Do not use `apply` with a term that needs no additional arguments filled in,
  because using `exact` would be clearer.
