### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For instance, you can run the files from the [School on Univalent Mathematics](h
 
 See [the documentation](./documentation/Documentation.md) for [general information](./documentation/unimath/About-UniMath.md) about UniMath, [install instructions](./documentation/setup/Setup.md), [guides](./documentation/guides/Guides.md), [tutorials](./documentation/guides/tutorials/) and information about [contributing](./documentation/contributing/Contributing.md).
 
-See also the automatically generated [alectryon](http://unimath.github.io/UniMath/gen/alectryon/UniMath.Foundations.PartA) documentation, where you can step through the proofs, viewing the goals at every step, and the the [rocqdoc](https://unimath.github.io/UniMath/gen/rocqdoc/toc) documentation, where you can click on identifiers (like [`disp_cat`](https://unimath.github.io/UniMath/gen/rocqdoc/UniMath.CategoryTheory.DisplayedCats.Core#disp_cat)) to go to their definition. By replacing `rocqdoc` with `alectryon` in the url and vice versa, you can switch between the rocqdoc and alectryon documentation.
+See also the automatically generated [alectryon](http://unimath.github.io/UniMath/gen/alectryon/UniMath.Foundations.PartA) documentation, where you can step through the proofs, viewing the goals at every step, and the [rocqdoc](https://unimath.github.io/UniMath/gen/rocqdoc/toc) documentation, where you can click on identifiers (like [`disp_cat`](https://unimath.github.io/UniMath/gen/rocqdoc/UniMath.CategoryTheory.DisplayedCats.Core#disp_cat)) to go to their definition. By replacing `rocqdoc` with `alectryon` in the url and vice versa, you can switch between the rocqdoc and alectryon documentation.
 
 ## Acknowledgments
 


### PR DESCRIPTION
docs: remove duplicate “the” in documentation section

The README contained a small typo:

  “… viewing the goals at every step, and **the the** rocqdoc documentation …”

This commit drops the extra “the”, leaving a single article so the sentence now reads smoothly.

No functional changes.