### PR TITLE
Move notation for `eqset` to scope `logic` instead of `set`?

### DIFF
--- a/UniMath/Algebra/BinaryOperations.v
+++ b/UniMath/Algebra/BinaryOperations.v
@@ -34,6 +34,8 @@
 
 Require Export UniMath.Foundations.Sets.
 
+Local Open Scope logic.
+
 (** To upstream files *)
 
 
@@ -326,7 +328,7 @@ Proof.
         rewrite e. apply idpath.
     -  apply (is x').
   }
-  assert (is' : ∏ x : X, hexists (λ x0 : X, eqset (opp x0 x) un0)).
+  assert (is' : ∏ x : X, hexists (λ x0 : X, (opp x0 x) = un0)).
   {
     intro x. apply (λ f : _ , hinhuniv f (is x)). intro s1.
     destruct s1 as [ x' eq ]. apply hinhpr. split with x'. simpl.
@@ -350,7 +352,7 @@ Proof.
         rewrite e. apply idpath.
     - apply (is' x').
   }
-  assert (int : ∏ x : X, isaprop (total2 (λ x0 : X, eqset (opp x0 x) un0))).
+  assert (int : ∏ x : X, isaprop (total2 (λ x0 : X, (opp x0 x) = un0))).
   {
     intro x. apply isapropsubtype. intros x1 x2. intros eq1 eq2.
     apply (invmaponpathsincl _ (l1 x)).
@@ -1472,7 +1474,7 @@ Proof.
       use funextfun. intros x1.
       use funextfun. intros x2.
       exact (i x1 x2).
-    + intros e. change (Xop = Yop) in e. intros x1 x2. induction e. use idpath.
+    + intros e. cbn in e. intros x1 x2. induction e. use idpath.
     + use isapropisbinopfun.
     + use isasetbinoponhSet.
 Defined.
@@ -2412,7 +2414,7 @@ Proof.
       * use funextfun. intros x1.
         use funextfun. intros x2.
         exact ((dirprod_pr2 i) x1 x2).
-    + intros e. change (Xop = Yop) in e.
+    + intros e. cbn in e.
       use make_istwobinopfun.
       * intros x1 x2. induction e. use idpath.
       * intros x1 x2. induction e. use idpath.

--- a/UniMath/Algebra/Domains_and_Fields.v
+++ b/UniMath/Algebra/Domains_and_Fields.v
@@ -18,6 +18,7 @@ Require Import UniMath.Algebra.Groups.
   - Relations and the canonical homomorphism to the field of fractions
 *)
 
+Local Open Scope logic.
 
 (** ** Preamble *)
 
@@ -306,7 +307,7 @@ Proof.
 Defined.
 
 Definition isintdom (X : commring) : UU :=
-  dirprod (isnonzerorig X) (∏ (a1 a2 : X), paths (a1 * a2) 0 -> hdisj (eqset a1 0) (eqset a2 0)).
+  dirprod (isnonzerorig X) (∏ (a1 a2 : X), (a1 * a2 = 0) -> (a1 = 0) ∨ (a2 = 0)).
 
 Lemma isapropisintdom (X : commring) : isaprop (isintdom X).
 Proof.
@@ -325,7 +326,7 @@ Coercion pr1intdom : intdom >-> commring.
 Definition nonzeroax (X : intdom) : neg (@paths X 1 0) := pr1 (pr2 X).
 
 Definition intdomax (X : intdom) :
-  ∏ (a1 a2 : X), (a1 * a2) = 0 -> hdisj (eqset a1 0) (eqset a2 0) := pr2 (pr2 X).
+  ∏ (a1 a2 : X), (a1 * a2) = 0 -> (a1 = 0) ∨ (a2 = 0) := pr2 (pr2 X).
 
 
 (** **** (X = Y) ≃ (ringiso X Y)
@@ -642,7 +643,7 @@ Definition fldfracmultinv0 (X : intdom) (is : isdeceq X)
 
 Lemma nonzeroincommringfrac (X : commring) (S : @submonoid (ringmultmonoid X)) (xa : dirprod X S)
       (ne : (setquotpr (eqrelcommringfrac X S) xa !=
-             setquotpr _ (make_dirprod 0 (unel S)))) : (pr1 xa != 0).
+             setquotpr _ (make_dirprod 0 (unel S)))%type) : (pr1 xa != 0).
 Proof.
   intros. set (x := pr1 xa). set (aa := pr2 xa).
   assert (e' := negf (weqpathsinsetquot (eqrelcommringfrac X S) _ _) ne).

--- a/UniMath/Algebra/GroupAction.v
+++ b/UniMath/Algebra/GroupAction.v
@@ -61,7 +61,7 @@ Definition right_mult {G:gr} {X:Action G} (x:X) := λ g, g*x.
 Definition left_mult {G:gr} {X:Action G} (g:G) := λ x:X, g*x.
 
 Definition is_equivariant {G:gr} {X Y:Action G} (f:X->Y) : hProp :=
-  (∀ g x, f (g*x) = g*(f x))%set.
+  (∀ g x, f (g*x) = g*(f x))%logic.
 
 Definition is_equivariant_isaprop {G:gr} {X Y:Action G} (f:X->Y) :
   isaprop (is_equivariant f).

--- a/UniMath/Algebra/Groups.v
+++ b/UniMath/Algebra/Groups.v
@@ -32,6 +32,8 @@ Require Import UniMath.MoreFoundations.Subtypes.
 Require Export UniMath.Algebra.BinaryOperations.
 Require Export UniMath.Algebra.Monoids.
 
+Local Open Scope logic.
+
 (** ** Groups *)
 
 (** *** Basic definitions *)
@@ -423,18 +425,12 @@ Lemma isinvongrquot {X : gr} (R : binopeqrel X) :
 Proof.
   split.
   - unfold islinv.
-    apply (setquotunivprop
-             R (λ x : setwithbinopquot R, eqset
-                                             (@op (setwithbinopquot R) (invongrquot R x) x)
-                                             (setquotpr R (unel X)))).
+    apply (setquotunivprop R (λ x, _ = _)).
     intro x.
     apply (@maponpaths _ _ (setquotpr R) (@op X (grinv X x) x) (unel X)).
     apply (grlinvax X).
   - unfold isrinv.
-    apply (setquotunivprop
-             R (λ x : setwithbinopquot R, eqset
-                                             (@op (setwithbinopquot R) x (invongrquot R x))
-                                             (setquotpr R (unel X)))).
+    apply (setquotunivprop R (λ x, _ = _)).
     intro x.
     apply (@maponpaths _ _ (setquotpr R) (@op X x (grinv X x)) (unel X)).
     apply (grrinvax X).
@@ -979,8 +975,7 @@ Proof.
   assert (isl : islinv (@op (abgrdiffcarrier X)) (unel (abgrdiffcarrier X)) (abgrdiffinv X)).
   {
     unfold islinv.
-    apply (setquotunivprop
-             R (λ x : abgrdiffcarrier X, eqset (abgrdiffinv X x + x) (unel (abgrdiffcarrier X)))).
+    apply (setquotunivprop R (λ x, _ = _)).
     intro xs.
     set (x := pr1 xs). set (s := pr2 xs).
     apply (iscompsetquotpr R (@op (abmonoiddirprod X X) (abgrdiffinvint X xs) xs) (unel _)).

--- a/UniMath/Algebra/Groups.v
+++ b/UniMath/Algebra/Groups.v
@@ -356,7 +356,7 @@ Defined.
 
 Definition trivialsubgr (X : gr) : subgr X.
 Proof.
-  exists (λ x, x = @unel X)%set.
+  exists (λ x, x = @unel X)%logic.
   split.
   - exact (pr2 (@trivialsubmonoid X)).
   - intro.

--- a/UniMath/Algebra/Monoids.v
+++ b/UniMath/Algebra/Monoids.v
@@ -30,7 +30,6 @@
 
 (** ** Preamble *)
 
-
 (** Settings *)
 
 (** The following line has to be removed for the file to compile with Coq8.2 *)
@@ -41,6 +40,8 @@ Unset Kernel Term Sharing.
 Require Export UniMath.Algebra.BinaryOperations.
 Require Import UniMath.MoreFoundations.Subtypes.
 Require Import UniMath.MoreFoundations.Sets.
+
+Local Open Scope logic.
 
 (** ** Standard Algebraic Structures *)
 
@@ -382,7 +383,7 @@ Defined.
 Definition trivialsubmonoid (X : monoid) : @submonoid X.
 Proof.
   intros.
-  exists (λ x, x = @unel X)%logic.
+  exists (λ x, x = @unel X).
   split.
   - intros b c.
     induction b as [x p], c as [y q].
@@ -494,11 +495,11 @@ Proof.
   set (qsetwithop := setwithbinopquot R).
   split.
   - intro x.
-    apply (setquotunivprop R (λ x, @eqset qsetwithop ((@op qsetwithop) qun x) x)).
+    apply (setquotunivprop R (λ x, (@op qsetwithop) qun x = x)).
     simpl. intro x0.
     apply (maponpaths (setquotpr R) (lunax X x0)).
   - intro x.
-    apply (setquotunivprop R (λ x, @eqset qsetwithop ((@op qsetwithop) x qun) x)).
+    apply (setquotunivprop R (λ x, (@op qsetwithop) x qun = x)).
     simpl. intro x0. apply (maponpaths (setquotpr R) (runax X x0)).
 Defined.
 Opaque isunitquot.
@@ -1006,7 +1007,7 @@ Proof.
     set (g := λ x0 : abmonoidfrac X A, prabmonoidfrac X A (pr1 a') a + x0).
     assert (egf : ∏ x0 : _, paths (g (f x0)) x0).
     {
-      apply (setquotunivprop R (λ x0 : abmonoidfrac X A, eqset (g (f x0)) x0)).
+      apply (setquotunivprop R (λ x, _ = _)).
       intro xb. simpl.
       apply (iscompsetquotpr
                R (@make_dirprod X A ((pr1 a') + ((pr1 a) + (pr1 xb)))
@@ -1026,7 +1027,7 @@ Proof.
     }
     assert (efg : ∏ x0 : _, paths (f (g x0)) x0).
     {
-      apply (setquotunivprop R (λ x0 : abmonoidfrac X A, eqset (f (g x0)) x0)).
+      apply (setquotunivprop R (λ x0, _ = _)).
       intro xb. simpl.
       apply (iscompsetquotpr
                R (@make_dirprod X A ((pr1 a) + ((pr1 a') + (pr1 xb)))
@@ -1080,7 +1081,7 @@ Definition ismonoidfuntoabmonoidfrac (X : abmonoid) (A : submonoid X) :
 (** **** Abelian monoid of fractions in the case when elements of the localziation submonoid are cancelable *)
 
 Definition hrel0abmonoidfrac (X : abmonoid) (A : submonoid X) : hrel (X × A) :=
-  λ xa yb : setdirprod X A, eqset ((pr1 xa) + (pr1 (pr2 yb))) ((pr1 yb) + (pr1 (pr2 xa))).
+  λ xa yb : setdirprod X A, (pr1 xa) + (pr1 (pr2 yb)) = (pr1 yb) + (pr1 (pr2 xa)).
 
 Lemma weqhrelhrel0abmonoidfrac (X : abmonoid) (A : submonoid X)
       (iscanc : ∏ a : A, isrcancelable (@op X) (pr1carrier _ a))
@@ -1088,7 +1089,7 @@ Lemma weqhrelhrel0abmonoidfrac (X : abmonoid) (A : submonoid X)
 Proof.
   unfold eqrelabmonoidfrac. unfold hrelabmonoidfrac. simpl.
   apply weqimplimpl.
-  apply (@hinhuniv _ (eqset (pr1 xa + pr1 (pr2 xa')) (pr1 xa' + pr1 (pr2 xa)))).
+  apply (@hinhuniv _ (pr1 xa + pr1 (pr2 xa') = pr1 xa' + pr1 (pr2 xa))).
   intro ae. destruct ae as [ a eq ].
   apply (invmaponpathsincl _ (iscanc a) _ _ eq).
   intro eq. apply hinhpr. split with (unel A). rewrite (runax X).
@@ -1124,7 +1125,7 @@ Proof.
   apply (isdecpropweqb (weqhrelhrel0abmonoidfrac X A iscanc xa xa')).
   apply isdecpropif. unfold isaprop. simpl.
   set (int := setproperty X (pr1 xa + pr1 (pr2 xa')) (pr1 xa' + pr1 (pr2 xa))).
-  simpl in int. apply int. unfold hrel0abmonoidfrac. unfold eqset.
+  simpl in int. apply int. unfold hrel0abmonoidfrac.
   simpl. apply (is _ _).
 Defined.
 

--- a/UniMath/Algebra/Monoids.v
+++ b/UniMath/Algebra/Monoids.v
@@ -382,7 +382,7 @@ Defined.
 Definition trivialsubmonoid (X : monoid) : @submonoid X.
 Proof.
   intros.
-  exists (λ x, x = @unel X)%set.
+  exists (λ x, x = @unel X)%logic.
   split.
   - intros b c.
     induction b as [x p], c as [y q].

--- a/UniMath/Algebra/RigsAndRings.v
+++ b/UniMath/Algebra/RigsAndRings.v
@@ -67,6 +67,8 @@ Unset Kernel Term Sharing.
 
 Require Export UniMath.Algebra.Monoids.
 
+Local Open Scope logic.
+
 (** To upstream files *)
 
 
@@ -1595,10 +1597,7 @@ Definition rigtoringop2 (X : rig) : binop (rigtoringcarrier X) :=
 Lemma rigtoringassoc2 (X : rig) : isassoc (rigtoringop2 X).
 Proof.
   unfold isassoc.
-  apply (setquotuniv3prop (eqrelrigtoring X)
-                          (λ x x' x'' : rigtoringcarrier X,
-                             eqset (rigtoringop2 X (rigtoringop2 X x x') x'')
-                                   (rigtoringop2 X x (rigtoringop2 X x' x'')))).
+  apply (setquotuniv3prop _ (λ x x' x'', _ = _)).
   intros x x' x''.
   change (paths (setquotpr (eqrelrigtoring X) (rigtoringop2int X (rigtoringop2int X x x') x''))
                 (setquotpr (eqrelrigtoring X) (rigtoringop2int X x (rigtoringop2int X x' x'')))).
@@ -1637,9 +1636,7 @@ Definition rigtoringunel2 (X : rig) : rigtoringcarrier X :=
 Lemma rigtoringlunit2 (X : rig) : islunit (rigtoringop2 X) (rigtoringunel2 X).
 Proof.
   unfold islunit.
-  apply (setquotunivprop
-           (eqrelrigtoring X) (λ x : rigtoringcarrier X,
-                                eqset (rigtoringop2 X (rigtoringunel2 X) x) x)).
+  apply (setquotunivprop _ (λ x, _ = _)).
   intro x.
   change (paths (setquotpr (eqrelrigtoring X) (rigtoringop2int X (rigtoringunel2int X) x))
                 (setquotpr (eqrelrigtoring X) x)).
@@ -1655,9 +1652,7 @@ Opaque rigtoringlunit2.
 Lemma rigtoringrunit2 (X : rig) : isrunit (rigtoringop2 X) (rigtoringunel2 X).
 Proof.
   unfold isrunit.
-  apply (setquotunivprop
-           (eqrelrigtoring X) (λ x : rigtoringcarrier X,
-                                eqset (rigtoringop2 X x (rigtoringunel2 X)) x)).
+  apply (setquotunivprop _ (λ x, _ = _)).
   intro x.
   change (paths (setquotpr (eqrelrigtoring X) (rigtoringop2int X x (rigtoringunel2int X)))
                 (setquotpr (eqrelrigtoring X) x)).
@@ -1683,11 +1678,7 @@ Definition rigtoringismonoidop2 (X : rig) : ismonoidop (rigtoringop2 X) :=
 Lemma rigtoringldistr (X : rig) : isldistr (rigtoringop1 X) (rigtoringop2 X).
 Proof.
   unfold isldistr.
-  apply (setquotuniv3prop
-           (eqrelrigtoring X) (λ x x' x'' : rigtoringcarrier X,
-                                eqset (rigtoringop2 X x'' (rigtoringop1 X x x'))
-                                      (rigtoringop1 X (rigtoringop2 X x'' x)
-                                                   (rigtoringop2 X x'' x')))).
+  apply (setquotuniv3prop _ (λ x x' x'', _ = _)).
   intros x x' x''.
   change (paths (setquotpr (eqrelrigtoring X) (rigtoringop2int X x'' (rigtoringop1int X x x')))
                 (setquotpr (eqrelrigtoring X) (rigtoringop1int X (rigtoringop2int X x'' x)
@@ -1707,11 +1698,7 @@ Opaque rigtoringldistr.
 Lemma rigtoringrdistr (X : rig) : isrdistr (rigtoringop1 X) (rigtoringop2 X).
 Proof.
   unfold isrdistr.
-  apply (setquotuniv3prop
-           (eqrelrigtoring X) (λ x x' x'' : rigtoringcarrier X,
-                                eqset (rigtoringop2 X (rigtoringop1 X x x') x'')
-                                      (rigtoringop1 X (rigtoringop2 X x x'')
-                                                   (rigtoringop2 X x' x'')))).
+  apply (setquotuniv3prop _ (λ x x' x'', _ = _)).
   intros x x' x''.
   change (paths (setquotpr (eqrelrigtoring X) (rigtoringop2int X (rigtoringop1int X x x') x''))
                 (setquotpr (eqrelrigtoring X)
@@ -2110,9 +2097,7 @@ Local Open Scope rig_scope.
 Lemma commrigtocommringcomm2 (X : commrig) : iscomm (rigtoringop2 X).
 Proof.
   unfold iscomm.
-  apply (setquotuniv2prop
-           (eqrelrigtoring X)
-           (λ x x' : rigtoringcarrier X,  eqset (rigtoringop2 X x x') (rigtoringop2 X x' x))).
+  apply (setquotuniv2prop _ (λ x x', _ = _)).
   intros x x'.
   change (paths (setquotpr (eqrelrigtoring X) (rigtoringop2int X x x'))
                 (setquotpr (eqrelrigtoring X) (rigtoringop2int X x' x))).
@@ -2267,9 +2252,7 @@ Proof.
   - apply (invmaponpathsincl _ (isinclpr1carrier (pr1 S))).
     unfold pr1carrier. simpl. set (assoc2 := ringassoc2 X).
     apply (assoc2 (pr1 (pr2 xs)) (pr1 (pr2 xs')) (pr1 (pr2 xs''))).
-  - apply (setquotuniv3prop R (λ x x' x'' : setquotinset R,
-                                 @eqset (setquotinset R) (add1 (add1 x x') x'')
-                                        (add1 x (add1 x' x''))) int).
+  - apply (setquotuniv3prop R (λ x x' x'', _ = _)), int.
 Defined.
 Opaque commringfracassoc1.
 
@@ -2281,8 +2264,7 @@ Proof.
   set (add1int := commringfracop1int X S).
   set (add1 := commringfracop1 X S).
   unfold iscomm.
-  apply (setquotuniv2prop R (λ x x' : setquotinset R ,
-                               @eqset (setquotinset R) (add1 x x') (add1 x' x))).
+  apply (setquotuniv2prop _ (λ x x', _ = _)).
   intros xs xs'.
   apply (@maponpaths _ _ (setquotpr R) (add1int xs xs') (add1int xs' xs)).
   unfold add1int. unfold commringfracop1int.
@@ -2339,8 +2321,7 @@ Proof.
     set (qunel1 := commringfracunel1 X S).
     set (assoc2 := ringassoc2 X).
     unfold islinv.
-    apply (setquotunivprop
-             R (λ x : setquotinset R, @eqset (setquotinset R) (add1 (inv1 x) x) qunel1)).
+    apply (setquotunivprop _ (λ x, _ = _)).
     intro xs.
     apply (iscompsetquotpr R  (add1int (inv1int xs) xs) qunel1int).
     simpl. apply hinhpr. split with (unel S).
@@ -2364,7 +2345,7 @@ Proof.
   set (R := eqrelcommringfrac X S). set (add1int := commringfracop1int X S).
   set (add1 := commringfracop1 X S). set (un1 := commringfracunel1 X S).
   unfold islunit.
-  apply (setquotunivprop R (λ x : _, @eqset (setquotinset R) (add1 un1 x) x)).
+  apply (setquotunivprop R (λ x, _ = _)).
   intro xs.
   assert (e0 : paths (add1int (commringfracunel1int X S) xs) xs).
   {
@@ -2416,10 +2397,7 @@ Proof.
   set (add1int := commringfracop1int X S).
   set (add1 := commringfracop1 X S).
   unfold isldistr.
-  apply (setquotuniv3prop
-           R (λ x x' x'' : setquotinset R,
-                @eqset (setquotinset R) (mult1 x'' (add1 x x'))
-                       (add1 (mult1 x'' x) (mult1  x'' x')))).
+  apply (setquotuniv3prop _ (λ x x' x'', _ = _)).
   intros xs xs' xs''.
   apply (iscompsetquotpr R (mult1int xs'' (add1int xs xs'))
                          (add1int (mult1int xs'' xs) (mult1int xs'' xs'))).
@@ -2580,7 +2558,7 @@ Definition isringfuntocommringfrac (X : commring) (S : @subabmonoid (ringmultabm
 
 Definition hrelcommringfrac0 (X : commring) (S : @submonoid (ringmultabmonoid X)) :
   hrel (X × S) :=
-  λ xa yb : setdirprod X S, eqset ((pr1 xa) * (pr1 (pr2 yb))) ((pr1 yb) * (pr1 (pr2 xa))).
+  λ xa yb : setdirprod X S, (pr1 xa) * (pr1 (pr2 yb)) = (pr1 yb) * (pr1 (pr2 xa)).
 
 Lemma weqhrelhrel0commringfrac (X : commring) (S : @submonoid (ringmultabmonoid X))
       (iscanc : ∏ a : S, isrcancelable (@op2 X) (pr1carrier _ a)) (xa xa' : dirprod X S) :
@@ -2588,7 +2566,7 @@ Lemma weqhrelhrel0commringfrac (X : commring) (S : @submonoid (ringmultabmonoid 
 Proof.
   intros. unfold eqrelabmonoidfrac. unfold hrelabmonoidfrac. simpl.
   apply weqimplimpl.
-  - apply (@hinhuniv _ (eqset (pr1 xa * pr1 (pr2 xa')) (pr1 xa' * pr1 (pr2 xa)))).
+  - apply (@hinhuniv _ (_ = _)).
     intro ae. destruct ae as [ a eq ].
     apply (invmaponpathsincl _ (iscanc a) _ _ eq).
   - intro eq. apply hinhpr. split with (unel S).
@@ -2625,7 +2603,7 @@ Proof.
   apply (isdecpropweqb (weqhrelhrel0commringfrac X S iscanc xa xa')).
   apply isdecpropif. unfold isaprop. simpl.
   set (int := setproperty X (pr1 xa * pr1 (pr2 xa')) (pr1 xa' * pr1 (pr2 xa))).
-  simpl in int. apply int. unfold hrelcommringfrac0. unfold eqset.
+  simpl in int. apply int. unfold hrelcommringfrac0.
   simpl. apply (is _ _).
 Defined.
 

--- a/UniMath/CategoryTheory/ExactCategories/ExactCategories.v
+++ b/UniMath/CategoryTheory/ExactCategories/ExactCategories.v
@@ -48,7 +48,6 @@ Require Export UniMath.MoreFoundations.Propositions.
 Local Arguments grinv {_}.
 
 Local Open Scope logic.
-Local Open Scope type.
 Local Open Scope cat.
 
 Local Definition hom (C:precategory_data) : ob C -> ob C -> UU := λ c c', precategory_morphisms c c'.
@@ -152,6 +151,9 @@ Section MorphismPairs.
 End MorphismPairs.
 
 Section Pullbacks.              (* move upstream *)
+
+  Local Open Scope type.
+
   Definition IsoArrowTo {M : precategory}     {A A' B:M} (g : A --> B) (g' : A' --> B) := ∑ i : z_iso A A', i · g' = g.
   Coercion IsoArrowTo_pr1 {M : precategory}   {A A' B:M} (g : A --> B) (g' : A' --> B) : IsoArrowTo g g' -> z_iso A A' := pr1.
   Definition IsoArrowFrom {M : precategory}   {A B B':M} (g : A --> B) (g' : A --> B') := ∑ i : z_iso B B', g · i  = g'.
@@ -271,7 +273,7 @@ Section PreAdditive.
   Defined.
 
   Definition isKernel' {M:PreAdditive} {x y z : M} (f : x --> y) (g : y --> z) : hProp :=
-    f · g = 0 ∧ ∀ (w : M) (h : w --> y), h · g = 0 ⇒ (∃! φ : w --> x, φ · f = h)%abgrcat%logic.
+    f · g = 0 ∧ ∀ (w : M) (h : w --> y), h · g = 0 ⇒ ∃! φ : w --> x, φ · f = h.
   Definition hasKernel {M:PreAdditive} {y z : M} (g : y --> z) : hProp :=
     ∃ x (f:x-->y), isKernel' f g.
   Lemma isKernel_iff {M:PreAdditive} {x y z : M} (Z:Zero M) (f : x --> y) (g : y --> z) :
@@ -294,7 +296,7 @@ Section PreAdditive.
     intros co. exists (x,,f). now apply isKernel_iff.
   Defined.
   Definition isCokernel' {M:PreAdditive} {x y z : M} (f : x --> y) (g : y --> z) : hProp :=
-    f · g = 0 ∧ ∀ (w : M) (h : y --> w), f · h = 0 ⇒ (∃! φ : z --> w, g · φ = h)%abgrcat%logic.
+    f · g = 0 ∧ ∀ (w : M) (h : y --> w), f · h = 0 ⇒ ∃! φ : z --> w, g · φ = h.
   Definition hasCokernel {M:PreAdditive} {x y : M} (f : x --> y) : hProp :=
     ∃ z (g:y-->z), isCokernel' f g.
   Lemma isCokernel_iff {M:PreAdditive} {x y z : M} (Z:Zero M) (f : x <-- y) (g : y <-- z) :
@@ -1805,7 +1807,7 @@ Section SplitSequences.
     apply makeMonicKernel.
     - apply to_In1_isMonic.
     - exact (to_Unel1 AB).
-    - intros T h e. exists (h · π₁). unfold eqset; cbn. refine (_ @ id_right _).
+    - intros T h e. exists (h · π₁). refine (_ @ id_right _).
       rewrite <- (to_BinOpId AB). rewrite rewrite_op. rewrite rightDistribute.
       rewrite assoc'. rewrite (assoc _ π₂ _). rewrite e. rewrite zeroLeft. rewrite runax. reflexivity.
   Defined.
@@ -1814,7 +1816,7 @@ Section SplitSequences.
     apply makeEpiCokernel.
     - apply to_Pr2_isEpi.
     - exact (to_Unel1 AB).
-    - intros T h e. exists (ι₂ · h). unfold eqset; cbn. refine (_ @ id_left _).
+    - intros T h e. exists (ι₂ · h). refine (_ @ id_left _).
       rewrite <- (to_BinOpId AB). rewrite rewrite_op. rewrite leftDistribute.
       rewrite assoc. rewrite (assoc' _ ι₁ _). rewrite e. rewrite zeroRight. rewrite lunax. reflexivity.
   Defined.
@@ -1843,7 +1845,7 @@ Section SplitSequences.
     apply hinhpr.
     exists (q' · p').
     exists (π₁ · i' · j + π₂ · j').
-    repeat split; unfold eqset; cbn; rewrite ? rewrite_op.
+    repeat split; rewrite ? rewrite_op.
     { rewrite assoc'. rewrite (assoc j). rewrite (to_IdIn1 jq). rewrite id_left.
       rewrite (to_IdIn1 ip). reflexivity. }
     { rewrite rightDistribute, 2 leftDistribute.

--- a/UniMath/CategoryTheory/ExactCategories/ExactCategories.v
+++ b/UniMath/CategoryTheory/ExactCategories/ExactCategories.v
@@ -48,6 +48,7 @@ Require Export UniMath.MoreFoundations.Propositions.
 Local Arguments grinv {_}.
 
 Local Open Scope logic.
+Local Open Scope type.
 Local Open Scope cat.
 
 Local Definition hom (C:precategory_data) : ob C -> ob C -> UU := λ c c', precategory_morphisms c c'.
@@ -151,7 +152,7 @@ Section MorphismPairs.
 End MorphismPairs.
 
 Section Pullbacks.              (* move upstream *)
-  Definition IsoArrowTo {M : precategory}     {A A' B:M} (g : A --> B) (g' : A' --> B) := ∑ i : z_iso A A', i · g' = g .
+  Definition IsoArrowTo {M : precategory}     {A A' B:M} (g : A --> B) (g' : A' --> B) := ∑ i : z_iso A A', i · g' = g.
   Coercion IsoArrowTo_pr1 {M : precategory}   {A A' B:M} (g : A --> B) (g' : A' --> B) : IsoArrowTo g g' -> z_iso A A' := pr1.
   Definition IsoArrowFrom {M : precategory}   {A B B':M} (g : A --> B) (g' : A --> B') := ∑ i : z_iso B B', g · i  = g'.
   Coercion IsoArrowFrom_pr1 {M : precategory} {A B B':M} (g : A --> B) (g' : A --> B') : IsoArrowFrom g g' -> z_iso B B' := pr1.
@@ -270,7 +271,7 @@ Section PreAdditive.
   Defined.
 
   Definition isKernel' {M:PreAdditive} {x y z : M} (f : x --> y) (g : y --> z) : hProp :=
-    f · g = 0 ∧ ∀ (w : M) (h : w --> y), h · g = 0 ⇒ ∃! φ : w --> x, φ · f = h.
+    f · g = 0 ∧ ∀ (w : M) (h : w --> y), h · g = 0 ⇒ (∃! φ : w --> x, φ · f = h)%abgrcat%logic.
   Definition hasKernel {M:PreAdditive} {y z : M} (g : y --> z) : hProp :=
     ∃ x (f:x-->y), isKernel' f g.
   Lemma isKernel_iff {M:PreAdditive} {x y z : M} (Z:Zero M) (f : x --> y) (g : y --> z) :
@@ -293,7 +294,7 @@ Section PreAdditive.
     intros co. exists (x,,f). now apply isKernel_iff.
   Defined.
   Definition isCokernel' {M:PreAdditive} {x y z : M} (f : x --> y) (g : y --> z) : hProp :=
-    f · g = 0 ∧ ∀ (w : M) (h : y --> w), f · h = 0 ⇒ ∃! φ : z --> w, g · φ = h.
+    f · g = 0 ∧ ∀ (w : M) (h : y --> w), f · h = 0 ⇒ (∃! φ : z --> w, g · φ = h)%abgrcat%logic.
   Definition hasCokernel {M:PreAdditive} {x y : M} (f : x --> y) : hProp :=
     ∃ z (g:y-->z), isCokernel' f g.
   Lemma isCokernel_iff {M:PreAdditive} {x y z : M} (Z:Zero M) (f : x <-- y) (g : y <-- z) :
@@ -384,7 +385,9 @@ Section PreAdditive.
     intros im eq ex. exists eq. intros w h e.
     apply iscontraprop1.
     - apply invproofirrelevance; intros [r R] [s S].
-      apply subtypePath_prop; simpl. apply im. exact (R@!S).
+      Unset Printing Notations. Arguments paths _ _ _ : clear implicits.
+      try assumption.
+      refine (@subtypePath_prop _ _ (_,,_) (_,,_) _); simpl. apply im. exact (R@!S).
     - apply ex. exact e.
   Qed.
   Definition makeEpiCokernel {M:PreAdditive} {x y z : M} (f : x --> y) (g : y --> z) :

--- a/UniMath/CategoryTheory/RepresentableFunctors/Bifunctor.v
+++ b/UniMath/CategoryTheory/RepresentableFunctors/Bifunctor.v
@@ -191,7 +191,7 @@ Definition θ_1 {B C:category} (F : [B, C]) (X : [B, [C^op, SET]]) : hSet
 
 Definition θ_2 {B C:category} (F : [B, C]) (X : [B, [C^op, SET]])
            (x : θ_1 F X) : hSet
-  := (∏ (b' b:B) (f:b'-->b), hProp_to_hSet (x b ⟲ F ▭ f = X ▭ f ⟳ x b' )) % set.
+  := hProp_to_hSet (∀ (b' b:B) (f:b'-->b), (x b ⟲ F ▭ f = X ▭ f ⟳ x b' )) % logic.
 
 Definition θ {B C:category} (F : [B, C]) (X : [B, [C^op, SET]]) : hSet
   := ( ∑ x : θ_1 F X, θ_2 F X x ) % set.

--- a/UniMath/CategoryTheory/categories/HSET/SliceFamEquiv.v
+++ b/UniMath/CategoryTheory/categories/HSET/SliceFamEquiv.v
@@ -71,7 +71,7 @@ Section set_slice_fam_equiv.
       apply funextsec; intro p;
         apply (invmaponpathsincl pr1); simpl;
           try (apply isofhlevelfpr1;
-               intros ?; exact (pr2 (eqset _ _)));
+               intros ?; apply setproperty);
           repeat (unfold hfiber; rewrite transportf_total2; simpl);
           repeat (rewrite transportf_const);
           reflexivity.
@@ -166,7 +166,7 @@ Section set_slice_fam_equiv.
     apply (invmaponpathsincl pr1).
     + apply isofhlevelfpr1.
       intros ?.
-      exact (pr2 (eqset _ _)).
+      apply setproperty.
     + reflexivity.
   Qed.
 
@@ -210,7 +210,7 @@ Section set_slice_fam_equiv.
       apply (invmaponpathsincl pr1).
     - apply isofhlevelfpr1.
       intros ?.
-      exact (pr2 (eqset _ _)).
+      apply setproperty.
     - simpl.
       unfold hfiber. rewrite transportf_total2.
       simpl. rewrite transportf_const.

--- a/UniMath/CategoryTheory/elems_slice_equiv.v
+++ b/UniMath/CategoryTheory/elems_slice_equiv.v
@@ -93,7 +93,7 @@ Section elems_slice_equiv.
       use total2_paths_f.
       * reflexivity.
       * rewrite idpath_transportf;
-        now apply eqset.
+        now apply setproperty.
 
     + set (T := ∑ p' : ## P Z, p' = # (pr1 P) (g ∘ f) p : UU).
       set (T' := ∑ p' : ## P Z, (pr1 F) (X ,, p) --> (pr1 F) (Z ,, p') : UU).
@@ -119,7 +119,7 @@ Section elems_slice_equiv.
       use total2_paths_f.
       * reflexivity.
       * rewrite idpath_transportf;
-        now apply eqset.
+        now apply setproperty.
   Qed.
 
   Definition PreShv_to_slice_ob_funct (F : PreShv ∫P) : PreShv C :=
@@ -200,7 +200,7 @@ Section elems_slice_equiv.
       apply funextsec; intro p;
         apply (invmaponpathsincl pr1);
         try (apply isofhlevelfpr1;
-             intros ?; exact (pr2 (eqset _ _))).
+             intros ?; apply setproperty).
     + exact (eqtohomot ((pr1 Qisfunct) x) (pr1 p)).
     + exact (eqtohomot ((pr2 Qisfunct) x y z f g) (pr1 p)).
   Qed.
@@ -229,7 +229,7 @@ Section elems_slice_equiv.
     apply (invmaponpathsincl pr1).
     + apply isofhlevelfpr1.
       intros ?.
-      exact (pr2 (eqset _ _)).
+      apply setproperty.
     + simpl.
       destruct peq.
       unfold hfiber.
@@ -255,7 +255,7 @@ Section elems_slice_equiv.
       apply (invmaponpathsincl pr1);
       try (apply isofhlevelfpr1;
            intros ?;
-                  exact (pr2 (eqset _ _)));
+                  apply setproperty);
       simpl;
       unfold hfiber;
       unfold hfibersgftog; unfold make_hfiber;
@@ -335,7 +335,7 @@ Section elems_slice_equiv.
       apply (invmaponpathsincl pr1).
       apply isofhlevelfpr1;
         intros ?;
-               exact (pr2 (eqset _ _)).
+               apply setproperty.
       induction (!feq).
       apply (total2_paths2_f (idpath _)).
       rewrite idpath_transportf.
@@ -353,7 +353,7 @@ Section elems_slice_equiv.
     apply (invmaponpathsincl pr1).
     apply isofhlevelfpr1;
       intros ?;
-             exact (pr2 (eqset _ _)).
+             apply setproperty.
     simpl. unfold hfiber.
     rewrite transportf_total2; simpl.
     now rewrite transportf_const.
@@ -378,7 +378,7 @@ Section elems_slice_equiv.
                exact (pr2 (@eqset
                              ((slice_to_PreShv_ob_ob (PreShv_to_slice_ob ((F,, Fmor),, Fisfunct)) (X,, p'))) _ _)).
       assert (eq_id : base_paths (p',, x'') (p',, x') (maponpaths pr1 t) = idpath p').
-      { set (c := iscontraprop1 (pr2 (@eqset ((pr1 P) X) p' p')) (idpath p')).
+      { set (c := iscontraprop1 (setproperty _ _ _) (idpath p')).
         exact ((pr2 c) _ @ !((pr2 c) _)).
       }
       set (eq := fiber_paths (maponpaths pr1 t)).

--- a/UniMath/Combinatorics/OrderedSets.v
+++ b/UniMath/Combinatorics/OrderedSets.v
@@ -12,32 +12,29 @@ Definition isTotalOrder {X : hSet} (R : hrel X) : hProp
   := make_hProp (isPartialOrder R × istotal R)
                (isapropdirprod _ _ (isaprop_isPartialOrder R) (isaprop_istotal R)).
 
-Section A.
+Local Open Scope logic.
 
-  Open Scope logic.
+Lemma tot_nge_to_le {X:hSet} (R:hrel X) : istotal R -> ∏ x y, ¬ (R x y) ->  R y x.
+Proof.
+  intros tot ? ? nle.
+  now apply (hdisjtoimpl (tot x y)).
+Defined.
 
-  Lemma tot_nge_to_le {X:hSet} (R:hrel X) : istotal R -> ∏ x y, ¬ (R x y) ->  R y x.
-  Proof.
-    intros tot ? ? nle.
-    now apply (hdisjtoimpl (tot x y)).
-  Defined.
+Lemma tot_nle_iff_gt {X:hSet} (R:hrel X) :
+  isTotalOrder R -> ∏ x y, ¬ (R x y)  <->  R y x ∧ ¬ (y = x).
+(** if [R x y] is [x ≤ y], then this shows the equivalence of two definitions for [y < x] *)
+Proof.
+  intros i.
+  assert (tot := pr2 i); simpl in tot.
+  assert (refl := pr2 (pr1 (pr1 i))); simpl in refl.
+  assert (anti := pr2 (pr1 i)); simpl in anti.
+  split.
+  { intros nle. split.
+    - now apply tot_nge_to_le.
+    - intros ne. induction ne. exact (nle (refl y)). }
+  { intros yltx xley. induction yltx as [ylex neq]. exact (neq (anti _ _ ylex xley)). }
+Defined.
 
-  Lemma tot_nle_iff_gt {X:hSet} (R:hrel X) :
-    isTotalOrder R -> ∏ x y, ¬ (R x y)  <->  R y x ∧ ¬ (y = x).
-  (** if [R x y] is [x ≤ y], then this shows the equivalence of two definitions for [y < x] *)
-  Proof.
-    intros i.
-    assert (tot := pr2 i); simpl in tot.
-    assert (refl := pr2 (pr1 (pr1 i))); simpl in refl.
-    assert (anti := pr2 (pr1 i)); simpl in anti.
-    split.
-    { intros nle. split.
-      - now apply tot_nge_to_le.
-      - intros ne. induction ne. exact (nle (refl y)). }
-    { intros yltx xley. induction yltx as [ylex neq]. exact (neq (anti _ _ ylex xley)). }
-  Defined.
-
-End A.
 
 Definition isSmallest {X : Poset} (x : X) : UU := ∏ y, x ≤ y.
 
@@ -69,7 +66,7 @@ Local Arguments isPosetEquivalence : clear implicits.
 Local Arguments isaposetmorphism : clear implicits.
 
 Lemma posetStructureIdentity {X:hSet} (R S:PartialOrder X) :
-  @isPosetEquivalence (X,,R) (X,,S) (idweq X) <-> R=S.
+  @isPosetEquivalence (X,,R) (X,,S) (idweq X) <-> (R=S)%type.
 Proof.
   intros. split.
   { intros e.
@@ -324,7 +321,7 @@ Definition FiniteOrderedSetDecidableOrdering (X:FiniteOrderedSet) : DecidableRel
   λ (x y:X), decidable_to_DecidableProposition (FiniteOrderedSet_isdec_ordering x y).
 
 Definition FiniteOrderedSetDecidableEquality (X:FiniteOrderedSet) : DecidableRelation X :=
-  λ (x y:X), @decidable_to_DecidableProposition (eqset x y) (FiniteOrderedSet_isdeceq x y).
+  λ (x y:X), @decidable_to_DecidableProposition (x = y) (FiniteOrderedSet_isdeceq x y).
 
 Definition FiniteOrderedSetDecidableInequality (X:FiniteOrderedSet) : DecidableRelation X.
   intros x y.
@@ -604,8 +601,6 @@ Abort.
 (* Here we abstract from Chapter 11 of the HoTT book just the order
    properties of the real numbers, as constructed there. *)
 
-Local Open Scope logic.
-
 Definition isLattice {X:hSet} (le:hrel X) (min max:binop X) :=
   ∑ po : isPartialOrder le,
   ∑ lub : ∏ x y z, le x z ∧ le y z <-> le (max x y) z,
@@ -643,8 +638,6 @@ Section OtherProperties.
 
   Let le x y := ¬ lt y x.
   Let apart x y := lt y x ∨ lt x y.
-  Let eq x y := @eqset X x y.
-  Let ne x y := hneg (eq x y).
 
   Local Lemma apart_isirrefl : isirrefl apart.
   Proof.
@@ -664,7 +657,7 @@ Section OtherProperties.
     exact (irrefl _ n).
   Defined.
 
-  Local Lemma apart_implies_ne x y : apart x y -> ne x y.
+  Local Lemma apart_implies_ne x y : apart x y -> x != y.
   Proof.
     expand ic.
     intros a e.
@@ -681,7 +674,7 @@ Section OtherProperties.
     - intro e. induction e. apply apart_isirrefl.
   Defined.
 
-  Local Lemma ne_implies_dnegapart x y : ne x y -> ¬¬ apart x y.
+  Local Lemma ne_implies_dnegapart x y : x != y -> ¬¬ apart x y.
   Proof.
     intros n m.
     refine (n _); clear n.
@@ -692,17 +685,17 @@ Section OtherProperties.
 
     Variable lem:LEM.
 
-    Local Lemma ne_implies_apart x y : ne x y -> apart x y.
+    Local Lemma ne_implies_apart x y : x != y -> apart x y.
     Proof.
       intros a.
       apply (dneg_LEM _ lem).
       now apply ne_implies_dnegapart.
     Defined.
 
-    Local Lemma trichotomy x y : lt x y ∨ eq x y ∨ lt y x.
+    Local Lemma trichotomy x y : lt x y ∨ x = y ∨ lt y x.
     Proof.
       intros.
-      induction (lem (eq x y)) as [a|b].
+      induction (lem (x = y)) as [a|b].
       - apply hdisj_in2; apply hdisj_in1; exact a.
       - assert (l := ne_implies_apart _ _ b); clear b.
         unfold apart in l.

--- a/UniMath/Combinatorics/WellOrderedSets.v
+++ b/UniMath/Combinatorics/WellOrderedSets.v
@@ -12,7 +12,6 @@ Require Import UniMath.MoreFoundations.AxiomOfChoice.
 Require Import UniMath.Combinatorics.OrderedSets.
 
 Local Open Scope logic.
-Local Open Scope prop.
 Local Open Scope set.
 Local Open Scope subtype.
 Local Open Scope poset.
@@ -785,7 +784,7 @@ Lemma chain_union_rel_isantisymm {X : hSet} {I : UU} {S : I → WOSubset X}
   isantisymm (chain_union_rel chain).
 Proof.
   intros x y l m.
-  change (x=y)%set.
+  change (x=y)%logic.
   apply (squash_to_hProp (common_index2 chain x y)); intros [i [r s]].
   apply subtypePath_prop.
   assert (p := chain_union_rel_eqn chain x y i r s). rewrite p in l; clear p.
@@ -1208,7 +1207,7 @@ Proof.
     assert (W'guided : is_guided_WOSubset g W').
     { unfold is_guided_WOSubset.
       intros [x W'x].
-      change (x = pr1 (g (@upto' X W' (x,, W'x))))%set.
+      change (x = pr1 (g (@upto' X W' (x,, W'x))))%logic.
       apply (squash_to_hProp W'x); intros [Wx|ezx].
       - assert (x_guided := Wguided (x,,Wx)).
         change (x = pr1 (g (@upto' X W (x,, Wx))))%type in x_guided.
@@ -1292,7 +1291,7 @@ Lemma isaprop_theSmallest {X : hSet}
 Proof.
   induction total as [[po anti] tot].
   apply invproofirrelevance; intros s t. apply subtypePath_prop.
-  induction s as [x i], t as [y j], i as [I i], j as [J j]. change (x=y)%set.
+  induction s as [x i], t as [y j], i as [I i], j as [J j]. change (x=y)%logic.
   apply (squash_to_hProp (tot x y)); intros [c|c].
   { apply anti. { exact c. } { exact (j x I). } }
   { apply anti. { exact (i y J). } { exact c. } }

--- a/UniMath/Combinatorics/ZFstructures.v
+++ b/UniMath/Combinatorics/ZFstructures.v
@@ -30,8 +30,9 @@ Require Export UniMath.Combinatorics.OrderedSets.
 
 Require Export UniMath.MoreFoundations.DecidablePropositions.
 Require Export UniMath.MoreFoundations.Propositions.
-Local Open Scope logic.
 
+Local Open Scope logic.
+Local Open Scope type.
 
 (*** Auxilliary Lemmas ***)
 

--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -232,7 +232,7 @@ Definition neg (X : UU) : UU := X -> empty.
 Notation "'¬' X" := (neg X).
 (* type this in emacs in agda-input method with \neg *)
 
-Notation "x != y" := (neg (x = y)).
+Notation "x != y" := (neg (x = y)) : type_scope.
 
 Definition negf {X Y : UU} (f : X -> Y) : ¬ Y -> ¬ X := λ phi x, phi (f x).
 
@@ -1225,7 +1225,7 @@ Defined.
 
 Definition weq (X Y : UU) : UU := ∑ f:X->Y, isweq f.
 
-Notation "X ≃ Y" := (weq X Y) : type_scope.
+Notation "X ≃ Y" := (weq X%type Y%type) : type_scope.
 (* written \~- or \simeq in Agda input method *)
 
 Definition pr1weq {X Y : UU} := pr1 : X ≃ Y -> (X -> Y).

--- a/UniMath/Foundations/Sets.v
+++ b/UniMath/Foundations/Sets.v
@@ -87,13 +87,12 @@ Coercion pr1hSet: hSet >-> UU.
 
 Definition eqset {X : hSet} (x x' : X) : hProp
   := make_hProp (x = x') (pr2 X x x').
-Declare Scope set.
-Notation "a = b" := (eqset a b) (at level 70, no associativity) : set.
+
+Notation "a = b" := (eqset a b) (at level 70, no associativity) : logic.
 
 Definition neqset {X : hSet} (x x' : X) : hProp
   := make_hProp (x != x') (isapropneg _). (* uses funextemptyAxiom *)
-Notation "a != b" := (neqset a b) (at level 70, no associativity) : set.
-Delimit Scope set with set.
+Notation "a != b" := (neqset a b) (at level 70, no associativity) : logic.
 
 Definition setproperty (X : hSet) := pr2 X.
 
@@ -121,6 +120,8 @@ Definition total2_hSet {X : hSet} (Y : X -> hSet) : hSet
 Definition hfiber_hSet {X Y : hSet} (f : X → Y) (y : Y) : hSet
   := make_hSet (hfiber f y) (isaset_hfiber f y (pr2 X) (pr2 Y)).
 
+
+Declare Scope set.
 Delimit Scope set with set.
 
 Notation "'∑' x .. y , P" := (total2_hSet (λ x,.. (total2_hSet (λ y, P))..))

--- a/UniMath/MoreFoundations/AxiomOfChoice.v
+++ b/UniMath/MoreFoundations/AxiomOfChoice.v
@@ -50,8 +50,6 @@ Defined.
 
 Local Open Scope logic.
 
-Local Open Scope set.
-
 (** We write these axioms as types rather than as axioms, which would assert them to be true, to
     force them to be mentioned as explicit hypotheses whenever they are used. *)
 

--- a/UniMath/MoreFoundations/Notations.v
+++ b/UniMath/MoreFoundations/Notations.v
@@ -4,9 +4,7 @@ Require Export UniMath.Foundations.All.
 
 Notation "A ⇒ B" := (himpl A B) : logic.
 
-Local Open Scope logic.
-
-Definition hequiv (P Q:hProp) : hProp := (P ⇒ Q) ∧ (Q ⇒ P).
+Definition hequiv (P Q:hProp) : hProp := ((P ⇒ Q) ∧ (Q ⇒ P))%logic.
 
 Notation "A ⇔ B" := (hequiv A B) (at level 95, no associativity) : logic.
 

--- a/UniMath/MoreFoundations/Propositions.v
+++ b/UniMath/MoreFoundations/Propositions.v
@@ -4,6 +4,7 @@ Require Export UniMath.MoreFoundations.Tactics.
 Require Export UniMath.MoreFoundations.DecidablePropositions.
 
 Local Open Scope logic.
+Local Open Scope type.
 
 Lemma ishinh_irrel {X:UU} (x:X) (x':∥X∥) : hinhpr x = x'.
 Proof.
@@ -118,7 +119,7 @@ Abort.
 
 (* here's another version *)
 Goal ∏ (X:Type)
-     (P := λ x':∥X∥, ∃ x, x' = hinhpr x)
+     (P := λ x':∥X∥, ∃ x, (x' = hinhpr x))
      (h := λ x, (hinhpr (x,,idpath _) : P (hinhpr x)))
      (x:X),
   squash_rec _ h (hinhpr x) = h x.

--- a/UniMath/MoreFoundations/Sets.v
+++ b/UniMath/MoreFoundations/Sets.v
@@ -11,7 +11,7 @@ Require Export UniMath.Foundations.Sets.
   - Subsets
  *)
 
-Local Open Scope set.
+Local Open Scope logic.
 
 Definition hProp_set : hSet := make_hSet _ isasethProp.
 

--- a/UniMath/MoreFoundations/Sets.v
+++ b/UniMath/MoreFoundations/Sets.v
@@ -23,7 +23,7 @@ Proof.
 Defined.
 
 Definition isconst_2 {X Y:UU} {Z:hSet} (f : X -> Y -> Z) : hProp :=
-  (∀ x x' y y', f x y = f x' y')%set.
+  ∀ x x' y y', f x y = f x' y'.
 
 Definition squash_to_hSet_2 {X Y : UU} {Z : hSet} (f : X -> Y -> Z) :
   isconst_2 f -> ∥ X ∥ -> ∥ Y ∥ -> Z.
@@ -40,11 +40,9 @@ Proof.
 Defined.
 
 Definition isconst_2' {X Y:UU} {Z:hSet} (f : X -> Y -> Z) : hProp :=
-  (
     (∀ x x' y, f x y = f x' y)
     ∧
-    (∀ x y y', f x y = f x y')
-  )%set.
+    (∀ x y y', f x y = f x y').
 
 Definition squash_to_hSet_2' {X Y : UU} {Z : hSet} (f : X -> Y -> Z) :
   isconst_2' f -> ∥ X ∥ -> ∥ Y ∥ -> Z.
@@ -60,7 +58,7 @@ Proof.
     induction e. change ( f x y = f x' y ). exact (c x x' y). }
 Defined.
 
-Definition eqset_to_path {X:hSet} (x y:X) : eqset x y -> x = y := λ e, e.
+Definition eqset_to_path {X:hSet} (x y:X) : eqset x y -> paths x y := λ e, e.
 
 Lemma isapropiscomprelfun {X : UU} {Y : hSet} (R : hrel X) (f : X -> Y) : isaprop (iscomprelfun R f).
 Proof.
@@ -118,7 +116,7 @@ Definition same_fiber_eqrel {X Y : hSet} (f : X → Y) : eqrel X.
 Proof.
   use make_eqrel.
   - intros x y.
-    exact (eqset (f x) (f y)).
+    exact ((f x) = (f y)).
   - use iseqrelconstr.
     + intros ? ? ? xy yz; exact (xy @ yz).
     + intro; reflexivity.

--- a/UniMath/MoreFoundations/Subtypes.v
+++ b/UniMath/MoreFoundations/Subtypes.v
@@ -7,6 +7,7 @@ Delimit Scope subtype with subtype.
 Local Open Scope subtype.
 
 Local Open Scope logic.
+Local Open Scope type.
 
 (** The powerset, or set of all subsets, of a set. *)
 Definition subtype_set X : hSet := make_hSet (hsubtype X) (isasethsubtype X).
@@ -33,8 +34,6 @@ Notation " S ⊈ T " := (subtype_notContainedIn S T) (at level 70) : subtype.
 Definition subtype_smallerThan {X:UU} (S T : hsubtype X) : hProp := (S ⊆ T) ∧ (T ⊈ S).
 
 Notation " S ⊊ T " := (subtype_smallerThan S T) (at level 70) : subtype.
-
-Local Open Scope logic.
 
 Definition subtype_equal {X:UU} (S T : hsubtype X) : hProp := ∀ x, S x ⇔ T x.
 


### PR DESCRIPTION
Currently, the notation of `x = y` for `eqset x y` (i.e. the `hProp` of paths in a `hSet`) lives in the scope `set`.

This seems a bit odd, and often inconvenient.  The scope `set` is otherwise for constructions producing sets, e.g. `total2_hSet`, whereas `eqset` produces a proposition, and is used most when working in the prop-valued logic.  So it seems like this notation for `eqset` should live in scope `logic`, with notations like `p ∧ q` and `p ∨ q`.

In this PR, I’ve tried out that change (and the same for `!=` as `neqset`), and updated various files to make use of the notation (since it no longer requires scope-juggling).  As hoped, it gives (I think) much better readability in many places, especially in `Algebra` — do others agree?

(Besides what shows up in this PR, I was prompted to make this change by getting annoyed by the scope-juggling needed in https://github.com/peterlefanulumsdaine/UniMath/tree/bourbaki-witt , where I’ve been working on formalising fixed-point theorems. I think this scope change will be very useful there.)

One caveat: I know we generally want to be *very* conservative about making changes to files in `Foundations`.  However, I think changing the scope of a couple of notations doesn’t affect Vladimir’s mathematical or expository intent, so seems to me worthwhile in this instance.