### PR TITLE
Some more examples of multisorted binding signatures

### DIFF
--- a/UniMath/CategoryTheory/whiskering.v
+++ b/UniMath/CategoryTheory/whiskering.v
@@ -187,8 +187,12 @@ Proof.
   apply pre_composition_is_functor.
 Defined.
 
-(** Postcomposition with a functor is functorial *)
+(* Variation with more implicit arguments *)
+Definition pre_comp_functor {A : precategory} {B : category} {C : category} :
+  [A, B] → [B, C] ⟶ [A, C] :=
+    pre_composition_functor _ _ _ (homset_property B) (homset_property C).
 
+(** Postcomposition with a functor is functorial *)
 
 Definition post_composition_functor_data (A B C : precategory)
   (hsB: has_homsets B) (hsC: has_homsets C)
@@ -244,3 +248,8 @@ Proof.
   exists (post_composition_functor_data A B C hsB hsC H).
   apply post_composition_is_functor.
 Defined.
+
+(* Variation with more implicit arguments *)
+Definition post_comp_functor {A : precategory} {B : category} {C : category} :
+  [B, C] → [A, B] ⟶ [A, C] :=
+    post_composition_functor _ _ _ (homset_property B) (homset_property C).

--- a/UniMath/SubstitutionSystems/.package/files
+++ b/UniMath/SubstitutionSystems/.package/files
@@ -27,3 +27,5 @@ MultiSorted_alt.v
 STLC.v
 STLC_alt.v
 CCS.v
+CCS_alt.v
+PCF_alt.v

--- a/UniMath/SubstitutionSystems/CCS_alt.v
+++ b/UniMath/SubstitutionSystems/CCS_alt.v
@@ -1,0 +1,303 @@
+(**
+
+Syntax of the calculus of constructions as in Streicher
+"Semantics of Type Theory" formalized as a multisorted
+binding signature.
+
+Written by: Anders Mörtberg, 2021 (adapted from CCS.v)
+
+*)
+
+Require Import UniMath.Foundations.PartD.
+Require Import UniMath.Foundations.Sets.
+
+Require Import UniMath.MoreFoundations.Tactics.
+
+Require Import UniMath.Combinatorics.StandardFiniteSets.
+Require Import UniMath.Combinatorics.Lists.
+
+Require Import UniMath.CategoryTheory.Core.Categories.
+Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
+Require Import UniMath.CategoryTheory.Core.Functors.
+Require Import UniMath.CategoryTheory.FunctorCategory.
+Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.limits.binproducts.
+Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.limits.bincoproducts.
+Require Import UniMath.CategoryTheory.limits.coproducts.
+Require Import UniMath.CategoryTheory.limits.terminal.
+Require Import UniMath.CategoryTheory.limits.initial.
+Require Import UniMath.CategoryTheory.FunctorAlgebras.
+Require Import UniMath.CategoryTheory.exponentials.
+Require Import UniMath.CategoryTheory.Adjunctions.Core.
+Require Import UniMath.CategoryTheory.Chains.All.
+Require Import UniMath.CategoryTheory.Monads.Monads.
+Require Import UniMath.CategoryTheory.categories.HSET.Core.
+Require Import UniMath.CategoryTheory.categories.HSET.Colimits.
+Require Import UniMath.CategoryTheory.categories.HSET.Limits.
+Require Import UniMath.CategoryTheory.categories.HSET.Structures.
+Require Import UniMath.CategoryTheory.categories.StandardCategories.
+Require Import UniMath.CategoryTheory.Groupoids.
+
+Require Import UniMath.SubstitutionSystems.Signatures.
+Require Import UniMath.SubstitutionSystems.SumOfSignatures.
+Require Import UniMath.SubstitutionSystems.BinProductOfSignatures.
+Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
+Require Import UniMath.SubstitutionSystems.LiftingInitial_alt.
+Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
+Require Import UniMath.SubstitutionSystems.SignatureExamples.
+Require Import UniMath.SubstitutionSystems.MultiSorted_alt.
+Require Import UniMath.SubstitutionSystems.MonadsMultiSorted_alt.
+
+Local Open Scope cat.
+
+Section ccs.
+
+(* Was there a general version of this somewhere? *)
+Definition six_rec {A : UU} (a b c d e f : A) : stn 6 → A.
+Proof.
+induction 1 as [n p].
+induction n as [|n _]; [apply a|].
+induction n as [|n _]; [apply b|].
+induction n as [|n _]; [apply c|].
+induction n as [|n _]; [apply d|].
+induction n as [|n _]; [apply e|].
+induction n as [|n _]; [apply f|].
+induction (nopathsfalsetotrue p).
+Defined.
+
+(** We assume a two element set of sorts *)
+Definition sort : hSet := (bool,,isasetbool).
+
+Local Lemma hsort : isofhlevel 3 sort.
+Proof.
+exact (isofhlevelssnset 1 sort (setproperty sort)).
+Defined.
+
+Definition ty : sort := true.
+Definition el : sort := false.
+
+Let sortToSet : category := [path_pregroupoid sort,SET].
+Let hs : has_homsets sortToSet := homset_property sortToSet.
+Let sortToSet2 := [sortToSet,sortToSet].
+Let hs2 : has_homsets sortToSet2 := homset_property sortToSet2.
+
+Local Lemma BinCoprodSortToSet : BinCoproducts sortToSet.
+Proof.
+apply BinCoproducts_functor_precat, BinCoproductsHSET.
+Defined.
+
+Local Lemma TerminalSortToSet : Terminal sortToSet.
+Proof.
+apply Terminal_functor_precat, TerminalHSET.
+Defined.
+
+Local Lemma BinProd : BinProducts [sortToSet,SET].
+Proof.
+apply BinProducts_functor_precat, BinProductsHSET.
+Defined.
+
+(** Some notations *)
+Local Infix "::" := (@cons _).
+Local Notation "[]" := (@nil _) (at level 0, format "[]").
+Local Notation "a + b" := (setcoprod a b) : set.
+Local Notation "'Id'" := (functor_identity _).
+Local Notation "a ⊕ b" := (BinCoproductObject _ (BinCoprodSortToSet a b)).
+Local Notation "'1'" := (TerminalObject TerminalSortToSet).
+Local Notation "F ⊗ G" := (BinProduct_of_functors BinProd F G).
+
+(** The grammar of expressions and objects from page 157:
+
+<<
+E ::= (Πx:E) E                product of types
+    | Prop                    type of propositions
+    | Proof(t)                type of proofs of proposition t
+
+t ::= x                       variable
+    | (λx:E) t                function abstraction
+    | App([x:E] E, t, t)      function application
+    | (∀x:E) t                universal quantification
+>>
+
+We refer to the first syntactic class as ty and the second as el. We first reformulate the rules as
+follows:
+
+<<
+A,B ::= Π(A,x.B)              product of types
+      | Prop                  type of propositions
+      | Proof(t)              type of proofs of proposition t
+
+t,u ::= x                     variable
+      | λ(A,x.t)              function abstraction
+      | App(A,x.B,t,u)        function application
+      | ∀(A,x.t)              universal quantification
+>>
+
+This grammar then gives 6 operations, to the left as Vladimir's restricted 2-sorted signature (where
+el is 0 and ty is 1) and to the right as a multisorted signature:
+
+((0, 1), (1, 1), 1)                 = (([],ty), ([el], ty), ty)
+(1)                                 = ([],ty)
+((0, 0), 1)                         = (([], el), ty)
+((0, 1), (1, 0), 0)                 = (([], ty), ([el], el), el)
+((0, 1), (1, 1), (0, 0), (0, 0), 0) = (([], ty), ([el], ty), ([], el), ([], el), el)
+((0, 1), (1, 0), 0)                 = (([], ty), ([el], el), el)
+
+*)
+
+(** The multisorted signature of CC-S *)
+Definition CCS_Sig : MultiSortedSig sort.
+Proof.
+use mkMultiSortedSig.
+- exact (stn 6,,isasetstn 6).
+- apply six_rec.
+  + exact ((([],,ty) :: (cons el [],,ty) :: nil),,ty).
+  + exact ([],,ty).
+  + exact ((([],,el) :: nil),,ty).
+  + exact ((([],,ty) :: (cons el [],,el) :: nil),,el).
+  + exact ((([],,ty) :: (cons el [],,ty) :: ([],,el) :: ([],,el) :: nil),,el).
+  + exact ((([],,ty) :: (cons el [],,el) :: nil),,el).
+Defined.
+
+Definition CCS_Signature : Signature sortToSet _ _ _ _ _ :=
+  MultiSortedSigToSignatureSet sort CCS_Sig.
+
+Definition CCS_Functor : functor sortToSet2 sortToSet2 :=
+  Id_H _ _ BinCoprodSortToSet CCS_Signature.
+
+Lemma CCS_Functor_Initial : Initial (FunctorAlg CCS_Functor hs2).
+Proof.
+apply SignatureInitialAlgebra.
+- apply InitialHSET.
+- apply ColimsHSET_of_shape.
+- apply is_omega_cocont_MultiSortedSigToSignature.
+  + apply ProductsHSET.
+  + apply Exponentials_functor_HSET, functor_category_has_homsets.
+  + apply ColimsHSET_of_shape.
+Defined.
+
+Definition CCS_Monad : Monad sortToSet :=
+  MultiSortedSigToMonadSet sort CCS_Sig.
+
+(** Extract the constructors from the initial algebra *)
+Definition CCS_M : sortToSet2 :=
+  alg_carrier _ (InitialObject CCS_Functor_Initial).
+
+Let CCS_M_mor : sortToSet2⟦CCS_Functor CCS_M,CCS_M⟧ :=
+  alg_map _ (InitialObject CCS_Functor_Initial).
+
+Let CCS_M_alg : algebra_ob CCS_Functor :=
+  InitialObject CCS_Functor_Initial.
+
+(** The variables *)
+Definition var_map : sortToSet2⟦Id,CCS_M⟧ :=
+  BinCoproductIn1 _ (BinCoproducts_functor_precat _ _ _ _ _ _) · CCS_M_mor.
+
+Definition Pi_source : functor sortToSet2 sortToSet2 :=
+  ( post_comp_functor (projSortToSet sort ty) ⊗ ( pre_comp_functor (sorted_option_functorSet sort el)
+                                                 ∙ post_comp_functor (projSortToC sort _ ty)))
+  ∙ (post_comp_functor (hat_functorSet sort ty)).
+
+(** The Pi constructor *)
+Definition Pi_map : sortToSet2⟦Pi_source CCS_M,CCS_M⟧ :=
+    (CoproductIn _ _ (Coproducts_functor_precat _ _ _ _ _ _) (● 0)%stn)
+  · (BinCoproductIn2 _ (BinCoproducts_functor_precat _ _ _ _ _ _))
+  · CCS_M_mor.
+
+Definition Prop_source : functor sortToSet2 sortToSet2.
+Proof.
+set (T := constant_functor [sortToSet,sortToSet] [sortToSet,SET]
+                           (constant_functor sortToSet SET (TerminalObject TerminalHSET))).
+use (T ∙ post_comp_functor (hat_functorSet sort ty)).
+Defined.
+(* use (functor_composite _ (post_comp_functor (hat_functorSet sort ty))). *)
+(* use (constant_functor sortToSet2 [sortToSet,SET] (constant_functor sortToSet SET 1%CS)). *)
+(* Defined. *)
+
+Definition Prop_map : sortToSet2⟦Prop_source CCS_M,CCS_M⟧ :=
+  (CoproductIn _ _ (Coproducts_functor_precat _ _ _ _ _ _) (● 1)%stn)
+    · (BinCoproductIn2 _ (BinCoproducts_functor_precat _ _ _ _ _ _))
+    · CCS_M_mor.
+
+Definition Proof_source : functor sortToSet2 sortToSet2 :=
+  post_comp_functor (projSortToSet sort el) ∙ post_comp_functor (hat_functorSet sort ty).
+
+(** The Proof constructor *)
+Definition Proof_map : sortToSet2⟦Proof_source CCS_M,CCS_M⟧ :=
+  (CoproductIn _ _ (Coproducts_functor_precat _ _ _ _ _ _) (● 2)%stn)
+    · (BinCoproductIn2 _ (BinCoproducts_functor_precat _ _ _ _ _ _))
+    · CCS_M_mor.
+
+Definition lam_source : functor sortToSet2 sortToSet2 :=
+  ( post_comp_functor (projSortToSet sort ty) ⊗ ( pre_comp_functor (sorted_option_functorSet sort el)
+                                                 ∙ post_comp_functor (projSortToC sort _ el)))
+  ∙ (post_comp_functor (hat_functorSet sort el)).
+
+(** The lambda constructor *)
+Definition lam_map : sortToSet2⟦lam_source CCS_M,CCS_M⟧ :=
+  (CoproductIn _ _ (Coproducts_functor_precat _ _ _ _ _ _) (● 3)%stn)
+    · (BinCoproductIn2 _ (BinCoproducts_functor_precat _ _ _ _ _ _))
+    · CCS_M_mor.
+
+Definition app_source : functor sortToSet2 sortToSet2 :=
+  ((post_comp_functor (projSortToSet sort ty)) ⊗
+  ((pre_comp_functor (sorted_option_functorSet sort el) ∙ post_comp_functor (projSortToSet sort ty)) ⊗
+  ((post_comp_functor (projSortToSet sort el)) ⊗
+   (post_comp_functor (projSortToSet sort el)))))
+ ∙ (post_comp_functor (hat_functorSet sort el)).
+
+(** The app constructor *)
+Definition app_map : sortToSet2⟦app_source CCS_M,CCS_M⟧ :=
+  (CoproductIn _ _ (Coproducts_functor_precat _ _ _ _ _ _) (● 4)%stn)
+    · (BinCoproductIn2 _ (BinCoproducts_functor_precat _ _ _ _ _ _))
+    · CCS_M_mor.
+
+Definition forall_source : functor sortToSet2 sortToSet2 :=
+  ((post_comp_functor (projSortToSet sort ty)) ⊗ (pre_comp_functor (sorted_option_functorSet sort el) ∙ post_comp_functor (projSortToSet sort el))) ∙ post_comp_functor (hat_functorSet sort el).
+
+(** The ∀ constructor *)
+Definition forall_map : sortToSet2⟦forall_source CCS_M,CCS_M⟧ :=
+  (CoproductIn _ _ (Coproducts_functor_precat _ _ _ _ _ _) (● 5)%stn)
+    · (BinCoproductIn2 _ (BinCoproducts_functor_precat _ _ _ _ _ _))
+    · CCS_M_mor.
+
+Definition make_CCS_Algebra X
+  (fvar    : sortToSet2⟦Id,X⟧)
+  (fPi     : sortToSet2⟦Pi_source X,X⟧)
+  (fProp   : sortToSet2⟦Prop_source X,X⟧)
+  (fProof  : sortToSet2⟦Proof_source X,X⟧)
+  (flam    : sortToSet2⟦lam_source X,X⟧)
+  (fapp    : sortToSet2⟦app_source X,X⟧)
+  (fforall : sortToSet2⟦forall_source X,X⟧) : algebra_ob CCS_Functor.
+Proof.
+apply (tpair _ X).
+use (BinCoproductArrow _ _ fvar).
+use CoproductArrow.
+intros i.
+induction i as [n p].
+repeat (induction n as [|n _]; try induction (nopathsfalsetotrue p)).
+- exact fPi.
+- exact fProp.
+- exact fProof.
+- exact flam.
+- simpl in fapp.
+  exact fapp.
+- exact fforall.
+Defined. (* This is slow *)
+
+(** The recursor for ccs *)
+Definition foldr_map X
+  (fvar    : sortToSet2⟦Id,X⟧)
+  (fPi     : sortToSet2⟦Pi_source X,X⟧)
+  (fProp   : sortToSet2⟦Prop_source X,X⟧)
+  (fProof  : sortToSet2⟦Proof_source X,X⟧)
+  (flam    : sortToSet2⟦lam_source X,X⟧)
+  (fapp    : sortToSet2⟦app_source X,X⟧)
+  (fforall : sortToSet2⟦forall_source X,X⟧) :
+  algebra_mor _ CCS_alg (make_CCS_Algebra X fvar fPi fProp fProof flam fapp fforall).
+Proof.
+apply (InitialArrow CCS_Functor_Initial (make_CCS_Algebra X fvar fPi fProp fProof flam fapp fforall)).
+Defined.
+
+End ccs.

