### PR TITLE
Improve some names

### DIFF
--- a/UniMath/Bicategories/DoubleCategories/AlternativeDefinitions/DoubleCatsEquivalentDefinitions.v
+++ b/UniMath/Bicategories/DoubleCategories/AlternativeDefinitions/DoubleCatsEquivalentDefinitions.v
@@ -167,7 +167,7 @@ Section DoubleCatsUnfolded_to_DoubleCats.
     make_double_cat (und_ob_hor_cat C) D I Cm l r a tr pe.
 
   Definition  doublecategory_to_univalent_double_cat : univalent_double_cat :=
-    make_univalent_double_cat doublecategory_to_double_cat HC HD.
+    make_univalent_double_cat doublecategory_to_double_cat (HC ,, HD).
 End DoubleCatsUnfolded_to_DoubleCats.
 
 (** * 2. The inverse *)

--- a/UniMath/Bicategories/DoubleCategories/Core/SymmetricUnivalent.v
+++ b/UniMath/Bicategories/DoubleCategories/Core/SymmetricUnivalent.v
@@ -1050,8 +1050,9 @@ Section TransposePseudoDoubleCat.
   Proof.
     use make_univalent_double_cat.
     - exact transpose_double_cat.
-    - exact HC'.
-    - exact HC''.
+    - split.
+      + exact HC'.
+      + exact HC''.
   Defined.
 End TransposePseudoDoubleCat.
 

--- a/UniMath/Bicategories/DoubleCategories/Core/UnivalentDoubleCats.v
+++ b/UniMath/Bicategories/DoubleCategories/Core/UnivalentDoubleCats.v
@@ -103,15 +103,21 @@ Proof.
 Defined.
 
 (** * 3. Builder for double categories *)
+Definition is_univalent_double_cat
+           (C : double_cat)
+  : UU
+  := is_univalent C
+     ×
+     is_univalent_twosided_disp_cat (hor_mor C).
+
 Definition make_univalent_double_cat
            (C : double_cat)
-           (HC : is_univalent C)
-           (HD : is_univalent_twosided_disp_cat (hor_mor C))
+           (HC : is_univalent_double_cat C)
   : univalent_double_cat.
 Proof.
   simple refine ((((_ ,, _) ,, _) ,, _) ,, _).
