### PR TITLE
More on the setgroupoid model

### DIFF
--- a/UniMath/Bicategories/ComprehensionCat/SetGroupoidModel.v
+++ b/UniMath/Bicategories/ComprehensionCat/SetGroupoidModel.v
@@ -44,7 +44,9 @@
 
  Note that we consider two versions of the setgroupid model: one where types in a context [Γ]
  are given by pseudofunctors from [Γ] to the bicategory of setgroupoids, and one where types
- in a context [Γ] are given by functors to the category of setgroupoids.
+ in a context [Γ] are given by functors to the category of setgroupoids. Usually, the groupoid
+ model is the latter of the two, and types are given by functors to setgroupoids. However, we
+ define both versions.
 
  References
  - 'Bicategorical type theory: semantics and syntax' by Ahrens, North, Van der Weide

--- a/UniMath/Bicategories/ComprehensionCat/SetGroupoidModel.v
+++ b/UniMath/Bicategories/ComprehensionCat/SetGroupoidModel.v
@@ -42,6 +42,10 @@
  univalent, morphisms must be required to preserve that structure on the nose. Since not all
  morphisms satisfy this requirement, the resulting comprehension category will not be full.
 
+ Note that we consider two versions of the setgroupid model: one where types in a context [Γ]
+ are given by pseudofunctors from [Γ] to the bicategory of setgroupoids, and one where types
+ in a context [Γ] are given by functors to the category of setgroupoids.
+
  References
  - 'Bicategorical type theory: semantics and syntax' by Ahrens, North, Van der Weide
  - 'Two-dimensional models of type theory' by Garner
@@ -52,6 +56,7 @@
 
  Content
  1. The univalent comprehension category of setgroupoids
+ 2. The univalent comprehension category of setgroupoids with split isofibrations
 
  *********************************************************************************************)
 Require Import UniMath.MoreFoundations.All.
@@ -102,4 +107,38 @@ Proof.
   use make_comp_cat.
   - exact setgroupoid_cat_with_terminal_cleaving.
   - exact setgroupoid_comprehension_functor.
+Defined.
+
+(** * 2. The univalent comprehension category of setgroupoids with split isofibrations *)
+Definition setgroupoid_cat_split_with_terminal_disp_cat
+  : cat_with_terminal_disp_cat.
+Proof.
+  use make_cat_with_terminal_disp_cat.
+  - exact univalent_cat_of_setgroupoid.
+  - exact terminal_obj_setgroupoid.
+  - exact univalent_disp_cat_split_isofib.
+Defined.
+
+Definition setgroupoid_cat_split_with_terminal_cleaving
+  : cat_with_terminal_cleaving.
+Proof.
+  use make_cat_with_terminal_cleaving.
+  - exact setgroupoid_cat_split_with_terminal_disp_cat.
+  - exact cleaving_disp_cat_split_isofib.
+Defined.
+
+Definition setgroupoid_split_comprehension_functor
+  : comprehension_functor setgroupoid_cat_split_with_terminal_cleaving.
+Proof.
+  use make_comprehension_functor.
+  - exact disp_cat_split_isofib_comprehension.
+  - exact disp_cat_split_isofib_comprehension_cartesian.
+Defined.
+
+Definition setgroupoid_comp_cat_split
+  : comp_cat.
+Proof.
+  use make_comp_cat.
+  - exact setgroupoid_cat_split_with_terminal_cleaving.
+  - exact setgroupoid_split_comprehension_functor.
 Defined.

--- a/UniMath/CategoryTheory/DisplayedCats/Examples/SetGroupoidComprehension.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Examples/SetGroupoidComprehension.v
@@ -13,6 +13,7 @@
  2. The comprehension functor
  3. Some transport lemmas that we need
  4. The comprehension functor is Cartesian
+ 5. Comprehension for split isofibrations
 
  *****************************************************************************************)
 Require Import UniMath.MoreFoundations.All.
