### PR TITLE
Provide better [maponpaths] lemmas for multi-argument functions, and unify duplicates elsewhere

### DIFF
--- a/UniMath/CategoryTheory/CategoriesWithBinOps.v
+++ b/UniMath/CategoryTheory/CategoriesWithBinOps.v
@@ -28,12 +28,6 @@ Section def_precategory_with_binops.
   (** Gives the binop of the homs from x to y. *)
   Definition to_binop {BC : precategoryWithBinOps} (x y : BC) : binop (BC⟦x, y⟧) := (pr2 BC) x y.
 
-  Lemma to_binop_eq {BC : precategoryWithBinOps} {x y : BC} {f1 f2 g1 g2 : x --> y}
-        (e1 : f1 = f2) (e2 : g1 = g2) : to_binop _ _ f1 g1 = to_binop _ _ f2 g2.
-  Proof.
-    induction e1, e2. apply idpath.
-  Qed.
-
 End def_precategory_with_binops.
 
 Definition oppositePrecategoryWithBinOps (M : precategoryWithBinOps) : precategoryWithBinOps

--- a/UniMath/CategoryTheory/Chains/OmegaCocontFunctors.v
+++ b/UniMath/CategoryTheory/Chains/OmegaCocontFunctors.v
@@ -55,6 +55,7 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.NaturalNumbers.
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Core.Categories.
@@ -979,7 +980,7 @@ destruct (natlthorgeh i j) as [h|h].
     rewrite BinProductOfArrows_comp, id_left.
     eapply pathscomp0; [apply BinProductOfArrows_comp|].
     rewrite id_right.
-    apply BinProductOfArrows_eq; trivial; rewrite id_left; simpl.
+    apply maponpaths_12; trivial; rewrite id_left; simpl.
     destruct (natlehchoice4 i j h0) as [h1|h1].
     + apply cancel_postcomposition, maponpaths, maponpaths, isasetbool.
     + destruct h1; destruct (isirreflnatlth _ h).
@@ -993,7 +994,8 @@ destruct (natlthorgeh i j) as [h|h].
       rewrite <- (coconeInCommutes ccK i (S i) (idpath _)), assoc.
       eapply pathscomp0; [apply cancel_postcomposition, BinProductOfArrows_comp|].
       rewrite id_left, id_right.
-      apply cancel_postcomposition, BinProductOfArrows_eq; trivial.
+      apply cancel_postcomposition,
+        (maponpaths_12 (BinProductOfArrows _ _ _)); trivial.
       simpl; destruct (natlehchoice4 i i h0) as [h1|h1]; [destruct (isirreflnatlth _ h1)|].
       apply maponpaths, maponpaths, isasetnat.
   * destruct (natgehchoice i j h) as [h1|h1].
@@ -1001,13 +1003,13 @@ destruct (natlthorgeh i j) as [h|h].
       { unfold fun_gt; rewrite assoc.
         eapply pathscomp0; [eapply cancel_postcomposition, BinProductOfArrows_comp|].
         rewrite id_right.
-        apply cancel_postcomposition, BinProductOfArrows_eq; trivial.
+        apply cancel_postcomposition, maponpaths_12; trivial.
         now rewrite <- (chain_mor_right h1 h2). }
       { destruct h; unfold fun_gt; simpl.
         generalize h1; clear h1.
         rewrite h2; intro h1.
         apply cancel_postcomposition.
-        apply BinProductOfArrows_eq; trivial; simpl.
+        apply maponpaths_12; trivial; simpl.
         destruct (natlehchoice4 j j h1); [destruct (isirreflnatlth _ h)|].
         apply maponpaths, maponpaths, isasetnat. }
     + destruct h1; destruct (negnatgehnsn _ h0).
@@ -1132,14 +1134,14 @@ Proof.
             unfold f, fun_gt.
             eapply pathscomp0; [apply BinProductOfArrows_comp|].
             rewrite id_left, id_right.
-            apply BinProductOfArrows_eq; trivial; simpl.
+            apply (maponpaths_12 (BinProductOfArrows _ _ _)); trivial; simpl.
             destruct (natlehchoice4 i i h0); [destruct (isirreflnatlth _ h1)|].
             apply maponpaths, maponpaths, isasetnat.
        }
     * destruct p, h.
       destruct (natlthorgeh i (S i)); [|destruct (negnatgehnsn _ h)].
       apply cancel_postcomposition; unfold f, fun_lt.
-      apply BinProductOfArrows_eq; trivial; simpl.
+      apply maponpaths_12; trivial; simpl.
       destruct (natlehchoice4 i i h); [destruct (isirreflnatlth _ h0)|].
       assert (H : idpath (S i) = maponpaths S p). apply isasetnat.
       now rewrite H.
@@ -1195,7 +1197,7 @@ Proof.
       apply pathsinv0.
       eapply pathscomp0; [apply BinProductOfArrows_comp|].
       rewrite !id_left, id_right.
