### PR TITLE
Reasoning with foldr1_map

### DIFF
--- a/UniMath/Combinatorics/Lists.v
+++ b/UniMath/Combinatorics/Lists.v
@@ -253,9 +253,7 @@ Defined.
 Lemma foldr1_foldr1_map {A B : UU} (f : B -> B -> B) (b : B) (h : A -> B) (xs : list A) :
   foldr1_map f b h xs = foldr1 f b (map h xs).
 Proof.
-  revert xs.
   set (P := fun xs b' => b' = foldr1 f b (map h xs)).
-  intro xs.
   apply (foldr1_map_ind f b h P).
   - apply idpath.
   - intro a. apply idpath.
@@ -313,17 +311,25 @@ Proof.
   revert l. apply list_ind.
   - apply idpath.
   - intros x l IH. now rewrite !map_cons, foldr_cons, IH.
-Defined.
+Qed.
+
+Lemma foldr1_map_concatenate {X Y : UU} (f : X → Y) (l : list X) :
+  map f l = foldr1_map concatenate [] (λ x, f x::[]) l.
+Proof.
+  set (P := fun xs b' => map f xs = b' ).
+  refine (foldr1_map_ind _ _ _ P _ _ _ l).
+  - apply idpath.
+  - intro; apply idpath.
+  - intros x' l' x'' b Hyp.
+    exact (maponpaths (cons (f x'')) Hyp).
+Qed.
 
 Lemma foldr1_concatenate {X Y : UU} (f : X → Y) (l : list X) :
   map f l = foldr1 concatenate [] (map (λ x, f x::[]) l).
 Proof.
-  revert l. apply list_ind.
-  - apply idpath.
-  - intros x. refine (list_ind _ _ _).
-    + intro. apply idpath.
-    + intros x' l _ IH. exact (maponpaths (cons (f x)) IH).
-Defined.
+  simple refine (foldr1_map_concatenate _ _ @ _).
+  apply foldr1_foldr1_map.
+Qed.
 
 (** Append a single element to a list *)
 

--- a/UniMath/Combinatorics/Lists.v
+++ b/UniMath/Combinatorics/Lists.v
@@ -219,10 +219,17 @@ Proof.
   apply idpath.
 Qed.
 
+(** an induction principle for [foldr1_map]
+
+    [P] takes the list argument [xs] of [foldr1_map] and the purported value of [foldr1_map f b h xs]
+    [P0] and [P1] ask that [P] is correct for lists of length <=1
+    [P2] deals with longer lists and reflects the effect of adding a subsequent element [a2] to the list, where [res] keeps the
+    result of [foldr1_map f b h (cons a1 xs)] abstract
+*)
 Definition foldr1_map_ind {A B : UU} (f : B -> B -> B) (b : B) (h : A -> B) (P : list A -> B -> UU)
   (P0 : P nil b)
   (P1 : ∏ a, P (cons a nil) (h a))
-  (P2 : ∏ a1 xs a2 b, P (cons a1 xs) b -> P (cons a2 (cons a1 xs)) (f (h a2) b))
+  (P2 : ∏ a1 xs a2 res, P (cons a1 xs) res -> P (cons a2 (cons a1 xs)) (f (h a2) res))
   (xs : list A) : P xs (foldr1_map f b h xs).
 Proof.
   revert xs.
@@ -240,24 +247,24 @@ Defined.
 Definition foldr1_map_ind_nodep {A B : UU} (f : B -> B -> B) (b : B) (h : A -> B) (P : B -> UU)
   (P0 : P b)
   (P1 : ∏ a, P (h a))
-  (P2 : ∏ a b, P b -> P (f (h a) b))
+  (P2 : ∏ a res, P res -> P (f (h a) res))
   (xs : list A) : P (foldr1_map f b h xs).
 Proof.
-  set (Pdep := fun (_ : list A) (b : B) => P b).
+  set (Pdep := fun (_ : list A) (res : B) => P res).
   apply (foldr1_map_ind f b h Pdep).
   - exact P0.
   - exact P1.
