### PR TITLE
Added examples of displayed bicategories

### DIFF
--- a/UniMath/Bicategories/.package/files
+++ b/UniMath/Bicategories/.package/files
@@ -78,6 +78,8 @@ DisplayedBicats/Examples/Add2Cell.v
 DisplayedBicats/Examples/ContravariantFunctor.v
 DisplayedBicats/Examples/Cofunctormap.v
 DisplayedBicats/Examples/CwF.v
+DisplayedBicats/Examples/Domain.v
+DisplayedBicats/Examples/Codomain.v
 DisplayedBicats/DispPseudofunctor.v
 Transformations/Examples/AlgebraMap.v
 DisplayedBicats/Examples/Monads.v

--- a/UniMath/Bicategories/DisplayedBicats/Examples/Codomain.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/Codomain.v
@@ -489,45 +489,6 @@ Proof.
 Defined.
 
 
-(*
-Section UnivalenceOfCodomain.
-  Context (B : bicat).
-
-  Definition cod_univalent_2_1
-             (HB_2_1 : is_univalent_2_1 B)
-    : is_univalent_2_1 (total_bicat (cod_disp_bicat B)).
-  Proof.
-    use sigma_is_univalent_2_1.
-    - exact HB_2_1.
-    - use trivial_is_univalent_2_1.
-      exact HB_2_1.
-    - admit.
-  Admitted.
-
-
-  Definition cod_univalent_2_0
-             (HB_2_0 : is_univalent_2_0 B)
-             (HB_2_1 : is_univalent_2_1 B)
-    : is_univalent_2_0 (total_bicat (cod_disp_bicat B)).
-  Proof.
-    use sigma_is_univalent_2_0.
-    - split.
-      + exact HB_2_0.
-      + exact HB_2_1.
-    - split.
-      + use trivial_is_univalent_2_0.
-        * exact HB_2_1.
-        * exact HB_2_0.
-        * exact HB_2_1.
-      + use trivial_is_univalent_2_1.
-        exact HB_2_1.
-    - split.
-      + admit.
-      + admit.
-  Admitted.
-End UnivalenceOfCodomain.
- *)
-
 
 (** MOVE ??? *)
 Definition transportf_total2_paths_f
@@ -734,8 +695,330 @@ Section UnivalenceOfCodomain.
     exact (cod_1cell_path_help f₁ f₂ ∘ make_weq _ (HB_2_1 _ _ _ _))%weq.
   Defined.
 
-  Definition TODO {A : UU} : A.
-  Admitted.
+  Section AdjEquivToDispAdjEquiv.
+    Context {c : B}
+            {f₁ f₂ : cod_disp_bicat B c}
+            (e : adjoint_equivalence (pr1 f₁) (pr1 f₂))
+            (α : pr2 f₁ ==> pr1 e · pr2 f₂).
+
+    Definition cod_adj_equiv_to_disp_adj_equiv_map
+      : f₁ -->[ internal_adjoint_equivalence_identity c] f₂.
+    Proof.
+      use make_disp_1cell_cod.
+      - exact (pr1 e).
+      - exact (runitor _ • α).
+    Defined.
+
+    Definition cod_adj_equiv_to_disp_adj_equiv_right_adj
+      : f₂ -->[ internal_adjoint_equivalence_identity c] f₁.
+    Proof.
+      use make_disp_1cell_cod.
+      - exact (pr112 e).
+      - simpl.
+        refine (_ • (_ ◃ (inv_B _ _ _ _ α)^-1)).
+        refine (_ • rassociator _ _ _).
+        refine (_ • ((inv_B _ _ _ _ (pr2 (pr212 e)))^-1 ▹ _)).
+        exact (runitor _ • linvunitor _).
+    Defined.
+
+    Definition cod_adj_equiv_to_disp_adj_equiv_unit
+      : pr1 (id_disp f₁)
+        ==>
+        pr1 (cod_adj_equiv_to_disp_adj_equiv_map
+        ;;
+        cod_adj_equiv_to_disp_adj_equiv_right_adj)
+      := pr1 (pr212 e).
+
+    Definition cod_adj_equiv_to_disp_adj_equiv_unit_homot
+      : coherent_homot
+          (left_adjoint_unit (internal_adjoint_equivalence_identity c))
+          cod_adj_equiv_to_disp_adj_equiv_unit.
+    Proof.
+      unfold coherent_homot, cod_adj_equiv_to_disp_adj_equiv_unit ; cbn.
+      rewrite !vassocr.
+      refine (!_).
+      etrans.
+      {
+        do 4 apply maponpaths_2.
+        rewrite lwhisker_hcomp.
+        rewrite triangle_l_inv.
+        rewrite <- rwhisker_hcomp.
+        apply idpath.
+      }
+      rewrite !rwhisker_vcomp.
+      rewrite !vassocr.
+      rewrite rinvunitor_runitor.
+      rewrite id2_left.
+      rewrite !vassocl.
+      rewrite <- !lwhisker_vcomp.
+      rewrite !vassocl.
+      rewrite lwhisker_lwhisker.
+      rewrite !vassocr.
+      use vcomp_move_R_Mp.
+      {
+        is_iso.
+      }
+      cbn.
+      refine (!_).
+      etrans.
+      {
+        rewrite !vassocl.
+        rewrite vcomp_whisker.
+        etrans.
+        {
+          apply maponpaths.
+          rewrite !vassocr.
+          rewrite lwhisker_hcomp.
+          rewrite <- linvunitor_natural.
+          apply idpath.
+        }
+        rewrite !vassocr.
+        rewrite <- vcomp_runitor.
+        apply idpath.
+      }
+      rewrite !vassocl.
+      apply maponpaths ; clear α.
+      rewrite <- runitor_triangle.
+      rewrite !vassocl.
+      do 2 apply maponpaths.
+      refine (!_).
+      etrans.
+      {
+        apply maponpaths.
+        rewrite !vassocr.
+        rewrite lwhisker_vcomp.
+        apply idpath.
+      }
+      rewrite !vassocr.
+      rewrite lwhisker_vcomp.
+      use vcomp_move_R_pM.
+      {
+        is_iso.
+      }
+      cbn.
+      refine (!_).
+
+      rewrite linvunitor_assoc.
+      rewrite !vassocl.
+      rewrite <- rwhisker_rwhisker_alt.
+      rewrite !vassocr.
+      etrans.
+      {
+        apply maponpaths_2.
+        rewrite !vassocl.
+        rewrite rwhisker_vcomp.
+        apply maponpaths.
+        assert (linvunitor (pr1 e) • (pr121 (pr2 e) ▹ pr1 e)
+                =
+                rinvunitor _ • (pr1 e ◃ (pr222 (pr2 e))^-1) • lassociator _ _ _)
+          as p.
+        {
+          refine (_ @ id2_left _).
+          use vcomp_move_L_Mp.
+          {
+            is_iso.
+          }
+          cbn.
+          rewrite !vassocr.
+          exact (pr1 (pr122 e)).
+        }
+        apply maponpaths.
+        exact p.
+      }
+      unfold left_adjoint_right_adjoint.
+      use vcomp_move_R_Mp.
+      {
+        is_iso.
+      }
+      cbn.
+      rewrite <- lassociator_lassociator.
+      rewrite <- !lwhisker_vcomp.
+      rewrite !vassocl.
+      apply maponpaths.
+      rewrite <- !rwhisker_vcomp.
+      rewrite !vassocr.
+      apply maponpaths_2.
+      rewrite !vassocl.
+      refine (_ @ id2_right _).
+      use vcomp_move_L_pM.
+      {
+        is_iso.
+      }
+      cbn.
+      rewrite !vassocr.
+      rewrite rwhisker_lwhisker_rassociator.
+      rewrite !vassocl.
+      etrans.
+      {
+        apply maponpaths.
+        rewrite !vassocr.
+        apply maponpaths_2.
+        rewrite lunitor_lwhisker.
+        rewrite rwhisker_vcomp.
+        rewrite runitor_rinvunitor.
+        apply id2_rwhisker.
+      }
+      rewrite id2_left.
+      rewrite rwhisker_vcomp.
+      rewrite lwhisker_vcomp.
+      rewrite vcomp_rinv.
+      rewrite lwhisker_id2.
+      rewrite id2_rwhisker.
+      apply idpath.
+    Qed.
+
+    Definition cod_adj_equiv_to_disp_adj_equiv_counit
+      : pr1 (cod_adj_equiv_to_disp_adj_equiv_right_adj
+        ;;
+        cod_adj_equiv_to_disp_adj_equiv_map)
+        ==>
+        pr1 (id_disp f₂)
+      := pr2 (pr212 e).
+
+    Definition cod_adj_equiv_to_disp_adj_equiv_counit_homot
+      : coherent_homot
+          (left_adjoint_counit
+             (internal_adjoint_equivalence_identity c))
+          cod_adj_equiv_to_disp_adj_equiv_counit.
+    Proof.
+      unfold coherent_homot, cod_adj_equiv_to_disp_adj_equiv_counit ; cbn.
+      rewrite !vassocl.
+      rewrite <- rwhisker_vcomp.
+      rewrite !vassocr.
+      rewrite runitor_rwhisker.
+      rewrite !vassocl.
+      apply maponpaths.
+      rewrite !vassocr.
+      rewrite <- rwhisker_vcomp.
+      rewrite !vassocl.
+      etrans.
+      {
+        apply maponpaths.
+        rewrite !vassocr.
+        rewrite <- rwhisker_lwhisker_rassociator.
+        rewrite !vassocl.
+        apply maponpaths.
+        rewrite !vassocr.
+        rewrite lwhisker_vcomp.
+        rewrite !vassocr.
+        rewrite vcomp_runitor.
+        rewrite !vassocl.
+        rewrite vcomp_linv.
+        rewrite id2_right.
+        apply idpath.
+      }
+      rewrite <- rwhisker_vcomp.
+      rewrite !vassocl.
+      assert (rassociator (pr112 e) (pr1 e) (pr2 f₂) ▹ id₁ c
+              • rassociator (pr112 e) (pr1 e · pr2 f₂) (id₁ c)
+              • (pr112 e ◃ runitor (pr1 e · pr2 f₂))
+              • lassociator (pr112 e) (pr1 e) (pr2 f₂)
+              =
+              runitor _)
+        as p.
+      {
+        rewrite !vassocl.
+        rewrite !left_unit_assoc.
+        rewrite !vassocl.
+        rewrite <- vcomp_runitor.
+        etrans.
+        {
+          apply maponpaths.
+          rewrite !vassocr.
+          rewrite rassociator_lassociator.
+          rewrite id2_left.
+          apply idpath.
+        }
+        rewrite !vassocr.
+        rewrite rwhisker_vcomp.
+        rewrite rassociator_lassociator.
+        rewrite id2_rwhisker.
+        apply id2_left.
+      }
+      rewrite <- !rwhisker_vcomp.
+      etrans.
+      {
+        apply maponpaths.
+        rewrite !vassocl.
+        apply maponpaths.
+        rewrite !vassocr.
+        apply maponpaths_2.
+        exact p.
+      }
+      rewrite <- vcomp_runitor.
+      etrans.
+      {
+        apply maponpaths.
+        rewrite !vassocr.
+        apply maponpaths_2.
+        rewrite !rwhisker_vcomp.
+        rewrite vcomp_linv.
+        rewrite !id2_rwhisker.
+        apply idpath.
+      }
+      rewrite id2_left.
+      rewrite vcomp_runitor.
+      apply idpath.
+    Qed.
+
+    Definition cod_adj_equiv_to_disp_adj_equiv_disp_adj
+      : disp_left_adjoint_equivalence
+          (internal_adjoint_equivalence_identity c)
+          cod_adj_equiv_to_disp_adj_equiv_map.
+    Proof.
+      simple refine (_ ,, (_ ,, _)).
+      - simple refine (_ ,, (_ ,, _)).
+        + apply cod_adj_equiv_to_disp_adj_equiv_right_adj.
+        + use make_disp_2cell_cod.
+          * apply cod_adj_equiv_to_disp_adj_equiv_unit.
+          * exact cod_adj_equiv_to_disp_adj_equiv_unit_homot.
+        + use make_disp_2cell_cod.
+          * apply cod_adj_equiv_to_disp_adj_equiv_counit.
+          * exact cod_adj_equiv_to_disp_adj_equiv_counit_homot.
+      - simple refine (_ ,, _).
+        + cbn.
+          use subtypePath.
+          {
+            intro.
+            apply B.
+          }
+          cbn.
+          etrans.
+          {
+            exact (pr1 (pr122 e)).
+          }
+          refine (!_).
+          refine (@pr1_transportf _ (λ _, _) _ _ _ _ _ @ _).
+          rewrite transportf_const.
+          apply idpath.
+        + cbn.
+          use subtypePath.
+          {
+            intro.
+            apply B.
+          }
+          cbn.
+          etrans.
+          {
+            exact (pr2 (pr122 e)).
+          }
+          refine (!_).
+          refine (@pr1_transportf _ (λ _, _) _ _ _ _ _ @ _).
+          rewrite transportf_const.
+          apply idpath.
+      - simple refine (_ ,, _) ;
+        apply disp_locally_groupoid_cod ;
+        exact inv_B.
+    Qed.
+
+    Definition cod_adj_equiv_to_disp_adj_equiv_help
+      : disp_adjoint_equivalence (internal_adjoint_equivalence_identity c) f₁ f₂.
+    Proof.
+      simple refine (_ ,, _).
+      - exact cod_adj_equiv_to_disp_adj_equiv_map.
+      - exact cod_adj_equiv_to_disp_adj_equiv_disp_adj.
+    Defined.
+  End AdjEquivToDispAdjEquiv.
 
   Definition cod_adj_equiv_to_disp_adj_equiv
              {c : B}
@@ -745,58 +1028,7 @@ Section UnivalenceOfCodomain.
       disp_adjoint_equivalence (internal_adjoint_equivalence_identity c) f₁ f₂.
   Proof.
     intro e.
-    induction e as [ e α ].
-    simple refine (_ ,, _).
-    - use make_disp_1cell_cod.
-      + exact (pr1 e).
-      + exact (runitor _ • α).
-    - simpl.
-      simple refine (_ ,, (_ ,, _)).
-      + simple refine (_ ,, (_ ,, _)).
-        * use make_disp_1cell_cod.
-          ** exact (pr112 e).
-          ** simpl.
-             refine (_ • (_ ◃ (inv_B _ _ _ _ α)^-1)).
-             refine (_ • rassociator _ _ _).
-             refine (_ • ((inv_B _ _ _ _ (pr2 (pr212 e)))^-1 ▹ _)).
-             exact (runitor _ • linvunitor _).
-        * use make_disp_2cell_cod.
-          ** exact (pr1 (pr212 e)).
-          ** cbn.
-             apply TODO.
-        * use make_disp_2cell_cod.
-          ** exact (pr2 (pr212 e)).
-          ** cbn.
-             unfold coherent_homot.
-             cbn.
-             rewrite !vassocl.
-             apply TODO.
-      + simple refine (_ ,, _).
-        * abstract
-            (cbn ;
-             use subtypePath ; [ intro ; apply B | ] ;
-             cbn ;
-             etrans ; [ exact (pr1 (pr122 e)) | ] ;
-             refine (!_) ;
-             refine (@pr1_transportf _ (λ _, _) _ _ _ _ _ @ _) ;
-             rewrite transportf_const ;
-             apply idpath).
-        * abstract
-            (cbn ;
-             use subtypePath ; [ intro ; apply B | ] ;
-             cbn ;
-             etrans ; [ exact (pr2 (pr122 e)) | ] ;
-             refine (!_) ;
-             refine (@pr1_transportf _ (λ _, _) _ _ _ _ _ @ _) ;
-             rewrite transportf_const ;
-             apply idpath).
-      + simple refine (_ ,, _).
-        * abstract
-            (apply disp_locally_groupoid_cod ;
-             exact inv_B).
-        * abstract
-            (apply disp_locally_groupoid_cod ;
-             exact inv_B).
+    exact (cod_adj_equiv_to_disp_adj_equiv_help (pr1 e) (pr2 e)).
   Defined.
 
   Definition cod_disp_adj_equiv_to_adj_equiv
