### PR TITLE
working on the package on monoidal categories

### DIFF
--- a/UniMath/CategoryTheory/Monoidal/Actions.v
+++ b/UniMath/CategoryTheory/Monoidal/Actions.v
@@ -34,96 +34,21 @@ Section Actions_Definition.
 
 Section Actions_Natural_Transformations.
 
-Context (A : precategory) (odot : functor (precategory_binproduct A V) A).
+Context {A : precategory} (odot : functor (precategory_binproduct A V) A).
 
 Notation "X ⊙ Y" := (odot (X , Y)) (at level 31).
 Notation "f #⊙ g" := (# odot (f #, g)) (at level 31).
 
-Definition odot_I_functor_data : functor_data A A.
-Proof.
-  exists (λ a, a ⊙ I).
-  intros ? ? f.
-  exact (f #⊙ (id I)).
-Defined.
-
-Definition odot_I_is_functor : is_functor odot_I_functor_data.
-Proof.
-  split.
-  - intro.
-    simpl.
-    rewrite binprod_id.
-    rewrite (functor_id odot).
-    reflexivity.
-  - unfold functor_compax.
-    simpl.
-    intros.
-    replace (id I) with (id I · id I).
-    rewrite binprod_comp.
-    rewrite id_left.
-    rewrite (functor_comp odot).
-    reflexivity.
-    rewrite id_left.
-    reflexivity.
-Qed.
-
-Definition odot_I_functor : functor A A := mk_functor odot_I_functor_data odot_I_is_functor.
+Definition odot_I_functor : functor A A := functor_fix_snd_arg _ _ _ odot I.
 
 Definition action_right_unitor : UU := nat_iso odot_I_functor (functor_identity A).
 
-Definition odot_x_odot_y_functor_data : functor_data ((A ⊠ V) ⊠ V) A.
-Proof.
-  exists (λ a, (ob1 (ob1 a) ⊙ ob2 (ob1 a)) ⊙ ob2 a).
-  intros ? ? f.
-  exact ((mor1 (mor1 f) #⊙ mor2 (mor1 f)) #⊙ mor2 f).
-Defined.
+Definition odot_x_odot_y_functor : (A ⊠ V) ⊠ V ⟶ A :=
+  functor_composite (pair_functor odot (functor_identity _)) odot.
 
-Definition odot_x_odot_y_is_functor : is_functor odot_x_odot_y_functor_data.
-Proof.
-  split.
-  - intro.
-    simpl.
-    repeat rewrite (binprod_proj_id a); repeat rewrite binprod_proj_id.
-    do 2 (rewrite binprod_id; rewrite (functor_id odot)).
-    reflexivity.
-  - unfold functor_compax.
-    simpl.
-    intros.
-    repeat rewrite (binprod_proj_comp f); repeat rewrite binprod_proj_comp.
-    do 2 (rewrite binprod_comp; rewrite (functor_comp odot)).
-    reflexivity.
-Qed.
-
-Definition odot_x_odot_y_functor : (A ⊠ V) ⊠ V ⟶ A := mk_functor odot_x_odot_y_functor_data odot_x_odot_y_is_functor.
-
-Definition odot_x_otimes_y_functor_data : functor_data ((A ⊠ V) ⊠ V) A.
-Proof.
-  exists (λ a, ob1 (ob1 a) ⊙ (ob2 (ob1 a) ⊗ ob2 a)).
-  intros ? ? f.
-  exact (mor1 (mor1 f) #⊙ (mor2 (mor1 f) #⊗ mor2 f)).
-Defined.
-
-Definition odot_x_otimes_y_is_functor : is_functor odot_x_otimes_y_functor_data.
-  split.
-  - intro.
-    simpl.
-    repeat rewrite (binprod_proj_id a); repeat rewrite binprod_proj_id.
-    rewrite binprod_id.
-    rewrite (functor_id tensor).
-    rewrite binprod_id.
-    rewrite (functor_id odot).
-    reflexivity.
-  - unfold functor_compax.
-    simpl.
-    intros.
-    rewrite <- (functor_comp odot).
-    rewrite <- binprod_comp.
-    repeat rewrite (binprod_proj_comp f); repeat rewrite binprod_proj_comp.
-    rewrite binprod_comp.
-    rewrite (functor_comp tensor).
-    reflexivity.
-Qed.
-
-Definition odot_x_otimes_y_functor : (A ⊠ V) ⊠ V ⟶ A := mk_functor odot_x_otimes_y_functor_data odot_x_otimes_y_is_functor.
+Definition odot_x_otimes_y_functor : (A ⊠ V) ⊠ V ⟶ A :=
+  functor_composite (precategory_binproduct_unassoc _ _ _)
+                    (functor_composite (pair_functor (functor_identity _) tensor) odot).
 
 Definition action_convertor : UU := nat_iso odot_x_odot_y_functor odot_x_otimes_y_functor.
 
@@ -131,14 +56,16 @@ Definition action_triangle_eq (ϱ : action_right_unitor) (χ : action_convertor)
   (pr1 ϱ a) #⊙ (id x) = (pr1 χ ((a, I), x)) · (id a) #⊙ (pr1 λ' x).
 
 Definition action_pentagon_eq (χ : action_convertor) := ∏ (a : A), ∏ (x y z : V),
-(pr1 χ ((a ⊙ x, y), z)) · (pr1 χ ((a, x), y ⊗ z)) = (pr1 χ ((a, x), y)) #⊙ (id z) · (pr1 χ ((a, x ⊗ y), z)) · (id a) #⊙ (pr1 α' ((x, y), z)).
+  (pr1 χ ((a ⊙ x, y), z)) · (pr1 χ ((a, x), y ⊗ z)) =
+  (pr1 χ ((a, x), y)) #⊙ (id z) · (pr1 χ ((a, x ⊗ y), z)) ·
+                                  (id a) #⊙ (pr1 α' ((x, y), z)).
 
 End Actions_Natural_Transformations.
 
 (* Action over a monoidal category. *)
-Definition action : UU := ∑ A : precategory, ∑ (odot : A ⊠ V ⟶ A), ∑ (ϱ : action_right_unitor A odot), ∑ (χ : action_convertor A odot), (action_triangle_eq A odot ϱ χ) × (action_pentagon_eq A odot χ).
+Definition action : UU := ∑ A : precategory, ∑ (odot : A ⊠ V ⟶ A), ∑ (ϱ : action_right_unitor odot), ∑ (χ : action_convertor odot), (action_triangle_eq odot ϱ χ) × (action_pentagon_eq odot χ).
 
-Definition action_struct : UU := ∑ A : precategory, ∑ (odot : A ⊠ V ⟶ A), ∑ (ϱ : action_right_unitor A odot), ∑ (χ : action_convertor A odot), unit.
+Definition action_struct : UU := ∑ A : precategory, ∑ (odot : A ⊠ V ⟶ A), ∑ (ϱ : action_right_unitor odot), ∑ (χ : action_convertor odot), unit.
 
 End Actions_Definition.
 
@@ -168,78 +95,39 @@ Let ρ_A := monoidal_precat_right_unitor Mon_A.
 
 Context (U : strong_monoidal_functor Mon_V Mon_A).
 
-Definition otimes_U_functor_data : functor_data (A ⊠ V) A.
-Proof.
-  exists (λ av, ob1 av ⊗_A U (ob2 av)).
-  intros ? ? f.
-  exact (mor1 f #⊗_A #U (mor2 f)).
-Defined.
+Definition otimes_U_functor : A ⊠ V ⟶ A := functor_composite (pair_functor (functor_identity _) U) tensor_A.
 
-Definition otimes_U_is_functor : is_functor otimes_U_functor_data.
-Proof.
-  split.
-  - intro.
-    simpl.
-    rewrite (functor_id U).
-    rewrite binprod_id.
-    rewrite (functor_id tensor_A).
-    reflexivity.
-  - unfold functor_compax.
-    simpl.
-    intros.
-    rewrite (functor_comp U).
-    rewrite binprod_comp.
-    rewrite (functor_comp tensor_A).
-    reflexivity.
-Qed.
-
-Definition otimes_U_functor : A ⊠ V ⟶ A := mk_functor otimes_U_functor_data otimes_U_is_functor.
-
-Definition U_action_ρ_nat_trans_data : nat_trans_data (odot_I_functor A otimes_U_functor) (functor_identity A).
-Proof.
+Definition U_action_ρ_nat_trans : odot_I_functor otimes_U_functor ⟹ functor_identity A.
+  refine (nat_trans_comp _ _ _ _  (pr1 ρ_A)).
+  unfold odot_I_functor.
   pose (ϵ_inv := inv_from_iso (mk_iso (pr1 (pr2 U)))).
-  exact (λ x, id x #⊗_A ϵ_inv · pr1 ρ_A x).
-Defined.
-
-Definition U_action_ρ_is_nat_trans : is_nat_trans (odot_I_functor A otimes_U_functor) (functor_identity A) U_action_ρ_nat_trans_data.
-  intros x x' f.
-  pose (ρ_nat_law := pr2 (pr1 ρ_A) x x' f).
-  simpl; simpl in ρ_nat_law.
-  pose (ϵ_inv := inv_from_iso (mk_iso (pr1 (pr2 U)))).
-  assert (ϵ_coher : id x #⊗_A ϵ_inv · f #⊗_A id I_A = f #⊗_A (#U (id I)) · id x' #⊗_A ϵ_inv).
-  * do 2 rewrite <- functor_comp.
-    do 2 rewrite <- binprod_comp.
+  set (aux := nat_trans_from_functor_fix_snd_morphism_arg _ _ _ tensor_A _ _ ϵ_inv).
+  (* aux is "morally" the result, but types do not fully agree, hence we argue more extensionally *)
+  use tpair.
+  - intro a.
+    apply (pr1 aux a).
+  - cbn; red.
+    intros a a' f.
+    cbn.
     rewrite functor_id.
-    do 2 (rewrite id_left; rewrite id_right).
-    reflexivity.
-  * unfold U_action_ρ_nat_trans_data.
-    rewrite assoc.
-    assert (goal' : (# tensor_A (f #, # U (id I)) · # tensor_A (id x' #, ϵ_inv) · (pr1 ρ_A) x' = # tensor_A (id x #, ϵ_inv) · (pr1 ρ_A) x · f)); [| exact goal'].
-    rewrite <- ϵ_coher.
-    repeat rewrite <- assoc.
-    assert (goal' : (# tensor_A (id x #, ϵ_inv) · (# tensor_A (f #, id I_A) · (pr1 ρ_A) x') = # tensor_A (id x #, ϵ_inv) · (pr1 (pr1 ρ_A) x · f))); [| exact goal'].
-    assert (ρ_nat_law' : (# (pr1 (pr2 Mon_A)) (f #, id pr1 (pr2 (pr2 Mon_A))) · pr1 (pr1 ρ_A) x' = pr1 (pr1 ρ_A) x · f)) by (exact ρ_nat_law); clear ρ_nat_law; rename ρ_nat_law' into ρ_nat_law.
-    rewrite <- ρ_nat_law.
-    reflexivity.
-Qed.
-
-Definition U_action_ρ_nat_trans : odot_I_functor A otimes_U_functor ⟹ functor_identity A := mk_nat_trans _ _ U_action_ρ_nat_trans_data U_action_ρ_is_nat_trans.
+    exact (pr2 aux a a' f).
+Defined.
 
 Definition U_action_ρ_is_nat_iso : is_nat_iso U_action_ρ_nat_trans.
 Proof.
   intro.
-  simpl.
+  cbn.
   use is_iso_comp_of_is_isos.
-  use is_iso_tensor_iso.
-  exact (identity_is_iso _ _).
-  use is_iso_inv_from_iso.
-  exact (pr2 ρ_A c).
+  - use is_iso_tensor_iso.
+    + exact (identity_is_iso _ _).
+    + use is_iso_inv_from_iso.
+  - exact (pr2 ρ_A c).
 Qed.
 
-Definition U_action_ρ : action_right_unitor A otimes_U_functor := mk_nat_iso _ _ U_action_ρ_nat_trans U_action_ρ_is_nat_iso.
+Definition U_action_ρ : action_right_unitor otimes_U_functor := mk_nat_iso _ _ U_action_ρ_nat_trans U_action_ρ_is_nat_iso.
 
-Definition U_action_χ_nat_trans_data : nat_trans_data (odot_x_odot_y_functor A otimes_U_functor)
-(odot_x_otimes_y_functor A otimes_U_functor).
+Definition U_action_χ_nat_trans_data : nat_trans_data (odot_x_odot_y_functor otimes_U_functor)
+(odot_x_otimes_y_functor otimes_U_functor).
 Proof.
   pose (μ := pr1 (pr2 (pr2 (pr1 U)))).
   intro x.
@@ -247,34 +135,52 @@ Proof.
   exact (pr1 α_A ((k, U k'), U k'') · id k #⊗_A pr1 μ (k', k'')).
 Defined.
 
-Definition U_action_χ_is_nat_trans : is_nat_trans (odot_x_odot_y_functor A otimes_U_functor)
-(odot_x_otimes_y_functor A otimes_U_functor) U_action_χ_nat_trans_data.
+Definition U_action_χ_is_nat_trans : is_nat_trans (odot_x_odot_y_functor otimes_U_functor)
+  (odot_x_otimes_y_functor otimes_U_functor) U_action_χ_nat_trans_data.
 Proof.
   pose (μ := pr1 (pr2 (pr2 (pr1 U)))).
   unfold U_action_χ_nat_trans_data.
   intros x x' g.
-  simpl.
+  cbn.
   pose (k_1 := ob1 (ob1 x)); pose (k'_1 := ob2 (ob1 x)); pose (k''_1 := ob2 x).
   pose (k_2 := ob1 (ob1 x')); pose (k'_2 := ob2 (ob1 x')); pose (k''_2 := ob2 x').
   pose (f := mor1 (mor1 g)); pose (f' := mor2 (mor1 g)); pose (f'' := mor2 g).
-  fold monoidal_precat_precat.
-  pose (α_nat_law := pr2 (pr1 α_A) ((k_1, U k'_1), U k''_1) ((k_2, U k'_2), U k''_2) ((f #, #U f') #, #U f'')).
-  assert (μ_coher : id k_1 #⊗_A (pr1 μ (k'_1, k''_1)) · (f #⊗_A #U (f' #⊗ f'')) = f #⊗_A (#U f' #⊗_A #U f'') · id k_2 #⊗_A (pr1 μ (k'_2, k''_2))).
-  do 2 rewrite <- tensor_comp.
-  rewrite id_left; rewrite id_right.
-  assert (snd_eq : pr1 μ (k'_1, k''_1) · # U (f' #⊗ f'') = # tensor_A (# U f' #, # U f'') · pr1 μ (k'_2, k''_2)).
-  symmetry.
-  exact (pr2 μ (k'_1, k''_1) (k'_2, k''_2) (f' #, f'')).
-  assert (goal' : (# tensor_A (f #, pr1 μ (k'_1, k''_1) · # U (# tensor (f' #, f''))) = # tensor_A (f #, # tensor_A (# U f' #, # U f'') · pr1 μ (k'_2, k''_2)))); [| exact goal'].
-  rewrite <- snd_eq.
-  reflexivity.
-  assert (α_nat_law' : (# tensor_A (# tensor_A (f #, # U f') #, # U f'') · pr1 (pr1 α_A) ((k_2, U k'_2), U k''_2) = pr1 (pr1 α_A) ((k_1, U k'_1), U k''_1) · # tensor_A (f #, # tensor_A (# U f' #, # U f'')))) by (exact α_nat_law); clear α_nat_law; rename α_nat_law' into α_nat_law.
-  pose (α_nat_law' := maponpaths (λ p, p · id k_2 #⊗_A (pr1 μ (k'_2, k''_2))) α_nat_law).
+  assert (α_nat_law := pr2 (pr1 α_A) ((k_1, U k'_1), U k''_1)
+                                     ((k_2, U k'_2), U k''_2)
+                                     ((f #, #U f') #, #U f'')).
+  assert (μ_coher : id k_1 #⊗_A (pr1 μ (k'_1, k''_1)) · (f #⊗_A #U (f' #⊗ f'')) =
+                    f #⊗_A (#U f' #⊗_A #U f'') · id k_2 #⊗_A (pr1 μ (k'_2, k''_2))).
+  { do 2 rewrite <- tensor_comp.
+    rewrite id_left; rewrite id_right.
+    assert (snd_eq : pr1 μ (k'_1, k''_1) · # U (f' #⊗ f'') =
+                     # tensor_A (# U f' #, # U f'') · pr1 μ (k'_2, k''_2)).
+    { apply pathsinv0.
+      exact (pr2 μ (k'_1, k''_1) (k'_2, k''_2) (f' #, f'')).
+    }
+    change (# tensor_A (f #, pr1 μ (k'_1, k''_1) · # U (# tensor (f' #, f''))) =
+            # tensor_A (f #, # tensor_A (# U f' #, # U f'') · pr1 μ (k'_2, k''_2))).
+    rewrite <- snd_eq.
+    apply idpath.
+  }
+  change (# tensor_A (# tensor_A (f #, # U f') #, # U f'') ·
+            pr1 (pr1 α_A) ((k_2, U k'_2), U k''_2) =
+          pr1 (pr1 α_A) ((k_1, U k'_1), U k''_1) ·
+              # tensor_A (f #, # tensor_A (# U f' #, # U f''))) in α_nat_law.
+  assert (α_nat_law' := maponpaths (λ p, p · id k_2 #⊗_A (pr1 μ (k'_2, k''_2))) α_nat_law).
   simpl in α_nat_law'.
   repeat rewrite <- assoc in α_nat_law'.
-  assert (α_nat_law'' : (# tensor_A (# tensor_A (f #, # U f') #, # U f'') · (pr1 (pr1 α_A) ((k_2, U k'_2), U k''_2) · # tensor_A (id k_2 #, pr1 μ (k'_2, k''_2))) = pr1 (pr1 α_A) ((k_1, U k'_1), U k''_1) · (# tensor_A (f #, # tensor_A (# U f' #, # U f'')) · # tensor_A (id k_2 #, pr1 μ (k'_2, k''_2))))) by (exact α_nat_law'); clear α_nat_law'; rename α_nat_law'' into α_nat_law'.
-  assert (μ_coher' : (# tensor_A (id k_1 #, pr1 μ (k'_1, k''_1)) · # tensor_A (f #, # U (# tensor (f' #, f''))) = # tensor_A (f #, # tensor_A (# U f' #, # U f'')) · # tensor_A (id k_2 #, pr1 μ (k'_2, k''_2)))) by (exact μ_coher); clear μ_coher; rename μ_coher' into μ_coher.
-  pose (common := (# tensor_A (f #, # tensor_A (# U f' #, # U f'')) · # tensor_A (id k_2 #, pr1 μ (k'_2, k''_2)))).
+  change (# tensor_A (# tensor_A (f #, # U f') #, # U f'') ·
+            (pr1 (pr1 α_A) ((k_2, U k'_2), U k''_2) ·
+                 # tensor_A (id k_2 #, pr1 μ (k'_2, k''_2))) =
+          pr1 (pr1 α_A) ((k_1, U k'_1), U k''_1) ·
+              (# tensor_A (f #, # tensor_A (# U f' #, # U f'')) ·
+                 # tensor_A (id k_2 #, pr1 μ (k'_2, k''_2)))) in α_nat_law'.
+  change (# tensor_A (id k_1 #, pr1 μ (k'_1, k''_1)) ·
+            # tensor_A (f #, # U (# tensor (f' #, f''))) =
+          # tensor_A (f #, # tensor_A (# U f' #, # U f'')) ·
+            # tensor_A (id k_2 #, pr1 μ (k'_2, k''_2))) in μ_coher.
+  pose (common := (# tensor_A (f #, # tensor_A (# U f' #, # U f'')) ·
+                     # tensor_A (id k_2 #, pr1 μ (k'_2, k''_2)))).
   fold common in μ_coher.
   fold common in α_nat_law'.
   rewrite <- μ_coher in α_nat_law'.
@@ -283,20 +189,22 @@ Proof.
   exact α_nat_law'.
 Qed.
 
-Definition U_action_χ_nat_trans : odot_x_odot_y_functor A otimes_U_functor ⟹ odot_x_otimes_y_functor A otimes_U_functor := mk_nat_trans _ _ U_action_χ_nat_trans_data U_action_χ_is_nat_trans.
+Definition U_action_χ_nat_trans : odot_x_odot_y_functor otimes_U_functor ⟹ odot_x_otimes_y_functor otimes_U_functor :=
+  mk_nat_trans _ _ U_action_χ_nat_trans_data U_action_χ_is_nat_trans.
 
-Definition U_action_χ_is_nat_iso : is_nat_iso U_action_χ_nat_trans.
+Lemma U_action_χ_is_nat_iso : is_nat_iso U_action_χ_nat_trans.
 Proof.
   intro x.
   pose (k := ob1 (ob1 x)); pose (k' := ob2 (ob1 x)); pose (k'' := ob2 x).
   use is_iso_comp_of_is_isos.
-  exact (pr2 α_A ((k, U k'), U k'')).
-  use is_iso_tensor_iso.
-  use identity_is_iso.
-  exact (pr2 (pr2 U) (k', k'')).
+  - exact (pr2 α_A ((k, U k'), U k'')).
+  - use is_iso_tensor_iso.
+    + use identity_is_iso.
+    + exact (pr2 (pr2 U) (k', k'')).
 Qed.
 
-Definition U_action_χ : action_convertor A otimes_U_functor := mk_nat_iso _ _ U_action_χ_nat_trans U_action_χ_is_nat_iso.
+Definition U_action_χ : action_convertor otimes_U_functor :=
+  mk_nat_iso _ _ U_action_χ_nat_trans U_action_χ_is_nat_iso.
 
 Definition U_action_struct : action_struct.
 Proof.
@@ -309,8 +217,13 @@ Proof.
 Defined.
 
 Context
-  {U_action_tlaw : action_triangle_eq (pr1 U_action_struct) (pr1 (pr2 U_action_struct)) (pr1 (pr2 (pr2 U_action_struct))) (pr1 (pr2 (pr2 (pr2 U_action_struct))))}
-  {U_action_plaw : action_pentagon_eq (pr1 U_action_struct) (pr1 (pr2 U_action_struct)) (pr1 (pr2 (pr2 (pr2 U_action_struct))))}.
+  {U_action_tlaw : action_triangle_eq (A := pr1 U_action_struct)
+                                      (pr1 (pr2 U_action_struct))
+                                      (pr1 (pr2 (pr2 U_action_struct)))
+                                      (pr1 (pr2 (pr2 (pr2 U_action_struct))))}
+  {U_action_plaw : action_pentagon_eq (A := pr1 U_action_struct)
+                                      (pr1 (pr2 U_action_struct))
+                                      (pr1 (pr2 (pr2 (pr2 U_action_struct))))}.
 
 Definition U_action : action.
   exists (pr1 U_action_struct).

--- a/UniMath/CategoryTheory/Monoidal/Actions.v
+++ b/UniMath/CategoryTheory/Monoidal/Actions.v
@@ -9,6 +9,7 @@ Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.Core.Isos.
 Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
 Require Import UniMath.CategoryTheory.Core.Functors.
+Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
 Require Import UniMath.CategoryTheory.Monoidal.MonoidalCategories.
 Require Import UniMath.CategoryTheory.Monoidal.MonoidalFunctors.
@@ -156,71 +157,22 @@ Qed.
 
 Definition U_action_ρ : action_right_unitor otimes_U_functor := mk_nat_iso _ _ U_action_ρ_nat_trans U_action_ρ_is_nat_iso.
 
-Definition U_action_χ_nat_trans_data : nat_trans_data (odot_x_odot_y_functor otimes_U_functor)
-(odot_x_otimes_y_functor otimes_U_functor).
+Definition U_action_χ_nat_trans : odot_x_odot_y_functor otimes_U_functor ⟹ odot_x_otimes_y_functor otimes_U_functor.
 Proof.
+  apply (nat_trans_comp _ _ _ (pre_whisker (pair_functor (pair_functor (functor_identity _) U) U) (pr1 α_A))).
   pose (μ := pr1 (pr2 (pr2 (pr1 U)))).
-  intro x.
-  pose (k := ob1 (ob1 x)); pose (k' := ob2 (ob1 x)); pose (k'' := ob2 x).
-  exact (pr1 α_A ((k, U k'), U k'') · id k #⊗_A pr1 μ (k', k'')).
+  exact (pre_whisker (precategory_binproduct_unassoc _ _ _) (post_whisker_fst_param μ tensor_A)).
 Defined.
 
-Definition U_action_χ_is_nat_trans : is_nat_trans (odot_x_odot_y_functor otimes_U_functor)
-  (odot_x_otimes_y_functor otimes_U_functor) U_action_χ_nat_trans_data.
+Lemma U_action_χ_nat_trans_ok: nat_trans_data_from_nat_trans U_action_χ_nat_trans =
+  let μ := pr1 (pr2 (pr2 (pr1 U))) in
+  λ x, let k   := ob1 (ob1 x) in
+       let k'  := ob2 (ob1 x) in
+       let k'' := ob2 x in
+       pr1 α_A ((k, U k'), U k'') · id k #⊗_A pr1 μ (k', k'').
 Proof.
-  pose (μ := pr1 (pr2 (pr2 (pr1 U)))).
-  unfold U_action_χ_nat_trans_data.
-  intros x x' g.
-  cbn.
-  pose (k_1 := ob1 (ob1 x)); pose (k'_1 := ob2 (ob1 x)); pose (k''_1 := ob2 x).
-  pose (k_2 := ob1 (ob1 x')); pose (k'_2 := ob2 (ob1 x')); pose (k''_2 := ob2 x').
-  pose (f := mor1 (mor1 g)); pose (f' := mor2 (mor1 g)); pose (f'' := mor2 g).
-  assert (α_nat_law := pr2 (pr1 α_A) ((k_1, U k'_1), U k''_1)
-                                     ((k_2, U k'_2), U k''_2)
-                                     ((f #, #U f') #, #U f'')).
-  assert (μ_coher : id k_1 #⊗_A (pr1 μ (k'_1, k''_1)) · (f #⊗_A #U (f' #⊗ f'')) =
-                    f #⊗_A (#U f' #⊗_A #U f'') · id k_2 #⊗_A (pr1 μ (k'_2, k''_2))).
-  { do 2 rewrite <- tensor_comp.
-    rewrite id_left; rewrite id_right.
-    assert (snd_eq : pr1 μ (k'_1, k''_1) · # U (f' #⊗ f'') =
-                     # tensor_A (# U f' #, # U f'') · pr1 μ (k'_2, k''_2)).
-    { apply pathsinv0.
-      exact (pr2 μ (k'_1, k''_1) (k'_2, k''_2) (f' #, f'')).
-    }
-    change (# tensor_A (f #, pr1 μ (k'_1, k''_1) · # U (# tensor (f' #, f''))) =
-            # tensor_A (f #, # tensor_A (# U f' #, # U f'') · pr1 μ (k'_2, k''_2))).
-    rewrite <- snd_eq.
-    apply idpath.
-  }
-  change (# tensor_A (# tensor_A (f #, # U f') #, # U f'') ·
-            pr1 (pr1 α_A) ((k_2, U k'_2), U k''_2) =
-          pr1 (pr1 α_A) ((k_1, U k'_1), U k''_1) ·
-              # tensor_A (f #, # tensor_A (# U f' #, # U f''))) in α_nat_law.
-  assert (α_nat_law' := maponpaths (λ p, p · id k_2 #⊗_A (pr1 μ (k'_2, k''_2))) α_nat_law).
-  simpl in α_nat_law'.
-  repeat rewrite <- assoc in α_nat_law'.
-  change (# tensor_A (# tensor_A (f #, # U f') #, # U f'') ·
-            (pr1 (pr1 α_A) ((k_2, U k'_2), U k''_2) ·
-                 # tensor_A (id k_2 #, pr1 μ (k'_2, k''_2))) =
-          pr1 (pr1 α_A) ((k_1, U k'_1), U k''_1) ·
-              (# tensor_A (f #, # tensor_A (# U f' #, # U f'')) ·
-                 # tensor_A (id k_2 #, pr1 μ (k'_2, k''_2)))) in α_nat_law'.
-  change (# tensor_A (id k_1 #, pr1 μ (k'_1, k''_1)) ·
-            # tensor_A (f #, # U (# tensor (f' #, f''))) =
-          # tensor_A (f #, # tensor_A (# U f' #, # U f'')) ·
-            # tensor_A (id k_2 #, pr1 μ (k'_2, k''_2))) in μ_coher.
-  pose (common := (# tensor_A (f #, # tensor_A (# U f' #, # U f'')) ·
-                     # tensor_A (id k_2 #, pr1 μ (k'_2, k''_2)))).
-  fold common in μ_coher.
-  fold common in α_nat_law'.
-  rewrite <- μ_coher in α_nat_law'.
-  repeat rewrite assoc in α_nat_law'.
-  repeat rewrite assoc.
-  exact α_nat_law'.
+  apply idpath.
 Qed.
-
-Definition U_action_χ_nat_trans : odot_x_odot_y_functor otimes_U_functor ⟹ odot_x_otimes_y_functor otimes_U_functor :=
-  mk_nat_trans _ _ U_action_χ_nat_trans_data U_action_χ_is_nat_trans.
 
 Lemma U_action_χ_is_nat_iso : is_nat_iso U_action_χ_nat_trans.
 Proof.

--- a/UniMath/CategoryTheory/Monoidal/Actions.v
+++ b/UniMath/CategoryTheory/Monoidal/Actions.v
@@ -41,14 +41,32 @@ Notation "f #⊙ g" := (# odot (f #, g)) (at level 31).
 
 Definition odot_I_functor : functor A A := functor_fix_snd_arg _ _ _ odot I.
 
+Lemma odot_I_functor_ok: functor_on_objects odot_I_functor =
+  λ a, a ⊙ I.
+Proof.
+  apply idpath.
+Qed.
+
 Definition action_right_unitor : UU := nat_iso odot_I_functor (functor_identity A).
 
 Definition odot_x_odot_y_functor : (A ⊠ V) ⊠ V ⟶ A :=
   functor_composite (pair_functor odot (functor_identity _)) odot.
 
+Lemma odot_x_odot_y_functor_ok: functor_on_objects odot_x_odot_y_functor =
+  λ a, (ob1 (ob1 a) ⊙ ob2 (ob1 a)) ⊙ ob2 a.
+Proof.
+  apply idpath.
+Qed.
+
 Definition odot_x_otimes_y_functor : (A ⊠ V) ⊠ V ⟶ A :=
   functor_composite (precategory_binproduct_unassoc _ _ _)
                     (functor_composite (pair_functor (functor_identity _) tensor) odot).
+
+Lemma odot_x_otimes_y_functor_ok: functor_on_objects odot_x_otimes_y_functor =
+  λ a, ob1 (ob1 a) ⊙ (ob2 (ob1 a) ⊗ ob2 a).
+Proof.
+  apply idpath.
+Qed.
 
 Definition action_convertor : UU := nat_iso odot_x_odot_y_functor odot_x_otimes_y_functor.
 
@@ -97,6 +115,12 @@ Context (U : strong_monoidal_functor Mon_V Mon_A).
 
 Definition otimes_U_functor : A ⊠ V ⟶ A := functor_composite (pair_functor (functor_identity _) U) tensor_A.
 
+Lemma otimes_U_functor_ok: functor_on_objects otimes_U_functor =
+  λ av, ob1 av ⊗_A U (ob2 av).
+Proof.
+  apply idpath.
+Qed.
+
 Definition U_action_ρ_nat_trans : odot_I_functor otimes_U_functor ⟹ functor_identity A.
   refine (nat_trans_comp _ _ _ _  (pr1 ρ_A)).
   unfold odot_I_functor.
@@ -112,6 +136,12 @@ Definition U_action_ρ_nat_trans : odot_I_functor otimes_U_functor ⟹ functor_i
     rewrite functor_id.
     exact (pr2 aux a a' f).
 Defined.
+
+Lemma U_action_ρ_nat_trans_ok: nat_trans_data_from_nat_trans U_action_ρ_nat_trans =
+ let ϵ_inv := inv_from_iso (mk_iso (pr1 (pr2 U))) in λ x, id x #⊗_A ϵ_inv · pr1 ρ_A x.
+Proof.
+  apply idpath.
+Qed.
 
 Definition U_action_ρ_is_nat_iso : is_nat_iso U_action_ρ_nat_trans.
 Proof.

--- a/UniMath/CategoryTheory/Monoidal/BicategoryFromMonoidal.v
+++ b/UniMath/CategoryTheory/Monoidal/BicategoryFromMonoidal.v
@@ -34,14 +34,15 @@ Local Notation "f '<==' g" := (prebicat_cells _ g f) (at level 60, only parsing)
  2-cells are given by the morphisms of the original monoidal category. *)
 Definition one_cells_data_from_monoidal : precategory_data.
 Proof.
-  unfold precategory_data.
+  red.
   use tpair.
-  apply (unit ,, (λ _ _, ob pM)).
-  simpl.
-  unfold precategory_id_comp.
-  split.
-  * intro c. apply I.
-  * intros a b c. apply (λ a b, tensor (a , b)).
+  - exact (unit ,, (λ _ _, ob pM)).
+  - cbn.
+    red.
+    cbn.
+    split.
+    + intros _. exact I.
+    + intros _ _ _. exact (λ a b, tensor (a , b)).
 Defined.
 
 Definition two_cells_from_monoidal : prebicat_2cell_struct (one_cells_data_from_monoidal)
@@ -50,17 +51,17 @@ Definition two_cells_from_monoidal : prebicat_2cell_struct (one_cells_data_from_
 Definition prebicat_data_from_monoidal : prebicat_data.
 Proof.
   use mk_prebicat_data.
-  - apply (one_cells_data_from_monoidal ,, two_cells_from_monoidal).
-  - split. { intros ? ? f. apply (id f). }
+  - exact (one_cells_data_from_monoidal ,, two_cells_from_monoidal).
+  - split. { intros ? ? f. exact (id f). }
     split. { intros ? ? f. apply l. }
     split. { intros ? ? f. apply ρ. }
     split. { intros ? ? f. apply (nat_iso_inv l). }
     split. { intros ? ? f. apply (nat_iso_inv ρ). }
     split. { intros ? ? ? ? f g h. apply (pr1 α ((f , g) , h)). }
     split. { intros ? ? ? ? f g h. apply (pr1 (nat_iso_inv α) ((f , g) , h)). }
-    split. { intros ? ? f g h. apply compose. }
-    split. { intros ? ? ? f g h. apply (λ u, (id f #⊗ u)). }
-             intros ? ? ? f g h. apply (λ u, (u #⊗ id h)).
+    split. { intros ? ? f g h. exact compose. }
+    split. { intros ? ? ? f g h. exact (λ u, (id f #⊗ u)). }
+             intros ? ? ? f g h. exact (λ u, (u #⊗ id h)).
 Defined.
 
 Definition prebicat_laws_from_monoidal : prebicat_laws (prebicat_data_from_monoidal).
@@ -73,42 +74,42 @@ Proof.
   split. { intros. apply assoc. }
 
   (* 3. Whiskering and identities. *)
-  split. { intros ? ? ? f g. apply (functor_id tensor (f , g)). }
-  split. { intros ? ? ? f g. apply (functor_id tensor (f , g)). }
+  split. { intros ? ? ? f g. exact (functor_id tensor (f , g)). }
+  split. { intros ? ? ? f g. exact (functor_id tensor (f , g)). }
 
-  (* 4. Left whiskering vertical copmosition. *)
+  (* 4. Left whiskering vertical composition. *)
   split. {
     intros ? ? ? f g h i x y.
     etrans.
-    apply (!(functor_comp tensor (id f #, x) (id f #, y))).
-    apply (maponpaths (fun z => z #⊗ (x · y)) (id_left _)).
+    exact (!(functor_comp tensor (id f #, x) (id f #, y))).
+    exact (maponpaths (fun z => z #⊗ (x · y)) (id_left _)).
   }
 
-  (* 5. Right whiskering vertical copmosition. *)
+  (* 5. Right whiskering vertical composition. *)
   split. {
     intros ? ? ? f g h i x y.
     etrans.
-    apply (!(functor_comp tensor _ _)).
-    apply (maponpaths (fun z => (x · y) #⊗ z) (id_left _)).
+    exact (!(functor_comp tensor _ _)).
+    exact (maponpaths (fun z => (x · y) #⊗ z) (id_left _)).
   }
 
   (* 6 and 7. Vertical composition and unitors. *)
-  split. { intros. apply (pr21 l _ _ _). }
-  split. { intros. apply (pr21 ρ _ _ _). }
+  split. { intros. exact (pr21 l _ _ _). }
+  split. { intros. exact (pr21 ρ _ _ _). }
 
   (* 8. Associator and left/left whiskering *)
   split. {
     intros ? ? ? ? f g h i x.
     etrans.
-    apply (pr21 (nat_iso_inv α) _ _ ((id f #, id g) #, x)).
-    apply (maponpaths (fun z => _ · (z #⊗ _)) (functor_id tensor (f , g))).
+    exact (pr21 (nat_iso_inv α) _ _ ((id f #, id g) #, x)).
+    exact (maponpaths (fun z => _ · (z #⊗ _)) (functor_id tensor (f , g))).
   }
 
   (* 9. Associator and right/left whiskering *)
   split. {
     intros ? ? ? ? f g h i x.
     etrans.
-    apply (pr21 (nat_iso_inv α) _ _ ((id f #, x) #, id i)).
+    exact (pr21 (nat_iso_inv α) _ _ ((id f #, x) #, id i)).
     apply idpath.
   }
 
@@ -116,42 +117,42 @@ Proof.
   split. {
     intros ? ? ? ? f g h i x.
     etrans.
-    apply (!(pr21 (nat_iso_inv α) _ _ ((x #, id h) #, id i))).
-    apply (maponpaths (fun z => (_ #⊗ z) · _) (functor_id tensor (h , i))).
+    exact (!(pr21 (nat_iso_inv α) _ _ ((x #, id h) #, id i))).
+    exact (maponpaths (fun z => (_ #⊗ z) · _) (functor_id tensor (h , i))).
   }
 
   (* 11. Vertical composition and whiskering *)
   split. {
     intros.
-    etrans. apply (!(functor_comp tensor _ _)).
-    etrans. apply (maponpaths (fun z => (_ #⊗ z)) (id_left _)).
-    etrans. apply (maponpaths (fun z => (z #⊗ _)) (id_right _)).
+    etrans. exact (!(functor_comp tensor _ _)).
+    etrans. exact (maponpaths (fun z => (_ #⊗ z)) (id_left _)).
+    etrans. exact (maponpaths (fun z => (z #⊗ _)) (id_right _)).
     apply pathsinv0.
-    etrans. apply (!(functor_comp tensor _ _)).
-    etrans. apply (maponpaths (fun z => (z #⊗ _)) (id_left _)).
-    etrans. apply (maponpaths (fun z => (_ #⊗ z)) (id_right _)).
+    etrans. exact (!(functor_comp tensor _ _)).
+    etrans. exact (maponpaths (fun z => (z #⊗ _)) (id_left _)).
+    etrans. exact (maponpaths (fun z => (_ #⊗ z)) (id_right _)).
     apply idpath.
   }
 
   (* 12. Left unitor invertible. *)
-  split. { intros ? ? f. apply (iso_inv_after_iso (pr1 l f,, pr2 l f)). }
-  split. { intros ? ? f. apply (iso_after_iso_inv (pr1 l f,, pr2 l f)). }
+  split. { intros ? ? f. exact (iso_inv_after_iso (pr1 l f,, pr2 l f)). }
+  split. { intros ? ? f. exact (iso_after_iso_inv (pr1 l f,, pr2 l f)). }
 
   (* 13. Right unitor invertible. *)
-  split. { intros ? ? f. apply (iso_inv_after_iso (pr1 ρ f,, pr2 ρ f)). }
-  split. { intros ? ? f. apply (iso_after_iso_inv (pr1 ρ f,, pr2 ρ f)). }
+  split. { intros ? ? f. exact (iso_inv_after_iso (pr1 ρ f,, pr2 ρ f)). }
+  split. { intros ? ? f. exact (iso_after_iso_inv (pr1 ρ f,, pr2 ρ f)). }
 
   (* 14. Associator invertible. *)
-  split. { intros ? ? ? ? f g h. apply (iso_after_iso_inv ( pr1 α ((f, g), h) ,, pr2 α ((f, g), h) )). }
-  split. { intros ? ? ? ? f g h. apply (iso_inv_after_iso ( pr1 α ((f, g), h) ,, pr2 α ((f, g), h) )). }
+  split. { intros ? ? ? ? f g h. exact (iso_after_iso_inv ( pr1 α ((f, g), h) ,, pr2 α ((f, g), h) )). }
+  split. { intros ? ? ? ? f g h. exact (iso_inv_after_iso ( pr1 α ((f, g), h) ,, pr2 α ((f, g), h) )). }
 
   (* 15. Right unitor whiskering. *)
   split. {
     intros ? ? ? f g.
-    etrans. apply (maponpaths (fun z => _ · z) (triangle_equality _ _)).
-    etrans. apply (assoc _ _ _).
-    etrans. apply (maponpaths (fun z => z · _) (iso_after_iso_inv ( pr1 α ((f, I), g) ,, pr2 α ((f, I), g) ))).
-    apply (id_left _).
+    etrans. exact (maponpaths (fun z => _ · z) (triangle_equality _ _)).
+    etrans. exact (assoc _ _ _).
+    etrans. exact (maponpaths (fun z => z · _) (iso_after_iso_inv ( pr1 α ((f, I), g) ,, pr2 α ((f, I), g) ))).
+    exact (id_left _).
   }
 
   (* 16. Pentagon equation *)
@@ -162,29 +163,29 @@ Proof.
   apply (pre_comp_with_iso_is_inj _ _ _ _ (pr1 α ((f, g), h ⊗ i)) (pr2 α _) _ _).
   apply (pre_comp_with_iso_is_inj _ _ _ _ (pr1 α (((f ⊗ g), h) , i)) (pr2 α _) _ _).
   apply pathsinv0.
-  etrans. apply (maponpaths (fun z => _ · z) (assoc _ _ _)).
-  etrans. apply (maponpaths (fun z => _ · (z · _)) (iso_inv_after_iso (pr1 α ((f, g), _) ,, pr2 α _ ))).
-  etrans. apply (maponpaths (fun z => _ · z) (id_left _)).
-  etrans. apply (iso_inv_after_iso (pr1 α ((f ⊗ g, h), _) ,, pr2 α _ )).
+  etrans. exact (maponpaths (fun z => _ · z) (assoc _ _ _)).
+  etrans. exact (maponpaths (fun z => _ · (z · _)) (iso_inv_after_iso (pr1 α ((f, g), _) ,, pr2 α _ ))).
+  etrans. exact (maponpaths (fun z => _ · z) (id_left _)).
+  etrans. exact (iso_inv_after_iso (pr1 α ((f ⊗ g, h), _) ,, pr2 α _ )).
   apply pathsinv0.
-  etrans. apply (assoc _ _ _).
-  etrans. apply (assoc _ _ _).
-  etrans. apply (maponpaths (fun z => (z · _) · _) (pentagon_equation _ _ _ _)).
-  etrans. apply (maponpaths (fun z => (z · _)) (!(assoc _ _ _))).
-  etrans. apply (maponpaths (fun z => (_ · z · _)) (assoc _ _ _)).
-  etrans. apply (maponpaths (fun z => (_ · (z · _) · _)) (!(functor_comp tensor _ _))). cbn.
-  etrans. apply (maponpaths (fun z => (_ · ((z #⊗ _) · _) · _)) (id_left _)). cbn.
-  etrans. apply (maponpaths (fun z => (_ · ((_ #⊗ z) · _) · _)) (iso_inv_after_iso (pr1 α ((g, h), i) ,, pr2 α _))).
-  assert (# tensor (id (f, (assoc_left (pr12 M)) ((g, h), i))) = id (f ⊗ (assoc_left (pr12 M)) ((g, h), i))).
-  apply (functor_id tensor ( f , (assoc_left (pr12 M)) ((g, h), i))  ).
-  etrans. apply (maponpaths (fun z => (_ · (z · _) · _)) X).
-  etrans. apply (maponpaths (fun z => (_ · z · _)) (id_left _)).
-  etrans. apply (maponpaths (fun z => (z · _)) (!(assoc _ _ _))).
-  etrans. apply (maponpaths (fun z => (_ · z · _)) (iso_inv_after_iso (pr1 α ((f,g ⊗ h),i) ,, pr2 α _))).
-  etrans. apply (maponpaths (fun z => (z · _)) (id_right _)).
-  etrans. apply (!(functor_comp tensor _ _)).
-  etrans. apply (maponpaths (fun z => (_ #⊗ z)) (id_right _)).
-  etrans. apply (maponpaths (fun z => (z #⊗ _)) (iso_inv_after_iso (pr1 α ((f,g),h) ,, pr2 α _))).
+  etrans. exact (assoc _ _ _).
+  etrans. exact (assoc _ _ _).
+  etrans. exact (maponpaths (fun z => (z · _) · _) (pentagon_equation _ _ _ _)).
+  etrans. exact (maponpaths (fun z => (z · _)) (!(assoc _ _ _))).
+  etrans. exact (maponpaths (fun z => (_ · z · _)) (assoc _ _ _)).
+  etrans. exact (maponpaths (fun z => (_ · (z · _) · _)) (!(functor_comp tensor _ _))). cbn.
+  etrans. exact (maponpaths (fun z => (_ · ((z #⊗ _) · _) · _)) (id_left _)).
+  etrans. exact (maponpaths (fun z => (_ · ((_ #⊗ z) · _) · _)) (iso_inv_after_iso (pr1 α ((g, h), i) ,, pr2 α _))).
+  assert (aux: # tensor (id (f, (assoc_left (pr12 M)) ((g, h), i))) = id (f ⊗ (assoc_left (pr12 M)) ((g, h), i))) by
+  exact (functor_id tensor ( f , (assoc_left (pr12 M)) ((g, h), i))).
+  etrans. exact (maponpaths (fun z => (_ · (z · _) · _)) aux).
+  etrans. exact (maponpaths (fun z => (_ · z · _)) (id_left _)).
+  etrans. exact (maponpaths (fun z => (z · _)) (!(assoc _ _ _))).
+  etrans. exact (maponpaths (fun z => (_ · z · _)) (iso_inv_after_iso (pr1 α ((f,g ⊗ h),i) ,, pr2 α _))).
+  etrans. exact (maponpaths (fun z => (z · _)) (id_right _)).
+  etrans. exact (!(functor_comp tensor _ _)).
+  etrans. exact (maponpaths (fun z => (_ #⊗ z)) (id_right _)).
+  etrans. exact (maponpaths (fun z => (z #⊗ _)) (iso_inv_after_iso (pr1 α ((f,g),h) ,, pr2 α _))).
   apply (functor_id tensor).
 Defined.
 

--- a/UniMath/CategoryTheory/Monoidal/MonoidalCategories.v
+++ b/UniMath/CategoryTheory/Monoidal/MonoidalCategories.v
@@ -31,18 +31,19 @@ Definition tensor_id {X Y : C} : id X #⊗ id Y = id (X ⊗ Y).
 Proof.
   rewrite binprod_id.
   rewrite (functor_id tensor).
-  reflexivity.
+  apply idpath.
 Defined.
 
-Definition tensor_comp {X Y Z X' Y' Z' : C} (f : X --> Y) (g : Y --> Z) (f' : X' --> Y') (g' : Y' --> Z') : (f · g) #⊗ (f' · g') = f #⊗ f' · g #⊗ g'.
+Definition tensor_comp {X Y Z X' Y' Z' : C} (f : X --> Y) (g : Y --> Z) (f' : X' --> Y') (g' : Y' --> Z') :
+  (f · g) #⊗ (f' · g') = f #⊗ f' · g #⊗ g'.
 Proof.
   rewrite binprod_comp.
   rewrite (functor_comp tensor).
-  reflexivity.
+  apply idpath.
 Defined.
 
-Definition is_iso_tensor_iso {X Y X' Y' : C} {f : X --> Y} {g : X' --> Y'} (f_is_iso : is_iso f)
-(g_is_iso : is_iso g) : is_iso (f #⊗ g).
+Definition is_iso_tensor_iso {X Y X' Y' : C} {f : X --> Y} {g : X' --> Y'}
+           (f_is_iso : is_iso f) (g_is_iso : is_iso g) : is_iso (f #⊗ g).
 Proof.
   exact (functor_on_is_iso_is_iso (is_iso_binprod_iso f_is_iso g_is_iso)).
 Defined.
@@ -52,24 +53,21 @@ Definition I_pretensor : C ⟶ C.
 Proof.
     use tpair.
     - use tpair.
-      exact (λ c, I ⊗ c).
-      intros ? ? f.
-      exact (id I #⊗ f).
+      + exact (λ c, I ⊗ c).
+      + intros ? ? f.
+        exact (id I #⊗ f).
     - split.
       + intro.
-        simpl.
+        cbn.
         apply tensor_id.
       + unfold functor_compax.
-        simpl.
+        cbn.
         intros.
-        replace (id I) with (id I · id I) by (
-          rewrite id_left;
-          reflexivity
-        ).
+        rewrite <- (id_left (id I)).
         rewrite binprod_comp.
         rewrite id_left.
         rewrite (functor_comp tensor).
-        reflexivity.
+        apply idpath.
 Defined.
 
 (* λ *)
@@ -81,24 +79,21 @@ Definition I_posttensor : C ⟶ C.
 Proof.
     use tpair.
     - use tpair.
-      exact (λ c, c ⊗ I).
-      intros ? ? f.
-      exact (f #⊗ id I).
+      + exact (λ c, c ⊗ I).
+      + intros ? ? f.
+        exact (f #⊗ id I).
     - split.
       + intro.
-        simpl.
+        cbn.
         apply tensor_id.
       + unfold functor_compax.
-        simpl.
+        cbn.
         intros.
-        replace (id I) with (id I · id I) by (
-          rewrite id_left;
-          reflexivity
-        ).
+        rewrite <- (id_left (id I)).
         rewrite binprod_comp.
         rewrite id_left.
         rewrite (functor_comp tensor).
-        reflexivity.
+        apply idpath.
 Defined.
 
 (* ρ *)
@@ -110,20 +105,20 @@ Definition assoc_left : (C ⊠ C) ⊠ C ⟶ C.
 Proof.
   use tpair; [| split].
   - use tpair.
-    exact (λ c, (ob1 (ob1 c) ⊗ ob2 (ob1 c)) ⊗ ob2 c).
-    intros ? ? f.
-    exact ((mor1 (mor1 f) #⊗ mor2 (mor1 f)) #⊗ mor2 f).
+    + exact (λ c, (ob1 (ob1 c) ⊗ ob2 (ob1 c)) ⊗ ob2 c).
+    + intros ? ? f.
+      exact ((mor1 (mor1 f) #⊗ mor2 (mor1 f)) #⊗ mor2 f).
   - intro a.
-    simpl.
+    cbn.
     repeat rewrite (binprod_proj_id a); repeat rewrite binprod_proj_id.
     do 2 rewrite tensor_id.
-    reflexivity.
+    apply idpath.
   - unfold functor_compax.
-    simpl.
+    cbn.
     intros a b c f g.
     repeat rewrite (binprod_proj_comp f); repeat rewrite binprod_proj_comp.
     do 2 rewrite tensor_comp.
-    reflexivity.
+    apply idpath.
 Defined.
 
 (* - ⊗ (= ⊗ ≡) *)
@@ -131,33 +126,38 @@ Definition assoc_right : (C ⊠ C) ⊠ C ⟶ C.
 Proof.
   use tpair; [| split].
   - use tpair.
-    exact (λ c, ob1 (ob1 c) ⊗ (ob2 (ob1 c) ⊗ ob2 c)).
-    intros ? ? f.
-    exact (mor1 (mor1 f) #⊗ (mor2 (mor1 f) #⊗ mor2 f)).
+    + exact (λ c, ob1 (ob1 c) ⊗ (ob2 (ob1 c) ⊗ ob2 c)).
+    + intros ? ? f.
+      exact (mor1 (mor1 f) #⊗ (mor2 (mor1 f) #⊗ mor2 f)).
   - intro a.
-    simpl.
+    cbn.
     repeat rewrite (binprod_proj_id a); repeat rewrite binprod_proj_id.
     do 2 rewrite tensor_id.
-    reflexivity.
+    apply idpath.
   - unfold functor_compax.
-    simpl.
+    cbn.
     intros a b c f g.
     repeat rewrite (binprod_proj_comp f); repeat rewrite binprod_proj_comp.
     do 2 rewrite tensor_comp.
-    reflexivity.
+    apply idpath.
 Defined.
 
 (* α *)
 Definition associator : UU :=
   nat_iso assoc_left assoc_right.
+(* This definition goes in the opposite direction of that by Mac Lane (CWM 2nd ed., p.162)
+   but conforms to the def. on Wikipedia. *)
 
 Definition triangle_eq (λ' : left_unitor) (ρ' : right_unitor) (α' : associator) : UU :=
   ∏ (a b : C), pr1 ρ' a #⊗ id b = pr1 α' ((a, I), b) · id a #⊗ pr1 λ' b.
 
 Definition pentagon_eq (α' : associator) : UU :=
-  ∏ (a b c d : C), pr1 α' ((a ⊗ b, c), d) · pr1 α' ((a, b), c ⊗ d) = pr1 α' ((a, b), c) #⊗ id d · pr1 α' ((a, b ⊗ c), d) · id a #⊗ pr1 α' ((b, c), d).
+  ∏ (a b c d : C), pr1 α' ((a ⊗ b, c), d) · pr1 α' ((a, b), c ⊗ d) =
+   pr1 α' ((a, b), c) #⊗ id d · pr1 α' ((a, b ⊗ c), d) · id a #⊗ pr1 α' ((b, c), d).
 
-Definition is_strict (eq_λ : I_pretensor = functor_identity C) (λ' : left_unitor) (eq_ρ : I_posttensor = functor_identity C) (ρ' : right_unitor) (eq_α : assoc_left = assoc_right) (α' : associator) : UU :=
+Definition is_strict (eq_λ : I_pretensor = functor_identity C) (λ' : left_unitor)
+           (eq_ρ : I_posttensor = functor_identity C) (ρ' : right_unitor)
+           (eq_α : assoc_left = assoc_right) (α' : associator) : UU :=
   (is_nat_iso_id eq_λ λ') × (is_nat_iso_id eq_ρ ρ') × (is_nat_iso_id eq_α α').
 
 End Monoidal_Precat.

--- a/UniMath/CategoryTheory/Monoidal/MonoidalCategories.v
+++ b/UniMath/CategoryTheory/Monoidal/MonoidalCategories.v
@@ -49,98 +49,50 @@ Proof.
 Defined.
 
 (* I ⊗ - *)
-Definition I_pretensor : C ⟶ C.
+Definition I_pretensor : C ⟶ C := functor_fix_fst_arg _ _ _ tensor I.
+
+Lemma I_pretensor_ok: functor_on_objects I_pretensor = λ c, I ⊗ c.
 Proof.
-    use tpair.
-    - use tpair.
-      + exact (λ c, I ⊗ c).
-      + intros ? ? f.
-        exact (id I #⊗ f).
-    - split.
-      + intro.
-        cbn.
-        apply tensor_id.
-      + unfold functor_compax.
-        cbn.
-        intros.
-        rewrite <- (id_left (id I)).
-        rewrite binprod_comp.
-        rewrite id_left.
-        rewrite (functor_comp tensor).
-        apply idpath.
-Defined.
+  apply idpath.
+Qed.
 
 (* λ *)
 Definition left_unitor : UU :=
   nat_iso I_pretensor (functor_identity C).
 
 (* - ⊗ I *)
-Definition I_posttensor : C ⟶ C.
+Definition I_posttensor : C ⟶ C := functor_fix_snd_arg _ _ _ tensor I.
+
+Lemma I_posttensor_ok: functor_on_objects I_posttensor = λ c, c ⊗ I.
 Proof.
-    use tpair.
-    - use tpair.
-      + exact (λ c, c ⊗ I).
-      + intros ? ? f.
-        exact (f #⊗ id I).
-    - split.
-      + intro.
-        cbn.
-        apply tensor_id.
-      + unfold functor_compax.
-        cbn.
-        intros.
-        rewrite <- (id_left (id I)).
-        rewrite binprod_comp.
-        rewrite id_left.
-        rewrite (functor_comp tensor).
-        apply idpath.
-Defined.
+  apply idpath.
+Qed.
 
 (* ρ *)
 Definition right_unitor : UU :=
   nat_iso I_posttensor (functor_identity C).
 
 (* (- ⊗ =) ⊗ ≡ *)
-Definition assoc_left : (C ⊠ C) ⊠ C ⟶ C.
+Definition assoc_left : (C ⊠ C) ⊠ C ⟶ C :=
+  functor_composite (pair_functor tensor (functor_identity _)) tensor.
+
+Lemma assoc_left_ok: functor_on_objects assoc_left =
+  λ c, (ob1 (ob1 c) ⊗ ob2 (ob1 c)) ⊗ ob2 c.
 Proof.
-  use tpair; [| split].
-  - use tpair.
-    + exact (λ c, (ob1 (ob1 c) ⊗ ob2 (ob1 c)) ⊗ ob2 c).
-    + intros ? ? f.
-      exact ((mor1 (mor1 f) #⊗ mor2 (mor1 f)) #⊗ mor2 f).
-  - intro a.
-    cbn.
-    repeat rewrite (binprod_proj_id a); repeat rewrite binprod_proj_id.
-    do 2 rewrite tensor_id.
-    apply idpath.
-  - unfold functor_compax.
-    cbn.
-    intros a b c f g.
-    repeat rewrite (binprod_proj_comp f); repeat rewrite binprod_proj_comp.
-    do 2 rewrite tensor_comp.
-    apply idpath.
-Defined.
+  apply idpath.
+Qed.
 
 (* - ⊗ (= ⊗ ≡) *)
-Definition assoc_right : (C ⊠ C) ⊠ C ⟶ C.
+Definition assoc_right : (C ⊠ C) ⊠ C ⟶ C :=
+  functor_composite
+    (precategory_binproduct_unassoc _ _ _)
+    (functor_composite (pair_functor (functor_identity _) tensor) tensor).
+
+Lemma assoc_right_ok: functor_on_objects assoc_right =
+  λ c, ob1 (ob1 c) ⊗ (ob2 (ob1 c) ⊗ ob2 c).
 Proof.
-  use tpair; [| split].
-  - use tpair.
-    + exact (λ c, ob1 (ob1 c) ⊗ (ob2 (ob1 c) ⊗ ob2 c)).
-    + intros ? ? f.
-      exact (mor1 (mor1 f) #⊗ (mor2 (mor1 f) #⊗ mor2 f)).
-  - intro a.
-    cbn.
-    repeat rewrite (binprod_proj_id a); repeat rewrite binprod_proj_id.
-    do 2 rewrite tensor_id.
-    apply idpath.
-  - unfold functor_compax.
-    cbn.
-    intros a b c f g.
-    repeat rewrite (binprod_proj_comp f); repeat rewrite binprod_proj_comp.
-    do 2 rewrite tensor_comp.
-    apply idpath.
-Defined.
+  apply idpath.
+Qed.
 
 (* α *)
 Definition associator : UU :=

--- a/UniMath/CategoryTheory/Monoidal/MonoidalFunctors.v
+++ b/UniMath/CategoryTheory/Monoidal/MonoidalFunctors.v
@@ -36,43 +36,23 @@ Section Monoidal_Functor_Conditions.
 
 Context (F : C ⟶ D).
 
-Definition monoidal_functor_map_dom : precategory_binproduct C C ⟶ D.
-use tpair; [| split].
-- use tpair.
-  + exact (λ c, F (ob1 c) ⊗_D F (ob2 c)).
-  + intros ? ? f.
-    exact (#F (mor1 f) #⊗_D #F (mor2 f)).
-- intro.
-  cbn.
-  repeat rewrite functor_id.
-  apply tensor_id.
-- red.
-  cbn.
-  intros.
-  repeat rewrite functor_comp.
-  apply tensor_comp.
-Defined.
+Definition monoidal_functor_map_dom : precategory_binproduct C C ⟶ D :=
+  functor_composite (pair_functor F F) tensor_D.
 
-Definition monoidal_functor_map_codom : precategory_binproduct C C ⟶ D.
-use tpair; [| split].
-- use tpair.
-  + exact (λ c, F (ob1 c ⊗_C ob2 c)).
-  + intros ? ? f.
-    exact (#F (mor1 f #⊗_C mor2 f)).
-- intro.
-  cbn.
-  rewrite binprod_id.
-  rewrite (functor_id tensor_C).
-  rewrite functor_id.
+Lemma monoidal_functor_map_dom_ok: functor_on_objects monoidal_functor_map_dom =
+  λ c, F (ob1 c) ⊗_D F (ob2 c).
+Proof.
   apply idpath.
-- red.
-  simpl.
-  intros.
-  rewrite binprod_comp.
-  rewrite (functor_comp tensor_C).
-  rewrite functor_comp.
+Qed.
+
+Definition monoidal_functor_map_codom : precategory_binproduct C C ⟶ D :=
+  functor_composite tensor_C F.
+
+Lemma monoidal_functor_map_codom_ok: functor_on_objects monoidal_functor_map_codom =
+  λ c, F (ob1 c ⊗_C ob2 c).
+Proof.
   apply idpath.
-Defined.
+Qed.
 
 Definition monoidal_functor_map :=
   monoidal_functor_map_dom ⟹ monoidal_functor_map_codom.

--- a/UniMath/CategoryTheory/Monoidal/MonoidalFunctors.v
+++ b/UniMath/CategoryTheory/Monoidal/MonoidalFunctors.v
@@ -39,15 +39,15 @@ Context (F : C ⟶ D).
 Definition monoidal_functor_map_dom : precategory_binproduct C C ⟶ D.
 use tpair; [| split].
 - use tpair.
-  exact (λ c, F (ob1 c) ⊗_D F (ob2 c)).
-  intros ? ? f.
-  exact (#F (mor1 f) #⊗_D #F (mor2 f)).
+  + exact (λ c, F (ob1 c) ⊗_D F (ob2 c)).
+  + intros ? ? f.
+    exact (#F (mor1 f) #⊗_D #F (mor2 f)).
 - intro.
-  simpl.
+  cbn.
   repeat rewrite functor_id.
   apply tensor_id.
-- unfold functor_compax.
-  simpl.
+- red.
+  cbn.
   intros.
   repeat rewrite functor_comp.
   apply tensor_comp.
@@ -56,22 +56,22 @@ Defined.
 Definition monoidal_functor_map_codom : precategory_binproduct C C ⟶ D.
 use tpair; [| split].
 - use tpair.
-  exact (λ c, F (ob1 c ⊗_C ob2 c)).
-  intros ? ? f.
-  exact (#F (mor1 f #⊗_C mor2 f)).
+  + exact (λ c, F (ob1 c ⊗_C ob2 c)).
+  + intros ? ? f.
+    exact (#F (mor1 f #⊗_C mor2 f)).
 - intro.
-  simpl.
+  cbn.
   rewrite binprod_id.
   rewrite (functor_id tensor_C).
   rewrite functor_id.
-  reflexivity.
-- unfold functor_compax.
+  apply idpath.
+- red.
   simpl.
   intros.
   rewrite binprod_comp.
   rewrite (functor_comp tensor_C).
   rewrite functor_comp.
-  reflexivity.
+  apply idpath.
 Defined.
 
 Definition monoidal_functor_map :=
@@ -92,7 +92,8 @@ Definition monoidal_functor_unitality (ϵ : I_D --> F I_C) (μ : monoidal_functo
 End Monoidal_Functor_Conditions.
 
 Definition lax_monoidal_functor : UU :=
-  ∑ F : C ⟶ D, ∑ ϵ : I_D --> F I_C, ∑ μ : monoidal_functor_map F, (monoidal_functor_associativity F μ) × (monoidal_functor_unitality F ϵ μ).
+  ∑ F : C ⟶ D, ∑ ϵ : I_D --> F I_C, ∑ μ : monoidal_functor_map F,
+   (monoidal_functor_associativity F μ) × (monoidal_functor_unitality F ϵ μ).
 
 Definition strong_monoidal_functor : UU :=
   ∑ L : lax_monoidal_functor,

--- a/UniMath/CategoryTheory/Monoidal/Strengths.v
+++ b/UniMath/CategoryTheory/Monoidal/Strengths.v
@@ -46,59 +46,21 @@ Notation "f #⊙ g" := (#odot (f #, g)) (at level 31).
 Notation "X ⊙' Y" := (odot' (X , Y)) (at level 31).
 Notation "f #⊙' g" := (#odot' (f #, g)) (at level 31).
 
-Definition strength_dom_data : functor_data (precategory_binproduct A V) A'.
-Proof.
-  exists (λ ax, F (ob1 ax) ⊙' (ob2 ax)).
-  intros ? ? f.
-  exact ((#F (mor1 f)) #⊙' (mor2 f)).
-Defined.
+Definition strength_dom : A ⊠ V ⟶ A' :=
+  functor_composite (pair_functor F (functor_identity _)) odot'.
 
-Definition strength_dom_is_functor : is_functor strength_dom_data.
+Lemma strength_dom_ok: functor_on_objects strength_dom = λ ax, F (ob1 ax) ⊙' (ob2 ax).
 Proof.
-  split.
-  - intro.
-    simpl.
-    rewrite (functor_id F).
-    rewrite <- (functor_id odot').
-    rewrite <- binprod_id.
-    apply idpath.
-  - unfold functor_compax.
-    simpl.
-    intros.
-    rewrite <- (functor_comp odot').
-    rewrite <- binprod_comp.
-    rewrite <- (functor_comp F).
-    apply idpath.
+  apply idpath.
 Qed.
 
-Definition strength_dom : (precategory_binproduct A V) ⟶ A' := mk_functor strength_dom_data strength_dom_is_functor.
+Definition strength_codom : A ⊠ V ⟶ A' :=
+  functor_composite odot F.
 
-Definition strength_codom_data : functor_data (A ⊠ V) A'.
+Lemma strength_codom_ok: functor_on_objects strength_codom = λ ax, F (ob1 ax ⊙ ob2 ax).
 Proof.
-  exists (λ ax, F (ob1 ax ⊙ ob2 ax)).
-  intros ? ? f.
-  exact (#F (mor1 f #⊙ mor2 f)).
-Defined.
-
-Definition strength_codom_is_functor : is_functor strength_codom_data.
-Proof.
-  split.
-  - intro.
-    simpl.
-    rewrite <- (functor_id F).
-    rewrite <- (functor_id odot).
-    rewrite <- binprod_id.
-    apply idpath.
-  - unfold functor_compax.
-    simpl.
-    intros.
-    rewrite <- (functor_comp F).
-    rewrite <- (functor_comp odot).
-    rewrite <- binprod_comp.
-    apply idpath.
+  apply idpath.
 Qed.
-
-Definition strength_codom : A ⊠ V ⟶ A' := mk_functor strength_codom_data strength_codom_is_functor.
 
 Definition strength_nat : UU := nat_iso strength_dom strength_codom.
 

--- a/UniMath/CategoryTheory/Monoidal/Strengths.v
+++ b/UniMath/CategoryTheory/Monoidal/Strengths.v
@@ -61,14 +61,14 @@ Proof.
     rewrite (functor_id F).
     rewrite <- (functor_id odot').
     rewrite <- binprod_id.
-    reflexivity.
+    apply idpath.
   - unfold functor_compax.
     simpl.
     intros.
     rewrite <- (functor_comp odot').
     rewrite <- binprod_comp.
     rewrite <- (functor_comp F).
-    reflexivity.
+    apply idpath.
 Qed.
 
 Definition strength_dom : (precategory_binproduct A V) ⟶ A' := mk_functor strength_dom_data strength_dom_is_functor.
@@ -88,30 +88,31 @@ Proof.
     rewrite <- (functor_id F).
     rewrite <- (functor_id odot).
     rewrite <- binprod_id.
-    reflexivity.
+    apply idpath.
   - unfold functor_compax.
     simpl.
     intros.
     rewrite <- (functor_comp F).
     rewrite <- (functor_comp odot).
     rewrite <- binprod_comp.
-    reflexivity.
+    apply idpath.
 Qed.
 
 Definition strength_codom : A ⊠ V ⟶ A' := mk_functor strength_codom_data strength_codom_is_functor.
 
 Definition strength_nat : UU := nat_iso strength_dom strength_codom.
 
-Definition strength_triangle_eq (ϛ : strength_nat) := ∏ (a : A),
-(pr1 ϛ (a, I)) · (#F (pr1 ϱ a)) = pr1 ϱ' (F a).
+Definition strength_triangle_eq (ϛ : strength_nat) :=
+  ∏ (a : A), (pr1 ϛ (a, I)) · (#F (pr1 ϱ a)) = pr1 ϱ' (F a).
 
-Definition strength_pentagon_eq (ϛ : strength_nat) := ∏ (a : A), ∏ (x y : V),
-  (pr1 χ' ((F a, x), y)) · pr1 ϛ (a, x ⊗ y) = (pr1 ϛ (a, x)) #⊙' (id y) · (pr1 ϛ (a ⊙ x, y)) · (#F (pr1 χ ((a, x), y))).
+Definition strength_pentagon_eq (ϛ : strength_nat): UU := ∏ (a : A), ∏ (x y : V),
+  (pr1 χ' ((F a, x), y)) · pr1 ϛ (a, x ⊗ y) =
+  (pr1 ϛ (a, x)) #⊙' (id y) · (pr1 ϛ (a ⊙ x, y)) · (#F (pr1 χ ((a, x), y))).
 
 End Strengths_Natural_Transformation.
 
-Definition strength : UU := ∏ F : A ⟶ A', ∑ (ϛ : strength_nat F),
-(strength_triangle_eq F ϛ) × (strength_pentagon_eq F ϛ).
+Definition strength (F : A ⟶ A'): UU := ∑ (ϛ : strength_nat F),
+  (strength_triangle_eq F ϛ) × (strength_pentagon_eq F ϛ).
 
 End Strengths_Definition.
 

--- a/UniMath/CategoryTheory/PrecategoryBinProduct.v
+++ b/UniMath/CategoryTheory/PrecategoryBinProduct.v
@@ -534,3 +534,72 @@ Definition binswap_pair_functor {C D : precategory} :
   pair_functor (pr2_functor C D) (pr1_functor C D) □ bindelta_functor (precategory_binproduct C D).
 
 End functors.
+
+Section whiskering.
+
+(** Postwhiskering with parameter *)
+
+Definition nat_trans_data_post_whisker_fst_param {B C D P: precategory}
+           {G H : functor B C} (γ : nat_trans G H) (K : functor (P × C) D):
+  nat_trans_data (functor_composite (pair_functor (functor_identity _) G) K)
+                 (functor_composite (pair_functor (functor_identity _) H) K) :=
+  λ pb : P × B, #K ((identity (ob1 pb),, γ (ob2 pb)):
+                      (P × C)⟦ob1 pb,, G(ob2 pb), ob1 pb,, H(ob2 pb)⟧).
+
+Lemma is_nat_trans_post_whisker_fst_param {B C D P: precategory}
+      {G H : functor B C} (γ : nat_trans G H) (K : functor (P × C) D):
+  is_nat_trans _ _ (nat_trans_data_post_whisker_fst_param γ K).
+Proof.
+  intros pb pb' f.
+  cbn.
+  unfold nat_trans_data_post_whisker_fst_param.
+  eapply pathscomp0.
+  2: { apply functor_comp. }
+  eapply pathscomp0.
+  { apply pathsinv0. apply functor_comp. }
+  apply maponpaths.
+  unfold compose; cbn.
+  rewrite id_left. rewrite id_right.
+  apply maponpaths.
+  apply (nat_trans_ax γ).
+Qed.
+
+Definition post_whisker_fst_param {B C D P: precategory}
+  {G H : functor B C} (γ : nat_trans G H) (K : functor (P × C) D):
+  (functor_composite (pair_functor (functor_identity _) G) K) ⟹
+  (functor_composite (pair_functor (functor_identity _) H) K) :=
+  mk_nat_trans _ _ _ (is_nat_trans_post_whisker_fst_param γ K).
+
+
+Definition nat_trans_data_post_whisker_snd_param {B C D P: precategory}
+           {G H : functor B C} (γ : nat_trans G H) (K : functor (C × P) D):
+  nat_trans_data (functor_composite (pair_functor G (functor_identity _)) K)
+                 (functor_composite (pair_functor H (functor_identity _)) K) :=
+  λ bp : B × P, #K ((γ (ob1 bp),, identity (ob2 bp)):
+                      (C × P)⟦G(ob1 bp),, ob2 bp, H(ob1 bp),, ob2 bp⟧).
+
+Lemma is_nat_trans_post_whisker_snd_param {B C D P: precategory}
+      {G H : functor B C} (γ : nat_trans G H) (K : functor (C × P) D):
+  is_nat_trans _ _ (nat_trans_data_post_whisker_snd_param γ K).
+Proof.
+  intros bp bp' f.
+  cbn.
+  unfold nat_trans_data_post_whisker_snd_param.
+  eapply pathscomp0.
+  2: { apply functor_comp. }
+  eapply pathscomp0.
+  { apply pathsinv0. apply functor_comp. }
+  apply maponpaths.
+  unfold compose; cbn.
+  rewrite id_left. rewrite id_right.
+  apply (maponpaths (λ x, dirprodpair x (pr2 f))).
+  apply (nat_trans_ax γ).
+Qed.
+
+Definition post_whisker_snd_param {B C D P: precategory}
+  {G H : functor B C} (γ : nat_trans G H) (K : functor (C × P) D):
+  (functor_composite (pair_functor G (functor_identity _)) K) ⟹
+  (functor_composite (pair_functor H (functor_identity _)) K) :=
+  mk_nat_trans _ _ _ (is_nat_trans_post_whisker_snd_param γ K).
+
+End whiskering.

--- a/UniMath/CategoryTheory/PrecategoryBinProduct.v
+++ b/UniMath/CategoryTheory/PrecategoryBinProduct.v
@@ -21,12 +21,18 @@
   - From a functor on a product of precategories to a functor on one of
     the categories by fixing the argument in the other component
 
+  - From a functor on a product of precategories to a nat. transformation on one of
+    the categories by fixing the morphism argument in the other component
+
   - Definition of the associator functors
 
   - Definition of the pair of two functors: A × C → B × D
     given A → B and C → D
 
   - Definition of the diagonal functor [bindelta_functor].
+
+  - Definition of post-whiskering with parameter (with a functor on a
+    product of precategories where one argument is seen as parameter)
 
 *)
 
@@ -540,14 +546,14 @@ Section whiskering.
 (** Postwhiskering with parameter *)
 
 Definition nat_trans_data_post_whisker_fst_param {B C D P: precategory}
-           {G H : functor B C} (γ : nat_trans G H) (K : functor (P × C) D):
+           {G H : functor B C} (γ : G ⟹ H) (K : functor (P × C) D):
   nat_trans_data (functor_composite (pair_functor (functor_identity _) G) K)
                  (functor_composite (pair_functor (functor_identity _) H) K) :=
   λ pb : P × B, #K ((identity (ob1 pb),, γ (ob2 pb)):
                       (P × C)⟦ob1 pb,, G(ob2 pb), ob1 pb,, H(ob2 pb)⟧).
 
 Lemma is_nat_trans_post_whisker_fst_param {B C D P: precategory}
-      {G H : functor B C} (γ : nat_trans G H) (K : functor (P × C) D):
+      {G H : functor B C} (γ : G ⟹ H) (K : functor (P × C) D):
   is_nat_trans _ _ (nat_trans_data_post_whisker_fst_param γ K).
 Proof.
   intros pb pb' f.
@@ -565,21 +571,21 @@ Proof.
 Qed.
 
 Definition post_whisker_fst_param {B C D P: precategory}
-  {G H : functor B C} (γ : nat_trans G H) (K : functor (P × C) D):
+  {G H : functor B C} (γ : G ⟹ H) (K : functor (P × C) D):
   (functor_composite (pair_functor (functor_identity _) G) K) ⟹
   (functor_composite (pair_functor (functor_identity _) H) K) :=
   mk_nat_trans _ _ _ (is_nat_trans_post_whisker_fst_param γ K).
 
 
 Definition nat_trans_data_post_whisker_snd_param {B C D P: precategory}
-           {G H : functor B C} (γ : nat_trans G H) (K : functor (C × P) D):
+           {G H : functor B C} (γ : G ⟹ H) (K : functor (C × P) D):
   nat_trans_data (functor_composite (pair_functor G (functor_identity _)) K)
                  (functor_composite (pair_functor H (functor_identity _)) K) :=
   λ bp : B × P, #K ((γ (ob1 bp),, identity (ob2 bp)):
                       (C × P)⟦G(ob1 bp),, ob2 bp, H(ob1 bp),, ob2 bp⟧).
 
 Lemma is_nat_trans_post_whisker_snd_param {B C D P: precategory}
-      {G H : functor B C} (γ : nat_trans G H) (K : functor (C × P) D):
+      {G H : functor B C} (γ : G ⟹ H) (K : functor (C × P) D):
   is_nat_trans _ _ (nat_trans_data_post_whisker_snd_param γ K).
 Proof.
   intros bp bp' f.
@@ -597,7 +603,7 @@ Proof.
 Qed.
 
 Definition post_whisker_snd_param {B C D P: precategory}
-  {G H : functor B C} (γ : nat_trans G H) (K : functor (C × P) D):
+  {G H : functor B C} (γ : G ⟹ H) (K : functor (C × P) D):
   (functor_composite (pair_functor G (functor_identity _)) K) ⟹
   (functor_composite (pair_functor H (functor_identity _)) K) :=
   mk_nat_trans _ _ _ (is_nat_trans_post_whisker_snd_param γ K).

--- a/UniMath/CategoryTheory/PrecategoryBinProduct.v
+++ b/UniMath/CategoryTheory/PrecategoryBinProduct.v
@@ -252,6 +252,48 @@ Definition functor_fix_fst_arg : functor D E
 
 End functor_fix_fst_arg.
 
+Section nat_trans_from_functor_fix_fst_morphism_arg.
+
+Variable C D E : precategory.
+Variable F : functor (precategory_binproduct C D) E.
+Variable c c' : C.
+Variable g: c --> c'.
+
+Definition nat_trans_from_functor_fix_fst_morphism_arg_data (d: D): functor_fix_fst_arg C D E F c d --> functor_fix_fst_arg C D E F c' d.
+Proof.
+  apply (#F).
+  exact (dirprodpair g (identity d)).
+Defined.
+
+Lemma nat_trans_from_functor_fix_fst_morphism_arg_ax: is_nat_trans _ _ nat_trans_from_functor_fix_fst_morphism_arg_data.
+Proof.
+  red.
+  intros d d' f.
+  unfold nat_trans_from_functor_fix_fst_morphism_arg_data.
+  unfold functor_fix_fst_arg; cbn.
+  unfold functor_fix_fst_arg_mor; simpl.
+  eapply pathscomp0.
+  2: { apply functor_comp. }
+  apply pathsinv0.
+  eapply pathscomp0.
+  2: { apply functor_comp. }
+  apply maponpaths.
+  unfold compose.
+  cbn.
+  do 2 rewrite id_left.
+  do 2 rewrite id_right.
+  apply idpath.
+Qed.
+
+Definition nat_trans_from_functor_fix_fst_morphism_arg: functor_fix_fst_arg C D E F c ⟹ functor_fix_fst_arg C D E F c'.
+Proof.
+  use tpair.
+  - intro d. apply nat_trans_from_functor_fix_fst_morphism_arg_data.
+  - cbn. exact nat_trans_from_functor_fix_fst_morphism_arg_ax.
+Defined.
+
+End nat_trans_from_functor_fix_fst_morphism_arg.
+
 Section nat_trans_fix_fst_arg.
 
 Variable C D E : precategory.
@@ -322,6 +364,48 @@ Proof.
 Defined.
 
 End functor_fix_snd_arg.
+
+Section nat_trans_from_functor_fix_snd_morphism_arg.
+
+Variable C D E : precategory.
+Variable F : functor (precategory_binproduct C D) E.
+Variable d d' : D.
+Variable f: d --> d'.
+
+Definition nat_trans_from_functor_fix_snd_morphism_arg_data (c: C): functor_fix_snd_arg C D E F d c --> functor_fix_snd_arg C D E F d' c.
+Proof.
+  apply (#F).
+  exact (dirprodpair (identity c) f).
+Defined.
+
+Lemma nat_trans_from_functor_fix_snd_morphism_arg_ax: is_nat_trans _ _ nat_trans_from_functor_fix_snd_morphism_arg_data.
+Proof.
+  red.
+  intros c c' g.
+  unfold nat_trans_from_functor_fix_snd_morphism_arg_data.
+  unfold functor_fix_snd_arg; cbn.
+  unfold functor_fix_snd_arg_mor; simpl.
+  eapply pathscomp0.
+  2: { apply functor_comp. }
+  apply pathsinv0.
+  eapply pathscomp0.
+  2: { apply functor_comp. }
+  apply maponpaths.
+  unfold compose.
+  cbn.
+  do 2 rewrite id_left.
+  do 2 rewrite id_right.
+  apply idpath.
+Qed.
+
+Definition nat_trans_from_functor_fix_snd_morphism_arg: functor_fix_snd_arg C D E F d ⟹ functor_fix_snd_arg C D E F d'.
+Proof.
+  use tpair.
+  - intro c. apply nat_trans_from_functor_fix_snd_morphism_arg_data.
+  - cbn. exact nat_trans_from_functor_fix_snd_morphism_arg_ax.
+Defined.
+
+End nat_trans_from_functor_fix_snd_morphism_arg.
 
 Section nat_trans_fix_snd_arg.
 


### PR DESCRIPTION
This is not yet a request for being pulled but rather an announcement of ongoing work.

The code conforms better with the style guide now, but the main change is the use of the library constructions of functors and natural transformations, so that the "hand coding" of those can be avoided. In particular, this makes lengthy proofs of functoriality or naturality unnecessary. This latter part is far from completion, but it can be done incrementally. 
A good example is `U_action_ρ_is_nat_trans` that could be deleted from `Actions.v` - at the price of an upstream lemma, but that one could be useful in the future.