### PR TITLE
the shallow corrections to ensure focus when working with bicategories

### DIFF
--- a/UniMath/Bicategories/BicategoryOfBicat.v
+++ b/UniMath/Bicategories/BicategoryOfBicat.v
@@ -89,8 +89,7 @@ Lemma bicate_transfs :
   (∏ a b : bicate_id_comp, left_unitor_trans_type a b) ×
   (∏ a b : bicate_id_comp, right_unitor_trans_type a b).
 Proof.
-  repeat split.
-  red. cbn.
+  repeat split; red; cbn.
   - exact lassociator_transf.
   - exact lunitor_transf.
   - exact runitor_transf.

--- a/UniMath/Bicategories/Core/Bicat.v
+++ b/UniMath/Bicategories/Core/Bicat.v
@@ -12,6 +12,8 @@ Require Import UniMath.CategoryTheory.Core.Functors.
 Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
 
+Export Set Default Goal Selector "!".
+
 Local Open Scope cat.
 
 (* ----------------------------------------------------------------------------------- *)
@@ -642,9 +644,9 @@ Lemma lhs_right_invert_cell {a b : C} {f g h : a --> b}
   : x = z • inv_y^-1 -> x • y = z.
 Proof.
   intro H1.
-  etrans. apply maponpaths_2. apply H1.
-  etrans. apply vassocl.
-  etrans. apply maponpaths. apply (vcomp_linv inv_y).
+  etrans. { apply maponpaths_2. apply H1. }
+  etrans. { apply vassocl. }
+  etrans. { apply maponpaths. apply (vcomp_linv inv_y). }
   apply id2_right.
 Qed.
 
@@ -653,9 +655,9 @@ Lemma lhs_left_invert_cell {a b : C} {f g h : a --> b}
   : y = inv_x^-1 • z -> x • y = z.
 Proof.
   intro H1.
-  etrans. apply maponpaths. apply H1.
-  etrans. apply vassocr.
-  etrans. apply maponpaths_2. apply (vcomp_rinv inv_x).
+  etrans. { apply maponpaths. apply H1. }
+  etrans. { apply vassocr. }
+  etrans. { apply maponpaths_2. apply (vcomp_rinv inv_x). }
   apply id2_left.
 Qed.
 
@@ -668,8 +670,8 @@ Proof.
   etrans. { apply H1. }
   etrans. 2: apply vassocr.
   apply pathsinv0.
-  etrans. apply maponpaths.
-  apply vcomp_linv.
+  etrans. { apply maponpaths.
+            apply vcomp_linv. }
   apply id2_right.
 Qed.
 
@@ -682,8 +684,8 @@ Proof.
   etrans. { apply H1. }
   etrans. 2: apply vassocl.
   apply pathsinv0.
-  etrans. apply maponpaths_2.
-  apply (vcomp_rinv inv_y).
+  etrans. { apply maponpaths_2.
+            apply (vcomp_rinv inv_y). }
   apply id2_left.
 Qed.
 
@@ -741,7 +743,7 @@ Lemma lunitor_lwhisker {a b c : C} (f : C⟦a, b⟧) (g : C⟦b, c⟧)
   : rassociator _ _ _ • (f ◃ lunitor g) = runitor f ▹ g.
 Proof.
   use lhs_left_invert_cell.
-  apply is_invertible_2cell_rassociator.
+  { apply is_invertible_2cell_rassociator. }
   cbn.
   apply pathsinv0.
   apply runitor_rwhisker.
@@ -821,11 +823,11 @@ Lemma hcomp_rassoc {a b c d : C}
     rassociator f1 f2 f3 • x1 ⋆ (x2 ⋆ x3).
 Proof.
   use lhs_right_invert_cell.
-  apply is_invertible_2cell_rassociator.
+  { apply is_invertible_2cell_rassociator. }
   etrans; [ | apply vassocr ].
   apply pathsinv0.
   use lhs_left_invert_cell.
-  apply is_invertible_2cell_rassociator.
+  { apply is_invertible_2cell_rassociator. }
   apply hcomp_lassoc.
 Qed.
 
@@ -887,16 +889,17 @@ Lemma rwhisker_lwhisker_rassociator
 Proof.
   apply (vcomp_lcancel (lassociator f g i)).
   { apply  is_invertible_2cell_lassociator. }
-  etrans. etrans. apply vassocr. apply maponpaths_2. apply lassociator_rassociator.
-  etrans. apply id2_left.
-
+  etrans.
+  { etrans; [ apply vassocr |].
+    apply maponpaths_2. apply lassociator_rassociator. }
+  etrans; [ apply id2_left |].
   apply (vcomp_rcancel (lassociator f h i)).
   { apply  is_invertible_2cell_lassociator. }
   apply pathsinv0.
-  etrans. apply vassocl.
-  etrans. apply maponpaths. apply vassocl.
-  etrans. do 2 apply maponpaths. apply  rassociator_lassociator.
-  etrans. apply maponpaths. apply id2_right.
+  etrans; [ apply vassocl |].
+  etrans. { apply maponpaths. apply vassocl. }
+  etrans. { do 2 apply maponpaths. apply rassociator_lassociator. }
+  etrans. { apply maponpaths. apply id2_right. }
   apply pathsinv0, rwhisker_lwhisker.
 Qed.
 
@@ -907,16 +910,17 @@ Lemma lwhisker_lwhisker_rassociator (a b c d : C) (f : C⟦a, b⟧)
 Proof.
   apply (vcomp_lcancel (lassociator f g h)).
   { apply  is_invertible_2cell_lassociator. }
-  etrans. etrans. apply vassocr. apply maponpaths_2. apply lassociator_rassociator.
-  etrans. apply id2_left.
-
+  etrans.
+  { etrans; [ apply vassocr |].
+    apply maponpaths_2. apply lassociator_rassociator. }
+  etrans; [ apply id2_left |].
   apply (vcomp_rcancel (lassociator f g i)).
   { apply  is_invertible_2cell_lassociator. }
   apply pathsinv0.
-  etrans. apply vassocl.
-  etrans. apply maponpaths. apply vassocl.
-  etrans. do 2 apply maponpaths. apply  rassociator_lassociator.
-  etrans. apply maponpaths. apply id2_right.
+  etrans; [ apply vassocl |].
+  etrans. { apply maponpaths. apply vassocl. }
+  etrans. { do 2 apply maponpaths. apply rassociator_lassociator. }
+  etrans. { apply maponpaths. apply id2_right. }
   apply pathsinv0, lwhisker_lwhisker.
 Qed.
 
@@ -969,7 +973,7 @@ Proof.
     etrans. { apply maponpaths_2, lassociator_rassociator. }
     apply id2_left. }
   etrans.
