### PR TITLE
Bicategories: Unify more lemmas and definitions from B&M and D&N.

### DIFF
--- a/UniMath/CategoryTheory/All.v
+++ b/UniMath/CategoryTheory/All.v
@@ -181,6 +181,7 @@ Require Export UniMath.CategoryTheory.Bicategories.Constructions.
 Require Export UniMath.CategoryTheory.Bicategories.Sigma.
 Require Export UniMath.CategoryTheory.Bicategories.Fibration.
 Require Export UniMath.CategoryTheory.Bicategories.Cofunctormap.
+Require Export UniMath.CategoryTheory.Bicategories.Algebras.
 Require Export UniMath.CategoryTheory.Bicategories.CwF.
 Require Export UniMath.CategoryTheory.Bicategories.WkCatEnrichment.prebicategory.
 Require Export UniMath.CategoryTheory.Bicategories.WkCatEnrichment.Notations.

--- a/UniMath/CategoryTheory/Bicategories/Bicat.v
+++ b/UniMath/CategoryTheory/Bicategories/Bicat.v
@@ -462,7 +462,7 @@ Definition is_invertible_2cell_inv {C : prebicat_data} {a b : C} {f g : a --> b}
   : is_invertible_2cell (inv_η^-1)
   := mk_is_invertible_2cell (vcomp_lid inv_η) (vcomp_rinv inv_η).
 
-Definition id2_is_invertible_2cell {C : prebicat} {a b : C} (f : a --> b)
+Definition is_invertible_2cell_id₂ {C : prebicat} {a b : C} (f : a --> b)
   : is_invertible_2cell (id2 f)
   := mk_is_invertible_2cell (id2_left (id2 f)) (id2_left (id2 f)).
 
@@ -495,8 +495,8 @@ Proof.
   intro x. apply isaprop_is_invertible_2cell.
 Qed.
 
-Lemma inv_2cell_right_cancellable {C : prebicat} {a b : C} {f g : C⟦a, b⟧}
-      {x : f ==> g} (inv_x : is_invertible_2cell x)
+Lemma vcomp_rcancel {C : prebicat} {a b : C} {f g : C⟦a, b⟧}
+      (x : f ==> g) (inv_x : is_invertible_2cell x)
       {e : C⟦a, b⟧} {y z : e ==> f}
   : y • x = z • x -> y = z.
 Proof.
@@ -506,8 +506,8 @@ Proof.
   - rewrite R, <- vassocr, vcomp_rinv. apply id2_right.
 Qed.
 
-Lemma inv_2cell_left_cancellable  {C : prebicat} {a b : C} {f g : C⟦a, b⟧}
-      {x : f ==> g} (inv_x : is_invertible_2cell x)
+Lemma vcomp_lcancel  {C : prebicat} {a b : C} {f g : C⟦a, b⟧}
+      (x : f ==> g) (inv_x : is_invertible_2cell x)
       {h : C⟦a, b⟧} {y z : g ==> h}
   : x • y = x • z -> y = z.
 Proof.
@@ -522,7 +522,7 @@ Lemma inv_cell_eq {C : bicat} {a b : C} {f g : C ⟦a, b⟧} (x y : f ==> g)
       (p : inv_x^-1 = inv_y^-1)
   : x = y.
 Proof.
-  apply (inv_2cell_right_cancellable (is_invertible_2cell_inv inv_x)).
+  apply (vcomp_rcancel _ (is_invertible_2cell_inv inv_x)).
   rewrite vcomp_rinv, p.
   apply (!vcomp_rinv _).
 Qed.
@@ -554,7 +554,7 @@ Coercion property_from_invertible_2cell {C : prebicat_data}
 
 Definition id2_invertible_2cell {C : prebicat} {a b : C} (f : a --> b)
   : invertible_2cell f f
-  := mk_invertible_2cell (id2_is_invertible_2cell f).
+  := mk_invertible_2cell (is_invertible_2cell_id₂ f).
 
 Lemma cell_from_invertible_2cell_eq {C : bicat}
       {a b : C} {f g : C⟦a,b⟧} {x y : invertible_2cell f g}
@@ -631,7 +631,7 @@ Lemma rhs_right_inv_cell {a b : C} {f g h : a --> b}
   : x • y = z -> x = z • inv_y^-1.
 Proof.
   intro H1.
-  use (inv_2cell_right_cancellable inv_y).
+  apply (vcomp_rcancel _ inv_y).
   etrans. { apply H1. }
   etrans. 2: apply vassocr.
   apply pathsinv0.
@@ -645,7 +645,7 @@ Lemma rhs_left_inv_cell {a b : C} {f g h : a --> b}
   : y • x = z -> x = inv_y^-1 • z.
 Proof.
   intro H1.
-  use (inv_2cell_left_cancellable inv_y).
+  apply (vcomp_lcancel _ inv_y).
   etrans. { apply H1. }
   etrans. 2: apply vassocl.
   apply pathsinv0.
