### PR TITLE
Avoid warnings on implicit arguments and some other warnings at compilation time

### DIFF
--- a/UniMath/Bicategories/PseudoFunctors/Display/PseudoFunctorBicat.v
+++ b/UniMath/Bicategories/PseudoFunctors/Display/PseudoFunctorBicat.v
@@ -178,7 +178,7 @@ Section FunctorLaws.
     := (∏ (a : C),
         is_invertible_2cell (psfunctor_id F a))
      ×
-       (∏ {a b c : C} (f : a --> b) (g : b --> c),
+       (∏ (a b c : C) (f : a --> b) (g : b --> c),
         is_invertible_2cell (psfunctor_comp F f g)).
 
   Definition is_psfunctor : UU

--- a/UniMath/CategoryTheory/Core/Categories.v
+++ b/UniMath/CategoryTheory/Core/Categories.v
@@ -87,7 +87,7 @@ Definition compose {C : precategory_data} { a b c : C }
   : a --> b -> b --> c -> a --> c
   := pr2 (pr2 C) a b c.
 
-Notation "f ;; g" := (compose f g) : cat_deprecated.
+Notation "f ;; g" := (compose f g) (at level 50, left associativity, format "f  ;;  g") : cat_deprecated.
 
 Notation "f · g" := (compose f g) : cat.
 (* to input: type "\centerdot" or "\cdot" with Agda input method *)

--- a/UniMath/CategoryTheory/DisplayedCats/Core.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Core.v
@@ -74,7 +74,7 @@ Definition disp_cat' (C : precategory) : UU :=
                   comp_disp ff (comp_disp gg hh)
                   = transportb (λ k, mor_disp k _ _) (assoc _ _ _)
                                (comp_disp (comp_disp ff gg) hh)),
-  (* homsets_disp : *) ∏ {x y} {f : x --> y} {xx} {yy}, isaset (mor_disp f xx yy).
+  (* homsets_disp : *) ∏ x y (f : x --> y) xx yy, isaset (mor_disp f xx yy).
 
 (** ** Definition *)
 

--- a/UniMath/CategoryTheory/RepresentableFunctors/Precategories.v
+++ b/UniMath/CategoryTheory/RepresentableFunctors/Precategories.v
@@ -62,7 +62,7 @@ Proof.
   exact (λ a b, pr2 C b a).
 Defined.
 
-Notation "C '^op'" := (oppositecategory C) (at level 3) : cat. (* this overwrites the previous definition *)
+Notation "C '^op'" := (oppositecategory C) (at level 3, format "C ^op") : cat. (* this overwrites the previous definition *)
 
 
 Definition precategory_obmor (C:precategory) : precategory_ob_mor :=

