### PR TITLE
currently only a bit cleaning of Isos.v

### DIFF
--- a/UniMath/Bicategories/Core/Examples/BicategoryFromMonoidal.v
+++ b/UniMath/Bicategories/Core/Examples/BicategoryFromMonoidal.v
@@ -161,8 +161,8 @@ Proof.
   monoidal category, we need to rewrite the equation in order to apply it. *)
   intros ? ? ? ? ? f g h i.
   cbn.
-  apply (pre_comp_with_iso_is_inj _ _ _ _ (pr1 α ((f, g), h ⊗ i)) (pr2 α _) _ _).
-  apply (pre_comp_with_iso_is_inj _ _ _ _ (pr1 α (((f ⊗ g), h) , i)) (pr2 α _) _ _).
+  apply (pre_comp_with_iso_is_inj _ _ _ (pr1 α ((f, g), h ⊗ i)) (pr2 α _) _ _).
+  apply (pre_comp_with_iso_is_inj _ _ _ (pr1 α (((f ⊗ g), h) , i)) (pr2 α _) _ _).
   apply pathsinv0.
   etrans. exact (maponpaths (fun z => _ · z) (assoc _ _ _)).
   etrans. exact (maponpaths (fun z => _ · (z · _)) (iso_inv_after_iso (pr1 α ((f, g), _) ,, pr2 α _ ))).

--- a/UniMath/Bicategories/Discreteness.v
+++ b/UniMath/Bicategories/Discreteness.v
@@ -26,7 +26,7 @@ Proof.
   apply weqimplimpl.
   - apply is_iso_from_is_z_iso.
   - apply is_z_iso_from_is_iso.
-  - apply isaprop_is_z_isomorphism, C.
+  - apply isaprop_is_z_isomorphism.
   - apply isaprop_is_iso.
 Defined.
 

--- a/UniMath/Bicategories/DisplayedBicats/Examples/KleisliTriple.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/KleisliTriple.v
@@ -458,7 +458,7 @@ Proof.
     pose (pr2 (invertible_2cell_to_nat_iso
                  _ _
                  (inv_of_invertible_2cell x)) (pr1 aa X)) as q.
-    apply (iso_inv_to_right _ _ _ _ _ (_ ,, q)).
+    apply (iso_inv_to_right _ _ _ _ (_ ,, q)).
     apply disp_locally_groupoid_kleisli_help.
     exact xx.
   - exact disp_2cells_isaprop_kleisli.

--- a/UniMath/Bicategories/WkCatEnrichment/whiskering.v
+++ b/UniMath/Bicategories/WkCatEnrichment/whiskering.v
@@ -66,7 +66,7 @@ Lemma whisker_left_inv {C : prebicategory} {a b c : C}
 Proof.
   unfold whisker_left.
   intermediate_path (inv_from_iso (identity_iso f);h;inv_from_iso alpha).
-    set (W := maponpaths pr1 (iso_inv_of_iso_id _ f)).
+    set (W := maponpaths pr1 (iso_inv_of_iso_id f)).
     simpl in W.
     rewrite <- W.
     reflexivity.
@@ -163,7 +163,7 @@ Lemma whisker_right_inv {C : prebicategory} {a b c : C}
 Proof.
   unfold whisker_right.
   intermediate_path (inv_from_iso alpha ;h; inv_from_iso (identity_iso h)).
-    set (W := maponpaths pr1 (iso_inv_of_iso_id _ h)).
+    set (W := maponpaths pr1 (iso_inv_of_iso_id h)).
     simpl in W.
     rewrite <- W.
     reflexivity.
@@ -355,7 +355,7 @@ Local Lemma kelly_left_region_12 :
   =   whisker_left f (associator (identity1 b) g h)
   ;v; whisker_left f (whisker_right (left_unitor g) h).
 Proof.
-  apply (post_comp_with_iso_is_inj _ _ _ (associator f g h) (pr2 (associator f g h))).
+  apply (post_comp_with_iso_is_inj _ _ (associator f g h) (pr2 (associator f g h))).
   unfold whisker_right at 1.
   rewrite <- horizontal_comp_id.
   rewrite <- assoc.
@@ -396,7 +396,7 @@ Lemma left_unitor_on_id {C : prebicategory} {a : C}
   : whisker_left (identity1 a) (left_unitor (identity1 a))
   = left_unitor (identity1 a ;1; identity1 a).
 Proof.
-  apply (post_comp_with_iso_is_inj _ _ _ (left_unitor (identity1 a))).
+  apply (post_comp_with_iso_is_inj _ _ (left_unitor (identity1 a))).
     apply (pr2 (left_unitor (identity1 a))).
   apply left_unitor_naturality.
 Defined.
@@ -406,7 +406,7 @@ Lemma left_unitor_id_is_right_unitor_id {C : prebicategory} {a : C}
   = right_unitor_2mor (identity1 a).
 Proof.
   apply whisker_right_id_inj.
-  apply (pre_comp_with_iso_is_inj _ _ _ _ (associator _ _ _) (pr2 (associator _ _ _))).
+  apply (pre_comp_with_iso_is_inj _ _ _ (associator _ _ _) (pr2 (associator _ _ _))).
   intermediate_path (left_unitor_2mor ((identity1 a) ;1; (identity1 a))).
     apply pathsinv0.
     apply kelly_left.

--- a/UniMath/CategoryTheory/Chains/Adamek.v
+++ b/UniMath/CategoryTheory/Chains/Adamek.v
@@ -194,7 +194,7 @@ induction n as [|n IHn]; simpl.
 - rewrite <- IHn, functor_comp, <- assoc.
   eapply pathscomp0; [| eapply maponpaths; apply hf].
   rewrite assoc.
-  apply cancel_postcomposition, pathsinv0, (iso_inv_to_right _ _ _ _ _ α).
+  apply cancel_postcomposition, pathsinv0, (iso_inv_to_right _ _ _ _ α).
   rewrite unfold_inv_from_iso_α; apply pathsinv0.
   now eapply pathscomp0; [apply (colimArrowCommutes shiftColimCocone)|].
 Qed.

--- a/UniMath/CategoryTheory/Core/Isos.v
+++ b/UniMath/CategoryTheory/Core/Isos.v
@@ -54,7 +54,7 @@ Definition inv_from_iso {C : precategory_data} {a b : C} (f : iso a b) : b --> a
 Definition iso_inv_after_iso {C : precategory_data} {a b : C} (f: iso a b) :
    f · inv_from_iso f = identity _ .
 Proof.
-  set (T:=homotweqinvweq (make_weq (precomp_with f) (pr2 f a ))).
+  set (T := homotweqinvweq (make_weq (precomp_with f) (pr2 f a ))).
   simpl in *.
   apply T.
 Defined.
@@ -62,10 +62,10 @@ Defined.
 Definition iso_after_iso_inv {C : precategory} {a b : C} (f : iso a b) :
   inv_from_iso f · f = identity _ .
 Proof.
-  set (T:= invmaponpathsweq (make_weq (precomp_with f) (pr2 f b))).
+  set (T := invmaponpathsweq (make_weq (precomp_with f) (pr2 f b))).
   apply T; clear T; simpl.
   unfold precomp_with.
-  intermediate_path ((f· inv_from_iso f)·f).
+  intermediate_path ((f · inv_from_iso f) · f).
   - apply assoc.
   - apply remove_id_left.
     + apply iso_inv_after_iso.
@@ -83,7 +83,7 @@ Proof.
     + apply remove_id_left. apply iso_inv_after_iso. apply idpath.
   - intro g.
     unfold precomp_with.
-    intermediate_path ((inv_from_iso f·f)·g).
+    intermediate_path ((inv_from_iso f · f) · g).
     + apply assoc.
     + apply remove_id_left. apply iso_after_iso_inv. apply idpath.
 Defined.
@@ -127,7 +127,7 @@ Definition iso_inv_from_is_iso {C : precategory} {a b : ob C}
   (f : a --> b) (H : is_iso f) : iso b a :=
   iso_inv_from_iso (f,,H).
 
-Lemma iso_inv_on_right (C : precategory) (a b c : ob C)
+Lemma iso_inv_on_right {C : precategory} (a b c : ob C)
   (f : iso a  b) (g : b --> c) (h : a --> c) (H : h = f · g) :
      inv_from_iso f · h = g.
 Proof.
@@ -140,7 +140,7 @@ Proof.
     + assumption.
 Defined.
 
-Lemma iso_inv_on_left (C : precategory) (a b c : ob C)
+Lemma iso_inv_on_left {C : precategory} (a b c : ob C)
   (f : a --> b) (g : iso b c) (h : a --> c) (H : h = f · g) :
      f = h · inv_from_iso g.
 Proof.
@@ -154,7 +154,7 @@ Proof.
   assumption.
 Qed.
 
-Lemma iso_inv_to_left (C : precategory) (a b c : ob C)
+Lemma iso_inv_to_left {C : precategory} (a b c : ob C)
   (f : iso a  b) (g : b --> c) (h : a --> c) :
     inv_from_iso f · h = g -> h = f · g.
 Proof.
@@ -164,7 +164,7 @@ Proof.
   - rewrite <- assoc. rewrite H. apply idpath.
 Qed.
 
-Lemma iso_inv_to_right (C : precategory) (a b c : ob C)
+Lemma iso_inv_to_right {C : precategory} (a b c : ob C)
   (f : a --> b) (g : iso b c) (h : a --> c) :
      f = h · inv_from_iso g -> f · g = h.
 Proof.
@@ -189,7 +189,7 @@ Lemma is_iso_comp_of_isos {C : precategory} {a b c : ob C}
 Proof.
   simpl.
   intro d.
