### PR TITLE
fix the coqdoc command line for html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,9 +192,12 @@ git-describe:
 doc: $(GLOBFILES) $(VFILES) 
 	mkdir -p $(ENHANCEDDOCTARGET)
 	cp $(ENHANCEDDOCSOURCE)/proofs-toggle.js $(ENHANCEDDOCTARGET)/proofs-toggle.js
-	$(COQDOC) -toc $(COQDOCFLAGS) -html $(COQDOCLIBS) -d $(ENHANCEDDOCTARGET) \
-	--with-header $(ENHANCEDDOCSOURCE)/header.html $(VFILES)
-	sed -i'.bk' -f $(ENHANCEDDOCSOURCE)/proofs-toggle.sed $(ENHANCEDDOCTARGET)/*html
+	$(SHOW)COQDOC
+	$(HIDE)$(COQDOC)									\
+	    -Q UniMath UniMath -toc $(COQDOCFLAGS) -html $(COQDOCLIBS) -d $(ENHANCEDDOCTARGET)	\
+	    --with-header $(ENHANCEDDOCSOURCE)/header.html					\
+	    $(VFILES)
+	sed -i '.bk' -f $(ENHANCEDDOCSOURCE)/proofs-toggle.sed $(ENHANCEDDOCTARGET)/*html
 
 # Jason Gross' coq-tools bug isolator:
 # The isolated bug will appear in this file, in the UniMath directory:

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ BUILD_COQIDE ?= no
 COQBIN ?=
 ############################################
 
-.PHONY: all everything install lc lcp wc describe clean distclean build-coq doc build-coqide
+.PHONY: all everything install lc lcp wc describe clean distclean build-coq doc build-coqide html
 all: check-first
 all: check-for-change-to-Foundations
 all: make-summary-files
@@ -52,7 +52,7 @@ endif
 
 # override the definition in build/CoqMakefile.make, to eliminate the -utf8 option
 COQDOC := coqdoc
-COQDOCFLAGS := -interpolate --charset utf-8
+COQDOCFLAGS := -interpolate --charset utf-8 -Q UniMath UniMath
 COQDOC_OPTIONS := -toc $(COQDOCFLAGS) $(COQDOCLIBS) -utf8
 
 PACKAGE_FILES := $(patsubst %, UniMath/%/.package/files, $(PACKAGES))
@@ -193,9 +193,9 @@ doc: $(GLOBFILES) $(VFILES)
 	mkdir -p $(ENHANCEDDOCTARGET)
 	cp $(ENHANCEDDOCSOURCE)/proofs-toggle.js $(ENHANCEDDOCTARGET)/proofs-toggle.js
 	$(SHOW)COQDOC
-	$(HIDE)$(COQDOC)									\
-	    -Q UniMath UniMath -toc $(COQDOCFLAGS) -html $(COQDOCLIBS) -d $(ENHANCEDDOCTARGET)	\
-	    --with-header $(ENHANCEDDOCSOURCE)/header.html					\
+	$(HIDE)$(COQDOC)							\
+	    -toc $(COQDOCFLAGS) -html $(COQDOCLIBS) -d $(ENHANCEDDOCTARGET)	\
+	    --with-header $(ENHANCEDDOCSOURCE)/header.html			\
 	    $(VFILES)
 	sed -i '.bk' -f $(ENHANCEDDOCSOURCE)/proofs-toggle.sed $(ENHANCEDDOCTARGET)/*html
 

--- a/UniMath/Algebra/All.v
+++ b/UniMath/Algebra/All.v
@@ -10,6 +10,7 @@ Require Export UniMath.Algebra.ConstructiveStructures.
 Require Export UniMath.Algebra.Archimedean.
 Require Export UniMath.Algebra.Lattice.
 Require Export UniMath.Algebra.IteratedBinaryOperations.
+Require Export UniMath.Algebra.Free_Monoids_and_Groups.
 Require Export UniMath.Algebra.Tests.
 Require Export UniMath.Algebra.Modules.Core.
 Require Export UniMath.Algebra.Modules.Submodule.


### PR DESCRIPTION
... so the UniMath path is provided and the links will work, once again

Resolves #890.