### PR TITLE
(Pre)category of (pre)categories 

### DIFF
--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -82,12 +82,6 @@ Inductives/Lists.v
 Inductives/Trees.v
 Inductives/LambdaCalculus.v
 catiso.v
-bicategories/prebicategory.v
-bicategories/Notations.v
-bicategories/whiskering.v
-bicategories/Cat.v
-bicategories/internal_equivalence.v
-bicategories/bicategory.v
 Additive.v
 Abelian.v
 category_binops.v
@@ -130,6 +124,12 @@ categories/Types.v
 categories/Cats.v
 categories/preorder_categories.v
 categories/wosets.v
+bicategories/prebicategory.v
+bicategories/Notations.v
+bicategories/whiskering.v
+bicategories/Cat.v
+bicategories/internal_equivalence.v
+bicategories/bicategory.v
 Monads/Derivative.v
 DisplayedCats/Auxiliary.v
 DisplayedCats/Core.v

--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -127,6 +127,7 @@ categories/flds.v
 categories/modules.v
 categories/StandardCategories.v
 categories/Types.v
+categories/Cats.v
 categories/preorder_categories.v
 categories/wosets.v
 Monads/Derivative.v

--- a/UniMath/CategoryTheory/All.v
+++ b/UniMath/CategoryTheory/All.v
@@ -127,6 +127,7 @@ Require Export UniMath.CategoryTheory.categories.intdoms.
 Require Export UniMath.CategoryTheory.categories.flds.
 Require Export UniMath.CategoryTheory.categories.modules.
 Require Export UniMath.CategoryTheory.categories.StandardCategories.
+Require Export UniMath.CategoryTheory.categories.Cats.
 Require Export UniMath.CategoryTheory.categories.preorder_categories.
 Require Export UniMath.CategoryTheory.categories.wosets.
 Require Export UniMath.CategoryTheory.Monads.Derivative.

--- a/UniMath/CategoryTheory/All.v
+++ b/UniMath/CategoryTheory/All.v
@@ -70,6 +70,7 @@ Require Export UniMath.CategoryTheory.CommaCategories.
 Require Export UniMath.CategoryTheory.RightKanExtension.
 Require Export UniMath.CategoryTheory.exponentials.
 Require Export UniMath.CategoryTheory.slicecat.
+Require Export UniMath.CategoryTheory.coslicecat.
 Require Export UniMath.CategoryTheory.limits.pullbacks_slice_products_equiv.
 Require Export UniMath.CategoryTheory.covyoneda.
 Require Export UniMath.CategoryTheory.categories.category_hset_structures.
@@ -83,12 +84,6 @@ Require Export UniMath.CategoryTheory.Inductives.Lists.
 Require Export UniMath.CategoryTheory.Inductives.Trees.
 Require Export UniMath.CategoryTheory.Inductives.LambdaCalculus.
 Require Export UniMath.CategoryTheory.catiso.
-Require Export UniMath.CategoryTheory.bicategories.prebicategory.
-Require Export UniMath.CategoryTheory.bicategories.Notations.
-Require Export UniMath.CategoryTheory.bicategories.whiskering.
-Require Export UniMath.CategoryTheory.bicategories.Cat.
-Require Export UniMath.CategoryTheory.bicategories.internal_equivalence.
-Require Export UniMath.CategoryTheory.bicategories.bicategory.
 Require Export UniMath.CategoryTheory.Additive.
 Require Export UniMath.CategoryTheory.Abelian.
 Require Export UniMath.CategoryTheory.category_binops.
@@ -127,9 +122,16 @@ Require Export UniMath.CategoryTheory.categories.intdoms.
 Require Export UniMath.CategoryTheory.categories.flds.
 Require Export UniMath.CategoryTheory.categories.modules.
 Require Export UniMath.CategoryTheory.categories.StandardCategories.
+Require Export UniMath.CategoryTheory.categories.Types.
 Require Export UniMath.CategoryTheory.categories.Cats.
 Require Export UniMath.CategoryTheory.categories.preorder_categories.
 Require Export UniMath.CategoryTheory.categories.wosets.
+Require Export UniMath.CategoryTheory.bicategories.prebicategory.
+Require Export UniMath.CategoryTheory.bicategories.Notations.
+Require Export UniMath.CategoryTheory.bicategories.whiskering.
+Require Export UniMath.CategoryTheory.bicategories.Cat.
+Require Export UniMath.CategoryTheory.bicategories.internal_equivalence.
+Require Export UniMath.CategoryTheory.bicategories.bicategory.
 Require Export UniMath.CategoryTheory.Monads.Derivative.
 Require Export UniMath.CategoryTheory.DisplayedCats.Auxiliary.
 Require Export UniMath.CategoryTheory.DisplayedCats.Core.
@@ -141,6 +143,7 @@ Require Export UniMath.CategoryTheory.DisplayedCats.Codomain.
 Require Export UniMath.CategoryTheory.DisplayedCats.SIP.
 Require Export UniMath.CategoryTheory.DisplayedCats.Limits.
 Require Export UniMath.CategoryTheory.DisplayedCats.Examples.
