### PR TITLE
more consequent use of Ltac definitions fron Foundations

### DIFF
--- a/UniMath/CategoryTheory/Adjunctions.v
+++ b/UniMath/CategoryTheory/Adjunctions.v
@@ -557,7 +557,7 @@ Section HomSetIso_from_Adjunction.
     assert (X2 := nat_trans_ax η). simpl in X2.
     rewrite <- X2; clear X2.
     rewrite <- assoc.
-    pathvia (g · identity _).
+    intermediate_path (g · identity _).
     - apply maponpaths.
       apply X'.
     - apply id_right.
@@ -572,7 +572,7 @@ Section HomSetIso_from_Adjunction.
     rewrite <- assoc.
     rewrite X2; clear X2.
     rewrite assoc.
-    pathvia (identity _ · f).
+    intermediate_path (identity _ · f).
     - apply cancel_postcomposition.
       apply triangle_id_left_ad.
     - apply id_left.

--- a/UniMath/CategoryTheory/Categories.v
+++ b/UniMath/CategoryTheory/Categories.v
@@ -40,8 +40,6 @@ Require Import UniMath.Foundations.Sets.
 Require Import UniMath.MoreFoundations.Tactics.
 
 
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
-
 (** * Definition of a precategory *)
 
 Definition precategory_ob_mor : UU
@@ -226,9 +224,9 @@ Lemma remove_id_left (C : precategory) (a b : C) (f g : a --> b) (h : a --> a):
   h = identity _ -> f = g -> h · f = g.
 Proof.
   intros H eq.
-  pathvia (identity _ · f).
+  intermediate_path (identity _ · f).
   - destruct H. apply idpath.
-  - pathvia f.
+  - intermediate_path f.
     + apply id_left.
     + apply eq.
 Defined.
@@ -237,9 +235,9 @@ Lemma remove_id_right (C : precategory) (a b : C) (f g : a --> b) (h : b --> b):
   h = identity _ -> f = g -> f · h = g.
 Proof.
   intros H eq.
-  pathvia (f · identity _).
+  intermediate_path (f · identity _).
   - destruct H. apply idpath.
-  - pathvia f.
+  - intermediate_path f.
     + apply id_right.
     + apply eq.
 Defined.
@@ -359,7 +357,7 @@ Proof.
   set (T:= invmaponpathsweq (weqpair (precomp_with f) (pr2 f b))).
   apply T; clear T; simpl.
   unfold precomp_with.
-  pathvia ((f· inv_from_iso f)·f).
+  intermediate_path ((f· inv_from_iso f)·f).
   - apply assoc.
   - apply remove_id_left.
     + apply iso_inv_after_iso.
@@ -372,12 +370,12 @@ Proof.
   apply (gradth _ (precomp_with f)).
   - intro g.
     unfold precomp_with.
-    pathvia ((f · inv_from_iso f) · g).
+    intermediate_path ((f · inv_from_iso f) · g).
     + apply assoc.
     + apply remove_id_left. apply iso_inv_after_iso. apply idpath.
   - intro g.
     unfold precomp_with.
-    pathvia ((inv_from_iso f·f)·g).
+    intermediate_path ((inv_from_iso f·f)·g).
     + apply assoc.
     + apply remove_id_left. apply iso_after_iso_inv. apply idpath.
 Defined.
@@ -427,7 +425,7 @@ Lemma iso_inv_on_right (C : precategory) (a b c: ob C)
 Proof.
   apply (invmaponpathsweq (weqpair (precomp_with f) (pr2 f c))).
   unfold precomp_with; simpl.
-  pathvia ((f·inv_from_iso f)·h).
+  intermediate_path ((f·inv_from_iso f)·h).
   - apply assoc.
   - apply remove_id_left.
     + apply iso_inv_after_iso.
@@ -511,7 +509,7 @@ Proof.
   apply eq_iso. simpl.
   set (T:=invmaponpathsweq (weqpair (precomp_with f) (pr2 f a ))).
   apply T; simpl.
-  pathvia (identity a ).
+  intermediate_path (identity a ).
   + assumption.
   + apply pathsinv0. apply iso_inv_after_iso.
 Defined.
@@ -522,7 +520,7 @@ Proof.
   intro H.
   set (T:=invmaponpathsweq (weqpair (precomp_with f) (pr2 f a ))).
   apply T; simpl.
-  pathvia (identity a ).
+  intermediate_path (identity a ).
   + assumption.
   + apply pathsinv0. apply iso_inv_after_iso.
 Defined.
@@ -534,7 +532,7 @@ Lemma iso_inv_of_iso_comp (C : precategory) (a b c : ob C)
 Proof.
   apply pathsinv0.
   apply inv_iso_unique. simpl. unfold precomp_with.
-  pathvia (f · (g·inv_from_iso g) · inv_from_iso f).
+  intermediate_path (f · (g·inv_from_iso g) · inv_from_iso f).
   - repeat rewrite assoc.  apply idpath.
   - rewrite iso_inv_after_iso. rewrite id_right.
     apply iso_inv_after_iso.
@@ -571,7 +569,7 @@ Lemma post_comp_with_iso_is_inj (C : precategory) (b c : ob C)
 Proof.
   intro HH.
   set (T:=iso_inv_after_iso (tpair _ h H)). simpl in T.
-  pathvia (f · (h · inv_from_iso (tpair _ h H))).
+  intermediate_path (f · (h · inv_from_iso (tpair _ h H))).
   - rewrite T. clear T.
     apply pathsinv0, id_right.
   - rewrite assoc. rewrite HH.