-  - exact (_ ,, HC).
-  - exact (_ ,, HD).
+  - exact (_ ,, pr1 HC).
+  - exact (hor_mor C ,, pr2 HC).
   - exact (hor_id_double_cat C ,, hor_comp_double_cat C).
   - exact (double_cat_double_lunitor C
            ,,

--- a/UniMath/Bicategories/DoubleCategories/Examples/KleisliDoubleCat.v
+++ b/UniMath/Bicategories/DoubleCategories/Examples/KleisliDoubleCat.v
@@ -255,8 +255,9 @@ Definition kleisli_univalent_double_cat
 Proof.
   use make_univalent_double_cat.
   - exact (kleisli_double_cat M).
-  - apply univalent_category_is_univalent.
-  - apply is_univalent_comma_twosided_disp_cat.
+  - split.
+    + apply univalent_category_is_univalent.
+    + apply is_univalent_comma_twosided_disp_cat.
 Defined.
 
 (** * 3. The strict Kleisli double category *)

--- a/UniMath/Bicategories/DoubleCategories/Examples/LensesDoubleCat.v
+++ b/UniMath/Bicategories/DoubleCategories/Examples/LensesDoubleCat.v
@@ -235,8 +235,9 @@ Definition lenses_univalent_double_cat
 Proof.
   use make_univalent_double_cat.
   - exact (lenses_double_cat C PC).
-  - apply univalent_category_is_univalent.
-  - apply is_univalent_lenses_twosided_disp_cat.
+  - split.
+    + apply univalent_category_is_univalent.
+    + apply is_univalent_lenses_twosided_disp_cat.
 Defined.
 
 (** * 5. The strict double category *)

--- a/UniMath/Bicategories/DoubleCategories/Examples/ProductDoubleCat.v
+++ b/UniMath/Bicategories/DoubleCategories/Examples/ProductDoubleCat.v
@@ -270,10 +270,11 @@ Definition prod_univalent_double_cat
 Proof.
   use make_univalent_double_cat.
   - exact (prod_double_cat D₁ D₂).
-  - use is_univalent_category_binproduct.
-    + apply univalent_category_is_univalent.
-    + apply univalent_category_is_univalent.
-  - use is_univalent_twosided_disp_cat_product.
-    + apply is_univalent_twosided_disp_cat_hor_mor.
-    + apply is_univalent_twosided_disp_cat_hor_mor.
+  - split.
+    + use is_univalent_category_binproduct.
+      * apply univalent_category_is_univalent.
+      * apply univalent_category_is_univalent.
+    + use is_univalent_twosided_disp_cat_product.
+      * apply is_univalent_twosided_disp_cat_hor_mor.
+      * apply is_univalent_twosided_disp_cat_hor_mor.
 Defined.

--- a/UniMath/Bicategories/DoubleCategories/Examples/ProfunctorDoubleBicat.v
+++ b/UniMath/Bicategories/DoubleCategories/Examples/ProfunctorDoubleBicat.v
@@ -73,7 +73,7 @@ Local Open Scope double_bicat.
 Local Notation "∁" := (op2_bicat bicat_of_univ_cats).
 
 (** * 1. The 2-sided displayed category of the Verity bicategory of profunctors *)
-Definition univalent_profunctor_twosided_disp_cat_ob_mor
+Definition univcat_profunctor_twosided_disp_cat_ob_mor
   : twosided_disp_cat_ob_mor ∁ ∁.
 Proof.
   simple refine (_ ,, _).
@@ -86,33 +86,33 @@ Proof.
            profunctor_square G F P Q).
 Defined.
 
-Proposition univalent_twosided_disp_cat_id_comp
-  : twosided_disp_cat_id_comp univalent_profunctor_twosided_disp_cat_ob_mor.
+Proposition univcat_profunctor_twosided_disp_cat_id_comp
+  : twosided_disp_cat_id_comp univcat_profunctor_twosided_disp_cat_ob_mor.
 Proof.
   simple refine (_ ,, _).
   - exact (λ C D P, id_h_profunctor_square P).
   - exact (λ C₁ C₂ C₃ D₁ D₂ D₃ P₁ P₂ P₃ F₁ F₂ G₁ G₂ τ₁ τ₂, comp_h_profunctor_square τ₁ τ₂).
 Defined.
 
-Definition univalent_profunctor_twosided_disp_cat_data
+Definition univcat_profunctor_twosided_disp_cat_data
   : twosided_disp_cat_data ∁ ∁.
 Proof.
   simple refine (_ ,, _).
-  - exact univalent_profunctor_twosided_disp_cat_ob_mor.
-  - exact univalent_twosided_disp_cat_id_comp.
+  - exact univcat_profunctor_twosided_disp_cat_ob_mor.
+  - exact univcat_profunctor_twosided_disp_cat_id_comp.
 Defined.
 
-Definition univalent_profunctor_ver_sq_bicat
+Definition univcat_profunctor_ver_sq_bicat
   : ver_sq_bicat.
 Proof.
   use make_ver_sq_bicat.
   - exact ∁.
-  - exact univalent_profunctor_twosided_disp_cat_data.
+  - exact univcat_profunctor_twosided_disp_cat_data.
 Defined.
 
 (** * 2. The vertical bicategory of profunctors *)
-Definition univalent_profunctor_ver_sq_bicat_ver_id_comp
-  : ver_sq_bicat_ver_id_comp univalent_profunctor_ver_sq_bicat.
+Definition univcat_profunctor_ver_sq_bicat_ver_id_comp
+  : ver_sq_bicat_ver_id_comp univcat_profunctor_ver_sq_bicat.
 Proof.
   split.
   - split.
