### PR TITLE
DCPOs: Use ⊑ instead of ≤

### DIFF
--- a/UniMath/OrderTheory/DCPOs/Basis/Algebraic.v
+++ b/UniMath/OrderTheory/DCPOs/Basis/Algebraic.v
@@ -48,7 +48,7 @@ Proposition compact_el_way_below_le
             {X : dcpo}
             {x y : X}
             (p : is_compact_el x)
-            (q : x ≤ y)
+            (q : x ⊑ y)
   : x ≪ y.
 Proof.
   exact (trans_way_below_le p q).

--- a/UniMath/OrderTheory/DCPOs/Basis/Basis.v
+++ b/UniMath/OrderTheory/DCPOs/Basis/Basis.v
@@ -15,14 +15,14 @@
  comes equipped with a continuity structure. Second, we look at the standard
  properties of continuous DCPOs and we reformulate them using the basis. For
  example, in a continuous DCPO the order relation can be characterized using
- the approximations (i.e., `x ≤ y` if and only if for every `z` such that
+ the approximations (i.e., `x ⊑ y` if and only if for every `z` such that
  `z ≪ x`, we have `z ≪ y`). Another standard property would be interpolation:
  if we have `x ≪ y`, then we can find an element of the basis `x ≪ b ≪ y`.
  Lastly, we look at the mapping property of a DCPO with a basis. We look at
  three properties:
  1. Two maps are equal if they are equal on the basis
- 2. We have `f x ≤ g x` for every `x` if for every basis element `b` we have
-   `f b ≤ g b`
+ 2. We have `f x ⊑ g x` for every `x` if for every basis element `b` we have
+   `f b ⊑ g b`
  3. If we have a monotone map from the basis to some DCPO `Y`, then we can
     extend that map to `X`.
  Note that the map from the third point is unique. The uniqueness would be
@@ -261,7 +261,7 @@ Section BasisProperties.
    *)
   Proposition dcpo_basis_le_via_approximation
               (x y : X)
-    : x ≤ y
+    : x ⊑ y
       ≃
       ∀ (z : B), (B z ≪ x ⇒ B z ≪ y)%logic.
   Proof.
@@ -320,7 +320,7 @@ Section BasisProperties.
     }
     intro z.
     induction z as [ z [ q₁ q₂ ] ].