-      apply BinProductOfArrows_eq; trivial.
+      apply maponpaths_12; trivial.
       apply (maponpaths pr1 (chain_mor_coconeIn cAB LM ccLM i j h)).
     * destruct (natgehchoice i j h).
       { unfold fun_gt; rewrite <- (p i), !assoc.

--- a/UniMath/CategoryTheory/Core/Categories.v
+++ b/UniMath/CategoryTheory/Core/Categories.v
@@ -14,6 +14,7 @@
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Notations.
 
 (** * Definition of a precategory *)
@@ -264,17 +265,13 @@ Qed.
 Lemma cancel_postcomposition {C : precategory_data} {a b c: C}
    (f f' : a --> b) (g : b --> c) : f = f' -> f · g = f' · g.
 Proof.
-  intro H.
-  induction H.
-  apply idpath.
+  intro; apply maponpaths_2; assumption.
 Defined.
 
 Lemma cancel_precomposition (C : precategory_data) (a b c: C)
    (f f' : b --> c) (g : a --> b) : f = f' -> g · f = g · f'.
 Proof.
-  intro H.
-  induction H.
-  apply idpath.
+  apply maponpaths.
 Defined.
 
 (** Any equality on objects a and b induces a morphism from a to b *)

--- a/UniMath/CategoryTheory/Core/NaturalTransformations.v
+++ b/UniMath/CategoryTheory/Core/NaturalTransformations.v
@@ -109,11 +109,13 @@ Section nat_trans_eq.
 
 End nat_trans_eq.
 
+(* Can be given as an instance of general equality lemmas,
+but useful to have specifically defined. *)
 Definition nat_trans_eq_pointwise {C C' : precategory_data}
    {F F' : functor_data C C'} {a a' : nat_trans F F'}:
       a = a' -> ∏ x, a x = a' x.
 Proof.
-  intro; apply toforallpaths, maponpaths; assumption.
+  intro. apply toforallpaths, maponpaths. assumption.
 Qed.
 
 (** a more intuitive variant of [functor_data_eq] *)

--- a/UniMath/CategoryTheory/PreAdditive.v
+++ b/UniMath/CategoryTheory/PreAdditive.v
@@ -11,6 +11,8 @@ Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
+Require Import UniMath.MoreFoundations.PartA.
+
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids.
 Require Import UniMath.Algebra.Groups.
@@ -174,12 +176,12 @@ Section preadditive_with_zero.
 
   Lemma to_lunax'' {Z : Zero A} (x y : A) (f : x --> y) : to_binop x y (ZeroArrow Z x y) f = f.
   Proof.
-    rewrite <- to_lunax'. use to_lrw. apply pathsinv0. apply PreAdditive_unel_zero.
+    rewrite <- to_lunax'. apply maponpaths_2, pathsinv0, PreAdditive_unel_zero.
   Qed.
 
   Lemma to_runax'' {Z : Zero A} (x y : A) (f : x --> y) : to_binop x y f (ZeroArrow Z x y) = f.
   Proof.
-    rewrite <- to_runax'. use to_rrw. apply pathsinv0. apply PreAdditive_unel_zero.
+    rewrite <- to_runax'. apply maponpaths, pathsinv0, PreAdditive_unel_zero.
   Qed.
 
   Lemma to_linvax' {Z : Zero A} {x y : A} (f : A⟦x, y⟧) :
@@ -362,12 +364,6 @@ Section preadditive_quotient.
   Definition subgrhrel {A : gr} (B : @subgr A) : @hrel A :=
     (λ a1 : A, λ a2 : A, (subgrhrel_hprop B a1 a2)).
 
-  (** Some equalities *)
-  Local Lemma ropeq (X : setwithbinop) (x y z : X) : x = y -> @op X x z = @op X y z.
-  Proof.
-    intros e. induction e. apply idpath.
-  Qed.
-
   (** Let B be a subgroup of A. Then the canonical map A -> A/B is a monoidfun. *)
   Local Lemma abgrquotpr_ismonoidfun {A : abgr} (H : @binopeqrel A) :
     @ismonoidfun A (abgrquot H) (λ a : A, setquotpr H a).
@@ -409,7 +405,7 @@ Section preadditive_quotient.
         * exact (op (pr1 t) (pr1 t0)).
         * exact (pr2subsetswithbinop B t t0).
       + cbn. rewrite p. rewrite p0. rewrite <- (assocax A).
-        apply ropeq. rewrite assocax. rewrite grlinvax. rewrite runax.
+        apply maponpaths_2. rewrite assocax. rewrite grlinvax. rewrite runax.
         apply idpath.
     (* isrefl *)
     - intros x.

--- a/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
+++ b/UniMath/CategoryTheory/PrecategoriesWithAbgrops.v
@@ -109,11 +109,6 @@ Section def_precategory_with_abgrops.
     apply (grinvmaponpathsinv (to_abgr x y) H).
   Qed.
 
-  Lemma to_apply_inv {x y : PA} (f g : PA⟦x, y⟧) (H : f = g) : (to_inv f) = (to_inv g).
-  Proof.
-    apply maponpaths. apply H.
-  Qed.
-
   Lemma to_inv_unel {x y : PA} : to_inv (to_unel x y) = to_unel x y.
   Proof.
     unfold to_unel.

--- a/UniMath/CategoryTheory/RepresentableFunctors/Precategories.v
+++ b/UniMath/CategoryTheory/RepresentableFunctors/Precategories.v
@@ -431,22 +431,6 @@ Proof.
   unshelve refine (total2_paths_f _ _); reflexivity.
 Qed.
 
-(*  *)
-
-Lemma total2_paths1 {A : UU} {B : A -> UU} (a:A) {b b':B a} :
-  b=b' -> tpair B a b = tpair B a b'.
-Proof.
-  intro e. induction e. reflexivity.
-Defined.
-
-Goal ∏ A : UU, ∏ B : A -> UU, ∏ p : (∑ a, B a), p = tpair B (pr1 p) (pr2 p).
-  induction p as [a b]. reflexivity.
-Defined.
-
-Goal ∏ X Y (f:X->Y), f = λ x, f x.
-  reflexivity.
-Defined.
-
 (* new categories from old *)
 
 Definition categoryWithStructure (C:category) (P:ob C -> UU) : category.

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -314,15 +314,6 @@ Variable C : precategory.
 Variable CC : BinCoproducts C.
 Variables a b c d x y : C.
 
-Lemma BinCoproductArrow_eq (f f' : a --> c) (g g' : b --> c)
-  : f = f' → g = g' →
-      BinCoproductArrow _ (CC _ _) f g = BinCoproductArrow _ _ f' g'.
-Proof.
-  induction 1.
-  induction 1.
-  apply idpath.
-Qed.
-
 Lemma BinCoproductArrow_eq_cor (f f' : BinCoproductObject C (CC a b) --> c)
   : BinCoproductIn1 _ _· f = BinCoproductIn1 _ _· f' → BinCoproductIn2 _ _· f = BinCoproductIn2 _ _· f' →
       f = f' .
@@ -330,7 +321,7 @@ Proof.
   intros Hyp1 Hyp2.
   rewrite (BinCoproductArrowEta _ _ _ _ _ f).
   rewrite (BinCoproductArrowEta _ _ _ _ _ f').
-  apply BinCoproductArrow_eq; assumption.
+  apply maponpaths_12; assumption.
 Qed.
 
 (** specialized versions of beta rules for coproducts *)

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -578,15 +578,6 @@ Proof.
     apply assoc.
 Qed.
 
-Definition BinCoproductOfArrows_eq (f f' : a --> c) (g g' : b --> d)
-  : f = f' → g = g' →
-      BinCoproductOfArrows _ _ _ f g = BinCoproductOfArrows _ (CC _ _) (CC _ _) f' g'.
-Proof.
-  induction 1.
-  induction 1.
-  apply idpath.
-Qed.
-
 Lemma precompWithBinCoproductArrow_eq  (CCab : BinCoproduct _ a b)
     (CCcd : BinCoproduct _ c d) (f : a --> c) (g : b --> d)
      (k : c --> x) (h : d --> x) (fk : a --> x) (gh : b --> x):

--- a/UniMath/CategoryTheory/limits/binproducts.v
+++ b/UniMath/CategoryTheory/limits/binproducts.v
@@ -235,15 +235,6 @@ Proof.
     apply assoc.
 Qed.
 
-Definition BinProductOfArrows_eq (f f' : a --> c) (g g' : b --> d)
-  : f = f' → g = g' →
-      BinProductOfArrows _ _ _ f g = BinProductOfArrows _ (CC _ _) (CC _ _) f' g'.
-Proof.
-  induction 1.
-  induction 1.
-  apply idpath.
-Qed.
-
 End BinProducts.
 
 Section BinProduct_unique.

--- a/UniMath/CategoryTheory/limits/binproducts.v
+++ b/UniMath/CategoryTheory/limits/binproducts.v
@@ -708,14 +708,6 @@ Arguments isBinProduct' _ _ _ _ _ : clear implicits.
 
 (** ** Terminal object as the unit (up to isomorphism) of binary products *)
 
-Local Lemma f_equal_2 :
-  forall {A B C : UU} (f : A -> B -> C) (a a' : A) (b b' : B),
-    a = a' -> b = b' -> f a b = f a' b'.
-Proof.
-  do 8 intro; intros eq1 eq2.
-  abstract (now rewrite eq1; rewrite eq2).
-Defined.
-
 (** [T × x ≅ x]*)
 Lemma terminal_binprod_unit_l {C : precategory}
       (T : Terminal C) (BC : BinProducts C) :
@@ -732,7 +724,7 @@ Proof.
     split; [|apply BinProductPr2Commutes].
     refine (precompWithBinProductArrow _ _ _ _ _ @ _).
     refine (_ @ !BinProductArrowEta _ _ _ _ _ (identity _)).
-    apply f_equal_2.
+    apply maponpaths_12.
     + apply TerminalArrowEq.
     + exact (id_right _ @ !id_left _).
 Defined.
@@ -754,7 +746,7 @@ Proof.
     split; [|apply BinProductPr1Commutes].
     refine (precompWithBinProductArrow _ _ _ _ _ @ _).
     refine (_ @ !BinProductArrowEta _ _ _ _ _ (identity _)).
-    apply f_equal_2.
+    apply maponpaths_12.
     + exact (id_right _ @ !id_left _).
     + apply TerminalArrowEq.
 Defined.

--- a/UniMath/CategoryTheory/limits/coproducts.v
+++ b/UniMath/CategoryTheory/limits/coproducts.v
@@ -178,12 +178,6 @@ rewrite assoc, CoproductOfArrowsIn.
 now rewrite <- assoc, CoproductOfArrowsIn, assoc.
 Qed.
 
-Definition CoproductOfArrows_eq (a c : I -> C) (f f' : ∏ i, a i --> c i) : f = f' ->
-  CoproductOfArrows _ _ _ _ f = CoproductOfArrows _ _ (CC _) (CC _) f'.
-Proof.
-now induction 1.
-Qed.
-
 End Coproducts.
 
 Section functors.

--- a/UniMath/CategoryTheory/limits/products.v
+++ b/UniMath/CategoryTheory/limits/products.v
@@ -155,15 +155,6 @@ rewrite <- assoc, ProductOfArrowsPr.
 now rewrite assoc, ProductOfArrowsPr, assoc.
 Qed.
 
-(* Definition ProductOfArrows_eq (f f' : a --> c) (g g' : b --> d) *)
-(*   : f = f' → g = g' → *)
-(*       ProductOfArrows _ _ _ f g = ProductOfArrows _ (CC _ _) (CC _ _) f' g'. *)
-(* Proof. *)
-(*   induction 1. *)
-(*   induction 1. *)
-(*   apply idpath. *)
-(* Qed. *)
-
 End Products.
 
 Section Product_unique.

--- a/UniMath/HomologicalAlgebra/Complexes.v
+++ b/UniMath/HomologicalAlgebra/Complexes.v
@@ -17,6 +17,8 @@ Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.NaturalNumbers.
 
+Require Import UniMath.MoreFoundations.PartA.
+
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids.
 Require Import UniMath.Algebra.Groups.
@@ -589,7 +591,7 @@ Section transport_section'.
         (i i' : hz) (e1 : i = i') :
     H i' = transportf (λ (x : ob C), C⟦x, f (i' + n)⟧) (maponpaths f e1)
                       (transportf (precategory_morphisms (f i))
-                                  (maponpaths f (hzplusradd i i' n e1)) (H i)).
+                                  (maponpaths f (maponpaths_2 _ e1 _)) (H i)).
   Proof.
     induction e1. apply idpath.
   Qed.
@@ -597,7 +599,7 @@ Section transport_section'.
   Lemma transport_hz_target_source (f : hz -> ob C) (n : hz) (H : ∏ (i : hz), C⟦f i, f (i + n)⟧)
         (i i' : hz) (e1 : i = i') :
     H i' = transportf (precategory_morphisms (f i'))
-                      (maponpaths f (hzplusradd i i' n e1))
+                      (maponpaths f (maponpaths_2 _ e1 _))
                       (transportf (λ (x : ob C), C⟦x, f (i + n)⟧) (maponpaths f e1) (H i)).
   Proof.
     induction e1. apply idpath.
@@ -605,7 +607,7 @@ Section transport_section'.
 
   Lemma transport_hz_section (f : hz -> ob C) (n : hz) (H : ∏ (i : hz), C⟦f i, f (i + n)⟧)
         (i i' : hz) (e1 : i = i') :
-    transportf (precategory_morphisms (f i)) (maponpaths f (hzplusradd i i' n e1)) (H i) =
+    transportf (precategory_morphisms (f i)) (maponpaths f (maponpaths_2 _ e1 _)) (H i) =
     transportf (λ (x : ob C), C⟦x, f (i' + n)⟧) (maponpaths f (! e1)) (H i').
   Proof.
     induction e1. apply idpath.
@@ -938,7 +940,7 @@ Section acyclic_complexes.
     use (transport_target_path _ _ (! maponpaths C (hzrminusplus i 1))).
     rewrite <- transport_target_postcompose. rewrite transport_f_f.
     rewrite pathsinv0r. rewrite transport_target_ZeroArrow.
-    use (transport_target_path _ _ (maponpaths C (hzplusradd _ _ 1 e'))).
+    use (transport_target_path _ _ (maponpaths C (maponpaths_2 _ e' _))).
     rewrite transport_target_ZeroArrow. rewrite transport_f_f. cbn.
     rewrite <- (DSq A C i0). rewrite transport_compose.
     rewrite transport_target_postcompose. apply cancel_precomposition.
@@ -1145,7 +1147,7 @@ Section complexes_precat.
       assert (e : (transportf (precategory_morphisms (C1 i0)) (maponpaths C2 (! T))
                               (MMor (EpiArrow _ E) i0)) · Diff C2 (i - 1) =
                   (Diff C1 i0) · (transportf (precategory_morphisms (C1 (i0 + 1)))
-                                              (maponpaths C2 (hzplusradd i0 (i - 1) 1 (! T)))
+                                              (maponpaths C2 (maponpaths_2 _ (!T) _))
                                               (MMor (EpiArrow _ E) (i0 + 1)))).
       {
         rewrite <- transport_target_postcompose. rewrite <- MComm.
@@ -1157,12 +1159,12 @@ Section complexes_precat.
       rewrite transport_f_f. rewrite <- maponpathscomp0.
       use (@transport_source_path
              A (C1 i) (C1 (i0 + 1)) a _ _
-             (maponpaths C1 (hzplusradd i0 (i - 1) 1 (! T) @ hzrminusplus i 1))).
+             (maponpaths C1 (maponpaths_2 _ (!T) _ @ hzrminusplus i 1))).
       rewrite transport_source_precompose. rewrite transport_source_precompose.
       rewrite transport_source_target_comm.
       set (tmp''' := transport_hz_double_section_source_target
                        A _ _ (MMor (EpiArrow _ E)) _ _
-                       (hzplusradd i0 (i - 1) 1 (! T) @ hzrminusplus i 1)).
+                       (maponpaths_2 _ (! T) _ @ hzrminusplus i 1)).
       cbn in tmp'''. cbn. rewrite <- tmp'''. clear tmp'''.
       exact H.
     - induction (isdecrelhzeq (i - 1 + 1) i0) as [e' | n'].

--- a/UniMath/HomologicalAlgebra/Complexes.v
+++ b/UniMath/HomologicalAlgebra/Complexes.v
@@ -216,6 +216,7 @@ Section def_complexes.
     - use proofirrelevance. apply impred_isaprop. intros t. apply to_has_homsets.
   Qed.
 
+  (** Inverse to [MorphismEq] *)
   Lemma MorphismEq' {C1 C2 : Complex} (M1 M2 : Morphism C1 C2) (H : M1 = M2) :
     ∏ i : hz, M1 i = M2 i.
   Proof.

--- a/UniMath/HomologicalAlgebra/MappingCone.v
+++ b/UniMath/HomologicalAlgebra/MappingCone.v
@@ -1478,7 +1478,7 @@ Section rotation_mapping_cone.
                                   (transportf (λ x' : A, A ⟦ x', DS6 ⟧)
                                               (maponpaths
                                                  C2 (hzrminusplus (i + 1) 1)) (to_In1 DS6))))).
-        use to_lrw. apply maponpaths.
+        apply maponpaths_2, maponpaths.
         unfold DS4, DS3, DS6, DS5.
         set (tmp := @transport_hz_to_In1
                       A (λ i0 : hz, C2 (i0 + 1))

--- a/UniMath/HomologicalAlgebra/MappingCone.v
+++ b/UniMath/HomologicalAlgebra/MappingCone.v
@@ -645,7 +645,7 @@ Section mapping_cone_of_id.
                       _ _ (hzrminusplus i 1)). cbn beta in tmp.
         exact (! tmp).
       }
-      set (e3 := to_binop_eq e1 e2).
+      set (e3 := maponpaths_12 (to_binop _ _) e1 e2).
       apply (maponpaths (λ gg : _, to_Pr2 DS1 · gg)) in e3.
       apply (maponpaths
                (λ gg : _, to_binop
@@ -824,7 +824,7 @@ Section rotation_mapping_cone.
     rewrite to_assoc. rewrite to_assoc. rewrite (@to_linvax' A (Additive.to_Zero _)).
     rewrite to_runax''. rewrite to_binop_inv_inv. apply maponpaths.
     rewrite to_commax'.
-    use to_binop_eq.
+    use maponpaths_12.
     - apply cancel_postcomposition. rewrite <- PreAdditive_invrcomp.
       rewrite <- PreAdditive_invrcomp. apply maponpaths.
       exact (MComm f (i + 1)).
@@ -1050,7 +1050,7 @@ Section rotation_mapping_cone.
     rewrite (to_IdIn1 DS8). rewrite (to_Unel1' DS8). rewrite id_left.
     rewrite ZeroArrow_comp_left. rewrite to_runax''. rewrite id_left.
     rewrite <- transport_target_to_binop. rewrite <- transport_source_to_binop.
-    use to_binop_eq.
+    use maponpaths_12.
     + rewrite PreAdditive_invlcomp.
       unfold DS2, DS1, DS6, DS5.
       set (tmp := transport_hz_double_section_source_target
@@ -1191,7 +1191,7 @@ Section rotation_mapping_cone.
   Proof.
     use MorphismEq. intros i. cbn.
     apply pathsinv0. use (pathscomp0 _ (RotMorphismIsoEq2'_eq f i)).
-    use to_binop_eq.
+    use maponpaths_12.
     - exact (RotMorphismIsoEq2''_1 f i).
     - unfold RotMorphismIsoHomot.
       unfold MappingConeDiff.
@@ -1215,7 +1215,7 @@ Section rotation_mapping_cone.
       rewrite <- (assoc _ (to_In2 DS4)). rewrite <- (assoc _ (to_In2 DS4)).
       rewrite (to_IdIn2 DS4). rewrite id_right. rewrite id_right.
       rewrite to_postmor_linear'. rewrite <- transport_target_to_binop.
-      use to_binop_eq.
+      use maponpaths_12.
       + exact (RotMorphismIsoEq2''_2 f i).
       + exact (RotMorphismIsoEq2''_3 f i).
   Qed.
@@ -1314,7 +1314,7 @@ Section rotation_mapping_cone.
     set (DS8 := to_BinDirectSums A (C2 (i - 1 + 1)) DS7).
     unfold DiffTranslationComplex.
     rewrite to_premor_linear'. rewrite to_premor_linear'.
-    use to_binop_eq.
+    use maponpaths_12.
     - rewrite <- assoc. apply cancel_precomposition.
       rewrite <- transport_source_precompose. rewrite assoc. rewrite (to_IdIn1 DS8).
       rewrite id_left. induction (hzrminusplus i 1). apply idpath.
@@ -1386,7 +1386,7 @@ Section rotation_mapping_cone.
     rewrite <- (assoc _ _ (to_Pr2 DS3)). rewrite (to_IdIn2 DS3). rewrite id_right.
     rewrite assoc. rewrite assoc.
     rewrite <- (assoc _ _ (to_Pr2 DS3)). rewrite (to_IdIn2 DS3). rewrite id_right.
-    use to_binop_eq.
+    use maponpaths_12.
     - rewrite assoc. apply idpath.
     - rewrite assoc. apply idpath.
   Qed.
@@ -1415,7 +1415,7 @@ Section rotation_mapping_cone.
                                                             (to_BinDirectSums
                                                                A (C1 (i0 + 1)) (C2 i0)))
                                      _ _ (hzrplusminus i 1)) (RotMorphismCommMor2 f i))).
-    - use to_binop_eq.
+    - use maponpaths_12.
       + apply maponpaths. exact (RotMorphismCommHomot1 f i).
       + apply maponpaths. exact (RotMorphismCommHomot2 f i).
     - unfold RotMorphismCommMor1, RotMorphismCommMor2. cbn.
@@ -1460,7 +1460,7 @@ Section rotation_mapping_cone.
                                 (to_binop DS1 DS2
                                           (to_Pr1 DS1 · to_inv (f (i + 1)) · to_In1 DS2)
                                           (to_Pr1 DS1 · to_In1 DS1 · to_In2 DS2))))).
-      use to_binop_eq.
+      use maponpaths_12.
       + rewrite <- PreAdditive_invrcomp. rewrite <- PreAdditive_invlcomp.
         rewrite PreAdditive_invrcomp. rewrite <- to_premor_linear'.
         rewrite <- (ZeroArrow_comp_right _ _ _ _ _ (to_Pr2 DS1 · Diff C2 i)).
@@ -1511,7 +1511,7 @@ Section rotation_mapping_cone.
       + rewrite <- to_binop_inv_inv.
         rewrite <- PreAdditive_invrcomp. rewrite <- PreAdditive_invlcomp. rewrite inv_inv_eq.
         rewrite <- to_assoc. rewrite (to_commax' A (to_In2 DS2)). rewrite to_assoc.
-        use to_binop_eq.
+        use maponpaths_12.
         * apply cancel_precomposition.
           set (tmp := @transport_hz_to_In1
                         A (λ i0 : hz, C2 (i0 + 1))
@@ -1644,7 +1644,7 @@ Section inv_rotation_mapping_cone.
     rewrite <- PreAdditive_invlcomp.
     rewrite <- transport_target_to_inv. rewrite <- to_assoc. rewrite to_commax'.
     rewrite <- (assoc _ (Diff C1 i)). rewrite <- (MComm f i). rewrite assoc.
-    use to_binop_eq.
+    use maponpaths_12.
     - rewrite transport_target_postcompose. rewrite transport_target_postcompose.
       rewrite transport_target_postcompose. rewrite <- transport_target_to_binop.
       rewrite PreAdditive_invrcomp. rewrite PreAdditive_invrcomp.
@@ -1674,7 +1674,7 @@ Section inv_rotation_mapping_cone.
                                           (maponpaths C2 (hzrplusminus i 1)) (to_Pr2 DS1) ·
                                           Diff C2 i)).
       use (pathscomp0 (! tmp)). clear tmp.
-      use to_binop_eq.
+      use maponpaths_12.
       + rewrite transport_compose. rewrite <- assoc. rewrite <- assoc.
         apply cancel_precomposition. rewrite <- transport_target_postcompose.
         rewrite <- transport_target_postcompose. rewrite assoc.
@@ -1744,7 +1744,7 @@ Section inv_rotation_mapping_cone.
       + rewrite to_postmor_linear'. rewrite to_assoc. rewrite to_commax'.
         rewrite <- (@to_runax''
                      A (Additive.to_Zero A) _ _ (ZeroArrow (Additive.to_Zero A) DS1 (C2 (i + 1)))).
-        use to_binop_eq.
+        use maponpaths_12.
         * rewrite <- PreAdditive_invlcomp.
           assert (e : (to_Pr1 DS1 · f (i + 1 - 1 + 1)
                               · transportf (precategory_morphisms (C2 (i + 1 - 1 + 1)))
@@ -1987,7 +1987,7 @@ Section inv_rotation_mapping_cone.
                                          (λ i0 : pr1 hz, to_BinDirectSums A (C1 (i0 + 1)) (C2 i0))
                                          _ _ (hzrminusplus i 1)) (to_In2 DS5)))).
     rewrite to_assoc. rewrite to_assoc.
-    use to_binop_eq.
+    use maponpaths_12.
     - rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
       set (tmp := @transport_hz_double_section A C1 C2 f _ _ (! hzrminusplus i 1)).
       rewrite pathsinv0inv0 in tmp. rewrite <- tmp. clear tmp.
@@ -2712,7 +2712,7 @@ Section inv_rotation_mapping_cone.
                                               (maponpaths C2 (hzrplusminus i 1))
                                               (to_In2 DS1) ·
                                               to_In1 DS2))))).
-    use to_binop_eq.
+    use maponpaths_12.
     - rewrite <- transport_compose.
       rewrite transport_source_precompose.
       use (transport_target_path
@@ -2765,7 +2765,7 @@ Section inv_rotation_mapping_cone.
                                                        C1 ((hzrminusplus (i + 1 - 1 + 1) 1)
                                                              @ hzrminusplus (i + 1) 1))
                                                     (to_In1 DS9) · to_In1 DS10)))))).
-      use to_binop_eq.
+      use maponpaths_12.
       + apply idpath.
       + exact (InvRotMorphismIso'_eq2_1 f i).
   Qed.
@@ -2871,7 +2871,7 @@ Section inv_rotation_mapping_cone.
                          (to_Pr2 DS2 · to_In2 DS2)).
     {
       rewrite <- to_assoc.
-      use to_binop_eq.
+      use maponpaths_12.
       - assert (e1 : to_Pr1 DS2 · to_In1 DS2 =
                      to_binop DS2 DS2
                               (to_Pr1 DS2 · to_Pr1 DS1 · to_In1 DS1 · to_In1 DS2)
@@ -2887,11 +2887,11 @@ Section inv_rotation_mapping_cone.
         use (pathscomp0 _ tmp). clear tmp.
         rewrite (to_commax' A (to_Pr1 DS2 · to_Pr1 DS1 · to_In1 DS1 · to_In1 DS2)).
         rewrite <- to_assoc.
-        use to_binop_eq.
+        use maponpaths_12.
         + set (tmp := @to_linvax' A (Additive.to_Zero A) _ _
                                   (to_Pr1 DS2 · to_Pr2 DS1 · to_In2 DS1 · to_In1 DS2)).
           use (pathscomp0 _ tmp). clear tmp.
-          use to_binop_eq.
+          use maponpaths_12.
           * apply maponpaths. apply cancel_postcomposition.
             rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
             rewrite transport_compose'. apply idpath.
@@ -2918,7 +2918,7 @@ Section inv_rotation_mapping_cone.
     rewrite (to_commax' A _ (to_Pr2 DS2 · to_In2 DS2)). rewrite <- to_assoc.
     rewrite (to_commax' A _ (to_Pr2 DS2 · to_In2 DS2)). rewrite to_assoc.
     rewrite to_assoc.
-    use to_binop_eq.
+    use maponpaths_12.
     - apply cancel_precomposition. rewrite transport_source_precompose.
       unfold DS2, DS6. rewrite transport_source_target_comm. unfold DS1, DS5.
       induction (hzrminusplus i 1). cbn. rewrite pathscomp0rid.
@@ -2943,7 +2943,7 @@ Section inv_rotation_mapping_cone.
                                           (C1 i0)) _ _ (hzrplusminus i 1))
                              (to_In1 DS10))).
       rewrite to_assoc.
-      use to_binop_eq.
+      use maponpaths_12.
       + rewrite <- assoc. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
         apply cancel_precomposition. rewrite transport_compose.
         apply cancel_precomposition. rewrite transport_source_precompose.
@@ -3488,13 +3488,13 @@ Section mapping_cone_ext.
     rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_left.
     rewrite id_right. rewrite id_right. rewrite id_right.
     rewrite to_runax''. rewrite to_runax''. rewrite to_runax''. rewrite to_lunax''.
-    use to_binop_eq.
+    use maponpaths_12.
     - apply cancel_postcomposition. rewrite <- assoc. rewrite <- assoc.
       apply cancel_precomposition. rewrite <- PreAdditive_invlcomp.
       rewrite <- PreAdditive_invrcomp. apply maponpaths.
       exact (MComm g1 (i + 1)).
     - rewrite <- to_assoc. rewrite <- to_assoc.
-      use to_binop_eq.
+      use maponpaths_12.
       + rewrite <- to_postmor_linear'. rewrite <- to_postmor_linear'. apply cancel_postcomposition.
         rewrite <- assoc. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
         rewrite <- to_premor_linear'. rewrite <- to_premor_linear'. apply cancel_precomposition.
@@ -3645,9 +3645,9 @@ Section mapping_cone_octa.
     rewrite ZeroArrow_comp_left. rewrite to_lunax''. rewrite id_right.
     (* binop_eq *)
     rewrite to_assoc.
-    use to_binop_eq.
+    use maponpaths_12.
     + apply idpath.
-    + use to_binop_eq.
+    + use maponpaths_12.
       * apply idpath.
       * apply cancel_postcomposition.
         rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
@@ -3722,8 +3722,8 @@ Section mapping_cone_octa.
     rewrite (to_IdIn2 DS4). rewrite (to_Unel2' DS4). rewrite ZeroArrow_comp_right.
     rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_left. rewrite to_lunax''.
     rewrite id_right.
-    (* to_binop_eq *)
-    rewrite to_assoc. use to_binop_eq.
+    (* maponpaths_12 *)
+    rewrite to_assoc. use maponpaths_12.
     - apply cancel_postcomposition. rewrite <- assoc. rewrite <- assoc.
       apply cancel_precomposition. rewrite <- PreAdditive_invlcomp.
       rewrite <- PreAdditive_invrcomp. apply maponpaths.
@@ -3832,7 +3832,7 @@ Section mapping_cone_octa.
     rewrite <- (to_assoc _ _ (to_Pr1 DS1 · f2 (i + 1) · to_In2 DS6 · to_In2 DS7)).
     rewrite (to_commax' _ _ (to_Pr1 DS1 · f2 (i + 1) · to_In2 DS6 · to_In2 DS7)).
     rewrite to_assoc.
-    use to_binop_eq.
+    use maponpaths_12.
     - apply idpath.
     - unfold MappingConeDiff. unfold MappingConeDiff1, MappingConeDiff2, MappingConeDiff3.
       unfold TranslationComplex. unfold DiffTranslationComplex. cbn.
@@ -3847,7 +3847,7 @@ Section mapping_cone_octa.
       rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_left.
       rewrite ZeroArrow_comp_left. rewrite ZeroArrow_comp_left.
       rewrite to_lunax''. rewrite to_lunax''.
-      use to_binop_eq.
+      use maponpaths_12.
       + apply cancel_postcomposition. rewrite <- assoc. rewrite <- assoc.
         rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
         apply cancel_precomposition. rewrite <- PreAdditive_invrcomp.
@@ -4227,7 +4227,7 @@ Section mapping_cone_octa.
                                Diff x (i - 1 + 1 + 1) · to_In1 DS14 · to_In1 DS16)))).
     rewrite to_assoc. rewrite to_assoc.
     (* binop_eq *)
