### PR TITLE
Expunge [cancel_precomposition] and [cancel_postcomposition] from library (take 2)

### DIFF
--- a/UniMath/CategoryTheory/Abelian.v
+++ b/UniMath/CategoryTheory/Abelian.v
@@ -24,6 +24,7 @@
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.Algebra.Monoids_and_Groups.
 
@@ -602,7 +603,7 @@ Section abelian_equalizers.
     use (pathscomp0 (! (maponpaths (λ h : _, PullbackPr1 Pb · h) H1))).
     use (pathscomp0 _ ((id_right (PullbackPr2 Pb)))).
     use (pathscomp0 _ (maponpaths (λ h : _, PullbackPr2 Pb · h) H2)).
-    rewrite assoc. rewrite assoc. apply cancel_postcomposition.
+    rewrite assoc. rewrite assoc. apply maponpaths_2.
     apply PullbackSqrCommutes.
   Qed.
 
@@ -619,7 +620,7 @@ Section abelian_equalizers.
     assert (H2 : BinProductArrow A BinProd (identity x) f2 · (BinProductPr2 A BinProd) = f2) by
         apply BinProductPr2Commutes.
     rewrite <- H1. rewrite <- H2. rewrite assoc. rewrite assoc.
-    apply cancel_postcomposition. unfold BinProd.
+    apply maponpaths_2. unfold BinProd.
     set (X := PullbackSqrCommutes (Equalizer_Pullback f1 f2)).
     rewrite <- H in X. apply X.
   Qed.
@@ -716,7 +717,7 @@ Section abelian_equalizers.
     use (pathscomp0 (!(maponpaths (λ h : _, h · PushoutIn1 Po) H1))).
     use (pathscomp0 _ ((id_left (PushoutIn2 Po)))).
     use (pathscomp0 _ (maponpaths (λ h : _, h · PushoutIn2 Po) H2)).
-    rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
+    rewrite <- assoc. rewrite <- assoc. apply maponpaths.
     apply PushoutSqrCommutes.
   Qed.
 
@@ -730,7 +731,7 @@ Section abelian_equalizers.
     set (Pb := Coequalizer_Pushout f1 f2).
     rewrite <- (BinCoproductIn2Commutes A _ _ BinCoprod _ (identity x) f1).
     rewrite <- (BinCoproductIn2Commutes A _ _ BinCoprod _ (identity x) f2).
-    repeat rewrite <- assoc. apply cancel_precomposition.
+    repeat rewrite <- assoc. apply maponpaths.
     set (X := PushoutSqrCommutes (Coequalizer_Pushout f1 f2)).
     rewrite <- H in X. apply X.
   Qed.
@@ -1104,7 +1105,7 @@ Section abelian_factorization.
     set (com0 := CokernelCommutes (to_Zero A) (CoImage f) y f (CoIm_ar_eq f)).
     apply pathsinv0 in com0. use (pathscomp0 com0).
     (* Cancel precomposition *)
-    rewrite <- assoc. apply cancel_precomposition.
+    rewrite <- assoc. apply maponpaths.
     (* Commutativity of kernel *)
     set (com1 := KernelCommutes (to_Zero A) (Image f) (CoImage f) (CoIm_ar f) (CoIm_to_Im_eq2 f)).
     apply pathsinv0 in com1. use (pathscomp0 com1).
@@ -1138,7 +1139,7 @@ Section abelian_factorization.
       {
         set (tmp := CokernelCompZero (to_Zero A) (EpiToCokernel E)).
         rewrite <- tmp.
-        apply cancel_precomposition.
+        apply maponpaths.
         unfold E. apply idpath.
       }
       assert (e : (KernelArrow (to_Kernels A _ _ E)) · f = ZeroArrow (to_Zero A) _ _).
@@ -1154,7 +1155,7 @@ Section abelian_factorization.
         set (tmpar1 := CoIm_to_Im f · KernelArrow (Image f)).
         set (tmpar2 := CoequalizerOut q y tmpar1 H).
         rewrite <- (ZeroArrow_comp_left A (to_Zero A) _ _ _ tmpar2).
-        apply cancel_postcomposition.
+        apply maponpaths_2.
         rewrite <- assoc.
         rewrite e0. apply idpath.
       }
@@ -1167,7 +1168,7 @@ Section abelian_factorization.
         fold l.
         rewrite <- (ZeroArrow_comp_right A (to_Zero A) _ _ _ l).
         rewrite <- assoc.
-        apply cancel_precomposition.
+        apply maponpaths.
         unfold CoImage.
         apply CokernelCompZero.
       }
@@ -1218,7 +1219,7 @@ Section abelian_factorization.
                    ZeroArrow (to_Zero A) (MonicToKernel M) _).
       {
         use (pathscomp0 _ (KernelCompZero (to_Zero A) (MonicToKernel M))).
-        apply cancel_precomposition. apply idpath.
+        apply maponpaths. apply idpath.
       }
       assert (e : f · (CokernelArrow (to_Cokernels A _ _ M)) = ZeroArrow (to_Zero A) _ _).
       {
@@ -1233,7 +1234,7 @@ Section abelian_factorization.
         set (tmpar2 := EqualizerIn q x tmpar1 H).
         rewrite <- (ZeroArrow_comp_right A (to_Zero A) _ _ _ tmpar2).
         rewrite <- assoc. rewrite <- assoc.
-        apply cancel_precomposition.
+        apply maponpaths.
         rewrite assoc.
         rewrite e0. apply idpath.
       }
@@ -1246,7 +1247,7 @@ Section abelian_factorization.
         fold l.
         rewrite <- (ZeroArrow_comp_left A (to_Zero A) _ _ _ l).
         rewrite assoc.
-        apply cancel_postcomposition.
+        apply maponpaths_2.
         unfold Image.
         apply KernelCompZero.
       }
@@ -1256,7 +1257,7 @@ Section abelian_factorization.
                    KernelArrow (Image f)).
       {
         rewrite <- com2. rewrite <- assoc.
-        apply cancel_precomposition. unfold ker.
+        apply maponpaths. unfold ker.
         apply idpath.
       }
       assert (e3 : (KernelIn (to_Zero A) ker (Image f) _ e1) · (EqualizerArrow q)  = identity _).

--- a/UniMath/CategoryTheory/AbelianPushoutPullback.v
+++ b/UniMath/CategoryTheory/AbelianPushoutPullback.v
@@ -9,6 +9,7 @@
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.CategoryTheory.limits.zero.
 Require Import UniMath.CategoryTheory.limits.pushouts.