@@ -124,8 +124,8 @@ Proof.
   - exact (λ (C₁ C₂ : univalent_category) (P Q : C₁ ↛ C₂), profunctor_nat_trans P Q).
 Defined.
 
-Definition univalent_profunctor_ver_sq_bicat_id_comp_cells
-  : ver_sq_bicat_id_comp_cells univalent_profunctor_ver_sq_bicat_ver_id_comp.
+Definition univcat_profunctor_ver_sq_bicat_id_comp_cells
+  : ver_sq_bicat_id_comp_cells univcat_profunctor_ver_sq_bicat_ver_id_comp.
 Proof.
   repeat split.
   - exact (λ (C₁ C₂ : univalent_category)
@@ -170,8 +170,8 @@ Proof.
            rwhisker_profunctor_nat_trans τ Q).
 Defined.
 
-Proposition univalent_profunctor_ver_sq_bicat_prebicat_laws
-  : ver_sq_bicat_prebicat_laws univalent_profunctor_ver_sq_bicat_id_comp_cells.
+Proposition univcat_profunctor_ver_sq_bicat_prebicat_laws
+  : ver_sq_bicat_prebicat_laws univcat_profunctor_ver_sq_bicat_id_comp_cells.
 Proof.
   repeat split.
   - intros C₁ C₂ P Q τ.
@@ -649,21 +649,21 @@ Proof.
     apply idpath.
 Qed.
 
-Definition univalent_profunctor_ver_bicat_sq_bicat
+Definition univcat_profunctor_ver_bicat_sq_bicat
   : ver_bicat_sq_bicat.
 Proof.
   use make_ver_bicat_sq_bicat.
-  - exact univalent_profunctor_ver_sq_bicat.
-  - exact univalent_profunctor_ver_sq_bicat_ver_id_comp.
-  - exact univalent_profunctor_ver_sq_bicat_id_comp_cells.
-  - exact univalent_profunctor_ver_sq_bicat_prebicat_laws.
+  - exact univcat_profunctor_ver_sq_bicat.
+  - exact univcat_profunctor_ver_sq_bicat_ver_id_comp.
+  - exact univcat_profunctor_ver_sq_bicat_id_comp_cells.
+  - exact univcat_profunctor_ver_sq_bicat_prebicat_laws.
   - abstract
       (intros C₁ C₂ P Q ;
        apply isaset_profunctor_nat_trans).
 Defined.
 
-Definition univalent_profunctor_ver_bicat_sq_bicat_ver_id_comp_sq
-  : ver_bicat_sq_bicat_ver_id_comp_sq univalent_profunctor_ver_bicat_sq_bicat.
+Definition univcat_profunctor_ver_bicat_sq_bicat_ver_id_comp_sq
+  : ver_bicat_sq_bicat_ver_id_comp_sq univcat_profunctor_ver_bicat_sq_bicat.
 Proof.
   split.
   - exact (λ (C₁ C₂ : univalent_category)
@@ -682,17 +682,17 @@ Proof.
            comp_v_profunctor_square τ θ).
 Defined.
 
-Definition univalent_profunctor_ver_bicat_sq_bicat_ver_id_comp
+Definition univcat_profunctor_ver_bicat_sq_bicat_ver_id_comp
   : ver_bicat_sq_bicat_ver_id_comp.
 Proof.
   use make_ver_bicat_sq_bicat_ver_id_comp.
-  - exact univalent_profunctor_ver_bicat_sq_bicat.
-  - exact univalent_profunctor_ver_bicat_sq_bicat_ver_id_comp_sq.
+  - exact univcat_profunctor_ver_bicat_sq_bicat.
+  - exact univcat_profunctor_ver_bicat_sq_bicat_ver_id_comp_sq.
 Defined.
 
 (** * 3. The whiskering operations *)