+Require Export UniMath.CategoryTheory.DisplayedCats.Adjunctions.
 Require Export UniMath.CategoryTheory.PlainBicat.Bicat.
 Require Export UniMath.CategoryTheory.PlainBicat.PseudoFunctor.
 Require Export UniMath.CategoryTheory.PlainBicat.OpCellBicat.

--- a/UniMath/CategoryTheory/Chains/OmegaCocontFunctors.v
+++ b/UniMath/CategoryTheory/Chains/OmegaCocontFunctors.v
@@ -481,8 +481,8 @@ not product), which seems to require some additional assumption (e.g. decidable 
 perhaps other conditions might also suffice. *)
 (* NOTE: other lemmas in below on cocones in [power_precategory] may be able to be simplified using this. *)
 Lemma isColimCocone_in_product_precategory
-  {g : graph} (c : diagram g (product_precategory I B))
-  (b : product_precategory I B) (cc : cocone c b)
+  {g : graph} (c : diagram g (product_precategory B))
+  (b : product_precategory B) (cc : cocone c b)
   (M : ∏ i, isColimCocone _ _ (mapcocone (pr_functor I B i) _ cc))
   : isColimCocone c b cc.
 Proof.
@@ -511,7 +511,7 @@ Proof.
 Defined.
 
 Lemma is_cocont_functor_into_product_precategory
-  {F : functor A (product_precategory I B)}
+  {F : functor A (product_precategory B)}
   (HF : ∏ (i : I), is_cocont (functor_composite F (pr_functor I B i))) :
   is_cocont F.
 Proof.
@@ -523,7 +523,7 @@ Proof.
 Defined.
 
 Lemma is_omega_cocont_functor_into_product_precategory
-  {F : functor A (product_precategory I B)}
+  {F : functor A (product_precategory B)}
   (HF : ∏ (i : I), is_omega_cocont (functor_composite F (pr_functor I B i))) :
   is_omega_cocont F.
 Proof.
@@ -633,7 +633,7 @@ Defined.
 Lemma isColimCocone_family_functor {gr : graph} (F : ∏ (i : I), functor A B)
   (HF : ∏ i (d : diagram gr A) (c : A) (cc : cocone d c) (h : isColimCocone d c cc),
         isColimCocone _ _ (mapcocone (F i) d cc)) :
-  ∏ (d : diagram gr (product_precategory I (λ _, A))) (cd : I -> A) (cc : cocone d cd),
+  ∏ (d : diagram gr (product_precategory (λ _, A))) (cd : I -> A) (cc : cocone d cd),
   isColimCocone _ _ cc ->
   isColimCocone _ _ (mapcocone (family_functor I F) d cc).
 Proof.

--- a/UniMath/CategoryTheory/PrecategoryBinProduct.v
+++ b/UniMath/CategoryTheory/PrecategoryBinProduct.v
@@ -7,6 +7,10 @@ SubstitutionSystems
 
 2015
 
+For the general case, see [product_precategory].
+
+See [unit_category] for the unit category, which is the unit
+under cartesian product up to isomorphism.
 ************************************************************)
 
 
@@ -21,12 +25,11 @@ Contents :
 
 By PLL:
 
-- Definition of the unit precategory
-
 - Definition of the associator functors
 
 - Definition of the pair of two functors: A × C → B × D
   given A → B and C → D
+
 
 ************************************************************)
 
@@ -167,30 +170,6 @@ Proof.
 Defined.
 
 End assoc.
-
-(** The terminal precategory *)
-
-Section unit_precategory.
-
-Definition unit_precategory : precategory.
-Proof.
-  use tpair. use tpair.
-  (* ob, mor *) exists unit. intros; exact unit.
-  (* identity, comp *) split; intros; constructor.
-  (* id_left *) simpl; split; try split; intros; apply isProofIrrelevantUnit.
-Defined.
-
-Definition unit_functor C : functor C unit_precategory.
-Proof.
-  use tpair. use tpair.
-  (* functor_on_objects *) intros; exact tt.
-  (* functor_on_morphisms *) intros F a b; apply identity.
-  split.
-  (* functor_id *) intros x; apply paths_refl.
-  (* functor_comp *) intros x y z w v; apply paths_refl.
-Defined.
-
-End unit_precategory.
 
 (** Fixing one argument of C × D -> E results in a functor *)
 Section functor_fix_fst_arg.

--- a/UniMath/CategoryTheory/ProductCategory.v
+++ b/UniMath/CategoryTheory/ProductCategory.v
@@ -5,10 +5,17 @@ Anders Mörtberg
 
 2016
 
+For a specialization to binary products, see [precategory_binproduct].
+
 Contents:
 
 - Definition of the general product category ([product_precategory])
-- Tuple functor ([tuple_functor])
+- Functors
+  - Families of functors ([family_functor])
+  - Projections ([pr_functor])
+  - Delta functor ([delta_functor])
+  - Tuple functor ([tuple_functor])
+- Equivalence between functors into components and functors into product
 
 ************************************************************)
 
@@ -22,74 +29,81 @@ Local Open Scope cat.
 
 Section dep_product_precategory.
 
