### PR TITLE
Update to Coq 8.13.2

### DIFF
--- a/.github/workflows/build-libs.yml
+++ b/.github/workflows/build-libs.yml
@@ -28,7 +28,7 @@ jobs:
       
       # Install everything needed for building UniMath (and more)
       - name: Install build dependencies
-        run: sudo apt-get install build-essential git ocaml ocaml-nox ocaml-native-compilers camlp5 libgtk2.0 libgtksourceview2.0 liblablgtk-extras-ocaml-dev ocaml-findlib libnum-ocaml-dev emacs
+        run: sudo apt-get install build-essential git ocaml ocaml-nox ocaml-native-compilers camlp5 libgtk2.0 libgtksourceview2.0 liblablgtk-extras-ocaml-dev ocaml-findlib libnum-ocaml-dev libzarith-ocaml-dev emacs
 
       # Change into UniMath directory and build UniMath
       - name: Build UniMath and libraries TypeTheory and Largecatmodules

--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -28,7 +28,7 @@ jobs:
       
       # Install everything needed for building UniMath (and more)
       - name: Install build dependencies
-        run: sudo apt-get install build-essential git ocaml ocaml-nox ocaml-native-compilers camlp5 libgtk2.0 libgtksourceview2.0 liblablgtk-extras-ocaml-dev ocaml-findlib libnum-ocaml-dev emacs
+        run: sudo apt-get install build-essential git ocaml ocaml-nox ocaml-native-compilers camlp5 libgtk2.0 libgtksourceview2.0 liblablgtk-extras-ocaml-dev ocaml-findlib libnum-ocaml-dev libzarith-ocaml-dev emacs
 
       # Change into UniMath directory and build UniMath
       - name: Build UniMath

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,7 +34,7 @@ Under Ubuntu or Debian, you may install ocaml with the
 following shell command.
 
 ```bash
- sudo apt-get install build-essential git ocaml ocaml-nox ocaml-native-compilers camlp5 libgtk2.0 libgtksourceview2.0 liblablgtk-extras-ocaml-dev ocaml-findlib libnum-ocaml-dev emacs
+ sudo apt-get install build-essential git ocaml ocaml-nox ocaml-native-compilers camlp5 libgtk2.0 libgtksourceview2.0 liblablgtk-extras-ocaml-dev ocaml-findlib libnum-ocaml-dev libzarith-ocaml-dev emacs
 ```
 Now proceed with [Installation of ProofGeneral](#installation-of-proofgeneral-all-operating-systems) and [Installing UniMath](#installing-unimath) below.
 


### PR DESCRIPTION
Requires library `zarith` to build.
