### PR TITLE
removes setquotprpathsandR from PAdics

### DIFF
--- a/UniMath/PAdics/lemmas.v
+++ b/UniMath/PAdics/lemmas.v
@@ -947,18 +947,6 @@ Proof.
            ++ intros k s. rewrite right in s. apply ( IHn k ). assumption.
 Defined.
 
-Lemma setquotprpathsandR { X : UU } ( R : eqrel X ) :
-  forall x y : X, setquotpr R x = setquotpr R y -> R x y.
-Proof.
-  intros.
-  assert ( pr1 ( setquotpr R x ) y ) as i.
-  { assert ( pr1 ( setquotpr R y ) y ) as i0.
-    { unfold setquotpr. simpl. apply (pr2 (pr1 (pr2 R))). }
-    destruct X0. assumption.
-  }
-  apply i.
-Defined.
-
 (* Some lemmas on decidable properties of natural numbers. *)
 
 Definition isdecnatprop ( P : nat -> hProp ) :=

--- a/UniMath/PAdics/z_mod_p.v
+++ b/UniMath/PAdics/z_mod_p.v
@@ -2344,7 +2344,7 @@ Proof.
     change ( 0%ring ) with
     ( setquotpr ( hzmodisringeqrel p ( isaprimetoneq0 y ) ) 0%hz ).
     assert ( hzmodisringeqrel p ( isaprimetoneq0 y ) 1%hz 0%hz ) as o.
-    { apply ( setquotprpathsandR
+    { apply ( weqpathsinsetquot
                 ( hzmodisringeqrel p ( isaprimetoneq0 y ) ) 1%hz 0%hz ).
       assumption.
     }


### PR DESCRIPTION
- @nmvdw  identified a richer result already in Foundations.Sets (with weq instead of only the implication), as mentioned in [the discussion of PR 1582](https://github.com/UniMath/UniMath/pull/1582#issuecomment-1293595958)
- satellite repos will have to use `weqpathsinsetquot `instead of `setquotprpathsandR`