### PR TITLE
fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ DEPFILES := $(VFILES:.v=.v.d)
 endif
 
 # DEPFILES is defined above
-$(DEPFILES): | build/CoqMakefile.make
+$(DEPFILES): make-summary-files | build/CoqMakefile.make
 	$(MAKE) -f build/CoqMakefile.make $@
 
 # here we ensure that the travis script checks every package


### PR DESCRIPTION
See https://github.com/UniMath/UniMath/pull/1056#issuecomment-439561519

The problem is that a pull request can add a new package but omit providing the
new All.v for the package, even though "git status" warns about the existence
of the new file, and then .  To fix it, we make the dependencies file
`.coqdeps.d` depend on the previous existence of all the package All.v files.