### PR TITLE
Orthogonal factorization systems in bicategories

### DIFF
--- a/UniMath/Bicategories/.package/files
+++ b/UniMath/Bicategories/.package/files
@@ -267,6 +267,8 @@ Morphisms/Examples/MorphismsInSliceBicat.v
 Morphisms/Examples/MorphismsInStructuredCat.v
 Morphisms/Examples/MorphismsInBicatOfEnrichedCats.v
 
+OrthogonalFactorization/EsoFactorizationSystem.v
+
 Colimits/Initial.v
 Colimits/Coproducts.v
 Colimits/Extensive.v

--- a/UniMath/Bicategories/.package/files
+++ b/UniMath/Bicategories/.package/files
@@ -254,6 +254,9 @@ Limits/PullbackEquivalences.v
 Limits/InserterEquivalences.v
 Limits/EquifierEquivalences.v
 
+OrthogonalFactorization/Orthogonality.v
+OrthogonalFactorization/FactorizationSystem.v
+
 Morphisms/Eso.v
 Morphisms/Properties/Projections.v
 Morphisms/Properties/ClosedUnderPullback.v

--- a/UniMath/Bicategories/Morphisms/Eso.v
+++ b/UniMath/Bicategories/Morphisms/Eso.v
@@ -270,34 +270,13 @@ Section EsoMorphisms.
   (**
    4. Esos via pullbacks
    *)
-  Definition is_eso_via_pb_cone
-             (HB_2_1 : is_univalent_2_1 B)
-             {c₁ c₂ : B}
-             (m : c₁ --> c₂)
-             (Hm : fully_faithful_1cell m)
-    : @pb_cone
-        bicat_of_univ_cats
-        (univ_hom HB_2_1 b₁ c₁)
-        (univ_hom HB_2_1 b₂ c₂)
-        (univ_hom HB_2_1 b₁ c₂)
-        (post_comp b₁ m)
-        (pre_comp c₂ f).
-  Proof.
-    use make_pb_cone.
-    - exact (univ_hom HB_2_1 b₂ c₁).
-    - exact (pre_comp c₁ f).
-    - exact (post_comp b₂ m).
-    - use nat_z_iso_to_invertible_2cell.
-      exact (pre_comp_post_comp_commute_z_iso f m).
-  Defined.
-
   Definition is_eso_via_pb
              (HB_2_1 : is_univalent_2_1 B)
     : UU
     := ∏ (c₁ c₂ : B)
          (m : c₁ --> c₂)
          (Hm : fully_faithful_1cell m),
-       has_pb_ump (is_eso_via_pb_cone HB_2_1 m Hm).
+       orthogonal_via_pb f m HB_2_1.
 
   Definition isaprop_is_eso_via_pb
              (HB_2_1 : is_univalent_2_1 B)
@@ -307,150 +286,18 @@ Section EsoMorphisms.
     use impred ; intro c₂.
     use impred ; intro m.
     use impred ; intro Hm.
-    use isaprop_has_pb_ump.
-    exact univalent_cat_is_univalent_2_1.
-  Defined.
-
-  (**
-   5. Equivalence of the definitions
-   *)
-  Definition is_eso_to_is_eso_via_pb
-             (HB_2_1 : is_univalent_2_1 B)
-             (Hf : is_eso)
-    : is_eso_via_pb HB_2_1.
-  Proof.
-    intros c₁ c₂ m Hm.
-    specialize (Hf c₁ c₂ m Hm).
-    use (left_adjoint_equivalence_to_pb
-           _ _ _
-           (@iso_comma_has_pb_ump
-               (univ_hom HB_2_1 b₁ c₁)
-               (univ_hom HB_2_1 b₂ c₂)
-               (univ_hom HB_2_1 b₁ c₂)
-               (post_comp b₁ m)
-               (pre_comp c₂ f))
-           _
-           _).
-    - exact univalent_cat_is_univalent_2_0.
-    - exact (orthogonal_functor f m).
-    - exact (@equiv_cat_to_adj_equiv
-               (univ_hom HB_2_1 b₂ c₁)
-               (@univalent_iso_comma
-                  (univ_hom HB_2_1 b₁ c₁)
-                  (univ_hom HB_2_1 b₂ c₂)
-                  (univ_hom HB_2_1 b₁ c₂)
-                  (post_comp b₁ m)
-                  (pre_comp c₂ f))
-               (orthogonal_functor f m)
-               Hf).
-    - use nat_z_iso_to_invertible_2cell.
-      use make_nat_z_iso.
-      + use make_nat_trans.
-        * exact (λ _, id2 _).
-        * abstract
-            (intros h₁ h₂ α ; cbn ;
-             rewrite id2_left, id2_right ;
-             apply idpath).
-      + intro.
-        use is_inv2cell_to_is_z_iso ; cbn.
-        is_iso.
-    - use nat_z_iso_to_invertible_2cell.
-      use make_nat_z_iso.
-      + use make_nat_trans.
-        * exact (λ _, id2 _).
-        * abstract
-            (intros h₁ h₂ α ; cbn ;
-             rewrite id2_left, id2_right ;
-             apply idpath).
-      + intro.
-        use is_inv2cell_to_is_z_iso ; cbn.
-        is_iso.
-    - abstract
-        (use nat_trans_eq ; [ apply homset_property | ] ;
-         intro x ; cbn ;
-         rewrite id2_rwhisker, lwhisker_id2 ;
-         rewrite !id2_left, !id2_right ;
-         apply idpath).
-  Defined.
-
-  Definition is_eso_via_pb_to_is_eso_nat_trans
-             (HB_2_1 : is_univalent_2_1 B)
-             {c₁ c₂ : B}
-             {m : c₁ --> c₂}
-             (Hm : fully_faithful_1cell m)
-    : orthogonal_functor f m
-      ⟹
-      pr1 (pb_ump_mor
-             (@iso_comma_has_pb_ump
-                (univ_hom HB_2_1 b₁ c₁)
-                (univ_hom HB_2_1 b₂ c₂)
-                (univ_hom HB_2_1 b₁ c₂)
-                (post_comp b₁ m)
-                (pre_comp c₂ f))
-             (is_eso_via_pb_cone HB_2_1 m Hm)).
-  Proof.
-    use make_nat_trans.
-    - intro h.
-      simple refine ((id2 _ ,, id2 _) ,, _).
-      abstract
-        (cbn ;
-         rewrite id2_rwhisker, lwhisker_id2, id2_left, id2_right ;
-         apply idpath).
-    - abstract
-        (intros h₁ h₂ γ ;
-         use subtypePath ; [ intro ; apply cellset_property | ] ;
-         cbn ;
-         rewrite !id2_left, !id2_right ;
-         apply idpath).
-  Defined.
-
-  Definition is_eso_via_pb_to_is_eso
-             (HB_2_1 : is_univalent_2_1 B)
-             (Hf : is_eso_via_pb HB_2_1)
-    : is_eso.
-  Proof.
-    intros c₁ c₂ m Hm.
-    specialize (Hf c₁ c₂ m Hm).
-    apply (@adj_equiv_to_equiv_cat
-             (univ_hom HB_2_1 b₂ c₁)
-             (@univalent_iso_comma
-                (univ_hom HB_2_1 b₁ c₁)
-                (univ_hom HB_2_1 b₂ c₂)
-                (univ_hom HB_2_1 b₁ c₂)
-                (post_comp b₁ m)
-                (pre_comp c₂ f))
-             (orthogonal_functor f m)).
-    pose (pb_ump_mor_left_adjoint_equivalence
-            _
-            _
-            (@iso_comma_has_pb_ump
-               (univ_hom HB_2_1 b₁ c₁)
-               (univ_hom HB_2_1 b₂ c₂)
-               (univ_hom HB_2_1 b₁ c₂)
-               (post_comp b₁ m)
-               (pre_comp c₂ f))
-            Hf)
-      as p.
-    use (left_adjoint_equivalence_invertible p).
-    - exact (is_eso_via_pb_to_is_eso_nat_trans HB_2_1 Hm).
-    - use is_nat_z_iso_to_is_invertible_2cell.
-      intro.
-      use is_z_iso_iso_comma.
-      + use is_inv2cell_to_is_z_iso ; cbn.
-        is_iso.
-      + use is_inv2cell_to_is_z_iso ; cbn.
-        is_iso.
+    exact (isaprop_orthogonal_via_pb f m HB_2_1).
   Defined.
 
   Definition is_eso_weq_is_eso_via_pb
              (HB_2_1 : is_univalent_2_1 B)
     : is_eso ≃ is_eso_via_pb HB_2_1.
   Proof.
-    use weqimplimpl.
-    - exact (is_eso_to_is_eso_via_pb HB_2_1).
-    - exact (is_eso_via_pb_to_is_eso HB_2_1).
-    - exact (isaprop_is_eso HB_2_1).
-    - exact (isaprop_is_eso_via_pb HB_2_1).
+    use weqonsecfibers ; intro c₁.
+    use weqonsecfibers ; intro c₂.
+    use weqonsecfibers ; intro m.
+    use weqonsecfibers ; intro Hm₁.
+    exact (orthogonal_weq_orthogonal_via_pb f m HB_2_1).
   Defined.
 End EsoMorphisms.
 

--- a/UniMath/Bicategories/Morphisms/Eso.v
+++ b/UniMath/Bicategories/Morphisms/Eso.v
@@ -310,11 +310,11 @@ Definition eso_ff_factorization
   := ∏ (b₁ b₂ : B)
        (f : b₁ --> b₂),
      ∑ (im : B)