-Variable I : UU.
-Variables C : I -> precategory.
+  Context {I : UU} (C : I -> precategory).
 
-Definition product_precategory_ob_mor : precategory_ob_mor.
-Proof.
-use tpair.
-- apply (∏ (i : I), ob (C i)).
-- intros f g.
-  apply (∏ i, f i --> g i).
-Defined.
+  Definition product_precategory_ob_mor : precategory_ob_mor.
+  Proof.
+  use tpair.
+  - apply (∏ (i : I), ob (C i)).
+  - intros f g.
+    apply (∏ i, f i --> g i).
+  Defined.
 
-Definition product_precategory_data : precategory_data.
-Proof.
-  exists product_precategory_ob_mor.
-  split.
-  - intros f i; simpl in *.
-    apply (identity (f i)).
-  - intros a b c f g i; simpl in *.
-    exact (f i · g i).
-Defined.
+  Definition product_precategory_data : precategory_data.
+  Proof.
+    exists product_precategory_ob_mor.
+    split.
+    - intros f i; simpl in *.
+      apply (identity (f i)).
+    - intros a b c f g i; simpl in *.
+      exact (f i · g i).
+  Defined.
 
-Lemma is_precategory_product_precategory_data :
-  is_precategory product_precategory_data.
-Proof.
-repeat split; intros; apply funextsec; intro i.
-- apply id_left.
-- apply id_right.
-- apply assoc.
-Qed.
+  Lemma is_precategory_product_precategory_data :
+    is_precategory product_precategory_data.
+  Proof.
+  repeat split; intros; apply funextsec; intro i.
+  - apply id_left.
+  - apply id_right.
+  - apply assoc.
+  Qed.
 
-Definition product_precategory : precategory
-  := tpair _ _ is_precategory_product_precategory_data.
+  Definition product_precategory : precategory
+    := tpair _ _ is_precategory_product_precategory_data.
 
-Definition has_homsets_product_precategory (hsC : ∏ (i:I), has_homsets (C i)) :
-  has_homsets product_precategory.
-Proof.
-intros a b; simpl.
-apply impred_isaset; intro i; apply hsC.
-Qed.
+  Definition has_homsets_product_precategory (hsC : ∏ (i:I), has_homsets (C i)) :
+    has_homsets product_precategory.
+  Proof.
+  intros ? ?; simpl.
+  apply impred_isaset; intro; apply hsC.
+  Qed.
 
 End dep_product_precategory.
 
+(** The product of categories is again a category. *)
+Definition product_category {I : UU} (C : I -> category) : category.
+  use category_pair.
+  - exact (product_precategory C).
+  - apply has_homsets_product_precategory.
+    intro; exact (homset_property (C _)).
+Defined.
 
 Section power_precategory.
+  Context (I : UU) (C : precategory).
 
-Variable I : UU.
-Variables C : precategory.
+  Definition power_precategory : precategory
+    := @product_precategory I (λ _, C).
 
-
-Definition power_precategory : precategory
-  := product_precategory I (λ _, C).
-
-Definition has_homsets_power_precategory (hsC : has_homsets C) :
-  has_homsets power_precategory.
-Proof.
-apply has_homsets_product_precategory.
-intro i; assumption.
-Qed.
+  Definition has_homsets_power_precategory (hsC : has_homsets C) :
+    has_homsets power_precategory.
+  Proof.
+  apply has_homsets_product_precategory.
+  intro i; assumption.
+  Qed.
 
 End power_precategory.
+
+(** ** Functors *)
 
 (* TODO: Some of the functors in this section can be defined in terms of each other *)
 Section functors.
 
+(** *** Families of functors ([family_functor]) *)
+
 Definition family_functor_data (I : UU) {A B : I -> precategory}
   (F : ∏ (i : I), functor (A i) (B i)) :
-  functor_data (product_precategory I A)
-               (product_precategory I B).
+  functor_data (product_precategory A)
+               (product_precategory B).
 Proof.
 use tpair.
 - intros a i; apply (F i (a i)).
@@ -98,8 +112,8 @@ Defined.
 
 Definition family_functor (I : UU) {A B : I -> precategory}
   (F : ∏ (i : I), functor (A i) (B i)) :
-  functor (product_precategory I A)
-          (product_precategory I B).
+  functor (product_precategory A)
+          (product_precategory B).
 Proof.
 apply (tpair _ (family_functor_data I F)).
 abstract
@@ -107,8 +121,10 @@ abstract
           | intros x y z f g; apply funextsec; intro i; apply functor_comp]).
 Defined.
 
+(** *** Projections ([pr_functor]) *)
+
 Definition pr_functor_data (I : UU) (C : I -> precategory) (i : I) :
-  functor_data (product_precategory I C) (C i).
+  functor_data (product_precategory C) (C i).
 Proof.
 use tpair.
 - intro a; apply (a i).
@@ -116,11 +132,13 @@ use tpair.
 Defined.
 
 Definition pr_functor (I : UU) (C : I -> precategory) (i : I) :
