### PR TITLE
Two more example of double categories

### DIFF
--- a/UniMath/Bicategories/.package/files
+++ b/UniMath/Bicategories/.package/files
@@ -185,6 +185,8 @@ DoubleCategories/Examples/UnitDoubleCat.v
 DoubleCategories/Examples/ProductDoubleCat.v
 DoubleCategories/Examples/SquareDoubleCat.v
 DoubleCategories/Examples/LensesDoubleCat.v
+DoubleCategories/Examples/SpansDoubleCat.v
+DoubleCategories/Examples/KleisliDoubleCat.v
 DoubleCategories/Examples/StructuredCospansDoubleCat.v
 DoubleCategories/Examples/StructuredCospansDoubleFunctor.v
 

--- a/UniMath/Bicategories/DoubleCategories/Examples/KleisliDoubleCat.v
+++ b/UniMath/Bicategories/DoubleCategories/Examples/KleisliDoubleCat.v
@@ -1,0 +1,207 @@
+(**********************************************************************************
+
+ The Kleisli double category
+
+ Let `C` be a category and let `M` be a monad on `C`. Then we can define the
+ following double category:
+ - Objects: objects of `C`
+ - Vertical morphisms: morphisms of `C`
+ - Horizontal morphisms: Kleisli morphisms
+ - Squares: commuting squares
+
+ Contents
+ 1. Horizontal operations
+ 2. The Kleisli double category
+
+ **********************************************************************************)
+Require Import UniMath.MoreFoundations.All.
+Require Import UniMath.CategoryTheory.Core.Categories.
+Require Import UniMath.CategoryTheory.Core.Functors.
+Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
+Require Import UniMath.CategoryTheory.Core.Isos.
+Require Import UniMath.CategoryTheory.Core.Univalence.
+Require Import UniMath.CategoryTheory.Monads.Monads.
+Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.TwoSidedDispCat.
+Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.Isos.
+Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.Univalence.
+Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.Examples.Comma.
+Require Import UniMath.Bicategories.Core.Bicat.
+Import Bicat.Notations.
+Require Import UniMath.Bicategories.Core.Examples.BicatOfUnivCats.
+Require Import UniMath.Bicategories.DoubleCategories.DoubleCategoryBasics.
+Require Import UniMath.Bicategories.DoubleCategories.DoubleCats.
+
+Local Open Scope cat.
+
+(**
+ 1. Horizontal operations
+ *)
+Section Kleisli.
+  Context {C : univalent_category}
+          (M : Monad C).
+
+  Let K : twosided_disp_cat C C := comma_twosided_disp_cat (functor_identity C) M.
+
+  Definition hor_id_data_kleisli
+    : hor_id_data K.
+  Proof.
+    use make_hor_id_data ; cbn.
+    - exact (λ x, η M x).
+    - abstract
+        (intros x y f ; cbn ;
+         exact (nat_trans_ax (η M) _ _ f)).
+  Defined.
+
+  Proposition hor_id_laws_kleisli
+    : hor_id_laws hor_id_data_kleisli.
+  Proof.
+    repeat split ; intros.
+    - apply homset_property.
+    - apply homset_property.
+  Qed.
+
+  Definition hor_id_kleisli
+    : hor_id K.
+  Proof.
+    use make_hor_id.
+    - exact hor_id_data_kleisli.
+    - exact hor_id_laws_kleisli.
+  Defined.
+
+  Definition hor_comp_data_kleisli
+    : hor_comp_data K.
+  Proof.
+    use make_hor_comp_data.
+    - exact (λ x y z f g, f · #M g · μ M z).
+    - abstract
+        (intros x₁ x₂ y₁ y₂ z₁ z₂ v₁ v₂ v₃ h₁ h₂ k₁ k₂ s₁ s₂ ; cbn in * ;
+         rewrite !assoc ;
+         rewrite s₁ ;
+         rewrite !assoc' ;
+         apply maponpaths ;
+         rewrite !assoc ;
+         rewrite <- functor_comp ;
+         rewrite s₂ ;
+         rewrite functor_comp ;
+         rewrite !assoc' ;
+         apply maponpaths ;
+         exact (nat_trans_ax (μ M) _ _ v₃)).
+  Defined.
+
+  Definition hor_comp_laws_kleisli
+    : hor_comp_laws hor_comp_data_kleisli.
+  Proof.
+    repeat split ; intros.
+    - apply homset_property.
+    - apply homset_property.
+  Qed.
+
+  Definition hor_comp_kleisli
+    : hor_comp K.
+  Proof.
+    use make_hor_comp.
+    - exact hor_comp_data_kleisli.
+    - exact hor_comp_laws_kleisli.
+  Defined.
+
+  Definition double_cat_lunitor_kleisli
+    : double_cat_lunitor
+        hor_id_kleisli
+        hor_comp_kleisli.
+  Proof.
+    use make_double_lunitor.
+    - intros x y f ; cbn.
+      use make_iso_twosided_disp.
+      + cbn.
+        rewrite id_left.
+        rewrite functor_id.
+        rewrite id_right.
+        refine (!_).
+        etrans.
+        {
+          apply maponpaths_2.
+          exact (!(nat_trans_ax (η M) _ _ f)).
+        }
+        cbn.
+        rewrite !assoc'.
+        refine (_ @ id_right _).
+        apply maponpaths.
+        apply Monad_law1.
+      + apply comma_twosided_disp_cat_is_iso.
+    - intro ; intros.
+      apply homset_property.
+  Qed.
+
+  Definition double_cat_runitor_kleisli
+    : double_cat_runitor
+        hor_id_kleisli
+        hor_comp_kleisli.
+  Proof.
+    use make_double_runitor.
+    - intros x y f ; cbn.
+      use make_iso_twosided_disp.
+      + cbn.
+        rewrite id_left.
+        rewrite functor_id.
+        rewrite id_right.
+        refine (!_).
+        rewrite !assoc'.
+        refine (_ @ id_right _).
+        apply maponpaths.
+        apply Monad_law2.
+      + apply comma_twosided_disp_cat_is_iso.
+    - intro ; intros.
+      apply homset_property.
+  Qed.
+
+  Definition double_cat_associator_kleisli
+    : double_cat_associator hor_comp_kleisli.
+  Proof.
+    use make_double_associator.
+    - intros w x y z h₁ h₂ h₃ ; cbn.
+      use make_iso_twosided_disp.
+      + cbn.
+        rewrite id_left.
+        rewrite functor_id.
+        rewrite id_right.
+        rewrite !assoc'.
+        apply maponpaths.
+        rewrite !functor_comp.
+        rewrite !assoc'.
+        apply maponpaths.
+        rewrite !assoc.
+        etrans.
+        {
+          apply maponpaths_2.
+          exact (!(nat_trans_ax (μ M) _ _ h₃)).
+        }
+        cbn.
+        rewrite !assoc'.
+        apply maponpaths.
+        refine (!_).
+        apply Monad_law3.
+      + apply comma_twosided_disp_cat_is_iso.
+    - intro ; intros.
+      apply homset_property.
+  Qed.
+
+  (**
+   2. The Kleisli double category
+   *)
+  Definition kleisli_double_cat
+    : double_cat.
+  Proof.
+    use make_double_cat.
+    - exact C.
+    - exact K.
+    - exact hor_id_kleisli.
+    - exact hor_comp_kleisli.
+    - exact double_cat_lunitor_kleisli.
+    - exact double_cat_runitor_kleisli.
+    - exact double_cat_associator_kleisli.
+    - abstract (intro ; intros ; apply homset_property).
+    - abstract (intro ; intros ; apply homset_property).
+    - apply univalent_category_is_univalent.
+    - apply is_univalent_comma_twosided_disp_cat.
+  Defined.
+End Kleisli.

--- a/UniMath/Bicategories/DoubleCategories/Examples/SpansDoubleCat.v
+++ b/UniMath/Bicategories/DoubleCategories/Examples/SpansDoubleCat.v
@@ -8,7 +8,7 @@
  - Vertical morphisms: morphisms in `C`
  - Horizontal morphisms: spans in `C`
  - Squares: morphisms of spans
- Spans are compose by taking a pullback.
+ Spans are composed by taking a pullback.
 
  Contents
  1. Horizontal identities

--- a/UniMath/Bicategories/DoubleCategories/Examples/SpansDoubleCat.v
+++ b/UniMath/Bicategories/DoubleCategories/Examples/SpansDoubleCat.v
@@ -1,0 +1,392 @@
+(**********************************************************************************
+
+ The double category of spans
+
+ In this file, we define the double category of spans. If `C` is a category with
+ pullbacks, then we have the following double category:
+ - Objects: objects in `C`
+ - Vertical morphisms: morphisms in `C`
+ - Horizontal morphisms: spans in `C`
+ - Squares: morphisms of spans
+ Spans are compose by taking a pullback.
+
+ Contents
+ 1. Horizontal identities
+ 2. Horizontal composition
+ 3. The unitors and associators
+ 4. The triangle and pentagon equations
+ 5. The double category of spans
+
+ **********************************************************************************)
+Require Import UniMath.MoreFoundations.All.
+Require Import UniMath.CategoryTheory.Core.Categories.
+Require Import UniMath.CategoryTheory.Core.Functors.
+Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
+Require Import UniMath.CategoryTheory.Core.Isos.
+Require Import UniMath.CategoryTheory.Core.Univalence.
+Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.TwoSidedDispCat.
+Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.DisplayedFunctor.
+Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.Isos.
+Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.Univalence.
+Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.Examples.Spans.
+Require Import UniMath.CategoryTheory.limits.pullbacks.
+Require Import UniMath.Bicategories.Core.Bicat.
+Import Bicat.Notations.
+Require Import UniMath.Bicategories.Core.Examples.BicatOfUnivCats.
+Require Import UniMath.Bicategories.DoubleCategories.DoubleCategoryBasics.
+Require Import UniMath.Bicategories.DoubleCategories.DoubleFunctor.Basics.
+Require Import UniMath.Bicategories.DoubleCategories.DoubleCats.
+
+Local Open Scope cat.
+
+Section SpansDoubleCat.
+  Context {C : univalent_category}
+          (PC : Pullbacks C).
+
+  (**
+   1. Horizontal identities
+   *)
+  Definition spans_double_cat_hor_id_data
+    : hor_id_data (twosided_disp_cat_of_spans C).
+  Proof.
+    use make_hor_id_data.
+    - exact (id_span C).
+    - exact (λ x y f, id_span_mor C f).
+  Defined.
+
+  Proposition spans_double_cat_hor_id_laws
+    : hor_id_laws spans_double_cat_hor_id_data.
+  Proof.
+    split.
+    - intros a.
+      use span_sqr_eq ; cbn.
+      apply idpath.
+    - intros a₁ a₂ a₃ f g.
+      use span_sqr_eq ; cbn.
+      apply idpath.
+  Qed.
+
+  Definition spans_double_cat_hor_id
+    : hor_id (twosided_disp_cat_of_spans C).
+  Proof.
+    use make_hor_id.
+    - exact spans_double_cat_hor_id_data.
+    - exact spans_double_cat_hor_id_laws.
+  Defined.
+
+  (**
+   2. Horizontal composition
+   *)
+  Definition spans_double_cat_hor_comp_data
+    : hor_comp_data (twosided_disp_cat_of_spans C).
+  Proof.
+    use make_hor_comp_data.
+    - exact (λ a₁ a₂ a₃ s t, comp_span C PC s t).
+    - exact (λ _ _ _ _ _ _ _ _ _ _ _ _ _ s₁ s₂, comp_span_mor C PC s₁ s₂).
+  Defined.
+
+  Proposition spans_double_cat_hor_comp_laws
+    : hor_comp_laws spans_double_cat_hor_comp_data.
+  Proof.
+    split.
+    - intros a₁ a₂ a₃ h₁ h₂.
+      use span_sqr_eq.
+      use (MorphismsIntoPullbackEqual (isPullback_Pullback (PC _ _ _ _ _))) ; cbn.
+      + unfold mor_of_comp_span_mor.
+        rewrite PullbackArrow_PullbackPr1 ; cbn.
+        rewrite id_left, id_right.
+        apply idpath.
+      + unfold mor_of_comp_span_mor.
+        rewrite PullbackArrow_PullbackPr2 ; cbn.
+        rewrite id_left, id_right.
+        apply idpath.
+    - intros.
+      use span_sqr_eq.
+      use (MorphismsIntoPullbackEqual (isPullback_Pullback (PC _ _ _ _ _))) ; cbn.
+      + rewrite !assoc'.
+        unfold mor_of_comp_span_mor.
+        rewrite !PullbackArrow_PullbackPr1 ; cbn.
+        rewrite !assoc.
+        rewrite !PullbackArrow_PullbackPr1.
+        rewrite !assoc'.
+        apply idpath.
+      + rewrite !assoc'.
+        unfold mor_of_comp_span_mor.
+        rewrite !PullbackArrow_PullbackPr2 ; cbn.
+        rewrite !assoc.
+        rewrite !PullbackArrow_PullbackPr2.
+        rewrite !assoc'.
+        apply idpath.
+  Qed.
+
+  Definition spans_double_cat_hor_comp
+    : hor_comp (twosided_disp_cat_of_spans C).
+  Proof.
+    use make_hor_comp.
+    - exact spans_double_cat_hor_comp_data.
+    - exact spans_double_cat_hor_comp_laws.
+  Defined.
+
+  (**
+   3. The unitors and associators
+   *)
+  Definition spans_double_cat_lunitor_data
+    : double_lunitor_data
+        spans_double_cat_hor_id
+        spans_double_cat_hor_comp.
+  Proof.
+    intros x y h.
+    simple refine (_ ,, _).
+    - exact (span_lunitor C PC h).
+    - use is_iso_twosided_disp_span_sqr ; cbn.
+      apply is_z_iso_span_lunitor_mor.
+  Defined.
+
+  Proposition spans_double_cat_lunitor_laws
+    : double_lunitor_laws spans_double_cat_lunitor_data.
+  Proof.
+    intros x₁ x₂ y₁ y₂ h₁ h₂ v₁ v₂ sq.
+    use span_sqr_eq.
+    rewrite transportb_disp_mor2_span ; cbn.
+    unfold span_lunitor_mor, mor_of_comp_span_mor.
+    rewrite PullbackArrow_PullbackPr2.
+    apply idpath.
+  Qed.
+
+  Definition spans_double_cat_lunitor
+    : double_cat_lunitor
+        spans_double_cat_hor_id
+        spans_double_cat_hor_comp.
+  Proof.
+    use make_double_lunitor.
+    - exact spans_double_cat_lunitor_data.
+    - exact spans_double_cat_lunitor_laws.
+  Defined.
+
+  Definition spans_double_cat_runitor_data
+    : double_runitor_data
+        spans_double_cat_hor_id
+        spans_double_cat_hor_comp.
+  Proof.
+    intros x y h.
+    simple refine (_ ,, _).
+    - exact (span_runitor C PC h).
+    - use is_iso_twosided_disp_span_sqr ; cbn.
+      apply is_z_iso_span_runitor_mor.
+  Defined.
+
+  Proposition spans_double_cat_runitor_laws
+    : double_runitor_laws spans_double_cat_runitor_data.
+  Proof.
+    intros x₁ x₂ y₁ y₂ h₁ h₂ v₁ v₂ sq.
+    use span_sqr_eq.
+    rewrite transportb_disp_mor2_span ; cbn.
+    unfold span_runitor_mor, mor_of_comp_span_mor.
+    rewrite PullbackArrow_PullbackPr1.
+    apply idpath.
+  Qed.
+
+  Definition spans_double_cat_runitor
+    : double_cat_runitor
+        spans_double_cat_hor_id
+        spans_double_cat_hor_comp.
+  Proof.
+    use make_double_runitor.
+    - exact spans_double_cat_runitor_data.
+    - exact spans_double_cat_runitor_laws.
+  Defined.
+
+  Definition spans_double_cat_associator_data
+    : double_associator_data spans_double_cat_hor_comp.
+  Proof.
+    intros w x y z h₁ h₂ h₃.
+    simple refine (_ ,, _).
+    - exact (span_associator C PC h₁ h₂ h₃).
+    - use is_iso_twosided_disp_span_sqr ; cbn.
+      apply is_z_iso_span_associator_mor.
+  Defined.
+
+  Proposition spans_double_cat_associator_laws
+    : double_associator_laws spans_double_cat_associator_data.
+  Proof.
+    intros w₁ w₂ x₁ x₂ y₁ y₂ z₁ z₂ h₁ h₂ j₁ j₂ k₁ k₂ vw vx vy vz sq₁ sq₂ sq₃.
+    use span_sqr_eq.
+    rewrite transportb_disp_mor2_span ; cbn.
+    use (MorphismsIntoPullbackEqual (isPullback_Pullback (PC _ _ _ _ _))) ; cbn.
+    - rewrite !assoc'.
+      unfold span_associator_mor, mor_of_comp_span_mor ; cbn.
+      rewrite !PullbackArrow_PullbackPr1.
+      rewrite !assoc.
+      rewrite PullbackArrow_PullbackPr1.
+      unfold mor_of_comp_span_mor.
+      use (MorphismsIntoPullbackEqual (isPullback_Pullback (PC _ _ _ _ _))) ; cbn.
+      + rewrite !assoc'.
+        rewrite !PullbackArrow_PullbackPr1.
+        rewrite !assoc.
+        rewrite PullbackArrow_PullbackPr1.
+        apply idpath.
+      + rewrite !assoc'.
+        rewrite !PullbackArrow_PullbackPr2.
+        rewrite !assoc.
+        rewrite !PullbackArrow_PullbackPr2.
+        rewrite !assoc'.
+        rewrite !PullbackArrow_PullbackPr1.
+        apply idpath.
+    - rewrite !assoc'.
+      unfold span_associator_mor, mor_of_comp_span_mor ; cbn.
+      rewrite !PullbackArrow_PullbackPr2.
+      rewrite !assoc.
+      rewrite !PullbackArrow_PullbackPr2.
+      rewrite !assoc'.
+      apply maponpaths.
+      unfold mor_of_comp_span_mor.
+      rewrite !PullbackArrow_PullbackPr2.
+      apply idpath.
+  Qed.
+
+  Definition spans_double_cat_associator
+    : double_cat_associator spans_double_cat_hor_comp.
+  Proof.
+    use make_double_associator.
+    - exact spans_double_cat_associator_data.
+    - exact spans_double_cat_associator_laws.
+  Defined.
+
+  (**
+   4. The triangle and pentagon equations
+   *)
+  Proposition spans_double_cat_triangle
+    : triangle_law
+        spans_double_cat_lunitor
+        spans_double_cat_runitor
+        spans_double_cat_associator.
+  Proof.
+    intro ; intros.
+    use span_sqr_eq.
+    rewrite transportf_disp_mor2_span ; cbn.
+    use (MorphismsIntoPullbackEqual (isPullback_Pullback (PC _ _ _ _ _))) ; cbn.
+    - unfold span_associator_mor, mor_of_comp_span_mor ; cbn.
+      rewrite !assoc'.
+      rewrite !PullbackArrow_PullbackPr1.
+      rewrite !assoc.
+      rewrite PullbackArrow_PullbackPr1.
+      unfold span_runitor_mor.
+      rewrite PullbackArrow_PullbackPr1, id_right.
+      apply idpath.
+    - unfold span_associator_mor, mor_of_comp_span_mor ; cbn.
+      rewrite !assoc'.
+      rewrite !PullbackArrow_PullbackPr2.
+      rewrite !assoc.
+      rewrite PullbackArrow_PullbackPr2.
+      refine (id_right _ @ _).
+      apply idpath.
+  Qed.
+
+  Proposition spans_double_cat_pentagon
+    : pentagon_law spans_double_cat_associator.
+  Proof.
+    intro ; intros.
+    use span_sqr_eq.
+    rewrite transportb_disp_mor2_span ; cbn.
+    use (MorphismsIntoPullbackEqual (isPullback_Pullback (PC _ _ _ _ _))) ; cbn.
+    - unfold span_associator_mor, mor_of_comp_span_mor ; cbn.
+      rewrite !assoc'.
+      rewrite !PullbackArrow_PullbackPr1.
+      use (MorphismsIntoPullbackEqual (isPullback_Pullback (PC _ _ _ _ _))) ; cbn.
+      + rewrite !assoc'.
+        unfold span_associator_mor.
+        rewrite !PullbackArrow_PullbackPr1.
+        refine (!_).
+        etrans.
+        {
+          apply maponpaths.
+          refine (assoc _ _ _ @ _).
+          rewrite PullbackArrow_PullbackPr1.
+          apply idpath.
+        }
+        use (MorphismsIntoPullbackEqual (isPullback_Pullback (PC _ _ _ _ _))) ; cbn.
+        * rewrite !assoc'.
+          rewrite !PullbackArrow_PullbackPr1.
+          apply id_right.
+        * rewrite !assoc'.
+          rewrite !PullbackArrow_PullbackPr2.
+          etrans.
+          {
+            apply maponpaths.
+            refine (assoc _ _ _ @ _).
+            rewrite !PullbackArrow_PullbackPr2.
+            apply idpath.
+          }
+          rewrite !assoc.
+          rewrite !PullbackArrow_PullbackPr2.
+          rewrite !assoc'.
+          apply maponpaths.
+          rewrite !assoc.
+          rewrite !PullbackArrow_PullbackPr1.
+          apply idpath.
+      + rewrite !assoc'.
+        unfold span_associator_mor.
+        rewrite !PullbackArrow_PullbackPr2.
+        refine (!_).
+        etrans.
+        {
+          apply maponpaths.
+          refine (assoc _ _ _ @ _).
+          rewrite PullbackArrow_PullbackPr1.
+          refine (assoc _ _ _ @ _).
+          rewrite PullbackArrow_PullbackPr2.
+          apply idpath.
+        }
+        rewrite !assoc.
+        rewrite !PullbackArrow_PullbackPr2.
+        rewrite !assoc'.
+        apply maponpaths.
+        rewrite !assoc.
+        rewrite PullbackArrow_PullbackPr1.
+        rewrite PullbackArrow_PullbackPr2.
+        apply idpath.
+    - unfold span_associator_mor, mor_of_comp_span_mor.
+      rewrite !assoc'.
+      rewrite !PullbackArrow_PullbackPr2.
+      rewrite !assoc.
+      rewrite !PullbackArrow_PullbackPr2.
+      rewrite !assoc'.
+      refine (!_).
+      etrans.
+      {
+        apply maponpaths.
+        refine (assoc _ _ _ @ _).
+        rewrite PullbackArrow_PullbackPr2.
+        apply idpath.
+      }
+      rewrite !assoc.
+      unfold span_sqr_ob_mor ; cbn.
+      rewrite id_right.
+      rewrite PullbackArrow_PullbackPr2.
+      unfold span_associator_mor .
+      rewrite !assoc'.
+      rewrite PullbackArrow_PullbackPr2.
+      apply idpath.
+  Qed.
+
+  (**
+   5. The double category of spans
+   *)
+  Definition spans_double_cat
+    : double_cat.
+  Proof.
+    use make_double_cat.
+    - exact C.
+    - exact (twosided_disp_cat_of_spans C).
+    - exact spans_double_cat_hor_id.
+    - exact spans_double_cat_hor_comp.
+    - exact spans_double_cat_lunitor.
+    - exact spans_double_cat_runitor.
+    - exact spans_double_cat_associator.
+    - exact spans_double_cat_triangle.
+    - exact spans_double_cat_pentagon.
+    - apply univalent_category_is_univalent.
+    - use is_univalent_spans_twosided_disp_cat.
+      apply univalent_category_is_univalent.
+  Defined.
+End SpansDoubleCat.

--- a/UniMath/CONTENTS.md
+++ b/UniMath/CONTENTS.md
@@ -821,6 +821,8 @@ The packages and files are listed here in logical order: each file depends only 
    - [DoubleCategories/Examples/ProductDoubleCat.v](Bicategories/DoubleCategories/Examples/ProductDoubleCat.v)
    - [DoubleCategories/Examples/SquareDoubleCat.v](Bicategories/DoubleCategories/Examples/SquareDoubleCat.v)
    - [DoubleCategories/Examples/LensesDoubleCat.v](Bicategories/DoubleCategories/Examples/LensesDoubleCat.v)
+   - [DoubleCategories/Examples/SpansDoubleCat.v](Bicategories/DoubleCategories/Examples/SpansDoubleCat.v)
+   - [DoubleCategories/Examples/KleisliDoubleCat.v](Bicategories/DoubleCategories/Examples/KleisliDoubleCat.v)
    - [DoubleCategories/Examples/StructuredCospansDoubleCat.v](Bicategories/DoubleCategories/Examples/StructuredCospansDoubleCat.v)
    - [DoubleCategories/Examples/StructuredCospansDoubleFunctor.v](Bicategories/DoubleCategories/Examples/StructuredCospansDoubleFunctor.v)
    - [PseudoFunctors/Examples/ChangeOfBaseEnriched.v](Bicategories/PseudoFunctors/Examples/ChangeOfBaseEnriched.v)

--- a/UniMath/CategoryTheory/TwoSidedDisplayedCats/Examples/Spans.v
+++ b/UniMath/CategoryTheory/TwoSidedDisplayedCats/Examples/Spans.v
@@ -3,11 +3,19 @@
  The two-sided displayed category of spans
 
  A span in a category `C` is a diagram `x₁ <-- y --> x₂`. We construct a two-sided
- displayed category whose displayed objects are spans.
+ displayed category whose displayed objects are spans. We also give the spans that
+ are necessary to construct the double category of spans.
 
  Contents
  1. The definition
  2. The univalence
+ 3. Builders and accessors
+ 4. Isomorphisms of spans
+ 5. The identity spans
+ 6. The composition of spans
+ 7. The left unitor of spans
+ 8. The right unitor of spans
+ 9. The associator of spans
 
  **********************************************************************************)
 Require Import UniMath.Foundations.All.