-       (m : im --> b₂)
-       (f' : b₁ --> im),
-     fully_faithful_1cell m
-     ×
+       (f' : b₁ --> im)
+       (m : im --> b₂),
      is_eso f'
+     ×
+     fully_faithful_1cell m
      ×
      invertible_2cell (f' · m) f.
 

--- a/UniMath/Bicategories/Morphisms/Eso.v
+++ b/UniMath/Bicategories/Morphisms/Eso.v
@@ -25,6 +25,9 @@
  functors are equivalences if the involved categories are univalent. From this
  formulation, we can also deduce a universal mapping property.
 
+ For both definitions, we use the notion of orthogonality for 1-cells in
+ bicategories.
+
  In this file, we consider both definitions, and we show that they are indeed
  equivalent.
 
@@ -58,6 +61,7 @@ Require Import UniMath.Bicategories.Core.Examples.BicatOfUnivCats.
 Require Import UniMath.Bicategories.Morphisms.FullyFaithful.
 Require Import UniMath.Bicategories.Morphisms.Adjunctions.
 Require Import UniMath.Bicategories.Morphisms.Properties.ClosedUnderInvertibles.
+Require Import UniMath.Bicategories.OrthogonalFactorization.Orthogonality.
 Require Import UniMath.Bicategories.Limits.Pullbacks.
 Require Import UniMath.Bicategories.Limits.PullbackFunctions.
 Import PullbackFunctions.Notations.
@@ -74,54 +78,13 @@ Section EsoMorphisms.
   (**
    1. Esos
    *)
-  Definition pre_comp_post_comp_commute
-             {c₁ c₂ : B}
-             (m : c₁ --> c₂)
-    : pre_comp c₁ f ∙ post_comp b₁ m
-      ⟹
-      post_comp b₂ m ∙ pre_comp c₂ f.
-  Proof.
-    use make_nat_trans.
-    - exact (λ _, rassociator _ _ _).
-    - abstract
-        (intros h₁ h₂ α ;
-         cbn ;
-         rewrite rwhisker_lwhisker_rassociator ;
-         apply idpath).
-  Defined.
-
-  Definition pre_comp_post_comp_commute_z_iso
-             {c₁ c₂ : B}
-             (m : c₁ --> c₂)
-    : nat_z_iso
-        (pre_comp c₁ f ∙ post_comp b₁ m)
-        (post_comp b₂ m ∙ pre_comp c₂ f).
-  Proof.
-    use make_nat_z_iso.
-    - exact (pre_comp_post_comp_commute m).
-    - intro.
-      use is_inv2cell_to_is_z_iso ; cbn.
-      is_iso.
-  Defined.
-
-  Definition is_eso_functor
-             {c₁ c₂ : B}
-             (m : c₁ --> c₂)
-    : hom b₂ c₁ ⟶ iso_comma (post_comp b₁ m) (pre_comp c₂ f).
-  Proof.
-    use iso_comma_ump1.
-    - exact (pre_comp c₁ f).
-    - exact (post_comp b₂ m).
-    - exact (pre_comp_post_comp_commute_z_iso m).
-  Defined.
 
   Definition is_eso
     : UU
     := ∏ (c₁ c₂ : B)
          (m : c₁ --> c₂)
          (Hm : fully_faithful_1cell m),
-       adj_equivalence_of_cats
-         (is_eso_functor m).
+       f ⊥ m.
 
   Definition isaprop_is_eso
              (HB_2_1 : is_univalent_2_1 B)
@@ -131,19 +94,7 @@ Section EsoMorphisms.
     use impred ; intro c₂.
     use impred ; intro m.
     use impred ; intro H.
-    use (isofhlevelweqf
-             1
-             (@adj_equiv_is_equiv_cat
-                (univ_hom HB_2_1 b₂ c₁)
-                (@univalent_iso_comma
-                   (univ_hom HB_2_1 b₁ c₁)
-                   (univ_hom HB_2_1 b₂ c₂)
-                   (univ_hom HB_2_1 b₁ c₂)
-                   (post_comp b₁ m)
-                   (pre_comp c₂ f))
-                (is_eso_functor m))).
-    apply isaprop_left_adjoint_equivalence.
-    exact univalent_cat_is_univalent_2_1.
+    exact (isaprop_orthogonal f m HB_2_1).
   Defined.
 
   (**
@@ -227,93 +178,20 @@ Section EsoMorphisms.
    Note that local univalence is needed so that we can get an equivalence from functors
    that are essentially surjective and fully faithful.
    *)
-  Section MakeEso.
-    Context (HB_2_1 : is_univalent_2_1 B)
-            (H₁ : is_eso_full)
-            (H₂ : is_eso_faithful)
-            (H₃ : is_eso_essentially_surjective).
-
-    Section MakeEsoHelp.
-      Context {c₁ c₂ : B}
-              {m : c₁ --> c₂}
-              (Hm : fully_faithful_1cell m).
-
-      Definition make_is_eso_full
-        : full (is_eso_functor m).
-      Proof.
-        intros l₁ l₂.
-        intro k.
-        apply hinhpr.
-        simple refine (_ ,, _) ; cbn.
-        - exact (pr1 (H₁ c₁ c₂ m Hm l₁ l₂ (pr11 k) (pr21 k) (pr2 k))).
-        - abstract
-            (use subtypePath ; [ intro ; apply cellset_property | ] ;
-             cbn ;
-             exact (pathsdirprod
-                      (pr12 (H₁ c₁ c₂ m Hm l₁ l₂ (pr11 k) (pr21 k) (pr2 k)))
-                      (pr22 (H₁ c₁ c₂ m Hm l₁ l₂ (pr11 k) (pr21 k) (pr2 k))))).
-      Defined.
-
-      Definition make_is_eso_faithful
-        : faithful (is_eso_functor m).
-      Proof.
-        intros l₁ l₂.
-        intro im.
-        use invproofirrelevance.
-        intros ζ₁ ζ₂.
-        use subtypePath.
-        {
-          intro.
-          apply homset_property.
-        }
-        use (H₂ c₁ c₂ m Hm l₁ l₂ (pr1 ζ₁) (pr1 ζ₂)).
-        - exact (maponpaths (λ z, pr11 z) (pr2 ζ₁)
-                 @ !(maponpaths (λ z, pr11 z) (pr2 ζ₂))).
-        - exact (maponpaths (λ z, dirprod_pr2 (pr1 z)) (pr2 ζ₁)
-                            @ !(maponpaths (λ z, dirprod_pr2 (pr1 z)) (pr2 ζ₂))).
-      Qed.
-
-      Definition make_is_eso_fully_faithful
-        : fully_faithful (is_eso_functor m).
-      Proof.
-        use full_and_faithful_implies_fully_faithful.
-        split.
-        - exact make_is_eso_full.
-        - exact make_is_eso_faithful.
-      Defined.
-
-      Definition make_is_eso_essentially_surjective
-        : essentially_surjective (is_eso_functor m).
-      Proof.
-        intros h.
-        pose (ℓ := H₃ c₁ c₂ m Hm (pr11 h) (pr21 h) (z_iso_to_inv2cell (pr2 h))).
-        apply hinhpr.
-        simple refine (_ ,, _).
-        - exact (pr1 ℓ).
-        - use make_z_iso'.
-          + simple refine ((_ ,, _) ,, _) ; cbn.
-            * exact (pr12 ℓ).
-            * exact (pr122 ℓ).
-            * exact (pr222 ℓ).
-          + use is_z_iso_iso_comma.
-            * use is_inv2cell_to_is_z_iso.
-              apply property_from_invertible_2cell.
-            * use is_inv2cell_to_is_z_iso.
-              apply property_from_invertible_2cell.
-      Defined.
-    End MakeEsoHelp.
-
-    Definition make_is_eso
-      : is_eso.
-    Proof.
-      intros c₁ c₂ m Hm.
-      use rad_equivalence_of_cats.
-      - use is_univ_hom.
-        exact HB_2_1.
-      - exact (make_is_eso_fully_faithful Hm).
-      - exact (make_is_eso_essentially_surjective Hm).
-    Defined.
-  End MakeEso.
+  Definition make_is_eso
+             (HB_2_1 : is_univalent_2_1 B)
+             (H₁ : is_eso_full)
+             (H₂ : is_eso_faithful)
+             (H₃ : is_eso_essentially_surjective)
+    : is_eso.
+  Proof.
+    intros c₁ c₂ m Hm.
+    use make_orthogonal.
+    - exact HB_2_1.
+    - exact (H₁ c₁ c₂ m Hm).
+    - exact (H₂ c₁ c₂ m Hm).
+    - exact (H₃ c₁ c₂ m Hm).
+  Defined.
 
   (**
    3. Projections for esos
@@ -332,37 +210,21 @@ Section EsoMorphisms.
 
       Definition is_eso_lift_1
         : b₂ --> c₁
-        := right_adjoint (H c₁ c₂ m Hm) ((g₁ ,, g₂) ,, inv2cell_to_z_iso α).
+        := orthogonal_lift_1 (H c₁ c₂ m Hm) g₁ g₂ α.
 
       Definition is_eso_lift_1_comm_left
-        : invertible_2cell (f · is_eso_lift_1) g₁.
-      Proof.
-        apply z_iso_to_inv2cell.
-        exact (functor_on_z_iso
-                (iso_comma_pr1 _ _)
-                (counit_pointwise_z_iso_from_adj_equivalence
-                   (H c₁ c₂ m Hm)
-                   ((g₁ ,, g₂) ,, inv2cell_to_z_iso α))).
-      Defined.
+        : invertible_2cell (f · is_eso_lift_1) g₁
+        := orthogonal_lift_1_comm_left (H c₁ c₂ m Hm) g₁ g₂ α.
 
       Definition is_eso_lift_1_comm_right
-        : invertible_2cell (is_eso_lift_1 · m) g₂.
-      Proof.
-        apply z_iso_to_inv2cell.
-        exact (functor_on_z_iso
-                 (iso_comma_pr2 _ _)
-                 (counit_pointwise_z_iso_from_adj_equivalence
-                    (H c₁ c₂ m Hm)
-                    ((g₁ ,, g₂) ,, inv2cell_to_z_iso α))).
-      Defined.
+        : invertible_2cell (is_eso_lift_1 · m) g₂
+        := orthogonal_lift_1_comm_right (H c₁ c₂ m Hm) g₁ g₂ α.
 
       Definition is_eso_lift_1_eq
         : (is_eso_lift_1_comm_left ▹ m) • α
           =
           rassociator _ _ _ • (f ◃ is_eso_lift_1_comm_right)
-        := pr2 (counit_from_left_adjoint
-                  (pr1 (H c₁ c₂ m Hm))
-                  ((g₁ ,, g₂) ,, inv2cell_to_z_iso α)).
+        := orthogonal_lift_1_eq (H c₁ c₂ m Hm) g₁ g₂ α.
     End LiftOne.
 
     (** Lifting property for for 2-cells *)
@@ -377,166 +239,17 @@ Section EsoMorphisms.
                    =
                    rassociator _ _ _ • (f ◃ k₂)).
 
-      Let R : iso_comma (post_comp b₁ m) (pre_comp c₂ f) ⟶ hom b₂ c₁
-        := right_adjoint (H c₁ c₂ m Hm).
-
-      Let φ : iso_comma (post_comp b₁ m) (pre_comp c₂ f)
-        := (f · l₁ ,, l₁ · m) ,, inv2cell_to_z_iso (rassociator_invertible_2cell _ _ _).
-      Let ψ : iso_comma (post_comp b₁ m) (pre_comp c₂ f)
-        := (f · l₂ ,, l₂ · m) ,, inv2cell_to_z_iso (rassociator_invertible_2cell _ _ _).
-      Let μ : φ --> ψ
-        := (k₁ ,, k₂) ,, p.
-
-      Let η₁ : l₁ ==> R φ
-        := unit_from_left_adjoint (H c₁ c₂ m Hm) l₁.
-      Let η₂ : R ψ ==> l₂
-        := z_iso_to_inv2cell (unit_pointwise_z_iso_from_adj_equivalence (H c₁ c₂ m Hm) l₂)^-1.
-      Let ε₁ : f · R φ ==> f · l₁
-        := pr11 (counit_from_left_adjoint (pr1 (H c₁ c₂ m Hm)) φ).
-      Let ε₂ : f · R ψ ==> f · l₂
-        := pr11 (counit_from_left_adjoint (pr1 (H c₁ c₂ m Hm)) ψ).
-      Let ε₁' : R φ · m ==> l₁ · m
-        := pr21 (counit_from_left_adjoint (pr1 (H c₁ c₂ m Hm)) φ).
-      Let ε₂' : R ψ · m ==> l₂ · m
-        := pr21 (counit_from_left_adjoint (pr1 (H c₁ c₂ m Hm)) ψ).
-
       Definition is_eso_lift_2
         : l₁ ==> l₂
-        := η₁ • #R μ • η₂.
-
-      Local Lemma is_eso_lift_2_counit_invertible
-        : is_invertible_2cell ε₂.
-      Proof.
-        exact (property_from_invertible_2cell
-                 (z_iso_to_inv2cell
-                    (functor_on_z_iso
-                       (iso_comma_pr1 _ _)
-                       (counit_pointwise_z_iso_from_adj_equivalence (H c₁ c₂ m Hm) ψ)))).
-      Qed.
-
-      Local Lemma is_eso_lift_2_left_path_1
-        : (f ◃ #R μ) • ε₂ = ε₁ • k₁.
-      Proof.
-        exact (maponpaths
-                 (λ z, pr11 z)
-                 (nat_trans_ax (counit_from_left_adjoint (H c₁ c₂ m Hm)) _ _ μ)).
-      Qed.
-
-      Local Lemma is_eso_lift_2_left_path_2
-        : (f ◃ η₁) • ε₁ = id2 _.
-      Proof.
-        exact (maponpaths
-                 (λ z, pr11 z)
-                 (triangle_id_left_ad (pr21 (H c₁ c₂ m Hm)) l₁)).
-      Qed.
+        := orthogonal_lift_2 (H c₁ c₂ m Hm) l₁ l₂ k₁ k₂ p.
 
       Definition is_eso_lift_2_left
-        : f ◃ is_eso_lift_2 = k₁.
-      Proof.
-        unfold is_eso_lift_2.
-        rewrite <- !lwhisker_vcomp.
-        use vcomp_move_R_Mp.
-        {
-          unfold η₂.
-          is_iso.
-        }
-        use (vcomp_rcancel ε₂).
-        {
-          exact is_eso_lift_2_counit_invertible.
-        }
-        rewrite !vassocl.
-        etrans.
-        {
-          apply maponpaths.
-          exact is_eso_lift_2_left_path_1.
-        }
-        cbn.
-        rewrite !vassocr.
-        etrans.
-        {
-          apply maponpaths_2.
-          exact is_eso_lift_2_left_path_2.
-        }
-        rewrite id2_left.
-        rewrite !vassocl.
-        refine (!_).
-        etrans.
-        {
-          apply maponpaths.
-          exact (maponpaths
-                   (λ z, pr11 z)
-                   (triangle_id_left_ad (pr21 (H c₁ c₂ m Hm)) l₂)).
-        }
-        cbn.
-        rewrite id2_right.
-        apply idpath.
-      Qed.
-
-      Local Lemma is_eso_lift_2_counit_invertible'
-        : is_invertible_2cell ε₂'.
-      Proof.
-        exact (property_from_invertible_2cell
-                 (z_iso_to_inv2cell
-                    (functor_on_z_iso
-                       (iso_comma_pr2 _ _)
-                       (counit_pointwise_z_iso_from_adj_equivalence (H c₁ c₂ m Hm) ψ)))).
-      Qed.
-
-      Local Lemma is_eso_lift_2_right_path_1
-        : (#R μ ▹ m) • ε₂' = ε₁' • k₂.
-      Proof.
-        exact (maponpaths
-                 (λ z, dirprod_pr2 (pr1 z))
-                 (nat_trans_ax (counit_from_left_adjoint (H c₁ c₂ m Hm)) _ _ μ)).
-      Qed.
-
-      Local Lemma is_eso_lift_2_right_path_2
-        : (η₁ ▹ m) • ε₁' = id2 _.
-      Proof.
-        exact (maponpaths
-                 (λ z, dirprod_pr2 (pr1 z))
-                 (triangle_id_left_ad (pr21 (H c₁ c₂ m Hm)) l₁)).
-      Qed.
+        : f ◃ is_eso_lift_2 = k₁
+        := orthogonal_lift_2_left (H c₁ c₂ m Hm) l₁ l₂ k₁ k₂ p.
 
       Definition is_eso_lift_2_right
-        : is_eso_lift_2 ▹ m = k₂.
-      Proof.
-        unfold is_eso_lift_2.
-        rewrite <- !rwhisker_vcomp.
-        use vcomp_move_R_Mp.
-        {
-          unfold η₂.
-          is_iso.
-        }
-        cbn.
-        use (vcomp_rcancel ε₂').
-        {
-          exact is_eso_lift_2_counit_invertible'.
-        }
-        rewrite !vassocl.
-        etrans.
-        {
-          apply maponpaths.
-          exact is_eso_lift_2_right_path_1.
-        }
-        rewrite !vassocr.
-        etrans.
-        {
-          apply maponpaths_2.
-          exact is_eso_lift_2_right_path_2.
-        }
-        rewrite id2_left.
-        rewrite !vassocl.
-        refine (!_).
-        etrans.
-        {
-          apply maponpaths.
-          exact (maponpaths
-                   (λ z, dirprod_pr2 (pr1 z))
-                   (triangle_id_left_ad (pr21 (H c₁ c₂ m Hm)) l₂)).
-        }
-        apply id2_right.
-      Qed.
+        : is_eso_lift_2 ▹ m = k₂
+        := orthogonal_lift_2_right (H c₁ c₂ m Hm) l₁ l₂ k₁ k₂ p.
     End LiftTwo.
 
     (** Lifting property for for equalities *)
@@ -550,48 +263,7 @@ Section EsoMorphisms.
                (p₂ : ζ₁ ▹ m = ζ₂ ▹ m)
       : ζ₁ = ζ₂.
     Proof.
-      pose (pr2 (fully_faithful_implies_full_and_faithful
-                   _ _ _
-                   (fully_faithful_from_equivalence _ _ _ (H c₁ c₂ m Hm)))
-                l₁ l₂)
-        as Heq.
-      assert (((f ◃ ζ₁) ▹ m) • rassociator f l₂ m
-              =
-              rassociator f l₁ m • (f ◃ (ζ₁ ▹ m)))
-        as r₁.
-      {
-        refine (!_).
-        apply rwhisker_lwhisker_rassociator.
-      }
-      assert (((f ◃ ζ₂) ▹ m) • rassociator f l₂ m
-              =
-              rassociator f l₁ m • (f ◃ (ζ₂ ▹ m)))
-        as r₂.
-      {
-        refine (!_).
-        apply rwhisker_lwhisker_rassociator.
-      }
-      pose (proofirrelevance
-              _
-              (Heq ((f ◃ ζ₁ ,, ζ₁ ▹ m) ,, r₁)))
-        as Hprop.
-      refine (maponpaths pr1 (Hprop (_ ,, _) (_ ,, _))).
-      - use subtypePath.
-        {
-          intro.
-          apply cellset_property.
-        }
-        cbn.
-        apply idpath.
-      - use subtypePath.
-        {
-          intro.
-          apply cellset_property.
-        }
-        cbn.
-        use pathsdirprod.
-        + exact (!p₁).
-        + exact (!p₂).
+      exact (orthogonal_lift_eq (H c₁ c₂ m Hm) ζ₁ ζ₂ p₁ p₂).
     Qed.
   End Projections.
 
@@ -616,7 +288,7 @@ Section EsoMorphisms.
     - exact (pre_comp c₁ f).
     - exact (post_comp b₂ m).
     - use nat_z_iso_to_invertible_2cell.
-      exact (pre_comp_post_comp_commute_z_iso m).
+      exact (pre_comp_post_comp_commute_z_iso f m).
   Defined.
 
   Definition is_eso_via_pb
@@ -660,7 +332,7 @@ Section EsoMorphisms.
            _
            _).
     - exact univalent_cat_is_univalent_2_0.
-    - exact (is_eso_functor m).
+    - exact (orthogonal_functor f m).
     - exact (@equiv_cat_to_adj_equiv
                (univ_hom HB_2_1 b₂ c₁)
                (@univalent_iso_comma
@@ -669,7 +341,7 @@ Section EsoMorphisms.
                   (univ_hom HB_2_1 b₁ c₂)
                   (post_comp b₁ m)
                   (pre_comp c₂ f))
-               (is_eso_functor m)
+               (orthogonal_functor f m)
                Hf).
     - use nat_z_iso_to_invertible_2cell.
       use make_nat_z_iso.
@@ -706,7 +378,7 @@ Section EsoMorphisms.
              {c₁ c₂ : B}
              {m : c₁ --> c₂}
              (Hm : fully_faithful_1cell m)
-    : is_eso_functor m
+    : orthogonal_functor f m
       ⟹
       pr1 (pb_ump_mor
              (@iso_comma_has_pb_ump
@@ -747,7 +419,7 @@ Section EsoMorphisms.
                 (univ_hom HB_2_1 b₁ c₂)
                 (post_comp b₁ m)
                 (pre_comp c₂ f))
-             (is_eso_functor m)).
+             (orthogonal_functor f m)).
     pose (pb_ump_mor_left_adjoint_equivalence
             _
             _

--- a/UniMath/Bicategories/Morphisms/Examples/EsosInBicatOfUnivCats.v
+++ b/UniMath/Bicategories/Morphisms/Examples/EsosInBicatOfUnivCats.v
@@ -651,12 +651,12 @@ Definition eso_ff_factorization_bicat_of_univ_cats
   : eso_ff_factorization bicat_of_univ_cats.
 Proof.
   intros C₁ C₂ F.
-  refine (univalent_image F ,, sub_precategory_inclusion _ _ ,, functor_full_img _ ,, _).
+  refine (univalent_image F ,, functor_full_img _ ,, sub_precategory_inclusion _ _ ,, _).
   simple refine (_ ,, _ ,, _).
-  - use cat_fully_faithful_is_fully_faithful_1cell.
-    apply fully_faithful_sub_precategory_inclusion.
   - use essentially_surjective_is_eso.
     apply functor_full_img_essentially_surjective.
+  - use cat_fully_faithful_is_fully_faithful_1cell.
+    apply fully_faithful_sub_precategory_inclusion.
   - use nat_z_iso_to_invertible_2cell.
     exact (full_image_inclusion_commute_nat_iso F).
 Defined.

--- a/UniMath/Bicategories/Morphisms/Examples/MorphismsInOneTypes.v
+++ b/UniMath/Bicategories/Morphisms/Examples/MorphismsInOneTypes.v
@@ -481,11 +481,11 @@ Definition eso_ff_factorization_one_types
 Proof.
   intros X Y f.
   refine (HLevel_image f ,, _).
-  refine (pr1_image f ,, prtoimage f ,, _ ,, _ ,, _).
-  - apply one_types_isInjective_fully_faithful_1cell.
-    apply isInjective_pr1_image.
+  refine (prtoimage f ,, pr1_image f ,, _ ,, _ ,, _).
   - apply issurjective_is_eso.
     apply issurjprtoimage.
+  - apply one_types_isInjective_fully_faithful_1cell.
+    apply isInjective_pr1_image.
   - use make_invertible_2cell.
     + intro x.
       apply idpath.

--- a/UniMath/Bicategories/OrthogonalFactorization/EsoFactorizationSystem.v
+++ b/UniMath/Bicategories/OrthogonalFactorization/EsoFactorizationSystem.v
@@ -2,7 +2,7 @@
 
  The factorization system of esos and ff morphisms
 
- In this file, we construct the factorization system of eso 1-cells and
+ In this file, we construct, in any bicategory, the factorization system of eso 1-cells and
  fully faithful 1-cells. In the file `Eso.v`, we defined `eso_ff_factorization`,
  which only expresses the existence of the factorization. Here we show that
  it actually gives rise to an orthogonal factorization system. We also

--- a/UniMath/Bicategories/OrthogonalFactorization/EsoFactorizationSystem.v
+++ b/UniMath/Bicategories/OrthogonalFactorization/EsoFactorizationSystem.v
@@ -1,0 +1,90 @@
+(*****************************************************************************
+
+ The factorization system of esos and ff morphisms
+
+ In this file, we construct the factorization system of eso 1-cells and
+ fully faithful 1-cells. In the file `Eso.v`, we defined `eso_ff_factorization`,
+ which only expresses the existence of the factorization. Here we show that
+ it actually gives rise to an orthogonal factorization system. We also
+ instantiate this to 1-types and to univalent categories.
+
+ Contents
+ 1. The eso-ff factorization system
+ 2. The eso-ff factorization system for 1-types
+ 3. The eso-ff factorization system for univalent categories
+
+ *****************************************************************************)
+Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.All.
+Require Import UniMath.CategoryTheory.Core.Prelude.
+Require Import UniMath.CategoryTheory.IsoCommaCategory.
+Require Import UniMath.Bicategories.Core.Bicat.
+Import Bicat.Notations.
+Require Import UniMath.Bicategories.Core.Invertible_2cells.
+Require Import UniMath.Bicategories.Core.Univalence.
+Require Import UniMath.Bicategories.Core.Examples.OneTypes.
+Require Import UniMath.Bicategories.Core.Examples.BicatOfUnivCats.
+Require Import UniMath.Bicategories.Morphisms.Eso.
+Require Import UniMath.Bicategories.Morphisms.FullyFaithful.
+Require Import UniMath.Bicategories.Morphisms.Properties.ClosedUnderInvertibles.
+Require Import UniMath.Bicategories.Morphisms.Properties.EsoProperties.
+Require Import UniMath.Bicategories.Morphisms.Examples.MorphismsInOneTypes.
+Require Import UniMath.Bicategories.Morphisms.Examples.EsosInBicatOfUnivCats.
+Require Import UniMath.Bicategories.OrthogonalFactorization.Orthogonality.
+Require Import UniMath.Bicategories.OrthogonalFactorization.FactorizationSystem.
+
+Local Open Scope cat.
+
+(**
+ 1. The eso-ff factorization system
+ *)
+Definition eso_ff_orthogonal_factorization_system
+           {B : bicat}
+           (fact_B : eso_ff_factorization B)
+           (HB_2_1 : is_univalent_2_1 B)
+  : orthogonal_factorization_system B.
+Proof.
+  use make_orthogonal_factorization_system.
+  - exact (λ x y f, is_eso f).
+  - exact (λ x y f, fully_faithful_1cell f).
+  - abstract
+      (intros ;
+       apply isaprop_is_eso ;
+       exact HB_2_1).
+  - abstract
+      (intros ;
+       apply isaprop_fully_faithful_1cell).
+  - intros x y f.
+    exact (fact_B x y f).
+  - intros x y f g τ Hf ; cbn.
+    use (invertible_is_eso HB_2_1 Hf τ).
+    apply property_from_invertible_2cell.
+  - intros x y f g τ Hf ; cbn.
+    use (fully_faithful_invertible τ _ Hf).
+    apply property_from_invertible_2cell.
+  - intros b₁ b₂ c₁ c₂ e m He Hm.
+    apply He.
+    exact Hm.
+Defined.
+
+(**
+ 2. The eso-ff factorization system for 1-types
+ *)
+Definition eso_ff_orthogonal_factorization_system_one_types
+  : orthogonal_factorization_system one_types.
+Proof.
+  use eso_ff_orthogonal_factorization_system.
+  - exact eso_ff_factorization_one_types.
+  - exact one_types_is_univalent_2_1.
+Defined.
+
+(**
+ 3. The eso-ff factorization system for univalent categories
+ *)
+Definition eso_ff_orthogonal_factorization_system_bicat_of_univ_cats
+  : orthogonal_factorization_system bicat_of_univ_cats.
+Proof.
+  use eso_ff_orthogonal_factorization_system.
+  - exact eso_ff_factorization_bicat_of_univ_cats.
+  - exact univalent_cat_is_univalent_2_1.
+Defined.

--- a/UniMath/Bicategories/OrthogonalFactorization/FactorizationSystem.v
+++ b/UniMath/Bicategories/OrthogonalFactorization/FactorizationSystem.v
@@ -86,7 +86,21 @@ Definition factorization_1cell
      ×
      R _ _ r
      ×
-     invertible_2cell f (l · r).
+     invertible_2cell (l · r) f.
+
+Definition make_factorization_1cell
+           {B : bicat}
+           {L R : ∏ (x y : B), x --> y → hProp}
+           {x y : B}
+           {f : x --> y}
+           (a : B)
+           (l : x --> a)
+           (r : a --> y)
+           (Ll : L _ _ l)
+           (Rr : R _ _ r)
+           (τ : invertible_2cell (l · r) f)
+  : factorization_1cell L R f
+  := a ,, l ,, r ,, Ll ,, Rr ,, τ.
 
 Coercion factorization_1cell_ob
          {B : bicat}
@@ -122,8 +136,8 @@ Section ProjectionsFactorization.
 
   Definition factorization_1cell_commutes
     : invertible_2cell
-        f
         (factorization_1cell_left · factorization_1cell_right)
+        f
     := pr22 (pr222 fact).
 End ProjectionsFactorization.
 
@@ -235,8 +249,8 @@ Section Projections.
              {x y : B}
              (f : x --> y)
     : invertible_2cell
-        f
         (orthogonal_factorization_left f · orthogonal_factorization_right f)
+        f
     := factorization_1cell_commutes (pr122 fact_B x y f).
 
   Definition orthogonal_left_inv2cell

--- a/UniMath/Bicategories/OrthogonalFactorization/FactorizationSystem.v
+++ b/UniMath/Bicategories/OrthogonalFactorization/FactorizationSystem.v
@@ -1,0 +1,289 @@
+(*****************************************************************************
+
+ Orthogonal factorization systems in bicategory
+
+ In this file, we define the notion of orthogonal factorization system in a
+ bicategory. An orthogonal factorization system consists of two classes of maps,
+ which we call `L` and `R` respectively. These classes of maps must satisfy
+ the following requirements:
+ - Each 1-cell can be factorized as a composition of a map in `L` followed by
+   a map in `R`. Note that we require strong existence for this factorization
+   (via a `∑`-type) instead of ordinary existence (via a `∃`-type).
+ - `L` and `R` are closed under invertible 2-cells.
+ - Maps in `L` and `R` are orthogonal to each other. This means that we can
+   solve lifting problems of the following shape
+
+<<
+         b₁ --------> c₁
+         |            |
+    in L |            | in R
+         |            |
+         V            V
+         b₂ --------> c₂
+>>
+
+ In an orthogonal factorization system, factorizations are unique up to unique
+ invertible 2-cell. As such, it does not matter whether we use strong existence
+ or ordinary existence for the factorizations. In a weak factorization (where
+ the factorization are not necessarily unique), this distinction does matter.
+
+ Note that in the literature, the second property (closure under invertible
+ 2-cells) is often formulated stronger. Suppose, that we have a diagram as
+ follows:
+
+<<
+         b₁ --------> c₁
+         |            |
+    in L |            |
+         |            |
+         V            V
+         b₂ --------> c₂
+>>
+
+ If `b₁ --> c₁` and `b₂ --> c₂` are adjoint equivalences, then this diagram
+ gives rise to an adjoint equivalence in the arrow bicategory. Usually, one
+ requires `L` and `R` to be closed under adjoint equivalences in the arrow
+ bicategory. However, by assuming univalence, we can simplify this requirement.
+ By using equivalence induction on both `b₁ --> c₁` and `b₂ --> c₂`, we can
+ assume that both the top and bottom morphism in this diagram are identities.
+ This way, we get that `L` and `R` must be closed under invertible 2-cells.
+
+ Finally, we show that every morphism that is both in `L` and `R` must also
+ be an adjoint equivalence.
+
+ Contents
+ 1. Factorizations
+ 2. Orthogonal factorization systems
+ 3. Projections for orthogonal factorization systems
+ 4. Properties of orthogonal factorization systems
+
+ *****************************************************************************)
+Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.All.
+Require Import UniMath.CategoryTheory.Core.Prelude.
+Require Import UniMath.CategoryTheory.IsoCommaCategory.
+Require Import UniMath.Bicategories.Core.Bicat.
+Import Bicat.Notations.
+Require Import UniMath.Bicategories.Core.Invertible_2cells.
+Require Import UniMath.Bicategories.Core.EquivToAdjequiv.
+Require Import UniMath.Bicategories.Morphisms.Adjunctions.
+Require Import UniMath.Bicategories.OrthogonalFactorization.Orthogonality.
+
+Local Open Scope cat.
+
+(** * 1. Factorizations *)
+Definition factorization_1cell
+           {B : bicat}
+           (L R : ∏ (x y : B), x --> y → hProp)
+           {x y : B}
+           (f : x --> y)
+  : UU
+  := ∑ (a : B)
+       (l : x --> a)
+       (r : a --> y),
+     L _ _ l
+     ×
+     R _ _ r
+     ×
+     invertible_2cell f (l · r).
+
+Coercion factorization_1cell_ob
+         {B : bicat}
+         {L R : ∏ (x y : B), x --> y → hProp}
+         {x y : B}
+         {f : x --> y}
+         (fact : factorization_1cell L R f)
+  : B
+  := pr1 fact.
+
+Section ProjectionsFactorization.
+  Context {B : bicat}
+          {L R : ∏ (x y : B), x --> y → hProp}
+          {x y : B}
+          {f : x --> y}
+          (fact : factorization_1cell L R f).
+
+  Definition factorization_1cell_left
+    : x --> fact
+    := pr12 fact.
+
+  Definition factorization_1cell_right
+    : fact --> y
+    := pr122 fact.
+
+  Definition factorization_1cell_left_class
+    : L _ _ factorization_1cell_left
+    := pr1 (pr222 fact).
+
+  Definition factorization_1cell_right_class
+    : R _ _ factorization_1cell_right
+    := pr12 (pr222 fact).
+
+  Definition factorization_1cell_commutes
+    : invertible_2cell
+        f
+        (factorization_1cell_left · factorization_1cell_right)
+    := pr22 (pr222 fact).
+End ProjectionsFactorization.
+
+(** * 2. Orthogonal factorization systems *)
+Definition closed_under_invertible_2cell
+           {B : bicat}
+           (P : ∏ (x y : B), x --> y → hProp)
+  : UU
+  := ∏ (x y : B)
+       (f g : x --> y)
+       (τ : invertible_2cell f g),
+     P _ _ f
+     →
+     P _ _ g.
+
+Definition orthogonal_maps
+           {B : bicat}
+           (L R : ∏ (x y : B), x --> y → hProp)
+  : UU
+  := ∏ (b₁ b₂ c₁ c₂ : B)
+       (f : b₁ --> b₂)
+       (g : c₁ --> c₂),
+     L _ _ f
+     →
+     R _ _ g
+     →
+     f ⊥ g.
+
+Definition orthogonal_factorization_system
+           (B : bicat)
+  : UU
+  := ∑ (L R : ∏ (x y : B), x --> y → hProp),
+     (∏ (x y : B) (f : x --> y), factorization_1cell L R f)
+     ×
+     closed_under_invertible_2cell L
+     ×
+     closed_under_invertible_2cell R
+     ×
+     orthogonal_maps L R.
+
+Definition make_orthogonal_factorization_system
+           {B : bicat}
+           (L R : ∏ (x y : B), x --> y → hProp)
+           (fact : ∏ (x y : B) (f : x --> y), factorization_1cell L R f)
+           (HL : closed_under_invertible_2cell L)
+           (HR : closed_under_invertible_2cell R)
+           (LR : orthogonal_maps L R)
+  : orthogonal_factorization_system B
+  := L ,, R ,, fact ,, HL ,, HR ,, LR.
+
+(** * 3. Projections for orthogonal factorization systems *)
+Section Projections.
+  Context {B : bicat}
+          (fact_B : orthogonal_factorization_system B).
+
+  Definition orthogonal_left_class
+             {x y : B}
+             (f : x --> y)
+    : hProp
+    := pr1 fact_B x y f.
+
+  Definition orthogonal_right_class
+             {x y : B}
+             (f : x --> y)
+    : hProp
+    := pr12 fact_B x y f.
+
+  Definition orthogonal_factorization_ob
+             {x y : B}
+             (f : x --> y)
+    : B
+    := factorization_1cell_ob (pr122 fact_B x y f).
+
+  Definition orthogonal_factorization_left
+             {x y : B}
+             (f : x --> y)
+    : x --> orthogonal_factorization_ob f
+    := factorization_1cell_left (pr122 fact_B x y f).
+
+  Definition orthogonal_factorization_right
+             {x y : B}
+             (f : x --> y)
+    : orthogonal_factorization_ob f --> y
+    := factorization_1cell_right (pr122 fact_B x y f).
+
+  Definition orthogonal_factorization_left_class
+             {x y : B}
+             (f : x --> y)
+    : orthogonal_left_class (orthogonal_factorization_left f)
+    := factorization_1cell_left_class (pr122 fact_B x y f).
+
+  Definition orthogonal_factorization_right_class
+             {x y : B}
+             (f : x --> y)
+    : orthogonal_right_class (orthogonal_factorization_right f)
+    := factorization_1cell_right_class (pr122 fact_B x y f).
+
+  Definition orthogonal_factorization_commutes
+             {x y : B}
+             (f : x --> y)
+    : invertible_2cell
+        f
+        (orthogonal_factorization_left f · orthogonal_factorization_right f)
+    := factorization_1cell_commutes (pr122 fact_B x y f).
+
+  Definition orthogonal_left_inv2cell
+             {x y : B}
+             (f g : x --> y)
+             (τ : invertible_2cell f g)
+             (Lf : orthogonal_left_class f)
+    : orthogonal_left_class g
+    := pr1 (pr222 fact_B) _ _ f g τ Lf.
+
+  Definition orthogonal_right_inv2cell
+             {x y : B}
+             (f g : x --> y)
+             (τ : invertible_2cell f g)
+             (Lf : orthogonal_right_class f)
+    : orthogonal_right_class g
+    := pr12 (pr222 fact_B) _ _ f g τ Lf.
+
+  Definition orthogonal_lifting
+             {b₁ b₂ c₁ c₂ : B}
+             (f : b₁ --> b₂)
+             (g : c₁ --> c₂)
+             (Lf : orthogonal_left_class f)
+             (Rg : orthogonal_right_class g)
+    : f ⊥ g
+    := pr22 (pr222 fact_B) _ _ _ _ f g Lf Rg.
+End Projections.
+
+(** * 4. Properties of orthogonal factorization systems *)
+Section Properties.
+  Context {B : bicat}
+          (fact_B : orthogonal_factorization_system B)
+          {x y : B}
+          (f : x --> y)
+          (Lf : orthogonal_left_class fact_B f)
+          (Rf : orthogonal_right_class fact_B f).
+
+  Let α : invertible_2cell (id₁ _ · f) (f · id₁ _)
+    := comp_of_invertible_2cell
+         (lunitor_invertible_2cell _)
+         (rinvunitor_invertible_2cell _).
+
+  Definition orthogonal_left_right_to_equiv
+    : left_equivalence f.
+  Proof.
+    simple refine ((_ ,, (_ ,, _)) ,, _ ,, _) ; cbn.
+    - refine (orthogonal_lift_1 _ _ _ α).
+      exact (orthogonal_lifting fact_B f f Lf Rf).
+    - exact (inv_of_invertible_2cell (orthogonal_lift_1_comm_left _ _ _ α)).
+    - exact ((orthogonal_lift_1_comm_right _ _ _ α)).
+    - apply property_from_invertible_2cell.
+    - apply property_from_invertible_2cell.
+  Defined.
+
+  Definition orthogonal_left_right_to_adjequiv
+    : left_adjoint_equivalence f.
+  Proof.
+    use equiv_to_adjequiv.
+    exact orthogonal_left_right_to_equiv.
+  Defined.
+End Properties.

--- a/UniMath/Bicategories/OrthogonalFactorization/FactorizationSystem.v
+++ b/UniMath/Bicategories/OrthogonalFactorization/FactorizationSystem.v
@@ -54,8 +54,9 @@
  Contents
  1. Factorizations
  2. Orthogonal factorization systems
- 3. Projections for orthogonal factorization systems
- 4. Properties of orthogonal factorization systems
+ 3. Builder for orthogonal factorization systems
+ 4. Projections for orthogonal factorization systems
+ 5. Properties of orthogonal factorization systems
 
  *****************************************************************************)
 Require Import UniMath.Foundations.All.
@@ -163,17 +164,27 @@ Definition orthogonal_factorization_system
      ×
      orthogonal_maps L R.
 
-Definition make_orthogonal_factorization_system
-           {B : bicat}
-           (L R : ∏ (x y : B), x --> y → hProp)
-           (fact : ∏ (x y : B) (f : x --> y), factorization_1cell L R f)
-           (HL : closed_under_invertible_2cell L)
-           (HR : closed_under_invertible_2cell R)
-           (LR : orthogonal_maps L R)
-  : orthogonal_factorization_system B
-  := L ,, R ,, fact ,, HL ,, HR ,, LR.
+(** * 3. Builder for orthogonal factorization systems *)
+Section MakeFactorizationSystem.
+  Context {B : bicat}
+          (L R : ∏ (x y : B), x --> y → UU)
+          (isapropL : ∏ (x y : B) (f : x --> y), isaprop (L _ _ f))
+          (isapropR : ∏ (x y : B) (f : x --> y), isaprop (R _ _ f)).
 
-(** * 3. Projections for orthogonal factorization systems *)
+  Let L' : ∏ (x y : B), x --> y → hProp := λ x y f, L x y f ,, isapropL x y f.
+  Let R' : ∏ (x y : B), x --> y → hProp := λ x y f, R x y f ,, isapropR x y f.
+
+  Context (fact : ∏ (x y : B) (f : x --> y), factorization_1cell L' R' f)
+          (HL : closed_under_invertible_2cell L')
+          (HR : closed_under_invertible_2cell R')
+          (LR : orthogonal_maps L' R').
+
+  Definition make_orthogonal_factorization_system
+    : orthogonal_factorization_system B
+    := L' ,, R' ,, fact ,, HL ,, HR ,, LR.
+End MakeFactorizationSystem.
+
+(** * 4. Projections for orthogonal factorization systems *)
 Section Projections.
   Context {B : bicat}
           (fact_B : orthogonal_factorization_system B).
@@ -254,7 +265,7 @@ Section Projections.
     := pr22 (pr222 fact_B) _ _ _ _ f g Lf Rg.
 End Projections.
 
-(** * 4. Properties of orthogonal factorization systems *)
+(** * 5. Properties of orthogonal factorization systems *)
 Section Properties.
   Context {B : bicat}
           (fact_B : orthogonal_factorization_system B)

--- a/UniMath/Bicategories/OrthogonalFactorization/Orthogonality.v
+++ b/UniMath/Bicategories/OrthogonalFactorization/Orthogonality.v
@@ -1,0 +1,763 @@
+(*****************************************************************************
+
+ Orthogonality
+
+ In this file, we define the left and right lifting properties of 1-cells in
+ bicategories.
+
+ The context in which we are interested in this notion, is given by orthogonal
+ factorization system. In such a factorization, we have two classes of
+ morphisms, which we call `L` and `R`. Each 1-cell in the bicategory can be
+ factorized as `f · g` where `f` is in `L` and where `g` is in `R`. To
+ guarantee that this factorization is unique up to unique invertible 2-cell,
+ we require that a lifting property between maps in `L` and maps in `R`.
+ This lifting property is expressed via orthogonal morphisms.
+
+ Suppose that we have 1-cells `f : b₁ --> b₂` and `g` : c₁ --> c₂`. Then we
+ say that `f` is left orthogonal to `g` (which we write as `f ⊥ g`) if the
+ following diagrams is a weak pullback of categories:
+
+<<
+       B(b₂, c₁) -------------> B(b₁, c₁)
+           |                        |
+           |                        |
+           V                        V
+       B(b₂, c₂) -------------> B(b₁, c₂)
+>>
+
+ The maps are given as follows:
+ - `B(b₂, c₁) --> B(b₁, c₁)`: precomposition with `f`
+ - `B(b₂, c₁) --> B(b₂, c₂)`: postcomposition with `g`
+ - `B(b₂, c₂) --> B(b₁, c₂)`: precomposition with `f`
+ - `B(b₁, c₁) --> B(b₁, c₂)`: postcomposition with `g`
+
+ Note that weak pullbacks of categories are given by iso-comma categories. We
+ express this lifting property by saying that a certain functor is an adjoint
+ equivalence of categories ([orthogonal]). This functor ([orthogonal_functor])
+ has type: `hom b₂ c₁ ⟶ iso_comma (post_comp b₁ g) (pre_comp c₂ f)`, so it
+ is the functor that we obtain from the universal property of the iso-comma
+ category.
+
+ To verify whether two classes of morphisms are orthogonal, one needs to
+ establish that a certain functor is an equivalence. To do so, it suffices to
+ check that this functor is essentially surjective and fully faithful (assuming
+ that the bicategory is locally univalent. Each of these properties has a
+ rather natural interpretation.
+ - Essential surjectivity ([orthogonal_essentially_surjective]): if we are given
+   a square as follows
+
+<<
+       b₁ ------------> c₁
+       |                |
+     f |                | g
+       |                |
+       V                V
+       b₂ ------------> c₂
+>>
+
+   where `f` is in the left class and where `g` is in the right class, then
+   we can find a lift `l : b₂ --> c₁` such that the resulting triangle commute
+   up to invertible 2-cell (and some coherence condition).
+ - Fullness ([orthogonal_full]): if we are given two lifts `l₁, l₂ : b₂ --> c₁`,
+   then we can obtain a 2-cell `l₁ ==> l₂` if we have 2-cells `f · l₁ ==> f · l₂`
+   and `l₁ · g ==> l₂ · g` (again requiring some coherence condition)
+ - Faithfulness ([orthogonal_faithful]) expresses the uniqueness of the 2-cell
+   obtained from fullness.
+
+ Finally, we show that the definition in this file, is equivalent to definition
+ of orthogonality expressed via pullbacks.
+
+ Contents
+ 1. Orthogonality
+ 2. Constructing orthogonal morphisms
+ 3. Projections of orthogonal morphisms
+ 3.1. Lifting property for for 1-cells
+ 3.2. Lifting property for for 2-cells
+ 3.3. Lifting property for for equalities
+ 4. Orthogonality via pullbacks
+ 5. Equivalence of the definitions
+
+ *****************************************************************************)
+Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.All.
+Require Import UniMath.CategoryTheory.Core.Prelude.
+Require Import UniMath.CategoryTheory.Adjunctions.Core.
+Require Import UniMath.CategoryTheory.Equivalences.Core.
+Require Import UniMath.CategoryTheory.Equivalences.FullyFaithful.
+Require Import UniMath.CategoryTheory.IsoCommaCategory.
+Require Import UniMath.Bicategories.Core.Bicat.
+Import Bicat.Notations.
+Require Import UniMath.Bicategories.Core.Invertible_2cells.
+Require Import UniMath.Bicategories.Core.Univalence.
+Require Import UniMath.Bicategories.Core.AdjointUnique.
+Require Import UniMath.Bicategories.Core.Examples.BicatOfUnivCats.
+Require Import UniMath.Bicategories.Morphisms.Properties.ClosedUnderInvertibles.
+Require Import UniMath.Bicategories.Limits.Pullbacks.
+Require Import UniMath.Bicategories.Limits.PullbackFunctions.
+Import PullbackFunctions.Notations.
+Require Import UniMath.Bicategories.Limits.PullbackEquivalences.
+Require Import UniMath.Bicategories.Limits.Examples.BicatOfUnivCatsLimits.
+
+Local Open Scope cat.
+
+Section Comp.
+  Context {B : bicat}.
+
+  Definition pre_comp_post_comp_commute
+             {b₁ b₂ : B}
+             (f : b₁ --> b₂)
+             {c₁ c₂ : B}
+             (g : c₁ --> c₂)
+    : pre_comp c₁ f ∙ post_comp b₁ g
+      ⟹
+      post_comp b₂ g ∙ pre_comp c₂ f.
+  Proof.
+    use make_nat_trans.
+    - exact (λ _, rassociator _ _ _).
+    - abstract
+        (intros h₁ h₂ α ;
+         cbn ;
+         rewrite rwhisker_lwhisker_rassociator ;
+         apply idpath).
+  Defined.
+
+  Definition pre_comp_post_comp_commute_z_iso
+             {b₁ b₂ : B}
+             (f : b₁ --> b₂)
+             {c₁ c₂ : B}
+             (g : c₁ --> c₂)
+    : nat_z_iso
+        (pre_comp c₁ f ∙ post_comp b₁ g)
+        (post_comp b₂ g ∙ pre_comp c₂ f).
+  Proof.
+    use make_nat_z_iso.
+    - exact (pre_comp_post_comp_commute f g).
+    - intro.
+      use is_inv2cell_to_is_z_iso ; cbn.
+      is_iso.
+  Defined.
+End Comp.
+
+(** * 1. Orthogonality *)
+Definition orthogonal_functor
+           {B : bicat}
+           {b₁ b₂ : B}
+           (f : b₁ --> b₂)
+           {c₁ c₂ : B}
+           (g : c₁ --> c₂)
+  : hom b₂ c₁ ⟶ iso_comma (post_comp b₁ g) (pre_comp c₂ f).
+Proof.
+  use iso_comma_ump1.
+  - exact (pre_comp c₁ f).
+  - exact (post_comp b₂ g).
+  - exact (pre_comp_post_comp_commute_z_iso f g).
+Defined.
+
+Definition orthogonal
+           {B : bicat}
+           {b₁ b₂ c₁ c₂ : B}
+           (f : b₁ --> b₂)
+           (g : c₁ --> c₂)
+  : UU
+  := adj_equivalence_of_cats (orthogonal_functor f g).
+
+Notation "f ⊥ g" := (orthogonal f g) (at level 60) : cat.
+
+Definition isaprop_orthogonal
+           {B : bicat}
+           {b₁ b₂ c₁ c₂ : B}
+           (f : b₁ --> b₂)
+           (g : c₁ --> c₂)
+           (HB_2_1 : is_univalent_2_1 B)
+  : isaprop (f ⊥ g).
+Proof.
+  use (isofhlevelweqf
+         1
+         (@adj_equiv_is_equiv_cat
+            (univ_hom HB_2_1 b₂ c₁)
+            (@univalent_iso_comma
+               (univ_hom HB_2_1 b₁ c₁)
+               (univ_hom HB_2_1 b₂ c₂)
+               (univ_hom HB_2_1 b₁ c₂)
+               (post_comp b₁ g)
+               (pre_comp c₂ f))
+            (orthogonal_functor f g))).
+  apply isaprop_left_adjoint_equivalence.
+  exact univalent_cat_is_univalent_2_1.
+Qed.
+
+(** * 2. Constructing orthogonal morphisms *)
+Section ConstructOrthogonality.
+  Context {B : bicat}
+          {b₁ b₂ c₁ c₂ : B}
+          (f : b₁ --> b₂)
+          (g : c₁ --> c₂).
+
+  Definition orthogonal_essentially_surjective
+    : UU
+    := ∏ (φ₁ : b₁ --> c₁)
+         (φ₂ : b₂ --> c₂)
+         (α : invertible_2cell (φ₁ · g) (f · φ₂)),
+       ∑ (l : b₂ --> c₁)
+         (ζ₁ : invertible_2cell (f · l) φ₁)
+         (ζ₂ : invertible_2cell (l · g) φ₂),
+       (ζ₁ ▹ g) • α = rassociator _ _ _ • (f ◃ ζ₂).
+
+  Definition orthogonal_full
+    : UU
+    := ∏ (l₁ l₂ : b₂ --> c₁)
+         (k₁ : f · l₁ ==> f · l₂)
+         (k₂ : l₁ · g ==> l₂ · g)
+         (p : (k₁ ▹ g) • rassociator _ _ _
+              =
+              rassociator _ _ _ • (f ◃ k₂)),
+       ∑ (ξ : l₁ ==> l₂),
+       f ◃ ξ = k₁
+       ×
+       ξ ▹ g = k₂.
+
+  Definition orthogonal_faithful
+    : UU
+    := ∏ (l₁ l₂ : b₂ --> c₁)
+         (ζ₁ ζ₂ : l₁ ==> l₂),
+       f ◃ ζ₁ = f ◃ ζ₂
+       →
+       ζ₁ ▹ g = ζ₂ ▹ g
+       →
+       ζ₁ = ζ₂.
+
+  Section MakeOrthogonal.
+    Context (HB_2_1 : is_univalent_2_1 B)
+            (H₁ : orthogonal_full)
+            (H₂ : orthogonal_faithful)
+            (H₃ : orthogonal_essentially_surjective).
+
+    Definition make_orthogonal_full
+      : full (orthogonal_functor f g).
+    Proof.
+      intros l₁ l₂.
+      intro k.
+      apply hinhpr.
+      simple refine (_ ,, _) ; cbn.
+      - exact (pr1 (H₁ l₁ l₂ (pr11 k) (pr21 k) (pr2 k))).
+      - abstract
+          (use subtypePath ; [ intro ; apply cellset_property | ] ;
+           cbn ;
+           exact (pathsdirprod
+                    (pr12 (H₁ l₁ l₂ (pr11 k) (pr21 k) (pr2 k)))
+                    (pr22 (H₁ l₁ l₂ (pr11 k) (pr21 k) (pr2 k))))).
+    Defined.
+
+    Definition make_orthogonal_faithful
+      : faithful (orthogonal_functor f g).
+    Proof.
+      intros l₁ l₂.
+      intro im.
+      use invproofirrelevance.
+      intros ζ₁ ζ₂.
+      use subtypePath.
+      {
+        intro.
+        apply homset_property.
+      }
+      use (H₂ l₁ l₂ (pr1 ζ₁) (pr1 ζ₂)).
+      - exact (maponpaths (λ z, pr11 z) (pr2 ζ₁)
+               @ !(maponpaths (λ z, pr11 z) (pr2 ζ₂))).
+      - exact (maponpaths (λ z, dirprod_pr2 (pr1 z)) (pr2 ζ₁)
+               @ !(maponpaths (λ z, dirprod_pr2 (pr1 z)) (pr2 ζ₂))).
+    Qed.
+
+    Definition make_orthogonal_fully_faithful
+      : fully_faithful (orthogonal_functor f g).
+    Proof.
+      use full_and_faithful_implies_fully_faithful.
+      split.
+      - exact make_orthogonal_full.
+      - exact make_orthogonal_faithful.
+    Defined.
+
+    Definition make_orthogonal_essentially_surjective
+      : essentially_surjective (orthogonal_functor f g).
+    Proof.
+      intros h.
+      pose (ℓ := H₃ (pr11 h) (pr21 h) (z_iso_to_inv2cell (pr2 h))).
+      apply hinhpr.
+      simple refine (_ ,, _).
+      - exact (pr1 ℓ).
+      - use make_z_iso'.
+        + simple refine ((_ ,, _) ,, _) ; cbn.
+          * exact (pr12 ℓ).
+          * exact (pr122 ℓ).
+          * exact (pr222 ℓ).
+        + use is_z_iso_iso_comma.
+          * use is_inv2cell_to_is_z_iso.
+            apply property_from_invertible_2cell.
+          * use is_inv2cell_to_is_z_iso.
+            apply property_from_invertible_2cell.
+    Defined.
+
+    Definition make_orthogonal : f ⊥ g.
+    Proof.
+      use rad_equivalence_of_cats.
+      - use is_univ_hom.
+        exact HB_2_1.
+      - exact make_orthogonal_fully_faithful.
+      - exact make_orthogonal_essentially_surjective.
+    Defined.
+  End MakeOrthogonal.
+End ConstructOrthogonality.
+
+(** * 3. Projections of orthogonal morphisms *)
+Section OrthogonalityProjections.
+  Context {B : bicat}
+          {b₁ b₂ c₁ c₂ : B}
+          {f : b₁ --> b₂}
+          {g : c₁ --> c₂}
+          (H : f ⊥ g).
+
+  (** ** 3.1. Lifting property for for 1-cells *)
+  Section LiftOne.
+    Context (φ₁ : b₁ --> c₁)
+            (φ₂ : b₂ --> c₂)
+            (α : invertible_2cell (φ₁ · g) (f · φ₂)).
+
+      Definition orthogonal_lift_1
+        : b₂ --> c₁
+        := right_adjoint (H : adj_equivalence_of_cats _) ((φ₁ ,, φ₂) ,, inv2cell_to_z_iso α).
+
+      Definition orthogonal_lift_1_comm_left
+        : invertible_2cell (f · orthogonal_lift_1) φ₁.
+      Proof.
+        apply z_iso_to_inv2cell.
+        exact (functor_on_z_iso
+                (iso_comma_pr1 _ _)
+                (counit_pointwise_z_iso_from_adj_equivalence
+                   H
+                   ((φ₁ ,, φ₂) ,, inv2cell_to_z_iso α))).
+      Defined.
+
+      Definition orthogonal_lift_1_comm_right
+        : invertible_2cell (orthogonal_lift_1 · g) φ₂.
+      Proof.
+        apply z_iso_to_inv2cell.
+        exact (functor_on_z_iso
+                 (iso_comma_pr2 _ _)
+                 (counit_pointwise_z_iso_from_adj_equivalence
+                    H
+                    ((φ₁ ,, φ₂) ,, inv2cell_to_z_iso α))).
+      Defined.
+
+      Definition orthogonal_lift_1_eq
+        : (orthogonal_lift_1_comm_left ▹ g) • α
+          =
+          rassociator _ _ _ • (f ◃ orthogonal_lift_1_comm_right)
+        := pr2 (counit_from_left_adjoint
+                  (pr1 H)
+                  ((φ₁ ,, φ₂) ,, inv2cell_to_z_iso α)).
+    End LiftOne.
+
+    (** ** 3.2. Lifting property for for 2-cells *)
+    Section LiftTwo.
+      Context (l₁ l₂ : b₂ --> c₁)
+              (k₁ : f · l₁ ==> f · l₂)
+              (k₂ : l₁ · g ==> l₂ · g)
+              (p : (k₁ ▹ g) • rassociator _ _ _
+                   =
+                   rassociator _ _ _ • (f ◃ k₂)).
+
+      Let R : iso_comma (post_comp b₁ g) (pre_comp c₂ f) ⟶ hom b₂ c₁
+        := right_adjoint (H : adj_equivalence_of_cats _).
+
+      Let φ : iso_comma (post_comp b₁ g) (pre_comp c₂ f)
+        := (f · l₁ ,, l₁ · g) ,, inv2cell_to_z_iso (rassociator_invertible_2cell _ _ _).
+      Let ψ : iso_comma (post_comp b₁ g) (pre_comp c₂ f)
+        := (f · l₂ ,, l₂ · g) ,, inv2cell_to_z_iso (rassociator_invertible_2cell _ _ _).
+      Let μ : φ --> ψ
+        := (k₁ ,, k₂) ,, p.
+
+      Let η₁ : l₁ ==> R φ
+        := unit_from_left_adjoint (H : adj_equivalence_of_cats _) l₁.
+      Let η₂ : R ψ ==> l₂
+        := z_iso_to_inv2cell (unit_pointwise_z_iso_from_adj_equivalence H l₂)^-1.
+      Let ε₁ : f · R φ ==> f · l₁
+        := pr11 (counit_from_left_adjoint (pr1 H) φ).
+      Let ε₂ : f · R ψ ==> f · l₂
+        := pr11 (counit_from_left_adjoint (pr1 H) ψ).
+      Let ε₁' : R φ · g ==> l₁ · g
+        := pr21 (counit_from_left_adjoint (pr1 H) φ).
+      Let ε₂' : R ψ · g ==> l₂ · g
+        := pr21 (counit_from_left_adjoint (pr1 H) ψ).
+
+      Definition orthogonal_lift_2
+        : l₁ ==> l₂
+        := η₁ • #R μ • η₂.
+
+      Local Lemma orthogonal_lift_2_counit_invertible
+        : is_invertible_2cell ε₂.
+      Proof.
+        exact (property_from_invertible_2cell
+                 (z_iso_to_inv2cell
+                    (functor_on_z_iso
+                       (iso_comma_pr1 _ _)
+                       (counit_pointwise_z_iso_from_adj_equivalence H ψ)))).
+      Qed.
+
+      Local Lemma orthogonal_lift_2_left_path_1
+        : (f ◃ #R μ) • ε₂ = ε₁ • k₁.
+      Proof.
+        exact (maponpaths
+                 (λ z, pr11 z)
+                 (nat_trans_ax
+                    (counit_from_left_adjoint (H : adj_equivalence_of_cats _))
+                    _ _
+                    μ)).
+      Qed.
+
+      Local Lemma orthogonal_lift_2_left_path_2
+        : (f ◃ η₁) • ε₁ = id2 _.
+      Proof.
+        exact (maponpaths
+                 (λ z, pr11 z)
+                 (triangle_id_left_ad (pr21 H) l₁)).
+      Qed.
+
+      Definition orthogonal_lift_2_left
+        : f ◃ orthogonal_lift_2 = k₁.
+      Proof.
+        unfold orthogonal_lift_2.
+        rewrite <- !lwhisker_vcomp.
+        use vcomp_move_R_Mp.
+        {
+          unfold η₂.
+          is_iso.
+        }
+        use (vcomp_rcancel ε₂).
+        {
+          exact orthogonal_lift_2_counit_invertible.
+        }
+        rewrite !vassocl.
+        etrans.
+        {
+          apply maponpaths.
+          exact orthogonal_lift_2_left_path_1.
+        }
+        cbn.
+        rewrite !vassocr.
+        etrans.
+        {
+          apply maponpaths_2.
+          exact orthogonal_lift_2_left_path_2.
+        }
+        rewrite id2_left.
+        rewrite !vassocl.
+        refine (!_).
+        etrans.
+        {
+          apply maponpaths.
+          exact (maponpaths
+                   (λ z, pr11 z)
+                   (triangle_id_left_ad (pr21 H) l₂)).
+        }
+        cbn.
+        rewrite id2_right.
+        apply idpath.
+      Qed.
+
+      Local Lemma orthogonal_lift_2_counit_invertible'
+        : is_invertible_2cell ε₂'.
+      Proof.
+        exact (property_from_invertible_2cell
+                 (z_iso_to_inv2cell
+                    (functor_on_z_iso
+                       (iso_comma_pr2 _ _)
+                       (counit_pointwise_z_iso_from_adj_equivalence H ψ)))).
+      Qed.
+
+      Local Lemma orthogonal_lift_2_right_path_1
+        : (#R μ ▹ g) • ε₂' = ε₁' • k₂.
+      Proof.
+        exact (maponpaths
+                 (λ z, dirprod_pr2 (pr1 z))
+                 (nat_trans_ax
+                    (counit_from_left_adjoint (H : adj_equivalence_of_cats _))
+                    _ _
+                    μ)).
+      Qed.
+
+      Local Lemma orthogonal_lift_2_right_path_2
+        : (η₁ ▹ g) • ε₁' = id2 _.
+      Proof.
+        exact (maponpaths
+                 (λ z, dirprod_pr2 (pr1 z))
+                 (triangle_id_left_ad (pr21 H) l₁)).
+      Qed.
+
+      Definition orthogonal_lift_2_right
+        : orthogonal_lift_2 ▹ g = k₂.
+      Proof.
+        unfold orthogonal_lift_2.
+        rewrite <- !rwhisker_vcomp.
+        use vcomp_move_R_Mp.
+        {
+          unfold η₂.
+          is_iso.
+        }
+        cbn.
+        use (vcomp_rcancel ε₂').
+        {
+          exact orthogonal_lift_2_counit_invertible'.
+        }
+        rewrite !vassocl.
+        etrans.
+        {
+          apply maponpaths.
+          exact orthogonal_lift_2_right_path_1.
+        }
+        rewrite !vassocr.
+        etrans.
+        {
+          apply maponpaths_2.
+          exact orthogonal_lift_2_right_path_2.
+        }
+        rewrite id2_left.
+        rewrite !vassocl.
+        refine (!_).
+        etrans.
+        {
+          apply maponpaths.
+          exact (maponpaths
+                   (λ z, dirprod_pr2 (pr1 z))
+                   (triangle_id_left_ad (pr21 H) l₂)).
+        }
+        apply id2_right.
+      Qed.
+    End LiftTwo.
+
+    (** ** 3.3. Lifting property for for equalities *)
+    Definition orthogonal_lift_eq
+               {l₁ l₂ : b₂ --> c₁}
+               (ζ₁ ζ₂ : l₁ ==> l₂)
+               (p₁ : f ◃ ζ₁ = f ◃ ζ₂)
+               (p₂ : ζ₁ ▹ g = ζ₂ ▹ g)
+      : ζ₁ = ζ₂.
+    Proof.
+      pose (pr2 (fully_faithful_implies_full_and_faithful
+                   _ _ _
+                   (fully_faithful_from_equivalence _ _ _ H))
+                l₁ l₂)
+        as Heq.
+      assert (((f ◃ ζ₁) ▹ g) • rassociator f l₂ g
+              =
+              rassociator f l₁ g • (f ◃ (ζ₁ ▹ g)))
+        as r₁.
+      {
+        refine (!_).
+        apply rwhisker_lwhisker_rassociator.
+      }
+      assert (((f ◃ ζ₂) ▹ g) • rassociator f l₂ g
+              =
+              rassociator f l₁ g • (f ◃ (ζ₂ ▹ g)))
+        as r₂.
+      {
+        refine (!_).
+        apply rwhisker_lwhisker_rassociator.
+      }
+      pose (proofirrelevance
+              _
+              (Heq ((f ◃ ζ₁ ,, ζ₁ ▹ g) ,, r₁)))
+        as Hprop.
+      refine (maponpaths pr1 (Hprop (_ ,, _) (_ ,, _))).
+      - use subtypePath.
+        {
+          intro.
+          apply cellset_property.
+        }
+        cbn.
+        apply idpath.
+      - use subtypePath.
+        {
+          intro.
+          apply cellset_property.
+        }
+        cbn.
+        use pathsdirprod.
+        + exact (!p₁).
+        + exact (!p₂).
+    Qed.
+End OrthogonalityProjections.
+
+Section OrthogonalityViaPullback.
+  Context {B : bicat}
+          {b₁ b₂ c₁ c₂ : B}
+          (f : b₁ --> b₂)
+          (g : c₁ --> c₂).
+
+  (**
+   4. Orthogonality via pullbacks
+   *)
+  Definition orthogonal_via_pb_cone
+             (HB_2_1 : is_univalent_2_1 B)
+    : @pb_cone
+        bicat_of_univ_cats
+        (univ_hom HB_2_1 b₁ c₁)
+        (univ_hom HB_2_1 b₂ c₂)
+        (univ_hom HB_2_1 b₁ c₂)
+        (post_comp b₁ g)
+        (pre_comp c₂ f).
+  Proof.
+    use make_pb_cone.
+    - exact (univ_hom HB_2_1 b₂ c₁).
+    - exact (pre_comp c₁ f).
+    - exact (post_comp b₂ g).
+    - use nat_z_iso_to_invertible_2cell.
+      exact (pre_comp_post_comp_commute_z_iso f g).
+  Defined.
+
+  Definition orthogonal_via_pb
+             (HB_2_1 : is_univalent_2_1 B)
+    : UU
+    := has_pb_ump (orthogonal_via_pb_cone HB_2_1).
+
+  Definition isaprop_orthogonal_via_pb
+             (HB_2_1 : is_univalent_2_1 B)
+    : isaprop (orthogonal_via_pb HB_2_1).
+  Proof.
+    use isaprop_has_pb_ump.
+    exact univalent_cat_is_univalent_2_1.
+  Defined.
+
+  (**
+   5. Equivalence of the definitions
+   *)
+  Definition orthogonal_to_orthogonal_via_pb
+             (HB_2_1 : is_univalent_2_1 B)
+             (Hf : f ⊥ g)
+    : orthogonal_via_pb HB_2_1.
+  Proof.
+    use (left_adjoint_equivalence_to_pb
+           _ _ _
+           (@iso_comma_has_pb_ump
+               (univ_hom HB_2_1 b₁ c₁)
+               (univ_hom HB_2_1 b₂ c₂)
+               (univ_hom HB_2_1 b₁ c₂)
+               (post_comp b₁ g)
+               (pre_comp c₂ f))
+           _
+           _).
+    - exact univalent_cat_is_univalent_2_0.
+    - exact (orthogonal_functor f g).
+    - exact (@equiv_cat_to_adj_equiv
+               (univ_hom HB_2_1 b₂ c₁)
+               (@univalent_iso_comma
+                  (univ_hom HB_2_1 b₁ c₁)
+                  (univ_hom HB_2_1 b₂ c₂)
+                  (univ_hom HB_2_1 b₁ c₂)
+                  (post_comp b₁ g)
+                  (pre_comp c₂ f))
+               (orthogonal_functor f g)
+               Hf).
+    - use nat_z_iso_to_invertible_2cell.
+      use make_nat_z_iso.
+      + use make_nat_trans.
+        * exact (λ _, id2 _).
+        * abstract
+            (intros h₁ h₂ α ; cbn ;
+             rewrite id2_left, id2_right ;
+             apply idpath).
+      + intro.
+        use is_inv2cell_to_is_z_iso ; cbn.
+        is_iso.
+    - use nat_z_iso_to_invertible_2cell.
+      use make_nat_z_iso.
+      + use make_nat_trans.
+        * exact (λ _, id2 _).
+        * abstract
+            (intros h₁ h₂ α ; cbn ;
+             rewrite id2_left, id2_right ;
+             apply idpath).
+      + intro.
+        use is_inv2cell_to_is_z_iso ; cbn.
+        is_iso.
+    - abstract
+        (use nat_trans_eq ; [ apply homset_property | ] ;
+         intro x ; cbn ;
+         rewrite id2_rwhisker, lwhisker_id2 ;
+         rewrite !id2_left, !id2_right ;
+         apply idpath).
+  Defined.
+
+  Definition orthogonal_via_pb_to_orthogonal_nat_trans
+             (HB_2_1 : is_univalent_2_1 B)
+    : orthogonal_functor f g
+      ⟹
+      pr1 (pb_ump_mor
+             (@iso_comma_has_pb_ump
+                (univ_hom HB_2_1 b₁ c₁)
+                (univ_hom HB_2_1 b₂ c₂)
+                (univ_hom HB_2_1 b₁ c₂)
+                (post_comp b₁ g)
+                (pre_comp c₂ f))
+             (orthogonal_via_pb_cone HB_2_1)).
+  Proof.
+    use make_nat_trans.
+    - intro h.
+      simple refine ((id2 _ ,, id2 _) ,, _).
+      abstract
+        (cbn ;
+         rewrite id2_rwhisker, lwhisker_id2, id2_left, id2_right ;
+         apply idpath).
+    - abstract
+        (intros h₁ h₂ γ ;
+         use subtypePath ; [ intro ; apply cellset_property | ] ;
+         cbn ;
+         rewrite !id2_left, !id2_right ;
+         apply idpath).
+  Defined.
+
+  Definition orthogonal_via_pb_to_orthogonal
+             (HB_2_1 : is_univalent_2_1 B)
+             (Hf : orthogonal_via_pb HB_2_1)
+    : f ⊥ g.
+  Proof.
+    apply (@adj_equiv_to_equiv_cat
+             (univ_hom HB_2_1 b₂ c₁)
+             (@univalent_iso_comma
+                (univ_hom HB_2_1 b₁ c₁)
+                (univ_hom HB_2_1 b₂ c₂)
+                (univ_hom HB_2_1 b₁ c₂)
+                (post_comp b₁ g)
+                (pre_comp c₂ f))
+             (orthogonal_functor f g)).
+    pose (pb_ump_mor_left_adjoint_equivalence
+            _
+            _
+            (@iso_comma_has_pb_ump
+               (univ_hom HB_2_1 b₁ c₁)
+               (univ_hom HB_2_1 b₂ c₂)
+               (univ_hom HB_2_1 b₁ c₂)
+               (post_comp b₁ g)
+               (pre_comp c₂ f))
+            Hf)
+      as p.
+    use (left_adjoint_equivalence_invertible p).
+    - exact (orthogonal_via_pb_to_orthogonal_nat_trans HB_2_1).
+    - use is_nat_z_iso_to_is_invertible_2cell.
+      intro.
+      use is_z_iso_iso_comma.
+      + use is_inv2cell_to_is_z_iso ; cbn.
+        is_iso.
+      + use is_inv2cell_to_is_z_iso ; cbn.
+        is_iso.
+  Defined.
+
+  Definition orthogonal_weq_orthogonal_via_pb
+             (HB_2_1 : is_univalent_2_1 B)
+    : f ⊥ g ≃ orthogonal_via_pb HB_2_1.
+  Proof.
+    use weqimplimpl.
+    - exact (orthogonal_to_orthogonal_via_pb HB_2_1).
+    - exact (orthogonal_via_pb_to_orthogonal HB_2_1).
+    - exact (isaprop_orthogonal f g HB_2_1).
+    - exact (isaprop_orthogonal_via_pb HB_2_1).
+  Defined.
+End OrthogonalityViaPullback.

--- a/UniMath/CONTENTS.md
+++ b/UniMath/CONTENTS.md
@@ -885,6 +885,8 @@ The packages and files are listed here in logical order: each file depends only 
    - [Limits/PullbackEquivalences.v](Bicategories/Limits/PullbackEquivalences.v)
    - [Limits/InserterEquivalences.v](Bicategories/Limits/InserterEquivalences.v)
    - [Limits/EquifierEquivalences.v](Bicategories/Limits/EquifierEquivalences.v)
+   - [OrthogonalFactorization/Orthogonality.v](Bicategories/OrthogonalFactorization/Orthogonality.v)
+   - [OrthogonalFactorization/FactorizationSystem.v](Bicategories/OrthogonalFactorization/FactorizationSystem.v)
    - [Morphisms/Eso.v](Bicategories/Morphisms/Eso.v)
    - [Morphisms/Properties/Projections.v](Bicategories/Morphisms/Properties/Projections.v)
    - [Morphisms/Properties/ClosedUnderPullback.v](Bicategories/Morphisms/Properties/ClosedUnderPullback.v)

--- a/UniMath/CONTENTS.md
+++ b/UniMath/CONTENTS.md
@@ -896,6 +896,7 @@ The packages and files are listed here in logical order: each file depends only 
    - [Morphisms/Examples/MorphismsInSliceBicat.v](Bicategories/Morphisms/Examples/MorphismsInSliceBicat.v)
    - [Morphisms/Examples/MorphismsInStructuredCat.v](Bicategories/Morphisms/Examples/MorphismsInStructuredCat.v)
    - [Morphisms/Examples/MorphismsInBicatOfEnrichedCats.v](Bicategories/Morphisms/Examples/MorphismsInBicatOfEnrichedCats.v)
+   - [OrthogonalFactorization/EsoFactorizationSystem.v](Bicategories/OrthogonalFactorization/EsoFactorizationSystem.v)
    - [Colimits/Initial.v](Bicategories/Colimits/Initial.v)
    - [Colimits/Coproducts.v](Bicategories/Colimits/Coproducts.v)
    - [Colimits/Extensive.v](Bicategories/Colimits/Extensive.v)


### PR DESCRIPTION
This PR cleans the file on eso 1-cells in bicategories. It does so by:
- defining the notion of orthogonality for 1-cells of bicategory (this means that certain lifting properties are satisfied)
- refactor the eso file by basing it on orthogonality
- defining the notion of orthogonal factorization systems in bicategories
- constructing the (eso, ff) factorization system for 1-types and for univalent categories

I am planning to also construct an orthogonal factorization system for enriched categories (using eso and fully faithful functors), but that's for a separate PR. From this factorization system, we directly get that functors that are essentially surjective and fully faithful, also are adjoint equivalences.