### PR TITLE
Fixed the definition of lax functor (reverse order of arrows)

### DIFF
--- a/UniMath/CategoryTheory/Bicategories/BicatOfCats.v
+++ b/UniMath/CategoryTheory/Bicategories/BicatOfCats.v
@@ -141,7 +141,8 @@ Proof.
   - intros C D F. cbn in *.
     apply nat_trans_eq; [apply (homset_property (op_cat D) )|].
     intro. cbn. apply pathsinv0.
-    rewrite id_left. rewrite id_right. apply functor_id.
+    rewrite !id_left.
+    apply functor_id.
   - intros C D F. cbn in *.
     apply nat_trans_eq; [apply (homset_property (op_cat D) )|].
     intro. cbn. apply pathsinv0.

--- a/UniMath/CategoryTheory/Bicategories/DispBicat.v
+++ b/UniMath/CategoryTheory/Bicategories/DispBicat.v
@@ -1179,12 +1179,8 @@ Proof.
     rewrite id2_left.
     rewrite id2_left.
     apply idpath.
-  - rewrite id2_right.
-    rewrite id2_left.
-    rewrite id2_rwhisker.
-    rewrite lwhisker_id2.
-    rewrite id2_left.
-    rewrite id2_right.
+  - rewrite !lwhisker_id2, !id2_rwhisker.
+    rewrite !id2_left, !id2_right.
     apply idpath.
   - rewrite id2_right.
     rewrite id2_left.

--- a/UniMath/CategoryTheory/Bicategories/PseudoFunctor.v
+++ b/UniMath/CategoryTheory/Bicategories/PseudoFunctor.v
@@ -42,9 +42,9 @@ Local Notation "'##'" := (laxfunctor_on_cells).
 
 Definition laxfunctor_cell_data {C C' : prebicat_data} (F : laxfunctor_ob_mor_cell C C')
   : UU