-  functor (product_precategory I C) (C i).
+  functor (product_precategory C) (C i).
 Proof.
 apply (tpair _ (pr_functor_data I C i)).
 abstract (split; intros x *; apply idpath).
 Defined.
+
+(** *** Delta functor ([delta_functor]) *)
 
 Definition delta_functor_data (I : UU) (C : precategory) :
   functor_data C (power_precategory I C).
@@ -137,8 +155,10 @@ apply (tpair _ (delta_functor_data I C)).
 abstract (split; intros x *; apply idpath).
 Defined.
 
+(** *** Tuple functor ([tuple_functor]) *)
+
 Definition tuple_functor_data {I : UU} {A : precategory} {B : I → precategory}
-  (F : ∏ i, functor A (B i)) : functor_data A (product_precategory I B).
+  (F : ∏ i, functor A (B i)) : functor_data A (product_precategory B).
 Proof.
 use tpair.
 - intros a i; exact (F i a).
@@ -154,7 +174,7 @@ split.
 Qed.
 
 Definition tuple_functor {I : UU} {A : precategory} {B : I → precategory}
-  (F : ∏ i, functor A (B i)) : functor A (product_precategory I B)
+  (F : ∏ i, functor A (B i)) : functor A (product_precategory B)
     := (tuple_functor_data F,, tuple_functor_axioms F).
 
 Lemma pr_tuple_functor {I : UU} {A : precategory} {B : I → precategory} (hsB : ∏ i, has_homsets (B i))
@@ -164,3 +184,26 @@ now apply functor_eq.
 Qed.
 
 End functors.
