### PR TITLE
Attempt to improve Fibration2

### DIFF
--- a/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Fibration/Fibration2.v
+++ b/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Fibration/Fibration2.v
@@ -26,6 +26,13 @@ Section LocalIsoFibration.
 
   Local Arguments transportf {_} {_} {_} {_} {_} _.
   Local Arguments transportb {_} {_} {_} {_} {_} _.
+  Local Arguments disp_lassociator {_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _}.
+  Local Arguments disp_rassociator {_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _}.
+  Local Notation "'ℓ1'" := (local_iso_cleaving_1cell h _ (idempunitor c))
+                               (at level 0).
+  Local Notation "'ℓ2'" := (disp_local_iso_cleaving_invertible_2cell h _ (idempunitor c))
+                               (at level 0).
+  Local Notation "f ^-1" := (disp_inv_cell f).
 
   Definition discrete_fiber_data_laws_rassociator_lassociator
     :  ∏ (a₁ a₂ a₃ a₄ : discrete_fiber_data D h c)
@@ -592,133 +599,181 @@ Section LocalIsoFibration.
     apply cellset_property.
   Qed.
 
-  Definition discrete_fiber_data_laws_lassociator_lassociator
-    : ∏ (a₁ a₂ a₃ a₄ a₅ : discrete_fiber_data D h c)
-        (f₁ : discrete_fiber_data D h c ⟦ a₁ , a₂ ⟧)
-        (f₂ : discrete_fiber_data D h c ⟦ a₂ , a₃ ⟧)
-        (f₃ : discrete_fiber_data D h c ⟦ a₃ , a₄ ⟧)
-        (f₄ : discrete_fiber_data D h c ⟦ a₄ , a₅ ⟧),
-      ((f₁ ◃ lassociator f₂ f₃ f₄)
-         • lassociator f₁ (f₂ · f₃) f₄)
-        • (lassociator f₁ f₂ f₃ ▹ f₄)
-      =
-      lassociator f₁ f₂ (f₃ · f₄) • lassociator (f₁ · f₂) f₃ f₄.
-  Proof.
-    intros a₁ a₂ a₃ a₄ a₅ f₁ f₂ f₃ f₄ ; cbn.
-    etrans.
-    {
+  Section LassociatorLassociator.
+    Variable (a₁ a₂ a₃ a₄ a₅ : discrete_fiber_data D h c)
+             (f₁ : discrete_fiber_data D h c ⟦ a₁ , a₂ ⟧)
+             (f₂ : discrete_fiber_data D h c ⟦ a₂ , a₃ ⟧)
+             (f₃ : discrete_fiber_data D h c ⟦ a₃ , a₄ ⟧)
+             (f₄ : discrete_fiber_data D h c ⟦ a₄ , a₅ ⟧).
+    Arguments transportf {_} _ {_} {_} _ _.
+
+    Local Definition step1
+      : ∑ p,
+        ((f₁ ◃ lassociator f₂ f₃ f₄)
+           • lassociator f₁ (f₂ · f₃) f₄)
+          • (lassociator f₁ f₂ f₃ ▹ f₄)
+        =
+        transportf
+          (λ z, _ ==>[ z] _)
+          p
+          ((((ℓ2 •• (f₁ ◃◃ (((ℓ2 •• (f₂ ◃◃ ℓ2)) •• disp_lassociator)
+                              •• ((ℓ2 ^-1 ▹▹ f₄) •• ℓ2 ^-1)))) •• ℓ2 ^-1)
+              •• (((ℓ2 •• (f₁ ◃◃ ℓ2)) •• disp_lassociator)
+                    •• ((ℓ2 ^-1 ▹▹ f₄) •• ℓ2^-1)))
+             •• ((ℓ2 •• ((((ℓ2 •• (f₁ ◃◃ ℓ2)) •• disp_lassociator)
+                            •• ((ℓ2^-1 ▹▹ f₃) •• ℓ2^-1)) ▹▹ f₄)) •• ℓ2^-1)).
+    Proof.
+      eexists.
+      cbn.
       etrans.
       {
-        apply maponpaths.
-        etrans.
-        {
-          apply disp_mor_transportf_prewhisker.
-        }
         etrans.
         {
           apply maponpaths.
           etrans.
           {
-            apply disp_mor_transportf_postwhisker.
-          }
-          apply maponpaths.
-          etrans.
-          {
-            apply maponpaths_2.
             apply disp_mor_transportf_prewhisker.
           }
           etrans.
           {
+            apply maponpaths.
             etrans.
             {
-              apply maponpaths_2.
-              etrans.
-              {
-                apply maponpaths.
-                apply disp_mor_transportf_postwhisker.
-              }
-              etrans.
-              {
-                apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-              }
-              etrans.
-              {
-                apply maponpaths.
-                etrans.
-                {
-                  apply maponpaths_2.
-                  etrans.
-                  {
-                    apply maponpaths_2.
-                    etrans.
-                    {
-                      apply maponpaths.
-                      apply disp_rwhisker_transport_right.
-                    }
-                    apply disp_mor_transportf_prewhisker.
-                  }
-                  apply disp_mor_transportf_postwhisker.
-                }
-                apply disp_mor_transportf_postwhisker.
-              }
-              apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+              apply disp_mor_transportf_postwhisker.
             }
             apply maponpaths.
             etrans.
             {
               apply maponpaths_2.
+              apply disp_mor_transportf_prewhisker.
+            }
+            etrans.
+            {
               etrans.
               {
-                apply maponpaths.
-                apply disp_rwhisker_transport_left_new.
+                apply maponpaths_2.
+                etrans.
+                {
+                  apply maponpaths.
+                  apply disp_mor_transportf_postwhisker.
+                }
+                etrans.
+                {
+                  apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                }
+                etrans.
+                {
+                  apply maponpaths.
+                  etrans.
+                  {
+                    apply maponpaths_2.
+                    etrans.
+                    {
+                      apply maponpaths_2.
+                      etrans.
+                      {
+                        apply maponpaths.
+                        apply disp_rwhisker_transport_right.
+                      }
+                      apply disp_mor_transportf_prewhisker.
+                    }
+                    apply disp_mor_transportf_postwhisker.
+                  }
+                  apply disp_mor_transportf_postwhisker.
+                }
+                apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
               }
-              apply disp_mor_transportf_prewhisker.
+              apply maponpaths.
+              etrans.
+              {
+                apply maponpaths_2.
+                etrans.
+                {
+                  apply maponpaths.
+                  apply disp_rwhisker_transport_left_new.
+                }
+                apply disp_mor_transportf_prewhisker.
+              }
+              apply disp_mor_transportf_postwhisker.
             }
             apply disp_mor_transportf_postwhisker.
           }
-          apply disp_mor_transportf_postwhisker.
-        }
-        etrans.
-        {
+          etrans.
+          {
+            apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+          }
+          etrans.
+          {
+            apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+          }
+          etrans.
+          {
+            apply maponpaths.
+            apply disp_mor_transportf_prewhisker.
+          }
           apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
         }
+        apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+      }
+      apply idpath.
+    Qed.
+
+    Local Definition step2
+      : ∑ p,
+        transportf
+          (λ z, _ ==>[ z] _)
+          p
+          ((((ℓ2 •• (f₁ ◃◃ ℓ2)) •• disp_lassociator)
+              •• ((ℓ2 ^-1 ▹▹ ℓ1) •• ℓ2^-1))
+             •• (((ℓ2 •• (ℓ1 ◃◃ ℓ2)) •• disp_lassociator)
+                   •• ((ℓ2^-1 ▹▹ f₄) •• ℓ2^-1)))
+        =
+        lassociator f₁ f₂ (f₃ · f₄) • lassociator (f₁ · f₂) f₃ f₄.
+    Proof.
+      eexists.
+      refine (!_).
+      cbn.
+      etrans.
+      {
+        apply maponpaths.
         etrans.
         {
-          apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+          apply disp_mor_transportf_prewhisker.
         }
         etrans.
         {
           apply maponpaths.
-          apply disp_mor_transportf_prewhisker.
+          apply disp_mor_transportf_postwhisker.
         }
         apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
       }
       apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    refine (!_).
-    etrans.
-    {
-      apply maponpaths.
-      etrans.
-      {
-        apply disp_mor_transportf_prewhisker.
-      }
-      etrans.
-      {
-        apply maponpaths.
-        apply disp_mor_transportf_postwhisker.
-      }
-      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    etrans.
-    {
-      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    refine (!_).
-    etrans.
-    {
-      apply maponpaths.
-      refine (disp_vassocl _ _ _ @ _).
+    Qed.
+
+    Local Definition step3
+      : ∑ p,
+        transportf
+          (λ z, _ ==>[ z] _)
+          (pr1 step1)
+          ((((ℓ2 •• (f₁ ◃◃ (((ℓ2 •• (f₂ ◃◃ ℓ2)) •• disp_lassociator)
+                              •• ((ℓ2 ^-1 ▹▹ f₄) •• ℓ2 ^-1)))) •• ℓ2 ^-1)
+              •• (((ℓ2 •• (f₁ ◃◃ ℓ2)) •• disp_lassociator)
+                    •• ((ℓ2 ^-1 ▹▹ f₄) •• ℓ2^-1)))
+             •• ((ℓ2 •• ((((ℓ2 •• (f₁ ◃◃ ℓ2)) •• disp_lassociator)
+                            •• ((ℓ2^-1 ▹▹ f₃) •• ℓ2^-1)) ▹▹ f₄)) •• ℓ2^-1))
+        =
+        transportf
+          (λ z, _ ==>[ z ] _)
+          p
+          ((ℓ2 •• (f₁ ◃◃ (((ℓ2 •• (f₂ ◃◃ ℓ2)) •• disp_lassociator)
+                            •• ((ℓ2 ^-1 ▹▹ f₄) •• ℓ2^-1))))
+             •• ((((f₁ ◃◃ ℓ2) •• disp_lassociator)
+                    •• ((ℓ2^-1 ▹▹ f₄) •• ℓ2^-1))
+                   •• ((ℓ2 •• ((((ℓ2 •• (f₁ ◃◃ ℓ2)) •• disp_lassociator)
+                                  •• ((ℓ2^-1 ▹▹ f₃) •• ℓ2^-1)) ▹▹ f₄))
+                         •• ℓ2^-1))).
+    Proof.
+      eexists.
       etrans.
       {
         apply maponpaths.
@@ -726,394 +781,62 @@ Section LocalIsoFibration.
         etrans.
         {
           apply maponpaths.
+          refine (disp_vassocl _ _ _ @ _).
           etrans.
           {
             apply maponpaths.
-            refine (disp_vassocr _ _ _ @ _).
             etrans.
             {
               apply maponpaths.
+              refine (disp_vassocr _ _ _ @ _).
               etrans.
-              {apply maponpaths_2.
-               refine (disp_vassocr _ _ _ @ _).
-               etrans.
-               {
-                 apply maponpaths.
+              {
+                apply maponpaths.
+                etrans.
+                {apply maponpaths_2.
+                 refine (disp_vassocr _ _ _ @ _).
                  etrans.
                  {
-                   apply maponpaths_2.
+                   apply maponpaths.
                    etrans.
                    {
-                     refine (disp_vassocr _ _ _ @ _).
-                     apply maponpaths.
+                     apply maponpaths_2.
                      etrans.
                      {
-                       apply maponpaths_2.
                        refine (disp_vassocr _ _ _ @ _).
+                       apply maponpaths.
                        etrans.
                        {
-                         apply maponpaths.
-                         etrans.
-                         {
-                           apply maponpaths_2.
-                           exact (disp_vcomp_linv
-                                    (disp_local_iso_cleaving_invertible_2cell
-                                       h
-                                       (f₁;;local_iso_cleaving_1cell h
-                                          (local_iso_cleaving_1cell
-                                             h (f₂;; f₃) (idempunitor c);; f₄)
-                                          (idempunitor c))
-                                       (idempunitor c))).
-                         }
-                         etrans.
-                         {
-                           apply disp_mor_transportf_postwhisker.
-                         }
+                         apply maponpaths_2.
+                         refine (disp_vassocr _ _ _ @ _).
                          etrans.
                          {
                            apply maponpaths.
-                           apply disp_id2_left.
+                           etrans.
+                           {
+                             apply maponpaths_2.
+                             exact (disp_vcomp_linv ℓ2).
+                           }
+                           etrans.
+                           {
+                             apply disp_mor_transportf_postwhisker.
+                           }
+                           etrans.
+                           {
+                             apply maponpaths.
+                             apply disp_id2_left.
+                           }
+                           apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
                          }
                          apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
                        }
-                       apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                       apply disp_mor_transportf_postwhisker.
                      }
-                     apply disp_mor_transportf_postwhisker.
+                     apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
                    }
-                   apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                   apply disp_mor_transportf_postwhisker.
                  }
-                 apply disp_mor_transportf_postwhisker.
-               }
-               apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-              }
-              apply disp_mor_transportf_postwhisker.
-            }
-            apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-          }
-          apply disp_mor_transportf_prewhisker.
-        }
-        apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-      }
-      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    etrans.
-    {
-      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    etrans.
-    {
-      apply maponpaths.
-      etrans.
-      {
-        apply maponpaths.
-        refine (disp_vassocl _ _ _ @ _).
-        etrans.
-        {
-          apply maponpaths.
-          etrans.
-          {
-            apply maponpaths.
-            refine (disp_vassocl _ _ _ @ _).
-            etrans.
-            {
-              apply maponpaths.
-              etrans.
-              {
-                apply maponpaths.
-                refine (disp_vassocr _ _ _ @ _).
-                etrans.
-                {
-                  apply maponpaths.
-                  etrans.
-                  {
-                    apply maponpaths_2.
-                    refine (disp_vassocr _ _ _ @ _).
-                    etrans.
-                    {
-                      apply maponpaths.
-                      etrans.
-                      {
-                        apply maponpaths_2.
-                        exact (disp_vcomp_linv
-                                 (disp_local_iso_cleaving_invertible_2cell
-                                    h
-                                    (local_iso_cleaving_1cell
-                                       h (f₁;; local_iso_cleaving_1cell h (f₂;; f₃) (idempunitor c))
-                                       (idempunitor c);; f₄)
-                                    (idempunitor c))).
-                      }
-                      etrans.
-                      {
-                        apply disp_mor_transportf_postwhisker.
-                      }
-                      etrans.
-                      {
-                        apply maponpaths.
-                        apply disp_id2_left.
-                      }
-                      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-                    }
-                    apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-                  }
-                  apply disp_mor_transportf_postwhisker.
-                }
-                apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-              }
-              apply disp_mor_transportf_prewhisker.
-            }
-            apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-          }
-          apply disp_mor_transportf_prewhisker.
-        }
-        apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-      }
-      apply disp_mor_transportf_prewhisker.
-    }
-    etrans.
-    {
-      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    etrans.
-    {
-      apply maponpaths.
-      etrans.
-      {
-        apply maponpaths.
-        etrans.
-        {
-          apply maponpaths.
-          refine (disp_vassocr _ _ _ @ _).
-          etrans.
-          {
-            apply maponpaths.
-            etrans.
-            {
-              apply maponpaths_2.
-              etrans.
-              {
-                apply disp_rwhisker_vcomp.
-              }
-              apply maponpaths.
-              etrans.
-              {
-                apply maponpaths.
-                refine (disp_vassocr _ _ _ @ _).
-                etrans.
-                {
-                  apply maponpaths.
-                  etrans.
-                  {
-                    apply maponpaths_2.
-                    refine (disp_vassocr _ _ _ @ _).
-                    etrans.
-                    {
-                      apply maponpaths.
-                      etrans.
-                      {
-                        apply maponpaths_2.
-                        refine (disp_vassocr _ _ _ @ _).
-                        etrans.
-                        {
-                          apply maponpaths.
-                          etrans.
-                          {
-                            apply maponpaths_2.
-                            exact (disp_vcomp_linv
-                                     (disp_local_iso_cleaving_invertible_2cell
-                                        h
-                                        (f₁;;local_iso_cleaving_1cell
-                                           h (f₂;; f₃) (idempunitor c))
-                                        (idempunitor c))).
-                          }
-                          etrans.
-                          {
-                            apply disp_mor_transportf_postwhisker.
-                          }
-                          etrans.
-                          {
-                            apply maponpaths.
-                            apply disp_id2_left.
-                          }
-                          apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-                        }
-                        apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-                      }
-                      apply disp_mor_transportf_postwhisker.
-                    }
-                    apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-                  }
-                  apply disp_mor_transportf_postwhisker.
-                }
-                apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-              }
-              apply disp_rwhisker_transport_left_new.
-            }
-            etrans.
-            {
-              apply maponpaths_2.
-              apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-            }
-            apply disp_mor_transportf_postwhisker.
-          }
-          apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-        }
-        apply disp_mor_transportf_prewhisker.
-      }
-      apply disp_mor_transportf_prewhisker.
-    }
-    etrans.
-    {
-      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    etrans.
-    {
-      apply maponpaths.
-      etrans.
-      {
-        apply maponpaths_2.
-        etrans.
-        {
-          apply maponpaths.
-          etrans.
-          {
-            apply maponpaths.
-            apply disp_vassocl.
-          }
-          etrans.
-          {
-            apply disp_rwhisker_transport_right.
-          }
-          etrans.
-          {
-            apply maponpaths.
-            etrans.
-            {
-              apply maponpaths.
-              apply disp_vassocl.
-            }
-            etrans.
-            {
-              apply disp_rwhisker_transport_right.
-            }
-            apply maponpaths.
-            apply disp_lwhisker_vcomp_alt.
-          }
-          etrans.
-          {
-            apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-          }
-          apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-        }
-        apply disp_mor_transportf_prewhisker.
-      }
-      apply disp_mor_transportf_postwhisker.
-    }
-    etrans.
-    {
-      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    etrans.
-    {
-      apply maponpaths.
-      refine (disp_vassocl _ _ _ @ _).
-      etrans.
-      {
-        apply maponpaths.
-        etrans.
-        {
-          apply maponpaths.
-          refine (disp_vassocl _ _ _ @ _).
-          etrans.
-          {
-            apply maponpaths.
-            etrans.
-            {
-              apply maponpaths.
-              refine (disp_vassocr _ _ _ @ _).
-              etrans.
-              {
-                apply maponpaths.
-                etrans.
-                {
-                  apply maponpaths_2.
-                  refine (disp_vassocr _ _ _ @ _).
-                  etrans.
-                  {
-                    apply maponpaths.
-                    etrans.
-                    {
-                      apply maponpaths_2.
-                      apply disp_lwhisker_vcomp.
-                    }
-                    etrans.
-                    {
-                      apply disp_mor_transportf_postwhisker.
-                    }
-                    etrans.
-                    {
-                      apply maponpaths.
-                      etrans.
-                      {
-                        apply maponpaths_2.
-                        etrans.
-                        {
-                          apply maponpaths.
-                          refine (disp_vassocl _ _ _ @ _).
-                          etrans.
-                          {
-                            apply maponpaths.
-                            etrans.
-                            {
-                              apply maponpaths.
-                              refine (disp_vassocl _ _ _ @ _).
-                              etrans.
-                              {
-                                apply maponpaths.
-                                etrans.
-                                {
-                                  apply maponpaths.
-                                  refine (disp_vassocl _ _ _ @ _).
-                                  etrans.
-                                  {
-                                    apply maponpaths.
-                                    etrans.
-                                    {
-                                      apply maponpaths.
-                                      exact (disp_vcomp_linv
-                                               (disp_local_iso_cleaving_invertible_2cell
-                                                  h
-                                                  (local_iso_cleaving_1cell
-                                                     h (f₂;; f₃) (idempunitor c);; f₄)
-                                                  (idempunitor c))).
-                                    }
-                                    etrans.
-                                    {
-                                      apply disp_mor_transportf_prewhisker.
-                                    }
-                                    apply maponpaths.
-                                    apply disp_id2_right.
-                                  }
-                                  etrans.
-                                  {
-                                    apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-                                  }
-                                  apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-                                }
-                                apply disp_mor_transportf_prewhisker.
-                              }
-                              apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-                            }
-                            apply disp_mor_transportf_prewhisker.
-                          }
-                          apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-                        }
-                        apply disp_rwhisker_transport_right.
-                      }
-                      apply disp_mor_transportf_postwhisker.
-                    }
-                    apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-                  }
-                  apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                 apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
                 }
                 apply disp_mor_transportf_postwhisker.
               }
@@ -1123,80 +846,36 @@ Section LocalIsoFibration.
           }
           apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
         }
-        apply disp_mor_transportf_prewhisker.
+        apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
       }
       apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    etrans.
-    {
-      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    etrans.
-    {
-      apply maponpaths.
-      etrans.
-      {
-        apply maponpaths.
-        etrans.
-        {
-          apply maponpaths.
-          etrans.
-          {
-            apply maponpaths_2.
-            etrans.
-            {
-              apply maponpaths_2.
-              etrans.
-              {
-                apply maponpaths.
-                apply disp_vassocr.
-              }
-              etrans.
-              {
-                apply disp_rwhisker_transport_right.
-              }
-              etrans.
-              {
-                apply maponpaths.
-                apply disp_lwhisker_vcomp_alt.
-              }
-              apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-            }
-            etrans.
-            {
-              apply disp_mor_transportf_postwhisker.
-            }
-            etrans.
-            {
-              apply maponpaths.
-              refine (disp_vassocl _ _ _ @ _).
-              etrans.
-              {
-                apply maponpaths.
-                etrans.
-                {
-                  apply maponpaths.
-                  apply disp_rwhisker_lwhisker.
-                }
-                apply disp_mor_transportf_prewhisker.
-              }
-              apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-            }
-            apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-          }
-          apply disp_mor_transportf_postwhisker.
-        }
-        apply disp_mor_transportf_prewhisker.
-      }
-      apply disp_mor_transportf_prewhisker.
-    }
-    etrans.
-    {
-      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    etrans.
-    {
-      apply maponpaths.
+    Qed.
+
+    Local Definition step4
+      : ∑ p,
+        transportf
+          (λ z, _ ==>[ z ] _)
+          (pr1 step3)
+          ((ℓ2 •• (f₁ ◃◃ (((ℓ2 •• (f₂ ◃◃ ℓ2)) •• disp_lassociator)
+                            •• ((ℓ2 ^-1 ▹▹ f₄) •• ℓ2^-1))))
+             •• ((((f₁ ◃◃ ℓ2) •• disp_lassociator)
+                    •• ((ℓ2^-1 ▹▹ f₄) •• ℓ2^-1))
+                   •• ((ℓ2 •• ((((ℓ2 •• (f₁ ◃◃ ℓ2)) •• disp_lassociator)
+                                  •• ((ℓ2^-1 ▹▹ f₃) •• ℓ2^-1)) ▹▹ f₄))
+                         •• ℓ2^-1)))
+           =
+           transportf
+             (λ z, _ ==>[ z] _)
+             p
+             ((ℓ2 •• (f₁ ◃◃ (((ℓ2 •• (f₂ ◃◃ ℓ2)) •• disp_lassociator)
+                               •• ((ℓ2^-1 ▹▹ f₄) •• ℓ2^-1))))
+                •• (((f₁ ◃◃ ℓ2) •• disp_lassociator)
+                      •• ((ℓ2^-1 ▹▹ f₄)
+                            •• (((((ℓ2 •• (f₁ ◃◃ ℓ2)) •• disp_lassociator)
+                                    •• ((ℓ2^-1 ▹▹ f₃) •• ℓ2^-1)) ▹▹ f₄)
+                                  •• ℓ2^-1)))).
+    Proof.
+      eexists.
       etrans.
       {
         apply maponpaths.
@@ -1217,239 +896,6 @@ Section LocalIsoFibration.
                 etrans.
                 {
                   apply maponpaths.
-                  refine (disp_vassocr _ _ _ @ _).
-                  etrans.
-                  {
-                    apply maponpaths.
-                    etrans.
-                    {
-                      apply maponpaths_2.
-                      etrans.
-                      {
-                        apply disp_rwhisker_vcomp.
-                      }
-                      apply maponpaths.
-                      etrans.
-                      {
-                        apply maponpaths.
-                        refine (disp_vassocr _ _ _ @ _).
-                        etrans.
-                        {
-                          apply maponpaths.
-                          etrans.
-                          {
-                            apply maponpaths_2.
-                            refine (disp_vassocr _ _ _ @ _).
-                            etrans.
-                            {
-                              apply maponpaths.
-                              etrans.
-                              {
-                                apply maponpaths_2.
-                                etrans.
-                                {
-                                  apply disp_lwhisker_vcomp.
-                                }
-                                apply maponpaths.
-                                etrans.
-                                {
-                                  apply maponpaths.
-                                  exact (disp_vcomp_linv
-                                           (disp_local_iso_cleaving_invertible_2cell
-                                              h (f₂;; f₃) (idempunitor c))).
-                                }
-                                etrans.
-                                {
-                                  apply disp_rwhisker_transport_right.
-                                }
-                                apply maponpaths.
-                                apply disp_lwhisker_id2.
-                              }
-                              etrans.
-                              {
-                                apply maponpaths_2.
-                                etrans.
-                                {
-                                  apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-                                }
-                                apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-                              }
-                              etrans.
-                              {
-                                apply disp_mor_transportf_postwhisker.
-                              }
-                              etrans.
-                              {
-                                apply maponpaths.
-                                apply disp_id2_left.
-                              }
-                              apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-                            }
-                            apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-                          }
-                          apply disp_mor_transportf_postwhisker.
-                        }
-                        apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-                      }
-                      apply disp_rwhisker_transport_left_new.
-                    }
-                    etrans.
-                    {
-                      apply maponpaths_2.
-                      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-                    }
-                    apply disp_mor_transportf_postwhisker.
-                  }
-                  apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-                }
-                apply disp_mor_transportf_prewhisker.
-              }
-              apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-            }
-            apply disp_mor_transportf_prewhisker.
-          }
-          apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-        }
-        apply disp_mor_transportf_prewhisker.
-      }
-      apply disp_mor_transportf_prewhisker.
-    }
-    etrans.
-    {
-      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    etrans.
-    {
-      apply maponpaths.
-      etrans.
-      {
-        apply maponpaths.
-        etrans.
-        {
-          apply maponpaths.
-          etrans.
-          {
-            apply maponpaths_2.
-            apply disp_lwhisker_vcomp_alt.
-          }
-          etrans.
-          {
-            apply disp_mor_transportf_postwhisker.
-          }
-          etrans.
-          {
-            apply maponpaths.
-            refine (disp_vassocl _ _ _ @ _).
-            etrans.
-            {
-              apply maponpaths.
-              etrans.
-              {
-                apply maponpaths.
-                etrans.
-                {
-                  apply maponpaths.
-                  etrans.
-                  {
-                    apply maponpaths.
-                    etrans.
-                    {
-                      apply maponpaths_2.
-                      apply disp_rwhisker_vcomp_alt.
-                    }
-                    apply disp_mor_transportf_postwhisker.
-                  }
-                  apply disp_mor_transportf_prewhisker.
-                }
-                apply disp_mor_transportf_prewhisker.
-              }
-              apply disp_mor_transportf_prewhisker.
-            }
-            apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-          }
-          apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-        }
-        etrans.
-        {
-          apply disp_mor_transportf_prewhisker.
-        }
-        apply maponpaths.
-        etrans.
-        {
-          apply maponpaths.
-          etrans.
-          {
-            apply maponpaths.
-            refine (disp_vassocr _ _ _ @ _).
-            etrans.
-            {
-              apply maponpaths.
-              refine (disp_vassocr _ _ _ @ _).
-              etrans.
-              {
-                apply maponpaths.
-                etrans.
-                {
-                  apply maponpaths_2.
-                  refine (disp_vassocr _ _ _ @ _).
-                  etrans.
-                  {
-                    apply maponpaths.
-                    etrans.
-                    {
-                      apply maponpaths_2.
-                      apply (disp_lassociator_lassociator).
-                    }
-                    apply disp_mor_transportf_postwhisker.
-                  }
-                  apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-                }
-                apply disp_mor_transportf_postwhisker.
-              }
-              apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-            }
-            apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-          }
-          apply disp_mor_transportf_prewhisker.
-        }
-        apply disp_mor_transportf_prewhisker.
-      }
-      etrans.
-      {
-        apply maponpaths.
-        apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-      }
-      apply disp_mor_transportf_prewhisker.
-    }
-    etrans.
-    {
-      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    refine (!_).
-    etrans.
-    {
-      apply maponpaths.
-      refine (disp_vassocl _ _ _ @ _).
-      etrans.
-      {
-        apply maponpaths.
-        etrans.
-        {
-          apply maponpaths.
-          refine (disp_vassocl _ _ _ @ _).
-          etrans.
-          {
-            apply maponpaths.
-            etrans.
-            {
-              apply maponpaths.
-              refine (disp_vassocr _ _ _ @ _).
-              etrans.
-              {
-                apply maponpaths.
-                etrans.
-                {
-                  apply maponpaths_2.
                   refine (disp_vassocr _ _ _ @ _).
                   etrans.
                   {
@@ -1464,14 +910,7 @@ Section LocalIsoFibration.
                         etrans.
                         {
                           apply maponpaths_2.
-                          exact (disp_vcomp_linv
-                                   (disp_local_iso_cleaving_invertible_2cell
-                                      h
-                                      (local_iso_cleaving_1cell
-                                         h (f₁;; f₂) (idempunitor c);;
-                                         local_iso_cleaving_1cell
-                                         h (f₃;; f₄) (idempunitor c))
-                                      (idempunitor c))).
+                          exact (disp_vcomp_linv ℓ2).
                         }
                         etrans.
                         {
@@ -1490,7 +929,7 @@ Section LocalIsoFibration.
                   }
                   apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
                 }
-                apply disp_mor_transportf_postwhisker.
+                apply disp_mor_transportf_prewhisker.
               }
               apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
             }
@@ -1501,138 +940,129 @@ Section LocalIsoFibration.
         apply disp_mor_transportf_prewhisker.
       }
       apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    etrans.
-    {
-      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    refine (!_).
-    etrans.
-    {
-      apply maponpaths.
+    Qed.
+
+    Local Definition step5
+      : ∑ p,
+           transportf
+             (λ z, _ ==>[ z] _)
+             (pr1 step4)
+             ((ℓ2 •• (f₁ ◃◃ (((ℓ2 •• (f₂ ◃◃ ℓ2)) •• disp_lassociator)
+                               •• ((ℓ2^-1 ▹▹ f₄) •• ℓ2^-1))))
+                •• (((f₁ ◃◃ ℓ2) •• disp_lassociator)
+                      •• ((ℓ2^-1 ▹▹ f₄)
+                            •• (((((ℓ2 •• (f₁ ◃◃ ℓ2)) •• disp_lassociator)
+                                    •• ((ℓ2^-1 ▹▹ f₃) •• ℓ2^-1)) ▹▹ f₄)
+                                  •• ℓ2^-1))))
+        =
+        transportf
+          (λ z, _ ==>[ z] _)
+          p
+          ((ℓ2 •• ((f₁ ◃◃ ℓ2)
+                     •• (f₁ ◃◃ ((f₂ ◃◃ ℓ2)
+                                  •• (disp_lassociator
+                                        •• ((ℓ2^-1 ▹▹ f₄)
+                                              •• ℓ2^-1))))))
+             •• (((f₁ ◃◃ ℓ2) •• disp_lassociator)
+                   •• ((ℓ2^-1 ▹▹ f₄)
+                         •• (((((ℓ2 •• (f₁ ◃◃ ℓ2))
+                                  •• disp_lassociator)
+                                 •• ((ℓ2^-1 ▹▹ f₃)
+                                       •• ℓ2^-1)) ▹▹ f₄)
+                               •• ℓ2^-1)))).
+    Proof.
+      eexists.
       etrans.
       {
         apply maponpaths.
         etrans.
         {
-          apply maponpaths.
-          refine (disp_vassocr _ _ _ @ _).
+          apply maponpaths_2.
           etrans.
           {
             apply maponpaths.
-            apply maponpaths_2.
-            refine (disp_vassocr _ _ _ @ _).
             etrans.
             {
               apply maponpaths.
-              etrans.
-              {
-                apply maponpaths_2.
-                refine (disp_vassocr _ _ _ @ _).
-                etrans.
-                {
-                  apply maponpaths.
-                  etrans.
-                  {
-                    apply maponpaths_2.
-                    apply disp_lwhisker_lwhisker.
-                  }
-                  apply disp_mor_transportf_postwhisker.
-                }
-                apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-              }
-              apply disp_mor_transportf_postwhisker.
+              apply disp_vassocl.
             }
-            apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-          }
-          etrans.
-          {
-            apply maponpaths.
-            apply disp_mor_transportf_postwhisker.
-          }
-          apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-        }
-        apply disp_mor_transportf_prewhisker.
-      }
-      apply disp_mor_transportf_prewhisker.
-    }
-    etrans.
-    {
-      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    etrans.
-    {
-      apply maponpaths.
-      etrans.
-      {
-        apply maponpaths.
-        etrans.
-        {
-          apply maponpaths.
-          etrans.
-          {
-            apply maponpaths_2.
-            refine (disp_vassocl _ _ _ @ _).
+            etrans.
+            {
+              apply disp_rwhisker_transport_right.
+            }
             etrans.
             {
               apply maponpaths.
               etrans.
               {
                 apply maponpaths.
-                etrans.
-                {
-                  apply maponpaths.
-                  apply disp_rwhisker_vcomp_alt.
-                }
-                etrans.
-                {
-                  apply disp_mor_transportf_prewhisker.
-                }
-                apply maponpaths.
-                refine (disp_vassocr _ _ _ @ _).
-                etrans.
-                {
-                  apply maponpaths.
-                  etrans.
-                  {
-                    apply maponpaths_2.
-                    apply disp_rwhisker_rwhisker.
-                  }
-                  apply disp_mor_transportf_postwhisker.
-                }
-                apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                apply disp_vassocl.
               }
               etrans.
               {
-                apply maponpaths.
-                apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                apply disp_rwhisker_transport_right.
               }
-              apply disp_mor_transportf_prewhisker.
+              apply maponpaths.
+              apply disp_lwhisker_vcomp_alt.
+            }
+            etrans.
+            {
+              apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
             }
             apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
           }
-          apply disp_mor_transportf_postwhisker.
+          apply disp_mor_transportf_prewhisker.
         }
-        apply disp_mor_transportf_prewhisker.
+        apply disp_mor_transportf_postwhisker.
       }
-      apply disp_mor_transportf_prewhisker.
-    }
-    etrans.
-    {
       apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    etrans.
-    {
-      apply maponpaths.
+    Qed.
+
+    Local Definition step6
+      : ∑ p,
+        transportf
+          (λ z, _ ==>[ z] _)
+          (pr1 step5)
+          ((ℓ2 •• ((f₁ ◃◃ ℓ2)
+                     •• (f₁ ◃◃ ((f₂ ◃◃ ℓ2)
+                                  •• (disp_lassociator
+                                        •• ((ℓ2^-1 ▹▹ f₄)
+                                              •• ℓ2^-1))))))
+             •• (((f₁ ◃◃ ℓ2) •• disp_lassociator)
+                   •• ((ℓ2^-1 ▹▹ f₄)
+                         •• (((((ℓ2 •• (f₁ ◃◃ ℓ2))
+                                  •• disp_lassociator)
+                                 •• ((ℓ2^-1 ▹▹ f₃)
+                                       •• ℓ2^-1)) ▹▹ f₄)
+                               •• ℓ2^-1))))
+        =
+        transportf
+          (λ z, _ ==>[ z] _)
+          p
+          (ℓ2 •• ((f₁ ◃◃ ℓ2)
+                    •• (((f₁ ◃◃ ((f₂ ◃◃ ℓ2)
+                                   •• (disp_lassociator
+                                         •• (ℓ2^-1 ▹▹ f₄))))
+                           •• disp_lassociator)
+                          •• ((ℓ2^-1 ▹▹ f₄)
+                                •• (((((ℓ2
+                                          •• (f₁ ◃◃ ℓ2))
+                                         •• disp_lassociator)
+                                        •• ((ℓ2^-1 ▹▹ f₃)
+                                              •• ℓ2^-1)) ▹▹ f₄)
+                                      •• ℓ2^-1))))).
+    Proof.
+      eexists.
       etrans.
       {
         apply maponpaths.
+        refine (disp_vassocl _ _ _ @ _).
         etrans.
         {
           apply maponpaths.
           etrans.
           {
-            apply maponpaths_2.
+            apply maponpaths.
             refine (disp_vassocl _ _ _ @ _).
             etrans.
             {
@@ -1654,9 +1084,70 @@ Section LocalIsoFibration.
                       etrans.
                       {
                         apply maponpaths_2.
-                        apply disp_vcomp_whisker_alt.
+                        apply disp_lwhisker_vcomp.
                       }
-                      apply disp_mor_transportf_postwhisker.
+                      etrans.
+                      {
+                        apply disp_mor_transportf_postwhisker.
+                      }
+                      etrans.
+                      {
+                        apply maponpaths.
+                        etrans.
+                        {
+                          apply maponpaths_2.
+                          etrans.
+                          {
+                            apply maponpaths.
+                            refine (disp_vassocl _ _ _ @ _).
+                            etrans.
+                            {
+                              apply maponpaths.
+                              etrans.
+                              {
+                                apply maponpaths.
+                                refine (disp_vassocl _ _ _ @ _).
+                                etrans.
+                                {
+                                  apply maponpaths.
+                                  etrans.
+                                  {
+                                    apply maponpaths.
+                                    refine (disp_vassocl _ _ _ @ _).
+                                    etrans.
+                                    {
+                                      apply maponpaths.
+                                      etrans.
+                                      {
+                                        apply maponpaths.
+                                        exact (disp_vcomp_linv ℓ2).
+                                      }
+                                      etrans.
+                                      {
+                                        apply disp_mor_transportf_prewhisker.
+                                      }
+                                      apply maponpaths.
+                                      apply disp_id2_right.
+                                    }
+                                    etrans.
+                                    {
+                                      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                                    }
+                                    apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                                  }
+                                  apply disp_mor_transportf_prewhisker.
+                                }
+                                apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                              }
+                              apply disp_mor_transportf_prewhisker.
+                            }
+                            apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                          }
+                          apply disp_rwhisker_transport_right.
+                        }
+                        apply disp_mor_transportf_postwhisker.
+                      }
+                      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
                     }
                     apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
                   }
@@ -1668,21 +1159,975 @@ Section LocalIsoFibration.
             }
             apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
           }
-          apply disp_mor_transportf_postwhisker.
+          apply disp_mor_transportf_prewhisker.
+        }
+        apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+      }
+      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+    Qed.
+
+    Local Definition step7
+      : ∑ p,
+        transportf
+          (λ z, _ ==>[ z] _)
+          (pr1 step6)
+          (ℓ2 •• ((f₁ ◃◃ ℓ2)
+                    •• (((f₁ ◃◃ ((f₂ ◃◃ ℓ2)
+                                   •• (disp_lassociator
+                                         •• (ℓ2^-1 ▹▹ f₄))))
+                           •• disp_lassociator)
+                          •• ((ℓ2^-1 ▹▹ f₄)
+                                •• (((((ℓ2
+                                          •• (f₁ ◃◃ ℓ2))
+                                         •• disp_lassociator)
+                                        •• ((ℓ2^-1 ▹▹ f₃)
+                                              •• ℓ2^-1)) ▹▹ f₄)
+                                      •• ℓ2^-1)))))
+        =
+        transportf
+          (λ z, _ ==>[ z] _)
+          p
+          (ℓ2 •• ((f₁ ◃◃ ℓ2)
+                    •• (((f₁ ◃◃ ((f₂ ◃◃ ℓ2)
+                                   •• disp_lassociator))
+                           •• (disp_lassociator
+                                 •• ((f₁ ◃◃ ℓ2^-1) ▹▹ f₄)))
+                          •• ((ℓ2^-1 ▹▹ f₄)
+                                •• (((((ℓ2 •• (f₁ ◃◃ ℓ2))
+                                         •• disp_lassociator)
+                                        •• ((ℓ2^-1 ▹▹ f₃)
+                                              •• ℓ2^-1)) ▹▹ f₄)
+                                      •• ℓ2^-1))))).
+    Proof.
+      eexists.
+      etrans.
+      {
+        apply maponpaths.
+        etrans.
+        {
+          apply maponpaths.
+          etrans.
+          {
+            apply maponpaths.
+            etrans.
+            {
+              apply maponpaths_2.
+              etrans.
+              {
+                apply maponpaths_2.
+                etrans.
+                {
+                  apply maponpaths.
+                  apply disp_vassocr.
+                }
+                etrans.
+                {
+                  apply disp_rwhisker_transport_right.
+                }
+                etrans.
+                {
+                  apply maponpaths.
+                  apply disp_lwhisker_vcomp_alt.
+                }
+                apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+              }
+              etrans.
+              {
+                apply disp_mor_transportf_postwhisker.
+              }
+              etrans.
+              {
+                apply maponpaths.
+                refine (disp_vassocl _ _ _ @ _).
+                etrans.
+                {
+                  apply maponpaths.
+                  etrans.
+                  {
+                    apply maponpaths.
+                    apply disp_rwhisker_lwhisker.
+                  }
+                  apply disp_mor_transportf_prewhisker.
+                }
+                apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+              }
+              apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+            }
+            apply disp_mor_transportf_postwhisker.
+          }
+          apply disp_mor_transportf_prewhisker.
         }
         apply disp_mor_transportf_prewhisker.
       }
-      apply disp_mor_transportf_prewhisker.
-    }
-    etrans.
-    {
       apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    refine (!_).
-    etrans.
-    {
-      apply maponpaths.
-      refine (disp_vassocl _ _ _ @ _).
+    Qed.
+
+    Local Definition step8
+      : ∑ p,
+        transportf
+          (λ z, _ ==>[ z] _)
+          (pr1 step7)
+          (ℓ2 •• ((f₁ ◃◃ ℓ2)
+                    •• (((f₁ ◃◃ ((f₂ ◃◃ ℓ2)
+                                   •• disp_lassociator))
+                           •• (disp_lassociator
+                                 •• ((f₁ ◃◃ ℓ2^-1) ▹▹ f₄)))
+                          •• ((ℓ2^-1 ▹▹ f₄)
+                                •• (((((ℓ2 •• (f₁ ◃◃ ℓ2))
+                                         •• disp_lassociator)
+                                        •• ((ℓ2^-1 ▹▹ f₃)
+                                              •• ℓ2^-1)) ▹▹ f₄)
+                                      •• ℓ2^-1)))))
+        =
+        transportf (λ z, _ ==>[ z] _)
+                   p
+                   (ℓ2
+                      •• ((f₁ ◃◃ ℓ2)
+                            •• (((f₁ ◃◃ ((f₂ ◃◃ ℓ2)
+                                           •• disp_lassociator))
+                                   •• (disp_lassociator
+                                         •• ((f₁ ◃◃ ℓ2 ^-1) ▹▹ f₄)))
+                                  •• ((((((f₁ ◃◃ ℓ2)
+                                            •• disp_lassociator)
+                                           •• (ℓ2 ^-1 ▹▹ f₃))
+                                          •• ℓ2 ^-1) ▹▹ f₄)
+                                        •• ℓ2 ^-1)))).
+    Proof.
+      eexists.
+      etrans.
+      {
+        apply maponpaths.
+        etrans.
+        {
+          apply maponpaths.
+          etrans.
+          {
+            apply maponpaths.
+            etrans.
+            {
+              apply maponpaths.
+              refine (disp_vassocr _ _ _ @ _).
+              etrans.
+              {
+                apply maponpaths.
+                etrans.
+                {
+                  apply maponpaths_2.
+                  etrans.
+                  {
+                    apply disp_rwhisker_vcomp.
+                  }
+                  apply maponpaths.
+                  etrans.
+                  {
+                    apply maponpaths.
+                    etrans.
+                    {
+                      apply disp_vassocr.
+                    }
+                    apply maponpaths.
+                    etrans.
+                    {
+                      apply disp_vassocr.
+                    }
+                    apply maponpaths.
+                    etrans.
+                    {
+                      apply maponpaths_2.
+                      etrans.
+                      {
+                        apply maponpaths_2.
+                        etrans.
+                        {
+                          apply disp_vassocr.
+                        }
+                        apply maponpaths.
+                        etrans.
+                        {
+                          apply maponpaths_2.
+                          etrans.
+                          {
+                            apply disp_vassocr.
+                          }
+                          apply maponpaths.
+                          etrans.
+                          {
+                            apply maponpaths_2.
+                            apply (disp_vcomp_linv ℓ2).
+                          }
+                          etrans.
+                          {
+                            apply disp_mor_transportf_postwhisker.
+                          }
+                          etrans.
+                          {
+                            apply maponpaths.
+                            apply disp_id2_left.
+                          }
+                          apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                        }
+                        etrans.
+                        {
+                          apply disp_mor_transportf_postwhisker.
+                        }
+                        etrans.
+                        {
+                          apply maponpaths.
+                          apply disp_mor_transportf_postwhisker.
+                        }
+                        apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                      }
+                      etrans.
+                      {
+                        apply disp_mor_transportf_postwhisker.
+                      }
+                      etrans.
+                      {
+                        apply maponpaths.
+                        apply disp_mor_transportf_postwhisker.
+                      }
+                      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                    }
+                    apply disp_mor_transportf_postwhisker.
+                  }
+                  etrans.
+                  {
+                    apply maponpaths.
+                    etrans.
+                    {
+                      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                    }
+                    apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                  }
+                  apply disp_rwhisker_transport_left_new.
+                }
+                etrans.
+                {
+                  apply disp_mor_transportf_postwhisker.
+                }
+                etrans.
+                {
+                  apply maponpaths.
+                  apply disp_mor_transportf_postwhisker.
+                }
+                apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+              }
+              apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+            }
+            apply disp_mor_transportf_prewhisker.
+          }
+          apply disp_mor_transportf_prewhisker.
+        }
+        apply disp_mor_transportf_prewhisker.
+      }
+      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+    Qed.
+
+    Local Definition step9
+      : ∑ p,
+        transportf
+          (λ z, _ ==>[ z] _)
+          (pr1 step8)
+          (ℓ2
+             •• ((f₁ ◃◃ ℓ2)
+                   •• (((f₁ ◃◃ ((f₂ ◃◃ ℓ2)
+                                  •• disp_lassociator))
+                          •• (disp_lassociator
+                                •• ((f₁ ◃◃ ℓ2 ^-1) ▹▹ f₄)))
+                         •• ((((((f₁ ◃◃ ℓ2)
+                                   •• disp_lassociator)
+                                  •• (ℓ2 ^-1 ▹▹ f₃))
+                                 •• ℓ2 ^-1) ▹▹ f₄)
+                               •• ℓ2 ^-1))))
+        =
+        transportf
+          (λ z, _ ==>[ z] _)
+          p
+          (ℓ2
+             •• ((f₁ ◃◃ ℓ2)
+                   •• ((f₁ ◃◃ ((f₂ ◃◃ ℓ2) •• disp_lassociator))
+                         •• (disp_lassociator
+                               •• ((((disp_lassociator
+                                        •• (ℓ2 ^-1 ▹▹ f₃))
+                                       •• ℓ2 ^-1) ▹▹ f₄)
+                                     •• ℓ2 ^-1))))).
+    Proof.
+      eexists.
+      etrans.
+      {
+        apply maponpaths.
+        etrans.
+        {
+          apply maponpaths.
+          etrans.
+          {
+            apply maponpaths.
+            etrans.
+            {
+              refine (disp_vassocl _ _ _ @ _).
+              apply maponpaths.
+              etrans.
+              {
+                apply maponpaths.
+                etrans.
+                {
+                  refine (disp_vassocl _ _ _ @ _).
+                  apply maponpaths.
+                  etrans.
+                  {
+                    apply maponpaths.
+                    etrans.
+                    {
+                      refine (disp_vassocr _ _ _ @ _).
+                      apply maponpaths.
+                      etrans.
+                      {
+                        apply maponpaths_2.
+                        etrans.
+                        {
+                          apply disp_rwhisker_vcomp.
+                        }
+                        apply maponpaths.
+                        etrans.
+                        {
+                          apply maponpaths.
+                          etrans.
+                          {
+                            refine (disp_vassocr _ _ _ @ _).
+                            apply maponpaths.
+                            etrans.
+                            {
+                              apply maponpaths_2.
+                              etrans.
+                              {
+                                refine (disp_vassocr _ _ _ @ _).
+                                apply maponpaths.
+                                etrans.
+                                {
+                                  apply maponpaths_2.
+                                  etrans.
+                                  {
+                                    refine (disp_vassocr _ _ _ @ _).
+                                    apply maponpaths.
+                                    etrans.
+                                    {
+                                      apply maponpaths_2.
+                                      etrans.
+                                      {
+                                        etrans.
+                                        {
+                                          apply disp_lwhisker_vcomp.
+                                        }
+                                        apply maponpaths.
+                                        etrans.
+                                        {
+                                          apply maponpaths.
+                                          apply (disp_vcomp_linv ℓ2).
+                                        }
+                                        etrans.
+                                        {
+                                          apply disp_rwhisker_transport_right.
+                                        }
+                                        apply maponpaths.
+                                        apply disp_lwhisker_id2.
+                                      }
+                                      apply (@transport_f_f
+                                               _
+                                               (λ z : _ ==> _, _ ==>[ z ] _)).
+                                    }
+                                    etrans.
+                                    {
+                                      apply disp_mor_transportf_postwhisker.
+                                    }
+                                    etrans.
+                                    {
+                                      apply maponpaths.
+                                      etrans.
+                                      {
+                                        apply disp_mor_transportf_postwhisker.
+                                      }
+                                      etrans.
+                                      {
+                                        apply maponpaths.
+                                        apply disp_id2_left.
+                                      }
+                                      apply (@transport_f_f
+                                               _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                                    }
+                                    apply (@transport_f_f
+                                             _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                                  }
+                                  apply (@transport_f_f
+                                           _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                                }
+                                apply disp_mor_transportf_postwhisker.
+                              }
+                              apply (@transport_f_f
+                                       _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                            }
+                            apply disp_mor_transportf_postwhisker.
+                          }
+                          apply (@transport_f_f
+                                   _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                        }
+                        apply disp_rwhisker_transport_left_new.
+                      }
+                      etrans.
+                      {
+                        apply disp_mor_transportf_postwhisker.
+                      }
+                      etrans.
+                      {
+                        apply maponpaths.
+                        apply disp_mor_transportf_postwhisker.
+                      }
+                      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                    }
+                    apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                  }
+                  apply disp_mor_transportf_prewhisker.
+                }
+                apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+              }
+              apply disp_mor_transportf_prewhisker.
+            }
+            apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+          }
+          apply disp_mor_transportf_prewhisker.
+        }
+        apply disp_mor_transportf_prewhisker.
+      }
+      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+    Qed.
+
+    Local Definition step10
+      : ∑ p,
+        transportf
+          (λ z, _ ==>[ z] _)
+          (pr1 step9)
+          (ℓ2
+             •• ((f₁ ◃◃ ℓ2)
+                   •• ((f₁ ◃◃ ((f₂ ◃◃ ℓ2) •• disp_lassociator))
+                         •• (disp_lassociator
+                               •• ((((disp_lassociator
+                                        •• (ℓ2 ^-1 ▹▹ f₃))
+                                       •• ℓ2 ^-1) ▹▹ f₄)
+                                     •• ℓ2 ^-1)))))
+        =
+        transportf
+          (λ z, _ ==>[ z] _)
+          p
+          (ℓ2
+             •• ((f₁ ◃◃ ℓ2)
+                   •• ((f₁ ◃◃ (f₂ ◃◃ ℓ2))
+                         •• (((disp_lassociator •• disp_lassociator)
+                                •• (((ℓ2 ^-1 ▹▹ f₃) •• ℓ2 ^-1) ▹▹ f₄))
+                               •• ℓ2 ^-1)))).
+    Proof.
+      eexists.
+      etrans.
+      {
+        apply maponpaths.
+        etrans.
+        {
+          apply maponpaths.
+          etrans.
+          {
+            apply maponpaths.
+            etrans.
+            {
+              apply maponpaths_2.
+              apply disp_lwhisker_vcomp_alt.
+            }
+            etrans.
+            {
+              apply disp_mor_transportf_postwhisker.
+            }
+            apply maponpaths.
+            etrans.
+            {
+              refine (disp_vassocl _ _ _ @ _).
+              apply maponpaths.
+              etrans.
+              {
+                apply maponpaths.
+                etrans.
+                {
+                  refine (disp_vassocr _ _ _ @ _).
+                  apply maponpaths.
+                  etrans.
+                  {
+                    refine (disp_vassocr _ _ _ @ _).
+                    apply maponpaths.
+                    etrans.
+                    {
+                      apply maponpaths_2.
+                      etrans.
+                      {
+                        etrans.
+                        {
+                          apply maponpaths.
+                          etrans.
+                          {
+                            apply maponpaths.
+                            apply disp_vassocl.
+                          }
+                          etrans.
+                          {
+                            apply disp_rwhisker_transport_left_new.
+                          }
+                          apply maponpaths.
+                          apply disp_rwhisker_vcomp_alt.
+                        }
+                        etrans.
+                        {
+                          apply disp_mor_transportf_prewhisker.
+                        }
+                        etrans.
+                        {
+                          apply maponpaths.
+                          apply disp_mor_transportf_prewhisker.
+                        }
+                        etrans.
+                        {
+                          apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                        }
+                        apply maponpaths.
+                        etrans.
+                        {
+                          refine (disp_vassocr _ _ _ @ _).
+                          apply maponpaths.
+                          etrans.
+                          {
+                            apply maponpaths_2.
+                            apply disp_lassociator_lassociator.
+                          }
+                          apply disp_mor_transportf_postwhisker.
+                        }
+                        apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                      }
+                      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                    }
+                    apply disp_mor_transportf_postwhisker.
+                  }
+                  apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                }
+                apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+              }
+              apply disp_mor_transportf_prewhisker.
+            }
+            apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+          }
+          apply disp_mor_transportf_prewhisker.
+        }
+        apply disp_mor_transportf_prewhisker.
+      }
+      etrans.
+      {
+        apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+      }
+      etrans.
+      {
+        apply maponpaths.
+        etrans.
+        {
+          apply maponpaths.
+          apply disp_mor_transportf_prewhisker.
+        }
+        apply disp_mor_transportf_prewhisker.
+      }
+      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+    Qed.
+
+    Local Definition step11
+      : ∑ p,
+        transportf
+          (λ z, _ ==>[ z] _)
+          (pr1 step10)
+          (ℓ2
+             •• ((f₁ ◃◃ ℓ2)
+                   •• ((f₁ ◃◃ (f₂ ◃◃ ℓ2))
+                         •• (((disp_lassociator •• disp_lassociator)
+                                •• (((ℓ2 ^-1 ▹▹ f₃) •• ℓ2 ^-1) ▹▹ f₄))
+                               •• ℓ2 ^-1))))
+        =
+        transportf
+          (λ z, _ ==>[ z] _)
+          p
+          (ℓ2
+             •• ((f₁ ◃◃ ℓ2)
+                   •• ((((disp_lassociator •• (f₁;; f₂ ◃◃ ℓ2)) •• disp_lassociator)
+                          •• (((ℓ2 ^-1 ▹▹ f₃) •• ℓ2 ^-1) ▹▹ f₄)) •• ℓ2 ^-1))).
+    Proof.
+      eexists.
+      etrans.
+      {
+        apply maponpaths.
+        etrans.
+        {
+          apply maponpaths.
+          etrans.
+          {
+            apply maponpaths.
+            etrans.
+            {
+              refine (disp_vassocr _ _ _ @ _).
+              apply maponpaths.
+              etrans.
+              {
+                apply maponpaths_2.
+                etrans.
+                {
+                  refine (disp_vassocr _ _ _ @ _).
+                  apply maponpaths.
+                  etrans.
+                  {
+                    apply maponpaths_2.
+                    etrans.
+                    {
+                      apply disp_vassocr.
+                    }
+                    apply maponpaths.
+                    etrans.
+                    {
+                      apply maponpaths_2.
+                      apply disp_lwhisker_lwhisker.
+                    }
+                    apply disp_mor_transportf_postwhisker.
+                  }
+                  etrans.
+                  {
+                    etrans.
+                    {
+                      apply disp_mor_transportf_postwhisker.
+                    }
+                    apply maponpaths.
+                    apply disp_mor_transportf_postwhisker.
+                  }
+                  apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                }
+                apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+              }
+              apply disp_mor_transportf_postwhisker.
+            }
+            apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+          }
+          apply disp_mor_transportf_prewhisker.
+        }
+        apply disp_mor_transportf_prewhisker.
+      }
+      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+    Qed.
+
+    Local Definition step12
+      : ∑ p,
+        transportf
+          (λ z, _ ==>[ z] _)
+          (pr1 step11)
+          (ℓ2
+             •• ((f₁ ◃◃ ℓ2)
+                   •• ((((disp_lassociator •• (f₁;; f₂ ◃◃ ℓ2)) •• disp_lassociator)
+                          •• (((ℓ2 ^-1 ▹▹ f₃) •• ℓ2 ^-1) ▹▹ f₄)) •• ℓ2 ^-1)))
+        =
+        transportf
+          (λ z, _ ==>[ z] _)
+          p
+          (ℓ2
+             •• ((f₁ ◃◃ ℓ2)
+                   •• (((disp_lassociator •• (f₁;; f₂ ◃◃ ℓ2))
+                          •• (((ℓ2 ^-1 ▹▹ f₃;; f₄)
+                                 •• disp_lassociator)
+                                •• (ℓ2 ^-1 ▹▹ f₄)))
+                         •• ℓ2 ^-1))).
+    Proof.
+      eexists.
+      etrans.
+      {
+        apply maponpaths.
+        etrans.
+        {
+          apply maponpaths.
+          etrans.
+          {
+            apply maponpaths.
+            etrans.
+            {
+              apply maponpaths_2.
+              etrans.
+              {
+                refine (disp_vassocl _ _ _ @ _).
+                apply maponpaths.
+                etrans.
+                {
+                  apply maponpaths.
+                  etrans.
+                  {
+                    apply maponpaths.
+                    apply disp_rwhisker_vcomp_alt.
+                  }
+                  etrans.
+                  {
+                    apply disp_mor_transportf_prewhisker.
+                  }
+                  etrans.
+                  {
+                    apply maponpaths.
+                    etrans.
+                    {
+                      refine (disp_vassocr _ _ _ @ _).
+                      apply maponpaths.
+                      etrans.
+                      {
+                        apply maponpaths_2.
+                        apply disp_rwhisker_rwhisker.
+                      }
+                      apply disp_mor_transportf_postwhisker.
+                    }
+                    apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                  }
+                  apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                }
+                apply disp_mor_transportf_prewhisker.
+              }
+              apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+            }
+            apply disp_mor_transportf_postwhisker.
+          }
+          apply disp_mor_transportf_prewhisker.
+        }
+        apply disp_mor_transportf_prewhisker.
+      }
+      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+    Qed.
+
+    Local Definition step13
+      : ∑ p,
+        transportf
+          (λ z, _ ==>[ z] _)
+          (pr1 step12)
+          (ℓ2
+             •• ((f₁ ◃◃ ℓ2)
+                   •• (((disp_lassociator •• (f₁;; f₂ ◃◃ ℓ2))
+                          •• (((ℓ2 ^-1 ▹▹ f₃;; f₄)
+                                 •• disp_lassociator)
+                                •• (ℓ2 ^-1 ▹▹ f₄)))
+                         •• ℓ2 ^-1)))
+        =
+        transportf
+          (λ z, _ ==>[ z] _)
+          p
+          (ℓ2
+             •• ((f₁ ◃◃ ℓ2)
+                   •• (((disp_lassociator •• (((ℓ2 ^-1 ▹▹ ℓ1) •• (ℓ1 ◃◃ ℓ2))
+                                                •• disp_lassociator))
+                          •• (ℓ2 ^-1 ▹▹ f₄))
+                         •• ℓ2 ^-1))).
+    Proof.
+      eexists.
+      etrans.
+      {
+        apply maponpaths.
+        etrans.
+        {
+          apply maponpaths.
+          etrans.
+          {
+            apply maponpaths.
+            etrans.
+            {
+              apply maponpaths_2.
+              etrans.
+              {
+                refine (disp_vassocr _ _ _ @ _).
+                apply maponpaths.
+                etrans.
+                {
+                  apply maponpaths_2.
+                  etrans.
+                  {
+                    refine (disp_vassocl _ _ _ @ _).
+                    apply maponpaths.
+                    etrans.
+                    {
+                      apply maponpaths.
+                      etrans.
+                      {
+                        refine (disp_vassocr _ _ _ @ _).
+                        apply maponpaths.
+                        etrans.
+                        {
+                          apply maponpaths_2.
+                          apply disp_vcomp_whisker_alt.
+                        }
+                        apply disp_mor_transportf_postwhisker.
+                      }
+                      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                    }
+                    apply disp_mor_transportf_prewhisker.
+                  }
+                  apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                }
+                apply disp_mor_transportf_postwhisker.
+              }
+              apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+            }
+            apply disp_mor_transportf_postwhisker.
+          }
+          apply disp_mor_transportf_prewhisker.
+        }
+        apply disp_mor_transportf_prewhisker.
+      }
+      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+    Qed.
+
+    Local Arguments transportf {_} _ {_} {_} {_} _.
+
+    Definition discrete_fiber_data_laws_lassociator_lassociator
+    : ((f₁ ◃ lassociator f₂ f₃ f₄)
+         • lassociator f₁ (f₂ · f₃) f₄)
+        • (lassociator f₁ f₂ f₃ ▹ f₄)
+      =
+      lassociator f₁ f₂ (f₃ · f₄) • lassociator (f₁ · f₂) f₃ f₄.
+    Proof.
+      refine (pr2 step1 @ _).
+      refine (_ @ pr2 step2).
+      refine (pr2 step3 @ _).
+      refine (pr2 step4 @ _).
+      refine (pr2 step5 @ _).
+      refine (pr2 step6 @ _).
+      refine (pr2 step7 @ _).
+      refine (pr2 step8 @ _).
+      refine (pr2 step9 @ _).
+      refine (pr2 step10 @ _).
+      refine (pr2 step11 @ _).
+      refine (pr2 step12 @ _).
+      refine (pr2 step13 @ _).
+      etrans.
+      {
+        apply maponpaths.
+        etrans.
+        {
+          apply maponpaths.
+          etrans.
+          {
+            apply maponpaths.
+            etrans.
+            {
+              refine (disp_vassocl _ _ _ @ _).
+              apply maponpaths.
+              etrans.
+              {
+                refine (disp_vassocl _ _ _ @ _).
+                apply maponpaths.
+                etrans.
+                {
+                  apply maponpaths.
+                  etrans.
+                  {
+                    apply maponpaths_2.
+                    apply disp_vassocl.
+                  }
+                  apply disp_mor_transportf_postwhisker.
+                }
+                apply disp_mor_transportf_prewhisker.
+              }
+              apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+            }
+            apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+          }
+          apply disp_mor_transportf_prewhisker.
+        }
+        apply disp_mor_transportf_prewhisker.
+      }
+      etrans.
+      {
+        apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+      }
+      refine (!_).
+      etrans.
+      {
+        apply maponpaths.
+        etrans.
+        {
+          refine (disp_vassocl _ _ _ @ _).
+          apply maponpaths.
+          etrans.
+          {
+            refine (disp_vassocl _ _ _ @ _).
+            apply maponpaths.
+            etrans.
+            {
+              apply maponpaths.
+              etrans.
+              {
+                apply maponpaths.
+                etrans.
+                {
+                  refine (disp_vassocl _ _ _ @ _).
+                  apply maponpaths.
+                  etrans.
+                  {
+                    apply maponpaths.
+                    etrans.
+                    {
+                      refine (disp_vassocr _ _ _ @ _).
+                      apply maponpaths.
+                      etrans.
+                      {
+                        apply maponpaths_2.
+                        etrans.
+                        {
+                          refine (disp_vassocr _ _ _ @ _).
+                          apply maponpaths.
+                          etrans.
+                          {
+                            apply maponpaths_2.
+                            etrans.
+                            {
+                              refine (disp_vassocr _ _ _ @ _).
+                              apply maponpaths.
+                              etrans.
+                              {
+                                apply maponpaths_2.
+                                apply (disp_vcomp_linv ℓ2).
+                              }
+                              etrans.
+                              {
+                                apply disp_mor_transportf_postwhisker.
+                              }
+                              etrans.
+                              {
+                                apply maponpaths.
+                                apply disp_id2_left.
+                              }
+                              apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                            }
+                            apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                          }
+                          apply disp_mor_transportf_postwhisker.
+                        }
+                        apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                      }
+                      apply disp_mor_transportf_postwhisker.
+                    }
+                    apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+                  }
+                  apply disp_mor_transportf_prewhisker.
+                }
+                apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+              }
+              apply disp_mor_transportf_prewhisker.
+            }
+            apply disp_mor_transportf_prewhisker.
+          }
+          apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+        }
+        apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+      }
+      etrans.
+      {
+        apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
+      }
       etrans.
       {
         apply maponpaths.
@@ -1699,12 +2144,7 @@ Section LocalIsoFibration.
               etrans.
               {
                 apply maponpaths.
-                etrans.
-                {
-                  apply maponpaths.
-                  apply disp_vassocl.
-                }
-                apply disp_mor_transportf_prewhisker.
+                apply disp_vassocr.
               }
               apply disp_mor_transportf_prewhisker.
             }
@@ -1714,55 +2154,10 @@ Section LocalIsoFibration.
         }
         apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
       }
-      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    etrans.
-    {
-      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
-    refine (!_).
-    etrans.
-    {
-      apply maponpaths.
       etrans.
       {
-        apply maponpaths.
-        etrans.
-        {
-          apply maponpaths.
-          refine (disp_vassocl _ _ _ @ _).
-          etrans.
-          {
-            apply maponpaths.
-            etrans.
-            {
-              apply maponpaths.
-              refine (disp_vassocl _ _ _ @ _).
-              etrans.
-              {
-                apply maponpaths.
-                refine (disp_vassocl _ _ _ @ _).
-                etrans.
-                {
-                  apply maponpaths.
-                  apply disp_vassocl.
-                }
-                apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-              }
-              apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-            }
-            apply disp_mor_transportf_prewhisker.
-          }
-          apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-        }
-        apply disp_mor_transportf_prewhisker.
+        apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
       }
-      apply disp_mor_transportf_prewhisker.
-    }
-    etrans.
-    {
-      apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
-    }
     apply (@transportf_paths _ (λ α : id₁ c ==> id₁ c, _ ==>[ α] _)).
     apply cellset_property.
   Qed.

--- a/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Fibration/Fibration2.v
+++ b/UniMath/CategoryTheory/Bicategories/DisplayedBicats/Fibration/Fibration2.v
@@ -29,9 +29,9 @@ Section LocalIsoFibration.
   Local Arguments disp_lassociator {_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _}.
   Local Arguments disp_rassociator {_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _}.
   Local Notation "'ℓ1'" := (local_iso_cleaving_1cell h _ (idempunitor c))
-                               (at level 0).
+                             (at level 0).
   Local Notation "'ℓ2'" := (disp_local_iso_cleaving_invertible_2cell h _ (idempunitor c))
-                               (at level 0).
+                             (at level 0).
   Local Notation "f ^-1" := (disp_inv_cell f).
 
   Definition discrete_fiber_data_laws_rassociator_lassociator
@@ -863,17 +863,17 @@ Section LocalIsoFibration.
                    •• ((ℓ2 •• ((((ℓ2 •• (f₁ ◃◃ ℓ2)) •• disp_lassociator)
                                   •• ((ℓ2^-1 ▹▹ f₃) •• ℓ2^-1)) ▹▹ f₄))
                          •• ℓ2^-1)))
-           =
-           transportf
-             (λ z, _ ==>[ z] _)
-             p
-             ((ℓ2 •• (f₁ ◃◃ (((ℓ2 •• (f₂ ◃◃ ℓ2)) •• disp_lassociator)
-                               •• ((ℓ2^-1 ▹▹ f₄) •• ℓ2^-1))))
-                •• (((f₁ ◃◃ ℓ2) •• disp_lassociator)
-                      •• ((ℓ2^-1 ▹▹ f₄)
-                            •• (((((ℓ2 •• (f₁ ◃◃ ℓ2)) •• disp_lassociator)
-                                    •• ((ℓ2^-1 ▹▹ f₃) •• ℓ2^-1)) ▹▹ f₄)
-                                  •• ℓ2^-1)))).
+        =
+        transportf
+          (λ z, _ ==>[ z] _)
+          p
+          ((ℓ2 •• (f₁ ◃◃ (((ℓ2 •• (f₂ ◃◃ ℓ2)) •• disp_lassociator)
+                            •• ((ℓ2^-1 ▹▹ f₄) •• ℓ2^-1))))
+             •• (((f₁ ◃◃ ℓ2) •• disp_lassociator)
+                   •• ((ℓ2^-1 ▹▹ f₄)
+                         •• (((((ℓ2 •• (f₁ ◃◃ ℓ2)) •• disp_lassociator)
+                                 •• ((ℓ2^-1 ▹▹ f₃) •• ℓ2^-1)) ▹▹ f₄)
+                               •• ℓ2^-1)))).
     Proof.
       eexists.
       etrans.
@@ -944,16 +944,16 @@ Section LocalIsoFibration.
 
     Local Definition step5
       : ∑ p,
-           transportf
-             (λ z, _ ==>[ z] _)
-             (pr1 step4)
-             ((ℓ2 •• (f₁ ◃◃ (((ℓ2 •• (f₂ ◃◃ ℓ2)) •• disp_lassociator)
-                               •• ((ℓ2^-1 ▹▹ f₄) •• ℓ2^-1))))
-                •• (((f₁ ◃◃ ℓ2) •• disp_lassociator)
-                      •• ((ℓ2^-1 ▹▹ f₄)
-                            •• (((((ℓ2 •• (f₁ ◃◃ ℓ2)) •• disp_lassociator)
-                                    •• ((ℓ2^-1 ▹▹ f₃) •• ℓ2^-1)) ▹▹ f₄)
-                                  •• ℓ2^-1))))
+        transportf
+          (λ z, _ ==>[ z] _)
+          (pr1 step4)
+          ((ℓ2 •• (f₁ ◃◃ (((ℓ2 •• (f₂ ◃◃ ℓ2)) •• disp_lassociator)
+                            •• ((ℓ2^-1 ▹▹ f₄) •• ℓ2^-1))))
+             •• (((f₁ ◃◃ ℓ2) •• disp_lassociator)
+                   •• ((ℓ2^-1 ▹▹ f₄)
+                         •• (((((ℓ2 •• (f₁ ◃◃ ℓ2)) •• disp_lassociator)
+                                 •• ((ℓ2^-1 ▹▹ f₃) •• ℓ2^-1)) ▹▹ f₄)
+                               •• ℓ2^-1))))
         =
         transportf
           (λ z, _ ==>[ z] _)
@@ -1983,11 +1983,11 @@ Section LocalIsoFibration.
     Local Arguments transportf {_} _ {_} {_} {_} _.
 
     Definition discrete_fiber_data_laws_lassociator_lassociator
-    : ((f₁ ◃ lassociator f₂ f₃ f₄)
-         • lassociator f₁ (f₂ · f₃) f₄)
-        • (lassociator f₁ f₂ f₃ ▹ f₄)
-      =
-      lassociator f₁ f₂ (f₃ · f₄) • lassociator (f₁ · f₂) f₃ f₄.
+      : ((f₁ ◃ lassociator f₂ f₃ f₄)
+           • lassociator f₁ (f₂ · f₃) f₄)
+          • (lassociator f₁ f₂ f₃ ▹ f₄)
+        =
+        lassociator f₁ f₂ (f₃ · f₄) • lassociator (f₁ · f₂) f₃ f₄.
     Proof.
       refine (pr2 step1 @ _).
       refine (_ @ pr2 step2).
@@ -2158,9 +2158,10 @@ Section LocalIsoFibration.
       {
         apply (@transport_f_f _ (λ z : _ ==> _, _ ==>[ z ] _)).
       }
-    apply (@transportf_paths _ (λ α : id₁ c ==> id₁ c, _ ==>[ α] _)).
-    apply cellset_property.
-  Qed.
+      apply (@transportf_paths _ (λ α : id₁ c ==> id₁ c, _ ==>[ α] _)).
+      apply cellset_property.
+    Qed.
+  End LassociatorLassociator.
 
   Definition discrete_fiber_data_laws : prebicat_laws (discrete_fiber_data D h c).
   Proof.


### PR DESCRIPTION
I think this version of Fibration2.v consumes less memory. I split the proof of `discrete_fiber_data_laws_lassociator_lassociator` in several smaller parts so that the ultimate proof term becomes smaller.