### PR TITLE
Move definition of subsets from RealNumbers to MoreFoundations

### DIFF
--- a/UniMath/MoreFoundations/Sets.v
+++ b/UniMath/MoreFoundations/Sets.v
@@ -1,4 +1,15 @@
+(** ** More results on sets *)
+
 Require Export UniMath.MoreFoundations.Propositions.
+Require Export UniMath.Foundations.Sets.
+
+(** ** Contents
+
+  - (More entries need to be added here...)
+  - Other universal properties for [setquot]
+  - The equivalence relation of being in the same fiber
+  - Subsets
+ *)
 
 Local Open Scope set.
 
@@ -61,6 +72,8 @@ Proof.
   intros x x' r. exact (Hg _ _ (Hf x x' r)).
 Defined.
 
+(** ** Other universal properties for [setquot] *)
+
 Theorem setquotunivprop' {X : UU} {R : eqrel X} (P : setquot (pr1 R) -> UU)
         (H : ∏ x, isaprop (P x)) (ps : ∏ x : X, P (setquotpr R x)) : ∏ c : setquot (pr1 R), P c.
 Proof.
@@ -108,3 +121,11 @@ Proof.
     + intro; reflexivity.
     + intros ? ? eq; exact (!eq).
 Defined.
+
+(** ** Subsets *)
+
+Definition subset {X : hSet} (Hsub : hsubtype X) : hSet :=
+  hSetpair (carrier Hsub) (isaset_carrier_subset _ Hsub).
+
+Definition makeSubset {X : hSet} {Hsub : hsubtype X} (x : X) (Hx : Hsub x) : subset Hsub :=
+  x,, Hx.

--- a/UniMath/RealNumbers/NonnegativeRationals.v
+++ b/UniMath/RealNumbers/NonnegativeRationals.v
@@ -4,6 +4,7 @@ Unset Kernel Term Sharing.
 
 Require Import UniMath.MoreFoundations.Tactics.
 Require Import UniMath.MoreFoundations.PartA.
+Require Import UniMath.MoreFoundations.Sets.
 
 Require Import UniMath.RealNumbers.Sets.
 Require Import UniMath.RealNumbers.Fields.

--- a/UniMath/RealNumbers/Sets.v
+++ b/UniMath/RealNumbers/Sets.v
@@ -3,22 +3,12 @@
 (** Previous theorems about hSet and order *)
 
 Require Import UniMath.MoreFoundations.Tactics.
+Require Import UniMath.MoreFoundations.Sets.
 
 Require Export UniMath.Foundations.Sets
                UniMath.Ktheory.QuotientSet.
 Require Import UniMath.Algebra.BinaryOperations
                UniMath.Algebra.Apartness.
-
-(** ** Subsets *)
-
-Lemma isaset_hsubtype {X : hSet} (Hsub : hsubtype X) : isaset (carrier Hsub).
-Proof.
-  apply (isasetsubset pr1 (pr2 X) (isinclpr1 (λ x : X, Hsub x) (λ x : X, pr2 (Hsub x)))).
-Qed.
-Definition subset {X : hSet} (Hsub : hsubtype X) : hSet :=
-  hSetpair (carrier Hsub) (isaset_hsubtype Hsub).
-Definition makeSubset {X : hSet} {Hsub : hsubtype X} (x : X) (Hx : Hsub x) : subset Hsub :=
-  x,, Hx.
 
 (** ** Additional definitions *)
 


### PR DESCRIPTION
Adds a TOC and removes a duplicate result as well. 