### PR TITLE
Remove obsolete [camlp4] from list of installation dependencies 

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ A more flexible, but complex, installation method is given in [INSTALL\_OPAM.md]
 1. Install "Homebrew", available from http://brew.sh/.
 2. Using Homebrew, install ocaml with the following command:
 ```bash
-$ brew install objective-caml ocaml-num camlp4 camlp5 bash ocaml-findlib
+$ brew install objective-caml ocaml-num camlp5 bash ocaml-findlib
 ```
 3. Install Emacs from https://emacsformacosx.com/.
   
@@ -32,7 +32,7 @@ Under Ubuntu or Debian, you may install ocaml with the
 following shell command.
 
 ```bash
- sudo apt-get install build-essential git ocaml ocaml-nox ocaml-native-compilers camlp4-extra camlp5 libgtk2.0 libgtksourceview2.0 liblablgtk-extras-ocaml-dev ocaml-findlib emacs
+ sudo apt-get install build-essential git ocaml ocaml-nox ocaml-native-compilers camlp5 libgtk2.0 libgtksourceview2.0 liblablgtk-extras-ocaml-dev ocaml-findlib emacs
 ```
 Now proceed with [Installation of ProofGeneral](#installation-of-proofgeneral-all-operating-systems) and [Installing UniMath](#installing-unimath) below.
 

--- a/INSTALL_NIX.md
+++ b/INSTALL_NIX.md
@@ -33,7 +33,7 @@ and it is not very well tested at the moment.
    [more detailed instructions](https://nixos.org/nix/download.html).)
 2. Start a "nix-shell" with the following command:
    ```bash
-   $ nix-shell -p ocaml ocamlPackages.findlib ocamlPackages.camlp4 ocamlPackages.camlp5 ocamlPackages.num gnumake git
+   $ nix-shell -p ocaml ocamlPackages.findlib ocamlPackages.camlp5 ocamlPackages.num gnumake git
    ```
    (This may require some time to download and deploy the ocaml
    environment into the Nix storage.)


### PR DESCRIPTION
If I understand right, `camlp4` has not been required by Coq since v8.7 (see https://github.com/coq/coq/pull/461), so is no longer needed as a `UniMath` installation dependency.

Moreover, `camlp4` is now somewhat deprecated, and is no longer available from Homebrew, so its presence makes the Mac OS build instructions broken.

I’ve confirmed with a build just now that `camlp4` is not required at least on Mac OS X.  I haven’t tested on other systems — in particular, I haven’t tested the Nix install instructions — but I can’t see any way that it could still be required.