--- a/UniMath/Folds/folds_isomorphism.v
+++ b/UniMath/Folds/folds_isomorphism.v
@@ -51,8 +51,8 @@ Local Notation "'id' a" := (identity (C:=C') a) (at level 30).
 
 
 Definition folds_iso_data (a b : C) : UU :=
-  ((∏ {x : C}, (x ⇒ a) ≃ (x ⇒ b))
- × (∏ {z : C}, (a ⇒ z) ≃ (b ⇒ z)))
+  ((∏ (x : C), (x ⇒ a) ≃ (x ⇒ b))
+ × (∏ (z : C), (a ⇒ z) ≃ (b ⇒ z)))
 ×             ((a ⇒ a) ≃ (b ⇒ b)).
 
 Definition ϕ₁ {a b : C} (f : folds_iso_data a b) {x : C} : (x ⇒ a) ≃ (x ⇒ b) :=

--- a/UniMath/Folds/folds_pre_2_cat.v
+++ b/UniMath/Folds/folds_pre_2_cat.v
@@ -110,11 +110,11 @@ Definition folds_ax_id (C : folds_3_id_comp_eq) :=
 (** ** The axioms for composition *)
 
 Definition folds_ax_comp (C : folds_3_id_comp_eq) :=
-     (∏ {a b c : C} (f : a ⇒ b) (g : b ⇒ c), ∥ ∑ h : a ⇒ c, T f g h ∥ )
+     (∏ (a b c : C) (f : a ⇒ b) (g : b ⇒ c), ∥ ∑ h : a ⇒ c, T f g h ∥ )
                                                         (* there is a composite *)
- × ( (∏ {a b c : C} {f : a ⇒ b} {g : b ⇒ c} {h k : a ⇒ c}, T f g h → T f g k → E h k )
+ × ( (∏ (a b c : C) (f : a ⇒ b) (g : b ⇒ c) (h k : a ⇒ c), T f g h → T f g k → E h k )
                                                         (* composite is unique mod E *)
-  ×  (∏ {a b c d : C} (f : a ⇒ b) (g : b ⇒ c) (h : c ⇒ d) (fg : a ⇒ c)
+  ×  (∏ (a b c d : C) (f : a ⇒ b) (g : b ⇒ c) (h : c ⇒ d) (fg : a ⇒ c)
                       (gh : b ⇒ d) (fg_h : a ⇒ d) (f_gh : a ⇒ d),
        T f g fg → T g h gh → T fg h fg_h → T f gh f_gh → E f_gh fg_h)).
                                                         (* composition is assoc mod E *)
@@ -296,9 +296,9 @@ Definition isotoid2 (C : folds_pre_2_cat) (H : is_univalent_folds_pre_2_cat C)
 
 Definition is_folds_precategory (C : folds_pre_2_cat) : UU :=
      (∏ a b : C, isaset (a ⇒ b))
- ×  ((∏ {a b c : C} {f : a ⇒ b} {g : b ⇒ c} {h k : a ⇒ c},
+ ×  ((∏ (a b c : C) (f : a ⇒ b) (g : b ⇒ c) (h k : a ⇒ c),
                   T f g h → T f g k → h = k )       (* T is unique mod identity *)
-  ×  (∏ {a b c d : C} (f : a ⇒ b) (g : b ⇒ c) (h : c ⇒ d)
+  ×  (∏ (a b c d : C) (f : a ⇒ b) (g : b ⇒ c) (h : c ⇒ d)
                   (fg : a ⇒ c) (gh : b ⇒ d) (fg_h : a ⇒ d) (f_gh : a ⇒ d),
                T f g fg → T g h gh →
                   T fg h fg_h → T f gh f_gh → f_gh = fg_h)). (* T is assoc mod identity *)

--- a/UniMath/Folds/folds_precat.v
+++ b/UniMath/Folds/folds_precat.v
@@ -64,10 +64,10 @@ Proof.
 Qed.
 
 Definition folds_ax_T (C : folds_id_T) :=
-     (∏ {a b c : C} (f : a ⇒ b) (g : b ⇒ c), ∥ ∑ h : a ⇒ c, T f g h ∥ ) (* there is a composite *)
- ×  ((∏ {a b c : C} {f : a ⇒ b} {g : b ⇒ c} {h k : a ⇒ c},
+     (∏ (a b c : C) (f : a ⇒ b) (g : b ⇒ c), ∥ ∑ h : a ⇒ c, T f g h ∥ ) (* there is a composite *)
+ ×  ((∏ (a b c : C) (f : a ⇒ b) (g : b ⇒ c) (h k : a ⇒ c),
                   T f g h → T f g k → h = k )       (* composite is unique *)
-  ×  (∏ {a b c d : C} (f : a ⇒ b) (g : b ⇒ c) (h : c ⇒ d)
+  ×  (∏ (a b c d : C) (f : a ⇒ b) (g : b ⇒ c) (h : c ⇒ d)
                   (fg : a ⇒ c) (gh : b ⇒ d) (fg_h : a ⇒ d) (f_gh : a ⇒ d),
                T f g fg → T g h gh →
                   T fg h fg_h → T f gh f_gh → f_gh = fg_h)). (* composition is assoc *)

--- a/UniMath/Foundations/Init.v
+++ b/UniMath/Foundations/Init.v
@@ -35,7 +35,7 @@ Reserved Notation "x :: y" (at level 60, right associativity). (* originally in 
 
 Reserved Notation "x ++ y" (at level 60, right associativity). (* originally in Coq.Init.Datatypes *)
 
-Reserved Notation "p # x" (right associativity, at level 65, only parsing).
+Reserved Notation "p # x" (right associativity, at level 65).
 
 Reserved Notation "a ╝ b" (at level 70, no associativity).
 (* in agda input mode use \--= and select the 6-th one in the first set,
@@ -44,7 +44,7 @@ Reserved Notation "a ╝ b" (at level 70, no associativity).
 Reserved Notation "X ≃ Y" (at level 80, no associativity).
 (* written \~- or \simeq in Agda input method *)
 
-Reserved Notation "p #' x" (right associativity, at level 65, only parsing).
+Reserved Notation "p #' x" (right associativity, at level 65).
 
 Reserved Notation "f ~ g" (at level 70, no associativity).
 
@@ -66,7 +66,7 @@ Reserved Notation "C ⟦ a , b ⟧" (at level 49, right associativity).
 
 Reserved Notation "⟦ a ⟧" (at level 48, left associativity).
 
-Reserved Notation "f ;; g"  (at level 50, left associativity, only parsing). (* deprecated *)
+Reserved Notation "f ;; g"  (at level 50, left associativity, format "f  ;;  g"). (* deprecated *)
 
 Reserved Notation "g ∘ f"  (at level 40, left associativity).
 (* to input: type "\circ" with Agda input method *)
@@ -83,7 +83,7 @@ Reserved Notation "! p " (at level 50, left associativity).
     Reserved Notation "p # x" (right associativity, at level 65, only parsing).
 *)
 
-Reserved Notation "p #' x" (right associativity, at level 65, only parsing).
+Reserved Notation "p #' x" (right associativity, at level 65).
 
 Reserved Notation "C '^op'" (at level 3, format "C ^op").
 

--- a/UniMath/Induction/W/Naturals.v
+++ b/UniMath/Induction/W/Naturals.v
@@ -182,7 +182,7 @@ Defined.
     and a function from each X n to X (S n).
  *)
 Definition fibered_algebra_nat :
-  fibered_alg nat_alg_z ≃ ∑ (X : ∏ n : ℕ, UU), (X 0) × (∏ {n}, X n → X (S n)).
+  fibered_alg nat_alg_z ≃ ∑ (X : ∏ n : ℕ, UU), (X 0) × (∏ n, X n → X (S n)).
 Proof.
   apply weqfibtototal; intro X; cbn in X.
   use weq_iso.


### PR DESCRIPTION
The last of the three commits also touches on Foundations - it could be applied manually, and then I could undo that last commit.