### PR TITLE
builder when displayed cat is locally propositional

### DIFF
--- a/UniMath/Bicategories/MonoidalCategories/ActionBasedStrongFunctorsWhiskeredMonoidal.v
+++ b/UniMath/Bicategories/MonoidalCategories/ActionBasedStrongFunctorsWhiskeredMonoidal.v
@@ -547,9 +547,11 @@ Section Main.
       change (montrafotargetbicat_disp w) in π.
       exact (montrafotargetbicat_tensor_comp_aux v w v' w f (identity w) η π η' π Hyp (id_disp π)).
     Qed.
+
     Definition montrafotargetbicat_disp_tensor: disp_tensor montrafotargetbicat_disp Mon_V.
     Proof.
-      use make_disp_bifunctor.
+      use make_disp_bifunctor_locally_prop.
+      - intro; intros; apply trafotargetbicat_disp_cells_isaprop.
       - use make_disp_bifunctor_data.
         + intros v w η π.
           exact (param_distr_bicat_pentagon_eq_body_variant_RHS v w η π).
@@ -559,8 +561,8 @@ Section Main.
         + cbn.
           intros v v' w f η η' π Hyp.
           apply montrafotargetbicat_tensor_comp_aux_inst2; assumption.
-      - red. repeat split; red; intros; apply trafotargetbicat_disp_cells_isaprop.
     Defined.
+
     (** the following are called data elements, but they have no computational content *)
     Lemma montrafotargetbicat_disp_leftunitor_data: disp_leftunitor_data montrafotargetbicat_disp_tensor montrafotargetbicat_disp_unit.
     Proof.
@@ -1272,19 +1274,6 @@ Section Main.
       exact lax_monoidal_functor_assoc_inst.
      Qed.
 
-    Lemma montrafotargetbicat_disp_associator_iso: disp_associator_iso montrafotargetbicat_disp_associator_data montrafotargetbicat_disp_associatorinv_data.
-    Proof.
-      intros v1 v2 v3 η1 η2 η3.
-      (** now we benefit from working in a displayed monoidal category *)
-      split; apply trafotargetbicat_disp_cells_isaprop.
-    Qed.
-
-    Lemma montrafotargetbicat_disp_associator_law: disp_associator_law montrafotargetbicat_disp_associator_data montrafotargetbicat_disp_associatorinv_data.
-    Proof.
-      (** now we benefit from working in a displayed monoidal category *)
-      repeat (split; try (red; intros; apply trafotargetbicat_disp_cells_isaprop)); try apply trafotargetbicat_disp_cells_isaprop.
-    Qed.
-
     Lemma montrafotargetbicat_disp_leftunitorinv_data: disp_leftunitorinv_data montrafotargetbicat_disp_tensor montrafotargetbicat_disp_unit.
     Proof.
       intros v η.
@@ -1381,19 +1370,6 @@ Section Main.
       apply (lhs_left_invert_cell _ _ _ (is_invertible_2cell_rassociator _ _ _)).
       cbn.
       apply pathsinv0, lunitor_triangle.
-    Qed.
-
-    Lemma montrafotargetbicat_disp_leftunitor_iso: disp_leftunitor_iso montrafotargetbicat_disp_leftunitor_data montrafotargetbicat_disp_leftunitorinv_data.
-    Proof.
-      intros v η.
-      (** now we benefit from working in a displayed monoidal category *) split; apply trafotargetbicat_disp_cells_isaprop.
-    Qed.
-
-    Lemma montrafotargetbicat_disp_leftunitor_law: disp_leftunitor_law montrafotargetbicat_disp_leftunitor_data montrafotargetbicat_disp_leftunitorinv_data.
-    Proof.
-      split.
-      - red. intros. apply trafotargetbicat_disp_cells_isaprop.
-      - exact montrafotargetbicat_disp_leftunitor_iso.
     Qed.
 
     Lemma montrafotargetbicat_disp_rightunitorinv_data: disp_rightunitorinv_data montrafotargetbicat_disp_tensor montrafotargetbicat_disp_unit.
@@ -1520,19 +1496,6 @@ Section Main.
       apply runitor_rwhisker.
     Qed.
 
-    Lemma montrafotargetbicat_disp_rightunitor_iso: disp_rightunitor_iso montrafotargetbicat_disp_rightunitor_data montrafotargetbicat_disp_rightunitorinv_data.
-    Proof.
-      intros v η.
-      (** now we benefit from working in a displayed monoidal category *) split; apply trafotargetbicat_disp_cells_isaprop.
-    Qed.
-
-    Lemma montrafotargetbicat_disp_rightunitor_law: disp_rightunitor_law montrafotargetbicat_disp_rightunitor_data montrafotargetbicat_disp_rightunitorinv_data.
-    Proof.
-      split.
-      - red. intros. apply trafotargetbicat_disp_cells_isaprop.
-      - exact montrafotargetbicat_disp_rightunitor_iso.
-    Qed.
-
     Definition montrafotargetbicat_disp_monoidal_data: disp_monoidal_data montrafotargetbicat_disp Mon_V.
     Proof.
       exists montrafotargetbicat_disp_tensor.
@@ -1547,13 +1510,9 @@ Section Main.
 
     Definition montrafotargetbicat_disp_monoidal: disp_monoidal montrafotargetbicat_disp Mon_V.
     Proof.
-      exists montrafotargetbicat_disp_monoidal_data.
-      split.
-      { exact montrafotargetbicat_disp_leftunitor_law. }
-      split; [ exact montrafotargetbicat_disp_rightunitor_law |].
-      split; [ exact montrafotargetbicat_disp_associator_law |].
-      (** now we benefit from working in a displayed monoidal category *)
-      split; red; intros; apply trafotargetbicat_disp_cells_isaprop.
+      use make_disp_monoidal_locally_prop.
+      - intro; intros; apply trafotargetbicat_disp_cells_isaprop.
+      - exact montrafotargetbicat_disp_monoidal_data.
     Defined.
 
     Definition parameterized_distributivity_bicat_nat : UU := H ⟹ H'.

--- a/UniMath/CategoryTheory/DisplayedCats/Binproducts.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Binproducts.v
@@ -483,6 +483,18 @@ Section FixDispCat.
   Definition dispTerminal (P : Terminal C) : UU :=
     ∑ pp :  D (TerminalObject P), is_dispTerminal P pp.
 