-    use to_binop_eq.
+    use maponpaths_12.
     - rewrite transport_target_postcompose. rewrite <- assoc. rewrite <- assoc.
       rewrite <- assoc. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
       rewrite <- assoc. apply cancel_precomposition. apply cancel_precomposition.
@@ -4261,7 +4261,7 @@ Section mapping_cone_octa.
       rewrite <- to_assoc. rewrite (to_commax' _ _ (transportf (precategory_morphisms DS3) _ _)).
       rewrite <- transport_target_to_binop.
       rewrite to_assoc.
-      use to_binop_eq.
+      use maponpaths_12.
       + rewrite <- transport_target_to_inv. apply maponpaths.
         rewrite transport_target_postcompose. rewrite <- assoc.
         rewrite <- (assoc _ (transportf (λ x' : A, A ⟦ x', DS11 ⟧)
@@ -4300,7 +4300,7 @@ Section mapping_cone_octa.
         rewrite <- (@to_runax'' A (Additive.to_Zero A)
                                _ _ (to_inv (to_Pr2 DS3 · to_Pr1 DS2
                                                    · to_In1 DS2 · to_In2 DS3))).
-        use to_binop_eq.
+        use maponpaths_12.
         * apply maponpaths. rewrite transport_target_postcompose.
           rewrite <- assoc.
           rewrite <- (assoc _ (transportf (λ x' : A, A ⟦ x', x (i - 1 + 1 + 1) ⟧)
@@ -4564,7 +4564,7 @@ Section mapping_cone_octa.
     rewrite <- transport_target_to_binop.
     rewrite to_assoc.
     (* binop_eq *)
-    use to_binop_eq.
+    use maponpaths_12.
     - rewrite <- transport_target_to_inv. apply maponpaths.
       unfold DS4, DS3, DS1. unfold DS13, DS12, DS11. induction (hzrminusplus i 1). cbn.
       apply idpath.
@@ -4574,7 +4574,7 @@ Section mapping_cone_octa.
       rewrite to_assoc.
       rewrite <- (@to_runax'' A (Additive.to_Zero A) _ _
                              (f1 (i + 1) · (to_In2 DS3 · to_In1 DS4))).
-      use to_binop_eq.
+      use maponpaths_12.
       + unfold DS4, DS3, DS1. unfold DS13, DS12, DS11. induction (hzrminusplus i 1). cbn.
         rewrite assoc. apply idpath.
       + rewrite <- PreAdditive_invlcomp.
@@ -4595,7 +4595,7 @@ Section mapping_cone_octa.
                                               (maponpaths x (maponpaths_2 _ (hzrminusplus i 1) _))
                                               (Diff x (i - 1 + 1 + 1)) ·
                                               to_In1 DS12 · to_In1 DS13)))).
-        use to_binop_eq.
+        use maponpaths_12.
         * apply idpath.
         * rewrite <- transport_source_precompose. rewrite <- transport_source_precompose.
           set (tmp := transport_hz_double_section_source_target

--- a/UniMath/HomologicalAlgebra/MappingCone.v
+++ b/UniMath/HomologicalAlgebra/MappingCone.v
@@ -14,6 +14,8 @@ Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.NaturalNumbers.
 
+Require Import UniMath.MoreFoundations.PartA.
+
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids.
 
@@ -1702,7 +1704,7 @@ Section inv_rotation_mapping_cone.
                                      A (C1 (i0 + 1 - 1 + 1 + 1)) (C2 (i0 + 1 - 1 + 1))))
                       _ _ (! (hzrplusminus i 1))).
         cbn in tmp.
-        set (e1 := maponpaths C2 (hzplusradd (i + 1 - 1) i 1 (hzrplusminus i 1))).
+        set (e1 := maponpaths C2 (maponpaths_2 _ (hzrplusminus i 1) _)).
         set (e2 := maponpaths (λ i0 : pr1 hz, C2 (i0 + 1 - 1 + 1)) (! hzrplusminus i 1)).
         cbn in e1, e2.
 
@@ -1711,7 +1713,7 @@ Section inv_rotation_mapping_cone.
                       C2
                       (λ (i0 : hz),
                          to_Pr2 (to_BinDirectSums A (C1 (i0 + 1)) (C2 i0)))
-                      _ _ (hzplusradd (i + 1 - 1) i 1 (hzrplusminus i 1))).
+                      _ _ (maponpaths_2 hzplus (hzrplusminus i 1) 1)).
         cbn in tmp'. unfold e1.
         use (pathscomp0 _ (! tmp')). clear tmp'. unfold DS3.
 
@@ -1728,7 +1730,7 @@ Section inv_rotation_mapping_cone.
                                                                      A (C1 (i0 + 1)) (C2 i0)) _ _
                                  (! (hzrminusplus (i + 1) 1 @ ! hzrplusminus (i + 1) 1))) =
                     @maponpaths hz A (λ i0 : pr1 hz, to_BinDirectSums A (C1 (i0 + 1)) (C2 i0))
-                                _ _ (! hzplusradd (i + 1 - 1) i 1 (hzrplusminus i 1))).
+                                _ _ (! maponpaths_2 _ (hzrplusminus i 1) _)).
         {
           set (tmp' := @maponpathscomp0
                          _ _ _ _ _
@@ -2027,8 +2029,8 @@ Section inv_rotation_mapping_cone.
         rewrite transport_compose. apply cancel_precomposition.
         rewrite transport_source_target_comm. unfold DS5. unfold DS1.
         rewrite <- maponpathsinv0.
-        assert (e : maponpaths C1 (! hzplusradd i (i - 1 + 1) 1 (! hzrminusplus i 1)) =
-                    maponpaths C1 (hzplusradd (i - 1 + 1) i 1 (hzrminusplus i 1))).
+        assert (e : maponpaths C1 (! maponpaths_2 hzplus (! hzrminusplus i 1) 1) =
+                    maponpaths C1 (maponpaths_2 hzplus (hzrminusplus i 1) 1)).
         {
           apply maponpaths. apply isasethz.
         }
@@ -2039,7 +2041,7 @@ Section inv_rotation_mapping_cone.
                       (λ i0 : hz, to_In1 (to_BinDirectSums A (C1 (i0 + 1)) (C2 i0)))
                       _ _ (hzrminusplus i 1)). cbn in tmp.
         assert (e : maponpaths (λ i0 : pr1 hz, C1 (i0 + 1)) (hzrminusplus i 1) =
-                    maponpaths C1 (hzplusradd (i - 1 + 1) i 1 (hzrminusplus i 1))).
+                    maponpaths C1 (maponpaths_2 _ (hzrminusplus i 1) _)).
         {
           induction (hzrminusplus i 1). apply idpath.
         }
@@ -2198,7 +2200,7 @@ Section inv_rotation_mapping_cone.
                   (maponpaths C2 (! hzrminusplus (i + 1) 1))).
     use (pathscomp0 _ tmp). clear tmp.
     set (tmp := transport_hz_section A C2 1 (Diff C2) _ _ (! hzrplusminus i 1)).
-    assert (e : maponpaths C2 (hzplusradd i (i + 1 - 1) 1 (! hzrplusminus i 1)) =
+    assert (e : maponpaths C2 (maponpaths_2 _ (! hzrplusminus i 1) _) =
                 maponpaths C2 (! hzrminusplus (i + 1) 1)).
     {
       apply maponpaths. apply isasethz.
@@ -2213,7 +2215,7 @@ Section inv_rotation_mapping_cone.
     cbn in tmp. use (pathscomp0 tmp).
     assert (e : (maponpaths C2 (! (hzrminusplus (i + 1) 1 @ ! hzrplusminus (i + 1) 1))) =
                 (maponpaths
-                   C2 (hzrplusminus (i + 1) 1 @ hzplusradd i (i + 1 - 1) 1 (! hzrplusminus i 1)))).
+                   C2 (hzrplusminus (i + 1) 1 @ maponpaths_2 _ (! hzrplusminus i 1) _))).
     {
       apply maponpaths. apply isasethz.
     }
@@ -2325,11 +2327,10 @@ Section inv_rotation_mapping_cone.
                   A C1 1 (Diff C1) _ _ (! (hzrminusplus (i - 1 + 1) 1 @ hzrminusplus i 1))).
     rewrite pathsinv0inv0 in tmp. cbn in tmp. rewrite <- tmp. clear tmp.
     rewrite transport_compose. rewrite <- assoc. apply cancel_precomposition.
-    assert (e : (! maponpaths C1 (hzplusradd i (i - 1 + 1 - 1 + 1) 1
-                                             (! (hzrminusplus (i - 1 + 1) 1 @
-                                                              hzrminusplus i 1)))) =
-                maponpaths C1 (hzplusradd (i - 1 + 1 - 1 + 1) i 1 (hzrminusplus (i - 1 + 1) 1 @
-                                                                                hzrminusplus i 1))).
+    assert (e : (! maponpaths C1 (maponpaths_2 hzplus
+                      (! (hzrminusplus (i - 1 + 1) 1 @ hzrminusplus i 1)) 1))
+              = maponpaths C1 (maponpaths_2 _
+                          (hzrminusplus (i - 1 + 1) 1 @ hzrminusplus i 1) _)).
     {
       rewrite <- maponpathsinv0. apply maponpaths. apply isasethz.
     }
@@ -2341,11 +2342,10 @@ Section inv_rotation_mapping_cone.
                   (λ i0 : pr1 hz, to_In1 (to_BinDirectSums A (C1 (i0 + 1)) (C2 i0)))
                   _ _ (! (hzrminusplus (i - 1 + 1) 1 @ hzrminusplus i 1))).
     cbn in tmp. unfold DS11. cbn. rewrite pathsinv0inv0 in tmp.
