### PR TITLE
Qualifying names from CategoryTheory.limits

### DIFF
--- a/UniMath/CategoryTheory/limits/graphs/cokernels.v
+++ b/UniMath/CategoryTheory/limits/graphs/cokernels.v
@@ -69,15 +69,14 @@ Section def_cokernels.
 
   (* Other direction *)
 
-
-  Lemma equiv_Cokernel2_eq {a b : C} (f : C⟦a, b⟧) (CK : cokernels.Cokernel (equiv_Zero2 Z) f) :
+  Lemma equiv_Cokernel2_eq {a b : C} (f : C⟦a, b⟧) (CK : limits.cokernels.Cokernel (equiv_Zero2 Z) f) :
     f · CokernelArrow CK = ZeroArrow Z a b · CokernelArrow CK.
   Proof.
     rewrite CokernelCompZero. rewrite postcomp_with_ZeroArrow. apply equiv_ZeroArrow.
   Qed.
 
   Lemma equiv_Cokernel2_isCoequalizer {a b : C} (f : C⟦a, b⟧)
-        (CK : cokernels.Cokernel (equiv_Zero2 Z) f) :
+        (CK : limits.cokernels.Cokernel (equiv_Zero2 Z) f) :
     isCoequalizer C f (ZeroArrow Z a b) CK (CokernelArrow CK) (equiv_Cokernel2_eq f CK).
   Proof.
     use (make_isCoequalizer _ ).

--- a/UniMath/CategoryTheory/limits/graphs/pullbacks.v
+++ b/UniMath/CategoryTheory/limits/graphs/pullbacks.v
@@ -248,7 +248,7 @@ Proof.
   set (XR := limits.pullbacks.make_Pullback _ X).
   use tpair.
   - use tpair.
-    + use (pullbacks.PullbackArrow XR).
+    + use (limits.pullbacks.PullbackArrow XR).
       * apply (coneOut cc One).
       * apply (coneOut cc Three).
       * abstract (
@@ -258,7 +258,7 @@ Proof.
         eapply pathscomp0; [| apply (XRT)]; apply idpath
          ).
     + use three_rec_dep.
-      * abstract (apply (pullbacks.PullbackArrow_PullbackPr1 XR)).
+      * abstract (apply (limits.pullbacks.PullbackArrow_PullbackPr1 XR)).
       * abstract (simpl;
         change (three_rec_dep (λ n, C⟦d,_⟧) _ _ _ _) with (p1 · f);
         rewrite assoc;


### PR DESCRIPTION
This PR is in anticipation of name collisions that would appear with the introduction of discharge on the fly in Coq (coq/coq#17888).

In the present case, the collisions would come from the introduction of new  discharged names of the form `pullbacks.PullbackArrow` in `graphs` which would collide with the same names in `limits`.

Apparently, the convention was anyway that names from `limits` had an explicit `limits` prefix up to the four exceptions of this PR. So, I believe that this PR can be merged anyway, as soon as now, independently of coq/coq#17888.