### PR TITLE
housekeeping: avoid warning about missing Proof command

### DIFF
--- a/UniMath/Algebra/GroupAction.v
+++ b/UniMath/Algebra/GroupAction.v
@@ -149,6 +149,7 @@ Proof.
 Defined.
 
 Local Goal ∏ G (X Y:Action G) (i : ActionIso X Y) (x:X), Y.
+Proof.
   intros.
   exact (i x).
 Qed.
@@ -685,10 +686,12 @@ Proof.
 Defined.
 
 Goal ∏ (G:gr), triviality_isomorphism (trivialTorsor G) (unel G) = idActionIso (trivialTorsor G).
+Proof.
   Fail reflexivity.
 Abort.
 
 Goal ∏ (G:gr), isBaseConnected_BG G (trivialTorsor G) = hinhpr (idpath (trivialTorsor G)).
+Proof.
   intros.
   unfold isBaseConnected_BG, pr2.
   change (pr1 (trivialTorsor G) : Type) with (G : Type).

--- a/UniMath/Algebra/Groups2.v
+++ b/UniMath/Algebra/Groups2.v
@@ -527,6 +527,7 @@ Section GrCosets.
   Defined.
 
   Definition in_same_left_coset_eqrel : eqrel X.
+  Proof.
     use make_eqrel.
     - exact in_same_left_coset_prop.
     - use iseqrelconstr.

--- a/UniMath/Algebra/Modules/Examples.v
+++ b/UniMath/Algebra/Modules/Examples.v
@@ -64,6 +64,7 @@ Example ring_left_mult {R : ring} : R → group_endomorphism_ring R :=
 (** A ring morphism R -> S defines an R-module structure on the additive abelian
     group of S *)
 Definition ringfun_module {R S : ring} (f : ringfun R S) : module R.
+Proof.
   apply (make_module (@ringaddabgr S)).
   apply (@mult_to_module_struct R S (λ x, (ringfun_left_mult f x : abelian_group_morphism _ _)));
     unfold funcomp, pr1, ringfun_left_mult.
@@ -115,6 +116,7 @@ Definition bimodule_struct' (R S : ring) (G : abgr) : UU :=
     ∏ (r : R) (s : S), mulr r ∘ muls s = muls s ∘ mulr r.
 
 Definition make_bimodule (R S : ring) {G} (str : bimodule_struct' R S G) : bimodule R S.
+Proof.
   refine (G,, _).
 
   (** Index the module structs over bool *)
@@ -133,6 +135,7 @@ Defined.
 
 (** A commutative ring is a bimodule over itself *)
 Example commring_bimodule (R : commring) : bimodule R R.
+Proof.
   apply (@make_bimodule R R (@ringaddabgr R)).
   unfold bimodule_struct'.
   refine (pr2module (ring_is_module R),, _).

--- a/UniMath/Algebra/Tests.v
+++ b/UniMath/Algebra/Tests.v
@@ -15,10 +15,10 @@ Module Test_assoc.
 
   Section Test.
     Context (X:UU) (e:X) (op:binop X) (w x y z:X).
-    Goal iterop_list e op [] = e. reflexivity. Qed.
-    Goal iterop_list e op (x::[]) = x. reflexivity. Qed.
-    Goal iterop_list e op (x::y::[]) = op x y. reflexivity. Qed.
-    Goal iterop_list e op (w::x::y::z::[]) = op w (op x (op y z)). reflexivity. Qed.
+    Goal iterop_list e op [] = e. Proof. reflexivity. Qed.
+    Goal iterop_list e op (x::[]) = x. Proof. reflexivity. Qed.
+    Goal iterop_list e op (x::y::[]) = op x y. Proof. reflexivity. Qed.
+    Goal iterop_list e op (w::x::y::z::[]) = op w (op x (op y z)). Proof. reflexivity. Qed.
   End Test.
 
   Local Open Scope stn.

--- a/UniMath/Algebra/Universal/Examples/Monoid.v
+++ b/UniMath/Algebra/Universal/Examples/Monoid.v
@@ -96,6 +96,7 @@ Proof.
 Defined.
 
 Definition make_monoid_eqalgebra : monoid_eqalgebra.
+Proof.
   use make_eqalgebra.
   - exact (monoid_algebra M).
   - exact is_eqalgebra_monoid.

--- a/UniMath/Bicategories/ComprehensionCat/Universes/Biequiv/CounitForUniv.v
+++ b/UniMath/Bicategories/ComprehensionCat/Universes/Biequiv/CounitForUniv.v
@@ -57,6 +57,7 @@ Definition dfl_comp_cat_to_finlim_disp_psfunctor_counit
          dfl_comp_cat_to_finlim_disp_psfunctor_universe
          finlim_to_dfl_comp_cat_disp_psfunctor_universe)
       finlim_dfl_comp_cat_counit.
+Proof.
   use make_disp_pstrans.
   - exact disp_2cells_isaprop_disp_bicat_dfl_full_comp_cat_with_univ.
   - exact disp_locally_groupoid_disp_bicat_dfl_full_comp_cat_with_univ.

--- a/UniMath/Bicategories/Core/Examples/BicategoryFromMonoidal.v
+++ b/UniMath/Bicategories/Core/Examples/BicategoryFromMonoidal.v
@@ -194,6 +194,7 @@ Definition prebicat_from_monoidal : prebicat :=
   prebicat_data_from_monoidal ,, prebicat_laws_from_monoidal.
 
 Definition bicat_from_monoidal : bicat.
+Proof.
   use build_bicategory.
   - exact prebicat_data_from_monoidal.
   - exact prebicat_laws_from_monoidal.

--- a/UniMath/Bicategories/Core/Examples/BicategoryFromWhiskeredMonoidal.v
+++ b/UniMath/Bicategories/Core/Examples/BicategoryFromWhiskeredMonoidal.v
@@ -152,6 +152,7 @@ Definition prebicat_from_monoidal : prebicat :=
   prebicat_data_from_monoidal ,, prebicat_laws_from_monoidal.
 
 Definition bicat_from_monoidal : bicat.
+Proof.
   use build_bicategory.
   - exact prebicat_data_from_monoidal.
   - exact prebicat_laws_from_monoidal.

--- a/UniMath/Bicategories/DisplayedBicats/Examples/Trivial.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/Trivial.v
@@ -62,6 +62,7 @@ Section Trivial_Displayed.
              (λ _ _ _ _ _ a b f g, f ==> g).
 
   Definition trivial_displayed_data : disp_prebicat_data B.
+  Proof.
     use (trivial_disp_prebicat_1_id_comp_cells,, _).
     repeat apply make_dirprod; cbn.
     - intros _ _ _. exact (λ a b f, id2 f).

--- a/UniMath/Bicategories/MonoidalCategories/Actions.v
+++ b/UniMath/Bicategories/MonoidalCategories/Actions.v
@@ -343,6 +343,7 @@ Proof.
 Qed.
 
 Definition U_action_ρ_nat_trans : odot_I_functor Mon_A otimes_U_functor ⟹ functor_identity Mon_A.
+Proof.
   refine (nat_trans_comp _ _ _ _  ρ_A).
   unfold odot_I_functor.
   set (aux := nat_trans_from_functor_fix_snd_morphism_arg _ _ _ tensor_A _ _ (strong_monoidal_functor_ϵ_inv U)).
@@ -582,6 +583,7 @@ Proof.
 Qed.
 
 Definition U_action : action Mon_A.
+Proof.
   exists otimes_U_functor.
   exists U_action_ρ.
   exists U_action_χ.

--- a/UniMath/CategoryTheory/Categories/HSET/Structures.v
+++ b/UniMath/CategoryTheory/Categories/HSET/Structures.v
@@ -309,6 +309,7 @@ Section kernel_pair_Set.
 
 
   Definition kernel_pair_HSET : kernel_pair f.
+  Proof.
     red.
     apply PullbacksHSET.
   Defined.

--- a/UniMath/CategoryTheory/Categories/PreorderCategory/Core.v
+++ b/UniMath/CategoryTheory/Categories/PreorderCategory/Core.v
@@ -108,6 +108,7 @@ Section PoCategory.
 
     Definition antisymm_po_univalent_category (PO : po X) (poasymm : isantisymm PO) :
       univalent_category.
+    Proof.
       use make_univalent_category.
       - exact (po_category PO).
       - apply po_category_is_univalent_iff_is_antisymm.

--- a/UniMath/CategoryTheory/Categories/StandardCategories.v
+++ b/UniMath/CategoryTheory/Categories/StandardCategories.v
@@ -39,6 +39,7 @@ Proof. intros. exact (compose f g). Defined.
 
 (** The pregroupoid with points in X as objects and paths as morphisms *)
 Definition path_pregroupoid (X:UU) (iobj : isofhlevel 3 X) : pregroupoid.
