### PR TITLE
This is not MP, so don't call it that

### DIFF
--- a/UniMath/Combinatorics/.package/files
+++ b/UniMath/Combinatorics/.package/files
@@ -4,5 +4,5 @@ FiniteSets.v
 OrderedSets.v
 WellOrderedSets.v
 FiniteSequences.v
-MarkovPrinciple.v
+BoundedSearch.v
 Tests.v

--- a/UniMath/Combinatorics/BoundedSearch.v
+++ b/UniMath/Combinatorics/BoundedSearch.v
@@ -1,5 +1,4 @@
-(** * Constructive instance of Markov's principle
-
+(**
 Auke Booij
 Nov. 2017
 

--- a/UniMath/Combinatorics/Tests.v
+++ b/UniMath/Combinatorics/Tests.v
@@ -7,7 +7,7 @@ Require UniMath.Combinatorics.FiniteSequences.
 Require UniMath.Combinatorics.FiniteSets.
 Require UniMath.Combinatorics.OrderedSets.
 Require UniMath.Combinatorics.StandardFiniteSets.
-Require UniMath.Combinatorics.MarkovPrinciple.
+Require UniMath.Combinatorics.BoundedSearch.
 Require UniMath.MoreFoundations.DecidablePropositions.
 
 Module Test_list.
@@ -492,9 +492,9 @@ Module Test_ord.
 
 End Test_ord.
 
-Module Test_markov.
+Module Test_search.
 
-  Import UniMath.Combinatorics.MarkovPrinciple.
+  Import UniMath.Combinatorics.BoundedSearch.
   Import UniMath.Foundations.Propositions.
 
   Local Definition someseq (n : nat) : bool.
@@ -538,4 +538,4 @@ Module Test_markov.
 
   Definition new_n' :  ∑ n : nat, P n := minimal_n P P_dec P_inhab'.
 
-End Test_markov.
+End Test_search.


### PR DESCRIPTION
Markov's principle says that from the double negation of the existence of some element, we can get some element. In other words, if it's impossible that some element _doesn't_ exist, then we can get its existence. It translates negative information into positive information.

What this code proves is that if there _exists_ some element, then we can _find_ it, which is a fundamentally different claim. I have renamed it to BoundedSearch.

I'm sorry for the confusion I may have caused.

Edit: in fact I now realize that even the branch name `rename-markov` is inappropriate, as I am not renaming markov's principle, nor am I renaming something that implements it. Sorry once again. Let's get rid of this quickly.