### PR TITLE
Tactic for proving facts about hlevels of types

### DIFF
--- a/UniMath/Algebra/DivisionRig.v
+++ b/UniMath/Algebra/DivisionRig.v
@@ -26,12 +26,8 @@ Definition isDivRig (X : rig) : UU :=
 
 Lemma isaprop_isDivRig (X : rig) : isaprop (isDivRig X).
 Proof.
-  intro X.
-  apply isofhleveldirprod.
-  - now apply isapropneg.
-  - apply impred_isaprop ; intro.
-    apply isapropimpl.
-    now apply isapropinvpair.
+  hleveltac.
+  now apply isapropinvpair.
 Qed.
 
 Definition isDivRig_zero {X : rig} (is : isDivRig X) : X := 0%rig.

--- a/UniMath/Algebra/Modules/Core.v
+++ b/UniMath/Algebra/Modules/Core.v
@@ -7,6 +7,7 @@ Require Import UniMath.Foundations.PartA.
 Require Import UniMath.Foundations.Preamble.
 Require Import UniMath.Algebra.Domains_and_Fields.
 Require Import UniMath.Foundations.PartD.
+Require Import UniMath.MoreFoundations.Tactics.
 
 (** ** Contents
 - The ring of endomorphisms of an abelian group
@@ -420,8 +421,13 @@ Definition pr1linearfun {R : rng} {M N : module R} (f : linearfun M N) : M -> N 
 
 Coercion pr1linearfun : linearfun >-> Funclass.
 
-Lemma islinearfuncomp {R : rng} {M N P : module R} (f : linearfun M N) (g : linearfun N P) :
-  islinear (funcomp (pr1 f) (pr1 g)).
+Lemma isapropislinear {R : rng} {M N : module R} (f : M -> N) : isaprop (islinear f).
+  unfold islinear.
+  hleveltac.
+  apply (setproperty N).
+Defined.
+
+Definition islinearfuncomp {R : rng} {M N P : module R} (f : linearfun M N) (g : linearfun N P) : islinear (funcomp (pr1 f) (pr1 g)).
 Proof.
   intros r x.
   unfold funcomp.
@@ -438,11 +444,10 @@ Definition ismodulefun {R : rng} {M N : module R} (f : M -> N) : UU :=
 
 Lemma isapropismodulefun {R : rng} {M N : module R} (f : M -> N) : isaprop (ismodulefun f).
 Proof.
-   refine (@isofhleveldirprod 1 (isbinopfun f) (islinear f) _ _).
-   exact (isapropisbinopfun f).
-   apply (impred 1 _). intro r.
-   apply (impred 1 _). intro x.
-   apply (setproperty N).
+  unfold ismodulefun.
+  hleveltac.
+  - exact (isapropisbinopfun f).
+  - exact (isapropislinear f).
 Defined.
 
 Definition modulefun {R : rng} (M N : module R) : UU := ∑ f : M -> N, ismodulefun f.

--- a/UniMath/Algebra/Modules/Multimodules.v
+++ b/UniMath/Algebra/Modules/Multimodules.v
@@ -5,6 +5,7 @@ Require Import UniMath.Algebra.Monoids_and_Groups.
 Require Import UniMath.Algebra.Rigs_and_Rings.
 Require Import UniMath.Foundations.Preamble.
 Require Import UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.Tactics.
 
 (** ** Contents
 - Definitions
@@ -60,6 +61,7 @@ Lemma isaproparecompatibleactions
       {R S G} (mr : module_struct R G) (ms : module_struct S G) :
   isaprop (arecompatibleactions mr ms).
 Proof.
+  hleveltac.
   apply (impredtwice 1); intros r s.
 
   (* We'll prove that all the homotopies are identical *)
@@ -69,7 +71,8 @@ Proof.
   apply invweq.
   apply weqfunextsec.
 
-  apply (impred 1); intros x.
+  unfold homot.
+  hleveltac.
   apply (pr2 (pr1 (pr1 G))).
 Defined.
 
@@ -77,8 +80,8 @@ Lemma isapropmultimodule_struct {I : UU} {rngs : I -> rng} {G : abgr}
                                 (structs : ∏ i : I, module_struct (rngs i) G) :
   isaprop (multimodule_struct structs).
 Proof.
-  apply (impredtwice 1); intros i1 i2.
-  apply impredfun.
+  unfold multimodule_struct.
+  hleveltac.
   apply isaproparecompatibleactions.
 Defined.
 
@@ -127,10 +130,12 @@ Definition ismultimodulefun {I : UU} {rngs : I -> rng}
 Lemma isapropismultimodulefun {I : UU} {rngs : I -> rng}
       {MM NN : multimodule rngs} (f : MM -> NN) : isaprop (ismultimodulefun f).
 Proof.
-  refine (@isofhleveldirprod 1 (isbinopfun f) (ismultilinear f)
-                             (isapropisbinopfun f) _).
-  do 3 (apply (impred 1 _); intros ?).
-  apply setproperty.
+  unfold ismultimodulefun.
+  hleveltac.
+  - exact (isapropisbinopfun f).
+  - unfold ismultilinear, islinear.
+    hleveltac.
+    apply setproperty.
 Defined.
 
 Definition multimodulefun {I : UU} {rngs : I -> rng}

--- a/UniMath/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Algebra/Monoids_and_Groups.v
@@ -59,6 +59,7 @@ Unset Kernel Term Sharing.
 
 Require Export UniMath.Algebra.BinaryOperations.
 Require Import UniMath.MoreFoundations.Subtypes.
+Require Import UniMath.MoreFoundations.Tactics.
 
 (** To upstream files *)
 
@@ -137,7 +138,7 @@ Definition ismonoidfununel {X Y : monoid} {f : X -> Y} (H : ismonoidfun f) : f (
 
 Lemma isapropismonoidfun {X Y : monoid} (f : X -> Y) : isaprop (ismonoidfun f).
 Proof.
-  intros. apply isofhleveldirprod.
+  intros. unfold ismonoidfun. hleveltac.
   - apply isapropisbinopfun.
   - apply (setproperty Y).
 Defined.
@@ -168,7 +169,7 @@ Lemma isasetmonoidfun (X Y : monoid) : isaset (monoidfun X Y).
 Proof.
   intros. apply (isasetsubset (pr1monoidfun X Y)).
   - change (isofhlevel 2 (X -> Y)).
-    apply impred. intro.
+    hleveltac.
     apply (setproperty Y).
   - refine (isinclpr1 _ _). intro.
     apply isapropismonoidfun.
@@ -377,9 +378,9 @@ Definition issubmonoidpair {X : monoid} {A : hsubtype X} (H1 : issubsetwithbinop
 Lemma isapropissubmonoid {X : monoid} (A : hsubtype X) :
   isaprop (issubmonoid A).
 Proof.
-  intros. apply (isofhleveldirprod 1).
+  intros. unfold issubmonoid. hleveltac.
   - apply isapropissubsetwithbinop.
-  - apply (pr2 (A (unel X))).
+  - apply (propproperty (A (unel X))).
 Defined.
 
 Definition submonoid {X : monoid} : UU := total2 (λ A : hsubtype X, issubmonoid A).
@@ -1346,9 +1347,7 @@ Proof.
                                   neg (abmonoidfracrel X A is x2 x1) ->
                                   x1 = x2)).
   {
-    intros x1 x2.
-    apply impred. intro.
-    apply impred. intro.
+    hleveltac.
     apply (isasetsetquot _ x1 x2).
   }
   unfold isantisymmneg.
@@ -1376,9 +1375,7 @@ Proof.
                                   (abmonoidfracrel X A is x2 x1) ->
                                   x1 = x2)).
   {
-    intros x1 x2.
-    apply impred. intro.
-    apply impred. intro.
+    hleveltac.
     apply (isasetsetquot _ x1 x2).
   }
   apply (setquotuniv2prop _ (λ x1 x2, hProppair _ (int x1 x2))).
@@ -1465,8 +1462,7 @@ Proof.
                                    X A is (prabmonoidfrac X A (pr1 aa) aa' + z)
                                    (prabmonoidfrac X A (pr1 aa) aa' + z'))).
   {
-    intros z z'.
-    apply impred. intro.
+    hleveltac.
     apply (pr2 (abmonoidfracrel _ _ _ _ _)).
   }
   apply (setquotuniv2prop _ (λ z z', hProppair _ (int z z'))).
