### PR TITLE
Stronger statement for `ScottContinuousFromBasis`.

### DIFF
--- a/UniMath/OrderTheory/DCPOs/Basis/Basis.v
+++ b/UniMath/OrderTheory/DCPOs/Basis/Basis.v
@@ -455,7 +455,7 @@ Section BasisProperties.
   Section ScottContinuousFromBasis.
     Context {Y : dcpo}
             (f : B → Y)
-            (Hf : ∏ (i₁ i₂ : B), B i₁ ≤ B i₂ → f i₁ ≤ f i₂).
+            (Hf : ∏ (i₁ i₂ : B), B i₁ ≪ B i₂ → f i₁ ≤ f i₂).
 
     Proposition is_directed_map_from_basis
                 (x : X)
@@ -471,15 +471,17 @@ Section BasisProperties.
         intro i.
         exact (hinhpr i).
       - intros i j.
-        assert (H := directed_set_top (directed_set_from_basis B x) i j).
+        induction i as [i Hix].
+        induction j as [j Hjx].
+        assert (H := basis_binary_interpolation Hix Hjx).
         revert H.
         use factor_through_squash.
         {
           apply propproperty.
         }
         intro k.
-        induction k as  [ k [ p q ]].
-        refine (hinhpr (k ,, _ ,, _)).
+        induction k as  [ k [ p [ q r ]]].
+        refine (hinhpr ((k ,, r) ,, _ ,, _)).
         + apply Hf.
           exact p.
         + apply Hf.
@@ -588,7 +590,6 @@ Section BasisProperties.
       intro j.
       induction j as [ j p ] ; cbn.
       apply Hf.
-      apply way_below_to_le.
       exact p.
     Qed.
   End ScottContinuousFromBasis.

--- a/UniMath/OrderTheory/DCPOs/Basis/CompactBasis.v
+++ b/UniMath/OrderTheory/DCPOs/Basis/CompactBasis.v
@@ -379,7 +379,7 @@ Proposition scott_continuous_map_from_compact_basis_eq
             (B : compact_basis X)
             {Y : dcpo}
             (f : B → Y)
-            (Hf : ∏ (i₁ i₂ : B), B i₁ ≤ B i₂ → f i₁ ≤ f i₂)
+            (Hf : ∏ (i₁ i₂ : B), B i₁ ≪ B i₂ → f i₁ ≤ f i₂)
             (i : B)
   : scott_continuous_map_from_basis
       (compact_basis_to_dcpo_basis B)
@@ -402,7 +402,7 @@ Definition scott_continuous_map_from_compact_basis_ump
            (B : compact_basis X)
            {Y : dcpo}
            (f : B → Y)
-           (Hf : ∏ (i₁ i₂ : B), B i₁ ≤ B i₂ → f i₁ ≤ f i₂)
+           (Hf : ∏ (i₁ i₂ : B), B i₁ ≪ B i₂ → f i₁ ≤ f i₂)
   : ∃! (g : scott_continuous_map X Y),
     ∏ (i : B), g (B i) = f i.
 Proof.


### PR DESCRIPTION
Use the approximation relation instead of the order of the domain.
For the abstract basis, we want to use its order instead of the inclusion of ideals