### PR TITLE
pre-strength used more consequently, and more in this spirit

### DIFF
--- a/UniMath/CategoryTheory/Monads/Monads.v
+++ b/UniMath/CategoryTheory/Monads/Monads.v
@@ -102,6 +102,33 @@ Proof.
     + apply nat_trans_eq; try exact hs. exact H3.
 Qed.
 
+Let T0' := (functor_from_functor_with_μ C T): EndC.
+Let η' := η: EndC⟦functor_identity C, T0'⟧.
+Let μ' := μ: EndC⟦functor_compose _ _ T0' T0', T0'⟧.
+
+Definition Monad_laws_pointfree_in_functor_category : UU :=
+    (
+      (#(pre_composition_functor _ _ _ _ _ T0') η' · μ' = identity(C:=EndC) T0')
+        ×
+      (#(post_composition_functor _ _ _ _ _ T0') η' · μ' = identity(C:=EndC) T0'))
+        ×
+      (#(post_composition_functor _ _ _ _ _ T0') μ' · μ' = (#(pre_composition_functor _ _ _ _ _ T0') μ') · μ').
+
+(** we check the types of left-hand side and right-hand side of the last equation *)
+Goal
+  [C, C, hs] ⟦ post_composition_functor C C C hs hs T0' (functor_compose hs hs T0' T0'), T0' ⟧ =
+  [C, C, hs] ⟦ pre_composition_functor C C C hs hs T0' (functor_compose hs hs T0' T0'), T0' ⟧ .
+Proof.
+  apply idpath.
+Qed.
+
+(** the last variant of the laws is convertible with the one before *)
+Goal
+  Monad_laws_pointfree = Monad_laws_pointfree_in_functor_category.
+Proof.
+  apply idpath.
+Qed.
+
 End pointfree.
 
 Lemma isaprop_Monad_laws (C : precategory_data) (hs : has_homsets C) (T : Monad_data C) :

--- a/UniMath/CategoryTheory/Monads/Monads.v
+++ b/UniMath/CategoryTheory/Monads/Monads.v
@@ -64,8 +64,45 @@ Definition Monad_laws {C : precategory_data} (T : Monad_data C) : UU :=
       (∏ c : C, η T (T c) · μ T c = identity (T c))
         ×
       (∏ c : C, #T (η T c) · μ T c = identity (T c)))
-      ×
-    (∏ c : C, #T (μ T c) · μ T c = μ T (T c) · μ T c).
+        ×
+      (∏ c : C, #T (μ T c) · μ T c = μ T (T c) · μ T c).
+
+Section pointfree.
+
+  Context {C : precategory} (hs : has_homsets C) (T : Monad_data C).
+
+  Let EndC := [C, C, hs].
+
+  Let η := η T.
+  Let μ := μ T.
+  Let T0 := functor_from_functor_with_μ C T.
+
+Definition Monad_laws_pointfree : UU :=
+    (
+      (nat_trans_comp _ _ _ (pre_whisker T0 η) μ = identity(C:=EndC) T0)
+        ×
+      (nat_trans_comp _ _ _ (post_whisker η T0) μ = identity(C:=EndC) T0))
+        ×
+      (nat_trans_comp _ _ _ (post_whisker μ T0) μ = nat_trans_comp _ _ _ (pre_whisker T0 μ) μ).
+
+Lemma pointfree_is_equiv: Monad_laws_pointfree <-> Monad_laws T.
+Proof.
+  split.
+  - intro H. induction H as [[H1 H2] H3].
+    split.
+    + split.
+      * intro c. apply (maponpaths pr1) in H1. apply toforallpaths in H1. apply H1.
+      * intro c. apply (maponpaths pr1) in H2. apply toforallpaths in H2. apply H2.
+    + intro c. apply (maponpaths pr1) in H3. apply toforallpaths in H3. apply H3.
+  - intro H. induction H as [[H1 H2] H3].
+    split.
+    + split.
+      * apply nat_trans_eq; try exact hs. exact H1.
+      * apply nat_trans_eq; try exact hs. exact H2.
+    + apply nat_trans_eq; try exact hs. exact H3.
+Qed.
+
+End pointfree.
 
 Lemma isaprop_Monad_laws (C : precategory_data) (hs : has_homsets C) (T : Monad_data C) :
    isaprop (Monad_laws T).

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -210,7 +210,7 @@ Definition DatatypeOfBindingSig
   (IC : Initial C) (TC : Terminal C) (CLC : Colims_of_shape nat_graph C)
   (HF : ∏ (F : [C,C]), is_omega_cocont (constprod_functor1 F))
   (sig : BindingSig) (CC : Coproducts (BindingSigIndex sig) C) :
-  Initial (FunctorAlg (Id_H (BindingSigToSignature TC sig CC))).
+  Initial (FunctorAlg (Id_H (Presignature_Signature(BindingSigToSignature TC sig CC)))).
 Proof.
 apply SignatureInitialAlgebra; trivial.
 now apply is_omega_cocont_BindingSigToSignature.
@@ -298,7 +298,7 @@ intro i; apply is_omega_cocont_Arity_to_Signature.
 Defined.
 
 (** ** Construction of initial algebra for a signature with strength for HSET *)
-Definition SignatureInitialAlgebraHSET (s : Signature HSET has_homsets_HSET _ _ _ _) (Hs : is_omega_cocont s) :
+Definition SignatureInitialAlgebraHSET (s : Presignature HSET has_homsets_HSET _ _ _ _) (Hs : is_omega_cocont s) :
   Initial (FunctorAlg (Id_H _ _ BinCoproductsHSET s) has_homsets_HSET2).
 Proof.
 apply SignatureInitialAlgebra; try assumption.

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -370,7 +370,7 @@ Definition DatatypeOfBindingSig :
     (_ : ∏ (F : functor_precategory C C hsC),
             is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C BPC hsC) F))
     (sig : BindingSig) (CC : Coproducts (BindingSigIndex sig) C),
-  Initial (FunctorAlg (Id_H C hsC BCC (pr1(BindingSigToSignature hsC BPC BCC TC sig CC)))
+  Initial (FunctorAlg (Id_H C hsC BCC (pr1 (BindingSigToSignature hsC BPC BCC TC sig CC)))
                       (BindingSigToMonad.has_homsets_C2 hsC)).
 Proof.
 exact @UniMath.SubstitutionSystems.BindingSigToMonad.DatatypeOfBindingSig.

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -370,7 +370,7 @@ Definition DatatypeOfBindingSig :
     (_ : ∏ (F : functor_precategory C C hsC),
             is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C BPC hsC) F))
     (sig : BindingSig) (CC : Coproducts (BindingSigIndex sig) C),
-  Initial (FunctorAlg (Id_H C hsC BCC (UniMath.SubstitutionSystems.Signatures.Presignature_Signature (BindingSigToSignature hsC BPC BCC TC sig CC)))
+  Initial (FunctorAlg (Id_H C hsC BCC (pr1(BindingSigToSignature hsC BPC BCC TC sig CC)))
                       (BindingSigToMonad.has_homsets_C2 hsC)).
 Proof.
 exact @UniMath.SubstitutionSystems.BindingSigToMonad.DatatypeOfBindingSig.

--- a/UniMath/SubstitutionSystems/Lam.v
+++ b/UniMath/SubstitutionSystems/Lam.v
@@ -225,16 +225,16 @@ Defined.
 Lemma bracket_property_for_LamE_algebra_on_Lam (Z : Ptd)
   (f : Ptd ⟦ Z, ptd_from_alg LamE_algebra_on_Lam ⟧)
  :
-   bracket_property f (fbracket_for_LamE_algebra_on_Lam Z f).
+   bracket_property (nat_trans_fix_snd_arg _ _ _ _ _ (theta LamE_S) Z) _ f (fbracket_for_LamE_algebra_on_Lam Z f).
 Proof.
   (* Could we have this in a more declarative style? *)
-  assert (Hyp := pr2 (pr1 (pr2 LamHSS _ (f· bla)))).
+  assert (Hyp := pr2 (pr1 (pr2 LamHSS _ (f · bla)))).
   apply parts_from_whole in Hyp.
   apply whole_from_parts.
   split.
   - (* the "easy" eta part *)
     apply pr1 in Hyp.
-    apply (maponpaths (λ x, x· #U (inv_from_iso bla))) in Hyp.
+    apply (maponpaths (λ x, x · #U (inv_from_iso bla))) in Hyp.
     rewrite <- functor_comp in Hyp.
     rewrite <- assoc in Hyp.
     rewrite iso_inv_after_iso in Hyp.
@@ -422,14 +422,14 @@ Lemma bracket_for_LamE_algebra_on_Lam_unique (Z : Ptd)
            ⟦ functor_composite (U Z)
                (` LamE_algebra_on_Lam),
            `LamE_algebra_on_Lam ⟧,
-       bracket_property f h,
+       bracket_property (nat_trans_fix_snd_arg _ _ _ _ _ (theta LamE_S) Z) _ f h,
    t =
    tpair
      (λ h : [C, C, hs]
             ⟦ functor_composite (U Z)
                 (` LamE_algebra_on_Lam),
             `LamE_algebra_on_Lam ⟧,
-      bracket_property f h)
+      bracket_property (nat_trans_fix_snd_arg _ _ _ _ _ (theta LamE_S) Z) _ f h)
      (fbracket_for_LamE_algebra_on_Lam Z f) (bracket_property_for_LamE_algebra_on_Lam Z f).
 Proof.
   intro t.
@@ -488,7 +488,7 @@ Qed.
 Definition bracket_for_LamE_algebra_on_Lam_at (Z : Ptd)
   (f : Ptd ⟦ Z, ptd_from_alg LamE_algebra_on_Lam ⟧)
   :
-    bracket_at C hs CC LamE_S LamE_algebra_on_Lam f.
+    bracket_at C hs CC LamE_S (nat_trans_fix_snd_arg _ _ _ _ _ (theta LamE_S) Z) LamE_algebra_on_Lam f.
 Proof.
   use tpair.
   - exists (fbracket_for_LamE_algebra_on_Lam Z f).
@@ -496,7 +496,7 @@ Proof.
   - simpl; apply bracket_for_LamE_algebra_on_Lam_unique.
 Defined.
 
-Definition bracket_for_LamE_algebra_on_Lam : bracket LamE_algebra_on_Lam.
+Definition bracket_for_LamE_algebra_on_Lam : bracket (theta LamE_S) LamE_algebra_on_Lam.
 Proof.
   intros Z f.
   simpl.

--- a/UniMath/SubstitutionSystems/LamFromBindingSig.v
+++ b/UniMath/SubstitutionSystems/LamFromBindingSig.v
@@ -92,7 +92,7 @@ Definition LamFunctor : functor HSET2 HSET2 := Id_H LamSignature.
 
 Lemma lambdaFunctor_Initial : Initial (FunctorAlg LamFunctor has_homsets_HSET2).
 Proof.
-apply SignatureInitialAlgebraHSET, is_omega_cocont_BindingSigToSignatureHSET.
+apply (SignatureInitialAlgebraHSET(Presignature_Signature LamSignature)), is_omega_cocont_BindingSigToSignatureHSET.
 Defined.
 
 Definition LamMonad : Monad HSET := BindingSigToMonadHSET LamSig.

--- a/UniMath/SubstitutionSystems/LamFromBindingSig.v
+++ b/UniMath/SubstitutionSystems/LamFromBindingSig.v
@@ -92,7 +92,7 @@ Definition LamFunctor : functor HSET2 HSET2 := Id_H LamSignature.
 
 Lemma lambdaFunctor_Initial : Initial (FunctorAlg LamFunctor has_homsets_HSET2).
 Proof.
-apply (SignatureInitialAlgebraHSET(Presignature_Signature LamSignature)), is_omega_cocont_BindingSigToSignatureHSET.
+apply (SignatureInitialAlgebraHSET (Presignature_Signature LamSignature)), is_omega_cocont_BindingSigToSignatureHSET.
 Defined.
 
 Definition LamMonad : Monad HSET := BindingSigToMonadHSET LamSig.

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -265,7 +265,7 @@ Proof.
     apply idpath.
 Qed.
 
-Definition App_θ: nat_trans (θ_source App_H) (θ_target App_H) :=
+Definition App_θ: PrestrengthForSignature App_H :=
   tpair _ _ is_nat_trans_App_θ_data.
 
 Lemma App_θ_strength1_int: θ_Strength1_int App_θ.
@@ -479,7 +479,7 @@ Proof.
     apply (nat_trans_ax β).
 Qed.
 
-Definition Abs_θ: nat_trans (θ_source Abs_H) (θ_target Abs_H) :=
+Definition Abs_θ: PrestrengthForSignature Abs_H :=
   tpair _ _ is_nat_trans_Abs_θ_data.
 
 Lemma Abs_θ_strength1_int: θ_Strength1_int Abs_θ.
@@ -596,7 +596,7 @@ Proof.
   apply idpath.
 Qed.
 
-Definition Flat_θ: nat_trans (θ_source Flat_H) (θ_target Flat_H) :=
+Definition Flat_θ: PrestrengthForSignature Flat_H :=
   tpair _ _ is_nat_trans_Flat_θ_data.
 
 Lemma Flat_θ_strength1_int: θ_Strength1_int Flat_θ.

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -184,7 +184,7 @@ Defined.
 
 *)
 Definition Flat_H_ob (X: EndC): functor C C := functor_composite X X.
-Definition Flat_H_mor (X X': EndC)(α: X --> X'): (Flat_H_ob X: EndC) --> Flat_H_ob X' := α ∙∙ α.
+Definition Flat_H_mor (X X': EndC)(α: X --> X'): (Flat_H_ob X: EndC) --> Flat_H_ob X' := α ⋆ α.
 Definition Flat_H_functor_data: functor_data EndC EndC.
 Proof.
   exists Flat_H_ob.
@@ -560,8 +560,8 @@ Proof.
 (*  destruct XZ as [X [Z e]].
   simpl.
 *)
-  set (h:= nat_trans_comp (λ_functor_inv (pr1 XZ)) ((nat_trans_id _) ∙∙ (pr2 (pr2 XZ)))).
-  exact (nat_trans_comp (α_functor_inv (pr1 (pr2 XZ)) (pr1 XZ) (pr1 XZ)) (h ∙∙ (nat_trans_id (functor_composite (pr1 (pr2 XZ)) (pr1 XZ))))).
+  set (h:= nat_trans_comp (λ_functor_inv (pr1 XZ)) ((nat_trans_id _) ⋆ (pr2 (pr2 XZ)))).
+  exact (nat_trans_comp (α_functor_inv (pr1 (pr2 XZ)) (pr1 XZ) (pr1 XZ)) (h ⋆ (nat_trans_id (functor_composite (pr1 (pr2 XZ)) (pr1 XZ))))).
 Defined.
 
 Lemma is_nat_trans_Flat_θ_data: is_nat_trans _ _ Flat_θ_data.

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -404,7 +404,7 @@ Proof.
 Qed.
 
 Lemma bracket_Thm15_ok (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧):
- bracket_property_parts f ⦃f⦄.
+ bracket_property_parts (nat_trans_fix_snd_arg _ _ _ _ _ θ Z) _ f ⦃f⦄.
 Proof.
   split.
   + exact (bracket_Thm15_ok_part1 Z f).
@@ -412,7 +412,7 @@ Proof.
 Qed.
 
 Lemma bracket_Thm15_ok_cor (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧):
- bracket_property f (bracket_Thm15 Z f).
+ bracket_property (nat_trans_fix_snd_arg _ _ _ _ _ θ Z) _ f (bracket_Thm15 Z f).
 Proof.
   apply whole_from_parts.
   apply bracket_Thm15_ok.
@@ -421,14 +421,14 @@ Qed.
 Local Lemma foo' (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
  ∏ t : ∑ h : [C, C, hs] ⟦ functor_composite (U Z) (pr1  InitAlg),
                          pr1 InitAlg ⟧,
-       bracket_property f h,
+       bracket_property (nat_trans_fix_snd_arg _ _ _ _ _ θ Z) _ f h,
    t
    =
    tpair
      (λ h : [C, C, hs]
             ⟦ functor_composite (U Z) (pr1 InitAlg),
               pr1 InitAlg ⟧,
-       bracket_property f h)
+       bracket_property (nat_trans_fix_snd_arg _ _ _ _ _ θ Z) _ f h)
       ⦃f⦄ (bracket_Thm15_ok_cor Z f).
 Proof.
   intros [h' h'_eq].
@@ -484,7 +484,7 @@ Proof.
       apply BinCoproductIn2Commutes.
 Qed.
 
-Definition bracket_for_InitAlg : bracket InitAlg.
+Definition bracket_for_InitAlg : bracket θ InitAlg.
 Proof.
   intros Z f.
   use tpair.
@@ -807,7 +807,7 @@ Proof.
         apply maponpaths.
         rewrite assoc.
         eapply pathsinv0.
-        assert (fbracket_τ_inst := fbracket_τ T' (f· ptd_from_alg_mor _ hs CP H β0)).
+        assert (fbracket_τ_inst := fbracket_τ T' (f · ptd_from_alg_mor _ hs CP H β0)).
         assert (fbracket_τ_inst_c := nat_trans_eq_pointwise fbracket_τ_inst c); clear fbracket_τ_inst.
         apply fbracket_τ_inst_c.
       simpl.
@@ -818,11 +818,11 @@ Proof.
       assert (Hyp:
                  ((# (pr1 (ℓ(U Z))) (# H β))·
                  (theta H) ((alg_carrier _  T') ⊗ Z)·
-                 # H (fbracket T' (f· ptd_from_alg_mor C hs CP H β0))
+                 # H (fbracket T' (f · ptd_from_alg_mor C hs CP H β0))
                  =
                  θ (tpair (λ _ : functor C C, ptd_obj C) (alg_carrier _ (InitialObject IA)) Z) ·
                  # H (# (pr1 (ℓ(U Z))) β ·
-                 fbracket T' (f· ptd_from_alg_mor C hs CP H β0)))).
+                 fbracket T' (f · ptd_from_alg_mor C hs CP H β0)))).
       2: { assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp.
            exact Hyp_c. }
       clear c. clear X. clear rhohat.
@@ -837,15 +837,9 @@ Proof.
       clear θ_nat_1_pointwise_inst.
       simpl.
       apply maponpaths.
-      assert (Hyp: # H (β ∙∙ nat_trans_id (pr1 Z)) = # H (# (pr1 (ℓ(U Z))) β)).
-      { apply maponpaths.
-        apply nat_trans_eq; try (exact hs).
-        intro c'.
-        simpl.
-        rewrite functor_id.
-        apply id_right. }
-      apply (nat_trans_eq_pointwise Hyp c).
-Qed.
+      rewrite horcomp_id_prewhisker; try exact hs.
+      apply idpath.
+ Qed.
 
 Definition hss_InitMor : ∏ T' : hss CP H, hssMor InitHSS T'.
 Proof.
@@ -858,7 +852,7 @@ Lemma hss_InitMor_unique (T' : hss_precategory CP H):
   ∏ t : hss_precategory CP H ⟦ InitHSS, T' ⟧, t = hss_InitMor T'.
 Proof.
   intro t.
-  apply (invmap (hssMor_eq1 _ _ _ _ _ _ _ _ )).
+  apply (invmap (hssMor_eq1 _ _ _ _ _ _ _ _)).
   apply (@InitialArrowUnique _ IA (pr1 T') (pr1 t)).
 Qed.
 

--- a/UniMath/SubstitutionSystems/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial_alt.v
@@ -2,8 +2,8 @@
 
 Contents:
 
-- Construction of a substitution system from an initial algebra Proof that the substitution system
-- Constructed from an initial algebra is an initial substitution system
+- Construction of a substitution system from an initial algebra
+- Proof that the substitution system constructed from an initial algebra is an initial substitution system
 
 This file differs from LiftingInitial.v in the hypotheses. Here we use omega cocontinuity instead of
 Kan extensions.
@@ -52,7 +52,6 @@ Section category_Algebra.
 
 Variables (C : precategory) (hsC : has_homsets C) (CP : BinCoproducts C).
 Variables (IC : Initial C) (CC : Colims_of_shape nat_graph C).
-Variables (H : Presignature C hsC C hsC C hsC) (HH : is_omega_cocont H).
 
 Local Notation "'EndC'":= ([C, C, hsC]) .
 Local Notation "'Ptd'" := (precategory_Ptd C hsC).
@@ -61,15 +60,6 @@ Let hsEndC : has_homsets EndC := functor_category_has_homsets C C hsC.
 Let CPEndC : BinCoproducts EndC := BinCoproducts_functor_precat _ _ CP hsC.
 Let EndEndC := [EndC, EndC, hsEndC].
 Let CPEndEndC:= BinCoproducts_functor_precat _ _ CPEndC hsEndC: BinCoproducts EndEndC.
-Let θ := theta H.
-
-Definition Const_plus_H (X : EndC) : functor EndC EndC
-  := BinCoproduct_of_functors _ _ CPEndC (constant_functor _ _ X) H.
-
-Definition Id_H :  functor [C, C, hsC] [C, C, hsC]
- := Const_plus_H (functor_identity _ : EndC).
-
-Let Alg : precategory := FunctorAlg Id_H hsEndC.
 
 Let InitialEndC : Initial EndC.
 Proof.
@@ -80,6 +70,18 @@ Let Colims_of_shape_nat_graph_EndC : Colims_of_shape nat_graph EndC.
 Proof.
 apply ColimsFunctorCategory_of_shape, CC.
 Defined.
+
+Section fix_an_H.
+
+  Context (H : functor [C, C, hsC] [C, C, hsC]) (HH : is_omega_cocont H).
+
+  Definition Const_plus_H (X : EndC) : functor EndC EndC
+    := BinCoproduct_of_functors _ _ CPEndC (constant_functor _ _ X) H.
+
+  Definition Id_H :  functor [C, C, hsC] [C, C, hsC]
+    := Const_plus_H (functor_identity _ : EndC).
+
+  Let Alg : precategory := FunctorAlg Id_H hsEndC.
 
 Lemma is_omega_cocont_Id_H : is_omega_cocont Id_H.
 Proof.
@@ -93,7 +95,11 @@ Definition InitAlg : Alg :=
 
 Definition ptdInitAlg : Ptd := ptd_from_alg InitAlg.
 
-Lemma isInitial_pre_comp (Z : Ptd) : isInitial [C, C, hsC] (ℓ (U Z) InitialEndC).
+Section fix_a_Z.
+
+  Context (Z : Ptd).
+
+Lemma isInitial_pre_comp : isInitial [C, C, hsC] (ℓ (U Z) InitialEndC).
 Proof.
 use make_isInitial; intros F.
 use tpair.
@@ -105,28 +111,23 @@ use tpair.
     | apply funextsec; intro c; apply InitialArrowUnique]).
 Defined.
 
-Local Lemma HU (Z : Ptd) : is_omega_cocont (pre_composition_functor C C C hsC hsC (U Z)).
+Local Lemma HU : is_omega_cocont (pre_composition_functor C C C hsC hsC (U Z)).
 Proof.
 apply is_omega_cocont_pre_composition_functor, CC.
 Defined.
 
-Definition SpecializedGMIt (Z : Ptd) (X : EndC) :
+Definition SpecializedGMIt (X : EndC) :
   ∏ (G : functor [C, C, hsC] [C, C, hsC]) (ρ : [C, C, hsC] ⟦ G X, X ⟧)
     (θ : functor_composite Id_H (ℓ (U Z)) ⟹ functor_composite (ℓ (U Z)) G),
   ∃! h : [C, C, hsC] ⟦ ℓ (U Z) (alg_carrier _ InitAlg), X ⟧,
     # (ℓ (U Z)) (alg_map Id_H InitAlg) · h =
     θ (alg_carrier _ InitAlg) · # G h · ρ
   := SpecialGenMendlerIteration hsEndC InitialEndC Colims_of_shape_nat_graph_EndC
-                                Id_H is_omega_cocont_Id_H hsEndC X (ℓ (U Z)) (isInitial_pre_comp Z) (HU Z).
+                                Id_H is_omega_cocont_Id_H hsEndC X (ℓ (U Z)) isInitial_pre_comp HU.
 
-Definition θ_in_first_arg (Z: Ptd)
-  : functor_fix_snd_arg [C, C,hsC] Ptd [C, C, hsC] (θ_source H) Z
-    ⟹
-    functor_fix_snd_arg [C, C, hsC] Ptd [C, C, hsC] (θ_target H) Z
-  := nat_trans_fix_snd_arg _ _ _ _ _ θ Z.
+Context (prestrength_in_first_arg : PrestrengthForSignatureAtPoint _ _ _ _ _ _ H Z).
 
-
-Local Lemma aux_iso_1_is_nat_trans (Z : Ptd) :
+Local Lemma aux_iso_1_is_nat_trans :
    is_nat_trans
      (functor_composite Id_H (ℓ (U Z)))
      (pr1 (BinCoproductObject EndEndC
@@ -145,7 +146,7 @@ eapply pathscomp0; [|eapply pathsinv0, BinCoproductOfArrows_comp]; simpl.
 now rewrite functor_id, !id_left, !id_right.
 Qed.
 
-Definition aux_iso_1 (Z : Ptd)
+Definition aux_iso_1
   : EndEndC
     ⟦ functor_composite Id_H (ℓ (U Z)),
       BinCoproductObject EndEndC
@@ -156,10 +157,10 @@ use tpair.
 - intro X.
   exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (ρ_functor (U Z))
            (nat_trans_id (θ_source H (X⊗Z):functor C C))).
-- exact (aux_iso_1_is_nat_trans Z).
+- exact aux_iso_1_is_nat_trans.
 Defined.
 
-Local Lemma aux_iso_1_inv_is_nat_trans (Z : Ptd) :
+Local Lemma aux_iso_1_inv_is_nat_trans :
    is_nat_trans
      (pr1 (BinCoproductObject EndEndC
         (CPEndEndC (constant_functor [C, C, hsC] [C, C, hsC] (U Z))
@@ -178,7 +179,7 @@ eapply pathscomp0;[|eapply pathsinv0, BinCoproductOfArrows_comp]; simpl.
 now rewrite functor_id, !id_left, !id_right.
 Qed.
 
-Local Definition aux_iso_1_inv (Z: Ptd)
+Local Definition aux_iso_1_inv
   : EndEndC
     ⟦ BinCoproductObject EndEndC
            (CPEndEndC (constant_functor [C, C, hsC] [C, C, hsC] (U Z))
@@ -189,10 +190,10 @@ use tpair.
 - intro X.
   exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (λ_functor (U Z))
          (nat_trans_id (θ_source H (X⊗Z):functor C C))).
-- exact (aux_iso_1_inv_is_nat_trans Z).
+- exact aux_iso_1_inv_is_nat_trans.
 Defined.
 
-Local Lemma aux_iso_2_inv_is_nat_trans (Z : Ptd) :
+Local Lemma aux_iso_2_inv_is_nat_trans :
    is_nat_trans
      (pr1 (BinCoproductObject EndEndC
         (CPEndEndC (constant_functor [C, C, hsC] [C, C, hsC] (U Z))
@@ -216,7 +217,7 @@ apply (nat_trans_eq hsC); intro c; simpl.
 now rewrite <- (nat_trans_ax α), functor_id, id_left.
 Qed.
 
-Local Definition aux_iso_2_inv (Z : Ptd)
+Local Definition aux_iso_2_inv
   : EndEndC
     ⟦ BinCoproductObject EndEndC
          (CPEndEndC (constant_functor [C, C, hsC] [C, C, hsC] (U Z))
@@ -227,10 +228,10 @@ use tpair.
 - intro X.
   exact (nat_trans_id ((@BinCoproductObject EndC (U Z) (θ_target H (X⊗Z)) (CPEndC _ _) )
            : functor C C)).
-- exact (aux_iso_2_inv_is_nat_trans Z).
+- exact aux_iso_2_inv_is_nat_trans.
 Defined.
 
-Definition θ'_Thm15 (Z: Ptd)
+Definition θ'_Thm15
   : EndEndC
     ⟦ BinCoproductObject EndEndC
         (CPEndEndC (constant_functor [C, C, hsC] [C, C, hsC] (U Z))
@@ -241,9 +242,9 @@ Definition θ'_Thm15 (Z: Ptd)
   := BinCoproductOfArrows
    EndEndC (CPEndEndC _ _) (CPEndEndC _ _)
    (identity (constant_functor EndC _ (U Z): functor_precategory EndC EndC hsEndC))
-   (θ_in_first_arg Z).
+   prestrength_in_first_arg.
 
-Definition ρ_Thm15 (Z: Ptd)(f : Ptd ⟦ Z, ptdInitAlg ⟧)
+Definition ρ_Thm15 (f : Ptd ⟦ Z, ptdInitAlg ⟧)
   : [C, C, hsC] ⟦ BinCoproductObject [C, C, hsC] (CPEndC (U Z) (H `InitAlg)), `InitAlg ⟧
   := @BinCoproductArrow
    EndC _ _  (CPEndC (U Z)
@@ -251,32 +252,32 @@ Definition ρ_Thm15 (Z: Ptd)(f : Ptd ⟦ Z, ptdInitAlg ⟧)
    (BinCoproductIn2 _ (CPEndC _ _) · (alg_map _ InitAlg)).
 
 
-Definition SpecializedGMIt_Thm15 (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧)
+Definition SpecializedGMIt_Thm15 (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧)
   : ∃! h : [C, C, hsC]
               ⟦ ℓ (U Z) (pr1 InitAlg),
               pr1 InitAlg ⟧,
        # (ℓ (U Z)) (alg_map Id_H InitAlg) · h =
-       pr1 (aux_iso_1 Z · θ'_Thm15 Z · aux_iso_2_inv Z)
+       pr1 (aux_iso_1 · θ'_Thm15 · aux_iso_2_inv)
          (pr1 InitAlg) ·
-       # (Const_plus_H (U Z)) h · ρ_Thm15 Z f :=
-   (SpecializedGMIt Z (pr1 InitAlg) (Const_plus_H (U Z))
-     (ρ_Thm15 Z f) (aux_iso_1 Z · θ'_Thm15 Z · aux_iso_2_inv Z)).
+       # (Const_plus_H (U Z)) h · ρ_Thm15 f :=
+   (SpecializedGMIt (pr1 InitAlg) (Const_plus_H (U Z))
+     (ρ_Thm15 f) (aux_iso_1 · θ'_Thm15 · aux_iso_2_inv)).
 
-Definition bracket_Thm15 (Z: Ptd)(f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧)
+Definition bracket_Thm15 (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧)
   : [C, C, hsC]
        ⟦ ℓ (U Z) (pr1 InitAlg), pr1 InitAlg ⟧
-  := pr1 (pr1 (SpecializedGMIt_Thm15 Z f)).
+  := pr1 (pr1 (SpecializedGMIt_Thm15 f)).
 
-Notation "⦃ f ⦄" := (bracket_Thm15 _ f) (at level 0).
+Notation "⦃ f ⦄" := (bracket_Thm15 f) (at level 0).
 
 (* we prove the individual components for ease of compilation *)
-Lemma bracket_Thm15_ok_part1 (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
+Lemma bracket_Thm15_ok_part1 (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
  # U f = # (pr1 (ℓ (U Z))) (η InitAlg) · ⦃f⦄.
 Proof.
 apply (nat_trans_eq hsC); intro c.
-assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))).
+assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 f))).
 assert (h_eq' := maponpaths (λ m,
-               (((aux_iso_1_inv Z):(_⟹_)) _)· m) h_eq); clear h_eq.
+               ((aux_iso_1_inv:(_⟹_)) _)· m) h_eq); clear h_eq.
 assert (h_eq1' := maponpaths (λ m,
                (BinCoproductIn1 EndC (CPEndC _ _))· m) h_eq'); clear h_eq'.
 assert (h_eq1'_inst := nat_trans_eq_pointwise h_eq1' c); clear h_eq1'.
@@ -292,14 +293,14 @@ eapply pathscomp0, pathscomp0; [|apply (!h_eq1'_inst)|]; clear h_eq1'_inst.
   now rewrite id_left, assoc.
 Qed.
 
-Lemma bracket_Thm15_ok_part2 (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
-  (theta H) ((alg_carrier _ InitAlg) ⊗ Z) ·  # H ⦃f⦄ · τ InitAlg =
+Lemma bracket_Thm15_ok_part2 (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
+  prestrength_in_first_arg (alg_carrier _ InitAlg) ·  # H ⦃f⦄ · τ InitAlg =
   # (pr1 (ℓ (U Z))) (τ InitAlg) · ⦃f⦄.
 Proof.
 apply (nat_trans_eq hsC); intro c.
-assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 Z f))).
+assert (h_eq := pr2 (pr1 (SpecializedGMIt_Thm15 f))).
 assert (h_eq' := maponpaths (λ m,
-                (((aux_iso_1_inv Z):(_⟹_)) _)· m) h_eq); clear h_eq.
+                ((aux_iso_1_inv:(_⟹_)) _)· m) h_eq); clear h_eq.
 (* until here same as in previous lemma *)
 assert (h_eq2' := maponpaths (λ m,
                 (BinCoproductIn2 EndC (CPEndC _ _))· m) h_eq');  clear h_eq'.
@@ -319,24 +320,24 @@ eapply pathscomp0, pathscomp0; [|apply (!h_eq2'_inst)|]; clear h_eq2'_inst.
   now rewrite id_left; apply assoc.
 Qed.
 
-Lemma bracket_Thm15_ok (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
-  bracket_property_parts f ⦃f⦄.
+Lemma bracket_Thm15_ok (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
+  bracket_property_parts prestrength_in_first_arg InitAlg f ⦃f⦄.
 Proof.
 split.
-+ exact (bracket_Thm15_ok_part1 Z f).
-+ exact (bracket_Thm15_ok_part2 Z f).
++ exact (bracket_Thm15_ok_part1 f).
++ exact (bracket_Thm15_ok_part2 f).
 Qed.
 
-Lemma bracket_Thm15_ok_cor (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
- bracket_property f (bracket_Thm15 Z f).
+Lemma bracket_Thm15_ok_cor (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
+ bracket_property prestrength_in_first_arg InitAlg f (bracket_Thm15 f).
 Proof.
 now apply whole_from_parts, bracket_Thm15_ok.
 Qed.
 
-Local Lemma bracket_unique (Z : Ptd) (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
+Local Lemma bracket_unique (f : Ptd ⟦ Z, ptd_from_alg InitAlg ⟧) :
  ∏ t : ∑ h : [C, C, hsC] ⟦ functor_composite (U Z) (pr1  InitAlg),
-                            pr1 InitAlg ⟧, bracket_property f h,
-   t = tpair _ ⦃f⦄ (bracket_Thm15_ok_cor Z f).
+                            pr1 InitAlg ⟧, bracket_property prestrength_in_first_arg InitAlg f h,
+   t = tpair _ ⦃f⦄ (bracket_Thm15_ok_cor f).
 Proof.
 intros [h' h'_eq]; apply subtypePath; [intro; apply (isaset_nat_trans hsC)|].
 simpl; apply parts_from_whole in h'_eq.
@@ -359,13 +360,23 @@ apply BinCoproductArrowUnique.
   now apply maponpaths, maponpaths, pathsinv0, BinCoproductIn2Commutes.
 Qed.
 
-Definition bracket_for_InitAlg : bracket InitAlg.
+End fix_a_Z.
+
+End fix_an_H.
+
+Context (H :  @Presignature C hsC C hsC C hsC) (HH : is_omega_cocont H).
+Let Id_H := Id_H H.
+Let θ := theta H.
+Let InitAlg := InitAlg H HH.
+Let ptdInitAlg := ptdInitAlg H HH.
+
+Definition bracket_for_InitAlg : bracket θ InitAlg.
 Proof.
 intros Z f.
 use tpair.
 - use tpair.
-  + exact (bracket_Thm15 Z f).
-  + exact (bracket_Thm15_ok_cor Z f).
+  + exact (bracket_Thm15 H HH Z (nat_trans_fix_snd_arg _ _ _ _ _ θ Z) f).
+  + exact (bracket_Thm15_ok_cor H HH Z (nat_trans_fix_snd_arg _ _ _ _ _ θ Z) f).
     (* B: better to prove the whole outside, and apply it here *)
     (* when the first components were not opaque, the following proof
        became extremely slow *)
@@ -382,7 +393,7 @@ exists InitAlg.
 exact bracket_for_InitAlg.
 Defined.
 
-Local Definition Ghat : EndEndC := Const_plus_H (pr1 InitAlg).
+Local Definition Ghat : EndEndC := Const_plus_H H (pr1 InitAlg).
 
 Definition constant_nat_trans (C' D : precategory)
    (hsD : has_homsets D) (d d' : D) (m : D⟦d,d'⟧)
@@ -403,14 +414,14 @@ Definition thetahat_0 (Z : Ptd) (f : Z --> ptdInitAlg) :
 Proof.
 exact (BinCoproductOfArrows EndEndC (CPEndEndC _ _) (CPEndEndC _ _)
                            (constant_nat_trans _ _ hsEndC _ _ (#U f))
-                           (θ_in_first_arg Z)).
+                           (nat_trans_fix_snd_arg _ _ _ _ _ θ Z)).
 Defined.
 
 Local Definition iso1' (Z : Ptd) : EndEndC ⟦ functor_composite Id_H (ℓ (U Z)),
  BinCoproductObject _
     (CPEndEndC (constant_functor _ _  (U Z)) (functor_fix_snd_arg _ _ _ (θ_source H) Z)) ⟧.
 Proof.
-exact (aux_iso_1 Z).
+exact (aux_iso_1 H Z).
 Defined.
 
 Local Lemma is_nat_trans_iso2' (Z : Ptd) :
@@ -479,7 +490,7 @@ use tpair.
             apply assoc').
 Defined.
 
-Let IA := colimAlgInitial hsEndC InitialEndC is_omega_cocont_Id_H (Colims_of_shape_nat_graph_EndC _).
+Let IA := colimAlgInitial hsEndC InitialEndC (is_omega_cocont_Id_H H HH) (Colims_of_shape_nat_graph_EndC _).
 
 Lemma ishssMor_InitAlg (T' : hss CP H) :
   @ishssMor C hsC CP H InitHSS T'
@@ -490,12 +501,12 @@ set (β0 := InitialArrow IA (pr1 T')).
 match goal with | [|- _ · ?b = _ ] => set (β := b) end.
 set (rhohat := BinCoproductArrow EndC  (CPEndC _ _ )  β (tau_from_alg T')
                 :  pr1 Ghat T' --> T').
-set (X:= SpecializedGMIt Z _ Ghat rhohat (thetahat Z f)).
+set (X:= SpecializedGMIt H HH Z _ Ghat rhohat (thetahat Z f)).
 intermediate_path (pr1 (pr1 X)).
 - set (TT := @fusion_law EndC hsEndC InitialEndC Colims_of_shape_nat_graph_EndC
-                         Id_H is_omega_cocont_Id_H _ hsEndC (pr1 (InitAlg)) T').
-  set (Psi := ψ_from_comps (Id_H) hsEndC _ (ℓ (U Z)) (Const_plus_H (U Z)) (ρ_Thm15 Z f)
-                             (aux_iso_1 Z · θ'_Thm15 Z · aux_iso_2_inv Z) ).
+                         Id_H (is_omega_cocont_Id_H H HH) _ hsEndC (pr1 (InitAlg)) T').
+  set (Psi := ψ_from_comps (Id_H) hsEndC _ (ℓ (U Z)) (Const_plus_H H (U Z)) (ρ_Thm15 H HH Z f)
+                             (aux_iso_1 H Z · θ'_Thm15 H Z (nat_trans_fix_snd_arg _ _ _ _ _ θ Z) · aux_iso_2_inv H Z) ).
   set (T2 := TT _ (HU Z) (isInitial_pre_comp Z) Psi).
   set (T3 := T2 (ℓ (U Z)) (HU Z)).
   set (Psi' := ψ_from_comps (Id_H) hsEndC _ (ℓ (U Z)) (Ghat) (rhohat)
@@ -559,7 +570,7 @@ intermediate_path (pr1 (pr1 X)).
         [| apply maponpaths, BinCoproductIn1Commutes_right_in_ctx_dir; simpl;
            rewrite id_left; apply BinCoproductIn1Commutes_right_dir, idpath].
       rewrite !assoc.
-      assert (fbracket_η_inst_c := nat_trans_eq_pointwise (fbracket_η T' (f· ptd_from_alg_mor _ hsC CP H β0)) c).
+      assert (fbracket_η_inst_c := nat_trans_eq_pointwise (fbracket_η T' (f · ptd_from_alg_mor _ hsC CP H β0)) c).
       eapply pathscomp0; [| apply (!fbracket_η_inst_c)].
       apply cancel_postcomposition, (ptd_mor_commutes _ (ptd_from_alg_mor _ hsC CP H β0) ((pr1 Z) c)).
     + (* now the difficult case *)
@@ -597,7 +608,7 @@ intermediate_path (pr1 (pr1 X)).
         apply maponpaths.
         rewrite assoc.
         eapply pathsinv0.
-        assert (fbracket_τ_inst := fbracket_τ T' (f· ptd_from_alg_mor _ hsC CP H β0)).
+        assert (fbracket_τ_inst := fbracket_τ T' (f · ptd_from_alg_mor _ hsC CP H β0)).
         assert (fbracket_τ_inst_c := nat_trans_eq_pointwise fbracket_τ_inst c); clear fbracket_τ_inst.
         apply fbracket_τ_inst_c.
       simpl.
@@ -607,12 +618,12 @@ intermediate_path (pr1 (pr1 X)).
       apply cancel_postcomposition.
       assert (Hyp:
                  ((# (pr1 (ℓ(U Z))) (# H β))·
-                 (theta H) ((alg_carrier _  T') ⊗ Z)·
-                 # H (fbracket T' (f· ptd_from_alg_mor C hsC CP H β0))
+                 θ ((alg_carrier _  T') ⊗ Z)·
+                 # H (fbracket T' (f · ptd_from_alg_mor C hsC CP H β0))
                  =
                  θ (tpair (λ _ : functor C C, ptd_obj C) (alg_carrier _ (InitialObject IA)) Z) ·
                  # H (# (pr1 (ℓ(U Z))) β ·
-                 fbracket T' (f· ptd_from_alg_mor C hsC CP H β0)))).
+                 fbracket T' (f · ptd_from_alg_mor C hsC CP H β0)))).
       2: { assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp.
            exact Hyp_c. }
       clear c. clear X. clear rhohat.
@@ -625,10 +636,8 @@ intermediate_path (pr1 (pr1 X)).
       clear θ_nat_1_pointwise_inst.
       simpl.
       apply maponpaths.
-      assert (Hyp: # H (β ∙∙ nat_trans_id (pr1 Z)) = # H (# (pr1 (ℓ(U Z))) β)).
-      { apply maponpaths, (nat_trans_eq hsC); intro c'; simpl.
-        now rewrite functor_id, id_right. }
-      now apply (nat_trans_eq_pointwise Hyp c).
+      rewrite horcomp_id_prewhisker; try exact hsC.
+      apply idpath.
 Qed.
 
 Definition hss_InitMor : ∏ T' : hss CP H, hssMor InitHSS T'.
@@ -642,7 +651,7 @@ Lemma hss_InitMor_unique (T' : hss_precategory CP H):
   ∏ t : hss_precategory CP H ⟦ InitHSS, T' ⟧, t = hss_InitMor T'.
 Proof.
 intro t.
-apply (invmap (hssMor_eq1 _ _ _ _ _ _ _ _ )).
+apply (invmap (hssMor_eq1 _ _ _ _ _ _ _ _)).
 apply (@InitialArrowUnique _ IA (pr1 T') (pr1 t)).
 Qed.
 

--- a/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
@@ -200,7 +200,7 @@ Proof.
   intro c.
   intermediate_path (μ_1 c).
   - unfold μ_1.
-    assert (H':= @fbracket_unique_target_pointwise _ _  _ _ T).
+    assert (H':= @fbracket_unique_target_pointwise _ _ _ _ T).
     assert (H1:= H'  _ μ_0_ptd).
     set (x:= post_whisker μ_0 (`T)
              : EndC ⟦ `T • functor_identity _  , `T • `T ⟧).
@@ -317,7 +317,7 @@ Lemma μ_3_T_μ_2_μ_2 : μ_3 =
                       (`T ∘ μ_2 : EndC ⟦ `T • _  , `T • `T ⟧ ) · μ_2.
 Proof.
   apply pathsinv0.
-  apply (fbracket_unique T  μ_2_ptd).
+  apply (fbracket_unique T μ_2_ptd).
   split.
   - apply nat_trans_eq; try assumption.
     intro c.

--- a/UniMath/SubstitutionSystems/Notation.v
+++ b/UniMath/SubstitutionSystems/Notation.v
@@ -45,7 +45,7 @@ Arguments nat_trans_comp {_ _ _ _ _} _ _ .
 Declare Scope subsys.
 Delimit Scope subsys with subsys.
 Notation "G • F" := (functor_composite F G : [ _ , _ , _ ]) (at level 35) : subsys.
-Notation "α ∙∙ β" := (horcomp β α) (at level 20) : subsys.
+Notation "α ⋆ β" := (horcomp β α) (at level 20) : subsys.
 
 Notation "α 'ø' Z" := (pre_whisker Z α)  (at level 25) : subsys.
 Notation "Z ∘ α" := (post_whisker α Z) : subsys.

--- a/UniMath/SubstitutionSystems/SignatureCategory.v
+++ b/UniMath/SubstitutionSystems/SignatureCategory.v
@@ -62,8 +62,8 @@ Variables (Ht Ht' : Signature C hsC D hsD D' hsD').
 
 Let H := Signature_Functor Ht.
 Let H' := Signature_Functor Ht'.
-Let θ : nat_trans (θ_source Ht) (θ_target Ht) := theta Ht.
-Let θ' : nat_trans (θ_source Ht') (θ_target Ht') := theta Ht'.
+Let θ : PrestrengthForSignature Ht := theta Ht.
+Let θ' : PrestrengthForSignature Ht' := theta Ht'.
 
 Variables (α : nat_trans H H').
 

--- a/UniMath/SubstitutionSystems/SignatureCategory.v
+++ b/UniMath/SubstitutionSystems/SignatureCategory.v
@@ -73,7 +73,7 @@ Variables (X : [C,D']) (Y : Ptd).
 Let f1 : [C,D] ⟦H X • U Y,H (X • U Y)⟧ := θ (X,,Y).
 Let f2 : [C,D] ⟦H (X • U Y),H' (X • U Y)⟧ := α (X • U Y).
 
-Let g1 : [C,D] ⟦H X • U Y,H' X • U Y⟧ := α X ∙∙ identity (U Y).
+Let g1 : [C,D] ⟦H X • U Y,H' X • U Y⟧ := α X ⋆ identity (U Y).
 Let g2 : [C,D] ⟦H' X • U Y,H' (X • U Y)⟧ := θ' (X,,Y).
 
 Definition Signature_category_mor_diagram : UU := f1 · f2 = g1 · g2.
@@ -112,7 +112,7 @@ Proof.
   rewrite (assoc ((theta Ht1) (X,,Y))).
   etrans; [apply (cancel_postcomposition ((theta Ht1) (X,,Y) · _)), Hα|].
   rewrite <- assoc; etrans; [apply maponpaths, Hβ|].
-  rewrite assoc; apply (cancel_postcomposition (C:=[C,D]) _  (_ ∙∙ identity (U Y))).
+  rewrite assoc; apply (cancel_postcomposition (C:=[C,D]) _  (_ ⋆ identity (U Y))).
   apply (nat_trans_eq hsD); intro c; simpl.
   now rewrite assoc, !functor_id, !id_right.
 Qed.

--- a/UniMath/SubstitutionSystems/Signatures.v
+++ b/UniMath/SubstitutionSystems/Signatures.v
@@ -272,8 +272,8 @@ End Strength_law_2_intensional.
     naturality in each component here *)
 
 Lemma θ_nat_1 (X X' : [C, D', hsD']) (α : X --> X') (Z : Ptd)
-  : compose (C := [C, D, hsD]) (# H α ∙∙ nat_trans_id (pr1 (U Z))) (θ (X' ⊗ Z)) =
-        θ (X ⊗ Z) · # H (α ∙∙ nat_trans_id (pr1 (U Z))).
+  : compose (C := [C, D, hsD]) (# H α ⋆ nat_trans_id (pr1 (U Z))) (θ (X' ⊗ Z)) =
+        θ (X ⊗ Z) · # H (α ⋆ nat_trans_id (pr1 (U Z))).
 Proof.
   set (t := nat_trans_ax θ).
   set (t' := t (X ⊗ Z) (X' ⊗ Z)).
@@ -292,7 +292,7 @@ Abort.
 
 Lemma θ_nat_1_pointwise (X X' : [C, D', hsD']) (α : X --> X') (Z : Ptd) (c : C)
   :  pr1 (# H α) ((pr1 Z) c) · pr1 (θ (X' ⊗ Z)) c =
-       pr1 (θ (X ⊗ Z)) c · pr1 (# H (α ∙∙ nat_trans_id (pr1 Z))) c.
+       pr1 (θ (X ⊗ Z)) c · pr1 (# H (α ⋆ nat_trans_id (pr1 Z))) c.
 Proof.
   assert (t := θ_nat_1 _ _ α Z).
   assert (t' := nat_trans_eq_weq hsD _ _ t c).
@@ -312,8 +312,8 @@ Proof.
 Qed.
 
 Lemma θ_nat_2 (X : [C, D', hsD']) (Z Z' : Ptd) (f : Z --> Z')
-  : compose (C := [C, D, hsD]) (identity (H X) ∙∙ pr1 f) (θ (X ⊗ Z')) =
-       θ (X ⊗ Z) · # H (identity X ∙∙ pr1 f).
+  : compose (C := [C, D, hsD]) (identity (H X) ⋆ pr1 f) (θ (X ⊗ Z')) =
+       θ (X ⊗ Z) · # H (identity X ⋆ pr1 f).
 Proof.
   set (t := nat_trans_ax θ).
   set (t' := t (X ⊗ Z) (X ⊗ Z') (precatbinprodmor (identity _ ) f)).
@@ -328,7 +328,7 @@ Qed.
 
 Lemma θ_nat_2_pointwise (X : [C, D', hsD']) (Z Z' : Ptd) (f : Z --> Z') (c : C)
   :  # (pr1 (H X)) ((pr1 f) c) · pr1 (θ (X ⊗ Z')) c =
-       pr1 (θ (X ⊗ Z)) c · pr1 (# H (identity X ∙∙ pr1 f)) c .
+       pr1 (θ (X ⊗ Z)) c · pr1 (# H (identity X ⋆ pr1 f)) c .
 Proof.
   set (t := θ_nat_2 X _ _ f).
   set (t' := nat_trans_eq_weq hsD _ _ t c).
@@ -406,7 +406,7 @@ Local Definition forget := forgetful_functor_from_ptd_as_strong_monoidal_functor
 Local Lemma auxH1 (H : functor [C, C, hs] [C, C, hs]) (X : functor C C) :
   # H
     (nat_trans_id (pr1 X)
-        ∙∙ nat_z_iso_to_trans_inv
+        ⋆ nat_z_iso_to_trans_inv
         (make_nat_z_iso (functor_identity C) (functor_identity C) (nat_trans_id (functor_identity C))
                     (is_nat_z_iso_nat_trans_id (functor_identity C)))) =
   identity (H (functor_identity C ∙ X)).
@@ -420,7 +420,7 @@ Qed.
 
 Local Lemma auxH2 (H : functor [C, C, hs] [C, C, hs]) (X : functor C C)
       (Z Z': precategory_Ptd C hs) :
-  # H (nat_trans_id (pr1 X) ∙∙ nat_trans_id (functor_composite (pr1 Z) (pr1 Z'))) =
+  # H (nat_trans_id (pr1 X) ⋆ nat_trans_id (functor_composite (pr1 Z) (pr1 Z'))) =
   identity (H (((pr1 Z) ∙ (pr1 Z')) ∙ X)).
 Proof.
   apply functor_id_id.

--- a/UniMath/SubstitutionSystems/Signatures.v
+++ b/UniMath/SubstitutionSystems/Signatures.v
@@ -48,7 +48,12 @@ Local Open Scope subsys.
 
 Section fix_a_category.
 
-Context (C : precategory) (hs : has_homsets C).
+  Context (C : precategory) (hs : has_homsets C).
+
+(** The precategory of pointed endofunctors on [C] *)
+Local Notation "'Ptd'" := (precategory_Ptd C hs).
+(** The category of endofunctors on [C] *)
+Local Notation "'EndC'":= ([C, C, hs]).
 
 (** in the original definition, this second category was the same as the first one *)
 Context (D : precategory) (hsD : has_homsets D).
@@ -60,11 +65,6 @@ Section about_signatures.
 
 (** [H] is a rank-2 functor: a functor between functor categories *)
 Context (H : functor [C, D', hsD'] [C, D, hsD]).
-
-(** The precategory of pointed endofunctors on [C] *)
-Local Notation "'Ptd'" := (precategory_Ptd C hs).
-(** The category of endofunctors on [C] *)
-Local Notation "'EndC'":= ([C, C, hs]).
 
 
 (** ** Source and target of the natural transformation [θ] *)
@@ -97,7 +97,9 @@ Proof.
   apply idpath.
 Qed.
 
-(** * Two alternative versions of the strength laws *)
+Section fix_a_θ.
+
+(** * Two alternative versions of the strength laws are defined and seen as equivalent *)
 
 
 (** We assume a suitable (bi)natural transformation [θ] *)
@@ -336,24 +338,34 @@ Proof.
   exact t'.
 Qed.
 
-End about_signatures.
+End fix_a_θ.
 
-Section Strength_laws.
-(** define strength laws *)
+(** * Definition of encapsulations of strength (locally/globally, with/without laws *)
 
-End Strength_laws.
+Definition PrestrengthForSignatureAtPoint (Z: Ptd) : UU :=
+  functor_fix_snd_arg [C, D',hsD'] Ptd [C, D, hsD] θ_source Z ⟹
+  functor_fix_snd_arg [C, D', hsD'] Ptd [C, D, hsD] θ_target Z.
 
-Definition PrestrengthForSignature (H : [C, D', hsD'] ⟶ [C, D, hsD]) : UU := (θ_source H) ⟹ (θ_target H).
+Definition PrestrengthForSignature : UU := θ_source ⟹ θ_target.
 
-Definition nat_trans_data_from_PrestrengthForSignature_funclass {H : [C, D', hsD'] ⟶ [C, D, hsD]}
-           (θ: PrestrengthForSignature H) : ∏ x, (θ_source H) x --> (θ_target H) x := pr1 θ.
+
+Definition nat_trans_data_from_PrestrengthForSignature_funclass (θ: PrestrengthForSignature) :
+  ∏ x, θ_source x --> θ_target x := pr1 θ.
 Coercion nat_trans_data_from_PrestrengthForSignature_funclass: PrestrengthForSignature >-> Funclass.
 
-Definition StrengthForSignature (H : [C, D', hsD'] ⟶ [C, D, hsD] ) : UU :=
-  ∑ θ : PrestrengthForSignature H , θ_Strength1_int H θ × θ_Strength2_int H θ.
+Definition nat_trans_data_from_PrestrengthForSignatureAtPoint_funclass (Z: Ptd)(θ: PrestrengthForSignatureAtPoint Z) :
+  ∏ x, functor_fix_snd_arg [C, D',hsD'] Ptd [C, D, hsD] θ_source Z x -->
+       functor_fix_snd_arg [C, D', hsD'] Ptd [C, D, hsD] θ_target Z x := pr1 θ.
+Coercion nat_trans_data_from_PrestrengthForSignatureAtPoint_funclass: PrestrengthForSignatureAtPoint >-> Funclass.
 
-Coercion Strength_Prestrength {H : [C, D', hsD'] ⟶ [C, D, hsD]} (θwithlaws: StrengthForSignature H) :
-  PrestrengthForSignature H := pr1 θwithlaws.
+
+Definition StrengthForSignature : UU :=
+  ∑ θ : PrestrengthForSignature, θ_Strength1_int θ × θ_Strength2_int θ.
+
+Coercion Strength_Prestrength (θwithlaws: StrengthForSignature) : PrestrengthForSignature := pr1 θwithlaws.
+
+
+End about_signatures.
 
 Definition Presignature : UU
   := ∑ H : [C, D', hsD'] ⟶ [C, D, hsD] , PrestrengthForSignature H.
@@ -363,7 +375,7 @@ Definition Signature : UU
 
 Coercion Presignature_Functor (S : Presignature) : functor _ _ := pr1 S.
 Coercion Signature_Functor (S : Signature) : functor _ _ := pr1 S.
-Coercion Presignature_Signature (S : Signature) : Presignature := Signature_Functor S ,, Strength_Prestrength(pr2 S).
+Coercion Presignature_Signature (S : Signature) : Presignature := Signature_Functor S ,, Strength_Prestrength _ (pr2 S).
 
 Definition theta (H : Presignature) : PrestrengthForSignature H := pr2 H.
 

--- a/UniMath/SubstitutionSystems/SubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/SubstitutionSystems.v
@@ -240,7 +240,7 @@ Section instantiate_with_identity.
     Context (θ : @PrestrengthForSignatureAtPoint C hs C hs C hs H (ptd_from_alg T)).
 
 Definition bracket_property_parts_identity_nicer (h : `T • `T  --> `T) : UU
-  := (ρ_functor _ = η T •• `T · h) × (θ `T · #H h · τ T  = τ T •• `T ·  h).
+  := (identity `T = η T •• `T · h) × (θ `T · #H h · τ T  = τ T •• `T ·  h).
 (** [ρ_functor] is a monoidal unitor, which is pointwise the identity *)
 
 Lemma bracket_property_parts_identity_nicer_impl1 (h : `T • `T  --> `T):
@@ -288,7 +288,7 @@ Definition join_from_hetsubst (T : heterogeneous_substitution) : `T • `T --> `
   := pr1 (pr1 (pr2 (pr2 T))).
 
 Lemma join_from_hetsubst_η (T : heterogeneous_substitution) :
-  ρ_functor _ = η T •• `T · (join_from_hetsubst T).
+  identity `T = η T •• `T · (join_from_hetsubst T).
 Proof.
   refine (pr1 (bracket_property_parts_identity_nicer_impl1 T (θ_from_hetsubst T) _ _)).
   apply parts_from_whole.


### PR DESCRIPTION
in particular, not only are the strength laws not necessary for the construction of the bracket operation, but one needs the strength only for fixed second parameter (the pointed Z)
this could have been implemented ages ago but better late than never

Please comment and then merge if it looks fine.