### PR TITLE
join of het.subst. systematically used (instead of bracket of identity)

### DIFF
--- a/UniMath/SubstitutionSystems/Lam.v
+++ b/UniMath/SubstitutionSystems/Lam.v
@@ -141,7 +141,7 @@ Defined.
 Definition Lam_Flatten :
   [C, C, hs] ⟦ (Flat_H C hs) `Lam , `Lam ⟧.
 Proof.
-  exact (fbracket LamHSS (identity _ )).
+  exact (prejoin_from_hetsubst (hetsubst_from_hss _ _ _ _ LamHSS)).
 Defined.
 
 

--- a/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
@@ -102,26 +102,28 @@ Local Notation "f ⊕ g" := (BinCoproductOfArrows _ (CPEndC _ _ ) (CPEndC _ _ ) 
 
 Definition μ_0 : functor_identity C ⟹ functor_data_from_functor _ _ `T := η T. (*ptd_pt _ (pr1 (pr1 T)).*)
 
+(** [η T] as pointed morphism *)
 Definition μ_0_ptd : id_Ptd C hs --> p T.
 Proof.
   exists μ_0.
   intro c. simpl. apply id_left.
 Defined.
 
+(** the bracket of the "degenerate" argument [η T] *)
 Definition μ_1 : functor_composite (U (id_Ptd C hs)) (`T) ⟹ functor_data_from_functor _ _ `T
   := fbracket _ μ_0_ptd.
 
-
+(** using uniqueness of bracket for [η T] *)
 Lemma μ_1_identity : μ_1 = identity `T .
 Proof.
   apply pathsinv0.
   apply fbracket_unique.
   split.
-  - apply nat_trans_eq; try assumption.
+  - apply nat_trans_eq; try exact hs.
     intros; simpl.
     rewrite id_right.
     apply idpath.