-  set (T:=twooutof3c (precomp_with g) (precomp_with f (c:=d)) (pr2 g d) (pr2 f _)).
+  set (T := twooutof3c (precomp_with g) (precomp_with f (c:=d)) (pr2 g d) (pr2 f _)).
   apply (isweqhomot' _ _ T).
   intro h. apply assoc.
 Defined.
@@ -217,7 +217,7 @@ Proof.
   apply eq_iso. simpl.
   set (T := invmaponpathsweq (make_weq (precomp_with f) (pr2 f a ))).
   apply T; simpl.
-  intermediate_path (identity a ).
+  intermediate_path (identity a).
   + assumption.
   + apply pathsinv0. apply iso_inv_after_iso.
 Defined.
@@ -228,7 +228,7 @@ Proof.
   intro H.
   set (T := invmaponpathsweq (make_weq (precomp_with f) (pr2 f a ))).
   apply T; simpl.
-  intermediate_path (identity a ).
+  intermediate_path (identity a).
   + assumption.
   + apply pathsinv0. apply iso_inv_after_iso.
 Defined.
@@ -246,7 +246,7 @@ Proof.
     apply iso_inv_after_iso.
 Qed.
 
-Lemma iso_inv_of_iso_id (C : precategory) (a : ob C) :
+Lemma iso_inv_of_iso_id {C : precategory} (a : ob C) :
    iso_inv_from_iso (identity_iso a) = identity_iso a.
 Proof.
   apply eq_iso.
@@ -254,7 +254,7 @@ Proof.
 Qed.
 
 
-Lemma iso_inv_iso_inv (C : precategory) (a b : ob C) (f : iso a b) :
+Lemma iso_inv_iso_inv {C : precategory} (a b : ob C) (f : iso a b) :
      iso_inv_from_iso (iso_inv_from_iso f) = f.
 Proof.
   apply eq_iso. simpl.
@@ -263,7 +263,7 @@ Proof.
   apply iso_after_iso_inv.
 Defined.
 
-Lemma pre_comp_with_iso_is_inj (C : precategory_data) (a b c : ob C)
+Lemma pre_comp_with_iso_is_inj {C : precategory_data} (a b c : ob C)
     (f : a --> b) (H : is_iso f) (g h : b --> c) : f · g = f · h -> g = h.
 Proof.
   intro X.
@@ -271,7 +271,7 @@ Proof.
   apply X.
 Qed.
 
-Lemma post_comp_with_iso_is_inj (C : precategory) (b c : ob C)
+Lemma post_comp_with_iso_is_inj {C : precategory} (b c : ob C)
      (h : b --> c) (H : is_iso h)
    (a : ob C) (f g : a --> b) : f · h = g · h -> f = g.
 Proof.
@@ -313,7 +313,7 @@ Definition is_iso' {C : precategory} {b c : C} (f : b --> c) :=
 
 Definition is_inverse_in_precat {C : precategory_data} {a b : C}
   (f : a --> b) (g : b --> a) :=
-  dirprod (f · g = identity a)
+          (f · g = identity a) ×
           (g · f = identity b).
 
 Definition make_is_inverse_in_precat {C : precategory_data} {a b : C} {f : a --> b} {g : b --> a}
@@ -376,7 +376,7 @@ Definition iso_conjug_weq {C : precategory} {a b : C} (h : iso a b) :
 
 Section are_isomorphic.
 
-  Context (C : precategory).
+  Context {C : precategory}.
 
   (** a and b are related if there merely exists an iso between them *)
   Definition are_isomorphic : hrel C := λ a b, ∥iso a b∥.
@@ -402,13 +402,13 @@ End are_isomorphic.
     isomorphism, called [z_iso] in the following.
 *)
 
-Lemma isaprop_is_inverse_in_precat (C : precategory_data) (hs: has_homsets C) (a b : ob C)
+Lemma isaprop_is_inverse_in_precat {C : category} (a b : ob C)
    (f : a --> b) (g : b --> a) : isaprop (is_inverse_in_precat f g).
 Proof.
-  apply isapropdirprod; apply hs.
+  apply isapropdirprod; apply homset_property.
 Qed.
 
