### PR TITLE
Travis optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,26 @@
 # validate this file at http://lint.travis-ci.org/
 # ocaml and coq are not on the list of languages:
 language:       generic
-sudo: 		required
+sudo: 		false
 # "trusty" is the most modern release of Ubuntu supported
 dist: 		trusty
 git:
   submodules:   false
-before_install:
-  - sudo apt-get update -qq
-install:
-  - sudo apt-get install -y ocaml ocaml-nox ocaml-native-compilers ocaml-findlib
-  - sudo apt-get install -y camlp5 camlp4-extra time libgtk2.0 libgtksourceview2.0
-  - sudo apt-get install -y liblablgtk-extras-ocaml-dev
-  # get etags from emacs:
-  - sudo apt-get install -y emacs
+cache:
+  apt: true
+addons:
+  apt:
+    packages:
+      - ocaml
+      - ocaml-nox
+      - ocaml-native-compilers
+      - ocaml-findlib
+      - camlp5
+      - camlp4-extra time
+      - libgtk2.0
+      - libgtksourceview2.0
+      - liblablgtk-extras-ocaml-dev
+      - emacs
 # build coqide along with the Tactics package, just because it's a short package
 env:
   - PACKAGES="Foundations Combinatorics Algebra NumberSystems PAdics"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ sudo: 		required
 dist: 		trusty
 git:
   submodules:   false
-cache:
-  apt: true
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,12 @@ env:
   - PACKAGES="Foundations Combinatorics Algebra NumberSystems PAdics"
   - PACKAGES=CategoryTheory
   - PACKAGES="MoreFoundations Ktheory"
+  - PACKAGES=HomologicalAlgebra
   - PACKAGES=Topology
   - PACKAGES=RealNumbers
   - PACKAGES=SubstitutionSystems
   - PACKAGES=Tactics BUILD_COQIDE=yes BUILD_ALSO=TAGS
   - PACKAGES=Folds
-  - PACKAGES=HomologicalAlgebra
   - FOUNDATIONS_CHANGE_ERROR=yes BUILD_ALSO="check-for-change-to-Foundations enforce-listing-of-proof-files"
 # building Coq in a separate stage folds up the output in the log:
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # validate this file at http://lint.travis-ci.org/
 # ocaml and coq are not on the list of languages:
 language:       generic
-sudo: 		false
+sudo: 		required
 # "trusty" is the most modern release of Ubuntu supported
 dist: 		trusty
 git:


### PR DESCRIPTION
I have done a bunch of experimentation with the travis setup. So I now indeed propose to start building `HomologicalAlgebra` sooner (closing #795). This change takes about 5-10 minutes off of the time from commit to CI completion.

I have tried the new container-based instances. Although they boot faster, they also seem to process noticably slower. So overall it is faster to use full virtualization (the current choice).

I made Travis install the required packages using the `apt` add-on, instead of the `apt-get install` commands. This is not necessarily faster, but it's more elegant, and enables switching to container-based instances.

The next obvious optimization steps would be:

- Optimize / break up `HomologicalAlgebra` (longest component at 19-23 minutes)
- Cache the coq build (this takes 2 minutes for every build that is done)

I have attempted to cache the coq build, but I didn't manage to write something that I felt was reliable. So this PR excludes that.