@@ -207,7 +208,7 @@ Section pushout_monic_pullback_epi.
                             (to_Zero A) K _ h (AbelianPushoutMonicisPullback_eq f g Hk)).
              cbn in comm. rewrite <- comm in Hk'. clear comm.
              apply (AbelianPushoutMonic2 f g Po'). rewrite <- Hk'.
-             cbn. rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
+             cbn. rewrite <- assoc. rewrite <- assoc. apply maponpaths.
              rewrite assoc. rewrite assoc. apply pathsinv0.
              use CoequalizerEqAr.
         * intros y0. apply isapropdirprod.
@@ -360,7 +361,7 @@ Section pushout_monic_pullback_epi.
                             (to_Zero A) CK _ h (AbelianPullbackEpiisPushout1_eq f g Hk)).
              cbn in comm. rewrite <- comm in Hk'. clear comm.
              apply (AbelianPullbackEpi2 f g Pb'). rewrite <- Hk'.
-             cbn. rewrite assoc. rewrite assoc. apply cancel_postcomposition.
+             cbn. rewrite assoc. rewrite assoc. apply maponpaths_2.
              rewrite <- assoc. rewrite <- assoc. apply pathsinv0.
              use EqualizerEqAr.
         * intros y0. apply isapropdirprod.

--- a/UniMath/CategoryTheory/AbelianToAdditive.v
+++ b/UniMath/CategoryTheory/AbelianToAdditive.v
@@ -8,6 +8,8 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.PartA.
+
 Require Import UniMath.Algebra.Monoids_and_Groups.
 
 Require Import UniMath.CategoryTheory.total2_paths.
@@ -394,7 +396,7 @@ Section abelian_is_additive.
     set (g := CokernelOut (to_Zero A) (CokernelOfDiagonal bpX) (CokernelOfDiagonal bpY) ar H).
     set (com := CokernelCommutes
                   (to_Zero A) (CokernelOfDiagonal bpX) (CokernelOfDiagonal bpY) ar H).
-    rewrite <- com. apply cancel_precomposition.
+    rewrite <- com. apply maponpaths.
     (* rewrite and use com *)
     set (e1 := Abelian_op_eq_IdZero X).
     set (e2 := Abelian_op_eq_IdZero Y).
@@ -418,7 +420,7 @@ Section abelian_is_additive.
     rewrite <- (id_right f). rewrite <- e2. rewrite assoc.
     rewrite <- e3. unfold ar'. rewrite <- assoc. fold ar.
     rewrite <- id_left. cbn. rewrite <- e1. rewrite <- assoc.
-    apply cancel_precomposition. apply pathsinv0.
+    apply maponpaths. apply pathsinv0.
     apply com.
   Qed.
 
@@ -444,7 +446,7 @@ Section abelian_is_additive.
     use BinProductArrowsEq.
     - rewrite <- assoc. rewrite com1.
       rewrite BinProductPr1Commutes. rewrite assoc.
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       use BinProductArrowsEq.
       + rewrite BinProductPr1Commutes. rewrite <- assoc.
         rewrite BinProductPr1Commutes. rewrite assoc.
@@ -458,7 +460,7 @@ Section abelian_is_additive.
         apply idpath.
     - rewrite <- assoc. rewrite com2.
       rewrite BinProductPr2Commutes. rewrite assoc.
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       use BinProductArrowsEq.
       + rewrite BinProductPr1Commutes. rewrite <- assoc.
         rewrite BinProductPr1Commutes. rewrite assoc.
@@ -508,7 +510,7 @@ Section abelian_is_additive.
     rewrite assoc.
     set (tmp1 := AbelianPreCat_op_eq2 a c b d).
     unfold Abelian_mor_to_BinProd, Abelian_mor_from_to_BinProd in tmp1.
-    rewrite tmp1. apply cancel_postcomposition.
+    rewrite tmp1. apply (maponpaths_2 compose).
     (* Use idpath *)
     unfold Abelian_minus_op. apply idpath.
   Qed.
@@ -552,7 +554,7 @@ Section abelian_is_additive.
     {
       use (pathscomp0 _ (ZeroArrow_comp_left A (to_Zero A) _ _ _
                                              (CokernelArrow (CokernelOfDiagonal bpY)))).
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       use BinProductArrowsEq.
       - rewrite BinProductPr1Commutes.
         rewrite ZeroArrow_comp_left. apply idpath.
@@ -747,7 +749,7 @@ Section abelian_is_additive.
       split.
       + intros x' x'0. unfold to_premor.
         cbn. unfold Abelian_op. unfold Abelian_minus_op.
-        cbn in x', x'0. rewrite assoc. apply cancel_postcomposition.
+        cbn in x', x'0. rewrite assoc. apply maponpaths_2.
         set (bpz := to_BinProducts A z z).
         assert (e : BinProductArrow
                       A bpz (f · x')
@@ -805,7 +807,7 @@ Section abelian_is_additive.
         repeat rewrite assoc.
         rewrite <- (postcompWithBinProductArrow A _ (to_BinProducts A y y)).
         repeat rewrite <- assoc.
-        apply cancel_precomposition.
+        apply maponpaths.
         unfold BinProductOfArrows.
         apply tmp.
       + unfold to_postmor. cbn.

--- a/UniMath/CategoryTheory/AdditiveFunctors.v
+++ b/UniMath/CategoryTheory/AdditiveFunctors.v
@@ -19,6 +19,7 @@
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids_and_Groups.
@@ -325,12 +326,12 @@ Section additivefunctor_preserves_bindirectsums.
     rewrite <- (id_right mor). rewrite assoc. unfold invmor. rewrite to_postmor_linear'.
     use (pathscomp0 (! (AdditiveFunctorPreservesBinDirectSums_isBinCoproductCocone_id2' F DS))).
     use to_binop_eq.
-    - fold BDS. apply cancel_postcomposition. rewrite <- assoc. rewrite <- assoc.
-      apply cancel_precomposition.
+    - fold BDS. apply maponpaths_2. rewrite <- assoc. rewrite <- assoc.
+      apply maponpaths.
       rewrite (BinDirectSumPr1Commutes B BDS _ (# F (to_Pr1 A DS)) (# F (to_Pr2 A DS))).
       apply idpath.
-    - fold BDS. apply cancel_postcomposition. rewrite <- assoc. rewrite <- assoc.
-      apply cancel_precomposition.
+    - fold BDS. apply maponpaths_2. rewrite <- assoc. rewrite <- assoc.
+      apply maponpaths.
       rewrite (BinDirectSumPr2Commutes B BDS _ (# F (to_Pr1 A DS)) (# F (to_Pr2 A DS))).
       apply idpath.
   Qed.
@@ -462,12 +463,12 @@ Section additivefunctor_preserves_bindirectsums.
     unfold invmor. rewrite to_premor_linear'. rewrite assoc. rewrite assoc.
     use (pathscomp0 (! (AdditiveFunctorPreservesBinDirectSums_isBinProduct_id2' F DS))).
     use to_binop_eq.
-    - fold BDS. apply cancel_postcomposition.
-      rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition. rewrite assoc.
+    - fold BDS. apply maponpaths_2.
+      rewrite <- assoc. rewrite <- assoc. apply maponpaths. rewrite assoc.
       rewrite (BinDirectSumIn1Commutes B BDS _ (# F (to_In1 A DS)) (# F (to_In2 A DS))).
       apply idpath.
-    - fold BDS. apply cancel_postcomposition.
-      rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition. rewrite assoc.
+    - fold BDS. apply maponpaths_2.
+      rewrite <- assoc. rewrite <- assoc. apply maponpaths. rewrite assoc.
       rewrite (BinDirectSumIn2Commutes B BDS _ (# F (to_In1 A DS)) (# F (to_In2 A DS))).
       apply idpath.
   Qed.
@@ -560,14 +561,14 @@ Section additivefunctor_criteria.
       + cbn. intros t.
         use (pathscomp0 (!(BinDirectSumIn1Commutes B BDS _ t (ZeroArrow (to_Zero B) _ _)))).
         use (pathscomp0 _ (BinDirectSumIn2Commutes B BDS _ t (ZeroArrow (to_Zero B) _ _))).
-        cbn. apply cancel_precomposition. apply idpath.
+        cbn. apply maponpaths. apply idpath.
     - intros a.
       use tpair.
       + apply (ZeroArrow (to_Zero B) _ _).
       + cbn. intros t.
         use (pathscomp0 (!(BinDirectSumPr1Commutes B BDS _ t (ZeroArrow (to_Zero B) _ _)))).
         use (pathscomp0 _ (BinDirectSumPr2Commutes B BDS _ t (ZeroArrow (to_Zero B) _ _))).
-        cbn. apply cancel_postcomposition. apply idpath.
+        cbn. apply maponpaths_2. apply idpath.
   Qed.
 
   (** F preserves unel *)
@@ -846,7 +847,7 @@ Section def_additive_equivalence.
     use (pre_comp_with_z_iso_is_inj (AddEquivUnitIso AE x)). rewrite assoc.
     rewrite (is_inverse_in_precat1 (AddEquivUnitIso AE x)). rewrite id_left.
     use (post_comp_with_z_iso_is_inj (AddEquivUnitIso AE x')).
-    rewrite AddEquivUnitComm. rewrite <- assoc. apply cancel_precomposition. cbn.
+    rewrite AddEquivUnitComm. rewrite <- assoc. apply maponpaths. cbn.
     rewrite <- assoc.
     set (tmp := is_inverse_in_precat2 (AddEquivUnitIso AE x')). cbn in tmp. cbn. rewrite tmp.
     rewrite id_right. apply idpath.
@@ -862,7 +863,7 @@ Section def_additive_equivalence.
     rewrite (is_inverse_in_precat1 (AddEquivCounitIso AE x)). rewrite id_left.
     use (post_comp_with_z_iso_is_inj (AddEquivCounitIso AE x')).
     use (pathscomp0 (AddEquivCounitComm AE _ _ f)). rewrite <- assoc.
-    apply cancel_precomposition. cbn.
+    apply maponpaths. cbn.
     rewrite <- assoc.
     set (tmp := is_inverse_in_precat2 (AddEquivCounitIso AE x')). cbn in tmp. cbn. rewrite tmp.
     rewrite id_right. apply idpath.

--- a/UniMath/CategoryTheory/Adjunctions.v
+++ b/UniMath/CategoryTheory/Adjunctions.v
@@ -23,7 +23,7 @@ Contents :
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
-
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -196,21 +196,21 @@ Coercion adjunction_data_from_is_left_adjoint {A B : precategory}
     - split; intros a; simpl.
       + rewrite !id_left, !id_right, <-functor_id, <- H11, !functor_comp, <-!assoc.
         apply maponpaths; rewrite assoc.
-        etrans; [eapply cancel_postcomposition, pathsinv0, functor_comp|].
+        etrans; [eapply maponpaths_2, pathsinv0, functor_comp|].
         etrans.
-        apply cancel_postcomposition, maponpaths.
+        apply maponpaths_2, maponpaths.
         apply (nat_trans_ax eps1 (F1 a) (G2 (F2 (F1 a))) (eta2 (F1 a))).
         simpl; rewrite functor_comp, <- assoc.
         etrans; [eapply maponpaths, H21|].
         now apply id_right.
       + rewrite !id_left, !id_right, <- functor_id, <- H22, !functor_comp, assoc.
-        apply cancel_postcomposition; rewrite <- assoc.
+        apply maponpaths_2; rewrite <- assoc.
         etrans; [eapply maponpaths, pathsinv0, functor_comp|].
         etrans.
         eapply maponpaths, maponpaths, pathsinv0.
         apply (nat_trans_ax eta2 (F1 (G1 (G2 a))) (G2 a) (eps1 _)).
         simpl; rewrite functor_comp, assoc.
-        etrans; [apply cancel_postcomposition, H12|].
+        etrans; [apply maponpaths_2, H12|].
         now apply id_left.
   Defined.
 
@@ -241,21 +241,21 @@ Coercion adjunction_data_from_is_left_adjoint {A B : precategory}
       + split.
         * unfold triangle_1_statement.
           simpl; intro a; rewrite assoc, functor_comp.
-          etrans; [ apply cancel_postcomposition; rewrite <- assoc;
+          etrans; [ apply maponpaths_2; rewrite <- assoc;
                     apply maponpaths, (nat_trans_ax αinv)|].
           etrans; [ rewrite assoc, <- !assoc;
                     apply maponpaths, maponpaths, (nat_trans_ax β')|].
           simpl; rewrite assoc.
-          etrans; [ apply cancel_postcomposition, (nat_trans_ax αinv)|].
+          etrans; [ apply maponpaths_2, (nat_trans_ax αinv)|].
           rewrite assoc.
-          etrans; [ apply cancel_postcomposition; rewrite <- assoc;
+          etrans; [ apply maponpaths_2; rewrite <- assoc;
                     apply maponpaths, HF1|].
           now rewrite id_right; apply (nat_trans_eq_pointwise (iso_after_iso_inv αiso)).
         * unfold triangle_2_statement in *.
           simpl; intro b; rewrite functor_comp, assoc.
-          etrans; [ apply cancel_postcomposition; rewrite <- assoc;
+          etrans; [ apply maponpaths_2; rewrite <- assoc;
                     eapply maponpaths, pathsinv0, functor_comp|].
-          etrans; [ apply cancel_postcomposition, maponpaths, maponpaths,
+          etrans; [ apply maponpaths_2, maponpaths, maponpaths,
                     (nat_trans_eq_pointwise (iso_inv_after_iso αiso))|].
           cbn. rewrite (functor_id F'), id_right. apply (HF2 b).
   Defined.
@@ -573,7 +573,7 @@ Section HomSetIso_from_Adjunction.
     rewrite X2; clear X2.
     rewrite assoc.
     intermediate_path (identity _ · f).
-    - apply cancel_postcomposition.
+    - apply maponpaths_2.
       apply triangle_id_left_ad.
     - apply id_left.
   Qed.

--- a/UniMath/CategoryTheory/Categories.v
+++ b/UniMath/CategoryTheory/Categories.v
@@ -267,22 +267,6 @@ Proof.
   exact (identity a).
 Defined.
 
-Lemma cancel_postcomposition {C : precategory_data} {a b c: C}
-   (f f' : a --> b) (g : b --> c) : f = f' -> f · g = f' · g.
-Proof.
-  intro H.
-  induction H.
-  apply idpath.
-Defined.
-
-Lemma cancel_precomposition (C : precategory_data) (a b c: C)
-   (f f' : b --> c) (g : a --> b) : f = f' -> g · f = g · f'.
-Proof.
-  intro H.
-  induction H.
-  apply idpath.
-Defined.
-
 (** * Setcategories: Precategories whose objects and morphisms are sets *)
 
 Definition setcategory := total2 (

--- a/UniMath/CategoryTheory/CocontFunctors.v
+++ b/UniMath/CategoryTheory/CocontFunctors.v
@@ -60,6 +60,7 @@ Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.NaturalNumbers.
 
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.total2_paths.
@@ -156,7 +157,7 @@ induction j as [|j IHj].
     * now rewrite <- (IHj h h0), assoc.
     * destruct p; simpl.
       destruct (natlehchoice4 _ _ h); [destruct (isirreflnatlth _ h0)|].
-      apply cancel_postcomposition, maponpaths, isasetnat.
+      apply maponpaths_2, maponpaths, isasetnat.
   + destruct p, (isirreflnatlth _ HSij).
 Qed.
 
@@ -169,10 +170,10 @@ destruct j.
 - simpl; destruct (natlehchoice4 i (S j) HiSj).
   + destruct (natlehchoice4 _ _ h).
     * destruct (natlehchoice4 _ _ Hij); [|destruct p, (isirreflnatlth _ h0)].
-      apply cancel_postcomposition, cancel_postcomposition, maponpaths, isasetbool.
+      apply maponpaths_2, maponpaths_2, maponpaths, isasetbool.
     * destruct p; simpl.
       destruct (natlehchoice4 _ _ Hij); [destruct (isirreflnatlth _ h0)|].
-      apply cancel_postcomposition, maponpaths, isasetnat.
+      apply maponpaths_2, maponpaths, isasetnat.
   + generalize Hij; rewrite p; intros H.
     destruct (isirreflnatlth _ H).
 Qed.
@@ -333,7 +334,7 @@ destruct e.
 induction n as [|n IHn].
 - now apply InitialArrowUnique.
 - simpl; rewrite assoc.
-  apply cancel_postcomposition, pathsinv0.
+  apply maponpaths_2, pathsinv0.
   eapply pathscomp0; [|simpl; apply functor_comp].
   now apply maponpaths, pathsinv0, IHn.
 Qed.
@@ -354,9 +355,9 @@ destruct n as [|n].
 - now apply InitialArrowUnique.
 - rewrite assoc, unfold_inv_from_iso_α.
   eapply pathscomp0;
-    [apply cancel_postcomposition, (colimArrowCommutes shiftColimCocone)|].
+    [apply maponpaths_2, (colimArrowCommutes shiftColimCocone)|].
   simpl; rewrite assoc, <- functor_comp.
-  apply cancel_postcomposition, maponpaths, (colimArrowCommutes CC).
+  apply maponpaths_2, maponpaths, (colimArrowCommutes CC).
 Qed.
 
 Local Definition ad_mor : algebra_mor F α_alg Aa := tpair _ _ ad_is_algebra_mor.
@@ -375,7 +376,7 @@ induction n as [|n IHn]; simpl.
 - rewrite <- IHn, functor_comp, <- assoc.
   eapply pathscomp0; [| eapply maponpaths; apply hf].
   rewrite assoc.
-  apply cancel_postcomposition, pathsinv0, (iso_inv_to_right _ _ _ _ _ α).
+  apply maponpaths_2, pathsinv0, (iso_inv_to_right _ _ _ _ _ α).
   rewrite unfold_inv_from_iso_α; apply pathsinv0.
   now eapply pathscomp0; [apply (colimArrowCommutes shiftColimCocone)|].
 Qed.
@@ -426,7 +427,7 @@ Proof.
 use mk_cocone.
 - intro v; apply (pr1 α (dob d v) · coconeIn ccGy v).
 - abstract (simpl; intros u v e; rewrite <- (coconeInCommutes ccGy u v e), !assoc;
-            apply cancel_postcomposition, nat_trans_ax).
+            apply maponpaths_2, nat_trans_ax).
 Defined.
 
 Lemma αinv_f_commutes y (ccGy : cocone (mapdiagram G d) y) (f : D⟦F L,y⟧)
@@ -434,10 +435,10 @@ Lemma αinv_f_commutes y (ccGy : cocone (mapdiagram G d) y) (f : D⟦F L,y⟧)
        ∏ v, # G (coconeIn cc v) · (pr1 αinv L · f) = coconeIn ccGy v.
 Proof.
 intro v; rewrite assoc.
-eapply pathscomp0; [apply cancel_postcomposition, nat_trans_ax|].
+eapply pathscomp0; [apply maponpaths_2, nat_trans_ax|].
 rewrite <- assoc; eapply pathscomp0; [apply maponpaths, (Hf v)|]; simpl; rewrite assoc.
 eapply pathscomp0.
-  apply cancel_postcomposition.
+  apply maponpaths_2.
   apply (nat_trans_eq_pointwise (@iso_after_iso_inv [C,D,hsD] _ _ (isopair _ Hα))).
 now rewrite id_left.
 Qed.
@@ -453,13 +454,13 @@ transparent assert (HH : (∑ x : D ⟦ F L, y ⟧,
             coconeIn (mapcocone F d cc) v · x = coconeIn (ccFy y ccGy) v)).
 { use tpair.
   - apply (pr1 α L · f').
-  - cbn. abstract (intro v; rewrite <- Hf', !assoc; apply cancel_postcomposition, nat_trans_ax).
+  - cbn. abstract (intro v; rewrite <- Hf', !assoc; apply maponpaths_2, nat_trans_ax).
 }
 apply pathsinv0.
 generalize (maponpaths pr1 (HHf HH)); intro Htemp; simpl in *.
 rewrite <- Htemp; simpl; rewrite assoc.
 eapply pathscomp0.
-  apply cancel_postcomposition.
+  apply maponpaths_2.
   apply (nat_trans_eq_pointwise (@iso_after_iso_inv [C,D,hsD] _ _ (isopair _ Hα))).
 now apply id_left.
 Qed.
@@ -909,7 +910,7 @@ use tpair.
   abstract (intro n;
     rewrite <- idtoiso_postcompose, assoc;
     eapply pathscomp0;
-      [eapply cancel_postcomposition, (toforallpaths _ _ _ (p1 n) i)|];
+      [eapply maponpaths_2, (toforallpaths _ _ _ (p1 n) i)|];
     unfold ifI, ifI_eq; simpl;
     destruct (HI i i); [|destruct (n0 (idpath _))];
     rewrite idtoiso_postcompose, idpath_transportf;
@@ -1278,13 +1279,13 @@ unfold BinProduct_of_functors_mor, map_to_K.
 destruct (natlthorgeh i j) as [h|h].
 - destruct (natlthorgeh i (S j)) as [h0|h0].
   * rewrite assoc, <- (coconeInCommutes ccK j (S j) (idpath _)), assoc; simpl.
-    apply cancel_postcomposition; unfold fun_lt.
+    apply maponpaths_2; unfold fun_lt.
     rewrite BinProductOfArrows_comp, id_left.
     eapply pathscomp0; [apply BinProductOfArrows_comp|].
     rewrite id_right.
     apply BinProductOfArrows_eq; trivial; rewrite id_left; simpl.
     destruct (natlehchoice4 i j h0) as [h1|h1].
-    + apply cancel_postcomposition, maponpaths, maponpaths, isasetbool.
+    + apply (maponpaths_2 compose), maponpaths, maponpaths, isasetbool.
     + destruct h1; destruct (isirreflnatlth _ h).
   * destruct (isirreflnatlth _ (natlthlehtrans _ _ _ (natlthtolths _ _ h) h0)).
 - destruct (natlthorgeh i (S j)) as [h0|h0].
@@ -1294,22 +1295,22 @@ destruct (natlthorgeh i j) as [h|h].
       { destruct h2; destruct (isirreflnatlth _ h0). }
     + destruct h1; simpl.
       rewrite <- (coconeInCommutes ccK i (S i) (idpath _)), assoc.
-      eapply pathscomp0; [apply cancel_postcomposition, BinProductOfArrows_comp|].
+      eapply pathscomp0; [apply maponpaths_2, BinProductOfArrows_comp|].
       rewrite id_left, id_right.
-      apply cancel_postcomposition, BinProductOfArrows_eq; trivial.
+      apply maponpaths_2, BinProductOfArrows_eq; trivial.
       simpl; destruct (natlehchoice4 i i h0) as [h1|h1]; [destruct (isirreflnatlth _ h1)|].
       apply maponpaths, maponpaths, isasetnat.
   * destruct (natgehchoice i j h) as [h1|h1].
     + destruct (natgehchoice i (S j) h0) as [h2|h2].
       { unfold fun_gt; rewrite assoc.
-        eapply pathscomp0; [eapply cancel_postcomposition, BinProductOfArrows_comp|].
+        eapply pathscomp0; [eapply maponpaths_2, BinProductOfArrows_comp|].
         rewrite id_right.
-        apply cancel_postcomposition, BinProductOfArrows_eq; trivial.
+        apply maponpaths_2, BinProductOfArrows_eq; trivial.
         now rewrite <- (chain_mor_right h1 h2). }
       { destruct h; unfold fun_gt; simpl.
         generalize h1; clear h1.
         rewrite h2; intro h1.
-        apply cancel_postcomposition.
+        apply maponpaths_2.
         apply BinProductOfArrows_eq; trivial; simpl.
         destruct (natlehchoice4 j j h1); [destruct (isirreflnatlth _ h)|].
         apply maponpaths, maponpaths, isasetnat. }
@@ -1410,7 +1411,7 @@ Proof.
   unfold map_to_K.
   destruct (natlthorgeh (S i) j).
   + destruct (natlthorgeh i j).
-    * rewrite assoc; apply cancel_postcomposition.
+    * rewrite assoc; apply maponpaths_2.
       unfold f, fun_lt; simpl.
       eapply pathscomp0; [apply BinProductOfArrows_comp|].
       now rewrite id_right, <- (chain_mor_right h0 h).
@@ -1424,14 +1425,14 @@ Proof.
         - destruct (natgehchoice i j h).
           + destruct h.
             rewrite <- (coconeInCommutes ccK i _ (idpath _)); simpl.
-            rewrite !assoc; apply cancel_postcomposition.
+            rewrite !assoc; apply maponpaths_2.
             unfold f, fun_gt.
             rewrite BinProductOfArrows_comp.
             eapply pathscomp0; [apply BinProductOfArrows_comp|].
             now rewrite !id_left, !id_right, <- (chain_mor_left h1 h0).
           + destruct p.
             rewrite <- (coconeInCommutes ccK i _ (idpath _)), assoc.
-            apply cancel_postcomposition.
+            apply maponpaths_2.
             unfold f, fun_gt.
             eapply pathscomp0; [apply BinProductOfArrows_comp|].
             rewrite id_left, id_right.
@@ -1441,7 +1442,7 @@ Proof.
        }
     * destruct p, h.
       destruct (natlthorgeh i (S i)); [|destruct (negnatgehnsn _ h)].
-      apply cancel_postcomposition; unfold f, fun_lt.
+      apply maponpaths_2; unfold f, fun_lt.
       apply BinProductOfArrows_eq; trivial; simpl.
       destruct (natlehchoice4 i i h); [destruct (isirreflnatlth _ h0)|].
       assert (H : idpath (S i) = maponpaths S p). apply isasetnat.
@@ -1468,7 +1469,7 @@ Proof.
   simpl; destruct h, p.
   intros HHH.
   rewrite <- HHH, assoc.
-  apply cancel_postcomposition.
+  apply maponpaths_2.
   unfold colimIn; simpl; unfold BinProduct_of_functors_mor; simpl.
   apply pathsinv0.
   eapply pathscomp0; [apply BinProductOfArrows_comp|].
@@ -1492,7 +1493,7 @@ Proof.
     induction (natlthorgeh i j) as [h|h].
     * rewrite <- (p j); unfold fun_lt.
       rewrite !assoc.
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       unfold colimIn; simpl; unfold BinProduct_of_functors_mor; simpl.
       eapply pathscomp0; [apply BinProductOfArrows_comp|].
       apply pathsinv0.
@@ -1502,7 +1503,7 @@ Proof.
       apply (maponpaths pr1 (chain_mor_coconeIn cAB LM ccLM i j h)).
     * destruct (natgehchoice i j h).
       { unfold fun_gt; rewrite <- (p i), !assoc.
-        apply cancel_postcomposition.
+        apply maponpaths_2.
         unfold colimIn; simpl; unfold BinProduct_of_functors_mor; simpl.
         eapply pathscomp0; [apply BinProductOfArrows_comp|].
         apply pathsinv0.
@@ -1510,7 +1511,7 @@ Proof.
         now rewrite !id_left, id_right, <- (chain_mor_coconeIn cAB LM ccLM _ _ h0). }
       { destruct p0.
         rewrite <- (p i), assoc.
-        apply cancel_postcomposition.
+        apply maponpaths_2.
         unfold colimIn; simpl; unfold BinProduct_of_functors_mor; simpl.
         eapply pathscomp0; [apply BinProductOfArrows_comp|].
         now rewrite id_left, id_right. }

--- a/UniMath/CategoryTheory/DisplayedCats/Core.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Core.v
@@ -253,7 +253,7 @@ Lemma mor_disp_transportf_postwhisker
     {x y z : C} {f f' : x --> y} (ef : f = f') {g : y --> z}
     {xx : D x} {yy} {zz} (ff : xx -->[f] yy) (gg : yy -->[g] zz)
   : (transportf _ ef ff) ;; gg
-  = transportf _ (cancel_postcomposition _ _ g ef) (ff ;; gg).
+  = transportf _ (maponpaths_2 _ ef _) (ff ;; gg).
 Proof.
   destruct ef; apply idpath.
 Qed.
@@ -270,23 +270,23 @@ Qed.
 
 (* TODO: use the following lemmas in more of the displayed category proofs. Most instances of [mor_disp_transportf_Xwhisker] are places that can be simplified with these. *)
 (* TODO: consider naming of [cancel_Xcomposition_disp].  Currently follows the UniMath base lemmas, but those are bad names — cancellation properties traditionally mean things like like [ ax = ay -> x = y ], whereas these lemmas are the converse of that. *)
-Lemma cancel_postcomposition_disp {C} {D : disp_cat C}
+Lemma maponpaths_2_disp {C} {D : disp_cat C}
   {x y z} {f f' : x --> y} {e : f' = f} {g : y --> z}
   {xx : D x} {yy} {zz}
   {ff : xx -->[f] yy} {ff' : xx -->[f'] yy} (gg : yy -->[g] zz)
   (ee : ff = transportf _ e ff')
-: ff ;; gg = transportf _ (cancel_postcomposition _ _ g e) (ff' ;; gg).
+: ff ;; gg = transportf _ (maponpaths_2 _ e _) (ff' ;; gg).
 Proof.
   etrans. apply maponpaths_2, ee.
   apply mor_disp_transportf_postwhisker.
 Qed.
 
-Lemma cancel_precomposition_disp {C} {D : disp_cat C}
+Lemma maponpaths_disp {C} {D : disp_cat C}
   {x y z} {f : x --> y} {g g' : y --> z} {e : g' = g}
   {xx : D x} {yy} {zz}
   (ff : xx -->[f] yy) {gg : yy -->[g] zz} {gg' : yy -->[g'] zz}
   (ee : gg = transportf _ e gg')
-: ff ;; gg = transportf _ (cancel_precomposition _ _ _ _ _ _ f e) (ff ;; gg').
+: ff ;; gg = transportf _ (maponpaths _ e) (ff ;; gg').
 Proof.
   etrans. apply maponpaths, ee.
   apply mor_disp_transportf_prewhisker.
@@ -709,7 +709,7 @@ Proof.
     etrans; [ apply maponpaths_2, iso_after_iso_inv | apply id_left ].
   - apply pathsinv0.
     etrans. eapply transportf_bind.
-      eapply cancel_postcomposition_disp, (iso_disp_after_inv_mor ii).
+      eapply maponpaths_2_disp, (iso_disp_after_inv_mor ii).
     rewrite id_left_disp.
     etrans. apply transport_f_f.
     use (@maponpaths_2 _ _ _ _ _ (idpath _)).
@@ -718,7 +718,7 @@ Proof.
     rewrite e.
     etrans. eapply transportf_bind, assoc_disp.
     etrans. eapply transportf_bind.
-      eapply cancel_postcomposition_disp, (iso_disp_after_inv_mor ii).
+      eapply maponpaths_2_disp, (iso_disp_after_inv_mor ii).
     rewrite id_left_disp.
     etrans. apply transport_f_f.
     use (@maponpaths_2 _ _ _ _ _ (idpath _)).
@@ -1012,7 +1012,7 @@ Proof.
 Defined.
 
 (* TODO: look more for this in library.  If doesn’t exist, upstream it? *)
-Lemma cancel_precomposition_iso {C' : precategory} {x y z : C'}
+Lemma maponpaths_iso {C' : precategory} {x y z : C'}
     (f : iso x y) (g1 g2 : y --> z)
   : (f ;; g1 = f ;; g2 -> g1 = g2)%cat_deprecated.
 Proof.
@@ -1035,7 +1035,7 @@ Lemma inv_mor_total_iso {xx yy : total_category}
   = (inv_from_iso f,, inv_mor_disp_from_iso ff).
 Proof.
   (* Could de-opacify [is_iso_total] and then use [inv_from_iso_from_is_z_iso].  If de-opacfying [is_iso_total] would make its inverse compute definitionally, that’d be wonderful, but for the sake of just this one lemma, it’s probably not worth it.  So we prove this the hard way. *)
-  apply cancel_precomposition_iso with (total_iso f ff).
+  apply maponpaths_iso with (total_iso f ff).
   etrans. apply iso_inv_after_iso. apply pathsinv0.
   use total2_paths_f; cbn.
   - apply iso_inv_after_iso.

--- a/UniMath/CategoryTheory/DisplayedCats/Equivalences.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Equivalences.v
@@ -404,16 +404,16 @@ Proof.
   It’s perhaps most readable when written in string diagrams. *)
   etrans. apply id_left_disp_var.
   etrans. eapply transportf_bind.
-    eapply cancel_postcomposition_disp.
+    eapply maponpaths_2_disp.
     etrans. eapply transportf_transpose. apply @pathsinv0.
       refine (iso_disp_after_inv_mor _).
       refine (disp_functor_on_is_iso_disp GG _).
       apply Hε. (*1a*)
     eapply transportf_bind.
-    eapply cancel_postcomposition_disp.
+    eapply maponpaths_2_disp.
     etrans. apply id_right_disp_var.
     eapply transportf_bind.
-    etrans. eapply cancel_precomposition_disp.
+    etrans. eapply maponpaths_disp.
     eapply transportf_transpose. apply @pathsinv0.
       refine (iso_disp_after_inv_mor _).
       apply (Hη). (*1b*)
@@ -423,16 +423,16 @@ Proof.
     eapply transportf_bind.
     etrans. apply assoc_disp_var.
     eapply transportf_bind.
-    eapply cancel_precomposition_disp.
-    etrans. eapply cancel_precomposition_disp.
+    eapply maponpaths_disp.
+    etrans. eapply maponpaths_disp.
       etrans. apply assoc_disp.
       eapply transportf_bind.
-      etrans. eapply cancel_postcomposition_disp.
+      etrans. eapply maponpaths_2_disp.
         exact (disp_nat_trans_ax η (# GG (ε x yy))). (*2*)
       eapply transportf_bind.
       etrans. apply assoc_disp_var.
       eapply transportf_bind.
-      eapply cancel_precomposition_disp.
+      eapply maponpaths_disp.
       cbn.
       etrans. eapply transportf_transpose.
         apply @pathsinv0, (disp_functor_comp GG).
@@ -446,16 +446,16 @@ Proof.
     eapply transportf_bind.
     etrans. apply assoc_disp.
     eapply transportf_bind.
-    etrans. eapply cancel_postcomposition_disp.
+    etrans. eapply maponpaths_2_disp.
       apply (disp_nat_trans_ax η (η x (GG x yy))). (*4*)
     cbn.
     eapply transportf_bind.
     etrans. apply assoc_disp_var.
     eapply transportf_bind.
-    eapply cancel_precomposition_disp.
+    eapply maponpaths_disp.
     etrans. apply assoc_disp.
     eapply transportf_bind.
-    etrans. eapply cancel_postcomposition_disp.
+    etrans. eapply maponpaths_2_disp.
       etrans. eapply transportf_transpose.
         apply @pathsinv0, (disp_functor_comp GG). (*5*)
       eapply transportf_bind.
@@ -466,10 +466,10 @@ Proof.
   etrans. eapply transportf_bind.
     etrans. apply assoc_disp_var.
     eapply transportf_bind.
-    etrans. eapply cancel_precomposition_disp.
+    etrans. eapply maponpaths_disp.
       etrans. apply assoc_disp.
       eapply transportf_bind.
-      etrans. eapply cancel_postcomposition_disp.
+      etrans. eapply maponpaths_2_disp.
         exact (iso_disp_after_inv_mor _). (*7a*)
       eapply transportf_bind. apply id_left_disp.
     apply maponpaths. exact (iso_disp_after_inv_mor _). (*7b*)

--- a/UniMath/CategoryTheory/DisplayedCats/Equivalences_bis.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Equivalences_bis.v
@@ -405,16 +405,16 @@ Proof.
   It’s perhaps most readable when written in string diagrams. *)
   etrans. apply id_left_disp_var.
   etrans. eapply transportf_bind.
-    eapply cancel_postcomposition_disp.
+    eapply maponpaths_2_disp.
     etrans. eapply transportf_transpose. apply @pathsinv0.
       refine (iso_disp_after_inv_mor _).
       refine (disp_functor_on_is_iso_disp GG _).
       apply Hε. (*1a*)
     eapply transportf_bind.
-    eapply cancel_postcomposition_disp.
+    eapply maponpaths_2_disp.
     etrans. apply id_right_disp_var.
     eapply transportf_bind.
-    etrans. eapply cancel_precomposition_disp.
+    etrans. eapply maponpaths_disp.
     eapply transportf_transpose. apply @pathsinv0.
       refine (iso_disp_after_inv_mor _).
       apply (Hη). (*1b*)
@@ -424,16 +424,16 @@ Proof.
     eapply transportf_bind.
     etrans. apply assoc_disp_var.
     eapply transportf_bind.
-    eapply cancel_precomposition_disp.
-    etrans. eapply cancel_precomposition_disp.
+    eapply maponpaths_disp.
+    etrans. eapply maponpaths_disp.
       etrans. apply assoc_disp.
       eapply transportf_bind.
-      etrans. eapply cancel_postcomposition_disp.
+      etrans. eapply maponpaths_2_disp.
         exact (disp_nat_trans_ax η (# GG (ε x yy))). (*2*)
       eapply transportf_bind.
       etrans. apply assoc_disp_var.
       eapply transportf_bind.
-      eapply cancel_precomposition_disp.
+      eapply maponpaths_disp.
       cbn.
       etrans. eapply transportf_transpose.
         apply @pathsinv0, (disp_functor_comp GG).
@@ -447,16 +447,16 @@ Proof.
     eapply transportf_bind.
     etrans. apply assoc_disp.
     eapply transportf_bind.
-    etrans. eapply cancel_postcomposition_disp.
+    etrans. eapply maponpaths_2_disp.
       apply (disp_nat_trans_ax η (η _ (GG x yy))). (*4*)
     cbn.
     eapply transportf_bind.
     etrans. apply assoc_disp_var.
     eapply transportf_bind.
-    eapply cancel_precomposition_disp.
+    eapply maponpaths_disp.
     etrans. apply assoc_disp.
     eapply transportf_bind.
-    etrans. eapply cancel_postcomposition_disp.
+    etrans. eapply maponpaths_2_disp.
       etrans. eapply transportf_transpose.
         apply @pathsinv0, (disp_functor_comp GG). (*5*)
       eapply transportf_bind.
@@ -467,10 +467,10 @@ Proof.
   etrans. eapply transportf_bind.
     etrans. apply assoc_disp_var.
     eapply transportf_bind.
-    etrans. eapply cancel_precomposition_disp.
+    etrans. eapply maponpaths_disp.
       etrans. apply assoc_disp.
       eapply transportf_bind.
-      etrans. eapply cancel_postcomposition_disp.
+      etrans. eapply maponpaths_2_disp.
         exact (iso_disp_after_inv_mor _). (*7a*)
       eapply transportf_bind. apply id_left_disp.
     apply maponpaths. exact (iso_disp_after_inv_mor _). (*7b*)

--- a/UniMath/CategoryTheory/DisplayedCats/Examples.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Examples.v
@@ -140,7 +140,7 @@ Proof.
     eapply pathscomp0. apply @pathsinv0, assoc.
     eapply pathscomp0. apply maponpaths, gg.
     eapply pathscomp0. apply assoc.
-    eapply pathscomp0. apply cancel_postcomposition, ff.
+    eapply pathscomp0. apply maponpaths_2, ff.
     apply pathsinv0, assoc.
 Qed.
 
@@ -184,7 +184,7 @@ Proof.
     eapply pathscomp0. apply @pathsinv0, assoc.
     eapply pathscomp0. apply maponpaths, gg.
     eapply pathscomp0. apply assoc.
-    eapply pathscomp0. apply cancel_postcomposition, ff.
+    eapply pathscomp0. apply maponpaths_2, ff.
     apply pathsinv0, assoc.
 Qed.
 

--- a/UniMath/CategoryTheory/DisplayedCats/Fibrations.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Fibrations.v
@@ -291,7 +291,7 @@ Proof.
   use (pathscomp0 (maponpaths _ _) (transportfbinv _ _ _)).
   apply (precomp_with_iso_disp_is_inj (cartesian_lifts_iso fd fd')).
   etrans. apply assoc_disp.
-  etrans. eapply transportf_bind, cancel_postcomposition_disp.
+  etrans. eapply transportf_bind, maponpaths_2_disp.
     use inv_mor_after_iso_disp.
   etrans. eapply transportf_bind, id_left_disp.
   apply pathsinv0.

--- a/UniMath/CategoryTheory/EpiFacts.v
+++ b/UniMath/CategoryTheory/EpiFacts.v
@@ -217,7 +217,7 @@ Proof.
     rewrite <- (id_left u), <- (id_left v).
     rewrite <- (pr2 hf).
     repeat rewrite <- assoc.
-    now apply cancel_precomposition.
+    now apply maponpaths.
 Qed.
 
 End DefSplitEpis.

--- a/UniMath/CategoryTheory/EquivalencesExamples.v
+++ b/UniMath/CategoryTheory/EquivalencesExamples.v
@@ -20,7 +20,7 @@ Written by: Anders Mörtberg, 2016
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
-
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -91,7 +91,7 @@ use tpair.
     | cbn; rewrite postcompWithProductArrow;
       apply pathsinv0, Product_endo_is_identity; intro i;
       eapply pathscomp0; [|apply (ProductPrCommutes I C _ (PC x))];
-      apply cancel_postcomposition, maponpaths, funextsec; intro j; apply id_left]).
+      apply maponpaths_2, maponpaths, funextsec; intro j; apply id_left]).
 Defined.
 
 End delta_functor_adjunction.

--- a/UniMath/CategoryTheory/FunctorAlgebras.v
+++ b/UniMath/CategoryTheory/FunctorAlgebras.v
@@ -24,6 +24,7 @@ Contents :
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -342,7 +343,7 @@ Proof.
 assert (Ha'a : a' · a = identity A).
   assert (algMor_a'a : is_algebra_mor _ _ _ (a' · a)).
     unfold is_algebra_mor, a'; rewrite functor_comp.
-    eapply pathscomp0; [|eapply cancel_postcomposition; apply Ha'].
+    eapply pathscomp0; [|eapply maponpaths_2; apply Ha'].
     now apply assoc.
   apply pathsinv0; set (X := tpair _ _ algMor_a'a).
   now apply (maponpaths pr1 (!@InitialEndo_is_identity _ AaInitial X)).

--- a/UniMath/CategoryTheory/FunctorCoalgebras.v
+++ b/UniMath/CategoryTheory/FunctorCoalgebras.v
@@ -174,7 +174,7 @@ Proof.
   exists (α · α').
   unfold is_coalgebra_homo.
   rewrite <- assoc.
-  apply cancel_precomposition.
+  apply maponpaths.
   rewrite functor_comp.
   apply (coalgebra_homo_commutes F f).
 Defined.

--- a/UniMath/CategoryTheory/HorizontalComposition.v
+++ b/UniMath/CategoryTheory/HorizontalComposition.v
@@ -9,7 +9,7 @@ Written by: Benedikt Ahrens, Ralph Matthes (2015)
 ************************************************************)
 
 Require Import UniMath.Foundations.PartD.
-
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -102,10 +102,10 @@ Proof.
 
     simpl.
     rewrite <- ?assoc.
-    apply cancel_precomposition.
+    apply maponpaths.
     rewrite (functor_comp _).
     rewrite -> ?assoc.
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     apply pathsinv0.
     apply nat_trans_ax.
 Defined.

--- a/UniMath/CategoryTheory/Inductives/LambdaCalculus.v
+++ b/UniMath/CategoryTheory/Inductives/LambdaCalculus.v
@@ -14,6 +14,7 @@ Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.NaturalNumbers.
 
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.total2_paths.
@@ -168,7 +169,7 @@ assert (F := maponpaths (λ x, BinCoproductIn1 _ (BinCoproductsHSET2 _ _) · x)
 rewrite assoc in F.
 eapply pathscomp0; [apply F|].
 rewrite assoc.
-eapply pathscomp0; [eapply cancel_postcomposition, BinCoproductOfArrowsIn1|].
+eapply pathscomp0; [eapply maponpaths_2, BinCoproductOfArrowsIn1|].
 rewrite <- assoc.
 eapply pathscomp0; [eapply maponpaths, BinCoproductIn1Commutes|].
 apply id_left.
@@ -185,12 +186,12 @@ rewrite assoc in F.
 eapply pathscomp0; [apply F|].
 rewrite assoc.
 eapply pathscomp0.
-  eapply cancel_postcomposition.
+  eapply maponpaths_2.
   rewrite <- assoc.
   eapply maponpaths, BinCoproductOfArrowsIn2.
 rewrite assoc.
 eapply pathscomp0.
-  eapply cancel_postcomposition, cancel_postcomposition, BinCoproductOfArrowsIn1.
+  eapply maponpaths_2, maponpaths_2, BinCoproductOfArrowsIn1.
 rewrite <- assoc.
 eapply pathscomp0; [eapply maponpaths, BinCoproductIn2Commutes|].
 rewrite <- assoc.
@@ -208,12 +209,12 @@ rewrite assoc in F.
 eapply pathscomp0; [apply F|].
 rewrite assoc.
 eapply pathscomp0.
-  eapply cancel_postcomposition.
+  eapply maponpaths_2.
   rewrite <- assoc.
   eapply maponpaths, BinCoproductOfArrowsIn2.
 rewrite assoc.
 eapply pathscomp0.
-  eapply cancel_postcomposition, cancel_postcomposition, BinCoproductOfArrowsIn2.
+  eapply maponpaths_2, maponpaths_2, BinCoproductOfArrowsIn2.
 rewrite <- assoc.
 eapply pathscomp0.
   eapply maponpaths, BinCoproductIn2Commutes.

--- a/UniMath/CategoryTheory/Inductives/Lists.v
+++ b/UniMath/CategoryTheory/Inductives/Lists.v
@@ -13,6 +13,7 @@ Require Import UniMath.Foundations.NaturalNumbers.
 
 Require Import UniMath.Combinatorics.Lists.
 
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.total2_paths.
@@ -420,7 +421,7 @@ use tpair.
         - abstract (
             intros m n e; destruct e; simpl;
             destruct cc as [f hf]; simpl in *; unfold BinCoproduct_of_functors_ob in *;
-            rewrite <- (hf m _ (idpath _)), !assoc; apply cancel_postcomposition;
+            rewrite <- (hf m _ (idpath _)), !assoc; apply maponpaths_2;
             now unfold BinCoproduct_of_functors_mor; rewrite BinCoproductOfArrowsIn2). }
       apply (pr1 (pr1 (ccL HcL ccHcL))).
   + abstract (

--- a/UniMath/CategoryTheory/LatticeObject.v
+++ b/UniMath/CategoryTheory/LatticeObject.v
@@ -18,7 +18,8 @@ Written by: Anders Mörtberg, 2017
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
-
+Require Import UniMath.MoreFoundations.PartA.
+Require Import UniMath.MoreFoundations.Tactics.
 Require Import UniMath.Algebra.Lattice.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -224,11 +225,11 @@ apply BinProductArrowUnique.
   now rewrite assoc, BinProductOfArrowsPr1, <- assoc, BinProductOfArrowsPr1, assoc.
 - rewrite postcompWithBinProductArrow.
   apply BinProductArrowUnique.
-  + etrans; [ apply cancel_postcomposition; rewrite <-assoc;
+  + etrans; [ apply maponpaths_2; rewrite <-assoc;
               apply maponpaths, BinProductPr2Commutes |].
     rewrite <- assoc, BinProductPr1Commutes.
     now rewrite assoc, BinProductOfArrowsPr1, <- assoc, BinProductOfArrowsPr2, assoc.
-  + etrans; [ apply cancel_postcomposition; rewrite <-assoc;
+  + etrans; [ apply maponpaths_2; rewrite <-assoc;
               apply maponpaths, BinProductPr2Commutes |].
     now rewrite <- assoc, BinProductPr2Commutes, BinProductOfArrowsPr2.
 Qed.
@@ -248,7 +249,7 @@ Proof.
 unfold isassoc_cat; intros H; apply Hi.
 rewrite <-!assoc, !Hfg, !assoc, BinProductOfArrows_comp, Hfg, <- !assoc, identity_comm.
 rewrite <- BinProductOfArrows_comp, <- assoc, H, !assoc.
-apply cancel_postcomposition.
+apply maponpaths_2.
 rewrite <-!assoc, BinProductOfArrows_comp, Hfg, identity_comm.
 now rewrite <- BinProductOfArrows_comp, !assoc, binprod_assoc_comm.
 Qed.
@@ -259,7 +260,7 @@ Proof.
 unfold iscomm_cat; intros H; apply Hi.
 rewrite <- !assoc, !Hfg.
 etrans; [eapply maponpaths, H|].
-rewrite !assoc; apply cancel_postcomposition.
+rewrite !assoc; apply maponpaths_2.
 unfold binprod_swap; rewrite postcompWithBinProductArrow.
 apply BinProductArrowUnique; rewrite <- assoc.
 * now rewrite BinProductPr1Commutes, BinProductOfArrowsPr2.
@@ -274,10 +275,10 @@ unfold isabsorb_cat; intros H; apply Hi.
 assert (HH : BinProductPr1 C (BPC M M) · i = (i ×× i) · BinProductPr1 C (BPC L L)).
 { now rewrite BinProductOfArrowsPr1. }
 rewrite HH, <- H, <-!assoc, Hfg1, !assoc.
-apply cancel_postcomposition.
+apply maponpaths_2.
 rewrite <-!assoc, BinProductOfArrows_comp, Hfg2, identity_comm, !assoc.
 rewrite BinProductOfArrows_comp, <-identity_comm, binprod_delta_comm.
-etrans; [| eapply pathsinv0; do 2 apply cancel_postcomposition;
+etrans; [| eapply pathsinv0; do 2 apply maponpaths_2;
            now rewrite <-BinProductOfArrows_comp].
 rewrite <-!assoc; apply maponpaths.
 rewrite assoc, binprod_assoc_comm, <-assoc; apply maponpaths.
@@ -322,11 +323,11 @@ unfold islunit_cat; intros H; apply Hi.
 rewrite <-!assoc.
 etrans; [ do 2 apply maponpaths; apply Hf |].
 rewrite identity_comm, <-H, postcompWithBinProductArrow, !assoc.
-apply cancel_postcomposition.
+apply maponpaths_2.
 rewrite !postcompWithBinProductArrow, <-assoc, Hg, !id_left.
 apply pathsinv0, BinProductArrowUnique.
 - rewrite <- assoc, BinProductPr1Commutes, assoc.
-  now apply cancel_postcomposition, TerminalArrowUnique.
+  now apply maponpaths_2, TerminalArrowUnique.
 - now rewrite <- assoc, BinProductPr2Commutes, id_right.
 Qed.
 

--- a/UniMath/CategoryTheory/LocalizingClass.v
+++ b/UniMath/CategoryTheory/LocalizingClass.v
@@ -2,6 +2,7 @@
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.Categories.
@@ -305,12 +306,12 @@ Section def_roofs.
         set (tmp := RoofTopEq1 T2). repeat rewrite <- assoc. rewrite <- tmp. clear tmp.
         repeat rewrite assoc. repeat rewrite <- (assoc (pr2 t)). rewrite D2.
         repeat rewrite <- assoc.
-        apply cancel_precomposition. apply cancel_precomposition.
+        apply maponpaths. apply maponpaths.
         exact (RoofTopEq1 T1).
       + induction p as [p1 p2]. repeat rewrite assoc in p2.
         set (tmp := RoofTopEq2 T2). repeat rewrite <- assoc. rewrite <- tmp. clear tmp.
         repeat rewrite assoc. rewrite p2. repeat rewrite <- assoc.
-        apply cancel_precomposition. apply cancel_precomposition.
+        apply maponpaths. apply maponpaths.
         exact (RoofTopEq2 T1).
     (* isrefl *)
     - intros R1.
@@ -522,11 +523,11 @@ Section def_roofs.
     - cbn. split.
       + rewrite <- (LocSqr1Comm sqr3).
         rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
-        apply cancel_postcomposition. apply cancel_postcomposition.
+        apply maponpaths_2. apply maponpaths_2.
         apply (LocSqr1Comm sqr1).
       + rewrite (PreSwitchEq PreS).
         rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
-        apply cancel_postcomposition. apply cancel_postcomposition.
+        apply maponpaths_2. apply maponpaths_2.
         apply (LocSqr1Comm sqr2).
   Defined.
   Opaque RoofTopToCoroof.
@@ -561,7 +562,7 @@ Section def_roofs.
       rewrite <- assoc. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
       rewrite <- (dirprod_pr1 eq). rewrite <- (dirprod_pr2 eq).
       rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       set (tmp := LocSqr2Comm sqr6). rewrite assoc in tmp. rewrite assoc in tmp.
       apply tmp.
     }
@@ -579,7 +580,7 @@ Section def_roofs.
         * exact (LocSqr2Mor2Is sqr6).
       + exact (RoofMor1Is R4).
     - cbn.
-      rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
+      rewrite <- assoc. rewrite <- assoc. apply maponpaths.
       apply (! (LocSqr2Comm sqr6)).
     - cbn.
       rewrite assoc. rewrite assoc.
@@ -612,7 +613,7 @@ Section def_roofs.
       rewrite <- (assoc _ (LocSqr2Mor1 sqr4)). rewrite (LocSqr2Comm sqr4).
       rewrite <- (assoc _ (LocSqr2Mor1 sqr5)). rewrite (LocSqr2Comm sqr5).
       rewrite assoc. rewrite assoc.
-      apply cancel_postcomposition. apply cancel_postcomposition.
+      apply maponpaths_2. apply maponpaths_2.
       apply (LocSqr2Comm sqr6).
     }
     set (PostS := isLocClassPost iLC _ _ _
@@ -628,7 +629,7 @@ Section def_roofs.
         * exact (PostSwitchMorIs PostS).
         * exact (LocSqr2Mor2Is sqr6).
       + exact (RoofMor1Is R4).
-    - cbn. rewrite assoc. rewrite assoc. apply cancel_postcomposition.
+    - cbn. rewrite assoc. rewrite assoc. apply maponpaths_2.
       set (tmp := ! (LocSqr2Comm sqr6)).
       apply (maponpaths (λ f : _, PostSwitchMor PostS · f)) in tmp.
       rewrite assoc in tmp. rewrite assoc in tmp. apply tmp.
@@ -923,9 +924,9 @@ Section def_roofs.
       rewrite assoc. rewrite assoc.
       rewrite <- (assoc _ (LocSqr2Mor1 sqr2)). rewrite (LocSqr2Comm sqr2).
       rewrite assoc.
-      apply cancel_postcomposition. apply cancel_postcomposition.
+      apply maponpaths_2. apply maponpaths_2.
       rewrite <- (LocSqr2Comm sqr). rewrite <- assoc. rewrite <- assoc.
-      apply cancel_precomposition.
+      apply maponpaths.
       apply (! (LocSqr2Comm sqr3)).
     }
     set (PostS := isLocClassPost iLC _ _ _ (LocSqr2Mor2 sqr · RoofMor2 R6')
@@ -942,9 +943,9 @@ Section def_roofs.
         * exact (LocSqr2Mor2Is sqr).
       + exact (RoofMor1Is R6').
     - rewrite <- assoc. rewrite <- assoc.
-      apply cancel_precomposition. cbn. fold sqr1. fold sqr2. fold sqr3. fold sqr4.
+      apply maponpaths. cbn. fold sqr1. fold sqr2. fold sqr3. fold sqr4.
       rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
-      apply cancel_postcomposition. apply cancel_postcomposition.
+      apply maponpaths_2. apply maponpaths_2.
       exact (! (LocSqr2Comm sqr)).
     - rewrite <- assoc. rewrite <- assoc.
       exact (PostSwitchEq PostS).
@@ -993,13 +994,13 @@ Section def_roofs.
       rewrite <- (assoc _ (LocSqr2Mor1 sqr2)). rewrite (LocSqr2Comm sqr2). rewrite assoc.
       rewrite <- assoc. rewrite <- (LocSqr1Comm sqrop). rewrite assoc.
       rewrite <- (assoc _ _ (LocSqr1Mor2 sqrop)). rewrite <- (LocSqr1Comm sqrop). rewrite assoc.
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       rewrite <- (assoc _ (LocSqr2Mor1 sqr3)). rewrite (LocSqr2Comm sqr3). rewrite assoc.
 
       rewrite <- assoc. rewrite <- assoc. rewrite (LocSqr2Comm sqr4). rewrite assoc.
       rewrite <- (LocSqr2Comm sqr).
       rewrite <- assoc. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
-      apply cancel_precomposition. apply cancel_precomposition.
+      apply maponpaths. apply maponpaths.
       apply (! (LocSqr2Comm sqr1)).
     }
     set (PostS := isLocClassPost iLC _ _ _ (LocSqr2Mor2 sqr · LocSqr2Mor1 sqr4 · LocSqr2Mor1 sqr2)
@@ -1016,12 +1017,12 @@ Section def_roofs.
         * exact (LocSqr2Mor2Is sqr).
       + exact (RoofMor1Is R6').
     - cbn. fold sqr1. fold sqr2. fold sqr3. fold sqr4.
-      rewrite <- assoc. apply pathsinv0. rewrite <- assoc. apply cancel_precomposition.
-      rewrite assoc. rewrite assoc. rewrite assoc. apply cancel_postcomposition.
+      rewrite <- assoc. apply pathsinv0. rewrite <- assoc. apply maponpaths.
+      rewrite assoc. rewrite assoc. rewrite assoc. apply maponpaths_2.
       rewrite <- assoc. apply (LocSqr2Comm sqr).
     - cbn. fold sqr1. fold sqr2. fold sqr3. fold sqr4.
       rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       set (tmp := PostSwitchEq PostS). rewrite assoc in tmp. rewrite assoc in tmp.
       rewrite assoc in tmp. rewrite assoc in tmp.
       exact tmp.
@@ -1167,7 +1168,7 @@ Section def_roofs.
       cbn. fold sqrop.
       rewrite <- assoc. rewrite <- (LocSqr1Comm sqrop). rewrite id_left.
       rewrite <- assoc. rewrite <- (LocSqr1Comm sqrop). rewrite id_left.
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       set (tmp := LocSqr2Comm sqr1). cbn in tmp. rewrite id_right in tmp.
       exact tmp.
     }
@@ -1269,7 +1270,7 @@ Section def_roofs.
         set (tmp := iso_inv_after_iso iso1). cbn in tmp.
         apply tmp.
       + set (tmp := iso_inv_after_iso iso2). cbn in tmp. rewrite <- tmp. clear tmp.
-        rewrite <- assoc. apply cancel_precomposition.
+        rewrite <- assoc. apply maponpaths.
         apply (post_comp_with_iso_is_inj _ _ _ g H2).
         set (tmp := iso_after_iso_inv iso2). cbn in tmp. rewrite tmp. clear tmp.
         rewrite <- assoc. set (tmp := iso_after_iso_inv iso1). cbn in tmp. exact tmp.
@@ -1334,7 +1335,7 @@ Section def_roofs.
     }
     rewrite X.
     rewrite inv_from_iso_comp. rewrite <- assoc.
-    apply cancel_precomposition.
+    apply maponpaths.
     rewrite assoc.
     set (tmp := iso_after_iso_inv iso4). cbn in tmp. rewrite tmp. clear tmp.
     apply id_left.
@@ -1423,15 +1424,15 @@ Section def_roofs.
     }
     rewrite X. rewrite inv_from_iso_comp. rewrite functor_comp. rewrite assoc.
     unfold MorMap. rewrite assoc. fold iso3 iso4.
-    apply cancel_postcomposition.
-    rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
+    apply maponpaths_2.
+    rewrite <- assoc. rewrite <- assoc. apply maponpaths.
     set (tmp := LocSqr2Comm sqr).
     apply (pre_comp_with_iso_is_inj D _ _ _ _ (pr2 iso2)). rewrite assoc.
     set (tmp2 := iso_inv_after_iso iso2). cbn in tmp2. cbn. rewrite tmp2. clear tmp2.
     rewrite id_left.
     apply (post_comp_with_iso_is_inj D _ _ _ (pr2 iso4)). cbn. rewrite <- functor_comp.
     rewrite tmp. clear tmp. rewrite functor_comp. rewrite <- assoc.
-    apply cancel_precomposition.
+    apply maponpaths.
     rewrite <- assoc.
     set (tmp2 := iso_after_iso_inv iso4). cbn in tmp2. rewrite tmp2. rewrite id_right.
     apply idpath.
@@ -1665,7 +1666,7 @@ Section def_roofs.
                          _ _ _
                          (RoofEqclassFromRoof (InvRoofFromMorInSom (RoofMor1 f1) (RoofMor1Is f1)))
                          (RoofEqclassFromRoof (MorToRoof (RoofMor2 f1))))).
-      unfold functor_composite. cbn. apply cancel_postcomposition.
+      unfold functor_composite. cbn. apply (maponpaths_2 compose).
       set (iso1 := isopair _ (H' f1 a (RoofMor1 f1) (RoofMor1Is f1))).
       apply (post_comp_with_iso_is_inj _ _ _ _ (pr2 iso1)).
       use (pathscomp0 _ (! (iso_after_iso_inv iso1))).

--- a/UniMath/CategoryTheory/Monads/Derivative.v
+++ b/UniMath/CategoryTheory/Monads/Derivative.v
@@ -19,6 +19,7 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -102,14 +103,14 @@ Proof.
   simpl.
   rewrite !assoc.
   etrans.
-    { do 3 apply cancel_postcomposition.
+    { do 3 apply maponpaths_2.
       apply (monad_dist_law1 l).
     }
   (* 3 *)
   rewrite <- (assoc (# T ((η S) (S x)))).
   etrans.
-    { apply cancel_postcomposition.
-      apply cancel_precomposition.
+    { apply maponpaths_2.
+      apply maponpaths.
       apply (Monad_law1).
     }
   (* 4 *)
@@ -148,9 +149,9 @@ Proof.
   rewrite (functor_comp S).
   rewrite <- !assoc.
   etrans.
-    { apply cancel_postcomposition.
+    { apply maponpaths_2.
       apply maponpaths.
-      apply cancel_precomposition.
+      apply maponpaths.
       apply (monad_dist_law2 l).
     }
   (* 2 *)
@@ -196,26 +197,26 @@ Proof.
   rewrite (assoc _ (a (T (S x)))).
   simpl.
   etrans.
-    { apply cancel_postcomposition.
+    { apply maponpaths_2.
       apply maponpaths.
-      apply cancel_precomposition.
-      apply cancel_postcomposition.
+      apply maponpaths.
+      apply maponpaths_2.
       apply (nat_trans_ax a).
     }
   rewrite <- assoc.
   rewrite (assoc _ (# T (a (S x)))).
   etrans.
-    { apply cancel_postcomposition.
+    { apply maponpaths_2.
       apply maponpaths.
-      do 2 apply cancel_precomposition.
-      apply cancel_postcomposition.
+      do 2 apply maponpaths.
+      apply maponpaths_2.
       apply (! (functor_comp T _ _)).
     }
   etrans.
-    { apply cancel_postcomposition.
+    { apply maponpaths_2.
       apply maponpaths.
-      do 2 apply cancel_precomposition.
-      apply cancel_postcomposition.
+      do 2 apply maponpaths.
+      apply maponpaths_2.
       apply maponpaths.
       apply (nat_trans_ax a).
     }
@@ -231,7 +232,7 @@ Proof.
   rewrite !assoc.
   rewrite <- functor_comp.
   etrans.
-    { do 5 apply cancel_postcomposition.
+    { do 5 apply maponpaths_2.
       apply maponpaths.
       apply (nat_trans_ax a).
     }
@@ -295,8 +296,8 @@ Proof.
   rewrite <- functor_comp.
   apply pathsinv0.
   etrans.
-    { apply cancel_precomposition.
-      apply cancel_postcomposition.
+    { apply maponpaths.
+      apply maponpaths_2.
       apply maponpaths.
       apply (nat_trans_ax a).
     }
@@ -313,8 +314,8 @@ Proof.
   simpl.
   rewrite <- !functor_comp.
   etrans.
-    { apply cancel_precomposition.
-      apply cancel_postcomposition.
+    { apply maponpaths.
+      apply maponpaths_2.
       do 2 apply maponpaths.
       apply Monad_law2.
     }
@@ -530,8 +531,8 @@ Proof.
   rewrite assoc.
   rewrite <- (assoc _ (#L (#T (a x)))).
   etrans.
-    { apply cancel_postcomposition.
-      apply cancel_precomposition.
+    { apply maponpaths_2.
+      apply maponpaths.
       apply (nat_trans_ax (lm_mult T L)).
     }
   now rewrite !assoc.

--- a/UniMath/CategoryTheory/Monads/LModules.v
+++ b/UniMath/CategoryTheory/Monads/LModules.v
@@ -15,7 +15,7 @@ Written by: Ambroise Lafont (November 2016)
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
-
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -122,10 +122,10 @@ Proof.
   unfold nat_trans_from_module_mor.
   rewrite assoc.
     etrans; revgoals.
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     apply (LModule_Mor_σ α a).
     rewrite <- !assoc.
-    apply cancel_precomposition.
+    apply maponpaths.
     apply (LModule_Mor_σ α' a).
 Qed.
 
@@ -241,20 +241,20 @@ Section Pullback_module.
       rewrite assoc.
       rewrite <- (functor_comp T).
       etrans.
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       apply maponpaths.
       apply Monad_Mor_μ.
       rewrite functor_comp.
       rewrite <- assoc.
       etrans.
-      apply cancel_precomposition.
+      apply maponpaths.
       apply LModule_law2.
       repeat rewrite functor_comp.
       etrans.
       rewrite <- assoc.
-      apply cancel_precomposition.
+      apply maponpaths.
       rewrite assoc.
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       apply (nat_trans_ax (σ M' T)).
       now repeat rewrite assoc.
   Qed.
@@ -284,10 +284,10 @@ Section Pullback_Module_Morphism.
     cbn.
     eapply pathscomp0;revgoals.
     rewrite <-assoc.
-    apply cancel_precomposition.
+    apply maponpaths.
     apply LModule_Mor_σ.
     repeat rewrite assoc.
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     apply pathsinv0.
     apply nat_trans_ax.
   Qed.

--- a/UniMath/CategoryTheory/Monads/Monads.v
+++ b/UniMath/CategoryTheory/Monads/Monads.v
@@ -22,7 +22,7 @@ Extended by: Anders Mörtberg, 2016
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
-
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -147,7 +147,7 @@ Proof.
     apply maponpaths.
     now rewrite !assoc, nat_trans_ax.
   - rewrite assoc.
-    eapply pathscomp0; [apply cancel_postcomposition, Monad_Mor_η|].
+    eapply pathscomp0; [apply maponpaths_2, Monad_Mor_η|].
     apply Monad_Mor_η.
 Qed.
 
@@ -243,7 +243,7 @@ Proof.
 unfold bind.
 rewrite assoc.
 eapply pathscomp0;
-  [apply cancel_postcomposition, (! (nat_trans_ax (η T) _ _ f))|]; simpl.
+  [apply maponpaths_2, (! (nat_trans_ax (η T) _ _ f))|]; simpl.
 rewrite <- assoc.
 eapply pathscomp0; [apply maponpaths, Monad_law1|].
 apply id_right.
@@ -259,7 +259,7 @@ Lemma bind_bind {a b c : C} (f : C⟦a,T b⟧) (g : C⟦b,T c⟧) :
 Proof.
 unfold bind; rewrite <- assoc.
 eapply pathscomp0; [apply maponpaths; rewrite assoc;
-                    apply cancel_postcomposition, (!nat_trans_ax (μ T) _ _ g)|].
+                    apply maponpaths_2, (!nat_trans_ax (μ T) _ _ g)|].
 rewrite !functor_comp, <- !assoc.
 now apply maponpaths, maponpaths, (!Monad_law3 c).
 Qed.
@@ -310,7 +310,7 @@ Proof.
     rewrite <- assoc.
     apply pathsinv0.
     eapply pathscomp0.
-    * apply cancel_precomposition.
+    * apply maponpaths.
       rewrite assoc.
       rewrite BinCoproductIn2Commutes.
       rewrite (η_bind(a:=(c ⊕ a))).
@@ -350,7 +350,7 @@ Proof.
       rewrite (η_bind(a:=let (pr1, _) := pr1 (BC b (c ⊕ a)) in pr1)).
       apply pathsinv0.
       eapply pathscomp0.
-      - apply cancel_precomposition.
+      - apply maponpaths.
         rewrite assoc.
         rewrite BinCoproductIn2Commutes.
         rewrite (η_bind(a:=(c ⊕ a))).

--- a/UniMath/CategoryTheory/PseudoElements.v
+++ b/UniMath/CategoryTheory/PseudoElements.v
@@ -9,6 +9,7 @@
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids_and_Groups.
@@ -135,7 +136,7 @@ Section def_pseudo_element.
   Proof.
     intros Pb.
     rewrite <- assoc. rewrite <- assoc. rewrite (PEqEq P2). rewrite <- (PEqEq P1).
-    rewrite assoc. rewrite assoc. apply cancel_postcomposition.
+    rewrite assoc. rewrite assoc. apply maponpaths_2.
     apply pathsinv0. exact (PullbackSqrCommutes Pb).
   Qed.
 
@@ -233,7 +234,7 @@ Section def_pseudo_element.
   Local Lemma PEq_Im_Eq {c d : A} (P1 P2 : PseudoElem c) (f : c --> d) (H : PEq P1 P2):
     PEqEpi1 H · (P2 · f) = PEqEpi2 H · (P1 · f).
   Proof.
-    rewrite assoc. rewrite assoc. apply cancel_postcomposition. exact (PEqEq H).
+    rewrite assoc. rewrite assoc. apply maponpaths_2. exact (PEqEq H).
   Qed.
 
   Definition PEq_Im {c d : A} (P1 P2 : PseudoElem c) (f : c --> d) (H : PEq P1 P2) :
@@ -433,7 +434,7 @@ Section def_pseudo_element.
           set (tmp' := factorization1 hs f).
           apply (maponpaths (λ gg : _, gg · (factorization1_monic A f))) in tmp.
           rewrite <- assoc in tmp. rewrite <- tmp' in tmp. clear tmp'.
-          use (pathscomp0 tmp). clear tmp. rewrite <- assoc. apply cancel_precomposition.
+          use (pathscomp0 tmp). clear tmp. rewrite <- assoc. apply maponpaths.
           use (KernelCommutes (to_Zero A) K).
     - intros X.
       set (fac := factorization1 hs f).
@@ -453,7 +454,7 @@ Section def_pseudo_element.
             {
               cbn. set (ee := PEqEq PE). cbn in ee. rewrite ee.
               rewrite assoc. rewrite <- (assoc _ _ (KernelArrow (Abelian.Image f))).
-              apply cancel_precomposition. exact fac.
+              apply maponpaths. exact fac.
             }
             set (tmp := PullbackArrow
                           Pb _ (PEqEpi1 PE)
@@ -527,10 +528,10 @@ Section def_pseudo_element.
     cbn in tmp. cbn. rewrite <- tmp. clear tmp.
     set (tmp' := @to_postmor_linear' PA _ _ _ (PEqEpi1 H · a') (PEqEpi1 H · @to_inv PA _ _ a') f).
     use (pathscomp0 (! tmp')). clear tmp'.
-    rewrite <- (ZeroArrow_comp_left _ _ _ _ _ f). apply cancel_postcomposition.
+    rewrite <- (ZeroArrow_comp_left _ _ _ _ _ f). apply maponpaths_2.
     set (tmp' := @to_premor_linear' PA _ _ _ (PEqEpi1 H) a' (@to_inv PA _ _ a')).
     use (pathscomp0 (! tmp')). clear tmp'.
-    rewrite <- (ZeroArrow_comp_right _ _ _ _ _ (PEqEpi1 H)). apply cancel_precomposition.
+    rewrite <- (ZeroArrow_comp_right _ _ _ _ _ (PEqEpi1 H)). apply maponpaths.
     use (@to_rinvax' PA).
   Qed.
 
@@ -547,7 +548,7 @@ Section def_pseudo_element.
     set (tmp := PEqEq H). cbn in tmp.
     set (tmp' := @to_postmor_linear' PA _ _ _ (PEqEpi2 H · a) (PEqEpi1 H · @to_inv PA _ _ a') g).
     use (pathscomp0 tmp'). clear tmp'. rewrite <- assoc. cbn. rewrite X. rewrite ZeroArrow_comp_right.
-    rewrite (@to_lunax'' PA). rewrite assoc. apply cancel_postcomposition.
+    rewrite (@to_lunax'' PA). rewrite assoc. apply maponpaths_2.
     rewrite <- (@PreAdditive_invlcomp PA). rewrite <- (@PreAdditive_invrcomp PA).
     apply idpath.
   Qed.

--- a/UniMath/CategoryTheory/RightKanExtension.v
+++ b/UniMath/CategoryTheory/RightKanExtension.v
@@ -25,7 +25,7 @@ Contents:
 ************************************************************)
 
 Require Import UniMath.Foundations.PartD.
-
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -164,7 +164,7 @@ use left_adjoint_from_partial.
     + intro mf; apply (# S (pr2 mf) · α (pr1 mf)).
     + abstract (intros fm fm' h; simpl; rewrite <- assoc;
                 eapply pathscomp0; [apply maponpaths, (pathsinv0 (nat_trans_ax α _ _ (pr1 h)))|];
-                simpl; rewrite assoc, <- functor_comp; apply cancel_postcomposition, maponpaths, (pr2 h)).
+                simpl; rewrite assoc, <- functor_comp; apply maponpaths_2, maponpaths, (pr2 h)).
   }
 
   transparent assert (σ : (∏ c, A ⟦ S c, R T c ⟧)).
@@ -215,7 +215,7 @@ use left_adjoint_from_partial.
     rewrite temp; simpl.
     destruct u as [n g]; simpl in *.
     apply pathsinv0; eapply pathscomp0;
-    [rewrite assoc; apply cancel_postcomposition, (nat_trans_ax t _ _ g)|].
+    [rewrite assoc; apply maponpaths_2, (nat_trans_ax t _ _ g)|].
     rewrite <- !assoc; apply maponpaths.
     generalize (limArrowCommutes (LA (K n ↓ K) _) _ (Rmor_cone T c (K n) g) (Kid n)).
     now simpl; rewrite id_right.

--- a/UniMath/CategoryTheory/ShortExactSequences.v
+++ b/UniMath/CategoryTheory/ShortExactSequences.v
@@ -243,7 +243,7 @@ Section def_shortexactseqs.
       use unique_exists.
       + use KernelIn.
         * exact h.
-        * rewrite <- (ZeroArrow_comp_right _ _ _ _ _ h). apply cancel_precomposition.
+        * rewrite <- (ZeroArrow_comp_right _ _ _ _ _ h). apply maponpaths.
           apply isE. rewrite CokernelCompZero. rewrite ZeroArrow_comp_right.
           apply idpath.
       + cbn. use KernelCommutes.

--- a/UniMath/CategoryTheory/Subobjects.v
+++ b/UniMath/CategoryTheory/Subobjects.v
@@ -16,6 +16,7 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -117,7 +118,7 @@ intermediate_path (pr1 (pr1 h1_inv) · pr1 (pr2 x1)).
 { apply maponpaths, pathsinv0, (pr2 f). }
 etrans; [ apply maponpaths, (maponpaths pr1 (pr2 (pr1 h1))) |]; simpl.
 rewrite assoc.
-etrans; [ eapply cancel_postcomposition, (maponpaths pr1 (maponpaths pr1 Hh1)) |].
+etrans; [ eapply maponpaths_2, (maponpaths pr1 (maponpaths pr1 Hh1)) |].
 apply id_left.
 Qed.
 

--- a/UniMath/CategoryTheory/UnderCategories.v
+++ b/UniMath/CategoryTheory/UnderCategories.v
@@ -131,7 +131,7 @@ Section undercategories_morphisms.
   Proof.
     cbn.
     rewrite <- assoc.
-    apply cancel_precomposition.
+    apply maponpaths.
     set (tmp := Under_mor_eq C c' g).
     unfold Under_mor_mor.
     unfold Under_mor_mor, Under_ob_mor in tmp.

--- a/UniMath/CategoryTheory/bicategories/whiskering.v
+++ b/UniMath/CategoryTheory/bicategories/whiskering.v
@@ -1,5 +1,5 @@
 Require Import UniMath.Foundations.PartD.
-
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -91,8 +91,8 @@ Proof.
   intermediate_path (iso_inv_from_iso (left_unitor _)
            ;v; whisker_left (identity_1mor _) alpha'
            ;v; left_unitor _ ).
-    apply cancel_postcomposition.
-    apply cancel_precomposition.
+    apply maponpaths_2.
+    apply maponpaths.
     assumption.
 
   apply iso_inv_to_right.
@@ -191,8 +191,8 @@ Proof.
   intermediate_path (iso_inv_from_iso (right_unitor _)
            ;v; whisker_right alpha' (identity_1mor _)
            ;v; right_unitor _ ).
-    apply cancel_postcomposition.
-    apply cancel_precomposition.
+    apply maponpaths_2.
+    apply maponpaths.
     assumption.
 
   apply iso_inv_to_right.
@@ -328,7 +328,7 @@ Proof.
   rewrite (cancel_whisker_right (triangle_axiom f g) h).
   rewrite whisker_right_on_comp.
   rewrite assoc.
-  apply cancel_postcomposition.
+  apply maponpaths_2.
 
   apply (pentagon_axiom f (identity_1mor b) g h).
 Defined.

--- a/UniMath/CategoryTheory/equivalences.v
+++ b/UniMath/CategoryTheory/equivalences.v
@@ -20,7 +20,7 @@ Contents:
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
-
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -158,14 +158,14 @@ Proof.
   match goal with |[ |- ?i1 · ?i2 · _ · _ · _ · _ = _ ] =>
                    set (i := i1); set (i':= i2) end.
 
-  etrans. apply cancel_postcomposition. repeat rewrite <- assoc.
+  etrans. apply maponpaths_2. repeat rewrite <- assoc.
           rewrite etaH. apply idpath.
   etrans. repeat rewrite <- assoc. rewrite <- functor_comp.
           rewrite (epsH). rewrite functor_comp. apply idpath.
   etrans. apply maponpaths. apply maponpaths. repeat rewrite assoc. rewrite etaH.
-          apply cancel_postcomposition. rewrite <- assoc. rewrite <- functor_comp.
+          apply maponpaths_2. rewrite <- assoc. rewrite <- functor_comp.
           rewrite T1. rewrite functor_id. apply id_right.
-  etrans. apply maponpaths. rewrite assoc. apply cancel_postcomposition.
+  etrans. apply maponpaths. rewrite assoc. apply maponpaths_2.
           use (iso_after_iso_inv (isopair _ (Hη _ ))).
   rewrite id_left.
   apply (iso_after_iso_inv ).
@@ -223,7 +223,7 @@ Proof.
   cbn in ηinvH. simpl in ηinvH.
   assert (εinvH := nat_trans_ax (inv_from_iso εntiso)).
   cbn in εinvH. simpl in εinvH.
-  etrans. apply cancel_postcomposition. apply cancel_postcomposition.
+  etrans. apply maponpaths_2. apply maponpaths_2.
           etrans. apply maponpaths. apply (! (id_right _ )).
           apply εinvH.
           rewrite id_right.
@@ -237,7 +237,7 @@ Proof.
     apply functor_id.
   - assert (XR := nat_trans_inv_pointwise_inv_before _ _ _ _ _ εntiso (pr2 εntiso)).
     cbn in XR.
-    etrans. apply cancel_postcomposition. eapply pathsinv0. apply id_right. apply XR.
+    etrans. apply maponpaths_2. eapply pathsinv0. apply id_right. apply XR.
 Qed.
 
 Lemma adjointification_forms_equivalence :

--- a/UniMath/CategoryTheory/exponentials.v
+++ b/UniMath/CategoryTheory/exponentials.v
@@ -20,7 +20,7 @@ Contents:
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
-
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -136,12 +136,12 @@ use tpair.
 + intro x; unfold eta', eps'; cbn.
   rewrite assoc.
   eapply pathscomp0.
-  - eapply cancel_postcomposition.
+  - eapply maponpaths_2.
     exact (nat_trans_ax (inv_from_iso (flip_iso _)) _ _ _).
   - rewrite functor_comp, assoc.
     eapply pathscomp0; [rewrite <- assoc; apply maponpaths, (nat_trans_ax eps)|].
     rewrite <- assoc.
-    eapply pathscomp0; [apply maponpaths; rewrite assoc; apply cancel_postcomposition, H1|].
+    eapply pathscomp0; [apply maponpaths; rewrite assoc; apply maponpaths_2, H1|].
     rewrite id_left.
     apply (nat_trans_eq_pointwise (iso_after_iso_inv (flip_iso a)) x).
 + intro x; cbn.

--- a/UniMath/CategoryTheory/limits/BinDirectSums.v
+++ b/UniMath/CategoryTheory/limits/BinDirectSums.v
@@ -8,7 +8,7 @@
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
-
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.Algebra.BinaryOperations.
@@ -615,7 +615,7 @@ Section bindirectsums_in_quot.
           rewrite <- tmp. clear tmp.
           rewrite comp_eq.
           rewrite (to_BinOpId A (BD x y)).
-          rewrite comp_eq. apply cancel_postcomposition.
+          rewrite comp_eq. apply maponpaths_2.
           apply idpath.
   Qed.
 
@@ -673,7 +673,7 @@ Section bindirectsums_in_quot.
           rewrite <- tmp. clear tmp.
           rewrite comp_eq.
           rewrite (to_BinOpId A (BD x y)).
-          rewrite comp_eq. apply cancel_precomposition.
+          rewrite comp_eq. apply maponpaths.
           apply idpath.
   Qed.
 

--- a/UniMath/CategoryTheory/limits/FinOrdCoproducts.v
+++ b/UniMath/CategoryTheory/limits/FinOrdCoproducts.v
@@ -2,6 +2,7 @@
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.Combinatorics.StandardFiniteSets.
 
@@ -158,18 +159,18 @@ Section FinOrdCoproduct_criteria.
     (* From stn n *)
     apply CoproductArrowUnique.
     intros i. rewrite <- (X (dni_lastelement i)). rewrite assoc.
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     induction (natlehchoice4 (pr1 (dni_lastelement i)) n
                              (pr2 (dni_lastelement i))) as [a0|b].
     unfold m1. rewrite assoc. unfold in1.
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     unfold Cone1In. apply pathsinv0.
 
     set (e := dni_lastelement_is_inj (dni_lastelement_eq n (dni_lastelement i)
                                                          a0)).
     use (pathscomp0 _ (CoproductIn_idtoiso (stn n) C (a ∘ dni_lastelement)%functions Cone1
                                            e)).
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     apply maponpaths. apply maponpaths. (* Why we need maponpaths twice? *)
     rewrite <- (maponpathscomp _ a).
     apply maponpaths. apply isasetstn.
@@ -183,21 +184,21 @@ Section FinOrdCoproduct_criteria.
     (* From stn 1 *)
     apply CoproductArrowUnique.
     intros i. rewrite <- (X lastelement). rewrite assoc.
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     induction (natlehchoice4 (pr1 lastelement) n (pr2 lastelement)) as [a0|b].
 
     (* This case is false because of a0 *)
     apply fromempty. cbn in a0. apply (isirreflnatlth _ a0).
 
     apply pathsinv0. unfold m2. rewrite assoc. unfold in2.
-    apply cancel_postcomposition. unfold Cone2In.
+    apply maponpaths_2. unfold Cone2In.
 
     (* This case makes sense *)
     set (e := isconnectedstn1 i (invweq(weqstn1tounit) tt)).
     use (pathscomp0 _ (CoproductIn_idtoiso (stn 1) C
                                            (λ _ : _, a lastelement)
                                            Cone2 e)).
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     apply maponpaths. apply maponpaths. (* Why we need maponpaths twice? *)
     fold (@funcomp (stn 1) _ _ (λ _ : stn 1, lastelement) a).
     rewrite <- (maponpathscomp (λ _ : stn 1, lastelement) a).

--- a/UniMath/CategoryTheory/limits/FinOrdProducts.v
+++ b/UniMath/CategoryTheory/limits/FinOrdProducts.v
@@ -159,11 +159,11 @@ Section FinOrdProduct_criteria.
     (* From stn n *)
     apply ProductArrowUnique.
     intros i. rewrite <- (X (dni_lastelement i)). rewrite <- assoc.
-    apply cancel_precomposition.
+    apply maponpaths.
     induction (natlehchoice4 (pr1 (dni_lastelement i)) n
                              (pr2 (dni_lastelement i))) as [a0|b].
     unfold m1. rewrite <- assoc. unfold p1.
-    apply cancel_precomposition.
+    apply maponpaths.
     unfold cone1Pr. apply pathsinv0.
 
     set (e := dni_lastelement_is_inj (dni_lastelement_eq n (dni_lastelement i)
@@ -171,7 +171,7 @@ Section FinOrdProduct_criteria.
     use (pathscomp0 _ (ProductPr_idtoiso (stn n) C (a ∘ dni_lastelement)%functions cone1
                                          (!e))).
     rewrite maponpathsinv0.
-    apply cancel_precomposition.
+    apply maponpaths.
     apply maponpaths. apply maponpaths. (* Why we need maponpaths twice? *)
     apply maponpaths.
     rewrite <- (maponpathscomp _ a).
@@ -186,7 +186,7 @@ Section FinOrdProduct_criteria.
     (* From stn 1 *)
     apply ProductArrowUnique.
     intros i. rewrite <- (X lastelement).  rewrite <- assoc.
-    apply cancel_precomposition.
+    apply maponpaths.
     induction (natlehchoice4 (pr1 lastelement) n (pr2 lastelement)) as [a0|b].
 
     (* This case is false because of a0 *)
@@ -194,13 +194,13 @@ Section FinOrdProduct_criteria.
 
     (* This case makes sense *)
     apply pathsinv0. unfold m2. rewrite <- assoc. unfold p2.
-    apply cancel_precomposition. unfold cone2Pr.
+    apply maponpaths. unfold cone2Pr.
 
     set (e := isconnectedstn1 i (invweq(weqstn1tounit) tt)).
     use (pathscomp0 _ (ProductPr_idtoiso (stn 1) C (λ _ : _, a lastelement)
                                          cone2 (!e))).
     rewrite maponpathsinv0.
-    apply cancel_precomposition.
+    apply maponpaths.
     apply maponpaths. apply maponpaths. (* Why we need maponpaths twice? *)
     apply maponpaths.
     fold (@funcomp (stn 1) _ _ (λ _ : stn 1, lastelement) a).

--- a/UniMath/CategoryTheory/limits/cokernels.v
+++ b/UniMath/CategoryTheory/limits/cokernels.v
@@ -10,6 +10,7 @@
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.CategoryTheory.Categories.
 Require Import UniMath.CategoryTheory.Epis.
@@ -334,7 +335,7 @@ Section cokernels_iso.
     rewrite H.
     rewrite <- (ZeroArrow_comp_left _ _ _ _ _ h).
     rewrite assoc.
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     apply CokernelCompZero.
   Qed.
 
@@ -356,8 +357,8 @@ Section cokernels_iso.
                              (is_inverse_in_precat1 h)). cbn in tmp.
       use (pathscomp0 _ (! tmp)). clear tmp. rewrite id_left.
       use CokernelOutsEq. rewrite CokernelCommutes. rewrite assoc.
-      rewrite <- X. apply cancel_postcomposition. rewrite H.
-      apply cancel_precomposition. apply idpath.
+      rewrite <- X. apply maponpaths_2. rewrite H.
+      apply maponpaths. apply idpath.
   Qed.
 
   Definition Cokernel_up_to_iso {x y z : C} (f : x --> y) (g : y --> z) (CK : Cokernel Z f)
@@ -482,7 +483,7 @@ Section cokernels_epis.
       + use CokernelOut.
         * exact h.
         * rewrite <- (ZeroArrow_comp_right _ _ _ _ _ E). rewrite <- assoc.
-          apply cancel_precomposition. exact H'.
+          apply maponpaths. exact H'.
       + cbn. rewrite CokernelCommutes. apply idpath.
       + intros y0. apply hs.
       + intros y0 X.

--- a/UniMath/CategoryTheory/limits/cones.v
+++ b/UniMath/CategoryTheory/limits/cones.v
@@ -8,6 +8,7 @@ Written by Benedikt Ahrens, following discussions with J. Gross, D. Grayson and 
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.Categories.
@@ -228,11 +229,11 @@ Proof.
   intro t.
   intermediate_path (idtoiso (isotoid C is_cat_C (iso_inv_from_iso (ConeConnectIso f)))·
        pr2 (pr1 a) t).
-  apply cancel_postcomposition.
+  apply maponpaths_2.
   apply maponpaths. apply maponpaths.
   apply inv_isotoid.
   intermediate_path (iso_inv_from_iso (ConeConnectIso f)· pr2 (pr1 a) t).
-  apply cancel_postcomposition.
+  apply maponpaths_2.
   set (H := idtoiso_isotoid _ is_cat_C _ _ (iso_inv_from_iso (ConeConnectIso f))).
   simpl in *.
   apply (base_paths _ _ H).

--- a/UniMath/CategoryTheory/limits/graphs/coequalizers.v
+++ b/UniMath/CategoryTheory/limits/graphs/coequalizers.v
@@ -88,7 +88,7 @@ Section def_coequalizers.
         change (coconeIn (Coequalizer_cocone f g d h H) _) with (f · h).
         change (dmor _ _) with f.
         rewrite <- assoc.
-        apply cancel_precomposition, (pr2 (pr1 H2)).
+        apply maponpaths, (pr2 (pr1 H2)).
       + apply (pr2 (pr1 H2)).
     - abstract (intro t; apply subtypeEquality;
                [intros y; apply impred; intros t0; apply hs
@@ -150,7 +150,7 @@ Section def_coequalizers.
       use (pathscomp0 (!X)); rewrite <- assoc.
       change (dmor _ _) with f.
       change (coconeIn _ _) with (f · h).
-      apply cancel_precomposition, H'.
+      apply maponpaths, H'.
     - apply H'.
   Qed.
 
@@ -191,7 +191,7 @@ Section def_coequalizers.
     + set (X := (coconeInCommutes (colimCocone E) One Two (ii1 tt))).
       use (pathscomp0 (! (maponpaths (λ h' : _, h' · k) X))).
       use (pathscomp0 _ X).
-      rewrite <- assoc. apply cancel_precomposition.
+      rewrite <- assoc. apply maponpaths.
       apply kH.
     + apply kH.
   Qed.

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -16,7 +16,7 @@ Written by Benedikt Ahrens and Anders Mörtberg, 2015-2016
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
-
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.total2_paths.
@@ -317,11 +317,11 @@ apply (tpair _ (colimArrow (mk_ColimCocone D d cd H) (colim CC) (colimCocone CC)
 abstract (split;
     [ apply pathsinv0, colim_endo_is_identity; simpl; intro u;
       rewrite assoc;
-      eapply pathscomp0; [eapply cancel_postcomposition; apply colimArrowCommutes|];
+      eapply pathscomp0; [eapply maponpaths_2; apply colimArrowCommutes|];
       apply (colimArrowCommutes CD) |
       apply pathsinv0, (colim_endo_is_identity _ CD); simpl; intro u;
       rewrite assoc;
-      eapply pathscomp0; [eapply cancel_postcomposition; apply (colimArrowCommutes CD)|];
+      eapply pathscomp0; [eapply maponpaths_2; apply (colimArrowCommutes CD)|];
       apply colimArrowCommutes ]).
 Defined.
 
@@ -346,7 +346,7 @@ use tpair.
   + exact (iinv · colimArrow CC x cx).
   + simpl; intro u.
     rewrite <- (colimArrowCommutes CC x cx u), assoc.
-    apply cancel_postcomposition, pathsinv0, z_iso_inv_on_left, pathsinv0, colimArrowCommutes.
+    apply maponpaths_2, pathsinv0, z_iso_inv_on_left, pathsinv0, colimArrowCommutes.
 - intros p; destruct p as [f Hf].
   apply subtypeEquality.
   + intro a; apply impred; intro u; apply hsC.

--- a/UniMath/CategoryTheory/limits/graphs/eqdiag.v
+++ b/UniMath/CategoryTheory/limits/graphs/eqdiag.v
@@ -188,7 +188,7 @@ Proof.
         apply pathsinv0;
         apply transport_compose|];
       etrans; [
-        apply cancel_postcomposition;
+        apply maponpaths_2;
         eapply pathsinv0; apply heq2|];
       clear;
       now destruct (heq u)).
@@ -216,7 +216,7 @@ Proof.
       etrans;[
         apply transport_compose|];
       rewrite transport_target_postcompose;
-      apply cancel_precomposition;
+      apply maponpaths;
       apply transportf_transpose;
       etrans;[
         apply (transport_swap (λ a b, C⟦a,b⟧))|];

--- a/UniMath/CategoryTheory/limits/graphs/equalizers.v
+++ b/UniMath/CategoryTheory/limits/graphs/equalizers.v
@@ -7,6 +7,7 @@
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.Combinatorics.StandardFiniteSets.
 
@@ -87,7 +88,7 @@ Section def_equalizers.
       + use (pathscomp0 _ (coneOutCommutes cx One Two (ii1 tt))).
         change (coneOut (Equalizer_cone f g d h H) (● 1)%stn) with (h · f).
         rewrite assoc.
-        apply cancel_postcomposition, (pr2 (pr1 H2)).
+        apply maponpaths_2, (pr2 (pr1 H2)).
     - abstract (intro t; apply subtypeEquality;
                 [ intros y; apply impred; intros t0; apply hs
                 | induction t as [t p]; apply path_to_ctr, (p One)]).
@@ -149,7 +150,7 @@ Section def_equalizers.
       use (pathscomp0 (!X)); rewrite assoc.
       change (dmor _ _) with f.
       change (coneOut _ _) with (h · f).
-      apply cancel_postcomposition, H'.
+      apply maponpaths_2, H'.
   Qed.
 
   Definition isEqualizer_Equalizer {a b : C} {f g : C⟦a, b⟧} (E : Equalizer f g) :
@@ -190,7 +191,7 @@ Section def_equalizers.
       use (pathscomp0 (! (maponpaths (λ h' : _, k · h') X))).
       use (pathscomp0 _ X).
       rewrite assoc; change (dmor _ _) with f.
-      apply cancel_postcomposition, kH.
+      apply maponpaths_2, kH.
   Qed.
 
   Definition from_Equalizer_to_Equalizer {a b : C} {f g : C⟦a, b⟧} (E1 E2 : Equalizer f g) :

--- a/UniMath/CategoryTheory/limits/graphs/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/graphs/pullbacks.v
@@ -2,6 +2,8 @@
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.PartA.
+
 Require Import UniMath.Combinatorics.StandardFiniteSets.
 Require Import UniMath.CategoryTheory.Categories.
 
@@ -101,7 +103,7 @@ Proof.
       change (three_rec_dep (λ n, C⟦d,_⟧) _ _ _ _) with (p1 · f).
       rewrite assoc.
       eapply pathscomp0.
-        eapply cancel_postcomposition, (pr2 (pr1 H2)).
+        eapply maponpaths_2, (pr2 (pr1 H2)).
       apply (coneOutCommutes cx One Two tt).
     * apply (pr2 (pr2 (pr1 H2))).
   + abstract (intro t; apply subtypeEquality;
@@ -206,7 +208,7 @@ Proof.
   simpl.
   rewrite assoc.
   eapply pathscomp0.
-    apply cancel_postcomposition, H2.
+    apply maponpaths_2, H2.
   apply (!Hcomm).
 Qed.
 
@@ -379,7 +381,7 @@ Proof.
     assert (T:= coneOutCommutes (limCone Pb) Three Two tt).
     eapply pathscomp0. apply maponpaths. apply (!T).
     rewrite assoc.
-    eapply pathscomp0. apply cancel_postcomposition.
+    eapply pathscomp0. apply maponpaths_2.
        apply kH2.
        apply T.
  - assumption.

--- a/UniMath/CategoryTheory/limits/graphs/pushouts.v
+++ b/UniMath/CategoryTheory/limits/graphs/pushouts.v
@@ -6,6 +6,7 @@
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.Combinatorics.StandardFiniteSets.
 
@@ -97,7 +98,7 @@ Section def_po.
       * abstract (use (pathscomp0 _ (coconeInCommutes cx One Two tt));
         change (three_rec_dep _ _ _ _ _) with (f · i1);
         change (dmor _ _) with f; rewrite <- assoc;
-        apply cancel_precomposition, (pr1 (pr2 (pr1 H2)))).
+        apply maponpaths, (pr1 (pr2 (pr1 H2)))).
       * abstract ( apply (pr1 (pr2 (pr1 H2)))).
       * abstract (now use (pathscomp0 _ (pr2 (pr2 (pr1 H2))))).
     + abstract (intro t; apply subtypeEquality;
@@ -228,7 +229,7 @@ Section def_po.
       set (T := (coconeInCommutes (colimCocone Po) One Three tt)).
       use (pathscomp0 (! (maponpaths (λ h' : _, h' · k) T))).
       use (pathscomp0 _ (coconeInCommutes (colimCocone Po) One Three tt)).
-      rewrite <- assoc. apply cancel_precomposition.
+      rewrite <- assoc. apply maponpaths.
       apply kH2.
     - apply kH1.
     - apply kH2.

--- a/UniMath/CategoryTheory/limits/kernels.v
+++ b/UniMath/CategoryTheory/limits/kernels.v
@@ -11,6 +11,7 @@
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.CategoryTheory.Categories.
 Require Import UniMath.CategoryTheory.Monics.
@@ -336,7 +337,7 @@ Section kernels_iso.
     rewrite H.
     rewrite <- (ZeroArrow_comp_right _ _ _ _ _ h).
     rewrite <- assoc.
-    apply cancel_precomposition.
+    apply maponpaths.
     apply KernelCompZero.
   Qed.
 
@@ -357,7 +358,7 @@ Section kernels_iso.
       use (pathscomp0 _ (! (maponpaths (λ gg : _, KernelIn Z K w h0 H' · gg)
                                        (is_inverse_in_precat2 h)))).
       rewrite id_right. use KernelInsEq. rewrite KernelCommutes. rewrite <- X.
-      rewrite <- assoc. apply cancel_precomposition. apply pathsinv0.
+      rewrite <- assoc. apply maponpaths. apply pathsinv0.
       apply H.
   Qed.
 
@@ -482,7 +483,7 @@ Section kernels_monics.
       use unique_exists.
       + use KernelIn.
         * exact h.
-        * rewrite assoc. rewrite <- (ZeroArrow_comp_left _ _ _ _ _ M). apply cancel_postcomposition.
+        * rewrite assoc. rewrite <- (ZeroArrow_comp_left _ _ _ _ _ M). apply maponpaths_2.
           exact H'.
       + cbn. rewrite KernelCommutes. apply idpath.
       + intros y0. apply hs.

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -17,7 +17,7 @@ Direct implementation of pullbacks together with:
 
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
-
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -696,7 +696,7 @@ Proof.
         {
         match goal with |[|- ?AA · _ · _ · ?K = _ ]
                          => intermediate_path (AA ·  K) end.
-        - apply cancel_postcomposition.
+        - apply maponpaths_2.
           repeat rewrite <- assoc.
           rewrite iso_after_iso_inv.
           apply id_right.
@@ -768,7 +768,7 @@ Proof.
       unfold xy.
       simpl.
       eapply pathscomp0.
-      eapply cancel_postcomposition.
+      eapply maponpaths_2.
       assert (XXX := XX FxFy).
       apply XX. exact t.
     + use (invmaponpathsweq (weqpair _ (Fff _ _ ))).
@@ -778,7 +778,7 @@ Proof.
       unfold xy.
       simpl.
       eapply pathscomp0.
-      eapply cancel_postcomposition.
+      eapply maponpaths_2.
       assert (XXX := XX FxFy).
       apply XX. exact p.
   - simpl.
@@ -1040,7 +1040,7 @@ Section pullbacks_functor_category.
     rewrite (nat_trans_ax α a b f).
     rewrite (nat_trans_ax β a b f).
     repeat rewrite assoc.
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     exact (PullbackSqrCommutes pba).
   Qed.
 
@@ -1086,12 +1086,12 @@ Section pullbacks_functor_category.
     use PullbackArrowUnique.
     rewrite functor_comp. rewrite assoc.
     rewrite <- assoc. rewrite pz1. rewrite assoc.
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     apply py1.
 
     rewrite functor_comp. rewrite assoc.
     rewrite <- assoc. rewrite pz2. rewrite assoc.
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     apply py2.
   Qed.
 

--- a/UniMath/CategoryTheory/precomp_fully_faithful.v
+++ b/UniMath/CategoryTheory/precomp_fully_faithful.v
@@ -24,6 +24,7 @@ Precomposition with a fully faithful and
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.CategoryTheory.Categories.
 Require Import UniMath.CategoryTheory.functor_categories.
@@ -70,7 +71,7 @@ Proof.
          (functor_on_iso_is_iso _ _ _ _ _ f)).
       repeat rewrite nat_trans_ax.
       change (gamma (H a)) with (pr1 gamma ((pr1 H) a)).
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       apply (nat_trans_eq_pointwise ex a).
 Qed.
 

--- a/UniMath/CategoryTheory/slicecat.v
+++ b/UniMath/CategoryTheory/slicecat.v
@@ -42,7 +42,7 @@ Contents:
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
-
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -471,7 +471,7 @@ use mk_ColimCocone.
     * apply colimArrow, (mapcocone U _ ccy).
     * abstract (apply pathsinv0, colimArrowUnique; intros v; simpl; rewrite assoc;
                 eapply pathscomp0;
-                  [apply cancel_postcomposition,
+                  [apply maponpaths_2,
                         (colimArrowCommutes H _ (mapcocone U _ ccy) v)|];
                 destruct ccy as [f Hf]; simpl; apply (! pr2 (f v))).
   + abstract (intro v; apply eq_mor_slicecat; simpl;

--- a/UniMath/HomologicalAlgebra/CohomologyComplex.v
+++ b/UniMath/HomologicalAlgebra/CohomologyComplex.v
@@ -19,6 +19,7 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.NaturalNumbers.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids_and_Groups.
@@ -224,7 +225,7 @@ Section def_cohomology_complex.
     use MorphismEq.
     intros i. cbn. apply pathsinv0.
     apply CokernelEndo_is_identity. unfold CohomologyMorphism_Mor. rewrite CokernelCommutes.
-    rewrite <- id_left. apply cancel_postcomposition.
+    rewrite <- id_left. apply maponpaths_2.
     use KernelInsEq. rewrite KernelCommutes.
     rewrite id_left. rewrite id_right. apply idpath.
   Qed.
@@ -239,7 +240,7 @@ Section def_cohomology_complex.
     intros i. cbn. unfold CohomologyMorphism_Mor. use CokernelOutsEq. rewrite CokernelCommutes.
     rewrite assoc. rewrite CokernelCommutes.
     rewrite <- assoc. rewrite CokernelCommutes.
-    rewrite assoc. apply cancel_postcomposition.
+    rewrite assoc. apply maponpaths_2.
     use KernelInsEq. rewrite KernelCommutes.
     rewrite <- assoc. rewrite KernelCommutes.
     rewrite assoc. rewrite KernelCommutes.
@@ -535,7 +536,7 @@ Section def_cohomology'_complex.
         use (KernelArrowisMonic (to_Zero A) (Kernel (Diff C i))). unfold K1.
         rewrite <- assoc. rewrite KernelCommutes.
         fold φ1. rewrite <- (KernelCommutes (to_Zero A) K3 _ _ H').
-        apply cancel_precomposition. apply idpath.
+        apply maponpaths. apply idpath.
       + intros y. apply hs.
       + intros y X. cbn beta in X. apply (CohomologyComplexIso_isMonic C i). fold K1. rewrite X.
         use (KernelArrowisMonic (to_Zero A) (Kernel (Diff C i))). unfold K1.
@@ -610,7 +611,7 @@ Section def_cohomology'_complex.
                                                  (Diff C (i - 1))))).
         unfold CK1. rewrite assoc. rewrite CokernelCommutes. fold φ2.
         rewrite <- (CokernelCommutes (to_Zero A) CK3 _ _ H').
-        apply cancel_postcomposition. apply idpath.
+        apply maponpaths_2. apply idpath.
       + intros y. apply hs.
       + intros y X. cbn beta in X. apply (CohomologyComplexIso_isEpi C i). fold CK1. rewrite X.
         use (CokernelArrowisEpi
@@ -955,7 +956,7 @@ Section def_cohomology_functor_additive.
       cbn in tmp. rewrite <- tmp. clear tmp.
       use CokernelOutsEq. rewrite CokernelCommutes. rewrite CokernelCommutes.
       set (tmp := @to_postmor_linear' (AbelianToAdditive A hs)). cbn in tmp.
-      rewrite <- tmp. clear tmp. apply cancel_postcomposition.
+      rewrite <- tmp. clear tmp. apply maponpaths_2.
       set (tmp := KernelInOp (AbelianToAdditive A hs)).
       cbn in tmp. rewrite <- tmp. clear tmp.
       use KernelInsEq. rewrite KernelCommutes. rewrite KernelCommutes.
@@ -979,7 +980,7 @@ Section def_cohomology_functor_additive.
       use CokernelOutsEq.
       rewrite CokernelCommutes. rewrite ZeroArrow_comp_right.
       rewrite <- (ZeroArrow_comp_left _ _ _ _ _ (CokernelArrow CK2)).
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       use KernelInsEq.
       rewrite KernelCommutes.
       rewrite ZeroArrow_comp_left. cbn. rewrite ZeroArrow_comp_right. apply idpath.
@@ -1092,7 +1093,7 @@ Section def_cohomology_homotopy.
                                 (CohomologyComplex_KernelIn_eq A hs C2 i))).
     {
       use KernelInsEq. rewrite KernelCommutes. rewrite <- assoc. rewrite <- assoc.
-      apply cancel_precomposition. rewrite KernelCommutes.
+      apply maponpaths. rewrite KernelCommutes.
       rewrite transport_target_postcompose. apply idpath.
     }
     cbn. cbn in e1. rewrite e1. clear e1. rewrite <- assoc. rewrite CokernelCompZero.
@@ -1409,7 +1410,7 @@ Section def_kernel_cokernel_complex.
   Proof.
     rewrite <- assoc.
     rewrite <- (ZeroArrow_comp_right _ _ _ _ _ (KernelArrow (Kernel (Diff C i)))).
-    apply cancel_precomposition.
+    apply maponpaths.
     exact (DSq (AbelianToAdditive A hs) C i).
   Qed.
 
@@ -1478,7 +1479,7 @@ Section def_kernel_cokernel_complex.
     rewrite ZeroArrow_comp_right. rewrite assoc. rewrite CokernelCommutes.
     rewrite <- assoc. rewrite CokernelCommutes. rewrite assoc.
     rewrite <- (ZeroArrow_comp_left _ _ _ _ _ (CokernelArrow (Cokernel (Diff C (i + 1 + 1 - 1))))).
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     use (transport_source_path _ _ (! maponpaths C (hzrplusminus i 1 @ hzrminusplus' i 1))).
     rewrite <- transport_source_precompose.
     rewrite <- maponpathsinv0. rewrite <- functtransportf.
@@ -1714,7 +1715,7 @@ Section def_kernel_cokernel_complex.
                              (C (i + 1)) (Diff C i) (CohomologyComplex_KernelIn_eq A hs C i))).
     cbn. use (KernelArrowisMonic (to_Zero A) (Kernel (Diff C (i + 1)))).
     rewrite <- assoc. rewrite <- assoc. rewrite KernelCommutes. rewrite ZeroArrow_comp_left.
-    cbn. cbn in K. fold K. rewrite <- (KernelCompZero (to_Zero A) K). apply cancel_precomposition.
+    cbn. cbn in K. fold K. rewrite <- (KernelCompZero (to_Zero A) K). apply maponpaths.
     use CokernelOutsEq. rewrite assoc. rewrite CokernelCommutes. rewrite CokernelCommutes.
     use transport_source_path.
     - exact (C (i - 1 + 1)).
@@ -1840,7 +1841,7 @@ Section def_kernel_cokernel_complex.
     rewrite <- (KernelCompZero (to_Zero A) K2).
     unfold CKO. unfold K2. clear K2. unfold CKO. clear CKO. cbn.
     rewrite <- assoc.
-    apply cancel_precomposition.
+    apply maponpaths.
     apply pathsinv0. use KernelCommutes.
   Qed.
 
@@ -1909,7 +1910,7 @@ Section def_kernel_cokernel_complex.
                                  (CokernelArrow CK1))
                               (CokernelKernelCohomology1_Mor1_eq1 C i))).
     {
-      rewrite assoc. rewrite assoc. apply cancel_postcomposition.
+      rewrite assoc. rewrite assoc. apply maponpaths_2.
       assert (ee' : (CohomologyComplexIso_Mor_i A hs C i)
                       · (inv_from_iso ((CohomologyComplexIso_Mor_i A hs C i)
                                           ,, (CohomologyComplexIso_is_iso_i A hs C i))) =
@@ -1931,7 +1932,7 @@ Section def_kernel_cokernel_complex.
     use (pathscomp0 ee). clear ee.
     (* Use KernelCommutes and CokernelCommutes to solve the goal *)
     rewrite assoc. rewrite KernelCommutes. rewrite <- id_right. rewrite <- assoc.
-    apply cancel_precomposition. use CokernelOutsEq.
+    apply maponpaths. use CokernelOutsEq.
     rewrite id_right. rewrite assoc. rewrite CokernelCommutes.
     use transport_source_path.
     -- exact (C i).
@@ -2012,7 +2013,7 @@ Section def_kernel_cokernel_complex.
     cbn.
     use KernelInsEq. rewrite <- assoc. rewrite KernelCommutes. rewrite assoc.
     rewrite KernelCommutes.
-    rewrite id_left. rewrite <- id_right. rewrite <- assoc. apply cancel_precomposition.
+    rewrite id_left. rewrite <- id_right. rewrite <- assoc. apply maponpaths.
     use CokernelOutsEq. rewrite assoc. rewrite CokernelCommutes. rewrite id_right.
     use transport_source_path.
     - exact (C (i - 1 + 1)).
@@ -2064,7 +2065,7 @@ Section def_kernel_cokernel_complex.
     - exact (C (i + 1 - 1)).
     - exact (! maponpaths C (hzrplusminus i 1)).
     - rewrite transport_source_ZeroArrow. cbn in tmp. rewrite <- tmp. clear tmp.
-      rewrite transport_source_precompose. apply cancel_postcomposition. clear CK.
+      rewrite transport_source_precompose. apply maponpaths_2. clear CK.
       rewrite transport_source_KernelIn. use KernelInsEq.
       rewrite KernelCommutes. rewrite KernelCommutes.
       apply pathsinv0. rewrite <- maponpathsinv0.

--- a/UniMath/HomologicalAlgebra/Complexes.v
+++ b/UniMath/HomologicalAlgebra/Complexes.v
@@ -16,6 +16,7 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.NaturalNumbers.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids_and_Groups.
@@ -290,7 +291,7 @@ Section def_complexes.
     rewrite assoc.
     rewrite <- (MComm M1).
     rewrite <- assoc. rewrite <- assoc.
-    apply cancel_precomposition.
+    apply maponpaths.
     exact (MComm M2 i).
   Qed.
 
@@ -595,7 +596,7 @@ Section def_complexes.
     rewrite <- (MComm g i).
     rewrite assoc. rewrite assoc.
     rewrite <- to_postmor_linear'.
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     rewrite <- FromBinDirectSumFormulaUnique.
     unfold FromBinDirectSumFormula.
     apply idpath.
@@ -628,7 +629,7 @@ Section def_complexes.
     rewrite (MComm g i).
     rewrite <- assoc. rewrite <- assoc.
     rewrite <- to_premor_linear'.
-    apply cancel_precomposition.
+    apply maponpaths.
     rewrite <- ToBinDirectSumFormulaUnique.
     unfold ToBinDirectSumFormula.
     apply idpath.
@@ -901,7 +902,7 @@ Section acyclic_complexes.
     identity a · transportf (precategory_morphisms a) (maponpaths C e'') (f · Diff C i).
   Proof.
     rewrite id_left. rewrite transport_target_postcompose.
-    rewrite transport_compose. apply cancel_precomposition.
+    rewrite transport_compose. apply maponpaths.
     rewrite <- maponpathsinv0.
     use (pathscomp0 (! (transport_hz_section A C 1 (Diff C) _ _ e))).
     use transportf_paths. apply maponpaths. apply isasethz.
@@ -993,7 +994,7 @@ Section acyclic_complexes.
   Proof.
     rewrite id_right. rewrite <- (pathsinv0inv0 (! hzrminusplus i 1 @ e'')).
     rewrite maponpathsinv0. rewrite <- transport_compose.
-    apply cancel_postcomposition. rewrite transport_source_target_comm.
+    apply maponpaths_2. rewrite transport_source_target_comm.
     induction e. use transportf_paths. apply maponpaths. apply isasethz.
   Qed.
 
@@ -1009,14 +1010,14 @@ Section acyclic_complexes.
     rewrite ZeroArrow_comp_left. rewrite assoc.
     rewrite <- (pathsinv0inv0 e'). rewrite maponpathsinv0.
     rewrite <- transport_compose.
-    rewrite <- (ZeroArrow_comp_left _ _ _ _ _ f). apply cancel_postcomposition.
+    rewrite <- (ZeroArrow_comp_left _ _ _ _ _ f). apply maponpaths_2.
     use (transport_target_path _ _ (! maponpaths C (hzrminusplus i 1))).
     rewrite <- transport_target_postcompose. rewrite transport_f_f.
     rewrite pathsinv0r. rewrite transport_target_ZeroArrow.
     use (transport_target_path _ _ (maponpaths C (hzplusradd _ _ 1 e'))).
     rewrite transport_target_ZeroArrow. rewrite transport_f_f. cbn.
     rewrite <- (DSq A C i0). rewrite transport_compose.
-    rewrite transport_target_postcompose. apply cancel_precomposition.
+    rewrite transport_target_postcompose. apply maponpaths.
     use (pathscomp0 (transport_hz_source_target A _ 1 (Diff C) _ _ e')).
     rewrite transport_source_target_comm.
     rewrite maponpathsinv0. rewrite pathsinv0inv0.
@@ -1156,7 +1157,7 @@ Section complexes_precat.
     - induction T. exact H.
     - induction (isdecrelhzeq (i + 1) i0) as [T' | F'].
       + induction T'. cbn. unfold idfun. rewrite <- assoc. rewrite <- assoc. rewrite <- MComm.
-        rewrite assoc. rewrite assoc. apply cancel_postcomposition.
+        rewrite assoc. rewrite assoc. apply maponpaths_2.
         exact H.
       + apply idpath.
   Qed.
@@ -1215,7 +1216,7 @@ Section complexes_precat.
       }
       cbn in e. cbn. rewrite e. clear e.
       rewrite transport_target_postcompose.
-      rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
+      rewrite <- assoc. rewrite <- assoc. apply maponpaths.
       rewrite transport_f_f. rewrite <- maponpathscomp0.
       use (@transport_source_path
              A (C1 i) (C1 (i0 + 1)) a _ _
@@ -1281,7 +1282,7 @@ Section complexes_precat.
           apply (iso_inv_after_iso (isopair _ (H i))).
         }
         rewrite assoc. rewrite assoc. rewrite e0. rewrite id_left.
-        rewrite <- (MComm f i). apply cancel_precomposition.
+        rewrite <- (MComm f i). apply maponpaths.
         assert (e1 : inv_from_iso (MMor f (i + 1),, H (i + 1)) · MMor f (i + 1) = identity _).
         {
           apply (iso_after_iso_inv (isopair _ (H (i + 1)))).
@@ -1843,7 +1844,7 @@ Section complexes_abelian.
     rewrite <- assoc. rewrite <- assoc. fold ker.
     rewrite (KernelCommutes _ ker). cbn. use (pathscomp0 _ (MComm h i)).
     set (tmp := MComm (MonicArrow _ M) i). cbn in tmp. rewrite <- tmp. clear tmp.
-    rewrite assoc. apply cancel_postcomposition.
+    rewrite assoc. apply maponpaths_2.
     apply (KernelCommutes _ (MonicToKernel (mk_Monic A _ (isM i))) (w i) (MMor h i)).
   Qed.
 
@@ -1987,7 +1988,7 @@ Section complexes_abelian.
     apply (CokernelArrowisEpi _ coker). rewrite assoc. rewrite assoc. rewrite CokernelCommutes.
     use (pathscomp0 _ (! (MComm h i))). cbn.
     set (tmp := MComm (EpiArrow _ E) i). cbn in tmp. rewrite tmp. clear tmp.
-    rewrite <- assoc. apply cancel_precomposition.
+    rewrite <- assoc. apply maponpaths.
     apply (CokernelCommutes _ (EpiToCokernel (mk_Epi A _ (isE (i + 1))))).
   Qed.
 

--- a/UniMath/HomologicalAlgebra/KA.v
+++ b/UniMath/HomologicalAlgebra/KA.v
@@ -114,10 +114,10 @@ Section complexes_homotopies.
     }
     rewrite e1. clear e1.
     rewrite <- PreAdditive_unel_zero. rewrite to_lunax'. rewrite to_runax'.
-    (* Here the idea is to apply cancel_precomposition *)
-    rewrite transport_target_postcompose. rewrite <- assoc. apply cancel_precomposition.
-    (* Other application of cancel_precomposition *)
-    rewrite transport_compose. rewrite transport_target_postcompose. apply cancel_precomposition.
+    (* Here the idea is to apply maponpaths *)
+    rewrite transport_target_postcompose. rewrite <- assoc. apply maponpaths.
+    (* Other application of maponpaths *)
+    rewrite transport_compose. rewrite transport_target_postcompose. apply maponpaths.
     (* Follows frm transport of differentials *)
     apply pathsinv0. rewrite <- maponpathsinv0.
     use (pathscomp0 _ (transport_hz_section A C2 1 (Diff C2) _ _ (hzrplusminus i 1))).

--- a/UniMath/HomologicalAlgebra/KAPreTriangulated.v
+++ b/UniMath/HomologicalAlgebra/KAPreTriangulated.v
@@ -16,6 +16,8 @@ Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.NaturalNumbers.
 
+Require Import UniMath.MoreFoundations.PartA.
+
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids_and_Groups.
 
@@ -410,7 +412,7 @@ Section KAPreTriangulated.
                       (AddEquivUnitIso (TranslationEquiv A) (Source (KADTriDataMor I)))))))
       in tmp'''.
     use (pathscomp0 _ (! tmp''')). clear tmp'''. unfold postcompose.
-    apply cancel_postcomposition. apply maponpaths.
+    apply maponpaths_2. apply maponpaths.
     use InvTranslationFunctorHImEq. apply idpath.
   Qed.
 
@@ -424,7 +426,7 @@ Section KAPreTriangulated.
   Proof.
     rewrite id_left. use (pathscomp0 (! (InvRotMorphismInvComm1 A I'))).
     use (pathscomp0 (functor_comp (ComplexHomotFunctor A) _ _)).
-    use cancel_postcomposition.
+    use maponpaths_2.
     exact (hfiberpr2 _ _ (KADTriDataFiber I)).
   Qed.
 
@@ -531,7 +533,7 @@ Section KAPreTriangulated.
                 ** exact (! (KAIdComm _ _ (idpath _))).
                 ** exact (! (KAIdComm _ _ (idpath _))).
           -- cbn. rewrite id_left.
-             use (pathscomp0 (! (id_right _))). apply cancel_precomposition.
+             use (pathscomp0 (! (id_right _))). apply maponpaths.
              apply (! (functor_id _ _)).
         * use mk_TriMor_is_iso.
           -- exact (is_z_isomorphism_identity _).
@@ -557,10 +559,10 @@ Section KAPreTriangulated.
     rewrite <- (assoc (MPMor1 (TriIsoInv (KADTriDataIso I1)))).
     rewrite <- (assoc (MPMor1 (TriIsoInv (KADTriDataIso I1)))).
     rewrite <- (assoc (MPMor1 (TriIsoInv (KADTriDataIso I1)))).
-    apply cancel_precomposition.
+    apply maponpaths.
     apply (maponpaths (postcompose (MPMor2 (KADTriDataIso I2)))) in H.
     unfold postcompose in H. use (pathscomp0 _ H). clear H.
-    rewrite <- (assoc g1). rewrite <- (assoc g1). apply cancel_precomposition.
+    rewrite <- (assoc g1). rewrite <- (assoc g1). apply maponpaths.
     exact (MPComm1 (KADTriDataIso I2)).
   Qed.
 
@@ -652,7 +654,7 @@ Section KAPreTriangulated.
            _ (maponpaths # (ComplexHomotFunctor A)
                          (MappingConeMorExtComm2 A I1' I2' h1' h2' HH1 (! HH2)))).
     use (pathscomp0 _ (! (functor_comp (ComplexHomotFunctor A) _ _))).
-    apply cancel_precomposition. use TranslationFunctorHImEq.
+    apply maponpaths. use TranslationFunctorHImEq.
     exact (hfiberpr2 _ _ h1).
   Qed.
 

--- a/UniMath/HomologicalAlgebra/KATriangulated.v
+++ b/UniMath/HomologicalAlgebra/KATriangulated.v
@@ -11,6 +11,8 @@ Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.NaturalNumbers.
 
+Require Import UniMath.MoreFoundations.PartA.
+
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids_and_Groups.
 
@@ -190,9 +192,9 @@ Section KATriangulated.
     - use (pathscomp0 (! (functor_comp (ComplexHomotFunctor A) _ _))).
       apply maponpaths. exact (KAOctaMor2Comm f1'' g1'').
     - use (pathscomp0 (KAOctaComm5' f1'' g1'')).
-      apply cancel_postcomposition. exact (hfiberpr2 _ _ g1').
+      apply maponpaths_2. exact (hfiberpr2 _ _ g1').
     - use (pathscomp0 (KAOctaComm4' f1'' g1'')).
-      apply cancel_precomposition. apply maponpaths. exact (hfiberpr2 _ _ f1').
+      apply maponpaths. apply maponpaths. exact (hfiberpr2 _ _ f1').
   Qed.
 
   Definition KATriang : Triang.

--- a/UniMath/HomologicalAlgebra/MappingCone.v
+++ b/UniMath/HomologicalAlgebra/MappingCone.v
@@ -14,6 +14,8 @@ Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.NaturalNumbers.
 
+Require Import UniMath.MoreFoundations.PartA.
+
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids_and_Groups.
 
@@ -539,7 +541,7 @@ Section mapping_cone_of_id.
                    to_Pr2 A DS1 · to_inv (Diff C i)).
       {
         rewrite transport_target_postcompose.
-        rewrite transport_compose. apply cancel_precomposition.
+        rewrite transport_compose. apply maponpaths.
         rewrite <- transport_target_to_inv. rewrite <- transport_source_to_inv.
         apply maponpaths. rewrite <- maponpathsinv0. rewrite pathsinv0inv0.
         induction (hzrminusplus i 1). apply idpath.
@@ -822,7 +824,7 @@ Section rotation_mapping_cone.
     rewrite to_runax''. rewrite to_binop_inv_inv. apply maponpaths.
     rewrite to_commax'.
     use to_binop_eq.
-    - apply cancel_postcomposition. rewrite <- PreAdditive_invrcomp.
+    - apply maponpaths_2. rewrite <- PreAdditive_invrcomp.
       rewrite <- PreAdditive_invrcomp. apply maponpaths.
       exact (MComm f (i + 1)).
     - apply idpath.
@@ -1040,7 +1042,7 @@ Section rotation_mapping_cone.
     set (DS10 := to_BinDirectSums A (C2 (i + 1 - 1 + 1)) DS9).
     unfold DiffTranslationComplex.
     rewrite <- to_premor_linear'. rewrite assoc.
-    rewrite transport_target_postcompose. rewrite <- assoc. apply cancel_precomposition.
+    rewrite transport_target_postcompose. rewrite <- assoc. apply maponpaths.
     rewrite <- transport_source_precompose. rewrite <- transport_target_postcompose.
     rewrite to_premor_linear'. rewrite to_premor_linear'. rewrite assoc.
     rewrite (assoc (to_In1 A DS8)). rewrite (assoc (to_In1 A DS8)).
@@ -1098,7 +1100,7 @@ Section rotation_mapping_cone.
   Proof.
     intros DS1 DS2 DS3 DS4 DS9 DS10.
     rewrite assoc. rewrite <- (assoc _ (to_In2 A DS3)). rewrite (to_IdIn2 A DS3).
-    rewrite id_right. rewrite transport_target_postcompose. apply cancel_precomposition.
+    rewrite id_right. rewrite transport_target_postcompose. apply maponpaths.
     set (tmp := transport_hz_double_section_source_target
                   A (λ i0 : hz, C2 (i0 + 1))
                   (λ i0 : hz, (to_BinDirectSums
@@ -1145,7 +1147,7 @@ Section rotation_mapping_cone.
     rewrite transport_target_postcompose. rewrite <- (assoc (to_Pr2 A DS2)).
     rewrite <- (assoc (to_Pr2 A DS2)). rewrite <- (assoc (to_Pr2 A DS2)).
     rewrite <- (assoc (to_Pr2 A DS2)). rewrite <- assoc. rewrite <- assoc.
-    rewrite <- to_premor_linear'. apply cancel_precomposition.
+    rewrite <- to_premor_linear'. apply maponpaths.
     rewrite assoc. rewrite <- to_postmor_linear'.
     unfold MappingConeDiff.
     unfold MappingConeDiff1, MappingConeDiff2, MappingConeDiff3. cbn.
@@ -1156,7 +1158,7 @@ Section rotation_mapping_cone.
     rewrite assoc. rewrite assoc. rewrite <- (assoc _ _ (to_Pr2 A DS3)).
     rewrite <- (assoc _ _ (to_Pr2 A DS3)). rewrite <- (assoc _ _ (to_Pr2 A DS3)).
     rewrite (to_Unel1' DS3). rewrite (to_IdIn2 A DS3). rewrite id_right. rewrite id_right.
-    rewrite ZeroArrow_comp_right. rewrite to_lunax''. apply cancel_precomposition.
+    rewrite ZeroArrow_comp_right. rewrite to_lunax''. apply maponpaths.
     set (tmp := transport_hz_double_section_source_target
                   A (λ i0 : hz, C2 (i0 + 1))
                   (λ i0 : hz, (to_BinDirectSums
@@ -1312,7 +1314,7 @@ Section rotation_mapping_cone.
     unfold DiffTranslationComplex.
     rewrite to_premor_linear'. rewrite to_premor_linear'.
     use to_binop_eq.
-    - rewrite <- assoc. apply cancel_precomposition.
+    - rewrite <- assoc. apply maponpaths.
       rewrite <- transport_source_precompose. rewrite assoc. rewrite (to_IdIn1 A DS8).
       rewrite id_left. induction (hzrminusplus i 1). apply idpath.
     - rewrite <- assoc. rewrite <- transport_source_precompose. rewrite assoc.
@@ -1461,7 +1463,7 @@ Section rotation_mapping_cone.
       + rewrite <- PreAdditive_invrcomp. rewrite <- PreAdditive_invlcomp.
         rewrite PreAdditive_invrcomp. rewrite <- to_premor_linear'.
         rewrite <- (ZeroArrow_comp_right _ _ _ _ _ (to_Pr2 A DS1 · Diff C2 i)).
-        apply cancel_precomposition.
+        apply maponpaths.
         unfold DS2. unfold DS1.
         rewrite <- (@to_linvax'
                      A (Additive.to_Zero A) _ _
@@ -1509,7 +1511,7 @@ Section rotation_mapping_cone.
         rewrite <- PreAdditive_invrcomp. rewrite <- PreAdditive_invlcomp. rewrite inv_inv_eq.
         rewrite <- to_assoc. rewrite (to_commax' A (to_In2 A DS2)). rewrite to_assoc.
         use to_binop_eq.
-        * apply cancel_precomposition.
+        * apply maponpaths.
           set (tmp := @transport_hz_to_In1
                         A (λ i0 : hz, C2 (i0 + 1))
                         (λ i0 : hz, to_BinDirectSums A (C1 (i0 + 1)) (C2 i0))
@@ -1536,7 +1538,7 @@ Section rotation_mapping_cone.
           }
           rewrite e. clear e. rewrite <- (to_BinOpId A DS1). rewrite to_postmor_linear'.
           rewrite to_commax'. rewrite <- to_assoc. rewrite (@to_linvax' A (Additive.to_Zero A)).
-          rewrite to_lunax''. rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
+          rewrite to_lunax''. rewrite <- assoc. rewrite <- assoc. apply maponpaths.
           unfold DS4, DS3, DS2, DS1. induction (hzrminusplus i 1). apply idpath.
   Qed.
 
@@ -1653,7 +1655,7 @@ Section inv_rotation_mapping_cone.
       rewrite <- (assoc (to_Pr1 A DS2)). rewrite <- (assoc (to_Pr1 A DS2)).
       rewrite <- to_premor_linear'. rewrite <- to_premor_linear'.
       rewrite <- (assoc (to_Pr1 A DS2)). rewrite <- to_premor_linear'.
-      apply cancel_precomposition. rewrite <- to_assoc.
+      apply maponpaths. rewrite <- to_assoc.
       rewrite (to_commax'
                  A _
                  (((to_Pr2 A DS1) · (Diff C2 (i + 1 - 1))
@@ -1673,7 +1675,7 @@ Section inv_rotation_mapping_cone.
       use (pathscomp0 (! tmp)). clear tmp.
       use to_binop_eq.
       + rewrite transport_compose. rewrite <- assoc. rewrite <- assoc.
-        apply cancel_precomposition. rewrite <- transport_target_postcompose.
+        apply maponpaths. rewrite <- transport_target_postcompose.
         rewrite <- transport_target_postcompose. rewrite assoc.
         rewrite <- transport_target_postcompose.
         rewrite <- maponpathsinv0.
@@ -1681,9 +1683,9 @@ Section inv_rotation_mapping_cone.
         use (pathscomp0 (! tmp)). clear tmp. apply pathsinv0.
         rewrite transport_target_postcompose. rewrite transport_compose.
         rewrite <- (id_right (Diff C2 (i + 1 - 1))). rewrite transport_target_postcompose.
-        rewrite id_right. rewrite <- assoc. apply cancel_precomposition.
+        rewrite id_right. rewrite <- assoc. apply maponpaths.
         rewrite <- (to_IdIn2 A DS5). rewrite transport_target_postcompose.
-        apply cancel_precomposition.
+        apply maponpaths.
         assert (e : ! (@maponpaths hz A (λ i0 : pr1 hz, to_BinDirectSums A (C1 (i0 + 1)) (C2 i0))
                                    _ _ (hzrminusplus (i + 1) 1 @ ! hzrplusminus (i + 1) 1)) =
                     @maponpaths hz A (λ i0 : pr1 hz, to_BinDirectSums A (C1 (i0 + 1)) (C2 i0))
@@ -1756,13 +1758,13 @@ Section inv_rotation_mapping_cone.
                                   (to_Pr1 A DS1) · f (i + 1))).
           {
             rewrite transport_compose. rewrite <- assoc. rewrite <- assoc.
-            apply cancel_precomposition.
+            apply maponpaths.
             set (tmp := transport_hz_double_section A C1 C2 f _ _ (hzrminusplus (i + 1) 1)).
             rewrite <- maponpathsinv0. use (pathscomp0 _ tmp). clear tmp.
             rewrite <- (id_right (f (i + 1 - 1 + 1))). rewrite transport_target_postcompose.
-            rewrite id_right. apply cancel_precomposition.
+            rewrite id_right. apply maponpaths.
             rewrite <- (to_IdIn2 A DS5). rewrite transport_target_postcompose.
-            rewrite transport_compose. apply cancel_precomposition.
+            rewrite transport_compose. apply maponpaths.
             assert (e : ! (@maponpaths
                              hz A (λ i0 : pr1 hz, to_BinDirectSums A (C1 (i0 + 1)) (C2 i0))
                              _ _ (hzrminusplus (i + 1) 1 @ ! hzrplusminus (i + 1) 1)) =
@@ -1817,8 +1819,8 @@ Section inv_rotation_mapping_cone.
           use (pathscomp0 _ (! e)). clear e. rewrite (@to_rinvax' A (Additive.to_Zero A)).
           apply idpath.
         * rewrite <- (ZeroArrow_comp_right _ _ _ _ _ (to_Pr1 A DS1 · Diff C1 (i + 1 - 1 + 1))).
-          rewrite <- assoc. rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
-          apply cancel_precomposition. rewrite transport_compose.
+          rewrite <- assoc. rewrite <- assoc. rewrite <- assoc. apply maponpaths.
+          apply maponpaths. rewrite transport_compose.
           rewrite <- PreAdditive_invlcomp. rewrite <- to_inv_zero. apply maponpaths.
           set (DS6 := to_BinDirectSums A (C1 (i + 1 - 1 + 1 + 1)) (C2 (i + 1))).
           rewrite <- (to_Unel1' DS6). rewrite <- transport_compose. unfold DS3.
@@ -1853,7 +1855,7 @@ Section inv_rotation_mapping_cone.
                                             (to_Pr2 A DS6))))
             in  e.
           use (pathscomp0 e). clear e. unfold postcompose.
-          apply cancel_precomposition.
+          apply maponpaths.
           unfold e'. clear e'. unfold DS6.
           set (e1 := (! @maponpaths hz A (λ i0 : pr1 hz, to_BinDirectSums
                                                            A (C1 (i + 1 - 1 + 1 + 1)) (C2 i0))
@@ -1985,10 +1987,10 @@ Section inv_rotation_mapping_cone.
                                          _ _ (hzrminusplus i 1)) (to_In2 A DS5)))).
     rewrite to_assoc. rewrite to_assoc.
     use to_binop_eq.
-    - rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
+    - rewrite <- assoc. rewrite <- assoc. apply maponpaths.
       set (tmp := @transport_hz_double_section A C1 C2 f _ _ (! hzrminusplus i 1)).
       rewrite pathsinv0inv0 in tmp. rewrite <- tmp. clear tmp.
-      rewrite transport_compose. apply cancel_precomposition.
+      rewrite transport_compose. apply maponpaths.
       rewrite maponpathsinv0. rewrite pathsinv0inv0. unfold DS3, DS5.
       induction (hzrminusplus i 1). apply idpath.
     - rewrite <- transport_target_to_inv. rewrite <- transport_source_to_inv.
@@ -2020,10 +2022,10 @@ Section inv_rotation_mapping_cone.
                                       (maponpaths C1 (hzrminusplus (i + 1) 1))
                                       (to_In1 A DS1)))).
       {
-        rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
+        rewrite <- assoc. rewrite <- assoc. apply maponpaths.
         set (tmp := @transport_hz_section A C1 1 (Diff C1) _ _ (! hzrminusplus i 1)).
         rewrite pathsinv0inv0 in tmp. rewrite <- tmp. clear tmp.
-        rewrite transport_compose. apply cancel_precomposition.
+        rewrite transport_compose. apply maponpaths.
         rewrite transport_source_target_comm. unfold DS5. unfold DS1.
         rewrite <- maponpathsinv0.
         assert (e : maponpaths C1 (! hzplusradd i (i - 1 + 1) 1 (! hzrminusplus i 1)) =
@@ -2095,7 +2097,7 @@ Section inv_rotation_mapping_cone.
       rewrite <- (id_right (to_Pr1 A DS2)). rewrite transport_target_postcompose.
       rewrite PreAdditive_invrcomp. rewrite id_right. rewrite <- assoc.
       rewrite <- assoc. rewrite PreAdditive_invrcomp.
-      rewrite <- to_premor_linear'. apply cancel_precomposition.
+      rewrite <- to_premor_linear'. apply maponpaths.
       rewrite to_binop_inv_comm_2. apply maponpaths.
       rewrite <- (to_BinOpId A DS1).
       rewrite (to_commax' A (to_Pr1 A DS1 · to_In1 A DS1) _).
@@ -2109,11 +2111,11 @@ Section inv_rotation_mapping_cone.
                               (to_Pr2 A DS1 · to_In2 A DS1))).
       {
         rewrite transport_compose. rewrite transport_target_postcompose.
-        apply cancel_precomposition. unfold DS1, DS3. induction (hzrplusminus i 1). apply idpath.
+        apply maponpaths. unfold DS1, DS3. induction (hzrplusminus i 1). apply idpath.
       }
       cbn in e. rewrite e. clear e. rewrite (@to_linvax' A (Additive.to_Zero A)).
       rewrite to_lunax''. rewrite transport_compose. rewrite transport_target_postcompose.
-      apply cancel_precomposition. rewrite transport_source_target_comm.
+      apply maponpaths. rewrite transport_source_target_comm.
       apply maponpaths. rewrite <- maponpathsinv0. rewrite transport_f_f.
       rewrite <- maponpathscomp0. rewrite pathsinv0r. apply idpath.
   Qed.
@@ -2182,7 +2184,7 @@ Section inv_rotation_mapping_cone.
     rewrite to_runax''. rewrite <- transport_target_to_inv. rewrite <- PreAdditive_invrcomp.
     rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invlcomp.
     rewrite <- transport_source_to_inv. rewrite <- transport_source_to_inv. rewrite inv_inv_eq.
-    rewrite transport_source_precompose. apply cancel_postcomposition.
+    rewrite transport_source_precompose. apply maponpaths_2.
     rewrite <- transport_target_postcompose. rewrite to_premor_linear'. rewrite to_premor_linear'.
     rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
     rewrite <- PreAdditive_invrcomp. rewrite assoc. rewrite assoc.
@@ -2203,7 +2205,7 @@ Section inv_rotation_mapping_cone.
       apply maponpaths. apply isasethz.
     }
     rewrite <- e. clear e. rewrite tmp. clear tmp. rewrite pathsinv0inv0.
-    apply cancel_precomposition. rewrite transport_f_f. unfold DS5, DS3.
+    apply maponpaths. rewrite transport_f_f. unfold DS5, DS3.
     rewrite <- maponpathscomp0.
     set (tmp := @transport_hz_double_section
                   A C2 (λ i0 : pr1 hz, to_BinDirectSums A (C1 (i0 + 1)) (C2 i0))
@@ -2323,7 +2325,7 @@ Section inv_rotation_mapping_cone.
     set (tmp := @transport_hz_section
                   A C1 1 (Diff C1) _ _ (! (hzrminusplus (i - 1 + 1) 1 @ hzrminusplus i 1))).
     rewrite pathsinv0inv0 in tmp. cbn in tmp. rewrite <- tmp. clear tmp.
-    rewrite transport_compose. rewrite <- assoc. apply cancel_precomposition.
+    rewrite transport_compose. rewrite <- assoc. apply maponpaths.
     assert (e : (! maponpaths C1 (hzplusradd i (i - 1 + 1 - 1 + 1) 1
                                              (! (hzrminusplus (i - 1 + 1) 1 @
                                                               hzrminusplus i 1)))) =
@@ -2374,7 +2376,7 @@ Section inv_rotation_mapping_cone.
       rewrite e'. apply maponpaths. apply isasethz.
     }
     cbn in e. rewrite e. clear e. cbn. cbn in tmp. rewrite <- tmp. clear tmp.
-    rewrite transport_compose. apply cancel_precomposition.
+    rewrite transport_compose. apply maponpaths.
     rewrite transport_source_target_comm.
     rewrite maponpathsinv0. rewrite pathsinv0inv0.
     rewrite maponpathsinv0. rewrite pathsinv0inv0.
@@ -2700,7 +2702,7 @@ Section inv_rotation_mapping_cone.
   Proof.
     intros DS1 DS2 DS3 DS4 DS5 DS6 DS7 DS8 DS9 DS10 DS11.
     cbn. rewrite to_binop_inv_inv. apply maponpaths. rewrite <- assoc. rewrite <- assoc.
-    rewrite <- assoc. rewrite <- to_premor_linear'. apply cancel_precomposition.
+    rewrite <- assoc. rewrite <- to_premor_linear'. apply maponpaths.
     rewrite transport_compose. rewrite to_postmor_linear'.
     rewrite <- transport_source_to_binop. rewrite <- transport_target_to_binop.
     rewrite <- transport_target_postcompose. rewrite <- transport_target_postcompose.
@@ -2728,14 +2730,14 @@ Section inv_rotation_mapping_cone.
       set (tmp := @transport_hz_double_section
                     A C1 C2 f _ _ (! (hzrminusplus (i - 1 + 1) 1 @ hzrminusplus i 1))).
       rewrite pathsinv0inv0 in tmp. cbn. cbn in tmp. rewrite <- tmp. clear tmp.
-      rewrite transport_compose. rewrite <- assoc. apply cancel_precomposition.
+      rewrite transport_compose. rewrite <- assoc. apply maponpaths.
       rewrite <- transport_source_precompose. rewrite <- transport_target_postcompose.
       rewrite transport_source_target_comm.
       rewrite <- maponpathsinv0. rewrite pathsinv0inv0.
       unfold DS11. unfold DS6, DS5, DS2, DS1.
       induction (hzrminusplus i 1). cbn. unfold idfun.
       fold DS11 DS6 DS5 DS2 DS1.
-      rewrite transport_source_precompose. apply cancel_postcomposition.
+      rewrite transport_source_precompose. apply maponpaths_2.
       rewrite pathscomp0rid. unfold DS11, DS5. induction (hzrplusminus (i - 1 + 1) 1).
       cbn. unfold idfun. fold DS5. rewrite pathscomp0rid.
       set (tmp := @transport_hz_double_section_source_target
@@ -2877,7 +2879,7 @@ Section inv_rotation_mapping_cone.
                               (to_Pr1 A DS2 · to_Pr2 A DS1 · to_In2 A DS1 · to_In1 A DS2)).
         {
           rewrite <- to_postmor_linear'. rewrite <- assoc. rewrite <- assoc.
-          rewrite <- to_premor_linear'. apply cancel_postcomposition.
+          rewrite <- to_premor_linear'. apply maponpaths_2.
           rewrite (to_BinOpId A DS1). rewrite id_right. apply idpath.
         }
         rewrite e1. clear e1.
@@ -2891,8 +2893,8 @@ Section inv_rotation_mapping_cone.
                                   (to_Pr1 A DS2 · to_Pr2 A DS1 · to_In2 A DS1 · to_In1 A DS2)).
           use (pathscomp0 _ tmp). clear tmp.
           use to_binop_eq.
-          * apply maponpaths. apply cancel_postcomposition.
-            rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
+          * apply maponpaths. apply maponpaths_2.
+            rewrite <- assoc. rewrite <- assoc. apply maponpaths.
             rewrite transport_compose'. apply idpath.
           * apply idpath.
         + apply idpath.
@@ -2918,7 +2920,7 @@ Section inv_rotation_mapping_cone.
     rewrite (to_commax' A _ (to_Pr2 A DS2 · to_In2 A DS2)). rewrite to_assoc.
     rewrite to_assoc.
     use to_binop_eq.
-    - apply cancel_precomposition. rewrite transport_source_precompose.
+    - apply maponpaths. rewrite transport_source_precompose.
       unfold DS2, DS6. rewrite transport_source_target_comm. unfold DS1, DS5.
       induction (hzrminusplus i 1). cbn. unfold idfun. rewrite pathscomp0rid.
       induction (hzrminusplus (i - 1 + 1) 1). cbn. unfold idfun.
@@ -2944,8 +2946,8 @@ Section inv_rotation_mapping_cone.
       rewrite to_assoc.
       use to_binop_eq.
       + rewrite <- assoc. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
-        apply cancel_precomposition. rewrite transport_compose.
-        apply cancel_precomposition. rewrite transport_source_precompose.
+        apply maponpaths. rewrite transport_compose.
+        apply maponpaths. rewrite transport_source_precompose.
         rewrite transport_f_f. rewrite <- maponpathsinv0. rewrite <- maponpathscomp0.
         rewrite <- path_assoc. rewrite pathsinv0r. rewrite pathscomp0rid.
         rewrite <- transport_source_precompose.
@@ -3163,20 +3165,20 @@ Section fiber_ext.
     apply maponpaths.
     rewrite <- to_postmor_linear'. rewrite <- to_postmor_linear'.
     rewrite <- to_postmor_linear'. rewrite <- to_postmor_linear'.
-    rewrite <- to_postmor_linear'. apply cancel_postcomposition.
+    rewrite <- to_postmor_linear'. apply maponpaths_2.
     rewrite <- to_assoc. rewrite to_postmor_linear'.
     rewrite to_commax'. rewrite (to_commax' _ _ (to_Pr2 A DS1 · Diff C2 i)).
     rewrite (to_commax' _ _ (to_Pr2 A DS1 · Diff C2 i)).
     rewrite to_assoc. apply maponpaths.
     rewrite <- assoc. rewrite <- assoc. rewrite <- to_premor_linear'. rewrite <- to_premor_linear'.
-    apply cancel_precomposition.
+    apply maponpaths.
     apply (to_rcan A (to_inv (g (i + 1)))). rewrite to_assoc. rewrite to_assoc.
     rewrite (Comm' (i + 1)). rewrite (@to_rinvax' A (Additive.to_Zero A)). rewrite to_runax''.
     rewrite <- transport_target_postcompose. rewrite <- PreAdditive_invlcomp.
     rewrite <- transport_target_to_inv. rewrite to_commax'. rewrite to_assoc.
     rewrite (@to_rinvax' A (Additive.to_Zero A)). rewrite to_runax''.
     rewrite transport_compose. rewrite transport_target_postcompose.
-    apply cancel_precomposition.
+    apply maponpaths.
     set (tmp := transport_hz_section A C2 1 (Diff C2) _ _ (hzrplusminus i 1)).
     rewrite <- maponpathsinv0.
     use (pathscomp0 (! tmp)). clear tmp. use transportf_paths.
@@ -3488,15 +3490,15 @@ Section mapping_cone_ext.
     rewrite id_right. rewrite id_right. rewrite id_right.
     rewrite to_runax''. rewrite to_runax''. rewrite to_runax''. rewrite to_lunax''.
     use to_binop_eq.
-    - apply cancel_postcomposition. rewrite <- assoc. rewrite <- assoc.
-      apply cancel_precomposition. rewrite <- PreAdditive_invlcomp.
+    - apply maponpaths_2. rewrite <- assoc. rewrite <- assoc.
+      apply maponpaths. rewrite <- PreAdditive_invlcomp.
       rewrite <- PreAdditive_invrcomp. apply maponpaths.
       exact (MComm g1 (i + 1)).
     - rewrite <- to_assoc. rewrite <- to_assoc.
       use to_binop_eq.
-      + rewrite <- to_postmor_linear'. rewrite <- to_postmor_linear'. apply cancel_postcomposition.
+      + rewrite <- to_postmor_linear'. rewrite <- to_postmor_linear'. apply maponpaths_2.
         rewrite <- assoc. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
-        rewrite <- to_premor_linear'. rewrite <- to_premor_linear'. apply cancel_precomposition.
+        rewrite <- to_premor_linear'. rewrite <- to_premor_linear'. apply maponpaths.
         rewrite <- PreAdditive_invlcomp. rewrite <- transport_target_postcompose.
         assert (e : (transportf (precategory_morphisms (C1 (i + 1)))
                                 (maponpaths C2' (hzrplusminus i 1)) (H (i + 1)) ·
@@ -3506,7 +3508,7 @@ Section mapping_cone_ext.
                                 (H (i + 1) · Diff C2' (i + 1 - 1)))).
         {
           rewrite transport_target_postcompose.
-          rewrite transport_compose. apply cancel_precomposition.
+          rewrite transport_compose. apply maponpaths.
           apply pathsinv0. rewrite <- maponpathsinv0.
           use (pathscomp0 _ (transport_hz_section A C2' 1 (Diff C2') _ _ (hzrplusminus i 1))).
           use transportf_paths. apply maponpaths. apply isasethz.
@@ -3520,8 +3522,8 @@ Section mapping_cone_ext.
         use (to_rcan A (to_inv (g1 (i + 1) · f' (i + 1)))). rewrite to_assoc.
         rewrite (@to_rinvax' A (Additive.to_Zero A)). rewrite to_runax''.
         apply pathsinv0. exact (Comm' (i + 1)).
-      + apply cancel_postcomposition. rewrite <- assoc. rewrite <- assoc.
-        apply cancel_precomposition. exact (MComm g2 i).
+      + apply maponpaths_2. rewrite <- assoc. rewrite <- assoc.
+        apply maponpaths. exact (MComm g2 i).
   Qed.
 
   Definition MappingConeMorExt {C1 C1' C2 C2' : Complex A}
@@ -3648,8 +3650,8 @@ Section mapping_cone_octa.
     + apply idpath.
     + use to_binop_eq.
       * apply idpath.
-      * apply cancel_postcomposition.
-        rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
+      * apply maponpaths_2.
+        rewrite <- assoc. rewrite <- assoc. apply maponpaths.
         exact (MComm f2 i).
   Qed.
 
@@ -3723,8 +3725,8 @@ Section mapping_cone_octa.
     rewrite id_right.
     (* to_binop_eq *)
     rewrite to_assoc. use to_binop_eq.
-    - apply cancel_postcomposition. rewrite <- assoc. rewrite <- assoc.
-      apply cancel_precomposition. rewrite <- PreAdditive_invlcomp.
+    - apply maponpaths_2. rewrite <- assoc. rewrite <- assoc.
+      apply maponpaths. rewrite <- PreAdditive_invlcomp.
       rewrite <- PreAdditive_invrcomp. apply maponpaths.
       exact (MComm f1 (i + 1)).
     - apply idpath.
@@ -3847,9 +3849,9 @@ Section mapping_cone_octa.
       rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_left.
       rewrite to_lunax''. rewrite to_lunax''.
       use to_binop_eq.
-      + apply cancel_postcomposition. rewrite <- assoc. rewrite <- assoc.
+      + apply maponpaths_2. rewrite <- assoc. rewrite <- assoc.
         rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
-        apply cancel_precomposition. rewrite <- PreAdditive_invrcomp.
+        apply maponpaths. rewrite <- PreAdditive_invrcomp.
         rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invlcomp.
         rewrite <- PreAdditive_invrcomp. rewrite to_binop_inv_comm_1.
         rewrite <- PreAdditive_invrcomp. rewrite inv_inv_eq.
@@ -4229,7 +4231,7 @@ Section mapping_cone_octa.
     use to_binop_eq.
     - rewrite transport_target_postcompose. rewrite <- assoc. rewrite <- assoc.
       rewrite <- assoc. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
-      rewrite <- assoc. apply cancel_precomposition. apply cancel_precomposition.
+      rewrite <- assoc. apply maponpaths. apply maponpaths.
       rewrite <- transport_source_precompose. rewrite id_left.
       unfold DS3, DS2, DS1. unfold DS16, DS15, DS14.
       induction (hzrminusplus i 1). apply idpath.
@@ -4268,7 +4270,7 @@ Section mapping_cone_octa.
                                           x (maponpaths (λ i0 : pr1 hz, i0 + 1)
                                                         (hzrminusplus (i + 1) 1)))
                                        (to_In1 A DS11))).
-        apply cancel_precomposition.
+        apply maponpaths.
         rewrite <- transport_target_postcompose. rewrite <- transport_source_precompose.
         set (tmp := transport_hz_double_section_source_target
                         A (λ i0 : hz, x (i0 + 1 + 1))
@@ -4311,7 +4313,7 @@ Section mapping_cone_octa.
                                          (maponpaths x (maponpaths (λ i0 : pr1 hz, i0 + 1)
                                                                    (hzrminusplus i 1)))
                                          (to_In1 A DS15))).
-          apply cancel_precomposition.
+          apply maponpaths.
           rewrite <- transport_target_postcompose. rewrite <- transport_source_precompose.
           unfold DS3, DS2, DS1, DS16, DS15, DS14. induction (hzrminusplus i 1). apply idpath.
         * rewrite <- (assoc _ _ (Diff x (i - 1 + 1 + 1))).
@@ -4344,7 +4346,7 @@ Section mapping_cone_octa.
           fold DS1 DS2 DS3. rewrite transport_target_postcompose.
           rewrite transport_target_postcompose. rewrite <- assoc.
           rewrite <- assoc. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
-          apply cancel_precomposition. apply cancel_precomposition.
+          apply maponpaths. apply maponpaths.
           set (tmp := transport_hz_section
                         A (λ i0 : hz, x (i0 + 1)) 1
                         (λ i0 : hz, Diff x (i0 + 1)) _ _ (! hzrminusplus i 1)).
@@ -4355,7 +4357,7 @@ Section mapping_cone_octa.
             induction (hzrminusplus i 1). apply idpath.
           }
           rewrite e in tmp. clear e. rewrite <- tmp. clear tmp.
-          rewrite transport_compose. apply cancel_precomposition.
+          rewrite transport_compose. apply maponpaths.
           assert (e : (! maponpaths (λ i0 : pr1 hz, x (i0 + 1))
                          (hzplusradd i (i - 1 + 1) 1 (! hzrminusplus i 1))) =
                       (maponpaths (λ i0 : pr1 hz, x (i0 + 1))
@@ -4549,7 +4551,7 @@ Section mapping_cone_octa.
     rewrite <- to_premor_linear'. rewrite inv_inv_eq. rewrite PreAdditive_invrcomp.
     rewrite <- to_premor_linear'.
     rewrite transport_target_postcompose. rewrite transport_target_postcompose.
-    rewrite <- assoc. rewrite <- to_premor_linear'. apply cancel_precomposition.
+    rewrite <- assoc. rewrite <- to_premor_linear'. apply maponpaths.
     rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invlcomp.
     rewrite <- PreAdditive_invlcomp. rewrite <- transport_target_to_inv.
     rewrite <- PreAdditive_invrcomp. rewrite <- PreAdditive_invrcomp. rewrite inv_inv_eq.
@@ -4617,7 +4619,7 @@ Section mapping_cone_octa.
             induction (hzrminusplus i 1). apply idpath.
           }
           rewrite e in tmp. clear e. use (pathscomp0 (! tmp)). clear tmp. rewrite <- assoc.
-          apply cancel_precomposition.
+          apply maponpaths.
           rewrite <- transport_source_precompose.
           unfold DS16, DS15, DS14.
           set (tmp := transport_hz_double_section_source_target
@@ -4726,7 +4728,7 @@ Section mapping_cone_octa.
     apply (maponpaths (# (ComplexHomotFunctor A))) in tmp.
     use (pathscomp0 tmp). clear tmp.
     use (pathscomp0 ((functor_comp (ComplexHomotFunctor A) _ _))).
-    apply cancel_precomposition.
+    apply maponpaths.
     unfold AddEquiv1, TranslationHEquiv. cbn. apply pathsinv0.
     use TranslationFunctorHImEq. apply idpath.
   Qed.
@@ -4742,7 +4744,7 @@ Section mapping_cone_octa.
     apply (maponpaths (# (ComplexHomotFunctor A))) in tmp.
     use (pathscomp0 tmp). clear tmp.
     use (pathscomp0 ((functor_comp (ComplexHomotFunctor A) _ _))).
-    apply cancel_precomposition. unfold AddEquiv1, TranslationHEquiv. cbn. apply pathsinv0.
+    apply maponpaths. unfold AddEquiv1, TranslationHEquiv. cbn. apply pathsinv0.
     use TranslationFunctorHImEq. apply idpath.
   Qed.
 

--- a/UniMath/HomologicalAlgebra/MappingCylinder.v
+++ b/UniMath/HomologicalAlgebra/MappingCylinder.v
@@ -9,6 +9,8 @@ Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.NaturalNumbers.
 
+Require Import UniMath.MoreFoundations.PartA.
+
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids_and_Groups.
 
@@ -250,9 +252,9 @@ Section mapping_cylinder.
     rewrite id_right. rewrite to_binop_inv_inv.
     apply cancel_inv. rewrite inv_inv_eq. rewrite to_inv_zero.
     rewrite <- to_postmor_linear'.
-    rewrite <- (ZeroArrow_comp_left _ _ _ _ _ (to_In1 A DS2')). apply cancel_postcomposition.
+    rewrite <- (ZeroArrow_comp_left _ _ _ _ _ (to_In1 A DS2')). apply maponpaths_2.
     rewrite <- assoc. rewrite <- assoc. rewrite <- to_premor_linear'.
-    rewrite <- (ZeroArrow_comp_right _ _ _ _ _ (to_Pr2 A DS1')). apply cancel_precomposition.
+    rewrite <- (ZeroArrow_comp_right _ _ _ _ _ (to_Pr2 A DS1')). apply maponpaths.
     unfold MappingConeDiff.
     unfold MappingConeDiff1. unfold MappingConeDiff2. unfold MappingConeDiff3.
     cbn in *. fold DS1 DS1' DS2 DS2' DS3 DS3'. unfold DiffTranslationComplex.
@@ -333,7 +335,7 @@ Section mapping_cylinder_KA_iso.
     rewrite <- (assoc _ _ (to_Pr2 A DS2)). rewrite (to_IdIn2 A DS2).
     rewrite id_right. rewrite <- PreAdditive_invrcomp.
     rewrite (to_Unel2' DS1). rewrite to_inv_zero. rewrite ZeroArrow_comp_left.
-    rewrite to_lunax''. apply cancel_postcomposition.
+    rewrite to_lunax''. apply maponpaths_2.
     unfold MappingConeDiff. unfold MappingConeDiff1.
     unfold MappingConeDiff2. unfold MappingConeDiff3.
     cbn. fold DS1 DS2 DS3 DS4. rewrite to_premor_linear'. rewrite assoc.
@@ -396,7 +398,7 @@ Section mapping_cylinder_KA_iso.
     rewrite <- (assoc _ _ (to_Pr2 A DS4)). rewrite (to_IdIn2 A DS4). rewrite id_right.
     rewrite <- assoc. rewrite (MComm f i). rewrite assoc. use to_rrw.
     rewrite <- assoc. rewrite <- assoc. rewrite <- assoc. rewrite <- to_premor_linear'.
-    apply cancel_precomposition.
+    apply maponpaths.
     unfold MappingConeDiff. unfold MappingConeDiff1.
     unfold MappingConeDiff2. unfold MappingConeDiff3.
     cbn. fold DS1 DS2 DS3 DS4. rewrite to_postmor_linear'. rewrite to_postmor_linear'.
@@ -515,7 +517,7 @@ Section mapping_cylinder_KA_iso.
     set (DS5 := to_BinDirectSums A (C1 (i - 1 + 1 + 1)) (C2 (i - 1 + 1))).
     set (DS6 := to_BinDirectSums A (C1 (i - 1 + 1)) DS5). cbn.
     rewrite <- assoc. rewrite <- assoc. rewrite <- to_premor_linear'. rewrite <- to_premor_linear'.
-    apply cancel_precomposition. rewrite <- transport_target_postcompose.
+    apply maponpaths. rewrite <- transport_target_postcompose.
     rewrite assoc. rewrite assoc. rewrite <- to_postmor_linear'.
     rewrite <- transport_target_postcompose. rewrite <- transport_source_precompose.
     (* Unfold MappingCylinderDiff *)
@@ -699,8 +701,8 @@ Section mapping_cylinder_KA_iso.
                  ((to_Pr1 A DS2) · (to_inv (Diff C1 i)) · (to_In1 A DS1) · (to_In2 A DS2))).
     {
       rewrite transport_target_postcompose. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
-      rewrite <- assoc. apply cancel_precomposition.
-      rewrite <- PreAdditive_invlcomp. rewrite PreAdditive_invrcomp. apply cancel_precomposition.
+      rewrite <- assoc. apply maponpaths.
+      rewrite <- PreAdditive_invlcomp. rewrite PreAdditive_invrcomp. apply maponpaths.
       rewrite <- transport_target_postcompose. rewrite <- transport_source_precompose.
       rewrite <- PreAdditive_invrcomp.
       unfold DS2, DS1, DS6, DS5.
@@ -718,7 +720,7 @@ Section mapping_cylinder_KA_iso.
       clear tmp''. apply maponpaths.
       rewrite <- transport_source_to_inv. rewrite <- transport_source_to_inv.
       apply maponpaths. rewrite transport_source_precompose. rewrite transport_source_precompose.
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       assert (e2 : maponpaths C1 (hzrminusplus (i + 1) 1) =
                    maponpaths (λ i0 : hz, C1 (i0 + 1)) (hzrplusminus i 1)).
       {
@@ -734,8 +736,8 @@ Section mapping_cylinder_KA_iso.
     cbn in e1. cbn. rewrite <- e1. clear e1. use to_rrw.
     (* Use similar technique as above *)
     rewrite transport_target_postcompose. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
-    rewrite <- assoc. apply cancel_precomposition.
-    rewrite <- PreAdditive_invlcomp. rewrite PreAdditive_invrcomp. apply cancel_precomposition.
+    rewrite <- assoc. apply maponpaths.
+    rewrite <- PreAdditive_invlcomp. rewrite PreAdditive_invrcomp. apply maponpaths.
     rewrite <- transport_target_postcompose. rewrite <- transport_source_precompose.
     rewrite <- PreAdditive_invrcomp.
     unfold DS2, DS1, DS6, DS5.
@@ -753,7 +755,7 @@ Section mapping_cylinder_KA_iso.
     unfold tmp'' in tmp'.
     rewrite tmp'. clear tmp'. unfold tmp. clear tmp. clear tmp''. apply maponpaths.
     rewrite transport_source_precompose. rewrite transport_source_precompose.
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     assert (e2 : maponpaths C1 (hzrminusplus (i + 1) 1) =
                  maponpaths (λ i0 : hz, C1 (i0 + 1)) (hzrplusminus i 1)).
     {

--- a/UniMath/HomologicalAlgebra/TranslationFunctors.v
+++ b/UniMath/HomologicalAlgebra/TranslationFunctors.v
@@ -226,7 +226,7 @@ Section translation_functor.
     (* Show that the first elements of to_binop are the same *)
     set (tmp := @transport_hz_source_target A C2 1 (Diff C2) _ _ (hzrplusminus (i - 1 + 1) 1)).
     rewrite tmp. clear tmp. rewrite transport_compose.
-    rewrite transport_target_postcompose. apply cancel_precomposition.
+    rewrite transport_target_postcompose. apply maponpaths.
     rewrite transport_f_f. rewrite <- maponpathsinv0. rewrite <- maponpathscomp0.
     rewrite pathsinv0r. rewrite <- functtransportf. rewrite idpath_transportf.
     apply transportf_paths. apply maponpaths. apply isasethz.
@@ -323,7 +323,7 @@ Section translation_functor.
       set (tmp := transport_hz_double_section A C1 C2 (MMor f) _ _ (hzrplusminus (i - 1 + 1) 1)).
       cbn. cbn in tmp. rewrite tmp. clear tmp.
       rewrite <- (transport_compose' _ _ (maponpaths C1 (! hzrplusminus (i - 1 + 1) 1))).
-      apply cancel_precomposition. apply idpath.
+      apply maponpaths. apply idpath.
   Qed.
 
   Definition InvTranslationMorphism (C1 C2 : Complex A) (f : Morphism C1 C2) :
@@ -398,7 +398,7 @@ Section translation_functor.
                             (maponpaths C2 (hzrplusminus (i + 1 - 1 - 1) 1))
                             (Diff C1 (i + 1 - 1 - 1) · H (i + 1 - 1 - 1 + 1))).
     {
-      rewrite transport_target_postcompose. rewrite transport_compose. apply cancel_precomposition.
+      rewrite transport_target_postcompose. rewrite transport_compose. apply maponpaths.
       rewrite <- maponpathsinv0.
       rewrite <- (transport_hz_double_section A _ _ H _ _ (hzrminusplus (i + 1 - 1) 1)).
       use transportf_paths.

--- a/UniMath/HomologicalAlgebra/Triangulated.v
+++ b/UniMath/HomologicalAlgebra/Triangulated.v
@@ -18,6 +18,8 @@ Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.NaturalNumbers.
 
+Require Import UniMath.MoreFoundations.PartA.
+
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids_and_Groups.
 
@@ -472,7 +474,7 @@ Section def_triangles.
     rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invlcomp.
     apply maponpaths. rewrite assoc. rewrite <- functor_comp.
     set (tmp := maponpaths (# (AddEquiv2 T)) (DComm3 M)). rewrite tmp. clear tmp.
-    rewrite functor_comp. rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
+    rewrite functor_comp. rewrite <- assoc. rewrite <- assoc. apply maponpaths.
     set (tmp := AddEquivUnitComm T _ _ (MPMor1 M)). cbn in tmp.
     use (! AddEquivUnitInv T (MPMor1 M)).
   Qed.
@@ -483,7 +485,7 @@ Section def_triangles.
          · # (AddEquiv1 T) (# (AddEquiv2 T) (MPMor3 M)).
   Proof.
     set (tmp := MPComm2 M). rewrite assoc. rewrite tmp. clear tmp.
-    rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
+    rewrite <- assoc. rewrite <- assoc. apply maponpaths.
     use (! AddEquivCounitInv T (MPMor3 M)).
   Qed.
 
@@ -944,7 +946,7 @@ Section rotation_isos.
       · ((Mor3 D) · (z_iso_inv_mor (AddEquivCounitIso Trans ((AddEquiv1 Trans) (Ob1 D))))) =
     Mor3 D · # (AddEquiv1 (@Trans PT)) (AddEquivUnitIso Trans (Ob1 D)).
   Proof.
-    rewrite id_left. apply cancel_precomposition. use AddEquivCounitUnit.
+    rewrite id_left. apply maponpaths. use AddEquivCounitUnit.
   Qed.
 
   Definition RotInvIso_Mor (D : DTri) : TriMor D (InvRotDTri PT (RotDTri PT D)).
@@ -1037,7 +1039,7 @@ Section rotation_isos.
     rewrite <- PreAdditive_invlcomp in tmp. rewrite <- PreAdditive_invrcomp in tmp.
     apply cancel_inv in tmp. rewrite <- functor_comp in tmp.
     use (AddEquiv1Inj Trans). use (pathscomp0 _ tmp). clear tmp.
-    rewrite functor_comp. apply cancel_postcomposition.
+    rewrite functor_comp. apply maponpaths_2.
     set (tmp := AddEquivCounitMorComm Trans (MPMor3 Mor)).
     use (pathscomp0 _ (! tmp)). clear tmp. cbn. rewrite functor_comp. rewrite functor_comp.
     set (tmp := AddEquivCounitUnit Trans (Ob1 D1)).
@@ -1046,7 +1048,7 @@ Section rotation_isos.
                             # (AddEquiv1 Trans)
                             (z_iso_inv_mor (AddEquivUnitIso Trans (Ob1 D2))))) in tmp.
     use (pathscomp0 (! tmp)). clear tmp. rewrite <- assoc. rewrite <- assoc.
-    apply cancel_precomposition. apply cancel_precomposition.
+    apply maponpaths. apply maponpaths.
     use (! AddEquivCounitUnit' Trans (Ob1 D2)).
   Qed.
 
@@ -1057,7 +1059,7 @@ Section rotation_isos.
                                z_iso_inv_mor (AddEquivUnitIso Trans (Ob1 D2))).
   Proof.
     set (tmp := MPComm2 Mor). cbn in tmp. cbn. rewrite tmp. clear tmp.
-    apply cancel_precomposition.
+    apply maponpaths.
     use (pathscomp0 (AddEquivCounitMorComm Trans (MPMor3 Mor))).
     set (tmp := AddEquivCounitUnit Trans (Ob1 D1)).
     apply (maponpaths
@@ -1065,7 +1067,7 @@ Section rotation_isos.
                                   (MPMor3 Mor))
                             · (AddEquivCounit Trans) ((AddEquiv1 Trans) (Ob1 D2)))) in tmp.
     use (pathscomp0 tmp). clear tmp. rewrite <- assoc. rewrite <- assoc. rewrite functor_comp.
-    apply cancel_precomposition. rewrite functor_comp. apply cancel_precomposition.
+    apply maponpaths. rewrite functor_comp. apply maponpaths.
     exact (AddEquivCounitUnit' Trans (Ob1 D2)).
   Qed.
 
@@ -1105,9 +1107,9 @@ Section rotation_isos.
     rewrite <- PreAdditive_invlcomp.
     rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invlcomp.
     rewrite <- PreAdditive_invlcomp.
-    apply maponpaths. apply cancel_postcomposition.
+    apply maponpaths. apply maponpaths_2.
     rewrite <- functor_comp. apply (maponpaths (# (AddEquiv2 Trans))) in H. use (pathscomp0 H).
-    rewrite functor_comp. apply cancel_postcomposition. rewrite <- assoc.
+    rewrite functor_comp. apply maponpaths_2. rewrite <- assoc.
     set (tmp := is_inverse_in_precat2 (AddEquivUnitIso Trans (Ob1 D1))).
     apply (maponpaths (compose (# (AddEquiv2 Trans) (Mor3 D1)))) in tmp.
     use (pathscomp0 _ (! tmp)). rewrite id_right. apply idpath.
@@ -1121,8 +1123,8 @@ Section rotation_isos.
   Proof.
     use (post_comp_with_z_iso_inv_is_inj (AddEquivCounitIso Trans (Ob3 D2))).
     rewrite <- assoc. use (pathscomp0 (DComm3 Mor)). rewrite <- assoc. rewrite <- assoc.
-    cbn. rewrite <- assoc. apply cancel_precomposition. rewrite <- assoc.
-    apply cancel_precomposition.
+    cbn. rewrite <- assoc. apply maponpaths. rewrite <- assoc.
+    apply maponpaths.
     set (tmp := is_inverse_in_precat1 (AddEquivCounitIso Trans (Ob3 D2))).
     apply (maponpaths (compose (# (AddEquiv1 Trans) (MPMor1 Mor)))) in tmp.
     use (pathscomp0 _ (! tmp)). clear tmp. rewrite id_right. apply idpath.
@@ -1266,7 +1268,7 @@ Section short_short_exact_sequences.
   Proof.
     cbn. rewrite <- (@AdditiveZeroArrow_postmor_Abelian PT).
     use monoidfun_paths. use funextfun. intros x. cbn. unfold to_postmor.
-    rewrite <- assoc. apply cancel_precomposition. exact (DTriCompZero D).
+    rewrite <- assoc. apply maponpaths. exact (DTriCompZero D).
   Qed.
 
   Definition ShortShortExactData_from_object (D : @DTri PT) (X : ob PT) :
@@ -1339,7 +1341,7 @@ Section short_short_exact_sequences.
   Proof.
     rewrite <- (@AdditiveZeroArrow_premor_Abelian PT).
     use monoidfun_paths. use funextfun. intros x. cbn. unfold to_premor. rewrite assoc.
-    apply cancel_postcomposition. exact (DTriCompZero D).
+    apply maponpaths_2. exact (DTriCompZero D).
   Qed.
 
   Definition ShortShortExactData_to_object (D : @DTri PT) (X : ob PT) :
@@ -1488,14 +1490,14 @@ Section triangulated_five_lemma.
   Proof.
     use mk_FiveRowMorsComm.
     - use monoidfun_paths. use funextfun. intros x. cbn. unfold to_postmor.
-      rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition. exact (! MPComm1 M).
+      rewrite <- assoc. rewrite <- assoc. apply maponpaths. exact (! MPComm1 M).
     - use monoidfun_paths. use funextfun. intros x. cbn. unfold to_postmor.
-      rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition. exact (! MPComm2 M).
+      rewrite <- assoc. rewrite <- assoc. apply maponpaths. exact (! MPComm2 M).
     - use monoidfun_paths. use funextfun. intros x. cbn. unfold to_postmor.
-      rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition. exact (! DComm3 M).
+      rewrite <- assoc. rewrite <- assoc. apply maponpaths. exact (! DComm3 M).
     - use monoidfun_paths. use funextfun. intros x. cbn. unfold to_postmor.
       rewrite <- assoc. rewrite <- assoc.
-      apply cancel_precomposition. rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invrcomp.
+      apply maponpaths. rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invrcomp.
       apply maponpaths. rewrite <- functor_comp. rewrite <- functor_comp.
       apply maponpaths. exact (! MPComm1 M).
   Qed.
@@ -1588,19 +1590,19 @@ Section triangulated_five_lemma.
     use mk_FiveRowMorsComm.
     - use monoidfun_paths. use funextfun. intros x. cbn. unfold to_premor.
       rewrite assoc. rewrite assoc.
-      apply cancel_postcomposition. rewrite <- PreAdditive_invlcomp.
+      apply maponpaths_2. rewrite <- PreAdditive_invlcomp.
       rewrite <- PreAdditive_invrcomp.
       apply maponpaths. rewrite <- functor_comp. rewrite <- functor_comp.
       apply maponpaths. exact (MPComm1 M).
     - use monoidfun_paths. use funextfun.
       intros x. cbn. unfold to_premor. rewrite assoc. rewrite assoc.
-      apply cancel_postcomposition. exact (DComm3 M).
+      apply maponpaths_2. exact (DComm3 M).
     - use monoidfun_paths. use funextfun. intros x. cbn. unfold to_premor.
       rewrite assoc. rewrite assoc.
-      apply cancel_postcomposition. exact (MPComm2 M).
+      apply maponpaths_2. exact (MPComm2 M).
     - use monoidfun_paths. use funextfun.
       intros x. cbn. unfold to_premor. rewrite assoc. rewrite assoc.
-      apply cancel_postcomposition. exact (MPComm1 M).
+      apply maponpaths_2. exact (MPComm1 M).
   Qed.
 
   Definition TriangulatedMorphism_to_object {D1 D2 : @DTri PT} (M : TriMor D1 D2) (X : ob PT) :
@@ -1677,7 +1679,7 @@ Section Ext_isomorphisms.
     rewrite assoc. rewrite assoc. rewrite <- (MPComm2 I1).
     rewrite <- (assoc _ (Mor2 D1')). rewrite comm1. rewrite assoc. rewrite assoc.
     rewrite assoc. cbn. rewrite (is_inverse_in_precat1 (TriMor_is_iso2 I1)).
-    rewrite id_left. rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
+    rewrite id_left. rewrite <- assoc. rewrite <- assoc. apply maponpaths.
     rewrite assoc. rewrite (MPComm2 I2). rewrite <- assoc.
     rewrite (is_inverse_in_precat1 (TriMor_is_iso3 I2)). apply id_right.
   Qed.
@@ -1775,13 +1777,13 @@ Section Octa_isomorphisms.
   Proof.
     use mk_MPMorComms.
     - cbn. rewrite <- assoc. rewrite <- assoc.
-      apply cancel_precomposition.
+      apply maponpaths.
       set (tmp := is_inverse_in_precat2 (TriMor_is_iso3 I3)).
       apply (maponpaths (compose (OctaMor1 O))) in tmp.
       use (pathscomp0 _ (! tmp)). clear tmp.
       rewrite id_right. apply idpath.
     - cbn. rewrite <- assoc. rewrite <- assoc.
-      apply cancel_precomposition.
+      apply maponpaths.
       set (tmp := is_inverse_in_precat2 (TriMor_is_iso3 I2)).
       apply (maponpaths (compose (OctaMor2 O))) in tmp.
       use (pathscomp0 _ (! tmp)). clear tmp.
@@ -1810,9 +1812,9 @@ Section Octa_isomorphisms.
   Proof.
     cbn. rewrite assoc.
     set (tmp := DComm3 I2). cbn in tmp. rewrite tmp. clear tmp.
-    rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
+    rewrite <- assoc. rewrite <- assoc. apply maponpaths.
     rewrite <- functor_comp. rewrite <- functor_comp. apply maponpaths.
-    set (tmp := MPComm2 I1). cbn in tmp. rewrite <- tmp. apply cancel_postcomposition.
+    set (tmp := MPComm2 I1). cbn in tmp. rewrite <- tmp. apply maponpaths_2.
     exact II12.
   Qed.
 
@@ -1896,7 +1898,7 @@ Section Octa_isomorphisms.
     set (tmp := OctaComm3 O). rewrite <- (assoc _ f2'). rewrite tmp. clear tmp.
     rewrite assoc.
     set (tmp := MPComm1 I2). cbn in tmp. cbn in II12. rewrite <- II12. rewrite tmp. clear tmp.
-    rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
+    rewrite <- assoc. rewrite <- assoc. apply maponpaths.
     cbn in II23. rewrite II23. rewrite assoc.
     set (tmp := MPComm2 I3). cbn in tmp. rewrite tmp. clear tmp.
     rewrite <- assoc. set (tmp := is_inverse_in_precat1 (TriMor_is_iso3 I3)). cbn in tmp.
@@ -1934,9 +1936,9 @@ Section Octa_isomorphisms.
       use is_z_isomorphism_mor_eq. exact II12.
     }
     cbn in e. rewrite e. clear e. rewrite <- tmp. clear tmp.
-    rewrite functor_comp. rewrite assoc. rewrite assoc. apply cancel_postcomposition.
+    rewrite functor_comp. rewrite assoc. rewrite assoc. apply maponpaths_2.
     set (tmp := DComm3 I3). cbn in tmp. rewrite tmp. clear tmp.
-    cbn. use (pathscomp0 _ (id_right _)). rewrite <- assoc. apply cancel_precomposition.
+    cbn. use (pathscomp0 _ (id_right _)). rewrite <- assoc. apply maponpaths.
     rewrite <- functor_id.
     use (pathscomp0 (! (functor_comp (AddEquiv1 Trans) _ _))). apply maponpaths.
     cbn in II13. rewrite <- II13.

--- a/UniMath/SubstitutionSystems/BinProductOfSignatures.v
+++ b/UniMath/SubstitutionSystems/BinProductOfSignatures.v
@@ -13,6 +13,8 @@ Written by Anders Mörtberg, 2016 (adapted from SumOfSignatures.v)
 
 Require Import UniMath.Foundations.PartD.
 
+Require Import UniMath.MoreFoundations.PartA.
+
 Require Import UniMath.CategoryTheory.Categories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Local Open Scope cat.
@@ -91,7 +93,7 @@ Proof.
   intros [X Z] [X' Z'] [α β].
   apply (nat_trans_eq hs); intro c; simpl.
   eapply pathscomp0; [ | eapply pathsinv0, BinProductOfArrows_comp].
-  eapply pathscomp0; [ apply cancel_postcomposition, BinProductOfArrows_comp |].
+  eapply pathscomp0; [ apply maponpaths_2, BinProductOfArrows_comp |].
   eapply pathscomp0; [ apply BinProductOfArrows_comp |].
   apply BinProductOfArrows_eq.
   + exact (nat_trans_eq_pointwise (nat_trans_ax θ1 _ _ (α,,β)) c).
@@ -126,7 +128,7 @@ Proof.
   apply (nat_trans_eq hs); intro x.
   eapply pathscomp0; [ apply BinProductOfArrows_comp |].
   apply pathsinv0.
-  eapply pathscomp0; [ apply cancel_postcomposition; simpl; apply BinProductOfArrows_comp|].
+  eapply pathscomp0; [ eapply (maponpaths_2 compose); simpl; apply BinProductOfArrows_comp|].
   eapply pathscomp0; [ apply BinProductOfArrows_comp|].
   apply pathsinv0, BinProductOfArrows_eq.
   - assert (Ha := S12 X Z Z' Y α); simpl in Ha.

--- a/UniMath/SubstitutionSystems/BinSumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/BinSumOfSignatures.v
@@ -20,6 +20,8 @@ Contents:
 
 Require Import UniMath.Foundations.PartD.
 
+Require Import UniMath.MoreFoundations.PartA.
+
 Require Import UniMath.CategoryTheory.Categories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.whiskering.
@@ -109,7 +111,7 @@ Proof.
     (* on the right-hand side, there is a second but unfolded BinCoproductOfArrows in the row -
        likewise a first such on the left-hand side, to be treater further below *)
     eapply pathscomp0; [ | eapply pathsinv0; apply BinCoproductOfArrows_comp].
-    eapply pathscomp0. apply cancel_postcomposition. apply BinCoproductOfArrows_comp.
+    eapply pathscomp0. apply maponpaths_2. apply BinCoproductOfArrows_comp.
     eapply pathscomp0. apply BinCoproductOfArrows_comp.
     apply BinCoproductOfArrows_eq.
     + apply (nat_trans_eq_pointwise Hyp1 c).
@@ -135,13 +137,13 @@ Proof.
     unfold θ_Strength1 in S11.
     assert (Ha := nat_trans_eq_pointwise (S11 X) x).
     eapply pathscomp0; [ | apply id_left].
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     apply Ha.
   + rewrite BinCoproductOfArrowsIn2.
     unfold θ_Strength1 in S21.
     assert (Ha := nat_trans_eq_pointwise (S21 X) x).
     eapply pathscomp0; [ | apply id_left].
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     apply Ha.
 Qed.
 
@@ -151,7 +153,7 @@ Proof.
   apply (nat_trans_eq hs); intro x.
   eapply pathscomp0; [ apply BinCoproductOfArrows_comp |].
   apply pathsinv0.
-  eapply pathscomp0. apply cancel_postcomposition. simpl. apply BinCoproductOfArrows_comp.
+  eapply pathscomp0. eapply (maponpaths_2 compose). simpl. apply BinCoproductOfArrows_comp.
   eapply pathscomp0. apply BinCoproductOfArrows_comp.
   apply pathsinv0.
   apply BinCoproductOfArrows_eq.
@@ -180,13 +182,13 @@ Proof.
     assert (Ha := nat_trans_eq_pointwise (S11' X) x).
     simpl in Ha.
     eapply pathscomp0; [ | apply id_left].
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     apply Ha.
   + rewrite BinCoproductOfArrowsIn2.
     assert (Ha := nat_trans_eq_pointwise (S21' X) x).
     simpl in Ha.
     eapply pathscomp0; [ | apply id_left].
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     apply Ha.
 Qed.
 

--- a/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
@@ -18,6 +18,7 @@ Based on a note by Ralph Matthes.
 
 Require Import UniMath.Foundations.PartD.
 
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -167,7 +168,7 @@ assert (H' : ∏ n, # L (e (S n)) · # L inF_inv · ψ μF preIt = pr1 (Pow (S n
 { intro n.
   rewrite e_comm, functor_comp.
   eapply pathscomp0;
-   [apply cancel_postcomposition; rewrite <-assoc;  apply maponpaths, H''|].
+   [apply maponpaths_2; rewrite <-assoc;  apply maponpaths, H''|].
   rewrite id_right.
   assert (H1 : # L (# F (e n)) · ψ μF preIt = ψ (iter_functor F n 0) (# L (e n) · preIt)).
   { apply pathsinv0, (toforallpaths _ _ _ (nat_trans_ax ψ _ _ (e n))). }

--- a/UniMath/SubstitutionSystems/Lam.v
+++ b/UniMath/SubstitutionSystems/Lam.v
@@ -25,6 +25,7 @@ Set Kernel Term Sharing.
 
 Require Import UniMath.Foundations.PartD.
 
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -249,7 +250,7 @@ Proof.
     rewrite idness. clear idness.
     rewrite id_right.
     (* does not work:
-       apply cancel_postcomposition.
+       apply maponpaths_2.
        although the terms are of identical type:
     match goal with | [ |- _ · ?l = _ ] => let ty:= (type of l) in idtac ty end.
 (*
@@ -266,7 +267,7 @@ Proof.
 *)
     apply nat_trans_eq; try (exact hs).
     intro c.
-    apply cancel_postcomposition.
+    apply (maponpaths_2 compose).
     apply BinCoproductIn1Commutes_right_dir.
     apply idpath.
     (* this proof did not work with pointedness but with brute force *)
@@ -281,7 +282,7 @@ Proof.
        the τ considered here is a BinCoproduct arrow *)
 
     rewrite τ_LamE_algebra_on_Lam.
-    eapply pathscomp0; [apply cancel_postcomposition ; apply BinCoproductOfArrows_comp | ].
+    eapply pathscomp0; [eapply (maponpaths_2 compose) ; apply BinCoproductOfArrows_comp | ].
     eapply pathscomp0. apply precompWithBinCoproductArrow.
     apply pathsinv0.
 
@@ -293,7 +294,7 @@ Proof.
 
     apply BinCoproductArrowUnique.
     + eapply pathscomp0. apply assoc.
-      eapply pathscomp0. apply cancel_postcomposition. apply BinCoproductIn1Commutes.
+      eapply pathscomp0. apply maponpaths_2. apply BinCoproductIn1Commutes.
       assert (T:= nat_trans_eq_pointwise Hyp2 c).
       clear Hyp2.
       apply pathsinv0.
@@ -304,7 +305,7 @@ Proof.
 
     + clear Hyp2.
       eapply pathscomp0. apply assoc.
-      eapply pathscomp0. apply cancel_postcomposition. apply BinCoproductIn2Commutes.
+      eapply pathscomp0. apply maponpaths_2. apply BinCoproductIn2Commutes.
       unfold Lam_Flatten.
 
     (* from here on 'simpl' is feasible
@@ -341,18 +342,18 @@ Proof.
 
       repeat rewrite assoc.
 (*
-    apply cancel_postcomposition. (* that's a bad idea, because it fucks up use of third monad law and
+    apply maponpaths_2. (* that's a bad idea, because it fucks up use of third monad law and
                                       leads to something that is generally false *)
 *)
 
       match goal with |[ T3' : _ = ?f |- _ = ?a · ?b · _ · ?d  ] => transitivity (a · b · #T f · d) end.
-        Focus 2. apply cancel_postcomposition. apply maponpaths. apply maponpaths. apply (!T3').
+        Focus 2. apply maponpaths_2. apply maponpaths. apply maponpaths. apply (!T3').
       clear T3'.
       apply pathsinv0.
 
       assert (T3':= nat_trans_eq_pointwise T3 (T (Z c))).
 
-      eapply pathscomp0. apply cancel_postcomposition. apply cancel_postcomposition. apply maponpaths. apply T3'.
+      eapply pathscomp0. apply maponpaths_2. apply maponpaths_2. apply maponpaths. apply T3'.
       clear T3'.
       apply pathsinv0.
       destruct f as [f fptdmor]. simpl in *.
@@ -366,8 +367,8 @@ Proof.
       rewrite functor_comp in X'.
 
       apply pathsinv0.
-      eapply pathscomp0. apply cancel_postcomposition. apply cancel_postcomposition.
-                       apply cancel_postcomposition. apply X'.
+      eapply pathscomp0. apply maponpaths_2. apply maponpaths_2.
+                       apply maponpaths_2. apply X'.
                        clear X'.
 
       assert (X := Monad_law_2_from_hss _ _ CC Lam_S LamHSS (T (Z c))).
@@ -375,13 +376,13 @@ Proof.
 
       match goal with |[ X : ?e = _ |- ?a · ?b · _ · _  = _ ] =>
                      assert (X' : e = a · b) end.
-      { apply cancel_postcomposition. apply maponpaths.
+      { apply maponpaths_2. apply maponpaths.
         apply pathsinv0, BinCoproductIn1Commutes.
       }
 
       rewrite X' in X. clear X'.
 
-      eapply pathscomp0. apply cancel_postcomposition. apply cancel_postcomposition. apply X. clear X.
+      eapply pathscomp0. apply maponpaths_2. apply maponpaths_2. apply X. clear X.
 
       rewrite id_left.
 
@@ -389,7 +390,7 @@ Proof.
       assert (X := μ_2_nat _ _ (f c)).
       unfold μ_2 in X.
 
-      eapply pathscomp0. Focus 2. apply cancel_postcomposition. apply X. clear X.
+      eapply pathscomp0. Focus 2. apply maponpaths_2. apply X. clear X.
 
       rewrite functor_comp.
       repeat rewrite <- assoc.
@@ -400,7 +401,7 @@ Proof.
       simpl in X'.
 
       eapply pathscomp0. apply X'.
-      clear X'. apply cancel_postcomposition. apply id_left.
+      clear X'. apply maponpaths_2. apply id_left.
 Qed.
 
 (** * Uniqueness of the bracket operation *)
@@ -443,7 +444,7 @@ Proof.
       simpl.
       rewrite id_right.
       eapply pathscomp0. apply HT.
-      simpl. repeat rewrite assoc. apply cancel_postcomposition.
+      simpl. repeat rewrite assoc. apply maponpaths_2.
       apply BinCoproductIn1Commutes.
     + apply parts_from_whole in Ht. destruct Ht as [_ H2].
       apply nat_trans_eq; try assumption.
@@ -457,7 +458,7 @@ Proof.
       match goal with |[X : _ = ?f |- _ ] => transitivity f end.
        Focus 2. rewrite τ_LamE_algebra_on_Lam.
        eapply pathscomp0. apply assoc.
-       apply cancel_postcomposition. apply BinCoproductIn1Commutes.
+       apply (maponpaths_2 compose). apply BinCoproductIn1Commutes.
 
       match goal with |[X : ?e = _ |- _ ] => transitivity e end.
        Focus 2. apply X.
@@ -466,14 +467,14 @@ Proof.
 
       apply pathsinv0.
       eapply pathscomp0. apply assoc.
-      eapply pathscomp0. apply cancel_postcomposition. apply assoc.
-      eapply pathscomp0. apply cancel_postcomposition. apply cancel_postcomposition.
+      eapply pathscomp0. apply maponpaths_2. apply assoc.
+      eapply pathscomp0. apply maponpaths_2. apply maponpaths_2.
       apply BinCoproductIn1Commutes.
 
       repeat rewrite <- assoc.
       eapply pathscomp0. apply maponpaths. apply assoc.
 
-      eapply pathscomp0. apply maponpaths. apply cancel_postcomposition. apply BinCoproductIn1Commutes.
+      eapply pathscomp0. apply maponpaths. apply maponpaths_2. apply BinCoproductIn1Commutes.
 
       eapply pathscomp0. apply maponpaths. apply (!assoc _ _ _ ).
       simpl. apply maponpaths. apply maponpaths.

--- a/UniMath/SubstitutionSystems/LamFromBindingSig.v
+++ b/UniMath/SubstitutionSystems/LamFromBindingSig.v
@@ -11,6 +11,7 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Combinatorics.Lists.
 
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -139,7 +140,7 @@ assert (F := maponpaths (λ x, BinCoproductIn1 _ (BinCoproducts_functor_precat _
 rewrite assoc in F.
 eapply pathscomp0; [apply F|].
 rewrite assoc.
-eapply pathscomp0; [eapply cancel_postcomposition, BinCoproductOfArrowsIn1|].
+eapply pathscomp0; [eapply maponpaths_2, BinCoproductOfArrowsIn1|].
 rewrite <- assoc.
 eapply pathscomp0; [eapply maponpaths, BinCoproductIn1Commutes|].
 apply id_left.
@@ -169,12 +170,12 @@ rewrite assoc in F.
 eapply pathscomp0; [apply F|].
 rewrite assoc.
 eapply pathscomp0.
-  eapply cancel_postcomposition.
+  eapply maponpaths_2.
   rewrite <- assoc.
   eapply maponpaths, BinCoproductOfArrowsIn2.
 rewrite assoc.
 eapply pathscomp0.
-  eapply @cancel_postcomposition. eapply @cancel_postcomposition.
+  eapply @maponpaths_2. eapply @maponpaths_2.
   apply (CoproductOfArrowsIn _ _ (Coproducts_functor_precat _ _ _
           (CoproductsHSET _ isasetbool)
           _ (λ i, pr1 (Arity_to_Signature has_homsets_HSET BinProductsHSET
@@ -199,12 +200,12 @@ rewrite assoc in F.
 eapply pathscomp0; [apply F|].
 rewrite assoc.
 eapply pathscomp0.
-  eapply cancel_postcomposition.
+  eapply maponpaths_2.
   rewrite <- assoc.
   eapply maponpaths, BinCoproductOfArrowsIn2.
 rewrite assoc.
 eapply pathscomp0.
-  eapply @cancel_postcomposition, @cancel_postcomposition.
+  eapply @maponpaths_2, @maponpaths_2.
   apply (CoproductOfArrowsIn _ _ (Coproducts_functor_precat _ _ _
           (CoproductsHSET _ isasetbool)
           _ (λ i, pr1 (Arity_to_Signature has_homsets_HSET BinProductsHSET

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -462,7 +462,7 @@ Proof.
   eapply pathscomp0. Focus 2. eapply pathsinv0.
   apply postcompWithBinCoproductArrow.
 (*
-  eapply cancel_postcomposition. apply postcompWithBinCoproductArrow.
+  eapply maponpaths_2. apply postcompWithBinCoproductArrow.
 *)
 (*  rewrite postcompWithBinCoproductArrow. *)
   apply BinCoproductArrow_eq.

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -25,6 +25,7 @@ Contents :
 Set Kernel Term Sharing.
 
 Require Import UniMath.Foundations.PartD.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.MoreFoundations.Tactics.
 
@@ -704,7 +705,7 @@ Proof.
         apply BinCoproductIn1Commutes_right_dir.
         apply idpath.
       * (* a bit out of order what follows *)
-        apply cancel_postcomposition.
+        apply (maponpaths_2 compose).
         apply idpath.
       * (* second diagram *)
         clear TT T2 T3 T4 T5.
@@ -768,7 +769,7 @@ Proof.
         rewrite id_left. apply BinCoproductIn1Commutes_right_dir. apply idpath.
       do 2 rewrite assoc.
       eapply pathscomp0.
-        apply cancel_postcomposition.
+        apply maponpaths_2.
         assert (ptd_mor_commutes_inst := ptd_mor_commutes _ (ptd_from_alg_mor _ hs CP H β0) ((pr1 Z) c)).
         apply ptd_mor_commutes_inst.
       assert (fbracket_η_inst := fbracket_η T' (f· ptd_from_alg_mor _ hs CP H β0)).
@@ -794,7 +795,7 @@ Proof.
         apply idpath.
       do 2 rewrite assoc.
       eapply pathscomp0.
-        apply cancel_postcomposition.
+        apply maponpaths_2.
         eapply pathsinv0.
         assert (τ_part_of_alg_mor_inst := τ_part_of_alg_mor _ hs CP H _ _ β0).
         assert (τ_part_of_alg_mor_inst_Zc :=
@@ -814,8 +815,8 @@ Proof.
       simpl.
       unfold coproduct_nat_trans_in2_data.
       repeat rewrite assoc.
-      apply cancel_postcomposition.
-      apply cancel_postcomposition.
+      apply maponpaths_2.
+      apply maponpaths_2.
       assert (Hyp:
                  ((# (pr1 (ℓ(U Z))) (# H β))·
                  (theta H) ((alg_carrier _  T') ⊗ Z)·
@@ -832,7 +833,7 @@ Proof.
       clear c. clear X. clear rhohat.
       rewrite (functor_comp H).
       rewrite assoc.
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       fold θ.
       apply nat_trans_eq; try (exact hs).
       intro c.

--- a/UniMath/SubstitutionSystems/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial_alt.v
@@ -16,6 +16,7 @@ Set Kernel Term Sharing.
 
 Require Import UniMath.Foundations.PartD.
 
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -511,7 +512,7 @@ intermediate_path (pr1 (pr1 X)).
   set (T5 := T4 Φ).
   intermediate_path (Φ _ (fbracket InitHSS f)); trivial.
   eapply pathscomp0; [|apply T5]; clear TT T2 T3 T4 T5 X.
-  * now apply cancel_postcomposition.
+  * now apply (maponpaths_2 compose).
   * (* hypothesis of fusion law *)
     apply funextsec; intro t.
     apply (nat_trans_eq hsC); intro c; simpl.
@@ -541,7 +542,7 @@ intermediate_path (pr1 (pr1 X)).
       simpl.
       rewrite <- !assoc.
       eapply pathscomp0;
-        [| eapply pathsinv0, cancel_postcomposition,
+        [| eapply pathsinv0, maponpaths_2,
            (nat_trans_eq_pointwise (functor_comp H t β) c)].
       simpl; rewrite <- assoc.
       apply maponpaths, BinCoproductIn2Commutes_left_in_ctx_dir.
@@ -567,7 +568,7 @@ intermediate_path (pr1 (pr1 X)).
       rewrite !assoc.
       assert (fbracket_η_inst_c := nat_trans_eq_pointwise (fbracket_η T' (f· ptd_from_alg_mor _ hsC CP H β0)) c).
       eapply pathscomp0; [| apply (!fbracket_η_inst_c)].
-      apply cancel_postcomposition, (ptd_mor_commutes _ (ptd_from_alg_mor _ hsC CP H β0) ((pr1 Z) c)).
+      apply (maponpaths_2 compose), (ptd_mor_commutes _ (ptd_from_alg_mor _ hsC CP H β0) ((pr1 Z) c)).
     + (* now the difficult case *)
       repeat rewrite <- assoc.
       apply BinCoproductIn2Commutes_right_in_ctx_dir.
@@ -588,7 +589,7 @@ intermediate_path (pr1 (pr1 X)).
         apply idpath.
       do 2 rewrite assoc.
       eapply pathscomp0.
-        apply cancel_postcomposition.
+        apply maponpaths_2.
         eapply pathsinv0.
         assert (τ_part_of_alg_mor_inst := τ_part_of_alg_mor _ hsC CP H _ _ β0).
         assert (τ_part_of_alg_mor_inst_Zc :=
@@ -608,8 +609,8 @@ intermediate_path (pr1 (pr1 X)).
       simpl.
       unfold coproduct_nat_trans_in2_data.
       repeat rewrite assoc.
-      apply cancel_postcomposition.
-      apply cancel_postcomposition.
+      apply maponpaths_2.
+      apply maponpaths_2.
       assert (Hyp:
                  ((# (pr1 (ℓ(U Z))) (# H β))·
                  (theta H) ((alg_carrier _  T') ⊗ Z)·
@@ -624,7 +625,7 @@ intermediate_path (pr1 (pr1 X)).
       clear c. clear X. clear rhohat.
       rewrite (functor_comp H).
       rewrite assoc.
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       apply (nat_trans_eq hsC); intro c.
       assert (θ_nat_1_pointwise_inst := θ_nat_1_pointwise _ hsC _ hsC H θ _ _ β Z c).
       eapply pathscomp0 ; [exact θ_nat_1_pointwise_inst | ].

--- a/UniMath/SubstitutionSystems/ModulesFromSignatures.v
+++ b/UniMath/SubstitutionSystems/ModulesFromSignatures.v
@@ -16,6 +16,7 @@ as the one one already proved formally for the standard notion of heterogeneous 
 
 *)
 Require Import UniMath.Foundations.PartD.
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.CategoryTheory.PointedFunctors.
 Require Import UniMath.CategoryTheory.PointedFunctorsComposition.
 
@@ -91,7 +92,7 @@ Proof.
   cbn.
   rewrite <- assoc.
   etrans; [|apply id_right].
-  apply cancel_precomposition.
+  apply maponpaths.
   apply Monad_law2.
 Qed.
 
@@ -123,7 +124,7 @@ Proof.
                                                   _
                                                   (identity _) ) x). }
   etrans;[eapply pathsinv0;apply id_right|].
-  apply cancel_precomposition.
+  apply (maponpaths (compose _)).
   apply pathsinv0.
   etrans.
   { eapply nat_trans_eq_pointwise.
@@ -154,18 +155,18 @@ Proof.
   - intro c.
     etrans; [apply assoc|].
     etrans.
-    {  apply cancel_postcomposition.
+    {  apply maponpaths_2.
        apply ( θ_nat_2_pw Mf (id_Ptd C hsC) (p T) (ptd_mor_pt hsC _) c). }
     etrans.
-    { apply cancel_postcomposition.
+    { apply maponpaths_2.
       rewrite (horcomp_pre_post _ _ (category_pair _ hsC )).
       rewrite (functor_comp H).
       etrans; [apply assoc|].
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       apply strength_law1_pw. }
     etrans;[|apply id_right].
     rewrite <- assoc.
-    apply cancel_precomposition.
+    apply maponpaths.
     etrans; [ apply functor_comp_pw|].
     etrans; [|apply (nat_trans_eq_pointwise (functor_id H Mf))].
     apply functor_cancel_pw.
@@ -175,26 +176,26 @@ Proof.
     cbn.
     etrans.
     { rewrite assoc.
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       etrans; [ apply (θ_nat_2_pw Mf _ _ (ptd_mor_from_μ)  c)|].
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       apply (strength_law2_pw Mf (p T) (p T)).  }
     etrans; revgoals.
     { rewrite <- assoc.
-      apply cancel_precomposition.
+      apply maponpaths.
       rewrite assoc.
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       eapply pathsinv0.
       apply (θ_nat_1_pw _ _ (σ M) (p T) c). }
     cbn.
     repeat rewrite <- assoc.
-    apply cancel_precomposition.
-    apply cancel_precomposition.
+    apply maponpaths.
+    apply maponpaths.
     etrans; revgoals.
     { eapply pathsinv0.
       apply (functor_comp_pw hsC hsD H). }
     etrans.
-    { apply cancel_precomposition.
+    { apply maponpaths.
       apply (functor_comp_pw hsC hsD H). }
     etrans; [ apply (functor_comp_pw hsC hsD H)|].
     apply functor_cancel_pw.
@@ -400,23 +401,23 @@ Proof.
   + apply pathsinv0,id_left.
   + apply pathsinv0.
     etrans;[apply assoc|].
-    apply cancel_postcomposition.
+    apply (maponpaths_2 compose).
     etrans;[apply assoc|].
     etrans.
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     apply (θ_nat_1_pw _ _ a (p T_alg)).
     rewrite <- assoc.
-    apply cancel_precomposition.
+    apply (maponpaths (compose _)).
     etrans; revgoals.
     { eapply pathsinv0.
       eapply nat_trans_eq_pointwise.
       apply (functor_comp H (_:EndC⟦ T_mon ∙ x', T_mon ∙ x⟧)). }
-    apply cancel_postcomposition.
+    apply (maponpaths_2 compose).
     apply functor_cancel_pw.
     apply (nat_trans_eq hs).
     intro c'.
     etrans;[|apply id_right].
-    apply cancel_precomposition.
+    apply (maponpaths (compose _)).
     apply (functor_id   x).
 Qed.
 
@@ -455,7 +456,7 @@ Proof.
   intros x.
   etrans.
   { etrans.
-    apply cancel_postcomposition.
+    eapply (maponpaths_2 compose).
     apply BinCoproductArrowEta.
     apply postcompWithBinCoproductArrow. }
   apply BinCoproductArrow_eq.
@@ -474,14 +475,14 @@ Proof.
   { eapply pathsinv0.
     apply assoc. }
   etrans.
-  { apply cancel_precomposition.
+  { apply maponpaths.
     apply (nat_trans_eq_pointwise (algebra_mor_commutes _ _ _ j) x). }
   etrans; [apply assoc|].
   etrans.
-  { apply cancel_postcomposition.
+  { apply maponpaths_2.
     apply BinCoproductIn2Commutes. }
   etrans;[eapply pathsinv0; apply assoc|].
-  apply cancel_precomposition.
+  apply maponpaths.
   apply BinCoproductIn2Commutes.
 Qed.
 
@@ -494,15 +495,15 @@ Proof.
   { eapply pathsinv0.
     apply assoc. }
   etrans.
-  { apply cancel_precomposition.
+  { apply maponpaths.
     apply (nat_trans_eq_pointwise (algebra_mor_commutes _ _ _ j) a). }
   etrans;[apply assoc|].
   etrans.
-  { apply cancel_postcomposition.
+  { apply maponpaths_2.
     apply BinCoproductIn1Commutes. }
   etrans;[eapply pathsinv0;apply assoc|].
   etrans.
-  { apply cancel_precomposition.
+  { apply maponpaths.
     apply BinCoproductIn1Commutes. }
   apply id_left.
 Qed.
@@ -526,21 +527,21 @@ Proof.
   - (* T monad law *)
     etrans;[apply assoc|].
     etrans.
-    { apply cancel_postcomposition.
+    { apply maponpaths_2.
       apply (Monad_law1 (T:=T_mon)). }
     apply id_left.
   - (* tau_T is a module morphism *)
     etrans;[apply assoc|].
     etrans.
-    { apply cancel_postcomposition.
+    { apply maponpaths_2.
       apply (LModule_Mor_σ _  τT). }
     etrans;[eapply pathsinv0;apply assoc|].
     etrans;[eapply pathsinv0;apply assoc|].
     etrans; [| apply assoc].
-    apply cancel_precomposition.
+    apply maponpaths.
     rewrite functor_comp.
     etrans; [| apply assoc].
-    apply cancel_precomposition.
+    apply maponpaths.
     apply j_mor_rep.
 Qed.
 
@@ -554,65 +555,65 @@ Proof.
   apply coprod_iter_eq; intro x.
   - etrans;[apply assoc|].
     etrans.
-    { apply cancel_postcomposition.
+    { apply maponpaths_2.
       etrans;[apply assoc|].
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       apply j_mon_η. }
     etrans.
-    { apply cancel_postcomposition.
+    { apply maponpaths_2.
       eapply pathsinv0.
       apply (nat_trans_ax (Monads.η M )). }
     etrans; [|apply id_right].
     rewrite <- assoc.
-    apply cancel_precomposition.
+    apply maponpaths.
     apply Monad_law1.
   - etrans;[apply assoc|].
     etrans.
-    { apply cancel_postcomposition.
+    { apply maponpaths_2.
       etrans;[apply assoc|].
       etrans.
-      { apply cancel_postcomposition.
+      { apply maponpaths_2.
         apply j_mor_rep. }
       rewrite <- assoc.
-      apply cancel_precomposition.
+      apply maponpaths.
       eapply pathsinv0.
       apply (nat_trans_ax τ_M). }
     etrans.
     { repeat rewrite <- assoc.
-      apply cancel_precomposition.
-      apply cancel_precomposition.
+      apply maponpaths.
+      apply maponpaths.
       apply (LModule_Mor_σ _  τ_M ( x)). }
     repeat rewrite assoc.
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     etrans.
     { repeat rewrite <- assoc.
-      apply cancel_precomposition.
+      apply maponpaths.
       etrans;[apply assoc|].
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       apply (θ_nat_2_pw _ _ _ j_ptd). }
     etrans.
     { repeat rewrite assoc.
-      apply cancel_postcomposition.
-      apply cancel_postcomposition.
+      apply maponpaths_2.
+      apply maponpaths_2.
       apply (θ_nat_1_pw _ _ j_mor (ptd_from_mon hs T_mon)). }
     repeat rewrite <- assoc.
-    apply cancel_precomposition.
+    apply maponpaths.
     rewrite functor_comp.
     rewrite functor_comp.
     repeat rewrite assoc.
-    apply cancel_postcomposition.
+    apply (maponpaths_2 compose).
     rewrite <- functor_comp.
     etrans;[ apply functor_comp_pw|].
     apply functor_cancel_pw.
     apply (nat_trans_eq hs).
     intro y.
     etrans.
-    { apply cancel_postcomposition.
+    { eapply (maponpaths_2 compose).
       etrans.
-      { apply cancel_precomposition.
-        apply functor_id. }
+      { eapply (maponpaths (compose _)).
+        refine (functor_id _ _). }
       apply id_right. }
-    apply cancel_precomposition.
+    apply (maponpaths (compose _)).
     apply id_left.
 Qed.
 

--- a/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
@@ -26,6 +26,7 @@ Unset Kernel Term Sharing.
 
 Require Import UniMath.Foundations.PartD.
 
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -127,7 +128,7 @@ Proof.
     assert (H3 := nat_trans_eq_pointwise H2 c).
     simpl in *.
     intermediate_path (identity _ · pr1 (τ T) c).
-    + apply cancel_postcomposition. apply H3.
+    + apply maponpaths_2. apply H3.
     + apply id_left.
 Qed.
 
@@ -232,9 +233,9 @@ Proof.
                   pr1 (# H μ_2) c · pr1 (τ T) c).
       * unfold tau_from_alg; cbn.
         do 2 rewrite assoc.
-        apply cancel_postcomposition.
-        apply cancel_postcomposition.
-        apply cancel_postcomposition.
+        apply maponpaths_2.
+        apply maponpaths_2.
+        apply maponpaths_2.
         assert (H':=θ_nat_2 _ _ _ _ H θ).
         assert (H2 := H' (`T) _ _ μ_0_ptd); clear H'.
         assert (H3:= nat_trans_eq_weq hs _ _ H2 c); clear H2.
@@ -255,10 +256,10 @@ Proof.
             apply H2; clear H2. (* rewrite done *)
           - clear H2.
             do 2 rewrite assoc.
-            apply cancel_postcomposition.
+            apply maponpaths_2.
             eapply pathscomp0.
             apply (nat_trans_ax (τ T) ).
-            apply cancel_postcomposition.
+            apply maponpaths_2.
             apply pathsinv0.
             apply id_right.
         }
@@ -337,8 +338,8 @@ Proof.
     repeat rewrite assoc.
     match goal with |[H1 : ?g = _ |- _ · _ · ?f · ?h = _ ] =>
          intermediate_path (g · f · h) end.
-    + apply cancel_postcomposition.
-      apply cancel_postcomposition.
+    + apply maponpaths_2.
+      apply maponpaths_2.
       apply pathsinv0.
       eapply pathscomp0. apply H1; clear H1.
       apply maponpaths.
@@ -362,7 +363,7 @@ Proof.
         apply assoc.
       * clear H3.
         repeat rewrite assoc.
-        apply cancel_postcomposition.
+        apply maponpaths_2.
         assert (H1 := nat_trans_ax (τ T )).
         unfold tau_from_alg in H1.
         eapply pathscomp0; [ | apply H1]; clear H1.
@@ -408,14 +409,14 @@ Proof.
     transitivity (identity _ · μ_2 c).
     + apply pathsinv0, id_left.
     + eapply pathscomp0; [ | apply (!assoc _ _ _ ) ].
-      apply cancel_postcomposition.
+      apply maponpaths_2.
       assert (H1 := Monad_law_1_from_hss (pr1 (`T) c)).
       apply (!H1).
   - set (B:= τ T).
     match goal with | [|- _ · # ?H (?f · _ ) · _ = _ ] => set (F:=f : (*TtimesTthenT'*) T•T² --> _ ) end.
     assert (H3:= functor_comp H F μ_2).
     unfold functor_compose in H3.
-    eapply pathscomp0. apply cancel_postcomposition. apply maponpaths. apply H3.
+    eapply pathscomp0. apply maponpaths_2. apply maponpaths. apply H3.
     clear H3.
     apply nat_trans_eq; try assumption.
     intro c.
@@ -436,9 +437,9 @@ Proof.
       intermediate_path (pr1 (θ ((`T) ⊗ (ptd_from_alg T))) (pr1 (pr1 (pr1 T)) c)·
                        f  · h · x· y) end.
     * repeat rewrite assoc.
-      apply cancel_postcomposition.
-      apply cancel_postcomposition.
-      apply cancel_postcomposition.
+      apply maponpaths_2.
+      apply maponpaths_2.
+      apply maponpaths_2.
       unfold Ac. clear Ac.
       eapply pathscomp0. Focus 2. apply assoc.
       eapply pathscomp0. Focus 2. apply maponpaths. apply (!HXX).
@@ -484,7 +485,7 @@ Proof.
           repeat rewrite <- assoc in H5. apply H5.
         - clear H5.
           repeat rewrite assoc.
-          apply cancel_postcomposition.
+          apply maponpaths_2.
           assert (HT := fbracket_τ T (identity _ )).
           assert (H6:= nat_trans_eq_pointwise HT); clear HT.
           unfold coproduct_nat_trans_in2_data.
@@ -516,7 +517,7 @@ Proof.
     rewrite assoc.
     intermediate_path (identity _ · μ_2 c).
     + apply pathsinv0, id_left.
-    + apply cancel_postcomposition.
+    + apply maponpaths_2.
       rewrite id_left.
       assert (H1 := Monad_law_1_from_hss (pr1 (`T) c)).
       simpl in H1.
@@ -536,9 +537,9 @@ Proof.
     simpl in HX'.
     match goal with | [ H : _  = ?f |- _ · _ · ?g · ?h · ?i = _ ] =>
                       intermediate_path (f · g · h · i) end.
-    + apply cancel_postcomposition.
-      apply cancel_postcomposition.
-      apply cancel_postcomposition.
+    + apply maponpaths_2.
+      apply maponpaths_2.
+      apply maponpaths_2.
       apply HX'.
     + clear HX'.
       rewrite id_left.
@@ -550,8 +551,8 @@ Proof.
       simpl in HXX.
       match goal with | [ H : ?x = _ |- ?e · _ · _ · ?f · ?g = _ ] =>
                  intermediate_path (e · x · f · g) end.
-      * apply cancel_postcomposition.
-        apply cancel_postcomposition.
+      * apply maponpaths_2.
+        apply maponpaths_2.
         repeat rewrite <- assoc.
         apply maponpaths.
         {
@@ -582,7 +583,7 @@ Proof.
         rewrite functor_id.
         rewrite id_left.
         repeat rewrite assoc.
-        apply cancel_postcomposition.
+        apply maponpaths_2.
         assert (H4':= fbracket_τ T (identity _ )).
         assert (H6:= nat_trans_eq_pointwise H4' (pr1 `T x)); clear H4'.
         simpl in H6.
@@ -648,7 +649,7 @@ Proof.
     rewrite compute_fbracket.
     rewrite <- assoc.
     apply maponpaths.
-    apply cancel_postcomposition.
+    apply (maponpaths_2 compose).
     apply idpath.
   - unfold μ_0.
     intro c.

--- a/UniMath/SubstitutionSystems/STLC.v
+++ b/UniMath/SubstitutionSystems/STLC.v
@@ -9,6 +9,7 @@ Written by: Anders Mörtberg, 2017
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.Combinatorics.Lists.
@@ -189,7 +190,7 @@ assert (F := maponpaths (λ x, BinCoproductIn1 _ (BinCoproducts_functor_precat _
 rewrite assoc in F.
 eapply pathscomp0; [apply F|].
 rewrite assoc.
-eapply pathscomp0; [eapply cancel_postcomposition, BinCoproductOfArrowsIn1|].
+eapply pathscomp0; [eapply maponpaths_2, BinCoproductOfArrowsIn1|].
 rewrite <- assoc.
 eapply pathscomp0; [eapply maponpaths, BinCoproductIn1Commutes|].
 apply id_left.

--- a/UniMath/SubstitutionSystems/SignatureCategory.v
+++ b/UniMath/SubstitutionSystems/SignatureCategory.v
@@ -11,6 +11,7 @@ Written by: Anders Mörtberg in October 2016 based on a note of Benedikt Ahrens.
 
 Require Import UniMath.Foundations.PartD.
 
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -109,9 +110,9 @@ Proof.
 destruct α as [α Hα]; destruct β as [β Hβ].
 unfold Signature_category_mor_diagram in *; simpl.
 rewrite (assoc ((theta Ht1) (X,,Y))).
-etrans; [apply (cancel_postcomposition ((theta Ht1) (X,,Y) · _)), Hα|].
+etrans; [apply maponpaths_2, Hα|].
 rewrite <- assoc; etrans; [apply maponpaths, Hβ|].
-rewrite assoc; apply (cancel_postcomposition (C:=[C,D]) _  (_ ∙∙ identity (U Y))).
+rewrite assoc; apply maponpaths_2.
 apply (nat_trans_eq hsD); intro c; simpl.
 now rewrite assoc, !functor_id, !id_right.
 Qed.
@@ -225,10 +226,10 @@ etrans; [apply postcompWithBinProductArrow|].
 apply pathsinv0, BinProductArrowUnique; rewrite <- assoc.
 + etrans; [apply maponpaths, BinProductPr1Commutes|].
   etrans; [apply (nat_trans_eq_pointwise (pr2 F X Y) c)|].
-  now etrans; [apply cancel_postcomposition, horcomp_id_left|].
+  now etrans; [eapply (maponpaths_2 compose), horcomp_id_left|].
 + etrans; [apply maponpaths, BinProductPr2Commutes|].
   etrans; [apply (nat_trans_eq_pointwise (pr2 G X Y) c)|].
-  now etrans; [apply cancel_postcomposition, horcomp_id_left|].
+  now etrans; [eapply (maponpaths_2 compose), horcomp_id_left|].
 Qed.
 
 Local Lemma isBinProduct_Signature_precategory (Ht1 Ht2 : Signature C hsC D hsD) :
@@ -304,9 +305,9 @@ apply Signature_category_mor_diagram_pointwise; intro c.
 etrans; [apply precompWithCoproductArrow|].
 apply pathsinv0, CoproductArrowUnique; intro i; rewrite assoc; simpl.
 etrans;
-  [apply cancel_postcomposition, (CoproductInCommutes _ _ _ (CD (λ j, pr1 (pr1 (Hti j) X) _)))|].
+  [apply maponpaths_2, (CoproductInCommutes _ _ _ (CD (λ j, pr1 (pr1 (Hti j) X) _)))|].
 apply pathsinv0; etrans; [apply (nat_trans_eq_pointwise (pr2 (F i) X Y) c)|].
-now etrans; [apply cancel_postcomposition, horcomp_id_left|].
+now etrans; [eapply (maponpaths_2 compose), horcomp_id_left|].
 Qed.
 
 Local Lemma isCoproduct_Signature_precategory (Hti : I → Signature_precategory C D) :

--- a/UniMath/SubstitutionSystems/SignatureExamples.v
+++ b/UniMath/SubstitutionSystems/SignatureExamples.v
@@ -10,7 +10,7 @@ Revised and extended by Ralph Matthes, 2017
 *)
 
 Require Import UniMath.Foundations.PartD.
-
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Categories.
@@ -179,7 +179,7 @@ eapply pathscomp0.
   eapply maponpaths, maponpaths, H.
 rewrite assoc; apply pathsinv0.
 eapply pathscomp0.
-  eapply cancel_postcomposition, nat_trans_ax.
+  eapply maponpaths_2, nat_trans_ax.
 now rewrite <- assoc, <- functor_comp.
 Qed.
 
@@ -246,9 +246,9 @@ intros Ze Z'e' αX; induction Ze as [Z e]; induction Z'e' as [Z' e']; induction 
 apply (nat_trans_eq hsC); intro c; simpl; rewrite functor_id, !id_right, !id_left.
 eapply pathscomp0.
   rewrite assoc.
-  eapply cancel_postcomposition, pathsinv0, functor_comp.
+  eapply maponpaths_2, pathsinv0, functor_comp.
 eapply pathscomp0.
-  eapply cancel_postcomposition, maponpaths.
+  eapply maponpaths_2, maponpaths.
   generalize (nat_trans_eq_pointwise (nat_trans_ax (δ G1 DL1) (Z,,e) (Z',, e') (α,,X)) c).
   simpl; rewrite id_left, functor_id, id_right; intro H1.
   apply H1.
@@ -270,7 +270,7 @@ apply (nat_trans_eq hsC); intro c; simpl; rewrite !id_left, id_right.
 eapply pathscomp0.
   eapply maponpaths, (nat_trans_eq_pointwise (distributive_law1 G2 DL2) (G1 c)).
 eapply pathscomp0.
-  eapply cancel_postcomposition, maponpaths, (nat_trans_eq_pointwise (distributive_law1  G1 DL1) c).
+  eapply maponpaths_2, maponpaths, (nat_trans_eq_pointwise (distributive_law1  G1 DL1) c).
 now rewrite id_right; apply functor_id.
 Qed.
 
@@ -279,17 +279,17 @@ Proof.
 intros Ze Ze'.
 apply (nat_trans_eq hsC); intro c; simpl; rewrite !id_left, !id_right.
 eapply pathscomp0.
-  eapply cancel_postcomposition, maponpaths, (nat_trans_eq_pointwise (distributive_law2 G1 DL1 Ze Ze') c).
+  eapply maponpaths_2, maponpaths, (nat_trans_eq_pointwise (distributive_law2 G1 DL1 Ze Ze') c).
 eapply pathscomp0.
   eapply maponpaths, (nat_trans_eq_pointwise (distributive_law2 G2 DL2 Ze Ze') (G1 c)).
 simpl; rewrite !id_left, !id_right.
 eapply pathscomp0.
-  eapply cancel_postcomposition, functor_comp.
+  eapply maponpaths_2, functor_comp.
 rewrite <- !assoc.
 apply maponpaths.
 rewrite assoc.
 eapply pathscomp0.
-  eapply cancel_postcomposition, (nat_trans_ax (δ G2 DL2 Ze') _ _ (pr1 (δ G1 DL1 Ze) c)).
+  eapply maponpaths_2, (nat_trans_ax (δ G2 DL2 Ze') _ _ (pr1 (δ G1 DL1 Ze) c)).
 simpl; rewrite <- !assoc.
 now apply maponpaths, pathsinv0, functor_comp.
 Qed.
@@ -333,18 +333,18 @@ rewrite id_left.
 apply pathsinv0, BinCoproductArrowUnique.
 - eapply pathscomp0.
     rewrite assoc.
-    eapply cancel_postcomposition, BinCoproductIn1Commutes.
+    eapply maponpaths_2, BinCoproductIn1Commutes.
   rewrite <- assoc.
   eapply pathscomp0.
     eapply maponpaths, pathsinv0, (nat_trans_ax e).
   simpl; rewrite assoc.
-  apply cancel_postcomposition.
+  apply maponpaths_2.
   eapply pathscomp0.
     apply BinCoproductOfArrowsIn1.
   now rewrite id_left.
 - rewrite assoc.
   eapply pathscomp0.
-    eapply cancel_postcomposition, BinCoproductIn2Commutes.
+    eapply maponpaths_2, BinCoproductIn2Commutes.
   rewrite <- !functor_comp.
   now apply maponpaths, BinCoproductOfArrowsIn2.
 Qed.
@@ -361,12 +361,12 @@ rewrite precompWithBinCoproductArrow.
 apply pathsinv0, BinCoproductArrowUnique.
 - rewrite id_left, assoc.
   eapply pathscomp0.
-    eapply cancel_postcomposition, BinCoproductIn1Commutes.
+    eapply maponpaths_2, BinCoproductIn1Commutes.
   rewrite <- assoc.
   now apply maponpaths, X.
 - rewrite assoc.
   eapply pathscomp0.
-    eapply cancel_postcomposition, BinCoproductIn2Commutes.
+    eapply maponpaths_2, BinCoproductIn2Commutes.
   now apply nat_trans_ax.
 Qed.
 
@@ -397,18 +397,18 @@ rewrite !id_left, id_right.
 apply pathsinv0, BinCoproductArrowUnique.
 - rewrite assoc.
   eapply pathscomp0.
-    eapply cancel_postcomposition, BinCoproductIn1Commutes.
+    eapply maponpaths_2, BinCoproductIn1Commutes.
   rewrite <- assoc.
   eapply pathscomp0.
     eapply maponpaths, pathsinv0, (nat_trans_ax e').
   simpl; rewrite assoc.
   eapply pathscomp0.
-    eapply cancel_postcomposition, BinCoproductIn1Commutes.
+    eapply maponpaths_2, BinCoproductIn1Commutes.
   rewrite <- !assoc.
   now apply maponpaths, (nat_trans_ax e').
 - rewrite assoc.
   eapply pathscomp0.
-    eapply cancel_postcomposition, BinCoproductIn2Commutes.
+    eapply maponpaths_2, BinCoproductIn2Commutes.
   eapply pathscomp0.
     eapply pathsinv0, functor_comp.
   now apply maponpaths, BinCoproductIn2Commutes.

--- a/UniMath/SubstitutionSystems/SubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/SubstitutionSystems.v
@@ -25,6 +25,7 @@ Contents :
 
 
 Require Import UniMath.Foundations.PartD.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.CategoryTheory.Categories.
 Require Import UniMath.CategoryTheory.functor_categories.
@@ -331,7 +332,7 @@ Proof.
     assert (H':=nat_trans_ax (tau_from_alg T)).
     simpl in H'.
     eapply pathscomp0. Focus 2. apply (!assoc _ _ _ ).
-    eapply pathscomp0. Focus 2.  apply  cancel_postcomposition. apply H'.
+    eapply pathscomp0. Focus 2.  apply  maponpaths_2. apply H'.
     clear H'.
     set (H':=fbracket_τ T g).
     simpl in H'.
@@ -359,9 +360,9 @@ Proof.
     apply maponpaths.
     simpl.
     repeat rewrite assoc.
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     rewrite (functor_comp H).
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     clear H'.
     set (A:=horcomp_id_postwhisker C _ _ hs hs).
     rewrite A.
@@ -442,7 +443,7 @@ Proof.
   repeat rewrite assoc.
   unfold coproduct_nat_trans_data.
   eapply pathscomp0.
-  apply cancel_postcomposition.
+  apply maponpaths_2.
   apply BinCoproductIn1Commutes.
   simpl.
   repeat rewrite <- assoc.
@@ -588,7 +589,7 @@ Proof.
     apply assoc.
   (* match goal with | [|- ?l = _ ] => assert (Hyp : l = fbracket T f· pr1 β· pr1 γ) end. *)
   eapply pathscomp0.
-    apply cancel_postcomposition.
+    apply maponpaths_2.
     apply isbracketMor_hssMor.
   rewrite <- assoc.
   eapply pathscomp0.
@@ -597,7 +598,7 @@ Proof.
   rewrite assoc.
   rewrite functor_comp.
   rewrite assoc.
-  apply cancel_postcomposition.
+  apply maponpaths_2.
   apply pathsinv0, (functor_comp (pre_composition_functor _ _ C _ hs (U Z)) ).
 Qed.
 

--- a/UniMath/SubstitutionSystems/SumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/SumOfSignatures.v
@@ -16,6 +16,8 @@ Adapted from the binary case
 
 Require Import UniMath.Foundations.PartD.
 
+Require Import UniMath.MoreFoundations.PartA.
+
 Require Import UniMath.CategoryTheory.Categories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Local Open Scope cat.
@@ -78,7 +80,7 @@ Proof.
 intros [X Z] [X' Z'] αβ.
 apply (nat_trans_eq hsD); intro c.
 eapply pathscomp0; [ | eapply pathsinv0, CoproductOfArrows_comp].
-eapply pathscomp0; [ apply cancel_postcomposition, CoproductOfArrows_comp |].
+eapply pathscomp0; [ eapply (maponpaths_2 compose), CoproductOfArrows_comp |].
 eapply pathscomp0; [ apply CoproductOfArrows_comp |].
 apply CoproductOfArrows_eq, funextsec; intro i.
 apply (nat_trans_eq_pointwise (nat_trans_ax (θ1 i) (X,,Z) (X',,Z') αβ) c).
@@ -100,7 +102,7 @@ apply pathsinv0, Coproduct_endo_is_identity; intro i.
 eapply pathscomp0.
   apply (CoproductOfArrowsIn _ _ (CD (λ i, pr1 (pr1 (H1 i) X) x))).
 eapply pathscomp0; [ | apply id_left].
-apply cancel_postcomposition, (nat_trans_eq_pointwise (S11' i X) x).
+apply maponpaths_2, (nat_trans_eq_pointwise (S11' i X) x).
 Qed.
 
 Lemma SumStrength2' : θ_Strength2_int θ.


### PR DESCRIPTION
This pull request expunges the lemmas `cancel_precomposition` and `cancel_postcomposition` from the library.  Instructions for removing them from dependent libraries follow below.  This is a fixed version of #874 — thanks @siddharthist for catching the errors there!

# Motivation

These lemmas were the facts `f = f' -> f ;; g = f' ;; g`, and `g = g' -> f ;; g = f ;; g'`.  On the one hand, their names are misleading; on the other hand, they are entirely redundant cases of the general lemmas `maponpaths`, `maponpaths_2`.

Regarding the names, these are not cancellation principles.  Cancellation principles are facts of the form “F a = F b -> a = b”.  These lemmas are the converse implication: facts of the form “a = b -> F a = F b”.

As such, they are just instances of the general principle that a function respects equality in its arguments, i.e. `maponpaths` and `maponpaths_2`.  Using the more general lemmas makes code more uniform, with less for newcomers to learn.  Special case lemmas may often be justified, if they are easier to use than the general lemmas (e.g. if the general lemmas often fail to unify or infer arguments).  In this case, though, the general lemmas are just as easy to use, as the ease of expunction shows.

Therefore (with the approval of @benediktahrens ) I suggest either removing these lemmas entirely from the library (as this PR currently does), or alternatively, if we don’t want to force users to follow suit, leaving the definitions but removing all uses of them and considering them as deprecated (for that, merge just the first commit of this PR).

# Instructions for updating code for compatibility with this PR

This PR will break all occurrences of `cancel_precomposition` and `cancel_postcomposition`.  Almost all occurrences can be fixed just by replacing them with `maponpaths` and `maponpaths_2` respectively.  E.g. run the following commandline search-and-replace, adapting the file pattern to your library’s layout:

```
perl -pi -e "s/cancel_precomposition/maponpaths/" */*.v
perl -pi -e "s/cancel_postcomposition/maponpaths_2/" */*.v
```

and then add the following import line as required to make `maponpaths_2` available:

```
Require Import UniMath.MoreFoundations.PartA.
```

Almost all occurrences in `UniMath` worked fine straight after the search-and-replace plus imports as above.  The remaining broken instances (<5% of occurrences of the `cancel_` lemmas) were fixed by:

- where arguments had been explicitly given to the `cancel_` lemmas, reorder and/or remove the arguments appropriately;

- expand `maponpaths` to `maponpaths (compose _)` (replacing `cancel_precomposition`);

- expand `maponpaths_2` to `maponpaths_2 compose` (replacing `cancel_postcomposition`);

- replace `apply` with `eapply` when invoking the general lemmas.