### PR TITLE
add weak equivalence between adjunctions and natural weqs of homsets

### DIFF
--- a/UniMath/CategoryTheory/Adjunctions.v
+++ b/UniMath/CategoryTheory/Adjunctions.v
@@ -634,15 +634,22 @@ End HomSetIso_from_Adjunction.
 
 Section Adjunction_from_HomSetIso.
 
-  Context {C D : precategory} {F : functor C D} {G : functor D C}
-          {hom_weq :  ∏ {A : C} {B : D}, F A --> B ≃ A --> G B}
-          {natural_precomp : ∏ (A : C) (B : D) (f : F A --> B) (X : C) (h : X --> A),
-                             hom_weq (#F h · f) = h · hom_weq f}
-          {natural_postcomp : ∏ (A : C) (B : D) (f : F A --> B) (Y : D) (k : B --> Y),
-                              hom_weq (f · k) = hom_weq f · #G k}.
+  Definition natural_hom_weq {C D : precategory} (F : functor C D) (G : functor D C) : UU
+    := ∑ (hom_weq :  ∏ {A : C} {B : D}, F A --> B ≃ A --> G B),
+         (∏ (A : C) (B : D) (f : F A --> B) (X : C) (h : X --> A),
+          hom_weq (#F h · f) = h · hom_weq f) ×
+         (∏ (A : C) (B : D) (f : F A --> B) (Y : D) (k : B --> Y),
+          hom_weq (f · k) = hom_weq f · #G k).
 
-  Local Definition hom_inv {A : C} {B : D}: A --> G B → F A --> B
-    := invmap (hom_weq A B).
+  Context {C D : precategory} {F : functor C D} {G : functor D C}
+          (H : natural_hom_weq F G).
+
+  Let hom_weq : ∏ {A : C} {B : D}, F A --> B ≃ A --> G B := pr1 H.
+  Let natural_precomp :  ∏ (A : C) (B : D) (f : F A --> B) (X : C) (h : X --> A),
+                         hom_weq (#F h · f) = h · hom_weq f := pr1 (pr2 H).
+  Let natural_postcomp : ∏ (A : C) (B : D) (f : F A --> B) (Y : D) (k : B --> Y),
+                         hom_weq (f · k) = hom_weq f · #G k := pr2 (pr2 H).
+  Let hom_inv : ∏ {A : C} {B : D}, A --> G B → F A --> B := λ A B, invmap hom_weq.
 
   Definition inv_natural_precomp {A : C} {B : D} (g : A --> G B) {X : C} (h : X --> A)
     : hom_inv (h · g) = #F h · hom_inv g.
@@ -665,7 +672,7 @@ Section Adjunction_from_HomSetIso.
   Definition unit_from_hom : nat_trans (functor_identity C) (F ∙ G).
   Proof.
     use mk_nat_trans.
-    - exact (λ A, (hom_weq _ _ (identity (F A)))).
+    - exact (λ A, (hom_weq (identity (F A)))).
     - intros A A' h. cbn.
       rewrite <- natural_precomp.
       rewrite <- natural_postcomp.
@@ -686,7 +693,7 @@ Section Adjunction_from_HomSetIso.
       apply id_right.
   Defined.
 
-  Definition adj_from_homsetiso : are_adjoints F G.
+  Definition adj_from_nathomweq : are_adjoints F G.
   Proof.
     apply (mk_are_adjoints F G unit_from_hom counit_from_hom).
     apply dirprodpair.
@@ -701,3 +708,79 @@ Section Adjunction_from_HomSetIso.
   Defined.
 
 End Adjunction_from_HomSetIso.
+
+Lemma isaprop_form_adjunction {A B : category} (F : functor A B) (G : functor B A)
+             (eta : nat_trans (functor_identity A) (functor_composite F G))
+             (eps : nat_trans (functor_composite G F) (functor_identity B))
+      : isaprop (form_adjunction F G eta eps).
+Proof.
+  apply isapropdirprod; apply impred_isaprop; intro.
+  - apply B.
+  - apply A.
+Defined.
+
+(* ** Weak equivalence between adjunctions F -| G and natural weqs of homsets (F A --> B) ≃ (A --> G B) *)
+
+Section Adjunction_HomSetIso_weq.
+
+  Context {C D : category} {F : functor C D} {G : functor D C}.
+
+  Definition nathomweq_from_adj : (are_adjoints F G) → (natural_hom_weq F G)
+    := λ H, (adjunction_hom_weq H,, (φ_adj_natural_precomp H,, φ_adj_natural_postcomp H)).
+
+  Lemma adj_after_nathomweq (H : are_adjoints F G)
+    : adj_from_nathomweq (nathomweq_from_adj H) = H.
+  Proof.
+    apply subtypeEquality'.
+    - apply dirprod_paths; cbn.
+      + apply subtypeEquality'.
+        * cbn.
+          unfold φ_adj, unit_from_are_adjoints.
+          apply funextsec.
+          intro c.
+          rewrite functor_id.
+          apply id_right.
+        * apply isaprop_is_nat_trans, C.
+      + apply subtypeEquality'.
+        * cbn.
+          unfold φ_adj_inv, counit_from_are_adjoints.
+          apply funextsec.
+          intro d.
+          rewrite functor_id.
+          apply id_left.
+        * apply isaprop_is_nat_trans, D.
+    - apply isaprop_form_adjunction.
+  Defined.
+
+  Lemma nathomweq_after_adj (H : natural_hom_weq F G)
+    : nathomweq_from_adj (adj_from_nathomweq H) = H.
+  Proof.
+    apply subtypeEquality'.
+    - cbn.
+      unfold adjunction_hom_weq.
+      do 2 (apply funextsec; intro).
+      apply subtypeEquality'.
+      + cbn.
+        unfold φ_adj, adj_from_nathomweq. cbn.
+        apply funextsec.
+        intro f.
+        rewrite <- (pr2 (pr2 H)).
+        apply maponpaths.
+        apply id_left.
+      + apply isapropisweq.
+    - apply isapropdirprod.
+      + do 5 (apply impred_isaprop; intro).
+        apply C.
+      + do 5 (apply impred_isaprop; intro).
+        apply C.
+  Defined.
+
+  Lemma adjunction_homsetiso_weq : (are_adjoints F G) ≃ (natural_hom_weq F G).
+  Proof.
+    exists nathomweq_from_adj.
+    apply (isweq_iso _ adj_from_nathomweq).
+    - apply adj_after_nathomweq.
+    - apply nathomweq_after_adj.
+  Defined.
+
+End Adjunction_HomSetIso_weq.


### PR DESCRIPTION
Suggested in comment to #608. (It only seems to work for categories not precategories though).