### PR TITLE
CI: Build with latest dev version of Coq.

### DIFF
--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -54,7 +54,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         # https://github.com/coq-community/docker-coq/wiki#ocaml-versions-policy
-        coq-version: [latest]
+        coq-version: [latest, dev]
         # coq-version: [8.16] or [latest, 8.16] (when 8.17 is released)
         ocaml-version: [default]
 


### PR DESCRIPTION
This builds PR's with the latest relased version of Coq and the latest development version. Should fix #1617.