@@ -826,14 +826,12 @@ Lemma rwhisker_lwhisker_rassociator
       (a b c d : C) (f : C⟦a, b⟧) (g h : C⟦b, c⟧) (i : c --> d) (x : g ==> h)
   : rassociator _ _ _ • (f ◃ (x ▹ i)) = ((f ◃ x) ▹ i) • rassociator _ _ _ .
 Proof.
-  use inv_2cell_left_cancellable.
-  2: exact (lassociator f g i).
+  apply (vcomp_lcancel (lassociator f g i)).
   { apply  is_invertible_2cell_lassociator. }
   etrans. etrans. apply vassocr. apply maponpaths_2. apply lassociator_rassociator.
   etrans. apply id2_left.
 
-  use inv_2cell_right_cancellable.
-  2: exact (lassociator f h i).
+  apply (vcomp_rcancel (lassociator f h i)).
   { apply  is_invertible_2cell_lassociator. }
   apply pathsinv0.
   etrans. apply vassocl.
@@ -848,14 +846,12 @@ Lemma lwhisker_lwhisker_rassociator (a b c d : C) (f : C⟦a, b⟧)
       (g : C⟦b, c⟧) (h i : c --> d) (x : h ==> i)
   : rassociator f g h  • (f ◃ (g ◃ x)) = (f · g ◃ x) • rassociator _ _ _ .
 Proof.
-  use inv_2cell_left_cancellable.
-  2: exact (lassociator f g h).
+  apply (vcomp_lcancel (lassociator f g h)).
   { apply  is_invertible_2cell_lassociator. }
   etrans. etrans. apply vassocr. apply maponpaths_2. apply lassociator_rassociator.
   etrans. apply id2_left.
 
-  use inv_2cell_right_cancellable.
-  2: exact (lassociator f g i).
+  apply (vcomp_rcancel (lassociator f g i)).
   { apply  is_invertible_2cell_lassociator. }
   apply pathsinv0.
   etrans. apply vassocl.
@@ -870,8 +866,7 @@ Lemma rwhisker_rwhisker_alt {a b c d : C}
       (f : C ⟦ b, a ⟧) (g : C ⟦ c, b ⟧) {h i : C ⟦ d, c ⟧} (x : h ==> i)
   : ((x ▹ g) ▹ f) • rassociator i g f = rassociator h g f • (x ▹ g · f).
 Proof.
-  use inv_2cell_left_cancellable.
-  2: exact (lassociator h g f).
+  apply (vcomp_lcancel (lassociator h g f)).
   { apply is_invertible_2cell_lassociator. }
   etrans. { apply vassocr. }
   etrans. { apply maponpaths_2, rwhisker_rwhisker. }
@@ -890,10 +885,9 @@ Lemma rassociator_rassociator {a b c d e : C}
   : ((rassociator f g h ▹ i) • rassociator f (g · h) i) • (f ◃ rassociator g h i) =
     rassociator (f · g) h i • rassociator f g (h · i).
 Proof.
-  use inv_2cell_left_cancellable.
-  2: exact (lassociator (f · g) h i).
+  apply (vcomp_lcancel (lassociator (f · g) h i)).
   { apply is_invertible_2cell_lassociator. }
-  use inv_2cell_left_cancellable. 2: exact (lassociator f g (h · i)).
+  apply (vcomp_lcancel (lassociator f g (h · i))).
   { apply is_invertible_2cell_lassociator. }
   etrans. { apply vassocr. }
   etrans.
@@ -1128,7 +1122,7 @@ Section Associators_Unitors_Iso.
 
 Context {C : prebicat}.
 
-Lemma lassociator_iso {a b c d : C} (f : hom a b) (g : hom b c) (h : hom c d)
+Lemma is_iso_lassociator {a b c d : C} (f : hom a b) (g : hom b c) (h : hom c d)
   : is_iso (lassociator f g h : (hom a d) ⟦ f · (g · h), (f · g) · h ⟧).
 Proof.
   apply is_iso_from_is_z_iso.
@@ -1138,7 +1132,7 @@ Proof.
   - apply rassociator_lassociator.
 Defined.
 
-Lemma lunitor_iso {a b : C} (f : hom a b)
+Lemma is_iso_lunitor {a b : C} (f : hom a b)
   : is_iso (lunitor f : (hom a b) ⟦ identity a · f, f ⟧).
 Proof.
   apply is_iso_from_is_z_iso.
@@ -1148,7 +1142,7 @@ Proof.
   - apply linvunitor_lunitor.
 Defined.
 
-Lemma runitor_iso {a b : C} (f : hom a b)
+Lemma is_iso_runitor {a b : C} (f : hom a b)
   : is_iso (runitor f : (hom a b) ⟦ f · identity b, f ⟧).
 Proof.
   apply is_iso_from_is_z_iso.

--- a/UniMath/CategoryTheory/Bicategories/BicategoryOfBicat.v
+++ b/UniMath/CategoryTheory/Bicategories/BicategoryOfBicat.v
@@ -98,9 +98,9 @@ Lemma prebicat_associator_and_unitors_are_iso
   : associator_and_unitors_are_iso bicate_data.
 Proof.
   repeat split; cbn; intros.