--- a/UniMath/SubstitutionSystems/CCS_alt.v
+++ b/UniMath/SubstitutionSystems/CCS_alt.v
@@ -1,7 +1,7 @@
 (**
 
 Syntax of the calculus of constructions as in Streicher
-"Semantics of Type Theory" formalized as a multisorted
+"Semantics of Type Theory" formalized as a 2-sorted
 binding signature.
 
 Written by: Anders Mörtberg, 2021 (adapted from CCS.v)
@@ -120,8 +120,8 @@ t ::= x                       variable
     | (∀x:E) t                universal quantification
 >>
 
-We refer to the first syntactic class as ty and the second as el. We first reformulate the rules as
-follows:
+We refer to the first syntactic class as ty and the second as el.
+We first reformulate the rules as follows:
 
 <<
 A,B ::= Π(A,x.B)              product of types
@@ -134,8 +134,9 @@ t,u ::= x                     variable
       | ∀(A,x.t)              universal quantification
 >>
 
-This grammar then gives 6 operations, to the left as Vladimir's restricted 2-sorted signature (where
-el is 0 and ty is 1) and to the right as a multisorted signature:
+This grammar then gives 6 operations, to the left as Vladimir's restricted
+2-sorted signature (where el is 0 and ty is 1) and to the right as a
+ multisorted signature:
 
 ((0, 1), (1, 1), 1)                 = (([],ty), ([el], ty), ty)
 (1)                                 = ([],ty)
@@ -209,36 +210,33 @@ Definition Prop_source : functor sortToSet2 sortToSet2.
 Proof.
 set (T := constant_functor [sortToSet,sortToSet] [sortToSet,SET]
                            (constant_functor sortToSet SET (TerminalObject TerminalHSET))).
-use (T ∙ post_comp_functor (hat_functorSet sort ty)).
+exact (T ∙ post_comp_functor (hat_functorSet sort ty)).
 Defined.
-(* use (functor_composite _ (post_comp_functor (hat_functorSet sort ty))). *)
-(* use (constant_functor sortToSet2 [sortToSet,SET] (constant_functor sortToSet SET 1%CS)). *)
-(* Defined. *)
 
 Definition Prop_map : sortToSet2⟦Prop_source CCS_M,CCS_M⟧ :=
-  (CoproductIn _ _ (Coproducts_functor_precat _ _ _ _ _ _) (● 1)%stn)
-    · (BinCoproductIn2 _ (BinCoproducts_functor_precat _ _ _ _ _ _))
-    · CCS_M_mor.
+    (CoproductIn _ _ (Coproducts_functor_precat _ _ _ _ _ _) (● 1%nat)%stn)
+  · (BinCoproductIn2 _ (BinCoproducts_functor_precat _ _ _ _ _ _))
+  · CCS_M_mor.
 
 Definition Proof_source : functor sortToSet2 sortToSet2 :=
   post_comp_functor (projSortToSet sort el) ∙ post_comp_functor (hat_functorSet sort ty).
 
 (** The Proof constructor *)
 Definition Proof_map : sortToSet2⟦Proof_source CCS_M,CCS_M⟧ :=
-  (CoproductIn _ _ (Coproducts_functor_precat _ _ _ _ _ _) (● 2)%stn)
-    · (BinCoproductIn2 _ (BinCoproducts_functor_precat _ _ _ _ _ _))
-    · CCS_M_mor.
+    (CoproductIn _ _ (Coproducts_functor_precat _ _ _ _ _ _) (● 2)%stn)
+  · (BinCoproductIn2 _ (BinCoproducts_functor_precat _ _ _ _ _ _))
+  · CCS_M_mor.
 
 Definition lam_source : functor sortToSet2 sortToSet2 :=
