### PR TITLE
Suppress build output

### DIFF
--- a/UniMath/CategoryTheory/Inductives/Lists.v
+++ b/UniMath/CategoryTheory/Inductives/Lists.v
@@ -240,13 +240,13 @@ Definition sum : List natHSET -> nat :=
 (* Eval vm_compute in sum testlistS. *)
 
 (* All of these compute *)
-Eval lazy in length _ (nil natHSET).
-Eval lazy in length _ testlist.
-Eval lazy in length _ testlistS.
-Eval lazy in sum testlist.
-Eval lazy in sum testlistS.
-Eval lazy in length _ (concatenate _ testlist testlistS).
-Eval lazy in sum (concatenate _ testlist testlistS).
+(* Eval lazy in length _ (nil natHSET). *)
+(* Eval lazy in length _ testlist. *)
+(* Eval lazy in length _ testlistS. *)
+(* Eval lazy in sum testlist. *)
+(* Eval lazy in sum testlistS. *)
+(* Eval lazy in length _ (concatenate _ testlist testlistS). *)
+(* Eval lazy in sum (concatenate _ testlist testlistS). *)
 
 Goal (∏ l, length _ (2 :: l) = S (length _ l)).
 simpl.
@@ -336,7 +336,7 @@ Defined.
 (* Eval compute in (to_list _ testlist). *)
 
 (* This does compute: *)
-Eval lazy in (to_list _ testlist).
+(* Eval lazy in (to_list _ testlist). *)
 
 
 End list.

--- a/UniMath/CategoryTheory/Inductives/Lists.v
+++ b/UniMath/CategoryTheory/Inductives/Lists.v
@@ -240,13 +240,11 @@ Definition sum : List natHSET -> nat :=
 (* Eval vm_compute in sum testlistS. *)
 
 (* All of these compute *)
-(* Eval lazy in length _ (nil natHSET). *)
-(* Eval lazy in length _ testlist. *)
-(* Eval lazy in length _ testlistS. *)
-(* Eval lazy in sum testlist. *)
-(* Eval lazy in sum testlistS. *)
-(* Eval lazy in length _ (concatenate _ testlist testlistS). *)
-(* Eval lazy in sum (concatenate _ testlist testlistS). *)
+Goal length _ (nil natHSET) = 0. reflexivity. Qed.
+Goal length _ testlist = length _ testlistS. reflexivity. Qed.
+Goal sum testlistS = sum testlist + length _ testlist. lazy. reflexivity. Qed.
+Goal length _ (concatenate _ testlist testlistS) = length _ testlist + length _ testlistS. reflexivity. Qed.
+Goal sum (concatenate _ testlist testlistS) = sum testlistS + sum testlist. reflexivity. Qed.
 
 Goal (∏ l, length _ (2 :: l) = S (length _ l)).
 simpl.
@@ -336,8 +334,7 @@ Defined.
 (* Eval compute in (to_list _ testlist). *)
 
 (* This does compute: *)
-(* Eval lazy in (to_list _ testlist). *)
-
+Goal to_list _ testlist = 2,,5,,2,,tt. reflexivity. Qed.
 
 End list.
 

--- a/UniMath/CategoryTheory/Inductives/Trees.v
+++ b/UniMath/CategoryTheory/Inductives/Trees.v
@@ -254,5 +254,4 @@ Proof.
   - exact t.
 Defined.
 
-(* Eval lazy in Lists.sum (flatten _ testtree). *)
-(* Eval lazy in sum testtree. *)
+Goal Lists.sum (flatten _ testtree) = sum testtree. reflexivity. Qed.

--- a/UniMath/CategoryTheory/Inductives/Trees.v
+++ b/UniMath/CategoryTheory/Inductives/Trees.v
@@ -254,5 +254,5 @@ Proof.
   - exact t.
 Defined.
 
-Eval lazy in Lists.sum (flatten _ testtree).
-Eval lazy in sum testtree.
+(* Eval lazy in Lists.sum (flatten _ testtree). *)
+(* Eval lazy in sum testtree. *)

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -338,9 +338,6 @@ Proof.
     apply idpath.
 Qed.
 