@@ -1017,7 +1015,7 @@ Proof.
   unfold inv_from_iso; simpl.
   destruct f as [f [f' Hf]]. simpl in *.
   destruct g as [g [g' Hg]]; simpl in *.
-  pathvia ((f · (g · g')) · f').
+  intermediate_path ((f · (g · g')) · f').
   repeat rewrite assoc; apply idpath.
   rewrite (pr1 Hg).
   rewrite id_right.
@@ -1026,7 +1024,7 @@ Proof.
 
   destruct f as [f [f' Hf]]. simpl in *.
   destruct g as [g [g' Hg]]; simpl in *.
-  pathvia ((g' · (f' · f)) · g).
+  intermediate_path ((g' · (f' · f)) · g).
   repeat rewrite assoc; apply idpath.
   rewrite (pr2 Hf).
   rewrite id_right.
@@ -1262,7 +1260,7 @@ Lemma double_transport_idtoiso (C : precategory) (a a' b b' : ob C)
 Proof.
   destruct p.
   destruct q.
-  pathvia (identity _ · f).
+  intermediate_path (identity _ · f).
   - apply pathsinv0; apply id_left.
   - apply pathsinv0; apply id_right.
 Defined.

--- a/UniMath/CategoryTheory/Categories.v
+++ b/UniMath/CategoryTheory/Categories.v
@@ -1077,9 +1077,9 @@ Lemma z_iso_comp_right_isweq {C:precategory} {a b:ob C} (h:z_iso a b) (c:C) :
   isweq (fun f : b --> c => h · f).
 Proof.
   intros. apply (gradth _ (λ g, inv_from_z_iso h · g)).
-       { intros f. refine (_ @ maponpaths (λ m, m · f) (pr2 (pr2 (pr2 h))) @ _).
+       { intros f. use (_ @ maponpaths (λ m, m · f) (pr2 (pr2 (pr2 h))) @ _).
          { apply assoc. } { apply id_left. } }
-       { intros g. refine (_ @ maponpaths (λ m, m · g) (pr1 (pr2 (pr2 h))) @ _).
+       { intros g. use (_ @ maponpaths (λ m, m · g) (pr1 (pr2 (pr2 h))) @ _).
          { apply assoc. } { apply id_left. } }
 Defined.
 
@@ -1090,9 +1090,9 @@ Lemma z_iso_comp_left_isweq {C:precategory} {a b:ob C} (h:z_iso a b) (c:C) :
   isweq (fun f : c --> a => f · h).
 Proof.
   intros. apply (gradth _ (λ g, g · inv_from_z_iso h)).
-       { intros f. refine (_ @ maponpaths (λ m, f·m) (pr1 (pr2 (pr2 h))) @ _).
+  { intros f. use (_ @ maponpaths (λ m, f·m) (pr1 (pr2 (pr2 h))) @ _).
          { apply pathsinv0. apply assoc. }  { apply id_right. } }
-       { intros g. refine (_ @ maponpaths (λ m, g·m) (pr2 (pr2 (pr2 h))) @ _).
+       { intros g. use (_ @ maponpaths (λ m, g·m) (pr2 (pr2 (pr2 h))) @ _).
          { apply pathsinv0, assoc. } { apply id_right. } }
 Defined.
 Definition z_iso_comp_left_weq {C:precategory} {a b:C} (h:z_iso a b) (c:C) :

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -805,17 +805,17 @@ Proof.
     apply funextsec; intros i;
     assert (MM := M i _ (mapcocone (pr_functor I B i) _ cc'));
     assert (H := proofirrelevance _ (isapropifcontr MM));
-    refine (maponpaths pr1 (H (pr1 f1 i,,_) (pr1 f2 i,,_)));
+    use (maponpaths pr1 (H (pr1 f1 i,,_) (pr1 f2 i,,_)));
       clear MM H; intros v ;
       [ exact (toforallpaths _ _ _ (pr2 f1 v) i) |
         exact (toforallpaths _ _ _ (pr2 f2 v) i) ]
       ) .
   - use tpair.
     + intros i.
-      refine (pr1 (pr1 (M i _ (mapcocone (pr_functor I B i) _ cc')))).
+      use (pr1 (pr1 (M i _ (mapcocone (pr_functor I B i) _ cc')))).
     + abstract (
           intros v; apply funextsec; intros i;
-          refine (pr2 (pr1 (M i _ (mapcocone (pr_functor I B i) _ cc'))) v)
+          use (pr2 (pr1 (M i _ (mapcocone (pr_functor I B i) _ cc'))) v)
         ).
 Defined.
 
@@ -949,7 +949,7 @@ Proof.
 intros cAB ml ccml Hccml xy ccxy; simpl in *.
 transparent assert (cc : (∏ i, cocone (mapdiagram (F i) (mapdiagram (pr_functor I (λ _ : I, A) i) cAB)) (xy i))).
 { intro i; use mk_cocone.
-  - intro n; simple refine (pr1 ccxy n _).
+  - intro n; use (pr1 ccxy n).
   - abstract (intros m n e; apply (toforallpaths _ _ _ (pr2 ccxy m n e) i)).
 }
 set (X i := HF i _ _ _ (isColimCocone_pr_functor _ _ _ Hccml i) (xy i) (cc i)).
@@ -1157,7 +1157,7 @@ Lemma is_cocont_coproduct_of_functors
   {F : ∏ (i : I), functor C D} (HF : ∏ i, is_cocont (F i)) :
   is_cocont (coproduct_of_functors I _ _ HD F).
 Proof.
-  refine (transportf _
+  use (transportf _
         (coproduct_of_functors_alt_eq_coproduct_of_functors _ _ _ _ hsD F)
         _).
   apply is_cocont_functor_composite; try apply hsD.
@@ -1170,7 +1170,7 @@ Lemma is_omega_cocont_coproduct_of_functors
   {F : ∏ (i : I), functor C D} (HF : ∏ i, is_omega_cocont (F i)) :
   is_omega_cocont (coproduct_of_functors I _ _ HD F).
 Proof.
-  refine (transportf _
+  use (transportf _
         (coproduct_of_functors_alt_eq_coproduct_of_functors _ _ _ _ hsD F)
         _).
   apply is_omega_cocont_functor_composite; try apply hsD.

--- a/UniMath/CategoryTheory/CommaCategories.v
+++ b/UniMath/CategoryTheory/CommaCategories.v
@@ -28,9 +28,6 @@ Require Import UniMath.CategoryTheory.Categories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Local Open Scope cat.
 
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
-
-
 Section const_comma_category_definition.
 
 Context {M C : precategory}.
@@ -65,7 +62,7 @@ Definition ccomma_id a : ccomma_morphism a a.
 Proof.
   exists (identity _ ).
   abstract (
-  pathvia (pr2 a · identity _ );
+  intermediate_path (pr2 a · identity _ );
    [ apply maponpaths; apply functor_id |];
   apply id_right
   ).

--- a/UniMath/CategoryTheory/DisplayedCats/Auxiliary.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Auxiliary.v
@@ -107,7 +107,7 @@ Defined.
 
 Definition prod_precategory_ob_mor (C D : precategory) : precategory_ob_mor.
   (* ob *) exists (C × D).
-  (* mor *) intros a b. refine (_ × _).
+  (* mor *) intros a b. use (_ × _).
     exact ((pr1 a) --> (pr1 b)). exact ((pr2 a) --> (pr2 b)).
 Defined.
 
@@ -226,7 +226,7 @@ Section Discrete_cats.
 
 Definition discrete_cat (X : hSet) : category.
 Proof.
-  refine (path_groupoid X _).
+  use (path_groupoid X).
     apply hlevelntosn, setproperty.
 Defined.
 

--- a/UniMath/CategoryTheory/DisplayedCats/Codomain.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Codomain.v
@@ -69,14 +69,14 @@ Proof.
     etrans. apply id_left.
     destruct ff as [ff H].
     apply pathsinv0.
-    etrans. refine (pr1_transportf (C⟦x,y⟧) _ _ _ _ _ _ ).
+    etrans. use(pr1_transportf (C⟦x,y⟧)).
     use transportf_const.
   - apply subtypeEquality.
     { intro. apply homset_property. }
     etrans. apply id_right.
     destruct ff as [ff H].
     apply pathsinv0.
-    etrans. refine (pr1_transportf (C⟦x,y⟧) _ _ _ _ _ _ ).
+    etrans. use(pr1_transportf (C⟦x,y⟧)).
     use transportf_const.
   - apply subtypeEquality.
     { intro. apply homset_property. }
@@ -84,7 +84,7 @@ Proof.
     destruct ff as [ff H].
     apply pathsinv0.
     etrans. unfold mor_disp.
-    refine (pr1_transportf (C⟦x,w⟧) _ _ _ _ _ _ ).
+    use (pr1_transportf (C⟦x,w⟧)).
     use transportf_const.
   - apply (isofhleveltotal2 2).
     + apply homset_property.
@@ -111,7 +111,7 @@ Proof.
     use Hpb.
     + exact (pr1 q).
     + exact (pr1 hh).
-    + simpl in q. refine (pr2 q · g).
+    + simpl in q. use (pr2 q · g).
     + etrans. apply (pr2 hh). apply assoc.
   } Unfocus.
   eapply weqcomp.

--- a/UniMath/CategoryTheory/DisplayedCats/Codomain.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Codomain.v
@@ -69,14 +69,14 @@ Proof.
     etrans. apply id_left.
     destruct ff as [ff H].
     apply pathsinv0.
-    etrans. use(pr1_transportf (C⟦x,y⟧)).
+    etrans. use (pr1_transportf (C⟦x,y⟧)).
     use transportf_const.
   - apply subtypeEquality.
     { intro. apply homset_property. }
     etrans. apply id_right.
     destruct ff as [ff H].
     apply pathsinv0.
-    etrans. use(pr1_transportf (C⟦x,y⟧)).
+    etrans. use (pr1_transportf (C⟦x,y⟧)).
     use transportf_const.
   - apply subtypeEquality.
     { intro. apply homset_property. }

--- a/UniMath/CategoryTheory/DisplayedCats/Constructions.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Constructions.v
@@ -166,14 +166,14 @@ Definition dirprod_disp_cat_axioms
   : disp_cat_axioms _ dirprod_disp_cat_data.
 Proof.
   repeat apply tpair.
-  - intros. apply dirprod_paths; refine (id_left_disp @ !_).
-    + refine (pr1_transportf _ _ _ _ _ _ _).
+  - intros. apply dirprod_paths; use (id_left_disp @ !_).
+    + use pr1_transportf.
     + apply pr2_transportf.
-  - intros. apply dirprod_paths; refine (id_right_disp @ !_).
-    + refine (pr1_transportf _ _ _ _ _ _ _).
+  - intros. apply dirprod_paths; use (id_right_disp @ !_).
+    + use pr1_transportf.
     + apply pr2_transportf.
-  - intros. apply dirprod_paths; refine (assoc_disp @ !_).
-    + refine (pr1_transportf _ _ _ _ _ _ _).
+  - intros. apply dirprod_paths; use (assoc_disp @ !_).
+    + use pr1_transportf.
     + apply pr2_transportf.
   - intros. apply isaset_dirprod; apply homsets_disp.
 Qed.
@@ -362,7 +362,7 @@ Proof.
         | apply pathsinv0, pr1_transportf_sigma_disp]).
     + etrans. Focus 2. apply @pathsinv0, pr2_transportf_sigma_disp.
       etrans. apply maponpaths.
-        refine (mor_disp_transportf_postwhisker
+        use (mor_disp_transportf_postwhisker
           (@inv_mor_total_iso _ _ (_,,_) (_,,_) f ffi) _ (pr2 fff)).
       etrans. apply functtransportf.
       etrans. apply transport_f_f.
@@ -375,7 +375,7 @@ Proof.
         | apply pathsinv0, pr1_transportf_sigma_disp ]).
     + etrans. Focus 2. apply @pathsinv0, pr2_transportf_sigma_disp.
       etrans. apply maponpaths.
-      refine (mor_disp_transportf_prewhisker
+      use (mor_disp_transportf_prewhisker
         (@inv_mor_total_iso _ _ (_,,_) (_,,_) f ffi) (pr2 fff) _).
       etrans. apply functtransportf.
       etrans. apply transport_f_f.
@@ -1112,12 +1112,12 @@ Proof.
   + set (H := pr2 (pr2 Hff)).
     etrans. apply maponpaths, H.
     etrans. apply transport_f_b.
-    refine (@maponpaths_2 _ _ _ _ _ (paths_refl _) _ _).
+    use (@maponpaths_2 _ _ _ _ _ (paths_refl _)).
     apply homset_property.
   + set (H := pr1 (pr2 Hff)).
     etrans. apply maponpaths, H.
     etrans. apply transport_f_b.
-    refine (@maponpaths_2 _ _ _ _ _ (paths_refl _) _ _).
+    use (@maponpaths_2 _ _ _ _ _ (paths_refl _)).
     apply homset_property.
 Qed.
 

--- a/UniMath/CategoryTheory/DisplayedCats/Core.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Core.v
@@ -393,7 +393,7 @@ Proof.
     etrans. apply transport_f_f.
     etrans. apply maponpaths, id_left_disp.
     etrans. apply transport_f_f.
-    use(@maponpaths_2 _ _ _ (transportf _) _ (idpath _)).
+    use (@maponpaths_2 _ _ _ (transportf _) _ (idpath _)).
     apply homset_property.
 Qed.
 

--- a/UniMath/CategoryTheory/DisplayedCats/Core.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Core.v
@@ -393,7 +393,7 @@ Proof.
     etrans. apply transport_f_f.
     etrans. apply maponpaths, id_left_disp.
     etrans. apply transport_f_f.
-    refine (@maponpaths_2 _ _ _ (transportf _) _ (idpath _) _ _).
+    use(@maponpaths_2 _ _ _ (transportf _) _ (idpath _)).
     apply homset_property.
 Qed.
 
@@ -704,15 +704,15 @@ Definition precomp_with_iso_disp_is_inj
   : (ii ;; ff = ii ;; ff') -> ff = ff'.
 Proof.
   intros e.
-  simple refine (pathscomp0 _ _).
-  - refine (transportf _ _ ((iso_inv_from_iso_disp ii ;; ii) ;; ff)).
+  use pathscomp0.
+  - use (transportf _ _ ((iso_inv_from_iso_disp ii ;; ii) ;; ff)).
     etrans; [ apply maponpaths_2, iso_after_iso_inv | apply id_left ].
   - apply pathsinv0.
     etrans. eapply transportf_bind.
       eapply cancel_postcomposition_disp, (iso_disp_after_inv_mor ii).
     rewrite id_left_disp.
     etrans. apply transport_f_f.
-    refine (@maponpaths_2 _ _ _ _ _ (idpath _) _ _).
+    use (@maponpaths_2 _ _ _ _ _ (idpath _)).
     apply homset_property.
   - etrans. eapply transportf_bind, assoc_disp_var.
     rewrite e.
@@ -721,7 +721,7 @@ Proof.
       eapply cancel_postcomposition_disp, (iso_disp_after_inv_mor ii).
     rewrite id_left_disp.
     etrans. apply transport_f_f.
-    refine (@maponpaths_2 _ _ _ _ _ (idpath _) _ _).
+    use (@maponpaths_2 _ _ _ _ _ (idpath _)).
     apply homset_property.
 Qed.
 
@@ -801,7 +801,7 @@ Definition idtoiso_isotoid_disp
     {c c' : C} (e : c = c') {d : D c} {d'} (i : iso_disp (idtoiso e) d d')
   : idtoiso_disp e (isotoid_disp D_cat e i) = i.
 Proof.
-  refine (homotweqinvweq _ _).
+  use homotweqinvweq.
 Qed.
 
 Definition isotoid_idtoiso_disp
@@ -809,7 +809,7 @@ Definition isotoid_idtoiso_disp
     {c c' : C} (e : c = c') {d : D c} {d'} (ee : transportf _ e d = d')
   : isotoid_disp D_cat e (idtoiso_disp e ee) = ee.
 Proof.
-  refine (homotinvweqweq _ _).
+  use homotinvweqweq.
 Qed.
 
 End Univalent_Categories.
@@ -986,13 +986,13 @@ Proof.
     etrans. apply maponpaths, @pathsinv0.
       exact (fiber_paths (!iso_after_iso_inv ffi)).
     etrans. apply transport_f_f.
-    refine (toforallpaths _ _ _ _ (id_disp _)).
+    use (toforallpaths _ _ _ _ (id_disp _)).
     unfold transportb; apply maponpaths, homset_property.
   - etrans. apply mor_disp_transportf_prewhisker.
     etrans. apply maponpaths, @pathsinv0.
       exact (fiber_paths (!iso_inv_after_iso ffi)).
     etrans. apply transport_f_f.
-    refine (toforallpaths _ _ _ _ (id_disp _)).
+    use (toforallpaths _ _ _ _ (id_disp _)).
     unfold transportb; apply maponpaths, homset_property.
 Qed.
 
@@ -1058,7 +1058,7 @@ Proof.
     + apply eq_iso_disp.
       etrans. apply transportf_iso_disp.
       simpl pr2. simpl (pr1 (iso_disp_from_total _)).
-      refine (@maponpaths_2 _ _ _ (transportf _) _ (idpath _) _ _).
+      use (@maponpaths_2 _ _ _ (transportf _) _ (idpath _)).
       apply homset_property.
   - intros f. apply eq_iso; simpl.
     destruct f as [[f ff] w]; apply idpath.
@@ -1084,7 +1084,7 @@ Proof.
     intros e. exists (λ ee, idtoiso_disp e ee).
     apply DD.
   apply (@weqcomp _ (∑ f : iso x y, iso_disp f xx yy) _).
-    refine (weqfp (weqpair _ _) _). apply CC.
+    use (weqfp (weqpair _ _)). apply CC.
   apply total_iso_equiv.
   intros e; destruct e; apply eq_iso; cbn.
     apply idpath.

--- a/UniMath/CategoryTheory/DisplayedCats/Equivalences.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Equivalences.v
@@ -428,7 +428,7 @@ Proof.
       etrans. apply assoc_disp.
       eapply transportf_bind.
       etrans. eapply cancel_postcomposition_disp.
-        refine (disp_nat_trans_ax η (# GG (ε x yy))). (*2*)
+        exact (disp_nat_trans_ax η (# GG (ε x yy))). (*2*)
       eapply transportf_bind.
       etrans. apply assoc_disp_var.
       eapply transportf_bind.
@@ -556,7 +556,7 @@ Definition FFinv_on_iso_is_iso   {x y} {xx : D' x} {yy : D' y} {f : iso x y}
   : is_iso_disp _ (FFinv ff).
 Proof.
   apply disp_functor_id_ff_reflects_isos.
-  refine (transportf _ _ Hff).
+  use (transportf _ _ Hff).
   apply @pathsinv0. use homotweqinvweq.
 Qed.
 
@@ -610,7 +610,7 @@ Proof.
           etrans. apply assoc_disp_var.
           apply maponpaths.
           etrans. apply maponpaths.
-            refine (iso_disp_after_inv_mor (pr2 (FF_split _ _))).
+            exact (iso_disp_after_inv_mor (pr2 (FF_split _ _))).
           etrans. apply mor_disp_transportf_prewhisker.
           etrans. apply maponpaths, id_right_disp.
           apply transport_f_f.
@@ -669,7 +669,7 @@ Definition η_ses_ff_data
 Proof.
   intros x xx. cbn.
   apply FFinv.
-  refine (inv_mor_disp_from_iso (pr2 (FF_split _ _))).
+  exact (inv_mor_disp_from_iso (pr2 (FF_split _ _))).
 Defined.
 
 Definition η_ses_ff_ax
@@ -744,7 +744,7 @@ Qed.
 
 Theorem is_equiv_from_ff_ess_over_id : is_equiv_over_id FF.
 Proof.
-  simple refine ((GGεη,, _) ,, _).
+  use ((GGεη,, _) ,, _).
   split. apply tri_1_GGεη. apply tri_2_GGεη.
   apply form_equiv_GGεη.
 Defined.
@@ -1020,14 +1020,14 @@ Proof.
     set (thisax := pr1 axs c d); clearbody thisax; clear axs.
     etrans. apply maponpaths, thisax.
     etrans. apply transport_f_b.
-    refine (@maponpaths_2 _ _ _ _ _ (paths_refl _) _ _).
+    use (@maponpaths_2 _ _ _ _ _ (paths_refl _)).
     apply homset_property.
   + unfold triangle_2_statement.
     intros d; cbn.
     set (thisax := pr2 axs c d); clearbody thisax; clear axs.
     etrans. apply maponpaths, thisax.
     etrans. apply transport_f_b.
-    refine (@maponpaths_2 _ _ _ _ _ (paths_refl _) _ _).
+    use (@maponpaths_2 _ _ _ _ _ (paths_refl _)).
     apply homset_property.
 Defined.
 

--- a/UniMath/CategoryTheory/DisplayedCats/Equivalences_bis.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Equivalences_bis.v
@@ -429,7 +429,7 @@ Proof.
       etrans. apply assoc_disp.
       eapply transportf_bind.
       etrans. eapply cancel_postcomposition_disp.
-        refine (disp_nat_trans_ax η (# GG (ε x yy))). (*2*)
+        exact (disp_nat_trans_ax η (# GG (ε x yy))). (*2*)
       eapply transportf_bind.
       etrans. apply assoc_disp_var.
       eapply transportf_bind.
@@ -574,7 +574,7 @@ Definition FFinv_on_iso_is_iso {x y} {xx : D x} {yy : D y} {f : iso x y}
   : is_iso_disp _ (FFinv ff).
 Proof.
   apply disp_functor_id_ff_reflects_isos.
-  refine (transportf _ _ Hff).
+  use (transportf _ _ Hff).
   apply @pathsinv0. use homotweqinvweq.
 Qed.
 

--- a/UniMath/CategoryTheory/DisplayedCats/Examples.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Examples.v
@@ -432,7 +432,7 @@ Proof.
 
         {
           unfold functor_alg_mor.
-          pathvia (limArrow LL _ X).
+          intermediate_path (limArrow LL _ X).
           - apply (limArrowUnique LL).
             intro j. rewrite <- assoc.
             rewrite (limArrowCommutes LL).

--- a/UniMath/CategoryTheory/DisplayedCats/Fibrations.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Fibrations.v
@@ -127,7 +127,7 @@ Definition cartesian_factorisation' {C : category} {D : disp_cat C}
     (e : (g · f = h))
   : d'' -->[g] d'.
 Proof.
-  simple refine (cartesian_factorisation H g _).
+  use (cartesian_factorisation H g).
   exact (transportb _ e hh).
 Defined.
 
@@ -201,9 +201,9 @@ Lemma is_iso_from_is_cartesian {C : category} {D : disp_cat C}
   : is_cartesian ff -> is_iso_disp i ff.
 Proof.
   intros Hff.
-  simple refine (_,,_); try split.
-  - simple refine
-      (cartesian_factorisation' Hff (inv_from_iso i) (id_disp _) _).
+  use (_,,_); try split.
+  - use
+      (cartesian_factorisation' Hff (inv_from_iso i) (id_disp _)).
     apply iso_after_iso_inv.
   - apply cartesian_factorisation_commutes'.
   - apply (cartesian_factorisation_unique Hff).
@@ -235,7 +235,7 @@ Definition cartesian_lifts_iso {C : category} {D : disp_cat C}
     {c} {d : D c} {c' : C} {f : c' --> c} (fd fd' : cartesian_lift d f)
   : iso_disp (identity_iso c') fd fd'.
 Proof.
-  simple refine (_,,(_,,_)).
+  use (_,,(_,,_)).
   - exact (cartesian_factorisation' fd' (identity _) fd (id_left _)).
   - exact (cartesian_factorisation' fd (identity _) fd' (id_left _)).
   - cbn; split.
@@ -285,14 +285,14 @@ Proof.
   { intros ff. repeat (apply impred; intro).
     apply isapropiscontr. }
   etrans.
-    refine (@functtransportf_2 (D c') _ _ (λ x, pr1) _ _ _ _).
+    use (@functtransportf_2 (D c') _ _ (λ x, pr1)).
   cbn. etrans. apply transportf_precompose_disp.
   rewrite idtoiso_isotoid_disp.
-  refine (pathscomp0 (maponpaths _ _) (transportfbinv _ _ _)).
+  use (pathscomp0 (maponpaths _ _) (transportfbinv _ _ _)).
   apply (precomp_with_iso_disp_is_inj (cartesian_lifts_iso fd fd')).
   etrans. apply assoc_disp.
   etrans. eapply transportf_bind, cancel_postcomposition_disp.
-    refine (inv_mor_after_iso_disp _).
+    use inv_mor_after_iso_disp.
   etrans. eapply transportf_bind, id_left_disp.
   apply pathsinv0.
   etrans. apply mor_disp_transportf_prewhisker.

--- a/UniMath/CategoryTheory/HorizontalComposition.v
+++ b/UniMath/CategoryTheory/HorizontalComposition.v
@@ -19,8 +19,6 @@ Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
 
 Local Open Scope cat.
 
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
-
 Section horizontal_composition.
 
 Variables C D E : precategory.

--- a/UniMath/CategoryTheory/Inductives/LambdaCalculus.v
+++ b/UniMath/CategoryTheory/Inductives/LambdaCalculus.v
@@ -142,7 +142,7 @@ Definition mk_lambdaAlgebra (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X�
   (fapp : HSET2⟦prod2 X X,X⟧) (flam : HSET2⟦precomp_option X,X⟧) : algebra_ob lambdaFunctor.
 Proof.
 apply (tpair _ X).
-simple refine (BinCoproductArrow _ _ fvar (BinCoproductArrow _ _ fapp flam)).
+use (BinCoproductArrow _ _ fvar (BinCoproductArrow _ _ fapp flam)).
 Defined.
 
 Definition foldr_map (X : HSET2) (fvar : HSET2⟦functor_identity HSET,X⟧)

--- a/UniMath/CategoryTheory/Inductives/Lists.v
+++ b/UniMath/CategoryTheory/Inductives/Lists.v
@@ -362,15 +362,15 @@ Definition flip {A B C : UU} (f : A -> B -> C) : B -> A -> C := λ x y, f y x.
 Lemma omega_cocontConstProdFunctor : is_omega_cocont constprod_functor.
 Proof.
 intros hF c L ccL HcL cc.
-simple refine (tpair _ _ _).
+use tpair.
 - transparent assert (HX : (cocone hF (hset_fun_space x HcL))).
-  { simple refine (mk_cocone _ _).
+  {  use mk_cocone.
     * simpl; intro n; apply flip, curry, (pr1 cc).
     * abstract (destruct cc as [f hf]; simpl; intros m n e;
                 rewrite <- (hf m n e); destruct e; simpl;
                 repeat (apply funextfun; intro); apply idpath).
   }
-  simple refine (tpair _ _ _).
+  use tpair.
   + simpl; apply uncurry, flip.
     apply (colimArrow (mk_ColimCocone _ _ _ ccL) (hset_fun_space x HcL)).
     apply HX.
@@ -384,12 +384,12 @@ simple refine (tpair _ _ _).
 - abstract (
   intro p; unfold uncurry; simpl; apply subtypeEquality; simpl;
   [ intro g; apply impred; intro t;
-    simple refine (let ff : HSET ⟦(x × dob hF t)%set,HcL⟧ := _ in _);
+    use (let ff : HSET ⟦(x × dob hF t)%set,HcL⟧ := _ in _);
     [ simpl; apply (pr1 cc)
     | apply (@has_homsets_HSET _ HcL _ ff) ]
   | destruct p as [t p]; simpl;
     apply funextfun; intro xc; destruct xc as [x' c']; simpl;
-    simple refine (let g : HSET⟦colim (mk_ColimCocone hF c L ccL),
+    use (let g : HSET⟦colim (mk_ColimCocone hF c L ccL),
                                 hset_fun_space x HcL⟧ := _ in _);
     [ simpl; apply flip, curry, t
     | rewrite <- (colimArrowUnique _ _ _ g); [apply idpath | ];
@@ -412,12 +412,12 @@ Definition constcoprod_functor : functor C C :=
 Lemma omega_cocontConstCoprodFunctor : is_omega_cocont constcoprod_functor.
 Proof.
 intros hF c L ccL HcL cc.
-simple refine (tpair _ _ _).
-- simple refine (tpair _ _ _).
+use tpair.
+- use tpair.
   + eapply BinCoproductArrow.
     * exact (BinCoproductIn1 _ (PC x (dob hF 0)) · pr1 cc 0).
-    * simple refine (let ccHcL : cocone hF HcL := _ in _).
-      { simple refine (mk_cocone _ _).
+    * use (let ccHcL : cocone hF HcL := _ in _).
+      { use mk_cocone.
         - intros n; exact (BinCoproductIn2 _ (PC x (dob hF n)) · pr1 cc n).
         - abstract (
             intros m n e; destruct e; simpl;
@@ -441,7 +441,7 @@ simple refine (tpair _ _ _).
   | destruct t as [t p]; destruct ccL as [t0 p0]; unfold BinCoproduct_of_functors_mor in *; destruct t0 as [t0 p1]; simpl;
     apply BinCoproductArrowUnique;
     [ now rewrite <- (p 0), assoc, BinCoproductOfArrowsIn1, id_left
-    | simple refine (let temp : ∑ x0 : C ⟦ c, HcL ⟧, ∏ v : nat,
+    | use (let temp : ∑ x0 : C ⟦ c, HcL ⟧, ∏ v : nat,
          coconeIn L v · x0 = BinCoproductIn2 C (PC x (dob hF v)) · f v := _ in _);
          [ apply (tpair _ (BinCoproductIn2 C (PC x c) · t));
           now intro n; rewrite <- (p n), !assoc, BinCoproductOfArrowsIn2|];
@@ -489,7 +489,7 @@ Let List_alg : algebra_ob listFunctor :=
 Definition nil_map : HSET⟦unitHSET,List⟧.
 Proof.
 simpl; intro x.
-refine (List_mor _).
+use List_mor.
 apply inl.
 exact x.
 Defined.
@@ -499,7 +499,7 @@ Definition nil : pr1 List := nil_map tt.
 Definition cons_map : HSET⟦(A × List)%set,List⟧.
 Proof.
 intros xs.
-refine (List_mor _).
+use List_mor.
 exact (inr xs).
 Defined.
 

--- a/UniMath/CategoryTheory/Inductives/Trees.v
+++ b/UniMath/CategoryTheory/Inductives/Trees.v
@@ -63,7 +63,7 @@ Let Tree_alg : algebra_ob treeFunctor :=
 Definition leaf_map : HSET⟦unitHSET,Tree⟧.
 Proof.
 simpl; intro x.
-simple refine (Tree_mor _).
+use Tree_mor.
 apply inl, x.
 Defined.
 
@@ -72,7 +72,7 @@ Definition leaf : pr1 Tree := leaf_map tt.
 Definition node_map : HSET⟦(A × (Tree × Tree))%set,Tree⟧.
 Proof.
 intros xs.
-simple refine (Tree_mor _).
+use Tree_mor.
 exact (inr xs).
 Defined.
 

--- a/UniMath/CategoryTheory/Monads/Kleisli.v
+++ b/UniMath/CategoryTheory/Monads/Kleisli.v
@@ -64,7 +64,7 @@ Section monad_types_equiv.
 
   Definition Kleisli_to_Monad {C : precategory} (T : Kleisli C) : Monad C.
   Proof.
-    refine (((Kleisli_to_functor T,, Kleisli_to_μ T) ,, Kleisli_to_η T) ,, _).
+    use (((Kleisli_to_functor T,, Kleisli_to_μ T) ,, Kleisli_to_η T) ,, _).
     do 2 try apply tpair; intros; simpl.
     - apply (r_eta_r_bind T).
     - now rewrite (r_bind_r_bind T), <- assoc, (r_eta_r_bind T (T c)), id_right, (r_bind_r_eta T).

--- a/UniMath/CategoryTheory/Monads/LModules.v
+++ b/UniMath/CategoryTheory/Monads/LModules.v
@@ -29,8 +29,6 @@ Local Open Scope cat.
 
 Local Notation "F ;;; G" := (nat_trans_comp _ _ _ F G) (at level 35).
 
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
-
 (** * Definition of module *)
 Section LModule_over_monad.
 

--- a/UniMath/CategoryTheory/Monads/Monads.v
+++ b/UniMath/CategoryTheory/Monads/Monads.v
@@ -33,8 +33,6 @@ Require Import UniMath.CategoryTheory.limits.bincoproducts.
 
 Local Open Scope cat.
 
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
-
 (** * Definition of monads *)
 Section Monad_def.
 

--- a/UniMath/CategoryTheory/Monads/RelativeMonads.v
+++ b/UniMath/CategoryTheory/Monads/RelativeMonads.v
@@ -24,8 +24,6 @@ Require Import UniMath.CategoryTheory.functor_categories.
 
 Local Open Scope cat.
 
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
-
 (** * Definition of relative monads *)
 Section RMonad_def.
 

--- a/UniMath/CategoryTheory/PointedFunctors.v
+++ b/UniMath/CategoryTheory/PointedFunctors.v
@@ -116,7 +116,7 @@ Defined.
 Lemma eq_ptd_mor_precat {F G : precategory_Ptd} (a b : F --> G)
   : a = b ≃ (a : ptd_mor F G) = b.
 Proof.
-  simple refine (tpair _ _ _).
+  use tpair.
   intro H.
   exact H.
   apply idisweq.

--- a/UniMath/CategoryTheory/PointedFunctors.v
+++ b/UniMath/CategoryTheory/PointedFunctors.v
@@ -28,8 +28,6 @@ Require Import UniMath.CategoryTheory.Categories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Local Open Scope cat.
 
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
-
 Section def_ptd.
 
 Variable C : precategory.

--- a/UniMath/CategoryTheory/PointedFunctorsComposition.v
+++ b/UniMath/CategoryTheory/PointedFunctorsComposition.v
@@ -29,8 +29,6 @@ Local Open Scope cat.
 Require Import UniMath.CategoryTheory.PointedFunctors.
 Require Import UniMath.CategoryTheory.HorizontalComposition.
 
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
-
 Section def_ptd.
 
 Variable C : precategory.

--- a/UniMath/CategoryTheory/PrecategoryBinProduct.v
+++ b/UniMath/CategoryTheory/PrecategoryBinProduct.v
@@ -37,8 +37,6 @@ Require Import UniMath.CategoryTheory.Categories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Local Open Scope cat.
 
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
-
 Definition precategory_binproduct_mor (C D : precategory_ob_mor) (cd cd' : C × D) := pr1 cd --> pr1 cd' × pr2 cd --> pr2 cd'.
 
 Definition precategory_binproduct_ob_mor (C D : precategory_ob_mor) : precategory_ob_mor

--- a/UniMath/CategoryTheory/bicategories/Cat.v
+++ b/UniMath/CategoryTheory/bicategories/Cat.v
@@ -56,7 +56,7 @@ Proof.
 
     (* Which is natural. *)
     intros oba oba' f.
-    refine (id_right _ @ !(id_left _)).
+    use (id_right _ @ !(id_left _)).
 
   - (* Step 2: Show the above is natural, so given
        f : F -> F', g : G -> G', h : H -> H', *)

--- a/UniMath/CategoryTheory/bicategories/internal_equivalence.v
+++ b/UniMath/CategoryTheory/bicategories/internal_equivalence.v
@@ -86,7 +86,7 @@ Proof.
   rewrite <- !assoc.
   apply iso_inv_on_right.
 
-  pathvia (identity (identity_1mor a ;1; identity_1mor a)).
+  intermediate_path (identity (identity_1mor a ;1; identity_1mor a)).
     rewrite whisker_right_inv.
     apply iso_inv_on_right.
     apply iso_inv_on_right.

--- a/UniMath/CategoryTheory/bicategories/prebicategory.v
+++ b/UniMath/CategoryTheory/bicategories/prebicategory.v
@@ -344,7 +344,7 @@ Lemma horizontal_comp_id {C : prebicategory_id_comp} {a b c : C}
   = identity_2mor (f ;1; g).
 Proof.
   unfold compose_2mor_horizontal.
-  pathvia (functor_on_morphisms (compose_functor a b c)
+  intermediate_path (functor_on_morphisms (compose_functor a b c)
             (identity (precatbinprodpair f g))).
     reflexivity.
   apply functor_id.

--- a/UniMath/CategoryTheory/bicategories/whiskering.v
+++ b/UniMath/CategoryTheory/bicategories/whiskering.v
@@ -32,7 +32,7 @@ Lemma whisker_left_id_2mor {C : prebicategory} {a b c : C}
            (f : a -1-> b) (g : b -1-> c)
   : whisker_left f (identity_2mor g) = identity_2mor (f ;1; g).
 Proof.
-  pathvia (functor_on_morphisms (compose_functor a b c)
+  intermediate_path (functor_on_morphisms (compose_functor a b c)
                                 (identity (precatbinprodpair f g))).
   reflexivity.
   apply functor_id.
@@ -63,7 +63,7 @@ Proof.
   unfold whisker_left.
   unfold identity_2mor.
 
-  pathvia (inv_from_iso (identity_iso f);h;inv_from_iso alpha).
+  intermediate_path (inv_from_iso (identity_iso f);h;inv_from_iso alpha).
     set (W := maponpaths pr1 (iso_inv_of_iso_id _ f)).
     simpl in W.
     rewrite <- W.
@@ -79,7 +79,7 @@ Lemma whisker_left_id_inj {C : prebicategory} {b c : C}
 Proof.
   intros w.
 
-  pathvia (iso_inv_from_iso (left_unitor _)
+  intermediate_path (iso_inv_from_iso (left_unitor _)
            ;v; whisker_left (identity_1mor _) alpha
            ;v; left_unitor _ ).
     apply pathsinv0.
@@ -88,7 +88,7 @@ Proof.
     rewrite assoc.
     apply whisker_left_id_1mor.
 
-  pathvia (iso_inv_from_iso (left_unitor _)
+  intermediate_path (iso_inv_from_iso (left_unitor _)
            ;v; whisker_left (identity_1mor _) alpha'
            ;v; left_unitor _ ).
     apply cancel_postcomposition.
@@ -108,7 +108,7 @@ Lemma whisker_left_on_comp {C : prebicategory} {a b c : C}
   = whisker_left f alpha ;v; whisker_left f alpha'.
 Proof.
   unfold whisker_left.
-  pathvia ((identity_2mor f;v; identity_2mor f);h;(alpha;v;alpha')).
+  intermediate_path ((identity_2mor f;v; identity_2mor f);h;(alpha;v;alpha')).
     rewrite id_left.
     reflexivity.
   now apply interchange.
@@ -132,7 +132,7 @@ Lemma whisker_right_id_2mor {C : prebicategory} {a b c : C}
   (f : a -1-> b) (g : b -1-> c)
   : whisker_right (identity_2mor f) g = identity_2mor (f ;1; g).
 Proof.
-  pathvia (functor_on_morphisms (compose_functor a b c)
+  intermediate_path (functor_on_morphisms (compose_functor a b c)
                                 (identity (precatbinprodpair f g))).
   reflexivity.
   apply functor_id.
@@ -163,7 +163,7 @@ Proof.
   unfold whisker_right.
   unfold identity_2mor.
 
-  pathvia (inv_from_iso alpha ;h; inv_from_iso (identity_iso h)).
+  intermediate_path (inv_from_iso alpha ;h; inv_from_iso (identity_iso h)).
     set (W := maponpaths pr1 (iso_inv_of_iso_id _ h)).
     simpl in W.
     rewrite <- W.
@@ -179,7 +179,7 @@ Lemma whisker_right_id_inj {C : prebicategory} {a b : C}
 Proof.
   intros w.
 
-  pathvia (iso_inv_from_iso (right_unitor _)
+  intermediate_path (iso_inv_from_iso (right_unitor _)
            ;v; whisker_right alpha (identity_1mor _)
            ;v; right_unitor _ ).
     apply pathsinv0.
@@ -188,7 +188,7 @@ Proof.
     rewrite assoc.
     apply whisker_right_id_1mor.
 
-  pathvia (iso_inv_from_iso (right_unitor _)
+  intermediate_path (iso_inv_from_iso (right_unitor _)
            ;v; whisker_right alpha' (identity_1mor _)
            ;v; right_unitor _ ).
     apply cancel_postcomposition.
@@ -207,7 +207,7 @@ Lemma whisker_right_on_comp {C : prebicategory} {a b c : C}
   = whisker_right alpha i ;v; whisker_right alpha' i.
 Proof.
   unfold whisker_right.
-  pathvia ((alpha;v;alpha');h;(identity_2mor i;v; identity_2mor i)).
+  intermediate_path ((alpha;v;alpha');h;(identity_2mor i;v; identity_2mor i)).
     rewrite id_left.
     reflexivity.
   now apply interchange.
@@ -218,7 +218,7 @@ Lemma left_unitor_naturality {C : prebicategory} {a b : C}
   : whisker_left (identity_1mor _) alpha ;v; left_unitor g
   = left_unitor f ;v; alpha.
 Proof.
-  pathvia ((functor_on_morphisms
+  intermediate_path ((functor_on_morphisms
                  (functor_composite
                      (bindelta_pair_functor
                         (functor_composite (unit_functor _) (constant_functor unit_precategory _ (identity_1mor a)))
@@ -228,7 +228,7 @@ Proof.
            ;v;(left_unitor g)).
     reflexivity.
 
-  pathvia (left_unitor f ;v; functor_on_morphisms (functor_identity _) alpha).
+  intermediate_path (left_unitor f ;v; functor_on_morphisms (functor_identity _) alpha).
     apply (nat_trans_ax (left_unitor_trans a b)).
 
   reflexivity.
@@ -239,7 +239,7 @@ Lemma right_unitor_naturality {C : prebicategory} {a b : C}
   : whisker_right alpha (identity_1mor _) ;v; right_unitor g
   = right_unitor f ;v; alpha.
 Proof.
-  pathvia ((functor_on_morphisms
+  intermediate_path ((functor_on_morphisms
                  (functor_composite
                     (bindelta_pair_functor
                        (functor_identity _)
@@ -249,7 +249,7 @@ Proof.
            ;v;(right_unitor _)).
     reflexivity.
 
-  pathvia (right_unitor f ;v; functor_on_morphisms (functor_identity _) alpha).
+  intermediate_path (right_unitor f ;v; functor_on_morphisms (functor_identity _) alpha).
     apply (nat_trans_ax (right_unitor_trans a b)).
 
   reflexivity.
@@ -262,7 +262,7 @@ Lemma associator_naturality {C : prebicategory} { a b c d : C }
   : (alpha ;h; (beta ;h; gamma)) ;v; associator f' g' h'
   = associator f g h ;v; ((alpha ;h; beta) ;h; gamma).
 Proof.
-  pathvia ((functor_on_morphisms
+  intermediate_path ((functor_on_morphisms
             (functor_composite
               (pair_functor (functor_identity _) (compose_functor b c d))
               (compose_functor a b d))
@@ -271,7 +271,7 @@ Proof.
           ).
     reflexivity.
 
-  pathvia (associator f g h ;v;
+  intermediate_path (associator f g h ;v;
           (functor_on_morphisms
             (functor_composite
               (precategory_binproduct_assoc _ _ _)
@@ -293,11 +293,11 @@ Lemma twomor_naturality {C : prebicategory} {a b c : C}
 Proof.
   unfold whisker_left, whisker_right.
 
-  pathvia ((gamma ;v; identity_2mor g);h;(identity_2mor h ;v; delta)).
+  intermediate_path ((gamma ;v; identity_2mor g);h;(identity_2mor h ;v; delta)).
     apply pathsinv0.
     apply interchange.
 
-  pathvia ((identity_2mor f ;v; gamma);h;(delta ;v; identity_2mor k)).
+  intermediate_path ((identity_2mor f ;v; gamma);h;(delta ;v; identity_2mor k)).
     rewrite !id_left, !id_right.
     reflexivity.
 
@@ -409,10 +409,10 @@ Lemma left_unitor_id_is_right_unitor_id {C : prebicategory} {a : C}
 Proof.
   apply whisker_right_id_inj.
   apply (pre_comp_with_iso_is_inj _ _ _ _ (associator _ _ _) (pr2 (associator _ _ _))).
-  pathvia (left_unitor_2mor ((identity_1mor a) ;1; (identity_1mor a))).
+  intermediate_path (left_unitor_2mor ((identity_1mor a) ;1; (identity_1mor a))).
     apply pathsinv0.
     apply kelly_left.
-  pathvia (whisker_left (identity_1mor a) (left_unitor (identity_1mor a))).
+  intermediate_path (whisker_left (identity_1mor a) (left_unitor (identity_1mor a))).
     apply pathsinv0.
     apply left_unitor_on_id.
   apply (triangle_axiom (identity_1mor a) (identity_1mor a)).

--- a/UniMath/CategoryTheory/categories/StandardCategories.v
+++ b/UniMath/CategoryTheory/categories/StandardCategories.v
@@ -41,8 +41,8 @@ Lemma is_univalent_groupoid {C : category}: is_groupoid C -> is_univalent C.
 Proof. intros ig  .
   split.
   { intros a b.
-    refine (isofhlevelff 0 idtoiso (morphism_from_iso _ _ _) _ _).
-    { refine (isweqhomot (idtomor _ _) _ _ _).
+    use (isofhlevelff 0 idtoiso (morphism_from_iso _ _ _)).
+    { use (isweqhomot (idtomor _ _)).
       { intro p. destruct p. reflexivity. }
       { apply ig. } }
     apply morphism_from_iso_is_incl. }
@@ -55,10 +55,10 @@ Definition path_pregroupoid (X:UU) : isofhlevel 3 X -> category.
      be useful, because in it, each arrow is a path, rather than an
      equivalence class of paths. *)
   intros iobj.
-  unshelve refine (makecategory X (λ x y, x = y) _ _ _ _ _ _).
+  use (makecategory X (λ x y, x = y)); simpl.
+  { intros. exact (iobj _ _). }
   { reflexivity. }
   { intros. exact (f @ g). }
-  { intros. exact (iobj _ _). }
   { reflexivity. }
   { intros. apply pathscomp0rid. }
   { intros. apply path_assoc. }

--- a/UniMath/CategoryTheory/categories/category_hset_structures.v
+++ b/UniMath/CategoryTheory/categories/category_hset_structures.v
@@ -177,7 +177,7 @@ Defined.
 
 Lemma rel0_impl a b (Hab : rel0 a b) : from_cobase_eqrel a b.
 Proof.
-refine (Hab _ _). clear Hab.
+use Hab. clear Hab.
 intro H; simpl.
 destruct H as [f Hf].
 generalize (toforallpaths _ _ _ (coconeInCommutes cc (pr1 a) (pr1 b) f) (pr2 a)).
@@ -867,7 +867,7 @@ use mk_are_adjoints.
   + intros x; apply eq_mor_slicecat, funextsec; intro x1; simpl.
     use total2_paths_f; [apply idpath|]; cbn.
     apply funextsec; intro y.
-    simple refine (subtypeEquality _ _).
+    use subtypeEquality.
     * intro z; apply setproperty.
     * simpl.
       apply maponpaths.
@@ -954,14 +954,14 @@ Proof.
   - apply invproofirrelevance; intros [ab [ea eb]] [ab' [ea' eb']].
     apply subtypeEquality; simpl.
       intros x; apply isapropdirprod; apply setproperty.
-    refine (@toforallpaths unitset _ (λ _, ab) (λ _, ab') _ tt).
-    refine (MorphismsIntoPullbackEqual pb _ _ _ _ );
+    use (@toforallpaths unitset _ (λ _, ab) (λ _, ab') _ tt).
+    use (MorphismsIntoPullbackEqual pb);
     apply funextsec; intros []; cbn;
     (eapply @pathscomp0; [ eassumption | apply pathsinv0; eassumption]).
-  - simple refine (_,,_).
-    refine (_ tt).
-    refine (PullbackArrow Pb (unitset : HSET)
-      (λ _, a) (λ _, b) _).
+  - use (_,,_).
+    use (_ tt).
+    use (PullbackArrow Pb (unitset : HSET)
+      (λ _, a) (λ _, b)).
     apply funextsec; intro; exact e.
     simpl; split.
     + generalize tt; apply toforallpaths.

--- a/UniMath/CategoryTheory/covyoneda.v
+++ b/UniMath/CategoryTheory/covyoneda.v
@@ -27,8 +27,6 @@ Require Import UniMath.CategoryTheory.categories.category_hset.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.whiskering.
 
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
-
 Ltac unf := unfold identity,
                    compose,
                    precategory_morphisms;

--- a/UniMath/CategoryTheory/elems_slice_equiv.v
+++ b/UniMath/CategoryTheory/elems_slice_equiv.v
@@ -80,11 +80,11 @@ Section elems_slice_equiv.
       set (e := fun (x : ∫P) => eqtohomot (!((functor_id P) (pr1 x))) (pr2 x)).
       set (h := λ (x : T'), pr1 x ,, (pr2 x) q : pr1hSet (PreShv_to_slice_ob_funct_fun F X)).
 
-      refine (maponpaths (funcomp G h)
+      use (maponpaths (funcomp G h)
                          (connectedcoconustot ((# (pr1 P) (identity X) p) ,, idpath _) (p ,, e (X ,, p))) @ _).
-      refine (@pair_path_in2 _ (λ x, pr1hSet ((pr1 F) (X ,, x))) p _ _ _).
-      refine (eqtohomot _ q @ eqtohomot (functor_id F (X ,, p)) q).
-      refine (maponpaths (# (pr1 F)) _).
+      use (@pair_path_in2 _ (λ x, pr1hSet ((pr1 F) (X ,, x))) p).
+      use (eqtohomot _ q @ eqtohomot (functor_id F (X ,, p)) q).
+      use (maponpaths (# (pr1 F))).
       use total2_paths_f.
       * reflexivity.
       * rewrite idpath_transportf;
@@ -99,18 +99,18 @@ Section elems_slice_equiv.
                     @ (eqtohomot (!(functor_comp P) (pr1 g) (pr1 f)) (pr2 x)))).
       set (h := λ (x : T'), pr1 x ,, (pr2 x) q : pr1hSet (PreShv_to_slice_ob_funct_fun F Z)).
 
-      refine (maponpaths (funcomp G h)
+      use (maponpaths (funcomp G h)
                          (connectedcoconustot (# (pr1 P) (g ∘ f) p ,, idpath _)
                                               (# (pr1 P) g (# (pr1 P) f p) ,,
                                                  e (mk_ob Z (# (pr1 P) g (# (pr1 P) f p)))
                                                  (mk_ob Y (# (pr1 P) f p)) (mk_ob X p)
                                                  (g ,, idpath _) (f ,, idpath _))) @ _).
-      refine (@pair_path_in2 _ (λ x, pr1hSet ((pr1 F) (Z ,, x))) (# (pr1 P) g (# (pr1 P) f p)) _ _ _).
-      refine (eqtohomot _ q @ eqtohomot (@functor_comp _ _ F (mk_ob X p)
+      use (@pair_path_in2 _ (λ x, pr1hSet ((pr1 F) (Z ,, x))) (# (pr1 P) g (# (pr1 P) f p))).
+      use (eqtohomot _ q @ eqtohomot (@functor_comp _ _ F (mk_ob X p)
                                                        (mk_ob Y (# (pr1 P) f p))
                                                        (mk_ob Z (# (pr1 P) g (# (pr1 P) f p)))
                                                        (f ,, idpath _) (g,, idpath _)) q).
-      refine (maponpaths (# (pr1 F)) _).
+      use (maponpaths (# (pr1 F))).
       use total2_paths_f.
       * reflexivity.
       * rewrite idpath_transportf;
@@ -180,7 +180,7 @@ Section elems_slice_equiv.
     apply (hfibersgftog (Qmor _ _ f) (Qnat y)).
     exists (pr1 s).
     rewrite feq.
-    refine (eqtohomot (Qisnat _ _ f) (pr1 s) @ _).
+    use (eqtohomot (Qisnat _ _ f) (pr1 s) @ _).
     exact (maponpaths (# (pr1 P) f) (pr2 s)).
   Defined.
 
@@ -371,7 +371,7 @@ Section elems_slice_equiv.
     assert (H : isweq (λ x : pr1hSet (F (X,, p)) , (p,, x) ,, idpath p : pr1hSet (slice_to_PreShv_ob_ob (PreShv_to_slice_ob ((F,, Fmor),, Fisfunct)) (X,, p)))).
     { unfold isweq. intros [[p' x'] e'].
       simpl in *. induction e'.
-      refine ((x',, idpath _),, _).
+      use ((x',, idpath _),, _).
       intros [x'' t].
       apply (invmaponpathsincl pr1).
       apply isofhlevelfpr1;
@@ -383,7 +383,7 @@ Section elems_slice_equiv.
         exact ((pr2 c) _ @ !((pr2 c) _)).
       }
       set (eq := fiber_paths (maponpaths pr1 t)).
-      refine (_ @ eq).
+      use (_ @ eq).
       rewrite (transportf_paths _ eq_id).
       now rewrite idpath_transportf.
     }

--- a/UniMath/CategoryTheory/equivalences.v
+++ b/UniMath/CategoryTheory/equivalences.v
@@ -325,7 +325,7 @@ Proof.
   set (fminusf := iso_comp f (iso_inv_from_iso f')).
   set (g := iso_from_fully_faithful_reflection HF fminusf).
   apply (two_arg_paths_f (B:=λ a', iso ((pr1 F) a') b) (isotoid _ HA g)).
-  pathvia (iso_comp (iso_inv_from_iso
+  intermediate_path (iso_comp (iso_inv_from_iso
     (functor_on_iso F (idtoiso (isotoid _ HA g)))) f).
     generalize (isotoid _ HA g).
     intro p0; destruct p0.

--- a/UniMath/CategoryTheory/equivalences_lemmas.v
+++ b/UniMath/CategoryTheory/equivalences_lemmas.v
@@ -55,7 +55,7 @@ Proof.
   set (H' := nat_trans_ax  (adjunit (pr1 H))).
   simpl in H'; rewrite <- H'; clear H'; simpl in *.
   rewrite <- assoc.
-  pathvia (f · identity _).
+  intermediate_path (f · identity _).
   apply maponpaths.
   set (H' := iso_inv_after_iso (eta b)).
   apply H'.

--- a/UniMath/CategoryTheory/functor_categories.v
+++ b/UniMath/CategoryTheory/functor_categories.v
@@ -58,8 +58,6 @@ Require Import UniMath.CategoryTheory.Categories.
 
 Local Open Scope cat.
 
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
-
 (** * Functors : Morphisms of precategories *)
 Section functors.
 
@@ -216,7 +214,7 @@ Lemma functor_id_id (A B : precategory) (G : functor A B) (a : A) (f : a --> a)
   : f = identity _ -> #G f = identity _ .
 Proof.
   intro e.
-  pathvia (#G (identity a )).
+  intermediate_path (#G (identity a )).
   - apply maponpaths. apply e.
   - apply functor_id.
 Defined.
@@ -926,7 +924,7 @@ Lemma nat_trans_comp_pointwise (C : precategory_data)(C' : precategory) (hs: has
         ∏ a, pr1 A a · pr1 A' a = pr1 B a.
 Proof.
   intros H' a.
-  pathvia (pr1 (A · A') a).
+  intermediate_path (pr1 (A · A') a).
   apply idpath.
   destruct H'.
   apply idpath.
@@ -1161,7 +1159,7 @@ Proof.
   apply funextsec; intro f.
   rewrite transport_of_functor_map_is_pointwise.
   rewrite toforallpaths_funextsec.
-  pathvia ((inv_from_iso
+  intermediate_path ((inv_from_iso
         (idtoiso
            (isotoid D H
               (functor_iso_pointwise_if_iso C D _ F G A (pr2 A) a)))·
@@ -1179,7 +1177,7 @@ Proof.
   rewrite idtoiso_isotoid.
   destruct A as [A Aiso].
   simpl in *.
-  pathvia
+  intermediate_path
     (inv_from_iso (functor_iso_pointwise_if_iso C D hs F G A Aiso a) ·
        (A a · #G f)).
   rewrite <- assoc.
@@ -1253,7 +1251,7 @@ Proof.
   simpl; apply nat_trans_eq; intro a. apply hs.
   assert (H':= idtoiso_compute_pointwise C D _ F G (functor_eq_from_functor_iso _ H F G gamma) a).
   simpl in *.
-  pathvia (pr1
+  intermediate_path (pr1
        (idtoiso
           (toforallpaths (λ _ : ob C, D) (pr1 (pr1 F)) (pr1 (pr1 G))
              (base_paths (pr1 F) (pr1 G)
@@ -1265,7 +1263,7 @@ Proof.
   rewrite base_total2_paths.
   unfold pr1_functor_eq_from_functor_iso.
   rewrite base_total2_paths.
-  pathvia (pr1 (idtoiso
+  intermediate_path (pr1 (idtoiso
      (isotoid D H (functor_iso_pointwise_if_iso C D hs F G gamma (pr2 gamma) a)))).
   apply maponpaths.
   apply maponpaths.

--- a/UniMath/CategoryTheory/functor_categories.v
+++ b/UniMath/CategoryTheory/functor_categories.v
@@ -527,7 +527,7 @@ Definition weq_ff_functor_on_iso_weqbandf {C D : precategory}
   (HF : fully_faithful F) (a b : C)
   : iso a b ≃ iso (F a) (F b).
 Proof.
-  simple refine (weqbandf _ _ _ _ ).
+  use weqbandf.
   - apply (weqpair _ (HF a b)).
   - simpl; intro f.
     apply weqimplimpl.
@@ -555,7 +555,7 @@ Proof.
   intro d.
   apply invproofirrelevance.
   intros [c e] [c' e'].
-  simple refine (total2_paths_f _ _ ).
+  use total2_paths_f.
   - simpl.
     set (X := idtoiso (e @ ! e')).
     (* set (X' := invmap (@weq_ff_functor_on_iso _ _ _ HF _ _ ) X). *)

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -158,7 +158,7 @@ Definition mk_BinCoproductCocone (a b : C) :
    isBinCoproductCocone _ _ _ f g →  BinCoproductCocone a b.
 Proof.
   intros.
-  simple refine (tpair _ _ _ ).
+  use tpair.
   - exists c.
     exists f.
     exact g.
@@ -962,11 +962,11 @@ Qed.
 Definition functor_precat_coproduct_cocone
   : BinCoproductCocone [C, D, hsD] F G.
 Proof.
-  simple refine (mk_BinCoproductCocone _ _ _ _ _ _ _ ).
+  use mk_BinCoproductCocone.
   - apply BinCoproduct_of_functors.
   - apply coproduct_nat_trans_in1.
   - apply coproduct_nat_trans_in2.
-  - simple refine (mk_isBinCoproductCocone _ _ _ _ _ _ _ _ ).
+  - use mk_isBinCoproductCocone.
     + apply functor_category_has_homsets.
     + intros A f g.
      exists (tpair _ (coproduct_nat_trans A f g)

--- a/UniMath/CategoryTheory/limits/binproducts.v
+++ b/UniMath/CategoryTheory/limits/binproducts.v
@@ -119,7 +119,7 @@ Definition mk_BinProductCone (a b : C) :
    isBinProductCone _ _ _ f g -> BinProductCone a b.
 Proof.
   intros.
-  simple refine (tpair _ _ _ ).
+  use tpair.
   - exists c.
     exists f.
     exact g.
@@ -562,11 +562,11 @@ Qed.
 Definition functor_precat_binproduct_cone
   : BinProductCone [C, D, hsD] F G.
 Proof.
-simple refine (mk_BinProductCone _ _ _ _ _ _ _).
+use mk_BinProductCone.
 - apply BinProduct_of_functors.
 - apply binproduct_nat_trans_pr1.
 - apply binproduct_nat_trans_pr2.
-- simple refine (mk_isBinProductCone _ _ _ _ _ _ _ _).
+- use mk_isBinProductCone.
   + apply functor_category_has_homsets.
   + intros A f g.
     exists (tpair _ (binproduct_nat_trans A f g)

--- a/UniMath/CategoryTheory/limits/cats/limits.v
+++ b/UniMath/CategoryTheory/limits/cats/limits.v
@@ -146,7 +146,7 @@ Definition limOfArrows {J C : precategory} {F1 F2 : functor J C}
   (fNat : ∏ u v (e : J⟦u,v⟧), f u · # F2 e = # F1 e · f v) :
   C⟦lim CC1 , lim CC2⟧.
 Proof.
-apply limArrow; simple refine (mk_cone _ _).
+apply limArrow; use mk_cone.
 - now intro u; apply (limOut CC1 u · f u).
 - abstract (intros u v e; simpl;
             now rewrite <- assoc, fNat, assoc, limOutCommutes).
@@ -202,10 +202,10 @@ Lemma lim_endo_is_identity {J C : precategory} {F : functor J C}
   (H : ∏ u, k · limOut CC u = limOut CC u) :
   identity _ = k.
 Proof.
-unshelve refine (uniqueExists _ _ (limUnivProp CC _ _) _ _ _ _).
+use (uniqueExists _ _ (limUnivProp CC _ _)).
 - now apply (limCone CC).
 - now intros v; apply id_left.
-- now apply H.
+- simpl; now apply H.
 Qed.
 
 (*
@@ -334,7 +334,7 @@ Definition LimFunctor_ob (a : A) : C := lim (HCg a).
 Definition LimFunctor_mor (a a' : A) (f : A⟦a, a'⟧) :
   C⟦LimFunctor_ob a,LimFunctor_ob a'⟧.
 Proof.
-simple refine (limOfArrows _ _ _ _).
+use limOfArrows.
 - now intro u; apply (# (pr1 (D u)) f).
 - abstract (now intros u v e; simpl; apply (nat_trans_ax (# D e))).
 Defined.
@@ -370,7 +370,7 @@ Defined.
 Definition cone_pointwise (F : [A,C,hsC]) (cc : cone D F) a :
   cone (functor_pointwise a) (pr1 F a).
 Proof.
-simple refine (mk_cone _ _).
+use mk_cone.
 - now intro v; apply (pr1 (coneOut cc v) a).
 - abstract (intros u v e;
     now apply (nat_trans_eq_pointwise (coneOutCommutes cc u v e))).
@@ -388,7 +388,7 @@ use tpair.
     | apply pathsinv0; eapply pathscomp0;
       [ apply postcompWithLimArrow
       | apply limArrowUnique; intro u; eapply pathscomp0;
-      [ now apply limArrowCommutes | now refine (nat_trans_ax _ _ _ _)]]]).
+      [ now apply limArrowCommutes | now use nat_trans_ax]]]).
   + abstract (intro u; apply (nat_trans_eq hsC); simpl; intro a;
               now apply (limArrowCommutes (HCg a))).
 - abstract (intro t; destruct t as [t1 t2];
@@ -401,9 +401,9 @@ Defined.
 
 Lemma LimFunctorCone : LimCone D.
 Proof.
-simple refine (mk_LimCone _ _ _ _).
+use mk_LimCone.
 - exact LimFunctor.
-- simple refine (mk_cone _ _).
+- use mk_cone.
   + now apply lim_nat_trans_in_data.
   + abstract (now intros u v e; apply (nat_trans_eq hsC);
                   intro a; apply (limOutCommutes (HCg a))).

--- a/UniMath/CategoryTheory/limits/coequalizers.v
+++ b/UniMath/CategoryTheory/limits/coequalizers.v
@@ -76,11 +76,11 @@ Section def_coequalizers.
              (H : f · e = g · e) (isE : isCoequalizer f g e H) :
     Coequalizer f g.
   Proof.
-    simple refine (tpair _ _ _).
-    - simple refine (tpair _ _ _).
+    use tpair.
+    - use tpair.
       + apply w.
       + apply e.
-    - simpl. refine (tpair _ H isE).
+    - simpl. exact (tpair _ H isE).
   Defined.
 
   (** Coequalizers in precategories. *)

--- a/UniMath/CategoryTheory/limits/coequalizers.v
+++ b/UniMath/CategoryTheory/limits/coequalizers.v
@@ -130,7 +130,7 @@ Section def_coequalizers.
     set (E' := mk_Coequalizer _ _ _ _ E).
     repeat rewrite <- assoc in H'1.
     set (E'ar := CoequalizerOut E' w0 (e · φ1) H'1).
-    pathvia E'ar.
+    intermediate_path E'ar.
     apply isCoequalizerOutUnique. apply idpath.
     apply pathsinv0. apply isCoequalizerOutUnique. apply pathsinv0. apply H'.
   Defined.

--- a/UniMath/CategoryTheory/limits/cones.v
+++ b/UniMath/CategoryTheory/limits/cones.v
@@ -222,17 +222,17 @@ Definition isotoid_CONE_pr1 (a b : CONE) : iso a b -> pr1 a = pr1 b.
 Proof.
   intro f.
   apply (total2_paths_f (isotoid _ is_cat_C (ConeConnectIso f))).
-  pathvia ((λ c : J,
+  intermediate_path ((λ c : J,
      idtoiso (!isotoid C is_cat_C (ConeConnectIso f))· pr2 (pr1 a) c)).
   apply transportf_isotoid_dep'.
   apply funextsec.
   intro t.
-  pathvia (idtoiso (isotoid C is_cat_C (iso_inv_from_iso (ConeConnectIso f)))·
+  intermediate_path (idtoiso (isotoid C is_cat_C (iso_inv_from_iso (ConeConnectIso f)))·
        pr2 (pr1 a) t).
   apply cancel_postcomposition.
   apply maponpaths. apply maponpaths.
   apply inv_isotoid.
-  pathvia (iso_inv_from_iso (ConeConnectIso f)· pr2 (pr1 a) t).
+  intermediate_path (iso_inv_from_iso (ConeConnectIso f)· pr2 (pr1 a) t).
   apply cancel_postcomposition.
   set (H := idtoiso_isotoid _ is_cat_C _ _ (iso_inv_from_iso (ConeConnectIso f))).
   simpl in *.
@@ -269,14 +269,14 @@ base_paths (pr1 M) (pr1 M)
       (base_paths M M (isotoid_CONE (identity_iso M))) =
     base_paths (pr1 M) (pr1 M) (idpath (pr1 M)).
 Proof.
-  pathvia (base_paths (pr1 M) (pr1 M) (isotoid_CONE_pr1 M M (identity_iso M))).
+  intermediate_path (base_paths (pr1 M) (pr1 M) (isotoid_CONE_pr1 M M (identity_iso M))).
   unfold Cone_eq.
   apply maponpaths.
   apply base_total2_paths.
-  pathvia (isotoid C is_cat_C (ConeConnectIso (identity_iso M))).
+  intermediate_path (isotoid C is_cat_C (ConeConnectIso (identity_iso M))).
   unfold isotoid_CONE_pr1.
   apply base_total2_paths.
-  pathvia (isotoid C is_cat_C (identity_iso (ConeTop (pr1 M)))).
+  intermediate_path (isotoid C is_cat_C (identity_iso (ConeTop (pr1 M)))).
   apply maponpaths, ConeConnectIso_identity_iso.
   apply isotoid_identity_iso.
 Defined.

--- a/UniMath/CategoryTheory/limits/coproducts.v
+++ b/UniMath/CategoryTheory/limits/coproducts.v
@@ -324,10 +324,10 @@ End vertex.
 Definition functor_precat_coproduct_cocone
   : CoproductCocone I [C, D, hsD] F.
 Proof.
-simple refine (mk_CoproductCocone _ _ _ _ _ _).
+use mk_CoproductCocone.
 - apply coproduct_of_functors.
 - apply coproduct_nat_trans_in.
-- simple refine (mk_isCoproductCocone _ _ _ _ _ _ _).
+- use mk_isCoproductCocone.
   + apply functor_category_has_homsets.
   + intros A f.
     use tpair.

--- a/UniMath/CategoryTheory/limits/equalizers.v
+++ b/UniMath/CategoryTheory/limits/equalizers.v
@@ -128,7 +128,7 @@ Section def_equalizers.
     rewrite <- assoc. rewrite H. rewrite assoc. apply idpath.
     set (E' := mk_Equalizer _ _ _ _ E).
     set (E'ar := EqualizerIn E' w (φ1 · e) H'1).
-    pathvia E'ar.
+    intermediate_path E'ar.
     apply isEqualizerInUnique. apply idpath.
     apply pathsinv0. apply isEqualizerInUnique. apply pathsinv0. apply H'.
   Defined.

--- a/UniMath/CategoryTheory/limits/equalizers.v
+++ b/UniMath/CategoryTheory/limits/equalizers.v
@@ -76,11 +76,11 @@ Section def_equalizers.
              (H : e · f = e · g) (isE : isEqualizer f g e H) :
     Equalizer f g.
   Proof.
-    simple refine (tpair _ _ _).
-    - simple refine (tpair _ _ _).
+    use tpair.
+    - use tpair.
       + apply x.
       + apply e.
-    - simpl. refine (tpair _ H isE).
+    - simpl. exact (tpair _ H isE).
   Defined.
 
   (** Equalizers in precategories. *)

--- a/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
@@ -35,7 +35,8 @@ Defined.
 
 Definition CopCocone {C : precategory} {a b : C} {c : C} (ac : a --> c) (bc : b --> c) :
    cocone (bincoproduct_diagram a b) c.
-simple refine (tpair _ _ _ ).
+Proof.
+  use tpair.
 + intro v.
   induction v; simpl.
   - exact ac.
@@ -60,12 +61,12 @@ Definition mk_isBinCoproductCocone (hsC : has_homsets C)(a b co : C) (ia : a -->
 Proof.
   intros H c cc.
   set (H':= H c (coconeIn cc true) (coconeIn cc false)).
-  unshelve refine (tpair _ _ _ ).
+  use tpair.
   - exists (pr1 (pr1 H')).
     set (T := pr2 (pr1 H')). simpl in T.
     abstract (intro u; induction u;
               [ apply (pr1 T) | apply (pr2 T)]).
-  - intros. abstract (intros;
+  - simpl. intros. abstract (intros;
               apply subtypeEquality;
               [ intro; apply impred; intro; apply hsC
               | apply path_to_ctr; split; [ apply (pr2 t true) | apply (pr2 t false)] ]).
@@ -79,7 +80,7 @@ Definition mk_BinCoproductCocone (a b : C) :
    isBinCoproductCocone _ _ _ f g →  BinCoproductCocone a b.
 Proof.
   intros.
-  simple refine (tpair _ _ _ ).
+  use tpair.
   - exists c.
     apply (CopCocone f g).
   - apply X.
@@ -99,7 +100,7 @@ Definition BinCoproductArrow {a b : C} (CC : BinCoproductCocone a b) {c : C} (f 
       BinCoproductObject CC --> c.
 Proof.
   apply (colimArrow CC).
-  simple refine (mk_cocone _ _ ).
+  use mk_cocone.
   + intro v. induction v.
     - apply f.
     - apply g.
@@ -130,7 +131,7 @@ Lemma BinCoproductArrowUnique (a b : C) (CC : BinCoproductCocone a b) (x : C)
       k = BinCoproductArrow CC f g.
 Proof.
   intros H1 H2.
-  refine (colimArrowUnique _ _ _ _ _ ).
+  use colimArrowUnique.
   simpl. intro u; induction u; simpl.
   - apply H1.
   - apply H2.
@@ -218,7 +219,7 @@ Lemma BinCoproduct_endo_is_identity (CC : BinCoproductCocone a b)
   : identity _ = k.
 Proof.
 (*  apply pathsinv0. *)
-  refine (colim_endo_is_identity _ _ _ _).
+  use colim_endo_is_identity.
   intro u; induction u; simpl; assumption.
 Defined.
 

--- a/UniMath/CategoryTheory/limits/graphs/binproducts.v
+++ b/UniMath/CategoryTheory/limits/graphs/binproducts.v
@@ -33,7 +33,7 @@ Defined.
 Definition ProdCone {a b c : C} (ca : C⟦c,a⟧) (cb : C⟦c,b⟧) :
   cone (binproduct_diagram a b) c.
 Proof.
-simple refine (tpair _ _ _); simpl.
+use tpair; simpl.
 - intro v; induction v.
   + exact ca.
   + exact cb.
@@ -52,11 +52,11 @@ Proof.
 intros H c cc.
 simpl in *.
 set (H' := H c (coneOut cc true) (coneOut cc false)).
-unshelve refine (tpair _ _ _).
+use tpair.
 - exists (pr1 (pr1 H')).
   set (T := pr2 (pr1 H')); simpl in T.
   abstract (intro u; induction u; simpl; [exact (pr1 T)|exact (pr2 T)]).
-- abstract (intros; apply subtypeEquality;
+- abstract (simpl; intros; apply subtypeEquality;
               [intro; apply impred;intro; apply hsC|]; simpl;
             apply path_to_ctr; split; [ apply (pr2 t true) | apply (pr2 t false) ]).
 Defined.
@@ -68,7 +68,7 @@ Definition mk_BinProductCone (a b : C) :
    isBinProductCone _ _ _ f g -> BinProductCone a b.
 Proof.
   intros.
-  simple refine (tpair _ _ _ ).
+  use tpair.
   - exists c.
     apply (ProdCone f g).
   - apply X.
@@ -93,7 +93,7 @@ Definition BinProductArrow {a b : C} (P : BinProductCone a b) {c : C}
   (f : C⟦c,a⟧) (g : C⟦c,b⟧) : C⟦c,BinProductObject P⟧.
 Proof.
 apply (limArrow P).
-simple refine (mk_cone _ _).
+use mk_cone.
 - intro v; induction v; [ apply f | apply g ].
 - intros ? ? e; induction e. (* <- should not be opaque! otherwise BinProductPr1Commutes doesn't work *)
 Defined.
@@ -118,7 +118,7 @@ Lemma BinProductArrowUnique (a b : C) (P : BinProductCone a b) (c : C)
       k = BinProductArrow P f g.
 Proof.
 intros H1 H2.
-refine (limArrowUnique _ _ _ _ _); simpl.
+use limArrowUnique; simpl.
 now intro u; induction u; simpl; [ apply H1 | apply H2 ].
 Qed.
 

--- a/UniMath/CategoryTheory/limits/graphs/coequalizers.v
+++ b/UniMath/CategoryTheory/limits/graphs/coequalizers.v
@@ -136,7 +136,7 @@ Section def_coequalizers.
   Lemma CoequalizerArrowComm {a b : C} {f g : C⟦a, b⟧} (E : Coequalizer f g) (e : C) (h : C⟦b, e⟧)
         (H : f · h = g · h) : CoequalizerArrow E · CoequalizerOut E e h H = h.
   Proof.
-    refine (colimArrowCommutes E e _ Two).
+    exact (colimArrowCommutes E e _ Two).
   Qed.
 
   Lemma CoequalizerOutUnique {a b : C} {f g : C⟦a, b⟧} (E : Coequalizer f g) (e : C) (h : C⟦b, e⟧)

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -194,7 +194,7 @@ Definition colimOfArrows {g : graph} {d1 d2 : diagram g C}
   (fNat : ∏ u v (e : edge u v), dmor d1 e · f v = f u · dmor d2 e) :
   C⟦colim CC1,colim CC2⟧.
 Proof.
-apply colimArrow; simple refine (mk_cocone _ _).
+apply colimArrow; use mk_cocone.
 - now intro u; apply (f u · colimIn CC2 u).
 - abstract (intros u v e; simpl;
             now rewrite assoc, fNat, <- assoc, colimInCommutes).
@@ -248,11 +248,11 @@ Lemma colim_endo_is_identity {g : graph} (D : diagram g C)
   (H : ∏ u, colimIn CC u · k = colimIn CC u) :
   identity _ = k.
 Proof.
-unshelve refine (uniqueExists _ _ (colimUnivProp CC _ _) _ _ _ _).
+use (uniqueExists _ _ (colimUnivProp CC _ _)).
 - now apply (colimCocone CC).
 - intros v; simpl.
   now apply id_right.
-- now apply H.
+- simpl; now apply H.
 Qed.
 
 Definition Cocone_by_postcompose {g : graph} (D : diagram g C)
@@ -283,7 +283,7 @@ Lemma isColim_weq {g : graph} (D : diagram g C) (c : C) (cc : cocone D c) :
 Proof.
 split.
 - intros H d.
-  simple refine (gradth _ _ _ _).
+  use gradth.
   + intros k.
     exact (colimArrow (mk_ColimCocone D c cc H) _ k).
   + abstract (intro k; simpl;
@@ -294,7 +294,7 @@ split.
                 | destruct k as [k Hk]; simpl; apply funextsec; intro u;
                   now apply (colimArrowCommutes (mk_ColimCocone D c cc H))]).
 - intros H d cd.
-  simple refine (tpair _ _ _).
+  use tpair.
   + exists (invmap (weqpair _ (H d)) cd).
     abstract (intro u; now apply isColim_weq_subproof2).
   + abstract (intro t; apply subtypeEquality;
@@ -341,8 +341,8 @@ Proof.
 intro H.
 set (iinv := z_iso_inv_from_is_z_iso _ (is_z_iso_from_is_iso _ H)).
 intros x cx.
-simple refine (tpair _ _ _).
-- simple refine (tpair _ _ _).
+use tpair.
+- use tpair.
   + exact (iinv · colimArrow CC x cx).
   + simpl; intro u.
     rewrite <- (colimArrowCommutes CC x cx u), assoc.
@@ -424,7 +424,7 @@ Definition ColimFunctor_ob (a : A) : C := colim (HCg a).
 Definition ColimFunctor_mor (a a' : A) (f : A⟦a, a'⟧) :
   C⟦ColimFunctor_ob a,ColimFunctor_ob a'⟧.
 Proof.
-simple refine (colimOfArrows _ _ _ _).
+use colimOfArrows.
 - now intro u; apply (# (pr1 (dob D u)) f).
 - abstract (now intros u v e; simpl; apply pathsinv0, (nat_trans_ax (dmor D e))).
 Defined.
@@ -451,7 +451,7 @@ Definition ColimFunctor : functor A C := tpair _ _ is_functor_ColimFunctor_data.
 
 Definition colim_nat_trans_in_data v : [A, C, hsC] ⟦ dob D v, ColimFunctor ⟧.
 Proof.
-simple refine (tpair _ _ _).
+use tpair.
 - intro a; exact (colimIn (HCg a) v).
 - abstract (intros a a' f;
             now apply pathsinv0, (colimOfArrowsIn _ _ (HCg a) (HCg a'))).
@@ -460,18 +460,18 @@ Defined.
 Definition cocone_pointwise (F : [A,C,hsC]) (cc : cocone D F) a :
   cocone (diagram_pointwise a) (pr1 F a).
 Proof.
-simple refine (mk_cocone _ _).
+use mk_cocone.
 - now intro v; apply (pr1 (coconeIn cc v) a).
 - abstract (intros u v e;
-    now apply (nat_trans_eq_pointwise  (coconeInCommutes cc u v e))).
+    now apply (nat_trans_eq_pointwise (coconeInCommutes cc u v e))).
 Defined.
 
 Lemma ColimFunctor_unique (F : [A, C, hsC]) (cc : cocone D F) :
   iscontr (∑ x : [A, C, hsC] ⟦ ColimFunctor, F ⟧,
             ∏ v : vertex g, colim_nat_trans_in_data v · x = coconeIn cc v).
 Proof.
-simple refine (tpair _ _ _).
-- simple refine (tpair _ _ _).
+use tpair.
+- use tpair.
   + apply (tpair _ (λ a, colimArrow (HCg a) _ (cocone_pointwise F cc a))).
     abstract (intros a a' f; simpl;
               eapply pathscomp0;
@@ -481,7 +481,7 @@ simple refine (tpair _ _ _).
                   | apply colimArrowUnique; intro u;
                     eapply pathscomp0;
                       [ now apply colimArrowCommutes
-                      | apply pathsinv0; now refine (nat_trans_ax _ _ _ _) ]]]).
+                      | apply pathsinv0; now use nat_trans_ax ]]]).
   + abstract (intro u; apply (nat_trans_eq hsC); simpl; intro a;
               now apply (colimArrowCommutes (HCg a))).
 - abstract (intro t; destruct t as [t1 t2];
@@ -494,9 +494,9 @@ Defined.
 
 Lemma ColimFunctorCocone : ColimCocone D.
 Proof.
-simple refine (mk_ColimCocone _ _ _ _).
+use mk_ColimCocone.
 - exact ColimFunctor.
-- simple refine (mk_cocone _ _).
+- use mk_cocone.
   + now apply colim_nat_trans_in_data.
   + abstract (now intros u v e; apply (nat_trans_eq hsC);
                   intro a; apply (colimInCommutes (HCg a))).

--- a/UniMath/CategoryTheory/limits/graphs/equalizers.v
+++ b/UniMath/CategoryTheory/limits/graphs/equalizers.v
@@ -134,7 +134,7 @@ Section def_equalizers.
   Lemma EqualizerArrowComm {a b : C} {f g : C⟦a, b⟧} (E : Equalizer f g) (e : C) (h : C⟦e, a⟧)
         (H : h · f = h · g) : EqualizerIn E e h H · EqualizerArrow E = h.
   Proof.
-    refine (limArrowCommutes E e _ One).
+    exact (limArrowCommutes E e _ One).
   Qed.
 
   Lemma EqualizerInUnique {a b : C} {f g : C⟦a, b⟧} (E : Equalizer f g) (e : C) (h : C⟦e, a⟧)

--- a/UniMath/CategoryTheory/limits/graphs/initial.v
+++ b/UniMath/CategoryTheory/limits/graphs/initial.v
@@ -31,7 +31,7 @@ Defined.
 
 Definition initCocone (c : C) : cocone initDiagram c.
 Proof.
-simple refine (mk_cocone _ _); intro v; induction v.
+use mk_cocone; intro v; induction v.
 Defined.
 
 Definition isInitial (a : C) :=
@@ -42,7 +42,7 @@ Definition mk_isInitial (a : C) (H : ∏ (b : C), iscontr (a --> b)) :
   isInitial a.
 Proof.
 intros b cb.
-simple refine (tpair _ _ _).
+use tpair.
 - exists (pr1 (H b)); intro v; induction v.
 - intro t.
   apply subtypeEquality; simpl;
@@ -55,11 +55,11 @@ Definition Initial : UU := ColimCocone initDiagram.
 
 Definition mk_Initial (a : C) (H : isInitial a) : Initial.
 Proof.
-refine (mk_ColimCocone _ a (initCocone a) _).
+use (mk_ColimCocone _ a (initCocone a)).
 apply mk_isInitial.
 intro b.
 set (x := H b (initCocone b)).
-simple refine (tpair _ _ _).
+use tpair.
 - apply (pr1 x).
 - simpl; intro f; apply path_to_ctr; intro v; induction v.
 Defined.

--- a/UniMath/CategoryTheory/limits/graphs/limits.v
+++ b/UniMath/CategoryTheory/limits/graphs/limits.v
@@ -136,7 +136,7 @@ Definition limOfArrows {g : graph} {d1 d2 : diagram g C}
   (fNat : ∏ u v (e : edge u v), f u · dmor d2 e = dmor d1 e · f v) :
   C⟦lim CC1 , lim CC2⟧.
 Proof.
-apply limArrow; simple refine (mk_cone _ _).
+apply limArrow; use mk_cone.
 - now intro u; apply (limOut CC1 u · f u).
 - abstract (intros u v e; simpl;
             now rewrite <- assoc, fNat, assoc, limOutCommutes).
@@ -190,12 +190,12 @@ Lemma lim_endo_is_identity {g : graph} (D : diagram g C)
   (H : ∏ u, k · limOut CC u = limOut CC u) :
   identity _ = k.
 Proof.
-unshelve refine (uniqueExists _ _ (limUnivProp CC _ _) _ _ _ _).
+use (uniqueExists _ _ (limUnivProp CC _ _)).
 - now apply (limCone CC).
 - intros v; simpl.
   unfold compose. simpl.
   now apply id_left.
-- now apply H.
+- simpl; now apply H.
 Qed.
 
 
@@ -235,8 +235,8 @@ Proof.
 intro H.
 set (iinv := z_iso_inv_from_is_z_iso _ (is_z_iso_from_is_iso _ H)).
 intros x cx.
-simple refine (tpair _ _ _).
-- simple refine (tpair _ _ _).
+use tpair.
+- use tpair.
   + exact (limArrow CC x cx·iinv).
   + simpl; intro u.
     assert (XR:=limArrowCommutes CC x cx u).
@@ -373,7 +373,7 @@ Definition LimFunctor_ob (a : A) : C := lim (HCg a).
 Definition LimFunctor_mor (a a' : A) (f : A⟦a, a'⟧) :
   C⟦LimFunctor_ob a,LimFunctor_ob a'⟧.
 Proof.
-simple refine (limOfArrows _ _ _ _).
+use limOfArrows.
 - now intro u; apply (# (pr1 (dob D u)) f).
 - abstract (now intros u v e; simpl; apply (nat_trans_ax (# D e))).
 Defined.
@@ -409,7 +409,7 @@ Defined.
 Definition cone_pointwise (F : [A,C,hsC]) (cc : cone D F) a :
   cone (diagram_pointwise _ D a) (pr1 F a).
 Proof.
-simple refine (mk_cone _ _).
+use mk_cone.
 - now intro v; apply (pr1 (coneOut cc v) a).
 - abstract (intros u v e;
     now apply (nat_trans_eq_pointwise (coneOutCommutes cc u v e))).
@@ -427,7 +427,7 @@ use tpair.
     | apply pathsinv0; eapply pathscomp0;
       [ apply postCompWithLimArrow
       | apply limArrowUnique; intro u; eapply pathscomp0;
-      [ now apply limArrowCommutes | now refine (nat_trans_ax _ _ _ _)]]]).
+      [ now apply limArrowCommutes | now use nat_trans_ax]]]).
   + abstract (intro u; apply (nat_trans_eq hsC); simpl; intro a;
               now apply (limArrowCommutes (HCg a))).
 - abstract (intro t; destruct t as [t1 t2];
@@ -440,9 +440,9 @@ Defined.
 
 Lemma LimFunctorCone : LimCone D.
 Proof.
-simple refine (mk_LimCone _ _ _ _).
+use mk_LimCone.
 - exact LimFunctor.
-- simple refine (mk_cone _ _).
+- use mk_cone.
   + now apply lim_nat_trans_in_data.
   + abstract (now intros u v e; apply (nat_trans_eq hsC);
                   intro a; apply (limOutCommutes (HCg a))).
@@ -595,7 +595,7 @@ Definition LimCone {g : graph} (d : diagram g C^op) : UU :=
 Definition mk_LimCone {g : graph} (d : diagram g C^op)
   (c : C) (cc : cone d c) (isCC : isLimCone d c cc) : LimCone d.
 Proof.
-simple refine (mk_ColimCocone _ _ _ _  ).
+use mk_ColimCocone.
 - apply c.
 - apply cc.
 - apply isCC.
@@ -736,12 +736,12 @@ Lemma lim_endo_is_identity {g : graph} (D : diagram g C^op)
   (H : ∏ u, k · limOut CC u = limOut CC u) :
   identity _ = k.
 Proof.
-unshelve refine (uniqueExists _ _ (limUnivProp CC _ _) _ _ _ _).
+use (uniqueExists _ _ (limUnivProp CC _ _)).
 - now apply (limCone CC).
 - intros v; simpl.
   unfold compose. simpl.
   now apply id_left.
-- now apply H.
+- simpl; now apply H.
 Qed.
 
 (*
@@ -834,8 +834,8 @@ Proof.
 intro H.
 set (iinv := z_iso_inv_from_is_z_iso _ (is_z_iso_from_is_iso _ H)).
 intros x cx.
-simple refine (tpair _ _ _).
-- simple refine (tpair _ _ _).
+use tpair.
+- use tpair.
   + exact (limArrow CC x cx·iinv).
   + simpl; intro u.
     assert (XR:=limArrowCommutes CC x cx u).
@@ -869,7 +869,7 @@ Definition get_diagram (A C : precategory) (hsC : has_homsets C)
 Proof.
 apply (tpair _ (λ u, from_opp_to_opp_opp _ _ _ (pr1 D u))).
 intros u v e; simpl.
-simple refine (tpair _ _ _); simpl.
+use tpair; simpl.
   + apply (pr2 D _ _ e).
   + abstract (intros a b f; apply pathsinv0, (pr2 (pr2 D u v e) b a f)).
 Defined.
@@ -880,7 +880,7 @@ Definition get_cocone  (A C : precategory) (hsC : has_homsets C)
 Proof.
 destruct ccF as [t p]. (* If I remove this destruct the Qed for LimsFunctorCategory
                  takes twice as long *)
-simple refine (mk_cocone _ _).
+use mk_cocone.
 - intro u; apply (tpair _ (pr1 (t u))).
   abstract (intros a b f; apply pathsinv0, (pr2 (t u) b a f)).
 - abstract (intros u v e; apply (nat_trans_eq (has_homsets_opp hsC));
@@ -901,9 +901,9 @@ destruct pr1x as [pr1pr1x pr2pr1x].
 destruct pr2pr1x as [pr1pr2pr1x pr2pr2pr1x].
 simpl in *.
 use (mk_ColimCocone _ (from_opp_opp_to_opp _ _ _ pr1pr1x)).
-- simple refine (mk_cocone _ _).
+- use mk_cocone.
   + simpl; intros.
-    simple refine (tpair _ _ _).
+    use tpair.
     * intro a; apply (pr1pr2pr1x v a).
     * abstract (intros a b f; apply pathsinv0, (nat_trans_ax (pr1pr2pr1x v) (*b a f*))).
   + abstract (intros u v e; apply (nat_trans_eq hsC); simpl; intro a;
@@ -913,8 +913,8 @@ use (mk_ColimCocone _ (from_opp_opp_to_opp _ _ _ pr1pr1x)).
   destruct H as [H1 H2].
   destruct H1 as [α Hα].
   simpl in *.
-  simple refine (tpair _ _ _).
-  + simple refine (tpair _ _ _).
+  use tpair.
+  + use tpair.
     * exists α.
       abstract (intros a b f; simpl; now apply pathsinv0, (nat_trans_ax α b a f)).
     * abstract (intro u; apply (nat_trans_eq hsC); intro a;
@@ -931,7 +931,7 @@ use (mk_ColimCocone _ (from_opp_opp_to_opp _ _ _ pr1pr1x)).
                                coconeIn (get_cocone A C hsC g D F ccF) v :=
                   _ in _).
       *)
-      { simple refine (tpair _ (tpair _ (pr1 f) _) _); simpl.
+      { use (tpair _ (tpair _ (pr1 f) _)); simpl.
         - abstract (intros x y fxy; apply pathsinv0, (pr2 f y x fxy)).
         - abstract (intro u; apply (nat_trans_eq (has_homsets_opp hsC)); intro x;
             destruct ccF as [t p]; apply (toforallpaths _ _ _ (maponpaths pr1 (Hf u)) x)).

--- a/UniMath/CategoryTheory/limits/graphs/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/graphs/pullbacks.v
@@ -89,7 +89,7 @@ Definition mk_isPullback {a b c d : C} (f : C ⟦b, a⟧) (g : C ⟦c, a⟧)
 Proof.
   intros H' x cx; simpl in *.
   set (H1 := H' x (coneOut cx One) (coneOut cx Three) ).
-  simple refine (let p : coneOut cx One · f = coneOut cx Three · g := _ in _ ).
+  use (let p : coneOut cx One · f = coneOut cx Three · g := _ in _ ).
   { eapply pathscomp0; [apply (coneOutCommutes cx One Two tt)|].
     apply pathsinv0, (coneOutCommutes cx Three Two tt). }
   set (H2 := H1 p).
@@ -180,14 +180,14 @@ Lemma PullbackArrow_PullbackPr1 {a b c : C} {f : C⟦b, a⟧} {g : C⟦c, a⟧}
    (Pb : Pullback f g) e (h : C⟦e, b⟧) (k : C⟦e, c⟧)(H : h · f = k · g) :
    PullbackArrow Pb e h k H · PullbackPr1 Pb = h.
 Proof.
-  refine (limArrowCommutes Pb e _ One).
+  exact (limArrowCommutes Pb e _ One).
 Qed.
 
 Lemma PullbackArrow_PullbackPr2 {a b c : C} {f : C⟦b, a⟧} {g : C⟦c, a⟧}
    (Pb : Pullback f g) e (h : C⟦e, b⟧) (k : C⟦e, c⟧)(H : h · f = k · g) :
    PullbackArrow Pb e h k H · PullbackPr2 Pb = k.
 Proof.
-  refine (limArrowCommutes Pb e _ Three).
+  exact (limArrowCommutes Pb e _ Three).
 Qed.
 
 Lemma PullbackArrowUnique {a b c d : C} (f : C⟦b, a⟧) (g : C⟦c, a⟧)
@@ -226,7 +226,7 @@ Proof.
     apply subtypeEquality.
     + intro. apply isapropdirprod; apply hs.
     + destruct t as [t p]. simpl.
-      refine (PullbackArrowUnique _ _ P _ _ _ _ _ _ _ ).
+      use(PullbackArrowUnique _ _ P).
       * apply e.
       * apply (pr1 p).
       * apply (pr2 p).

--- a/UniMath/CategoryTheory/limits/graphs/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/graphs/pullbacks.v
@@ -226,7 +226,7 @@ Proof.
     apply subtypeEquality.
     + intro. apply isapropdirprod; apply hs.
     + destruct t as [t p]. simpl.
-      use(PullbackArrowUnique _ _ P).
+      use (PullbackArrowUnique _ _ P).
       * apply e.
       * apply (pr1 p).
       * apply (pr2 p).

--- a/UniMath/CategoryTheory/limits/graphs/pushouts.v
+++ b/UniMath/CategoryTheory/limits/graphs/pushouts.v
@@ -86,7 +86,7 @@ Section def_po.
   Proof.
     intros H' x cx; simpl in *.
     set (H1 := H' x (coconeIn cx Two) (coconeIn cx Three)).
-    simple refine (let p : f · coconeIn cx Two = g · coconeIn cx Three
+    use (let p : f · coconeIn cx Two = g · coconeIn cx Three
                        := _ in _ ).
     { eapply pathscomp0; [apply (coconeInCommutes cx One Two tt)|].
       apply pathsinv0, (coconeInCommutes cx One Three tt). }
@@ -150,14 +150,14 @@ Section def_po.
         (e : C) (h : C⟦b , e⟧) (k : C⟦c, e⟧) (H : f · h = g · k) :
     PushoutIn1 Po · PushoutArrow Po e h k H = h.
   Proof.
-    refine (colimArrowCommutes Po e _ Two).
+    exact (colimArrowCommutes Po e _ Two).
   Qed.
 
   Lemma PushoutArrow_PushoutIn2 {a b c : C} {f : C⟦a, b⟧} {g : C⟦a, c⟧} (Po : Pushout f g)
         (e : C) (h : C⟦b, e⟧) (k : C⟦c, e⟧) (H : f · h = g · k) :
     PushoutIn2 Po · PushoutArrow Po e h k H = k.
   Proof.
-    refine (colimArrowCommutes Po e _ Three).
+    exact (colimArrowCommutes Po e _ Three).
   Qed.
 
   Lemma PushoutArrowUnique {a b c d : C} (f : C⟦a, b⟧) (g : C⟦a, c⟧) (Po : Pushout f g) (e : C)
@@ -187,7 +187,7 @@ Section def_po.
       apply subtypeEquality.
       + intro. apply isapropdirprod; apply hs.
       + destruct t as [t p]. simpl.
-        refine (PushoutArrowUnique _ _ P _ _ _ _ _ _ _ ).
+        use (PushoutArrowUnique _ _ P).
         * apply e.
         * apply (pr1 p).
         * apply (pr2 p).

--- a/UniMath/CategoryTheory/limits/graphs/terminal.v
+++ b/UniMath/CategoryTheory/limits/graphs/terminal.v
@@ -33,7 +33,7 @@ Defined.
 
 Definition termCone (c : C) : cone termDiagram c.
 Proof.
-simple refine (mk_cone _ _); intro v; induction v.
+use mk_cone; intro v; induction v.
 Defined.
 
 Definition isTerminal (a : C) :=
@@ -43,7 +43,7 @@ Definition mk_isTerminal (b : C) (H : ∏ (a : C), iscontr (a --> b)) :
   isTerminal b.
 Proof.
 intros a ca.
-simple refine (tpair _ _ _).
+use tpair.
 - exists (pr1 (H a)); intro v; induction v.
 - intro t.
   apply subtypeEquality; simpl;
@@ -56,11 +56,11 @@ Definition Terminal : UU := LimCone termDiagram.
 
 Definition mk_Terminal (b : C) (H : isTerminal b) : Terminal.
 Proof.
-refine (mk_LimCone _ b (termCone b) _).
+use (mk_LimCone _ b (termCone b)).
 apply mk_isTerminal.
 intro a.
 set (x := H a (termCone a)).
-simple refine (tpair _ _ _).
+use tpair.
 - apply (pr1 x).
 - simpl; intro f; apply path_to_ctr; intro v; induction v.
 Defined.

--- a/UniMath/CategoryTheory/limits/graphs/zero.v
+++ b/UniMath/CategoryTheory/limits/graphs/zero.v
@@ -159,11 +159,11 @@ Section def_zero.
              (I : Initial C) (T : Terminal C)
              (e: iso (InitialObject I) (TerminalObject T)) : Zero.
   Proof.
-    refine (mk_Zero (InitialObject I) _).
+    use (mk_Zero (InitialObject I)).
     split.
-    - refine (mk_isInitial (InitialObject I) _); intro b.
+    - use (mk_isInitial (InitialObject I)); intro b.
       apply iscontrpair with (x := (InitialArrow I b)), InitialArrowUnique.
-    - refine (mk_isTerminal (InitialObject I) _ ); intro a.
+    - use (mk_isTerminal (InitialObject I)); intro a.
       apply (iscontrretract (postcomp_with (inv_from_iso e))
                             (postcomp_with (morphism_from_iso _ _ _  e))).
       intros y. unfold postcomp_with.

--- a/UniMath/CategoryTheory/limits/initial.v
+++ b/UniMath/CategoryTheory/limits/initial.v
@@ -111,8 +111,8 @@ Section Initial_and_EmptyCoprod.
     CoproductCocone empty C fromempty -> Initial C.
   Proof.
     intros X.
-    refine (mk_Initial (CoproductObject _ _ X) _).
-    refine (mk_isInitial _ _).
+    use (mk_Initial (CoproductObject _ _ X)).
+    use mk_isInitial.
     intros b.
     assert (H : ∏ i : empty, C⟦fromempty i, b⟧) by
         (intros i; apply (fromempty i)).

--- a/UniMath/CategoryTheory/limits/products.v
+++ b/UniMath/CategoryTheory/limits/products.v
@@ -87,7 +87,7 @@ Definition mk_ProductCone (a : ∏ i, C) :
   ∏ (c : C) (f : ∏ i, C⟦c,a i⟧), isProductCone _ _ f -> ProductCone a.
 Proof.
   intros c f X.
-  simple refine (tpair _ (c,,f) X).
+  exact (tpair _ (c,,f) X).
 Defined.
 
 Definition mk_isProductCone (hsC : has_homsets C) (a : I -> C) (p : C)
@@ -312,10 +312,10 @@ End vertex.
 Definition functor_precat_product_cone
   : ProductCone I [C, D, hsD] F.
 Proof.
-simple refine (mk_ProductCone _ _ _ _ _ _).
+use mk_ProductCone.
 - apply product_of_functors.
 - apply product_nat_trans_pr.
-- simple refine (mk_isProductCone _ _ _ _ _ _ _).
+- use mk_isProductCone.
   + apply functor_category_has_homsets.
   + intros A f.
     use tpair.

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -183,7 +183,7 @@ Proof.
   { rewrite <- assoc , H, assoc; apply idpath. }
   set (Pb := mk_Pullback _ _ _ _ _ _ P).
   set (Xw := PullbackArrow Pb e (w·p1) (w·p2) Hw).
-  pathvia Xw; [ apply PullbackArrowUnique; apply idpath |].
+  intermediate_path Xw; [ apply PullbackArrowUnique; apply idpath |].
   apply pathsinv0.
   apply PullbackArrowUnique. apply pathsinv0. apply H1.
   apply pathsinv0. apply H2.
@@ -621,7 +621,7 @@ Proof.
       ];
       apply (MorphismsIntoPullbackEqual Hinnerpb);
       [rewrite <- assoc;
-        match goal with |[ |- ?KK · ( _ · _ ) = _ ] => pathvia (KK · (h' · i)) end;
+        match goal with |[ |- ?KK · ( _ · _ ) = _ ] => intermediate_path (KK · (h' · i)) end;
         [ apply maponpaths; apply (!Hleft) |
           rewrite assoc;
           assert (T:= PullbackArrow_PullbackPr1 (mk_Pullback (i · f) g d' h' (i' · k) _ Houterpb));
@@ -682,7 +682,7 @@ Proof.
         {
         match goal with
           |[ |- ?AA · _ · _ = _ ] =>
-           pathvia (AA · h · inv_from_iso (isopair i xi)) end.
+           intermediate_path (AA · h · inv_from_iso (isopair i xi)) end.
         - repeat rewrite <- assoc. apply maponpaths.
           apply iso_inv_on_right.
           rewrite assoc.
@@ -697,7 +697,7 @@ Proof.
         repeat rewrite assoc.
         {
         match goal with |[|- ?AA · _ · _ · ?K = _ ]
-                         => pathvia (AA ·  K) end.
+                         => intermediate_path (AA ·  K) end.
         - apply cancel_postcomposition.
           repeat rewrite <- assoc.
           rewrite iso_after_iso_inv.

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -130,8 +130,8 @@ Definition mk_Pullback {a b c : C} (f : C⟦b, a⟧)(g : C⟦c, a⟧)
     (ispb : isPullback f g p1 p2 H)
   : Pullback f g.
 Proof.
-  simple refine (tpair _ _ _ ).
-  - simple refine (tpair _ _ _ ).
+  use tpair.
+  - use tpair.
     + apply d.
     + exists p1.
       exact p2.
@@ -507,12 +507,12 @@ Lemma is_symmetric_isPullback
   : isPullback _ _ _ _ H -> isPullback _ _ _ _ (!H).
 Proof.
   intro isPb.
-  simple refine (mk_isPullback _ _ _ _ _ _ ).
+  use mk_isPullback.
   intros e x y Hxy.
   set (Pb := mk_Pullback _ _ _ _ _ _ isPb).
-  simple refine (tpair _ _ _ ).
-  - simple refine (tpair _ _ _ ).
-    + simple refine (PullbackArrow Pb _ _ _ _ ).
+  use tpair.
+  - use tpair.
+    + use (PullbackArrow Pb).
       * assumption.
       * assumption.
       * apply (!Hxy).
@@ -535,9 +535,9 @@ Definition pb_of_section (isPb : isPullback _ _ _ _ H)
   (s : C⟦a,c⟧) (K : s · g = identity _ )
   : ∑ s' : C⟦b, d⟧, s' · h = identity _ .
 Proof.
-  simple refine (tpair _ _ _ ).
-  - simple refine (PullbackArrow (mk_Pullback _ _ _ _ _ _ isPb) b (identity _ )
-                  (f · s) _ ).
+  use tpair.
+  - use (PullbackArrow (mk_Pullback _ _ _ _ _ _ isPb) b (identity _ )
+                  (f · s)).
     abstract (rewrite id_left, <- assoc, K, id_right; apply idpath).
   - abstract (cbn; apply (PullbackArrow_PullbackPr1 (mk_Pullback f g d h k H isPb))).
 Defined.
@@ -551,7 +551,7 @@ Definition section_from_diagonal (isPb : isPullback _ _ _ _ H)
 Proof.
   intro X.
   use tpair.
-  - simple refine (PullbackArrow (mk_Pullback _ _ _ _ _ _ isPb) _ (identity _ ) (pr1 X) _ ).
+  - use (PullbackArrow (mk_Pullback _ _ _ _ _ _ isPb) _ (identity _ ) (pr1 X)).
     abstract (rewrite id_left ;  apply (! (pr2 X))).
   - cbn. apply (PullbackArrow_PullbackPr1 (mk_Pullback f g d h k H isPb) ).
 Defined.
@@ -666,12 +666,12 @@ Lemma isPullback_iso_of_morphisms (b' d' : C) (h' : C⟦d', b'⟧)
      isPullback _ _ _ _ H'.
 Proof.
   intro isPb.
-  simple refine (mk_isPullback _ _ _ _ _ _ ).
+  use mk_isPullback.
   intros e x y Hxy.
   set (Pb:= mk_Pullback _ _ _ _ _ _ isPb).
-  simple refine (tpair _ _ _ ).
-  - simple refine (tpair _ _ _ ).
-    + simple refine ( PullbackArrow Pb _ _  _ _ · _ ).
+  use tpair.
+  - use tpair.
+    + use ( PullbackArrow Pb _ _  _ _ · _ ).
       * apply (x · i).
       * apply y.
       * abstract (rewrite <- assoc; apply Hxy).
@@ -746,7 +746,7 @@ Variable X : isPullback _ _ _ _ functor_on_square.
 
 Lemma isPullback_preimage_square : isPullback _ _ _ _ H.
 Proof.
-  refine (mk_isPullback _ _ _ _ _ _ ).
+  use mk_isPullback.
   intros e x y Hxy.
   set (T := maponpaths (#F) Hxy).
   set (T' := !functor_comp _ _ _
@@ -758,12 +758,12 @@ Proof.
   set (FxFy := pr1 (pr1 TH)).
   set (HFxFy := pr2 (pr1 TH)). simpl in HFxFy.
   set (xy := fully_faithful_inv_hom Fff _ _ FxFy).
-  simple refine (tpair _ _ _ ).
+  use tpair.
   - exists xy.
     set (t := pr1 HFxFy).
     set (p := pr2 HFxFy).
     split.
-    + refine ( invmaponpathsweq (weqpair _ (Fff _ _ )) _ _ _ ).
+    + use (invmaponpathsweq (weqpair _ (Fff _ _ ))).
       simpl.
       rewrite functor_comp.
       assert (XX:=homotweqinvweq (weqpair _ (Fff e d ))). simpl in XX.
@@ -773,7 +773,7 @@ Proof.
       eapply cancel_postcomposition.
       assert (XXX := XX FxFy).
       apply XX. exact t.
-    + refine ( invmaponpathsweq (weqpair _ (Fff _ _ )) _ _ _ ).
+    + use (invmaponpathsweq (weqpair _ (Fff _ _ ))).
       simpl.
       rewrite functor_comp.
       assert (XX:=homotweqinvweq (weqpair _ (Fff e d ))). simpl in XX.
@@ -788,7 +788,7 @@ Proof.
     apply subtypeEquality.
     + intro kkkk. apply isapropdirprod; apply hsC.
     + simpl.
-      refine ( invmaponpathsweq (weqpair _ (Fff _ _ )) _ _ _ ).
+      use (invmaponpathsweq (weqpair _ (Fff _ _ ))).
       simpl.
       unfold xy.
       assert (XX:=homotweqinvweq (weqpair _ (Fff e d ))). simpl in XX.
@@ -849,7 +849,7 @@ Proof.
   set (umorPr1 := PullbackArrow_PullbackPr1 Pb _ _ _ XX).
   set (umorPr2 := PullbackArrow_PullbackPr2 Pb _ _ _ XX).
   cbn in *.
-  simple refine (tpair _ _ _ ).
+  use tpair.
   - exists (inv_from_iso i · #F umor ).
     split.
     + rewrite <- assoc. apply iso_inv_on_right.

--- a/UniMath/CategoryTheory/limits/pushouts.v
+++ b/UniMath/CategoryTheory/limits/pushouts.v
@@ -111,8 +111,8 @@ Section def_po.
              (ispb : isPushout f g in1 in2 H)
     : Pushout f g.
   Proof.
-    simple refine (tpair _ _ _ ).
-    - simple refine (tpair _ _ _ ).
+    use tpair.
+    - use tpair.
       + apply d.
       + exists in1.
         exact in2.

--- a/UniMath/CategoryTheory/limits/pushouts.v
+++ b/UniMath/CategoryTheory/limits/pushouts.v
@@ -146,7 +146,7 @@ Section def_po.
     set (Pb := mk_Pushout _ _ _ _ _ _ P).
     rewrite <- assoc in Hw. rewrite <- assoc in Hw.
     set (Xw := PushoutArrow Pb e (in1 · w) (in2 · w) Hw).
-    pathvia Xw; [ apply PushoutArrowUnique; apply idpath |].
+    intermediate_path Xw; [ apply PushoutArrowUnique; apply idpath |].
     apply pathsinv0.
     apply PushoutArrowUnique. apply pathsinv0. apply H1.
     apply pathsinv0. apply H2.

--- a/UniMath/CategoryTheory/limits/terminal.v
+++ b/UniMath/CategoryTheory/limits/terminal.v
@@ -114,8 +114,8 @@ Section Terminal_and_EmptyProd.
     ProductCone empty C fromempty -> Terminal C.
   Proof.
     intros X.
-    refine (mk_Terminal (ProductObject _ C X) _).
-    refine (mk_isTerminal _ _).
+    use (mk_Terminal (ProductObject _ C X)).
+    use mk_isTerminal.
     intros a.
     assert (H : ∏ i : empty, C⟦a, fromempty i⟧) by
         (intros i; apply (fromempty i)).

--- a/UniMath/CategoryTheory/opp_precat.v
+++ b/UniMath/CategoryTheory/opp_precat.v
@@ -172,7 +172,7 @@ Proof.
   intros HF d.
   set (TH := HF d).
   set (X:=@hinhuniv  (∑ a : C, iso (F a) d)).
-  refine (X _ _ TH).
+  use (X _ _ TH).
   intro H. clear TH. clear X.
   apply hinhpr.
   destruct H as [a X].
@@ -199,7 +199,7 @@ Definition from_opp_to_opp_opp (A C : precategory) (hsC : has_homsets C) :
 Proof.
 apply (tpair _ functor_opp).
 simpl; intros F G α.
-simple refine (tpair _ _ _).
+use tpair.
 + simpl; intro a; apply α.
 + abstract (intros a b f; simpl in *;
             apply pathsinv0, (nat_trans_ax α)).
@@ -220,9 +220,9 @@ Definition functor_from_opp_to_opp_opp (A C : precategory) (hsC : has_homsets C)
 Definition from_opp_opp_to_opp (A C : precategory) (hsC : has_homsets C) :
   functor_data [A^op, C^op, has_homsets_opp hsC] [A, C, hsC]^op.
 Proof.
-simple refine (tpair _ _ _); simpl.
+use tpair; simpl.
 - intro F.
-  simple refine (tpair _ _ _).
+  use tpair.
   + exists F.
     apply (λ a b f, # F f).
   + abstract (split; [ intro a; apply (functor_id F)

--- a/UniMath/CategoryTheory/precomp_ess_surj.v
+++ b/UniMath/CategoryTheory/precomp_ess_surj.v
@@ -30,8 +30,6 @@ Require Import UniMath.CategoryTheory.whiskering.
 
 Local Open Scope cat.
 
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
-
 Local Notation "FF ^-1" := (fully_faithful_inv_hom FF _ _ ) (at level 20).
 Local Notation "F '^-i'" := (iso_from_fully_faithful_reflection F) (at level 20).
 Local Notation "G 'O' F" := (functor_compose _ _ _ F G) (at level 25).
@@ -156,7 +154,7 @@ Proof.
     apply id_right.
   assert (quack := qhelp feedtoqhelp).
   simpl in *.
-  pathvia (iso_comp  (functor_on_iso F
+  intermediate_path (iso_comp  (functor_on_iso F
        (fH^-i (iso_comp h (iso_inv_from_iso hnot)))) (idtoiso w) ).
   generalize w; intro w0.
   induction w0.
@@ -308,7 +306,7 @@ Proof.
     unfold l0.
     inv_functor fH a0 a0'.
     unfold hfh.
-    pathvia (h0 · f · (inv_from_iso h0' · h0') · inv_from_iso h').
+    intermediate_path (h0 · f · (inv_from_iso h0' · h0') · inv_from_iso h').
       repeat rewrite assoc; apply idpath.
     rewrite iso_after_iso_inv, id_right, functor_comp.
     inv_functor fH a0 a.
@@ -474,7 +472,7 @@ Proof.
     inv_functor fH a0' a0''.
     unfold l0.
     inv_functor fH a0 a0'.
-    pathvia (h0 · f · (inv_from_iso h0' · h0') · f' · inv_from_iso h0'').
+    intermediate_path (h0 · f · (inv_from_iso h0' · h0') · f' · inv_from_iso h0'').
       repeat rewrite assoc; apply idpath.
     rewrite iso_after_iso_inv, id_right.
     unfold l0''.
@@ -514,7 +512,7 @@ Proof.
       inv_functor fH a0' a'.
       unfold l0.
       inv_functor fH a0 a0'.
-      pathvia (h0 · f · (inv_from_iso h0' · h0') · inv_from_iso h').
+      intermediate_path (h0 · f · (inv_from_iso h0' · h0') · inv_from_iso h').
         repeat rewrite assoc; apply idpath.
       rewrite iso_after_iso_inv, id_right, functor_comp.
       inv_functor fH a0 a.
@@ -603,7 +601,7 @@ Proof.
       inv_functor fH a0'' a''.
       unfold l0'.
       inv_functor fH a0' a0''.
-      pathvia (h0' · f' · (inv_from_iso h0'' · h0'') · inv_from_iso h'').
+      intermediate_path (h0' · f' · (inv_from_iso h0'' · h0'') · inv_from_iso h'').
         repeat rewrite assoc; apply idpath.
       rewrite iso_after_iso_inv, id_right, functor_comp.
       inv_functor fH a0' a'.
@@ -679,7 +677,7 @@ Proof.
       inv_functor fH a0'' a''.
       unfold l0''.
       inv_functor fH a0 a0''.
-      pathvia (h0 · (f · f') · (inv_from_iso h0'' · h0'') · inv_from_iso h'').
+      intermediate_path (h0 · (f · f') · (inv_from_iso h0'' · h0'') · inv_from_iso h'').
         repeat rewrite assoc; apply idpath.
       rewrite iso_after_iso_inv, id_right, functor_comp.
       inv_functor fH a0 a.
@@ -723,7 +721,7 @@ Proof.
     apply idpath.
   clear PR2.
   rewrite HGf, HGf'.
-  pathvia (inv_from_iso (k b a0 h0)· #F l0· (k b' a0' h0'·
+  intermediate_path (inv_from_iso (k b a0 h0)· #F l0· (k b' a0' h0'·
               inv_from_iso (k b' a0' h0'))· #F l0'· k b'' a0'' h0'').
     rewrite iso_inv_after_iso, id_right.
     rewrite HGff'.
@@ -830,7 +828,7 @@ Proof.
       inv_functor fH a a0.
       inv_functor fH a' a0'.
       apply pathsinv0, alpha.
-    pathvia (#F (fH^-1 h· f)).
+    intermediate_path (#F (fH^-1 h· f)).
       rewrite functor_comp.
       apply idpath.
     rewrite HH4.

--- a/UniMath/CategoryTheory/precomp_fully_faithful.v
+++ b/UniMath/CategoryTheory/precomp_fully_faithful.v
@@ -30,7 +30,6 @@ Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.whiskering.
 Local Open Scope cat.
 
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 Ltac simp_rew lem := let H:=fresh in
      assert (H:= lem); simpl in *; rewrite H; clear H.
 Ltac simp_rerew lem := let H:=fresh in
@@ -192,7 +191,7 @@ Proof.
              (iso_comp f (iso_inv_from_iso h))).
     set (GHk := functor_on_iso G
                 (functor_on_iso H k)).
-    pathvia (#F (#H k) · gamma anot · iso_inv_from_iso GHk).
+    intermediate_path (#F (#H k) · gamma anot · iso_inv_from_iso GHk).
       apply (post_comp_with_iso_is_inj _ _ _ GHk (pr2 GHk)).
       rewrite <- assoc.
       change (iso_inv_from_iso GHk · GHk) with (inv_from_iso GHk · GHk).
@@ -275,7 +274,7 @@ Proof.
   repeat rewrite <- assoc.
   simpl in *.
   rewrite <- functor_comp.
-  pathvia (inv_from_iso (functor_on_iso F h)·
+  intermediate_path (inv_from_iso (functor_on_iso F h)·
        (gamma a· #G (h· f · iso_inv_from_iso h' · h')) ).
     repeat rewrite <- assoc.
     simpl. rewrite iso_after_iso_inv, id_right.
@@ -325,7 +324,7 @@ Proof.
   simpl.
   set (tr := pr1 (iscontr_aux_space (H a))).
   change (gamma a) with (pr1 gamma a).
-  pathvia ((#F (identity (H a))· pr1 tr)·
+  intermediate_path ((#F (identity (H a))· pr1 tr)·
        #G (inv_from_iso (identity_iso (H a)))).
   rewrite functor_id.
   rewrite id_left.

--- a/UniMath/CategoryTheory/pullbacks_slice_products_equiv.v
+++ b/UniMath/CategoryTheory/pullbacks_slice_products_equiv.v
@@ -54,7 +54,7 @@ Section pullbacks_slice_products_equiv.
                 [apply (pr1 (pr2 (pr1 (isPull _)))) | apply (pr2 (pr2 (pr1 (isPull _))))]).
     + abstract (now intros q; apply isapropdirprod; apply (has_homsets_slice_precat hsC)).
     + abstract (intros q [H1 H2]; apply (eq_mor_slicecat hsC);
-                refine (maponpaths pr1 ((pr2 (isPull _)) ((pr1 q) ,, (_ ,, _))));
+                use (maponpaths pr1 ((pr2 (isPull _)) ((pr1 q) ,, (_ ,, _))));
                 [apply (maponpaths pr1 H1) | apply (maponpaths pr1 H2)]).
   Defined.
 
@@ -69,7 +69,7 @@ Section pullbacks_slice_products_equiv.
                                   maponpaths pr1 (pr2 (pr2 (pr1 (PisProd (Y ,, j · f) (j ,, idpath _) (k ,, Yeq))))))).
     + abstract (intros x; apply isofhleveldirprod; apply (hsC _ _)).
     + intros t teqs.
-      refine (maponpaths pr1 (maponpaths pr1 (pr2 (PisProd (Y ,, j · f) (j ,, idpath _) (k ,, Yeq))
+      use (maponpaths pr1 (maponpaths pr1 (pr2 (PisProd (Y ,, j · f) (j ,, idpath _) (k ,, Yeq))
                                                   ((t ,, (maponpaths (λ x, x · f) (!(pr1 teqs)) @ !(assoc _ _ _) @ maponpaths (λ x, t · x) (idpath _))) ,, _)))).
       abstract (split; apply eq_mor_slicecat; [exact (pr1 teqs) | exact (pr2 teqs)]).
   Defined.
@@ -164,7 +164,7 @@ Section pullbacks_slice_products_equiv.
   Definition pullback_to_binprod : some_pullback C Z → some_binprod (C / Z).
   Proof.
     intros [A [B [f [g P]]]].
-    refine ((A ,, f) ,, (B ,, g) ,, pullback_to_slice_binprod hsC P).
+    use ((A ,, f) ,, (B ,, g) ,, pullback_to_slice_binprod hsC P).
   Defined.
 
   (** ** binprod_to_pullback is invertible *)

--- a/UniMath/CategoryTheory/rezk_completion.v
+++ b/UniMath/CategoryTheory/rezk_completion.v
@@ -36,8 +36,6 @@ Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.precomp_fully_faithful.
 Require Import UniMath.CategoryTheory.precomp_ess_surj.
 
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
-
 (** * Construction of the Rezk completion via Yoneda *)
 
 Section rezk.
@@ -166,7 +164,7 @@ Definition Rezk_completion_endo_is_identity (D : functor_from A)
 Proof.
   intros X H.
   set (DH' := DH D).
-  pathvia (pr1 (pr1 DH')).
+  intermediate_path (pr1 (pr1 DH')).
   - apply path_to_ctr.
     apply H.
   - apply pathsinv0.

--- a/UniMath/CategoryTheory/slicecat.v
+++ b/UniMath/CategoryTheory/slicecat.v
@@ -159,7 +159,7 @@ Qed.
 Lemma eq_iso_slicecat (af bg : C / x) (f g : iso af bg) : pr1 f = pr1 g -> f = g.
 Proof.
 case g; case f; clear f g; simpl; intros f fP g gP eq.
-refine (subtypePairEquality _ eq).
+use (subtypePairEquality _ eq).
 now intro; apply isaprop_is_iso.
 Qed.
 
@@ -507,7 +507,7 @@ Definition pullback_to_slice_binprod {A B Z : C} {f : A --> Z} {g : B --> Z} :
   Pullback f g -> BinProductCone (C / Z) (A ,, f) (B ,, g).
 Proof.
   intros P.
-  refine (((PullbackObject P ,, (PullbackPr1 P) · f) ,, (((PullbackPr1 P) ,, idpath _) ,, (((PullbackPr2 P) ,, (PullbackSqrCommutes P))))) ,, _).
+  use (((PullbackObject P ,, (PullbackPr1 P) · f) ,, (((PullbackPr1 P) ,, idpath _) ,, (((PullbackPr2 P) ,, (PullbackSqrCommutes P))))) ,, _).
   intros Y [j jeq] [k keq]; simpl in jeq , keq.
   use unique_exists.
   + use tpair.
@@ -530,7 +530,7 @@ Proof.
   induction AZ as [A f].
   induction BZ as [B g].
   intros [[[P h] [[l leq] [r req]]] PisProd].
-  refine ((P ,, l ,, r) ,, (! leq @ req) ,, _).
+  use ((P ,, l ,, r) ,, (! leq @ req) ,, _).
   intros Y j k Yeq. simpl in *.
   use unique_exists.
   + exact (pr1 (pr1 (pr1 (PisProd (Y ,, j · f) (j ,, idpath _) (k ,, Yeq))))).
@@ -538,7 +538,7 @@ Proof.
                                 maponpaths pr1 (pr2 (pr2 (pr1 (PisProd (Y ,, j · f) (j ,, idpath _) (k ,, Yeq))))))).
   + abstract (intros x; apply isofhleveldirprod; apply (hsC _ _)).
   + intros t teqs.
-    refine (maponpaths pr1 (maponpaths pr1 (pr2 (PisProd (Y ,, j · f) (j ,, idpath _) (k ,, Yeq)) ((t ,, (maponpaths (λ x, x · f) (!(pr1 teqs)) @ !(assoc _ _ _) @ maponpaths (λ x, t · x) (!leq))) ,, _)))).
+    use (maponpaths pr1 (maponpaths pr1 (pr2 (PisProd (Y ,, j · f) (j ,, idpath _) (k ,, Yeq)) ((t ,, (maponpaths (λ x, x · f) (!(pr1 teqs)) @ !(assoc _ _ _) @ maponpaths (λ x, t · x) (!leq))) ,, _)))).
     abstract (split; apply eq_mor_slicecat; [exact (pr1 teqs) | exact (pr2 teqs)]).
 Defined.
 

--- a/UniMath/CategoryTheory/sub_precategories.v
+++ b/UniMath/CategoryTheory/sub_precategories.v
@@ -603,7 +603,7 @@ Lemma functor_full_img_essentially_surjective (A B : precategory)
   essentially_surjective (functor_full_img F).
 Proof.
   intro b.
-  refine (pr2 b _ _).
+  use (pr2 b).
   intros [c h] q Hq.
   apply Hq.
   exists c.

--- a/UniMath/CategoryTheory/whiskering.v
+++ b/UniMath/CategoryTheory/whiskering.v
@@ -31,8 +31,6 @@ Require Import UniMath.CategoryTheory.Categories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Local Open Scope cat.
 
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
-
 Definition functor_compose {A B C : precategory} (hsB: has_homsets B)
                            (hsC: has_homsets C) (F : ob [A, B, hsB])
       (G : ob [B , C, hsC]) : ob [A , C, hsC] :=

--- a/UniMath/CategoryTheory/yoneda.v
+++ b/UniMath/CategoryTheory/yoneda.v
@@ -241,7 +241,7 @@ Definition yoneda_iso_target (C : precategory) (hs : has_homsets C)
            (F : [C^op, HSET, has_homsets_HSET])
   : functor C^op HSET.
 Proof.
-  simple refine (@functor_composite _ [C^op, HSET, has_homsets_HSET]^op _ _ _  ).
+  use (@functor_composite _ [C^op, HSET, has_homsets_HSET]^op).
   - apply functor_opp.
     apply yoneda. apply hs.
   - apply (yoneda _ (functor_category_has_homsets _ _ _ ) F).
@@ -312,7 +312,7 @@ Lemma isweq_yoneda_map_1 (C : precategory) (hs: has_homsets C) (c : C)
      (yoneda_map_1 C hs c F).
 Proof.
   set (T:=yoneda_map_2 C hs c F). simpl in T.
-  simple refine (gradth _ _ _ _ ).
+  use gradth.
   - apply T.
   - apply yoneda_map_1_2.
   - apply yoneda_map_2_1.
@@ -361,7 +361,7 @@ Variable c : C.
 Definition yoneda_functor_precomp' : nat_trans (yoneda_objects C hsC c)
       (functor_composite (functor_opp F) (yoneda_objects D hsD (F c))).
 Proof.
-  simple refine (tpair _ _ _ ).
+  use tpair.
   - intros d f ; simpl.
     apply (#F f).
   - abstract (intros d d' f ;
@@ -399,7 +399,7 @@ Definition yoneda_functor_precomp_nat_trans :
       (yoneda C hsC)
       (functor_composite A B).
 Proof.
-  simple refine (tpair _ _ _ ).
+  use tpair.
   - intro c; simpl.
     apply yoneda_functor_precomp.
   - abstract (

--- a/UniMath/CategoryTheory/yoneda.v
+++ b/UniMath/CategoryTheory/yoneda.v
@@ -35,8 +35,6 @@ Require Import UniMath.CategoryTheory.whiskering.
 
 Local Notation "'hom' C" := (precategory_morphisms (C := C)) (at level 2).
 
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
-
 Ltac unf := unfold identity,
                    compose,
                    precategory_morphisms;
@@ -190,7 +188,7 @@ Proof.
   intro a'; simpl.
   apply funextsec; intro f.
   unfold yoneda_map_1.
-  pathvia ((alpha c · #F f) (identity c)).
+  intermediate_path ((alpha c · #F f) (identity c)).
     apply idpath.
   rewrite <- nat_trans_ax.
   unf; apply maponpaths.

--- a/UniMath/Folds/from_precats_to_folds_and_back.v
+++ b/UniMath/Folds/from_precats_to_folds_and_back.v
@@ -78,11 +78,11 @@ Proof.
     exists (identity a).
     apply idpath.
   - intros; unfold id, T; simpl.
-    pathvia (compose f (identity _ )).
+    intermediate_path (compose f (identity _ )).
     + apply maponpaths; assumption.
     + apply id_right.
  - intros; unfold id, T; simpl.
-   pathvia (compose (identity _ ) f).
+   intermediate_path (compose (identity _ ) f).
    +  rewrite X. apply idpath.
    +  apply id_left.
  - intros a b c f g.
@@ -91,7 +91,7 @@ Proof.
    apply idpath.
  - simpl.
    intros a b c f g h k H1 H2.
-   pathvia (compose f g).
+   intermediate_path (compose f g).
    + apply pathsinv0. apply H1.
    + apply H2.
  - simpl. intros a b c d f g h fg gh fg_h f_gh H1 H2 H3 H4.

--- a/UniMath/SubstitutionSystems/GenMendlerIteration.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration.v
@@ -196,7 +196,7 @@ Focus 2.
       apply maponpaths.
       exact h_rec_eq.
     + (* set(φh_alg_mor := tpair _ _ φh_is_alg_mor : pr1 μF_Initial --> ⟨ R X, φ (ψ (R X) (ε X)) ⟩). *)
-       use(let X : AF ⟦ InitialObject μF_Initial, ⟨ R X, φ (ψ (R X) (ε X)) ⟩ ⟧ := _ in _).
+       use (let X : AF ⟦ InitialObject μF_Initial, ⟨ R X, φ (ψ (R X) (ε X)) ⟩ ⟧ := _ in _).
        * apply (tpair _ (φ h)); assumption.
        * apply (maponpaths pr1 (InitialArrowUnique _ _ X0)).
 Qed.

--- a/UniMath/SubstitutionSystems/GenMendlerIteration.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration.v
@@ -39,7 +39,6 @@ Require Import UniMath.CategoryTheory.Adjunctions.
 Arguments functor_composite {_ _ _} _ _ .
 Arguments nat_trans_comp {_ _ _ _ _} _ _ .
 Local Notation "G ∙ F" := (functor_composite F G : [ _ , _ , _ ]) (at level 35).
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
 Local Notation "↓ f" := (mor_from_algebra_mor _ _ _ f) (at level 3, format "↓ f").
 (* in Agda mode \downarrow *)

--- a/UniMath/SubstitutionSystems/GenMendlerIteration.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration.v
@@ -196,14 +196,14 @@ Focus 2.
       apply maponpaths.
       exact h_rec_eq.
     + (* set(φh_alg_mor := tpair _ _ φh_is_alg_mor : pr1 μF_Initial --> ⟨ R X, φ (ψ (R X) (ε X)) ⟩). *)
-       simple refine (let X : AF ⟦ InitialObject μF_Initial, ⟨ R X, φ (ψ (R X) (ε X)) ⟩ ⟧ := _ in _).
+       use(let X : AF ⟦ InitialObject μF_Initial, ⟨ R X, φ (ψ (R X) (ε X)) ⟩ ⟧ := _ in _).
        * apply (tpair _ (φ h)); assumption.
        * apply (maponpaths pr1 (InitialArrowUnique _ _ X0)).
 Qed.
 
 Theorem GenMendlerIteration : iscontr (∑ h : L μF --> X, #L inF · h = ψ μF h).
 Proof.
-  simple refine (tpair _ _ _ ).
+  use tpair.
   - exists preIt.
     exact preIt_ok.
   - exact preIt_uniq.
@@ -246,7 +246,7 @@ Section special_case.
 
   Definition ψ_from_comps : ψ_source ⟹ ψ_target.
   Proof.
-    simple refine (tpair _ _ _ ).
+    use tpair.
     - intro A. simpl. intro f.
       unfold yoneda_objects_ob in *.
       exact (θ A · #G f · ρ).

--- a/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
@@ -37,7 +37,6 @@ Local Open Scope cat.
 Arguments functor_composite {_ _ _} _ _ .
 Arguments nat_trans_comp {_ _ _ _ _} _ _ .
 Local Notation "G ∙ F" := (functor_composite F G : [ _ , _ , _ ]) (at level 35).
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
 Local Notation "↓ f" := (mor_from_algebra_mor _ _ _ f) (at level 3, format "↓ f").
 Local Notation "'chain'" := (diagram nat_graph).

--- a/UniMath/SubstitutionSystems/Lam.v
+++ b/UniMath/SubstitutionSystems/Lam.v
@@ -146,9 +146,9 @@ Defined.
 Definition LamE_algebra_on_Lam : FunctorAlg (Id_H _ _ CC LamE_S) hsEndC.
 Proof.
   exists ((*ob_from_algebra_ob _ _*) `Lam).
-  refine (BinCoproductArrow _ (CPEndC _ _ )  _ _ ) .
+  use (BinCoproductArrow _ (CPEndC _ _ )).
   + exact Lam_Var.
-  + refine (BinCoproductArrow _ (CPEndC _ _ )  _ _ ).
+  + use (BinCoproductArrow _ (CPEndC _ _ )).
     * apply Lam_App_Abs. (* do NOT destruct and reassemble more, use App_Abs directly *)
     * apply Lam_Flatten.
 Defined.
@@ -165,7 +165,7 @@ Defined.
 (** preparations for typedness *)
 Local Definition bla': (ptd_from_alg_functor CC LamE_S LamE_algebra_on_Lam) --> (ptd_from_alg_functor CC _ Lam).
 Proof.
-  simple refine (tpair _ _ _ ).
+  use tpair.
     + apply (nat_trans_id _ ).
     + abstract
         (intro c; rewrite id_right
@@ -175,7 +175,7 @@ Defined.
 
 Local Definition bla'_inv: (ptd_from_alg_functor CC _ Lam) --> (ptd_from_alg_functor CC LamE_S LamE_algebra_on_Lam).
 Proof.
-  simple refine (tpair _ _ _ ).
+  use tpair.
     + apply (nat_trans_id _ ).
     + abstract
         (intro c; rewrite id_right ;
@@ -486,10 +486,10 @@ Definition bracket_for_LamE_algebra_on_Lam_at (Z : Ptd)
   :
     bracket_at C hs CC LamE_S LamE_algebra_on_Lam f.
 Proof.
-  unshelve refine (tpair _ _ _ ).
+  use tpair.
   - exists (fbracket_for_LamE_algebra_on_Lam Z f).
     apply (bracket_property_for_LamE_algebra_on_Lam Z f).
-  - apply bracket_for_LamE_algebra_on_Lam_unique.
+  - simpl; apply bracket_for_LamE_algebra_on_Lam_unique.
 Defined.
 
 Definition bracket_for_LamE_algebra_on_Lam : bracket LamE_algebra_on_Lam.

--- a/UniMath/SubstitutionSystems/LamFromBindingSig.v
+++ b/UniMath/SubstitutionSystems/LamFromBindingSig.v
@@ -183,7 +183,7 @@ rewrite <- assoc.
 eapply pathscomp0; [eapply maponpaths, BinCoproductIn2Commutes|].
 rewrite <- assoc.
 eapply pathscomp0; eapply maponpaths.
-  refine (CoproductInCommutes _ _ _ _ _ _ true).
+  exact (CoproductInCommutes _ _ _ _ _ _ true).
 apply idpath.
 Defined.
 
@@ -214,7 +214,7 @@ eapply pathscomp0.
   eapply maponpaths, BinCoproductIn2Commutes.
 rewrite <- assoc.
 eapply pathscomp0; eapply maponpaths.
-  refine (CoproductInCommutes _ _ _ _ _ _ false).
+  exact (CoproductInCommutes _ _ _ _ _ _ false).
 apply idpath.
 Defined.
 

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -367,7 +367,7 @@ Focus 2.
   + assert (NN :=  nat_trans_ax (pr2 (pr2 XZ)) _ _ (BinCoproductOfArrows C (CC (TerminalObject terminal) c) (CC (TerminalObject terminal) c')
          (identity (TerminalObject terminal)) f)).
     match goal with |[ H1: _ = ?f·?g |- _ = ?h · _ ] =>
-         pathvia (h·(f·g)) end.
+         intermediate_path (h·(f·g)) end.
     * rewrite <- NN.
       clear NN.
       unfold functor_identity.
@@ -408,7 +408,7 @@ Focus 2.
   + assert (NN :=  nat_trans_ax e _ _ (BinCoproductOfArrows C (CC (TerminalObject terminal) c) (CC (TerminalObject terminal) c')
          (identity (TerminalObject terminal)) f)).
     match goal with |[ H1: _ = ?f·?g |- _ = ?h · _ ] =>
-         pathvia (h·(f·g)) end.
+         intermediate_path (h·(f·g)) end.
     * rewrite <- NN.
       clear NN.
       unfold functor_identity.
@@ -525,7 +525,7 @@ Focus 2.
     assert (NN := nat_trans_ax e' _ _ (e (BinCoproductObject C (CC (TerminalObject terminal) c)))).
     simpl in NN. (* is important for success of the trick *)
     match goal with |[ H1: _ = ?f·?g |- ?h · _ = _ ] =>
-         pathvia (h·(f·g)) end.
+         intermediate_path (h·(f·g)) end.
     * apply idpath.
     * simpl. rewrite <- NN.
       clear NN.
@@ -535,7 +535,7 @@ Focus 2.
          (# Z (BinCoproductIn2 C (CC (TerminalObject terminal) c))))).
       simpl in NNN.
       match goal with |[ H1: _ = ?f·?g |- _ = ?h · _] =>
-         pathvia (h·(f·g)) end.
+         intermediate_path (h·(f·g)) end.
       - simpl. rewrite <- NNN.
         clear NNN.
         do 2 rewrite assoc.

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -306,7 +306,7 @@ Proof.
   clear h_eq1'.
 (* match goal right in the beginning in contrast with earlier approach - suggestion by Benedikt *)
   match goal with |[ H1 : _  = ?f |- _ = _   ] =>
-         pathvia f end.
+         intermediate_path f end.
 
   - clear h_eq1'_inst.
     unfold coproduct_nat_trans_data; simpl.
@@ -360,7 +360,7 @@ Proof.
   assert (h_eq2'_inst := nat_trans_eq_pointwise h_eq2' c).
   clear h_eq2'.
   match goal with |[ H1 : _  = ?f |- _ = _   ] =>
-                   pathvia (f) end.
+                   intermediate_path (f) end.
   - clear h_eq2'_inst.
     apply BinCoproductIn2Commutes_right_in_ctx_dir.
     unfold aux_iso_1; simpl.
@@ -524,7 +524,7 @@ Proof.
   exists (λ _, m).
   abstract (
     intros ? ? ? ;
-    pathvia m ;
+    intermediate_path m ;
     [
     apply id_left |
     apply pathsinv0 ;
@@ -656,7 +656,7 @@ Proof.
   set ( rhohat := BinCoproductArrow EndC  (CPEndC _ _ )  β (tau_from_alg T')
                   :  pr1 Ghat T' --> T').
   set (X:= SpecializedGMIt Z _ Ghat rhohat (thetahat Z f)).
-  pathvia (pr1 (pr1 X)).
+  intermediate_path (pr1 (pr1 X)).
   - set (TT:= fusion_law _ _ _ IA _ hsEndC (pr1 InitAlg) T' _ (KanExt Z)).
     set (Psi := ψ_from_comps _ (Id_H) _ hsEndC _ (ℓ (U Z)) (Const_plus_H (U Z)) (ρ_Thm15 Z f)
                              (aux_iso_1 Z · θ'_Thm15 Z · aux_iso_2_inv Z) ).
@@ -667,7 +667,7 @@ Proof.
     set (T4 := T3 Psi').
     set (Φ := (Phi_fusion Z T' β)).
     set (T5 := T4 Φ).
-    pathvia (Φ _ (fbracket InitHSS f)).
+    intermediate_path (Φ _ (fbracket InitHSS f)).
     + apply idpath.
     + eapply pathscomp0. Focus 2. apply T5.
       (* hypothesis of fusion law *)
@@ -725,7 +725,7 @@ Proof.
         assert (H_nat_inst_c := nat_trans_eq_pointwise H_nat_inst c); clear H_nat_inst.
         {
           match goal with |[ H1 : _  = ?f |- _ = _· ?g · ?h  ] =>
-             pathvia (f·g·h) end.
+             intermediate_path (f·g·h) end.
           + clear H_nat_inst_c.
             simpl.
             repeat rewrite <- assoc.

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -145,7 +145,7 @@ Definition aux_iso_1 (Z : Ptd)
            (CPEndEndC (constant_functor [C, C, hs] [C, C, hs] (U Z))
               (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_source H) Z))⟧.
 Proof.
-  simple refine (tpair _ _ _).
+  use tpair.
   - intro X.
     exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (ρ_functor (U Z))
             (nat_trans_id (θ_source H (X⊗Z):functor C C))).
@@ -189,7 +189,7 @@ Local Definition aux_iso_1_inv (Z: Ptd)
               (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_source H) Z)),
       functor_composite Id_H (ℓ (U Z)) ⟧.
 Proof.
-  simple refine (tpair _ _ _).
+  use tpair.
   - intro X.
     exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (λ_functor (U Z))
            (nat_trans_id (θ_source H (X⊗Z):functor C C))).
@@ -244,7 +244,7 @@ Local Definition aux_iso_2_inv (Z : Ptd)
                     (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_target H) Z)),
       functor_composite (ℓ (U Z) )   (Const_plus_H (U Z)) ⟧.
 Proof.
-  simple refine (tpair _ _ _).
+  use tpair.
   - intro X.
     exact (nat_trans_id ((@BinCoproductObject EndC (U Z) (θ_target H (X⊗Z)) (CPEndC _ _) )
              : functor C C)).
@@ -488,14 +488,14 @@ Qed.
 Definition bracket_for_InitAlg : bracket InitAlg.
 Proof.
   intros Z f.
-  unshelve refine (tpair _ _ _ ).
-  - unshelve refine (tpair _ _ _ ).
+  use tpair.
+  - use tpair.
     + exact (bracket_Thm15 Z f).
     + exact (bracket_Thm15_ok_cor Z f).
        (* B: better to prove the whole outside, and apply it here *)
      (* when the first components were not opaque, the following proof
         became extremely slow *)
-  - apply foo'.
+  - simpl; apply foo'.
 Defined.
 
 (* produce some output to keep TRAVIS running *)
@@ -598,7 +598,7 @@ Local Definition iso2' (Z : Ptd) : EndEndC ⟦
              (functor_fix_snd_arg [C, C, hs] Ptd [C, C, hs] (θ_target H) Z)),
   functor_composite (ℓ (U Z)) Ghat ⟧.
 Proof.
-    simple refine (tpair _ _ _).
+    use tpair.
   - intro X.
     exact (nat_trans_id ((@BinCoproductObject EndC _ (θ_target H (X⊗Z)) (CPEndC _ _) )
             : functor C C)).
@@ -624,7 +624,7 @@ Definition Phi_fusion (Z : Ptd) (X : EndC) (b : pr1 InitAlg --> X) :
    ⟹
   functor_composite (functor_opp (ℓ (U Z))) (Yon X) .
 Proof.
-  simple refine (tpair _ _ _ ).
+  use tpair.
   - intro Y.
     intro a.
     exact (a · b).
@@ -868,7 +868,7 @@ Qed.
 
 Lemma isInitial_InitHSS : isInitial (hss_precategory CP H) InitHSS.
 Proof.
-  simple refine (mk_isInitial _ _).
+  use mk_isInitial.
   intro T.
   exists (hss_InitMor T).
   apply hss_InitMor_unique.
@@ -877,7 +877,7 @@ Defined.
 
 Lemma InitialHSS : Initial (hss_precategory CP H).
 Proof.
-  simple refine (mk_Initial InitHSS _).
+  use (mk_Initial InitHSS).
   apply isInitial_InitHSS.
 Defined.
 

--- a/UniMath/SubstitutionSystems/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial_alt.v
@@ -394,7 +394,7 @@ Definition constant_nat_trans (C' D : precategory)
     : [C', D, hsD] ⟦constant_functor C' D d, constant_functor C' D d'⟧.
 Proof.
 exists (λ _, m).
-abstract (intros ? ? ?; pathvia m; [ apply id_left | apply pathsinv0, id_right]).
+abstract (intros ? ? ?; intermediate_path m; [ apply id_left | apply pathsinv0, id_right]).
 Defined.
 
 Definition thetahat_0 (Z : Ptd) (f : Z --> ptd_from_alg InitAlg) :
@@ -497,7 +497,7 @@ match goal with | [|- _ · ?b = _ ] => set (β := b) end.
 set (rhohat := BinCoproductArrow EndC  (CPEndC _ _ )  β (tau_from_alg T')
                 :  pr1 Ghat T' --> T').
 set (X:= SpecializedGMIt Z _ Ghat rhohat (thetahat Z f)).
-pathvia (pr1 (pr1 X)).
+intermediate_path (pr1 (pr1 X)).
 - set (TT := @fusion_law EndC hsEndC InitialEndC Colims_of_shape_nat_graph_EndC
                          Id_H is_omega_cocont_Id_H _ hsEndC (pr1 (InitAlg)) T').
   set (Psi := ψ_from_comps (Id_H) hsEndC _ (ℓ (U Z)) (Const_plus_H (U Z)) (ρ_Thm15 Z f)
@@ -509,7 +509,7 @@ pathvia (pr1 (pr1 X)).
   set (T4 := T3 (isInitial_pre_comp Z) Psi').
   set (Φ := (Phi_fusion Z T' β)).
   set (T5 := T4 Φ).
-  pathvia (Φ _ (fbracket InitHSS f)); trivial.
+  intermediate_path (Φ _ (fbracket InitHSS f)); trivial.
   eapply pathscomp0; [|apply T5]; clear TT T2 T3 T4 T5 X.
   * now apply cancel_postcomposition.
   * (* hypothesis of fusion law *)

--- a/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
@@ -126,7 +126,7 @@ Proof.
     assert (H2 := H' (`T)).
     assert (H3 := nat_trans_eq_pointwise H2 c).
     simpl in *.
-    pathvia (identity _ · pr1 (τ T) c).
+    intermediate_path (identity _ · pr1 (τ T) c).
     + apply cancel_postcomposition. apply H3.
     + apply id_left.
 Qed.
@@ -195,7 +195,7 @@ Lemma Monad_law_2_from_hss:
   ∏ c : C, # (pr1 (`T)) (μ_0 c)· μ_2 c = identity ((pr1 (`T)) c).
 Proof.
   intro c.
-  pathvia (μ_1 c).
+  intermediate_path (μ_1 c).
   - unfold μ_1.
     assert (H':= @fbracket_unique_target_pointwise _ _  _ _ T).
     assert (H1:= H'  _ μ_0_ptd).
@@ -228,7 +228,7 @@ Proof.
       rewrite <- horcomp_id_postwhisker.
       do 2 rewrite assoc.
       simpl in *.
-      pathvia ( # (pr1 (H ( (` T)))) (μ_0 c)· pr1 (θ ((`T) ⊗ (p T))) c ·
+      intermediate_path ( # (pr1 (H ( (` T)))) (μ_0 c)· pr1 (θ ((`T) ⊗ (p T))) c ·
                   pr1 (# H μ_2) c · pr1 (τ T) c).
       * unfold tau_from_alg; cbn.
         do 2 rewrite assoc.
@@ -248,7 +248,7 @@ Proof.
         simpl in *.
         do 2 rewrite <- assoc.
         {
-          pathvia (  # (pr1 (H (` T))) (μ_0 c)·
+          intermediate_path (  # (pr1 (H (` T))) (μ_0 c)·
                        (pr1 (τ T) (pr1 (`T) c)· pr1 (fbracket T (identity (p T))) c)).
           - apply maponpaths.
             rewrite assoc.
@@ -283,7 +283,7 @@ Proof.
   unfold T_squared. simpl.
   assert (H':=Monad_law_2_from_hss c).
   simpl in H'.
-  pathvia (pr1 (η T) c · identity _ ).
+  intermediate_path (pr1 (η T) c · identity _ ).
   - unfold eta_from_alg; simpl.
     repeat rewrite <- assoc.
     apply maponpaths.
@@ -326,7 +326,7 @@ Proof.
     rewrite assoc.
     simpl; rewrite <- H2 ; clear H2.
     (* rewrite <- assoc. *)
-    pathvia (μ_2 c · identity _ ).
+    intermediate_path (μ_2 c · identity _ ).
     + apply pathsinv0, id_right.
     + eapply pathscomp0. Focus 2.  apply assoc.
       apply pathsinv0.
@@ -336,7 +336,7 @@ Proof.
     simpl in H1.
     repeat rewrite assoc.
     match goal with |[H1 : ?g = _ |- _ · _ · ?f · ?h = _ ] =>
-         pathvia (g · f · h) end.
+         intermediate_path (g · f · h) end.
     + apply cancel_postcomposition.
       apply cancel_postcomposition.
       apply pathsinv0.
@@ -354,7 +354,7 @@ Proof.
       assert (H3:= nat_trans_eq_pointwise H2 c); clear H2.
       simpl in *.
       match goal with |[H3 : _ = ?f |- ?e · _ · _ · _  = _ ] =>
-         pathvia (e · f) end.
+         intermediate_path (e · f) end.
       * eapply pathscomp0. apply (!assoc _ _ _).
         eapply pathscomp0. apply (!assoc _ _ _ ).
         apply maponpaths.
@@ -433,7 +433,7 @@ Proof.
     rewrite (functor_id ( H (`T))) in HXX.
     rewrite id_right in HXX. (* last two lines needed because of def. of theta on product category *)
     match goal with |[HXX : ?f · ?h = _ · _ |- _ · (_ · ?x ) · ?y = _ ] =>
-      pathvia (pr1 (θ ((`T) ⊗ (ptd_from_alg T))) (pr1 (pr1 (pr1 T)) c)·
+      intermediate_path (pr1 (θ ((`T) ⊗ (ptd_from_alg T))) (pr1 (pr1 (pr1 T)) c)·
                        f  · h · x· y) end.
     * repeat rewrite assoc.
       apply cancel_postcomposition.
@@ -477,7 +477,7 @@ Proof.
       unfold μ_2.
       {
         match goal with |[ H5 : _ = ?e |- ?a · ?b · _ · _ · _ = _ ] =>
-                         pathvia (a · b · e) end.
+                         intermediate_path (a · b · e) end.
         - repeat rewrite <- assoc.
           apply maponpaths.
           apply maponpaths.
@@ -507,14 +507,14 @@ Lemma third_monad_law_from_hss :
   =
   (α_functor _ _ _ : functor_compose hs hs _ _  --> _) · (μ_2 •• `T) · μ_2.
 Proof.
-  pathvia μ_3; [apply pathsinv0, μ_3_T_μ_2_μ_2 | ].
+  intermediate_path μ_3; [apply pathsinv0, μ_3_T_μ_2_μ_2 | ].
   apply pathsinv0.
   apply (fbracket_unique (*_pointwise*) T  μ_2_ptd).
   split.
   - apply nat_trans_eq; try assumption; intro c.
     simpl.
     rewrite assoc.
-    pathvia (identity _ · μ_2 c).
+    intermediate_path (identity _ · μ_2 c).
     + apply pathsinv0, id_left.
     + apply cancel_postcomposition.
       rewrite id_left.
@@ -535,7 +535,7 @@ Proof.
     assert (HX':= nat_trans_eq_pointwise HX x); clear HX.
     simpl in HX'.
     match goal with | [ H : _  = ?f |- _ · _ · ?g · ?h · ?i = _ ] =>
-                      pathvia (f · g · h · i) end.
+                      intermediate_path (f · g · h · i) end.
     + apply cancel_postcomposition.
       apply cancel_postcomposition.
       apply cancel_postcomposition.
@@ -549,13 +549,13 @@ Proof.
       assert (HXX:=nat_trans_eq_pointwise HX1 x); clear HX1.
       simpl in HXX.
       match goal with | [ H : ?x = _ |- ?e · _ · _ · ?f · ?g = _ ] =>
-                 pathvia (e · x · f · g) end.
+                 intermediate_path (e · x · f · g) end.
       * apply cancel_postcomposition.
         apply cancel_postcomposition.
         repeat rewrite <- assoc.
         apply maponpaths.
         {
-          match goal with | [ H : _ = ?x |- _ ] => pathvia x end.
+          match goal with | [ H : _ = ?x |- _ ] => intermediate_path x end.
           -  clear HXX.
              apply maponpaths.
              match goal with | [ |- _  ?a ?x = _  ?b ?y ] => assert (TTT : a = b) end.
@@ -611,7 +611,7 @@ Proof.
 
   - unfold Monad_data_from_hss; simpl.
     intro c.
-    pathvia (pr1 μ_3 c).
+    intermediate_path (pr1 μ_3 c).
     + set (H1 := μ_3_T_μ_2_μ_2).
       set (H2 := nat_trans_eq_weq hs _ _ H1).
       apply pathsinv0, H2.

--- a/UniMath/SubstitutionSystems/MonadsMultiSorted.v
+++ b/UniMath/SubstitutionSystems/MonadsMultiSorted.v
@@ -247,7 +247,7 @@ Qed.
 Definition subst_slice_as_bind_slice {Γ:SET_over_sort}(N : wellsorted_in Γ)
   (M : wellsorted_in (sorted_option_functor (sort_in N) Γ)): wellsorted_in Γ.
 Proof.
-  refine (bind_slice (BinCoproductArrow _ (BinCoproductsHSET _ _) (λ _, N) (η_slice(Γ:=Γ))) _ M).
+  use (bind_slice (BinCoproductArrow _ (BinCoproductsHSET _ _) (λ _, N) (η_slice(Γ:=Γ))) _ M).
   abstract(intro a1; induction a1 as [u | a1];
            [apply idpath | unfold BinCoproductArrow; simpl; now rewrite η_slice_ok]).
 Defined.
@@ -301,9 +301,9 @@ Qed.
 
 Definition mweak_slice_as_bind_slice (Γ1 : SET_over_sort)(Γ2 : SET_over_sort)(M : wellsorted_in Γ2) : wellsorted_in (Γ1 ⊕ Γ2).
 Proof.
-  refine (bind_slice (λ a1, η_slice(Γ:=Γ1 ⊕ Γ2) (pr1 (BinCoproductIn2 _ (BC _ _)) a1)) _ M).
+  use (bind_slice (λ a1, η_slice(Γ:=Γ1 ⊕ Γ2) (pr1 (BinCoproductIn2 _ (BC _ _)) a1)) _ M).
   intro a1.
-  now rewrite η_slice_ok.
+  simpl; now rewrite η_slice_ok.
 Defined.
 
 Lemma mweak_slice_as_bind_slice_agrees (Γ1 : SET_over_sort){Γ2 : SET_over_sort}(M : wellsorted_in Γ2) :
@@ -351,7 +351,7 @@ Proof.
   set (a1 := BinCoproductIn1 _ (BinCoproductsHSET _ _) · BinCoproductIn2 _ (BinCoproductsHSET _ _): HSET⟦pr1 Γ1, pr1(Γ2 ⊕ (Γ1 ⊕ Γ3))⟧).
   set (a21 := BinCoproductIn1 _ (BinCoproductsHSET _ _): HSET⟦pr1 Γ2, pr1(Γ2 ⊕ (Γ1 ⊕ Γ3))⟧).
   set (a22 := BinCoproductIn2 _ (BinCoproductsHSET _ _) · BinCoproductIn2 _ (BinCoproductsHSET _ _): HSET⟦pr1 Γ3, pr1(Γ2 ⊕ (Γ1 ⊕ Γ3))⟧).
-  refine (bind_slice ((BinCoproductArrow _ _ a1 (BinCoproductArrow _ _ a21 a22)) · η_slice(Γ:=Γ2 ⊕ (Γ1 ⊕ Γ3))) _ M).
+  use (bind_slice ((BinCoproductArrow _ _ a1 (BinCoproductArrow _ _ a21 a22)) · η_slice(Γ:=Γ2 ⊕ (Γ1 ⊕ Γ3))) _ M).
   intro x.
   induction x as [x1 | x2].
   + unfold BinCoproductArrow.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -305,7 +305,7 @@ Qed.
 Definition MultiSortedSigToSignature (M : MultiSortedSig) : Signature _ hs _ hs.
 Proof.
 set (Hyps := λ (op : ops M), Sig_hat_exp_functor_list (arity M op)).
-refine (Sum_of_Signatures (ops M) _ Hyps).
+use (Sum_of_Signatures (ops M) _ Hyps).
 apply Coproducts_slice_precat, CoproductsHSET, setproperty.
 Defined.
 

--- a/UniMath/SubstitutionSystems/Notation.v
+++ b/UniMath/SubstitutionSystems/Notation.v
@@ -41,7 +41,6 @@ Arguments functor_composite {_ _ _} _ _ .
 Arguments nat_trans_comp {_ _ _ _ _} _ _ .
 Notation "G • F" := (functor_composite F G : [ _ , _ , _ ]) (at level 35).
 Notation "α ∙∙ β" := (horcomp β α) (at level 20).
-Ltac pathvia b := (apply (@pathscomp0 _ _ b _ )).
 
 Notation "α 'ø' Z" := (pre_whisker Z α)  (at level 25).
 Notation "Z ∘ α" := (post_whisker α Z) (at level 50, left associativity).

--- a/UniMath/SubstitutionSystems/Signatures.v
+++ b/UniMath/SubstitutionSystems/Signatures.v
@@ -348,7 +348,7 @@ Proof.
   assert (H':= functor_id (H X') (pr1 (pr1 Z) c));
   simpl in H'.
   match goal with |[H1 : ?f · _ · ?g = _ , H2 : ?x = _ |- _ ] =>
-                        pathvia (f · x · g) end.
+                        intermediate_path (f · x · g) end.
   - repeat rewrite <- assoc.
     apply maponpaths.
     rewrite H'.

--- a/UniMath/SubstitutionSystems/SubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/SubstitutionSystems.v
@@ -152,7 +152,7 @@ Proof.
     assert (Hyp_inst := nat_trans_eq_pointwise Hyp c); clear Hyp.
     apply (maponpaths (λ m, BinCoproductIn1 C (CP _ _)· m)) in Hyp_inst.
     match goal with |[ H1 : _  = ?f |- _ = _   ] =>
-         pathvia (f) end.
+         intermediate_path (f) end.
 
     * clear Hyp_inst.
       rewrite <- assoc.
@@ -173,7 +173,7 @@ Proof.
     assert (Hyp_inst := nat_trans_eq_pointwise Hyp c); clear Hyp.
     apply (maponpaths (λ m,  BinCoproductIn2 C (CP _ _)· m)) in Hyp_inst.
     match goal with |[ H1 : _  = ?f |- _ = _   ] =>
-         pathvia (f) end.
+         intermediate_path (f) end.
 
     * clear Hyp_inst.
       do 2 rewrite <- assoc.


### PR DESCRIPTION
I only worked on the packages CategoryTheory and SubstitutionSystems. intermediate_path and use are used in place of pathvia and variations of refine.