@@ -886,7 +1118,7 @@ Section UnivalenceOfCodomain.
         exact HB_2_1.
     }
     cbn.
-    unfold make_disp_1cell_cod.
+    unfold cod_adj_equiv_to_disp_adj_equiv_map, make_disp_1cell_cod.
     use maponpaths.
     rewrite vassocr.
     rewrite runitor_rinvunitor.

--- a/UniMath/Bicategories/DisplayedBicats/Examples/Codomain.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/Codomain.v
@@ -1,0 +1,939 @@
+Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.All.
+Require Import UniMath.CategoryTheory.Core.Prelude.
+Require Import UniMath.CategoryTheory.opp_precat.
+Require Import UniMath.CategoryTheory.Core.Functors.
+Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
+Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
+Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.DisplayedCats.Core.
+Require Import UniMath.CategoryTheory.DisplayedCats.Constructions.
+Require Import UniMath.Bicategories.Core.Bicat. Import Bicat.Notations.
+Require Import UniMath.Bicategories.Core.Adjunctions.
+Require Import UniMath.Bicategories.Core.Invertible_2cells.
+Require Import UniMath.Bicategories.Core.Univalence.
+Require Import UniMath.Bicategories.Core.Unitors.
+Require Import UniMath.Bicategories.Core.BicategoryLaws.
+Require Import UniMath.Bicategories.Core.AdjointUnique.
+Require Import UniMath.Bicategories.Core.Examples.OneTypes.
+Require Import UniMath.Bicategories.DisplayedBicats.Examples.ContravariantFunctor.
+Require Import UniMath.Bicategories.DisplayedBicats.DispBicat.
+Import DispBicat.Notations.
+Require Import UniMath.Bicategories.DisplayedBicats.DispAdjunctions.
+Require Import UniMath.Bicategories.DisplayedBicats.DispInvertibles.
+Require Import UniMath.Bicategories.DisplayedBicats.DispUnivalence.
+Require Import UniMath.Bicategories.DisplayedBicats.Examples.Trivial.
+Require Import UniMath.Bicategories.DisplayedBicats.Examples.Sigma.
+
+Local Open Scope cat.
+Local Open Scope mor_disp_scope.
+
+Section CodomainArrow.
+  Variable (B : bicat).
+
+  Definition cod_disp_prebicat_1_id_comp_cells
+    : disp_prebicat_1_id_comp_cells (prod_bicat B B).
+  Proof.
+    use tpair.
+    - use tpair.
+      + use tpair.
+        * exact (λ X, pr2 X --> pr1 X).
+        * exact (λ X Y fX fY f, fX · pr1 f ==> pr2 f · fY).
+      + use tpair.
+        * exact (λ X fX, runitor _ • linvunitor _).
+        * exact (λ X Y Z f g fX fY fZ ff fg,
+                 lassociator _ _ _
+                 • (ff ▹ _)
+                 • rassociator _ _ _
+                 • (_ ◃ fg)
+                 • lassociator _ _ _).
+    - exact (λ X Y f g α fX fY ff fg,
+             ff • (pr2 α ▹ _)
+             =
+             (_ ◃ pr1 α) • fg).
+  Defined.
+
+  Definition cod_disp_prebicat_ops
+    : disp_prebicat_ops cod_disp_prebicat_1_id_comp_cells.
+  Proof.
+    repeat split.
+    - intros X Y f fX fY pf.
+      simpl ; cbn.
+      rewrite id2_rwhisker, id2_right.
+      rewrite lwhisker_id2, id2_left.
+      apply idpath.
+    - intros X Y f fX fY pf.
+      simpl ; cbn.
+      rewrite <- rwhisker_vcomp.
+      rewrite !vassocr.
+      rewrite runitor_rwhisker.
+      rewrite !vassocl.
+      apply maponpaths.
+      rewrite !vassocr.
+      rewrite <- linvunitor_assoc.
+      rewrite lwhisker_hcomp.
+      rewrite <- linvunitor_natural.
+      rewrite !vassocl.
+      rewrite lunitor_triangle.
+      rewrite linvunitor_lunitor.
+      apply id2_right.
+    - intros X Y f fX fY pf.
+      simpl ; cbn.
+      rewrite !vassocl.
+      rewrite runitor_rwhisker.
+      rewrite lwhisker_vcomp.
+      rewrite !vassocl.
+      rewrite linvunitor_lunitor, id2_right.
+      rewrite runitor_triangle.
+      rewrite vcomp_runitor.
+      rewrite !vassocr.
+      apply maponpaths_2.
+      rewrite left_unit_assoc.
+      apply idpath.
+    - intros X Y f fX fY pf.
+      simpl ; cbn.
+      rewrite !vassocr.
+      rewrite lwhisker_hcomp.
+      rewrite triangle_l_inv.
+      rewrite <- rwhisker_hcomp.
+      rewrite rwhisker_vcomp.
+      rewrite !vassocr.
+      rewrite rinvunitor_runitor, id2_left.
+      rewrite <- linvunitor_assoc.
+      rewrite lwhisker_hcomp.
+      rewrite <- linvunitor_natural.
+      rewrite !vassocl.
+      rewrite linvunitor_assoc.
+      rewrite !vassocl.
+      rewrite rassociator_lassociator, id2_right.
+      apply idpath.
+    - intros X Y f fX fY pf.
+      simpl ; cbn.
+      rewrite !vassocr.
+      rewrite rinvunitor_triangle.
+      rewrite !rwhisker_hcomp.
+      rewrite <- rinvunitor_natural.
+      rewrite !vassocl.
+      apply maponpaths.
+      rewrite !vassocr.
+      rewrite <- left_unit_inv_assoc.
+      rewrite lwhisker_vcomp.
+      rewrite !vassocr.
+      rewrite rinvunitor_runitor, id2_left.
+      rewrite lwhisker_hcomp.
+      rewrite triangle_l_inv.
+      apply idpath.
+    - intros X₁ X₂ X₃ X₄ f g h fX₁ fX₂ fX₃ fX₄ pf pg ph.
+      simpl ; cbn.
+      rewrite <- !rwhisker_vcomp.
+      rewrite <- !lwhisker_vcomp.
+      rewrite !vassocl.
+      use vcomp_move_L_pM.
+      { is_iso. }
+      simpl.
+      etrans.
+      {
+        rewrite !vassocr.
+        etrans.
+        {
+          do 8 apply maponpaths_2.
+          apply lassociator_lassociator.
+        }
+        rewrite !vassocl.
+        apply idpath.
+      }
+      apply maponpaths.
+      etrans.
+      {
+        rewrite !vassocr.
+        rewrite rwhisker_rwhisker.
+        rewrite !vassocl.
+        apply idpath.
+      }
+      apply maponpaths.
+      rewrite !vassocr.
+      use vcomp_move_R_Mp.
+      { is_iso. }
+      simpl.
+      rewrite !vassocl.
+      refine (!_).
+      etrans.
+      {
+        do 5 apply maponpaths.
+        rewrite !vassocr.
+        apply lassociator_lassociator.
+      }
+      rewrite !vassocr.
+      apply maponpaths_2.
+      rewrite !vassocl.
+      rewrite lwhisker_lwhisker.
+      rewrite !vassocr.
+      apply maponpaths_2.
+      use vcomp_move_L_Mp.
+      { is_iso. }
+      simpl.
+      etrans.
+      {
+        rewrite !vassocl.
+        do 4 apply maponpaths.
+        exact (!(lassociator_lassociator _ _ _ _)).
+      }
+      rewrite !vassocr.
+      apply maponpaths_2.
+      etrans.
+      {
+        rewrite !vassocl.
+        do 3 apply maponpaths.
+        rewrite !vassocr.
+        rewrite lwhisker_vcomp.
+        rewrite rassociator_lassociator, lwhisker_id2.
+        apply id2_left.
+      }
+      rewrite rwhisker_lwhisker.
+      rewrite !vassocr.
+      apply maponpaths_2.
+      rewrite !vassocl.
+      use vcomp_move_R_pM.
+      { is_iso. }
+      simpl.
+      rewrite !vassocr.
+      use vcomp_move_L_Mp.
+      { is_iso. }
+      simpl.
+      rewrite lassociator_lassociator.
+      apply idpath.
+    - intros X₁ X₂ X₃ X₄ f g h fX₁ fX₂ fX₃ fX₄ pf pg ph.
+      simpl ; cbn.
+      rewrite <- !rwhisker_vcomp.
+      rewrite <- !lwhisker_vcomp.
+      rewrite !vassocr.
+      refine (!_).
+      etrans.
+      {
+        do 7 apply maponpaths_2.
+        rewrite lassociator_lassociator.
+        apply idpath.
+      }
+      rewrite !vassocl.
+      apply maponpaths.
+      etrans.
+      {
+        rewrite !vassocr.
+        rewrite rwhisker_rwhisker.
+        rewrite !vassocl.
+        apply idpath.
+      }
+      apply maponpaths.
+      use vcomp_move_L_pM.
+      { is_iso. }
+      simpl.
+      etrans.
+      {
+        rewrite !vassocr.
+        rewrite <- lassociator_lassociator.
+        rewrite !vassocl.
+        do 2 apply maponpaths.
+        rewrite !vassocr.
+        rewrite rwhisker_vcomp.
+        rewrite lassociator_rassociator, id2_rwhisker.
+        rewrite id2_left.
+        rewrite !vassocl.
+        apply idpath.
+      }
+      apply maponpaths.
+      etrans.
+      {
+        rewrite !vassocr.
+        rewrite <- rwhisker_lwhisker.
+        rewrite !vassocl.
+        apply idpath.
+      }
+      apply maponpaths.
+      use vcomp_move_L_pM.
+      { is_iso. }
+      simpl.
+      etrans.
+      {
+        rewrite !vassocr.
+        rewrite lassociator_lassociator.
+        rewrite !vassocl.
+        apply maponpaths.
+        rewrite !vassocr.
+        rewrite lassociator_rassociator.
+        rewrite id2_left.
+        apply idpath.
+      }
+      rewrite !vassocr.
+      rewrite <- lwhisker_lwhisker.
+      rewrite !vassocl.
+      apply maponpaths.
+      rewrite <- lassociator_lassociator.
+      rewrite vassocr.
+      apply idpath.
+    - intros X Y f g h p q fX fY pf pg ph pp pq.
+      simpl ; cbn in *.
+      rewrite <- rwhisker_vcomp.
+      rewrite !vassocr.
+      rewrite pp.
+      rewrite !vassocl.
+      rewrite pq.
+      rewrite !vassocr.
+      apply maponpaths_2.
+      apply lwhisker_vcomp.
+    - intros X Y Z f g₁ g₂ p fX fY fZ pf pg₁ pg₂ pp.
+      simpl ; cbn in *.
+      rewrite !vassocr.
+      rewrite lwhisker_lwhisker.
+      rewrite !vassocl.
+      apply maponpaths.
+      rewrite !vassocr.
+      rewrite <- vcomp_whisker.
+      rewrite !vassocl.
+      apply maponpaths.
+      rewrite !vassocr.
+      rewrite <- lwhisker_lwhisker_rassociator.
+      rewrite !vassocl.
+      apply maponpaths.
+      rewrite <- rwhisker_lwhisker.
+      rewrite !vassocr.
+      apply maponpaths_2.
+      rewrite !lwhisker_vcomp.
+      apply maponpaths.
+      exact pp.
+    - intros X Y Z f₁ f₂ g p fX fY fZ pf₁ pf₂ pg pp.
+      simpl ; cbn in *.
+      rewrite !vassocr.
+      rewrite rwhisker_lwhisker.
+      rewrite !vassocl.
+      apply maponpaths.
+      rewrite rwhisker_rwhisker.
+      rewrite !vassocr.
+      apply maponpaths_2.
+      rewrite rwhisker_vcomp.
+      rewrite <- pp.
+      rewrite <- rwhisker_vcomp.
+      rewrite !vassocl.
+      apply maponpaths.
+      rewrite !vassocr.
+      rewrite rwhisker_rwhisker_alt.
+      rewrite !vassocl.
+      rewrite vcomp_whisker.
+      apply idpath.
+  Qed.
+
+  Definition cod_disp_prebicat_data
+    : disp_prebicat_data (prod_bicat B B).
+  Proof.
+    use tpair.
+    - exact cod_disp_prebicat_1_id_comp_cells.
+    - exact cod_disp_prebicat_ops.
+  Defined.
+
+  Definition cod_disp_prebicat_laws
+    : disp_prebicat_laws cod_disp_prebicat_data.
+  Proof.
+    repeat split ; intro ; intros ; apply B.
+  Qed.
+
+  Definition cod_disp_prebicat
+    : disp_prebicat (prod_bicat B B).
+  Proof.
+    use tpair.
+    - exact cod_disp_prebicat_data.
+    - exact cod_disp_prebicat_laws.
+  Defined.
+
+  Definition cod_has_disp_cellset
+    : has_disp_cellset cod_disp_prebicat.
+  Proof.
+    intros X Y f g p fX fY pf pg.
+    apply isasetaprop.
+    apply B.
+  Qed.
+
+  Definition cod_disp_bicat_help
+    : disp_bicat (prod_bicat B B).
+  Proof.
+    use tpair.
+    - exact cod_disp_prebicat.
+    - exact cod_has_disp_cellset.
+  Defined.
+
+  Definition cod_disp_bicat
+    : disp_bicat B
+    := sigma_bicat _ _ cod_disp_bicat_help.
+End CodomainArrow.
+
+(** Some projections and builders *)
+Definition dom
+           {B : bicat}
+           {X : B}
+           (f : cod_disp_bicat B X)
+  : B
+  := pr1 f.
+
+Definition ar
+           {B : bicat}
+           {X : B}
+           (f : cod_disp_bicat B X)
+  : dom f --> X
+  := pr2 f.
+
+Definition make_ar
+           {B : bicat}
+           {X Y : B}
+           (f : X --> Y)
+  : cod_disp_bicat B Y
+  := (X ,, f).
+
+Definition make_disp_1cell_cod
+           {B : bicat}
+           {X Y : B}
+           {f : X --> Y}
+           {dX : cod_disp_bicat B X}
+           {dY : cod_disp_bicat B Y}
+           (h : dom dX --> dom dY)
+           (p : pr2 dX · f ==> h · pr2 dY)
+  : dX -->[ f ] dY
+  := h ,, p.
+
+Definition coherent_homot
+           {B : bicat}
+           {X Y : B}
+           {f g : X --> Y}
+           (α : f ==> g)
+           {dX : cod_disp_bicat B X}
+           {dY : cod_disp_bicat B Y}
+           {df : dX -->[ f ] dY}
+           {dg : dX -->[ g ] dY}
+           (h : pr1 df ==> pr1 dg)
+  : UU
+  := pr2 df • (h ▹ pr2 dY)
+     =
+     (pr2 dX ◃ α) • pr2 dg.
+
+Definition make_disp_2cell_cod
+           {B : bicat}
+           {X Y : B}
+           {f g : X --> Y}
+           {α : f ==> g}
+           {dX : cod_disp_bicat B X}
+           {dY : cod_disp_bicat B Y}
+           {df : dX -->[ f ] dY}
+           {dg : dX -->[ g ] dY}
+           (h : pr1 df ==> pr1 dg)
+           (hh : coherent_homot α h)
+  : df ==>[ α ] dg
+  := h ,, hh.
+
+Definition is_disp_invertible_2cell_cod
+           {B : bicat}
+           {X Y : B}
+           {f g : X --> Y}
+           {α : invertible_2cell f g}
+           {dX : cod_disp_bicat B X}
+           {dY : cod_disp_bicat B Y}
+           {ff : dX -->[ f ] dY}
+           {gg : dX -->[ g ] dY}
+           (αα : ff ==>[ α ] gg)
+           (Hαα : is_invertible_2cell (pr1 αα))
+  : is_disp_invertible_2cell α αα.
+Proof.
+  use tpair.
+  - use tpair.
+    + exact (Hαα^-1).
+    + abstract
+        (simpl ;
+         use vcomp_move_R_Mp ; is_iso ;
+         simpl ;
+         rewrite !vassocl ;
+         use vcomp_move_L_pM ; is_iso ;
+         simpl ;
+         refine (!_) ;
+         apply αα).
+  - split.
+    + abstract
+        (use subtypePath ; [ intro ; apply B | ] ;
+         simpl ;
+         unfold transportb ;
+         rewrite pr1_transportf ;
+         rewrite transportf_const ;
+         unfold idfun ; cbn ;
+         apply vcomp_rinv).
+    + abstract
+        (use subtypePath ; [ intro ; apply B | ] ;
+         simpl ;
+         unfold transportb ;
+         rewrite pr1_transportf ;
+         rewrite transportf_const ;
+         cbn ;
+         apply vcomp_linv).
+Defined.
+
+Definition disp_locally_groupoid_cod
+           (B : bicat)
+           (inv_B : ∏ (a b : B) (f g : a --> b) (x : f ==> g),
+                    is_invertible_2cell x)
+  : disp_locally_groupoid (cod_disp_bicat B).
+Proof.
+  intro ; intros.
+  apply is_disp_invertible_2cell_cod.
+  apply inv_B.
+Defined.
+
+Definition disp_locally_groupoid_cod_one_types
+  : disp_locally_groupoid (cod_disp_bicat one_types).
+Proof.
+  use disp_locally_groupoid_cod.
+  exact @one_type_2cell_iso.
+Defined.
+
+
+(*
+Section UnivalenceOfCodomain.
+  Context (B : bicat).
+
+  Definition cod_univalent_2_1
+             (HB_2_1 : is_univalent_2_1 B)
+    : is_univalent_2_1 (total_bicat (cod_disp_bicat B)).
+  Proof.
+    use sigma_is_univalent_2_1.
+    - exact HB_2_1.
+    - use trivial_is_univalent_2_1.
+      exact HB_2_1.
+    - admit.
+  Admitted.
+
+
+  Definition cod_univalent_2_0
+             (HB_2_0 : is_univalent_2_0 B)
+             (HB_2_1 : is_univalent_2_1 B)
+    : is_univalent_2_0 (total_bicat (cod_disp_bicat B)).
+  Proof.
+    use sigma_is_univalent_2_0.
+    - split.
+      + exact HB_2_0.
+      + exact HB_2_1.
+    - split.
+      + use trivial_is_univalent_2_0.
+        * exact HB_2_1.
+        * exact HB_2_0.
+        * exact HB_2_1.
+      + use trivial_is_univalent_2_1.
+        exact HB_2_1.
+    - split.
+      + admit.
+      + admit.
+  Admitted.
+End UnivalenceOfCodomain.
+ *)
+
+
+(** MOVE ??? *)
+Definition transportf_total2_paths_f
+           {A : UU}
+           {B : A → UU}
+           (C : A → UU)
+           {a₁ a₂ : A}
+           {b₁ : B a₁}
+           {b₂ : B a₂}
+           (p : a₁ = a₂)
+           (q : transportf B p b₁ = b₂)
+           (c₁ : C a₁)
+  : transportf
+      (λ z, C (pr1 z))
+      (@total2_paths_f
+         A B
+         (a₁ ,, b₁) (a₂ ,, b₂)
+         p
+         q)
+      c₁
+    =
+    transportf
+      C
+      p
+      c₁.
+Proof.
+  induction p.
+  induction q.
+  apply idpath.
+Defined.
+
+
+Section UnivalenceOfCodomain.
+  Context (B : bicat)
+          (inv_B : ∏ (a b : B) (f g : a --> b) (x : f ==> g),
+                   is_invertible_2cell x).
+
+  Definition cod_invertible_2_cell_to_disp_invertible_help
+             {c₁ c₂ : B}
+             {f : B ⟦ c₁, c₂ ⟧}
+             {φ₁ : cod_disp_bicat B c₁}
+             {φ₂ : cod_disp_bicat B c₂}
+             {ψ₁ ψ₂ : φ₁ -->[ f] φ₂}
+             (α : invertible_2cell (pr1 ψ₁) (pr1 ψ₂))
+             (Hα : coherent_homot (id2_invertible_2cell f) (pr1 α))
+    : disp_invertible_2cell (id2_invertible_2cell f) ψ₁ ψ₂.
+  Proof.
+    simple refine (_ ,, _).
+    - use make_disp_2cell_cod.
+      + exact (pr1 α).
+      + exact Hα.
+    - apply disp_locally_groupoid_cod.
+      exact inv_B.
+  Defined.
+
+  Definition cod_invertible_2_cell_to_disp_invertible
+             {c₁ c₂ : B}
+             {f : B ⟦ c₁, c₂ ⟧}
+             {φ₁ : cod_disp_bicat B c₁}
+             {φ₂ : cod_disp_bicat B c₂}
+             {ψ₁ ψ₂ : φ₁ -->[ f] φ₂}
+    : (∑ (α : invertible_2cell (pr1 ψ₁) (pr1 ψ₂)),
+       coherent_homot (id2_invertible_2cell f) (pr1 α))
+      →
+      disp_invertible_2cell (id2_invertible_2cell f) ψ₁ ψ₂.
+  Proof.
+    intro α.
+    exact (cod_invertible_2_cell_to_disp_invertible_help _ (pr2 α)).
+  Defined.
+
+  Definition cod_disp_invertible_invertible_2_cell
+             {c₁ c₂ : B}
+             {f : B ⟦ c₁, c₂ ⟧}
+             {φ₁ : cod_disp_bicat B c₁}
+             {φ₂ : cod_disp_bicat B c₂}
+             {ψ₁ ψ₂ : φ₁ -->[ f] φ₂}
+    : disp_invertible_2cell (id2_invertible_2cell f) ψ₁ ψ₂
+      →
+      ∑ (α : invertible_2cell (pr1 ψ₁) (pr1 ψ₂)),
+      coherent_homot (id2_invertible_2cell f) (pr1 α).
+  Proof.
+    intro α.
+    simple refine ((_ ,, _) ,, _).
+    - exact (pr11 α).
+    - apply inv_B.
+    - exact (pr21 α).
+  Defined.
+
+  Definition cod_invertible_2_cell_weq_disp_invertible
+             {c₁ c₂ : B}
+             {f : B ⟦ c₁, c₂ ⟧}
+             {φ₁ : cod_disp_bicat B c₁}
+             {φ₂ : cod_disp_bicat B c₂}
+             {ψ₁ ψ₂ : φ₁ -->[ f] φ₂}
+    : (∑ (α : invertible_2cell (pr1 ψ₁) (pr1 ψ₂)),
+       coherent_homot (id2_invertible_2cell f) (pr1 α))
+      ≃
+      disp_invertible_2cell (id2_invertible_2cell f) ψ₁ ψ₂.
+  Proof.
+    use make_weq.
+    - exact cod_invertible_2_cell_to_disp_invertible.
+    - use gradth.
+      + exact cod_disp_invertible_invertible_2_cell.
+      + abstract
+          (intro α ;
+           use subtypePath ; [ intro ; apply B | ] ;
+           use subtypePath ; [ intro ; apply isaprop_is_invertible_2cell | ] ;
+           apply idpath).
+      + abstract
+          (intro α ;
+           use subtypePath ; [ intro ; apply isaprop_is_disp_invertible_2cell | ] ;
+           use subtypePath ; [ intro ; apply B | ] ;
+           apply idpath).
+  Defined.
+
+  Definition cod_2cell_path
+             {c₁ c₂ : B}
+             {f : B ⟦ c₁, c₂ ⟧}
+             {φ₁ : cod_disp_bicat B c₁}
+             {φ₂ : cod_disp_bicat B c₂}
+             {ψ₁ ψ₂ : φ₁ -->[ f ] φ₂}
+             (p : pr1 ψ₁ = pr1 ψ₂)
+    : (transportf (λ x, pr2 φ₁ · f ==> x · pr2 φ₂) p (pr2 ψ₁) = pr2 ψ₂)
+      ≃
+      coherent_homot (id₂ f) (pr1 (idtoiso_2_1 (pr1 ψ₁) (pr1 ψ₂) p)).
+  Proof.
+    induction ψ₁ as [ψ₁ q₁].
+    induction ψ₂ as [ψ₂ q₂].
+    cbn in *.
+    induction p.
+    cbn.
+    unfold coherent_homot.
+    cbn.
+    rewrite id2_rwhisker.
+    rewrite id2_right.
+    rewrite lwhisker_id2.
+    rewrite id2_left.
+    apply idweq.
+  Qed.
+
+  Definition cod_disp_univalent_2_1
+             (HB_2_1 : is_univalent_2_1 B)
+    : disp_univalent_2_1 (cod_disp_bicat B).
+  Proof.
+    use fiberwise_local_univalent_is_univalent_2_1.
+    intros c₁ c₂ f φ₁ φ₂ ψ₁ ψ₂.
+    use weqhomot.
+    - exact (cod_invertible_2_cell_weq_disp_invertible
+             ∘ weqtotal2 (make_weq _ (HB_2_1 _ _ _ _)) cod_2cell_path
+             ∘ total2_paths_equiv _ _ _)%weq.
+    - intro p.
+      induction p.
+      use subtypePath.
+      {
+        intro ; apply isaprop_is_disp_invertible_2cell.
+      }
+      use subtypePath.
+      {
+        intro ; apply B.
+      }
+      apply idpath.
+  Defined.
+
+  Definition cod_1cell_path_help
+             {b c : B}
+             (f₁ f₂ : B ⟦ b , c ⟧)
+    : invertible_2cell f₁ f₂ ≃ f₁ ==> id₁ _ · f₂.
+  Proof.
+    use make_weq.
+    - intro α.
+      exact (α • linvunitor _).
+    - use gradth.
+      + intro α.
+        use make_invertible_2cell.
+        * exact (α • lunitor _).
+        * apply inv_B.
+      + abstract
+          (intro p ;
+           use subtypePath ; [ intro ; apply isaprop_is_invertible_2cell | ] ;
+           cbn ;
+           rewrite vassocl ;
+           rewrite linvunitor_lunitor ;
+           apply id2_right).
+      + abstract
+          (intros α ; cbn ;
+           rewrite vassocl ;
+           rewrite lunitor_linvunitor ;
+           apply id2_right).
+  Defined.
+
+  Definition cod_1cell_path
+             (HB_2_1 : is_univalent_2_1 B)
+             {c : B}
+             (f₁ f₂ : cod_disp_bicat B c)
+             (p : pr1 f₁ = pr1 f₂)
+    : (transportf (λ b, B ⟦ b, c ⟧) p (pr2 f₁) = pr2 f₂)
+      ≃
+      pr2 f₁ ==> idtoiso_2_0 _ _ p · pr2 f₂.
+  Proof.
+    induction f₁ as [ c₁ f₁ ].
+    induction f₂ as [ c₂ f₂ ].
+    cbn in *.
+    induction p.
+    exact (cod_1cell_path_help f₁ f₂ ∘ make_weq _ (HB_2_1 _ _ _ _))%weq.
+  Defined.
+
+  Definition TODO {A : UU} : A.
+  Admitted.
+
+  Definition cod_adj_equiv_to_disp_adj_equiv
+             {c : B}
+             {f₁ f₂ : cod_disp_bicat B c}
+    : (∑ (y : adjoint_equivalence (pr1 f₁) (pr1 f₂)), pr2 f₁ ==> pr1 y · pr2 f₂)
+      →
+      disp_adjoint_equivalence (internal_adjoint_equivalence_identity c) f₁ f₂.
+  Proof.
+    intro e.
+    induction e as [ e α ].
+    simple refine (_ ,, _).
+    - use make_disp_1cell_cod.
+      + exact (pr1 e).
+      + exact (runitor _ • α).
+    - simpl.
+      simple refine (_ ,, (_ ,, _)).
+      + simple refine (_ ,, (_ ,, _)).
+        * use make_disp_1cell_cod.
+          ** exact (pr112 e).
+          ** simpl.
+             refine (_ • (_ ◃ (inv_B _ _ _ _ α)^-1)).
+             refine (_ • rassociator _ _ _).
+             refine (_ • ((inv_B _ _ _ _ (pr2 (pr212 e)))^-1 ▹ _)).
+             exact (runitor _ • linvunitor _).
+        * use make_disp_2cell_cod.
+          ** exact (pr1 (pr212 e)).
+          ** cbn.
+             apply TODO.
+        * use make_disp_2cell_cod.
+          ** exact (pr2 (pr212 e)).
+          ** cbn.
+             unfold coherent_homot.
+             cbn.
+             rewrite !vassocl.
+             apply TODO.
+      + simple refine (_ ,, _).
+        * abstract
+            (cbn ;
+             use subtypePath ; [ intro ; apply B | ] ;
+             cbn ;
+             etrans ; [ exact (pr1 (pr122 e)) | ] ;
+             refine (!_) ;
+             refine (@pr1_transportf _ (λ _, _) _ _ _ _ _ @ _) ;
+             rewrite transportf_const ;
+             apply idpath).
+        * abstract
+            (cbn ;
+             use subtypePath ; [ intro ; apply B | ] ;
+             cbn ;
+             etrans ; [ exact (pr2 (pr122 e)) | ] ;
+             refine (!_) ;
+             refine (@pr1_transportf _ (λ _, _) _ _ _ _ _ @ _) ;
+             rewrite transportf_const ;
+             apply idpath).
+      + simple refine (_ ,, _).
+        * abstract
+            (apply disp_locally_groupoid_cod ;
+             exact inv_B).
+        * abstract
+            (apply disp_locally_groupoid_cod ;
+             exact inv_B).
+  Defined.
+
+  Definition cod_disp_adj_equiv_to_adj_equiv
+             {c : B}
+             {f₁ f₂ : cod_disp_bicat B c}
+    : disp_adjoint_equivalence (internal_adjoint_equivalence_identity c) f₁ f₂
+      →
+      ∑ (y : adjoint_equivalence (pr1 f₁) (pr1 f₂)), pr2 f₁ ==> pr1 y · pr2 f₂.
+  Proof.
+    intro e.
+    simple refine (_ ,, _).
+    - simple refine (_ ,, _).
+      + exact (pr11 e).
+      + simpl.
+        simple refine (_ ,, (_ ,, _)).
+        * simple refine (_ ,, (_ ,, _)).
+          ** exact (pr1 (pr112 e)).
+          ** exact (pr11 (pr212 e)).
+          ** exact (pr12 (pr212 e)).
+        * split.
+          ** abstract
+               (refine (maponpaths pr1 (pr1 (pr122 e)) @ _) ;
+                unfold transportb ;
+                cbn ;
+                refine (@pr1_transportf _ (λ _, _) _ _ _ _ _ @ _) ;
+                rewrite transportf_const ;
+                apply idpath).
+          ** abstract
+               (refine (maponpaths pr1 (pr2 (pr122 e)) @ _) ;
+                unfold transportb ;
+                cbn ;
+                refine (@pr1_transportf _ (λ _, _) _ _ _ _ _ @ _) ;
+                rewrite transportf_const ;
+                apply idpath).
+        * split ; apply inv_B.
+    - exact (rinvunitor _ • pr21 e).
+  Defined.
+
+  Definition cod_adj_equiv_to_disp_to_adj
+             (HB_2_1 : is_univalent_2_1 B)
+             {c : B}
+             {f₁ f₂ : cod_disp_bicat B c}
+             (e : ∑ (y : adjoint_equivalence (pr1 f₁) (pr1 f₂)),
+                  pr2 f₁ ==> pr1 y · pr2 f₂)
+    : cod_disp_adj_equiv_to_adj_equiv
+        (cod_adj_equiv_to_disp_adj_equiv e)
+      =
+      e.
+  Proof.
+    use total2_paths_f.
+    - simpl.
+      use subtypePath.
+      {
+        intro ; apply isaprop_left_adjoint_equivalence.
+        exact HB_2_1.
+      }
+      apply idpath.
+    - unfold subtypePath.
+      etrans.
+      {
+        apply (transportf_total2_paths_f (λ x, pr2 f₁ ==> x · pr2 f₂)).
+      }
+      cbn.
+      rewrite vassocr.
+      rewrite rinvunitor_runitor.
+      apply id2_left.
+  Qed.
+
+  Definition cod_disp_adj_to_adj_to_disp
+             (HB_2_1 : is_univalent_2_1 B)
+             {c : B}
+             {f₁ f₂ : cod_disp_bicat B c}
+             (e : disp_adjoint_equivalence
+                    (internal_adjoint_equivalence_identity c)
+                    f₁ f₂)
+    : cod_adj_equiv_to_disp_adj_equiv
+        (cod_disp_adj_equiv_to_adj_equiv e)
+      =
+      e.
+  Proof.
+    use subtypePath.
+    {
+      intro.
+      use isaprop_disp_left_adjoint_equivalence.
+      - exact HB_2_1.
+      - apply cod_disp_univalent_2_1.
+        exact HB_2_1.
+    }
+    cbn.
+    unfold make_disp_1cell_cod.
+    use maponpaths.
+    rewrite vassocr.
+    rewrite runitor_rinvunitor.
+    apply id2_left.
+  Qed.
+
+  Definition cod_adj_equiv_weq_disp_adj_equiv
+             (HB_2_1 : is_univalent_2_1 B)
+             {c : B}
+             (f₁ f₂ : cod_disp_bicat B c)
+    : (∑ y : adjoint_equivalence (pr1 f₁) (pr1 f₂), pr2 f₁ ==> pr1 y · pr2 f₂)
+      ≃
+      disp_adjoint_equivalence (internal_adjoint_equivalence_identity c) f₁ f₂.
+  Proof.
+    use make_weq.
+    - exact cod_adj_equiv_to_disp_adj_equiv.
+    - use gradth.
+      + exact cod_disp_adj_equiv_to_adj_equiv.
+      + exact (cod_adj_equiv_to_disp_to_adj HB_2_1).
+      + exact (cod_disp_adj_to_adj_to_disp HB_2_1).
+  Defined.
+
+  Definition cod_disp_univalent_2_0
+             (HB_2_0 : is_univalent_2_0 B)
+             (HB_2_1 : is_univalent_2_1 B)
+    : disp_univalent_2_0 (cod_disp_bicat B).
+  Proof.
+    use fiberwise_univalent_2_0_to_disp_univalent_2_0.
+    intros c f₁ f₂.
+    use weqhomot.
+    - refine (cod_adj_equiv_weq_disp_adj_equiv HB_2_1 f₁ f₂
+             ∘ weqtotal2 (make_weq _ (HB_2_0 _ _)) (cod_1cell_path HB_2_1 f₁ f₂)
+             ∘ total2_paths_equiv _ _ _)%weq.
+    - intro p.
+      cbn in p.
+      induction p.
+      use subtypePath.
+      {
+        intro.
+        use isaprop_disp_left_adjoint_equivalence.
+        - exact HB_2_1.
+        - apply cod_disp_univalent_2_1.
+          exact HB_2_1.
+      }
+      cbn.
+      unfold make_disp_1cell_cod.
+      rewrite id2_left.
+      apply idpath.
+  Qed.
+End UnivalenceOfCodomain.

