### PR TITLE
rename to_abgrop → to_abgr

### DIFF
--- a/UniMath/CategoryTheory/AdditiveFunctors.v
+++ b/UniMath/CategoryTheory/AdditiveFunctors.v
@@ -48,11 +48,11 @@ Section def_additivefunctor.
   (** ** isAdditiveFunctor *)
 
   Definition isAdditiveFunctor {A B : Additive} (F : functor A B) : UU :=
-    ∏ (a1 a2 : A), @ismonoidfun (to_abgrop a1 a2) (to_abgrop (F a1) (F a2)) (# F).
+    ∏ (a1 a2 : A), @ismonoidfun (to_abgr a1 a2) (to_abgr (F a1) (F a2)) (# F).
 
   Definition mk_isAdditiveFunctor {A B : Additive} (F : functor A B)
              (H : ∏ (a1 a2 : A),
-                  @ismonoidfun (to_abgrop a1 a2) (to_abgrop (F a1) (F a2)) (# F)) :
+                  @ismonoidfun (to_abgr a1 a2) (to_abgr (F a1) (F a2)) (# F)) :
     isAdditiveFunctor F.
   Proof.
     intros a1 a2.

--- a/UniMath/CategoryTheory/PreAdditive.v
+++ b/UniMath/CategoryTheory/PreAdditive.v
@@ -76,11 +76,11 @@ Section def_preadditive.
     ∏ (x y z : PWA) (f : y --> z), ismonoidfun (to_postmor x f) := dirprod_pr2 iPA.
 
   Definition to_premor_monoidfun {PWA : categoryWithAbgrops} (iPA : isPreAdditive PWA)
-             (x y z : PWA) (f : x --> y) : monoidfun (to_abgrop y z) (to_abgrop x z) :=
+             (x y z : PWA) (f : x --> y) : monoidfun (to_abgr y z) (to_abgr x z) :=
     monoidfunconstr (to_premor_monoid iPA x y z f).
 
   Definition to_postmor_monoidfun {PWA : categoryWithAbgrops} (iPA : isPreAdditive PWA)
-             (x y z : PWA) (f : y --> z) : monoidfun (to_abgrop x y) (to_abgrop x z) :=
+             (x y z : PWA) (f : y --> z) : monoidfun (to_abgr x y) (to_abgr x z) :=
     monoidfunconstr (to_postmor_monoid iPA x y z f).
 
   (** Definition of preadditive categories *)
@@ -210,7 +210,7 @@ Section preadditive_inv_comp.
   Lemma PreAdditive_invlcomp {x y z : A} (f : A⟦x, y⟧) (g : A⟦y, z⟧) :
     (to_inv (f · g)) = (to_inv f) · g.
   Proof.
-    use (grrcan (to_abgrop x z) (f · g)).
+    use (grrcan (to_abgr x z) (f · g)).
     unfold to_inv at 1. rewrite grlinvax.
     use (pathscomp0 _ (to_postmor_linear' (to_inv f) f g)).
     rewrite linvax. rewrite to_postmor_unel'.
@@ -221,7 +221,7 @@ Section preadditive_inv_comp.
   Lemma PreAdditive_invrcomp {x y z : A} (f : A⟦x, y⟧) (g : A⟦y, z⟧) :
     (to_inv (f · g)) = f · (to_inv g).
   Proof.
-    use (grrcan (to_abgrop x z) (f · g)).
+    use (grrcan (to_abgr x z) (f · g)).
     unfold to_inv at 1. rewrite grlinvax.
     use (pathscomp0 _ (to_premor_linear' f (to_inv g) g)).
     rewrite linvax. rewrite to_premor_unel'.
@@ -231,7 +231,7 @@ Section preadditive_inv_comp.
 
   Lemma PreAdditive_cancel_inv {x y : A} (f g : A⟦x, y⟧) (H : (to_inv f)  = (to_inv g)) : f = g.
   Proof.
-    apply (grinvmaponpathsinv (to_abgrop x y) H).
+    apply (grinvmaponpathsinv (to_abgr x y) H).
   Qed.
 
 End preadditive_inv_comp.
@@ -331,7 +331,7 @@ Section preadditive_quotient.
   Local Opaque ishinh.
 
   (** For every set morphisms we have a subgroup. *)
-  Definition PreAdditiveSubabgrs : UU := ∏ (x y : ob PA), @subabgr (to_abgrop x y).
+  Definition PreAdditiveSubabgrs : UU := ∏ (x y : ob PA), @subabgr (to_abgr x y).
 
   Hypothesis PAS : PreAdditiveSubabgrs.
 
@@ -341,11 +341,11 @@ Section preadditive_quotient.
   Definition PreAdditiveComps : UU :=
     ∏ (x y : ob PA),
     (∏ (z : ob PA) (f : x --> y)
-       (inf : pr1submonoid (@to_abgrop PA x y) (PAS x y) f) (g : y --> z),
-     pr1submonoid (@to_abgrop PA x z) (PAS x z) (f · g))
+       (inf : pr1submonoid (@to_abgr PA x y) (PAS x y) f) (g : y --> z),
+     pr1submonoid (@to_abgr PA x z) (PAS x z) (f · g))
       × (∏ (z : ob PA) (f : x --> y) (g : y --> z)
-           (ing : pr1submonoid (@to_abgrop PA y z) (PAS y z) g),
-         pr1submonoid (@to_abgrop PA x z) (PAS x z) (f · g)).
+           (ing : pr1submonoid (@to_abgr PA y z) (PAS y z) g),
+         pr1submonoid (@to_abgr PA x z) (PAS x z) (f · g)).
 
   Hypothesis PAC : PreAdditiveComps.
 
@@ -512,7 +512,7 @@ Section preadditive_quotient.
   Local Lemma to_inv_elem {a b : PA} (f : PA⟦a, b⟧) (H : pr1 (PAS a b) f) : carrier (pr1 (PAS a b)).
   Proof.
     use tpair.
-    - exact (@grinv (to_abgrop a b) f).
+    - exact (@grinv (to_abgr a b) f).
     - apply (pr2 (pr2 (PAS a b))). exact H.
   Defined.
 
@@ -560,19 +560,19 @@ Section preadditive_quotient.
 
   Lemma Quotcategory_comp_iscontr_PAS {A B C : PA} {t : pr1 (PAS A B)} {t' : pr1 (PAS B C)}
         {f1 f'1 : PA⟦A, B⟧} {g1 g'1 : PA⟦B, C⟧}
-        (p : pr1 t = to_binop A B f'1 (grinv (to_abgrop A B) f1))
-        (p' : pr1 t' = to_binop B C g'1 (grinv (to_abgrop B C) g1)) :
-    pr1 (PAS A C) (to_binop A C (f1 · g1) (grinv (to_abgrop A C) (f'1 · g'1))).
+        (p : pr1 t = to_binop A B f'1 (grinv (to_abgr A B) f1))
+        (p' : pr1 t' = to_binop B C g'1 (grinv (to_abgr B C) g1)) :
+    pr1 (PAS A C) (to_binop A C (f1 · g1) (grinv (to_abgr A C) (f'1 · g'1))).
   Proof.
     set (e1 := Quotcategory_comp_iscontr_PAS_eq p).
     set (e2 := Quotcategory_comp_iscontr_PAS_eq p').
     rewrite e1. rewrite e2. clear e1 e2 p p'. cbn.
     rewrite to_premor_linear'. rewrite to_postmor_linear'. rewrite to_postmor_linear'.
-    set (ac := assocax (to_abgrop A C)). unfold isassoc in ac. cbn in ac.
-    set (comm := commax (to_abgrop A C)). unfold iscomm in comm. cbn in comm.
+    set (ac := assocax (to_abgr A C)). unfold isassoc in ac. cbn in ac.
+    set (comm := commax (to_abgr A C)). unfold iscomm in comm. cbn in comm.
     rewrite (comm _ (f1 · g1)). rewrite <- (ac _ (f1 · g1) _).
     rewrite (comm _ (f1 · g1)). rewrite ac. rewrite ac.
-    set (i := grinvop (to_abgrop A C)). cbn in i. rewrite i. repeat rewrite <- ac.
+    set (i := grinvop (to_abgr A C)). cbn in i. rewrite i. repeat rewrite <- ac.
     rewrite comm. rewrite <- ac.
     set (il := linvax _ (f1 · g1)). unfold to_inv in il. rewrite il. clear il.
     set (lu := to_lunax A C). unfold islunit in lu. cbn in lu. unfold to_unel. rewrite lu.
@@ -591,11 +591,11 @@ Section preadditive_quotient.
     setquotpr _ (f' · g') = setquotpr (binopeqrel_subgr_eqrel (PAS A C)) (f'1 · g'1).
   Proof.
     intros f1 Hf g1 Hg. cbn.
-    apply (iscompsetquotpr (eqrelpair _ (iseqrel_subgrhrel (to_abgrop A C) (PAS A C)))).
+    apply (iscompsetquotpr (eqrelpair _ (iseqrel_subgrhrel (to_abgr A C) (PAS A C)))).
     set (HH := @abgrquotpr_rels_to_unel
-                 (to_abgrop A B) f'1 f1 (binopeqrel_subgr_eqrel (PAS A B)) f f''1 Hf).
+                 (to_abgr A B) f'1 f1 (binopeqrel_subgr_eqrel (PAS A B)) f f''1 Hf).
     set (HH' := @abgrquotpr_rels_to_unel
-                  (to_abgrop B C) g'1 g1 (binopeqrel_subgr_eqrel (PAS B C)) g g''1 Hg).
+                  (to_abgr B C) g'1 g1 (binopeqrel_subgr_eqrel (PAS B C)) g g''1 Hg).
     apply abgrquotpr_rel_paths in HH. apply abgrquotpr_rel_paths in HH'.
     use (squash_to_prop HH). apply propproperty. intros HHH. clear HH.
     use (squash_to_prop HH'). apply propproperty. intros HHH'. clear HH'.
@@ -606,7 +606,7 @@ Section preadditive_quotient.
     use hinhpr.
     use tpair.
     + use tpair.
-      * exact (to_binop A C (f1 · g1) (grinv (to_abgrop A C) (f'1 · g'1))).
+      * exact (to_binop A C (f1 · g1) (grinv (to_abgr A C) (f'1 · g'1))).
       * apply (Quotcategory_comp_iscontr_PAS p p').
     + apply idpath.
   Qed.
@@ -813,7 +813,7 @@ Section preadditive_quotient.
     - split.
       (* id left *)
       + intros a b f. apply pathsinv0. cbn. unfold Quotcategory_comp.
-        set (f'' := @issurjsetquotpr (to_abgrop a b) (binopeqrel_subgr_eqrel (PAS a b)) f).
+        set (f'' := @issurjsetquotpr (to_abgr a b) (binopeqrel_subgr_eqrel (PAS a b)) f).
         use (squash_to_prop f''). apply isasetsetquot. intros f'. clear f''.
         induction f' as [f1 f2]. rewrite <- f2. cbn in f1, a, b.
         eapply pathscomp0.
@@ -825,7 +825,7 @@ Section preadditive_quotient.
           -- apply idpath.
       (* id right *)
       + intros a b f. apply pathsinv0. cbn. unfold Quotcategory_comp.
-        set (f'' := @issurjsetquotpr (to_abgrop a b) (binopeqrel_subgr_eqrel (PAS a b)) f).
+        set (f'' := @issurjsetquotpr (to_abgr a b) (binopeqrel_subgr_eqrel (PAS a b)) f).
         use (squash_to_prop f''). apply isasetsetquot. intros f'. clear f''.
         induction f' as [f1 f2]. rewrite <- f2. cbn in f1, a, b.
         eapply pathscomp0.
@@ -837,11 +837,11 @@ Section preadditive_quotient.
           -- apply idpath.
     (* assoc *)
     - intros a b c d f g h. cbn.
-      set (f'' := @issurjsetquotpr (to_abgrop a b) (binopeqrel_subgr_eqrel (PAS a b)) f).
+      set (f'' := @issurjsetquotpr (to_abgr a b) (binopeqrel_subgr_eqrel (PAS a b)) f).
       use (squash_to_prop f''). apply isasetsetquot. intros f'. clear f''.
-      set (g'' := @issurjsetquotpr (to_abgrop b c) (binopeqrel_subgr_eqrel (PAS b c)) g).
+      set (g'' := @issurjsetquotpr (to_abgr b c) (binopeqrel_subgr_eqrel (PAS b c)) g).
       use (squash_to_prop g''). apply isasetsetquot. intros g'. clear g''.
-      set (h'' := @issurjsetquotpr (to_abgrop c d) (binopeqrel_subgr_eqrel (PAS c d)) h).
+      set (h'' := @issurjsetquotpr (to_abgr c d) (binopeqrel_subgr_eqrel (PAS c d)) h).
       use (squash_to_prop h''). apply isasetsetquot. intros h'. clear h''.
       induction f' as [f1 f2]. induction g' as [g1 g2]. induction h' as [h1 h2].
       cbn in f1, g1, h1.
@@ -880,12 +880,12 @@ Section preadditive_quotient.
 
   Local Lemma quot_unel {x y : PA} :
     setquotpr (binopeqrel_subgr_eqrel (PAS x y)) (@to_unel PA x y) =
-    unel (@to_abgrop Quotcategory_abgrops x y).
+    unel (@to_abgr Quotcategory_abgrops x y).
   Proof.
     apply idpath.
   Qed.
 
-  Local Opaque to_abgrop.
+  Local Opaque to_abgr.
   Local Lemma PreAdditive_pre_linear (x y z : ob Quotcategory_abgrops)
     (f : Quotcategory_abgrops⟦x, y⟧) (g h : Quotcategory_abgrops ⟦y, z⟧):
     f · to_binop y z g h = to_binop x z (f · g) (f · h).
@@ -993,7 +993,7 @@ Section preadditive_quotient.
       use tpair.
       + exact (to_quot_mor (@ZeroArrowFrom PA Z a)).
       + cbn beta. intros t.
-        set (t'1 := @issurjsetquotpr (to_abgrop Z a) (binopeqrel_subgr_eqrel (PAS Z a)) t).
+        set (t'1 := @issurjsetquotpr (to_abgr Z a) (binopeqrel_subgr_eqrel (PAS Z a)) t).
         use (squash_to_prop t'1). apply has_homsets_Quotcategory. intros t1. clear t'1.
         induction t1 as [t1 t2]. rewrite <- t2. unfold to_quot_mor. apply maponpaths.
         apply ArrowsFromZero.
@@ -1001,7 +1001,7 @@ Section preadditive_quotient.
       use tpair.
       + exact (to_quot_mor (@ZeroArrowTo PA Z a)).
       + cbn beta. intros t.
-        set (t'1 := @issurjsetquotpr (to_abgrop a Z) (binopeqrel_subgr_eqrel (PAS a Z)) t).
+        set (t'1 := @issurjsetquotpr (to_abgr a Z) (binopeqrel_subgr_eqrel (PAS a Z)) t).
         use (squash_to_prop t'1). apply has_homsets_Quotcategory. intros t1. clear t'1.
         induction t1 as [t1 t2]. rewrite <- t2. unfold to_quot_mor. apply maponpaths.
         apply ArrowsToZero.

--- a/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
+++ b/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
@@ -60,27 +60,27 @@ Section def_precategory_with_abgrops.
 
   Definition to_isabgrop (x y : PA) := (pr2 PA) x y.
 
-  Definition to_abgrop (x y : PA) : abgr := abgrpair (to_setwithbinoppair x y) (to_isabgrop x y).
+  Definition to_abgr (x y : PA) : abgr := abgrpair (to_setwithbinoppair x y) (to_isabgrop x y).
 
-  Definition to_unel (x y : PA) := unel (to_abgrop x y).
+  Definition to_unel (x y : PA) := unel (to_abgr x y).
 
-  Definition to_lunax (x y : PA) := lunax (to_abgrop x y).
+  Definition to_lunax (x y : PA) := lunax (to_abgr x y).
 
   Definition to_lunax' (x y : PA) (f : x --> y) : to_binop x y (to_unel x y) f = f.
   Proof.
     apply to_lunax.
   Qed.
 
-  Definition to_runax (x y : PA) : isrunit op 1%multmonoid := runax (to_abgrop x y).
+  Definition to_runax (x y : PA) : isrunit op 1%multmonoid := runax (to_abgr x y).
 
   Definition to_runax' (x y : PA) (f : x --> y) : to_binop x y f (to_unel x y) = f.
   Proof.
     apply to_runax.
   Qed.
 
-  Definition to_inv {x y : PA} : PA⟦x, y⟧ -> PA⟦x, y⟧ := grinv (to_abgrop x y).
+  Definition to_inv {x y : PA} : PA⟦x, y⟧ -> PA⟦x, y⟧ := grinv (to_abgr x y).
 
-  Definition to_commax (x y : PA) := commax (to_abgrop x y).
+  Definition to_commax (x y : PA) := commax (to_abgr x y).
 
   Definition to_commax' {x y : ob PA} (f g : x --> y) : to_binop x y f g = to_binop x y g f.
   Proof.
@@ -90,23 +90,23 @@ Section def_precategory_with_abgrops.
   (** The following definition gives maps between abgrops homsets by precomposing and postcomposing
       with a morphism. Note that we have not required these to be abelian group morphisms of abelian
       groups. *)
-  Definition to_premor {x y : PA} (z : PA) (f : x --> y) : to_abgrop y z -> to_abgrop x z :=
-    fun (g : (to_abgrop y z)) => f · g.
+  Definition to_premor {x y : PA} (z : PA) (f : x --> y) : to_abgr y z -> to_abgr x z :=
+    fun (g : (to_abgr y z)) => f · g.
 
-  Definition to_postmor (x : PA) {y z : PA} (f : y --> z) : to_abgrop x y -> to_abgrop x z :=
-    fun (g : (to_abgrop x y)) => g · f.
+  Definition to_postmor (x : PA) {y z : PA} (f : y --> z) : to_abgr x y -> to_abgr x z :=
+    fun (g : (to_abgr x y)) => g · f.
 
 
   (** Some equatios on inverses *)
   Lemma inv_inv_eq {x y : PA} (f : PA⟦x, y⟧) : to_inv (to_inv f) = f.
   Proof.
     unfold to_inv.
-    apply (grinvinv (to_abgrop x y) f).
+    apply (grinvinv (to_abgr x y) f).
   Qed.
 
   Lemma cancel_inv {x y : PA} (f g : PA⟦x, y⟧) (H : (to_inv f) = (to_inv g)) : f = g.
   Proof.
-    apply (grinvmaponpathsinv (to_abgrop x y) H).
+    apply (grinvmaponpathsinv (to_abgr x y) H).
   Qed.
 
   Lemma to_apply_inv {x y : PA} (f g : PA⟦x, y⟧) (H : f = g) : (to_inv f) = (to_inv g).
@@ -117,32 +117,32 @@ Section def_precategory_with_abgrops.
   Lemma to_inv_unel {x y : PA} : to_inv (to_unel x y) = to_unel x y.
   Proof.
     unfold to_unel.
-    set (tmp := grinvunel (to_abgrop x y)). cbn in tmp. unfold to_inv.
+    set (tmp := grinvunel (to_abgr x y)). cbn in tmp. unfold to_inv.
     apply tmp.
   Qed.
 
   Lemma linvax {x y : PA} (f : PA⟦x, y⟧) : to_binop x y (to_inv f) f = to_unel x y.
   Proof.
-    apply (grlinvax (to_abgrop x y)).
+    apply (grlinvax (to_abgr x y)).
   Qed.
 
   Lemma rinvax {x y : PA} (f : PA⟦x, y⟧) : to_binop x y f (to_inv f) = to_unel x y.
   Proof.
-    apply (grrinvax (to_abgrop x y)).
+    apply (grrinvax (to_abgr x y)).
   Qed.
 
   Lemma to_lcan {x y : PA} {f g : PA⟦x, y⟧} (h : PA⟦x, y⟧) :
     to_binop x y h f = to_binop x y h g -> f = g.
   Proof.
     intros H.
-    apply (grlcan (to_abgrop x y) h H).
+    apply (grlcan (to_abgr x y) h H).
   Qed.
 
   Lemma to_rcan {x y : PA} {f g : PA⟦x, y⟧} (h : PA⟦x, y⟧) :
     to_binop x y f h = to_binop x y g h -> f = g.
   Proof.
     intros H.
-    apply (grrcan (to_abgrop x y) h H).
+    apply (grrcan (to_abgr x y) h H).
   Qed.
 
   Lemma to_lrw {x y : PA} (f g h : PA⟦x, y⟧) (e : f = g) : to_binop x y f h = to_binop x y g h.
@@ -158,7 +158,7 @@ Section def_precategory_with_abgrops.
   Lemma to_assoc {x y : PA} (f g h : PA⟦x, y⟧) :
     to_binop _ _ (to_binop _ _ f g) h = to_binop _ _ f (to_binop _ _ g h).
   Proof.
-    apply (assocax (to_abgrop x y)).
+    apply (assocax (to_abgr x y)).
   Qed.
 
   Lemma to_binop_inv_inv {x y : PA} (f g : PA⟦x, y⟧) :
@@ -188,7 +188,7 @@ Arguments to_has_homsets [PA] _ _ _ _ _ _.
 Arguments to_homset [PA] _ _.
 Arguments to_setwithbinoppair [PA] _ _.
 Arguments to_isabgrop [PA] _ _.
-Arguments to_abgrop [PA] _ _.
+Arguments to_abgr [PA] _ _.
 Arguments to_unel [PA] _ _.
 Arguments to_lunax [PA] _ _ _.
 Arguments to_runax [PA] _ _ _.

--- a/UniMath/CategoryTheory/categories/abgrs.v
+++ b/UniMath/CategoryTheory/categories/abgrs.v
@@ -1486,7 +1486,7 @@ Section abgr_corollaries.
 
   Lemma AdditiveZeroArrow_postmor_Abelian {Add : Additive} (x y z : Add) :
     to_postmor_monoidfun Add x y z (ZeroArrow (Additive.to_Zero Add) y z) =
-    ZeroArrow (to_Zero abgr_Abelian) (@to_abgrop Add x y) (@to_abgrop Add x z).
+    ZeroArrow (to_Zero abgr_Abelian) (@to_abgr Add x y) (@to_abgr Add x z).
   Proof.
     rewrite <- PreAdditive_unel_zero.
     use monoidfun_paths. use funextfun. intros f. exact (to_premor_unel Add z f).
@@ -1494,7 +1494,7 @@ Section abgr_corollaries.
 
   Lemma AdditiveZeroArrow_premor_Abelian {Add : Additive} (x y z : Add) :
     to_premor_monoidfun Add x y z (ZeroArrow (Additive.to_Zero Add) x y) =
-    ZeroArrow (to_Zero abgr_Abelian) (@to_abgrop Add y z) (@to_abgrop Add x z).
+    ZeroArrow (to_Zero abgr_Abelian) (@to_abgr Add y z) (@to_abgr Add x z).
   Proof.
     rewrite <- PreAdditive_unel_zero.
     use monoidfun_paths. use funextfun. intros f. exact (to_postmor_unel Add x f).
@@ -1556,13 +1556,13 @@ Section abgr_corollaries.
         {f : x --> y}
         (H1 : @is_z_isomorphism abgr_Abelian _ _ (to_premor_monoidfun Add x y x f))
         (H2 : @is_z_isomorphism abgr_Abelian _ _ (to_postmor_monoidfun Add y x y f)) :
-    is_inverse_in_precat f ((is_z_isomorphism_mor H1 : monoidfun (to_abgrop x x) (to_abgrop y x))
-                              (identity x : to_abgrop x x)).
+    is_inverse_in_precat f ((is_z_isomorphism_mor H1 : monoidfun (to_abgr x x) (to_abgr y x))
+                              (identity x : to_abgr x x)).
   Proof.
-    set (mor1 := ((is_z_isomorphism_mor H1) : (monoidfun (to_abgrop x x) (to_abgrop y x)))
-                   ((identity x) : to_abgrop x x)).
-    set (mor2 := ((is_z_isomorphism_mor H2) : (monoidfun (to_abgrop y y) (to_abgrop y x)))
-                   ((identity y) : to_abgrop y y)).
+    set (mor1 := ((is_z_isomorphism_mor H1) : (monoidfun (to_abgr x x) (to_abgr y x)))
+                   ((identity x) : to_abgr x x)).
+    set (mor2 := ((is_z_isomorphism_mor H2) : (monoidfun (to_abgr y y) (to_abgr y x)))
+                   ((identity y) : to_abgr y y)).
     assert (Hx : f · mor1 = identity x).
     {
       exact (toforallpaths _ _ _ (base_paths _ _ (is_inverse_in_precat2 H1)) (identity x)).
@@ -1591,8 +1591,8 @@ Section abgr_corollaries.
     is_z_isomorphism f.
   Proof.
     use mk_is_z_isomorphism.
-    - exact (((is_z_isomorphism_mor H1) : (monoidfun (to_abgrop x x) (to_abgrop y x)))
-               ((identity x) : to_abgrop x x)).
+    - exact (((is_z_isomorphism_mor H1) : (monoidfun (to_abgr x x) (to_abgr y x)))
+               ((identity x) : to_abgr x x)).
     - exact (abgr_Additive_premor_postmor_is_iso_inverses _ _ H1 H2).
   Defined.
 

--- a/UniMath/CategoryTheory/limits/BinDirectSums.v
+++ b/UniMath/CategoryTheory/limits/BinDirectSums.v
@@ -569,9 +569,9 @@ Section bindirectsums_in_quot.
     use mk_isBinCoproduct.
     - apply has_homsets_Quotcategory.
     - intros c f g.
-      set (f'' := @issurjsetquotpr (@to_abgrop A x c) (binopeqrel_subgr_eqrel (PAS x c)) f).
+      set (f'' := @issurjsetquotpr (@to_abgr A x c) (binopeqrel_subgr_eqrel (PAS x c)) f).
       use (squash_to_prop f''). apply isapropiscontr. intros f'. clear f''.
-      set (g'' := @issurjsetquotpr (@to_abgrop A y c) (binopeqrel_subgr_eqrel (PAS y c)) g).
+      set (g'' := @issurjsetquotpr (@to_abgr A y c) (binopeqrel_subgr_eqrel (PAS y c)) g).
       use (squash_to_prop g''). apply isapropiscontr. intros g'. clear g''.
       induction f' as [f1 f2]. induction g' as [g1 g2]. cbn in f1, g1.
       use unique_exists.
@@ -583,7 +583,7 @@ Section bindirectsums_in_quot.
           rewrite BinDirectSumIn2Commutes. exact g2.
       + intros y0. apply isapropdirprod; apply has_homsets_Quotcategory.
       + intros y0 T. cbn beta in T. induction T as [T1 T2].
-        * set (y'' := @issurjsetquotpr (@to_abgrop A (BD x y) c)
+        * set (y'' := @issurjsetquotpr (@to_abgr A (BD x y) c)
                                        (binopeqrel_subgr_eqrel (PAS (BD x y) c)) y0).
           use (squash_to_prop y''). apply has_homsets_Quotcategory. intros y'. clear y''.
           induction y' as [y1 y2]. rewrite <- y2. rewrite <- y2 in T1. rewrite <- y2 in T2.
@@ -627,9 +627,9 @@ Section bindirectsums_in_quot.
     use mk_isBinProduct.
     - apply has_homsets_Quotcategory.
     - intros c f g.
-      set (f'' := @issurjsetquotpr (@to_abgrop A c x) (binopeqrel_subgr_eqrel (PAS c x)) f).
+      set (f'' := @issurjsetquotpr (@to_abgr A c x) (binopeqrel_subgr_eqrel (PAS c x)) f).
       use (squash_to_prop f''). apply isapropiscontr. intros f'. clear f''.
-      set (g'' := @issurjsetquotpr (@to_abgrop A c y) (binopeqrel_subgr_eqrel (PAS c y)) g).
+      set (g'' := @issurjsetquotpr (@to_abgr A c y) (binopeqrel_subgr_eqrel (PAS c y)) g).
       use (squash_to_prop g''). apply isapropiscontr. intros g'. clear g''.
       induction f' as [f1 f2]. induction g' as [g1 g2]. cbn in f1, g1.
       use unique_exists.
@@ -641,7 +641,7 @@ Section bindirectsums_in_quot.
           rewrite BinDirectSumPr2Commutes. exact g2.
       + intros y0. apply isapropdirprod; apply has_homsets_Quotcategory.
       + intros y0 T. cbn beta in T. induction T as [T1 T2].
-        * set (y'' := @issurjsetquotpr (@to_abgrop A c (BD x y))
+        * set (y'' := @issurjsetquotpr (@to_abgr A c (BD x y))
                                        (binopeqrel_subgr_eqrel (PAS c (BD x y))) y0).
           use (squash_to_prop y''). apply has_homsets_Quotcategory. intros y'. clear y''.
           induction y' as [y1 y2]. rewrite <- y2. rewrite <- y2 in T1. rewrite <- y2 in T2.

--- a/UniMath/HomologicalAlgebra/CohomologyComplex.v
+++ b/UniMath/HomologicalAlgebra/CohomologyComplex.v
@@ -1106,7 +1106,7 @@ Section def_cohomology_homotopy.
   Proof.
     set (inv := @to_inv (ComplexPreCat_Additive (AbelianToAdditive A hs)) _ _
                         (# (CohomologyFunctor_Additive A hs) g)).
-    set (tmp := @grrcan (@to_abgrop (ComplexPreCat_Additive (AbelianToAdditive A hs)) _ _)
+    set (tmp := @grrcan (@to_abgr (ComplexPreCat_Additive (AbelianToAdditive A hs)) _ _)
                         (# (CohomologyFunctor_Additive A hs) f)
                         (# (CohomologyFunctor_Additive A hs) g) inv).
     apply tmp. clear tmp. unfold inv. clear inv.

--- a/UniMath/HomologicalAlgebra/Complexes.v
+++ b/UniMath/HomologicalAlgebra/Complexes.v
@@ -487,7 +487,7 @@ Section def_complexes.
     intros M1 M2 M3.
     use MorphismEq.
     intros i. cbn.
-    apply (assocax (to_abgrop (C1 i) (C2 i))).
+    apply (assocax (to_abgr (C1 i) (C2 i))).
   Qed.
 
   Lemma MorphismOp_isunit (C1 C2 : Complex) :
@@ -543,7 +543,7 @@ Section def_complexes.
     intros M1 M2.
     use MorphismEq.
     intros i. cbn.
-    apply (commax (to_abgrop (C1 i) (C2 i)) (MMor M1 i) (MMor M2 i)).
+    apply (commax (to_abgr (C1 i) (C2 i)) (MMor M1 i) (MMor M2 i)).
   Qed.
 
   Definition MorphismOp_isabgrop (C1 C2 : Complex) : @isabgrop (Morphisms_hSet C1 C2) MorphismOp.

--- a/UniMath/HomologicalAlgebra/KA.v
+++ b/UniMath/HomologicalAlgebra/KA.v
@@ -150,7 +150,7 @@ Section complexes_homotopies.
 
   (** This lemma shows that the subset [ComplexHomotSubset] satisfies the axioms of a subgroup. *)
   Lemma ComplexHomotisSubgrop (C1 C2 : Complex A) :
-    @issubgr (@to_abgrop (ComplexPreCat_Additive A) C1 C2) (ComplexHomotSubset C1 C2).
+    @issubgr (@to_abgr (ComplexPreCat_Additive A) C1 C2) (ComplexHomotSubset C1 C2).
   Proof.
     use tpair.
     - use tpair.
@@ -198,10 +198,10 @@ Section complexes_homotopies.
             induction (hzrminusplus i 1). apply idpath.
           }
           cbn in e1. rewrite e1. clear e1.
-          set (tmp := @assocax (@to_abgrop A (C1 i) (C2 i))). cbn in tmp.
+          set (tmp := @assocax (@to_abgr A (C1 i) (C2 i))). cbn in tmp.
           rewrite tmp. rewrite tmp. apply maponpaths.
           rewrite <- tmp. rewrite <- tmp.
-          set (tmp' := @commax (@to_abgrop A (C1 i) (C2 i))). cbn in tmp'.
+          set (tmp' := @commax (@to_abgr A (C1 i) (C2 i))). cbn in tmp'.
           rewrite tmp'.
           rewrite (tmp' _ (transportf (precategory_morphisms (C1 i))
                                       (maponpaths C2 (hzrplusminus i 1))
@@ -219,13 +219,13 @@ Section complexes_homotopies.
     - intros f H. use (squash_to_prop H). apply propproperty. intros H'. clear H.
       induction H' as [homot eq]. use hinhpr.
       use tpair.
-      + intros i. exact (grinv (to_abgrop (C1 i) (C2 (i - 1))) (homot i)).
+      + intros i. exact (grinv (to_abgr (C1 i) (C2 (i - 1))) (homot i)).
       + cbn. rewrite <- eq. use MorphismEq. intros i. cbn.
         set (tmp := @PreAdditive_invrcomp A _ _ _ (Diff C1 i) (homot (i + 1))).
         unfold to_inv in tmp. cbn in tmp. cbn. rewrite <- tmp. clear tmp.
         assert (e0 : (transportf (precategory_morphisms (C1 i))
                                  (maponpaths C2 (hzrplusminus i 1))
-                                 (grinv (to_abgrop (C1 i) (C2 (i + 1 - 1)))
+                                 (grinv (to_abgr (C1 i) (C2 (i + 1 - 1)))
                                         (Diff C1 i · homot (i + 1)))) =
                      to_inv (transportf (precategory_morphisms (C1 i))
                                         (maponpaths C2 (hzrplusminus i 1))
@@ -235,7 +235,7 @@ Section complexes_homotopies.
         }
         cbn in e0. rewrite e0. clear e0.
         assert (e1 : (transportf (precategory_morphisms (C1 i)) (maponpaths C2 (hzrminusplus i 1))
-                                 (grinv (to_abgrop (C1 i) (C2 (i - 1)))
+                                 (grinv (to_abgr (C1 i) (C2 (i - 1)))
                                         (homot i) · Diff C2 (i - 1))) =
                      to_inv (transportf (precategory_morphisms (C1 i))
                                         (maponpaths C2 (hzrminusplus i 1))
@@ -248,14 +248,14 @@ Section complexes_homotopies.
           apply tmp.
         }
         cbn in e1. rewrite e1. clear e1.
-        set (tmp' := @commax (@to_abgrop A (C1 i) (C2 i))). cbn in tmp'. rewrite tmp'. clear tmp'.
-        set (tmp := @grinvop (@to_abgrop A (C1 i) (C2 i))). cbn in tmp. unfold to_inv.
+        set (tmp' := @commax (@to_abgr A (C1 i) (C2 i))). cbn in tmp'. rewrite tmp'. clear tmp'.
+        set (tmp := @grinvop (@to_abgr A (C1 i) (C2 i))). cbn in tmp. unfold to_inv.
         apply pathsinv0.
         apply tmp.
   Qed.
 
   Definition ComplexHomotSubgrp (C1 C2 : Complex A) :
-    @subabgr (@to_abgrop (ComplexPreCat_Additive A) C1 C2).
+    @subabgr (@to_abgr (ComplexPreCat_Additive A) C1 C2).
   Proof.
     use subgrconstr.
     - exact (ComplexHomotSubset C1 C2).

--- a/UniMath/HomologicalAlgebra/KAPreTriangulated.v
+++ b/UniMath/HomologicalAlgebra/KAPreTriangulated.v
@@ -106,7 +106,7 @@ Section KAPreTriangulated.
 
   Local Opaque ComplexHomotFunctor ComplexHomotSubset Quotcategory identity
         MappingConePr1 MappingConeIn2 RotMorphism RotMorphismInv InvRotMorphism InvRotMorphismInv
-        to_inv compose pathsinv0 pathscomp0 ishinh to_abgrop.
+        to_inv compose pathsinv0 pathscomp0 ishinh to_abgr.
 
   Definition MappingConeTri {x y : ob (ComplexHomot_Additive A)} (f : x --> y)
              (f' : hfiber (# (ComplexHomotFunctor A)) f) :

--- a/UniMath/HomologicalAlgebra/KATriangulated.v
+++ b/UniMath/HomologicalAlgebra/KATriangulated.v
@@ -64,7 +64,7 @@ Section KATriangulated.
 
   Local Opaque ComplexHomotFunctor ComplexHomotSubset Quotcategory identity
         MappingConePr1 MappingConeIn2 RotMorphism RotMorphismInv InvRotMorphism InvRotMorphismInv
-        to_inv compose to_abgrop pathsinv0 pathscomp0 ishinh.
+        to_inv compose to_abgr pathsinv0 pathscomp0 ishinh.
 
   Definition KATriangOcta_TriIso {x y z : ob (@KAPreTriang A)} {f1 : x --> y} {g1 : y --> z}
              (f1' : hfiber # (ComplexHomotFunctor A) f1)

--- a/UniMath/HomologicalAlgebra/Triangulated.v
+++ b/UniMath/HomologicalAlgebra/Triangulated.v
@@ -1252,9 +1252,9 @@ Section short_short_exact_sequences.
     @MorphismPair abgr_Abelian.
   Proof.
     use mk_MorphismPair.
-    - exact (@to_abgrop PT X (Ob1 D)).
-    - exact (@to_abgrop PT X (Ob2 D)).
-    - exact (@to_abgrop PT X (Ob3 D)).
+    - exact (@to_abgr PT X (Ob1 D)).
+    - exact (@to_abgr PT X (Ob2 D)).
+    - exact (@to_abgr PT X (Ob3 D)).
     - exact (to_postmor_monoidfun PT X (Ob1 D) (Ob2 D) (Mor1 D)).
     - exact (to_postmor_monoidfun PT X (Ob2 D) (Ob3 D) (Mor2 D)).
   Defined.
@@ -1262,7 +1262,7 @@ Section short_short_exact_sequences.
   Local Lemma ShortShortExactData_Eq_from_object (D : @DTri PT) (X : ob PT):
     monoidfuncomp (to_postmor_monoidfun PT X (Ob1 D) (Ob2 D) (Mor1 D))
                   (to_postmor_monoidfun PT X (Ob2 D) (Ob3 D) (Mor2 D)) =
-    ZeroArrow abgr_Zero (to_abgrop X (Ob1 D)) (to_abgrop X (Ob3 D)).
+    ZeroArrow abgr_Zero (to_abgr X (Ob1 D)) (to_abgr X (Ob3 D)).
   Proof.
     cbn. rewrite <- (@AdditiveZeroArrow_postmor_Abelian PT).
     use monoidfun_paths. use funextfun. intros x. cbn. unfold to_postmor.
@@ -1325,9 +1325,9 @@ Section short_short_exact_sequences.
   Definition MorphismPair_to_object (D : @DTri PT) (X : ob PT) : @MorphismPair abgr_Abelian.
   Proof.
     use mk_MorphismPair.
-    - exact (@to_abgrop PT (Ob3 D) X).
-    - exact (@to_abgrop PT (Ob2 D) X).
-    - exact (@to_abgrop PT (Ob1 D) X).
+    - exact (@to_abgr PT (Ob3 D) X).
+    - exact (@to_abgr PT (Ob2 D) X).
+    - exact (@to_abgr PT (Ob1 D) X).
     - exact (to_premor_monoidfun PT (Ob2 D) (Ob3 D) X (Mor2 D)).
     - exact (to_premor_monoidfun PT (Ob1 D) (Ob2 D) X (Mor1 D)).
   Defined.
@@ -1335,7 +1335,7 @@ Section short_short_exact_sequences.
   Local Lemma ShortShortExactData_Eq_to_object (D : @DTri PT) (X : ob PT) :
     monoidfuncomp (to_premor_monoidfun PT (Ob2 D) (Ob3 D) X (Mor2 D))
                   (to_premor_monoidfun PT (Ob1 D) (Ob2 D) X (Mor1 D)) =
-    ZeroArrow (Abelian.to_Zero abgr_Abelian) (to_abgrop (Ob3 D) X) (to_abgrop (Ob1 D) X).
+    ZeroArrow (Abelian.to_Zero abgr_Abelian) (to_abgr (Ob3 D) X) (to_abgr (Ob1 D) X).
   Proof.
     rewrite <- (@AdditiveZeroArrow_premor_Abelian PT).
     use monoidfun_paths. use funextfun. intros x. cbn. unfold to_premor. rewrite assoc.
@@ -1416,11 +1416,11 @@ Section triangulated_five_lemma.
     @FiveRowObs abgr_Abelian.
   Proof.
     use mk_FiveRowObs.
-    - exact (to_abgrop X (Ob1 D)).
-    - exact (to_abgrop X (Ob2 D)).
-    - exact (to_abgrop X (Ob3 D)).
-    - exact (to_abgrop X (AddEquiv1 Trans (Ob1 D))).
-    - exact (to_abgrop X (AddEquiv1 Trans (Ob2 D))).
+    - exact (to_abgr X (Ob1 D)).
+    - exact (to_abgr X (Ob2 D)).
+    - exact (to_abgr X (Ob3 D)).
+    - exact (to_abgr X (AddEquiv1 Trans (Ob1 D))).
+    - exact (to_abgr X (AddEquiv1 Trans (Ob2 D))).
   Defined.
 
   Definition TriangulatedRowDiffs_from_object (D : @DTri PT) (X : ob PT) :
@@ -1512,11 +1512,11 @@ Section triangulated_five_lemma.
   Definition TriangulatedRowObs_to_object (D : @DTri PT) (X : ob PT) : @FiveRowObs abgr_Abelian.
   Proof.
     use mk_FiveRowObs.
-    - exact (to_abgrop (AddEquiv1 Trans (Ob2 D)) X).
-    - exact (to_abgrop (AddEquiv1 Trans (Ob1 D)) X).
-    - exact (to_abgrop (Ob3 D) X).
-    - exact (to_abgrop (Ob2 D) X).
-    - exact (to_abgrop (Ob1 D) X).
+    - exact (to_abgr (AddEquiv1 Trans (Ob2 D)) X).
+    - exact (to_abgr (AddEquiv1 Trans (Ob1 D)) X).
+    - exact (to_abgr (Ob3 D) X).
+    - exact (to_abgr (Ob2 D) X).
+    - exact (to_abgr (Ob1 D) X).
   Defined.
 
   Definition TriangulatedRowDiffs_to_object (D : @DTri PT) (X : ob PT) :


### PR DESCRIPTION
We change
```
  Definition to_abgrop (x y : PA) : abgr := abgrpair (to_setwithbinoppair x y) (to_isabgrop x y).
```
to
```
  Definition to_abgr (x y : PA) : abgr := abgrpair (to_setwithbinoppair x y) (to_isabgrop x y).
```
, because the value returned is an abelian group (as in abgr), not an
abelian group operation (as in isabgrop).