### PR TITLE
bypass a coq notation bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -430,7 +430,6 @@ UniMath/$1/All.v: UniMath/$1/.package/files
 	$(HIDE)																		\
 	exec > $$@ ;																	\
 	echo "(* This file has been auto-generated, do not edit it. *)" ;										\
-	echo "Require Export UniMath.Foundations.Init." ;												\
 	<UniMath/$1/.package/files $(FILES_FILTER_2) | grep -v '^All.v$$$$' |sed -e "s=^=Require Export UniMath.$1.=" -e "s=/=.=g" -e s/\.v$$$$/./
 endef
 $(foreach P, $(PACKAGES), $(eval $(call make-summary-file,$P)) $(eval make-summary-files: UniMath/$P/All.v))

--- a/UniMath/Algebra/All.v
+++ b/UniMath/Algebra/All.v
@@ -1,5 +1,4 @@
 (* This file has been auto-generated, do not edit it. *)
-Require Export UniMath.Foundations.Init.
 Require Export UniMath.Algebra.BinaryOperations.
 Require Export UniMath.Algebra.Monoids_and_Groups.
 Require Export UniMath.Algebra.RigsAndRings.

--- a/UniMath/CategoryTheory/All.v
+++ b/UniMath/CategoryTheory/All.v
@@ -1,5 +1,4 @@
 (* This file has been auto-generated, do not edit it. *)
-Require Export UniMath.Foundations.Init.
 Require Export UniMath.CategoryTheory.total2_paths.
 Require Export UniMath.CategoryTheory.Categories.
 Require Export UniMath.CategoryTheory.functor_categories.

--- a/UniMath/CategoryTheory/Bicategories/Bicat.v
+++ b/UniMath/CategoryTheory/Bicategories/Bicat.v
@@ -130,7 +130,7 @@ Definition hcomp' {C : prebicat_data} {a b c : C} {f1 f2 : C⟦a, b⟧} {g1 g2 :
   : f1 ==> f2 -> g1 ==> g2 -> f1 · g1 ==> f2 · g2
   := λ x y, (f1 ◃ y) • (x ▹ g2).
 
-Local Notation "x ⋆ y" := (hcomp x y) (at level 50).
+Local Notation "x ⋆ y" := (hcomp x y) (at level 50, left associativity).
 
 (* ----------------------------------------------------------------------------------- *)
 (** ** Laws                                                                            *)
@@ -1289,6 +1289,6 @@ Notation "f '<==' g" := (prebicat_cells _ g f) (at level 60, only parsing).
 Notation "x • y" := (vcomp2 x y) (at level 60).
 Notation "f ◃ x" := (lwhisker f x) (at level 60). (* \tw *)
 Notation "y ▹ g" := (rwhisker g y) (at level 60). (* \tw nr 2 *)
-Notation "x ⋆ y" := (hcomp x y) (at level 50).
+Notation "x ⋆ y" := (hcomp x y) (at level 50, left associativity).
 
 End Notations.

--- a/UniMath/CategoryTheory/Bicategories/WkCatEnrichment/Notations.v
+++ b/UniMath/CategoryTheory/Bicategories/WkCatEnrichment/Notations.v
@@ -7,9 +7,9 @@ Require Import UniMath.CategoryTheory.equivalences.
 Require Export UniMath.CategoryTheory.Bicategories.WkCatEnrichment.prebicategory.
 
 (* Local Notation "C  'c×'  D" := (precategory_binproduct C D) (at level 75, right associativity). *)
-Notation "a  '-1->'  b" := (homprecat a b) (at level 50).
-Notation "f  '-2->'  g" := (@precategory_morphisms (_ -1->_) f g) (at level 50).
-Notation "alpha  ';v;'  beta" := (@compose (_ -1-> _) _ _ _ alpha beta) (at level 50).
-Notation "f  ';1;'  g" := (compose1 f g) (at level 50, no associativity).
-Notation "alpha  ';h;'  beta" := (compose2h alpha beta) (at level 50).
-Notation "alpha  ';hi;'  beta" := (compose2h_iso alpha beta) (at level 50).
+Notation "a  '-1->'  b" := (homprecat a b) (at level 50, left associativity).
+Notation "f  '-2->'  g" := (@precategory_morphisms (_ -1->_) f g) (at level 50, left associativity).
+Notation "alpha  ';v;'  beta" := (@compose (_ -1-> _) _ _ _ alpha beta) (at level 50, left associativity).
+Notation "f  ';1;'  g" := (compose1 f g) (at level 50, left associativity).
+Notation "alpha  ';h;'  beta" := (compose2h alpha beta) (at level 50, left associativity).
+Notation "alpha  ';hi;'  beta" := (compose2h_iso alpha beta) (at level 50, left associativity).

