### PR TITLE
With Coq PR #13513, "intros []" uses "destruct" rather than "case" and becomes a bit "smarter"

### DIFF
--- a/UniMath/.dir-locals.el
+++ b/UniMath/.dir-locals.el
@@ -7,7 +7,7 @@
 	     (make-local-variable 'coq-prog-args)
 	     (setq coq-prog-args
 		   ;; these options should match what's used in ../Makefile
-		   `("-emacs" "-noinit" "-indices-matter" "-type-in-type" "-w" "-notation-overridden" "-Q" ,(concat unimath-topdir "UniMath") "UniMath" )
+		   `("-quiet" "-emacs" "-noinit" "-indices-matter" "-type-in-type" "-w" "-notation-overridden" "-Q" ,(concat unimath-topdir "UniMath") "UniMath" )
 		   )
 	     (make-local-variable 'coq-prog-name)
 	     (setq coq-prog-name (concat unimath-topdir "sub/coq/bin/coqtop"))

--- a/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
@@ -120,7 +120,7 @@ Proof.
 use make_cocone.
 - intro n.
   apply (pr1 (Pow n) _ z).
-- abstract (intros n m []; clear m; apply Pow_cocone_subproof).
+- abstract (intros n m []; try clear m; apply Pow_cocone_subproof).
 Defined.
 
 Local Definition CC_LchnF : ColimCocone LchnF.

--- a/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
@@ -120,7 +120,7 @@ Proof.
 use make_cocone.
 - intro n.
   apply (pr1 (Pow n) _ z).
-- abstract (intros n m []; try clear m; apply Pow_cocone_subproof).
+- abstract (intros n m k; induction k; apply Pow_cocone_subproof).
 Defined.
 
 Local Definition CC_LchnF : ColimCocone LchnF.


### PR DESCRIPTION
As a consequence, some `clear` on a residual dependent argument of an inductive type becomes useless.

We leave a `try` so as to be backwards-compatible (you may prefer a clean non-compatible script though).

Cf coq/coq#13513.