@@ -1505,8 +1501,7 @@ Proof.
                                          (z + (prabmonoidfrac X A (pr1 aa) aa'))
                                          (z' + prabmonoidfrac X A (pr1 aa) aa'))).
   {
-    intros z z'.
-    apply impred. intro.
+    hleveltac.
     apply (pr2 (abmonoidfracrel _ _ _ _ _)).
   }
   apply (setquotuniv2prop _ (λ z z', hProppair _ (int z z'))).
@@ -1900,11 +1895,11 @@ Definition issubgrpair {X : gr} {A : hsubtype X} (H1 : issubmonoid A)
 
 Lemma isapropissubgr {X : gr} (A : hsubtype X) : isaprop (issubgr A).
 Proof.
-  intros. apply (isofhleveldirprod 1).
+  unfold issubgr.
+  hleveltac.
   - apply isapropissubmonoid.
-  - apply impred. intro x.
-    apply impred. intro a.
-    apply (pr2 (A (grinv X x))).
+  - hleveltac.
+    apply (propproperty (A (grinv X _))).
 Defined.
 
 Definition subgr {X : gr} : UU := total2 (λ A : hsubtype X, issubgr A).
@@ -2461,9 +2456,8 @@ Proof.
   intros X L is x1 x2. split.
   - assert (int : ∏ x x', isaprop (abgrdiffrel' X is x x' -> abgrdiffrel X is x x')).
     {
-      intros x x'.
-      apply impred. intro.
-      apply (pr2 _).
+      hleveltac.
+      apply (propproperty _).
     }
     generalize x1 x2. clear x1 x2.
     apply (setquotuniv2prop _ (λ x x', hProppair _ (int x x'))).
