### PR TITLE
make with 2 jobs on github action

### DIFF
--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build UniMath
         run: |
           cd $GITHUB_WORKSPACE
-          time make build-coq BUILD_COQIDE=$BUILD_COQIDE && time make TIMECMD=time
+          time make build-coq BUILD_COQIDE=$BUILD_COQIDE && time make -j2 TIMECMD=time
 
       # Change into UniMath directory and run sanity checks
       - name: Change into UniMath directory and run sanity checks


### PR DESCRIPTION
The runners have 2 cores, so we could speed this up a bit: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners

However, Coq sometimes does not like being compiled with more than 1 job, so I am leaving it as is.