### PR TITLE
remove destruct from most of Foundations

### DIFF
--- a/UniMath/Foundations/NaturalNumbers.v
+++ b/UniMath/Foundations/NaturalNumbers.v
@@ -179,12 +179,12 @@ Defined.
 Definition isdeceqnat: isdeceq nat.
 Proof.
   unfold isdeceq. intro x. induction x as [ | x IHx ].
-  - intro x'. destruct x'.
+  - intro x'. induction x'.
     + apply (ii1 (idpath O)).
     + apply (ii2 (negpaths0sx x')).
-  - intro x'. destruct x'.
+  - intro x'. induction x'.
     + apply (ii2 (negpathssx0 x)).
-    + destruct (IHx x') as [ p | e ].
+    + induction (IHx x') as [ p | e ].
       * apply (ii1 (maponpaths S  p)).
       * apply (ii2 (noeqinjS  _ _ e)).
 Defined.
@@ -249,7 +249,7 @@ Proof.
   - apply (isinclS n).
   - destruct n as [ | n ].
     + assert (nh : ¬ (hfiber S 0)).
-      * intro hf. destruct hf as [ m e ]. apply (negpathssx0 _ e).
+      * intro hf. induction hf as [ m e ]. apply (negpathssx0 _ e).
       * apply (ii2 nh).
     + apply (ii1 (hfiberpair _ n (idpath _))).
 Defined.
@@ -303,13 +303,13 @@ Lemma negnatgth0tois0 (n : nat) (ng : ¬ (n > 0)) : n = 0.
 Proof.
   intro. destruct n as [ | n ].
   - intro. apply idpath.
-  - intro ng. destruct (ng (natgthsn0 _)).
+  - intro ng. induction (ng (natgthsn0 _)).
 Defined.
 
 Lemma natneq0togth0 (n : nat) (ne : n ≠ 0) : n > 0.
 Proof.
   intros. destruct n as [ | n ].
-  - destruct ne.
+  - induction ne.
   - apply natgthsn0.
 Defined.
 
@@ -317,15 +317,15 @@ Lemma nat1gthtois0 (n : nat) (g : 1 > n) : n = 0.
 Proof.
   intro. destruct n as [ | n ].
   - intro. apply idpath.
-  - intro x. destruct (negnatgth0n n x).
+  - intro x. induction (negnatgth0n n x).
 Defined.
 
 Lemma istransnatgth (n m k : nat) : n > m -> m > k -> n > k.
 Proof.
   intro. induction n as [ | n IHn ].
-  - intros m k g. destruct (negnatgth0n _ g).
+  - intros m k g. induction (negnatgth0n _ g).
   - intro m. destruct m as [ | m ].
-    + intros k g g'. destruct (negnatgth0n _ g').
+    + intros k g g'. induction (negnatgth0n _ g').
     + intro k. destruct k as [ | k ].
       * intros. apply natgthsn0.
       * apply (IHn m k).
@@ -357,7 +357,7 @@ Proof.
   intro n. induction n as [ | n IHn ].
   - intros m ng0m ngm0. apply (pathsinv0 (negnatgth0tois0 _ ngm0)).
   - intro m. destruct m as [ | m ].
-    + intros ngsn0 ng0sn. destruct (ngsn0 (natgthsn0 _)).
+    + intros ngsn0 ng0sn. induction (ngsn0 (natgthsn0 _)).
     + intros ng1 ng2. apply (maponpaths S (IHn m ng1 ng2)).
 Defined.
 
@@ -382,9 +382,9 @@ Defined.
 
 Lemma iscotransnatgth (n m k : nat) : n > k -> (n > m) ⨿ (m > k).
 Proof.
-  intros x y z gxz. destruct (isdecrelnatgth x y) as [ p | np ].
+  intros x y z gxz. induction (isdecrelnatgth x y) as [ p | np ].
   - apply ii1. assumption.
-  - apply ii2. destruct (isdecrelnatgth y x) as [r|nr].
+  - apply ii2. induction (isdecrelnatgth y x) as [r|nr].
     + apply (istransnatgth _ _ _ r gxz).
     + assert (e := isantisymmnegnatgth _ _ np nr); clear np nr.
       induction e. assumption.
@@ -435,7 +435,7 @@ Definition isnegrelnatlth : isnegrel natlth := λ n m, isnegrelnatgth m n.
 Definition iscoantisymmnatlth (n m : nat) : ¬ (natlth n m) -> (natlth m n) ⨿ (n = m).
 Proof.
   intros n m nlnm.
-  destruct (iscoantisymmnatgth m n nlnm) as [ l | e ].
+  induction (iscoantisymmnatgth m n nlnm) as [ l | e ].
   - apply (ii1 l).
   - apply (ii2 (pathsinv0 e)).
 Defined.
@@ -562,7 +562,7 @@ Defined.
 
 Definition istotalnatleh : istotal natleh.
 Proof.
-  intros x y. destruct (isdecrelnatleh x y) as [ lxy | lyx ].
+  intros x y. induction (isdecrelnatleh x y) as [ lxy | lyx ].
   - apply (hinhpr (ii1 lxy)).
   - apply hinhpr. apply ii2. apply (iscoasymmnatleh _ _ lyx).
 Defined.
@@ -664,14 +664,14 @@ Defined.
 
 Definition natlehchoice (n m : nat) (l : n ≤ m) : (n < m) ⨿ (n = m).
 Proof.
-  intros. destruct (natlthorgeh n m) as [ l' | g ].
+  intros. induction (natlthorgeh n m) as [ l' | g ].
   - apply (ii1 l').
   - apply (ii2 (isantisymmnatleh _ _ l g)).
 Defined.
 
 Definition natgehchoice (n m : nat) (g : n ≥ m) : (n > m) ⨿ (n = m).
 Proof.
-  intros. destruct (natgthorleh n m) as [ g' | l ].
+  intros. induction (natgthorleh n m) as [ g' | l ].
   - apply (ii1 g').
   - apply (ii2 (isantisymmnatleh _ _ l g)).
 Defined.
@@ -681,14 +681,14 @@ Defined.
 
 Lemma natgthgehtrans (n m k : nat) : n > m -> m ≥ k -> n > k.
 Proof.
-  intros n m k gnm gmk. destruct (natgehchoice m k gmk) as [ g' | e ].
+  intros n m k gnm gmk. induction (natgehchoice m k gmk) as [ g' | e ].
   - apply (istransnatgth _ _ _ gnm g').
   - rewrite e in gnm. apply gnm.
 Defined.
 
 Lemma natgehgthtrans (n m k : nat) : n ≥ m -> m > k -> n > k.
 Proof.
-  intros n m k gnm gmk. destruct (natgehchoice n m gnm) as [ g' | e ].
+  intros n m k gnm gmk. induction (natgehchoice n m gnm) as [ g' | e ].
   - apply (istransnatgth _ _ _ g' gmk).
   - rewrite e. apply gmk.
 Defined.
@@ -714,7 +714,7 @@ Defined.
 Lemma natgthtogehsn (n m : nat) : n > m -> n ≥ (S m).
 Proof.
   intro n. induction n as [ | n IHn ].
-  - intros m X. destruct (negnatgth0n _ X).
+  - intros m X. induction (negnatgth0n _ X).
   - intros m X. destruct m as [ | m ].
     + apply (natgehn0 n).
     + apply (IHn m X).
@@ -764,14 +764,14 @@ Defined. (* PeWa *)
 
 Lemma natlehchoice2 (n m : nat) : n ≤ m -> (S n ≤ m) ⨿ (n = m).
 Proof.
-  intros n m l. destruct (natlehchoice n m l) as [ l' | e ].
+  intros n m l. induction (natlehchoice n m l) as [ l' | e ].
   - apply (ii1 (natlthtolehsn _ _ l')).
   - apply (ii2 e).
 Defined.
 
 Lemma natgehchoice2 (n m : nat) : n ≥ m -> (n ≥ (S m)) ⨿ (n = m).
 Proof.
-  intros n m g. destruct (natgehchoice n m g) as [ g' | e ].
+  intros n m g. induction (natgehchoice n m g) as [ g' | e ].
   - apply (ii1 (natgthtogehsn _ _ g')).
   - apply (ii2 e).
 Defined.
@@ -779,7 +779,7 @@ Defined.
 Lemma natgthchoice2 (n m : nat) : n > m -> (n > S m) ⨿ (n = (S m)).
 Proof.
   intros n m g.
-  destruct (natgehchoice _ _ (natgthtogehsn _ _ g)) as [ g' | e ].
+  induction (natgehchoice _ _ (natgthtogehsn _ _ g)) as [ g' | e ].
   - apply (ii1 g').
   - apply (ii2 e).
 Defined.
@@ -787,7 +787,7 @@ Defined.
 Lemma natlthchoice2 (n m : nat) : n < m -> (S n < m) ⨿ ((S n) = m).
 Proof.
   intros n m l.
-  destruct (natlehchoice _ _ (natlthtolehsn _ _ l)) as [ l' | e ].
+  induction (natlehchoice _ _ (natlthtolehsn _ _ l)) as [ l' | e ].
   - apply (ii1 l').
   - apply (ii2 e).
 Defined.
@@ -1013,7 +1013,7 @@ Definition natgehandplusrinv (n m k : nat) :  n + k ≥ m + k -> n ≥ m := natl
 
 Definition natgthtogthp1 (n m : nat) : n > m -> (n + 1) > m.
 Proof.
-  intros n m is. destruct (natpluscomm 1 n).
+  intros n m is. induction (natpluscomm 1 n).
   apply (natgthtogths n m is).
 Defined.
 
@@ -1021,7 +1021,7 @@ Definition natlthtolthp1 (n m : nat) : n < m -> n < m + 1 := natgthtogthp1 _ _.
 
 Definition natlehtolehp1 (n m : nat) : n ≤ m -> n ≤ m + 1.
 Proof.
-  intros n m is. destruct (natpluscomm 1 m).
+  intros n m is. induction (natpluscomm 1 m).
   apply (natlehtolehs n m is).
 Defined.
 
@@ -1032,37 +1032,37 @@ Definition natgehtogehp1 (n m : nat) : n ≥ m -> (n + 1) ≥ m := natlehtolehp1
 
 Lemma natgthtogehp1 (n m : nat) : n > m -> n ≥ (m + 1).
 Proof.
-  intros n m is. destruct (natpluscomm 1 m).
+  intros n m is. induction (natpluscomm 1 m).
   apply (natgthtogehsn n m is).
 Defined.
 
 Lemma natgthp1togeh (n m : nat) : (n + 1) > m -> n ≥ m.
 Proof.
-  intros n m is. destruct (natpluscomm 1 n).
+  intros n m is. induction (natpluscomm 1 n).
   apply (natgthsntogeh n m is).
 Defined. (* PeWa *)
 
 Lemma natlehp1tolth (n m : nat) : n + 1 ≤ m -> n < m.
 Proof.
-  intros n m is. destruct (natpluscomm 1 n).
+  intros n m is. induction (natpluscomm 1 n).
   apply (natlehsntolth n m is).
 Defined.
 
 Lemma natlthtolehp1 (n m : nat) : n < m -> n + 1 ≤  m.
 Proof.
-  intros n m is. destruct (natpluscomm 1 n).
+  intros n m is. induction (natpluscomm 1 n).
   apply (natlthtolehsn n m is).
 Defined.
 
 Lemma natlthp1toleh (n m : nat) : n < m + 1 -> n ≤ m.
 Proof.
-  intros n m is. destruct (natpluscomm 1 m).
+  intros n m is. induction (natpluscomm 1 m).
   apply (natlthsntoleh n m is).
 Defined. (* PeWa *)
 
 Lemma natgehp1togth (n m : nat) : n ≥ (m + 1) -> n > m.
 Proof.
-  intros n m is. destruct (natpluscomm 1 m).
+  intros n m is. induction (natpluscomm 1 m).
   apply (natgehsntogth n m is).
 Defined.
 
@@ -1071,14 +1071,14 @@ Defined.
 
 Lemma natlehchoice3 (n m : nat) : n ≤ m -> (n + 1 ≤ m) ⨿ (n = m).
 Proof.
-  intros n m l. destruct (natlehchoice n m l) as [ l' | e ].
+  intros n m l. induction (natlehchoice n m l) as [ l' | e ].
   - apply (ii1 (natlthtolehp1 _ _ l')).
   - apply (ii2 e).
 Defined.
 
 Lemma natgehchoice3 (n m : nat) : n ≥ m -> (n ≥ (m + 1)) ⨿ (n = m).
 Proof.
-  intros n m g. destruct (natgehchoice n m g) as [ g' | e ].
+  intros n m g. induction (natgehchoice n m g) as [ g' | e ].
   - apply (ii1 (natgthtogehp1 _ _ g')).
   - apply (ii2 e).
 Defined.
@@ -1086,7 +1086,7 @@ Defined.
 Lemma natgthchoice3 (n m : nat) : n > m -> (n > (m + 1)) ⨿ (n = (m + 1)).
 Proof.
   intros n m g.
-  destruct (natgehchoice _ _ (natgthtogehp1 _ _ g)) as [ g' | e ].
+  induction (natgehchoice _ _ (natgthtogehp1 _ _ g)) as [ g' | e ].
   - apply (ii1 g').
   - apply (ii2 e).
 Defined.
@@ -1094,7 +1094,7 @@ Defined.
 Lemma natlthchoice3 (n m : nat) : n < m -> (n + 1 < m) ⨿ ((n + 1) = m).
 Proof.
   intros n m l.
-  destruct (natlehchoice _ _ (natlthtolehp1 _ _ l)) as [ l' | e ].
+  induction (natlehchoice _ _ (natlthtolehp1 _ _ l)) as [ l' | e ].
   - apply (ii1 l').
   - apply (ii2 e).
 Defined.
@@ -1150,8 +1150,8 @@ Proof.
   - apply isinclnatplusr.
   - induction m as [ | m IHm ].
     + set (e := natleh0tois0 is). split with 0. apply e.
-    + destruct (natlehchoice2 _ _ is) as [ l | e ].
-      * set (j := IHm l). destruct j as [ j e' ]. split with (S j). simpl.
+    + induction (natlehchoice2 _ _ is) as [ l | e ].
+      * set (j := IHm l). induction j as [ j e' ]. split with (S j). simpl.
         apply (maponpaths S e').
       * split with 0. simpl. assumption.
 Defined.
@@ -1163,23 +1163,23 @@ Proof.
   - induction m as [ | m IHm ].
     + set (e := natleh0tois0 is). split with 0.
       rewrite <- plus_n_O. apply e.
-    + destruct (natlehchoice2 _ _ is) as [ l | e ].
-      * set (j := IHm l). destruct j as [ j e' ]. split with (S j). simpl.
+    + induction (natlehchoice2 _ _ is) as [ l | e ].
+      * set (j := IHm l). induction j as [ j e' ]. split with (S j). simpl.
         rewrite <- plus_n_Sm. apply (maponpaths S e').
       * split with 0. simpl. rewrite <- plus_n_O. assumption.
 Defined.
 
 Lemma neghfibernatplusr (n m : nat) (is : m < n) : ¬ (hfiber (λ i : nat, i + n) m).
 Proof.
-  intros. intro h. destruct h as [ i e ]. rewrite (pathsinv0 e) in is.
-  destruct (natlehtonegnatgth _ _ (natlehmplusnm i n) is).
+  intros. intro h. induction h as [ i e ]. rewrite (pathsinv0 e) in is.
+  induction (natlehtonegnatgth _ _ (natlehmplusnm i n) is).
 Defined.
 
 Lemma isdecinclnatplusr (n : nat) : isdecincl (λ i : nat, i + n).
 Proof.
   intros. intro m. apply isdecpropif.
   - apply (isinclnatplusr _ m).
-  - destruct (natlthorgeh m n) as [ ni | i ].
+  - induction (natlthorgeh m n) as [ ni | i ].
     + apply (ii2 (neghfibernatplusr n m ni)).
     + apply (ii1 (pr1 (iscontrhfibernatplusr n m i))).
 Defined.
@@ -1218,8 +1218,8 @@ Defined.
 Definition minusgth0 (n m : nat) (is : n > m) : n - m > 0.
 Proof.
   intro n. induction n as [ | n IHn ].
-  - intros. destruct (negnatgth0n _ is).
-  - intro m. destruct m as [ | m ].
+  - intros. induction (negnatgth0n _ is).
+  - intro m. induction m as [ | m ].
     + intro. apply natgthsn0.
     + intro is. apply (IHn m is).
 Defined.
@@ -1227,7 +1227,7 @@ Defined.
 Definition minusgth0inv (n m : nat) (is : n - m > 0) : n > m.
 Proof.
   intro. induction n as [ | n IHn ].
-  - intros. destruct (negnatgth0n _ is).
+  - intros. induction (negnatgth0n _ is).
   - intro. destruct m as [ | m ].
     + intros. apply natgthsn0.
     + intro. apply (IHn m is).
@@ -1252,9 +1252,9 @@ Definition natminusgehn (n m : nat) : n ≥ n - m := natminuslehn _ _.
 Definition natminuslthn (n m : nat) (is : n > 0) (is' : m > 0) : n - m < n.
 Proof.
   intro. induction n as [ | n IHn ].
-  - intros. destruct (negnatgth0n _ is).
+  - intros. induction (negnatgth0n _ is).
   - intro m. induction m.
-    + intros. destruct (negnatgth0n _ is').
+    + intros. induction (negnatgth0n _ is').
     + intros. apply (natlehlthtrans _ n _).
       * apply (natminuslehn n m).
       * apply natlthnsn.
@@ -1263,9 +1263,9 @@ Defined.
 Definition natminuslthninv (n m : nat) (is : n - m < n) : m > 0.
 Proof.
   intro. induction n as [ | n IHn ].
-  - intros. destruct (negnatlthn0 _ is).
+  - intros. induction (negnatlthn0 _ is).
   - intro m. destruct m as [ | m ].
-    + intro. destruct (negnatlthnn _ is).
+    + intro. induction (negnatlthnn _ is).
     + intro. apply (natgthsn0 m).
 Defined.
 
@@ -1281,7 +1281,7 @@ Defined.
 
 Definition minusplusnmmineq (n m : nat) : (n - m) + m ≥ n.
 Proof.
-  intros. destruct (natlthorgeh n m) as [ lt | ge ].
+  intros. induction (natlthorgeh n m) as [ lt | ge ].
   - rewrite (minuseq0 _ _ (natlthtoleh _ _ lt)).
     apply (natgthtogeh _ _ lt).
   - rewrite (minusplusnmm _ _ ge).
@@ -1753,7 +1753,7 @@ Defined.
 Definition natgthandmultl (n m k : nat) : k ≠ 0 -> n > m -> (k * n) > (k * m).
 Proof.
   intro n. induction n as [ | n IHn ].
-  - intros m k g g'. destruct (negnatgth0n _ g').
+  - intros m k g g'. induction (negnatgth0n _ g').
   - intro m. destruct m as [ | m ].
     + intros k g g'.
       rewrite (natmultn0 k). rewrite (multnsm k n).
@@ -1771,7 +1771,7 @@ Defined.
 Definition natgthandmultlinv (n m k : nat) : (k * n) > (k * m) -> n > m.
 Proof.
   intro n. induction n as [ | n IHn ].
-  - intros m k g. rewrite (natmultn0 k) in g. destruct (negnatgth0n _ g).
+  - intros m k g. rewrite (natmultn0 k) in g. induction (negnatgth0n _ g).
   - intro m. destruct m as [ | m ].
     + intros. apply (natgthsn0 _).
     + intros k g. rewrite (multnsm k n) in g. rewrite (multnsm k m) in g.
@@ -1843,7 +1843,7 @@ Definition natdivrem (n m : nat) : dirprod nat nat.
 Proof.
   intros. induction n as [ | n IHn ].
   - intros. apply (dirprodpair 0 0).
-  - destruct (natlthorgeh (S (pr2 IHn)) m).
+  - induction (natlthorgeh (S (pr2 IHn)) m).
     + apply (dirprodpair (pr1 IHn) (S (pr2 IHn))).
     + apply (dirprodpair (S (pr1 IHn)) 0).
 Defined.
@@ -1859,7 +1859,7 @@ Lemma lthnatrem (n m : nat) : m ≠ 0 -> n /+ m < m.
 Proof.
   unfold natrem. intros ? ? is. destruct n as [ | n ].
   - simpl. intros. apply (natneq0togth0 _ is).
-  - simpl. destruct (natlthorgeh (S (pr2 (natdivrem n m))) m) as [ nt | t ].
+  - simpl. induction (natlthorgeh (S (pr2 (natdivrem n m))) m) as [ nt | t ].
     + simpl. apply nt.
     + simpl. apply (natneq0togth0 _ is).
 Defined.
@@ -1869,11 +1869,11 @@ Proof.
   intro. induction n as [ | n IHn ].
   - simpl. intros. apply idpath.
   - intros m is. unfold natrem. unfold natdiv. simpl.
-    destruct (natlthorgeh (S (pr2 (natdivrem n m))) m)  as [ nt | t ].
+    induction (natlthorgeh (S (pr2 (natdivrem n m))) m)  as [ nt | t ].
     + simpl. apply (maponpaths S (IHn m is)).
     + simpl. set (is' := lthnatrem n m is).
-      destruct (natgthchoice2 _ _ is') as [ h | e ].
-      destruct (natlehtonegnatgth _ _ t h).
+      induction (natgthchoice2 _ _ is') as [ h | e ].
+      induction (natlehtonegnatgth _ _ t h).
       fold (natdiv n m).
       set (e'' := maponpaths S (IHn m is)).
       change (S (natrem n m + natdiv n m * m))
@@ -1915,7 +1915,7 @@ Proof.
       rewrite natplusr0 in e.
       rewrite <- e in lj'.
       rewrite <- natplusassoc in lj'.
-      destruct (negnatgthmplusnm _ _ lj').
+      induction (negnatgthmplusnm _ _ lj').
     + simpl in e.
       rewrite <- (natplusassoc j) in e.
       rewrite <- (natplusassoc j') in e.
@@ -2029,14 +2029,14 @@ Defined.
 
 Lemma natlehdinsn (i n : nat) : (di i n) ≤ (S n).
 Proof.
-  intros. unfold di. destruct (natlthorgeh n i).
+  intros. unfold di. induction (natlthorgeh n i).
   - apply natlthtoleh. apply natlthnsn.
   - apply isreflnatleh.
 Defined.
 
 Lemma natgehdinn (i n : nat) : (di i n) ≥ n.
 Proof.
-  intros. unfold di. destruct (natlthorgeh n i).
+  intros. unfold di. induction (natlthorgeh n i).
   - apply isreflnatleh.
   - apply natlthtoleh. apply natlthnsn.
 Defined.
@@ -2045,14 +2045,14 @@ Lemma isincldi (i : nat) : isincl (di i).
 Proof.
   intro. apply (isinclbetweensets (di i) isasetnat isasetnat).
   intros x x'. unfold di. intro e.
-  destruct (natlthorgeh x i) as [ l | nel ].
-  - destruct (natlthorgeh x' i) as [ l' | nel' ].
+  induction (natlthorgeh x i) as [ l | nel ].
+  - induction (natlthorgeh x' i) as [ l' | nel' ].
     + apply e.
     + rewrite e in l. assert (e' := natgthtogths _ _  l).
       change (S i > S x') with (i > x') in e'.
       contradicts (natlehtonegnatgth _ _ nel') e'.
-  - destruct  (natlthorgeh x' i)  as [ l' | nel' ].
-    + destruct e.
+  - induction  (natlthorgeh x' i)  as [ l' | nel' ].
+    + induction e.
       set (e' := natgthtogths _ _ l').
       contradicts (natlehtonegnatgth _ _ nel) e'.
     + apply (invmaponpathsS _ _ e).
@@ -2060,34 +2060,34 @@ Defined.
 
 Lemma neghfiberdi (i : nat) : ¬ (hfiber (di i) i).
 Proof.
-  intros i hf. unfold di in hf. destruct hf as [ j e ].
-  destruct (natlthorgeh j i) as [ l | g ]. destruct e.
-  apply (isirreflnatlth _ l). destruct e in g. apply (negnatgehnsn _ g).
+  intros i hf. unfold di in hf. induction hf as [ j e ].
+  induction (natlthorgeh j i) as [ l | g ]. induction e.
+  apply (isirreflnatlth _ l). induction e in g. apply (negnatgehnsn _ g).
 Defined.
 
 Lemma iscontrhfiberdi (i j : nat) (ne : i ≠ j) : iscontr (hfiber (di i) j).
 Proof.
   intros. apply iscontraprop1. apply (isincldi i j).
-  destruct (natlthorgeh j i) as [ l | nel ].
+  induction (natlthorgeh j i) as [ l | nel ].
   - split with j. unfold di.
-    destruct (natlthorgeh j i) as [ l' | nel' ].
+    induction (natlthorgeh j i) as [ l' | nel' ].
     + apply idpath.
     + contradicts (natlehtonegnatgth _ _ nel') l.
-  - destruct (natgehchoice2 _ _ nel) as [ g | e ].
+  - induction (natgehchoice2 _ _ nel) as [ g | e ].
     destruct j as [ | j ].
-    + destruct (negnatgeh0sn _ g).
-    + split with j. unfold di. destruct (natlthorgeh j i) as [ l' | g' ].
+    + induction (negnatgeh0sn _ g).
+    + split with j. unfold di. induction (natlthorgeh j i) as [ l' | g' ].
       * contradicts (natlehtonegnatgth _ _ g) l'.
       * apply idpath.
-    + destruct ((nat_neq_to_nopath ne) (pathsinv0 e)).
+    + induction ((nat_neq_to_nopath ne) (pathsinv0 e)).
 Defined.
 
 Lemma isdecincldi (i : nat) : isdecincl (di i).
 Proof.
   intros i j. apply isdecpropif.
   - apply (isincldi i j).
-  - destruct (nat_eq_or_neq i j)  as [ eq | neq ].
-    + apply ii2. destruct eq.  apply (neghfiberdi i).
+  - induction (nat_eq_or_neq i j)  as [ eq | neq ].
+    + apply ii2. induction eq.  apply (neghfiberdi i).
     + apply ii1. apply (pr1 (iscontrhfiberdi i j neq)).
 Defined.
 

--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -752,12 +752,12 @@ Local Open Scope transport.
 
 Definition transportbfinv {T} (P:T->Type) {t u:T} (e:t = u) (p:P t) : e#'e#p = p.
 Proof.
-  intros. destruct e. apply idpath.
+  intros. induction e. apply idpath.
 Defined.
 
 Definition transportfbinv {T} (P:T->Type) {t u:T} (e:t = u) (p:P u) : e#e#'p = p.
 Proof.
-  intros. destruct e. apply idpath.
+  intros. induction e. apply idpath.
 Defined.
 
 Close Scope transport.

--- a/UniMath/Foundations/PartB.v
+++ b/UniMath/Foundations/PartB.v
@@ -239,10 +239,6 @@ Proof.
 Defined.
 
 
-(* destruct -> induction ok to this point *)
-
-
-
 Theorem isofhlevelfsnfib (n : nat) {X : UU} (P : X -> UU) (x : X)
         (is : isofhlevel (S n) (x = x)) : isofhlevelf (S n) (tpair P x).
 Proof.

--- a/UniMath/Foundations/Propositions.v
+++ b/UniMath/Foundations/Propositions.v
@@ -491,7 +491,8 @@ Proof.
     intro X1.
     assert (s2: coprod P Q -> R).
     {
-      intro X2. destruct X2 as [ XP | XQ ].
+      intro X2.
+      induction X2 as [ XP | XQ ].
       - apply X0. apply XP.
       - apply (pr2 X0). apply XQ.
     }
@@ -515,7 +516,7 @@ Lemma hexistsnegtonegforall {X : UU} (F : X -> UU) :
 Proof.
   intros X F. simpl.
   apply (@hinhuniv _ (hProppair _ (isapropneg (∏ x : X, F x)))).
-  simpl. intros t2 f2. destruct t2 as [ x d2 ]. apply (d2 (f2 x)).
+  simpl. intros t2 f2. induction t2 as [ x d2 ]. apply (d2 (f2 x)).
 Defined.
 
 Lemma forallnegtoneghexists {X : UU} (F : X -> UU) :
@@ -523,7 +524,7 @@ Lemma forallnegtoneghexists {X : UU} (F : X -> UU) :
 Proof.
   intros X F nf.
   change ((ishinh_UU (total2 F)) -> hfalse).
-  apply hinhuniv. intro t2. destruct t2 as [ x f ]. apply (nf x f).
+  apply hinhuniv. intro t2. induction t2 as [ x f ]. apply (nf x f).
 Defined.
 
 Lemma neghexisttoforallneg {X : UU} (F : X -> UU) :
@@ -556,7 +557,7 @@ Lemma tonegdirprod {X Y : UU} : ¬ X ∨ ¬ Y -> ¬ (X × Y).
 Proof.
   intros X Y. simpl.
   apply (@hinhuniv _ (hProppair _ (isapropneg (X × Y)))).
-  intro c. destruct c as [ nx | ny ].
+  intro c. induction c as [ nx | ny ].
   - simpl. intro xy. apply (nx (pr1 xy)).
   - simpl. intro xy. apply (ny (pr2 xy)).
 Defined.
@@ -580,7 +581,7 @@ Defined.
 
 Lemma tonegcoprod {X Y : UU} : ¬ X × ¬ Y -> ¬ (X ⨿ Y).
 Proof.
-  intros ? ? is. intro c. destruct c as [ x | y ].
+  intros ? ? is. intro c. induction c as [ x | y ].
   - apply (pr1 is x).
   - apply (pr2 is y).
 Defined.
@@ -617,8 +618,8 @@ Proof.
     apply (pr2 Q).
   }
   simpl. apply (@hinhuniv _ (hProppair _ int)).
-  simpl. intro pq. destruct pq as [ p | q ].
-  - intro np. destruct (np p).
+  simpl. intro pq. induction pq as [ p | q ].
+  - intro np. induction (np p).
   - intro np. apply q.
 Defined.
 
@@ -633,9 +634,9 @@ Lemma isdecprophdisj {X Y : UU} (isx : isdecprop X) (isy : isdecprop Y) :
 Proof.
   intros.
   apply isdecpropif. apply (pr2 (hdisj X Y)).
-  destruct (pr1 isx) as [ x | nx ].
+  induction (pr1 isx) as [ x | nx ].
   - apply (ii1 (hinhpr (ii1 x))).
-  - destruct (pr1 isy) as [ y | ny ].
+  - induction (pr1 isy) as [ y | ny ].
     + apply (ii1 (hinhpr (ii2 y))).
     + apply (ii2 (toneghdisj (dirprodpair nx ny))).
 Defined.
@@ -682,7 +683,7 @@ Defined.
 
 Definition eqweqmaphProp {P P' : hProp} (e : @paths hProp P P') : P ≃ P'.
 Proof.
-  intros. destruct e. apply idweq.
+  intros. induction e. apply idweq.
 Defined.
 
 Definition weqtopathshProp {P P' : hProp} (w : P ≃ P') : P = P'
@@ -750,7 +751,7 @@ Defined.
 
 Lemma iscontrtildehProp : iscontr tildehProp.
 Proof.
-  split with (tpair _ htrue tt). intro tP. destruct tP as [ P p ].
+  split with (tpair _ htrue tt). intro tP. induction tP as [ P p ].
   apply (invmaponpathsincl _ (isinclpr1 (λ P : hProp, P) (λ P, pr2 P))).
   simpl. apply hPropUnivalence. apply (λ x, tt). intro t. apply p.
 Defined.

--- a/UniMath/Foundations/Sets.v
+++ b/UniMath/Foundations/Sets.v
@@ -373,17 +373,17 @@ Proof.
   assert (egf : ∏ a : _, paths (g (f a)) a).
   {
     intro a.
-    destruct a as [ xy is ].
-    destruct xy as [ x y ].
-    destruct is as [ isx isy ].
+    induction a as [ xy is ].
+    induction xy as [ x y ].
+    induction is as [ isx isy ].
     apply idpath.
   }
   assert (efg : ∏ a : _, paths (f (g a)) a).
   {
     intro a.
-    destruct a as [ xis yis ].
-    destruct xis as [ x isx ].
-    destruct yis as [ y isy ].
+    induction a as [ xis yis ].
+    induction xis as [ x isx ].
+    induction yis as [ y isy ].
     apply idpath.
   }
   apply (gradth _ _ egf efg).
@@ -414,8 +414,8 @@ Proof.
     apply (pr2 (A x0)).
   }
   apply (invmaponpathsincl (@pr1 _ A) X0).
-  destruct x as [ x0 is0 ].
-  destruct x' as [ x0' is0' ].
+  induction x as [ x0 is0 ].
+  induction x' as [ x0' is0' ].
   simpl.
   apply (is x0 x0' is0 is0').
 Defined.
@@ -624,16 +624,16 @@ Defined.
 Lemma isdecreltoisnegrel {X : UU} {R : hrel X} (is : isdecrel R) : isnegrel R.
 Proof.
   intros. intros x1 x2.
-  destruct (is x1 x2) as [ r | nr ].
+  induction (is x1 x2) as [ r | nr ].
   - intro. apply r.
-  - intro nnr. destruct (nnr nr).
+  - intro nnr. induction (nnr nr).
 Defined.
 
 Lemma isantisymmnegtoiscoantisymm {X : UU} {R : hrel X}
       (isdr : isdecrel R) (isr : isantisymmneg R) : iscoantisymm R.
 Proof.
   intros. intros x1 x2 nrx12.
-  destruct (isdr x2 x1) as [ r | nr ].
+  induction (isdr x2 x1) as [ r | nr ].
   apply (ii1 r). apply ii2. apply (isr _ _ nrx12 nr).
 Defined.
 
@@ -724,7 +724,7 @@ Definition isdecrellogeqf {X : UU} {L R : hrel X}
            (lg : ∏ x1 x2, L x1 x2 <-> R x1 x2) (isl : isdecrel L) : isdecrel R.
 Proof.
   intros. intros x1 x2.
-  destruct (isl x1 x2) as [ l | nl ].
+  induction (isl x1 x2) as [ l | nl ].
   - apply (ii1 (pr1 (lg _ _) l)).
   - apply (ii2 (negf (pr2 (lg _ _)) nl)).
 Defined.
@@ -1021,7 +1021,7 @@ Lemma isdecnegrel {X : UU} (R : hrel X) (isr : isdecrel R) :
 (* uses [funextemptyAxiom] *)
 Proof.
   intros. intros x1 x2.
-  destruct (isr x1 x2) as [ r | nr ].
+  induction (isr x1 x2) as [ r | nr ].
   - apply ii2. apply (todneg _ r).
   - apply (ii1 nr).
 Defined.
@@ -1051,20 +1051,20 @@ Definition neqh {X : UU} (is : isdeceq X) : hrel X
 Lemma isrefleqh {X : UU} (is : isdeceq X) : isrefl (eqh is).
 Proof.
   intros. unfold eqh. unfold booleq.
-  intro x. destruct (is x x) as [ e | ne ].
+  intro x. induction (is x x) as [ e | ne ].
   - simpl. apply idpath.
-  - destruct (ne (idpath x)).
+  - induction (ne (idpath x)).
 Defined.
 
 Definition weqeqh {X : UU} (is : isdeceq X) (x x' : X) :
   (x = x') ≃ (eqh is x x').
 Proof.
   intros. apply weqimplimpl.
-  - intro e. destruct e. apply isrefleqh.
+  - intro e. induction e. apply isrefleqh.
   - intro e. unfold eqh in e. unfold booleq in e.
-    destruct (is x x') as [ e' | ne' ].
+    induction (is x x') as [ e' | ne' ].
     + apply e'.
-    + destruct (nopathsfalsetotrue e).
+    + induction (nopathsfalsetotrue e).
   - unfold isaprop. unfold isofhlevel. apply (isasetifdeceq X is x x').
   - unfold eqh. simpl. unfold isaprop. unfold isofhlevel.
     apply (isasetbool _ true).
@@ -1074,11 +1074,11 @@ Definition weqneqh {X : UU} (is : isdeceq X) (x x' : X) :
   (x != x') ≃ (neqh is x x').
 Proof.
   intros. unfold neqh. unfold booleq. apply weqimplimpl.
-  - destruct (is x x') as [ e | ne ].
-    + intro ne. destruct (ne e).
+  - induction (is x x') as [ e | ne ].
+    + intro ne. induction (ne e).
     + intro ne'. simpl. apply idpath.
-  - destruct (is x x') as [ e | ne ].
-    + intro tf. destruct (nopathstruetofalse tf).
+  - induction (is x x') as [ e | ne ].
+    + intro tf. induction (nopathstruetofalse tf).
     + intro. exact ne.
   - apply (isapropneg).
   - simpl. unfold isaprop. unfold isofhlevel. apply (isasetbool _ false).
@@ -1098,7 +1098,7 @@ Coercion pr1decrel : decrel >-> hrel.
 
 Definition decreltobrel {X : UU} (R : decrel X) : brel X.
 Proof.
-  intros. intros x x'. destruct ((pr2 R) x x').
+  intros. intros x x'. induction ((pr2 R) x x').
   - apply true.
   - apply false.
 Defined.
@@ -1111,24 +1111,24 @@ Definition pathstor {X : UU} (R : decrel X) (x x' : X)
            (e : decreltobrel R x x' = true) : R x x'.
 Proof.
   unfold decreltobrel. intros.
-  destruct (pr2 R x x') as [ e' | ne ].
+  induction (pr2 R x x') as [ e' | ne ].
   - apply e'.
-  - destruct (nopathsfalsetotrue e).
+  - induction (nopathsfalsetotrue e).
 Defined.
 
 Definition rtopaths {X : UU} (R : decrel X) (x x' : X) (r : R x x') :
   decreltobrel R x x' = true.
 Proof.
-  unfold decreltobrel. intros. destruct ((pr2 R) x x') as [ r' | nr ].
+  unfold decreltobrel. intros. induction ((pr2 R) x x') as [ r' | nr ].
   - apply idpath.
-  - destruct (nr r).
+  - induction (nr r).
 Defined.
 
 Definition pathstonegr {X : UU} (R : decrel X) (x x' : X)
            (e : decreltobrel R x x' = false) : neg (R x x').
 Proof.
-  unfold decreltobrel. intros. destruct (pr2 R x x') as [ e' | ne ].
-  - destruct (nopathstruetofalse e).
+  unfold decreltobrel. intros. induction (pr2 R x x') as [ e' | ne ].
+  - induction (nopathstruetofalse e).
   - apply ne.
 Defined.
 
@@ -1136,8 +1136,8 @@ Definition negrtopaths {X : UU} (R : decrel X) (x x' : X) (nr : neg (R x x')) :
   decreltobrel R x x' = false.
 Proof.
   unfold decreltobrel. intros.
-  destruct (pr2 R x x') as [ r | nr' ].
-  - destruct (nr r).
+  induction (pr2 R x x') as [ r | nr' ].
+  - induction (nr r).
   - apply idpath.
 Defined.
 
@@ -1150,8 +1150,8 @@ Defined.
 
   Definition pathstor_comp {X : UU} (R : decrel X) (x x' : X)
   (e : (decreltobrel R x x') = true) : R x x'.
-  Proof. unfold decreltobrel. intros.  destruct (pr2 R x x') as [ e' | ne ].
-  apply e'. destruct (nopathsfalsetotrue e).
+  Proof. unfold decreltobrel. intros.  induction (pr2 R x x') as [ e' | ne ].
+  apply e'. induction (nopathsfalsetotrue e).
 Defined.
 
   Notation " 'ct' (R, x, y) " := ((pathstor_comp _ x y (idpath true)) : R x y)
@@ -1162,9 +1162,9 @@ Defined.
 Definition ctlong {X : UU} (R : hrel X) (is : isdecrel R) (x x' : X)
            (e : decreltobrel (decrelpair is) x x' = true) : R x x'.
 Proof.
-  unfold decreltobrel. intros. simpl in e. destruct (is x x') as [ e' | ne ].
+  unfold decreltobrel. intros. simpl in e. induction (is x x') as [ e' | ne ].
   - apply e'.
-  - destruct (nopathsfalsetotrue e).
+  - induction (nopathsfalsetotrue e).
 Defined.
 
 Notation " 'ct' ( R , is , x , y ) " := (ctlong R is x y (idpath true))
@@ -1322,7 +1322,7 @@ Defined.
 Definition iscoantisymmresrel {X : UU} (L : hrel X) (P : hsubtype X)
            (isl : iscoantisymm L) : iscoantisymm (resrel L P).
 Proof.
-  intros. intros x1 x2 r12. destruct (isl _ _ r12) as [ l | e ].
+  intros. intros x1 x2 r12. induction (isl _ _ r12) as [ l | e ].
   - apply (ii1 l).
   - apply ii2. apply (invmaponpathsincl _ (isinclpr1carrier _) _ _ e).
 Defined.
@@ -1414,7 +1414,7 @@ Proof.
   unfold issurjective in is1.
   assert (s1: (hfiber f y)-> paths (g1 y) (g2 y)).
   {
-    intro X1. destruct X1 as [t x ]. induction x. apply (isf t).
+    intro X1. induction X1 as [t x ]. induction x. apply (isf t).
   }
   assert (s2: ishinh (paths (g1 y) (g2 y)))
     by apply (hinhfun s1 (is1 y)).
@@ -1529,8 +1529,8 @@ Section LiftSurjection.
        intros x1 x2.
        apply (@hinhuniv2 _ _ (hProppair _ (hsc _ _))).
        simpl; intros y1 y2; simpl.
-       destruct y1 as [ [z1 h1] h1' ].
-       destruct y2 as [ [z2 h2] h2' ].
+       induction y1 as [ [z1 h1] h1' ].
+       induction y2 as [ [z2 h2] h2' ].
        rewrite <- h1' ,<-h2'.
        apply comp_f_epi;simpl.
        rewrite h1,h2.
@@ -1694,9 +1694,9 @@ Proof.
   intros y1 y2. simpl.
   apply (@hinhuniv2 _ _ (hProppair (y1 = y2) (pr2 Y y1 y2))).
   intros x1 x2. simpl.
-  destruct c as [ A iseq ].
-  destruct x1 as [ x1 is1 ]. destruct x2 as [ x2 is2 ].
-  destruct x1 as [ x1 is1' ]. destruct x2 as [ x2 is2' ].
+  induction c as [ A iseq ].
+  induction x1 as [ x1 is1 ]. induction x2 as [ x2 is2 ].
+  induction x1 as [ x1 is1' ]. induction x2 as [ x2 is2' ].
   simpl in is1. simpl in is2. simpl in is1'. simpl in is2'.
   assert (r : R x1 x2) by apply (eqax2 iseq _ _ is1' is2').
   apply (pathscomp0 (pathsinv0 is1) (pathscomp0 (is _ _ r) is2)).
@@ -2000,14 +2000,14 @@ Proof.
   {
     apply (setquotunivprop _ (λ a : _, (hProppair _ (isasetsetquot _ (g (f a))
                                                                     a)))).
-    intro xy. destruct xy as [ x y ]. simpl.
+    intro xy. induction xy as [ x y ]. simpl.
     apply (invmaponpathsincl _ (isinclpr1setquot _)).
     simpl. apply funextsec. intro xy'.
-    destruct xy' as [ x' y' ]. apply idpath.
+    induction xy' as [ x' y' ]. apply idpath.
   }
   assert (efg : ∏ a : _, paths (f (g a)) a).
   {
-    intro a. destruct a as [ ax ay ]. apply pathsdirprod.
+    intro a. induction a as [ ax ay ]. apply pathsdirprod.
     generalize ax. clear ax.
     apply (setquotunivprop RX (λ ax : _, (hProppair _ (isasetsetquot _ _ _)))).
     intro x. simpl. generalize ay. clear ay.
@@ -2054,7 +2054,7 @@ Local Lemma setquotuniv2_iscomprelfun {X : UU} (R : hrel X) (Y : hSet) (f : X ->
   iscomprelfun (hreldirprod R R) (λ xy : dirprod X X, f (pr1 xy) (pr2 xy)).
 Proof.
   intros X R Y f is c c0.
-  intros xy x'y'. simpl. intro dp. destruct dp as [ r r'].
+  intros xy x'y'. simpl. intro dp. induction dp as [ r r'].
   apply (is _ _ _ _ r r').
 Defined.
 Global Opaque setquotuniv2_iscomprelfun.
@@ -2158,7 +2158,7 @@ Defined.
 Definition setquotbooleqint {X : UU} (R : eqrel X)
            (is : ∏ x x' : X, isdecprop (R x x')) (x x' : X) : bool.
 Proof.
-  intros. destruct (pr1 (is x x')). apply true. apply false.
+  intros. induction (pr1 (is x x')). apply true. apply false.
 Defined.
 
 Lemma setquotbooleqintcomp {X : UU} (R : eqrel X)
@@ -2167,14 +2167,14 @@ Lemma setquotbooleqintcomp {X : UU} (R : eqrel X)
 Proof.
   intros. unfold iscomprelfun2.
   intros x x' x0 x0' r r0. unfold setquotbooleqint.
-  destruct (pr1 (is x x0)) as [ r1 | nr1 ].
-  - destruct (pr1 (is x' x0')) as [ r1' | nr1' ].
+  induction (pr1 (is x x0)) as [ r1 | nr1 ].
+  - induction (pr1 (is x' x0')) as [ r1' | nr1' ].
     + apply idpath.
-    + destruct (nr1' (eqreltrans
+    + induction (nr1' (eqreltrans
                         R _ _ _ (eqreltrans
                                    R _ _ _ (eqrelsymm R _ _ r) r1) r0)).
-  - destruct (pr1 (is x' x0')) as [ r1' | nr1' ].
-    + destruct (nr1 (eqreltrans
+  - induction (pr1 (is x' x0')) as [ r1' | nr1' ].
+    + induction (nr1 (eqreltrans
                        R _ _ _ r (eqreltrans
                                     R _ _ _ r1' (eqrelsymm R _ _ r0)))).
     + apply idpath.
@@ -2201,33 +2201,33 @@ Proof.
   intros x x'.
   change ((setquotbooleqint R is x x') = true
           -> paths (setquotpr R x) (setquotpr R x')).
-  unfold setquotbooleqint. destruct (pr1 (is x x')) as [ i1 | i2 ].
+  unfold setquotbooleqint. induction (pr1 (is x x')) as [ i1 | i2 ].
   - intro. apply (weqpathsinsetquot R _ _ i1).
-  - intro H. destruct (nopathsfalsetotrue H).
+  - intro H. induction (nopathsfalsetotrue H).
 Defined.
 
 Lemma setquotpathstobooleq {X : UU} (R : eqrel X)
       (is : ∏ x x' : X, isdecprop (R x x')) (x x' : setquot R) :
   x = x' -> setquotbooleq R is x x' = true.
 Proof.
-  intros X R is x x' e. destruct e. generalize x.
+  intros X R is x x' e. induction e. generalize x.
   apply (setquotunivprop
            R (λ x, hProppair _ (isasetbool (setquotbooleq R is x x) true))).
   simpl. intro x0.
   change ((setquotbooleqint R is x0 x0) = true).
-  unfold setquotbooleqint. destruct (pr1 (is x0 x0)) as [ i1 | i2 ].
+  unfold setquotbooleqint. induction (pr1 (is x0 x0)) as [ i1 | i2 ].
   - apply idpath.
-  - destruct (i2 (eqrelrefl R x0)).
+  - induction (i2 (eqrelrefl R x0)).
 Defined.
 
 Definition isdeceqsetquot {X : UU} (R : eqrel X)
            (is : ∏ x x' : X, isdecprop (R x x')) : isdeceq (setquot R).
 Proof.
   intros. intros x x'.
-  destruct (boolchoice (setquotbooleq R is x x')) as [ i | ni ].
+  induction (boolchoice (setquotbooleq R is x x')) as [ i | ni ].
   - apply (ii1 (setquotbooleqtopaths R is x x' i)).
   - apply ii2. intro e.
-    destruct (falsetonegtrue _ ni (setquotpathstobooleq R is x x' e)).
+    induction (falsetonegtrue _ ni (setquotpathstobooleq R is x x' e)).
 Defined.
 
 
@@ -2274,7 +2274,7 @@ Proof.
     - apply (pr1 (lg _ _)).
     - apply (pr2 (lg _ _)).
   }
-  destruct e. destruct e'.
+  induction e. induction e'.
   apply (is _ _ _ _ r r0).
 Defined.
 
@@ -2485,21 +2485,21 @@ Proof.
   set (f := decreltobrel L). unfold brel.
   apply (setquotuniv2 R boolset f).
   intros x x' x0 x0' r r0. unfold f. unfold decreltobrel in *.
-  destruct (pr2 L x x0') as [ l | nl ].
-  - destruct (pr2 L x' x0') as [ l' | nl' ].
-    + destruct (pr2 L x x0) as [ l'' | nl'' ].
+  induction (pr2 L x x0') as [ l | nl ].
+  - induction (pr2 L x' x0') as [ l' | nl' ].
+    + induction (pr2 L x x0) as [ l'' | nl'' ].
       * apply idpath.
       * set (e := is x x' x0 x0' r r0).
-        destruct e. destruct (nl'' l').
-    + destruct (pr2 L x x0) as [ l'' | nl'' ].
-      * set (e := is x x' x0 x0' r r0). destruct e. destruct (nl' l'').
+        induction e. induction (nl'' l').
+    + induction (pr2 L x x0) as [ l'' | nl'' ].
+      * set (e := is x x' x0 x0' r r0). induction e. induction (nl' l'').
       * apply idpath.
-  - destruct (pr2 L x x0) as [ l' | nl' ].
-    + destruct (pr2 L x' x0') as [ l'' | nl'' ].
+  - induction (pr2 L x x0) as [ l' | nl' ].
+    + induction (pr2 L x' x0') as [ l'' | nl'' ].
       * apply idpath.
-      * set (e := is x x' x0 x0' r r0). destruct e. destruct (nl'' l').
-    + destruct (pr2 L x' x0') as [ l'' | nl'' ].
-      * set (e := is x x' x0 x0' r r0). destruct e. destruct (nl' l'').
+      * set (e := is x x' x0 x0' r r0). induction e. induction (nl'' l').
+    + induction (pr2 L x' x0') as [ l'' | nl'' ].
+      * set (e := is x x' x0 x0' r r0). induction e. induction (nl' l'').
       * apply idpath.
 Defined.
 
@@ -2597,7 +2597,7 @@ Proof.
   }
   assert (egf : ∏ (a : P), paths (g (f a)) a).
   {
-    intros a. destruct a as [ p isp ].
+    intros a. induction a as [ p isp ].
     generalize isp. generalize p. clear isp. clear p.
     assert (int : ∏ (p : setquot R),
                   isaprop (∏ isp : P p, paths (g (f (tpair _ p isp)))
@@ -2913,7 +2913,7 @@ Inductive try0 (T : UU) (t : T) :
 Definition try0map1 (T : UU) (t : T) (t1 t2 : T) (e1 : t = t1)
    (e2 : t = t2) (X : try0 T t t1 t2 e1 e2) : t1 = t2.
 Proof.
-  intros. destruct  X. apply idpath.
+  intros. induction  X. apply idpath.
 Defined.
 
 Definition try0map2 (T : UU) (t : T) (t1 t2 : T) (e1 : t = t1)
@@ -2941,7 +2941,7 @@ Lemma test {X : UU} (R : eqrel X) (Y : hSet) (f : setquot R -> Y) :
            (λ x x' : X, λ r : R x x',
                                 maponpaths f (iscompsetquotpr R x x' r))).
 Proof.
- intros. apply funextfun. intro c. simpl. destruct c as [ A iseq ]. simpl. *)
+ intros. apply funextfun. intro c. simpl. induction c as [ A iseq ]. simpl. *)
 
 
 
@@ -3028,7 +3028,7 @@ Proof.
   intros. apply weqimplimpl. apply iscompsetquot2pr.
   set (int := setquot2univ R hPropset (λ x'', R x x'')
                            (weqpathssetquot2l1 R x)).
-  intro e. change (pr1 (int (setquot2pr R x'))). destruct e.
+  intro e. change (pr1 (int (setquot2pr R x'))). induction e.
   change (R x x). apply (eqrelrefl R). apply (pr2 (R x x')).
   apply (isasetsetquot2).
 Defined.

--- a/UniMath/Foundations/UnivalenceAxiom.v
+++ b/UniMath/Foundations/UnivalenceAxiom.v
@@ -53,7 +53,7 @@ Defined.
 
 Lemma isweqtransportf10 { X : UU } ( P : X -> UU ) { x x' : X } ( e :  x = x' ) : isweq ( transportf P e ).
 Proof.
-  intros. destruct e.  apply idisweq.
+  intros. induction e.  apply idisweq.
 Defined.
 
 Lemma isweqtransportb10 { X : UU } ( P : X -> UU ) { x x' : X } ( e :  x = x' ) : isweq ( transportb P e ).
@@ -63,7 +63,7 @@ Defined.
 
 Lemma l1  { X0 X0' : UU } ( ee : X0 = X0' ) ( P : UU -> UU ) ( pp' : P X0' ) ( R : ∏ X X' : UU , ∏ w : X ≃ X' , P X' -> P X ) ( r : ∏ X : UU , ∏ p : P X , paths ( R X X ( idweq X ) p ) p ) : paths ( R X0 X0' ( eqweqmap ee ) pp' ) (  transportb P ee pp' ).
 Proof.
-  destruct ee. simpl. apply r.
+  induction ee. simpl. apply r.
 Defined.
 
 (** Axiom statements (propositions) *)
@@ -217,7 +217,7 @@ Section UnivalenceImplications.
         assert ( ee' : R' v = R' w ).
         * apply (  maponpaths R' e ).
         * assumption.
-      + destruct ee. apply l1. assumption.
+      + induction ee. apply l1. assumption.
   Defined.
 
   Corollary isweqweqtransportbUAH


### PR DESCRIPTION
replace the remaining uses of destruct by induction, except for those on natural numbers in NaturalNumbers.v
in PartB.v: remove the comment that the replacement was done until the position of the comment

This touches on Foundations, but is really very shallow.