### PR TITLE
Rename some identifiers in bicategories for consistency.

### DIFF
--- a/UniMath/CategoryTheory/Bicategories/DisplayedBicats/DispUnivalence.v
+++ b/UniMath/CategoryTheory/Bicategories/DisplayedBicats/DispUnivalence.v
@@ -42,7 +42,7 @@ Section Displayed_Local_Univalence.
     exact (disp_id2_invertible_2cell ff).
   Defined.
 
-  Definition disp_locally_univalent
+  Definition disp_univalent_2_1
     : UU
     := ∏ (a b : C) (f g : C⟦a,b⟧) (p : f = g) (aa : D a) (bb : D b)
          (ff : aa -->[ f ] bb) (gg : aa -->[ g ] bb),
@@ -50,11 +50,11 @@ Section Displayed_Local_Univalence.
 End Displayed_Local_Univalence.
 
 
-Section Total_Category_Locally_Univalent.
+Section Total_Category_Univalent_2_1.
   Context {C : bicat}.
   Variable (D : disp_bicat C)
            (HC : is_univalent_2_1 C)
-           (HD : disp_locally_univalent D).
+           (HD : disp_univalent_2_1 D).
   Local Definition E := (total_bicat D).
 
   Local Definition path_E
@@ -100,12 +100,12 @@ Section Total_Category_Locally_Univalent.
     reflexivity.
   Defined.
 
-  Definition total_is_locally_univalent : is_univalent_2_1 E.
+  Definition total_is_univalent_2_1 : is_univalent_2_1 E.
   Proof.
     intros x y f g.
     exact (weqhomot (idtoiso_2_1 f g) _ (invhomot (idtoiso_alt f g))).
   Defined.
-End Total_Category_Locally_Univalent.
+End Total_Category_Univalent_2_1.
 
 Definition fiberwise_local_univalent
            {C : bicat}
@@ -115,11 +115,11 @@ Definition fiberwise_local_univalent
        (ff : aa -->[ f] bb) (gg : aa -->[ f ] bb),
      isweq (disp_idtoiso_2_1 D (idpath f) ff gg).
 
-Definition fiberwise_local_univalent_is_locally_univalent
+Definition fiberwise_local_univalent_is_univalent_2_1
            {C : bicat}
            (D : disp_bicat C)
            (HD : fiberwise_local_univalent D)
-  : disp_locally_univalent D.
+  : disp_univalent_2_1 D.
 Proof.
   intros x y f g p xx yy ff gg.
   induction p.
@@ -135,7 +135,7 @@ Lemma isaprop_disp_left_adjoint_equivalence
       (Hf : left_adjoint_equivalence f)
       (ff : aa -->[f] bb)
   : is_univalent_2_1 C →
-    disp_locally_univalent D →
+    disp_univalent_2_1 D →
     isaprop (disp_left_adjoint_equivalence Hf ff).
 Proof.
   intros HUC HUD.
@@ -146,7 +146,7 @@ Proof.
   eapply isofhlevelweqf.
   { apply left_adjoint_equivalence_total_disp_weq. }
   apply isaprop_left_adjoint_equivalence.
-  apply total_is_locally_univalent; assumption.
+  apply total_is_univalent_2_1; assumption.
 Defined.
 
 Section Displayed_Global_Univalence.
@@ -254,7 +254,7 @@ Lemma total_is_univalent
       {C : bicat}
       {D: disp_bicat C}
   : disp_univalent_2_0 D →
-    disp_locally_univalent D →
+    disp_univalent_2_1 D →
     is_univalent_2 C →
     is_univalent_2 (total_bicat D).
 Proof.
@@ -262,6 +262,6 @@ Proof.
   split.
   - apply total_is_univalent_2_0. apply UC.
     assumption.
-  - apply total_is_locally_univalent. apply UC.
+  - apply total_is_univalent_2_1. apply UC.
     assumption.
 Defined.