-    assert (r : y ≤ ⨆ directed_set_from_basis B y).
+    assert (r : y ⊑ ⨆ directed_set_from_basis B y).
     {
       rewrite approximating_basis_lub.
       apply refl_dcpo.
@@ -422,9 +422,9 @@ Section BasisProperties.
   Proposition scott_continuous_map_le_on_basis
               {Y : dcpo}
               {f g : scott_continuous_map X Y}
-              (p : ∏ (i : B), f (B i) ≤ g (B i))
+              (p : ∏ (i : B), f (B i) ⊑ g (B i))
               (x : X)
-    : f x ≤ g x.
+    : f x ⊑ g x.
   Proof.
     rewrite (maponpaths f (!((approximating_basis_lub B x)))).
     rewrite (maponpaths g (!(approximating_basis_lub B x))).
@@ -440,11 +440,11 @@ Section BasisProperties.
   Proposition map_le_on_basis_if_scott_continuous
               {Y : dcpo}
               {f g : X → Y}
-              (p : ∏ (i : B), f (B i) ≤ g (B i))
+              (p : ∏ (i : B), f (B i) ⊑ g (B i))
               (Hf : is_scott_continuous X Y f)
               (Hg : is_scott_continuous X Y g)
               (x : X)
-    : f x ≤ g x.
+    : f x ⊑ g x.
   Proof.
     exact (@scott_continuous_map_le_on_basis Y (f ,, Hf) (g ,, Hg) p x).
   Qed.
@@ -455,7 +455,7 @@ Section BasisProperties.
   Section ScottContinuousFromBasis.
     Context {Y : dcpo}
             (f : B → Y)
-            (Hf : ∏ (i₁ i₂ : B), B i₁ ≪ B i₂ → f i₁ ≤ f i₂).
+            (Hf : ∏ (i₁ i₂ : B), B i₁ ≪ B i₂ → f i₁ ⊑ f i₂).
 
     Proposition is_directed_map_from_basis
                 (x : X)
@@ -505,8 +505,8 @@ Section BasisProperties.
 
     Proposition map_from_basis_monotone
                 (x₁ x₂ : X)
-                (p : x₁ ≤ x₂)
-      : map_from_basis x₁ ≤ map_from_basis x₂.
+                (p : x₁ ⊑ x₂)
+      : map_from_basis x₁ ⊑ map_from_basis x₂.
     Proof.
       unfold map_from_basis.
       use dcpo_lub_is_least ; cbn.
@@ -584,7 +584,7 @@ Section BasisProperties.
 
     Proposition scott_continuous_map_from_basis_le
                 (i : B)
-      : scott_continuous_map_from_basis (B i) ≤ f i.
+      : scott_continuous_map_from_basis (B i) ⊑ f i.
     Proof.
       use dcpo_lub_is_least ; cbn.
       intro j.

--- a/UniMath/OrderTheory/DCPOs/Basis/CompactBasis.v
+++ b/UniMath/OrderTheory/DCPOs/Basis/CompactBasis.v
@@ -49,7 +49,7 @@ Section CompactBasisInDCPO.
              (B : dcpo_basis_data X)
              (x : X)
     : UU
-    := ∑ (b : B), B b ≤ x.
+    := ∑ (b : B), B b ⊑ x.
 
   Definition compact_basis_le_map
              (B : dcpo_basis_data X)
@@ -311,13 +311,13 @@ Proof.
     + intros y z.
       induction y as [ [ y Hy ] p ].
       induction z as [ [ z Hz ] q ].
-      assert (Hxy : y ≤ ⨆ D).
+      assert (Hxy : y ⊑ ⨆ D).
       {
         unfold D.
         rewrite (compact_approximating_family_lub AX x).
         exact p.
       }
-      assert (Hxz : z ≤ ⨆ D).
+      assert (Hxz : z ⊑ ⨆ D).
       {
         unfold D.
         rewrite (compact_approximating_family_lub AX x).
@@ -379,7 +379,7 @@ Proposition scott_continuous_map_from_compact_basis_eq
             (B : compact_basis X)
             {Y : dcpo}
             (f : B → Y)
-            (Hf : ∏ (i₁ i₂ : B), B i₁ ≪ B i₂ → f i₁ ≤ f i₂)
+            (Hf : ∏ (i₁ i₂ : B), B i₁ ≪ B i₂ → f i₁ ⊑ f i₂)
             (i : B)
   : scott_continuous_map_from_basis
       (compact_basis_to_dcpo_basis B)
@@ -402,7 +402,7 @@ Definition scott_continuous_map_from_compact_basis_ump
            (B : compact_basis X)
            {Y : dcpo}
            (f : B → Y)
-           (Hf : ∏ (i₁ i₂ : B), B i₁ ≪ B i₂ → f i₁ ≤ f i₂)
+           (Hf : ∏ (i₁ i₂ : B), B i₁ ≪ B i₂ → f i₁ ⊑ f i₂)
   : ∃! (g : scott_continuous_map X Y),
     ∏ (i : B), g (B i) = f i.
 Proof.

--- a/UniMath/OrderTheory/DCPOs/Basis/Continuous.v
+++ b/UniMath/OrderTheory/DCPOs/Basis/Continuous.v
@@ -16,10 +16,10 @@
  These come in three flavors:
  1. Nullary interpolation: given an element, we can find some element that is
     way-below the original element.
- 2. Unary interpolation: given two elements `x` and `y` such that `x ≤ y`, we
+ 2. Unary interpolation: given two elements `x` and `y` such that `x ⊑ y`, we
     can find an element inbetween `x` and `y`: `x ≪ i ≪ y`.
- 3. Binary interpolation: given three elements `x₁, x₂, y` such that `x₁ ≤ y`
-    and `x₂ ≤ y`, we can find an element `i` such that `x₁ ≪ i ≪ y` and
+ 3. Binary interpolation: given three elements `x₁, x₂, y` such that `x₁ ⊑ y`
+    and `x₂ ⊑ y`, we can find an element `i` such that `x₁ ≪ i ≪ y` and
     `x₂ ≪ i ≪ y`.
  Note that we can generalize interpolation to finite sets. These interpolation
  properties are useful when proving stuff about continuous DCPOs.
@@ -108,7 +108,7 @@ Section PropertiesContinuousDCPO.
    *)
   Proposition continuous_dcpo_struct_le_to_way_below
               {x y : X}
-              (p : x ≤ y)
+              (p : x ⊑ y)
               (i : approximating_family CX x)
     : approximating_family CX x i ≪ y.
   Proof.
@@ -121,7 +121,7 @@ Section PropertiesContinuousDCPO.
               (p : ∏ (i : approximating_family CX x),
                    approximating_family CX x i ≪ y)
               (i : approximating_family CX x)
-    : approximating_family CX x i ≤ y.
+    : approximating_family CX x i ⊑ y.
   Proof.
     use way_below_to_le.
     apply p.
@@ -130,8 +130,8 @@ Section PropertiesContinuousDCPO.
   Proposition continuous_dcpo_struct_approx_le_to_le
               {x y : X}
               (p : ∏ (i : approximating_family CX x),
-                   approximating_family CX x i ≤ y)
-    : x ≤ y.
+                   approximating_family CX x i ⊑ y)
+    : x ⊑ y.
   Proof.
     rewrite <- (approximating_family_lub CX x).
     use dcpo_lub_is_least.
