### PR TITLE
Need to require module Ltac rather than Notations to import tactics with -nois

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ distclean::          ; - $(MAKE) -C sub/lablgtk arch-clean
 # building coq:
 export PATH:=$(shell pwd)/sub/coq/bin:$(PATH)
 CONFIGURE_OPTIONS := -coqide "$(COQIDE_OPTION)" -with-doc no -local -no-custom
-BUILD_TARGETS := coqbinaries tools states
+BUILD_TARGETS := coqbinaries tools states ltac
 ifeq ($(DEBUG_COQ),yes)
 CONFIGURE_OPTIONS += -annot
 BUILD_TARGETS += byte

--- a/UniMath/Foundations/Init.v
+++ b/UniMath/Foundations/Init.v
@@ -7,7 +7,7 @@ Require Export Coq.Init.Logic.
 Require Export Coq.Init.Notations.
 (* get the standard Coq reserved notations *)
 
-Require Export Coq.Init.Ltac.
+From Coq Require Ltac.
 (* get the tactics *)
 
 (** Notations *)

--- a/UniMath/Foundations/Init.v
+++ b/UniMath/Foundations/Init.v
@@ -7,7 +7,7 @@ Require Export Coq.Init.Logic.
 Require Export Coq.Init.Notations.
 (* get the standard Coq reserved notations *)
 
-From Coq Require Ltac.
+From Coq Require Export Ltac.
 (* get the tactics *)
 
 (** Notations *)

--- a/UniMath/Foundations/Init.v
+++ b/UniMath/Foundations/Init.v
@@ -7,6 +7,9 @@ Require Export Coq.Init.Logic.
 Require Export Coq.Init.Notations.
 (* get the standard Coq reserved notations *)
 
+Require Export Coq.Init.Ltac.
+(* get the tactics *)
+
 (** Notations *)
 
 Notation "'∏'  x .. y , P" := (forall x, .. (forall y, P) ..)


### PR DESCRIPTION
Hi, there is a change in how tactics are imported with option `-nois`. They are now imported by requiring module `Coq.Init.Ltac` rather than `Coq.Init.Notations`.

This PR adapts UniMath to this change, as noticed on Coq CI. It should be merged synchronously with the Coq PR.