--- a/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/Add2Cell.v
+++ b/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/Add2Cell.v
@@ -54,7 +54,7 @@ Section Add2Cell.
                • (#S(#F f) ◃ β)).
   Defined.
 
-  Definition add_cell_disp_cat_laws : disp_cat_id_comp E add_cell_disp_cat_data.
+  Definition add_cell_disp_cat_id_comp : disp_cat_id_comp E add_cell_disp_cat_data.
   Proof.
     split.
     - intros x xx ; cbn.
@@ -121,24 +121,24 @@ Section Add2Cell.
     use disp_cell_unit_bicat.
     use tpair.
     - exact add_cell_disp_cat_data.
-    - exact add_cell_disp_cat_laws.
+    - exact add_cell_disp_cat_id_comp.
   Defined.
 
-  Definition add_cell_disp_cat_locally_univalent
-    : disp_locally_univalent add_cell_disp_cat.
+  Definition add_cell_disp_cat_univalent_2_1
+    : disp_univalent_2_1 add_cell_disp_cat.
   Proof.
-    apply disp_cell_unit_bicat_locally_univalent.
+    apply disp_cell_unit_bicat_univalent_2_1.
     intros.
     apply C.
   Defined.
 
   Definition add_cell_disp_cat_univalent_2_0
              (HC : is_univalent_2_1 C)
-             (HD : disp_locally_univalent D)
+             (HD : disp_univalent_2_1 D)
     : disp_univalent_2_0 add_cell_disp_cat.
   Proof.
     use disp_cell_unit_bicat_univalent_2_0.
-    - apply total_is_locally_univalent.
+    - apply total_is_univalent_2_1.
       + exact HC.
       + exact HD.
     - intros.

--- a/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/Algebras.v
+++ b/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/Algebras.v
@@ -516,8 +516,8 @@ Section Algebra.
     - apply C.
   Defined.
 
-  Definition disp_alg_bicat_locally_univalent
-    : disp_locally_univalent disp_alg_bicat.
+  Definition disp_alg_bicat_univalent_2_1
+    : disp_univalent_2_1 disp_alg_bicat.
   Proof.
     intros a b f g p aa bb ff gg.
     induction p.
@@ -1072,7 +1072,7 @@ Section Algebra.
         * intro.
           apply isaprop_disp_left_adjoint_equivalence.
           ** exact HC.
-          ** exact disp_alg_bicat_locally_univalent.
+          ** exact disp_alg_bicat_univalent_2_1.
         * cbn.
           unfold left_adjoint_2cell.
           unfold disp_alg_bicat_adjoint_equivalence_inv ; cbn.
@@ -1105,7 +1105,7 @@ Section Algebra.
       + intro ; simpl.
         apply (@isaprop_disp_left_adjoint_equivalence C disp_alg_bicat).
         * exact HC.
-        * exact disp_alg_bicat_locally_univalent.
+        * exact disp_alg_bicat_univalent_2_1.
       + cbn ; unfold left_adjoint_2cell ; cbn.
         use subtypeEquality.
         { intro ; apply isaprop_is_invertible_2cell. }
@@ -1120,9 +1120,9 @@ Section Algebra.
              (HC : is_univalent_2_1 C)
     : is_univalent_2_1 bicat_algebra.
   Proof.
-    apply total_is_locally_univalent.
+    apply total_is_univalent_2_1.
     - exact HC.
-    - exact disp_alg_bicat_locally_univalent.
+    - exact disp_alg_bicat_univalent_2_1.
   Defined.
 
   Definition bicat_algebra_is_univalent_2_0

--- a/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/Cofunctormap.v
+++ b/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/Cofunctormap.v
@@ -48,7 +48,7 @@ Section Cofunctormaps.
     := disp_dirprod_bicat disp_presheaf disp_presheaf.
 
   Definition disp_two_presheaves_is_univalent_2_1
-    : disp_locally_univalent disp_two_presheaves.
+    : disp_univalent_2_1 disp_two_presheaves.
   Proof.
     apply is_univalent_2_1_dirprod_bicat.
     - exact (disp_presheaves_is_univalent_2_1 K).
@@ -130,9 +130,9 @@ Section Cofunctormaps.
     := total_bicat morphisms_of_presheaves_display.
 
   Definition disp_cofunctormaps_bicat_univalent_2_1
-    : disp_locally_univalent disp_cofunctormaps_bicat.
+    : disp_univalent_2_1 disp_cofunctormaps_bicat.
   Proof.
-    apply disp_cell_unit_bicat_locally_univalent.
+    apply disp_cell_unit_bicat_univalent_2_1.
     intros F G η x y ; simpl in *.
     apply isaset_nat_trans.
     apply K.
@@ -151,7 +151,7 @@ Section Cofunctormaps.
     : disp_univalent_2_0 disp_cofunctormaps_bicat.
   Proof.
     apply disp_cell_unit_bicat_univalent_2_0.
-    + apply total_is_locally_univalent.
+    + apply total_is_univalent_2_1.
       * exact univalent_cat_is_univalent_2_1.
       * exact disp_two_presheaves_is_univalent_2_1.
     + intros F G η x y ; simpl in *.

--- a/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/ContravariantFunctor.v
+++ b/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/ContravariantFunctor.v
@@ -170,9 +170,9 @@ Section fix_a_category.
   Qed.
 
   Definition disp_presheaves_is_univalent_2_1
-    : disp_locally_univalent disp_presheaf_bicat.
+    : disp_univalent_2_1 disp_presheaf_bicat.
   Proof.
-    apply fiberwise_local_univalent_is_locally_univalent.
+    apply fiberwise_local_univalent_is_univalent_2_1.
     intros C D F CD FC α β.
     use isweqimplimpl.
     - intro p ; cbn in * ; unfold idfun in *.

--- a/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/DisplayedCatToBicat.v
+++ b/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/DisplayedCatToBicat.v
@@ -57,12 +57,12 @@ Section Disp_Prebicat_Cells_Unit.
   Defined.
 
   (** Local Univalence *)
-  Definition disp_cell_unit_bicat_locally_univalent
+  Definition disp_cell_unit_bicat_univalent_2_1
              (H : ∏ (a b : C)
                     (f : a --> b)
                     (aa : D a) (bb : D b),
                   isaprop (aa -->[ f] bb))
-    : disp_locally_univalent disp_cell_unit_bicat.
+    : disp_univalent_2_1 disp_cell_unit_bicat.
   Proof.
     intros a b f g p aa bb ff gg.
     use isweqimplimpl.

--- a/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/FullSub.v
+++ b/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/FullSub.v
@@ -131,10 +131,10 @@ Section FullSubBicat.
     - apply isaprop_is_invertible_2cell.
   Defined.
 
-  Definition disp_fullsubbicat_locally_univalent
-    : disp_locally_univalent disp_fullsubbicat.
+  Definition disp_fullsubbicat_univalent_2_1
+    : disp_univalent_2_1 disp_fullsubbicat.
   Proof.
-    apply fiberwise_local_univalent_is_locally_univalent.
+    apply fiberwise_local_univalent_is_univalent_2_1.
     intros x y f xx yy ff gg.
     use isweqimplimpl.
     - intros.
@@ -152,9 +152,9 @@ Section FullSubBicat.
              (HC : is_univalent_2_1 C)
     : is_univalent_2_1 fullsubbicat.
   Proof.
-    apply total_is_locally_univalent.
+    apply total_is_univalent_2_1.
     - exact HC.
-    - exact disp_fullsubbicat_locally_univalent.
+    - exact disp_fullsubbicat_univalent_2_1.
   Defined.
 
   Definition fullsub_left_adjoint_equivalence_to_bicat_left_adjoint_equivalence
@@ -273,6 +273,6 @@ Section FullSubBicat.
         * exact isapropunit.
         * apply isaprop_disp_left_adjoint_equivalence.
           ** apply HC1.
-          ** exact disp_fullsubbicat_locally_univalent.
+          ** exact disp_fullsubbicat_univalent_2_1.
   Defined.
 End FullSubBicat.

--- a/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/Monads.v
+++ b/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/Monads.v
@@ -129,8 +129,8 @@ Section MonadBicategory.
   Proof.
     apply is_univalent_2_1_total_dirprod.
     - exact (plain_monad_is_univalent_2_1 HC_1).
-    - apply add_cell_disp_cat_locally_univalent.
-    - apply add_cell_disp_cat_locally_univalent.
+    - apply add_cell_disp_cat_univalent_2_1.
+    - apply add_cell_disp_cat_univalent_2_1.
   Defined.
 
   Definition lawless_monad_is_univalent_2_0
@@ -144,12 +144,12 @@ Section MonadBicategory.
       exact HC_1.
     - apply add_cell_disp_cat_univalent_2_0.
       + exact HC_1.
-      + apply disp_alg_bicat_locally_univalent.
+      + apply disp_alg_bicat_univalent_2_1.
     - apply add_cell_disp_cat_univalent_2_0.
       + exact HC_1.
-      + apply disp_alg_bicat_locally_univalent.
-    - apply add_cell_disp_cat_locally_univalent.
-    - apply add_cell_disp_cat_locally_univalent.
+      + apply disp_alg_bicat_univalent_2_1.
+    - apply add_cell_disp_cat_univalent_2_1.
+    - apply add_cell_disp_cat_univalent_2_1.
   Defined.
 
   Definition monad_obj : lawless_monad → C

--- a/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/PointedOneTypes.v
+++ b/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/PointedOneTypes.v
@@ -89,9 +89,9 @@ Defined.
 
 Definition p1types : bicat := total_bicat p1types_disp.
 
-Lemma p1types_disp_locally_univalent : disp_locally_univalent p1types_disp.
+Lemma p1types_disp_univalent_2_1 : disp_univalent_2_1 p1types_disp.
 Proof.
-  apply fiberwise_local_univalent_is_locally_univalent.
+  apply fiberwise_local_univalent_is_univalent_2_1.
   intros X Y f x y. cbn. intros p q.
   use gradth.
   - intro α. apply α.
@@ -116,13 +116,13 @@ Proof.
     { induction f. reflexivity. }
     { apply (isaprop_disp_left_adjoint_equivalence (D:=p1types_disp)).
       apply one_types_is_univalent_2.
-      apply p1types_disp_locally_univalent. }
+      apply p1types_disp_univalent_2_1. }
 Defined.
 
 Lemma p1types_univalent : is_univalent_2 p1types.
 Proof.
   apply total_is_univalent.
   - apply p1types_disp_global_univalent.