-  apply lassociator_rassociator.
+  { apply lassociator_rassociator. }
   apply pathsinv0.
   etrans.
   { apply maponpaths.
@@ -980,20 +984,21 @@ Proof.
     apply id2_left.
   }
   etrans.
-  apply vassocl.
+  { apply vassocl. }
   etrans.
-  apply maponpaths.
+  { apply maponpaths.
+    etrans.
+    { apply vassocr. }
+    etrans.
+    { apply maponpaths_2.
+      apply lassociator_rassociator. }
+    apply id2_left.
+  }
   etrans.
-  apply vassocr.
+  { apply lwhisker_vcomp. }
   etrans.
-  apply maponpaths_2.
-  apply lassociator_rassociator.
-  apply id2_left.
-  etrans.
-  apply lwhisker_vcomp.
-  etrans.
-  apply maponpaths.
-  apply lassociator_rassociator.
+  { apply maponpaths.
+    apply lassociator_rassociator. }
   apply lwhisker_id2.
 Qed.
 

--- a/UniMath/Bicategories/Core/BicategoryLaws.v
+++ b/UniMath/Bicategories/Core/BicategoryLaws.v
@@ -24,7 +24,7 @@ Section laws.
       etrans. { apply maponpaths.
                 apply lwhisker_id2. }
               apply id2_right. }
-    etrans. apply runitor_rwhisker.
+    etrans. { apply runitor_rwhisker. }
     apply pathsinv0.
     etrans. { apply maponpaths_2. apply id2_rwhisker. }
             apply id2_left.

