### PR TITLE
Tweak management of .dir-locals.el from Makefile: build more often, and remove on distclean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ TAGS : Makefile $(PACKAGE_FILES) $(VFILES)
 FILES_FILTER := grep -vE '^[ \t]*(\#.*)?$$'
 FILES_FILTER_2 := grep -vE '^[ \t]*(\#.*)?$$$$'
 $(foreach P,$(PACKAGES),												\
-	$(eval $P: make-summary-files build/CoqMakefile.make;								\
+	$(eval $P: make-summary-files build/CoqMakefile.make UniMath/.dir-locals.el;								\
 		+ ulimit -v $(EFFECTIVE_MEMORY_LIMIT) ;									\
 		  $(MAKE) -f build/CoqMakefile.make									\
 			$(shell <UniMath/$P/.package/files $(FILES_FILTER) |sed "s=^\(.*\).v=UniMath/$P/\1.vo=" )	\

--- a/Makefile
+++ b/Makefile
@@ -484,6 +484,7 @@ ifeq ($(BUILD_COQ),yes)
 else
 	sed -e "s/@LOCAL@ /;;/" <$< >$@
 endif
+distclean::; rm -f UniMath/.dir-locals.el
 
 # make *.vo files by calling the coq makefile
 %.vo : always; $(MAKE) -f build/CoqMakefile.make $@


### PR DESCRIPTION
This PR implements a suggested solution to the issues raised in #1555 :

- add `.dir-locals.el` as a dependency of the individual package targets
- add `rm -f UniMath/.dir-locals.el` as part of the `distclean` target