--- a/UniMath/CategoryTheory/Bicategories/WkCatEnrichment/prebicategory.v
+++ b/UniMath/CategoryTheory/Bicategories/WkCatEnrichment/prebicategory.v
@@ -52,13 +52,13 @@ Coercion bicat_ob (C : prebicategory_ob_hom) : UU := pr1 C.
 
 Definition homprecat {C : prebicategory_ob_hom} (a b : C) : precategory := pr2 C a b.
 
-Local Notation "a  '-1->'  b" := (homprecat a b) (at level 50).
+Local Notation "a  '-1->'  b" := (homprecat a b) (at level 50, left associativity).
 
 Local Notation "f  '-2->'  g" := (@precategory_morphisms (_ -1->_) f g)
-  (at level 50).
+  (at level 50, left associativity).
 
 Local Notation "alpha  ';v;'  beta" := (@compose (_ -1-> _) _ _ _ alpha beta)
- (at level 50).
+ (at level 50, left associativity).
 
 Definition prebicategory_id_comp :=
   ∑ C : prebicategory_ob_hom,
@@ -78,7 +78,7 @@ Definition compose1 {C : prebicategory_id_comp} {a b c : C} (f : a -1-> b) (g : 
   := functor_on_objects (compose_functor a b c) (dirprodpair f g).
 
 Local Notation "f  ';1;'  g" := (compose1 f g)
-  (at level 50, no associativity).
+  (at level 50, left associativity).
 
 Definition compose2h {C : prebicategory_id_comp} {a b c : C}
            {f f' : a -1-> b}
@@ -91,7 +91,7 @@ Proof.
   exact (precatbinprodmor alpha beta).
 Defined.
 
-Local Notation "alpha  ';h;'  beta" := (compose2h alpha beta) (at level 50).
+Local Notation "alpha  ';h;'  beta" := (compose2h alpha beta) (at level 50, left associativity).
 
 Definition compose2h_iso {C : prebicategory_id_comp} {a b c : C}
            {f f' : a -1-> b}
@@ -103,7 +103,7 @@ Proof.
   apply functor_on_iso. exact (precatbinprodiso alpha beta).
 Defined.
 
-Local Notation "alpha  ';hi;'  beta" := (compose2h_iso alpha beta) (at level 50).
+Local Notation "alpha  ';hi;'  beta" := (compose2h_iso alpha beta) (at level 50, left associativity).
 
 Definition associator_trans_type {C : prebicategory_id_comp} (a b c d : C) : UU
   := pair_functor (functor_identity (a -1-> b)) (compose_functor b c d) ∙

--- a/UniMath/CategoryTheory/DisplayedCats/Core.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Core.v
@@ -112,7 +112,7 @@ Definition mor_disp {C} {D : disp_cat_ob_mor C}
   {x y} xx yy (f : x --> y)
 := pr2 D x y xx yy f : UU.
 
-Local Notation "xx -->[ f ] yy" := (mor_disp xx yy f) (at level 50, yy at next level).
+Local Notation "xx -->[ f ] yy" := (mor_disp xx yy f) (at level 50, left associativity, yy at next level).
 
 Definition disp_cat_id_comp (C : precategory_data)
   (D : disp_cat_ob_mor C)
@@ -304,7 +304,7 @@ End Lemmas.
 End Disp_Cat.
 
 (** Redeclare sectional notations globally. *)
-Notation "xx -->[ f ] yy" := (mor_disp xx yy f) (at level 50, yy at next level).
+Notation "xx -->[ f ] yy" := (mor_disp xx yy f) (at level 50, left associativity, yy at next level).
 
 Notation "ff ;; gg" := (comp_disp ff gg)
   (at level 50, left associativity, format "ff  ;;  gg")

--- a/UniMath/Combinatorics/All.v
+++ b/UniMath/Combinatorics/All.v
@@ -1,5 +1,4 @@
 (* This file has been auto-generated, do not edit it. *)
-Require Export UniMath.Foundations.Init.
 Require Export UniMath.Combinatorics.StandardFiniteSets.
 Require Export UniMath.Combinatorics.Lists.
 Require Export UniMath.Combinatorics.FiniteSets.

--- a/UniMath/Combinatorics/OrderedSets.v
+++ b/UniMath/Combinatorics/OrderedSets.v
@@ -380,7 +380,7 @@ Proof.
   - apply isfinitestn.
 Defined.
 
-Notation "⟦ n ⟧" := (standardFiniteOrderedSet n) (at level 50) : foset.
+Notation "⟦ n ⟧" := (standardFiniteOrderedSet n) : foset.
 (* in agda-mode \[[ n \]] *)
 
 Lemma inducedPartialOrder {X Y} (f:X->Y) (incl:isInjective f) (R:hrel Y) (po:isPartialOrder R) :

--- a/UniMath/Combinatorics/StandardFiniteSets.v
+++ b/UniMath/Combinatorics/StandardFiniteSets.v
@@ -40,7 +40,7 @@ Notation " 'stnel' ( i , j ) " := ( (j,,idpath _) : stn i ) ( at level 70 ).
 
 Delimit Scope stn with stn.
 
-Notation "⟦ n ⟧" := (stn n) (at level 50) : stn.
+Notation "⟦ n ⟧" := (stn n) : stn.
 (* in agda-mode \[[ n \]] *)
 
 Notation "● i" := (i ,, (idpath _ : natgtb _ _ = _)) (at level 35) : stn.

--- a/UniMath/Folds/All.v
+++ b/UniMath/Folds/All.v
@@ -1,5 +1,4 @@
 (* This file has been auto-generated, do not edit it. *)
-Require Export UniMath.Foundations.Init.
 Require Export UniMath.Folds.UnicodeNotations.
 Require Export UniMath.Folds.aux_lemmas.
 Require Export UniMath.Folds.folds_precat.

--- a/UniMath/Foundations/All.v
+++ b/UniMath/Foundations/All.v
@@ -1,6 +1,5 @@
 (* This file has been auto-generated, do not edit it. *)
 Require Export UniMath.Foundations.Init.
-Require Export UniMath.Foundations.Init.
 Require Export UniMath.Foundations.Preamble.
 Require Export UniMath.Foundations.PartA.
 Require Export UniMath.Foundations.PartB.

--- a/UniMath/Foundations/Init.v
+++ b/UniMath/Foundations/Init.v
@@ -57,18 +57,20 @@ Reserved Notation "'¬' X" (at level 35, right associativity).
 
 Reserved Notation "A × B" (at level 75, right associativity).
 
-Reserved Notation "C ⟦ a , b ⟧" (at level 50).
+Reserved Notation "C ⟦ a , b ⟧" (at level 49, right associativity).
 (* ⟦   to input: type "\[[" or "\(" with Agda input method
    ⟧   to input: type "\]]" or "\)" with Agda input method *)
+
+Reserved Notation "⟦ a ⟧" (at level 48, left associativity).
 
 Reserved Notation "f ;; g"  (at level 50, left associativity, only parsing). (* deprecated *)
 
 Reserved Notation "f · g"  (at level 50, format "f  ·  g", left associativity).
 (* to input: type "\centerdot" or "\cdot" with Agda input method *)
 
-Reserved Notation "a --> b" (at level 50).
+Reserved Notation "a --> b" (at level 50, left associativity).
 
-Reserved Notation "! p " (at level 50).
+Reserved Notation "! p " (at level 50, left associativity).
 
 (* conflict:
     Reserved Notation "# F"  (at level 3).
@@ -79,11 +81,11 @@ Reserved Notation "p #' x" (right associativity, at level 65, only parsing).
 
 Reserved Notation "C '^op'" (at level 3, format "C ^op").
 
-Reserved Notation "a <-- b" (at level 50).
+Reserved Notation "a <-- b" (at level 50, left associativity).
 
 Reserved Notation "[ C , D ]" .
 
-Reserved Notation "C [ a , b ]"  (at level 50).
+Reserved Notation "C [ a , b ]"  (at level 50, left associativity).
 
 Reserved Notation "X ⟶ Y"  (at level 39).
 (* to input: type "\-->" with Agda input method *)
@@ -114,7 +116,7 @@ Reserved Notation "F ▭ f"  (at level 40, left associativity). (* \rew1 *)
     (* to input: type "\Rightarrow" or "\r=" or "\r" or "\Longrightarrow" or "\=>" with Agda input method *)
 *)
 
-Reserved Notation "X ⇐ c"   (at level 50).
+Reserved Notation "X ⇐ c"   (at level 50, left associativity).
 (* to input: type "\Leftarrow" or "\Longleftarrow" or "\l=" or "\l" with Agda input method *)
 
 Reserved Notation "x ⟲ f"  (at level 50, left associativity).
@@ -126,7 +128,7 @@ Reserved Notation "q ⟳ x"  (at level 50, left associativity).
 Reserved Notation "p ◽ b"  (at level 40).
 (* to input: type "\sqw" or "\sq" with Agda input method *)
 
-Reserved Notation "xe ⟲⟲ p"  (at level 50).
+Reserved Notation "xe ⟲⟲ p"  (at level 50, left associativity).
 (* to input: type "\l" and select from the menu, row 4, spot 2, with Agda input method *)
 
 Reserved Notation "r \\ x"  (at level 50, left associativity).

--- a/UniMath/HomologicalAlgebra/All.v
+++ b/UniMath/HomologicalAlgebra/All.v
@@ -1,5 +1,4 @@
 (* This file has been auto-generated, do not edit it. *)
-Require Export UniMath.Foundations.Init.
 Require Export UniMath.HomologicalAlgebra.Triangulated.
 Require Export UniMath.HomologicalAlgebra.Complexes.
 Require Export UniMath.HomologicalAlgebra.KA.

--- a/UniMath/Induction/All.v
+++ b/UniMath/Induction/All.v
@@ -1,5 +1,4 @@
 (* This file has been auto-generated, do not edit it. *)
-Require Export UniMath.Foundations.Init.
 Require Export UniMath.Induction.PolynomialFunctors.
 Require Export UniMath.Induction.M.Core.
 Require Export UniMath.Induction.M.Limits.

--- a/UniMath/Ktheory/All.v
+++ b/UniMath/Ktheory/All.v
@@ -1,5 +1,4 @@
 (* This file has been auto-generated, do not edit it. *)
-Require Export UniMath.Foundations.Init.
 Require Export UniMath.Ktheory.Tactics.
 Require Export UniMath.Ktheory.Equivalences.
 Require Export UniMath.Ktheory.Utilities.

--- a/UniMath/Ktheory/Bifunctor.v
+++ b/UniMath/Ktheory/Bifunctor.v
@@ -232,7 +232,7 @@ Definition θ_map {B C:category} {F' F:[B, C]} {X : [B, [C^op, SET]]} :
   F' --> F -> F ⟹ X -> F' ⟹ X
   := λ p xe, θ_map_1 p xe ,, θ_map_2 p xe.
 
-Notation "xe ⟲⟲ p" := (θ_map p xe) (at level 50) : cat.
+Notation "xe ⟲⟲ p" := (θ_map p xe) (at level 50, left associativity) : cat.
 
 Definition φ_map_1 {B C:category} {F:[B, C]} {X' X: [B, [C^op, SET]]} :
   F ⟹ X -> X --> X' -> θ_1 F X'

--- a/UniMath/Ktheory/Precategories.v
+++ b/UniMath/Ktheory/Precategories.v
@@ -13,7 +13,7 @@ Require Import UniMath.MoreFoundations.Tactics.
 
 Local Open Scope cat.
 
-Notation "a <-- b" := (@precategory_morphisms (opp_precat _) a b) (at level 50) : cat.
+Notation "a <-- b" := (@precategory_morphisms (opp_precat _) a b) (at level 50, left associativity) : cat.
 
 Definition src {C:precategory} {a b:C} (f:a-->b) : C := a.
 Definition tar {C:precategory} {a b:C} (f:a-->b) : C := b.
@@ -150,10 +150,10 @@ Definition functor_mor_application {B C:category} {b b':B} (F:[B,C]) :
 Notation "F ▭ f" := (functor_mor_application F f) (at level 40, left associativity) : cat. (* \rew1 *)
 
 Definition arrow {C:category} (c : C) (X : [C^op,SET]) : hSet := X ◾ c.
-Notation "c ⇒ X" := (arrow c X)  (at level 50) : cat. (* \r= *)
+Notation "c ⇒ X" := (arrow c X)  (at level 50, left associativity) : cat. (* \r= *)
 
 Definition arrow' {C:category} (c : C) (X : [C^op^op,SET]) : hSet := X ◾ c.
-Notation "X ⇐ c" := (arrow' c X)  (at level 50) : cat. (* \l= *)
+Notation "X ⇐ c" := (arrow' c X)  (at level 50, left associativity) : cat. (* \l= *)
 
 Definition arrow_morphism_composition {C:category} {c' c:C} {X:[C^op,SET]} :
   c'-->c -> c⇒X -> c'⇒X

--- a/UniMath/MoreFoundations/All.v
+++ b/UniMath/MoreFoundations/All.v
@@ -1,5 +1,4 @@
 (* This file has been auto-generated, do not edit it. *)
-Require Export UniMath.Foundations.Init.
 Require Export UniMath.MoreFoundations.Foundations.
 Require Export UniMath.MoreFoundations.WeakEquivalences.
 Require Export UniMath.MoreFoundations.Tactics.

--- a/UniMath/NumberSystems/All.v
+++ b/UniMath/NumberSystems/All.v
@@ -1,5 +1,4 @@
 (* This file has been auto-generated, do not edit it. *)
-Require Export UniMath.Foundations.Init.
 Require Export UniMath.NumberSystems.NaturalNumbersAlgebra.
 Require Export UniMath.NumberSystems.NaturalNumbers_le_Inductive.
 Require Export UniMath.NumberSystems.Integers.

--- a/UniMath/PAdics/All.v
+++ b/UniMath/PAdics/All.v
@@ -1,5 +1,4 @@
 (* This file has been auto-generated, do not edit it. *)
-Require Export UniMath.Foundations.Init.
 Require Export UniMath.PAdics.lemmas.
 Require Export UniMath.PAdics.fps.
 Require Export UniMath.PAdics.frac.

--- a/UniMath/RealNumbers/All.v
+++ b/UniMath/RealNumbers/All.v
@@ -1,5 +1,4 @@
 (* This file has been auto-generated, do not edit it. *)
-Require Export UniMath.Foundations.Init.
 Require Export UniMath.RealNumbers.Prelim.
 Require Export UniMath.RealNumbers.Fields.
 Require Export UniMath.RealNumbers.Sets.

--- a/UniMath/SubstitutionSystems/All.v
+++ b/UniMath/SubstitutionSystems/All.v
@@ -1,5 +1,4 @@
 (* This file has been auto-generated, do not edit it. *)
-Require Export UniMath.Foundations.Init.
 Require Export UniMath.SubstitutionSystems.Notation.
 Require Export UniMath.SubstitutionSystems.Signatures.
 Require Export UniMath.SubstitutionSystems.BinSumOfSignatures.

--- a/UniMath/Tactics/All.v
+++ b/UniMath/Tactics/All.v
@@ -1,5 +1,4 @@
 (* This file has been auto-generated, do not edit it. *)
-Require Export UniMath.Foundations.Init.
 Require Export UniMath.Tactics.Utilities.
 Require Export UniMath.Tactics.Monoids_Tactics.
 Require Export UniMath.Tactics.Abmonoids_Tactics.

--- a/UniMath/Topology/All.v
+++ b/UniMath/Topology/All.v
@@ -1,5 +1,4 @@
 (* This file has been auto-generated, do not edit it. *)
-Require Export UniMath.Foundations.Init.
 Require Export UniMath.Topology.Prelim.
 Require Export UniMath.Topology.Filters.
 Require Export UniMath.Topology.Topology.


### PR DESCRIPTION
... that forced us to read in our notations file (Foundations/Init.v)
too often.

We bypass the problem by adding "left associativity" to many
declarations of notations at level 50.

Our theory is that Coq processes notation declarations in an
indeterminate order when *.vo files are loaded.