--- a/UniMath/Bicategories/Core/Examples/BicategoryFromMonoidal.v
+++ b/UniMath/Bicategories/Core/Examples/BicategoryFromMonoidal.v
@@ -82,7 +82,7 @@ Proof.
   split. {
     intros ? ? ? f g h i x y.
     etrans.
-    exact (!(functor_comp tensor (id f #, x) (id f #, y))).
+    { exact (!(functor_comp tensor (id f #, x) (id f #, y))). }
     exact (maponpaths (fun z => z #⊗ (x · y)) (id_left _)).
   }
 
@@ -90,7 +90,7 @@ Proof.
   split. {
     intros ? ? ? f g h i x y.
     etrans.
-    exact (!(functor_comp tensor _ _)).
+    { exact (!(functor_comp tensor _ _)). }
     exact (maponpaths (fun z => (x · y) #⊗ z) (id_left _)).
   }
 
@@ -102,7 +102,7 @@ Proof.
   split. {
     intros ? ? ? ? f g h i x.
     etrans.
-    exact (pr21 (nat_z_iso_inv α) _ _ ((id f #, id g) #, x)).
+    { exact (pr21 (nat_z_iso_inv α) _ _ ((id f #, id g) #, x)). }
     exact (maponpaths (fun z => _ · (z #⊗ _)) (functor_id tensor (f , g))).
   }
 
@@ -110,7 +110,7 @@ Proof.
   split. {
     intros ? ? ? ? f g h i x.
     etrans.
-    exact (pr21 (nat_z_iso_inv α) _ _ ((id f #, x) #, id i)).
+    { exact (pr21 (nat_z_iso_inv α) _ _ ((id f #, x) #, id i)). }
     apply idpath.
   }
 
@@ -118,20 +118,20 @@ Proof.
   split. {
     intros ? ? ? ? f g h i x.
     etrans.
-    exact (!(pr21 (nat_z_iso_inv α) _ _ ((x #, id h) #, id i))).
+    { exact (!(pr21 (nat_z_iso_inv α) _ _ ((x #, id h) #, id i))). }
     exact (maponpaths (fun z => (_ #⊗ z) · _) (functor_id tensor (h , i))).
   }
 
   (* 11. Vertical composition and whiskering *)
   split. {
     intros.
-    etrans. exact (!(functor_comp tensor _ _)).
-    etrans. exact (maponpaths (fun z => (_ #⊗ z)) (id_left _)).
-    etrans. exact (maponpaths (fun z => (z #⊗ _)) (id_right _)).
+    etrans. { exact (!(functor_comp tensor _ _)). }
+    etrans. { exact (maponpaths (fun z => (_ #⊗ z)) (id_left _)). }
+    etrans. { exact (maponpaths (fun z => (z #⊗ _)) (id_right _)). }
     apply pathsinv0.
-    etrans. exact (!(functor_comp tensor _ _)).
-    etrans. exact (maponpaths (fun z => (z #⊗ _)) (id_left _)).
-    etrans. exact (maponpaths (fun z => (_ #⊗ z)) (id_right _)).
+    etrans. { exact (!(functor_comp tensor _ _)). }
+    etrans. { exact (maponpaths (fun z => (z #⊗ _)) (id_left _)). }
+    etrans. { exact (maponpaths (fun z => (_ #⊗ z)) (id_right _)). }
     apply idpath.
   }
 
@@ -150,9 +150,9 @@ Proof.
   (* 15. Right unitor whiskering. *)
   split. {
     intros ? ? ? f g.
-    etrans. exact (maponpaths (fun z => _ · z) (triangle_equality _ _)).
-    etrans. exact (assoc _ _ _).
-    etrans. exact (maponpaths (fun z => z · _) (z_iso_after_z_iso_inv (α ((f, I), g) ,, pr2 α ((f, I), g) ))).
+    etrans. { exact (maponpaths (fun z => _ · z) (triangle_equality _ _)). }
+    etrans. { exact (assoc _ _ _). }
+    etrans. { exact (maponpaths (fun z => z · _) (z_iso_after_z_iso_inv (α ((f, I), g) ,, pr2 α ((f, I), g) ))). }
     exact (id_left _).
   }
 
@@ -164,29 +164,29 @@ Proof.
   apply (pre_comp_with_z_iso_is_inj'(f := α ((f, g), h ⊗ i)) (pr2 α _)).
   apply (pre_comp_with_z_iso_is_inj'(f := α (((f ⊗ g), h) , i)) (pr2 α _)).
   apply pathsinv0.
-  etrans. exact (maponpaths (fun z => _ · z) (assoc _ _ _)).
-  etrans. exact (maponpaths (fun z => _ · (z · _)) (z_iso_inv_after_z_iso (α ((f, g), _) ,, pr2 α _ ))).
-  etrans. exact (maponpaths (fun z => _ · z) (id_left _)).
-  etrans. exact (z_iso_inv_after_z_iso (α ((f ⊗ g, h), _) ,, pr2 α _ )).
+  etrans. { exact (maponpaths (fun z => _ · z) (assoc _ _ _)). }
+  etrans. { exact (maponpaths (fun z => _ · (z · _)) (z_iso_inv_after_z_iso (α ((f, g), _) ,, pr2 α _ ))). }
+  etrans. { exact (maponpaths (fun z => _ · z) (id_left _)). }
+  etrans. { exact (z_iso_inv_after_z_iso (α ((f ⊗ g, h), _) ,, pr2 α _ )). }
   apply pathsinv0.
-  etrans. exact (assoc _ _ _).
-  etrans. exact (assoc _ _ _).
-  etrans. exact (maponpaths (fun z => (z · _) · _) (pentagon_equation _ _ _ _)).
-  etrans. exact (maponpaths (fun z => (z · _)) (!(assoc _ _ _))).
-  etrans. exact (maponpaths (fun z => (_ · z · _)) (assoc _ _ _)).
-  etrans. exact (maponpaths (fun z => (_ · (z · _) · _)) (!(functor_comp tensor _ _))). cbn.
-  etrans. exact (maponpaths (fun z => (_ · ((z #⊗ _) · _) · _)) (id_left _)).
-  etrans. exact (maponpaths (fun z => (_ · ((_ #⊗ z) · _) · _)) (z_iso_inv_after_z_iso (α ((g, h), i) ,, pr2 α _))).
+  etrans. { exact (assoc _ _ _). }
+  etrans. { exact (assoc _ _ _). }
+  etrans. { exact (maponpaths (fun z => (z · _) · _) (pentagon_equation _ _ _ _)). }
+  etrans. { exact (maponpaths (fun z => (z · _)) (!(assoc _ _ _))). }
+  etrans. { exact (maponpaths (fun z => (_ · z · _)) (assoc _ _ _)). }
+  etrans. { exact (maponpaths (fun z => (_ · (z · _) · _)) (!(functor_comp tensor _ _))). } cbn.
+  etrans. { exact (maponpaths (fun z => (_ · ((z #⊗ _) · _) · _)) (id_left _)). }
+  etrans. { exact (maponpaths (fun z => (_ · ((_ #⊗ z) · _) · _)) (z_iso_inv_after_z_iso (α ((g, h), i) ,, pr2 α _))). }
   assert (aux: # tensor (id (f, (assoc_left (pr12 M)) ((g, h), i))) = id (f ⊗ (assoc_left (pr12 M)) ((g, h), i))) by
-  exact (functor_id tensor ( f , (assoc_left (pr12 M)) ((g, h), i))).
-  etrans. exact (maponpaths (fun z => (_ · (z · _) · _)) aux).
-  etrans. exact (maponpaths (fun z => (_ · z · _)) (id_left _)).
-  etrans. exact (maponpaths (fun z => (z · _)) (!(assoc _ _ _))).
-  etrans. exact (maponpaths (fun z => (_ · z · _)) (z_iso_inv_after_z_iso (α ((f,g ⊗ h),i) ,, pr2 α _))).
-  etrans. exact (maponpaths (fun z => (z · _)) (id_right _)).
-  etrans. exact (!(functor_comp tensor _ _)).
-  etrans. exact (maponpaths (fun z => (_ #⊗ z)) (id_right _)).
-  etrans. exact (maponpaths (fun z => (z #⊗ _)) (z_iso_inv_after_z_iso (α ((f,g),h) ,, pr2 α _))).
+    exact (functor_id tensor ( f , (assoc_left (pr12 M)) ((g, h), i))).
+  etrans. { exact (maponpaths (fun z => (_ · (z · _) · _)) aux). }
+  etrans. { exact (maponpaths (fun z => (_ · z · _)) (id_left _)). }
+  etrans. { exact (maponpaths (fun z => (z · _)) (!(assoc _ _ _))). }
+  etrans. { exact (maponpaths (fun z => (_ · z · _)) (z_iso_inv_after_z_iso (α ((f,g ⊗ h),i) ,, pr2 α _))). }
+  etrans. { exact (maponpaths (fun z => (z · _)) (id_right _)). }
+  etrans. { exact (!(functor_comp tensor _ _)). }
+  etrans. { exact (maponpaths (fun z => (_ #⊗ z)) (id_right _)). }
+  etrans. { exact (maponpaths (fun z => (z #⊗ _)) (z_iso_inv_after_z_iso (α ((f,g),h) ,, pr2 α _))). }
   apply (functor_id tensor).
 Qed.
 

--- a/UniMath/Bicategories/Core/Examples/OneTypes.v
+++ b/UniMath/Bicategories/Core/Examples/OneTypes.v
@@ -97,7 +97,7 @@ Proof.
   - intros X Y f g p ; cbn in *.
     apply funextsec. intro x.
     unfold homotcomp, homotfun. simpl.
-    etrans. apply pathscomp0rid.
+    etrans. { apply pathscomp0rid. }
     apply maponpathsidfun.
   - intros W X Y Z f g h i p ; cbn in *.
     apply funextsec. intro x.
@@ -109,7 +109,7 @@ Proof.
   - intros W X Y Z f g h i p ; cbn in *.
     apply funextsec. intro x.
     unfold homotcomp, homotfun. simpl.
-    etrans. apply maponpathscomp.
+    etrans. { apply maponpathscomp. }
     apply (! pathscomp0rid _).
   - intros X Y Z f g h i p q ; cbn in *.
     apply funextsec. intro x.

--- a/UniMath/Bicategories/Core/Examples/OpCellBicat.v
+++ b/UniMath/Bicategories/Core/Examples/OpCellBicat.v
@@ -56,30 +56,30 @@ Section OpCell.
     - use lhs_left_invert_cell; [ apply is_invertible_2cell_linvunitor |].
       cbn.
       apply pathsinv0.
-      etrans. apply vassocr.
+      etrans. { apply vassocr. }
       use lhs_right_invert_cell; [ apply is_invertible_2cell_linvunitor |].
       cbn.
       apply pathsinv0. apply vcomp_lunitor.
     - use lhs_left_invert_cell; [ apply is_invertible_2cell_rinvunitor |].
       cbn.
       apply pathsinv0.
-      etrans. apply vassocr.
+      etrans. { apply vassocr. }
       use lhs_right_invert_cell; [ apply is_invertible_2cell_rinvunitor |].
       cbn.
       apply pathsinv0. apply vcomp_runitor.
     - apply lassociator_to_rassociator_pre.
       apply pathsinv0.
-      etrans. apply (vassocr _ _ _ ).
+      etrans. { apply (vassocr _ _ _ ). }
       apply lassociator_to_rassociator_post.
       apply pathsinv0. apply lwhisker_lwhisker.
     - apply lassociator_to_rassociator_pre.
       apply pathsinv0.
-      etrans. apply (vassocr _ _ _ ).
+      etrans. { apply (vassocr _ _ _ ). }
       apply lassociator_to_rassociator_post.
       apply pathsinv0. apply rwhisker_lwhisker.
     - apply pathsinv0, lassociator_to_rassociator_pre.
       apply pathsinv0.
-      etrans. apply (vassocr _ _ _ ).
+      etrans. { apply (vassocr _ _ _ ). }
       apply lassociator_to_rassociator_post.
       apply rwhisker_rwhisker.
     - apply (!vcomp_whisker _ _  ).
@@ -106,7 +106,7 @@ Section OpCell.
         apply is_invertible_2cell_rassociator.
       } cbn.
       apply pathsinv0.
-      etrans. apply vassocr.
+      etrans. { apply vassocr. }
       use lhs_right_invert_cell.
       { apply is_invertible_2cell_rassociator.
       } cbn.

--- a/UniMath/Bicategories/Core/Unitors.v
+++ b/UniMath/Bicategories/Core/Unitors.v
@@ -91,7 +91,7 @@ Proof.
       apply is_invertible_2cell_rassociator.
   - cbn.
     apply pathsinv0.
-    etrans. apply vassocr.
+    etrans. { apply vassocr. }
     apply lassociator_lassociator.
 Qed.
 
@@ -102,7 +102,7 @@ Proof.
   intro H.
   apply (vcomp_lcancel (runitor _)).
   - apply is_invertible_2cell_runitor.
-  - etrans. apply pathsinv0, vcomp_runitor.
+  - etrans. { apply pathsinv0, vcomp_runitor. }
     etrans. 2: apply vcomp_runitor.
     apply maponpaths_2. apply H.
 Qed.
@@ -114,7 +114,7 @@ Proof.
   intro H.
   apply (vcomp_lcancel (lunitor _)).
   - apply is_invertible_2cell_lunitor.
-  - etrans. apply pathsinv0, vcomp_lunitor.
+  - etrans. { apply pathsinv0, vcomp_lunitor. }
     etrans. 2: apply vcomp_lunitor.
     apply maponpaths_2. apply H.
 Qed.

--- a/UniMath/Bicategories/Core/Univalence.v
+++ b/UniMath/Bicategories/Core/Univalence.v
@@ -133,8 +133,8 @@ Lemma isaprop_is_univalent_2 (C : bicat)
   : isaprop (is_univalent_2 C).
 Proof.
   apply isapropdirprod.
-  apply isaprop_is_univalent_2_0.
-  apply isaprop_is_univalent_2_1.
+  - apply isaprop_is_univalent_2_0.
+  - apply isaprop_is_univalent_2_1.
 Qed.
 
 Definition isotoid_2_1

--- a/UniMath/Bicategories/DisplayedBicats/DispAdjunctions.v
+++ b/UniMath/Bicategories/DisplayedBicats/DispAdjunctions.v
@@ -299,7 +299,7 @@ Proof.
           apply disp_mor_transportf_prewhisker. }
         etrans. { apply (transport_f_f (λ x, _ ==>[x] _)). }
         etrans.
-        apply maponpaths. apply disp_vassocl.
+        { apply maponpaths. apply disp_vassocl. }
         etrans. { apply (transport_f_f (λ x, _ ==>[x] _)). }
         etrans.
         { apply maponpaths. apply maponpaths.
@@ -508,12 +508,12 @@ Proof.
     use tpair.
     + (* Units *)
       use tpair; simpl.
-      apply (left_adjoint_unit j).
-      apply (disp_left_adjoint_unit _ jj).
+      * apply (left_adjoint_unit j).
+      * apply (disp_left_adjoint_unit _ jj).
     + (* Counits *)
       use tpair; simpl.
-      apply (left_adjoint_counit j).
-      apply (disp_left_adjoint_counit _ jj).
+      * apply (left_adjoint_counit j).
+      * apply (disp_left_adjoint_counit _ jj).
 Defined.
 
 Definition left_adjoint_data_total_weq

--- a/UniMath/Bicategories/DisplayedBicats/DispBicat.v
+++ b/UniMath/Bicategories/DisplayedBicats/DispBicat.v
@@ -709,7 +709,7 @@ Proof.
   apply (transportf_transpose_right (P := λ x', _ ==>[x'] _)).
   apply pathsinv0.
   etrans.
-  apply disp_vassocr.
+  { apply disp_vassocr. }
   apply maponpaths_2.
   unfold vassocl.
   apply pathsinv0, pathsinv0inv0.
@@ -822,18 +822,18 @@ Section Display_Invertible_2cell.
     : xx •• yy = transportb (λ x, _ ==>[x] _) q zz.
   Proof.
     set (yy' := (yy,,H) : disp_invertible_2cell _ _ _).
-    etrans. apply maponpaths_2. apply pp.
-    etrans. apply disp_mor_transportf_postwhisker.
-    etrans. apply maponpaths. apply disp_vassocl.
-    etrans. unfold transportb. apply (transport_f_f (λ x' : f ==> h, ff ==>[x'] hh)).
-    etrans. apply maponpaths. apply maponpaths.
-    apply disp_vcomp_linv.
-    etrans. apply maponpaths.
-    apply disp_mor_transportf_prewhisker.
-    etrans. unfold transportb. apply (transport_f_f (λ x' : f ==> h, ff ==>[x'] hh)).
-    etrans. apply maponpaths.
-    apply disp_id2_right.
-    etrans. unfold transportb. apply (transport_f_f (λ x' : f ==> h, ff ==>[x'] hh)).
+    etrans. { apply maponpaths_2. apply pp. }
+    etrans. { apply disp_mor_transportf_postwhisker. }
+    etrans. { apply maponpaths. apply disp_vassocl. }
+    etrans. { unfold transportb. apply (transport_f_f (λ x' : f ==> h, ff ==>[x'] hh)). }
+    etrans. { apply maponpaths. apply maponpaths.
+              apply disp_vcomp_linv. }
+    etrans. { apply maponpaths.
+              apply disp_mor_transportf_prewhisker. }
+    etrans. { unfold transportb. apply (transport_f_f (λ x' : f ==> h, ff ==>[x'] hh)). }
+    etrans. { apply maponpaths.
+              apply disp_id2_right. }
+    etrans. { unfold transportb. apply (transport_f_f (λ x' : f ==> h, ff ==>[x'] hh)). }
     unfold transportb.
     apply maponpaths_2.
     apply cellset_property.
@@ -859,7 +859,7 @@ Section Display_Invertible_2cell.
     : xx •• yy = transportb (λ x, _ ==>[x] _) q zz.
   Proof.
     etrans.
-    use (disp_lhs_right_invert_cell' _ _ _ _ pp).
+    { use (disp_lhs_right_invert_cell' _ _ _ _ pp). }
     apply maponpaths_2.
     apply cellset_property.
   Qed.
@@ -882,20 +882,20 @@ Section Display_Invertible_2cell.
                 (disp_inv_cell ((xx,,inv_xx):disp_invertible_2cell (x,,inv_x) ff gg) •• zz))
     : xx •• yy = transportb (λ x, _ ==>[x] _) q zz.
   Proof.
-    etrans. apply maponpaths. apply pp.
+    etrans. { apply maponpaths. apply pp. }
     etrans.
-    apply disp_mor_transportf_prewhisker.
-    etrans. apply maponpaths.
-    apply disp_vassocr.
-    etrans. apply (transport_f_f (λ x, _ ==>[x] _)).
-    etrans. apply maponpaths.
-    apply maponpaths_2.
-    apply (disp_vcomp_rinv
-             ((xx,,inv_xx):disp_invertible_2cell (x,,inv_x) _ _)).
-    etrans. apply maponpaths. apply disp_mor_transportf_postwhisker.
-    etrans. unfold transportb. apply (transport_f_f (λ x, _ ==>[x] _)).
-    etrans. apply maponpaths. apply disp_id2_left.
-    etrans. unfold transportb. apply (transport_f_f (λ x, _ ==>[x] _)).
+    { apply disp_mor_transportf_prewhisker. }
+    etrans. { apply maponpaths.
+              apply disp_vassocr. }
+    etrans. { apply (transport_f_f (λ x, _ ==>[x] _)). }
+    etrans. { apply maponpaths.
+              apply maponpaths_2.
+              apply (disp_vcomp_rinv
+                       ((xx,,inv_xx):disp_invertible_2cell (x,,inv_x) _ _)). }
+    etrans. { apply maponpaths. apply disp_mor_transportf_postwhisker. }
+    etrans. { unfold transportb. apply (transport_f_f (λ x, _ ==>[x] _)). }
+    etrans. { apply maponpaths. apply disp_id2_left. }
+    etrans. { unfold transportb. apply (transport_f_f (λ x, _ ==>[x] _)). }
     unfold transportb.
     apply maponpaths_2. apply cellset_property.
   Qed.
@@ -957,16 +957,17 @@ Lemma disp_lassociator_to_rassociator_post' {a b c d : C}
   : xx •• disp_rassociator ff gg hh = transportb (λ x, _ ==>[x] _) q (yy).
 Proof.
   etrans.
-  use disp_lhs_right_invert_cell.
-  - exact y.
-  - apply is_invertible_2cell_rassociator.
-  - exact yy.
-  - apply is_disp_invertible_2cell_rassociator.
-  - apply lassociator_to_rassociator_post. exact p.
-  - cbn. etrans. apply pp.
-    apply maponpaths_2.
-    apply cellset_property.
-  - apply maponpaths_2. apply cellset_property.
+  { use disp_lhs_right_invert_cell.
+    - exact y.
+    - apply is_invertible_2cell_rassociator.
+    - exact yy.
+    - apply is_disp_invertible_2cell_rassociator.
+    - apply lassociator_to_rassociator_post. exact p.
+    - cbn. etrans. { apply pp. }
+      apply maponpaths_2.
+      apply cellset_property.
+  }
+  apply maponpaths_2. apply cellset_property.
 Qed.
 
 Lemma disp_lassociator_to_rassociator_post {a b c d : C}
@@ -986,12 +987,13 @@ Lemma disp_lassociator_to_rassociator_post {a b c d : C}
   : xx •• disp_rassociator ff gg hh = transportb (λ x, _ ==>[x] _) q (yy).
 Proof.
   etrans.
-  use disp_lassociator_to_rassociator_post'.
-  - exact y.
-  - exact p.
-  - exact yy.
-  - exact pp.
-  - apply maponpaths_2. apply cellset_property.
+  { use disp_lassociator_to_rassociator_post'.
+    - exact y.
+    - exact p.
+    - exact yy.
+    - exact pp.
+  }
+  apply maponpaths_2. apply cellset_property.
 Qed.
 
 Lemma disp_lassociator_to_rassociator_pre {a b c d : C}
@@ -1011,17 +1013,18 @@ Lemma disp_lassociator_to_rassociator_pre {a b c d : C}
   : disp_rassociator ff gg hh •• xx = transportb (λ x, _ ==>[x] _) q (yy).
 Proof.
   etrans.
-  use disp_lhs_left_invert_cell.
-  - exact y.
-  - apply is_invertible_2cell_rassociator.
-  - exact yy.
-  - apply is_disp_invertible_2cell_rassociator.
-  - apply lassociator_to_rassociator_pre. exact p.
-  - cbn. etrans. apply pp.
-    apply maponpaths_2.
-    apply cellset_property.
-  - apply maponpaths_2.
-    apply cellset_property.
+  { use disp_lhs_left_invert_cell.
+    - exact y.
+    - apply is_invertible_2cell_rassociator.
+    - exact yy.
+    - apply is_disp_invertible_2cell_rassociator.
+    - apply lassociator_to_rassociator_pre. exact p.
+    - cbn. etrans. { apply pp. }
+      apply maponpaths_2.
+      apply cellset_property.
+  }
+  apply maponpaths_2.
+  apply cellset_property.
 Qed.
 
 Lemma disp_lunitor_lwhisker {a b c : C} {f : C⟦a,b⟧} {g : C⟦b,c⟧}
@@ -1033,18 +1036,19 @@ Lemma disp_lunitor_lwhisker {a b c : C} {f : C⟦a,b⟧} {g : C⟦b,c⟧}
                (disp_runitor ff ▹▹ gg).
 Proof.
   etrans.
-  use disp_lassociator_to_rassociator_pre.
-  - exact (runitor f ▹ g).
-  - exact (disp_runitor ff ▹▹ gg).
-  - apply lunitor_lwhisker.
-  - apply pathsinv0.
-    etrans.
-    apply maponpaths. apply disp_runitor_rwhisker.
-    etrans.
-    apply (transport_f_f (λ α, _ ==>[α] _)).
-    apply (transportf_set (λ α, _ ==>[α] _)).
-    apply cellset_property.
-  - apply maponpaths_2, cellset_property.
+  { use disp_lassociator_to_rassociator_pre.
+    - exact (runitor f ▹ g).
+    - exact (disp_runitor ff ▹▹ gg).
+    - apply lunitor_lwhisker.
+    - apply pathsinv0.
+      etrans.
+      { apply maponpaths. apply disp_runitor_rwhisker. }
+      etrans.
+      { apply (transport_f_f (λ α, _ ==>[α] _)). }
+      apply (transportf_set (λ α, _ ==>[α] _)).
+      apply cellset_property.
+  }
+  apply maponpaths_2, cellset_property.
 Qed.
 
 
@@ -1471,9 +1475,9 @@ cbn.
 intros.
 unfold total_prebicat_cell_struct.
 apply isaset_total2.
-apply cellset_property.
-intros.
-apply disp_cellset_property.
+- apply cellset_property.
+- intros.
+  apply disp_cellset_property.
 Qed.
 
 Definition total_bicat (D : disp_bicat) : bicat

--- a/UniMath/Bicategories/DisplayedBicats/DispInvertibles.v
+++ b/UniMath/Bicategories/DisplayedBicats/DispInvertibles.v
@@ -478,11 +478,11 @@ Section Total_invertible_2cells.
     apply weqimplimpl.
     3: apply isaprop_is_invertible_2cell.
     3: { apply isofhleveltotal2.
-         apply isaprop_is_invertible_2cell.
+         { apply isaprop_is_invertible_2cell. }
          intro Hα.
          pose (α' := (α,,Hα) : invertible_2cell _ _).
          apply (isaprop_is_disp_invertible_2cell (x:=α') αα). }
-    apply is_invertible_total_to_disp.
+    { apply is_invertible_total_to_disp. }
     apply is_invertible_disp_to_total.
   Defined.
 
@@ -707,9 +707,9 @@ Definition vcomp_disp_invertible
   : disp_invertible_2cell (comp_of_invertible_2cell α β) ff hh.
 Proof.
   use tpair.
-  repeat use tpair.
-  - exact (αα •• ββ).
-  - apply vcomp_disp_is_invertible.
+  { repeat use tpair.
+    exact (αα •• ββ). }
+  apply vcomp_disp_is_invertible.
 Defined.
 
 Definition is_disp_invertible_2cell_lunitor

--- a/UniMath/Bicategories/DisplayedBicats/DispUnivalence.v
+++ b/UniMath/Bicategories/DisplayedBicats/DispUnivalence.v
@@ -534,9 +534,9 @@ Lemma total_is_univalent_2
 Proof.
   intros UD UC.
   split.
-  - apply total_is_univalent_2_0. apply UC.
+  - apply total_is_univalent_2_0. { apply UC. }
     apply disp_univalent_2_0_of_2. assumption.
-  - apply total_is_univalent_2_1. apply UC.
+  - apply total_is_univalent_2_1. { apply UC. }
     apply disp_univalent_2_1_of_2. assumption.
 Defined.
 

--- a/UniMath/Bicategories/DisplayedBicats/Examples/Cofunctormap.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/Cofunctormap.v
@@ -128,8 +128,8 @@ Section Cofunctormaps.
   Definition morphisms_of_presheaves_display : disp_bicat bicat_of_univ_cats.
   Proof.
     use sigma_bicat.
-    apply disp_two_presheaves.
-    exact disp_cofunctormaps_bicat.
+    - apply disp_two_presheaves.
+    - exact disp_cofunctormaps_bicat.
   Defined.
 
   Definition morphisms_of_presheaves : bicat

--- a/UniMath/Bicategories/DisplayedBicats/Examples/CwF.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/CwF.v
@@ -205,7 +205,7 @@ Section CwFRepresentation.
   Proof.
     apply pathsinv0.
     etrans. 2: apply yy_natural.
-    etrans. apply yy_comp_nat_trans.
+    etrans. { apply yy_comp_nat_trans. }
     apply maponpaths, e.
   Qed.
 
@@ -271,7 +271,7 @@ Section CwFRepresentation.
         cbn in XR'.
         assert (XR'':= toforallpaths _ _  _ XR').
         cbn in XR''.
-        etrans. apply XR''.
+        etrans. { apply XR''. }
         apply id_left.
       + unfold TT; clear TT.
         match goal with |[|- transportf ?r  _ _ = _ ] => set (P:=r) end.
@@ -289,9 +289,9 @@ Section CwFRepresentation.
         rewrite inv_from_z_iso_iso_from_fully_faithful_reflection.
         assert (XX:=homotweqinvweq (weq_from_fully_faithful
                                       (yoneda_fully_faithful _) ΓA' ΓA )).
-        etrans. apply maponpaths_2. apply XX.
+        etrans. { apply maponpaths_2. apply XX. }
         clear XX.
-        etrans. apply maponpaths_2. unfold from_Pullback_to_Pullback. apply idpath.
+        etrans. { apply maponpaths_2. unfold from_Pullback_to_Pullback. apply idpath. }
         pose (XR' := PullbackArrow_PullbackPr2
                        (make_Pullback _ isP)
                        (yoneda_objects C ΓA')

--- a/UniMath/Bicategories/DisplayedBicats/Examples/DispBicatOfDispCats.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/DispBicatOfDispCats.v
@@ -92,15 +92,15 @@ Proof.
   ; unfold transportb
   ; (etrans ; [ apply disp_nat_trans_transportf | ]).
   - apply pathsinv0.
-    etrans. apply id_left_disp.
+    etrans. { apply id_left_disp. }
     apply pathsinv0; unfold transportb.
     apply maponpaths_2. apply homset_property.
   - apply pathsinv0.
-    etrans. apply id_right_disp.
+    etrans. { apply id_right_disp. }
     apply pathsinv0; unfold transportb.
     apply maponpaths_2. apply homset_property.
   - apply pathsinv0.
-    etrans. apply assoc_disp.
+    etrans. { apply assoc_disp. }
     apply pathsinv0; unfold transportb.
     apply maponpaths_2. apply homset_property.
   - apply transportf_set. apply homset_property.
@@ -119,7 +119,7 @@ Proof.
       apply maponpaths.
       apply disp_functor_comp.
     }
-    etrans. apply transport_f_f.
+    etrans. { apply transport_f_f. }
     apply transportf_set. apply homset_property.
   - cbn.
     etrans.
@@ -127,15 +127,15 @@ Proof.
       apply maponpaths.
       apply id_left_disp.
     }
-    etrans. apply transport_f_f.
+    etrans. { apply transport_f_f. }
     apply pathsinv0.
-    etrans. apply id_right_disp.
+    etrans. { apply id_right_disp. }
     unfold transportb. apply maponpaths_2. apply homset_property.
   - cbn.
-    etrans. apply maponpaths. apply id_left_disp.
-    etrans. apply transport_f_f.
+    etrans. { apply maponpaths. apply id_left_disp. }
+    etrans. { apply transport_f_f. }
     apply pathsinv0.
-    etrans. apply id_right_disp.
+    etrans. { apply id_right_disp. }
     unfold transportb. apply maponpaths_2. apply homset_property.
   - cbn.
     etrans.
@@ -143,70 +143,69 @@ Proof.
       apply maponpaths.
       apply id_left_disp.
     }
-    etrans. apply transport_f_f.
+    etrans. { apply transport_f_f. }
     apply pathsinv0.
-    etrans. apply id_right_disp.
+    etrans. { apply id_right_disp. }
     unfold transportb. apply maponpaths_2. apply homset_property.
   - cbn.
-    etrans. apply maponpaths. apply id_left_disp.
-    etrans. apply transport_f_f.
+    etrans. { apply maponpaths. apply id_left_disp. }
+    etrans. { apply transport_f_f. }
     apply pathsinv0.
-    etrans. apply id_right_disp.
+    etrans. { apply id_right_disp. }
     unfold transportb. apply maponpaths_2. apply homset_property.
   - cbn.
-    etrans. apply maponpaths. apply id_right_disp.
-    etrans. apply transport_f_f.
+    etrans. { apply maponpaths. apply id_right_disp. }
+    etrans. { apply transport_f_f. }
     apply pathsinv0.
-    etrans. apply id_left_disp.
+    etrans. { apply id_left_disp. }
     unfold transportb. apply maponpaths_2. apply homset_property.
   - cbn.
     set (RR := @disp_nat_trans_ax_var _ _ _ _ _ _ _ _ _ φφ).
-    etrans. apply maponpaths. apply RR.
-    etrans. apply transport_f_f.
+    etrans. { apply maponpaths. apply RR. }
+    etrans. { apply transport_f_f. }
     apply transportf_set. apply homset_property.
   - cbn.
     apply pathsinv0.
-    etrans. apply id_right_disp.
+    etrans. { apply id_right_disp. }
     unfold transportb. apply maponpaths_2. apply homset_property.
   - cbn.
     apply pathsinv0.
-    etrans. apply id_right_disp.
+    etrans. { apply id_right_disp. }
     unfold transportb. apply maponpaths_2. apply homset_property.
   - cbn.
     apply pathsinv0.
-    etrans. apply id_right_disp.
+    etrans. { apply id_right_disp. }
     unfold transportb. apply maponpaths_2. apply homset_property.
   - cbn.
     apply pathsinv0.
-    etrans. apply id_right_disp.
+    etrans. { apply id_right_disp. }
     unfold transportb. apply maponpaths_2. apply homset_property.
   - cbn.
     apply pathsinv0.
-    etrans. apply id_right_disp.
+    etrans. { apply id_right_disp. }
     unfold transportb. apply maponpaths_2. apply homset_property.
   - cbn.
     apply pathsinv0.
-    etrans. apply id_right_disp.
+    etrans. { apply id_right_disp. }
     unfold transportb. apply maponpaths_2. apply homset_property.
   - cbn.
     apply pathsinv0.
-    etrans. apply id_left_disp.
-    etrans. apply maponpaths. apply disp_functor_id.
-    etrans. apply transport_f_f.
+    etrans. { apply id_left_disp. }
+    etrans. { apply maponpaths. apply disp_functor_id. }
+    etrans. { apply transport_f_f. }
     apply maponpaths_2. apply homset_property.
   - cbn.
     apply pathsinv0.
-    etrans. apply assoc_disp_var.
-    etrans. apply maponpaths. apply id_left_disp.
-    etrans. apply transport_f_f.
-    etrans. apply maponpaths. apply id_left_disp.
-    etrans. apply transport_f_f.
-    etrans. apply maponpaths. apply disp_functor_id.
-    etrans. apply transport_f_f.
-
+    etrans. { apply assoc_disp_var. }
+    etrans. { apply maponpaths. apply id_left_disp. }
+    etrans. { apply transport_f_f. }
+    etrans. { apply maponpaths. apply id_left_disp. }
+    etrans. { apply transport_f_f. }
+    etrans. { apply maponpaths. apply disp_functor_id. }
+    etrans. { apply transport_f_f. }
     apply pathsinv0.
-    etrans. apply maponpaths. apply id_left_disp.
-    etrans. apply transport_f_f.
+    etrans. { apply maponpaths. apply id_left_disp. }
+    etrans. { apply transport_f_f. }
     apply maponpaths_2. apply homset_property.
 Qed.
 

--- a/UniMath/Bicategories/DisplayedBicats/Examples/PointedOneTypes.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/PointedOneTypes.v
@@ -113,8 +113,8 @@ Proof.
     use subtypePath.
     { intros y y'.
       apply (isaprop_disp_left_adjoint_equivalence (D:=p1types_disp)).
-      apply one_types_is_univalent_2.
-      apply p1types_disp_univalent_2_1. }
+      + apply one_types_is_univalent_2.
+      + apply p1types_disp_univalent_2_1. }
     cbn ; cbn in f.
     induction f.
     apply idpath.

--- a/UniMath/Bicategories/DisplayedBicats/Examples/Trivial.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/Trivial.v
@@ -79,27 +79,27 @@ Section Trivial_Displayed.
   Lemma trivial_disp_prebicat_laws : disp_prebicat_laws trivial_displayed_data.
   Proof.
     repeat apply make_dirprod; red; cbn; intros.
-    - etrans. apply id2_left. apply transportf_trivial.
-    - etrans. apply id2_right. apply transportf_trivial.
-    - etrans. apply vassocr. apply transportf_trivial.
-    - etrans. apply lwhisker_id2. apply transportf_trivial.
-    - etrans. apply id2_rwhisker. apply transportf_trivial.
-    - etrans. apply lwhisker_vcomp. apply transportf_trivial.
-    - etrans. apply rwhisker_vcomp. apply transportf_trivial.
-    - etrans. apply vcomp_lunitor. apply transportf_trivial.
-    - etrans. apply vcomp_runitor. apply transportf_trivial.
-    - etrans. apply lwhisker_lwhisker. apply transportf_trivial.
-    - etrans. apply rwhisker_lwhisker. apply transportf_trivial.
-    - etrans. apply rwhisker_rwhisker. apply transportf_trivial.
-    - etrans. apply vcomp_whisker. apply transportf_trivial.
-    - etrans. apply lunitor_linvunitor. apply transportf_trivial.
-    - etrans. apply linvunitor_lunitor. apply transportf_trivial.
-    - etrans. apply runitor_rinvunitor. apply transportf_trivial.
-    - etrans. apply rinvunitor_runitor. apply transportf_trivial.
-    - etrans. apply lassociator_rassociator. apply transportf_trivial.
-    - etrans. apply rassociator_lassociator. apply transportf_trivial.
-    - etrans. apply runitor_rwhisker. apply transportf_trivial.
-    - etrans. apply lassociator_lassociator. apply transportf_trivial.
+    - etrans. { apply id2_left. } apply transportf_trivial.
+    - etrans. { apply id2_right. } apply transportf_trivial.
+    - etrans. { apply vassocr. } apply transportf_trivial.
+    - etrans. { apply lwhisker_id2. } apply transportf_trivial.
+    - etrans. { apply id2_rwhisker. } apply transportf_trivial.
+    - etrans. { apply lwhisker_vcomp. } apply transportf_trivial.
+    - etrans. { apply rwhisker_vcomp. } apply transportf_trivial.
+    - etrans. { apply vcomp_lunitor. } apply transportf_trivial.
+    - etrans. { apply vcomp_runitor. } apply transportf_trivial.
+    - etrans. { apply lwhisker_lwhisker. } apply transportf_trivial.
+    - etrans. { apply rwhisker_lwhisker. } apply transportf_trivial.
+    - etrans. { apply rwhisker_rwhisker. } apply transportf_trivial.
+    - etrans. { apply vcomp_whisker. } apply transportf_trivial.
+    - etrans. { apply lunitor_linvunitor. } apply transportf_trivial.
+    - etrans. { apply linvunitor_lunitor. } apply transportf_trivial.
+    - etrans. { apply runitor_rinvunitor. } apply transportf_trivial.
+    - etrans. { apply rinvunitor_runitor. } apply transportf_trivial.
+    - etrans. { apply lassociator_rassociator. } apply transportf_trivial.
+    - etrans. { apply rassociator_lassociator. } apply transportf_trivial.
+    - etrans. { apply runitor_rwhisker. } apply transportf_trivial.
+    - etrans. { apply lassociator_lassociator. } apply transportf_trivial.
   Qed.
 
   Definition trivial_displayed_prebicat : disp_prebicat B

--- a/UniMath/Bicategories/MonoidalCategories/ActionBasedStrongFunctorsWhiskeredMonoidal.v
+++ b/UniMath/Bicategories/MonoidalCategories/ActionBasedStrongFunctorsWhiskeredMonoidal.v
@@ -1549,7 +1549,7 @@ Section Main.
     Proof.
       exists montrafotargetbicat_disp_monoidal_data.
       split.
-      exact montrafotargetbicat_disp_leftunitor_law.
+      { exact montrafotargetbicat_disp_leftunitor_law. }
       split; [ exact montrafotargetbicat_disp_rightunitor_law |].
       split; [ exact montrafotargetbicat_disp_associator_law |].
       (** now we benefit from working in a displayed monoidal category *)

--- a/UniMath/Bicategories/MonoidalCategories/UnivalenceMonCat/TensorLayer.v
+++ b/UniMath/Bicategories/MonoidalCategories/UnivalenceMonCat/TensorLayer.v
@@ -602,8 +602,8 @@ Section TensorLayer.
       use subtypePath.
       + intro f.
         apply isaprop_disp_left_adjoint_equivalence.
-        apply univalent_cat_is_univalent_2_1.
-        apply bidisp_tensor_disp_bicat_is_locally_univalent.
+        * apply univalent_cat_is_univalent_2_1.
+        * apply bidisp_tensor_disp_bicat_is_locally_univalent.
       + apply idpath.
   Defined.
 

--- a/UniMath/Bicategories/MonoidalCategories/UnivalenceMonCat/UnitLayer.v
+++ b/UniMath/Bicategories/MonoidalCategories/UnivalenceMonCat/UnitLayer.v
@@ -248,8 +248,8 @@ Section UnitLayer.
         use subtypePath.
         * intro f.
           apply isaprop_disp_left_adjoint_equivalence.
-          apply univalent_cat_is_univalent_2_1.
-          apply bidisp_unit_disp_prebicat_is_locally_univalent.
+          -- apply univalent_cat_is_univalent_2_1.
+          -- apply bidisp_unit_disp_prebicat_is_locally_univalent.
         * apply idpath.
   Defined.
 

--- a/UniMath/Bicategories/PseudoFunctors/Display/Map1Cells.v
+++ b/UniMath/Bicategories/PseudoFunctors/Display/Map1Cells.v
@@ -656,13 +656,13 @@ Section Map1Cells.
         simple refine (_ ∘ make_weq _ (isweqtoforallpaths _ _ _))%weq.
         apply idweq.
       + refine (_ ∘ weqonsecfibers _ _ _)%weq.
-        intro X ; cbn.
-        refine (weqonsecfibers _ _ _).
-        intro Y ; cbn.
-        simple refine (weqonsecfibers _ _ _).
-        * exact (λ f, invertible_2cell (F₁ X Y f) (F₁' X Y f)).
-        * intro f ; cbn.
-          exact (make_weq (idtoiso_2_1 (F₁ X Y f) (F₁' X Y f)) (HD_2_1 _ _ _ _)).
+        * intro X ; cbn.
+          refine (weqonsecfibers _ _ _).
+          intro Y ; cbn.
+          simple refine (weqonsecfibers _ _ _).
+          -- exact (λ f, invertible_2cell (F₁ X Y f) (F₁' X Y f)).
+          -- intro f ; cbn.
+             exact (make_weq (idtoiso_2_1 (F₁ X Y f) (F₁' X Y f)) (HD_2_1 _ _ _ _)).
         * exact (all_invertible_2cell_is_disp_adjoint_equivalence HD_2_1 F₀ F₁ F₁').
     - intro p.
       induction p.

--- a/UniMath/Bicategories/WkCatEnrichment/hcomp_bicat.v
+++ b/UniMath/Bicategories/WkCatEnrichment/hcomp_bicat.v
@@ -839,6 +839,6 @@ Defined.
 Definition weq_bicat_prebicategory : bicat ≃ prebicategory.
 Proof.
   eapply weqcomp.
-  apply (invweq hcomp_bicat_weq_bicat).
-  apply hcomp_bicat_weq_prebicategory.
+  - apply (invweq hcomp_bicat_weq_bicat).
+  - apply hcomp_bicat_weq_prebicategory.
 Defined.

--- a/UniMath/SubstitutionSystems/EquivalenceSignaturesWithActegoryMorphisms.v
+++ b/UniMath/SubstitutionSystems/EquivalenceSignaturesWithActegoryMorphisms.v
@@ -97,7 +97,7 @@ Section A.
    unfold actionbased_strength_nat.
    unfold nat_trans.
    eapply weqcomp.
-   apply weqtotal2asstor.
+   { apply weqtotal2asstor. }
 (*
    set (P := is_nat_trans (actionbased_strength_dom Mon_endo' (ActionBasedStrengthOnHomsInBicat.target_action C D) H)
                (actionbased_strength_codom Mon_endo' (ActionBasedStrengthOnHomsInBicat.domain_action C D') H)).


### PR DESCRIPTION
following issue 1576 puts Export Set Default Goal Selector "!". into the file Bicategories/Core/Bicat.v and then restores compilation It should be safe to assume that any use of bicategories is after an import statement for that file.