### PR TITLE
Make INSTALL shorter and clearer

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,8 +36,9 @@ Under Ubuntu or Debian, you may install ocaml with the
 following shell command.
 
 ```bash
- sudo apt-get install build-essential git ocaml ocaml-nox ocaml-native-compilers camlp4-extra camlp5 libgtk2.0 libgtksourceview2.0 liblablgtk-extras-ocaml-dev ocaml-findlib
+ sudo apt-get install build-essential git ocaml ocaml-nox ocaml-native-compilers camlp4-extra camlp5 libgtk2.0 libgtksourceview2.0 liblablgtk-extras-ocaml-dev ocaml-findlib emacs
 ```
+Now proceed with [Installation of ProofGeneral](#installation-of-proofgeneral-all-operating-systems) and [Installing UniMath](#installing-unimath) below.
 
 ### Preparing for the installation under Arch Linux or Manjaro Linux
 
@@ -49,7 +50,7 @@ shell commands.
  sudo pacman-key --populate archlinux
  sudo pacman --sync --needed ocaml camlp5 ocaml-findlib ocaml-num
 ```
-
+Now proceed with [Installation of ProofGeneral](#installation-of-proofgeneral-all-operating-systems) and [Installing UniMath](#installing-unimath) below.
 ## Installation of ProofGeneral (all operating systems)
 
 You may obtain ProofGeneral from by using the quick installation instructions

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,52 +29,6 @@ the program `coqide` and will have to depend on ProofGeneral instead.
 
 Now proceed with [Installation of ProofGeneral](#installation-of-proofgeneral-all-operating-systems) and [Installing UniMath](#installing-unimath) below.
 
-#### Second method (allows more flexibility, but is more involved than first method)
-
-Under Mac OS X, the most convenient way to do that is with "Homebrew",
-available from http://brew.sh/, with the following command:
-
-```bash
-$ brew install bash opam gtk+
-$ opam init --no-setup --compiler=4.02.3
-$ opam install --yes lablgtk camlp5 ocamlfind num
-```
-
-(We choose version 4.02.3 of ocamlc above, because it can successfully compile
-Coq 8.6.1.)
-
-Now arrange for the programs installed by opam to be available to the currently
-running shell:
-
-```bash
-$ eval `opam config env`
-```
-
-If you haven't done it previously in connection with installing opam, as you
-have just done, arrange for the programs (such as ocamlc) that opam will
-install for you to be found by your shell, the next time you log in, by adding
-the line
-
-```bash
-$ eval `opam config env`
-```
-
-to your file `~/.profile`, after any lines in the file that add
-`/usr/local/bin` to the `PATH` environment variable.  (Homebrew and opam both
-know how to install `ocamlc`, and we intend to use `opam` to get a version of
-`ocamlc` appropriate for compiling the version of Coq used by UniMath.)
-
-The next time you log in, or now, you may check that the progams installed by
-opam are accessible by you as follows.
-
-```bash
-$ type ocamlc
-ocamlc is hashed (/Users/XXXXXXXX/.opam/4.02.3/bin/ocamlc)
-$ ocamlc -version
-4.02.3
-$ camlp5 -v
-Camlp5 version 7.03 (ocaml 4.02.3)
-```
 
 ### Preparing for the installation under Ubuntu or Debian (Linux)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,6 +21,7 @@ A more flexible, but complex, installation method is given in [INSTALL\_MACOS.md
 ```bash
 $ brew install objective-caml ocaml-num camlp4 camlp5 bash ocaml-findlib
 ```
+3. Install Emacs from https://emacsformacosx.com/.
   
 Now proceed with [Installation of ProofGeneral](#installation-of-proofgeneral-all-operating-systems) and [Installing UniMath](#installing-unimath) below.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,17 +16,12 @@ and under [Arch/Manjaro Linux](#preparing-for-the-installation-under-arch-linux-
 NB: The method explained below is recommended for beginners.
 A more flexible, but complex, installation method is given in [INSTALL\_MACOS.md](./INSTALL_MACOS.md).
 
-Install "Homebrew", available from http://brew.sh/.
-
-Using Homebrew, install ocaml with the following command:
-
+1. Install "Homebrew", available from http://brew.sh/.
+2. Using Homebrew, install ocaml with the following command:
 ```bash
-$ brew install objective-caml ocaml-num camlp4 camlp5 lablgtk bash ocaml-findlib
+$ brew install objective-caml ocaml-num camlp4 camlp5 bash ocaml-findlib
 ```
-
-If installing `lablgtk` fails, you can omit it, but you won't be able to build
-the program `coqide` and will have to depend on ProofGeneral instead.
-
+  
 Now proceed with [Installation of ProofGeneral](#installation-of-proofgeneral-all-operating-systems) and [Installing UniMath](#installing-unimath) below.
 
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,13 +13,12 @@ and under [Arch/Manjaro Linux](#preparing-for-the-installation-under-arch-linux-
 
 ### Preparing for the installation under Mac OS X
 
-To prepare for the installation under Mac OS X, there are two methods.
+NB: The method explained below is recommended for beginners.
+A more flexible, but complex, installation method is given in [INSTALL\_MACOS.md](./INSTALL_MACOS.md).
 
-#### First method (recommended for beginners)
+Install "Homebrew", available from http://brew.sh/.
 
-Under Mac OS X, the most convenient way to
-do that is with "Homebrew", available from http://brew.sh/, with the following
-command:
+Using Homebrew, install ocaml with the following command:
 
 ```bash
 $ brew install objective-caml ocaml-num camlp4 camlp5 lablgtk bash ocaml-findlib

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,13 +37,14 @@ Now proceed with [Installation of ProofGeneral](#installation-of-proofgeneral-al
 
 ### Preparing for the installation under Arch Linux or Manjaro Linux
 
-Under Arch Linux or Manjaro Linux you may install ocaml with the following
+Under Arch Linux or Manjaro Linux you may install ocaml and Emacs  with the following
 shell commands.
 
 ```bash
  sudo pacman --sync --needed archlinux-keyring
  sudo pacman-key --populate archlinux
  sudo pacman --sync --needed ocaml camlp5 ocaml-findlib ocaml-num
+ sudo pacman -S emacs
 ```
 Now proceed with [Installation of ProofGeneral](#installation-of-proofgeneral-all-operating-systems) and [Installing UniMath](#installing-unimath) below.
 ## Installation of ProofGeneral (all operating systems)

--- a/INSTALL_MACOS.md
+++ b/INSTALL_MACOS.md
@@ -1,0 +1,49 @@
+# Second method to install ocaml on Mac OS X
+
+This method allows more flexibility, but is more involved than the method in [INSTALL.md](./INSTALL.md).
+
+Install "Homebrew", available from http://brew.sh/.
+
+Using Homebrew, install opam with the following command:
+
+```bash
+$ brew install bash opam gtk+
+$ opam init --no-setup --compiler=4.02.3
+$ opam install --yes lablgtk camlp5 ocamlfind num
+```
+
+(We choose version 4.02.3 of ocamlc above, because it can successfully compile
+Coq 8.6.1.)
+
+Now arrange for the programs installed by opam to be available to the currently
+running shell:
+
+```bash
+$ eval `opam config env`
+```
+
+If you haven't done it previously in connection with installing opam, as you
+have just done, arrange for the programs (such as ocamlc) that opam will
+install for you to be found by your shell, the next time you log in, by adding
+the line
+
+```bash
+$ eval `opam config env`
+```
+
+to your file `~/.profile`, after any lines in the file that add
+`/usr/local/bin` to the `PATH` environment variable.  (Homebrew and opam both
+know how to install `ocamlc`, and we intend to use `opam` to get a version of
+`ocamlc` appropriate for compiling the version of Coq used by UniMath.)
+
+The next time you log in, or now, you may check that the progams installed by
+opam are accessible by you as follows.
+
+```bash
+$ type ocamlc
+ocamlc is hashed (/Users/XXXXXXXX/.opam/4.02.3/bin/ocamlc)
+$ ocamlc -version
+4.02.3
+$ camlp5 -v
+Camlp5 version 7.03 (ocaml 4.02.3)
+```


### PR DESCRIPTION
This PR is not complete: the installation instructions for Emacs under Mac OS X and Arch are missing.

I don't know what the recommended way is to install Emacs on those systems.

@DanGrayson @tomdjong : can you help?

solves #1175 and #1177 