### PR TITLE
Use disp_lunitor_runitor_identity (from DispBicat) in DispUnivalence.

### DIFF
--- a/UniMath/CategoryTheory/Bicategories/DispBicat.v
+++ b/UniMath/CategoryTheory/Bicategories/DispBicat.v
@@ -1265,10 +1265,23 @@ Proof.
   cbn in TT.
   apply cell_transportf_to_b.
   etrans.
-  2: apply TT.
+  2: now apply TT.
   unfold cell_transportf.
   apply maponpaths_2.
   apply cellset_property.
+Qed.
+
+Theorem disp_runitor_lunitor_identity {C : bicat} {D : disp_bicat C} {a : C} (aa : D a)
+  : disp_runitor (id_disp aa) =
+    transportb (λ x, disp_2cells x _ _) (runitor_lunitor_identity a)
+               (disp_lunitor (id_disp aa)).
+Proof.
+  apply (transportf_transpose (P := (λ x, disp_2cells x _ _))).
+  apply pathsinv0.
+  etrans.
+  1: now apply disp_lunitor_runitor_identity.
+  unfold cell_transportb.
+  apply maponpaths_2, cellset_property.
 Qed.
 
 (* -----------------------------------------------------------------------------------*)

--- a/UniMath/CategoryTheory/Bicategories/DispUnivalence.v
+++ b/UniMath/CategoryTheory/Bicategories/DispUnivalence.v
@@ -149,37 +149,6 @@ Proof.
   apply (disp_lunitor _ ).
 Defined.
 
-
-Definition disp_lunitor_runitor_identity_type {a : C} (aa : D a)
-  : UU
-  := disp_lunitor (id_disp aa) =
-     transportb (λ x, _ ==>[x] _) (lunitor_runitor_identity a)
-                (disp_runitor (id_disp aa)).
-
-Theorem disp_lunitor_runitor_identity {a : C} (aa : D a)
-  : disp_lunitor_runitor_identity_type aa.
-Proof.
-Abort.
-
-(** Once the theorem above is proved, remove this section and its assumption. *)
-
-Section assume_disp_lunitor_runitor_identity.
-
-Variable disp_lunitor_runitor_identity :
-  ∏ {a : C} (aa : D a), disp_lunitor_runitor_identity_type aa.
-
-Theorem disp_runitor_lunitor_identity {a : C} (aa : D a)
-  : disp_runitor (id_disp aa) =
-    transportb (λ x, _ ==>[x] _) (runitor_lunitor_identity a)
-               (disp_lunitor (id_disp aa)).
-Proof.
-  apply (transportf_transpose (P := λ x, _ ==>[x] _)).
-  apply pathsinv0.
-  etrans. apply disp_lunitor_runitor_identity.
-  apply maponpaths_2.
-  apply cellset_property.
-Qed.
-
 Lemma disp_rwhisker_transport_left {a b c : C}
       {f1 f2 : C⟦a,b⟧} {g : C⟦b,c⟧}
       {x x' : f1 ==> f2} (p : x = x')
@@ -222,7 +191,13 @@ Proof.
   induction p. apply idpath.
 Defined.
 
-Definition is_disp_internal_adjunction_identity {a : C} (aa : D a)
+End Displayed_Internal_Adjunction.
+
+(** From now on, we need the [has_disp_cellset property]. *)
+
+Definition is_disp_internal_adjunction_identity
+           {C : bicat} {D : disp_bicat C}
+           {a : C} (aa : D a)
   : is_disp_internal_adjunction (disp_internal_adjunction_data_identity aa).
 Proof.
   split.
@@ -344,7 +319,3 @@ Proof.
     apply maponpaths_2.
     apply cellset_property.
 Qed.
-
-End assume_disp_lunitor_runitor_identity.
-
-End Displayed_Internal_Adjunction.

--- a/UniMath/Paradoxes/All.v
+++ b/UniMath/Paradoxes/All.v
@@ -1,0 +1,2 @@
+(* This file has been auto-generated, do not edit it. *)
+Require Export UniMath.Paradoxes.GirardsParadox.


### PR DESCRIPTION
Also use disp_bicats instead of disp_prebicats in the statement of
is_disp_internal_adjunction_identity .