### PR TITLE
avoid CI failure after September 23

### DIFF
--- a/.github/workflows/build-unimath.yml
+++ b/.github/workflows/build-unimath.yml
@@ -32,7 +32,7 @@ jobs:
     name: Sanity Checks
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install build dependencies
         run: |
           sudo apt-get update
@@ -60,12 +60,12 @@ jobs:
     name: Build on Linux (Coq ${{ matrix.coq-version }})
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Grab the cache if available and extract it to dune-cache/. We tell dune
       # to use $(pwd)/dune-cache/ in the custom_script when initiating the
       # docker run.
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         id: cache
         with:
           path: dune-cache
@@ -110,12 +110,12 @@ jobs:
 
       - name: Upload the generated vo files
         if: github.ref == 'refs/heads/master' && matrix.coq-version == '8.20'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: build
           path: _build/default/UniMath/
 
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@v5
         if: always()
         with:
           path: dune-cache
@@ -178,18 +178,18 @@ jobs:
 
     steps:
       # Check out the current branch of UniMath in the current directory.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Check out the satellite we want to build in Satellite/.
       - name: Clone ${{ matrix.satellite }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: UniMath/${{ matrix.satellite }}
           path: Satellite
 
       # Grab the cache if available. We tell dune to use $(pwd)/dune-cache/ in
       # the custom_script below.
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         id: cache
         with:
           path: dune-cache
@@ -229,7 +229,7 @@ jobs:
         if: ${{ always() }}
         run: sudo chown -R 1001:116 .
 
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@v5
         if: always ()
         with:
           path: dune-cache
@@ -241,9 +241,9 @@ jobs:
     needs: build-Unimath-ubuntu
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         id: cache
         with:
           path: dune-cache
@@ -275,14 +275,14 @@ jobs:
         if: ${{ always() }}
         run: sudo chown -R 1001:116 .
 
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@v5
         if: always()
         with:
           path: dune-cache
           key: UniMath-doc-Linux-coq-latest-${{ github.run_id }}-${{ github.run_number }}
 
       - name: Upload the generated documentation
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: rocqdoc
           path: _build/default/UniMath/UniMath.html
@@ -294,10 +294,10 @@ jobs:
   #  needs: build-Unimath-ubuntu
   #  runs-on: "ubuntu-22.04"
   #  steps:
-  #    - uses: actions/checkout@v4
+  #    - uses: actions/checkout@v5
 
   #    - name: Grab the cache if available and extract it to alectryon-cache
-  #      uses: actions/cache/restore@v4
+  #      uses: actions/cache/restore@v5
   #      with:
   #        path: alectryon-cache
   #        key: UniMath-alectryon-${{ github.run_id }}-${{ github.run_number }}
@@ -306,7 +306,7 @@ jobs:
   #          UniMath-alectryon-
 
   #    - name: Download the generated vo files
-  #      uses: actions/download-artifact@v4
+  #      uses: actions/download-artifact@v5
   #      with:
   #        name: build
   #        path: _build/default/UniMath/
@@ -356,12 +356,12 @@ jobs:
   #      run: sudo chown -R 1001:116 .
 
   #    - name: Upload the generated alectryon files
-  #      uses: actions/upload-artifact@v4
+  #      uses: actions/upload-artifact@v5
   #      with:
   #        name: alectryon
   #        path: alectryon
 
-  #    - uses: actions/cache/save@v4
+  #    - uses: actions/cache/save@v5
   #      if: always()
   #      with:
   #        path: alectryon-cache
@@ -376,7 +376,7 @@ jobs:
       contents: write
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Create the site directory
         run: mkdir site && mkdir site/gen
@@ -385,13 +385,13 @@ jobs:
         run: cp _config.yml site; find . -name "*.md" -exec cp --parents {} site \;
 
       - name: Download the rocqdoc documentation
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: rocqdoc
           path: site/gen/rocqdoc
 
       #- name: Download the alectryon documentation
-      #  uses: actions/download-artifact@v4
+      #  uses: actions/download-artifact@v5
       #  with:
       #    name: alectryon
       #    path: site/gen/alectryon


### PR DESCRIPTION
v4 -> v5 for first-party actions checkout, cache/save, cache/restore, upload-artifact, download-artifact

see https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/ for the announcement of removal of Node20 that seems to run the v4 actions (which is not spelt out in that post)