-  - apply p1types_disp_locally_univalent.
+  - apply p1types_disp_univalent_2_1.
   - apply one_types_is_univalent_2.
 Defined.

--- a/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/Prod.v
+++ b/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/Prod.v
@@ -439,8 +439,8 @@ Section Disp_Dirprod.
              {bb : disp_dirprod_bicat b}
              (ff : aa -->[f] bb)
              (gg : aa -->[g] bb)
-             (HD1 : disp_locally_univalent D1)
-             (HD2 : disp_locally_univalent D2)
+             (HD1 : disp_univalent_2_1 D1)
+             (HD2 : disp_univalent_2_1 D2)
     : (transportf (λ z : C ⟦ a, b ⟧, aa -->[ z] bb) p ff = gg)
         ≃
         disp_invertible_2cell (idtoiso_2_1 f g p) ff gg.
@@ -455,9 +455,9 @@ Section Disp_Dirprod.
   Defined.
 
   Definition is_univalent_2_1_dirprod_bicat
-             (HD1 : disp_locally_univalent D1)
-             (HD2 : disp_locally_univalent D2)
-    : disp_locally_univalent disp_dirprod_bicat.
+             (HD1 : disp_univalent_2_1 D1)
+             (HD2 : disp_univalent_2_1 D2)
+    : disp_univalent_2_1 disp_dirprod_bicat.
   Proof.
     intros a b f g p aa bb ff gg.
     use weqhomot.
