### PR TITLE
Renaming some concepts for package SubstitutionSystems

### DIFF
--- a/UniMath/Bicategories/MonoidalCategories/ActionOfEndomorphismsInBicatWhiskered.v
+++ b/UniMath/Bicategories/MonoidalCategories/ActionOfEndomorphismsInBicatWhiskered.v
@@ -182,7 +182,7 @@ Proof.
   rewrite X.
   apply idpath.
 Qed. (* 44s on a modern Intel machine *)
-(** in fact, we need this with lifted actegories everywhere *)
+(** in fact, we need this with reindexed actegories everywhere *)
 
 End TheHomogeneousCase.
 
@@ -227,7 +227,7 @@ Lemma lax_lineators_for_actegoryfromprecomp_and_CAT_version_agree (F : functor [
 Proof.
   Time (apply idpath). (* very slow: __ on a modern Intel machine *)
 Time Qed. (* __ on a modern Intel machine *)
-(** in fact, we need this with lifted actegories everywhere *)
+(** in fact, we need this with reindexed actegories everywhere *)
 *)
 
 Section DistributionOfCoproducts.

--- a/UniMath/Bicategories/MonoidalCategories/ConstructionOfActions.v
+++ b/UniMath/Bicategories/MonoidalCategories/ConstructionOfActions.v
@@ -1,7 +1,7 @@
 (**
   Construction of actions, over monoidal categories:
   - the monoidal category acting on itself
-  - lifting an action from the target of a strong monoidal functor to its source
+  - reindexing an action from the target of a strong monoidal functor to its source
 
   These modularize the construction of the action induced by a strong monoidal functor U, see [U_action].
 
@@ -44,7 +44,7 @@ Proof.
   split; [apply monoidal_cat_triangle_eq | apply monoidal_cat_pentagon_eq].
 Defined.
 
-Section Action_Lifting_Through_Strong_Monoidal_Functor.
+Section Action_Reindexing_Through_Strong_Monoidal_Functor.
 
 Context {Mon_A : monoidal_cat}.
 
@@ -66,11 +66,11 @@ Context {C : category} (actA : action Mon_A C).
 
 Local Definition odotA := act_odot actA.
 
-Definition lifted_odot : C ⊠ V ⟶ C :=
+Definition reindexed_odot : C ⊠ V ⟶ C :=
   functor_composite (pair_functor (functor_identity _) U) odotA.
 
-Definition lifted_action_right_unitor_nat_trans:
-  odot_I_functor Mon_V C lifted_odot ⟹ functor_identity C.
+Definition reindexed_action_right_unitor_nat_trans:
+  odot_I_functor Mon_V C reindexed_odot ⟹ functor_identity C.
 Proof.
   cbn.
   refine (nat_trans_comp _ _ _ _  (act_ϱ actA)).
@@ -85,9 +85,9 @@ Proof.
     exact (pr2 aux a a' f).
 Defined.
 
-Definition lifted_action_right_unitor: action_right_unitor Mon_V C lifted_odot.
+Definition reindexed_action_right_unitor: action_right_unitor Mon_V C reindexed_odot.
 Proof.
-  exists lifted_action_right_unitor_nat_trans.
+  exists reindexed_action_right_unitor_nat_trans.
   intro.
   cbn.
   use is_z_iso_comp_of_is_z_isos.
@@ -97,16 +97,16 @@ Proof.
     + apply (is_z_iso_inv_from_z_iso (strong_monoidal_functor_ϵ U)).
 Defined.
 
-Definition lifted_action_convertor_nat_trans :
-  odot_x_odot_y_functor _ C lifted_odot ⟹ odot_x_otimes_y_functor _ C lifted_odot.
+Definition reindexed_action_convertor_nat_trans :
+  odot_x_odot_y_functor _ C reindexed_odot ⟹ odot_x_otimes_y_functor _ C reindexed_odot.
 Proof.
   apply (nat_trans_comp _ _ _ (pre_whisker (pair_functor (pair_functor (functor_identity _) U) U) (act_χ actA))).
   exact (pre_whisker (precategory_binproduct_unassoc _ _ _) (post_whisker_fst_param (lax_monoidal_functor_μ U) odotA)).
 Defined.
 
-Definition lifted_action_convertor : action_convertor Mon_V C lifted_odot.
+Definition reindexed_action_convertor : action_convertor Mon_V C reindexed_odot.
 Proof.
-  exists lifted_action_convertor_nat_trans.
+  exists reindexed_action_convertor_nat_trans.
   intro x.
   pose (k := ob1 (ob1 x)); pose (k' := ob2 (ob1 x)); pose (k'' := ob2 x).
   use is_z_iso_comp_of_is_z_isos.
@@ -116,8 +116,8 @@ Proof.
     + exact (strong_monoidal_functor_μ_is_nat_z_iso U (k', k'')).
 Defined.
 
-Lemma lifted_action_tlaw : action_triangle_eq Mon_V C
-        lifted_odot lifted_action_right_unitor lifted_action_convertor.
+Lemma reindexed_action_tlaw : action_triangle_eq Mon_V C
+        reindexed_odot reindexed_action_right_unitor reindexed_action_convertor.
 Proof.
   red.
   intros a x.
@@ -189,8 +189,8 @@ Proof.
     apply (act_triangle actA).
 Qed.
 
-Lemma lifted_action_plaw : action_pentagon_eq Mon_V C
-                             lifted_odot lifted_action_convertor.
+Lemma reindexed_action_plaw : action_pentagon_eq Mon_V C
+                             reindexed_odot reindexed_action_convertor.
 Proof.
   red.
   intros a x y z.
@@ -282,17 +282,17 @@ Proof.
   apply idpath.
 Qed.
 
-Definition lifted_action: action Mon_V C.
+Definition reindexed_action: action Mon_V C.
 Proof.
-  exists lifted_odot.
-  exists lifted_action_right_unitor.
-  exists lifted_action_convertor.
+  exists reindexed_odot.
+  exists reindexed_action_right_unitor.
+  exists reindexed_action_convertor.
   split.
-  - exact lifted_action_tlaw.
-  - exact lifted_action_plaw.
+  - exact reindexed_action_tlaw.
+  - exact reindexed_action_plaw.
 Defined.
 
-End Action_Lifting_Through_Strong_Monoidal_Functor.
+End Action_Reindexing_Through_Strong_Monoidal_Functor.
 
 End A.
 
@@ -302,9 +302,9 @@ Section Strong_Monoidal_Functor_Action_Reloaded.
   Context (U : strong_monoidal_functor Mon_V Mon_A).
   Context (C : precategory).
 
-  Definition U_action_alt : action Mon_V (monoidal_cat_cat Mon_A) := lifted_action Mon_V U (action_on_itself Mon_A).
+  Definition U_action_alt : action Mon_V (monoidal_cat_cat Mon_A) := reindexed_action Mon_V U (action_on_itself Mon_A).
 
-(* the two actions would even be convertible - if one would ask for definedness of the proofs of the equations [lifted_action_tlaw] and [lifted_action_plaw] and also [U_action_tlaw] and [U_action_plaw]
+(* the two actions would even be convertible - if one would ask for definedness of the proofs of the equations [reindexed_action_tlaw] and [reindexed_action_plaw] and also [U_action_tlaw] and [U_action_plaw]
   Lemma U_action_alt_ok: U_action_alt = U_action _ U.
   Proof.
     apply idpath.

--- a/UniMath/Bicategories/PseudoFunctors/Examples/LiftingActegories.v
+++ b/UniMath/Bicategories/PseudoFunctors/Examples/LiftingActegories.v
@@ -1,6 +1,8 @@
-(** construction of a (displayed) pseudofunctor from the operation [lifted_actegory] on actegories
+(** construction of a (displayed) pseudofunctor from the operation [reindexed_actegory] on actegories
 
 author: Ralph Matthes 2023
+
+Notice that lifting was renamed into reindexing in July 2023, but the file name stayed the same although [ReindexingActegories.v] would be more appropriate.
 
 *)
 
@@ -30,7 +32,7 @@ Require Import UniMath.Bicategories.DisplayedBicats.DispBuilders.
 
 Local Open Scope cat.
 
-Section PseudofunctorFromLifting.
+Section PseudofunctorFromReindexing.
 
   Context {V : category} (Mon_V : monoidal V) {W : category} (Mon_W : monoidal W)
     {F : W ⟶ V} (U : fmonoidal Mon_W Mon_V F).
@@ -38,17 +40,17 @@ Section PseudofunctorFromLifting.
   Let dBV : disp_bicat bicat_of_cats := bidisp_actbicat_disp_bicat Mon_V.
   Let dBW : disp_bicat bicat_of_cats := bidisp_actbicat_disp_bicat Mon_W.
 
-  Definition lifting_actegories_disp_psfunctor : disp_psfunctor dBV dBW (id_psfunctor _).
+  Definition reindexing_actegories_disp_psfunctor : disp_psfunctor dBV dBW (id_psfunctor _).
   Proof.
     use make_disp_psfunctor.
     - apply actbicat_disp_2cells_isaprop.
     - apply actbicat_disp_locally_groupoid.
     - intros C Act.
-      exact (lifted_actegory Mon_V Act Mon_W U).
+      exact (reindexed_actegory Mon_V Act Mon_W U).
     - intros C D H ActC ActD ll.
-      exact (lifted_lax_lineator Mon_V Mon_W U ActC ActD ll).
+      exact (reindexed_lax_lineator Mon_V Mon_W U ActC ActD ll).
     - intros C D H K ξ ActC ActD Hl Kl islntξ.
-      apply preserves_linearity_lifted_lax_lineator.
+      apply preserves_linearity_reindexed_lax_lineator.
       exact islntξ.
     - abstract (intros C ActC w c;
                 cbn;
@@ -62,7 +64,7 @@ Section PseudofunctorFromLifting.
         apply idpath).
   Defined.
 
-  Definition lifting_actegories_psfunctor : psfunctor (actbicat Mon_V) (actbicat Mon_W)
-    := total_psfunctor dBV dBW (id_psfunctor _) lifting_actegories_disp_psfunctor.
+  Definition reindexing_actegories_psfunctor : psfunctor (actbicat Mon_V) (actbicat Mon_W)
+    := total_psfunctor dBV dBW (id_psfunctor _) reindexing_actegories_disp_psfunctor.
 
-End PseudofunctorFromLifting.
+End PseudofunctorFromReindexing.

--- a/UniMath/CategoryTheory/Actegories/ConstructionOfActegories.v
+++ b/UniMath/CategoryTheory/Actegories/ConstructionOfActegories.v
@@ -1,7 +1,7 @@
 (**
   Construction of actegories:
   - the monoidal category acting on itself
-  - lifting an action from the target of a strong monoidal functor to its source
+  - reindexing an action from the target of a strong monoidal functor to its source
 
 Reconstructs the results from [UniMath.Bicategories.MonoidalCategories.ConstructionOfActions]
 in the whiskered setting.
@@ -61,7 +61,7 @@ Context {C : category} (Act : actegory Mon_V C)
 
 Context {F : W ⟶ V} (U : fmonoidal Mon_W Mon_V F).
 
-Definition lifted_action_data: bifunctor_data W C C.
+Definition reindexed_action_data: bifunctor_data W C C.
 Proof.
   use make_bifunctor_data.
   - intros w x. exact (F w ⊗_{Act} x).
@@ -69,7 +69,7 @@ Proof.
   - intros x w w' g. exact (#F g ⊗^{Act}_{r} x).
 Defined.
 
-Lemma lifted_action_data_is_bifunctor: is_bifunctor lifted_action_data.
+Lemma reindexed_action_data_is_bifunctor: is_bifunctor reindexed_action_data.
 Proof.
   split5; red; intros; cbn.
   - apply (bifunctor_leftid Act).
@@ -79,46 +79,46 @@ Proof.
   - apply (bifunctor_equalwhiskers Act).
 Qed.
 
-Definition lifted_action_unitor_data : action_unitor_data Mon_W lifted_action_data.
+Definition reindexed_action_unitor_data : action_unitor_data Mon_W reindexed_action_data.
 Proof.
   intro x.
   exact (pr1 (fmonoidal_preservesunitstrongly U) ⊗^{Act}_{r} x · au^{Act}_{x}).
 Defined.
 
-Definition lifted_action_unitorinv_data : action_unitorinv_data Mon_W lifted_action_data.
+Definition reindexed_action_unitorinv_data : action_unitorinv_data Mon_W reindexed_action_data.
 Proof.
   intro x.
   exact (auinv^{Act}_{x} · fmonoidal_preservesunit U ⊗^{Act}_{r} x).
 Defined.
 
-Definition lifted_actor_data : actor_data Mon_W lifted_action_data.
+Definition reindexed_actor_data : actor_data Mon_W reindexed_action_data.
 Proof.
   intros v w x.
   exact (pr1 (fmonoidal_preservestensorstrongly U v w) ⊗^{Act}_{r} x · aα^{Act}_{F v,F w,x}).
 Defined.
 
-Definition lifted_actorinv_data : actorinv_data Mon_W lifted_action_data.
+Definition reindexed_actorinv_data : actorinv_data Mon_W reindexed_action_data.
 Proof.
   intros v w x.
   exact (aαinv^{Act}_{F v,F w,x} · fmonoidal_preservestensordata U v w ⊗^{Act}_{r} x).
 Defined.
 
-Definition lifted_actegory_data: actegory_data Mon_W C.
+Definition reindexed_actegory_data: actegory_data Mon_W C.
 Proof.
   use make_actegory_data.
-  - exact lifted_action_data.
-  - exact lifted_action_unitor_data.
-  - exact lifted_action_unitorinv_data.
-  - exact lifted_actor_data.
-  - exact lifted_actorinv_data.
+  - exact reindexed_action_data.
+  - exact reindexed_action_unitor_data.
+  - exact reindexed_action_unitorinv_data.
+  - exact reindexed_actor_data.
+  - exact reindexed_actorinv_data.
 Defined.
 
-Lemma lifted_actegory_laws: actegory_laws Mon_W lifted_actegory_data.
+Lemma reindexed_actegory_laws: actegory_laws Mon_W reindexed_actegory_data.
 Proof.
   split5. (* splits into the 5 main goals *)
-  - exact lifted_action_data_is_bifunctor.
+  - exact reindexed_action_data_is_bifunctor.
   - split3.
-    + intros x y f. cbn. unfold lifted_action_unitor_data.
+    + intros x y f. cbn. unfold reindexed_action_unitor_data.
       etrans.
       2: {
         rewrite assoc'.
@@ -128,8 +128,8 @@ Proof.
       do 2 rewrite assoc.
       apply maponpaths_2.
       apply (! bifunctor_equalwhiskers Act _ _ _ _  (pr1 (fmonoidal_preservesunitstrongly U)) f).
-    + cbn. unfold lifted_action_unitor_data.
-      unfold lifted_action_unitorinv_data.
+    + cbn. unfold reindexed_action_unitor_data.
+      unfold reindexed_action_unitorinv_data.
       etrans. {
         rewrite assoc'.
         apply maponpaths.
@@ -144,8 +144,8 @@ Proof.
         exact (pr22 (fmonoidal_preservesunitstrongly U)).
       }
       apply (bifunctor_rightid Act).
-    + cbn. unfold lifted_action_unitor_data.
-      unfold lifted_action_unitorinv_data.
+    + cbn. unfold reindexed_action_unitor_data.
+      unfold reindexed_action_unitorinv_data.
       etrans. {
         rewrite assoc'.
         apply maponpaths.
@@ -161,7 +161,7 @@ Proof.
   - split4.
     + intros v w z z' h.
       cbn.
-      unfold lifted_actor_data.
+      unfold reindexed_actor_data.
       rewrite assoc'.
       rewrite (actegory_actornatleft Mon_V Act (F v) (F w) z z' h).
       do 2 rewrite assoc.
@@ -169,7 +169,7 @@ Proof.
       apply (bifunctor_equalwhiskers Act).
     + intros v v' w z f.
       cbn.
-      unfold lifted_actor_data.
+      unfold reindexed_actor_data.
       rewrite assoc'.
       rewrite (actegory_actornatright Mon_V Act).
       do 2 rewrite assoc.
@@ -180,7 +180,7 @@ Proof.
       exact (fmonoidal_preservestensornatright U).
     + intros v w w' z g.
       cbn.
-      unfold lifted_actor_data.
+      unfold reindexed_actor_data.
       rewrite assoc'.
       rewrite (actegory_actornatleftright Mon_V Act).
       do 2 rewrite assoc.
@@ -191,8 +191,8 @@ Proof.
       exact (fmonoidal_preservestensornatleft U).
     + split.
       * cbn.
-        unfold lifted_actor_data.
-        unfold lifted_actorinv_data.
+        unfold reindexed_actor_data.
+        unfold reindexed_actorinv_data.
         etrans. {
           rewrite assoc'.
           apply maponpaths.
@@ -208,8 +208,8 @@ Proof.
         }
         apply bifunctor_rightid.
       * cbn.
-        unfold lifted_actor_data.
-        unfold lifted_actorinv_data.
+        unfold reindexed_actor_data.
+        unfold reindexed_actorinv_data.
         etrans. {
           rewrite assoc'.
           apply maponpaths.
@@ -224,8 +224,8 @@ Proof.
         exact (pr2 (actegory_actorisolaw Mon_V Act (F v) (F w) z)).
   - intros v y.
     cbn.
-    unfold lifted_actor_data.
-    unfold lifted_action_unitor_data.
+    unfold reindexed_actor_data.
+    unfold reindexed_action_unitor_data.
     rewrite assoc'.
     rewrite (bifunctor_leftcomp Act).
     etrans. {
@@ -258,7 +258,7 @@ Proof.
     apply id_left.
   - intros w v v' z.
     cbn.
-    unfold lifted_actor_data.
+    unfold reindexed_actor_data.
 
     etrans.
     2: {
@@ -297,7 +297,7 @@ Proof.
     apply (! preserves_associativity_of_inverse_preserves_tensor pα _ _ _ _).
 Qed.
 
-Definition lifted_actegory: actegory Mon_W C := lifted_actegory_data,,lifted_actegory_laws.
+Definition reindexed_actegory: actegory Mon_W C := reindexed_actegory_data,,reindexed_actegory_laws.
 
 End A.
 
@@ -306,7 +306,7 @@ Section B.
   Context {V : category} (Mon_V : monoidal V).
 
   Definition actegory_with_canonical_pointed_action: actegory (monoidal_pointed_objects Mon_V) V :=
-    lifted_actegory Mon_V (actegory_with_canonical_self_action Mon_V)
+    reindexed_actegory Mon_V (actegory_with_canonical_self_action Mon_V)
       (monoidal_pointed_objects Mon_V) (forget_monoidal_pointed_objects_monoidal Mon_V).
 
 End B.

--- a/UniMath/CategoryTheory/Actegories/ConstructionOfActegoryMorphisms.v
+++ b/UniMath/CategoryTheory/Actegories/ConstructionOfActegoryMorphisms.v
@@ -42,14 +42,14 @@ Import BifunctorNotations.
 Import MonoidalNotations.
 Import ActegoryNotations.
 
-Section LiftedLineatorAndLiftedDistributivity.
+Section ReindexedLineatorAndLiftedDistributivity.
 
   Context {V : category} (Mon_V : monoidal V)
           {W : category} (Mon_W : monoidal W)
           {F : W ⟶ V} (U : fmonoidal Mon_W Mon_V F).
 
 
-Section LiftedLaxLineator.
+Section ReindexedLaxLineator.
 
   Context {C D : category} (ActC : actegory Mon_V C) (ActD : actegory Mon_V D).
 
@@ -57,19 +57,19 @@ Section OnFunctors.
 
   Context {H : functor C D} (ll : lineator_lax Mon_V ActC ActD H).
 
-  Definition lifted_lax_lineator_data : lineator_data Mon_W (lifted_actegory Mon_V ActC Mon_W U)
-                                                            (lifted_actegory Mon_V ActD Mon_W U) H.
+  Definition reindexed_lax_lineator_data : lineator_data Mon_W (reindexed_actegory Mon_V ActC Mon_W U)
+                                                            (reindexed_actegory Mon_V ActD Mon_W U) H.
   Proof.
     intros w c. exact (ll (F w) c).
   Defined.
 
-  Lemma lifted_lax_lineator_laws : lineator_laxlaws Mon_W (lifted_actegory Mon_V ActC Mon_W U)
-                                     (lifted_actegory Mon_V ActD Mon_W U) H lifted_lax_lineator_data.
+  Lemma reindexed_lax_lineator_laws : lineator_laxlaws Mon_W (reindexed_actegory Mon_V ActC Mon_W U)
+                                     (reindexed_actegory Mon_V ActD Mon_W U) H reindexed_lax_lineator_data.
   Proof.
     split4.
     - intro; intros. apply (lineator_linnatleft _ _ _ _ ll).
     - intro; intros. apply (lineator_linnatright _ _ _ _ ll).
-    - intro; intros. cbn. unfold lifted_lax_lineator_data, lifted_actor_data.
+    - intro; intros. cbn. unfold reindexed_lax_lineator_data, reindexed_actor_data.
       etrans.
       2: { repeat rewrite assoc'. apply maponpaths.
            rewrite assoc.
@@ -83,7 +83,7 @@ Section OnFunctors.
            apply maponpaths.
            apply functor_comp. }
       apply idpath.
-    - intro; intros. cbn. unfold lifted_lax_lineator_data, lifted_action_unitor_data.
+    - intro; intros. cbn. unfold reindexed_lax_lineator_data, reindexed_action_unitor_data.
       etrans.
       2: { apply maponpaths.
            apply (lineator_preservesunitor _ _ _ _ ll). }
@@ -98,9 +98,9 @@ Section OnFunctors.
       apply idpath.
   Qed.
 
-  Definition lifted_lax_lineator : lineator_lax Mon_W (lifted_actegory Mon_V ActC Mon_W U)
-                                                      (lifted_actegory Mon_V ActD Mon_W U) H :=
-    _,,lifted_lax_lineator_laws.
+  Definition reindexed_lax_lineator : lineator_lax Mon_W (reindexed_actegory Mon_V ActC Mon_W U)
+                                                      (reindexed_actegory Mon_V ActD Mon_W U) H :=
+    _,,reindexed_lax_lineator_laws.
 
 End OnFunctors.
 
@@ -110,8 +110,8 @@ Section OnNaturalTransformations.
     {K : functor C D} (Kl : lineator_lax Mon_V ActC ActD K)
     {ξ : H ⟹ K} (islntξ : is_linear_nat_trans Hl Kl ξ).
 
-  Lemma preserves_linearity_lifted_lax_lineator :
-    is_linear_nat_trans (lifted_lax_lineator Hl) (lifted_lax_lineator Kl) ξ.
+  Lemma preserves_linearity_reindexed_lax_lineator :
+    is_linear_nat_trans (reindexed_lax_lineator Hl) (reindexed_lax_lineator Kl) ξ.
   Proof.
     intros w c.
     apply islntξ.
@@ -119,7 +119,7 @@ Section OnNaturalTransformations.
 
 End OnNaturalTransformations.
 
-End LiftedLaxLineator.
+End ReindexedLaxLineator.
 
 Section LiftedDistributivity.
 
@@ -169,7 +169,7 @@ Section ActegoryMorphismFromLiftedDistributivity.
   Context (δ : lifteddistributivity) {C : category} (ActV : actegory Mon_V C).
 
   Local Definition FF: C ⟶ C := leftwhiskering_functor ActV v0.
-  Local Definition ActW: actegory Mon_W C := lifted_actegory Mon_V ActV Mon_W U.
+  Local Definition ActW: actegory Mon_W C := reindexed_actegory Mon_V ActV Mon_W U.
 
   Definition lineator_data_from_δ: lineator_data Mon_W ActW ActW FF.
   Proof.
@@ -181,8 +181,8 @@ Section ActegoryMorphismFromLiftedDistributivity.
   Proof.
     assert (δ_nat := lifteddistributivity_ldnat δ).
     do 2 red in δ_nat. cbn in δ_nat.
-    repeat split; red; intros; unfold lineator_data_from_δ; try unfold lifted_actor_data; try unfold lifted_action_unitor_data; cbn;
-      try unfold lifted_actor_data; try unfold lifted_action_unitor_data; cbn.
+    repeat split; red; intros; unfold lineator_data_from_δ; try unfold reindexed_actor_data; try unfold reindexed_action_unitor_data; cbn;
+      try unfold reindexed_actor_data; try unfold reindexed_action_unitor_data; cbn.
     - etrans.
       { repeat rewrite assoc.
         do 2 apply cancel_postcomposition.
@@ -400,14 +400,14 @@ Section ActegoryMorphismFromLiftedDistributivity.
       apply id_left.
   Qed.
 
-  Definition liftedstrength_from_δ: liftedstrength Mon_V Mon_W U ActV ActV FF :=
+  Definition reindexedstrength_from_δ: reindexedstrength Mon_V Mon_W U ActV ActV FF :=
     lineator_data_from_δ,,lineator_laxlaws_from_δ.
 
 End ActegoryMorphismFromLiftedDistributivity.
 
 End FixAnObject.
 
-Arguments liftedstrength_from_δ _ _ {_} _.
+Arguments reindexedstrength_from_δ _ _ {_} _.
 Arguments lifteddistributivity _ : clear implicits.
 Arguments lifteddistributivity_data _ : clear implicits.
 
@@ -865,7 +865,7 @@ End CompositionOfLiftedDistributivities.
 
 End LiftedDistributivity.
 
-End LiftedLineatorAndLiftedDistributivity.
+End ReindexedLineatorAndLiftedDistributivity.
 
 Arguments lifteddistributivity {_} _ {_} _ {_} _ _.
 Arguments lifteddistributivity_data {_} _ {_ _} _.

--- a/UniMath/CategoryTheory/Actegories/ConstructionOfActegoryMorphisms.v
+++ b/UniMath/CategoryTheory/Actegories/ConstructionOfActegoryMorphisms.v
@@ -1,6 +1,6 @@
 (** Construction of actegory morphisms
 
-Part Generalization of pointed distributivity laws to lifted distributivity laws in general monads
+Part Generalization of pointed distributivity laws (a misnomer as it became clear in July 2023) to relative lax commutators in general monoidal categories
 - definition
 - construction of actegory morphism from it
 - composition
@@ -524,7 +524,7 @@ Arguments relativelaxcommutator_data _ : clear implicits.
       + exact unit_relativelaxcommutator_unit.
   Defined.
 
-Section CompositionOfLiftedDistributivities.
+Section CompositionOfRelativeLaxCommutators.
 
   Context (v1 v2 : V) (γ1 : relativelaxcommutator v1) (γ2 : relativelaxcommutator v2).
 
@@ -861,7 +861,7 @@ Section CompositionOfLiftedDistributivities.
            composedrelativelaxcommutator_unit).
   Defined.
 
-End CompositionOfLiftedDistributivities.
+End CompositionOfRelativeLaxCommutators.
 
 End RelativeLaxCommutator.
 

--- a/UniMath/CategoryTheory/Actegories/ConstructionOfActegoryMorphisms.v
+++ b/UniMath/CategoryTheory/Actegories/ConstructionOfActegoryMorphisms.v
@@ -42,7 +42,7 @@ Import BifunctorNotations.
 Import MonoidalNotations.
 Import ActegoryNotations.
 
-Section ReindexedLineatorAndLiftedDistributivity.
+Section ReindexedLineatorAndRelativeLaxCommutator.
 
   Context {V : category} (Mon_V : monoidal V)
           {W : category} (Mon_W : monoidal W)
@@ -121,67 +121,67 @@ End OnNaturalTransformations.
 
 End ReindexedLaxLineator.
 
-Section LiftedDistributivity.
+Section RelativeLaxCommutator.
 
 Section FixAnObject.
 
   Context {v0 : V}.
 
-  Definition lifteddistributivity_data: UU := ∏ (w: W), F w ⊗_{Mon_V} v0 --> v0 ⊗_{Mon_V} F w.
+  Definition relativelaxcommutator_data: UU := ∏ (w: W), F w ⊗_{Mon_V} v0 --> v0 ⊗_{Mon_V} F w.
 
-  Identity Coercion lifteddistributivity_data_funclass: lifteddistributivity_data >-> Funclass.
+  Identity Coercion relativelaxcommutator_data_funclass: relativelaxcommutator_data >-> Funclass.
 
-Section δ_laws.
+Section γ_laws.
 
-  Context (δ : lifteddistributivity_data).
+  Context (γ : relativelaxcommutator_data).
 
-  Definition lifteddistributivity_nat: UU := is_nat_trans (functor_composite F (rightwhiskering_functor Mon_V v0))
-                                                           (functor_composite F (leftwhiskering_functor Mon_V v0)) δ.
+  Definition relativelaxcommutator_nat: UU := is_nat_trans (functor_composite F (rightwhiskering_functor Mon_V v0))
+                                                           (functor_composite F (leftwhiskering_functor Mon_V v0)) γ.
 
-  Definition lifteddistributivity_tensor_body (w w' : W): UU :=
-    δ (w ⊗_{Mon_W} w') = pr1 (fmonoidal_preservestensorstrongly U w w') ⊗^{Mon_V}_{r} v0 · α_{Mon_V} _ _ _ ·
-                           F w ⊗^{Mon_V}_{l} δ w' · αinv_{Mon_V} _ _ _ · δ w ⊗^{Mon_V}_{r} F w' ·
+  Definition relativelaxcommutator_tensor_body (w w' : W): UU :=
+    γ (w ⊗_{Mon_W} w') = pr1 (fmonoidal_preservestensorstrongly U w w') ⊗^{Mon_V}_{r} v0 · α_{Mon_V} _ _ _ ·
+                           F w ⊗^{Mon_V}_{l} γ w' · αinv_{Mon_V} _ _ _ · γ w ⊗^{Mon_V}_{r} F w' ·
                            α_{Mon_V} _ _ _ · v0 ⊗^{Mon_V}_{l} fmonoidal_preservestensordata U w w'.
 
-  Definition lifteddistributivity_tensor: UU := ∏ (w w' : W), lifteddistributivity_tensor_body w w'.
+  Definition relativelaxcommutator_tensor: UU := ∏ (w w' : W), relativelaxcommutator_tensor_body w w'.
 
-  Definition lifteddistributivity_unit: UU :=
-    δ I_{Mon_W} = pr1 (fmonoidal_preservesunitstrongly U) ⊗^{Mon_V}_{r} v0 · lu_{Mon_V} v0 ·
+  Definition relativelaxcommutator_unit: UU :=
+    γ I_{Mon_W} = pr1 (fmonoidal_preservesunitstrongly U) ⊗^{Mon_V}_{r} v0 · lu_{Mon_V} v0 ·
                   ruinv_{Mon_V} v0 · v0 ⊗^{Mon_V}_{l} fmonoidal_preservesunit U.
 
 
-End δ_laws.
+End γ_laws.
 
-Definition lifteddistributivity: UU := ∑ δ : lifteddistributivity_data,
-      lifteddistributivity_nat δ × lifteddistributivity_tensor δ × lifteddistributivity_unit δ.
+Definition relativelaxcommutator: UU := ∑ γ : relativelaxcommutator_data,
+      relativelaxcommutator_nat γ × relativelaxcommutator_tensor γ × relativelaxcommutator_unit γ.
 
-Definition lifteddistributivity_lddata (δ : lifteddistributivity): lifteddistributivity_data := pr1 δ.
-Coercion lifteddistributivity_lddata : lifteddistributivity >-> lifteddistributivity_data.
+Definition relativelaxcommutator_lddata (γ : relativelaxcommutator): relativelaxcommutator_data := pr1 γ.
+Coercion relativelaxcommutator_lddata : relativelaxcommutator >-> relativelaxcommutator_data.
 
-Definition lifteddistributivity_ldnat (δ : lifteddistributivity): lifteddistributivity_nat δ := pr12 δ.
-Definition lifteddistributivity_ldtensor (δ : lifteddistributivity): lifteddistributivity_tensor δ := pr122 δ.
-Definition lifteddistributivity_ldunit (δ : lifteddistributivity): lifteddistributivity_unit δ := pr222 δ.
+Definition relativelaxcommutator_ldnat (γ : relativelaxcommutator): relativelaxcommutator_nat γ := pr12 γ.
+Definition relativelaxcommutator_ldtensor (γ : relativelaxcommutator): relativelaxcommutator_tensor γ := pr122 γ.
+Definition relativelaxcommutator_ldunit (γ : relativelaxcommutator): relativelaxcommutator_unit γ := pr222 γ.
 
 
 
-Section ActegoryMorphismFromLiftedDistributivity.
+Section ActegoryMorphismFromRelativeLaxCommutator.
 
-  Context (δ : lifteddistributivity) {C : category} (ActV : actegory Mon_V C).
+  Context (γ : relativelaxcommutator) {C : category} (ActV : actegory Mon_V C).
 
   Local Definition FF: C ⟶ C := leftwhiskering_functor ActV v0.
   Local Definition ActW: actegory Mon_W C := reindexed_actegory Mon_V ActV Mon_W U.
 
-  Definition lineator_data_from_δ: lineator_data Mon_W ActW ActW FF.
+  Definition lineator_data_from_commutator: lineator_data Mon_W ActW ActW FF.
   Proof.
     intros w x. unfold FF. cbn.
-    exact (aαinv^{ActV}_{F w, v0, x} · δ w ⊗^{ActV}_{r} x · aα^{ActV}_{v0, F w, x}).
+    exact (aαinv^{ActV}_{F w, v0, x} · γ w ⊗^{ActV}_{r} x · aα^{ActV}_{v0, F w, x}).
   Defined.
 
-  Lemma lineator_laxlaws_from_δ: lineator_laxlaws Mon_W ActW ActW FF lineator_data_from_δ.
+  Lemma lineator_laxlaws_from_commutator: lineator_laxlaws Mon_W ActW ActW FF lineator_data_from_commutator.
   Proof.
-    assert (δ_nat := lifteddistributivity_ldnat δ).
-    do 2 red in δ_nat. cbn in δ_nat.
-    repeat split; red; intros; unfold lineator_data_from_δ; try unfold reindexed_actor_data; try unfold reindexed_action_unitor_data; cbn;
+    assert (γ_nat := relativelaxcommutator_ldnat γ).
+    do 2 red in γ_nat. cbn in γ_nat.
+    repeat split; red; intros; unfold lineator_data_from_commutator; try unfold reindexed_actor_data; try unfold reindexed_action_unitor_data; cbn;
       try unfold reindexed_actor_data; try unfold reindexed_action_unitor_data; cbn.
     - etrans.
       { repeat rewrite assoc.
@@ -215,7 +215,7 @@ Section ActegoryMorphismFromLiftedDistributivity.
       etrans.
       2: { apply (functor_comp (rightwhiskering_functor ActV x)). }
       apply maponpaths.
-      apply δ_nat.
+      apply γ_nat.
     - etrans.
       { apply maponpaths.
         apply (functor_comp (leftwhiskering_functor ActV v0)). }
@@ -238,7 +238,7 @@ Section ActegoryMorphismFromLiftedDistributivity.
       etrans.
       { do 2 apply cancel_postcomposition.
         do 2 apply maponpaths.
-        rewrite (lifteddistributivity_ldtensor δ).
+        rewrite (relativelaxcommutator_ldtensor γ).
         repeat rewrite assoc'.
         do 6 apply maponpaths.
         etrans.
@@ -361,7 +361,7 @@ Section ActegoryMorphismFromLiftedDistributivity.
       etrans.
       { do 2 apply cancel_postcomposition.
         do 2 apply maponpaths.
-        rewrite (lifteddistributivity_ldunit δ).
+        rewrite (relativelaxcommutator_ldunit γ).
         repeat rewrite assoc'.
         do 3 apply maponpaths.
         etrans.
@@ -400,27 +400,27 @@ Section ActegoryMorphismFromLiftedDistributivity.
       apply id_left.
   Qed.
 
-  Definition reindexedstrength_from_δ: reindexedstrength Mon_V Mon_W U ActV ActV FF :=
-    lineator_data_from_δ,,lineator_laxlaws_from_δ.
+  Definition reindexedstrength_from_commutator: reindexedstrength Mon_V Mon_W U ActV ActV FF :=
+    lineator_data_from_commutator,,lineator_laxlaws_from_commutator.
 
-End ActegoryMorphismFromLiftedDistributivity.
+End ActegoryMorphismFromRelativeLaxCommutator.
 
 End FixAnObject.
 
-Arguments reindexedstrength_from_δ _ _ {_} _.
-Arguments lifteddistributivity _ : clear implicits.
-Arguments lifteddistributivity_data _ : clear implicits.
+Arguments reindexedstrength_from_commutator _ _ {_} _.
+Arguments relativelaxcommutator _ : clear implicits.
+Arguments relativelaxcommutator_data _ : clear implicits.
 
 
-  Definition unit_lifteddistributivity_data: lifteddistributivity_data I_{Mon_V}.
+  Definition unit_relativelaxcommutator_data: relativelaxcommutator_data I_{Mon_V}.
   Proof.
     intro w.
     exact (ru^{Mon_V}_{F w} · luinv^{Mon_V}_{F w}).
   Defined.
 
-  Lemma unit_lifteddistributivity_nat: lifteddistributivity_nat unit_lifteddistributivity_data.
+  Lemma unit_relativelaxcommutator_nat: relativelaxcommutator_nat unit_relativelaxcommutator_data.
   Proof.
-    intro; intros. unfold unit_lifteddistributivity_data.
+    intro; intros. unfold unit_relativelaxcommutator_data.
     cbn.
     etrans.
     { rewrite assoc.
@@ -431,9 +431,9 @@ Arguments lifteddistributivity_data _ : clear implicits.
     apply pathsinv0, monoidal_leftunitorinvnat.
   Qed.
 
-  Lemma unit_lifteddistributivity_tensor: lifteddistributivity_tensor unit_lifteddistributivity_data.
+  Lemma unit_relativelaxcommutator_tensor: relativelaxcommutator_tensor unit_relativelaxcommutator_data.
   Proof.
-    intro; intros. unfold lifteddistributivity_tensor_body, unit_lifteddistributivity_data.
+    intro; intros. unfold relativelaxcommutator_tensor_body, unit_relativelaxcommutator_data.
     etrans.
     2: { do 2 apply cancel_postcomposition.
          etrans.
@@ -494,9 +494,9 @@ Arguments lifteddistributivity_data _ : clear implicits.
     apply pathsinv0, id_right.
   Qed.
 
-  Lemma unit_lifteddistributivity_unit: lifteddistributivity_unit unit_lifteddistributivity_data.
+  Lemma unit_relativelaxcommutator_unit: relativelaxcommutator_unit unit_relativelaxcommutator_data.
   Proof.
-    unfold lifteddistributivity_unit, unit_lifteddistributivity_data.
+    unfold relativelaxcommutator_unit, unit_relativelaxcommutator_data.
     etrans.
     2: { do 2 apply cancel_postcomposition.
          rewrite unitors_coincide_on_unit.
@@ -514,33 +514,33 @@ Arguments lifteddistributivity_data _ : clear implicits.
     apply pathsinv0, id_left.
   Qed.
 
-  Definition unit_lifteddistributivity: lifteddistributivity I_{Mon_V}.
+  Definition unit_relativelaxcommutator: relativelaxcommutator I_{Mon_V}.
   Proof.
     use tpair.
-    - exact  unit_lifteddistributivity_data.
+    - exact  unit_relativelaxcommutator_data.
     - split3.
-      + exact unit_lifteddistributivity_nat.
-      + exact unit_lifteddistributivity_tensor.
-      + exact unit_lifteddistributivity_unit.
+      + exact unit_relativelaxcommutator_nat.
+      + exact unit_relativelaxcommutator_tensor.
+      + exact unit_relativelaxcommutator_unit.
   Defined.
 
 Section CompositionOfLiftedDistributivities.
 
-  Context (v1 v2 : V) (δ1 : lifteddistributivity v1) (δ2 : lifteddistributivity v2).
+  Context (v1 v2 : V) (γ1 : relativelaxcommutator v1) (γ2 : relativelaxcommutator v2).
 
-  Definition composedlifteddistributivity_data: lifteddistributivity_data (v1 ⊗_{Mon_V} v2).
+  Definition composedrelativelaxcommutator_data: relativelaxcommutator_data (v1 ⊗_{Mon_V} v2).
   Proof.
     red; intros.
-    exact (αinv_{Mon_V} _ _ _ · δ1 w ⊗^{Mon_V}_{r} v2 · α_{Mon_V} _ _ _
-             · v1 ⊗^{Mon_V}_{l} δ2 w · αinv_{Mon_V} _ _ _).
+    exact (αinv_{Mon_V} _ _ _ · γ1 w ⊗^{Mon_V}_{r} v2 · α_{Mon_V} _ _ _
+             · v1 ⊗^{Mon_V}_{l} γ2 w · αinv_{Mon_V} _ _ _).
   Defined.
 
-  Lemma composedlifteddistributivity_nat: lifteddistributivity_nat composedlifteddistributivity_data.
+  Lemma composedrelativelaxcommutator_nat: relativelaxcommutator_nat composedrelativelaxcommutator_data.
   Proof.
-    do 2 red; intros; unfold composedlifteddistributivity_data; cbn.
-    assert (δ1_nat := lifteddistributivity_ldnat δ1).
-    assert (δ2_nat := lifteddistributivity_ldnat δ2).
-    do 2 red in δ1_nat, δ2_nat; cbn in δ1_nat, δ2_nat.
+    do 2 red; intros; unfold composedrelativelaxcommutator_data; cbn.
+    assert (γ1_nat := relativelaxcommutator_ldnat γ1).
+    assert (γ2_nat := relativelaxcommutator_ldnat γ2).
+    do 2 red in γ1_nat, γ2_nat; cbn in γ1_nat, γ2_nat.
     etrans.
     { repeat rewrite assoc.
       do 4 apply cancel_postcomposition.
@@ -552,7 +552,7 @@ Section CompositionOfLiftedDistributivities.
       apply cancel_postcomposition.
       apply pathsinv0, (functor_comp (rightwhiskering_functor Mon_V v2)). }
     cbn.
-    rewrite δ1_nat.
+    rewrite γ1_nat.
     etrans.
     { rewrite assoc.
       do 2 apply cancel_postcomposition.
@@ -570,7 +570,7 @@ Section CompositionOfLiftedDistributivities.
          apply maponpaths.
          apply (functor_comp (leftwhiskering_functor Mon_V v1)). }
     cbn.
-    rewrite <- δ2_nat.
+    rewrite <- γ2_nat.
     etrans.
     2: { apply maponpaths.
          apply pathsinv0, (functor_comp (leftwhiskering_functor Mon_V v1)). }
@@ -580,11 +580,11 @@ Section CompositionOfLiftedDistributivities.
     apply pathsinv0, monoidal_associatornatleftright.
   Qed.
 
-  Lemma composedlifteddistributivity_tensor: lifteddistributivity_tensor composedlifteddistributivity_data.
+  Lemma composedrelativelaxcommutator_tensor: relativelaxcommutator_tensor composedrelativelaxcommutator_data.
   Proof.
-    do 2 red; intros; unfold composedlifteddistributivity_data; cbn.
-    rewrite (lifteddistributivity_ldtensor δ1).
-    rewrite (lifteddistributivity_ldtensor δ2).
+    do 2 red; intros; unfold composedrelativelaxcommutator_data; cbn.
+    rewrite (relativelaxcommutator_ldtensor γ1).
+    rewrite (relativelaxcommutator_ldtensor γ2).
     etrans.
     { do 3 apply cancel_postcomposition.
       apply maponpaths.
@@ -767,11 +767,11 @@ Section CompositionOfLiftedDistributivities.
     apply pathsinv0, monoidal_pentagonidentity.
   Qed.
 
-  Lemma composedlifteddistributivity_unit: lifteddistributivity_unit composedlifteddistributivity_data.
+  Lemma composedrelativelaxcommutator_unit: relativelaxcommutator_unit composedrelativelaxcommutator_data.
   Proof.
-    red; unfold composedlifteddistributivity_data; cbn.
-    rewrite (lifteddistributivity_ldunit δ1).
-    rewrite (lifteddistributivity_ldunit δ2).
+    red; unfold composedrelativelaxcommutator_data; cbn.
+    rewrite (relativelaxcommutator_ldunit γ1).
+    rewrite (relativelaxcommutator_ldunit γ2).
     etrans.
     { do 3 apply cancel_postcomposition.
       apply maponpaths.
@@ -853,22 +853,22 @@ Section CompositionOfLiftedDistributivities.
     apply id_left.
   Qed.
 
-  Definition composedlifteddistributivity: lifteddistributivity (v1 ⊗_{Mon_V} v2).
+  Definition composedrelativelaxcommutator: relativelaxcommutator (v1 ⊗_{Mon_V} v2).
   Proof.
-    exists composedlifteddistributivity_data.
-    exact (composedlifteddistributivity_nat,,
-           composedlifteddistributivity_tensor,,
-           composedlifteddistributivity_unit).
+    exists composedrelativelaxcommutator_data.
+    exact (composedrelativelaxcommutator_nat,,
+           composedrelativelaxcommutator_tensor,,
+           composedrelativelaxcommutator_unit).
   Defined.
 
 End CompositionOfLiftedDistributivities.
 
-End LiftedDistributivity.
+End RelativeLaxCommutator.
 
-End ReindexedLineatorAndLiftedDistributivity.
+End ReindexedLineatorAndRelativeLaxCommutator.
 
-Arguments lifteddistributivity {_} _ {_} _ {_} _ _.
-Arguments lifteddistributivity_data {_} _ {_ _} _.
+Arguments relativelaxcommutator {_} _ {_} _ {_} _ _.
+Arguments relativelaxcommutator_data {_} _ {_ _} _.
 
 Section PointwiseOperationsOnLinearFunctors.
 

--- a/UniMath/CategoryTheory/Actegories/CoproductsInActegories.v
+++ b/UniMath/CategoryTheory/Actegories/CoproductsInActegories.v
@@ -354,27 +354,27 @@ Section TwoMonoidalCategories.
     {W : category} (Mon_W : monoidal W)
     {F : W ⟶ V} (U : fmonoidal Mon_W Mon_V F).
 
-  Let ActW : actegory Mon_W C := lifted_actegory Mon_V Act Mon_W U.
+  Let ActW : actegory Mon_W C := reindexed_actegory Mon_V Act Mon_W U.
 
 Section BinaryCase.
 
   Context (BCP : BinCoproducts C) (δ : actegory_bincoprod_distributor Mon_V BCP Act).
 
-  Definition lifted_bincoprod_distributor_data : actegory_bincoprod_distributor_data Mon_W BCP ActW.
+  Definition reindexed_bincoprod_distributor_data : actegory_bincoprod_distributor_data Mon_W BCP ActW.
   Proof.
     intros w c c'.
     apply (δ (F w)).
   Defined.
 
-  Lemma lifted_bincoprod_distributor_law :
-    actegory_bincoprod_distributor_iso_law _ _ _ lifted_bincoprod_distributor_data.
+  Lemma reindexed_bincoprod_distributor_law :
+    actegory_bincoprod_distributor_iso_law _ _ _ reindexed_bincoprod_distributor_data.
   Proof.
     intros w c c'.
-    split; unfold lifted_bincoprod_distributor_data; apply (pr2 δ (F w)).
+    split; unfold reindexed_bincoprod_distributor_data; apply (pr2 δ (F w)).
   Qed.
 
-  Definition lifted_bincoprod_distributor : actegory_bincoprod_distributor Mon_W BCP ActW :=
-    _,,lifted_bincoprod_distributor_law.
+  Definition reindexed_bincoprod_distributor : actegory_bincoprod_distributor Mon_W BCP ActW :=
+    _,,reindexed_bincoprod_distributor_law.
 
 End BinaryCase.
 
@@ -382,21 +382,21 @@ Section IndexedCase.
 
   Context {I : UU} (CP : Coproducts I C) (δ : actegory_coprod_distributor Mon_V CP Act).
 
-  Definition lifted_coprod_distributor_data : actegory_coprod_distributor_data Mon_W CP ActW.
+  Definition reindexed_coprod_distributor_data : actegory_coprod_distributor_data Mon_W CP ActW.
   Proof.
     intros w cs.
     apply (δ (F w)).
   Defined.
 
-  Lemma lifted_coprod_distributor_law :
-    actegory_coprod_distributor_iso_law _ _ _ lifted_coprod_distributor_data.
+  Lemma reindexed_coprod_distributor_law :
+    actegory_coprod_distributor_iso_law _ _ _ reindexed_coprod_distributor_data.
   Proof.
     intros w cs.
-    split; unfold lifted_coprod_distributor_data; apply (pr2 δ).
+    split; unfold reindexed_coprod_distributor_data; apply (pr2 δ).
   Qed.
 
-  Definition lifted_coprod_distributor : actegory_coprod_distributor Mon_W CP ActW :=
-    _,,lifted_coprod_distributor_law.
+  Definition reindexed_coprod_distributor : actegory_coprod_distributor Mon_W CP ActW :=
+    _,,reindexed_coprod_distributor_law.
 
 End IndexedCase.
 

--- a/UniMath/CategoryTheory/Actegories/Examples/ActionOfEndomorphismsInCATElementary.v
+++ b/UniMath/CategoryTheory/Actegories/Examples/ActionOfEndomorphismsInCATElementary.v
@@ -134,7 +134,7 @@ Lemma lax_lineators_for_actegory_from_precomp_CAT_and_self_action_agree (F : fun
 Proof.
   apply idpath.
 Qed.
-(** in fact, we need this with lifted actegories everywhere *)
+(** in fact, we need this with reindexed actegories everywhere *)
 
 End TheHomogeneousCase.
 

--- a/UniMath/CategoryTheory/Actegories/MorphismsOfActegories.v
+++ b/UniMath/CategoryTheory/Actegories/MorphismsOfActegories.v
@@ -556,22 +556,22 @@ Section StrongFunctors.
     apply idpath.
   Qed.
 
-Section LiftedStrength.
+Section ReindexedStrength.
 
   Context {V : category} (Mon_V : monoidal V)
           {W : category} (Mon_W : monoidal W)
           {F : W ⟶ V} (U : fmonoidal Mon_W Mon_V F)
           {C D : category} (ActC : actegory Mon_V C) (ActD : actegory Mon_V D) (FF :  C ⟶ D).
 
-  Definition liftedstrength : UU :=
-    lineator_lax Mon_W (lifted_actegory Mon_V ActC Mon_W U) (lifted_actegory Mon_V ActD Mon_W U) FF.
+  Definition reindexedstrength : UU :=
+    lineator_lax Mon_W (reindexed_actegory Mon_V ActC Mon_W U) (reindexed_actegory Mon_V ActD Mon_W U) FF.
 
-  Identity Coercion id_liftedstrength : liftedstrength >-> lineator_lax.
+  Identity Coercion id_reindexedstrength : reindexedstrength >-> lineator_lax.
 
-End LiftedStrength.
+End ReindexedStrength.
 
   Definition pointedtensorialstrength {C : category} (M : monoidal C) (F : functor C C) : UU :=
-    liftedstrength M (monoidal_pointed_objects M) (forget_monoidal_pointed_objects_monoidal M)
+    reindexedstrength M (monoidal_pointed_objects M) (forget_monoidal_pointed_objects_monoidal M)
                    (actegory_with_canonical_self_action M) (actegory_with_canonical_self_action M) F.
 
   Goal ∏ (C : category)(M : monoidal C) (F : functor C C), pointedtensorialstrength M F =
@@ -582,7 +582,7 @@ End LiftedStrength.
     apply idpath.
   Qed.
 
-  Identity Coercion id_pointedtensorialstrength : pointedtensorialstrength >-> liftedstrength.
+  Identity Coercion id_pointedtensorialstrength : pointedtensorialstrength >-> reindexedstrength.
 
   Lemma pointedtensorialstrength_lineator_nat_left {C : category} (M : monoidal C)
     {F : functor C C} (pts : pointedtensorialstrength M F):
@@ -611,12 +611,12 @@ End LiftedStrength.
     - intros H c.
       assert (Hc := H c). clear H.
       cbn in Hc.
-      unfold total_unit, lifted_action_unitor_data in Hc. cbn in Hc.
+      unfold total_unit, reindexed_action_unitor_data in Hc. cbn in Hc.
       do 2 rewrite (bifunctor_rightid M) in Hc. do 2 rewrite id_left in Hc.
       exact Hc.
     - intros H c.
       cbn.
-      unfold total_unit, lifted_action_unitor_data. cbn.
+      unfold total_unit, reindexed_action_unitor_data. cbn.
       do 2 rewrite (bifunctor_rightid M). do 2 rewrite id_left.
       apply H.
     - apply impred; intro c. apply C.
@@ -634,12 +634,12 @@ End LiftedStrength.
     - intros H v w x.
       assert (Hinst := H v w x). clear H.
       cbn in Hinst.
-      unfold lifted_actor_data in Hinst. cbn in Hinst.
+      unfold reindexed_actor_data in Hinst. cbn in Hinst.
       do 2 rewrite (bifunctor_rightid M) in Hinst. do 2 rewrite id_left in Hinst.
       exact Hinst.
     - intros H v w x.
       cbn.
-      unfold lifted_actor_data. cbn.
+      unfold reindexed_actor_data. cbn.
       do 2 rewrite (bifunctor_rightid M). do 2 rewrite id_left.
       apply H.
     - do 3 (apply impred; intro). apply C.

--- a/UniMath/SubstitutionSystems/ActionBasedStrengthOnHomsInBicat.v
+++ b/UniMath/SubstitutionSystems/ActionBasedStrengthOnHomsInBicat.v
@@ -48,9 +48,9 @@ Local Definition Mon_endo: monoidal_cat
 Context (U: strong_monoidal_functor Mon_M Mon_endo).
 
 Local Definition ab_strength_domain_action : action Mon_M (hom c0 d0')
-  := lifted_action Mon_M U (action_from_precomp c0 d0').
+  := reindexed_action Mon_M U (action_from_precomp c0 d0').
 Local Definition ab_strength_target_action : action Mon_M (hom c0 d0)
-  := lifted_action Mon_M U (action_from_precomp c0 d0).
+  := reindexed_action Mon_M U (action_from_precomp c0 d0).
 
 Context (F: hom c0 d0' ⟶ hom c0 d0).
 

--- a/UniMath/SubstitutionSystems/BindingSigToMonad_actegorical.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad_actegorical.v
@@ -124,10 +124,10 @@ Section FixACategory.
     apply bincoprod_distributor_CAT.
   Defined.
 
-  Local Definition ptdlifteddistributivity_CAT (G : functor C C) :=
-    lifteddistributivity Mon_endo_CAT Mon_ptdendo_CAT (forget_monoidal_pointed_objects_monoidal Mon_endo_CAT) G.
-  Local Definition ptdlifteddistributivity_CAT_data (G : functor C C) :=
-    lifteddistributivity_data Mon_endo_CAT (F:=pr1_category (coslice_cat_disp endoCAT I_{Mon_endo_CAT})) G.
+  Local Definition pointedlaxcommutator_CAT (G : functor C C) :=
+    relativelaxcommutator Mon_endo_CAT Mon_ptdendo_CAT (forget_monoidal_pointed_objects_monoidal Mon_endo_CAT) G.
+  Local Definition pointedlaxcommutator_CAT_data (G : functor C C) :=
+    relativelaxcommutator_data Mon_endo_CAT (F:=pr1_category (coslice_cat_disp endoCAT I_{Mon_endo_CAT})) G.
 
   Section ConstConst.
 
@@ -153,7 +153,7 @@ Section FixACategory.
 
   Local Definition genopt : endoCAT := constcoprod_functor1 BC a.
 
-  Definition lifteddistr_genopt_data : ptdlifteddistributivity_CAT_data genopt.
+  Definition ptdlaxcommutator_genopt_data : pointedlaxcommutator_CAT_data genopt.
   Proof.
     apply δ_genoption.
   Defined.
@@ -168,7 +168,7 @@ Section FixACategory.
         apply BinCoproductIn2.
  *)
 
-  Lemma lifteddistr_genopt_nat : lifteddistributivity_nat Mon_endo_CAT lifteddistr_genopt_data.
+  Lemma ptdlaxcommutator_genopt_nat : relativelaxcommutator_nat Mon_endo_CAT ptdlaxcommutator_genopt_data.
   Proof.
     intro Ze; induction Ze as [Z e]; intro Z'e'; induction Z'e' as [Z' e']; intro αX; induction αX as [α X]; simpl in *.
     apply nat_trans_eq; [apply homset_property |]; intro c; simpl.
@@ -184,8 +184,8 @@ Section FixACategory.
     - apply pathsinv0,  nat_trans_ax.
   Qed.
 
-  Lemma lifteddistr_genopt_tensor : lifteddistributivity_tensor Mon_endo_CAT Mon_ptdendo_CAT
-                                      (forget_monoidal_pointed_objects_monoidal Mon_endo_CAT) lifteddistr_genopt_data.
+  Lemma ptdlaxcommutator_genopt_tensor : relativelaxcommutator_tensor Mon_endo_CAT Mon_ptdendo_CAT
+                                      (forget_monoidal_pointed_objects_monoidal Mon_endo_CAT) ptdlaxcommutator_genopt_data.
   Proof.
     intros Ze Z'e'; induction Ze as [Z e]; induction Z'e' as [Z' e'].
     apply nat_trans_eq_alt; intro c; simpl.
@@ -210,8 +210,8 @@ Section FixACategory.
       apply pathsinv0, maponpaths, BinCoproductIn2Commutes.
   Qed.
 
-  Lemma lifteddistr_genopt_unit : lifteddistributivity_unit Mon_endo_CAT Mon_ptdendo_CAT
-                                    (forget_monoidal_pointed_objects_monoidal Mon_endo_CAT) lifteddistr_genopt_data.
+  Lemma ptdlaxcommutator_genopt_unit : relativelaxcommutator_unit Mon_endo_CAT Mon_ptdendo_CAT
+                                    (forget_monoidal_pointed_objects_monoidal Mon_endo_CAT) ptdlaxcommutator_genopt_data.
   Proof.
     apply nat_trans_eq_alt; intro c; simpl.
     unfold δ_genoption_mor, BinCoproduct_of_functors_ob, BinCoproduct_of_functors_mor, BinCoproductOfArrows; simpl.
@@ -220,24 +220,24 @@ Section FixACategory.
     apply idpath.
   Qed.
 
-  Definition lifteddistr_genopt : ptdlifteddistributivity_CAT genopt.
+  Definition ptdlaxcommutator_genopt : pointedlaxcommutator_CAT genopt.
   Proof.
-    exists lifteddistr_genopt_data.
+    exists ptdlaxcommutator_genopt_data.
     split3.
-    - exact lifteddistr_genopt_nat.
-    - exact lifteddistr_genopt_tensor.
-    - exact lifteddistr_genopt_unit.
+    - exact ptdlaxcommutator_genopt_nat.
+    - exact ptdlaxcommutator_genopt_tensor.
+    - exact ptdlaxcommutator_genopt_unit.
   Defined.
 
   End genopt.
 
     (** Define δ for G = F^n *)
-  Definition lifteddistr_iter_functor1 (G : functor C C) (δ : ptdlifteddistributivity_CAT G) (n: nat) :
-    ptdlifteddistributivity_CAT (iter_functor1 _ G n).
+  Definition ptdlaxcommutator_iter_functor1 (G : functor C C) (δ : pointedlaxcommutator_CAT G) (n: nat) :
+    pointedlaxcommutator_CAT (iter_functor1 _ G n).
   Proof.
     induction n as [|n IHn].
     - exact δ.
-    - use composedlifteddistributivity.
+    - use composedrelativelaxcommutator.
       + apply IHn.
       + exact δ.
   Defined.
@@ -247,8 +247,8 @@ Section FixACategory.
   Proof.
     destruct n; simpl.
     - apply identity_lineator.
-    - use reindexedstrength_from_δ.
-      refine (lifteddistr_iter_functor1 (option_functor BCC TC) (lifteddistr_genopt TC BCC) n).
+    - use reindexedstrength_from_commutator.
+      refine (ptdlaxcommutator_iter_functor1 (option_functor BCC TC) (ptdlaxcommutator_genopt TC BCC) n).
   Defined.
 
 

--- a/UniMath/SubstitutionSystems/BindingSigToMonad_actegorical.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad_actegorical.v
@@ -1,7 +1,7 @@
 (** a follow-up of [BindingSigToMonad], where the semantic signatures [Signature] are replaced by functors with tensorial strength
 
     the concept of binding signatures is inherited, as well as the reasoning about omega-cocontinuity
-    the strength notion is the one of generalized heterogeneous substitution systems (GHSS), and accordingly a GHSS
+    the strength notion is the one of monoidal heterogeneous substitution systems (MHSS), and accordingly a MHSS
     is constructed and a monad obtained through it
 
 author: Ralph Matthes, 2023
@@ -358,11 +358,11 @@ Section PuttingAllTogether.
     - apply ColimsFunctorCategory_of_shape, CLC.
   Defined.
 
-  (** the associated GHSS *)
-  Definition GHSSOfBindingSig_CAT :
-    ghss Mon_endo_CAT (BindingSigToFunctor TC sig CC) (BindingSigToStrengthCAT TC sig CC).
+  (** the associated MHSS *)
+  Definition MHSSOfBindingSig_CAT :
+    mhss Mon_endo_CAT (BindingSigToFunctor TC sig CC) (BindingSigToStrengthCAT TC sig CC).
   Proof.
-    use (initial_alg_to_ghss (BindingSigToStrengthCAT TC sig CC) BCC2 (bincoprod_distributor_pointed_CAT BCC)).
+    use (initial_alg_to_mhss (BindingSigToStrengthCAT TC sig CC) BCC2 (bincoprod_distributor_pointed_CAT BCC)).
     - apply (Initial_functor_precat _ _ IC).
     - apply ColimsFunctorCategory_of_shape, CLC.
     - apply (is_omega_cocont_BindingSigToFunctor TC CLC HF sig CC).
@@ -373,8 +373,8 @@ Section PuttingAllTogether.
   (** the associated Sigma-monoid *)
   Definition SigmaMonoidOfBindingSig_CAT : SigmaMonoid (BindingSigToStrengthCAT TC sig CC).
   Proof.
-    apply ghss_to_sigma_monoid.
-    exact GHSSOfBindingSig_CAT.
+    apply mhss_to_sigma_monoid.
+    exact MHSSOfBindingSig_CAT.
   Defined.
 
   (** the associated monad *)

--- a/UniMath/SubstitutionSystems/BindingSigToMonad_actegorical.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad_actegorical.v
@@ -103,7 +103,7 @@ Section FixACategory.
     actegory_coprod_distributor Mon_ptdendo_CAT (Coproducts_functor_precat I C C CP)
       (actegory_with_canonical_pointed_action Mon_endo_CAT).
   Proof.
-    apply lifted_coprod_distributor.
+    apply reindexed_coprod_distributor.
     apply coprod_distributor_CAT.
   Defined.
 
@@ -120,7 +120,7 @@ Section FixACategory.
     actegory_bincoprod_distributor Mon_ptdendo_CAT (BinCoproducts_functor_precat C C BCP)
       (actegory_with_canonical_pointed_action Mon_endo_CAT).
   Proof.
-    apply lifted_bincoprod_distributor.
+    apply reindexed_bincoprod_distributor.
     apply bincoprod_distributor_CAT.
   Defined.
 
@@ -247,7 +247,7 @@ Section FixACategory.
   Proof.
     destruct n; simpl.
     - apply identity_lineator.
-    - use liftedstrength_from_δ.
+    - use reindexedstrength_from_δ.
       refine (lifteddistr_iter_functor1 (option_functor BCC TC) (lifteddistr_genopt TC BCC) n).
   Defined.
 

--- a/UniMath/SubstitutionSystems/ConstructionOfGHSS.v
+++ b/UniMath/SubstitutionSystems/ConstructionOfGHSS.v
@@ -1,7 +1,10 @@
-(** construction of generalized heterogeneous substitution systems from arbitrary final coalgebras
+(** construction of monoidal heterogeneous substitution systems from arbitrary final coalgebras
    and from initial algebras arising from iteration in omega-cocontinuous functors
 
 authors: Ralph Matthes, Kobe Wullaert, 2023
+
+Note: the name of the file still refers to GHSS although it would more appropriately be MHSS after the renaming from "generalized" to "monoidal" done in July 2023.
+
 *)
 
 
@@ -61,7 +64,7 @@ Section FixTheContext.
 
   Definition I_H : functor V V := Const_plus_H I_{Mon_V}.
 
-Section FinalCoalgebraToGHSS.
+Section FinalCoalgebraToMHSS.
 
   Context (νH : coalgebra_ob I_H)
           (isTerminalνH : isTerminal (CoAlg_category I_H) νH).
@@ -71,7 +74,7 @@ Section FinalCoalgebraToGHSS.
   Let out_z_iso : z_iso t (I_H t) := finalcoalgebra_z_iso _ I_H νH isTerminalνH.
   Let out_inv : I_H t --> t := inv_from_z_iso out_z_iso.
 
-  Definition final_coalg_to_ghss_step_term
+  Definition final_coalg_to_mhss_step_term
              {Z : PtdV} (f : pr1 Z --> t)
     : Z ⊗_{Act} t --> I_H (CP (Z ⊗_{Act} t) t).
   Proof.
@@ -83,7 +86,7 @@ Section FinalCoalgebraToGHSS.
   Defined.
 
   (** an alternative route through completely iterative algebras *)
-  Definition final_coalg_to_ghss_equation_morphism
+  Definition final_coalg_to_mhss_equation_morphism
              {Z : PtdV} (f : pr1 Z --> t)
     : Z ⊗_{Act} t --> CP (I_H (Z ⊗_{Act} t)) t.
   Proof.
@@ -97,13 +100,13 @@ Section FinalCoalgebraToGHSS.
       apply BinCoproductIn1.
   Defined.
 
-  Lemma final_coalg_to_ghss_equation_morphism_is_factor
+  Lemma final_coalg_to_mhss_equation_morphism_is_factor
     {Z : PtdV} (f : pr1 Z --> t)
-    :  final_coalg_to_ghss_step_term f =
+    :  final_coalg_to_mhss_step_term f =
          CompletelyIterativeAlgebras.ϕ_for_cia CP I_H νH isTerminalνH
-           (Z ⊗_{Act} t) (final_coalg_to_ghss_equation_morphism f).
+           (Z ⊗_{Act} t) (final_coalg_to_mhss_equation_morphism f).
   Proof.
-    unfold final_coalg_to_ghss_step_term, CompletelyIterativeAlgebras.ϕ_for_cia, final_coalg_to_ghss_equation_morphism.
+    unfold final_coalg_to_mhss_step_term, CompletelyIterativeAlgebras.ϕ_for_cia, final_coalg_to_mhss_equation_morphism.
     repeat rewrite assoc'.
     do 3 apply maponpaths.
     unfold Const_plus_H, GeneralizedSubstitutionSystems.Const_plus_H. cbn. unfold BinCoproduct_of_functors_mor.
@@ -135,7 +138,7 @@ Section FinalCoalgebraToGHSS.
   Qed.
 
   Local Definition ϕ {Z : PtdV} (f : pr1 Z --> t)
-    := final_coalg_to_ghss_step_term f.
+    := final_coalg_to_mhss_step_term f.
   Local Definition Corec_ϕ {Z : PtdV} (f : pr1 Z --> t)
     := primitive_corecursion CP isTerminalνH (x :=  Z ⊗_{Act} t) (ϕ f).
 
@@ -183,14 +186,14 @@ Section FinalCoalgebraToGHSS.
       apply idpath.
   Qed.
 
-  Lemma final_coalg_to_ghss_has_equivalent_characteristic_formula
+  Lemma final_coalg_to_mhss_has_equivalent_characteristic_formula
     {Z : PtdV} (f : pr1 Z --> t) (h : Z ⊗_{Act} t --> t) :
     primitive_corecursion_characteristic_formula CP (ϕ f) h ≃
-      gbracket_property_parts Mon_V H θ t η τ (pr2 Z) f h.
+      mbracket_property_parts Mon_V H θ t η τ (pr2 Z) f h.
   Proof.
     apply weqimplimpl.
     - intro Hcorec.
-      apply (pr2 (gbracket_property_single_equivalent _ _ _ _ _ _ CP _ _ _)).
+      apply (pr2 (mbracket_property_single_equivalent _ _ _ _ _ _ CP _ _ _)).
       red.
       red in Hcorec.
       fold out t in Hcorec.
@@ -200,7 +203,7 @@ Section FinalCoalgebraToGHSS.
       { apply maponpaths.
         exact Hcorec. }
       clear Hcorec.
-      unfold ϕ, final_coalg_to_ghss_step_term.
+      unfold ϕ, final_coalg_to_mhss_step_term.
       etrans.
       { repeat rewrite assoc.
         do 6 apply cancel_postcomposition.
@@ -247,21 +250,21 @@ Section FinalCoalgebraToGHSS.
       { apply maponpaths.
         apply (pr122 out_z_iso). }
       apply id_right.
-    - intro Hghss.
-      apply (pr1 (gbracket_property_single_equivalent _ _ _ _ _ _ CP _ _ _)) in Hghss.
+    - intro Hmhss.
+      apply (pr1 (mbracket_property_single_equivalent _ _ _ _ _ _ CP _ _ _)) in Hmhss.
       red.
-      red in Hghss.
+      red in Hmhss.
       fold out t.
-      rewrite ητ_is_out_inv in Hghss.
-      rewrite assoc' in Hghss.
+      rewrite ητ_is_out_inv in Hmhss.
+      rewrite assoc' in Hmhss.
       apply (z_iso_inv_to_left _ _ _ (_,,bincoprod_functor_lineator_strongly
-                                        Mon_PtdV CP Act δ (pr1 Z,, pr2 Z) (I_{ Mon_V},,H t))) in Hghss.
-      apply (z_iso_inv_to_left _ _ _ (functor_on_z_iso (leftwhiskering_functor Act (pr1 Z,, pr2 Z)) out_z_iso)) in Hghss.
+                                        Mon_PtdV CP Act δ (pr1 Z,, pr2 Z) (I_{ Mon_V},,H t))) in Hmhss.
+      apply (z_iso_inv_to_left _ _ _ (functor_on_z_iso (leftwhiskering_functor Act (pr1 Z,, pr2 Z)) out_z_iso)) in Hmhss.
       etrans.
       { apply cancel_postcomposition.
-        exact Hghss. }
-      clear Hghss.
-      unfold ϕ, final_coalg_to_ghss_step_term.
+        exact Hmhss. }
+      clear Hmhss.
+      unfold ϕ, final_coalg_to_mhss_step_term.
       repeat rewrite assoc'.
       do 2 apply maponpaths.
       etrans.
@@ -289,10 +292,10 @@ Section FinalCoalgebraToGHSS.
         apply (pr222 out_z_iso). }
       apply id_right.
     - apply V.
-    - apply isaprop_gbracket_property_parts.
+    - apply isaprop_mbracket_property_parts.
   Qed.
 
-  Definition final_coalg_to_ghss : ghss Mon_V H θ.
+  Definition final_coalg_to_mhss : mhss Mon_V H θ.
   Proof.
     exists t.
     exists η.
@@ -300,26 +303,26 @@ Section FinalCoalgebraToGHSS.
     intros Z f.
     simple refine (iscontrretract _ _ _ (Corec_ϕ f)).
     - intros [h Hyp].
-      exists h. apply final_coalg_to_ghss_has_equivalent_characteristic_formula. exact Hyp.
+      exists h. apply final_coalg_to_mhss_has_equivalent_characteristic_formula. exact Hyp.
     - intros [h Hyp].
-      exists h. apply final_coalg_to_ghss_has_equivalent_characteristic_formula. exact Hyp.
+      exists h. apply final_coalg_to_mhss_has_equivalent_characteristic_formula. exact Hyp.
     - intros [h Hyp].
       use total2_paths_f.
       + apply idpath.
-      + apply isaprop_gbracket_property_parts.
+      + apply isaprop_mbracket_property_parts.
   Defined.
 
   (** the alternative proof through cia *)
-  Lemma final_coalg_to_ghss_equation_morphism_has_equivalent_characteristic_formula
+  Lemma final_coalg_to_mhss_equation_morphism_has_equivalent_characteristic_formula
     {Z : PtdV} (f : pr1 Z --> t) (h : Z ⊗_{Act} t --> t) :
     cia_characteristic_formula CP I_H
       (CompletelyIterativeAlgebras.Xinv _ _ isTerminalνH)
-      (final_coalg_to_ghss_equation_morphism f) h ≃
-      gbracket_property_parts Mon_V H θ t η τ (pr2 Z) f h.
+      (final_coalg_to_mhss_equation_morphism f) h ≃
+      mbracket_property_parts Mon_V H θ t η τ (pr2 Z) f h.
   Proof.
     apply weqimplimpl.
     - intro Hcia.
-      apply (pr2 (gbracket_property_single_equivalent _ _ _ _ _ _ CP _ _ _)).
+      apply (pr2 (mbracket_property_single_equivalent _ _ _ _ _ _ CP _ _ _)).
       red.
       red in Hcia.
       rewrite ητ_is_out_inv.
@@ -327,7 +330,7 @@ Section FinalCoalgebraToGHSS.
       { apply maponpaths.
         exact Hcia. }
       clear Hcia.
-      unfold final_coalg_to_ghss_equation_morphism.
+      unfold final_coalg_to_mhss_equation_morphism.
       etrans.
       { repeat rewrite assoc'.
         apply maponpaths.
@@ -369,19 +372,19 @@ Section FinalCoalgebraToGHSS.
           apply BinCoproductOfArrowsIn2. }
         rewrite assoc'.
         apply idpath.
-    - intro Hghss.
-      apply (pr1 (gbracket_property_single_equivalent _ _ _ _ _ _ CP _ _ _)) in Hghss.
+    - intro Hmhss.
+      apply (pr1 (mbracket_property_single_equivalent _ _ _ _ _ _ CP _ _ _)) in Hmhss.
       red.
-      red in Hghss.
-      rewrite ητ_is_out_inv in Hghss.
-      rewrite assoc' in Hghss.
+      red in Hmhss.
+      rewrite ητ_is_out_inv in Hmhss.
+      rewrite assoc' in Hmhss.
       apply (z_iso_inv_to_left _ _ _ (_,,bincoprod_functor_lineator_strongly
-                                        Mon_PtdV CP Act δ (pr1 Z,, pr2 Z) (I_{ Mon_V},,H t))) in Hghss.
-      apply (z_iso_inv_to_left _ _ _ (functor_on_z_iso (leftwhiskering_functor Act (pr1 Z,, pr2 Z)) out_z_iso)) in Hghss.
+                                        Mon_PtdV CP Act δ (pr1 Z,, pr2 Z) (I_{ Mon_V},,H t))) in Hmhss.
+      apply (z_iso_inv_to_left _ _ _ (functor_on_z_iso (leftwhiskering_functor Act (pr1 Z,, pr2 Z)) out_z_iso)) in Hmhss.
       etrans.
-      { exact Hghss. }
-      clear Hghss.
-      unfold final_coalg_to_ghss_equation_morphism.
+      { exact Hmhss. }
+      clear Hmhss.
+      unfold final_coalg_to_mhss_equation_morphism.
       repeat rewrite assoc'.
       do 3 apply maponpaths.
       unfold GeneralizedSubstitutionSystems.Const_plus_H. cbn.
@@ -406,31 +409,31 @@ Section FinalCoalgebraToGHSS.
         rewrite assoc'.
         apply idpath.
     - apply V.
-    - apply isaprop_gbracket_property_parts.
+    - apply isaprop_mbracket_property_parts.
   Qed.
   (** this proof is a bit shorter and does not need the hand-crafted auxiliary lemma [changing_the_constant_Const_plus_H] *)
 
-  Definition final_coalg_to_ghss_alt : ghss Mon_V H θ.
+  Definition final_coalg_to_mhss_alt : mhss Mon_V H θ.
   Proof.
     exists t.
     exists η.
     exists τ.
     intros Z f.
     simple refine (iscontrretract _ _ _ (cia_from_final_coalgebra CP I_H
-      _ isTerminalνH _ (final_coalg_to_ghss_equation_morphism f))).
+      _ isTerminalνH _ (final_coalg_to_mhss_equation_morphism f))).
     - intros [h Hyp].
-      exists h. apply final_coalg_to_ghss_equation_morphism_has_equivalent_characteristic_formula. exact Hyp.
+      exists h. apply final_coalg_to_mhss_equation_morphism_has_equivalent_characteristic_formula. exact Hyp.
     - intros [h Hyp].
-      exists h. apply final_coalg_to_ghss_equation_morphism_has_equivalent_characteristic_formula. exact Hyp.
+      exists h. apply final_coalg_to_mhss_equation_morphism_has_equivalent_characteristic_formula. exact Hyp.
     - intros [h Hyp].
       use total2_paths_f.
       + apply idpath.
-      + apply isaprop_gbracket_property_parts.
+      + apply isaprop_mbracket_property_parts.
   Defined.
 
-End FinalCoalgebraToGHSS.
+End FinalCoalgebraToMHSS.
 
-Section InitialAlgebraToGHSS.
+Section InitialAlgebraToMHSS.
 
   Context (IV : Initial V) (CV : Colims_of_shape nat_graph V) (HH : is_omega_cocont H).
 
@@ -516,14 +519,14 @@ Section InitialAlgebraToGHSS.
   Context (initial_annihilates : ∏ (v : V), isInitial V (v ⊗_{Mon_V} (InitialObject IV))).
   Context (left_whiskering_omega_cocont : ∏ (v : V), is_omega_cocont (leftwhiskering_functor Mon_V v)).
 
-  Definition initial_alg_to_ghss : ghss Mon_V H θ.
+  Definition initial_alg_to_mhss : mhss Mon_V H θ.
   Proof.
     exists t.
     exists η.
     exists τ.
     intros Z f.
     red.
-    unfold gbracket_property_parts.
+    unfold mbracket_property_parts.
     set (Mendler_inst := SpecialGenMendlerIterationWithActegoryAndStrength Mon_PtdV IV CV Act
                            Z CP H HH I_{Mon_V} t θ τ (ru^{Mon_V}_{ pr1 Z} · f)
                            (initial_annihilates (pr1 Z)) (left_whiskering_omega_cocont (pr1 Z)) δ).
@@ -541,7 +544,7 @@ Section InitialAlgebraToGHSS.
         apply idpath.
   Defined.
 
-  Let σ : SigmaMonoid θ := ghss_to_sigma_monoid θ initial_alg_to_ghss.
+  Let σ : SigmaMonoid θ := mhss_to_sigma_monoid θ initial_alg_to_mhss.
   Let μ : pr1 σ ⊗_{Mon_V} pr1 σ --> pr1 σ := pr11 (pr212 σ).
 
   Theorem SigmaMonoidFromInitialAlgebra_is_initial : isInitial _ σ.
@@ -665,6 +668,6 @@ Section InitialAlgebraToGHSS.
   Definition SigmaMonoidFromInitialAlgebraInitial : Initial (SigmaMonoid θ)
     := σ,,SigmaMonoidFromInitialAlgebra_is_initial.
 
-End InitialAlgebraToGHSS.
+End InitialAlgebraToMHSS.
 
 End FixTheContext.

--- a/UniMath/SubstitutionSystems/EquivalenceLaxLineatorsHomogeneousCase.v
+++ b/UniMath/SubstitutionSystems/EquivalenceLaxLineatorsHomogeneousCase.v
@@ -36,7 +36,7 @@ Section FixACategory.
  Local Definition ptdendo_CAT : category := coslice_cat_total endoCAT I_{Mon_endo_CAT}.
  Local Definition Mon_ptdendo_CAT : monoidal ptdendo_CAT := monoidal_pointed_objects Mon_endo_CAT.
  Local Definition actegoryPtdEndosOnFunctors_CAT (E : category) : actegory Mon_ptdendo_CAT [C,E]
-   := lifted_actegory Mon_endo_CAT (actegory_from_precomp_CAT C E) Mon_ptdendo_CAT
+   := reindexed_actegory Mon_endo_CAT (actegory_from_precomp_CAT C E) Mon_ptdendo_CAT
         (forget_monoidal_pointed_objects_monoidal Mon_endo_CAT).
 
  (* not possible without some transparent proofs
@@ -63,7 +63,7 @@ Section FixACategory.
 
  (* commented for reasons of time consumption (easily more than 3 minutes compilation time)
 
-Local Lemma lax_lineators_data_from_lifted_precomp_CAT_and_lifted_self_action_agree (H : functor [C, C] [C, C]) :
+Local Lemma lax_lineators_data_from_reindexed_precomp_CAT_and_reindexed_self_action_agree (H : functor [C, C] [C, C]) :
    lineator_data Mon_ptdendo_CAT (actegoryPtdEndosOnFunctors_CAT C) (actegoryPtdEndosOnFunctors_CAT C) H ≃
      lineator_data Mon_ptdendo_CAT (actegory_with_canonical_pointed_action Mon_endo_CAT)
        (actegory_with_canonical_pointed_action Mon_endo_CAT) H.
@@ -88,12 +88,12 @@ Defined. (* 57s on modern Intel machine *)
 
 (* commented for reasons of time consumption (easily more than 30 minutes compilation time) - no longer needed with the modified definition [MultiSortedSigToStrength'] of signature functor
 
- Local Lemma lax_lineators_from_lifted_precomp_CAT_and_lifted_self_action_agree (H : functor [C, C] [C, C]) :
+ Local Lemma lax_lineators_from_reindexed_precomp_CAT_and_reindexed_self_action_agree (H : functor [C, C] [C, C]) :
    lineator_lax Mon_ptdendo_CAT (actegoryPtdEndosOnFunctors_CAT C) (actegoryPtdEndosOnFunctors_CAT C) H ≃
      lineator_lax Mon_ptdendo_CAT (actegory_with_canonical_pointed_action Mon_endo_CAT)
        (actegory_with_canonical_pointed_action Mon_endo_CAT) H.
  Proof.
-   use (weqbandf (lax_lineators_data_from_lifted_precomp_CAT_and_lifted_self_action_agree H)).
+   use (weqbandf (lax_lineators_data_from_reindexed_precomp_CAT_and_reindexed_self_action_agree H)).
    intro ld.
    use weqimplimpl.
    4: { apply isaprop_lineator_laxlaws. }

--- a/UniMath/SubstitutionSystems/EquivalenceSignaturesWithActegoryMorphisms.v
+++ b/UniMath/SubstitutionSystems/EquivalenceSignaturesWithActegoryMorphisms.v
@@ -73,7 +73,7 @@ Section A.
    := monoidal_pointed_objects Mon_endo.
 
  Local Definition actegoryPtdEndosOnFunctors (E : category) : actegory Mon_ptdendo [C,E]
-   := lifted_actegory Mon_endo (actegoryfromprecomp C E) Mon_ptdendo
+   := reindexed_actegory Mon_endo (actegoryfromprecomp C E) Mon_ptdendo
         (forget_monoidal_pointed_objects_monoidal Mon_endo).
 
  (* not possible without some transparent proofs
@@ -98,7 +98,7 @@ Section A.
  Qed. (* slow *)
 
  (*
- Local Lemma lax_lineators_from_lifted_precomp_and_lifted_self_action_agree (F : functor [C, C] [C, C]) :
+ Local Lemma lax_lineators_from_reindexed_precomp_and_reindexed_self_action_agree (F : functor [C, C] [C, C]) :
    lineator_lax Mon_ptdendo (actegoryPtdEndosOnFunctors C) (actegoryPtdEndosOnFunctors C) F ≃
      lineator_lax Mon_ptdendo (actegory_with_canonical_pointed_action Mon_endo)
        (actegory_with_canonical_pointed_action Mon_endo) F.

--- a/UniMath/SubstitutionSystems/GeneralizedSubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/GeneralizedSubstitutionSystems.v
@@ -380,7 +380,7 @@ Section hss.
       apply (bifunctor_equalwhiskers Mon_V).
   Qed.
 
-  Definition gh_squared : PtdV := Ptd_from_mhss ⊗_{Mon_PtdV} Ptd_from_mhss.
+  Definition mh_squared : PtdV := Ptd_from_mhss ⊗_{Mon_PtdV} Ptd_from_mhss.
 
   Definition μ_2 : gh ⊗_{Mon_V} gh --> gh := μ.
 
@@ -397,18 +397,18 @@ Section hss.
     apply (bifunctor_equalwhiskers Mon_V).
   Qed.
 
-  Definition μ_2_Ptd : gh_squared --> Ptd_from_mhss := μ_2,,μ_2_is_Ptd_mor.
+  Definition μ_2_Ptd : mh_squared --> Ptd_from_mhss := μ_2,,μ_2_is_Ptd_mor.
 
-  Definition μ_3 : (gh ⊗_{Mon_V} gh) ⊗_{Mon_V} gh --> gh := ⦃μ_2⦄_{gh_squared}.
+  Definition μ_3 : (gh ⊗_{Mon_V} gh) ⊗_{Mon_V} gh --> gh := ⦃μ_2⦄_{mh_squared}.
 
-  Lemma mhss_third_monoidlaw_aux : θ (pr1 gh_squared,, pr2 gh_squared) gh · # H (μ ⊗^{Mon_V}_{r} gh) =
+  Lemma mhss_third_monoidlaw_aux : θ (pr1 mh_squared,, pr2 mh_squared) gh · # H (μ ⊗^{Mon_V}_{r} gh) =
                                      μ_2 ⊗^{Mon_V}_{r} H gh · θ Ptd_from_mhss gh.
   Proof.
     apply pathsinv0.
     assert (aux := lineator_linnatright Mon_PtdV
                      (actegory_with_canonical_pointed_action Mon_V)
                      (actegory_with_canonical_pointed_action Mon_V)
-                     H θ gh_squared Ptd_from_mhss gh μ_2_Ptd).
+                     H θ mh_squared Ptd_from_mhss gh μ_2_Ptd).
     simpl in aux. (* simpl not cbn for efficiency of Qed *)
     etrans.
     { exact aux. }
@@ -420,7 +420,7 @@ Section hss.
     red. cbn. apply pathsinv0.
     transitivity μ_3.
     - (** this case is the monoidal generalization of the second item on p.168 of Matthes & Uustalu, TCS 2004 *)
-      apply (mfbracket_unique(Z:=gh_squared)).
+      apply (mfbracket_unique(Z:=mh_squared)).
       split.
       + cbn.
         etrans.
@@ -452,7 +452,7 @@ Section hss.
         cbn.
         apply (bifunctor_equalwhiskers Mon_V).
     - (** this case is the monoidal generalization of the first item on p.168 of Matthes & Uustalu, TCS 2004 *)
-      apply pathsinv0, (mfbracket_unique(Z:=gh_squared)).
+      apply pathsinv0, (mfbracket_unique(Z:=mh_squared)).
       split.
       + cbn.
         etrans.

--- a/UniMath/SubstitutionSystems/GeneralizedSubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/GeneralizedSubstitutionSystems.v
@@ -1,6 +1,9 @@
 (** a generalization of heterogeneous substitution systems to monoidal categories in place of endofunctor categories
 
 author: Ralph Matthes 2022
+
+Update in 2023: Instead of speaking about generalized heterogeneous substitution systems (short ghss), it seems better to call them monoidal heterogeneous substitution systems (short mhss). The name of the file stays the same.
+
 *)
 
 Require Import UniMath.Foundations.All.
@@ -42,23 +45,23 @@ Section hss.
 
     Context (t : V) (η : I_{Mon_V} --> t) (τ : H t --> t).
 
-  Definition gbracket_property_parts {z : V} (e : I_{Mon_V} --> z) (f : z --> t) (h : z ⊗_{Mon_V} t --> t) : UU :=
+  Definition mbracket_property_parts {z : V} (e : I_{Mon_V} --> z) (f : z --> t) (h : z ⊗_{Mon_V} t --> t) : UU :=
     (ru^{Mon_V}_{z} · f = z ⊗^{Mon_V}_{l} η · h) ×
       (θ (z,,e) t · #H h · τ =  z ⊗^{Mon_V}_{l} τ · h).
 
-  Definition gbracket_parts_at {z : V} (e : I_{Mon_V} --> z) (f : z --> t) : UU :=
-    ∃! h : z ⊗_{Mon_V} t --> t, gbracket_property_parts e f h.
+  Definition mbracket_parts_at {z : V} (e : I_{Mon_V} --> z) (f : z --> t) : UU :=
+    ∃! h : z ⊗_{Mon_V} t --> t, mbracket_property_parts e f h.
 
-  Definition gbracket : UU :=
-    ∏ (Z : PtdV) (f : pr1 Z --> t), gbracket_parts_at (pr2 Z) f.
+  Definition mbracket : UU :=
+    ∏ (Z : PtdV) (f : pr1 Z --> t), mbracket_parts_at (pr2 Z) f.
 
-  Lemma isaprop_gbracket_property_parts {z : V} (e : I_{Mon_V} --> z) (f : z --> t) (h : z ⊗_{Mon_V} t --> t) :
-    isaprop (gbracket_property_parts e f h).
+  Lemma isaprop_mbracket_property_parts {z : V} (e : I_{Mon_V} --> z) (f : z --> t) (h : z ⊗_{Mon_V} t --> t) :
+    isaprop (mbracket_property_parts e f h).
   Proof.
     apply isapropdirprod; apply V.
   Qed.
 
-  Lemma isaprop_gbracket : isaprop gbracket.
+  Lemma isaprop_mbracket : isaprop mbracket.
   Proof.
     apply impred_isaprop; intro Z.
     apply impred_isaprop; intro f.
@@ -71,20 +74,20 @@ Section hss.
 
   Definition Const_plus_H (v : V) : functor V V := BinCoproduct_of_functors _ _ CP (constant_functor _ _ v) H.
 
-  Definition gbracket_property_single {z : V} (e : I_{Mon_V} --> z) (f : z --> t) (h : z ⊗_{Mon_V} t --> t) : UU :=
+  Definition mbracket_property_single {z : V} (e : I_{Mon_V} --> z) (f : z --> t) (h : z ⊗_{Mon_V} t --> t) : UU :=
     actegory_bincoprod_antidistributor Mon_PtdV CP Act (z,,e) I_{Mon_V} (H t) ·
       (z,,e) ⊗^{Act}_{l} (BinCoproductArrow (CP _ _) η τ) · h =
     BinCoproductOfArrows _ (CP _ _) (CP _ _) (ru_{Mon_V} z) (θ (z,,e) t) ·
       #(Const_plus_H z) h · BinCoproductArrow (CP _ _) f τ.
 
-  Lemma isaprop_gbracket_property_single {z : V} (e : I_{Mon_V} --> z) (f : z --> t) (h : z ⊗_{Mon_V} t --> t) :
-    isaprop (gbracket_property_single e f h).
+  Lemma isaprop_mbracket_property_single {z : V} (e : I_{Mon_V} --> z) (f : z --> t) (h : z ⊗_{Mon_V} t --> t) :
+    isaprop (mbracket_property_single e f h).
   Proof.
     apply V.
   Qed.
 
-  Lemma gbracket_property_single_equivalent {z : V} (e : I_{Mon_V} --> z) (f : z --> t) (h : z ⊗_{Mon_V} t --> t) :
-    gbracket_property_parts e f h <-> gbracket_property_single e f h.
+  Lemma mbracket_property_single_equivalent {z : V} (e : I_{Mon_V} --> z) (f : z --> t) (h : z ⊗_{Mon_V} t --> t) :
+    mbracket_property_parts e f h <-> mbracket_property_single e f h.
   Proof.
     split.
     - intros [Hη Hτ].
@@ -199,12 +202,12 @@ Section hss.
 
   End TheProperty.
 
-  Definition ghss : UU := ∑ (t : V) (η : I_{Mon_V} --> t) (τ : H t --> t), gbracket t η τ.
-  Coercion carrierghss (t : ghss) : V := pr1 t.
+  Definition mhss : UU := ∑ (t : V) (η : I_{Mon_V} --> t) (τ : H t --> t), mbracket t η τ.
+  Coercion carriermhss (t : mhss) : V := pr1 t.
 
-  Section FixAGhss.
+  Section FixAMhss.
 
-  Context (gh : ghss).
+  Context (gh : mhss).
 
   Definition eta_from_alg : I_{Mon_V} --> gh := pr12 gh.
   Definition tau_from_alg : H gh --> gh := pr122 gh.
@@ -212,15 +215,15 @@ Section hss.
   Local Notation η := eta_from_alg.
   Local Notation τ := tau_from_alg.
 
-  Definition Ptd_from_ghss : PtdV := (pr1 gh,,η).
+  Definition Ptd_from_mhss : PtdV := (pr1 gh,,η).
 
-  Definition gfbracket (Z : PtdV) (f : pr1 Z --> gh) : pr1 Z ⊗_{Mon_V} gh --> gh :=
+  Definition mfbracket (Z : PtdV) (f : pr1 Z --> gh) : pr1 Z ⊗_{Mon_V} gh --> gh :=
     pr1 (pr1 (pr222 gh Z f)).
 
-  Notation "⦃ f ⦄_{ Z }" := (gfbracket Z f)(at level 0).
+  Notation "⦃ f ⦄_{ Z }" := (mfbracket Z f)(at level 0).
 
-  Lemma gfbracket_unique {Z : PtdV} (f : pr1 Z --> gh)
-    : ∏ α : pr1 Z ⊗_{Mon_V} gh --> gh, gbracket_property_parts gh η τ (pr2 Z) f α
+  Lemma mfbracket_unique {Z : PtdV} (f : pr1 Z --> gh)
+    : ∏ α : pr1 Z ⊗_{Mon_V} gh --> gh, mbracket_property_parts gh η τ (pr2 Z) f α
    → α = ⦃f⦄_{Z}.
   Proof.
     intros α Hyp.
@@ -228,23 +231,23 @@ Section hss.
     assumption.
   Qed.
 
-  Lemma gfbracket_η {Z : PtdV} (f : pr1 Z --> gh) :
+  Lemma mfbracket_η {Z : PtdV} (f : pr1 Z --> gh) :
     ru^{Mon_V}_{pr1 Z} · f = pr1 Z ⊗^{Mon_V}_{l} η · ⦃f⦄_{Z}.
   Proof.
     exact (pr1 ((pr2 (pr1 (pr222 gh Z f))))).
   Qed.
 
-  Lemma gfbracket_τ {Z : PtdV} (f : pr1 Z --> gh) :
+  Lemma mfbracket_τ {Z : PtdV} (f : pr1 Z --> gh) :
     θ Z gh · #H ⦃f⦄_{Z} · τ =  pr1 Z ⊗^{Mon_V}_{l} τ · ⦃f⦄_{Z}.
   Proof.
     exact (pr2 ((pr2 (pr1 (pr222 gh Z f))))).
   Qed.
 
   (** there is a restricted form of naturality in the [f] argument, only for pointed [f] *)
-  Lemma gfbracket_natural {Z Z' : PtdV} (f : Z --> Z') (g : pr1 Z' --> gh) :
+  Lemma mfbracket_natural {Z Z' : PtdV} (f : Z --> Z') (g : pr1 Z' --> gh) :
     pr1 f ⊗^{ Mon_V}_{r} gh · ⦃g⦄_{Z'} = ⦃pr1 f · g⦄_{Z}.
   Proof.
-    apply gfbracket_unique.
+    apply mfbracket_unique.
     split.
     - etrans.
       2: { rewrite assoc.
@@ -254,7 +257,7 @@ Section hss.
       etrans.
       2: { rewrite assoc'.
            apply maponpaths.
-           apply gfbracket_η. }
+           apply mfbracket_η. }
       repeat rewrite assoc.
       apply cancel_postcomposition.
       apply pathsinv0, monoidal_rightunitornat.
@@ -266,33 +269,33 @@ Section hss.
       etrans.
       2: { rewrite assoc'.
            apply maponpaths.
-           apply gfbracket_τ. }
+           apply mfbracket_τ. }
       rewrite functor_comp.
       repeat rewrite assoc.
       do 2 apply cancel_postcomposition.
       apply pathsinv0, (lineator_linnatright Mon_PtdV Act Act).
   Qed.
 
-  (** As a consequence of naturality, we can compute [gfbracket f] from [gfbracket identity] for
+  (** As a consequence of naturality, we can compute [mfbracket f] from [mfbracket identity] for
       pointed morphisms [f] *)
-  Lemma compute_gfbracket {Z : PtdV} (f : Z --> Ptd_from_ghss) :
-    ⦃pr1 f⦄_{Z} = pr1 f ⊗^{ Mon_V}_{r} gh · ⦃identity gh⦄_{Ptd_from_ghss}.
+  Lemma compute_mfbracket {Z : PtdV} (f : Z --> Ptd_from_mhss) :
+    ⦃pr1 f⦄_{Z} = pr1 f ⊗^{ Mon_V}_{r} gh · ⦃identity gh⦄_{Ptd_from_mhss}.
   Proof.
     etrans.
     { rewrite <- (id_right (pr1 f)).
-      apply pathsinv0, gfbracket_natural. }
+      apply pathsinv0, mfbracket_natural. }
     apply idpath.
   Qed.
 
   (** we are constructing a monoid in the monoidal base category *)
 
-  Definition mu_from_ghss : gh ⊗_{Mon_V} gh --> gh := ⦃identity gh⦄_{Ptd_from_ghss}.
+  Definition mu_from_mhss : gh ⊗_{Mon_V} gh --> gh := ⦃identity gh⦄_{Ptd_from_mhss}.
 
-  Local Notation μ := mu_from_ghss.
+  Local Notation μ := mu_from_mhss.
 
   Definition μ_0 : I_{Mon_V} --> gh := η.
 
-  Definition μ_0_Ptd : I_{Mon_PtdV} --> Ptd_from_ghss.
+  Definition μ_0_Ptd : I_{Mon_PtdV} --> Ptd_from_mhss.
   Proof.
     exists μ_0.
     cbn. apply id_left.
@@ -302,7 +305,7 @@ Section hss.
 
   Lemma μ_1_is_instance_of_left_unitor : μ_1 = lu^{Mon_V}_{gh}.
   Proof.
-    apply pathsinv0, (gfbracket_unique(Z:=I_{Mon_PtdV})).
+    apply pathsinv0, (mfbracket_unique(Z:=I_{Mon_PtdV})).
     split.
     - cbn. unfold μ_0.
       rewrite monoidal_leftunitornat.
@@ -316,18 +319,18 @@ Section hss.
       apply pathsinv0, monoidal_leftunitornat.
   Qed.
 
-  Definition ghss_monoid_data : monoid_data Mon_V gh := μ,,μ_0.
+  Definition mhss_monoid_data : monoid_data Mon_V gh := μ,,μ_0.
 
-  Lemma ghss_first_monoidlaw : monoid_laws_unit_right Mon_V ghss_monoid_data.
+  Lemma mhss_first_monoidlaw : monoid_laws_unit_right Mon_V mhss_monoid_data.
   Proof.
     red. cbn.
     etrans.
-    { apply pathsinv0, (gfbracket_η(Z:=Ptd_from_ghss)). }
+    { apply pathsinv0, (mfbracket_η(Z:=Ptd_from_mhss)). }
     apply id_right.
   Qed.
 
 
-  Lemma ghss_second_monoidlaw_aux :
+  Lemma mhss_second_monoidlaw_aux :
     ru^{Mon_V}_{I_{Mon_V}} · η = I_{Mon_V} ⊗^{Mon_V}_{l} η · (η ⊗^{Mon_V}_{r} gh · μ).
   Proof.
     rewrite assoc.
@@ -338,20 +341,20 @@ Section hss.
     rewrite assoc'.
     etrans.
     2: { apply maponpaths.
-         apply pathsinv0, ghss_first_monoidlaw. }
+         apply pathsinv0, mhss_first_monoidlaw. }
     apply pathsinv0, monoidal_rightunitornat.
   Qed.
 
-  Lemma ghss_second_monoidlaw : monoid_laws_unit_left Mon_V ghss_monoid_data.
+  Lemma mhss_second_monoidlaw : monoid_laws_unit_left Mon_V mhss_monoid_data.
   Proof.
     red. cbn.
     etrans.
     2: { apply μ_1_is_instance_of_left_unitor. }
-    apply (gfbracket_unique(Z:=I_{Mon_PtdV})).
+    apply (mfbracket_unique(Z:=I_{Mon_PtdV})).
     split.
-    - exact ghss_second_monoidlaw_aux.
+    - exact mhss_second_monoidlaw_aux.
     - rewrite functor_comp.
-      transitivity (μ_0 ⊗^{ Mon_V}_{r} H (pr1 gh) · θ Ptd_from_ghss (pr1 gh) · # H μ · τ). (* give this term due to efficiency problems *)
+      transitivity (μ_0 ⊗^{ Mon_V}_{r} H (pr1 gh) · θ Ptd_from_mhss (pr1 gh) · # H μ · τ). (* give this term due to efficiency problems *)
       { apply cancel_postcomposition.
         rewrite assoc.
         apply cancel_postcomposition.
@@ -359,7 +362,7 @@ Section hss.
         set (aux := lineator_linnatright Mon_PtdV
                       (actegory_with_canonical_pointed_action Mon_V)
                       (actegory_with_canonical_pointed_action Mon_V)
-                      H θ I_{ Mon_PtdV} Ptd_from_ghss (pr1 gh) μ_0_Ptd).
+                      H θ I_{ Mon_PtdV} Ptd_from_mhss (pr1 gh) μ_0_Ptd).
         cbn in aux.
         etrans.
         { exact aux. }
@@ -369,7 +372,7 @@ Section hss.
       { do 2 rewrite assoc'.
         apply maponpaths.
         rewrite assoc.
-        apply (gfbracket_τ(Z:=Ptd_from_ghss)).
+        apply (mfbracket_τ(Z:=Ptd_from_mhss)).
       }
       repeat rewrite assoc.
       apply cancel_postcomposition.
@@ -377,7 +380,7 @@ Section hss.
       apply (bifunctor_equalwhiskers Mon_V).
   Qed.
 
-  Definition gh_squared : PtdV := Ptd_from_ghss ⊗_{Mon_PtdV} Ptd_from_ghss.
+  Definition gh_squared : PtdV := Ptd_from_mhss ⊗_{Mon_PtdV} Ptd_from_mhss.
 
   Definition μ_2 : gh ⊗_{Mon_V} gh --> gh := μ.
 
@@ -388,36 +391,36 @@ Section hss.
     cbn.
     rewrite unitors_coincide_on_unit.
     etrans.
-    2: { apply pathsinv0, ghss_second_monoidlaw_aux. }
+    2: { apply pathsinv0, mhss_second_monoidlaw_aux. }
     rewrite assoc.
     apply cancel_postcomposition.
     apply (bifunctor_equalwhiskers Mon_V).
   Qed.
 
-  Definition μ_2_Ptd : gh_squared --> Ptd_from_ghss := μ_2,,μ_2_is_Ptd_mor.
+  Definition μ_2_Ptd : gh_squared --> Ptd_from_mhss := μ_2,,μ_2_is_Ptd_mor.
 
   Definition μ_3 : (gh ⊗_{Mon_V} gh) ⊗_{Mon_V} gh --> gh := ⦃μ_2⦄_{gh_squared}.
 
-  Lemma ghss_third_monoidlaw_aux : θ (pr1 gh_squared,, pr2 gh_squared) gh · # H (μ ⊗^{Mon_V}_{r} gh) =
-                                     μ_2 ⊗^{Mon_V}_{r} H gh · θ Ptd_from_ghss gh.
+  Lemma mhss_third_monoidlaw_aux : θ (pr1 gh_squared,, pr2 gh_squared) gh · # H (μ ⊗^{Mon_V}_{r} gh) =
+                                     μ_2 ⊗^{Mon_V}_{r} H gh · θ Ptd_from_mhss gh.
   Proof.
     apply pathsinv0.
     assert (aux := lineator_linnatright Mon_PtdV
                      (actegory_with_canonical_pointed_action Mon_V)
                      (actegory_with_canonical_pointed_action Mon_V)
-                     H θ gh_squared Ptd_from_ghss gh μ_2_Ptd).
+                     H θ gh_squared Ptd_from_mhss gh μ_2_Ptd).
     simpl in aux. (* simpl not cbn for efficiency of Qed *)
     etrans.
     { exact aux. }
     apply idpath.
   Qed.
 
-  Lemma ghss_third_monoidlaw : monoid_laws_assoc Mon_V ghss_monoid_data.
+  Lemma mhss_third_monoidlaw : monoid_laws_assoc Mon_V mhss_monoid_data.
   Proof.
     red. cbn. apply pathsinv0.
     transitivity μ_3.
     - (** this case is the monoidal generalization of the second item on p.168 of Matthes & Uustalu, TCS 2004 *)
-      apply (gfbracket_unique(Z:=gh_squared)).
+      apply (mfbracket_unique(Z:=gh_squared)).
       split.
       + cbn.
         etrans.
@@ -428,7 +431,7 @@ Section hss.
         etrans.
         2: { rewrite assoc'.
              apply maponpaths.
-             apply pathsinv0, ghss_first_monoidlaw.
+             apply pathsinv0, mhss_first_monoidlaw.
         }
         apply pathsinv0, monoidal_rightunitornat.
       + etrans.
@@ -436,20 +439,20 @@ Section hss.
           rewrite functor_comp.
           rewrite assoc.
           apply cancel_postcomposition.
-          exact ghss_third_monoidlaw_aux.
+          exact mhss_third_monoidlaw_aux.
         }
         etrans.
         { do 2 rewrite assoc'.
           apply maponpaths.
           rewrite assoc.
-          apply (gfbracket_τ(Z:=Ptd_from_ghss)).
+          apply (mfbracket_τ(Z:=Ptd_from_mhss)).
         }
         do 2 rewrite assoc.
         apply cancel_postcomposition.
         cbn.
         apply (bifunctor_equalwhiskers Mon_V).
     - (** this case is the monoidal generalization of the first item on p.168 of Matthes & Uustalu, TCS 2004 *)
-      apply pathsinv0, (gfbracket_unique(Z:=gh_squared)).
+      apply pathsinv0, (mfbracket_unique(Z:=gh_squared)).
       split.
       + cbn.
         etrans.
@@ -463,7 +466,7 @@ Section hss.
         etrans.
         2: { apply cancel_postcomposition.
              do 2 apply maponpaths.
-             apply pathsinv0, ghss_first_monoidlaw. }
+             apply pathsinv0, mhss_first_monoidlaw. }
         apply cancel_postcomposition.
         apply pathsinv0, left_whisker_with_runitor.
       + etrans.
@@ -484,12 +487,12 @@ Section hss.
             rewrite functor_comp.
             rewrite assoc.
             apply cancel_postcomposition.
-            apply pathsinv0, (lineator_linnatleft Mon_PtdV _ _ H θ Ptd_from_ghss _ _ μ).
+            apply pathsinv0, (lineator_linnatleft Mon_PtdV _ _ H θ Ptd_from_mhss _ _ μ).
           }
           repeat rewrite assoc'.
           apply maponpaths.
           rewrite assoc.
-          apply (gfbracket_τ(Z:=Ptd_from_ghss)).
+          apply (mfbracket_τ(Z:=Ptd_from_mhss)).
         }
         cbn.
         repeat rewrite assoc.
@@ -500,7 +503,7 @@ Section hss.
           do 2 rewrite <- (bifunctor_leftcomp Mon_V).
           apply maponpaths.
           rewrite assoc.
-          apply (gfbracket_τ(Z:=Ptd_from_ghss)).
+          apply (mfbracket_τ(Z:=Ptd_from_mhss)).
         }
         cbn.
         rewrite (bifunctor_leftcomp Mon_V).
@@ -509,12 +512,12 @@ Section hss.
         apply monoidal_associatornatleft.
   Qed.
 
-  Definition ghss_monoid : monoid Mon_V gh.
+  Definition mhss_monoid : monoid Mon_V gh.
   Proof.
-    exists ghss_monoid_data.
-    exact (ghss_second_monoidlaw,,ghss_first_monoidlaw,,ghss_third_monoidlaw).
+    exists mhss_monoid_data.
+    exact (mhss_second_monoidlaw,,mhss_first_monoidlaw,,mhss_third_monoidlaw).
   Defined.
 
-  End FixAGhss.
+  End FixAMhss.
 
 End hss.

--- a/UniMath/SubstitutionSystems/MultiSortedMonadConstruction_actegorical.v
+++ b/UniMath/SubstitutionSystems/MultiSortedMonadConstruction_actegorical.v
@@ -202,7 +202,7 @@ Section CharEq.
   Lemma SigmaMonoidOfMultiSortedSig_CAT_char_eq_ok :
     SigmaMonoid_characteristic_equation (SigmaMonoid_carrier _ σ) (SigmaMonoid_η _ σ) (SigmaMonoid_μ _ σ) (SigmaMonoid_τ _ σ) st'.
   Proof.
-   Admitted. (* the proof depends on [lax_lineators_from_lifted_precomp_CAT_and_lifted_self_action_agree] to be defined! *)
+   Admitted. (* the proof depends on [lax_lineators_from_reindexed_precomp_CAT_and_reindexed_self_action_agree] to be defined! *)
  (*
     (** beginning of proof that depends on that currently deactivated definition *)
     assert (Hyp := SigmaMonoid_is_compatible (MultiSortedSigToStrengthFromSelfCAT sig) σ).

--- a/UniMath/SubstitutionSystems/MultiSortedMonadConstruction_actegorical.v
+++ b/UniMath/SubstitutionSystems/MultiSortedMonadConstruction_actegorical.v
@@ -1,7 +1,7 @@
-(** this file is a follow-up of [MultisortedMonadConstruction_alt], where the semantic signatures [Signature] are replaced by functors with tensorial strength and HSS by GHSS
+(** this file is a follow-up of [MultisortedMonadConstruction_alt], where the semantic signatures [Signature] are replaced by functors with tensorial strength and HSS by MHSS
 
 based on the lax lineator constructed in [Multisorted_actegories] and transferred (through weak equivalence) to the strength notion of
-generalized heterogeneous substitution systems (GHSS), a GHSS is constructed and a monad obtained through it
+monoidal heterogeneous substitution systems (MHSS), a MHSS is constructed and a monad obtained through it
 
 author: Ralph Matthes, 2023
 
@@ -152,11 +152,11 @@ Section monad.
     - apply HCsortToC1.
   Defined.
 
-  (** the associated GHSS *)
-  Definition GHSSOfMultiSortedSig_CAT (sig : MultiSortedSig sort) :
-    ghss (monendocat_monoidal sortToC) (MultiSortedSigToFunctor' sig) (MultiSortedSigToStrength' sig).
+  (** the associated MHSS *)
+  Definition MHSSOfMultiSortedSig_CAT (sig : MultiSortedSig sort) :
+    mhss (monendocat_monoidal sortToC) (MultiSortedSigToFunctor' sig) (MultiSortedSigToStrength' sig).
   Proof.
-    use (initial_alg_to_ghss (MultiSortedSigToStrength' sig) BCsortToC1).
+    use (initial_alg_to_mhss (MultiSortedSigToStrength' sig) BCsortToC1).
     - apply BindingSigToMonad_actegorical.bincoprod_distributor_pointed_CAT.
     - exact ICsortToC1.
     - apply HCsortToC1.
@@ -180,8 +180,8 @@ Section monad.
   (** the associated Sigma-monoid - defined separately *)
   Definition SigmaMonoidOfMultiSortedSig_CAT (sig : MultiSortedSig sort) : SigmaMonoid (MultiSortedSigToStrength' sig).
   Proof.
-    apply ghss_to_sigma_monoid.
-    exact (GHSSOfMultiSortedSig_CAT sig).
+    apply mhss_to_sigma_monoid.
+    exact (MHSSOfMultiSortedSig_CAT sig).
   Defined.
 
 (* currently obsolete because this was only for the original definition with [MultiSortedSigToFunctor]

--- a/UniMath/SubstitutionSystems/MultiSortedMonadConstruction_coind_actegorical.v
+++ b/UniMath/SubstitutionSystems/MultiSortedMonadConstruction_coind_actegorical.v
@@ -460,10 +460,10 @@ Section monad.
     - apply HcoCsortToC1.
   Defined.
 
-  Definition coindGHSSOfMultiSortedSig_CAT (sig : MultiSortedSig sort) (Cuniv : is_univalent C) :
-    ghss (monendocat_monoidal sortToC) (MultiSortedSigToFunctor' sig) (MultiSortedSigToStrength' sig).
+  Definition coindMHSSOfMultiSortedSig_CAT (sig : MultiSortedSig sort) (Cuniv : is_univalent C) :
+    mhss (monendocat_monoidal sortToC) (MultiSortedSigToFunctor' sig) (MultiSortedSigToStrength' sig).
   Proof.
-    use (final_coalg_to_ghss (MultiSortedSigToStrength' sig) BCsortToC1).
+    use (final_coalg_to_mhss (MultiSortedSigToStrength' sig) BCsortToC1).
     - apply BindingSigToMonad_actegorical.bincoprod_distributor_pointed_CAT.
     - exact (pr1 (coindCodatatypeOfMultisortedBindingSig_CAT sig Cuniv)).
     - exact (pr2 (coindCodatatypeOfMultisortedBindingSig_CAT sig Cuniv)).
@@ -472,8 +472,8 @@ Section monad.
   (** the associated Sigma-monoid *)
   Definition coindSigmaMonoidOfMultiSortedSig_CAT (sig : MultiSortedSig sort) (Cuniv : is_univalent C) : SigmaMonoid (MultiSortedSigToStrength' sig).
   Proof.
-    apply ghss_to_sigma_monoid.
-    exact (coindGHSSOfMultiSortedSig_CAT sig Cuniv).
+    apply mhss_to_sigma_monoid.
+    exact (coindMHSSOfMultiSortedSig_CAT sig Cuniv).
   Defined.
 
   (** the associated monad *)

--- a/UniMath/SubstitutionSystems/MultiSorted_actegorical.v
+++ b/UniMath/SubstitutionSystems/MultiSorted_actegorical.v
@@ -158,8 +158,8 @@ Section strength_through_actegories.
   Local Definition pointedstrengthfromselfaction_CAT :=
     lineator_lax Mon_ptdendo_CAT ActPtd_CAT_FromSelf ActPtd_CAT_FromSelf.
 
-  Let ptdlifteddistributivity_CAT (G : sortToC1) : UU :=
-        BindingSigToMonad_actegorical.ptdlifteddistributivity_CAT G.
+  Let pointedlaxcommutator_CAT (G : sortToC1) : UU :=
+        BindingSigToMonad_actegorical.pointedlaxcommutator_CAT G.
 
   Local Definition δCCCATEndo (M : MultiSortedSig sort) :
     actegory_coprod_distributor Mon_ptdendo_CAT (CoproductsMultiSortedSig M) ActPtd_CAT_Endo.
@@ -175,24 +175,24 @@ Section strength_through_actegories.
     use SelfActCAT_CAT_coprod_distributor.
   Defined.
 
-  Definition lifteddistrCAT_option_functor (s : sort) :
-    ptdlifteddistributivity_CAT (sorted_option_functor s).
+  Definition ptdlaxcommutatorCAT_option_functor (s : sort) :
+    pointedlaxcommutator_CAT (sorted_option_functor s).
   Proof.
-    use BindingSigToMonad_actegorical.lifteddistr_genopt.
+    use BindingSigToMonad_actegorical.ptdlaxcommutator_genopt.
   Defined.
 
-  Definition lifteddistrCAT_option_list (xs : list sort) :
-    ptdlifteddistributivity_CAT (option_list xs).
+  Definition ptdlaxcommutatorCAT_option_list (xs : list sort) :
+    pointedlaxcommutator_CAT (option_list xs).
   Proof.
     induction xs as [[|n] xs].
     + induction xs.
-      apply unit_lifteddistributivity.
+      apply unit_relativelaxcommutator.
     + induction n as [|n IH].
       * induction xs as [m []].
-        apply lifteddistrCAT_option_functor.
+        apply ptdlaxcommutatorCAT_option_functor.
       * induction xs as [m [k xs]].
-        use composedlifteddistributivity.
-        -- exact (lifteddistrCAT_option_functor m).
+        use composedrelativelaxcommutator.
+        -- exact (ptdlaxcommutatorCAT_option_functor m).
         -- exact (IH (k,,xs)).
   Defined.
 
@@ -210,8 +210,8 @@ Section strength_through_actegories.
       3: { use reindexed_lax_lineator.
            2: { exact (lax_lineator_postcomp_actegories_from_precomp_CAT _ _ _ (projSortToC t)). }
       }
-      use reindexedstrength_from_δ.
-      exact (lifteddistrCAT_option_list (cons x xs)).
+      use reindexedstrength_from_commutator.
+      exact (ptdlaxcommutatorCAT_option_list (cons x xs)).
   Defined.
 
   Definition StrengthCAT_exp_functor_list (xs : list (list sort × sort)) :
@@ -292,9 +292,9 @@ Section strength_through_actegories.
   Proof.
     unfold hat_exp_functor_list'_piece, ContinuityOfMultiSortedSigToFunctor.hat_exp_functor_list'_piece.
     use comp_lineator_lax.
-    2: { refine (reindexedstrength_from_δ Mon_endo_CAT Mon_ptdendo_CAT (forget_monoidal_pointed_objects_monoidal Mon_endo_CAT)
+    2: { refine (reindexedstrength_from_commutator Mon_endo_CAT Mon_ptdendo_CAT (forget_monoidal_pointed_objects_monoidal Mon_endo_CAT)
                    _ (SelfActCAT sortToC)).
-         exact (lifteddistrCAT_option_list (pr1 (pr1 xt))).
+         exact (ptdlaxcommutatorCAT_option_list (pr1 (pr1 xt))).
     }
     use reindexed_lax_lineator.
     apply (lax_lineator_postcomp_SelfActCAT).

--- a/UniMath/SubstitutionSystems/MultiSorted_actegorical.v
+++ b/UniMath/SubstitutionSystems/MultiSorted_actegorical.v
@@ -164,14 +164,14 @@ Section strength_through_actegories.
   Local Definition δCCCATEndo (M : MultiSortedSig sort) :
     actegory_coprod_distributor Mon_ptdendo_CAT (CoproductsMultiSortedSig M) ActPtd_CAT_Endo.
   Proof.
-    use lifted_coprod_distributor.
+    use reindexed_coprod_distributor.
     use actegory_from_precomp_CAT_coprod_distributor.
   Defined.
 
   Local Definition δCCCATfromSelf (M : MultiSortedSig sort) :
     actegory_coprod_distributor Mon_ptdendo_CAT (CoproductsMultiSortedSig M) ActPtd_CAT_FromSelf.
   Proof.
-    use lifted_coprod_distributor.
+    use reindexed_coprod_distributor.
     use SelfActCAT_CAT_coprod_distributor.
   Defined.
 
@@ -203,14 +203,14 @@ Section strength_through_actegories.
     use list_ind.
     - cbn. (* in [MultiSorted_alt], the analogous construction [Sig_exp_functor] has a composition
               with the strength of the identity functor since [Gθ_Signature] needs a composition *)
-      use lifted_lax_lineator.
+      use reindexed_lax_lineator.
       exact (lax_lineator_postcomp_actegories_from_precomp_CAT _ _ _ (projSortToC t)).
     - intros x xs H; simpl.
       use comp_lineator_lax.
-      3: { use lifted_lax_lineator.
+      3: { use reindexed_lax_lineator.
            2: { exact (lax_lineator_postcomp_actegories_from_precomp_CAT _ _ _ (projSortToC t)). }
       }
-      use liftedstrength_from_δ.
+      use reindexedstrength_from_δ.
       exact (lifteddistrCAT_option_list (cons x xs)).
   Defined.
 
@@ -219,7 +219,7 @@ Section strength_through_actegories.
   Proof.
     induction xs as [[|n] xs].
     - induction xs.
-      use lifted_lax_lineator.
+      use reindexed_lax_lineator.
       apply constconst_functor_lax_lineator.
     - induction n as [|n IH].
       + induction xs as [m []].
@@ -237,7 +237,7 @@ Section strength_through_actegories.
     use comp_lineator_lax.
     - exact (ActPtd_CAT C).
     - apply StrengthCAT_exp_functor_list.
-    - use lifted_lax_lineator.
+    - use reindexed_lax_lineator.
       apply lax_lineator_postcomp_actegories_from_precomp_CAT.
   Defined.
 
@@ -255,7 +255,7 @@ Section strength_through_actegories.
   Definition MultiSortedSigToStrengthFromSelfCAT (M : MultiSortedSig sort) :
     pointedstrengthfromselfaction_CAT (MultiSortedSigToFunctor M).
   Proof.
-    apply EquivalenceLaxLineatorsHomogeneousCase.lax_lineators_from_lifted_precomp_CAT_and_lifted_self_action_agree.
+    apply EquivalenceLaxLineatorsHomogeneousCase.lax_lineators_from_reindexed_precomp_CAT_and_reindexed_self_action_agree.
     apply MultiSortedSigToStrengthCAT.
   Defined.
    *)
@@ -267,7 +267,7 @@ Section strength_through_actegories.
   Proof.
     apply weqSignatureLaxMorphismActegoriesHomogeneous_alt.
     exists (MultiSortedSigToFunctor M).
-    apply lax_lineators_from_lifted_precomp_and_lifted_self_action_agree.
+    apply lax_lineators_from_reindexed_precomp_and_reindexed_self_action_agree.
     apply MultiSortedSigToStrength.
   Defined.
 
@@ -292,11 +292,11 @@ Section strength_through_actegories.
   Proof.
     unfold hat_exp_functor_list'_piece, ContinuityOfMultiSortedSigToFunctor.hat_exp_functor_list'_piece.
     use comp_lineator_lax.
-    2: { refine (liftedstrength_from_δ Mon_endo_CAT Mon_ptdendo_CAT (forget_monoidal_pointed_objects_monoidal Mon_endo_CAT)
+    2: { refine (reindexedstrength_from_δ Mon_endo_CAT Mon_ptdendo_CAT (forget_monoidal_pointed_objects_monoidal Mon_endo_CAT)
                    _ (SelfActCAT sortToC)).
          exact (lifteddistrCAT_option_list (pr1 (pr1 xt))).
     }
-    use lifted_lax_lineator.
+    use reindexed_lax_lineator.
     apply (lax_lineator_postcomp_SelfActCAT).
     Defined.
 
@@ -306,7 +306,7 @@ Section strength_through_actegories.
     induction xst as [xs t].
     induction xs as [[|n] xs].
     - induction xs.
-      use lifted_lax_lineator.
+      use reindexed_lax_lineator.
       use comp_lineator_lax. (* the next two lines go through [actegory_from_precomp_CAT] *)
       2: { apply constconst_functor_lax_lineator. }
       apply lax_lineator_postcomp_SelfActCAT_alt.

--- a/UniMath/SubstitutionSystems/MultiSorted_actegorical.v
+++ b/UniMath/SubstitutionSystems/MultiSorted_actegorical.v
@@ -4,9 +4,9 @@
     the strength notion is based on lax lineators where endofunctors act on possibly non-endofunctors, but the
     signature functor generated from a multi-sorted binding signature falls into the special case of endofunctors,
     and the lineator notion can be transferred (through weak equivalence) to the strength notion of
-    generalized heterogeneous substitution systems (GHSS)
+    monoidal heterogeneous substitution systems (MHSS)
 
-    accordingly a GHSS is constructed and a monad obtained through it, cf. [MultiSortedMonadConstruction_actegorical]
+    accordingly a MHSS is constructed and a monad obtained through it, cf. [MultiSortedMonadConstruction_actegorical]
 
 author: Ralph Matthes, 2023
 

--- a/UniMath/SubstitutionSystems/SigmaMonoids.v
+++ b/UniMath/SubstitutionSystems/SigmaMonoids.v
@@ -103,19 +103,19 @@ Section SigmaMonoid.
 
 End SigmaMonoid.
 
-Section GHSS_to_SigmaMonoid.
+Section MHSS_to_SigmaMonoid.
 
   Context {V : category}
           {Mon_V : monoidal V}
           {H : V ⟶ V}
           (θ : pointedtensorialstrength Mon_V H).
 
-  Definition ghss_to_sigma_monoid (t : ghss Mon_V H θ)
+  Definition mhss_to_sigma_monoid (t : mhss Mon_V H θ)
     : SigmaMonoid θ.
   Proof.
     exists (pr1 t).
-    exists (tau_from_alg Mon_V H θ t ,, ghss_monoid Mon_V H θ t).
-    exact (gfbracket_τ Mon_V H θ t (Z :=  (pr1 t,, μ_0 Mon_V H θ t)) (identity _)).
+    exists (tau_from_alg Mon_V H θ t ,, mhss_monoid Mon_V H θ t).
+    exact (mfbracket_τ Mon_V H θ t (Z :=  (pr1 t,, μ_0 Mon_V H θ t)) (identity _)).
   Defined.
 
-End GHSS_to_SigmaMonoid.
+End MHSS_to_SigmaMonoid.

--- a/UniMath/SubstitutionSystems/SignatureExamples.v
+++ b/UniMath/SubstitutionSystems/SignatureExamples.v
@@ -48,7 +48,12 @@ Local Notation "'Ptd'" := (category_Ptd C).
 Local Notation "'EndC'":= ([C, C]) .
 
 (** distributivity with laws as a simple form the strength with laws,
-    for endofunctors on the base category *)
+    for endofunctors on the base category
+
+    in July 2023, it became clear that this should rather have been
+    called a pointed lax commutator; since a paper is based on this
+    notion, we keep the name
+*)
 Section def_of_δ.
 
 Variable G : EndC.


### PR DESCRIPTION
propagates name changes in our view of the mathematical concepts:
- generalized heterogeneous substitution system -> monoidal heterogeneous substitution system
- lifting of actegories -> reindexing of actegories
- lifted distributivity -> relative lax commutator
No changes to file names, though.