### PR TITLE
Improve reduction behaviour of funcomp and idfun

### DIFF
--- a/UniMath/Algebra/BinaryOperations.v
+++ b/UniMath/Algebra/BinaryOperations.v
@@ -33,7 +33,6 @@
 (** Imports *)
 
 Require Export UniMath.Foundations.Sets.
-Require Import UniMath.MoreFoundations.PartA.
 
 Local Open Scope logic.
 

--- a/UniMath/Algebra/BinaryOperations.v
+++ b/UniMath/Algebra/BinaryOperations.v
@@ -33,6 +33,7 @@
 (** Imports *)
 
 Require Export UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.PartA.
 
 Local Open Scope logic.
 
@@ -1385,7 +1386,7 @@ Lemma isbinopfuncomp {X Y Z : setwithbinop} (f : binopfun X Y) (g : binopfun Y Z
   isbinopfun (funcomp (pr1 f) (pr1 g)).
 Proof.
   set (axf := pr2 f). set (axg := pr2 g).
-  intros a b. unfold funcomp.
+  intros a b. simpl.
   rewrite (axf a b). rewrite (axg (pr1 f a) (pr1 f b)).
   apply idpath.
 Defined.
@@ -1527,7 +1528,7 @@ Proof.
   apply (isincltwooutof3a (λ x0 : X, op x x0) f (pr2 (pr1 f))).
   assert (h : homot (funcomp f (λ y0 : Y, op (f x) y0)) (funcomp (λ x0 : X, op x x0) f)).
   {
-    intro x0. unfold funcomp. apply (pathsinv0 ((pr2 f) x x0)).
+    intro x0; simpl. apply (pathsinv0 ((pr2 f) x x0)).
   }
   apply (isinclhomot _ _ h).
   apply (isinclcomp f (make_incl _ is)).
@@ -1540,7 +1541,7 @@ Proof.
   apply (isincltwooutof3a (λ x0 : X, op x0 x) f (pr2 (pr1 f))).
   assert (h : homot (funcomp f (λ y0 : Y, op y0 (f x))) (funcomp (λ x0 : X, op x0 x) f)).
   {
-    intro x0. unfold funcomp. apply (pathsinv0 ((pr2 f) x0 x)).
+    intro x0; simpl. apply (pathsinv0 ((pr2 f) x0 x)).
   }
   apply (isinclhomot _ _ h). apply (isinclcomp f (make_incl _ is)).
 Defined.
@@ -1561,7 +1562,7 @@ Proof.
   unfold islinvertible. apply (twooutof3a (λ x0 : X, op x x0) f).
   - assert (h : homot (funcomp f (λ y0 : Y, op (f x) y0)) (funcomp (λ x0 : X, op x x0) f)).
     {
-      intro x0. unfold funcomp. apply (pathsinv0 ((pr2 f) x x0)).
+      intro x0; simpl. apply (pathsinv0 ((pr2 f) x x0)).
     }
     apply (isweqhomot _ _ h). apply (pr2 (weqcomp f (make_weq _ is))).
   - apply (pr2 (pr1 f)).
@@ -1573,7 +1574,7 @@ Proof.
   unfold islinvertible. apply (twooutof3a (λ x0 : X, op x0 x) f).
   - assert (h : homot (funcomp f (λ y0 : Y, op y0 (f x))) (funcomp (λ x0 : X, op x0 x) f)).
     {
-      intro x0. unfold funcomp. apply (pathsinv0 ((pr2 f) x0 x)).
+      intro x0; simpl. apply (pathsinv0 ((pr2 f) x0 x)).
     }
     apply (isweqhomot _ _ h). apply (pr2 (weqcomp f (make_weq _ is))).
   - apply (pr2 (pr1 f)).
@@ -1592,7 +1593,7 @@ Proof.
   - apply (pr2 (pr1 f)).
   - assert (h : homot (funcomp (λ x0 : X, op x x0) f) (λ x0 : X, op (f x) (f x0))).
     {
-      intro x0. unfold funcomp. apply (pr2 f x x0).
+      intro x0; simpl. apply (pr2 f x x0).
     }
     apply (isweqhomot _ _ h). apply (pr2 (weqcomp (make_weq _ is) f)).
 Defined.
@@ -1604,7 +1605,7 @@ Proof.
   - apply (pr2 (pr1 f)).
   - assert (h : homot (funcomp (λ x0 : X, op x0 x) f) (λ x0 : X, op (f x0) (f x))).
     {
-      intro x0. unfold funcomp. apply (pr2 f x0 x).
+      intro x0; simpl. apply (pr2 f x0 x).
     }
     apply (isweqhomot _ _ h). apply (pr2 (weqcomp (make_weq _ is) f)).
 Defined.
@@ -1688,7 +1689,7 @@ Lemma isinvisof {X Y : setwithbinop} (f : binopiso X Y) (unx : X) (invx : X -> X
   isinv (@op Y) (pr1 f unx) (funcomp (invmap (pr1 f)) (funcomp invx (pr1 f))).
 Proof.
   set (axf := pr2 f). set (axinvf := pr2 (invbinopiso f)).
-  simpl in axf. simpl in axinvf. unfold funcomp. split.
+  simpl in axf, axinvf. split.
   - intro a. apply (invmaponpathsweq (pr1 (invbinopiso f))).
     simpl. rewrite (axinvf ((pr1 f) (invx (invmap (pr1 f) a))) a).
     rewrite (homotinvweqweq (pr1 f) unx).
@@ -2291,10 +2292,10 @@ Proof.
   set (ax1f := pr1 (pr2 f)). set (ax2f := pr2 (pr2 f)).
   set (ax1g := pr1 (pr2 g)). set (ax2g := pr2 (pr2 g)).
   split.
-  - intros a b. unfold funcomp.
+  - intros a b. simpl.
     rewrite (ax1f a b). rewrite (ax1g (pr1 f a) (pr1 f b)).
     apply idpath.
-  - intros a b. unfold funcomp.
+  - intros a b. simpl.
     rewrite (ax2f a b). rewrite (ax2g (pr1 f a) (pr1 f b)).
     apply idpath.
 Defined.

--- a/UniMath/Algebra/Dcpo.v
+++ b/UniMath/Algebra/Dcpo.v
@@ -22,6 +22,7 @@ Refactored: January 2019
 *)
 
 Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.PartA.
 
 Local Open Scope poset. (* So we can write ≤ *)
 
@@ -238,7 +239,7 @@ Proof.
   use mkdcpomorphism.
   - exact (λ _, e).
   - intros I u isdirec v islubv. split.
-    + intro i. unfold funcomp; simpl. apply isrefl_posetRelation.
+    + intro i. simpl. apply isrefl_posetRelation.
     + intros d' ineqs. apply (@factor_through_squash I).
       * apply propproperty.
       * intro i. exact (ineqs i).
@@ -509,7 +510,7 @@ Proof.
     eapply dcpomorphism_preserveslub.
     + exact isdirec'.
     + exact islubu'.
-    + intro j; unfold funcomp.
+    + intro j. simpl.
       use factor_through_squash.
       * exact (directeduntruncated F i j).
       * apply propproperty.
@@ -530,7 +531,7 @@ Proof.
   intros n I F isdirec g islubg.
   induction n as [| m IH].
   - split.
-    + intro i. unfold funcomp; simpl. apply dcpowithbottom_isMinimal.
+    + intro i. simpl. apply dcpowithbottom_isMinimal.
     + intros y ineqs. apply dcpowithbottom_isMinimal.
   - simpl. eapply doublelubdirected.
     + exact isdirec.
@@ -601,7 +602,7 @@ Proof.
     eapply dcpomorphism_preserveslub.
     + exact isdirec.
     + apply pointwiselub_islubpointwise.
-    + intro n. unfold funcomp.
+    + intro n. simpl.
       eapply (istrans_posetRelation _ _ (pointwisefamily iter' f (S n)) _).
       * apply isrefl_posetRelation.
       * apply pointwiselub_islubpointwise.

--- a/UniMath/Algebra/Dcpo.v
+++ b/UniMath/Algebra/Dcpo.v
@@ -22,7 +22,6 @@ Refactored: January 2019
 *)
 
 Require Import UniMath.Foundations.All.
-Require Import UniMath.MoreFoundations.PartA.
 
 Local Open Scope poset. (* So we can write ≤ *)
 

--- a/UniMath/Algebra/Free_Monoids_and_Groups.v
+++ b/UniMath/Algebra/Free_Monoids_and_Groups.v
@@ -94,7 +94,7 @@ Lemma free_monoid_extend_funcomp {X Y : hSet} {Z : monoid} (f : X → Y) (g : Y 
 Proof.
   unfold homot. simpl. apply list_ind.
     + reflexivity.
-    + intros x xs IH. unfold funcomp in *. now rewrite !map_cons, !iterop_list_mon_step, IH.
+    + intros x xs IH. now rewrite !map_cons, !iterop_list_mon_step, IH.
 Defined.
 
 (** Functoriality of the [free_monoidfun] *)

--- a/UniMath/Algebra/GroupAction.v
+++ b/UniMath/Algebra/GroupAction.v
@@ -83,7 +83,7 @@ Definition is_equivariant_identity {G:gr} {X Y:Action G}
 Proof.
   revert X Y p; intros [X [Xm [Xu Xa]]] [Y [Ym [Yu Ya]]] ? .
   (* should just apply hPropUnivalence at this point, as in Poset_univalence_prelim! *)
-  simpl in p. destruct p; simpl. unfold transportf; simpl. unfold idfun; simpl.
+  simpl in p. destruct p; simpl. unfold transportf; simpl.
   simple refine (make_weq _ _).
   { intros p g x. simpl in x. simpl.
     exact (eqtohomot (eqtohomot (maponpaths act_mult p) g) x). }

--- a/UniMath/Algebra/IteratedBinaryOperations.v
+++ b/UniMath/Algebra/IteratedBinaryOperations.v
@@ -127,7 +127,7 @@ Section BinaryOperations.
     rewrite append_vec_compute_2.
     apply (maponpaths (λ x, op (iterop_fun x) y)).
     apply funextfun; intro i.
-    unfold funcomp.
+    simpl.
     rewrite append_vec_compute_1.
     reflexivity.
   Defined.
@@ -197,7 +197,6 @@ Section Monoids.
      apply (maponpaths (λ a, a * m)).
      apply (maponpaths (λ x, iterop_seq_mon (n,,x))).
      apply funextfun; intros [i b]; simpl.
-     unfold funcomp.
      now rewrite append_vec_compute_1.
   Defined.
 
@@ -332,7 +331,7 @@ Proof.
   set (x' := x ∘ r).
   intermediate_path (iterop_seq_mon (stnsum f,, x')).
   { induction B. apply iterop_seq_mon_homot. intros i. unfold x'.
-    unfold funcomp. apply maponpaths.
+    simpl. apply maponpaths.
     apply ( invmaponpathsincl _ ( isinclstntonat _ ) _ _).
     reflexivity. }
   unfold iterop_seq_mon. unfold iterop_seq.
@@ -340,9 +339,8 @@ Proof.
   unfold partition.
   rewrite 3 iterop_seq_seq_mon_step.
   change (iterop_seq_seq_mon (0,,_)) with (unel M); rewrite lunax.
-  unfold funcomp at 1 2.
   set (s0 := dni lastelement (dni lastelement (@lastelement 0))).
-  unfold funcomp at 1.
+  unfold funcomp at 1 2 3.
   set (s1 := dni lastelement (@lastelement 1)).
   set (s2 := @lastelement 2).
   unfold partition'. unfold inverse_lexicalEnumeration.
@@ -386,12 +384,12 @@ Proof.
         { apply fromempty. exact (negnatlthplusnmn j i c). }
         { change_rhs (1 + (j + i)). rewrite <- natplusassoc. rewrite (natpluscomm j 1).
           reflexivity. } } }
-    unfold x'. unfold funcomp. apply maponpaths.
+    unfold x'; simpl. apply maponpaths.
     apply subtypePath_prop. change (j+0 = j). apply natplusr0. }
   { apply (maponpaths (λ k, k * _)). induction (!B').
     change_rhs (iterop_seq_mon (n,, x ∘ dni (j,, jlt))).
     apply iterop_seq_mon_homot; intros i.
-    unfold x''. unfold funcomp. apply maponpaths.
+    unfold x''; simpl. apply maponpaths.
     apply ( invmaponpathsincl _ ( isinclstntonat _ ) _ _).
     reflexivity. }
 Qed.
@@ -418,7 +416,6 @@ Proof.
       induction j as [j J]. unfold g, i, f', g', stntonat.
       rewrite <- (weqdnicompl_compute i').
       unfold pr1compl_ne.
-      unfold funcomp.
       rewrite homotweqinvweq.
       rewrite (weqoncompl_ne_compute f i (stnneq i) (stnneq i') _).
       apply maponpaths, maponpaths.
@@ -524,7 +521,7 @@ Proof.
   assert (w := commutativityOfProducts (m ∘ x') (invweq x' ∘ x)%weq).
   simple refine (_ @ ! w); clear w. unfold iterop_seq_mon, iterop_fun_mon, iterop_seq.
   apply maponpaths. rewrite weqcomp_to_funcomp. apply funextfun; intro i.
-  unfold funcomp. simpl. apply maponpaths. exact (! homotweqinvweq x' (x i)).
+  simpl. apply maponpaths. exact (! homotweqinvweq x' (x i)).
 Defined.
 
 Definition iterop_unoseq_abgr {G:abgr} : MultipleOperation G.

--- a/UniMath/Algebra/Modules/Core.v
+++ b/UniMath/Algebra/Modules/Core.v
@@ -442,8 +442,7 @@ Definition linearfun_islinear {R} {M N : module R} (f : linearfun M N) :
 Lemma islinearfuncomp {R : ring} {M N P : module R} (f : linearfun M N) (g : linearfun N P) :
   islinear (funcomp f g).
 Proof.
-  intros r x.
-  unfold funcomp.
+  intros r x; simpl.
   rewrite (linearfun_islinear f).
   rewrite (linearfun_islinear g).
   apply idpath.

--- a/UniMath/Algebra/Modules/Examples.v
+++ b/UniMath/Algebra/Modules/Examples.v
@@ -141,12 +141,12 @@ Example commring_bimodule (R : commring) : bimodule R R.
             (ringfun_module
                (rigisotorigfun (invrigiso (iso_commring_opposite R)))),, _).
 
-  unfold funcomp; cbn.
+  simpl.
   intros r s.
   apply funextfun.
   intros x.
   exact (!@rigassoc2 R r s x @ (maponpaths (fun z => z * x) (@ringcomm2 R r s))
                       @ (rigassoc2 R s r x)).
-Defined. (* TODO: this line takes a while, not sure why *)
+  Time Defined. (* TODO: this line takes a while, not sure why *)
 
 Local Close Scope ring.

--- a/UniMath/Algebra/Modules/Examples.v
+++ b/UniMath/Algebra/Modules/Examples.v
@@ -147,6 +147,6 @@ Example commring_bimodule (R : commring) : bimodule R R.
   intros x.
   exact (!@rigassoc2 R r s x @ (maponpaths (fun z => z * x) (@ringcomm2 R r s))
                       @ (rigassoc2 R s r x)).
-  Time Defined. (* TODO: this line takes a while, not sure why *)
+  Defined. (* TODO: this line takes a while, not sure why *)
 
 Local Close Scope ring.

--- a/UniMath/Algebra/Modules/Quotient.v
+++ b/UniMath/Algebra/Modules/Quotient.v
@@ -172,7 +172,7 @@ Section quotmod_def.
       (* We show this using the universal property of the set quotient. *)
       all: use (setquotunivprop E (λ m, make_hProp _ _)); [use isasetsetquot|].
       (* Expand out some definitions. *)
-      all: intros m; simpl; unfold unel, quotmod_ringact, funcomp.
+      all: intros m; simpl; unfold unel, quotmod_ringact.
       (* Apply the computation rule of the universal property of the set quotient. *)
       all: [> do 3 rewrite (setquotunivcomm E) | rewrite (setquotunivcomm E)
             | do 3 rewrite (setquotunivcomm E) | rewrite (setquotunivcomm E)].

--- a/UniMath/Algebra/Monoids.v
+++ b/UniMath/Algebra/Monoids.v
@@ -166,7 +166,7 @@ Lemma ismonoidfuncomp {X Y Z : monoid} (f : monoidfun X Y) (g : monoidfun Y Z) :
   ismonoidfun (funcomp (pr1 f) (pr1 g)).
 Proof.
   split with (isbinopfuncomp f g).
-  unfold funcomp. rewrite (pr2 (pr2 f)).
+  simpl. rewrite (pr2 (pr2 f)).
   apply (pr2 (pr2 g)).
 Defined.
 Opaque ismonoidfuncomp.

--- a/UniMath/Algebra/Universal/Terms.v
+++ b/UniMath/Algebra/Universal/Terms.v
@@ -82,7 +82,7 @@ Section Oplists.
     : ((opexec nm (just ss) = nothing) × (prefix_remove (arity nm) ss = nothing))
               ⨿  ∑ (ss': list (sorts σ)), (opexec nm (just ss) = just ((sort nm) :: ss')) × (prefix_remove (arity nm) ss = just ss').
   Proof.
-    unfold opexec, funcomp, just.
+    unfold opexec, just.
     simpl.
     induction (prefix_remove (arity nm) ss) as [ ss' | error ].
     - apply ii2.
@@ -207,7 +207,7 @@ Section Oplists.
       rewrite scons.
       simpl.
       rewrite concatenateStep.
-      unfold opexec, funcomp.
+      unfold opexec.
       simpl.
       erewrite prefix_remove_concatenate.
       * apply idpath.
@@ -375,7 +375,7 @@ Section Oplists.
              apply natlehnplusnm.
         * rewrite oplistexec_cons.
           rewrite t1def.
-          unfold opexec, funcomp.
+          unfold opexec.
           simpl.
           rewrite prefix_remove_drop.
           -- simpl.

--- a/UniMath/Bicategories/Core/TransportLaws.v
+++ b/UniMath/Bicategories/Core/TransportLaws.v
@@ -32,7 +32,6 @@ Definition transport_one_cell_FlFr
       ∘ (idtoiso_2_0 _ _ (maponpaths f (!p))).
 Proof.
   induction p ; cbn.
-  unfold idfun.
   exact (linvunitor _ o rinvunitor _).
 Defined.
 
@@ -50,7 +49,6 @@ Definition transport_one_cell_FlFr_inv
       (transportf (λ (z : A), C⟦f z,g z⟧) p h).
 Proof.
   induction p ; cbn.
-  unfold idfun.
   exact (runitor _ o lunitor _).
 Defined.
 
@@ -66,13 +64,11 @@ Proof.
   refine (transport_one_cell_FlFr_inv f g p h ,, _).
   split ; cbn.
   - induction p ; cbn.
-    unfold idfun.
     rewrite <- !vassocr.
     rewrite !(maponpaths (λ z, _ • z) (vassocr _ _ _)).
     rewrite linvunitor_lunitor, id2_left.
     apply rinvunitor_runitor.
   - induction p ; cbn.
-    unfold idfun.
     rewrite <- !vassocr.
     rewrite !(maponpaths (λ z, _ • z) (vassocr _ _ _)).
     rewrite runitor_rinvunitor, id2_left.

--- a/UniMath/Bicategories/DisplayedBicats/DispPseudofunctor.v
+++ b/UniMath/Bicategories/DisplayedBicats/DispPseudofunctor.v
@@ -577,7 +577,7 @@ Section FiberOfFunctor.
                HD₂_2_1 (idpath _)
                _ _
                (pr22 (pr221 F) c c c (id₁ c) (id₁ c) x y z f g))) as p.
-      cbn in p ; unfold idfun in p.
+      cbn in p.
       rewrite p ; clear p.
       pose (disp_local_iso_cleaving_invertible_2cell
               h₂

--- a/UniMath/Bicategories/DisplayedBicats/Examples/Add2Cell.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/Add2Cell.v
@@ -173,7 +173,7 @@ Section Add2Cell.
         (intros x xx yy;
          intros p;
          induction p as [p q];
-         cbn ; unfold idfun;
+         cbn;
          cbn in p, q;
          pose (pstrans_id_alt l) as pl;
          cbn in pl ; rewrite pl in p ; clear pl;

--- a/UniMath/Bicategories/DisplayedBicats/Examples/Algebras.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/Algebras.v
@@ -522,7 +522,7 @@ Section Algebra.
     intros a b f g p aa bb ff gg.
     induction p.
     apply isweqimplimpl.
-    - cbn ; unfold idfun.
+    - cbn.
       intros x.
       pose (pr1 x) as d.
       cbn in *.
@@ -1100,7 +1100,7 @@ Section Algebra.
     use weqhomot.
     - exact (disp_alg_bicat_adjoint_equivalence_weq HC aa bb ∘ (_ ,, HC _ _ aa bb))%weq.
     - intros p.
-      induction p ; cbn ; unfold idfun.
+      induction p ; cbn.
       use subtypePath.
       + intro ; simpl.
         apply (@isaprop_disp_left_adjoint_equivalence C disp_alg_bicat).

--- a/UniMath/Bicategories/DisplayedBicats/Examples/ContravariantFunctor.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/ContravariantFunctor.v
@@ -175,7 +175,7 @@ Section fix_a_category.
     apply fiberwise_local_univalent_is_univalent_2_1.
     intros C D F CD FC α β.
     use isweqimplimpl.
-    - intro p ; cbn in * ; unfold idfun in *.
+    - intro p ; cbn in *.
       apply nat_trans_eq.
       { apply K. }
       intro x.

--- a/UniMath/Bicategories/DisplayedBicats/Examples/DisplayedCatToBicat.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/DisplayedCatToBicat.v
@@ -84,8 +84,7 @@ Section Disp_Prebicat_Cells_Unit.
   Proof.
     intros a b f g p aa bb ff gg.
     use isweqimplimpl.
-    - unfold idfun.
-      cbn in *.
+    - cbn in *.
       intros.
       apply H.
     - apply isasetaprop.
@@ -212,7 +211,7 @@ Section Disp_Prebicat_Cells_Unit.
         ×
         (bb -->[ left_adjoint_right_adjoint (idtoiso_2_0 _ _ p)] aa).
   Proof.
-    induction p ; cbn ; unfold idfun.
+    induction p ; cbn.
     intros pp.
     induction pp ; cbn.
     split ; apply id_disp.
@@ -234,7 +233,7 @@ Section Disp_Prebicat_Cells_Unit.
     apply fiberwise_univalent_2_0_to_disp_univalent_2_0.
     intros a aa bb.
     use isweqimplimpl.
-    - intro η ; cbn ; unfold idfun.
+    - intro η ; cbn.
       apply inv.
       exact (invmap (disp_cell_unit_bicat_adjoint_equivalent
                        (idtoiso_2_0 a a (idpath a))

--- a/UniMath/Bicategories/DisplayedBicats/Examples/PointedOneTypes.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/PointedOneTypes.v
@@ -104,7 +104,7 @@ Lemma p1types_disp_univalent_2_0 : disp_univalent_2_0 p1types_disp.
 Proof.
   apply fiberwise_univalent_2_0_to_disp_univalent_2_0.
   intros X x x'. cbn in *.
-  use gradth; unfold idfun.
+  use gradth.
   - intros f. apply f.
   - intro p.
     induction p.

--- a/UniMath/Bicategories/DisplayedBicats/Examples/Prod.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/Prod.v
@@ -450,7 +450,7 @@ Section Disp_Dirprod.
               (_ ,, HD1 a b f g p (pr1 aa) (pr1 bb) (pr1 ff) (pr1 gg))
               (_ ,, HD2 a b f g p (pr2 aa) (pr2 bb) (pr2 ff) (pr2 gg))
               ∘ _)%weq.
-    induction p ; cbn ; unfold idfun.
+    induction p ; cbn.
     apply WeakEquivalences.pathsdirprodweq.
   Defined.
 
@@ -740,7 +740,7 @@ Section Disp_Dirprod.
               (_ ,, pr1 HD1 a b p (pr1 aa) (pr1 bb))
               (_ ,, pr1 HD2 a b p (pr2 aa) (pr2 bb))
               ∘ _)%weq.
-    induction p ; cbn ; unfold idfun.
+    induction p ; cbn.
     apply WeakEquivalences.pathsdirprodweq.
   Defined.
 

--- a/UniMath/Bicategories/DisplayedBicats/Examples/Sigma.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/Sigma.v
@@ -768,7 +768,7 @@ Section SigmaDisplayedUnivalent.
     apply fiberwise_local_univalent_is_univalent_2_1.
     intros x y f xx yy ff gg.
     use weqhomot.
-    - cbn ; unfold idfun.
+    - cbn.
       refine (_ ∘ total2_paths_equiv _ _ _)%weq.
       refine (pair_disp_invertible_to_sigma_disp_invertible_weq _ _ ∘ _)%weq.
       induction ff as [ff1 ff2] ; induction gg as [gg1 gg2].
@@ -777,13 +777,13 @@ Section SigmaDisplayedUnivalent.
                    _
                    (HD₁_2_1 _ _ _ _ (idpath _) _ _ ff1 gg1))
                 _).
-      intro p ; cbn in p ; unfold idfun in p.
+      intro p ; cbn in p.
       induction p.
       exact (make_weq
                _
                (HD₂_2_1 _ _ _ _ (idpath _) _ _ ff2 gg2)).
     - intros p.
-      cbn in p ; unfold idfun in p.
+      cbn in p.
       induction p.
       use subtypePath.
       { intro ; apply isaprop_is_disp_invertible_2cell. }
@@ -1084,9 +1084,9 @@ Section SigmaDisplayedUnivalent.
               _)%weq.
     induction xx as [xx1 xx2].
     induction yy as [yy1 yy2].
-    intro p ; cbn in p ; unfold idfun in p.
+    intro p ; cbn in p.
     induction p.
-    unfold transportf ; simpl ; unfold idfun.
+    unfold transportf ; simpl.
     refine (_ ∘ make_weq
               _
               (HD₂_2_0 _ _ (idpath (x ,, xx1)) xx2 yy2))%weq.
@@ -1103,7 +1103,7 @@ Section SigmaDisplayedUnivalent.
     use weqhomot.
     - exact (sigma_idtoiso_2_0_alt HD₁_2_0 HD₂_2_0 xx yy).
     - intros p.
-      cbn in p ; unfold idfun in p.
+      cbn in p.
       induction p.
       use subtypePath.
       { intro ; apply isaprop_disp_left_adjoint_equivalence.

--- a/UniMath/Bicategories/PseudoFunctors/Display/Base.v
+++ b/UniMath/Bicategories/PseudoFunctors/Display/Base.v
@@ -296,7 +296,7 @@ Section BasePseudoFunctor.
       apply funextsec ; intro X.
       use total2_paths_b.
       + reflexivity.
-      + cbn ; unfold idfun.
+      + cbn.
         use subtypePath.
         {
           intro.
@@ -307,7 +307,7 @@ Section BasePseudoFunctor.
     - intros η.
       use total2_paths_b.
       + reflexivity.
-      + cbn ; unfold idfun.
+      + cbn.
         use subtypePath.
         {
           intro.

--- a/UniMath/Bicategories/PseudoFunctors/Display/Map1Cells.v
+++ b/UniMath/Bicategories/PseudoFunctors/Display/Map1Cells.v
@@ -346,7 +346,7 @@ Section Map1Cells.
     apply fiberwise_local_univalent_is_univalent_2_1.
     intros F G η F₁ G₁ η₁ η₁'.
     use isweqimplimpl.
-    - intro m ; cbn in * ; unfold idfun.
+    - intro m ; cbn in *.
       apply funextsec ; intro X.
       apply funextsec ; intro Y.
       apply funextsec ; intro f.
@@ -625,7 +625,7 @@ Section Map1Cells.
       apply funextsec ; intro f.
       apply subtypePath.
       { intro ; apply isaprop_is_invertible_2cell. }
-      cbn ; unfold idfun.
+      cbn.
       rewrite id2_right.
       reflexivity.
   Defined.

--- a/UniMath/CategoryTheory/CategoryEquality.v
+++ b/UniMath/CategoryTheory/CategoryEquality.v
@@ -59,7 +59,7 @@ Proof.
     induction C as [C HC].
     induction D as [D HD].
     cbn in *.
-    induction p ; cbn ; unfold idfun.
+    induction p ; cbn.
     refine (_ ∘ total2_paths_equiv _ _ _)%weq.
     use weqfibtototal.
     intros p.
@@ -124,7 +124,7 @@ Proof.
     induction p as [p1 p2] ; cbn in *.
     unfold data_cat_eq_1 in p2.
     induction p1 ; cbn in *.
-    induction p2 ; cbn ; unfold idfun.
+    induction p2 ; cbn.
     use weqdirprodf.
     + use weqimplimpl.
       * intros f a.

--- a/UniMath/CategoryTheory/Chains/Cochains.v
+++ b/UniMath/CategoryTheory/Chains/Cochains.v
@@ -38,7 +38,7 @@ Proof.
     refine (_ · ars b).
     exact (transportf (λ o, C ⟦ obs o, obs (S b) ⟧) aeqSb (identity _)).
   - exact (λ ars n, ars (S n) n (idpath _)).
-  - intros ars; cbn; unfold idfun.
+  - intros ars; cbn.
     apply funextsec; intro n.
     apply id_left.
   - intros ars.
@@ -47,7 +47,7 @@ Proof.
     apply funextsec; intro b.
     apply funextsec; intro p.
     induction p.
-    cbn; unfold idfun.
+    cbn.
     apply id_left.
 Defined.
 

--- a/UniMath/CategoryTheory/DisplayedCats/Core.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Core.v
@@ -710,7 +710,7 @@ Lemma transportf_precompose_disp {C} {D : disp_cat C}
   = transportf _ (id_left _)
     (iso_inv_from_iso_disp (idtoiso_disp (idpath _) (e)) ;; ff).
 Proof.
-  destruct e; cbn; unfold idfun; cbn.
+  destruct e; cbn.
   rewrite (@id_left_disp _ _ _ _ _ cc).
   apply pathsinv0, transportfbinv.
 Qed.

--- a/UniMath/CategoryTheory/DisplayedCats/Examples/HLevel.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Examples/HLevel.v
@@ -74,7 +74,7 @@ Proof.
         intros ? ? ?.
         apply subtypePath.
         -- intro. apply isapropunit.
-        -- unfold funcomp; apply funextfun; intro; reflexivity.
+        -- apply funextfun; intro; reflexivity.
     + use make_nat_trans.
       * intros ?; exact (idfun _).
       * intros ? ? ?; apply funextfun; intro; reflexivity.

--- a/UniMath/CategoryTheory/DisplayedCats/Fibrations.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Fibrations.v
@@ -666,7 +666,7 @@ Proof.
       * cbn. intros c c' x y f H.
         set (XR := pr2 (iscontrpr1 (unique_lift f y))). cbn in XR.
         apply (transportf (λ t, t -->[f] y) H XR).
-    + abstract (split; cbn; unfold idfun; intros; apply  disp_mor_unique_disc_fib).
+    + abstract (split; cbn; intros; apply  disp_mor_unique_disc_fib).
   - abstract (intros c c' f; apply eq_discrete_fib_mor; intros; apply idpath).
 Defined.
 
@@ -682,7 +682,6 @@ Proof.
       * cbn. intro c; apply idfun.
       * abstract (
             intros c c' x y f H; cbn;
-            unfold idfun;
             apply pathsinv0; apply path_to_ctr; apply H
           ).
     + abstract (

--- a/UniMath/CategoryTheory/LocalizingClass.v
+++ b/UniMath/CategoryTheory/LocalizingClass.v
@@ -1651,7 +1651,7 @@ Section def_roofs.
     - use funextsec. intros a.
       use funextsec. intros b.
       use funextsec. intros f.
-      induction T. cbn. unfold idfun.
+      induction T. cbn.
       use (squash_to_prop (pr1 (RoofEqclassIs f))). apply hsD. intros f'. induction f' as [f1 f2].
       rewrite (RoofEqclassEqRoof f f1 f2).
       use (pathscomp0 _ (! (pr2 (pr1 (MorMap_iscontr

--- a/UniMath/CategoryTheory/Monads/KleisliCategory.v
+++ b/UniMath/CategoryTheory/Monads/KleisliCategory.v
@@ -180,7 +180,7 @@ Proof.
   use tpair.
   - intros a b; cbn.
     apply idweq.
-  - cbn; unfold idfun; split.
+  - cbn; split.
     + intros.
       rewrite <- assoc.
       apply cancel_precomposition.
@@ -218,7 +218,7 @@ Proof.
            apply bind_comp_η.
         -- cbn.
            rewrite transportf_const.
-           unfold idfun.
+           cbn.
            apply funextsec; intro c.
            apply bind_identity.
       * cbn.

--- a/UniMath/CategoryTheory/Monads/RelativeMonads.v
+++ b/UniMath/CategoryTheory/Monads/RelativeMonads.v
@@ -1168,14 +1168,13 @@ Proof.
       apply idfun.
     + simpl.
       apply idisweq.
-  - unfold idfun; split.
+  - simpl; split.
     + intros a b f c h.
-      simpl.
       unfold compose at 1; simpl.
       rewrite <- assoc.
       apply cancel_precomposition.
       apply (r_eta_r_bind R).
-    + intros a b f c k; simpl.
+    + intros a b f c k.
       reflexivity.
 Defined.
 

--- a/UniMath/CategoryTheory/RepresentableFunctors/Representation.v
+++ b/UniMath/CategoryTheory/RepresentableFunctors/Representation.v
@@ -246,7 +246,7 @@ Defined.
 Lemma Hom1_Representation {C:category} (c:C) : Representation (Hom1 c).
 Proof.
   exists c. exists (identity c). intro b. apply (isweqhomot (idweq _)).
-  - abstract (intro f; unfold arrow_morphism_composition; unfold Hom1, idfun; simpl;
+  - abstract (intro f; unfold arrow_morphism_composition; unfold Hom1; simpl;
               apply pathsinv0, id_right) using _R_.
   - abstract (apply weqproperty) using _T_.
 Defined.

--- a/UniMath/CategoryTheory/RepresentableFunctors/Representation.v
+++ b/UniMath/CategoryTheory/RepresentableFunctors/Representation.v
@@ -32,7 +32,7 @@ Proof.
   - simpl; intros x. apply weqonsecfibers; intro b. apply weqiff.
     + unshelve refine (twooutof3c_iff_1_homot _ _ _ _ _).
       * exact (pr1 i ◽ opp_ob b).
-      * intro f; unfold funcomp; simpl.
+      * intro f; simpl.
         exact (eqtohomot (nat_trans_ax (pr1 i) _ _ f) x).
       * exact (hset_iso_is_equiv _ _ (I b)).
     + apply isapropisweq.

--- a/UniMath/CategoryTheory/categories/Cats.v
+++ b/UniMath/CategoryTheory/categories/Cats.v
@@ -267,8 +267,8 @@ Proof.
   - intro i.
     use morphism_in_full_subcat.
     exact (pr_functor I (pr1 ∘ f) i).
-  - intros other_prod other_proj; cbn in other_proj.
-    unfold funcomp; cbn.
+  - unfold funcomp; cbn.
+    intros other_prod other_proj.
     apply (@iscontrweqf (hfiber functor_into_product_weq (λ i, pr1 (other_proj i)))).
     + unfold hfiber.
       unfold sub_precategory_morphisms, sub_precategory_predicate_morphisms; cbn.

--- a/UniMath/CategoryTheory/categories/StandardCategories.v
+++ b/UniMath/CategoryTheory/categories/StandardCategories.v
@@ -132,7 +132,7 @@ Proof.
     + intros a b c g h; cbn.
       refine (maponpaths (λ p, transportf _ p _) (maponpathscomp0 _ _ _) @ _).
       refine (!transport_f_f _ (maponpaths f g) (maponpaths f h) _ @ _).
-      abstract (induction h; cbn; unfold idfun; apply pathsinv0; apply id_right).
+      abstract (induction h; cbn; apply pathsinv0; apply id_right).
 Defined.
 
 (** A natural transformation of functors out of a path groupoid is given by any

--- a/UniMath/CategoryTheory/categories/Type/Core.v
+++ b/UniMath/CategoryTheory/categories/Type/Core.v
@@ -67,11 +67,10 @@ Section HomFunctors.
     use make_dirprod.
     - intro; cbn.
       apply funextsec; intro.
-      unfold idfun.
       refine (id_right _ @ _).
       apply id_left.
-    - intros ? ? ? ? ?; cbn in *.
-      apply funextsec; intro; unfold funcomp.
+    - intros ? ? ? ? ?.
+      apply funextsec; intro; cbn.
       abstract (do 3 rewrite assoc; reflexivity).
   Defined.
 

--- a/UniMath/CategoryTheory/categories/abgrs.v
+++ b/UniMath/CategoryTheory/categories/abgrs.v
@@ -821,7 +821,7 @@ Section abgr_monics_and_epis.
                             monoidfuncomp (nat_nat_prod_abmonoid_monoidfun a2) f.
   Proof.
     use monoidfun_paths. use funextfun. intros x. induction x as [x1 x2]. cbn.
-    unfold funcomp. unfold nataddabmonoid_nataddabmonoid_to_monoid_fun.
+    unfold nataddabmonoid_nataddabmonoid_to_monoid_fun.
     unfold nat_nat_to_monoid_fun. Opaque nat_to_monoid_fun. cbn.
     use (pathscomp0 (binopfunisbinopfun f _ _)).
     use (pathscomp0 _ (! (binopfunisbinopfun f _ _))). cbn.

--- a/UniMath/CategoryTheory/categories/modules.v
+++ b/UniMath/CategoryTheory/categories/modules.v
@@ -55,7 +55,6 @@ Proof.
     use total2_paths_f.
     + apply funextfun. intro x.
       unfold compose. cbn.
-      rewrite funcomp_assoc.
       apply idpath.
     + apply isapropismodulefun.
 Defined.
@@ -153,7 +152,6 @@ Proof.
    apply (is_iso_qinv (C:= mod_precategory) _ (make_modulefun (invmoduleiso f) (pr2 (invmoduleiso f)))).
    split; use total2_paths_f.
     + apply funextfun. intro.
-      unfold funcomp, idfun.
       apply homotinvweqweq.
     + apply isapropismodulefun.
     + apply funextfun. intro.

--- a/UniMath/CategoryTheory/categories/monoids.v
+++ b/UniMath/CategoryTheory/categories/monoids.v
@@ -257,7 +257,7 @@ Proof.
   apply list_ind.
   - apply pathsinv0, monoidfununel.
   - intros x xs H.
-    unfold funcomp in *.
+    simpl in *.
     refine (maponpaths iterop_list_mon (map_cons _ _ _) @ _).
     refine (iterop_list_mon_step _ _ @ _).
     refine (_ @ !maponpaths _ (iterop_list_mon_step _ _)).
@@ -303,14 +303,13 @@ Proof.
   split; intro.
   - apply monoidfun_paths.
     apply funextfun.
-    simpl; unfold funcomp.
+    simpl.
     unfold homot; apply list_ind; [reflexivity|].
     intros x xs ?.
-    unfold funcomp.
+    simpl.
     rewrite map_cons.
     (* For some reason, the unifier needs a lot of help here... *)
-    refine (iterop_list_mon_step ((cons _ _) : pr1hSet (free_monoid _))
-                                  (map singleton xs) @ _).
+    refine (iterop_list_mon_step (_ : pr1hSet (free_monoid _)) _ @ _).
     apply maponpaths; assumption.
   - reflexivity.
 Qed.

--- a/UniMath/CategoryTheory/category_binops.v
+++ b/UniMath/CategoryTheory/category_binops.v
@@ -4,6 +4,8 @@ Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.UnivalenceAxiom.
 
+Require Import UniMath.MoreFoundations.PartA.
+
 Require Import UniMath.Algebra.BinaryOperations.
 
 Require Import UniMath.CategoryTheory.Core.Categories.
@@ -32,8 +34,8 @@ Section BINOPS_precategory.
     binopfuncomp (idbinopfun A) f = f.
   Proof.
     unfold binopfuncomp. unfold idbinopfun.
-    use total2_paths_f. cbn. unfold funcomp. apply maponpaths.
-    apply idpath. apply proofirrelevance. apply isapropisbinopfun.
+    use total2_paths_f. cbn. apply idpath.
+    apply proofirrelevance. apply isapropisbinopfun.
   Defined.
 
 
@@ -41,8 +43,8 @@ Section BINOPS_precategory.
     binopfuncomp f (idbinopfun B) = f.
   Proof.
     unfold binopfuncomp. unfold idbinopfun.
-    use total2_paths_f. cbn. unfold funcomp. apply maponpaths.
-    apply idpath. apply proofirrelevance. apply isapropisbinopfun.
+    use total2_paths_f. cbn. apply idpath.
+    apply proofirrelevance. apply isapropisbinopfun.
   Defined.
 
   Definition binopfuncomp_assoc (A B C D : setwithbinop) (f : binopfun A B)

--- a/UniMath/CategoryTheory/category_binops.v
+++ b/UniMath/CategoryTheory/category_binops.v
@@ -4,8 +4,6 @@ Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.UnivalenceAxiom.
 
-Require Import UniMath.MoreFoundations.PartA.
-
 Require Import UniMath.Algebra.BinaryOperations.
 
 Require Import UniMath.CategoryTheory.Core.Categories.

--- a/UniMath/CategoryTheory/elems_slice_equiv.v
+++ b/UniMath/CategoryTheory/elems_slice_equiv.v
@@ -298,7 +298,7 @@ Section elems_slice_equiv.
     apply maponpaths. unfold hfiber.
     rewrite transportf_total2. simpl.
     rewrite transportf_const.
-    now unfold idfun.
+    reflexivity.
   Qed.
 
   Definition slice_counit : slice_to_PreShv ∙ PreShv_to_slice ⟹ functor_identity (PreShv C / P) :=

--- a/UniMath/CategoryTheory/limits/graphs/equalizers.v
+++ b/UniMath/CategoryTheory/limits/graphs/equalizers.v
@@ -61,7 +61,7 @@ Section def_equalizers.
       + exact (h · f).
     - use two_rec_dep; use two_rec_dep.
       + exact (empty_rect _).
-      + intro e. unfold idfun. induction e.
+      + intro e. induction e.
         * apply idpath.
         * apply (! H).
       + exact (empty_rect _).

--- a/UniMath/CategoryTheory/limits/kernels.v
+++ b/UniMath/CategoryTheory/limits/kernels.v
@@ -572,7 +572,7 @@ Section transport_kernels.
     KernelIn Z K _ (transportf (λ x' : ob C, precategory_morphisms x' y) e f)
              (transport_source_KernelIn_eq f K e H).
   Proof.
-    induction e. use KernelInsEq. cbn. unfold idfun.
+    induction e. use KernelInsEq. cbn.
     rewrite KernelCommutes. rewrite KernelCommutes.
     apply idpath.
   Qed.

--- a/UniMath/Combinatorics/FiniteSequences.v
+++ b/UniMath/Combinatorics/FiniteSequences.v
@@ -95,7 +95,7 @@ Proof.
   apply funextfun; intros [i b].
   simpl.
   induction (natlehchoice4 i n b) as [p|p].
-  - unfold funcomp; simpl.
+  - simpl.
     unfold append_vec. simpl.
     induction (natlehchoice4 i n b) as [q|q].
     + simpl. apply maponpaths. apply isinjstntonat; simpl. reflexivity.
@@ -103,7 +103,7 @@ Proof.
   - induction p.
     unfold append_vec; simpl.
     induction (natlehchoice4 i i b) as [r|r].
-    * simpl. unfold funcomp; simpl. apply maponpaths.
+    * simpl. apply maponpaths.
       apply isinjstntonat; simpl. reflexivity.
     * simpl. apply maponpaths. apply isinjstntonat; simpl. reflexivity.
 Defined.
@@ -291,7 +291,7 @@ Proof.
     + apply transportf_fun.
     + apply funextfun. intro x. induction x as [ i b ].
       simple refine (_ @ e_el _ _ _).
-      * unfold funcomp.
+      * simpl.
         apply maponpaths.
         apply transport_stn.
 Defined.
@@ -429,7 +429,7 @@ Lemma append_and_drop_fun {X n} (x : stn n -> X) y :
 Proof.
   intros.
   apply funextsec; intros i.
-  unfold funcomp.
+  simpl.
   unfold append_vec.
   induction (natlehchoice4 (pr1 (dni lastelement i)) n (pr2 (dni lastelement i))) as [I|J].
   - simpl. apply maponpaths. apply subtypePath_prop. simpl. apply di_eq1. exact (stnlt i).
@@ -479,13 +479,13 @@ Proof.
     apply proofirrelevancecontr. apply iscontrunit. }
   induction p as [x y]. induction y as [n y].
   apply (maponpaths (@inr unit (X × Sequence X))).
-  unfold append_vec, lastelement, funcomp; simpl.
+  unfold append_vec, lastelement; simpl.
   unfold append_vec. simpl.
   induction (natlehchoice4 n n (natgthsnn n)) as [e|e].
   { contradicts e (isirreflnatlth n). }
   simpl. apply maponpaths, maponpaths.
   apply funextfun; intro i. clear e. induction i as [i b].
-  unfold funcomp, dni_lastelement; simpl.
+  unfold dni_lastelement; simpl.
   induction (natlehchoice4 i n (natlthtolths i n b)) as [d|d].
   { simpl. apply maponpaths. now apply isinjstntonat. }
   simpl. induction d; contradicts b (isirreflnatlth i).
@@ -559,7 +559,7 @@ Proof.
   - cbn. apply natplusnsm.
   - intros i r s.
     unfold concatenate, concatenate', weqfromcoprodofstn_invmap; cbn.
-    unfold append_vec, coprod_rect, funcomp; cbn.
+    unfold append_vec, coprod_rect; cbn.
     induction (natlthorgeh i m) as [H | H].
     + induction (natlehchoice4 i (m + n) s) as [H1 | H1].
       * reflexivity.

--- a/UniMath/Combinatorics/OrderedSets.v
+++ b/UniMath/Combinatorics/OrderedSets.v
@@ -455,14 +455,14 @@ Proof.
       induction e.
       exact (pn,,pl).
   - induction p as [e s].
-    induction e; unfold transportf in s; simpl in s; unfold idfun in s.
+    induction e; unfold transportf in s; simpl in s.
     refine (q _ _); clear q; intro q; simpl in q.
     induction q as [q|q].
     + induction q as [n r].
       apply hdisj_in1; simpl.
       exact (n,,r).
     + induction q as [e' s']. induction e'.
-      unfold transportf in s'; simpl in s'; unfold idfun in s'.
+      unfold transportf in s'; simpl in s'.
       apply hdisj_in2; simpl.
       exists (idpath x).
       exact (Strans x y y' y'' s s').

--- a/UniMath/Combinatorics/StandardFiniteSets.v
+++ b/UniMath/Combinatorics/StandardFiniteSets.v
@@ -10,7 +10,6 @@ This file contains main constructions related to the standard finite sets define
 (** Imports. *)
 
 Require Export UniMath.Foundations.NaturalNumbers.
-Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 Require Import UniMath.MoreFoundations.DecidablePropositions.
 Require Import UniMath.MoreFoundations.NegativePropositions.

--- a/UniMath/Combinatorics/StandardFiniteSets.v
+++ b/UniMath/Combinatorics/StandardFiniteSets.v
@@ -10,6 +10,7 @@ This file contains main constructions related to the standard finite sets define
 (** Imports. *)
 
 Require Export UniMath.Foundations.NaturalNumbers.
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 Require Import UniMath.MoreFoundations.DecidablePropositions.
 Require Import UniMath.MoreFoundations.NegativePropositions.
@@ -796,9 +797,9 @@ Definition coprod_stn_assoc (l m n : nat) : (
 Proof.
   intros.
   intros abc.
-  rewrite 4? weqcomp_to_funcomp.
+  simpl.
   apply (invmaponpathsincl pr1). apply isinclstntonat.
-  rewrite <- funcomp_assoc. unfold funcomp at 1. rewrite pr1_eqweqmap_stn.
+  rewrite pr1_eqweqmap_stn.
   induction abc as [[a|b]|c].
   - simpl. apply idpath.
   - simpl. apply idpath.
@@ -869,23 +870,23 @@ Proof.
   intros. induction n as [|n IHn].
   { change (stnsum _) with 0 at 3. rewrite natplusr0.
     assert (e := ! natplusr0 m).
-    rewrite (transport_stnsum e). apply stnsum_eq; intro i. unfold funcomp.
+    rewrite (transport_stnsum e). apply stnsum_eq; intro i. simpl.
     apply maponpaths. apply pathsinv0. apply stn_left_0. }
   rewrite stnsum_step. assert (e : S (m+n) = m + S n).
   { apply pathsinv0. apply natplusnsm. }
   rewrite (transport_stnsum e).
   rewrite stnsum_step. rewrite <- natplusassoc. apply map_on_two_paths.
   { rewrite IHn; clear IHn. apply map_on_two_paths.
-    { apply stnsum_eq; intro i. unfold funcomp.
+    { apply stnsum_eq; intro i. simpl.
       apply maponpaths. apply subtypePath_prop.
       rewrite stn_left_compute. induction e.
       rewrite idpath_transportf. rewrite dni_last.
       apply idpath. }
-    { apply stnsum_eq; intro i. unfold funcomp.
+    { apply stnsum_eq; intro i. simpl.
       apply maponpaths. apply subtypePath_prop.
       rewrite stn_right_compute. unfold stntonat. induction e.
       rewrite idpath_transportf. rewrite 2? dni_last. apply idpath. } }
-  unfold funcomp. apply maponpaths. apply subtypePath_prop.
+  simpl. apply maponpaths. apply subtypePath_prop.
   induction e. apply idpath.
 Defined.
 
@@ -1037,10 +1038,10 @@ Proof.
     unfold m1 ; clear m1.
     apply two_arg_paths.
     + apply stnsum_eq. intro l.
-      unfold funcomp. apply maponpaths.
+      simpl. apply maponpaths.
       apply subtypePath_prop; simpl.
       apply pathsinv0, di_eq1, stnlt.
-    + unfold funcomp. apply maponpaths. apply subtypePath_prop.
+    + simpl. apply maponpaths. apply subtypePath_prop.
       simpl. apply idpath.
 Defined.
 
@@ -1103,7 +1104,7 @@ Proof.
             stnsum (m ∘ stn_left'' ltS ∘ dni lastelement)) as e. {
       apply stnsum_eq.
       intros k.
-      unfold funcomp. apply maponpaths.
+      simpl. apply maponpaths.
       apply subtypePath_prop. simpl.
       apply pathsinv0, di_eq1.
       apply (stnlt k).
@@ -1111,7 +1112,7 @@ Proof.
     induction e.
     apply natlthandplusl.
     assert ((m ∘ stn_left'' ltS) lastelement = m i) as e. {
-      unfold funcomp. apply maponpaths.
+      simpl. apply maponpaths.
       apply subtypePath_prop, idpath.
     }
     induction e.
@@ -1120,7 +1121,7 @@ Proof.
             stnsum (m ∘ stn_left'' (stnlt i') ∘ stn_left' _ _ lt)) as e. {
       apply stnsum_eq.
       intros k.
-      unfold funcomp. apply maponpaths.
+      simpl. apply maponpaths.
       apply subtypePath_prop, idpath.
     }
     rewrite e.
@@ -1170,7 +1171,7 @@ Proof.
     use tpair.
     + exists (dni_lastelement i). exists j.
       abstract (use (_ @ J); apply (maponpaths (λ x, x+j)); apply stnsum_eq; intro r;
-      unfold m'; unfold funcomp; apply maponpaths; apply subtypePath_prop, idpath).
+      unfold m'; simpl; apply maponpaths; apply subtypePath_prop, idpath).
     + intro t.
       apply partial_sum_prop.
   - clear IH. set (j := l - len').
@@ -1187,7 +1188,7 @@ Proof.
       induction C. exact lt.
     * simpl. intermediate_path (stnsum m' + j).
       -- apply (maponpaths (λ x, x+j)). apply stnsum_eq; intro i.
-         unfold m'. unfold funcomp. apply maponpaths.
+         unfold m'. simpl. apply maponpaths.
          apply subtypePath_prop, idpath.
       -- rewrite natpluscomm. exact K.
 Defined.
@@ -1269,7 +1270,7 @@ Proof.
                                                 (idfun _) c))
             ).
       intros c.
-      unfold funcomp.
+      simpl.
       set (P := λ i, ⟦ f i ⟧).
       change (pr1weq (weqfromcoprodofstn (stnsum (λ x : ⟦ n ⟧, f (dni lastelement x))) (f lastelement)))
       with (weqfromcoprodofstn_map (stnsum (λ x : ⟦ n ⟧, f (dni lastelement x))) (f lastelement)).
@@ -1280,7 +1281,7 @@ Proof.
         unfold weqfromcoprodofstn_map. unfold coprod_rect. unfold weqstnsum_map.
         apply subtypePath_prop.
         induction k as [k K]. simpl.
-        apply (maponpaths (λ x, x+k)). unfold funcomp. unfold stntonat. unfold di.
+        apply (maponpaths (λ x, x+k)). unfold funcomp, stntonat, di.
         clear K k.
         induction (natlthorgeh _ n) as [G|G'].
         -- simpl. apply stnsum_eq; intro k. apply maponpaths.
@@ -1296,7 +1297,7 @@ Proof.
         apply (maponpaths (λ x, x+k)).
         apply maponpaths.
         apply funextfun; intro i. induction i as [i I].
-        unfold funcomp. apply maponpaths.
+        simpl. apply maponpaths.
         apply subtypePath_prop.
         simpl.
         apply pathsinv0, di_eq1. assumption.
@@ -2163,7 +2164,7 @@ Proof.
     change ((λ i : ⟦ S m ⟧, f i + g i) ∘ dni lastelement)
     with (λ y : ⟦ m ⟧, f (dni lastelement y) + g (dni lastelement y)).
     rewrite I. rewrite natplusassoc.
-    rewrite natplusassoc. unfold funcomp. apply maponpaths. rewrite natpluscomm.
+    rewrite natplusassoc. simpl. apply maponpaths. rewrite natpluscomm.
     rewrite natplusassoc. apply maponpaths. rewrite natpluscomm. apply idpath.
 Defined.
 
@@ -2196,7 +2197,7 @@ Proof.
                      (f firstelement) _ _).
     + apply maponpaths.
       use (_ @ I (f ∘ dni_lastelement) _ @ _).
-      * unfold funcomp. apply stnsum_eq; intros i.
+      * simpl. apply stnsum_eq; intros i.
         rewrite replace_dni_last. apply idpath.
       * intros i j s. unfold funcomp. apply e. apply s.
       * apply idpath.

--- a/UniMath/Combinatorics/StandardFiniteSets.v
+++ b/UniMath/Combinatorics/StandardFiniteSets.v
@@ -1289,7 +1289,7 @@ Proof.
            exact (istransnatlth _ _ _ (stnlt k) G).
         -- apply fromempty. exact (natlthtonegnatgeh _ _ (stnlt j) G').
       * change (invmap (weqoverdnicoprod P) (ii2 k)) with (tpair P lastelement k).
-        unfold coprodf, idfun. unfold weqfromcoprodofstn_map. unfold coprod_rect.
+        simpl.
         unfold weqstnsum_map.
         apply subtypePath_prop.
         induction k as [k K]. simpl.

--- a/UniMath/Combinatorics/Vectors.v
+++ b/UniMath/Combinatorics/Vectors.v
@@ -94,7 +94,7 @@ Proof.
       apply idpath.
     + etrans.
       { apply meq. }
-      unfold funcomp, drop.
+      unfold drop.
       apply maponpaths.
       apply idpath.
 Defined.
@@ -341,4 +341,3 @@ Proof.
     induction v2 as [x2 xs2].
     exact ((x1 ,, x2) ::: IHn xs1 xs2).
 Defined.
-

--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -158,7 +158,13 @@ Definition termfun {X : UU} (x : X) : unit -> X := λ _, x.
 
 Definition idfun (T : UU) := λ t:T, t.
 
+(** makes [simpl], [cbn], etc. unfold [idfun X x] but not [ idfun X ]: *)
+Arguments idfun _ _ /.
+
 Definition funcomp {X Y : UU} {Z:Y->UU} (f : X -> Y) (g : ∏ y:Y, Z y) := λ x, g (f x).
+
+(** make [simpl], [cbn], etc. unfold [ (f ∘ g) x ] but not [ f ∘ g ]: *)
+Arguments funcomp {_ _ _} _ _ _/.
 
 Declare Scope functions.
 Delimit Scope functions with functions.

--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -1380,14 +1380,14 @@ Lemma homotweqinv  {X Y Z} (f:X->Z) (w:X≃Y) (g:Y->Z) : f ~ g ∘ w -> f ∘ in
 Proof.
   intros p y.
   simple refine (p (invmap w y) @ _); clear p.
-  unfold funcomp. apply maponpaths. apply homotweqinvweq.
+  simpl. apply maponpaths. apply homotweqinvweq.
 Defined.
 
 Lemma homotweqinv' {X Y Z} (f:X->Z) (w:X≃Y) (g:Y->Z) : f ~ g ∘ w <- f ∘ invmap w ~ g.
 Proof.
   intros q x.
   simple refine (_ @ q (w x)).
-  unfold funcomp. apply maponpaths, pathsinv0. apply homotinvweqweq.
+  simpl. apply maponpaths, pathsinv0. apply homotinvweqweq.
 Defined.
 
 Definition isinjinvmap {X Y} (v w:X≃Y) : invmap v ~ invmap w -> v ~ w.

--- a/UniMath/Foundations/PartC.v
+++ b/UniMath/Foundations/PartC.v
@@ -263,7 +263,7 @@ Lemma pathsrecomplfxtoy {X Y : UU} (x : X) (y : Y) (isx : isisolated X x)
       (f : compl X x -> compl Y y) : (recomplf x y isx f x) = y.
 Proof.
   intros. unfold recomplf. unfold weqrecompl. unfold invmap. simpl.
-  unfold invrecompl. unfold funcomp. induction (isx x) as [ i1 | i2 ].
+  unfold invrecompl. induction (isx x) as [ i1 | i2 ].
   - simpl. apply idpath.
   - induction (i2 (idpath _)).
 Defined.
@@ -278,10 +278,10 @@ Proof.
   set (e := homotinvweqweq (weqrecompl Y y isy)
                            (coprodf f (idfun unit)
                                     (invmap (weqrecompl X x isx) x'))).
-  unfold funcomp. simpl in e. simpl. rewrite e.
+  simpl in e. simpl. rewrite e.
   set (e' := homotcoprodfcomp f (idfun unit) g (idfun unit)
                               (invmap (weqrecompl X x isx) x')).
-  unfold funcomp in e'. rewrite e'. apply idpath.
+  simpl in e'. rewrite e'. apply idpath.
 Defined.
 
 
@@ -289,7 +289,7 @@ Definition homotrecomplfidfun {X : UU} (x : X) (isx : isisolated X x) :
   homot (recomplf x x isx (idfun (compl X x))) (idfun _).
 Proof.
   intros. intro x'. unfold recomplf. unfold weqrecompl. unfold invmap. simpl.
-  unfold invrecompl. unfold funcomp. induction (isx x') as [ e | ne ].
+  unfold invrecompl. induction (isx x') as [ e | ne ].
   - simpl. apply e.
   - simpl. apply idpath.
 Defined.
@@ -303,7 +303,7 @@ Proof.
   intros. induction x'n as [ x' nexx' ]. induction y'n as [ y' neyy' ].
   simpl in e . apply (invmaponpathsincl _ (isinclpr1compl _ _)). simpl.
   rewrite (pathsinv0 e). unfold recomplf. unfold invmap. unfold coprodf.
-  simpl. unfold funcomp. unfold invrecompl.
+  simpl. unfold invrecompl.
   induction (isx x') as [ exx' | nexx'' ].
   - induction (nexx' exx').
   - simpl. assert (ee : nexx' = nexx'').
@@ -330,7 +330,7 @@ Definition homottranspos0t2t1t1t2 {T : UU} (t1 t2 : T)
            (is1 : isisolated T t1) (is2 : isisolated T t2) :
   funtranspos0 t2 t1 is1 ∘ funtranspos0 t1 t2 is2 ~ idfun _.
 Proof.
-  intros. intro x. unfold funtranspos0. unfold funcomp.
+  intros. intro x. unfold funtranspos0. simpl.
        induction x as [ t net1 ]; simpl.
        induction (is2 t) as [ et2 | net2 ].
        - induction (is2 t1) as [ et2t1 | net2t1 ].
@@ -406,7 +406,7 @@ Lemma pathsfuntransposoft2 {T : UU} (t1 t2 : T) (is1 : isisolated T t1)
   paths (funtranspos (tpair _ t1 is1) (tpair _ t2 is2) t2) t1.
 Proof.
   intros. unfold funtranspos. simpl. unfold funtranspos0.
-  unfold recomplf. unfold funcomp. unfold coprodf. unfold invmap.
+  unfold recomplf. unfold coprodf. unfold invmap.
   unfold weqrecompl. unfold recompl. simpl. unfold invrecompl.
   induction (is1 t2) as [ et1t2 | net1t2 ].
   - apply (pathsinv0 et1t2).
@@ -423,7 +423,7 @@ Lemma pathsfuntransposofnet1t2 {T : UU} (t1 t2 : T) (is1 : isisolated T t1)
   paths (funtranspos (tpair _ t1 is1) (tpair _ t2 is2) t) t.
 Proof.
   intros. unfold funtranspos. simpl. unfold funtranspos0. unfold recomplf.
-  unfold funcomp. unfold coprodf. unfold invmap. unfold weqrecompl.
+  unfold coprodf. unfold invmap. unfold weqrecompl.
   unfold recompl. simpl. unfold invrecompl.
   induction (is1 t) as [ et1t | net1t' ].
   - induction (net1t et1t).
@@ -436,7 +436,7 @@ Lemma homotfuntranspos2 {T : UU} (t1 t2 : T) (is1 : isisolated T t1)
   homot (funcomp (funtranspos (tpair _ t1 is1) (tpair _ t2 is2))
                  (funtranspos (tpair _ t1 is1) (tpair _ t2 is2))) (idfun _).
 Proof.
-  intros. intro t. unfold funcomp. unfold idfun.
+  intros. intro t. simpl.
   induction (is1 t) as [ et1t | net1t ].
   - rewrite (pathsinv0 et1t). rewrite (pathsfuntransposoft1 _ _).
     rewrite (pathsfuntransposoft2 _ _). apply idpath.

--- a/UniMath/Foundations/PartD.v
+++ b/UniMath/Foundations/PartD.v
@@ -1004,7 +1004,7 @@ Proof.
                   t t' is is'
                   (recompl T t (coprodf w (λ x0 : unit, x0)
                                         (invmap (weqrecompl T t is) x)))).
-      unfold funcomp,idfun in e.
+      simpl in e.
       rewrite e. unfold recompl, coprodf, invmap; simpl. unfold invrecompl.
       induction (is x) as [ etx | netx' ].
       * induction (netx etx).

--- a/UniMath/Foundations/UnivalenceAxiom.v
+++ b/UniMath/Foundations/UnivalenceAxiom.v
@@ -128,7 +128,7 @@ Proof.
     set ( g := totalfun _ _ ( λ XY : UU × UU,  weqtopaths (pr1 XY) (pr2 XY) ) : Z2 -> Z1 ) .
     assert (efg : funcomp g f ~ idfun _) .
     - intro z2 . induction z2 as [ XY e ] .
-      unfold funcomp . unfold idfun . unfold g . unfold f . unfold totalfun . simpl .
+      unfold g . unfold f . unfold totalfun . simpl .
       apply ( maponpaths ( fun w : ( pr1 XY) ≃ (pr2 XY) =>  tpair P2 XY w )
                        ( weqpathsweq ( pr1 XY ) ( pr2 XY ) e )) .
     - set ( h := λ a1 : Z1,  pr1 ( pr1 a1 ) ) .

--- a/UniMath/HomologicalAlgebra/CohomologyComplex.v
+++ b/UniMath/HomologicalAlgebra/CohomologyComplex.v
@@ -92,7 +92,7 @@ Section def_cohomology_complex.
     (transportf (λ x : pr1 hz, A ⟦ C (i - 1), C x ⟧) (hzrminusplus i 1) (Diff C (i - 1)))
       · (Diff C i) = ZeroArrow (to_Zero A) _ _.
   Proof.
-    induction (hzrminusplus i 1). cbn. unfold idfun.
+    induction (hzrminusplus i 1). cbn.
     apply (DSq (AbelianToAdditive A hs) C (i - 1)).
   Qed.
 
@@ -101,7 +101,7 @@ Section def_cohomology_complex.
                   (Diff C (i - 1))) · (Diff C i) = ZeroArrow (to_Zero A) _ _.
   Proof.
     rewrite <- functtransportf. cbn.
-    induction (hzrminusplus i 1). cbn. unfold idfun.
+    induction (hzrminusplus i 1). cbn.
     apply (DSq (AbelianToAdditive A hs) C (i - 1)).
   Qed.
 
@@ -148,7 +148,7 @@ Section def_cohomology_complex.
     cbn. rewrite <- transport_target_postcompose. cbn.
     set (tmp := MComm f (i - 1)). cbn in tmp. rewrite tmp. clear tmp.
     rewrite assoc. rewrite KernelCommutes.
-    induction (hzrminusplus i 1). cbn. unfold idfun. apply idpath.
+    induction (hzrminusplus i 1). cbn. apply idpath.
   Qed.
 
   Local Lemma CohomologyMorphism_Ker_Coker_Zero {C1 C2 : Complex (AbelianToAdditive A hs)}
@@ -1042,7 +1042,7 @@ Section def_cohomology_homotopy.
                 (maponpaths C2 (hzrminusplus i 1)) (H i · Diff C2 (i - 1)) ·
                 Diff C2 i = ZeroArrow (to_Zero A) (Kernel (Diff C1 i)) (C2 (i + 1)).
   Proof.
-    induction (hzrminusplus i 1). cbn. unfold idfun. rewrite <- assoc. rewrite <- assoc.
+    induction (hzrminusplus i 1). cbn. rewrite <- assoc. rewrite <- assoc.
     set (tmp := DSq _ C2 (i - 1)). cbn in tmp. rewrite tmp. clear tmp.
     rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_right. apply idpath.
   Qed.
@@ -1454,7 +1454,7 @@ Section def_kernel_cokernel_complex.
                      CokernelArrow (Cokernel (Diff C (i + 1 - 1)))) =
     ZeroArrow (to_Zero A) (C (i - 1)) (Cokernel (Diff C (i + 1 - 1))).
   Proof.
-    induction (hzrminusplus i 1 @ hzrplusminus' i 1). cbn. unfold idfun.
+    induction (hzrminusplus i 1 @ hzrplusminus' i 1). cbn.
     rewrite assoc. set (tmp := DSq (AbelianToAdditive A hs) C (i - 1)). cbn in tmp.
     rewrite tmp. clear tmp. apply ZeroArrow_comp_left.
   Qed.
@@ -1488,10 +1488,10 @@ Section def_kernel_cokernel_complex.
     rewrite transport_f_f.
     assert (e0 : (! (hzrminusplus i 1 @ hzrplusminus' i 1)
                     @ ! (hzrplusminus i 1 @ hzrminusplus' i 1)) = idpath _) by apply isasethz.
-    cbn in e0. cbn. rewrite e0. clear e0. cbn. unfold idfun.
+    cbn in e0. cbn. rewrite e0. clear e0. cbn.
     rewrite transport_source_ZeroArrow.
     induction (hzrminusplus (i + 1) 1). cbn.
-    induction (hzrplusminus' (i + 1 - 1 + 1) 1). cbn. unfold idfun.
+    induction (hzrplusminus' (i + 1 - 1 + 1) 1). cbn.
     exact (DSq _ C (i + 1 - 1)).
   Qed.
 
@@ -1522,7 +1522,7 @@ Section def_kernel_cokernel_complex.
          (! maponpaths C (hzrminusplus i 1)) (Diff C i) =
     ZeroArrow (to_Zero A) (C (i - 1)) (C (i + 1)).
   Proof.
-    induction (hzrminusplus i 1). cbn. unfold idfun. exact (DSq _ C (i - 1)).
+    induction (hzrminusplus i 1). cbn. exact (DSq _ C (i - 1)).
   Qed.
 
 
@@ -1535,7 +1535,7 @@ Section def_kernel_cokernel_complex.
   Proof.
     use CokernelOutsEq.
     rewrite assoc. rewrite CokernelCommutes. rewrite ZeroArrow_comp_right.
-    induction (hzrminusplus i 1). cbn. unfold idfun.
+    induction (hzrminusplus i 1). cbn.
     exact (DSq _ C (i - 1 + 1)).
   Qed.
 
@@ -1574,7 +1574,7 @@ Section def_kernel_cokernel_complex.
          (! maponpaths C (hzrminusplus i 1)) (Diff C i) =
     ZeroArrow (to_Zero A) (C (i - 1)) (C (i + 1)).
   Proof.
-    induction (hzrminusplus i 1). cbn. unfold idfun. exact (DSq _ C (i - 1)).
+    induction (hzrminusplus i 1). cbn. exact (DSq _ C (i - 1)).
   Qed.
 
   Local Lemma CokernelKernelMorphism_comm2' (C : Complex (AbelianToAdditive A hs)) (i : hz) :
@@ -1623,7 +1623,7 @@ Section def_kernel_cokernel_complex.
       + rewrite transport_f_f. rewrite <- maponpathsinv0. rewrite <- maponpathsinv0.
         rewrite <- maponpathscomp0.
         assert (e0 : (! hzrminusplus i 1 @ ! hzrminusplus' i 1) = idpath _) by apply isasethz.
-        cbn in e0. cbn. rewrite e0. clear e0. cbn. unfold idfun.
+        cbn in e0. cbn. rewrite e0. clear e0. cbn.
         rewrite transport_source_precompose. rewrite transport_source_precompose.
         rewrite <- functtransportf.
         assert (e1 : ! hzrminusplus' i 1 = hzrminusplus i 1) by apply isasethz.
@@ -1671,7 +1671,7 @@ Section def_kernel_cokernel_complex.
                      (! maponpaths C (hzrminusplus i 1)) (CokernelArrow CK)) =
     ZeroArrow (to_Zero A) _ _.
   Proof.
-    induction (hzrminusplus i 1). cbn. unfold idfun. apply CokernelCompZero.
+    induction (hzrminusplus i 1). cbn. apply CokernelCompZero.
   Qed.
 
   Local Lemma CokernelKernelCohomology1_Mor1_eq1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
@@ -1727,7 +1727,7 @@ Section def_kernel_cokernel_complex.
       cbn in tmp. cbn. rewrite tmp. clear tmp. rewrite transport_f_f.
       rewrite <- maponpathsinv0. rewrite <- maponpathscomp0.
       assert (e0 : (hzrminusplus i 1 @ ! hzrminusplus i 1) = idpath _) by apply isasethz.
-      cbn. cbn in e0. rewrite e0. clear e0. cbn. unfold idfun. apply idpath.
+      cbn. cbn in e0. rewrite e0. clear e0. cbn. apply idpath.
   Qed.
 
   Definition CokernelKernelCohomology1_Mor1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :
@@ -1819,14 +1819,14 @@ Section def_kernel_cokernel_complex.
           rewrite <- maponpathsinv0. rewrite <- maponpathscomp0. apply maponpaths.
           apply isasethz.
         }
-        cbn. cbn in e0. rewrite e0. clear e0. cbn. unfold idfun. rewrite CokernelCommutes.
+        cbn. cbn in e0. rewrite e0. clear e0. cbn. rewrite CokernelCommutes.
         cbn in tmp. rewrite <- tmp. clear tmp.
         use transport_source_path.
         * exact (C (i - 1 + 1)).
         * exact (! maponpaths C (hzrminusplus i 1)).
         * rewrite transport_source_precompose. rewrite transport_source_precompose.
           rewrite transport_f_f. rewrite <- maponpathsinv0. rewrite <- maponpathscomp0.
-          rewrite pathsinv0r. cbn. unfold idfun. rewrite CokernelCommutes.
+          rewrite pathsinv0r. cbn. rewrite CokernelCommutes.
           rewrite maponpathsinv0. apply idpath.
     }
     rewrite <- assoc. cbn in e0. rewrite e0. clear e0.
@@ -1940,7 +1940,7 @@ Section def_kernel_cokernel_complex.
     -- exact (! maponpaths C (! hzrminusplus i 1)).
     -- rewrite transport_source_precompose. rewrite transport_f_f.
        rewrite <- maponpathsinv0. rewrite <- maponpathsinv0. rewrite <- maponpathscomp0.
-       rewrite pathsinv0inv0. rewrite pathsinv0l. cbn. unfold idfun.
+       rewrite pathsinv0inv0. rewrite pathsinv0l. cbn.
        apply CokernelCommutes.
   Qed.
 
@@ -2021,7 +2021,7 @@ Section def_kernel_cokernel_complex.
     - exact (! maponpaths C (hzrminusplus i 1)).
     - rewrite transport_source_precompose. rewrite transport_f_f.
       rewrite <- maponpathsinv0. rewrite <- maponpathscomp0.
-      rewrite pathsinv0r. cbn. unfold idfun. rewrite maponpathsinv0. apply CokernelCommutes.
+      rewrite pathsinv0r. cbn. rewrite maponpathsinv0. apply CokernelCommutes.
   Qed.
 
   Definition CokernelKernelCohomology1 (C : Complex (AbelianToAdditive A hs)) (i : hz) :

--- a/UniMath/HomologicalAlgebra/Complexes.v
+++ b/UniMath/HomologicalAlgebra/Complexes.v
@@ -1093,7 +1093,7 @@ Section complexes_precat.
     induction (isdecrelhzeq i i0) as [T | F].
     - induction T. exact H.
     - induction (isdecrelhzeq (i + 1) i0) as [T' | F'].
-      + induction T'. cbn. unfold idfun. rewrite <- assoc. rewrite <- assoc. rewrite <- MComm.
+      + induction T'. cbn. rewrite <- assoc. rewrite <- assoc. rewrite <- MComm.
         rewrite assoc. rewrite assoc. apply cancel_postcomposition.
         exact H.
       + apply idpath.

--- a/UniMath/HomologicalAlgebra/KA.v
+++ b/UniMath/HomologicalAlgebra/KA.v
@@ -101,7 +101,7 @@ Section complexes_homotopies.
                              (H i · Diff C2 (i - 1)) ·
                              Diff C2 i) = ZeroArrow (Additive.to_Zero A) _ _).
     {
-      induction (hzrminusplus i 1). cbn. unfold idfun. rewrite <- assoc.
+      induction (hzrminusplus i 1). cbn. rewrite <- assoc.
       rewrite (@DSq A C2 (i - 1)). apply ZeroArrow_comp_right.
     }
     rewrite e0. clear e0.
@@ -242,7 +242,7 @@ Section complexes_homotopies.
                                         (maponpaths C2 (hzrminusplus i 1))
                                         (homot i · Diff C2 (i - 1)))).
         {
-          unfold to_inv. cbn. induction (hzrminusplus i 1). cbn. unfold idfun.
+          unfold to_inv. cbn. induction (hzrminusplus i 1). cbn.
           set (tmp := @PreAdditive_invlcomp A (C1 i) (C2 (i - 1)) (C2 (i - 1 + 1))
                                             (homot i) (Diff C2 (i - 1))).
           apply pathsinv0. unfold to_inv in tmp.

--- a/UniMath/HomologicalAlgebra/MappingCone.v
+++ b/UniMath/HomologicalAlgebra/MappingCone.v
@@ -1864,7 +1864,7 @@ Section inv_rotation_mapping_cone.
                                   ! @maponpaths
                                   hz A (λ i0 : pr1 hz, to_BinDirectSums A (C1 (i0 + 1)) (C2 i0))
                                   _ _ (hzrminusplus (i + 1) 1 @ ! hzrplusminus (i + 1) 1))).
-          cbn in e1, e2. induction (hzrminusplus (i + 1) 1). cbn. unfold idfun. fold DS5.
+          cbn in e1, e2. induction (hzrminusplus (i + 1) 1). cbn. fold DS5.
           clear e1 e2.
           assert (e : (@maponpaths hz A (λ i0 : pr1 hz, to_BinDirectSums A (C1 (i0 + 1)) (C2 i0))
                                    _ _ (! hzrplusminus (i + 1 - 1 + 1) 1) @
@@ -2242,7 +2242,7 @@ Section inv_rotation_mapping_cone.
     rewrite (to_Unel1' DS2). rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left.
     rewrite to_lunax''. rewrite assoc. rewrite <- (assoc _ (to_In1 DS2)).
     rewrite (to_IdIn1 DS2). rewrite id_right. induction (hzrplusminus i 1).
-    cbn. unfold idfun. exact (to_IdIn2 DS1).
+    cbn. exact (to_IdIn2 DS1).
   Qed.
 
   Definition InvRotMorphismIsoHomot {C1 C2 : Complex A} (f : Morphism C1 C2) :
@@ -2455,7 +2455,7 @@ Section inv_rotation_mapping_cone.
                e
                (to_In1 DS2)).
     - unfold DS10, DS9, DS6, DS5, DS2, DS1. unfold e.
-      induction (hzrminusplus i 1). cbn. unfold idfun.
+      induction (hzrminusplus i 1). cbn.
       apply idpath.
     - unfold DS10, DS9, DS6, DS5, DS2, DS1. unfold e. clear e.
       set (tmp := @transport_hz_to_In1'
@@ -2475,7 +2475,7 @@ Section inv_rotation_mapping_cone.
                  (C1 (i + 1 - 1))).
       + exact (! e).
       + unfold e. rewrite transport_f_f. rewrite transport_f_f.
-        rewrite pathsinv0r. cbn. unfold idfun.
+        rewrite pathsinv0r. cbn.
 
         set (tmp := @transport_hz_to_In1'
                       A (λ i0 : hz, to_BinDirectSums A (C1 (i0 + 1)) (C2 i0))
@@ -2723,7 +2723,7 @@ Section inv_rotation_mapping_cone.
                                               A (C1 (i0 + 1 - 1 + 1))
                                               (C2 (i0 + 1 - 1))) (C1 i0))
                        _ _ (hzrminusplus i 1)))).
-      rewrite transport_f_f. rewrite pathsinv0r. cbn. unfold idfun.
+      rewrite transport_f_f. rewrite pathsinv0r. cbn.
       rewrite transport_target_postcompose. rewrite transport_target_postcompose.
       rewrite transport_target_postcompose. rewrite transport_source_precompose.
       set (tmp := @transport_hz_double_section
@@ -2734,11 +2734,11 @@ Section inv_rotation_mapping_cone.
       rewrite transport_source_target_comm.
       rewrite <- maponpathsinv0. rewrite pathsinv0inv0.
       unfold DS11. unfold DS6, DS5, DS2, DS1.
-      induction (hzrminusplus i 1). cbn. unfold idfun.
+      induction (hzrminusplus i 1). cbn.
       fold DS11 DS6 DS5 DS2 DS1.
       rewrite transport_source_precompose. apply cancel_postcomposition.
       rewrite pathscomp0rid. unfold DS11, DS5. induction (hzrplusminus (i - 1 + 1) 1).
-      cbn. unfold idfun. fold DS5. rewrite pathscomp0rid.
+      cbn. fold DS5. rewrite pathscomp0rid.
       set (tmp := @transport_hz_double_section_source_target
                     A (λ i0 : pr1 hz, C2 i0)
                     (λ i0 : pr1 hz, to_BinDirectSums A (C1 (i0 + 1)) (C2 i0))
@@ -2921,8 +2921,8 @@ Section inv_rotation_mapping_cone.
     use to_binop_eq.
     - apply cancel_precomposition. rewrite transport_source_precompose.
       unfold DS2, DS6. rewrite transport_source_target_comm. unfold DS1, DS5.
-      induction (hzrminusplus i 1). cbn. unfold idfun. rewrite pathscomp0rid.
-      induction (hzrminusplus (i - 1 + 1) 1). cbn. unfold idfun.
+      induction (hzrminusplus i 1). cbn. rewrite pathscomp0rid.
+      induction (hzrminusplus (i - 1 + 1) 1). cbn.
       rewrite id_left. apply idpath.
     - fold DS1 DS2. fold DS5 DS6. rewrite <- to_binop_inv_comm_2.
       rewrite to_commax'. rewrite <- to_assoc.
@@ -3080,7 +3080,7 @@ Section inv_rotation_mapping_cone.
     rewrite <- transport_source_precompose. rewrite <- assoc.
     rewrite (to_IdIn1 (to_BinDirectSums
                            A (to_BinDirectSums A (C1 (i + 1 - 1 + 1)) (C2 (i + 1 - 1))) (C1 i))).
-    rewrite id_right. induction (hzrplusminus i 1). cbn. unfold idfun. rewrite id_right.
+    rewrite id_right. induction (hzrplusminus i 1). cbn. rewrite id_right.
     apply idpath.
   Qed.
 
@@ -4566,7 +4566,7 @@ Section mapping_cone_octa.
     use to_binop_eq.
     - rewrite <- transport_target_to_inv. apply maponpaths.
       unfold DS4, DS3, DS1. unfold DS13, DS12, DS11. induction (hzrminusplus i 1). cbn.
-      unfold idfun. apply idpath.
+      apply idpath.
     - rewrite to_postmor_linear'.
       rewrite (to_commax' _ _ (f1 (i - 1 + 1 + 1) · to_In2 DS12 · to_In1 DS13)).
       rewrite <- transport_source_to_binop. rewrite <- transport_target_to_binop.
@@ -4575,7 +4575,7 @@ Section mapping_cone_octa.
                              (f1 (i + 1) · (to_In2 DS3 · to_In1 DS4))).
       use to_binop_eq.
       + unfold DS4, DS3, DS1. unfold DS13, DS12, DS11. induction (hzrminusplus i 1). cbn.
-        unfold idfun. rewrite assoc. apply idpath.
+        rewrite assoc. apply idpath.
       + rewrite <- PreAdditive_invlcomp.
         rewrite <- transport_source_to_inv. rewrite <- transport_target_to_inv.
         rewrite transport_source_precompose. rewrite transport_source_precompose.

--- a/UniMath/HomologicalAlgebra/TranslationFunctors.v
+++ b/UniMath/HomologicalAlgebra/TranslationFunctors.v
@@ -189,7 +189,7 @@ Section translation_functor.
     TranslationMorphism C1 C2 (ComplexHomotMorphism A H).
   Proof.
     unfold TranslationHomot. cbn. use MorphismEq. intros i. cbn.
-    induction (hzrminusplus i 1). cbn. rewrite pathscomp0rid. cbn. unfold idfun.
+    induction (hzrminusplus i 1). cbn. rewrite pathscomp0rid. cbn.
     rewrite <- PreAdditive_invrcomp. rewrite <- transport_target_to_inv.
     rewrite PreAdditive_invlcomp. rewrite inv_inv_eq.
     rewrite <- transport_target_to_inv.
@@ -222,7 +222,7 @@ Section translation_functor.
                      @ maponpaths (λ i0 : pr1 hz, i0 + 1) (hzrplusminus (i - 1 + 1) 1))).
       assert (ee : tmp = (hzrplusminus (i - 1 + 1 + 1) 1)) by apply isasethz.
       unfold tmp in ee. cbn in ee. unfold tmp. cbn. rewrite ee. clear ee. clear tmp.
-      induction (hzrplusminus (i - 1 + 1 + 1) 1). cbn. unfold idfun. apply idpath.
+      induction (hzrplusminus (i - 1 + 1 + 1) 1). cbn. apply idpath.
     }
     cbn in e1. rewrite e1. clear e1. use to_lrw.
     (* Show that the first elements of to_binop are the same *)
@@ -273,7 +273,7 @@ Section translation_functor.
     ZeroArrow (Additive.to_Zero A) _ _.
   Proof.
     induction (hzrminusplus (i + 1) 1 @ ! hzrplusminus (i + 1) 1).
-    induction (hzrminusplus i 1 @ ! hzrplusminus i 1). cbn. unfold idfun.
+    induction (hzrminusplus i 1 @ ! hzrplusminus i 1). cbn.
     rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invrcomp.
     rewrite inv_inv_eq. apply DSq.
   Qed.
@@ -320,7 +320,7 @@ Section translation_functor.
     - exact (maponpaths C2 (hzrplusminus i 1)).
     - rewrite transport_target_postcompose. rewrite transport_f_f. rewrite <- maponpathscomp0.
       rewrite <- path_assoc. rewrite pathsinv0l. rewrite pathscomp0rid.
-      induction (hzrminusplus i 1). cbn. unfold idfun.
+      induction (hzrminusplus i 1). cbn.
       rewrite transport_target_postcompose.
       set (tmp := transport_hz_double_section A C1 C2 (MMor f) _ _ (hzrplusminus (i - 1 + 1) 1)).
       cbn. cbn in tmp. rewrite tmp. clear tmp.
@@ -388,7 +388,7 @@ Section translation_functor.
     InvTranslationMorphism C1 C2 (ComplexHomotMorphism A H).
   Proof.
     unfold InvTranslationHomot. cbn. use MorphismEq. intros i. cbn.
-    induction (hzrplusminus i 1). cbn. unfold idfun. rewrite pathscomp0rid.
+    induction (hzrplusminus i 1). cbn. rewrite pathscomp0rid.
     rewrite <- transport_target_to_inv. rewrite <- PreAdditive_invrcomp.
     rewrite <- PreAdditive_invlcomp. rewrite inv_inv_eq.
     rewrite <- transport_target_to_inv. rewrite <- PreAdditive_invlcomp.
@@ -521,7 +521,7 @@ Section translation_functor.
                                        (to_inv (to_inv (Diff C (i - 1 + 1)))))) = Diff C i.
   Proof.
     rewrite inv_inv_eq.
-    induction (hzrminusplus i 1). cbn. unfold idfun.
+    induction (hzrminusplus i 1). cbn.
     rewrite transport_f_f.
     assert (e : maponpaths (λ i0 : pr1 hz, (C : Complex _) (i0 + 1))
                            (! hzrplusminus (i - 1 + 1) 1) =
@@ -555,7 +555,7 @@ Section translation_functor.
   Proof.
     use MorphismEq. intros i. Local Opaque ComplexEq. cbn.
     rewrite ComplexEq_transport_target. rewrite ComplexEq_transport_source. cbn.
-    induction (hzrminusplus i 1). cbn. unfold idfun. apply idpath.
+    induction (hzrminusplus i 1). cbn. apply idpath.
   Qed.
 
   Lemma TranslationInvTranslation :
@@ -604,7 +604,7 @@ Section translation_functor.
   Proof.
     Local Opaque ComplexEq. use MorphismEq. intros i. cbn.
     rewrite ComplexEq_transport_target. rewrite ComplexEq_transport_source. cbn.
-    induction (hzrplusminus i 1). cbn. unfold idfun. apply idpath.
+    induction (hzrplusminus i 1). cbn. apply idpath.
   Qed.
 
   Lemma InvTranslationTranslation :
@@ -636,7 +636,7 @@ Section translation_functor.
     rewrite <- transport_target_postcompose.
     rewrite id_right.
     rewrite transport_target_postcompose.
-    induction (hzrminusplus i 1). cbn. unfold idfun. rewrite id_left.
+    induction (hzrminusplus i 1). cbn. rewrite id_left.
     use transportf_paths.
     assert (e : maponpaths (λ i0 : pr1 hz, (x : Complex A) (i0 + 1))
                            (! hzrplusminus (i - 1 + 1) 1) =

--- a/UniMath/Induction/ImpredicativeInductiveSets.v
+++ b/UniMath/Induction/ImpredicativeInductiveSets.v
@@ -135,7 +135,7 @@ Proof.
   eapply pathscomp0.
   - apply (Product_com_con (C := Product_as_set) Pair).
   - apply funextfun; intro p.
-    unfold funcomp.
+    simpl.
     apply maponpaths.
     apply Product_weak_η.
 Defined.
@@ -335,7 +335,7 @@ Proof.
   eapply pathscomp0.
   apply Sum_com_con.
   apply funextfun; intro s.
-  unfold funcomp.
+  simpl.
   apply maponpaths.
   apply Sum_weak_eta.
 Defined.

--- a/UniMath/Induction/M/Chains.v
+++ b/UniMath/Induction/M/Chains.v
@@ -68,7 +68,7 @@ Lemma cochain_dmor_paths_type {ver1 ver2 ver3 : vertex conat_graph}
 Proof.
   intro v1; cbn in *.
   induction q1.
-  cbn; unfold idfun.
+  cbn.
   exact (toforallpaths _ _ _ (cochain_dmor_paths cochn p1 p2) v1).
 Defined.
 
@@ -240,7 +240,7 @@ Proof.
           xs (S u)).
     + apply (@weqsecovercontr_uncurried
                nat (λ n, (S u) = n) (λ _ _, _ _ = xs (S u)) (iscontr_paths_from _)).
-    + cbn; unfold funcomp, idfun.
+    + cbn.
       apply invweq.
       apply (@weqsecovercontr_uncurried
                nat (λ n, (S (S u)) = n) (λ _ _, _ = xs (S u)) (iscontr_paths_from _)).

--- a/UniMath/Induction/M/Chains.v
+++ b/UniMath/Induction/M/Chains.v
@@ -143,7 +143,7 @@ Definition shifted_limit (cocha : cochain type_precat) :
 Proof.
   pose (X := dob cocha); cbn in X.
   pose (π n := (@dmor _ _ cocha (S n) n (idpath _))).
-  unfold standard_limit, shift_cochain, funcomp, idfun; cbn.
+  unfold standard_limit, shift_cochain; cbn.
 
   assert (isc : ∏ x : ∏ v : nat, dob cocha (S v),
                 iscontr (∑ x0 : X 0, (π 0 (x 0)) = x0)).

--- a/UniMath/Induction/M/Limits.v
+++ b/UniMath/Induction/M/Limits.v
@@ -32,7 +32,7 @@ Section StandardLimits.
     use make_cone; cbn.
     - exact (λ n l, pr1 l n).
     - intros u v f.
-      apply funextsec; intro l; unfold funcomp; cbn.
+      apply funextsec; intro l; cbn.
       apply (pr2 l).
   Defined.
 
@@ -61,7 +61,7 @@ Section StandardLimitHomot.
                 @ pr2 x _ _ ed
                 @ toforallpaths _ _ _ p v).
     {
-      intros p; induction p; cbn; unfold idfun.
+      intros p; induction p; cbn.
       do 3 (apply funextsec; intro).
       exact (!(pathscomp0rid _)).
     }
@@ -126,7 +126,7 @@ Section StandardLimitUP.
     - intros f.
       apply funextfun; intro xcone.
       use total2_paths_f; cbn; [reflexivity|].
-      cbn; unfold idfun.
+      cbn.
       apply funextsec; intro ver1.
       apply funextsec; intro ver2.
       apply funextsec; intro ed.
@@ -139,7 +139,7 @@ Section StandardLimitUP.
       + apply funextsec; intro ver1.
         apply funextsec; intro ver2.
         apply funextsec; intro ed.
-        unfold funcomp; cbn; unfold idfun.
+        cbn.
         rewrite toforallpaths_funextsec; cbn.
         rewrite funextsec_toforallpaths.
         reflexivity.
@@ -185,7 +185,7 @@ Section CochainLimit.
     - intros v cochain_limit_element.
       apply (pr1 cochain_limit_element).
     - intros u v e.
-      apply funextsec; intro l; unfold funcomp; cbn.
+      apply funextsec; intro l; cbn.
       refine (_ @ pr2 l _).
       unfold dmor, π', π.
       apply simplify_cochain_step.

--- a/UniMath/Induction/W/Naturals.v
+++ b/UniMath/Induction/W/Naturals.v
@@ -121,8 +121,7 @@ Definition make_nat_functor_algebra_mor {X Y : algebra_ob nat_functor} :
 Proof.
   intros X' Y' f p.
   apply from_nat_functor_eq.
-  + unfold funcomp.
-    refine (_ @ !maponpaths _ (nat_functor_arr_true f _)).
+  + refine (_ @ !maponpaths _ (nat_functor_arr_true f _)).
     refine (pr1 p @ _).
     apply (maponpaths (pr2 Y)), maponpaths.
     reflexivity.

--- a/UniMath/Ktheory/GrothendieckGroup.v
+++ b/UniMath/Ktheory/GrothendieckGroup.v
@@ -25,7 +25,7 @@ Section setquot.
   Proof.
     use weq_iso.
     - intros h. exists (h ∘ setquotpr R).
-      intros x x' r. unfold funcomp. apply maponpaths. apply iscompsetquotpr. exact r.
+      intros x x' r. simpl. apply maponpaths. apply iscompsetquotpr. exact r.
     - intros f. exact (setquotuniv R Y (pr1 f) (pr2 f)).
     - intros h. apply funextsec. unfold pr1,pr2. intros w. apply setquot_map_recovery.
     - intros f. cbn beta. apply subtypePath.

--- a/UniMath/MoreFoundations/Equivalences.v
+++ b/UniMath/MoreFoundations/Equivalences.v
@@ -1,7 +1,6 @@
 (** * Equivalences *)
 
 Require Import UniMath.Foundations.All.
-Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Notations.
 Require Import UniMath.MoreFoundations.Tactics.
 

--- a/UniMath/MoreFoundations/Equivalences.v
+++ b/UniMath/MoreFoundations/Equivalences.v
@@ -1,6 +1,7 @@
 (** * Equivalences *)
 
 Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Notations.
 Require Import UniMath.MoreFoundations.Tactics.
 
@@ -330,7 +331,7 @@ Proof.
     apply (maponpaths pathsinv0).
     assert (r := ! maponpaths_fun_fun_fun_natl q (funcomp f g) q (g y)); simpl in r.
     rewrite maponpathsidfun in r. repeat rewrite <- (maponpathscomp f g) in r.
-    unfold funcomp in r; simpl in r. repeat rewrite path_assoc.
+    simpl in r. repeat rewrite path_assoc.
     rewrite r. maponpaths_pre_post_cat. clear r.
     assert (r := ! maponpaths_fun_fun_fun_natl p g q y); simpl in r.
     rewrite maponpathsidfun in r. rewrite (maponpathscomp f).
@@ -364,7 +365,7 @@ Proof.
     apply pathsinv0. repeat rewrite <- (maponpathscomp0 g).
     apply (maponpaths (maponpaths g)). rewrite h.
     assert (r := ! maponpaths_fun_fun_natl p p (f (g y))); simpl in r.
-    rewrite maponpathsidfun in r. unfold funcomp in *; simpl in *.
+    rewrite maponpathsidfun in r. simpl in *.
     repeat rewrite <- (maponpathscomp g f) in r.
     repeat rewrite (path_assoc _ _ (p y)). rewrite r.
     repeat rewrite <- (path_assoc _ _ (p y)). apply (maponpaths pre_cat). clear r.

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -2,11 +2,6 @@
 Require Import UniMath.Foundations.All.
 Require Import UniMath.MoreFoundations.Tactics.
 
-(** Make [simpl], [cbn], etc. unfold [idfun X x] but not [ idfun x ]: *)
-Arguments idfun _ _ / .
-
-(** Make [simpl], [cbn], etc. unfold [ (f ∘ g) x ] but not [ f ∘ g ]: *)
-Arguments funcomp {_ _ _} _ _ _/.
 
 Lemma maponpaths_for_constant_function {T1 T2 : UU} (x : T2) {t1 t2 : T1}
       (e: t1 = t2): maponpaths (fun _: T1 => x) e = idpath x.

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -2,6 +2,12 @@
 Require Import UniMath.Foundations.All.
 Require Import UniMath.MoreFoundations.Tactics.
 
+(** Make [simpl], [cbn], etc. unfold [idfun X x] but not [ idfun x ]: *)
+Arguments idfun _ _ / .
+
+(** Make [simpl], [cbn], etc. unfold [ (f ∘ g) x ] but not [ f ∘ g ]: *)
+Arguments funcomp {_ _ _} _ _ _/.
+
 Lemma maponpaths_for_constant_function {T1 T2 : UU} (x : T2) {t1 t2 : T1}
       (e: t1 = t2): maponpaths (fun _: T1 => x) e = idpath x.
 Proof.
@@ -828,8 +834,8 @@ Lemma transportf_paths_FlFr {A B : UU} {f g : A -> B} {x1 x2 : A}
  (p : x1 = x2) (q : f x1 = g x1)
  : transportf (λ x, f x = g x) p q = !maponpaths f p @ q @ maponpaths g p.
 Proof.
- induction p; cbn.
- symmetry.
+ induction p. cbn.
+ apply pathsinv0.
  apply pathscomp0rid.
 Qed.
 

--- a/UniMath/MoreFoundations/Univalence.v
+++ b/UniMath/MoreFoundations/Univalence.v
@@ -20,7 +20,7 @@ Defined.
 Definition toforallpaths_funextsec_comp {T : UU} {P : T -> UU} (f g : ∏ t, P t) :
   toforallpaths P f g ∘ funextsec P f g = idfun _.
 Proof.
-  apply funextsec; intro; unfold funcomp.
+  apply funextsec; intro. simpl.
   apply toforallpaths_funextsec.
 Defined.
 
@@ -131,5 +131,5 @@ Proof.
     { unfold weqonsecbase; simpl. exact g. } }
   { intros [f h]. simpl. unfold maponsec1; simpl.
     induction k, l; simpl. unfold transportf; simpl.
-    unfold idfun; simpl. apply idweq. }
+    apply idweq. }
 Defined.

--- a/UniMath/NumberSystems/NaturalNumbersAlgebra.v
+++ b/UniMath/NumberSystems/NaturalNumbersAlgebra.v
@@ -71,7 +71,7 @@ Proof.
   simple refine (_ @ w).
   unfold iterop_fun_mon.
   apply maponpaths. rewrite weqcomp_to_funcomp. apply funextfun; intro i.
-  unfold funcomp. apply maponpaths. exact (! homotweqinvweq x' (x i)).
+  simpl. apply maponpaths. exact (! homotweqinvweq x' (x i)).
 Defined.
 
 (** *** [nat] as a commutative rig *)

--- a/UniMath/NumberSystems/NaturalNumbers_le_Inductive.v
+++ b/UniMath/NumberSystems/NaturalNumbers_le_Inductive.v
@@ -18,7 +18,7 @@ numbers from the univalent perspecive. *)
 (** Imports. *)
 
 Require Export UniMath.Foundations.NaturalNumbers.
-
+Require Import UniMath.MoreFoundations.PartA.
 
 
 (** ** Inductive types [le] with values in [UU].
@@ -38,7 +38,7 @@ Lemma leFiter {T : UU} (F : T -> T) (t : T) (n : nat) : leF F t (iteration F n t
 Proof.
   intros. induction n as [ | n IHn ].
   - apply leF_O.
-  - simpl. unfold funcomp. apply leF_S. assumption.
+  - simpl. apply leF_S. assumption.
 Defined.
 
 Lemma leFtototal2withnat {T : UU} (F : T -> T) (t t' : T) (a : leF F t t') :

--- a/UniMath/NumberSystems/NaturalNumbers_le_Inductive.v
+++ b/UniMath/NumberSystems/NaturalNumbers_le_Inductive.v
@@ -18,8 +18,6 @@ numbers from the univalent perspecive. *)
 (** Imports. *)
 
 Require Export UniMath.Foundations.NaturalNumbers.
-Require Import UniMath.MoreFoundations.PartA.
-
 
 (** ** Inductive types [le] with values in [UU].
 

--- a/UniMath/PAdics/fps.v
+++ b/UniMath/PAdics/fps.v
@@ -123,8 +123,7 @@ Proof.
   revert f i p. induction upper.
   - intros f i p.
     destruct i.
-    + unfold funcomp. simpl.
-      unfold natcoface. simpl.
+    + unfold natcoface. simpl.
       set (H:=pr2 R). simpl in H.
       set (H1:=pr1 H).
       set (H2:=pr1 H1).
@@ -140,7 +139,7 @@ Proof.
       * change ( natsummation0 ( S upper ) f + f ( S ( S upper ) ) =
                  natsummation0 ( S upper ) ( funcomp ( natcoface ( S i ) ) f ) + f ( S i ) ).
         rewrite ( IHupper f ( S i ) ).
-        -- simpl. unfold funcomp at 3. unfold natcoface at 3.
+        -- simpl. unfold natcoface at 3.
            rewrite 2! ( ringassoc1 R ).
            rewrite ( ringcomm1 R _ ( f ( S i ) ) ).
            simpl.
@@ -152,16 +151,16 @@ Proof.
         assert ( natsummation0 upper ( funcomp ( natcoface ( S i ) ) f ) =
                  natsummation0 upper f ) as h.
         { apply natsummationpathsupperfixed.
-          intros m q. unfold funcomp. unfold natcoface.
+          intros m q. unfold natcoface.
           assert ( natlth m ( S i ) ) as q'.
           { apply ( natlehlthtrans _ upper ).
             -- assumption.
             -- rewrite k. apply natlthnsn.
           }
           unfold natlth in q'.
-          rewrite q'. apply idpath.
+          unfold funcomp. rewrite q'. apply idpath.
         }
-        rewrite <- h. unfold funcomp, natcoface at 3. simpl.
+        rewrite <- h. unfold natcoface at 3. simpl.
         rewrite ( natgehimplnatgtbfalse i upper ).
         -- rewrite 2! ( ringassoc1 R ).
            rewrite ( ringcomm1 R ( f ( S ( S upper ) ) ) ).
@@ -827,7 +826,7 @@ Proof.
               }
               change ( idfun _ m'' = idfun _ n ).
               rewrite <- ( natcofaceretractisretract v ).
-              unfold funcomp.
+              simpl.
               rewrite g.
               apply idpath.
       * apply fromempty.
@@ -844,7 +843,6 @@ Proof.
            assumption.
         -- apply natlthnsn.
   - intros x X.
-    unfold funcomp.
     assert ( natleh ( i ( natcoface v x ) ) ( S upper ) ) as a0.
     { apply (pr2 p).
       apply natcofaceleh.
@@ -896,12 +894,12 @@ Proof.
     split.
     + apply ( nattruncautopreimageineq p' ).
     + split.
-      * unfold funcomp.
+      * simpl.
         rewrite ( nattruncautopreimagepath p' _ ).
         rewrite ( nattruncautopreimagepath p _ ).
         apply idpath.
       * intros x X y.
-        unfold funcomp in y.
+        simpl in y.
         apply ( nattruncautoisinj p' ).
         -- apply nattruncautopreimageineq.
         -- assumption.
@@ -914,7 +912,6 @@ Proof.
               rewrite y.
               apply idpath.
   - intros x X.
-    unfold funcomp.
     apply (pr2 p).
     apply (pr2 p').
     assumption.
@@ -1094,13 +1091,13 @@ Proof.
                  ( natlthtoleh m ( S upper ) ( natlehlthtrans m upper ( S upper ) q
                    ( natlthnsn upper ) ) ) ) ).
       * split.
-        -- unfold funcomp.
+        -- simpl.
            rewrite pathssminus.
            ++ rewrite minussn1.
               apply nattruncautopreimagepath.
            ++ assumption.
         -- intros n uu k.
-           unfold funcomp in k.
+           simpl in k.
            rewrite <- ( minussn1 n ).
            assert ( v = S n ) as f.
            { apply ( nattruncautopreimagecanon p _ ); assumption. }
@@ -1140,7 +1137,7 @@ Lemma natsummationreindexing { R : commring } { upper : nat }
 Proof.
   revert i p f.
   induction upper.
-  - intros. simpl. unfold funcomp.
+  - intros. simpl.
     assert ( 0%nat = i 0%nat ) as f0.
     { destruct ( natlehchoice ( i 0%nat ) 0%nat ( pr2 p 0%nat ( isreflnatleh 0%nat ) ) )
         as [ h | k ].
@@ -1163,7 +1160,7 @@ Proof.
         -- change ( funcomp ( funcomp ( natcoface v ) i ) f ) with
                ( funcomp ( natcoface v ) ( funcomp i f ) ).
            assert ( f ( S upper ) = ( funcomp i f ) v ) as f0.
-           { unfold funcomp. rewrite j. apply idpath. }
+           { simpl. rewrite j. apply idpath. }
            rewrite f0.
            assert ( natleh v upper ) as aux.
            { apply natlthsntoleh. assumption. }
@@ -1175,7 +1172,7 @@ Proof.
          -- assert ( natsummation0 upper ( funcomp ( funcomp ( natcoface v ) i) f ) =
                     natsummation0 upper ( funcomp i f ) ) as f0.
             { apply natsummationpathsupperfixed.
-              intros x X. unfold funcomp. unfold natcoface.
+              intros x X. simpl. unfold natcoface.
               assert ( natlth x v ) as a0.
               { apply ( natlehlthtrans _ upper ).
                 ++ assumption.
@@ -1187,7 +1184,7 @@ Proof.
             }
             rewrite f0.
             assert ( f ( S upper ) = funcomp i f ( S upper ) ) as f1.
-            { unfold funcomp.
+            { simpl.
               rewrite <- r.
               rewrite j.
               rewrite <- r.
@@ -1198,7 +1195,7 @@ Proof.
          -- apply precompwithnatcofaceisauto.
             assumption.
     + rewrite natsummationshift0.
-      unfold funcomp at 2.
+      simpl.
       rewrite p0.
       rewrite j.
       assert ( i 0%nat = S upper ) as j'.

--- a/UniMath/PAdics/lemmas.v
+++ b/UniMath/PAdics/lemmas.v
@@ -283,7 +283,7 @@ Lemma natcofaceretractisretract ( i : nat ) :
   funcomp ( natcoface i ) ( natcofaceretract i ) = idfun nat.
 Proof.
   simpl. apply funextfun.
-  intro n. unfold funcomp.
+  intro n. simpl.
   set ( c := natlthorgeh n i ). destruct c as [ h | k ].
   - unfold natcoface. rewrite h. unfold natcofaceretract. rewrite h.  apply idpath.
   - assert ( natgtb i n = false ) as f.
@@ -303,7 +303,7 @@ Proof.
   rewrite <- ( natcofaceretractisretract i ).
   change y with ( idfun _ y ).
   rewrite <- ( natcofaceretractisretract i ).
-  unfold funcomp. rewrite p. apply idpath.
+  simpl. rewrite p. apply idpath.
 Defined.
 
 Lemma natlehdecomp ( b a : nat ) :

--- a/UniMath/Topology/Prelim.v
+++ b/UniMath/Topology/Prelim.v
@@ -262,7 +262,7 @@ Proof.
         intros m Hm.
       induction (natlehchoice _ _ (natlthsntoleh _ _ Hm)) as [Hm' | ->].
       generalize (pr2 Hx (m,,Hm')).
-      unfold funcomp, dni_lastelement ; simpl.
+      unfold dni_lastelement ; simpl.
       assert (H : Hm = natlthtolths m n Hm' ).
       { apply (pr2 (natlth m (S n))). }
       now rewrite H.
@@ -285,7 +285,7 @@ Proof.
   - induction L as [n L] ; simpl.
     apply maponpaths.
     apply funextfun ; intro m.
-    unfold funcomp.
+    simpl.
     rewrite <- replace_dni_last.
     apply append_vec_compute_1.
   - reflexivity.


### PR DESCRIPTION
A frequent cause of minor annoyance was the need to manually unfold `funcomp` and `idfun` in a lot of places.  This commit aims to reduce that, by tweaking their reduction behaviour so that they automatically unfold more easily (but not too easily):
```
(** Make [simpl], [cbn], etc. unfold [idfun X x] but not [ idfun x ]: *)
Arguments idfun _ _ / .

(** Make [simpl], [cbn], etc. unfold [ (f ∘ g) x ] but not [ f ∘ g ]: *)
Arguments funcomp {_ _ _} _ _ _ /.
```

This allows most instances of `unfold funcomp` and `unfold idfun` to be either removed entirely or replaced by `simpl`/`cbn` — much easier when writing proofs.  Before this change, the library had 132 instances of `unfold funcomp` and 95 of `unfold idfun`; afterwards, there are 42 and 5 respectively (and about a third of those are in `Foundations`, where I didn’t try to change/remove them).

When removing/changing uses of `unfold`, I was careful to avoid hurting both human-readability of the interactive proof states, and overall compilation speed.

This reduction tweak is an upstreaming from https://github.com/UniMath/TypeTheory/tree/master/TypeTheory .  As the maintainers may have noticed, I’m working on upstreaming a lot of things from there at the moment.  To try to keep the reviewing burden as easy as possible, I’m doing most of the miscellaneous upstreaming in a single branch, but for larger and potentially more impactful changes like this one, I’m splitting them out into separate branches+PR’s.  I hope that sounds good to the maintainers — please let me know if you’d like me to work differently, either consolidating or splitting up the PR’s more.