### PR TITLE
change parsing precedence of --> and <--

### DIFF
--- a/UniMath/Foundations/Init.v
+++ b/UniMath/Foundations/Init.v
@@ -68,7 +68,7 @@ Reserved Notation "f ;; g"  (at level 50, left associativity, only parsing). (* 
 Reserved Notation "f · g"  (at level 40, format "f  ·  g", left associativity).
 (* to input: type "\centerdot" or "\cdot" with Agda input method *)
 
-Reserved Notation "a --> b" (at level 50, left associativity).
+Reserved Notation "a --> b" (at level 55).
 
 Reserved Notation "! p " (at level 50, left associativity).
 
@@ -81,7 +81,7 @@ Reserved Notation "p #' x" (right associativity, at level 65, only parsing).
 
 Reserved Notation "C '^op'" (at level 3, format "C ^op").
 
-Reserved Notation "a <-- b" (at level 50, left associativity).
+Reserved Notation "a <-- b" (at level 55).
 
 Reserved Notation "[ C , D ]" .
 

--- a/UniMath/Ktheory/Precategories.v
+++ b/UniMath/Ktheory/Precategories.v
@@ -13,7 +13,7 @@ Require Import UniMath.MoreFoundations.Tactics.
 
 Local Open Scope cat.
 
-Notation "a <-- b" := (@precategory_morphisms (opp_precat _) a b) (at level 50, left associativity) : cat.
+Notation "a <-- b" := (@precategory_morphisms (opp_precat _) a b) : cat.
 
 Definition src {C:precategory} {a b:C} (f:a-->b) : C := a.
 Definition tar {C:precategory} {a b:C} (f:a-->b) : C := b.


### PR DESCRIPTION
The parsing precedence of --> is the same as that of binary operators
such as + and ⊕, but it should be a little looser, so we could write
A⊕B-->C⊕D without parentheses.

resolves #1027

    -Reserved Notation "a --> b" (at level 50, left associativity).
    +Reserved Notation "a --> b" (at level 55).

    -Reserved Notation "a <-- b" (at level 50, left associativity).
    +Reserved Notation "a <-- b" (at level 55).