### PR TITLE
add a few notations for bigger natural numbers

### DIFF
--- a/UniMath/Foundations/Preamble.v
+++ b/UniMath/Foundations/Preamble.v
@@ -106,32 +106,33 @@ Fixpoint min n m :=
     | S n', S m' => S (min n' m')
   end.
 
-(* some code is commented out with this comment: wait for numeral parsing *)
 Notation  "0" := (O) : nat_scope.
-Notation  "1" := (S O) : nat_scope.
-Notation  "2" := (S (S O)) : nat_scope.
-Notation  "3" := (S (S (S O))) : nat_scope.
-Notation  "4" := (S (S (S (S O)))) : nat_scope.
-Notation  "5" := (S (S (S (S (S O))))) : nat_scope.
-Notation  "6" := (S (S (S (S (S (S O)))))) : nat_scope.
-Notation  "7" := (S (S (S (S (S (S (S O))))))) : nat_scope.
-Notation  "8" := (S (S (S (S (S (S (S (S O)))))))) : nat_scope.
-Notation  "9" := (S (S (S (S (S (S (S (S (S O))))))))) : nat_scope.
-Notation "10" := (S (S (S (S (S (S (S (S (S (S O)))))))))) : nat_scope.
-Notation "11" := (S (S (S (S (S (S (S (S (S (S (S O))))))))))) : nat_scope.
-Notation "12" := (S (S (S (S (S (S (S (S (S (S (S (S O)))))))))))) : nat_scope.
-Notation "13" := (S (S (S (S (S (S (S (S (S (S (S (S (S O))))))))))))) : nat_scope.
-Notation "14" := (S (S (S (S (S (S (S (S (S (S (S (S (S (S O)))))))))))))) : nat_scope.
-Notation "15" := (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S O))))))))))))))) : nat_scope.
-Notation "16" := (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S O)))))))))))))))) : nat_scope.
-Notation "17" := (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S O))))))))))))))))) : nat_scope.
-Notation "18" := (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S O)))))))))))))))))) : nat_scope.
-Notation "19" := (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S O))))))))))))))))))) : nat_scope.
-Notation "20" := (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S O)))))))))))))))))))) : nat_scope.
-Notation "21" := (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S O))))))))))))))))))))) : nat_scope.
-Notation "22" := (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S O)))))))))))))))))))))) : nat_scope.
-Notation "23" := (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S O))))))))))))))))))))))) : nat_scope.
-Notation "24" := (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S O)))))))))))))))))))))))) : nat_scope.
+Notation  "1" := (S 0) : nat_scope.
+Notation  "2" := (S 1) : nat_scope.
+Notation  "3" := (S 2) : nat_scope.
+Notation  "4" := (S 3) : nat_scope.
+Notation  "5" := (S 4) : nat_scope.
+Notation  "6" := (S 5) : nat_scope.
+Notation  "7" := (S 6) : nat_scope.
+Notation  "8" := (S 7) : nat_scope.
+Notation  "9" := (S 8) : nat_scope.
+Notation "10" := (S 9) : nat_scope.
+Notation "11" := (S 10) : nat_scope.
+Notation "12" := (S 11) : nat_scope.
+Notation "13" := (S 12) : nat_scope.
+Notation "14" := (S 13) : nat_scope.
+Notation "15" := (S 14) : nat_scope.
+Notation "16" := (S 15) : nat_scope.
+Notation "17" := (S 16) : nat_scope.
+Notation "18" := (S 17) : nat_scope.
+Notation "19" := (S 18) : nat_scope.
+Notation "20" := (S 19) : nat_scope.
+Notation "21" := (S 20) : nat_scope.
+Notation "22" := (S 21) : nat_scope.
+Notation "23" := (S 22) : nat_scope.
+Notation "24" := (S 23) : nat_scope.
+Notation "100" := (10 * 10) : nat_scope.
+Notation "1000" := (10 * 100) : nat_scope.
 
 (** Identity Types *)
 

--- a/UniMath/NumberSystems/Tests.v
+++ b/UniMath/NumberSystems/Tests.v
@@ -76,16 +76,10 @@ Module Test_int.
 
   Goal true = (hzbooleq (natnattohz 3 4) (natnattohz 17 18)) . reflexivity. Qed.
   Goal false = (hzbooleq (natnattohz 3 4) (natnattohz 17 19)) . reflexivity. Qed.
-  (*
-    wait for numeral parsing
-  Goal 274 = (hzabsval (natnattohz 58 332)) . reflexivity. Qed.
-   *)
+  Goal 2 * 100 + 7 * 10 + 4 = (hzabsval (natnattohz (5 * 10 + 8) (3 * 100 + 3 * 10 + 2))) . reflexivity. Qed.
   Goal O = (hzabsval (hzplus (natnattohz 2 3) (natnattohz 3 2))) . reflexivity. Qed.
   Goal 2 = (hzabsval (hzminus (natnattohz 2 3) (natnattohz 3 2))) . reflexivity. Qed.
-  (*
-    wait for numeral parsing
-  Goal 300 =  (hzabsval (hzmult (natnattohz 20 50) (natnattohz 30 20))) . reflexivity. Qed.
-   *)
+  Goal 3 * 100 =  (hzabsval (hzmult (natnattohz (2 * 10) (5 * 10)) (natnattohz (3 * 10) (2 * 10)))) . reflexivity. Qed.
 
 End Test_int.
 


### PR DESCRIPTION
... so we can reinstate two former examples.

If we don't restore natural number syntax, as in #894, we should add
these simple notations for 100 and 1000, so small natural numbers can be
written as arithmetic expressions.  Numbers bigger than 5000 result in a
warning from Coq, anyway, since they aren't really usable, so we might
not worry about natural number parsing until Coq offers a way to tailor
it to our situation.