@@ -140,10 +140,10 @@ Section PropertiesContinuousDCPO.
 
   Proposition continuous_dcpo_struct_le_weq_approx_le
               (x y : X)
-    : x ≤ y
+    : x ⊑ y
       ≃
       ∀ (i : approximating_family CX x),
-      approximating_family CX x i ≤ y.
+      approximating_family CX x i ⊑ y.
   Proof.
     use weqimplimpl.
     - intros p i.
@@ -160,7 +160,7 @@ Section PropertiesContinuousDCPO.
 
   Proposition continuous_dcpo_struct_le_weq_approx_way_below
               (x y : X)
-    : x ≤ y
+    : x ⊑ y
       ≃
       ∀ (i : approximating_family CX x),
       approximating_family CX x i ≪ y.
@@ -178,7 +178,7 @@ Section PropertiesContinuousDCPO.
 
   Proposition continuous_dcpo_struct_le_via_approximation
               (x y : X)
-    : x ≤ y
+    : x ⊑ y
       ≃
       ∀ (z : X), (z ≪ x ⇒ z ≪ y)%logic.
   Proof.
@@ -205,7 +205,7 @@ Section PropertiesContinuousDCPO.
               (x y : X)
     : x ≪ y
       ≃
-      ∃ (i : approximating_family CX y), x ≤ approximating_family CX y i.
+      ∃ (i : approximating_family CX y), x ⊑ approximating_family CX y i.
   Proof.
     use weqimplimpl.
     - intro p.
@@ -255,7 +255,7 @@ Section PropertiesContinuousDCPO.
 
     Proposition unary_interpolation_cofinal_lem
                 {i₁ i₂ : D}
-                (q : D i₁ ≤ D i₂)
+                (q : D i₁ ⊑ D i₂)
                 (j₁ : D_a i₁)
       : D_a i₁ j₁ ≪ ⨆ (D_a i₂).
     Proof.
@@ -269,9 +269,9 @@ Section PropertiesContinuousDCPO.
 
     Proposition unary_interpolation_cofinal
                 {i₁ i₂ : D}
-                (q : D i₁ ≤ D i₂)
+                (q : D i₁ ⊑ D i₂)
                 (j₁ : D_a i₁)
-      : ∃ (j₂ : D_a i₂), D_a i₁ j₁ ≤ D_a i₂ j₂.
+      : ∃ (j₂ : D_a i₂), D_a i₁ j₁ ⊑ D_a i₂ j₂.
     Proof.
       use (unary_interpolation_cofinal_lem q j₁ (D_a i₂)).
       apply refl_dcpo.
@@ -330,7 +330,7 @@ Section PropertiesContinuousDCPO.
     Proposition unary_interpolation
       : ∃ (z : X), x ≪ z ∧ z ≪ y.
     Proof.
