### PR TITLE
Fix defs of hasProducts etc, resolving #830

### DIFF
--- a/UniMath/CategoryTheory/limits/BinDirectSums.v
+++ b/UniMath/CategoryTheory/limits/BinDirectSums.v
@@ -123,7 +123,7 @@ Section def_bindirectsums.
 
   Definition mk_BinDirectSums (H : ∏ (a b : A), BinDirectSumCone a b) : BinDirectSums := H.
 
-  Definition has_BinDirectSums : UU := ishinh BinDirectSums.
+  Definition has_BinDirectSums : UU := ∏ (a b : A), ∥ BinDirectSumCone a b ∥.
 
   (** The direct sum object. *)
   Definition BinDirectSumConeOb {a b : A} (B : BinDirectSumCone a b) : A := pr1 (pr1 B).

--- a/UniMath/CategoryTheory/limits/FinOrdCoproducts.v
+++ b/UniMath/CategoryTheory/limits/FinOrdCoproducts.v
@@ -22,7 +22,8 @@ Section def_FinOrdCoproducts.
 
   Definition FinOrdCoproducts : UU :=
     ∏ (n : nat) (a : stn n -> C), CoproductCocone (stn n) C a.
-  Definition hasFinOrdCoproducts := ishinh FinOrdCoproducts.
+  Definition hasFinOrdCoproducts :=
+    ∏ (n : nat) (a : stn n -> C), ∥ CoproductCocone (stn n) C a ∥.
 
 End def_FinOrdCoproducts.
 

--- a/UniMath/CategoryTheory/limits/FinOrdProducts.v
+++ b/UniMath/CategoryTheory/limits/FinOrdProducts.v
@@ -22,7 +22,8 @@ Section def_FinOrdProducts.
 
   Definition FinOrdProducts : UU :=
     ∏ (n : nat) (a : stn n -> C), ProductCone (stn n) C a.
-  Definition hasFinOrdProducts := ishinh FinOrdProducts.
+  Definition hasFinOrdProducts :=
+    ∏ (n : nat) (a : stn n -> C), ∥ ProductCone (stn n) C a ∥.
 
 End def_FinOrdProducts.
 

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -59,7 +59,7 @@ Definition BinCoproductCocone (a b : C) :=
 
 
 Definition BinCoproducts := ∏ (a b : C), BinCoproductCocone a b.
-Definition hasBinCoproducts := ishinh BinCoproducts.
+Definition hasBinCoproducts := ∏ (a b : C), ∥ BinCoproductCocone a b ∥.
 
 Definition BinCoproductObject {a b : C} (CC : BinCoproductCocone a b) : C := pr1 (pr1 CC).
 Coercion BinCoproductObject : BinCoproductCocone >-> ob.

--- a/UniMath/CategoryTheory/limits/binproducts.v
+++ b/UniMath/CategoryTheory/limits/binproducts.v
@@ -52,7 +52,7 @@ Definition BinProductCone (c d : C) :=
 
 
 Definition BinProducts := ∏ (c d : C), BinProductCone c d.
-Definition hasBinProducts := ishinh BinProducts.
+Definition hasBinProducts := ∏ (c d : C), ∥ BinProductCone c d ∥.
 
 Definition BinProductObject {c d : C} (P : BinProductCone c d) : C := pr1 (pr1 P).
 Definition BinProductPr1 {c d : C} (P : BinProductCone c d): BinProductObject P --> c :=

--- a/UniMath/CategoryTheory/limits/coproducts.v
+++ b/UniMath/CategoryTheory/limits/coproducts.v
@@ -40,7 +40,7 @@ Definition CoproductCocone (a : I -> C) :=
           isCoproductCocone a (pr1 coia) (pr2 coia).
 
 Definition Coproducts := ∏ (a : I -> C), CoproductCocone a.
-Definition hasCoproducts := ishinh Coproducts.
+Definition hasCoproducts :=  ∏ (a : I -> C), ∥ CoproductCocone a ∥.
 
 Definition CoproductObject {a : I -> C} (CC : CoproductCocone a) : C := pr1 (pr1 CC).
 Definition CoproductIn {a : I -> C} (CC : CoproductCocone a): ∏ i, a i --> CoproductObject CC :=

