### PR TITLE
the shallow corrections to ensure focus in package SubstitutionSystems

### DIFF
--- a/UniMath/SubstitutionSystems/ActionBasedStrengthOnHomsInBicat.v
+++ b/UniMath/SubstitutionSystems/ActionBasedStrengthOnHomsInBicat.v
@@ -32,6 +32,7 @@ Require Import UniMath.SubstitutionSystems.Signatures.
 Require Import UniMath.SubstitutionSystems.SignatureCategory.
 Require Import UniMath.CategoryTheory.Core.Univalence.
 
+Export Set Default Goal Selector "!".
 
 Import Bicat.Notations.
 

--- a/UniMath/SubstitutionSystems/ApplicationsGenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/ApplicationsGenMendlerIteration_alt.v
@@ -30,6 +30,7 @@ Require Import UniMath.SubstitutionSystems.GenMendlerIteration_alt.
 Require Import UniMath.CategoryTheory.Monoidal.WhiskeredBifunctors.
 Require Import UniMath.CategoryTheory.Monoidal.MonoidalCategoriesWhiskered.
 
+Export Set Default Goal Selector "!".
 
 Import BifunctorNotations.
 

--- a/UniMath/SubstitutionSystems/BinSumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/BinSumOfSignatures.v
@@ -84,8 +84,8 @@ Local Lemma is_nat_trans_θ_ob_fun (X : [C, D']) (Z : category_Ptd C):
    is_nat_trans _ _ (θ_ob_fun X Z).
 Proof.
   intros x x' f.
-  eapply pathscomp0; [ apply BinCoproductOfArrows_comp | ].
-  eapply pathscomp0; [ | eapply pathsinv0; apply BinCoproductOfArrows_comp].
+  etrans; [ apply BinCoproductOfArrows_comp | ].
+  etrans; [ | eapply pathsinv0; apply BinCoproductOfArrows_comp].
   apply maponpaths_12.
   * apply (nat_trans_ax (θ1 (X ⊗ Z))).
   * apply (nat_trans_ax (θ2 (X ⊗ Z))).
@@ -112,9 +112,9 @@ Proof.
     destruct αβ as [α β]. simpl in *.
     (* on the right-hand side, there is a second but unfolded BinCoproductOfArrows in the row -
        likewise a first such on the left-hand side, to be treater further below *)
-    eapply pathscomp0; [ | eapply pathsinv0; apply BinCoproductOfArrows_comp].
-    eapply pathscomp0. apply cancel_postcomposition. apply BinCoproductOfArrows_comp.
-    eapply pathscomp0. apply BinCoproductOfArrows_comp.
+    etrans; [ | eapply pathsinv0; apply BinCoproductOfArrows_comp].
+    etrans. { apply cancel_postcomposition. apply BinCoproductOfArrows_comp. }
+    etrans. { apply BinCoproductOfArrows_comp. }
     apply maponpaths_12.
     + apply (nat_trans_eq_pointwise Hyp1 c).
     + apply (nat_trans_eq_pointwise Hyp2 c).
@@ -133,7 +133,7 @@ Proof.
   intro X.
   apply nat_trans_eq_alt.
   intro x; simpl.
-  eapply pathscomp0; [ apply BinCoproductOfArrows_comp |].
+  etrans; [ apply BinCoproductOfArrows_comp |].
   apply pathsinv0, BinCoproduct_endo_is_identity.
   + rewrite BinCoproductOfArrowsIn1.
     unfold θ_Strength1 in S11.
@@ -153,10 +153,10 @@ Lemma SumStrength2 : θ_Strength2 θ.
 Proof.
   intros X Z Z' Y α.
   apply nat_trans_eq_alt; intro x.
-  eapply pathscomp0; [ apply BinCoproductOfArrows_comp |].
+  etrans; [ apply BinCoproductOfArrows_comp |].
   apply pathsinv0.
-  eapply pathscomp0. apply cancel_postcomposition. simpl. apply BinCoproductOfArrows_comp.
-  eapply pathscomp0. apply BinCoproductOfArrows_comp.
+  etrans. { apply cancel_postcomposition. simpl. apply BinCoproductOfArrows_comp. }
+  etrans; [apply BinCoproductOfArrows_comp |].
   apply pathsinv0.
   apply maponpaths_12.
   - assert (Ha:=S12 X Z Z' Y α).
@@ -178,18 +178,18 @@ Lemma SumStrength1' : θ_Strength1_int θ.
 Proof.
   clear S11 S12 S21 S22 S12' S22'; intro X.
   apply nat_trans_eq_alt; intro x.
-  eapply pathscomp0. apply BinCoproductOfArrows_comp.
+  etrans; [ apply BinCoproductOfArrows_comp |].
   apply pathsinv0, BinCoproduct_endo_is_identity.
   + rewrite BinCoproductOfArrowsIn1.
     assert (Ha := nat_trans_eq_pointwise (S11' X) x).
     simpl in Ha.
-    eapply pathscomp0; [ | apply id_left].
+    etrans; [ | apply id_left].
     apply cancel_postcomposition.
     apply Ha.
   + rewrite BinCoproductOfArrowsIn2.
     assert (Ha := nat_trans_eq_pointwise (S21' X) x).
     simpl in Ha.
-    eapply pathscomp0; [ | apply id_left].
+    etrans; [ | apply id_left].
     apply cancel_postcomposition.
     apply Ha.
 Qed.
@@ -198,9 +198,9 @@ Lemma SumStrength2' : θ_Strength2_int θ.
 Proof.
   clear S11 S12 S21 S22 S11' S21'; intros X Z Z'.
   apply nat_trans_eq_alt; intro x; simpl; rewrite id_left.
-  eapply pathscomp0. apply BinCoproductOfArrows_comp.
+  etrans; [ apply BinCoproductOfArrows_comp |].
   apply pathsinv0.
-  eapply pathscomp0. apply BinCoproductOfArrows_comp.
+  etrans; [ apply BinCoproductOfArrows_comp |].
   apply pathsinv0.
   apply maponpaths_12.
   - assert (Ha:=S12' X Z Z').

--- a/UniMath/SubstitutionSystems/CCS_alt.v
+++ b/UniMath/SubstitutionSystems/CCS_alt.v
@@ -50,6 +50,8 @@ Require Import UniMath.SubstitutionSystems.SignatureExamples.
 Require Import UniMath.SubstitutionSystems.MultiSorted_alt.
 Require Import UniMath.SubstitutionSystems.MonadsMultiSorted_alt.
 
+Export Set Default Goal Selector "!".
+
 Local Open Scope cat.
 
 Section ccs.

--- a/UniMath/SubstitutionSystems/EquivalenceSignaturesWithActegoryMorphisms.v
+++ b/UniMath/SubstitutionSystems/EquivalenceSignaturesWithActegoryMorphisms.v
@@ -36,6 +36,8 @@ Require Import UniMath.Bicategories.MonoidalCategories.PointedFunctorsWhiskeredM
 Require Import UniMath.Bicategories.MonoidalCategories.ActionOfEndomorphismsInBicatWhiskered.
 Require Import UniMath.Bicategories.MonoidalCategories.BicatOfActegories.
 
+Export Set Default Goal Selector "!".
+
 Import Bicat.Notations.
 Import MonoidalNotations.
 
@@ -97,7 +99,7 @@ Section A.
    unfold actionbased_strength_nat.
    unfold nat_trans.
    eapply weqcomp.
-   apply weqtotal2asstor.
+   { apply weqtotal2asstor. }
 (*
    set (P := is_nat_trans (actionbased_strength_dom Mon_endo' (ActionBasedStrengthOnHomsInBicat.target_action C D) H)
                (actionbased_strength_codom Mon_endo' (ActionBasedStrengthOnHomsInBicat.domain_action C D') H)).

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -45,6 +45,8 @@ Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.BindingSigToMonad.
 Require Import UniMath.SubstitutionSystems.LiftingInitial_alt.
 
+Export Set Default Goal Selector "!".
+
 Local Open Scope cat.
 
 Local Notation "[ C , D ]" := (functor_category C D).

--- a/UniMath/SubstitutionSystems/GenMendlerIteration.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration.v
@@ -37,6 +37,8 @@ Require Import UniMath.CategoryTheory.opp_precat.
 Require Import UniMath.CategoryTheory.yoneda.
 Require Import UniMath.CategoryTheory.Adjunctions.Core.
 
+Export Set Default Goal Selector "!".
+
 Arguments functor_composite {_ _ _} _ _ .
 Arguments nat_trans_comp {_ _ _ _ _} _ _ .
 Local Notation "G ∙ F" := (functor_composite F G : [ _ , _ , _ ]) (at level 35).

--- a/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
@@ -35,6 +35,8 @@ Require Import UniMath.CategoryTheory.yoneda.
 Require Import UniMath.CategoryTheory.HorizontalComposition.
 Require Import UniMath.CategoryTheory.whiskering.
 
+Export Set Default Goal Selector "!".
+
 Local Open Scope cat.
 
 Arguments functor_composite {_ _ _} _ _ .
@@ -111,7 +113,7 @@ induction n as [|n IHn].
 + change (pr1 (Pow (S (S n))) _ z) with (ψ (iter_functor F (S n) 0) (Pow (S n) _ z)).
   assert (H : dmor LchnF (idpath (S (S n))) · ψ ((iter_functor F (S n)) IC) ((Pow (S n)) IC z) =
               ψ (iter_functor F n 0) (dmor LchnF (idpath (S n)) · pr1 (Pow (S n)) _ z)).
-    apply pathsinv0, (toforallpaths _ _ _ (nat_trans_ax ψ _ _ (dmor chnF (idpath (S n))))).
+  { apply pathsinv0, (toforallpaths _ _ _ (nat_trans_ax ψ _ _ (dmor chnF (idpath (S n))))). }
   now rewrite H, IHn.
 Qed.
 
@@ -156,7 +158,7 @@ induction n.
   apply (InitialArrowUnique ILD).
 - rewrite e_comm, functor_comp, <- assoc, Hh.
   assert (H : # L (# F (e n)) · ψ μF h = ψ (iter_functor F n 0) (# L (e n) · h)).
-    apply pathsinv0, (toforallpaths _ _ _ (nat_trans_ax ψ _ _ (e n))).
+  { apply pathsinv0, (toforallpaths _ _ _ (nat_trans_ax ψ _ _ (e n))). }
   now rewrite H, IHn.
 Qed.
 
@@ -169,22 +171,22 @@ assert (H'' : # L inF · # L inF_inv = identity _).
 assert (H' : ∏ n, # L (e (S n)) · # L inF_inv · ψ μF preIt = pr1 (Pow (S n)) _ z).
 { intro n.
   rewrite e_comm, functor_comp.
-  eapply pathscomp0;
+  etrans;
    [apply cancel_postcomposition; rewrite <-assoc;  apply maponpaths, H''|].
   rewrite id_right.
   assert (H1 : # L (# F (e n)) · ψ μF preIt = ψ (iter_functor F n 0) (# L (e n) · preIt)).
   { apply pathsinv0, (toforallpaths _ _ _ (nat_trans_ax ψ _ _ (e n))). }
-  eapply pathscomp0; [ apply H1|].
+  etrans; [ apply H1|].
   now rewrite H.
 }
 assert (HH : preIt = # L inF_inv · ψ μF preIt).
 { apply pathsinv0, (colimArrowUnique CC_LchnF); simpl; intro n.
   destruct n.
   - apply (InitialArrowUnique ILD).
-  - simpl; eapply pathscomp0; [| apply H'].
+  - simpl; etrans; [| apply H'].
     now apply assoc.
 }
-eapply pathscomp0; [ apply maponpaths, HH|].
+etrans; [ apply maponpaths, HH|].
 now rewrite assoc, H'', id_left.
 Qed.
 

--- a/UniMath/SubstitutionSystems/LamFromBindingSig.v
+++ b/UniMath/SubstitutionSystems/LamFromBindingSig.v
@@ -166,24 +166,24 @@ Proof.
                                                                      _ _ _ _ _) · x)
                         (algebra_mor_commutes _ _ _ (foldr_map X fvar fapp flam))).
 rewrite assoc in F.
-eapply pathscomp0; [apply F|].
+etrans; [apply F|].
 rewrite assoc.
-eapply pathscomp0.
-  eapply cancel_postcomposition.
+etrans.
+{ eapply cancel_postcomposition.
   rewrite <- assoc.
-  eapply maponpaths, BinCoproductOfArrowsIn2.
+  eapply maponpaths, BinCoproductOfArrowsIn2. }
 rewrite assoc.
-eapply pathscomp0.
-  eapply @cancel_postcomposition. eapply @cancel_postcomposition.
+etrans.
+{ eapply @cancel_postcomposition. eapply @cancel_postcomposition.
   apply (CoproductOfArrowsIn _ _ (Coproducts_functor_precat _ _ _
           _ (λ i, pr1 (Arity_to_Signature BinProductsHSET
-                         BinCoproductsHSET TerminalHSET (BindingSigMap LamSig i)) `LC_alg))).
+                         BinCoproductsHSET TerminalHSET (BindingSigMap LamSig i)) `LC_alg))). }
 rewrite <- assoc.
-eapply pathscomp0; [eapply maponpaths, BinCoproductIn2Commutes|].
+etrans; [eapply maponpaths, BinCoproductIn2Commutes|].
 rewrite <- assoc.
-eapply pathscomp0; eapply maponpaths.
-  exact (CoproductInCommutes _ _ _ _ _ _ true).
-apply idpath.
+etrans; eapply maponpaths.
+- exact (CoproductInCommutes _ _ _ _ _ _ true).
+- apply idpath.
 Defined.
 
 Lemma foldr_lam X (fvar : HSET2⟦1,X⟧) (fapp : HSET2⟦X ⊗ X,X⟧) (flam : HSET2⟦X + 1,X⟧) :
@@ -195,25 +195,25 @@ Proof.
                                                                      _ _ _ _ _) · x)
                         (algebra_mor_commutes _ _ _ (foldr_map X fvar fapp flam))).
 rewrite assoc in F.
-eapply pathscomp0; [apply F|].
+etrans; [apply F|].
 rewrite assoc.
-eapply pathscomp0.
-  eapply cancel_postcomposition.
+etrans.
+{ eapply cancel_postcomposition.
   rewrite <- assoc.
-  eapply maponpaths, BinCoproductOfArrowsIn2.
+  eapply maponpaths, BinCoproductOfArrowsIn2. }
 rewrite assoc.
-eapply pathscomp0.
-  eapply @cancel_postcomposition, @cancel_postcomposition.
+etrans.
+{ eapply @cancel_postcomposition, @cancel_postcomposition.
   apply (CoproductOfArrowsIn _ _ (Coproducts_functor_precat _ _ _
           _ (λ i, pr1 (Arity_to_Signature BinProductsHSET
-                         BinCoproductsHSET TerminalHSET (BindingSigMap LamSig i)) `LC_alg))).
+                         BinCoproductsHSET TerminalHSET (BindingSigMap LamSig i)) `LC_alg))). }
 rewrite <- assoc.
-eapply pathscomp0.
-  eapply maponpaths, BinCoproductIn2Commutes.
+etrans.
+{ eapply maponpaths, BinCoproductIn2Commutes. }
 rewrite <- assoc.
-eapply pathscomp0; eapply maponpaths.
-  exact (CoproductInCommutes _ _ _ _ _ _ false).
-apply idpath.
+etrans; eapply maponpaths.
+- exact (CoproductInCommutes _ _ _ _ _ _ false).
+- apply idpath.
 Defined.
 
 

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -448,12 +448,12 @@ Proof.
       unfold coproduct_nat_trans_in1_data in h'_eq1_inst; simpl in h'_eq1_inst.
       rewrite <- @assoc in h'_eq1_inst.
       etrans.
-      eapply pathsinv0. exact h'_eq1_inst.
+      { eapply pathsinv0; exact h'_eq1_inst. }
       clear h'_eq1_inst.
       apply BinCoproductIn1Commutes_right_in_ctx_dir.
       apply BinCoproductIn1Commutes_right_in_ctx_dir.
       apply BinCoproductIn1Commutes_right_dir.
-        apply idpath.
+      apply idpath.
     + destruct h'_eq as [_ h'_eq2]. (*clear h'_eq2.*)
       assert (h'_eq2_inst := nat_trans_eq_pointwise h'_eq2 c);
         clear h'_eq2.
@@ -710,7 +710,7 @@ Proof.
             assert (Hyp := τ_part_of_alg_mor _ CP _ _ _ (InitialArrow IA (pr1 T'))).
             assert (Hyp_c := nat_trans_eq_pointwise Hyp c); clear Hyp.
             simpl in Hyp_c.
-            eapply pathscomp0. eapply pathsinv0. exact Hyp_c.
+            etrans; [ eapply pathsinv0; exact Hyp_c |].
             clear Hyp_c.
             apply maponpaths.
             apply pathsinv0.

--- a/UniMath/SubstitutionSystems/ModulesFromSignatures.v
+++ b/UniMath/SubstitutionSystems/ModulesFromSignatures.v
@@ -311,8 +311,8 @@ Local Definition M_alg : Alg.
 Proof.
   apply (tpair (λ x, EndC ⟦ Id_H x, x ⟧) (M:functor _ _)).
   apply BinCoproductArrow.
-  apply Monads.η.
-  apply τ_M.
+  - apply Monads.η.
+  - apply τ_M.
 Defined.
 
 (** j : T --> M is the initial Id+H-algebra morphism *)
@@ -404,8 +404,8 @@ Proof.
     apply cancel_postcomposition.
     etrans; [ apply assoc |].
     etrans.
-    apply cancel_postcomposition.
-    apply (θ_nat_1_pw _ _ a (p T_alg)).
+    { apply cancel_postcomposition.
+      apply (θ_nat_1_pw _ _ a (p T_alg)). }
     rewrite <- assoc.
     apply cancel_precomposition.
     etrans; revgoals.
@@ -418,7 +418,7 @@ Proof.
     intro c'.
     etrans; [| apply id_right ].
     apply cancel_precomposition.
-    apply (functor_id   x).
+    apply (functor_id x).
 Qed.
 
 Local Definition ψ  : (PreShv EndC)⟦ψ_source(D:=[C,C]) X L , ψ_target(D:=[C,C]) Id_H X L⟧ :=

--- a/UniMath/SubstitutionSystems/MonadsMultiSorted.v
+++ b/UniMath/SubstitutionSystems/MonadsMultiSorted.v
@@ -26,6 +26,8 @@ Require Import UniMath.CategoryTheory.categories.HSET.Limits.
 Require Import UniMath.CategoryTheory.categories.HSET.Slice.
 Require Import UniMath.CategoryTheory.slicecat.
 
+Export Set Default Goal Selector "!".
+
 Local Open Scope cat.
 
 Local Notation "C / X" := (slicecat_ob C X).

--- a/UniMath/SubstitutionSystems/MonadsMultiSorted_alt.v
+++ b/UniMath/SubstitutionSystems/MonadsMultiSorted_alt.v
@@ -34,6 +34,8 @@ Require Import UniMath.CategoryTheory.Monads.Monads.
 Require Import UniMath.CategoryTheory.categories.StandardCategories.
 Require Import UniMath.CategoryTheory.Groupoids.
 
+Export Set Default Goal Selector "!".
+
 Local Open Scope cat.
 
 Section MonadInSortToC.

--- a/UniMath/SubstitutionSystems/MultiSorted_alt.v
+++ b/UniMath/SubstitutionSystems/MultiSorted_alt.v
@@ -58,6 +58,8 @@ Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.SignatureExamples.
 Require Import UniMath.SubstitutionSystems.BindingSigToMonad.
 
+Export Set Default Goal Selector "!".
+
 Local Open Scope cat.
 
 (* These should be global *)

--- a/UniMath/SubstitutionSystems/Notation.v
+++ b/UniMath/SubstitutionSystems/Notation.v
@@ -39,6 +39,8 @@ Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
 Require Import UniMath.CategoryTheory.HorizontalComposition.
 Require Import UniMath.CategoryTheory.PointedFunctorsComposition.
 
+Export Set Default Goal Selector "!".
+
 Arguments functor_composite {_ _ _} _ _ .
 Arguments nat_trans_comp {_ _ _ _ _} _ _ .
 

--- a/UniMath/SubstitutionSystems/PCF_alt.v
+++ b/UniMath/SubstitutionSystems/PCF_alt.v
@@ -48,6 +48,8 @@ Require Import UniMath.SubstitutionSystems.MultiSorted_alt.
 Require Import UniMath.SubstitutionSystems.MonadsMultiSorted_alt.
 Require Import UniMath.SubstitutionSystems.STLC_alt.
 
+Export Set Default Goal Selector "!".
+
 Local Open Scope cat.
 
 Section pcf.

--- a/UniMath/SubstitutionSystems/STLC_alt.v
+++ b/UniMath/SubstitutionSystems/STLC_alt.v
@@ -47,6 +47,8 @@ Require Import UniMath.SubstitutionSystems.SignatureExamples.
 Require Import UniMath.SubstitutionSystems.MultiSorted_alt.
 Require Import UniMath.SubstitutionSystems.MonadsMultiSorted_alt.
 
+Export Set Default Goal Selector "!".
+
 Local Open Scope cat.
 
 (** * The simply typed lambda calculus from a multisorted binding signature *)

--- a/UniMath/SubstitutionSystems/SignatureCategory.v
+++ b/UniMath/SubstitutionSystems/SignatureCategory.v
@@ -197,7 +197,7 @@ Qed.
   Proof.
     change isaset with (isofhlevel 2).
     apply isofhleveltotal2.
-    apply (functor_category_has_homsets ([C, D'] ⊠ category_Ptd C) ([C, D]) (functor_category_has_homsets _ _ _)).
+    { apply (functor_category_has_homsets ([C, D'] ⊠ category_Ptd C) ([C, D]) (functor_category_has_homsets _ _ _)). }
     intro θ.
     apply isasetaprop.
     apply isapropdirprod.

--- a/UniMath/SubstitutionSystems/Signatures.v
+++ b/UniMath/SubstitutionSystems/Signatures.v
@@ -552,8 +552,8 @@ Section relative_strength_instantiates_to_signature.
       rewrite <- assoc.
       apply maponpaths.
       etrans.
-      apply pathsinv0.
-      apply id_left.
+      { apply pathsinv0.
+        apply id_left. }
       apply cancel_postcomposition.
       apply pathsinv0.
       apply (nat_trans_eq_weq (homset_property C) _ _ (auxH1 H X) c).
@@ -576,11 +576,12 @@ Section relative_strength_instantiates_to_signature.
       apply maponpaths.
       apply pathsinv0.
       etrans.
-      use (maponpaths (fun x => pr1 (# H x) c)).
-      + exact (identity (functor_compose (functor_compose (pr1 Z) (pr1 Z')) X)).
-      + apply auxH2aux.
-      + rewrite functor_id.
-        apply idpath.
+      { use (maponpaths (fun x => pr1 (# H x) c)).
+        + exact (identity (functor_compose (functor_compose (pr1 Z) (pr1 Z')) X)).
+        + apply auxH2aux.
+      }
+      rewrite functor_id.
+      apply idpath.
   Qed.
 
   Definition signature_from_rel_strength : Signature C C C.
@@ -645,11 +646,11 @@ Section strength_in_signature_is_a_relative_strength.
       apply maponpaths.
       (** now identical reasoning as in [signature_from_rel_strength_laws] *)
       etrans.
-      use (maponpaths (fun x => pr1 (# H x) c)).
-      + exact (identity (functor_compose (functor_compose (pr1 Z) (pr1 Z')) X)).
-      + apply auxH2aux.
-      + rewrite functor_id.
-        apply idpath.
+      { use (maponpaths (fun x => pr1 (# H x) c)).
+        + exact (identity (functor_compose (functor_compose (pr1 Z) (pr1 Z')) X)).
+        + apply auxH2aux. }
+      rewrite functor_id.
+      apply idpath.
   Qed.
 
   Definition rel_strength_from_signature : rel_strength forget H := (ϛ',,rel_strength_from_signature_laws).

--- a/UniMath/SubstitutionSystems/SubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/SubstitutionSystems.v
@@ -610,13 +610,13 @@ Proof.
   assert (X:=pr2 β).
   assert (X':= nat_trans_eq_pointwise X c).
   simpl in *.
-  eapply pathscomp0. apply maponpaths. apply X'.
+  etrans. { apply maponpaths. apply X'. }
   unfold coproduct_nat_trans_in1_data.
   repeat rewrite assoc.
   unfold coproduct_nat_trans_data.
-  eapply pathscomp0.
-  apply cancel_postcomposition.
-  apply BinCoproductIn1Commutes.
+  etrans.
+  { apply cancel_postcomposition.
+    apply BinCoproductIn1Commutes. }
   simpl.
   repeat rewrite <- assoc.
   apply id_left.
@@ -759,13 +759,13 @@ Proof.
   intros Z f.
   eapply pathscomp0; [apply assoc|].
   (* match goal with | [|- ?l = _ ] => assert (Hyp : l = fbracket T f· pr1 β· pr1 γ) end. *)
-  eapply pathscomp0.
-    apply cancel_postcomposition.
-    apply isbracketMor_hssMor.
+  etrans.
+  { apply cancel_postcomposition.
+    apply isbracketMor_hssMor. }
   rewrite <- assoc.
-  eapply pathscomp0.
-    apply maponpaths.
-    apply isbracketMor_hssMor.
+  etrans.
+  { apply maponpaths.
+    apply isbracketMor_hssMor. }
   rewrite assoc.
   rewrite functor_comp.
   rewrite assoc.


### PR DESCRIPTION
- following issue 1576 puts Export Set Default Goal Selector "!". into the file Notations.v and in those files that do not import that file
- very few tactic applications without focus on one single goal detected
- in passing a few occurrences of eapply pathscomp0 replaced by etrans