### PR TITLE
Update Style Guide to include notes on CamelCase.

### DIFF
--- a/UniMath/README.md
+++ b/UniMath/README.md
@@ -84,8 +84,27 @@ semantics is more likely to be rigorously verifiable and portable to new proof
 checking systems, and we follow a style of coding designed to render proofs
 less fragile and to make the files have a more uniform and pleasing appearance.
 
-* Constructing identifiers:
-    * form the identifier by concatenating English words or existing identifiers, separating them by underscores
+* Identifiers and function names
+  * Form identifiers by concatenating English words or existing identifiers in
+    lower case, separating them by underscores.
+  * Unless it impedes clarity or goes against common practice avoid using
+    abbreviations.
+  * In some parts of the library uppercase is used for bundled mathematical
+    objects (e.g. `Pullback`, `Topos`).  It is sometimes justified to introduce
+    new identifiers using this naming scheme.  The following guidelines should
+    then be applied:
+    * Identifiers with capital letters must not use underscores to separate
+      words, they must use `CamelCase`.
+    * Only use `CamelCase` when it is already used in the parts of the library
+      you are working in or there is some compelling reason for it to be
+      introduced.
+    * Do not use `CamelCase` for intermediary structures.  Example: if
+      `CamelCase`contains a data part and a property part then name these
+      `camel_case_data` and `is_camel_case`, do not call them `CamelCaseData`
+      and `IsCamelCase`.
+    * Capital letters must _never_ occur in function names.  Name your functions
+      `make_camel_case` and `camel_case_property`, not `make_CamelCase` and
+      `CamelCase_property`.
 * Do not use `Admitted` or introduce new axioms.
 * Do not use `apply` with a term that needs no additional arguments filled in,
   because using `exact` would be clearer.

--- a/UniMath/README.md
+++ b/UniMath/README.md
@@ -102,9 +102,10 @@ less fragile and to make the files have a more uniform and pleasing appearance.
       `CamelCase`contains a data part and a property part then name these
       `camel_case_data` and `is_camel_case`, do not call them `CamelCaseData`
       and `IsCamelCase`.
-    * Capital letters must _never_ occur in function names.  Name your functions
+    * Upper-case letters should not be used in function names unless there is
+      specific good reason to do so.  In general name your functions
       `make_camel_case` and `camel_case_property`, not `make_CamelCase` and
-      `CamelCase_property`.
+      `CamelCase_property`, even if the object is called `CamelCase`.
 * Do not use `Admitted` or introduce new axioms.
 * Do not use `apply` with a term that needs no additional arguments filled in,
   because using `exact` would be clearer.


### PR DESCRIPTION
Most of the library use lower case identifiers, but there are some parts where `CamelCase` is used a lot. This codifies parts of this usage, but adds some guidelines on how and when to use that naming scheme.

In particular I propose that reviewers may permit `CamelCase` if the contributors are adding a _mathematical_object_ of some significance to a part of the library where CamelCase _is_ _already_ used. Not every structure or object should use CamelCase, it should be reserved for identifiers of established mathematical objects and structures, in particular not intermediary structures. The guiding principle should be "don't use upper case letters in identifiers, but we may make exceptions to this". I.e. we should be pretty restrictive with allowing new CamelCase identifiers (i.e. ask ourselves: does it harmonize with the surrounding code? does it look good? does it make sense? would lower_case_name look better?), but not shut the door on CamelCase completely.

Most important in my opinion: This adds the guideline that you should never use upper case letters in function names, so it should be `make_product` even if the object is `Product`. This looks a lot better in practice, and also makes the CamelCase identifiers occur almost exclusively in the type declaration of a function and not in the body of it. In my experience it makes it a lot easier for the eyes to find where a type assignment occurs as opposed to a function application.

I also added a note on avoiding abbreviations unless it makes it more readable to use them (no new `gr` please, and `make_binary_product` looks better than `make_binproduct` IMO).

And I stress that these should only be used as they are today - as guidelines - not rules.

Comments, suggestions and dissenting opinions very welcome.