--- a/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
@@ -87,7 +87,7 @@ Proof.
 Defined.
 
 Definition BinCoproducts := ∏ (a b : C), BinCoproductCocone a b.
-Definition hasBinCoproducts := ishinh BinCoproducts.
+Definition hasBinCoproducts := ∏ (a b : C), ∥ BinCoproductCocone a b ∥.
 
 Definition BinCoproductObject {a b : C} (CC : BinCoproductCocone a b) : C := colim CC.
 Definition BinCoproductIn1 {a b : C} (CC : BinCoproductCocone a b): a --> BinCoproductObject CC

--- a/UniMath/CategoryTheory/limits/graphs/binproducts.v
+++ b/UniMath/CategoryTheory/limits/graphs/binproducts.v
@@ -75,7 +75,7 @@ Proof.
 Defined.
 
 Definition BinProducts := ∏ (a b : C), BinProductCone a b.
-Definition BinProducts := ∏ (a b : C), ∥ BinProductCone a b ∥.
+Definition hasBinProducts := ∏ (a b : C), ∥ BinProductCone a b ∥.
 
 Definition BinProductObject {c d : C} (P : BinProductCone c d) : C := lim P.
 Definition BinProductPr1 {c d : C} (P : BinProductCone c d): C⟦BinProductObject P,c⟧ :=

--- a/UniMath/CategoryTheory/limits/graphs/binproducts.v
+++ b/UniMath/CategoryTheory/limits/graphs/binproducts.v
@@ -75,9 +75,7 @@ Proof.
 Defined.
 
 Definition BinProducts := ∏ (a b : C), BinProductCone a b.
-
-(* What is the best definition of this? *)
-(* Definition hasBinProducts (C : precategory) := ishinh (BinProducts C). *)
+Definition BinProducts := ∏ (a b : C), ∥ BinProductCone a b ∥.
 
 Definition BinProductObject {c d : C} (P : BinProductCone c d) : C := lim P.
 Definition BinProductPr1 {c d : C} (P : BinProductCone c d): C⟦BinProductObject P,c⟧ :=

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -372,7 +372,7 @@ Section Colims.
 
 Definition Colims (C : precategory) : UU := ∏ (g : graph) (d : diagram g C), ColimCocone d.
 Definition hasColims (C : precategory) : UU  :=
-  ∏ (g : graph) (d : diagram g C), ishinh (ColimCocone d).
+  ∏ (g : graph) (d : diagram g C), ∥ ColimCocone d ∥.
 
 (** Colimits of a specific shape *)
 Definition Colims_of_shape (g : graph) (C : precategory) : UU :=

--- a/UniMath/CategoryTheory/limits/products.v
+++ b/UniMath/CategoryTheory/limits/products.v
@@ -42,7 +42,7 @@ Definition ProductCone (ci : ∏ i, C) :=
              isProductCone ci (pr1 pp1p2) (pr2 pp1p2)).
 
 Definition Products := ∏ (ci : ∏ i, C), ProductCone ci.
-Definition hasProducts := ishinh Products.
+Definition hasProducts := ∏ (ci : ∏ i, C), ∥ ProductCone ci ∥.
 
 Definition ProductObject {c : ∏ i, C} (P : ProductCone c) : C := pr1 (pr1 P).
 Definition ProductPr {c : ∏ i, C} (P : ProductCone c) : ∏ i, ProductObject P --> c i :=


### PR DESCRIPTION
Mostly just implementing the fix described in #830.  A couple of notes:

- In the fixes, I’ve used the UniCode notation for truncation, i.e. ` ∥ ProductCone ci ∥` not `ishinh (ProductCone ci)` — it seems much more reasonable.  I’ve not however updated the definitions that were already correct (e.g. `hasLims`) to also use the notation.  I can update those as well for consistency if desired.

- I’m think I found all the definitions that need fixing, but it would be good if someone else (Anders?) could also search in case I missed any.