### PR TITLE
Make two definitions of sets in HSET/Core into aliases ...

### DIFF
--- a/UniMath/CategoryTheory/Categories/HSET/Core.v
+++ b/UniMath/CategoryTheory/Categories/HSET/Core.v
@@ -75,20 +75,14 @@ Notation "'SET'" := hset_category : cat.
 Definition emptyHSET : HSET.
 Proof.
   exists empty.
-  abstract (apply isasetempty).
+  exact isasetempty.
 Defined.
 
-Definition unitHSET : HSET.
-Proof.
-  exists unit.
-  abstract (apply isasetunit).
-Defined.
+Definition unitHSET : HSET
+  := unitset.
 
-Definition natHSET : HSET.
-Proof.
-  exists nat.
-  abstract (apply isasetnat).
-Defined.
+Definition natHSET : HSET
+  := natset.
 
 (*Definition of HomFunctor for categories, analagous definition for precategories is in ../Type/Core*)
 Section HomSetFunctors.


### PR DESCRIPTION
... for the definitions of which they are duplicates. Resolves #1092.