### PR TITLE
Housekeeping

### DIFF
--- a/UniMath/Algebra/Dcpo.v
+++ b/UniMath/Algebra/Dcpo.v
@@ -109,14 +109,14 @@ Coercion dcpoposet : dcpo >-> Poset.
 Definition dcpoisdirectedcomplete (D : dcpo) : isdirectedcomplete D := pr2 D.
 Definition make_dcpo (X : Poset) (i : isdirectedcomplete X) : dcpo := (X,,i).
 
-Definition dcpo_mklub {D : dcpo} {I : UU} {f : I -> D} : isdirected f -> D.
+Definition dcpo_make_lub {D : dcpo} {I : UU} {f : I -> D} : isdirected f -> D.
 Proof.
   intro isdirec.
   exact (pr1 (dcpoisdirectedcomplete D I f isdirec)).
 Defined.
 
-Definition dcpo_mklub_islub {D : dcpo} {I : UU} {f : I -> D}
-           (isdirec : isdirected f) : islub f (dcpo_mklub isdirec).
+Definition dcpo_make_lub_islub {D : dcpo} {I : UU} {f : I -> D}
+           (isdirec : isdirected f) : islub f (dcpo_make_lub isdirec).
 Proof.
   exact (pr2 (dcpoisdirectedcomplete D I f isdirec)).
 Defined.
@@ -225,7 +225,7 @@ Proof.
   - exact preservesdireclub.
 Qed.
 
