### PR TITLE
WIP: Smarter cache management for CI.

### DIFF
--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -101,7 +101,7 @@ jobs:
           gh extension install actions/gh-actions-cache
           REPO=${{ github.repository }}
           REF=${{ github.ref }}
-          KEY=${{ github.unimath-cache.key }}
+          KEY=${{ steps.unimath-cache.inputs.key }}
 
           set +e
           echo "Deleting old cache..."

--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Remove old cache
         if: steps.unimath-cache.outputs.cache-hit == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.UNIMATH_ACTION_TOKEN }}
         run: |
           gh extension install actions/gh-actions-cache
           REPO=${{ github.repository }}

--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -47,6 +47,7 @@ jobs:
   build-Unimath-ubuntu:
     permissions:
       actions: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -101,7 +101,7 @@ jobs:
           gh extension install actions/gh-actions-cache
           REPO=${{ github.repository }}
           REF=${{ github.ref }}
-          KEY=${{ steps.unimath-cache.inputs.key }}
+          KEY=${{ steps.unimath-cache.outputs.cache-primary-key }}
 
           set +e
           echo "Deleting old cache..."

--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -93,7 +93,7 @@ jobs:
             startGroup "Build UniMath"
             export DUNE_CACHE_ROOT=$(pwd)/dune-cache/
             opam exec -- dune build -j 2 --display=short \
-                         --cache=enabled --error-reporting=twice
+                         --cache=enabled --error-reporting=twice UniMath/Algebra
             endGroup
 
       - name: Revert permissions

--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -16,6 +16,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   # This workflow contains four jobs:
   #   - sanity-checks

--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         # https://github.com/coq-community/docker-coq/wiki#ocaml-versions-policy
-        coq-version: [latest, dev]
+        coq-version: [latest]
         # coq-version: [8.16] or [latest, 8.16] (when 8.17 is released)
         ocaml-version: [default]
 

--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -208,7 +208,7 @@ jobs:
             endGroup
 
       - name: Revert permissions
-        if: ${{ always() }}
+        if: always ()
         run: sudo chown -R 1001:116 .
 
       - uses: actions/cache/save@v3

--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -41,6 +41,8 @@ jobs:
 
   # Build the current PR/branch with the latest stable release of Coq.
   build-Unimath-ubuntu:
+    permissions:
+      actions: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -10,7 +10,7 @@ on:
   schedule:
     # Based on https://github.com/marketplace/actions/set-up-ocaml
     # Prime the caches every Monday
-    - cron: '0 1 * * MON'
+    - cron: '0 12 * * MON'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -59,14 +59,13 @@ jobs:
       # to use $(pwd)/dune-cache/ in the custom_script when initiating the
       # docker run.
       - uses: actions/cache/restore@v3
-        id: cache
+        id: unimath-cache
         with:
           path: dune-cache
-          # Example key: UniMath-Linux-coq-8.16-123456789-10
-          key: UniMath-${{ runner.os }}-coq-${{ matrix.coq-version }}-${{ github.run_id }}-${{ github.run_number }}
-          restore-keys: |
-            UniMath-${{ runner.os }}-coq-${{ matrix.coq-version }}-${{ github.run_id }}
-            UniMath-${{ runner.os }}-coq-${{ matrix.coq-version }}-
+          # What about UniMath-${{ runner.os }}-coq-${{ matrix.coq-version }}-${{ github.ref }} ?
+          # so keys are: UniMath....ref/pull/1466/merge and
+          #              UniMath....ref/branch/master
+          key: UniMath-${{ runner.os }}-coq-${{ matrix.coq-version }}
 
       - name: Build UniMath
         uses: coq-community/docker-coq-action@v1
@@ -91,27 +90,41 @@ jobs:
             endGroup
 
       - name: Revert permissions
-        if: ${{ always() }}
+        if: always ()
         run: sudo chown -R 1001:116 .
+
+      - name: Remove old cache
+        if: steps.unimath-cache.outputs.cache-hit == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh extension install actions/gh-actions-cache
+          REPO=${{ github.repository }}
+          REF=${{ github.ref }}
+          KEY=${{ github.unimath-cache.key }}
+
+          set +e
+          echo "Deleting old cache..."
+          gh actions-cache delete $KEY -R $REPO -B $REF --confirm
+          echo "Done."
 
       - uses: actions/cache/save@v3
         if: always()
         with:
           path: dune-cache
-          key: UniMath-${{ runner.os }}-coq-${{ matrix.coq-version }}-${{ github.run_id }}-${{ github.run_number }}
+          key: UniMath-${{ runner.os }}-coq-${{ matrix.coq-version }}
 
   # Build UniMath on MacOS using latest stable release of Coq installed with
   # Homebrew (currently 8.16.1). Build files are cached.
   build-macos:
     name: Build on macOS (Coq 8.16)
-
+    if: false
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install Coq
         run: |
           brew install coq ocaml-findlib dune
-
           coqc --version
           dune --version
 
@@ -139,6 +152,7 @@ jobs:
   # stable patch-release of Coq 8.16, except for TypeTheory, which is built
   # using the latest stable 8.15 release.
   build-satellites:
+    if: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Remove old cache
         if: steps.unimath-cache.outputs.cache-hit == 'true'
         env:
-          GH_TOKEN: ${{ secrets.UNIMATH_ACTION_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh extension install actions/gh-actions-cache
           REPO=${{ github.repository }}

--- a/.github/workflows/clean-cache.yml
+++ b/.github/workflows/clean-cache.yml
@@ -1,0 +1,45 @@
+---
+name: Cleanup cache
+on:
+  pull_request:
+    types:
+      - closed
+  workflow_dispatch:
+
+# When a PR is closed (this includes merged into master) this job
+# will remove any cache entries owned by that PR.
+# This is based on:
+# https://github.com/actions/cache/blob/main/tips-and-workarounds.md#force-deletion-of-caches-overriding-default-cache-eviction-policy
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      # `actions:write` permission is required to delete caches
+      #  See also: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-a-github-actions-cache-for-a-repository-using-a-cache-id
+      actions: write
+      contents: read
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Cleanup ${{ github.ref }}
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+          BRANCH=${{ github.ref }}
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list --limit 100 -R $REPO -B $BRANCH | tail -n +5 | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is a work in progress trying to make the cache management a bit smarter.

Currently a PR can easily consume all 10 GB available because on each run the cache is duplicated instead of updated. This in and of it self is _not_ a critical problem: GitHub will just evict the oldest cache files until we are below the quota again. It is however a nuisance since it will cause unnecessary rebuilds when a PR is merged, or when another PR is opened. 

This does two things so far: 
- When a PR is closed (or merged into master) all cache files owned by it are removed.
- When a job is rerun for a PR the cache is updated with the new contents, instead of duplicated. Precisely: the old cache file is deleted and the new is saved with the same name.