@@ -16,6 +24,7 @@ Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.Core.Functors.
 Require Import UniMath.CategoryTheory.Core.Isos.
 Require Import UniMath.CategoryTheory.Core.Univalence.
+Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
 Require Import UniMath.CategoryTheory.DisplayedCats.Constructions.
 Require Import UniMath.CategoryTheory.DisplayedCats.Isos.
@@ -32,9 +41,7 @@ Local Open Scope cat.
 Section Spans.
   Context (C : category).
 
-  (**
-   1. The definition
-   *)
+  (** * 1. The definition *)
   Definition spans_ob
     : twosided_disp_cat C C
     := constant_twosided_disp_cat C C C.
@@ -171,9 +178,7 @@ Section Spans.
     : twosided_disp_cat C C
     := sigma_twosided_disp_cat _ spans_mors.
 
-  (**
-   2. The univalence
-   *)
+  (** * 2. The univalence *)
   Definition is_univalent_disp_spans_mor_left
     : is_univalent_disp spans_mor_left.
   Proof.
@@ -221,4 +226,645 @@ Section Spans.
       + exact is_univalent_disp_spans_mor_left.
       + exact is_univalent_disp_spans_mor_right.
   Defined.
+
+  (** * 3. Builders and accessors *)
+  Definition span
+             (a b : C)
+    : UU
+    := twosided_disp_cat_of_spans a b.
+
+  Definition make_span
+             {a b x : C}
+             (l : x --> a)
+             (r : x --> b)
+    : span a b
+    :=  x ,, l ,, r.
+
+  Definition ob_of_span
+             {a b : C}
+             (s : span a b)
+    : C
+    := pr1 s.
+
+  Definition mor_left_of_span
+             {a b : C}
+             (s : span a b)
+    : ob_of_span s --> a
+    := pr12 s.
+
+  Definition mor_right_of_span
+             {a b : C}
+             (s : span a b)
+    : ob_of_span s --> b
+    := pr22 s.
+
+  Definition span_sqr
+             {a₁ a₂ b₁ b₂ : C}
+             (f : a₁ --> a₂)
+             (g : b₁ --> b₂)
+             (s₁ : span a₁ b₁)
+             (s₂ : span a₂ b₂)
+    : UU
+    := s₁ -->[ f ][ g ] s₂.
+
+  Definition span_laws
+             {a₁ a₂ b₁ b₂ : C}
+             (f : a₁ --> a₂)
+             (g : b₁ --> b₂)
+             (s₁ : span a₁ b₁)
+             (s₂ : span a₂ b₂)
+             (φ : ob_of_span s₁ --> ob_of_span s₂)
+    : UU
+    := (mor_left_of_span s₁ · f
+        =
+        φ · mor_left_of_span s₂)
+       ×
+       (mor_right_of_span s₁ · g
+        =
+        φ · mor_right_of_span s₂).
+
+  Definition make_span_sqr
+             {a₁ a₂ b₁ b₂ : C}
+             {f : a₁ --> a₂}
+             {g : b₁ --> b₂}
+             {s₁ : span a₁ b₁}
+             {s₂ : span a₂ b₂}
+             (φ : ob_of_span s₁ --> ob_of_span s₂)
+             (Hφ : span_laws f g _ _ φ)
+    : span_sqr f g s₁ s₂
+    := φ ,, Hφ.
+
+  Definition span_sqr_ob_mor
+             {a₁ a₂ b₁ b₂ : C}
+             {f : a₁ --> a₂}
+             {g : b₁ --> b₂}
+             {s₁ : span a₁ b₁}
+             {s₂ : span a₂ b₂}
+             (sq : span_sqr f g s₁ s₂)
+    : ob_of_span s₁ --> ob_of_span s₂
+    := pr1 sq.
+
+  Proposition span_sqr_mor_left
+              {a₁ a₂ b₁ b₂ : C}
+              {f : a₁ --> a₂}
+              {g : b₁ --> b₂}
+              {s₁ : span a₁ b₁}
+              {s₂ : span a₂ b₂}
+              (sq : span_sqr f g s₁ s₂)
+    : mor_left_of_span s₁ · f
+      =
+      span_sqr_ob_mor sq · mor_left_of_span s₂.
+  Proof.
+    exact (pr12 sq).
+  Qed.
+
+  Proposition span_sqr_mor_right
+              {a₁ a₂ b₁ b₂ : C}
+              {f : a₁ --> a₂}
+              {g : b₁ --> b₂}
+              {s₁ : span a₁ b₁}
+              {s₂ : span a₂ b₂}
+              (sq : span_sqr f g s₁ s₂)
+    : mor_right_of_span s₁ · g
+      =
+      span_sqr_ob_mor sq · mor_right_of_span s₂.
+  Proof.
+    exact (pr22 sq).
+  Qed.
+
+  Proposition span_sqr_eq
+              {a₁ a₂ b₁ b₂ : C}
+              {f : a₁ --> a₂}
+              {g : b₁ --> b₂}
+              {s₁ : span a₁ b₁}
+              {s₂ : span a₂ b₂}
+              (sq₁ sq₂ : span_sqr f g s₁ s₂)
+              (p : span_sqr_ob_mor sq₁
+                   =
+                   span_sqr_ob_mor sq₂)
+    : sq₁ = sq₂.
+  Proof.
+    use subtypePath.
+    {
+      intro.
+      apply isapropdirprod ; apply homset_property.
+    }
+    exact p.
+  Qed.
+
+  (** * 4. Isomorphisms of spans *)
+  Proposition transportf_disp_mor2_span
+              {a₁ a₂ b₁ b₂ : C}
+              {f f' : a₁ --> a₂}
+              (p : f = f')
+              {g g' : b₁ --> b₂}
+              (q : g = g')
+              {s₁ : span a₁ b₁}
+              {s₂ : span a₂ b₂}
+              (sq : span_sqr f g s₁ s₂)
+    : span_sqr_ob_mor
+        (transportf_disp_mor2
+           p
+           q
+           sq)
+      =
+      span_sqr_ob_mor sq.
+  Proof.
+    induction p, q ; cbn.
+    apply idpath.
+  Qed.
+
+  Proposition transportb_disp_mor2_span
+              {a₁ a₂ b₁ b₂ : C}
+              {f f' : a₁ --> a₂}
+              (p : f' = f)
+              {g g' : b₁ --> b₂}
+              (q : g' = g)
+              {s₁ : span a₁ b₁}
+              {s₂ : span a₂ b₂}
+              (sq : span_sqr f g s₁ s₂)
+    : span_sqr_ob_mor
+        (transportb_disp_mor2
+           p
+           q
+           sq)
+      =
+      span_sqr_ob_mor sq.
+  Proof.
+    apply transportf_disp_mor2_span.
+  Qed.
+
+  Section IsoSpan.
+    Context {a b : C}
+            {s₁ : span a b}
+            {s₂ : span a b}
+            (sq : span_sqr (identity _) (identity _) s₁ s₂)
+            (Hsq : is_z_isomorphism (span_sqr_ob_mor sq)).
+
+    Let i : z_iso (ob_of_span s₁) (ob_of_span s₂)
+      := make_z_iso _ _ Hsq.
+
+    Proposition is_iso_twosided_disp_span_sqr_inv_laws
+      : span_laws
+          (identity a) (identity b)
+          s₂ s₁
+          (inv_from_z_iso i).
+    Proof.
+      split.
+      - rewrite id_right.
+        refine (!_).
+        use z_iso_inv_on_right.
+        refine (_ @ span_sqr_mor_left sq).
+        rewrite id_right.
+        apply idpath.
+      - rewrite id_right.
+        refine (!_).
+        use z_iso_inv_on_right.
+        refine (_ @ span_sqr_mor_right sq).
+        rewrite id_right.
+        apply idpath.
+    Qed.
+
+    Definition is_iso_twosided_disp_span_sqr_inv
+      : span_sqr (identity _) (identity _) s₂ s₁.
+    Proof.
+      use make_span_sqr.
+      - exact (inv_from_z_iso i).
+      - exact is_iso_twosided_disp_span_sqr_inv_laws.
+    Defined.
+
+    Definition is_iso_twosided_disp_span_sqr
+      : is_iso_twosided_disp
+          (identity_is_z_iso _)
+          (identity_is_z_iso _)
+          sq.
+    Proof.
+      simple refine (_ ,, _ ,, _).
+      - exact is_iso_twosided_disp_span_sqr_inv.
+      - abstract
+          (use span_sqr_eq ;
+           rewrite transportb_disp_mor2_span ; cbn ;
+           exact (z_iso_inv_after_z_iso i)).
+      - abstract
+          (use span_sqr_eq ;
+           rewrite transportb_disp_mor2_span ; cbn ;
+           exact (z_iso_after_z_iso_inv i)).
+    Defined.
+  End IsoSpan.
+
+  (** * 5. The identity spans *)
+  Definition id_span
+             (a : C)
+    : span a a.
+  Proof.
+    use make_span.
+    - exact a.
+    - exact (identity _).
+    - exact (identity _).
+  Defined.
+
+  Proposition id_span_mor_laws
+              {x y : C}
+              (f : x --> y)
+    : span_laws
+        f f
+        (id_span x) (id_span y)
+        f.
+  Proof.
+    split ; cbn.
+    - rewrite id_left, id_right.
+      apply idpath.
+    - rewrite id_left, id_right.
+      apply idpath.
+  Qed.
+
+  Definition id_span_mor
+             {x y : C}
+             (f : x --> y)
+    : span_sqr f f (id_span x) (id_span y).
+  Proof.
+    use make_span_sqr.
+    - exact f.
+    - apply id_span_mor_laws.
+  Defined.
+
+  Context (PC : Pullbacks C).
+
+  (** * 6. The composition of spans *)
+  Section CompSpan.
+    Context {x y z : C}
+            (s : span x y)
+            (t : span y z).
+
+    Definition comp_span_Pullback
+      : Pullback (mor_right_of_span s) (mor_left_of_span t)
+      := PC _ _ _ (mor_right_of_span s) (mor_left_of_span t).
+
+    Definition comp_span
+      : span x z.
+    Proof.
+      use make_span.
+      - exact comp_span_Pullback.
+      - exact (PullbackPr1 _ · mor_left_of_span s).
+      - exact (PullbackPr2 _ · mor_right_of_span t).
+    Defined.
+  End CompSpan.
+
+  Section CompSpanMor.
+    Context {x₁ x₂ y₁ y₂ z₁ z₂ : C}
+            {v₁ : x₁ --> x₂} {v₂ : y₁ --> y₂} {v₃ : z₁ --> z₂}
+            {h₁ : span x₁ y₁}
+            {h₂ : span y₁ z₁}
+            {k₁ : span x₂ y₂}
+            {k₂ : span y₂ z₂}
+            (s₁ : span_sqr v₁ v₂ h₁ k₁)
+            (s₂ : span_sqr v₂ v₃ h₂ k₂).
+
+    Definition mor_of_comp_span_mor
+      : comp_span_Pullback h₁ h₂ --> comp_span_Pullback k₁ k₂.
+    Proof.
+      use PullbackArrow.
+      - exact (PullbackPr1 _ · span_sqr_ob_mor s₁).
+      - exact (PullbackPr2 _ · span_sqr_ob_mor s₂).
+      - abstract
+          (rewrite !assoc' ;
+           rewrite <- span_sqr_mor_left, <- span_sqr_mor_right ;
+           rewrite !assoc ;
+           apply maponpaths_2 ;
+           apply PullbackSqrCommutes).
+    Defined.
+
+    Proposition comp_span_mor_laws
+      : span_laws
+          v₁ v₃
+          (comp_span h₁ h₂) (comp_span k₁ k₂)
+          mor_of_comp_span_mor.
+    Proof.
+      split ; cbn.
+      - unfold mor_of_comp_span_mor.
+        rewrite !assoc.
+        rewrite PullbackArrow_PullbackPr1.
+        rewrite !assoc'.
+        apply maponpaths.
+        apply span_sqr_mor_left.
+      - unfold mor_of_comp_span_mor.
+        rewrite !assoc.
+        rewrite PullbackArrow_PullbackPr2.
+        rewrite !assoc'.
+        apply maponpaths.
+        apply span_sqr_mor_right.
+    Qed.
+
+    Definition comp_span_mor
+      : span_sqr
+          v₁ v₃
+          (comp_span h₁ h₂) (comp_span k₁ k₂).
+    Proof.
+      use make_span_sqr.
+      - exact mor_of_comp_span_mor.
+      - exact comp_span_mor_laws.
+    Defined.
+  End CompSpanMor.
+
+  (** * 7. The left unitor of spans *)
+  Section SpanLunitor.
+    Context {x y : C}
+            (h : span x y).
+
+    Definition span_lunitor_mor
+      : comp_span_Pullback (id_span x) h --> ob_of_span h
+      := PullbackPr2 _.
+
+    Definition span_linvunitor
+      : ob_of_span h --> comp_span_Pullback (id_span x) h.
+    Proof.
+      use PullbackArrow.
+      - exact (mor_left_of_span h).
+      - exact (identity _).
+      - abstract
+          (cbn ;
+           rewrite id_left, id_right ;
+           apply idpath).
+    Defined.
+
+    Proposition is_z_iso_span_lunitor_mor_eqs
+      : is_inverse_in_precat
+          span_lunitor_mor
+          span_linvunitor.
+    Proof.
+      split ; unfold span_lunitor_mor, span_linvunitor ; cbn.
+      - use (MorphismsIntoPullbackEqual (isPullback_Pullback (PC _ _ _ _ _))) ; cbn.
+        + rewrite !assoc'.
+          rewrite PullbackArrow_PullbackPr1.
+          rewrite id_left.
+          rewrite <- PullbackSqrCommutes.
+          apply id_right.
+        + rewrite !assoc'.
+          rewrite PullbackArrow_PullbackPr2.
+          rewrite id_left, id_right.
+          apply idpath.
+      - apply PullbackArrow_PullbackPr2.
+    Qed.
+
+    Definition is_z_iso_span_lunitor_mor
+      : is_z_isomorphism span_lunitor_mor.
+    Proof.
+      use make_is_z_isomorphism.
+      - exact span_linvunitor.
+      - exact is_z_iso_span_lunitor_mor_eqs.
+    Defined.
+
+    Proposition span_lunitor_laws
+      : span_laws
+          (identity x) (identity y)
+          (comp_span (id_span x) h) h
+          span_lunitor_mor.
+    Proof.
+      split ; cbn ; unfold span_lunitor_mor.
+      - rewrite !id_right.
+        rewrite <- PullbackSqrCommutes ; cbn.
+        rewrite id_right.
+        apply idpath.
+      - rewrite id_right.
+        apply idpath.
+    Qed.
+
+    Definition span_lunitor
+      : span_sqr
+          (identity _) (identity _)
+          (comp_span (id_span _) h)
+          h.
+    Proof.
+      use make_span_sqr.
+      - exact span_lunitor_mor.
+      - exact span_lunitor_laws.
+    Defined.
+  End SpanLunitor.
+
+  (** * 8. The right unitor of spans *)
+  Section SpanRunitor.
+    Context {x y : C}
+            (h : span x y).
+
+    Definition span_runitor_mor
+      : comp_span_Pullback h (id_span y) --> ob_of_span h
+      := PullbackPr1 _.
+
+    Definition span_rinvunitor
+      : ob_of_span h --> comp_span_Pullback h (id_span y).
+    Proof.
+      use PullbackArrow.
+      - exact (identity _).
+      - exact (mor_right_of_span h).
+      - abstract
+          (cbn ;
+           rewrite id_left, id_right ;
+           apply idpath).
+    Defined.
+
+    Proposition is_z_iso_span_runitor_mor_eqs
+      : is_inverse_in_precat
+          span_runitor_mor
+          span_rinvunitor.
+    Proof.
+      split ; unfold span_runitor_mor, span_rinvunitor ; cbn.
+      - use (MorphismsIntoPullbackEqual (isPullback_Pullback (PC _ _ _ _ _))) ; cbn.
+        + rewrite !assoc'.
+          rewrite PullbackArrow_PullbackPr1.
+          rewrite id_left.
+          apply id_right.
+        + rewrite !assoc'.
+          rewrite PullbackArrow_PullbackPr2.
+          rewrite id_left.
+          rewrite PullbackSqrCommutes.
+          apply id_right.
+      - apply PullbackArrow_PullbackPr1.
+    Qed.
+
+    Definition is_z_iso_span_runitor_mor
+      : is_z_isomorphism span_runitor_mor.
+    Proof.
+      use make_is_z_isomorphism.
+      - exact span_rinvunitor.
+      - exact is_z_iso_span_runitor_mor_eqs.
+    Defined.
+
+    Proposition span_runitor_laws
+      : span_laws
+          (identity x) (identity y)
+          (comp_span h (id_span y)) h
+          span_runitor_mor.
+    Proof.
+      split ; cbn ; unfold span_runitor_mor.
+      - rewrite id_right.
+        apply idpath.
+      - rewrite !id_right.
+        rewrite PullbackSqrCommutes ; cbn.
+        rewrite id_right.
+        apply idpath.
+    Qed.
+
+    Definition span_runitor
+      : span_sqr
+          (identity _) (identity _)
+          (comp_span h (id_span _))
+          h.
+    Proof.
+      use make_span_sqr.
+      - exact span_runitor_mor.
+      - exact span_runitor_laws.
+    Defined.
+  End SpanRunitor.
+
+  (** * 9. The associator of spans *)
+  Section SpanAssociator.
+    Context {w x y z : C}
+            (h₁ : span w x)
+            (h₂ : span x y)
+            (h₃ : span y z).
+
+    Definition span_associator_mor
+      : comp_span_Pullback h₁ (comp_span h₂ h₃)
+        -->
+        comp_span_Pullback (comp_span h₁ h₂) h₃.
+    Proof.
+      use PullbackArrow.
+      - use PullbackArrow.
+        + exact (PullbackPr1 _).
+        + exact (PullbackPr2 _ · PullbackPr1 _).
+        + abstract
+            (rewrite !assoc' ;
+             rewrite PullbackSqrCommutes ;
+             apply idpath).
+      - exact (PullbackPr2 _ · PullbackPr2 _).
+      - abstract
+          (cbn ;
+           rewrite !assoc ;
+           rewrite PullbackArrow_PullbackPr2 ;
+           rewrite !assoc' ;
+           rewrite PullbackSqrCommutes ;
+           apply idpath).
+    Defined.
+
+    Definition span_associator_mor_inv
+      : comp_span_Pullback (comp_span h₁ h₂) h₃
+        -->
+        comp_span_Pullback h₁ (comp_span h₂ h₃).
+    Proof.
+      use PullbackArrow.
+      - exact (PullbackPr1 _ · PullbackPr1 _).
+      - use PullbackArrow.
+        + exact (PullbackPr1 _ · PullbackPr2 _).
+        + exact (PullbackPr2 _).
+        + abstract
+            (rewrite !assoc' ;
+             rewrite PullbackSqrCommutes ;
+             apply idpath).
+      - abstract
+          (cbn ;
+           rewrite !assoc ;
+           rewrite PullbackArrow_PullbackPr1 ;
+           rewrite !assoc' ;
+           rewrite PullbackSqrCommutes ;
+           apply idpath).
+    Defined.
+
+    Proposition is_iso_span_associator_mor_eq
+      : is_inverse_in_precat
+          span_associator_mor
+          span_associator_mor_inv.
+    Proof.
+      split.
+      - use (MorphismsIntoPullbackEqual (isPullback_Pullback (PC _ _ _ _ _))) ; cbn.
+        + rewrite id_left.
+          unfold span_associator_mor_inv.
+          rewrite !assoc'.
+          rewrite PullbackArrow_PullbackPr1.
+          unfold span_associator_mor.
+          rewrite !assoc.
+          rewrite !PullbackArrow_PullbackPr1.
+          apply idpath.
+        + rewrite id_left.
+          unfold span_associator_mor_inv.
+          rewrite !assoc'.
+          rewrite PullbackArrow_PullbackPr2.
+          use (MorphismsIntoPullbackEqual (isPullback_Pullback (PC _ _ _ _ _))) ; cbn.
+          * rewrite !assoc'.
+            rewrite PullbackArrow_PullbackPr1.
+            unfold span_associator_mor.
+            rewrite !assoc.
+            rewrite PullbackArrow_PullbackPr1.
+            rewrite PullbackArrow_PullbackPr2.
+            apply idpath.
+          * rewrite !assoc'.
+            unfold span_associator_mor.
+            rewrite !PullbackArrow_PullbackPr2.
+            apply idpath.
+      - use (MorphismsIntoPullbackEqual (isPullback_Pullback (PC _ _ _ _ _))) ; cbn.
+        + rewrite id_left.
+          unfold span_associator_mor.
+          rewrite !assoc'.
+          rewrite PullbackArrow_PullbackPr1.
+          use (MorphismsIntoPullbackEqual (isPullback_Pullback (PC _ _ _ _ _))) ; cbn.
+          * rewrite !assoc'.
+            rewrite !PullbackArrow_PullbackPr1.
+            unfold span_associator_mor_inv.
+            rewrite PullbackArrow_PullbackPr1.
+            apply idpath.
+          * rewrite !assoc'.
+            rewrite !PullbackArrow_PullbackPr2.
+            unfold span_associator_mor_inv.
+            rewrite !assoc.
+            rewrite PullbackArrow_PullbackPr2.
+            rewrite PullbackArrow_PullbackPr1.
+            apply idpath.
+        + rewrite !assoc'.
+          unfold span_associator_mor.
+          rewrite PullbackArrow_PullbackPr2.
+          unfold span_associator_mor_inv.
+          rewrite !assoc.
+          rewrite !PullbackArrow_PullbackPr2.
+          rewrite id_left.
+          apply idpath.
+    Qed.
+
+    Definition is_z_iso_span_associator_mor
+      : is_z_isomorphism span_associator_mor.
+    Proof.
+      use make_is_z_isomorphism.
+      - exact span_associator_mor_inv.
+      - exact is_iso_span_associator_mor_eq.
+    Defined.
+
+    Proposition span_associator_laws
+      : span_laws
+          (identity _) (identity _)
+          (comp_span h₁ (comp_span h₂ h₃))
+          (comp_span (comp_span h₁ h₂) h₃)
+          span_associator_mor.
+    Proof.
+      split ; cbn.
+      - rewrite id_right.
+        unfold span_associator_mor.
+        rewrite !assoc.
+        rewrite !PullbackArrow_PullbackPr1.
+        apply idpath.
+      - rewrite id_right.
+        unfold span_associator_mor.
+        rewrite !assoc.
+        rewrite !PullbackArrow_PullbackPr2.
+        apply idpath.
+    Qed.
+
+    Definition span_associator
+      : span_sqr
+          (identity _) (identity _)
+          (comp_span h₁ (comp_span h₂ h₃))
+          (comp_span (comp_span h₁ h₂) h₃).
+    Proof.
+      use make_span_sqr.
+      - exact span_associator_mor.
+      - exact span_associator_laws.
+    Defined.
+  End SpanAssociator.
 End Spans.


### PR DESCRIPTION
This PR contains two more examples of double categories, namely the double category of spans and the double category whose horizontal morphisms are morphisms in the Kleisli category.