### PR TITLE
Pullbacks in bicategories

### DIFF
--- a/UniMath/Bicategories/.package/files
+++ b/UniMath/Bicategories/.package/files
@@ -92,6 +92,7 @@ Core/YonedaLemma.v
 
 Colimits/Initial.v
 Colimits/Final.v
+Colimits/Pullback.v
 PseudoFunctors/Biadjunction.v
 PseudoFunctors/Examples/CurryingInBicatOfCatsWithoutUnivalence.v
 DisplayedBicats/DispBiadjunction.v

--- a/UniMath/Bicategories/Colimits/Pullback.v
+++ b/UniMath/Bicategories/Colimits/Pullback.v
@@ -1,0 +1,960 @@
+(****************************************************************
+
+ Pullbacks in bicategories
+
+ In this file we define the notion of pullback square in arbitrary
+ bicategories. For this definition, there are 2 possibilities. One
+ could either write universal properties, which expresses the
+ existence of a morphism up to a unique 2-cell. Alternatively, one
+ could define the universal property via the hom-categories.
+ Here, we choose the first approach.
+
+ *****************************************************************)
+Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.All.
+Require Import UniMath.CategoryTheory.Core.Categories.
+Require Import UniMath.CategoryTheory.Core.Functors.
+Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
+Require Import UniMath.CategoryTheory.Core.Isos.
+Require Import UniMath.CategoryTheory.Equivalences.Core.
+Require Import UniMath.CategoryTheory.Equivalences.CompositesAndInverses.
+Require Import UniMath.CategoryTheory.IsoCommaCategory.
+Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.Bicategories.Core.Bicat. Import Notations.
+Require Import UniMath.Bicategories.Core.Invertible_2cells.
+Require Import UniMath.Bicategories.Core.Examples.BicatOfCats.
+Require Import UniMath.Bicategories.Core.Examples.OneTypes.
+Require Import UniMath.Bicategories.Core.Adjunctions.
+Require Import UniMath.Bicategories.Core.AdjointUnique.
+Require Import UniMath.Bicategories.Core.EquivToAdjequiv.
+Require Import UniMath.Bicategories.Core.Examples.OneTypes.
+Require Import UniMath.Bicategories.Core.Examples.BicatOfCats.
+Require Import UniMath.CategoryTheory.categories.StandardCategories.
+Require Import UniMath.Bicategories.Core.Univalence.
+Require Import UniMath.CategoryTheory.Core.Univalence.
+Require Import UniMath.CategoryTheory.catiso.
+
+Local Open Scope cat.
+
+Section Pullback.
+  Context {B : bicat}
+          {b₁ b₂ b₃ : B}
+          {f : b₁ --> b₃}
+          {g : b₂ --> b₃}.
+
+  (** Cones on the diagram *)
+  Definition pb_cone
+    : UU
+    := ∑ (p : B)
+         (π₁ : p --> b₁)
+         (π₂ : p --> b₂),
+       invertible_2cell (π₁ · f) (π₂ · g).
+
+  Coercion pb_cone_obj
+           (p : pb_cone)
+    : B
+    := pr1 p.
+
+  Definition pb_cone_pr1
+             (p : pb_cone)
+    : p --> b₁
+    := pr12 p.
+
+  Definition pb_cone_pr2
+             (p : pb_cone)
+    : p --> b₂
+    := pr122 p.
+
+  Definition pb_cone_cell
+             (p : pb_cone)
+    : invertible_2cell
+        (pb_cone_pr1 p · f)
+        (pb_cone_pr2 p · g)
+    := pr222 p.
+
+  Definition make_pb_cone
+             (p : B)
+             (π₁ : p --> b₁)
+             (π₂ : p --> b₂)
+             (η : invertible_2cell (π₁ · f) (π₂ · g))
+    : pb_cone
+    := (p ,, π₁ ,, π₂ ,, η).
+
+  (** 1-cells between cones *)
+  Definition pb_1cell
+             (p q : pb_cone)
+    : UU
+    := ∑ (φ : p --> q)
+         (τ : invertible_2cell
+                (φ · pb_cone_pr1 q)
+                (pb_cone_pr1 p))
+         (θ : invertible_2cell
+                (φ · pb_cone_pr2 q)
+                (pb_cone_pr2 p)),
+       φ ◃ pb_cone_cell q
+       =
+       lassociator _ _ _
+       • (τ ▹ f)
+       • pb_cone_cell p
+       • (θ^-1 ▹ g)
+       • rassociator _ _ _.
+
+  Coercion pb_1cell_1cell
+           {p q : pb_cone}
+           (φ : pb_1cell p q)
+    : p --> q
+    := pr1 φ.
+
+  Definition pb_1cell_pr1
+             {p q : pb_cone}
+             (φ : pb_1cell p q)
+    : invertible_2cell
+        (φ · pb_cone_pr1 q)
+        (pb_cone_pr1 p)
+    := pr12 φ.
+
+  Definition pb_1cell_pr2
+             {p q : pb_cone}
+             (φ : pb_1cell p q)
+    : invertible_2cell
+        (φ · pb_cone_pr2 q)
+        (pb_cone_pr2 p)
+    := pr122 φ.
+
+  Definition pb_1cell_eq
+             {p q : pb_cone}
+             (φ : pb_1cell p q)
+    : φ ◃ pb_cone_cell q
+      =
+      lassociator _ _ _
+      • (pb_1cell_pr1 φ ▹ f)
+      • pb_cone_cell p
+      • ((pb_1cell_pr2 φ)^-1 ▹ g)
+      • rassociator _ _ _
+    := pr222 φ.
+
+  Definition make_pb_1cell
+             {p q : pb_cone}
+             (φ : p --> q)
+             (τ : invertible_2cell
+                    (φ · pb_cone_pr1 q)
+                    (pb_cone_pr1 p))
+             (θ : invertible_2cell
+                    (φ · pb_cone_pr2 q)
+                    (pb_cone_pr2 p))
+             (H : φ ◃ pb_cone_cell q
+                  =
+                  lassociator _ _ _
+                  • (τ ▹ f)
+                  • pb_cone_cell p
+                  • (θ^-1 ▹ g)
+                  • rassociator _ _ _)
+    : pb_1cell p q
+    := (φ ,, τ ,, θ ,, H).
+
+  Definition eq_pb_1cell
+             {p q : pb_cone}
+             (φ ψ : pb_1cell p q)
+             (r₁ : pr1 φ = pr1 ψ)
+             (r₂ : pr1 (pb_1cell_pr1 φ)
+                   =
+                   (idtoiso_2_1 _ _ r₁ ▹ pb_cone_pr1 q) • pr1 (pb_1cell_pr1 ψ))
+             (r₃ : pr1 (pb_1cell_pr2 φ)
+                   =
+                   (idtoiso_2_1 _ _ r₁ ▹ pb_cone_pr2 q) • pr1 (pb_1cell_pr2 ψ))
+    : φ = ψ.
+  Proof.
+    induction φ as [ φ₁ [ φ₂ [ φ₃ φ₄ ]]].
+    induction ψ as [ ψ₁ [ ψ₂ [ ψ₃ ψ₄ ]]].
+    cbn in r₁.
+    induction r₁ ; cbn in r₂.
+    apply maponpaths.
+    assert (φ₂ = ψ₂) as r'.
+    {
+      use subtypePath.
+      {
+        intro ; apply isaprop_is_invertible_2cell.
+      }
+      rewrite id2_rwhisker, id2_left in r₂.
+      exact r₂.
+    }
+    induction r'.
+    apply maponpaths.
+    use subtypePath.
+    {
+      intro ; apply cellset_property.
+    }
+    cbn.
+    cbn in r₃.
+    rewrite id2_rwhisker, id2_left in r₃.
+    use subtypePath.
+    {
+      intro ; apply isaprop_is_invertible_2cell.
+    }
+    exact r₃.
+  Qed.
+
+  (** 2-cells of cones *)
+  Definition pb_2cell
+             {p q : pb_cone}
+             (φ ψ : pb_1cell p q)
+    : UU
+    := ∑ (η : φ ==> ψ),
+       ((η ▹ pb_cone_pr1 q) • pb_1cell_pr1 ψ = pb_1cell_pr1 φ)
+       ×
+       ((η ▹ pb_cone_pr2 q) • pb_1cell_pr2 ψ = pb_1cell_pr2 φ).
+
+  Coercion pb_2cell_2cell
+           {p q : pb_cone}
+           {φ ψ : pb_1cell p q}
+           (η : pb_2cell φ ψ)
+    : φ ==> ψ
+    := pr1 η.
+
+  Definition pb_2cell_pr1
+             {p q : pb_cone}
+             {φ ψ : pb_1cell p q}
+             (η : pb_2cell φ ψ)
+    : (η ▹ pb_cone_pr1 q) • pb_1cell_pr1 ψ = pb_1cell_pr1 φ
+    := pr12 η.
+
+  Definition pb_2cell_pr2
+             {p q : pb_cone}
+             {φ ψ : pb_1cell p q}
+             (η : pb_2cell φ ψ)
+    : (η ▹ pb_cone_pr2 q) • pb_1cell_pr2 ψ = pb_1cell_pr2 φ
+    := pr22 η.
+
+  Definition make_pb_2cell
+             {p q : pb_cone}
+             {φ ψ : pb_1cell p q}
+             (η : φ ==> ψ)
+             (H₁ : (η ▹ pb_cone_pr1 q) • pb_1cell_pr1 ψ = pb_1cell_pr1 φ)
+             (H₂ : (η ▹ pb_cone_pr2 q) • pb_1cell_pr2 ψ = pb_1cell_pr2 φ)
+    : pb_2cell φ ψ
+    := (η ,, H₁ ,, H₂).
+
+  Definition isaset_pb_2cell
+             {p q : pb_cone}
+             (φ ψ : pb_1cell p q)
+    : isaset (pb_2cell φ ψ).
+  Proof.
+    use isaset_total2.
+    - apply cellset_property.
+    - intro.
+      apply isasetdirprod ; apply isasetaprop ; apply cellset_property.
+  Qed.
+
+  Definition id2_pb_2cell
+             {p q : pb_cone}
+             (φ : pb_1cell p q)
+    : pb_2cell φ φ.
+  Proof.
+    use make_pb_2cell.
+    - exact (id2 φ).
+    - abstract
+        (rewrite id2_rwhisker, id2_left ;
+         apply idpath).
+    - abstract
+        (rewrite id2_rwhisker, id2_left ;
+         apply idpath).
+  Defined.
+
+  Definition comp_pb_2cell
+             {p q : pb_cone}
+             {φ ψ χ : pb_1cell p q}
+             (η₁ : pb_2cell φ ψ)
+             (η₂ : pb_2cell ψ χ)
+    : pb_2cell φ χ.
+  Proof.
+    use make_pb_2cell.
+    - exact (η₁ • η₂).
+    - abstract
+        (rewrite <- rwhisker_vcomp ;
+         rewrite vassocl ;
+         rewrite !pb_2cell_pr1 ;
+         apply idpath).
+    - abstract
+        (rewrite <- rwhisker_vcomp ;
+         rewrite vassocl ;
+         rewrite !pb_2cell_pr2 ;
+         apply idpath).
+  Defined.
+
+  (** Statements of universal mapping properties of pullbacks *)
+  Section UniversalMappingPropertyStatements.
+    Variable (p : pb_cone).
+
+    Definition pb_ump_1
+      : UU
+      := ∏ (q : pb_cone), pb_1cell q p.
+
+    Definition pb_ump_2
+      : UU
+      := ∏ (q : pb_cone)
+           (φ ψ : pb_1cell q p),
+         pb_2cell φ ψ.
+
+    Definition pb_ump_eq
+      : UU
+      := ∏ (q : pb_cone)
+           (φ ψ : pb_1cell q p)
+           (η₁ η₂ : pb_2cell φ ψ),
+         η₁ = η₂.
+
+    Definition has_pb_ump
+      : UU
+      := pb_ump_1 × pb_ump_2 × pb_ump_eq.
+
+    Definition has_pb_ump_1
+               (H : has_pb_ump)
+      : pb_ump_1
+      := pr1 H.
+
+    Definition has_pb_ump_2
+               (H : has_pb_ump)
+      : pb_ump_2
+      := pr12 H.
+
+    Definition has_pb_ump_eq
+               (H : has_pb_ump)
+      : pb_ump_eq
+      := pr22 H.
+
+    Definition make_has_pb_ump
+               (H₁ : pb_ump_1)
+               (H₂ : pb_ump_2)
+               (Heq : pb_ump_eq)
+      : has_pb_ump
+      := H₁ ,, H₂ ,, Heq.
+
+    (** In locally univalent bicateogires, being a pullback is a proposition *)
+    Definition isaprop_has_pb_ump
+               (HB_2_1 : is_univalent_2_1 B)
+      : isaprop has_pb_ump.
+    Proof.
+      use invproofirrelevance.
+      intros χ₁ χ₂.
+      repeat use pathsdirprod.
+      - use funextsec ; intro q.
+        use eq_pb_1cell ; cbn.
+        + use (isotoid_2_1 HB_2_1).
+          use make_invertible_2cell.
+          * apply (has_pb_ump_2 χ₁).
+          * use make_is_invertible_2cell.
+            ** apply (has_pb_ump_2 χ₁).
+            ** abstract
+                 (exact (maponpaths
+                           pr1
+                           (has_pb_ump_eq
+                              χ₁
+                              _
+                              (pr1 χ₁ q)
+                              (pr1 χ₁ q)
+                              (comp_pb_2cell
+                                 (has_pb_ump_2 χ₁ q (pr1 χ₁ q) (pr1 χ₂ q))
+                                 (has_pb_ump_2 χ₁ q (pr1 χ₂ q) (pr1 χ₁ q)))
+                              (id2_pb_2cell _)))).
+            ** abstract
+                 (exact (maponpaths
+                           pr1
+                           (has_pb_ump_eq
+                              χ₁
+                              _
+                              (pr1 χ₂ q)
+                              (pr1 χ₂ q)
+                              (comp_pb_2cell
+                                 (has_pb_ump_2 χ₁ q (pr1 χ₂ q) (pr1 χ₁ q))
+                                 (has_pb_ump_2 χ₁ q (pr1 χ₁ q) (pr1 χ₂ q)))
+                              (id2_pb_2cell _)))).
+        + rewrite idtoiso_2_1_isotoid_2_1 ; cbn.
+          refine (!_).
+          apply pb_2cell_pr1.
+        + rewrite idtoiso_2_1_isotoid_2_1.
+          refine (!_).
+          apply pb_2cell_pr2.
+      - use funextsec ; intro q.
+        use funextsec ; intro φ.
+        use funextsec ; intro ψ.
+        exact (has_pb_ump_eq
+                 χ₁ q φ ψ
+                 (has_pb_ump_2 χ₁ q φ ψ)
+                 (has_pb_ump_2 χ₂ q φ ψ)).
+      - repeat (use funextsec ; intro).
+        apply isaset_pb_2cell.
+    Qed.
+  End UniversalMappingPropertyStatements.
+End Pullback.
+
+Arguments pb_cone {_ _ _ _} _ _.
+
+Definition has_pb
+           (B : bicat)
+  : UU
+  := ∏ (b₁ b₂ b₃ : B)
+       (f : b₁ --> b₃)
+       (g : b₂ --> b₃),
+     ∑ (p : pb_cone f g),
+     has_pb_ump p.
+
+
+(** MOVE ??!??!???!??? *)
+Definition pb_type
+           {X Y Z : UU}
+           (f : X → Z)
+           (g : Y → Z)
+  : UU
+  := ∑ (x : X × Y), f (pr1 x) = g (pr2 x).
+
+Definition pb_type_pr1
+           {X Y Z : UU}
+           {f : X → Z}
+           {g : Y → Z}
+  : pb_type f g → X
+  := λ x, pr11 x.
+
+Definition pb_type_pr2
+           {X Y Z : UU}
+           {f : X → Z}
+           {g : Y → Z}
+  : pb_type f g → Y
+  := λ x, pr21 x.
+
+Definition pb_type_eq
+           {X Y Z : UU}
+           {f : X → Z}
+           {g : Y → Z}
+           (x : pb_type f g)
+  : f (pb_type_pr1 x) = g (pb_type_pr2 x)
+  := pr2 x.
+
+Definition path_pb_type
+           {X Y Z : UU}
+           {f : X → Z}
+           {g : Y → Z}
+           {x y : pb_type f g}
+           (p₁ : pb_type_pr1 x = pb_type_pr1 y)
+           (p₂ : pb_type_pr2 x = pb_type_pr2 y)
+           (p₃ : pb_type_eq x @ maponpaths g p₂
+                 =
+                 maponpaths f p₁ @ pb_type_eq y)
+  : x = y.
+Proof.
+  induction x as [ [ x₁ x₂ ] px ].
+  induction y as [ [ y₁ y₂ ] py ].
+  cbn in p₁, p₂.
+  induction p₁, p₂.
+  cbn in p₃.
+  apply maponpaths.
+  exact (!(pathscomp0rid _) @ p₃).
+Defined.
+
+Definition maponpaths_pr1_path_pb_type
+           {X Y Z : UU}
+           {f : X → Z}
+           {g : Y → Z}
+           {x y : pb_type f g}
+           (p₁ : pb_type_pr1 x = pb_type_pr1 y)
+           (p₂ : pb_type_pr2 x = pb_type_pr2 y)
+           (p₃ : pb_type_eq x @ maponpaths g p₂
+                 =
+                 maponpaths f p₁ @ pb_type_eq y)
+  : maponpaths
+      pb_type_pr1
+      (path_pb_type p₁ p₂ p₃)
+    =
+    p₁.
+Proof.
+  induction x as [ [ x₁ x₂ ] px ].
+  induction y as [ [ y₁ y₂ ] py ].
+  cbn in p₁, p₂.
+  induction p₁, p₂.
+  cbn in p₃.
+  induction p₃ ; cbn.
+  etrans.
+  {
+    apply (maponpathscomp
+             (tpair (λ x : X × Y, f (pr1 x) = g (pr2 x)) (x₁,, x₂))
+             pb_type_pr1).
+  }
+  apply maponpaths_for_constant_function.
+Qed.
+
+Definition maponpaths_pr2_path_pb_type
+           {X Y Z : UU}
+           {f : X → Z}
+           {g : Y → Z}
+           {x y : pb_type f g}
+           (p₁ : pb_type_pr1 x = pb_type_pr1 y)
+           (p₂ : pb_type_pr2 x = pb_type_pr2 y)
+           (p₃ : pb_type_eq x @ maponpaths g p₂
+                 =
+                 maponpaths f p₁ @ pb_type_eq y)
+  : maponpaths
+      pb_type_pr2
+      (path_pb_type p₁ p₂ p₃)
+    =
+    p₂.
+Proof.
+  induction x as [ [ x₁ x₂ ] px ].
+  induction y as [ [ y₁ y₂ ] py ].
+  cbn in p₁, p₂.
+  induction p₁, p₂.
+  cbn in p₃.
+  induction p₃ ; cbn.
+  etrans.
+  {
+    apply (maponpathscomp
+             (tpair (λ x : X × Y, f (pr1 x) = g (pr2 x)) (x₁,, x₂))
+             pb_type_pr2).
+  }
+  apply maponpaths_for_constant_function.
+Qed.
+
+Definition homot_pb_type_eta
+           {X Y Z : UU}
+           {f : X → Z}
+           {g : Y → Z}
+           {x y : pb_type f g}
+           (p : x = y)
+  : p
+    =
+    path_pb_type
+      (maponpaths pb_type_pr1 p)
+      (maponpaths pb_type_pr2 p)
+      (maponpaths (λ z, _ @ z) (maponpathscomp pb_type_pr2 g p)
+       @ !(homotsec_natural pb_type_eq p)
+       @ maponpaths (λ z, z @ _) (!(maponpathscomp pb_type_pr1 f p))).
+Proof.
+  induction p.
+  cbn -[path_pb_type].
+  rewrite pathscomp0rid.
+  simpl.
+  rewrite pathsinv0r.
+  apply idpath.
+Qed.
+
+Definition homot_pb
+           {X Y Z : UU}
+           {f : X → Z} {g : Y → Z}
+           {x y : pb_type f g}
+           {h₁ h₁' : pb_type_pr1 x = pb_type_pr1 y} (e₁ : h₁ = h₁')
+           {h₂ h₂' : pb_type_pr2 x = pb_type_pr2 y} (e₂ : h₂ = h₂')
+           (h₃ : pb_type_eq x @ maponpaths g h₂ = maponpaths f h₁ @ pb_type_eq y)
+  : path_pb_type h₁ h₂ h₃
+    =
+    path_pb_type
+      h₁' h₂'
+      (maponpaths
+         (λ z, _ @ maponpaths g z)
+         (!e₂)
+       @ h₃
+       @ maponpaths
+           (λ z, maponpaths f z @ _)
+           e₁).
+Proof.
+  induction e₁ ; induction e₂.
+  simpl.
+  apply maponpaths.
+  exact (!(pathscomp0rid _)).
+Qed.
+
+Definition homot_pb_one_type
+           {X Y Z : UU}
+           (HZ : isofhlevel 3 Z)
+           {f : X → Z}
+           {g : Y → Z}
+           {x y : pb_type f g}
+           (p q : x = y)
+           (r₁ : maponpaths pb_type_pr1 p
+                 =
+                 maponpaths pb_type_pr1 q)
+           (r₂ : maponpaths pb_type_pr2 p
+                 =
+                 maponpaths pb_type_pr2 q)
+  : p = q.
+Proof.
+  refine (homot_pb_type_eta p @ _ @ !(homot_pb_type_eta q)).
+  etrans.
+  {
+    exact (homot_pb r₁ r₂ _).
+  }
+  apply maponpaths.
+  apply HZ.
+Qed.
+
+Definition pb_is_of_hlevel
+           (n : nat)
+           {X Y Z : UU}
+           (HX : isofhlevel n X)
+           (HY : isofhlevel n Y)
+           (HZ : isofhlevel n Z)
+           (f : X → Z)
+           (g : Y → Z)
+  : isofhlevel n (pb_type f g).
+Proof.
+  use isofhleveltotal2.
+  - use isofhleveldirprod.
+    + exact HX.
+    + exact HY.
+  - simpl.
+    intro x.
+    apply (hlevelntosn n _ HZ).
+Qed.
+
+Definition pb_HLevel
+           (n : nat)
+           {X Y Z : HLevel n}
+           (f : pr1 X → pr1 Z)
+           (g : pr1 Y → pr1 Z)
+  : HLevel n.
+Proof.
+  simple refine (pb_type f g ,, _).
+  apply pb_is_of_hlevel.
+  - exact (pr2 X).
+  - exact (pr2 Y).
+  - exact (pr2 Z).
+Defined.
+
+(** END MOVE ??!??!???!??? *)
+
+
+(** Pullbacks of 1-types *)
+Definition one_types_pb_cone
+           {X Y Z : one_types}
+           (f : X --> Z)
+           (g : Y --> Z)
+  : pb_cone f g.
+Proof.
+  use make_pb_cone.
+  - exact (pb_HLevel 3 f g).
+  - exact pb_type_pr1.
+  - exact pb_type_pr2.
+  - use make_invertible_2cell.
+    + exact pb_type_eq.
+    + apply one_type_2cell_iso.
+Defined.
+
+Section OneTypesPullbackUMP.
+  Context {X Y Z : one_types}
+          (f : X --> Z)
+          (g : Y --> Z).
+
+  Definition pb_ump_1_one_types
+    : pb_ump_1 (one_types_pb_cone f g).
+  Proof.
+    intro q.
+    use make_pb_1cell.
+    - exact (λ x, (pb_cone_pr1 q x ,, pb_cone_pr2 q x) ,, pr1 (pb_cone_cell q) x).
+    - use make_invertible_2cell.
+      + intro x ; cbn.
+        apply idpath.
+      + apply one_type_2cell_iso.
+    - use make_invertible_2cell.
+      + intro x ; cbn.
+        apply idpath.
+      + apply one_type_2cell_iso.
+    - abstract
+        (use funextsec ;
+         intro x ; cbn ;
+         unfold homotcomp, homotfun, invhomot ;
+         cbn ;
+         rewrite !pathscomp0rid ;
+         apply idpath).
+  Defined.
+
+  Definition pb_ump_2_one_types
+    : pb_ump_2 (one_types_pb_cone f g).
+  Proof.
+    intros q φ ψ.
+    use make_pb_2cell.
+    - intro x.
+      use path_pb_type.
+      + exact (pr1 (pb_1cell_pr1 φ) x @ !(pr1 (pb_1cell_pr1 ψ) x)).
+      + exact (pr1 (pb_1cell_pr2 φ) x @ !(pr1 (pb_1cell_pr2 ψ) x)).
+      + abstract
+          (pose (eqtohomot (pb_1cell_eq φ) x) as p ;
+           cbn in p ; unfold homotcomp, homotfun in p ; cbn in p ;
+           rewrite pathscomp0rid in p ;
+           rewrite p ; clear p ;
+           rewrite !maponpathscomp0 ;
+           rewrite <- !path_assoc ;
+           apply maponpaths ;
+           pose (eqtohomot (pb_1cell_eq ψ) x) as p ;
+           cbn in p ; unfold homotcomp, homotfun in p ; cbn in p ;
+           rewrite pathscomp0rid in p ;
+           rewrite p ; clear p ;
+           rewrite !path_assoc ;
+           rewrite <- !maponpathscomp0 ;
+           rewrite pathsinv0l ;
+           cbn ;
+           rewrite <- !path_assoc ;
+           apply maponpaths ;
+           rewrite <- !maponpathscomp0 ;
+           apply maponpaths ;
+           rewrite !path_assoc ;
+           refine (maponpaths
+                     (λ z, z @ _)
+                     (eqtohomot
+                        (vcomp_linv
+                           (pb_1cell_pr2 φ))
+                        x)
+                   @ _) ;
+           cbn ;
+           use pathsinv0_to_right' ;
+           refine (!_) ;
+           exact (eqtohomot
+                    (vcomp_rinv
+                       (pb_1cell_pr2 ψ))
+                    x)).
+    - abstract
+        (use funextsec ;
+         intro x ; cbn ; unfold homotcomp, homotfun ;
+         refine (maponpaths (λ z, z @ _) (maponpaths_pr1_path_pb_type _ _ _) @ _) ;
+         rewrite <- path_assoc ;
+         rewrite pathsinv0l ;
+         apply pathscomp0rid).
+    - abstract
+        (use funextsec ;
+         intro x ; cbn ; unfold homotcomp, homotfun ;
+         refine (maponpaths (λ z, z @ _) (maponpaths_pr2_path_pb_type _ _ _) @ _) ;
+         rewrite <- path_assoc ;
+         rewrite pathsinv0l ;
+         apply pathscomp0rid).
+  Defined.
+
+  Definition pb_ump_eq_one_types
+    : pb_ump_eq (one_types_pb_cone f g).
+  Proof.
+    intros q φ ψ η₁ η₂.
+    use subtypePath.
+    {
+      intro ; apply isapropdirprod ; apply cellset_property.
+    }
+    use funextsec ; intro x.
+    use homot_pb_one_type.
+    - apply Z.
+    - pose (eqtohomot (pb_2cell_pr1 η₁) x) as m.
+      cbn in m.
+      unfold homotcomp, homotfun in m.
+      pose (eqtohomot (pb_2cell_pr1 η₂) x) as n.
+      cbn in n.
+      unfold homotcomp, homotfun in n.
+      pose (r := m @ !n).
+      apply (pathscomp_cancel_right _ _ (pr1 (pb_1cell_pr1 ψ) x)).
+      exact r.
+    - pose (eqtohomot (pb_2cell_pr2 η₁) x) as m.
+      cbn in m.
+      unfold homotcomp, homotfun in m.
+      pose (eqtohomot (pb_2cell_pr2 η₂) x) as n.
+      cbn in n.
+      unfold homotcomp, homotfun in n.
+      pose (r := m @ !n).
+      apply (pathscomp_cancel_right _ _ (pr1 (pb_1cell_pr2 ψ) x)).
+      exact r.
+  Qed.
+
+  Definition has_pb_ump_one_types
+    : has_pb_ump (one_types_pb_cone f g).
+  Proof.
+    use make_has_pb_ump.
+    - exact pb_ump_1_one_types.
+    - exact pb_ump_2_one_types.
+    - exact pb_ump_eq_one_types.
+  Defined.
+End OneTypesPullbackUMP.
+
+Definition has_pb_one_types
+  : has_pb one_types.
+Proof.
+  intros X Y Z f g ; cbn in *.
+  simple refine (_ ,, _).
+  - exact (one_types_pb_cone f g).
+  - exact (has_pb_ump_one_types f g).
+Defined.
+
+(** Pullbacks in the bicategory of univalent categories.
+    Here, we use the iso-comma category.
+ *)
+Definition iso_comma_pb_cone
+           {C₁ C₂ C₃ : bicat_of_cats}
+           (F : C₁ --> C₃)
+           (G : C₂ --> C₃)
+  : pb_cone F G.
+Proof.
+  use make_pb_cone.
+  - use make_univalent_category.
+    + exact (iso_comma F G).
+    + apply is_univalent_iso_comma.
+      * apply C₁.
+      * apply C₂.
+      * apply C₃.
+  - apply iso_comma_pr1.
+  - apply iso_comma_pr2.
+  - apply nat_iso_to_invertible_2cell.
+    apply iso_comma_commute.
+Defined.
+
+Section IsoCommaUMP.
+  Context {C₁ C₂ C₃ : bicat_of_cats}
+          (F : C₁ --> C₃)
+          (G : C₂ --> C₃).
+
+  Definition pb_ump_1_iso_comma
+    : pb_ump_1 (iso_comma_pb_cone F G).
+  Proof.
+    intro q.
+    use make_pb_1cell.
+    - use iso_comma_ump1.
+      + exact (pb_cone_pr1 q).
+      + exact (pb_cone_pr2 q).
+      + apply invertible_2cell_to_nat_iso.
+        exact (pb_cone_cell q).
+    - apply nat_iso_to_invertible_2cell.
+      apply iso_comma_ump1_pr1.
+    - apply nat_iso_to_invertible_2cell.
+      apply iso_comma_ump1_pr2.
+    - abstract
+        (use nat_trans_eq ; [ apply homset_property | ] ;
+         intro x ; cbn ; unfold pb_cone_cell ;
+         rewrite (functor_id F), (functor_id G) ;
+         rewrite !id_left, !id_right ;
+         apply idpath).
+  Defined.
+
+  Definition pb_ump_2_iso_comma
+    : pb_ump_2 (iso_comma_pb_cone F G).
+  Proof.
+    intros q φ ψ.
+    use make_pb_2cell.
+    - use (iso_comma_ump2).
+      + exact (pb_cone_pr1 q).
+      + exact (pb_cone_pr2 q).
+      + apply invertible_2cell_to_nat_iso.
+        exact (pb_cone_cell q).
+      + apply invertible_2cell_to_nat_iso.
+        exact (pb_1cell_pr1 φ).
+      + apply invertible_2cell_to_nat_iso.
+        exact (pb_1cell_pr1 ψ).
+      + apply invertible_2cell_to_nat_iso.
+        exact (pb_1cell_pr2 φ).
+      + apply invertible_2cell_to_nat_iso.
+        exact (pb_1cell_pr2 ψ).
+      + abstract
+          (use nat_trans_eq ; [ apply homset_property | ] ;
+           intro x ; cbn ;
+           pose (nat_trans_eq_pointwise (pb_1cell_eq φ) x) as m ;
+           cbn in m ;
+           rewrite m ;
+           rewrite !assoc ;
+           unfold precomp_with ;
+           rewrite !id_left, !id_right ;
+           apply idpath).
+      + abstract
+          (use nat_trans_eq ; [ apply homset_property | ] ;
+           intro x ; cbn ;
+           pose (nat_trans_eq_pointwise (pb_1cell_eq ψ) x) as m ;
+           cbn in m ;
+           rewrite m ;
+           rewrite !assoc ;
+           unfold precomp_with ;
+           rewrite !id_left, !id_right ;
+           apply idpath).
+    - abstract
+        (use nat_trans_eq ; [ apply homset_property | ] ;
+         intro x ; cbn ; unfold precomp_with ;
+         rewrite id_right ;
+         refine (_ @ id_right _) ;
+         rewrite !assoc' ;
+         apply maponpaths ;
+         exact (nat_trans_eq_pointwise
+                  (vcomp_linv (pr2 (pb_1cell_pr1 ψ)))
+                  x)).
+    - abstract
+        (use nat_trans_eq ; [ apply homset_property | ] ;
+         intro x ; cbn ; unfold precomp_with ;
+         rewrite id_right ;
+         refine (_ @ id_right _) ;
+         rewrite !assoc' ;
+         apply maponpaths ;
+         exact (nat_trans_eq_pointwise
+                  (vcomp_linv (pr2 (pb_1cell_pr2 ψ)))
+                  x)).
+  Defined.
+
+  Definition pb_ump_eq_iso_comma
+    : pb_ump_eq (iso_comma_pb_cone F G).
+  Proof.
+    intros q φ ψ η₁ η₂.
+    use subtypePath.
+    {
+      intro.
+      apply isapropdirprod ; apply cellset_property.
+    }
+    use nat_trans_eq.
+    {
+      apply homset_property.
+    }
+    intro x.
+    use subtypePath.
+    {
+      intro.
+      apply homset_property.
+    }
+    use pathsdirprod.
+    - pose (nat_trans_eq_pointwise
+              (pb_2cell_pr1 η₁)
+              x)
+        as m.
+      pose (nat_trans_eq_pointwise
+              (pb_2cell_pr1 η₂)
+              x)
+        as n.
+      pose (r := m @ !n).
+      cbn in r.
+      exact (cancel_postcomposition_iso
+               (nat_iso_pointwise_iso
+                  (invertible_2cell_to_nat_iso
+                     _ _
+                     (pb_1cell_pr1 ψ))
+                  x)
+               _ _
+               r).
+    - pose (nat_trans_eq_pointwise
+              (pb_2cell_pr2 η₁)
+              x)
+        as m.
+      pose (nat_trans_eq_pointwise
+              (pb_2cell_pr2 η₂)
+              x)
+        as n.
+      pose (r := m @ !n).
+      cbn in r.
+      exact (cancel_postcomposition_iso
+               (nat_iso_pointwise_iso
+                  (invertible_2cell_to_nat_iso
+                     _ _
+                     (pb_1cell_pr2 ψ))
+                  x)
+               _ _
+               r).
+  Qed.
+
+  Definition has_pb_ump_iso_comma
+    : has_pb_ump (iso_comma_pb_cone F G).
+  Proof.
+    use make_has_pb_ump.
+    - exact pb_ump_1_iso_comma.
+    - exact pb_ump_2_iso_comma.
+    - exact pb_ump_eq_iso_comma.
+  Defined.
+End IsoCommaUMP.
+
+Definition has_pb_bicat_of_cats
+  : has_pb bicat_of_cats.
+Proof.
+  intros C₁ C₂ C₃ F G.
+  simple refine (_ ,, _).
+  - exact (iso_comma_pb_cone F G).
+  - exact (has_pb_ump_iso_comma F G).
+Defined.

