### PR TITLE
Generalize curry and uncurry

### DIFF
--- a/UniMath/Algebra/IteratedBinaryOperations.v
+++ b/UniMath/Algebra/IteratedBinaryOperations.v
@@ -457,7 +457,7 @@ Section NatCard.
   Defined.
 
   Corollary nat_plus_associativity' n (m:stn n->nat) (k:∏ i, stn (m i) -> nat) :
-    stnsum (λ i, stnsum (k i)) = stnsum (uncurry k ∘ lexicalEnumeration m).
+    stnsum (λ i, stnsum (k i)) = stnsum (uncurry (Z := λ _,_) k ∘ lexicalEnumeration m).
   Proof. intros. exact (nat_plus_associativity (uncurry k)). Defined.
 
   Lemma iterop_fun_nat {n:nat} (x:stn n->nat) : iterop_fun 0 add x = stnsum x.

--- a/UniMath/CategoryTheory/Inductives/Lists.v
+++ b/UniMath/CategoryTheory/Inductives/Lists.v
@@ -363,7 +363,7 @@ intros hF c L ccL HcL cc.
 use tpair.
 - transparent assert (HX : (cocone hF (hset_fun_space x HcL))).
   {  use mk_cocone.
-    * simpl; intro n; apply flip, curry, (pr1 cc).
+    * simpl; intro n; apply flip, (curry (Z := λ _,_)), (pr1 cc).
     * abstract (destruct cc as [f hf]; simpl; intros m n e;
                 rewrite <- (hf m n e); destruct e; simpl;
                 repeat (apply funextfun; intro); apply idpath).
@@ -389,7 +389,7 @@ use tpair.
     apply funextfun; intro xc; destruct xc as [x' c']; simpl;
     use (let g : HSET⟦colim (mk_ColimCocone hF c L ccL),
                                 hset_fun_space x HcL⟧ := _ in _);
-    [ simpl; apply flip, curry, t
+    [ simpl; apply flip, (curry (Z := λ _,_)), t
     | rewrite <- (colimArrowUnique _ _ _ g); [apply idpath | ];
       destruct cc as [f hf]; simpl in *;
       now intro n; simpl; rewrite <- (p n) ]

--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -173,19 +173,13 @@ Notation "g ∘ f" := (funcomp f g) : functions.
 (** back and forth between functions of pairs and functions returning
   functions *)
 
-Definition curry {X Z : UU} {Y : X -> UU} (f : (∑ x : X, Y x) -> Z) :
-  ∏ x, Y x -> Z.
-Proof.
-  intros ? ? ? ? ? y.
-  exact (f (x,,y)).
-Defined.
+Definition curry {X : UU} {Y : X -> UU} {Z : (∑ x, Y x) -> UU}
+           (f : ∏ p, Z p) : (∏ x : X, ∏ y : Y x, Z (x,, y)) :=
+  λ x y, f (x,, y).
 
-Definition uncurry {X Z : UU} {Y : X -> UU} (g : ∏ x : X, Y x -> Z) :
-  (∑ x, Y x) -> Z.
-Proof.
-  intros ? ? ? ? xy.
-  exact (g (pr1 xy) (pr2 xy)).
-Defined.
+Definition uncurry {X : UU} {Y : X -> UU} {Z : (∑ x, Y x) -> UU}
+           (g : ∏ x : X, ∏ y : Y x, Z (x,, y)) : (∏ p, Z p) :=
+  λ x, g (pr1 x) (pr2 x).
 
 (** *** Definition of binary operation *)
 
@@ -343,7 +337,6 @@ Lemma curry_uncurry {X Z : UU} {Y : X -> UU} (g : ∏ x : X, Y x -> Z) :
 Proof.
   intros. apply idpath.
 Defined.
-
 
 (** *** Composition of paths and inverse paths *)
 

--- a/UniMath/Foundations/PartD.v
+++ b/UniMath/Foundations/PartD.v
@@ -558,7 +558,7 @@ Proof.
   intros. induction xp as [ x p ]. apply (a x p).
 Defined.
 
-
+(** General equivalence between curried and uncurried function types *)
 Definition weqsecovertotal2 {X : UU} (P : X -> UU) (Q : total2 P -> UU) :
   weq (∏ xp : total2 P, Q xp) (∏ x : X, ∏ p : P x, Q (tpair _ x p)).
 Proof.


### PR DESCRIPTION
I acknowledge this is a change to `Foundations`, so I leave it totally to your discretion @DanGrayson. 

I see no harm in generalizing these definitions, though it also might be helpful to provide (several) non-dependent versions for simplicity. Some other changes would have to be made around the codebase before merging, either changing proofs to use a new non-dependent version or providing implicit arguments. 