### PR TITLE
Fix possibly typo — double-sufficed make targets, `UniMath/Foundations/Preamble.v.vo` etc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ PACKAGE_FILES := $(patsubst %, UniMath/%/.package/files, $(PACKAGES))
 ifneq "$(INCLUDE)" "no"
 include .coq_makefile_output.conf
 VFILES := $(COQMF_VFILES)
+VFILES_BASE := $(VFILES:.v=)
 VOFILES := $(VFILES:.v=.vo)
 endif
 
@@ -173,7 +174,7 @@ $(foreach P,$(PACKAGES),												\
 			$(shell <UniMath/$P/.package/files $(FILES_FILTER) |sed "s=^\(.*\).v=UniMath/$P/\1.vo=" )	\
 			UniMath/$P/All.vo))
 
-$(foreach v,$(VFILES), $(eval $v.vo: $v.v; ulimit -v $(EFFECTIVE_MEMORY_LIMIT) ; $(MAKE) -f build/CoqMakefile.make $v.vo))
+$(foreach v,$(VFILES_BASE), $(eval $v.vo: $v.v; ulimit -v $(EFFECTIVE_MEMORY_LIMIT) ; $(MAKE) -f build/CoqMakefile.make $v.vo))
 
 install:all
 coqwc:; coqwc $(VFILES)


### PR DESCRIPTION
I was looking over the Makefile’s generated targets (for various reasons), and noticed that it generates some targets/dependencies with double-suffixed file names, e.g. `UniMath/Foundations/Preamble.v.vo`.   In the output of `make -pRrq`, we find:

```
UniMath/Foundations/Preamble.v.vo: UniMath/Foundations/Preamble.v.v
#  Implicit rule search has not been done.
#  Modification time never checked.
#  File has not been updated.
#  commands to execute (from `Makefile', line 158):
	ulimit -v unlimited ; /Applications/Xcode.app/Contents/Developer/usr/bin/make -f build/CoqMakefile.make UniMath/Foundations/Preamble.v.vo
```

**Is this intended/correct?**  I can’t quite figure out what that part of the Makefile is doing, but it looks like this might just be a typo; in that case I think it’s fixed by this PR.  But this should certainly be checked by someone who properly understands the Makefile, before merging!

In order to troubleshoot this issue, I prepared a branch `makefile-debugging` with most of the repo deleted — in case it’s of use to others troubleshooting this issue, it’s at https://github.com/peterlefanulumsdaine/UniMath/tree/makefile-debugging