### PR TITLE
Adapt w.r.t. coq/coq#14937.

### DIFF
--- a/UniMath/CategoryTheory/Limits/Examples/CategoryOfSetcategoriesLimits.v
+++ b/UniMath/CategoryTheory/Limits/Examples/CategoryOfSetcategoriesLimits.v
@@ -240,14 +240,16 @@ Proof.
   {
     apply homset_property.
   }
-  use functor_data_eq.
-  - abstract
+  assert (equalizer_of_setcategory_ump_unique_subproof : pr1 K ~ pr1 (equalizer_of_setcategory_ump_mor F G H p)).
+  { abstract
       (intro x ;
        use subtypePath ;
        [ intro z ;
          exact (pr12 C₂ (F z) (G z))
        | ] ;
-       exact (maponpaths (λ z, pr11 z x) K_pr1)).
+       exact (maponpaths (λ z, pr11 z x) K_pr1)). }
+  use functor_data_eq.
+  - exact equalizer_of_setcategory_ump_unique_subproof.
   - intros x₁ x₂ f.
     rewrite double_transport_idtoiso.
     rewrite !assoc'.
@@ -259,11 +261,11 @@ Proof.
     }
     refine (_ @ path_functor_mor K_pr1 f @ _).
     + apply (maponpaths (λ x, _ · x)).
-      refine (idtoiso_equalizer_of_setcategory _ _ (equalizer_of_setcategory_ump_unique_subproof C₁ C₂ F G C₀ H p K K_pr1 x₂) @ _).
+      refine (idtoiso_equalizer_of_setcategory _ _ (equalizer_of_setcategory_ump_unique_subproof x₂) @ _).
       apply (maponpaths (λ x, _ (idtoiso x))).
       apply isaset_ob.
     + apply (maponpaths (λ x, x · _)).
-      refine (_ @ !idtoiso_equalizer_of_setcategory _ _ (equalizer_of_setcategory_ump_unique_subproof C₁ C₂ F G C₀ H p K K_pr1 x₁)).
+      refine (_ @ !idtoiso_equalizer_of_setcategory _ _ (equalizer_of_setcategory_ump_unique_subproof x₁)).
       apply (maponpaths (λ x, _ (idtoiso x))).
       apply isaset_ob.
 Qed.


### PR DESCRIPTION
We don't rely anymore on the name of the proof generated by abstract. This is backwards compatible.