-      assert (s : y ≤ ⨆ unary_interpolation_directed_set).
+      assert (s : y ⊑ ⨆ unary_interpolation_directed_set).
       {
         apply continuous_dcpo_struct_approx_le_to_le.
         intro i.
@@ -367,7 +367,7 @@ Section PropertiesContinuousDCPO.
     : ∃ (z : X), x₁ ≪ z ∧ x₂ ≪ z ∧ z ≪ y.
   Proof.
     pose (D := approximating_family CX y).
-    assert (s : y ≤ ⨆ D).
+    assert (s : y ⊑ ⨆ D).
     {
       unfold D.
       rewrite approximating_family_lub.

--- a/UniMath/OrderTheory/DCPOs/Core/Basics.v
+++ b/UniMath/OrderTheory/DCPOs/Core/Basics.v
@@ -206,7 +206,8 @@ Coercion dcpo_to_PartialOrder (X : dcpo) : PartialOrder X := pr12 X.
 
 Definition dcpo_order {X : dcpo} (x y : X) : hProp := pr12 X x y.
 
-Notation "x ≤ y" := (dcpo_order x y) : dcpo.
+Notation "x ⊑ y" := (dcpo_order x y) (no associativity, at level 70) : dcpo.
+(* ⊑ - \sqsubseteq  *)
 
 (**
  4. Accessors for DCPOs
@@ -214,7 +215,7 @@ Notation "x ≤ y" := (dcpo_order x y) : dcpo.
 Proposition refl_dcpo
             {X : dcpo}
             (x : X)
-  : x ≤ x.
+  : x ⊑ x.
 Proof.
   apply refl_PartialOrder.
 Qed.
@@ -223,7 +224,7 @@ Definition eq_to_le_dcpo
            {X : dcpo}
            {x y : X}
            (p : x = y)
-  : x ≤ y.
+  : x ⊑ y.
 Proof.
   induction p.
   apply refl_dcpo.
@@ -232,9 +233,9 @@ Qed.
 Proposition trans_dcpo
             {X : dcpo}
             {x y z : X}
-            (p : x ≤ y)
-            (q : y ≤ z)
-  : x ≤ z.
+            (p : x ⊑ y)
+            (q : y ⊑ z)
+  : x ⊑ z.
 Proof.
   exact (trans_PartialOrder X p q).
 Qed.
@@ -242,8 +243,8 @@ Qed.
 Proposition antisymm_dcpo
             {X : dcpo}
             {x y : X}
-            (p : x ≤ y)
-            (q : y ≤ x)
+            (p : x ⊑ y)
+            (q : y ⊑ x)
   : x = y.
 Proof.
   exact (antisymm_PartialOrder X p q).
@@ -256,14 +257,15 @@ Definition dcpo_lub
   := pr22 X _ D (directed_set_is_directed D).
 
 Notation "⨆ D" := (dcpo_lub D) (at level 20) : dcpo.
+(* ⊔ - \sqcup *)
 Notation "⨆_{ D } f" := (⨆ (f {{ D }})) (at level 20) : dcpo.
 
 Definition make_dcpo_is_least_upperbound
            {X : dcpo}
            (D : directed_set X)
            (x : X)
-           (H₁ : ∏ (i : D), D i ≤ x)
-           (H₂ : ∏ (x' : X), (∏ (i : D), D i ≤ x') → x ≤ x')
+           (H₁ : ∏ (i : D), D i ⊑ x)
+           (H₂ : ∏ (x' : X), (∏ (i : D), D i ⊑ x') → x ⊑ x')
   : is_least_upperbound X D x.
 Proof.
   split.
@@ -284,8 +286,8 @@ Proposition less_than_dcpo_lub
             (D : directed_set X)
             (x : X)
             (i : D)
-            (H : x ≤ D i)
-  : x ≤ ⨆ D.
+            (H : x ⊑ D i)
+  : x ⊑ ⨆ D.
 Proof.
   exact (trans_PartialOrder
            X
@@ -299,8 +301,8 @@ Proposition dcpo_lub_is_least
             {X : dcpo}
             (D : directed_set X)
             (x : X)
-            (H : ∏ (i : D), D i ≤ x)
-  : ⨆ D ≤ x.
+            (H : ∏ (i : D), D i ⊑ x)
+  : ⨆ D ⊑ x.
 Proof.
   exact (is_least_upperbound_is_least (is_least_upperbound_dcpo_lub D) x H).
 Qed.
@@ -400,11 +402,12 @@ Definition bottom_dcppo
   := pr122 X.
 
 Notation "⊥_{ X }" := (bottom_dcppo X) : dcpo.
+(* ⊥ - \bot*)
 
 Proposition is_min_bottom_dcppo
             {X : dcppo}
             (x : X)
-  : ⊥_{ X } ≤ x.
+  : ⊥_{ X } ⊑ x.
 Proof.
   exact (pr222 X x).
 Qed.

--- a/UniMath/OrderTheory/DCPOs/Core/IntrinsicApartness.v
+++ b/UniMath/OrderTheory/DCPOs/Core/IntrinsicApartness.v
@@ -44,7 +44,7 @@ Definition dcpo_specialization
   : hProp
   := (∀ (P : X → hProp), is_scott_open P ⇒ P x ⇒ P y)%logic.
 
-Notation "x ≤s y" := (dcpo_specialization x y) (at level 70) : dcpo.
+Notation "x ⊑s y" := (dcpo_specialization x y) (at level 70) : dcpo.
 
 (**
  2. Properties of the specialization preorder
@@ -54,7 +54,7 @@ Section PropertiesSpecialization.
 
   Proposition refl_dcpo_specialization
               (x : X)
-    : x ≤s x.
+    : x ⊑s x.
   Proof.
     intros P HP Px.
     exact Px.
@@ -62,9 +62,9 @@ Section PropertiesSpecialization.
 
   Proposition trans_dcpo_specialization
               {x y z : X}
-              (p : x ≤s y)
-              (q : y ≤s z)
-    : x ≤s z.
+              (p : x ⊑s y)
+              (q : y ⊑s z)
+    : x ⊑s z.
   Proof.
     intros P HP Px.
     apply (q P HP).
@@ -73,8 +73,8 @@ Section PropertiesSpecialization.
 
   Proposition le_dcpo_specialization
               {x y : X}
-              (p : x ≤ y)
-    : x ≤s y.
+              (p : x ⊑ y)
+    : x ⊑s y.
   Proof.
     intros P HP Px.
     exact (is_scott_open_upper_set HP Px p).
@@ -83,7 +83,7 @@ Section PropertiesSpecialization.
   Proposition le_dcpo_specialization_equiv
               (CX : continuous_dcpo_struct X)
               (x y : X)
-    : x ≤ y ≃ x ≤s y.
+    : x ⊑ y ≃ x ⊑s y.
   Proof.
     use weqimplimpl.
     - exact le_dcpo_specialization.
@@ -130,7 +130,7 @@ Section PropertiesNotSpecialization.
   Proposition dcpo_not_specialization_le
               {x y : X}
               (p : x ⊄ y)
-    : ¬(x ≤ y).
+    : ¬(x ⊑ y).
   Proof.
     intro q.
     revert p.
@@ -147,7 +147,7 @@ Section PropertiesNotSpecialization.
   Proposition continuous_not_specialization_weq
               (CX : continuous_dcpo_struct X)
               (x y : X)
-    : x ⊄ y ≃ (∃ (b : X), b ≪ x ∧ ¬(b ≤ y))%logic.
+    : x ⊄ y ≃ (∃ (b : X), b ≪ x ∧ ¬(b ⊑ y))%logic.
   Proof.
     use weqimplimpl.
     - use factor_through_squash.

--- a/UniMath/OrderTheory/DCPOs/Core/ScottContinuous.v
+++ b/UniMath/OrderTheory/DCPOs/Core/ScottContinuous.v
@@ -385,8 +385,8 @@ Proposition is_monotone_scott_continuous_map
             {X Y : dcpo}
             (f : scott_continuous_map X Y)
             {x₁ x₂ : X}
-            (p : x₁ ≤ x₂)
-  : f x₁ ≤ f x₂.
+            (p : x₁ ⊑ x₂)
+  : f x₁ ⊑ f x₂.
 Proof.
   exact (pr12 f x₁ x₂ p).
 Qed.
@@ -419,7 +419,7 @@ Defined.
 Section MakeScottContinuous.
   Context {X Y : dcpo}
           (f : X → Y)
-          (Hf₁ : ∏ (x₁ x₂ : X), x₁ ≤ x₂ → f x₁ ≤ f x₂).
+          (Hf₁ : ∏ (x₁ x₂ : X), x₁ ⊑ x₂ → f x₁ ⊑ f x₂).
 
   Definition make_dcpo_is_monotone
     : monotone_function X Y
@@ -492,7 +492,7 @@ Qed.
 Section MakeStrictScottContinuous.
   Context {X Y : dcppo}
           (f : X → Y)
-          (Hf₁ : ∏ (x₁ x₂ : X), x₁ ≤ x₂ → f x₁ ≤ f x₂)
+          (Hf₁ : ∏ (x₁ x₂ : X), x₁ ⊑ x₂ → f x₁ ⊑ f x₂)
           (Hf₂ : ∏ (D : directed_set X), f (⨆ D) = ⨆_{D} (f ,, Hf₁))
           (Hf₃ : f ⊥_{X} = ⊥_{Y}).
 

--- a/UniMath/OrderTheory/DCPOs/Core/ScottTopology.v
+++ b/UniMath/OrderTheory/DCPOs/Core/ScottTopology.v
@@ -41,12 +41,12 @@ Section ScottTopology.
   Definition is_lower_set
              (P : X → hProp)
     : hProp
-    := (∀ (x y : X), P y ⇒ x ≤ y ⇒ P x)%logic.
+    := (∀ (x y : X), P y ⇒ x ⊑ y ⇒ P x)%logic.
 
   Definition is_upper_set
              (P : X → hProp)
     : hProp
-    := (∀ (x y : X), P x ⇒ x ≤ y ⇒ P y)%logic.
+    := (∀ (x y : X), P x ⇒ x ⊑ y ⇒ P y)%logic.
 
   (**
    2. Scott open and Scott closed sets
@@ -126,7 +126,7 @@ Section ScottClosedAccessors.
   Proposition is_scott_closed_lower_set
               {x y : X}
               (Py : P y)
-              (p : x ≤ y)
+              (p : x ⊑ y)
     : P x.
   Proof.
     exact (pr1 HP x y Py p).
@@ -149,7 +149,7 @@ Section ScottOpenAccessors.
   Proposition is_scott_open_upper_set
               {x y : X}
               (Py : P x)
-              (p : x ≤ y)
+              (p : x ⊑ y)
     : P y.
   Proof.
     exact (pr1 HP x y Py p).
@@ -172,7 +172,7 @@ Section PropertiesScottTopology.
    *)
   Proposition lower_set_is_scott_closed
               (x : X)
-    : is_scott_closed (λ y, y ≤ x).
+    : is_scott_closed (λ y, y ⊑ x).
   Proof.
     split.
     - intros y₁ y₂ p q.

--- a/UniMath/OrderTheory/DCPOs/Core/WayBelow.v
+++ b/UniMath/OrderTheory/DCPOs/Core/WayBelow.v
@@ -42,7 +42,7 @@ Definition way_below
            {X : dcpo}
            (x y : X)
   : hProp
-  := (∀ (D : directed_set X), y ≤ ⨆ D ⇒ ∃ (i : D), x ≤ D i)%logic.
+  := (∀ (D : directed_set X), y ⊑ ⨆ D ⇒ ∃ (i : D), x ⊑ D i)%logic.
 
 Notation "x ≪ y" := (way_below x y) (at level 70). (* \ll *)
 
@@ -51,8 +51,8 @@ Proposition way_below_elem
             {x y : X}
             (p : x ≪ y)
             (D : directed_set X)
-            (HD : y ≤ ⨆ D)
-  : ∃ (i : D), x ≤ D i.
+            (HD : y ⊑ ⨆ D)
+  : ∃ (i : D), x ⊑ D i.
 Proof.
   exact (p D HD).
 Qed.
@@ -78,7 +78,7 @@ Section PropertiesOfWayBelow.
     }
     intros H.
     induction H as [ i H ].
-    assert (H' : y ≤ ⨆ D).
+    assert (H' : y ⊑ ⨆ D).
     {
       refine (trans_dcpo H _).
       use (less_than_dcpo_lub D _ i).
@@ -93,7 +93,7 @@ Section PropertiesOfWayBelow.
   Proposition trans_way_below_le
               {x y z : X}
               (p : x ≪ y)
-              (q : y ≤ z)
+              (q : y ⊑ z)
     : x ≪ z.
   Proof.
     intros D HD.
@@ -102,7 +102,7 @@ Section PropertiesOfWayBelow.
 
   Proposition trans_le_way_below
               {x y z : X}
-              (p : x ≤ y)
+              (p : x ⊑ y)
               (q : y ≪ z)
     : x ≪ z.
   Proof.
@@ -122,10 +122,10 @@ Section PropertiesOfWayBelow.
   Proposition way_below_to_le
               {x y : X}
               (p : x ≪ y)
-    : x ≤ y.
+    : x ⊑ y.
   Proof.
     pose (D := nat_directed_set X (λ _, y) (λ _, refl_dcpo _)).
-    assert (q : y ≤ ⨆ D).
+    assert (q : y ⊑ ⨆ D).
     {
       exact (less_than_dcpo_lub D y 0 (refl_dcpo _)).
     }

--- a/UniMath/OrderTheory/DCPOs/Elements/Maximal.v
+++ b/UniMath/OrderTheory/DCPOs/Elements/Maximal.v
@@ -3,7 +3,7 @@
  Maximal elements in a DCPO
 
  In this file, we define maximal elements in DCPOs. In classical foundations,
- an element `x` is called maximal if for every `y` such that `x ≤ y`, we have
+ an element `x` is called maximal if for every `y` such that `x ⊑ y`, we have
  that `x = y`. However, constructively, there is a better notion, namely that
  of a strongly maximal element (see https://arxiv.org/pdf/2106.05064.pdf).
 
@@ -54,7 +54,7 @@ Definition is_maximal
            {X : dcpo}
            (x : X)
   : hProp
-  := (∀ (y : X), x ≤ y ⇒ y ≤ x)%logic.
+  := (∀ (y : X), x ⊑ y ⇒ y ⊑ x)%logic.
 
 (**
  2. Hausdorff separated elements
@@ -104,7 +104,7 @@ Section PropertiesHausdorffSeparated.
   Proposition is_hausdorff_separated_not_le
               {x y : X}
               (H : is_hausdorff_separated x y)
-    : ¬(x ≤ y).
+    : ¬(x ⊑ y).
   Proof.
     intro p.
     revert H.

--- a/UniMath/OrderTheory/DCPOs/Elements/Sharp.v
+++ b/UniMath/OrderTheory/DCPOs/Elements/Sharp.v
@@ -36,7 +36,7 @@ Definition is_sharp
            {X : dcpo}
            (x : X)
   : hProp
-  := (∀ (y z : X), y ≪ z ⇒ (y ≪ x ∨ ¬(z ≤ x)))%logic.
+  := (∀ (y z : X), y ≪ z ⇒ (y ≪ x ∨ ¬(z ⊑ x)))%logic.
 
 (**
  2. Characterization of sharp elements in a continuous DCPO
@@ -105,7 +105,7 @@ Lemma is_sharp_to_le
       {x y : X}
       (Hy : is_sharp y)
       (p : ¬(x ⊄ y))
-  : x ≤ y.
+  : x ⊑ y.
 Proof.
   use (invmap (continuous_dcpo_struct_le_via_approximation CX x y)).
   intros z q.

--- a/UniMath/OrderTheory/DCPOs/Examples/BinaryProducts.v
+++ b/UniMath/OrderTheory/DCPOs/Examples/BinaryProducts.v
@@ -120,9 +120,9 @@ Notation "X × Y" := (prod_dcpo X Y) : dcpo.
 Proposition prod_dcpo_le
             {X Y : dcpo}
             (xy₁ xy₂ : (X × Y)%dcpo)
-            (p : pr1 xy₁ ≤ pr1 xy₂)
-            (q : pr2 xy₁ ≤ pr2 xy₂)
-  : xy₁ ≤ xy₂.
+            (p : pr1 xy₁ ⊑ pr1 xy₂)
+            (q : pr2 xy₁ ⊑ pr2 xy₂)
+  : xy₁ ⊑ xy₂.
 Proof.
   exact (p ,, q).
 Qed.
@@ -426,7 +426,7 @@ Section ProductBasis.
   Proof.
     intros D q.
     pose (D' := prod_directed_set_dcpo D (directed_set_from_basis BY (pr2 xy₂))).
-    assert (HD : xy₂ ≤ ⨆ D').
+    assert (HD : xy₂ ⊑ ⨆ D').
     {
       unfold D'.
       rewrite prod_dcpo_lub'.
@@ -451,7 +451,7 @@ Section ProductBasis.
   Proof.
     intros D q.
     pose (D' := prod_directed_set_dcpo (directed_set_from_basis BX (pr1 xy₂)) D).
-    assert (HD : xy₂ ≤ ⨆ D').
+    assert (HD : xy₂ ⊑ ⨆ D').
     {
       unfold D'.
       rewrite prod_dcpo_lub'.

--- a/UniMath/OrderTheory/DCPOs/Examples/Exponentials.v
+++ b/UniMath/OrderTheory/DCPOs/Examples/Exponentials.v
@@ -114,7 +114,7 @@ Definition scott_continuous_map_PartialOrder
   : PartialOrder (scott_continuous_map_hSet X Y).
 Proof.
   use make_PartialOrder.
-  - exact (λ f g, ∀ (x : X), pr1 f x ≤ pr1 g x).
+  - exact (λ f g, ∀ (x : X), pr1 f x ⊑ pr1 g x).
   - refine ((_ ,, _) ,, _).
     + abstract
         (intros f g h p q x ;
@@ -156,8 +156,8 @@ Section FunctionLub.
 
   Proposition is_monotone_pointwise_lub
               (x₁ x₂ : X)
-              (p : x₁ ≤ x₂)
-    : pointwise_lub x₁ ≤ pointwise_lub x₂.
+              (p : x₁ ⊑ x₂)
+    : pointwise_lub x₁ ⊑ pointwise_lub x₂.
   Proof.
     unfold pointwise_lub.
     use dcpo_lub_is_least ; cbn.

--- a/UniMath/OrderTheory/DCPOs/Examples/IdealCompletion.v
+++ b/UniMath/OrderTheory/DCPOs/Examples/IdealCompletion.v
@@ -329,7 +329,7 @@ Section RoundedIdealCompletion.
   Proposition principal_ideal_monotone
               {b₁ b₂ : B}
               (p : b₁ ≺ b₂)
-    : principal_ideal b₁ ≤ principal_ideal b₂.
+    : principal_ideal b₁ ⊑ principal_ideal b₂.
   Proof.
     intros a q ; cbn in *.
     exact (trans_abstract_basis q p).
@@ -371,7 +371,7 @@ Section RoundedIdealCompletion.
 
   Proposition rounded_ideal_lub_2
               (I : rounded_ideal_completion)
-    : ⨆ below_ideal_directed_set I ≤ I.
+    : ⨆ below_ideal_directed_set I ⊑ I.
   Proof.
     apply dcpo_lub_is_least.
     intros [b Hb].
@@ -382,7 +382,7 @@ Section RoundedIdealCompletion.
 
   Proposition rounded_ideal_lub_1
               (I : rounded_ideal_completion)
-    : I ≤ ⨆ below_ideal_directed_set I.
+    : I ⊑ ⨆ below_ideal_directed_set I.
   Proof.
     intros x Hx.
     assert (H := is_ideal_rounded (pr2 I) Hx).
@@ -433,7 +433,7 @@ Section RoundedIdealCompletion.
   Proposition from_way_below_ideal_completion
               {I J : rounded_ideal_completion}
               (Hb : I ≪ J)
-    : ∃ b₁, b₁ ∈ J ∧ I ≤ principal_ideal b₁.
+    : ∃ b₁, b₁ ∈ J ∧ I ⊑ principal_ideal b₁.
   Proof.
     specialize (Hb (below_ideal_directed_set J) (rounded_ideal_lub_1 J)).
     revert Hb.
@@ -458,7 +458,7 @@ Section RoundedIdealCompletion.
     {I J : rounded_ideal_completion}
     (b₁ : B)
     (Hb1 : b₁ ∈ J)
-    (HI : I ≤ principal_ideal b₁)
+    (HI : I ⊑ principal_ideal b₁)
     : I ≪ J.
   Proof.
     intros D HJ.
@@ -476,7 +476,7 @@ Section RoundedIdealCompletion.
   Qed.
 
   Proposition way_below_ideal_completion_eq (I J : rounded_ideal_completion) :
-    I ≪ J ≃ ∃ b₁, b₁ ∈ J ∧ I ≤ principal_ideal b₁.
+    I ≪ J ≃ ∃ b₁, b₁ ∈ J ∧ I ⊑ principal_ideal b₁.
   Proof.
     use weqimplimpl.
     - apply from_way_below_ideal_completion.

--- a/UniMath/OrderTheory/DCPOs/FixpointTheorems/LeastFixpoint.v
+++ b/UniMath/OrderTheory/DCPOs/FixpointTheorems/LeastFixpoint.v
@@ -67,7 +67,7 @@ Section FixpointTheorem.
 
   Lemma is_monotone_bot_iteration_map_S
         (n : ℕ)
-    : bot_iteration_map n ≤ f (bot_iteration_map n).
+    : bot_iteration_map n ⊑ f (bot_iteration_map n).
   Proof.
     induction n as [ | n IHn ].
     - apply is_min_bottom_dcppo.
@@ -107,7 +107,7 @@ Section FixpointTheorem.
   Theorem is_least_fixpoint_least_fixpoint
           (x : X)
           (p : f x = x)
-    : least_fixpoint ≤ x.
+    : least_fixpoint ⊑ x.
   Proof.
     use dcpo_lub_is_least ; cbn.
     intro n.

--- a/UniMath/OrderTheory/DCPOs/FixpointTheorems/Pataraia.v
+++ b/UniMath/OrderTheory/DCPOs/FixpointTheorems/Pataraia.v
@@ -7,9 +7,9 @@
 
  There are two fundamental notions required for this proof. The
  first one is the notion of progressive maps. A map `f` is called
- progressive if for all `x` we have `x ≤ f x`. The second one is
+ progressive if for all `x` we have `x ⊑ f x`. The second one is
  the notion of post fixpoints. A post fixpoint for a map `f` is a
- point `x` such that `x ≤ f x`.
+ point `x` such that `x ⊑ f x`.
 
  The key observation of the proof is that every DCPO has a largest
  progressive map [largest_progressive_map]. This is so because the
@@ -49,7 +49,7 @@ Definition is_progressive
            {X : dcpo}
            (f : monotone_function X X)
   : hProp
-  := ∀ (x : X), x ≤ f x.
+  := ∀ (x : X), x ⊑ f x.
 
 Definition progressive_map
            (X : dcpo)
@@ -190,7 +190,7 @@ Proposition le_largest_progressive_map
             {X : dcpo}
             (f : progressive_map X)
             (x : X)
-  : f x ≤ largest_progressive_map X x.
+  : f x ⊑ largest_progressive_map X x.
 Proof.
   exact (less_than_dcpo_lub
            (directed_set_progressive_maps X)
@@ -207,8 +207,8 @@ Proposition lub_post_fixpoint
             {X : dcpo}
             (f : monotone_function X X)
             (D : directed_set X)
-            (HD : ∏ (d : D), D d ≤ f (D d))
-  : ⨆ D ≤ f (⨆ D).
+            (HD : ∏ (d : D), D d ⊑ f (D d))
+  : ⨆ D ⊑ f (⨆ D).
 Proof.
   use dcpo_lub_is_least.
   intro d.
@@ -223,7 +223,7 @@ Definition post_fixpoint_dcpo
            {X : dcpo}
            (f : monotone_function X X)
   : dcpo
-  := sub_dcpo X (λ x, x ≤ f x) (lub_post_fixpoint f).
+  := sub_dcpo X (λ x, x ⊑ f x) (lub_post_fixpoint f).
 
 Definition restriction_to_post_fixpoint
            {X : dcpo}


### PR DESCRIPTION
Change the notation used for the order in DCPOs, to make it consistent with what is usually in textbooks and in papers