### PR TITLE
Update to Coq8.15.2

### DIFF
--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -89,7 +89,7 @@ jobs:
            brew config --verbose
            opam init --bare -n
            opam switch create with-coq 4.07.1+flambda
-           opam install -y num lablgtk conf-gtksourceview lablgtk3-sourceview3 camlp5
+           opam install -y num lablgtk conf-gtksourceview lablgtk3-sourceview3 camlp5 zarith
       - name: Build UniMath
         run: |
           eval `opam env`

--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -17,7 +17,7 @@ jobs:
 
   sanity-checks:
     name: Sanity-Checks-Ubuntu
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Install build dependencies
@@ -33,7 +33,7 @@ jobs:
 
   build-Unimath-ubuntu:
     name: Build-UniMath-Ubuntu
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Install build dependencies
@@ -49,13 +49,13 @@ jobs:
 
   build-coq-and-Unimath-ubuntu:
     name: Build-coq-and-UniMath-Ubuntu
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential git ocaml ocaml-nox ocaml-native-compilers camlp5 libgtk2.0 libgtksourceview2.0 liblablgtk-extras-ocaml-dev ocaml-findlib libnum-ocaml-dev emacs
+          sudo apt-get install build-essential git ocaml ocaml-nox ocaml-native-compilers camlp5 libgtk2.0 liblablgtk-extras-ocaml-dev ocaml-findlib libnum-ocaml-dev emacs ocaml-dune libzarith-ocaml-dev
       - name: Build UniMath
         run: |
           cd $GITHUB_WORKSPACE

--- a/Makefile
+++ b/Makefile
@@ -229,8 +229,8 @@ distclean::          ; rm -f build/Makefile-configuration
 #############################################################################
 # building coq:
 export PATH:=$(shell pwd)/sub/coq/bin:$(PATH)
-CONFIGURE_OPTIONS := -coqide "$(COQIDE_OPTION)" -with-doc no -local -no-custom
-BUILD_TARGETS := coqbinaries tools states ltac
+CONFIGURE_OPTIONS := -coqide "$(COQIDE_OPTION)" -with-doc no -prefix $(shell pwd)
+BUILD_TARGETS := coqbinaries tools states world
 ifeq ($(DEBUG_COQ),yes)
 CONFIGURE_OPTIONS += -annot
 BUILD_TARGETS += byte
@@ -249,6 +249,7 @@ sub/coq/bin/coq_makefile sub/coq/bin/coqc: sub/coq/config/coq_config.ml
 .PHONY: rebuild-coq
 rebuild-coq sub/coq/bin/coq_makefile sub/coq/bin/coqc:
 	$(MAKE) -w -C sub/coq $(BUILD_OPTIONS) $(BUILD_TARGETS)
+	$(MAKE) -w -C sub/coq install
 ifeq ($(DEBUG_COQ),yes)
 	$(MAKE) -w -C sub/coq tags
 endif

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ distclean::          ; rm -f build/Makefile-configuration
 # building coq:
 export PATH:=$(shell pwd)/sub/coq/bin:$(PATH)
 CONFIGURE_OPTIONS := -coqide "$(COQIDE_OPTION)" -with-doc no -prefix $(shell pwd)
-BUILD_TARGETS := coqbinaries tools states world
+BUILD_TARGETS := coqbinaries tools states coq
 ifeq ($(DEBUG_COQ),yes)
 CONFIGURE_OPTIONS += -annot
 BUILD_TARGETS += byte

--- a/UniMath/CONTENTS.md
+++ b/UniMath/CONTENTS.md
@@ -346,6 +346,8 @@ The packages and files are listed here in logical order: each file depends only 
    - [Monoidal/DisplayedCartesianMonoidalCategoriesWhiskered.v](CategoryTheory/Monoidal/DisplayedCartesianMonoidalCategoriesWhiskered.v)
    - [Monoidal/TotalDisplayedMonoidalWhiskered.v](CategoryTheory/Monoidal/TotalDisplayedMonoidalWhiskered.v)
    - [Monoidal/MonoidalSectionsWhiskered.v](CategoryTheory/Monoidal/MonoidalSectionsWhiskered.v)
+   - [Monoidal/BraidedMonoidalCategoriesWhiskered.v](CategoryTheory/Monoidal/BraidedMonoidalCategoriesWhiskered.v)
+   - [Monoidal/ClosedMonoidalCategoriesWhiskered.v](CategoryTheory/Monoidal/ClosedMonoidalCategoriesWhiskered.v)
    - [Monoidal/MonoidalCategoriesReordered.v](CategoryTheory/Monoidal/MonoidalCategoriesReordered.v)
    - [Monoidal/MonoidalDialgebras.v](CategoryTheory/Monoidal/MonoidalDialgebras.v)
    - [DisplayedCats/MoreFibrations/Prefibrations.v](CategoryTheory/DisplayedCats/MoreFibrations/Prefibrations.v)


### PR DESCRIPTION
This PR does not work yet. I don't know what to do to fix it.

- `ltac` is not a make target any more, it seems. I temporarily make `world` to compile everything needed
- the `make install` seems to be necessary when compiling Coq 8.15.2 manually. Here, it seems to create a loop.

@DanGrayson : can you help?