-  :=   (∏ (a : C), #F (identity a) ==> identity _)
+  :=   (∏ (a : C), identity (F a) ==> #F (identity a))
      × (∏ (a b c : C) (f : a --> b) (g : b --> c),
-        #F (f · g) ==> #F f · #F g).
+        #F f · #F g ==> #F (f · g)).
 
 Definition laxfunctor_data (C C' : prebicat_data) : UU
   := ∑ F : laxfunctor_ob_mor_cell C C', laxfunctor_cell_data F.
@@ -55,12 +55,12 @@ Coercion laxfunctor_ob_mor_cell_from_bifunctor_data {C C' : prebicat_data}
   := pr1 F.
 
 Definition laxfunctor_id {C C' : prebicat_data} (F : laxfunctor_data C C') (a : C)
-  : #F (identity a) ==> identity _
+  : identity (F a) ==> #F (identity a)
   := pr1 (pr2 F) a.
 
 Definition laxfunctor_comp {C C' : prebicat_data} (F : laxfunctor_data C C')
            {a b c : C} (f : a --> b) (g : b --> c)
-  : #F (f · g) ==> #F f · #F g
+  : #F f · #F g ==> #F (f · g)
   := pr2 (pr2 F) a b c f g.
 
 (** A builder function for lax functor data. *)
@@ -69,9 +69,9 @@ Definition build_laxfunctor_data
            (F₀ : C → C')
            (F₁ : ∏ {a b : C}, C⟦a,b⟧ → C'⟦F₀ a, F₀ b⟧)
            (F₂ : ∏ {a b : C} {f g : C⟦a,b⟧}, f ==> g → F₁ f ==> F₁ g)
-           (Fid : ∏ (a : C), F₁ (identity a) ==> identity _)
+           (Fid : ∏ (a : C), identity (F₀ a) ==> F₁ (identity a))
            (Fcomp : (∏ (a b c : C) (f : a --> b) (g : b --> c),
-                     F₁ (f · g) ==> F₁ f · F₁ g))
+                     F₁ f · F₁ g ==> F₁ (f · g)))
   : laxfunctor_data C C'.
 Proof.
   use tpair.
@@ -98,40 +98,41 @@ Definition laxfunctor_vcomp2_law : UU
 
 Definition laxfunctor_lunitor_law : UU
   := ∏ (a b : C) (f : C⟦a, b⟧),
-       ##F (lunitor f)
-     =   laxfunctor_comp F (identity a) f
-       • (laxfunctor_id _ _ ▹ #F f)
-       • lunitor (#F f).
+     lunitor (#F f)
+     =
+     (laxfunctor_id F a ▹ #F f)
+       • laxfunctor_comp F (identity a) f
+       • ##F (lunitor f).
 
 Definition laxfunctor_runitor_law : UU
   := ∏ (a b : C) (f : C⟦a, b⟧),
-       ##F (runitor f)
-     =   laxfunctor_comp F f (identity b)
-       • (#F f ◃ laxfunctor_id _ _)
-       • runitor (#F f).
+     runitor (#F f)
+     =
+     (#F f ◃ laxfunctor_id F b)
+       • laxfunctor_comp F f (identity b)
+       • ##F (runitor f).
 
 Definition laxfunctor_lassociator_law : UU
-  := ∏ (a b c d : C) (f : C⟦a, b⟧) (g : C⟦b, c⟧) (h : C⟦c, d⟧) ,
-       ##F (lassociator f g h)
-       • (laxfunctor_comp F _ _)
-       • ((laxfunctor_comp F _ _) ▹ #F _)
-     =   laxfunctor_comp F _ _
-       • (#F f ◃ laxfunctor_comp F _ _)
-       • lassociator (#F f) (#F g) (#F h).
+  := ∏ (a b c d : C) (f : C⟦a, b⟧) (g : C⟦b, c⟧) (h : C⟦c, d⟧),
+     (#F f ◃ laxfunctor_comp F g h)
+       • laxfunctor_comp F f (g · h)
+       • ##F (lassociator f g h)
+     =
+     (lassociator (#F f) (#F g) (#F h))
+       • (laxfunctor_comp F f g ▹ #F h)
+       • laxfunctor_comp F (f · g) h.
 
 Definition laxfunctor_lwhisker_law : UU
-  := ∏ (a b c : C) (f : C⟦a, b⟧) (g1 g2 : C⟦b, c⟧) (η : g1 ==> g2),
-       ##F (f ◃ η)
-       • laxfunctor_comp F _ _
-     =   laxfunctor_comp F _ _
-       • (#F f ◃ ##F η).
+  := ∏ (a b c : C) (f : C⟦a, b⟧) (g₁ g₂ : C⟦b, c⟧) (η : g₁ ==> g₂),
+     laxfunctor_comp F f g₁ • ##F (f ◃ η)
+     =
+     #F f ◃ ##F η • laxfunctor_comp F f g₂.
 
 Definition laxfunctor_rwhisker_law : UU
-  := ∏ (a b c : C) (f1 f2 : C⟦a, b⟧) (g : C⟦b, c⟧) (η : f1 ==> f2),
-       ##F (η ▹ g)
-       • laxfunctor_comp F _ _
-     =   laxfunctor_comp F _ _
-       • (##F η ▹ #F g).
+  := ∏ (a b c : C) (f₁ f₂ : C⟦a, b⟧) (g : C⟦b, c⟧) (η : f₁ ==> f₂),
+     laxfunctor_comp F f₁ g • ##F (η ▹ g)
+     =
+     ##F η ▹ #F g • laxfunctor_comp F f₂ g.
 
 Definition laxfunctor_laws : UU
   :=   laxfunctor_id2_law
@@ -157,54 +158,55 @@ Section Projection.
   Variable (F : laxfunctor C C').
 
   Definition laxfunctor_id2
-    : ∏ (a b : C) (f : a --> b), ##F (id2 f) = id2 (#F f)
+    : ∏ {a b : C} (f : a --> b), ##F (id2 f) = id2 (#F f)
     := pr1(pr2 F).
 
   Definition laxfunctor_vcomp
-    : ∏ (a b : C) (f g h: C⟦a, b⟧) (η : f ==> g) (φ : g ==> h),
+    : ∏ {a b : C} {f g h : C⟦a, b⟧} (η : f ==> g) (φ : g ==> h),
       ##F (η • φ) = ##F η • ##F φ
     := pr1(pr2(pr2 F)).
 
   Definition laxfunctor_lunitor
-    : ∏ (a b : C) (f : C⟦a, b⟧),
-       ##F (lunitor f)
-     =   laxfunctor_comp F (identity a) f
-       • (laxfunctor_id _ _ ▹ #F f)
-       • lunitor (#F f)
+    : ∏ {a b : C} (f : C⟦a, b⟧),
+      lunitor (#F f)
+      =
+      (laxfunctor_id F a ▹ #F f)
+        • laxfunctor_comp F (identity a) f
+        • ##F (lunitor f)
     := pr1(pr2(pr2(pr2 F))).
 
   Definition laxfunctor_runitor
-    : ∏ (a b : C) (f : C⟦a, b⟧),
-       ##F (runitor f)
-     =   laxfunctor_comp F f (identity b)
-       • (#F f ◃ laxfunctor_id _ _)
-       • runitor (#F f)
+    : ∏ {a b : C} (f : C⟦a, b⟧),
+      runitor (#F f)
+      =
+      (#F f ◃ laxfunctor_id F b)
+        • laxfunctor_comp F f (identity b)
+        • ##F (runitor f)
     := pr1(pr2(pr2(pr2(pr2 F)))).
 
   Definition laxfunctor_lassociator
-    : ∏ (a b c d : C) (f : C⟦a, b⟧) (g : C⟦b, c⟧) (h : C⟦c, d⟧) ,
-       ##F (lassociator f g h)
-       • (laxfunctor_comp F _ _)
-       • ((laxfunctor_comp F _ _) ▹ #F _)
-     =   laxfunctor_comp F _ _
-       • (#F f ◃ laxfunctor_comp F _ _)
-       • lassociator (#F f) (#F g) (#F h)
+    : ∏ {a b c d : C} (f : C⟦a, b⟧) (g : C⟦b, c⟧) (h : C⟦c, d⟧) ,
+      (#F f ◃ laxfunctor_comp F g h)
+        • laxfunctor_comp F f (g · h)
+        • ##F (lassociator f g h)
+      =
+      (lassociator (#F f) (#F g) (#F h))
+        • (laxfunctor_comp F f g ▹ #F h)
+        • laxfunctor_comp F (f · g) h
     := pr1(pr2(pr2(pr2(pr2(pr2 F))))).
 
   Definition laxfunctor_lwhisker
-    : ∏ (a b c : C) (f : C⟦a, b⟧) (g1 g2 : C⟦b, c⟧) (η : g1 ==> g2),
-       ##F (f ◃ η)
-       • laxfunctor_comp F _ _
-     =   laxfunctor_comp F _ _
-       • (#F f ◃ ##F η)
+    : ∏ {a b c : C} (f : C⟦a, b⟧) {g₁ g₂ : C⟦b, c⟧} (η : g₁ ==> g₂),
+      laxfunctor_comp F f g₁ • ##F (f ◃ η)
+      =
+      #F f ◃ ##F η • laxfunctor_comp F f g₂
     := pr1(pr2(pr2(pr2(pr2(pr2(pr2 F)))))).
 
   Definition laxfunctor_rwhisker
-    : ∏ (a b c : C) (f1 f2 : C⟦a, b⟧) (g : C⟦b, c⟧) (η : f1 ==> f2),
-       ##F (η ▹ g)
-       • laxfunctor_comp F _ _
-     =   laxfunctor_comp F _ _
-       • (##F η ▹ #F g)
+    : ∏ {a b c : C} {f₁ f₂ : C⟦a, b⟧} (g : C⟦b, c⟧) (η : f₁ ==> f₂),
+      laxfunctor_comp F f₁ g • ##F (η ▹ g)
+      =
+      ##F η ▹ #F g • laxfunctor_comp F f₂ g
     := pr2(pr2(pr2(pr2(pr2(pr2(pr2 F)))))).
 End Projection.
 
@@ -224,6 +226,102 @@ Proof.
     + apply invertible_2cell_after_inv_cell.
     + apply inv_cell_after_invertible_2cell.
 Defined.
+
+Section LaxFunctorDerivedLaws.
+  Context {C C' : bicat}.
+  Variable (F : laxfunctor C C').
+
+  Definition laxfunctor_linvunitor
+             {a b : C}
+             (f : C⟦a, b⟧)
+  : ##F (linvunitor f)
+    =
+    (linvunitor (#F f))
+      • ((laxfunctor_id F a) ▹ #F f)
+      • (laxfunctor_comp F _ _).
+  Proof.
+    rewrite !vassocl.
+    cbn.
+    use vcomp_move_L_pM.
+    { is_iso. }
+    cbn.
+    use vcomp_move_R_Mp.
+    {
+      refine (laxfunctor_is_iso F (linvunitor f ,, _)).
+      is_iso.
+    }
+    cbn.
+    rewrite laxfunctor_lunitor ; cbn.
+    rewrite <- !vassocr.
+    reflexivity.
+  Qed.
+
+  Definition psfunctor_rinvunitor
+             (a b : C)
+             (f : C⟦a, b⟧)
+    : ##F (rinvunitor f)
+      =
+      (rinvunitor (#F f))
+        • (#F f ◃ laxfunctor_id F b)
+        • laxfunctor_comp F _ _.
+  Proof.
+    rewrite !vassocl.
+    use vcomp_move_L_pM.
+    { is_iso. }
+    cbn.
+    use vcomp_move_R_Mp.
+    {
+      refine (laxfunctor_is_iso F (rinvunitor f ,, _)).
+      is_iso.
+    }
+    cbn.
+    rewrite laxfunctor_runitor ; cbn.
+    rewrite <- !vassocr.
+    reflexivity.
+  Qed.
+
+  Definition laxfunctor_rassociator
+             {a b c d : C}
+             (f : C⟦a, b⟧) (g : C⟦b, c⟧) (h : C⟦c, d⟧)
+    : (laxfunctor_comp F f g ▹ #F h)
+        • laxfunctor_comp F (f · g) h
+        • ##F (rassociator f g h)
+      =
+      (rassociator (#F f) (#F g) (#F h))
+        • (#F f ◃ laxfunctor_comp F g h)
+        • laxfunctor_comp F f (g · h).
+  Proof.
+    rewrite !vassocl.
+    use vcomp_move_L_pM.
+    { is_iso. }
+    cbn.
+    rewrite !vassocr.
+    use vcomp_move_R_Mp.
+    { refine (laxfunctor_is_iso F (rassociator f g h ,, _)).
+      is_iso.
+    }
+    cbn.
+    symmetry.
+    exact (laxfunctor_lassociator F f g h).
+  Qed.
+
+  Definition laxfunctor_comp_natural
+             {a b c : C}
+             {g₁ g₂ : C⟦b,c⟧} {f₁ f₂ : C⟦a,b⟧}
+             (ηg : g₁ ==> g₂) (ηf : f₁ ==> f₂)
+    : laxfunctor_comp F f₁ g₁ • ##F (ηf ⋆ ηg)
+      =
+      (##F ηf) ⋆ (##F ηg) • laxfunctor_comp F f₂ g₂.
+  Proof.
+    unfold hcomp.
+    rewrite !laxfunctor_vcomp.
+    rewrite !vassocr.
+    rewrite laxfunctor_rwhisker.
+    rewrite !vassocl.
+    rewrite laxfunctor_lwhisker.
+    reflexivity.
+  Qed.
+End LaxFunctorDerivedLaws.
 
 Definition is_pseudofunctor
            {C C' : prebicat_data}
@@ -246,7 +344,7 @@ Definition psfunctor_id
            {C C' : prebicat_data}
            (F : psfunctor C C')
            (a : C)
-  : invertible_2cell (#F (identity a)) (identity _)
+  : invertible_2cell (identity (F a)) (#F (identity a))
   := (_ ,, pr1 (pr2 F) a).
 
 Definition psfunctor_comp
@@ -254,125 +352,50 @@ Definition psfunctor_comp
            (F : psfunctor C C')
            {a b c : C}
            (f : a --> b) (g : b --> c)
-  : invertible_2cell (#F (f · g)) (#F f · #F g)
+  : invertible_2cell (#F f · #F g) (#F (f · g))
   := (_ ,, pr2(pr2 F) a b c f g).
 
 Section PseudoFunctorDerivedLaws.
   Context {C C' : bicat}.
   Variable (F : psfunctor C C').
 
-  Definition psfunctor_linvunitor
+  Definition psfunctor_F_lunitor
              {a b : C}
              (f : C⟦a, b⟧)
-    : ##F (linvunitor f)
-      =   linvunitor (#F f)
-        • (inv_cell (psfunctor_id F a) ▹ #F f)
-        • inv_cell (psfunctor_comp F _ _).
-  Proof.
-    rewrite <- !vassocr.
-    cbn.
-    use vcomp_move_L_pM.
-    { is_iso. }
-    cbn.
-    use vcomp_move_R_Mp.
-    {
-      refine (laxfunctor_is_iso F (linvunitor f ,, _)).
-      is_iso.
-    }
-    cbn.
-    rewrite laxfunctor_lunitor ; cbn.
-    rewrite <- !vassocr.
-    rewrite !(maponpaths (λ z, _ • z) (vassocr _ _ _)).
-    rewrite inv_cell_after_invertible_2cell.
-    rewrite id2_left.
-    rewrite !vassocr.
-    rewrite rwhisker_vcomp.
-    rewrite inv_cell_after_invertible_2cell.
-    rewrite id2_rwhisker.
-    rewrite id2_left.
-    reflexivity.
-  Qed.
-
-  Definition psfunctor_rinvunitor
-             (a b : C)
-             (f : C⟦a, b⟧)
-    : ##F (rinvunitor f)
-      =   rinvunitor (#F f)
-        • (#F f ◃ inv_cell (psfunctor_id F b))
-        • inv_cell (psfunctor_comp F _ _).
-  Proof.
-    rewrite <- !vassocr.
-    use vcomp_move_L_pM.
-    { is_iso. }
-    cbn.
-    use vcomp_move_R_Mp.
-    {
-      refine (laxfunctor_is_iso F (rinvunitor f ,, _)).
-      is_iso.
-    }
-    cbn.
-    rewrite laxfunctor_runitor ; cbn.
-    rewrite <- !vassocr.
-    rewrite !(maponpaths (λ z, _ • z) (vassocr _ _ _)).
-    rewrite inv_cell_after_invertible_2cell.
-    rewrite id2_left.
-    rewrite !vassocr.
-    rewrite lwhisker_vcomp.
-    rewrite inv_cell_after_invertible_2cell.
-    rewrite lwhisker_id2.
-    rewrite id2_left.
-    reflexivity.
-  Qed.
-
-  Definition psfunctor_rassociator
-             {a b c d : C}
-             (f : C⟦a, b⟧) (g : C⟦b, c⟧) (h : C⟦c, d⟧)
-    : ##F (rassociator f g h)
-      =   psfunctor_comp F _ _
-        • (psfunctor_comp F _ _ ▹ #F h)
-        • rassociator (#F f) (#F g) (#F h)
-        • (#F f ◃ inv_cell (psfunctor_comp F _ _))
-        • inv_cell (psfunctor_comp F _ _).
-  Proof.
-    use vcomp_move_L_Mp.
-    { is_iso. }
-    cbn.
-    use vcomp_move_L_Mp.
-    { is_iso. }
-    cbn.
-    rewrite <- !vassocr.
-    use vcomp_move_R_pM.
-    {
-      refine (laxfunctor_is_iso F (rassociator f g h ,, _)).
-      is_iso.
-    }
-    cbn.
-    rewrite !vassocr.
-    use vcomp_move_L_Mp.
-    {
-      is_iso.
-    }
-    cbn.
-    symmetry.
-    apply laxfunctor_lassociator.
-  Qed.
-
-  Definition laxfunctor_comp_natural
-            {a b c : C}
-           {g₁ g₂ : C⟦b,c⟧} {f₁ f₂ : C⟦a,b⟧}
-           (ηg : g₁ ==> g₂) (ηf : f₁ ==> f₂)
-    : laxfunctor_comp F f₂ g₂ o ##F (ηf ⋆ ηg)
+    : ##F (lunitor f)
       =
-      (##F ηf) ⋆ (##F ηg) o laxfunctor_comp F f₁ g₁.
+      ((psfunctor_comp F (identity a) f)^-1)
+        • ((psfunctor_id F a)^-1 ▹ #F f)
+        • lunitor (#F f).
   Proof.
-    unfold hcomp.
-    rewrite !laxfunctor_vcomp.
     rewrite !vassocl.
-    rewrite laxfunctor_lwhisker.
+    use vcomp_move_L_pM.
+    { is_iso. }
+    use vcomp_move_L_pM.
+    { is_iso. }
+    cbn.
     rewrite !vassocr.
-    rewrite laxfunctor_rwhisker.
-    reflexivity.
-  Defined.
+    exact (!(laxfunctor_lunitor F f)).
+  Qed.
+
+  Definition psfunctor_F_runitor
+             {a b : C}
+             (f : C⟦a,b⟧)
+    : ##F (runitor f)
+      =
+      ((psfunctor_comp F f (identity b))^-1)
+        • (#F f ◃ (psfunctor_id F b)^-1)
+        • runitor (#F f).
+  Proof.
+    rewrite !vassocl.
+    use vcomp_move_L_pM.
+    { is_iso. }
+    use vcomp_move_L_pM.
+    { is_iso. }
+    cbn.
+    rewrite !vassocr.
+    exact (!(laxfunctor_runitor F f)).
+  Qed.
 End PseudoFunctorDerivedLaws.
 
 Module Notations.

--- a/UniMath/CategoryTheory/Bicategories/ap_functor.v
+++ b/UniMath/CategoryTheory/Bicategories/ap_functor.v
@@ -30,7 +30,7 @@ Section ApFunctor.
     - exact (λ _ _, maponpaths f).
     - exact (λ _ _ _ _ s, maponpaths (maponpaths f) s).
     - exact (λ x, idpath (idpath (f x))).
-    - exact (λ _ _ _ p q, maponpathscomp0 f p q).
+    - exact (λ _ _ _ p q, !(maponpathscomp0 f p q)).
   Defined.
 
   Definition ap_functor_laws
@@ -50,10 +50,10 @@ Section ApFunctor.
       reflexivity.
     - intros x y z p q₁ q₂ s ; cbn in *.
       induction s ; cbn.
-      exact (!(pathscomp0rid _)).
+      exact (pathscomp0rid _).
     - intros x y z p₁ p₂ q s ; cbn in *.
       induction s ; cbn.
-      exact (!(pathscomp0rid _)).
+      exact (pathscomp0rid _).
   Qed.
 
   Definition lax_ap_functor
@@ -68,6 +68,6 @@ Section ApFunctor.
     - intros a.
       exact (fundamental_groupoid_2cell_iso Y HY (idpath(idpath (f a)))).
     - intros a b c p q.
-      exact (fundamental_groupoid_2cell_iso Y HY (maponpathscomp0 f p q)).
+      exact (fundamental_groupoid_2cell_iso Y HY (!(maponpathscomp0 f p q))).
   Defined.
 End ApFunctor.

--- a/UniMath/CategoryTheory/Bicategories/composition.v
+++ b/UniMath/CategoryTheory/Bicategories/composition.v
@@ -25,8 +25,8 @@ Section FunctorComposition.
     - exact (λ X, G(F X)).
     - exact (λ _ _ f, #G(#F f)).
     - exact (λ _ _ _ _ α, ##G(##F α)).
-    - exact (λ a, laxfunctor_id G (F a) o ##G (laxfunctor_id F a)).
-    - exact (λ _ _ _ f g, laxfunctor_comp G (#F f) (#F g) o ##G (laxfunctor_comp F f g)).
+    - exact (λ a, laxfunctor_id G (F a) • ##G (laxfunctor_id F a)).
+    - exact (λ _ _ _ f g, laxfunctor_comp G (#F f) (#F g) • ##G (laxfunctor_comp F f g)).
   Defined.
 
   Definition comp_is_lax : laxfunctor_laws lax_comp_d.
@@ -40,57 +40,58 @@ Section FunctorComposition.
       reflexivity.
     - intros a b f ; cbn in *.
       rewrite !laxfunctor_lunitor.
-      rewrite !laxfunctor_vcomp.
-      rewrite laxfunctor_lunitor.
-      rewrite !vassocl.
-      rewrite !(maponpaths (λ z, _ • z) (vassocr _ _ _)).
-      rewrite laxfunctor_rwhisker.
       rewrite <- rwhisker_vcomp.
-      rewrite !vassocl.
-      reflexivity.
-    - intros a b f ; cbn.
-      rewrite !laxfunctor_runitor.
-      rewrite !laxfunctor_vcomp.
-      rewrite laxfunctor_runitor.
-      rewrite !vassocl.
-      rewrite !(maponpaths (λ z, _ • z) (vassocr _ _ _)).
-      rewrite laxfunctor_lwhisker.
-      rewrite <- lwhisker_vcomp.
-      rewrite !vassocl.
-      reflexivity.
-    - intros a b c d f g h ; cbn.
       rewrite !vassocr.
-      rewrite !vassocl.
-      rewrite <- rwhisker_vcomp.
-      rewrite !(maponpaths (λ z, _ • (_ • z)) (vassocr _ _ _)).
-      rewrite <- laxfunctor_rwhisker.
-      rewrite !vassocr.
-      rewrite <- !laxfunctor_vcomp.
-      rewrite laxfunctor_lassociator.
       rewrite !laxfunctor_vcomp.
       rewrite !vassocl.
       apply maponpaths.
-      rewrite !(maponpaths (λ z, _ • z) (vassocr _ _ _)).
-      rewrite laxfunctor_lassociator.
       rewrite !vassocr.
-      rewrite laxfunctor_lwhisker.
+      rewrite <- laxfunctor_rwhisker.
+      reflexivity.
+    - intros a b f ; cbn.
+      rewrite !laxfunctor_runitor.
       rewrite <- lwhisker_vcomp.
+      rewrite !laxfunctor_vcomp.
       rewrite !vassocl.
+      apply maponpaths.
+      rewrite !vassocr.
+      rewrite <- laxfunctor_lwhisker.
+      reflexivity.
+    - intros a b c d f g h ; cbn.
+      rewrite <- !lwhisker_vcomp.
+      rewrite !vassocl.
+      rewrite <- laxfunctor_vcomp.
+      rewrite !(maponpaths (λ z, _ • z) (vassocr _ _ _)).
+      rewrite <- laxfunctor_lwhisker.
+      rewrite !vassocl.
+      rewrite <- !laxfunctor_vcomp.
+      rewrite !vassocr.
+      rewrite laxfunctor_lassociator.
+      rewrite !laxfunctor_vcomp.
+      rewrite !vassocl.
+      rewrite !vassocr.
+      apply (maponpaths (λ z, z • _)).
+      rewrite laxfunctor_lassociator.
+      rewrite !vassocl.
+      apply (maponpaths (λ z, _ • z)).
+      rewrite laxfunctor_rwhisker.
+      rewrite <- !rwhisker_vcomp.
+      rewrite !vassocr.
       reflexivity.
     - intros a b c f g₁ g₂ α ; cbn.
-      rewrite !vassocr.
+      rewrite !vassocl.
       rewrite <- laxfunctor_vcomp.
       rewrite !laxfunctor_lwhisker.
-      rewrite !vassocl.
+      rewrite !vassocr.
       rewrite <- (laxfunctor_lwhisker G).
       rewrite laxfunctor_vcomp.
       rewrite !vassocr.
       reflexivity.
     - intros a b c f g₁ g₂ α ; cbn.
-      rewrite !vassocr.
+      rewrite !vassocl.
       rewrite <- laxfunctor_vcomp.
       rewrite !laxfunctor_rwhisker.
-      rewrite !vassocl.
+      rewrite !vassocr.
       rewrite <- (laxfunctor_rwhisker G).
       rewrite laxfunctor_vcomp.
       rewrite !vassocr.
@@ -110,10 +111,10 @@ Proof.
   split.
   - intros a ; cbn.
     is_iso.
-    + exact (laxfunctor_is_iso G (psfunctor_id F a)).
     + exact (psfunctor_id G (F a)).
+    + exact (laxfunctor_is_iso G (psfunctor_id F a)).
   - intros a b c f g ; cbn.
     is_iso.
-    + exact (laxfunctor_is_iso G (psfunctor_comp F f g)).
     + exact (psfunctor_comp G (#F f) (#F g)).
+    + exact (laxfunctor_is_iso G (psfunctor_comp F f g)).
 Defined.


### PR DESCRIPTION
In the previous version, the order of the laws of lax functors were reversed. Now this is fixed.