@@ -2471,9 +2465,8 @@ Proof.
     change ((abgrdiffrelint' X L x x')  -> (abgrdiffrelint _ L x x')).
     apply (pr1 (logeqabgrdiffrelints X L x x')).
   - assert (int : ∏ x x', isaprop (abgrdiffrel X is x x' -> abgrdiffrel' X is x x')).
-    intros x x'.
-    apply impred. intro.
-    apply (pr2 _).
+    hleveltac.
+    apply (propproperty _).
     generalize x1 x2. clear x1 x2.
     apply (setquotuniv2prop _ (λ x x', hProppair _ (int x x'))).
     intros x x'.

--- a/UniMath/CategoryTheory/Categories.v
+++ b/UniMath/CategoryTheory/Categories.v
@@ -36,7 +36,6 @@ Contents :
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
-
 Require Import UniMath.MoreFoundations.Tactics.
 
 
@@ -152,8 +151,7 @@ Definition has_homsets (C : precategory_ob_mor) : UU := ∏ a b : C, isaset (a -
 
 Lemma isaprop_has_homsets (C : precategory_ob_mor) : isaprop (has_homsets C).
 Proof.
-  do 2 (apply impred; intro).
-  apply isapropisaset.
+  hleveltac.
 Qed.
 
 Definition category := ∑ C:precategory, has_homsets C.
@@ -189,10 +187,8 @@ Definition makecategory
 Lemma isaprop_is_precategory (C : precategory_data)(hs: has_homsets C)
   : isaprop (is_precategory C).
 Proof.
-  apply isofhleveltotal2.
-  { apply isofhleveltotal2. { repeat (apply impred; intro). apply hs. }
-    intros _. repeat (apply impred; intro); apply hs. }
-  intros _. repeat (apply impred; intro); apply hs.
+  unfold is_precategory.
+  hleveltac; apply hs.
 Qed.
 
 
@@ -327,7 +323,8 @@ Definition is_iso {C : precategory_data} {a b : C} (f : a --> b) :=
 
 Lemma isaprop_is_iso {C : precategory_data}(a b : C) (f : a --> b) : isaprop (is_iso f).
 Proof.
-  apply impred; intro.
+  unfold is_iso.
+  hleveltac.
   apply isapropisweq.
 Qed.
 
@@ -394,8 +391,8 @@ Defined.
 Lemma isaset_iso {C : precategory_data} (hs: has_homsets C) (a b :ob C) :
   isaset (iso a b).
 Proof.
-  change isaset with (isofhlevel 2).
-  apply isofhleveltotal2.
+  unfold iso.
+  hleveltac.
   - apply hs.
   - intro f.
     apply isasetaprop.
@@ -693,7 +690,8 @@ End are_isomorphic.
 Lemma isaprop_is_inverse_in_precat (C : precategory_data) (hs: has_homsets C) (a b : ob C)
    (f : a --> b) (g : b --> a) : isaprop (is_inverse_in_precat f g).
 Proof.
-  apply isapropdirprod; apply hs.
+  unfold is_inverse_in_precat.
+  hleveltac; apply hs.
 Qed.
 
 Lemma inverse_unique_precat (C : precategory) (a b : ob C)
@@ -1150,17 +1148,9 @@ Defined.
 
 Lemma isaprop_is_univalent (C : precategory) : isaprop (is_univalent C).
 Proof.
-  apply isapropdirprod.
-  - apply impred.
-    intro a.
-    apply impred.
-    intro b.
-    apply isapropisweq.
-  - apply impred.
-    intro a.
-    apply impred.
-    intro b.
-    apply isapropisaset.
+  unfold is_univalent.
+  hleveltac.
+  apply isapropisweq.
 Qed.
 
 Definition univalent_category : UU := total2 (λ C : precategory, is_univalent C).

--- a/UniMath/MoreFoundations/.package/files
+++ b/UniMath/MoreFoundations/.package/files
@@ -11,3 +11,4 @@ AxiomOfChoice.v
 StructureIdentity.v
 PartA.v
 All.v
+Tests.v

--- a/UniMath/MoreFoundations/Tactics.v
+++ b/UniMath/MoreFoundations/Tactics.v
@@ -1,8 +1,13 @@
-(************************************************************************
+(** This file contains various useful tactics. *) 
+(** ** Contents:
 
-This file contains various useful tactics
-
-************************************************************************)
+- [unimath_easy]
+- [now]
+- [hSet_induction]
+- [hlevelmatch] - Author: Langston Barrett (@siddharthist)
+- [hleveltac] - Author: Langston Barrett (@siddharthist)
+- [hleveltacS] - Author: Langston Barrett (@siddharthist)
+ *)
 
 Require Import UniMath.MoreFoundations.Foundations.
 
@@ -22,3 +27,93 @@ Tactic Notation "now" tactic(t) := t; unimath_easy.
 
 (* hSet_induction in Foundations is wrong, so redefine it here: *)
 Ltac hSet_induction f e := generalize f; apply hSet_rect; intro e; clear f.
+
+(** The tactics hlevelmatch performs one "step" in proving that a type has a
+    given hlevel. Specifically, it applies one of several lemmas based on the
+    type formers used in the expression. It is mainly used as a helper for the
+    more fully automated tactic [hleveltac].
+
+    Here are some ideas for improvement:
+    - When proving a [homot], use [impred]
+    - Reason more about coproducts using [isofhlevelssncoprod]
+    - Reason that terms using [hProppair] are of any hlevel higher than [iscontr]
+    - Reason about weak equivalences, as in [isofhlevelweqf] and [isofhlevelweqb]
+    - Reason about double negation using [isapropdneg] and [isapropaninvprop]
+    - If we have Z : hSet, and our goal is isaset (pr1hSet Z), solve it.
+    - If we have Z : hProp, and our goal is isaprop (hProptoType Z), solve it.
+    - Do the more general version of the above two (unfold them to ∑-types and pr1)?
+
+    We don't include [isapropneg] because its proof includes an axiom.
+ *)
+Ltac hlevelmatch :=
+  multimatch goal with
+
+  (** h-levels involving positive type formers *)
+  (*01*)| [ |- isofhlevel ?n unit ] => apply iscontrunit
+  (*02*)| [ |- isofhlevel ?n (?X × ?Y) ] => apply isofhleveldirprod
+  (*03*)| [ |- isofhlevel ?n (total2 ?Y) ] => apply isofhleveltotal2
+  (*04*)| [ |- isofhlevel ?n (?X -> ?Y) ] => apply impred; intro
+  (*05*)| [ |- isofhlevel ?n (forall _ : ?X, _) ] => apply impred; intro
+
+  (** h-levels involving negative type formers. Some of these are only
+      useful if we have the appropriate hypothesis. For instance, when proving
+      <<
+        isofhlevel n (X × Y)
+      >>
+      we almost always want to split into cases for A and B. However, when
+      proving
+      <<
+        isofhlevel n Y
+      >>
+      we rarely want to instead prove
+      <<
+        isofhlevel n (X ⨿ Y)
+      >>
+      unless this is a hypothesis of our context. We try to apply *all*
+      hypotheses in this way, which is not the best, but it works. Someone who
+      knows more about Ltac might want to fix this.
+   *)
+  (*06*)| [ H : (?X -> empty) |- isofhlevel _ ?X ] => apply isapropifnegtrue
+  (*07*)| [ H : _ |- isofhlevel (S ?n) _ ] => apply (@isofhlevelsnsummand1 n _ _ H)
+  (*07*)| [ H : _ |- isofhlevel (S ?n) _ ] => apply (@isofhlevelsnsummand2 n _ _ H)
+
+  (*08*)| [|- isofhlevel _ empty] => apply isapropempty
+  (*09*)| [|- isofhlevel _ (isaset _)] => apply isapropisaset
+  (*10*)| [|- isofhlevel _ (isofhlevel _ _)] => apply isapropisofhlevel
+  end.
+
+(** This tactic attempts to automatically (partially) solve goals of the form
+    [isofhlevel]. It breaks the goal down using lemmas about hlevels of terms
+    formed using various constructors, and recurses on subterms.
+ *)
+Ltac hleveltac :=
+  intros;
+  (** We unfold isaprop so as to match directly against isofhlevel ?n ?X, for
+      more generality. *)
+  unfold isaprop in *;
+
+  (** For similar reasons, we replace iscontr with isofhlevel *)
+  change iscontr with (isofhlevel 0) in *;
+  change isaset with (isofhlevel 2) in *;
+  repeat (hlevelmatch ||
+          (** It's possible we just need to unfold a bit more. Try this. *)
+          multimatch goal with
+          | |- isofhlevel ?n (?f _) => try (unfold f)
+          | |- isofhlevel ?n ?X => try (unfold X)
+          | |- _ => idtac (* we never want the match to fail *)
+          end);
+  try assumption.
+
+(** hlevel is cumulative, so we can try removing successors until it
+    works. This isn't the default because we don't want to stick users with a
+    goal of the form isofhlevel 0 X if nothing works. Optimally, this would
+    backtrack, but I'm not sure how to get that right.
+
+    We use easy instead of assumption because this one sometimes generates
+    a goal like isofhlevel n (x y) where we have ∏ y, isofhlevel n (x y) in
+    the context.
+ *)
+Ltac hleveltacS :=
+  repeat hleveltac;
+  repeat (apply hlevelntosn; hleveltac);
+  easy || fail "hleveltacS could not solve this goal".

--- a/UniMath/MoreFoundations/Tests.v
+++ b/UniMath/MoreFoundations/Tests.v
@@ -1,0 +1,57 @@
+(** These are tests for the tactics in Tactics.v *)
+
+Add LoadPath "../" as UniMath.
+Require Import UniMath.MoreFoundations.Foundations.
+Require Import UniMath.MoreFoundations.Tactics.
+
+Goal isaprop unit. hleveltacS. Qed.
+Goal isofhlevel 1 unit. hleveltacS. Qed.
+
+Section hlevel_tac_test2.
+  Hypothesis (X Y : Type) (xprop : isaprop X) (yprop : isaprop Y).
+
+  Goal isaprop (X × Y). hleveltac. Qed.
+  Goal isofhlevel 1 (X × Y). hleveltac. Qed.
+  Goal isofhlevel 20 (X × Y). hleveltacS. Qed.
+End hlevel_tac_test2.
+
+Section hlevel_tac_test3.
+  Hypothesis (n : nat) (X : Type) (Y : X -> UU) (nx : isofhlevel n X).
+  Hypothesis Pcontr : ∏ x : X, isofhlevel n (Y x).
+  Goal isofhlevel n (total2 Y). hleveltac. Qed.
+  Goal isofhlevel (S (S n)) (total2 Y). hleveltacS. Qed.
+  Goal isofhlevel (S (S n)) (∑ x : X, Y x). hleveltacS. Qed.
+End hlevel_tac_test3.
+
+Section hlevel_tac_test4.
+  Hypothesis (n : nat) (X Y : Type) (xlvl : isofhlevel n Y).
+  Goal isofhlevel (S n) (X -> Y). hleveltacS. Qed.
+End hlevel_tac_test4.
+
+Section hlevel_tac_test5.
+  Hypothesis (n : nat) (X Z : Type) (Y : X -> UU)
+             (xlvl : forall x, isofhlevel n (Y x)).
+  Goal isofhlevel (S n) (forall x : X, Y x). hleveltacS. Qed.
+  Goal isofhlevel (S n) (∏ x : X, Y x). hleveltacS. Qed.
+End hlevel_tac_test5.
+
+Section hlevel_tac_test6.
+  Hypothesis (X : Type) (f : X -> empty) .
+  Goal isofhlevel 1 X. hleveltac. Qed.
+  Goal isofhlevel 5 X. hleveltacS. Qed.
+
+Section hlevel_tac_test7.
+  Variables (n : nat) (X Y : Type) (ncoprod : isofhlevel (S n) (X ⨿ Y)).
+  Goal isofhlevel (S n) X. hleveltac. Qed.
+  Goal isofhlevel (S (S (S n))) X. hleveltacS. Qed.
+  Goal isofhlevel (S n) Y. hleveltac. Qed.
+  Goal isofhlevel (S (S (S n))) Y. hleveltacS. Qed.
+End hlevel_tac_test7.
+
+Section hlevel_tac_test09.
+  Variables (n : nat) (X : Type).
+  Goal isofhlevel 1 (isaprop X). hleveltac. Qed.
+  Goal isofhlevel 1 (isaset X). hleveltac. Qed.
+  Goal isofhlevel 1 (isofhlevel 1 X). hleveltac. Qed.
+  Goal isofhlevel 1 (isofhlevel n X). hleveltac. Qed.
+End hlevel_tac_test09.


### PR DESCRIPTION
This tactic is usful for proving goals of the form `isofhlevel n X`. It dissects commonly used type formers such as direct product, sigma, and pi, and then tries to analyze their components.

It reduces the burden on the programmer to remember the names of such lemmas, and to figure out which ones should be applied, in which branches, how many times, and in what order.

There is plenty of room for improvement, but this is a solid first step. If you all agree, I can add its use to other places in the standard library and/or add more features before merging. 