+  Definition make_dispTerminal_locally_prop (P : Terminal C)
+    (LP : locally_propositional D) (dTO_data : D (TerminalObject P))
+    (mediating : ∏ (a : C) (aa : D a), aa -->[TerminalArrow P a] dTO_data)
+    : dispTerminal P.
+  Proof.
+    exists dTO_data.
+    intro; intros.
+    use tpair.
+    - exact (mediating a aa).
+    - intro; apply LP.
+  Defined.
+
   Definition dispTerminalObject {P : Terminal C} (dP : dispTerminal P) : D (TerminalObject P) := pr1 dP.
 
   Definition is_dispTerminal_dispTerminal (P : Terminal C) (dP : dispTerminal P) :

--- a/UniMath/CategoryTheory/DisplayedCats/Binproducts.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Binproducts.v
@@ -54,6 +54,24 @@ Section FixDispCat.
                      (pp -->[BinProductPr1 _ P] cc) × (pp -->[BinProductPr2 _ P] dd)),
         is_dispBinProduct c d P cc dd (pr1 pppp1pp2) (pr1 (pr2 pppp1pp2)) (pr2 (pr2 pppp1pp2)).
 
+  Definition make_dispBinProduct_locally_prop (c d : C) (P : BinProduct C c d) (cc : D c) (dd : D d)
+    (LP : locally_propositional D)
+    (dBP_data : ∑ pp : D (BinProductObject _ P),
+          (pp -->[BinProductPr1 _ P] cc) × (pp -->[BinProductPr2 _ P] dd))
+    (mediating : ∏ (a : C) (f : a --> c) (g : a --> d) (aa : D a)
+                   (ff : aa -->[f] cc) (gg : aa -->[g] dd),
+        aa -->[ BinProductArrow C P f g] pr1 dBP_data)
+    : dispBinProduct c d P cc dd.
+  Proof.
+    exists dBP_data.
+    intro; intros.
+    use tpair.
+    - exists (mediating a f g aa ff gg).
+      abstract (split; apply LP).
+    - abstract (intro t; apply subtypePath;
+                [intro; apply isapropdirprod; apply homsets_disp | apply LP]).
+  Defined.
+
   Definition dispBinProductObject {c d : C} (P : BinProduct C c d) {cc : D c} {dd : D d}
     (dP : dispBinProduct c d P cc dd) : D (BinProductObject _ P) := pr1 (pr1 dP).
 

--- a/UniMath/CategoryTheory/DisplayedCats/Constructions.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Constructions.v
@@ -67,15 +67,19 @@ Definition disp_full_sub_data (C : precategory_data) (P : C → UU)
   : disp_cat_data C
   :=  disp_full_sub_ob_mor C P,, disp_full_sub_id_comp C P.
 
-Definition disp_full_sub_axioms (C : category) (P : C → UU)
-  : disp_cat_axioms _ (disp_full_sub_data C P).
+Lemma disp_full_sub_locally_prop (C : category) (P : C → UU) :
+  locally_propositional (disp_full_sub_data C P).
 Proof.
-  repeat split; intros; try (apply proofirrelevance; apply isapropunit).
-  apply isasetaprop; apply isapropunit.
+  intro; intros; apply isapropunit.
 Qed.
 
 Definition disp_full_sub (C : category) (P : C → UU)
-  : disp_cat C := _ ,, disp_full_sub_axioms C P.
+  : disp_cat C.
+Proof.
+  use make_disp_cat_locally_prop.
+  - exact (disp_full_sub_data C P).
+  - apply disp_full_sub_locally_prop.
+Defined.
 
 Lemma disp_full_sub_univalent (C : category) (P : C → UU) :
   (∏ x : C, isaprop (P x)) →
@@ -133,13 +137,12 @@ Qed.
 
 Definition disp_struct_data : disp_cat_data C := _ ,, disp_struct_id_comp.
 
-Definition disp_struct_axioms : disp_cat_axioms _ disp_struct_data.
+Definition disp_struct : disp_cat C.
 Proof.
-  repeat split; intros; try (apply proofirrelevance; apply Hisprop).
-  apply isasetaprop; apply Hisprop.
-Qed.
-
-Definition disp_struct : disp_cat C := _ ,, disp_struct_axioms.
+  use make_disp_cat_locally_prop.
+  - exact disp_struct_data.
+  - intro; intros; apply Hisprop.
+Defined.
 
 End struct_hom.
 

--- a/UniMath/CategoryTheory/DisplayedCats/Core.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Core.v
@@ -140,6 +140,24 @@ Definition comp_disp {C: precategory_data} {D : disp_cat_data C}
   : xx -->[f · g] zz
 := pr2 (pr2 D) _ _ _ _ _ _ _ _ ff gg.
 
+Definition locally_propositional
+           {C : category}
+           (D : disp_cat_data C)
+  : UU
+  := ∏ (x y : C)
+       (f : x --> y)
+       (xx : D x) (yy : D y),
+     isaprop (xx -->[ f ] yy).
+
+Definition isaprop_locally_propositional
+           {C : category}
+           (D : disp_cat_data C)
+  : isaprop (locally_propositional D).
+Proof.
+  do 5 (use impred ; intro).
+  apply isapropisaprop.
+Defined.
+
 Declare Scope mor_disp_scope.
 Local Notation "ff ;; gg" := (comp_disp ff gg)
   (at level 50, left associativity, format "ff  ;;  gg")
@@ -169,6 +187,17 @@ Definition disp_cat_data_from_disp_cat {C} (D : disp_cat C)
  := pr1 D : disp_cat_data C.
 Coercion disp_cat_data_from_disp_cat : disp_cat >-> disp_cat_data.
 
+Definition make_disp_cat_locally_prop
+           {C : category}
+           {D : disp_cat_data C}
+           (LP : locally_propositional D)
+  : disp_cat C.
+Proof.
+  exists D.
+  abstract (repeat split; intro; intros; try apply LP;
+            apply isasetaprop;
+            apply LP).
+Defined.
 
 (** All the axioms are given in two versions, [foo : T1 = transportb e T2] and [foo_var : T2 = transportf e T1], so that either direction can be invoked easily in “compute left-to-right” style. *)
 