-  - intros a1 xs' a2 b' H. apply P2. exact H.
+  - intros a1 xs' a2 res H. apply P2. exact H.
 Defined.
 
 Lemma foldr1_foldr1_map {A B : UU} (f : B -> B -> B) (b : B) (h : A -> B) (xs : list A) :
   foldr1_map f b h xs = foldr1 f b (map h xs).
 Proof.
-  set (P := fun xs b' => b' = foldr1 f b (map h xs)).
+  set (P := fun xs res => res = foldr1 f b (map h xs)).
   apply (foldr1_map_ind f b h P).
   - apply idpath.
   - intro a. apply idpath.
-  - intros a1 xs' a2 b' H.
+  - intros a1 xs' a2 res H.
     red.
     do 2 rewrite map_cons.
     rewrite foldr1_cons.
@@ -316,11 +323,11 @@ Qed.
 Lemma foldr1_map_concatenate {X Y : UU} (f : X → Y) (l : list X) :
   map f l = foldr1_map concatenate [] (λ x, f x::[]) l.
 Proof.
-  set (P := fun xs b' => map f xs = b' ).
+  set (P := fun xs res => map f xs = res).
   refine (foldr1_map_ind _ _ _ P _ _ _ l).
   - apply idpath.
   - intro; apply idpath.
-  - intros x' l' x'' b Hyp.
+  - intros x' l' x'' res Hyp.
     exact (maponpaths (cons (f x'')) Hyp).
 Qed.
 

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -135,10 +135,10 @@ Qed.
 Context (BPC : BinProducts C) (BCC : BinCoproducts C).
 
 (** [nat] to a Signature *)
-Definition Arity_to_Signature (TC : Terminal C) (xs : list nat) : Signature C C C:=
-  foldr1 (BinProduct_of_Signatures _ _ _ BPC)
+Definition Arity_to_Signature (TC : Terminal C) (xs : list nat) : Signature C C C :=
+  foldr1_map (BinProduct_of_Signatures _ _ _ BPC)
          (ConstConstSignature C C C (TerminalObject TC))
-        (map (precomp_option_iter_Signature BCC TC) xs).
+         (precomp_option_iter_Signature BCC TC) xs.
 
 Let BPC2 BPC := BinProducts_functor_precat C C BPC.
 Let constprod_functor1 := constprod_functor1 (BPC2 BPC).
@@ -150,18 +150,15 @@ Lemma is_omega_cocont_Arity_to_Signature
   (xs : list nat) :
   is_omega_cocont (Arity_to_Signature TC xs).
 Proof.
-destruct xs as [[|n] xs].
-- destruct xs; apply is_omega_cocont_constant_functor.
-- induction n as [|n IHn].
-  + destruct xs as [m []]; simpl.
-    unfold Arity_to_Signature.
-    apply is_omega_cocont_precomp_option_iter, CLC.
-  + destruct xs as [m [k xs]].
+  refine (foldr1_map_ind_nodep (BinProduct_of_Signatures _ _ _ BPC) _ _ is_omega_cocont _ _ _ xs).
+  - apply is_omega_cocont_constant_functor.
+  - intro n. apply is_omega_cocont_precomp_option_iter, CLC.
+  - intros m sig Hyp.
     apply is_omega_cocont_BinProduct_of_Signatures.
-    * apply is_omega_cocont_precomp_option_iter, CLC.
-    * apply (IHn (k,,xs)).
-    * assumption.
-    * intro x; apply (H x).
+    + apply is_omega_cocont_precomp_option_iter, CLC.
+    + exact Hyp.
+    + exact BPC.
+    + exact H.
 Defined.
 
 (** ** Binding signature to a signature with strength *)

