### PR TITLE
Change some Qed into Defined for some proofs of equivalences

### DIFF
--- a/UniMath/CategoryTheory/Core/Functors.v
+++ b/UniMath/CategoryTheory/Core/Functors.v
@@ -810,7 +810,7 @@ Proof.
   apply isweqinclandsurj.
   - apply Hfaith.
   - apply Hfull.
-Qed.
+Defined.
 
 Lemma isaprop_full_and_faithful (C D : precategory_data) (F : functor C D) :
    isaprop (full_and_faithful F).

--- a/UniMath/CategoryTheory/Subcategory/Full.v
+++ b/UniMath/CategoryTheory/Subcategory/Full.v
@@ -76,7 +76,7 @@ Section FullyFaithful.
     unfold hfiber.
     exists (f,, tt).
     reflexivity.
-  Qed.
+  Defined.
 
   (** *** Faithfulness *)
 
@@ -86,7 +86,7 @@ Section FullyFaithful.
     intros a b; cbn.
     apply isinclpr1.
     intro; apply isapropunit.
-  Qed.
+  Defined.
 
   Lemma fully_faithful_sub_precategory_inclusion :
     fully_faithful (sub_precategory_inclusion C (full_sub_precategory C')).
@@ -95,7 +95,7 @@ Section FullyFaithful.
     split.
     - apply full_sub_precategory_inclusion.
     - apply faithful_sub_precategory_inclusion.
-  Qed.
+  Defined.
 
 End FullyFaithful.
 


### PR DESCRIPTION
The underlying equivalences really need to be known and unfolded
for some use cases.