+
+(** ** Equivalence between functors into components and functors into product *)
+
+(** This is a phrasing of the universal property of the product, compare to
+    [weqfuntoprodtoprod]. *)
+Lemma functor_into_product_weq {I : UU} {A : category} {B : I → category} :
+  functor A (product_category B) ≃ (∏ i : I, functor A (B i)).
+Proof.
+  use weq_iso.
+  - intros ? i.
+    (** Compose A ⟶ product_precategory I B ⟶ B i *)
+    apply (functor_composite (C' := product_precategory B)).
+    + assumption.
+    + exact (pr_functor _ _ i).
+  - exact tuple_functor.
+  - intro y.
+    apply functor_eq; [apply homset_property|].
+    reflexivity.
+  - intro f; cbn.
+    apply funextsec; intro i.
+    apply functor_eq; [exact (homset_property (B i))|].
+    reflexivity.
+Defined.

--- a/UniMath/CategoryTheory/bicategories/Cat.v
+++ b/UniMath/CategoryTheory/bicategories/Cat.v
@@ -13,6 +13,7 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.CategoryTheory.Categories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
+Require Import UniMath.CategoryTheory.categories.StandardCategories. (* unit *)
 Require Import UniMath.CategoryTheory.HorizontalComposition.
 Require Import UniMath.CategoryTheory.equivalences.
 Local Open Scope cat.
@@ -100,8 +101,8 @@ Definition Catlike_left_unitor (a b : precategory) (hsA : has_homsets a) (hsB : 
   nat_trans
      (functor_composite
         (bindelta_pair_functor
-           (functor_composite (unit_functor (functor_precategory a b hsB))
-              (constant_functor unit_precategory (functor_precategory a a hsA) (functor_identity a)))
+           (functor_composite (functor_to_unit (functor_precategory a b hsB))
+              (constant_functor unit_category (functor_precategory a a hsA) (functor_identity a)))
            (functor_identity (functor_precategory a b hsB)))
         (functorial_composition a a b hsA hsB))
      (functor_identity (functor_precategory a b hsB)).
@@ -146,8 +147,8 @@ Definition Catlike_right_unitor (a b : precategory) (hsB : has_homsets b) :
   nat_trans
      (functor_composite
         (bindelta_pair_functor (functor_identity (functor_precategory a b hsB))
-           (functor_composite (unit_functor (functor_precategory a b hsB))
-              (constant_functor unit_precategory (functor_precategory b b hsB) (functor_identity b))))
+           (functor_composite (functor_to_unit (functor_precategory a b hsB))
+              (constant_functor unit_category (functor_precategory b b hsB) (functor_identity b))))
         (functorial_composition a b b hsB hsB))
      (functor_identity (functor_precategory a b hsB)).
 Proof.

--- a/UniMath/CategoryTheory/bicategories/prebicategory.v
+++ b/UniMath/CategoryTheory/bicategories/prebicategory.v
@@ -103,58 +103,51 @@ Proof.
   apply functor_on_iso. exact (precatbinprodiso alpha beta).
 Defined.
 
-Local Notation "alpha ;hi; beta" := (compose_2mor_iso_horizontal alpha beta) (at level 50, format "alpha ;hi; beta").
+Local Notation "alpha  ';hi;'  beta" := (compose2h_iso alpha beta) (at level 50).
 
-Definition associator_trans_type { C : prebicategory_id_comp } (a b c d : C) :=
-  nat_trans
-    (functor_composite
-      (pair_functor (functor_identity _) (compose_functor b c d))
-      (compose_functor a b d))
-    (functor_composite
-      (precategory_binproduct_assoc _ _ _)
-      (functor_composite
-        (pair_functor (compose_functor a b c) (functor_identity _))
-        (compose_functor a c d))).
+Definition associator_trans_type {C : prebicategory_id_comp} (a b c d : C) : UU
+  := pair_functor (functor_identity (a -1-> b)) (compose_functor b c d) ∙
+     compose_functor a b d
+     ⟹
+     precategory_binproduct_assoc (a -1-> b) (b -1-> c) (c -1-> d) ∙
+     (pair_functor (compose_functor a b c) (functor_identity (c -1-> d)) ∙
+      compose_functor a c d).
 
-Definition left_unitor_trans_type { C : prebicategory_id_comp } (a b : C) :=
-  nat_trans
-    (functor_composite
-      (bindelta_pair_functor
-        (functor_composite (functor_to_unit _) (constant_functor unit_category _ (identity_1mor a)))
-        (functor_identity _))
-      (compose_functor a a b))
-    (functor_identity _).
+Definition left_unitor_trans_type {C : prebicategory_id_comp} (a b : C) : UU
+  := bindelta_pair_functor
+       (constant_functor (a -1-> b) (a -1-> a) (identity1 a))
+       (functor_identity (a -1-> b)) ∙ compose_functor a a b
+     ⟹
+     functor_identity (a -1-> b).
 
-Definition right_unitor_trans_type { C : prebicategory_id_comp } (a b : C) :=
-  nat_trans
-    (functor_composite
-      (bindelta_pair_functor
-        (functor_identity _)
-        (functor_composite (functor_to_unit _) (constant_functor unit_category _ (identity_1mor b))))
-      (compose_functor a b b))
-    (functor_identity _).
+Definition right_unitor_trans_type {C : prebicategory_id_comp} (a b : C) : UU
+  := bindelta_pair_functor
+       (functor_identity (a -1-> b))
+       (constant_functor (a -1-> b) (b -1-> b) (identity1 b)) ∙
+     compose_functor a b b
+     ⟹
+     functor_identity (a -1-> b).
 
-Definition prebicategory_data :=
-  total2 (λ C : prebicategory_id_comp,
-    dirprod
-      (forall a b c d : C, associator_trans_type a b c d)
-      ( dirprod
-        (forall a b : C, left_unitor_trans_type a b)
-        (* Right *)
-        (forall a b : C, right_unitor_trans_type a b)
-      )).
+Definition prebicategory_data : UU :=
+  ∑ C : prebicategory_id_comp,
+          (∏ a b c d : C, associator_trans_type a b c d)
+        × (∏ a b : C, left_unitor_trans_type a b)
+        × (∏ a b : C, right_unitor_trans_type a b).         (* Right *)
 
-Definition prebicategory_id_comp_from_prebicategory_data (C : prebicategory_data) :
-     prebicategory_id_comp := pr1 C.
-Coercion prebicategory_id_comp_from_prebicategory_data :
-  prebicategory_data >-> prebicategory_id_comp.
+Coercion prebicategory_id_comp_from_prebicategory_data (C : prebicategory_data)
+  : prebicategory_id_comp
+  := pr1 C.
 
-Definition has_2mor_sets (C : prebicategory_data) :=
-  forall a b : C,
-  forall f g : a -1-> b,
-    isaset (f -2-> g).
+Definition has_2mor_sets (C : prebicategory_data) : UU
+  := ∏ (a b : C) (f g : a -1-> b), isaset (f -2-> g).
 
-Definition associator_trans {C : prebicategory_data} ( a b c d : C )
+Definition associator_trans {C : prebicategory_data} (a b c d : C)
+  : pair_functor (functor_identity (a -1-> b))
+                 (compose_functor b c d) ∙ compose_functor a b d
+    ⟹
+    precategory_binproduct_assoc (a -1-> b) (b -1-> c) (c -1-> d) ∙
+    (pair_functor (compose_functor a b c) (functor_identity (c -1-> d)) ∙
+     compose_functor a c d)
   := pr1 (pr2 C) a b c d.
 
 Definition associator_2mor {C : prebicategory_data} {a b c d : C}

--- a/UniMath/CategoryTheory/bicategories/prebicategory.v
+++ b/UniMath/CategoryTheory/bicategories/prebicategory.v
@@ -13,6 +13,7 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.CategoryTheory.Categories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
+Require Import UniMath.CategoryTheory.categories.StandardCategories. (* unit *)
 Require Import UniMath.CategoryTheory.HorizontalComposition.
 Require Import UniMath.CategoryTheory.equivalences.
 
@@ -102,51 +103,58 @@ Proof.
   apply functor_on_iso. exact (precatbinprodiso alpha beta).
 Defined.
 
-Local Notation "alpha  ';hi;'  beta" := (compose2h_iso alpha beta) (at level 50).
+Local Notation "alpha ;hi; beta" := (compose_2mor_iso_horizontal alpha beta) (at level 50, format "alpha ;hi; beta").
 
-Definition associator_trans_type {C : prebicategory_id_comp} (a b c d : C) : UU
-  := pair_functor (functor_identity (a -1-> b)) (compose_functor b c d) ∙
-     compose_functor a b d
-     ⟹
-     precategory_binproduct_assoc (a -1-> b) (b -1-> c) (c -1-> d) ∙
-     (pair_functor (compose_functor a b c) (functor_identity (c -1-> d)) ∙
-      compose_functor a c d).
+Definition associator_trans_type { C : prebicategory_id_comp } (a b c d : C) :=
+  nat_trans
+    (functor_composite
+      (pair_functor (functor_identity _) (compose_functor b c d))
+      (compose_functor a b d))
+    (functor_composite
+      (precategory_binproduct_assoc _ _ _)
+      (functor_composite
+        (pair_functor (compose_functor a b c) (functor_identity _))
+        (compose_functor a c d))).
 
-Definition left_unitor_trans_type {C : prebicategory_id_comp} (a b : C) : UU
-  := bindelta_pair_functor
-       (constant_functor (a -1-> b) (a -1-> a) (identity1 a))
-       (functor_identity (a -1-> b)) ∙ compose_functor a a b
-     ⟹
-     functor_identity (a -1-> b).
+Definition left_unitor_trans_type { C : prebicategory_id_comp } (a b : C) :=
+  nat_trans
+    (functor_composite
+      (bindelta_pair_functor
+        (functor_composite (functor_to_unit _) (constant_functor unit_category _ (identity_1mor a)))
+        (functor_identity _))
+      (compose_functor a a b))
+    (functor_identity _).
 
-Definition right_unitor_trans_type {C : prebicategory_id_comp} (a b : C) : UU
-  := bindelta_pair_functor
-       (functor_identity (a -1-> b))
-       (constant_functor (a -1-> b) (b -1-> b) (identity1 b)) ∙
-     compose_functor a b b
-     ⟹
-     functor_identity (a -1-> b).
+Definition right_unitor_trans_type { C : prebicategory_id_comp } (a b : C) :=
+  nat_trans
+    (functor_composite
+      (bindelta_pair_functor
+        (functor_identity _)
+        (functor_composite (functor_to_unit _) (constant_functor unit_category _ (identity_1mor b))))
+      (compose_functor a b b))
+    (functor_identity _).
 
-Definition prebicategory_data : UU :=
-  ∑ C : prebicategory_id_comp,
-          (∏ a b c d : C, associator_trans_type a b c d)
-        × (∏ a b : C, left_unitor_trans_type a b)
-        × (∏ a b : C, right_unitor_trans_type a b).         (* Right *)
+Definition prebicategory_data :=
+  total2 (λ C : prebicategory_id_comp,
+    dirprod
+      (forall a b c d : C, associator_trans_type a b c d)
+      ( dirprod
+        (forall a b : C, left_unitor_trans_type a b)
+        (* Right *)
+        (forall a b : C, right_unitor_trans_type a b)
+      )).
 
-Coercion prebicategory_id_comp_from_prebicategory_data (C : prebicategory_data)
-  : prebicategory_id_comp
-  := pr1 C.
+Definition prebicategory_id_comp_from_prebicategory_data (C : prebicategory_data) :
+     prebicategory_id_comp := pr1 C.
+Coercion prebicategory_id_comp_from_prebicategory_data :
+  prebicategory_data >-> prebicategory_id_comp.
 
-Definition has_2mor_sets (C : prebicategory_data) : UU
-  := ∏ (a b : C) (f g : a -1-> b), isaset (f -2-> g).
+Definition has_2mor_sets (C : prebicategory_data) :=
+  forall a b : C,
+  forall f g : a -1-> b,
+    isaset (f -2-> g).
 
-Definition associator_trans {C : prebicategory_data} (a b c d : C)
-  : pair_functor (functor_identity (a -1-> b))
-                 (compose_functor b c d) ∙ compose_functor a b d
-    ⟹
-    precategory_binproduct_assoc (a -1-> b) (b -1-> c) (c -1-> d) ∙
-    (pair_functor (compose_functor a b c) (functor_identity (c -1-> d)) ∙
-     compose_functor a c d)
+Definition associator_trans {C : prebicategory_data} ( a b c d : C )
   := pr1 (pr2 C) a b c d.
 
 Definition associator_2mor {C : prebicategory_data} {a b c d : C}

--- a/UniMath/CategoryTheory/bicategories/whiskering.v
+++ b/UniMath/CategoryTheory/bicategories/whiskering.v
@@ -217,7 +217,7 @@ Proof.
   intermediate_path ((functor_on_morphisms
                  (functor_composite
                      (bindelta_pair_functor
-                        (functor_composite (functor_to_unit _) (constant_functor unit_category _ (identity_1mor a)))
+                        (functor_composite (functor_to_unit _) (constant_functor unit_category _ (identity1 a)))
                         (functor_identity _))
                      (compose_functor a a b))
                  alpha)
@@ -239,7 +239,7 @@ Proof.
                  (functor_composite
                     (bindelta_pair_functor
                        (functor_identity _)
-                       (functor_composite (functor_to_unit _) (constant_functor unit_category _ (identity_1mor b))))
+                       (functor_composite (functor_to_unit _) (constant_functor unit_category _ (identity1 b))))
                     (compose_functor a b b))
                  alpha)
            ;v;(right_unitor _)).

