### PR TITLE
Linear to linear non-linear

### DIFF
--- a/UniMath/CONTENTS.md
+++ b/UniMath/CONTENTS.md
@@ -1126,6 +1126,8 @@ The packages and files are listed here in logical order: each file depends only 
    - [LinearLogic/LinearNonLinear.v](Semantics/LinearLogic/LinearNonLinear.v)
    - [LinearLogic/LafontCategory.v](Semantics/LinearLogic/LafontCategory.v)
    - [LinearLogic/LinearCategory.v](Semantics/LinearLogic/LinearCategory.v)
+   - [LinearLogic/LinearCategoryEilenbergMooreAdjunction.v](Semantics/LinearLogic/LinearCategoryEilenbergMooreAdjunction.v)
+   - [LinearLogic/LinearToLinearNonLinear.v](Semantics/LinearLogic/LinearToLinearNonLinear.v)
    - [LinearLogic/LiftingModel.v](Semantics/LinearLogic/LiftingModel.v)
    - [EnrichedEffectCalculus/EECModel.v](Semantics/EnrichedEffectCalculus/EECModel.v)
    - [EnrichedEffectCalculus/ContinuationModel.v](Semantics/EnrichedEffectCalculus/ContinuationModel.v)

--- a/UniMath/Semantics/.package/files
+++ b/UniMath/Semantics/.package/files
@@ -1,6 +1,8 @@
 LinearLogic/LinearNonLinear.v
 LinearLogic/LafontCategory.v
 LinearLogic/LinearCategory.v
+LinearLogic/LinearCategoryEilenbergMooreAdjunction.v
+LinearLogic/LinearToLinearNonLinear.v
 LinearLogic/LiftingModel.v
 
 EnrichedEffectCalculus/EECModel.v

--- a/UniMath/Semantics/LinearLogic/LiftingModel.v
+++ b/UniMath/Semantics/LinearLogic/LiftingModel.v
@@ -82,7 +82,11 @@ Proof.
     apply idpath.
   - intros X.
     apply (commutative_comonoid_is_commutative _ (lift_commutative_comonoid X)).
-Qed.
+  - admit.
+  - admit.
+  - admit.
+  - admit.
+Admitted.
 
 Definition lifting_linear_category
   : linear_category.

--- a/UniMath/Semantics/LinearLogic/LinearCategory.v
+++ b/UniMath/Semantics/LinearLogic/LinearCategory.v
@@ -20,6 +20,7 @@ Require Import UniMath.CategoryTheory.Monoidal.Categories.
 Require Import UniMath.CategoryTheory.Monoidal.Functors.
 Require Import UniMath.CategoryTheory.Monoidal.FunctorCategories.
 Require Import UniMath.CategoryTheory.Monoidal.Structure.Symmetric.
+Require Import UniMath.CategoryTheory.Monoidal.Structure.SymmetricDiagonal.
 Require Import UniMath.CategoryTheory.Monoidal.Structure.Closed.
 Require Import UniMath.CategoryTheory.Monoidal.Comonoids.Category.
 
@@ -152,7 +153,39 @@ Definition linear_category_laws
       linear_category_comult 𝕃 x
       · sym_mon_braiding 𝕃 _ _
       =
