### PR TITLE
remove extraneous lemma from Ktheory/Utilities

### DIFF
--- a/UniMath/Foundations/PartB.v
+++ b/UniMath/Foundations/PartB.v
@@ -591,6 +591,7 @@ Proof.
   intros x x'. apply isofhlevelcontr. apply (X0 x x').
 Defined.
 
+(** A proposition that is inhabited is contractible. *)
 Lemma iscontraprop1 {X : UU} (is : isaprop X) (x : X) : iscontr X.
 Proof.
   intros. unfold iscontr. split with x. intro t.

--- a/UniMath/Ktheory/Nat.v
+++ b/UniMath/Ktheory/Nat.v
@@ -112,7 +112,7 @@ Module Discern.
   Proof. intros m. induction m as [|m IHm]. { reflexivity. } { simpl. apply IHm. } Defined.
 
   Lemma nat_discern_iscontr m : iscontr (nat_discern m m).
-  Proof. intros m. apply iscontr_if_inhab_prop.
+  Proof. intros m. apply iscontraprop1.
          { apply nat_discern_isaprop. }
          { induction m as [|m IHm]. { exact tt. } { simpl. exact IHm. } } Defined.
 

--- a/UniMath/Ktheory/Utilities.v
+++ b/UniMath/Ktheory/Utilities.v
@@ -116,9 +116,6 @@ Proof. intros ? [Q i] f h. refine (h _ _). assumption. Defined.
 Lemma funspace_isaset {X Y} : isaset Y -> isaset (X -> Y).
 Proof. intros ? ? is. apply (impredfun 2). assumption. Defined.
 
-Lemma iscontr_if_inhab_prop {P} : isaprop P -> P -> iscontr P.
-Proof. intros ? i p. exists p. intros p'. apply i. Defined.
-
 Lemma squash_map_uniqueness {X S} (ip : isaset S) (g g' : ∥ X ∥ -> S) :
   g ∘ squash_element ~ g' ∘ squash_element -> g ~ g'.
 Proof.


### PR DESCRIPTION
I found the lemma in Foundations when grepping for "inhabited" and "prop", so I added a comment explaining the lemma with those words.