### PR TITLE
Adjoint equivalences between pseudofunctors

### DIFF
--- a/UniMath/CONTENTS.md
+++ b/UniMath/CONTENTS.md
@@ -331,6 +331,7 @@ The packages and files are listed here in logical order: each file depends only 
    - [Bicategories/PseudoFunctors/StrictPseudoFunctor.v](CategoryTheory/Bicategories/PseudoFunctors/StrictPseudoFunctor.v)
    - [Bicategories/PseudoFunctors/Examples/Identity.v](CategoryTheory/Bicategories/PseudoFunctors/Examples/Identity.v)
    - [Bicategories/PseudoFunctors/Examples/Composition.v](CategoryTheory/Bicategories/PseudoFunctors/Examples/Composition.v)
+   - [Bicategories/PseudoFunctors/Examples/Constant.v](CategoryTheory/Bicategories/PseudoFunctors/Examples/Constant.v)
    - [Bicategories/PseudoFunctors/Examples/ApFunctor.v](CategoryTheory/Bicategories/PseudoFunctors/Examples/ApFunctor.v)
    - [Bicategories/PseudoFunctors/Examples/OpFunctor.v](CategoryTheory/Bicategories/PseudoFunctors/Examples/OpFunctor.v)
    - [Bicategories/Transformations/PseudoTransformation.v](CategoryTheory/Bicategories/Transformations/PseudoTransformation.v)

--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -235,6 +235,7 @@ Bicategories/PseudoFunctors/PseudoFunctor.v
 Bicategories/PseudoFunctors/StrictPseudoFunctor.v
 Bicategories/PseudoFunctors/Examples/Identity.v
 Bicategories/PseudoFunctors/Examples/Composition.v
+Bicategories/PseudoFunctors/Examples/Constant.v
 Bicategories/PseudoFunctors/Examples/ApFunctor.v
 Bicategories/PseudoFunctors/Examples/OpFunctor.v
 Bicategories/Transformations/PseudoTransformation.v

--- a/UniMath/CategoryTheory/Bicategories/PseudoFunctors/Examples/Constant.v
+++ b/UniMath/CategoryTheory/Bicategories/PseudoFunctors/Examples/Constant.v
@@ -1,0 +1,80 @@
+(** Constant pseudofunctor *)
+Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.All.
+
+Require Import UniMath.CategoryTheory.Core.Categories.
+Require Import UniMath.CategoryTheory.Core.Functors.
+
+Require Import UniMath.CategoryTheory.Bicategories.Bicategories.Bicat.
+Import Bicat.Notations.
+Require Import UniMath.CategoryTheory.Bicategories.Bicategories.Invertible_2cells.
+Require Import UniMath.CategoryTheory.Bicategories.Bicategories.Unitors.
+Require Import UniMath.CategoryTheory.Bicategories.PseudoFunctors.Display.Base.
+Require Import UniMath.CategoryTheory.Bicategories.PseudoFunctors.Display.Map1Cells.
+Require Import UniMath.CategoryTheory.Bicategories.PseudoFunctors.Display.Map2Cells.
+Require Import UniMath.CategoryTheory.Bicategories.PseudoFunctors.Display.Identitor.
+Require Import UniMath.CategoryTheory.Bicategories.PseudoFunctors.Display.Compositor.
+Require Import UniMath.CategoryTheory.Bicategories.PseudoFunctors.Display.PseudoFunctorBicat.
+Require Import UniMath.CategoryTheory.Bicategories.PseudoFunctors.PseudoFunctor.
+Import UniMath.CategoryTheory.Bicategories.PseudoFunctors.PseudoFunctor.Notations.
+
+Local Open Scope cat.
+
+Section Constant.
+  Context (B₁ : bicat)
+          {B₂ : bicat}
+          (Y : B₂).
+
+  Definition constant_data : psfunctor_data B₁ B₂.
+  Proof.
+    use make_psfunctor_data.
+    - exact (λ _, Y).
+    - exact (λ _ _ _, id₁ Y).
+    - exact (λ _ _ _ _ _, id₂ (id₁ Y)).
+    - exact (λ _, id₂ (id₁ Y)).
+    - exact (λ _ _ _ _ _, lunitor (id₁ Y)).
+  Defined.
+
+  Definition constant_laws : psfunctor_laws constant_data.
+  Proof.
+    repeat split.
+    - intros a b f g h α β ; cbn.
+      rewrite id2_left.
+      apply idpath.
+    - intros a b f ; cbn.
+      rewrite id2_rwhisker, id2_left, id2_right.
+      apply idpath.
+    - intros a b f ; cbn.
+      rewrite lwhisker_id2, id2_left, id2_right, runitor_lunitor_identity.
+      apply idpath.
+    - intros a b c d f g h ; cbn.
+      rewrite id2_right.
+      rewrite lunitor_triangle.
+      rewrite lunitor_is_lunitor_lwhisker.
+      apply idpath.
+    - intros a b c f g h α ; cbn.
+      rewrite lwhisker_id2, id2_left, id2_right.
+      apply idpath.
+    - intros a b c f g h α ; cbn.
+      rewrite id2_rwhisker, id2_left, id2_right.
+      apply idpath.
+  Qed.
+
+  Definition constant_invertible_cells
+    : invertible_cells constant_data.
+  Proof.
+    split.
+    - intro a ; cbn.
+      is_iso.
+    - intros a b c f g ; cbn.
+      is_iso.
+  Defined.
+  
+  Definition constant : psfunctor B₁ B₂.
+  Proof.
+    use make_psfunctor.
+    - exact constant_data.
+    - exact constant_laws.
+    - exact constant_invertible_cells.
+  Defined.
+End Constant. 