--- a/UniMath/CategoryTheory/bicategories/whiskering.v
+++ b/UniMath/CategoryTheory/bicategories/whiskering.v
@@ -5,6 +5,7 @@ Require Import UniMath.MoreFoundations.Tactics.
 Require Import UniMath.CategoryTheory.Categories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
+Require Import UniMath.CategoryTheory.categories.StandardCategories. (* unit *)
 Require Import UniMath.CategoryTheory.HorizontalComposition.
 Require Import UniMath.CategoryTheory.equivalences.
 
@@ -216,7 +217,7 @@ Proof.
   intermediate_path ((functor_on_morphisms
                  (functor_composite
                      (bindelta_pair_functor
-                        (functor_composite (unit_functor _) (constant_functor unit_precategory _ (identity1 a)))
+                        (functor_composite (functor_to_unit _) (constant_functor unit_category _ (identity_1mor a)))
                         (functor_identity _))
                      (compose_functor a a b))
                  alpha)
@@ -238,7 +239,7 @@ Proof.
                  (functor_composite
                     (bindelta_pair_functor
                        (functor_identity _)
-                       (functor_composite (unit_functor _) (constant_functor unit_precategory _ (identity1 b))))
+                       (functor_composite (functor_to_unit _) (constant_functor unit_category _ (identity_1mor b))))
                     (compose_functor a b b))
                  alpha)
            ;v;(right_unitor _)).

