### PR TITLE
fix unit type in comprehension categories

### DIFF
--- a/UniMath/CategoryTheory/ComprehensionCats/CompCatTypeFormers.v
+++ b/UniMath/CategoryTheory/ComprehensionCats/CompCatTypeFormers.v
@@ -19,6 +19,7 @@
 Require Import UniMath.Foundations.All.
 Require Import UniMath.MoreFoundations.All.
 Require Import UniMath.CategoryTheory.Core.Prelude.
+Require Import UniMath.CategoryTheory.Limits.Pullbacks.
 
 Require Import UniMath.CategoryTheory.DisplayedCats.ComprehensionC.
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
@@ -101,13 +102,10 @@ Section Sigma_For_Comp_Cat.
     (σiso : sigma_sub_iso Σty) : UU :=
     ∏ (Γ Δ : C) (s : Δ --> Γ)
       (A : comp_cat_ty Γ) (B : comp_cat_ty (Γ & A)),
-      let sA  := comp_cat_ext_subst s A in
-      let sAB := comp_cat_ext_subst sA B in
-      let i   := σiso Γ Δ s A B in
-      pair Δ (A [[ s ]]) (B [[ sA ]]) ·
-        comp_cat_comp_mor (C:=C) (Γ:=Δ) (inv_from_z_iso i : _ -->[ identity _ ] _) ·
+      pair Δ (A [[ s ]]) (B [[ (comp_cat_ext_subst s A) ]]) ·
+        comp_cat_comp_mor (inv_from_z_iso (σiso _ _ _ _ _)) ·
         comp_cat_ext_subst s (Σty Γ A B)
-      = sAB · pair Γ A B.
+      = (comp_cat_ext_subst (comp_cat_ext_subst _ _) B) · pair Γ A B .
 
   Definition comp_cat_sigma : UU :=
     ∑ (Σty    : sigma_form),
@@ -166,13 +164,11 @@ Definition comp_cat_sigma_sub_iso
 Definition comp_cat_sigma_sub_pair
   {C : comp_cat} {Σ : comp_cat_sigma C}
   {Γ Δ : C} (s : Δ --> Γ) (A : comp_cat_ty Γ) (B : comp_cat_ty (Γ & A))
-  (sA  := comp_cat_ext_subst s A)
-  (sAB := comp_cat_ext_subst sA B)
-  (i := comp_cat_sigma_sub_iso s A B)
-  : comp_cat_sigma_pair (A [[ s ]]) (B [[ sA ]]) ·
-      comp_cat_comp_mor (C:=C) (Γ:=Δ) (inv_from_z_iso i : _ -->[ identity _ ] _) ·
+  : comp_cat_sigma_pair (A [[ s ]]) (B [[ (comp_cat_ext_subst s A ) ]]) ·
+      comp_cat_comp_mor (inv_from_z_iso (comp_cat_sigma_sub_iso _ _ _ )) ·
       comp_cat_ext_subst s ((pr1 Σ) Γ A B)
-    = sAB · comp_cat_sigma_pair A B
+    = comp_cat_ext_subst (comp_cat_ext_subst _ _) B
+        · comp_cat_sigma_pair A B
   := pr2 (pr222 (pr222 Σ)) Γ Δ s A B.
 
 Definition comp_cat_sigma_pair_proj_iso
@@ -216,6 +212,151 @@ Lemma comp_cat_sigma_proj_law
 Proof.
   apply comp_cat_sigma_proj_1_law.
 Qed.
