### PR TITLE
Housekeeping PR october

### DIFF
--- a/UniMath/Bicategories/DisplayedBicats/Examples/CwF.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/CwF.v
@@ -144,33 +144,6 @@ Proof.
   apply idpath.
 Defined.
 
-Lemma forall_isotid (A : category) (a_is : is_univalent A)
-      (a a' : A) (P : z_iso a a' -> UU)
-  : (∏ e, P (idtoiso e)) → ∏ i, P i.
-Proof.
-  intros H i.
-  rewrite <- (idtoiso_isotoid _ a_is).
-  apply H.
-Defined.
-
-Lemma transportf_isotoid_functor
-      (A X : category) (H : is_univalent A)
-      (K : functor A X)
-      (a a' : A) (p : z_iso a a') (b : X) (f : K a --> b)
-  : transportf (fun a0 => K a0 --> b) (isotoid _ H p) f = (#K)%cat (inv_from_z_iso p) · f.
-Proof.
-  rewrite functor_on_inv_from_z_iso. simpl. cbn.
-  generalize p.
-  apply forall_isotid.
-  - apply H.
-  - intro e. induction e.
-    cbn.
-    rewrite functor_id.
-    rewrite id_left.
-    rewrite isotoid_identity_iso.
-    apply idpath.
-Defined.
-
 Lemma inv_from_z_iso_iso_from_fully_faithful_reflection {C D : precategory}
       (F : functor C D) (HF : fully_faithful F) (a b : C) (i : z_iso (F a) (F b))
   : inv_from_z_iso
@@ -284,7 +257,7 @@ Section CwFRepresentation.
         }
         etrans.
         {
-          apply (transportf_isotoid_functor C (functor_category _ SET)).
+          apply (@transportf_functor_isotoid C (functor_category _ SET)).
         }
         rewrite inv_from_z_iso_iso_from_fully_faithful_reflection.
         assert (XX:=homotweqinvweq (weq_from_fully_faithful

--- a/UniMath/CategoryTheory/Adjunctions/Core.v
+++ b/UniMath/CategoryTheory/Adjunctions/Core.v
@@ -592,7 +592,6 @@ Let G : functor E D := left_adjoint HF.
 Let H : are_adjoints G F := pr2 HF.
 Let ε : nat_trans (functor_composite F G) (functor_identity D) := counit_from_left_adjoint H.
 Let η : nat_trans (functor_identity E) (functor_composite G F) := unit_from_left_adjoint H.
-Check triangle_id_right_ad H.
 Let H1 : ∏ d : D, _ = identity (F d) := triangle_id_right_ad H.
 Let H2 : ∏ e : E, _ = identity (G e) := triangle_id_left_ad H.
 

--- a/UniMath/CategoryTheory/Core/Categories.v
+++ b/UniMath/CategoryTheory/Core/Categories.v
@@ -38,8 +38,6 @@ Definition precategory_morphisms { C : precategory_ob_mor } :
 Declare Scope cat.
 Delimit Scope cat with cat.     (* for precategories *)
 Delimit Scope cat with Cat.     (* a slight enhancement for categories *)
-Declare Scope cat_deprecated.
-Delimit Scope cat_deprecated with cat_deprecated.
 Local Open Scope cat.
 
 Notation "a --> b" := (precategory_morphisms a b) : cat.
@@ -84,8 +82,6 @@ Definition identity {C : precategory_data}
 Definition compose {C : precategory_data} { a b c : C }
   : a --> b -> b --> c -> a --> c
   := pr2 (pr2 C) a b c.
-
-Notation "f ;; g" := (compose f g) (at level 50, left associativity, format "f  ;;  g") : cat_deprecated.
 
 Notation "f · g" := (compose f g) : cat.
 (* to input: type "\centerdot" or "\cdot" with Agda input method *)

--- a/UniMath/CategoryTheory/Core/Functors.v
+++ b/UniMath/CategoryTheory/Core/Functors.v
@@ -992,13 +992,9 @@ Defined.
 Lemma isaprop_full_and_faithful (C D : precategory_data) (F : functor C D) :
    isaprop (full_and_faithful F).
 Proof.
-  apply isofhleveldirprod.
-  apply impred; intro.
-  apply impred; intro.
-  apply impred; intro.
-  simpl. repeat (apply impred; intro).
-  apply isapropishinh.
-  apply isaprop_faithful.
+  apply isapropdirprod.
+  - apply isaprop_full.
+  - apply isaprop_faithful.
 Qed.
 
 

--- a/UniMath/CategoryTheory/Core/Functors.v
+++ b/UniMath/CategoryTheory/Core/Functors.v
@@ -404,6 +404,22 @@ Proof.
   apply id_left.
 Qed.
 
+Lemma idtoiso_functor_precompose'
+      {C₁ C₂ : category}
+      (F : C₁ ⟶ C₂)
+      {y : C₂}
+      {x₁ x₂ : C₁}
+      (p : x₁ = x₂)
+      (f : y --> F x₁)
+  : f · idtoiso (maponpaths (λ z, F z) p)
+    =
+      transportf (λ z, y --> F z) p f.
+Proof.
+  induction p.
+  cbn.
+  apply id_right.
+Qed.
+
 Definition transportf_functor_isotoid
            {C₁ C₂ : category}
            (HC₁ : is_univalent C₁)
@@ -422,6 +438,27 @@ Proof.
   rewrite <- idtoiso_functor_precompose.
   rewrite maponpaths_idtoiso.
   rewrite idtoiso_inv.
+  rewrite idtoiso_isotoid.
+  apply idpath.
+Qed.
+
+Lemma transportf_functor_isotoid'
+      {C₁ C₂ : category}
+      (HC₁ : is_univalent C₁)
+      (F : C₁ ⟶ C₂)
+      {y : C₂}
+      {x₁ x₂ : C₁}
+      (i : z_iso x₁ x₂)
+      (f : y --> F x₁)
+  : transportf
+      (λ z, y --> F z)
+      (isotoid _ HC₁ i)
+      f
+    =
+      f · #F i.
+Proof.
+  rewrite <- idtoiso_functor_precompose'.
+  rewrite maponpaths_idtoiso.
   rewrite idtoiso_isotoid.
   apply idpath.
 Qed.

--- a/UniMath/CategoryTheory/Core/Univalence.v
+++ b/UniMath/CategoryTheory/Core/Univalence.v
@@ -13,6 +13,7 @@
 
 Require Import UniMath.Foundations.PartA.
 Require Import UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Tactics.
 
 Require Import UniMath.CategoryTheory.Core.Categories.
@@ -240,6 +241,19 @@ Proof.
   apply maponpaths.
   rewrite idtoiso_isotoid.
   apply idpath.
+Qed.
+
+Lemma transportb_isotoid (C : category) (H : is_univalent C)
+  (a b b' : ob C) (p : z_iso b b') (f : a --> b') :
+  transportb (λ b0 : C, a --> b0) (isotoid C H p) f = f · inv_from_z_iso p.
+Proof.
+  apply pathsinv0.
+  apply transportb_transpose_right.
+  change (precategory_morphisms a) with (λ b0 : C, a --> b0).
+  rewrite transportf_isotoid'.
+  rewrite <- assoc.
+  rewrite z_iso_after_z_iso_inv.
+  apply id_right.
 Qed.
 
 Lemma transportf_isotoid_dep (C : precategory)

--- a/UniMath/CategoryTheory/DisplayedCats/Core.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Core.v
@@ -40,9 +40,6 @@ Require Import UniMath.CategoryTheory.Core.Univalence.
 Require Import UniMath.CategoryTheory.Core.Functors.
 Require Import UniMath.CategoryTheory.whiskering.
 Local Open Scope cat.
-Local Open Scope cat_deprecated.
-
-
 Local Open Scope type_scope.
 
 (* Undelimit Scope transport. *)
@@ -60,7 +57,7 @@ Definition disp_cat' (C : category) : UU :=
     (id_disp : ∏ {x : C} (xx : ob_disp x), mor_disp (identity x) xx xx)
     (comp_disp : ∏ {x y z : C} {f : x --> y} {g : y --> z}
                    {xx : ob_disp x} {yy : ob_disp y} {zz : ob_disp z},
-                 mor_disp f xx yy -> mor_disp g yy zz -> mor_disp (f ;; g) xx zz)
+                 mor_disp f xx yy -> mor_disp g yy zz -> mor_disp (f · g) xx zz)
     (id_left_disp : ∏ {x y} {f : x --> y} {xx} {yy} (ff : mor_disp f xx yy),
                     comp_disp (id_disp xx) ff
                     = transportb (λ g, mor_disp g xx yy) (id_left _) ff)
@@ -121,7 +118,7 @@ Definition disp_cat_id_comp (C : precategory_data)
   : UU
 := (forall (x:C) (xx : D x), xx -->[identity x] xx)
   × (forall (x y z : C) (f : x --> y) (g : y --> z) (xx:D x) (yy:D y) (zz:D z),
-           (xx -->[f] yy) -> (yy -->[g] zz) -> (xx -->[f ;; g] zz)).
+           (xx -->[f] yy) -> (yy -->[g] zz) -> (xx -->[f · g] zz)).
 
 Definition disp_cat_data C := total2 (disp_cat_id_comp C).
 
@@ -140,7 +137,7 @@ Definition id_disp {C: precategory_data} {D : disp_cat_data C} {x:C} (xx : D x)
 Definition comp_disp {C: precategory_data} {D : disp_cat_data C}
   {x y z : C} {f : x --> y} {g : y --> z}
   {xx : D x} {yy} {zz} (ff : xx -->[f] yy) (gg : yy -->[g] zz)
-  : xx -->[f;;g] zz
+  : xx -->[f · g] zz
 := pr2 (pr2 D) _ _ _ _ _ _ _ _ ff gg.
 
 Declare Scope mor_disp_scope.

--- a/UniMath/CategoryTheory/DisplayedCats/StreetOpFibration.v
+++ b/UniMath/CategoryTheory/DisplayedCats/StreetOpFibration.v
@@ -11,43 +11,6 @@ Require Import UniMath.CategoryTheory.DisplayedCats.Fibrations.
 
 Local Open Scope cat.
 
-Lemma idtoiso_functor_precompose'
-      {C₁ C₂ : category}
-      (F : C₁ ⟶ C₂)
-      {y : C₂}
-      {x₁ x₂ : C₁}
-      (p : x₁ = x₂)
-      (f : y --> F x₁)
-  : f · idtoiso (maponpaths (λ z, F z) p)
-    =
-    transportf (λ z, y --> F z) p f.
-Proof.
-  induction p.
-  cbn.
-  apply id_right.
-Qed.
-
-Definition transportf_functor_isotoid'
-           {C₁ C₂ : category}
-           (HC₁ : is_univalent C₁)
-           (F : C₁ ⟶ C₂)
-           {y : C₂}
-           {x₁ x₂ : C₁}
-           (i : z_iso x₁ x₂)
-           (f : y --> F x₁)
-  : transportf
-      (λ z, y --> F z)
-      (isotoid _ HC₁ i)
-      f
-    =
-    f · #F i.
-Proof.
-  rewrite <- idtoiso_functor_precompose'.
-  rewrite maponpaths_idtoiso.
-  rewrite idtoiso_isotoid.
-  apply idpath.
-Qed.
-
 (**
 The definition of a Street opfibration of categories
  *)

--- a/UniMath/CategoryTheory/Equivalences/CompositesAndInverses.v
+++ b/UniMath/CategoryTheory/Equivalences/CompositesAndInverses.v
@@ -26,13 +26,12 @@ Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.PrecategoryBinProduct.
 
 Local Open Scope cat.
-Local Open Scope cat_deprecated.
 
 (** ** Preliminaries *)
 
 Lemma is_z_iso_comp_is_z_iso {C : category} {a b c : ob C}
   (f : C⟦a, b⟧) (g : C⟦b, c⟧)
-  : is_z_isomorphism f -> is_z_isomorphism g -> is_z_isomorphism (f ;; g).
+  : is_z_isomorphism f -> is_z_isomorphism g -> is_z_isomorphism (f · g).
 Proof.
   intros Hf Hg.
   apply (is_z_iso_comp_of_is_z_isos f g Hf Hg).
@@ -65,7 +64,7 @@ Let εinv a := z_iso_inv_from_z_iso (counit_pointwise_z_iso_from_adj_equivalence
 Lemma right_adj_equiv_is_ff : fully_faithful G.
 Proof.
   intros c d.
-  set (inv := (fun f : D1 ⟦G c, G d⟧ => εinv _ ;; #F f ;; ε _ )).
+  set (inv := (fun f : D1 ⟦G c, G d⟧ => εinv _ · #F f · ε _ )).
   simpl in inv.
   apply (isweq_iso _ inv ).
   - intro f. simpl in f. unfold inv.
@@ -78,7 +77,7 @@ Proof.
   - intro g.
     unfold inv.
     do 2 rewrite functor_comp.
-    intermediate_path ((# G (inv_from_z_iso (counit_pointwise_z_iso_from_adj_equivalence GG c)) ;; ηinv _ ) ;; (η _ ;; # G (# F g)) ;; # G (ε d)).
+    intermediate_path ((# G (inv_from_z_iso (counit_pointwise_z_iso_from_adj_equivalence GG c)) · ηinv _ ) · (η _ · # G (# F g)) · # G (ε d)).
     + do 4 rewrite <- assoc.
       apply maponpaths.
       do 2 rewrite assoc.

--- a/UniMath/CategoryTheory/Monads/RelativeMonads.v
+++ b/UniMath/CategoryTheory/Monads/RelativeMonads.v
@@ -885,23 +885,6 @@ Proof.
   apply (isotoid_functorcat_pointwise C D H (R_functor R) (R_functor R')).
 Defined.
 
-
-(** the following lemma should also be put upstream *)
-Lemma transportb_isotoid (C : category) (H : is_univalent C)
-   (a b b' : ob C) (p : z_iso b b') (f : a --> b') :
- transportb (λ b0 : C, a --> b0) (isotoid C H p) f = f · inv_from_z_iso p.
-Proof.
-  apply pathsinv0.
-  apply transportb_transpose_right.
-  change (precategory_morphisms a) with (λ b0 : C, a --> b0).
-  rewrite transportf_isotoid'.
-  rewrite <- assoc.
-  rewrite z_iso_after_z_iso_inv.
-  apply id_right.
-Qed.
-
-
-
 Definition bind_relmonadmor_eq_from_relmonadmor_z_iso {C : precategory_data} {D : category}
            (H: is_univalent D) (J : functor C D) {R R': RelMonad J}
            (α: z_iso(C := category_RelMonad D J) R R')

--- a/UniMath/CategoryTheory/RepresentableFunctors/Precategories.v
+++ b/UniMath/CategoryTheory/RepresentableFunctors/Precategories.v
@@ -118,8 +118,6 @@ Definition makecategory_data
   := make_precategory_data (makecategory_ob_mor obj mor) identity compose.
 
 
-Local Open Scope cat_deprecated.
-
 Definition makeFunctor {C D:category}
            (obj : C -> D)
            (mor : ∏ c c' : C, c --> c' -> obj c --> obj c')

--- a/UniMath/CategoryTheory/ShortExactSequences.v
+++ b/UniMath/CategoryTheory/ShortExactSequences.v
@@ -363,13 +363,10 @@ Arguments CoImage_Eq [A] _.
 Arguments make_ShortShortExact [A] _ _.
 Arguments ShortShortExact_isKernel [A] _ _ _ _.
 Arguments ShortShortExact_Kernel [A] _.
-Arguments LeftShortExact _.
 Arguments make_LeftShortExact [A] _ _.
 Arguments isMonic [A] _ _ _ _ _.
-Arguments RightShortExact _.
 Arguments make_RightShortExact [A] _ _ .
 Arguments isEpi [A] _ _ _ _ _ .
-Arguments ShortShortExact _.
 Arguments make_ShortShortExact [A] _ _.
 
 

--- a/UniMath/CategoryTheory/categories/HSET/Colimits.v
+++ b/UniMath/CategoryTheory/categories/HSET/Colimits.v
@@ -318,7 +318,7 @@ Section finite_subsets.
     : diagram (finite_subsets_graph X) HSET.
   Proof.
     use make_diagram.
-    - exact(λ (A : finite_subset X), carrier_set A).
+    - exact(λ (A : finite_subset X), carrier_subset A).
     - exact(λ (A B : finite_subset X)
               (E : A ⊆ B),
              subtype_inc E).

--- a/UniMath/CategoryTheory/categories/HSET/Colimits.v
+++ b/UniMath/CategoryTheory/categories/HSET/Colimits.v
@@ -55,8 +55,7 @@ Local Definition cobase : UU := ∑ j : vertex g, pr1hSet (dob D j).
 
 (* Theory about hprop is in UniMath.Foundations.Propositions *)
 Local Definition rel0 : hrel cobase := λ (ia jb : cobase),
-  make_hProp (ishinh (∑ f : edge (pr1 ia) (pr1 jb), dmor D f (pr2 ia) = pr2 jb))
-            (isapropishinh _).
+    ∥(∑ f : edge (pr1 ia) (pr1 jb), dmor D f (pr2 ia) = pr2 jb)∥.
 
 Local Definition rel : hrel cobase := eqrel_from_hrel rel0.
 

--- a/UniMath/CategoryTheory/categories/HSET/FilteredColimits.v
+++ b/UniMath/CategoryTheory/categories/HSET/FilteredColimits.v
@@ -281,7 +281,7 @@ Section category_of_kfinite_subsets.
     : functor_data (kfinite_subsets_category X) SET.
   Proof.
     use make_functor_data.
-    - exact(λ (A : kfinite_subtype X), carrier_set A).
+    - exact(λ (A : kfinite_subtype X), carrier_subset A).
     - exact(λ _ _ E, subtype_inc E).
   Defined.
 

--- a/UniMath/CategoryTheory/categories/HSET/Limits.v
+++ b/UniMath/CategoryTheory/categories/HSET/Limits.v
@@ -271,26 +271,15 @@ Proof.
   apply weqfunfromunit.
 Defined.
 
-(** The [hfiber] of a function between sets is also a set. *)
-Definition hfiber_hSet {X Y : hSet} (f : HSET⟦X, Y⟧) (y : Y) : hSet.
-Proof.
-  use make_hSet.
-  - exact (hfiber f y).
-  - apply isaset_hfiber; apply setproperty.
-Defined.
-
 Local Lemma tosecoverunit_compute {X : UU} {x : X} :
   ∏ t, tosecoverunit (λ _ : unit, X) x t = x.
 Proof.
   abstract (induction t; reflexivity).
 Qed.
 
-Local Definition hfiber_hSet_pr1 {X Y : hSet} (f : HSET⟦X, Y⟧) (y : Y) :
-    HSET⟦hfiber_hSet f y, X⟧ := hfiberpr1 f y.
-
 Lemma hfiber_is_pullback {X Y : hSet} (f : HSET⟦X, Y⟧)
       (y : Y) (y' := invweq (weqfunfromunit_HSET _) y) :
-  ∑ H, @isPullback _ _ _ _ _ f y' (hfiber_hSet_pr1 f y)
+  ∑ H, @isPullback _ _ _ _ _ f y' (hfiberpr1 f y : HSET⟦hfiber_hSet f y , X⟧)
                        (TerminalArrow TerminalHSET _) H.
 Proof.
   use tpair.
@@ -302,7 +291,7 @@ Proof.
         Part of the condition is trivial. *)
     use iscontrweqb.
     + exact (∑ hk : HSET ⟦ pb, hfiber_hSet f y ⟧,
-              hk · hfiber_hSet_pr1 f y = pbpr1).
+              hk · hfiberpr1 f y = pbpr1).
     + apply weqfibtototal; intro.
       apply invweq.
       apply dirprod_with_contr_r.

--- a/UniMath/CategoryTheory/categories/HSET/Univalence.v
+++ b/UniMath/CategoryTheory/categories/HSET/Univalence.v
@@ -19,9 +19,6 @@ Local Open Scope cat.
 
 (** ** HSET is a univalent_category. *)
 
-Definition univalenceweq (X X' : UU) : (X = X') ≃ (X ≃ X') :=
-   tpair _ _ (univalenceAxiom X X').
-
 Definition hset_id_weq_z_iso (A B : ob HSET) :
   (A = B) ≃ (z_iso A B) :=
   weqcomp (UA_for_HLevels 2 A B) (hset_equiv_weq_z_iso A B).

--- a/UniMath/CategoryTheory/categories/Type/Univalence.v
+++ b/UniMath/CategoryTheory/categories/Type/Univalence.v
@@ -18,9 +18,6 @@ Require Import UniMath.CategoryTheory.categories.Type.MonoEpiIso.
 
 Local Open Scope cat.
 
-Definition univalenceweq (X X' : UU) : (X = X') ≃ (X ≃ X') :=
-   tpair _ _ (univalenceAxiom X X').
-
 (*
 Definition type_id_weq_iso (A B : ob type_precat) :
   (A = B) ≃ (iso A B) :=

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -285,15 +285,6 @@ Hypothesis H : is_univalent C.
 
 Variables a b : C.
 
-(* TODO: upstream *)
-Lemma transportf_isotoid' (c d d': C) (p : z_iso d d') (f : c --> d) :
-  transportf (λ a0 : C, c --> a0) (isotoid C H p) f = f · p .
-Proof.
-  rewrite <- idtoiso_postcompose.
-  rewrite idtoiso_isotoid.
-  apply idpath.
-Defined.
-
 Lemma isaprop_BinCoproduct : isaprop (BinCoproduct a b).
 Proof.
   apply invproofirrelevance.

--- a/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/graphs/bincoproducts.v
@@ -264,15 +264,6 @@ Definition z_iso_from_BinCoproduct_to_BinCoproduct (CC CC' : BinCoproductCocone 
   : z_iso (BinCoproductObject CC) (BinCoproductObject CC')
   := make_z_iso' _ (is_z_iso_from_BinCoproduct_to_BinCoproduct CC CC').
 
-Lemma transportf_isotoid' (c d d': C) (p : z_iso d d') (f : c --> d) :
-  transportf (λ a0 : C, c --> a0) (isotoid C H p) f = f · p .
-Proof.
-  rewrite <- idtoiso_postcompose.
-  rewrite idtoiso_isotoid.
-  apply idpath.
-Defined.
-
-
 (* should be an instance of a lemma about colimits *)
 (*
 Lemma isaprop_BinCoproductCocone : isaprop (BinCoproductCocone a b).

--- a/UniMath/CategoryTheory/limits/graphs/colimits.v
+++ b/UniMath/CategoryTheory/limits/graphs/colimits.v
@@ -172,18 +172,14 @@ repeat (apply impred; intro).
 apply isapropiscontr.
 Qed.
 
-Definition isColimCocone_ColimCocone {C : precategory} {g : graph} {d : diagram g C}
-  (CC : ColimCocone d) :
-  isColimCocone d (colim CC) (tpair _ (colimIn CC) (colimInCommutes CC)) := pr2 CC.
-
 Definition colimArrow {C : precategory} {g : graph} {d : diagram g C} (CC : ColimCocone d)
-  (c : C) (cc : cocone d c) : C⟦colim CC,c⟧ := pr1 (pr1 (isColimCocone_ColimCocone CC c cc)).
+  (c : C) (cc : cocone d c) : C⟦colim CC,c⟧ := pr1 (pr1 (isColimCocone_from_ColimCocone CC c cc)).
 
 Lemma colimArrowCommutes {C : precategory} {g : graph} {d : diagram g C} (CC : ColimCocone d)
   (c : C) (cc : cocone d c) (u : vertex g) :
   colimIn CC u · colimArrow CC c cc = coconeIn cc u.
 Proof.
-exact ((pr2 (pr1 (isColimCocone_ColimCocone CC _ cc))) u).
+exact ((pr2 (pr1 (isColimCocone_from_ColimCocone CC _ cc))) u).
 Qed.
 
 Lemma colimArrowUnique {C : precategory} {g : graph} {d : diagram g C} (CC : ColimCocone d)

--- a/UniMath/CategoryTheory/limits/graphs/eqdiag.v
+++ b/UniMath/CategoryTheory/limits/graphs/eqdiag.v
@@ -342,7 +342,7 @@ Definition eq_diag_liftcolimcocone
            (eq_d : eq_diag d d')
            (cc:ColimCocone d ) : ColimCocone d'
   := make_ColimCocone _ _ _ (eq_diag_iscolimcocone _ eq_d
-                                                 (isColimCocone_ColimCocone cc)).
+                                                 (isColimCocone_from_ColimCocone cc)).
 
 Definition eq_diag_liftlimcone
            {C : category} {g : graph} {d : diagram g C}

--- a/UniMath/CategoryTheory/limits/graphs/limits.v
+++ b/UniMath/CategoryTheory/limits/graphs/limits.v
@@ -706,7 +706,7 @@ Qed.
 Definition isLimCone_LimCone {g : graph} {d : diagram g C^op}
     (CC : LimCone d)
   : isLimCone d (lim CC) (tpair _ (limOut CC) (limOutCommutes CC))
-  := isColimCocone_ColimCocone CC.
+  := isColimCocone_from_ColimCocone CC.
 
 Definition limArrow {g : graph} {d : diagram g C^op} (CC : LimCone d)
   (c : C) (cc : cone d c) : C⟦c, lim CC⟧.

--- a/UniMath/Combinatorics/FiniteSequences.v
+++ b/UniMath/Combinatorics/FiniteSequences.v
@@ -339,13 +339,6 @@ Proof.
   intros. unfold nil. apply maponpaths. apply isapropifcontr. apply iscontr_vector_0.
 Defined.
 
-Definition isaset_transportf {X : hSet} (P : X ->UU) {x : X} (e : x = x) (p : P x) :
-  transportf P e p = p.
-(* move upstream *)
-Proof. induction (pr1 ((setproperty _) _ _ (idpath _) e)).
-       reflexivity.
-Defined.
-
 (* induction principle for contractible types, as a warmup *)
 
 (* Three ways.  Use induction: *)

--- a/UniMath/Combinatorics/FiniteSets.v
+++ b/UniMath/Combinatorics/FiniteSets.v
@@ -1,12 +1,10 @@
 (** * Finite sets. Vladimir Voevodsky . Apr. - Sep. 2011.
 
-This file contains the definition and main properties of finite sets. At the end of the file there are several elementary examples which are used as test cases to check that our constructions do not prevent Coq from normalizing terms of type nat to numerals.
-
-*)
-
-
-
-
+    This file contains the definition and main properties of finite sets. In the
+    file [Combinatorics/Tests.v] there are several elementary examples which are
+    used as test cases to check that our constructions do not prevent Coq from
+    normalizing terms of type nat to numerals.
+ *)
 
 (** ** Preamble *)
 
@@ -15,264 +13,440 @@ This file contains the definition and main properties of finite sets. At the end
 Require Import UniMath.MoreFoundations.Tactics.
 Require Import UniMath.MoreFoundations.DecidablePropositions.
 Require Import UniMath.MoreFoundations.NegativePropositions.
-Require Export UniMath.Combinatorics.StandardFiniteSets .
+Require Export UniMath.Combinatorics.StandardFiniteSets.
 
 Require Import UniMath.MoreFoundations.Subtypes.
 
-
+Local Open Scope stn.
 
 (** ** Sets with a given number of elements. *)
 
-(** *** Structure of a set with [ n ] elements on [ X ] defined as a term in [ weq ( stn n ) X ]  *)
+Section nelstructure.
+  (** *** Structure of a set with [n] elements on [X] defined as a term in [⟦ n ⟧ ≃ X].  *)
 
-Definition nelstruct ( n : nat ) ( X : UU ) := weq ( stn n ) X .
+  Definition nelstruct (n : nat) (X : UU) : UU
+    := ⟦ n ⟧ ≃ X.
 
-Definition nelstructToFunction {n} {X} (S : nelstruct n X) : stn n -> X := pr1weq S.
+  Definition nelstructToFunction {n : nat} {X : UU} (S : nelstruct n X)
+    : ⟦ n ⟧ -> X
+    := pr1weq S.
 
-Coercion nelstructToFunction : nelstruct >-> Funclass.
+  Coercion nelstructToFunction : nelstruct >-> Funclass.
 
-Definition nelstructonstn ( n : nat ) : nelstruct n ( stn n ) := idweq _ .
+  Definition nelstructonstn (n : nat) : nelstruct n (⟦ n ⟧)
+    := idweq (⟦ n ⟧).
 
-Definition nelstructweqf { X Y : UU } { n : nat } ( w : X ≃ Y ) ( sx : nelstruct n X ) : nelstruct n Y := weqcomp sx w .
+  Definition nelstructweqf {X Y : UU} {n : nat}
+    (w : X ≃ Y) (sx : nelstruct n X)
+    : nelstruct n Y
+    := weqcomp sx w.
 
-Definition nelstructweqb { X Y : UU } { n : nat } ( w : X ≃ Y ) ( sy : nelstruct n Y ) : nelstruct n X := weqcomp sy ( invweq w ) .
+  Definition nelstructweqb {X Y : UU} {n : nat}
+    (w : X ≃ Y) (sy : nelstruct n Y)
+    : nelstruct n X
+    := weqcomp sy (invweq w).
 
-Definition nelstructonempty : nelstruct 0 empty := weqstn0toempty .
+  Definition nelstructonempty : nelstruct 0 empty
+    := weqstn0toempty.
 
-Definition nelstructonempty2 { X : UU } ( is : neg X ) : nelstruct 0 X :=  weqcomp weqstn0toempty ( invweq ( weqtoempty is ) ) .
+  Definition nelstructonempty2 {X : UU} (nx : neg X)
+    : nelstruct 0 X
+    := weqcomp weqstn0toempty (invweq (weqtoempty nx)).
 
-Definition nelstructonunit : nelstruct 1 unit := weqstn1tounit .
+  Definition nelstructonunit : nelstruct 1 unit
+    := weqstn1tounit.
 
-Definition nelstructoncontr { X : UU } ( is : iscontr X ) : nelstruct 1 X := weqcomp weqstn1tounit ( invweq ( weqcontrtounit is ) ) .
+  Definition nelstructoncontr {X : UU} (contrx : iscontr X)
+    : nelstruct 1 X
+    := weqcomp weqstn1tounit (invweq (weqcontrtounit contrx)).
 
-Definition nelstructonbool : nelstruct 2 bool := weqstn2tobool .
+  Definition nelstructonbool : nelstruct 2 bool := weqstn2tobool.
 
-Definition nelstructoncoprodwithunit { X : UU } { n : nat } ( sx : nelstruct n X ) : nelstruct ( S n ) ( coprod X unit ) :=  weqcomp ( invweq ( weqdnicoprod n lastelement ) ) ( weqcoprodf sx ( idweq unit ) ) .
+  Definition nelstructoncoprodwithunit {X : UU} {n : nat}
+    (sx : nelstruct n X)
+    : nelstruct (S n) (X ⨿ unit)
+    := weqcomp (invweq (weqdnicoprod n lastelement)) (weqcoprodf1 sx).
 
-Definition nelstructoncompl {X} {n} (x:X) : nelstruct (S n) X -> nelstruct n (compl X x).
-Proof.
-  intros sx.
-  refine (invweq ( weqoncompl ( invweq sx ) x) ∘ _ ∘ weqdnicompl (invweq sx x))%weq.
-  apply compl_weq_compl_ne.
-Defined.
+  Definition nelstructoncompl {X : UU} {n : nat}
+    (x : X)
+    : nelstruct (S n) X -> nelstruct n (compl X x).
+  Proof.
+    intros sx.
+    refine (invweq (weqoncompl (invweq sx) x) ∘ _ ∘ weqdnicompl (invweq sx x))%weq.
+    apply compl_weq_compl_ne.
+  Defined.
 
-Definition nelstructoncoprod { X  Y : UU } { n m : nat } ( sx : nelstruct n X ) ( sy : nelstruct m Y ) : nelstruct ( n + m ) ( coprod X Y ) := weqcomp ( invweq ( weqfromcoprodofstn n m ) ) ( weqcoprodf sx sy ) .
+  Definition nelstructoncoprod {X Y : UU} {n m : nat}
+    (sx : nelstruct n X)
+    (sy : nelstruct m Y)
+    : nelstruct (n + m) (X ⨿ Y)
+    := ((weqcoprodf sx sy) ∘ (invweq (weqfromcoprodofstn n m)))%weq.
 
-Definition nelstructontotal2 { X : UU } ( P : X -> UU ) ( f : X -> nat ) { n : nat } ( sx : nelstruct n X ) ( fs : ∏ x : X , nelstruct ( f x ) ( P x ) ) : nelstruct ( stnsum ( funcomp ( pr1 sx ) f ) ) ( total2 P )  := weqcomp ( invweq ( weqstnsum ( funcomp ( pr1 sx ) P ) ( funcomp ( pr1 sx ) f ) ( λ i : stn n, fs ( ( pr1 sx ) i ) ) ) )  ( weqfp sx P )  .
+  Definition nelstructontotal2 {X : UU} {n : nat} (P : X -> UU)
+    (f : X -> nat)
+    (sx : nelstruct n X)
+    (fs : ∏ x : X, nelstruct (f x) (P x))
+    : nelstruct (stnsum (f ∘ sx)) (∑ (y : X), P y)
+    := weqcomp
+         (invweq (weqstnsum (P ∘ sx) (f ∘ sx) (fs ∘ sx)))
+         (weqfp sx P).
 
-Definition nelstructondirprod { X Y : UU } { n m : nat } ( sx : nelstruct n X ) ( sy : nelstruct m Y ) : nelstruct ( n * m ) ( dirprod X Y ) := weqcomp ( invweq ( weqfromprodofstn n m ) ) ( weqdirprodf sx sy ) .
+  Definition nelstructondirprod {X Y : UU} {n m : nat}
+    (sx : nelstruct n X)
+    (sy : nelstruct m Y)
+    : nelstruct (n * m) (X × Y)
+    := (weqdirprodf sx sy ∘ invweq (weqfromprodofstn n m))%weq.
 
-(** For a generalization of [ weqfromdecsubsetofstn ] see below *)
+  (** For a generalization of [ weqfromdecsubsetofstn ] see below *)
 
-Definition nelstructonfun { X Y : UU } { n m : nat } ( sx : nelstruct n X ) ( sy : nelstruct m Y ) : nelstruct ( natpower m n ) ( X -> Y ) := weqcomp ( invweq ( weqfromfunstntostn n m ) ) ( weqcomp ( weqbfun _ ( invweq sx ) ) ( weqffun _ sy ) )  .
+  Definition nelstructonfun {X Y : UU} {n m : nat}
+    (sx : nelstruct n X)
+    (sy : nelstruct m Y)
+    : nelstruct (natpower m n) (X -> Y)
+    := (weqbfun Y (invweq sx) ∘ weqffun (⟦ n ⟧) sy ∘ invweq (weqfromfunstntostn n m))%weq.
 
-Definition nelstructonforall { X : UU } ( P : X -> UU ) ( f : X -> nat ) { n : nat } ( sx : nelstruct n X ) ( fs : ∏ x : X , nelstruct ( f x ) ( P x ) ) : nelstruct ( stnprod ( funcomp ( pr1 sx ) f ) ) ( ∏ x : X , P x )  := invweq ( weqcomp ( weqonsecbase P sx ) ( weqstnprod ( funcomp ( pr1 sx ) P ) ( funcomp ( pr1 sx ) f ) ( λ i : stn n, fs ( ( pr1 sx ) i ) ) ) )  .
+  Definition nelstructonforall {X : UU} {n : nat} (P : X -> UU)
+    (f : X -> nat)
+    (sx : nelstruct n X)
+    (fs : ∏ x : X , nelstruct (f x) (P x))
+    : nelstruct (stnprod (f ∘ sx)) (∏ x : X , P x)
+    := invweq (weqcomp
+                 (weqonsecbase P sx)
+                 (weqstnprod (P ∘ sx) (f ∘ sx) (λ i : ⟦ n ⟧, fs (sx i)))).
 
-Definition nelstructonweq { X : UU } { n : nat } ( sx : nelstruct n X ) : nelstruct ( factorial n ) ( X ≃ X ) := weqcomp ( invweq ( weqfromweqstntostn n ) ) ( weqcomp ( weqbweq _ ( invweq sx ) ) ( weqfweq _ sx ) ) .
+  Definition nelstructonweq {X : UU} {n : nat}
+    (sx : nelstruct n X)
+    : nelstruct (factorial n) (X ≃ X)
+    := (weqfweq X sx ∘ weqbweq (⟦ n ⟧) (invweq sx) ∘ invweq (weqfromweqstntostn n))%weq.
+End nelstructure.
 
+Section nelproperty.
 
+  (** *** The property of [ X ] to have [ n ] elements *)
 
-(** *** The property of [ X ] to have [ n ] elements *)
+  Definition isofnel (n : nat) (X : UU) : hProp
+    := ∥ ⟦ n ⟧ ≃  X ∥.
 
-Definition isofnel ( n : nat ) ( X : UU ) : hProp := ishinh ( weq ( stn n ) X ) .
+  Definition isofneluniv {n : nat} {X : UU}  (P : hProp)
+    : ((nelstruct n X) -> P) -> (isofnel n X -> P).
+  Proof.
+    intros pnel xofnel.
+    exact(hinhuniv pnel xofnel).
+  Defined.
 
-Lemma isofneluniv { n : nat} { X : UU }  ( P : hProp ) : ( ( nelstruct n X ) -> P ) -> ( isofnel n X -> P ) .
-Proof. intros.  apply @hinhuniv with ( weq ( stn n ) X ) . assumption. assumption. Defined.
+  Definition isofnelstn (n : nat) : isofnel n (⟦ n ⟧)
+    := hinhpr (nelstructonstn n).
 
-Definition isofnelstn ( n : nat ) : isofnel n ( stn n ) := hinhpr ( nelstructonstn n ) .
+  Definition isofnelweqf {X Y : UU} {n : nat}
+    (w : X ≃ Y) (sx : isofnel n X)
+    : isofnel n Y
+    := hinhfun (nelstructweqf w) sx.
 
-Definition isofnelweqf { X Y : UU } { n : nat } ( w : X ≃ Y ) ( sx : isofnel n X ) : isofnel n Y := hinhfun ( λ sx0 : _,  nelstructweqf w sx0 ) sx .
+  Definition isofnelweqb {X Y : UU} {n : nat}
+    (w : X ≃ Y) (sy : isofnel n Y)
+    : isofnel n X
+    := hinhfun (nelstructweqb w) sy.
 
-Definition isofnelweqb { X Y : UU } { n : nat } ( w : X ≃ Y ) ( sy : isofnel n Y ) : isofnel n X :=  hinhfun ( λ sy0 : _, nelstructweqb w sy0 ) sy .
+  Definition isofnelempty : isofnel 0 empty
+    := hinhpr nelstructonempty.
 
-Definition isofnelempty : isofnel 0 empty := hinhpr nelstructonempty .
+  Definition isofnelempty2 {X : UU} (nx : neg X) : isofnel 0 X
+    := hinhpr (nelstructonempty2 nx).
 
-Definition isofnelempty2 { X : UU } ( is : neg X ) : isofnel 0 X :=  hinhpr ( nelstructonempty2 is ) .
+  Definition isofnelunit : isofnel 1 unit
+    := hinhpr nelstructonunit.
 
-Definition isofnelunit : isofnel 1 unit := hinhpr nelstructonunit  .
+  Definition isofnelcontr {X : UU} (contrx : iscontr X) : isofnel 1 X
+    := hinhpr (nelstructoncontr contrx).
 
-Definition isofnelcontr { X : UU } ( is : iscontr X ) : isofnel 1 X := hinhpr ( nelstructoncontr is ) .
+  Definition isofnelbool : isofnel 2 bool
+    := hinhpr nelstructonbool.
 
-Definition isofnelbool : isofnel 2 bool := hinhpr nelstructonbool .
+  Definition isofnelcoprodwithunit {X : UU} {n : nat}
+    (sx : isofnel n X)
+    : isofnel (S n) (X ⨿ unit)
+    := hinhfun nelstructoncoprodwithunit sx.
 
-Definition isofnelcoprodwithunit { X : UU } { n : nat } ( sx : isofnel n X ) : isofnel ( S n ) ( coprod X unit ) :=   hinhfun ( λ sx0 : _,  nelstructoncoprodwithunit sx0 ) sx .
+  Definition isofnelcompl {X : UU} {n : nat}
+    (x : X) (sx : isofnel (S n) X)
+    : isofnel n (compl X x)
+    := hinhfun (nelstructoncompl x) sx.
 
-Definition isofnelcompl { X : UU } { n : nat } ( x : X ) ( sx : isofnel ( S n ) X ) : isofnel n ( compl X x ) := hinhfun ( λ sx0 : _,  nelstructoncompl x sx0 ) sx .
+  Definition isofnelcoprod {X Y : UU} {n m : nat}
+    (sx : isofnel n X) (sy : isofnel m Y)
+    : isofnel (n + m) (X ⨿ Y)
+    := hinhfun2 nelstructoncoprod sx sy.
 
-Definition isofnelcoprod { X  Y : UU } { n m : nat } ( sx : isofnel n X ) ( sy : isofnel m Y ) : isofnel ( n + m ) ( coprod X Y ) :=  hinhfun2 ( λ sx0 : _, λ sy0 : _,  nelstructoncoprod sx0 sy0 ) sx sy .
+  (** For a result corresponding to [ nelstructontotal2 ] see below . *)
 
-(** For a result corresponding to [ nelstructontotal2 ] see below . *)
+  Definition isofnelondirprod {X Y : UU} {n m : nat}
+    (sx : isofnel n X) (sy : isofnel m Y)
+    : isofnel (n * m) (X × Y)
+    := hinhfun2 nelstructondirprod sx sy.
 
-Definition isofnelondirprod { X Y : UU } { n m : nat } ( sx : isofnel n X ) ( sy : isofnel m Y ) : isofnel ( n * m ) ( dirprod X Y ) := hinhfun2 ( λ sx0 : _, λ sy0 : _,  nelstructondirprod sx0 sy0 ) sx sy .
+  Definition isofnelonfun {X Y : UU} {n m : nat}
+    (sx : isofnel n X) (sy : isofnel m Y)
+    : isofnel (natpower m n) (X -> Y)
+    := hinhfun2 nelstructonfun sx sy.
 
-Definition isofnelonfun { X Y : UU } { n m : nat } ( sx : isofnel n X ) ( sy : isofnel m Y ) : isofnel ( natpower m n ) ( X -> Y ) := hinhfun2 ( λ sx0 : _, λ sy0 : _,  nelstructonfun sx0 sy0 ) sx sy .
+  (** For a result corresponding to [ nelstructonforall ] see below . *)
 
-(** For a result corresponding to [ nelstructonforall ] see below . *)
-
-Definition isofnelonweq { X : UU } { n : nat } ( sx : isofnel n X ) : isofnel ( factorial n ) ( X ≃ X ) := hinhfun ( λ sx0 : _,  nelstructonweq sx0 ) sx .
-
-
-
+  Definition isofnelonweq {X : UU} {n : nat}
+    (sx : isofnel n X)
+    : isofnel (factorial n) (X ≃ X)
+    := hinhfun nelstructonweq sx.
+End nelproperty.
 
 (** ** General finite sets. *)
 
-(** *** Finite structure on a type [ X ] defined as a pair [ ( n , w ) ] where [ n : nat ] and [ w : weq ( stn n ) X ] *)
-
-
-Definition finstruct  ( X : UU ) := total2 ( λ n : nat, nelstruct n X ) .
-
-Definition finstructToFunction {X} (S : finstruct X) := pr2 S : nelstruct (pr1 S) X.
-
-Coercion finstructToFunction : finstruct >-> nelstruct.
-
-Definition make_finstruct  ( X : UU )  := tpair ( λ n : nat, nelstruct n X ) .
-
-Definition finstructonstn ( n : nat ) : finstruct ( stn n ) := tpair _ n ( nelstructonstn n ) .
-
-Definition finstructweqf { X Y : UU } ( w : X ≃ Y ) ( sx : finstruct X ) : finstruct Y := tpair _ ( pr1 sx ) ( nelstructweqf w ( pr2 sx ) ) .
-
-Definition finstructweqb { X Y : UU } ( w : X ≃ Y ) ( sy : finstruct Y ) : finstruct X :=  tpair _ ( pr1 sy ) ( nelstructweqb w ( pr2 sy ) ) .
-
-Definition finstructonempty : finstruct empty := tpair _ 0 nelstructonempty .
-
-Definition finstructonempty2 { X : UU } ( is : neg X ) : finstruct X :=  tpair _ 0 ( nelstructonempty2 is ) .
-
-Definition finstructonunit : finstruct unit := tpair _ 1 nelstructonunit .
-
-Definition finstructoncontr { X : UU } ( is : iscontr X ) : finstruct X := tpair _ 1 ( nelstructoncontr is ) .
-
-(** It is not difficult to show that a direct summand of a finite set is a finite set . As a corrolary it follows that a proposition ( a type of h-level 1 ) is a finite set if and only if it is decidable . *)
-
-Definition finstructonbool : finstruct bool := tpair _ 2 nelstructonbool .
-
-Definition finstructoncoprodwithunit { X : UU }  ( sx : finstruct X ) : finstruct ( coprod X unit ) :=  tpair _ ( S ( pr1 sx ) ) ( nelstructoncoprodwithunit ( pr2 sx ) ) .
-
-Definition finstructoncompl { X : UU } ( x : X ) ( sx : finstruct X ) : finstruct ( compl X x ) .
-Proof . intros . unfold finstruct .  unfold finstruct in sx . destruct sx as [ n w ] . destruct n as [ | n ] .  destruct ( negstn0 ( invweq w x ) ) . split with n .   apply ( nelstructoncompl x w ) .  Defined .
-
-Definition finstructoncoprod { X  Y : UU } ( sx : finstruct X ) ( sy : finstruct Y ) : finstruct ( coprod X Y ) := tpair _ ( ( pr1 sx ) + ( pr1 sy ) ) ( nelstructoncoprod ( pr2 sx ) ( pr2 sy ) ) .
-
-Definition finstructontotal2 { X : UU } ( P : X -> UU )   ( sx : finstruct X ) ( fs : ∏ x : X , finstruct ( P x ) ) : finstruct ( total2 P ) := tpair _ ( stnsum ( funcomp ( pr1 ( pr2 sx ) ) ( λ x : X,  pr1 ( fs x ) ) ) ) ( nelstructontotal2 P ( λ x : X, pr1 ( fs x ) ) ( pr2 sx ) ( λ x : X, pr2 ( fs x ) ) ) .
-
-Definition finstructondirprod { X Y : UU } ( sx : finstruct X ) ( sy : finstruct Y ) : finstruct ( dirprod X Y ) := tpair _ ( ( pr1 sx ) * ( pr1 sy ) ) ( nelstructondirprod ( pr2 sx ) ( pr2 sy ) ) .
-
-Definition finstructondecsubset { X : UU }  ( f : X -> bool ) ( sx : finstruct X ) : finstruct ( hfiber f true ) := tpair _ ( pr1 ( weqfromdecsubsetofstn ( funcomp ( pr1 ( pr2 sx ) ) f ) ) ) ( weqcomp ( invweq ( pr2 ( weqfromdecsubsetofstn ( funcomp ( pr1 ( pr2 sx ) ) f ) ) ) ) ( weqhfibersgwtog ( pr2 sx ) f true ) ) .
-
-
-Definition finstructonfun { X Y : UU } ( sx : finstruct X ) ( sy : finstruct Y ) : finstruct ( X -> Y ) := tpair _ ( natpower ( pr1 sy ) ( pr1 sx ) ) ( nelstructonfun ( pr2 sx ) ( pr2 sy ) ) .
-
-Definition finstructonforall { X : UU } ( P : X -> UU )  ( sx : finstruct X ) ( fs : ∏ x : X , finstruct ( P x ) ) : finstruct ( ∏ x : X , P x )  := tpair _ ( stnprod ( funcomp ( pr1 ( pr2 sx ) ) ( λ x : X,  pr1 ( fs x ) ) ) ) ( nelstructonforall P ( λ x : X, pr1 ( fs x ) ) ( pr2 sx ) ( λ x : X, pr2 ( fs x ) ) ) .
-
-Definition finstructonweq { X : UU }  ( sx : finstruct X ) : finstruct ( X ≃ X ) := tpair _ ( factorial ( pr1 sx ) ) ( nelstructonweq ( pr2 sx ) ) .
-
-
-
-
-(** *** The property of being finite *)
-
-Definition isfinite  ( X : UU ) := ishinh ( finstruct X ) .
-
-Definition FiniteSet := ∑ X:UU, isfinite X.
-
-Definition isfinite_to_FiniteSet {X:UU} (f:isfinite X) : FiniteSet := X,,f.
-
-Lemma isfinite_isdeceq X : isfinite X -> isdeceq X.
-(* uses funextemptyAxiom *)
-Proof. intros isfin.
-       apply (isfin (make_hProp _ (isapropisdeceq X))); intro f; clear isfin; simpl.
-       apply (isdeceqweqf (pr2 f)).
-       apply isdeceqstn.
-Defined.
-
-Lemma isfinite_isaset X : isfinite X -> isaset X.
-Proof.
-  intros isfin. apply (isfin (make_hProp _ (isapropisaset X))); intro f; clear isfin; simpl.
-  apply (isofhlevelweqf 2 (pr2 f)). apply isasetstn.
-Defined.
-
-Definition FiniteSet_to_hSet : FiniteSet -> hSet.
-Proof. intro X. exact (make_hSet (pr1 X) (isfinite_isaset (pr1 X) (pr2 X))).
-Defined.
-Coercion FiniteSet_to_hSet : FiniteSet >-> hSet.
-
-Definition fincard { X : UU } ( is : isfinite X ) : nat .
-Proof.
-  intros. apply (squash_pairs_to_set (λ n, stn n ≃ X) isasetnat).
-  { intros n n' w w'. apply weqtoeqstn. exact (invweq w' ∘ w)%weq. }
-  assumption.
-Defined.
-
-Definition cardinalityFiniteSet (X:FiniteSet) : nat := fincard (pr2 X).
-
-Theorem ischoicebasefiniteset { X : UU } ( is : isfinite X ) : ischoicebase X .
-Proof . intros . apply ( @hinhuniv ( finstruct X ) ( ischoicebase X ) ) .  intro nw . destruct nw as [ n w ] .   apply ( ischoicebaseweqf w ( ischoicebasestn n ) ) .  apply is .  Defined .
-
-Definition isfinitestn ( n : nat ) : isfinite ( stn n ) := hinhpr ( finstructonstn n ) .
-
-Definition standardFiniteSet n : FiniteSet := isfinite_to_FiniteSet (isfinitestn n).
-
-Definition isfiniteweqf { X Y : UU } ( w : X ≃ Y ) ( sx : isfinite X ) : isfinite Y :=  hinhfun ( λ sx0 : _,  finstructweqf w sx0 ) sx .
-
-Definition isfiniteweqb { X Y : UU } ( w : X ≃ Y ) ( sy : isfinite Y ) : isfinite X :=   hinhfun ( λ sy0 : _,  finstructweqb w sy0 ) sy .
-
-Definition isfiniteempty : isfinite empty := hinhpr finstructonempty .
-
-Definition isfiniteempty2 { X : UU } ( is : neg X ) : isfinite X :=  hinhpr ( finstructonempty2 is ) .
-
-Definition isfiniteunit : isfinite unit := hinhpr finstructonunit .
-
-Definition isfinitecontr { X : UU } ( is : iscontr X ) : isfinite X := hinhpr ( finstructoncontr is ) .
-
-Definition isfinitebool : isfinite bool := hinhpr finstructonbool .
-
-Definition isfinitecoprodwithunit { X : UU } ( sx : isfinite X ) : isfinite ( coprod X unit ) :=  hinhfun ( λ sx0 : _, finstructoncoprodwithunit sx0 ) sx .
-
-Definition isfinitecompl { X : UU } ( x : X ) ( sx : isfinite X ) : isfinite ( compl X x ) := hinhfun ( λ sx0 : _, finstructoncompl x sx0 ) sx .
-
-Definition isfinitecoprod { X  Y : UU } ( sx : isfinite X ) ( sy : isfinite Y ) : isfinite ( coprod X Y ) := hinhfun2 ( λ sx0 : _, λ sy0 : _, finstructoncoprod sx0 sy0 ) sx sy .
-
-Definition isfinitetotal2 { X : UU } ( P : X -> UU ) ( sx : isfinite X ) ( fs : ∏ x : X , isfinite ( P x ) ) : isfinite ( total2 P ) .
-Proof . intros . set ( fs' := ischoicebasefiniteset sx _ fs ) .  apply ( hinhfun2 ( fun fx0 : ∏ x : X , finstruct ( P x )  => λ sx0 : _, finstructontotal2 P sx0 fx0 ) fs' sx ) .  Defined .
-
-Definition FiniteSetSum {I:FiniteSet} (X : I -> FiniteSet) : FiniteSet.
-Proof.
-  intros. exists (∑ i, X i).
-  apply isfinitetotal2.
-  - exact (pr2 I).
-  - intros i. exact (pr2 (X i)).
-Defined.
-
-Declare Scope finset.
-Delimit Scope finset with finset.
-
-Notation "'∑' x .. y , P" := (FiniteSetSum (λ x,.. (FiniteSetSum (λ y, P))..))
-  (at level 200, x binder, y binder, right associativity) : finset.
-  (* type this in emacs in agda-input method with \sum *)
-
-Definition isfinitedirprod { X Y : UU } ( sx : isfinite X ) ( sy : isfinite Y ) : isfinite ( dirprod X Y ) := hinhfun2 ( λ sx0 : _, λ sy0 : _, finstructondirprod sx0 sy0 ) sx sy .
-
-Definition isfinitedecsubset { X : UU } ( f : X -> bool ) ( sx : isfinite X ) : isfinite ( hfiber f true ) := hinhfun ( λ sx0 : _,  finstructondecsubset f sx0 ) sx .
-
-Definition isfinitefun { X Y : UU } ( sx : isfinite X ) ( sy : isfinite Y ) : isfinite ( X -> Y ) := hinhfun2 ( λ sx0 : _, λ sy0 : _, finstructonfun sx0 sy0 ) sx sy .
-
-Definition isfiniteforall { X : UU } ( P : X -> UU ) ( sx : isfinite X ) ( fs : ∏ x : X , isfinite ( P x ) ) : isfinite ( ∏ x : X , P x ) .
-Proof . intros . set ( fs' := ischoicebasefiniteset sx _ fs ) .  apply ( hinhfun2 ( fun fx0 : ∏ x : X , finstruct ( P x )  => λ sx0 : _, finstructonforall P sx0 fx0 ) fs' sx ) .  Defined .
-
-Definition isfiniteweq { X : UU } ( sx : isfinite X ) : isfinite ( X ≃ X ) := hinhfun ( λ sx0 : _,  finstructonweq sx0 ) sx .
-
-
-
-
-
-
-
-
-
+Section finite_structure.
+  (** *** Finite structure.
+
+      A finite structure on a type [X] is defined as a pair [( n , w )]
+      where [n : nat] and [w : ⟦ n ⟧ ≃ X]. *)
+
+  Definition finstruct  (X : UU) : UU
+    := ∑ (n : nat), nelstruct n X.
+
+  Definition finstruct_cardinality {X : UU}
+    (fs : finstruct X) : nat
+    := pr1 fs.
+
+  Definition finstructToFunction {X : UU} (S : finstruct X) : nelstruct (pr1 S) X
+    := pr2 S.
+  Coercion finstructToFunction : finstruct >-> nelstruct.
+
+  Definition make_finstruct (X : UU) {n : nat} (w : ⟦ n ⟧ ≃ X) : finstruct X
+    := (n ,, w).
+
+  Definition finstructonstn (n : nat) : finstruct (⟦ n ⟧)
+    := make_finstruct _ (nelstructonstn n).
+
+  Definition finstructweqf {X Y : UU} (w : X ≃ Y) (sx : finstruct X)
+    : finstruct Y
+    := make_finstruct Y (nelstructweqf w sx).
+
+  Definition finstructweqb {X Y : UU} (w : X ≃ Y) (sy : finstruct Y)
+    : finstruct X
+    := make_finstruct X (nelstructweqb w sy).
+
+  Definition finstructonempty : finstruct empty
+    := make_finstruct empty nelstructonempty.
+
+  Definition finstructonempty2 {X : UU} (nx : neg X)
+    : finstruct X
+    := make_finstruct X (nelstructonempty2 nx).
+
+  Definition finstructonunit : finstruct unit
+    := make_finstruct unit nelstructonunit.
+
+  Definition finstructoncontr {X : UU} (xcontr : iscontr X)
+    : finstruct X
+    := make_finstruct X (nelstructoncontr xcontr).
+
+  (** It is not difficult to show that a direct summand of a finite set is a finite set. As a
+    corrolary it follows that a proposition (a type of h-level 1) is a finite set if and only if it
+    is decidable . *)
+
+  Definition finstructonbool : finstruct bool
+    := make_finstruct bool nelstructonbool.
+
+  Definition finstructoncoprodwithunit {X : UU}
+    (sx : finstruct X)
+    : finstruct (X ⨿ unit)
+    := make_finstruct (X ⨿ unit) (nelstructoncoprodwithunit sx).
+
+  Definition finstructoncompl {X : UU} (x : X) (sx : finstruct X) : finstruct (compl X x).
+  Proof.
+    destruct sx as [n w].
+    induction n as [| n ].
+    - exact(fromempty (negstn0 (invweq w x))).
+    - exact(make_finstruct (compl X x) (nelstructoncompl x w)).
+  Defined.
+
+  Definition finstructoncoprod {X Y : UU}
+    (sx : finstruct X) (sy : finstruct Y)
+    : finstruct (X ⨿ Y)
+    := make_finstruct (X ⨿ Y) (nelstructoncoprod sx sy).
+
+  Definition finstructontotal2 {X : UU} (P : X -> UU)
+    (sx : finstruct X)
+    (fs : ∏ x : X, finstruct (P x))
+    : finstruct (∑ (x : X), P x)
+    := make_finstruct _
+         (nelstructontotal2 P
+            (λ x : X, finstruct_cardinality (fs x))
+            sx
+            (λ x : X, fs x)).
+
+  Definition finstructondirprod {X Y : UU}
+    (sx : finstruct X) (sy : finstruct Y)
+    : finstruct (X × Y)
+    := make_finstruct (X × Y) (nelstructondirprod sx sy).
+
+  Definition finstructondecsubset {X : UU}
+    (f : X -> bool) (sx : finstruct X)
+    : finstruct (hfiber f true)
+    := make_finstruct _  (weqcomp (invweq (pr2 (weqfromdecsubsetofstn (f ∘ sx))))
+                            (weqhfibersgwtog _ f true)).
+
+  Definition finstructonfun {X Y : UU}
+    (sx : finstruct X) (sy : finstruct Y)
+    : finstruct (X -> Y)
+    := make_finstruct _ (nelstructonfun sx sy).
+
+  Definition finstructonforall {X : UU} (P : X -> UU)
+    (sx : finstruct X)
+    (fs : ∏ x : X , finstruct (P x))
+    : finstruct (∏ x : X , P x)
+    := make_finstruct _
+         (nelstructonforall P _ sx fs).
+
+  Definition finstructonweq {X : UU}
+    (sx : finstruct X)
+    : finstruct (X ≃ X)
+    := make_finstruct (X ≃ X) (nelstructonweq sx).
+End finite_structure.
+
+
+Section finite_property.
+  (** *** Finite types.
+
+      A type [X] is finite if it is merely equipped with some finite
+      structure.
+   *)
+
+  Definition isfinite (X : UU) : hProp
+    := ∥ finstruct X ∥.
+
+  Definition isfinite_isdeceq (X : UU)
+    : isfinite X -> isdeceq X.
+  (* uses funextemptyAxiom *)
+  Proof.
+    intros isfin.
+    use(factor_through_squash (isapropisdeceq X) _ isfin).
+    intro fstruct.
+    use(isdeceqweqf _ (isdeceqstn (finstruct_cardinality fstruct))).
+    apply fstruct.
+  Defined.
+
+  Definition isfinite_isaset (X : UU) : isfinite X -> isaset X.
+  Proof.
+    intros isfin.
+    use(factor_through_squash (isapropisaset X) _ isfin).
+    intros f.
+    use(isofhlevelweqf 2 _ (isasetstn (finstruct_cardinality f))).
+    apply f.
+  Defined.
+
+  Definition fincard {X : UU} (xf : isfinite X) : nat.
+  Proof.
+    apply (squash_pairs_to_set (λ n : nat, ⟦ n ⟧ ≃ X) isasetnat).
+    {
+      intros n n' w w'.
+      apply weqtoeqstn.
+      exact (invweq w' ∘ w)%weq.
+    }
+    assumption.
+  Defined.
+
+  Definition ischoicebasefiniteset {X : UU} (xf : isfinite X) : ischoicebase X.
+  Proof.
+    use(hinhuniv _ xf).
+    intros [n w].
+    exact(ischoicebaseweqf w (ischoicebasestn n)).
+  Defined.
+
+  Definition isfinitestn (n : nat) : isfinite (⟦ n ⟧)
+    := hinhpr (finstructonstn n).
+
+  Definition isfiniteweqf {X Y : UU} (w : X ≃ Y) (sx : isfinite X)
+    : isfinite Y
+    := hinhfun (finstructweqf w) sx.
+
+  Definition isfiniteweqb {X Y : UU} (w : X ≃ Y) (sy : isfinite Y)
+    : isfinite X
+    := hinhfun (finstructweqb w) sy.
+
+  Definition isfiniteempty : isfinite empty
+    := hinhpr finstructonempty.
+
+  Definition isfiniteempty2 {X : UU} (nx : neg X)
+    : isfinite X
+    := hinhpr (finstructonempty2 nx).
+
+  Definition isfiniteunit : isfinite unit
+    := hinhpr finstructonunit.
+
+  Definition isfinitecontr {X : UU} (contrx : iscontr X)
+    : isfinite X
+    := hinhpr (finstructoncontr contrx).
+
+  Definition isfinitebool : isfinite bool
+    := hinhpr finstructonbool.
+
+  Definition isfinitecoprodwithunit {X : UU}
+    (sx : isfinite X)
+    : isfinite (X ⨿ unit)
+    := hinhfun finstructoncoprodwithunit sx.
+
+  Definition isfinitecompl {X : UU}
+    (x : X) (sx : isfinite X)
+    : isfinite (compl X x)
+    := hinhfun (finstructoncompl x) sx.
+
+  Definition isfinitecoprod {X Y : UU}
+    (sx : isfinite X) (sy : isfinite Y)
+    : isfinite (X ⨿ Y)
+    := hinhfun2 finstructoncoprod sx sy.
+
+  Definition isfinitetotal2 {X : UU}
+    (P : X -> UU)
+    (sx : isfinite X)
+    (fs : ∏ x : X , isfinite (P x))
+    : isfinite (∑ (x : X), P x).
+  Proof.
+    set (fs' := ischoicebasefiniteset sx _ fs).
+    use(hinhfun2 _ fs' sx).
+    intros.
+    apply finstructontotal2;
+      assumption.
+  Defined.
+
+  Definition isfinitedirprod {X Y : UU}
+    (sx : isfinite X) (sy : isfinite Y)
+    : isfinite (X × Y)
+    := hinhfun2 finstructondirprod sx sy.
+
+  Definition isfinitedecsubset {X : UU}
+    (f : X -> bool)  (sx : isfinite X)
+    : isfinite (hfiber f true)
+    := hinhfun (finstructondecsubset f) sx.
+
+  Definition isfinitefun {X Y : UU}
+    (sx : isfinite X) (sy : isfinite Y)
+    : isfinite (X -> Y)
+    := hinhfun2 finstructonfun sx sy.
+
+  Definition isfiniteforall {X : UU}
+    (P : X -> UU)
+    (sx : isfinite X)
+    (fs : ∏ x : X , isfinite (P x))
+    : isfinite (∏ (x : X) , P x).
+  Proof.
+    set (fs' := ischoicebasefiniteset sx _ fs).
+    exact(hinhfun2 (fun a b => finstructonforall P b a) fs' sx).
+  Defined.
+
+  Definition isfiniteweq {X : UU} (sx : isfinite X) : isfinite (X ≃ X)
+    := hinhfun finstructonweq sx.
+End finite_property.
 (*
 
 (* The cardinality of finite sets using double negation and decidability of equality in nat. *)
 
-Definition carddneg  ( X : UU ) (is: isfinite X): nat:= pr1 (isfiniteimplisfinite0 X is).
+   Definition carddneg  (X : UU) (fx: isfinite X) : nat
+              := pr1 (isfiniteimplisfinite0 X fx).
 
 Definition preweq  ( X : UU ) (is: isfinite X): isofnel (carddneg X is) X.
 Proof. intros X is X0.  set (c:= carddneg X is). set (dnw:= pr2 (isfiniteimplisfinite0 X is)). simpl in dnw. change (pr1 nat (λ n : nat, isofnel0 n X) (isfiniteimplisfinite0 X is)) with c in dnw.
@@ -291,17 +465,19 @@ Proof. intros. *)
 
 (* The cardinality of finite sets defined using the "impredicative" ishinh *)
 
-Definition isfinite_to_DecidableEquality {X} : isfinite X -> DecidableRelation X.
+Definition isfinite_to_DecidableEquality {X : UU}
+  : isfinite X -> DecidableRelation X.
+Proof.
   intros fin x y.
   exact (@isdecprop_to_DecidableProposition
-                  (x=y)
-                  (isdecpropif (x=y)
-                               (isfinite_isaset X fin x y)
-                               (isfinite_isdeceq X fin x y))).
+           (x=y)
+           (isdecpropif (x=y)
+              (isfinite_isaset X fin x y)
+              (isfinite_isdeceq X fin x y))).
 Defined.
 
-Lemma subsetFiniteness {X} (is : isfinite X) (P : DecidableSubtype X) :
-  isfinite (decidableSubtypeCarrier P).
+Definition subsetFiniteness {X : UU} (is : isfinite X) (P : DecidableSubtype X)
+  : isfinite (decidableSubtypeCarrier P).
 Proof.
   intros.
   assert (fin : isfinite (decidableSubtypeCarrier' P)).
@@ -310,36 +486,59 @@ Proof.
   apply decidableSubtypeCarrier_weq.
 Defined.
 
-Definition subsetFiniteSet {X:FiniteSet} (P:DecidableSubtype X) : FiniteSet.
-Proof. exact (isfinite_to_FiniteSet (subsetFiniteness (pr2 X) P)). Defined.
+Definition fincard_subset {X : UU}
+  (fx : isfinite X) (P : DecidableSubtype X)
+  : nat
+  := fincard (subsetFiniteness fx P).
 
-Definition fincard_subset {X} (is : isfinite X) (P : DecidableSubtype X) : nat.
-Proof. exact (fincard (subsetFiniteness is P)). Defined.
+Definition fincard_standardSubset {n : nat}
+  (P : DecidableSubtype (⟦ n ⟧))
+  : nat
+  := fincard (subsetFiniteness (isfinitestn n) P).
 
-Definition fincard_standardSubset {n} (P : DecidableSubtype (stn n)) : nat.
-Proof. intros. exact (fincard (subsetFiniteness (isfinitestn n) P)). Defined.
-
-Local Definition bound01 (P:DecidableProposition) : ((choice P 1 0) ≤ 1)%nat.
+Local Definition bound01 (P : DecidableProposition) : ((choice P 1 0) ≤ 1)%nat.
 Proof.
-  intros. unfold choice. choose P p q; reflexivity.
+  unfold choice.
+  choose P p q;
+    reflexivity.
 Defined.
 
-Definition tallyStandardSubset {n} (P: DecidableSubtype (stn n)) : stn (S n).
-Proof. intros. exists (stnsum (λ x, choice (P x) 1 0)). apply natlehtolthsn.
-       apply (istransnatleh (m := stnsum(λ _ : stn n, 1))).
-       { apply stnsum_le; intro i. apply bound01. }
-       assert ( p : ∏ r s, r = s -> (r ≤ s)%nat). { intros ? ? e. destruct e. apply isreflnatleh. }
-       apply p. apply stnsum_1.
+Definition tallyStandardSubset {n : nat}
+  (P : DecidableSubtype (⟦ n ⟧))
+  : ⟦ S n ⟧.
+Proof.
+  exists (stnsum (λ x, choice (P x) 1 0)).
+  apply natlehtolthsn.
+  apply (istransnatleh (m := stnsum(λ _ : stn n, 1))).
+  {
+    apply stnsum_le; intro i.
+    apply bound01.
+  }
+  assert (p : ∏ r s : nat, r = s -> (r ≤ s)%nat).
+  {
+    intros ? ? e.
+    destruct e.
+    apply isreflnatleh.
+  }
+  apply p.
+  exact(stnsum_1 n).
 Defined.
 
-Definition tallyStandardSubsetSegment {n} (P: DecidableSubtype (stn n))
-           (i:stn n) : stn n.
+Definition tallyStandardSubsetSegment {n : nat}
+  (P : DecidableSubtype (⟦ n ⟧))
+  (i : ⟦ n ⟧)
+  : ⟦ n ⟧.
+Proof.
   (* count how many elements less than i satisfy P *)
-  intros.
   assert (k := tallyStandardSubset
-                 (λ j:stn i, P (stnmtostnn i n (natlthtoleh i n (pr2 i)) j))).
+                 (λ j : ⟦ i ⟧, P (stnmtostnn i n (natlthtoleh i n (pr2 i)) j))).
+
   apply (stnmtostnn (S i) n).
-  { apply natlthtolehsn. exact (pr2 i). }
+  {
+    apply natlthtolehsn.
+    exact(pr2 i).
+  }
+
   exact k.
 Defined.
 
@@ -380,3 +579,42 @@ Section finite_subsets.
   Defined.
 
 End finite_subsets.
+
+Section FiniteSets.
+  Definition FiniteSet : UU
+    := ∑ (X : UU), isfinite X.
+
+  Definition isfinite_to_FiniteSet {X : UU} (f : isfinite X) : FiniteSet
+    := X ,, f.
+
+  Definition FiniteSet_to_hSet (X : FiniteSet) : hSet
+    := make_hSet (pr1 X) (isfinite_isaset (pr1 X) (pr2 X)).
+  Coercion FiniteSet_to_hSet : FiniteSet >-> hSet.
+
+  Definition FiniteSetSum {I : FiniteSet} (X : I -> FiniteSet) : FiniteSet.
+  Proof.
+    intros. exists (∑ i, X i).
+    apply isfinitetotal2.
+    - exact (pr2 I).
+    - exact (λ (i : I), pr2 (X i)).
+  Defined.
+
+  Definition cardinalityFiniteSet (X : FiniteSet) : nat
+    := fincard (pr2 X).
+
+  Definition standardFiniteSet (n : nat) : FiniteSet
+    := isfinite_to_FiniteSet (isfinitestn n).
+
+  Definition subsetFiniteSet {X : FiniteSet} (P : DecidableSubtype X)
+    : FiniteSet.
+  Proof.
+    exact(isfinite_to_FiniteSet (subsetFiniteness (pr2 X) P)).
+  Defined.
+End FiniteSets.
+
+Declare Scope finset.
+Delimit Scope finset with finset.
+
+Notation "'∑' x .. y , P" := (FiniteSetSum (λ x,.. (FiniteSetSum (λ y, P))..))
+                               (at level 200, x binder, y binder, right associativity) : finset.
+(* type this in emacs in agda-input method with \sum *)

--- a/UniMath/Combinatorics/WellOrderedSets.v
+++ b/UniMath/Combinatorics/WellOrderedSets.v
@@ -28,7 +28,7 @@ Local Open Scope wosubset.
 
 Definition TotalOrdering (S:hSet) : hSet := ∑ (R : hrel_set S), hProp_to_hSet (isTotalOrder R).
 
-Definition TOSubset_set (X:hSet) : hSet := ∑ (S:subtype_set X), TotalOrdering (carrier_set S).
+Definition TOSubset_set (X:hSet) : hSet := ∑ (S:subtype_set X), TotalOrdering (carrier_subset S).
 
 Definition TOSubset (X:hSet) : UU := TOSubset_set X.
 
@@ -37,7 +37,7 @@ Definition TOSubset_to_subtype {X:hSet} : TOSubset X -> hsubtype X
 
 Coercion TOSubset_to_subtype : TOSubset >-> hsubtype.
 
-Local Definition TOSrel {X:hSet} (S : TOSubset X) : hrel (carrier_set S) := pr12 S.
+Local Definition TOSrel {X:hSet} (S : TOSubset X) : hrel (carrier_subset S) := pr12 S.
 
 Notation "s ≤ s'" := (TOSrel _ s s') : tosubset.
 
@@ -49,12 +49,12 @@ Definition TOanti {X:hSet} (S : TOSubset X) : isantisymm (TOSrel S) := pr2 (pr12
 
 Definition TOrefl {X:hSet} (S : TOSubset X) : isrefl (TOSrel S) := pr211 (pr22 S).
 
-Definition TOeq_to_refl {X:hSet} (S : TOSubset X) : ∀ s t : carrier_set S, s = t ⇒ s ≤ t.
+Definition TOeq_to_refl {X:hSet} (S : TOSubset X) : ∀ s t : carrier_subset S, s = t ⇒ s ≤ t.
 Proof.
   intros s t e. induction e. apply TOrefl.
 Defined.
 
-Definition TOeq_to_refl_1 {X:hSet} (S : TOSubset X) : ∀ s t : carrier_set S, pr1 s = pr1 t ⇒ s ≤ t.
+Definition TOeq_to_refl_1 {X:hSet} (S : TOSubset X) : ∀ s t : carrier_subset S, pr1 s = pr1 t ⇒ s ≤ t.
 Proof.
   intros s t e. induction (subtypePath_prop e). apply TOrefl.
 Defined.
@@ -174,7 +174,7 @@ Defined.
     equivalence. *)
 
 Definition TOSubset_plus_point_rel {X:hSet} (S:TOSubset X) (z:X) (nSz : ¬ S z) :
-  hrel (carrier_set (subtype_plus S z)).
+  hrel (carrier_subset (subtype_plus S z)).
 Proof.
   intros [s i] [t j]. unfold subtype_plus in i,j. change hPropset.
   use (squash_to_hSet_2' _ _ i j); clear i j.
@@ -339,7 +339,7 @@ Definition isWellOrder {X : hSet} (R : hrel X) : hProp := isTotalOrder R ∧ has
 
 Definition WellOrdering (S:hSet) : hSet := ∑ (R : hrel_set S), hProp_to_hSet (isWellOrder R).
 
-Definition WOSubset_set (X:hSet) : hSet := ∑ (S:subtype_set X), WellOrdering (carrier_set S).
+Definition WOSubset_set (X:hSet) : hSet := ∑ (S:subtype_set X), WellOrdering (carrier_subset S).
 
 Definition WOSubset (X:hSet) : UU := WOSubset_set X.
 
@@ -347,7 +347,7 @@ Definition WOSubset_to_subtype {X:hSet} : WOSubset X -> hsubtype X
   := pr1.
 
 Definition WOSrel {X:hSet} (S : WOSubset X)
-  : hrel (carrier_set (WOSubset_to_subtype S))
+  : hrel (carrier_subset (WOSubset_to_subtype S))
   := pr12 S.
 
 Definition WOStotal {X:hSet} (S : WOSubset X) : isTotalOrder (WOSrel S) := pr122 S.
@@ -357,7 +357,7 @@ Definition WOSubset_to_TOSubset {X:hSet} : WOSubset X -> TOSubset X
 
 Coercion WOSubset_to_TOSubset : WOSubset >-> TOSubset.
 
-Definition WOSwo {X:hSet} (S : WOSubset X) : WellOrdering (carrier_set S) := pr2 S.
+Definition WOSwo {X:hSet} (S : WOSubset X) : WellOrdering (carrier_subset S) := pr2 S.
 
 Notation "s ≤ s'" := (WOSrel _ s s') : wosubset.
 
@@ -491,7 +491,7 @@ Proof.
           change (v=w ≃ (S,, v ≼ S,, w ∧ S,, w ≼ S,, v)).
           induction v as [v i], w as [w j].
           intermediate_weq (v=w)%type.
-          { apply subtypeInjectivity. change (isPredicate (λ R : hrel (carrier_set S), isWellOrder R)).
+          { apply subtypeInjectivity. change (isPredicate (λ R : hrel (carrier_subset S), isWellOrder R)).
             intros R. apply propproperty. }
           apply weqimplimpl.
           { intros p. induction p. split.
@@ -506,7 +506,7 @@ Proof.
                 { intros s s' le. exact le. }
                 { intros s t Ss St le. exact St. } } } }
           { simpl. unfold WOSrel. simpl. intros [[a [b _]] [d [e _]]].
-            assert (triv : ∏ (f:∏ x : X, S x → S x) (x:carrier_set S), subtype_inc f x = x).
+            assert (triv : ∏ (f:∏ x : X, S x → S x) (x:carrier_subset S), subtype_inc f x = x).
             { intros f s. apply subtypePath_prop. reflexivity. }
             apply funextfun; intros s. apply funextfun; intros t.
             apply hPropUnivalence.
@@ -656,7 +656,7 @@ Definition is_wosubset_chain {X : hSet} {I : UU} (S : I → WOSubset X)
   := ∀ i j : I, wosub_comparable (S i) (S j).
 
 Lemma common_index {X : hSet} {I : UU} {S : I → WOSubset X}
-      (chain : is_wosubset_chain S) (i : I) (x : carrier_set (⋃ (λ i, S i))) :
+      (chain : is_wosubset_chain S) (i : I) (x : carrier_subset (⋃ (λ i, S i))) :
    ∃ j, S i ≼ S j ∧ S j (pr1 x).
 Proof.
   induction x as [x xinU]. apply (squash_to_hProp xinU); intros [k xinSk].
@@ -671,7 +671,7 @@ Proof.
 Defined.
 
 Lemma common_index2 {X : hSet} {I : UU} {S : I → WOSubset X}
-      (chain : is_wosubset_chain S) (x y : carrier_set (⋃ (λ i, S i))) :
+      (chain : is_wosubset_chain S) (x y : carrier_subset (⋃ (λ i, S i))) :
    ∃ i, S i (pr1 x) ∧ S i (pr1 y).
 Proof.
   induction x as [x j], y as [y k]. change (∃ i, S i x ∧ S i y).
@@ -687,7 +687,7 @@ Proof.
 Defined.
 
 Lemma common_index3 {X : hSet} {I : UU} {S : I → WOSubset X}
-      (chain : is_wosubset_chain S) (x y z : carrier_set (⋃ (λ i, S i))) :
+      (chain : is_wosubset_chain S) (x y z : carrier_subset (⋃ (λ i, S i))) :
    ∃ i, S i (pr1 x) ∧ S i (pr1 y) ∧ S i (pr1 z).
 Proof.
   induction x as [x j], y as [y k], z as [z l]. change (∃ i, S i x ∧ S i y ∧ S i z).
@@ -734,7 +734,7 @@ Defined.
 
 Definition chain_union_rel {X : hSet} {I : UU} {S : I → WOSubset X}
            (chain : is_wosubset_chain S) :
-  hrel (carrier_set (⋃ (λ i, S i))).
+  hrel (carrier_subset (⋃ (λ i, S i))).
 Proof.
   intros x y.
   change (hPropset). simple refine (squash_to_hSet _ _ (common_index2 chain x y)).
@@ -744,7 +744,7 @@ Defined.
 
 Definition chain_union_rel_eqn {X : hSet} {I : UU} {S : I → WOSubset X}
            (chain : is_wosubset_chain S)
-           (x y : carrier_set (⋃ (λ i, S i)))
+           (x y : carrier_subset (⋃ (λ i, S i)))
            i (s : S i (pr1 x)) (t : S i (pr1 y)) :
   chain_union_rel chain x y = WOSrel (S i) (pr1 x,,s) (pr1 y,,t).
 Proof.
@@ -1026,7 +1026,7 @@ Proof.
         { now apply subtypePath_prop. }
         induction e. clear W'c'. induction v as [v W'v]. apply (squash_to_hProp W'v); intros [Wv|k].
         - assert (L := pr1 (cE v) Wv). unfold upto,lt in L.
-          assert (Q := @tot_nge_to_le (carrier_set C) (TOSrel C) (TOtot C) _ _ (pr2 L)).
+          assert (Q := @tot_nge_to_le (carrier_subset C) (TOSrel C) (TOtot C) _ _ (pr2 L)).
           now apply(h1'' Q).
         - use (TOeq_to_refl C). apply subtypePath_prop. simpl. exact (!k). }
       assert (cmax' : ∏ (w : carrier W) (W'c : W' (pr1 c)),
@@ -1035,8 +1035,8 @@ Proof.
         { now apply subtypePath_prop. }
         induction e. clear W'c'. induction w as [v Wv].
         assert (L := pr1 (cE v) Wv). unfold upto,lt in L.
-        assert (Q := @tot_nge_to_le (carrier_set C) (TOSrel C) (TOtot C) _ _ (pr2 L)).
-        apply (@tot_nle_iff_gt (carrier_set C) (TOSrel C) (pr122 C)).
+        assert (Q := @tot_nge_to_le (carrier_subset C) (TOSrel C) (TOtot C) _ _ (pr2 L)).
+        apply (@tot_nle_iff_gt (carrier_subset C) (TOSrel C) (pr122 C)).
         split.
         - now apply (h1'' Q).
         - intros e. assert (e' := maponpaths pr1 e); clear e. change (v = pr1 c)%type in e'.
@@ -1048,7 +1048,7 @@ Proof.
         { now apply subtypePath_prop. }
         induction e. clear W'd'. induction v as [v W'v]. apply (squash_to_hProp W'v); intros [Wv|k].
         - assert (L := pr1 (dE v) Wv). unfold upto,lt in L.
-          assert (Q := @tot_nge_to_le (carrier_set D) (TOSrel D) (TOtot D) _ _ (pr2 L)).
+          assert (Q := @tot_nge_to_le (carrier_subset D) (TOSrel D) (TOtot D) _ _ (pr2 L)).
           now apply(h1'' Q).
         - use (TOeq_to_refl D). apply subtypePath_prop. simpl. exact (!k @ cd1). }
       assert (dmax' : ∏ (w : carrier W) (W'd : W' (pr1 d)),
@@ -1057,8 +1057,8 @@ Proof.
         { now apply subtypePath_prop. }
         induction e. clear W'd'. induction w as [v Wv].
         assert (L := pr1 (dE v) Wv). unfold upto,lt in L.
-        assert (Q := @tot_nge_to_le (carrier_set D) (TOSrel D) (TOtot D) _ _ (pr2 L)).
-        apply (@tot_nle_iff_gt (carrier_set D) (TOSrel D) (pr122 D)).
+        assert (Q := @tot_nge_to_le (carrier_subset D) (TOSrel D) (TOtot D) _ _ (pr2 L)).
+        apply (@tot_nle_iff_gt (carrier_subset D) (TOSrel D) (pr122 D)).
         split.
         - now apply (h1'' Q).
         - intros e. assert (e' := maponpaths pr1 e); clear e. change (v = pr1 d)%type in e'.
@@ -1254,7 +1254,7 @@ Proof.
   induction W as [W R'].
   change (∏ x : X, W x)%type in all.
   change (WellOrdering X).
-  assert (e : X = carrier_set W).
+  assert (e : X = carrier_subset W).
   { apply (invmap (hSet_univalence _ _)). apply invweq. apply weqpr1.
     intros x.
     simpl in all.

--- a/UniMath/MoreFoundations/Sets.v
+++ b/UniMath/MoreFoundations/Sets.v
@@ -110,10 +110,6 @@ Proof.
   exact (setquotuniv4prop R (λ x1 x2 x3 x4, make_hProp (P x1 x2 x3 x4) (H x1 x2 x3 x4)) ps).
 Defined.
 
-Definition setcoprod (X Y : hSet) : hSet :=
-  make_hSet (X ⨿ Y) (isasetcoprod X Y (pr2 X) (pr2 Y)).
-
-
 (** ** The equivalence relation of being in the same fiber *)
 
 Definition same_fiber_eqrel {X Y : hSet} (f : X → Y) : eqrel X.

--- a/UniMath/MoreFoundations/Sets.v
+++ b/UniMath/MoreFoundations/Sets.v
@@ -129,12 +129,6 @@ Defined.
 
 (** ** Subsets *)
 
-Definition subset {X : hSet} (Hsub : hsubtype X) : hSet :=
-  make_hSet (carrier Hsub) (isaset_carrier_subset _ Hsub).
-
-Definition makeSubset {X : hSet} {Hsub : hsubtype X} (x : X) (Hx : Hsub x) : subset Hsub :=
-  x,, Hx.
-
 Definition pi0 (X : UU) : hSet := setquotinset (pathseqrel X).
 
 Section Pi0.

--- a/UniMath/MoreFoundations/Subtypes.v
+++ b/UniMath/MoreFoundations/Subtypes.v
@@ -119,9 +119,6 @@ Definition subtype_binaryunion_leq1 {X} (A B : hsubtype X) : A ⊆ (A ∪ B)
 Definition subtype_binaryunion_leq2 {X} (A B : hsubtype X) : B ⊆ (A ∪ B)
   := fun x => hdisj_in2.
 
-Definition carrier_set {X : hSet} (S : hsubtype X) : hSet :=
-  make_hSet (carrier S) (isaset_carrier_subset _ S).
-
 Definition subtype_union_containedIn {X:hSet} {I:UU} (S : I -> hsubtype X) i : S i ⊆ ⋃ S
   := λ x s, hinhpr (i,,s).
 

--- a/UniMath/RealNumbers/DedekindCuts.v
+++ b/UniMath/RealNumbers/DedekindCuts.v
@@ -364,8 +364,7 @@ Proof.
       * exact Hm.
       * change (¬ D ((nattoring m * hqdiv (pr1 c) 2) + (pr1 c))).
         intros H0.
-        refine (hinhuniv' _ _ _).
-        { apply isapropempty. }
+        refine (factor_through_squash isapropempty _ _).
         2: apply (pr2 (pr2 H) (nattoring (m + 1) * hqdiv (pr1 c) 2) (nattoring m * hqdiv (pr1 c) 2 + pr1 c)).
         ** apply sumofmaps.
            *** exact Hn.

--- a/UniMath/RealNumbers/NonnegativeRationals.v
+++ b/UniMath/RealNumbers/NonnegativeRationals.v
@@ -19,7 +19,7 @@ Local Open Scope hq_scope.
 
 (** * Definition of non-negative rational numbers *)
 
-Definition hnnq_set := subset (hqleh 0).
+Definition hnnq_set := carrier_subset (hqleh 0).
 
 Local Definition hnnq_set_to_hq (r : hnnq_set) : hq := pr1 r.
 
@@ -175,7 +175,7 @@ Proof.
 Qed.
 Local Lemma islinv'_hnnq_inv:
   islinv' hnnq_one hnnq_mult (hnnq_lt hnnq_zero)
-          (λ x : subset (hnnq_lt hnnq_zero), hnnq_inv (pr1 x)).
+          (λ x : carrier_subset (hnnq_lt hnnq_zero), hnnq_inv (pr1 x)).
 Proof.
   intros x Hx0.
   unfold hnnq_inv.
@@ -191,7 +191,7 @@ Proof.
 Qed.
 Local Lemma isrinv'_hnnq_inv:
  isrinv' hnnq_one hnnq_mult (hnnq_lt hnnq_zero)
-         (λ x : subset (hnnq_lt hnnq_zero), hnnq_inv (pr1 x)).
+         (λ x : carrier_subset (hnnq_lt hnnq_zero), hnnq_inv (pr1 x)).
 Proof.
   intros x Hx.
   rewrite iscomm_hnnq_mult.

--- a/UniMath/RealNumbers/NonnegativeReals.v
+++ b/UniMath/RealNumbers/NonnegativeReals.v
@@ -677,7 +677,7 @@ Lemma Dcuts_notlt_0 :
 Proof.
   intros x.
   unfold neg.
-  apply hinhuniv'.
+  apply factor_through_squash.
   - exact isapropempty.
   - intros r.
     exact (Dcuts_zero_empty _ (pr2 (pr2 r))).
@@ -4130,7 +4130,7 @@ Proof.
   apply isapfun_NonnegativeRationals_to_Dcuts_aux in Hc.
   apply hinhuniv ; apply sumofmaps ; [intros He | ].
   - apply hinhpr ; left.
-    unfold neg ; apply hinhuniv'.
+    use factor_through_squash.
     { exact isapropempty. }
     intros X.
     apply He.
@@ -4148,7 +4148,7 @@ Proof.
     generalize (is_Dcuts_corr (pr1 X) _ Hc).
     apply hinhfun ; apply sumofmaps ; [intros Xc | ].
     + left.
-      unfold neg ; apply hinhuniv'.
+      use factor_through_squash.
       { exact isapropempty. }
       intros Y.
       apply (pr2 (pr2 X)).
@@ -4185,7 +4185,7 @@ Proof.
         exists (pr1 X) ; split.
         ** exact (pr1 (pr2 X)).
         ** exact (pr1 (pr2 q)).
-      * unfold neg ; apply hinhuniv'.
+      * use factor_through_squash.
         { exact isapropempty. }
         intros Y.
         apply (pr2 (pr2 X)).
@@ -4301,7 +4301,7 @@ Proof.
   apply hinhfun.
   apply sumofmaps ; [intros Ec | intros q].
   - left.
-    unfold neg ; apply hinhuniv'.
+    use factor_through_squash.
     { exact isapropempty. }
     intros r.
     apply Ec.

--- a/UniMath/RealNumbers/Reals.v
+++ b/UniMath/RealNumbers/Reals.v
@@ -53,7 +53,7 @@ Lemma iscomprelfun_hr_to_NR :
                       pr1 x - pr2 x ,, pr2 x - pr1 x).
 Proof.
   intros x y.
-  apply hinhuniv'.
+  apply factor_through_squash.
   { refine (isasetdirprod _ _ _ _ _ _) ;
     apply (pr2 (pr1 (pr1 (pr1 NonnegativeReals)))).
   }
@@ -196,7 +196,7 @@ Proof.
     apply_pr2 plusNonnegativeReals_eqcompat_l.
     exact H.
   - generalize (invmap (weqpathsinsetquot _ _ _) H) ; clear H.
-    apply hinhuniv'.
+    apply factor_through_squash.
     { apply (pr2 (pr1 (pr1 (pr1 NonnegativeReals)))). }
     intros (c,p); generalize p; clear p.
     apply plusNonnegativeReals_eqcompat_l.
@@ -1656,7 +1656,7 @@ Proof.
   intros x y z Hxy Hyz.
   apply notRlt_Rle ; intro H.
   generalize (iscotrans_Rlt _ y _ H).
-  apply hinhuniv'.
+  apply factor_through_squash.
   { exact isapropempty. }
   apply sumofmaps.
   + apply_pr2 notRlt_Rle.

--- a/UniMath/RealNumbers/Sets.v
+++ b/UniMath/RealNumbers/Sets.v
@@ -15,11 +15,11 @@ Require Import UniMath.Algebra.BinaryOperations
 
 (** * Partially-defined inverse functions *)
 
-Definition islinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtype X) (inv : subset exinv -> X) :=
+Definition islinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtype X) (inv : carrier_subset exinv -> X) :=
   ∏ (x : X) (Hx : exinv x), op (inv (x ,, Hx)) x = x1.
-Definition isrinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtype X) (inv : subset exinv -> X) :=
+Definition isrinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtype X) (inv : carrier_subset exinv -> X) :=
   ∏ (x : X) (Hx : exinv x), op x (inv (x ,, Hx)) = x1.
-Definition isinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtype X) (inv : subset exinv -> X)  :=
+Definition isinv' {X : hSet} (x1 : X) (op : binop X) (exinv : hsubtype X) (inv : carrier_subset exinv -> X)  :=
   islinv' x1 op exinv inv × isrinv' x1 op exinv inv.
 
 (** * Effective Orders *)

--- a/UniMath/SubstitutionSystems/MLTT79.v
+++ b/UniMath/SubstitutionSystems/MLTT79.v
@@ -17,30 +17,14 @@ Require Import UniMath.CategoryTheory.Core.Functors.
 Local Open Scope cat.
 Require Import UniMath.CategoryTheory.FunctorCategory.
 Require Import UniMath.CategoryTheory.categories.HSET.Core.
-Require Import UniMath.CategoryTheory.categories.HSET.Limits.
 Require Import UniMath.CategoryTheory.categories.HSET.Colimits.
-Require Import UniMath.CategoryTheory.categories.HSET.Structures.
-Require Import UniMath.CategoryTheory.Chains.Chains.
-Require Import UniMath.CategoryTheory.Chains.OmegaCocontFunctors.
-Require Import UniMath.CategoryTheory.limits.graphs.limits.
-Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.limits.initial.
 Require Import UniMath.CategoryTheory.limits.binproducts.
-Require Import UniMath.CategoryTheory.limits.products.
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
-Require Import UniMath.CategoryTheory.limits.coproducts.
-Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.FunctorAlgebras.
-Require Import UniMath.CategoryTheory.exponentials.
-Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.Monads.Monads.
 
 Require Import UniMath.SubstitutionSystems.Signatures.
-Require Import UniMath.SubstitutionSystems.BinSumOfSignatures.
-Require Import UniMath.SubstitutionSystems.SumOfSignatures.
-Require Import UniMath.SubstitutionSystems.BinProductOfSignatures.
-Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
-Require Import UniMath.SubstitutionSystems.LamSignature.
 Require Import UniMath.SubstitutionSystems.Notation.
 Local Open Scope subsys.
 Require Import UniMath.SubstitutionSystems.BindingSigToMonad.

--- a/UniMath/SubstitutionSystems/STLC.v
+++ b/UniMath/SubstitutionSystems/STLC.v
@@ -20,32 +20,18 @@ Require Import UniMath.CategoryTheory.categories.HSET.Core.
 Require Import UniMath.CategoryTheory.categories.HSET.Colimits.
 Require Import UniMath.CategoryTheory.categories.HSET.Limits.
 Require Import UniMath.CategoryTheory.categories.HSET.Slice.
-Require Import UniMath.CategoryTheory.Chains.Chains.
-Require Import UniMath.CategoryTheory.Chains.OmegaCocontFunctors.
-Require Import UniMath.CategoryTheory.limits.graphs.limits.
-Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.limits.initial.
 Require Import UniMath.CategoryTheory.limits.binproducts.
-Require Import UniMath.CategoryTheory.limits.products.
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
 Require Import UniMath.CategoryTheory.limits.coproducts.
-Require Import UniMath.CategoryTheory.limits.terminal.
 Require Import UniMath.CategoryTheory.FunctorAlgebras.
-Require Import UniMath.CategoryTheory.exponentials.
-Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.Monads.Monads.
 Require Import UniMath.CategoryTheory.slicecat.
 
 Require Import UniMath.SubstitutionSystems.Signatures.
-Require Import UniMath.SubstitutionSystems.SumOfSignatures.
-Require Import UniMath.SubstitutionSystems.BinProductOfSignatures.
-Require Import UniMath.SubstitutionSystems.SubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.LiftingInitial_alt.
-Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.Notation.
 Local Open Scope subsys.
-Require Import UniMath.SubstitutionSystems.SignatureExamples.
-Require Import UniMath.SubstitutionSystems.BindingSigToMonad.
 Require Import UniMath.SubstitutionSystems.MonadsMultiSorted.
 Require Import UniMath.SubstitutionSystems.MultiSorted.
 

--- a/UniMath/Topology/Filters.v
+++ b/UniMath/Topology/Filters.v
@@ -131,7 +131,7 @@ Proof.
   intros F Hf.
   generalize (isfilter_finite_intersection_htrue _ (pr2 (pr1 Hf))) ; intros Htrue.
   generalize (pr2 Hf _ Htrue).
-  apply hinhuniv'.
+  apply factor_through_squash.
   - apply isapropempty.
   - intros x.
     apply (pr1 x).
@@ -193,7 +193,7 @@ Lemma filter_const :
 Proof.
   intros A Fa Ha.
   generalize (filter_notempty _ Fa).
-  apply hinhuniv'.
+  apply factor_through_squash.
   - apply isapropempty.
   - intros x ; generalize (pr2 x); clear x.
     exact Ha.

--- a/UniMath/Topology/Prelim.v
+++ b/UniMath/Topology/Prelim.v
@@ -10,13 +10,6 @@ Require Export UniMath.Tactics.EnsureStructuredProofs.
 
 (** ** hProp *)
 
-Lemma hinhuniv' {P X : UU} :
-  isaprop P → (X → P) → (∥ X ∥ → P).
-Proof.
-  intros HP Hx.
-  apply (hinhuniv (P := make_hProp _ HP)).
-  exact Hx.
-Qed.
 Lemma hinhuniv2' {P X Y : UU} :
   isaprop P → (X → Y → P) → (∥ X ∥ → ∥ Y ∥ → P).
 Proof.

--- a/UniMath/Topology/Topology.v
+++ b/UniMath/Topology/Topology.v
@@ -953,7 +953,7 @@ Definition TopologySubtype {T : TopologicalSpace}
   : TopologicalSpace.
 Proof.
   simple refine (TopologyFromNeighborhood _ _).
-  - exact (Subtypes.carrier_set dom).
+  - exact (carrier_subset dom).
   - apply topologysubtype.
   - repeat split.
     + apply topologysubtype_imply.


### PR DESCRIPTION
Some minor housekeeping commits I collected in October that I forgot to create a PR for.

Mostly removing duplicate definitions and upstreaming some useful definitions. Also removes the scope [cat_deprecated]. This will cause TypeTheory to fail until [232](https://github.com/UniMath/TypeTheory/pull/232) is merged.