### PR TITLE
CI: Save cache even if build fails.

### DIFF
--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -58,7 +58,8 @@ jobs:
       # Grab the cache if available and extract it to dune-cache/. We tell dune
       # to use $(pwd)/dune-cache/ in the custom_script when initiating the
       # docker run.
-      - uses: actions/cache@v3
+      - uses: actions/cache/restore@v3
+        id: cache
         with:
           path: dune-cache
           # Example key: UniMath-Linux-coq-8.16-123456789-10
@@ -88,6 +89,13 @@ jobs:
             opam exec -- dune build -j 2 --display=short \
                          --cache=enabled --error-reporting=twice
             endGroup
+
+      - uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: dune-cache
+          key: UniMath-${{ runner.os }}-coq-${{ matrix.coq-version }}-${{ github.run_id }}-${{ github.run_number }}
+
       - name: Revert permissions
         if: ${{ always() }}
         run: sudo chown -R 1001:116 .
@@ -107,7 +115,8 @@ jobs:
           coqc --version
           dune --version
 
-      - uses: actions/cache@v3
+      - uses: actions/cache/restore@v3
+        id: cache
         with:
           path: dune-cache
           key: UniMath-MacOS-${{ github.run_id }}-${{ github.run_number }}
@@ -119,6 +128,12 @@ jobs:
         run: |
           export DUNE_CACHE_ROOT=$(pwd)/dune-cache/
           dune build --display=short --error-reporting=twice --cache=enabled UniMath/
+
+      - uses: actions/cache/save@v3
+        if: always ()
+        with:
+          path: dune-cache
+          key: UniMath-MacOS-${{ github.run_id }}-${{ github.run_number }}
 
   # Build the satellites in parallel using docker-coq images with the latest
   # stable patch-release of Coq 8.16, except for TypeTheory, which is built
@@ -146,7 +161,8 @@ jobs:
 
       # Grab the cache if available. We tell dune to use $(pwd)/dune-cache/ in
       # the custom_script below.
-      - uses: actions/cache@v3
+      - uses: actions/cache/restore@v3
+        id: cache
         with:
           path: dune-cache
           # Example key: SetHITs-coq-8.15-123456789-10
@@ -154,7 +170,6 @@ jobs:
           restore-keys: |
             ${{ matrix.satellite }}-coq-${{ matrix.coq-version }}-${{ github.run_id }}
             ${{ matrix.satellite }}-coq-${{ matrix.coq-version }}-
-
 
       - name: Build ${{ matrix.satellite }}
         uses: coq-community/docker-coq-action@v1
@@ -177,6 +192,14 @@ jobs:
             opam exec -- dune build -j 2 Satellite --display=short \
                          --cache=enabled --error-reporting=twice
             endGroup
+
+
+      - uses: actions/cache/save@v3
+        if: always ()
+        with:
+          path: dune-cache
+          key: ${{ matrix.satellite }}-coq-${{ matrix.coq-version }}-${{ github.run_id }}-${{ github.run_number }}
+
       - name: Revert permissions
         if: ${{ always() }}
         run: sudo chown -R 1001:116 .

--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -90,15 +90,15 @@ jobs:
                          --cache=enabled --error-reporting=twice
             endGroup
 
+      - name: Revert permissions
+        if: ${{ always() }}
+        run: sudo chown -R 1001:116 .
+
       - uses: actions/cache/save@v3
         if: always()
         with:
           path: dune-cache
           key: UniMath-${{ runner.os }}-coq-${{ matrix.coq-version }}-${{ github.run_id }}-${{ github.run_number }}
-
-      - name: Revert permissions
-        if: ${{ always() }}
-        run: sudo chown -R 1001:116 .
 
   # Build UniMath on MacOS using latest stable release of Coq installed with
   # Homebrew (currently 8.16.1). Build files are cached.
@@ -193,13 +193,12 @@ jobs:
                          --cache=enabled --error-reporting=twice
             endGroup
 
+      - name: Revert permissions
+        if: ${{ always() }}
+        run: sudo chown -R 1001:116 .
 
       - uses: actions/cache/save@v3
         if: always ()
         with:
           path: dune-cache
           key: ${{ matrix.satellite }}-coq-${{ matrix.coq-version }}-${{ github.run_id }}-${{ github.run_number }}
-
-      - name: Revert permissions
-        if: ${{ always() }}
-        run: sudo chown -R 1001:116 .


### PR DESCRIPTION
Currently when a job fails no cache will be saved. This often causes time consuming rebuilds of files that really needn't be rebuilt. At the end of last year github released a beta-version of a script that allows the cache action to save the cache even if a job failed.

Merging this would give it some real world use. Hopefully it'll save us some rebuild time.