### PR TITLE
corrects identifier unvialent_category_binproduct

### DIFF
--- a/UniMath/Bicategories/DisplayedBicats/Examples/Sigma.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/Sigma.v
@@ -3,7 +3,7 @@
     Benedikt Ahrens, Marco Maggesi
     February 2018
 
-   Dependent product of displayed bicategories
+   Dependent sum of displayed bicategories
  ********************************************************************************* *)
 
 Require Import UniMath.Foundations.All.

--- a/UniMath/CategoryTheory/CommaCategories.v
+++ b/UniMath/CategoryTheory/CommaCategories.v
@@ -293,7 +293,7 @@ Section CommaCategory.
     : is_univalent comma.
   Proof.
     use is_univalent_total_category.
-    - apply is_unvialent_category_binproduct.
+    - apply is_univalent_category_binproduct.
       + exact HC₁.
       + exact HC₂.
     - exact (is_univalent_disp_comma_disp_cat HC₃).

--- a/UniMath/CategoryTheory/IsoCommaCategory.v
+++ b/UniMath/CategoryTheory/IsoCommaCategory.v
@@ -194,7 +194,7 @@ Section IsoCommaCategory.
     : is_univalent iso_comma.
   Proof.
     use is_univalent_total_category.
-    - apply is_unvialent_category_binproduct.
+    - apply is_univalent_category_binproduct.
       + exact HC₁.
       + exact HC₂.
     - exact (is_univalent_disp_iso_comma_disp_cat HC₃).

--- a/UniMath/CategoryTheory/Monoidal/RezkCompletion/LiftedAssociator.v
+++ b/UniMath/CategoryTheory/Monoidal/RezkCompletion/LiftedAssociator.v
@@ -48,7 +48,6 @@ Section RezkAssociator.
 
   Definition DDDuniv : is_univalent ((D ⊠ D) ⊠ D).
   Proof.
-    (* Search (is_univalent (_ ⊠ _)). *)
     apply is_univalent_category_binproduct.
     2: exact Duniv.
     apply is_univalent_category_binproduct.

--- a/UniMath/CategoryTheory/Monoidal/RezkCompletion/LiftedAssociator.v
+++ b/UniMath/CategoryTheory/Monoidal/RezkCompletion/LiftedAssociator.v
@@ -48,10 +48,10 @@ Section RezkAssociator.
 
   Definition DDDuniv : is_univalent ((D ⊠ D) ⊠ D).
   Proof.
-    Search (is_univalent (_ ⊠ _)).
-    apply is_unvialent_category_binproduct.
+    (* Search (is_univalent (_ ⊠ _)). *)
+    apply is_univalent_category_binproduct.
     2: exact Duniv.
-    apply is_unvialent_category_binproduct.
+    apply is_univalent_category_binproduct.
     exact Duniv.
     exact Duniv.
   Qed.

--- a/UniMath/CategoryTheory/PrecategoryBinProduct.v
+++ b/UniMath/CategoryTheory/PrecategoryBinProduct.v
@@ -1235,7 +1235,7 @@ Section Univalence.
           (HC : is_univalent C)
           (HD : is_univalent D).
 
-  Definition is_unvialent_category_binproduct
+  Definition is_univalent_category_binproduct
     : is_univalent (category_binproduct C D).
   Proof.
     intros x y.
@@ -1260,7 +1260,7 @@ Definition univalent_category_binproduct
 Proof.
   use make_univalent_category.
   - exact (category_binproduct C₁ C₂).
-  - use is_unvialent_category_binproduct.
+  - use is_univalent_category_binproduct.
     + exact (pr2 C₁).
     + exact (pr2 C₂).
 Defined.

--- a/UniMath/CategoryTheory/PrecompEquivalence.v
+++ b/UniMath/CategoryTheory/PrecompEquivalence.v
@@ -380,7 +380,7 @@ Section LiftedFunctorsPairFunctor.
   Let FF_eso := pair_functor_eso _ _ F1_eso F2_eso.
   Let FF_ff := pair_functor_ff _ _ F1_ff F2_ff.
 
-  Let DD' := (_ ,, is_unvialent_category_binproduct (pr2 D1') (pr2 D2')) : univalent_category.
+  Let DD' := (_ ,, is_univalent_category_binproduct (pr2 D1') (pr2 D2')) : univalent_category.
 
   Definition lift_functor_along_pair
              (H1 : functor C1 C1') (H2 : functor C2 C2')
@@ -428,9 +428,9 @@ Section LiftedFunctorsProperties.
   Let FFF'_ff := pair_functor_ff _ _ F1_ff FF_ff.
   Let FFF'_eso := pair_functor_eso _ _ F1_eso FF_eso.
 
-  Let DD := (_ ,, is_unvialent_category_binproduct (pr2 D) (pr2 D)) : univalent_category.
-  Let DDD := (_ ,, is_unvialent_category_binproduct (pr2 DD) (pr2 D)) : univalent_category.
-  Let DDD' := (_ ,, is_unvialent_category_binproduct (pr2 D) (pr2 DD)) : univalent_category.
+  Let DD := (_ ,, is_univalent_category_binproduct (pr2 D) (pr2 D)) : univalent_category.
+  Let DDD := (_ ,, is_univalent_category_binproduct (pr2 DD) (pr2 D)) : univalent_category.
+  Let DDD' := (_ ,, is_univalent_category_binproduct (pr2 D) (pr2 DD)) : univalent_category.
 
   Lemma lift_functor_along_comm_prod
         (H : functor (category_binproduct C C) C)


### PR DESCRIPTION
plus minor stuff: comments out a Search command and corrects a wrong header comment (in Sigma.v)