### PR TITLE
Adapt to rocq#19987

### DIFF
--- a/UniMath/Algebra/Universal/WTypes.v
+++ b/UniMath/Algebra/Universal/WTypes.v
@@ -395,6 +395,7 @@ Section groundTermAlgebraWtype.
         use pathsinv0.
         etrans.
         { use idpath_transportf. }
+        unfold idfun.
         use maponpaths.
         induction (!homotweqinvweq (gtweq_sec nm) f).
         use pathsinv0.


### PR DESCRIPTION
https://github.com/coq/coq/pull/19987 refolds terms before using them to instantiate evars. There is one instance where we need to unfold by hand.