### PR TITLE
Adapt to coq/coq#15789

### DIFF
--- a/UniMath/Bicategories/DisplayedBicats/Examples/CwF.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/CwF.v
@@ -195,6 +195,7 @@ Section CwFRepresentation.
   Lemma cwf_square_comm {Γ} {A}
         {ΓA : C} {π : ΓA --> Γ}
         {t : Tm ΓA : hSet} (e : (pp : nat_trans _ _) _ t = functor_on_morphisms Ty π A)
+(* TODO: see #1470 *)
     : @paths _
     (@compose _ _
        (@functor_on_objects _ (functor_category _ HSET_univalent_category) _ Γ)

--- a/UniMath/Bicategories/DisplayedBicats/Examples/CwF.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/CwF.v
@@ -133,6 +133,7 @@ Lemma transportf_yy
       {C : category}
       (F : opp_precat_data C ⟶ SET) (c c' : C) (A : (F : functor _ _ ) c : hSet)
       (e : c = c')
+(* TODO: see #1470 *)
   : paths
     (pr1weq
        (@yy C F c')

--- a/UniMath/Bicategories/DisplayedBicats/Examples/CwF.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/CwF.v
@@ -133,9 +133,11 @@ Lemma transportf_yy
       {C : category}
       (F : opp_precat_data C ⟶ SET) (c c' : C) (A : (F : functor _ _ ) c : hSet)
       (e : c = c')
-  : yy (transportf (fun d => (F : functor _ _ ) d : hSet) e A)
-    =
-    transportf (fun d => nat_trans (yoneda _ d : functor _ _) F) e (yy A).
+  : paths
+    (pr1weq
+       (@yy C F c')
+       (@transportf _ (fun d => pr1hSet (functor_on_objects F d : hSet)) _ _ e A))
+    (@transportf _ (fun d => nat_trans _ F) _ _ e (pr1weq (@yy C F c) A)).
 Proof.
   induction e.
   apply idpath.
@@ -192,7 +194,15 @@ Section CwFRepresentation.
   Lemma cwf_square_comm {Γ} {A}
         {ΓA : C} {π : ΓA --> Γ}
         {t : Tm ΓA : hSet} (e : (pp : nat_trans _ _) _ t = functor_on_morphisms Ty π A)
-    : functor_on_morphisms Yo π · yy A = yy t · pp.
+    : @paths _
+    (@compose _ _
+       (@functor_on_objects _ (functor_category _ HSET_univalent_category) _ Γ)
+       Ty (functor_on_morphisms _ π)
+       (pr1weq (@yy C Ty Γ) A))
+    (@compose _
+       (@functor_on_objects _ (functor_category _ hset_category) _ ΓA)
+       Tm Ty
+       (pr1weq (@yy C Tm ΓA) t) pp).
   Proof.
     apply pathsinv0.
     etrans. 2: apply yy_natural.

--- a/UniMath/CategoryTheory/DisplayedCats/Fibrations.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Fibrations.v
@@ -1038,6 +1038,7 @@ Proof.
   use make_weq.
   - exact (λ HD c₁ c₂ cc₁ f,
            let ℓ := HD c₁ c₂ f cc₁ in
+(* TODO: see #1470 *)
            tpair
              (fun d' => total2 (fun ff => @is_cartesian _ _ _ _ _ f d' ff))
              (pr1 ℓ)

--- a/UniMath/CategoryTheory/DisplayedCats/Fibrations.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Fibrations.v
@@ -1015,6 +1015,7 @@ Proof.
   use make_weq.
   - exact (λ HD c₁ c₂ cc₁ f,
            let ℓ := HD c₁ c₂ f cc₁ in
+(* TODO: see #1470 *)
            tpair
              (fun cc₂ => total2 (fun ff => @is_opcartesian _ _ _ _ _ cc₁ cc₂ ff))
              (pr1 ℓ)

--- a/UniMath/CategoryTheory/DisplayedCats/Fibrations.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Fibrations.v
@@ -1015,7 +1015,12 @@ Proof.
   use make_weq.
   - exact (λ HD c₁ c₂ cc₁ f,
            let ℓ := HD c₁ c₂ f cc₁ in
-           pr1 ℓ ,, pr12 ℓ ,, is_cartesian_weq_is_opcartesian _ ℓ).
+           tpair
+             (fun cc₂ => total2 (fun ff => @is_opcartesian _ _ _ _ _ cc₁ cc₂ ff))
+             (pr1 ℓ)
+             (tpair
+                (@is_opcartesian _ _ _ _ _ cc₁ ℓ) (pr12 ℓ)
+                (pr1weq (is_cartesian_weq_is_opcartesian ℓ) ℓ))).
   - use gradth.
     + refine (λ HD c₁ c₂ cc₁ f,
               let ℓ := HD c₁ c₂ f cc₁ in
@@ -1033,7 +1038,14 @@ Proof.
   use make_weq.
   - exact (λ HD c₁ c₂ cc₁ f,
            let ℓ := HD c₁ c₂ f cc₁ in
-           pr1 ℓ ,, pr12 ℓ ,, is_opcartesian_weq_is_cartesian _ (pr22 ℓ)).
+           tpair
+             (fun d' => total2 (fun ff => @is_cartesian _ _ _ _ _ f d' ff))
+             (pr1 ℓ)
+             (tpair
+                (@is_cartesian _ _ _ _ _ f (pr1 ℓ)) (pr12 ℓ)
+                (pr1weq
+                   (@is_opcartesian_weq_is_cartesian _ D _ _ _ _ _ (pr12 ℓ))
+                   (pr22 ℓ)))).
   - use gradth.
     + refine (λ HD c₁ c₂ cc₁ f,
               let ℓ := HD c₁ c₂ f cc₁ in


### PR DESCRIPTION
Adapt to https://github.com/coq/coq/pull/15789

The upstream PR generalizes coercions by removing the uniform inheritance conditions.
Unimath has ambiguous coercion paths that were inocuous before because some of them did not satisfy the uniform inheritance condition, hence were never applied. Now that they do, a few conflict appear. I make here a quick fix, It's probably possible to get a nicer fix, but not knowing the library, I'm unable to do it. Anyway, the change is backward compatible and appart a few more not nice looking lines, it doesn't change anything.