### PR TITLE
Fix CI w.r.t. Rocq latest (9.0)

### DIFF
--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -78,6 +78,10 @@ jobs:
             sudo chown -R 1000:1000 .
             endGroup
 
+            startGroup "Install the coq shim if need be"
+            command -v coqc || opam install --confirm-level=unsafe-yes -j 2 coq-core
+            endGroup
+
             startGroup "Print versions"
             opam --version
             opam exec -- dune --version
@@ -183,6 +187,10 @@ jobs:
           custom_script: |
             startGroup "Workaround permission issue"
             sudo chown -R 1000:1000 .
+            endGroup
+
+            startGroup "Install the coq shim if need be"
+            command -v coqc || opam install --confirm-level=unsafe-yes -j 2 coq-core
             endGroup
 
             startGroup "Print versions"

--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -75,7 +75,7 @@ jobs:
           ocaml_version: ${{ matrix.ocaml-version }}
           custom_script: |
             startGroup "Workaround permission issue"
-            sudo chown -R coq:coq . || sudo chown -R rocq:rocq .
+            sudo chown -R 1000:1000 .
             endGroup
 
             startGroup "Print versions"
@@ -182,7 +182,7 @@ jobs:
           ocaml_version: ${{ matrix.ocaml-version }}
           custom_script: |
             startGroup "Workaround permission issue"
-            sudo chown -R coq:coq . || sudo chown -R rocq:rocq .
+            sudo chown -R 1000:1000 .
             endGroup
 
             startGroup "Print versions"

--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -85,7 +85,7 @@ jobs:
             startGroup "Print versions"
             opam --version
             opam exec -- dune --version
-            opam exec -- coqc --version
+            opam exec -- coqc --version || opam exec -- rocq --version
             endGroup
 
             startGroup "Build UniMath"
@@ -196,7 +196,7 @@ jobs:
             startGroup "Print versions"
             opam --version
             opam exec -- dune --version
-            opam exec -- coqc --version
+            opam exec -- coqc --version || opam exec -- rocq --version
             endGroup
 
             startGroup "Build Satellite"


### PR DESCRIPTION
Dear UniMath developers,
Following a discussion with @rmatthes, I took a look at the issue you got with the CI, actually related to [this issue](https://github.com/rocq-community/docker-coq-action/issues/104).

**TL;DR:** this is basically not a "bug" of docker-coq-action, but just a consequence that:

* the `rocq/rocq-prover:9.0` Docker image does not contain the `coq` opam package on purpose (nor `coq-core`, which provides the `coqc` binary);
* UniMath's CI script relies on docker-coq-action's `custom_script` feature, which overwrites the default `install` script documented at https://github.com/rocq-community/docker-coq-action#install (which would have installed "coq" otherwise, as per the `coq-unimath.opam` file);
* all this being combined with the fact that dune's support of Rocq 9.0 requires the `coqc` binary, to date.

I'm confident in the fix except that `opam update -v` might be needed (as opam's cache is forcibly cleared in Docker-Rocq).

Note: commit bb29441 can be reverted later on, as soon as dune fully supports Rocq's CLI (https://github.com/ocaml/dune/issues/11572).

Note also that "morally speaking" (for consistency), the `coqc` binary should also be removed from the `rocq/rocq-prover:dev` image. This will be done shortly this week, sorry it wasn't done earlier (but admittedly, the upside of this lag is that it actually broke fewer CI jobs...)