### PR TITLE
splits monoidal_cat_eq into two components

### DIFF
--- a/UniMath/CategoryTheory/Monoidal/ActionBasedStrongFunctorsMonoidal.v
+++ b/UniMath/CategoryTheory/Monoidal/ActionBasedStrongFunctorsMonoidal.v
@@ -1922,7 +1922,7 @@ Section Main.
       intros vη wη'.
       use total2_paths_f.
       + cbn. repeat rewrite id_left. repeat rewrite id_right.
-        assert (triangleinst := pr1 (monoidal_cat_eq Mon_V) (pr1 vη) (pr1 wη')).
+        assert (triangleinst := monoidal_cat_triangle_eq Mon_V (pr1 vη) (pr1 wη')).
         exact triangleinst.
       + apply trafotargetbicat_disp_cells_isaprop.
     Qed.
@@ -1933,7 +1933,7 @@ Section Main.
       intros vη1 vη2 vη3 vη4.
       use total2_paths_f.
       + cbn. repeat rewrite id_left. repeat rewrite id_right.
-        assert (pentagoninst := pr2 (monoidal_cat_eq Mon_V) (pr1 vη1) (pr1 vη2) (pr1 vη3) (pr1 vη4)).
+        assert (pentagoninst := monoidal_cat_pentagon_eq Mon_V (pr1 vη1) (pr1 vη2) (pr1 vη3) (pr1 vη4)).
         exact pentagoninst.
       + apply trafotargetbicat_disp_cells_isaprop.
     Qed.

--- a/UniMath/CategoryTheory/Monoidal/Actions.v
+++ b/UniMath/CategoryTheory/Monoidal/Actions.v
@@ -310,7 +310,7 @@ Proof.
   exists tensor.
   exists ρ'.
   exists α'.
-  exact (monoidal_cat_eq Mon_V).
+  exact (monoidal_cat_triangle_eq Mon_V,, monoidal_cat_pentagon_eq Mon_V).
 Defined.
 
 (* The action induced by a strong monoidal functor U. *)
@@ -325,8 +325,8 @@ Notation "f #⊗_A g" := (#tensor_A (f #, g)) (at level 31).
 Local Definition α_A : associator tensor_A := monoidal_cat_associator Mon_A.
 Local Definition λ_A : left_unitor tensor_A I_A := monoidal_cat_left_unitor Mon_A.
 Local Definition ρ_A : right_unitor tensor_A I_A := monoidal_cat_right_unitor Mon_A.
-Local Definition triangle_eq_A : triangle_eq tensor_A I_A λ_A ρ_A α_A := pr1 (monoidal_cat_eq Mon_A).
-Local Definition pentagon_eq_A : pentagon_eq tensor_A α_A := pr2 (monoidal_cat_eq Mon_A).
+Local Definition triangle_eq_A : triangle_eq tensor_A I_A λ_A ρ_A α_A := monoidal_cat_triangle_eq Mon_A.
+Local Definition pentagon_eq_A : pentagon_eq tensor_A α_A := monoidal_cat_pentagon_eq Mon_A.
 
 
 Context (U : strong_monoidal_functor Mon_V Mon_A).

--- a/UniMath/CategoryTheory/Monoidal/ConstructionOfActions.v
+++ b/UniMath/CategoryTheory/Monoidal/ConstructionOfActions.v
@@ -41,7 +41,7 @@ Proof.
   exists tensor.
   exists ρ'.
   exists α'.
-  apply monoidal_cat_eq.
+  split; [apply monoidal_cat_triangle_eq | apply monoidal_cat_pentagon_eq].
 Defined.
 
 Section Action_Lifting_Through_Strong_Monoidal_Functor.
@@ -56,8 +56,8 @@ Notation "f #⊗_A g" := (#tensor_A (f #, g)) (at level 31).
 Local Definition α_A := monoidal_cat_associator Mon_A.
 Local Definition λ_A := monoidal_cat_left_unitor Mon_A.
 Local Definition ρ_A := monoidal_cat_right_unitor Mon_A.
-Local Definition triangle_eq_A := pr1 (monoidal_cat_eq Mon_A).
-Local Definition pentagon_eq_A := pr2 (monoidal_cat_eq Mon_A).
+Local Definition triangle_eq_A := monoidal_cat_triangle_eq Mon_A.
+Local Definition pentagon_eq_A := monoidal_cat_pentagon_eq Mon_A.
 
 
 Context (U : strong_monoidal_functor Mon_V Mon_A).

--- a/UniMath/CategoryTheory/Monoidal/MonoidalCategories.v
+++ b/UniMath/CategoryTheory/Monoidal/MonoidalCategories.v
@@ -191,12 +191,9 @@ Definition monoidal_cat_right_unitor : right_unitor (pr1 (pr2 M)) (pr1 (pr2 (pr2
 
 Definition monoidal_cat_associator : associator (pr1 (pr2 M)) := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 M))))).
 
-Definition monoidal_cat_eq :
-  (λ α' : associator (pr1 (pr2 M)),
-          triangle_eq (pr1 (pr2 M)) (pr1 (pr2 (pr2 M))) (pr1 (pr2 (pr2 (pr2 M)))) (pr1 (pr2 (pr2 (pr2 (pr2 M))))) α'
-                      × pentagon_eq (pr1 (pr2 M)) α')
-    (pr1 (pr2 (pr2 (pr2 (pr2 (pr2 M))))))
-  := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 M))))).
+Definition monoidal_cat_triangle_eq : triangle_eq (pr1 (pr2 M)) (pr1 (pr2 (pr2 M))) (pr1 (pr2 (pr2 (pr2 M)))) (pr1 (pr2 (pr2 (pr2 (pr2 M))))) (pr1 (pr2 (pr2 (pr2 (pr2 (pr2 M)))))) := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 M)))))).
+
+Definition monoidal_cat_pentagon_eq : pentagon_eq (pr1 (pr2 M)) (pr1 (pr2 (pr2 (pr2 (pr2 (pr2 M)))))) := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 M)))))).
 
 End Monoidal_Cat_Accessors.
 
@@ -234,7 +231,7 @@ Lemma triangle_eq_swapping_of_tensor: triangle_eq swapping_of_tensor (monoidal_c
   (monoidal_cat_right_unitor M) (monoidal_cat_left_unitor M) associator_swapping_of_tensor.
 Proof.
   red. intros a b. cbn.
-  set (H := pr1 (monoidal_cat_eq M)).
+  set (H := monoidal_cat_triangle_eq M).
   unfold triangle_eq in H.
   etrans.
   2: { apply cancel_precomposition.
@@ -254,7 +251,7 @@ Qed.
 Lemma pentagon_eq_swapping_of_tensor: pentagon_eq swapping_of_tensor associator_swapping_of_tensor.
 Proof.
   red. intros a b c d. cbn.
-  set (H := pr2 (monoidal_cat_eq M)).
+  set (H := monoidal_cat_pentagon_eq M).
   unfold pentagon_eq in H.
   set (f := nat_z_iso_pointwise_z_iso (monoidal_cat_associator M) ((d, c), monoidal_cat_tensor M (b, a))).
   apply (z_iso_inv_on_right _ _ _ f).


### PR DESCRIPTION
they are monoidal_cat_triangle_eq and monoidal_cat_pentagon_eq

this only corrects an unelegant design decision and is mathematically trivial and was triggered by PR #1432