-Definition univalent_profunctor_double_bicat_whiskering
-  : double_bicat_whiskering univalent_profunctor_ver_bicat_sq_bicat_ver_id_comp.
+Definition univcat_profunctor_double_bicat_whiskering
+  : double_bicat_whiskering univcat_profunctor_ver_bicat_sq_bicat_ver_id_comp.
 Proof.
   repeat split.
   - exact (λ (C₁ C₂ C₃ C₄ : univalent_category)
@@ -729,17 +729,17 @@ Proof.
            uwhisker_profunctor_square τ s).
 Defined.
 
-Definition univalent_profunctor_ver_bicat_sq_id_comp_whisker
+Definition univcat_profunctor_ver_bicat_sq_id_comp_whisker
   : ver_bicat_sq_id_comp_whisker.
 Proof.
   use make_ver_bicat_sq_id_comp_whisker.
-  - exact univalent_profunctor_ver_bicat_sq_bicat_ver_id_comp.
-  - exact univalent_profunctor_double_bicat_whiskering.
+  - exact univcat_profunctor_ver_bicat_sq_bicat_ver_id_comp.
+  - exact univcat_profunctor_double_bicat_whiskering.
 Defined.
 
 (** * 4. More laws *)
-Proposition univalent_profunctor_whisker_square_bicat_law
-  : whisker_square_bicat_law univalent_profunctor_ver_bicat_sq_id_comp_whisker.
+Proposition univcat_profunctor_whisker_square_bicat_law
+  : whisker_square_bicat_law univcat_profunctor_ver_bicat_sq_id_comp_whisker.
 Proof.
   repeat split.
   - intros C₁ C₂ C₃ C₄ F G P Q τ ; cbn in *.
@@ -875,8 +875,8 @@ Proof.
     apply idpath.
 Qed.
 
-Proposition univalent_profunctor_double_bicat_id_comp_square_laws
-  : double_bicat_id_comp_square_laws univalent_profunctor_ver_bicat_sq_id_comp_whisker.
+Proposition univcat_profunctor_double_bicat_id_comp_square_laws
+  : double_bicat_id_comp_square_laws univcat_profunctor_ver_bicat_sq_id_comp_whisker.
 Proof.
   repeat split.
   - intros C₁ C₂ C₃ C₄ C₅ C₆ C₇ C₈ C₀ P₁ P₂ Q₁ Q₂ R₁ R₂ F₁ F₂ G₁ G₂ H₁ H₂ τ₁ τ₂ θ₁ θ₂.
@@ -928,8 +928,8 @@ Proof.
     apply idpath.
 Qed.
 
-Proposition univalent_profunctor_double_bicat_cylinder_laws
-  : double_bicat_cylinder_laws univalent_profunctor_ver_bicat_sq_id_comp_whisker.
+Proposition univcat_profunctor_double_bicat_cylinder_laws
+  : double_bicat_cylinder_laws univcat_profunctor_ver_bicat_sq_id_comp_whisker.
 Proof.
   repeat split.
   - intros C₁ C₂ C₃ C₄ D₁ D₂ D₃ D₄ F₁ F₂ F₃ G₁ G₂ G₃ P₁ P₂ P₃ P₄ τ₁ τ₂ τ₃.
@@ -1127,30 +1127,30 @@ Proof.
     apply idpath.
 Qed.
 
-Proposition univalent_profunctor_double_bicat_laws
-  : double_bicat_laws univalent_profunctor_ver_bicat_sq_id_comp_whisker.
+Proposition univcat_profunctor_double_bicat_laws
+  : double_bicat_laws univcat_profunctor_ver_bicat_sq_id_comp_whisker.
 Proof.
   use make_double_bicat_laws.
-  - exact univalent_profunctor_whisker_square_bicat_law.
-  - exact univalent_profunctor_double_bicat_id_comp_square_laws.
-  - exact univalent_profunctor_double_bicat_cylinder_laws.
+  - exact univcat_profunctor_whisker_square_bicat_law.
+  - exact univcat_profunctor_double_bicat_id_comp_square_laws.
+  - exact univcat_profunctor_double_bicat_cylinder_laws.
   - intro ; intros.
     apply isaset_profunctor_square.
 Qed.
 
 (** * 5. The Verity double bicategory of univalent categories and profunctors *)
