### PR TITLE
improve citation suggestion for UniMath

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ Citing UniMath
 To cite UniMath in your article, you can use the following bibtex item:
 ```bibtex
 @Misc{UniMath,
-   author = {Voevodsky, Vladimir and Ahrens, Benedikt and Grayson, Daniel and others},
-   title = {{\em UniMath}: {Univalent} {Mathematics}},
-   howpublished = {Available at \url{https://github.com/UniMath}}
-}
+    author = {Voevodsky, Vladimir and Ahrens, Benedikt and Grayson, Daniel and others},
+    title = {{UniMath---A computer-checked library of univalent mathematics}},
+    url = {https://github.com/UniMath/UniMath}
+ }
 ```
 Note that this requires ```\usepackage{url}``` or ```\usepackage{hyperref}```.
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ To cite UniMath in your article, you can use the following bibtex item:
 ```bibtex
 @Misc{UniMath,
     author = {Voevodsky, Vladimir and Ahrens, Benedikt and Grayson, Daniel and others},
-    title = {{UniMath---A computer-checked library of univalent mathematics}},
-    url = {https://github.com/UniMath/UniMath}
+    title = {{UniMath --- a computer-checked library of univalent mathematics}},
+    url = {https://github.com/UniMath/UniMath},
+    howpublished = {{available} at \url{https://github.com/UniMath/UniMath}}
  }
 ```
 Note that this requires ```\usepackage{url}``` or ```\usepackage{hyperref}```.


### PR DESCRIPTION
- give a more descriptive title
- improve the colon that Vladimir once complained about ("what does it mean?"); the emdash, by convention, indicates a subtitle
- remove manual formatting "\em", which should not be part of a bibtex entry