### PR TITLE
more clarity for monoidal isos in functor category

### DIFF
--- a/UniMath/CategoryTheory/CategoricalRecursionSchemes.v
+++ b/UniMath/CategoryTheory/CategoricalRecursionSchemes.v
@@ -66,10 +66,10 @@ Definition comp_distr_laws {C C' C'' D D' D'' : precategory}{F : functor C D}{F'
   DistrLaw F F'' (H' ∙ H ) (K' ∙ K).
 Proof.
   red.
-  apply (nat_trans_comp _ _ _ (α_functor _ _ _)).
-  use (nat_trans_comp _ _ _ _ (α_functor _ _ _)).
+  apply (nat_trans_comp _ _ _ (α_functors _ _ _)).
+  use (nat_trans_comp _ _ _ _ (α_functors _ _ _)).
   apply (nat_trans_comp _ _ _ (pre_whisker H' lambda)).
-  apply (nat_trans_comp _ _ _ (α_functor_inv _ _ _)).
+  apply (nat_trans_comp _ _ _ (α_functors_inv _ _ _)).
   exact (post_whisker lambda' K).
 Defined.
 
@@ -79,8 +79,8 @@ Definition id_distr_law  {C D : precategory} (F : functor C D) :
   DistrLaw F F (functor_identity C) (functor_identity D).
 Proof.
   red.
-  apply (nat_trans_comp _ _ _ (λ_functor _)).
-  apply ρ_functor_inv.
+  apply (nat_trans_comp _ _ _ (λ_functors _)).
+  apply ρ_functors_inv.
 Defined.
 
 Lemma comp_distr_laws_assoc {C C' C'' C''' D D' D'' D''' : precategory} {F : functor C D}

--- a/UniMath/CategoryTheory/Core/NaturalTransformations.v
+++ b/UniMath/CategoryTheory/Core/NaturalTransformations.v
@@ -175,8 +175,7 @@ Context {A B C D : precategory}.
 Definition nat_trans_functor_id_right (F : functor A B) :
   nat_trans (functor_composite F (functor_identity B)) F.
 Proof.
-exists (λ x, identity _).
-abstract (now intros a b f; rewrite id_left, id_right).
+  apply nat_trans_id.
 Defined.
 
 Definition nat_trans_functor_id_right_inv (F : functor A B) :
@@ -195,8 +194,7 @@ Definition nat_trans_functor_assoc (F1 : functor A B) (F2 : functor B C) (F3 : f
   nat_trans (functor_composite (functor_composite F1 F2) F3)
             (functor_composite F1 (functor_composite F2 F3)).
 Proof.
-exists (λ x, identity _).
-abstract (now intros a b f; rewrite id_right, id_left).
+  apply nat_trans_id.
 Defined.
 
 Definition nat_trans_functor_assoc_inv (F1 : functor A B) (F2 : functor B C) (F3 : functor C D) :

--- a/UniMath/CategoryTheory/Monads/Monads.v
+++ b/UniMath/CategoryTheory/Monads/Monads.v
@@ -114,14 +114,6 @@ Definition Monad_laws_pointfree_in_functor_category : UU :=
         ×
       (#(post_composition_functor _ _ _ _ _ T0') μ' · μ' = (#(pre_composition_functor _ _ _ _ _ T0') μ') · μ').
 
-(** we check the types of left-hand side and right-hand side of the last equation *)
-Goal
-  [C, C, hs] ⟦ post_composition_functor C C C hs hs T0' (functor_compose hs hs T0' T0'), T0' ⟧ =
-  [C, C, hs] ⟦ pre_composition_functor C C C hs hs T0' (functor_compose hs hs T0' T0'), T0' ⟧ .
-Proof.
-  apply idpath.
-Qed.
-
 (** the last variant of the laws is convertible with the one before *)
 Goal
   Monad_laws_pointfree = Monad_laws_pointfree_in_functor_category.

--- a/UniMath/CategoryTheory/Monoidal/EndofunctorsMonoidal.v
+++ b/UniMath/CategoryTheory/Monoidal/EndofunctorsMonoidal.v
@@ -36,7 +36,7 @@ Section Endofunctors_as_monoidal_category.
 Local Notation "'EndC'":= ([C, C, hs]) .
 
 Local Lemma is_nat_trans_left_unitor_data: is_nat_trans (I_pretensor (functorial_composition C C C hs hs) (functor_identity C))
-  (functor_identity [C, C, hs]) (λ F : [C, C, hs], λ_functor ((functor_identity [C, C, hs]) F)).
+  (functor_identity [C, C, hs]) (λ F : [C, C, hs], λ_functors ((functor_identity [C, C, hs]) F)).
 Proof.
   intros F F' m.
   apply nat_trans_eq; try assumption.
@@ -51,7 +51,7 @@ Definition left_unitor_of_endofunctors: left_unitor (functorial_composition C C 
 Proof.
   use make_nat_z_iso.
   + use make_nat_trans.
-    * intro F. apply λ_functor.
+    * intro F. apply λ_functors.
     * apply is_nat_trans_left_unitor_data.
   + red. intro F. cbn.
     use nat_trafo_z_iso_if_pointwise_z_iso.
@@ -62,7 +62,7 @@ Proof.
 Defined.
 
 Local Lemma is_nat_trans_right_unitor_data: is_nat_trans (I_posttensor (functorial_composition C C C hs hs) (functor_identity C))
-  (functor_identity [C, C, hs]) (λ F : [C, C, hs], ρ_functor ((functor_identity [C, C, hs]) F)).
+  (functor_identity [C, C, hs]) (λ F : [C, C, hs], ρ_functors ((functor_identity [C, C, hs]) F)).
 Proof.
   intros F F' m.
   apply nat_trans_eq; try assumption.
@@ -76,7 +76,7 @@ Definition right_unitor_of_endofunctors: right_unitor (functorial_composition C 
 Proof.
   use make_nat_z_iso.
   + use make_nat_trans.
-    * intro F. apply ρ_functor.
+    * intro F. apply ρ_functors.
     * apply is_nat_trans_right_unitor_data.
   + red. intro F. cbn.
     use nat_trafo_z_iso_if_pointwise_z_iso.
@@ -88,7 +88,7 @@ Defined.
 
 Local Lemma is_nat_trans_associator_data: is_nat_trans (assoc_left (functorial_composition C C C hs hs))
                                                  (assoc_right (functorial_composition C C C hs hs))
-  (λ F : (C ⟶ C × C ⟶ C) × C ⟶ C, α_functor (pr1 (pr1 F)) (pr2 (pr1 F)) (pr2 F)).
+  (λ F : (C ⟶ C × C ⟶ C) × C ⟶ C, α_functors (pr1 (pr1 F)) (pr2 (pr1 F)) (pr2 F)).
 Proof.
   cbn. intros F F' m.
   apply nat_trans_eq; try assumption.
@@ -106,11 +106,11 @@ Definition associator_of_endofunctors: associator (functorial_composition C C C 
 Proof.
   use make_nat_z_iso.
   + use make_nat_trans.
-    * intro F. apply α_functor.
+    * intro F. apply α_functors.
     * apply is_nat_trans_associator_data.
   + intro F; use nat_trafo_z_iso_if_pointwise_z_iso; intro c.
     use tpair.
-    * apply α_functor_inv.
+    * apply α_functors_inv.
     * abstract ( apply Isos.is_inverse_in_precat_identity ).
 Defined.
 

--- a/UniMath/CategoryTheory/Monoidal/PointedFunctorsMonoidal.v
+++ b/UniMath/CategoryTheory/Monoidal/PointedFunctorsMonoidal.v
@@ -129,7 +129,7 @@ Section PointedFunctors_as_monoidal_category.
     use make_nat_z_iso.
     + use make_nat_trans.
       * intro PF.
-        exists (λ_functor (pr1 PF)).
+        exists (λ_functors (pr1 PF)).
         abstract
           (red; intro c ;
            cbn ;
@@ -158,7 +158,7 @@ Section PointedFunctors_as_monoidal_category.
     use make_nat_z_iso.
     + use make_nat_trans.
       * intro PF.
-        exists (ρ_functor (pr1 PF)).
+        exists (ρ_functors (pr1 PF)).
         abstract
           (red; intro c ;
            cbn ;
@@ -184,7 +184,7 @@ Section PointedFunctors_as_monoidal_category.
     + use make_nat_trans.
       * intro PFtriple.
         induction PFtriple as [[PF1 PF2] PF3].
-        exists (α_functor (pr1 PF1) (pr1 PF2) (pr1 PF3)).
+        exists (α_functors (pr1 PF1) (pr1 PF2) (pr1 PF3)).
         abstract
           (red; intro c ;
            cbn ;

--- a/UniMath/CategoryTheory/UnitorsAndAssociatorsForEndofunctors.v
+++ b/UniMath/CategoryTheory/UnitorsAndAssociatorsForEndofunctors.v
@@ -59,56 +59,118 @@ Section Monoidal_Structure_on_Endofunctors.
 
 Context {C D : precategory}.
 
-Definition ρ_functor (X : functor C D) :
-  nat_trans (functor_composite X (functor_identity D)) X := nat_trans_functor_id_right X.
+Goal ∏ X Y : C ⟶ D, functor_composite X (functor_identity D) ⟹ Y = (X ⟹ Y).
+Proof.
+  intros X Y.
+  apply idpath.
+Qed.
 
-Definition ρ_functor_inv (X : functor C D) :
-  nat_trans X (functor_composite X (functor_identity D)) := ρ_functor X.
+(** this also holds in the target but is not needed here *)
+Goal ∏ X Y : C ⟶ D, Y ⟹ functor_composite X (functor_identity D) = (Y ⟹ X).
+Proof.
+  intros X Y.
+  apply idpath.
+Qed.
 
-Definition λ_functor (X : functor C D) :
-  nat_trans (functor_composite (functor_identity C) X) X := ρ_functor X.
+Goal ∏ X Y : C ⟶ D, functor_composite (functor_identity C) X ⟹ Y = (X ⟹ Y).
+Proof.
+  intros X Y.
+  apply idpath.
+Qed.
 
-Definition λ_functor_inv (X : functor C D) :
-  nat_trans X (functor_composite (functor_identity C) X) := ρ_functor X.
+(** again, this also holds in the target but is not needed here *)
+Goal ∏ X Y : C ⟶ D, Y ⟹ functor_composite (functor_identity C) X = (Y ⟹ X).
+Proof.
+  intros X Y.
+  apply idpath.
+Qed.
+
+Definition ρ_functors (X : functor C D) :
+  nat_trans (functor_composite X (functor_identity D)) X := nat_trans_id X.
+
+Definition ρ_functors_inv (X : functor C D) :
+  nat_trans X (functor_composite X (functor_identity D)) := nat_trans_id X.
+
+Definition λ_functors (X : functor C D) :
+  nat_trans (functor_composite (functor_identity C) X) X := nat_trans_id X.
+
+Definition λ_functors_inv (X : functor C D) :
+  nat_trans X (functor_composite (functor_identity C) X) := nat_trans_id X.
 
 
 Context {E F: precategory}.
 
-Definition α_functor (X : functor C D)(Y : functor D E)(Z : functor E F) :
-  nat_trans (functor_composite (functor_composite X Y) Z)
-            (functor_composite X (functor_composite Y Z)) := nat_trans_functor_assoc X Y Z.
-
-Definition α_functor_inv (X : functor C D)(Y : functor D E)(Z : functor E F) :
-  nat_trans (functor_composite X (functor_composite Y Z))
-            (functor_composite (functor_composite X Y) Z) := α_functor X Y Z.
-
-Lemma α_functor_pointwise_is_z_iso (hsF: has_homsets F)(X : functor C D)(Y : functor D E)(Z : functor E F) :
-  is_z_isomorphism(C:= functor_precategory C F hsF) (α_functor X Y Z).
+Goal ∏ (X : functor C D)(Y : functor D E)(Z : functor E F) (U: functor C F),
+  (functor_composite (functor_composite X Y) Z) ⟹ U =
+  (functor_composite X (functor_composite Y Z)) ⟹ U.
 Proof.
-  exists (α_functor_inv X Y Z).
+  intros.
+  apply idpath.
+Qed.
+
+Goal ∏ (X : functor C D)(Y : functor D E)(Z : functor E F) (U: functor C F),
+  U ⟹ (functor_composite (functor_composite X Y) Z) =
+  U ⟹ (functor_composite X (functor_composite Y Z)).
+Proof.
+  intros.
+  apply idpath.
+Qed.
+
+Definition α_functors (X : functor C D)(Y : functor D E)(Z : functor E F) :
+  nat_trans (functor_composite (functor_composite X Y) Z)
+            (functor_composite X (functor_composite Y Z)) := nat_trans_id ((X ∙ Y) ∙ Z).
+
+Definition α_functors_inv (X : functor C D)(Y : functor D E)(Z : functor E F) :
+  nat_trans (functor_composite X (functor_composite Y Z))
+            (functor_composite (functor_composite X Y) Z) := nat_trans_id ((X ∙ Y) ∙ Z).
+
+Lemma α_functors_pointwise_is_z_iso (hsF: has_homsets F)(X : functor C D)(Y : functor D E)(Z : functor E F) :
+  is_z_isomorphism(C:= functor_precategory C F hsF) (α_functors X Y Z).
+Proof.
+  exists (α_functors_inv X Y Z).
   split; apply nat_trans_eq; try assumption; intro c; apply id_left.
 Defined.
 
-(** as a motivation, we show here that, propositionally, both functors are equal, for each
-    of the three pairs of functors; the extra assumption on having homsets is only used in order
-    to have simple proofs, it is not necessary, as shown in Section "functor_equalities" in
-    functor_categories.v: Lemmas functor_identity_left, functor_identity_right and functor_assoc *)
-Local Lemma motivation_ρ_functor (hsD : has_homsets D)(X : functor C D) : functor_composite X (functor_identity D) = X.
+(** as a motivation, we show here that, propositionally, the functors in source and target of these
+    are equal, for each of the three pairs of functors; the extra assumption on having homsets is only used in order
+    to have simple proofs, it is not necessary, as shown below *)
+Local Lemma motivation_ρ_functors (hsD : has_homsets D)(X : functor C D) : functor_composite X (functor_identity D) = X.
 Proof.
   now apply (functor_eq _ _ hsD); induction X as [data laws]; induction data as [onobs onmorphs].
-Defined.
+Qed.
 
-Local Lemma motivation_λ_functor (hsD : has_homsets D)(X : functor C D) : functor_composite (functor_identity C) X = X.
+Local Lemma motivation_λ_functors (hsD : has_homsets D)(X : functor C D) : functor_composite (functor_identity C) X = X.
 Proof.
   now apply (functor_eq _ _ hsD); induction X as [data laws]; induction data as [onobs onmorphs].
-Defined.
+Qed.
 
-Local Lemma motivation_α_functor (hsF : has_homsets F)(X : functor C D)(Y : functor D E)(Z : functor E F) :
+Local Lemma motivation_α_functors (hsF : has_homsets F)(X : functor C D)(Y : functor D E)(Z : functor E F) :
   functor_composite (functor_composite X Y) Z = functor_composite X (functor_composite Y Z).
 Proof.
   now apply (functor_eq _ _ hsF); induction X as [data laws]; induction data as [onobs onmorphs].
-Defined.
+Qed.
 
 (** these laws do not help in type-checking definitions which is why the transformations further above are needed *)
+
+
+(** now we get rid of the homset assumptions by using results of Section "functor_equalities" in
+    UniMath.CategoryTheory.Core.Functors.v *)
+
+Local Lemma motivation_ρ_functors_stronger (X : functor C D) : functor_composite X (functor_identity D) = X.
+Proof.
+  apply functor_identity_right.
+Qed.
+
+Local Lemma motivation_λ_functors_stronger (X : functor C D) : functor_composite (functor_identity C) X = X.
+Proof.
+  apply functor_identity_left.
+Qed.
+
+Local Lemma motivation_α_functors_stronger (X : functor C D)(Y : functor D E)(Z : functor E F) :
+  functor_composite (functor_composite X Y) Z = functor_composite X (functor_composite Y Z).
+Proof.
+  apply functor_assoc.
+Qed.
+
 
 End Monoidal_Structure_on_Endofunctors.

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -283,14 +283,14 @@ Proof.
   apply pathsinv0.
   apply BinProductArrowUnique.
   + rewrite id_left.
-    unfold UnitorsAndAssociatorsForEndofunctors.λ_functor.
-    unfold UnitorsAndAssociatorsForEndofunctors.ρ_functor.
+    unfold UnitorsAndAssociatorsForEndofunctors.λ_functors.
+    unfold UnitorsAndAssociatorsForEndofunctors.ρ_functors.
     simpl.
     rewrite id_right.
     apply idpath.
   + rewrite id_left.
-    unfold UnitorsAndAssociatorsForEndofunctors.λ_functor.
-    unfold UnitorsAndAssociatorsForEndofunctors.ρ_functor.
+    unfold UnitorsAndAssociatorsForEndofunctors.λ_functors.
+    unfold UnitorsAndAssociatorsForEndofunctors.ρ_functors.
     simpl.
     rewrite id_right.
     apply idpath.
@@ -312,12 +312,12 @@ Proof.
   apply pathsinv0.
   apply BinProductArrowUnique.
   + rewrite id_left.
-    unfold UnitorsAndAssociatorsForEndofunctors.α_functor.
+    unfold UnitorsAndAssociatorsForEndofunctors.α_functors.
     simpl.
     rewrite id_right.
     apply idpath.
   + rewrite id_left.
-    unfold UnitorsAndAssociatorsForEndofunctors.α_functor.
+    unfold UnitorsAndAssociatorsForEndofunctors.α_functors.
     simpl.
     rewrite id_right.
     apply idpath.
@@ -560,8 +560,8 @@ Proof.
 (*  destruct XZ as [X [Z e]].
   simpl.
 *)
-  set (h:= nat_trans_comp (λ_functor_inv (pr1 XZ)) ((nat_trans_id _) ⋆ (pr2 (pr2 XZ)))).
-  exact (nat_trans_comp (α_functor_inv (pr1 (pr2 XZ)) (pr1 XZ) (pr1 XZ)) (h ⋆ (nat_trans_id (functor_composite (pr1 (pr2 XZ)) (pr1 XZ))))).
+  set (h:= nat_trans_comp (λ_functors_inv (pr1 XZ)) ((nat_trans_id _) ⋆ (pr2 (pr2 XZ)))).
+  exact (nat_trans_comp (α_functors_inv (pr1 (pr2 XZ)) (pr1 XZ) (pr1 XZ)) (h ⋆ (nat_trans_id (functor_composite (pr1 (pr2 XZ)) (pr1 XZ))))).
 Defined.
 
 Lemma is_nat_trans_Flat_θ_data: is_nat_trans _ _ Flat_θ_data.

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -122,7 +122,7 @@ Local Lemma aux_iso_1_is_nat_trans (Z : Ptd) :
       BinCoproductOfArrows [C, C, hs]
         (CPEndC (functor_composite (U Z) (functor_identity C))
            ((θ_source H) (X ⊗ Z))) (CPEndC (U Z) ((θ_source H) (X ⊗ Z)))
-        (ρ_functor (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
+        (ρ_functors (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
 Proof.
   unfold is_nat_trans; simpl.
   intros X X' α.
@@ -152,7 +152,7 @@ Definition aux_iso_1 (Z : Ptd)
 Proof.
   use tpair.
   - intro X.
-    exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (ρ_functor (U Z))
+    exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (ρ_functors (U Z))
             (nat_trans_id (θ_source H (X⊗Z):functor C C))).
   - exact (aux_iso_1_is_nat_trans Z).
 Defined.
@@ -167,7 +167,7 @@ Local Lemma aux_iso_1_inv_is_nat_trans (Z : Ptd) :
       BinCoproductOfArrows [C, C, hs]
         (CPEndC (functor_composite (functor_identity C) (U Z))
            ((θ_source H) (X ⊗ Z))) (CPEndC (U Z) ((θ_source H) (X ⊗ Z)))
-        (λ_functor (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
+        (λ_functors (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
 Proof.
   unfold is_nat_trans;
   intros X X' α.
@@ -197,7 +197,7 @@ Local Definition aux_iso_1_inv (Z: Ptd)
 Proof.
   use tpair.
   - intro X.
-    exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (λ_functor (U Z))
+    exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (λ_functors (U Z))
            (nat_trans_id (θ_source H (X⊗Z):functor C C))).
   - exact (aux_iso_1_inv_is_nat_trans Z).
 Defined.
@@ -318,10 +318,10 @@ Proof.
     unfold coproduct_nat_trans_in1_data ; simpl.
     repeat rewrite <- assoc .
     apply BinCoproductIn1Commutes_right_in_ctx_dir.
-    unfold λ_functor; simpl.
+    unfold λ_functors; simpl.
     rewrite id_left.
     apply BinCoproductIn1Commutes_right_in_ctx_dir.
-    unfold ρ_functor; simpl.
+    unfold ρ_functors; simpl.
     rewrite id_left.
     apply BinCoproductIn1Commutes_right_in_ctx_dir.
     rewrite (@id_left EndC).
@@ -333,7 +333,7 @@ Proof.
   - rewrite <- h_eq1'_inst.
     clear h_eq1'_inst.
     apply BinCoproductIn1Commutes_left_in_ctx_dir.
-    unfold λ_functor, nat_trans_id; simpl.
+    unfold λ_functors, nat_trans_id; simpl.
     rewrite id_left.
     repeat rewrite (id_left EndEndC).
     repeat rewrite (id_left EndC).

--- a/UniMath/SubstitutionSystems/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial_alt.v
@@ -137,7 +137,7 @@ Local Lemma aux_iso_1_is_nat_trans :
       BinCoproductOfArrows [C, C, hsC]
         (CPEndC (functor_composite (U Z) (functor_identity C))
            ((θ_source H) (X ⊗ Z))) (CPEndC (U Z) ((θ_source H) (X ⊗ Z)))
-        (ρ_functor (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
+        (ρ_functors (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
 Proof.
 intros X X' α.
 apply (nat_trans_eq hsC); intro c; simpl.
@@ -155,7 +155,7 @@ Definition aux_iso_1
 Proof.
 use tpair.
 - intro X.
-  exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (ρ_functor (U Z))
+  exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (ρ_functors (U Z))
            (nat_trans_id (θ_source H (X⊗Z):functor C C))).
 - exact aux_iso_1_is_nat_trans.
 Defined.
@@ -170,7 +170,7 @@ Local Lemma aux_iso_1_inv_is_nat_trans :
       BinCoproductOfArrows [C, C, hsC]
         (CPEndC (functor_composite (functor_identity C) (U Z))
            ((θ_source H) (X ⊗ Z))) (CPEndC (U Z) ((θ_source H) (X ⊗ Z)))
-        (λ_functor (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
+        (λ_functors (U Z)) (nat_trans_id ((θ_source H) (X ⊗ Z):functor C C))).
 Proof.
 intros X X' α.
 apply (nat_trans_eq hsC); intro c; simpl.
@@ -188,7 +188,7 @@ Local Definition aux_iso_1_inv
 Proof.
 use tpair.
 - intro X.
-  exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (λ_functor (U Z))
+  exact (BinCoproductOfArrows EndC (CPEndC _ _) (CPEndC _ _) (λ_functors (U Z))
          (nat_trans_id (θ_source H (X⊗Z):functor C C))).
 - exact aux_iso_1_inv_is_nat_trans.
 Defined.

--- a/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
@@ -497,7 +497,7 @@ Section third_monad_law_with_assoc.
 Lemma third_monad_law_from_hss :
   (`T ∘ μ_2 : EndC ⟦ functor_composite (functor_composite `T `T) `T , `T • `T ⟧) · μ_2
   =
-  (α_functor _ _ _ : functor_compose hs hs _ _  --> _) · (μ_2 •• `T) · μ_2.
+  (α_functors _ _ _ : functor_compose hs hs _ _  --> _) · (μ_2 •• `T) · μ_2.
 Proof.
   intermediate_path μ_3; [apply pathsinv0, μ_3_T_μ_2_μ_2 | ].
   apply pathsinv0.

--- a/UniMath/SubstitutionSystems/SignatureExamples.v
+++ b/UniMath/SubstitutionSystems/SignatureExamples.v
@@ -107,11 +107,11 @@ Variable δ : δ_source ⟹ δ_target.
 (* Should be ρ_G^-1 ∘ λ_G ? *)
 Definition δ_law1 : UU := δ (id_Ptd C hsC) = nat_trans_id G.
 Let D' Ze Ze' :=
-  nat_trans_comp (α_functor (pr1 Ze) (pr1 Ze') G)
+  nat_trans_comp (α_functors (pr1 Ze) (pr1 Ze') G)
  (nat_trans_comp (pre_whisker (pr1 Ze) (δ Ze'))
- (nat_trans_comp (α_functor_inv (pr1 Ze) G (pr1 Ze'))
+ (nat_trans_comp (α_functors_inv (pr1 Ze) G (pr1 Ze'))
  (nat_trans_comp (post_whisker (δ Ze) (pr1 Ze'))
-                 (α_functor G (pr1 Ze) (pr1 Ze'))))).
+                 (α_functors G (pr1 Ze) (pr1 Ze'))))).
 Definition δ_law2 : UU := ∏ Ze Ze', δ (Ze p• Ze') = D' Ze Ze'.
 
 End δ_laws.
@@ -161,9 +161,9 @@ Definition θ_from_δ_mor (XZe : [C, C, hsC] ⊠ Ptd) :
   [C, C, hsC] ⟦ θ_source precompG XZe, θ_target precompG XZe ⟧.
 Proof.
 set (X := pr1 XZe); set (Z := pr1 (pr2 XZe)).
-set (F1 := α_functor G Z X).
+set (F1 := α_functors G Z X).
 set (F2 := post_whisker (δ G DL (pr2 XZe)) X).
-set (F3 := α_functor_inv Z G X).
+set (F3 := α_functors_inv Z G X).
 apply (nat_trans_comp F3 (nat_trans_comp F2 F1)).
 Defined.
 
@@ -231,11 +231,11 @@ Definition δ_comp_mor (Ze : ptd_obj C) :
    ⟹ functor_composite_data (functor_composite_data G1 G2) (pr1 Ze).
 Proof.
 set (Z := pr1 Ze).
-set (F1 := α_functor_inv Z G1 G2).
+set (F1 := α_functors_inv Z G1 G2).
 set (F2 := post_whisker (δ G1 DL1 Ze) G2).
-set (F3 := α_functor G1 Z G2).
+set (F3 := α_functors G1 Z G2).
 set (F4 := pre_whisker G1 (δ G2 DL2 Ze)).
-set (F5 := α_functor_inv G1 G2 Z).
+set (F5 := α_functors_inv G1 G2 Z).
 exact (nat_trans_comp F1 (nat_trans_comp F2 (nat_trans_comp F3 (nat_trans_comp F4 F5)))).
 Defined.
 
@@ -557,7 +557,7 @@ Let GH : functor [C, D', hsD'] [C, E, hsE] := functor_composite H (post_composit
 Definition Gθ_mor (XZe : [C, D', hsD'] ⊠ Ptd) : [C, E, hsE] ⟦ θ_source GH XZe, θ_target GH XZe ⟧.
 Proof.
 set (X := pr1 XZe); set (Z := pr1 (pr2 XZe)).
-set (F1 := α_functor_inv Z (H X) G).
+set (F1 := α_functors_inv Z (H X) G).
 set (F2 := post_whisker (θ XZe) G).
 apply (nat_trans_comp F1 F2).
 Defined.

--- a/UniMath/SubstitutionSystems/Signatures.v
+++ b/UniMath/SubstitutionSystems/Signatures.v
@@ -116,7 +116,7 @@ Section Strength_law_1_intensional.
 (** needs the heterogeneous formulation of the monoidal operation to type-check *)
 Definition θ_Strength1_int : UU
   := ∏ X : [C, D', hsD'],
-           θ (X ⊗ (id_Ptd C hs)) · # H (λ_functor _) = λ_functor _.
+           θ (X ⊗ (id_Ptd C hs)) · # H (λ_functors _) = λ_functors _.
 
 Lemma isaprop_θ_Strength1_int: isaprop θ_Strength1_int.
 Proof.
@@ -133,7 +133,7 @@ Proof.
   intro c; cbn.
   assert (T2 := nat_trans_eq_pointwise TX c).
   cbn in *.
-  assert (X0 : λ_functor X = identity (X : [C, D', hsD'])).
+  assert (X0 : λ_functors X = identity (X : [C, D', hsD'])).
   { apply nat_trans_eq; try assumption; intros; apply idpath. }
   rewrite X0 in T2.
   apply T2.
@@ -149,7 +149,7 @@ Proof.
   intro c; cbn.
   assert (T2 := nat_trans_eq_pointwise TX c).
   cbn in *.
-  assert (X0 : λ_functor X = identity (X : [C, D', hsD'])).
+  assert (X0 : λ_functors X = identity (X : [C, D', hsD'])).
   { apply nat_trans_eq; try assumption; intros; apply idpath. }
   rewrite X0.
   apply T2.
@@ -170,8 +170,8 @@ Section Strength_law_2_intensional.
  (* does not typecheck in the heterogeneous formulation *)
 Definition θ_Strength2_int : UU
   := ∏ (X : [C, D', hsD']) (Z Z' : Ptd),
-      θ (X ⊗ (Z p• Z')) · #H (α_functor (U Z) (U Z') X )  =
-      (α_functor (U Z) (U Z') (H X) : [C, D, hsD] ⟦ functor_compose hs hsD (functor_composite (U Z) (U Z')) (H X), functor_composite (U Z) (functor_composite (U Z') (H X)) ⟧
+      θ (X ⊗ (Z p• Z')) · #H (α_functors (U Z) (U Z') X )  =
+      (α_functors (U Z) (U Z') (H X) : [C, D, hsD] ⟦ functor_compose hs hsD (functor_composite (U Z) (U Z')) (H X), functor_composite (U Z) (functor_composite (U Z') (H X)) ⟧
       ) ·
       θ (X ⊗ Z') •• (U Z) · θ ((functor_compose hs hsD' (U Z') X) ⊗ Z) .
 
@@ -198,7 +198,7 @@ Proof.
   cbn. rewrite <- TXZZ'c; clear TXZZ'c.
   rewrite <- assoc.
   apply maponpaths.
-  assert (functor_comp_H := functor_comp H (α_functor (pr1 Z) (pr1 Z') X)
+  assert (functor_comp_H := functor_comp H (α_functors (pr1 Z) (pr1 Z') X)
            (a : functor_compose hs hsD' (U Z) (functor_composite (U Z') X) --> Y)).
   assert (functor_comp_H_c := nat_trans_eq_pointwise functor_comp_H c).
   cbn in functor_comp_H_c.
@@ -218,7 +218,7 @@ Proof.
   unfold θ_Strength2_int, θ_Strength2.
   intros T X Z Z'.
   assert (TXZZ'_inst := T X Z Z' (functor_compose hs hsD' (U Z)
-          (functor_composite (U Z') X)) (α_functor (pr1 Z) (pr1 Z') X)).
+          (functor_composite (U Z') X)) (α_functors (pr1 Z) (pr1 Z') X)).
   eapply pathscomp0.
   { apply TXZZ'_inst. }
   clear T TXZZ'_inst.
@@ -243,8 +243,8 @@ Qed.
 
 Definition θ_Strength2_int_nicer : UU := ∏ (X : [C, D', hsD']) (Z Z' : Ptd),
       θ (X ⊗ (Z p• Z'))  =
-      (α_functor (U Z) (U Z') (H X) : [C, D, hsD] ⟦ functor_compose hs hsD (functor_composite (U Z) (U Z')) (H X), functor_composite (U Z) (functor_composite (U Z') (H X)) ⟧) ·
-      θ (X ⊗ Z') •• (U Z) · θ ((functor_compose hs hsD' (U Z') X) ⊗ Z) · #H (α_functor_inv (U Z) (U Z') X ).
+      (α_functors (U Z) (U Z') (H X) : [C, D, hsD] ⟦ functor_compose hs hsD (functor_composite (U Z) (U Z')) (H X), functor_composite (U Z) (functor_composite (U Z') (H X)) ⟧) ·
+      θ (X ⊗ Z') •• (U Z) · θ ((functor_compose hs hsD' (U Z') X) ⊗ Z) · #H (α_functors_inv (U Z) (U Z') X ).
 
 
 Lemma θ_Strength2_int_implies_θ_Strength2_int_nicer: θ_Strength2_int -> θ_Strength2_int_nicer.
@@ -252,7 +252,7 @@ Proof.
   intro Hyp.
   intros X Z Z'.
   assert (HypX := Hyp X Z Z').
-  set (auxiso := functor_on_z_iso H (_,,(α_functor_pointwise_is_z_iso hsD' (U Z) (U Z') X))).
+  set (auxiso := functor_on_z_iso H (_,,(α_functors_pointwise_is_z_iso hsD' (U Z) (U Z') X))).
   apply pathsinv0 in HypX. apply (z_iso_inv_on_left _ _ _ _ auxiso) in HypX.
   assumption.
 Qed.
@@ -261,7 +261,7 @@ Lemma θ_Strength2_int_nicer_implies_θ_Strength2_int: θ_Strength2_int_nicer ->
   intro Hyp.
   intros X Z Z'.
   assert (HypX := Hyp X Z Z').
-  set (auxiso := functor_on_z_iso H (_,,(α_functor_pointwise_is_z_iso hsD' (U Z) (U Z') X))).
+  set (auxiso := functor_on_z_iso H (_,,(α_functors_pointwise_is_z_iso hsD' (U Z) (U Z') X))).
   apply (z_iso_inv_to_right _ _ _ _ auxiso).
   assumption.
 Qed.


### PR DESCRIPTION
NaturalTransformations.v: take identity instead of pointwise identity in two lemmas
UnitorsAndAssociatorsForEndofunctors.v:
- verify that the types of the isos are convertible with those of identity (formulated a bit more generally)
- explicitly define all those isos as the identity
- show the motivational equality lemmas w/o homset hypotheses (the comments pointed to obsolete files)
- rename these isos to have names of the form XX_functors[_inv] instead of with _functor (those are the monoidal isos for functors, they are not functors themselves)
the other nine files only suffer those identifier changes