### PR TITLE
replace the deprecated elements (as of Coq 8.8.0)

### DIFF
--- a/UniMath/Algebra/IteratedBinaryOperations.v
+++ b/UniMath/Algebra/IteratedBinaryOperations.v
@@ -433,10 +433,11 @@ Defined.
 
 (** finite products (or sums) in monoids *)
 
-Section NatCard.
 
   Require Export UniMath.Combinatorics.FiniteSets.
   Require Export UniMath.Foundations.NaturalNumbers.
+
+Section NatCard.
 
   (** first a toy warm-up with addition in nat, based on cardinalities of standard finite sets *)
 

--- a/UniMath/CategoryTheory/DisplayedCats/Codomain.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Codomain.v
@@ -107,15 +107,15 @@ Definition isPullback_cartesian_in_cod_disp
 Proof.
   intros Hpb Δ g q hh.
   eapply iscontrweqf.
-  Focus 2. {
+  2: {
     use Hpb.
     + exact (pr1 q).
     + exact (pr1 hh).
     + simpl in q. use (pr2 q · g).
     + etrans. apply (pr2 hh). apply assoc.
-  } Unfocus.
+  }
   eapply weqcomp.
-  Focus 2. apply weqtotal2asstol.
+  2: apply weqtotal2asstol.
   apply weq_subtypes_iff.
   - intro. apply isapropdirprod; apply homset_property.
   - intro. apply (isofhleveltotal2 1).
@@ -143,14 +143,14 @@ Proof.
   unfold is_cartesian in cf.
   simpl in *.
   eapply iscontrweqf.
-  Focus 2. {
+  2: {
     use cf.
     + exact Γ'.
     + exact (identity _ ).
     + exists c. exact k.
     + cbn. exists h.
       etrans. apply H. apply maponpaths. apply (! id_left _ ).
-  } Unfocus.
+  }
   eapply weqcomp.
   apply weqtotal2asstor.
   apply weq_subtypes_iff.

--- a/UniMath/CategoryTheory/DisplayedCats/Constructions.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Constructions.v
@@ -360,7 +360,7 @@ Proof.
     + abstract ( etrans;
         [ apply iso_disp_after_inv_mor
         | apply pathsinv0, pr1_transportf_sigma_disp]).
-    + etrans. Focus 2. apply @pathsinv0, pr2_transportf_sigma_disp.
+    + etrans. 2: apply @pathsinv0, pr2_transportf_sigma_disp.
       etrans. apply maponpaths.
         use (mor_disp_transportf_postwhisker
           (@inv_mor_total_iso _ _ (_,,_) (_,,_) f ffi) _ (pr2 fff)).
@@ -373,7 +373,7 @@ Proof.
     + abstract ( etrans;
         [ apply inv_mor_after_iso_disp
         | apply pathsinv0, pr1_transportf_sigma_disp ]).
-    + etrans. Focus 2. apply @pathsinv0, pr2_transportf_sigma_disp.
+    + etrans. 2: apply @pathsinv0, pr2_transportf_sigma_disp.
       etrans. apply maponpaths.
       use (mor_disp_transportf_prewhisker
         (@inv_mor_total_iso _ _ (_,,_) (_,,_) f ffi) (pr2 fff) _).

--- a/UniMath/CategoryTheory/DisplayedCats/Core.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Core.v
@@ -1079,7 +1079,7 @@ Definition total_iso_equiv (xx yy : total_category)
 Lemma is_univalent_total_category (CC : is_univalent C) (DD : is_univalent_disp D)
   : is_univalent (total_category).
 Proof.
-  split. Focus 2. apply homset_property.
+  split. 2: apply homset_property.
   intros xs ys.
   set (x := pr1 xs). set (xx := pr2 xs).
   set (y := pr1 ys). set (yy := pr2 ys).