-      linear_category_comult 𝕃 x).
+        linear_category_comult 𝕃 x)
+     ×
+     (* counit preserves tensor *)
+     (∏ x y : 𝕃, mon_functor_tensor (linear_category_bang_functor 𝕃) x y
+                           · linear_category_counit 𝕃 (x ⊗ y)
+                         = linear_category_counit 𝕃 x #⊗ linear_category_counit 𝕃 y
+                             · mon_lunitor (monoidal_unit 𝕃))
+     ×
+     (* counit preserves unit *)
+     (mon_functor_unit (linear_category_bang_functor 𝕃)
+                · linear_category_counit 𝕃 I_{𝕃}
+              = identity I_{𝕃})
+     ×
+     (* comult preserves unit *)
+     (mon_functor_unit (linear_category_bang_functor 𝕃)
+                · linear_category_comult 𝕃 I_{𝕃}
+              = mon_linvunitor I_{𝕃}
+                  · mon_functor_unit (linear_category_bang_functor 𝕃)
+                  #⊗ mon_functor_unit (linear_category_bang_functor 𝕃))
+     ×
+     (* comult preserves tensor *)
+     (∏ x y : 𝕃,
+         mon_functor_tensor (linear_category_bang_functor 𝕃) x y
+           · linear_category_comult 𝕃 (x ⊗ y)
+         = (linear_category_comult 𝕃 x) #⊗ (linear_category_comult 𝕃 y)
+             · (inner_swap 𝕃
+                  (linear_category_bang 𝕃 x)
+                  (linear_category_bang 𝕃 x)
+                  (linear_category_bang 𝕃 y)
+                  (linear_category_bang 𝕃 y)
+                  · mon_functor_tensor (linear_category_bang_functor 𝕃) x y
+                  #⊗ mon_functor_tensor (linear_category_bang_functor 𝕃) x y)).
+
 
 Definition linear_category
   : UU
@@ -268,8 +301,53 @@ Section AccessorsLaws.
       =
       linear_category_comult 𝕃 x.
   Proof.
-    exact (pr222 (pr222 (pr222 𝕃)) x).
+    exact (pr1 (pr222 (pr222 (pr222 𝕃))) x).
   Qed.
+
+  Proposition linear_category_counit_preserves_tensor
+    (x y : 𝕃)
+    : mon_functor_tensor (linear_category_bang_functor 𝕃) x y
+        · linear_category_counit 𝕃 (x ⊗ y)
+      = linear_category_counit 𝕃 x #⊗ linear_category_counit 𝕃 y
+          · mon_lunitor (monoidal_unit 𝕃).
+  Proof.
+    exact (pr12 (pr222 (pr222 (pr222 𝕃))) x y).
+  Qed.
+
+  Proposition linear_category_counit_preserves_unit
+    : mon_functor_unit (linear_category_bang_functor 𝕃)
+        · linear_category_counit 𝕃 I_{𝕃}
+      = identity I_{𝕃}.
+  Proof.
+    exact (pr122 (pr222 (pr222 (pr222 𝕃)))).
+  Qed.
+
+  Proposition linear_category_comult_preserves_unit
+    : mon_functor_unit (linear_category_bang_functor 𝕃)
+        · linear_category_comult 𝕃 I_{𝕃}
+      = mon_linvunitor I_{𝕃}
+          · mon_functor_unit (linear_category_bang_functor 𝕃)
+          #⊗ mon_functor_unit (linear_category_bang_functor 𝕃).
+  Proof.
+    exact (pr1 (pr222 (pr222 (pr222 (pr222 𝕃))))).
+  Qed.
+
+  Proposition linear_category_comult_preserves_tensor
+    (x y : 𝕃)
+    : mon_functor_tensor (linear_category_bang_functor 𝕃) x y
+           · linear_category_comult 𝕃 (x ⊗ y)
+         = (linear_category_comult 𝕃 x) #⊗ (linear_category_comult 𝕃 y)
+             · (inner_swap 𝕃
+                  (linear_category_bang 𝕃 x)
+                  (linear_category_bang 𝕃 x)
+                  (linear_category_bang 𝕃 y)
+                  (linear_category_bang 𝕃 y)
+                  · mon_functor_tensor (linear_category_bang_functor 𝕃) x y
+                  #⊗ mon_functor_tensor (linear_category_bang_functor 𝕃) x y).
+  Proof.
+    exact (pr2 (pr222 (pr222 (pr222 (pr222 𝕃)))) x y).
+  Qed.
+
 End AccessorsLaws.
 
 (**

--- a/UniMath/Semantics/LinearLogic/LinearCategoryEilenbergMooreAdjunction.v
+++ b/UniMath/Semantics/LinearLogic/LinearCategoryEilenbergMooreAdjunction.v
@@ -1,6 +1,5 @@
 (*
-In this file, we show how any linear category induces a linear non linear model.
-This boils down to proving how the eilenberg moore category of the (symmetric monoidal) comonad, given by a linear category, is cartesian monoidal.
+In this file, the cofree adjunction between a linear category and its eilenberg-moore category is constructed.
 *)
 
 Require Import UniMath.MoreFoundations.All.

--- a/UniMath/Semantics/LinearLogic/LinearCategoryEilenbergMooreAdjunction.v
+++ b/UniMath/Semantics/LinearLogic/LinearCategoryEilenbergMooreAdjunction.v
@@ -42,7 +42,7 @@ Section CofreeAdjunction.
   Context (L : linear_category).
 
   Definition eilenberg_moore_cofree
-    :  pr1 L ⟶ co_eilenberg_moore_cat (linear_category_bang L).
+    : L ⟶ co_eilenberg_moore_cat (linear_category_bang L).
   Proof.
     use functor_to_co_eilenberg_moore_cat.
     - apply (linear_category_bang L).
@@ -61,20 +61,8 @@ Section CofreeAdjunction.
           exact (Comonad_law3 (T := linear_category_bang L) x)).
   Defined.
 
-  (* Lemma test_ob (x : L)
-    : pr11 (eilenberg_moore_cofree x) = linear_category_bang L x.
-  Proof.
-    apply idpath.
-  Qed.
-
-  Lemma test_mor (x : L)
-    : pr21 (eilenberg_moore_cofree x) =  δ (linear_category_bang L) x.
-  Proof.
-    apply id_left.
-  Qed. *)
-
   Local Definition eilenberg_moore_forget
-    : full_subcat (dialgebra (functor_identity (pr1 L)) (linear_category_bang L))
+    : full_subcat (dialgebra (functor_identity L) (linear_category_bang L))
         mon_cat_co_eilenberg_moore_extra_condition ⟶ L.
     (* : co_eilenberg_moore_cat (linear_category_bang L) ⟶ L. *)
   Proof.
@@ -83,7 +71,7 @@ Section CofreeAdjunction.
 
   Local Definition eilenberg_moore_adj_unit
     : functor_identity
-        (full_subcat (dialgebra (functor_identity (pr1 L)) (linear_category_bang L))
+        (full_subcat (dialgebra (functor_identity L) (linear_category_bang L))
            mon_cat_co_eilenberg_moore_extra_condition) ⟹
         eilenberg_moore_forget ∙ eilenberg_moore_cofree.
   Proof.
@@ -121,7 +109,7 @@ Section CofreeAdjunction.
 
   Definition eilenberg_moore_cmd_adj
     : adjunction
-    (full_subcat (dialgebra (functor_identity (pr1 L)) (linear_category_bang L))
+    (full_subcat (dialgebra (functor_identity L) (linear_category_bang L))
        mon_cat_co_eilenberg_moore_extra_condition) L.
   Proof.
     use make_adjunction.

--- a/UniMath/Semantics/LinearLogic/LinearCategoryEilenbergMooreAdjunction.v
+++ b/UniMath/Semantics/LinearLogic/LinearCategoryEilenbergMooreAdjunction.v
@@ -1,0 +1,136 @@
+(*
+In this file, we show how any linear category induces a linear non linear model.
+This boils down to proving how the eilenberg moore category of the (symmetric monoidal) comonad, given by a linear category, is cartesian monoidal.
+*)
+
+Require Import UniMath.MoreFoundations.All.
+Require Import UniMath.CategoryTheory.Core.Prelude.
+Require Import UniMath.CategoryTheory.Adjunctions.Core.
+Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.Monads.Comonads.
+Require Import UniMath.CategoryTheory.Monoidal.WhiskeredBifunctors.
+Require Import UniMath.CategoryTheory.Monoidal.Categories.
+Require Import UniMath.CategoryTheory.Monoidal.Functors.
+Require Import UniMath.CategoryTheory.Monoidal.Adjunctions.
+Require Import UniMath.CategoryTheory.Monoidal.FunctorCategories.
+Require Import UniMath.CategoryTheory.Monoidal.Structure.Cartesian.
+Require Import UniMath.CategoryTheory.Monoidal.Structure.Symmetric.
+Require Import UniMath.CategoryTheory.Monoidal.Structure.Closed.
+Require Import UniMath.CategoryTheory.Monoidal.Structure.SymmetricDiagonal.
+
+Require Import UniMath.CategoryTheory.DisplayedCats.Core.
+Require Import UniMath.CategoryTheory.DisplayedCats.Total.
+Require Import UniMath.CategoryTheory.DisplayedCats.Constructions.
+Require Import UniMath.CategoryTheory.categories.Dialgebras.
+
+Require Import UniMath.CategoryTheory.Monoidal.Displayed.WhiskeredDisplayedBifunctors.
+Require Import UniMath.CategoryTheory.Monoidal.Displayed.Monoidal.
+
+Require Import UniMath.CategoryTheory.categories.CoEilenbergMoore.
+Require Import UniMath.CategoryTheory.Monoidal.Examples.MonoidalDialgebras.
+Require Import UniMath.CategoryTheory.Monoidal.Examples.SymmetricMonoidalCoEilenbergMoore.
+
+Require Import UniMath.Semantics.LinearLogic.LinearCategory.
+
+Import MonoidalNotations.
+
+Local Open Scope cat.
+Local Open Scope moncat.
+
+Section CofreeAdjunction.
+
+  Context (L : linear_category).
+
+  Definition eilenberg_moore_cofree
+    :  pr1 L ⟶ co_eilenberg_moore_cat (linear_category_bang L).
+  Proof.
+    use functor_to_co_eilenberg_moore_cat.
+    - apply (linear_category_bang L).
+    - use nat_trans_comp.
+      2: { apply nat_trans_functor_id_left. }
+      exact (δ (linear_category_bang L)).
+    - abstract (
+          intro x;
+          refine (_ @ Comonad_law1 (T := linear_category_bang L) x);
+          refine (assoc' _ _ _ @ _);
+          apply id_left).
+    - abstract (
+          intro x;
+          cbn;
+          rewrite id_left;
+          exact (Comonad_law3 (T := linear_category_bang L) x)).
+  Defined.
+
+  (* Lemma test_ob (x : L)
+    : pr11 (eilenberg_moore_cofree x) = linear_category_bang L x.
+  Proof.
+    apply idpath.
+  Qed.
+
+  Lemma test_mor (x : L)
+    : pr21 (eilenberg_moore_cofree x) =  δ (linear_category_bang L) x.
+  Proof.
+    apply id_left.
+  Qed. *)
+
+  Local Definition eilenberg_moore_forget
+    : full_subcat (dialgebra (functor_identity (pr1 L)) (linear_category_bang L))
+        mon_cat_co_eilenberg_moore_extra_condition ⟶ L.
+    (* : co_eilenberg_moore_cat (linear_category_bang L) ⟶ L. *)
+  Proof.
+    exact (functor_composite (pr1_category _) (pr1_category _)).
+  Defined.
+
+  Local Definition eilenberg_moore_adj_unit
+    : functor_identity
+        (full_subcat (dialgebra (functor_identity (pr1 L)) (linear_category_bang L))
+           mon_cat_co_eilenberg_moore_extra_condition) ⟹
+        eilenberg_moore_forget ∙ eilenberg_moore_cofree.
+  Proof.
+    use make_nat_trans.
+    - intro x.
+      use make_mor_co_eilenberg_moore.
+      + exact (pr21 x).
+      + abstract (
+            refine (! pr22 x @ _);
+            apply maponpaths,
+              pathsinv0,
+              id_left).
+    - abstract (
+          intros x y f;
+          use eq_mor_co_eilenberg_moore;
+          exact (! pr21 f)).
+  Defined.
+
+  Lemma eilenberg_moore_cmd_form_adj
+    :  form_adjunction'
+         (eilenberg_moore_forget,,
+            eilenberg_moore_cofree,,
+            eilenberg_moore_adj_unit,,
+            ε (linear_category_bang L)).
+  Proof.
+    split.
+    - exact (λ x, pr12 x).
+    - intro x.
+      use eq_mor_co_eilenberg_moore.
+      cbn.
+      refine (assoc' _ _ _ @ _).
+      refine (id_left _ @ _).
+      exact (Comonad_law2 (T := linear_category_bang L) x).
+  Qed.
+
+  Definition eilenberg_moore_cmd_adj
+    : adjunction
+    (full_subcat (dialgebra (functor_identity (pr1 L)) (linear_category_bang L))
+       mon_cat_co_eilenberg_moore_extra_condition) L.
+  Proof.
+    use make_adjunction.
+    - simple refine (_ ,, _ ,, _ ,, _).
+      + exact eilenberg_moore_forget.
+      + exact eilenberg_moore_cofree.
+      + exact eilenberg_moore_adj_unit.
+      + exact (ε (linear_category_bang L)).
+    - exact eilenberg_moore_cmd_form_adj.
+  Defined.
+
+End CofreeAdjunction.

--- a/UniMath/Semantics/LinearLogic/LinearToLinearNonLinear.v
+++ b/UniMath/Semantics/LinearLogic/LinearToLinearNonLinear.v
@@ -1,0 +1,489 @@
+(*
+In this file, we show how any linear category induces a linear non linear model.
+This boils down to proving how the eilenberg moore category of the (symmetric monoidal) comonad, given by a linear category, is cartesian monoidal.
+*)
+
+Require Import UniMath.MoreFoundations.All.
+Require Import UniMath.CategoryTheory.Core.Prelude.
+Require Import UniMath.CategoryTheory.Adjunctions.Core.
+Require Import UniMath.CategoryTheory.whiskering.
+Require Import UniMath.CategoryTheory.Monads.Comonads.
+Require Import UniMath.CategoryTheory.Monoidal.WhiskeredBifunctors.
+Require Import UniMath.CategoryTheory.Monoidal.Categories.
+Require Import UniMath.CategoryTheory.Monoidal.Functors.
+Require Import UniMath.CategoryTheory.Monoidal.Adjunctions.
+Require Import UniMath.CategoryTheory.Monoidal.FunctorCategories.
+Require Import UniMath.CategoryTheory.Monoidal.Structure.Cartesian.
+Require Import UniMath.CategoryTheory.Monoidal.Structure.Symmetric.
+Require Import UniMath.CategoryTheory.Monoidal.Structure.Closed.
+
+Require Import UniMath.CategoryTheory.DisplayedCats.Core.
+Require Import UniMath.CategoryTheory.DisplayedCats.Constructions.
+Require Import UniMath.CategoryTheory.categories.Dialgebras.
+
+Require Import UniMath.CategoryTheory.Monoidal.Displayed.WhiskeredDisplayedBifunctors.
+Require Import UniMath.CategoryTheory.Monoidal.Displayed.Monoidal.
+
+Require Import UniMath.CategoryTheory.Monoidal.Comonoids.Category.
+Require Import UniMath.CategoryTheory.Monoidal.Comonoids.MonoidalCartesianBuilder.
+
+Require Import UniMath.CategoryTheory.categories.CoEilenbergMoore.
+Require Import UniMath.CategoryTheory.Monoidal.Examples.SymmetricMonoidalCoEilenbergMoore.
+
+Require Import UniMath.Semantics.LinearLogic.LinearCategory.
+Require Import UniMath.Semantics.LinearLogic.LinearNonLinear.
+
+Import MonoidalNotations.
+
+Local Open Scope cat.
+Local Open Scope moncat.
+
+Import ComonoidNotations.
+
+Section ConstructionOfComonoidsInLinearCategory.
+
+  Context {L : linear_category}.
+  Context (B : comonoid L) (a : L) (i : L⟦a,B⟧) (r : L⟦B,a⟧) (ir : is_retraction i r).
+  Context (p : i · δ_{B} · (r #⊗ r) · (i #⊗ i) = i · δ_{B}).
+
+  Definition comonoid_comult_data_in_linear_category
+    : L⟦a, a ⊗ a⟧.
+  Proof.
+    exact (i · δ_{B} · r #⊗ r).
+  Defined.
+
+  Definition comonoid_counit_data_in_linear_category
+    : L⟦a, monoidal_unit L⟧.
+  Proof.
+    exact (i · ε_{B}).
+  Defined.
+
+  Definition comonoid_data_in_linear_category
+    : disp_cat_of_comonoids_data L a.
+  Proof.
+    split.
+    - exact comonoid_comult_data_in_linear_category.
+    - exact comonoid_counit_data_in_linear_category.
+  Defined.
+
+  Local Lemma diagram_1
+    : i · δ_{B} · (r #⊗ r) · (i #⊗ identity a) = i · δ_{B} · identity (pr1 B) #⊗ r.
+  Proof.
+    etrans.
+    2: {
+      apply maponpaths_2.
+      exact p.
+    }
+    rewrite ! assoc'.
+    do 3 apply maponpaths.
+    rewrite <- tensor_comp_mor.
+    rewrite id_right.
+    apply maponpaths.
+    apply pathsinv0, ir.
+  Qed.
+
+  Local Lemma diagram_2
+    : i · δ_{B} · (r #⊗ r) · (identity a #⊗ i) = i · δ_{B} · r #⊗ identity (pr1 B).
+  Proof.
+    etrans.
+    2: {
+      apply maponpaths_2.
+      exact p.
+    }
+    rewrite ! assoc'.
+    do 3 apply maponpaths.
+    rewrite <- tensor_comp_mor.
+    rewrite id_right.
+    apply maponpaths_2.
+    apply pathsinv0, ir.
+  Qed.
+
+  Lemma comonoid_laws_unit_left_in_linear_category
+    : comonoid_laws_unit_left L (a,, comonoid_data_in_linear_category).
+  Proof.
+    unfold comonoid_laws_unit_left.
+    cbn.
+    unfold comonoid_comult_data_in_linear_category.
+
+    etrans. {
+      apply maponpaths_2.
+      unfold comonoid_counit_data_in_linear_category.
+      rewrite tensor_mor_right.
+      rewrite tensor_comp_id_r.
+      rewrite assoc.
+      apply maponpaths_2.
+      apply diagram_1.
+    }
+
+    etrans. {
+      apply maponpaths_2.
+      rewrite assoc'.
+      apply maponpaths.
+      apply tensor_swap'.
+    }
+
+    etrans. {
+      rewrite assoc'.
+      apply maponpaths.
+      rewrite assoc'.
+      apply maponpaths.
+      apply tensor_lunitor.
+    }
+
+    etrans. {
+      rewrite assoc'.
+      apply maponpaths.
+      rewrite ! assoc.
+      apply maponpaths_2.
+      rewrite <- tensor_mor_right.
+      apply comonoid_to_law_unit_left.
+    }
+    rewrite id_left.
+    exact ir.
+  Qed.
+
+  Lemma comonoid_laws_unit_right_in_linear_category
+    : comonoid_laws_unit_right L (a,, comonoid_data_in_linear_category).
+  Proof.
+    unfold comonoid_laws_unit_right.
+    cbn.
+    unfold comonoid_comult_data_in_linear_category.
+
+    etrans. {
+      apply maponpaths_2.
+      unfold comonoid_counit_data_in_linear_category.
+      rewrite tensor_mor_left.
+      rewrite tensor_comp_id_l.
+      rewrite assoc.
+      apply maponpaths_2.
+      apply diagram_2.
+    }
+
+    etrans. {
+      apply maponpaths_2.
+      rewrite assoc'.
+      apply maponpaths.
+      apply tensor_swap.
+    }
+
+    etrans. {
+      rewrite assoc'.
+      apply maponpaths.
+      rewrite assoc'.
+      apply maponpaths.
+      apply tensor_runitor.
+    }
+
+    etrans. {
+      rewrite assoc'.
+      apply maponpaths.
+      rewrite ! assoc.
+      apply maponpaths_2.
+      rewrite <- tensor_mor_left.
+      apply comonoid_to_law_unit_right.
+    }
+    rewrite id_left.
+    exact ir.
+  Qed.
+
+  Lemma comonoid_laws_assoc_in_linear_category
+    : comonoid_laws_assoc L (a,, comonoid_data_in_linear_category).
+  Proof.
+    unfold comonoid_laws_assoc.
+    cbn.
+    unfold comonoid_comult_data_in_linear_category.
+    (* page 155 *)
+  Admitted.
+
+  Definition comonoid_in_linear_category
+    : disp_cat_of_comonoids L a.
+  Proof.
+    simple refine (_ ,, _ ,, _ ,, _).
+    - exact comonoid_data_in_linear_category.
+    - exact comonoid_laws_unit_left_in_linear_category.
+    - exact comonoid_laws_unit_right_in_linear_category.
+    - exact comonoid_laws_assoc_in_linear_category.
+  Defined.
+
+  Definition comonoid_mor_in_linear_category
+    : comonoid_mor_struct L (a,,comonoid_in_linear_category) B i.
+  Proof.
+    use make_is_comonoid_mor.
+    - exact p.
+    - apply id_right.
+  Qed.
+
+End ConstructionOfComonoidsInLinearCategory.
+
+Section ConstructionOfComonoidsInEilenbergMoore.
+
+  Context (L : linear_category).
+
+  Let EM := (@sym_monoidal_cat_co_eilenberg_moore _ _ _ (linear_category_bang L)).
+
+  Let bang : sym_monoidal_cmd L
+      := linear_category_bang L.
+
+  Context (xx : EM).
+  Let x : L := pr11 xx.
+  Let hx : L⟦x, bang x⟧ := pr21 xx.
+
+  Let comonoid_on_bang_x := linear_category_cocommutative_comonoid L x.
+
+  Lemma linear_category_comult_factors_through_comult_bang
+    :  δ (linear_category_bang L) x
+         · (linear_category_comult L (bang x)
+              · ε bang (bang x) #⊗ ε bang (bang x))
+       = linear_category_comult L x.
+  Proof.
+    rewrite assoc.
+    etrans. {
+      apply maponpaths_2.
+      apply linear_category_counit_comonoid_mor_comult.
+    }
+    rewrite assoc'.
+    rewrite <- tensor_comp_mor.
+    refine (_ @ id_right _).
+    apply maponpaths.
+    rewrite <- tensor_id_id.
+    use two_arg_paths ; apply Comonad_law1.
+  Qed.
+
+  Lemma yank
+    : hx · δ_{comonoid_on_bang_x} · ε bang x #⊗ ε bang x · hx #⊗ hx
+      = hx · δ_{comonoid_on_bang_x}.
+  Proof.
+    cbn.
+    set (t := pr22 xx).
+    cbn in t.
+
+    etrans. {
+      rewrite assoc'.
+      apply maponpaths.
+      rewrite <- tensor_comp_mor.
+      apply maponpaths.
+      apply pathsinv0.
+      apply (pr2 (disp_ε _) _ _ hx).
+    }
+    etrans. {
+      apply maponpaths.
+      apply maponpaths_2.
+      apply pathsinv0.
+      apply (pr2 (disp_ε _) _ _ hx).
+    }
+
+    rewrite tensor_comp_mor.
+    rewrite assoc.
+    etrans. {
+      apply maponpaths_2.
+      rewrite assoc'.
+      apply maponpaths.
+      apply pathsinv0.
+      apply linear_category_comult_nat.
+    }
+    rewrite assoc.
+    etrans. {
+      do 2 apply maponpaths_2.
+      apply pathsinv0, (pr22 xx).
+    }
+
+    rewrite ! assoc'.
+    apply maponpaths.
+    exact linear_category_comult_factors_through_comult_bang.
+  Qed.
+
+  Let comonoid_on_x
+    : disp_cat_of_comonoids L x
+      := comonoid_in_linear_category comonoid_on_bang_x x hx (ε bang x) (pr12 xx) yank.
+
+  Lemma comonoid_comult_is_coalgebra_mor
+    : hx · # ((linear_category_bang L)) δ_{(x,, comonoid_on_x) : comonoid L}
+      = δ_{(x,, comonoid_on_x) : comonoid L}
+          · MonoidalDialgebras.dialgebra_disp_tensor_op (identity_fmonoidal (pr1 L))
+          (lax_monoidal_from_symmetric_monoidal_comonad L (linear_category_bang L))
+          hx hx.
+  Proof.
+    (* page 157 *)
+  Admitted.
+
+  Definition comonoid_comult_coalgebra_mor
+    : EM⟦xx, xx ⊗ xx⟧.
+  Proof.
+    use make_mor_co_eilenberg_moore.
+    - exact δ_{(x ,, comonoid_on_x) : comonoid L}.
+    - exact comonoid_comult_is_coalgebra_mor.
+  Defined.
+
+  (* The following lemma is actually an application that coalgebra morphisms are closed under composition, I c(sh)ould use this directly, however, I have to find the proof of that first (in the formalization) *)
+  Lemma comonoid_counit_is_coalgebra_mor
+    : hx · # (linear_category_bang L) ε_{ x,, comonoid_on_x : comonoid L}
+      = ε_{ x,, comonoid_on_x : comonoid L} · pr21 (constant_functor EM EM I_{ EM} xx).
+  Proof.
+    cbn.
+    unfold MonoidalDialgebras.dialgebra_disp_unit.
+    cbn.
+    rewrite id_left.
+    cbn in *.
+    unfold comonoid_counit_data_in_linear_category.
+    rewrite functor_comp.
+    rewrite assoc.
+    etrans. {
+      apply maponpaths_2.
+      apply pathsinv0.
+      exact (pr22 xx).
+    }
+
+    do 2 rewrite assoc'.
+    apply maponpaths.
+    apply pathsinv0.
+    apply linear_category_counit_coalgebra_mor.
+  Qed.
+
+  Definition comonoid_counit_coalgebra_mor
+    : EM⟦xx, monoidal_unit EM⟧.
+  Proof.
+    use make_mor_co_eilenberg_moore.
+    - exact ε_{(x ,, comonoid_on_x) : comonoid L}.
+    - exact comonoid_counit_is_coalgebra_mor.
+  Defined.
+
+  Definition comonoid_data_in_eilenberg_moore
+    : disp_cat_of_comonoids_data EM xx.
+  Proof.
+    split.
+    - exact comonoid_comult_coalgebra_mor.
+    - exact comonoid_counit_coalgebra_mor.
+  Defined.
+
+  Lemma comonoid_laws_unit_left_in_eilenberg_moore
+    : comonoid_laws_unit_left EM (xx,, comonoid_data_in_eilenberg_moore).
+  Proof.
+    use eq_mor_co_eilenberg_moore.
+    exact (comonoid_laws_unit_left_in_linear_category comonoid_on_bang_x x hx (ε bang x) (pr12 xx) yank).
+  Qed.
+
+  Lemma comonoid_laws_unit_right_in_eilenberg_moore
+    : comonoid_laws_unit_right EM (xx,, comonoid_data_in_eilenberg_moore).
+  Proof.
+    use eq_mor_co_eilenberg_moore.
+    exact (comonoid_laws_unit_right_in_linear_category comonoid_on_bang_x x hx (ε bang x) (pr12 xx) yank).
+  Qed.
+
+  Lemma comonoid_laws_assoc_in_eilenberg_moore
+    : comonoid_laws_assoc EM (xx,, comonoid_data_in_eilenberg_moore).
+  Proof.
+    use eq_mor_co_eilenberg_moore.
+    exact (comonoid_laws_assoc_in_linear_category comonoid_on_bang_x x hx (ε bang x) (pr12 xx) yank).
+  Qed.
+
+  Definition comonoid_in_eilenberg_moore
+    : disp_cat_of_comonoids EM xx.
+  Proof.
+    simple refine (_ ,, _ ,, _ ,, _).
+    - exact comonoid_data_in_eilenberg_moore.
+    - exact comonoid_laws_unit_left_in_eilenberg_moore.
+    - exact comonoid_laws_unit_right_in_eilenberg_moore.
+    - exact comonoid_laws_assoc_in_eilenberg_moore.
+  Defined.
+
+End ConstructionOfComonoidsInEilenbergMoore.
+
+Section EilenbergMooreCartesian.
+
+  Context (L : linear_category).
+
+  (* naturality of the comultiplication and counit *)
+  Lemma comonoid_mor_in_eilenberg_moore
+    {x y : (@sym_monoidal_cat_co_eilenberg_moore _ _ _ (linear_category_bang L))}
+    (f : _⟦x, y⟧)
+    :  comonoid_mor_struct
+         (@sym_monoidal_cat_co_eilenberg_moore _ _ _ (linear_category_bang L))
+         (x,, comonoid_in_eilenberg_moore L x)
+         (y,, comonoid_in_eilenberg_moore L y)
+         f.
+  Proof.
+    use make_is_comonoid_mor.
+    - use eq_mor_co_eilenberg_moore.
+      cbn.
+      unfold comonoid_comult_data_in_linear_category.
+      cbn.
+      refine (_ @ assoc' _ _ _).
+      etrans.
+      2: {
+        apply maponpaths_2.
+        rewrite assoc.
+        apply maponpaths_2.
+        exact (pr21 f).
+      }
+      rewrite ! assoc'.
+      apply maponpaths.
+
+      etrans.
+      2: {
+        rewrite assoc.
+        apply maponpaths_2.
+        exact (! linear_category_comult_nat (pr11 f)).
+      }
+      rewrite ! assoc'.
+      apply maponpaths.
+      rewrite tensor_mor_right.
+      rewrite tensor_mor_left.
+      etrans. {
+        apply maponpaths.
+        apply pathsinv0.
+        apply tensor_split'.
+      }
+      refine (! tensor_comp_mor _ _ _ _ @ _).
+      refine (_ @ tensor_comp_mor _ _ _ _).
+      use two_arg_paths
+      ; apply (! pr2 (disp_ε _) _ _ (pr11 f)).
+    - use eq_mor_co_eilenberg_moore.
+      refine (_ @ assoc' _ _ _).
+      etrans.
+      2: {
+        apply maponpaths_2.
+        exact (pr21 f).
+      }
+      rewrite id_right.
+      cbn.
+      unfold comonoid_counit_data_in_linear_category.
+      rewrite assoc'.
+      apply maponpaths.
+      exact (! linear_category_counit_nat (pr11 f)).
+  Qed.
+
+  Definition linear_category_eilenberg_moore_cartesian
+    : is_cartesian (@sym_monoidal_cat_co_eilenberg_moore _ _ _ (linear_category_bang L)).
+  Proof.
+    use symm_monoidal_is_cartesian_from_comonoid.
+    - intro ; apply comonoid_in_eilenberg_moore.
+    - intro ; intros ; apply comonoid_mor_in_eilenberg_moore.
+    - use eq_mor_co_eilenberg_moore.
+      cbn.
+      unfold comonoid_counit_data_in_linear_category.
+      unfold MonoidalDialgebras.dialgebra_disp_unit.
+      cbn.
+      rewrite id_left.
+      (* the natural transformations are monoidal; page 159 *)
+      admit.
+    - intros x y.
+      (* the natural transformations are monoidal; page 159 *)
+      use eq_mor_co_eilenberg_moore.
+      cbn.
+      admit.
+  Admitted.
+
+  Definition linear_to_lnl
+    : linear_non_linear_model.
+  Proof.
+    use make_linear_non_linear_from_strong.
+    - exact (linear_category_data_to_sym_mon_closed_cat L).
+    - exact (@sym_monoidal_cat_co_eilenberg_moore _ _ _ (linear_category_bang L)).
+    - admit.
+    - exact linear_category_eilenberg_moore_cartesian.
+    - admit.
+    - admit.
+
+  Admitted.
+
+End EilenbergMooreCartesian.

--- a/UniMath/Semantics/LinearLogic/LinearToLinearNonLinear.v
+++ b/UniMath/Semantics/LinearLogic/LinearToLinearNonLinear.v
@@ -25,6 +25,7 @@ Require Import UniMath.CategoryTheory.categories.Dialgebras.
 
 Require Import UniMath.CategoryTheory.Monoidal.Displayed.WhiskeredDisplayedBifunctors.
 Require Import UniMath.CategoryTheory.Monoidal.Displayed.Monoidal.
+Require Import UniMath.CategoryTheory.Monoidal.Displayed.TotalMonoidal.
 
 Require Import UniMath.CategoryTheory.Monoidal.Comonoids.Category.
 Require Import UniMath.CategoryTheory.Monoidal.Comonoids.MonoidalCartesianBuilder.
@@ -44,26 +45,10 @@ Local Open Scope moncat.
 
 Import ComonoidNotations.
 
-Section ToBeMoved.
-
-  (* In here, I will add some accessors that need to be moved to a more appropriate place *)
-
-  Context (L : linear_category).
-
-  Definition bang_comult_is_mon_nat_trans
-    := pr1 (symmetric_monoidal_comonad_extra_laws _ (linear_category_bang L)).
-
-  Definition bang_counit_is_mon_nat_trans
-    := pr2 (symmetric_monoidal_comonad_extra_laws _ (linear_category_bang L)).
-
-End ToBeMoved.
-
-(*** **)
-
 Section ConstructionOfComonoidsInLinearCategory.
 
   Context {L : linear_category}.
-  Context (B : comonoid L) (a : L) (i : L⟦a,B⟧) (r : L⟦B,a⟧) (ir : is_retraction i r).
+  Context (B : comonoid L) {a : L} (i : L⟦a,B⟧) (r : L⟦B,a⟧) (ir : is_retraction i r).
   Context (p : i · δ_{B} · (r #⊗ r) · (i #⊗ i) = i · δ_{B}).
 
   Definition comonoid_comult_data_in_linear_category
@@ -287,28 +272,15 @@ End ConstructionOfComonoidsInLinearCategory.
 
 Section LiftingPropertyCoalgebraMorSection.
 
-  Context (L : linear_category).
-
-  Let EM := (@sym_monoidal_cat_co_eilenberg_moore _ _ _ (linear_category_bang L)).
-  Let bang : sym_monoidal_cmd L
-      := linear_category_bang L.
-
-  Context (xx aa bb : EM).
-
-  Let x : L := pr11 xx.
-  Let hx : L⟦x, bang x⟧ := pr21 xx.
-  Let a : L := pr11 aa.
-  Let ha : L⟦a, bang a⟧ := pr21 aa.
-  Let b : L := pr11 bb.
-  Let hb : L⟦b, bang b⟧ := pr21 bb.
-
-  Context (i : EM⟦aa,bb⟧) (f : L⟦x,a⟧).
-
-  Context (f_i_coalg : hx · #(linear_category_bang L) (f · pr11 i) = (f · pr11 i) · hb).
-  Context (r : L⟦b,a⟧) (ir_id : is_retraction (pr11 i) r).
-
   Lemma postcomp_with_section_reflect_coalg_mor
-    : hx · #(linear_category_bang L) f = f · ha.
+    (L : linear_category)
+    (xx aa bb : @sym_monoidal_cat_co_eilenberg_moore _ _ _ (linear_category_bang L))
+    (i : _⟦aa,bb⟧)
+    (f : L⟦pr11 xx, pr11 aa⟧)
+    (f_i_coalg : pr21 xx · #(linear_category_bang L) (f · pr11 i) = (f · pr11 i) · pr21 bb)
+    (r : L⟦pr11 bb, pr11 aa⟧)
+    (ir_id : is_retraction (pr11 i) r)
+    : pr21 xx · #(linear_category_bang L) f = f · pr21 aa.
   Proof.
     pose (p := cancel_postcomposition _ _ (#(linear_category_bang L) r) f_i_coalg).
     rewrite assoc' in p.
@@ -336,39 +308,14 @@ Section LiftingPropertyCoalgebraMorSection.
       exact ir_id.
   Qed.
 
-  (* Let ff : EM⟦xx,aa⟧.
-  Proof.
-    use make_mor_co_eilenberg_moore.
-    - exact f.
-    - exact lifting_is_coalg_mor.
-  Defined.
-  *)
-
-End LiftingPropertyCoalgebraMorSection.
-
-Section LiftingPropertyCoalgebraMorSectionCor.
-
-  Context (L : linear_category).
-
-  Let EM := (@sym_monoidal_cat_co_eilenberg_moore _ _ _ (linear_category_bang L)).
-  Let bang : sym_monoidal_cmd L
-      := linear_category_bang L.
-
-  Context {xx aa bb : EM}.
-
-  Let x : L := pr11 xx.
-  Let hx : L⟦x, bang x⟧ := pr21 xx.
-  Let a : L := pr11 aa.
-  Let ha : L⟦a, bang a⟧ := pr21 aa.
-  Let b : L := pr11 bb.
-  Let hb : L⟦b, bang b⟧ := pr21 bb.
-
-  Context {g : EM⟦xx,bb⟧} {i : EM⟦aa,bb⟧} {f : L⟦x,a⟧}.
-  Context {r : L⟦b,a⟧} (ir_id : is_retraction (pr11 i) r).
-  Context (p : f · pr11 i = pr11 g).
-
   Definition lifting_is_coalg_mor
-    : hx · #(linear_category_bang L) f = f · ha.
+    {L : linear_category}
+    {xx aa bb : (@sym_monoidal_cat_co_eilenberg_moore _ _ _ (linear_category_bang L))}
+    {g : _⟦xx,bb⟧} {i : _⟦aa,bb⟧} {f : L⟦pr11 xx, pr11 aa⟧}
+    {r : L⟦pr11 bb, pr11 aa⟧}
+    (ir_id : is_retraction (pr11 i) r)
+    (p : f · pr11 i = pr11 g)
+    : pr21 xx · #(linear_category_bang L) f = f · pr21 aa.
   Proof.
     use (postcomp_with_section_reflect_coalg_mor L xx aa bb i f _ r ir_id).
     etrans. {
@@ -383,7 +330,7 @@ Section LiftingPropertyCoalgebraMorSectionCor.
     exact (pr21 g).
   Qed.
 
-End LiftingPropertyCoalgebraMorSectionCor.
+End LiftingPropertyCoalgebraMorSection.
 
 Section TransportationFreeCoalgebraComonoid.
 
@@ -416,7 +363,7 @@ Section TransportationFreeCoalgebraComonoid.
     use two_arg_paths ; apply Comonad_law1.
   Qed.
 
-  Lemma yank
+  Local Lemma yank (* any suggestions for the name are welcome *)
     : hx · δ_{comonoid_on_bang_x} · ε bang x #⊗ ε bang x · hx #⊗ hx
       = hx · δ_{comonoid_on_bang_x}.
   Proof.
@@ -552,7 +499,6 @@ Section ConstructionOfComonoidsInEilenbergMoore.
   Let x : L := pr11 xx.
   Let hx : L⟦x, bang x⟧ := pr21 xx.
 
-  (* The following lemma is actually an application that coalgebra morphisms are closed under composition, I c(sh)ould use this directly, however, I have to find the proof of that first (in the formalization) *)
   Lemma comonoid_in_eilenberg_moore_from_coalg_counit_alg_mor
     :  hx · #bang ε_{(x,, transport_comonoid_from_free L xx) : comonoid L}
        = ε_{(x,, transport_comonoid_from_free L xx) : comonoid L}
@@ -595,11 +541,10 @@ Section ConstructionOfComonoidsInEilenbergMoore.
       use two_arg_paths ; apply (pr2 xx).
     }
 
-    use (lifting_is_coalg_mor L
+    use (lifting_is_coalg_mor
            (xx := xx)
            (aa :=  xx ⊗ xx)
            (bb := (eilenberg_moore_cofree L x : EM) ⊗ (eilenberg_moore_cofree L x : EM))
-           (* (bb := ((bang x ⊗ bang x,,_),,(_,,_))) *)
            (g := (hx · linear_category_comult L x ,, _) ,, tt)
            (i := (hx #⊗ hx,, _) ,, tt)
            (f := δ_{ x,, transport_comonoid_from_free L xx : comonoid L})
@@ -607,7 +552,7 @@ Section ConstructionOfComonoidsInEilenbergMoore.
            retr
         ).
 
-    - (* hx · linear_category_comult L x is a coalgebra morphism, because it is the composition of coalgebra morphisms *)
+    - (* (hx · linear_category_comult L x) is a coalgebra morphism, because it is the composition of coalgebra morphisms *)
       cbn.
       unfold dialgebra_disp_tensor_op.
       cbn.
@@ -727,86 +672,117 @@ Section EilenbergMooreCartesian.
       exact (! linear_category_counit_nat (pr11 f)).
   Qed.
 
+  (* Unfortunately, I'm unable to clean up this lemma.
+     If I do this, I will have to do some manipulation in
+     definition linear_category_eilenberg_moore_cartesian.
+     The purpose of this lemma is to avoid having to prove this property in that definition.
+   *)
+  Local Lemma aux
+    (x y : @sym_monoidal_cat_co_eilenberg_moore _ _ _ (linear_category_bang L))
+    :
+    identity (pr11 x ⊗ pr11 y)
+      · (pr21 x #⊗ pr21 y)
+      · fmonoidal_preservestensordata
+      (lax_monoidal_from_symmetric_monoidal_comonad _ (linear_category_bang L))
+      (pr11 x) (pr11 y)
+      · linear_category_comult L (pr11 x ⊗ pr11 y)
+      · ε (linear_category_bang L) (pr11 x ⊗ pr11 y) #⊗ ε (linear_category_bang L) (pr11 x ⊗ pr11 y)
+    = rightwhiskering_on_morphisms (pr1 L) (pr11 y) _ _
+        (pr21 x · linear_category_comult L (pr11 x) · ε (linear_category_bang L) (pr11 x) #⊗ ε (linear_category_bang L) (pr11 x))
+        · leftwhiskering_on_morphisms (pr1 L) (pr11 x ⊗ pr11 x) _ _
+        (pr21 y · linear_category_comult L (pr11 y)
+           · ε (linear_category_bang L) (pr11 y) #⊗ ε (linear_category_bang L) (pr11 y))
+  · pr11 (inner_swap sym_monoidal_cat_co_eilenberg_moore x x y y).
+  Proof.
+    Opaque SymmetricDiagonal.inner_swap. (* I do not include the file SymmetricDiagonal because this is the only place I use it *)
+
+    rewrite ! tensor_mor_right.
+    rewrite ! tensor_mor_left.
+    unfold dialgebra_disp_tensor_op.
+    cbn.
+    rewrite id_left.
+    etrans.
+    2: {
+      apply maponpaths_2.
+      apply tensor_split'.
+    }
+    etrans.
+    2: {
+      apply maponpaths_2.
+      apply pathsinv0, tensor_comp_mor.
+    }
+    etrans.
+    2: {
+      do 2 apply maponpaths_2.
+      apply pathsinv0, tensor_comp_mor.
+    }
+
+    rewrite ! assoc'.
+    apply maponpaths.
+    etrans.
+    2: {
+      apply maponpaths.
+      apply naturality_inner_swap.
+    }
+
+    etrans.
+    2: {
+      do 2 apply maponpaths.
+      etrans.
+      2: {
+        apply maponpaths.
+        refine (_ @ id_right _).
+        apply (symmetric_monoidal_comonad_extra_laws _ (linear_category_bang L)).
+      }
+      apply maponpaths_2.
+      refine (_ @ id_right _).
+      apply (symmetric_monoidal_comonad_extra_laws _ (linear_category_bang L)).
+    }
+    rewrite ! tensor_comp_mor.
+    rewrite ! assoc.
+    apply maponpaths_2.
+    refine (linear_category_comult_preserves_tensor (pr11 x) (pr11 y) @ _).
+    apply assoc.
+  Qed.
+
   Definition linear_category_eilenberg_moore_cartesian
     : is_cartesian (@sym_monoidal_cat_co_eilenberg_moore _ _ _ (linear_category_bang L)).
   Proof.
     use symm_monoidal_is_cartesian_from_comonoid.
     - intro ; apply comonoid_in_eilenberg_moore_from_coalg.
     - intro ; intros ; apply comonoid_mor_in_eilenberg_moore.
-    - use eq_mor_co_eilenberg_moore.
-      refine (assoc' _ _ _ @ _).
-      refine (id_left _ @ _).
-      apply linear_category_counit_preserves_unit.
+    - abstract (
+          use eq_mor_co_eilenberg_moore;
+          refine (assoc' _ _ _ @ _);
+          refine (id_left _ @ _);
+          apply linear_category_counit_preserves_unit).
     - intros x y.
       use eq_mor_co_eilenberg_moore.
-      Opaque SymmetricDiagonal.inner_swap.
-      cbn.
-      unfold comonoid_comult_data_in_linear_category.
-      cbn.
-      rewrite ! tensor_mor_right.
-      rewrite ! tensor_mor_left.
-      unfold dialgebra_disp_tensor_op.
-      cbn.
-      rewrite id_left.
-      etrans.
-      2: {
-        apply maponpaths_2.
-        apply tensor_split'.
-      }
-      etrans.
-      2: {
-        apply maponpaths_2.
-        apply pathsinv0, tensor_comp_mor.
-      }
-      etrans.
-      2: {
-        do 2 apply maponpaths_2.
-        apply pathsinv0, tensor_comp_mor.
-      }
-
-      rewrite ! assoc'.
-      apply maponpaths.
-      etrans.
-      2: {
-        apply maponpaths.
-        apply naturality_inner_swap.
-      }
-
-      etrans.
-      2: {
-        do 2 apply maponpaths.
-        etrans.
-        2: {
-          apply maponpaths.
-          exact (pr1 (bang_counit_is_mon_nat_trans L) (pr11 x) (pr11 y) @ id_right _).
-        }
-        apply maponpaths_2.
-        exact (pr1 (bang_counit_is_mon_nat_trans L) (pr11 x) (pr11 y) @ id_right _).
-      }
-      rewrite ! tensor_comp_mor.
-      rewrite ! assoc.
-      apply maponpaths_2.
-      refine (linear_category_comult_preserves_tensor (pr11 x) (pr11 y) @ _).
-      apply assoc.
+      apply aux.
   Qed.
 
 End EilenbergMooreCartesian.
 
 Section LinearToLNL.
 
-  Definition linear_to_lnl (L : linear_category)
-    : linear_non_linear_model.
+  Context (L : linear_category).
+
+  Local Definition em_projection
+    : fmonoidal
+        sym_monoidal_cat_co_eilenberg_moore
+        L
+        (left_adjoint (eilenberg_moore_cmd_adj L)).
   Proof.
-    use make_linear_non_linear_from_strong.
-    - exact (linear_category_data_to_sym_mon_closed_cat L).
-    - exact (@sym_monoidal_cat_co_eilenberg_moore _ _ _ (linear_category_bang L)).
-    - apply eilenberg_moore_cmd_adj.
-    - apply linear_category_eilenberg_moore_cartesian.
-    - use comp_fmonoidal.
-      + apply mon_cat_co_eilenberg_moore_base.
-      + apply TotalMonoidal.projection_fmonoidal.
-      + apply TotalMonoidal.projection_fmonoidal.
-    - intros x y.
+    use comp_fmonoidal.
+    - apply mon_cat_co_eilenberg_moore_base.
+    - apply projection_fmonoidal.
+    - apply projection_fmonoidal.
+  Defined.
+
+  Local Lemma em_projection_is_symmetric
+    : is_symmetric_monoidal_functor sym_monoidal_cat_co_eilenberg_moore L em_projection.
+  Proof.
+    intros x y.
       etrans. {
         apply maponpaths.
         apply id_right.
@@ -818,6 +794,18 @@ Section LinearToLNL.
       apply pathsinv0.
       refine (id_left _ @ _).
       apply id_left.
+  Qed.
+
+  Definition linear_to_lnl
+    : linear_non_linear_model.
+  Proof.
+    use make_linear_non_linear_from_strong.
+    - exact (linear_category_data_to_sym_mon_closed_cat L).
+    - exact (@sym_monoidal_cat_co_eilenberg_moore _ _ _ (linear_category_bang L)).
+    - apply eilenberg_moore_cmd_adj.
+    - apply linear_category_eilenberg_moore_cartesian.
+    - exact em_projection.
+    - exact em_projection_is_symmetric.
   Defined.
 
 End LinearToLNL.

--- a/UniMath/Semantics/LinearLogic/LinearToLinearNonLinear.v
+++ b/UniMath/Semantics/LinearLogic/LinearToLinearNonLinear.v
@@ -210,8 +210,58 @@ Section ConstructionOfComonoidsInLinearCategory.
     unfold comonoid_laws_assoc.
     cbn.
     unfold comonoid_comult_data_in_linear_category.
-    (* page 155 *)
-  Admitted.
+
+    rewrite tensor_mor_left.
+    rewrite tensor_mor_right.
+    rewrite ! tensor_comp_id_l.
+    rewrite ! tensor_comp_id_r.
+    rewrite ! assoc.
+
+    etrans.
+    2: {
+      do 2 apply maponpaths_2.
+      exact (! diagram_2).
+    }
+
+    etrans. {
+      do 3 apply maponpaths_2.
+      exact diagram_1.
+    }
+
+    etrans.
+    2: {
+      apply maponpaths_2.
+      rewrite assoc'.
+      apply maponpaths.
+      apply tensor_swap'.
+    }
+
+    etrans.
+    2: {
+      rewrite assoc.
+      do 2 apply maponpaths_2.
+      rewrite assoc'.
+      apply maponpaths.
+      rewrite <- tensor_mor_left.
+      apply comonoid_to_law_assoc.
+    }
+    rewrite tensor_mor_right.
+    rewrite ! assoc'.
+    do 2 apply maponpaths.
+
+    rewrite <- tensor_split'.
+    etrans.
+    2: {
+      apply maponpaths.
+      apply tensor_lassociator.
+    }
+    rewrite ! assoc.
+    apply maponpaths_2.
+    rewrite <- tensor_split.
+    do 2 rewrite <- tensor_comp_mor.
+    apply maponpaths.
+    exact (id_right _ @ ! id_left _).
+  Qed.
 
   Definition comonoid_in_linear_category
     : disp_cat_of_comonoids L a.


### PR DESCRIPTION
Every linear category is part of a linear non-linear model.
The associated cartesian (monoidal) category is the eilenberg-moore category. 
This construction has been formalized in this PR.
Some laws in the definition of a linear category were missing, these are now added. 
Consequently, a construction in LiftingModel has now become incomplete (@nmvdw ). 