### PR TITLE
explicit apt-get commands in Travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,10 @@ sudo: 		required
 dist: 		trusty
 git:
   submodules:   false
-addons:
-  apt:
-    sources:
-      - avsm
-    packages:
-      - opam
-      - aspcud
-      - time
-      - libgtk2.0-dev
-      - libgtksourceview2.0-dev
-      - emacs
+install:
+  - sudo add-apt-repository -y ppa:avsm
+  - sudo apt-get update
+  - sudo apt-get install -y opam aspcud time libgtk2.0-dev libgtksourceview2.0-dev emacs
 # build coqide along with the Tactics package, just because it's a short package
 env:
   - PACKAGES="Foundations Combinatorics Algebra NumberSystems PAdics"
@@ -31,7 +24,7 @@ env:
   - FOUNDATIONS_CHANGE_ERROR=yes BUILD_ALSO="check-for-change-to-Foundations enforce-listing-of-proof-files"
 # building Coq in a separate stage folds up the output in the log:
 before_script:
-  - opam init --yes --no-setup --compiler=4.06.0
+  - opam init --yes --no-setup
   - eval $(opam config env)
   - opam install lablgtk camlp5 num --yes --verbose
   - time make build-coq


### PR DESCRIPTION
Experiment to try to solve the problem with intermittently failing Travis builds by using explicit apt-get commands.

Note that as far as I can tell, failing builds will fail quickly no matter whether `--compiler=4.06.0` is used or not. Without the option, the error message will be `[ERROR] No OCaml compiler found in path.` and with the option, it will be `opam: unknown option --compiler`. Compare [failing build a](https://travis-ci.org/UniMath/UniMath/jobs/320394439) and [failing build b](https://travis-ci.org/UniMath/UniMath/jobs/322615798).