+
+(** Useful isomorphisms for Sigma  *)
+
+
+Definition comp_cat_sigma_iso_2
+  {C : comp_cat} {Sig : comp_cat_sigma C}
+  {Γ : C} {A : comp_cat_ty Γ} {B B' : comp_cat_ty (Γ & A)}
+  (i : z_iso ((Γ & A) & B) ((Γ & A) & B'))
+  : z_iso (Γ & (pr1 Sig) Γ A B) (Γ & (pr1 Sig) Γ A B')
+  := z_iso_comp (comp_cat_sigma_pair_proj_iso A B)
+       (z_iso_comp i
+          (z_iso_inv (comp_cat_sigma_pair_proj_iso A B'))).
+
+Definition comp_cat_sigma_iso_1
+  {C : comp_cat} {Sig : comp_cat_sigma C}
+  {Γ : C} {A A' : comp_cat_ty Γ} {B : comp_cat_ty (Γ & A)}
+  (i : z_iso (Γ & A) (Γ & A'))
+  : z_iso (Γ & (pr1 Sig) Γ A B)
+      (Γ & (pr1 Sig) Γ A' (B [[ inv_from_z_iso i ]]))
+  := z_iso_comp (comp_cat_sigma_pair_proj_iso A B)
+       (z_iso_comp
+          (z_iso_inv (comp_cat_ext_subst_z_iso (z_iso_inv i) B))
+          (z_iso_inv (comp_cat_sigma_pair_proj_iso A' _))).
+
+Lemma comp_cat_sigma_iso_2_id
+  {C : comp_cat} {Sig : comp_cat_sigma C} {Γ : C}
+  (A : comp_cat_ty Γ) (B : comp_cat_ty (Γ & A))
+  : comp_cat_sigma_iso_2 (Sig:=Sig) (identity_z_iso ((Γ & A) & B))
+    = identity_z_iso (Γ & (pr1 Sig) Γ A B).
+Proof.
+  use z_iso_eq.
+  cbn.
+  rewrite id_left.
+  apply comp_cat_sigma_eta.
+Qed.
+
+Lemma comp_cat_sigma_iso_2_comp
+  {C : comp_cat} {Sig : comp_cat_sigma C} {Γ : C}
+  {A : comp_cat_ty Γ} {B B' B'' : comp_cat_ty (Γ & A)}
+  (i : z_iso ((Γ & A) & B) ((Γ & A) & B'))
+  (i' : z_iso ((Γ & A) & B') ((Γ & A) & B''))
+  : comp_cat_sigma_iso_2 (Sig:=Sig) (z_iso_comp i i')
+    = z_iso_comp (comp_cat_sigma_iso_2 i) (comp_cat_sigma_iso_2 i').
+Proof.
+  use z_iso_eq.
+  cbn.
+  rewrite !assoc'.
+  do 2 apply maponpaths.
+  refine (!_).
+  rewrite assoc.
+  rewrite comp_cat_sigma_beta.
+  apply id_left.
+Qed.
+
+Lemma comp_cat_sigma_iso_2_comp'
+  {C : comp_cat} {Sig : comp_cat_sigma C} {Γ : C}
+  {A : comp_cat_ty Γ} {B B' B'' : comp_cat_ty (Γ & A)}
+  (i : z_iso ((Γ & A) & B) ((Γ & A) & B'))
+  (i' : z_iso ((Γ & A) & B') ((Γ & A) & B''))
+  : morphism_from_z_iso _ _ (comp_cat_sigma_iso_2 (Sig:=Sig) (z_iso_comp i i'))
+    = (comp_cat_sigma_iso_2 i) · (comp_cat_sigma_iso_2 i').
+Proof.
+  rewrite comp_cat_sigma_iso_2_comp.
+  apply idpath.
+Qed.
+
+Lemma comp_cat_sigma_iso_2_proj
+  {C : comp_cat} {Sig : comp_cat_sigma C}
+  {Γ : C} {A : comp_cat_ty Γ} {B B' : comp_cat_ty (Γ & A)}
+  (i : z_iso ((Γ & A) & B) ((Γ & A) & B'))
+  (p : i · π B' = π B)
+  : comp_cat_sigma_iso_2 (Sig:=Sig) i · comp_cat_sigma_proj_1 A B'
+    = comp_cat_sigma_proj_1 A B.
+Proof.
+  unfold comp_cat_sigma_proj_1.
+  cbn.
+  rewrite !assoc'.
+  apply maponpaths.
+  etrans.
+  { apply maponpaths.
+    etrans. { apply assoc. }
+    etrans. { apply maponpaths_2. apply comp_cat_sigma_beta. }
+    apply id_left. }
+  exact p.
+Qed.
+
+Lemma comp_cat_sigma_iso_1_proj
+  {C : comp_cat} {Sig : comp_cat_sigma C}
+  {Γ : C} {A A' : comp_cat_ty Γ} {B : comp_cat_ty (Γ & A)}
+  (i : z_iso (Γ & A) (Γ & A'))
+  : comp_cat_sigma_iso_1 (Sig:=Sig) i
+      · comp_cat_sigma_proj_1 A' (B [[ inv_from_z_iso i ]])
+    = comp_cat_sigma_proj_1 A B · i.
+Proof.
+  unfold comp_cat_sigma_proj_1.
+  cbn.
+  rewrite !assoc'.
+  apply maponpaths.
+  etrans.
+  { apply maponpaths.
+    etrans. { apply assoc. }
+    etrans. { apply maponpaths_2. apply comp_cat_sigma_beta. }
+    apply id_left. }
+  exact (PullbackArrow_PullbackPr2 (comp_cat_pullback _ _) _ _ _ _).
+Qed.
+
+Definition comp_cat_sigma_assoc
+  {C : comp_cat} {Σ : comp_cat_sigma C} {Γ : C}
+  (A : comp_cat_ty Γ)
+  (B : comp_cat_ty (Γ & A))
+  (D : comp_cat_ty ((Γ & A) & B))
+  : z_iso
+      (Γ & ((pr1 Σ) Γ ((pr1 Σ) Γ A B) (D [[ comp_cat_sigma_proj A B ]])))
+      (Γ & ((pr1 Σ) Γ A ((pr1 Σ) (Γ & A) B D))).
+Proof.
+  refine (z_iso_comp (comp_cat_sigma_pair_proj_iso _ _) _).
+  refine (z_iso_comp (comp_cat_ext_subst_z_iso
+                        (comp_cat_sigma_pair_proj_iso A B) D) _).
+  refine (z_iso_comp (z_iso_inv (comp_cat_sigma_pair_proj_iso B D)) _).
+  exact (z_iso_inv (comp_cat_sigma_pair_proj_iso A _)).
+Defined.
+
+Lemma comp_cat_sigma_assoc_proj_1
+  {C : comp_cat} {Σ : comp_cat_sigma C} {Γ : C}
+  (A : comp_cat_ty Γ) (B : comp_cat_ty (Γ & A)) (D : comp_cat_ty ((Γ & A) & B))
+  : comp_cat_sigma_assoc A B D
+      · comp_cat_sigma_proj_1 A ((pr1 Σ) (Γ & A) B D)
+    = comp_cat_sigma_proj_1 ((pr1 Σ) Γ A B) (D [[ comp_cat_sigma_proj A B ]])
+        · comp_cat_sigma_proj_1 A B.
+Proof.
+  unfold comp_cat_sigma_assoc, comp_cat_sigma_proj_1.
+  cbn.
+  rewrite !assoc'.
+  apply maponpaths.
+  etrans.
+  { do 2 apply maponpaths.
+    etrans. { apply assoc. }
+    etrans. { apply maponpaths_2. apply comp_cat_sigma_beta. }
+    apply id_left. }
+  rewrite comp_cat_sigma_pair_π.
+  rewrite assoc.
+  rewrite comp_cat_ext_subst_commute.
+  apply assoc'.
+Qed.
+
 
 (** * 2. Pi-types for comprehension categories *)
 
@@ -277,9 +418,7 @@ Section Pi_For_Comp_Cat.
     ∏ (Γ Δ : C) (s : Δ --> Γ)
       (A : comp_cat_ty Γ) (B : comp_cat_ty (Γ & A))
       (b : comp_cat_tm B),
-      let sA := comp_cat_ext_subst s A in
-      let i  := πiso Γ Δ s A B in
-      lam Δ (A [[ s ]]) (B [[ sA ]]) (b [[ sA ]]tm) ↑ inv_from_z_iso i
+      lam Δ (A [[ s ]]) (B [[ (comp_cat_ext_subst s A ) ]]) (b [[ (comp_cat_ext_subst s A ) ]]tm) ↑ inv_from_z_iso (πiso _ _ _ _ _)
       = (lam Γ A B b) [[ s ]]tm.
 
   Definition comp_cat_pi : UU :=
@@ -358,26 +497,7 @@ Section Unit_For_Comp_Cat.
   Definition unit_intro_data (One : unit_form) : UU :=
     ∏ (Γ : C), comp_cat_tm (One Γ).
 
-  (* Elimination *)
-  Definition unit_elim_data
-    (One : unit_form)
-    (tt  : unit_intro_data One) : UU :=
-    ∏ (Γ : C)
-      (Cty : comp_cat_ty (Γ & (One Γ)))
-      (c   : comp_cat_tm (Cty [[ tt Γ ]])),
-      comp_cat_tm Cty.
-
-  (* Computation rule *)
-  Definition unit_comp_law
-    (One : unit_form)
-    (tt  : unit_intro_data One)
-    (ind : unit_elim_data One tt) : UU :=
-    ∏ (Γ : C)
-      (Cty : comp_cat_ty (Γ & (One Γ)))
-      (c   : comp_cat_tm (Cty [[ tt Γ ]])),
-      ind Γ Cty c [[ tt Γ ]]tm = c.
-
-  (* Uniqueness of the introduction term *)
+  (* Uniqueness of tt *)
   Definition unit_uniqueness
     (One : unit_form)
     (tt  : unit_intro_data One) : UU :=
@@ -388,57 +508,11 @@ Section Unit_For_Comp_Cat.
     ∏ (Γ Δ : C) (s : Γ --> Δ),
       z_iso (C := fiber_category _ _) ((One Δ) [[ s ]]) (One Γ).
 
-  (* Stability of tt under reindexing *)
-  Definition unit_sub_tt
-    (One   : unit_form)
-    (tt    : unit_intro_data One)
-    (uiso  : unit_sub_iso One) : UU :=
-    ∏ (Γ Δ : C) (s : Γ --> Δ),
-      tt Δ [[ s ]]tm · comp_cat_comp_mor (⌈uiso Γ Δ s⌉) = tt Γ.
-
-  (* Helper: tt commutes with extended substitution *)
-  Lemma unit_tt_ext_path
-    (One    : unit_form)
-    (tt     : unit_intro_data One)
-    (uiso   : unit_sub_iso One)
-    (usubtt : unit_sub_tt One tt uiso)
-    {Γ Δ : C} (s : Γ --> Δ)
-    : s · tt Δ =
-        tt Γ · comp_cat_comp_mor (⌈uiso Γ Δ s⌉⁻¹) · comp_cat_ext_subst s (One Δ).
-  Proof.
-    rewrite <- (comp_cat_ext_subst_term_commute s (One Δ) (tt Δ)).
-    apply cancel_postcomposition.
-    rewrite <- (usubtt _ _ s).
-    rewrite assoc'.
-    rewrite (comp_cat_comp_mor_z_iso_inv_after_z_iso (uiso Γ Δ s)).
-    rewrite id_right.
-    apply idpath.
-  Defined.
-
-  (* Stability of the eliminator under reindexing *)
-  Definition unit_sub_elim
-    (One    : unit_form)
-    (tt     : unit_intro_data One)
-    (ind    : unit_elim_data One tt)
-    (uiso   : unit_sub_iso One)
-    (usubtt : unit_sub_tt One tt uiso) : UU :=
-    ∏ (Γ Δ : C) (s : Γ --> Δ)
-      (Cty : comp_cat_ty (Δ & (One Δ)))
-      (d   : comp_cat_tm (Cty [[ tt Δ ]])),
-      let s1       := comp_cat_comp_mor (⌈uiso Γ Δ s⌉⁻¹) · comp_cat_ext_subst s (One Δ) in
-      let p        := pathscomp0 (unit_tt_ext_path One tt uiso usubtt s) (! assoc (tt Γ) _ _) in
-      let icompiso := comp_cat_subst_ty_eq_comp_iso Cty p in
-      ind Δ Cty d [[ s1 ]]tm = ind Γ (Cty [[ s1 ]]) (d [[ s ]]tm ↑ ⌈icompiso⌉).
-
   Definition comp_cat_unit : UU :=
     ∑ (One    : unit_form),
       ∑ (tt     : unit_intro_data One),
-      ∑ (ind    : unit_elim_data One tt),
-      ∑ (comp   : unit_comp_law One tt ind),
       ∑ (uniq   : unit_uniqueness One tt),
-      ∑ (uiso   : unit_sub_iso One),
-      ∑ (usubtt : unit_sub_tt One tt uiso),
-      unit_sub_elim One tt ind uiso usubtt.
+      unit_sub_iso One.
 
   Coercion unit_ty_from_unit (Unit : comp_cat_unit) : unit_form := pr1 Unit.
 
@@ -452,51 +526,113 @@ Definition comp_cat_unit_tt
   : comp_cat_tm ((pr1 Unit) Γ)
   := pr12 Unit Γ.
 
-Definition comp_cat_unit_ind
-  {C : comp_cat} {Unit : comp_cat_unit C}
-  {Γ : C} (Cty : comp_cat_ty (Γ & ((pr1 Unit) Γ)))
-  (c : comp_cat_tm (Cty [[ comp_cat_unit_tt Γ ]]))
-  : comp_cat_tm Cty
-  := pr122 Unit Γ Cty c.
-
-Definition comp_cat_unit_comp
-  {C : comp_cat} {Unit : comp_cat_unit C}
-  {Γ : C} (Cty : comp_cat_ty (Γ & ((pr1 Unit) Γ)))
-  (c : comp_cat_tm (Cty [[ comp_cat_unit_tt Γ ]]))
-  : comp_cat_unit_ind Cty c [[ comp_cat_unit_tt Γ ]]tm = c
-  := pr1 (pr222 Unit) Γ Cty c.
-
 Definition comp_cat_unit_unique
   {C : comp_cat} {Unit : comp_cat_unit C}
   {Γ : C} (u : comp_cat_tm ((pr1 Unit) Γ))
   : u = comp_cat_unit_tt Γ
-  := pr12 (pr222 Unit) Γ u.
+  := pr122 Unit Γ u.
 
 Definition comp_cat_unit_sub_iso
   {C : comp_cat} {Unit : comp_cat_unit C}
   {Γ Δ : C} (s : Γ --> Δ)
   : z_iso (C := fiber_category _ _) (((pr1 Unit) Δ) [[ s ]]) ((pr1 Unit) Γ)
-  := pr1 (pr22 (pr222 Unit)) Γ Δ s.
+  := pr222 Unit Γ Δ s.
+
+(** deriving elimination, computation and stabilities under substitution  *)
+
+Definition comp_cat_tt_is_iso
+  {C : comp_cat} {Unit : comp_cat_unit C}
+  (Γ : C):
+  π _ · comp_cat_unit_tt (Unit:=Unit) Γ = identity _.
+Proof.
+  use comp_cat_mor_into_ext_eq.
+  - abstract (rewrite assoc';
+              etrans; [ apply maponpaths; apply (pr2 (comp_cat_unit_tt Γ)) | ];
+              rewrite id_right, id_left;
+              apply idpath).
+  - use (iscontr_tm_of_iso _ (z_iso_inv (comp_cat_unit_sub_iso _))).
+    use tpair.
+    + exact (comp_cat_unit_tt (Γ & (pr1 Unit) Γ)).
+    + intro u. exact (comp_cat_unit_unique u).
+Qed.
+
+Definition comp_cat_unit_unique_mor
+  {C : comp_cat} {Unit : comp_cat_unit C}
+  {Γ : C} (u : Γ --> Γ & _)
+  ( p : u · π _ = identity _)
+  : u = comp_cat_unit_tt (Unit:=Unit) Γ
+  := maponpaths pr1 (comp_cat_unit_unique (u ,, p)).
+
+Definition comp_cat_unit_ind
+  {C : comp_cat} {Unit : comp_cat_unit C}
+  {Γ : C} (Cty : comp_cat_ty (Γ & ((pr1 Unit) Γ)))
+  (c : comp_cat_tm (Cty [[ comp_cat_unit_tt Γ ]]))
+  : comp_cat_tm Cty.
+Proof.
+  use make_comp_cat_tm.
+  - exact (π _ · c · comp_cat_ext_subst (comp_cat_unit_tt _) Cty).
+  - abstract (rewrite assoc';
+              rewrite comp_cat_ext_subst_commute;
+              rewrite assoc;
+              rewrite assoc4;
+              etrans; [ apply maponpaths_2; apply maponpaths; apply (pr2 c) | ];
+              rewrite id_right;
+              apply comp_cat_tt_is_iso).
+Defined.
+
+Definition comp_cat_unit_comp
+  {C : comp_cat} {Unit : comp_cat_unit C}
+  {Γ : C} (Cty : comp_cat_ty (Γ & ((pr1 Unit) Γ)))
+  (c : comp_cat_tm (Cty [[ comp_cat_unit_tt Γ ]]))
+  : comp_cat_unit_ind Cty c [[ comp_cat_unit_tt Γ ]]tm = c.
+Proof.
+  use comp_cat_tm_eq.
+  refine (!_).
+  use (PullbackArrowUnique _ (isPullback_Pullback (comp_cat_pullback _ _))).
+  - unfold comp_cat_unit_ind.
+    simpl.
+    rewrite !assoc.
+    etrans.
+    2: { do 2  apply maponpaths_2.
+         refine (!_).
+         apply (pr2 (comp_cat_unit_tt Γ)). }
+    rewrite id_left.
+    apply idpath.
+  - apply (pr2 c).
+Qed. 
 
 Definition comp_cat_unit_sub_tt
   {C : comp_cat} {Unit : comp_cat_unit C}
   {Γ Δ : C} (s : Γ --> Δ)
-  : comp_cat_unit_tt Δ [[ s ]]tm · comp_cat_comp_mor (⌈comp_cat_unit_sub_iso s⌉) =
-      comp_cat_unit_tt Γ
-  := pr1 (pr222 (pr222 Unit)) Γ Δ s.
+  : comp_cat_unit_tt (Unit:=Unit) Δ [[ s ]]tm · comp_cat_comp_mor (⌈comp_cat_unit_sub_iso s⌉) =
+      comp_cat_unit_tt Γ.
+Proof.
+  refine (comp_cat_unit_unique_mor _ _).
+  rewrite assoc'.
+  rewrite comp_cat_comp_mor_law.
+  exact (pr2 ((comp_cat_unit_tt Δ) [[s]]tm)).
+Qed.
 
 Lemma comp_cat_unit_tt_ext_path
   {C : comp_cat} {Unit : comp_cat_unit C}
   {Γ Δ : C} (s : Γ --> Δ)
+  (ttΔ := comp_cat_unit_tt (Unit:= Unit) Δ)
+  (usubtt := comp_cat_unit_sub_tt (Unit:=Unit) s)
+  (uiso := comp_cat_unit_sub_iso (Unit:=Unit) s)
   : s · comp_cat_unit_tt Δ =
       comp_cat_unit_tt Γ
         · comp_cat_comp_mor (⌈comp_cat_unit_sub_iso (Unit := Unit) s⌉⁻¹)
         · comp_cat_ext_subst s ((pr1 Unit) Δ).
 Proof.
-  exact (unit_tt_ext_path C Unit (pr12 Unit)
-           (pr122 (pr222 Unit))
-           (pr1 (pr222 (pr222 Unit))) s).
-Defined.
+  etrans. { refine (!_). apply (comp_cat_ext_subst_term_commute s _ (ttΔ)). } 
+  apply cancel_postcomposition.
+  rewrite <- usubtt.
+  rewrite assoc'.
+  etrans. 2 : { refine (!_).
+                apply maponpaths. apply (comp_cat_comp_mor_z_iso_inv_after_z_iso uiso). }
+        rewrite id_right.
+  apply idpath.
+Qed.
 
 Definition comp_cat_unit_sub_elim
   {C : comp_cat} {Unit : comp_cat_unit C}
@@ -509,5 +645,44 @@ Definition comp_cat_unit_sub_elim
           (! assoc (comp_cat_unit_tt Γ) _ _))
   (icompiso := comp_cat_subst_ty_eq_comp_iso Cty p)
   : comp_cat_unit_ind Cty d [[ s1 ]]tm =
-      comp_cat_unit_ind (Cty [[ s1 ]]) (d [[ s ]]tm ↑ ⌈icompiso⌉)
-  := pr2 (pr222 (pr222 Unit)) Γ Δ s Cty d.
+      comp_cat_unit_ind (Cty [[ s1 ]]) (d [[ s ]]tm ↑ ⌈icompiso⌉).
+Proof.
+  unfold comp_cat_unit_ind.
+  use comp_cat_tm_eq.
+  refine (!_).
+  use (PullbackArrowUnique _ (isPullback_Pullback (comp_cat_pullback _ _))).
+  - cbn -[ "_ [[ _ ]]tm" comp_cat_ext_subst comp_cat_subst_ty_eq_comp_iso].  
+    unfold s1.
+    set (q := comp_cat_comp_mor (⌈comp_cat_unit_sub_iso s⌉⁻¹)
+                · comp_cat_ext_subst s (pr1 Unit Δ)).
+    change (comprehension_functor_mor q
+              (mor_disp_of_cartesian_lift _ _ (cleaving_of_types C _ _ q Cty)))
+      with (comp_cat_ext_subst q Cty).
+    rewrite assoc'.
+    rewrite <- (comp_cat_ext_subst_comp' Cty (comp_cat_unit_tt Γ) q).
+    unfold icompiso.
+    assert (h : q · π (pr1 Unit Δ) = π (pr1 Unit Γ) · s).
+    { unfold q.
+      rewrite assoc'.
+      etrans.
+      { apply maponpaths. apply comp_cat_ext_subst_commute. }
+      refine (assoc _ _ _ @ _).
+      apply maponpaths_2.
+      apply comp_cat_comp_mor_law. }
+    rewrite !assoc.
+    etrans.
+    2: { do 2 apply maponpaths_2. refine (!_). exact h. }
+    rewrite !assoc'.
+    apply maponpaths.
+    refine (_ @ ! comp_cat_extend_subst_subst s (comp_cat_unit_tt Δ) d).
+    rewrite !assoc.
+    rewrite assoc4.
+    rewrite <- comp_cat_comp_mor_comp'.
+    rewrite comp_cat_subst_ty_eq_comp_iso_comp.
+    rewrite comp_cat_comp_mor_comp'.
+    rewrite assoc.
+    refine (! comp_cat_extend_subst_eq p
+              (d [[s]]tm ↑ ⌈comp_cat_subst_ty_comp_iso Cty (comp_cat_unit_tt Δ) s⌉)).
+  - exact (pr2 (make_comp_cat_tm (π (pr1 Unit Γ) · d [[s ]]tm ↑ ⌈ icompiso ⌉ · comp_cat_ext_subst (comp_cat_unit_tt Γ) (Cty [[s1]]))
+                  (comp_cat_unit_ind_subproof C Unit Γ (Cty [[s1]]) (d [[s ]]tm ↑ ⌈ icompiso ⌉)))).
+Qed.

--- a/UniMath/CategoryTheory/ComprehensionCats/CompCatTypeFormers.v
+++ b/UniMath/CategoryTheory/ComprehensionCats/CompCatTypeFormers.v
@@ -521,7 +521,7 @@ End Unit_For_Comp_Cat.
 (** Accessors for comp_cat_unit *)
 
 Definition comp_cat_unit_tt
-  {C : comp_cat} {Unit : comp_cat_unit C}
+  {C : comp_cat} (Unit : comp_cat_unit C)
   (Γ : C)
   : comp_cat_tm ((pr1 Unit) Γ)
   := pr12 Unit Γ.
@@ -529,11 +529,11 @@ Definition comp_cat_unit_tt
 Definition comp_cat_unit_unique
   {C : comp_cat} {Unit : comp_cat_unit C}
   {Γ : C} (u : comp_cat_tm ((pr1 Unit) Γ))
-  : u = comp_cat_unit_tt Γ
+  : u = comp_cat_unit_tt _ Γ
   := pr122 Unit Γ u.
 
 Definition comp_cat_unit_sub_iso
-  {C : comp_cat} {Unit : comp_cat_unit C}
+  {C : comp_cat} (Unit : comp_cat_unit C)
   {Γ Δ : C} (s : Γ --> Δ)
   : z_iso (C := fiber_category _ _) (((pr1 Unit) Δ) [[ s ]]) ((pr1 Unit) Γ)
   := pr222 Unit Γ Δ s.
@@ -543,16 +543,16 @@ Definition comp_cat_unit_sub_iso
 Definition comp_cat_tt_is_iso
   {C : comp_cat} {Unit : comp_cat_unit C}
   (Γ : C):
-  π _ · comp_cat_unit_tt (Unit:=Unit) Γ = identity _.
+  π _ · comp_cat_unit_tt Unit Γ = identity _.
 Proof.
   use comp_cat_mor_into_ext_eq.
   - abstract (rewrite assoc';
-              etrans; [ apply maponpaths; apply (pr2 (comp_cat_unit_tt Γ)) | ];
+              etrans; [ apply maponpaths; apply (pr2 (comp_cat_unit_tt _ Γ)) | ];
               rewrite id_right, id_left;
               apply idpath).
-  - use (iscontr_tm_of_iso _ (z_iso_inv (comp_cat_unit_sub_iso _))).
+  - use (iscontr_tm_of_iso _ (z_iso_inv (comp_cat_unit_sub_iso _ _))).
     use tpair.
-    + exact (comp_cat_unit_tt (Γ & (pr1 Unit) Γ)).
+    + exact (comp_cat_unit_tt _ (Γ & (pr1 Unit) Γ)).
     + intro u. exact (comp_cat_unit_unique u).
 Qed.
 
@@ -560,17 +560,17 @@ Definition comp_cat_unit_unique_mor
   {C : comp_cat} {Unit : comp_cat_unit C}
   {Γ : C} (u : Γ --> Γ & _)
   ( p : u · π _ = identity _)
-  : u = comp_cat_unit_tt (Unit:=Unit) Γ
+  : u = comp_cat_unit_tt Unit Γ
   := maponpaths pr1 (comp_cat_unit_unique (u ,, p)).
 
 Definition comp_cat_unit_ind
   {C : comp_cat} {Unit : comp_cat_unit C}
   {Γ : C} (Cty : comp_cat_ty (Γ & ((pr1 Unit) Γ)))
-  (c : comp_cat_tm (Cty [[ comp_cat_unit_tt Γ ]]))
+  (c : comp_cat_tm (Cty [[ comp_cat_unit_tt _ Γ ]]))
   : comp_cat_tm Cty.
 Proof.
   use make_comp_cat_tm.
-  - exact (π _ · c · comp_cat_ext_subst (comp_cat_unit_tt _) Cty).
+  - exact (π _ · c · comp_cat_ext_subst (comp_cat_unit_tt _ _) Cty).
   - abstract (rewrite assoc';
               rewrite comp_cat_ext_subst_commute;
               rewrite assoc;
@@ -583,8 +583,8 @@ Defined.
 Definition comp_cat_unit_comp
   {C : comp_cat} {Unit : comp_cat_unit C}
   {Γ : C} (Cty : comp_cat_ty (Γ & ((pr1 Unit) Γ)))
-  (c : comp_cat_tm (Cty [[ comp_cat_unit_tt Γ ]]))
-  : comp_cat_unit_ind Cty c [[ comp_cat_unit_tt Γ ]]tm = c.
+  (c : comp_cat_tm (Cty [[ comp_cat_unit_tt _ Γ ]]))
+  : comp_cat_unit_ind Cty c [[ comp_cat_unit_tt _ Γ ]]tm = c.
 Proof.
   use comp_cat_tm_eq.
   refine (!_).
@@ -595,36 +595,36 @@ Proof.
     etrans.
     2: { do 2  apply maponpaths_2.
          refine (!_).
-         apply (pr2 (comp_cat_unit_tt Γ)). }
+         apply (pr2 (comp_cat_unit_tt _ Γ)). }
     rewrite id_left.
     apply idpath.
   - apply (pr2 c).
-Qed. 
+Qed.
 
 Definition comp_cat_unit_sub_tt
-  {C : comp_cat} {Unit : comp_cat_unit C}
+  {C : comp_cat} (Unit : comp_cat_unit C)
   {Γ Δ : C} (s : Γ --> Δ)
-  : comp_cat_unit_tt (Unit:=Unit) Δ [[ s ]]tm · comp_cat_comp_mor (⌈comp_cat_unit_sub_iso s⌉) =
-      comp_cat_unit_tt Γ.
+  : comp_cat_unit_tt Unit Δ [[ s ]]tm · comp_cat_comp_mor (⌈comp_cat_unit_sub_iso _ s⌉) =
+      comp_cat_unit_tt _ Γ.
 Proof.
   refine (comp_cat_unit_unique_mor _ _).
   rewrite assoc'.
   rewrite comp_cat_comp_mor_law.
-  exact (pr2 ((comp_cat_unit_tt Δ) [[s]]tm)).
+  exact (pr2 ((comp_cat_unit_tt _ Δ) [[s]]tm)).
 Qed.
 
 Lemma comp_cat_unit_tt_ext_path
   {C : comp_cat} {Unit : comp_cat_unit C}
   {Γ Δ : C} (s : Γ --> Δ)
-  (ttΔ := comp_cat_unit_tt (Unit:= Unit) Δ)
-  (usubtt := comp_cat_unit_sub_tt (Unit:=Unit) s)
-  (uiso := comp_cat_unit_sub_iso (Unit:=Unit) s)
-  : s · comp_cat_unit_tt Δ =
-      comp_cat_unit_tt Γ
-        · comp_cat_comp_mor (⌈comp_cat_unit_sub_iso (Unit := Unit) s⌉⁻¹)
+  (ttΔ := comp_cat_unit_tt Unit Δ)
+  (usubtt := comp_cat_unit_sub_tt Unit s)
+  (uiso := comp_cat_unit_sub_iso Unit s)
+  : s · comp_cat_unit_tt _ Δ =
+      comp_cat_unit_tt _ Γ
+        · comp_cat_comp_mor (⌈comp_cat_unit_sub_iso Unit s⌉⁻¹)
         · comp_cat_ext_subst s ((pr1 Unit) Δ).
 Proof.
-  etrans. { refine (!_). apply (comp_cat_ext_subst_term_commute s _ (ttΔ)). } 
+  etrans. { refine (!_). apply (comp_cat_ext_subst_term_commute s _ (ttΔ)). }
   apply cancel_postcomposition.
   rewrite <- usubtt.
   rewrite assoc'.
@@ -638,11 +638,11 @@ Definition comp_cat_unit_sub_elim
   {C : comp_cat} {Unit : comp_cat_unit C}
   {Γ Δ : C} (s : Γ --> Δ)
   (Cty : comp_cat_ty (Δ & ((pr1 Unit) Δ)))
-  (d : comp_cat_tm (Cty [[ comp_cat_unit_tt Δ ]]))
-  (s1 := comp_cat_comp_mor (⌈comp_cat_unit_sub_iso s⌉⁻¹)
+  (d : comp_cat_tm (Cty [[ comp_cat_unit_tt _ Δ ]]))
+  (s1 := comp_cat_comp_mor (⌈comp_cat_unit_sub_iso _ s⌉⁻¹)
            · comp_cat_ext_subst s ((pr1 Unit) Δ))
   (p := pathscomp0 (comp_cat_unit_tt_ext_path s)
-          (! assoc (comp_cat_unit_tt Γ) _ _))
+          (! assoc (comp_cat_unit_tt _ Γ) _ _))
   (icompiso := comp_cat_subst_ty_eq_comp_iso Cty p)
   : comp_cat_unit_ind Cty d [[ s1 ]]tm =
       comp_cat_unit_ind (Cty [[ s1 ]]) (d [[ s ]]tm ↑ ⌈icompiso⌉).
@@ -651,15 +651,15 @@ Proof.
   use comp_cat_tm_eq.
   refine (!_).
   use (PullbackArrowUnique _ (isPullback_Pullback (comp_cat_pullback _ _))).
-  - cbn -[ "_ [[ _ ]]tm" comp_cat_ext_subst comp_cat_subst_ty_eq_comp_iso].  
+  - cbn -[ "_ [[ _ ]]tm" comp_cat_ext_subst comp_cat_subst_ty_eq_comp_iso].
     unfold s1.
-    set (q := comp_cat_comp_mor (⌈comp_cat_unit_sub_iso s⌉⁻¹)
+    set (q := comp_cat_comp_mor (⌈comp_cat_unit_sub_iso _ s⌉⁻¹)
                 · comp_cat_ext_subst s (pr1 Unit Δ)).
     change (comprehension_functor_mor q
               (mor_disp_of_cartesian_lift _ _ (cleaving_of_types C _ _ q Cty)))
       with (comp_cat_ext_subst q Cty).
     rewrite assoc'.
-    rewrite <- (comp_cat_ext_subst_comp' Cty (comp_cat_unit_tt Γ) q).
+    rewrite <- (comp_cat_ext_subst_comp' Cty (comp_cat_unit_tt _ Γ) q).
     unfold icompiso.
     assert (h : q · π (pr1 Unit Δ) = π (pr1 Unit Γ) · s).
     { unfold q.
@@ -674,7 +674,7 @@ Proof.
     2: { do 2 apply maponpaths_2. refine (!_). exact h. }
     rewrite !assoc'.
     apply maponpaths.
-    refine (_ @ ! comp_cat_extend_subst_subst s (comp_cat_unit_tt Δ) d).
+    refine (_ @ ! comp_cat_extend_subst_subst s (comp_cat_unit_tt _ Δ) d).
     rewrite !assoc.
     rewrite assoc4.
     rewrite <- comp_cat_comp_mor_comp'.
@@ -682,7 +682,7 @@ Proof.
     rewrite comp_cat_comp_mor_comp'.
     rewrite assoc.
     refine (! comp_cat_extend_subst_eq p
-              (d [[s]]tm ↑ ⌈comp_cat_subst_ty_comp_iso Cty (comp_cat_unit_tt Δ) s⌉)).
-  - exact (pr2 (make_comp_cat_tm (π (pr1 Unit Γ) · d [[s ]]tm ↑ ⌈ icompiso ⌉ · comp_cat_ext_subst (comp_cat_unit_tt Γ) (Cty [[s1]]))
+              (d [[s]]tm ↑ ⌈comp_cat_subst_ty_comp_iso Cty (comp_cat_unit_tt _ Δ) s⌉)).
+  - exact (pr2 (make_comp_cat_tm (π (pr1 Unit Γ) · d [[s ]]tm ↑ ⌈ icompiso ⌉ · comp_cat_ext_subst (comp_cat_unit_tt _ Γ) (Cty [[s1]]))
                   (comp_cat_unit_ind_subproof C Unit Γ (Cty [[s1]]) (d [[s ]]tm ↑ ⌈ icompiso ⌉)))).
 Qed.

--- a/UniMath/CategoryTheory/ComprehensionCats/CompCatUniverse.v
+++ b/UniMath/CategoryTheory/ComprehensionCats/CompCatUniverse.v
@@ -531,7 +531,7 @@ Section Universe_Unit_Closure.
       set (tΓ := TerminalArrow (empty_context C) Γ).
       refine (z_iso_comp (z_iso_inv (comp_cat_el_iso tΓ (comp_cat_unit_code UnitU))) _).
       refine (z_iso_comp (comp_cat_reindex_iso tΓ (comp_cat_unit_el_iso UnitU)) _).
-      exact (comp_cat_unit_sub_iso tΓ).
+      exact (comp_cat_unit_sub_iso _ _).
     Defined.
 
     (* Reindexing commutes with unit codes *)
@@ -645,12 +645,12 @@ Section Universe_Unit_Closure.
       comp_cat_tm (comp_cat_el (comp_cat_unit_code_weakened UnitU Γ)).
     Proof.
       use tpair.
-      - exact ( (comp_cat_unit_tt Γ) ↑ ( ⌈ (comp_cat_unit_el_iso_w UnitU Γ) ⌉⁻¹ ) ).
+      - exact ( (comp_cat_unit_tt _ Γ) ↑ ( ⌈ (comp_cat_unit_el_iso_w UnitU Γ) ⌉⁻¹ ) ).
       - abstract(
             cbn;
             rewrite <- assoc;
             rewrite comp_cat_comp_mor_law;
-            exact (pr2 (comp_cat_unit_tt Γ))).
+            exact (pr2 (comp_cat_unit_tt _ Γ))).
     Defined.
 
     Lemma iscontr_tm_of_iso {Γ : C} {A B : comp_cat_ty Γ}
@@ -676,7 +676,7 @@ Section Universe_Unit_Closure.
       assert (HOneΓ : iscontr (comp_cat_tm ((pr1 Unit) Γ))).
       {
         use tpair.
-        - exact ( comp_cat_unit_tt Γ).
+        - exact ( comp_cat_unit_tt _ Γ).
         - intro u.
           exact (comp_cat_unit_unique u).
       }

--- a/UniMath/CategoryTheory/ComprehensionCats/CompCats.v
+++ b/UniMath/CategoryTheory/ComprehensionCats/CompCats.v
@@ -401,7 +401,7 @@ Proof.
   intros Γ Δ s A.
   exact (comprehension_functor_mor_comm  s
            (mor_disp_of_cartesian_lift _ _ (cleaving_of_types C _ _ s A))).
-Qed.
+Qed.  
 
 Lemma comp_cat_ext_subst_term_commute {C : comp_cat} {Γ Δ : C}
   (s : Γ --> Δ) (A : comp_cat_ty Δ) (t : comp_cat_tm A)
@@ -1032,7 +1032,6 @@ Proof.
                           · ⌈ idtoiso (C:=F) (comp_cat_subst_ty_eq A (assoc  s₁ s₂ s₃)) ⌉).
   etrans.
   2: { apply pr1_idtoiso_concat. }
-  Check comp_cat_subst_ty_eq.
   etrans.
   2: {
     do 2 apply maponpaths.
@@ -1071,6 +1070,49 @@ Proof.
     apply comp_cat_comp_mor_id.
   }
   exact (!id_left _).
+Qed.
+
+
+Definition comp_cat_ext_subst_z_iso
+  {C : comp_cat} {Γ Δ : C} (s : z_iso Δ Γ) (A : comp_cat_ty Γ)
+  : z_iso (Δ & (A [[ s ]])) (Γ & A).
+Proof.
+  use make_z_iso.
+  - exact (comp_cat_ext_subst s A).
+  - use (PullbackArrow (comp_cat_pullback A s)).
+    + exact (identity _).
+    + exact (π A · inv_from_z_iso s).
+    + abstract (rewrite id_left, assoc', z_iso_after_z_iso_inv, id_right;
+                apply idpath).
+  - split.
+    + use (MorphismsIntoPullbackEqual (isPullback_Pullback (comp_cat_pullback A s))).
+      * rewrite assoc'.
+        rewrite (PullbackArrow_PullbackPr1 (comp_cat_pullback A s)).
+        rewrite id_left, id_right.
+        apply idpath.
+      * rewrite assoc'.
+        rewrite (PullbackArrow_PullbackPr2 (comp_cat_pullback A s)).
+        rewrite assoc.
+        etrans. { apply maponpaths_2. apply comp_cat_ext_subst_commute. }
+        rewrite assoc'.
+        rewrite z_iso_inv_after_z_iso.
+        rewrite id_left, id_right.
+        apply idpath.
+    + exact (PullbackArrow_PullbackPr1 (comp_cat_pullback A s) _ _ _ _).
+Defined.
+
+
+Lemma iscontr_tm_of_iso {C: comp_cat} {Γ : C} {A B : comp_cat_ty Γ}
+  (HA : iscontr (comp_cat_tm A))
+  (i : z_iso (C := fiber_category _ _) A B)
+  : iscontr (comp_cat_tm B).
+Proof.
+  set (toB := (λ u : comp_cat_tm A, u ↑ ⌈ i ⌉)).
+  set (toA := (λ v : comp_cat_tm B, v ↑ ⌈ i ⌉⁻¹)).
+  assert (toB_toA : ∏ v : comp_cat_tm B, toB (toA v) = v) by apply coerce_tm_after_inv.
+  assert (toA_toB : ∏ u : comp_cat_tm A, toA (toB u) = u) by apply coerce_tm_inv_after.
+  set (w := weq_iso toB toA toA_toB toB_toA).
+  exact (iscontrweqf w HA).
 Qed.
 
 (** * Comprehension Structure ctd.  *)
@@ -1291,12 +1333,64 @@ Proof.
     apply (pr2 t).
 Qed.
 
+Lemma comp_cat_ext_subst_comp' {C: comp_cat} {Γ Δ Θ : C} (A : comp_cat_ty Θ)
+  (s₁ : Γ --> Δ) (s₂ : Δ --> Θ)
+  : comp_cat_comp_mor ( ⌈ comp_cat_subst_ty_comp_iso A s₂ s₁ ⌉ )
+      · comp_cat_ext_subst (s₁ · s₂) A
+    = comp_cat_ext_subst s₁ (A [[ s₂ ]]) · comp_cat_ext_subst s₂ A.
+Proof.
+  unfold comp_cat_comp_mor, comp_cat_ext_subst.
+  etrans.
+  { refine (!_). apply comprehension_functor_mor_comp. }
+  etrans.
+  { apply maponpaths. apply cartesian_factorisation_commutes. }
+  unfold transportb.
+  rewrite (comprehension_functor_mor_transportf (C := C)).
+  apply comprehension_functor_mor_comp.
+Qed.
+
+Lemma comp_cat_ext_subst_comp  {C: comp_cat}  {Γ Δ Θ : C} (A : comp_cat_ty Θ)
+  (s₁ : Γ --> Δ) (s₂ : Δ --> Θ)
+  : comp_cat_ext_subst (s₁ · s₂) A
+    = comp_cat_comp_mor (⌈comp_cat_subst_ty_comp_iso A s₂ s₁⌉⁻¹)
+        · comp_cat_ext_subst s₁ (A [[ s₂ ]]) · comp_cat_ext_subst s₂ A.
+Proof.
+  refine (! id_left _ @ _).
+  etrans.
+  { apply maponpaths_2.
+    refine (!_).
+    apply (comp_cat_comp_mor_z_iso_after_z_iso_inv
+             (comp_cat_subst_ty_comp_iso A s₂ s₁)). }
+  refine (assoc' _ _ _ @ _).
+  etrans.
+  { apply cancel_precomposition. apply comp_cat_ext_subst_comp'. }
+  apply assoc.
+Qed.
+
 (** * Extension of Substitution with Term   *)
 
 (*
   This section covers the rules sub-ext, sub-proj, sub-beta and sub-eta from
    From Semantics to Syntax: A Type Theory for Comprehension Categories
  *)
+
+Lemma comp_cat_var_subst_mor_eq
+  {C' : comp_cat} {Γ' Δ' : C'} {X : comp_cat_ty Γ'}
+  {σ σ' : Δ' --> Γ' & X} (e : σ = σ')
+  (r : σ · π X = σ' · π X)
+  : comp_cat_var X [[ σ ]]tm
+      ↑ ⌈ comp_cat_subst_ty_comp_iso X (π X) σ ⌉
+    = comp_cat_var X [[ σ' ]]tm
+        ↑ ⌈ comp_cat_subst_ty_comp_iso X (π X) σ' ⌉
+        ↑ ⌈ comp_cat_subst_ty_iso X r ⌉⁻¹.
+Proof.
+  induction e.
+  assert (H : r = idpath _) by apply homset_property.
+  rewrite H.
+  refine (!_).
+  apply comp_cat_id_coerce_tm.
+Qed.
+
 
 Definition comp_cat_extend_subst
   {C : comp_cat} {Γ Δ : C} {A : comp_cat_ty Γ}
@@ -1349,26 +1443,88 @@ Definition comp_cat_extend_subst_eta
   : comp_cat_extend_subst (s · π _) (comp_cat_tm_from_extend_subst s) = s.
 Proof.
   unfold comp_cat_extend_subst, comp_cat_tm_from_extend_subst.
-  assert (H : comp_cat_comp_mor ( ⌈comp_cat_subst_ty_comp_iso A (π A) s⌉ )
-                · comp_cat_ext_subst (s · π A) A
-              = comp_cat_ext_subst s (A [[ π A ]]) · comp_cat_ext_subst (π A) A).
-  { unfold comp_cat_comp_mor, comp_cat_ext_subst.
-    etrans.
-    { refine (!_).
-      apply comprehension_functor_mor_comp. }
-    etrans.
-    { apply maponpaths.
-      apply cartesian_factorisation_commutes. }
-    unfold transportb.
-    rewrite (comprehension_functor_mor_transportf (C:=C)).
-    apply comprehension_functor_mor_comp. }
   etrans.
   { refine (assoc' _ _ _ @ _).
-    rewrite H.
+    rewrite comp_cat_ext_subst_comp'.
     rewrite assoc.
     rewrite (comp_cat_ext_subst_term_commute s (A [[ π A ]]) (comp_cat_var A)).
     rewrite assoc'.
     apply maponpaths.
     apply (PullbackArrow_PullbackPr1 (comp_cat_pullback A (π A))). }
   apply id_right.
+Qed.
+
+Lemma comp_cat_mor_into_ext_eq
+  {C : comp_cat} {Γ Δ : C} {A : comp_cat_ty Γ} (σ₁ σ₂ : Δ --> Γ & A)
+  (H : σ₁ · π A = σ₂ · π A)
+  (Hc : iscontr (comp_cat_tm (A [[ σ₂ · π A ]])))
+  : σ₁ = σ₂.
+Proof.
+  refine (! comp_cat_extend_subst_eta σ₁ @ _ @ comp_cat_extend_subst_eta σ₂).
+  unfold comp_cat_extend_subst.
+  etrans.
+  { apply maponpaths. apply (comp_cat_ext_subst_eq A H). }
+  refine (assoc _ _ _ @ _).
+  apply cancel_postcomposition.
+  refine (maponpaths pr1 (_ : _ ↑ ⌈comp_cat_subst_ty_iso A H⌉ = _)).
+  exact (pr2 Hc _ @ ! pr2 Hc _).
+Qed.
+
+
+Lemma comp_cat_extend_subst_subst
+  {C : comp_cat} {Γ Δ Θ : C} (r : Θ --> Γ) (σ : Γ --> Δ)
+  {A : comp_cat_ty Δ} (t : comp_cat_tm (A [[ σ ]]))
+  : r · comp_cat_extend_subst σ t
+    = comp_cat_extend_subst (r · σ)
+        (t [[ r ]]tm ↑ ⌈comp_cat_subst_ty_comp_iso A σ r⌉).
+Proof.
+  unfold comp_cat_extend_subst.
+  rewrite !assoc.
+  etrans.
+  2: { apply maponpaths.
+       refine (!_).
+       apply comp_cat_ext_subst_comp. }
+  rewrite !assoc.
+  apply maponpaths_2.
+  rewrite <- comp_cat_ext_subst_term_commute.
+  apply maponpaths_2.
+  unfold "_ ↑ _".
+  etrans. 2: { apply assoc. }
+        rewrite comp_cat_comp_mor_z_iso_inv_after_z_iso.
+  rewrite id_right.
+  apply idpath.
+Qed.
+
+Lemma comp_cat_subst_ty_eq_comp_iso_comp
+  {C : comp_cat} {Δ Γ₁ Γ₂ Θ : C} (A : comp_cat_ty Δ)
+  {s₁ : Γ₁ --> Δ} {s₂ : Θ --> Γ₁} {s₃ : Γ₂ --> Δ} {s₄ : Θ --> Γ₂}
+  (p : s₂ · s₁ = s₄ · s₃)
+  : ⌈comp_cat_subst_ty_eq_comp_iso A p⌉ · ⌈comp_cat_subst_ty_comp_iso A s₃ s₄⌉
+    = ⌈comp_cat_subst_ty_comp_iso A s₁ s₂⌉ · ⌈comp_cat_subst_ty_iso A p⌉.
+Proof.
+  unfold comp_cat_subst_ty_eq_comp_iso.
+  change (⌈z_iso_comp (comp_cat_subst_ty_comp_iso A s₁ s₂)
+            (z_iso_comp (comp_cat_subst_ty_iso A p)
+               (z_iso_inv (comp_cat_subst_ty_comp_iso A s₃ s₄)))⌉)
+    with (⌈comp_cat_subst_ty_comp_iso A s₁ s₂⌉
+            · (⌈comp_cat_subst_ty_iso A p⌉
+                 · ⌈comp_cat_subst_ty_comp_iso A s₃ s₄⌉⁻¹)).
+  rewrite !assoc'.
+  etrans. { do 2 apply maponpaths.
+            apply (z_iso_after_z_iso_inv (comp_cat_subst_ty_comp_iso A s₃ s₄)). }
+  rewrite id_right.
+  apply idpath.
+Qed.
+
+Lemma comp_cat_extend_subst_eq
+  {C : comp_cat} {Γ Δ : C} {A : comp_cat_ty Γ}
+  {s s' : Δ --> Γ} (p : s = s') (t : comp_cat_tm (A [[ s ]]))
+  : comp_cat_extend_subst s t
+    = comp_cat_extend_subst s' (t ↑ ⌈comp_cat_subst_ty_iso A p⌉).
+Proof.
+  induction p.
+  unfold comp_cat_extend_subst.
+  apply maponpaths_2.
+  refine (!_).
+  exact (maponpaths pr1 (comp_cat_id_coerce_tm t)).
 Qed.

--- a/UniMath/CategoryTheory/ComprehensionCats/CompCats.v
+++ b/UniMath/CategoryTheory/ComprehensionCats/CompCats.v
@@ -1470,7 +1470,6 @@ Proof.
   exact (pr2 Hc _ @ ! pr2 Hc _).
 Qed.
 
-
 Lemma comp_cat_extend_subst_subst
   {C : comp_cat} {Γ Δ Θ : C} (r : Θ --> Γ) (σ : Γ --> Δ)
   {A : comp_cat_ty Δ} (t : comp_cat_tm (A [[ σ ]]))

--- a/UniMath/CategoryTheory/ComprehensionCats/CompCats.v
+++ b/UniMath/CategoryTheory/ComprehensionCats/CompCats.v
@@ -401,7 +401,7 @@ Proof.
   intros Γ Δ s A.
   exact (comprehension_functor_mor_comm  s
            (mor_disp_of_cartesian_lift _ _ (cleaving_of_types C _ _ s A))).
-Qed.  
+Qed. 
 
 Lemma comp_cat_ext_subst_term_commute {C : comp_cat} {Γ Δ : C}
   (s : Γ --> Δ) (A : comp_cat_ty Δ) (t : comp_cat_tm A)

--- a/UniMath/CategoryTheory/ComprehensionCats/CompCats.v
+++ b/UniMath/CategoryTheory/ComprehensionCats/CompCats.v
@@ -401,7 +401,7 @@ Proof.
   intros Γ Δ s A.
   exact (comprehension_functor_mor_comm  s
            (mor_disp_of_cartesian_lift _ _ (cleaving_of_types C _ _ s A))).
-Qed. 
+Qed.
 
 Lemma comp_cat_ext_subst_term_commute {C : comp_cat} {Γ Δ : C}
   (s : Γ --> Δ) (A : comp_cat_ty Δ) (t : comp_cat_tm A)
@@ -1072,7 +1072,6 @@ Proof.
   exact (!id_left _).
 Qed.
 
-
 Definition comp_cat_ext_subst_z_iso
   {C : comp_cat} {Γ Δ : C} (s : z_iso Δ Γ) (A : comp_cat_ty Γ)
   : z_iso (Δ & (A [[ s ]])) (Γ & A).
@@ -1084,23 +1083,24 @@ Proof.
     + exact (π A · inv_from_z_iso s).
     + abstract (rewrite id_left, assoc', z_iso_after_z_iso_inv, id_right;
                 apply idpath).
-  - split.
-    + use (MorphismsIntoPullbackEqual (isPullback_Pullback (comp_cat_pullback A s))).
-      * rewrite assoc'.
-        rewrite (PullbackArrow_PullbackPr1 (comp_cat_pullback A s)).
-        rewrite id_left, id_right.
-        apply idpath.
-      * rewrite assoc'.
-        rewrite (PullbackArrow_PullbackPr2 (comp_cat_pullback A s)).
-        rewrite assoc.
-        etrans. { apply maponpaths_2. apply comp_cat_ext_subst_commute. }
-        rewrite assoc'.
-        rewrite z_iso_inv_after_z_iso.
-        rewrite id_left, id_right.
-        apply idpath.
-    + exact (PullbackArrow_PullbackPr1 (comp_cat_pullback A s) _ _ _ _).
+  - abstract (
+        split ;
+        [ use (MorphismsIntoPullbackEqual (isPullback_Pullback (comp_cat_pullback A s))) ;
+          [ rewrite assoc' ;
+            rewrite (PullbackArrow_PullbackPr1 (comp_cat_pullback A s)) ;
+            rewrite id_left, id_right ;
+            apply idpath
+          | rewrite assoc' ;
+            rewrite (PullbackArrow_PullbackPr2 (comp_cat_pullback A s)) ;
+            rewrite assoc ;
+            etrans ; [ apply maponpaths_2 ; apply comp_cat_ext_subst_commute | ] ;
+            rewrite assoc' ;
+            rewrite z_iso_inv_after_z_iso ;
+            rewrite id_left, id_right ;
+            apply idpath ]
+        | exact (PullbackArrow_PullbackPr1 (comp_cat_pullback A s) _ _ _ _) ]
+      ).
 Defined.
-
 
 Lemma iscontr_tm_of_iso {C: comp_cat} {Γ : C} {A B : comp_cat_ty Γ}
   (HA : iscontr (comp_cat_tm A))

--- a/UniMath/CategoryTheory/ComprehensionCats/CwfFromCompCatWithUniv.v
+++ b/UniMath/CategoryTheory/ComprehensionCats/CwfFromCompCatWithUniv.v
@@ -142,7 +142,7 @@ Section Construction.
           ((pr1 Unit) ([] & (comp_cat_el Γ)))
           ((comp_cat_el unit_code_w) [[ π (comp_cat_el Γ) ]]).
     Proof.
-      exact (z_iso_comp (z_iso_inv (comp_cat_unit_sub_iso _ ))
+      exact (z_iso_comp (z_iso_inv (comp_cat_unit_sub_iso _ _ ))
                (z_iso_inv (comp_cat_reindex_iso _ (comp_cat_unit_el_iso_w _ _ _ _)))).
     Defined.
 

--- a/UniMath/CategoryTheory/ComprehensionCats/CwfFromCompCatWithUniv.v
+++ b/UniMath/CategoryTheory/ComprehensionCats/CwfFromCompCatWithUniv.v
@@ -817,7 +817,6 @@ Section Construction.
         refine (!_).
         apply comp_cat_subst_ty_iso_comp.
       }
-      Check comp_cat_subst_ty_eq.
       unfold comp_cat_subst_ty_iso.
       etrans.
       2: {


### PR DESCRIPTION
Removes some redundant data from the definition of unit types in comprehension categories that @nmvdw has pointed out. 
Also adds some useful lemmas about comprehension categories and some refactoring of the file.