-Definition univalent_profunctor_verity_double_bicat
+Definition univcat_profunctor_verity_double_bicat
   : verity_double_bicat.
 Proof.
   use make_verity_double_bicat.
-  - exact univalent_profunctor_ver_bicat_sq_id_comp_whisker.
-  - exact univalent_profunctor_double_bicat_laws.
+  - exact univcat_profunctor_ver_bicat_sq_id_comp_whisker.
+  - exact univcat_profunctor_double_bicat_laws.
 Defined.
 
 (** * 6. 2-cells versus squares *)
-Definition univalent_profunctor_vertically_saturated
+Definition univcat_profunctor_vertically_saturated
   : vertically_saturated
-      univalent_profunctor_verity_double_bicat.
+      univcat_profunctor_verity_double_bicat.
 Proof.
   intros C₁ C₂ P Q ; cbn in *.
   use isweq_iso.
@@ -1167,9 +1167,9 @@ Proof.
        apply idpath).
 Defined.
 
-Definition univalent_profunctor_horizontally_saturated
+Definition univcat_profunctor_horizontally_saturated
   : horizontally_saturated
-      univalent_profunctor_verity_double_bicat.
+      univcat_profunctor_verity_double_bicat.
 Proof.
   intros C₁ C₂ F G ; cbn in *.
   use isweq_iso.
@@ -1193,17 +1193,17 @@ Proof.
        exact (!p)).
 Defined.
 
-Definition univalent_profunctor_is_weak_double_cat
-  : is_weak_double_cat univalent_profunctor_verity_double_bicat.
+Definition univcat_profunctor_is_weak_double_cat
+  : is_weak_double_cat univcat_profunctor_verity_double_bicat.
 Proof.
   split.
-  - exact univalent_profunctor_vertically_saturated.
-  - exact univalent_profunctor_horizontally_saturated.
+  - exact univcat_profunctor_vertically_saturated.
+  - exact univcat_profunctor_horizontally_saturated.
 Defined.
 
 (** * 7. Companion pairs of profunctors *)
-Definition all_companions_univalent_profunctor_verity_double_bicat
-  : all_companions univalent_profunctor_verity_double_bicat.
+Definition all_companions_univcat_profunctor_verity_double_bicat
+  : all_companions univcat_profunctor_verity_double_bicat.
 Proof.
   refine (λ (C₁ C₂ : univalent_category)
             (F : C₁ ⟶ C₂),
@@ -1232,8 +1232,8 @@ Proof.
        apply idpath).
 Defined.
 
