### PR TITLE
avoids one kind of warning when compiling UniMath

### DIFF
--- a/UniMath/Tactics/EnsureStructuredProofs.v
+++ b/UniMath/Tactics/EnsureStructuredProofs.v
@@ -8,4 +8,4 @@ Do not copy this line into the files but put
 into the header part.
  *)
 
-Export Set Default Goal Selector "!".
+#[export] Set Default Goal Selector "!".


### PR DESCRIPTION
only one occurrence, but right in the beginning, which might be irritating