--- a/UniMath/Bicategories/DisplayedBicats/Examples/DispBicatOfDispCats.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/DispBicatOfDispCats.v
@@ -448,27 +448,6 @@ Definition is_fibration
   : UU
   := is_univalent_disp D × cleaving D.
 
-Definition isaprop_cleaving
-           {C : univalent_category}
-           (D : disp_cat C)
-           (HD : is_univalent_disp D)
-  : isaprop (cleaving D).
-Proof.
-  repeat (use impred ; intro).
-  apply isaprop_cartesian_lifts.
-  exact HD.
-Defined.
-
-Definition isaprop_is_univalent_disp
-           {C : category}
-           (D : disp_cat C)
-  : isaprop (is_univalent_disp D).
-Proof.
-  unfold is_univalent_disp.
-  do 5 (use impred ; intro).
-  apply isapropisweq.
-Defined.
-
 Definition isaprop_is_fibration
            {C : univalent_category}
            (D : disp_cat C)

--- a/UniMath/Bicategories/DisplayedBicats/Examples/DispBicatOfDispCats.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/DispBicatOfDispCats.v
@@ -9,19 +9,85 @@
 Require Import UniMath.Foundations.All.
 Require Import UniMath.MoreFoundations.All.
 Require Import UniMath.CategoryTheory.DisplayedCats.Auxiliary.
