### PR TITLE
Fixed postfix + closed notation levels to recommended defaults, to squash a few warnings

### DIFF
--- a/UniMath/CategoryTheory/RepresentableFunctors/Precategories.v
+++ b/UniMath/CategoryTheory/RepresentableFunctors/Precategories.v
@@ -63,7 +63,7 @@ Proof.
   exact (λ a b, pr2 C b a).
 Defined.
 
-Notation "C '^op'" := (oppositecategory C) (at level 3, format "C ^op") : cat. (* this overwrites the previous definition *)
+Notation "C '^op'" := (oppositecategory C) (at level 1, format "C ^op") : cat. (* this overwrites the previous definition *)
 
 
 Definition precategory_obmor (C:precategory) : precategory_ob_mor :=

--- a/UniMath/CategoryTheory/elems_slice_equiv.v
+++ b/UniMath/CategoryTheory/elems_slice_equiv.v
@@ -208,7 +208,7 @@ Section elems_slice_equiv.
   Definition slice_to_PreShv_ob : PreShv C / P → PreShv ∫P :=
     λ Q,  slice_to_PreShv_ob_funct_data Q ,,  slice_to_PreShv_ob_is_funct Q.
 
-  Definition slice_to_PreShv_ob_nat {X Y : PreShv C / P} (F : X --> Y) (e : ∫P^op) :
+  Definition slice_to_PreShv_ob_nat {X Y : PreShv C / P} (F : X --> Y) (e : (∫P)^op) :
     (slice_to_PreShv_ob_ob X) e --> (slice_to_PreShv_ob_ob Y) e.
   Proof.
     induction e as [e Pe].

--- a/UniMath/CategoryTheory/opp_precat.v
+++ b/UniMath/CategoryTheory/opp_precat.v
@@ -46,7 +46,7 @@ Definition is_precat_opp_precat_data (C : precategory) : is_precategory (opp_pre
 Definition opp_precat (C : precategory) : precategory :=
   tpair _ (opp_precat_data C) (is_precat_opp_precat_data C).
 
-Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op") : cat.
+Local Notation "C '^op'" := (opp_precat C) (at level 1, format "C ^op") : cat.
 
 Goal ∏ C:precategory, C^op^op = C. reflexivity. Qed.
 
@@ -204,7 +204,7 @@ Qed.
 
 End opp_functor_properties.
 
-Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op") : cat.
+Notation "C '^op'" := (opp_precat C) (at level 1, format "C ^op") : cat.
 
 Lemma functor_opp_identity {C : precategory} (hsC : has_homsets C) :
   functor_opp (functor_identity C) = functor_identity C^op.
@@ -352,7 +352,7 @@ Definition op_unicat (C : univalent_category)
   : univalent_category
   := (op_category C ,, op_is_univalent C).
 
-Notation "C '^op'" := (op_category C) (at level 3, format "C ^op") : cat.
+Notation "C '^op'" := (op_category C) (at level 1, format "C ^op") : cat.
 
 
 Definition op_ob {C : category} (c : ob C) : ob C^op := c.

--- a/UniMath/Foundations/Init.v
+++ b/UniMath/Foundations/Init.v
@@ -83,9 +83,9 @@ Reserved Notation "! p " (at level 50, left associativity).
 
 Reserved Notation "p #' x" (right associativity, at level 65).
 
-Reserved Notation "C '^op'" (at level 3, format "C ^op").
+Reserved Notation "C '^op'" (at level 1, format "C ^op").
 
-Reserved Notation "q '^-1'" (at level 10).
+Reserved Notation "q '^-1'" (at level 1).
 
 Reserved Notation "a <-- b" (at level 55).
 

--- a/UniMath/Foundations/Preamble.v
+++ b/UniMath/Foundations/Preamble.v
@@ -65,7 +65,7 @@ Definition succ := S.
 Declare Scope nat_scope.
 Delimit Scope nat_scope with nat.
 Bind Scope nat_scope with nat.
-Arguments S _%nat.
+Arguments S _%_nat.
 Open Scope nat_scope.
 
 Fixpoint add n m :=

--- a/UniMath/SubstitutionSystems/GenMendlerIteration.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration.v
@@ -41,7 +41,7 @@ Require Import UniMath.CategoryTheory.Adjunctions.Core.
 Arguments functor_composite {_ _ _} _ _ .
 Arguments nat_trans_comp {_ _ _ _ _} _ _ .
 Local Notation "G ∙ F" := (functor_composite F G : [ _ , _ , _ ]) (at level 35).
-Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
+Local Notation "C '^op'" := (opp_precat C) (format "C ^op").
 Local Notation "↓ f" := (mor_from_algebra_mor _ f) (at level 3, format "↓ f").
 (* in Agda mode \downarrow *)
 

--- a/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/GenMendlerIteration_alt.v
@@ -41,7 +41,7 @@ Local Open Scope cat.
 Arguments functor_composite {_ _ _} _ _ .
 Arguments nat_trans_comp {_ _ _ _ _} _ _ .
 Local Notation "G ∙ F" := (functor_composite F G : [ _ , _ , _ ]) (at level 35).
-Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
+Local Notation "C '^op'" := (opp_precat C) (format "C ^op").
 Local Notation "↓ f" := (mor_from_algebra_mor _ _ _ f) (at level 3, format "↓ f").
 Local Notation "'chain'" := (diagram nat_graph).
 

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -592,7 +592,7 @@ Defined.
 
 
 
-Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
+Local Notation "C '^op'" := (opp_precat C) (format "C ^op").
 
 Let Yon (X : EndC) : functor EndC^op HSET := yoneda_objects EndC X.
 

--- a/UniMath/SubstitutionSystems/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial_alt.v
@@ -476,7 +476,7 @@ exact (iso1' Z · thetahat_0 Z f · iso2' Z).
 Defined.
 
 
-Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
+Local Notation "C '^op'" := (opp_precat C) (format "C ^op").
 
 Let Yon (X : EndC) : functor EndC^op HSET := yoneda_objects EndC X.
 

--- a/UniMath/SubstitutionSystems/SimplifiedHSS/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/SimplifiedHSS/LiftingInitial.v
@@ -595,7 +595,7 @@ Defined.
 
 
 
-Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
+Local Notation "C '^op'" := (opp_precat C) (format "C ^op").
 
 Let Yon (X : EndC) : functor EndC^op HSET := yoneda_objects EndC X.
 

--- a/UniMath/SubstitutionSystems/SimplifiedHSS/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/SimplifiedHSS/LiftingInitial_alt.v
@@ -479,7 +479,7 @@ exact (iso1' Z · thetahat_0 Z f · iso2' Z).
 Defined.
 
 
-Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
+Local Notation "C '^op'" := (opp_precat C) (format "C ^op").
 
 Let Yon (X : EndC) : functor EndC^op HSET := yoneda_objects EndC X.
 


### PR DESCRIPTION
This addresses the easy parts of #1972 : moved the simple postfix notations `C^op` and `q^-1` to level 1 (postfix at higher levels raises a warning in recent Coq) and also updated the notation scope delimiter in argument commands (similarly, recommended in recent Coq via a warning).