### PR TITLE
Vectors, matrices, and magnitude

### DIFF
--- a/UniMath/Algebra/.package/files
+++ b/UniMath/Algebra/.package/files
@@ -15,3 +15,4 @@ Modules/Submodule.v
 Modules/Multimodules.v
 Modules/Examples.v
 Modules.v
+Matrix.v

--- a/UniMath/Algebra/All.v
+++ b/UniMath/Algebra/All.v
@@ -17,3 +17,4 @@ Require Export UniMath.Algebra.Modules.Submodule.
 Require Export UniMath.Algebra.Modules.Multimodules.
 Require Export UniMath.Algebra.Modules.Examples.
 Require Export UniMath.Algebra.Modules.
+Require Export UniMath.Algebra.Matrix.

--- a/UniMath/Algebra/BinaryOperations.v
+++ b/UniMath/Algebra/BinaryOperations.v
@@ -142,6 +142,9 @@ Definition lunax_is {X : UU} {opp : binop X} (is : ismonoidop opp) :
 Definition runax_is {X : UU} {opp : binop X} (is : ismonoidop opp) :
   isrunit opp (pr1 (pr2 is)) := pr2 (pr2 (pr2 is)).
 
+Definition unax_is {X : UU} {opp : binop X} (is : ismonoidop opp) :
+  isunit opp (pr1 (pr2 is)) := dirprodpair (lunax_is is) (runax_is is).
+
 Lemma isapropismonoidop {X : hSet} (opp : binop X) : isaprop (ismonoidop opp).
 Proof.
   apply (isofhleveldirprod 1).
@@ -587,7 +590,7 @@ Definition isrigops {X : UU} (opp1 opp2 : binop X) : UU :=
              × (∏ x : X, (opp2 x (unel_is (pr1 axs))) = (unel_is (pr1 axs))))
     × (isdistr opp1 opp2).
 
-Definition mk_isrigops {X : hSet} {opp1 opp2 : binop X} (H1 : isabmonoidop opp1)
+Definition mk_isrigops {X : UU} {opp1 opp2 : binop X} (H1 : isabmonoidop opp1)
            (H2 : ismonoidop opp2) (H3 : ∏ x : X, (opp2 (unel_is H1) x) = (unel_is H1))
            (H4 : ∏ x : X, (opp2 x (unel_is H1)) = (unel_is H1))
            (H5 : isdistr opp1 opp2) : isrigops opp1 opp2 :=

--- a/UniMath/Algebra/IteratedBinaryOperations.v
+++ b/UniMath/Algebra/IteratedBinaryOperations.v
@@ -99,14 +99,14 @@ Section BinaryOperations.
   Defined.
 
   Definition iterop_fun_step' (lunax : islunit op unel) {m} (xs:stn m -> X) (x:X) :
-    iterop_fun (append_fun xs x) = op (iterop_fun xs) x.
+    iterop_fun (append_vec xs x) = op (iterop_fun xs) x.
   Proof.
     intros lunax ? ? ?.
     unfold iterop_fun at 1.
     simpl.
     induction m as [|m _].
-    - simpl. rewrite append_fun_compute_2. apply pathsinv0. apply lunax.
-    - simpl. rewrite append_fun_compute_2.
+    - simpl. rewrite append_vec_compute_2. apply pathsinv0. apply lunax.
+    - simpl. rewrite append_vec_compute_2.
       apply (maponpaths (λ y, op y x)). apply maponpaths.
       apply append_and_drop_fun.
   Defined.
@@ -123,15 +123,15 @@ Section BinaryOperations.
   Defined.
 
   Definition iterop_fun_append (lunax : islunit op unel) {m} (x:stn m -> X) (y:X) :
-    iterop_fun (append_fun x y) = op (iterop_fun x) y.
+    iterop_fun (append_vec x y) = op (iterop_fun x) y.
   Proof.
     intros lunax. intros.
     rewrite (iterop_fun_step lunax).