@@ -1142,14 +1142,14 @@ Proof.
     eapply pathscomp0. apply transport_b_f.
     eapply pathscomp0. apply maponpaths, id_left_disp.
     eapply pathscomp0. apply transport_f_b.
-    eapply pathscomp0. Focus 2. apply @pathsinv0, (functtransportb (# F)).
+    eapply pathscomp0. 2: apply @pathsinv0, (functtransportb (# F)).
     unfold transportb; apply maponpaths_2, homset_property.
   - intros x y f xx yy ff.
     eapply pathscomp0. apply maponpaths, mor_disp_transportf_prewhisker.
     eapply pathscomp0. apply transport_b_f.
     eapply pathscomp0. apply maponpaths, id_right_disp.
     eapply pathscomp0. apply transport_f_b.
-    eapply pathscomp0. Focus 2. apply @pathsinv0, (functtransportb (# F)).
+    eapply pathscomp0. 2: apply @pathsinv0, (functtransportb (# F)).
     unfold transportb; apply maponpaths_2, homset_property.
   - intros x y z w f g h xx yy zz ww ff gg hh.
     eapply pathscomp0. apply maponpaths, mor_disp_transportf_prewhisker.

--- a/UniMath/CategoryTheory/DisplayedCats/Equivalences.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Equivalences.v
@@ -59,7 +59,7 @@ Proof.
     { apply eq_iso. cbn. simpl. unfold precomp_with.
       etrans. apply maponpaths_2. apply id_right.
       etrans. eapply pathsinv0. apply functor_comp.
-      etrans. Focus 2. apply functor_id.
+      etrans. 2: apply functor_id.
       apply maponpaths. apply iso_after_iso_inv.
    }
     set (XRT := transportf (λ r, iso_disp r (FF x dd) yy )
@@ -571,8 +571,8 @@ Proof.
     set (Hxx := FF_split x xx).
     set (Hyy := FF_split y yy).
     apply FFinv.
-    refine (transportf (mor_disp _ _) _ _). Focus 2.
-    exact ((pr2 Hxx ;; ff) ;; inv_mor_disp_from_iso (pr2 Hyy)).
+    refine (transportf (mor_disp _ _) _ _).
+    2: exact ((pr2 Hxx ;; ff) ;; inv_mor_disp_from_iso (pr2 Hyy)).
     cbn. etrans. apply id_right. apply id_left.
 Defined.
 
@@ -581,7 +581,7 @@ Proof.
   split; simpl.
   + intros x xx.
     apply invmap_eq. cbn.
-    etrans. Focus 2. apply @pathsinv0, (disp_functor_id FF).
+    etrans. 2: apply @pathsinv0, (disp_functor_id FF).
     etrans. apply maponpaths.
       etrans. apply maponpaths_2, id_right_disp.
       etrans. apply mor_disp_transportf_postwhisker.
@@ -591,46 +591,48 @@ Proof.
     unfold transportb. apply maponpaths_2, homset_property.
   + intros x y z xx yy zz f g ff gg.
     apply invmap_eq. cbn.
-    etrans. Focus 2. apply @pathsinv0.
-      etrans. apply (disp_functor_comp FF).
-      etrans. apply maponpaths.
-        etrans. apply maponpaths; use homotweqinvweq.
-        apply maponpaths_2; use homotweqinvweq.
-      etrans. apply maponpaths.
-        etrans. apply mor_disp_transportf_prewhisker.
-        apply maponpaths.
-        etrans. apply mor_disp_transportf_postwhisker.
-        apply maponpaths.
-        etrans. apply maponpaths, assoc_disp_var.
-        etrans. apply mor_disp_transportf_prewhisker.
-        apply maponpaths.
-        etrans. apply assoc_disp.
-        apply maponpaths.
-        etrans. apply maponpaths_2.
-          etrans. apply assoc_disp_var.
-          apply maponpaths.
-          etrans. apply maponpaths.
-            exact (iso_disp_after_inv_mor (pr2 (FF_split _ _))).
-          etrans. apply mor_disp_transportf_prewhisker.
-          etrans. apply maponpaths, id_right_disp.
-          apply transport_f_f.
-        etrans. apply maponpaths_2, transport_f_f.
-        apply mor_disp_transportf_postwhisker.
-      etrans. apply transport_f_f.
-      etrans. apply transport_f_f.
-      etrans. apply transport_f_f.
-      etrans. apply transport_f_f.
-      etrans. apply transport_f_f.
-      (* A trick to hide the huge equality term: *)
-      apply maponpaths_2. shelve.
+    etrans.
+    2: { apply @pathsinv0.
+         etrans. apply (disp_functor_comp FF).
+         etrans. apply maponpaths.
+         etrans. apply maponpaths; use homotweqinvweq.
+         apply maponpaths_2; use homotweqinvweq.
+         etrans. apply maponpaths.
+         etrans. apply mor_disp_transportf_prewhisker.
+         apply maponpaths.
+         etrans. apply mor_disp_transportf_postwhisker.
+         apply maponpaths.
+         etrans. apply maponpaths, assoc_disp_var.
+         etrans. apply mor_disp_transportf_prewhisker.
+         apply maponpaths.
+         etrans. apply assoc_disp.
+         apply maponpaths.
+         etrans. apply maponpaths_2.
+         etrans. apply assoc_disp_var.
+         apply maponpaths.
+         etrans. apply maponpaths.
+         exact (iso_disp_after_inv_mor (pr2 (FF_split _ _))).
+         etrans. apply mor_disp_transportf_prewhisker.
+         etrans. apply maponpaths, id_right_disp.
+         apply transport_f_f.
+         etrans. apply maponpaths_2, transport_f_f.
+         apply mor_disp_transportf_postwhisker.
+         etrans. apply transport_f_f.
+         etrans. apply transport_f_f.
+         etrans. apply transport_f_f.
+         etrans. apply transport_f_f.
+         etrans. apply transport_f_f.
+         (* A trick to hide the huge equality term: *)
+         apply maponpaths_2. shelve.
+    }
     etrans. apply maponpaths.
-      etrans. apply maponpaths_2, assoc_disp.
-      etrans. apply mor_disp_transportf_postwhisker.
-      apply maponpaths. apply assoc_disp_var.
+    etrans. apply maponpaths_2, assoc_disp.
+    etrans. apply mor_disp_transportf_postwhisker.
+    apply maponpaths. apply assoc_disp_var.
     etrans. apply transport_f_f.
     etrans. apply transport_f_f.
     apply maponpaths_2, homset_property.
-    Unshelve. Focus 2. apply idpath.
+    Unshelve. 2: apply idpath.
 Qed.
 
 Definition GG : disp_functor _ _ _ := (_ ,, GG_ax).

--- a/UniMath/CategoryTheory/DisplayedCats/Equivalences_bis.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Equivalences_bis.v
@@ -55,7 +55,7 @@ Proof.
     { apply eq_iso. cbn. simpl. unfold precomp_with.
       etrans. apply maponpaths_2. apply id_right.
       etrans. eapply pathsinv0. apply functor_comp.
-      etrans. Focus 2. apply functor_id.
+      etrans. 2: apply functor_id.
       apply maponpaths. apply iso_after_iso_inv.
    }
     set (XRT := transportf (λ r, iso_disp r (FF x dd) yy )

--- a/UniMath/CategoryTheory/DisplayedCats/Examples.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Examples.v
@@ -249,6 +249,9 @@ Definition precat_of_elements {C : category} (P : functor C SET)
 End Elements_Disp.
 
 
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.limits.graphs.limits.
+
 
 Section functor_algebras.
 
@@ -344,9 +347,6 @@ Proof.
       * split; apply homset_property.
 Defined.
 
-
-Require Import UniMath.CategoryTheory.limits.graphs.colimits.
-Require Import UniMath.CategoryTheory.limits.graphs.limits.
 
 Local Notation "'π'" := (pr1_category disp_cat_functor_alg).
 

--- a/UniMath/CategoryTheory/Monads/RelativeMonads.v
+++ b/UniMath/CategoryTheory/Monads/RelativeMonads.v
@@ -71,14 +71,15 @@ Proof.
       etrans. eapply (maponpaths (λ x, x · _  )). apply functor_id.
       apply id_left.
     apply (r_bind_r_eta R).
-  - etrans. Focus 2. eapply pathsinv0; apply (r_bind_r_bind R).
+  - etrans. 2: { eapply pathsinv0; apply (r_bind_r_bind R). }
     apply maponpaths.
     etrans.
     apply map_on_two_paths. apply functor_comp. apply idpath.
-    etrans. Focus 2.
-      etrans. Focus 2. apply assoc.
-      eapply pathsinv0. apply maponpaths. apply (r_eta_r_bind R).
-      apply pathsinv0, assoc.
+    etrans.
+    2: { etrans. 2: apply assoc.
+         eapply pathsinv0. apply maponpaths. apply (r_eta_r_bind R).
+    }
+    apply pathsinv0, assoc.
 Defined.
 
 End RMonad_def.

--- a/UniMath/CategoryTheory/PlainBicat/CwF.v
+++ b/UniMath/CategoryTheory/PlainBicat/CwF.v
@@ -106,7 +106,7 @@ Section Representation.
     : functor_on_morphisms Yo π · yy A = yy t · pp.
   Proof.
     apply pathsinv0.
-    etrans. Focus 2. apply yy_natural.
+    etrans. 2: apply yy_natural.
     etrans. apply yy_comp_nat_trans.
     apply maponpaths, e.
   Qed.

--- a/UniMath/CategoryTheory/PlainBicat/DispBicatOfDispCats.v
+++ b/UniMath/CategoryTheory/PlainBicat/DispBicatOfDispCats.v
@@ -70,9 +70,8 @@ Proof.
       apply pathsinv0.
       apply disp_functor_comp_var.
       etrans.
-      Focus 2.
-      apply maponpaths.
-      apply disp_functor_comp_var.
+      2: { apply maponpaths.
+      apply disp_functor_comp_var. }
       apply pathsinv0.
       etrans.
       apply transport_f_f.

--- a/UniMath/CategoryTheory/categories/category_hset_structures.v
+++ b/UniMath/CategoryTheory/categories/category_hset_structures.v
@@ -318,9 +318,11 @@ use mk_Coproduct.
         intro x; rewrite <- ht; destruct x; apply idpath]).
 Defined.
 
-Section CoproductsHSET_from_Colims.
+
 
 Require UniMath.CategoryTheory.limits.graphs.bincoproducts.
+
+Section CoproductsHSET_from_Colims.
 
 Lemma BinCoproductsHSET_from_Colims : graphs.bincoproducts.BinCoproducts HSET.
 Proof.
@@ -338,9 +340,11 @@ use tpair.
 - abstract (intro f; apply funextfun; intro e; induction e).
 Defined.
 
-Section InitialHSET_from_Colims.
 
 Require UniMath.CategoryTheory.limits.graphs.initial.
+
+Section InitialHSET_from_Colims.
+
 
 Lemma InitialHSET_from_Colims : graphs.initial.Initial HSET.
 Proof.
@@ -399,10 +403,10 @@ now intros d; apply LimConeHSET.
 Defined.
 
 
+Require UniMath.CategoryTheory.limits.cats.limits.
+
 (** Alternative definition of limits using cats/limits *)
 Section cats_limits.
-
-Require UniMath.CategoryTheory.limits.cats.limits.
 
 Variable J : precategory.
 Variable D : functor J HSET.
@@ -485,9 +489,9 @@ use mk_Product.
          apply funextsec; intro i; rewrite <- ht; apply idpath ]).
 Defined.
 
-Section BinProductsHSET_from_Lims.
-
 Require UniMath.CategoryTheory.limits.graphs.binproducts.
+
+Section BinProductsHSET_from_Lims.
 
 Lemma BinProductsHSET_from_Lims : graphs.binproducts.BinProducts HSET.
 Proof.
@@ -504,9 +508,10 @@ exists (λ _, tt).
 abstract (simpl; intro f; apply funextfun; intro x; case (f x); apply idpath).
 Defined.
 
-Section TerminalHSET_from_Lims.
 
 Require UniMath.CategoryTheory.limits.graphs.terminal.
+
+Section TerminalHSET_from_Lims.
 
 Lemma TerminalHSET_from_Lims : graphs.terminal.Terminal HSET.
 Proof.
@@ -543,9 +548,10 @@ use mk_Pullback.
     now rewrite <- (toforallpaths _ _ _ H1 x), <- (toforallpaths _ _ _ H2 x)).
 Defined.
 
-Section PullbacksHSET_from_Lims.
 
-  Require UniMath.CategoryTheory.limits.graphs.pullbacks.
+Require UniMath.CategoryTheory.limits.graphs.pullbacks.
+
+Section PullbacksHSET_from_Lims.
 
   Lemma PullbacksHSET_from_Lims : graphs.pullbacks.Pullbacks HSET.
   Proof.
@@ -554,9 +560,11 @@ Section PullbacksHSET_from_Lims.
 
 End PullbacksHSET_from_Lims.
 
+
+Require UniMath.CategoryTheory.limits.graphs.equalizers.
+
 Section EqualizersHSET_from_Lims.
 
-  Require UniMath.CategoryTheory.limits.graphs.equalizers.
 
   Lemma EqualizersHSET_from_Lims : graphs.equalizers.Equalizers HSET.
   Proof.
@@ -565,8 +573,10 @@ Section EqualizersHSET_from_Lims.
 
 End EqualizersHSET_from_Lims.
 
+Require UniMath.CategoryTheory.limits.graphs.pushouts.
+
 Section PushoutsHSET_from_colims.
-  Require UniMath.CategoryTheory.limits.graphs.pushouts.
+
   Lemma PushoutsHSET_from_Colims : graphs.pushouts.Pushouts HSET.
   Proof.
     red.

--- a/UniMath/CategoryTheory/catiso.v
+++ b/UniMath/CategoryTheory/catiso.v
@@ -441,22 +441,22 @@ Proof.
   destruct A as [[[Ao Am] [Ai Ac]] Aax].
   destruct B as [[[Bo Bm] [Bi Bc]] Bax].
 
-  eapply total2_paths_b. Unshelve. Focus 2. simpl.
-  - exact (catiso_to_precategory_ob_mor_path F).
-  - apply pathsinv0.
-    eapply pathscomp0.
-    apply (transportb_dirprod _ _ _ _ _ (catiso_to_precategory_ob_mor_path F)).
-    apply dirprodeq.
-    + apply funextsec.
-      intros a.
-      apply (catiso_to_precategory_id_path F).
-    + apply funextsec.
-      intro.
-      apply funextsec.
-      intro.
-      apply funextsec.
-      intro.
-      apply (catiso_to_precategory_comp_path F).
+  eapply total2_paths_b. Unshelve.
+  2: { simpl. exact (catiso_to_precategory_ob_mor_path F). }
+  apply pathsinv0.
+  eapply pathscomp0.
+  apply (transportb_dirprod _ _ _ _ _ (catiso_to_precategory_ob_mor_path F)).
+  apply dirprodeq.
+  - apply funextsec.
+    intros a.
+    apply (catiso_to_precategory_id_path F).
+  - apply funextsec.
+    intro.
+    apply funextsec.
+    intro.
+    apply funextsec.
+    intro.
+    apply (catiso_to_precategory_comp_path F).
 Defined.
 
 Lemma catiso_to_precategory_path {A B : precategory}
@@ -464,9 +464,9 @@ Lemma catiso_to_precategory_path {A B : precategory}
   (F : catiso A B)
   : A = B.
 Proof.
-  eapply total2_paths_b. Unshelve. Focus 2. simpl.
-  - exact (catiso_to_precategory_data_path F).
-  - apply proofirrelevance.
-    apply isaprop_is_precategory.
-    apply hs.
+  eapply total2_paths_b. Unshelve.
+  2: { simpl. exact (catiso_to_precategory_data_path F). }
+  apply proofirrelevance.
+  apply isaprop_is_precategory.
+  apply hs.
 Defined.

--- a/UniMath/CategoryTheory/equivalences.v
+++ b/UniMath/CategoryTheory/equivalences.v
@@ -207,7 +207,7 @@ Proof.
     set (XR := functor_on_iso GG (functor_on_iso FF εntiso)).
     set (XR':= iso_inv_from_iso XR). apply XR'.
   eapply iso_comp.
-     Focus 2. apply εntiso.
+     2: apply εntiso.
   set (XR := functor_on_iso (pre_composition_functor _ _ _ (homset_property _) (homset_property _ ) G) (iso_inv_from_iso ηntiso)).
   set (XR':= functor_on_iso (post_composition_functor _ _ _ (homset_property _ )(homset_property _ ) F) XR).
   apply XR'.

--- a/UniMath/CategoryTheory/yoneda.v
+++ b/UniMath/CategoryTheory/yoneda.v
@@ -268,7 +268,7 @@ Proof.
   clear XH2 XH'.
   assert (XH' := XH _ _ f).
   assert (XH2 := toforallpaths _ _ _ XH').
-  eapply pathscomp0. Focus 2. apply XH2.
+  eapply pathscomp0. 2: apply XH2.
   rewrite id_right.
   apply idpath.
 Qed.

--- a/UniMath/Folds/from_precats_to_folds_and_back.v
+++ b/UniMath/Folds/from_precats_to_folds_and_back.v
@@ -134,50 +134,50 @@ Lemma folds_precat_from_precat_precat_from_folds_precat
     folds_precat_from_precat (precat_from_folds_precat C) hs = C.
 Proof.
   apply subtypeEquality'.
-  Focus 2.
-  - intro a; apply isapropdirprod.
+  2: { intro a; apply isapropdirprod.
     + apply isaprop_folds_ax_id.
-    Focus 2. apply isaprop_folds_ax_T. apply hs.
-  - set (Hid := I_contr C).
-    set (Hcomp := T_contr C).
-    destruct C as [Cd CC]; simpl in *.
-    destruct Cd as [Ca Cb]; simpl in *.
-    unfold folds_id_comp_from_precat_data.
-    apply maponpaths.
-    destruct CC as [C1 C2]. simpl in *.
-    destruct Cb as [Cid Ccomp]. simpl in *.
-    apply pathsdirprod.
-    +  apply funextsec.  intro a.
-       apply funextsec. intro f. unfold id_pred.  simpl.
-       apply subtypeEquality.
-       { intro. apply isapropisaprop. }
-       simpl.
-       apply weqtopaths.
-       apply weqimplimpl.
-       * intro H. rewrite H.
-         set (Hid' := pr1 (Hid a)).
-         apply (pr2 (Hid')).
-       * intro H. unfold precategory_morphisms in f.
-         set (H2 := pr2 (Hid a)). simpl in H2.
-         apply (path_to_ctr). assumption.
-       * apply hs. (* apply (pr2 (precategory_morphisms _ _ )). *)
-       * apply (pr2 (Cid a f)).
-   + apply funextsec; intro a.
-     apply funextsec; intro b.
-     apply funextsec; intro c.
-     apply funextsec; intro f.
-     apply funextsec; intro g.
-     apply funextsec; intro fg.
-     clear Hid.
+    + apply isaprop_folds_ax_T. apply hs.
+  }
+  set (Hid := I_contr C).
+  set (Hcomp := T_contr C).
+  destruct C as [Cd CC]; simpl in *.
+  destruct Cd as [Ca Cb]; simpl in *.
+  unfold folds_id_comp_from_precat_data.
+  apply maponpaths.
+  destruct CC as [C1 C2]. simpl in *.
+  destruct Cb as [Cid Ccomp]. simpl in *.
+  apply pathsdirprod.
+  +  apply funextsec.  intro a.
+     apply funextsec. intro f. unfold id_pred. simpl.
      apply subtypeEquality.
-     { intro; apply isapropisaprop. }
-     apply weqtopaths. apply weqimplimpl.
-       * intro H. simpl in *. rewrite <- H.
-         apply (pr2 (pr1 (Hcomp a b c f g))).
-       * simpl. intro H. apply pathsinv0. apply path_to_ctr.
-           assumption.
-       * simpl in *. apply hs. (* apply (pr2 (precategory_morphisms _ _ )). *)
-       * apply (pr2 (Ccomp _ _ _ _ _ _ )).
+     { intro. apply isapropisaprop. }
+     simpl.
+     apply weqtopaths.
+     apply weqimplimpl.
+     * intro H. rewrite H.
+       set (Hid' := pr1 (Hid a)).
+       apply (pr2 (Hid')).
+     * intro H. unfold precategory_morphisms in f.
+       set (H2 := pr2 (Hid a)). simpl in H2.
+       apply (path_to_ctr). assumption.
+     * apply hs. (* apply (pr2 (precategory_morphisms _ _ )). *)
+     * apply (pr2 (Cid a f)).
+  + apply funextsec; intro a.
+    apply funextsec; intro b.
+    apply funextsec; intro c.
+    apply funextsec; intro f.
+    apply funextsec; intro g.
+    apply funextsec; intro fg.
+    clear Hid.
+    apply subtypeEquality.
+    { intro; apply isapropisaprop. }
+    apply weqtopaths. apply weqimplimpl.
+    * intro H. simpl in *. rewrite <- H.
+      apply (pr2 (pr1 (Hcomp a b c f g))).
+    * simpl. intro H. apply pathsinv0. apply path_to_ctr.
+      assumption.
+    * simpl in *. apply hs. (* apply (pr2 (precategory_morphisms _ _ )). *)
+    * apply (pr2 (Ccomp _ _ _ _ _ _ )).
 Qed.
 
 (** * From precats to FOLDS precats to precats *)
@@ -186,8 +186,7 @@ Lemma precat_from_folds_precat_folds_precat_from_precat (C : precategory)(hs: ha
      precat_from_folds_precat (folds_precat_from_precat C hs) = C.
 Proof.
   apply subtypeEquality'.
-  Focus 2. intro; apply isaprop_is_precategory. assumption.
-
+  2: { intro; apply isaprop_is_precategory. assumption. }
   destruct C as [Cdata Cax]; simpl in *.
   destruct Cdata as [Cobmor Cidcomp]; simpl in *.
   unfold precat_from_folds_data.

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -39,10 +39,10 @@ Lemma transportf_comp_lemma (X : UU) (B : X -> UU) {A A' A'': X} (e : A = A'') (
   -> transportf _ e x = transportf _ e' x'.
 Proof.
   intro H.
-  eapply pathscomp0. Focus 2.
-    apply maponpaths. exact H.
-  eapply pathscomp0. Focus 2.
-    symmetry. apply transport_f_f.
+  eapply pathscomp0.
+  2: { apply maponpaths. exact H. }
+  eapply pathscomp0.
+  2: { symmetry. apply transport_f_f. }
   apply (maponpaths (λ p, transportf _ p x)).
   apply pathsinv0.
   eapply pathscomp0.


### PR DESCRIPTION
It concerns Import in sections and Focus.

This in particular makes proofs cleaner where goals were spawned within the focused proof development.