@@ -684,8 +684,8 @@ Section Disp_Dirprod.
   Definition pair_adjoint_equivalence_weq
              {a b : C}
              (HC : is_univalent_2_1 C)
-             (HD1 : disp_locally_univalent D1)
-             (HD2 : disp_locally_univalent D2)
+             (HD1 : disp_univalent_2_1 D1)
+             (HD2 : disp_univalent_2_1 D2)
              (f : adjoint_equivalence a b)
              (aa : disp_dirprod_bicat a)
              (bb : disp_dirprod_bicat b)
@@ -727,8 +727,8 @@ Section Disp_Dirprod.
              (HC : is_univalent_2_1 C)
              (HD1_0 : disp_univalent_2_0 D1)
              (HD2_0 : disp_univalent_2_0 D2)
-             (HD1_1 : disp_locally_univalent D1)
-             (HD2_1 : disp_locally_univalent D2)
+             (HD1_1 : disp_univalent_2_1 D1)
+             (HD2_1 : disp_univalent_2_1 D2)
              {a b : C}
              (p : a = b)
              (aa : disp_dirprod_bicat a)
@@ -750,8 +750,8 @@ Section Disp_Dirprod.
              (HC : is_univalent_2_1 C)
              (HD1_0 : disp_univalent_2_0 D1)
              (HD2_0 : disp_univalent_2_0 D2)
