### PR TITLE
Hom (bi)functor with type_precat codomain

### DIFF
--- a/UniMath/CategoryTheory/categories/Types.v
+++ b/UniMath/CategoryTheory/categories/Types.v
@@ -19,7 +19,10 @@ Author: Langston Barrett (@siddharthist), Feb 2018
 - Exponentials
   - The exponential functor y ↦ yˣ ([exp_functor])
   - Exponentials ([ExponentialsType])
-
+- Hom functors
+  - As a bifunctor ([hom_functor])
+  - Covariant ([cov_hom_functor])
+  - Contravariant ([contra_hom_functor])
 *)
 
 Require Import UniMath.Foundations.PartA.
@@ -39,6 +42,10 @@ Require Import UniMath.CategoryTheory.limits.binproducts.
 (* Exponentials *)
 Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.Adjunctions.
+
+(* Hom functors *)
+Require Import UniMath.CategoryTheory.opp_precat.
+Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
 
 Local Open Scope cat.
 Local Open Scope functions.
@@ -148,3 +155,52 @@ Proof.
       * intros ? ? ?; reflexivity.
   - use mk_form_adjunction; reflexivity.
 Defined.
+
+(** ** Hom functors *)
+
+Section HomFunctors.
+
+  Context {C : precategory}.
+
+  (** ** As a bifunctor [hom_functor] *)
+
+  Definition hom_functor_data :
+    functor_data (precategory_binproduct C^op C) type_precat.
+  Proof.
+    use mk_functor_data.
+    - intros pair; exact (C ⟦ pr1 pair, pr2 pair ⟧).
+    - intros x y fg h.
+      refine (_ · h · _).
+      + exact (pr1 fg).
+      + exact (pr2 fg).
+  Defined.
+
+  Lemma is_functor_hom_functor_type : is_functor hom_functor_data.
+  Proof.
+    use dirprodpair.
+    - intro; cbn.
+      apply funextsec; intro.
+      unfold idfun.
+      refine (id_right _ @ _).
+      apply id_left.
+    - intros ? ? ? ? ?; cbn in *.
+      apply funextsec; intro; unfold funcomp.
+      abstract (do 3 rewrite assoc; reflexivity).
+  Defined.
+
+  Definition hom_functor : functor (precategory_binproduct C^op C) type_precat :=
+    mk_functor _ is_functor_hom_functor_type.
+
+  Context (c : C).
+
+  (** ** Covariant [cov_hom_functor] *)
+
+  Definition cov_hom_functor : functor C type_precat :=
+    functor_fix_fst_arg (C^op) _ _ hom_functor c.
+
+  (** ** Contravariant [contra_hom_functor] *)
+
+  Definition contra_hom_functor : functor (C^op) type_precat :=
+    functor_fix_snd_arg (C^op) _ _ hom_functor c.
+
+End HomFunctors.


### PR DESCRIPTION
Hom functors are defined in `yoneda.v`, but only for categories (i.e. with homsets), and the have codomain `HSET`. These are for general precategories. 