### PR TITLE
docs: add root CONTRIBUTING.md pointing to full guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to UniMath
+
+UniMath is a Rocq library for mathematics from the univalent point of view.  
+Full contribution guidelines are at [documentation/contributing/Contributing.md](./documentation/contributing/Contributing.md).
+
+## Quick start
+
+1. [Install UniMath](./documentation/setup/Setup.md)
+2. Browse [open issues](https://github.com/UniMath/UniMath/issues)
+3. Ask questions on [Zulip](https://unimath.zulipchat.com) before starting significant new work
+4. Submit a pull request against `master`
+
+## Style conventions (summary)
+
+- Use `--without-K` and `--safe` flags
+- Prefer `destruct` over `induction` for non-recursive types
+- Follow existing naming conventions in the file you are editing
+- Add a module-level comment explaining what the file proves
+
+## What contributions are welcome
+
+- New formalized results
+- Improved proofs (shorter, faster, more general)
+- Documentation and comment improvements
+- Bug reports via issues
+
+For the full guide, see [documentation/contributing/](./documentation/contributing/).


### PR DESCRIPTION
Adds a root-level CONTRIBUTING.md that GitHub surfaces automatically on the repo and new-issue pages. It links to the full guide at documentation/contributing/Contributing.md and summarises the quick steps for new contributors. Currently there is no CONTRIBUTING.md at the root, so GitHub shows no contribution guidance on pull request creation.