### PR TITLE
Update coq-unimath.opam to require coq 8.16.1.

### DIFF
--- a/coq-unimath.opam
+++ b/coq-unimath.opam
@@ -9,6 +9,6 @@ build: [make "BUILD_COQ=no" "-j%{jobs}%"]
 install: [make "BUILD_COQ=no" "install"]
 depends: [
   "ocaml"
-  "coq" {>= "8.12.2"}
+  "coq" {>= "8.16.1"}
 ]
 synopsis: "Library of Univalent Mathematics"


### PR DESCRIPTION
Currently we use some features of 8.16, and we expect this usage to increase given the improvements to coercions made in `8.16`. Also we do not test in CI if earlier version of Coq builds UniMath. 

This updates the opam file to require 8.16.1.