--- a/UniMath/Bicategories/Colimits/Pullback.v
+++ b/UniMath/Bicategories/Colimits/Pullback.v
@@ -397,228 +397,6 @@ Definition has_pb
      ∑ (p : pb_cone f g),
      has_pb_ump p.
 
-
-(** MOVE ??!??!???!??? *)
-Definition pb_type
-           {X Y Z : UU}
-           (f : X → Z)
-           (g : Y → Z)
-  : UU
-  := ∑ (x : X × Y), f (pr1 x) = g (pr2 x).
-
-Definition pb_type_pr1
-           {X Y Z : UU}
-           {f : X → Z}
-           {g : Y → Z}
-  : pb_type f g → X
-  := λ x, pr11 x.
-
-Definition pb_type_pr2
-           {X Y Z : UU}
-           {f : X → Z}
-           {g : Y → Z}
-  : pb_type f g → Y
-  := λ x, pr21 x.
-
-Definition pb_type_eq
-           {X Y Z : UU}
-           {f : X → Z}
-           {g : Y → Z}
-           (x : pb_type f g)
-  : f (pb_type_pr1 x) = g (pb_type_pr2 x)
-  := pr2 x.
-
-Definition path_pb_type
-           {X Y Z : UU}
-           {f : X → Z}
-           {g : Y → Z}
-           {x y : pb_type f g}
-           (p₁ : pb_type_pr1 x = pb_type_pr1 y)
-           (p₂ : pb_type_pr2 x = pb_type_pr2 y)
-           (p₃ : pb_type_eq x @ maponpaths g p₂
-                 =
-                 maponpaths f p₁ @ pb_type_eq y)
-  : x = y.
-Proof.
-  induction x as [ [ x₁ x₂ ] px ].
-  induction y as [ [ y₁ y₂ ] py ].
-  cbn in p₁, p₂.
-  induction p₁, p₂.
-  cbn in p₃.
-  apply maponpaths.
-  exact (!(pathscomp0rid _) @ p₃).
-Defined.
-
-Definition maponpaths_pr1_path_pb_type
-           {X Y Z : UU}
-           {f : X → Z}
-           {g : Y → Z}
-           {x y : pb_type f g}
-           (p₁ : pb_type_pr1 x = pb_type_pr1 y)
-           (p₂ : pb_type_pr2 x = pb_type_pr2 y)
-           (p₃ : pb_type_eq x @ maponpaths g p₂
-                 =
-                 maponpaths f p₁ @ pb_type_eq y)
-  : maponpaths
-      pb_type_pr1
-      (path_pb_type p₁ p₂ p₃)
-    =
-    p₁.
-Proof.
-  induction x as [ [ x₁ x₂ ] px ].
-  induction y as [ [ y₁ y₂ ] py ].
-  cbn in p₁, p₂.
-  induction p₁, p₂.
-  cbn in p₃.
-  induction p₃ ; cbn.
-  etrans.
-  {
-    apply (maponpathscomp
-             (tpair (λ x : X × Y, f (pr1 x) = g (pr2 x)) (x₁,, x₂))
-             pb_type_pr1).
-  }
-  apply maponpaths_for_constant_function.
-Qed.
-
-Definition maponpaths_pr2_path_pb_type
-           {X Y Z : UU}
-           {f : X → Z}
-           {g : Y → Z}
-           {x y : pb_type f g}
-           (p₁ : pb_type_pr1 x = pb_type_pr1 y)
-           (p₂ : pb_type_pr2 x = pb_type_pr2 y)
-           (p₃ : pb_type_eq x @ maponpaths g p₂
-                 =
-                 maponpaths f p₁ @ pb_type_eq y)
-  : maponpaths
-      pb_type_pr2
-      (path_pb_type p₁ p₂ p₃)
-    =
-    p₂.
-Proof.
-  induction x as [ [ x₁ x₂ ] px ].
-  induction y as [ [ y₁ y₂ ] py ].
-  cbn in p₁, p₂.
-  induction p₁, p₂.
-  cbn in p₃.
-  induction p₃ ; cbn.
-  etrans.
-  {
-    apply (maponpathscomp
-             (tpair (λ x : X × Y, f (pr1 x) = g (pr2 x)) (x₁,, x₂))
-             pb_type_pr2).
-  }
-  apply maponpaths_for_constant_function.
-Qed.
-
-Definition homot_pb_type_eta
-           {X Y Z : UU}
-           {f : X → Z}
-           {g : Y → Z}
-           {x y : pb_type f g}
-           (p : x = y)
-  : p
-    =
-    path_pb_type
-      (maponpaths pb_type_pr1 p)
-      (maponpaths pb_type_pr2 p)
-      (maponpaths (λ z, _ @ z) (maponpathscomp pb_type_pr2 g p)
-       @ !(homotsec_natural pb_type_eq p)
-       @ maponpaths (λ z, z @ _) (!(maponpathscomp pb_type_pr1 f p))).
-Proof.
-  induction p.
-  cbn -[path_pb_type].
-  rewrite pathscomp0rid.
-  simpl.
-  rewrite pathsinv0r.
-  apply idpath.
-Qed.
-
-Definition homot_pb
-           {X Y Z : UU}
-           {f : X → Z} {g : Y → Z}
-           {x y : pb_type f g}
-           {h₁ h₁' : pb_type_pr1 x = pb_type_pr1 y} (e₁ : h₁ = h₁')
-           {h₂ h₂' : pb_type_pr2 x = pb_type_pr2 y} (e₂ : h₂ = h₂')
-           (h₃ : pb_type_eq x @ maponpaths g h₂ = maponpaths f h₁ @ pb_type_eq y)
-  : path_pb_type h₁ h₂ h₃
-    =
-    path_pb_type
-      h₁' h₂'
-      (maponpaths
-         (λ z, _ @ maponpaths g z)
-         (!e₂)
-       @ h₃
-       @ maponpaths
-           (λ z, maponpaths f z @ _)
-           e₁).
-Proof.
-  induction e₁ ; induction e₂.
-  simpl.
-  apply maponpaths.
-  exact (!(pathscomp0rid _)).
-Qed.
-
-Definition homot_pb_one_type
-           {X Y Z : UU}
-           (HZ : isofhlevel 3 Z)
-           {f : X → Z}
-           {g : Y → Z}
-           {x y : pb_type f g}
-           (p q : x = y)
-           (r₁ : maponpaths pb_type_pr1 p
-                 =
-                 maponpaths pb_type_pr1 q)
-           (r₂ : maponpaths pb_type_pr2 p
-                 =
-                 maponpaths pb_type_pr2 q)
-  : p = q.
-Proof.
-  refine (homot_pb_type_eta p @ _ @ !(homot_pb_type_eta q)).
-  etrans.
-  {
-    exact (homot_pb r₁ r₂ _).
-  }
-  apply maponpaths.
-  apply HZ.
-Qed.
-
-Definition pb_is_of_hlevel
-           (n : nat)
-           {X Y Z : UU}
-           (HX : isofhlevel n X)
-           (HY : isofhlevel n Y)
-           (HZ : isofhlevel n Z)
-           (f : X → Z)
-           (g : Y → Z)
-  : isofhlevel n (pb_type f g).
-Proof.
-  use isofhleveltotal2.
-  - use isofhleveldirprod.
-    + exact HX.
-    + exact HY.
-  - simpl.
-    intro x.
-    apply (hlevelntosn n _ HZ).
-Qed.
-
-Definition pb_HLevel
-           (n : nat)
-           {X Y Z : HLevel n}
-           (f : pr1 X → pr1 Z)
-           (g : pr1 Y → pr1 Z)
-  : HLevel n.
-Proof.
-  simple refine (pb_type f g ,, _).
-  apply pb_is_of_hlevel.
-  - exact (pr2 X).
-  - exact (pr2 Y).
-  - exact (pr2 Z).
-Defined.
-
-(** END MOVE ??!??!???!??? *)
-
-
 (** Pullbacks of 1-types *)
 Definition one_types_pb_cone
            {X Y Z : one_types}
