### PR TITLE
Define natural numbers objects as an initial algebra

### DIFF
--- a/UniMath/CategoryTheory/FunctorAlgebras.v
+++ b/UniMath/CategoryTheory/FunctorAlgebras.v
@@ -11,18 +11,19 @@ Extended by: Anders Mörtberg. October 2015
 
 Contents :
 
-- category of algebras of an endofunctor
+- Category of algebras of an endofunctor
 
-- Saturated if base precategory is
+- This category is saturated if base precategory is
 
 - Lambek's lemma: if (A,a) is an inital F-algebra then a is an iso
+
+- The natural numbers are intial for X ↦ 1 + X
 
 ******************************************************************)
 
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
-
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -30,7 +31,13 @@ Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.limits.initial.
 
+(* The following are used for examples *)
+Require Import UniMath.CategoryTheory.limits.terminal.
+Require Import UniMath.CategoryTheory.limits.bincoproducts.
+
 Local Open Scope cat.
+
+(** ** Category of algebras of an endofunctor *)
 
 Section Algebra_Definition.
 
@@ -46,6 +53,19 @@ Local Coercion alg_carrier : algebra_ob >-> ob.
 
 Definition alg_map (X : algebra_ob) : F X --> X := pr2 X.
 
+(** A morphism of an F-algebras (F X, g : F X --> X) and (F Y, h : F Y --> Y)
+    is a morphism f : X --> Y such that the following diagram commutes:
+    
+    <<
+         F f
+    F x ----> F y
+    |         |
+    | g       | h
+    V         V
+    x ------> y
+         f
+    >>
+ *)
 Definition is_algebra_mor (X Y : algebra_ob) (f : alg_carrier X --> alg_carrier Y) : UU
   := alg_map X · f = #F f · alg_map Y.
 
@@ -140,6 +160,8 @@ Proof.
   apply isaset_algebra_mor.
   assumption.
 Qed.
+
+(** ** This category is saturated if the base category is  *)
 
 Section FunctorAlg_saturated.
 
@@ -296,7 +318,8 @@ End Algebra_Definition.
 
 Notation FunctorAlg := precategory_FunctorAlg.
 