-  - apply nat_trans_eq; try assumption.
+  - apply nat_trans_eq; try exact hs.
     intro c. simpl.
     rewrite id_right.
     assert (H':= θ_Strength1_int_implies_θ_Strength1 _ θ_strength1_int).
@@ -162,49 +164,45 @@ Qed.
 (** This is the multiplication of the monad to be constructed *)
 
 Definition μ_2 : functor_composite (`T) (`T) ⟹ pr1 (`T)
-  := fbracket T (identity _ ).
+  := prejoin_from_hetsubst T.
 
-
-Definition functor_with_mu_from_hss : functor_with_μ C.
+Goal μ_2 = fbracket T (identity _ ).
 Proof.
-  exists (`T).
-  exact μ_2.
-Defined.
+  apply idpath.
+Qed.
 
-Definition Monad_data_from_hss : Monad_data C.
-Proof.
-  exists functor_with_mu_from_hss.
-  exact μ_0.
-Defined.
+Definition functor_with_mu_from_hss : functor_with_μ C := `T,, μ_2.
+
+Definition Monad_data_from_hss : Monad_data C := functor_with_mu_from_hss ,, μ_0.
 
 (** *** Proof of the first monad law *)
 
+(** this directly comes from the contained heterogeneous substitution *)
 Lemma Monad_law_1_from_hss :
-  ∏ c : C, μ_0 (pr1 (`T) c)· μ_2 c = identity ((pr1 (`T)) c).
+  ∏ c : C, μ_0 (pr1 (`T) c) · μ_2 c = identity ((pr1 (`T)) c).
 Proof.
   intro c.
-  unfold μ_2. simpl.
-  unfold μ_0. simpl.
-  set (H':=fbracket_η T (identity _) ).
+  unfold μ_0.
+  set (H' := prejoin_from_hetsubst_η T).
   set (H2:= nat_trans_eq_weq hs _ _ H').
-  simpl in H2.
   apply pathsinv0.
   apply H2.
 Qed.
 
 (** *** Proof of the second monad law *)
 
+(** using uniqueness of bracket for [η T] *)
 Lemma Monad_law_2_from_hss:
   ∏ c : C, # (pr1 (`T)) (μ_0 c)· μ_2 c = identity ((pr1 (`T)) c).
 Proof.
   intro c.
   intermediate_path (μ_1 c).
   - unfold μ_1.
-    assert (H':= @fbracket_unique_target_pointwise _ _ _ _ T).
-    assert (H1:= H'  _ μ_0_ptd).
-    set (x:= post_whisker μ_0 (`T)
+    assert (H' := @fbracket_unique_target_pointwise _ _ _ _ T).
+    assert (H1 := H'  _ μ_0_ptd).
+    set (x := post_whisker μ_0 (`T)
              : EndC ⟦ `T • functor_identity _  , `T • `T ⟧).
-    set (x':= x · μ_2).
+    set (x' := x · μ_2).
     assert (H2 := H1 x').
     apply H2; clear H2.
     unfold x'. clear x'.
@@ -213,54 +211,51 @@ Proof.
     split.
     + apply nat_trans_eq; try apply hs.
       intro c.
-      assert (H':=nat_trans_ax (η T)).
+      assert (H' := nat_trans_ax (η T)).
       simpl in H'.
       rewrite assoc.
       cbn.
       rewrite <- H'; clear H'.
-      assert (H':= fbracket_η T (identity _ )).
-      unfold μ_2.
+      assert (H' := prejoin_from_hetsubst_η T).
       assert (H2 := nat_trans_eq_weq hs _ _ H').
       simpl in H2.
       rewrite <- assoc.
       rewrite <- H2.
-      apply pathsinv0. apply id_right. (* done *)
+      apply pathsinv0. apply id_right.
     + rewrite functor_comp.
       apply nat_trans_eq; try assumption.
       intro c.
       rewrite <- horcomp_id_postwhisker.
       do 2 rewrite assoc.
       simpl in *.
-      intermediate_path ( # (pr1 (H ( (` T)))) (μ_0 c)· pr1 (θ ((`T) ⊗ (p T))) c ·
+      intermediate_path ( # (pr1 (H ( (` T)))) (μ_0 c) · pr1 (θ ((`T) ⊗ (p T))) c ·
                   pr1 (# H μ_2) c · pr1 (τ T) c).
       * unfold tau_from_alg; cbn.
         do 2 rewrite assoc.
         apply cancel_postcomposition.
         apply cancel_postcomposition.
         apply cancel_postcomposition.
-        assert (H':=θ_nat_2 _ _ _ _ _ _ H θ).
+        assert (H' := θ_nat_2 _ _ _ _ _ _ H θ).
         assert (H2 := H' (`T) _ _ μ_0_ptd); clear H'.
-        assert (H3:= nat_trans_eq_weq hs _ _ H2 c); clear H2.
+        assert (H3 := nat_trans_eq_weq hs _ _ H2 c); clear H2.
         simpl in H3.
         rewrite id_left in H3.
-        apply (!H3). (* done *)
-      * assert (H':= fbracket_τ T (identity _ )).
-        unfold μ_2.
-        simpl.
-        assert (H2:= nat_trans_eq_weq hs _ _ H' c); clear H'.
+        apply (!H3).
+      * assert (H' := prejoin_from_hetsubst_τ T).
+        assert (H2 := nat_trans_eq_weq hs _ _ H' c); clear H'.
         simpl in *.
         do 2 rewrite <- assoc.
         {
-          intermediate_path (  # (pr1 (H (` T))) (μ_0 c)·
-                       (pr1 (τ T) (pr1 (`T) c)· pr1 (fbracket T (identity (p T))) c)).
+          intermediate_path (  # (pr1 (H (` T))) (μ_0 c) ·
+                       (pr1 (τ T) (pr1 (`T) c) · pr1 μ_2 c)).
           - apply maponpaths.
             rewrite assoc.
-            apply H2; clear H2. (* rewrite done *)
+            apply H2. (* rewrite done *)
           - clear H2.
             do 2 rewrite assoc.
             apply cancel_postcomposition.
-            eapply pathscomp0.
-            apply (nat_trans_ax (τ T) ).
+            etrans.
+            { apply (nat_trans_ax (τ T) ). }
             apply cancel_postcomposition.
             apply pathsinv0.
             apply id_right.
@@ -270,21 +265,18 @@ Qed.
 
 (** [T_squared] is [T∙T, η∙η], that is, the selfcomposition of [T] as a pointed functor *)
 
-Definition T_squared : Ptd.
-Proof.
-  exact (ptd_composite _ _ (p T) (p T)).
-Defined.
+Definition T_squared : Ptd := ptd_composite _ _ (p T) (p T).
 
 (** [μ_2] is not just a natural transformation from [T∙T] to [T], but also compatible with
     the pointed structure given by [η] *)
 
 Lemma μ_2_is_ptd_mor :
-  ∏ c : C, (ptd_pt C T_squared) c· μ_2 c = pr1 (η T) c.
+  ∏ c : C, (ptd_pt C T_squared) c · μ_2 c = pr1 (η T) c.
 Proof.
   intro c.
   unfold μ_2.
   unfold T_squared. simpl.
-  assert (H':=Monad_law_2_from_hss c).
+  assert (H' := Monad_law_2_from_hss c).
   simpl in H'.
   intermediate_path (pr1 (η T) c · identity _ ).
   - unfold eta_from_alg; simpl.
@@ -298,38 +290,33 @@ Qed.
 Definition μ_2_ptd : T_squared --> p T.
 Proof.
   exists μ_2.
-  unfold is_ptd_mor.
+  red.
   apply μ_2_is_ptd_mor.
 Defined.
 
 Definition μ_3 : EndC ⟦ U T_squared • `T,  `T⟧ := fbracket T μ_2_ptd.
 
-(*
-Definition μ_3' := fbracket T μ_2_ptd.
-Check μ_3'.
-Check (μ_3' = μ_3).
-*)
 
 (** *** Proof of the third monad law via transitivity *)
 (** We show that both sides are equal to [μ_3 = fbracket μ_2] *)
 
+(** using uniqueness of bracket for the prejoin *)
 Lemma μ_3_T_μ_2_μ_2 : μ_3 =
                       (`T ∘ μ_2 : EndC ⟦ `T • _  , `T • `T ⟧ ) · μ_2.
 Proof.
   apply pathsinv0.
   apply (fbracket_unique T μ_2_ptd).
   split.
-  - apply nat_trans_eq; try assumption.
+  - apply nat_trans_eq; try exact hs.
     intro c.
     assert (H2 := nat_trans_ax (η T)); simpl in H2.
     rewrite assoc.
     simpl; rewrite <- H2 ; clear H2.
-    (* rewrite <- assoc. *)
     intermediate_path (μ_2 c · identity _ ).
     + apply pathsinv0, id_right.
-    + eapply pathscomp0. 2: apply assoc.
-      apply pathsinv0.
-      apply maponpaths. apply Monad_law_1_from_hss.
+    + etrans.
+      2: { apply assoc. }
+      apply maponpaths. apply pathsinv0. apply Monad_law_1_from_hss.
   - rewrite functor_comp.
     assert (H1 := θ_nat_2 _ _ _ _ _ _ H θ (`T) _ _ μ_2_ptd).
     simpl in H1.
@@ -339,32 +326,35 @@ Proof.
     + apply cancel_postcomposition.
       apply cancel_postcomposition.
       apply pathsinv0.
-      eapply pathscomp0. apply H1; clear H1.
+      etrans.
+      { apply H1. }
+      clear H1.
       apply maponpaths.
       apply maponpaths.
-      assert (H3:=horcomp_id_postwhisker).
+      assert (H3 := horcomp_id_postwhisker).
       assert (H4 := H3 _ _ _ hs hs _ _ μ_2 (`T)); clear H3.
       apply H4.
     + clear H1.
       apply nat_trans_eq; try assumption.
       intro c; simpl.
       rewrite id_left.
-      assert (H2 := fbracket_τ T  (identity _ )).
-      assert (H3:= nat_trans_eq_pointwise H2 c); clear H2.
+      assert (H2 := prejoin_from_hetsubst_τ T).
+      assert (H3 := nat_trans_eq_pointwise H2 c); clear H2.
       simpl in *.
       match goal with |[H3 : _ = ?f |- ?e · _ · _ · _  = _ ] =>
          intermediate_path (e · f) end.
-      * eapply pathscomp0. apply assoc'.
-        eapply pathscomp0. apply assoc'.
+      * etrans. { apply assoc'. }
+        etrans. { apply assoc'. }
         apply maponpaths.
-        eapply pathscomp0. 2: apply H3.
+        etrans.
+        2: { apply H3. }
         apply assoc.
       * clear H3.
         repeat rewrite assoc.
         apply cancel_postcomposition.
         assert (H1 := nat_trans_ax (τ T )).
         unfold tau_from_alg in H1.
-        eapply pathscomp0; [ | apply H1]; clear H1.
+        etrans; [ | apply H1]; clear H1.
         apply assoc'.
 Qed.
 
@@ -383,7 +373,8 @@ Definition TtimesTthenT: functor C C := @functor_composite C C C
                     (@functor_composite C C C ((functor_ptd_forget C hs) T)
                                               ((functor_ptd_forget C hs) T))
                     ((functor_ptd_forget C hs) T).
-*)
+ *)
+(** using uniqueness of bracket for the prejoin also here *)
 Lemma μ_3_μ_2_T_μ_2 :  (
     @compose (functor_precategory C C hs)
                  (* TtimesTthenT *) T²∙T _ _
@@ -407,53 +398,54 @@ Proof.
       apply cancel_postcomposition.
       assert (H1 := Monad_law_1_from_hss (pr1 (`T) c)).
       apply (!H1).
-  - set (B:= τ T).
-    match goal with | [|- _ · # ?H (?f · _ ) · _ = _ ] => set (F:=f : (*TtimesTthenT'*) T•T² --> _ ) end.
-    assert (H3:= functor_comp H F μ_2).
+  - set (B := τ T).
+    match goal with | [|- _ · # ?H (?f · _ ) · _ = _ ] => set (F := f : (*TtimesTthenT'*) T•T² --> _ ) end.
+    assert (H3 := functor_comp H F μ_2).
     unfold functor_compose in H3.
     eapply pathscomp0. apply cancel_postcomposition. apply maponpaths. apply H3.
     clear H3.
     apply nat_trans_eq; try assumption.
     intro c.
     simpl.
-    match goal with | [ |- ?a · _ · _ = _ ] => set (Ac:= a) end.
+    match goal with | [ |- ?a · _ · _ = _ ] => set (Ac := a) end.
     simpl in Ac.
     simpl in *.
     unfold functor_compose in *.
-    assert (HX:=θ_nat_1 _ _ _ _ _ _ H θ _ _ μ_2).  (* it may be tested with the primed version *)
-    assert (HX1:= HX (ptd_from_alg T)); clear HX.
+    assert (HX := θ_nat_1 _ _ _ _ _ _ H θ _ _ μ_2).  (* it may be tested with the primed version *)
+    assert (HX1 := HX (ptd_from_alg T)); clear HX.
     simpl in HX1.
-    assert (HXX:=nat_trans_eq_pointwise HX1 c); clear HX1.
+    assert (HXX := nat_trans_eq_pointwise HX1 c); clear HX1.
     simpl in HXX.
     rewrite (functor_id ( H (`T))) in HXX.
     rewrite id_right in HXX. (* last two lines needed because of def. of theta on product category *)
     match goal with |[HXX : ?f · ?h = _ · _ |- _ · (_ · ?x ) · ?y = _ ] =>
       intermediate_path (pr1 (θ ((`T) ⊗ (ptd_from_alg T))) (pr1 (pr1 (pr1 T)) c)·
-                       f  · h · x· y) end.
+                       f · h · x · y) end.
     * repeat rewrite assoc.
       apply cancel_postcomposition.
       apply cancel_postcomposition.
       apply cancel_postcomposition.
       unfold Ac. clear Ac.
-      eapply pathscomp0. 2: apply assoc.
-      eapply pathscomp0.
+      etrans.
+      2: {apply assoc. }
+      etrans.
       2: { apply maponpaths. apply (!HXX). }
       clear HXX.
-      assert (Strength_2 : ∏ α : functor_compose hs hs (functor_composite (`T) (`T))(`T) --> functor_composite (` T) (`T),
-
-                    pr1 (θ (`T ⊗ T_squared)) c · pr1 (# H α) c =
+      assert (Strength_2 :
+                ∏ α : functor_compose hs hs (functor_composite (`T) (`T))(`T) --> functor_composite (` T) (`T),
+                     pr1 (θ (`T ⊗ T_squared)) c · pr1 (# H α) c =
                      pr1 (θ ((`T) ⊗ (ptd_from_alg T))) ((pr1 (pr1 (pr1 T))) c)·
                      pr1 (θ (( ((`T) • (`T) : [_, _, hs])) ⊗ (ptd_from_alg T))) c·
-                     pr1 (# H (α : functor_compose hs hs (`T) (functor_composite (`T) (` T))--> _)) c       ).
-      { (intro α;
+                     pr1 (# H (α : functor_compose hs hs (`T) (functor_composite (`T) (` T))--> _)) c ).
+      { intro α;
           assert (HA := θ_Strength2_int_implies_θ_Strength2 _ θ_strength2_int);
-          assert (HA':= HA (`T) (ptd_from_alg T) (ptd_from_alg T) _ α); clear HA;
+          assert (HA' := HA (`T) (ptd_from_alg T) (ptd_from_alg T) _ α); clear HA;
           assert (HA2 := nat_trans_eq_pointwise HA' c ); clear HA';
-          simpl in HA2; apply HA2 ).
+          simpl in HA2; apply HA2.
       }
-      eapply pathscomp0. apply (Strength_2 F).
+      etrans. { apply (Strength_2 F). }
       clear Strength_2.
-      eapply pathscomp0. apply assoc'.
+      etrans. { apply assoc'. }
       apply maponpaths.
       apply maponpaths.
       match goal with |[ |- _ = ?pr1 (# ?G ?g) _ ] =>
@@ -467,10 +459,9 @@ Proof.
       apply (maponpaths (λ T,  pr1 (# H T) c)).
       apply X.
     * clear HXX. clear Ac. clear F. clear B.
-      assert (H4 := fbracket_τ T  (identity _ )).
-      assert (H5:= nat_trans_eq_pointwise H4 c); clear H4.
+      assert (H4 := prejoin_from_hetsubst_τ T).
+      assert (H5 := nat_trans_eq_pointwise H4 c); clear H4.
       simpl in H5.
-      unfold μ_2.
       {
         match goal with |[ H5 : _ = ?e |- ?a · ?b · _ · _ · _ = _ ] =>
                          intermediate_path (a · b · e) end.
@@ -481,8 +472,8 @@ Proof.
         - clear H5.
           repeat rewrite assoc.
           apply cancel_postcomposition.
-          assert (HT := fbracket_τ T (identity _ )).
-          assert (H6:= nat_trans_eq_pointwise HT); clear HT.
+          assert (HT := prejoin_from_hetsubst_τ T).
+          assert (H6 := nat_trans_eq_pointwise HT); clear HT.
           unfold coproduct_nat_trans_in2_data.
           unfold tau_from_alg in H6.
           rewrite assoc in H6.
@@ -501,6 +492,7 @@ Lemma third_monad_law_from_hss :
 Proof.
   intermediate_path μ_3; [apply pathsinv0, μ_3_T_μ_2_μ_2 | ].
   apply pathsinv0.
+  (** we only aim at a proof alternative to [μ_3_μ_2_T_μ_2] *)
   apply (fbracket_unique (*_pointwise*) T  μ_2_ptd).
   split.
   - apply nat_trans_eq; try assumption; intro c.
@@ -524,7 +516,7 @@ Proof.
     intro x; simpl.
     assert (HTT := θ_strength2_int).
     assert (HX := HTT (`T) (ptd_from_alg T) (ptd_from_alg T)); clear HTT.
-    assert (HX':= nat_trans_eq_pointwise HX x); clear HX.
+    assert (HX' := nat_trans_eq_pointwise HX x); clear HX.
     simpl in HX'.
     match goal with | [ H : _  = ?f |- _ · _ · ?g · ?h · ?i = _ ] =>
                       intermediate_path (f · g · h · i) end.
@@ -535,10 +527,10 @@ Proof.
     + clear HX'.
       rewrite id_left.
       rewrite id_right.
-      assert (HX:=θ_nat_1 _ _ _ _ _ _ H θ _ _ μ_2).
-      assert (HX1:= HX (ptd_from_alg T)); clear HX.
+      assert (HX :=θ_nat_1 _ _ _ _ _ _ H θ _ _ μ_2).
+      assert (HX1 := HX (ptd_from_alg T)); clear HX.
       simpl in HX1.
-      assert (HXX:=nat_trans_eq_pointwise HX1 x); clear HX1.
+      assert (HXX := nat_trans_eq_pointwise HX1 x); clear HX1.
       simpl in HXX.
       match goal with | [ H : ?x = _ |- ?e · _ · _ · ?f · ?g = _ ] =>
                  intermediate_path (e · x · f · g) end.
@@ -564,19 +556,20 @@ Proof.
             apply (!HXX).
          }
       * clear HXX.
-        assert (H4 := fbracket_τ T (identity _ )).
-        assert (H5:= nat_trans_eq_pointwise H4 x); clear H4.
+        assert (H4 := prejoin_from_hetsubst_τ T).
+        assert (H5 := nat_trans_eq_pointwise H4 x); clear H4.
         unfold μ_2.
         repeat rewrite <- assoc.
         simpl in H5; repeat rewrite <- assoc in H5.
-        eapply pathscomp0. apply maponpaths. apply maponpaths. apply maponpaths. apply H5.
+        etrans.
+        { apply maponpaths. apply maponpaths. apply maponpaths. apply H5. }
         clear H5.
         rewrite functor_id.
         rewrite id_left.
         repeat rewrite assoc.
         apply cancel_postcomposition.
-        assert (H4':= fbracket_τ T (identity _ )).
-        assert (H6:= nat_trans_eq_pointwise H4' (pr1 `T x)); clear H4'.
+        assert (H4' := prejoin_from_hetsubst_τ T).
+        assert (H6 := nat_trans_eq_pointwise H4' (pr1 `T x)); clear H4'.
         simpl in H6.
         unfold coproduct_nat_trans_in2_data in H6. simpl in H6.
         rewrite assoc in H6.
@@ -585,9 +578,11 @@ Qed.
 
 End third_monad_law_with_assoc.
 
+(*
 Unset Printing All.
 Set Printing Notations.
 Unset Printing Implicit.
+ *)
 
 (** Finally putting together all the preparatory results to obtain a monad *)
 
@@ -627,10 +622,10 @@ Proof.
   repeat split; simpl.
   - intro c.
     unfold μ_2. simpl.
-    set (H':=isbracketMor_hssMor _ _ _ _ β).
+    set (H' := isbracketMor_hssMor _ _ _ _ β).
     unfold isbracketMor in H'.
-    set (H2:= H' _ (identity _ )).
-    set (H3:=(nat_trans_eq_weq hs _ _ H2)).
+    set (H2 := H' _ (identity _ )).
+    set (H3 := nat_trans_eq_weq hs _ _ H2).
     rewrite id_left in H3.
     simpl in H3.
     rewrite H3; clear H3 H2 H'.
@@ -641,7 +636,7 @@ Proof.
     apply idpath.
   - unfold μ_0.
     intro c.
-    set (H':=ptd_mor_commutes _  (ptd_from_alg_mor _ _ _ _ β)).
+    set (H' := ptd_mor_commutes _ (ptd_from_alg_mor _ _ _ _ β)).
     apply H'.
 Qed.
 

--- a/UniMath/SubstitutionSystems/SubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/SubstitutionSystems.v
@@ -241,7 +241,6 @@ Section instantiate_with_identity.
 
 Definition bracket_property_parts_identity_nicer (h : `T • `T  --> `T) : UU
   := (identity `T = η T •• `T · h) × (θ `T · #H h · τ T  = τ T •• `T ·  h).
-(** [ρ_functor] is a monoidal unitor, which is pointwise the identity *)
 
 Lemma bracket_property_parts_identity_nicer_impl1 (h : `T • `T  --> `T):
   bracket_property_parts θ T (identity _) h -> bracket_property_parts_identity_nicer h.
@@ -284,19 +283,20 @@ Coercion alg_from_hetsubst (T : heterogeneous_substitution) : algebra_ob Id_H :=
 Definition θ_from_hetsubst (T : heterogeneous_substitution) : @PrestrengthForSignatureAtPoint C hs C hs C hs H (ptd_from_alg T)
   := pr1 (pr2 T).
 
-Definition join_from_hetsubst (T : heterogeneous_substitution) : `T • `T --> `T
+(** we write prejoin as a warning that the monad laws are not necessarily fulfilled *)
+Definition prejoin_from_hetsubst (T : heterogeneous_substitution) : `T • `T --> `T
   := pr1 (pr1 (pr2 (pr2 T))).
 
-Lemma join_from_hetsubst_η (T : heterogeneous_substitution) :
-  identity `T = η T •• `T · (join_from_hetsubst T).
+Lemma prejoin_from_hetsubst_η (T : heterogeneous_substitution) :
+  identity `T = η T •• `T · (prejoin_from_hetsubst T).
 Proof.
   refine (pr1 (bracket_property_parts_identity_nicer_impl1 T (θ_from_hetsubst T) _ _)).
   apply parts_from_whole.
   exact (pr2 (pr1 (pr2 (pr2 T)))).
 Qed.
 
-Lemma join_from_hetsubst_τ (T : heterogeneous_substitution) :
-  θ_from_hetsubst T `T · #H (join_from_hetsubst T) · τ T  = τ T •• `T ·  (join_from_hetsubst T).
+Lemma prejoin_from_hetsubst_τ (T : heterogeneous_substitution) :
+  θ_from_hetsubst T `T · #H (prejoin_from_hetsubst T) · τ T  = τ T •• `T ·  (prejoin_from_hetsubst T).
 Proof.
   refine (pr2 (bracket_property_parts_identity_nicer_impl1 T (θ_from_hetsubst T) _ _)).
   apply parts_from_whole.
@@ -325,9 +325,9 @@ End fix_a_prestrength.
 End prep_hss.
 
 Arguments ptd_from_alg {_} _ .
-Arguments join_from_hetsubst {_} _ .
-Arguments join_from_hetsubst_η {_} _ .
-Arguments join_from_hetsubst_τ {_} _ .
+Arguments prejoin_from_hetsubst {_} _ .
+Arguments prejoin_from_hetsubst_η {_} _ .
+Arguments prejoin_from_hetsubst_τ {_} _ .
 Arguments bracket_parts {_} _ _ .
 
   Section def_hss.
@@ -487,13 +487,15 @@ Section from_identity_to_hss.
 (** the operations of an hss can be obtained through this formula from
     just a heterogeneous substitution *)
 
-  Context (T : algebra_ob Id_H) (join : bracket_at H (nat_trans_fix_snd_arg _ _ _ _ _ θ (ptd_from_alg T)) T (identity _)).
+  Context (T : algebra_ob Id_H).
+  Context (prejoin : bracket_at H (nat_trans_fix_snd_arg _ _ _ _ _ θ (ptd_from_alg T)) T (identity _)).
 
-  Let T0 : heterogeneous_substitution H := T ,, (nat_trans_fix_snd_arg _ _ _ _ _ θ (ptd_from_alg T) ,, join).
+  Let T0 : heterogeneous_substitution H :=
+    T ,, (nat_trans_fix_snd_arg _ _ _ _ _ θ (ptd_from_alg T) ,, prejoin).
 
 Lemma heterogeneous_substitution_into_bracket {Z : Ptd} (f : Z --> ptd_from_alg T0) :
   bracket_property H (nat_trans_fix_snd_arg _ _ _ _ _ θ Z) T0 f
-                   ((` T0 ∘ # U f : EndC ⟦ `T0 • U Z , `T0 • U (ptd_from_alg T0) ⟧) · join_from_hetsubst T0).
+    ((` T0 ∘ # U f : EndC ⟦ `T0 • U Z , `T0 • U (ptd_from_alg T0) ⟧) · prejoin_from_hetsubst T0).
 Proof.
   apply whole_from_parts.
   split.
@@ -519,10 +521,10 @@ Proof.
     do 2 rewrite <- assoc.
     apply maponpaths.
     rewrite assoc.
-    assert (join_ok := join_from_hetsubst_η T0).
-    apply (maponpaths pr1) in join_ok.
-    apply toforallpaths in join_ok.
-    apply join_ok.
+    assert (prejoin_ok := prejoin_from_hetsubst_η T0).
+    apply (maponpaths pr1) in prejoin_ok.
+    apply toforallpaths in prejoin_ok.
+    apply prejoin_ok.
   - rewrite functor_comp.
     apply nat_trans_eq; try exact hs.
     intro c.
@@ -537,11 +539,11 @@ Proof.
     etrans.
     2: { do 2 rewrite assoc. do 2 apply cancel_postcomposition.
          apply pathsinv0. unfold Id_H. simpl. apply BinCoproductIn2Commutes. }
-    assert (join_ok := join_from_hetsubst_τ T0).
-    apply (maponpaths pr1) in join_ok.
-    apply toforallpaths in join_ok.
-    assert (join_ok_inst := join_ok c).
-    simpl in join_ok_inst.
+    assert (prejoin_ok := prejoin_from_hetsubst_τ T0).
+    apply (maponpaths pr1) in prejoin_ok.
+    apply toforallpaths in prejoin_ok.
+    assert (prejoin_ok_inst := prejoin_ok c).
+    simpl in prejoin_ok_inst.
     etrans.
     { repeat rewrite assoc. do 3 apply cancel_postcomposition.
       apply pathsinv0.
@@ -552,9 +554,9 @@ Proof.
     etrans.
     { repeat rewrite <- assoc. apply maponpaths.
       rewrite assoc.
-      exact join_ok_inst.
+      exact prejoin_ok_inst.
     }
-    clear join_ok join_ok_inst.
+    clear prejoin_ok prejoin_ok_inst.
     repeat rewrite assoc.
     apply idpath.
 Qed.
@@ -582,7 +584,8 @@ Lemma τ_part_of_alg_mor  (T T' : @algebra_ob [C, C, hs] Id_H)
 Proof.
   assert (β_is_alg_mor := pr2 β).
   simpl in β_is_alg_mor.
-  assert (β_is_alg_mor_inst := maponpaths (fun m:EndC⟦_,_⟧ => (BinCoproductIn2 EndC (CPEndC _ _))· m) β_is_alg_mor); clear β_is_alg_mor.
+  assert (β_is_alg_mor_inst := maponpaths (fun m:EndC⟦_,_⟧ => (BinCoproductIn2 EndC (CPEndC _ _))· m)
+                                          β_is_alg_mor); clear β_is_alg_mor.
   simpl in β_is_alg_mor_inst.
   apply nat_trans_eq; try (exact hs).
   intro c.
@@ -827,6 +830,9 @@ Arguments ptd_from_alg_functor {_ _} _ _ .
 Arguments bracket_property {_ _ _ _ _ } _ _ _ _ .
 Arguments bracket_property_parts {_ _ _ _ _} _ _ _ _ .
 Arguments bracket {_ _ _ _} _ _.
+Arguments prejoin_from_hetsubst {_ _ _ _} _ .
+Arguments prejoin_from_hetsubst_η {_ _ _ _} _ .
+Arguments prejoin_from_hetsubst_τ {_ _ _ _} _ .
 
 Notation τ := tau_from_alg.
 Notation η := eta_from_alg.


### PR DESCRIPTION
join of het.subst. now called prejoin
code cleaning and a bit more comments for MonadsFromSubstitutionSystems.v in passing

This is a hygiene PR. No further work on this is intended.