### PR TITLE
remove duplicate definitions of `flip`

### DIFF
--- a/UniMath/CategoryTheory/Inductives/Lists.v
+++ b/UniMath/CategoryTheory/Inductives/Lists.v
@@ -13,6 +13,7 @@ Require Import UniMath.Foundations.NaturalNumbers.
 
 Require Import UniMath.Combinatorics.Lists.
 
+Require Import UniMath.MoreFoundations.PartA. (* flip *)
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.total2_paths.
@@ -351,8 +352,6 @@ Variables (x : HSET).
 Definition constprod_functor : functor HSET HSET :=
   BinProduct_of_functors HSET HSET BinProductsHSET (constant_functor HSET HSET x)
                                          (functor_identity HSET).
-
-Definition flip {A B C : UU} (f : A -> B -> C) : B -> A -> C := λ x y, f y x.
 
 Lemma omega_cocontConstProdFunctor : is_omega_cocont constprod_functor.
 Proof.

--- a/UniMath/CategoryTheory/categories/Types.v
+++ b/UniMath/CategoryTheory/categories/Types.v
@@ -127,11 +127,6 @@ Section ExponentialFunctor.
     mk_functor exp_functor_data exp_functor_is_functor.
 End ExponentialFunctor.
 
-(** Flip the arguments of a function TODO: https://github.com/UniMath/UniMath/pull/924 *)
-Definition flipsec {A B : UU} {C : A -> B -> UU} (f : ∏ a b, C a b) : ∏ b a, C a b :=
-  λ x y, f y x.
-Notation flip := flipsec.
-
 Lemma ExponentialsType : Exponentials BinProductsType.
 Proof.
   intro X.

--- a/UniMath/CategoryTheory/categories/category_hset_structures.v
+++ b/UniMath/CategoryTheory/categories/category_hset_structures.v
@@ -35,6 +35,7 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.PartA. (* flip *)
 Require Import UniMath.MoreFoundations.Tactics.
 Require Import UniMath.MoreFoundations.AxiomOfChoice.
 
@@ -586,8 +587,6 @@ use tpair.
   [ intro x; now (repeat apply funextfun; intro)
   | intros x y z f g; now (repeat apply funextfun; intro)]).
 Defined.
-
-Definition flip {A B C : UU} (f : A -> B -> C) : B -> A -> C := λ x y, f y x.
 
 (** This checks that if we use constprod_functor2 the flip is not necessary *)
 Lemma are_adjoints_constprod_functor2 A :

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -164,3 +164,17 @@ Proof.
     apply transitive_paths_weq.
     apply (toforallpaths _ _ _ (transportf_const p Y) y1).
 Defined.
+
+(** Flip the arguments of a function *)
+Definition flipsec {A B : UU} {C : A -> B -> UU} (f : ∏ a b, C a b) : ∏ b a, C a b :=
+  λ x y, f y x.
+Notation flip := flipsec.
+
+(** Flip is a weak equivalence (in fact, it is an involution) *)
+Lemma isweq_flipsec {A B : UU} {C : A -> B -> UU} : isweq (@flipsec A B C).
+Proof.
+  apply (isweq_iso _ flipsec); reflexivity.
+Defined.
+
+Definition flipsec_weq {A B : UU} {C : A -> B -> UU} :
+  (∏ a b, C a b) ≃ (∏ b a, C a b) := weqpair flipsec isweq_flipsec.


### PR DESCRIPTION
Also, generalizes it and shows that it's a weak equivalence. 