### PR TITLE
Remove hset_fun_space.

### DIFF
--- a/UniMath/CategoryTheory/Chains/OmegaCocontFunctors.v
+++ b/UniMath/CategoryTheory/Chains/OmegaCocontFunctors.v
@@ -1444,7 +1444,8 @@ Proof.
     apply funextsec; intro x; cbn.
     now etrans; [apply maponpaths,
         (toforallpaths _ _ _ (maponpaths pr1 (colimArrowCommutes CC c cc n)) x)|].
-  - intros z; apply impred_isaprop; intro n; apply setproperty.
+  - intro ; apply impred_isaprop.
+    intro ; apply homset_property.
   - simpl; intros f Hf.
     apply funextsec; intro l.
     transparent assert (k : (HSET/X⟦colim CC,c⟧)).
@@ -1456,7 +1457,7 @@ Proof.
     }
     assert (Hk : (∏ n, colimIn CC n · k = coconeIn cc n)).
     { intros n.
-      apply subtypePath; [intros x; apply setproperty|].
+      apply subtypePath; [intros x; apply homset_property|].
       apply funextsec; intro z.
       use total2_paths_f; [apply idpath|].
       now rewrite idpath_transportf; cbn; rewrite <- (toforallpaths _ _ _ (Hf n) z).

--- a/UniMath/CategoryTheory/Inductives/Lists.v
+++ b/UniMath/CategoryTheory/Inductives/Lists.v
@@ -347,7 +347,7 @@ Module AltList.
    moment as it needs that the category is cartesian closed *)
 Section constprod_functor.
 
-Variables (x : HSET).
+Variables (x : hSet).
 
 Definition constprod_functor : functor HSET HSET :=
   BinProduct_of_functors HSET HSET BinProductsHSET (constant_functor HSET HSET x)
@@ -357,7 +357,7 @@ Lemma omega_cocontConstProdFunctor : is_omega_cocont constprod_functor.
 Proof.
 intros hF c L ccL HcL cc.
 use tpair.
