### PR TITLE
Prove interval in cartesian cubical sets has decidable equality

### DIFF
--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -57,11 +57,12 @@ Require Import UniMath.CategoryTheory.limits.pullbacks.
 Local Open Scope cat.
 
 Notation "'PreShv' C" := [C^op,SET] (at level 4) : cat.
+Notation "F '⟨' x '⟩'" := (pr1 (functor_on_objects (pr1 F) x)) (at level 4) : cat.
 
 Section basics.
 
 Lemma transportf_PreShv {C : precategory} (F : PreShv C) {x y z : C}
-  (e : x = y) (f : C⟦x,z⟧) (u : pr1 (pr1 F z)) :
+  (e : x = y) (f : C⟦x,z⟧) (u : F ⟨ z ⟩) :
   transportf (λ x, pr1 (pr1 F x)) e (# (pr1 F) f u) =
   # (pr1 F) (transportf (@precategory_morphisms C^op z) e f) u.
 Proof.

--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -57,12 +57,11 @@ Require Import UniMath.CategoryTheory.limits.pullbacks.
 Local Open Scope cat.
 
 Notation "'PreShv' C" := [C^op,SET] (at level 4) : cat.
-Notation "F '⟨' x '⟩'" := (pr1 (functor_on_objects (pr1 F) x)) (at level 4) : cat.
 
 Section basics.
 
 Lemma transportf_PreShv {C : precategory} (F : PreShv C) {x y z : C}
-  (e : x = y) (f : C⟦x,z⟧) (u : F ⟨ z ⟩) :
+  (e : x = y) (f : C⟦x,z⟧) (u : ((F : functor _ _) z : hSet)) :
   transportf (λ x, pr1 (pr1 F x)) e (# (pr1 F) f u) =
   # (pr1 F) (transportf (@precategory_morphisms C^op z) e f) u.
 Proof.

--- a/UniMath/CategoryTheory/categories/CartesianCubicalSets.v
+++ b/UniMath/CategoryTheory/categories/CartesianCubicalSets.v
@@ -138,7 +138,7 @@ Local Definition I : cartesian_cubical_sets :=
 
 (** The interval in cartesian cubical sets has two distinct elements *)
 Lemma interval_cartesian_cubical_sets_two_elements :
-  ∏ n : cartesian_cube_category, ∑ f g : I ⟨ n ⟩, f != g.
+  ∏ n : cartesian_cube_category, ∑ f g : ((I : functor _ _) n : hSet), f != g.
 Proof.
   intro n.
   exists (λ _ : stn 1, @inr (stn n) (stn 2) (make_stn 2 0 (idpath _))).
@@ -153,7 +153,7 @@ Defined.
 
 (** The interval in cartesian cubical sets has decidable equality *)
 Lemma interval_cartesian_cubical_sets_dec_eq :
-  ∏ (n : cartesian_cube_category), isdeceq I ⟨ n ⟩.
+  ∏ (n : cartesian_cube_category), isdeceq ((I : functor _ _) n : hSet).
 Proof.
   intro n.
   use isdeceqweqb.

--- a/UniMath/CategoryTheory/categories/CartesianCubicalSets.v
+++ b/UniMath/CategoryTheory/categories/CartesianCubicalSets.v
@@ -1,6 +1,11 @@
 (** ****************************************************************************
 
-Theory about the cartesian cube category and cartesian cubical sets.
+We define the cartesian cubical sets and show that the interval satisfies
+axioms B1, B2 and B3 in:
+
+A Survey of Constructive Presheaf Models of Univalence (2018),
+Thierry Coquand
+https://dl.acm.org/doi/abs/10.1145/3242953.3242962
 
 Contents:
 
@@ -8,11 +13,11 @@ Contents:
 - Binary products in the cartesian cube category ([cartesian_cube_category_binproducts])
 - The empty set is a terminal object in the cartesian cube category
   ([empty_is_terminal_cartesian_cube_category])
-- The interval in cartesian cubical sets has two distinct elements
+- The interval in cartesian cubical sets has two distinct elements (axiom B1)
   ([interval_cartesian_cubical_sets_two_elements])
-- The interval in cartesian cubical sets has decidable equality
+- The interval in cartesian cubical sets has decidable equality (axiom B2)
   ([interval_cartesian_cubical_sets_dec_eq])
-- The interval in cartesian cubical sets is tiny
+- The interval in cartesian cubical sets is tiny (axiom B3)
   ([interval_cartesian_cubical_sets_is_tiny])
 
 
@@ -133,7 +138,7 @@ Local Definition I : cartesian_cubical_sets :=
 
 (** The interval in cartesian cubical sets has two distinct elements *)
 Lemma interval_cartesian_cubical_sets_two_elements :
-  ∏ n : cartesian_cube_category, ∑ f g : pr1 (pr1 I n), f != g.
+  ∏ n : cartesian_cube_category, ∑ f g : I ⟨ n ⟩, f != g.
 Proof.
   intro n.
   exists (λ _ : stn 1, @inr (stn n) (stn 2) (make_stn 2 0 (idpath _))).
@@ -148,7 +153,7 @@ Defined.
 
 (** The interval in cartesian cubical sets has decidable equality *)
 Lemma interval_cartesian_cubical_sets_dec_eq :
-  ∏ (n : cartesian_cube_category), isdeceq (pr1 (pr1 I n)).
+  ∏ (n : cartesian_cube_category), isdeceq I ⟨ n ⟩.
 Proof.
   intro n.
   use isdeceqweqb.

--- a/UniMath/CategoryTheory/categories/CartesianCubicalSets.v
+++ b/UniMath/CategoryTheory/categories/CartesianCubicalSets.v
@@ -8,10 +8,12 @@ Contents:
 - Binary products in the cartesian cube category ([cartesian_cube_category_binproducts])
 - The empty set is a terminal object in the cartesian cube category
   ([empty_is_terminal_cartesian_cube_category])
-- The unit interval in cartesian cubical sets has two distinct elements
-  ([unit_interval_cartesian_cubical_sets_two_elements])
-- The unit interval in cartesian cubical sets is tiny
-  ([unit_interval_cartesian_cubical_sets_is_tiny])
+- The interval in cartesian cubical sets has two distinct elements
+  ([interval_cartesian_cubical_sets_two_elements])
+- The interval in cartesian cubical sets has decidable equality
+  ([interval_cartesian_cubical_sets_dec_eq])
+- The interval in cartesian cubical sets is tiny
+  ([interval_cartesian_cubical_sets_is_tiny])
 
 
 Written by: Elisabeth Bonnevier, 2019
@@ -129,8 +131,8 @@ Definition cartesian_cubical_sets : category :=
 Local Definition I : cartesian_cubical_sets :=
   yoneda cartesian_cube_category (homset_property cartesian_cube_category) 1.
 
-(** The unit interval in cartesian cubical sets has two distinct elements *)
-Lemma unit_interval_cartesian_cubical_sets_two_elements :
+(** The interval in cartesian cubical sets has two distinct elements *)
+Lemma interval_cartesian_cubical_sets_two_elements :
   ∏ n : cartesian_cube_category, ∑ f g : pr1 (pr1 I n), f != g.
 Proof.
   intro n.
@@ -144,6 +146,20 @@ Proof.
   apply (negpaths0sx 0 e).
 Defined.
 
+(** The interval in cartesian cubical sets has decidable equality *)
+Lemma interval_cartesian_cubical_sets_dec_eq :
+  ∏ (n : cartesian_cube_category), isdeceq (pr1 (pr1 I n)).
+Proof.
+  intro n.
+  use isdeceqweqb.
+  - exact (stn ((n+2) * 1)).
+  - use weqcomp.
+    + exact ((stn 1) → (stn (n+2))).
+    + apply weqffun, weqfromcoprodofstn.
+    + apply weqfromfunstntostn.
+  - apply isdeceqstn.
+Defined.
+
 Definition cartesian_cubical_sets_exponentials : Exponentials (@BinProducts_PreShv cartesian_cube_category).
 Proof.
   apply Exponentials_functor_HSET.
@@ -154,8 +170,8 @@ Defined.
 Local Definition exp_I : cartesian_cubical_sets ⟶ cartesian_cubical_sets :=
   pr1 (cartesian_cubical_sets_exponentials I).
 
-(** The unit interval in cartesian cubical sets is tiny *)
-Theorem unit_interval_cartesian_cubical_sets_is_tiny : is_left_adjoint exp_I.
+(** The interval in cartesian cubical sets is tiny *)
+Theorem interval_cartesian_cubical_sets_is_tiny : is_left_adjoint exp_I.
 Proof.
   use is_left_adjoint_exp_yoneda.
   apply cartesian_cube_category_binproducts.


### PR DESCRIPTION
Proof that the interval in cartesian cubical sets has decidable equality for every object in the cartesian cube category.