### PR TITLE
Ensure that some evars get unshelved

### DIFF
--- a/UniMath/ModelCategories/Generated/OneStepMonadSmall.v
+++ b/UniMath/ModelCategories/Generated/OneStepMonadSmall.v
@@ -331,7 +331,7 @@ Proof.
   set (homset_iso := isColim_is_z_iso _ (ColimsHSET _ (homSet_diagram (pr1 (morcls_lp_map S)) d)) _ _ homset_ccbase_isCC).
   set (carrcomm := colimArrowCommutes (homset_ccbase_CC) _ (colimCocone (ColimsHSET _ (homSet_diagram (pr1 (morcls_lp_map S)) d))) v).
   use (pathscomp1 (funeq carrcomm (pr2 S))); [|reflexivity].
-  etrans. use (funeq _ (pr2 S)).
+  etrans. unshelve use (funeq _ (pr2 S)).
           2: {
             use (colimArrowCommutes (homset_ccbase_CC)).
           }

--- a/UniMath/SubstitutionSystems/STLC_actegorical.v
+++ b/UniMath/SubstitutionSystems/STLC_actegorical.v
@@ -502,7 +502,7 @@ Section IndAndCoind.
         (** now begins the naturality reasoning *)
         etrans.
         match goal with |[ |- _ ?arg = _] => set (thearg := arg) end.
-        use (maponpaths (fun x : SET
+        unshelve use (maponpaths (fun x : SET
                                  ⟦ pr1 (pr1 STLC_gen (sorted_option_functorSet s (sorted_option_functorSet (s ⇒ s) ξ))) s,
                                    pr1 (pr1 STLC_gen (sorted_option_functorSet s (sorted_option_functorSet (s ⇒ s) ξ'))) s ⟧
                          => x thearg)).
@@ -562,7 +562,7 @@ Section IndAndCoind.
         unfold functor_compose.
         etrans.
         2: { match goal with |[ |- _= _ ?arg ] => set (thearg := arg) end.
-             use (maponpaths (fun x : SET
+             unshelve use (maponpaths (fun x : SET
                                       ⟦ pr1 (pr1 (sorted_option_functorSet (s ⇒ s) ∙ STLC_gen) ξ) (s ⇒ s),
                                         pr1 (pr1 (sorted_option_functorSet (s ⇒ s) ∙ STLC_gen) ξ') (s ⇒ s) ⟧
                               =>  x thearg)).
@@ -625,7 +625,7 @@ Section IndAndCoind.
           unfold functor_compose.
           etrans.
           match goal with |[ |- _ ?arg = _] => set (thearg := arg) end.
-          use (maponpaths (fun x : SET
+          unshelve use (maponpaths (fun x : SET
                                    ⟦ pr1 (pr1 (sorted_option_functorSet (s ⇒ s) ∙ STLC_gen) ξ) (s ⇒ s),
                                      pr1 (pr1 (sorted_option_functorSet (s ⇒ s) ∙ STLC_gen) ξ') (s ⇒ s) ⟧
                            =>  x thearg)).
@@ -643,7 +643,7 @@ Section IndAndCoind.
             { apply postcomp_with_projSortToSet_on_mor. }
             etrans.
             match goal with |[ |- _ ?arg = _] => set (thearg := arg) end.
-            use (maponpaths (fun x : SET
+            unshelve use (maponpaths (fun x : SET
        ⟦ pr1 (pr1 (functor_compose (sorted_option_functorSet s) STLC_gen) (pr1 (sorted_option_functorSet (s ⇒ s)) ξ)) s,
         pr1 (pr1 (functor_compose (sorted_option_functorSet s) STLC_gen) (pr1 (sorted_option_functorSet (s ⇒ s)) ξ')) s ⟧
                              => x thearg)).
@@ -669,7 +669,7 @@ Section IndAndCoind.
             unfold functor_compose.
             etrans.
             match goal with |[ |- _ ?arg = _] => set (thearg := arg) end.
-            use (maponpaths (fun x : SET
+            unshelve use (maponpaths (fun x : SET
        ⟦ pr1 (pr1 (sorted_option_functor sort Hsort SET TerminalHSET BinCoproductsHSET CoproductsHSET (s ⇒ s) ∙ STLC_gen) ξ) (s ⇒ s),
        pr1 (pr1 (sorted_option_functor sort Hsort SET TerminalHSET BinCoproductsHSET CoproductsHSET (s ⇒ s) ∙ STLC_gen) ξ') (s ⇒ s) ⟧
                              => x thearg)).
@@ -687,7 +687,7 @@ Section IndAndCoind.
                unfold functor_compose.
                etrans.
                match goal with |[ |- _ ?arg = _] => set (thearg := arg) end.
-               use (maponpaths (fun x : SET
+               unshelve use (maponpaths (fun x : SET
        ⟦ pr1 (pr1 (sorted_option_functorSet s ∙ STLC_gen) (pr1 (sorted_option_functorSet (s ⇒ s)) ξ)) s,
         pr1 (pr1 (sorted_option_functorSet s ∙ STLC_gen) (pr1 (sorted_option_functorSet (s ⇒ s)) ξ')) s ⟧
                                 => x thearg)).


### PR DESCRIPTION
https://github.com/rocq-prover/rocq/pull/21180 slightly changes the behavior of the shelving of evars. There are a few situations here where some evar used to be unshelved (which is debatable) and is not anymore. In the cases here, my PR should ideally not change anything but I could not find a way to keep the previous behavior. Considering how small the fix is, can we consider going through?