### PR TITLE
remove exception to enforcing listing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ clean::; rm -f .check-travis.okay
 
 # here we ensure that every *.v file F in each package P is listed in the corresponding file UniMath/P/.package/files
 # except for one, which someone has to look at and fix or eliminate:
-GRANDFATHER_UNLISTED = UniMath/CategoryTheory/equivalences_lemmas.v
+GRANDFATHER_UNLISTED = 
 enforce-listing-of-proof-files:
 	@ if declare -A islisted 2>/dev/null ;										\
 	  then for i in $(VFILES) $(GRANDFATHER_UNLISTED) ;								\

--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,7 @@ clean::; rm -f .check-travis.okay
 
 
 # here we ensure that every *.v file F in each package P is listed in the corresponding file UniMath/P/.package/files
-# except for one, which someone has to look at and fix or eliminate:
+# except for those listed in $GRANDFATHER_UNLISTED (currently none)
 GRANDFATHER_UNLISTED = 
 enforce-listing-of-proof-files:
 	@ if declare -A islisted 2>/dev/null ;										\


### PR DESCRIPTION
following up on #783 , we remove the exception to the rule that *.v files must be listed.