### PR TITLE
Define rig ideals

### DIFF
--- a/UniMath/Algebra/.package/files
+++ b/UniMath/Algebra/.package/files
@@ -1,6 +1,7 @@
 BinaryOperations.v
 Monoids_and_Groups.v
-Rigs_and_Rings.v
+RigsAndRings.v
+RigsAndRings/Ideals.v
 Domains_and_Fields.v
 DivisionRig.v
 Apartness.v

--- a/UniMath/Algebra/All.v
+++ b/UniMath/Algebra/All.v
@@ -2,7 +2,8 @@
 Require Export UniMath.Foundations.Init.
 Require Export UniMath.Algebra.BinaryOperations.
 Require Export UniMath.Algebra.Monoids_and_Groups.
-Require Export UniMath.Algebra.Rigs_and_Rings.
+Require Export UniMath.Algebra.RigsAndRings.
+Require Export UniMath.Algebra.RigsAndRings.Ideals.
 Require Export UniMath.Algebra.Domains_and_Fields.
 Require Export UniMath.Algebra.DivisionRig.
 Require Export UniMath.Algebra.Apartness.

--- a/UniMath/Algebra/Archimedean.v
+++ b/UniMath/Algebra/Archimedean.v
@@ -12,7 +12,7 @@ Unset Kernel Term Sharing.
 
 (** Imports *)
 
-Require Import UniMath.Algebra.Rigs_and_Rings .
+Require Import UniMath.Algebra.RigsAndRings .
 Require Import UniMath.Algebra.DivisionRig .
 Require Import UniMath.Algebra.Domains_and_Fields .
 Require Import UniMath.Algebra.ConstructiveStructures.

--- a/UniMath/Algebra/Archimedean.v
+++ b/UniMath/Algebra/Archimedean.v
@@ -12,9 +12,10 @@ Unset Kernel Term Sharing.
 
 (** Imports *)
 
-Require Import UniMath.Algebra.RigsAndRings .
-Require Import UniMath.Algebra.DivisionRig .
-Require Import UniMath.Algebra.Domains_and_Fields .
+Require Import UniMath.Foundations.NaturalNumbers.
+Require Import UniMath.Algebra.RigsAndRings.
+Require Import UniMath.Algebra.DivisionRig.
+Require Import UniMath.Algebra.Domains_and_Fields.
 Require Import UniMath.Algebra.ConstructiveStructures.
 
 Require Import UniMath.MoreFoundations.Tactics.