-    assert (e : (maponpaths (λ i0 : pr1 hz, C1 (i0 + 1)) (hzrminusplus (i - 1 + 1) 1
-                                                                       @ hzrminusplus i 1)) =
-                (maponpaths C1 (hzplusradd (i - 1 + 1 - 1 + 1) i 1
-                                           (hzrminusplus (i - 1 + 1) 1
-                                                         @ hzrminusplus i 1)))).
+    assert (e : (maponpaths (λ i0 : pr1 hz, C1 (i0 + 1))
+                            (hzrminusplus (i - 1 + 1) 1 @ hzrminusplus i 1))
+                = maponpaths C1 (maponpaths_2 _
+                         (hzrminusplus (i - 1 + 1) 1 @ hzrminusplus i 1) _)).
     {
       induction (hzrminusplus (i - 1 + 1) 1 @ hzrminusplus i 1).
       apply idpath.
@@ -4358,9 +4358,9 @@ Section mapping_cone_octa.
           rewrite e in tmp. clear e. rewrite <- tmp. clear tmp.
           rewrite transport_compose. apply cancel_precomposition.
           assert (e : (! maponpaths (λ i0 : pr1 hz, x (i0 + 1))
-                         (hzplusradd i (i - 1 + 1) 1 (! hzrminusplus i 1))) =
-                      (maponpaths (λ i0 : pr1 hz, x (i0 + 1))
-                                  (hzplusradd _ _ 1 (hzrminusplus i 1)))).
+                             (maponpaths_2 hzplus (! hzrminusplus i 1) 1))
+                     = maponpaths (λ i0 : pr1 hz, x (i0 + 1))
+                                    (maponpaths_2 _ (hzrminusplus i 1) _)).
           {
             induction (hzrminusplus i 1). apply idpath.
           }
@@ -4381,9 +4381,10 @@ Section mapping_cone_octa.
                                                        (to_BinDirectSums A (x (i0 + 1)) (z i0)))))
                         _ _ (hzrminusplus i 1)).
           cbn in tmp. unfold DS16, DS15, DS14.
-          assert (e : (maponpaths (λ i0 : pr1 hz, x (i0 + 1 + 1)) (hzrminusplus i 1)) =
-                      (maponpaths (λ i0 : pr1 hz, x (i0 + 1))
-                                  (hzplusradd (i - 1 + 1) i 1 (hzrminusplus i 1)))).
+          assert (e : maponpaths (λ i0 : pr1 hz, x (i0 + 1 + 1))
+                                                      (hzrminusplus i 1)
+                      = maponpaths (λ i0 : pr1 hz, x (i0 + 1))
+                                  (maponpaths_2 _ (hzrminusplus i 1) _)).
           {
             induction (hzrminusplus i 1). apply idpath.
           }
@@ -4445,7 +4446,7 @@ Section mapping_cone_octa.
     - use compose.
       + exact (to_BinDirectSums A (x (i - 1 + 1 + 1)) (y (i - 1 + 1))).
       + exact (to_inv (transportf (λ x' : ob A, A⟦x', _⟧)
-                                  (maponpaths x (hzplusradd _ _ 1 (hzrminusplus i 1)))
+                             (maponpaths x (maponpaths_2 _ (hzrminusplus i 1) _))
                                   (to_In1 _))).
       + exact (to_In1 _).
   Defined.
@@ -4558,7 +4559,7 @@ Section mapping_cone_octa.
     rewrite (to_commax'
                _ _ (to_inv
                       (transportf (λ x' : A, A ⟦ x', DS13 ⟧)
-                                  (maponpaths x (hzplusradd (i - 1 + 1) i 1 (hzrminusplus i 1)))
+                         (maponpaths x (maponpaths_2 _ (hzrminusplus i 1) _))
                                   (to_In1 DS11 · to_In2 DS13)))).
     rewrite <- transport_target_to_binop.
     rewrite to_assoc.
@@ -4591,8 +4592,7 @@ Section mapping_cone_octa.
                                                (to_BinDirectSums A (x (i0 + 1)) (z i0))) _ _
                                      (hzrminusplus i 1))
                                   (transportf (λ x' : A, A ⟦ x', x (i - 1 + 1 + 1 + 1) ⟧)
-                                              (maponpaths x (hzplusradd (i - 1 + 1) i 1
-                                                                        (hzrminusplus i 1)))
+                                              (maponpaths x (maponpaths_2 _ (hzrminusplus i 1) _))
                                               (Diff x (i - 1 + 1 + 1)) ·
                                               to_In1 DS12 · to_In1 DS13)))).
         use to_binop_eq.
@@ -4613,7 +4613,7 @@ Section mapping_cone_octa.
                         _ _ (hzrminusplus i 1)).
           cbn in tmp.
           assert (e : (maponpaths (λ i0 : pr1 hz, x (i0 + 1)) (hzrminusplus i 1)) =
-                      (maponpaths x (hzplusradd (i - 1 + 1) i 1 (hzrminusplus i 1)))).
+                      (maponpaths x (maponpaths_2 _ (hzrminusplus i 1) _))).
           {
             induction (hzrminusplus i 1). apply idpath.
           }
@@ -4636,8 +4636,7 @@ Section mapping_cone_octa.
                         _ _ (hzrplusminus i 1)).
           cbn in tmp. use (pathscomp0 tmp). clear tmp. apply maponpaths.
           assert (e : (maponpaths (λ i0 : pr1 hz, x (i0 + 1 + 1)) (hzrplusminus i 1)) =
-                      (maponpaths x (hzplusradd (i + 1 - 1 + 1) (i + 1) 1
-                                                (hzrminusplus (i + 1) 1)))).
+                      (maponpaths x (maponpaths_2 _ (hzrminusplus (i + 1) 1) _))).
           {
             assert (e' : maponpaths (λ i0 : pr1 hz, x (i0 + 1 + 1)) (hzrplusminus i 1) =
                          maponpaths x (maponpaths (λ i0 : pr1 hz, (i0 + 1 + 1))

--- a/UniMath/HomologicalAlgebra/MappingCylinder.v
+++ b/UniMath/HomologicalAlgebra/MappingCylinder.v
@@ -395,7 +395,7 @@ Section mapping_cylinder_KA_iso.
     rewrite <- (assoc _ _ (to_Pr1 DS4)). rewrite (to_Unel2' DS4).
     rewrite ZeroArrow_comp_right. rewrite ZeroArrow_comp_left. rewrite to_lunax''.
     rewrite <- (assoc _ _ (to_Pr2 DS4)). rewrite (to_IdIn2 DS4). rewrite id_right.
-    rewrite <- assoc. rewrite (MComm f i). rewrite assoc. use to_rrw.
+    rewrite <- assoc. rewrite (MComm f i). rewrite assoc. apply maponpaths.
     rewrite <- assoc. rewrite <- assoc. rewrite <- assoc. rewrite <- to_premor_linear'.
     apply cancel_precomposition.
     unfold MappingConeDiff. unfold MappingConeDiff1.
@@ -577,7 +577,7 @@ Section mapping_cylinder_KA_iso.
       unfold tmp'' in tmp'.
       rewrite tmp'. unfold tmp. apply idpath.
     }
-    cbn in e1. cbn. rewrite <- e1. clear e1. use to_rrw.
+    cbn in e1. cbn. rewrite <- e1. clear e1. apply maponpaths.
     (* The first term of to_binop are equal, cancel them *)
     rewrite <- to_binop_inv_inv. rewrite transport_target_to_inv. rewrite transport_source_to_inv.
     rewrite <- PreAdditive_invlcomp. rewrite <- PreAdditive_invlcomp. rewrite inv_inv_eq.
@@ -609,7 +609,7 @@ Section mapping_cylinder_KA_iso.
       unfold tmp'' in tmp'.
       rewrite tmp'. unfold tmp. apply idpath.
     }
-    rewrite <- e1. clear e1. use to_rrw.
+    rewrite <- e1. clear e1. apply maponpaths.
     (* Solve the rest *)
     cbn. unfold DS2, DS1, DS6, DS5.
     set (tmp := λ i0 : hz, BinDirectSumOb
@@ -732,7 +732,7 @@ Section mapping_cylinder_KA_iso.
       }
       rewrite <- e2. apply idpath.
     }
-    cbn in e1. cbn. rewrite <- e1. clear e1. use to_rrw.
+    cbn in e1. cbn. rewrite <- e1. clear e1. apply maponpaths.
     (* Use similar technique as above *)
     rewrite transport_target_postcompose. rewrite <- assoc. rewrite <- assoc. rewrite <- assoc.
     rewrite <- assoc. apply cancel_precomposition.
@@ -782,11 +782,11 @@ Section mapping_cylinder_KA_iso.
     unfold MappingCylinderIsoHomot_mor1. unfold MappingCylinderIsoHomot_mor2.
     cbn. fold DS1 DS2. cbn. rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
     rewrite assoc. rewrite assoc. rewrite assoc. rewrite assoc.
-    rewrite to_assoc. rewrite to_assoc. use to_rrw. rewrite to_commax'.
+    rewrite to_assoc. rewrite to_assoc. apply maponpaths. rewrite to_commax'.
     rewrite (to_commax'
                _ _ ((to_Pr1 DS2) · (to_inv (MMor f i)) · (to_In2 DS1) · (to_In2 DS2))).
     rewrite to_assoc. rewrite <- PreAdditive_invrcomp. rewrite <- PreAdditive_invlcomp.
-    rewrite <- PreAdditive_invlcomp. use to_rrw. rewrite <- to_assoc.
+    rewrite <- PreAdditive_invlcomp. apply maponpaths. rewrite <- to_assoc.
     rewrite <- PreAdditive_invrcomp. rewrite <- PreAdditive_invlcomp.
     rewrite <- PreAdditive_invlcomp. rewrite (@to_rinvax' A (Additive.to_Zero A)).
     rewrite to_lunax''. apply idpath.

--- a/UniMath/HomologicalAlgebra/TranslationFunctors.v
+++ b/UniMath/HomologicalAlgebra/TranslationFunctors.v
@@ -13,6 +13,8 @@ Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.NaturalNumbers.
 
+Require Import UniMath.MoreFoundations.PartA.
+
 Require Import UniMath.Algebra.BinaryOperations.
 Require Import UniMath.Algebra.Monoids.
 
@@ -224,7 +226,7 @@ Section translation_functor.
       unfold tmp in ee. cbn in ee. unfold tmp. cbn. rewrite ee. clear ee. clear tmp.
       induction (hzrplusminus (i - 1 + 1 + 1) 1). cbn. apply idpath.
     }
-    cbn in e1. rewrite e1. clear e1. use to_lrw.
+    cbn in e1. rewrite e1. clear e1. use maponpaths_2.
     (* Show that the first elements of to_binop are the same *)
     set (tmp := @transport_hz_source_target A C2 1 (Diff C2) _ _ (hzrplusminus (i - 1 + 1) 1)).
     rewrite tmp. clear tmp. rewrite transport_compose.
@@ -411,7 +413,7 @@ Section translation_functor.
       }
       rewrite e2. clear e2. apply maponpaths. apply isasethz.
     }
-    cbn in e1. rewrite e1. clear e1. use to_lrw.
+    cbn in e1. rewrite e1. clear e1. use maponpaths_2.
     rewrite <- transport_target_postcompose. rewrite transport_f_f.
     assert (e2 : maponpaths (λ i0 : pr1 hz, C2 (i0 - 1)) (hzrminusplus (i + 1 - 1) 1) =
                  maponpaths C2 (maponpaths (λ i0 : hz, i0 - 1) (hzrminusplus (i + 1 - 1) 1))).

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -58,7 +58,6 @@ The following are specialisations of [maponpaths]:
 [Foundations.PartA.base_paths] — keep since in [Foundations]
 [Foundations.PartA.pair_path_in2] — in [Foundations], also useful specialisation
 
-[CategoryTheory.RepresentableFunctors.Precategories.total2_paths1] — duplicate of [pair_path_in2], remove?
 [CategoryTheory.PrecategoriesWithAbgrops.to_apply_inv] — to investigate
 [CategoryTheory.PrecategoriesWithAbgrops.to_rrw] — to investigate
 [CategoryTheory.limits.coproducts.CoproductOfArrows_eq] — looks probably like unnecessary duplicate; remove?

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -84,7 +84,6 @@ Specialisations:
   [Foundations.PartA.pathsdirprod] — in [Foundations], useful specialisation
   [Foundations.PartA.total2_paths2] — in [Foundations], but also dupe of [pathsdirprod]!
 
-  [CategoriesWithBinOps.to_binop_eq] — looks probably unnecessary
   [CategoryTheory.limits.bincoproducts.BinCoproductArrow_eq]  — looks probably like unnecessary duplicate; investigate, remove?
   [CategoryTheory.limits.binproducts.BinProductOfArrows_eq] — looks probably like unnecessary duplicate; investigate, remove?
   [CategoryTheory.limits.bincoproducts.BinCoproductOfArrows_eq] — looks probably like unnecessary duplicate; investigate, remove?

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -73,7 +73,6 @@ Specialisations:
   [Foundations.PartA.pathsdirprod] — in [Foundations], useful specialisation
   [Foundations.PartA.total2_paths2] — in [Foundations], but also dupe of [pathsdirprod]!
 