-- transparent assert (HX : (cocone hF (hset_fun_space x HcL))).
+- transparent assert (HX : (cocone hF (funset x HcL))).
   {  use make_cocone.
     * simpl; intro n; apply flip, (curry (Z := λ _,_)), (pr1 cc).
     * abstract (destruct cc as [f hf]; simpl; intros m n e;
@@ -366,7 +366,7 @@ use tpair.
   }
   use tpair.
   + simpl; apply uncurry, flip.
-    apply (colimArrow (make_ColimCocone _ _ _ ccL) (hset_fun_space x HcL)).
+    apply (colimArrow (make_ColimCocone _ _ _ ccL) (funset x HcL)).
     apply HX.
   + cbn.
     destruct cc as [f hf]; simpl; intro n.
@@ -384,7 +384,7 @@ use tpair.
   | destruct p as [t p]; simpl;
     apply funextfun; intro xc; destruct xc as [x' c']; simpl;
     use (let g : HSET⟦colim (make_ColimCocone hF c L ccL),
-                                hset_fun_space x HcL⟧ := _ in _);
+                                funset x HcL⟧ := _ in _);
     [ simpl; apply flip, (curry (Z := λ _,_)), t
     | rewrite <- (colimArrowUnique _ _ _ g); [apply idpath | ];
       destruct cc as [f hf]; unfold is_cocone_mor in p; simpl in *;

--- a/UniMath/CategoryTheory/Profunctors/Core.v
+++ b/UniMath/CategoryTheory/Profunctors/Core.v
@@ -89,7 +89,7 @@ Section Dinatural.
     use make_hProp.
     - exact (∏ (a b : ob C) (f : a --> b),
                lmap F f · data a · rmap G f = rmap F f · data b · lmap G f).
-    - abstract (do 3 (apply impred; intro); apply setproperty).
+    - abstract (do 3 (apply impred; intro); apply homset_property).
   Defined.
 
   Definition dinatural_transformation (f : C ↛ C) (g : C ↛ C) : UU :=
@@ -195,7 +195,7 @@ Section Ends.
   Proof.
     use make_hProp.
     - exact (∏ (a b : ob C) (f : a --> b), pi a · rmap F f = pi b · lmap F f).
-    - abstract (do 3 (apply impred; intro); apply setproperty).
+    - abstract (do 3 (apply impred; intro); apply homset_property).
   Defined.
 
   (** Following the convention for limits, the tip is explicit in the type. *)

--- a/UniMath/CategoryTheory/categories/HSET/Core.v
+++ b/UniMath/CategoryTheory/categories/HSET/Core.v
@@ -21,6 +21,7 @@ Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Foundations.UnivalenceAxiom.
 Require Import UniMath.Foundations.NaturalNumbers.
 Require Import UniMath.Foundations.HLevels.
+Require Import UniMath.MoreFoundations.PartA.
 
 Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.Core.Functors.
@@ -30,12 +31,10 @@ Local Open Scope cat.
 (** ** Category HSET of [hSet]s ([hset_category]) *)
 Section HSET_precategory.
 
-Definition hset_fun_space (A B : hSet) : hSet :=
-  make_hSet _ (isaset_set_fun_space A B).
-
-Definition hset_precategory_ob_mor : precategory_ob_mor :=
-  tpair (λ ob : UU, ob -> ob -> UU) hSet
-        (λ A B : hSet, hset_fun_space A B).
+  Definition hset_precategory_ob_mor : precategory_ob_mor :=
+    make_precategory_ob_mor
+      hSet
+      (λ A B : hSet, A -> B).
 
 Definition hset_precategory_data : precategory_data :=
   make_precategory_data hset_precategory_ob_mor (fun (A:hSet) (x : A) => x)

--- a/UniMath/CategoryTheory/categories/HSET/Limits.v
+++ b/UniMath/CategoryTheory/categories/HSET/Limits.v
@@ -307,10 +307,9 @@ Proof.
       apply invweq.
       apply dirprod_with_contr_r.
       use make_iscontr.
-      * apply proofirrelevance.
-        apply hlevelntosn.
-        apply (pr2 TerminalHSET). (** TODO: should be an accessor *)
-      * intro; apply proofirrelevance; apply setproperty.
+      * apply isapropifcontr.
+        apply TerminalHSET.
+      * intro; apply proofirrelevance; apply homset_property.
     + unfold hfiber_hSet, hfiber; cbn.
       use make_iscontr.
       * use tpair.
@@ -322,7 +321,7 @@ Proof.
            specialize (pbH pb0); cbn in pbH.
            refine (pbH @ _).
            apply tosecoverunit_compute.
-        -- apply funextfun; intro; apply idpath.
+        -- apply idpath.
       * intros t.
         apply subtypePath.
         -- intro; apply has_homsets_HSET.

--- a/UniMath/CategoryTheory/categories/HSET/Structures.v
+++ b/UniMath/CategoryTheory/categories/HSET/Structures.v
@@ -64,7 +64,7 @@ Proof.
     * exact (z tt).
     * exact (s n).
   + now split; apply funextfun; intros [].
-  + now intros; apply isapropdirprod; apply setproperty.
+  + now intros; apply isapropdirprod; apply homset_property.
   + intros q [hq1 hq2].
     apply funextfun; intros n.
     induction n as [|n IH].
@@ -88,8 +88,8 @@ Section exponentials.
 (** Define the functor: A -> _^A *)
 Definition exponential_functor (A : HSET) : functor HSET HSET.
 Proof.
-use tpair.
-+ exists (hset_fun_space A); simpl.
+use make_functor.
++ exists (funset (A : hSet)); simpl.
   intros b c f g; apply (λ x, f (g x)).
 + abstract (use tpair;
   [ intro x; now (repeat apply funextfun; intro)
@@ -478,8 +478,8 @@ Proof.
       apply subtypePath.
       -- intro.
           apply isapropdirprod.
-          ++ apply (setproperty (hset_fun_space _ _)).
-          ++ apply (setproperty (hset_fun_space _ unitset)).
+         ++ apply funspace_isaset, setproperty.
+         ++ apply funspace_isaset, isasetunit.
       -- cbn.
           apply funextsec; intro; cbn.
           (** Precompose with [m] and use the commutative square *)
@@ -515,7 +515,7 @@ Proof.
       * split; [apply idpath|].
         apply proofirrelevance, hlevelntosn, iscontrfuntounit.
     + intro t.
-      apply subtypePath; [intro; apply isapropdirprod; apply setproperty|].
+      apply subtypePath; [intro; apply isapropdirprod; apply isaset_set_fun_space|].
       apply funextfun; intro.
       apply subtypePath; [intro; apply propproperty|].
       refine (_ @ toforallpaths _ _ _ (pr1 (pr2 t)) x).
@@ -546,7 +546,7 @@ Proof.
     + intro.
       apply Propositions.isaproptotal2.
       * intro; apply isaprop_isPullback.
-      * intros; apply proofirrelevance, setproperty.
+      * intros; apply proofirrelevance, homset_property.
     + (** If the following is a pullback square,
 <<
             X ------- ! ---> unit

--- a/UniMath/CategoryTheory/categories/wosets.v
+++ b/UniMath/CategoryTheory/categories/wosets.v
@@ -122,7 +122,7 @@ Defined.
 
 Lemma has_homsets_WOSET : has_homsets WOSET_precategory.
 Proof.
-now intros X Y; apply hset_fun_space.
+  red ; intros ; apply isaset_set_fun_space.
 Qed.
 
 Definition WOSET : category := (WOSET_precategory,,has_homsets_WOSET).


### PR DESCRIPTION
hset_fun_space is a duplicate of funset, defined in MoreFoundations/PartA.v

This also changes the type of morphisms in HSET. Before this commit the morphisms were defined to be hSets, but there is no need to bundle the isaset-property with each homset. This PR defines the homsets in HSET to be the ordinary function type.

TypeTheory needs a one-line patch to build following this PR. 