--- a/UniMath/CategoryTheory/categories/Cats.v
+++ b/UniMath/CategoryTheory/categories/Cats.v
@@ -1,0 +1,115 @@
+(** * The (pre)category of (pre)categories
+
+This file defines the (pre)category of 𝒰-small (pre)categories, i.e.
+(pre)categories that fit within some fixed universe.
+
+Author: Langston Barrett (@siddharthist), Feb 2018
+*)
+
+(** ** Contents:
+
+- The precategory of 𝒰-small precategories (for fixed U) ([precat_precat])
+- The precategory of 𝒰-small categories (for fixed U) ([cat_precat])
+- (Co)limits
+  - Colimits
+  - Limits
+    - Terminal precategory ([TerminalPrecat])
+    - Terminal category ([TerminalCat])
+    - Products ([ProductsCat])
+*)
+
+Require Import UniMath.Foundations.PartA.
+Require Import UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.PartA.
+
+(* Basic category theory *)
+Require Import UniMath.CategoryTheory.Categories.
+Require Import UniMath.CategoryTheory.functor_categories.
+
+(* (Co)limits *)
+Require Import UniMath.CategoryTheory.categories.StandardCategories.
+Require Import UniMath.CategoryTheory.limits.initial.
+Require Import UniMath.CategoryTheory.limits.terminal.
+Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.ProductCategory.
+
+Local Open Scope cat.
+Local Open Scope functions.
+
+(** ** The precategory of 𝒰-small precategories (for fixed U) ([precat_precat]) *)
+
+Definition precat_precat : precategory.
+Proof.
+  use mk_precategory.
+  - use tpair; use tpair; cbn.
+    + exact precategory.
+    + exact functor.
+    + exact functor_identity.
+    + exact @functor_composite.
+  - repeat split; intros.
+    + apply functor_identity_right.
+    + apply pathsinv0, functor_assoc.
+Defined.
+
+(** ** The precategory of 𝒰-small categories (for fixed U) ([cat_precat]) *)
+
+Definition cat_precat : precategory.
+Proof.
+  use mk_precategory.
+  - use tpair; use tpair; cbn.
+    + exact category.
+    + exact functor.
+    + exact functor_identity.
+    + exact @functor_composite.
+  - repeat split; intros.
+    + apply functor_identity_right.
+    + apply pathsinv0, functor_assoc.
+Defined.
+
+(** ** (Co)limits *)
+
+(** *** Colimits *)
+
+(** **** Initial category ([InitialCat]) *)
+
+(** *** Limits *)
+
+(** **** Terminal precategory ([TerminalPrecat]) *)
+
+Definition TerminalPrecat : Terminal precat_precat.
+Proof.
+  use mk_Terminal.
+  - cbn; exact unit_category.
+  - intros ?; apply iscontr_functor_to_unit.
+Defined.
+
+(** **** Terminal category ([TerminalCat]) *)
+
+Definition TerminalCat : Terminal cat_precat.
+Proof.
+  use mk_Terminal.
+  - cbn; exact unit_category.
+  - intros ?; apply iscontr_functor_to_unit.
+Defined.
+
+(** **** Products ([ProductsCat]) *)
+
+(** We essentially proved the universal property in [functor_into_product_weq],
+    an equivalence between A → (product_category B) and (∏ i : I, A → (B i)).
+  *)
+Definition ProductsCat {I : UU} : Products I cat_precat.
+Proof.
+  intros f; cbn in *.
+  use mk_Product.
+  - exact (product_category f).
+  - intro i; exact (pr_functor I f i).
+  - intros other_prod other_proj; cbn in other_proj.
+    apply (@iscontrweqf (hfiber functor_into_product_weq other_proj)).
+    + use weqfibtototal; intros other_functor; cbn.
+      use weqpair.
+      * apply toforallpaths.
+      * apply isweqtoforallpaths.
+    + apply weqproperty.
+Defined.
+
+(** *)