-    rewrite append_fun_compute_2.
+    rewrite append_vec_compute_2.
     apply (maponpaths (λ x, op (iterop_fun x) y)).
     apply funextfun; intro i.
     unfold funcomp.
-    rewrite append_fun_compute_1.
+    rewrite append_vec_compute_1.
     reflexivity.
   Defined.
 
@@ -195,12 +195,12 @@ Section Monoids.
     iterop_seq_mon (append x m) = iterop_seq_mon x * m.
   Proof.
      intros [n x] ?. unfold append. rewrite iterop_seq_mon_step.
-     rewrite append_fun_compute_2.
+     rewrite append_vec_compute_2.
      apply (maponpaths (λ a, a * m)).
      apply (maponpaths (λ x, iterop_seq_mon (n,,x))).
      apply funextfun; intros [i b]; simpl.
      unfold funcomp.
-     now rewrite append_fun_compute_1.
+     now rewrite append_vec_compute_1.
   Defined.
 
   Local Lemma iterop_seq_seq_mon_step {n} (x:stn (S n) -> Sequence M) :
@@ -326,7 +326,7 @@ Proof.
   Local Open Scope transport.
   set (f := nil □ j □ S O □ n-j : stn 3 -> nat).
   assert (B : stnsum f = S n).
-  { unfold stnsum, f; simpl. repeat unfold append_fun; simpl. rewrite natplusassoc.
+  { unfold stnsum, f; simpl. repeat unfold append_vec; simpl. rewrite natplusassoc.
     rewrite (natpluscomm 1). rewrite <- natplusassoc.
     rewrite natpluscomm. apply (maponpaths S). rewrite natpluscomm. now apply minusplusnmm. }
   set (r := weqfibtototal _ _ (λ k, eqweqmap (maponpaths (λ n, k < n : UU) B) ) :
@@ -351,7 +351,7 @@ Proof.
   change (f s0) with j; change (f s1) with (S O); change (f s2) with (n-j).
   set (f' := nil □ j □ n-j : stn 2 -> nat).
   assert (B' : stnsum f' = n).
-  { unfold stnsum, f'; simpl. repeat unfold append_fun; simpl.
+  { unfold stnsum, f'; simpl. repeat unfold append_vec; simpl.
     rewrite natpluscomm. now apply minusplusnmm. }
   set (r' := weqfibtototal _ _ (λ k, eqweqmap (maponpaths (λ n, k < n : UU) B') ) :
               stn (stnsum f') ≃ stn n).

--- a/UniMath/Algebra/Matrix.v
+++ b/UniMath/Algebra/Matrix.v
@@ -1,0 +1,320 @@
+(** * Matrices
+
+Operations on vectors and matrices.
+
+Author: Langston Barrett (@siddharthist) (March 2018)
+*)
+
+Require Import UniMath.Foundations.PartA.
+Require Import UniMath.MoreFoundations.PartA.
+Require Import UniMath.Combinatorics.FiniteSequences.
+Require Import UniMath.Algebra.BinaryOperations.
+Require Import UniMath.Algebra.IteratedBinaryOperations.
+
+Require Import UniMath.Algebra.Rigs_and_Rings.
+
+(** ** Contents
+
+ - Vectors
+   - Standard conditions on one binary operation
+   - Standard conditions on a pair of binary operations
+   - Structures
+ - Matrices
+   - Standard conditions on one binary operation
+   - Standard conditions on a pair of binary operations
+   - Structures
+   - Matrix rig
+*)
+
+(** ** Vectors *)
+
+Definition pointwise {X : UU} (n : nat) (op : binop X) : binop (Vector X n) :=
+  λ v1 v2 i, op (v1 i) (v2 i).
+
+(** *** Standard conditions on one binary operation *)
+
+(** Most features of binary operations (associativity, unity, etc) carry over to
+    pointwise operations. *)
+Section OneOp.
+  Context {X : UU} {n : nat} {op : binop X}.
+
+  Definition pointwise_assoc (assocax : isassoc op) : isassoc (pointwise n op).
+  Proof.
+    intros ? ? ?; apply funextfun; intro; apply assocax.
+  Defined.
+
+  Definition pointwise_lunit (lun : X) (lunax : islunit op lun) :
+    islunit (pointwise n op) (const_vec lun).
+  Proof.
+    intros ?; apply funextfun; intro; apply lunax.
+  Defined.
+
+  Definition pointwise_runit (run : X) (runax : isrunit op run) :
+    isrunit (pointwise n op) (const_vec run).
+  Proof.
+    intros ?; apply funextfun; intro; apply runax.
+  Defined.
+
+  Definition pointwise_unit (un : X) (unax : isunit op un) :
+    isunit (pointwise n op) (const_vec un).
+  Proof.
+    use isunitpair.
+    - apply pointwise_lunit; exact (pr1 unax).
+    - apply pointwise_runit; exact (pr2 unax).
+  Defined.
+
+  Definition pointwise_comm (commax : iscomm op) : iscomm (pointwise n op).
+  Proof.
+    intros ? ?; apply funextfun; intro; apply commax.
+  Defined.
+
+  Definition pointwise_monoidop (monoidax : ismonoidop op) :
+    ismonoidop (pointwise n op).
+  Proof.
+    use mk_ismonoidop.
+    - apply pointwise_assoc, assocax_is; assumption.
+    - use isunitalpair.
+      + apply (const_vec (unel_is monoidax)).
+      + apply pointwise_unit, unax_is.
+  Defined.
+
+  Definition pointwise_abmonoidop (abmonoidax : isabmonoidop op) :
+    isabmonoidop (pointwise n op).
+  Proof.
+    use mk_isabmonoidop.
+    - apply pointwise_monoidop; exact (pr1isabmonoidop _ _ abmonoidax).
+    - apply pointwise_comm; exact (pr2 abmonoidax).
+  Defined.
+
+End OneOp.
+
+(** *** Standard conditions on a pair of binary operations *)
+
+Section TwoOps.
+  Context {X : UU} {n : nat} {op : binop X} {op' : binop X}.
+
+  Definition pointwise_ldistr (isldistrax : isldistr op op') :
+    isldistr (pointwise n op) (pointwise n op').
+  Proof.
+    intros ? ? ?; apply funextfun; intro; apply isldistrax.
+  Defined.
+
+  Definition pointwise_rdistr (isrdistrax : isrdistr op op') :
+    isrdistr (pointwise n op) (pointwise n op').
+  Proof.
+    intros ? ? ?; apply funextfun; intro; apply isrdistrax.
+  Defined.
+
+  Definition pointwise_distr (isdistrax : isdistr op op') :
+    isdistr (pointwise n op) (pointwise n op').
+  Proof.
+    use dirprodpair.
+    - apply pointwise_ldistr; apply (dirprod_pr1 isdistrax).
+    - apply pointwise_rdistr; apply (dirprod_pr2 isdistrax).
+  Defined.
+
+  Definition pointwise_isrigops (isrigopsax : isrigops op op') :
+    isrigops (pointwise n op) (pointwise n op').
+  Proof.
+    use mk_isrigops.
+    - apply pointwise_abmonoidop, (rigop1axs_is isrigopsax).
+    - apply pointwise_monoidop, (rigop2axs_is isrigopsax).
+    - intro; apply funextfun; intro;
+        apply (dirprod_pr1 (pr2 (dirprod_pr1 isrigopsax))).
+    - intro; apply funextfun; intro;
+        apply (dirprod_pr2 (pr2 (dirprod_pr1 isrigopsax))).
+    - apply pointwise_distr, rigdistraxs_is; assumption.
+  Defined.
+
+End TwoOps.
+
+(** *** Structures *)
+
+Section Structures.
+
+  Definition pointwise_hSet (X : hSet) (n : nat) : hSet.
+  Proof.
+    use hSetpair.
+    - exact (Vector X n).
+    - change isaset with (isofhlevel 2).
+      apply vector_hlevel, setproperty.
+  Defined.
+
+  Definition pointwise_setwithbinop (X : setwithbinop) (n : nat) : setwithbinop.
+  Proof.
+    use setwithbinoppair.
+    - apply pointwise_hSet; [exact X|assumption].
+    - exact (pointwise n op).
+  Defined.
+
+  Definition pointwise_setwith2binop (X : setwith2binop) (n : nat) : setwith2binop.
+  Proof.
+    use setwith2binoppair.
+    - apply pointwise_hSet; [exact X|assumption].
+    - split.
+      + exact (pointwise n op1).
+      + exact (pointwise n op2).
+  Defined.
+
+  Definition pointwise_monoid (X : monoid) (n : nat) : monoid.
+  Proof.
+    use monoidpair.
+    - apply pointwise_setwithbinop; [exact X|assumption].
+    - apply pointwise_monoidop; exact (pr2 X).
+  Defined.
+
+  Definition pointwise_abmonoid (X : abmonoid) (n : nat) : abmonoid.
+  Proof.
+    use abmonoidpair.
+    - apply pointwise_setwithbinop; [exact X|assumption].
+    - apply pointwise_abmonoidop; exact (pr2 X).
+  Defined.
+
+  Definition pointwise_rig (X : rig) (n : nat) : rig.
+  Proof.
+    use rigpair.
+    - apply pointwise_setwith2binop; [exact X|assumption].
+    - apply pointwise_isrigops; exact (pr2 X).
+  Defined.
+
+End Structures.
+
+(** ** Matrices *)
+
+Definition entrywise {X : UU} (n m : nat) (op : binop X) : binop (Matrix X n m) :=
+  λ mat1 mat2 i, pointwise _ op (mat1 i) (mat2 i).
+
+(** *** Standard conditions on one binary operation *)
+
+Section OneOpMat.
+  Context {X : UU} {n m : nat} {op : binop X}.
+
+  Definition entrywise_assoc (assocax : isassoc op) : isassoc (entrywise n m op).
+  Proof.
+    intros ? ? ?; apply funextfun; intro; apply pointwise_assoc, assocax.
+  Defined.
+
+  Definition entrywise_lunit (lun : X) (lunax : islunit op lun) :
+    islunit (entrywise n m op) (const_matrix lun).
+  Proof.
+    intros ?; apply funextfun; intro; apply pointwise_lunit, lunax.
+  Defined.
+
+  Definition entrywise_runit (run : X) (runax : isrunit op run) :
+    isrunit (entrywise n m op) (const_matrix run).
+  Proof.
+    intros ?; apply funextfun; intro; apply pointwise_runit, runax.
+  Defined.
+
+  Definition entrywise_unit (un : X) (unax : isunit op un) :
+    isunit (entrywise n m op) (const_matrix un).
+  Proof.
+    use isunitpair.
+    - apply entrywise_lunit; exact (pr1 unax).
+    - apply entrywise_runit; exact (pr2 unax).
+  Defined.
+
+  Definition entrywise_comm (commax : iscomm op) : iscomm (entrywise n m op).
+  Proof.
+    intros ? ?; apply funextfun; intro; apply pointwise_comm, commax.
+  Defined.
+
+  Definition entrywise_monoidop (monoidax : ismonoidop op) :
+    ismonoidop (entrywise n m op).
+  Proof.
+    use mk_ismonoidop.
+    - apply entrywise_assoc, assocax_is; assumption.
+    - use isunitalpair.
+      + apply (const_matrix (unel_is monoidax)).
+      + apply entrywise_unit, unax_is.
+  Defined.
+
+  Definition entrywise_abmonoidop (abmonoidax : isabmonoidop op) :
+    isabmonoidop (entrywise n m op).
+  Proof.
+    use mk_isabmonoidop.
+    - apply entrywise_monoidop; exact (pr1isabmonoidop _ _ abmonoidax).
+    - apply entrywise_comm; exact (pr2 abmonoidax).
+  Defined.
+
+End OneOpMat.
+
+(** *** Standard conditions on a pair of binary operations *)
+
+Section TwoOpsMat.
+  Context {X : UU} {n m : nat} {op : binop X} {op' : binop X}.
+
+  Definition entrywise_ldistr (isldistrax : isldistr op op') :
+    isldistr (entrywise n m op) (entrywise n m op').
+  Proof.
+    intros ? ? ?; apply funextfun; intro; apply pointwise_ldistr, isldistrax.
+  Defined.
+
+  Definition entrywise_rdistr (isrdistrax : isrdistr op op') :
+    isrdistr (entrywise n m op) (entrywise n m op').
+  Proof.
+    intros ? ? ?; apply funextfun; intro; apply pointwise_rdistr, isrdistrax.
+  Defined.
+
+  Definition entrywise_distr (isdistrax : isdistr op op') :
+    isdistr (entrywise n m op) (entrywise n m op').
+  Proof.
+    use dirprodpair.
+    - apply entrywise_ldistr; apply (dirprod_pr1 isdistrax).
+    - apply entrywise_rdistr; apply (dirprod_pr2 isdistrax).
+  Defined.
+
+  Definition entrywise_isrigops (isrigopsax : isrigops op op') :
+    isrigops (entrywise n m op) (entrywise n m op').
+  Proof.
+    use mk_isrigops.
+    - apply entrywise_abmonoidop, (rigop1axs_is isrigopsax).
+    - apply entrywise_monoidop, (rigop2axs_is isrigopsax).
+    - do 2 (intro; apply funextfun); intro;
+        apply (dirprod_pr1 (pr2 (dirprod_pr1 isrigopsax))).
+    - do 2 (intro; apply funextfun); intro;
+        apply (dirprod_pr2 (pr2 (dirprod_pr1 isrigopsax))).
+    - apply entrywise_distr, rigdistraxs_is; assumption.
+  Defined.
+
+End TwoOpsMat.
+
+(** *** Structures *)
+
+(** *** Matrix rig *)
+
+Section MatrixMult.
+
+  Context {R : rig}.
+
+  (** Summation and pointwise multiplication *)
+  Local Notation Σ := (iterop_fun rigunel1 op1).
+  Local Notation "R1 ^ R2" := ((pointwise _ op2) R1 R2).
+
+  (** If A is m × n (so B is n × p),
+      <<
+        AB(i, j) = A(i, 1) * B(1, j) + A(i, 2) * B(2, j) + ⋯ + A(i, n) * B(n, j)
+      >>
+      The order of the arguments allows currying the first matrix.
+  *)
+  Definition matrix_mult {m n : nat} (mat1 : Matrix R m n)
+                         {p : nat} (mat2 : Matrix R n p) : (Matrix R m p) :=
+    λ i j, Σ ((row mat1 i) ^ (col mat2 j)).
+
+  Local Notation "A ** B" := (matrix_mult A B) (at level 80).
+
+  Lemma identity_matrix {n : nat} : (Matrix R n n).
+  Proof.
+    intros i j.
+    induction (stn_eq_or_neq i j).
+    - exact (rigunel2). (* The multiplicative identity *)
+    - exact (rigunel1). (* The additive identity *)
+  Defined.
+
+  (*
+  Lemma matrix_mult_assoc {m n : nat} (mat1 : Matrix R m n)
+                          {p : nat} (mat2 : Matrix R n p)
+                          {q : nat} (mat3 : Matrix R p q) :
+    ((mat1 ** mat2) ** mat3) = (mat1 ** (mat2 ** mat3)).
+  *)
+End MatrixMult.

--- a/UniMath/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Algebra/Monoids_and_Groups.v
@@ -86,6 +86,8 @@ Definition lunax (X : monoid) : islunit (@op X) (unel X) := pr1 (pr2 (pr2 (pr2 X
 
 Definition runax (X : monoid) : isrunit (@op X) (unel X) := pr2 (pr2 (pr2 (pr2 X))).
 
+Definition unax (X : monoid) : isunit (@op X) (unel X) := dirprodpair (lunax X) (runax X).
+
 Definition isasetmonoid (X : monoid) : isaset X := pr2 (pr1 (pr1 X)).
 
 Notation "x + y" := (op x y) : addmonoid_scope.

--- a/UniMath/Combinatorics/FiniteSequences.v
+++ b/UniMath/Combinatorics/FiniteSequences.v
@@ -183,6 +183,12 @@ Definition row {X : UU} {m n : nat} (mat : Matrix X m n) : ⟦ S m ⟧ → Vecto
 
 Definition col {X : UU} {m n : nat} (mat : Matrix X m n) : ⟦ S n ⟧ → Vector X (S m) := transpose mat.
 
+Definition row_vec {X : UU} {n : nat} (vec : Vector X (S n)) : Matrix X 0 n :=
+  λ i j, vec j.
+
+Definition col_vec {X : UU} {n : nat} (vec : Vector X (S n)) : Matrix X n 0 :=
+  λ i j, vec i.
+
 (** hlevel of matrices *)
 Lemma matrix_hlevel (X : UU) (n m : nat) {o : nat} (ism : isofhlevel o X) :
   isofhlevel o (Matrix X n m).

--- a/UniMath/Topology/Filters.v
+++ b/UniMath/Topology/Filters.v
@@ -1192,7 +1192,7 @@ Proof.
           3: apply IHl.
           intros C.
           generalize (Hl lastelement) ; simpl.
-          rewrite append_fun_compute_2.
+          rewrite append_vec_compute_2.
           apply hinhfun.
           apply sumofmaps ; [intros Fl | intros ->].
           + refine (tpair _ _ _).
@@ -1217,7 +1217,7 @@ Proof.
           + intros.
             generalize (Hl (dni_lastelement m)) ; simpl.
             rewrite <- replace_dni_last.
-            now rewrite append_fun_compute_1. }
+            now rewrite append_vec_compute_1. }
       revert B.
       apply hinhuniv.
       intros B.

--- a/UniMath/Topology/Prelim.v
+++ b/UniMath/Topology/Prelim.v
@@ -261,7 +261,7 @@ Proof.
   intros X A L.
   rewrite finite_intersection_case.
   simpl.
-  rewrite append_fun_compute_2.
+  rewrite append_vec_compute_2.
   apply funextfun ; intro x.
   apply maponpaths.
   apply map_on_two_paths.
@@ -270,7 +270,7 @@ Proof.
     apply funextfun ; intro m.
     unfold funcomp.
     rewrite <- replace_dni_last.
-    apply append_fun_compute_1.
+    apply append_vec_compute_1.
   - reflexivity.
 Qed.
 
@@ -304,10 +304,10 @@ Proof.
     + intros L A IHl Hl.
       rewrite finite_intersection_append.
       apply (pr2 Hp).
-      * rewrite <- (append_fun_compute_2 L A).
+      * rewrite <- (append_vec_compute_2 L A).
         now apply Hl.
       * apply IHl.
         intros n.
-        rewrite <- (append_fun_compute_1 L A).
+        rewrite <- (append_vec_compute_1 L A).
         apply Hl.
 Qed.


### PR DESCRIPTION
Currently, `Sequence`s in `X` are sigma-types ` ∑ n, stn n -> X`. Here, I give a name to the type `stn n -> X`, namely `Vector X n`. A `Matrix` is a vector of vectors. 

I show that most algebraic properties of binary operations hold when said operations are extended pointwise to vectors and entrywise to matrices. I then define matrix multiplication, weighting and coweighting, and the magnitude of a matrix with entries in a semiring (as in [The magnitude of metric spaces](https://arxiv.org/abs/1012.5857)).