+Require Import UniMath.CategoryTheory.DisplayedCats.Fibrations.
 Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.CategoryTheory.Core.Categories.
-Require Import UniMath.CategoryTheory.Core.Univalence.
 Require Import UniMath.CategoryTheory.Core.Functors.
+Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
+Require Import UniMath.CategoryTheory.Core.Isos.
+Require Import UniMath.CategoryTheory.Core.Univalence.
+Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.DisplayedCats.Auxiliary.
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
 Require Import UniMath.CategoryTheory.DisplayedCats.Constructions.
-Require Import UniMath.Bicategories.Core.Bicat. Import Bicat.Notations.
+Require Import UniMath.Bicategories.Core.Bicat.
+Import Bicat.Notations.
 Require Import UniMath.Bicategories.DisplayedBicats.DispBicat.
+Import DispBicat.Notations.
 Require Import UniMath.Bicategories.Core.Examples.BicatOfCats.
+Require Import UniMath.Bicategories.DisplayedBicats.Examples.FullSub.
+Require Import UniMath.Bicategories.DisplayedBicats.Examples.Sigma.
+Require Import UniMath.Bicategories.DisplayedBicats.Examples.DisplayedCatToBicat.
 
 Local Open Scope cat.
 Local Open Scope mor_disp_scope.
+
+Definition pre_whisker_disp_nat_trans
+           {C₁ C₂ C₃ : category}
+           {F : C₁ ⟶ C₂}
+           {G₁ G₂ : C₂ ⟶ C₃}
+           {n : G₁ ⟹ G₂}
+           {D₁ : disp_precat C₁}
+           {D₂ : disp_precat C₂}
+           {D₃ : disp_precat C₃}
+           (FF : disp_functor F D₁ D₂)
+           {GG₁ : disp_functor G₁ D₂ D₃}
+           {GG₂ : disp_functor G₂ D₂ D₃}
+           (nn : disp_nat_trans n GG₁ GG₂)
+  : disp_nat_trans
+      (pre_whisker F n)
+      (disp_functor_composite FF GG₁)
+      (disp_functor_composite FF GG₂).
+Proof.
+  use tpair.
+  - exact (λ x xx, nn (F x) (FF x xx)).
+  - abstract
+      (intros x y f xx yy ff ; cbn ;
+       rewrite (disp_nat_trans_ax nn) ;
+       apply maponpaths_2 ;
+       apply C₃).
+Defined.
+
+Definition post_whisker_disp_nat_trans
+           {C₁ C₂ C₃ : category}
+           {F₁ F₂ : C₁ ⟶ C₂}
+           {n : F₁ ⟹ F₂}
+           {G : C₂ ⟶ C₃}
+           {D₁ : disp_precat C₁}
+           {D₂ : disp_precat C₂}
+           {D₃ : disp_precat C₃}
+           {FF₁ : disp_functor F₁ D₁ D₂}
+           {FF₂ : disp_functor F₂ D₁ D₂}
+           (nn : disp_nat_trans n FF₁ FF₂)
+           (GG : disp_functor G D₂ D₃)
+  : disp_nat_trans
+      (post_whisker n G)
+      (disp_functor_composite FF₁ GG)
+      (disp_functor_composite FF₂ GG).
+Proof.
+  use tpair.
+  - exact (λ x xx, # GG (nn x xx)).
+  - abstract
+      (intros x y f xx yy ff ; cbn ;
+       rewrite <- !(disp_functor_comp_var GG) ;
+       unfold transportb ;
+       rewrite transport_f_f ;
+       rewrite (disp_nat_trans_ax_var nn) ;
+       rewrite disp_functor_transportf ;
+       rewrite transport_f_f ;
+       apply maponpaths_2 ;
+       apply C₃).
+Defined.
 
 Definition disp_prebicat_of_disp_cats_cat_data : disp_cat_data bicat_of_cats.
 Proof.
@@ -65,241 +131,452 @@ Proof.
     exact (disp_nat_trans_id (disp_functor_composite_data (disp_functor_composite ff gg) F')).
   - intros C D ? ? ? ? ? ? ? ? ? ? rr ss ; cbn in *.
     exact (@disp_nat_trans_comp C _ _ _ _ _ _ _ _ _ _ _ rr ss).
+  - intros C₁ C₂ C₃ f g₁ g₂ r D₁ D₂ D₃ ff gg₁ gg₂ rr ; cbn in *.
+    exact (@pre_whisker_disp_nat_trans C₁ C₂ _ _ _ _ _ _ _ _ _ _ _ rr).
   - intros C₁ C₂ C₃ ? ? ? ? ? ? ? ? ? ? rr ; cbn in *.
-    use tpair.
-    + cbn. red. intros A AA.
-      cbn.
-      apply rr.
-    + red. cbn. intros A B F AA BB FF.
-      pose (RR := @disp_nat_trans_ax _ _ _ _ _ _ _ _ _ rr).
-      etrans.
-      * apply RR.
-      * apply maponpaths_2. apply uip.
-        apply homset_property.
-  - intros C₁ C₂ C₃ ? ? ? ? ? ? ? ? ? ? rr.
-    use tpair.
-    + cbn. red. intros A AA.
-      cbn.
-      apply disp_functor_on_morphisms.
-      apply rr.
-    + red. cbn. intros A B F AA BB FF.
-      etrans.
-      apply pathsinv0.
-      apply (@disp_functor_comp_var (pr1 C₂) (pr1 C₃)).
-      etrans.
-      2: { apply maponpaths.
-           apply (@disp_functor_comp_var (pr1 C₂) (pr1 C₃)). }
-      apply pathsinv0.
-      etrans.
-      apply transport_f_f.
-      etrans.
-      * apply maponpaths.
-        apply maponpaths.
-        pose (RR := @disp_nat_trans_ax_var _ _ _ _ _ _ _ _ _ rr).
-        apply RR.
-      * etrans.
-        apply maponpaths.
-        apply (@disp_functor_transportf (pr1 C₂) (pr1 C₃)).
-        etrans.
-        apply transport_f_f.
-        apply maponpaths_2. apply uip. apply homset_property.
+    exact (@post_whisker_disp_nat_trans C₁ C₂ _ _ _ _ _ _ _ _ _ _ rr _).
 Defined.
 
 Lemma DispBicatOfDispCats_laws : disp_prebicat_laws disp_prebicat_of_disp_cats_data.
 Proof.
   repeat split ; red
-  ; try (intros C₁ C₂ ; cbn in C₁, C₂ ; intros
-         ; apply (@disp_nat_trans_eq (pr1 C₁) (pr1 C₂))
-         ; intros ; apply pathsinv0; unfold transportb)
-  ; try (intros C₁ C₂ C₃ ; cbn in C₁, C₂, C₃ ; intros
-         ; apply (@disp_nat_trans_eq (pr1 C₁) (pr1 C₃))
-         ; intros ; apply pathsinv0; unfold transportb)
-  ; try (intros C₁ C₂ C₃ C₄ ; cbn in C₁, C₂, C₃, C₄ ; intros
-         ; apply (@disp_nat_trans_eq (pr1 C₁) (pr1 C₄))
-         ; intros ; apply pathsinv0; unfold transportb)
-  ; try (intros C₁ C₂ C₃ C₄ C₅ ; cbn in C₁, C₂, C₃, C₄, C₅ ; intros
-         ; apply (@disp_nat_trans_eq (pr1 C₁) (pr1 C₅))
-         ; intros ; apply pathsinv0; unfold transportb).
-  - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-    etrans; [
-      apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    apply pathsinv0.
+  ; intros; intros
+  ; apply (@disp_nat_trans_eq)
+  ; intros ; apply pathsinv0
+  ; unfold transportb
+  ; (etrans ; [ apply disp_nat_trans_transportf | ]).
+  - apply pathsinv0.
     etrans. apply id_left_disp.
     apply pathsinv0; unfold transportb.
     apply maponpaths_2. apply homset_property.
-  - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    apply pathsinv0.
+  - apply pathsinv0.
     etrans. apply id_right_disp.
     apply pathsinv0; unfold transportb.
     apply maponpaths_2. apply homset_property.
-  - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    apply pathsinv0.
+  - apply pathsinv0.
     etrans. apply assoc_disp.
     apply pathsinv0; unfold transportb.
     apply maponpaths_2. apply homset_property.
-  - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    apply transportf_set. apply homset_property.
-  - cbn in C₁, C₂, C₃.
-    match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    cbn.
-    apply pathsinv0.
+  - apply transportf_set. apply homset_property.
+  - apply pathsinv0.
     etrans.
-    { apply (@disp_functor_id C₂). }
+    {
+      cbn.
+      apply disp_functor_id.
+    }
     unfold transportb.
     apply maponpaths_2. apply homset_property.
-  - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    apply transportf_set. apply homset_property.
-  - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    cbn.
+  - apply transportf_set. apply homset_property.
+  - cbn.
     etrans.
     {
       apply maponpaths.
-      apply (@disp_functor_comp C₂ C₃).
+      apply disp_functor_comp.
     }
     etrans. apply transport_f_f.
     apply transportf_set. apply homset_property.
-  - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    cbn.
+  - cbn.
     etrans.
     {
       apply maponpaths.
-      apply (@id_left_disp C₂).
+      apply id_left_disp.
     }
     etrans. apply transport_f_f.
     apply pathsinv0.
-    etrans. apply (@id_right_disp C₂).
+    etrans. apply id_right_disp.
     unfold transportb. apply maponpaths_2. apply homset_property.
-      - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    cbn.
-    etrans. apply maponpaths. apply (@id_left_disp C₂).
+  - cbn.
+    etrans. apply maponpaths. apply id_left_disp.
     etrans. apply transport_f_f.
     apply pathsinv0.
-    etrans. apply (@id_right_disp C₂).
+    etrans. apply id_right_disp.
     unfold transportb. apply maponpaths_2. apply homset_property.
-  - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    cbn.
+  - cbn.
     etrans.
     {
       apply maponpaths.
-      apply (@id_left_disp C₄).
+      apply id_left_disp.
     }
     etrans. apply transport_f_f.
     apply pathsinv0.
-    etrans. apply (@id_right_disp C₄).
+    etrans. apply id_right_disp.
     unfold transportb. apply maponpaths_2. apply homset_property.
-  - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    cbn.
-    etrans. apply maponpaths. apply (@id_left_disp C₄).
+  - cbn.
+    etrans. apply maponpaths. apply id_left_disp.
     etrans. apply transport_f_f.
     apply pathsinv0.
-    etrans. apply (@id_right_disp C₄).
+    etrans. apply id_right_disp.
     unfold transportb. apply maponpaths_2. apply homset_property.
-  - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    cbn.
-    etrans. apply maponpaths. apply (@id_right_disp C₄).
+  - cbn.
+    etrans. apply maponpaths. apply id_right_disp.
     etrans. apply transport_f_f.
     apply pathsinv0.
-    etrans. apply (@id_left_disp C₄).
+    etrans. apply id_left_disp.
     unfold transportb. apply maponpaths_2. apply homset_property.
-  - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    cbn.
+  - cbn.
     set (RR := @disp_nat_trans_ax_var _ _ _ _ _ _ _ _ _ φφ).
     etrans. apply maponpaths. apply RR.
     etrans. apply transport_f_f.
     apply transportf_set. apply homset_property.
-  - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    cbn.
+  - cbn.
     apply pathsinv0.
-    etrans. apply (@id_right_disp C₂).
+    etrans. apply id_right_disp.
     unfold transportb. apply maponpaths_2. apply homset_property.
-  - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    cbn.
+  - cbn.
     apply pathsinv0.
-    etrans. apply (@id_right_disp C₂).
+    etrans. apply id_right_disp.
     unfold transportb. apply maponpaths_2. apply homset_property.
-  - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    cbn.
+  - cbn.
     apply pathsinv0.
-    etrans. apply (@id_right_disp C₂).
+    etrans. apply id_right_disp.
     unfold transportb. apply maponpaths_2. apply homset_property.
-  - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    cbn.
+  - cbn.
     apply pathsinv0.
-    etrans. apply (@id_right_disp C₂).
+    etrans. apply id_right_disp.
     unfold transportb. apply maponpaths_2. apply homset_property.
-  - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    cbn.
+  - cbn.
     apply pathsinv0.
-    etrans. apply (@id_right_disp C₄).
+    etrans. apply id_right_disp.
     unfold transportb. apply maponpaths_2. apply homset_property.
-  - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    cbn.
+  - cbn.
     apply pathsinv0.
-    etrans. apply (@id_right_disp C₄).
+    etrans. apply id_right_disp.
     unfold transportb. apply maponpaths_2. apply homset_property.
-  - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    cbn.
+  - cbn.
     apply pathsinv0.
-    etrans. apply (@id_left_disp C₃).
-    etrans. apply maponpaths. apply (@disp_functor_id C₂).
+    etrans. apply id_left_disp.
+    etrans. apply maponpaths. apply disp_functor_id.
     etrans. apply transport_f_f.
     apply maponpaths_2. apply homset_property.
-  - match goal with |[ |-  (_ (_ ?E _ ))  _ _  = _ ] => set (XYZ := E) end;
-      etrans; [
-        apply (disp_nat_trans_transportf _ _ _ _ _ _ _ _  XYZ) | ].
-    cbn.
+  - cbn.
     apply pathsinv0.
-    etrans. apply (@assoc_disp_var C₅).
-    etrans. apply maponpaths. apply (@id_left_disp C₅).
+    etrans. apply assoc_disp_var.
+    etrans. apply maponpaths. apply id_left_disp.
     etrans. apply transport_f_f.
-    etrans. apply maponpaths. apply (@id_left_disp C₅).
+    etrans. apply maponpaths. apply id_left_disp.
     etrans. apply transport_f_f.
-    etrans. apply maponpaths. apply (@disp_functor_id C₄).
+    etrans. apply maponpaths. apply disp_functor_id.
     etrans. apply transport_f_f.
 
     apply pathsinv0.
-    etrans. apply maponpaths. apply (@id_left_disp C₅).
+    etrans. apply maponpaths. apply id_left_disp.
     etrans. apply transport_f_f.
     apply maponpaths_2. apply homset_property.
 Qed.
 
 
-Definition DispBicatOfDispCats : disp_prebicat bicat_of_cats := _ ,, DispBicatOfDispCats_laws.
+Definition DispPreBicatOfDispCats : disp_prebicat bicat_of_cats := _ ,, DispBicatOfDispCats_laws.
+
+Definition DispBicatOfDispCats : disp_bicat bicat_of_cats.
+Proof.
+  use tpair.
+  - exact DispPreBicatOfDispCats.
+  - abstract
+      (intros C₁ C₂ F₁ F₂ n D₁ D₂ FF₁ FF₂ ;
+       simpl in * ;
+       cbn ;
+       exact (isaset_disp_nat_trans C₁ C₂ D₁ D₂ F₁ F₂ n FF₁ FF₂)).
+Defined.
+
+(** Condition for displayed invertible 2-cells in this bicategory *)
+Definition DispBicatOfDispCats_is_disp_invertible_2cell_natural
+           {C C' : category}
+           {F : C ⟶ C'}
+           {D : disp_cat C} {D' : disp_cat C'}
+           {FF : disp_functor F D D'} {GG : disp_functor F D D'}
+           (αα : disp_nat_trans (nat_trans_id F) FF GG)
+           (Hαα : ∏ (x : C) (xx : D x),
+                  is_iso_disp
+                    (identity_iso (pr1 F x))
+                    (pr1 αα x xx))
+           {x y : pr1 C}
+           {f : x --> y}
+           {xx : D x} {yy : D y}
+           (ff : xx -->[ f ] yy)
+  : # GG ff;; inv_mor_disp_from_iso (Hαα y yy)
+    =
+    transportb
+      (mor_disp (GG x xx) (FF y yy))
+      (is_nat_trans_id F x y f)
+      (inv_mor_disp_from_iso (Hαα x xx);; # FF ff).
+Proof.
+  use (precomp_with_iso_disp_is_inj (make_iso_disp _ (Hαα x xx))).
+  simpl.
+  refine (assoc_disp _ _ _ @ _).
+  unfold transportb.
+  rewrite mor_disp_transportf_prewhisker.
+  rewrite assoc_disp.
+  refine (!_).
+  refine (transport_f_f _ _ _ _ @ _).
+  etrans.
+  {
+    apply maponpaths.
+    apply maponpaths_2.
+    apply (inv_mor_after_iso_disp (Hαα x xx)).
+  }
+  etrans.
+  {
+    apply maponpaths.
+    etrans.
+    {
+      apply mor_disp_transportf_postwhisker.
+    }
+    etrans.
+    {
+      apply maponpaths.
+      apply id_left_disp.
+    }
+    apply transport_f_f.
+  }
+  etrans.
+  {
+    apply transport_f_f.
+  }
+  assert (transportf
+            (mor_disp (FF x xx) (GG y yy)) (nat_trans_ax (nat_trans_id F) x y f)
+            (# FF ff;; pr1 αα y yy) =
+          pr1 αα x xx;; # GG ff)
+    as X.
+  {
+    apply transportf_transpose_left.
+    exact (pr2 αα x y f xx yy ff).
+  }
+  refine (!_).
+  apply transportf_transpose_left.
+  etrans.
+  {
+    apply maponpaths_2.
+    exact (!X).
+  }
+  rewrite mor_disp_transportf_postwhisker.
+  etrans.
+  {
+    etrans.
+    {
+      apply maponpaths.
+      etrans.
+      {
+        apply assoc_disp_var.
+      }
+      etrans.
+      {
+        apply maponpaths.
+        etrans.
+        {
+          apply maponpaths.
+          apply (inv_mor_after_iso_disp (Hαα y yy)).
+        }
+        etrans.
+        {
+          apply mor_disp_transportf_prewhisker.
+        }
+        etrans.
+        {
+          apply maponpaths.
+          apply id_right_disp.
+        }
+        apply transport_f_f.
+      }
+      apply transport_f_f.
+    }
+    apply transport_f_f.
+  }
+  refine (!_).
+  etrans.
+  {
+    apply transport_f_f.
+  }
+  apply transportf_paths.
+  apply C'.
+Qed.
+
+Definition DispBicatOfDispCats_is_disp_invertible_2cell
+           {C C' : bicat_of_cats}
+           {F : C --> C'}
+           {D : DispBicatOfDispCats C} {D' : DispBicatOfDispCats C'}
+           {FF : D -->[ F ] D'} {GG : D -->[ F ] D'}
+           (αα : FF ==>[ id₂ F ] GG)
+           (Hαα : ∏ (x : (C : univalent_category)) (xx : pr1 D x),
+                  is_iso_disp
+                    (identity_iso (pr1 F x))
+                    (pr1 αα x xx))
+  : is_disp_invertible_2cell (id2_invertible_2cell F) αα.
+Proof.
+  use tpair.
+  - use tpair.
+    + intros x xx ; cbn.
+      exact (inv_mor_disp_from_iso (Hαα x xx)).
+    + intros x xx y yy f ff ; cbn in *.
+      apply (@DispBicatOfDispCats_is_disp_invertible_2cell_natural
+               C C').
+  - split.
+    + abstract
+        (cbn ;
+         simpl in * ;
+         use (@disp_nat_trans_eq C C') ;
+         intros x xx ; cbn ;
+         refine (inv_mor_after_iso_disp (Hαα x xx) @ _) ;
+         refine (!_) ;
+         refine (disp_nat_trans_transportf
+                   _ _ _ _ _ _
+                   _ _
+                   (!(@id2_left bicat_of_cats _ _ _ _ (nat_trans_id F)))
+                   _ _ _ _ _
+                   @ _) ;
+         apply transportf_paths ;
+         apply homset_property).
+    + abstract
+        (cbn ;
+         simpl in * ;
+         use (@disp_nat_trans_eq C C') ;
+         intros x xx ; cbn ;
+         refine (iso_disp_after_inv_mor (Hαα x xx) @ _) ;
+         refine (!_) ;
+         refine (disp_nat_trans_transportf
+                   _ _ _ _ _ _
+                   _ _
+                   (!(@id2_left bicat_of_cats _ _ _ _ (nat_trans_id F)))
+                   _ _ _ _ _
+                   @ _) ;
+         apply transportf_paths ;
+         apply homset_property).
+Defined.
+
+Definition is_fibration
+           {C : univalent_category}
+           (D : disp_cat C)
+  : UU
+  := is_univalent_disp D × cleaving D.
+
+Definition isaprop_cleaving
+           {C : univalent_category}
+           (D : disp_cat C)
+           (HD : is_univalent_disp D)
+  : isaprop (cleaving D).
+Proof.
+  repeat (use impred ; intro).
+  apply isaprop_cartesian_lifts.
+  exact HD.
+Defined.
+
+Definition isaprop_is_univalent_disp
+           {C : category}
+           (D : disp_cat C)
+  : isaprop (is_univalent_disp D).
+Proof.
+  unfold is_univalent_disp.
+  do 5 (use impred ; intro).
+  apply isapropisweq.
+Defined.
+
+Definition isaprop_is_fibration
+           {C : univalent_category}
+           (D : disp_cat C)
+           (HD : is_univalent_disp D)
+  : isaprop (is_fibration D).
+Proof.
+  use isapropdirprod.
+  - exact (isaprop_is_univalent_disp D).
+  - exact (isaprop_cleaving D HD).
+Defined.
+
+Definition DispBicatOfFibs_ob_mor
+  : disp_cat_ob_mor (total_bicat DispBicatOfDispCats).
+Proof.
+  use tpair.
+  - exact (λ X, is_fibration (pr2 X)).
+  - exact (λ X Y fibX fibY F, is_cartesian_disp_functor (pr2 F)).
+Defined.
+
+Definition DispBicatOfFibs_id_comp
+  : disp_cat_id_comp (total_bicat DispBicatOfDispCats) DispBicatOfFibs_ob_mor.
+Proof.
+  use tpair.
+  - intros X fibX x y f xx yy ff p.
+    exact p.
+  - intros X Y Z F G fibX fibY fibZ cartF cartG x y f xx yy ff p ; simpl.
+    apply cartG.
+    apply cartF.
+    exact p.
+Qed.
+
+Definition DispBicatOfFibs_cat_data
+  : disp_cat_data (total_bicat DispBicatOfDispCats).
+Proof.
+  use tpair.
+  - exact DispBicatOfFibs_ob_mor.
+  - exact DispBicatOfFibs_id_comp.
+Defined.
+
+Definition DispBicatOfFibs_help
+  : disp_bicat (total_bicat DispBicatOfDispCats).
+Proof.
+  use disp_cell_unit_bicat.
+  exact DispBicatOfFibs_cat_data.
+Defined.
+
+Definition DispBicatOfFibs
+  : disp_bicat bicat_of_cats
+  := sigma_bicat
+       bicat_of_cats
+       DispBicatOfDispCats
+       DispBicatOfFibs_help.
+
+Definition DispBicatOfFibs_is_disp_invertible_2cell
+           {C C' : bicat_of_cats}
+           {F : C --> C'}
+           {D : DispBicatOfFibs C} {D' : DispBicatOfFibs C'}
+           {FF : D -->[ F ] D'} {GG : D -->[ F ] D'}
+           (αα : FF ==>[ id₂ F ] GG)
+           (Hαα : ∏ (x : (C : univalent_category)) (xx : pr11 D x),
+                  is_iso_disp
+                    (identity_iso (pr1 F x))
+                    (pr11 αα x xx))
+  : is_disp_invertible_2cell (id2_invertible_2cell F) αα.
+Proof.
+  use tpair.
+  - refine (_ ,, tt).
+    use tpair.
+    + intros x xx ; cbn.
+      exact (inv_mor_disp_from_iso (Hαα x xx)).
+    + intros x xx y yy f ff ; cbn in *.
+      apply (@DispBicatOfDispCats_is_disp_invertible_2cell_natural
+               C C').
+  - split.
+    + abstract
+        (cbn ;
+         simpl in * ;
+         use subtypePath ; [intro ; apply isapropunit | ];
+         use (@disp_nat_trans_eq C C') ;
+         intros x xx ; cbn ;
+         refine (inv_mor_after_iso_disp (Hαα x xx) @ _) ;
+         refine (!_) ;
+         unfold transportb ;
+         rewrite pr1_transportf ;
+         refine (disp_nat_trans_transportf
+                   _ _ _ _ _ _
+                   _ _
+                   (!(@id2_left bicat_of_cats _ _ _ _ (nat_trans_id F)))
+                   _ _ _ _ _
+                   @ _) ;
+         apply transportf_paths ;
+         apply homset_property).
+    + abstract
+        (cbn ;
+         simpl in * ;
+         use subtypePath ; [intro ; apply isapropunit | ];
+         use (@disp_nat_trans_eq C C') ;
+         intros x xx ; cbn ;
+         refine (iso_disp_after_inv_mor (Hαα x xx) @ _) ;
+         refine (!_) ;
+         unfold transportb ;
+         rewrite pr1_transportf ;
+         refine (disp_nat_trans_transportf
+                   _ _ _ _ _ _
+                   _ _
+                   (!(@id2_left bicat_of_cats _ _ _ _ (nat_trans_id F)))
+                   _ _ _ _ _
+                   @ _) ;
+         apply transportf_paths ;
+         apply homset_property).
+Defined.

--- a/UniMath/Bicategories/DisplayedBicats/Examples/DispBicatOfDispCats.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/DispBicatOfDispCats.v
@@ -32,68 +32,12 @@ Require Import UniMath.Bicategories.DisplayedBicats.Examples.DisplayedCatToBicat
 Local Open Scope cat.
 Local Open Scope mor_disp_scope.
 
-Definition pre_whisker_disp_nat_trans
-           {C₁ C₂ C₃ : category}
-           {F : C₁ ⟶ C₂}
-           {G₁ G₂ : C₂ ⟶ C₃}
-           {n : G₁ ⟹ G₂}
-           {D₁ : disp_precat C₁}
-           {D₂ : disp_precat C₂}
-           {D₃ : disp_precat C₃}
-           (FF : disp_functor F D₁ D₂)
-           {GG₁ : disp_functor G₁ D₂ D₃}
-           {GG₂ : disp_functor G₂ D₂ D₃}
-           (nn : disp_nat_trans n GG₁ GG₂)
-  : disp_nat_trans
-      (pre_whisker F n)
-      (disp_functor_composite FF GG₁)
-      (disp_functor_composite FF GG₂).
-Proof.
-  use tpair.
-  - exact (λ x xx, nn (F x) (FF x xx)).
-  - abstract
-      (intros x y f xx yy ff ; cbn ;
-       rewrite (disp_nat_trans_ax nn) ;
-       apply maponpaths_2 ;
-       apply C₃).
-Defined.
-
-Definition post_whisker_disp_nat_trans
-           {C₁ C₂ C₃ : category}
-           {F₁ F₂ : C₁ ⟶ C₂}
-           {n : F₁ ⟹ F₂}
-           {G : C₂ ⟶ C₃}
-           {D₁ : disp_precat C₁}
-           {D₂ : disp_precat C₂}
-           {D₃ : disp_precat C₃}
-           {FF₁ : disp_functor F₁ D₁ D₂}
-           {FF₂ : disp_functor F₂ D₁ D₂}
-           (nn : disp_nat_trans n FF₁ FF₂)
-           (GG : disp_functor G D₂ D₃)
-  : disp_nat_trans
-      (post_whisker n G)
-      (disp_functor_composite FF₁ GG)
-      (disp_functor_composite FF₂ GG).
-Proof.
-  use tpair.
-  - exact (λ x xx, # GG (nn x xx)).
-  - abstract
-      (intros x y f xx yy ff ; cbn ;
-       rewrite <- !(disp_functor_comp_var GG) ;
-       unfold transportb ;
-       rewrite transport_f_f ;
-       rewrite (disp_nat_trans_ax_var nn) ;
-       rewrite disp_functor_transportf ;
-       rewrite transport_f_f ;
-       apply maponpaths_2 ;
-       apply C₃).
-Defined.
-
-Definition disp_prebicat_of_disp_cats_cat_data : disp_cat_data bicat_of_cats.
+Definition disp_bicat_of_univ_disp_cats_disp_cat_data
+  : disp_cat_data bicat_of_cats.
 Proof.
   use tpair.
   - use tpair.
-    + exact (λ C : univalent_category, disp_cat C).
+    + exact (λ C : univalent_category, disp_univalent_category C).
     + intros C C' D D' F.
       exact (disp_functor F D D').
   - use tpair; cbn.
@@ -103,17 +47,17 @@ Proof.
       apply (disp_functor_composite G G').
 Defined.
 
-Definition disp_prebicat_of_disp_cats_1_id_comp_cells
+Definition disp_bicat_of_univ_disp_cats_1_id_comp_cells
   : disp_prebicat_1_id_comp_cells bicat_of_cats.
 Proof.
-  exists disp_prebicat_of_disp_cats_cat_data.
+  exists disp_bicat_of_univ_disp_cats_disp_cat_data.
   cbn. intros C C' F F' a D D' G G'. cbn in *.
   apply (disp_nat_trans a G G').
 Defined.
 
-Definition disp_prebicat_of_disp_cats_data : disp_prebicat_data bicat_of_cats.
+Definition disp_prebicat_of_univ_disp_cats_data : disp_prebicat_data bicat_of_cats.
 Proof.
-  exists disp_prebicat_of_disp_cats_1_id_comp_cells.
+  exists disp_bicat_of_univ_disp_cats_1_id_comp_cells.
   repeat split.
   - intros ? ? ? ? ? F' ; cbn in *.
     exact (disp_nat_trans_id F').
@@ -137,7 +81,8 @@ Proof.
     exact (@post_whisker_disp_nat_trans C₁ C₂ _ _ _ _ _ _ _ _ _ _ rr _).
 Defined.
 
-Lemma DispBicatOfDispCats_laws : disp_prebicat_laws disp_prebicat_of_disp_cats_data.
+Lemma disp_prebicat_of_univ_disp_cats_laws
+  : disp_prebicat_laws disp_prebicat_of_univ_disp_cats_data.
 Proof.
   repeat split ; red
   ; intros; intros
@@ -265,12 +210,14 @@ Proof.
 Qed.
 
 
-Definition DispPreBicatOfDispCats : disp_prebicat bicat_of_cats := _ ,, DispBicatOfDispCats_laws.
+Definition disp_prebicat_of_univ_disp_cats
+  : disp_prebicat bicat_of_cats
+  := _ ,, disp_prebicat_of_univ_disp_cats_laws.
 
-Definition DispBicatOfDispCats : disp_bicat bicat_of_cats.
+Definition disp_bicat_of_univ_disp_cats : disp_bicat bicat_of_cats.
 Proof.
   use tpair.
-  - exact DispPreBicatOfDispCats.
+  - exact disp_prebicat_of_univ_disp_cats.
   - abstract
       (intros C₁ C₂ F₁ F₂ n D₁ D₂ FF₁ FF₂ ;
        simpl in * ;
@@ -279,7 +226,7 @@ Proof.
 Defined.
 
 (** Condition for displayed invertible 2-cells in this bicategory *)
-Definition DispBicatOfDispCats_is_disp_invertible_2cell_natural
+Definition disp_bicat_of_univ_disp_cats_is_disp_invertible_2cell_natural
            {C C' : category}
            {F : C ⟶ C'}
            {D : disp_cat C} {D' : disp_cat C'}
@@ -390,10 +337,11 @@ Proof.
   apply C'.
 Qed.
 
-Definition DispBicatOfDispCats_is_disp_invertible_2cell
+Definition disp_bicat_of_univ_disp_cats_is_disp_invertible_2cell
            {C C' : bicat_of_cats}
            {F : C --> C'}
-           {D : DispBicatOfDispCats C} {D' : DispBicatOfDispCats C'}
+           {D : disp_bicat_of_univ_disp_cats C}
+           {D' : disp_bicat_of_univ_disp_cats C'}
            {FF : D -->[ F ] D'} {GG : D -->[ F ] D'}
            (αα : FF ==>[ id₂ F ] GG)
            (Hαα : ∏ (x : (C : univalent_category)) (xx : pr1 D x),
@@ -407,7 +355,7 @@ Proof.
     + intros x xx ; cbn.
       exact (inv_mor_disp_from_iso (Hαα x xx)).
     + intros x xx y yy f ff ; cbn in *.
-      apply (@DispBicatOfDispCats_is_disp_invertible_2cell_natural
+      apply (@disp_bicat_of_univ_disp_cats_is_disp_invertible_2cell_natural
                C C').
   - split.
     + abstract
@@ -442,33 +390,16 @@ Proof.
          apply homset_property).
 Defined.
 
-Definition is_fibration
-           {C : univalent_category}
-           (D : disp_cat C)
-  : UU
-  := is_univalent_disp D × cleaving D.
-
-Definition isaprop_is_fibration
-           {C : univalent_category}
-           (D : disp_cat C)
-           (HD : is_univalent_disp D)
-  : isaprop (is_fibration D).
-Proof.
-  use isapropdirprod.
-  - exact (isaprop_is_univalent_disp D).
-  - exact (isaprop_cleaving D HD).
-Defined.
-
-Definition DispBicatOfFibs_ob_mor
-  : disp_cat_ob_mor (total_bicat DispBicatOfDispCats).
+Definition disp_bicat_of_fibs_ob_mor
+  : disp_cat_ob_mor (total_bicat disp_bicat_of_univ_disp_cats).
 Proof.
   use tpair.
-  - exact (λ X, is_fibration (pr2 X)).
+  - exact (λ X, cleaving (pr12 X)).
   - exact (λ X Y fibX fibY F, is_cartesian_disp_functor (pr2 F)).
 Defined.
 
-Definition DispBicatOfFibs_id_comp
-  : disp_cat_id_comp (total_bicat DispBicatOfDispCats) DispBicatOfFibs_ob_mor.
+Definition disp_bicat_of_fibs_id_comp
+  : disp_cat_id_comp (total_bicat disp_bicat_of_univ_disp_cats) disp_bicat_of_fibs_ob_mor.
 Proof.
   use tpair.
   - intros X fibX x y f xx yy ff p.
@@ -479,32 +410,32 @@ Proof.
     exact p.
 Qed.
 
-Definition DispBicatOfFibs_cat_data
-  : disp_cat_data (total_bicat DispBicatOfDispCats).
+Definition disp_bicat_of_fibs_cat_data
+  : disp_cat_data (total_bicat disp_bicat_of_univ_disp_cats).
 Proof.
   use tpair.
-  - exact DispBicatOfFibs_ob_mor.
-  - exact DispBicatOfFibs_id_comp.
+  - exact disp_bicat_of_fibs_ob_mor.
+  - exact disp_bicat_of_fibs_id_comp.
 Defined.
 
-Definition DispBicatOfFibs_help
-  : disp_bicat (total_bicat DispBicatOfDispCats).
+Definition disp_bicat_of_fibs_help
+  : disp_bicat (total_bicat disp_bicat_of_univ_disp_cats).
 Proof.
   use disp_cell_unit_bicat.
-  exact DispBicatOfFibs_cat_data.
+  exact disp_bicat_of_fibs_cat_data.
 Defined.
 
-Definition DispBicatOfFibs
+Definition disp_bicat_of_fibs
   : disp_bicat bicat_of_cats
   := sigma_bicat
        bicat_of_cats
-       DispBicatOfDispCats
-       DispBicatOfFibs_help.
+       disp_bicat_of_univ_disp_cats
+       disp_bicat_of_fibs_help.
 
-Definition DispBicatOfFibs_is_disp_invertible_2cell
+Definition disp_bicat_of_fibs_is_disp_invertible_2cell
            {C C' : bicat_of_cats}
            {F : C --> C'}
-           {D : DispBicatOfFibs C} {D' : DispBicatOfFibs C'}
+           {D : disp_bicat_of_fibs C} {D' : disp_bicat_of_fibs C'}
            {FF : D -->[ F ] D'} {GG : D -->[ F ] D'}
            (αα : FF ==>[ id₂ F ] GG)
            (Hαα : ∏ (x : (C : univalent_category)) (xx : pr11 D x),
@@ -519,7 +450,7 @@ Proof.
     + intros x xx ; cbn.
       exact (inv_mor_disp_from_iso (Hαα x xx)).
     + intros x xx y yy f ff ; cbn in *.
-      apply (@DispBicatOfDispCats_is_disp_invertible_2cell_natural
+      apply (@disp_bicat_of_univ_disp_cats_is_disp_invertible_2cell_natural
                C C').
   - split.
     + abstract

--- a/UniMath/Bicategories/DisplayedBicats/Examples/Domain.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/Domain.v
@@ -252,9 +252,6 @@ Section DomainArrow.
         apply B.
   Qed.
 
-  Definition TODO {A : UU} : A.
-  Admitted.
-
   Definition dom_invertible_2cell_to_disp_adj_equiv
              {c : B}
              {t₁ t₂ : dom_disp_bicat c}
@@ -263,15 +260,48 @@ Section DomainArrow.
       disp_adjoint_equivalence (internal_adjoint_equivalence_identity c) t₁ t₂.
   Proof.
     intros α.
-    simple refine (_ ,, ((_ ,, (_ ,, _)) ,, ((_ ,, _) ,, (_ ,, _)))) ; cbn.
+    simple refine (_ ,, ((_ ,, (_ ,, _)) ,, ((_ ,, _) ,, (_ ,, _)))).
     - exact (pr1 α • linvunitor _).
     - exact (α^-1 • linvunitor _).
-    - apply TODO.
-    - apply TODO.
+    - abstract
+        (cbn ;
+         rewrite linvunitor_natural ;
+         rewrite !vassocl ;
+         apply maponpaths ;
+         rewrite <- lwhisker_hcomp ;
+         rewrite !vassocr ;
+         rewrite lwhisker_vcomp ;
+         rewrite vassocr ;
+         rewrite vcomp_rinv ;
+         rewrite id2_left ;
+         rewrite lwhisker_hcomp ;
+         rewrite triangle_l_inv ;
+         rewrite <- rwhisker_hcomp ;
+         apply maponpaths ;
+         apply lunitor_V_id_is_left_unit_V_id).
+    - abstract
+        (cbn ;
+         rewrite linvunitor_natural ;
+         rewrite <- lwhisker_hcomp ;
+         rewrite !vassocl ;
+         refine (_ @ id2_right _) ;
+         apply maponpaths ;
+         rewrite !vassocr ;
+         rewrite lwhisker_vcomp ;
+         rewrite !vassocr ;
+         rewrite vcomp_linv ;
+         rewrite id2_left ;
+         rewrite lwhisker_hcomp ;
+         rewrite triangle_l_inv ;
+         rewrite <- rwhisker_hcomp ;
+         rewrite rwhisker_vcomp ;
+         rewrite lunitor_runitor_identity ;
+         rewrite rinvunitor_runitor ;
+         apply id2_rwhisker).
     - apply dom_disp_2cells_isaprop.
     - apply dom_disp_2cells_isaprop.
-    - apply TODO.
-    - apply TODO.
+    - apply dom_disp_locally_groupoid.
+    - apply dom_disp_locally_groupoid.
   Defined.
 
   Definition dom_disp_adj_equiv_to_invertible_2cell

--- a/UniMath/Bicategories/DisplayedBicats/Examples/Domain.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/Domain.v
@@ -1,0 +1,382 @@
+Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.All.
+Require Import UniMath.CategoryTheory.Core.Prelude.
+Require Import UniMath.CategoryTheory.opp_precat.
+Require Import UniMath.CategoryTheory.Core.Functors.
+Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
+Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
+Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.DisplayedCats.Core.
+Require Import UniMath.CategoryTheory.DisplayedCats.Constructions.
+Require Import UniMath.Bicategories.Core.Bicat. Import Bicat.Notations.
+Require Import UniMath.Bicategories.Core.Adjunctions.
+Require Import UniMath.Bicategories.Core.Invertible_2cells.
+Require Import UniMath.Bicategories.Core.Univalence.
+Require Import UniMath.Bicategories.Core.Unitors.
+Require Import UniMath.Bicategories.Core.BicategoryLaws.
+Require Import UniMath.Bicategories.Core.AdjointUnique.
+Require Import UniMath.Bicategories.Core.Examples.OneTypes.
+Require Import UniMath.Bicategories.DisplayedBicats.Examples.ContravariantFunctor.
+Require Import UniMath.Bicategories.DisplayedBicats.Examples.DisplayedCatToBicat.
+Require Import UniMath.Bicategories.DisplayedBicats.DispBicat.
+Import DispBicat.Notations.
+Require Import UniMath.Bicategories.DisplayedBicats.DispAdjunctions.
+Require Import UniMath.Bicategories.DisplayedBicats.DispInvertibles.
+Require Import UniMath.Bicategories.DisplayedBicats.DispUnivalence.
+Require Import UniMath.Bicategories.DisplayedBicats.Examples.Trivial.
+Require Import UniMath.Bicategories.DisplayedBicats.Examples.Sigma.
+
+Local Open Scope cat.
+Local Open Scope mor_disp_scope.
+
+Section DomainArrow.
+  Variable (B : bicat)
+           (a : B).
+
+  Definition dom_disp_cat_ob_mor
+    : disp_cat_ob_mor B.
+  Proof.
+    use tpair.
+    - exact (λ c, c --> a).
+    - exact (λ c₁ c₂ t₁ t₂ s, t₁ ==> s · t₂).
+  Defined.
+
+  Definition dom_disp_cat_id_comp
+    : disp_cat_id_comp B dom_disp_cat_ob_mor.
+  Proof.
+    use tpair.
+    - exact (λ c t, linvunitor _).
+    - exact (λ c₁ c₂ c₃ s₁ s₂ t₁ t₂ t₃ α β, α • (s₁ ◃ β) • lassociator _ _ _).
+  Defined.
+
+  Definition dom_disp_cat_data
+    : disp_cat_data B.
+  Proof.
+    use tpair.
+    - exact dom_disp_cat_ob_mor.
+    - exact dom_disp_cat_id_comp.
+  Defined.
+
+  Definition dom_disp_prebicat_1_id_comp_cells
+    : disp_prebicat_1_id_comp_cells B.
+  Proof.
+    use tpair.
+    - exact dom_disp_cat_data.
+    - exact (λ c₁ c₂ s₁ s₂ α t₁ t₂ ss₁ ss₂, ss₁ • (α ▹ _) = ss₂).
+  Defined.
+
+  Definition dom_disp_prebicat_ops
+    : disp_prebicat_ops dom_disp_prebicat_1_id_comp_cells.
+  Proof.
+    repeat split ; cbn.
+    - intros.
+      rewrite id2_rwhisker.
+      apply id2_right.
+    - intros.
+      rewrite lwhisker_hcomp.
+      rewrite <- linvunitor_natural.
+      rewrite !vassocl.
+      rewrite linvunitor_assoc.
+      rewrite !vassocl.
+      etrans.
+      {
+        do 2 apply maponpaths.
+        rewrite !vassocr.
+        rewrite rassociator_lassociator.
+        apply id2_left.
+      }
+      rewrite rwhisker_vcomp.
+      rewrite linvunitor_lunitor.
+      rewrite id2_rwhisker.
+      apply id2_right.
+    - intros.
+      rewrite rwhisker_hcomp.
+      rewrite !vassocl.
+      rewrite <- triangle_r.
+      rewrite <- lwhisker_hcomp.
+      rewrite lwhisker_vcomp.
+      rewrite linvunitor_lunitor.
+      rewrite lwhisker_id2.
+      apply id2_right.
+    - intros.
+      rewrite lwhisker_hcomp.
+      rewrite <- linvunitor_natural.
+      rewrite !vassocl.
+      apply maponpaths.
+      rewrite linvunitor_assoc.
+      rewrite !vassocl.
+      rewrite rassociator_lassociator.
+      rewrite id2_right.
+      apply idpath.
+    - intros.
+      rewrite !vassocl.
+      apply maponpaths.
+      rewrite lwhisker_hcomp, rwhisker_hcomp.
+      rewrite triangle_l_inv.
+      apply idpath.
+    - intros.
+      rewrite !vassocl.
+      apply maponpaths.
+      rewrite <- !lwhisker_vcomp.
+      rewrite !vassocl.
+      apply maponpaths.
+      rewrite !vassocr.
+      rewrite <- lwhisker_lwhisker.
+      rewrite !vassocl.
+      apply maponpaths.
+      rewrite !vassocr.
+      rewrite <- lassociator_lassociator.
+      rewrite !vassocl.
+      apply maponpaths.
+      rewrite rwhisker_vcomp.
+      rewrite lassociator_rassociator.
+      rewrite id2_rwhisker.
+      apply id2_right.
+    - intros.
+      rewrite !vassocl.
+      apply maponpaths.
+      rewrite <- !lwhisker_vcomp.
+      rewrite !vassocl.
+      apply maponpaths.
+      etrans.
+      {
+        apply maponpaths.
+        rewrite !vassocr.
+        apply lassociator_lassociator.
+      }
+      rewrite !vassocr.
+      apply maponpaths_2.
+      rewrite lwhisker_lwhisker.
+      apply idpath.
+    - intros ? ? ? ? ? ? ? ? ? ? ? ? α β.
+      rewrite <- rwhisker_vcomp.
+      rewrite !vassocr.
+      rewrite α.
+      exact β.
+    - intros ? ? ? ? ? ? ? ? ? ? ? ? ? α.
+      rewrite !vassocl.
+      apply maponpaths.
+      rewrite <- rwhisker_lwhisker.
+      rewrite !vassocr.
+      apply maponpaths_2.
+      rewrite lwhisker_vcomp.
+      rewrite α.
+      apply idpath.
+    - intros ? ? ? ? ? ? ? ? ? ? ? ? ? α.
+      rewrite !vassocl.
+      rewrite rwhisker_rwhisker.
+      rewrite !vassocr.
+      apply maponpaths_2.
+      rewrite !vassocl.
+      rewrite <- vcomp_whisker.
+      rewrite !vassocr.
+      rewrite α.
+      apply idpath.
+  Qed.
+
+  Definition dom_disp_prebicat_data
+    : disp_prebicat_data B.
+  Proof.
+    use tpair.
+    - exact dom_disp_prebicat_1_id_comp_cells.
+    - exact dom_disp_prebicat_ops.
+  Defined.
+
+  Definition dom_disp_prebicat_laws
+    : disp_prebicat_laws dom_disp_prebicat_data.
+  Proof.
+    repeat split ; intro ; intros ; apply B.
+  Qed.
+
+  Definition dom_disp_prebicat
+    : disp_prebicat B.
+  Proof.
+    use tpair.
+    - exact dom_disp_prebicat_data.
+    - exact dom_disp_prebicat_laws.
+  Defined.
+
+  Definition dom_disp_bicat
+    : disp_bicat B.
+  Proof.
+    use tpair.
+    - exact dom_disp_prebicat.
+    - intro ; intros.
+      apply isasetaprop.
+      apply B.
+  Defined.
+
+  Definition dom_disp_2cells_isaprop
+    : disp_2cells_isaprop dom_disp_bicat.
+  Proof.
+    intro ; intros.
+    apply B.
+  Qed.
+
+  Definition dom_disp_locally_sym
+    : disp_locally_sym dom_disp_bicat.
+  Proof.
+    intros c₁ c₂ s₁ s₂ α t₁ t₂ φ₁ φ₂ p ; cbn in *.
+    rewrite <- p.
+    rewrite !vassocl.
+    rewrite rwhisker_vcomp.
+    rewrite vcomp_rinv.
+    rewrite id2_rwhisker.
+    apply id2_right.
+  Qed.
+
+  Definition dom_disp_locally_groupoid
+    : disp_locally_groupoid dom_disp_bicat.
+  Proof.
+    use make_disp_locally_groupoid.
+    - exact dom_disp_locally_sym.
+    - exact dom_disp_2cells_isaprop.
+  Defined.
+
+  Definition dom_disp_univalent_2_1
+    : disp_univalent_2_1 dom_disp_bicat.
+  Proof.
+    use fiberwise_local_univalent_is_univalent_2_1.
+    intros c₁ c₂ s t₁ t₂ φ₁ φ₂.
+    use isweqimplimpl.
+    - intros α.
+      pose (pr1 α) as p ; cbn in p.
+      rewrite id2_rwhisker in p.
+      rewrite id2_right in p.
+      exact p.
+    - apply B.
+    - use isaproptotal2.
+      + intro.
+        apply isaprop_is_disp_invertible_2cell.
+      + intros.
+        apply B.
+  Qed.
+
+  Definition TODO {A : UU} : A.
+  Admitted.
+
+  Definition dom_invertible_2cell_to_disp_adj_equiv
+             {c : B}
+             {t₁ t₂ : dom_disp_bicat c}
+    : invertible_2cell t₁ t₂
+      →
+      disp_adjoint_equivalence (internal_adjoint_equivalence_identity c) t₁ t₂.
+  Proof.
+    intros α.
+    simple refine (_ ,, ((_ ,, (_ ,, _)) ,, ((_ ,, _) ,, (_ ,, _)))) ; cbn.
+    - exact (pr1 α • linvunitor _).
+    - exact (α^-1 • linvunitor _).
+    - apply TODO.
+    - apply TODO.
+    - apply dom_disp_2cells_isaprop.
+    - apply dom_disp_2cells_isaprop.
+    - apply TODO.
+    - apply TODO.
+  Defined.
+
+  Definition dom_disp_adj_equiv_to_invertible_2cell
+             {c : B}
+             {t₁ t₂ : dom_disp_bicat c}
+    : disp_adjoint_equivalence (internal_adjoint_equivalence_identity c) t₁ t₂
+      →
+      invertible_2cell t₁ t₂.
+  Proof.
+    intros e.
+    use make_invertible_2cell.
+    - exact (pr1 e • lunitor _).
+    - use make_is_invertible_2cell.
+      + exact (pr112 e • lunitor _).
+      + abstract
+          (pose (pr1 (pr212 e)) as m ;
+           cbn in m ;
+           rewrite !vassocl ;
+           etrans ;
+           [ apply maponpaths ;
+             rewrite !vassocr ;
+             apply maponpaths_2 ;
+             refine (!_) ;
+             apply vcomp_lunitor
+           | ] ;
+           cbn ;
+           rewrite <- lunitor_triangle ;
+           rewrite !vassocr ;
+           rewrite <- m ;
+           rewrite !vassocl ;
+           etrans ;
+           [ apply maponpaths ;
+             rewrite vassocr ;
+             rewrite rwhisker_vcomp ;
+             rewrite linvunitor_lunitor ;
+             rewrite id2_rwhisker ;
+             apply id2_left
+           | ] ;
+           apply linvunitor_lunitor).
+      + abstract
+          (pose (pr2 (pr212 e)) as m ;
+           cbn in m ;
+           refine (_ @ linvunitor_lunitor _) ;
+           rewrite !vassocr ;
+           apply maponpaths_2 ;
+           refine (_ @ m) ;
+           rewrite !vassocl ;
+           apply maponpaths ;
+           rewrite lunitor_triangle ;
+           rewrite vcomp_lunitor ;
+           apply idpath).
+  Defined.
+
+  Definition dom_invertible_2cell_weq_disp_adj_equiv
+             (HB_2_1 : is_univalent_2_1 B)
+             {c : B}
+             (t₁ t₂ : dom_disp_bicat c)
+    : invertible_2cell t₁ t₂
+      ≃
+      disp_adjoint_equivalence (internal_adjoint_equivalence_identity c) t₁ t₂.
+  Proof.
+    use make_weq.
+    - exact dom_invertible_2cell_to_disp_adj_equiv.
+    - use gradth.
+      + exact dom_disp_adj_equiv_to_invertible_2cell.
+      + abstract
+          (intros α ;
+           use subtypePath ; [ intro ; apply isaprop_is_invertible_2cell | ] ;
+           cbn ;
+           rewrite vassocl ;
+           rewrite linvunitor_lunitor ;
+           apply id2_right).
+      + abstract
+          (intros α ;
+           use subtypePath ;
+           [ intro ;
+             use isaprop_disp_left_adjoint_equivalence ;
+             [ exact HB_2_1
+             |  apply dom_disp_univalent_2_1 ]
+           | ] ;
+           cbn ;
+           rewrite vassocl ;
+           rewrite lunitor_linvunitor ;
+           apply id2_right).
+  Defined.
+
+  Definition dom_disp_univalent_2_0
+             (HB_2_1 : is_univalent_2_1 B)
+    : disp_univalent_2_0 dom_disp_bicat.
+  Proof.
+    use fiberwise_univalent_2_0_to_disp_univalent_2_0.
+    intros c t₁ t₂.
+    use weqhomot.
+    - exact (dom_invertible_2cell_weq_disp_adj_equiv HB_2_1 t₁ t₂
+             ∘ make_weq _ (HB_2_1 _ _ _ _))%weq.
+    - abstract
+        (intros p ;
+         cbn in p ;
+         induction p ;
+         use subtypePath ;
+           [ intro ;
+             use isaprop_disp_left_adjoint_equivalence ;
+             [ exact HB_2_1
+             |  apply dom_disp_univalent_2_1 ]
+           | ] ;
+         apply id2_left).
+  Qed.
+End DomainArrow.

--- a/UniMath/Bicategories/DisplayedBicats/Examples/Domain.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/Domain.v
@@ -1,30 +1,16 @@
 Require Import UniMath.Foundations.All.
 Require Import UniMath.MoreFoundations.All.
 Require Import UniMath.CategoryTheory.Core.Prelude.
-Require Import UniMath.CategoryTheory.opp_precat.
-Require Import UniMath.CategoryTheory.Core.Functors.
-Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
-Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
-Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
-Require Import UniMath.CategoryTheory.DisplayedCats.Constructions.
 Require Import UniMath.Bicategories.Core.Bicat. Import Bicat.Notations.
 Require Import UniMath.Bicategories.Core.Adjunctions.
 Require Import UniMath.Bicategories.Core.Invertible_2cells.
 Require Import UniMath.Bicategories.Core.Univalence.
 Require Import UniMath.Bicategories.Core.Unitors.
 Require Import UniMath.Bicategories.Core.BicategoryLaws.
-Require Import UniMath.Bicategories.Core.AdjointUnique.
-Require Import UniMath.Bicategories.Core.Examples.OneTypes.
-Require Import UniMath.Bicategories.DisplayedBicats.Examples.ContravariantFunctor.
-Require Import UniMath.Bicategories.DisplayedBicats.Examples.DisplayedCatToBicat.
 Require Import UniMath.Bicategories.DisplayedBicats.DispBicat.
 Import DispBicat.Notations.
-Require Import UniMath.Bicategories.DisplayedBicats.DispAdjunctions.
-Require Import UniMath.Bicategories.DisplayedBicats.DispInvertibles.
 Require Import UniMath.Bicategories.DisplayedBicats.DispUnivalence.
-Require Import UniMath.Bicategories.DisplayedBicats.Examples.Trivial.
-Require Import UniMath.Bicategories.DisplayedBicats.Examples.Sigma.
 
 Local Open Scope cat.
 Local Open Scope mor_disp_scope.

--- a/UniMath/Bicategories/DisplayedBicats/Examples/Trivial.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/Trivial.v
@@ -5,7 +5,7 @@
    bicategory.                                                                         *)
 (* ----------------------------------------------------------------------------------- *)
 Require Import UniMath.Foundations.All.
-Require Import UniMath.MoreFoundations.PartA.
+Require Import UniMath.MoreFoundations.All.
 Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.DisplayedCats.Auxiliary.
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
@@ -13,7 +13,14 @@ Require Import UniMath.CategoryTheory.DisplayedCats.Constructions.
 Require Import UniMath.Bicategories.Core.Bicat. Import Bicat.Notations.
 Require Import UniMath.Bicategories.Core.Examples.Initial.
 Require Import UniMath.Bicategories.Core.Examples.Final.
+Require Import UniMath.Bicategories.Core.Invertible_2cells.
+Require Import UniMath.Bicategories.Core.Univalence.
+Require Import UniMath.Bicategories.Core.Unitors.
+Require Import UniMath.Bicategories.Core.AdjointUnique.
 Require Import UniMath.Bicategories.DisplayedBicats.DispBicat. Import DispBicat.Notations.
+Require Import UniMath.Bicategories.DisplayedBicats.DispAdjunctions.
+Require Import UniMath.Bicategories.DisplayedBicats.DispInvertibles.
+Require Import UniMath.Bicategories.DisplayedBicats.DispUnivalence.
 
 Local Open Scope cat.
 Local Open Scope mor_disp_scope.
@@ -131,3 +138,316 @@ Definition paircell
            (α : f₁ ==> f₂) (β : g₁ ==> g₂)
   : pairmor f₁ g₁ ==> pairmor f₂ g₂
   := α ,, β.
+
+Definition trivial_is_invertible_2cell_to_is_disp_invertible
+           {B C : bicat}
+           {b₁ b₂ : B}
+           {f g : B ⟦ b₁, b₂ ⟧}
+           {α : f ==> g}
+           (Hα : is_invertible_2cell α)
+           {c₁ : trivial_displayed_bicat B C b₁}
+           {c₂ : trivial_displayed_bicat B C b₂}
+           {ff : c₁ -->[ f ] c₂}
+           {gg : c₁ -->[ g ] c₂}
+           (β : ff ==> gg)
+           (Hβ : is_invertible_2cell β)
+  : is_disp_invertible_2cell Hα β.
+Proof.
+  simple refine (_ ,, (_ ,, _)).
+  - exact (Hβ^-1).
+  - abstract
+      (unfold transportb ; cbn ;
+       rewrite transportf_const ;
+       apply vcomp_rinv).
+  - abstract
+      (unfold transportb ; cbn ;
+       rewrite transportf_const ;
+       apply vcomp_linv).
+Defined.
+
+Definition trivial_invertible_2cell_to_disp_invertible
+           {B C : bicat}
+           {b₁ b₂ : B}
+           {f : B ⟦ b₁, b₂ ⟧}
+           {c₁ : trivial_displayed_bicat B C b₁}
+           {c₂ : trivial_displayed_bicat B C b₂}
+           {ff gg : c₁ -->[ f] c₂}
+  : invertible_2cell ff gg → disp_invertible_2cell (id2_invertible_2cell f) ff gg.
+Proof.
+  intros α.
+  simple refine (_ ,, _).
+  - exact (pr1 α).
+  - apply trivial_is_invertible_2cell_to_is_disp_invertible.
+    exact (pr2 α).
+Defined.
+
+Definition trivial_is_disp_invertible_to_is_invertible_2cell
+           {B C : bicat}
+           {b₁ b₂ : B}
+           {f g : B ⟦ b₁, b₂ ⟧}
+           {α : f ==> g}
+           (Hα : is_invertible_2cell α)
+           {c₁ : trivial_displayed_bicat B C b₁}
+           {c₂ : trivial_displayed_bicat B C b₂}
+           {ff gg : c₁ -->[ f] c₂}
+           (β : ff ==> gg)
+           (Hβ : is_disp_invertible_2cell Hα β)
+  : is_invertible_2cell β.
+Proof.
+  use make_is_invertible_2cell.
+  - exact (pr1 Hβ).
+  - abstract
+      (pose (pr12 Hβ) as p ;
+       cbn in p ; unfold transportb in p ;
+       rewrite transportf_const in p ;
+       exact p).
+  - abstract
+      (pose (pr22 Hβ) as p ;
+       cbn in p ; unfold transportb in p ;
+       rewrite transportf_const in p ;
+       exact p).
+Defined.
+
+Definition trivial_disp_invertible_to_invertible_2cell
+           {B C : bicat}
+           {b₁ b₂ : B}
+           {f : B ⟦ b₁, b₂ ⟧}
+           {c₁ : trivial_displayed_bicat B C b₁}
+           {c₂ : trivial_displayed_bicat B C b₂}
+           {ff gg : c₁ -->[ f] c₂}
+  : disp_invertible_2cell (id2_invertible_2cell f) ff gg → invertible_2cell ff gg.
+Proof.
+  intros α.
+  use make_invertible_2cell.
+  - exact (pr1 α).
+  - use (trivial_is_disp_invertible_to_is_invertible_2cell
+           (is_invertible_2cell_id₂ f)).
+    apply α.
+Defined.
+
+Definition trivial_invertible_to_disp_invertible_to_invertible
+           {B C : bicat}
+           {b₁ b₂ : B}
+           {f : B ⟦ b₁, b₂ ⟧}
+           {c₁ : trivial_displayed_bicat B C b₁}
+           {c₂ : trivial_displayed_bicat B C b₂}
+           {ff gg : c₁ -->[ f] c₂}
+           (α : invertible_2cell ff gg)
+  :  trivial_disp_invertible_to_invertible_2cell
+       (trivial_invertible_2cell_to_disp_invertible α)
+     =
+     α.
+Proof.
+  use subtypePath.
+  {
+    intro ; apply isaprop_is_invertible_2cell.
+  }
+  apply idpath.
+Qed.
+
+Definition trivial_disp_invertible_to_invertible_to_disp_invertible
+           {B C : bicat}
+           {b₁ b₂ : B}
+           {f : B ⟦ b₁, b₂ ⟧}
+           {c₁ : trivial_displayed_bicat B C b₁}
+           {c₂ : trivial_displayed_bicat B C b₂}
+           {ff gg : c₁ -->[ f] c₂}
+           (α : disp_invertible_2cell (id2_invertible_2cell f) ff gg)
+  : trivial_invertible_2cell_to_disp_invertible
+      (trivial_disp_invertible_to_invertible_2cell α)
+    =
+    α.
+Proof.
+  use subtypePath.
+  {
+    intro ; apply isaprop_is_disp_invertible_2cell.
+  }
+  apply idpath.
+Qed.
+
+Definition trivial_invertible_2cell_weq_disp_invertible
+           {B C : bicat}
+           {b₁ b₂ : B}
+           {f : B ⟦ b₁, b₂ ⟧}
+           {c₁ : trivial_displayed_bicat B C b₁}
+           {c₂ : trivial_displayed_bicat B C b₂}
+           (ff gg : c₁ -->[ f] c₂)
+  : invertible_2cell ff gg ≃ disp_invertible_2cell (id2_invertible_2cell f) ff gg.
+Proof.
+  use make_weq.
+  - exact trivial_invertible_2cell_to_disp_invertible.
+  - use gradth.
+    + exact trivial_disp_invertible_to_invertible_2cell.
+    + exact trivial_invertible_to_disp_invertible_to_invertible.
+    + exact trivial_disp_invertible_to_invertible_to_disp_invertible.
+Defined.
+
+Definition trivial_is_univalent_2_1
+           {B C : bicat}
+           (HC : is_univalent_2_1 C)
+  : disp_univalent_2_1 (trivial_displayed_bicat B C).
+Proof.
+  use fiberwise_local_univalent_is_univalent_2_1.
+  intros b₁ b₂ f c₁ c₂ ff gg.
+  use weqhomot.
+  - exact (trivial_invertible_2cell_weq_disp_invertible ff gg
+           ∘ make_weq (idtoiso_2_1 ff gg) (HC _ _ ff gg))%weq.
+  - intro p ; cbn in p.
+    induction p.
+    use subtypePath.
+    {
+      intro ; apply isaprop_is_disp_invertible_2cell.
+    }
+    apply idpath.
+Defined.
+
+Definition trivial_adj_equiv_to_disp_adj_equiv
+           {B C : bicat}
+           {b : B}
+           {c₁ c₂ : trivial_displayed_bicat B C b}
+  : adjoint_equivalence c₁ c₂
+    →
+    disp_adjoint_equivalence (internal_adjoint_equivalence_identity b) c₁ c₂.
+Proof.
+  intros e.
+  simple refine (_ ,, ((_ ,, (_ ,, _)) ,, ((_ ,, _) ,, (_ ,, _)))).
+  - exact (pr1 e).
+  - exact (left_adjoint_right_adjoint e).
+  - exact (left_adjoint_unit e).
+  - exact (left_adjoint_counit e).
+  - abstract
+      (unfold transportb ;
+       cbn ;
+       rewrite transportf_const ; cbn ;
+       exact (pr1 (pr122 e))).
+  - abstract
+      (unfold transportb ;
+       cbn ;
+       rewrite transportf_const ; cbn ;
+       exact (pr2 (pr122 e))).
+  - abstract
+      (apply trivial_is_invertible_2cell_to_is_disp_invertible ;
+       apply (pr2 e)).
+  - abstract
+      (apply trivial_is_invertible_2cell_to_is_disp_invertible ;
+       apply (pr2 e)).
+Defined.
+
+Definition trivial_disp_adj_equiv_to_adj_equiv
+           {B C : bicat}
+           {b : B}
+           {c₁ c₂ : trivial_displayed_bicat B C b}
+  : disp_adjoint_equivalence (internal_adjoint_equivalence_identity b) c₁ c₂
+    →
+    adjoint_equivalence c₁ c₂.
+Proof.
+  intros e.
+  simple refine (_ ,, ((_ ,, (_ ,, _)) ,, ((_ ,, _) ,, (_ ,, _)))).
+  - exact (pr1 e).
+  - exact (pr112 e).
+  - exact (pr1 (pr212 e)).
+  - exact (pr2 (pr212 e)).
+  - abstract
+      (pose (pr1 (pr122 e)) as p ;
+       cbn in p ;
+       unfold transportb in p ;
+       rewrite transportf_const in p ;
+       exact p).
+  - abstract
+      (pose (pr2 (pr122 e)) as p ;
+       cbn in p ;
+       unfold transportb in p ;
+       rewrite transportf_const in p ;
+       exact p).
+  - abstract
+      (apply (trivial_is_disp_invertible_to_is_invertible_2cell _ _ (pr1 (pr222 e)))).
+  - abstract
+      (apply (trivial_is_disp_invertible_to_is_invertible_2cell _ _ (pr2 (pr222 e)))).
+Defined.
+
+Definition trivial_adj_equiv_to_disp_to_adj
+           {B C : bicat}
+           (HC_2_1 : is_univalent_2_1 C)
+           {b : B}
+           {c₁ c₂ : trivial_displayed_bicat B C b}
+           (e : adjoint_equivalence c₁ c₂)
+  : trivial_disp_adj_equiv_to_adj_equiv
+      (trivial_adj_equiv_to_disp_adj_equiv e)
+    =
+    e.
+Proof.
+  use subtypePath.
+  {
+    intro.
+    use isaprop_left_adjoint_equivalence.
+    exact HC_2_1.
+  }
+  apply idpath.
+Qed.
+
+Definition trivial_disp_adj_equiv_to_adj_to_disp
+           {B C : bicat}
+           (HB_2_1 : is_univalent_2_1 B)
+           (HC_2_1 : is_univalent_2_1 C)
+           {b : B}
+           {c₁ c₂ : trivial_displayed_bicat B C b}
+           (e : disp_adjoint_equivalence (internal_adjoint_equivalence_identity b) c₁ c₂)
+  : trivial_adj_equiv_to_disp_adj_equiv
+      (trivial_disp_adj_equiv_to_adj_equiv e)
+    =
+    e.
+Proof.
+  use subtypePath.
+  {
+    intro.
+    use isaprop_disp_left_adjoint_equivalence.
+    - exact HB_2_1.
+    - apply trivial_is_univalent_2_1.
+      exact HC_2_1.
+  }
+  apply idpath.
+Qed.
+
+Definition trivial_adj_equiv_weq_disp_adj_equiv
+           {B C : bicat}
+           (HB_2_1 : is_univalent_2_1 B)
+           (HC_2_1 : is_univalent_2_1 C)
+           {b : B}
+           (c₁ c₂ : trivial_displayed_bicat B C b)
+  : adjoint_equivalence c₁ c₂
+    ≃
+    disp_adjoint_equivalence (internal_adjoint_equivalence_identity b) c₁ c₂.
+Proof.
+  use make_weq.
+  - exact trivial_adj_equiv_to_disp_adj_equiv.
+  - use gradth.
+    + exact trivial_disp_adj_equiv_to_adj_equiv.
+    + exact (trivial_adj_equiv_to_disp_to_adj HC_2_1).
+    + exact (trivial_disp_adj_equiv_to_adj_to_disp HB_2_1 HC_2_1).
+Defined.
+
+Definition trivial_is_univalent_2_0
+           {B C : bicat}
+           (HB_2_1 : is_univalent_2_1 B)
+           (HC_2_0 : is_univalent_2_0 C)
+           (HC_2_1 : is_univalent_2_1 C)
+  : disp_univalent_2_0 (trivial_displayed_bicat B C).
+Proof.
+  use fiberwise_univalent_2_0_to_disp_univalent_2_0.
+  intros b c₁ c₂.
+  use weqhomot.
+  - exact (trivial_adj_equiv_weq_disp_adj_equiv HB_2_1 HC_2_1 c₁ c₂
+           ∘ make_weq (idtoiso_2_0 c₁ c₂) (HC_2_0 c₁ c₂))%weq.
+  - intros p.
+    cbn in p.
+    induction p.
+    use subtypePath.
+    {
+      intro.
+      use isaprop_disp_left_adjoint_equivalence.
+      - exact HB_2_1.
+      - apply trivial_is_univalent_2_1.
+        exact HC_2_1.
+    }
+    apply idpath.
+Defined.

--- a/UniMath/CONTENTS.md
+++ b/UniMath/CONTENTS.md
@@ -423,6 +423,8 @@ The packages and files are listed here in logical order: each file depends only 
    - [DisplayedBicats/Examples/ContravariantFunctor.v](Bicategories/DisplayedBicats/Examples/ContravariantFunctor.v)
    - [DisplayedBicats/Examples/Cofunctormap.v](Bicategories/DisplayedBicats/Examples/Cofunctormap.v)
    - [DisplayedBicats/Examples/CwF.v](Bicategories/DisplayedBicats/Examples/CwF.v)
+   - [DisplayedBicats/Examples/Domain.v](Bicategories/DisplayedBicats/Examples/Domain.v)
+   - [DisplayedBicats/Examples/Codomain.v](Bicategories/DisplayedBicats/Examples/Codomain.v)
    - [DisplayedBicats/DispPseudofunctor.v](Bicategories/DisplayedBicats/DispPseudofunctor.v)
    - [Transformations/Examples/AlgebraMap.v](Bicategories/Transformations/Examples/AlgebraMap.v)
    - [DisplayedBicats/Examples/Monads.v](Bicategories/DisplayedBicats/Examples/Monads.v)

--- a/UniMath/CategoryTheory/DisplayedCats/Core.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Core.v
@@ -754,7 +754,17 @@ Section Univalent_Categories.
 
 Definition is_univalent_disp {C} (D : disp_cat C)
   := ∏ x x' (e : x = x') (xx : D x) (xx' : D x'),
-       isweq (λ ee, @idtoiso_disp _ _ _ _ e xx xx' ee).
+     isweq (λ ee, @idtoiso_disp _ _ _ _ e xx xx' ee).
+
+Definition isaprop_is_univalent_disp
+           {C : category}
+           (D : disp_cat C)
+  : isaprop (is_univalent_disp D).
+Proof.
+  unfold is_univalent_disp.
+  do 5 (use impred ; intro).
+  apply isapropisweq.
+Defined.
 
 Definition is_univalent_in_fibers {C} (D : disp_cat C) : UU
   := ∏ x (xx xx' : D x), isweq (fun e : xx = xx' => idtoiso_fiber_disp e).

--- a/UniMath/CategoryTheory/DisplayedCats/Core.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Core.v
@@ -38,6 +38,7 @@ Require Import UniMath.CategoryTheory.Core.Isos.
 Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
 Require Import UniMath.CategoryTheory.Core.Univalence.
 Require Import UniMath.CategoryTheory.Core.Functors.
+Require Import UniMath.CategoryTheory.whiskering.
 Local Open Scope cat.
 Local Open Scope cat_deprecated.
 
@@ -1981,4 +1982,61 @@ End Disp_Nat_Trans.
 - add lemmas connecting with products of cats (as required for displayed bicats)
 - add more applications of the displayed arrow category: slices; equalisers, inserters; hence groups etc.
 
-*)
+ *)
+
+Definition pre_whisker_disp_nat_trans
+           {C₁ C₂ C₃ : category}
+           {F : C₁ ⟶ C₂}
+           {G₁ G₂ : C₂ ⟶ C₃}
+           {n : G₁ ⟹ G₂}
+           {D₁ : disp_precat C₁}
+           {D₂ : disp_precat C₂}
+           {D₃ : disp_precat C₃}
+           (FF : disp_functor F D₁ D₂)
+           {GG₁ : disp_functor G₁ D₂ D₃}
+           {GG₂ : disp_functor G₂ D₂ D₃}
+           (nn : disp_nat_trans n GG₁ GG₂)
+  : disp_nat_trans
+      (pre_whisker F n)
+      (disp_functor_composite FF GG₁)
+      (disp_functor_composite FF GG₂).
+Proof.
+  use tpair.
+  - exact (λ x xx, nn (F x) (FF x xx)).
+  - abstract
+      (intros x y f xx yy ff ; cbn ;
+       rewrite (disp_nat_trans_ax nn) ;
+       apply maponpaths_2 ;
+       apply C₃).
+Defined.
+
+Definition post_whisker_disp_nat_trans
+           {C₁ C₂ C₃ : category}
+           {F₁ F₂ : C₁ ⟶ C₂}
+           {n : F₁ ⟹ F₂}
+           {G : C₂ ⟶ C₃}
+           {D₁ : disp_precat C₁}
+           {D₂ : disp_precat C₂}
+           {D₃ : disp_precat C₃}
+           {FF₁ : disp_functor F₁ D₁ D₂}
+           {FF₂ : disp_functor F₂ D₁ D₂}
+           (nn : disp_nat_trans n FF₁ FF₂)
+           (GG : disp_functor G D₂ D₃)
+  : disp_nat_trans
+      (post_whisker n G)
+      (disp_functor_composite FF₁ GG)
+      (disp_functor_composite FF₂ GG).
+Proof.
+  use tpair.
+  - exact (λ x xx, # GG (nn x xx)).
+  - abstract
+      (intros x y f xx yy ff ; cbn ;
+       rewrite <- !(disp_functor_comp_var GG) ;
+       unfold transportb ;
+       rewrite transport_f_f ;
+       rewrite (disp_nat_trans_ax_var nn) ;
+       rewrite disp_functor_transportf ;
+       rewrite transport_f_f ;
+       apply maponpaths_2 ;
+       apply C₃).
+Defined.

--- a/UniMath/CategoryTheory/DisplayedCats/Fibrations.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Fibrations.v
@@ -336,6 +336,17 @@ Defined.
 
 End Fibrations.
 
+Definition isaprop_cleaving
+           {C : univalent_category}
+           (D : disp_cat C)
+           (HD : is_univalent_disp D)
+  : isaprop (cleaving D).
+Proof.
+  repeat (use impred ; intro).
+  apply isaprop_cartesian_lifts.
+  exact HD.
+Defined.
+
 Section Discrete_Fibrations.
 
 Definition is_discrete_fibration {C : category} (D : disp_cat C) : UU


### PR DESCRIPTION
- In `Codomain.v`: the codomain displayed bicategory. Univalence is proven under the assumption that all 2-cells are invertible
- In `Domain.v`: domain displayed bicategory. Univalence is proven in general
- In `DispBicatOfCats.v`: displayed bicategory of fibrations
- In `Trivial.v`: I added a proof of its univalence