### PR TITLE
Algebras for pointed endofunctors and Kelly's transfinite construction

### DIFF
--- a/UniMath/CONTENTS.md
+++ b/UniMath/CONTENTS.md
@@ -490,6 +490,7 @@ The packages and files are listed here in logical order: each file depends only 
    - [Inductives/LambdaCalculus.v](CategoryTheory/Inductives/LambdaCalculus.v)
    - [Inductives/PropositionalLogic.v](CategoryTheory/Inductives/PropositionalLogic.v)
    - [CategoricalRecursionSchemes.v](CategoryTheory/CategoricalRecursionSchemes.v)
+   - [PointedFunctorAlgebras.v](CategoryTheory/PointedFunctorAlgebras.v)
    - [DisplayedCats/Equivalences.v](CategoryTheory/DisplayedCats/Equivalences.v)
    - [DisplayedCats/EquivalenceOverId.v](CategoryTheory/DisplayedCats/EquivalenceOverId.v)
    - [DisplayedCats/DisplayedCatEq.v](CategoryTheory/DisplayedCats/DisplayedCatEq.v)

--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -311,6 +311,7 @@ Inductives/Trees.v
 Inductives/LambdaCalculus.v
 Inductives/PropositionalLogic.v
 CategoricalRecursionSchemes.v
+PointedFunctorAlgebras.v
 
 DisplayedCats/Equivalences.v
 DisplayedCats/EquivalenceOverId.v

--- a/UniMath/CategoryTheory/PointedFunctorAlgebras.v
+++ b/UniMath/CategoryTheory/PointedFunctorAlgebras.v
@@ -37,7 +37,8 @@
 
  **************************************************************************************************)
 
-Require Import UniMath.Foundations.PartD.
+Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.All.
 Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.Core.Functors.
 Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
@@ -692,8 +693,9 @@ Theorem well_pointed_of_fully_faithful_right_adjoint
   : fully_faithful R → well_pointed (L∙R,,η).
 Proof.
   intro R_ff.
-  set (ɛ := counit_from_are_adjoints H).
+  apply (nat_trans_eq (homset_property _)).
   intros A. simpl.
+  set (ɛ := counit_from_are_adjoints H).
   (* The triangle identities imply that RLη and ηRL are sections of RɛLA, which is iso *)
   assert (t1 : # R (# L (η A)) · # R (ɛ (L A)) = identity (R (L A))). {
     rewrite <- functor_id, <- functor_comp.

--- a/UniMath/CategoryTheory/PointedFunctorAlgebras.v
+++ b/UniMath/CategoryTheory/PointedFunctorAlgebras.v
@@ -28,7 +28,7 @@
   3.2. The shift map F(F^ω A) --> F^ω A [shift_iter_map]
   3.3. The shift map forms a pointed algebra [shift_iter_map_forms_ptd_alg]
   3.4. The free functor C ⟶ ptd_alg_category F [free_ptd_alg]
-  3.5. The free-forgetful adjunction [free_forgetful_form_adjunction]
+  3.5. The free-forgetful adjunction [free_ptd_alg_forgetful_form_adjunction]
   4. Reflective subcategories give well-pointed endofunctors
     [well_pointed_of_fully_faithful_right_adjoint]
 
@@ -444,7 +444,7 @@ Definition shift_iter_map_restricts' (A : C) (i : nat)
     => free_ptd_alg_ob => free_ptd_alg
   
   The pointed algebra law is then used to construct the cocone for the counit
-  (see counit_FF_forms_cocone).
+  (see free_ptd_alg_counit_forms_cocone).
 *)
 Section TransfiniteConstructionWellPointed.
 
@@ -553,27 +553,27 @@ Qed.
 Definition free_ptd_alg : C ⟶ ptd_alg_category F
   := make_functor free_ptd_alg_functor_data free_ptd_alg_is_functor.
 
