### PR TITLE
Potential fix for #1625.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To cite UniMath in your article, you can use the following bibtex item:
 ```bibtex
 @Misc{UniMath,
     author = {Voevodsky, Vladimir and Ahrens, Benedikt and Grayson, Daniel and others},
-    title = {{UniMath --- a computer-checked library of univalent mathematics}},
+    title = {UniMath --- a computer-checked library of univalent mathematics},
     url = {https://github.com/UniMath/UniMath},
     howpublished = {available at \url{http://unimath.org}}
  }


### PR DESCRIPTION
Hopefully this fixes #1625. I'm not sure but I guess that Jekyll or whatever it is that generates unimath.org treats the second pair of `{ }` as a special block, and omits the contents in it when generating the page. 

I think the only way to see if this actually works is to merge it to have the pages rebuilt.