### PR TITLE
Adapt to fixing dropped implicit arguments in Context

### DIFF
--- a/UniMath/CategoryTheory/slicecat.v
+++ b/UniMath/CategoryTheory/slicecat.v
@@ -840,10 +840,10 @@ Defined.
 *)
 Section dependent_product.
 
-Context (H : ∏ {c c' : C} (g : C⟦c,c'⟧), is_left_adjoint (base_change_functor g)).
+Context (H : ∏ (c c' : C) (g : C⟦c,c'⟧), is_left_adjoint (base_change_functor g)).
 
 Let dependent_product_functor {c c' : C} (g : C⟦c,c'⟧) :
-  functor (C / c) (C / c') := right_adjoint (H g).
+  functor (C / c) (C / c') := right_adjoint (H c c' g).
 
 Let BPC c : BinProducts (C / c) := @BinProducts_slice_precat C hsC PC c.
 
@@ -868,7 +868,7 @@ use tpair.
                            (dependent_product_functor (pr2 Af))).
 + rewrite const_prod_functor1_slicecat.
   apply are_adjoints_functor_composite.
-  - apply (pr2 (H _)).
+  - apply (pr2 (H _ _ _)).
   - apply are_adjoints_slicecat_functor_base_change.
 Defined.
 

--- a/UniMath/CategoryTheory/slicecat.v
+++ b/UniMath/CategoryTheory/slicecat.v
@@ -843,7 +843,7 @@ Section dependent_product.
 Context (H : ∏ {c c' : C} (g : C⟦c,c'⟧), is_left_adjoint (base_change_functor g)).
 
 Let dependent_product_functor {c c' : C} (g : C⟦c,c'⟧) :
-  functor (C / c) (C / c') := right_adjoint (H c c' g).
+  functor (C / c) (C / c') := right_adjoint (H g).
 
 Let BPC c : BinProducts (C / c) := @BinProducts_slice_precat C hsC PC c.
 
@@ -868,7 +868,7 @@ use tpair.
                            (dependent_product_functor (pr2 Af))).
 + rewrite const_prod_functor1_slicecat.
   apply are_adjoints_functor_composite.
-  - apply (pr2 (H _ _ _)).
+  - apply (pr2 (H _)).
   - apply are_adjoints_slicecat_functor_base_change.
 Defined.
 


### PR DESCRIPTION
Hi, implicit arguments in `Context` were discarded. Coq PR [#11390](https://github.com/coq/coq/pull/11390) preserves them. The present PR adapts UniMath to the new semantics.

I went for a backwards-incompatible change preserving the intent of providing an implicit argument to an hypothesis named `H` in file `slicecat.v`. As such it'll have to be merged synchronously with the Coq PR.

Note that, if you prefer, a backward-compatible could be done by instead replacing the `{ }` around `{c c' : C}` with parentheses in the type of `H`.

Best,