--- a/UniMath/Algebra/DivisionRig.v
+++ b/UniMath/Algebra/DivisionRig.v
@@ -12,7 +12,7 @@ Unset Automatic Introduction. (** This line has to be removed for the file to co
 Unset Kernel Term Sharing.
 
 Require Export UniMath.Foundations.Sets.
-Require Export UniMath.Algebra.Rigs_and_Rings.
+Require Export UniMath.Algebra.RigsAndRings.
 Require Export UniMath.Algebra.Domains_and_Fields.
 
 Require Import UniMath.MoreFoundations.Tactics.

--- a/UniMath/Algebra/Domains_and_Fields.v
+++ b/UniMath/Algebra/Domains_and_Fields.v
@@ -29,7 +29,7 @@ Unset Kernel Term Sharing.
 
 (** Imports *)
 
-Require Export UniMath.Algebra.Rigs_and_Rings.
+Require Export UniMath.Algebra.RigsAndRings.
 
 (** To upstream files *)
 

--- a/UniMath/Algebra/Domains_and_Fields.v
+++ b/UniMath/Algebra/Domains_and_Fields.v
@@ -185,7 +185,7 @@ Definition multrinvpair (X : rig) (x : X) : UU := rinvpair (rigmultmonoid X) x.
 
 Definition multinvpair (X : rig) (x : X) : UU := invpair (rigmultmonoid X) x.
 
-Definition rigneq0andmultlinv (X : rig) (n m : X) (isnm : neg (paths (n * m) 0)%rig) :
+Definition rigneq0andmultlinv (X : rig) (n m : X) (isnm : ((n * m) != 0)%rig) :
   n != 0%rig.
 Proof.
   intros. intro e. rewrite e in isnm.
@@ -193,7 +193,7 @@ Proof.
   destruct (isnm (idpath _)).
 Defined.
 
-Definition rigneq0andmultrinv (X : rig) (n m : X) (isnm : neg (paths (n * m) 0)%rig) :
+Definition rigneq0andmultrinv (X : rig) (n m : X) (isnm : ((n * m) != 0)%rig) :
   m != 0%rig.
 Proof.
   intros. intro e. rewrite e in isnm. rewrite (rigmultx0 _) in isnm.
@@ -204,14 +204,14 @@ Defined.
 
 Local Open Scope ring_scope.
 
-Definition ringneq0andmultlinv (X : ring) (n m : X) (isnm : neg (paths (n * m) 0)) : n != 0.
+Definition ringneq0andmultlinv (X : ring) (n m : X) (isnm : ((n * m) != 0)) : n != 0.
 Proof.
   intros. intro e. rewrite e in isnm.
   rewrite (ringmult0x X) in isnm.
   destruct (isnm (idpath _)).
 Defined.
 
-Definition ringneq0andmultrinv (X : ring) (n m : X) (isnm : neg (paths (n * m) 0)) : m != 0.
+Definition ringneq0andmultrinv (X : ring) (n m : X) (isnm : ((n * m) != 0)) : m != 0.
 Proof.
   intros. intro e. rewrite e in isnm.
   rewrite (ringmultx0 _) in isnm.
@@ -270,7 +270,7 @@ Local Open Scope ring_scope.
 (** **** General definitions *)
 
 Lemma isnonzerolinvel (X : ring) (is : isnonzerorig X) (x : X) (x' : multlinvpair X x) :
-  neg ((pr1 x') = 0).
+  ((pr1 x') != 0).
 Proof.
   intros.
   apply (negf (maponpaths (λ a : X, a * x))).
@@ -280,7 +280,7 @@ Proof.
 Defined.
 
 Lemma isnonzerorinvel (X : ring) (is : isnonzerorig X) (x : X) (x' : multrinvpair X x) :
-  neg ((pr1 x') = 0).
+  ((pr1 x') != 0).
 Proof.
   intros.
   apply (negf (maponpaths (λ a : X, x * a))).
@@ -328,7 +328,7 @@ Coercion pr1intdom : intdom >-> commring.
 Definition nonzeroax (X : intdom) : neg (@paths X 1 0) := pr1 (pr2 X).
 
 Definition intdomax (X : intdom) :
-  ∏ (a1 a2 : X), paths (a1 * a2) 0 -> hdisj (eqset a1 0) (eqset a2 0) := pr2 (pr2 X).
+  ∏ (a1 a2 : X), (a1 * a2) = 0 -> hdisj (eqset a1 0) (eqset a2 0) := pr2 (pr2 X).
 
 
 (** **** (X = Y) ≃ (ringiso X Y)
@@ -410,7 +410,7 @@ Proof.
 Defined.
 
 Definition intdomneq0andmult (X : intdom) (n m : X) (isn : n != 0)
-           (ism : m != 0) : neg (paths (n * m) 0).
+           (ism : m != 0) : ((n * m) != 0).
 Proof.
   intros. intro e. destruct (ism (intdomax2l X n m e isn )).
 Defined.
@@ -651,8 +651,8 @@ Definition fldfracmultinv0 (X : intdom) (is : isdeceq X)
   commringfrac X (intdomnonzerosubmonoid X) := setquotfun _ _ _ (fldfracmultinvintcomp X is) x.
 
 Lemma nonzeroincommringfrac (X : commring) (S : @submonoid (ringmultmonoid X)) (xa : dirprod X S)
-      (ne : neg (paths (setquotpr (eqrelcommringfrac X S) xa)
-                       (setquotpr _ (dirprodpair 0 (unel S))))) : neg ((pr1 xa) = 0).
+      (ne : (setquotpr (eqrelcommringfrac X S) xa !=
+             setquotpr _ (dirprodpair 0 (unel S)))) : (pr1 xa != 0).
 Proof.
   intros. set (x := pr1 xa). set (aa := pr2 xa).
   assert (e' := negf (weqpathsinsetquot (eqrelcommringfrac X S) _ _) ne).
@@ -665,7 +665,7 @@ Defined.
 Opaque nonzeroincommringfrac.
 
 Lemma zeroincommringfrac (X : intdom) (S : @submonoid (ringmultmonoid X))
-      (is : ∏ s : S, neg ((pr1 s) = 0)) (x : X) (aa : S)
+      (is : ∏ s : S, (pr1 s != 0)) (x : X) (aa : S)
       (e : paths (setquotpr (eqrelcommringfrac X S) (dirprodpair x aa))
                  (setquotpr _ (dirprodpair 0 (unel S)))) : x = 0.
 Proof.

--- a/UniMath/Algebra/Domains_and_Fields.v
+++ b/UniMath/Algebra/Domains_and_Fields.v
@@ -269,15 +269,7 @@ Local Open Scope ring_scope.
 
 (** **** General definitions *)
 
-Definition isnonzeroring (X : ring) : UU := neg (@paths X 1 0).
-
-Lemma isapropisnonzeroring (X : ring) : isaprop (isnonzeroring X).
-Proof.
-  intros X. use isapropneg.
-Defined.
-Opaque isapropisnonzeroring.
-
-Lemma isnonzerolinvel (X : ring) (is : isnonzeroring X) (x : X) (x' : multlinvpair X x) :
+Lemma isnonzerolinvel (X : ring) (is : isnonzerorig X) (x : X) (x' : multlinvpair X x) :
   neg ((pr1 x') = 0).
 Proof.
   intros.
@@ -287,7 +279,7 @@ Proof.
   rewrite (ringmult0x X _). apply is.
 Defined.
 
-Lemma isnonzerorinvel (X : ring) (is : isnonzeroring X) (x : X) (x' : multrinvpair X x) :
+Lemma isnonzerorinvel (X : ring) (is : isnonzerorig X) (x : X) (x' : multrinvpair X x) :
   neg ((pr1 x') = 0).
 Proof.
   intros.
@@ -297,7 +289,7 @@ Proof.
   rewrite e. rewrite (ringmultx0 X _). apply is.
 Defined.
 
-Lemma isnonzerofromlinvel (X : ring) (is : isnonzeroring X) (x : X) (x' : multlinvpair X x) :
+Lemma isnonzerofromlinvel (X : ring) (is : isnonzerorig X) (x : X) (x' : multlinvpair X x) :
   x != 0.
 Proof.
   intros. apply (negf (maponpaths (λ a : X, (pr1 x') * a))).
@@ -306,7 +298,7 @@ Proof.
   rewrite e. rewrite (ringmultx0 X _). apply is.
 Defined.
 
-Lemma isnonzerofromrinvel (X : ring) (is : isnonzeroring X) (x : X) (x' : multrinvpair X x) :
+Lemma isnonzerofromrinvel (X : ring) (is : isnonzerorig X) (x : X) (x' : multrinvpair X x) :
   x != 0.
 Proof.
   intros. apply (negf (maponpaths (λ a : X, a * (pr1 x')))).
@@ -316,13 +308,13 @@ Proof.
 Defined.
 
 Definition isintdom (X : commring) : UU :=
-  dirprod (isnonzeroring X) (∏ (a1 a2 : X), paths (a1 * a2) 0 -> hdisj (eqset a1 0) (eqset a2 0)).
+  dirprod (isnonzerorig X) (∏ (a1 a2 : X), paths (a1 * a2) 0 -> hdisj (eqset a1 0) (eqset a2 0)).
 
 Lemma isapropisintdom (X : commring) : isaprop (isintdom X).
 Proof.
   intros X.
   use isapropdirprod.
-  - use isapropisnonzeroring.
+  - apply propproperty.
   - use impred. intros x1. use impred. intros x2. use impred. intros H.
     use propproperty.
 Defined.
@@ -506,13 +498,13 @@ Defined.
 (** **** Main definitions *)
 
 Definition isafield (X : commring) : UU :=
-  (isnonzeroring X) × (∏ x : X, (multinvpair X x) ⨿ (x = 0)).
+  (isnonzerorig X) × (∏ x : X, (multinvpair X x) ⨿ (x = 0)).
 
 Lemma isapropisafield (X : commring) : isaprop (isafield X).
 Proof.
   intros X.
   use isofhleveltotal2.
-  - use isapropisnonzeroring.
+  - apply propproperty.
   - intros H.
     use impred. intros x. use isapropcoprod.
     + use isapropinvpair.

--- a/UniMath/Algebra/IteratedBinaryOperations.v
+++ b/UniMath/Algebra/IteratedBinaryOperations.v
@@ -480,38 +480,6 @@ Section NatCard.
     - now apply nat_plus_associativity'.
   Defined.
 
-  Theorem nat_plus_commutativity : isCommutative_fun_mon nat_add_abmonoid.
-  Proof.
-    intros ? ? ?. apply weqtoeqstn.
-    intermediate_weq (∑ i, stn (x i)).
-    - intermediate_weq (∑ i, stn (x(f i))).
-      + apply invweq. rewrite iterop_fun_nat. apply weqstnsum1.
-      + apply (weqfp _ (stn∘x)).
-    - rewrite iterop_fun_nat. apply weqstnsum1.
-  Defined.
-
-  Arguments nat_plus_commutativity {_} _ _.
-
-  Definition finsum {X} (fin : isfinite X) (f : X -> nat) : nat.
-  Proof.
-    intros.
-    unfold isfinite,finstruct,nelstruct in fin.
-    simple refine (squash_to_set
-                     isasetnat
-                     (λ (x : ∑ n, stn n ≃ X), iterop_fun_mon (M := nat_add_abmonoid) (f ∘ pr2 x))
-                     _ fin).
-    intros.
-    induction x as [n x].
-    induction x' as [n' x'].
-    assert (p := weqtoeqstn (invweq x' ∘ x)%weq).
-    induction p.
-    assert (w := nat_plus_commutativity (f ∘ x') (invweq x' ∘ x)%weq).
-    simple refine (_ @ w).
-    unfold iterop_fun_mon.
-    apply maponpaths. rewrite weqcomp_to_funcomp. apply funextfun; intro i.
-    unfold funcomp. apply maponpaths. exact (! homotweqinvweq x' (x i)).
-  Defined.
-
   (* A shorter definition: *)
   Definition finsum' {X} (fin : isfinite X) (f : X -> nat) : nat.
   Proof.

--- a/UniMath/Algebra/IteratedBinaryOperations.v
+++ b/UniMath/Algebra/IteratedBinaryOperations.v
@@ -1,6 +1,6 @@
 Require Export UniMath.Combinatorics.Lists.
 Require Export UniMath.Combinatorics.FiniteSequences.
-Require Export UniMath.Algebra.Rigs_and_Rings.
+Require Export UniMath.Algebra.RigsAndRings.
 Require Export UniMath.Foundations.UnivalenceAxiom.
 
 Require Import UniMath.MoreFoundations.Tactics.

--- a/UniMath/Algebra/Modules/Core.v
+++ b/UniMath/Algebra/Modules/Core.v
@@ -1,7 +1,7 @@
 (** Authors Anthony Bordg and Floris van Doorn, February-December 2017 *)
 
 Require Import UniMath.MoreFoundations.All.
-Require Import UniMath.Algebra.Rigs_and_Rings.
+Require Import UniMath.Algebra.RigsAndRings.
 Require Import UniMath.Algebra.Monoids_and_Groups.
 
 (** ** Contents

--- a/UniMath/Algebra/Modules/Examples.v
+++ b/UniMath/Algebra/Modules/Examples.v
@@ -3,7 +3,7 @@
 Require Import UniMath.Algebra.Modules.Core.
 Require Import UniMath.Algebra.Modules.Multimodules.
 Require Import UniMath.Algebra.Monoids_and_Groups.
-Require Import UniMath.Algebra.Rigs_and_Rings.
+Require Import UniMath.Algebra.RigsAndRings.
 Require Import UniMath.Foundations.Preamble.
 Require Import UniMath.MoreFoundations.Tactics.
 

--- a/UniMath/Algebra/Modules/Multimodules.v
+++ b/UniMath/Algebra/Modules/Multimodules.v
@@ -2,7 +2,7 @@
 
 Require Import UniMath.Algebra.Modules.Core.
 Require Import UniMath.Algebra.Monoids_and_Groups.
-Require Import UniMath.Algebra.Rigs_and_Rings.
+Require Import UniMath.Algebra.RigsAndRings.
 Require Import UniMath.Foundations.Preamble.
 Require Import UniMath.Foundations.Sets.
 

--- a/UniMath/Algebra/Modules/Submodule.v
+++ b/UniMath/Algebra/Modules/Submodule.v
@@ -1,7 +1,7 @@
 (** Authors Floris van Doorn, December 2017 *)
 
 Require Import UniMath.MoreFoundations.All.
-Require Import UniMath.Algebra.Rigs_and_Rings.
+Require Import UniMath.Algebra.RigsAndRings.
 Require Import UniMath.Algebra.Monoids_and_Groups.
 Require Import UniMath.Algebra.Modules.Core.
 

--- a/UniMath/Algebra/Modules/Submodule.v
+++ b/UniMath/Algebra/Modules/Submodule.v
@@ -98,20 +98,18 @@ Lemma issubmodule_kernel {R : ring} {A B : module R} (f : modulefun A B) :
 Proof.
   split.
   - apply abgr_Kernel_subabgr_issubgr.
-  - intros r x. apply hinhfun. cbn. intro p.
-    now rewrite (modulefun_to_islinear f), <- (module_mult_1 r), <- p.
+  - intros r x p.
+    cbn.
+    rewrite (modulefun_to_islinear f).
+    rewrite <- (module_mult_1 r), <- p.
+    reflexivity.
 Defined.
 
 Definition module_kernel {R : ring} {A B : module R} (f : modulefun A B) : submodule A :=
   submodulepair _ (issubmodule_kernel f).
 
-Lemma module_kernel_eq {R : ring} {A B : module R} (f : modulefun A B) x :
-  f (submodule_incl (module_kernel f) x) = unel B.
-Proof.
-  use (squash_to_prop (pr2 x)).
-  - apply isasetmodule.
-  - apply idfun.
-Defined.
+Definition module_kernel_eq {R : ring} {A B : module R} (f : modulefun A B) x :
+  f (submodule_incl (module_kernel f) x) = unel B := (pr2 x).
 
 Lemma issubmodule_image {R : ring} {A B : module R} (f : modulefun A B) :
   issubmodule (abgr_image_hsubtype (modulefun_to_monoidfun f)).

--- a/UniMath/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Algebra/Monoids_and_Groups.v
@@ -7,6 +7,7 @@
   - Functions between monoids compatible with structures (homomorphisms)
     and their properties
   - Subobjects
+  - Kernels
   - Quotient objects
   - Direct products
  - Abelian (commutative) monoids
@@ -33,6 +34,7 @@
   - Basic definitions
   - Univalence for abelian groups
   - Subobjects
+  - Kernels
   - Quotient objects
   - Direct products
   - Abelian group of fractions of an abelian unitary monoid
@@ -450,6 +452,38 @@ Defined.
 
 Definition submonoid_incl {X : monoid} (A : submonoid X) : monoidfun A X :=
 monoidfunconstr (ismonoidfun_pr1 A).
+
+(** **** Kernels *)
+
+(** Kernels
+    Let f : X → Y be a morphism of monoids. The kernel of f is
+    the submonoid of X consisting of elements x such that [f x = unel Y].
+ *)
+
+Definition monoid_kernel_hsubtype {A B : monoid} (f : monoidfun A B) : hsubtype A.
+Proof.
+  intros a.
+  use hProppair.
+  - exact (f a = unel B).
+  - apply setproperty.
+Defined.
+
+(** Kernel as a monoid *)
+
+Definition kernel_issubmonoid {A B : monoid} (f : monoidfun A B) :
+  issubmonoid (monoid_kernel_hsubtype f).
+Proof.
+  use issubmonoidpair.
+  - intros x y.
+    refine (monoidfunmul f _ _ @ _).
+    refine (maponpaths _ (pr2 y) @ _).
+    refine (runax _ _ @ _).
+    exact (pr2 x).
+  - apply monoidfununel.
+Defined.
+
+Definition kernel_submonoid {A B : monoid} (f : monoidfun A B) : @submonoid A :=
+  submonoidpair _ (kernel_issubmonoid f).
 
 (** **** Quotient objects *)
 

--- a/UniMath/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Algebra/Monoids_and_Groups.v
@@ -2183,7 +2183,6 @@ Section GrCosets.
     apply subtypeEquality'; [|apply propproperty].
     pose (p' := (pr11 p,, pr2 p) : ∑ y : X, x1 * y = x2).
     pose (q' := (pr11 q,, pr2 q) : ∑ y : X, x1 * y = x2).
-    Check proofirrelevance.
     apply (maponpaths pr1 (iscontrpr1 (isaprop_mult_eq_r _ _ p' q'))).
   Defined.
 

--- a/UniMath/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Algebra/Monoids_and_Groups.v
@@ -2146,21 +2146,45 @@ Proof. split with (setwithbinopquot R). apply isgrquot. Defined.
 (** **** Cosets *)
 
 Section GrCosets.
-  Context {X : gr} (Y : subgr X).
+  Context {X : gr}.
+
+  Local Lemma isaprop_mult_eq_r (x y : X) : isaprop (∑ z : X, x * z = y).
+  Proof.
+    apply invproofirrelevance; intros z1 z2.
+    apply subtypeEquality'; [|apply setproperty].
+    refine (!lunax _ _ @ _ @ lunax _ _).
+    refine (maponpaths (λ z, z * _) (!grlinvax X x) @ _ @
+            maponpaths (λ z, z * _) (grlinvax X x)).
+    refine (assocax _ _ _ _ @ _ @ !assocax _ _ _ _).
+    refine (maponpaths _ (pr2 z1) @ _ @ !maponpaths _ (pr2 z2)).
+    reflexivity.
+  Defined.
+
+  Local Lemma isaprop_mult_eq_l (x y : X) : isaprop (∑ z : X, z * x = y).
+  Proof.
+    apply invproofirrelevance; intros z1 z2.
+    apply subtypeEquality'; [|apply setproperty].
+    refine (!runax _ _ @ _ @ runax _ _).
+    refine (maponpaths (λ z, _ * z) (!grrinvax X x) @ _ @
+            maponpaths (λ z, _ * z) (grrinvax X x)).
+    refine (!assocax _ _ _ _ @ _ @ assocax _ _ _ _).
+    refine (maponpaths (λ z, z * _) (pr2 z1) @ _ @ !maponpaths (λ z, z * _) (pr2 z2)).
+    reflexivity.
+  Defined.
+
+  Context (Y : subgr X).
 
   Lemma isaprop_in_same_left_coset (x1 x2 : X) :
     isaprop (in_same_left_coset Y x1 x2).
   Proof.
-    apply invproofirrelevance.
-    intros p q.
+    unfold in_same_left_coset.
+    apply invproofirrelevance; intros p q.
     apply subtypeEquality'; [|apply setproperty].
     apply subtypeEquality'; [|apply propproperty].
-    refine (!lunax _ _ @ _ @ lunax _ _).
-    refine (maponpaths (λ z, z * _) (!grlinvax X x1) @ _ @
-            maponpaths (λ z, z * _) (grlinvax X x1)).
-    refine (assocax _ _ _ _ @ _ @ !assocax _ _ _ _).
-    refine (maponpaths _ (pr2 p) @ _ @ !maponpaths _ (pr2 q)).
-    reflexivity.
+    pose (p' := (pr11 p,, pr2 p) : ∑ y : X, x1 * y = x2).
+    pose (q' := (pr11 q,, pr2 q) : ∑ y : X, x1 * y = x2).
+    Check proofirrelevance.
+    apply (maponpaths pr1 (iscontrpr1 (isaprop_mult_eq_r _ _ p' q'))).
   Defined.
 
   Lemma isaprop_in_same_right_coset (x1 x2 : X) :
@@ -2170,12 +2194,9 @@ Section GrCosets.
     intros p q.
     apply subtypeEquality'; [|apply setproperty].
     apply subtypeEquality'; [|apply propproperty].
-    refine (!runax _ _ @ _ @ runax _ _).
-    refine (maponpaths (λ z, _ * z) (!grrinvax X x1) @ _ @
-            maponpaths (λ z, _ * z) (grrinvax X x1)).
-    refine (!assocax _ _ _ _ @ _ @ assocax _ _ _ _).
-    refine (maponpaths (λ z, z * _) (pr2 p) @ _ @ !maponpaths (λ z, z * _) (pr2 q)).
-    reflexivity.
+    pose (p' := (pr11 p,, pr2 p) : ∑ y : X, y * x1 = x2).
+    pose (q' := (pr11 q,, pr2 q) : ∑ y : X, y * x1 = x2).
+    apply (maponpaths pr1 (iscontrpr1 (isaprop_mult_eq_l _ _ p' q'))).
   Defined.
 
   (** The property of being in the same coset defines an equivalence relation. *)
@@ -2213,6 +2234,30 @@ Section GrCosets.
           refine (assocax _ _ _ _ @ _).
           refine (maponpaths _ (grrinvax _ _) @ _).
           apply runax.
+  Defined.
+
+  (** x₁ and x₂ are in the same Y-coset if and only if x₁⁻¹ * x₂ is in Y.
+      (Proposition 4 in Dummit and Foote) *)
+
+  Definition in_same_coset_test (x1 x2 : X) :
+             (Y ((grinv _ x1) * x2)) ≃ in_same_left_coset Y x1 x2.
+  Proof.
+    apply weqimplimpl; unfold in_same_left_coset in *.
+    - intros yx1x2.
+      exists ((grinv _ x1) * x2,, yx1x2); cbn.
+      refine (!assocax X _ _ _ @ _).
+      refine (maponpaths (λ z, z * _) (grrinvax X _) @ _).
+      apply lunax.
+    - intros y.
+      use (transportf (pr1 Y)).
+      + exact (pr11 y).
+      + refine (_ @ maponpaths _ (pr2 y)).
+        refine (_ @ assocax _ _ _ _).
+        refine (_ @ !maponpaths (λ z, z * _) (grlinvax X _)).
+        apply pathsinv0, lunax.
+      + exact (pr2 (pr1 y)).
+    - apply propproperty.
+    - apply isaprop_in_same_left_coset.
   Defined.
 End GrCosets.
 

--- a/UniMath/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Algebra/Monoids_and_Groups.v
@@ -2308,7 +2308,7 @@ Definition subabgr_incl {X : abgr} (A : subabgr X) : monoidfun A X :=
   submonoid_incl A.
 
 Definition abgr_kernel_hsubtype {A B : abgr} (f : monoidfun A B) : hsubtype A :=
-  (λ x : A, ishinh ((f x) = unel B)).
+  monoid_kernel_hsubtype f.
 
 Definition abgr_image_hsubtype {A B : abgr} (f : monoidfun A B) : hsubtype B :=
   (λ y : B, ∃ x : A, (f x) = y).
@@ -2324,23 +2324,16 @@ Definition abgr_Kernel_subabgr_issubgr {A B : abgr} (f : monoidfun A B) :
   issubgr (abgr_kernel_hsubtype f).
 Proof.
   use issubgrpair.
-  - use issubmonoidpair.
-    + intros a a'.
-      use (hinhuniv _ (pr2 a)). intros ae.
-      use (hinhuniv _ (pr2 a')). intros a'e.
-      use hinhpr.
-      use (pathscomp0 (binopfunisbinopfun f (pr1 a) (pr1 a'))).
-      rewrite ae. rewrite a'e. use (runax B).
-    + use hinhpr. exact (monoidfununel f).
+  - apply kernel_issubmonoid.
   - intros x a.
-    use (hinhuniv _ a). intros ae.
-    use hinhpr.
-    use (grrcan B (f x)).
-    use (pathscomp0 (! (binopfunisbinopfun f (grinv A x) x))).
-    use (pathscomp0 (maponpaths (λ a : A, f a) (grlinvax A x))).
-    use (pathscomp0 (monoidfununel f)).
-    use pathsinv0. use (pathscomp0 (lunax B (f x))). exact ae.
-Qed.
+    apply (grrcan B (f x)).
+    apply (pathscomp0 (! (binopfunisbinopfun f (grinv A x) x))).
+    apply (pathscomp0 (maponpaths (λ a : A, f a) (grlinvax A x))).
+    apply (pathscomp0 (monoidfununel f)).
+    apply pathsinv0.
+    apply (pathscomp0 (lunax B (f x))).
+    exact a.
+Defined.
 
 Definition abgr_Kernel_subabgr {A B : abgr} (f : monoidfun A B) : @subabgr A :=
   subgrconstr (@abgr_kernel_hsubtype A B f) (abgr_Kernel_subabgr_issubgr f).

--- a/UniMath/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Algebra/Monoids_and_Groups.v
@@ -48,6 +48,7 @@
   - Relations and the canonical homomorphism to [abgrdiff]
 *)
 
+(** For some examples, see [UniMath.NumberSystems.NaturalNumbersAlgebra] *)
 
 (** ** Preamble *)
 
@@ -2999,15 +3000,3 @@ Defined.
 Opaque iscomptoabgrdiff.
 
 Close Scope addmonoid_scope.
-
-(** simple examples *)
-
-Require Export UniMath.Foundations.NaturalNumbers.
-
-Definition nat_add_abmonoid : abmonoid :=
-  (natset,, add),, (natplusassoc,, 0,, natplusl0,, natplusr0),, natpluscomm.
-
-Definition nat_mul_abmonoid : abmonoid :=
-  (natset,, mul),, (natmultassoc,, 1,, natmultl1,, natmultr1),, natmultcomm.
-
-(* End of the file algebra1b.v *)

--- a/UniMath/Algebra/RigsAndRings.v
+++ b/UniMath/Algebra/RigsAndRings.v
@@ -431,7 +431,6 @@ Definition carrierofasubrig (X : rig) (A : subrig X) : rig.
 Proof. intros. split with A. apply isrigcarrier. Defined.
 Coercion carrierofasubrig : subrig >-> rig.
 
-
 (** **** Quotient objects *)
 
 Definition rigeqrel {X : rig} : UU := @twobinopeqrel X.

--- a/UniMath/Algebra/RigsAndRings.v
+++ b/UniMath/Algebra/RigsAndRings.v
@@ -9,6 +9,8 @@
   - Quotient objects
   - Direct products
   - Opposite rigs
+  - Nonzero rigs
+  - Group of units
  - Commutative rigs
   - General definitions
   - Relations similar to "greater" on commutative rigs
@@ -539,6 +541,15 @@ Proof.
   intros X.
   refine ((idfun X,, idisweq X),, _).
   repeat split.
+Defined.
+
+(** **** Nonzero rigs *)
+
+Definition isnonzerorig (X : rig) : hProp.
+Proof.
+  intros; use hProppair.
+  - exact (¬ (@paths X 1 0)).
+  - apply isapropneg.
 Defined.
 
 Local Close Scope rig.

--- a/UniMath/Algebra/RigsAndRings/Ideals.v
+++ b/UniMath/Algebra/RigsAndRings/Ideals.v
@@ -1,0 +1,85 @@
+(** * Ideals
+
+Author: Langston Barrett (@siddharthist)
+*)
+
+(** ** Contents
+
+- Definitions
+  - Left ideals ([lideal])
+  - Right ideals ([rideal])
+  - Two-sided ideals ([ideal])
+- Kernel ideal
+ *)
+
+Require Import UniMath.Algebra.RigsAndRings.
+
+Local Open Scope ring.
+Local Open Scope rig.
+
+Section Definitions.
+  Context {R : rig}.
+
+  (** *** Left ideals ([lideal]) *)
+
+  Definition is_lideal (S : subabmonoid (rigaddabmonoid R)) : hProp.
+  Proof.
+    use hProppair.
+    - exact (∏ (r : R) (s : R), S s → S (r * s)).
+    - do 3 (apply impred; intro).
+      apply propproperty.
+  Defined.
+
+  Definition lideal : UU := ∑ S : subabmonoid (rigaddabmonoid R), is_lideal S.
+
+  Definition mk_lideal :
+    ∏ (S : subabmonoid (rigaddabmonoid R)), is_lideal S → lideal := tpair _.
+
+  (** *** Right ideals ([rideal]) *)
+
+  Definition is_rideal (S : subabmonoid (rigaddabmonoid R)) : hProp.
+  Proof.
+    use hProppair.
+    - exact (∏ (r : R) (s : R), S s → S (s * r)).
+    - do 3 (apply impred; intro).
+      apply propproperty.
+  Defined.
+
+  Definition rideal : UU := ∑ S : subabmonoid (rigaddabmonoid R), is_rideal S.
+
+  Definition mk_rideal :
+    ∏ (S : subabmonoid (rigaddabmonoid R)), is_rideal S → rideal := tpair _.
+
+  (** *** Two-sided ideals ([ideal]) *)
+
+  Definition is_ideal (S : subabmonoid (rigaddabmonoid R)) : hProp :=
+    hconj (is_lideal S) (is_rideal S).
+
+  Definition ideal : UU := ∑ S : subabmonoid (rigaddabmonoid R), is_ideal S.
+
+  Definition mk_ideal (S : subabmonoid (rigaddabmonoid R))
+             (isl : is_lideal S) (isr : is_rideal S) : ideal :=
+    tpair _ S (dirprodpair isl isr).
+End Definitions.
+
+(** ** Kernel ideal *)
+
+(** The kernel of a rig homomorphism is a two-sided ideal. *)
+Definition kernel_ideal {R S : rig} (f : rigfun R S) : @ideal R.
+Proof.
+  use mk_ideal.
+  - use submonoidpair.
+    + exact (@monoid_kernel_hsubtype (rigaddabmonoid R) (rigaddabmonoid S)
+                                      (rigaddfun f)).
+    + (** This does, in fact, describe a submonoid *)
+      apply kernel_issubmonoid.
+  - (** It's closed under × from the left *)
+    intros r s ss; cbn in *.
+    refine (monoidfunmul (rigmultfun f) _ _ @ _); cbn.
+    refine (maponpaths _ ss @ _).
+    refine (rigmultx0 _ (pr1 f r) @ _).
+    reflexivity.
+  - intros r s ss; cbn in *.
+    refine (monoidfunmul (rigmultfun f) _ _ @ _); cbn.
+    abstract (rewrite ss; refine (rigmult0x _ (pr1 f r) @ _); reflexivity).
+Defined.

--- a/UniMath/Algebra/RigsAndRings/Ideals.v
+++ b/UniMath/Algebra/RigsAndRings/Ideals.v
@@ -9,6 +9,7 @@ Author: Langston Barrett (@siddharthist)
   - Left ideals ([lideal])
   - Right ideals ([rideal])
   - Two-sided ideals ([ideal])
+  - The above notions coincide for commutative rigs
 - Kernel ideal
  *)
 
@@ -61,6 +62,35 @@ Section Definitions.
              (isl : is_lideal S) (isr : is_rideal S) : ideal :=
     tpair _ S (dirprodpair isl isr).
 End Definitions.
+
+Arguments lideal _ : clear implicits.
+Arguments rideal _ : clear implicits.
+Arguments ideal _ : clear implicits.
+
+(** *** The above notions for commutative rigs *)
+
+Lemma commrig_ideals (R : commrig) (S : subabmonoid (rigaddabmonoid  R)) :
+  is_lideal S ≃ is_rideal S.
+Proof.
+  apply weqimplimpl.
+  - intros islid r s ss.
+    use transportf.
+    + exact (S (r * s)).
+    + exact (maponpaths S (rigcomm2 _ _ _)).
+    + apply (islid r s ss).
+  - intros isrid r s ss.
+    use transportf.
+    + exact (S (s * r)).
+    + exact (maponpaths S (rigcomm2 _ _ _)).
+    + apply (isrid r s ss).
+  - apply propproperty.
+  - apply propproperty.
+Defined.
+
+Corollary commrig_ideals' (R : commrig) : lideal R ≃ rideal R.
+Proof.
+  apply weqfibtototal; intro; apply commrig_ideals.
+Defined.
 
 (** ** Kernel ideal *)
 

--- a/UniMath/Algebra/Tests.v
+++ b/UniMath/Algebra/Tests.v
@@ -48,58 +48,6 @@ Module Test_assoc.
   Goal ∏ (M:monoid) (x y z:M), x+y+z = x+(y+z). Proof. apply assocax. Defined.
 
 End Test_assoc.
-
-Module Test_finsum.
-
-  Import UniMath.Algebra.IteratedBinaryOperations.
-  Import UniMath.Combinatorics.FiniteSets.
-
-  Goal ∏ X (fin : finstruct X) (f : X -> nat),
-    finsum (hinhpr fin) f = stnsum (f ∘ pr1weq (pr2 fin)).
-  Proof.
-    intros.
-    intermediate_path (iterop_fun_mon (M := nat_add_abmonoid) (f ∘ pr1weq (pr2 fin))).
-    - reflexivity.
-    - apply iterop_fun_nat.
-  Qed.
-
-  Goal 15 = finsum (isfinitestn _) (λ i:stn 6, i). reflexivity. Qed.
-  Goal 20 = finsum isfinitebool (λ i:bool, 10). reflexivity. Qed.
-  Goal 21 = finsum (isfinitecoprod isfinitebool isfinitebool)
-                   (coprod_rect (λ _, nat) (bool_rect _ 10 4) (bool_rect _  6 1)).
-    reflexivity.            (* fixed *)
-  Qed.
-
-  Goal 10 = finsum' (isfinitestn _) (λ i:stn 5, i). reflexivity. Defined. (* fixed! *)
-  Goal 20 = finsum' isfinitebool (λ i:bool, 10). reflexivity. Qed.
-  Goal 21 = finsum' (isfinitecoprod isfinitebool isfinitebool)
-                   (coprod_rect (λ _, nat) (bool_rect _ 10 4) (bool_rect _  6 1)).
-    try reflexivity.            (* fails, for some reason *)
-  Abort.
-
-  Section Iteration.
-    Local Notation "s □ x" := (append s x) (at level 64, left associativity).
-    Context (G:abgr) (R:ring) (S:commring) (g g' g'':G) (r r' r'':R) (s s' s'':S).
-    Local Open Scope multmonoid.
-    Goal iterop_unoseq_abgr (nil : Sequence G) = 1. reflexivity. Qed.
-    Goal iterop_unoseq_abgr (nil □ g □ g') = g*g'. reflexivity. Qed.
-    Goal iterop_unoseq_abgr (nil □ g □ g' □ g'') = g*g'*g''. reflexivity. Qed.
-    Goal iterop_unoseq_unoseq_mon (M:=G) (sequenceToUnorderedSequence(nil □ sequenceToUnorderedSequence(nil □ g □ g') □ sequenceToUnorderedSequence(nil □ g □ g' □ g''))) = (g*g') * (g*g'*g''). reflexivity. Qed.
-    Goal iterop_unoseq_unoseq_mon (M:=G) (sequenceToUnorderedSequence(nil □ sequenceToUnorderedSequence(nil □ g) □ sequenceToUnorderedSequence(nil))) = g * 1. reflexivity. Qed.
-    Goal iterop_unoseq_unoseq_mon (M:=G) (sequenceToUnorderedSequence(nil □ sequenceToUnorderedSequence(nil) □ sequenceToUnorderedSequence(nil □ g))) = 1 * g. reflexivity. Qed.
-    Close Scope multmonoid.
-
-    Local Open Scope ring.
-    Goal sum_unoseq_ring (nil : Sequence R) = 0. reflexivity. Qed.
-    Goal sum_unoseq_ring (nil □ r □ r') = r+r'. reflexivity. Qed.
-    Goal sum_unoseq_ring (nil □ r □ r' □ r'') = r+r'+r''. reflexivity. Qed.
-    Goal product_unoseq_ring (nil : Sequence S) = 1. reflexivity. Qed.
-    Goal product_unoseq_ring (nil □ s □ s') = s*s'. reflexivity. Qed.
-    Goal product_unoseq_ring (nil □ s □ s' □ s'') = s*s'*s''. reflexivity. Qed.
-  End Iteration.
-
-End Test_finsum.
-
 (*
 Local Variables:
 compile-command: "make -C ../../.. TAGS UniMath/Foundations/Algebra/Tests.vo"

--- a/UniMath/CONTENTS.md
+++ b/UniMath/CONTENTS.md
@@ -47,7 +47,8 @@ The packages and files are listed here in logical order: each file depends only 
 ## Package Algebra
    - [BinaryOperations.v](Algebra/BinaryOperations.v)
    - [Monoids_and_Groups.v](Algebra/Monoids_and_Groups.v)
-   - [Rigs_and_Rings.v](Algebra/Rigs_and_Rings.v)
+   - [RigsAndRings.v](Algebra/RigsAndRings.v)
+   - [RigsAndRings/Ideals.v](Algebra/RigsAndRings/Ideals.v)
    - [Domains_and_Fields.v](Algebra/Domains_and_Fields.v)
    - [DivisionRig.v](Algebra/DivisionRig.v)
    - [Apartness.v](Algebra/Apartness.v)

--- a/UniMath/CategoryTheory/categories/abgrs.v
+++ b/UniMath/CategoryTheory/categories/abgrs.v
@@ -641,18 +641,18 @@ Section abgr_kernels_and_cokernels.
   Definition abgr_Kernel_eq {A B : abgr} (f : monoidfun A B) :
     abgr_Kernel_monoidfun f · f = ZeroArrow abgr_Zero (carrierofasubabgr (abgr_Kernel_subabgr f)) B.
   Proof.
-    use monoidfun_paths. use funextfun. intros x.
-    use (squash_to_prop (pr2 x) (setproperty B _ _)).
-    intros H. exact H.
+    apply monoidfun_paths.
+    apply funextfun; intro x.
+    apply (pr2 x).
   Qed.
 
   (** *** KernelIn morphism *)
 
   Lemma abgr_KernelArrowIn_map_property {A B C : abgr_category} (h : C --> A) (f : A --> B)
              (H : h · f = ZeroArrow abgr_Zero C B) (c : (C : abgr)) :
-    ishinh_UU (pr1 f (pr1 h c) = 1%multmonoid).
+    (pr1 f (pr1 h c) = 1%multmonoid).
   Proof.
-    use hinhpr. use (pathscomp0 (toforallpaths _ _ _ (base_paths _ _ H) c)). use idpath.
+    use (pathscomp0 (toforallpaths _ _ _ (base_paths _ _ H) c)). use idpath.
   Qed.
 
   Definition abgr_KernelArrowIn_map {A B C : abgr_category} (h : C --> A) (f : A --> B)
@@ -1240,12 +1240,11 @@ Section abgr_monic_kernels_epi_cokernels.
 
   (** ** Epis are cokernels of their kernels *)
 
-  Definition abgr_epi_cokernel_out_kernel_hsubtype {A B : abgr} (f : abgr_category⟦A, B⟧) (a : A)
+  Definition abgr_epi_cokernel_out_kernel_hsubtype {A B : abgr}
+             (f : abgr_category⟦A, B⟧) (a : A)
              (H : pr1 f a = 1%multmonoid) : abgr_kernel_hsubtype f.
   Proof.
-    use tpair.
-    - exact a.
-    - use hinhpr. exact H.
+    exact (a,, H).
   Defined.
 
   Lemma abgr_epi_cokernel_out_data_eq {A B C : abgr} (f : abgr_category⟦A, B⟧)

--- a/UniMath/CategoryTheory/categories/commrigs.v
+++ b/UniMath/CategoryTheory/categories/commrigs.v
@@ -11,7 +11,7 @@ Require Import UniMath.Foundations.UnivalenceAxiom.
 
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids_and_Groups.
-Require Import UniMath.Algebra.Rigs_and_Rings.
+Require Import UniMath.Algebra.RigsAndRings.
 
 Require Import UniMath.CategoryTheory.Categories.
 Local Open Scope cat.

--- a/UniMath/CategoryTheory/categories/commrings.v
+++ b/UniMath/CategoryTheory/categories/commrings.v
@@ -11,7 +11,7 @@ Require Import UniMath.Foundations.UnivalenceAxiom.
 
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids_and_Groups.
-Require Import UniMath.Algebra.Rigs_and_Rings.
+Require Import UniMath.Algebra.RigsAndRings.
 
 Require Import UniMath.CategoryTheory.Categories.
 Local Open Scope cat.

--- a/UniMath/CategoryTheory/categories/flds.v
+++ b/UniMath/CategoryTheory/categories/flds.v
@@ -11,7 +11,7 @@ Require Import UniMath.Foundations.UnivalenceAxiom.
 
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids_and_Groups.
-Require Import UniMath.Algebra.Rigs_and_Rings.
+Require Import UniMath.Algebra.RigsAndRings.
 Require Import UniMath.Algebra.Domains_and_Fields.
 
 Require Import UniMath.CategoryTheory.Categories.

--- a/UniMath/CategoryTheory/categories/intdoms.v
+++ b/UniMath/CategoryTheory/categories/intdoms.v
@@ -11,7 +11,7 @@ Require Import UniMath.Foundations.UnivalenceAxiom.
 
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids_and_Groups.
-Require Import UniMath.Algebra.Rigs_and_Rings.
+Require Import UniMath.Algebra.RigsAndRings.
 Require Import UniMath.Algebra.Domains_and_Fields.
 
 Require Import UniMath.CategoryTheory.Categories.

--- a/UniMath/CategoryTheory/categories/modules.v
+++ b/UniMath/CategoryTheory/categories/modules.v
@@ -2,7 +2,7 @@
  - Anthony Bordg, March-April 2017
  - Langston Barrett (@siddharthist), November-December 2017 *)
 
-Require Import UniMath.Algebra.Rigs_and_Rings.
+Require Import UniMath.Algebra.RigsAndRings.
 Require Import UniMath.CategoryTheory.Categories.
 Require Import UniMath.Algebra.Modules.
 Require Import UniMath.Algebra.Modules.Examples.

--- a/UniMath/CategoryTheory/categories/rigs.v
+++ b/UniMath/CategoryTheory/categories/rigs.v
@@ -11,7 +11,7 @@ Require Import UniMath.Foundations.UnivalenceAxiom.
 
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids_and_Groups.
-Require Import UniMath.Algebra.Rigs_and_Rings.
+Require Import UniMath.Algebra.RigsAndRings.
 
 Require Import UniMath.CategoryTheory.Categories.
 Local Open Scope cat.

--- a/UniMath/CategoryTheory/categories/rings.v
+++ b/UniMath/CategoryTheory/categories/rings.v
@@ -11,7 +11,7 @@ Require Import UniMath.Foundations.UnivalenceAxiom.
 
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids_and_Groups.
-Require Import UniMath.Algebra.Rigs_and_Rings.
+Require Import UniMath.Algebra.RigsAndRings.
 
 Require Import UniMath.CategoryTheory.Categories.
 Local Open Scope cat.

--- a/UniMath/MoreFoundations/Sets.v
+++ b/UniMath/MoreFoundations/Sets.v
@@ -95,3 +95,16 @@ Defined.
 
 Definition setcoprod (X Y : hSet) : hSet :=
   hSetpair (X ⨿ Y) (isasetcoprod X Y (pr2 X) (pr2 Y)).
+
+(** ** The equivalence relation of being in the same fiber *)
+
+Definition same_fiber_eqrel {X Y : hSet} (f : X → Y) : eqrel X.
+Proof.
+  use eqrelpair.
+  - intros x y.
+    exact (eqset (f x) (f y)).
+  - use iseqrelconstr.
+    + intros ? ? ? xy yz; exact (xy @ yz).
+    + intro; reflexivity.
+    + intros ? ? eq; exact (!eq).
+Defined.

--- a/UniMath/NumberSystems/Integers.v
+++ b/UniMath/NumberSystems/Integers.v
@@ -18,7 +18,7 @@ Unset Kernel Term Sharing.
 (** Imports *)
 
 Require Export UniMath.Foundations.NaturalNumbers .
-Require Export UniMath.Algebra.Rigs_and_Rings.
+Require Export UniMath.Algebra.RigsAndRings.
 Require Export UniMath.NumberSystems.NaturalNumbersAlgebra.
 
 

--- a/UniMath/NumberSystems/Integers.v
+++ b/UniMath/NumberSystems/Integers.v
@@ -89,7 +89,7 @@ Local Open Scope hz_scope .
 
 (** *** [ hz ] is a non-zero ring *)
 
-Lemma isnonzeroringhz : isnonzeroring hz .
+Lemma isnonzerorighz : isnonzerorig hz .
 Proof . apply  ( ct ( hzneq , isdecrelhzneq, 1 , 0 ) ) . Defined .
 
 
@@ -676,7 +676,7 @@ rewrite en .  rewrite ( hzmultx0 m ) . apply isreflhzgeh .   Defined .
 
 
 Lemma isintdomhz : isintdom hz .
-Proof . split with isnonzeroringhz .  intros a b e0 .  destruct ( isdeceqhz a 0 ) as [ ea | nea ] .  apply ( hinhpr ( ii1 ea ) ) . destruct ( isdeceqhz b 0 ) as [ eb | neb ] . apply ( hinhpr ( ii2 eb ) ) .  destruct ( hzneqchoice _ _ nea ) as [ ga | la ] .  destruct ( hzneqchoice _ _ neb ) as [ gb | lb ] . destruct ( hzgthtoneq _ _ ( hzmultgth0gth0 ga gb ) e0 ) .  destruct ( hzlthtoneq _ _ ( hzmultgth0lth0 ga lb ) e0 ) .  destruct ( hzneqchoice _ _ neb ) as [ gb | lb ] .  destruct ( hzlthtoneq _ _ ( hzmultlth0gth0 la gb ) e0 ) .  destruct ( hzgthtoneq _ _ ( hzmultlth0lth0 la lb ) e0 ) .  Defined .
+Proof . split with isnonzerorighz .  intros a b e0 .  destruct ( isdeceqhz a 0 ) as [ ea | nea ] .  apply ( hinhpr ( ii1 ea ) ) . destruct ( isdeceqhz b 0 ) as [ eb | neb ] . apply ( hinhpr ( ii2 eb ) ) .  destruct ( hzneqchoice _ _ nea ) as [ ga | la ] .  destruct ( hzneqchoice _ _ neb ) as [ gb | lb ] . destruct ( hzgthtoneq _ _ ( hzmultgth0gth0 ga gb ) e0 ) .  destruct ( hzlthtoneq _ _ ( hzmultgth0lth0 ga lb ) e0 ) .  destruct ( hzneqchoice _ _ neb ) as [ gb | lb ] .  destruct ( hzlthtoneq _ _ ( hzmultlth0gth0 la gb ) e0 ) .  destruct ( hzgthtoneq _ _ ( hzmultlth0lth0 la lb ) e0 ) .  Defined .
 
 
 Definition hzintdom : intdom := tpair _ _ isintdomhz .

--- a/UniMath/NumberSystems/NaturalNumbersAlgebra.v
+++ b/UniMath/NumberSystems/NaturalNumbersAlgebra.v
@@ -1,9 +1,11 @@
 (** * Facts about the natural numbers that depend on definitions from algebra *)
 
-Require Export UniMath.Algebra.Archimedean.
-Require Export UniMath.Algebra.Domains_and_Fields.
 Require Export UniMath.Foundations.NaturalNumbers.
 Require Import UniMath.MoreFoundations.Tactics.
+
+Require Export UniMath.Algebra.Archimedean.
+Require Export UniMath.Algebra.Domains_and_Fields.
+Require Export UniMath.Algebra.IteratedBinaryOperations.
 
 Definition nataddabmonoid : abmonoid :=
   abmonoidpair (setwithbinoppair natset (λ n m : nat, n + m))
@@ -36,6 +38,38 @@ Proof.
   intros.
   apply (invmaponpathsincl _ (isinclpr1carrier _) (@op natnonzero a b) (@op natnonzero b a)).
   simpl. apply natmultcomm.
+Defined.
+
+Theorem nat_plus_commutativity : isCommutative_fun_mon nataddabmonoid.
+Proof.
+  intros ? ? ?. apply weqtoeqstn.
+  intermediate_weq (∑ i, stn (x i)).
+  - intermediate_weq (∑ i, stn (x(f i))).
+    + apply invweq. rewrite iterop_fun_nat. apply weqstnsum1.
+    + apply (weqfp _ (stn∘x)).
+  - rewrite iterop_fun_nat. apply weqstnsum1.
+Defined.
+
+Arguments nat_plus_commutativity {_} _ _.
+
+Definition finsum {X} (fin : isfinite X) (f : X -> nat) : nat.
+Proof.
+  intros.
+  unfold isfinite,finstruct,nelstruct in fin.
+  simple refine (squash_to_set
+                    isasetnat
+                    (λ (x : ∑ n, stn n ≃ X), iterop_fun_mon (M := nataddabmonoid) (f ∘ pr2 x))
+                    _ fin).
+  intros.
+  induction x as [n x].
+  induction x' as [n' x'].
+  assert (p := weqtoeqstn (invweq x' ∘ x)%weq).
+  induction p.
+  assert (w := nat_plus_commutativity (f ∘ x') (invweq x' ∘ x)%weq).
+  simple refine (_ @ w).
+  unfold iterop_fun_mon.
+  apply maponpaths. rewrite weqcomp_to_funcomp. apply funextfun; intro i.
+  unfold funcomp. apply maponpaths. exact (! homotweqinvweq x' (x i)).
 Defined.
 
 (** *** [nat] as a commutative rig *)

--- a/UniMath/NumberSystems/Tests.v
+++ b/UniMath/NumberSystems/Tests.v
@@ -68,6 +68,60 @@ Module Test_nat.
 
 End Test_nat.
 
+
+Module Test_finsum.
+
+  Require Import UniMath.Algebra.IteratedBinaryOperations.
+  Require Import UniMath.Combinatorics.FiniteSets.
+  Require Import UniMath.NumberSystems.NaturalNumbersAlgebra.
+
+  Goal ∏ X (fin : finstruct X) (f : X -> nat),
+    finsum (hinhpr fin) f = stnsum (f ∘ pr1weq (pr2 fin)).
+  Proof.
+    intros.
+    intermediate_path (iterop_fun_mon (M := nataddabmonoid) (f ∘ pr1weq (pr2 fin))).
+    - reflexivity.
+    - apply iterop_fun_nat.
+  Qed.
+
+  Goal 15 = finsum (isfinitestn _) (λ i:stn 6, i). reflexivity. Qed.
+  Goal 20 = finsum isfinitebool (λ i:bool, 10). reflexivity. Qed.
+  Goal 21 = finsum (isfinitecoprod isfinitebool isfinitebool)
+                   (coprod_rect (λ _, nat) (bool_rect _ 10 4) (bool_rect _  6 1)).
+    reflexivity.            (* fixed *)
+  Qed.
+
+  Goal 10 = finsum' (isfinitestn _) (λ i:stn 5, i). reflexivity. Defined. (* fixed! *)
+  Goal 20 = finsum' isfinitebool (λ i:bool, 10). reflexivity. Qed.
+  Goal 21 = finsum' (isfinitecoprod isfinitebool isfinitebool)
+                   (coprod_rect (λ _, nat) (bool_rect _ 10 4) (bool_rect _  6 1)).
+    try reflexivity.            (* fails, for some reason *)
+  Abort.
+
+  Section Iteration.
+    Local Notation "s □ x" := (append s x) (at level 64, left associativity).
+    Context (G:abgr) (R:ring) (S:commring) (g g' g'':G) (r r' r'':R) (s s' s'':S).
+    Local Open Scope multmonoid.
+    Goal iterop_unoseq_abgr (nil : Sequence G) = 1. reflexivity. Qed.
+    Goal iterop_unoseq_abgr (nil □ g □ g') = g*g'. reflexivity. Qed.
+    Goal iterop_unoseq_abgr (nil □ g □ g' □ g'') = g*g'*g''. reflexivity. Qed.
+    Goal iterop_unoseq_unoseq_mon (M:=G) (sequenceToUnorderedSequence(nil □ sequenceToUnorderedSequence(nil □ g □ g') □ sequenceToUnorderedSequence(nil □ g □ g' □ g''))) = (g*g') * (g*g'*g''). reflexivity. Qed.
+    Goal iterop_unoseq_unoseq_mon (M:=G) (sequenceToUnorderedSequence(nil □ sequenceToUnorderedSequence(nil □ g) □ sequenceToUnorderedSequence(nil))) = g * 1. reflexivity. Qed.
+    Goal iterop_unoseq_unoseq_mon (M:=G) (sequenceToUnorderedSequence(nil □ sequenceToUnorderedSequence(nil) □ sequenceToUnorderedSequence(nil □ g))) = 1 * g. reflexivity. Qed.
+    Close Scope multmonoid.
+
+    Local Open Scope ring.
+    Goal sum_unoseq_ring (nil : Sequence R) = 0. reflexivity. Qed.
+    Goal sum_unoseq_ring (nil □ r □ r') = r+r'. reflexivity. Qed.
+    Goal sum_unoseq_ring (nil □ r □ r' □ r'') = r+r'+r''. reflexivity. Qed.
+    Goal product_unoseq_ring (nil : Sequence S) = 1. reflexivity. Qed.
+    Goal product_unoseq_ring (nil □ s □ s') = s*s'. reflexivity. Qed.
+    Goal product_unoseq_ring (nil □ s □ s' □ s'') = s*s'*s''. reflexivity. Qed.
+  End Iteration.
+
+End Test_finsum.
+
+
 Require UniMath.NumberSystems.Integers.
 
 Module Test_int.

--- a/UniMath/PAdics/fps.v
+++ b/UniMath/PAdics/fps.v
@@ -14,7 +14,7 @@ Unset Automatic Introduction.
 (** Imports *)
 
 Require Import UniMath.PAdics.lemmas.
-Require Import UniMath.Algebra.Rigs_and_Rings.
+Require Import UniMath.Algebra.RigsAndRings.
 Require Import UniMath.NumberSystems.Integers.
 
 (** ** I. Summation in a commutative ring *)

--- a/UniMath/PAdics/frac.v
+++ b/UniMath/PAdics/frac.v
@@ -13,7 +13,7 @@ Unset Automatic Introduction.
 (** Imports *)
 
 Require Import UniMath.PAdics.lemmas.
-Require Import UniMath.Algebra.Rigs_and_Rings.
+Require Import UniMath.Algebra.RigsAndRings.
 Require Import UniMath.Algebra.Domains_and_Fields.
 
 (** * I. The field of fractions for an integrable domain with an apartness relation *)

--- a/UniMath/PAdics/lemmas.v
+++ b/UniMath/PAdics/lemmas.v
@@ -14,7 +14,7 @@ Unset Automatic Introduction.
 Require Import UniMath.Foundations.PartA.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.NaturalNumbers.
-Require Import UniMath.Algebra.Rigs_and_Rings.
+Require Import UniMath.Algebra.RigsAndRings.
 Require Import UniMath.Algebra.Domains_and_Fields.
 Require Import UniMath.NumberSystems.Integers.
 Require Import UniMath.Algebra.Monoids_and_Groups.

--- a/UniMath/PAdics/padics.v
+++ b/UniMath/PAdics/padics.v
@@ -2313,7 +2313,7 @@ Proof.
     unfold precarry.
     rewrite hzqrand1r.
     rewrite hzqrand0r.
-    apply isnonzeroringhz.
+    apply isnonzerorighz.
   - apply padicintsareintdom.
 Defined.
 


### PR DESCRIPTION
 * Ideals in rigs
    - Ideals from kernels
    - Right and left ideals are equivalent for commutative rings
 * Cosets in monoids and groups (eventually, to get to quotients by normal subgroups and then quotients by ideals)
    - Definitions
    - Proof that being in the same coset is an equivalence relation on a group
 * Move results about natural numbers to`NumberSystems.NaturalNumbersAlgebra`