@@ -627,11 +405,11 @@ Definition one_types_pb_cone
   : pb_cone f g.
 Proof.
   use make_pb_cone.
-  - exact (pb_HLevel 3 f g).
-  - exact pb_type_pr1.
-  - exact pb_type_pr2.
+  - exact (hfp_HLevel 3 f g).
+  - exact (hfpg f g).
+  - exact (hfpg' f g).
   - use make_invertible_2cell.
-    + exact pb_type_eq.
+    + exact (λ x, !(commhfp f g x)).
     + apply one_type_2cell_iso.
 Defined.
 
@@ -645,7 +423,7 @@ Section OneTypesPullbackUMP.
   Proof.
     intro q.
     use make_pb_1cell.
-    - exact (λ x, (pb_cone_pr1 q x ,, pb_cone_pr2 q x) ,, pr1 (pb_cone_cell q) x).
+    - exact (λ x, (pb_cone_pr1 q x ,, pb_cone_pr2 q x) ,, !(pr1 (pb_cone_cell q) x)).
     - use make_invertible_2cell.
       + intro x ; cbn.
         apply idpath.
@@ -660,7 +438,7 @@ Section OneTypesPullbackUMP.
          unfold homotcomp, homotfun, invhomot ;
          cbn ;
          rewrite !pathscomp0rid ;
-         apply idpath).
+         apply pathsinv0inv0).
   Defined.
 
   Definition pb_ump_2_one_types
