### PR TITLE
Removed long-empty file `UniMath/Folds/aux_lemmas.v`

### DIFF
--- a/UniMath/Folds/.package/files
+++ b/UniMath/Folds/.package/files
@@ -1,5 +1,4 @@
 UnicodeNotations.v
-aux_lemmas.v
 folds_precat.v
 from_precats_to_folds_and_back.v
 folds_isomorphism.v

--- a/UniMath/Folds/folds_isomorphism.v
+++ b/UniMath/Folds/folds_isomorphism.v
@@ -32,7 +32,6 @@ Require Import UniMath.Foundations.UnivalenceAxiom.
 Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.Core.Isos.
 
-Require Import UniMath.Folds.aux_lemmas.
 Require Import UniMath.Folds.folds_precat.
 Require Import UniMath.Folds.from_precats_to_folds_and_back.
 

--- a/UniMath/Folds/folds_pre_2_cat.v
+++ b/UniMath/Folds/folds_pre_2_cat.v
@@ -48,9 +48,6 @@ Require Import UniMath.Foundations.Propositions.
 Require Import UniMath.Foundations.Sets.
 
 
-(* Require Import FOLDS.aux_lemmas. *)
-
-
 Local Notation "p ## a" := (transportf _ p a) (at level 3, only parsing).
 
 

--- a/UniMath/Folds/from_precats_to_folds_and_back.v
+++ b/UniMath/Folds/from_precats_to_folds_and_back.v
@@ -22,7 +22,6 @@ Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.UnivalenceAxiom.
 Require Import UniMath.CategoryTheory.Core.Categories.
 
-Require Import UniMath.Folds.aux_lemmas.
 Require Import UniMath.Folds.folds_precat.
 
 Local Open Scope cat.


### PR DESCRIPTION
The file [`UniMath/Folds/aux_lemma.v`](https://github.com/UniMath/UniMath/blob/master/UniMath/Folds/aux_lemmas.v) has been empty since commit f26b873 in 2019.  This PR deletes it.

(It can sometimes be useful to keep this sort of file around, even when all its lemmas have been upstreamed, in order to have a place available to put more such lemmas.  However, those reasons typically apply (a) when a package is under active development, and (b) when the auxiliary file provides some useful *context* — imports, notation scope setup, etc — that would be non-trivial to recreate.  Neither of those applies here: the package has been stable for several years, and the file is completely empty.)