-             (HD1_1 : disp_locally_univalent D1)
-             (HD2_1 : disp_locally_univalent D2)
+             (HD1_1 : disp_univalent_2_1 D1)
+             (HD2_1 : disp_univalent_2_1 D2)
     : disp_univalent_2_0 disp_dirprod_bicat.
   Proof.
     intros a b p aa bb.
@@ -769,11 +769,11 @@ Section Disp_Dirprod.
 
   Definition is_univalent_2_1_total_dirprod
              (HC : is_univalent_2_1 C)
-             (HD1 : disp_locally_univalent D1)
-             (HD2 : disp_locally_univalent D2)
+             (HD1 : disp_univalent_2_1 D1)
+             (HD2 : disp_univalent_2_1 D2)
     : is_univalent_2_1 (total_bicat disp_dirprod_bicat).
   Proof.
-    apply total_is_locally_univalent.
+    apply total_is_univalent_2_1.
     - exact HC.
     - apply is_univalent_2_1_dirprod_bicat.
       * exact HD1.
@@ -785,8 +785,8 @@ Section Disp_Dirprod.
              (HC_1 : is_univalent_2_1 C)
              (HD1_0 : disp_univalent_2_0 D1)
              (HD2_0 : disp_univalent_2_0 D2)
-             (HD1_1 : disp_locally_univalent D1)
-             (HD2_1 : disp_locally_univalent D2)
+             (HD1_1 : disp_univalent_2_1 D1)
+             (HD2_1 : disp_univalent_2_1 D2)
     : is_univalent_2_0 (total_bicat disp_dirprod_bicat).
   Proof.
     apply total_is_univalent_2_0.

--- a/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/Sigma.v
+++ b/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/Sigma.v
@@ -209,9 +209,9 @@ Section SigmaUnivalent.
            (HC_2_0 : is_univalent_2_0 C)
            (HC_2_1 : is_univalent_2_1 C)
            (HD₁_2_0 : disp_univalent_2_0 D₁)
-           (HD₁_2_1 : disp_locally_univalent D₁)
+           (HD₁_2_1 : disp_univalent_2_1 D₁)
            (HD₂_2_0 : disp_univalent_2_0 D₂)
-           (HD₂_2_1 : disp_locally_univalent D₂).
+           (HD₂_2_1 : disp_univalent_2_1 D₂).
 
   Local Notation E₁ := (total_bicat D₂).
   Local Notation E₂ := (total_bicat (sigma_bicat C D₁ D₂)).
@@ -229,8 +229,8 @@ Section SigmaUnivalent.
   Definition E₁_univalent_2_1
     : is_univalent_2_1 E₁.
   Proof.
-    apply total_is_locally_univalent.
-    - apply total_is_locally_univalent.
+    apply total_is_univalent_2_1.
+    - apply total_is_univalent_2_1.
       + exact HC_2_1.
       + exact HD₁_2_1.
     - exact HD₂_2_1.

--- a/UniMath/CategoryTheory/Bicategories/PseudoFunctors/Display/Compositor.v
+++ b/UniMath/CategoryTheory/Bicategories/PseudoFunctors/Display/Compositor.v
@@ -44,7 +44,7 @@ Section Compositor.
                • (Fcomp X Y Z f g ▹ ηobj η Z)).
   Defined.
 
-  Definition compositor_disp_cat_laws
+  Definition compositor_disp_cat_id_comp
     : disp_cat_id_comp (map1cells C D) compositor_disp_cat_data.
   Proof.
     split.
@@ -250,13 +250,13 @@ Section Compositor.
     use disp_cell_unit_bicat.
     use tpair.
     - exact compositor_disp_cat_data.
-    - exact compositor_disp_cat_laws.
+    - exact compositor_disp_cat_id_comp.
   Defined.
 
   Definition compositor_is_disp_univalent_2_1
-    : disp_locally_univalent compositor_disp_cat.
+    : disp_univalent_2_1 compositor_disp_cat.
   Proof.
-    apply disp_cell_unit_bicat_locally_univalent.
+    apply disp_cell_unit_bicat_univalent_2_1.
     intros F G η Fcomp Gcomp ; simpl in *.
     repeat (apply impred ; intro).
     apply D.