@@ -669,55 +447,73 @@ Section OneTypesPullbackUMP.
     intros q φ ψ.
     use make_pb_2cell.
     - intro x.
-      use path_pb_type.
+      use path_hfp.
       + exact (pr1 (pb_1cell_pr1 φ) x @ !(pr1 (pb_1cell_pr1 ψ) x)).
       + exact (pr1 (pb_1cell_pr2 φ) x @ !(pr1 (pb_1cell_pr2 ψ) x)).
       + abstract
           (pose (eqtohomot (pb_1cell_eq φ) x) as p ;
            cbn in p ; unfold homotcomp, homotfun in p ; cbn in p ;
            rewrite pathscomp0rid in p ;
-           rewrite p ; clear p ;
-           rewrite !maponpathscomp0 ;
+           pose (invrot p) as p' ;
+           refine (maponpaths (λ z, z @ _) p' @ _) ;
+           clear p p' ;
+           rewrite !pathscomp_inv ;
+           rewrite maponpathscomp0 ;
            rewrite <- !path_assoc ;
-           apply maponpaths ;
+           etrans ;
+           [ do 2 apply maponpaths ;
+             rewrite !path_assoc ;
+             rewrite pathsinv0l ;
+             cbn ;
+             apply idpath
+           | ] ;
            pose (eqtohomot (pb_1cell_eq ψ) x) as p ;
            cbn in p ; unfold homotcomp, homotfun in p ; cbn in p ;
            rewrite pathscomp0rid in p ;
-           rewrite p ; clear p ;
+           pose (invrot p) as p' ;
+           refine (!_) ;
+           refine (maponpaths (λ z, _ @ z) p' @ _) ;
+           clear p p' ;
+           rewrite !maponpathscomp0 ;
+           rewrite !pathscomp_inv ;
+           rewrite !maponpathsinv0 ;
            rewrite !path_assoc ;
-           rewrite <- !maponpathscomp0 ;
-           rewrite pathsinv0l ;
-           cbn ;
+           do 2 apply maponpaths_2 ;
            rewrite <- !path_assoc ;
-           apply maponpaths ;
-           rewrite <- !maponpathscomp0 ;
-           apply maponpaths ;
-           rewrite !path_assoc ;
+           rewrite <- pathscomp_inv ;
+           rewrite <- maponpathscomp0 ;
            refine (maponpaths
-                     (λ z, z @ _)
+                     (λ z, _ @ !(maponpaths g z))
+                     (eqtohomot
+                        (vcomp_linv
+                           (pb_1cell_pr2 ψ))
+                        x)
+                     @ _) ;
+           cbn ;
+           rewrite pathscomp0rid ;
+           refine (!_) ;
+           use pathsinv0_to_right' ;
+           refine (!_) ;
+           rewrite <- maponpathscomp0 ;
+           refine (maponpaths
+                     (λ z, maponpaths g z)
                      (eqtohomot
                         (vcomp_linv
                            (pb_1cell_pr2 φ))
                         x)
-                   @ _) ;
-           cbn ;
-           use pathsinv0_to_right' ;
-           refine (!_) ;
-           exact (eqtohomot
-                    (vcomp_rinv
-                       (pb_1cell_pr2 ψ))
-                    x)).
+                     @ _) ;
+           apply idpath).
     - abstract
         (use funextsec ;
          intro x ; cbn ; unfold homotcomp, homotfun ;
-         refine (maponpaths (λ z, z @ _) (maponpaths_pr1_path_pb_type _ _ _) @ _) ;
+         refine (maponpaths (λ z, z @ _) (maponpaths_hfpg_path_hfp _ _ _) @ _) ;
          rewrite <- path_assoc ;
          rewrite pathsinv0l ;
          apply pathscomp0rid).
     - abstract
         (use funextsec ;
          intro x ; cbn ; unfold homotcomp, homotfun ;
-         refine (maponpaths (λ z, z @ _) (maponpaths_pr2_path_pb_type _ _ _) @ _) ;
+         refine (maponpaths (λ z, z @ _) (maponpaths_hfpg'_path_hfp _ _ _) @ _) ;
          rewrite <- path_assoc ;
          rewrite pathsinv0l ;
          apply pathscomp0rid).
@@ -732,7 +528,7 @@ Section OneTypesPullbackUMP.
       intro ; apply isapropdirprod ; apply cellset_property.
     }
     use funextsec ; intro x.
-    use homot_pb_one_type.
+    use homot_hfp_one_type.
     - apply Z.
     - pose (eqtohomot (pb_2cell_pr1 η₁) x) as m.
       cbn in m.

--- a/UniMath/CONTENTS.md
+++ b/UniMath/CONTENTS.md
@@ -221,6 +221,7 @@ The packages and files are listed here in logical order: each file depends only 
    - [CATAsInstanceOfBicat.v](CategoryTheory/CATAsInstanceOfBicat.v)
    - [PointedFunctorsComposition.v](CategoryTheory/PointedFunctorsComposition.v)
    - [CommaCategories.v](CategoryTheory/CommaCategories.v)
+   - [IsoCommaCategory.v](CategoryTheory/IsoCommaCategory.v)
    - [ArrowCategory.v](CategoryTheory/ArrowCategory.v)
    - [RightKanExtension.v](CategoryTheory/RightKanExtension.v)
    - [slicecat.v](CategoryTheory/slicecat.v)

--- a/UniMath/CONTENTS.md
+++ b/UniMath/CONTENTS.md
@@ -436,6 +436,7 @@ The packages and files are listed here in logical order: each file depends only 
    - [Core/YonedaLemma.v](Bicategories/Core/YonedaLemma.v)
    - [Colimits/Initial.v](Bicategories/Colimits/Initial.v)
    - [Colimits/Final.v](Bicategories/Colimits/Final.v)
+   - [Colimits/Pullback.v](Bicategories/Colimits/Pullback.v)
    - [PseudoFunctors/Biadjunction.v](Bicategories/PseudoFunctors/Biadjunction.v)
    - [PseudoFunctors/Examples/CurryingInBicatOfCatsWithoutUnivalence.v](Bicategories/PseudoFunctors/Examples/CurryingInBicatOfCatsWithoutUnivalence.v)
    - [DisplayedBicats/DispBiadjunction.v](Bicategories/DisplayedBicats/DispBiadjunction.v)

--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -91,6 +91,7 @@ HorizontalComposition.v
 CATAsInstanceOfBicat.v
 PointedFunctorsComposition.v
 CommaCategories.v
+IsoCommaCategory.v
 ArrowCategory.v
 RightKanExtension.v
 slicecat.v

--- a/UniMath/CategoryTheory/IsoCommaCategory.v
+++ b/UniMath/CategoryTheory/IsoCommaCategory.v
@@ -2,8 +2,6 @@
 
  Iso comma categories
 
- Author: Niels van der Weide
-
  Given functors `F : C₁ ⟶ C₃` and `G : C₂ ⟶ C₃`.
  Then the iso-comma category of `F` and `G` is defined as follows:
  - Objects: pairs `(x, y) : C₁ × C₂` with an iso  `F x --> G y`
@@ -37,7 +35,7 @@ Require Import UniMath.CategoryTheory.whiskering.
 
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
 
-Open Scope cat.
+Local Open Scope cat.
 
 Section IsoCommaCategory.
   Context {C₁ C₂ C₃ : category}
@@ -324,7 +322,7 @@ Section IsoCommaCategory.
       rewrite id_right.
       apply idpath.
     Qed.
-    
+
     (** Now we look at the second universal mapping property *)
     Context (Φ₁ Φ₂ : D ⟶ iso_comma)
             (τ₁ : nat_iso (Φ₁ ∙ iso_comma_pr1) P)

--- a/UniMath/CategoryTheory/IsoCommaCategory.v
+++ b/UniMath/CategoryTheory/IsoCommaCategory.v
@@ -1,0 +1,532 @@
+(****************************************************************
+
+ Iso comma categories
+
+ Author: Niels van der Weide
+
+ Given functors `F : C₁ ⟶ C₃` and `G : C₂ ⟶ C₃`.
+ Then the iso-comma category of `F` and `G` is defined as follows:
+ - Objects: pairs `(x, y) : C₁ × C₂` with an iso  `F x --> G y`
+ - Morphisms: morphisms from `(x₁, y₁, i₁)` to `(x₂, y₂, i₂)`
+              consists of maps `f : x₁ --> x₂` and `g : y₁ --> y₂`
+              such that that the following square commutes
+
+                     F x₁   -->     F x₂
+                      |              |
+                      |              |
+                      v              v
+                     G y₁   -->     G y₂
+
+ In this file, we define the iso-comma category using displayed
+ category. We also prove that it's univalent, and we define the
+ necessary projection functors and transformations.
+
+ We also show that the iso-comma category satisfies the universal
+ mapping property of a pullback.
+
+ *****************************************************************)
+Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.All.
+Require Import UniMath.CategoryTheory.Core.Categories.
+Require Import UniMath.CategoryTheory.Core.Isos.
+Require Import UniMath.CategoryTheory.Core.Univalence.
+Require Import UniMath.CategoryTheory.Core.Functors.
+Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
+Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
+Require Import UniMath.CategoryTheory.whiskering.
+
+Require Import UniMath.CategoryTheory.DisplayedCats.Core.
+
+Open Scope cat.
+
+Section IsoCommaCategory.
+  Context {C₁ C₂ C₃ : category}
+          (F : C₁ ⟶ C₃)
+          (G : C₂ ⟶ C₃).
+
+  (** Definition of iso comma categories via displayed categories *)
+  Definition iso_comma_disp_cat_ob_mor
+    : disp_cat_ob_mor (category_binproduct C₁ C₂).
+  Proof.
+    simple refine (_ ,, _).
+    - exact (λ x, iso (F (pr1 x)) (G (pr2 x))).
+    - exact (λ x y i₁ i₂ f, #F (pr1 f) · i₂ = i₁ · #G (pr2 f)).
+  Defined.
+
+  Definition iso_comma_disp_cat_id_comp
+    : disp_cat_id_comp _ iso_comma_disp_cat_ob_mor.
+  Proof.
+    simple refine (_ ,, _).
+    - intros x i ; cbn.
+      rewrite !functor_id.
+      rewrite id_left, id_right.
+      apply idpath.
+    - cbn ; intros x y z f g i₁ i₂ i₃ p q.
+      rewrite !functor_comp.
+      rewrite !assoc'.
+      rewrite q.
+      rewrite !assoc.
+      rewrite p.
+      apply idpath.
+  Qed.
+
+  Definition iso_comma_disp_cat_data
+    : disp_cat_data (category_binproduct C₁ C₂).
+  Proof.
+    simple refine (_ ,, _).
+    - exact iso_comma_disp_cat_ob_mor.
+    - exact iso_comma_disp_cat_id_comp.
+  Defined.
+
+  Definition iso_comma_disp_cat_axioms
+    : disp_cat_axioms _ iso_comma_disp_cat_data.
+  Proof.
+    repeat split ; intros ; try (apply homset_property).
+    apply isasetaprop.
+    apply homset_property.
+  Qed.
+
+  Definition iso_comma_disp_cat
+    : disp_cat (category_binproduct C₁ C₂).
+  Proof.
+    simple refine (_ ,, _).
+    - exact iso_comma_disp_cat_data.
+    - exact iso_comma_disp_cat_axioms.
+  Defined.
+
+  Definition iso_comma
+    : category
+    := total_category iso_comma_disp_cat.
+
+  (** Univalence of the iso-comma category *)
+  Definition is_univalent_disp_iso_comma_disp_cat
+             (HC₃ : is_univalent C₃)
+    : is_univalent_disp iso_comma_disp_cat.
+  Proof.
+    intros x y p i₁ i₂.
+    induction p.
+    use isweqimplimpl.
+    - intros p.
+      pose (pr1 p) as m.
+      cbn in m.
+      rewrite !functor_id in m.
+      rewrite id_left, id_right in m.
+      use subtypePath.
+      {
+        intro ; apply isaprop_is_iso.
+      }
+      exact (!m).
+    - apply isaset_iso.
+      apply homset_property.
+    - use isaproptotal2.
+      + intro.
+        apply isaprop_is_iso_disp.
+      + intros.
+        apply homset_property.
+  Qed.
+
+  Definition is_univalent_iso_comma
+             (HC₁ : is_univalent C₁)
+             (HC₂ : is_univalent C₂)
+             (HC₃ : is_univalent C₃)
+    : is_univalent iso_comma.
+  Proof.
+    use is_univalent_total_category.
+    - apply is_unvialent_category_binproduct.
+      + exact HC₁.
+      + exact HC₂.
+    - exact (is_univalent_disp_iso_comma_disp_cat HC₃).
+  Defined.
+
+  (** Projection functors *)
+  Definition iso_comma_pr1
+    : iso_comma ⟶ C₁
+    := pr1_category iso_comma_disp_cat ∙ pr1_functor C₁ C₂.
+
+  Definition iso_comma_pr2
+    : iso_comma ⟶ C₂
+    := pr1_category iso_comma_disp_cat ∙ pr2_functor C₁ C₂.
+
+  (** Natural isomorphism witnessing the commutation *)
+  Definition iso_comma_commute_nat_trans_data
+    : nat_trans_data (iso_comma_pr1 ∙ F) (iso_comma_pr2 ∙ G).
+  Proof.
+    intros x ; cbn in x.
+    exact (pr2 x).
+  Defined.
+
+  Definition iso_comma_commute_is_nat_trans
+    : is_nat_trans _ _ iso_comma_commute_nat_trans_data.
+  Proof.
+    intros x y f ; unfold iso_comma_commute_nat_trans_data ; cbn ; cbn in f.
+    exact (pr2 f).
+  Qed.
+
+  Definition iso_comma_commute_nat_trans
+    : iso_comma_pr1 ∙ F ⟹ iso_comma_pr2 ∙ G.
+  Proof.
+    use make_nat_trans.
+    - exact iso_comma_commute_nat_trans_data.
+    - exact iso_comma_commute_is_nat_trans.
+  Defined.
+
+  Definition iso_comma_commute
+    : nat_iso
+        (iso_comma_pr1 ∙ F)
+        (iso_comma_pr2 ∙ G).
+  Proof.
+    use make_nat_iso.
+    - exact iso_comma_commute_nat_trans.
+    - intros x.
+      apply iso_is_iso.
+  Defined.
+
+  (**
+     Mapping property of iso-comma category
+
+     We need to check three mapping properties:
+     - The first one gives the existence of a functor
+     - The second one gives the existence of a natural transformation
+     - The third one can be used to show that two natural transformations
+       are equal
+   *)
+  Section UniversalMappingProperty.
+    Context {D : category}
+            (P : D ⟶ C₁)
+            (Q : D ⟶ C₂)
+            (η : nat_iso (P ∙ F) (Q ∙ G)).
+
+    (** The functor witnessing the universal property *)
+    Definition iso_comma_ump1_data
+      : functor_data D iso_comma.
+    Proof.
+      use make_functor_data.
+      - exact (λ d, (P d ,, Q d) ,, nat_iso_pointwise_iso η d).
+      - exact (λ d₁ d₂ f, (#P f ,, #Q f) ,, nat_trans_ax η _ _ f).
+    Defined.
+
+    Definition iso_comma_ump1_is_functor
+      : is_functor iso_comma_ump1_data.
+    Proof.
+      split.
+      - intro x ; cbn.
+        use subtypePath.
+        {
+          intro ; apply homset_property.
+        }
+        cbn.
+        rewrite !functor_id.
+        apply idpath.
+      - intros x y z f g ; cbn.
+        use subtypePath.
+        {
+          intro ; apply homset_property.
+        }
+        cbn.
+        rewrite !functor_comp.
+        apply idpath.
+    Qed.
+
+    Definition iso_comma_ump1
+      : D ⟶ iso_comma.
+    Proof.
+      use make_functor.
+      - exact iso_comma_ump1_data.
+      - exact iso_comma_ump1_is_functor.
+    Defined.
+
+    (** The computation rules *)
+    Definition iso_comma_ump1_pr1_nat_trans_data
+      : nat_trans_data (iso_comma_ump1 ∙ iso_comma_pr1) P
+      := λ x, identity _.
+
+    Definition iso_comma_ump1_pr1_is_nat_trans
+      : is_nat_trans _ _ iso_comma_ump1_pr1_nat_trans_data.
+    Proof.
+      intros x y f ; cbn ; unfold iso_comma_ump1_pr1_nat_trans_data.
+      rewrite id_left, id_right.
+      apply idpath.
+    Qed.
+
+    Definition iso_comma_ump1_pr1_nat_trans
+      : iso_comma_ump1 ∙ iso_comma_pr1 ⟹ P.
+    Proof.
+      use make_nat_trans.
+      - exact iso_comma_ump1_pr1_nat_trans_data.
+      - exact iso_comma_ump1_pr1_is_nat_trans.
+    Defined.
+
+    (** Computation rule for first projection *)
+    Definition iso_comma_ump1_pr1
+      : nat_iso (iso_comma_ump1 ∙ iso_comma_pr1) P.
+    Proof.
+      use make_nat_iso.
+      - exact iso_comma_ump1_pr1_nat_trans.
+      - intro.
+        apply identity_is_iso.
+    Defined.
+
+    Definition iso_comma_ump1_pr2_nat_trans_data
+      : nat_trans_data (iso_comma_ump1 ∙ iso_comma_pr2) Q
+      := λ x, identity _.
+
+    Definition iso_comma_ump1_pr2_is_nat_trans
+      : is_nat_trans _ _ iso_comma_ump1_pr2_nat_trans_data.
+    Proof.
+      intros x y f ; cbn ; unfold iso_comma_ump1_pr2_nat_trans_data.
+      rewrite id_left, id_right.
+      apply idpath.
+    Qed.
+
+    Definition iso_comma_ump1_pr2_nat_trans
+      : iso_comma_ump1 ∙ iso_comma_pr2 ⟹ Q.
+    Proof.
+      use make_nat_trans.
+      - exact iso_comma_ump1_pr2_nat_trans_data.
+      - exact iso_comma_ump1_pr2_is_nat_trans.
+    Defined.
+
+    (** Computation rule for second projection *)
+    Definition iso_comma_ump1_pr2
+      : nat_iso (iso_comma_ump1 ∙ iso_comma_pr2) Q.
+    Proof.
+      use make_nat_iso.
+      - exact iso_comma_ump1_pr2_nat_trans.
+      - intro.
+        apply identity_is_iso.
+    Defined.
+
+    (** Computation rule for natural iso *)
+    Definition iso_comma_ump1_commute
+      : pre_whisker iso_comma_ump1 iso_comma_commute
+        =
+        nat_trans_comp
+          _ _ _
+          (nat_trans_functor_assoc_inv _ _ _)
+          (nat_trans_comp
+             _ _ _
+             (post_whisker iso_comma_ump1_pr1 F)
+             (nat_trans_comp
+                _ _ _
+                η
+                (nat_trans_comp
+                   _ _ _
+                   (post_whisker (nat_iso_inv iso_comma_ump1_pr2) G)
+                   (nat_trans_functor_assoc _ _ _)))).
+    Proof.
+      use nat_trans_eq.
+      {
+        apply homset_property.
+      }
+      intro ; cbn ; unfold iso_comma_ump1_pr1_nat_trans_data.
+      rewrite (functor_id F), (functor_id G).
+      rewrite !id_left.
+      rewrite id_right.
+      apply idpath.
+    Qed.
+    
+    (** Now we look at the second universal mapping property *)
+    Context (Φ₁ Φ₂ : D ⟶ iso_comma)
+            (τ₁ : nat_iso (Φ₁ ∙ iso_comma_pr1) P)
+            (τ₂ : nat_iso (Φ₂ ∙ iso_comma_pr1) P)
+            (θ₁ : nat_iso (Φ₁ ∙ iso_comma_pr2) Q)
+            (θ₂ : nat_iso (Φ₂ ∙ iso_comma_pr2) Q)
+            (p₁ : pre_whisker Φ₁ iso_comma_commute
+                  =
+                  nat_trans_comp
+                    _ _ _
+                    (nat_trans_functor_assoc_inv _ _ _)
+                    (nat_trans_comp
+                       _ _ _
+                       (post_whisker τ₁ F)
+                       (nat_trans_comp
+                          _ _ _
+                          η
+                          (nat_trans_comp
+                             _ _ _
+                             (post_whisker (nat_iso_inv θ₁) G)
+                             (nat_trans_functor_assoc _ _ _)))))
+            (p₂ : pre_whisker Φ₂ iso_comma_commute
+                  =
+                  nat_trans_comp
+                    _ _ _
+                    (nat_trans_functor_assoc_inv _ _ _)
+                    (nat_trans_comp
+                       _ _ _
+                       (post_whisker τ₂ F)
+                       (nat_trans_comp
+                          _ _ _
+                          η
+                          (nat_trans_comp
+                             _ _ _
+                             (post_whisker (nat_iso_inv θ₂) G)
+                             (nat_trans_functor_assoc _ _ _))))).
+
+    Definition iso_comma_ump2_nat_trans_data
+      : nat_trans_data Φ₁ Φ₂.
+    Proof.
+      intro x.
+      simple refine ((_ ,, _) ,, _) ; cbn.
+      - exact (τ₁ x · inv_from_iso (nat_iso_pointwise_iso τ₂ x)).
+      - exact (θ₁ x · inv_from_iso (nat_iso_pointwise_iso θ₂ x)).
+      - abstract
+          (pose (nat_trans_eq_pointwise p₁ x) as q₁ ;
+           pose (nat_trans_eq_pointwise p₂ x) as q₂ ;
+           cbn in q₁, q₂ ; unfold iso_comma_commute_nat_trans_data in q₁, q₂ ;
+           rewrite id_left in q₁, q₂ ;
+           rewrite id_right in q₁, q₂ ;
+           unfold nat_iso_pointwise_iso ; simpl ;
+           rewrite !functor_comp ;
+           refine (!_) ;
+           refine (maponpaths (λ z, z · _) q₁ @ _) ; clear q₁ ;
+           rewrite !assoc' ;
+           apply maponpaths ;
+           refine (!_) ;
+           refine (maponpaths (λ z, _ · z) q₂ @ _) ; clear q₂ ;
+           rewrite !assoc ;
+           apply maponpaths_2 ;
+           rewrite <- functor_comp ;
+           rewrite iso_after_iso_inv ;
+           rewrite functor_id ;
+           rewrite id_left ;
+           rewrite !assoc' ;
+           rewrite <- functor_comp ;
+           rewrite iso_after_iso_inv ;
+           rewrite functor_id ;
+           rewrite id_right ;
+           apply idpath).
+    Defined.
+
+    Definition iso_comma_ump2_is_nat_trans
+      : is_nat_trans _ _ iso_comma_ump2_nat_trans_data.
+    Proof.
+      intros x y f.
+      use subtypePath.
+      {
+        intro ; apply homset_property.
+      }
+      use pathsdirprod ; cbn.
+      - pose (nat_trans_ax τ₁ _ _ f) as q.
+        cbn in q.
+        rewrite !assoc.
+        etrans.
+        {
+          apply maponpaths_2.
+          exact q.
+        }
+        rewrite !assoc'.
+        apply maponpaths.
+        exact (nat_trans_ax (nat_iso_inv τ₂) _ _ f).
+      - pose (nat_trans_ax θ₁ _ _ f) as q.
+        cbn in q.
+        rewrite !assoc.
+        etrans.
+        {
+          apply maponpaths_2.
+          exact q.
+        }
+        rewrite !assoc'.
+        apply maponpaths.
+        exact (nat_trans_ax (nat_iso_inv θ₂) _ _ f).
+    Qed.
+
+    Definition iso_comma_ump2
+      : Φ₁ ⟹ Φ₂.
+    Proof.
+      use make_nat_trans.
+      - exact iso_comma_ump2_nat_trans_data.
+      - exact iso_comma_ump2_is_nat_trans.
+    Defined.
+
+    (** The computation rules *)
+    Definition iso_comma_ump2_pr1
+      : nat_trans_comp
+          _ _ _
+          (post_whisker iso_comma_ump2 iso_comma_pr1)
+          τ₂
+        =
+        τ₁.
+    Proof.
+      use nat_trans_eq.
+      {
+        intro ; apply homset_property.
+      }
+      intro x ; cbn.
+      rewrite !assoc'.
+      rewrite iso_after_iso_inv.
+      apply id_right.
+    Qed.
+
+    Definition iso_comma_ump2_pr2
+      : nat_trans_comp
+          _ _ _
+          (post_whisker iso_comma_ump2 iso_comma_pr2)
+          θ₂
+        =
+        θ₁.
+    Proof.
+      use nat_trans_eq.
+      {
+        intro ; apply homset_property.
+      }
+      intro x ; cbn.
+      rewrite !assoc'.
+      rewrite iso_after_iso_inv.
+      apply id_right.
+    Qed.
+
+    (** Next we look at the third universal property *)
+    Context {n₁ n₂ : Φ₁ ⟹ Φ₂}
+            (n₁pr1 : nat_trans_comp
+                      _ _ _
+                      (post_whisker n₁ iso_comma_pr1)
+                      τ₂
+                    =
+                    τ₁)
+            (n₂pr1 : nat_trans_comp
+                       _ _ _
+                       (post_whisker n₂ iso_comma_pr1)
+                       τ₂
+                     =
+                     τ₁)
+            (n₁pr2 : nat_trans_comp
+                       _ _ _
+                       (post_whisker n₁ iso_comma_pr2)
+                       θ₂
+                     =
+                     θ₁)
+            (n₂pr2 : nat_trans_comp
+                       _ _ _
+                       (post_whisker n₂ iso_comma_pr2)
+                       θ₂
+                     =
+                     θ₁).
+
+    Definition iso_comma_ump_eq
+      : n₁ = n₂.
+    Proof.
+      use nat_trans_eq.
+      {
+        apply homset_property.
+      }
+      intro x.
+      use subtypePath.
+      {
+        intro ; apply homset_property.
+      }
+      use pathsdirprod.
+      - pose (nat_trans_eq_pointwise n₁pr1 x) as q₁.
+        pose (nat_trans_eq_pointwise n₂pr1 x) as q₂.
+        cbn in q₁, q₂.
+        pose (r := q₁ @ !q₂).
+        apply (cancel_postcomposition_iso (nat_iso_pointwise_iso τ₂ x)).
+        exact r.
+      - pose (nat_trans_eq_pointwise n₁pr2 x) as q₁.
+        pose (nat_trans_eq_pointwise n₂pr2 x) as q₂.
+        cbn in q₁, q₂.
+        pose (r := q₁ @ !q₂).
+        apply (cancel_postcomposition_iso (nat_iso_pointwise_iso θ₂ x)).
+        exact r.
+    Qed.
+  End UniversalMappingProperty.
+End IsoCommaCategory.

--- a/UniMath/CategoryTheory/PrecategoryBinProduct.v
+++ b/UniMath/CategoryTheory/PrecategoryBinProduct.v
@@ -37,10 +37,12 @@
 *)
 
 
-Require Import UniMath.Foundations.PartD.
+Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.All.
 
 Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.Core.Isos.
+Require Import UniMath.CategoryTheory.Core.Univalence.
 Require Import UniMath.CategoryTheory.Core.Functors.
 Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
 Require Import UniMath.CategoryTheory.FunctorCategory.
@@ -872,3 +874,64 @@ Section Coevaluation.
   Defined.
 
 End Coevaluation.
+
+Section CategoryBinproductIsoWeq.
+  Context {C D : category}
+          (x y : category_binproduct C D).
+
+  Definition category_binproduct_iso_map
+    : iso (pr1 x) (pr1 y) × iso (pr2 x) (pr2 y) → iso x y.
+  Proof.
+    intros i.
+    simple refine ((pr11 i ,, pr12 i) ,, _).
+    apply is_iso_binprod_iso.
+    - exact (pr21 i).
+    - exact (pr22 i).
+  Defined.
+
+  Definition category_binproduct_iso_inv
+    : iso x y → iso (pr1 x) (pr1 y) × iso (pr2 x) (pr2 y)
+    := λ i, functor_on_iso (pr1_functor C D) i ,, functor_on_iso (pr2_functor C D) i.
+
+  Definition category_binproduct_iso_weq
+    : iso (pr1 x) (pr1 y) × iso (pr2 x) (pr2 y) ≃ iso x y.
+  Proof.
+    use make_weq.
+    - exact category_binproduct_iso_map.
+    - use gradth.
+      + exact category_binproduct_iso_inv.
+      + abstract
+          (intros i ;
+           use pathsdirprod ;
+           (use subtypePath ; [ intro ; apply isaprop_is_iso | ]) ;
+           apply idpath).
+      + abstract
+          (intros i ;
+           use subtypePath ; [ intro ; apply isaprop_is_iso | ] ;
+           apply idpath).
+  Defined.
+End CategoryBinproductIsoWeq.
+
+Section Univalence.
+  Context {C D : category}
+          (HC : is_univalent C)
+          (HD : is_univalent D).
+
+  Definition is_unvialent_category_binproduct
+    : is_univalent (category_binproduct C D).
+  Proof.
+    intros x y.
+    use weqhomot.
+    - exact (category_binproduct_iso_weq x y
+             ∘ weqdirprodf
+                 (make_weq _ (HC _ _))
+                 (make_weq _ (HD _ _))
+             ∘ pathsdirprodweq)%weq.
+    - abstract
+        (intro p ;
+         induction p ;
+         use subtypePath ; [ intro ; apply isaprop_is_iso | ] ;
+         cbn ;
+         apply idpath).
+  Defined.
+End Univalence.

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -896,3 +896,206 @@ Lemma transportf_sec_constant
 Proof.
  induction p; reflexivity.
 Qed.
+
+(** More facts on fiber products *)
+Definition path_hfp
+           {X Y Z : UU}
+           {f : X → Z}
+           {g : Y → Z}
+           {x y : hfp f g}
+           (p₁ : hfpg f g x = hfpg f g y)
+           (p₂ : hfpg' f g x = hfpg' f g y)
+           (p₃ : commhfp f g x @ maponpaths f p₁
+                 =
+                 maponpaths g p₂ @ commhfp f g y)
+  : x = y.
+Proof.
+  induction x as [ [ x₁ x₂ ] px ].
+  induction y as [ [ y₁ y₂ ] py ].
+  cbn in p₁, p₂.
+  induction p₁, p₂.
+  cbn in p₃.
+  apply maponpaths.
+  exact (!(pathscomp0rid _) @ p₃).
+Defined.
+
+Definition maponpaths_hfpg_path_hfp
+           {X Y Z : UU}
+           {f : X → Z}
+           {g : Y → Z}
+           {x y : hfp f g}
+           (p₁ : hfpg f g x = hfpg f g y)
+           (p₂ : hfpg' f g x = hfpg' f g y)
+           (p₃ : commhfp f g x @ maponpaths f p₁
+                 =
+                 maponpaths g p₂ @ commhfp f g y)
+  : maponpaths
+      (hfpg f g)
+      (path_hfp p₁ p₂ p₃)
+    =
+    p₁.
+Proof.
+  induction x as [ [ x₁ x₂ ] px ].
+  induction y as [ [ y₁ y₂ ] py ].
+  cbn in p₁, p₂.
+  induction p₁, p₂.
+  cbn in p₃.
+  induction p₃ ; cbn.
+  etrans.
+  {
+    apply (maponpathscomp
+             (tpair (λ xx', g (pr2 xx') = f (pr1 xx')) (x₁,, x₂))
+             (hfpg f g)).
+  }
+  apply maponpaths_for_constant_function.
+Qed.
+
+Definition maponpaths_hfpg'_path_hfp
+           {X Y Z : UU}
+           {f : X → Z}
+           {g : Y → Z}
+           {x y : hfp f g}
+           (p₁ : hfpg f g x = hfpg f g y)
+           (p₂ : hfpg' f g x = hfpg' f g y)
+           (p₃ : commhfp f g x @ maponpaths f p₁
+                 =
+                 maponpaths g p₂ @ commhfp f g y)
+  : maponpaths
+      (hfpg' f g)
+      (path_hfp p₁ p₂ p₃)
+    =
+    p₂.
+Proof.
+  induction x as [ [ x₁ x₂ ] px ].
+  induction y as [ [ y₁ y₂ ] py ].
+  cbn in p₁, p₂.
+  induction p₁, p₂.
+  cbn in p₃.
+  induction p₃ ; cbn.
+  etrans.
+  {
+    apply (maponpathscomp
+             (tpair (λ xx', g (pr2 xx') = f (pr1 xx')) (x₁,, x₂))
+             (hfpg' f g)).
+  }
+  apply maponpaths_for_constant_function.
+Qed.
+
+Definition path_hfp_eta
+           {X Y Z : UU}
+           {f : X → Z}
+           {g : Y → Z}
+           {x y : hfp f g}
+           (p : x = y)
+  : p
+    =
+    path_hfp
+      (maponpaths (hfpg f g) p)
+      (maponpaths (hfpg' f g) p)
+      (maponpaths (λ z, _ @ z) (maponpathscomp (hfpg f g) f p)
+       @ !(homotsec_natural (commhfp f g) p)
+       @ maponpaths (λ z, z @ _) (!(maponpathscomp (hfpg' f g) g p))).
+Proof.
+  induction p.
+  cbn.
+  refine (!_).
+  etrans.
+  {
+    apply maponpaths.
+    etrans.
+    {
+      apply maponpaths.
+      etrans.
+      {
+        apply pathscomp0rid.
+      }
+      apply pathsinv0inv0.
+    }
+    apply pathsinv0l.
+  }
+  apply idpath.
+Qed.
+
+Definition homot_hfp
+           {X Y Z : UU}
+           {f : X → Z} {g : Y → Z}
+           {x y : hfp f g}
+           {h₁ h₁' : hfpg f g x = hfpg f g y}
+           (e₁ : h₁ = h₁')
+           {h₂ h₂' : hfpg' f g x = hfpg' f g y}
+           (e₂ : h₂ = h₂')
+           (h₃ : commhfp f g x @ maponpaths f h₁ = maponpaths g h₂ @ commhfp f g y)
+  : path_hfp h₁ h₂ h₃
+    =
+    path_hfp
+      h₁' h₂'
+      (maponpaths
+         (λ z, _ @ maponpaths f z)
+         (!e₁)
+       @ h₃
+       @ maponpaths
+           (λ z, maponpaths g z @ _)
+           e₂).
+Proof.
+  induction e₁ ; induction e₂.
+  simpl.
+  apply maponpaths.
+  exact (!(pathscomp0rid _)).
+Qed.
+
+Definition homot_hfp_one_type
+           {X Y Z : UU}
+           (HZ : isofhlevel 3 Z)
+           {f : X → Z}
+           {g : Y → Z}
+           {x y : hfp f g}
+           (p q : x = y)
+           (r₁ : maponpaths (hfpg f g) p
+                 =
+                 maponpaths (hfpg f g) q)
+           (r₂ : maponpaths (hfpg' f g) p
+                 =
+                 maponpaths (hfpg' f g) q)
+  : p = q.
+Proof.
+  refine (path_hfp_eta p @ _ @ !(path_hfp_eta q)).
+  etrans.
+  {
+    exact (homot_hfp r₁ r₂ _).
+  }
+  apply maponpaths.
+  apply HZ.
+Qed.
+
+Definition hfp_is_of_hlevel
+           (n : nat)
+           {X Y Z : UU}
+           (HX : isofhlevel n X)
+           (HY : isofhlevel n Y)
+           (HZ : isofhlevel n Z)
+           (f : X → Z)
+           (g : Y → Z)
+  : isofhlevel n (hfp f g).
+Proof.
+  use isofhleveltotal2.
+  - use isofhleveldirprod.
+    + exact HX.
+    + exact HY.
+  - simpl.
+    intro x.
+    apply (hlevelntosn n _ HZ).
+Qed.
+
+Definition hfp_HLevel
+           (n : nat)
+           {X Y Z : HLevel n}
+           (f : pr1 X → pr1 Z)
+           (g : pr1 Y → pr1 Z)
+  : HLevel n.
+Proof.
+  simple refine (hfp f g ,, _).
+  apply hfp_is_of_hlevel.
+  - exact (pr2 X).
+  - exact (pr2 Y).
+  - exact (pr2 Z).
+Defined.


### PR DESCRIPTION
- Added the definition of iso-comma category
- Added a proof that the product of univalent categories is again univalent
- Added definition of pullbacks in bicategories, and showed that 1-types and Cat have pullbacks

In the file `Pullback.v`, lines 401-619 could be moved elsewhere.