### PR TITLE
PathsOver notations and restore a lost lemma

### DIFF
--- a/UniMath/MoreFoundations/PathsOver.v
+++ b/UniMath/MoreFoundations/PathsOver.v
@@ -76,12 +76,12 @@ Definition pathOverIdpath {X:Type} {x:X} {Y : X -> Type} (y y' : Y x) : PathOver
 Definition toPathOverIdpath {X:Type} {x:X} {Y : X -> Type} (y y' : Y x) : y = y' -> PathOver y y' (idpath x)
   := idfun _.
 
-Notation "'∇' q" := (toPathOverIdpath q) (at level 10) : pathsover.
+Local Notation "'∇' q" := (toPathOverIdpath q) (at level 10) : pathsover.
 
 Definition fromPathOverIdpath {X:Type} {x:X} {Y : X -> Type} (y y' : Y x) : PathOver y y' (idpath x) -> y = y'
   := idfun _.
 
-Notation "'Δ' q" := (fromPathOverIdpath q) (at level 10) : pathsover.
+Local Notation "'Δ' q" := (fromPathOverIdpath q) (at level 10) : pathsover.
 
 Definition inductionPathOver {X:Type} {x:X} {Y : X -> Type} (y : Y x)
            (T : ∏ x' (y' : Y x') (p : x = x'), PathOver y y' p → Type)
@@ -111,7 +111,7 @@ Proof.
   induction p, p'. exact pathscomp0.
 Defined.
 
-Notation "x * y" := (composePathOver x y) : pathsover.
+Local Notation "x * y" := (composePathOver x y) : pathsover.
 
 Definition composePathOverPath {X:Type} {x x':X} {Y : X -> Type} {y : Y x} {y' y'' : Y x'}
            {p:x=x'} : PathOver y y' p → y' = y'' → PathOver y y'' p.
@@ -119,7 +119,7 @@ Proof.
   intros q e. now induction e.
 Defined.
 
-Notation "q ⟥ e" := (composePathOverPath q e) (at level 56, left associativity) : pathsover.
+Local Notation "q ⟥ e" := (composePathOverPath q e) (at level 56, left associativity) : pathsover.
 
 Definition composePathPathOver {X:Type} {x' x'':X} {Y : X -> Type} {y y': Y x'} {y'' : Y x''}
            {p:x'=x''} : y = y' → PathOver y' y'' p → PathOver y y'' p.
@@ -127,7 +127,7 @@ Proof.
   intros e q. now induction e.
 Defined.
 
-Notation "e ⟤ q" := (composePathPathOver e q) (at level 56, left associativity) : pathsover.
+Local Notation "e ⟤ q" := (composePathPathOver e q) (at level 56, left associativity) : pathsover.
 
 Definition composePathOverLeftUnit {X:Type} {x x':X} {Y : X -> Type} (y : Y x) (y' : Y x') (p:x=x') (q:PathOver y y' p) :
   identityPathOver y * q = q.
@@ -164,7 +164,7 @@ Proof.
   intros q. induction p, q. reflexivity.
 Defined.
 
-Notation "q '^-1'" := (inversePathOver q) : pathsover.
+Local Notation "q '^-1'" := (inversePathOver q) : pathsover.
 
 Definition inversePathOverIdpath {X:Type} {x:X} {Y : X -> Type} (y y' : Y x) (e : y = y') :
   inversePathOver (∇ e) = ∇ (!e).

--- a/UniMath/MoreFoundations/PathsOver.v
+++ b/UniMath/MoreFoundations/PathsOver.v
@@ -374,3 +374,12 @@ Definition cp_apstar'
 Proof.
   now induction α, p.
 Defined.
+
+Module PathsOverNotations.
+Notation "'Δ' q" := (fromPathOverIdpath q) (at level 10) : pathsover.
+Notation "'∇' q" := (toPathOverIdpath q) (at level 10) : pathsover.
+Notation "x * y" := (composePathOver x y) : pathsover.
+Notation "q ⟥ e" := (composePathOverPath q e) (at level 56, left associativity) : pathsover.
+Notation "e ⟤ q" := (composePathPathOver e q) (at level 56, left associativity) : pathsover.
+Notation "q '^-1'" := (inversePathOver q) : pathsover.
+End PathsOverNotations.

--- a/UniMath/MoreFoundations/Sets.v
+++ b/UniMath/MoreFoundations/Sets.v
@@ -170,10 +170,8 @@ End Pi0.
 
 
 (** ** Minimal equivalence relations *)
-
-(* This should be moved upstream. Constructs the smallest eqrel
-   containing a given relation *)
-Section extras.
+(* Constructs the smallest eqrel containing a given relation *)
+Section mineqrel.
 
   Close Scope set.
 
@@ -208,4 +206,11 @@ Section extras.
     now intros a b H'; apply (H' _ H).
   Qed.
 
-End extras.
+End mineqrel.
+
+Lemma eqreleq {A : UU} (R : eqrel A) (x y : A) : x = y → R x y.
+Proof.
+  intros e.
+  induction e.
+  apply eqrelrefl.
+Defined.

--- a/UniMath/SyntheticHomotopyTheory/Circle2.v
+++ b/UniMath/SyntheticHomotopyTheory/Circle2.v
@@ -22,7 +22,7 @@
   *)
 
 Require Import UniMath.Foundations.All.
-Require Import UniMath.MoreFoundations.All.
+Require Import UniMath.MoreFoundations.All. Import PathsOverNotations.
 Require Import UniMath.Algebra.Monoids. Import AddNotation.
 Require Import UniMath.SyntheticHomotopyTheory.AffineLine.
 Require Import UniMath.NumberSystems.Integers.


### PR DESCRIPTION
The PathsOver file in MoreFoundations was exporting a lot of notations globally which disrupted a soon to appear PR of mine to TypeTheory (in particular the notation for Delta). I made all of these notations local and put them in a Module so that we can control when we want to have them and when we don't want them.

I also saved a lemma about equivalence relations that was lost when UniMath.Ktheory.Monoid was removed in https://github.com/UniMath/UniMath/pull/1163.