### PR TITLE
Add opam file for the development version of UniMath.

### DIFF
--- a/coq-unimath.opam
+++ b/coq-unimath.opam
@@ -1,0 +1,14 @@
+opam-version: "2.0"
+maintainer: "The UniMath Development Team"
+homepage: "https://github.com/UniMath/UniMath"
+dev-repo: "git+https://github.com/UniMath/UniMath.git"
+bug-reports: "https://github.com/UniMath/UniMath/issues"
+license: "Kind of MIT"
+authors: ["The UniMath Development Team"]
+build: [make "BUILD_COQ=no" "-j%{jobs}%"]
+install: [make "BUILD_COQ=no" "install"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.12.2"}
+]
+synopsis: "Library of Univalent Mathematics"


### PR DESCRIPTION
Opam file for installing the development version of package coq-unimath.
Instructions in the README will be added with a subsequent PR once everything is double-checked.
So far, it has been tested from a private repository.