-(* Lambek's lemma: If (A,a) is an initial F-algebra then a is an iso *)
+(** ** Lambek's lemma: If (A,a) is an initial F-algebra then a is an iso *)
+
 Section Lambeks_lemma.
 
 Variables (C : precategory) (hsC : has_homsets C) (F : functor C C).
@@ -336,3 +359,185 @@ exact (is_iso_qinv _ a' initialAlg_is_iso_subproof).
 Defined.
 
 End Lambeks_lemma.
+
+
+(** ** The natural numbers are intial for X ↦ 1 + X *)
+
+(** This can be used as a definition of a natural numbers object (NNO) in
+    any category with binary coproducts and a terminal object. We prove
+    the universal property of NNOs below. *)
+
+Section Nats.
+  Context (C : precategory).
+  Context (bc :  BinCoproducts C).
+  Context (hsC :  has_homsets C).
+  Context (T : Terminal C).
+
+  Local Notation "1" := T.
+  Local Notation "f + g" := (BinCoproductOfArrows _ _ _ f g).
+  Local Notation "[ f , g ]" := (BinCoproductArrow _ _ f g).
+
+  Let F : functor C C := BinCoproduct_of_functors _ _ bc
+                                                  (constant_functor _ _ 1)
+                                                  (functor_identity _).
+
+  (** F on objects: X ↦ 1 + X *)
+  Definition F_compute1 : ∏ c : C, F c = BinCoproductObject _ (bc 1 c) :=
+    fun c => (idpath _).
+
+  (** F on arrows: f ↦ [identity 1, f] *)
+  Definition F_compute2 {x y : C} : ∏ f : x --> y, # F f = (identity 1) + f :=
+    fun c => (idpath _).
+
+  Definition nat_ob : UU := Initial (FunctorAlg F hsC).
+
+  Definition nat_ob_carrier (N : nat_ob) : ob C :=
+    alg_carrier _ (InitialObject N).
+  Local Coercion nat_ob_carrier : nat_ob >-> ob.
+
+  (** We have an arrow alg_map : (F N = 1 + N) --> N,
+      so by the η-rule (UMP) for the coproduct, we can assume that it
+      arises from a pair of maps [nat_ob_z,nat_ob_s] by composing with
+      coproduct injections.
+
+      <<
+                  in1         in2
+               1 ----> 1 + N <---- N
+               |         |         |
+      nat_ob_z |         | alg_map | nat_ob_s
+               |         V         |
+               +-------> N <-------+
+      >>
+   *)
+  Definition nat_ob_z (N : nat_ob) : (1 --> N) :=
+    BinCoproductIn1 C (bc 1 (alg_carrier F (pr1 N))) · (alg_map _ (pr1 N)).
+
+  Definition nat_ob_s (N : nat_ob) : (N --> N) :=
+    BinCoproductIn2 C (bc 1 (alg_carrier F (pr1 N))) · (alg_map _ (pr1 N)).
+
+  Local Notation "0" := (nat_ob_z _).
+
+  (** Use the universal property of the coproduct to make any object with a
+      point and an endomorphism into an F-algebra *)
+  Definition mk_F_alg {X : ob C} (f : 1 --> X) (g : X --> X) : ob (FunctorAlg F hsC).
+  Proof.
+    refine (X,, _).
+    exact (BinCoproductArrow _ _ f g).
+  Defined.
+
+  (** Using mk_F_alg, X will be an F-algebra, and by initiality of N, there will
+      be a unique morphism of F-algebras N --> X, which can be projected to a
+      morphism in C. *)
+  Definition nat_ob_rec (N : nat_ob) {X : ob C} :
+    ∏ (f : 1 --> X) (g : X --> X), (N --> X) :=
+    fun f g => mor_from_algebra_mor _ _ _ (InitialArrow N (mk_F_alg f g)).
+
+  (** When calling the recursor on 0, you get the base case.
+      Specifically,
+
+        nat_ob_z · nat_ob_rec = f
+   *)
+  Lemma nat_ob_rec_z (N : nat_ob) {X : ob C} :
+    ∏ (f : 1 --> X) (g : X --> X), nat_ob_z N · nat_ob_rec N f g = f.
+  Proof.
+    intros f g.
+
+    pose (inlN := BinCoproductIn1 _ (bc 1 N)).
+    pose (succ := nat_ob_s N).
+
+    (** By initiality of N, there is a unique morphism making the following
+        diagram commute:
+
+        <<
+               inlN         identity 1 + nat_ob_rec
+            1 -----> 1 + N -------------------------> 1 + X
+                       |                                |
+             alg_map N |                                | alg_map X
+                       V                                V
+                       N   -------------------------->  X
+                                   nat_ob_rec
+        >>
+
+        This proof uses somewhat idiosyncratic "forward reasoning", transforming
+        the term "diagram" rather than the goal.
+     *)
+    pose
+      (diagram :=
+         maponpaths
+           (fun x => inlN · x)
+           (algebra_mor_commutes F (pr1 N) _ (InitialArrow N (mk_F_alg f g)))).
+    rewrite (F_compute2 _) in diagram.
+
+    (** Using the η-rules for coproducts, we can assume that alg_map X = [f,g] 
+        for f : 1 --> X, g : X --> X. *)
+    rewrite (BinCoproductArrowEta C 1 X (bc _ _) _ _) in diagram.
+
+    (** Using the β-rules for coproducts, we can simplify some of the terms *)
+    (** (identity 1 + _) · [f, g] --β--> [identity 1 · f, _ · g] *)
+    rewrite (precompWithBinCoproductArrow C (bc 1 N) (bc 1 X)
+                                          (identity 1) _ _ _) in diagram.
+
+    (** inl · [identity 1 · f, _ · g] --β--> identity 1 · f *)
+    rewrite (BinCoproductIn1Commutes C 1 N (bc 1 _) _ _ _) in diagram.
+
+    (** We can dispense with the identity *)
+    rewrite (id_left _) in diagram.
+
+    rewrite assoc in diagram.
+    rewrite (BinCoproductArrowEta C 1 N (bc _ _) _ _) in diagram.
+
+    refine (_ @ (BinCoproductIn1Commutes C _ _ (bc 1 _) _ f g)).
+    rewrite (!BinCoproductIn1Commutes C _ _ (bc 1 _) _ 0 succ).
+    unfold nat_ob_rec in *.
+    exact diagram.
+  Defined.
+
+  Opaque nat_ob_rec_z.
+
+  (** The succesor case:
+
+        nat_ob_s · nat_ob_rec = nat_ob_rec · g
+
+      The proof is very similar.
+   *)
+  Lemma nat_ob_rec_s (N : nat_ob) {X : ob C} :
+    ∏ (f : 1 --> X) (g : X --> X),
+    nat_ob_s N · nat_ob_rec N f g = nat_ob_rec N f g · g.
+  Proof.
+    intros f g.
+
+    pose (inrN := BinCoproductIn2 _ (bc 1 N)).
+    pose (succ := nat_ob_s N).
+
+    (** By initiality of N, there is a unique morphism making the same diagram
+        commute as above, but with "inrN" in place of "inlN". *)
+    pose
+      (diagram :=
+         maponpaths
+           (fun x => inrN · x)
+           (algebra_mor_commutes F (pr1 N) _ (InitialArrow N (mk_F_alg f g)))).
+    rewrite (F_compute2 _) in diagram.
+
+    rewrite (BinCoproductArrowEta C 1 X (bc _ _) _ _) in diagram.
+
+    (** Using the β-rules for coproducts, we can simplify some of the terms *)
+    (** (identity 1 + _) · [f, g] --β--> [identity 1 · f, _ · g] *)
+    rewrite (precompWithBinCoproductArrow C (bc 1 N) (bc 1 X)
+                                          (identity 1) _ _ _) in diagram.
+
+    (** inl · [identity 1 · f, _ · g] --β--> identity 1 · f *)
+    rewrite (BinCoproductIn2Commutes C 1 N (bc 1 _) _ _ _) in diagram.
+
+    rewrite assoc in diagram.
+    rewrite (BinCoproductArrowEta C 1 N (bc _ _) _ _) in diagram.
+
+    refine
+      (_ @ maponpaths (fun x => nat_ob_rec N f g · x)
+         (BinCoproductIn2Commutes C _ _ (bc 1 _) _ f g)).
+    rewrite (!BinCoproductIn2Commutes C _ _ (bc 1 _) _ 0 (nat_ob_s N)).
+    unfold nat_ob_rec in *.
+    exact diagram.
+  Defined.
+
+  Opaque nat_ob_rec_s.
+End Nats.


### PR DESCRIPTION
The natural numbers are initial for the functor X ↦ 1 + X. I _think_ this is somewhat different in focus from the `SubstitutionSystems` code, but someone should double check me on that. This defines a natural numbers object in any category, and derives their usual universal property (just the beta rules so far, no eta yet). 