### PR TITLE
Opaque PathOver (needed for coq/coq#13037)

### DIFF
--- a/UniMath/SyntheticHomotopyTheory/Circle2.v
+++ b/UniMath/SyntheticHomotopyTheory/Circle2.v
@@ -209,6 +209,7 @@ Proof.
   apply (maponpaths (λ f, pr1weq f v)). apply cp_irrelevance. apply torsor_hlevel.
 Defined.
 
+Opaque PathOver.
 Section A.
 
   Context (A : circle -> Type) (a : A pt) (p : PathOver a a loop).


### PR DESCRIPTION
This little change makes coq/coq#13037 show no regression on Circle2.v