-(* produce some output to keep TRAVIS running *)
-Check bracket_Thm15_ok_part1.
-
 Lemma bracket_Thm15_ok_part2 (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg  InitAlg ⟧):
  (theta H) ((alg_carrier _  InitAlg) ⊗ Z) ·  # H ⦃f⦄ · τ InitAlg
   =
@@ -400,10 +397,6 @@ Proof.
     repeat rewrite id_left.
     apply assoc.
 Qed.
-
-(* produce some output to keep TRAVIS running *)
-Check bracket_Thm15_ok_part2.
-
 
 Lemma bracket_Thm15_ok (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧):
  bracket_property_parts f ⦃f⦄.
@@ -497,10 +490,6 @@ Proof.
         became extremely slow *)
   - simpl; apply foo'.
 Defined.
-
-(* produce some output to keep TRAVIS running *)
-Check bracket_for_InitAlg.
-
 
 Definition InitHSS : hss_precategory CP H.
 Proof.

--- a/UniMath/SubstitutionSystems/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial_alt.v
@@ -288,9 +288,6 @@ eapply pathscomp0, pathscomp0; [|apply (!h_eq1'_inst)|]; clear h_eq1'_inst.
   now rewrite id_left, assoc.
 Qed.
 
-(* produce some output to keep TRAVIS running *)
-Check bracket_Thm15_ok_part1.
-
 Lemma bracket_Thm15_ok_part2 (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
   (theta H) ((alg_carrier _ InitAlg) ⊗ Z) ·  # H ⦃f⦄ · τ InitAlg =
   # (pr1 (ℓ (U Z))) (τ InitAlg) · ⦃f⦄.
@@ -317,9 +314,6 @@ eapply pathscomp0, pathscomp0; [|apply (!h_eq2'_inst)|]; clear h_eq2'_inst.
 - apply BinCoproductIn2Commutes_left_in_ctx_dir.
   now rewrite id_left; apply assoc.
 Qed.
-
-(* produce some output to keep TRAVIS running *)
-Check bracket_Thm15_ok_part2.
 
 Lemma bracket_Thm15_ok (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
   bracket_property_parts f ⦃f⦄.
@@ -373,9 +367,6 @@ use tpair.
        became extremely slow *)
 - cbn. apply bracket_unique.
 Defined.
-
-(* produce some output to keep TRAVIS running *)
-Check bracket_for_InitAlg.
 
 Definition InitHSS : hss_precategory CP H.
 Proof.

--- a/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
@@ -301,10 +301,6 @@ Defined.
 
 Definition μ_3 : EndC ⟦ U T_squared • `T,  `T⟧ := fbracket T μ_2_ptd.
 
-(* for Travis *)
-
-Check μ_3.
-
 (*
 Definition μ_3' := fbracket T μ_2_ptd.
 Check μ_3'.
@@ -368,9 +364,6 @@ Proof.
         eapply pathscomp0; [ | apply H1]; clear H1.
         apply pathsinv0, assoc.
 Qed.
-
-(* for Travis *)
-Check μ_3_T_μ_2_μ_2.
 
 Local Notation "'T•T²'" := (functor_compose hs hs (functor_composite (`T) (`T)) (`T) : [C, C, hs]).
 (*
@@ -494,10 +487,6 @@ Proof.
       }
 Qed.
 
-(* for Travis *)
-Check  μ_3_μ_2_T_μ_2.
-
-
 (** proving a variant of the third monad law with assoc iso explicitly inserted *)
 
 Section third_monad_law_with_assoc.
@@ -592,9 +581,6 @@ Proof.
 Qed.
 
 End third_monad_law_with_assoc.
-
-(* for Travis *)
-Check third_monad_law_from_hss.
 
 Unset Printing All.
 Set Printing Notations.


### PR DESCRIPTION
When building, a number of files print output (some seemingly unnecessarily, and some to previously ensure that Travis would not fail spuriously while trying to detect a lack of progress). I think the output in `CategoryTheory/Inductives` can definitely be removed, but the easiest way to tell whether Travis still has issues with `SubstitutionSystems` is to try it.

If Travis times out with this change, perhaps the best solution is to use `travis_wait` (https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received) rather than printing needlessly?

Fixes #773.