+Proof.
   use make_pregroupoid.
   - use tpair.
     {
@@ -210,6 +211,7 @@ Defined.
 Require Import UniMath.Combinatorics.StandardFiniteSets.
 
 Definition cat_n (n:nat): univalent_groupoid.
+Proof.
   apply path_groupoid_hset; use make_hSet.
   - exact (stn n).
   - apply isasetstn.

--- a/UniMath/CategoryTheory/DisplayedCats/Adjunctions.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Adjunctions.v
@@ -180,7 +180,8 @@ Section DispHomSetIso_from_Adjunction.
   Lemma homset_conj'_after_conj_inv {c : C} {c' : C'} {g : C⟦c, G c'⟧} {d : D c} (d' : D' c')
         (alpha : d -->[g] GG _ d') :
     transportf _ (φ_adj_after_φ_adj_inv A g)
-     (homset_conj' _ _ _ (homset_conj_inv g d d' alpha)) = alpha.
+      (homset_conj' _ _ _ (homset_conj_inv g d d' alpha)) = alpha.
+  Proof.
     unfold homset_conj_inv.
     cbn.
     set (eq := homset_conj'_natural_precomp (εε c' d') alpha).

--- a/UniMath/CategoryTheory/ExactCategories/ExactCategories.v
+++ b/UniMath/CategoryTheory/ExactCategories/ExactCategories.v
@@ -60,6 +60,7 @@ Section InvestigateNotations.
   Context (M : PreAdditive) (x y z:M) (f g : hom M x y) (h k : Hom_add M y z).
   Local Open Scope abgrcat.
   Goal empty.
+  Proof.
     set (Q := h+k).
     set (r := -g).
     set (t := f-g).

--- a/UniMath/CategoryTheory/ExactCategories/Tests.v
+++ b/UniMath/CategoryTheory/ExactCategories/Tests.v
@@ -55,19 +55,24 @@ Local Arguments isBinDirectSum {_ _ _ _}.
 Require Import UniMath.CategoryTheory.ExactCategories.ExactCategories.
 
 Goal ∏ (C:category) (a b:C) (f: a --> b), isMonic (C:=C) f = isEpi (C:=C^op) f.
+Proof.
   reflexivity.
 Defined.
 Goal ∏ (C:category) (a b:C) (f: a --> b), isEpi (C:=C) f = isMonic (C:=C^op) f.
+Proof.
   reflexivity.
 Defined.
 (** Here's why we prefer to use z_iso instead of iso : *)
 Goal ∏ (C:precategory) (a b:C) (f:z_iso a b), z_iso_inv (z_iso_inv f) = f.
+Proof.
   reflexivity.
 Defined.
 Goal ∏ (C:precategory) (a b:C) (f:z_iso (C:=C) a b), opp_z_iso (opp_z_iso f) = f.
+Proof.
   reflexivity.
 Defined.
 Goal ∏ (C:category) (a b:C) (f:z_iso (C:=C^op) b a), opp_z_iso (opp_z_iso f) = f.
+Proof.
   reflexivity.
 Defined.
 Goal ∏ (M : category) {X:Type} (j : X -> ob M),
@@ -80,9 +85,11 @@ Proof.
   reflexivity.
 Qed.
 Goal ∏ {M : category} (A B C:M) (f : A --> C) (g : B --> C), Pullback f g = Pushout (C:=M^op) f g.
+Proof.
   reflexivity.
 Defined.
 Goal ∏ {M : category} (A B C:M) (f : A --> C) (g : A --> C), Pushout f g = Pullback (C:=M^op) f g.
+Proof.
   reflexivity.
 Defined.
 Goal ∏ (M : precategoryWithBinOps), oppositePrecategoryWithBinOps (oppositePrecategoryWithBinOps M) = M.
@@ -119,9 +126,11 @@ Proof.
   reflexivity.
 Defined.
 Goal ∏ (M:PreAdditive) (A B:M) (AB : BinDirectSum A B), reverseBinDirectSum (oppositeBinDirectSum AB) = oppositeBinDirectSum (reverseBinDirectSum AB).
+Proof.
   reflexivity.
 Defined.
 Goal ∏ (M:PreAdditive) (A B:M) (AB : BinDirectSum A B), reverseBinDirectSum (reverseBinDirectSum AB) = AB.
+Proof.
   Fail reflexivity.
 Abort.
 
@@ -131,18 +140,18 @@ Local Definition Hom_add (C : PreAdditive) : ob C -> ob C -> abgr := λ c c', (@
 
 Section Sanity.
   Context (M : category) (x y:M) (f : hom M x y) (g : Hom M x y).
-  Goal Hom M x y. exact f. Defined.
-  Goal hom M x y. exact g. Defined.
+  Goal Hom M x y. Proof. exact f. Defined.
+  Goal hom M x y. Proof. exact g. Defined.
 End Sanity.
 
 Section Sanity2.
   Context (M : PreAdditive) (x y:M) (f : hom M x y) (g : Hom M x y) (h : Hom_add M x y).
-  Goal Hom_add M x y. exact f. Defined.
-  Goal Hom_add M x y. exact g. Defined.
-  Goal Hom M x y. exact f. Defined.
-  Goal Hom M x y. exact h. Defined.
-  Goal hom M x y. exact g. Defined.
-  Goal hom M x y. exact h. Defined.
+  Goal Hom_add M x y. Proof. exact f. Defined.
+  Goal Hom_add M x y. Proof. exact g. Defined.
+  Goal Hom M x y. Proof. exact f. Defined.
+  Goal Hom M x y. Proof. exact h. Defined.
+  Goal hom M x y. Proof. exact g. Defined.
+  Goal hom M x y. Proof. exact h. Defined.
 End Sanity2.
 
 Goal ∏ (M:precategory) (P:MorphismPair M), MorphismPair_opp (MorphismPair_opp P) = P.
@@ -150,6 +159,7 @@ Proof.
   reflexivity.
 Qed.
 Goal ∏ (M:category) (p:MorphismPair M^op), MorphismPair M.
+Proof.
   intros. exact (MorphismPair_opp p).
 Qed.
 Goal ∏ (M:category) (P Q : MorphismPair M^op) (f:MorphismPairIsomorphism P Q),
@@ -173,6 +183,7 @@ Proof.
   reflexivity.
 Qed.
 Goal ∏ (M:ExactCategoryData), oppositeExactCategoryData (oppositeExactCategoryData M) = M.
+Proof.
   reflexivity.
 Qed.
 Goal ∏ (M:ExactCategory), ExactCategoryDataToAdditiveCategory (ExactCategoryToData (oppositeExactCategory M))
@@ -204,15 +215,19 @@ Proof.
   reflexivity.
 Defined.
 Goal ∏ {M : ExactCategory} {A:M} (Z:Zero M), Mor1 (TrivialExactSequence A Z) = identity A.
+Proof.
   reflexivity.
 Qed.
 Goal ∏ {M : ExactCategory} {A:M} (Z:Zero M), Ob3 (TrivialExactSequence A Z) = Z.
+Proof.
   reflexivity.
 Qed.
 Goal ∏ {M : ExactCategory} {A:M} (Z:Zero M), Mor2 (TrivialExactSequence' Z A) = identity A.
+Proof.
   reflexivity.
 Qed.
 Goal ∏ {M : ExactCategory} {A:M} (Z:Zero M), Ob1 (TrivialExactSequence' Z A) = Z.
+Proof.
   reflexivity.
 Qed.
 Goal ∏ {M:ExactCategory} {X:Type} (j : X -> ob M) (ce : exts_lift M j),
@@ -241,6 +256,7 @@ Proof.
 Defined.
 
 Goal ∏ (M:category), oppositeCategory (oppositeCategory M) = M.
+Proof.
   reflexivity.
 Qed.
 
@@ -268,9 +284,11 @@ Proof.
   reflexivity.
 Defined.
 Goal ∏ (M:PreAdditive) (x y z : M) (f : x --> y) (g : y --> z), isKernel' (M:=M) f g = isCokernel' (M:=oppositePreAdditive M) g f.
+Proof.
   reflexivity.
 Defined.
 Goal ∏ (M:PreAdditive) (x y z : M) (f : x --> y) (g : y --> z), isCokernel' (M:=M) f g = isKernel' (M:=oppositePreAdditive M) g f.
+Proof.
   reflexivity.
 Defined.
 Goal ∏ (M :PreAdditive) (A B C A':M) (i : A <-- B) (p : B <-- C)

--- a/UniMath/CategoryTheory/Inductives/Lists.v
+++ b/UniMath/CategoryTheory/Inductives/Lists.v
@@ -247,13 +247,14 @@ Definition sum : List natHSET -> nat :=
 (* Eval vm_compute in sum testlistS. *)
 
 (* All of these compute *)
-Goal length _ (nil natHSET) = 0. reflexivity. Qed.
-Goal length _ testlist = length _ testlistS. reflexivity. Qed.
-Goal sum testlistS = sum testlist + length _ testlist. lazy. reflexivity. Qed.
-Goal length _ (concatenate _ testlist testlistS) = length _ testlist + length _ testlistS. reflexivity. Qed.
-Goal sum (concatenate _ testlist testlistS) = sum testlistS + sum testlist. reflexivity. Qed.
+Goal length _ (nil natHSET) = 0. Proof. reflexivity. Qed.
+Goal length _ testlist = length _ testlistS. Proof. reflexivity. Qed.
+Goal sum testlistS = sum testlist + length _ testlist. Proof. lazy. reflexivity. Qed.
+Goal length _ (concatenate _ testlist testlistS) = length _ testlist + length _ testlistS. Proof. reflexivity. Qed.
+Goal sum (concatenate _ testlist testlistS) = sum testlistS + sum testlist. Proof. reflexivity. Qed.
 
 Goal (∏ l, length _ (2 :: l) = S (length _ l)).
+Proof.
 simpl.
 intro l.
 try apply idpath. (* this doesn't work *)
@@ -341,7 +342,7 @@ Defined.
 (* Eval compute in (to_list _ testlist). *)
 
 (* This does compute: *)
-Goal to_list _ testlist = 2,,5,,2,,tt. reflexivity. Qed.
+Goal to_list _ testlist = 2,,5,,2,,tt. Proof. reflexivity. Qed.
 
 End list.
 
@@ -667,6 +668,7 @@ Definition sum : pr1 (List natHSET) -> nat :=
 (* Abort. *)
 
 Goal (∏ l, length _ (2 :: l) = S (length _ l)).
+Proof.
 simpl.
 intro l.
 try apply idpath. (* this doesn't work *)

--- a/UniMath/CategoryTheory/Inductives/PropositionalLogic.v
+++ b/UniMath/CategoryTheory/Inductives/PropositionalLogic.v
@@ -92,16 +92,19 @@ Definition PL : hSet := alg_carrier _ PL_alg.
 Definition PL_type : UU := pr1hSet PL.
 
 Definition PL_var : HSET⟦vars, PL⟧.
+Proof.
   refine (_ · alg_map _ PL_alg).
   intro v; do 4 apply inl; exact v.
 Defined.
 
 Definition PL_not : HSET⟦PL, PL⟧.
+Proof.
   refine (_ · alg_map _ PL_alg).
   intro s; do 3 apply inl; apply inr; exact s.
 Defined.
 
 Definition PL_and : HSET⟦PL ⊗ PL, PL⟧.
+Proof.
   refine (_ · alg_map _ PL_alg).
   intro s; do 2 apply inl; apply inr; exact s.
 Defined.
@@ -110,6 +113,7 @@ Definition PL_and_fun (x : PL_type) (y : PL_type) : PL_type :=
   PL_and (make_dirprod x y).
 
 Definition PL_or : HSET⟦PL ⊗ PL, PL⟧.
+Proof.
   refine (_ · alg_map _ PL_alg).
   intro s; do 1 apply inl; apply inr; exact s.
 Defined.
@@ -118,6 +122,7 @@ Definition PL_or_fun (x : PL_type) (y : PL_type) : PL_type :=
   PL_or (make_dirprod x y).
 
 Definition PL_impl : HSET⟦PL ⊗ PL, PL⟧.
+Proof.
   refine (_ · alg_map _ PL_alg).
   intro s; apply inr; exact s.
 Defined.

--- a/UniMath/CategoryTheory/Inductives/Trees.v
+++ b/UniMath/CategoryTheory/Inductives/Trees.v
@@ -254,4 +254,4 @@ Proof.
   - exact t.
 Defined.
 
-Goal Lists.sum (flatten _ testtree) = sum testtree. reflexivity. Qed.
+Goal Lists.sum (flatten _ testtree) = sum testtree. Proof. reflexivity. Qed.

--- a/UniMath/CategoryTheory/Monoidal/AlternativeDefinitions/AugmentedSimplexCategory.v
+++ b/UniMath/CategoryTheory/Monoidal/AlternativeDefinitions/AugmentedSimplexCategory.v
@@ -765,6 +765,7 @@ Proof.
 Defined.
 
 Definition tensor_associator_ord : associator tensor_functor_ord.
+Proof.
   unfold associator, nat_z_iso.
   exists tensor_associator_ord_nat_trans.
   unfold is_nat_z_iso.

--- a/UniMath/CategoryTheory/ProductCategory.v
+++ b/UniMath/CategoryTheory/ProductCategory.v
@@ -77,6 +77,7 @@ End dep_product_precategory.
 
 (** The product of categories is again a category. *)
 Definition product_category {I : UU} (C : I -> category) : category.
+Proof.
   use make_category.
   - exact (product_precategory C).
   - apply has_homsets_product_precategory.

--- a/UniMath/CategoryTheory/RepresentableFunctors/Representation.v
+++ b/UniMath/CategoryTheory/RepresentableFunctors/Representation.v
@@ -277,6 +277,7 @@ Defined.
 (** initial and final objects and zero maps  *)
 
 Definition UnitFunctor (C:category) : [C,SET].
+Proof.
   unshelve refine (_,,_).
   { exists (λ c, unitset). exact (λ a b f t, t). }
   { split.
@@ -902,6 +903,7 @@ Defined.
 
 Goal ∏ B C t b,
        universalObject(functorcategoryTerminalObject B C t) ◾ b = universalObject t.
+Proof.
   reflexivity.
 Defined.
 

--- a/UniMath/CategoryTheory/Subcategory/Reflective.v
+++ b/UniMath/CategoryTheory/Subcategory/Reflective.v
@@ -35,6 +35,7 @@ Section Def.
 
   Definition reflective_subcategory_to_precategory :
     reflective_subcategory -> precategory.
+  Proof.
     intro D; exact (full_sub_precategory D).
   Defined.
 

--- a/UniMath/CategoryTheory/elems_slice_equiv.v
+++ b/UniMath/CategoryTheory/elems_slice_equiv.v
@@ -140,6 +140,7 @@ Section elems_slice_equiv.
 
   Definition PreShv_to_slice_ob_isnat {X Y : PreShv ∫P} (f : X --> Y) :
     is_nat_trans (PreShv_to_slice_ob_funct_data X) (PreShv_to_slice_ob_funct_data Y) (PreShv_to_slice_ob_nat f).
+  Proof.
     simpl.
     intros c c' g.
     apply funextsec; intro p.
@@ -149,6 +150,7 @@ Section elems_slice_equiv.
 
   Definition PreShv_to_slice_mor {X Y : PreShv ∫P} (f : X --> Y) :
     PreShv_to_slice_ob X --> PreShv_to_slice_ob Y.
+  Proof.
     exists (PreShv_to_slice_ob_nat f ,, PreShv_to_slice_ob_isnat f).
     now apply (nat_trans_eq has_homsets_HSET).
   Defined.
@@ -178,6 +180,7 @@ Section elems_slice_equiv.
 
   Definition slice_to_PreShv_ob_mor (Q : PreShv C / P) {F G : (∫P)^op} (f : F --> G) :
     slice_to_PreShv_ob_ob Q F --> slice_to_PreShv_ob_ob Q G.
+  Proof.
     intros s.
     destruct Q as [[[Q Qmor] Qisfunct] [Qnat Qisnat]].
     destruct F as [x Px]. destruct G as [y Py].

--- a/UniMath/CategoryTheory/opp_precat.v
+++ b/UniMath/CategoryTheory/opp_precat.v
@@ -48,7 +48,7 @@ Definition opp_precat (C : precategory) : precategory :=
 
 Local Notation "C '^op'" := (opp_precat C) (at level 1, format "C ^op") : cat.
 
-Goal ∏ C:precategory, C^op^op = C. reflexivity. Qed.
+Goal ∏ C:precategory, C^op^op = C. Proof. reflexivity. Qed.
 
 Definition opp_ob {C : precategory} (c : ob C) : ob C^op := c.
 
@@ -106,6 +106,7 @@ Proof.
 Qed.
 
 Definition opp_iso {C : precategory} {a b : C} : @iso C a b -> @iso C^op b a.
+Proof.
   intro f.
   exists (pr1 f).
   set (T := is_z_iso_from_is_iso _ (pr2 f)).

--- a/UniMath/Combinatorics/FMatrices.v
+++ b/UniMath/Combinatorics/FMatrices.v
@@ -58,5 +58,6 @@ Definition const_matrix {X : UU} {n m : nat} (x : X) : Matrix X n m :=
 
 (** Every type is equivalent to 1 × 1 matrices on that type. *)
 Lemma weq_matrix_1_1 {X : UU} : X ≃ Matrix X 1 1.
+Proof.
   intermediate_weq (Vector X 1); apply weq_vector_1.
 Defined.

--- a/UniMath/Combinatorics/FVectors.v
+++ b/UniMath/Combinatorics/FVectors.v
@@ -40,6 +40,7 @@ Definition empty_vec {X : UU} : Vector X 0 := iscontrpr1 (iscontr_vector_0 X).
 
 (** Every type is equivalent to vectors of length 1 on that type. *)
 Lemma weq_vector_1 {X : UU} : X ≃ Vector X 1.
+Proof.
   intermediate_weq (unit → X).
   - apply invweq, weqfunfromunit.
   - apply weqbfun.

--- a/UniMath/Combinatorics/Lists.v
+++ b/UniMath/Combinatorics/Lists.v
@@ -112,12 +112,12 @@ Section Test.
 
   Context {a b c d:A}.
   Let x := a::b::c::d::[].
-  Goal nth x (●0) = a. apply idpath. Qed.
-  Goal nth x (●1) = b. apply idpath. Qed.
-  Goal nth x (●2) = c. apply idpath. Qed.
-  Goal nth x (●3) = d. apply idpath. Qed.
+  Goal nth x (●0) = a. Proof. apply idpath. Qed.
+  Goal nth x (●1) = b. Proof. apply idpath. Qed.
+  Goal nth x (●2) = c. Proof. apply idpath. Qed.
+  Goal nth x (●3) = d. Proof. apply idpath. Qed.
 
-  Goal functionToList _ (nth x) = x. apply idpath. Qed.
+  Goal functionToList _ (nth x) = x. Proof. apply idpath. Qed.
 
 End Test.
 

--- a/UniMath/Combinatorics/Tests.v
+++ b/UniMath/Combinatorics/Tests.v
@@ -19,10 +19,12 @@ Section Test_list.
   Local Infix "::" := cons.
 
   Local Goal concatenate (1::2::[]) (3::4::5::[]) = (1::2::3::4::5::[]).
+  Proof.
     reflexivity.
   Defined.
 
   Goal flatten ((1::2::[])::(3::4::5::[])::(6::[])::[]) = (1::2::3::4::5::6::[]).
+  Proof.
     reflexivity.
   Defined.
 
@@ -32,26 +34,27 @@ Section Test_stn.
 
   Local Open Scope stn.
 
-  Goal stn 6. exact (stnel(6,3)). Qed.
-  Goal stn 6. exact (stnpr 3). Qed.
+  Goal stn 6. Proof. exact (stnel(6,3)). Qed.
+  Goal stn 6. Proof. exact (stnpr 3). Qed.
 
 
-  Goal (stnel(6,3) ≠ stnel(6,4)). exact tt. Defined.
-  Goal ¬(stnel(6,3) ≠ stnel(6,3)). intro n. apply n. Defined.
+  Goal (stnel(6,3) ≠ stnel(6,4)). Proof. exact tt. Defined.
+  Goal ¬(stnel(6,3) ≠ stnel(6,3)). Proof. intro n. apply n. Defined.
 
   Goal ∏ m n (i:m≤n) (j:stn m), pr1 (stnmtostnn m n i j) = pr1 j.
+  Proof.
     intros. induction j as [j J]. reflexivity.
   Defined.
 
-  Goal @sni 6 (●3) (@dni 6 (●3) (●2)) = ●2. reflexivity. Defined.
-  Goal @sni 6 (●3) (@dni 6 (●3) (●3)) = ●3. reflexivity. Defined.
-  Goal @sni 6 (●3) (@dni 6 (●3) (●4)) = ●4. reflexivity. Defined.
+  Goal @sni 6 (●3) (@dni 6 (●3) (●2)) = ●2. Proof. reflexivity. Defined.
+  Goal @sni 6 (●3) (@dni 6 (●3) (●3)) = ●3. Proof. reflexivity. Defined.
+  Goal @sni 6 (●3) (@dni 6 (●3) (●4)) = ●4. Proof. reflexivity. Defined.
 
 
-  Goal @sni 6 (●3) (●2) = ●2. reflexivity. Defined.
-  Goal @sni 6 (●3) (●3) = ●3. reflexivity. Defined.
-  Goal @sni 6 (●3) (●4) = ●3. reflexivity. Defined.
-  Goal @sni 6 (●3) (●5) = ●4. reflexivity. Defined.
+  Goal @sni 6 (●3) (●2) = ●2. Proof. reflexivity. Defined.
+  Goal @sni 6 (●3) (●3) = ●3. Proof. reflexivity. Defined.
+  Goal @sni 6 (●3) (●4) = ●3. Proof. reflexivity. Defined.
+  Goal @sni 6 (●3) (●5) = ●4. Proof. reflexivity. Defined.
 
   Section Test_weqdnicompl.
 
@@ -63,35 +66,39 @@ Section Test_stn.
     Let j := ●4 : X.
     Let jni := ●5,,tt : Y.
 
-    Goal v j = jni. reflexivity. Defined.
-    Goal invmap v jni = j. reflexivity. Defined.
-    Goal homotweqinvweq v jni = idpath _. reflexivity. Defined.
+    Goal v j = jni. Proof. reflexivity. Defined.
+    Goal invmap v jni = j. Proof. reflexivity. Defined.
+    Goal homotweqinvweq v jni = idpath _. Proof. reflexivity. Defined.
     Goal homotinvweqweq v j = idpath _.
+    Proof.
       reflexivity.                (* fixed; 2 seconds *)
     Defined.                      (* fixed, 2 seconds *)
     Goal homotweqinvweqweq v j = idpath _. (* 2 seconds *)
+    Proof.
       reflexivity.                         (* 2 seconds *)
     Defined.                               (* 3 seconds *)
 
   End Test_weqdnicompl.
 
   Section Test2.
-    Goal weqdnicoprod 4 firstelement (ii1 (●0)) = ●1. reflexivity. Defined.
-    Goal weqdnicoprod 4 firstelement (ii1 (●3)) = ●4. reflexivity. Defined.
-    Goal invmap (weqdnicoprod 4 firstelement) (●1) = (ii1 (●0)). reflexivity. Defined.
-    Goal invmap (weqdnicoprod 4 firstelement) (●4) = (ii1 (●3)). reflexivity. Defined.
-    Goal weqdnicoprod 4 lastelement (ii1 (●3)) = ●3. reflexivity. Defined.
-    Goal weqdnicoprod 4 lastelement (ii2 tt) = ●4. reflexivity. Defined.
-    Goal invmap (weqdnicoprod 4 lastelement) (●1) = (ii1 (●1)). reflexivity. Defined.
-    Goal invmap (weqdnicoprod 4 lastelement) (●4) = (ii2 tt). reflexivity. Defined.
-    Goal homotweqinvweq (weqdnicoprod 4 lastelement) (● 0) = idpath _. reflexivity. Defined. (* fixed! *)
-    Goal homotinvweqweq (weqdnicoprod 4 (●4)) (ii2 tt) = idpath _. reflexivity. Defined.
+    Goal weqdnicoprod 4 firstelement (ii1 (●0)) = ●1. Proof. reflexivity. Defined.
+    Goal weqdnicoprod 4 firstelement (ii1 (●3)) = ●4. Proof. reflexivity. Defined.
+    Goal invmap (weqdnicoprod 4 firstelement) (●1) = (ii1 (●0)). Proof. reflexivity. Defined.
+    Goal invmap (weqdnicoprod 4 firstelement) (●4) = (ii1 (●3)). Proof. reflexivity. Defined.
+    Goal weqdnicoprod 4 lastelement (ii1 (●3)) = ●3. Proof. reflexivity. Defined.
+    Goal weqdnicoprod 4 lastelement (ii2 tt) = ●4. Proof. reflexivity. Defined.
+    Goal invmap (weqdnicoprod 4 lastelement) (●1) = (ii1 (●1)). Proof. reflexivity. Defined.
+    Goal invmap (weqdnicoprod 4 lastelement) (●4) = (ii2 tt). Proof. reflexivity. Defined.
+    Goal homotweqinvweq (weqdnicoprod 4 lastelement) (● 0) = idpath _. Proof. reflexivity. Defined. (* fixed! *)
+    Goal homotinvweqweq (weqdnicoprod 4 (●4)) (ii2 tt) = idpath _. Proof. reflexivity. Defined.
     Goal homotinvweqweq (weqdnicoprod 4 (●4)) (ii1 (●1)) = idpath _.
+    Proof.
       reflexivity.                (* fixed; 5 seconds *)
     Defined.                      (* 5 seconds *)
 
     (* here's an example that shows complications need not impede that sort of computability: *)
     Local Definition w : unit ≃ stn 1.
+    Proof.
       simple refine (weq_iso _ _ _ _).
       { intro. exact firstelement. }
       { intro. exact tt. }
@@ -99,28 +106,28 @@ Section Test_stn.
       { intro i. simpl. apply subtypePath_prop.
         simpl. induction i as [i I]. simpl. apply pathsinv0. apply natlth1tois0. exact I. }
     Defined.
-    Goal w tt = firstelement. reflexivity. Defined.
-    Goal invmap w firstelement = tt. reflexivity. Defined.
-    Goal homotweqinvweq w firstelement = idpath _. reflexivity. Defined.
-    Goal homotinvweqweq w tt = idpath _. reflexivity. Defined.
+    Goal w tt = firstelement. Proof. reflexivity. Defined.
+    Goal invmap w firstelement = tt. Proof. reflexivity. Defined.
+    Goal homotweqinvweq w firstelement = idpath _. Proof. reflexivity. Defined.
+    Goal homotinvweqweq w tt = idpath _. Proof. reflexivity. Defined.
 
     Local Definition w' := invweq w.
-    Goal w' firstelement = tt. reflexivity. Defined.
-    Goal invmap w' tt= firstelement. reflexivity. Defined.
-    Goal homotweqinvweq w' tt = idpath _. reflexivity. Defined.
-    Goal homotinvweqweq w' firstelement = idpath _. reflexivity. Defined.
+    Goal w' firstelement = tt. Proof. reflexivity. Defined.
+    Goal invmap w' tt= firstelement. Proof. reflexivity. Defined.
+    Goal homotweqinvweq w' tt = idpath _. Proof. reflexivity. Defined.
+    Goal homotinvweqweq w' firstelement = idpath _. Proof. reflexivity. Defined.
 
     Local Definition ww' := weqcomp w w'.
-    Goal ww' tt = tt. reflexivity. Defined.
-    Goal invmap ww' tt = tt. reflexivity. Defined.
-    Goal homotweqinvweq ww' tt = idpath _. reflexivity. Defined.
-    Goal homotinvweqweq ww' tt = idpath _. reflexivity. Defined.
+    Goal ww' tt = tt. Proof. reflexivity. Defined.
+    Goal invmap ww' tt = tt. Proof. reflexivity. Defined.
+    Goal homotweqinvweq ww' tt = idpath _. Proof. reflexivity. Defined.
+    Goal homotinvweqweq ww' tt = idpath _. Proof. reflexivity. Defined.
 
     Local Definition w_w := weqcoprodf w w.
-    Goal w_w (ii1 tt) = ii1 firstelement. reflexivity. Defined.
-    Goal invmap w_w (ii2 firstelement) = ii2 tt. reflexivity. Defined.
-    Goal homotweqinvweq w_w (ii2 firstelement) = idpath _. reflexivity. Defined.
-    Goal homotinvweqweq w_w (ii1 tt) = idpath _. reflexivity. Defined.
+    Goal w_w (ii1 tt) = ii1 firstelement. Proof. reflexivity. Defined.
+    Goal invmap w_w (ii2 firstelement) = ii2 tt. Proof. reflexivity. Defined.
+    Goal homotweqinvweq w_w (ii2 firstelement) = idpath _. Proof. reflexivity. Defined.
+    Goal homotinvweqweq w_w (ii1 tt) = idpath _. Proof. reflexivity. Defined.
 
     Local Definition i := ●1 : stn 4.
     Local Definition j := ●0 : stn 4.
@@ -130,42 +137,43 @@ Section Test_stn.
     Local Definition re' := weqrecompl_ne (stn 4) i (isisolatedinstn i) (stnneq i).
     Local Definition c := make_compl (stn 4) i j ne : compl _ i.
     Local Definition c' := make_compl_ne (stn 4) i (stnneq i) j tt : stn_compl i.
-    Goal re (ii2 tt) = i. reflexivity. Defined.
-    Goal re (ii1 c) = j. reflexivity. Defined.
-    Goal invmap re i = (ii2 tt). reflexivity. Defined.
-    Goal invmap re j = (ii1 c). reflexivity. Defined.
-    Goal homotweqinvweq re i = idpath _. reflexivity. Defined.
-    Goal homotweqinvweq re j = idpath _. reflexivity. Defined.
-    Goal homotinvweqweq re (ii2 tt) = idpath _. reflexivity. Defined.
+    Goal re (ii2 tt) = i. Proof. reflexivity. Defined.
+    Goal re (ii1 c) = j. Proof. reflexivity. Defined.
+    Goal invmap re i = (ii2 tt). Proof. reflexivity. Defined.
+    Goal invmap re j = (ii1 c). Proof. reflexivity. Defined.
+    Goal homotweqinvweq re i = idpath _. Proof. reflexivity. Defined.
+    Goal homotweqinvweq re j = idpath _. Proof. reflexivity. Defined.
+    Goal homotinvweqweq re (ii2 tt) = idpath _. Proof. reflexivity. Defined.
     Goal homotinvweqweq re (ii1 c) = idpath _.
+    Proof.
       try reflexivity.
       (* quickly returns due to the use of funextemptyAxiom in the proof of isweqrecompl. *)
     Abort.
 
-    Goal re' (ii2 tt) = i. reflexivity. Defined.
-    Goal re' (ii1 c') = j. reflexivity. Defined.
-    Goal invmap re' i = (ii2 tt). reflexivity. Defined.
-    Goal invmap re' j = (ii1 c'). reflexivity. Defined.
-    Goal homotweqinvweq re' i = idpath _. reflexivity. Defined.
-    Goal homotweqinvweq re' j = idpath _. reflexivity. Defined.
-    Goal homotinvweqweq re' (ii2 tt) = idpath _. reflexivity. Defined.
-    Goal homotinvweqweq re' (ii1 c') = idpath _. reflexivity. Defined. (* fixed! *)
+    Goal re' (ii2 tt) = i. Proof. reflexivity. Defined.
+    Goal re' (ii1 c') = j. Proof. reflexivity. Defined.
+    Goal invmap re' i = (ii2 tt). Proof. reflexivity. Defined.
+    Goal invmap re' j = (ii1 c'). Proof. reflexivity. Defined.
+    Goal homotweqinvweq re' i = idpath _. Proof. reflexivity. Defined.
+    Goal homotweqinvweq re' j = idpath _. Proof. reflexivity. Defined.
+    Goal homotinvweqweq re' (ii2 tt) = idpath _. Proof. reflexivity. Defined.
+    Goal homotinvweqweq re' (ii1 c') = idpath _. Proof. reflexivity. Defined. (* fixed! *)
 
 
-    Goal @weqdnicoprod_map 4 (●2) (ii2 tt) = (●2). reflexivity. Defined.
-    Goal @weqdnicoprod_map 4 (●2) (ii1 (●2)) = (●3). reflexivity. Defined.
-    Goal @weqdnicoprod_map 4 (●2) (ii1 (●1)) = (●1). reflexivity. Defined.
-    Goal @weqdnicoprod_invmap 4 (●2) (●2) = (ii2 tt). reflexivity. Defined.
-    Goal @weqdnicoprod_invmap 4 (●2) (●3) = (ii1 (●2)). reflexivity. Defined.
-    Goal @weqdnicoprod_invmap 4 (●2) (●1) = (ii1 (●1)). reflexivity. Defined.
+    Goal @weqdnicoprod_map 4 (●2) (ii2 tt) = (●2). Proof. reflexivity. Defined.
+    Goal @weqdnicoprod_map 4 (●2) (ii1 (●2)) = (●3). Proof. reflexivity. Defined.
+    Goal @weqdnicoprod_map 4 (●2) (ii1 (●1)) = (●1). Proof. reflexivity. Defined.
+    Goal @weqdnicoprod_invmap 4 (●2) (●2) = (ii2 tt). Proof. reflexivity. Defined.
+    Goal @weqdnicoprod_invmap 4 (●2) (●3) = (ii1 (●2)). Proof. reflexivity. Defined.
+    Goal @weqdnicoprod_invmap 4 (●2) (●1) = (ii1 (●1)). Proof. reflexivity. Defined.
 
 
 
   End Test2.
 
   (* confirm that [stnsum] is associative in the same way as the parser, which is left associative *)
-  Goal ∏ (f : stn 3 -> nat), stnsum f =  f(●0) + f(●1)  +  f(●2). reflexivity. Defined.
-  Goal ∏ (f : stn 3 -> nat), stnsum f = (f(●0) + f(●1)) +  f(●2). reflexivity. Defined.
+  Goal ∏ (f : stn 3 -> nat), stnsum f =  f(●0) + f(●1)  +  f(●2). Proof. reflexivity. Defined.
+  Goal ∏ (f : stn 3 -> nat), stnsum f = (f(●0) + f(●1)) +  f(●2). Proof. reflexivity. Defined.
 
   Section Test_weqstnsum.
     (* this module exports nothing *)
@@ -174,27 +182,27 @@ Section Test_stn.
     Let W := ∑ x, Y x.
     Let f : W ≃ stn _ := weqstnsum1 _.
     Let f' : stn _ ≃ W := invweq f.
-    Goal f(●1,,●0) = ●0. reflexivity. Defined. (* fixed! (formerly, it failed quickly) *)
-    Goal f(●2,,●0) = ●1. reflexivity. Defined.
-    Goal f(●2,,●1) = ●2. reflexivity. Defined.
-    Goal f(●3,,●0) = ●3. reflexivity. Defined.
-    Goal f(●3,,●1) = ●4. reflexivity. Defined.
-    Goal f(●3,,●2) = ●5. reflexivity. Defined.
-    Goal f(●4,,●0) = ●6. reflexivity. Defined.
-    Goal f(●5,,●0) = ●10. reflexivity. Defined.
-    Goal f(●6,,●0) = ●15. reflexivity. Defined.
+    Goal f(●1,,●0) = ●0. Proof. reflexivity. Defined. (* fixed! (formerly, it failed quickly) *)
+    Goal f(●2,,●0) = ●1. Proof. reflexivity. Defined.
+    Goal f(●2,,●1) = ●2. Proof. reflexivity. Defined.
+    Goal f(●3,,●0) = ●3. Proof. reflexivity. Defined.
+    Goal f(●3,,●1) = ●4. Proof. reflexivity. Defined.
+    Goal f(●3,,●2) = ●5. Proof. reflexivity. Defined.
+    Goal f(●4,,●0) = ●6. Proof. reflexivity. Defined.
+    Goal f(●5,,●0) = ●10. Proof. reflexivity. Defined.
+    Goal f(●6,,●0) = ●15. Proof. reflexivity. Defined.
 
-    Goal (pr2 (pr2 (f'(●0)))) = idpath true. reflexivity. Defined. (* fixed, Coq bug? *)
-    Goal f'(●0) = (●1,,●0). reflexivity. Defined. (* fixed, Coq bug? *)
-    Goal f'(●0) = (●1,,●0). reflexivity. Defined.
-    Goal f'(●1) = (●2,,●0). reflexivity. Defined.
-    Goal f'(●2) = (●2,,●1). reflexivity. Defined.
-    Goal f'(●3) = (●3,,●0). reflexivity. Defined.
-    Goal f'(●4) = (●3,,●1). reflexivity. Defined.
-    Goal f'(●5) = (●3,,●2). reflexivity. Defined.
-    Goal f'(●6) = (●4,,●0). reflexivity. Defined.
-    Goal f'(●10) = (●5,,●0). reflexivity. Defined.
-    Goal f'(●15) = (●6,,●0). reflexivity. Defined.
+    Goal (pr2 (pr2 (f'(●0)))) = idpath true. Proof. reflexivity. Defined. (* fixed, Coq bug? *)
+    Goal f'(●0) = (●1,,●0). Proof. reflexivity. Defined. (* fixed, Coq bug? *)
+    Goal f'(●0) = (●1,,●0). Proof. reflexivity. Defined.
+    Goal f'(●1) = (●2,,●0). Proof. reflexivity. Defined.
+    Goal f'(●2) = (●2,,●1). Proof. reflexivity. Defined.
+    Goal f'(●3) = (●3,,●0). Proof. reflexivity. Defined.
+    Goal f'(●4) = (●3,,●1). Proof. reflexivity. Defined.
+    Goal f'(●5) = (●3,,●2). Proof. reflexivity. Defined.
+    Goal f'(●6) = (●4,,●0). Proof. reflexivity. Defined.
+    Goal f'(●10) = (●5,,●0). Proof. reflexivity. Defined.
+    Goal f'(●15) = (●6,,●0). Proof. reflexivity. Defined.
 
   End Test_weqstnsum.
 
@@ -202,14 +210,14 @@ Section Test_stn.
     (* verify computability in both directions *)
     (* this module exports nothing *)
     Let f : stn 5 × stn 4 ≃ stn 20 := weqfromprodofstn 5 4.
-    Goal f(●0,,●0) = ●0. reflexivity. Defined.
-    Goal f(●0,,●1) = ●1. reflexivity. Defined.
-    Goal f(●2,,●0) = ●8. reflexivity. Defined.
-    Goal f(●4,,●3) = ●19. reflexivity. Defined.
+    Goal f(●0,,●0) = ●0. Proof. reflexivity. Defined.
+    Goal f(●0,,●1) = ●1. Proof. reflexivity. Defined.
+    Goal f(●2,,●0) = ●8. Proof. reflexivity. Defined.
+    Goal f(●4,,●3) = ●19. Proof. reflexivity. Defined.
     Let f' := invweq f.
-    Goal f'(●19) = (●4,,●3). reflexivity. Defined.
-    Goal f'(●18) = (●4,,●2). reflexivity. Defined.
-    Goal f'(●14) = (●3,,●2). reflexivity. Defined.
+    Goal f'(●19) = (●4,,●3). Proof. reflexivity. Defined.
+    Goal f'(●18) = (●4,,●2). Proof. reflexivity. Defined.
+    Goal f'(●14) = (●3,,●2). Proof. reflexivity. Defined.
   End Test_weqfromprodofstn.
 
   (* confirm that [stnprod] is associative in the same way as the parser *)
@@ -245,21 +253,23 @@ Section Test_fin.
   Import UniMath.Combinatorics.FiniteSets.
 
   (** ** Test computations. *)
-  Goal fincard (isfiniteempty) = 0. reflexivity. Qed.
-  Goal fincard (isfiniteunit) = 1. reflexivity. Qed.
-  Goal fincard (isfinitebool) = 2. reflexivity. Qed.
-  Goal fincard (isfinitecompl true isfinitebool) = 1. reflexivity. Qed.
-  Goal fincard (isfinitedirprod  isfinitebool isfinitebool) = 4. reflexivity. Qed.
-  Goal fincard (isfinitedirprod  isfinitebool (isfinitedirprod  isfinitebool isfinitebool)) = 8. reflexivity. Qed.
-  Goal cardinalityFiniteSet (isfinite_to_FiniteSet (isfinitedirprod  isfinitebool (isfinitedirprod  isfinitebool isfinitebool))) = 8. reflexivity. Qed.
-  Goal fincard (isfinitecompl (ii1 tt) (isfinitecoprod  (isfiniteunit) (isfinitebool))) = 2. reflexivity. Qed.
-  Goal fincard (isfinitecompl (ii1 tt) (isfinitecoprod (isfiniteunit) (isfinitebool))) = 2. reflexivity. Qed.
-  Goal fincard (isfinitecompl (make_dirprod tt tt) (isfinitedirprod  isfiniteunit isfiniteunit)) = 0. reflexivity. Qed.
-  Goal fincard (isfinitecompl (make_dirprod  true (make_dirprod  true false)) (isfinitedirprod  (isfinitebool) (isfinitedirprod  (isfinitebool) (isfinitebool)))) = 7. reflexivity. Qed.
+  Goal fincard (isfiniteempty) = 0. Proof. reflexivity. Qed.
+  Goal fincard (isfiniteunit) = 1. Proof. reflexivity. Qed.
+  Goal fincard (isfinitebool) = 2. Proof. reflexivity. Qed.
+  Goal fincard (isfinitecompl true isfinitebool) = 1. Proof. reflexivity. Qed.
+  Goal fincard (isfinitedirprod  isfinitebool isfinitebool) = 4. Proof. reflexivity. Qed.
+  Goal fincard (isfinitedirprod  isfinitebool (isfinitedirprod  isfinitebool isfinitebool)) = 8. Proof. reflexivity. Qed.
+  Goal cardinalityFiniteSet (isfinite_to_FiniteSet (isfinitedirprod  isfinitebool (isfinitedirprod  isfinitebool isfinitebool))) = 8. Proof. reflexivity. Qed.
+  Goal fincard (isfinitecompl (ii1 tt) (isfinitecoprod  (isfiniteunit) (isfinitebool))) = 2. Proof. reflexivity. Qed.
+  Goal fincard (isfinitecompl (ii1 tt) (isfinitecoprod (isfiniteunit) (isfinitebool))) = 2. Proof. reflexivity. Qed.
+  Goal fincard (isfinitecompl (make_dirprod tt tt) (isfinitedirprod  isfiniteunit isfiniteunit)) = 0. Proof. reflexivity. Qed.
+  Goal fincard (isfinitecompl (make_dirprod  true (make_dirprod  true false)) (isfinitedirprod  (isfinitebool) (isfinitedirprod  (isfinitebool) (isfinitebool)))) = 7.
+  Proof. reflexivity. Qed.
 
   Goal fincard (
          isfiniteweq (isfinitedirprod isfinitebool isfinitebool)
-       ) = 24. reflexivity. Qed.
+    ) = 24.
+  Proof. reflexivity. Qed.
 
   (*
 
@@ -290,14 +300,14 @@ Section Test_fin.
     Let x := ●3 : X.
     Let x' := ●4 : X.
     Let decide P := choice P true false.
-    Goal decide (eqX x x') = false. reflexivity. Defined.
-    Goal decide (eqX x x) = true. reflexivity. Defined.
+    Goal decide (eqX x x') = false. Proof. reflexivity. Defined.
+    Goal decide (eqX x x) = true. Proof. reflexivity. Defined.
 
     (* test isfinitebool *)
 
     Let eqbool := isfinite_to_DecidableEquality isfinitebool : DecidableRelation bool.
-    Goal decide (eqbool true true) = true. reflexivity. Defined.
-    Goal decide (eqbool false true) = false. reflexivity. Defined.
+    Goal decide (eqbool true true) = true. Proof. reflexivity. Defined.
+    Goal decide (eqbool false true) = false. Proof. reflexivity. Defined.
 
     (* test isfinitecoprod *)
 
@@ -307,9 +317,9 @@ Section Test_fin.
     Let c := ii1 x : C.
     Let c' := ii1 x' : C.
     Let c'' := ii2 x : C.
-    Goal decide (eqQ c c') = false. reflexivity. Defined.
-    Goal decide (eqQ c c) = true. reflexivity. Defined.
-    Goal decide (eqQ c c'') = false. reflexivity. Defined.
+    Goal decide (eqQ c c') = false. Proof. reflexivity. Defined.
+    Goal decide (eqQ c c) = true. Proof. reflexivity. Defined.
+    Goal decide (eqQ c c'') = false. Proof. reflexivity. Defined.
 
     (* test isfinitedirprod *)
     Let Y := stnset 4.
@@ -318,7 +328,7 @@ Section Test_fin.
     Let finY : isfinite Y := isfinitestn _.
     Let V := X × Y.
     Let eqV := isfinite_to_DecidableEquality (isfinitedirprod finX finY).
-    Goal decide (eqV (x,,y) (x',,y')) = false. reflexivity. Defined.
+    Goal decide (eqV (x,,y) (x',,y')) = false. Proof. reflexivity. Defined.
 
     (* test isfinitetotal2 *)
 
@@ -327,6 +337,7 @@ Section Test_fin.
     Let eqW : DecidableRelation W :=
       isfinite_to_DecidableEquality (isfinitetotal2 Y' finX (λ _, finY)).
     Goal decide (eqW (x,,y) (x',,y')) = false.
+    Proof.
       reflexivity. (* fixed *)
     Defined.
 
@@ -335,6 +346,7 @@ Section Test_fin.
     Let eqT : DecidableRelation T :=
       isfinite_to_DecidableEquality (isfiniteforall Y' finX (λ _, finY)).
     Goal decide (eqT (λ _, y) (λ _, y)) = true.
+    Proof.
       reflexivity. (* fixed *)
     Defined.
 
@@ -370,7 +382,7 @@ Section Test_ord.
 
   Local Open Scope stn.
 
-  Goal 3 = height ( ●3 : ⟦ 8 ⟧ %foset ). reflexivity. Defined.
+  Goal 3 = height ( ●3 : ⟦ 8 ⟧ %foset ). Proof. reflexivity. Defined.
 
   Section TestLex.
     (* we want lex order to be computable if R and S both are *)
@@ -384,9 +396,9 @@ Section Test_ord.
     Let x2 := ●2 : X.
     Let x3 := ●3 : X.
 
-    Goal (choice (R x2 x3) true false = true). reflexivity. Defined.
-    Goal (choice (R x2 x2) true false = true). reflexivity. Defined.
-    Goal (choice (R x3 x2) true false = false). reflexivity. Defined.
+    Goal (choice (R x2 x3) true false = true). Proof. reflexivity. Defined.
+    Goal (choice (R x2 x2) true false = true). Proof. reflexivity. Defined.
+    Goal (choice (R x3 x2) true false = false). Proof. reflexivity. Defined.
 
     Let y1 := ●1 : Y x2.
     Let y2 := ●2 : Y x3.
@@ -404,9 +416,9 @@ Section Test_ord.
     Let i := ●2 : ⟦ 4 ⟧.
     Let j := ●3 : ⟦ 4 ⟧.
 
-    Goal choice (i < j)%foset true false = true. reflexivity. Defined.
-    Goal choice (i ≤ j)%foset true false = true. reflexivity. Defined.
-    Goal choice (i ≐ j)%foset true false = false. reflexivity. Defined.
+    Goal choice (i < j)%foset true false = true. Proof. reflexivity. Defined.
+    Goal choice (i ≤ j)%foset true false = true. Proof. reflexivity. Defined.
+    Goal choice (i ≐ j)%foset true false = false. Proof. reflexivity. Defined.
 
     Let X := (∑ i:⟦ 4 ⟧, ⟦ pr1 i ⟧)%foset.
     Let x := ( ●2 ,, ●1 ):X.
@@ -430,46 +442,57 @@ Section Test_ord.
     (* we want these to work: *)
 
     Goal choice (x < y) true false = true.
+    Proof.
       reflexivity.                (* fixed *)
     Defined.
 
     Goal choice (x ≤ y)%foset true false = true.
+    Proof.
       reflexivity.
     Defined.
 
     Goal choice (y < x)%foset true false = false.
+    Proof.
       reflexivity.
     Defined.
 
     Goal choice (y ≤ x)%foset true false = false.
+    Proof.
       reflexivity.
     Defined.
 
     Goal choice (x ≐ y)%foset true false = false.
+    Proof.
       reflexivity.
     Defined.
 
     Goal choice (x ≐ x)%foset true false = true.
+    Proof.
       reflexivity.
     Defined.
 
     Goal which (d x y) = false.
+    Proof.
       reflexivity.
     Defined.
 
     Goal which (d x x) = true.
+    Proof.
       reflexivity.
     Defined.
 
     Goal choice (x ≠ y)%foset true false = true.
+    Proof.
       reflexivity.
     Defined.
 
     Goal which (isdeceqnat 2 (height x)) = true.
+    Proof.
       try reflexivity.          (* fix *)
     Abort.
 
     Goal 2 = height x.
+    Proof.
       try reflexivity.                (* fix *)
     Abort.
 
@@ -482,10 +505,10 @@ Section Test_ord.
     { intros i x z y. apply i. }
   Defined.
 
-  Goal (idweq nat ∘ idweq _ ∘ idweq _)%weq 3 = 3. reflexivity. Defined.
-  Goal (idweq nat ∘ invweq (idweq _) ∘ idweq _)%weq 3 = 3. reflexivity. Defined.
-  Goal invmap (idweq nat ∘ idweq _ ∘ idweq _)%weq 3 = 3. reflexivity. Defined.
-  Goal invmap (idweq nat ∘ invweq (idweq _) ∘ idweq _)%weq 3 = 3. reflexivity. Defined.
+  Goal (idweq nat ∘ idweq _ ∘ idweq _)%weq 3 = 3. Proof. reflexivity. Defined.
+  Goal (idweq nat ∘ invweq (idweq _) ∘ idweq _)%weq 3 = 3. Proof. reflexivity. Defined.
+  Goal invmap (idweq nat ∘ idweq _ ∘ idweq _)%weq 3 = 3. Proof. reflexivity. Defined.
+  Goal invmap (idweq nat ∘ invweq (idweq _) ∘ idweq _)%weq 3 = 3. Proof. reflexivity. Defined.
 
 End Test_ord.
 
@@ -529,7 +552,7 @@ Section Test_search.
     apply hinhpr. refine (2%nat,,_). apply idpath.
   Defined.
 
-  Goal 1 = pr1 (minimal_n P P_dec P_inhab). reflexivity. Defined.
+  Goal 1 = pr1 (minimal_n P P_dec P_inhab). Proof. reflexivity. Defined.
 
   Variable P_inhab' : ∃ n, P n.
 

--- a/UniMath/Combinatorics/VectorsTests.v
+++ b/UniMath/Combinatorics/VectorsTests.v
@@ -12,16 +12,16 @@ Section Tests_el.
 
   Let v := vcons a (vcons b (vcons c (vcons d vnil))).
 
-  Goal el v (●0) = a. reflexivity. Qed.
-  Goal el v (●1) = b. reflexivity. Qed.
-  Goal el v (●2) = c. reflexivity. Qed.
-  Goal el v (●3) = d. reflexivity. Qed.
+  Goal el v (●0) = a. Proof. reflexivity. Qed.
+  Goal el v (●1) = b. Proof. reflexivity. Qed.
+  Goal el v (●2) = c. Proof. reflexivity. Qed.
+  Goal el v (●3) = d. Proof. reflexivity. Qed.
 
-  Goal make_vec (el v) = v. reflexivity. Qed.
+  Goal make_vec (el v) = v. Proof. reflexivity. Qed.
 
   Let f : ⟦ 4 ⟧ → A := Eval compute in (el v).
 
-  Goal (el (make_vec f) = f). reflexivity. Qed.
+  Goal (el (make_vec f) = f). Proof. reflexivity. Qed.
 
 End Tests_el.
 
@@ -31,7 +31,7 @@ Section Test_vec_foldr.
 
   Let v := vcons p (vcons q (vcons r vnil)).
 
-  Goal vec_foldr f b v = f p (f q (f r b)). reflexivity. Qed.
+  Goal vec_foldr f b v = f p (f q (f r b)). Proof. reflexivity. Qed.
 
 End Test_vec_foldr.
 
@@ -41,7 +41,7 @@ Section Test_vec_foldr1.
 
   Let v := vcons p (vcons q (vcons r (vcons t vnil))).
 
-  Goal vec_foldr1 f v = f p (f q (f r t)). reflexivity. Qed.
+  Goal vec_foldr1 f v = f p (f q (f r t)). Proof. reflexivity. Qed.
 
 End Test_vec_foldr1.
 
@@ -53,6 +53,6 @@ Section Test_vec_append.
   Let v := vcons d (vcons e vnil).
   Let w := vcons a (vcons b (vcons c (vcons d (vcons e vnil)))).
 
-  Goal vec_append u v = w. reflexivity. Qed.
+  Goal vec_append u v = w. Proof. reflexivity. Qed.
 
 End Test_vec_append.

--- a/UniMath/Foundations/PartA.v
+++ b/UniMath/Foundations/PartA.v
@@ -2359,6 +2359,7 @@ Defined.
 
 Definition weqtotal2dirprodassoc  {X Y : UU} (P : X × Y -> UU) :
   (∑ xy : X × Y, P xy) ≃ (∑ (x : X) (y : Y), P (x,,y)).
+Proof.
   intros.
   use weq_iso.
   - intros xyp.

--- a/UniMath/Foundations/PartB.v
+++ b/UniMath/Foundations/PartB.v
@@ -1318,6 +1318,7 @@ Proof.
 Defined.
 
 Definition decfun3 {X Y:UU} (i : isdeceq X) (x1 x2 x3:X) (y1 y2 y3 y':Y) : X → Y.
+Proof.
   revert y1 y2 y3 y'.
   exact (isolfun3 x1 x2 x3 (i x1) (i x2) (i x3)).
 Defined.

--- a/UniMath/Foundations/Sets.v
+++ b/UniMath/Foundations/Sets.v
@@ -596,6 +596,7 @@ Defined.
 (** the relations on a set form a set *)
 
 Definition isaset_hrel (X : hSet) : isaset (hrel X).
+Proof.
   intros. unfold hrel.
   apply impred_isaset; intro x.
   apply impred_isaset; intro y.
@@ -837,6 +838,7 @@ Defined.
 (** the preorders on a set form a set *)
 
 Definition isaset_po (X : hSet) : isaset (po X).
+Proof.
   intros.
   unfold po.
   apply (isofhleveltotal2 2).
@@ -847,6 +849,7 @@ Defined.
 (** the partial orders on a set form a set *)
 
 Definition isaset_PartialOrder X : isaset (PartialOrder X).
+Proof.
   intros.
   unfold PartialOrder.
   apply (isofhleveltotal2 2).

--- a/UniMath/Foundations/Tests.v
+++ b/UniMath/Foundations/Tests.v
@@ -1,68 +1,68 @@
 Require Export UniMath.Foundations.PartD.
 
-Goal ∑ (_:nat) (_:nat) (_:nat) (_:nat), nat. exact (2,,3,,4,,5,,6). Defined.
-Goal ∏ i j k, i+j+k = (i+j)+k. intros. apply idpath. Defined.
-Goal ∏ n, 1+n = S n. intros. apply idpath. Defined.
-Goal ∏ i j k, i*j*k = (i*j)*k. intros. apply idpath. Defined.
-Goal ∏ n, 0*n = 0. intros. apply idpath. Defined.
-Goal ∏ n, 0+n = n. intros. apply idpath. Defined.
-Goal ∏ n, 0*n = 0. intros. apply idpath. Defined.
-Goal ∏ n m, S n * m = n*m + m. intros. apply idpath. Defined.
-Goal ∏ n, 1*n = n. intros. apply idpath. Defined.
-Goal ∏ n, 4*n = n+n+n+n. intros. apply idpath. Defined.
-Goal ∏ X x, idweq X x = x. intros. apply idpath. Defined.
+Goal ∑ (_:nat) (_:nat) (_:nat) (_:nat), nat. Proof. exact (2,,3,,4,,5,,6). Defined.
+Goal ∏ i j k, i+j+k = (i+j)+k. Proof. intros. apply idpath. Defined.
+Goal ∏ n, 1+n = S n. Proof. intros. apply idpath. Defined.
+Goal ∏ i j k, i*j*k = (i*j)*k. Proof. intros. apply idpath. Defined.
+Goal ∏ n, 0*n = 0. Proof. intros. apply idpath. Defined.
+Goal ∏ n, 0+n = n. Proof. intros. apply idpath. Defined.
+Goal ∏ n, 0*n = 0. Proof. intros. apply idpath. Defined.
+Goal ∏ n m, S n * m = n*m + m. Proof. intros. apply idpath. Defined.
+Goal ∏ n, 1*n = n. Proof. intros. apply idpath. Defined.
+Goal ∏ n, 4*n = n+n+n+n. Proof. intros. apply idpath. Defined.
+Goal ∏ X x, idweq X x = x. Proof. intros. apply idpath. Defined.
 
 Section Test_isweq_iso.
   Let f := idfun nat.
   Let w : nat ≃ nat := weq_iso f f (λ _, idpath _) (λ _, idpath _).
-  Goal homotinvweqweq w 3 = idpath _. apply idpath. Defined.
-  Goal homotweqinvweq w 3 = idpath _. apply idpath. Defined.
-  Goal homotweqinvweqweq w 3 = idpath _. apply idpath. Defined.
+  Goal homotinvweqweq w 3 = idpath _. Proof. apply idpath. Defined.
+  Goal homotweqinvweq w 3 = idpath _. Proof. apply idpath. Defined.
+  Goal homotweqinvweqweq w 3 = idpath _. Proof. apply idpath. Defined.
 
   Definition v : bool ≃ bool.
-    simple refine (weq_iso negb negb _ _); intro x; induction x; apply idpath. Defined.
-  Goal homotinvweqweq v true = idpath _. apply idpath. Defined.
-  Goal homotweqinvweq v true = idpath _. apply idpath. Defined.
-  Goal homotweqinvweqweq v true = idpath _. apply idpath. Defined.
+  Proof. simple refine (weq_iso negb negb _ _); intro x; induction x; apply idpath. Defined.
+  Goal homotinvweqweq v true = idpath _. Proof. apply idpath. Defined.
+  Goal homotweqinvweq v true = idpath _. Proof. apply idpath. Defined.
+  Goal homotweqinvweqweq v true = idpath _. Proof. apply idpath. Defined.
 End Test_isweq_iso.
 
-Goal ∏ X x, invweq (idweq X) x = x. intros. apply idpath. Defined.
+Goal ∏ X x, invweq (idweq X) x = x. Proof. intros. apply idpath. Defined.
 
 Section Test_weqtotal2overcoprod.
   Let P (t : bool ⨿ bool) := nat.
-  Goal weqtotal2overcoprod P (ii1 true,,3) = ii1 (true,,3). apply idpath. Defined.
-  Goal weqtotal2overcoprod P (ii2 false,,3) = ii2 (false,,3). apply idpath. Defined.
-  Goal invmap (weqtotal2overcoprod P) (ii1 (true,,3)) = ii1 true,,3. apply idpath. Defined.
-  Goal invmap (weqtotal2overcoprod P) (ii2 (false,,3)) = ii2 false,,3. apply idpath. Defined.
+  Goal weqtotal2overcoprod P (ii1 true,,3) = ii1 (true,,3). Proof. apply idpath. Defined.
+  Goal weqtotal2overcoprod P (ii2 false,,3) = ii2 (false,,3). Proof. apply idpath. Defined.
+  Goal invmap (weqtotal2overcoprod P) (ii1 (true,,3)) = ii1 true,,3. Proof. apply idpath. Defined.
+  Goal invmap (weqtotal2overcoprod P) (ii2 (false,,3)) = ii2 false,,3. Proof. apply idpath. Defined.
 End Test_weqtotal2overcoprod.
 
-Goal weqcoprodf (idweq nat) (idweq nat) (ii1 3) = ii1 3. apply idpath. Defined.
-Goal weqcoprodf (idweq nat) (idweq nat) (ii2 3) = ii2 3. apply idpath. Defined.
-Goal invmap (weqcoprodf (idweq nat) (idweq nat)) (ii1 3) = ii1 3. apply idpath. Defined.
-Goal invmap (weqcoprodf (idweq nat) (idweq nat)) (ii2 3) = ii2 3. apply idpath. Defined.
+Goal weqcoprodf (idweq nat) (idweq nat) (ii1 3) = ii1 3. Proof. apply idpath. Defined.
+Goal weqcoprodf (idweq nat) (idweq nat) (ii2 3) = ii2 3. Proof. apply idpath. Defined.
+Goal invmap (weqcoprodf (idweq nat) (idweq nat)) (ii1 3) = ii1 3. Proof. apply idpath. Defined.
+Goal invmap (weqcoprodf (idweq nat) (idweq nat)) (ii2 3) = ii2 3. Proof. apply idpath. Defined.
 
-Goal bool_to_type true  = unit . apply idpath. Defined.
-Goal bool_to_type false = empty. apply idpath. Defined.
+Goal bool_to_type true  = unit . Proof. apply idpath. Defined.
+Goal bool_to_type false = empty. Proof. apply idpath. Defined.
 
 Goal @weqfibtototal bool _ _ (λ _, idweq bool) (true,,true) = (true,,true).
-  apply idpath. Defined.
+  Proof. apply idpath. Defined.
 Goal invmap (@weqfibtototal bool _ _ (λ _, idweq bool)) (true,,true) = (true,,true).
-  apply idpath. Defined.
+  Proof. apply idpath. Defined.
 
-Goal @weqfp_map nat nat (idweq _) (λ _,nat) (3,,4) = (3,,4). apply idpath. Defined.
-Goal @weqfp_map _ _ boolascoprod (λ _,nat) (ii1 tt,,4) = (true,,4). apply idpath. Defined.
+Goal @weqfp_map nat nat (idweq _) (λ _,nat) (3,,4) = (3,,4). Proof. apply idpath. Defined.
+Goal @weqfp_map _ _ boolascoprod (λ _,nat) (ii1 tt,,4) = (true,,4). Proof. apply idpath. Defined.
 
-Goal @weqfp_invmap nat nat (idweq _) (λ _,nat) (3,,4) = (3,,4). apply idpath. Defined.
-Goal @weqfp_invmap _ _ boolascoprod (λ _,nat) (true,,4) = (ii1 tt,,4). apply idpath. Defined.
+Goal @weqfp_invmap nat nat (idweq _) (λ _,nat) (3,,4) = (3,,4). Proof. apply idpath. Defined.
+Goal @weqfp_invmap _ _ boolascoprod (λ _,nat) (true,,4) = (ii1 tt,,4). Proof. apply idpath. Defined.
 
-Goal weqfp (idweq nat) (λ _,nat) (3,,4) = (3,,4). apply idpath. Defined.
-Goal invmap (weqfp (idweq nat) (λ _,nat)) (3,,4) = (3,,4). apply idpath. Defined.
+Goal weqfp (idweq nat) (λ _,nat) (3,,4) = (3,,4). Proof. apply idpath. Defined.
+Goal invmap (weqfp (idweq nat) (λ _,nat)) (3,,4) = (3,,4). Proof. apply idpath. Defined.
 
-Goal weqtotal2overunit (λ _,nat) (tt,,3) = 3. apply idpath. Defined.
-Goal invmap (weqtotal2overunit (λ _,nat)) 3 = (tt,,3). apply idpath. Defined.
+Goal weqtotal2overunit (λ _,nat) (tt,,3) = 3. Proof. apply idpath. Defined.
+Goal invmap (weqtotal2overunit (λ _,nat)) 3 = (tt,,3). Proof. apply idpath. Defined.
 
-Goal iscontr = isofhlevel 0. apply idpath. Defined.
-Goal isaset = isofhlevel 2.  apply idpath. Defined.
+Goal iscontr = isofhlevel 0. Proof. apply idpath. Defined.
+Goal isaset = isofhlevel 2.  Proof. apply idpath. Defined.
 
 Require UniMath.Foundations.Sets.
 

--- a/UniMath/Induction/M/Limits.v
+++ b/UniMath/Induction/M/Limits.v
@@ -29,6 +29,7 @@ Section StandardLimits.
   (** The condition that [standard_limit] is a cone is basically a rephrasing of
       its definition. *)
   Lemma type_cone : cone d standard_limit.
+  Proof.
     use make_cone; cbn.
     - exact (λ n l, pr1 l n).
     - intros u v f.
@@ -80,7 +81,8 @@ End StandardLimitHomot.
 (** The canonical cone given by an arrow X → Y where Y has a cone *)
 
 Definition into_cone_to_cone {X Y : UU} {g : graph} {d : diagram g _}
-            (coneY : cone d (Y : ob type_precat)) (f : X → Y) : cone d X.
+  (coneY : cone d (Y : ob type_precat)) (f : X → Y) : cone d X.
+Proof.
   use make_cone.
   - intro ver.
     exact (pr1 coneY ver ∘ (f : type_precat ⟦ X, Y ⟧)).
@@ -115,6 +117,7 @@ Section StandardLimitUP.
       - Generalizes univ-iso in HoTT/M-types
   *)
   Lemma limit_universal : is_limit_cone (type_cone d).
+  Proof.
     intro X.
     use isweq_iso.
     - intros xcone x.

--- a/UniMath/Induction/M/Uniqueness.v
+++ b/UniMath/Induction/M/Uniqueness.v
@@ -144,6 +144,7 @@ Section Uniqueness.
   Defined.
 
   Lemma isaprop_M : isaprop (M B).
+  Proof.
     apply invproofirrelevance.
     intros X Y.
     apply subtypePath.

--- a/UniMath/Induction/W/Uniqueness.v
+++ b/UniMath/Induction/W/Uniqueness.v
@@ -136,6 +136,7 @@ Section Uniqueness.
   Defined.
 
   Lemma isaprop_W : isaprop (W B).
+  Proof.
     apply invproofirrelevance.
     intros X Y.
     apply subtypePath.

--- a/UniMath/MoreFoundations/Equivalences.v
+++ b/UniMath/MoreFoundations/Equivalences.v
@@ -85,6 +85,7 @@ Proof.
 Defined.
 
 Definition weq_to_Equivalence {X Y} : X ≃ Y -> X ≅ Y.
+Proof.
   intros f.
   exact (makeEquivalence X Y f (invmap f)
                          (homotweqinvweq f) (homotinvweqweq f)
@@ -123,6 +124,7 @@ Abort.
 
 (* another proof *)
 Definition weq_to_Equivalence' X Y : X ≃ Y -> Equivalence X Y.
+Proof.
   intros [f r].
   unfold isweq in r.
   set (g := λ y, hfiberpr1 f y (pr1 (r y))).

--- a/UniMath/MoreFoundations/Interval.v
+++ b/UniMath/MoreFoundations/Interval.v
@@ -18,10 +18,12 @@ Proof.
 Defined.
 
 Goal ∏ Y {y y':Y} (e : y = y'), interval_map e left = y.
+Proof.
    reflexivity.
 Qed.
 
 Goal ∏ Y {y y':Y} (e : y = y'), interval_map e right = y'.
+Proof.
    reflexivity.
 Qed.
 

--- a/UniMath/MoreFoundations/MoreEquivalences.v
+++ b/UniMath/MoreFoundations/MoreEquivalences.v
@@ -5,6 +5,7 @@ Require Import UniMath.MoreFoundations.PartA.
 Require Import UniMath.MoreFoundations.Equivalences.
 
 Definition weq_to_InverseEquivalence X Y : X ≃ Y -> Equivalence Y X.
+Proof.
   intros [f r].
   unfold isweq in r.
   set (g := λ y, hfiberpr1 f y (pr1 (r y))).

--- a/UniMath/MoreFoundations/PartA.v
+++ b/UniMath/MoreFoundations/PartA.v
@@ -707,6 +707,7 @@ Defined.
 Definition evalat {T} {P:T->UU} (t:T) (f:∏ t:T, P t) := f t.
 
 Definition apfun {X Y} {f f':X->Y} (p:f = f') {x x'} (q:x = x') : f x = f' x'.
+Proof.
   intros. induction q. exact (eqtohomot p x).
 Defined.
 

--- a/UniMath/MoreFoundations/Test.v
+++ b/UniMath/MoreFoundations/Test.v
@@ -7,17 +7,17 @@ Require Import UniMath.MoreFoundations.Bool.
 (** ** Bool.v *)
 
 (* Double check they have the right truth tables: *)
-Goal andb true true = true. reflexivity. Qed.
-Goal andb true false = false. reflexivity. Qed.
-Goal andb false true = false. reflexivity. Qed.
-Goal andb false false = false. reflexivity. Qed.
+Goal andb true true = true. Proof. reflexivity. Qed.
+Goal andb true false = false. Proof. reflexivity. Qed.
+Goal andb false true = false. Proof. reflexivity. Qed.
+Goal andb false false = false. Proof. reflexivity. Qed.
 
-Goal orb true true = true. reflexivity. Qed.
-Goal orb true false = true. reflexivity. Qed.
-Goal orb false true = true. reflexivity. Qed.
-Goal orb false false = false. reflexivity. Qed.
+Goal orb true true = true. Proof. reflexivity. Qed.
+Goal orb true false = true. Proof. reflexivity. Qed.
+Goal orb false true = true. Proof. reflexivity. Qed.
+Goal orb false false = false. Proof. reflexivity. Qed.
 
-Goal implb true true = true. reflexivity. Qed.
-Goal implb true false = false. reflexivity. Qed.
-Goal implb false true = true. reflexivity. Qed.
-Goal implb false false = true. reflexivity. Qed.
+Goal implb true true = true. Proof. reflexivity. Qed.
+Goal implb true false = false. Proof. reflexivity. Qed.
+Goal implb false true = true. Proof. reflexivity. Qed.
+Goal implb false false = true. Proof. reflexivity. Qed.

--- a/UniMath/NumberSystems/Tests.v
+++ b/UniMath/NumberSystems/Tests.v
@@ -11,8 +11,8 @@ Module Test_nat.
 
   Local Open Scope nat_scope.
 
-  Goal 3 ≠ 5. exact tt. Defined.
-  Goal ¬ (3 ≠ 3). intro n. apply n. Defined.
+  Goal 3 ≠ 5. Proof. exact tt. Defined.
+  Goal ¬ (3 ≠ 3). Proof. intro n. apply n. Defined.
 
   Section Test_A.
     Let C  := compl nat 0.
@@ -20,50 +20,50 @@ Module Test_nat.
     Let w := compl_ne_weq_compl nat 0 (λ m, 0 ≠ m) : C ≃ C'.
     Let cn : C := (3,,negpaths0sx _).
     Let cn' : C' := (3,,tt).
-    Goal w cn = cn'. reflexivity. Defined.
-    Goal invmap w cn' = cn. reflexivity. Defined.
-    Goal homotinvweqweq w cn = idpath _. try reflexivity. Abort. (* prevented by funextfun *)
-    Goal homotweqinvweq w cn' = idpath _. reflexivity. Defined. (* 2 seconds *)
+    Goal w cn = cn'. Proof. reflexivity. Defined.
+    Goal invmap w cn' = cn. Proof. reflexivity. Defined.
+    Goal homotinvweqweq w cn = idpath _. Proof. try reflexivity. Abort. (* prevented by funextfun *)
+    Goal homotweqinvweq w cn' = idpath _. Proof. reflexivity. Defined. (* 2 seconds *)
     Let f := weqrecompl nat 0 (isdeceqnat 0).
     Let f' := weqrecompl_ne nat 0 (isdeceqnat 0) (λ m, 0 ≠ m).
-    Goal f (ii1 cn) = 3. reflexivity. Defined.
-    Goal f' (ii1 cn') = 3. reflexivity. Defined.
-    Goal invmap f 3 = (ii1 cn). reflexivity. Defined.
-    Goal invmap f' 3 = (ii1 cn'). reflexivity. Defined.
-    Goal homotweqinvweq f 3 = idpath _. reflexivity. Defined.
-    Goal homotweqinvweq f' 3 = idpath _. reflexivity. Defined.
-    Goal homotinvweqweq f (ii1 cn) = idpath _. try reflexivity. Abort. (* prevented by funextfun *)
-    Goal homotinvweqweq f' (ii1 cn') = idpath _. reflexivity. Defined. (* succeeds by avoiding funextfun *)
+    Goal f (ii1 cn) = 3. Proof. reflexivity. Defined.
+    Goal f' (ii1 cn') = 3. Proof. reflexivity. Defined.
+    Goal invmap f 3 = (ii1 cn). Proof. reflexivity. Defined.
+    Goal invmap f' 3 = (ii1 cn'). Proof. reflexivity. Defined.
+    Goal homotweqinvweq f 3 = idpath _. Proof. reflexivity. Defined.
+    Goal homotweqinvweq f' 3 = idpath _. Proof. reflexivity. Defined.
+    Goal homotinvweqweq f (ii1 cn) = idpath _. Proof. try reflexivity. Abort. (* prevented by funextfun *)
+    Goal homotinvweqweq f' (ii1 cn') = idpath _. Proof. reflexivity. Defined. (* succeeds by avoiding funextfun *)
   End Test_A.
 
-  Goal choice (3 < 4)%dnat true false = true. reflexivity. Defined.
-  Goal choice (3 < 4 ∧ 4 < 5)%dnat%declog true false = true. reflexivity. Defined.
-  Goal choice (¬ (3 < 4))%dnat%declog true false = false. reflexivity. Defined.
-  Goal choice (3 < 4 ∨ 4 < 3)%dnat%declog true false = true. reflexivity. Defined.
-  Goal choice (4 < 3 ∨ 2 < 1)%dnat%declog true false = false. reflexivity. Defined.
+  Goal choice (3 < 4)%dnat true false = true. Proof. reflexivity. Defined.
+  Goal choice (3 < 4 ∧ 4 < 5)%dnat%declog true false = true. Proof. reflexivity. Defined.
+  Goal choice (¬ (3 < 4))%dnat%declog true false = false. Proof. reflexivity. Defined.
+  Goal choice (3 < 4 ∨ 4 < 3)%dnat%declog true false = true. Proof. reflexivity. Defined.
+  Goal choice (4 < 3 ∨ 2 < 1)%dnat%declog true false = false. Proof. reflexivity. Defined.
 
-  Goal si 3 (di 3 2) = 2. reflexivity. Defined.
-  Goal si 3 (di 3 3) = 3. reflexivity. Defined.
-  Goal si 3 (di 3 4) = 4. reflexivity. Defined.
+  Goal si 3 (di 3 2) = 2. Proof. reflexivity. Defined.
+  Goal si 3 (di 3 3) = 3. Proof. reflexivity. Defined.
+  Goal si 3 (di 3 4) = 4. Proof. reflexivity. Defined.
 
-  Goal si 3 2 = 2. reflexivity. Defined.
-  Goal si 3 3 = 3. reflexivity. Defined.
-  Goal si 3 4 = 3. reflexivity. Defined.
-  Goal si 3 5 = 4. reflexivity. Defined.
+  Goal si 3 2 = 2. Proof. reflexivity. Defined.
+  Goal si 3 3 = 3. Proof. reflexivity. Defined.
+  Goal si 3 4 = 3. Proof. reflexivity. Defined.
+  Goal si 3 5 = 4. Proof. reflexivity. Defined.
 
   Section Test_weqdicompl.
 
     Let w := weqdicompl 3 : nat ≃ nat_compl 3.
-    Goal w 2 = (2,,tt). reflexivity. Defined.
-    Goal w 3 = (4,,tt). reflexivity. Defined.
-    Goal invmap w (2,,tt) = 2. reflexivity. Defined.
-    Goal invmap w (4,,tt) = 3. reflexivity. Defined.
-    Goal homotweqinvweq w (2,,tt) = idpath _. reflexivity. Defined.
-    Goal homotweqinvweq w (4,,tt) = idpath _. reflexivity. Defined.
-    Goal homotinvweqweq w 2 = idpath _. reflexivity. Defined.
-    Goal homotinvweqweq w 4 = idpath _. reflexivity. Defined.
-    Goal homotweqinvweqweq w 2 = idpath _. reflexivity. Defined.
-    Goal homotweqinvweqweq w 4 = idpath _. reflexivity. Defined.
+    Goal w 2 = (2,,tt). Proof. reflexivity. Defined.
+    Goal w 3 = (4,,tt). Proof. reflexivity. Defined.
+    Goal invmap w (2,,tt) = 2. Proof. reflexivity. Defined.
+    Goal invmap w (4,,tt) = 3. Proof. reflexivity. Defined.
+    Goal homotweqinvweq w (2,,tt) = idpath _. Proof. reflexivity. Defined.
+    Goal homotweqinvweq w (4,,tt) = idpath _. Proof. reflexivity. Defined.
+    Goal homotinvweqweq w 2 = idpath _. Proof. reflexivity. Defined.
+    Goal homotinvweqweq w 4 = idpath _. Proof. reflexivity. Defined.
+    Goal homotweqinvweqweq w 2 = idpath _. Proof. reflexivity. Defined.
+    Goal homotweqinvweqweq w 4 = idpath _. Proof. reflexivity. Defined.
 
   End Test_weqdicompl.
 
@@ -89,17 +89,19 @@ Module Test_finsum.
     - apply iterop_fun_nat.
   Qed.
 
-  Goal 15 = finsum (isfinitestn _) (λ i:stn 6, i). reflexivity. Qed.
-  Goal 20 = finsum isfinitebool (λ i:bool, 10). reflexivity. Qed.
+  Goal 15 = finsum (isfinitestn _) (λ i:stn 6, i). Proof. reflexivity. Qed.
+  Goal 20 = finsum isfinitebool (λ i:bool, 10). Proof. reflexivity. Qed.
   Goal 21 = finsum (isfinitecoprod isfinitebool isfinitebool)
                    (coprod_rect (λ _, nat) (bool_rect _ 10 4) (bool_rect _  6 1)).
+  Proof.
     reflexivity.            (* fixed *)
   Qed.
 
-  Goal 10 = finsum' (isfinitestn _) (λ i:stn 5, i). reflexivity. Defined. (* fixed! *)
-  Goal 20 = finsum' isfinitebool (λ i:bool, 10). reflexivity. Qed.
+  Goal 10 = finsum' (isfinitestn _) (λ i:stn 5, i). Proof. reflexivity. Defined. (* fixed! *)
+  Goal 20 = finsum' isfinitebool (λ i:bool, 10). Proof. reflexivity. Qed.
   Goal 21 = finsum' (isfinitecoprod isfinitebool isfinitebool)
-                   (coprod_rect (λ _, nat) (bool_rect _ 10 4) (bool_rect _  6 1)).
+              (coprod_rect (λ _, nat) (bool_rect _ 10 4) (bool_rect _  6 1)).
+  Proof.
     try reflexivity.            (* fails, for some reason *)
   Abort.
 
@@ -107,21 +109,21 @@ Module Test_finsum.
     Local Notation "s □ x" := (append s x) (at level 64, left associativity).
     Context (G:abgr) (R:ring) (S:commring) (g g' g'':G) (r r' r'':R) (s s' s'':S).
     Local Open Scope multmonoid.
-    Goal iterop_unoseq_abgr (nil : Sequence G) = 1. reflexivity. Qed.
-    Goal iterop_unoseq_abgr (nil □ g □ g') = g*g'. reflexivity. Qed.
-    Goal iterop_unoseq_abgr (nil □ g □ g' □ g'') = g*g'*g''. reflexivity. Qed.
-    Goal iterop_unoseq_unoseq_mon (M:=G) (sequenceToUnorderedSequence(nil □ sequenceToUnorderedSequence(nil □ g □ g') □ sequenceToUnorderedSequence(nil □ g □ g' □ g''))) = (g*g') * (g*g'*g''). reflexivity. Qed.
-    Goal iterop_unoseq_unoseq_mon (M:=G) (sequenceToUnorderedSequence(nil □ sequenceToUnorderedSequence(nil □ g) □ sequenceToUnorderedSequence(nil))) = g * 1. reflexivity. Qed.
-    Goal iterop_unoseq_unoseq_mon (M:=G) (sequenceToUnorderedSequence(nil □ sequenceToUnorderedSequence(nil) □ sequenceToUnorderedSequence(nil □ g))) = 1 * g. reflexivity. Qed.
+    Goal iterop_unoseq_abgr (nil : Sequence G) = 1. Proof. reflexivity. Qed.
+    Goal iterop_unoseq_abgr (nil □ g □ g') = g*g'. Proof. reflexivity. Qed.
+    Goal iterop_unoseq_abgr (nil □ g □ g' □ g'') = g*g'*g''. Proof. reflexivity. Qed.
+    Goal iterop_unoseq_unoseq_mon (M:=G) (sequenceToUnorderedSequence(nil □ sequenceToUnorderedSequence(nil □ g □ g') □ sequenceToUnorderedSequence(nil □ g □ g' □ g''))) = (g*g') * (g*g'*g''). Proof. reflexivity. Qed.
+    Goal iterop_unoseq_unoseq_mon (M:=G) (sequenceToUnorderedSequence(nil □ sequenceToUnorderedSequence(nil □ g) □ sequenceToUnorderedSequence(nil))) = g * 1. Proof. reflexivity. Qed.
+    Goal iterop_unoseq_unoseq_mon (M:=G) (sequenceToUnorderedSequence(nil □ sequenceToUnorderedSequence(nil) □ sequenceToUnorderedSequence(nil □ g))) = 1 * g. Proof. reflexivity. Qed.
     Close Scope multmonoid.
 
     Local Open Scope ring.
-    Goal sum_unoseq_ring (nil : Sequence R) = 0. reflexivity. Qed.
-    Goal sum_unoseq_ring (nil □ r □ r') = r+r'. reflexivity. Qed.
-    Goal sum_unoseq_ring (nil □ r □ r' □ r'') = r+r'+r''. reflexivity. Qed.
-    Goal product_unoseq_ring (nil : Sequence S) = 1. reflexivity. Qed.
-    Goal product_unoseq_ring (nil □ s □ s') = s*s'. reflexivity. Qed.
-    Goal product_unoseq_ring (nil □ s □ s' □ s'') = s*s'*s''. reflexivity. Qed.
+    Goal sum_unoseq_ring (nil : Sequence R) = 0. Proof. reflexivity. Qed.
+    Goal sum_unoseq_ring (nil □ r □ r') = r+r'. Proof. reflexivity. Qed.
+    Goal sum_unoseq_ring (nil □ r □ r' □ r'') = r+r'+r''. Proof. reflexivity. Qed.
+    Goal product_unoseq_ring (nil : Sequence S) = 1. Proof. reflexivity. Qed.
+    Goal product_unoseq_ring (nil □ s □ s') = s*s'. Proof. reflexivity. Qed.
+    Goal product_unoseq_ring (nil □ s □ s' □ s'') = s*s'*s''. Proof. reflexivity. Qed.
   End Iteration.
 
 End Test_finsum.
@@ -133,12 +135,12 @@ Module Test_int.
 
   Import UniMath.NumberSystems.Integers.
 
-  Goal true = (hzbooleq (natnattohz 3 4) (natnattohz 17 18)) . reflexivity. Qed.
-  Goal false = (hzbooleq (natnattohz 3 4) (natnattohz 17 19)) . reflexivity. Qed.
-  Goal 2 * 100 + 7 * 10 + 4 = (hzabsval (natnattohz (5 * 10 + 8) (3 * 100 + 3 * 10 + 2))) . reflexivity. Qed.
-  Goal O = (hzabsval (hzplus (natnattohz 2 3) (natnattohz 3 2))) . reflexivity. Qed.
-  Goal 2 = (hzabsval (hzminus (natnattohz 2 3) (natnattohz 3 2))) . reflexivity. Qed.
-  Goal 3 * 100 =  (hzabsval (hzmult (natnattohz (2 * 10) (5 * 10)) (natnattohz (3 * 10) (2 * 10)))) . reflexivity. Qed.
+  Goal true = (hzbooleq (natnattohz 3 4) (natnattohz 17 18)) . Proof. reflexivity. Qed.
+  Goal false = (hzbooleq (natnattohz 3 4) (natnattohz 17 19)) . Proof. reflexivity. Qed.
+  Goal 2 * 100 + 7 * 10 + 4 = (hzabsval (natnattohz (5 * 10 + 8) (3 * 100 + 3 * 10 + 2))) . Proof. reflexivity. Qed.
+  Goal O = (hzabsval (hzplus (natnattohz 2 3) (natnattohz 3 2))) . Proof. reflexivity. Qed.
+  Goal 2 = (hzabsval (hzminus (natnattohz 2 3) (natnattohz 3 2))) . Proof. reflexivity. Qed.
+  Goal 3 * 100 =  (hzabsval (hzmult (natnattohz (2 * 10) (5 * 10)) (natnattohz (3 * 10) (2 * 10)))) . Proof. reflexivity. Qed.
 
 End Test_int.
 
@@ -154,11 +156,14 @@ Module Test_rat.
 
   Transparent hz .
 
-  Goal true = ( hqbooleq ( hzhztohq ( natnattohz 4 0 ) ( tpair _ ( natnattohz 3 0 ) ( ct ( hzneq , isdecrelhzneq, ( natnattohz 3 0 ) , 0 %hz ) ) ) )  ( hzhztohq ( natnattohz 13 1 ) ( tpair _ ( natnattohz 11 2 ) ( ct ( hzneq , isdecrelhzneq , ( natnattohz 11 2 ) , 0 %hz ) ) ) ) ) . reflexivity. Qed.
+  Goal true = ( hqbooleq ( hzhztohq ( natnattohz 4 0 ) ( tpair _ ( natnattohz 3 0 ) ( ct ( hzneq , isdecrelhzneq, ( natnattohz 3 0 ) , 0 %hz ) ) ) )  ( hzhztohq ( natnattohz 13 1 ) ( tpair _ ( natnattohz 11 2 ) ( ct ( hzneq , isdecrelhzneq , ( natnattohz 11 2 ) , 0 %hz ) ) ) ) ) .
+  Proof. reflexivity. Qed.
 
-  Goal true = ( decreltobrel hqgthdec ( hzhztohq ( natnattohz 5 0 ) ( tpair _ ( natnattohz 3 0 ) ( ct ( hzneq , isdecrelhzneq , ( natnattohz 3 0 ) , hzzero ) ) ) )  ( hzhztohq ( natnattohz 13 1 ) ( tpair _ ( natnattohz 11 2 ) ( ct ( hzneq , isdecrelhzneq , ( natnattohz 11 2 ) , hzzero ) ) ) ) ) . reflexivity. Qed.
+  Goal true = ( decreltobrel hqgthdec ( hzhztohq ( natnattohz 5 0 ) ( tpair _ ( natnattohz 3 0 ) ( ct ( hzneq , isdecrelhzneq , ( natnattohz 3 0 ) , hzzero ) ) ) )  ( hzhztohq ( natnattohz 13 1 ) ( tpair _ ( natnattohz 11 2 ) ( ct ( hzneq , isdecrelhzneq , ( natnattohz 11 2 ) , hzzero ) ) ) ) ) .
+  Proof. reflexivity. Qed.
 
-  Goal 4 = ( hzabsval ( intpart ( hqdiv ( hztohq ( nattohz ( 10 ) ) )  ( - ( 1 + 1 + 1 ) ) ) ) ) . reflexivity. Qed.
+  Goal 4 = ( hzabsval ( intpart ( hqdiv ( hztohq ( nattohz ( 10 ) ) )  ( - ( 1 + 1 + 1 ) ) ) ) ) .
+  Proof. reflexivity. Qed.
 
 
 

--- a/UniMath/OrderTheory/Lattice/Examples/Subsets.v
+++ b/UniMath/OrderTheory/Lattice/Examples/Subsets.v
@@ -90,6 +90,7 @@ Section Subsets.
   Qed.
 
   Lemma iscomm_union_binop : iscomm union_binop.
+  Proof.
     intros ? ?; unfold union_binop, infinitary_op_to_binop; cbn.
     apply (invweq (hsubtype_univalence _ _)), subtype_equal_cond.
     use make_dirprod; intro; cbn; intros ain;

--- a/UniMath/OrderTheory/OrderedSets/OrderedSets.v
+++ b/UniMath/OrderTheory/OrderedSets/OrderedSets.v
@@ -323,6 +323,7 @@ Definition FiniteOrderedSetDecidableEquality (X:FiniteOrderedSet) : DecidableRel
   λ (x y:X), @decidable_to_DecidableProposition (x = y) (FiniteOrderedSet_isdeceq x y).
 
 Definition FiniteOrderedSetDecidableInequality (X:FiniteOrderedSet) : DecidableRelation X.
+Proof.
   intros x y.
   apply (@decidable_to_DecidableProposition (¬ (x = y)))%logic.
   unfold decidable; simpl.
@@ -333,6 +334,7 @@ Definition FiniteOrderedSetDecidableInequality (X:FiniteOrderedSet) : DecidableR
 Defined.
 
 Definition FiniteOrderedSetDecidableLessThan (X:FiniteOrderedSet) : DecidableRelation X.
+Proof.
   intros x y. simple refine (decidable_to_DecidableProposition _).
   - exact (x < y).
   - apply isfinite_isdec_lessthan. apply finitenessProperty.
@@ -351,10 +353,12 @@ Notation " x > y " := ( FiniteOrderedSetDecidableLessThan _ y x ) (at level 70, 
 Delimit Scope foset with foset.
 
 Definition FiniteOrderedSet_segment {X:FiniteOrderedSet} (x:X) : FiniteSet.
+Proof.
   intros. apply (@subsetFiniteSet X); intro y. exact (y < x)%foset.
 Defined.
 
 Definition height {X:FiniteOrderedSet} : X -> nat.
+Proof.
   intros x. exact (cardinalityFiniteSet (FiniteOrderedSet_segment x)).
 Defined.
 
@@ -420,6 +424,7 @@ Close Scope foset.
 Definition lexicographicOrder
            (X:hSet) (Y:X->hSet)
            (R:hrel X) (S : ∏ x, hrel (Y x)) : hrel (∑ x, Y x)%set.
+Proof.
   intros u u'.
   set (x := pr1 u). set (y := pr2 u). set (x' := pr1 u'). set (y' := pr2 u').
   exact ((x != x' × R x x') ∨ (∑ e : x = x', S x' (transportf Y e y) y')).

--- a/UniMath/Paradoxes/GirardsParadox.v
+++ b/UniMath/Paradoxes/GirardsParadox.v
@@ -203,6 +203,4 @@ Defined.
 End girard.
 
 (* especially if Flse=False *)
-Proposition but_seriously_the_world_explodes : empty.
-  exact (the_world_explodes empty).
-Defined.
+Definition but_seriously_the_world_explodes : empty := the_world_explodes empty.

--- a/UniMath/RealNumbers/Prelim.v
+++ b/UniMath/RealNumbers/Prelim.v
@@ -76,6 +76,7 @@ Proof.
 Qed.
 
 Lemma hqplusdiv2 : ∏ x : hq, x = (x + x) / 2.
+Proof.
   intros x.
   apply hqmultrcan with 2.
   - now apply hqgth_hqneq, hq2_gt0.

--- a/UniMath/SubstitutionSystems/STLC_actegorical.v
+++ b/UniMath/SubstitutionSystems/STLC_actegorical.v
@@ -541,6 +541,7 @@ Section IndAndCoind.
     Defined.
 
     Lemma Church_gen_header_sortToSet_data_ok : is_nat_trans _ _ Church_gen_header_sortToSet_data.
+    Proof.
       intros ξ ξ' f.
       apply nat_trans_eq; try apply HSET.
       intros s. apply funextfun.

--- a/UniMath/SubstitutionSystems/STLC_actegorical_abstractcat.v
+++ b/UniMath/SubstitutionSystems/STLC_actegorical_abstractcat.v
@@ -619,6 +619,7 @@ Section IndAndCoind.
     Defined.
 
     Lemma Church_gen_header_sortToC_data_ok : is_nat_trans _ _ Church_gen_header_sortToC_data.
+    Proof.
       intros ξ ξ' f.
       apply nat_trans_eq; try apply C.
       intros s.

--- a/UniMath/SubstitutionSystems/Signatures.v
+++ b/UniMath/SubstitutionSystems/Signatures.v
@@ -286,6 +286,7 @@ Proof.
 Qed.
 
 Lemma θ_Strength2_int_nicer_implies_θ_Strength2_int: θ_Strength2_int_nicer -> θ_Strength2_int.
+Proof.
   intro Hyp.
   intros X Z Z'.
   assert (HypX := Hyp X Z Z').

--- a/UniMath/SubstitutionSystems/SimplifiedHSS/SubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/SimplifiedHSS/SubstitutionSystems.v
@@ -257,6 +257,7 @@ Qed.
 (** basically the same proof *)
 Lemma bracket_property_parts_identity_nicer_impl2 (h : `T • `T  --> `T):
   bracket_property_parts_identity_nicer h -> bracket_property_parts θ T (identity _) h.
+Proof.
   intro Hyp. induction Hyp as [Hyp1 Hyp2].
   split.
   - etrans.

--- a/UniMath/SubstitutionSystems/SubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/SubstitutionSystems.v
@@ -254,6 +254,7 @@ Qed.
 (** basically the same proof *)
 Lemma bracket_property_parts_identity_nicer_impl2 (h : `T • `T  --> `T):
   bracket_property_parts_identity_nicer h -> bracket_property_parts θ T (identity _) h.
+Proof.
   intro Hyp. induction Hyp as [Hyp1 Hyp2].
   split.
   - etrans.

--- a/UniMath/SyntheticHomotopyTheory/Test.v
+++ b/UniMath/SyntheticHomotopyTheory/Test.v
@@ -15,67 +15,72 @@ Local Notation "1" := (toℤ 1).
 Section A.
 
   Goal ∏ (X:Type) (f := eqweqmap (idpath X)), f = idweq X.
-    reflexivity. Qed.
+  Proof. reflexivity. Qed.
 
   Goal ∏ (X:Type), invmap (idweq X) = idfun X.
-    reflexivity. Qed.
+  Proof. reflexivity. Qed.
 
   Goal ∏ (X:Type) (x:X), iscontrpr1 (iscontrcoconusfromt X x) = (x,,idpath x).
-    reflexivity. Qed.
+  Proof. reflexivity. Qed.
 
   Goal ∏ (X:Type) (x:X), iscontrpr1 (iscontrcoconustot X x) = (x,,idpath x).
-    reflexivity. Qed.
+  Proof. reflexivity. Qed.
 
   Goal ∏ (X Y:Type) (f:X≃Y), invmap (invweq f) = f.
-    reflexivity. Qed.
+  Proof. reflexivity. Qed.
 
   Goal ∏ (X Y Z:Type) (f:X≃Y) (g:Y≃Z), pr1weq (weqcomp f g) = funcomp f g.
-    reflexivity. Qed.
+  Proof. reflexivity. Qed.
 
   Goal ∏ (X Y Z:Type) (f:X≃Y) (g:Y≃Z), invmap (weqcomp f g) = funcomp (invmap g) (invmap f).
-    reflexivity. Qed.
+  Proof. reflexivity. Qed.
 
   Goal ∏ {X : UU} (P Q : X -> Type) (f : ∏ x, P x ≃ Q x) (x:X) (p:P x), weqfibtototal _ _ f (x,,p) = (x,,f x p).
-    reflexivity. Qed.
+  Proof. reflexivity. Qed.
 
   Goal ∏ {X : UU} (P Q : X -> Type) (f : ∏ x, P x ≃ Q x) (x:X) (q:Q x), invmap (weqfibtototal _ _ f) (x,,q) = (x,,invmap (f x) q).
-    reflexivity. Qed.
+  Proof. reflexivity. Qed.
 
   Goal ∏ {X Y : Type} (w : X ≃ Y) (isc : iscontr Y), iscontrpr1 (iscontrweqb w isc) = invmap w (iscontrpr1 isc).
-    reflexivity. Qed.
+  Proof. reflexivity. Qed.
 
   Goal ∏ {X Y : Type} (w : X ≃ Y) (isc : iscontr X), iscontrpr1 (iscontrweqf w isc) = w (iscontrpr1 isc).
-    reflexivity. Qed.
+  Proof. reflexivity. Qed.
 
   Goal ∏ (X:Type) (i : isConnected X) (P:X->hProp) (x0:X) (p:P x0), @predicateOnConnectedType X i P x0 p x0 = p.
-    Fail reflexivity. Abort.
+  Proof. Fail reflexivity. Abort.
 
   Goal ∏ (X:Type) (i : iscontr X) (x0 := pr1 i : X), pr2 i x0 = idpath x0.
-    Fail reflexivity. Abort.
+  Proof. Fail reflexivity. Abort.
 
   Goal ∏ (X Y:Type) (p:X=Y) (x:X), eqweqmap p x = cast p x.
-    Fail reflexivity. Abort.
+  Proof. Fail reflexivity. Abort.
 
   Goal ∏ (X Y:Type) (p:X=Y) (x:X), eqweqmap p x = transportf (λ T, T) p x.
-    Fail reflexivity. Abort.
+  Proof. Fail reflexivity. Abort.
 
   Goal ∏ {X:PointedType} (bc : isBaseConnected X) (t := basepoint X), pr2 (baseConnectedness X bc) t t = hinhpr (idpath t).
+  Proof.
     Fail reflexivity.
   Abort.
 
   Goal ∏ (G:gr), isBaseConnected_BG G (trivialTorsor G) = hinhpr (idpath (trivialTorsor G)).
+  Proof.
     Fail reflexivity.
   Abort.
 
   Goal ∏ (n:ℤ), (n+0 = n)%hz.
+  Proof.
     Fail reflexivity.
   Abort.
 
   Goal ∏ (n:ℤ), (0+n = n)%hz.
+  Proof.
     Fail reflexivity.
   Abort.
 
   Goal ∏ (X : UU) (P : hProp) (f : X → P) (x : X), hinhuniv f (hinhpr x) = f x.
+  Proof.
     reflexivity.
   Qed.
 


### PR DESCRIPTION
put a Proof command at the beginning of every interactive proof and definition, incl. after a Goal command

in Rocq 9.4alpha, not putting it gives rise to a warning missing-proof-command

(I am sorry, but only now do I notice that I have not worked on my fork to create this PR - this is because I was on a test environment for Rocq 9.4alpha. Anyway, this is a trivial PR.)