-Definition all_conjoints_univalent_profunctor_verity_double_bicat
-  : all_conjoints univalent_profunctor_verity_double_bicat.
+Definition all_conjoints_univcat_profunctor_verity_double_bicat
+  : all_conjoints univcat_profunctor_verity_double_bicat.
 Proof.
   refine (λ (C₁ C₂ : univalent_category)
             (F : C₁ ⟶ C₂),
@@ -1264,7 +1264,7 @@ Defined.
 
 (** * 8. Vertical invertible 2-cells of profunctors *)
 Definition profunctor_nat_iso_weq_vertible_invertible_2cell
-           {C₁ C₂ : univalent_profunctor_verity_double_bicat}
+           {C₁ C₂ : univcat_profunctor_verity_double_bicat}
            {P Q : C₁ -|-> C₂}
            (τ : P =|=> Q)
   : is_profunctor_nat_iso τ ≃ is_invertible_2cell τ.
@@ -1290,8 +1290,8 @@ Proof.
 Defined.
 
 (** * 9. The local univalence of the Verity double bicategory of squares *)
-Definition ver_locally_univalent_profunctor_verity_double_bicat
-  : ver_locally_univalent univalent_profunctor_verity_double_bicat.
+Definition ver_locally_univcat_profunctor_verity_double_bicat
+  : ver_locally_univalent univcat_profunctor_verity_double_bicat.
 Proof.
   intros C₁ C₂ P Q.
   use weqhomot.
@@ -1308,29 +1308,29 @@ Proof.
     apply idpath.
 Qed.
 
-Definition locally_univalent_profunctor_verity_double_bicat
-  : locally_univalent_verity_double_bicat univalent_profunctor_verity_double_bicat.
+Definition locally_univcat_profunctor_verity_double_bicat
+  : locally_univalent_verity_double_bicat univcat_profunctor_verity_double_bicat.
 Proof.
   split.
   - use op2_bicat_is_univalent_2_1.
     exact univalent_cat_is_univalent_2_1.
-  - exact ver_locally_univalent_profunctor_verity_double_bicat.
+  - exact ver_locally_univcat_profunctor_verity_double_bicat.
 Defined.
 
 (** * 10. The global univalence of the Verity double bicategory of squares *)
-Definition hor_globally_univalent_profunctor_verity_double_bicat
-  : hor_globally_univalent univalent_profunctor_verity_double_bicat.
+Definition hor_globally_univcat_profunctor_verity_double_bicat
+  : hor_globally_univalent univcat_profunctor_verity_double_bicat.
 Proof.
   use op2_bicat_is_univalent_2_0.
   - exact univalent_cat_is_univalent_2_1.
   - exact univalent_cat_is_univalent_2_0.
 Defined.
 
-Definition gregarious_univalent_profunctor_verity_double_bicat
-  : gregarious_univalent univalent_profunctor_verity_double_bicat.
+Definition gregarious_univcat_profunctor_verity_double_bicat
+  : gregarious_univalent univcat_profunctor_verity_double_bicat.
 Proof.
   use hor_globally_univalent_to_gregarious_univalent.
-  - exact locally_univalent_profunctor_verity_double_bicat.
-  - exact hor_globally_univalent_profunctor_verity_double_bicat.
-  - exact univalent_profunctor_vertically_saturated.
+  - exact locally_univcat_profunctor_verity_double_bicat.
+  - exact hor_globally_univcat_profunctor_verity_double_bicat.
+  - exact univcat_profunctor_vertically_saturated.
 Defined.

--- a/UniMath/Bicategories/DoubleCategories/Examples/ProfunctorDoubleCat.v
+++ b/UniMath/Bicategories/DoubleCategories/Examples/ProfunctorDoubleCat.v
@@ -534,7 +534,7 @@ Proof.
 Qed.
 
 (** * 5. The univalent pseudo double category of profunctors *)
-Definition strict_profunctor_double_cat
+Definition setcat_profunctor_double_cat
   : double_cat.
 Proof.
   use make_double_cat.
@@ -549,18 +549,19 @@ Proof.
   - exact profunctor_pentagon_law.
 Defined.
 
-Definition strict_profunctor_univalent_double_cat
+Definition setcat_profunctor_univalent_double_cat
   : univalent_double_cat.
 Proof.
   use make_univalent_double_cat.
-  - exact strict_profunctor_double_cat.
-  - exact is_univalent_cat_of_setcategory.
-  - exact is_univalent_twosided_disp_cat_of_profunctors.
+  - exact setcat_profunctor_double_cat.
+  - split.
+    + exact is_univalent_cat_of_setcategory.
+    + exact is_univalent_twosided_disp_cat_of_profunctors.
 Defined.
 
 (** * 6. Companions and conjoints *)
-Definition all_companions_strict_profunctor_double_cat
-  : all_companions_double_cat strict_profunctor_double_cat.
+Definition all_companions_setcat_profunctor_double_cat
+  : all_companions_double_cat setcat_profunctor_double_cat.
 Proof.
   intros C₁ C₂ F.
   refine (representable_profunctor_left F ,, _).
@@ -591,8 +592,8 @@ Proof.
        apply idpath).
 Defined.
 
