### PR TITLE
Remove outdated BUILD_COQ instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -106,12 +106,6 @@ shell command (in this directory).
 make
 ```
 
-Alternatively, if you want to build a specific version of Coq for UniMath (not usually needed, but sometimes useful for compatibility reasons), and you have installed its dependencies as described above, you may issue the following command.
-
-```bash
-make BUILD_COQ=yes
-```
-
 Once this is done, you can start [browsing and editing UniMath](./USAGE.md).
 Below, we explain how to compile individual packages of UniMath, and how to
 create HTML documentation.


### PR DESCRIPTION
(Background: The Makefile's `BUILD_COQ` option currently builds Coq 8.16.1, which is too old to compile UniMath; unfortunately, Coq's build process completely changed as of Coq 8.17 so it is non-trivial to update `BUILD_COQ` to a newer version of Coq.)

In the first draft of this PR, I have removed the mention of `BUILD_COQ` from `INSTALL.md`. IMO, this is the minimal change that will keep users from having to learn all of this the hard way (as I did). Additionally, I notice that many of the install instructions haven't been updated in a couple years and could be simplified by mentioning the new build system (e.g., `INSTALL_OPAM.md` and `INSTALL_COQIDE.md`), and I am willing to take a crack at some of this but I wanted to check in with the developers first. (I am not interested in working on the Windows or Nix instructions, though.)

A more ambitious project would be to actually remove the considerable `BUILD_COQ` machinery from the build process altogether. I think this is worth doing because it considerably simplifies the Makefile, removes the useless git submodules, etc., but maybe that should be a different PR.