@@ -220,9 +249,9 @@ Definition homsets_disp {C} {D : disp_cat C} {x y} (f : x --> y) (xx : D x) (yy 
   : isaset (xx -->[f] yy) := pr2 (pr2 (pr2 (pr2 D))) _ _ _ _ _.
 
 Definition double_transport_disp {C C':category} {D':disp_cat C'} {a b a' b':C}
-(F:functor C C') (f:a-->b)  (x:D' (F a)) (y:D' (F b)) (p:a=a') (q:b=b')  
-: x-->[#F f]y 
--> transportf (λ z, D' (F z)) p x -->[# F (double_transport p q f)] 
+(F:functor C C') (f:a-->b)  (x:D' (F a)) (y:D' (F b)) (p:a=a') (q:b=b')
+: x-->[#F f]y
+-> transportf (λ z, D' (F z)) p x -->[# F (double_transport p q f)]
      transportf (λ z, D' (F z)) q y.
 Proof.
   intro Df.
@@ -311,8 +340,8 @@ Proof.
   apply mor_disp_transportf_prewhisker.
 Qed.
 
-Lemma assoc4_disp {C: category} {D: disp_cat C} {a b c d e: C} 
-{da: D a} {db: D b} {dc: D c} {dd: D d} {de: D e} {f: a--> b} {g: b --> c} {h: c --> d} {i: d --> e} 
+Lemma assoc4_disp {C: category} {D: disp_cat C} {a b c d e: C}
+{da: D a} {db: D b} {dc: D c} {dd: D d} {de: D e} {f: a--> b} {g: b --> c} {h: c --> d} {i: d --> e}
 (df: da -->[f] db) (dg: db -->[g] dc) (dh: dc -->[h] dd) (di: dd -->[i] de)
   : df ;; dg ;; dh ;; di = transportb _ (assoc4 C  a b c d e f g h i) (df ;; (dg ;; dh) ;; di).
 Proof.
@@ -325,18 +354,18 @@ Proof.
   apply homset_property.
 Qed.
 
-Lemma id_conjugation_disp {C: category} {D: disp_cat C} {a b: C} 
-{da: D a} {db: D b} {f: a--> b} {g: b --> a} {x: b --> b} 
+Lemma id_conjugation_disp {C: category} {D: disp_cat C} {a b: C}
+{da: D a} {db: D b} {f: a--> b} {g: b --> a} {x: b --> b}
 (df: da -->[f] db) (dg: db -->[g] da) (dx: db -->[x] db) (e0: x = identity _) (e1 : f · g = identity _)
-  : dx = transportb _ e0 (id_disp _) -> df ;; dg = transportb _ e1 (id_disp _) -> 
+  : dx = transportb _ e0 (id_disp _) -> df ;; dg = transportb _ e1 (id_disp _) ->
     df ;; dx ;;dg = transportb _ (id_conjugation f g x e0 e1) (id_disp _).
 Proof.
   intros H H'.
   rewrite H. unfold transportb.
-  rewrite mor_disp_transportf_prewhisker. 
+  rewrite mor_disp_transportf_prewhisker.
   rewrite (id_right_disp df).
   rewrite transport_f_b.
-  repeat rewrite mor_disp_transportf_postwhisker. 
+  repeat rewrite mor_disp_transportf_postwhisker.
   rewrite H'.
   rewrite transport_f_b.
   apply (maponpaths (λ e, transportf _ e _)).

--- a/UniMath/CategoryTheory/DisplayedCats/Examples/CategoryOfPosets.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Examples/CategoryOfPosets.v
@@ -99,15 +99,11 @@ Defined.
 Definition dispTerminal_poset_disp_cat
   : dispTerminal poset_disp_cat TerminalHSET.
 Proof.
-  simple refine (_ ,, _).
+  use make_dispTerminal_locally_prop.
+  - exact poset_disp_cat_locally_prop.
   - exact unit_PartialOrder.
   - intros X RX.
-    use iscontraprop1.
-    + abstract
-        (use invproofirrelevance ;
-         intros f g ;
-         apply isaprop_is_monotone).
-    + exact (λ x y p, tt).
+    exact (λ x y p, tt).
 Defined.
 
 Definition Terminal_category_of_posets

--- a/UniMath/CategoryTheory/DisplayedCats/Examples/CategoryOfPosets.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Examples/CategoryOfPosets.v
@@ -54,6 +54,11 @@ Proof.
   - exact (λ X₁ X₂ X₃ R₁ R₂ R₃ f g Hf Hg, comp_is_monotone Hf Hg).
 Defined.
 
+Lemma poset_disp_cat_locally_prop : locally_propositional poset_disp_cat.
+Proof.
+  intro; intros; apply isaprop_is_monotone.
+Qed.
+
 Proposition is_univalent_poset_disp_cat
   : is_univalent_disp poset_disp_cat.
 Proof.
@@ -120,27 +125,15 @@ Definition dispBinProducts_poset_disp_cat
   : dispBinProducts poset_disp_cat BinProductsHSET.
 Proof.
   intros X₁ X₂ R₁ R₂.
-  simple refine ((_ ,, _) ,, _).
-  - exact (prod_PartialOrder R₁ R₂).
-  - split ; cbn.
+  use make_dispBinProduct_locally_prop.
+  - exact poset_disp_cat_locally_prop.
+  - exists (prod_PartialOrder R₁ R₂).
+    split ; cbn.
     + exact (dirprod_pr1_is_monotone R₁ R₂).
     + exact (dirprod_pr2_is_monotone R₁ R₂).
   - cbn.
     intros W f g RW Hf Hg.
-    use iscontraprop1.
-    + abstract
-        (use invproofirrelevance ;
-         intros φ₁ φ₂ ;
-         use subtypePath ;
-         [ intro ;
-           apply isapropdirprod ;
-           apply poset_disp_cat
-         | ] ;
-         apply isaprop_is_monotone).
-    + simple refine (_ ,, _ ,, _).
-      * exact (prodtofun_is_monotone Hf Hg).
-      * apply isaprop_is_monotone.
-      * apply isaprop_is_monotone.
+    exact (prodtofun_is_monotone Hf Hg).
 Defined.
 
 Definition BinProducts_category_of_posets

--- a/UniMath/CategoryTheory/DisplayedCats/Projection.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Projection.v
@@ -59,7 +59,7 @@ We start with local propositionality.
  *)
 Definition locally_propositional
            {C : category}
-           (D : disp_cat C)
+           (D : disp_cat_data C)
   : UU
   := ∏ (x y : C)
        (f : x --> y)
@@ -68,11 +68,23 @@ Definition locally_propositional
 
 Definition isaprop_locally_propositional
            {C : category}
-           (D : disp_cat C)
+           (D : disp_cat_data C)
   : isaprop (locally_propositional D).
 Proof.
   do 5 (use impred ; intro).
   apply isapropisaprop.
+Defined.
+
+Definition make_disp_cat_locally_prop
+           {C : category}
+           {D : disp_cat_data C}
+           (LP : locally_propositional D)
+  : disp_cat C.
+Proof.
+  exists D.
+  abstract (repeat split; intro; intros; try apply LP;
+            apply isasetaprop;
+            apply LP).
 Defined.
 
 (**

--- a/UniMath/CategoryTheory/DisplayedCats/Projection.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Projection.v
@@ -55,39 +55,8 @@ Definition pseudomonic_pr1_category
 
 (**
 Now we give some conditions to check whether structure or properties are being added via the hlevel of the displayed morphisms.
-We start with local propositionality.
- *)
-Definition locally_propositional
-           {C : category}
-           (D : disp_cat_data C)
-  : UU
-  := ∏ (x y : C)
-       (f : x --> y)
-       (xx : D x) (yy : D y),
-     isaprop (xx -->[ f ] yy).
+Local propositionality is now found in [Core.v]
 
-Definition isaprop_locally_propositional
-           {C : category}
-           (D : disp_cat_data C)
-  : isaprop (locally_propositional D).
-Proof.
-  do 5 (use impred ; intro).
-  apply isapropisaprop.
-Defined.
-
-Definition make_disp_cat_locally_prop
-           {C : category}
-           {D : disp_cat_data C}
-           (LP : locally_propositional D)
-  : disp_cat C.
-Proof.
-  exists D.
-  abstract (repeat split; intro; intros; try apply LP;
-            apply isasetaprop;
-            apply LP).
-Defined.
-
-(**
 A displayed category is locally inhabited if there is a displayed morphism above each morphism in the base.
  *)
 Definition locally_inhabited

--- a/UniMath/CategoryTheory/Monoidal/Displayed/Monoidal.v
+++ b/UniMath/CategoryTheory/Monoidal/Displayed/Monoidal.v
@@ -23,7 +23,6 @@ Require Import UniMath.CategoryTheory.DisplayedCats.Functors.
 Require Import UniMath.CategoryTheory.DisplayedCats.Constructions.
 Require Import UniMath.CategoryTheory.DisplayedCats.Isos.
 Require Import UniMath.CategoryTheory.DisplayedCats.NaturalTransformations.
-Require Import UniMath.CategoryTheory.DisplayedCats.Projection.
 
 Local Open Scope cat.
 Local Open Scope mor_disp_scope.

--- a/UniMath/CategoryTheory/Monoidal/Displayed/Monoidal.v
+++ b/UniMath/CategoryTheory/Monoidal/Displayed/Monoidal.v
@@ -23,6 +23,7 @@ Require Import UniMath.CategoryTheory.DisplayedCats.Functors.
 Require Import UniMath.CategoryTheory.DisplayedCats.Constructions.
 Require Import UniMath.CategoryTheory.DisplayedCats.Isos.
 Require Import UniMath.CategoryTheory.DisplayedCats.NaturalTransformations.
+Require Import UniMath.CategoryTheory.DisplayedCats.Projection.
 
 Local Open Scope cat.
 Local Open Scope mor_disp_scope.
@@ -623,7 +624,7 @@ Section DisplayedMonoidalCategories.
              {C : category}
              {D : disp_cat C}
              {M : monoidal C}
-             (DMD :  disp_monoidal_data D M)
+             (DMD : disp_monoidal_data D M)
     : UU
     := (disp_leftunitor_law dlu_{DMD} dluinv_{DMD})
        × (disp_rightunitor_law dru_{DMD} druinv_{DMD})
@@ -637,6 +638,18 @@ Section DisplayedMonoidalCategories.
              (M : monoidal C)
     : UU
     := ∑ (MD : disp_monoidal_data D M), (disp_monoidal_laws MD).
+
+  Definition make_disp_monoidal_locally_prop
+             {C : category}
+             {D : disp_cat C}
+             (LP : locally_propositional D)
+             {M : monoidal C}
+             (DMD : disp_monoidal_data D M)
+    : disp_monoidal D M.
+  Proof.
+    exists DMD.
+    abstract (repeat split ; try intro ; intros ; apply LP).
+  Defined.
 
   Definition disp_monoidal_mondata
              {C : category}

--- a/UniMath/CategoryTheory/Monoidal/Displayed/WhiskeredDisplayedBifunctors.v
+++ b/UniMath/CategoryTheory/Monoidal/Displayed/WhiskeredDisplayedBifunctors.v
@@ -17,7 +17,6 @@ Require Import UniMath.CategoryTheory.Core.Functors.
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
 Require Import UniMath.CategoryTheory.DisplayedCats.Functors.
 Require Import UniMath.CategoryTheory.DisplayedCats.Isos.
-Require Import UniMath.CategoryTheory.DisplayedCats.Projection.
 Require Import UniMath.CategoryTheory.Monoidal.WhiskeredBifunctors.
 Require Import UniMath.CategoryTheory.Core.Isos.
 

--- a/UniMath/CategoryTheory/Monoidal/Displayed/WhiskeredDisplayedBifunctors.v
+++ b/UniMath/CategoryTheory/Monoidal/Displayed/WhiskeredDisplayedBifunctors.v
@@ -17,6 +17,7 @@ Require Import UniMath.CategoryTheory.Core.Functors.
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
 Require Import UniMath.CategoryTheory.DisplayedCats.Functors.
 Require Import UniMath.CategoryTheory.DisplayedCats.Isos.
+Require Import UniMath.CategoryTheory.DisplayedCats.Projection.
 Require Import UniMath.CategoryTheory.Monoidal.WhiskeredBifunctors.
 Require Import UniMath.CategoryTheory.Core.Isos.
 
@@ -381,6 +382,20 @@ Section DisplayedBifunctor.
              (H : is_disp_bifunctor DF)
     : disp_bifunctor F DA DB DC
     := (DF,,H).
+
+  Definition make_disp_bifunctor_locally_prop
+             {A B C : category}
+             {F : bifunctor A B C}
+             {DA : disp_cat A}
+             {DB : disp_cat B}
+             {DC : disp_cat C}
+             {LP : locally_propositional DC}
+             (DF : disp_bifunctor_data F DA DB DC)
+    : disp_bifunctor F DA DB DC.
+  Proof.
+    exists DF.
+    abstract (repeat split ; try intro ; intros ; apply LP).
+  Defined.
 
   Definition disp_bifunctordata_from_disp_bifunctor
              {A B C : category}

--- a/UniMath/CategoryTheory/Monoidal/Examples/BinopCartesianMonoidal.v
+++ b/UniMath/CategoryTheory/Monoidal/Examples/BinopCartesianMonoidal.v
@@ -39,29 +39,27 @@ Section BinopCategory.
             (make_binopfun (X := (Y,,n)) (Y := (Z,,o)) g pg)).
   Defined.
 
+  Lemma Binop_disp_cat_locally_prop : locally_propositional Binop_disp_cat.
+  Proof.
+    intro; intros; apply isapropisbinopfun.
+  Qed.
+
   Definition Binop_cat : category := total_category Binop_disp_cat.
 
   Definition Binop_dispBinproducts : dispBinProducts Binop_disp_cat BinProductsHSET.
   Proof.
     intros X Y m n.
-    use tpair.
+    use make_dispBinProduct_locally_prop.
+    - exact Binop_disp_cat_locally_prop.
     - use tpair.
       + intros xy1 xy2.
         exact (m (pr1 xy1) (pr1 xy2),, n (pr2 xy1) (pr2 xy2)).
       + split; intros x1 x2; apply idpath.
-    - cbn. intros Z f g o pf pg.
-      use unique_exists.
-      + cbn. intros x1 x2.
-        apply dirprodeq; cbn.
-        * rewrite pf. apply idpath.
-        * rewrite pg. apply idpath.
-      + split; apply isapropisbinopfun.
-      + intro pfg.
-        apply isapropdirprod; apply isasetaprop, isapropisbinopfun.
-      + intro pfg.
-        cbn.
-        intros.
-        apply isapropisbinopfun.
+    - intros Z f g o pf pg.
+      cbn. intros x1 x2.
+      apply dirprodeq; cbn.
+      + rewrite pf. apply idpath.
+      + rewrite pg. apply idpath.
   Defined.
 
   Definition Binop_dispTerminal : dispTerminal Binop_disp_cat TerminalHSET.
@@ -115,13 +113,12 @@ Section BinopIsCartesianMonoidal.
         apply idpath.
   Defined.
 
-  Lemma BO_disp_tensor_laws : is_disp_bifunctor BO_disp_tensor_data.
+  Definition BO_disp_tensor : disp_tensor DBO SET_cartesian_monoidal.
   Proof.
-    repeat split; red; intros; apply isapropisbinopfun.
-  Qed.
-
-  Definition BO_disp_tensor : disp_tensor DBO SET_cartesian_monoidal
-    := (BO_disp_tensor_data,, BO_disp_tensor_laws).
+    use make_disp_bifunctor_locally_prop.
+    - exact Binop_disp_cat_locally_prop.
+    - exact BO_disp_tensor_data.
+  Defined.
 
   Definition BO_cart_disp_monoidal_data : disp_monoidal_data DBO SET_cartesian_monoidal.
   Proof.
@@ -132,13 +129,12 @@ Section BinopIsCartesianMonoidal.
       + repeat split.
   Defined.
 
-  Lemma BO_cart_disp_monoidal_laws : disp_monoidal_laws BO_cart_disp_monoidal_data.
+  Definition BO_cart_disp_monoidal_elementary : disp_monoidal DBO SET_cartesian_monoidal.
   Proof.
-    repeat split; try (red; intros; apply isapropisbinopfun); try (apply isapropisbinopfun).
-  Qed.
-
-  Definition BO_cart_disp_monoidal_elementary : disp_monoidal DBO SET_cartesian_monoidal
-    := (BO_cart_disp_monoidal_data,, BO_cart_disp_monoidal_laws).
+    use make_disp_monoidal_locally_prop.
+    - exact Binop_disp_cat_locally_prop.
+    - exact BO_cart_disp_monoidal_data.
+  Defined.
 
  End ElementaryProof.
 

--- a/UniMath/CategoryTheory/Monoidal/Examples/BinopCartesianMonoidal.v
+++ b/UniMath/CategoryTheory/Monoidal/Examples/BinopCartesianMonoidal.v
@@ -64,13 +64,11 @@ Section BinopCategory.
 
   Definition Binop_dispTerminal : dispTerminal Binop_disp_cat TerminalHSET.
   Proof.
-    use tpair.
+    use make_dispTerminal_locally_prop.
+    - exact Binop_disp_cat_locally_prop.
     - exact (fun _ _ => tt).
     - cbn.
-      intros X m.
-      use tpair.
-      + intros ? ?. apply idpath.
-      + intro pf. apply isapropisbinopfun.
+      intros X m. intros ? ?. apply idpath.
   Defined.
 
   Definition Binop_cat_cart_monoidal_via_cartesian : monoidal Binop_cat.

--- a/UniMath/CategoryTheory/Monoidal/Examples/Fullsub.v
+++ b/UniMath/CategoryTheory/Monoidal/Examples/Fullsub.v
@@ -17,6 +17,7 @@ Require Import UniMath.CategoryTheory.DisplayedCats.Core.
 Require Import UniMath.CategoryTheory.DisplayedCats.Functors.
 Require Import UniMath.CategoryTheory.DisplayedCats.Total.
 Require Import UniMath.CategoryTheory.DisplayedCats.Constructions.
+Require Import UniMath.CategoryTheory.DisplayedCats.Projection.
 
 Require Import UniMath.CategoryTheory.Monoidal.WhiskeredBifunctors.
 Require Import UniMath.CategoryTheory.Monoidal.Categories.
@@ -42,6 +43,11 @@ Section FullSubOfMonoidal.
     (P_u : P I_{M})
     (P_t : ∏ x y : C, P x → P y → P (x ⊗_{ M} y)).
 
+  Lemma disp_full_sub_locally_prop : locally_propositional (disp_full_sub C P).
+  Proof.
+    intro; intros; apply isapropunit.
+  Qed.
+
   Definition disp_monoidal_tensor_data_fullsub
     : disp_bifunctor_data M (disp_full_sub C P) (disp_full_sub C P) (disp_full_sub C P).
   Proof.
@@ -50,17 +56,12 @@ Section FullSubOfMonoidal.
     - split ; intro ; intros ; exact tt.
   Defined.
 
-  Lemma disp_monoidal_tensor_is_tensor_fullsub
-    :  is_disp_bifunctor disp_monoidal_tensor_data_fullsub.
-  Proof.
-    repeat split ; intro ; intros ; apply isapropunit.
-  Qed.
-
   Definition disp_monoidal_tensor_fullsub
     : disp_tensor (disp_full_sub C P) M.
   Proof.
-    exists disp_monoidal_tensor_data_fullsub.
-    exact disp_monoidal_tensor_is_tensor_fullsub.
+    use make_disp_bifunctor_locally_prop.
+    - exact disp_full_sub_locally_prop.
+    - exact disp_monoidal_tensor_data_fullsub.
   Defined.
 
   Definition disp_monoidal_data_fullsub
@@ -72,15 +73,13 @@ Section FullSubOfMonoidal.
     repeat (use tpair) ; intro ; intros ; exact tt.
   Defined.
 
-  Lemma disp_monoidal_laws_fullsub
-    : disp_monoidal_laws disp_monoidal_data_fullsub.
-  Proof.
-    repeat split ; try (intro ; intros) ; apply isapropunit.
-  Qed.
-
   Definition disp_monoidal_fullsub
-    : disp_monoidal (disp_full_sub C P) M
-    := _ ,, disp_monoidal_laws_fullsub.
+    : disp_monoidal (disp_full_sub C P) M.
+  Proof.
+    use make_disp_monoidal_locally_prop.
+    - exact disp_full_sub_locally_prop.
+    - exact disp_monoidal_data_fullsub.
+  Defined.
 
   Definition monoidal_fullsubcat : monoidal (full_subcat C P)
   := total_monoidal disp_monoidal_fullsub.

--- a/UniMath/CategoryTheory/Monoidal/Examples/Fullsub.v
+++ b/UniMath/CategoryTheory/Monoidal/Examples/Fullsub.v
@@ -17,7 +17,6 @@ Require Import UniMath.CategoryTheory.DisplayedCats.Core.
 Require Import UniMath.CategoryTheory.DisplayedCats.Functors.
 Require Import UniMath.CategoryTheory.DisplayedCats.Total.
 Require Import UniMath.CategoryTheory.DisplayedCats.Constructions.
-Require Import UniMath.CategoryTheory.DisplayedCats.Projection.
 
 Require Import UniMath.CategoryTheory.Monoidal.WhiskeredBifunctors.
 Require Import UniMath.CategoryTheory.Monoidal.Categories.
@@ -43,11 +42,6 @@ Section FullSubOfMonoidal.
     (P_u : P I_{M})
     (P_t : ∏ x y : C, P x → P y → P (x ⊗_{ M} y)).
 
-  Lemma disp_full_sub_locally_prop : locally_propositional (disp_full_sub C P).
-  Proof.
-    intro; intros; apply isapropunit.
-  Qed.
-
   Definition disp_monoidal_tensor_data_fullsub
     : disp_bifunctor_data M (disp_full_sub C P) (disp_full_sub C P) (disp_full_sub C P).
   Proof.
@@ -60,7 +54,7 @@ Section FullSubOfMonoidal.
     : disp_tensor (disp_full_sub C P) M.
   Proof.
     use make_disp_bifunctor_locally_prop.
-    - exact disp_full_sub_locally_prop.
+    - apply disp_full_sub_locally_prop.
     - exact disp_monoidal_tensor_data_fullsub.
   Defined.
 
@@ -77,7 +71,7 @@ Section FullSubOfMonoidal.
     : disp_monoidal (disp_full_sub C P) M.
   Proof.
     use make_disp_monoidal_locally_prop.
-    - exact disp_full_sub_locally_prop.
+    - apply disp_full_sub_locally_prop.
     - exact disp_monoidal_data_fullsub.
   Defined.
 

--- a/UniMath/CategoryTheory/Monoidal/Examples/MonoidalDialgebras.v
+++ b/UniMath/CategoryTheory/Monoidal/Examples/MonoidalDialgebras.v
@@ -506,33 +506,11 @@ Section FixTwoMonoidalFunctors.
     exact dialgebra_disp_associatorinv_data.
   Defined.
 
-  Lemma dialgebra_disp_leftunitor_law :
-    disp_leftunitor_law dlu^{ dialgebra_disp_monoidal_data} dluinv^{ dialgebra_disp_monoidal_data}.
-  Proof.
-    repeat (split; try (red; intros; apply base_disp_cells_isaprop)); try apply base_disp_cells_isaprop.
-  Qed.
-
-  Lemma dialgebra_disp_rightunitor_law :
-    disp_rightunitor_law dru^{ dialgebra_disp_monoidal_data} druinv^{ dialgebra_disp_monoidal_data}.
-  Proof.
-    repeat (split; try (red; intros; apply base_disp_cells_isaprop)); try apply base_disp_cells_isaprop.
-  Qed.
-
-  Lemma dialgebra_disp_associator_law :
-    disp_associator_law dα^{ dialgebra_disp_monoidal_data} dαinv^{ dialgebra_disp_monoidal_data}.
-  Proof.
-    repeat (split; try (red; intros; apply base_disp_cells_isaprop)); try apply base_disp_cells_isaprop.
-  Qed.
-
   Definition dialgebra_disp_monoidal : disp_monoidal base_disp V.
   Proof.
-    exists dialgebra_disp_monoidal_data.
-    split.
-    { exact dialgebra_disp_leftunitor_law. }
-    split; [ exact dialgebra_disp_rightunitor_law |].
-    split; [ exact dialgebra_disp_associator_law |].
-    (** now we benefit from working in a displayed monoidal category *)
-    split; red; intros; apply base_disp_cells_isaprop.
+    use make_disp_monoidal_locally_prop.
+    - apply is_locally_propositional_dialgebra_disp_cat.
+    - exact dialgebra_disp_monoidal_data.
   Defined.
 
   Definition dialgebra_monoidal : monoidal (dialgebra F G) := total_monoidal dialgebra_disp_monoidal.

--- a/UniMath/CategoryTheory/Monoidal/Examples/MonoidalPointedObjects.v
+++ b/UniMath/CategoryTheory/Monoidal/Examples/MonoidalPointedObjects.v
@@ -75,16 +75,12 @@ Proof.
   - exact monoidal_pointed_objects_disp_tensor_data_aux2.
 Defined.
 
-Lemma monoidal_pointed_objects_disp_tensor_data_is_disp_bifunctor
-  : is_disp_bifunctor monoidal_pointed_objects_disp_tensor_data.
+Definition monoidal_pointed_objects_disp_tensor : disp_tensor cosliced Mon_V.
 Proof.
-  split5; intro; intros; apply V.
-Qed.
-
-Definition monoidal_pointed_objects_disp_tensor : disp_tensor cosliced Mon_V
-  := monoidal_pointed_objects_disp_tensor_data
-     ,,
-     monoidal_pointed_objects_disp_tensor_data_is_disp_bifunctor.
+  use make_disp_bifunctor_locally_prop.
+  - apply coslice_cat_disp_locally_prop.
+  - exact monoidal_pointed_objects_disp_tensor_data.
+Defined.
 
 Lemma monoidal_pointed_objects_disp_data_verif :
   disp_leftunitor_data monoidal_pointed_objects_disp_tensor (identity I_{Mon_V})
@@ -187,14 +183,12 @@ Proof.
   - exact monoidal_pointed_objects_disp_data_verif.
 Defined.
 
-Lemma monoidal_pointed_objects_disp_laws
-  : disp_monoidal_laws monoidal_pointed_objects_disp_data.
+Definition monoidal_pointed_objects_disp : disp_monoidal cosliced Mon_V.
 Proof.
-  repeat split; try intro; intros; apply V.
-Qed.
-
-Definition monoidal_pointed_objects_disp : disp_monoidal cosliced Mon_V
-  := monoidal_pointed_objects_disp_data,,monoidal_pointed_objects_disp_laws.
+  apply make_disp_monoidal_locally_prop.
+  - apply coslice_cat_disp_locally_prop.
+  - exact monoidal_pointed_objects_disp_data.
+Defined.
 
 Definition monoidal_pointed_objects : monoidal (coslice_cat_total V I_{Mon_V})
   := total_monoidal monoidal_pointed_objects_disp.

--- a/UniMath/CategoryTheory/Monoidal/Examples/PointedSetCartesianMonoidal.v
+++ b/UniMath/CategoryTheory/Monoidal/Examples/PointedSetCartesianMonoidal.v
@@ -70,45 +70,38 @@ Section PointedSetCategory.
       apply (comp_preserve_ptset pf pg).
   Defined.
 
+  Lemma ptset_disp_cat_locally_prop : locally_propositional ptset_disp_cat.
+  Proof.
+    intros x y m n f. apply isaprop_preserve_ptset.
+  Qed.
+
   Definition ptset_cat : category := total_category ptset_disp_cat.
 
-  Definition ptset_dispBinproducts : dispBinProducts ptset_disp_cat BinProductsHSET.
+  Definition ptset_dispBinProducts : dispBinProducts ptset_disp_cat BinProductsHSET.
   Proof.
     intros X Y x y.
-    use tpair.
-    - use tpair.
-      + exact (x ,, y).
-      + split; apply idpath.
+    use make_dispBinProduct_locally_prop.
+    - exact ptset_disp_cat_locally_prop.
+    - exists (x ,, y).
+      split; apply idpath.
     - cbn. intros Z f g z pf pg.
-      use unique_exists.
-      + cbn. unfold preserve_ptset. unfold prodtofuntoprod. cbn. rewrite pf, pg.
-        apply idpath.
-      + cbn. split.
-        * (* show_id_type. *) apply X.
-        * apply Y.
-      + intro pfg.
-        apply isapropdirprod; apply isasetaprop, isaprop_preserve_ptset.
-      + intro pfg.
-        cbn.
-        intros.
-        apply isaprop_preserve_ptset.
+      unfold preserve_ptset. unfold prodtofuntoprod. cbn. rewrite pf, pg.
+      apply idpath.
   Defined.
 
   Definition ptset_dispTerminal : dispTerminal ptset_disp_cat TerminalHSET.
   Proof.
-    use tpair.
+    use make_dispTerminal_locally_prop.
+    - exact ptset_disp_cat_locally_prop.
     - exact tt.
     - cbn.
-      intros X x.
-      use tpair.
-      + apply idpath.
-      + intro f. apply isaprop_preserve_ptset.
+      intros X x. apply idpath.
   Defined.
 
   Definition PS_cat_cart_monoidal_via_cartesian : monoidal ptset_cat.
   Proof.
     use cartesian_monoidal.
-    - apply (total_category_Binproducts _ BinProductsHSET ptset_dispBinproducts).
+    - apply (total_category_Binproducts _ BinProductsHSET ptset_dispBinProducts).
     - apply (total_category_Terminal _ TerminalHSET ptset_dispTerminal).
   Defined.
 
@@ -120,7 +113,7 @@ Section PointedSetIsCartesianMonoidal.
   Local Notation DPS := ptset_disp_cat.
 
   Definition PS_cart_disp_monoidal : disp_monoidal DPS SET_cartesian_monoidal
-    := displayedcartesianmonoidalcat BinProductsHSET TerminalHSET ptset_disp_cat ptset_dispBinproducts ptset_dispTerminal.
+    := displayedcartesianmonoidalcat BinProductsHSET TerminalHSET ptset_disp_cat ptset_dispBinProducts ptset_dispTerminal.
 
   Section ElementaryProof.
 

--- a/UniMath/CategoryTheory/Monoidal/Examples/SetWithSubset.v
+++ b/UniMath/CategoryTheory/Monoidal/Examples/SetWithSubset.v
@@ -46,14 +46,17 @@ Section SetWithSubset.
       apply (comp_hsubtype_preserving fsp gsp).
   Defined.
 
-  Definition SS_disp_cat_axioms : disp_cat_axioms hset_category SS_disp_cat_data.
+  Lemma SS_disp_cat_locally_prop : locally_propositional SS_disp_cat_data.
   Proof.
-    repeat split; cbn; intros; try (apply proofirrelevance, isaprop_hsubtype_preserving).
-    apply isasetaprop. apply isaprop_hsubtype_preserving.
-  Defined.
+    intro; intros; apply isaprop_hsubtype_preserving.
+  Qed.
 
-  Definition SS_disp_cat : disp_cat hset_category
-    := SS_disp_cat_data ,, SS_disp_cat_axioms.
+  Definition SS_disp_cat : disp_cat hset_category.
+  Proof.
+    use make_disp_cat_locally_prop.
+    - exact SS_disp_cat_data.
+    - exact SS_disp_cat_locally_prop.
+  Defined.
 
   Definition total_subset_section_data : section_disp_data SS_disp_cat.
   Proof.
@@ -114,11 +117,6 @@ Section SetWithSubsetMonoidal.
       + rewrite (! pr12 x1y).
         exact (pr222 x1y).
   Defined.
-
-  Lemma SS_disp_cat_locally_prop : locally_propositional SS_disp_cat.
-  Proof.
-    repeat split; red; intros; apply isaprop_hsubtype_preserving.
-  Qed.
 
   Definition SS_disp_cat_tensor : disp_tensor SS_disp_cat SET_cart_monoidal.
   Proof.

--- a/UniMath/CategoryTheory/Monoidal/Examples/SetWithSubset.v
+++ b/UniMath/CategoryTheory/Monoidal/Examples/SetWithSubset.v
@@ -12,6 +12,7 @@ Require Import UniMath.CategoryTheory.Core.Functors.
 Require Import UniMath.CategoryTheory.Core.Isos.
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
 Require Import UniMath.CategoryTheory.DisplayedCats.Constructions.
+Require Import UniMath.CategoryTheory.DisplayedCats.Projection.
 
 Require Import UniMath.CategoryTheory.Monoidal.WhiskeredBifunctors.
 Require Import UniMath.CategoryTheory.Monoidal.Categories.
@@ -114,13 +115,17 @@ Section SetWithSubsetMonoidal.
         exact (pr222 x1y).
   Defined.
 
-  Lemma SS_disp_cat_tensor_laws : is_disp_bifunctor SS_disp_cat_tensor_data.
+  Lemma SS_disp_cat_locally_prop : locally_propositional SS_disp_cat.
   Proof.
     repeat split; red; intros; apply isaprop_hsubtype_preserving.
   Qed.
 
-  Definition SS_disp_cat_tensor : disp_tensor SS_disp_cat SET_cart_monoidal
-    := SS_disp_cat_tensor_data,, SS_disp_cat_tensor_laws.
+  Definition SS_disp_cat_tensor : disp_tensor SS_disp_cat SET_cart_monoidal.
+  Proof.
+    use make_disp_bifunctor_locally_prop.
+    - exact SS_disp_cat_locally_prop.
+    - exact SS_disp_cat_tensor_data.
+  Defined.
 
   Definition SS_disp_monoidal_data : disp_monoidal_data SS_disp_cat SET_cart_monoidal.
   Proof.
@@ -177,13 +182,12 @@ Section SetWithSubsetMonoidal.
       repeat split ; apply (pr22 xyzinUVW).
   Defined.
 
-  Definition SS_disp_monoidal_laws : disp_monoidal_laws (SS_disp_monoidal_data).
+  Definition SS_disp_monoidal : disp_monoidal SS_disp_cat SET_cart_monoidal.
   Proof.
-    repeat split ; try (intro ; intros) ; apply isaprop_hsubtype_preserving.
-  Qed.
-
-  Definition SS_disp_monoidal : disp_monoidal SS_disp_cat SET_cart_monoidal
-    := SS_disp_monoidal_data,, SS_disp_monoidal_laws.
+    apply make_disp_monoidal_locally_prop.
+    - exact SS_disp_cat_locally_prop.
+    - exact SS_disp_monoidal_data.
+  Defined.
 
   Definition total_subset_section_monoidal_data
     : smonoidal_data SET_cart_monoidal SS_disp_monoidal total_subset_section.

--- a/UniMath/CategoryTheory/coslicecat.v
+++ b/UniMath/CategoryTheory/coslicecat.v
@@ -21,7 +21,6 @@ Require Import UniMath.CategoryTheory.Core.Functors.
 (** for second construction: *)
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
 Require Import UniMath.CategoryTheory.DisplayedCats.Total.
-Require Import UniMath.CategoryTheory.DisplayedCats.Projection.
 
 Local Open Scope cat.
 
@@ -135,19 +134,20 @@ Proof.
     exact Hyph'.
 Qed.
 
+Definition coslice_cat_disp_data : disp_cat_data C :=
+  coslice_cat_disp_ob_mor ,, coslice_cat_disp_id_comp.
+
+Lemma coslice_cat_disp_locally_prop : locally_propositional coslice_cat_disp_data.
+Proof.
+  intro; intros; apply C.
+Qed.
+
 Definition coslice_cat_disp : disp_cat C.
 Proof.
-  use tpair.
-  - use tpair.
-    + exact coslice_cat_disp_ob_mor.
-    + exact coslice_cat_disp_id_comp.
-  - abstract (split4; intros; [apply C | apply C | apply C | apply isasetaprop; apply C]).
+  use make_disp_cat_locally_prop.
+  - exact coslice_cat_disp_data.
+  - exact coslice_cat_disp_locally_prop.
 Defined.
-
-Lemma coslice_cat_disp_locally_prop : locally_propositional coslice_cat_disp.
-Proof.
-  intro; intros. apply C.
-Qed.
 
 Definition coslice_cat_total : category := total_category coslice_cat_disp.
 

--- a/UniMath/CategoryTheory/coslicecat.v
+++ b/UniMath/CategoryTheory/coslicecat.v
@@ -21,6 +21,7 @@ Require Import UniMath.CategoryTheory.Core.Functors.
 (** for second construction: *)
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
 Require Import UniMath.CategoryTheory.DisplayedCats.Total.
+Require Import UniMath.CategoryTheory.DisplayedCats.Projection.
 
 Local Open Scope cat.
 
@@ -142,6 +143,11 @@ Proof.
     + exact coslice_cat_disp_id_comp.
   - abstract (split4; intros; [apply C | apply C | apply C | apply isasetaprop; apply C]).
 Defined.
+
+Lemma coslice_cat_disp_locally_prop : locally_propositional coslice_cat_disp.
+Proof.
+  intro; intros. apply C.
+Qed.
 
 Definition coslice_cat_total : category := total_category coslice_cat_disp.
 


### PR DESCRIPTION
first example: monoidal full subcategory
this does not avoid code but is conceptually clearer

also builders for displayed binary products and displayed terminal objects in the locally propositional case