-Definition all_conjoints_strict_profunctor_double_cat
-  : all_conjoints_double_cat strict_profunctor_double_cat.
+Definition all_conjoints_setcat_profunctor_double_cat
+  : all_conjoints_double_cat setcat_profunctor_double_cat.
 Proof.
   intros C₁ C₂ F.
   refine (representable_profunctor_right F ,, _).

--- a/UniMath/Bicategories/DoubleCategories/Examples/SpansDoubleCat.v
+++ b/UniMath/Bicategories/DoubleCategories/Examples/SpansDoubleCat.v
@@ -469,9 +469,10 @@ Definition spans_univalent_double_cat
 Proof.
   use make_univalent_double_cat.
   - exact (spans_double_cat PC).
-  - apply univalent_category_is_univalent.
-  - use is_univalent_spans_twosided_disp_cat.
-    apply univalent_category_is_univalent.
+  - split.
+    + apply univalent_category_is_univalent.
+    + use is_univalent_spans_twosided_disp_cat.
+      apply univalent_category_is_univalent.
 Defined.
 
 Definition spans_pseudo_double_setcat

--- a/UniMath/Bicategories/DoubleCategories/Examples/SquareDoubleCat.v
+++ b/UniMath/Bicategories/DoubleCategories/Examples/SquareDoubleCat.v
@@ -206,8 +206,9 @@ Definition square_univalent_double_cat
 Proof.
   use make_univalent_double_cat.
   - exact (square_double_cat C).
-  - apply univalent_category_is_univalent.
-  - apply is_univalent_arrow_twosided_disp_cat.
+  - split.
+    + apply univalent_category_is_univalent.
+    + apply is_univalent_arrow_twosided_disp_cat.
 Defined.
 
 Proposition symmetric_univalent_square_double_cat

--- a/UniMath/Bicategories/DoubleCategories/Examples/StructuredCospansDoubleCat.v
+++ b/UniMath/Bicategories/DoubleCategories/Examples/StructuredCospansDoubleCat.v
@@ -536,9 +536,10 @@ Definition structured_cospans_univalent_double_cat
 Proof.
   use make_univalent_double_cat.
   - exact (structured_cospans_double_cat PX L).
-  - apply univalent_category_is_univalent.
-  - use is_univalent_struct_cospans_twosided_disp_cat.
-    apply univalent_category_is_univalent.
+  - split.
+    + apply univalent_category_is_univalent.
+    + use is_univalent_struct_cospans_twosided_disp_cat.
+      apply univalent_category_is_univalent.
 Defined.
 
 Definition structured_cospans_pseudo_double_setcat

--- a/UniMath/Bicategories/DoubleCategories/Examples/UnitDoubleCat.v
+++ b/UniMath/Bicategories/DoubleCategories/Examples/UnitDoubleCat.v
@@ -144,7 +144,8 @@ Definition unit_univalent_double_cat
 Proof.
   use make_univalent_double_cat.
   - exact unit_double_cat.
-  - apply univalent_category_is_univalent.
-  - apply is_univalent_constant_twosided_disp_cat.
-    apply univalent_category_is_univalent.
+  - split.
+    + apply univalent_category_is_univalent.
+    + apply is_univalent_constant_twosided_disp_cat.
+      apply univalent_category_is_univalent.
 Defined.

--- a/UniMath/Bicategories/DoubleCategories/Underlying/HorizontalBicategory.v
+++ b/UniMath/Bicategories/DoubleCategories/Underlying/HorizontalBicategory.v
@@ -376,7 +376,7 @@ Proof.
   apply is_setcategory_vertical_cat.
 Qed.
 
-Definition horizontal_setbicat
+Definition horizontal_bisetcat
           (C : pseudo_double_setcat)
   : bisetcat.
 Proof.


### PR DESCRIPTION
- `horizontal_setbicat` is renamed to `horizontal_bisetcat`
- Add an identifier for when a double category is univalent and use that one
- `strict_profunctor_univalent_double_cat` is renamed to `setcat_profunctor_univalent_double_cat`
- `univalent_profunctor_verity_double_bicat` is renamed to `univcat_profunctor_verity_double_bicat`