### PR TITLE
Consistent use of suffix `univalent_2` for biunivalence.

### DIFF
--- a/UniMath/CategoryTheory/Bicategories/DisplayedBicats/DispUnivalence.v
+++ b/UniMath/CategoryTheory/Bicategories/DisplayedBicats/DispUnivalence.v
@@ -250,7 +250,7 @@ Section Total_Category_Globally_Univalent.
   Defined.
 End Total_Category_Globally_Univalent.
 
-Lemma total_is_univalent
+Lemma total_is_univalent_2
       {C : bicat}
       {D: disp_bicat C}
   : disp_univalent_2_0 D →

--- a/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/PointedOneTypes.v
+++ b/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Examples/PointedOneTypes.v
@@ -103,7 +103,7 @@ Proof.
     apply Y.
 Defined.
 
-Lemma p1types_disp_global_univalent : disp_univalent_2_0 p1types_disp.
+Lemma p1types_disp_univalent_2_0 : disp_univalent_2_0 p1types_disp.
 Proof.
   apply fiberwise_univalent_2_0_to_disp_univalent_2_0.
   intros X x x'. cbn in *.
@@ -119,10 +119,10 @@ Proof.
       apply p1types_disp_univalent_2_1. }
 Defined.
 
-Lemma p1types_univalent : is_univalent_2 p1types.
+Lemma p1types_univalent_2 : is_univalent_2 p1types.
 Proof.
-  apply total_is_univalent.
-  - apply p1types_disp_global_univalent.
+  apply total_is_univalent_2.
+  - apply p1types_disp_univalent_2_0.
   - apply p1types_disp_univalent_2_1.
   - apply one_types_is_univalent_2.
 Defined.


### PR DESCRIPTION
And also rename `*_global_univalent` into `*_univalent_2_0`.