--- a/UniMath/SubstitutionSystems/ContinuitySignature/ContinuityOfMultiSortedSigToFunctor.v
+++ b/UniMath/SubstitutionSystems/ContinuitySignature/ContinuityOfMultiSortedSigToFunctor.v
@@ -356,31 +356,16 @@ Section FixTheContext.
     is_omega_cont (hat_exp_functor_list'_optimized xst).
   Proof.
     induction xst as [xs t].
-      revert t.
-      induction xs as [[|n] xs].
-      - induction xs.
-        intro t.
-        use nat_z_iso_preserve_ωlimits.
-        3: apply nat_z_iso_inv, constant_functor_composition_nat_z_iso.
-        apply is_omega_cont_constant_functor.
-      - induction n as [|n IH].
-        + induction xs as [m []].
-          change (1,, m,, tt) with (cons m nil).
-          intro t.
-          unfold hat_exp_functor_list'_optimized.
-          rewrite foldr1_map_cons_nil.
-          apply is_omega_cont_hat_exp_functor_list'_piece.
-        + induction xs as [m [k xs]].
-          intro t.
-          assert (IHinst := IH (k,,xs) t).
-          change (S (S n),, m,, k,, xs) with (cons m (cons k (n,,xs))).
-          unfold hat_exp_functor_list'_optimized.
-          rewrite foldr1_map_cons.
-          change (S n,, k,, xs) with (cons k (n,,xs)) in IHinst.
-          unfold hat_exp_functor_list'_optimized in IHinst.
-          apply is_omega_cont_BinProduct_of_functors.
-          * apply is_omega_cont_hat_exp_functor_list'_piece.
-          * exact IHinst.
+    refine (foldr1_map_ind_nodep _ _ _ (fun F => is_omega_cont F) _ _ _ xs).
+    - use nat_z_iso_preserve_ωlimits.
+      3: apply nat_z_iso_inv, constant_functor_composition_nat_z_iso.
+      apply is_omega_cont_constant_functor.
+    - intro xst.
+      apply is_omega_cont_hat_exp_functor_list'_piece.
+    - intros xst F Hyp.
+      apply is_omega_cont_BinProduct_of_functors.
+      + apply is_omega_cont_hat_exp_functor_list'_piece.
+      + exact Hyp.
   Defined.
 
   (** The functor obtained from a multisorted binding signature is omega-continuous *)

--- a/UniMath/SubstitutionSystems/ContinuitySignature/ContinuityOfMultiSortedSigToFunctor.v
+++ b/UniMath/SubstitutionSystems/ContinuitySignature/ContinuityOfMultiSortedSigToFunctor.v
@@ -169,34 +169,18 @@ Section FixTheContext.
       is_omega_cocont (hat_exp_functor_list'_optimized xst).
     Proof.
       induction xst as [xs t].
-      revert t.
-      induction xs as [[|n] xs].
-      - induction xs.
-        intro t.
-        apply is_omega_cocont_functor_composite.
+      refine (foldr1_map_ind_nodep _ _ _ (fun F => is_omega_cocont F) _ _ _ xs).
+      - apply is_omega_cocont_functor_composite.
         + apply is_omega_cocont_constant_functor.
         + apply is_omega_cocont_post_composition_functor, MultiSorted_alt.is_left_adjoint_hat.
-      - induction n as [|n IH].
-        + induction xs as [m []].
-          change (1,, m,, tt) with (cons m nil).
-          intro t.
-          unfold hat_exp_functor_list'_optimized.
-          rewrite foldr1_map_cons_nil.
-          apply is_omega_cocont_hat_exp_functor_list'_piece.
-        + induction xs as [m [k xs]].
-          intro t.
-          assert (IHinst := IH (k,,xs) t).
-          change (S (S n),, m,, k,, xs) with (cons m (cons k (n,,xs))).
-          unfold hat_exp_functor_list'_optimized.
-          rewrite foldr1_map_cons.
-          change (S n,, k,, xs) with (cons k (n,,xs)) in IHinst.
-          unfold hat_exp_functor_list'_optimized in IHinst.
-          apply is_omega_cocont_BinProduct_of_functors.
-          * apply BPsortToC2.
-          * apply is_omega_cocont_constprod_functor1.
-            apply EsortToC2.
-          * apply is_omega_cocont_hat_exp_functor_list'_piece.
-          * exact IHinst.
+      - intro xst. apply is_omega_cocont_hat_exp_functor_list'_piece.
+      - intros xst F Hyp.
+        apply is_omega_cocont_BinProduct_of_functors.
+        + apply BPsortToC2.
+        + apply is_omega_cocont_constprod_functor1.
+          apply EsortToC2.
+        + apply is_omega_cocont_hat_exp_functor_list'_piece.
+        + exact Hyp.
     Defined.
 
     Lemma is_omega_cocont_MultiSortedSigToFunctor' (M : MultiSortedSig sort) :

--- a/UniMath/SubstitutionSystems/ContinuitySignature/ContinuityOfMultiSortedSigToFunctor.v
+++ b/UniMath/SubstitutionSystems/ContinuitySignature/ContinuityOfMultiSortedSigToFunctor.v
@@ -169,12 +169,12 @@ Section FixTheContext.
       is_omega_cocont (hat_exp_functor_list'_optimized xst).
     Proof.
       induction xst as [xs t].
-      refine (foldr1_map_ind_nodep _ _ _ (fun F => is_omega_cocont F) _ _ _ xs).
+      refine (foldr1_map_ind_nodep _ _ _ is_omega_cocont _ _ _ xs).
       - apply is_omega_cocont_functor_composite.
         + apply is_omega_cocont_constant_functor.
         + apply is_omega_cocont_post_composition_functor, MultiSorted_alt.is_left_adjoint_hat.
-      - intro xst. apply is_omega_cocont_hat_exp_functor_list'_piece.
-      - intros xst F Hyp.
+      - intro lt. apply is_omega_cocont_hat_exp_functor_list'_piece.
+      - intros lt F Hyp.
         apply is_omega_cocont_BinProduct_of_functors.
         + apply BPsortToC2.
         + apply is_omega_cocont_constprod_functor1.
@@ -356,13 +356,13 @@ Section FixTheContext.
     is_omega_cont (hat_exp_functor_list'_optimized xst).
   Proof.
     induction xst as [xs t].
-    refine (foldr1_map_ind_nodep _ _ _ (fun F => is_omega_cont F) _ _ _ xs).
+    refine (foldr1_map_ind_nodep _ _ _ is_omega_cont _ _ _ xs).
     - use nat_z_iso_preserve_ωlimits.
       3: apply nat_z_iso_inv, constant_functor_composition_nat_z_iso.
       apply is_omega_cont_constant_functor.
-    - intro xst.
+    - intro lt.
       apply is_omega_cont_hat_exp_functor_list'_piece.
-    - intros xst F Hyp.
+    - intros lt F Hyp.
       apply is_omega_cont_BinProduct_of_functors.
       + apply is_omega_cont_hat_exp_functor_list'_piece.
       + exact Hyp.

--- a/UniMath/SubstitutionSystems/ContinuitySignature/MultiSortedSignatureFunctorEquivalence.v
+++ b/UniMath/SubstitutionSystems/ContinuitySignature/MultiSortedSignatureFunctorEquivalence.v
@@ -709,53 +709,38 @@ Section EquivalenceBetweenDifferentCharacterizationsOfMultiSortedSignatureToFunc
         exact c.
   Defined.  (* the result will not be needed in the sequel *)
 
-
   Definition hat_exp_functor_list'_optimized_test
              (xst : list (list sort × sort) × sort)
              (c : propcoproducts_commute_binproducts C BP (λ p, CC p (isasetaprop (pr2 p))))
     : nat_z_iso (hat_exp_functor_list0 xst)
                 (hat_exp_functor_list'_optimized0 xst).
   Proof.
-    induction xst as [xs t]; revert t.
-    induction xs as [[|n] xs].
-    - induction xs.
-      intro t.
-      use tpair.
+    induction xst as [xs t].
+    set (P := fun xs b' => nat_z_iso (hat_exp_functor_list0 (xs,, t)) b').
+    refine (foldr1_map_ind _ _ _ P _ _ _ xs).
+    - use tpair.
       + apply (nat_trans_id (C := sortToC2) (C' := sortToC2)).
       + intro ; apply (identity_is_z_iso (C := sortToC2)).
-    - induction n as [|n IH].
-      + induction xs as [m []].
-        change (1,, m,, tt) with (cons m nil).
-        intro t.
-        unfold hat_exp_functor_list'_optimized0, hat_exp_functor_list'_optimized.
-        rewrite foldr1_map_cons_nil.
-        (* unfold hat_exp_functor_list0, hat_exp_functor_list. *)
-        exact (hat_exp_functor_list'_piece_test (m,,t)).
-      + induction xs as [m [k xs]].
-        intro t.
-        assert (IHinst := IH (k,,xs) t).
-        change (S (S n),, m,, k,, xs) with (cons m (cons k (n,,xs))).
-        unfold hat_exp_functor_list'_optimized0, hat_exp_functor_list'_optimized.
-        rewrite foldr1_map_cons.
-        change (S n,, k,, xs) with (cons k (n,,xs)) in IHinst.
-        unfold hat_exp_functor_list'_optimized0, hat_exp_functor_list'_optimized in IHinst.
-        use nat_z_iso_comp.
-        3: {
-          use nat_z_iso_BinProduct_of_functors.
-          4: exact IHinst.
-          2: exact (hat_exp_functor_list'_piece_test (m ,, t)).
-        }
-        clear IH IHinst.
-        unfold hat_exp_functor_list0, hat_exp_functor_list.
-        unfold exp_functor_list.
-        change (pr1 (cons m (cons k (n,, xs)),, t)) with (cons m (cons k (n,, xs))).
-        rewrite foldr1_map_cons.
-        apply BinProduct_of_functors_distr.
-        apply post_comp_functor_preserves_binproduct.
-        * apply BP.
-        * apply (BinProducts_functor_precat _ C BP).
-        * apply hat_functor_preserves_binproducts.
-          exact c.
+    - intro xst. exact (hat_exp_functor_list'_piece_test (xst,,t)).
+    - intros k xs' m F Hyp.
+      red.
+      use nat_z_iso_comp.
+      3: {
+        use nat_z_iso_BinProduct_of_functors.
+        4: exact Hyp.
+        2: exact (hat_exp_functor_list'_piece_test (m ,, t)).
+      }
+      clear F Hyp.
+      unfold hat_exp_functor_list0, hat_exp_functor_list.
+      unfold exp_functor_list.
+      change (pr1 (cons m (cons k xs'),, t)) with (cons m (cons k xs')).
+      rewrite foldr1_map_cons.
+      apply BinProduct_of_functors_distr.
+      apply post_comp_functor_preserves_binproduct.
+      + apply BP.
+      + apply (BinProducts_functor_precat _ C BP).
+      + apply hat_functor_preserves_binproducts.
+        exact c.
   Defined.
 
   Definition MultiSortedSigToFunctor_test

--- a/UniMath/SubstitutionSystems/ContinuitySignature/MultiSortedSignatureFunctorEquivalence.v
+++ b/UniMath/SubstitutionSystems/ContinuitySignature/MultiSortedSignatureFunctorEquivalence.v
@@ -676,9 +676,7 @@ Section EquivalenceBetweenDifferentCharacterizationsOfMultiSortedSignatureToFunc
       exact (terminal_BinProduct_of_functors_unit_l _ _ BPsortToCC TsortToCC (exp_functor sort Hsort C TC BC CC x)).
     - induction xs.
       change (cons x (S n,, pr1,, pr2)) with  (cons x (cons pr1 (n,,pr2))).
-      unfold exp_functor_list at 1.
-      rewrite foldr1_map_cons.
-      change (nat_z_iso (BinProduct_of_functors BPsortToCC (exp_functor sort Hsort C TC BC CC x) (exp_functor_list sort Hsort C TC BP BC CC (S n,, pr1,, pr2)) ) (BinProduct_of_functors BPsortToCC (exp_functor_list sort Hsort C TC BP BC CC (S n,, pr1,, pr2)) (exp_functor sort Hsort C TC BC CC x))).
+      rewrite MultiSorted_alt.exp_functor_list_cons.
       apply BinProduct_of_functors_commutes.
   Defined.
 
@@ -723,7 +721,7 @@ Section EquivalenceBetweenDifferentCharacterizationsOfMultiSortedSignatureToFunc
     - use tpair.
       + apply (nat_trans_id (C := sortToC2) (C' := sortToC2)).
       + intro ; apply (identity_is_z_iso (C := sortToC2)).
-    - intro xst. exact (hat_exp_functor_list'_piece_test (xst,,t)).
+    - intro lt. exact (hat_exp_functor_list'_piece_test (lt,,t)).
     - intros k xs' m F Hyp.
       red.
       use nat_z_iso_comp.

--- a/UniMath/SubstitutionSystems/ContinuitySignature/MultiSortedSignatureFunctorEquivalence.v
+++ b/UniMath/SubstitutionSystems/ContinuitySignature/MultiSortedSignatureFunctorEquivalence.v
@@ -663,6 +663,25 @@ Section EquivalenceBetweenDifferentCharacterizationsOfMultiSortedSignatureToFunc
         apply assoc.
   Defined.
 
+  Definition hat_exp_functor_list'_test_aux (x : list sort × sort) (xs : list (list sort × sort)) :
+    nat_z_iso (exp_functor_list sort Hsort C TC BP BC CC (cons x xs))
+      (BinProduct_of_functors BPsortToCC
+         (exp_functor_list sort Hsort C TC BP BC CC xs)
+         (exp_functor sort Hsort C TC BC CC x)).
+  Proof.
+    induction xs as [[|n] xs].
+    - induction xs. unfold exp_functor_list at 1. change (cons x (0,, tt)) with (cons x nil). rewrite foldr1_map_cons_nil.
+      unfold exp_functor_list at 1. change (0,, tt) with (nil(A:=list sort × sort)). rewrite foldr1_map_nil.
+      apply nat_z_iso_inv.
+      exact (terminal_BinProduct_of_functors_unit_l _ _ BPsortToCC TsortToCC (exp_functor sort Hsort C TC BC CC x)).
+    - induction xs.
+      change (cons x (S n,, pr1,, pr2)) with  (cons x (cons pr1 (n,,pr2))).
+      unfold exp_functor_list at 1.
+      rewrite foldr1_map_cons.
+      change (nat_z_iso (BinProduct_of_functors BPsortToCC (exp_functor sort Hsort C TC BC CC x) (exp_functor_list sort Hsort C TC BP BC CC (S n,, pr1,, pr2)) ) (BinProduct_of_functors BPsortToCC (exp_functor_list sort Hsort C TC BP BC CC (S n,, pr1,, pr2)) (exp_functor sort Hsort C TC BC CC x))).
+      apply BinProduct_of_functors_commutes.
+  Defined.
+
   Definition hat_exp_functor_list'_test
              (xst : list (list sort × sort) × sort)
              (c : propcoproducts_commute_binproducts C BP (λ p, CC p (isasetaprop (pr2 p))))
@@ -683,24 +702,7 @@ Section EquivalenceBetweenDifferentCharacterizationsOfMultiSortedSignatureToFunc
         2: exact (hat_exp_functor_list'_piece_test (x ,, t)).
       }
       clear IHn.
-
-      transparent assert (q : (nat_z_iso (exp_functor_list sort Hsort C TC BP BC CC (cons x xs)) (BinProduct_of_functors BPsortToCC (exp_functor_list sort Hsort C TC BP BC CC xs) (exp_functor sort Hsort C TC BC CC x)))).
-      {
-        induction xs as [[|n] xs].
-        - induction xs. unfold exp_functor_list at 1. change (cons x (0,, tt)) with (cons x nil). rewrite foldr1_map_cons_nil.
-          unfold exp_functor_list at 1. change (0,, tt) with (nil(A:=list sort × sort)). rewrite foldr1_map_nil.
-          apply nat_z_iso_inv.
-          exact (terminal_BinProduct_of_functors_unit_l _ _ BPsortToCC TsortToCC (exp_functor sort Hsort C TC BC CC x)).
-        - induction xs.
-          change (cons x (S n,, pr1,, pr2)) with  (cons x (cons pr1 (n,,pr2))).
-          unfold exp_functor_list at 1.
-          rewrite foldr1_map_cons.
-          change (nat_z_iso (BinProduct_of_functors BPsortToCC (exp_functor sort Hsort C TC BC CC x) (exp_functor_list sort Hsort C TC BP BC CC (S n,, pr1,, pr2)) ) (BinProduct_of_functors BPsortToCC (exp_functor_list sort Hsort C TC BP BC CC (S n,, pr1,, pr2)) (exp_functor sort Hsort C TC BC CC x))).
-          apply BinProduct_of_functors_commutes.
-      }
-
-      use (nat_z_iso_comp (post_whisker_nat_z_iso q _)).
-
+      use (nat_z_iso_comp (post_whisker_nat_z_iso (hat_exp_functor_list'_test_aux x xs) _)).
       apply BinProduct_of_functors_distr.
       apply post_comp_functor_preserves_binproduct.
       + apply BP.

--- a/UniMath/SubstitutionSystems/MultiSorted_alt.v
+++ b/UniMath/SubstitutionSystems/MultiSorted_alt.v
@@ -251,6 +251,13 @@ set (T := constant_functor sortToC2 _ TsortToCC).
 exact (foldr1_map (λ F G, BinProduct_of_functors BPsortToCC F G) T exp_functor xs).
 Defined.
 
+Local Lemma exp_functor_list_cons (lt1 lt2 : list sort × sort) (xs : list (list sort × sort)) :
+  exp_functor_list (cons lt2 (cons lt1 xs)) =
+    BinProduct_of_functors BPsortToCC (exp_functor lt2) (exp_functor_list (cons lt1 xs)).
+Proof.
+  apply idpath.
+Qed.
+
 Definition hat_exp_functor_list (xst : list (list sort × sort) × sort) :
   functor sortToC2 sortToC2 :=
     exp_functor_list (pr1 xst) ∙ post_comp_functor (hat_functor (pr2 xst)).
@@ -428,19 +435,16 @@ Defined.
 Local Lemma is_omega_cocont_exp_functor_list (xs : list (list sort × sort)) :
   is_omega_cocont (exp_functor_list xs).
 Proof.
-induction xs as [[|n] xs].
-- induction xs.
-  apply is_omega_cocont_constant_functor.
-- induction n as [|n IHn].
-  + induction xs as [m []].
-    apply is_omega_cocont_exp_functor.
-  + induction xs as [m [k xs]].
+  refine (foldr1_map_ind_nodep _ _ _ is_omega_cocont _ _ _ xs).
+  - apply is_omega_cocont_constant_functor.
+  - intro lt. apply is_omega_cocont_exp_functor.
+  - intros lt F Hyp.
     apply is_omega_cocont_BinProduct_of_functors.
-    * apply BinProducts_functor_precat, BinProducts_functor_precat, BP.
-    * apply is_omega_cocont_constprod_functor1.
+    + apply BinProducts_functor_precat, BinProducts_functor_precat, BP.
+    + apply is_omega_cocont_constprod_functor1.
       apply EsortToCC.
-    * apply is_omega_cocont_exp_functor.
-    * apply (IHn (k,,xs)).
+    + apply is_omega_cocont_exp_functor.
+    + exact Hyp.
 Defined.
 
 (* The hat_functor is left adjoint to projSortToC *)


### PR DESCRIPTION
The idea is to have a lemma as interface instead of going into the details of the encoding of lists.

This is shown to be useful for non-trivial situations in package SubstitutionSystems.