### PR TITLE
Compatibility with Coq PR #7257 fixing the result of a "random" unification heuristic.

### DIFF
--- a/UniMath/Algebra/Modules/Core.v
+++ b/UniMath/Algebra/Modules/Core.v
@@ -341,7 +341,7 @@ Defined.
 Lemma module_mult_neg1 {R : ring} {M : module R} (x : M) : ringminus1 * x = @grinv _ x.
 Proof.
   apply pathsinv0. apply grinv_path_from_op_path.
-  refine (maponpaths (λ y, y * _)%multmonoid (!(module_mult_unel2 x)) @ _).
+  refine (maponpaths (λ y, y * ((_ * x)%module))%multmonoid (!(module_mult_unel2 x)) @ _).
   now rewrite <- module_mult_is_rdistr, ringrinvax1, module_mult_0_to_0.
 Defined.
 


### PR DESCRIPTION
I'm very sorry, but a bug-fix PR, number coq/coq#7257, is causing an incompatibility in UniMath. Indeed, we discovered that some unification heuristic was sensitive to the alphabetic order and a PR has been proposed to use a more stable heuristic. In UniMath's file `Algebra/Modules/Core.v`, there is indeed an example of a unification problem which is sensitive to the name of some variable. The problem works because a variable is called `y` but it would not have worked if the variable had been called `v` because it involves another variable `x`, and `v`<`x`<`y` alphabetically :(((

We fix the file by giving a more refined pattern to help unification.