-  [CategoryTheory.limits.bincoproducts.BinCoproductArrow_eq]  — looks probably like unnecessary duplicate; investigate, remove?
 *)
 
 (* Most awkwardly: [maponpaths_12] is a duplicate of [two_arg_paths] and [map_on_two_paths] from [Foundations].  Currently, [two_arg_paths] seems to be the most used, and with the most lemmas.

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -53,38 +53,39 @@ Definition maponpaths_1234 {W Z Y X A : UU} (f : W -> Z -> Y -> X -> A)
 
 (* NOTE: some of the lemmas above are provided multiple times elsewhere in the library, including some pure duplicates, and some specialisations (maybe for good reason, maybe not). TODO: chase them down, unify them where desirable, or document when there’s good reason for the duplication/specialisation.
 
-The following are specialisations of [maponpaths]:
+The following are specialisations of [maponpaths] or [maponpaths_2]:
 
-[Foundations.PartA.base_paths] — keep since in [Foundations]
-[Foundations.PartA.pair_path_in2] — in [Foundations], also useful specialisation
-
-[CategoryTheory.PrecategoriesWithAbgrops.to_apply_inv] — to investigate
-[CategoryTheory.PrecategoriesWithAbgrops.to_rrw] — to investigate
-[CategoryTheory.limits.coproducts.CoproductOfArrows_eq] — looks probably like unnecessary duplicate; remove?
-[SyntheticHomotopyTheory.AffineLine.makeGuidedHomotopy_localPath] — to investigate
-[SyntheticHomotopyTheory.Circle.makeGH_localPath] — to investigate
-
-
-The following appear to be duplicates/specialisations of [maponpaths_2], found with [Search (?x = ?x' -> ?f ?x ?y = ?f ?x' ?y)] and similar searches (following [Require UniMath.All]):
-
+  [Foundations.PartA.base_paths] — keep since in [Foundations]
+  [Foundations.PartA.pair_path_in2] — in [Foundations], also useful specialisation
   [Foundations.PartA.transportf_paths] — in [Foundations], and very useful
+
   [Integers.hzplusradd] — looks like unnecessary specialisation?
-  [CategoryTheory.PreAdditive.ropeq] — looks like unnecessary specialisation
+
+  [CategoryTheory.PrecategoriesWithAbgrops.to_apply_inv] — to investigate
+  [CategoryTheory.PrecategoriesWithAbgrops.to_rrw] — to investigate
   [CategoryTheory.PrecategoriesWithAbgrops.to_lrw] — to investigate
+
+  [CategoryTheory.PreAdditive.ropeq] — looks like unnecessary specialisation
   [CategoryTheory.Core.NaturalTransformations.nat_trans_eq_pointwise] — clearly useful; keep; perhaps define in terms of [maponpaths_2]?
+  [CategoryTheory.limits.coproducts.CoproductOfArrows_eq] — looks probably like unnecessary duplicate; remove?
+
+  [SyntheticHomotopyTheory.AffineLine.makeGuidedHomotopy_localPath] — to investigate
+  [SyntheticHomotopyTheory.Circle.makeGH_localPath] — to investigate
+
   [HomologicalAlgebra.Complexes.MorphismEq'] – to investigate
   [Bicategories.Modifications.Modification.modcomponent_eq] — to investigate
+
   [Bicategories.WkCatEnrichment.whiskering.cancel_whisker_right] — to investigate
 
-The following appear to be duplicates/specialisations of [maponpaths_12], found with [Search (?x = ?x' -> ?y = ?y' -> ?f ?x ?y = ?f ?x' ?y')] and [Search (?x = ?x' -> forall y y', y = y' -> ?f ?x y = ?f ?x' y')]:
-
+The following appear to be duplicates/specialisations of [maponpaths_12]:
 Duplicates:
   [Foundations.PartA.two_arg_paths] — in [Foundations], complete duplicate of [maponpaths_12] and [map_on_two_paths]
   [Foundations.PartA.map_on_two_paths] — in [Foundations], complete duplicate of [maponpaths_12] and [two_arg_paths]
 
 Specialisations:
   [Foundations.PartA.pathsdirprod] — in [Foundations], useful specialisation
-  [Foundations.PartA.total2_paths2] — in [Foundations], but also dupe of [pathsdirprod]
+  [Foundations.PartA.total2_paths2] — in [Foundations], but also dupe of [pathsdirprod]!
+
   [CategoriesWithBinOps.to_binop_eq] — looks probably unnecessary
   [CategoryTheory.limits.bincoproducts.BinCoproductArrow_eq]  — looks probably like unnecessary duplicate; investigate, remove?
   [CategoryTheory.limits.binproducts.BinProductOfArrows_eq] — looks probably like unnecessary duplicate; investigate, remove?

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -2,6 +2,54 @@
 Require Import UniMath.Foundations.All.
 Require Import UniMath.MoreFoundations.Tactics.
 
+(** * Generalisations of [maponpaths]
+
+The following are a uniformly-named set of lemmas giving how multi-argument (non-dependent) functions act on paths, generalising [maponpaths].
+
+  The naming convention is that e.g. [maponpaths_135] takes paths in the 1st, 3rd, and 5th arguments, counting _backwards_ from the end.  (The “counting backwards” is so that it doesn’t depend on the total number of arguments the function takes.)
+
+  All are defined in terms of [maponpaths], to allow use of lemmas about it for reasoning about these. *)
+Definition maponpaths_1 {X A : UU} (f : X -> A) {x x'} (e : x = x')
+  : f x = f x'
+:= maponpaths f e.
+
+Definition maponpaths_2 {Y X A : UU} (f : Y -> X -> A)
+    {y y'} (e_y : y = y') x
+  : f y x = f y' x
+:= maponpaths (fun y => f y x) e_y.
+
+Definition maponpaths_12 {Y X A : UU} (f : Y -> X -> A)
+    {y y'} (e_y : y = y') {x x'} (e_x : x = x')
+  : f y x = f y' x'
+:= maponpaths_1 _ e_x @ maponpaths_2 f e_y _.
+
+Definition maponpaths_3 {Z Y X A : UU} (f : Z -> Y -> X -> A)
+    {z z'} (e_z : z = z') y x
+  : f z y x = f z' y x
+:= maponpaths (fun z => f z y x) e_z.
+
+Definition maponpaths_123 {Z Y X A : UU} (f : Z -> Y -> X -> A)
+    {z z'} (e_z : z = z') {y y'} (e_y : y = y') {x x'} (e_x : x = x')
+  : f z y x = f z' y' x'
+:= maponpaths_12 _ e_y e_x @ maponpaths_3 f e_z _ _.
+
+Definition maponpaths_13 {Z Y X A : UU} (f : Z -> Y -> X -> A)
+    {z z'} (e_z : z = z') (y:Y) {x x'} (e_x : x = x')
+  : f z y x = f z' y x'
+:= maponpaths_123 _ e_z (idpath y) e_x.
+
+Definition maponpaths_4 {W Z Y X A : UU} (f : W -> Z -> Y -> X -> A)
+    {w w'} (e_w : w = w') z y x
+  : f w z y x = f w' z y x
+:= maponpaths (fun w => f w z y x) e_w.
+
+Definition maponpaths_1234 {W Z Y X A : UU} (f : W -> Z -> Y -> X -> A)
+    {w w'} (e_w : w = w') {z z'} (e_z : z = z')
+    {y y'} (e_y : y = y') {x x'} (e_x : x = x')
+  : f w z y x = f w' z' y' x'
+:= maponpaths_123 _ e_z e_y e_x @ maponpaths_4 _ e_w _ _ _.
+
+(* NOTE: some of the lemmas above have been re-proved independently multiple times elsewhere in the library, including some pure duplicates, and some specialisations (maybe for good reason, maybe not). TODO: chase the duplicates down; work out + document which ones seem justified; and unify the rest. *)
 
 Lemma maponpaths_for_constant_function {T1 T2 : UU} (x : T2) {t1 t2 : T1}
       (e: t1 = t2): maponpaths (fun _: T1 => x) e = idpath x.
@@ -74,10 +122,6 @@ library lemma.
 Definition transportf_pathsinv0 {X} (P:X->UU) {x y:X} (p:x = y) (u:P x) (v:P y) :
   transportf _ (!p) v = u -> transportf _ p u = v.
 Proof. intro e. induction p, e. reflexivity. Defined.
-
-Definition maponpaths_2 {X Y Z : UU} (f : X -> Y -> Z) {x x'} (e : x = x') y
-  : f x y = f x' y
-:= maponpaths (λ x, f x y) e.
 
 Lemma transportf_comp_lemma (X : UU) (B : X -> UU) {A A' A'': X} (e : A = A'') (e' : A' = A'')
   (x : B A) (x' : B A')

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -49,66 +49,63 @@ Definition maponpaths_1234 {W Z Y X A : UU} (f : W -> Z -> Y -> X -> A)
   : f w z y x = f w' z' y' x'
 := maponpaths_123 _ e_z e_y e_x @ maponpaths_4 _ e_w _ _ _.
 
-(* Notes on duplciation issues: *)
+(* Notes on duplication issues: *)
 
 (* NOTE: some of the lemmas above are provided multiple times elsewhere in the library, including some pure duplicates, and some specialisations (maybe for good reason, maybe not). TODO: chase them down, unify them where desirable, or document when there’s good reason for the duplication/specialisation.
 
 The following are specialisations of [maponpaths]:
 
-base_paths — [Foundations], see below
-lemmas.pathintotalpr1
-pair_path_in2
-maponpathsPrecategories.total2_paths1
-PathsOver.pullBackPathOverPoint
-cancel_precomposition
-PrecategoriesWithAbgrops.to_apply_inv
-PrecategoriesWithAbgrops.to_rrw
-AffineLine.makeGuidedHomotopy_localPath
-Circle.makeGH_localPath
-coproducts.CoproductOfArrows_eq
+[Foundations.PartA.base_paths] — keep since in [Foundations]
+[Foundations.PartA.pair_path_in2] — in [Foundations], also useful specialisation
+
+[PAdics.lemmas.pathintotalpr1] — duplicate of [base_paths], remove?
+[CategoryTheory.RepresentableFunctors.Precategories.total2_paths1] — duplicate of [pair_path_in2], remove?
+[MoreFoundations.PathsOver.pullBackPathOverPoint] — specialisation of [maponpaths_1], probably useful; investigate
+[CategoryTheory.Core.Categories.cancel_precomposition] — specialisation of [maponpaths_1], previously discussed and decided to keep
+[CategoryTheory.PrecategoriesWithAbgrops.to_apply_inv] — to investigate
+[CategoryTheory.PrecategoriesWithAbgrops.to_rrw] — to investigate
+[SyntheticHomotopyTheory.AffineLine.makeGuidedHomotopy_localPath] — to investigate
+[SyntheticHomotopyTheory.Circle.makeGH_localPath] — to investigate
+[CategoryTheory.limits.coproducts.CoproductOfArrows_eq] — looks probably like unnecessary duplicate; remove?
 
 
 The following appear to be duplicates/specialisations of [maponpaths_2], found with [Search (?x = ?x' -> ?f ?x ?y = ?f ?x' ?y)] and similar searches (following [Require UniMath.All]):
 
-  PreAdditive.ropeq
-  padics.hzmultrmul
-  Integers.hzplusradd
-  cancel_postcomposition
-  PrecategoriesWithAbgrops.to_lrw
-  transportf_paths
-  fps.natsummationpaths
-  nat_trans_eq_pointwise
-  Complexes.MorphismEq'
-  Modification.modcomponent_eq
-  whiskering.cancel_whisker_right
+  [Foundations.PartA.transportf_paths] — in [Foundations], also probably useful
+  [CategoryTheory.PreAdditive.ropeq] — looks like unnecessary specialisation
+  [PAdics.padics.hzmultrmul] — looks like unnecessary specialisation?
+  [Integers.hzplusradd] — looks like unnecessary specialisation?
+  [CategoryTheory.Core.Categories.cancel_postcomposition] — discussed before; probably desirable specialisation
+  [CategoryTheory.PrecategoriesWithAbgrops.to_lrw] — to investigate
+  [PAdics.fps.natsummationpaths] — to investigate
+  [CategoryTheory.Core.NaturalTransformations.nat_trans_eq_pointwise] — clearly useful; keep; perhaps define in terms of [maponpaths_2]?
+  [HomologicalAlgebra.Complexes.MorphismEq'] – to investigate
+  [Bicategories.Modifications.Modification.modcomponent_eq] — to investigate
+  [Bicategories.WkCatEnrichment.whiskering.cancel_whisker_right] — to investigate
 
 The following appear to be duplicates/specialisations of [maponpaths_12], found with [Search (?x = ?x' -> ?y = ?y' -> ?f ?x ?y = ?f ?x' ?y')] and [Search (?x = ?x' -> forall y y', y = y' -> ?f ?x y = ?f ?x' y')]:
 
 Duplicates:
-  Foundations.two_arg_paths
-  MoreFoundations.PartA.aptwice
-  binproducts.f_equal_2
-  map_on_two_paths
+  [Foundations.PartA.two_arg_paths] — in [Foundations], complete duplicate of [maponpaths_12] and [map_on_two_paths]
+  [Foundations.PartA.map_on_two_paths] — in [Foundations], complete duplicate of [maponpaths_12] and [two_arg_paths]
+  [CategoryTheory.binproducts.f_equal_2] — looks like unnecessary duplicate, remove?
+
 Specialisations:
-  pathsdirprod
-  total2_paths2
-  PathsOver.apstar
-  CategoriesWithBinOps.to_binop_eq
-  bincoproducts.BinCoproductArrow_eq
-  binproducts.BinProductOfArrows_eq
-  bincoproducts.BinCoproductOfArrows_eq
+  [Foundations.PartA.pathsdirprod] — in [Foundations], useful specialisation
+  [Foundations.PartA.total2_paths2] — in [Foundations], but also dupe of [pathsdirprod]
+  [MoreFoundations.PathsOver.apstar] — possibly unnecessary; investigate
+  [CategoriesWithBinOps.to_binop_eq] — looks probably unnecessary
+  [CategoryTheory.limits.bincoproducts.BinCoproductArrow_eq]  — looks probably like unnecessary duplicate; investigate, remove?
+  [CategoryTheory.limits.binproducts.BinProductOfArrows_eq] — looks probably like unnecessary duplicate; investigate, remove?
+  [CategoryTheory.limits.bincoproducts.BinCoproductOfArrows_eq] — looks probably like unnecessary duplicate; investigate, remove?
 *)
 
+(* Most awkwardly: [maponpaths_12] is a duplicate of [two_arg_paths] and [map_on_two_paths] from [Foundations].  Currently, [two_arg_paths] seems to be the most used, and with the most lemmas.
 
-(* [maponpaths_12] is a duplicate of [two_arg_paths] from [Foundations].
+How should we deal with this?  Keep all?  Make them notations/synonyms for each other?  Use primarily one throughout the library?
 
-Option 1: keep both.  Disadvantage: all the usual problems with duplication, e.g. searchability (even if they’re judgementally equal)
-
-Option 2: make this a notation for that.  Disadvantage: notations that look like identifiers can cause very confusing errors.
-
-Option 3: remove this.  Disadvantage: loses the consistently-named series.
-
-Option 4: rename [two_arg_paths] to [maponpaths_12].  Disadvantage: messing with Foundations. *)
+Similarly, [total2_paths2] and [pathsdirprod], both from [Foundations], seem to be complete duplicates of each other, both widely used?
+ *)
 
 Lemma maponpaths_for_constant_function {T1 T2 : UU} (x : T2) {t1 t2 : T1}
       (e: t1 = t2): maponpaths (fun _: T1 => x) e = idpath x.

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -49,11 +49,27 @@ Definition maponpaths_1234 {W Z Y X A : UU} (f : W -> Z -> Y -> X -> A)
   : f w z y x = f w' z' y' x'
 := maponpaths_123 _ e_z e_y e_x @ maponpaths_4 _ e_w _ _ _.
 
-(* NOTE: some of the lemmas above are provided multiple times elsewhere in the library, including some pure duplicates, and some specialisations (maybe for good reason, maybe not). TODO:
+(* Notes on duplciation issues: *)
+
+(* NOTE: some of the lemmas above are provided multiple times elsewhere in the library, including some pure duplicates, and some specialisations (maybe for good reason, maybe not). TODO: chase them down, unify them where desirable, or document when there’s good reason for the duplication/specialisation.
+
+The following are specialisations of [maponpaths]:
+
+base_paths — [Foundations], see below
+lemmas.pathintotalpr1
+pair_path_in2
+maponpathsPrecategories.total2_paths1
+PathsOver.pullBackPathOverPoint
+cancel_precomposition
+PrecategoriesWithAbgrops.to_apply_inv
+PrecategoriesWithAbgrops.to_rrw
+AffineLine.makeGuidedHomotopy_localPath
+Circle.makeGH_localPath
+coproducts.CoproductOfArrows_eq
+
 
 The following appear to be duplicates/specialisations of [maponpaths_2], found with [Search (?x = ?x' -> ?f ?x ?y = ?f ?x' ?y)] and similar searches (following [Require UniMath.All]):
 
-  PartA.app
   PreAdditive.ropeq
   padics.hzmultrmul
   Integers.hzplusradd
@@ -69,9 +85,9 @@ The following appear to be duplicates/specialisations of [maponpaths_2], found w
 The following appear to be duplicates/specialisations of [maponpaths_12], found with [Search (?x = ?x' -> ?y = ?y' -> ?f ?x ?y = ?f ?x' ?y')] and [Search (?x = ?x' -> forall y y', y = y' -> ?f ?x y = ?f ?x' y')]:
 
 Duplicates:
-  PartA.aptwice
+  Foundations.two_arg_paths
+  MoreFoundations.PartA.aptwice
   binproducts.f_equal_2
-  two_arg_paths
   map_on_two_paths
 Specialisations:
   pathsdirprod
@@ -81,22 +97,18 @@ Specialisations:
   bincoproducts.BinCoproductArrow_eq
   binproducts.BinProductOfArrows_eq
   bincoproducts.BinCoproductOfArrows_eq
-
-The following are specialisations of [maponpaths]:
-
-base_paths — specislisation of
-lemmas.pathintotalpr1
-pair_path_in2
-maponpathsPrecategories.total2_paths1
-PathsOver.pullBackPathOverPoint
-cancel_precomposition
-PrecategoriesWithAbgrops.to_apply_inv
-PrecategoriesWithAbgrops.to_rrw
-AffineLine.makeGuidedHomotopy_localPath
-Circle.makeGH_localPath
-coproducts.CoproductOfArrows_eq
 *)
 
+
+(* [maponpaths_12] is a duplicate of [two_arg_paths] from [Foundations].
+
+Option 1: keep both.  Disadvantage: all the usual problems with duplication, e.g. searchability (even if they’re judgementally equal)
+
+Option 2: make this a notation for that.  Disadvantage: notations that look like identifiers can cause very confusing errors.
+
+Option 3: remove this.  Disadvantage: loses the consistently-named series.
+
+Option 4: rename [two_arg_paths] to [maponpaths_12].  Disadvantage: messing with Foundations. *)
 
 Lemma maponpaths_for_constant_function {T1 T2 : UU} (x : T2) {t1 t2 : T1}
       (e: t1 = t2): maponpaths (fun _: T1 => x) e = idpath x.
@@ -422,12 +434,6 @@ Proof.
   intros e. induction e. induction p. reflexivity.
 Defined.
 
-Definition app {X} {P:X->Type} {x x':X} {e e':x = x'} (q:e = e') (p:P x) :
-  transportf P e p = transportf P e' p.
-Proof.
-  intros. induction q. reflexivity.
-Defined.
-
 (** ** Paths *)
 
 Definition pathsinv0_to_right {X} {x y z:X} (p:y = x) (q:y = z) (r:x = z) :
@@ -540,7 +546,7 @@ Defined.
 
 Definition total2_paths2_comp2 {X} {Y:X->Type} {x} {y:Y x} {x'} {y':Y x'}
            (p:x = x') (q:p#y = y') :
-  ! app (total2_paths2_comp1 p q) y @ fiber_paths (two_arg_paths_f p q) = q.
+  ! maponpaths_2 _ (total2_paths2_comp1 p q) y @ fiber_paths (two_arg_paths_f p q) = q.
 Proof.
   intros. induction p, q. reflexivity.
 Defined.
@@ -574,10 +580,6 @@ Definition evalat {T} {P:T->UU} (t:T) (f:∏ t:T, P t) := f t.
 
 Definition apfun {X Y} {f f':X->Y} (p:f = f') {x x'} (q:x = x') : f x = f' x'.
   intros. induction q. exact (eqtohomot p x).
-Defined.
-
-Definition aptwice {X Y Z} (f:X->Y->Z) {a a' b b'} (p:a = a') (q:b = b') : f a b = f a' b'.
-  intros. exact (apfun (maponpaths f p) q).
 Defined.
 
 Definition fromemptysec { X : empty -> UU } (nothing:empty) : X nothing.

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -58,7 +58,6 @@ The following are specialisations of [maponpaths]:
 [Foundations.PartA.base_paths] — keep since in [Foundations]
 [Foundations.PartA.pair_path_in2] — in [Foundations], also useful specialisation
 
-[PAdics.lemmas.pathintotalpr1] — duplicate of [base_paths], remove?
 [CategoryTheory.RepresentableFunctors.Precategories.total2_paths1] — duplicate of [pair_path_in2], remove?
 [MoreFoundations.PathsOver.pullBackPathOverPoint] — specialisation of [maponpaths_1], probably useful; investigate
 [CategoryTheory.Core.Categories.cancel_precomposition] — specialisation of [maponpaths_1], previously discussed and decided to keep
@@ -73,11 +72,9 @@ The following appear to be duplicates/specialisations of [maponpaths_2], found w
 
   [Foundations.PartA.transportf_paths] — in [Foundations], also useful
   [CategoryTheory.PreAdditive.ropeq] — looks like unnecessary specialisation
-  [PAdics.padics.hzmultrmul] — looks like unnecessary specialisation?
   [Integers.hzplusradd] — looks like unnecessary specialisation?
   [CategoryTheory.Core.Categories.cancel_postcomposition] — discussed before; probably desirable specialisation
   [CategoryTheory.PrecategoriesWithAbgrops.to_lrw] — to investigate
-  [PAdics.fps.natsummationpaths] — to investigate
   [CategoryTheory.Core.NaturalTransformations.nat_trans_eq_pointwise] — clearly useful; keep; perhaps define in terms of [maponpaths_2]?
   [HomologicalAlgebra.Complexes.MorphismEq'] – to investigate
   [Bicategories.Modifications.Modification.modcomponent_eq] — to investigate

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -59,14 +59,10 @@ The following are specialisations of [maponpaths] or [maponpaths_2]:
   [Foundations.PartA.pair_path_in2] — in [Foundations], also useful specialisation
   [Foundations.PartA.transportf_paths] — in [Foundations], and very useful
 
-  [CategoryTheory.Core.NaturalTransformations.nat_trans_eq_pointwise] — clearly useful; keep; perhaps define in terms of [maponpaths_2]?
   [CategoryTheory.limits.coproducts.CoproductOfArrows_eq] — looks probably like unnecessary duplicate; remove?
 
   [SyntheticHomotopyTheory.AffineLine.makeGuidedHomotopy_localPath] — to investigate
   [SyntheticHomotopyTheory.Circle.makeGH_localPath] — to investigate
-
-  [HomologicalAlgebra.Complexes.MorphismEq'] – to investigate
-  [Bicategories.Modifications.Modification.modcomponent_eq] — to investigate
 
   [Bicategories.WkCatEnrichment.whiskering.cancel_whisker_right] — to investigate
 

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -59,21 +59,18 @@ The following are specialisations of [maponpaths]:
 [Foundations.PartA.pair_path_in2] — in [Foundations], also useful specialisation
 
 [CategoryTheory.RepresentableFunctors.Precategories.total2_paths1] — duplicate of [pair_path_in2], remove?
-[MoreFoundations.PathsOver.pullBackPathOverPoint] — specialisation of [maponpaths_1], probably useful; investigate
-[CategoryTheory.Core.Categories.cancel_precomposition] — specialisation of [maponpaths_1], previously discussed and decided to keep
 [CategoryTheory.PrecategoriesWithAbgrops.to_apply_inv] — to investigate
 [CategoryTheory.PrecategoriesWithAbgrops.to_rrw] — to investigate
+[CategoryTheory.limits.coproducts.CoproductOfArrows_eq] — looks probably like unnecessary duplicate; remove?
 [SyntheticHomotopyTheory.AffineLine.makeGuidedHomotopy_localPath] — to investigate
 [SyntheticHomotopyTheory.Circle.makeGH_localPath] — to investigate
-[CategoryTheory.limits.coproducts.CoproductOfArrows_eq] — looks probably like unnecessary duplicate; remove?
 
 
 The following appear to be duplicates/specialisations of [maponpaths_2], found with [Search (?x = ?x' -> ?f ?x ?y = ?f ?x' ?y)] and similar searches (following [Require UniMath.All]):
 
-  [Foundations.PartA.transportf_paths] — in [Foundations], also useful
-  [CategoryTheory.PreAdditive.ropeq] — looks like unnecessary specialisation
+  [Foundations.PartA.transportf_paths] — in [Foundations], and very useful
   [Integers.hzplusradd] — looks like unnecessary specialisation?
-  [CategoryTheory.Core.Categories.cancel_postcomposition] — discussed before; probably desirable specialisation
+  [CategoryTheory.PreAdditive.ropeq] — looks like unnecessary specialisation
   [CategoryTheory.PrecategoriesWithAbgrops.to_lrw] — to investigate
   [CategoryTheory.Core.NaturalTransformations.nat_trans_eq_pointwise] — clearly useful; keep; perhaps define in terms of [maponpaths_2]?
   [HomologicalAlgebra.Complexes.MorphismEq'] – to investigate

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -71,7 +71,7 @@ The following are specialisations of [maponpaths]:
 
 The following appear to be duplicates/specialisations of [maponpaths_2], found with [Search (?x = ?x' -> ?f ?x ?y = ?f ?x' ?y)] and similar searches (following [Require UniMath.All]):
 
-  [Foundations.PartA.transportf_paths] — in [Foundations], also probably useful
+  [Foundations.PartA.transportf_paths] — in [Foundations], also useful
   [CategoryTheory.PreAdditive.ropeq] — looks like unnecessary specialisation
   [PAdics.padics.hzmultrmul] — looks like unnecessary specialisation?
   [Integers.hzplusradd] — looks like unnecessary specialisation?
@@ -92,7 +92,6 @@ Duplicates:
 Specialisations:
   [Foundations.PartA.pathsdirprod] — in [Foundations], useful specialisation
   [Foundations.PartA.total2_paths2] — in [Foundations], but also dupe of [pathsdirprod]
-  [MoreFoundations.PathsOver.apstar] — possibly unnecessary; investigate
   [CategoriesWithBinOps.to_binop_eq] — looks probably unnecessary
   [CategoryTheory.limits.bincoproducts.BinCoproductArrow_eq]  — looks probably like unnecessary duplicate; investigate, remove?
   [CategoryTheory.limits.binproducts.BinProductOfArrows_eq] — looks probably like unnecessary duplicate; investigate, remove?

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -88,7 +88,6 @@ The following appear to be duplicates/specialisations of [maponpaths_12], found 
 Duplicates:
   [Foundations.PartA.two_arg_paths] — in [Foundations], complete duplicate of [maponpaths_12] and [map_on_two_paths]
   [Foundations.PartA.map_on_two_paths] — in [Foundations], complete duplicate of [maponpaths_12] and [two_arg_paths]
-  [CategoryTheory.binproducts.f_equal_2] — looks like unnecessary duplicate, remove?
 
 Specialisations:
   [Foundations.PartA.pathsdirprod] — in [Foundations], useful specialisation

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -59,11 +59,6 @@ The following are specialisations of [maponpaths] or [maponpaths_2]:
   [Foundations.PartA.pair_path_in2] — in [Foundations], also useful specialisation
   [Foundations.PartA.transportf_paths] — in [Foundations], and very useful
 
-  [CategoryTheory.PrecategoriesWithAbgrops.to_apply_inv] — to investigate
-  [CategoryTheory.PrecategoriesWithAbgrops.to_rrw] — to investigate
-  [CategoryTheory.PrecategoriesWithAbgrops.to_lrw] — to investigate
-
-  [CategoryTheory.PreAdditive.ropeq] — looks like unnecessary specialisation
   [CategoryTheory.Core.NaturalTransformations.nat_trans_eq_pointwise] — clearly useful; keep; perhaps define in terms of [maponpaths_2]?
   [CategoryTheory.limits.coproducts.CoproductOfArrows_eq] — looks probably like unnecessary duplicate; remove?
 

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -59,8 +59,6 @@ The following are specialisations of [maponpaths] or [maponpaths_2]:
   [Foundations.PartA.pair_path_in2] — in [Foundations], also useful specialisation
   [Foundations.PartA.transportf_paths] — in [Foundations], and very useful
 
-  [Integers.hzplusradd] — looks like unnecessary specialisation?
-
   [CategoryTheory.PrecategoriesWithAbgrops.to_apply_inv] — to investigate
   [CategoryTheory.PrecategoriesWithAbgrops.to_rrw] — to investigate
   [CategoryTheory.PrecategoriesWithAbgrops.to_lrw] — to investigate

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -49,7 +49,54 @@ Definition maponpaths_1234 {W Z Y X A : UU} (f : W -> Z -> Y -> X -> A)
   : f w z y x = f w' z' y' x'
 := maponpaths_123 _ e_z e_y e_x @ maponpaths_4 _ e_w _ _ _.
 
-(* NOTE: some of the lemmas above have been re-proved independently multiple times elsewhere in the library, including some pure duplicates, and some specialisations (maybe for good reason, maybe not). TODO: chase the duplicates down; work out + document which ones seem justified; and unify the rest. *)
+(* NOTE: some of the lemmas above are provided multiple times elsewhere in the library, including some pure duplicates, and some specialisations (maybe for good reason, maybe not). TODO:
+
+The following appear to be duplicates/specialisations of [maponpaths_2], found with [Search (?x = ?x' -> ?f ?x ?y = ?f ?x' ?y)] and similar searches (following [Require UniMath.All]):
+
+  PartA.app
+  PreAdditive.ropeq
+  padics.hzmultrmul
+  Integers.hzplusradd
+  cancel_postcomposition
+  PrecategoriesWithAbgrops.to_lrw
+  transportf_paths
+  fps.natsummationpaths
+  nat_trans_eq_pointwise
+  Complexes.MorphismEq'
+  Modification.modcomponent_eq
+  whiskering.cancel_whisker_right
+
+The following appear to be duplicates/specialisations of [maponpaths_12], found with [Search (?x = ?x' -> ?y = ?y' -> ?f ?x ?y = ?f ?x' ?y')] and [Search (?x = ?x' -> forall y y', y = y' -> ?f ?x y = ?f ?x' y')]:
+
+Duplicates:
+  PartA.aptwice
+  binproducts.f_equal_2
+  two_arg_paths
+  map_on_two_paths
+Specialisations:
+  pathsdirprod
+  total2_paths2
+  PathsOver.apstar
+  CategoriesWithBinOps.to_binop_eq
+  bincoproducts.BinCoproductArrow_eq
+  binproducts.BinProductOfArrows_eq
+  bincoproducts.BinCoproductOfArrows_eq
+
+The following are specialisations of [maponpaths]:
+
+base_paths — specislisation of
+lemmas.pathintotalpr1
+pair_path_in2
+maponpathsPrecategories.total2_paths1
+PathsOver.pullBackPathOverPoint
+cancel_precomposition
+PrecategoriesWithAbgrops.to_apply_inv
+PrecategoriesWithAbgrops.to_rrw
+AffineLine.makeGuidedHomotopy_localPath
+Circle.makeGH_localPath
+coproducts.CoproductOfArrows_eq
+*)
+
 
 Lemma maponpaths_for_constant_function {T1 T2 : UU} (x : T2) {t1 t2 : T1}
       (e: t1 = t2): maponpaths (fun _: T1 => x) e = idpath x.

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -8,7 +8,10 @@ The following are a uniformly-named set of lemmas giving how multi-argument (non
 
   The naming convention is that e.g. [maponpaths_135] takes paths in the 1st, 3rd, and 5th arguments, counting _backwards_ from the end.  (The “counting backwards” is so that it doesn’t depend on the total number of arguments the function takes.)
 
-  All are defined in terms of [maponpaths], to allow use of lemmas about it for reasoning about these. *)
+  All are defined in terms of [maponpaths], to allow use of lemmas about it for reasoning about these.
+
+ See below for a note about defining duplicates/special cases of these lemmas downstream. *)
+
 Definition maponpaths_1 {X A : UU} (f : X -> A) {x x'} (e : x = x')
   : f x = f x'
 := maponpaths f e.
@@ -18,6 +21,7 @@ Definition maponpaths_2 {Y X A : UU} (f : Y -> X -> A)
   : f y x = f y' x
 := maponpaths (fun y => f y x) e_y.
 
+(* TODO: should this be defined in terms of [two_arg_paths] or [map_on_two_paths], from [Foundations]?*)
 Definition maponpaths_12 {Y X A : UU} (f : Y -> X -> A)
     {y y'} (e_y : y = y') {x x'} (e_x : x = x')
   : f y x = f y' x'
@@ -49,38 +53,23 @@ Definition maponpaths_1234 {W Z Y X A : UU} (f : W -> Z -> Y -> X -> A)
   : f w z y x = f w' z' y' x'
 := maponpaths_123 _ e_z e_y e_x @ maponpaths_4 _ e_w _ _ _.
 
-(* Notes on duplication issues: *)
+(** Notes on duplication issues:
 
-(* NOTE: some of the lemmas above are provided multiple times elsewhere in the library, including some pure duplicates, and some specialisations (maybe for good reason, maybe not). TODO: chase them down, unify them where desirable, or document when there’s good reason for the duplication/specialisation.
+Duplicates and special cases of these lemmas have been re-written multiple times, in multiple packages, by multiple contributors.
 
-The following are specialisations of [maponpaths] or [maponpaths_2]:
+Sometimes this is intended and useful — e.g. for frequently-used specialisations such as [base_paths], especially when subsequent definitions mention them, like [fiber_paths].
 
-  [Foundations.PartA.base_paths] — keep since in [Foundations]
-  [Foundations.PartA.pair_path_in2] — in [Foundations], also useful specialisation
-  [Foundations.PartA.transportf_paths] — in [Foundations], and very useful
+Other times, it just happens because the contributor hasn’t been aware of the applicable general versions (or they weren’t available at the time of writing).  These cases are code duplication, causing redundancy and inconsistent coding style, and should be avoided/refactored.
 
-  [SyntheticHomotopyTheory.AffineLine.makeGuidedHomotopy_localPath] — to investigate
-  [SyntheticHomotopyTheory.Circle.makeGH_localPath] — to investigate
+To keep these clearly distinguished: if you are defining duplicates or special cases of these lemmas, please (a) define them in terms of the general ones, so that lemmas about these are applicable, and (b) add a comment noting why your definitions are desirable.
 
-  [Bicategories.WkCatEnrichment.whiskering.cancel_whisker_right] — to investigate
+A few direct duplicates remain:
 
-The following appear to be duplicates/specialisations of [maponpaths_12]:
-Duplicates:
-  [Foundations.PartA.two_arg_paths] — in [Foundations], complete duplicate of [maponpaths_12] and [map_on_two_paths]
-  [Foundations.PartA.map_on_two_paths] — in [Foundations], complete duplicate of [maponpaths_12] and [two_arg_paths]
-
-Specialisations:
-  [Foundations.PartA.pathsdirprod] — in [Foundations], useful specialisation
-  [Foundations.PartA.total2_paths2] — in [Foundations], but also dupe of [pathsdirprod]!
-
-*)
-
-(* Most awkwardly: [maponpaths_12] is a duplicate of [two_arg_paths] and [map_on_two_paths] from [Foundations].  Currently, [two_arg_paths] seems to be the most used, and with the most lemmas.
-
-How should we deal with this?  Keep all?  Make them notations/synonyms for each other?  Use primarily one throughout the library?
-
-Similarly, [total2_paths2] and [pathsdirprod], both from [Foundations], seem to be complete duplicates of each other, both widely used?
+- [Foundations.PartA.two_arg_paths] and [Foundations.PartA.map_on_two_paths] are complete duplicates of [maponpaths_12], and of each other (modulo reordering of arguments).
+- [Foundations.PartA.pathsdirprod] and [Foundations.PartA.total2_paths2] are complete duplicates of each other.
  *)
+
+(* TODO: several of the [maponpaths] family could usefully be generalised, to work with functions whose output type is dependent on the arguments that aren’t being varied in the specific lemma. *)
 
 Lemma maponpaths_for_constant_function {T1 T2 : UU} (x : T2) {t1 t2 : T1}
       (e: t1 = t2): maponpaths (fun _: T1 => x) e = idpath x.

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -59,8 +59,6 @@ The following are specialisations of [maponpaths] or [maponpaths_2]:
   [Foundations.PartA.pair_path_in2] — in [Foundations], also useful specialisation
   [Foundations.PartA.transportf_paths] — in [Foundations], and very useful
 
-  [CategoryTheory.limits.coproducts.CoproductOfArrows_eq] — looks probably like unnecessary duplicate; remove?
-
   [SyntheticHomotopyTheory.AffineLine.makeGuidedHomotopy_localPath] — to investigate
   [SyntheticHomotopyTheory.Circle.makeGH_localPath] — to investigate
 
@@ -76,8 +74,6 @@ Specialisations:
   [Foundations.PartA.total2_paths2] — in [Foundations], but also dupe of [pathsdirprod]!
 
   [CategoryTheory.limits.bincoproducts.BinCoproductArrow_eq]  — looks probably like unnecessary duplicate; investigate, remove?
-  [CategoryTheory.limits.binproducts.BinProductOfArrows_eq] — looks probably like unnecessary duplicate; investigate, remove?
-  [CategoryTheory.limits.bincoproducts.BinCoproductOfArrows_eq] — looks probably like unnecessary duplicate; investigate, remove?
 *)
 
 (* Most awkwardly: [maponpaths_12] is a duplicate of [two_arg_paths] and [map_on_two_paths] from [Foundations].  Currently, [two_arg_paths] seems to be the most used, and with the most lemmas.

--- a/UniMath/MoreFoundations/PathsOver.v
+++ b/UniMath/MoreFoundations/PathsOver.v
@@ -622,7 +622,7 @@ Definition pullBackPathOverPoint {X X':Type} (g : X -> X')
            {Y : X' -> Type} {y y' : Y x'} (t : y = y')
   : pullBackPointOver g r y = pullBackPointOver g r y'.
 Proof.
-  induction t. reflexivity.
+  apply maponpaths; assumption.
 Defined.
 
 Definition pullBackPathOver {X X':Type} (g : X -> X')

--- a/UniMath/MoreFoundations/PathsOver.v
+++ b/UniMath/MoreFoundations/PathsOver.v
@@ -524,11 +524,12 @@ Proof.
   now induction α.
 Defined.
 
+(* a frequently-useful specialisation of [maponpaths_12] *)
 Definition apstar               (* 0.2.7 *)
            (A:Type) (a1 a2 a3:A) (p p':a1=a2) (q q':a2=a3) :
   p=p' -> q=q' -> p @ q = p' @ q'.
 Proof.
-  intros α β. induction α, p. exact β.
+  intros; apply maponpaths_12; assumption.
 Defined.
 
 Definition cp_apstar

--- a/UniMath/NumberSystems/Integers.v
+++ b/UniMath/NumberSystems/Integers.v
@@ -131,7 +131,7 @@ Lemma hzplusrcan ( a b c : hz ) ( is : ( a + c ) = ( b + c ) ) : a = b .
 Proof . intros . apply ( @grrcan hzaddabgr a b c is ) .  Defined .
 
 Lemma hzplusradd (a b c : hz) (is : a = b) : (a + c) = (b + c).
-Proof. intros. induction is. apply idpath. Defined.
+Proof. apply maponpaths_2, is. Defined.
 
 Lemma hzplusladd (a b c : hz) (is : a = b) : (c + a) = (c + b).
 Proof. intros. apply maponpaths. apply is. Defined.

--- a/UniMath/NumberSystems/Integers.v
+++ b/UniMath/NumberSystems/Integers.v
@@ -130,12 +130,6 @@ Proof . intros . apply ( @grlcan hzaddabgr a b c is ) .  Defined .
 Lemma hzplusrcan ( a b c : hz ) ( is : ( a + c ) = ( b + c ) ) : a = b .
 Proof . intros . apply ( @grrcan hzaddabgr a b c is ) .  Defined .
 
-Lemma hzplusradd (a b c : hz) (is : a = b) : (a + c) = (b + c).
-Proof. apply maponpaths_2, is. Defined.
-
-Lemma hzplusladd (a b c : hz) (is : a = b) : (c + a) = (c + b).
-Proof. intros. apply maponpaths. apply is. Defined.
-
 Definition hzinvmaponpathsminus { a b : hz } ( e : ( - a ) = ( - b ) ) : a = b := grinvmaponpathsinv hzaddabgr e .
 
 Lemma hzrplusminus (n m : hz) : n + m - m = n.
@@ -980,7 +974,7 @@ Qed.
 
 Lemma hzeqnmplusr {n m i : hz} (e : n = m) (e' : ¬ (n + i = m + i)) : empty.
 Proof.
-  apply e'. exact (hzplusradd _ _ i e).
+  apply e'. exact (maponpaths_2 _ e _).
 Qed.
 
 Lemma hzeqnmplusr' {n m i : hz} (e : ¬ (n = m)) (e' : n + i = m + i) : empty.

--- a/UniMath/PAdics/fps.v
+++ b/UniMath/PAdics/fps.v
@@ -25,13 +25,6 @@ Proof.
   - intros. exact ( IHupper f + f ( S upper ) ).
 Defined.
 
-Lemma natsummationpaths { R : commring } { upper upper' : nat }
-  ( u : upper = upper' ) ( f : nat -> R ) :
-  natsummation0 upper f = natsummation0 upper' f.
-Proof.
-  intros. destruct u. auto.
-Defined.
-
 Lemma natsummationpathsupperfixed { R : commring } { upper : nat }
   ( f f' : nat -> R ) ( p : forall x : nat, natleh x upper -> f x = f' x ):
   natsummation0 upper f = natsummation0 upper f'.

--- a/UniMath/PAdics/lemmas.v
+++ b/UniMath/PAdics/lemmas.v
@@ -19,33 +19,12 @@ Unset Kernel Term Sharing. (** for quicker proof-checking, approx. by factor 25 
 
 (** Fixing some notation *)
 
-(** * Notation, terminology and very basic facts *)
+(** * Notation, terminology  *)
 
 Arguments tpair [ T P ].
 
-Lemma pathintotalfiber ( B : UU ) ( E : B -> UU ) ( b0 b1 : B )
-      ( e0 : E b0 ) ( e1 : E b1 ) ( p0 : b0 = b1 ) ( p1 : transportf E p0 e0 = e1 ) :
-  ( tpair b0 e0 ) = ( tpair b1 e1 ).
-Proof.
-  intros. destruct p0, p1. apply idpath.
-Defined.
-
 Definition neq ( X : UU ) : hrel X :=
   fun x y : X => make_hProp (neg (x = y)) (isapropneg (x = y)).
-
-Definition pathintotalpr1 { B : UU } { E : B -> UU } { v w : total2 E} ( p : v = w ) :
-  ( pr1 v ) = ( pr1 w ) := maponpaths ( fun x => pr1 x ) p.
-
-Lemma isinclisinj { A B : UU } { f : A -> B } ( p : isincl f ) { a b : A }
-      ( f_eq : f a = f b ) : a = b.
-Proof.
-  intros.
-  set ( q := p ( f a )).
-  set ( a' := make_hfiber f a ( idpath ( f a ) ) ).
-  set ( b' := make_hfiber f b ( pathsinv0 f_eq ) ).
-  assert ( a' = b' ) as p1. apply (p ( f a ) ).
-  apply ( pathintotalpr1 p1 ).
-Defined.
 
 (** * I. Lemmas on natural numbers *)
 
@@ -414,7 +393,7 @@ Proof.
       change ( ( @ringunel2 X ) * c = c )%ring.
       apply ringlunax2.
     }
-    apply pathintotalfiber with ( p0 := f0 ).
+    apply (total2_paths2_f f0 ).
     assert ( isaprop ( c * a = ( @ringunel2 X )  ×
                        a * c = ( @ringunel2 X ) ) ) as is.
     { apply isofhleveldirprod.
@@ -634,7 +613,7 @@ Definition hzldistr ( a b c : hz ) : c * ( a + b ) = ( c * a ) + ( c * b ) :=
 
 Lemma hzabsvaland1 : hzabsval 1 = 1%nat.
 Proof.
-  apply ( isinclisinj isinclnattohz ).
+  apply ( invmaponpathsincl _ isinclnattohz ).
   rewrite hzabsvalgth0.
   - rewrite nattohzand1.
     apply idpath.
@@ -654,7 +633,7 @@ Proof.
       apply p.
     - assumption.
   }
-  apply ( isinclisinj isinclnattohz ).
+  apply ( invmaponpathsincl _ isinclnattohz ).
   rewrite nattohzandplus.
   rewrite hzabsvalgeh0. (* used to start with rewrite 3! hzabsvalgeh0 *)
   - rewrite hzabsvalgeh0.
@@ -678,7 +657,7 @@ Proof.
     - apply hzlth0andminus.
       assumption.
   }
-  apply ( isinclisinj isinclnattohz ).
+  apply ( invmaponpathsincl _ isinclnattohz ).
   rewrite nattohzandplus.
   rewrite hzabsvallth0.
   - rewrite hzabsvallth0.

--- a/UniMath/PAdics/padics.v
+++ b/UniMath/PAdics/padics.v
@@ -17,28 +17,6 @@ Require Import UniMath.NumberSystems.Integers.
 
 Unset Kernel Term Sharing. (** crucial for timely proof-checking, otherwise unbearable *)
 
-Section Upstream.
-  (* these lemmas are only used for pointing to a problem but could be worth
-     integrating into upstream *)
-Local Open Scope hz_scope.
-
-Lemma hzmultrmul (a b c : hz) (is : a = b) : a * c = b * c.
-Proof.
-  intros.
-  induction is.
-  apply idpath.
-Defined.
-
-Lemma hzmultlmul (a b c : hz) (is : a = b) : c * a = c * b.
-Proof.
-  intros.
-  apply maponpaths.
-  apply is.
-Defined.
-
-Close Scope hz_scope.
-End Upstream.
-
 (** * I. Several basic lemmas *)
 
 Local Open Scope hz_scope.
@@ -205,14 +183,7 @@ Proof.
       rewrite hzmultx0.
       rewrite hzplusl0.
       rewrite hzremaindermoditerated.
-      (* Coq hangs on this command on Oct. 29, 2017: apply idpath. Solution by Benedikt Ahrens : *)
-      exact (idpath _).
-(* a less pleasing solution was the following - together with interesting observations:
-      apply hzplusladd.
-      Fail (apply hzmultlmul).
-      Fail (apply hzmultrmul).
       apply idpath.
-*)
     }
     rewrite h.
     apply idpath.

--- a/UniMath/PAdics/z_mod_p.v
+++ b/UniMath/PAdics/z_mod_p.v
@@ -671,7 +671,7 @@ Proof.
   assert ( make_dirprod q' r' = ( make_dirprod q r ) ) as j
   by (apply pathsdirprod; assumption).
   (* Proof of general path: *)
-  apply pathintotalfiber with ( p0 := j ).
+  apply ( total2_paths2_f j ).
   assert ( iscontr ( n = m * q + r ×
              ( hzleh 0 r ×
                hzlth r ( nattohz ( hzabsval m ) ) ) ) ) as contract.
@@ -1147,7 +1147,7 @@ Proof.
       - apply q.
         assumption.
     }
-    apply pathintotalfiber with ( p0 := f0 ).
+    apply ( total2_paths2_f f0 ).
     assert ( isaprop ( iscommonhzdiv l n m ×
                        forall x : hz, iscommonhzdiv x n m -> hzleh x l ) ) as is.
     { apply isofhleveldirprod.
@@ -1258,7 +1258,7 @@ Proof.
              unfold hzdiv0 in t2.
              assert ( natleh ( hzabsval l ) n ⨿ ( n = 0%nat ) ) as C.
              { apply ( natdivleh ( hzabsval l ) n ( hzabsval k ) ).
-               apply ( isinclisinj isinclnattohz ).
+               apply ( invmaponpathsincl _ isinclnattohz ).
                rewrite nattohzandmult.
                rewrite 2! hzabsvalgeh0.
                ++ assumption.
@@ -1429,7 +1429,7 @@ Proof.
           assumption.
         * exact ( pr2 f ).
   }
-  apply ( pathintotalpr1 x ).
+  apply ( base_paths _ _ x ).
 Defined.
 
 Lemma hzgcdsymm ( m n : hz ) : hzgcd m n = hzgcd n m.
@@ -1463,7 +1463,7 @@ Proof.
         * exact ( pr2 o ).
         * exact ( pr1 o ).
   }
-  apply ( pathintotalpr1 x ).
+  apply ( base_paths _ _ x ).
 Defined.
 
 Lemma hzgcdandminusr ( m n : hz ) : hzgcd m n = hzgcd m ( - n ).
@@ -2233,7 +2233,7 @@ Proof.
                               ( make_dirprod ( isreflhzleh 0 ) ( lemmas.hzabsvalneq0 p x ) ) ) ).
   assert ( e = pr1 ( divalgorithm a p x ) ) as s
   by apply ( pr2 ( divalgorithm a p x ) ).
-  set ( w := pathintotalpr1 ( pathsinv0 s ) ).
+  set ( w := base_paths _ _ ( pathsinv0 s ) ).
   unfold e in w.
   unfold hzremaindermod.
   apply ( maponpaths ( fun z : hz × hz => pr2 z ) w ).

--- a/UniMath/SubstitutionSystems/BinProductOfSignatures.v
+++ b/UniMath/SubstitutionSystems/BinProductOfSignatures.v
@@ -12,6 +12,7 @@ Written by Anders Mörtberg, 2016 (adapted from SumOfSignatures.v)
 ************************************************************)
 
 Require Import UniMath.Foundations.PartD.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.Core.Functors.
@@ -78,7 +79,7 @@ Proof.
   intros x x' f.
   eapply pathscomp0; [ apply BinProductOfArrows_comp | ].
   eapply pathscomp0; [ | eapply pathsinv0; apply BinProductOfArrows_comp].
-  apply BinProductOfArrows_eq.
+  apply maponpaths_12.
   * apply (nat_trans_ax (θ1 (X ⊗ Z))).
   * apply (nat_trans_ax (θ2 (X ⊗ Z))).
 Qed.
@@ -99,7 +100,7 @@ Proof.
   eapply pathscomp0; [ | eapply pathsinv0, BinProductOfArrows_comp].
   eapply pathscomp0; [ apply cancel_postcomposition, BinProductOfArrows_comp |].
   eapply pathscomp0; [ apply BinProductOfArrows_comp |].
-  apply BinProductOfArrows_eq.
+  apply maponpaths_12.
   + exact (nat_trans_eq_pointwise (nat_trans_ax θ1 _ _ (α,,β)) c).
   + exact (nat_trans_eq_pointwise (nat_trans_ax θ2 _ _ (α,,β)) c).
 Qed.
@@ -134,7 +135,7 @@ Proof.
   apply pathsinv0.
   eapply pathscomp0; [ apply cancel_postcomposition; simpl; apply BinProductOfArrows_comp|].
   eapply pathscomp0; [ apply BinProductOfArrows_comp|].
-  apply pathsinv0, BinProductOfArrows_eq.
+  apply pathsinv0, maponpaths_12.
   - assert (Ha := S12 X Z Z' Y α); simpl in Ha.
     apply (nat_trans_eq_pointwise Ha x).
   - assert (Ha := S22 X Z Z' Y α); simpl in Ha.
@@ -168,7 +169,7 @@ Proof.
   eapply pathscomp0; [apply BinProductOfArrows_comp|].
   apply pathsinv0.
   eapply pathscomp0; [apply BinProductOfArrows_comp|].
-  apply pathsinv0, BinProductOfArrows_eq.
+  apply pathsinv0, maponpaths_12.
   - assert (Ha_x := nat_trans_eq_pointwise (S12' X Z Z') x).
     simpl in Ha_x; rewrite id_left in Ha_x.
     exact Ha_x.

--- a/UniMath/SubstitutionSystems/BinSumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/BinSumOfSignatures.v
@@ -19,6 +19,7 @@ Contents:
 ************************************************************)
 
 Require Import UniMath.Foundations.PartD.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.Core.Functors.
@@ -88,7 +89,7 @@ Proof.
   intros x x' f.
   eapply pathscomp0; [ apply BinCoproductOfArrows_comp | ].
   eapply pathscomp0; [ | eapply pathsinv0; apply BinCoproductOfArrows_comp].
-  apply BinCoproductOfArrows_eq.
+  apply maponpaths_12.
   * apply (nat_trans_ax (θ1 (X ⊗ Z))).
   * apply (nat_trans_ax (θ2 (X ⊗ Z))).
 Qed.
@@ -117,7 +118,7 @@ Proof.
     eapply pathscomp0; [ | eapply pathsinv0; apply BinCoproductOfArrows_comp].
     eapply pathscomp0. apply cancel_postcomposition. apply BinCoproductOfArrows_comp.
     eapply pathscomp0. apply BinCoproductOfArrows_comp.
-    apply BinCoproductOfArrows_eq.
+    apply maponpaths_12.
     + apply (nat_trans_eq_pointwise Hyp1 c).
     + apply (nat_trans_eq_pointwise Hyp2 c).
 Qed.
@@ -160,7 +161,7 @@ Proof.
   eapply pathscomp0. apply cancel_postcomposition. simpl. apply BinCoproductOfArrows_comp.
   eapply pathscomp0. apply BinCoproductOfArrows_comp.
   apply pathsinv0.
-  apply BinCoproductOfArrows_eq.
+  apply maponpaths_12.
   - assert (Ha:=S12 X Z Z' Y α).
     simpl in Ha.
     assert (Ha_x := nat_trans_eq_pointwise Ha x).
@@ -204,7 +205,7 @@ Proof.
   apply pathsinv0.
   eapply pathscomp0. apply BinCoproductOfArrows_comp.
   apply pathsinv0.
-  apply BinCoproductOfArrows_eq.
+  apply maponpaths_12.
   - assert (Ha:=S12' X Z Z').
     simpl in Ha.
     assert (Ha_x := nat_trans_eq_pointwise Ha x).

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -24,6 +24,7 @@ Contents :
 
 
 Require Import UniMath.Foundations.PartD.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.Core.Functors.
@@ -366,7 +367,7 @@ Proof.
   rewrite <- functor_comp.
   rewrite <- functor_comp.
   simpl.
-  apply BinCoproductArrow_eq.
+  apply maponpaths_12.
   + assert (NN :=  nat_trans_ax (pr2 (pr2 XZ)) _ _ (BinCoproductOfArrows C (CC (TerminalObject terminal) c) (CC (TerminalObject terminal) c')
          (identity (TerminalObject terminal)) f)).
     match goal with |[ H1: _ = ?f·?g |- _ = ?h · _ ] =>
@@ -406,7 +407,7 @@ Focus 2.
   rewrite <- functor_comp.
   rewrite <- functor_comp.
   simpl.
-  apply BinCoproductArrow_eq.
+  apply maponpaths_12.
   + assert (NN :=  nat_trans_ax e _ _ (BinCoproductOfArrows C (CC (TerminalObject terminal) c) (CC (TerminalObject terminal) c')
          (identity (TerminalObject terminal)) f)).
     match goal with |[ H1: _ = ?f·?g |- _ = ?h · _ ] =>
@@ -468,7 +469,7 @@ Proof.
   eapply cancel_postcomposition. apply postcompWithBinCoproductArrow.
 *)
 (*  rewrite postcompWithBinCoproductArrow. *)
-  apply BinCoproductArrow_eq.
+  apply maponpaths_12.
   + rewrite id_left.
     rewrite <- assoc.
     rewrite <- (ptd_mor_commutes _ β).
@@ -522,7 +523,7 @@ Proof.
   2: { eapply pathsinv0.
        apply postcompWithBinCoproductArrow. }
   simpl in *.
-  apply BinCoproductArrow_eq.
+  apply maponpaths_12.
   + rewrite <- assoc.
     assert (NN := nat_trans_ax e' _ _ (e (BinCoproductObject C (CC (TerminalObject terminal) c)))).
     simpl in NN. (* is important for success of the trick *)

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -26,6 +26,7 @@ Set Kernel Term Sharing.
 
 Require Import UniMath.Foundations.PartD.
 
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Core.Categories.
@@ -132,7 +133,7 @@ Proof.
   eapply pathscomp0; [apply BinCoproductOfArrows_comp |].
   eapply pathscomp0.
   2: { eapply pathsinv0. apply BinCoproductOfArrows_comp. }
-  apply BinCoproductOfArrows_eq.
+  apply maponpaths_12.
   - eapply pathscomp0. apply id_left.
     apply pathsinv0.
     apply id_right.
@@ -176,7 +177,7 @@ Proof.
   eapply pathscomp0. apply BinCoproductOfArrows_comp.
   eapply pathscomp0.
   2: { eapply pathsinv0. apply BinCoproductOfArrows_comp. }
-  apply BinCoproductOfArrows_eq.
+  apply maponpaths_12.
   - rewrite id_right.
     apply pathsinv0.
     apply id_right.
@@ -226,7 +227,7 @@ Proof.
   intro c; simpl.
   unfold coproduct_nat_trans_data; simpl.
   unfold coproduct_nat_trans_in1_data, coproduct_nat_trans_in2_data; simpl.
-  apply BinCoproductOfArrows_eq.
+  apply (maponpaths_12 (BinCoproductOfArrows _ _ _)).
   + apply idpath.
   + unfold functor_fix_snd_arg_mor; simpl.
     revert c.
@@ -570,7 +571,7 @@ Proof.
   intro c; simpl.
   unfold coproduct_nat_trans_data; simpl.
   unfold coproduct_nat_trans_in1_data, coproduct_nat_trans_in2_data; simpl.
-  apply BinCoproductOfArrows_eq.
+  apply (maponpaths_12 (BinCoproductOfArrows _ _ _)).
   - apply idpath.
   - unfold functor_fix_snd_arg_mor; simpl.
     revert c.

--- a/UniMath/SubstitutionSystems/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial_alt.v
@@ -16,6 +16,7 @@ Set Kernel Term Sharing.
 
 Require Import UniMath.Foundations.PartD.
 
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Core.Categories.
@@ -206,7 +207,7 @@ rewrite id_left, id_right.
 apply (nat_trans_eq hsC); intro c; simpl.
 unfold coproduct_nat_trans_data; simpl.
 unfold coproduct_nat_trans_in1_data, coproduct_nat_trans_in2_data; simpl.
-apply BinCoproductOfArrows_eq; trivial.
+apply (maponpaths_12 (BinCoproductOfArrows _ _ _)); trivial.
 unfold functor_fix_snd_arg_mor; simpl.
 revert c; apply nat_trans_eq_pointwise, maponpaths.
 apply (nat_trans_eq hsC); intro c; simpl.
@@ -429,7 +430,7 @@ rewrite id_left, id_right.
 apply (nat_trans_eq hsC); intro c; simpl.
 unfold coproduct_nat_trans_data; simpl.
 unfold coproduct_nat_trans_in1_data, coproduct_nat_trans_in2_data; simpl.
-apply BinCoproductOfArrows_eq; trivial.
+apply (maponpaths_12 (BinCoproductOfArrows _ _ _)); trivial.
 unfold functor_fix_snd_arg_mor; simpl.
 revert c; apply nat_trans_eq_pointwise, maponpaths.
 apply (nat_trans_eq hsC); intro c; simpl.

--- a/UniMath/SubstitutionSystems/ModulesFromSignatures.v
+++ b/UniMath/SubstitutionSystems/ModulesFromSignatures.v
@@ -401,7 +401,7 @@ Proof.
   { eapply pathsinv0.
     apply (precompWithBinCoproductArrow C (CP _ _) (CP _ _)
                                         (identity _) (((# H a):nat_trans _ _) (T_func c))). }
-  apply BinCoproductArrow_eq.
+  use (maponpaths_12 (BinCoproductArrow _ _)).
   + apply pathsinv0,id_left.
   + apply pathsinv0.
     etrans;[apply assoc|].
@@ -463,7 +463,7 @@ Proof.
     apply cancel_postcomposition.
     apply BinCoproductArrowEta.
     apply postcompWithBinCoproductArrow. }
-  apply BinCoproductArrow_eq.
+  use maponpaths_12.
   - apply hB1.
   - apply hB2.
 Qed.

--- a/UniMath/SubstitutionSystems/SumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/SumOfSignatures.v
@@ -67,7 +67,7 @@ Proof.
 intros x x' f.
 eapply pathscomp0; [ apply CoproductOfArrows_comp | ].
 eapply pathscomp0; [ | eapply pathsinv0; apply CoproductOfArrows_comp].
-apply CoproductOfArrows_eq, funextsec; intro i.
+apply maponpaths, funextsec; intro i.
 apply (nat_trans_ax (θ1 i (X ⊗ Z))).
 Qed.
 
@@ -84,7 +84,7 @@ apply (nat_trans_eq hsD); intro c.
 eapply pathscomp0; [ | eapply pathsinv0, CoproductOfArrows_comp].
 eapply pathscomp0; [ apply cancel_postcomposition, CoproductOfArrows_comp |].
 eapply pathscomp0; [ apply CoproductOfArrows_comp |].
-apply CoproductOfArrows_eq, funextsec; intro i.
+apply maponpaths, funextsec; intro i.
 apply (nat_trans_eq_pointwise (nat_trans_ax (θ1 i) (X,,Z) (X',,Z') αβ) c).
 Qed.
 
@@ -114,7 +114,7 @@ apply (nat_trans_eq hsD); intro x; simpl; rewrite id_left.
 eapply pathscomp0; [apply CoproductOfArrows_comp|].
 apply pathsinv0.
 eapply pathscomp0; [apply CoproductOfArrows_comp|].
-apply pathsinv0, CoproductOfArrows_eq, funextsec; intro i.
+apply pathsinv0, maponpaths, funextsec; intro i.
 assert (Ha_x := nat_trans_eq_pointwise (S12' i X Z Z') x); simpl in Ha_x.
 rewrite id_left in Ha_x; apply Ha_x.
 Qed.


### PR DESCRIPTION
The library (before this PR) contains quite a lot of duplicate lemmas providing [maponpaths]-stype principles for multiple-argument functions.

Some of these are special cases that are worth specifically naming (e.g. `base_paths`, `cancel_precomposition`), but most seem like just redundant code duplication, hand-rolled each time because suitable general lemmas weren’t available or discoverable at the time of writing.

In this PR, I have:

1. provided a family of uniformly-named [maponpaths]-style lemmas for multi-argument functions, in `MoreFoundations.PartA`, upstreamed from https://github.com/UniMath/TypeTheory/

2. refactored away special cases/duplicates elsewhere, when they seemed like just unnecessary duplication

3. when special cases elsewhere seemed clearly intended/justified, added comments documenting their added value

A couple of points remain slightly unsatisfactory after this PR.  In particular, `Foundations` itself contains a pair of duplicate functions `map_on_two_paths`, `two_arg_paths`, and this family adds a third, `maponpaths_12` (to fit the family’s general naming convention).  I’ve agonised over what to do about this, and it seems difficult — the desiderata “avoid duplication”, “have consistently-named family of lemmas”, and “don’t change `Foundations`” are all in conflict here.  So to avoid blockage/bikeshedding, I suggest we defer it to a separate issue after this PR is merged, if the maintainers agree that this PR is an improvement on the current situation.