### PR TITLE
CI: Build satellites with dev version of Coq.

### DIFF
--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -138,7 +138,7 @@ jobs:
       fail-fast: false
       matrix:
         satellite: [SetHITs, largecatmodules, GrpdHITs]
-        coq-version: [8.16]
+        coq-version: [latest, dev]
         ocaml-version: [4.14-flambda]
         # Once TypeTheory compiles with 8.16 remove the following section and
         # add TypeTheory to matrix.satellite above.


### PR DESCRIPTION
This change builds all satellites except TypeTheory using two different versions of Coq: the latest released version (currently 8.16.1 but soon 8.17) and current head of the master branch. Fixes #1620.