--- a/UniMath/CategoryTheory/categories/StandardCategories.v
+++ b/UniMath/CategoryTheory/categories/StandardCategories.v
@@ -3,7 +3,8 @@
 
 - The path groupoid ([path_groupoid])
 - The discrete univalent_category on n objects ([cat_n])
-
+  - The category with one object ([unit_category])
+  - The category with no objects ([empty_category])
 *)
 
 Require Import UniMath.Foundations.Sets.
@@ -98,6 +99,7 @@ Proof. apply isofhleveltotal2. apply isapropisaset.
 Lemma is_discrete_cat_n (n:nat) : is_discrete (cat_n n).
 Proof. split. apply isasetstn. apply is_groupoid_path_pregroupoid. Qed.
 
+(** ** The category with one object ([unit_category]) *)
 
 Definition unit_category : univalent_category.
 Proof.
@@ -106,42 +108,81 @@ Proof.
   - do 2 (apply hlevelntosn). apply isapropunit.
 Defined.
 
+Section FunctorToUnit.
+  Context (A : precategory).
 
-Section functor.
+  Definition functor_to_unit_data : functor_data A unit_category.
+  Proof.
+    use mk_functor_data.
+    - exact tounit.
+    - exact (λ _ _ _, idpath _ ).
+  Defined.
 
-Variable A : precategory.
+  Definition is_functor_to_unit : is_functor functor_to_unit_data.
+  Proof.
+    split.
+    - intro. apply idpath.
+    - intros ? ? ? ? ?; apply idpath.
+  Qed.
 
-Definition functor_to_unit_data : functor_data A unit_category.
+  Definition functor_to_unit : functor A _ := mk_functor _ is_functor_to_unit.
+
+  Lemma iscontr_functor_to_unit : iscontr (functor A unit_category).
+  Proof.
+    use iscontrpair.
+    - exact functor_to_unit.
+    - intro F.
+      apply functor_eq.
+      + apply (homset_property unit_category).
+      + use total2_paths_f.
+        * apply funextsec. intro. cbn.
+          apply proofirrelevance.
+          apply isapropunit.
+        * do 3 (apply funextsec; intro).
+          apply proofirrelevance.
+          simpl.
+          apply hlevelntosn.
+          apply isapropunit.
+  Qed.
+End FunctorToUnit.
+
+(** ** The category with no objects ([empty_category]) *)
+
+Definition empty_category : univalent_category.
 Proof.
-  exists (λ _, tt).
-  exact (λ _ _ _, idpath _ ).
+  use path_groupoid.
+  - exact empty.
+  - do 2 (apply hlevelntosn). apply isapropempty.
 Defined.
 
-Definition is_functor_to_unit : is_functor functor_to_unit_data.
-Proof.
-  split.
-  - intro a. apply idpath.
-  - intros a b c f g . apply idpath.
-Qed.
+Section FunctorFromEmpty.
+  Context (A : precategory).
 
-Definition functor_to_unit : functor A _ := _ ,, is_functor_to_unit.
+  Definition functor_from_empty_data : functor_data empty_category A.
+  Proof.
+    use mk_functor_data.
+    - exact fromempty.
+    - intros empt ?; induction empt.
+  Defined.
 
-Lemma functor_to_unit_unique (F : functor A unit_category)
-  : F = functor_to_unit.
-Proof.
-  apply functor_eq.
-  - apply (homset_property unit_category).
-  - use total2_paths_f.
-    + apply funextsec. intro. cbn.
-      apply proofirrelevance.
-      apply isapropunit.
-    + do 3 (apply funextsec; intro).
-      apply proofirrelevance.
-      simpl.
-      apply hlevelntosn.
-      apply isapropunit.
-Qed.
+  Definition is_functor_from_empty : is_functor functor_from_empty_data.
+  Proof.
+    use tpair; intro a; induction a.
+  Defined.
 
-End functor.
+  Definition functor_from_empty : functor empty_category A :=
+    mk_functor _ is_functor_from_empty.
+
+  Lemma iscontr_functor_from_empty {hs : has_homsets A} :
+    iscontr (functor empty_category A).
+  Proof.
+    use iscontrpair.
+    - exact functor_from_empty.
+    - intro F.
+      apply functor_eq; [assumption|].
+      use total2_paths_f;
+        apply funextsec; intro empt; induction empt.
+  Qed.
+End FunctorFromEmpty.
 
 (* *)


### PR DESCRIPTION
See commit messages for details.

Both `bicategories` and #925 have their own definitions of the bicategory of (pre)categories, but no definition of the 1-category of (pre)categories. @benediktahrens It might be good to add a way to define a bicategory "layered over" a 1-category at some point? 