--- a/UniMath/CategoryTheory/Bicategories/PseudoFunctors/Display/Identitor.v
+++ b/UniMath/CategoryTheory/Bicategories/PseudoFunctors/Display/Identitor.v
@@ -39,7 +39,7 @@ Section Identitor.
                • (Fid X ▹ ηobj η X)).
   Defined.
 
-  Definition identitor_disp_cat_laws
+  Definition identitor_disp_id_comp
     : disp_cat_id_comp (map1cells C D) identitor_disp_cat_data.
   Proof.
     split.
@@ -93,13 +93,13 @@ Section Identitor.
     use disp_cell_unit_bicat.
     use tpair.
     - exact identitor_disp_cat_data.
-    - exact identitor_disp_cat_laws.
+    - exact identitor_disp_id_comp.
   Defined.
 
   Definition identitor_is_disp_univalent_2_1
-    : disp_locally_univalent identitor_disp_cat.
+    : disp_univalent_2_1 identitor_disp_cat.
   Proof.
-    apply disp_cell_unit_bicat_locally_univalent.
+    apply disp_cell_unit_bicat_univalent_2_1.
     intros F G η Fid Gid ; simpl in *.
     apply impred ; intro.
     apply D.

--- a/UniMath/CategoryTheory/Bicategories/PseudoFunctors/Display/Map1Cells.v
+++ b/UniMath/CategoryTheory/Bicategories/PseudoFunctors/Display/Map1Cells.v
@@ -341,9 +341,9 @@ Section Map1Cells.
   Defined.
 
   Definition map1cells_disp_univalent_2_1
-    : disp_locally_univalent map1cells_disp_bicat.
+    : disp_univalent_2_1 map1cells_disp_bicat.
   Proof.
-    apply fiberwise_local_univalent_is_locally_univalent.
+    apply fiberwise_local_univalent_is_univalent_2_1.
     intros F G η F₁ G₁ η₁ η₁'.
     use isweqimplimpl.
     - intro m ; cbn in * ; unfold idfun.
@@ -636,7 +636,7 @@ Section Map1Cells.
              (HD_2_1 : is_univalent_2_1 D)
     : is_univalent_2_1 map1cells.
   Proof.
-    apply total_is_locally_univalent.
+    apply total_is_univalent_2_1.
     - apply ps_base_is_univalent_2_1.
       exact HD_2_1.
     - exact map1cells_disp_univalent_2_1.

--- a/UniMath/CategoryTheory/Bicategories/PseudoFunctors/Display/Map2Cells.v
+++ b/UniMath/CategoryTheory/Bicategories/PseudoFunctors/Display/Map2Cells.v
@@ -35,7 +35,7 @@ Section Map2Cells.
              ηmor η f • (F₂ X Y f g α ▹ ηobj η Y)) ; cbn in *.
   Defined.
 
-  Definition map2cells_disp_cat_laws
+  Definition map2cells_disp_cat_id_comp
     : disp_cat_id_comp (map1cells C D) map2cells_disp_cat_data.
   Proof.
     split.
@@ -76,13 +76,13 @@ Section Map2Cells.
     use disp_cell_unit_bicat.
     use tpair.
     - exact map2cells_disp_cat_data.
-    - exact map2cells_disp_cat_laws.
+    - exact map2cells_disp_cat_id_comp.
   Defined.
 
   Definition map2cells_is_disp_univalent_2_1
-    : disp_locally_univalent map2cells_disp_cat.
+    : disp_univalent_2_1 map2cells_disp_cat.
   Proof.
-    apply disp_cell_unit_bicat_locally_univalent.
+    apply disp_cell_unit_bicat_univalent_2_1.
     intros F G η F₂ G₂ ; simpl in *.
     repeat (apply impred ; intro).
     apply D.


### PR DESCRIPTION
- `identitor_disp_cat_laws` --> `identitor_disp_cat_id_comp`
- `compositor_disp_cat_laws` --> `compositor_disp_cat_id_comp`
- `map2cells_disp_cat_laws` -->  `map2cells_disp_cat_id_comp`
- `add_cell_disp_cat_laws` -->  `add_cell_disp_cat_id_comp`
- `..._locally_univalent` --> `..._univalent_2_1`