-  ( post_comp_functor (projSortToSet sort ty) ⊗ ( pre_comp_functor (sorted_option_functorSet sort el)
-                                                 ∙ post_comp_functor (projSortToC sort _ el)))
+  (post_comp_functor (projSortToSet sort ty) ⊗ (pre_comp_functor (sorted_option_functorSet sort el)
+   ∙ post_comp_functor (projSortToC sort _ el)))
   ∙ (post_comp_functor (hat_functorSet sort el)).
 
 (** The lambda constructor *)
 Definition lam_map : sortToSet2⟦lam_source CCS_M,CCS_M⟧ :=
-  (CoproductIn _ _ (Coproducts_functor_precat _ _ _ _ _ _) (● 3)%stn)
-    · (BinCoproductIn2 _ (BinCoproducts_functor_precat _ _ _ _ _ _))
-    · CCS_M_mor.
+    (CoproductIn _ _ (Coproducts_functor_precat _ _ _ _ _ _) (● 3)%stn)
+  · (BinCoproductIn2 _ (BinCoproducts_functor_precat _ _ _ _ _ _))
+  · CCS_M_mor.
 
 Definition app_source : functor sortToSet2 sortToSet2 :=
   ((post_comp_functor (projSortToSet sort ty)) ⊗
@@ -254,13 +252,15 @@ Definition app_map : sortToSet2⟦app_source CCS_M,CCS_M⟧ :=
     · CCS_M_mor.
 
 Definition forall_source : functor sortToSet2 sortToSet2 :=
-  ((post_comp_functor (projSortToSet sort ty)) ⊗ (pre_comp_functor (sorted_option_functorSet sort el) ∙ post_comp_functor (projSortToSet sort el))) ∙ post_comp_functor (hat_functorSet sort el).
+  ((post_comp_functor (projSortToSet sort ty)) ⊗
+   (pre_comp_functor (sorted_option_functorSet sort el) ∙ post_comp_functor (projSortToSet sort el)))
+  ∙ post_comp_functor (hat_functorSet sort el).
 
 (** The ∀ constructor *)
 Definition forall_map : sortToSet2⟦forall_source CCS_M,CCS_M⟧ :=
-  (CoproductIn _ _ (Coproducts_functor_precat _ _ _ _ _ _) (● 5)%stn)
-    · (BinCoproductIn2 _ (BinCoproducts_functor_precat _ _ _ _ _ _))
-    · CCS_M_mor.
+    (CoproductIn _ _ (Coproducts_functor_precat _ _ _ _ _ _) (● 5)%stn)
+  · (BinCoproductIn2 _ (BinCoproducts_functor_precat _ _ _ _ _ _))
+  · CCS_M_mor.
 
 Definition make_CCS_Algebra X
   (fvar    : sortToSet2⟦Id,X⟧)
@@ -295,7 +295,7 @@ Definition foldr_map X
   (flam    : sortToSet2⟦lam_source X,X⟧)
   (fapp    : sortToSet2⟦app_source X,X⟧)
   (fforall : sortToSet2⟦forall_source X,X⟧) :
-  algebra_mor _ CCS_alg (make_CCS_Algebra X fvar fPi fProp fProof flam fapp fforall).
+  algebra_mor _ CCS_M_alg (make_CCS_Algebra X fvar fPi fProp fProof flam fapp fforall).
 Proof.
 apply (InitialArrow CCS_Functor_Initial (make_CCS_Algebra X fvar fPi fProp fProof flam fapp fforall)).
 Defined.

--- a/UniMath/SubstitutionSystems/MonadsMultiSorted_alt.v
+++ b/UniMath/SubstitutionSystems/MonadsMultiSorted_alt.v
@@ -38,7 +38,7 @@ Local Open Scope cat.
 
 Section MonadInSortToC.
 
-Variables (sort : hSet) (C : category) (BC : BinCoproducts C).
+Variables (sort : hSet) (C : category) (BC : BinCoproducts C) (TC : Terminal C).
 
 Let sortToC : category := [path_pregroupoid sort,C].
 Let hs : has_homsets sortToC := homset_property sortToC.
@@ -48,10 +48,17 @@ Proof.
 apply BinCoproducts_functor_precat, BC.
 Defined.
 
+Local Lemma TerminalSortToC : Terminal sortToC.
+Proof.
+apply Terminal_functor_precat, TC.
+Defined.
+
 Local Notation "a ⊕ b" := (BinCoproductObject _ (BinCoproductsSortToC a b)).
+Local Notation "1" := (TerminalObject TerminalSortToC).
 
 Context {M : Monad sortToC}.
 
+(* We can instantiate the monad laws at a specific sort t *)
 Definition sortToC_fun {X Y : sortToC} (f : ∏ t, C⟦pr1 X t,pr1 Y t⟧) : sortToC⟦X,Y⟧ :=
   nat_trans_functor_path_pregroupoid (homset_property _) f.
 
@@ -84,259 +91,44 @@ Lemma bind_bind_fun {X Y Z : sortToC}
                     (t : sort) :
   bind_fun f t · bind_fun g t = bind_fun (λ s, f s · bind_fun g s) t.
 Proof.
-  etrans.
-  apply (nat_trans_eq_pointwise (bind_bind (sortToC_fun f) (sortToC_fun g)) t).
-  apply cancel_postcomposition.
-  assert (H : sortToC_fun f · bind (sortToC_fun g) = sortToC_fun (λ s, f s · bind_fun g s)).
-  { now apply nat_trans_eq; [apply homset_property|]. }
-  exact (nat_trans_eq_pointwise (maponpaths (λ a, # M a) H) t).
+etrans; [apply (nat_trans_eq_pointwise (bind_bind (sortToC_fun f) (sortToC_fun g)) t)|].
+apply cancel_postcomposition.
+assert (H : sortToC_fun f · bind (sortToC_fun g) = sortToC_fun (λ s, f s · bind_fun g s)).
+{ now apply nat_trans_eq; [apply homset_property|]. }
+exact (nat_trans_eq_pointwise (maponpaths (λ a, # M a) H) t).
 Qed.
 
+(* As the instantiation at a specific sort t does not add much we don't do it for the exchange law *)
+Definition monadSubstGen_instantiated {X Y : sortToC} (f : sortToC⟦X,M Y⟧) :
+  sortToC⟦M (X ⊕ Y),M Y⟧ := monadSubstGen M BinCoproductsSortToC Y f.
 
-(** now we only substitute a single sorted variable *)
+Definition monadSubstGen_fun {X Y : sortToC} (f : ∏ s, C⟦pr1 X s,pr1 (M Y) s⟧) :
+  ∏ t, C⟦pr1 (M (X ⊕ Y)) t,pr1 (M Y) t⟧ :=
+    λ t, pr1 (monadSubstGen_instantiated (sortToC_fun f)) t.
 
+Definition mweak_instantiated {X Y : sortToC} :
+  sortToC⟦M Y,M (X ⊕ Y)⟧ := mweak M BinCoproductsSortToC _ _.
 
+Definition mexch_instantiated {X Y Z : sortToC} :
+  sortToC⟦M (X ⊕ (Y ⊕ Z)), M (Y ⊕ (X ⊕ Z))⟧ :=
+    mexch M BinCoproductsSortToC _ _ _.
 
-(* Definition aux_inject_N {Γ:SET_over_sort}(N : wellsorted_in Γ): *)
-(*   SET_over_sort⟦constHSET_slice (sort_in N),T Γ⟧. *)
-(* Proof. *)
-(*   use tpair. *)
-(*   + exact (fun _=> N). *)
-(*   + now apply funextsec. *)
-(* Defined. *)
-
-Definition monadSubstGen_instantiated {X Y : sortToC} :
-  sortToC⟦X,M Y⟧ → sortToC⟦M (X ⊕ Y),M Y⟧ := monadSubstGen M BinCoproductsSortToC Y.
-
-
-Definition monadSubstGen_instantiated_fun {X Y : sortToC}
-           (e : ∏ s, C⟦pr1 X s,pr1 (M Y) s⟧) (t : sort) : C⟦pr1 (M (X ⊕ Y)) t, pr1 (M Y) t⟧ :=
-  pr1 (monadSubstGen_instantiated (sortToC_fun e)) t.
-
-
-(*
-
-Definition subst_slice {Γ:SET_over_sort}(N : wellsorted_in Γ)
-  (M : wellsorted_in (sorted_option_functor (sort_in N) Γ)): wellsorted_in Γ :=
-  pr1 (monadSubstGen_instantiated _ (aux_inject_N N)) M.
-
-Lemma subst_slice_ok {Γ:SET_over_sort}(N : wellsorted_in Γ)
-   (M : wellsorted_in (sorted_option_functor (sort_in N) Γ)): sort_in (subst_slice N M) = sort_in M.
+Lemma subst_interchange_law_gen_instantiated {X Y Z : sortToC}
+      (f : sortToC⟦X,M (Y ⊕ Z)⟧) (g : sortToC⟦Y, M Z⟧) :
+  monadSubstGen_instantiated f · monadSubstGen_instantiated g =
+  mexch_instantiated · monadSubstGen_instantiated (g · mweak_instantiated)
+                     · monadSubstGen_instantiated (f · monadSubstGen_instantiated g).
 Proof.
-  assert (H1 := pr2 (monadSubstGen_instantiated _ (aux_inject_N N))).
-  apply toforallpaths in H1.
-  apply pathsinv0.
-  now rewrite H1.
+apply subst_interchange_law_gen.
 Qed.
 
-
-
-
-Local Definition mweak_instantiated (Γ1 : SET_over_sort){Γ2 : SET_over_sort} :
-  SET_over_sort⟦T Γ2,T (Γ1 ⊕ Γ2)⟧ := mweak T BC _ _.
-
-Definition mweak_slice (Γ1 : SET_over_sort)(Γ2 : SET_over_sort) : wellsorted_in Γ2 -> wellsorted_in (Γ1 ⊕ Γ2) := pr1 (mweak_instantiated Γ1).
-
-Arguments mweak_slice _ _ _ : clear implicits.
-
-Lemma mweak_slice_ok (Γ1 : SET_over_sort){Γ2 : SET_over_sort}(M : wellsorted_in Γ2) :
-  sort_in (mweak_slice Γ1 Γ2 M) = sort_in M.
+Lemma subst_interchange_law_instantiated {X Y Z : sortToC}
+      (f : sortToC⟦1,M (1 ⊕ Z)⟧) (g : sortToC⟦1,M Z⟧) :
+  monadSubstGen_instantiated f · monadSubstGen_instantiated g =
+  mexch_instantiated · monadSubstGen_instantiated (g · mweak_instantiated)
+                     · monadSubstGen_instantiated (f · monadSubstGen_instantiated g).
 Proof.
-  set (H1 := pr2 (mweak_instantiated(Γ2:=Γ2) Γ1)).
-  apply toforallpaths in H1.
-  apply pathsinv0.
-  now rewrite H1.
+use subst_interchange_law.
 Qed.
-
-Definition mweak_slice_as_bind_slice (Γ1 : SET_over_sort)(Γ2 : SET_over_sort)(M : wellsorted_in Γ2) : wellsorted_in (Γ1 ⊕ Γ2).
-Proof.
-  use (bind_slice (λ a1, η_slice(Γ:=Γ1 ⊕ Γ2) (pr1 (BinCoproductIn2 _ (BC _ _)) a1)) _ M).
-  intro a1.
-  simpl; now rewrite η_slice_ok.
-Defined.
-
-Lemma mweak_slice_as_bind_slice_agrees (Γ1 : SET_over_sort){Γ2 : SET_over_sort}(M : wellsorted_in Γ2) :
-  mweak_slice_as_bind_slice Γ1 Γ2 M = mweak_slice Γ1 Γ2 M.
-Proof.
-  unfold mweak_slice_as_bind_slice, mweak_slice.
-  unfold bind_slice, mweak_instantiated.
-  apply (maponpaths (λ f, f M)).
-  apply maponpaths.
-  unfold mweak, bind_instantiated.
-  apply maponpaths.
-  now apply eq_mor_slicecat.
-Qed.
-
-Lemma mweak_slice_as_bind_slice_ok (Γ1 : SET_over_sort){Γ2 : SET_over_sort}(M : wellsorted_in Γ2) :
-  sort_in (mweak_slice_as_bind_slice Γ1 Γ2 M) = sort_in M.
-Proof.
-  rewrite mweak_slice_as_bind_slice_agrees; apply mweak_slice_ok.
-Qed.
-
-
-Local Definition mexch_instantiated {Γ1 Γ2 Γ3: SET_over_sort} :
-  SET_over_sort⟦T (Γ1 ⊕ (Γ2 ⊕ Γ3)), T (Γ2 ⊕ (Γ1 ⊕ Γ3))⟧ := mexch T BC _ _ _.
-
-Definition mexch_slice {Γ1 Γ2 Γ3: SET_over_sort} :
-  wellsorted_in (Γ1 ⊕ (Γ2 ⊕ Γ3)) -> wellsorted_in (Γ2 ⊕ (Γ1 ⊕ Γ3)) :=
-  pr1 (mexch_instantiated).
-
-Lemma mexch_slice_ok {Γ1 Γ2 Γ3: SET_over_sort}(M : wellsorted_in (Γ1 ⊕ (Γ2 ⊕ Γ3))) :
-  sort_in (mexch_slice M) = sort_in M.
-Proof.
-  set (H1 := pr2 (mexch_instantiated(Γ1:=Γ1)(Γ2:=Γ2)(Γ3:=Γ3))).
-  apply toforallpaths in H1.
-  apply pathsinv0.
-  now rewrite H1.
-Qed.
-
-
-Definition mexch_slice_as_bind_slice {Γ1 Γ2 Γ3: SET_over_sort}(M : wellsorted_in (Γ1 ⊕ (Γ2 ⊕ Γ3))) :
-  wellsorted_in (Γ2 ⊕ (Γ1 ⊕ Γ3)).
-Proof.
-  (* first important preparations *)
-  unfold BinCoproductObject in M.
-  simpl in M.
-  set (a1 := BinCoproductIn1 _ (BinCoproductsHSET _ _) · BinCoproductIn2 _ (BinCoproductsHSET _ _): HSET⟦pr1 Γ1, pr1(Γ2 ⊕ (Γ1 ⊕ Γ3))⟧).
-  set (a21 := BinCoproductIn1 _ (BinCoproductsHSET _ _): HSET⟦pr1 Γ2, pr1(Γ2 ⊕ (Γ1 ⊕ Γ3))⟧).
-  set (a22 := BinCoproductIn2 _ (BinCoproductsHSET _ _) · BinCoproductIn2 _ (BinCoproductsHSET _ _): HSET⟦pr1 Γ3, pr1(Γ2 ⊕ (Γ1 ⊕ Γ3))⟧).
-  use (bind_slice ((BinCoproductArrow _ _ a1 (BinCoproductArrow _ _ a21 a22)) · η_slice(Γ:=Γ2 ⊕ (Γ1 ⊕ Γ3))) _ M).
-  intro x.
-  induction x as [x1 | x2].
-  + unfold BinCoproductArrow.
-    simpl.
-    unfold compose.
-    simpl.
-    now rewrite η_slice_ok.
-  + induction x2 as [x21 | x22].
-    * unfold BinCoproductArrow.
-      simpl.
-      unfold compose.
-      simpl.
-      now rewrite η_slice_ok.
-    * unfold BinCoproductArrow.
-      simpl.
-      unfold compose.
-      simpl.
-      now rewrite η_slice_ok.
-Defined.
-
-Lemma mexch_slice_as_bind_slice_agrees {Γ1 Γ2 Γ3: SET_over_sort}(M : wellsorted_in (Γ1 ⊕ (Γ2 ⊕ Γ3))) :
-  mexch_slice_as_bind_slice M = mexch_slice M.
-Proof.
-  unfold mexch_slice_as_bind_slice, mexch_slice.
-  unfold bind_slice, mexch_instantiated.
-  apply (maponpaths (λ f, f M)).
-  apply maponpaths.
-  unfold mexch, bind_instantiated.
-  apply maponpaths.
-  now apply eq_mor_slicecat.
-Qed.
-
-
-Lemma mexch_slice_as_bind_slice_ok {Γ1 Γ2 Γ3: SET_over_sort}
-      (M : wellsorted_in (Γ1 ⊕ (Γ2 ⊕ Γ3))) :
-  sort_in (mexch_slice_as_bind_slice M) = sort_in M.
-Proof.
-  rewrite mexch_slice_as_bind_slice_agrees; apply mexch_slice_ok.
-Qed.
-
-Lemma subst_interchange_law_instantiated {t s:sort}{Γ: SET_over_sort}
-      (NN:SET_over_sort⟦constHSET_slice t, T (constHSET_slice s ⊕ Γ)⟧)
-      (LL:SET_over_sort⟦constHSET_slice s, T Γ⟧):
-  (monadSubstGen_instantiated _ NN) · (monadSubstGen_instantiated _ LL) =
-  (mexch_instantiated (Γ1:=constHSET_slice t) (Γ2:=constHSET_slice s) (Γ3:=Γ))
-    · (monadSubstGen_instantiated _ (LL · (mweak_instantiated _)))
-    · (monadSubstGen_instantiated _ (NN · (monadSubstGen_instantiated _ LL))).
-Proof.
-  apply subst_interchange_law_gen.
-Qed.
-
-(*
-(* we were heading for the following lemma that presents the result in terms of the application domain and not category theory: *)
-Lemma subst_interchange_law_slice {Γ : SET_over_sort}
-      (L : wellsorted_in Γ)
-      (N : wellsorted_in (sorted_option_functor (sort_in L) Γ))
-      (M : wellsorted_in (sorted_option_functor (sort_in N) (sorted_option_functor (sort_in L) Γ))) :
-  subst_slice L (subst_slice N M) =
-  subst_slice_eqn (subst_slice L N)
-                  (subst_slice_eqn (mweak_slice _ _ L) (mexch_slice M) (mweak_slice_ok _ L))
-                  (subst_slice_ok L N).
-Proof.
-  set (ls := subst_slice L (subst_slice N M)).
-  set (rs1 := subst_slice_eqn (mweak_slice _ _ L) (mexch_slice M) (mweak_slice_ok _ L)).
-  set (rs2 := subst_slice L N).
-  simpl in rs1.
-
-(* Problem: mweak_slice is not an instance of bind_slice, and rewriting is not possible since also *)
-(* mweak_slice_ok appears in the term. *)
-Admitted.
-*)
-
-Context {Γ : SET_over_sort}
-      (L : wellsorted_in Γ)
-      (N : wellsorted_in (sorted_option_functor (sort_in L) Γ))
-      (M : wellsorted_in (sorted_option_functor (sort_in N)
-                            (sorted_option_functor (sort_in L) Γ))).
-
-Local Definition LHS : wellsorted_in Γ := subst_slice L (subst_slice N M).
-Local Definition RHS : wellsorted_in Γ :=
-  subst_slice_eqn (subst_slice L N)
-           (subst_slice_eqn (mweak_slice_as_bind_slice _ _ L)
-                            (mexch_slice M) (mweak_slice_as_bind_slice_ok _ L))
-        (subst_slice_ok L N).
-
-Local Lemma same_sort_LHS_RHS : sort_in LHS = sort_in RHS.
-Proof.
-  unfold LHS.
-  rewrite subst_slice_ok.
-  rewrite subst_slice_ok.
-  unfold RHS.
-  do 2 rewrite subst_slice_eqn_ok.
-  apply pathsinv0.
-  apply mexch_slice_ok.
-Qed.
-
-(*
-Lemma subst_interchange_law_slice: LHS = RHS.
-Proof.
-   unfold LHS.
-   do 2 rewrite <- subst_slice_as_bind_slice_agrees.
-   unfold subst_slice_as_bind_slice.
-   rewrite bind_bind_slice_inst.
-
-
-(* first treat the question of having the right sort *)
-  Focus 2.
-    simpl.
-  induction a1 as [u | a1].
-  + rewrite bind_slice_ok.
-    now rewrite postcompWithBinCoproductArrowHSET.
-  Focus 2.
-  simpl.
-  rewrite bind_slice_ok.
-   rewrite postcompWithBinCoproductArrowHSET.
-   unfold BinCoproductArrow.
-   simpl. unfold compose. simpl.
-   unfold BinCoproduct_of_functors_ob.
-   simpl.
-   intermediate_path (sort_in (η_slice(Γ:=BinCoproductObject
-          (slice_precat HSET sort has_homsets_HSET)
-          (BinCoproducts_HSET_slice sort (constHSET_slice (sort_in L)) Γ))
-          a1)).
-   Focus 2.
-   now rewrite η_slice_ok.
-   apply maponpaths. apply idpath.
-(* end of verifying the right sort *)
-
-   (* the left-hand side is now of the form bind_slice f' H' M *)
-   Admitted.
-*)
-
-
-
-
-*)
-
 
 End MonadInSortToC.

--- a/UniMath/SubstitutionSystems/MonadsMultiSorted_alt.v
+++ b/UniMath/SubstitutionSystems/MonadsMultiSorted_alt.v
@@ -106,6 +106,9 @@ Definition monadSubstGen_fun {X Y : sortToC} (f : ∏ s, C⟦pr1 X s,pr1 (M Y) s
   ∏ t, C⟦pr1 (M (X ⊕ Y)) t,pr1 (M Y) t⟧ :=
     λ t, pr1 (monadSubstGen_instantiated (sortToC_fun f)) t.
 
+Definition monadSubst_instantiated {X : sortToC} (f : sortToC⟦1,M X⟧) :
+  sortToC⟦M (1 ⊕ X),M X⟧ := monadSubst M BinCoproductsSortToC TerminalSortToC X f.
+
 Definition mweak_instantiated {X Y : sortToC} :
   sortToC⟦M Y,M (X ⊕ Y)⟧ := mweak M BinCoproductsSortToC _ _.
 
@@ -122,13 +125,13 @@ Proof.
 apply subst_interchange_law_gen.
 Qed.
 
-Lemma subst_interchange_law_instantiated {X Y Z : sortToC}
-      (f : sortToC⟦1,M (1 ⊕ Z)⟧) (g : sortToC⟦1,M Z⟧) :
-  monadSubstGen_instantiated f · monadSubstGen_instantiated g =
-  mexch_instantiated · monadSubstGen_instantiated (g · mweak_instantiated)
-                     · monadSubstGen_instantiated (f · monadSubstGen_instantiated g).
+Lemma subst_interchange_law_instantiated {X : sortToC}
+      (f : sortToC⟦1,M (1 ⊕ X)⟧) (g : sortToC⟦1,M X⟧) :
+  monadSubst_instantiated f · monadSubst_instantiated g =
+  mexch_instantiated · monadSubst_instantiated (g · mweak_instantiated)
+                     · monadSubst_instantiated (f · monadSubst_instantiated g).
 Proof.
-use subst_interchange_law.
+apply subst_interchange_law.
 Qed.
 
 End MonadInSortToC.

--- a/UniMath/SubstitutionSystems/MultiSorted_alt.v
+++ b/UniMath/SubstitutionSystems/MultiSorted_alt.v
@@ -121,6 +121,17 @@ Definition arity (M : MultiSortedSig) : ops M → list (list sort × sort) × so
 Definition mkMultiSortedSig {I : hSet}
   (ar : I → list (list sort × sort) × sort) : MultiSortedSig := (I,,ar).
 
+(** Sum of multisorted binding signatures *)
+Definition SumMultiSortedSig : MultiSortedSig → MultiSortedSig → MultiSortedSig.
+Proof.
+intros s1 s2.
+use tpair.
+- apply (setcoprod (ops s1) (ops s2)).
+- induction 1 as [i|i].
+  + apply (arity s1 i).
+  + apply (arity s2 i).
+Defined.
+
 (** * Construction of an endofunctor on [C^sort,C^sort] from a multisorted signature *)
 Section functor.
 

--- a/UniMath/SubstitutionSystems/MultiSorted_alt.v
+++ b/UniMath/SubstitutionSystems/MultiSorted_alt.v
@@ -61,8 +61,6 @@ Require Import UniMath.SubstitutionSystems.BindingSigToMonad.
 Local Open Scope cat.
 
 (* These should be global *)
-Arguments post_composition_functor {_ _ _} _ _ _.
-Arguments pre_composition_functor {_ _ _} _ _ _.
 Arguments Gθ_Signature {_ _ _ _ _ _} _ _.
 Arguments Signature_Functor {_ _ _ _} _.
 Arguments BinProduct_of_functors {_ _} _ _ _.
@@ -191,7 +189,7 @@ End Sorted_Option_Functor.
 
 
 (** Sorted option functor for lists *)
-Definition option_list (xs : list sort) : functor sortToC sortToC.
+Definition option_list (xs : list sort) : [sortToC,sortToC].
 Proof.
 (* This should be foldr1 in order to avoid composing with the
    identity functor in the base case *)
@@ -214,11 +212,9 @@ Proof.
 induction lt as [l t].
 (* use list_ind to do a case on whether l is empty or not *)
 use (list_ind _ _ _ l); clear l.
-- exact (post_composition_functor _ _ (projSortToC t)).
-- intros s l _; simpl.
-  eapply functor_composite.
-  + exact (pre_composition_functor hs hs (option_list (cons s l))).
-  + exact (post_composition_functor _ hsC (projSortToC t)).
+- exact (post_comp_functor (projSortToC t)).
+- intros s l _.
+  exact (pre_comp_functor (option_list (cons s l)) ∙ post_comp_functor (projSortToC t)).
 Defined.
 
 (** This defines F^lts where lts is a list of (l,t). Outputs a product of
@@ -238,7 +234,7 @@ Defined.
 
 Definition hat_exp_functor_list (xst : list (list sort × sort) × sort) :
   functor [sortToC,sortToC] [sortToC,sortToC] :=
-    exp_functor_list (pr1 xst) ∙ post_composition_functor _ _ (hat_functor (pr2 xst)).
+    exp_functor_list (pr1 xst) ∙ post_comp_functor (hat_functor (pr2 xst)).
 
 (** The function from multisorted signatures to functors *)
 Definition MultiSortedSigToFunctor (M : MultiSortedSig) :
@@ -399,7 +395,7 @@ use make_are_adjoints.
 Qed.
 
 Local Lemma is_omega_cocont_post_comp_projSortToC (s : sort) :
-  is_omega_cocont (@post_composition_functor sortToC _ _ hs hsC (projSortToC s)).
+  is_omega_cocont (post_comp_functor (A := sortToC) (projSortToC s)).
 Proof.
 apply is_omega_cocont_post_composition_functor.
 apply is_left_adjoint_projSortToC.
@@ -474,8 +470,7 @@ use make_are_adjoints.
 Qed.
 
 Local Lemma is_omega_cocont_post_comp_hat_functor (s : sort) :
-  is_omega_cocont (@post_composition_functor sortToC  _ _
-       hsC hs (hat_functor s)).
+  is_omega_cocont (post_comp_functor (A := sortToC) (hat_functor s)).
 Proof.
 apply is_omega_cocont_post_composition_functor, is_left_adjoint_hat.
 Defined.

--- a/UniMath/SubstitutionSystems/PCF_alt.v
+++ b/UniMath/SubstitutionSystems/PCF_alt.v
@@ -117,7 +117,7 @@ Inductive PCF_consts : TY -> Type :=
  | tt : PCF_consts Bool
  | ff : PCF_consts Bool
  | succ : PCF_consts (arrow Nat Nat)
- | zero : PCF_consts Nat
+ | is_zero : PCF_consts (arr Nat Bool)
  | condN: PCF_consts (arrow Bool (arrow Nat (arrow Nat Nat)))
  | condB: PCF_consts (arrow Bool (arrow Bool (arrow Bool Bool))).
 
@@ -145,7 +145,7 @@ use mkMultiSortedSig.
     * exact ([],,Bool).                                (* True *)
     * exact ([],,Bool).                                (* False *)
     * exact ([],,arr Nat Nat).                         (* Succ *)
-    * exact ([],,Nat).                                 (* Zero *)
+    * exact ([],,arr Nat Bool).                        (* is_zero *)
     * exact ([],,arr Bool (arr Nat (arr Nat Nat))).    (* CondN *)
     * exact ([],,arr Bool (arr Bool (arr Bool Bool))). (* CondB *)
 Defined.

--- a/UniMath/SubstitutionSystems/PCF_alt.v
+++ b/UniMath/SubstitutionSystems/PCF_alt.v
@@ -140,13 +140,13 @@ Proof.
 use mkMultiSortedSig.
 - exact ((nat,,isasetnat) + (stn 6,,isasetstn 6))%set.
 - induction 1 as [n|i].
-  + exact ([],,Nat).      (* Nat *)
+  + exact ([],,Nat).                                   (* Nat (one for each nat) *)
   + apply (six_rec i).
-    * exact ([],,Bool).   (* True *)
-    * exact ([],,Bool).   (* False *)
-    * exact ([],,arr Nat Nat). (* Succ *)
-    * exact ([],,Nat). (* Zero *)
-    * exact ([],,arr Bool (arr Nat (arr Nat Nat))). (* CondN *)
+    * exact ([],,Bool).                                (* True *)
+    * exact ([],,Bool).                                (* False *)
+    * exact ([],,arr Nat Nat).                         (* Succ *)
+    * exact ([],,Nat).                                 (* Zero *)
+    * exact ([],,arr Bool (arr Nat (arr Nat Nat))).    (* CondN *)
     * exact ([],,arr Bool (arr Bool (arr Bool Bool))). (* CondB *)
 Defined.
 

--- a/UniMath/SubstitutionSystems/PCF_alt.v
+++ b/UniMath/SubstitutionSystems/PCF_alt.v
@@ -46,6 +46,7 @@ Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.SignatureExamples.
 Require Import UniMath.SubstitutionSystems.MultiSorted_alt.
 Require Import UniMath.SubstitutionSystems.MonadsMultiSorted_alt.
+Require Import UniMath.SubstitutionSystems.STLC_alt.
 
 Local Open Scope cat.
 
@@ -100,6 +101,7 @@ Local Notation "'Id'" := (functor_identity _).
 Local Notation "a ⊕ b" := (BinCoproductObject _ (BinCoprodTypeToSet a b)).
 Local Notation "'1'" := (TerminalObject TerminalTypeToSet).
 Local Notation "F ⊗ G" := (BinProduct_of_functors BinProd F G).
+Infix "++" := (SumMultiSortedSig _).
 
 (**
 
@@ -150,19 +152,31 @@ use mkMultiSortedSig.
     * exact ([],,arr Bool (arr Bool (arr Bool Bool))). (* CondB *)
 Defined.
 
-Definition PCF : MultiSortedSig type.
+(* We could define PCF as follows, but we instead get App and Lam from the STLC signature *)
+(* Definition PCF : MultiSortedSig type. *)
+(* Proof. *)
+(* use mkMultiSortedSig. *)
+(* - apply (type + (type × type) + (type × type) + type)%set. *)
+(* - intros [[[t|[t s]]|[t s]]|t]. *)
+(*   * exact ([],,t).                                  (* Bottom *) *)
+(*   * exact ((([],,(arr s t)) :: ([],,s) :: nil),,t). (* App *) *)
+(*   * exact (((cons t [],,s) :: []),,(arr t s)).      (* Lam *) *)
+(*   * exact ((([],,(arr t t)) :: nil),,t).            (* Y *) *)
+(* Defined. *)
+
+Definition PCF_Bot_Y : MultiSortedSig type.
 Proof.
 use mkMultiSortedSig.
-- apply (type + (type × type) + (type × type) + type)%set.
-- intros [[[t|[t s]]|[t s]]|t].
+- apply (type + type)%set.
+- intros [t|t].
   * exact ([],,t).                                  (* Bottom *)
-  * exact ((([],,(arr s t)) :: ([],,s) :: nil),,t). (* App *)
-  * exact (((cons t [],,s) :: []),,(arr t s)).      (* Lam *)
   * exact ((([],,(arr t t)) :: nil),,t).            (* Y *)
 Defined.
 
+Definition PCF_App_Lam : MultiSortedSig type := STLC_Sig type arr.
+
 Definition PCF_Sig : MultiSortedSig type :=
-  SumMultiSortedSig type PCF_Consts PCF.
+  PCF_Consts ++ PCF_Bot_Y ++ PCF_App_Lam.
 
 Definition PCF_Signature : Signature typeToSet _ _ _ _ _ :=
   MultiSortedSigToSignatureSet type PCF_Sig.

--- a/UniMath/SubstitutionSystems/PCF_alt.v
+++ b/UniMath/SubstitutionSystems/PCF_alt.v
@@ -1,0 +1,203 @@
+(**
+
+Syntax of PCF as a multisorted binding signature.
+
+Written by: Anders Mörtberg, 2021
+
+*)
+Require Import UniMath.Foundations.PartD.
+Require Import UniMath.Foundations.Sets.
+
+Require Import UniMath.MoreFoundations.Tactics.
+
+Require Import UniMath.Combinatorics.StandardFiniteSets.
+Require Import UniMath.Combinatorics.Lists.
+
+Require Import UniMath.CategoryTheory.Core.Categories.
+Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
+Require Import UniMath.CategoryTheory.Core.Functors.
+Require Import UniMath.CategoryTheory.FunctorCategory.
+Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.limits.graphs.colimits.
+Require Import UniMath.CategoryTheory.limits.binproducts.
+Require Import UniMath.CategoryTheory.limits.products.
+Require Import UniMath.CategoryTheory.limits.bincoproducts.
+Require Import UniMath.CategoryTheory.limits.coproducts.
+Require Import UniMath.CategoryTheory.limits.terminal.
+Require Import UniMath.CategoryTheory.limits.initial.
+Require Import UniMath.CategoryTheory.FunctorAlgebras.
+Require Import UniMath.CategoryTheory.exponentials.
+Require Import UniMath.CategoryTheory.Adjunctions.Core.
+Require Import UniMath.CategoryTheory.Chains.All.
+Require Import UniMath.CategoryTheory.Monads.Monads.
+Require Import UniMath.CategoryTheory.categories.HSET.Core.
+Require Import UniMath.CategoryTheory.categories.HSET.Colimits.
+Require Import UniMath.CategoryTheory.categories.HSET.Limits.
+Require Import UniMath.CategoryTheory.categories.HSET.Structures.
+Require Import UniMath.CategoryTheory.categories.StandardCategories.
+Require Import UniMath.CategoryTheory.Groupoids.
+
+Require Import UniMath.SubstitutionSystems.Signatures.
+Require Import UniMath.SubstitutionSystems.SumOfSignatures.
+Require Import UniMath.SubstitutionSystems.BinProductOfSignatures.
+Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
+Require Import UniMath.SubstitutionSystems.LiftingInitial_alt.
+Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
+Require Import UniMath.SubstitutionSystems.SignatureExamples.
+Require Import UniMath.SubstitutionSystems.MultiSorted_alt.
+Require Import UniMath.SubstitutionSystems.MonadsMultiSorted_alt.
+
+Local Open Scope cat.
+
+Section pcf.
+
+(* Was there a general version of this somewhere? *)
+Definition six_rec {A : UU} (i : stn 6) (a b c d e f : A) : A.
+Proof.
+induction i as [n p].
+induction n as [|n _]; [apply a|].
+induction n as [|n _]; [apply b|].
+induction n as [|n _]; [apply c|].
+induction n as [|n _]; [apply d|].
+induction n as [|n _]; [apply e|].
+induction n as [|n _]; [apply f|].
+induction (nopathsfalsetotrue p).
+Defined.
+
+(** We assume a set of types with bool, nat and function types *)
+Variable (type : hSet) (Bool Nat : type) (arr : type → type → type).
+
+Let typeToSet : category := [path_pregroupoid type,SET].
+Let hs : has_homsets typeToSet := homset_property typeToSet.
+Let typeToSet2 := [typeToSet,typeToSet].
+Let hs2 : has_homsets typeToSet2 := homset_property typeToSet2.
+
+Local Lemma BinCoprodTypeToSet : BinCoproducts typeToSet.
+Proof.
+apply BinCoproducts_functor_precat, BinCoproductsHSET.
+Defined.
+
+Local Lemma TerminalTypeToSet : Terminal typeToSet.
+Proof.
+apply Terminal_functor_precat, TerminalHSET.
+Defined.
+
+Local Lemma BinProd : BinProducts [typeToSet,SET].
+Proof.
+apply BinProducts_functor_precat, BinProductsHSET.
+Defined.
+
+Local Lemma BinCoprodTypeToSet2 : BinCoproducts typeToSet2.
+Proof.
+apply BinCoproducts_functor_precat, BinCoprodTypeToSet.
+Defined.
+
+(** Some notations *)
+Local Infix "::" := (@cons _).
+Local Notation "[]" := (@nil _) (at level 0, format "[]").
+Local Notation "a + b" := (setcoprod a b) : set.
+Local Notation "'Id'" := (functor_identity _).
+Local Notation "a ⊕ b" := (BinCoproductObject _ (BinCoprodTypeToSet a b)).
+Local Notation "'1'" := (TerminalObject TerminalTypeToSet).
+Local Notation "F ⊗ G" := (BinProduct_of_functors BinProd F G).
+
+(**
+
+The Inductive version of PCF that we are going to model (copied from
+https://github.com/benediktahrens/monads/blob/trunk/PCF/pcf.v):
+
+<<
+Inductive TY :=
+ | Bool : TY
+ | Nat : TY
+ | arrow: TY -> TY -> TY.
+
+Inductive PCF_consts : TY -> Type :=
+ | Nats : nat -> PCF_consts Nat
+ | tt : PCF_consts Bool
+ | ff : PCF_consts Bool
+ | succ : PCF_consts (arrow Nat Nat)
+ | zero : PCF_consts Nat
+ | condN: PCF_consts (arrow Bool (arrow Nat (arrow Nat Nat)))
+ | condB: PCF_consts (arrow Bool (arrow Bool (arrow Bool Bool))).
+
+Inductive PCF (V:TY -> Type) : TY -> Type:=
+ | PCFVar : forall t, V t -> PCF V t
+ | Const  : forall t, PCF_consts t -> PCF V t
+ | Bottom : forall t, PCF V t
+ | PApp   : forall t s, PCF V (arrow s t) -> PCF V s -> PCF V t
+ | PLam   : forall t s, PCF (opt_T t V) s -> PCF V (arrow t s)
+ | PRec   : forall t, PCF V (arrow t t) -> PCF V t.
+>>
+
+We do this by defining the constants and non-constants separately and
+then taking the sum of the signatures.
+
+*)
+
+Definition PCF_Consts : MultiSortedSig type.
+Proof.
+use mkMultiSortedSig.
+- exact ((nat,,isasetnat) + (stn 6,,isasetstn 6))%set.
+- induction 1 as [n|i].
+  + exact ([],,Nat).      (* Nat *)
+  + apply (six_rec i).
+    * exact ([],,Bool).   (* True *)
+    * exact ([],,Bool).   (* False *)
+    * exact ([],,arr Nat Nat). (* Succ *)
+    * exact ([],,Nat). (* Zero *)
+    * exact ([],,arr Bool (arr Nat (arr Nat Nat))). (* CondN *)
+    * exact ([],,arr Bool (arr Bool (arr Bool Bool))). (* CondB *)
+Defined.
+
+Definition PCF : MultiSortedSig type.
+Proof.
+use mkMultiSortedSig.
+- apply (type + (type × type) + (type × type) + type)%set.
+- intros [[[t|[t s]]|[t s]]|t].
+  * exact ([],,t).                                  (* Bottom *)
+  * exact ((([],,(arr s t)) :: ([],,s) :: nil),,t). (* App *)
+  * exact (((cons t [],,s) :: []),,(arr t s)).      (* Lam *)
+  * exact ((([],,(arr t t)) :: nil),,t).            (* Y *)
+Defined.
+
+Definition PCF_Sig : MultiSortedSig type :=
+  SumMultiSortedSig type PCF_Consts PCF.
+
+Definition PCF_Signature : Signature typeToSet _ _ _ _ _ :=
+  MultiSortedSigToSignatureSet type PCF_Sig.
+
+Definition PCF_Functor : functor typeToSet2 typeToSet2 :=
+  Id_H _ _ BinCoprodTypeToSet PCF_Signature.
+
+Lemma PCF_Functor_Initial : Initial (FunctorAlg PCF_Functor hs2).
+Proof.
+apply SignatureInitialAlgebra.
+- apply InitialHSET.
+- apply ColimsHSET_of_shape.
+- apply is_omega_cocont_MultiSortedSigToSignature.
+  + apply ProductsHSET.
+  + apply Exponentials_functor_HSET, functor_category_has_homsets.
+  + apply ColimsHSET_of_shape.
+Defined.
+
+Definition PCF_Monad : Monad typeToSet :=
+  MultiSortedSigToMonadSet type PCF_Sig.
+
+(** Extract the constructors from the initial algebra *)
+Definition PCF_M : typeToSet2 :=
+  alg_carrier _ (InitialObject PCF_Functor_Initial).
+
+Let PCF_M_mor : typeToSet2⟦PCF_Functor PCF_M,PCF_M⟧ :=
+  alg_map _ (InitialObject PCF_Functor_Initial).
+
+Let PCF_M_alg : algebra_ob PCF_Functor :=
+  InitialObject PCF_Functor_Initial.
+
+(** The variables *)
+Definition var_map : typeToSet2⟦Id,PCF_M⟧ :=
+  BinCoproductIn1 _ (BinCoproducts_functor_precat _ _ _ _ _ _) · PCF_M_mor.
+
+(* TODO: extract the other constructors *)
+
+End pcf.

--- a/UniMath/SubstitutionSystems/STLC_alt.v
+++ b/UniMath/SubstitutionSystems/STLC_alt.v
@@ -131,16 +131,6 @@ Let STLC_alg : algebra_ob STLC_Functor :=
 Definition var_map : sortToSet2⟦1,STLC⟧ :=
   BinCoproductIn1 _ (BinCoprodSortToSet2 _ _) · STLC_mor.
 
-
-(* TODO: upstream? *)
-Definition post_comp_functor {A : precategory} {B : category} {C : category} :
-  [B, C] → [A, B] ⟶ [A, C] :=
-    post_composition_functor (homset_property B) (homset_property C).
-
-Definition pre_comp_functor {A : precategory} {B : category} {C : category} :
-  [A, B] → [B, C] ⟶ [A, C] :=
-    pre_composition_functor (homset_property B) (homset_property C).
-
 Local Notation "F ⊗ G" := (BinProduct_of_functors BinProd F G).
 
 (** The source of the application constructor *)

--- a/UniMath/SubstitutionSystems/STLC_alt.v
+++ b/UniMath/SubstitutionSystems/STLC_alt.v
@@ -270,9 +270,8 @@ Proof.
 apply subst_interchange_law_gen_instantiated.
 Qed.
 
-End Lam.
-
-
+(* We could also unfold these as statements about sort-indexed sets, but
+   this quickly gets very cumbersome: *)
 (* Definition psubst {X Y : sort → hSet} (f : ∏ t, X t → STLC Y t) (t : sort) : *)
 (*   STLC (λ t, (X t + Y t)%set) t → STLC Y t. *)
 (* Proof. *)
@@ -282,6 +281,7 @@ End Lam.
 (* transparent assert (Y' : (sortToSet)). *)
 (* { use (functor_path_pregroupoid _); apply Y. } *)
 (* transparent assert (f' : (sortToSet⟦ X' , STLC_Monad Y' ⟧)). *)
-(* { use nat_trans_functor_path_pregroupoid. apply homset_property. *)
-(*   use f. } *)
+(* { use nat_trans_functor_path_pregroupoid; apply homset_property; use f. } *)
 (* use (pr1 (@monadSubstGen_instantiated sort SET BinCoproductsHSET STLC_Monad X' Y' f') t). *)
+
+End Lam.

--- a/UniMath/SubstitutionSystems/STLC_alt.v
+++ b/UniMath/SubstitutionSystems/STLC_alt.v
@@ -54,11 +54,6 @@ Section Lam.
 
 Variable (sort : hSet) (arr : sort → sort → sort).
 
-Local Lemma hsort : isofhlevel 3 sort.
-Proof.
-exact (isofhlevelssnset 1 sort (setproperty sort)).
-Defined.
-
 Let sortToSet : category := [path_pregroupoid sort,SET].
 Let hs : has_homsets sortToSet := homset_property sortToSet.
 
@@ -290,8 +285,3 @@ End Lam.
 (* { use nat_trans_functor_path_pregroupoid. apply homset_property. *)
 (*   use f. } *)
 (* use (pr1 (@monadSubstGen_instantiated sort SET BinCoproductsHSET STLC_Monad X' Y' f') t). *)
-(* use u. *)
-(* simpl. *)
-(* cbn. *)
-
-(* use u. *)

--- a/UniMath/SubstitutionSystems/STLC_alt.v
+++ b/UniMath/SubstitutionSystems/STLC_alt.v
@@ -58,10 +58,11 @@ Proof.
 exact (isofhlevelssnset 1 sort (setproperty sort)).
 Defined.
 
-(** A lot of notations, upstream? *)
+(** Some notations *)
 Local Infix "::" := (@cons _).
 Local Notation "[]" := (@nil _) (at level 0, format "[]").
 Local Notation "a + b" := (setcoprod a b) : set.
+Local Notation "s ⇒ t" := (arr s t).
 
 Let sortToSet : category := [path_pregroupoid sort,SET].
 Let hs : has_homsets sortToSet := homset_property sortToSet.
@@ -92,8 +93,8 @@ Proof.
 use mkMultiSortedSig.
 - apply ((sort × sort) + (sort × sort))%set.
 - intros H; induction H as [st|st]; induction st as [s t].
-  + exact ((([],,arr s t) :: ([],,s) :: nil),,t).
-  + exact (((cons s [],,t) :: []),,arr s t).
+  + exact ((([],,(s ⇒ t)) :: ([],,s) :: nil),,t).
+  + exact (((cons s [],,t) :: []),,(s ⇒ t)).
 Defined.
 
 (** The signature with strength for the simply typed lambda calculus *)
@@ -135,7 +136,7 @@ Local Notation "F ⊗ G" := (BinProduct_of_functors BinProd F G).
 
 (** The source of the application constructor *)
 Definition app_source (s t : sort) : functor sortToSet2 sortToSet2 :=
-    (post_comp_functor (projSortToSet sort (arr s t)) ⊗ post_comp_functor (projSortToSet sort s))
+    (post_comp_functor (projSortToSet sort (s ⇒ t)) ⊗ post_comp_functor (projSortToSet sort s))
   ∙ (post_comp_functor (hat_functorSet sort t)).
 
 (** The application constructor *)
@@ -148,7 +149,7 @@ Definition app_map (s t : sort) : sortToSet2⟦app_source s t STLC,STLC⟧ :=
 Definition lam_source (s t : sort) : functor sortToSet2 sortToSet2 :=
     pre_comp_functor (sorted_option_functorSet sort s)
   ∙ post_comp_functor (projSortToC sort _ t)
-  ∙ post_comp_functor (hat_functorSet sort (arr s t)).
+  ∙ post_comp_functor (hat_functorSet sort (s ⇒ t)).
 
 Definition lam_map (s t : sort) : sortToSet2⟦lam_source s t STLC,STLC⟧ :=
     CoproductIn _ _ (Coproducts_functor_precat _ _ _ _ _ (λ _, _)) (ii2 (s,,t))

--- a/UniMath/SubstitutionSystems/STLC_alt.v
+++ b/UniMath/SubstitutionSystems/STLC_alt.v
@@ -45,6 +45,7 @@ Require Import UniMath.SubstitutionSystems.LiftingInitial_alt.
 Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.SignatureExamples.
 Require Import UniMath.SubstitutionSystems.MultiSorted_alt.
+Require Import UniMath.SubstitutionSystems.MonadsMultiSorted_alt.
 
 Local Open Scope cat.
 
@@ -58,14 +59,13 @@ Proof.
 exact (isofhlevelssnset 1 sort (setproperty sort)).
 Defined.
 
-(** Some notations *)
-Local Infix "::" := (@cons _).
-Local Notation "[]" := (@nil _) (at level 0, format "[]").
-Local Notation "a + b" := (setcoprod a b) : set.
-Local Notation "s ⇒ t" := (arr s t).
-
 Let sortToSet : category := [path_pregroupoid sort,SET].
 Let hs : has_homsets sortToSet := homset_property sortToSet.
+
+Local Lemma TerminalSortToSet : Terminal sortToSet.
+Proof.
+apply Terminal_functor_precat, TerminalHSET.
+Defined.
 
 Local Lemma BinCoprodSortToSet : BinCoproducts sortToSet.
 Proof.
@@ -77,7 +77,15 @@ Proof.
 apply BinProducts_functor_precat, BinProductsHSET.
 Defined.
 
-Local Notation "'1'" := (functor_identity _).
+(** Some notations *)
+Local Infix "::" := (@cons _).
+Local Notation "[]" := (@nil _) (at level 0, format "[]").
+Local Notation "a + b" := (setcoprod a b) : set.
+Local Notation "s ⇒ t" := (arr s t).
+Local Notation "'Id'" := (functor_identity _).
+Local Notation "a ⊕ b" := (BinCoproductObject _ (BinCoprodSortToSet a b)).
+Local Notation "'1'" := (TerminalObject TerminalSortToSet).
+Local Notation "F ⊗ G" := (BinProduct_of_functors BinProd F G).
 
 Let sortToSet2 := [sortToSet,sortToSet].
 Let hs2 : has_homsets sortToSet2 := homset_property sortToSet2.
@@ -119,20 +127,24 @@ Definition STLC_Monad : Monad sortToSet :=
   MultiSortedSigToMonadSet sort STLC_Sig.
 
 (** Extract the constructors of the STLC from the initial algebra *)
-Definition STLC : sortToSet2 :=
+Definition STLC_M : sortToSet2 :=
   alg_carrier _ (InitialObject STLC_Functor_Initial).
 
-Let STLC_mor : sortToSet2⟦STLC_Functor STLC,STLC⟧ :=
+(* The functor parts coincide *)
+Lemma STLC_Monad_ok : STLC_M = pr1 (pr1 (pr1 STLC_Monad)).
+Proof.
+apply idpath.
+Qed.
+
+Let STLC_M_mor : sortToSet2⟦STLC_Functor STLC_M,STLC_M⟧ :=
   alg_map _ (InitialObject STLC_Functor_Initial).
 
-Let STLC_alg : algebra_ob STLC_Functor :=
+Let STLC_M_alg : algebra_ob STLC_Functor :=
   InitialObject STLC_Functor_Initial.
 
 (** The variables *)
-Definition var_map : sortToSet2⟦1,STLC⟧ :=
-  BinCoproductIn1 _ (BinCoprodSortToSet2 _ _) · STLC_mor.
-
-Local Notation "F ⊗ G" := (BinProduct_of_functors BinProd F G).
+Definition var_map : sortToSet2⟦Id,STLC_M⟧ :=
+  BinCoproductIn1 _ (BinCoprodSortToSet2 _ _) · STLC_M_mor.
 
 (** The source of the application constructor *)
 Definition app_source (s t : sort) : functor sortToSet2 sortToSet2 :=
@@ -140,10 +152,10 @@ Definition app_source (s t : sort) : functor sortToSet2 sortToSet2 :=
   ∙ (post_comp_functor (hat_functorSet sort t)).
 
 (** The application constructor *)
-Definition app_map (s t : sort) : sortToSet2⟦app_source s t STLC,STLC⟧ :=
+Definition app_map (s t : sort) : sortToSet2⟦app_source s t STLC_M,STLC_M⟧ :=
     CoproductIn _ _ (Coproducts_functor_precat _ _ _ _ _ (λ _, _)) (ii1 (s,,t))
   · BinCoproductIn2 _ (BinCoprodSortToSet2 _ _)
-  · STLC_mor.
+  · STLC_M_mor.
 
 (** The source of the lambda constructor *)
 Definition lam_source (s t : sort) : functor sortToSet2 sortToSet2 :=
@@ -151,12 +163,12 @@ Definition lam_source (s t : sort) : functor sortToSet2 sortToSet2 :=
   ∙ post_comp_functor (projSortToC sort _ t)
   ∙ post_comp_functor (hat_functorSet sort (s ⇒ t)).
 
-Definition lam_map (s t : sort) : sortToSet2⟦lam_source s t STLC,STLC⟧ :=
+Definition lam_map (s t : sort) : sortToSet2⟦lam_source s t STLC_M,STLC_M⟧ :=
     CoproductIn _ _ (Coproducts_functor_precat _ _ _ _ _ (λ _, _)) (ii2 (s,,t))
   · BinCoproductIn2 _ (BinCoprodSortToSet2 _ _)
-  · STLC_mor.
+  · STLC_M_mor.
 
-Definition make_STLC_Algebra X (fvar : sortToSet2⟦1,X⟧)
+Definition make_STLC_M_Algebra X (fvar : sortToSet2⟦Id,X⟧)
   (fapp : ∏ s t, sortToSet2⟦app_source s t X,X⟧)
   (flam : ∏ s t, sortToSet2⟦lam_source s t X,X⟧) :
     algebra_ob STLC_Functor.
@@ -168,14 +180,14 @@ induction b as [st|st]; induction st as [s t].
 Defined.
 
 (** The recursor for the stlc *)
-Definition foldr_map X (fvar : sortToSet2⟦1,X⟧)
+Definition foldr_map X (fvar : sortToSet2⟦Id,X⟧)
                        (fapp : ∏ s t, sortToSet2⟦app_source s t X,X⟧)
                        (flam : ∏ s t, sortToSet2⟦lam_source s t X,X⟧) :
-                        algebra_mor _ STLC_alg (make_STLC_Algebra X fvar fapp flam) :=
-  InitialArrow STLC_Functor_Initial (make_STLC_Algebra X fvar fapp flam).
+                        algebra_mor _ STLC_M_alg (make_STLC_M_Algebra X fvar fapp flam) :=
+  InitialArrow STLC_Functor_Initial (make_STLC_M_Algebra X fvar fapp flam).
 
 (** The equation for variables *)
-Lemma foldr_var X (fvar : sortToSet2⟦1,X⟧)
+Lemma foldr_var X (fvar : sortToSet2⟦Id,X⟧)
   (fapp : ∏ s t, sortToSet2⟦app_source s t X,X⟧)
   (flam : ∏ s t, sortToSet2⟦lam_source s t X,X⟧) :
   var_map · foldr_map X fvar fapp flam = fvar.
@@ -187,7 +199,7 @@ rewrite id_left.
 apply BinCoproductIn1Commutes.
 Qed.
 
-Lemma foldr_app X (fvar : sortToSet2⟦1,X⟧)
+Lemma foldr_app X (fvar : sortToSet2⟦Id,X⟧)
   (fapp : ∏ s t, sortToSet2⟦app_source s t X,X⟧)
   (flam : ∏ s t, sortToSet2⟦lam_source s t X,X⟧)
   (s t : sort) :
@@ -209,7 +221,7 @@ apply maponpaths.
 exact (CoproductInCommutes _ _ _ _ _ _ (inl (s,,t))).
 Qed.
 
-Lemma foldr_lam X (fvar : sortToSet2⟦1,X⟧)
+Lemma foldr_lam X (fvar : sortToSet2⟦Id,X⟧)
   (fapp : ∏ s t, sortToSet2⟦app_source s t X,X⟧)
   (flam : ∏ s t, sortToSet2⟦lam_source s t X,X⟧)
   (s t : sort) :
@@ -231,4 +243,55 @@ apply maponpaths.
 exact (CoproductInCommutes _ _ _ _ _ _ (inr (s,,t))).
 Qed.
 
+
+(* Now substitution *)
+Let STLC := STLC_Monad.
+
+(* Parallel substitution *)
+Definition psubst {X Y : sortToSet} (f : sortToSet⟦X, STLC Y ⟧) :
+  sortToSet⟦ STLC (X ⊕ Y), STLC Y ⟧ := monadSubstGen_instantiated _ _ _ f.
+
+(* Substitution of a single variable *)
+Definition subst {X : sortToSet} (f : sortToSet⟦ 1, STLC X ⟧) :
+  sortToSet⟦ STLC (1 ⊕ X), STLC X ⟧ := monadSubstGen_instantiated _ _ _ f.
+
+Definition weak {X Y : sortToSet} : sortToSet⟦STLC Y,STLC (X ⊕ Y)⟧ :=
+  mweak_instantiated sort SET BinCoproductsHSET.
+
+Definition exch {X Y Z : sortToSet} : sortToSet⟦STLC (X ⊕ (Y ⊕ Z)), STLC (Y ⊕ (X ⊕ Z))⟧ :=
+  mexch_instantiated sort SET BinCoproductsHSET.
+
+Lemma psubst_interchange {X Y Z : sortToSet}
+        (f : sortToSet⟦X,STLC (Y ⊕ Z)⟧) (g : sortToSet⟦Y, STLC Z⟧) :
+        psubst f · psubst g = exch · psubst (g · weak) · psubst (f · psubst g).
+Proof.
+apply subst_interchange_law_gen_instantiated.
+Qed.
+
+Lemma subst_interchange {X : sortToSet}
+        (f : sortToSet⟦1,STLC (1 ⊕ X)⟧) (g : sortToSet⟦1,STLC X⟧) :
+  subst f · subst g = exch · subst (g · weak) · subst (f · subst g).
+Proof.
+apply subst_interchange_law_gen_instantiated.
+Qed.
+
 End Lam.
+
+
+(* Definition psubst {X Y : sort → hSet} (f : ∏ t, X t → STLC Y t) (t : sort) : *)
+(*   STLC (λ t, (X t + Y t)%set) t → STLC Y t. *)
+(* Proof. *)
+(* intros u. *)
+(* transparent assert (X' : (sortToSet)). *)
+(* { use (functor_path_pregroupoid _); apply X. } *)
+(* transparent assert (Y' : (sortToSet)). *)
+(* { use (functor_path_pregroupoid _); apply Y. } *)
+(* transparent assert (f' : (sortToSet⟦ X' , STLC_Monad Y' ⟧)). *)
+(* { use nat_trans_functor_path_pregroupoid. apply homset_property. *)
+(*   use f. } *)
+(* use (pr1 (@monadSubstGen_instantiated sort SET BinCoproductsHSET STLC_Monad X' Y' f') t). *)
+(* use u. *)
+(* simpl. *)
+(* cbn. *)
+
+(* use u. *)


### PR DESCRIPTION
This PR does the following:
- Add PCF as a MS sig
- Port CoC à la Streicher as a 2-sorted sig to use `[sort,Set]`
- Instantiate abstract monadic interchange law for STLC
- Polish `MonadsMultiSorted_alt.v`