-Definition mkdcpomorphism {D D' : dcpo}
+Definition make_dcpomorphism {D D' : dcpo}
            (f : D -> D') (i : isdcpomorphism' f) : dcpomorphism D D'.
 Proof.
   exists f.
@@ -233,9 +233,9 @@ Proof.
 Defined.
 
 (** Constant functions between dcpos are continuous *)
-Definition mkconst_dcpomor (D E : dcpo) (e : E) : dcpomorphism D E.
+Definition const_dcpomor (D E : dcpo) (e : E) : dcpomorphism D E.
 Proof.
-  use mkdcpomorphism.
+  use make_dcpomorphism.
   - exact (λ _, e).
   - intros I u isdirec v islubv. split.
     + intro i. simpl. apply isrefl_posetRelation.
@@ -330,7 +330,7 @@ Definition pointwiselub {D D' : dcpo} {I : UU}
 Proof.
   intro d.
   set (ptfamdir := pointwisefamily_isdirected F isdir d).
-  exact (dcpo_mklub ptfamdir).
+  exact (dcpo_make_lub ptfamdir).
 Defined.
 
 Lemma pointwiselub_islubpointwise {D D' : dcpo} {I : UU}
@@ -339,7 +339,7 @@ Lemma pointwiselub_islubpointwise {D D' : dcpo} {I : UU}
 Proof.
   intro d.
   set (ptfamdir := pointwisefamily_isdirected F isdirec d).
-  exact (dcpo_mklub_islub ptfamdir).
+  exact (dcpo_make_lub_islub ptfamdir).
 Qed.
 
 Lemma pointwiselub_preservesorder {D D' : dcpo} {I : UU}
@@ -380,7 +380,7 @@ Qed.
 
 Lemma pointwiselub_islub {D D' : dcpo} {I : UU}
       (F : I -> posetofdcpomorphisms D D') (isdirec : isdirected F) :
-  islub F (mkdcpomorphism (pointwiselub F isdirec)
+  islub F (make_dcpomorphism (pointwiselub F isdirec)
                             (pointwiselub_isdcpomorphism' F isdirec)).
 Proof.
   split.
@@ -396,7 +396,7 @@ Lemma islub_islubpointwise {D D' : dcpo} {I : UU} {g : posetofdcpomorphisms D D'
   islub F g -> ∏ (d : D), islub (pointwisefamily F d) (pr1 g d).
 Proof.
   intros islubFg d.
-  set (ptlub := mkdcpomorphism (pointwiselub F isdirec)
+  set (ptlub := make_dcpomorphism (pointwiselub F isdirec)
                                (pointwiselub_isdcpomorphism' F isdirec)).
   assert (lubeq : g = ptlub).
   { apply (lubsareunique F islubFg).
@@ -409,7 +409,7 @@ Lemma posetofdcpomorphisms_isdirectedcomplete (D D' : dcpo) :
   isdirectedcomplete (posetofdcpomorphisms D D').
 Proof.
   intros I F isdirec.
-  exists (mkdcpomorphism (pointwiselub F isdirec)
+  exists (make_dcpomorphism (pointwiselub F isdirec)
                          (pointwiselub_isdcpomorphism' F isdirec)).
   apply pointwiselub_islub.
 Qed.
@@ -434,7 +434,7 @@ Definition dcpowithbottom_ofdcpomorphisms (D D' : dcpowithbottom) :
 Proof.
   exists (dcpoofdcpomorphisms D D').
   set (leastD' := dcpowithbottom_bottom D').
-  set (l := mkconst_dcpomor D D' leastD').
+  set (l := const_dcpomor D D' leastD').
   exists l.
   intro f. simpl. intro d.
   apply dcpowithbottom_isMinimal.
@@ -544,7 +544,7 @@ Qed.
 (** Iter as dcpo morphism *)
 Definition iter' {D : dcpowithbottom} (n : nat) : (D --> D) --> D.
 Proof.
-  eapply mkdcpomorphism.
+  eapply make_dcpomorphism.
   exact (iter_isdcpomorphism' D n).
 Defined.
 
@@ -584,7 +584,7 @@ Qed.
 
 Definition leastfixedpoint {D : dcpowithbottom} : (D --> D) --> D.
 Proof.
-  use mkdcpomorphism.
+  use make_dcpomorphism.
   - eapply pointwiselub.
     apply iter'_isdirected.
   - apply pointwiselub_isdcpomorphism'.

--- a/UniMath/Algebra/Dcpo.v
+++ b/UniMath/Algebra/Dcpo.v
@@ -109,14 +109,14 @@ Coercion dcpoposet : dcpo >-> Poset.
 Definition dcpoisdirectedcomplete (D : dcpo) : isdirectedcomplete D := pr2 D.
 Definition make_dcpo (X : Poset) (i : isdirectedcomplete X) : dcpo := (X,,i).
 
-Definition dcpo_make_lub {D : dcpo} {I : UU} {f : I -> D} : isdirected f -> D.
+Definition make_dcpo_lub {D : dcpo} {I : UU} {f : I -> D} : isdirected f -> D.
 Proof.
   intro isdirec.
   exact (pr1 (dcpoisdirectedcomplete D I f isdirec)).
 Defined.
 
-Definition dcpo_make_lub_islub {D : dcpo} {I : UU} {f : I -> D}
-           (isdirec : isdirected f) : islub f (dcpo_make_lub isdirec).
+Definition make_dcpo_lub_islub {D : dcpo} {I : UU} {f : I -> D}
+           (isdirec : isdirected f) : islub f (make_dcpo_lub isdirec).
 Proof.
   exact (pr2 (dcpoisdirectedcomplete D I f isdirec)).
 Defined.
@@ -330,7 +330,7 @@ Definition pointwiselub {D D' : dcpo} {I : UU}
 Proof.
   intro d.
   set (ptfamdir := pointwisefamily_isdirected F isdir d).
-  exact (dcpo_make_lub ptfamdir).
+  exact (make_dcpo_lub ptfamdir).
 Defined.
 
 Lemma pointwiselub_islubpointwise {D D' : dcpo} {I : UU}
@@ -339,7 +339,7 @@ Lemma pointwiselub_islubpointwise {D D' : dcpo} {I : UU}
 Proof.
   intro d.
   set (ptfamdir := pointwisefamily_isdirected F isdirec d).
-  exact (dcpo_make_lub_islub ptfamdir).
+  exact (make_dcpo_lub_islub ptfamdir).
 Qed.
 
 Lemma pointwiselub_preservesorder {D D' : dcpo} {I : UU}

--- a/UniMath/Algebra/Lattice/Bounded.v
+++ b/UniMath/Algebra/Lattice/Bounded.v
@@ -13,7 +13,7 @@ Definition bounded_latticeop {X : hSet} (l : lattice X) (bot top : X) :=
 Definition bounded_lattice (X : hSet) :=
   ∑ (l : lattice X) (bot top : X), bounded_latticeop l bot top.
 
-Definition mkbounded_lattice {X : hSet} {l : lattice X} {bot top : X} :
+Definition make_bounded_lattice {X : hSet} {l : lattice X} {bot top : X} :
   bounded_latticeop l bot top → bounded_lattice X := λ bl, l,, bot,, top,, bl.
 
 Definition bounded_lattice_to_lattice X : bounded_lattice X → lattice X := pr1.
@@ -46,7 +46,7 @@ End bounded_lattice_pty.
 
 Definition hProp_bounded_lattice : bounded_lattice (hProp,,isasethProp).
 Proof.
-use mkbounded_lattice.
+use make_bounded_lattice.
 - exact hProp_lattice.
 - exact hfalse.
 - exact htrue.

--- a/UniMath/Algebra/Lattice/Examples/Bool.v
+++ b/UniMath/Algebra/Lattice/Examples/Bool.v
@@ -12,7 +12,7 @@ Require Import UniMath.Algebra.Lattice.Boolean.
 
 Lemma boolset_lattice : lattice boolset.
 Proof.
-  use mklattice.
+  use make_lattice.
   - exact andb. (** [Lmin] *)
   - exact orb. (** [Lmax] *)
   - (** TODO: constructor for this *)
@@ -32,7 +32,7 @@ Proof.
 Qed.
 
 Lemma boolset_lattice_is_complemented :
-  complemented_structure (mkbounded_lattice boolset_lattice_is_bounded).
+  complemented_structure (make_bounded_lattice boolset_lattice_is_bounded).
 Proof.
   intros b.
   exists (negb b).
@@ -43,7 +43,7 @@ Qed.
 
 Definition boolset_bounded_lattice : bounded_lattice boolset.
 Proof.
-  use mkbounded_lattice.
+  use make_bounded_lattice.
   - exact boolset_lattice.
   - exact false.
   - exact true.

--- a/UniMath/Algebra/Lattice/Examples/Subsets.v
+++ b/UniMath/Algebra/Lattice/Examples/Subsets.v
@@ -104,7 +104,7 @@ Section Subsets.
 
   Lemma subset_lattice : lattice (subtype_set X).
   Proof.
-    use mklattice.
+    use make_lattice.
     - exact intersection_binop. (** [Lmin] *)
     - exact union_binop. (** [Lmax] *)
     - (** TODO: constructor for this *)
@@ -157,7 +157,7 @@ Section Subsets.
 
   (** Using [LEM], we can show the lattice is complemented *)
   Lemma subset_lattice_is_complemented :
-    LEM -> complemented_structure (mkbounded_lattice subset_lattice_is_bounded).
+    LEM -> complemented_structure (make_bounded_lattice subset_lattice_is_bounded).
   Proof.
     intros lem sub.
     exists (subtype_complement sub).
@@ -175,7 +175,7 @@ Section Subsets.
 
   Definition subset_bounded_lattice : bounded_lattice (subtype_set X).
   Proof.
-    use mkbounded_lattice.
+    use make_bounded_lattice.
     - exact subset_lattice.
     - exact (emptysubtype X).
     - exact (totalsubtype X).

--- a/UniMath/Algebra/Lattice/Lattice.v
+++ b/UniMath/Algebra/Lattice/Lattice.v
@@ -63,7 +63,7 @@ Qed.
 Definition lattice (X : hSet) :=
   ∑ min max : binop X, islatticeop min max.
 
-Definition mklattice {X : hSet} {min max : binop X} : islatticeop min max → lattice X :=
+Definition make_lattice {X : hSet} {min max : binop X} : islatticeop min max → lattice X :=
   λ (is : islatticeop min max), min,, max ,, is.
 
 Definition Lmin {X : hSet} (lat : lattice X) : binop X := pr1 lat.
@@ -1581,7 +1581,7 @@ Section hProp_lattice.
 
 Definition hProp_lattice : lattice (hProp,,isasethProp).
 Proof.
-use mklattice.
+use make_lattice.
 - intros P Q; exact (P ∧ Q).
 - simpl; intros P Q; exact (P ∨ Q).
 - repeat split.

--- a/UniMath/AlgebraicGeometry/Spec.v
+++ b/UniMath/AlgebraicGeometry/Spec.v
@@ -114,7 +114,7 @@ Section spec.
   Defined.
 
   Definition Spec : TopologicalSpace :=
-    mkTopologicalSpace (make_hSet (prime_ideal R) isaset_prime_ideal)
+    make_TopologicalSpace (make_hSet (prime_ideal R) isaset_prime_ideal)
                        zariski_topology
                        zariski_topology_union
                        zariski_topology_htrue

--- a/UniMath/Bicategories/BicatOfBicategory.v
+++ b/UniMath/Bicategories/BicatOfBicategory.v
@@ -5,8 +5,8 @@
  ********************************************************************************* *)
 
 (* ========================================================================= *)
-(* Every (pre)bicategory of UniMath.CategoryTheory.WkCatEnrichment is a      *)
-(* (pre)bicategory of UniMath.Bicategories.Bicat.             *)
+(* Every (pre)bicategory of UniMath.Bicategories.WkCatEnrichment is a      *)
+(* (pre)bicategory of UniMath.Bicategories.Core.Bicat.             *)
 (* ========================================================================= *)
 
 (* Note: an equivalence is established in WkCatEnrichment/hcomp_bicat.v *)

--- a/UniMath/Bicategories/BicategoryOfBicat.v
+++ b/UniMath/Bicategories/BicategoryOfBicat.v
@@ -5,8 +5,8 @@
  ********************************************************************************* *)
 
 (* =================================================================================== *)
-(* Every (pre)bicategory of UniMath.CategoryTheory.Bicat is a                          *)
-(* (pre)bicategory of UniMath.CategoryTheory.WkCatEnrichment.                          *)
+(* Every (pre)bicategory of UniMath.Bicategories.Core.Bicat is a                          *)
+(* (pre)bicategory of UniMath.Bicategories.WkCatEnrichment.                          *)
 (* =================================================================================== *)
 
 (* Note: an equivalence is established in WkCatEnrichment/hcomp_bicat.v *)

--- a/UniMath/Bicategories/MonoidalCategories/ActionBasedStrongFunctorsMonoidal.v
+++ b/UniMath/Bicategories/MonoidalCategories/ActionBasedStrongFunctorsMonoidal.v
@@ -1939,7 +1939,7 @@ Section Main.
     Qed.
 
     Definition montrafotargetbicat_moncat: monoidal_cat :=
-      mk_monoidal_cat montrafotargetbicat_cat
+      make_monoidal_cat montrafotargetbicat_cat
                       montrafotargetbicat_tensor
                       montrafotargetbicat_unit
                       montrafotargetbicat_left_unitor
@@ -2064,7 +2064,7 @@ Section Main.
       Qed.
 
       Definition lmf_from_param_distr_bicat: lax_monoidal_functor Mon_V montrafotargetbicat_moncat :=
-        mk_lax_monoidal_functor _ _
+        make_lax_monoidal_functor _ _
                                 lmf_from_param_distr_bicat_functor
                                 lmf_from_param_distr_bicat_ε
                                 lmf_from_param_distr_bicat_μ

--- a/UniMath/Bicategories/MonoidalCategories/EndofunctorsMonoidal.v
+++ b/UniMath/Bicategories/MonoidalCategories/EndofunctorsMonoidal.v
@@ -117,7 +117,7 @@ Qed.
 
 Definition monoidal_cat_of_endofunctors: monoidal_cat.
 Proof.
-  use mk_monoidal_cat.
+  use make_monoidal_cat.
   - exact EndC.
   - apply functorial_composition.
   - apply functor_identity.

--- a/UniMath/Bicategories/MonoidalCategories/MonoidalFromBicategory.v
+++ b/UniMath/Bicategories/MonoidalCategories/MonoidalFromBicategory.v
@@ -98,13 +98,13 @@ Proof.
   (* very slow with library elements:
   set (aux := rassociator_transf(C := C) c0 c0 c0 c0).
   set (aux' := pre_whisker (precategory_binproduct_unassoc _ _ _) aux).
-  use mk_nat_trans.
+  use make_nat_trans.
   - intro c. exact (pr1 aux' c).
   - apply (pr2 aux').
    *)
   (* still very slow with new additions to library:
   set (aux := rassociator_transf'(C := C) c0 c0 c0 c0).
-  use mk_nat_trans.
+  use make_nat_trans.
   - intro c. exact (pr1 aux c).
   - abstract ( apply (pr2 aux) ).
    *)
@@ -122,7 +122,7 @@ Defined.
 
 Definition monoidal_cat_from_bicat_and_ob: monoidal_cat.
 Proof.
-  use (mk_monoidal_cat category_from_bicat_and_ob tensor_from_bicat_and_ob (id c0) build_left_unitor build_right_unitor build_associator).
+  use (make_monoidal_cat category_from_bicat_and_ob tensor_from_bicat_and_ob (id c0) build_left_unitor build_right_unitor build_associator).
   - abstract ( intros a b; apply pathsinv0; apply unit_triangle ).
   - abstract ( intros a b c d; apply pathsinv0; apply associativity_pentagon ).
 Defined.

--- a/UniMath/Bicategories/MonoidalCategories/PointedFunctorsMonoidal.v
+++ b/UniMath/Bicategories/MonoidalCategories/PointedFunctorsMonoidal.v
@@ -235,7 +235,7 @@ Section PointedFunctors_as_monoidal_category.
 
   Definition monoidal_cat_of_pointedfunctors : monoidal_cat.
   Proof.
-    use mk_monoidal_cat.
+    use make_monoidal_cat.
     - exact Ptd.
     - apply tensor_pointedfunctors.
     - apply id_Ptd.
@@ -252,7 +252,7 @@ Section PointedFunctors_as_monoidal_category.
         (monoidal_cat_of_endofunctors C).
   Proof.
     use tpair.
-    - apply (mk_lax_monoidal_functor
+    - apply (make_lax_monoidal_functor
                monoidal_cat_of_pointedfunctors
                (monoidal_cat_of_endofunctors C)
                (functor_ptd_forget C)

--- a/UniMath/CategoryTheory/Inductives/PropositionalLogic.v
+++ b/UniMath/CategoryTheory/Inductives/PropositionalLogic.v
@@ -136,7 +136,7 @@ Infix "∨" := (PL_or) : PL.
 Infix "⇒" := (PL_impl) : PL.
 Infix "⇔" := (PL_iff_fun) (at level 90) : PL.
 
-Definition PL_mk_algebra (X : hSet) (vs : vars -> X) (not : X -> X)
+Definition make_PL_algebra (X : hSet) (vs : vars -> X) (not : X -> X)
            (and : X -> X -> X) (or : X -> X -> X) (impl : X -> X -> X) :
   algebra_ob PL_functor'.
 Proof.
@@ -154,9 +154,9 @@ Defined.
     other set, we can construct an interpretation of PL in that set. *)
 Definition PL_fold_alg_mor {X : hSet} (vs : vars -> X)
            (not : X -> X) (and : X -> X -> X) (or : X -> X -> X) (impl : X -> X -> X) :
-  algebra_mor PL_functor' PL_alg (PL_mk_algebra X vs not and or impl).
+  algebra_mor PL_functor' PL_alg (make_PL_algebra X vs not and or impl).
 Proof.
-  apply (InitialArrow PL_functor_initial (PL_mk_algebra X vs not and or impl)).
+  apply (InitialArrow PL_functor_initial (make_PL_algebra X vs not and or impl)).
 Defined.
 
 Definition PL_fold {X : hSet} (vs : vars -> X)

--- a/UniMath/CategoryTheory/Monads/KTriplesEquiv.v
+++ b/UniMath/CategoryTheory/Monads/KTriplesEquiv.v
@@ -535,7 +535,7 @@ Section Adjunction.
     set (aux := pr2 is_catiso).
     exact (invweq (make_weq _ aux)).
   Defined.
-(** This is the main result of [UniMath.CategoryTheory.Monad.Kleisli]. *)
+(** This is the main result of [UniMath.CategoryTheory.Monads.Kleisli]. *)
 
 
 End Adjunction.

--- a/UniMath/CategoryTheory/Monads/RelativeMonads.v
+++ b/UniMath/CategoryTheory/Monads/RelativeMonads.v
@@ -174,7 +174,7 @@ Arguments RelMonad_data {C} {D} J.
 Arguments RelMonad {C} {D} J.
 
 
-(** analogue of [UniMath.CategoryTheory.functor_categories.functor_eq_eq_from_functor_ob_eq] *)
+(** analogue of [UniMath.CategoryTheory.Core.Functors.functor_eq_eq_from_functor_ob_eq] *)
 Definition relmonad_eq_eq_from_relmonad_ob_eq {C: precategory_data} {D: precategory} (hs: has_homsets D)
            {J : functor C D} (R R' : RelMonad J) (p q : R = R')
     (H : base_paths _ _ (base_paths _ _ p) =

--- a/UniMath/CategoryTheory/Monoidal/AugmentedSimplexCategory.v
+++ b/UniMath/CategoryTheory/Monoidal/AugmentedSimplexCategory.v
@@ -872,7 +872,7 @@ Qed.
 
 Definition AugmentedSimplexCategory : monoidal_cat.
 Proof.
-  use mk_monoidal_cat.
+  use make_monoidal_cat.
   + exact Δ.
   + exact tensor_functor_ord.
   + exact tensor_unit.
@@ -885,7 +885,7 @@ Defined.
 
 Definition FinCard : monoidal_cat.
 Proof.
-  use mk_monoidal_cat.
+  use make_monoidal_cat.
   + exact Δ_sdg.
   + exact tensor_functor_card.
   + exact tensor_unit.
@@ -966,7 +966,7 @@ Qed.
 
 Definition U_Mon_Lax : lax_monoidal_functor AugmentedSimplexCategory FinCard.
 Proof.
-  use mk_lax_monoidal_functor.
+  use make_lax_monoidal_functor.
   + exact U.
   + exact U_ε.
   + exact U_μ.

--- a/UniMath/CategoryTheory/Monoidal/MonoidalCategories.v
+++ b/UniMath/CategoryTheory/Monoidal/MonoidalCategories.v
@@ -156,12 +156,12 @@ Definition monoidal_precat_struct : UU :=
   ∑ ρ' : right_unitor tensor I,
   ∑ α' : associator tensor, unit.
 
-Definition mk_monoidal_precat_struct (C: precategory)(tensor: C ⊠ C ⟶ C)(I: C)
+Definition make_monoidal_precat_struct (C: precategory)(tensor: C ⊠ C ⟶ C)(I: C)
   (λ': left_unitor tensor I)(ρ': right_unitor tensor I)(α': associator tensor): monoidal_precat_struct :=
   (C,, (tensor,, (I,, (λ',, (ρ',, (α',, tt)))))).
 *)
 
-Definition mk_monoidal_cat (C: category)(tensor: C ⊠ C ⟶ C)(I: C)
+Definition make_monoidal_cat (C: category)(tensor: C ⊠ C ⟶ C)(I: C)
   (λ': left_unitor tensor I)(ρ': right_unitor tensor I)(α': associator tensor)
   (eq1: triangle_eq tensor I λ' ρ' α')(eq2: pentagon_eq tensor α'): monoidal_cat :=
   (C,, (tensor,, (I,, (λ',, (ρ',, (α',, (eq1,, eq2))))))).
@@ -292,7 +292,7 @@ Qed.
 
 Definition swapping_of_monoidal_cat: monoidal_cat.
 Proof.
-  use (mk_monoidal_cat M swapping_of_tensor).
+  use (make_monoidal_cat M swapping_of_tensor).
   - exact (monoidal_cat_unit M).
   - apply monoidal_cat_right_unitor.
   - apply monoidal_cat_left_unitor.

--- a/UniMath/CategoryTheory/Monoidal/MonoidalFunctors.v
+++ b/UniMath/CategoryTheory/Monoidal/MonoidalFunctors.v
@@ -81,7 +81,7 @@ Definition lax_monoidal_functor : UU :=
   ∑ F : Mon_C ⟶ Mon_D, ∑ ϵ : I_D --> F I_C, ∑ μ : monoidal_functor_map F,
   (monoidal_functor_associativity F μ) × (monoidal_functor_unitality F ϵ μ).
 
-Definition mk_lax_monoidal_functor (F : Mon_C ⟶ Mon_D) (ϵ : I_D --> F I_C)
+Definition make_lax_monoidal_functor (F : Mon_C ⟶ Mon_D) (ϵ : I_D --> F I_C)
   (μ : monoidal_functor_map F) (Hass: monoidal_functor_associativity F μ)
   (Hunit: monoidal_functor_unitality F ϵ μ): lax_monoidal_functor :=
   (F,, (ϵ,, (μ,, (Hass,, Hunit)))).
@@ -192,7 +192,7 @@ Definition swapping_of_lax_monoidal_functor: lax_monoidal_functor Mon Mon' ->
 Proof.
   intro lmF.
   induction lmF as [F [ϵ [μ [Hass Hunit]]]].
-  use mk_lax_monoidal_functor.
+  use make_lax_monoidal_functor.
   - exact F.
   - exact ϵ.
   - exact (pre_whisker binswap_pair_functor μ).

--- a/UniMath/CategoryTheory/Presheaf.v
+++ b/UniMath/CategoryTheory/Presheaf.v
@@ -238,7 +238,7 @@ Defined.
 
 Definition sieve_lattice (c : C) : lattice (sieve c).
 Proof.
-use mklattice.
+use make_lattice.
 - apply intersection_sieve.
 - apply union_sieve.
 - repeat split; intros S1; intros;
@@ -253,7 +253,7 @@ Defined.
 
 Definition sieve_bounded_lattice (c : C) : bounded_lattice (sieve c).
 Proof.
-use mkbounded_lattice.
+use make_bounded_lattice.
 - apply sieve_lattice.
 - apply empty_sieve.
 - apply maximal_sieve.

--- a/UniMath/CategoryTheory/categories/HSET/Slice.v
+++ b/UniMath/CategoryTheory/categories/HSET/Slice.v
@@ -72,7 +72,7 @@ Section products_set_slice.
 (* The following is an experiment which computes what the product in Set/X
    should be from the one in [X,Set] using the equivalence between Set/X
    and [X,Set] *)
-(* Require Import UniMath.CategoryTheory.set_slice_fam_equiv. *)
+(* Require Import UniMath.CategoryTheory.categories.HSET.SliceFamEquiv. *)
 
 (* Lemma Products_HSET_slice I X : Products I (HSET / X). *)
 (* Proof. *)

--- a/UniMath/CategoryTheory/categories/HSET/SliceFamEquiv.v
+++ b/UniMath/CategoryTheory/categories/HSET/SliceFamEquiv.v
@@ -43,11 +43,11 @@ Section set_slice_fam_equiv.
   Local Definition fam (A : hSet) : category :=
     functor_category (discrete A) HSET.
 
-  Local Definition mkfam (f : X → hSet) : functor (discrete X) HSET :=
+  Local Definition make_fam (f : X → hSet) : functor (discrete X) HSET :=
     functor_path_pregroupoid _ (f : X → ob HSET).
 
   Definition slice_to_fam_fun (a : slice X) : fam X :=
-    mkfam (λ x : X, hfiber_hSet (pr2 a) x).
+    make_fam (λ x : X, hfiber_hSet (pr2 a) x).
 
   Local Notation s_to_f := slice_to_fam_fun.
 

--- a/UniMath/CategoryTheory/limits/graphs/eqdiag.v
+++ b/UniMath/CategoryTheory/limits/graphs/eqdiag.v
@@ -23,7 +23,7 @@ J and J' are not definitionnally equal.
 Let co a cone of J based on c.
 
 Using a (not too stupid) proof (e : eq_diag J J'), we can transport the cone co
-with eq_diag_mkcone to get a cone co' of J' based on c that satisfies the
+with make_eq_diag_cone to get a cone co' of J' based on c that satisfies the
 definitional equalities :
   coneOut co' true  ≡ coneOut co true
   coneOut co' false ≡ coneOut co false
@@ -164,7 +164,7 @@ Proof.
 
 Defined.
 
-Lemma eq_diag_mkcocone  :
+Lemma make_eq_diag_cocone  :
   ∏ {C : category} {g : graph} {d : diagram g C}
     (d' : diagram g C)
     (heq_d: eq_diag d d')
@@ -197,7 +197,7 @@ Defined.
 
 
 (* The dual proof *)
-Lemma eq_diag_mkcone  :
+Lemma make_eq_diag_cone  :
   ∏ {C : category} {g : graph} {d : diagram g C}
     (d' : diagram g C)
     (heq_d: eq_diag d d')
@@ -238,7 +238,7 @@ Lemma eq_diag_islimcone:
     (eq_d : eq_diag d d')
     {c : C} {cc:cone d c}
     (islimcone : isLimCone _ _ cc) ,
-  isLimCone _ _ (eq_diag_mkcone d' eq_d cc).
+  isLimCone _ _ (make_eq_diag_cone d' eq_d cc).
 Proof.
 
   intros.
@@ -249,7 +249,7 @@ Proof.
   set (eq_d2' := pr2 eq_d').
     red.
   intros c' cc'.
-  set (cc'2 := eq_diag_mkcone _ eq_d' cc').
+  set (cc'2 := make_eq_diag_cone _ eq_d' cc').
   specialize (islimcone c' cc'2).
   apply (unique_exists (pr1 (pr1 islimcone))).
   - intro v.
@@ -290,7 +290,7 @@ Lemma eq_diag_iscolimcocone:
     (eq_d : eq_diag d d')
     {c : C} {cc:cocone d c}
     (islimcone : isColimCocone _ _ cc) ,
-  isColimCocone _ _ (eq_diag_mkcocone d' eq_d cc).
+  isColimCocone _ _ (make_eq_diag_cocone d' eq_d cc).
 Proof.
   intros.
   destruct eq_d as [eq_d1 eq_d2].
@@ -301,7 +301,7 @@ Proof.
   set (eq_d'  := (eq_d1',,eq_d2'):eq_diag d' d).
   red.
   intros c' cc'.
-  set (cc'2 := eq_diag_mkcocone _ eq_d' cc').
+  set (cc'2 := make_eq_diag_cocone _ eq_d' cc').
   specialize (islimcone c' cc'2).
   apply (unique_exists (pr1 (pr1 islimcone))).
   - intro v.

--- a/UniMath/Combinatorics/MoreLists.v
+++ b/UniMath/Combinatorics/MoreLists.v
@@ -33,7 +33,7 @@ Local Open Scope list_scope.
 (** ** Proofs that [cons] is injective on both arguments.
 
 Introduces the [head] and [tail] operations on lists, using the maybe monad defined in
-[UniMath.Algebra.Universal.Maybe] for dealing with invalid function applications. Then, proves
+[UniMath.Combinatorics.Maybe] for dealing with invalid function applications. Then, proves
 that [cons] is injective on both arguments and that there are no paths between [cons] and [nil].
 *)
 

--- a/UniMath/MoreFoundations/Orders.v
+++ b/UniMath/MoreFoundations/Orders.v
@@ -4,6 +4,23 @@ Require Import UniMath.MoreFoundations.Propositions.
 Require Import UniMath.MoreFoundations.Sets.
 
 
+(** * Preorders *)
+(** [po] is defined in [Foundations.Sets], but with some access functions missing *)
+
+Section po_pty.
+
+Context {X : UU}.
+Context (R : po X).
+
+Definition istrans_po : istrans R :=
+  pr1 (pr2 R).
+Definition isrefl_po : isrefl R :=
+  pr2 (pr2 R).
+
+End po_pty.
+
+
+
 (** * Strong orders *)
 (** A _strong ordering_ is a transitive, irreflexive, and cotransitive relation.
 
@@ -94,3 +111,116 @@ Qed.
 Definition StrongOrder_setquot {X : UU} {R : eqrel X} {L : StrongOrder X}
            (is : iscomprelrel R L) : StrongOrder (setquot R) :=
   quotrel is,, isStrongOrder_setquot is (pr2 L).
+
+
+(** * Reverse orders *)
+(** or how easily define ge x y := le x y *)
+
+Definition hrel_reverse {X : UU} (l : hrel X) := λ x y, l y x.
+
+Lemma istrans_reverse {X : UU} (l : hrel X) :
+  istrans l → istrans (hrel_reverse l).
+Proof.
+  intros Hl x y z Hxy Hyz.
+  now apply (Hl z y x).
+Qed.
+
+Lemma isrefl_reverse {X : UU} (l : hrel X) :
+  isrefl l → isrefl (hrel_reverse l).
+Proof.
+  intros Hl x.
+  now apply Hl.
+Qed.
+
+Lemma ispreorder_reverse {X : UU} (l : hrel X) :
+  ispreorder l → ispreorder (hrel_reverse l).
+Proof.
+  intros H.
+  split.
+  now apply istrans_reverse, (pr1 H).
+  now apply isrefl_reverse, (pr2 H).
+Qed.
+Definition po_reverse {X : UU} (l : po X) :=
+  make_po (hrel_reverse l) (ispreorder_reverse l (pr2 l)).
+Lemma po_reverse_correct {X : UU} (l : po X) :
+  ∏ x y : X, po_reverse l x y = l y x.
+Proof.
+  intros x y.
+  now apply paths_refl.
+Qed.
+
+Lemma issymm_reverse {X : UU} (l : hrel X) :
+  issymm l → issymm (hrel_reverse l).
+Proof.
+  intros Hl x y.
+  now apply Hl.
+Qed.
+
+Lemma iseqrel_reverse {X : UU} (l : hrel X) :
+  iseqrel l → iseqrel (hrel_reverse l).
+Proof.
+  intros H.
+  split.
+  now apply ispreorder_reverse, (pr1 H).
+  now apply issymm_reverse, (pr2 H).
+Qed.
+Definition eqrel_reverse {X : UU} (l : eqrel X) :=
+  make_eqrel (hrel_reverse l) (iseqrel_reverse l (pr2 l)).
+Lemma eqrel_reverse_correct {X : UU} (l : eqrel X) :
+  ∏ x y : X, eqrel_reverse l x y = l y x.
+Proof.
+  intros x y.
+  now apply paths_refl.
+Qed.
+
+Lemma isirrefl_reverse {X : UU} (l : hrel X) :
+  isirrefl l → isirrefl (hrel_reverse l).
+Proof.
+  intros Hl x.
+  now apply Hl.
+Qed.
+Lemma iscotrans_reverse {X : UU} (l : hrel X) :
+  iscotrans l -> iscotrans (hrel_reverse l).
+Proof.
+  intros Hl x y z H.
+  now apply islogeqcommhdisj, Hl.
+Qed.
+
+Lemma isStrongOrder_reverse {X : UU} (l : hrel X) :
+  isStrongOrder l → isStrongOrder (hrel_reverse l).
+Proof.
+  intros H.
+  repeat split.
+  - apply istrans_reverse, (istrans_isStrongOrder H).
+  - apply iscotrans_reverse,(iscotrans_isStrongOrder H).
+  - apply isirrefl_reverse, (isirrefl_isStrongOrder H).
+Qed.
+Definition StrongOrder_reverse {X : UU} (l : StrongOrder X) :=
+  make_StrongOrder (hrel_reverse l) (isStrongOrder_reverse l (pr2 l)).
+Lemma StrongOrder_reverse_correct {X : UU} (l : StrongOrder X) :
+  ∏ x y : X, StrongOrder_reverse l x y = l y x.
+Proof.
+  intros x y.
+  now apply paths_refl.
+Qed.
+
+Lemma isasymm_reverse {X : UU} (l : hrel X) :
+  isasymm l → isasymm (hrel_reverse l).
+Proof.
+  intros Hl x y.
+  now apply Hl.
+Qed.
+
+Lemma iscoasymm_reverse {X : UU} (l : hrel X) :
+  iscoasymm l → iscoasymm (hrel_reverse l).
+Proof.
+  intros Hl x y.
+  now apply Hl.
+Qed.
+
+Lemma istotal_reverse {X : UU} (l : hrel X) :
+  istotal l → istotal (hrel_reverse l).
+Proof.
+  intros Hl x y.
+  now apply Hl.
+Qed.

--- a/UniMath/RealNumbers/Sets.v
+++ b/UniMath/RealNumbers/Sets.v
@@ -13,9 +13,7 @@ Require Import UniMath.Algebra.BinaryOperations
                UniMath.Algebra.Apartness
                UniMath.Algebra.Lattice.Lattice.
 
-(** ** Additional definitions *)
-
-Definition unop (X : UU) := X → X.
+(** * Partially-defined inverse functions *)
 
 Definition islinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtype X) (inv : subset exinv -> X) :=
   ∏ (x : X) (Hx : exinv x), op (inv (x ,, Hx)) x = x1.
@@ -24,134 +22,8 @@ Definition isrinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtype X) (inv 
 Definition isinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtype X) (inv : subset exinv -> X)  :=
   islinv' x1 op exinv inv × isrinv' x1 op exinv inv.
 
-(** ** Properties of [po] *)
-
-Section po_pty.
-
-Context {X : UU}.
-Context (R : po X).
-
-Definition istrans_po : istrans R :=
-  pr1 (pr2 R).
-Definition isrefl_po : isrefl R :=
-  pr2 (pr2 R).
-
-End po_pty.
-
-(** ** Reverse orderse *)
-(** or how easily define ge x y := le x y *)
-
-Definition hrel_reverse {X : UU} (l : hrel X) := λ x y, l y x.
-
-Lemma istrans_reverse {X : UU} (l : hrel X) :
-  istrans l → istrans (hrel_reverse l).
-Proof.
-  intros Hl x y z Hxy Hyz.
-  now apply (Hl z y x).
-Qed.
-
-Lemma isrefl_reverse {X : UU} (l : hrel X) :
-  isrefl l → isrefl (hrel_reverse l).
-Proof.
-  intros Hl x.
-  now apply Hl.
-Qed.
-
-Lemma ispreorder_reverse {X : UU} (l : hrel X) :
-  ispreorder l → ispreorder (hrel_reverse l).
-Proof.
-  intros H.
-  split.
-  now apply istrans_reverse, (pr1 H).
-  now apply isrefl_reverse, (pr2 H).
-Qed.
-Definition po_reverse {X : UU} (l : po X) :=
-  make_po (hrel_reverse l) (ispreorder_reverse l (pr2 l)).
-Lemma po_reverse_correct {X : UU} (l : po X) :
-  ∏ x y : X, po_reverse l x y = l y x.
-Proof.
-  intros x y.
-  now apply paths_refl.
-Qed.
-
-Lemma issymm_reverse {X : UU} (l : hrel X) :
-  issymm l → issymm (hrel_reverse l).
-Proof.
-  intros Hl x y.
-  now apply Hl.
-Qed.
-
-Lemma iseqrel_reverse {X : UU} (l : hrel X) :
-  iseqrel l → iseqrel (hrel_reverse l).
-Proof.
-  intros H.
-  split.
-  now apply ispreorder_reverse, (pr1 H).
-  now apply issymm_reverse, (pr2 H).
-Qed.
-Definition eqrel_reverse {X : UU} (l : eqrel X) :=
-  make_eqrel (hrel_reverse l) (iseqrel_reverse l (pr2 l)).
-Lemma eqrel_reverse_correct {X : UU} (l : eqrel X) :
-  ∏ x y : X, eqrel_reverse l x y = l y x.
-Proof.
-  intros x y.
-  now apply paths_refl.
-Qed.
-
-Lemma isirrefl_reverse {X : UU} (l : hrel X) :
-  isirrefl l → isirrefl (hrel_reverse l).
-Proof.
-  intros Hl x.
-  now apply Hl.
-Qed.
-Lemma iscotrans_reverse {X : UU} (l : hrel X) :
-  iscotrans l -> iscotrans (hrel_reverse l).
-Proof.
-  intros Hl x y z H.
-  now apply islogeqcommhdisj, Hl.
-Qed.
-
-Lemma isStrongOrder_reverse {X : UU} (l : hrel X) :
-  isStrongOrder l → isStrongOrder (hrel_reverse l).
-Proof.
-  intros H.
-  repeat split.
-  - apply istrans_reverse, (istrans_isStrongOrder H).
-  - apply iscotrans_reverse,(iscotrans_isStrongOrder H).
-  - apply isirrefl_reverse, (isirrefl_isStrongOrder H).
-Qed.
-Definition StrongOrder_reverse {X : UU} (l : StrongOrder X) :=
-  make_StrongOrder (hrel_reverse l) (isStrongOrder_reverse l (pr2 l)).
-Lemma StrongOrder_reverse_correct {X : UU} (l : StrongOrder X) :
-  ∏ x y : X, StrongOrder_reverse l x y = l y x.
-Proof.
-  intros x y.
-  now apply paths_refl.
-Qed.
-
-Lemma isasymm_reverse {X : UU} (l : hrel X) :
-  isasymm l → isasymm (hrel_reverse l).
-Proof.
-  intros Hl x y.
-  now apply Hl.
-Qed.
-
-Lemma iscoasymm_reverse {X : UU} (l : hrel X) :
-  iscoasymm l → iscoasymm (hrel_reverse l).
-Proof.
-  intros Hl x y.
-  now apply Hl.
-Qed.
-
-Lemma istotal_reverse {X : UU} (l : hrel X) :
-  istotal l → istotal (hrel_reverse l).
-Proof.
-  intros Hl x y.
-  now apply Hl.
-Qed.
-
-(** ** Effectively Ordered *)
-(** An alternative of total orders *)
+(** * Effective Orders *)
+(** An alternative to total orders *)
 
 Definition isEffectiveOrder {X : UU} (le lt : hrel X) :=
   dirprod ((ispreorder le) × (isStrongOrder lt))

--- a/UniMath/SubstitutionSystems/ActionBasedStrengthOnHomsInBicat.v
+++ b/UniMath/SubstitutionSystems/ActionBasedStrengthOnHomsInBicat.v
@@ -281,7 +281,7 @@ Section a_different_type_for_the_forgetful_functor_from_ptd.
                                               (monoidal_cat_from_bicat_and_ob (C:=bicat_of_cats) C).
   Proof.
     use tpair.
-    - apply (mk_lax_monoidal_functor (monoidal_cat_of_pointedfunctors C)
+    - apply (make_lax_monoidal_functor (monoidal_cat_of_pointedfunctors C)
                        (monoidal_cat_from_bicat_and_ob (C:=bicat_of_cats) C)
                        functor_ptd_forget_alt (nat_trans_id _) aux).
       + abstract

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -65,7 +65,7 @@ Definition BindingSigIsaset (s : BindingSig) : isaset (BindingSigIndex s) :=
 Definition BindingSigMap (s : BindingSig) : BindingSigIndex s -> list nat :=
   pr2 (pr2 s).
 
-Definition mkBindingSig {I : UU} (h : isaset I) (f : I -> list nat) : BindingSig := (I,,h,,f).
+Definition make_BindingSig {I : UU} (h : isaset I) (f : I -> list nat) : BindingSig := (I,,h,,f).
 
 (** Sum of binding signatures *)
 Definition SumBindingSig : BindingSig -> BindingSig -> BindingSig.

--- a/UniMath/SubstitutionSystems/CCS.v
+++ b/UniMath/SubstitutionSystems/CCS.v
@@ -129,7 +129,7 @@ el is 0 and ty is 1) and to the right as a multisorted signature:
 (** The multisorted signature of CC-S *)
 Definition CCS_Sig : MultiSortedSig sort.
 Proof.
-use mkMultiSortedSig.
+use make_MultiSortedSig.
 - exact (stn 6,,isasetstn 6).
 - apply six_rec.
   + exact ((([],,ty) :: (cons el [],,ty) :: nil),,ty).

--- a/UniMath/SubstitutionSystems/CCS_alt.v
+++ b/UniMath/SubstitutionSystems/CCS_alt.v
@@ -146,7 +146,7 @@ This grammar then gives 6 operations, to the left as Vladimir's restricted
 (** The multisorted signature of CC-S *)
 Definition CCS_Sig : MultiSortedSig sort.
 Proof.
-use mkMultiSortedSig.
+use make_MultiSortedSig.
 - exact (stn 6,,isasetstn 6).
 - apply six_rec.
   + exact ((([],,ty) :: (cons el [],,ty) :: nil),,ty).

--- a/UniMath/SubstitutionSystems/LamFromBindingSig.v
+++ b/UniMath/SubstitutionSystems/LamFromBindingSig.v
@@ -76,7 +76,7 @@ Local Notation "'1'" := (functor_identity HSET).
 
 (** The signature of the lambda calculus: { [0,0], [1] } *)
 Definition LamSig : BindingSig :=
-  mkBindingSig isasetbool (λ b, if b then 0 :: 0 :: [] else 1 :: [])%nat.
+  make_BindingSig isasetbool (λ b, if b then 0 :: 0 :: [] else 1 :: [])%nat.
 
 (** The signature with strength for the lambda calculus *)
 Definition LamSignature : Signature HSET _ _ :=

--- a/UniMath/SubstitutionSystems/MLTT79.v
+++ b/UniMath/SubstitutionSystems/MLTT79.v
@@ -116,16 +116,16 @@ Local Notation "[0,0,2]" := (0 :: 0 :: 2 :: []).
 Local Notation "[0,1,1]" := (0 :: 1 :: 1 :: []).
 
 Definition PiSig : BindingSig :=
-  mkBindingSig (isasetstn 3) (three_rec [0,1] [1] [0,0]).
+  make_BindingSig (isasetstn 3) (three_rec [0,1] [1] [0,0]).
 
 Definition SigmaSig : BindingSig :=
-  mkBindingSig (isasetstn 3) (three_rec [0,1] [0,0] [0,2]).
+  make_BindingSig (isasetstn 3) (three_rec [0,1] [0,0] [0,2]).
 
 Definition SumSig : BindingSig :=
-  mkBindingSig (isasetstn 4) (four_rec [0,0] [0] [0] [0,1,1]).
+  make_BindingSig (isasetstn 4) (four_rec [0,0] [0] [0] [0,1,1]).
 
 Definition IdSig : BindingSig :=
-  mkBindingSig (isasetstn 3) (three_rec [0,0,0] [] [0,0]).
+  make_BindingSig (isasetstn 3) (three_rec [0,0,0] [] [0,0]).
 
 (** Define the arity of the eliminators for Fin by recursion *)
 Definition FinSigElim (n : nat) : list nat.
@@ -176,15 +176,15 @@ Proof.
     apply isdeceqstn.
 Defined.
 
-Definition FinSig : BindingSig := mkBindingSig isasetFinSig FinSigFun.
+Definition FinSig : BindingSig := make_BindingSig isasetFinSig FinSigFun.
 
 Definition NatSig : BindingSig :=
-  mkBindingSig (isasetstn 4) (four_rec [] [] [0] [0,0,2]).
+  make_BindingSig (isasetstn 4) (four_rec [] [] [0] [0,0,2]).
 
 Definition WSig : BindingSig :=
-  mkBindingSig (isasetstn 3) (three_rec [0,1] [0,0] [0,3]).
+  make_BindingSig (isasetstn 3) (three_rec [0,1] [0,0] [0,3]).
 
-Definition USig : BindingSig := mkBindingSig isasetnat (λ _, []).
+Definition USig : BindingSig := make_BindingSig isasetnat (λ _, []).
 
 Let SigHSET := Signature HSET HSET HSET.
 

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -104,7 +104,7 @@ Definition ops (M : MultiSortedSig) : hSet := pr1 M.
 Definition arity (M : MultiSortedSig) : ops M → list (list sort × sort) × sort :=
   λ x, pr2 M x.
 
-Definition mkMultiSortedSig {I : hSet}
+Definition make_MultiSortedSig {I : hSet}
   (ar : I → list (list sort × sort) × sort) : MultiSortedSig := (I,,ar).
 
 

--- a/UniMath/SubstitutionSystems/MultiSorted_alt.v
+++ b/UniMath/SubstitutionSystems/MultiSorted_alt.v
@@ -115,7 +115,7 @@ Definition ops (M : MultiSortedSig) : hSet := pr1 M.
 Definition arity (M : MultiSortedSig) : ops M → list (list sort × sort) × sort :=
   λ x, pr2 M x.
 
-Definition mkMultiSortedSig {I : hSet}
+Definition make_MultiSortedSig {I : hSet}
   (ar : I → list (list sort × sort) × sort) : MultiSortedSig := (I,,ar).
 
 (** Sum of multisorted binding signatures *)

--- a/UniMath/SubstitutionSystems/PCF_alt.v
+++ b/UniMath/SubstitutionSystems/PCF_alt.v
@@ -142,7 +142,7 @@ then taking the sum of the signatures.
 
 Definition PCF_Consts : MultiSortedSig type.
 Proof.
-use mkMultiSortedSig.
+use make_MultiSortedSig.
 - exact ((nat,,isasetnat) + (stn 6,,isasetstn 6))%set.
 - induction 1 as [n|i].
   + exact ([],,Nat).                                   (* Nat (one for each nat) *)
@@ -158,7 +158,7 @@ Defined.
 (* We could define PCF as follows, but we instead get App and Lam from the STLC signature *)
 (* Definition PCF : MultiSortedSig type. *)
 (* Proof. *)
-(* use mkMultiSortedSig. *)
+(* use make_MultiSortedSig. *)
 (* - apply (type + (type × type) + (type × type) + type)%set. *)
 (* - intros [[[t|[t s]]|[t s]]|t]. *)
 (*   * exact ([],,t).                                  (* Bottom *) *)
@@ -169,7 +169,7 @@ Defined.
 
 Definition PCF_Bot_Y : MultiSortedSig type.
 Proof.
-use mkMultiSortedSig.
+use make_MultiSortedSig.
 - apply (type + type)%set.
 - intros [t|t].
   * exact ([],,t).                                  (* Bottom *)

--- a/UniMath/SubstitutionSystems/STLC.v
+++ b/UniMath/SubstitutionSystems/STLC.v
@@ -85,7 +85,7 @@ Defined.
 (** The signature of the simply typed lambda calculus *)
 Definition STLC_Sig : MultiSortedSig sort.
 Proof.
-use mkMultiSortedSig.
+use make_MultiSortedSig.
 - apply ((sort × sort) + (sort × sort))%set. (* todo: fix this once level of × is fixed *)
 - intros H; induction H as [st|st]; induction st as [s t].
   + exact ((([],,arr s t) :: ([],,s) :: nil),,t).

--- a/UniMath/SubstitutionSystems/STLC_alt.v
+++ b/UniMath/SubstitutionSystems/STLC_alt.v
@@ -96,7 +96,7 @@ Defined.
 (** The signature of the simply typed lambda calculus *)
 Definition STLC_Sig : MultiSortedSig sort.
 Proof.
-use mkMultiSortedSig.
+use make_MultiSortedSig.
 - apply ((sort × sort) + (sort × sort))%set.
 - intros H; induction H as [st|st]; induction st as [s t].
   + exact ((([],,(s ⇒ t)) :: ([],,s) :: nil),,t).

--- a/UniMath/Topology/Filters.v
+++ b/UniMath/Topology/Filters.v
@@ -102,7 +102,7 @@ Definition isPreFilter {X : UU} (F : (X → hProp) → hProp) :=
   isfilter_imply F × isfilter_finite_intersection F.
 Definition PreFilter (X : UU) :=
   ∑ (F : (X → hProp) → hProp), isPreFilter F.
-Definition mkPreFilter {X : UU} (F : (X → hProp) → hProp)
+Definition make_PreFilter {X : UU} (F : (X → hProp) → hProp)
            (Himpl : isfilter_imply F)
            (Htrue : isfilter_htrue F)
            (Hand : isfilter_and F) : PreFilter X :=
@@ -117,7 +117,7 @@ Definition Filter (X : UU) := ∑ F : (X → hProp) → hProp, isFilter F.
 Definition pr1Filter (X : UU) (F : Filter X) : PreFilter X :=
   pr1 F,, pr1 (pr2 F).
 Coercion pr1Filter : Filter >-> PreFilter.
-Definition mkFilter {X : UU} (F : (X → hProp) → hProp)
+Definition make_Filter {X : UU} (F : (X → hProp) → hProp)
            (Himp : isfilter_imply F)
            (Htrue : isfilter_htrue F)
            (Hand : isfilter_and F)
@@ -321,7 +321,7 @@ End filterim.
 
 Definition PreFilterIm {X Y : UU} (f : X → Y) (F : PreFilter X) : PreFilter Y.
 Proof.
-  simple refine (mkPreFilter _ _ _ _).
+  simple refine (make_PreFilter _ _ _ _).
   exact (filterim f F).
   apply filterim_imply, filter_imply.
   apply filterim_htrue, filter_htrue.
@@ -447,7 +447,7 @@ End filterdom.
 
 Definition PreFilterDom {X : UU} (F : PreFilter X) (dom : X → hProp) : PreFilter X.
 Proof.
-  simple refine (mkPreFilter _ _ _ _).
+  simple refine (make_PreFilter _ _ _ _).
   - exact (filterdom F dom).
   - apply filterdom_imply, filter_imply.
   - apply filterdom_htrue.
@@ -526,7 +526,7 @@ End filtersubtype.
 
 Definition PreFilterSubtype {X : UU} (F : PreFilter X) (dom : X → hProp) : PreFilter (∑ x : X, dom x).
 Proof.
-  simple refine (mkPreFilter _ _ _ _).
+  simple refine (make_PreFilter _ _ _ _).
   - exact (filtersubtype F dom).
   - apply filtersubtype_imply, filter_imply.
   - apply filtersubtype_htrue.
@@ -634,7 +634,7 @@ End filterdirprod.
 
 Definition PreFilterDirprod {X Y : UU} (Fx : PreFilter X) (Fy : PreFilter Y) : PreFilter (X × Y).
 Proof.
-  simple refine (mkPreFilter _ _ _ _).
+  simple refine (make_PreFilter _ _ _ _).
   - exact (filterdirprod Fx Fy).
   - apply filterdirprod_imply.
   - apply filterdirprod_htrue.
@@ -763,7 +763,7 @@ End filternat.
 
 Definition FilterNat : Filter nat.
 Proof.
-  simple refine (mkFilter _ _ _ _ _).
+  simple refine (make_Filter _ _ _ _ _).
   - apply filternat.
   - apply filternat_imply.
   - apply filternat_htrue.
@@ -816,7 +816,7 @@ End filtertop.
 
 Definition PreFilterTop {X : UU} : PreFilter X.
 Proof.
-  simple refine (mkPreFilter _ _ _ _).
+  simple refine (make_PreFilter _ _ _ _).
   - exact filtertop.
   - exact filtertop_imply.
   - exact filtertop_htrue.
@@ -902,7 +902,7 @@ End filterintersection.
 Definition PreFilterIntersection {X : UU} (FF : PreFilter X → hProp) : PreFilter X.
 Proof.
   intros.
-  simple refine (mkPreFilter _ _ _ _).
+  simple refine (make_PreFilter _ _ _ _).
   - apply (filterintersection _ FF).
   - apply filterintersection_imply.
     intros F _.
@@ -918,7 +918,7 @@ Defined.
 Definition FilterIntersection {X : UU} (FF : Filter X → hProp)
            (Hff : ∃ F : Filter X, FF F) : Filter X.
 Proof.
-  simple refine (mkFilter _ _ _ _ _).
+  simple refine (make_Filter _ _ _ _ _).
   - apply (filterintersection _ FF).
   - apply filterintersection_imply.
     intros F _.
@@ -1043,7 +1043,7 @@ End filtergenerated.
 
 Definition PreFilterGenerated {X : UU} (L : (X → hProp) → hProp) : PreFilter X.
 Proof.
-  simple refine (mkPreFilter _ _ _ _).
+  simple refine (make_PreFilter _ _ _ _).
   - apply (filtergenerated L).
   - apply filtergenerated_imply.
   - apply filtergenerated_htrue.
@@ -1433,7 +1433,7 @@ End filterbase.
 
 Definition PreFilterBase {X : UU} (base : BaseOfPreFilter X) : PreFilter X.
 Proof.
-  simple refine (mkPreFilter _ _ _ _).
+  simple refine (make_PreFilter _ _ _ _).
   - apply (filterbase base).
   - apply filterbase_imply.
   - apply filterbase_htrue, BaseOfPreFilter_notempty.

--- a/UniMath/Topology/Topology.v
+++ b/UniMath/Topology/Topology.v
@@ -99,7 +99,7 @@ Definition isTopologicalSpace (X : hSet) :=
   ∑ O : (X → hProp) → hProp, isSetOfOpen O.
 Definition TopologicalSpace := ∑ X : hSet, isTopologicalSpace X.
 
-Definition mkTopologicalSpace (X : hSet) (O : (X → hProp) → hProp)
+Definition make_TopologicalSpace (X : hSet) (O : (X → hProp) → hProp)
            (is : isSetOfOpen_union O)
            (is0 : isSetOfOpen_htrue O)
            (is1 : isSetOfOpen_and O) : TopologicalSpace :=
@@ -308,7 +308,7 @@ End Neighborhood.
 
 Definition locally {T : TopologicalSpace} (x : T) : Filter T.
 Proof.
-  simple refine (mkFilter _ _ _ _ _).
+  simple refine (make_Filter _ _ _ _ _).
   - apply (neighborhood x).
   - abstract (intros A B ;
               apply neighborhood_imply).
@@ -468,7 +468,7 @@ Definition TopologyFromNeighborhood {X : hSet}
   (H : isNeighborhood N)
   : TopologicalSpace.
 Proof.
-  use mkTopologicalSpace.
+  use make_TopologicalSpace.
   - apply X.
   - intros A.
     simple refine (make_hProp _ _).
@@ -1001,7 +1001,7 @@ End locally_base.
 
 Definition locally_base {T : TopologicalSpace} (x : T) (base : base_of_neighborhood x) : Filter T.
 Proof.
-  simple refine (mkFilter _ _ _ _ _).
+  simple refine (make_Filter _ _ _ _ _).
   - apply (neighborhood' x base).
   - apply locally_base_imply.
   - apply locally_base_htrue.


### PR DESCRIPTION
Several small pieces of tidying-up I’d noted during recent work on other PR’s:

- renamed constructor functions named `mk…` to `make_…`, to follow our main convention (established in #1216)
- updated some internal references in comments, which had gone out-of-date when filenames/locations changed
- upstreamed some of the material of [RealNumbers.Sets] to [MoreFoundations.Orders] (and removed a little redundant material)