### PR TITLE
Make sure bound scopes are imported correctly.

### DIFF
--- a/UniMath/Topology/CategoryTop.v
+++ b/UniMath/Topology/CategoryTop.v
@@ -11,6 +11,7 @@ Require Import UniMath.Algebra.ConstructiveStructures.
 Require Import UniMath.Topology.Topology.
 Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.categories.HSET.Core.
+Require Import UniMath.CategoryTheory.DisplayedCats.Auxiliary.
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
 
 (** * Displayed category of topological spaces *)


### PR DESCRIPTION
Scopes used for arguments depend on the bound scopes (in the sense of
`Bind Scope`) that have been imported (as in `Import`). A Coq bug was
making some non-imported bound scopes visibles, and one file of UniMath
was relying on this bug. We fix it here.

This is in preparation for https://github.com/coq/coq/pull/10181, but
should be backward compatible (remains to be tested).