### PR TITLE
Mark non-uses of Axiom as such, so that `grep` output is easier to check

### DIFF
--- a/UniMath/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Algebra/Monoids_and_Groups.v
@@ -1567,15 +1567,6 @@ Proof.
 Defined.
 Opaque ispartbinopabmonoidfracrelint.
 
-(* ??? Coq 8.4-8.5 trunk hangs here on the following line:
-
-(* Axiom ispartlbinopabmonoidfracrel : ∏ (X : abmonoid) (A : subabmonoid X) *)
-(*  {L : hrel X} (is : ispartbinophrel A L) (aa aa' : A) *)
-(*  (z z' : abmonoidfrac X A) (l : abmonoidfracrel X A is z z'), *)
-(* abmonoidfracrel X A is ((prabmonoidfrac X A (pr1 aa) aa') + z) *)
-(*                        ((prabmonoidfrac X A (pr1 aa) aa') + z'). *)
-
-*)
 
 Lemma ispartlbinopabmonoidfracrel (X : abmonoid) (A : subabmonoid X) {L : hrel X}
       (is : ispartbinophrel A L) (aa aa' : A) (z z' : abmonoidfrac X A)

--- a/UniMath/Algebra/Monoids_and_Groups.v
+++ b/UniMath/Algebra/Monoids_and_Groups.v
@@ -1569,11 +1569,11 @@ Opaque ispartbinopabmonoidfracrelint.
 
 (* ??? Coq 8.4-8.5 trunk hangs here on the following line:
 
-Axiom ispartlbinopabmonoidfracrel : ∏ (X : abmonoid) (A : subabmonoid X)
- {L : hrel X} (is : ispartbinophrel A L) (aa aa' : A)
- (z z' : abmonoidfrac X A) (l : abmonoidfracrel X A is z z'),
-abmonoidfracrel X A is ((prabmonoidfrac X A (pr1 aa) aa') + z)
-                       ((prabmonoidfrac X A (pr1 aa) aa') + z').
+(* Axiom ispartlbinopabmonoidfracrel : ∏ (X : abmonoid) (A : subabmonoid X) *)
+(*  {L : hrel X} (is : ispartbinophrel A L) (aa aa' : A) *)
+(*  (z z' : abmonoidfrac X A) (l : abmonoidfracrel X A is z z'), *)
+(* abmonoidfracrel X A is ((prabmonoidfrac X A (pr1 aa) aa') + z) *)
+(*                        ((prabmonoidfrac X A (pr1 aa) aa') + z'). *)
 
 *)
 

--- a/UniMath/Combinatorics/Tests.v
+++ b/UniMath/Combinatorics/Tests.v
@@ -535,7 +535,7 @@ Module Test_search.
 
   Goal 1 = pr1 (minimal_n P P_dec P_inhab). reflexivity. Defined.
 
-  Axiom P_inhab' : ∃ n, P n.
+  Variable P_inhab' : ∃ n, P n.
 
   Definition new_n' :  ∑ n : nat, P n := minimal_n P P_dec P_inhab'.
 


### PR DESCRIPTION
replace one Axiom by Parameter, make block comment to clarify another use of Axiom