@@ -601,6 +602,86 @@ Definition disp_cat_isofib_comprehension_cartesian
 Proof.
   use is_cartesian_disp_functor_chosen_lifts.
   - exact cleaving_disp_cat_isofib.
+  - intros G₁ G₂ F D.
+    use isPullback_cartesian_in_cod_disp.
+    intros G₀ H₁ H₂ p.
+    simple refine (_ ,, _).
+    + simple refine (_ ,, _ ,, _).
+      * exact (isofib_comprehension_pb_mor p).
+      * apply isofib_comprehension_pb_mor_pr1.
+      * apply isofib_comprehension_pb_mor_pr2.
+    + abstract
+        (intros H' ;
+         use subtypePath ;
+         [ intro ; apply isapropdirprod ; apply homset_property | ] ;
+         exact (isofib_comprehension_pb_mor_unique
+                  _
+                  (pr12 H')
+                  (pr22 H'))).
+Defined.
+
+(** * 5. Comprehension for split isofibrations *)
+Definition disp_cat_split_isofib_comprehension_data
+  : disp_functor_data
+      (functor_identity _)
+      disp_cat_split_isofib
+      (disp_codomain _).
+Proof.
+  simple refine (_ ,, _).
+  - exact (λ (G : setgroupoid)
+             (D : disp_cat_split_isofib G),
+           total_set_groupoid (pr1 D)
+           ,,
+           pr1_category _).
+  - refine (λ (G₁ G₂ : setgroupoid)
+              (D₁ : disp_cat_split_isofib G₁)
+              (D₂ : disp_cat_split_isofib G₂)
+              (F : G₁ ⟶ G₂)
+              (FF : D₁ -->[ F ] D₂),
+             total_functor (pr11 FF)
+             ,,
+             _).
+    exact (total_functor_commute_eq (pr11 FF)).
+Defined.
+
+Proposition disp_cat_split_isofib_comprehension_axioms
+  : disp_functor_axioms disp_cat_split_isofib_comprehension_data.
+Proof.
+  split.
+  - intros.
+    use subtypePath.
+    {
+      intro.
+      apply homset_property.
+    }
+    use functor_eq ; [ apply homset_property | ] ; cbn.
+    apply idpath.
+  - intros.
+    use subtypePath.
+    {
+      intro.
+      apply homset_property.
+    }
+    use functor_eq ; [ apply homset_property | ] ; cbn.
+    apply idpath.
+Qed.
+
+Definition disp_cat_split_isofib_comprehension
+  : disp_functor
+      (functor_identity _)
+      disp_cat_split_isofib
+      (disp_codomain _).
+Proof.
+  simple refine (_ ,, _).
+  - exact disp_cat_split_isofib_comprehension_data.
+  - exact disp_cat_split_isofib_comprehension_axioms.
+Defined.
+
+Definition disp_cat_split_isofib_comprehension_cartesian
+  : is_cartesian_disp_functor disp_cat_split_isofib_comprehension.
+Proof.
+  use is_cartesian_disp_functor_chosen_lifts.
+  - exact cleaving_disp_cat_split_isofib.
   - intros G₁ G₂ F D.
     use isPullback_cartesian_in_cod_disp.
     intros G₀ H₁ H₂ p.

--- a/UniMath/CategoryTheory/DisplayedCats/Examples/SetGroupoidsIsoFib.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Examples/SetGroupoidsIsoFib.v
@@ -30,6 +30,7 @@
  6.2. Proof of univalence
  7. The displayed category of isofibrations
  8. A cleaving for the displayed category of isofibrations
+ 9. The displayed category of split isofibrations
 
  *****************************************************************************************)
 Require Import UniMath.MoreFoundations.All.
@@ -48,6 +49,7 @@ Require Import UniMath.CategoryTheory.DisplayedCats.Univalence.
 Require Import UniMath.CategoryTheory.DisplayedCats.DisplayedCatEq.
 Require Import UniMath.CategoryTheory.DisplayedCats.Projection.
 Require Import UniMath.CategoryTheory.DisplayedCats.Examples.Reindexing.
+Require Import UniMath.CategoryTheory.DisplayedCats.Constructions.
 
 Local Open Scope cat.
 
@@ -1543,4 +1545,444 @@ Proof.
   - exact (disp_cat_isofib_subst F (pr1 D) (pr2 D)).
   - exact (disp_cat_isofib_subst_mor F (pr1 D) (pr2 D)).
   - exact (is_cartesian_disp_cat_isofib_subst F (pr1 D) (pr2 D)).
+Defined.
+
+(** * 9. The displayed category of split isofibrations *)
+Definition is_split_isofibration
+           {G : setgroupoid}
+           {D : disp_setgrpd G}
+           (I : cleaving D)
+  : UU
+  := is_split_id I × is_split_comp I.
+
+Proposition split_isofib_cleaving_id_ob_path
+            {G : setgroupoid}
+            {D : disp_setgrpd G}
+            {I : cleaving D}
+            (H : is_split_isofibration I)
+            {x : G}
+            (xx : D x)
+  : cleaving_ob I (identity x) xx = xx.
+Proof.
+  exact (pr1 (pr1 H x xx)).
+Defined.
+
+Proposition split_isofib_cleaving_id_mor_path
+            {G : setgroupoid}
+            {D : disp_setgrpd G}
+            {I : cleaving D}
+            (H : is_split_isofibration I)
+            {x : G}
+            (xx : D x)
+  : cleaving_mor I (identity x) xx
+    =
+    transportb
+      (λ zz, zz -->[ _ ] _)
+      (split_isofib_cleaving_id_ob_path H xx)
+      (id_disp xx).
+Proof.
+  exact (pr2 (pr1 H x xx)).
+Defined.
+
+Proposition split_isofib_cleaving_id_mor_path'
+            {G : setgroupoid}
+            {D : disp_setgrpd G}
+            {I : cleaving D}
+            (H : is_split_isofibration I)
+            {x : G}
+            (xx : D x)
+  : cleaving_mor I (identity x) xx
+    =
+    transportf
+      (λ z, _ -->[ z ] _)
+      (!(id_right _) @ id_left _)
+      (idtoiso_disp (idpath x) (split_isofib_cleaving_id_ob_path H xx)).
+Proof.
+  refine (split_isofib_cleaving_id_mor_path H xx @ _).
+  etrans.
+  {
+    apply transportf_precompose_disp.
+  }
+  rewrite idtoiso_disp_inv.
+  rewrite pathsinv0inv0.
+  rewrite id_right_disp.
+  unfold transportb.
+  rewrite transport_f_f.
+  apply idpath.
+Qed.
+
+Proposition split_isofib_cleaving_comp_ob_path
+            {G : setgroupoid}
+            {D : disp_setgrpd G}
+            {I : cleaving D}
+            (H : is_split_isofibration I)
+            {x y z : G}
+            (f : y --> z)
+            (g : x --> y)
+            (zz : D z)
+  : cleaving_ob I (g · f) zz = cleaving_ob I g (cleaving_ob I f zz).
+Proof.
+  exact (pr1 (pr2 H z y x f g zz)).
+Defined.
+
+Proposition split_isofib_cleaving_comp_mor_path
+            {G : setgroupoid}
+            {D : disp_setgrpd G}
+            {I : cleaving D}
+            (H : is_split_isofibration I)
+            {x y z : G}
+            (f : y --> z)
+            (g : x --> y)
+            (zz : D z)
+  : cleaving_mor I (g · f) zz
+    =
+    transportb
+      (λ xx, xx -->[ g · f ] zz)
+      (split_isofib_cleaving_comp_ob_path H f g zz)
+      (cleaving_mor I g (cleaving_ob I f zz) ;; cleaving_mor I f zz)%mor_disp.
+Proof.
+  exact (pr2 (pr2 H z y x f g zz)).
+Defined.
+
+Proposition split_isofib_cleaving_comp_mor_path'
+            {G : setgroupoid}
+            {D : disp_setgrpd G}
+            {I : cleaving D}
+            (H : is_split_isofibration I)
+            {x y z : G}
+            (f : y --> z)
+            (g : x --> y)
+            (zz : D z)
+  : (cleaving_mor I g (cleaving_ob I f zz) ;; cleaving_mor I f zz)%mor_disp
+    =
+    transportf
+      (λ z, _ -->[ z ] _)
+      (id_left _)
+      (idtoiso_disp (idpath x) (!(split_isofib_cleaving_comp_ob_path H f g zz))
+       ;; cleaving_mor I (g · f) zz)%mor_disp.
+Proof.
+  refine (!_).
+  etrans.
+  {
+    do 2 apply maponpaths.
+    exact (split_isofib_cleaving_comp_mor_path H f g zz).
+  }
+  etrans.
+  {
+    do 2 apply maponpaths.
+    apply transportf_precompose_disp.
+  }
+  rewrite mor_disp_transportf_prewhisker.
+  rewrite transport_f_f.
+  rewrite idtoiso_disp_inv.
+  rewrite pathsinv0inv0.
+  rewrite assoc_disp.
+  unfold transportb.
+  rewrite transport_f_f.
+  rewrite assoc_disp.
+  unfold transportb.
+  rewrite transport_f_f.
+  etrans.
+  {
+    apply maponpaths.
+    do 2 apply maponpaths_2.
+    apply idtoiso_disp_comp.
+  }
+  unfold transportb.
+  rewrite !mor_disp_transportf_postwhisker.
+  rewrite transport_f_f.
+  rewrite pathsinv0l.
+  cbn.
+  rewrite (id_left_disp (D := D)).
+  unfold transportb.
+  rewrite mor_disp_transportf_postwhisker.
+  rewrite transport_f_f.
+  apply transportf_set.
+  apply (homset_property G).
+Qed.
+
+Proposition isaprop_is_split_isofibration
+            {G : setgroupoid}
+            {D : disp_setgrpd G}
+            (I : cleaving D)
+  : isaprop (is_split_isofibration I).
+Proof.
+  use isapropdirprod.
+  - repeat (use impred ; intro).
+    use isaproptotal2.
+    + intro.
+      apply homsets_disp.
+    + intros.
+      apply isaset_ob_disp_set_grpd.
+  - repeat (use impred ; intro).
+    use isaproptotal2.
+    + intro.
+      apply homsets_disp.
+    + intros.
+      apply isaset_ob_disp_set_grpd.
+Qed.
+
+Definition disp_cat_split_isofib
+  : disp_cat cat_of_setgroupoid
+  := sigma_disp_cat
+       (disp_full_sub
+          (total_category disp_cat_isofib)
+          (λ D, is_split_isofibration (pr22 D))).
+
+Definition is_univalent_disp_cat_split_isofib
+  : is_univalent_disp disp_cat_split_isofib.
+Proof.
+  use is_univalent_sigma_disp.
+  - exact is_univalent_disp_cat_isofib.
+  - use disp_full_sub_univalent.
+    intros D.
+    exact (isaprop_is_split_isofibration (pr22 D)).
+Qed.
+
+Definition univalent_disp_cat_split_isofib
+  : disp_univalent_category univalent_cat_of_setgroupoid.
+Proof.
+  use make_disp_univalent_category.
+  - exact disp_cat_split_isofib.
+  - exact is_univalent_disp_cat_split_isofib.
+Defined.
+
+Proposition mor_eq_disp_cat_split_isofib
+            {G₁ G₂ : setgroupoid}
+            {F : G₁ ⟶ G₂}
+            {D₁ : disp_cat_split_isofib G₁}
+            {D₂ : disp_cat_split_isofib G₂}
+            {FF FF' : D₁ -->[ F ] D₂}
+            (p : pr11 FF = pr11 FF')
+  : FF = FF'.
+Proof.
+  use subtypePath.
+  {
+    intro.
+    apply isapropunit.
+  }
+  use mor_eq_disp_cat_isofib.
+  exact p.
+Qed.
+
+(** * 10. A cleaving for the displayed category of split isofibrations *)
+Proposition cleaving_mor_on_eq_base
+            {C : category}
+            {x y : C}
+            {f g : x --> y}
+            (p : f = g)
+  : idtoiso (idpath x) · g = f.
+Proof.
+  induction p ; cbn.
+  apply id_left.
+Qed.
+
+Proposition cleaving_ob_eq
+            {C : category}
+            {D : disp_cat C}
+            (H : cleaving D)
+            {x y : C}
+            {f g : x --> y}
+            (p : f = g)
+            (yy : D y)
+  : cleaving_ob H f yy = cleaving_ob H g yy.
+Proof.
+  induction p.
+  apply idpath.
+Defined.
+
+Proposition cleaving_mor_on_eq
+            {C : category}
+            {D : disp_cat C}
+            (H : cleaving D)
+            {x y : C}
+            {f g : x --> y}
+            (p : f = g)
+            (yy : D y)
+  : cleaving_mor H f yy
+    =
+    transportf
+      (λ z, cleaving_ob H f yy -->[ z ] yy)
+      (cleaving_mor_on_eq_base p)
+      (idtoiso_disp (idpath _) (cleaving_ob_eq H p yy)
+       ;;
+       cleaving_mor H g yy)%mor_disp.
+Proof.
+  induction p.
+  cbn.
+  rewrite id_left_disp.
+  unfold transportb.
+  rewrite transport_f_f.
+  refine (!_).
+  apply transportf_set.
+  apply homset_property.
+Qed.
+
+Section Cleaving.
+  Context {G₁ G₂ : setgroupoid}
+          (F : G₂ ⟶ G₁)
+          (D : disp_setgrpd G₁)
+          (I : cleaving D)
+          (H : is_split_isofibration I).
+
+  Let DD : disp_cat_split_isofib G₁ := (D ,, I) ,, H.
+
+  Proposition is_split_cleaving_reindex
+    : is_split_isofibration (pr2 (disp_cat_isofib_subst F D I)).
+  Proof.
+    cbn ; split.
+    - intros x xx.
+      simple refine (_ ,, _).
+      + refine (_ @ split_isofib_cleaving_id_ob_path H xx).
+        exact (!(cleaving_ob_eq I (!functor_id F x) xx)).
+      + cbn.
+        refine (!_).
+        etrans.
+        {
+          apply transportf_precompose_disp.
+        }
+        rewrite idtoiso_disp_inv.
+        rewrite pathsinv0inv0.
+        unfold transportb.
+        rewrite mor_disp_transportf_prewhisker.
+        rewrite transport_f_f.
+        rewrite (id_right_disp (D := D)).
+        unfold transportb.
+        rewrite transport_f_f.
+        cbn -[idtoiso_disp].
+        etrans.
+        {
+          apply maponpaths.
+          exact (!(transportf_transpose_left (idtoiso_disp_comp _ _))).
+        }
+        rewrite transport_f_f.
+        etrans.
+        {
+          do 2 apply maponpaths.
+          exact (!(transportb_transpose_left (split_isofib_cleaving_id_mor_path' H xx))).
+        }
+        unfold transportb.
+        rewrite mor_disp_transportf_prewhisker.
+        rewrite transport_f_f.
+        etrans.
+        {
+          do 2 apply maponpaths.
+          exact (cleaving_mor_on_eq I (!functor_id F x) xx).
+        }
+        rewrite mor_disp_transportf_prewhisker.
+        rewrite transport_f_f.
+        rewrite assoc_disp.
+        unfold transportb.
+        rewrite transport_f_f.
+        rewrite idtoiso_disp_comp.
+        unfold transportb.
+        rewrite mor_disp_transportf_postwhisker.
+        rewrite transport_f_f.
+        rewrite pathsinv0l.
+        cbn.
+        rewrite (id_left_disp (D := D)).
+        unfold transportb.
+        rewrite transport_f_f.
+        apply transportf_set.
+        apply (homset_property G₁).
+    - intros z y x f g zz.
+      simple refine (_ ,, _).
+      + refine (_ @ split_isofib_cleaving_comp_ob_path H _ _ zz).
+        exact (cleaving_ob_eq I (functor_comp F g f) zz).
+      + cbn.
+        refine (!_).
+        etrans.
+        {
+          apply transportf_precompose_disp.
+        }
+        rewrite idtoiso_disp_inv.
+        rewrite pathsinv0inv0.
+        unfold transportb.
+        rewrite mor_disp_transportf_prewhisker.
+        rewrite transport_f_f.
+        etrans.
+        {
+          do 2 apply maponpaths.
+          apply (split_isofib_cleaving_comp_mor_path' H).
+        }
+        rewrite mor_disp_transportf_prewhisker.
+        rewrite transport_f_f.
+        rewrite assoc_disp.
+        unfold transportb.
+        rewrite transport_f_f.
+        etrans.
+        {
+          apply maponpaths.
+          apply maponpaths_2.
+          apply idtoiso_disp_comp.
+        }
+        unfold transportb.
+        rewrite mor_disp_transportf_postwhisker.
+        rewrite transport_f_f.
+        etrans.
+        {
+          apply maponpaths.
+          apply maponpaths_2.
+          rewrite <- path_assoc.
+          rewrite pathsinv0r.
+          rewrite pathscomp0rid.
+          apply idpath.
+        }
+        refine (!_).
+        etrans.
+        {
+          exact (cleaving_mor_on_eq I (functor_comp F g f) zz).
+        }
+        apply maponpaths_2.
+        apply (homset_property G₁).
+  Qed.
+
+  Definition disp_cat_split_isofib_subst
+    : disp_cat_split_isofib G₂.
+  Proof.
+    simple refine (_ ,, _).
+    - exact (disp_cat_isofib_subst F D I).
+    - exact is_split_cleaving_reindex.
+  Defined.
+
+  Definition disp_cat_split_isofib_subst_mor
+    : disp_cat_split_isofib_subst -->[ F ] DD.
+  Proof.
+    simple refine (_ ,, _).
+    - exact (disp_cat_isofib_subst_mor F D I).
+    - exact tt.
+  Defined.
+
+  Definition is_cartesian_disp_cat_split_isofib_subst
+    : is_cartesian disp_cat_split_isofib_subst_mor.
+  Proof.
+    intros G₃ F' D' FF.
+    simple refine (_ ,, _).
+    - simple refine (((_ ,, _) ,, tt) ,, _) ; cbn.
+      + exact (lift_functor_into_reindex (pr11 FF)).
+      + apply preserves_cleaving_lift_reindex.
+        exact (pr21 FF).
+      + abstract
+          (use (mor_eq_disp_cat_split_isofib (FF' := FF)) ;
+           use disp_functor_eq ;
+           apply idpath).
+    - abstract
+        (intros K ;
+         induction K as [ K KK ] ;
+         use subtypePath ; [ intro ; apply homsets_disp | ] ;
+         use mor_eq_disp_cat_split_isofib ;
+         use disp_functor_eq ;
+         cbn ;
+         exact (maponpaths (λ z, pr111 z) KK)).
+  Defined.
+End Cleaving.
+
+Definition cleaving_disp_cat_split_isofib
+  : cleaving disp_cat_split_isofib.
+Proof.
+  intros G₁ G₂ F D.
+  simple refine (_ ,, _ ,, _).
+  - exact (disp_cat_split_isofib_subst F _ _ (pr2 D)).
+  - exact (disp_cat_split_isofib_subst_mor F _ _ (pr2 D)).
+  - exact (is_cartesian_disp_cat_split_isofib_subst F _ _ (pr2 D)).
 Defined.


### PR DESCRIPTION
In my previous PR, I defined a univalent (non-full) comprehension category of setgroupoids. In that comprehension category, types in a context `G` are given by pseudofunctors from `G` to the bicategory of setgroupoids. In this PR, I define a variation where types in a context `G` are given by functors from `G` to the category of setgroupoids. This is done by adding suitable splitness assumptions.