-  - apply lassociator_iso.
-  - apply lunitor_iso.
-  - apply runitor_iso.
+  - apply is_iso_lassociator.
+  - apply is_iso_lunitor.
+  - apply is_iso_runitor.
 Defined.
 
 Lemma triangle_identity {a b c : C} (f : C ⟦ a, b ⟧) (g : C ⟦ b, c ⟧)

--- a/UniMath/CategoryTheory/Bicategories/DispBicat.v
+++ b/UniMath/CategoryTheory/Bicategories/DispBicat.v
@@ -749,7 +749,7 @@ Section Display_Invertible_2cell.
     : ff' ==>[α^-1] ff
     := pr1 (pr2 e).
 
-  Definition disp_vcomp_lid {α : invertible_2cell f f'}
+  Definition disp_vcomp_linv {α : invertible_2cell f f'}
              {ff : d -->[f] d'} {ff' : d -->[f'] d'}
              (e : disp_invertible_2cell α ff ff')
     : e •• disp_inv_cell e =
@@ -878,7 +878,7 @@ Section Display_Invertible_2cell.
     etrans. apply (transport_f_f (λ x, _ ==>[x] _)).
     etrans. apply maponpaths.
     apply maponpaths_2.
-    apply (disp_vcomp_lid
+    apply (disp_vcomp_linv
              ((xx,,inv_xx):disp_invertible_2cell (x,,inv_x) _ _)).
     etrans. apply maponpaths. apply disp_mor_transportf_postwhisker.
     etrans. unfold transportb. apply (transport_f_f (λ x, _ ==>[x] _)).

--- a/UniMath/CategoryTheory/Bicategories/DispBicat.v
+++ b/UniMath/CategoryTheory/Bicategories/DispBicat.v
@@ -749,14 +749,14 @@ Section Display_Invertible_2cell.
     : ff' ==>[α^-1] ff
     := pr1 (pr2 e).
 
-  Definition disp_vcomp_linv {α : invertible_2cell f f'}
+  Definition disp_vcomp_rinv {α : invertible_2cell f f'}
              {ff : d -->[f] d'} {ff' : d -->[f'] d'}
              (e : disp_invertible_2cell α ff ff')
     : e •• disp_inv_cell e =
       transportb (λ α, _ ==>[α] _) (vcomp_rinv α) (disp_id2 ff)
     := pr1 (pr2 (pr2 e)).
 
-  Definition disp_vcomp_rinv {α : invertible_2cell f f'}
+  Definition disp_vcomp_linv {α : invertible_2cell f f'}
              {ff : d -->[f] d'} {ff' : d -->[f'] d'}
              (e : disp_invertible_2cell α ff ff')
     : disp_inv_cell e •• e =
@@ -815,7 +815,7 @@ Section Display_Invertible_2cell.
     etrans. apply maponpaths. apply disp_vassocl.
     etrans. unfold transportb. apply (transport_f_f (λ x' : f ==> h, ff ==>[x'] hh)).
     etrans. apply maponpaths. apply maponpaths.
-    apply disp_vcomp_rinv.
+    apply disp_vcomp_linv.
     etrans. apply maponpaths.
     apply disp_mor_transportf_prewhisker.
     etrans. unfold transportb. apply (transport_f_f (λ x' : f ==> h, ff ==>[x'] hh)).
@@ -878,7 +878,7 @@ Section Display_Invertible_2cell.
     etrans. apply (transport_f_f (λ x, _ ==>[x] _)).
     etrans. apply maponpaths.
     apply maponpaths_2.
-    apply (disp_vcomp_linv
+    apply (disp_vcomp_rinv
              ((xx,,inv_xx):disp_invertible_2cell (x,,inv_x) _ _)).
     etrans. apply maponpaths. apply disp_mor_transportf_postwhisker.
     etrans. unfold transportb. apply (transport_f_f (λ x, _ ==>[x] _)).

--- a/UniMath/CategoryTheory/Bicategories/DispUnivalence.v
+++ b/UniMath/CategoryTheory/Bicategories/DispUnivalence.v
@@ -161,11 +161,11 @@ Section Total_Category_Locally_Univalent.
              *** cbn.
                  apply vcomp_rinv. (* invertible_2cell_after_inv_cell. *)
              *** cbn.
-                 apply  disp_vcomp_lid.
+                 apply  disp_vcomp_linv.
           ** cbn.
              use total2_paths_b.
              *** cbn.
-                 apply vcomp_lid. 
+                 apply vcomp_lid.
              *** cbn.
                  apply disp_vcomp_rinv.
     - use isweq_iso.

--- a/UniMath/CategoryTheory/Bicategories/DispUnivalence.v
+++ b/UniMath/CategoryTheory/Bicategories/DispUnivalence.v
@@ -161,13 +161,13 @@ Section Total_Category_Locally_Univalent.
              *** cbn.
                  apply vcomp_rinv. (* invertible_2cell_after_inv_cell. *)
              *** cbn.
-                 apply  disp_vcomp_linv.
+                 apply  disp_vcomp_rinv.
           ** cbn.
              use total2_paths_b.
              *** cbn.
                  apply vcomp_lid.
              *** cbn.
-                 apply disp_vcomp_rinv.
+                 apply disp_vcomp_linv.
     - use isweq_iso.
       * intros z.
         destruct z as [z Hz].

--- a/UniMath/CategoryTheory/Bicategories/Invertible_2cells.v
+++ b/UniMath/CategoryTheory/Bicategories/Invertible_2cells.v
@@ -1,3 +1,7 @@
+(* *********************************************************************************** *)
+(** * More on invertible 2cells                                                        *)
+(* *********************************************************************************** *)
+
 Require Import UniMath.Foundations.All.
 Require Import UniMath.MoreFoundations.All.
 Require Import UniMath.CategoryTheory.Categories.
@@ -7,16 +11,16 @@ Require Import UniMath.CategoryTheory.Bicategories.Bicat. Import Notations.
 Local Open Scope cat.
 
 (* ----------------------------------------------------------------------------------- *)
-(** * Inverse 2cell of a composition                                                   *)
+(** ** Inverse 2cell of a composition                                                  *)
 (* ----------------------------------------------------------------------------------- *)
 
 Lemma is_invertible_2cell_vcomp {C : prebicat} {a b : C} {f g h: C ⟦a, b⟧}
-      (x : f ==> g) (y : g ==> h)
-      (inv_x : is_invertible_2cell x) (inv_y : is_invertible_2cell y)
+      {x : f ==> g} (inv_x : is_invertible_2cell x)
+      {y : g ==> h} (inv_y : is_invertible_2cell y)
   : is_invertible_2cell (x • y).
 Proof.
-  exists (inv_y^-1 • inv_x^-1).
-  split.
+  use mk_is_invertible_2cell.
+  - exact (inv_y^-1 • inv_x^-1).
   - abstract (
         repeat rewrite vassocl;
         etrans; [apply vassoc4|];
@@ -35,21 +39,13 @@ Proof.
       ).
 Defined.
 
-Lemma inv_cell_of_composite {C : prebicat} {a b : C} {f g h: C ⟦a, b⟧}
-      (x : f ==> g) (y : g ==> h)
-      (inv_x : is_invertible_2cell x) (inv_y : is_invertible_2cell y)
-  : is_invertible_2cell_vcomp _ _ inv_x inv_y ^-1 =
-    inv_y^-1 • inv_x^-1.
-Proof.
-  cbn. apply idpath.
-Defined.
-
-Lemma is_invertible_2cell_lwhisker {C : prebicat} {a b c : C} (f : a --> b) {g1 g2 : b --> c}
+Lemma is_invertible_2cell_lwhisker {C : prebicat} {a b c : C}
+      (f : a --> b) {g1 g2 : b --> c}
       {x : g1 ==> g2} (inv_x : is_invertible_2cell x)
   : is_invertible_2cell (f ◃ x).
 Proof.
-  exists (f ◃ inv_x^-1).
-  split.
+  use mk_is_invertible_2cell.
+  - exact (f ◃ inv_x^-1).
   - abstract (
         etrans; [ apply lwhisker_vcomp |];
         etrans; [ apply maponpaths; apply (vcomp_rinv inv_x) |];
@@ -64,8 +60,8 @@ Lemma is_invertible_2cell_rwhisker {C : prebicat} {a b c : C} {f1 f2 : a --> b} 
       {x : f1 ==> f2} (inv_x : is_invertible_2cell x)
   : is_invertible_2cell (x ▹ g).
 Proof.
-  exists (inv_x^-1 ▹ g).
-  split.
+  use mk_is_invertible_2cell.
+  - exact (inv_x^-1 ▹ g).
   - abstract (
         etrans; [ apply rwhisker_vcomp |];
         etrans; [ apply maponpaths; apply (vcomp_rinv inv_x) |];
@@ -77,53 +73,6 @@ Proof.
 Defined.
 
 (** ** Two-cells that are isomorphisms **)
-
-Definition iso_id₂
-         {C : bicat}
-         {X Y : C}
-         (f : C⟦X,Y⟧)
-  : is_invertible_2cell (id₂ f).
-Proof.
-  exists (id2 _).
-  split; apply id2_left.
-Defined.
-
-Definition left_unit_iso
-         {C : bicat}
-         {X Y : C}
-         (f : C⟦X,Y⟧)
-  : is_invertible_2cell (runitor f).
-Proof.
-  apply is_invertible_2cell_runitor.
-Defined.
-
-Definition left_unit_inv_iso
-         {C : bicat}
-         {X Y : C}
-         (f : C⟦X,Y⟧)
-  : is_invertible_2cell (rinvunitor f).
-Proof.
-  apply is_invertible_2cell_rinvunitor.
-Defined.
-
-Definition lunitor_iso
-         {C : bicat}
-         {X Y : C}
-         (f : C⟦X,Y⟧)
-  : is_invertible_2cell (lunitor f).
-Proof.
-  apply is_invertible_2cell_lunitor.
-Defined.
-
-Definition lunitor_inv_iso
-         {C : bicat}
-         {X Y : C}
-         (f : C⟦X,Y⟧)
-  : is_invertible_2cell (linvunitor f).
-Proof.
-  apply is_invertible_2cell_linvunitor.
-Defined.
-
 
 Definition pentagon
            {C : bicat}
@@ -145,24 +94,19 @@ Proof.
   apply lassociator_lassociator.
 Qed.
 
-
-Definition hcomp_iso
+Definition is_invertible_2cell_hcomp
        {C : bicat}
        {X Y Z : C}
        {f₁ g₁ : C⟦Y,Z⟧} {f₂ g₂ : C⟦X,Y⟧}
        (η₁ : f₁ ==> g₁) (η₂ : f₂ ==> g₂)
-       (Hη₁ : is_invertible_2cell η₁)
-       (Hη₂ : is_invertible_2cell η₂)
+       (inv_η₁ : is_invertible_2cell η₁)
+       (inv_η₂ : is_invertible_2cell η₂)
   : is_invertible_2cell (η₁ ⋆⋆ η₂).
 Proof.
   use mk_is_invertible_2cell.
-  - exact (Hη₁^-1 ⋆⋆ Hη₂^-1).
-  - rewrite <- hcomp_vcomp.
-    rewrite !vcomp_rinv.
-    apply hcomp_identity.
-  - rewrite <- hcomp_vcomp.
-    rewrite !vcomp_lid.
-    apply hcomp_identity.
+  - exact (inv_η₁^-1 ⋆⋆ inv_η₂^-1).
+  - abstract (rewrite <- hcomp_vcomp, !vcomp_rinv; apply hcomp_identity).
+  - abstract (rewrite <- hcomp_vcomp, !vcomp_lid; apply hcomp_identity).
 Defined.
 
 Definition bc_whisker_l
@@ -216,81 +160,7 @@ Proof.
   apply idpath.
 Qed.
 
-Definition inverse_of_left_unit
-           {C : bicat}
-           {X Y : C}
-           (f : C⟦X,Y⟧)
-  : (left_unit_iso f)^-1 = rinvunitor f
-  := idpath _ .
-
-Definition inverse_of_lunitor
-           {C : bicat}
-           {X Y : C}
-           (f : C⟦X,Y⟧)
-  : (lunitor_iso f)^-1 = linvunitor f
-  := idpath _.
-
 (**** Properties of isomorphisms ***)
-
-Definition id₂_inverse
-           {C : bicat}
-           {X Y : C}
-           (f : C⟦X,Y⟧)
-  : (iso_id₂ f)^-1 = id₂ f
-  := idpath _.
-
-Definition vcomp_inverse
-           {C : bicat}
-           {X Y : C}
-           {f g h : C⟦X,Y⟧}
-           (η₁ : f ==> g) (η₂ : g ==> h)
-           (Hη₁ : is_invertible_2cell η₁)
-           (Hη₂ : is_invertible_2cell η₂)
-  : (is_invertible_2cell_vcomp _ _ Hη₁ Hη₂)^-1 = Hη₁^-1 o Hη₂^-1
-  := idpath _ .
-
-Definition hcomp_inverse
-           {C : bicat}
-           {X Y Z : C}
-           {f₁ g₁ : C⟦Y,Z⟧} {f₂ g₂ : C⟦X,Y⟧}
-           (η₁ : f₁ ==> g₁) (η₂ : f₂ ==> g₂)
-           (Hη₁ : is_invertible_2cell η₁)
-           (Hη₂ : is_invertible_2cell η₂)
-  : (hcomp_iso _ _ Hη₁ Hη₂)^-1 = Hη₁^-1 ⋆⋆ Hη₂^-1
-  := idpath _ .
-
-Definition vcomp_cancel_left
-           {C : bicat}
-           {X Y : C}
-           {f g h : C⟦X,Y⟧}
-           (ε : g ==> h)
-           (η₁ η₂ : f ==> g)
-           (Hε : is_invertible_2cell ε)
-  : ε o η₁ = ε o η₂ -> η₁ = η₂.
-Proof.
-  intros Hhf.
-  simple refine (!(id2_right _) @ _ @ id2_right _).
-  rewrite <- (vcomp_rinv Hε).
-  rewrite !vassocr.
-  rewrite Hhf.
-  reflexivity.
-Qed.
-
-Definition vcomp_cancel_right
-           {C : bicat}
-           {X Y : C}
-           {f g h : C⟦X,Y⟧}
-           (ε : f ==> g) (η₁ η₂ : g ==> h)
-           (Hε : is_invertible_2cell ε)
-  : η₁ o ε = η₂ o ε -> η₁ = η₂.
-Proof.
-  intros Hhf.
-  refine (!(id2_left _) @ _ @ id2_left _).
-  rewrite <- (vcomp_lid Hε).
-  rewrite <- !vassocr.
-  rewrite Hhf.
-  reflexivity.
-Qed.
 
 Definition vcomp_move_L_Vp
            {C : bicat}
@@ -393,14 +263,14 @@ Definition path_inverse_2cell
            {X Y : C}
            {f g : C⟦X,Y⟧}
            (η₁ η₂ : f ==> g)
-           {Hη₁ : is_invertible_2cell η₁}
-           {Hη₂ : is_invertible_2cell η₂}
-  : η₁ = η₂ -> Hη₁^-1 = Hη₂^-1.
+           {inv_η₁ : is_invertible_2cell η₁}
+           {inv_η₂ : is_invertible_2cell η₂}
+  : η₁ = η₂ -> inv_η₁^-1 = inv_η₂^-1.
 Proof.
   intros p.
-  rewrite <- (id2_left (Hη₁^-1)).
-  rewrite <- (id2_right (Hη₂^-1)).
-  rewrite <- (vcomp_lid Hη₂).
+  rewrite <- (id2_left (inv_η₁^-1)).
+  rewrite <- (id2_right (inv_η₂^-1)).
+  rewrite <- (vcomp_lid inv_η₂).
   rewrite <- vassocr.
   apply maponpaths.
   rewrite <- p.
@@ -420,8 +290,8 @@ Ltac is_iso :=
   | [ |- is_invertible_2cell (_ • _)] => apply is_invertible_2cell_vcomp ; is_iso
   | [ |- is_invertible_2cell (_ ◃ _)] => apply is_invertible_2cell_lwhisker ; is_iso
   | [ |- is_invertible_2cell (_ ▹ _)] => apply is_invertible_2cell_rwhisker ; is_iso
-  | [ |- is_invertible_2cell (_ ⋆⋆ _)] => apply hcomp_iso ; is_iso
-  | [ |- is_invertible_2cell (_ ⋆ _)] => apply hcomp_iso ; is_iso
-  | [ |- is_invertible_2cell (id₂ _)] => apply iso_id₂
+  | [ |- is_invertible_2cell (_ ⋆⋆ _)] => apply is_invertible_2cell_hcomp ; is_iso
+  | [ |- is_invertible_2cell (_ ⋆ _)] => apply is_invertible_2cell_hcomp ; is_iso
+  | [ |- is_invertible_2cell (id₂ _)] => apply is_invertible_2cell_id₂
   | _ => try assumption
   end.

--- a/UniMath/CategoryTheory/Bicategories/Unitors.v
+++ b/UniMath/CategoryTheory/Bicategories/Unitors.v
@@ -37,7 +37,7 @@ Proof.
   { apply pathsinv0. apply lunitor_lwhisker. }
 
   (** attach rassociator on both sides *)
-  use inv_2cell_right_cancellable. 2: exact (rassociator _ _ _ ).
+  apply (vcomp_rcancel (rassociator _ _ _ )).
   { apply is_invertible_2cell_rassociator. }
 
   (** rewrite upper right square *)
@@ -100,9 +100,7 @@ Lemma rwhisker_id_inj {a b : C} (f g : C⟦a, b⟧)
   : x ▹ identity b = y ▹ identity b → x = y.
 Proof.
   intro H.
-  use inv_2cell_left_cancellable.
-  - apply (f · identity _ ).
-  - apply runitor.
+  apply (vcomp_lcancel (runitor _)).
   - apply is_invertible_2cell_runitor.
   - etrans. apply pathsinv0, vcomp_runitor.
     etrans. 2: apply vcomp_runitor.
@@ -114,9 +112,7 @@ Lemma lwhisker_id_inj {a b : C} (f g : C⟦a, b⟧)
   : identity a ◃ x = identity a ◃ y → x = y.
 Proof.
   intro H.
-  use inv_2cell_left_cancellable.
-  - apply (identity _ · f).
-  - apply lunitor.
+  apply (vcomp_lcancel (lunitor _)).
   - apply is_invertible_2cell_lunitor.
   - etrans. apply pathsinv0, vcomp_lunitor.
     etrans. 2: apply vcomp_lunitor.
@@ -139,7 +135,7 @@ Qed.
 Lemma runitor_is_runitor_rwhisker (a : C)
   : runitor (identity a · identity a) = runitor (identity a) ▹ (identity a).
 Proof.
-  use inv_2cell_right_cancellable. 2: exact (runitor _ ).
+  apply (vcomp_rcancel (runitor _ )).
   - apply is_invertible_2cell_runitor.
   - apply pathsinv0. apply vcomp_runitor .
 Qed.
@@ -148,7 +144,7 @@ Qed.
 Lemma lunitor_is_lunitor_lwhisker (a : C)
   : lunitor (identity a · identity a) = identity a ◃ lunitor (identity a).
 Proof.
-  use inv_2cell_right_cancellable. 2: exact (lunitor _ ).
+  apply (vcomp_rcancel (lunitor _ )).
   - apply is_invertible_2cell_lunitor.
   - apply pathsinv0. apply vcomp_lunitor .
 Qed.
@@ -157,7 +153,7 @@ Qed.
 Lemma lwhisker_runitor_lunitor (a : C)
   : identity a  ◃ runitor (identity a) = identity a ◃ lunitor (identity a).
 Proof.
-  use inv_2cell_left_cancellable. 2: exact (rassociator _ _ _ ).
+  apply (vcomp_lcancel (rassociator _ _ _ )).
   - apply is_invertible_2cell_rassociator.
   - rewrite runitor_triangle.
     rewrite lunitor_lwhisker.
@@ -167,7 +163,7 @@ Qed.
 Lemma runitor_lunitor_identity (a : C)
   : runitor (identity a) = lunitor (identity a).
 Proof.
-  use inv_2cell_left_cancellable. 2: exact (lunitor _ ).
+  apply (vcomp_lcancel (lunitor _ )).
   { apply is_invertible_2cell_lunitor. }
   etrans. { apply pathsinv0. apply vcomp_lunitor. }
   etrans. { apply maponpaths_2. apply lwhisker_runitor_lunitor. }

--- a/UniMath/CategoryTheory/Bicategories/bicategory_laws.v
+++ b/UniMath/CategoryTheory/Bicategories/bicategory_laws.v
@@ -48,11 +48,11 @@ Section laws.
              (η : f ==> g)
     : rinvunitor g o η = (id₂ (id₁ Y) ⋆⋆ η) o rinvunitor f.
   Proof.
-    use (inv_2cell_right_cancellable (runitor _ )).
+    use (vcomp_rcancel (runitor _ )).
     { apply is_invertible_2cell_runitor. }
     rewrite vassocl.
     rewrite rinvunitor_runitor.
-    use (inv_2cell_left_cancellable (runitor _ )).
+    use (vcomp_lcancel (runitor _ )).
     { apply is_invertible_2cell_runitor. }
     repeat rewrite vassocr.
     rewrite runitor_rinvunitor.
@@ -66,11 +66,11 @@ Section laws.
              (η : f ==> g)
     : linvunitor g o η = (η ⋆⋆ id₂ (id₁ X)) o linvunitor f.
   Proof.
-    use (inv_2cell_right_cancellable (lunitor _ )).
+    use (vcomp_rcancel (lunitor _ )).
     { apply is_invertible_2cell_lunitor. }
     rewrite vassocl.
     rewrite linvunitor_lunitor.
-    use (inv_2cell_left_cancellable (lunitor _ )).
+    use (vcomp_lcancel (lunitor _ )).
     { apply is_invertible_2cell_lunitor. }
     repeat rewrite vassocr.
     rewrite lunitor_linvunitor.

--- a/UniMath/CategoryTheory/Bicategories/bicategory_laws.v
+++ b/UniMath/CategoryTheory/Bicategories/bicategory_laws.v
@@ -94,14 +94,10 @@ Section laws.
       (id₂ f ⋆ rassociator g h k) o (rassociator f (h ∘ g) k)
                                   o (rassociator f g h ⋆ id₂ k).
   Proof.
-    rewrite <- !inverse_of_assoc.
-    rewrite <- (id₂_inverse f).
-    rewrite <- (id₂_inverse k).
-    rewrite <- !hcomp_inverse.
-    rewrite <- !vcomp_inverse.
-    apply path_inverse_2cell.
-    rewrite <- !vassocr.
-    apply pentagon.
+    use inv_cell_eq.
+    - is_iso.
+    - is_iso.
+    - cbn. rewrite <- !vassocr. apply pentagon.
   Qed.
 
   Definition inverse_pentagon_2
@@ -244,14 +240,10 @@ Section laws.
       =
       rassociator _ _ _ o id₂ g ⋆⋆ rinvunitor f.
   Proof.
-    rewrite <- inverse_of_lunitor, <- inverse_of_left_unit.
-    rewrite <- inverse_of_assoc.
-    rewrite <- (id₂_inverse f).
-    rewrite <- (id₂_inverse g).
-    rewrite <- !hcomp_inverse.
-    rewrite <- vcomp_inverse.
-    apply path_inverse_2cell.
-    apply triangle_r.
+    use inv_cell_eq.
+    - is_iso.
+    - is_iso.
+    - cbn. apply triangle_r.
   Qed.
 
   Definition triangle_l
@@ -415,7 +407,7 @@ Section laws.
     rewrite !rwhisker_hcomp.
     rewrite !rwhisker_hcomp in Hαβ.
     rewrite <- !hcomp_identity.
-    apply (vcomp_cancel_left (lassociator _ _ _) _ _).
+    apply (vcomp_rcancel (lassociator _ _ _)).
     {
       is_iso.
     }
@@ -435,7 +427,7 @@ Section laws.
     rewrite !lwhisker_hcomp.
     rewrite !lwhisker_hcomp in Hαβ.
     rewrite <- !hcomp_identity.
-    apply (vcomp_cancel_right (lassociator _ _ _) _ _).
+    apply (vcomp_lcancel (lassociator _ _ _)).
     {
       is_iso.
     }
@@ -512,9 +504,10 @@ Section laws.
              (X : C)
     : linvunitor (id₁ X) = rinvunitor (id₁ X).
   Proof.
-    rewrite <- inverse_of_lunitor, <- inverse_of_left_unit.
-    apply path_inverse_2cell.
-    apply lunitor_runitor_identity.
+    use inv_cell_eq.
+    - is_iso.
+    - is_iso.
+    - cbn. apply lunitor_runitor_identity.
   Qed.
 
   Definition left_unit_inv_assoc₂
@@ -534,20 +527,10 @@ Section laws.
              (g : C⟦Y,Z⟧) (f : C⟦X,Y⟧)
     : lassociator f (id₁ Y) g o linvunitor g ⋆⋆ id₂ f = id₂ g ⋆⋆ rinvunitor f.
   Proof.
-    use vcomp_move_R_Mp.
-    {
-      is_iso.
-    }
-    rewrite <- inverse_of_lunitor, <- inverse_of_left_unit.
-    rewrite <- (id₂_inverse f).
-    rewrite <- (id₂_inverse g).
-    rewrite <- !hcomp_inverse.
-    rewrite <- vcomp_inverse.
-    apply path_inverse_2cell.
-    rewrite <- triangle_l.
-    rewrite !vassocr.
-    rewrite lassociator_rassociator.
-    rewrite id2_left.
-    reflexivity.
+    use inv_cell_eq.
+    - is_iso.
+    - is_iso.
+    - cbn. apply triangle_l.
   Qed.
+
 End laws.

--- a/UniMath/CategoryTheory/Bicategories/equiv_to_adjequiv.v
+++ b/UniMath/CategoryTheory/Bicategories/equiv_to_adjequiv.v
@@ -68,20 +68,20 @@ Definition full_spec
 Proof.
   refine (representable_faithful (Hθ^-1) (f ∘ k₁) (f ∘ k₂) _ α _ _).
   { is_iso. }
-  apply (vcomp_cancel_right (lassociator _ _ _) _ _).
+  apply (vcomp_lcancel (lassociator _ _ _)).
   { is_iso. }
   rewrite <- whisker_l_hcomp.
-  apply (vcomp_cancel_left (rassociator _ _ _) _ _).
+  apply (vcomp_rcancel (rassociator _ _ _)).
   { is_iso. }
   rewrite <- !vassocr.
   rewrite lassociator_rassociator, id2_right.
-  apply (vcomp_cancel_left (Hη^-1 ▻ k₂) _ _).
+  apply (vcomp_rcancel (Hη^-1 ▻ k₂)).
   { is_iso. }
-  apply (vcomp_cancel_left (runitor k₂) _ _).
+  apply (vcomp_rcancel (runitor k₂)).
   { is_iso. }
-  apply (vcomp_cancel_right (η ▻ k₁) _ _).
+  apply (vcomp_lcancel (η ▻ k₁)).
   { is_iso. }
-  apply (vcomp_cancel_right (rinvunitor k₁) _ _).
+  apply (vcomp_lcancel (rinvunitor k₁)).
   { is_iso. }
   rewrite <- !vassocr.
   rewrite <- (whisker_l_iso_id₁ η k₁ k₂ (representable_full η θ Hη k₁ k₂ α) Hη).
@@ -193,7 +193,7 @@ Section EquivToAdjEquiv.
     : η ▻ (g ∘ f) o rinvunitor (g ∘ f)
       =
       (g ∘ f) ◅ η o linvunitor (g ∘ f)
-    := vcomp_cancel_right η _ _ ηiso η_natural.
+    := vcomp_lcancel η ηiso η_natural.
 
   Local Definition η_whisker_l_hcomp
     : (g ∘ f) ◅ η = rassociator (g ∘ f) f g o g ◅ (f ◅ η) o lassociator (id₁ X) f g.
@@ -265,7 +265,7 @@ Section EquivToAdjEquiv.
     rewrite !lwhisker_hcomp in p.
     rewrite q in p ; clear q.
     rewrite !vassocr in p.
-    use inv_2cell_right_cancellable. 2: exact (rassociator (f · g) f g).
+    use vcomp_rcancel. 2: exact (rassociator (f · g) f g).
     { is_iso. }
     rewrite rwhisker_vcomp.
     refine (_ @ p) ; clear p.


### PR DESCRIPTION
Hopefully the last reorganization and cleanup about invertible 2-cells.

Unify definitions:
  id2_is_invertible_2cell, iso_id₂ -> is_invertible_2cell_id₂
  hcomp_iso -> is_invertible_2cell_hcomp
  lassociator_iso -> is_iso_lassociator
  lunitor_iso -> is_iso_lunitor
  runitor_iso -> is_iso_runitor
  inv_2cell_right_cancellable,vcomp_cancel_left -> vcomp_rcancel
  inv_2cell_left_cancellable,vcomp_cancel_right -> vcomp_lcancel

Also fix a badly chose name:
  vcomp_lid -> vcomp_linv.

Remove duplicated lemmas:
  left_unit_iso
  left_unit_inv_iso
  lunitor_iso
  lunitor_iso_inv

Remove unused trivial lemmas:
  inv_cell_of_composite
  inverse_of_left_unit
  inverse_of_lunitor
  id₂_inverse
  vcomp_inverse
  hcomp_inverse