### PR TITLE
8.20-alpha replaced by '8.20' as extra Coq version for CI, thanks to …

### DIFF
--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         # https://github.com/coq-community/docker-coq/wiki#ocaml-versions-policy
-        coq-version: [latest, 8.20-alpha, dev]
+        coq-version: ['latest', '8.20', 'dev']
         # (the following is obsolete:) coq-version: [8.16] or [latest, 8.16] (when 8.17 is released)
         ocaml-version: [default]
 
@@ -144,7 +144,7 @@ jobs:
       fail-fast: false
       matrix:
         satellite: [SetHITs, largecatmodules, GrpdHITs, TypeTheory]
-        coq-version: [latest, 8.20-alpha, dev]
+        coq-version: ['latest', '8.20', 'dev']
         ocaml-version: [default]
         # (outdated exception:) exclude:
         # - satellite: GrpdHITs


### PR DESCRIPTION
…advice by Érik Martin-Dorel

The intention is to make bullet-proof PR #1908 in two ways: 8.20-alpha will soon disappear, and then the generic 8.20 will point to the official release candidate for 8.20. And the labels are now clearly marked a strings so that there will be no problems with 8.30 in the distant future.