### PR TITLE
Instructions for installing UniMath using Nix

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,9 @@
 Installation of UniMath
 =======================
 
+NB: This file describes the default method for installing UniMath.  An
+alternative method using the [Nix Package Manager](https://nixos.org/nix/) is available in the file [INSTALL\_NIX.md](https://github.com/UniMath/UniMath/blob/master/INSTALL_NIX.md).
+
 Prepare for installation by installing the OCAML compiler and a more modern
 version of `bash` on your system.
 

--- a/INSTALL_NIX.md
+++ b/INSTALL_NIX.md
@@ -1,0 +1,62 @@
+Building UniMath with Nix
+=====================================
+
+## Introduction
+
+These are instructions to install UniMath on a Unix-like system using
+the Nix Package Manager.
+
+This method has some advantages:
+1. Should work both on Mac and on any major Linux distribution without
+   any difference.
+2. Does not require to install OCaml or Git or other dependencies
+   separately (only Nix itself).
+3. It makes possible to uninstall cleanly all the software.
+
+The main disadvantage of this method is that it is not the most used
+(see [INSTALL.md](https://github.com/UniMath/UniMath/blob/master/INSTALL.md))
+and it is not very well tested at the moment.
+
+## Installation step-by-step
+
+1. If you already have the Nix Package Manager installed, skip this step.
+   Otherwise, type the following command to install Nix:
+   ```bash
+   $ curl https://nixos.org/nix/install | sh
+   ```
+
+  (Or go to the [NixOS website](https://nixos.org) to get
+  [more detailed instructions](https://nixos.org/nix/download.html).)
+
+2. Start a "nix-shell" with the following command:
+   ```bash
+   $ nix-shell -p ocaml ocamlPackages.findlib ocamlPackages.camlp4 ocamlPackages.camlp5 ocamlPackages.num gnumake git
+   ```
+   (This may require some time to download and deploy the ocaml
+   environment into the Nix storage.)
+3. Clone UniMath, move to the top directory and launch the build:
+   ```bash
+   $ git clone https://github.com/UniMath/UniMath.git
+   $ cd UniMath
+   $ make
+   ```
+   Once the building is finished, you can quit the nix-shell (type `exit`).
+4. You may also want to install emacs using Nix:
+   ```bash
+   $ nix-env -i emacs
+   ```
+   (Or skip this step if you have emacs already installed.)
+5. Finally, you need to install Proof-General following the instructions
+   on the [website](https://proofgeneral.github.io).
+
+## How to uninstall UniMath and its dependencies
+
+If you want to uninstall UniMath and OCaml to reclaim disk space:
+1. Delete the UniMath directory:
+   ```bash
+   $ rm -rf UniMath
+   ```
+2. Purge the software installed with Nix:
+   ```
+   $ nix-collect-garbage
+   ```


### PR DESCRIPTION
Installing UniMath from scratch using Nix is pretty easy.
It is enough to copy paste the instructions below:
just 8 lines that work independently on any major Unix-system.
(No differences between Mac and Linux; no differences either between the various Linux distributions: dpkg/rpm etc.)
I think it worth to inform the users of this alternative method and perhaps consider it for adoption as the default one. 
```bash
curl https://nixos.org/nix/install | sh
git clone https://github.com/UniMath/UniMath.git
nix-shell -p ocaml ocamlPackages.findlib ocamlPackages.camlp4 ocamlPackages.camlp5 ocamlPackages.num gnumake git
git clone https://github.com/UniMath/UniMath.git
cd UniMath
make
exit
```

NB: This is a preliminary draft.  E.g., these instructions can be further refined for installing and configuring Emacs and Proof-General in one shot.  (For now, we simply suggest to use the default method.)