-(** 3.5. The free-forgetful adjunction [free_forgetful_form_adjunction]
+(** 3.5. The free-forgetful adjunction [free_ptd_alg_forgetful_form_adjunction]
   We now prove that this is indeed the free functor, by constructing an adjunction *)
 
-Definition unit_FF_adjunction : functor_identity C ⟹ free_ptd_alg ∙ forget_ptd_alg F.
+Definition free_ptd_alg_unit : functor_identity C ⟹ free_ptd_alg ∙ forget_ptd_alg F.
 Proof.
   apply make_nat_trans with (λ A, colimIn (CC A) 0).
   abstract (intros A B f; apply pathsinv0, (free_ptd_alg_mor_restricts f 0)).
 Defined.
 
-Definition counit_FF_cocone_arrows (X : ptd_alg F) : ∏ i : nat, C ⟦ (F ^ i) X, X ⟧.
+Definition free_ptd_alg_counit_cocone_arrows (X : ptd_alg F) : ∏ i : nat, C ⟦ (F ^ i) X, X ⟧.
 Proof.
   induction i as [|i IH].
   - exact (identity X). (* Forced by triangle identities *)
   - exact (# F IH · ptd_alg_map F X). (* Necessary to make ɛ an morphism of algebras *)
 Defined.
 
-Lemma counit_FF_forms_cocone (X : ptd_alg F)
-  : forms_cocone (iter_chain_at X) (counit_FF_cocone_arrows X).
+Lemma free_ptd_alg_counit_forms_cocone (X : ptd_alg F)
+  : forms_cocone (iter_chain_at X) (free_ptd_alg_counit_cocone_arrows X).
 Proof.
   red; intros i _ []; simpl.
-  set (ɛ := counit_FF_cocone_arrows).
+  set (ɛ := free_ptd_alg_counit_cocone_arrows).
   rewrite assoc.
   (* This could be done using iter_chain_mor_is_point, but it's not necessary! *)
   induction i.
@@ -586,45 +586,45 @@ Qed.
   This is the underlying morphism in C.
   (Be aware of the implicit coercion of X to it's underlying object in C)
 *)
-Definition counit_FF_map (X : ptd_alg F) : C ⟦ free_ptd_alg_ob X, X ⟧
-  := colimArrow _ _ (make_cocone _ (counit_FF_forms_cocone X)).
+Definition free_ptd_alg_counit_map (X : ptd_alg F) : C ⟦ free_ptd_alg_ob X, X ⟧
+  := colimArrow _ _ (make_cocone _ (free_ptd_alg_counit_forms_cocone X)).
 
-Definition counit_FF_map_restricts (X : ptd_alg F) (i : nat)
-  : colimIn (CC X) i · counit_FF_map X = counit_FF_cocone_arrows X i
+Definition free_ptd_alg_counit_map_restricts (X : ptd_alg F) (i : nat)
+  : colimIn (CC X) i · free_ptd_alg_counit_map X = free_ptd_alg_counit_cocone_arrows X i
   := colimArrowCommutes _ _ _ _.
 
-Definition counit_FF_mor_is_mor (X : ptd_alg F) :
-  is_ptd_alg_mor F (free_ptd_alg X) X (counit_FF_map X).
+Definition free_ptd_alg_counit_map_is_mor (X : ptd_alg F) :
+  is_ptd_alg_mor F (free_ptd_alg X) X (free_ptd_alg_counit_map X).
 Proof.
   unfold is_ptd_alg_mor; simpl.
   apply (colim_mor_eq (F_CC X)).
   intros i.
   rewrite assoc, assoc.
   rewrite shift_iter_map_restricts.
-  refine (counit_FF_map_restricts X (S i) @ _); simpl.
+  refine (free_ptd_alg_counit_map_restricts X (S i) @ _); simpl.
   apply cancel_postcomposition.
   change (colimIn (F_CC X) i) with (# F (colimIn (CC X) i)).
   rewrite <- functor_comp.
   apply maponpaths, pathsinv0.
-  apply counit_FF_map_restricts.
+  apply free_ptd_alg_counit_map_restricts.
 Qed.
 
-Definition counit_FF_mor (X : ptd_alg F) : free_ptd_alg X --> X
-  := make_ptd_alg_mor F (counit_FF_map X) (counit_FF_mor_is_mor X).
+Definition free_ptd_alg_counit_mor (X : ptd_alg F) : free_ptd_alg X --> X
+  := make_ptd_alg_mor F (free_ptd_alg_counit_map X) (free_ptd_alg_counit_map_is_mor X).
 
-Definition counit_FF_adjunction_is_nat_trans
+Definition free_ptd_alg_counit_is_nat_trans
   : is_nat_trans
       (forget_ptd_alg F ∙ free_ptd_alg)
       (functor_identity (ptd_alg_category F))
-      counit_FF_mor.
+      free_ptd_alg_counit_mor.
 Proof.
   intros X Y f. apply ptd_alg_mor_eq; simpl in *.
   apply colim_mor_eq; intros i. do 2 rewrite assoc.
   rw_left_comp (free_ptd_alg_mor_restricts f i).
   rewrite <- assoc.
-  rw_right_comp (counit_FF_map_restricts Y i).
-  rewrite (counit_FF_map_restricts X i).
-  set (ɛ := counit_FF_cocone_arrows).
+  rw_right_comp (free_ptd_alg_counit_map_restricts Y i).
+  rewrite (free_ptd_alg_counit_map_restricts X i).
+  set (ɛ := free_ptd_alg_counit_cocone_arrows).
 
   induction i; simpl. { rewrite id_left. apply id_right. }
   rewrite assoc. rewrite <- functor_comp.
@@ -636,17 +636,17 @@ Proof.
   apply pathsinv0, ptd_alg_mor_commutes.
 Qed.
 
-Definition counit_FF_adjunction
+Definition free_ptd_alg_counit
   : (forget_ptd_alg F ∙ free_ptd_alg) ⟹ (functor_identity (ptd_alg_category F))
-  := make_nat_trans _ _ _ counit_FF_adjunction_is_nat_trans.
+  := make_nat_trans _ _ _ free_ptd_alg_counit_is_nat_trans.
 
 (** This proves free construction is correctly named, it is left adjoint
   to the forgetful functor. *)
-Theorem free_forgetful_form_adjunction
+Theorem free_ptd_alg_forgetful_form_adjunction
   : form_adjunction free_ptd_alg
       (forget_ptd_alg F)
-      unit_FF_adjunction
-      counit_FF_adjunction.
+      free_ptd_alg_unit
+      free_ptd_alg_counit.
 Proof.
   split; red.
   + intro A. apply ptd_alg_mor_eq, pathsinv0; simpl.
@@ -654,17 +654,17 @@ Proof.
     rewrite assoc.
     rw_left_comp (free_ptd_alg_mor_restricts (colimIn (CC A) 0) i).
     rewrite <- assoc.
-    rw_right_comp (counit_FF_map_restricts (free_ptd_alg_ob A) i).
-    set (ɛ := counit_FF_cocone_arrows).
+    rw_right_comp (free_ptd_alg_counit_map_restricts (free_ptd_alg_ob A) i).
+    set (ɛ := free_ptd_alg_counit_cocone_arrows).
     induction i; simpl. { apply id_right. }
     rewrite assoc, <- functor_comp.
     apply (transportb (λ x, # F x · _ = _) IHi).
     apply shift_iter_map_restricts.
-  + intro X. simpl. apply (counit_FF_map_restricts X 0).
+  + intro X. simpl. apply (free_ptd_alg_counit_map_restricts X 0).
 Qed.
 
-Definition free_forgetful_are_adjoints : are_adjoints free_ptd_alg (forget_ptd_alg F)
-  := make_are_adjoints _ _ _ _ free_forgetful_form_adjunction.
+Definition free_ptd_alg_forgetful_are_adjoints : are_adjoints free_ptd_alg (forget_ptd_alg F)
+  := make_are_adjoints _ _ _ _ free_ptd_alg_forgetful_form_adjunction.
 
 (* TODO: Involve fully-faithfulness of forget_ptd_alg F to say something
 about reflective subcategories *)

--- a/UniMath/CategoryTheory/PointedFunctorAlgebras.v
+++ b/UniMath/CategoryTheory/PointedFunctorAlgebras.v
@@ -86,11 +86,17 @@ Proof.
 Qed.
 
 (** 1.2. Well-pointedness
-  A well-pointed functor (F,,σ) satisfies Fσ = σF, i.e. for every c : C, the two
-  ways of constructing a morphism F c --> F (F c) coincide.
+  A well-pointed functor (F,,σ) satisfies Fσ = σF, i.e. for every A : C, the two
+  ways of constructing a morphism F A --> F (F A) coincide.
 *)
-Definition well_pointed {C : category} (F : pointed_endofunctor C) : UU
-  := ∏ A : C, point F (F A) =  #F (point F A).
+Definition well_pointed {C : category} (F : pointed_endofunctor C)
+  : UU
+  := pre_whisker F (point F) = post_whisker (point F) F.
+
+(** In practice we use this pointwise version, which is also easier to read *)
+Definition well_pointed_pointwise {C : category} {F : pointed_endofunctor C}
+  : well_pointed F → ∏ A : C, point F (F A) = #F (point F A)
+  := λ H A, nat_trans_eq_pointwise H A.
 
 (** 1.3. Pointed endofunctor algebras (algebras for a pointed endofunctor)
   Endofunctors, pointed-endofunctors, monads all have associated categories
@@ -253,6 +259,7 @@ Context (F : pointed_endofunctor C).
 Context (H : well_pointed F).
 
 Let σ := point F.
+Let H' := well_pointed_pointwise H.
 
 (** 2.1. Structure maps are iso-inverses [well_pointed_point_is_z_iso_at_algebra]
 If X is a pointed algebra for (F, σ) (well-pointed), then σ_X : X --> F X is iso.
@@ -265,7 +272,7 @@ Proof.
   - apply ptd_alg_law.
   (* s · σ_X = id_{FX} follows from naturality + well-pointedness + law for pointed algebras *)
   - rewrite point_naturality.
-    rewrite H.
+    rewrite H'.
     refine (! functor_comp F _ _ @ _).
     rewrite <- functor_id.
     apply maponpaths.
@@ -443,7 +450,7 @@ Definition shift_iter_map_restricts' (A : C) (i : nat)
 *)
 Section TransfiniteConstructionWellPointed.
 
-Context (F_well_pointed : well_pointed F). 
+Context (F_well_pointed : well_pointed F).
 
 (** Since F is well-pointed, the chain morphisms are all points, i.e. F^i σ = σ F^i *)
 Lemma iter_chain_mor_is_point (i : nat) (A : C) : iter_chain_mor i A = σ ((F ^ i) A).
@@ -451,7 +458,7 @@ Proof.
   apply pathsinv0.
   induction i.
   - exact (idpath _).
-  - exact (F_well_pointed ((F ^ i) A) @ maponpaths (#F) IHi).
+  - exact (well_pointed_pointwise F_well_pointed ((F ^ i) A) @ maponpaths (#F) IHi).
 Qed.
 
 (** 3.3. The shift map forms a pointed algebra [shift_iter_map_forms_ptd_alg]

--- a/UniMath/CategoryTheory/PointedFunctorAlgebras.v
+++ b/UniMath/CategoryTheory/PointedFunctorAlgebras.v
@@ -163,9 +163,7 @@ Definition ptd_alg_mor_commutes {X Y : ptd_alg} (f : ptd_alg_mor X Y)
 Definition ptd_alg_mor_id (X : ptd_alg) : ptd_alg_mor X X.
 Proof.
   apply make_ptd_alg_mor with (identity X).
-  abstract (unfold is_ptd_alg_mor;
-            rewrite functor_id, id_right, id_left;
-            apply idpath).
+  abstract (unfold is_ptd_alg_mor; now rewrite functor_id, id_right, id_left).
 Defined.
 
 Definition ptd_alg_mor_comp (X Y Z : ptd_alg) (f : ptd_alg_mor X Y) (g : ptd_alg_mor Y Z)
@@ -177,8 +175,7 @@ Proof.
             rewrite ptd_alg_mor_commutes;
             rewrite <- assoc;
             rewrite ptd_alg_mor_commutes;
-            rewrite functor_comp, assoc;
-            apply idpath).
+            now rewrite functor_comp, assoc).
 Defined.
 
 Definition precategory_ptd_alg_ob_mor : precategory_ob_mor
@@ -235,7 +232,7 @@ Proof.
   - use make_functor_data.
     + simpl. exact (ptd_alg_carrier F).
     + simpl. intros X Y. exact (mor_from_ptd_alg_mor F).
-  - abstract (split; red; intros; apply idpath).
+  - abstract (split; red; now intros).
 Defined.
 
 End PointedAlgebraCategory.
@@ -303,7 +300,7 @@ Proof.
   rw_left_comp (! point_naturality F f).
   rewrite <- assoc.
   rw_right_comp (ptd_alg_law F Y).
-  rewrite id_left, id_right; apply idpath.
+  now rewrite id_left, id_right.
 Qed.
 
 (** 2.3. The forgetful functor is fully-faithful [well_pointed_forgetul_fully_faithful] *)
@@ -315,8 +312,8 @@ Lemma well_pointed_forgetul_fully_faithful : fully_faithful (forget_ptd_alg F).
 Proof.
   red. intros X Y.
   apply isweq_iso with (λ f, make_ptd_alg_mor F f (well_pointed_mor_is_algebra_mor X Y f)).
-  - abstract (intros; apply ptd_alg_mor_eq; apply idpath).
-  - abstract (intros; apply idpath). 
+  - abstract (intros; now apply ptd_alg_mor_eq).
+  - abstract easy. 
 Defined.
 
 (** Being in the (strict) image of the forgetful functor is a proposition. *)
@@ -335,8 +332,8 @@ Proof.
     induction h.
     exists (ptd_alg_map F X).
     apply ptd_alg_law.
-  - intros [a p]; apply idpath.
-  - intros [X h]; induction h; apply idpath.
+  - easy.
+  - now intros [X h]; induction h.
 Qed.
 
 End AlgebrasWellPointed.


### PR DESCRIPTION
This is my first contribution to UniMath so feedback is appreciated.

It consists contains the construction of a free algebra for a well-pointed endofunctor and some relationships between well-pointed endofunctors and reflective subcategories.

I did my best to reuse existing definitions, however I haven't used PointedFunctors.v, and instead just have my own `pointed_endofunctor` definition, since I had issues with `F : category_Ptd C` not coercing to a `functor C C`. Using `ptd_obj C` works, but this naming is obscure in my opinion - I would not guess that it's a functor.

I followed `UniMath/CategoryTheory/Monads/MonadAlgebras.v` to implement the definition of the category of algebras for a pointed endofunctor. Everything is much the same, except we have only 1 algebra law, not 2. I'm not sure if I should also be capitalising like `MonadAlg`? Also worth noting is I've called them `pointed_algebras`, which may imply the algebra X has a point (1 --> X) rather than the endofunctor F, but I don't there's a better alternative.

The relationship to reflective subcategories hasn't been made concrete. I use the term `reflective` in comments and the final theorem, but I'm essentially just using a fully-faithful right adjoint in the code.