### PR TITLE
Equivalence between the two definitions of double categories

### DIFF
--- a/UniMath/Bicategories/.package/files
+++ b/UniMath/Bicategories/.package/files
@@ -190,6 +190,7 @@ DoubleCategories/Examples/KleisliDoubleCat.v
 DoubleCategories/Examples/StructuredCospansDoubleCat.v
 DoubleCategories/Examples/StructuredCospansDoubleFunctor.v
 DoubleCategories/DoubleCatsUnfolded.v
+DoubleCategories/DoubleCatsEquivalentDefinitions.v
 
 PseudoFunctors/Examples/ChangeOfBaseEnriched.v
 DisplayedBicats/Examples/MonadsLax.v

--- a/UniMath/Bicategories/DoubleCategories/DoubleCategoryBasics.v
+++ b/UniMath/Bicategories/DoubleCategories/DoubleCategoryBasics.v
@@ -903,14 +903,14 @@ Definition triangle_law
   := ∏ (x y z : C)
        (h : D x y)
        (k : D y z),
-     transportf_disp_mor2
-       (id_left _)
-       (id_left _)
-       (double_associator a h _ k
-        ;;2
-        double_hor_comp_mor Cm (double_runitor r h) (id_two_disp _))
+     double_associator a h _ k
+     ;;2
+     double_hor_comp_mor Cm (double_runitor r h) (id_two_disp _)
      =
-     double_hor_comp_mor Cm (id_two_disp _) (double_lunitor l k).
+     transportb_disp_mor2
+       (id_left _)
+       (id_left _)
+       (double_hor_comp_mor Cm (id_two_disp _) (double_lunitor l k)).
 
 Proposition isaprop_triangle_law
             {C : category}

--- a/UniMath/Bicategories/DoubleCategories/DoubleCats.v
+++ b/UniMath/Bicategories/DoubleCategories/DoubleCats.v
@@ -273,7 +273,7 @@ Proposition square_id_left_v
     transportb_square s (id_left _) (id_left _).
 Proof.
   apply id_two_disp_left.
-Qed.
+Defined.
 
 Proposition square_id_right_v
             {C : double_cat}
@@ -288,7 +288,7 @@ Proposition square_id_right_v
     transportb_square s (id_right _) (id_right _).
 Proof.
   apply id_two_disp_right.
-Qed.
+Defined.
 
 Proposition square_assoc_v
             {C : double_cat}
@@ -307,7 +307,7 @@ Proposition square_assoc_v
     transportb_square ((s₁ ⋆v s₂) ⋆v s₃) (assoc _ _ _) (assoc _ _ _).
 Proof.
   exact (assoc_two_disp s₁ s₂ s₃).
