### PR TITLE
Add initial and terminal objects to precategory of types

### DIFF
--- a/UniMath/CategoryTheory/categories/StandardCategories.v
+++ b/UniMath/CategoryTheory/categories/StandardCategories.v
@@ -3,6 +3,8 @@
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.CategoryTheory.Categories.
 Require Import UniMath.CategoryTheory.functor_categories.
+Require Import UniMath.CategoryTheory.limits.initial.
+Require Import UniMath.CategoryTheory.limits.terminal.
 
 Local Open Scope cat.
 
@@ -21,6 +23,18 @@ Proof.
     + exact (λ X, idfun X).
     + exact (λ X Y Z f g, funcomp f g).
   - repeat split; intros; apply idpath.
+Defined.
+
+Lemma InitialType : Initial type_precat.
+Proof.
+  apply (mk_Initial (empty : ob type_precat)).
+  exact iscontrfunfromempty.
+Defined.
+
+Lemma TerminalType : Terminal type_precat.
+Proof.
+  apply (mk_Terminal (unit : ob type_precat)).
+  exact iscontrfuntounit.
 Defined.
 
 (** *** the path groupoid *)


### PR DESCRIPTION
I also have what I imagine is a basic question. Does this (pre)category have other (co)limits?

I was trying to prove the universal property of the coproduct, but didn't really get anywhere:
```coq
Lemma coprod_universal :
  ∏ A B C (f g : A ⨿ B → C),
    (f ∘ inl = g ∘ inl × f ∘ inr = g ∘ inr) ≃ f = g.
Proof.
  intros ? ? ? f g.
  intermediate_weq (f ~ g).
  - use weq_iso.
    intros pair.
    intro copair; induction copair.
    + apply (toforallpaths _ _ _ (pr1 pair)).
    + apply (toforallpaths _ _ _ (pr2 pair)).
    + intro homot.
      use dirprodpair;
        apply maponpaths;
        apply funextsec;
        assumption.
    + intro pair; cbn.
      admit.
    + intro pair; cbn.
      admit.
  - apply invweq.
    apply weqtoforallpaths.
Admitted.
```
Maybe this is the problem tackled in https://arxiv.org/pdf/1304.0680v3.pdf ?