-Lemma inverse_unique_precat (C : precategory) (a b : ob C)
+Lemma inverse_unique_precat {C : precategory} (a b : ob C)
    (f : a --> b) (g g': b --> a) (H : is_inverse_in_precat f g)
     (H' : is_inverse_in_precat f g') : g = g'.
 Proof.
@@ -461,17 +461,17 @@ Proof.
   - exact (is_inverse_in_precat_identity c).
 Defined.
 
-Lemma isaprop_is_z_isomorphism {C : precategory} {a b : ob C} (hs: has_homsets C)
+Lemma isaprop_is_z_isomorphism {C : category} {a b : ob C}
      (f : a --> b) : isaprop (is_z_isomorphism f).
 Proof.
   apply invproofirrelevance.
   intros g g'.
-  set (Hpr1 := inverse_unique_precat _ _ _ _ _ _ (pr2 g) (pr2 g')).
+  set (Hpr1 := inverse_unique_precat _ _ _ _ _ (pr2 g) (pr2 g')).
   apply (total2_paths_f Hpr1).
   destruct g as [g [eta eps]].
   destruct g' as [g' [eta' eps']].
   simpl in *.
-  apply isapropdirprod; apply hs.
+  apply isapropdirprod; apply homset_property.
 Qed.
 
 Lemma is_z_isomorphism_mor_eq {C : precategory} {a b : C} {f g : a --> b}
@@ -587,7 +587,7 @@ Lemma z_iso_eq {C : category} {a b : C} (i i' : z_iso a b) (e : z_iso_mor i = z_
 Proof.
   use total2_paths_f.
   - exact e.
-  - use proofirrelevance. apply isaprop_is_z_isomorphism. apply homset_property.
+  - use proofirrelevance. apply isaprop_is_z_isomorphism.
 Qed.
 
 Lemma z_iso_eq_inv {C : category} {a b : C} (i i' : z_iso a b)
@@ -600,30 +600,30 @@ Proof.
     - rewrite e2. exact (is_inverse_in_precat2 i').
     - rewrite e2. exact (is_inverse_in_precat1 i').
   }
-  exact (inverse_unique_precat _ _ _ _ _ _ (z_iso_inv i) H).
+  exact (inverse_unique_precat _ _ _ _ _ (z_iso_inv i) H).
 Qed.
 
-Lemma eq_z_iso {C : precategory} (hs : has_homsets C) (a b : ob C)
+Lemma eq_z_iso {C : category} (a b : ob C)
    (f g : z_iso a b) : pr1 f = pr1 g -> f = g.
 Proof.
   intro H.
   apply (total2_paths_f H).
   apply proofirrelevance.
-  apply isaprop_is_z_isomorphism, hs.
+  apply isaprop_is_z_isomorphism.
 Defined.
 
 Definition morphism_from_z_iso {C : precategory_data} (a b : ob C)
    (f : z_iso a b) : a --> b := pr1 f.
 Coercion morphism_from_z_iso : z_iso >-> precategory_morphisms.
 
-Lemma isaset_z_iso {C : precategory} (hs : has_homsets C) (a b : ob C) : isaset (z_iso a b).
+Lemma isaset_z_iso {C : category} (a b : ob C) : isaset (z_iso a b).
 Proof.
   change isaset with (isofhlevel 2).
   apply isofhleveltotal2.
-  - apply hs.
+  - apply homset_property.
   - intro f.
     apply isasetaprop.
-    apply isaprop_is_z_isomorphism, hs.
+    apply isaprop_is_z_isomorphism.
 Qed.
 
 Lemma identity_is_z_iso {C : precategory} (a : ob C) :
@@ -669,7 +669,7 @@ Definition z_iso_after_z_iso_inv {C : precategory_data} (a b : ob C)
       pr2 (pr2 (pr2 f)).
 
 
-Lemma z_iso_inv_on_right (C : precategory) (a b c : ob C)
+Lemma z_iso_inv_on_right {C : precategory} (a b c : ob C)
   (f : z_iso a  b) (g : b --> c) (h : a --> c) (H : h = f · g) :
      inv_from_z_iso f · h = g.
 Proof.
@@ -682,7 +682,7 @@ Proof.
   apply id_left.
 Qed.
 
-Lemma z_iso_inv_on_left (C : precategory) (a b c : ob C)
+Lemma z_iso_inv_on_left {C : precategory} (a b c : ob C)
   (f : a --> b) (g : z_iso b c) (h : a --> c) (H : h = f · g) :
      f = h · inv_from_z_iso g.
 Proof.
@@ -696,7 +696,7 @@ Proof.
   assumption.
 Qed.
 
-Lemma z_iso_inv_to_left (C : precategory) (a b c : ob C)
+Lemma z_iso_inv_to_left {C : precategory} (a b c : ob C)
   (f : z_iso a  b) (g : b --> c) (h : a --> c) :
     inv_from_z_iso f · h = g -> h = f · g.
 Proof.
@@ -706,7 +706,7 @@ Proof.
   - rewrite <- assoc. apply maponpaths. assumption.
 Qed.
 
-Lemma z_iso_inv_to_right (C : precategory) (a b c : ob C)
+Lemma z_iso_inv_to_right {C : precategory} (a b c : ob C)
   (f : a --> b) (g : z_iso b c) (h : a --> c) :
      f = h · inv_from_z_iso g -> f · g = h.
 Proof.
@@ -760,45 +760,41 @@ Proof.
   - apply (pr2 g).
 Qed.
 
-Lemma inv_z_iso_unique {C : precategory} (hs : has_homsets C) (a b : ob C)
+Lemma inv_z_iso_unique {C : category} (a b : ob C)
   (f : z_iso a b) (g : z_iso b a) :
   is_inverse_in_precat f g -> g = z_iso_inv_from_z_iso f.
 Proof.
   intro H.
   apply eq_z_iso.
-  - apply hs.
-  - apply (inverse_unique_precat _ _ _ f).
-    + assumption.
-    + split.
-      * apply z_iso_inv_after_z_iso.
-      * set (h := z_iso_after_z_iso_inv _ _ f).
+  apply (inverse_unique_precat _ _ f).
+    - assumption.
+    - split.
+      + apply z_iso_inv_after_z_iso.
+      + set (h := z_iso_after_z_iso_inv _ _ f).
         apply h.
 Qed.
 
-Lemma z_iso_inv_of_z_iso_comp {C : precategory} (hs : has_homsets C) (a b c : ob C)
+Lemma z_iso_inv_of_z_iso_comp {C : category} (a b c : ob C)
    (f : z_iso a b) (g : z_iso b c) :
    z_iso_inv_from_z_iso (z_iso_comp f g) =
        z_iso_comp (z_iso_inv_from_z_iso g) (z_iso_inv_from_z_iso f).
 Proof.
   apply eq_z_iso.
-  - apply hs.
-  - reflexivity.
+  apply idpath.
 Defined.
 
-Lemma z_iso_inv_of_z_iso_id {C : precategory} (hs : has_homsets C) (a : ob C) :
+Lemma z_iso_inv_of_z_iso_id {C : category} (a : ob C) :
    z_iso_inv_from_z_iso (identity_z_iso a) = identity_z_iso a.
 Proof.
   apply eq_z_iso.
-  - apply hs.
-  - apply idpath.
+  apply idpath.
 Qed.
 
-Lemma z_iso_inv_z_iso_inv {C : precategory} (hs : has_homsets C) (a b : ob C) (f : z_iso a b) :
+Lemma z_iso_inv_z_iso_inv {C : category} (a b : ob C) (f : z_iso a b) :
      z_iso_inv_from_z_iso (z_iso_inv_from_z_iso f) = f.
 Proof.
   apply eq_z_iso.
-  - apply hs.
-  - reflexivity.
+  apply idpath.
 Defined.
 
 Lemma z_iso_comp_right_isweq {C : precategory} {a b : ob C} (h : z_iso a b) (c : C) :
@@ -823,6 +819,7 @@ Proof.
        { intros g. use (_ @ maponpaths (λ m, g · m) (pr2 (pr2 (pr2 h))) @ _).
          { apply pathsinv0, assoc. } { apply id_right. } }
 Defined.
+
 Definition z_iso_comp_left_weq {C : precategory} {a b : C} (h : z_iso a b) (c : C) :
  (c --> a) ≃ (c --> b) := make_weq _ (z_iso_comp_left_isweq h c).
 
@@ -845,12 +842,12 @@ Lemma is_z_iso_from_is_iso {C : precategory} {a b : C} (f : a --> b):
      is_iso f -> is_z_isomorphism f.
 Proof.
   intro H.
-  set (fiso:= make_iso f H).
+  set (fiso := make_iso f H).
   exists (inv_from_iso fiso).
   split.
-  - set (H2:= iso_inv_after_iso fiso).
+  - set (H2 := iso_inv_after_iso fiso).
     simpl in H2. apply H2.
-  - set (H2:=iso_after_iso_inv fiso).
+  - set (H2 := iso_after_iso_inv fiso).
     simpl in H2. apply H2.
 Defined.
 

--- a/UniMath/CategoryTheory/Core/Isos.v
+++ b/UniMath/CategoryTheory/Core/Isos.v
@@ -28,28 +28,27 @@ Local Open Scope cat.
     Definition suggested by V. Voevodsky
 *)
 
-Definition precomp_with {C : precategory_data} {a b : C} (f : a --> b) {c} (g : b --> c): a --> c :=
+Definition precomp_with {C : precategory_data} {a b : C} (f : a --> b) {c : C} (g : b --> c): a --> c :=
    f · g.
 
 Definition is_iso {C : precategory_data} {a b : C} (f : a --> b) :=
   ∏ c, isweq (precomp_with f (c:=c)).
 
-Lemma isaprop_is_iso {C : precategory_data}(a b : C) (f : a --> b) : isaprop (is_iso f).
+Lemma isaprop_is_iso {C : precategory_data} (a b : C) (f : a --> b) : isaprop (is_iso f).
 Proof.
   apply impred; intro.
   apply isapropisweq.
 Qed.
 
-Definition iso {C: precategory_data}(a b : C) := total2 (fun f : a --> b => is_iso f).
-Definition morphism_from_iso {C:precategory_data} {a b : C} (f : iso a b) : a --> b := pr1 f.
+Definition iso {C: precategory_data} (a b : C) := ∑ f : a --> b, is_iso f.
+Definition morphism_from_iso {C : precategory_data} {a b : C} (f : iso a b) : a --> b := pr1 f.
 Coercion morphism_from_iso : iso >-> precategory_morphisms.
 
-Definition iso_is_iso {C: precategory_data} {a b : C} (f : iso a b) : is_iso f := pr2 f.
+Definition iso_is_iso {C : precategory_data} {a b : C} (f : iso a b) : is_iso f := pr2 f.
 
-Definition make_iso {C: precategory_data}{a b : C} (f : a --> b) (fiso: is_iso f) : iso a b :=
-   tpair _ f fiso.
+Definition make_iso {C : precategory_data} {a b : C} (f : a --> b) (fiso: is_iso f) : iso a b := (f,,fiso).
 
-Definition inv_from_iso {C:precategory_data}{a b : C} (f : iso a b) : b --> a :=
+Definition inv_from_iso {C : precategory_data} {a b : C} (f : iso a b) : b --> a :=
    invmap (make_weq (precomp_with f) (pr2 f a)) (identity _ ).
 
 Definition iso_inv_after_iso {C : precategory_data} {a b : C} (f: iso a b) :
@@ -73,7 +72,7 @@ Proof.
     + apply (!(id_right _ )).
 Defined.
 
-Definition is_iso_inv_from_iso {C:precategory}{a b : C} (f : iso a b) : is_iso (inv_from_iso f).
+Definition is_iso_inv_from_iso {C : precategory} {a b : C} (f : iso a b) : is_iso (inv_from_iso f).
 Proof.
   intro c.
   apply (isweq_iso _ (precomp_with f)).
@@ -89,7 +88,7 @@ Proof.
     + apply remove_id_left. apply iso_after_iso_inv. apply idpath.
 Defined.
 
-Definition iso_inv_from_iso {C:precategory}{a b : C} (f : iso a b) : iso b a :=
+Definition iso_inv_from_iso {C : precategory} {a b : C} (f : iso a b) : iso b a :=
   tpair _ _ (is_iso_inv_from_iso f).
 
 Lemma eq_iso {C: precategory_data} {a b : C} (f g : iso a b) : pr1 f = pr1 g -> f = g.
@@ -100,7 +99,7 @@ Proof.
   - apply H.
 Defined.
 
-Lemma isaset_iso {C : precategory_data} (hs: has_homsets C) (a b :ob C) :
+Lemma isaset_iso {C : precategory_data} (hs : has_homsets C) (a b : ob C) :
   isaset (iso a b).
 Proof.
   change isaset with (isofhlevel 2).
@@ -114,7 +113,7 @@ Qed.
 Lemma identity_is_iso (C : precategory) (a : ob C) : is_iso (identity a).
 Proof.
   intros c.
-  set (T:=@isweqhomot (a --> c) (a --> c) (λ t, t) (precomp_with (identity a))).
+  set (T := @isweqhomot (a --> c) (a --> c) (λ t, t) (precomp_with (identity a))).
   apply T.
   - intro g. apply pathsinv0. apply id_left.
   - apply idisweq.
@@ -126,27 +125,27 @@ Definition identity_iso {C : precategory} (a : ob C) :
 
 Definition iso_inv_from_is_iso {C : precategory} {a b : ob C}
   (f : a --> b) (H : is_iso f) : iso b a :=
-  iso_inv_from_iso (tpair _ f H).
+  iso_inv_from_iso (f,,H).
 
-Lemma iso_inv_on_right (C : precategory) (a b c: ob C)
-  (f : iso a  b) (g : b --> c) (h : a --> c) (H : h = f·g) :
+Lemma iso_inv_on_right (C : precategory) (a b c : ob C)
+  (f : iso a  b) (g : b --> c) (h : a --> c) (H : h = f · g) :
      inv_from_iso f · h = g.
 Proof.
   apply (invmaponpathsweq (make_weq (precomp_with f) (pr2 f c))).
   unfold precomp_with; simpl.
-  intermediate_path ((f·inv_from_iso f)·h).
+  intermediate_path ((f · inv_from_iso f) · h).
   - apply assoc.
   - apply remove_id_left.
     + apply iso_inv_after_iso.
     + assumption.
 Defined.
 
-Lemma iso_inv_on_left (C : precategory) (a b c: ob C)
-  (f : a --> b) (g : iso b c) (h : a --> c) (H : h = f·g) :
+Lemma iso_inv_on_left (C : precategory) (a b c : ob C)
+  (f : a --> b) (g : iso b c) (h : a --> c) (H : h = f · g) :
      f = h · inv_from_iso g.
 Proof.
   assert (H2 : h · inv_from_iso g =
-                         (f· g) · inv_from_iso g).
+                         (f · g) · inv_from_iso g).
     rewrite H. apply idpath.
   rewrite <- assoc in H2.
   rewrite iso_inv_after_iso in H2.
@@ -155,22 +154,22 @@ Proof.
   assumption.
 Qed.
 
-Lemma iso_inv_to_left (C : precategory) (a b c: ob C)
+Lemma iso_inv_to_left (C : precategory) (a b c : ob C)
   (f : iso a  b) (g : b --> c) (h : a --> c) :
     inv_from_iso f · h = g -> h = f · g.
 Proof.
   intro H.
-  transitivity (f· inv_from_iso f· h).
+  intermediate_path (f · inv_from_iso f · h).
   - rewrite iso_inv_after_iso, id_left; apply idpath.
   - rewrite <- assoc. rewrite H. apply idpath.
 Qed.
 
-Lemma iso_inv_to_right (C : precategory) (a b c: ob C)
+Lemma iso_inv_to_right (C : precategory) (a b c : ob C)
   (f : a --> b) (g : iso b c) (h : a --> c) :
      f = h · inv_from_iso g -> f · g = h.
 Proof.
   intro H.
-  transitivity (h· inv_from_iso g· g).
+  intermediate_path (h · inv_from_iso g · g).
   - rewrite H. apply idpath.
   - rewrite <- assoc, iso_after_iso_inv, id_right. apply idpath.
 Qed.
@@ -190,7 +189,7 @@ Lemma is_iso_comp_of_isos {C : precategory} {a b c : ob C}
 Proof.
   simpl.
   intro d.
-  set (T:=twooutof3c (precomp_with g) (precomp_with f(c:=d)) (pr2 g d) (pr2 f _)).
+  set (T:=twooutof3c (precomp_with g) (precomp_with f (c:=d)) (pr2 g d) (pr2 f _)).
   apply (isweqhomot' _ _ T).
   intro h. apply assoc.
 Defined.
@@ -216,7 +215,7 @@ Lemma inv_iso_unique (C : precategory) (a b : C) (f : iso a b) (g : iso b a) :
 Proof.
   intro H.
   apply eq_iso. simpl.
-  set (T:=invmaponpathsweq (make_weq (precomp_with f) (pr2 f a ))).
+  set (T := invmaponpathsweq (make_weq (precomp_with f) (pr2 f a ))).
   apply T; simpl.
   intermediate_path (identity a ).
   + assumption.
@@ -227,7 +226,7 @@ Lemma inv_iso_unique' (C : precategory) (a b : C) (f : iso a b) (g : b --> a) :
   precomp_with f g = identity _ -> g = inv_from_iso f.
 Proof.
   intro H.
-  set (T:=invmaponpathsweq (make_weq (precomp_with f) (pr2 f a ))).
+  set (T := invmaponpathsweq (make_weq (precomp_with f) (pr2 f a ))).
   apply T; simpl.
   intermediate_path (identity a ).
   + assumption.
@@ -241,7 +240,7 @@ Lemma iso_inv_of_iso_comp (C : precategory) (a b c : ob C)
 Proof.
   apply pathsinv0.
   apply inv_iso_unique. simpl. unfold precomp_with.
-  intermediate_path (f · (g·inv_from_iso g) · inv_from_iso f).
+  intermediate_path (f · (g · inv_from_iso g) · inv_from_iso f).
   - repeat rewrite assoc.  apply idpath.
   - rewrite iso_inv_after_iso. rewrite id_right.
     apply iso_inv_after_iso.
@@ -277,8 +276,8 @@ Lemma post_comp_with_iso_is_inj (C : precategory) (b c : ob C)
    (a : ob C) (f g : a --> b) : f · h = g · h -> f = g.
 Proof.
   intro HH.
-  set (T:=iso_inv_after_iso (tpair _ h H)). simpl in T.
-  intermediate_path (f · (h · inv_from_iso (tpair _ h H))).
+  set (T := iso_inv_after_iso (h,,H)). simpl in T.
+  intermediate_path (f · (h · inv_from_iso (h,,H))).
   - rewrite T. clear T.
     apply pathsinv0, id_right.
   - rewrite assoc. rewrite HH.
@@ -287,16 +286,16 @@ Proof.
 Qed.
 
 
-Lemma iso_comp_right_isweq {C:precategory_data} {a b:ob C} (h:iso a b) (c:C) :
+Lemma iso_comp_right_isweq {C : precategory_data} {a b : ob C} (h : iso a b) (c : C) :
   isweq (fun f : b --> c => h · f).
 Proof.
   apply (pr2 h _ ).
 Defined.
 
-Definition iso_comp_right_weq {C:precategory_data} {a b:C} (h:iso a b) (c:C) :
+Definition iso_comp_right_weq {C : precategory_data} {a b : C} (h : iso a b) (c : C) :
  (b --> c) ≃ (a --> c) := make_weq _ (iso_comp_right_isweq h c).
 
-Lemma iso_comp_left_isweq {C:precategory} {a b:ob C} (h:iso a b) (c:C) :
+Lemma iso_comp_left_isweq {C : precategory} {a b : ob C} (h : iso a b) (c : C) :
   isweq (fun f : c --> a => f · h).
 Proof.
   intros. apply (isweq_iso _ (λ g, g · inv_from_iso h)).
@@ -306,7 +305,7 @@ Proof.
     apply iso_after_iso_inv. apply idpath.
 Defined.
 
-Definition postcomp_with {C : precategory_data}{b c : C}(h : b --> c) {a : C}
+Definition postcomp_with {C : precategory_data} {b c : C} (h : b --> c) {a : C}
   (f : a --> b) : a --> c := f · h.
 
 Definition is_iso' {C : precategory} {b c : C} (f : b --> c) :=
@@ -366,10 +365,10 @@ Proof.
     apply (pr1 H). apply idpath.
 Defined.
 
-Definition iso_comp_left_weq {C:precategory} {a b:C} (h:iso a b) (c:C) :
+Definition iso_comp_left_weq {C : precategory} {a b : C} (h : iso a b) (c : C) :
  (c --> a) ≃ (c --> b) := make_weq _ (iso_comp_left_isweq h c).
 
-Definition iso_conjug_weq {C:precategory} {a b:C} (h:iso a b) :
+Definition iso_conjug_weq {C : precategory} {a b : C} (h : iso a b) :
  (a --> a) ≃ (b --> b) := weqcomp (iso_comp_left_weq h _ ) (iso_comp_right_weq (iso_inv_from_iso h) _ ).
 
 
@@ -425,7 +424,7 @@ Proof.
 Qed.
 
 Definition is_z_isomorphism {C : precategory_data} {a b : ob C}
-           (f : a --> b) := total2 (λ g, is_inverse_in_precat f g).
+           (f : a --> b) := ∑ g, is_inverse_in_precat f g.
 
 Definition make_is_z_isomorphism {C : precategory_data} {a b : C} (f : a --> b)
            (g : b --> a) (H : is_inverse_in_precat f g) : is_z_isomorphism f := (g,,H).
@@ -485,8 +484,7 @@ Proof.
   - rewrite e. exact I2.
 Qed.
 
-Definition z_iso {C : precategory_data} (a b :ob C) := total2
-    (fun f : a --> b => is_z_isomorphism f).
+Definition z_iso {C : precategory_data} (a b : ob C) := ∑ f : a --> b, is_z_isomorphism f.
 
 Definition make_z_iso {C : precategory_data} {a b : C} (f : a --> b) (g : b --> a)
            (H : is_inverse_in_precat f g) : z_iso a b := (f,,make_is_z_isomorphism f g H).
@@ -518,6 +516,7 @@ Proof.
   - exact (is_inverse_in_precat_comp I1 I2).
 Defined.
 
+(* see below [identity_z_iso]
 Definition z_iso_identity {C : precategory} (c : C) : z_iso c c.
 Proof.
   use make_z_iso.
@@ -525,6 +524,7 @@ Proof.
   - exact (identity c).
   - exact (is_inverse_in_precat_identity c).
 Defined.
+*)
 
 Definition z_iso_is_z_isomorphism1 {C : precategory} {a b : C} (I : z_iso a b) :
   is_z_isomorphism I.
@@ -547,8 +547,8 @@ Lemma post_comp_with_z_iso_is_inj {C : precategory} {a' a b : C} {f : a --> b} {
 Proof.
   intros f' g' H.
   apply (maponpaths (postcompose g)) in H. unfold postcompose in H.
-  rewrite <- assoc in H. rewrite <- assoc in H.
-  rewrite (is_inverse_in_precat1 i) in H. rewrite id_right in H. rewrite id_right in H.
+  do 2 rewrite <- assoc in H.
+  rewrite (is_inverse_in_precat1 i) in H. do 2 rewrite id_right in H.
   exact H.
 Qed.
 
@@ -557,8 +557,8 @@ Lemma post_comp_with_z_iso_inv_is_inj {C : precategory} {a b b' : C} {f : a --> 
 Proof.
   intros f' g' H.
   apply (maponpaths (postcompose f)) in H. unfold postcompose in H.
-  rewrite <- assoc in H. rewrite <- assoc in H.
-  rewrite (is_inverse_in_precat2 i) in H. rewrite id_right in H. rewrite id_right in H.
+  do 2 rewrite <- assoc in H.
+  rewrite (is_inverse_in_precat2 i) in H. do 2 rewrite id_right in H.
   exact H.
 Qed.
 
@@ -567,8 +567,8 @@ Lemma pre_comp_with_z_iso_is_inj {C : precategory} {a b b' : C} {f : a --> b} {g
 Proof.
   intros f' g' H.
   apply (maponpaths (compose g)) in H.
-  rewrite assoc in H. rewrite assoc in H.
-  rewrite (is_inverse_in_precat2 i) in H. rewrite id_left in H. rewrite id_left in H.
+  do 2 rewrite assoc in H.
+  rewrite (is_inverse_in_precat2 i) in H. do 2 rewrite id_left in H.
   exact H.
 Qed.
 
@@ -577,8 +577,8 @@ Lemma pre_comp_with_z_iso_inv_is_inj {C : precategory} {a' a b : C} {f : a --> b
 Proof.
   intros f' g' H.
   apply (maponpaths (compose f)) in H.
-  rewrite assoc in H. rewrite assoc in H.
-  rewrite (is_inverse_in_precat1 i) in H. rewrite id_left in H. rewrite id_left in H.
+  do 2 rewrite assoc in H.
+  rewrite (is_inverse_in_precat1 i) in H. do 2 rewrite id_left in H.
   exact H.
 Qed.
 
@@ -603,7 +603,7 @@ Proof.
   exact (inverse_unique_precat _ _ _ _ _ _ (z_iso_inv i) H).
 Qed.
 
-Lemma eq_z_iso (C : precategory)(hs: has_homsets C) (a b : ob C)
+Lemma eq_z_iso {C : precategory} (hs : has_homsets C) (a b : ob C)
    (f g : z_iso a b) : pr1 f = pr1 g -> f = g.
 Proof.
   intro H.
@@ -612,21 +612,21 @@ Proof.
   apply isaprop_is_z_isomorphism, hs.
 Defined.
 
-Definition morphism_from_z_iso (C : precategory_data)(a b : ob C)
+Definition morphism_from_z_iso {C : precategory_data} (a b : ob C)
    (f : z_iso a b) : a --> b := pr1 f.
 Coercion morphism_from_z_iso : z_iso >-> precategory_morphisms.
 
-Lemma isaset_z_iso {C : precategory} (hs: has_homsets C) (a b :ob C) : isaset (z_iso a b).
+Lemma isaset_z_iso {C : precategory} (hs : has_homsets C) (a b : ob C) : isaset (z_iso a b).
 Proof.
   change isaset with (isofhlevel 2).
   apply isofhleveltotal2.
-  apply hs.
-  intro f.
-  apply isasetaprop.
-  apply isaprop_is_z_isomorphism, hs.
+  - apply hs.
+  - intro f.
+    apply isasetaprop.
+    apply isaprop_is_z_isomorphism, hs.
 Qed.
 
-Lemma identity_is_z_iso (C : precategory) (a : ob C) :
+Lemma identity_is_z_iso {C : precategory} (a : ob C) :
     is_z_isomorphism (identity a).
 Proof.
   exists (identity a).
@@ -635,7 +635,7 @@ Proof.
 Defined.
 
 Definition identity_z_iso {C : precategory} (a : ob C) :
-   z_iso a a := tpair _ _ (identity_is_z_iso C a).
+   z_iso a a := tpair _ _ (identity_is_z_iso a).
 
 Definition inv_from_z_iso {C : precategory_data} {a b : ob C}
   (f : z_iso a b) : b --> a := pr1 (pr2 f).
@@ -658,36 +658,36 @@ Defined.
 
 Definition z_iso_inv_from_is_z_iso {C : precategory_data} {a b : ob C}
   (f : a --> b) (H : is_z_isomorphism f) : z_iso b a :=
-  z_iso_inv_from_z_iso (tpair _ f H).
+  z_iso_inv_from_z_iso (f,,H).
 
-Definition z_iso_inv_after_z_iso (C : precategory_data) (a b : ob C)
-   (f : z_iso a b) : f· inv_from_z_iso f = identity _ :=
+Definition z_iso_inv_after_z_iso {C : precategory_data} (a b : ob C)
+   (f : z_iso a b) : f · inv_from_z_iso f = identity _ :=
       pr1 (pr2 (pr2 f)).
 
-Definition z_iso_after_z_iso_inv (C : precategory_data) (a b : ob C)
+Definition z_iso_after_z_iso_inv {C : precategory_data} (a b : ob C)
    (f : z_iso a b) : inv_from_z_iso f · f = identity _ :=
       pr2 (pr2 (pr2 f)).
 
 
-Lemma z_iso_inv_on_right (C : precategory) (a b c: ob C)
-  (f : z_iso a  b) (g : b --> c) (h : a --> c) (H : h = f·g) :
+Lemma z_iso_inv_on_right (C : precategory) (a b c : ob C)
+  (f : z_iso a  b) (g : b --> c) (h : a --> c) (H : h = f · g) :
      inv_from_z_iso f · h = g.
 Proof.
-  assert (H2 : inv_from_z_iso f· h =
-                  inv_from_z_iso f· (f · g)).
-  apply maponpaths; assumption.
+  assert (H2 : inv_from_z_iso f · h =
+                  inv_from_z_iso f · (f · g)).
+    apply maponpaths; assumption.
   rewrite assoc in H2.
   rewrite H2.
   rewrite z_iso_after_z_iso_inv.
   apply id_left.
 Qed.
 
-Lemma z_iso_inv_on_left (C : precategory) (a b c: ob C)
-  (f : a --> b) (g : z_iso b c) (h : a --> c) (H : h = f·g) :
+Lemma z_iso_inv_on_left (C : precategory) (a b c : ob C)
+  (f : a --> b) (g : z_iso b c) (h : a --> c) (H : h = f · g) :
      f = h · inv_from_z_iso g.
 Proof.
   assert (H2 : h · inv_from_z_iso g =
-                         (f· g) · inv_from_z_iso g).
+                         (f · g) · inv_from_z_iso g).
     rewrite H. apply idpath.
   rewrite <- assoc in H2.
   rewrite z_iso_inv_after_z_iso in H2.
@@ -696,54 +696,54 @@ Proof.
   assumption.
 Qed.
 
-Lemma z_iso_inv_to_left (C : precategory) (a b c: ob C)
+Lemma z_iso_inv_to_left (C : precategory) (a b c : ob C)
   (f : z_iso a  b) (g : b --> c) (h : a --> c) :
     inv_from_z_iso f · h = g -> h = f · g.
 Proof.
   intro H.
-  transitivity (f· inv_from_z_iso f· h).
+  intermediate_path (f · inv_from_z_iso f · h).
   - rewrite z_iso_inv_after_z_iso, id_left; apply idpath.
-  - rewrite <- assoc. rewrite H. apply idpath.
+  - rewrite <- assoc. apply maponpaths. assumption.
 Qed.
 
-Lemma z_iso_inv_to_right (C : precategory) (a b c: ob C)
+Lemma z_iso_inv_to_right (C : precategory) (a b c : ob C)
   (f : a --> b) (g : z_iso b c) (h : a --> c) :
      f = h · inv_from_z_iso g -> f · g = h.
 Proof.
   intro H.
-  transitivity (h· inv_from_z_iso g· g).
+  intermediate_path (h · inv_from_z_iso g · g).
   - rewrite H. apply idpath.
   - rewrite <- assoc, z_iso_after_z_iso_inv, id_right. apply idpath.
 Qed.
 
-Lemma wrap_inverse {M:precategory} {x y : M} (g : x --> x) (f : z_iso x y) :
+Lemma wrap_inverse {M : precategory} {x y : M} (g : x --> x) (f : z_iso x y) :
   g = identity x -> z_iso_inv f · g · f = identity y.
 Proof.
   intros e. rewrite e. rewrite id_right. apply z_iso_after_z_iso_inv.
 Defined.
 
-Lemma wrap_inverse' {M:precategory} {x y : M} (g : x --> x) (f : z_iso y x) :
+Lemma wrap_inverse' {M : precategory} {x y : M} (g : x --> x) (f : z_iso y x) :
   g = identity x -> f · g · z_iso_inv f = identity y.
 Proof.
   intros e. rewrite e. rewrite id_right. apply z_iso_inv_after_z_iso.
 Defined.
 
-Lemma cancel_z_iso {M:precategory} {x y z : M} (f f' : x --> y) (g : z_iso y z) :
+Lemma cancel_z_iso {M : precategory} {x y z : M} (f f' : x --> y) (g : z_iso y z) :
   f · g = f' · g -> f = f'.
 Proof.
-  intros e.
-  refine (_ @ maponpaths (λ k, k · z_iso_inv g) e @ _).
-  - rewrite assoc'. rewrite z_iso_inv_after_z_iso. rewrite id_right. reflexivity.
-  - rewrite assoc'. rewrite z_iso_inv_after_z_iso. rewrite id_right. reflexivity.
+  intro e.
+  destruct g as [g [g' H]].
+  apply (post_comp_with_z_iso_is_inj H).
+  assumption.
 Qed.
 
-Lemma cancel_z_iso' {M:precategory} {w x y : M} (g : z_iso w x) (f f' : x --> y) :
+Lemma cancel_z_iso' {M : precategory} {w x y : M} (g : z_iso w x) (f f' : x --> y) :
   g · f = g · f' -> f = f'.
 Proof.
-  intros e.
-  refine (_ @ maponpaths (λ k, z_iso_inv g · k) e @ _).
-  - rewrite assoc. rewrite z_iso_inv_after_z_iso. rewrite id_left. reflexivity.
-  - rewrite assoc. rewrite z_iso_inv_after_z_iso. rewrite id_left. reflexivity.
+  intro e.
+  destruct g as [g [g' H]].
+  apply (pre_comp_with_z_iso_is_inj H).
+  assumption.
 Qed.
 
 
@@ -751,73 +751,57 @@ Qed.
 
 (** Stability under composition, inverses etc *)
 
-Lemma are_inverse_comp_of_inverses (C : precategory) (a b c : C)
+Lemma are_inverse_comp_of_inverses {C : precategory} (a b c : C)
      (f : z_iso a b) (g : z_iso b c) :
-  is_inverse_in_precat (f· g) (inv_from_z_iso g· inv_from_z_iso f).
+  is_inverse_in_precat (f · g) (inv_from_z_iso g · inv_from_z_iso f).
 Proof.
-  simpl; split; simpl;
-  unfold inv_from_iso; simpl.
-  destruct f as [f [f' Hf]]. simpl in *.
-  destruct g as [g [g' Hg]]; simpl in *.
-  intermediate_path ((f · (g · g')) · f').
-  repeat rewrite assoc; apply idpath.
-  rewrite (pr1 Hg).
-  rewrite id_right.
-  rewrite (pr1 Hf).
-  apply idpath.
-
-  destruct f as [f [f' Hf]]. simpl in *.
-  destruct g as [g [g' Hg]]; simpl in *.
-  intermediate_path ((g' · (f' · f)) · g).
-  repeat rewrite assoc; apply idpath.
-  rewrite (pr2 Hf).
-  rewrite id_right.
-  rewrite (pr2 Hg).
-  apply idpath.
+  apply is_inverse_in_precat_comp.
+  - apply (pr2 f).
+  - apply (pr2 g).
 Qed.
 
-Lemma inv_z_iso_unique (C : precategory) (hs: has_homsets C) (a b : ob C)
+Lemma inv_z_iso_unique {C : precategory} (hs : has_homsets C) (a b : ob C)
   (f : z_iso a b) (g : z_iso b a) :
   is_inverse_in_precat f g -> g = z_iso_inv_from_z_iso f.
 Proof.
   intro H.
   apply eq_z_iso.
-  apply hs.
-  apply (inverse_unique_precat _ _ _ f).
-  assumption.
-  split.
-  apply z_iso_inv_after_z_iso.
-  set (h := z_iso_after_z_iso_inv _ _ _ f).
-  apply h.
+  - apply hs.
+  - apply (inverse_unique_precat _ _ _ f).
+    + assumption.
+    + split.
+      * apply z_iso_inv_after_z_iso.
+      * set (h := z_iso_after_z_iso_inv _ _ f).
+        apply h.
 Qed.
 
-Lemma z_iso_inv_of_z_iso_comp (C : precategory) (hs: has_homsets C) (a b c : ob C)
+Lemma z_iso_inv_of_z_iso_comp {C : precategory} (hs : has_homsets C) (a b c : ob C)
    (f : z_iso a b) (g : z_iso b c) :
    z_iso_inv_from_z_iso (z_iso_comp f g) =
        z_iso_comp (z_iso_inv_from_z_iso g) (z_iso_inv_from_z_iso f).
 Proof.
   apply eq_z_iso.
-  apply hs.
-  reflexivity.
+  - apply hs.
+  - reflexivity.
 Defined.
 
-Lemma z_iso_inv_of_z_iso_id (C : precategory) (hs: has_homsets C) (a : ob C) :
+Lemma z_iso_inv_of_z_iso_id {C : precategory} (hs : has_homsets C) (a : ob C) :
    z_iso_inv_from_z_iso (identity_z_iso a) = identity_z_iso a.
 Proof.
   apply eq_z_iso.
-  apply hs.
-  apply idpath.
+  - apply hs.
+  - apply idpath.
 Qed.
 
-Lemma z_iso_inv_z_iso_inv (C : precategory) (hs: has_homsets C) (a b : ob C) (f : z_iso a b) :
+Lemma z_iso_inv_z_iso_inv {C : precategory} (hs : has_homsets C) (a b : ob C) (f : z_iso a b) :
      z_iso_inv_from_z_iso (z_iso_inv_from_z_iso f) = f.
 Proof.
   apply eq_z_iso.
-  apply hs.
-  reflexivity.
+  - apply hs.
+  - reflexivity.
 Defined.
 
-Lemma z_iso_comp_right_isweq {C:precategory} {a b:ob C} (h:z_iso a b) (c:C) :
+Lemma z_iso_comp_right_isweq {C : precategory} {a b : ob C} (h : z_iso a b) (c : C) :
   isweq (fun f : b --> c => h · f).
 Proof.
   intros. apply (isweq_iso _ (λ g, inv_from_z_iso h · g)).
@@ -827,26 +811,26 @@ Proof.
          { apply assoc. } { apply id_left. } }
 Defined.
 
-Definition z_iso_comp_right_weq {C:precategory} {a b:C} (h:z_iso a b) (c:C) :
+Definition z_iso_comp_right_weq {C : precategory} {a b : C} (h : z_iso a b) (c : C) :
  (b --> c) ≃ (a --> c) := make_weq _ (z_iso_comp_right_isweq h c).
 
-Lemma z_iso_comp_left_isweq {C:precategory} {a b:ob C} (h:z_iso a b) (c:C) :
+Lemma z_iso_comp_left_isweq {C : precategory} {a b : ob C} (h : z_iso a b) (c : C) :
   isweq (fun f : c --> a => f · h).
 Proof.
   intros. apply (isweq_iso _ (λ g, g · inv_from_z_iso h)).
-  { intros f. use (_ @ maponpaths (λ m, f·m) (pr1 (pr2 (pr2 h))) @ _).
+  { intros f. use (_ @ maponpaths (λ m, f · m) (pr1 (pr2 (pr2 h))) @ _).
          { apply pathsinv0. apply assoc. }  { apply id_right. } }
-       { intros g. use (_ @ maponpaths (λ m, g·m) (pr2 (pr2 (pr2 h))) @ _).
+       { intros g. use (_ @ maponpaths (λ m, g · m) (pr2 (pr2 (pr2 h))) @ _).
          { apply pathsinv0, assoc. } { apply id_right. } }
 Defined.
-Definition z_iso_comp_left_weq {C:precategory} {a b:C} (h:z_iso a b) (c:C) :
+Definition z_iso_comp_left_weq {C : precategory} {a b : C} (h : z_iso a b) (c : C) :
  (c --> a) ≃ (c --> b) := make_weq _ (z_iso_comp_left_isweq h c).
 
-Definition z_iso_conjug_weq {C:precategory} {a b:C} (h:z_iso a b) :
+Definition z_iso_conjug_weq {C : precategory} {a b : C} (h : z_iso a b) :
  (a --> a) ≃ (b --> b) := weqcomp (z_iso_comp_left_weq h _ )
          (z_iso_comp_right_weq (z_iso_inv_from_z_iso h) _ ).
 
-Lemma is_iso_from_is_z_iso {C: precategory}{a b : C} (f: a --> b) :
+Lemma is_iso_from_is_z_iso {C : precategory} {a b : C} (f: a --> b) :
      is_z_isomorphism f -> is_iso f.
 Proof.
   intro H.
@@ -857,7 +841,7 @@ Defined.
 Definition z_iso_to_iso {C : precategory} {b c : C} (f : z_iso b c) : iso b c
   := pr1 f ,, is_iso_from_is_z_iso (pr1 f) (pr2 f).
 
-Lemma is_z_iso_from_is_iso {C: precategory}{a b : C} (f: a --> b):
+Lemma is_z_iso_from_is_iso {C : precategory} {a b : C} (f : a --> b):
      is_iso f -> is_z_isomorphism f.
 Proof.
   intro H.

--- a/UniMath/CategoryTheory/DisplayedCats/Core.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Core.v
@@ -463,7 +463,7 @@ Proof.
   use tpair.
   - change ( xx -->[ iso_inv_from_iso (iso_inv_from_iso f)] yy).
     set (XR := transportb (mor_disp xx yy )
-                          (maponpaths pr1 (iso_inv_iso_inv _ _ _ f))).
+                          (maponpaths pr1 (iso_inv_iso_inv _ _ f))).
     apply XR. apply i.
   - cbn.
     split.

--- a/UniMath/CategoryTheory/Equivalences/CompositesAndInverses.v
+++ b/UniMath/CategoryTheory/Equivalences/CompositesAndInverses.v
@@ -182,7 +182,7 @@ Section eqv_inv.
       refine (_ @ triangle_id_right_ad (pr2 (pr1 adEquivF)) b).
 
       (** Transform it by precomposing with the inverse isos *)
-      apply (pre_comp_with_iso_is_inj _ _ _ _
+      apply (pre_comp_with_iso_is_inj _ _ _
                                       (#G (nat_iso_to_pointwise_iso εiso b)));
         [apply (functor_is_iso_is_iso G), iso_is_iso |].
 
@@ -198,7 +198,7 @@ Section eqv_inv.
       rewrite assoc.
 
       (** Again, precompose with the inverse iso *)
-      apply (pre_comp_with_iso_is_inj _ _ _ _
+      apply (pre_comp_with_iso_is_inj _ _ _
                                       ((nat_iso_to_pointwise_iso ηiso (G b))));
         [apply iso_is_iso; rewrite iso_inv_after_iso|].
       rewrite (nat_iso_inv_after_nat_iso ηiso).
@@ -213,14 +213,14 @@ Section eqv_inv.
       intro a.
       refine (_ @ triangle_id_left_ad (pr2 (pr1 adEquivF)) a).
 
-      apply (pre_comp_with_iso_is_inj _ _ _ _
+      apply (pre_comp_with_iso_is_inj _ _ _
                                       ((nat_iso_to_pointwise_iso εiso (F a))));
         [apply iso_is_iso; rewrite iso_inv_after_iso|].
       rewrite assoc.
       rewrite (nat_iso_inv_after_nat_iso εiso).
       rewrite id_left.
 
-      apply (pre_comp_with_iso_is_inj _ _ _ _ (#F (nat_iso_to_pointwise_iso ηiso a)));
+      apply (pre_comp_with_iso_is_inj _ _ _ (#F (nat_iso_to_pointwise_iso ηiso a)));
         [apply (functor_is_iso_is_iso F), iso_is_iso |].
       unfold adjunit; unfold adjcounit.
       unfold right_functor.

--- a/UniMath/CategoryTheory/Equivalences/Core.v
+++ b/UniMath/CategoryTheory/Equivalences/Core.v
@@ -156,14 +156,14 @@ Proof.
   cbn.
   apply pathsinv0. etrans. apply id_left. etrans. apply (! id_right _ ).
   apply pathsinv0.
-  apply (iso_inv_to_left _ _ _ _  (make_iso _ (Hη _ ))).
+  apply (iso_inv_to_left _ _ _  (make_iso _ (Hη _ ))).
   apply (invmaponpathsweq (make_weq _ (iso_comp_left_isweq (functor_on_iso G (make_iso _ (Hε _ ))) _ ))).
   cbn.
   set (XR := functor_on_iso_is_iso _ _ G _ _ (make_iso _ (Hε x))).
   set (XR' := make_iso (#G (ε x)) XR). cbn in XR'.
   apply pathsinv0. etrans. apply id_left. etrans. apply (! id_right _ ).
   apply pathsinv0.
-  apply (iso_inv_to_left _ _ _  _ XR').
+  apply (iso_inv_to_left _ _  _ XR').
   unfold XR', XR; clear XR' XR.
 
   repeat rewrite assoc.
@@ -340,7 +340,7 @@ Proof.
     (functor_on_iso F (idtoiso (isotoid _ HA g)))) f).
   - generalize (isotoid _ HA g).
     intro p0; destruct p0.
-    rewrite <- functor_on_iso_inv.
+    rewrite <- functor_on_iso_inv. simpl.
     rewrite iso_inv_of_iso_id.
     apply eq_iso.
     simpl; rewrite functor_id.
@@ -366,7 +366,7 @@ Proof.
       repeat rewrite <- assoc.
       rewrite iso_after_iso_inv.
       rewrite id_right.
-      set (H := iso_inv_iso_inv _ _ _ f').
+      set (H := iso_inv_iso_inv _ _ f').
       now apply (base_paths _ _ H).
 Qed.
 

--- a/UniMath/CategoryTheory/ExactCategories/ExactCategories.v
+++ b/UniMath/CategoryTheory/ExactCategories/ExactCategories.v
@@ -201,7 +201,6 @@ Section Pullbacks.              (* move upstream *)
     - intro. apply homset_property.
     - induction k as [[k K] e], k' as [[k' K'] e']; cbn; cbn in e, e'.
       induction (i A k k' (e @ !e')). apply maponpaths. apply isaprop_is_z_isomorphism.
-      apply homset_property.
   Qed.
   Lemma IsoArrowFrom_isaprop (M : category) {A B B':M} (g : A --> B) (g' : A --> B') :
      isEpi g -> isaprop (IsoArrowFrom g g').
@@ -210,7 +209,7 @@ Section Pullbacks.              (* move upstream *)
     { intros j. apply homset_property. }
     induction k as [[k K] e], k' as [[k' K'] e']; cbn; cbn in e, e'.
     apply subtypePath; cbn.
-    { intros f. apply isaprop_is_z_isomorphism. apply homset_property. }
+    { intros f. apply isaprop_is_z_isomorphism. }
     use i. exact (e @ !e').
   Qed.
 End Pullbacks.
@@ -407,7 +406,7 @@ Section PreAdditive.
     - exact (KernelIsMonic _ _ i).
     - exact (assoc _ _ _ @ maponpaths (postcomp_with _) (pr1 i) @ zeroLeft h).
     - intros w k e. apply (pr2 i).
-      refine (post_comp_with_iso_is_inj _ _ _ h (is_iso_from_is_z_iso h j) _ _ _ _).
+      refine (post_comp_with_iso_is_inj _ _ h (is_iso_from_is_z_iso h j) _ _ _ _).
       refine (! assoc _ _ _ @ e @ ! zeroLeft _).
   Qed.
   Lemma IsoWithCokernel {M:PreAdditive} {x x' y z:M} (f : x --> y) (g : y --> z) (h : x' --> x) :
@@ -1292,7 +1291,7 @@ Section ExactCategoryFacts.
   Lemma MonicAdmEpiIsIso {M : ExactCategory} {A B:M} (p : A ↠ B) : isMonic p -> is_z_isomorphism p.
   Proof.
     induction p as [p E]. cbn. intros I. apply (squash_to_prop E).
-    { apply isaprop_is_z_isomorphism. apply to_has_homsets. }
+    { apply (isaprop_is_z_isomorphism (C:=M)). }
     clear E; intros [K [i E]].
     assert (Q := EC_ExactToKernelCokernel E); clear E.
     induction Q as [ke co];

--- a/UniMath/CategoryTheory/LocalizingClass.v
+++ b/UniMath/CategoryTheory/LocalizingClass.v
@@ -1271,7 +1271,7 @@ Section def_roofs.
         apply tmp.
       + set (tmp := iso_inv_after_iso iso2). cbn in tmp. rewrite <- tmp. clear tmp.
         rewrite <- assoc. apply cancel_precomposition.
-        apply (post_comp_with_iso_is_inj _ _ _ g H2).
+        apply (post_comp_with_iso_is_inj _ _ g H2).
         set (tmp := iso_after_iso_inv iso2). cbn in tmp. rewrite tmp. clear tmp.
         rewrite <- assoc. set (tmp := iso_after_iso_inv iso1). cbn in tmp. exact tmp.
   Qed.
@@ -1427,10 +1427,10 @@ Section def_roofs.
     apply cancel_postcomposition.
     rewrite <- assoc. rewrite <- assoc. apply cancel_precomposition.
     set (tmp := LocSqr2Comm sqr).
-    apply (pre_comp_with_iso_is_inj D _ _ _ _ (pr2 iso2)). rewrite assoc.
+    apply (pre_comp_with_iso_is_inj (C:=D) _ _ _ _ (pr2 iso2)). rewrite assoc.
     set (tmp2 := iso_inv_after_iso iso2). cbn in tmp2. cbn. rewrite tmp2. clear tmp2.
     rewrite id_left.
-    apply (post_comp_with_iso_is_inj D _ _ _ (pr2 iso4)). cbn. rewrite <- functor_comp.
+    apply (post_comp_with_iso_is_inj (C:=D) _ _ _ (pr2 iso4)). cbn. rewrite <- functor_comp.
     rewrite tmp. clear tmp. rewrite functor_comp. rewrite <- assoc.
     apply cancel_precomposition.
     rewrite <- assoc.
@@ -1668,7 +1668,7 @@ Section def_roofs.
                          (RoofEqclassFromRoof (MorToRoof (RoofMor2 f1))))).
       unfold functor_composite. cbn. apply cancel_postcomposition.
       set (iso1 := make_iso _ (H' f1 a (RoofMor1 f1) (RoofMor1Is f1))).
-      apply (post_comp_with_iso_is_inj _ _ _ _ (pr2 iso1)).
+      apply (post_comp_with_iso_is_inj _ _ _ (pr2 iso1)).
       use (pathscomp0 _ (! (iso_after_iso_inv iso1))).
       unfold iso1. clear iso1. cbn.
       set (tmp := @functor_comp

--- a/UniMath/CategoryTheory/Monoidal/MonoidalFunctors.v
+++ b/UniMath/CategoryTheory/Monoidal/MonoidalFunctors.v
@@ -116,7 +116,7 @@ Proof.
   { apply functor_on_is_iso_is_iso.
     apply monoidal_precat_associator.
   }
-  set (Hass_inst' := iso_inv_on_left _ _ _ _ _ (_,, is) _ (! Hass_inst)).
+  set (Hass_inst' := iso_inv_on_left _ _ _ _ (_,, is) _ (! Hass_inst)).
   eapply pathscomp0.
   { exact Hass_inst'. }
   clear Hass_inst Hass_inst'.

--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -405,8 +405,8 @@ Proof.
       * abstract (intros X Y α;
                   apply nat_trans_eq; [ apply homset_property|];
                   intro x; simpl;
-                  apply pathsinv0, (iso_inv_on_left _ _ _ _ _ (set_iso Y x));
-                  rewrite <- assoc; apply pathsinv0, iso_inv_on_right;
+                  apply pathsinv0, (iso_inv_on_left _ _ _ _ (set_iso Y x));
+                  rewrite <- assoc; apply pathsinv0, (iso_inv_on_right (C:=SET));
                   exact (eqtohomot (maponpaths pr1 (nat_in_X X Y α)) x)).
     + abstract (use make_is_inverse_in_precat;
                 [ apply nat_trans_eq; [ apply homset_property |]; intro X;

--- a/UniMath/CategoryTheory/Subobjects.v
+++ b/UniMath/CategoryTheory/Subobjects.v
@@ -71,7 +71,7 @@ Context {C : precategory} (hsC : has_homsets C).
 (** Equivalence classes of subobjects defined by identifying monos into c
     with isomorphic source *)
 Definition SubObj (c : C) : HSET :=
-  make_hSet (setquot (iso_eqrel (Subobjectscategory hsC c))) (isasetsetquot _).
+  make_hSet (setquot (iso_eqrel (C:=Subobjectscategory hsC c))) (isasetsetquot _).
 
 (* For f and g monics into c: f <= g := ∃ h, f = h · g *)
 Definition monorel c : hrel (Subobjectscategory hsC c) :=
@@ -99,7 +99,7 @@ exact (istrans_monorel c,,isrefl_monorel c).
 Qed.
 
 Lemma are_isomorphic_monorel {c : C} {x1 y1 x2 y2 : Subobjectscategory hsC c}
-  (h1 : are_isomorphic _ x1 y1) (h2 : are_isomorphic _ x2 y2) :
+  (h1 : are_isomorphic x1 y1) (h2 : are_isomorphic x2 y2) :
   monorel c x1 x2 → monorel c y1 y2.
 Proof.
 apply hinhuniv; intros f.
@@ -130,8 +130,8 @@ use quotrel.
 - intros x1 y1 x2 y2 h1 h2.
   apply hPropUnivalence.
   + apply (are_isomorphic_monorel h1 h2).
-  + apply (are_isomorphic_monorel (eqrelsymm (iso_eqrel _) _ _ h1)
-                                  (eqrelsymm (iso_eqrel _) _ _ h2)).
+  + apply (are_isomorphic_monorel (eqrelsymm (iso_eqrel) _ _ h1)
+                                  (eqrelsymm (iso_eqrel) _ _ h2)).
 Defined.
 
 Lemma istrans_SubObj_rel (c : C) : istrans (SubObj_rel c).
@@ -160,7 +160,7 @@ assert (int : ∏ x1 x2, isaprop (SubObj_rel c x1 x2 → SubObj_rel c x2 x1 -> x
 apply (setquotuniv2prop _ (λ x1 x2, make_hProp _ (int x1 x2))).
 intros x y h1 h2.
 simpl in *. (* This is slow *)
-apply (iscompsetquotpr (iso_eqrel (Subobjectscategory hsC c))).
+apply (iscompsetquotpr (iso_eqrel (C:=Subobjectscategory hsC c))).
 generalize h1; clear h1; apply hinhuniv; intros [h1 Hh1].
 generalize h2; clear h2; apply hinhuniv; intros [h2 Hh2].
 apply hinhpr, (invmap (weq_iso _ (subprecategory_of_monics_ob C hsC c) _ _)).

--- a/UniMath/CategoryTheory/categories/HSET/Structures.v
+++ b/UniMath/CategoryTheory/categories/HSET/Structures.v
@@ -576,8 +576,8 @@ Proof.
         pose (pbiso := pullbackiso PBC PBO').
 
         use make_hfiber.
-        -- exact (morphism_from_z_iso _ _ _ (pr1 pbiso) (y,, isO)).
-        -- change (pr1 m (morphism_from_z_iso _ _ _ (pr1 pbiso) (y,, isO))) with
+        -- exact (morphism_from_z_iso _ _ (pr1 pbiso) (y,, isO)).
+        -- change (pr1 m (morphism_from_z_iso _ _ (pr1 pbiso) (y,, isO))) with
                   (((pr1 pbiso) · pr1 m) (y,, isO)).
            change (pr1 m) with (PullbackPr1 PBO').
            rewrite (pr1 (pr2 pbiso)).

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -1022,7 +1022,7 @@ Section BinCoproduct_from_iso.
                × (BinCoproductIn2 C BP · inv_from_iso i · y0 = g)) :
     y0 = i · BinCoproductArrow C BP f g.
   Proof.
-    apply (pre_comp_with_iso_is_inj C _ _ w (iso_inv_from_iso i) (pr2 (iso_inv_from_iso i))).
+    apply (pre_comp_with_iso_is_inj _ _ w (iso_inv_from_iso i) (pr2 (iso_inv_from_iso i))).
     rewrite assoc. cbn. rewrite (iso_after_iso_inv i). rewrite id_left.
     apply BinCoproductArrowUnique.
     - rewrite assoc. apply (dirprod_pr1 T).

--- a/UniMath/CategoryTheory/limits/binproducts.v
+++ b/UniMath/CategoryTheory/limits/binproducts.v
@@ -617,7 +617,7 @@ Section BinProduct_from_iso.
         (T : y0 · (i · BinProductPr1 C BP) = f × y0 · (i · BinProductPr2 C BP) = g) :
     y0 = BinProductArrow C BP f g · iso_inv_from_iso i.
   Proof.
-    apply (post_comp_with_iso_is_inj C _ _ i (pr2 i)).
+    apply (post_comp_with_iso_is_inj _ _ i (pr2 i)).
     rewrite <- assoc. cbn. rewrite (iso_after_iso_inv i). rewrite id_right.
     apply BinProductArrowUnique.
     - rewrite <- assoc. apply (dirprod_pr1 T).

--- a/UniMath/CategoryTheory/limits/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/pullbacks.v
@@ -890,7 +890,7 @@ Proof.
   - cbn. intro t. apply subtypePath ; [
         intros ?; apply isapropdirprod; apply hsD | cbn ].
     destruct t as [t [Htx Hty]]; cbn.
-    apply (pre_comp_with_iso_is_inj _ _ _ _ i (pr2 i)).
+    apply (pre_comp_with_iso_is_inj _ _ _ i (pr2 i)).
     rewrite assoc. rewrite iso_inv_after_iso.
     rewrite id_left.
     apply (invmaponpathsweq (invweq (FF _ _ ))).

--- a/UniMath/CategoryTheory/limits/zero.v
+++ b/UniMath/CategoryTheory/limits/zero.v
@@ -156,14 +156,14 @@ Section def_zero.
       + exact (i · (ZeroArrowFrom Z a)).
       + cbn. intros t.
         apply (pre_comp_with_iso_is_inj
-                 C _ _ a (iso_inv_from_iso i) (pr2 (iso_inv_from_iso i))).
+                 _ _ a (iso_inv_from_iso i) (pr2 (iso_inv_from_iso i))).
         rewrite assoc. cbn. rewrite (iso_after_iso_inv i). rewrite id_left.
         apply ArrowsFromZero.
     - intros a.
       use tpair.
       + exact ((ZeroArrowTo Z a) · (iso_inv_from_iso i)).
       + cbn. intros t.
-        apply (post_comp_with_iso_is_inj C _ _ i (pr2 i)).
+        apply (post_comp_with_iso_is_inj _ _ i (pr2 i)).
         rewrite <- assoc. rewrite (iso_after_iso_inv i). rewrite id_right.
         apply ArrowsToZero.
   Qed.

--- a/UniMath/CategoryTheory/precomp_fully_faithful.v
+++ b/UniMath/CategoryTheory/precomp_fully_faithful.v
@@ -65,7 +65,7 @@ Proof.
     + intro b.
       apply (p b (make_hProp _ (hsC _ _ _ _))).
       intro t; induction t as [a f]; simpl.
-      apply (pre_comp_with_iso_is_inj _ _ _ _ (# F f)
+      apply (pre_comp_with_iso_is_inj _ _ _ (# F f)
          (functor_on_iso_is_iso _ _ _ _ _ f)).
       rewrite 2 nat_trans_ax.
       apply cancel_postcomposition.

--- a/UniMath/Folds/folds_isomorphism.v
+++ b/UniMath/Folds/folds_isomorphism.v
@@ -202,7 +202,7 @@ Proof.
     - rewrite H. apply ϕ₁_ϕ₂_id.
     - rewrite H. apply ϕ₂_ϕ₁_id. }
   assert (X : ϕ₂ i (id _ ) = ϕ₂ i' (id _ )).
-  { set (H1:= inverse_unique_precat C' _ _  _ _  _ (ϕ₁_ϕ₂_are_inverse i) H').
+  { set (H1:= inverse_unique_precat _ _  _ _  _ (ϕ₁_ϕ₂_are_inverse i) H').
     assumption.
   }
   rewrite X.
@@ -487,10 +487,10 @@ Proof.
       apply (z_iso_after_z_iso_inv _ _ f).
     + intro H. apply id_identity2.
       set (H':=id_identity2' H); clearbody H'; clear H.
-      set (H2:=z_iso_inv_to_left _ _ _ _ f _ _ H'); clearbody H2.
+      set (H2:=z_iso_inv_to_left _ _ _ f _ _ H'); clearbody H2.
       rewrite id_right in H2.
       transitivity (f □ (inv_from_z_iso f)).
-      * apply (z_iso_inv_on_left C'), pathsinv0, H2.
+      * apply (z_iso_inv_on_left (C:=C')), pathsinv0, H2.
       * apply (z_iso_inv_after_z_iso (C := C')).
 Qed.
 
@@ -526,7 +526,7 @@ Context {a b : C} (i : z_iso (C:=C') a b).
 
 Lemma iso_from_folds_iso_folds_iso_from_iso : iso_from_folds_iso _ _ (folds_iso_from_iso _ _ i) = i.
 Proof.
-  apply eq_z_iso. apply hs.
+  apply (eq_z_iso(C:=C',,hs)).
   apply (@id_left C').
 Qed.
 

--- a/UniMath/Folds/folds_isomorphism.v
+++ b/UniMath/Folds/folds_isomorphism.v
@@ -484,14 +484,14 @@ Proof.
   - simpl. apply logeqweq.
     + intro H. apply id_identity2.
       rewrite (id_identity2' H). rewrite (@id_left C').
-      apply (z_iso_after_z_iso_inv _ _ _ f).
+      apply (z_iso_after_z_iso_inv _ _ f).
     + intro H. apply id_identity2.
       set (H':=id_identity2' H); clearbody H'; clear H.
       set (H2:=z_iso_inv_to_left _ _ _ _ f _ _ H'); clearbody H2.
       rewrite id_right in H2.
       transitivity (f □ (inv_from_z_iso f)).
       * apply (z_iso_inv_on_left C'), pathsinv0, H2.
-      * apply (z_iso_inv_after_z_iso C').
+      * apply (z_iso_inv_after_z_iso (C := C')).
 Qed.
 
 Definition folds_iso_from_iso : folds_iso a b := tpair _ _ folds_iso_data_prop.

--- a/UniMath/HomologicalAlgebra/CohomologyComplex.v
+++ b/UniMath/HomologicalAlgebra/CohomologyComplex.v
@@ -1984,7 +1984,7 @@ Section def_kernel_cokernel_complex.
     cbn in KI12. fold KI12.
     (* Begin to prove the equality *)
     (* Cancel the inv_from_iso *)
-    use (pre_comp_with_iso_is_inj _ _ _ _ _ (CohomologyComplexIso_is_iso_i A hs C i)).
+    use (pre_comp_with_iso_is_inj _ _ _ _ (CohomologyComplexIso_is_iso_i A hs C i)).
     rewrite assoc. rewrite assoc. rewrite assoc.
     assert (e : (CohomologyComplexIso_Mor_i A hs C i)
                   · (inv_from_iso ((CohomologyComplexIso_Mor_i A hs C i)
@@ -1998,7 +1998,7 @@ Section def_kernel_cokernel_complex.
     use (pathscomp0 e). clear e. rewrite id_left.
     (* Cancel the last morphism *)
     use (post_comp_with_iso_is_inj
-           _ _ _ _  (is_iso_inv_from_iso (make_iso _ (CohomologyComplexIso_is_iso_i A hs C i)))).
+           _ _ _  (is_iso_inv_from_iso (make_iso _ (CohomologyComplexIso_is_iso_i A hs C i)))).
     rewrite <- assoc. rewrite <- assoc.
     assert (ee : (CohomologyComplexIso_Mor_i A hs C i)
                    · (inv_from_iso (make_iso _ (CohomologyComplexIso_is_iso_i A hs C i))) =

--- a/UniMath/HomologicalAlgebra/Complexes.v
+++ b/UniMath/HomologicalAlgebra/Complexes.v
@@ -1215,8 +1215,8 @@ Section complexes_precat.
     - use make_Morphism.
       + intros i. exact (iso_inv_from_is_iso _ (H i)).
       + intros i. cbn.
-        use (post_comp_with_iso_is_inj _ _ _ _ (H (i + 1))).
-        use (pre_comp_with_iso_is_inj _ _ _ _ _ (H i)).
+        use (post_comp_with_iso_is_inj _ _ _ (H (i + 1))).
+        use (pre_comp_with_iso_is_inj _ _ _ _ (H i)).
         assert (e0 : MMor f i · inv_from_iso (MMor f i,, H i) = identity _).
         {
           apply (iso_inv_after_iso (make_iso _ (H i))).


### PR DESCRIPTION
The intention was to prepare for a more important use of z_iso. The code is presented more beautifully, some redundancy in proofs is omitted. The second commit does incompatible changes concerning the (pre-)category argument - compilation is restored through very light changes in many files.
