### PR TITLE
Include zarith for coq8.13.2

### DIFF
--- a/INSTALL_NIX.md
+++ b/INSTALL_NIX.md
@@ -33,7 +33,7 @@ and it is not very well tested at the moment.
    [more detailed instructions](https://nixos.org/nix/download.html).)
 2. Start a "nix-shell" with the following command:
    ```bash
-   $ nix-shell -p ocaml ocamlPackages.findlib ocamlPackages.camlp5 ocamlPackages.num gnumake git
+   $ nix-shell -p ocaml ocamlPackages.findlib ocamlPackages.camlp5 ocamlPackages.num ocamlPackages.zarith gnumake git
    ```
    (This may require some time to download and deploy the ocaml
    environment into the Nix storage.)


### PR DESCRIPTION
Issue https://github.com/UniMath/UniMath/issues/1340 discusses the update to Coq 8.13 requiring a new libzarith.  I'm on NixOS 21.11pre311431.88226ea038e, and the [coq8.13.2 branch](https://github.com/UniMath/UniMath/tree/coq8.13.2) builds fine on my machine, provided I include `ocamlPackages.zarith` so I updated the `INSTALL_NIX.md` to reflect this.