-Qed.
+Defined.
 
 (**
  2.4. Functoriality of horizontal identities
@@ -429,7 +429,7 @@ Proposition lunitor_linvunitor_h
     transportb_square (id_v_square _) (id_v_left _) (id_v_left _).
 Proof.
   exact (pr122 (pr1 (pr121 C) x y f)).
-Qed.
+Defined.
 
 Proposition linvunitor_lunitor_h
             {C : double_cat}
@@ -440,7 +440,7 @@ Proposition linvunitor_lunitor_h
     transportb_square (id_v_square _) (id_v_left _) (id_v_left _).
 Proof.
   exact (pr222 (pr1 (pr121 C) x y f)).
-Qed.
+Defined.
 
 Proposition lunitor_square
             {C : double_cat}
@@ -491,7 +491,7 @@ Proposition runitor_rinvunitor_h
     transportb_square (id_v_square _) (id_v_left _) (id_v_left _).
 Proof.
   exact (pr122 (pr11 (pr221 C) x y f)).
-Qed.
+Defined.
 
 Proposition rinvunitor_runitor_h
             {C : double_cat}
@@ -502,7 +502,7 @@ Proposition rinvunitor_runitor_h
     transportb_square (id_v_square _) (id_v_left _) (id_v_left _).
 Proof.
   exact (pr222 (pr11 (pr221 C) x y f)).
-Qed.
+Defined.
 
 Proposition runitor_square
             {C : double_cat}
@@ -559,7 +559,7 @@ Proposition lassociator_rassociator_h
     transportb_square (id_v_square _) (id_v_left _) (id_v_left _).
 Proof.
   exact (pr122 (pr12 (pr221 C) w x y z f g h)).
-Qed.
+Defined.
 
 Proposition rassociator_lassociator_h
             {C : double_cat}
@@ -572,7 +572,7 @@ Proposition rassociator_lassociator_h
     transportb_square (id_v_square _) (id_v_left _) (id_v_left _).
 Proof.
   exact (pr222 (pr12 (pr221 C) w x y z f g h)).
-Qed.
+Defined.
 
 Proposition lassociator_h_square
             {C : double_cat}

--- a/UniMath/Bicategories/DoubleCategories/DoubleCats.v
+++ b/UniMath/Bicategories/DoubleCategories/DoubleCats.v
@@ -325,7 +325,7 @@ Proposition id_h_square_id
   : id_h_square (identity_v x) = id_v_square (identity_h x).
 Proof.
   exact (pr121 (pr211 C) x).
-Qed.
+Defined.
 
 Proposition id_h_square_comp
             {C : double_cat}
@@ -337,7 +337,7 @@ Proposition id_h_square_comp
     id_h_square v₁ ⋆v id_h_square v₂.
 Proof.
   exact (pr221 (pr211 C) x y z v₁ v₂).
-Qed.
+Defined.
 
 (**
  2.5. Functoriality of horizontal composition
@@ -367,7 +367,7 @@ Proposition comp_h_square_id
   : id_v_square h₁ ⋆h id_v_square h₂ = id_v_square (h₁ ·h h₂).
 Proof.
   exact (pr122 (pr211 C) x y z h₁ h₂).
-Qed.
+Defined.
 
 Proposition comp_h_square_comp
             {C : double_cat}
@@ -396,7 +396,7 @@ Proof.
            l₁ l₂
            s₁ s₁'
            s₂ s₂').
-Qed.
+Defined.
 
 (**
  2.6. Left unitor
@@ -458,7 +458,7 @@ Proposition lunitor_square
       (id_v_right _ @ !(id_v_left _)).
 Proof.
   exact (!(pr2 (pr121 C) x₁ x₂ y₁ y₂ h₁ h₂ v₁ v₂ s)).
-Qed.
+Defined.
 
 (**
  2.7. Right unitor
@@ -520,7 +520,7 @@ Proposition runitor_square
       (id_v_right _ @ !(id_v_left _)).
 Proof.
   exact (!(pr21 (pr221 C) x₁ x₂ y₁ y₂ h₁ h₂ v₁ v₂ s)).
-Qed.
+Defined.
 
 (**
  2.8. Associator
@@ -593,7 +593,7 @@ Proposition lassociator_h_square
       (id_v_right _ @ !(id_v_left _)).
 Proof.
   exact (!(pr22 (pr221 C) w₁ w₂ x₁ x₂ y₁ y₂ z₁ z₂ h₁ h₂ j₁ j₂ k₁ k₂ vw vx vy vz s₁ s₂ s₃)).
-Qed.
+Defined.
 
 (**
  2.9. Triangle and pentagon equations

--- a/UniMath/Bicategories/DoubleCategories/DoubleCats.v
+++ b/UniMath/Bicategories/DoubleCategories/DoubleCats.v
@@ -603,12 +603,12 @@ Proposition double_triangle
             {x y z : C}
             (h : x -->h y)
             (k : y -->h z)
-  : transportf_square
-      (lassociator_h h _ k ⋆v (runitor_h h ⋆h id_v_square _))
-      (id_v_left _)
-      (id_v_left _)
+  : lassociator_h h _ k ⋆v (runitor_h h ⋆h id_v_square _)
     =
-    id_v_square h ⋆h lunitor_h k.
+    transportb_square
+      (id_v_square h ⋆h lunitor_h k)
+      (id_v_left _)
+      (id_v_left _).
 Proof.
   exact (pr12 C x y z h k).
 Qed.

--- a/UniMath/Bicategories/DoubleCategories/DoubleCatsEquivalentDefinitions.v
+++ b/UniMath/Bicategories/DoubleCategories/DoubleCatsEquivalentDefinitions.v
@@ -2,47 +2,26 @@
 
   Authors: Benedikt Ahrens, Paige North, Nima Rasekh, Niels van der Weide
   June 2023
-  Based on definition of weak double category in Section 3.3 of the book Higher Dimensional Categories by Marco Grandis.
+
+  We construct an equivalence between the unfolded definition and the folded
+  definition of double categories. The proof is a matter of reorganizing the
+  sigma type.
+
+  Contents:
+  1. The map from unfolded double categories to double categories
+  2. The inverse
+  3. It forms an equivalences
  *)
 
-
-(** ** Contents :
-
-  - Define a pre double category as a ``weak double category`` in the sense of Grandis.
-    This means one direction is weak and the other direction is strict.
-
-  - Double categories: A double category is a pre-double category with two set-truncated hom sets.
-  -
-  - Univalent Double Categories: A univalent double category is a double category with two univalent underlying categories.
-
-  - The structure is defined from scratch rather than building on a category.
-    This makes further generalizations easier.
- *)
-
-Require Import UniMath.Foundations.Propositions.
-Require Import UniMath.Foundations.Sets.
-Require Import UniMath.MoreFoundations.PartA.
-Require Import UniMath.MoreFoundations.Notations.
+Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.All.
 Require Import UniMath.CategoryTheory.Core.Prelude.
-
-Require Import UniMath.CategoryTheory.Core.Categories.
-Require Import UniMath.CategoryTheory.Core.Functors.
-Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
-Require Import UniMath.CategoryTheory.Core.Isos.
-Require Import UniMath.CategoryTheory.Core.Univalence.
 Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.TwoSidedDispCat.
-Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.DisplayedFunctor.
-Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.DisplayedNatTrans.
 Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.Isos.
 Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.Univalence.
 Require Import UniMath.Bicategories.Core.Bicat.
 Import Bicat.Notations.
-Require Import UniMath.Bicategories.Core.Invertible_2cells.
-Require Import UniMath.Bicategories.DisplayedBicats.DispBicat.
-Import DispBicat.Notations.
 Require Import UniMath.Bicategories.DoubleCategories.DoubleCategoryBasics.
-Require Import UniMath.Bicategories.DoubleCategories.DoubleFunctor.
-Require Import UniMath.Bicategories.DoubleCategories.DoubleTransformation.
 Require Import UniMath.Bicategories.DoubleCategories.BicatOfDoubleCats.
 Require Import UniMath.Bicategories.DoubleCategories.DoubleCats.
 Require Import UniMath.Bicategories.DoubleCategories.DoubleCatsUnfolded.
@@ -50,49 +29,17 @@ Require Import UniMath.Bicategories.DoubleCategories.DoubleCatsUnfolded.
 Local Open Scope cat.
 Local Open Scope double_cat.
 
-Definition TODO { A : UU} : A.
-Admitted.
-
+(**
+ 1. The map from unfolded double categories to double categories
+ *)
 Section DoubleCatsUnfolded_to_DoubleCats.
   Context (C : univalent_doublecategory).
 
   Definition doublecategory_to_cat : category :=
     (und_ob_hor_cat C).
 
-  Definition doublecategory_to_twosided_disp_cat_data
-    : twosided_disp_cat_data  (und_ob_hor_cat C) (und_ob_hor_cat C).
-  Proof.
-    use tpair.
-    - use tpair.
-      * intros x y.
-        exact (x -v-> y).
-      * intros x y z w f g h k.
-        exact (sqq h f g k).
-    - use tpair.
-      * intros x y f.
-        exact (hor_sq_identity f).
-      * intros x y z a b c f1 f2 f3 f4 f5 f6 f7 α β.
-        exact (α ·sqh β).
-  Defined.
-
-  Definition doublecategory_to_twosided_disp_cat
-    : twosided_disp_cat doublecategory_to_cat doublecategory_to_cat.
-  Proof.
-    use tpair.
-    - exact doublecategory_to_twosided_disp_cat_data.
-    - repeat split.
-      + intros x0 x1 y0 y1 f0 f1 g0 g1 α.
-        exact (id_hor_sq_left α).
-      + intros x0 x1 y0 y1 f0 f1 g0 g1 α.
-        exact (id_hor_sq_right α).
-      + intros ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? α β γ.
-        exact (assoc_sq_hor α β γ).
-      + intros x0 x1 y0 y1 f0 g0 f1 g1.
-        exact (get_has_sq_hor_homsets f0 g0 f1 g1).
-  Defined.
-
   Let D : twosided_disp_cat doublecategory_to_cat doublecategory_to_cat
-      := doublecategory_to_twosided_disp_cat.
+      := doublecategory_to_twosided_disp_cat C.
 
   Definition doublecategory_to_horid : hor_id D.
   Proof.
@@ -211,7 +158,8 @@ Section DoubleCatsUnfolded_to_DoubleCats.
   Definition is_univalent_doublecategory_to_twosided_disp_cat
     : is_univalent_twosided_disp_cat D.
   Proof.
-  Admitted.
+    apply C.
+  Defined.
 
   Let HD : is_univalent_twosided_disp_cat D
       := is_univalent_doublecategory_to_twosided_disp_cat.
@@ -220,6 +168,9 @@ Section DoubleCatsUnfolded_to_DoubleCats.
     make_double_cat (und_ob_hor_cat C) D I Cm l r a tr pe HC HD.
 End DoubleCatsUnfolded_to_DoubleCats.
 
+(**
+ 2. The inverse
+ *)
 Section DoubleCats_to_DoubleCatsUnfolded.
   Context (C : double_cat).
 
@@ -465,10 +416,13 @@ Section DoubleCats_to_DoubleCatsUnfolded.
   Proof.
     simple refine (double_cat_to_doublecategory ,, _ ,, _).
     - exact (pr21 (pr111 C)).
-    - apply TODO.
+    - exact (pr22 (pr111 C)).
   Defined.
 End DoubleCats_to_DoubleCatsUnfolded.
 
+(**
+ 3. It forms an equivalences
+ *)
 Proposition double_cat_weq_univalent_doublecategory_inv₁
             (C : double_cat)
   : doublecategory_to_double_cat (double_cat_to_univalent_doublecategory C) = C.
@@ -479,21 +433,28 @@ Proof.
     intro.
     apply isapropdirprod ; repeat (use impred ; intro) ; apply isaset_disp_mor.
   }
-  induction C1 as [ [ [ C D ] IC ] UnAs ].
-  use total2_paths_f.
-  - use total2_paths_f.
-    + use total2_paths_f.
-      * apply idpath.
-      * use subtypePath.
-        {
-          intro.
-          apply isaprop_is_univalent_twosided_disp_cat.
-        }
-        apply idpath.
-    + (* rewrite transportf_total2_paths_f. *)
-      admit.
-  - admit.
-Admitted.
+  use total2_paths_f ; [ apply idpath | ].
+  use pathsdirprod.
+  - use subtypePath.
+    {
+      intro.
+      apply isaprop_double_lunitor_laws.
+    }
+    apply idpath.
+  - use pathsdirprod.
+    + use subtypePath.
+      {
+        intro.
+        apply isaprop_double_runitor_laws.
+      }
+      apply idpath.
+    + use subtypePath.
+      {
+        intro.
+        apply isaprop_double_associator_laws.
+      }
+      apply idpath.
+Qed.
 
 Proposition double_cat_weq_univalent_doublecategory_inv₂
             (C : univalent_doublecategory)
@@ -504,7 +465,7 @@ Proof.
     intro.
     apply isapropdirprod.
     - apply isaprop_is_univalent.
-    - admit.
+    - apply isaprop_is_univalent_twosided_disp_cat.
   }
   use subtypePath.
   {
@@ -513,12 +474,11 @@ Proof.
     repeat (use impred ; intro) ;
     apply isapropiscontr.
   }
-  induction C as [ [ [ C1 C2 ] C3 ] H ] ; cbn.
-  refine (maponpaths (λ z, _ ,, z) _).
+  use total2_paths_f ; [ apply idpath | ].
   repeat (use pathsdirprod) ;
   repeat (use funextsec ; intro) ;
   apply get_has_sq_hor_homsets.
-Admitted.
+Qed.
 
 Definition double_cat_weq_univalent_doublecategory
   : double_cat ≃ univalent_doublecategory.
@@ -527,5 +487,5 @@ Proof.
   - exact double_cat_to_univalent_doublecategory.
   - exact doublecategory_to_double_cat.
   - exact double_cat_weq_univalent_doublecategory_inv₁.
-  - intros C.
-    revert C.
+  - exact double_cat_weq_univalent_doublecategory_inv₂.
+Defined.

--- a/UniMath/Bicategories/DoubleCategories/DoubleCatsUnfolded.v
+++ b/UniMath/Bicategories/DoubleCategories/DoubleCatsUnfolded.v
@@ -418,7 +418,7 @@ Definition get_predoublecat_sq_special {C: predoublecategory_ob_mor_sq_data} {a 
 Definition is_iso_square {C: predoublecategory_sq_hor_data} {a b : C} {g: a -v-> b} {h: a -v-> b}
   (α : get_predoublecat_sq_special g h): UU
   := ∑ (β : get_predoublecat_sq_special h g),
-  ( (α ·sqh β) =hor_trans_id_right_sq (hor_sq_identity g)) × ( (β ·sqh α) = hor_trans_id_right_sq (hor_sq_identity h)).
+  ( (α ·sqh β) =hor_trans_id_left_sq (hor_sq_identity g)) × ( (β ·sqh α) = hor_trans_id_left_sq (hor_sq_identity h)).
 
 Definition get_special_iso_squares {C: predoublecategory_sq_hor_data} {a b : C} (g: a -v-> b) (h: a -v-> b)
   : UU
@@ -519,25 +519,39 @@ Definition get_ver_associator {C: predoublecategory_sq_hor_ver_unit_assoc_data} 
     (f : a -v-> b) (g : b -v-> c) (h : c -v-> d) : sqq_iso_special (f ·v (g ·v h)) ((f ·v g) ·v h)
       := (pr222 C) a b c d f g h.
 
-Definition predoublecategory_ver_left_unitor_naturality ( C : predoublecategory_sq_hor_ver_unit_assoc_data) : UU :=
-  ∏ (a b c d : C)
+Definition predoublecategory_ver_left_unitor_naturality ( C : predoublecategory_sq_hor_ver_unit_assoc_data) : UU
+  := ∏ (a b c d : C)
   (f: a -h-> b) (g: a -v-> c) (h: b -v-> d) (k: c -h-> d)
   (α : sqq f g h k),
-    ( hor_trans_id_left_sq ( ((ver_sq_identity f) ·sqv α) ·sqh (pr1 (get_ver_left_unitor h)))  = hor_trans_assoc_sq  (hor_trans_id_right_sq  ( ((pr1 (get_ver_left_unitor g)) ·sqh α)))).
+    ((ver_sq_identity f) ·sqv α) ·sqh (pr1 (get_ver_left_unitor h))
+    =
+    boundary_sq_transport
+      (id_hor_right _ @ !(id_hor_left _))
+      (id_hor_right _ @ !(id_hor_left _))
+      ((pr1 (get_ver_left_unitor g)) ·sqh α).
 
 Definition predoublecategory_ver_right_unitor_naturality ( C : predoublecategory_sq_hor_ver_unit_assoc_data) : UU :=
   ∏ (a b c d : C)
   (f: a -h-> b) (g: a -v-> c) (h: b -v-> d) (k: c -h-> d)
   (α : sqq f g h k),
-  (( hor_trans_id_left_sq ((α ·sqv (ver_sq_identity k)) ·sqh (pr1 (get_ver_right_unitor h)))) = hor_trans_assoc_sq ( hor_trans_id_right_sq ((pr1 (get_ver_right_unitor g)) ·sqh α))).
+    (α ·sqv (ver_sq_identity k)) ·sqh (pr1 (get_ver_right_unitor h))
+     =
+     boundary_sq_transport
+      (id_hor_right _ @ !(id_hor_left _))
+      (id_hor_right _ @ !(id_hor_left _))
+      ((pr1 (get_ver_right_unitor g)) ·sqh α).
 
 Definition predoublecategory_ver_assoc_naturality ( C : predoublecategory_sq_hor_ver_unit_assoc_data) : UU :=
   ∏ (a0 a1 a2 a3 b0 b1 b2 b3 : C)
   (fa: a0 -v-> a1) (fb: b0 -v-> b1) (ha: a1 -v-> a2) (hb: b1 -v-> b2) (ka: a2 -v-> a3) (kb: b2 -v-> b3)
   (g0: a0 -h-> b0) (g1: a1 -h-> b1) (g2: a2 -h-> b2) (g3: a3 -h-> b3)
   (α : sqq g0 fa fb g1) (β : sqq g1 ha hb g2) (γ : sqq g2 ka kb g3),
-  (hor_trans_id_left_sq ( ( (α) ·sqv ( (β) ·sqv (γ)) ) ·sqh (pr1 (get_ver_associator fb hb kb)))) =
-  (hor_trans_assoc_sq  (hor_trans_id_right_sq ((pr1 (get_ver_associator fa ha ka)) ·sqh ( (α ·sqv β) ·sqv (γ) )) )).
+  ( (α) ·sqv ( (β) ·sqv (γ)) ) ·sqh (pr1 (get_ver_associator fb hb kb))
+  =
+  boundary_sq_transport
+      (id_hor_right _ @ !(id_hor_left _))
+      (id_hor_right _ @ !(id_hor_left _))
+      ((pr1 (get_ver_associator fa ha ka)) ·sqh ( (α ·sqv β) ·sqv (γ) )).
 
 Definition predoublecategory_ver_unitor_coherence ( C : predoublecategory_sq_hor_ver_unit_assoc_data) : UU :=
   ∏ (a b c: C)
@@ -567,7 +581,7 @@ Definition predoublecategory_interchange_id_obj  ( C : predoublecategory_sq_hor_
 
 Definition predoublecategory_interchange_id_hor  ( C : predoublecategory_sq_hor_ver_unit_assoc_data) : UU :=
   ∏ (a b c: C) (f: a -h-> b) (g: b -h-> c),
-    (ver_sq_identity f) ·sqh (ver_sq_identity g) =ver_sq_identity(f ·h g).
+  ver_sq_identity(f ·h g) = (ver_sq_identity f) ·sqh (ver_sq_identity g).
 
 
 Definition predoublecategory_interchange_id_ver  ( C : predoublecategory_sq_hor_ver_unit_assoc_data) : UU :=

--- a/UniMath/Bicategories/DoubleCategories/DoubleCatsUnfolded.v
+++ b/UniMath/Bicategories/DoubleCategories/DoubleCatsUnfolded.v
@@ -602,7 +602,10 @@ Notation "α ∘sqv β" := (ver_sq_compose α β) (at level 60).
 Section Pre_Double_Categories. (*Finally we define double categories by adding appropriate set truncation conditions. *)
 
 Definition has_sq_hor_homsets (C : predoublecategory_hor_sq) : UU :=
-  ∏ (a b c d : C) (g: a -v-> c) (h: b -v-> d), isaset (hom_sq_between_ver C g h).
+  ∏ (a b c d : C)
+    (g: a -v-> c) (h: b -v-> d)
+    (f : a -h-> b) (k : c -h-> d),
+    isaset (Sq[ a -hv- f h -hv-> b, c -vh- g k -vh-> d]).
 
 Definition doublecategory_hor_sq := ∑ C:predoublecategory_hor_sq, has_sq_hor_homsets C.
 
@@ -732,7 +735,7 @@ End Underlying_Category_Vertical_Morphisms_Squares.
 
 Section Double_Categories. (* We now use the underlying categories to define double categories *)
 
-Definition doublecategory := ∑ C:predoublecategory, (has_homsets (und_ob_hor_precategory C) × has_homsets (und_ver_precategory C)).
+  Definition doublecategory := ∑ C:predoublecategory, (has_homsets (und_ob_hor_precategory C) × has_sq_hor_homsets C).
 
 Definition make_doublecategory C h k : doublecategory := C,,h,,k.
 
@@ -740,16 +743,27 @@ Definition doublecategory_to_predoublecategory : doublecategory → predoublecat
 
 Coercion doublecategory_to_predoublecategory : doublecategory >-> predoublecategory.
 
-Coercion homset_sq_property (C : doublecategory) : (has_homsets (und_ob_hor_precategory C) × has_homsets (und_ver_precategory C)) := pr2 C.
+Coercion homset_sq_property (C : doublecategory) : (has_homsets (und_ob_hor_precategory C) × has_sq_hor_homsets C) := pr2 C.
 
 Definition und_ob_hor_cat (C: doublecategory) : category := make_category (und_ob_hor_precategory C) (pr12 C).
 
-Definition und_ver_cat (C: doublecategory) : category := make_category (und_ver_precategory C) (pr22 C).
-
+Definition und_ver_cat (C: doublecategory) : category.
+Proof.
+  use (make_category (und_ver_precategory C)).
+  intros x y.
+  use isaset_total2.
+  - apply C.
+  - intro.
+    use isaset_total2.
+    + apply C.
+    + intro.
+      apply C.
+Defined.
 End Double_Categories.
 
 Section Univalent_Double_Categories.
 (* We now use the underlying categories to define double univalence, as the univalence of the underlying two categories *)
+
 
 Definition is_double_univalent (C: doublecategory) := (is_univalent (und_ob_hor_cat C) × is_univalent (und_ver_cat C)).
 

--- a/UniMath/Bicategories/DoubleCategories/DoubleCatsUnfolded.v
+++ b/UniMath/Bicategories/DoubleCategories/DoubleCatsUnfolded.v
@@ -20,11 +20,12 @@
  *)
 
 Require Import UniMath.Foundations.Propositions.
-  Require Import UniMath.Foundations.Sets.
-  Require Import UniMath.MoreFoundations.PartA.
-  Require Import UniMath.MoreFoundations.Notations.
-  Require Import UniMath.CategoryTheory.Core.Prelude.
-
+Require Import UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.PartA.
+Require Import UniMath.MoreFoundations.Notations.
+Require Import UniMath.CategoryTheory.Core.Prelude.
+Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.TwoSidedDispCat.
+Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.Univalence.
 
 Section Definition_of_Double_Graphs.
 (*  Definition of a double graph.*)
@@ -849,15 +850,52 @@ Proof.
       apply C.
 Defined.
 
+Definition doublecategory_to_twosided_disp_cat_data
+           (C : doublecategory)
+  : twosided_disp_cat_data (und_ob_hor_cat C) (und_ob_hor_cat C).
+Proof.
+  use tpair.
+  - use tpair.
+    * intros x y.
+      exact (x -v-> y).
+    * intros x y z w f g h k.
+      exact (sqq h f g k).
+  - use tpair.
+    * intros x y f.
+      exact (hor_sq_identity f).
+    * intros x y z a b c f1 f2 f3 f4 f5 f6 f7 α β.
+      exact (α ·sqh β).
+Defined.
+
+Definition doublecategory_to_twosided_disp_cat
+           (C : doublecategory)
+  : twosided_disp_cat (und_ob_hor_cat C) (und_ob_hor_cat C).
+Proof.
+  use tpair.
+  - exact (doublecategory_to_twosided_disp_cat_data C).
+  - repeat split.
+    + intros x0 x1 y0 y1 f0 f1 g0 g1 α.
+      exact (id_hor_sq_left α).
+    + intros x0 x1 y0 y1 f0 f1 g0 g1 α.
+      exact (id_hor_sq_right α).
+    + intros ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? α β γ.
+      exact (assoc_sq_hor α β γ).
+    + intros x0 x1 y0 y1 f0 g0 f1 g1.
+      exact (get_has_sq_hor_homsets f0 g0 f1 g1).
+Defined.
+
 End Double_Categories.
 
 Section Univalent_Double_Categories.
 (* We now use the underlying categories to define double univalence, as the univalence of the underlying two categories *)
 
-Definition is_double_univalent (C: doublecategory) := (is_univalent (und_ob_hor_cat C) × is_univalent (und_ver_cat C)).
+  Definition is_double_univalent
+             (C : doublecategory)
+    := (is_univalent (und_ob_hor_cat C)
+        ×
+        is_univalent_twosided_disp_cat (doublecategory_to_twosided_disp_cat C)).
 
-Definition univalent_doublecategory : UU := ∑ (C: doublecategory), is_double_univalent C.
+  Definition univalent_doublecategory : UU := ∑ (C: doublecategory), is_double_univalent C.
 
-Coercion univalent_doublecategory_to_doublecategory (C: univalent_doublecategory) := pr1 C.
-
+  Coercion univalent_doublecategory_to_doublecategory (C: univalent_doublecategory) := pr1 C.
 End Univalent_Double_Categories.

--- a/UniMath/Bicategories/DoubleCategories/DoubleCatsUnfolded.v
+++ b/UniMath/Bicategories/DoubleCategories/DoubleCatsUnfolded.v
@@ -239,13 +239,22 @@ Definition sqq {C: predoublecategory_ob_mor_sq_data}
 {a b c d : C} (f: a -h-> b)  (g: a -v-> c) (h: b -v-> d) (k: c -h-> d):  UU
 := get_predoublecat_sq C a b c d f g h k.
 
-Definition boundary_sq_transport {C : predoublecategory_ob_mor_sq_data}
-{ a b c d : C } {f1: a -h-> b} {g1: a -v-> c} {h1: b -v-> d} {k1: c -h-> d}
-  {f2: a -h-> b} {k2: c -h-> d}
-    (eqf: f1 = f2) (eqk: k1 = k2)
-    (α : sqq f2 g1 h1 k2) : sqq f1 g1 h1 k1 :=
-    (transportb (fun k0 : c-h-> d => sqq f1 g1 h1 k0) eqk
-    (transportb (fun f0 : a-h-> b => sqq f0 g1 h1 k2) eqf α)).
+Definition boundary_sq_transport
+           {C : predoublecategory_ob_mor_sq_data}
+           { a b c d : C }
+           {f1: a -h-> b} {g1: a -v-> c}
+           {h1: b -v-> d} {k1: c -h-> d}
+           {f2: a -h-> b} {k2: c -h-> d}
+           (eqf: f1 = f2) (eqk: k1 = k2)
+           (α : sqq f2 g1 h1 k2)
+  : sqq f1 g1 h1 k1
+  := transportb
+       (fun f0 => sqq f0 _ _ _)
+       eqf
+       (transportb
+          (fun k0 => sqq _ _ _ k0)
+          eqk
+          α).
 
 End Squares.
 

--- a/UniMath/Bicategories/DoubleCategories/DoubleCatsUnfolded.v
+++ b/UniMath/Bicategories/DoubleCategories/DoubleCatsUnfolded.v
@@ -519,39 +519,39 @@ Definition get_ver_associator {C: predoublecategory_sq_hor_ver_unit_assoc_data} 
     (f : a -v-> b) (g : b -v-> c) (h : c -v-> d) : sqq_iso_special (f ·v (g ·v h)) ((f ·v g) ·v h)
       := (pr222 C) a b c d f g h.
 
-Definition predoublecategory_ver_left_unitor_naturality ( C : predoublecategory_sq_hor_ver_unit_assoc_data) : UU
-  := ∏ (a b c d : C)
-  (f: a -h-> b) (g: a -v-> c) (h: b -v-> d) (k: c -h-> d)
-  (α : sqq f g h k),
-    ((ver_sq_identity f) ·sqv α) ·sqh (pr1 (get_ver_left_unitor h))
-    =
-    boundary_sq_transport
-      (id_hor_right _ @ !(id_hor_left _))
-      (id_hor_right _ @ !(id_hor_left _))
-      ((pr1 (get_ver_left_unitor g)) ·sqh α).
+      Definition predoublecategory_ver_left_unitor_naturality ( C : predoublecategory_sq_hor_ver_unit_assoc_data) : UU
+      := ∏ (a b c d : C)
+      (f: a -h-> b) (g: a -v-> c) (h: b -v-> d) (k: c -h-> d)
+      (α : sqq f g h k),
+        ((ver_sq_identity f) ·sqv α) ·sqh (pr1 (get_ver_left_unitor h))
+        =
+        boundary_sq_transport
+          (id_hor_right _ @ !(id_hor_left _))
+          (id_hor_right _ @ !(id_hor_left _))
+          ((pr1 (get_ver_left_unitor g)) ·sqh α).
 
-Definition predoublecategory_ver_right_unitor_naturality ( C : predoublecategory_sq_hor_ver_unit_assoc_data) : UU :=
-  ∏ (a b c d : C)
-  (f: a -h-> b) (g: a -v-> c) (h: b -v-> d) (k: c -h-> d)
-  (α : sqq f g h k),
-    (α ·sqv (ver_sq_identity k)) ·sqh (pr1 (get_ver_right_unitor h))
-     =
-     boundary_sq_transport
-      (id_hor_right _ @ !(id_hor_left _))
-      (id_hor_right _ @ !(id_hor_left _))
-      ((pr1 (get_ver_right_unitor g)) ·sqh α).
+      Definition predoublecategory_ver_right_unitor_naturality ( C : predoublecategory_sq_hor_ver_unit_assoc_data) : UU :=
+      ∏ (a b c d : C)
+      (f: a -h-> b) (g: a -v-> c) (h: b -v-> d) (k: c -h-> d)
+      (α : sqq f g h k),
+        (α ·sqv (ver_sq_identity k)) ·sqh (pr1 (get_ver_right_unitor h))
+         =
+         boundary_sq_transport
+          (id_hor_right _ @ !(id_hor_left _))
+          (id_hor_right _ @ !(id_hor_left _))
+          ((pr1 (get_ver_right_unitor g)) ·sqh α).
 
-Definition predoublecategory_ver_assoc_naturality ( C : predoublecategory_sq_hor_ver_unit_assoc_data) : UU :=
-  ∏ (a0 a1 a2 a3 b0 b1 b2 b3 : C)
-  (fa: a0 -v-> a1) (fb: b0 -v-> b1) (ha: a1 -v-> a2) (hb: b1 -v-> b2) (ka: a2 -v-> a3) (kb: b2 -v-> b3)
-  (g0: a0 -h-> b0) (g1: a1 -h-> b1) (g2: a2 -h-> b2) (g3: a3 -h-> b3)
-  (α : sqq g0 fa fb g1) (β : sqq g1 ha hb g2) (γ : sqq g2 ka kb g3),
-  ( (α) ·sqv ( (β) ·sqv (γ)) ) ·sqh (pr1 (get_ver_associator fb hb kb))
-  =
-  boundary_sq_transport
-      (id_hor_right _ @ !(id_hor_left _))
-      (id_hor_right _ @ !(id_hor_left _))
-      ((pr1 (get_ver_associator fa ha ka)) ·sqh ( (α ·sqv β) ·sqv (γ) )).
+    Definition predoublecategory_ver_assoc_naturality ( C : predoublecategory_sq_hor_ver_unit_assoc_data) : UU :=
+      ∏ (a0 a1 a2 a3 b0 b1 b2 b3 : C)
+      (fa: a0 -v-> a1) (fb: b0 -v-> b1) (ha: a1 -v-> a2) (hb: b1 -v-> b2) (ka: a2 -v-> a3) (kb: b2 -v-> b3)
+      (g0: a0 -h-> b0) (g1: a1 -h-> b1) (g2: a2 -h-> b2) (g3: a3 -h-> b3)
+      (α : sqq g0 fa fb g1) (β : sqq g1 ha hb g2) (γ : sqq g2 ka kb g3),
+      ( (α) ·sqv ( (β) ·sqv (γ)) ) ·sqh (pr1 (get_ver_associator fb hb kb))
+      =
+      boundary_sq_transport
+          (id_hor_right _ @ !(id_hor_left _))
+          (id_hor_right _ @ !(id_hor_left _))
+          ((pr1 (get_ver_associator fa ha ka)) ·sqh ( (α ·sqv β) ·sqv (γ) )).
 
 Definition predoublecategory_ver_unitor_coherence ( C : predoublecategory_sq_hor_ver_unit_assoc_data) : UU :=
   ∏ (a b c: C)
@@ -579,20 +579,21 @@ Definition predoublecategory_interchange_comp ( C : predoublecategory_sq_hor_ver
 Definition predoublecategory_interchange_id_obj  ( C : predoublecategory_sq_hor_ver_unit_assoc_data) : UU :=
   ∏ (a :C), ver_sq_identity (hor_identity a) = hor_sq_identity (ver_identity a).
 
+
 Definition predoublecategory_interchange_id_hor  ( C : predoublecategory_sq_hor_ver_unit_assoc_data) : UU :=
   ∏ (a b c: C) (f: a -h-> b) (g: b -h-> c),
-  ver_sq_identity(f ·h g) = (ver_sq_identity f) ·sqh (ver_sq_identity g).
+     ver_sq_identity(f ·h g) = (ver_sq_identity f) ·sqh (ver_sq_identity g).
 
 
 Definition predoublecategory_interchange_id_ver  ( C : predoublecategory_sq_hor_ver_unit_assoc_data) : UU :=
    ∏ (a b c: C) (f: a -v-> b) (g: b -v-> c),
     (hor_sq_identity f) ·sqv (hor_sq_identity g) =hor_sq_identity(f ·v g).
 
-      Definition predoublecategory_interchange  ( C : predoublecategory_sq_hor_ver_unit_assoc_data) : UU :=
+Definition predoublecategory_interchange  ( C : predoublecategory_sq_hor_ver_unit_assoc_data) : UU :=
         predoublecategory_interchange_id_obj C ×
-          predoublecategory_interchange_id_hor C ×
-          predoublecategory_interchange_id_ver C ×
-           predoublecategory_interchange_comp C.
+        predoublecategory_interchange_id_hor C ×
+        predoublecategory_interchange_id_ver C ×
+        predoublecategory_interchange_comp C.
 
 End Vertical_Unitor_and_Associator_Coherences.
 
@@ -620,10 +621,92 @@ Definition predoublecategory : UU :=
     (predoublecategory_ver_assoc_naturality C) ×
     (predoublecategory_ver_unitor_coherence C) ×
     (predoublecategory_ver_assoc_coherence C) ×
-    (predoublecategory_interchange C)) .
+    (predoublecategory_interchange C)).
+
 
 Coercion predoublecategory_sq_hor_ver_unit_assoc_data_from_predoublecategory (C: predoublecategory)
     : predoublecategory_sq_hor_ver_unit_assoc_data := pr1 C.
+
+Definition get_predoublecategory_ver_left_unitor_naturality
+  {C : predoublecategory} {a b c d : C}
+  {f: a -h-> b} {g: a -v-> c} {h: b -v-> d} {k: c -h-> d}
+  (α : sqq f g h k) :
+  ((ver_sq_identity f) ·sqv α) ·sqh (pr1 (get_ver_left_unitor h))	=
+        boundary_sq_transport
+          (id_hor_right _ @ !(id_hor_left _))
+          (id_hor_right _ @ !(id_hor_left _))
+          ((pr1 (get_ver_left_unitor g)) ·sqh α) :=
+          (pr12 C) a b c d f g h k α.
+
+
+Definition get_predoublecategory_ver_right_unitor_naturality
+  {C : predoublecategory}
+  {a b c d : C}
+    {f: a -h-> b} {g: a -v-> c} {h: b -v-> d} {k: c -h-> d}
+    (α : sqq f g h k) :
+      (α ·sqv (ver_sq_identity k)) ·sqh (pr1 (get_ver_right_unitor h))
+       =
+       boundary_sq_transport
+        (id_hor_right _ @ !(id_hor_left _))
+        (id_hor_right _ @ !(id_hor_left _))
+        ((pr1 (get_ver_right_unitor g)) ·sqh α) :=
+        (pr122 C) a b c d f g h k α.
+
+
+Definition get_predoublecategory_ver_assoc_naturality
+  {C : predoublecategory}
+  {a0 a1 a2 a3 b0 b1 b2 b3 : C}
+  {fa: a0 -v-> a1} {fb: b0 -v-> b1} {ha: a1 -v-> a2} {hb: b1 -v-> b2} {ka: a2 -v-> a3} {kb: b2 -v-> b3}
+      {g0: a0 -h-> b0} {g1: a1 -h-> b1} {g2: a2 -h-> b2} {g3: a3 -h-> b3}
+      (α : sqq g0 fa fb g1) (β : sqq g1 ha hb g2) (γ : sqq g2 ka kb g3) :
+      ( ( (α) ·sqv ( (β) ·sqv (γ)) ) ·sqh (pr1 (get_ver_associator fb hb kb))	=
+      boundary_sq_transport
+          (id_hor_right _ @ !(id_hor_left _))
+          (id_hor_right _ @ !(id_hor_left _))
+          ((pr1 (get_ver_associator fa ha ka)) ·sqh ( (α ·sqv β) ·sqv (γ) )) ) :=
+          (pr1 (pr222 C)) a0 a1 a2 a3 b0 b1 b2 b3 fa fb ha hb ka kb g0 g1 g2 g3 α β γ.
+
+Definition get_predoublecategory_ver_unitor_coherence
+  {C : predoublecategory}
+  {a b c: C} (f: a -v-> b) (g: b -v-> c) :
+    ( ((pr1 (get_ver_associator f (ver_identity b) g)) ·sqh ( (pr1 (get_ver_right_unitor f)) ·sqv (hor_sq_identity g) ))  =
+      hor_trans_id_left_sq ((hor_sq_identity f) ·sqv (pr1 (get_ver_left_unitor g))))
+      := (pr12 (pr222 C)) a b c f g.
+
+Definition get_predoublecategory_ver_assoc_coherence
+  {C : predoublecategory}
+  {a b c d e: C} (f : a -v-> b) (g : b -v-> c) (h : c -v-> d) (k : d -v-> e) :
+    ( (hor_trans_id_right_sq ( (pr1 (get_ver_associator f g (h ·v k))) ·sqh (pr1 (get_ver_associator (f ·v g) h k)) ))  =
+    ( ( ( (hor_sq_identity f) ·sqv (pr1 (get_ver_associator g h k)) )
+    ·sqh (pr1 (get_ver_associator f (g ·v h) k)) )
+    ·sqh  (  (pr1 (get_ver_associator f g h)) ·sqv (hor_sq_identity k)) ) )
+    := (pr122 (pr222 C)) a b c d e f g h k.
+
+Definition get_predoublecategory_interchange_comp
+    {C : predoublecategory}
+    {a0 a1 a2 b0 b1 b2 c0 c1 c2 : C}
+  {fa: a0 -h-> a1} {ga: a1 -h-> a2} {fb: b0 -h-> b1} {gb: b1 -h-> b2} {fc: c0 -h-> c1} {gc: c1 -h-> c2}
+  {h0: a0 -v-> b0} {k0: b0 -v-> c0} {h1: a1 -v-> b1} {k1: b1 -v-> c1} {h2: a2 -v-> b2} {k2: b2 -v-> c2}
+  (α : sqq fa h0 h1 fb)
+  (β : sqq ga h1 h2 gb)
+  (γ : sqq fb k0 k1 fc)
+  (δ : sqq gb k1 k2 gc) : (α ·sqh β) ·sqv (γ ·sqh δ) = (α ·sqv γ) ·sqh (β ·sqv δ)
+    := pr222 (pr222 (pr222 C)) a0 a1 a2 b0 b1 b2 c0 c1 c2 fa ga fb gb fc gc h0 k0 h1 k1 h2 k2 α β γ δ.
+
+
+Definition get_predoublecategory_interchange_id_obj {C : predoublecategory}
+      (a :C) : ver_sq_identity (hor_identity a) = hor_sq_identity (ver_identity a)
+      := (pr1 (pr222 (pr222 C))) a.
+
+Definition get_predoublecategory_interchange_id_hor  {C : predoublecategory}
+       {a b c: C} (f: a -h-> b) (g: b -h-> c) :
+         ver_sq_identity(f ·h g) = (ver_sq_identity f) ·sqh (ver_sq_identity g)
+    := (pr12 (pr222 (pr222 C))) a b c f g.
+
+Definition get_predoublecategory_interchange_id_ver  {C : predoublecategory}
+       {a b c: C} (f: a -v-> b) (g: b -v-> c) :
+        (hor_sq_identity f) ·sqv (hor_sq_identity g) =hor_sq_identity(f ·v g)
+        := (pr122 (pr222 (pr222 C))) a b c f g.
 
 End Pre_Double_Categories.
 
@@ -735,7 +818,7 @@ End Underlying_Category_Vertical_Morphisms_Squares.
 
 Section Double_Categories. (* We now use the underlying categories to define double categories *)
 
-  Definition doublecategory := ∑ C:predoublecategory, (has_homsets (und_ob_hor_precategory C) × has_sq_hor_homsets C).
+Definition doublecategory := ∑ C:predoublecategory, (has_homsets (und_ob_hor_precategory C) × has_sq_hor_homsets C).
 
 Definition make_doublecategory C h k : doublecategory := C,,h,,k.
 
@@ -744,6 +827,12 @@ Definition doublecategory_to_predoublecategory : doublecategory → predoublecat
 Coercion doublecategory_to_predoublecategory : doublecategory >-> predoublecategory.
 
 Coercion homset_sq_property (C : doublecategory) : (has_homsets (und_ob_hor_precategory C) × has_sq_hor_homsets C) := pr2 C.
+
+Definition get_has_sq_hor_homsets
+{C : doublecategory} {a b c d : C}
+(g: a -v-> c) (h: b -v-> d)
+(f : a -h-> b) (k : c -h-> d) :isaset (Sq[ a -hv- f h -hv-> b, c -vh- g k -vh-> d])
+  := (pr22 C) a b c d g h f k.
 
 Definition und_ob_hor_cat (C: doublecategory) : category := make_category (und_ob_hor_precategory C) (pr12 C).
 
@@ -759,11 +848,11 @@ Proof.
     + intro.
       apply C.
 Defined.
+
 End Double_Categories.
 
 Section Univalent_Double_Categories.
 (* We now use the underlying categories to define double univalence, as the univalence of the underlying two categories *)
-
 
 Definition is_double_univalent (C: doublecategory) := (is_univalent (und_ob_hor_cat C) × is_univalent (und_ver_cat C)).
 

--- a/UniMath/Bicategories/DoubleCategories/Examples/ProductDoubleCat.v
+++ b/UniMath/Bicategories/DoubleCategories/Examples/ProductDoubleCat.v
@@ -228,13 +228,13 @@ Section ProdOfDoubleCat.
         prod_double_cat_associator.
   Proof.
     intro ; intros ; cbn.
-    rewrite transportf_twosided_disp_cat_product.
+    rewrite transportb_twosided_disp_cat_product.
     use dirprodeq ; cbn.
-    - refine (_ @ double_triangle _ _).
-      apply transportf_disp_mor2_eq.
+    - refine (double_triangle _ _ @ _).
+      apply transportb_disp_mor2_eq.
       apply idpath.
-    - refine (_ @ double_triangle _ _).
-      apply transportf_disp_mor2_eq.
+    - refine (double_triangle _ _ @ _).
+      apply transportb_disp_mor2_eq.
       apply idpath.
   Qed.
 

--- a/UniMath/Bicategories/DoubleCategories/Examples/SpansDoubleCat.v
+++ b/UniMath/Bicategories/DoubleCategories/Examples/SpansDoubleCat.v
@@ -263,7 +263,7 @@ Section SpansDoubleCat.
   Proof.
     intro ; intros.
     use span_sqr_eq.
-    rewrite transportf_disp_mor2_span ; cbn.
+    rewrite transportb_disp_mor2_span ; cbn.
     use (MorphismsIntoPullbackEqual (isPullback_Pullback (PC _ _ _ _ _))) ; cbn.
     - unfold span_associator_mor, mor_of_comp_span_mor ; cbn.
       rewrite !assoc'.

--- a/UniMath/Bicategories/DoubleCategories/Examples/StructuredCospansDoubleCat.v
+++ b/UniMath/Bicategories/DoubleCategories/Examples/StructuredCospansDoubleCat.v
@@ -309,7 +309,7 @@ Section StructuredCospansDoubleCat.
   Proof.
     intro ; intros.
     use struct_cospan_sqr_eq.
-    rewrite transportf_disp_mor2_struct_cospan ; cbn.
+    rewrite transportb_disp_mor2_struct_cospan ; cbn.
     use (MorphismsOutofPushoutEqual (isPushout_Pushout (PX _ _ _ _ _))) ; cbn.
     - unfold struct_cospan_associator_mor, mor_of_comp_struct_cospan_mor ; cbn.
       rewrite !assoc.

--- a/UniMath/Bicategories/DoubleCategories/UnfoldedDoubleCatstoDoubleCats.v
+++ b/UniMath/Bicategories/DoubleCategories/UnfoldedDoubleCatstoDoubleCats.v
@@ -337,26 +337,20 @@ Section DoubleCats_to_DoubleCatsUnfolded.
       simple refine (_ ,, _ ,, _ ,, _) ; cbn.
       + exact (lunitor_h f).
       + exact (linvunitor_h f).
-      + refine (lunitor_linvunitor_h f @ _).
-        apply TODO.
-      + refine (linvunitor_lunitor_h f @ _).
-        apply TODO.
+      + exact (lunitor_linvunitor_h f).
+      + exact (linvunitor_lunitor_h f).
     - intros x y f.
       simple refine (_ ,, _ ,, _ ,, _) ; cbn.
       + exact (runitor_h f).
       + exact (rinvunitor_h f).
-      + refine (runitor_rinvunitor_h f @ _).
-        apply TODO.
-      + refine (rinvunitor_runitor_h f @ _).
-        apply TODO.
+      + exact (runitor_rinvunitor_h f).
+      + exact (rinvunitor_runitor_h f).
     - intros w x y z f g h.
       simple refine (_ ,, _ ,, _ ,, _) ; cbn.
       + exact (lassociator_h f g h).
       + exact (rassociator_h f g h).
-      + refine (lassociator_rassociator_h f g h @ _).
-        apply TODO.
-      + refine (rassociator_lassociator_h f g h @ _).
-        apply TODO.
+      + exact (lassociator_rassociator_h f g h).
+      + exact (rassociator_lassociator_h f g h).
   Defined.
 
   Definition double_cat_to_predoublecategory_sq_hor_ver_unit_assoc_data
@@ -371,44 +365,52 @@ Section DoubleCats_to_DoubleCatsUnfolded.
     : predoublecategory_ver_left_unitor_naturality
         double_cat_to_predoublecategory_sq_hor_ver_unit_assoc_data.
   Proof.
-    unfold predoublecategory_ver_left_unitor_naturality ; cbn.
     intros w x y z v₁ h₁ h₂ v₂ α.
-    etrans.
-    {
-      apply maponpaths.
-      exact (lunitor_square α).
-    }
-  Admitted.
+    exact (lunitor_square α).
+  Defined.
 
   Proposition double_cat_to_predoublecategory_ver_right_unitor_naturality
     : predoublecategory_ver_right_unitor_naturality
         double_cat_to_predoublecategory_sq_hor_ver_unit_assoc_data.
   Proof.
-  Admitted.
+    intros w x y z v₁ h₁ h₂ v₂ α.
+    exact (runitor_square α).
+  Defined.
 
   Proposition double_cat_to_predoublecategory_ver_assoc_naturality
     : predoublecategory_ver_assoc_naturality
         double_cat_to_predoublecategory_sq_hor_ver_unit_assoc_data.
   Proof.
-  Admitted.
+    intro ; intros ; cbn.
+    apply lassociator_h_square.
+  Defined.
 
   Proposition double_cat_to_predoublecategory_ver_unitor_coherence
     : predoublecategory_ver_unitor_coherence
         double_cat_to_predoublecategory_sq_hor_ver_unit_assoc_data.
   Proof.
+    intro ; intros ; cbn.
+
   Admitted.
 
   Proposition double_cat_to_predoublecategory_ver_assoc_coherence
     : predoublecategory_ver_assoc_coherence
         double_cat_to_predoublecategory_sq_hor_ver_unit_assoc_data.
   Proof.
-  Admitted.
+    intro ; intros ; cbn.
+    apply double_pentagon.
+  Defined.
 
   Proposition double_cat_to_predoublecategory_interchange
     : predoublecategory_interchange
         double_cat_to_predoublecategory_sq_hor_ver_unit_assoc_data.
   Proof.
-  Admitted.
+    repeat split ; intro ; intros ; cbn.
+    - apply id_h_square_id.
+    - apply id_h_square_comp.
+    - apply comp_h_square_id.
+    - apply comp_h_square_comp.
+  Defined.
 
   Definition double_cat_to_predoublecategory
     : predoublecategory.

--- a/UniMath/Bicategories/DoubleCategories/UnfoldedDoubleCatstoDoubleCats.v
+++ b/UniMath/Bicategories/DoubleCategories/UnfoldedDoubleCatstoDoubleCats.v
@@ -431,6 +431,7 @@ Section DoubleCats_to_DoubleCatsUnfolded.
     use make_doublecategory.
     - exact double_cat_to_predoublecategory.
     - apply homset_property.
-    - apply TODO.
+    - intro ; intros ; cbn.
+      apply isaset_disp_mor.
   Defined.
 End DoubleCats_to_DoubleCatsUnfolded.

--- a/UniMath/Bicategories/DoubleCategories/UnfoldedDoubleCatstoDoubleCats.v
+++ b/UniMath/Bicategories/DoubleCategories/UnfoldedDoubleCatstoDoubleCats.v
@@ -390,8 +390,8 @@ Section DoubleCats_to_DoubleCatsUnfolded.
         double_cat_to_predoublecategory_sq_hor_ver_unit_assoc_data.
   Proof.
     intro ; intros ; cbn.
-
-  Admitted.
+    apply double_triangle.
+  Defined.
 
   Proposition double_cat_to_predoublecategory_ver_assoc_coherence
     : predoublecategory_ver_assoc_coherence

--- a/UniMath/Bicategories/DoubleCategories/UnfoldedDoubleCatstoDoubleCats.v
+++ b/UniMath/Bicategories/DoubleCategories/UnfoldedDoubleCatstoDoubleCats.v
@@ -1,0 +1,434 @@
+(** * Double Categories
+
+  Authors: Benedikt Ahrens, Paige North, Nima Rasekh, Niels van der Weide
+  June 2023
+  Based on definition of weak double category in Section 3.3 of the book Higher Dimensional Categories by Marco Grandis.
+ *)
+
+
+(** ** Contents :
+
+  - Define a pre double category as a ``weak double category`` in the sense of Grandis.
+    This means one direction is weak and the other direction is strict.
+
+  - Double categories: A double category is a pre-double category with two set-truncated hom sets.
+  -
+  - Univalent Double Categories: A univalent double category is a double category with two univalent underlying categories.
+
+  - The structure is defined from scratch rather than building on a category.
+    This makes further generalizations easier.
+ *)
+
+Require Import UniMath.Foundations.Propositions.
+Require Import UniMath.Foundations.Sets.
+Require Import UniMath.MoreFoundations.PartA.
+Require Import UniMath.MoreFoundations.Notations.
+Require Import UniMath.CategoryTheory.Core.Prelude.
+
+Require Import UniMath.CategoryTheory.Core.Categories.
+Require Import UniMath.CategoryTheory.Core.Functors.
+Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
+Require Import UniMath.CategoryTheory.Core.Isos.
+Require Import UniMath.CategoryTheory.Core.Univalence.
+Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.TwoSidedDispCat.
+Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.DisplayedFunctor.
+Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.DisplayedNatTrans.
+Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.Isos.
+Require Import UniMath.CategoryTheory.TwoSidedDisplayedCats.Univalence.
+Require Import UniMath.Bicategories.Core.Bicat.
+Import Bicat.Notations.
+Require Import UniMath.Bicategories.Core.Invertible_2cells.
+Require Import UniMath.Bicategories.DisplayedBicats.DispBicat.
+Import DispBicat.Notations.
+Require Import UniMath.Bicategories.DoubleCategories.DoubleCategoryBasics.
+Require Import UniMath.Bicategories.DoubleCategories.DoubleFunctor.
+Require Import UniMath.Bicategories.DoubleCategories.DoubleTransformation.
+Require Import UniMath.Bicategories.DoubleCategories.BicatOfDoubleCats.
+Require Import UniMath.Bicategories.DoubleCategories.DoubleCats.
+Require Import UniMath.Bicategories.DoubleCategories.DoubleCatsUnfolded.
+
+Local Open Scope cat.
+Local Open Scope double_cat.
+
+Definition TODO { A : UU} : A.
+Admitted.
+
+Section DoubleCatsUnfolded_to_DoubleCats.
+  Context (C : doublecategory).
+
+  Definition doublecategory_to_cat : category :=
+     (und_ob_hor_cat C).
+
+  Definition doublecategory_to_twosided_disp_cat_data
+    : twosided_disp_cat_data  (und_ob_hor_cat C) (und_ob_hor_cat C).
+   Proof.
+     use tpair.
+     - use tpair.
+       * intros x y.
+         exact (x -v-> y).
+       * intros x y z w f g h k.
+         exact (sqq h f g k).
+     - use tpair.
+       * intros x y f.
+         exact (hor_sq_identity f).
+       * intros x y z a b c f1 f2 f3 f4 f5 f6 f7 α β.
+         exact (α ·sqh β).
+   Defined.
+
+   Definition doublecategory_to_twosided_disp_cat
+     : twosided_disp_cat doublecategory_to_cat doublecategory_to_cat.
+   Proof.
+      use tpair.
+      - exact doublecategory_to_twosided_disp_cat_data.
+      - repeat split.
+        + intros x0 x1 y0 y1 f0 f1 g0 g1 α.
+          exact (id_hor_sq_left α).
+        + intros x0 x1 y0 y1 f0 f1 g0 g1 α.
+          exact (id_hor_sq_right α).
+        + intros ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? α β γ.
+          exact (assoc_sq_hor α β γ).
+        + intros ? ? ? ? ? ? ? ?.
+          apply TODO. (* this law is formulated differently! *)
+   Defined.
+
+   Let D : twosided_disp_cat doublecategory_to_cat doublecategory_to_cat
+     := doublecategory_to_twosided_disp_cat.
+
+   Definition doublecategory_to_horid : hor_id D.
+   Proof.
+     use make_hor_id.
+     - use make_hor_id_data.
+       + apply TODO.
+       + apply TODO.
+     - split.
+       + apply TODO.
+       + apply TODO.
+   Defined.
+
+   Let I : hor_id D := doublecategory_to_horid.
+
+   Definition doublecategory_to_horcomp : hor_comp D.
+   Proof.
+     use make_hor_comp.
+     - use make_hor_comp_data.
+       + apply TODO.
+       + apply TODO.
+     - split.
+       + apply TODO.
+       + apply TODO.
+   Defined.
+
+   Let Cm : hor_comp D := doublecategory_to_horcomp.
+
+   Definition  doublecategory_to_lunitor : double_cat_lunitor I Cm.
+   Proof.
+     use make_double_lunitor.
+     - intros x y h.
+       use make_iso_twosided_disp.
+       + apply TODO.
+       + simple refine (_ ,, _ ,, _).
+         * apply TODO.
+         * apply TODO.
+         * apply TODO.
+     - apply TODO.
+   Defined.
+
+   Let l : double_cat_lunitor I Cm := doublecategory_to_lunitor.
+
+   Definition doublecategory_to_runitor : double_cat_runitor I Cm.
+   Proof.
+     use make_double_runitor.
+     - intros x y h.
+       use make_iso_twosided_disp.
+       + apply TODO.
+       + simple refine (_ ,, _ ,, _).
+         * apply TODO.
+         * apply TODO.
+         * apply TODO.
+     - apply TODO.
+   Defined.
+
+   Let r : double_cat_runitor I Cm := doublecategory_to_runitor.
+
+   Definition doublecategory_to_associator : double_cat_associator Cm.
+   Proof.
+     use make_double_associator.
+     - intros w x y z h₁ h₂ h₃.
+       use make_iso_twosided_disp.
+       + apply TODO.
+       + simple refine (_ ,, _ ,, _).
+         * apply TODO.
+         * apply TODO.
+         * apply TODO.
+     - apply TODO.
+   Defined.
+
+   Let a : double_cat_associator Cm := doublecategory_to_associator.
+
+   Proposition doublecategory_to_triangle : triangle_law l r a.
+   Proof.
+   Admitted.
+
+   Let tr : triangle_law l r a := doublecategory_to_triangle.
+
+   Proposition doublecategory_to_pentagon : pentagon_law a.
+   Proof.
+   Admitted.
+
+   Let pe : pentagon_law a := doublecategory_to_pentagon.
+
+   Definition is_univalent_und_ob_hor_cat : is_univalent (und_ob_hor_cat C).
+   Proof.
+   Admitted.
+
+   Let HC : is_univalent (und_ob_hor_cat C) := is_univalent_und_ob_hor_cat.
+
+   Definition is_univalent_doublecategory_to_twosided_disp_cat
+     : is_univalent_twosided_disp_cat D.
+   Proof.
+   Admitted.
+
+   Let HD : is_univalent_twosided_disp_cat D
+     := is_univalent_doublecategory_to_twosided_disp_cat.
+
+   Definition  doublecategory_to_double_cat : double_cat :=
+     make_double_cat (und_ob_hor_cat C) D I Cm l r a tr pe HC HD.
+End DoubleCatsUnfolded_to_DoubleCats.
+
+Section DoubleCats_to_DoubleCatsUnfolded.
+  Context (C : double_cat).
+
+  Definition double_cat_to_predoublecategory_ob_mor_hor
+    : predoublecategory_ob_mor_hor.
+  Proof.
+    simple refine (_ ,, _).
+    - exact C.
+    - exact (λ x y, x -->v y).
+  Defined.
+
+  Definition double_cat_to_predoublecategory_ob_mor_data
+    : predoublecategory_ob_mor_data.
+  Proof.
+    simple refine (_ ,, _).
+    - exact double_cat_to_predoublecategory_ob_mor_hor.
+    - exact (λ x y, x -->h y).
+  Defined.
+
+  Definition double_cat_to_predoublecategory_hor_id_comp
+    : predoublecategory_hor_id_comp double_cat_to_predoublecategory_ob_mor_data.
+  Proof.
+    split.
+    - exact (λ x, identity x).
+    - exact (λ x y z f g, f · g).
+  Defined.
+
+  Definition double_cat_to_predoublecategory_hor_precat_data
+    : predoublecategory_hor_precat_data.
+  Proof.
+    simple refine (_ ,, _).
+    - exact double_cat_to_predoublecategory_ob_mor_data.
+    - exact double_cat_to_predoublecategory_hor_id_comp.
+  Defined.
+
+  Proposition double_cat_to_is_predoublecategory_hor
+    : is_predoublecategory_hor double_cat_to_predoublecategory_hor_precat_data.
+  Proof.
+    repeat split.
+    - intro ; intros ; cbn.
+      apply id_left.
+    - intro ; intros ; cbn.
+      apply id_right.
+    - intro ; intros ; cbn.
+      apply assoc.
+    - intro ; intros ; cbn.
+      apply assoc'.
+  Defined.
+
+  Definition double_cat_to_predoublecategory_hor
+    : predoublecategory_hor.
+  Proof.
+    simple refine (_ ,, _).
+    - exact double_cat_to_predoublecategory_hor_precat_data.
+    - exact double_cat_to_is_predoublecategory_hor.
+  Defined.
+
+  Definition double_cat_to_predoublecategory_ver_id_comp
+    : predoublecategory_ver_id_comp double_cat_to_predoublecategory_hor.
+  Proof.
+    split.
+    - exact (λ x, identity_h x).
+    - exact (λ x y z f g, f ·h g).
+  Defined.
+
+  Definition double_cat_to_predoublecategory_hor_cat_ver_precat_data
+    : predoublecategory_hor_cat_ver_precat_data.
+  Proof.
+    simple refine (_ ,, _).
+    - exact double_cat_to_predoublecategory_hor.
+    - exact double_cat_to_predoublecategory_ver_id_comp.
+  Defined.
+
+  Definition double_cat_to_predoublecategory_ob_mor_sq_data
+    : predoublecategory_ob_mor_sq_data.
+  Proof.
+    simple refine (_ ,, _).
+    - exact double_cat_to_predoublecategory_hor_cat_ver_precat_data.
+    - exact (λ w x y z v₁ h₁ h₂ v₂, square v₁ v₂ h₁ h₂).
+  Defined.
+
+  Definition double_cat_to_predoublecategory_sq_hor_id_comp
+    : predoublecategory_sq_hor_id_comp double_cat_to_predoublecategory_ob_mor_sq_data.
+  Proof.
+    split.
+    - exact (λ x y f, id_v_square f).
+    - exact (λ _ _ _ _ _ _ _ _ _ _ _ _ _ s₁ s₂, s₁ ⋆v s₂).
+  Defined.
+
+  Definition double_cat_to_predoublecategory_sq_hor_data
+    : predoublecategory_sq_hor_data.
+  Proof.
+    simple refine (_ ,, _).
+    - exact double_cat_to_predoublecategory_ob_mor_sq_data.
+    - exact double_cat_to_predoublecategory_sq_hor_id_comp.
+  Defined.
+
+  Proposition double_cat_to_is_predoublecategory_hor_sq
+    : is_predoublecategory_hor_sq double_cat_to_predoublecategory_sq_hor_data.
+  Proof.
+    repeat split.
+    - intro ; intros ; cbn.
+      apply square_id_left_v.
+    - intro ; intros ; cbn.
+      apply square_id_right_v.
+    - intro ; intros ; cbn.
+      apply square_assoc_v.
+  Defined.
+
+  Definition double_cat_to_predoublecategory_hor_sq
+    : predoublecategory_hor_sq.
+  Proof.
+    simple refine (_ ,, _).
+    - exact double_cat_to_predoublecategory_sq_hor_data.
+    - exact double_cat_to_is_predoublecategory_hor_sq.
+  Defined.
+
+  Definition double_cat_to_predoublecategory_sq_ver_id_comp
+    : predoublecategory_sq_ver_id_comp double_cat_to_predoublecategory_hor_sq.
+  Proof.
+    split.
+    - exact (λ x y f, id_h_square f).
+    - exact (λ _ _ _ _ _ _ _ _ _ _ _ _ _ s₁ s₂, s₁ ⋆h s₂).
+  Defined.
+
+  Definition double_cat_to_predoublecategory_sq_hor_ver_data
+    : predoublecategory_sq_hor_ver_data.
+  Proof.
+    simple refine (_ ,, _).
+    - exact double_cat_to_predoublecategory_hor_sq.
+    - exact double_cat_to_predoublecategory_sq_ver_id_comp.
+  Defined.
+
+  Proposition double_cat_to_has_predoublecategory_sq_hor_ver_unit_assoc
+    : has_predoublecategory_sq_hor_ver_unit_assoc
+        double_cat_to_predoublecategory_sq_hor_ver_data.
+  Proof.
+    repeat split ; cbn.
+    - intros x y f.
+      simple refine (_ ,, _ ,, _ ,, _) ; cbn.
+      + exact (lunitor_h f).
+      + exact (linvunitor_h f).
+      + refine (lunitor_linvunitor_h f @ _).
+        apply TODO.
+      + refine (linvunitor_lunitor_h f @ _).
+        apply TODO.
+    - intros x y f.
+      simple refine (_ ,, _ ,, _ ,, _) ; cbn.
+      + exact (runitor_h f).
+      + exact (rinvunitor_h f).
+      + refine (runitor_rinvunitor_h f @ _).
+        apply TODO.
+      + refine (rinvunitor_runitor_h f @ _).
+        apply TODO.
+    - intros w x y z f g h.
+      simple refine (_ ,, _ ,, _ ,, _) ; cbn.
+      + exact (lassociator_h f g h).
+      + exact (rassociator_h f g h).
+      + refine (lassociator_rassociator_h f g h @ _).
+        apply TODO.
+      + refine (rassociator_lassociator_h f g h @ _).
+        apply TODO.
+  Defined.
+
+  Definition double_cat_to_predoublecategory_sq_hor_ver_unit_assoc_data
+    : predoublecategory_sq_hor_ver_unit_assoc_data.
+  Proof.
+    simple refine (_ ,, _).
+    - exact double_cat_to_predoublecategory_sq_hor_ver_data.
+    - exact double_cat_to_has_predoublecategory_sq_hor_ver_unit_assoc.
+  Defined.
+
+  Proposition double_cat_to_predoublecategory_ver_left_unitor_naturality
+    : predoublecategory_ver_left_unitor_naturality
+        double_cat_to_predoublecategory_sq_hor_ver_unit_assoc_data.
+  Proof.
+    unfold predoublecategory_ver_left_unitor_naturality ; cbn.
+    intros w x y z v₁ h₁ h₂ v₂ α.
+    etrans.
+    {
+      apply maponpaths.
+      exact (lunitor_square α).
+    }
+  Admitted.
+
+  Proposition double_cat_to_predoublecategory_ver_right_unitor_naturality
+    : predoublecategory_ver_right_unitor_naturality
+        double_cat_to_predoublecategory_sq_hor_ver_unit_assoc_data.
+  Proof.
+  Admitted.
+
+  Proposition double_cat_to_predoublecategory_ver_assoc_naturality
+    : predoublecategory_ver_assoc_naturality
+        double_cat_to_predoublecategory_sq_hor_ver_unit_assoc_data.
+  Proof.
+  Admitted.
+
+  Proposition double_cat_to_predoublecategory_ver_unitor_coherence
+    : predoublecategory_ver_unitor_coherence
+        double_cat_to_predoublecategory_sq_hor_ver_unit_assoc_data.
+  Proof.
+  Admitted.
+
+  Proposition double_cat_to_predoublecategory_ver_assoc_coherence
+    : predoublecategory_ver_assoc_coherence
+        double_cat_to_predoublecategory_sq_hor_ver_unit_assoc_data.
+  Proof.
+  Admitted.
+
+  Proposition double_cat_to_predoublecategory_interchange
+    : predoublecategory_interchange
+        double_cat_to_predoublecategory_sq_hor_ver_unit_assoc_data.
+  Proof.
+  Admitted.
+
+  Definition double_cat_to_predoublecategory
+    : predoublecategory.
+  Proof.
+    simple refine (_ ,, _ ,, _ ,, _ ,, _ ,, _ ,, _).
+    - exact double_cat_to_predoublecategory_sq_hor_ver_unit_assoc_data.
+    - exact double_cat_to_predoublecategory_ver_left_unitor_naturality.
+    - exact double_cat_to_predoublecategory_ver_right_unitor_naturality.
+    - exact double_cat_to_predoublecategory_ver_assoc_naturality.
+    - exact double_cat_to_predoublecategory_ver_unitor_coherence.
+    - exact double_cat_to_predoublecategory_ver_assoc_coherence.
+    - exact double_cat_to_predoublecategory_interchange.
+  Defined.
+
+  Definition double_cat_to_doublecategory
+    : doublecategory.
+  Proof.
+    use make_doublecategory.
+    - exact double_cat_to_predoublecategory.
+    - apply homset_property.
+    - apply TODO.
+  Defined.
+End DoubleCats_to_DoubleCatsUnfolded.

--- a/UniMath/Bicategories/DoubleCategories/UnfoldedDoubleCatstoDoubleCats.v
+++ b/UniMath/Bicategories/DoubleCategories/UnfoldedDoubleCatstoDoubleCats.v
@@ -54,145 +54,170 @@ Definition TODO { A : UU} : A.
 Admitted.
 
 Section DoubleCatsUnfolded_to_DoubleCats.
-  Context (C : doublecategory).
+  Context (C : univalent_doublecategory).
 
   Definition doublecategory_to_cat : category :=
-     (und_ob_hor_cat C).
+    (und_ob_hor_cat C).
 
   Definition doublecategory_to_twosided_disp_cat_data
     : twosided_disp_cat_data  (und_ob_hor_cat C) (und_ob_hor_cat C).
-   Proof.
-     use tpair.
-     - use tpair.
-       * intros x y.
-         exact (x -v-> y).
-       * intros x y z w f g h k.
-         exact (sqq h f g k).
-     - use tpair.
-       * intros x y f.
-         exact (hor_sq_identity f).
-       * intros x y z a b c f1 f2 f3 f4 f5 f6 f7 α β.
-         exact (α ·sqh β).
-   Defined.
+  Proof.
+    use tpair.
+    - use tpair.
+      * intros x y.
+        exact (x -v-> y).
+      * intros x y z w f g h k.
+        exact (sqq h f g k).
+    - use tpair.
+      * intros x y f.
+        exact (hor_sq_identity f).
+      * intros x y z a b c f1 f2 f3 f4 f5 f6 f7 α β.
+        exact (α ·sqh β).
+  Defined.
 
-   Definition doublecategory_to_twosided_disp_cat
-     : twosided_disp_cat doublecategory_to_cat doublecategory_to_cat.
-   Proof.
-      use tpair.
-      - exact doublecategory_to_twosided_disp_cat_data.
-      - repeat split.
-        + intros x0 x1 y0 y1 f0 f1 g0 g1 α.
-          exact (id_hor_sq_left α).
-        + intros x0 x1 y0 y1 f0 f1 g0 g1 α.
-          exact (id_hor_sq_right α).
-        + intros ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? α β γ.
-          exact (assoc_sq_hor α β γ).
-        + intros ? ? ? ? ? ? ? ?.
-          apply TODO. (* this law is formulated differently! *)
-   Defined.
+  Definition doublecategory_to_twosided_disp_cat
+    : twosided_disp_cat doublecategory_to_cat doublecategory_to_cat.
+  Proof.
+    use tpair.
+    - exact doublecategory_to_twosided_disp_cat_data.
+    - repeat split.
+      + intros x0 x1 y0 y1 f0 f1 g0 g1 α.
+        exact (id_hor_sq_left α).
+      + intros x0 x1 y0 y1 f0 f1 g0 g1 α.
+        exact (id_hor_sq_right α).
+      + intros ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? α β γ.
+        exact (assoc_sq_hor α β γ).
+      + intros x0 x1 y0 y1 f0 g0 f1 g1.
+        exact (get_has_sq_hor_homsets f0 g0 f1 g1).
+  Defined.
 
-   Let D : twosided_disp_cat doublecategory_to_cat doublecategory_to_cat
-     := doublecategory_to_twosided_disp_cat.
+  Let D : twosided_disp_cat doublecategory_to_cat doublecategory_to_cat
+      := doublecategory_to_twosided_disp_cat.
 
-   Definition doublecategory_to_horid : hor_id D.
-   Proof.
-     use make_hor_id.
-     - use make_hor_id_data.
-       + apply TODO.
-       + apply TODO.
-     - split.
-       + apply TODO.
-       + apply TODO.
-   Defined.
+  Definition doublecategory_to_horid : hor_id D.
+  Proof.
+    use make_hor_id.
+    - use make_hor_id_data.
+      + intro x.
+        exact (ver_identity x).
+      + intros x y f.
+        exact (ver_sq_identity f).
+    - split.
+      + intro x.
+        exact (get_predoublecategory_interchange_id_obj x).
+      + intros x y z f g.
+        exact ( get_predoublecategory_interchange_id_hor f g).
+  Defined.
 
-   Let I : hor_id D := doublecategory_to_horid.
+  Let I : hor_id D := doublecategory_to_horid.
 
-   Definition doublecategory_to_horcomp : hor_comp D.
-   Proof.
-     use make_hor_comp.
-     - use make_hor_comp_data.
-       + apply TODO.
-       + apply TODO.
-     - split.
-       + apply TODO.
-       + apply TODO.
-   Defined.
+  Definition doublecategory_to_horcomp : hor_comp D.
+  Proof.
+    use make_hor_comp.
+    - use make_hor_comp_data.
+      + intros x y z f g.
+        exact (ver_compose f g).
+      + cbn in *.
+        intros x1 x2 y1 y2 z1 z2 v1 v2 v3 h1 h2 k1 k2 α β.
+        exact (ver_sq_compose α β).
+    - split.
+      + cbn in *.
+        intros x y z f g.
+        exact (get_predoublecategory_interchange_id_ver f g).
+      + cbn in *.
+        intros a0 a1 a2 b0 b1 b2 c0 c1 c2 fa ga fb gb fc gc h0 k0 h1 k1 h2 k2 α β γ δ.
+        exact (get_predoublecategory_interchange_comp α β γ δ).
+  Defined.
 
-   Let Cm : hor_comp D := doublecategory_to_horcomp.
+  Let Cm : hor_comp D := doublecategory_to_horcomp.
 
-   Definition  doublecategory_to_lunitor : double_cat_lunitor I Cm.
-   Proof.
-     use make_double_lunitor.
-     - intros x y h.
-       use make_iso_twosided_disp.
-       + apply TODO.
-       + simple refine (_ ,, _ ,, _).
-         * apply TODO.
-         * apply TODO.
-         * apply TODO.
-     - apply TODO.
-   Defined.
+  Definition  doublecategory_to_lunitor : double_cat_lunitor I Cm.
+  Proof.
+    use make_double_lunitor.
+    - intros x y h.
+      use make_iso_twosided_disp.
+      + cbn in *.
+        exact (pr1 (get_ver_left_unitor h)).
+      + simple refine (_ ,, _ ,, _).
+        * exact (pr12 (get_ver_left_unitor h)).
+        * cbn in *. exact (pr122 (get_ver_left_unitor h)).
+        * exact (pr222 (get_ver_left_unitor h)).
+    - cbn in *.
+      intros a b c d f g h k α.
+      exact (! get_predoublecategory_ver_left_unitor_naturality α).
+  Defined.
 
-   Let l : double_cat_lunitor I Cm := doublecategory_to_lunitor.
+  Let l : double_cat_lunitor I Cm := doublecategory_to_lunitor.
 
-   Definition doublecategory_to_runitor : double_cat_runitor I Cm.
-   Proof.
-     use make_double_runitor.
-     - intros x y h.
-       use make_iso_twosided_disp.
-       + apply TODO.
-       + simple refine (_ ,, _ ,, _).
-         * apply TODO.
-         * apply TODO.
-         * apply TODO.
-     - apply TODO.
-   Defined.
+  Definition doublecategory_to_runitor : double_cat_runitor I Cm.
+  Proof.
+    use make_double_runitor.
+    - intros x y h.
+      use make_iso_twosided_disp.
+      + cbn in *.
+        exact (pr1 (get_ver_right_unitor h)).
+      + simple refine (_ ,, _ ,, _).
+        * exact (pr12 (get_ver_right_unitor h)).
+        * cbn in *. exact (pr122 (get_ver_right_unitor h)).
+        * exact (pr222 (get_ver_right_unitor h)).
+    - cbn in *.
+      intros a b c d f g h k α.
+      exact (! get_predoublecategory_ver_right_unitor_naturality α).
+  Defined.
 
-   Let r : double_cat_runitor I Cm := doublecategory_to_runitor.
+  Let r : double_cat_runitor I Cm := doublecategory_to_runitor.
 
-   Definition doublecategory_to_associator : double_cat_associator Cm.
-   Proof.
-     use make_double_associator.
-     - intros w x y z h₁ h₂ h₃.
-       use make_iso_twosided_disp.
-       + apply TODO.
-       + simple refine (_ ,, _ ,, _).
-         * apply TODO.
-         * apply TODO.
-         * apply TODO.
-     - apply TODO.
-   Defined.
+  Definition doublecategory_to_associator : double_cat_associator Cm.
+  Proof.
+    use make_double_associator.
+    - intros w x y z f g h.
+      use make_iso_twosided_disp.
+      + exact (pr1 (get_ver_associator f g h)).
+      + simple refine (_ ,, _ ,, _).
+        * exact (pr12 (get_ver_associator f g h)).
+        * exact (pr122 (get_ver_associator f g h)).
+        * exact (pr222 (get_ver_associator f g h)).
+    - cbn in *.
+      intros a0 a1 a2 a3 b0 b1 b2 b3 fa fb ha hb ka kb g0 g1 g2 g3 α β γ.
+      exact (! get_predoublecategory_ver_assoc_naturality α β γ).
+  Defined.
 
-   Let a : double_cat_associator Cm := doublecategory_to_associator.
+  Let a : double_cat_associator Cm := doublecategory_to_associator.
 
-   Proposition doublecategory_to_triangle : triangle_law l r a.
-   Proof.
-   Admitted.
+  Proposition doublecategory_to_triangle : triangle_law l r a.
+  Proof.
+    intros x y z h k.
+    cbn in *.
+    exact (get_predoublecategory_ver_unitor_coherence h k).
+  Defined.
 
-   Let tr : triangle_law l r a := doublecategory_to_triangle.
+  Let tr : triangle_law l r a := doublecategory_to_triangle.
 
-   Proposition doublecategory_to_pentagon : pentagon_law a.
-   Proof.
-   Admitted.
+  Proposition doublecategory_to_pentagon : pentagon_law a.
+  Proof.
+    intros i b c d e f g h k.
+    exact (get_predoublecategory_ver_assoc_coherence f g h k).
+  Defined.
 
-   Let pe : pentagon_law a := doublecategory_to_pentagon.
+  Let pe : pentagon_law a := doublecategory_to_pentagon.
 
-   Definition is_univalent_und_ob_hor_cat : is_univalent (und_ob_hor_cat C).
-   Proof.
-   Admitted.
+  Definition is_univalent_und_ob_hor_cat : is_univalent (und_ob_hor_cat C).
+  Proof.
+    apply C.
+  Defined.
 
-   Let HC : is_univalent (und_ob_hor_cat C) := is_univalent_und_ob_hor_cat.
+  Let HC : is_univalent (und_ob_hor_cat C) := is_univalent_und_ob_hor_cat.
 
-   Definition is_univalent_doublecategory_to_twosided_disp_cat
-     : is_univalent_twosided_disp_cat D.
-   Proof.
-   Admitted.
+  Definition is_univalent_doublecategory_to_twosided_disp_cat
+    : is_univalent_twosided_disp_cat D.
+  Proof.
+  Admitted.
 
-   Let HD : is_univalent_twosided_disp_cat D
-     := is_univalent_doublecategory_to_twosided_disp_cat.
+  Let HD : is_univalent_twosided_disp_cat D
+      := is_univalent_doublecategory_to_twosided_disp_cat.
 
-   Definition  doublecategory_to_double_cat : double_cat :=
-     make_double_cat (und_ob_hor_cat C) D I Cm l r a tr pe HC HD.
+  Definition  doublecategory_to_double_cat : double_cat :=
+    make_double_cat (und_ob_hor_cat C) D I Cm l r a tr pe HC HD.
 End DoubleCatsUnfolded_to_DoubleCats.
 
 Section DoubleCats_to_DoubleCatsUnfolded.
@@ -434,4 +459,73 @@ Section DoubleCats_to_DoubleCatsUnfolded.
     - intro ; intros ; cbn.
       apply isaset_disp_mor.
   Defined.
+
+  Definition double_cat_to_univalent_doublecategory
+    : univalent_doublecategory.
+  Proof.
+    simple refine (double_cat_to_doublecategory ,, _ ,, _).
+    - exact (pr21 (pr111 C)).
+    - apply TODO.
+  Defined.
 End DoubleCats_to_DoubleCatsUnfolded.
+
+Proposition double_cat_weq_univalent_doublecategory_inv₁
+            (C : double_cat)
+  : doublecategory_to_double_cat (double_cat_to_univalent_doublecategory C) = C.
+Proof.
+  induction C as [ C1 H ].
+  use subtypePath.
+  {
+    intro.
+    apply isapropdirprod ; repeat (use impred ; intro) ; apply isaset_disp_mor.
+  }
+  induction C1 as [ [ [ C D ] IC ] UnAs ].
+  use total2_paths_f.
+  - use total2_paths_f.
+    + use total2_paths_f.
+      * apply idpath.
+      * use subtypePath.
+        {
+          intro.
+          apply isaprop_is_univalent_twosided_disp_cat.
+        }
+        apply idpath.
+    + (* rewrite transportf_total2_paths_f. *)
+      admit.
+  - admit.
+Admitted.
+
+Proposition double_cat_weq_univalent_doublecategory_inv₂
+            (C : univalent_doublecategory)
+  : double_cat_to_univalent_doublecategory (doublecategory_to_double_cat C) = C.
+Proof.
+  use subtypePath.
+  {
+    intro.
+    apply isapropdirprod.
+    - apply isaprop_is_univalent.
+    - admit.
+  }
+  use subtypePath.
+  {
+    intro.
+    use isapropdirprod ;
+    repeat (use impred ; intro) ;
+    apply isapropiscontr.
+  }
+  induction C as [ [ [ C1 C2 ] C3 ] H ] ; cbn.
+  refine (maponpaths (λ z, _ ,, z) _).
+  repeat (use pathsdirprod) ;
+  repeat (use funextsec ; intro) ;
+  apply get_has_sq_hor_homsets.
+Admitted.
+
+Definition double_cat_weq_univalent_doublecategory
+  : double_cat ≃ univalent_doublecategory.
+Proof.
+  use weq_iso.
+  - exact double_cat_to_univalent_doublecategory.
+  - exact doublecategory_to_double_cat.
+  - exact double_cat_weq_univalent_doublecategory_inv₁.
+  - intros C.
+    revert C.

--- a/UniMath/CONTENTS.md
+++ b/UniMath/CONTENTS.md
@@ -826,6 +826,7 @@ The packages and files are listed here in logical order: each file depends only 
    - [DoubleCategories/Examples/StructuredCospansDoubleCat.v](Bicategories/DoubleCategories/Examples/StructuredCospansDoubleCat.v)
    - [DoubleCategories/Examples/StructuredCospansDoubleFunctor.v](Bicategories/DoubleCategories/Examples/StructuredCospansDoubleFunctor.v)
    - [DoubleCategories/DoubleCatsUnfolded.v](Bicategories/DoubleCategories/DoubleCatsUnfolded.v)
+   - [DoubleCategories/DoubleCatsEquivalentDefinitions.v](Bicategories/DoubleCategories/DoubleCatsEquivalentDefinitions.v)
    - [PseudoFunctors/Examples/ChangeOfBaseEnriched.v](Bicategories/PseudoFunctors/Examples/ChangeOfBaseEnriched.v)
    - [DisplayedBicats/Examples/MonadsLax.v](Bicategories/DisplayedBicats/Examples/MonadsLax.v)
    - [DisplayedBicats/Examples/DispBicatOnCatToUniv.v](Bicategories/DisplayedBicats/Examples/DispBicatOnCatToUniv.v)

--- a/UniMath/CategoryTheory/TwoSidedDisplayedCats/TwoSidedDispCat.v
+++ b/UniMath/CategoryTheory/TwoSidedDisplayedCats/TwoSidedDispCat.v
@@ -460,7 +460,7 @@ Section TwoSidedDispCat.
         fg.
   Proof.
     exact (pr12 D _ _ _ _ _ _ _ _ fg).
-  Qed.
+  Defined.
 
   Definition id_two_disp_right
              {D : twosided_disp_cat}
@@ -479,7 +479,7 @@ Section TwoSidedDispCat.
         fg.
   Proof.
     exact (pr122 D _ _ _ _ _ _ _ _ fg).
-  Qed.
+  Defined.
 
   Definition assoc_two_disp
              {D : twosided_disp_cat}
@@ -506,7 +506,7 @@ Section TwoSidedDispCat.
         ((fg₁ ;;2 fg₂) ;;2 fg₃).
   Proof.
     exact (pr1 (pr222 D) _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ fg₁ fg₂ fg₃).
-  Qed.
+  Defined.
 
   Definition isaset_disp_mor
              {D : twosided_disp_cat}
@@ -519,7 +519,7 @@ Section TwoSidedDispCat.
     : isaset (xy₁ -->[ f ][ g ] xy₂).
   Proof.
     exact (pr2 (pr222 D) _ _ _ _ xy₁ xy₂ f g).
-  Qed.
+  Defined.
 
   (**
    1.2. Derived laws


### PR DESCRIPTION
We have an unfolded one, and it is equivalent to the one construct via displayed bicategories. The proof is a matter of reorganizing the data.