### PR TITLE
Mark gradth as deprecated

### DIFF
--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install build dependencies
         run: |
-           brew install coq
+           brew install coq ocaml-findlib
            brew config --verbose
            type coqc
            coqc --version

--- a/UniMath/Bicategories/Core/Discreteness.v
+++ b/UniMath/Bicategories/Core/Discreteness.v
@@ -63,7 +63,7 @@ Definition is_univalent_2_1_discrete_bicat
   : is_univalent_2_1 (discrete_bicat C).
 Proof.
   intros x y f g.
-  use gradth.
+  use isweq_iso.
   - exact (λ p, pr1 p).
   - abstract
       (intro p ; cbn ;
@@ -212,7 +212,7 @@ Definition discrete_left_adj_equiv_weq_z_iso
 Proof.
   use make_weq.
   - exact (λ f, _ ,, z_iso_to_discrete_left_adj_equiv HB (pr2 f)).
-  - use gradth.
+  - use isweq_iso.
     + exact (λ f, make_z_iso' _ (discrete_left_adj_equiv_to_z_iso HB f)).
     + abstract
         (intro Hf ;

--- a/UniMath/Bicategories/Core/Examples/OpCellBicat.v
+++ b/UniMath/Bicategories/Core/Examples/OpCellBicat.v
@@ -274,7 +274,7 @@ Definition weq_op2_left_adjequiv
 Proof.
   use make_weq.
   - exact (to_op2_left_adjequiv f).
-  - use gradth.
+  - use isweq_iso.
     + exact (from_op2_left_adjequiv f).
     + abstract
         (intros Hf ;

--- a/UniMath/Bicategories/Core/Invertible_2cells.v
+++ b/UniMath/Bicategories/Core/Invertible_2cells.v
@@ -510,7 +510,7 @@ Section InvertibleIsIso.
              (f g : hom a b)
     : isweq (@inv2cell_to_z_iso _ _ f g).
   Proof.
-    use gradth.
+    use isweq_iso.
     - exact z_iso_to_inv2cell.
     - abstract
         (intro i ;

--- a/UniMath/Bicategories/Core/Strictness.v
+++ b/UniMath/Bicategories/Core/Strictness.v
@@ -1010,7 +1010,7 @@ Definition two_cat_equiv_strict_bicat
 Proof.
   use make_weq.
   - exact two_cat_to_strict_bicat.
-  - use gradth.
+  - use isweq_iso.
     + exact strict_bicat_to_two_cat.
     + exact two_cat_to_strict_bicat_to_two_cat.
     + exact strict_bicat_to_two_cat_to_strict_bicat.

--- a/UniMath/Bicategories/DisplayedBicats/CleavingOfBicat.v
+++ b/UniMath/Bicategories/DisplayedBicats/CleavingOfBicat.v
@@ -542,7 +542,7 @@ Definition local_fib_weq_local_cleaving
 Proof.
   use make_weq.
   - exact local_cleaving_to_local_fib.
-  - use gradth.
+  - use isweq_iso.
     + exact local_fib_to_local_cleaving.
     + abstract
         (intro HD ;
@@ -1021,7 +1021,7 @@ Definition local_opfib_weq_local_opcleaving
 Proof.
   use make_weq.
   - exact local_opcleaving_to_local_opfib.
-  - use gradth.
+  - use isweq_iso.
     + exact local_opfib_to_local_opcleaving.
     + abstract
         (intro HD ;

--- a/UniMath/Bicategories/DisplayedBicats/DispAdjunctions.v
+++ b/UniMath/Bicategories/DisplayedBicats/DispAdjunctions.v
@@ -525,7 +525,7 @@ Definition left_adjoint_data_total_weq
   ∑ (α : left_adjoint_data f), disp_left_adjoint_data α ff.
 Proof.
   exists (left_adjoint_data_total_to_disp ff).
-  use gradth.
+  use isweq_iso.
   - exact (left_adjoint_data_disp_to_total ff).
   - intros ?. reflexivity.
   - intros ?. reflexivity.

--- a/UniMath/Bicategories/DisplayedBicats/DispUnivalence.v
+++ b/UniMath/Bicategories/DisplayedBicats/DispUnivalence.v
@@ -598,7 +598,7 @@ Section DispLocallyUnivalent.
   Proof.
     use make_weq.
     - exact disp_inv2cell_to_disp_z_iso.
-    - use gradth.
+    - use isweq_iso.
       + exact disp_z_iso_to_disp_inv2cell.
       + abstract
           (intro α ;

--- a/UniMath/Bicategories/DisplayedBicats/Examples/Codomain.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/Codomain.v
@@ -48,7 +48,7 @@ Proof.
     refine (α • linvunitor _ ,, _).
     is_iso.
     apply α.
-  - use gradth.
+  - use isweq_iso.
     + intro α.
       use make_invertible_2cell.
       * exact (α • lunitor _).
@@ -686,7 +686,7 @@ Section UnivalenceOfCodomain.
   Proof.
     use make_weq.
     - exact cod_invertible_2_cell_to_disp_invertible.
-    - use gradth.
+    - use isweq_iso.
       + exact cod_disp_invertible_invertible_2_cell.
       + abstract
           (intro α ;
@@ -1233,7 +1233,7 @@ Section UnivalenceOfCodomain.
   Proof.
     use make_weq.
     - exact cod_adj_equiv_to_disp_adj_equiv.
-    - use gradth.
+    - use isweq_iso.
       + exact cod_disp_adj_equiv_to_adj_equiv.
       + exact (cod_adj_equiv_to_disp_to_adj HB_2_1).
       + exact (cod_disp_adj_to_adj_to_disp HB_2_1).

--- a/UniMath/Bicategories/DisplayedBicats/Examples/DispDepProd.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/DispDepProd.v
@@ -258,7 +258,7 @@ Section DispDepprod.
   Proof.
     use make_weq.
     - exact (disp_depprod_bicat_disp_invertible_2cell_map ff gg).
-    - use gradth.
+    - use isweq_iso.
       + exact (disp_depprod_bicat_disp_invertible_2cell_inv_map ff gg).
       + intros x.
         use funextsec.
@@ -384,7 +384,7 @@ Section DispDepprod.
   Proof.
     use make_weq.
     - exact (disp_depprod_bicat_disp_adjequiv_map aa bb).
-    - use gradth.
+    - use isweq_iso.
       + exact (disp_depprod_bicat_disp_adjequiv_inv aa bb).
       + intros f.
         use funextsec.

--- a/UniMath/Bicategories/DisplayedBicats/Examples/DisplayMapBicatSlice.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/DisplayMapBicatSlice.v
@@ -369,7 +369,7 @@ Section DispMapSliceBicat.
   Proof.
     use make_weq.
     - exact (disp_map_slice_inv2cell_to_disp_adj_equiv HB).
-    - use gradth.
+    - use isweq_iso.
       + exact disp_map_slice_disp_adj_equiv_to_inv2cell.
       + abstract
           (intros α ;

--- a/UniMath/Bicategories/DisplayedBicats/Examples/DisplayMapBicatToDispBicat.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/DisplayMapBicatToDispBicat.v
@@ -626,7 +626,7 @@ Section ArrowSubBicatToDispBicat.
   Proof.
     use make_weq.
     - exact disp_map_inv_2cell_to_disp_invertible_2cell.
-    - use gradth.
+    - use isweq_iso.
       + exact disp_map_disp_invertible_2cell_to_inv_2cell.
       + abstract
           (intro α ;
@@ -656,7 +656,7 @@ Section ArrowSubBicatToDispBicat.
   Proof.
     use make_weq.
     - exact (λ α, ((pr11 α ,, pr2 α) ,, pr21 α)).
-    - use gradth.
+    - use isweq_iso.
       + exact (λ α, (pr11 α ,, pr2 α) ,, pr21 α).
       + intro ; apply idpath.
       + intro ; apply idpath.
@@ -1251,7 +1251,7 @@ Section ArrowSubBicatToDispBicat.
   Proof.
     use make_weq.
     - exact (λ e, disp_map_bicat_adj_equiv_to_disp_adj_equiv HB (pr1 e) (pr2 e)).
-    - use gradth.
+    - use isweq_iso.
       + exact disp_map_bicat_disp_adj_equiv_to_adj_equiv_pair.
       + exact (adj_equiv_to_disp_adj_equiv_to_adj_equiv HB).
       + exact (disp_adj_equiv_to_adj_equiv_to_disp_adj_equiv HB HD).

--- a/UniMath/Bicategories/DisplayedBicats/Examples/DisplayedInserter.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/DisplayedInserter.v
@@ -1819,7 +1819,7 @@ Section DisplayedInserter.
   Proof.
     use make_weq.
     - exact inv2_cell_to_disp_adjequiv.
-    - use gradth.
+    - use isweq_iso.
       + exact disp_adjequiv_to_inv2cell.
       + exact inv2_cell_to_disp_adjequiv_weq_left.
       + intros.

--- a/UniMath/Bicategories/DisplayedBicats/Examples/Domain.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/Domain.v
@@ -368,7 +368,7 @@ Section DomainArrow.
   Proof.
     use make_weq.
     - exact dom_invertible_2cell_to_disp_adj_equiv.
-    - use gradth.
+    - use isweq_iso.
       + exact dom_disp_adj_equiv_to_invertible_2cell.
       + abstract
           (intros α ;

--- a/UniMath/Bicategories/DisplayedBicats/Examples/EndoMap.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/EndoMap.v
@@ -582,7 +582,7 @@ Section EndoMap.
   Proof.
     use make_weq.
     - exact inv2cell_to_disp_adj_equiv_disp_end.
-    - use gradth.
+    - use isweq_iso.
       + exact disp_adj_equiv_to_inv2cell_disp_end.
       + abstract
           (intros τ ;

--- a/UniMath/Bicategories/DisplayedBicats/Examples/PointedOneTypes.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/PointedOneTypes.v
@@ -89,7 +89,7 @@ Lemma p1types_disp_univalent_2_1 : disp_univalent_2_1 p1types_disp.
 Proof.
   apply fiberwise_local_univalent_is_univalent_2_1.
   intros X Y f x y. cbn. intros p q.
-  use gradth.
+  use isweq_iso.
   - intro α. apply α.
   - intros α. apply Y.
   - intros α. cbn in  *.
@@ -104,7 +104,7 @@ Lemma p1types_disp_univalent_2_0 : disp_univalent_2_0 p1types_disp.
 Proof.
   apply fiberwise_univalent_2_0_to_disp_univalent_2_0.
   intros X x x'. cbn in *.
-  use gradth.
+  use isweq_iso.
   - intros f. apply f.
   - intro p.
     induction p.

--- a/UniMath/Bicategories/DisplayedBicats/Examples/Sigma.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/Sigma.v
@@ -744,7 +744,7 @@ Section SigmaDisplayedUnivalent.
   Proof.
     use make_weq.
     - apply pair_disp_invertible_to_sigma_disp_invertible.
-    - use gradth.
+    - use isweq_iso.
       + apply sigma_disp_invertible_to_pair_disp_invertible.
       + intro p.
         induction p as [p1 p2].
@@ -969,7 +969,7 @@ Section SigmaDisplayedUnivalent.
   Proof.
     use make_weq.
     - exact (pair_disp_adjequiv_to_sigma_disp_adjequiv xx yy).
-    - use gradth.
+    - use isweq_iso.
       + exact (pair_disp_adjequiv_to_sigma_disp_adjequiv_inv xx yy).
       + exact (pair_disp_adjequiv_to_sigma_disp_adjequiv_weq_help xx yy).
       + intros p.
@@ -1046,7 +1046,7 @@ Section SigmaDisplayedUnivalent.
   Proof.
     use make_weq.
     - exact (disp_adjequiv_sigma_help x xx1 xx2 yy2).
-    - use gradth.
+    - use isweq_iso.
       + exact (disp_adjequiv_sigma_help_inv x xx1 xx2 yy2).
       + intros p.
         use subtypePath.

--- a/UniMath/Bicategories/DisplayedBicats/Examples/Slice.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/Slice.v
@@ -331,7 +331,7 @@ Section SliceBicat.
   Proof.
     use make_weq.
     - exact slice_inv2cell_to_disp_adj_equiv.
-    - use gradth.
+    - use isweq_iso.
       + exact slice_disp_adj_equiv_to_inv2cell.
       + abstract
           (intros α ;

--- a/UniMath/Bicategories/DisplayedBicats/Examples/Trivial.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/Trivial.v
@@ -275,7 +275,7 @@ Definition trivial_invertible_2cell_weq_disp_invertible
 Proof.
   use make_weq.
   - exact trivial_invertible_2cell_to_disp_invertible.
-  - use gradth.
+  - use isweq_iso.
     + exact trivial_disp_invertible_to_invertible_2cell.
     + exact trivial_invertible_to_disp_invertible_to_invertible.
     + exact trivial_disp_invertible_to_invertible_to_disp_invertible.
@@ -419,7 +419,7 @@ Definition trivial_adj_equiv_weq_disp_adj_equiv
 Proof.
   use make_weq.
   - exact trivial_adj_equiv_to_disp_adj_equiv.
-  - use gradth.
+  - use isweq_iso.
     + exact trivial_disp_adj_equiv_to_adj_equiv.
     + exact (trivial_adj_equiv_to_disp_to_adj HC_2_1).
     + exact (trivial_disp_adj_equiv_to_adj_to_disp HB_2_1 HC_2_1).

--- a/UniMath/Bicategories/Monads/Examples/MonadsInBicatOfCats.v
+++ b/UniMath/Bicategories/Monads/Examples/MonadsInBicatOfCats.v
@@ -134,7 +134,7 @@ Definition mnd_bicat_of_cats_weq_Monad
 Proof.
   use make_weq.
   - exact (λ m, ob_of_mnd m ,, mnd_bicat_of_cats_to_Monad m).
-  - use gradth.
+  - use isweq_iso.
     + exact (λ m, Monad_to_mnd_bicat_of_cats (pr2 m)).
     + exact mnd_bicat_of_cats_weq_Monad_inv₁.
     + abstract

--- a/UniMath/Bicategories/Monads/Examples/MonadsInBicatOfUnivCats.v
+++ b/UniMath/Bicategories/Monads/Examples/MonadsInBicatOfUnivCats.v
@@ -134,7 +134,7 @@ Definition mnd_bicat_of_univ_cats_weq_Monad
 Proof.
   use make_weq.
   - exact (λ m, ob_of_mnd m ,, mnd_bicat_of_univ_cats_to_Monad m).
-  - use gradth.
+  - use isweq_iso.
     + exact (λ m, Monad_to_mnd_bicat_of_univ_cats (pr2 m)).
     + exact mnd_bicat_of_univ_cats_weq_Monad_inv₁.
     + abstract

--- a/UniMath/Bicategories/Monads/Examples/MonadsInOp1Bicat.v
+++ b/UniMath/Bicategories/Monads/Examples/MonadsInOp1Bicat.v
@@ -283,7 +283,7 @@ Definition op1_mnd_weq_mnd
 Proof.
   use make_weq.
   - exact op1_mnd_to_mnd.
-  - use gradth.
+  - use isweq_iso.
     + exact mnd_to_op1_mnd.
     + exact op1_mnd_weq_mnd_inv₁.
     + exact op1_mnd_weq_mnd_inv₂.
@@ -374,7 +374,7 @@ Definition op1_mnd_mor_weq_mnd_opmor
 Proof.
   use make_weq.
   - exact op1_mnd_mor_to_mnd_opmor.
-  - use gradth.
+  - use isweq_iso.
     + exact mnd_opmor_to_op1_mnd_mor.
     + exact op1_mnd_mor_weq_mnd_opmor_inv₁.
     + exact op1_mnd_mor_weq_mnd_opmor_inv₂.
@@ -420,7 +420,7 @@ Definition op1_mnd_cell_weq_mnd_opcell
 Proof.
   use make_weq.
   - exact op1_mnd_cell_to_mnd_opcell.
-  - use gradth.
+  - use isweq_iso.
     + exact mnd_opcell_to_op1_mnd_cell.
     + abstract
         (intro α ;

--- a/UniMath/Bicategories/Monads/Examples/MonadsInOp2Bicat.v
+++ b/UniMath/Bicategories/Monads/Examples/MonadsInOp2Bicat.v
@@ -370,7 +370,7 @@ Definition op2_mnd_weq_comnd
 Proof.
   use make_weq.
   - exact op2_mnd_to_comnd.
-  - use gradth.
+  - use isweq_iso.
     + exact comnd_to_op2_mnd.
     + exact op2_mnd_weq_comnd_inv₁.
     + exact op2_mnd_weq_comnd_inv₂.
@@ -460,7 +460,7 @@ Definition op2_mnd_mor_weq_comnd_mor
 Proof.
   use make_weq.
   - exact op2_mnd_mor_to_comnd_mor.
-  - use gradth.
+  - use isweq_iso.
     + exact comnd_mor_to_op2_mnd_mor.
     + exact op2_mnd_mor_weq_comnd_mor_inv₁.
     + exact op2_mnd_mor_weq_comnd_mor_inv₂.
@@ -501,7 +501,7 @@ Definition op2_mnd_cell_weq_comnd_cell
 Proof.
   use make_weq.
   - exact op2_mnd_cell_to_comnd_cell.
-  - use gradth.
+  - use isweq_iso.
     + exact comnd_cell_to_op2_mnd_cell.
     + abstract
         (intro ;

--- a/UniMath/Bicategories/Morphisms/Examples/MorphismsInBicatOfUnivCats.v
+++ b/UniMath/Bicategories/Morphisms/Examples/MorphismsInBicatOfUnivCats.v
@@ -519,7 +519,7 @@ Definition left_adjoint_weq_is_left_adjoint
 Proof.
   use make_weq.
   - exact left_adjoint_to_is_left_adjoint.
-  - use gradth.
+  - use isweq_iso.
     + exact is_left_adjoint_to_left_adjoint.
     + abstract
         (intro HF ;

--- a/UniMath/Bicategories/Morphisms/Examples/MorphismsInOneTypes.v
+++ b/UniMath/Bicategories/Morphisms/Examples/MorphismsInOneTypes.v
@@ -197,7 +197,7 @@ Definition one_types_fully_faithful_isInjective
   : isInjective f.
 Proof.
   intros x y ; cbn in *.
-  use gradth.
+  use isweq_iso.
   - intro p.
     exact (pr1 (pr2 Hf X (λ _, x) (λ _, y) (λ _, p)) x).
   - intro p ; simpl.

--- a/UniMath/Bicategories/Morphisms/Examples/MorphismsInOp1Bicat.v
+++ b/UniMath/Bicategories/Morphisms/Examples/MorphismsInOp1Bicat.v
@@ -59,7 +59,7 @@ Definition op1_left_adjoint_weq_right_adjoint
 Proof.
   use make_weq.
   - exact op1_left_adjoint_to_right_adjoint.
-  - use gradth.
+  - use isweq_iso.
     + exact right_adjoint_to_op1_left_adjoint.
     + intro.
       apply idpath.

--- a/UniMath/Bicategories/Morphisms/Examples/MorphismsInOp2Bicat.v
+++ b/UniMath/Bicategories/Morphisms/Examples/MorphismsInOp2Bicat.v
@@ -169,7 +169,7 @@ Definition op2_left_adjoint_weq_right_adjoint
 Proof.
   use make_weq.
   - exact op2_left_adjoint_to_right_adjoint.
-  - use gradth.
+  - use isweq_iso.
     + exact right_adjoint_to_op2_left_adjoint.
     + abstract
         (intro Hf ;

--- a/UniMath/Bicategories/Morphisms/InternalStreetFibration.v
+++ b/UniMath/Bicategories/Morphisms/InternalStreetFibration.v
@@ -306,7 +306,7 @@ Section InternalStreetFibration.
   Proof.
     use make_weq.
     - exact rep_internal_sfib_to_internal_sfib.
-    - use gradth.
+    - use isweq_iso.
       + exact internal_sfib_to_rep_internal_sfib.
       + exact internal_sfib_to_rep_to_sfib.
       + exact rep_sfib_to_internal_to_rep.

--- a/UniMath/Bicategories/Morphisms/InternalStreetOpFibration.v
+++ b/UniMath/Bicategories/Morphisms/InternalStreetOpFibration.v
@@ -397,7 +397,7 @@ Definition internal_sopfib_weq_internal_sfib
 Proof.
   use make_weq.
   - exact internal_sfib_is_internal_sopfib.
-  - use gradth.
+  - use isweq_iso.
     + exact internal_sopfib_is_internal_sfib.
     + exact internal_sopfib_weq_internal_sfib_inv_left.
     + exact internal_sopfib_weq_internal_sfib_inv_right.

--- a/UniMath/Bicategories/PseudoFunctors/Biequivalence.v
+++ b/UniMath/Bicategories/PseudoFunctors/Biequivalence.v
@@ -292,7 +292,7 @@ Proof.
   pose (ε := is_biequivalence_adjoint_counit (pr2 e)).
   use make_weq.
   - exact (λ x, F x).
-  - use gradth.
+  - use isweq_iso.
     + exact (λ x, G x).
     + intro x.
       cbn.

--- a/UniMath/Bicategories/WkCatEnrichment/hcomp_bicat.v
+++ b/UniMath/Bicategories/WkCatEnrichment/hcomp_bicat.v
@@ -515,7 +515,7 @@ Definition hcomp_bicat_weq_prebicategory
 Proof.
   use make_weq.
   - exact hcomp_bicat_to_prebicategory.
-  - use gradth.
+  - use isweq_iso.
     + exact prebicategory_to_hcomp_bicat.
     + intros b.
       apply idpath.
@@ -830,7 +830,7 @@ Definition hcomp_bicat_weq_bicat
 Proof.
   use make_weq.
   - exact hcomp_bicat_to_bicat.
-  - use gradth.
+  - use isweq_iso.
     + exact bicat_to_hcomp_bicat.
     + exact hcomp_bicat_to_bicat_to_hcomp_bicat.
     + exact bicat_to_hcomp_bicat_to_bicat.

--- a/UniMath/CategoryTheory/CategorySum.v
+++ b/UniMath/CategoryTheory/CategorySum.v
@@ -37,7 +37,7 @@ Definition inl_eq_weq
 Proof.
   use make_weq.
   - apply ii1_injectivity.
-  -  use gradth.
+  -  use isweq_iso.
      + exact (maponpaths inl).
      + abstract
          (intro p ;
@@ -55,7 +55,7 @@ Definition inr_eq_weq
 Proof.
   use make_weq.
   - apply ii2_injectivity.
-  -  use gradth.
+  -  use isweq_iso.
      + exact (maponpaths inr).
      + abstract
          (intro p ;
@@ -207,7 +207,7 @@ Definition inl_iso
 Proof.
   use make_weq.
   - exact inl_iso_map.
-  - use gradth.
+  - use isweq_iso.
     + exact inl_iso_inv.
     + abstract
         (intro f ;
@@ -254,7 +254,7 @@ Definition inr_iso
 Proof.
   use make_weq.
   - exact inr_iso_map.
-  - use gradth.
+  - use isweq_iso.
     + exact inr_iso_inv.
     + abstract
         (intro f ;
@@ -317,13 +317,13 @@ Proof.
          refine (@idtoiso_in_bincoprod_inl C₁ C₂ _ _ (ii1_injectivity x₁ x₂ p) @ _) ;
          do 2 apply maponpaths ;
          apply (@inv_equality_by_case_equality_by_case C₁ C₂ (inl x₁) (inl x₂) p)).
-  - use gradth.
+  - use isweq_iso.
     + exact (λ f, fromempty (pr1 f)).
     + intro p ; cbn.
       exact (fromempty (negpathsii1ii2 _ _ p)).
     + intro p ; cbn.
       exact (fromempty (pr1 p)).
-  - use gradth.
+  - use isweq_iso.
     + exact (λ f, fromempty (pr1 f)).
     + intro p ; cbn.
       exact (fromempty (negpathsii2ii1 _ _ p)).

--- a/UniMath/CategoryTheory/Core.v
+++ b/UniMath/CategoryTheory/Core.v
@@ -77,7 +77,7 @@ Section Core.
     - simple refine (λ i, _,,_).
       + exact i.
       + apply is_z_iso_core.
-    - use gradth.
+    - use isweq_iso.
       + exact (λ i, pr1 i).
       + abstract
           (intro i ;

--- a/UniMath/CategoryTheory/Core/Isos.v
+++ b/UniMath/CategoryTheory/Core/Isos.v
@@ -936,7 +936,7 @@ Qed.
 Definition weq_iso_z_iso {C : category} {b c : C} : iso b c ≃ z_iso b c.
 Proof.
   exists iso_to_z_iso.
-  use gradth.
+  use isweq_iso.
   - apply z_iso_to_iso.
   - apply roundtrip1_iso_z_iso.
   - apply roundtrip2_iso_z_iso.

--- a/UniMath/CategoryTheory/DisplayedCats/Adjunctions.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Adjunctions.v
@@ -247,7 +247,7 @@ Section DispHomSetIso_from_Adjunction.
       (d -->[g] GG _ d') ≃ (FF _ d -->[# F g · ε _] d').
   Proof.
     exists (homset_conj_inv _ _ _).
-    apply (gradth _ (homset_conj _ _ _)).
+    apply (isweq_iso _ (homset_conj _ _ _)).
     - apply homset_conj_after_conj_inv.
     - apply homset_conj_inv_after_conj.
   Defined.
@@ -256,7 +256,7 @@ Section DispHomSetIso_from_Adjunction.
        (FF _ d -->[f] d') ≃ (d -->[η _ · # G f] GG _ d').
   Proof.
     exists (homset_conj' _ _ _).
-    apply (gradth _ (homset_conj'_inv _ _ _)).
+    apply (isweq_iso _ (homset_conj'_inv _ _ _)).
     - apply homset_conj'_inv_after_conj'.
     - apply homset_conj'_after_conj'_inv.
   Defined.

--- a/UniMath/CategoryTheory/DisplayedCats/Constructions.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Constructions.v
@@ -273,7 +273,7 @@ Lemma z_iso_disp_prod_weq
   (z_iso_disp (identity_z_iso x) xx1 xx1') × (z_iso_disp (identity_z_iso x) xx2 xx2').
 Proof.
   exists (z_iso_disp_prod1 xx1 xx1' xx2 xx2').
-  use gradth.
+  use isweq_iso.
   - apply z_iso_disp_prod2.
   - apply z_iso_disp_prod21.
   - apply z_iso_disp_prod12.

--- a/UniMath/CategoryTheory/DisplayedCats/Examples/Opposite.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Examples/Opposite.v
@@ -162,7 +162,7 @@ Definition z_iso_disp_weq_op_disp_cat
 Proof.
   use make_weq.
   - exact z_iso_disp_from_op_disp_cat.
-  - use gradth.
+  - use isweq_iso.
     + exact z_iso_disp_to_op_disp_cat.
     + abstract
         (intro f ;

--- a/UniMath/CategoryTheory/DisplayedCats/Examples/Reindexing.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Examples/Reindexing.v
@@ -303,7 +303,7 @@ Definition z_iso_disp_weq_z_iso_disp_reindex
 Proof.
   use make_weq.
   - exact z_iso_disp_to_z_iso_disp_reindex.
-  - use gradth.
+  - use isweq_iso.
     + exact z_iso_disp_reindex_to_z_iso_disp.
     + abstract
         (intros i ;

--- a/UniMath/CategoryTheory/DisplayedCats/Examples/UnitalBinop.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Examples/UnitalBinop.v
@@ -207,7 +207,7 @@ Definition point_disp_cat_disp_univalent
 Proof.
   use is_univalent_disp_from_fibers.
   intros X x y.
-  use gradth.
+  use isweq_iso.
   - intros f.
     exact (pr1 f).
   - intros e.

--- a/UniMath/CategoryTheory/DisplayedCats/Fibrations.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Fibrations.v
@@ -888,7 +888,7 @@ Definition is_cartesian_weq_is_opcartesian
 Proof.
   use make_weq.
   - exact (λ Hff c₃ cc₃ g hh, Hff c₃ g cc₃ hh).
-  - use gradth.
+  - use isweq_iso.
     + exact (λ Hff c₃ cc₃ g hh, Hff c₃ g cc₃ hh).
     + intro ; apply idpath.
     + intro ; apply idpath.
@@ -906,7 +906,7 @@ Definition is_opcartesian_weq_is_cartesian
 Proof.
   use make_weq.
   - exact (λ Hff c₃ cc₃ g hh, Hff c₃ g cc₃ hh).
-  - use gradth.
+  - use isweq_iso.
     + exact (λ Hff c₃ cc₃ g hh, Hff c₃ g cc₃ hh).
     + intro ; apply idpath.
     + intro ; apply idpath.
@@ -1024,7 +1024,7 @@ Proof.
              (tpair
                 (@is_opcartesian _ _ _ _ _ cc₁ ℓ) (pr12 ℓ)
                 (pr1weq (is_cartesian_weq_is_opcartesian ℓ) ℓ))).
-  - use gradth.
+  - use isweq_iso.
     + refine (λ HD c₁ c₂ cc₁ f,
               let ℓ := HD c₁ c₂ f cc₁ in
               pr1 ℓ ,, pr12 ℓ ,, _).
@@ -1050,7 +1050,7 @@ Proof.
                 (pr1weq
                    (@is_opcartesian_weq_is_cartesian _ D _ _ _ _ _ (pr12 ℓ))
                    (pr22 ℓ)))).
-  - use gradth.
+  - use isweq_iso.
     + refine (λ HD c₁ c₂ cc₁ f,
               let ℓ := HD c₁ c₂ f cc₁ in
               pr1 ℓ ,, pr12 ℓ ,, _).

--- a/UniMath/CategoryTheory/DisplayedCats/FunctorCategory.v
+++ b/UniMath/CategoryTheory/DisplayedCats/FunctorCategory.v
@@ -239,7 +239,7 @@ Lemma base_category_z_iso_weq (F₀ G₀ : base_category) :
   z_iso F₀ G₀ ≃ (∏ (x : C), z_iso (F₀ x) (G₀ x)).
 Proof.
   exists (base_category_z_iso_to_z_iso_fam F₀ G₀).
-  use gradth.
+  use isweq_iso.
   - apply base_category_z_iso_fam_to_z_iso.
   - intros x. apply z_iso_eq. apply idpath.
   - intros x. apply funextsec. intros y.

--- a/UniMath/CategoryTheory/Equivalences/CompositesAndInverses.v
+++ b/UniMath/CategoryTheory/Equivalences/CompositesAndInverses.v
@@ -67,7 +67,7 @@ Proof.
   intros c d.
   set (inv := (fun f : D1 ⟦G c, G d⟧ => εinv _ ;; #F f ;; ε _ )).
   simpl in inv.
-  apply (gradth _ inv ).
+  apply (isweq_iso _ inv ).
   - intro f. simpl in f. unfold inv.
     assert (XR := nat_trans_ax ε). simpl in XR.
     rewrite <- assoc.

--- a/UniMath/CategoryTheory/Monads/KTriplesEquiv.v
+++ b/UniMath/CategoryTheory/Monads/KTriplesEquiv.v
@@ -524,7 +524,7 @@ Section Adjunction.
     split.
     - apply fully_faithful_from_equivalence.
       use (is_left_adjoint_functor_unkleislify,, form_equivalence_unkleislify).
-    - apply (gradth _ (λ T : Monad C, kleislify T)).
+    - apply (isweq_iso _ (λ T : Monad C, kleislify T)).
       + intro T. simpl. apply kleislify_unkleislify.
       + simpl. apply unkleislify_kleislify.
   Defined.

--- a/UniMath/CategoryTheory/Monoidal/DisplayedMonoidal.v
+++ b/UniMath/CategoryTheory/Monoidal/DisplayedMonoidal.v
@@ -199,7 +199,7 @@ We can build the total category of a [disp_binprod D D'], or we can take the car
  Definition fully_faithful_reord1_functor : fully_faithful reord1_functor.
  Proof.
    intros a b.
-   use gradth.
+   use isweq_iso.
    - exact (reord1_hom_inverse a b).
    - intros. apply idpath.
    - intros; apply idpath.
@@ -217,7 +217,7 @@ We can build the total category of a [disp_binprod D D'], or we can take the car
  Proof.
    split.
    - exact fully_faithful_reord1_functor.
-   - use gradth.
+   - use isweq_iso.
      + exact reord1_ob_inverse.
      + intro; apply idpath.
      + intro; apply idpath.

--- a/UniMath/CategoryTheory/PrecategoryBinProduct.v
+++ b/UniMath/CategoryTheory/PrecategoryBinProduct.v
@@ -1181,7 +1181,7 @@ Section CategoryBinproductIsoWeq.
   Proof.
     use make_weq.
     - exact category_binproduct_z_iso_map.
-    - use gradth.
+    - use isweq_iso.
       + exact category_binproduct_z_iso_inv.
       + abstract
           (intros i ;
@@ -1214,7 +1214,7 @@ Section CategoryBinproductIsoWeq.
   Proof.
     use make_weq.
     - exact category_binproduct_iso_map.
-    - use gradth.
+    - use isweq_iso.
       + exact category_binproduct_iso_inv.
       + abstract
           (intros i ;

--- a/UniMath/CategoryTheory/categories/StandardCategories.v
+++ b/UniMath/CategoryTheory/categories/StandardCategories.v
@@ -358,7 +358,7 @@ Definition nat_trans_from_unit_weq_morphisms
 Proof.
   use make_weq.
   - exact nat_trans_from_unit.
-  - use gradth.
+  - use isweq_iso.
     + exact (λ n, n tt).
     + abstract
         (intro f ;

--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -1766,9 +1766,8 @@ Defined.
 
 (** This is kept to preserve compatibility with publications that use the
     name "gradth" for the "grad theorem". *)
-Definition gradth {X Y : UU} (f : X -> Y) (g : Y -> X)
-        (egf: ∏ x : X, g (f x) = x)
-        (efg: ∏ y : Y, f (g y) = y) : isweq f := isweq_iso f g egf efg.
+#[deprecated(note="Use isweq_iso instead.")]
+Notation gradth := isweq_iso (only parsing).
 
 Definition weq_iso {X Y : UU} (f : X -> Y) (g : Y -> X)
            (egf: ∏ x : X, g (f x) = x)


### PR DESCRIPTION
This PR changes gradth to be a Notation for isweq_iso and marks it as [deprecated](https://coq.inria.fr/refman/using/libraries/writing.html#coq:attr.deprecated). This means that coqc / coqtop will issue a warning and a suggestion to use isweq_iso whenever gradth is used. This addresses #792 and also replaces all instances of gradth added since #848.

Any satellite repos that use gradth _should_ still work, but will now trigger warnings.

As this PR contains a change to Foundations I expect `make sanity-checks` to fail. 