### PR TITLE
Update Mac OS install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,7 +31,7 @@ This should prepare you for [Installing UniMath](#installing-unimath) below.
 
 You will also need an editor.  There are several options for this:
 
-1. We recommend Emacs with ProofGeneral.  A classic Emacs can be installed from https://emacsformacosx.com/; alternatively, Aquamacs (https://aquamacs.org) provides a slightly more native interface, with standard Mac OS keybindings.  Instructions for [installation of ProofGeneral](#installation-of-proofgeneral-all-operating-systems) are below.  
+1. We recommend Emacs with Proof General.  A classic Emacs can be installed from https://emacsformacosx.com/; alternatively, Aquamacs (https://aquamacs.org) provides a slightly more native interface, with standard Mac OS keybindings.  Instructions for [installation of Proof General](#installation-of-proofgeneral-all-operating-systems) are below.  
 
 2. A popular newer option is Visual Studio Code, available from https://code.visualstudio.com, with the VSCoq extension.
 
@@ -50,7 +50,7 @@ following shell command.
 ```bash
  sudo apt-get install build-essential git ocaml ocaml-nox ocaml-native-compilers camlp5 libgtk2.0 libgtksourceview2.0 liblablgtk-extras-ocaml-dev ocaml-findlib libnum-ocaml-dev emacs
 ```
-Now proceed with [Installation of ProofGeneral](#installation-of-proofgeneral-all-operating-systems) and [Installing UniMath](#installing-unimath) below.
+Now proceed with [Installation of Proof General](#installation-of-proofgeneral-all-operating-systems) and [Installing UniMath](#installing-unimath) below.
 
 ### Preparing for the installation under Arch Linux or Manjaro Linux
 
@@ -63,13 +63,13 @@ shell commands.
  sudo pacman --sync --needed ocaml camlp5 ocaml-findlib ocaml-num
  sudo pacman -S emacs
 ```
-Now proceed with [Installation of ProofGeneral](#installation-of-proofgeneral-all-operating-systems) and [Installing UniMath](#installing-unimath) below.
+Now proceed with [Installation of Proof General](#installation-of-proofgeneral-all-operating-systems) and [Installing UniMath](#installing-unimath) below.
 
-## Installation of ProofGeneral (all operating systems)
+## Installation of Proof General (all operating systems)
 
-You may obtain ProofGeneral from by using the quick installation instructions
+You may obtain Proof General from by using the quick installation instructions
 at http://proofgeneral.inf.ed.ac.uk/ or at https://proofgeneral.github.io/.
-Your version of emacs determines which version of ProofGeneral you need,
+Your version of emacs determines which version of Proof General you need,
 roughly, so some experimentation may be required; you may even need the current
 development version if your emacs is recent.
 
@@ -80,13 +80,13 @@ started.
 
 Finally, `RET` means "press Enter".
 
-Hence, the first ProofGeneral installation instruction
+Hence, the first Proof General installation instruction
 ```
 M-x package-refresh-contents RET
 ```
 reads "hold Alt, press x; type package-refresh-contents; press Enter".
 
-Optional: some useful ProofGeneral add-ons are available for installation at
+Optional: some useful Proof General add-ons are available for installation at
 https://github.com/cpitclaudel/company-coq/.
 
 ## Installing UniMath
@@ -224,7 +224,7 @@ The correct version of Coq is built and used automatically by the command
 then follow the instructions in the file build/Makefile-configuration-template.)
 
 The file ```UniMath/.dir-locals.el``` contains code that arranges for
-ProofGeneral to use the Coq programs built by ```make``` when one of the proof
+Proof General to use the Coq programs built by ```make``` when one of the proof
 files of UniMath is opened in emacs; in order to use them more generally, such
 as from the command line,, then add the full path for the directory
 ```./sub/coq/bin``` to your ```PATH``` environment variable, or set the emacs
@@ -234,7 +234,7 @@ The various *.v files are compiled by Coq in such a way that the fully
 qualified name of each identifier begins with UniMath.  For example, the fully
 qualified name of ```maponpaths``` in uu0.v is ```UniMath.Foundations.Basics.PartA.maponpaths```.
 
-The preferred way to interact with the Coq code is with ProofGeneral, running
+The preferred way to interact with the Coq code is with Proof General, running
 in a modern version of emacs.  The file UniMath/.dir-locals.el will set the
 emacs variable ```coq-prog-args``` appropriately.  In particular, it will add the
 directory UniMath to the path, using the ```-R``` option, and it will arrange for

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,18 +15,32 @@ and under [Arch/Manjaro Linux](#preparing-for-the-installation-under-arch-linux-
 
 ### Preparing for the installation under Mac OS X
 
-NB: The method explained below is recommended for beginners.
-A more flexible, but complex, installation method is given in [INSTALL\_OPAM.md](./INSTALL_OPAM.md).
+NB: The following is a recommended simple approach.
+For more customisation of your installation, see [INSTALL\_OPAM.md](./INSTALL_OPAM.md).
 
-1. Install "Homebrew", available from http://brew.sh/.
-2. Using Homebrew, install ocaml with the following command:
+1. Install OCaml and required libraries, using your preferred package manager.  E.g. using Homebrew (http://brew.sh/), issue the command:
 ```bash
-$ brew install objective-caml ocaml-num camlp5 bash ocaml-findlib
+$ brew install ocaml opam ocaml-num ocaml-findlib
 ```
-3. Install Emacs from https://emacsformacosx.com/.
-  
-Now proceed with [Installation of ProofGeneral](#installation-of-proofgeneral-all-operating-systems) and [Installing UniMath](#installing-unimath) below.
+2. If the build script later asks you to switch to a specific OCaml version, and/or install extra packages, you can do this with:
+```bash
+$ opam switch 4.11.0
+$ opam install num ocamlfind
+```
+This should prepare you for [Installing UniMath](#installing-unimath) below.
 
+You will also need an editor.  There are several options for this:
+
+1. We recommend Emacs with ProofGeneral.  A classic Emacs can be installed from https://emacsformacosx.com/; alternatively, Aquamacs (https://aquamacs.org) provides a slightly more native interface, with standard Mac OS keybindings.  Instructions for [installation of ProofGeneral](#installation-of-proofgeneral-all-operating-systems) are below.  
+
+2. A popular newer option is Visual Studio Code, available from https://code.visualstudio.com, with the VSCoq extension.
+
+3. Alternatively, you can use Coq’s own CoqIDE.  For this you will need LablGtk3 and LablGtkSourceView3; these can be installed with:
+```bash
+$ brew install lablgtk gtksourceview3
+$ opam install lablgtk3 lablgtk-sourceview3
+```
+With those installed, follow the instructions in [INSTALL\_COQIDE.md](./INSTALL_COQIDE.md).
 
 ### Preparing for the installation under Ubuntu or Debian (Linux)
 
@@ -50,6 +64,7 @@ shell commands.
  sudo pacman -S emacs
 ```
 Now proceed with [Installation of ProofGeneral](#installation-of-proofgeneral-all-operating-systems) and [Installing UniMath](#installing-unimath) below.
+
 ## Installation of ProofGeneral (all operating systems)
 
 You may obtain ProofGeneral from by using the quick installation instructions

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,14 +22,16 @@ For more customisation of your installation, see [INSTALL\_OPAM.md](./INSTALL_OP
 ```bash
 $ brew install ocaml opam ocaml-num ocaml-findlib
 ```
-2. If the build script later asks you to switch to a specific OCaml version, and/or install extra packages, you can do this with:
+2. If later in the installation you get a message asking for a specific OCaml version, and/or installing extra packages, you can do this with:
 ```bash
-$ opam switch 4.11.0
+$ opam init
+$ eval $(opam env)
+$ opam switch create 4.11.0
 $ opam install num ocamlfind
 ```
-This should prepare you for [Installing UniMath](#installing-unimath) below.
+This should prepare your system for [Installing UniMath](#installing-unimath) below.
 
-You will also need an editor.  There are several options for this:
+You will also need an editor.  There are several options:
 
 1. We recommend Emacs with Proof General.  A classic Emacs can be installed from https://emacsformacosx.com/; alternatively, Aquamacs (https://aquamacs.org) provides a slightly more native interface, with standard Mac OS keybindings.  Instructions for [installation of Proof General](#installation-of-proofgeneral-all-operating-systems) are below.  
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -11,9 +11,9 @@ Once you have [installed](./INSTALL.md) UniMath, you can start browsing and edit
 There are several programs to interactively edit and step through the files, among which
 are 
 1. [CoqIDE](https://coq.inria.fr/refman/practical-tools/coqide.html) and 
-2. Emacs with the [ProofGeneral](https://proofgeneral.github.io/) add-on.
+2. Emacs with the [Proof General](https://proofgeneral.github.io/) add-on.
 
-Here, we focus on Emacs/ProofGeneral.
+Here, we focus on Emacs/Proof General.
 
 Automatic setup of work environment using Emacs
 -----------------------------------------------
@@ -22,14 +22,14 @@ When first opening a file in `UniMath/UniMath`, you will be asked to apply a lis
 ![Screenshot Emacs](https://raw.githubusercontent.com/wiki/UniMath/UniMath/Screenshot_Emacs.png)
 
 When opening a source file in the directory `UniMath/UniMath` in Emacs, the following happens **automatically**.
-1. *The ProofGeneral add-on to Emacs is loaded.*
-   ProofGeneral is an add-on to the text editor Emacs, adding buttons, menus, and keyboard shortcuts
+1. *The Proof General add-on to Emacs is loaded.*
+   Proof General is an add-on to the text editor Emacs, adding buttons, menus, and keyboard shortcuts
    to interact with Coq, the proof assistant that UniMath relies on.
-   During the [installation procedure](./INSTALL.md) you have set up ProofGeneral on your computer.
+   During the [installation procedure](./INSTALL.md) you have set up Proof General on your computer.
 2. *A Unicode input method is loaded.* 
    It allows you to insert Unicode symbols using a LaTeX-like syntax.
    See [Section on Unicode input below](USAGE.md/#unicode-input)
-3. ProofGeneral is informed about the location of the Coq proof assistant installed during the installation of UniMath,
+3. Proof General is informed about the location of the Coq proof assistant installed during the installation of UniMath,
    and of the options that need to passed to Coq.
 
 Items 2 and 3 are achieved through the Emacs configuration file [`.dir-locals.el`](./UniMath/.dir-locals.el) located in 
@@ -37,9 +37,9 @@ the subdirectory `UniMath/UniMath`.
 For this reason, we recommend you save your UniMath files in this subdirectory as well.
 
 
-Stepping through a Coq file in Emacs/ProofGeneral
+Stepping through a Coq file in Emacs/Proof General
 -------------------------------------------------
-Andrej Bauer has a [screencast](https://www.youtube.com/watch?v=l6zqLJQCnzo) on using Emacs/ProofGeneral
+Andrej Bauer has a [screencast](https://www.youtube.com/watch?v=l6zqLJQCnzo) on using Emacs/Proof General
 for writing and stepping through a Coq file.
 (More screencasts are listed on his [website](http://math.andrej.com/2011/02/22/video-tutorials-for-the-coq-proof-assistant/).)
 For following his instructions using his example, we recommend you save the Coq file in the subdirectory `UniMath/UniMath`


### PR DESCRIPTION
Addresses #1360 : bring the Mac OS install instructions up-to-date.  Several changes:

- remove instructions to install packages that are no longer needed, in particular `camlp5` and the CoqIDE packages
- add note about how to switch OCaml versions if needed
- include mention of VSCode as an alternative to Emacs

Another minor change, while I was working on `INSTALL.md`: fixed spelling of Proof General throughout (it’s two words not one: https://proofgeneral.github.io)