--- a/UniMath/CategoryTheory/Bicategories/Transformations/PseudoTransformation.v
+++ b/UniMath/CategoryTheory/Bicategories/Transformations/PseudoTransformation.v
@@ -5,8 +5,11 @@ Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.Core.Functors.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
 Require Import UniMath.CategoryTheory.Bicategories.Bicategories.Bicat. Import Bicat.Notations.
+Require Import UniMath.CategoryTheory.Bicategories.Bicategories.Adjunctions.
 Require Import UniMath.CategoryTheory.Bicategories.Bicategories.Invertible_2cells.
 Require Import UniMath.CategoryTheory.Bicategories.Bicategories.BicategoryLaws.
+Require Import UniMath.CategoryTheory.Bicategories.DisplayedBicats.DispBicat.
+Require Import UniMath.CategoryTheory.Bicategories.DisplayedBicats.DispUnivalence.
 Require Import UniMath.CategoryTheory.Bicategories.PseudoFunctors.Display.Base.
 Require Import UniMath.CategoryTheory.Bicategories.PseudoFunctors.Display.Map1Cells.
 Require Import UniMath.CategoryTheory.Bicategories.PseudoFunctors.Display.Map2Cells.
@@ -15,7 +18,6 @@ Require Import UniMath.CategoryTheory.Bicategories.PseudoFunctors.Display.Compos
 Require Import UniMath.CategoryTheory.Bicategories.PseudoFunctors.Display.PseudoFunctorBicat.
 Require Import UniMath.CategoryTheory.Bicategories.PseudoFunctors.PseudoFunctor.
 Import PseudoFunctor.Notations.
-Require Import UniMath.CategoryTheory.Bicategories.Bicategories.Examples.TwoType.
 
 Local Open Scope cat.
 
@@ -251,3 +253,18 @@ Definition comp_trans
            (σ₁ : pstrans F₁ F₂) (σ₂ : pstrans F₂ F₃)
   : pstrans F₁ F₃
   := σ₁ · σ₂.
+
+(** Pseudo adjoint equivalence is pointwise adjoint equivalence *)
+Definition pointwise_adjequiv
+           {B₁ B₂ : bicat}
+           {F₁ F₂ : psfunctor B₁ B₂}
+           (σ : pstrans F₁ F₂)
+           (Hf : left_adjoint_equivalence σ)
+  : ∏ (X : B₁), left_adjoint_equivalence (σ X).
+Proof.
+  intro X.
+  pose (pr1 (left_adjoint_equivalence_total_disp_weq _ _ Hf)) as t₁.
+  pose (pr1 (left_adjoint_equivalence_total_disp_weq _ _ t₁)) as t₂.
+  pose (pr1 (left_adjoint_equivalence_total_disp_weq _ _ t₂)) as t₃.
+  exact (is_adjequiv_to_all_is_adjequiv _ _ _ t₃ X).
+Defined.


### PR DESCRIPTION
Simple result: if we have an adjoint equivalence between pseudofunctors, then it's a pointwise adjoint equivalence.