### PR TITLE
Add reflexive graphs library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ endif
 # The packages, listed in order by dependency:
 PACKAGES += Foundations
 PACKAGES += MoreFoundations
+PACKAGES += IdentitySystems
 PACKAGES += Combinatorics
 PACKAGES += Algebra
 PACKAGES += Tactics

--- a/UniMath/CategoryTheory/CategoryRXGraph.v
+++ b/UniMath/CategoryTheory/CategoryRXGraph.v
@@ -1,0 +1,197 @@
+(********************************************************************************
+
+ Reflexive Graphs of (Small) Categories
+
+ We construct categories as a tower of reflexive graphs, obtaining that
+ [catiso]s correspond to identifications of [category]s in
+ [weq_category_paths_to_catiso].  Compare this file to [CategoryEquality.v].
+
+ Contents:
+ 1. Reflexive graph of [precategory_ob_mor]
+ 2. Reflexive graph of [precategory_data]
+ 3. Reflexive graphs of [precategory] and [category]
+
+ Author: B. Szilvasy
+ September 2026
+
+ ********************************************************************************)
+
+Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.All.
+
+Require Import UniMath.CategoryTheory.Core.Categories.
+Require Import UniMath.CategoryTheory.Core.Functors.
+Require Import UniMath.CategoryTheory.catiso.
+
+Require Import UniMath.IdentitySystems.RXGraph.
+Require Import UniMath.IdentitySystems.Examples.
+Require Import UniMath.IdentitySystems.Lenses.
+Require Import UniMath.IdentitySystems.RXGraphOfRXGraphs.
+
+Local Open Scope cat.
+Local Open Scope rxgraph.
+Local Bind Scope rxgraph_spec with rxgraph.
+
+(** ** Reflexive graph of [precategory_ob_mor] *)
+
+Definition precategory_mor_on_rxgraph : contra_lens UU_rxgraph.
+Proof.
+  use make_contra_lens.
+  - intro ob; exact (∏ (_ _ : ob), UU_rxgraph)%rxgraph_spec.
+  - cbn; intros C D w mor a b.
+    exact (mor (w a) (w b)).
+  - intros C mor; exact (refl mor).
+Defined.
+
+Definition precategory_ob_mor_rxgraph : rxgraph
+  := total_rxgraph (contra_lens_disp_rxgraph precategory_mor_on_rxgraph).
+
+Lemma is_univalent_precategory_ob_mor_rxgraph : is_univalent precategory_ob_mor_rxgraph.
+Proof.
+  apply is_univalent_total_rxgraph.
+  - exact UU_rxgraph'.
+  - apply is_univalent_contra_lens_disp_rxgraph; intro.
+    exact (∏! _ _, UU_rxgraph')%rxgraph_spec.
+Qed.
+
+Definition precategory_ob_mor_iso (C D : precategory_ob_mor) : UU
+  := C ≈{precategory_ob_mor_rxgraph} D.
+Coercion precategory_ob_mor_iso_to_functor_data {C D : precategory_ob_mor}
+  (F : precategory_ob_mor_iso C D)
+  : functor_data C D.
+Proof.
+  cbn in F.
+  exists (pr1 F).
+  exact (pr2 F).
+Defined.
+
+(** ** Reflexive graph of [precategory_data] *)
+
+Definition precategory_id_comp_rxgraph : unbiased_lens precategory_ob_mor_rxgraph.
+Proof.
+  use make_unbiased_lens.
+  - intros C D F.
+    change precategory_ob_mor in C, D.
+    change (precategory_ob_mor_iso C D) in F.
+    exact ((∏ (a : C), Δ D ⟦F a, F a⟧)
+          × (∏ a b c (_ : C ⟦a, b⟧) (_ : C ⟦b, c⟧),
+               Δ D ⟦F a, F c⟧))%rxgraph_spec.
+  - cbn; intros C D F [id comp].
+    change precategory_ob_mor in C, D.
+    change (precategory_ob_mor_iso C D) in F.
+    split.
+    + exact (λ x, #F (id x)).
+    + exact (λ _ _ _ f g, #F (comp _ _ _ f g)).
+  - cbn; intros C D F [id comp].
+    change precategory_ob_mor in C, D.
+    change (precategory_ob_mor_iso C D) in F.
+    split.
+    + exact (λ x, id (F x)).
+    + exact (λ _ _ _ f g, comp _ _ _ (#F f) (#F g)).
+  - intros C idmor; exact (refl idmor).
+  - intros C idmor; exact (refl idmor).
+Defined.
+
+Definition precategory_data_rxgraph₀ : rxgraph
+  := total_rxgraph
+       (unbiased_lens_disp_rxgraph
+          precategory_id_comp_rxgraph).
+
+Lemma is_univalent_precategory_data_rxgraph₀ : is_univalent precategory_data_rxgraph₀.
+Proof.
+  apply is_univalent_total_rxgraph.
+  - exact is_univalent_precategory_ob_mor_rxgraph.
+  - apply is_univalent_unbiased_lens_disp_rxgraph; intros x y e.
+    apply is_univalent_dirprod_rxgraph.
+    + apply is_univalent_product_rxgraph; intro.
+      apply rxgraph_univalence.
+    + do 5 (apply is_univalent_product_rxgraph; intro).
+      apply rxgraph_univalence.
+Qed.
+
+Lemma weq_precategory_data_rxgraph₀_edge_catiso (C D : precategory_data)
+  : C ≈{precategory_data_rxgraph₀} D ≃ catiso C D.
+Proof.
+  use weq_iso.
+  - intros [F HF].
+    change (precategory_ob_mor_iso C D) in F.
+    change (is_functor F) in HF.
+    exists (make_functor F HF).
+    split.
+    + intros a b; apply weqproperty.
+    + apply weqproperty.
+  - intros [F [HFF Hobs]].
+    simple refine ((_,, _),, _,, _); cbn.
+    + exact (make_weq F Hobs).
+    + exact (weq_from_fully_faithful HFF).
+    + exact (functor_id F).
+    + intros a b c f g.
+      exact (functor_comp F f g).
+  - easy.
+  - easy.
+Defined.
+
+Definition precategory_data_rxgraph : rxgraph.
+Proof.
+  use make_rxgraph.
+  - exact precategory_data.
+  - exact catiso.
+  - exact identity_catiso.
+Defined.
+
+Lemma is_univalent_precategory_data_rxgraph : is_univalent precategory_data_rxgraph.
+Proof.
+  apply is_univalent_from_weq.
+  intros a b.
+  apply (weqcomp (weq_id_to_edge is_univalent_precategory_data_rxgraph₀ a b)).
+  apply weq_precategory_data_rxgraph₀_edge_catiso.
+Qed.
+
+(** ** Reflexive graphs of [precategory] and [category] *)
+
+(* This is not univalent *)
+Definition precategory_rxgraph : rxgraph.
+Proof.
+  use make_rxgraph.
+  - exact precategory.
+  - exact catiso.
+  - exact identity_catiso.
+Defined.
+
+Definition category_rxgraph : rxgraph.
+Proof.
+  use make_rxgraph.
+  - exact category.
+  - exact catiso.
+  - exact identity_catiso.
+Defined.
+
+Definition is_univalent_category_rxgraph : is_univalent category_rxgraph.
+Proof.
+  use is_univalent_rxgraph_iso_f.
+  - exact (sub_rxgraph precategory_data_rxgraph (λ (C : precategory_data),
+               has_homsets C × is_precategory C)).
+  - use make_rxgraph_iso.
+    + use weq_iso.
+      * intros [C [H₁ H₂]]; exact ((C,, H₂),, H₁).
+      * intros [[C H₂] H₁]; exact (C,, H₁,, H₂).
+      * easy.
+      * easy.
+    + intros C D; cbn.
+      exact (idweq _).
+    + easy.
+  - apply is_univalent_sub_rxgraph.
+    + apply is_univalent_precategory_data_rxgraph.
+    + intro C.
+      apply isaprop_assume_it_is.
+      intros [hs H].
+      apply isapropdirprod.
+      * apply isaprop_has_homsets.
+      * apply isaprop_is_precategory, hs.
+Qed.
+
+Corollary weq_category_paths_to_catiso (C D : category)
+  : C = D ≃ catiso C D.
+Proof.
+  exact (weq_id_to_edge is_univalent_category_rxgraph C D).
+Defined.

--- a/UniMath/IdentitySystems/.package/files
+++ b/UniMath/IdentitySystems/.package/files
@@ -1,0 +1,6 @@
+RXGraph.v
+Examples.v
+Lenses.v
+RXGraphOfRXGraphs.v
+Fibred.v
+

--- a/UniMath/IdentitySystems/Examples.v
+++ b/UniMath/IdentitySystems/Examples.v
@@ -1,0 +1,519 @@
+(********************************************************************************
+
+ Constructions of reflexive graphs
+
+ This file contains a zoo of reflexive graph constructions,
+ corresponding to various type constructors.
+
+ Contains:
+ - Reflexive graphs:
+   discrete (Δ), codiscrete (∇),
+   product (∏), binary product (×),
+   binary coproduct (⨿), universe ([UU_rxgraph]),
+   opposite (^op), total ([total_rxgraph]),
+   component (⟦⟧), sub- ({ ∣ }).
+ - Displayed reflexive graphs:
+   sigma, discrete, trivial, total opposite.
+ - Notations for the above.
+
+ Author: B. Szilvasy
+ February—September 2026
+
+ ********************************************************************************)
+
+Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.All.
+
+Require Import UniMath.IdentitySystems.RXGraph.
+
+Local Open Scope rxgraph.
+
+(** ** Reflexive graphs *)
+
+(** The discrete reflexive graph [Δ A] is the reflexive graph whose vertices are
+    [A] and whose edges are identifications.  It is always univalent. *)
+
+Definition discrete_rxgraph (A : UU) : univalent_rxgraph.
+Proof.
+  use make_univalent_rxgraph.
+  1: use make_rxgraph.
+  - exact A.
+  - exact (@paths A).
+  - exact idpath.
+  - apply is_univalent_from_iscontr_edges_from; intro.
+    exact (iscontr_paths_from _).
+Defined.
+
+(** The codiscrete reflexive graph [∇ A] has vertices [A]
+    and edges [unit].  It is univalent if [A] is a proposition. *)
+
+Definition codiscrete_rxgraph (A : UU) : rxgraph.
+Proof.
+  use make_rxgraph.
+  - exact A.
+  - exact (λ _ _, unit).
+  - easy.
+Defined.
+
+Definition is_univalent_codiscrete_rxgraph (A : UU)
+  (H : isaprop A)
+  : is_univalent (codiscrete_rxgraph A).
+Proof.
+  apply is_univalent_from_weq.
+  intros a b; apply weqcontrtounit, H.
+Qed.
+
+Definition prop_rxgraph (A : UU) (H : isaprop A) : univalent_rxgraph
+  := make_univalent_rxgraph _ (is_univalent_codiscrete_rxgraph A H).
+
+Definition hProp_rxgraph (A : hProp) : univalent_rxgraph
+  := prop_rxgraph A (propproperty A).
+
+(** A family of reflexive graphs [x : B ⊢ E[x]] gives rise to a univalent
+    reflexive graph whose vertices are [∏ x, E[x]].  It is univalent
+    if all [E] are (assuming function extensionality). *)
+
+Definition product_rxgraph {B : UU} (E : B -> rxgraph) : rxgraph.
+Proof.
+  use make_rxgraph.
+  - exact (∏ x, E x).
+  - intros f g.
+    exact (∏ x, f x ≈ g x).
+  - intros f x.
+    exact (refl (f x)).
+Defined.
+
+Definition is_univalent_product_rxgraph {B : UU} (E : B -> rxgraph)
+  (H : ∏ x, is_univalent (E x))
+  : is_univalent (product_rxgraph E).
+Proof.
+  use is_univalent_from_weq.
+  intros f g.
+  apply (weqcomp (weqtoforallpaths _ _ _)).
+  use weqonsecfibers; intro a.
+  apply (weq_id_to_edge (H a)).
+Qed.
+
+Definition product_rxgraph' {B : UU} (E : B -> univalent_rxgraph) : univalent_rxgraph
+  := make_univalent_rxgraph _ (is_univalent_product_rxgraph E (λ x, E x)).
+
+(** The binary product [A × B] of reflexive graphs [A] and [B] has the obvious
+    vertices and edges the binary products of [A]- and [B]-edges.  It is univalent
+    if both [A] and [B] are. *)
+
+Definition dirprod_rxgraph (A B : rxgraph) : rxgraph.
+Proof.
+  use make_rxgraph.
+  - exact (A × B).
+  - intros a b.
+    exact (pr1 a ≈ pr1 b × pr2 a ≈ pr2 b).
+  - intro a.
+    exact (refl (pr1 a),, refl (pr2 a)).
+Defined.
+
+Lemma is_univalent_dirprod_rxgraph (A B : rxgraph)
+  (HA : is_univalent A)
+  (HB : is_univalent B)
+  : is_univalent (dirprod_rxgraph A B).
+Proof.
+  apply is_univalent_from_weq.
+  intros aa bb.
+  apply (weqcomp pathsdirprodweq).
+  apply weqdirprodf.
+  - apply (weq_id_to_edge HA).
+  - apply (weq_id_to_edge HB).
+Qed.
+
+Definition dirprod_rxgraph' (A B : univalent_rxgraph) : univalent_rxgraph
+  := make_univalent_rxgraph _ (is_univalent_dirprod_rxgraph _ _ A B).
+
+(** The (binary) coproduct reflexive graph [A ⨿ B] has the obvious vertices.
+    Its edges [inl a₁ ≈ inl a₂] are [a₁ ≈ a₂], and edges [inr b₁ ≈ inr b₂] are
+    [b₁ ≈ b₂], while the other two edges are [empty].  It is univalent if [A]
+    and [B] are. *)
+
+Definition coprod_edges
+  {A B : rxgraph}
+  (x y : A ⨿ B)
+  : UU.
+Proof.
+  induction x as [a₁ | b₁];
+    induction y as [a₂ | b₂].
+  - exact (a₁ ≈ a₂).
+  - exact empty.
+  - exact empty.
+  - exact (b₁ ≈ b₂).
+Defined.
+
+Definition coprod_refl
+  {A B : rxgraph}
+  (x : A ⨿ B)
+  : coprod_edges x x.
+Proof.
+  induction x as [a | b]; apply refl.
+Defined.
+
+Definition coprod_rxgraph (A B : rxgraph) : rxgraph.
+Proof.
+  use make_rxgraph.
+  - exact (A ⨿ B).
+  - exact (@coprod_edges A B).
+  - exact (@coprod_refl A B).
+Defined.
+
+Definition is_univalent_coprod_rxgraph
+  (A B : rxgraph)
+  (HA : is_univalent A)
+  (HB : is_univalent B)
+  : is_univalent (coprod_rxgraph A B).
+Proof.
+  use is_univalent_from_weq.
+  intros x y.
+  apply (weqcomp (equality_by_case_equiv x y)).
+  induction x as [a₁ | b₁]; induction y as [a₂ | b₂]; cbn.
+  - apply (weq_id_to_edge HA).
+  - exact (idweq empty).
+  - exact (idweq empty).
+  - apply (weq_id_to_edge HB).
+Qed.
+
+Definition coprod_rxgraph'
+  (A B : univalent_rxgraph)
+  : univalent_rxgraph
+  := make_univalent_rxgraph _
+       (is_univalent_coprod_rxgraph A B A B).
+
+(** [UU_rxgraph] is the (large) reflexive graph of (small) types.
+    It is univalent precisely if the universe is.  We indicate
+    the larger size with an imaginary universe parameter [ℓ]. *)
+
+Definition UU_rxgraph (* ℓ *) : rxgraph (* ℓ+1 *).
+Proof.
+  use make_rxgraph.
+  - exact (UU (* ℓ *)).
+  - exact weq.
+  - exact idweq.
+Defined.
+
+Goal univalenceStatement = is_univalent UU_rxgraph.
+  reflexivity.
+Qed.
+
+Definition UU_rxgraph' (* ℓ *) : univalent_rxgraph (* ℓ+1 *)
+  := make_univalent_rxgraph UU_rxgraph univalenceAxiom.
+
+(** A family of types [x : B ⊢ E[x]] gives a reflexive graph [B/E] called the image of the family. *)
+
+Definition family_image_rxgraph (B : UU) (E : B -> UU) : rxgraph.
+Proof.
+  use make_rxgraph.
+  - exact B.
+  - intros a b; exact (E a ≃ E b).
+  - intro a; exact (idweq (E a)).
+Defined.
+
+(** The opposite [G^op] of a reflexive graph [G] has the same vertices, but
+    flipped edges.  It is univalent if and only if G is. *)
+
+Definition opp_rxgraph (A : rxgraph) : rxgraph.
+Proof.
+  use make_rxgraph.
+  - exact A.
+  - intros a b.
+    exact (b ≈ a).
+  - intro a.
+    exact (refl a).
+Defined.
+
+Lemma opp_opp_rxgraph_compute (A : rxgraph)
+  : opp_rxgraph (opp_rxgraph A) = A.
+Proof. reflexivity. Defined.
+
+Lemma is_univalent_opp_rxgraph (A : rxgraph)
+  (HA : is_univalent A)
+  : is_univalent (opp_rxgraph A).
+Proof.
+  apply (is_univalent_from_isaprop_edges_from (opp_rxgraph A)).
+  exact (is_univalent_to_isaprop_edges_to A HA).
+Defined.
+
+Definition opp_rxgraph' (A : univalent_rxgraph) : univalent_rxgraph
+  := make_univalent_rxgraph _ (is_univalent_opp_rxgraph _ A).
+
+(** A displayed reflexive graph [x : B |- E[x]] gives a reflexive graph
+    whose vertices are sigma types.  It is univalent if [B] and [E] are. *)
+
+Definition total_rxgraph
+  {B : rxgraph} (E : disp_rxgraph B) : rxgraph.
+Proof.
+  use make_rxgraph.
+  - exact (∑ x, E x).
+  - intros [x a] [y b].
+    exact (∑ (e : x ≈ y), a ≈[e] b).
+  - intros [x a].
+    exists (refl x).
+    exact (disp_refl x a).
+Defined.
+
+Definition is_univalent_total_rxgraph
+  {B : rxgraph} (E : disp_rxgraph B)
+  (HB : is_univalent B)
+  (HE : is_disp_univalent E)
+  : is_univalent (total_rxgraph E).
+Proof.
+  apply is_univalent_from_weq.
+  intros xa yb.
+  apply (weqcomp (total2_paths_equiv' _ _ _)).
+  use weqbandf; cbn.
+  - apply (weq_id_to_edge HB).
+  - intro e.
+    apply (weqcomp (transportf_weq_pathover _ _ _)).
+    apply (weq_PathOver_to_disp_edge HE).
+Qed.
+
+Definition total_rxgraph'
+  {B : univalent_rxgraph} (E : univalent_disp_rxgraph B)
+  : univalent_rxgraph
+  := make_univalent_rxgraph _ (is_univalent_total_rxgraph E B E).
+
+(** A displayed reflexive graph's components are (by definition) univalent if
+    the displayed reflexive graph is. *)
+
+Definition is_univalent_disp_rxgraph_at
+  {B : rxgraph} (E : disp_rxgraph B)
+  (HA : is_disp_univalent E)
+  : ∏ x, is_univalent (disp_rxgraph_at E x)
+  := HA.
+
+Definition disp_rxgraph_at'
+  {B : rxgraph} (E : univalent_disp_rxgraph B)
+  (x : B)
+  : univalent_rxgraph
+  := make_univalent_rxgraph _
+       (is_univalent_disp_rxgraph_at E E x).
+
+(** Given a family of types [x : A ⊢ P[x]] over a reflexive graph A,
+    the sub-reflexive graph of [A] satisfying [P] is the
+    reflexive graph whose elements are those of [A] satisfying [P].
+    It is univalent if [A] is univalent and [P] is a predicate. *)
+
+Definition sub_rxgraph (A : rxgraph) (P : A -> UU) : rxgraph.
+Proof.
+  use make_rxgraph.
+  - exact (∑ a, P a).
+  - intros a b.
+    exact (pr1 a ≈ pr1 b).
+  - intros a.
+    apply refl.
+Defined.
+
+Definition is_univalent_sub_rxgraph
+  (A : rxgraph) (P : A -> UU)
+  (HA : is_univalent A)
+  (HP : isPredicate P)
+  : is_univalent (sub_rxgraph A P).
+Proof.
+  apply is_univalent_from_weq.
+  intros a b.
+  refine (weqcomp (Injectivity pr1 _ a b) _).
+  { apply isweqonpathsincl, isinclpr1, HP. }
+  apply (weq_id_to_edge HA).
+Defined.
+
+Definition sub_rxgraph_pred'
+  (A : univalent_rxgraph) (P : A -> UU)
+  (HP : isPredicate P)
+  : univalent_rxgraph
+  := make_univalent_rxgraph _
+       (is_univalent_sub_rxgraph A P A HP).
+
+Definition sub_rxgraph'
+  (A : univalent_rxgraph) (P : A -> hProp)
+  : univalent_rxgraph
+  := make_univalent_rxgraph _
+       (is_univalent_sub_rxgraph A P A
+          (λ x, propproperty (P x))).
+
+(** A displayed reflexive graph [E₁] over [B], along with a
+    displayed reflexive graph [E₂] over the total reflexive graph of [E₁],
+    gives rise to a displayed reflexive graph over [B] whose
+    vertices are the sums of [E₁].  It is univalent if [E₁] and [E₂] are. *)
+
+Definition sigma_disp_rxgraph
+  {B : rxgraph}
+  (E₁ : disp_rxgraph B)
+  (E₂ : disp_rxgraph (total_rxgraph E₁))
+  : disp_rxgraph B.
+Proof.
+  use make_disp_rxgraph.
+  - intro x; exact (∑ (e₁ : E₁ x), E₂ (x,, e₁)).
+  - intros x y p [e₁ e₂] [e₁' e₂'].
+    refine (∑ (p₁ : e₁ ≈[p] e₁'), e₂ ≈[_] e₂').
+    exact (p,,p₁).
+  - intros x [e₁ e₂].
+    exists (disp_refl x e₁).
+    exact (disp_refl _ e₂).
+Defined.
+
+(** Components of [sigma_disp_rxgraph] wind up being the total reflexive graph of
+    the following displayed reflexive graph over the components of [E₁]. *)
+
+Definition sigma_disp_rxgraph_at
+  {B : rxgraph}
+  (E₁ : disp_rxgraph B)
+  (E₂ : disp_rxgraph (total_rxgraph E₁))
+  (x : B)
+  : disp_rxgraph (disp_rxgraph_at E₁ x).
+Proof.
+  use make_disp_rxgraph.
+  - intro e₁; exact (E₂ (x,,e₁)).
+  - intros e₁ e₁' p₁ e₂ e₂'.
+    refine (e₂ ≈[_] e₂').
+    exact (refl _,,p₁).
+  - intros e₁ e₂.
+    cbn in e₂.
+    exact (disp_refl _ e₂).
+Defined.
+
+Definition is_univalent_sigma_disp_rxgraph
+  {B : rxgraph}
+  (E₁ : disp_rxgraph B)
+  (E₂ : disp_rxgraph (total_rxgraph E₁))
+  (H₁ : is_disp_univalent E₁)
+  (H₂ : is_disp_univalent E₂)
+  : is_disp_univalent (sigma_disp_rxgraph E₁ E₂).
+Proof.
+  intro x.
+  change (is_univalent (total_rxgraph (sigma_disp_rxgraph_at E₁ E₂ x))).
+  apply is_univalent_total_rxgraph.
+  - exact (H₁ x).
+  - intro e₁.
+    exact (H₂ _).
+Qed.
+
+Definition sigma_disp_rxgraph'
+  {B : rxgraph}
+  (E₁ : univalent_disp_rxgraph B)
+  (E₂ : univalent_disp_rxgraph (total_rxgraph E₁))
+  : univalent_disp_rxgraph B
+  := _,, is_univalent_sigma_disp_rxgraph E₁ E₂ E₁ E₂.
+
+(** A family of types [x : B |- E[x]] gives rise to a discrete displayed
+    reflexive graph whose vertices are the [PathPair]s.  It is always
+    univalent. *)
+
+Definition discrete_disp_rxgraph {B : UU} (E : B -> UU)
+  : univalent_disp_rxgraph (discrete_rxgraph B).
+Proof.
+  use make_univalent_disp_rxgraph.
+  1: use make_disp_rxgraph.
+  - exact E.
+  - intros x y e a b.
+    exact (PathOver e a b).
+  - easy.
+  - intros x a b.
+    apply (weqhomot _ (idweq (a = b))).
+    intro p; now induction p.
+Defined.
+
+(** A reflexive graph [E] lifts trivially to a displayed reflexive graph over
+    another. *)
+
+Definition trivial_disp_rxgraph (B E : rxgraph)
+  : disp_rxgraph B.
+Proof.
+  use make_disp_rxgraph.
+  - intro; exact E.
+  - intros x y e; exact (edge E).
+  - intro; exact refl.
+Defined.
+
+Lemma trivial_disp_rxgraph_at_compute
+  (B E : rxgraph) (x : B)
+  : disp_rxgraph_at (trivial_disp_rxgraph B E) x = E.
+Proof. reflexivity. Defined.
+
+Definition trivial_disp_rxgraph'
+  (B : rxgraph) (E : univalent_rxgraph)
+  : univalent_disp_rxgraph B
+  := make_univalent_disp_rxgraph
+       (trivial_disp_rxgraph B E)
+       (λ x, E).
+
+(** The total opposite of a displayed reflexive graph [x : B ⊢ E[x]]
+    is the displayed reflexive graph over [B^op] with the same
+    vertices as [E] but flipped edges.  It is univalent if [E] is. *)
+
+Definition total_opp_disp_rxgraph
+  {B : rxgraph} (E : disp_rxgraph B)
+  : disp_rxgraph (opp_rxgraph B).
+Proof.
+  use make_disp_rxgraph.
+  - exact E.
+  - intros x y e a b; cbn in e.
+    exact (b ≈[e] a).
+  - intros x a; cbn in x.
+    exact (disp_refl x a).
+Defined.
+
+Definition is_univalent_total_opp_disp_rxgraph
+  {B : rxgraph} (E : disp_rxgraph B)
+  (HE : is_disp_univalent E)
+  : is_disp_univalent (total_opp_disp_rxgraph E).
+Proof.
+  intro x.
+  apply is_univalent_from_isaprop_edges_from.
+  exact (is_univalent_to_isaprop_edges_to _ (HE x)).
+Qed.
+
+Lemma total_opp_opp_disp_rxgraph_compute
+  {B : rxgraph} (E : disp_rxgraph B)
+  : total_opp_disp_rxgraph (total_opp_disp_rxgraph E) = E.
+Proof. reflexivity. Defined.
+
+Definition total_opp_disp_rxgraph'
+  {B : rxgraph} (E : univalent_disp_rxgraph B)
+  : univalent_disp_rxgraph (opp_rxgraph B)
+  := make_univalent_disp_rxgraph _
+       (is_univalent_total_opp_disp_rxgraph E E).
+
+(** ** Notations for building reflexive graphs. *)
+
+Notation "'Δ' A" := (discrete_rxgraph A) (at level 200) : rxgraph_spec.
+(* type in Emacs using agda-input with \Delta or \GD *)
+
+Notation "'∇' A" := (codiscrete_rxgraph A) (at level 200) : rxgraph_spec.
+Notation "'∇![' H  ']' A" := (prop_rxgraph A H) (at level 200) : rxgraph_spec.
+Notation "'∇!' A" := (hProp_rxgraph A) (at level 200) : rxgraph_spec.
+(* type in Emacs using agda-input with \nabla *)
+
+Notation "'∏' x .. y , G" :=
+  (product_rxgraph (λ x, .. (product_rxgraph (λ y, G%rxgraph_spec)) ..)) : rxgraph_spec.
+Notation "'∏!' x .. y , G" :=
+  (product_rxgraph' (λ x, .. (product_rxgraph' (λ y, G%rxgraph_spec)) ..))
+    (at level 200, x binder, y binder, right associativity) : rxgraph_spec.
+(* type in Emacs using agda-input with \prod *)
+
+Notation "A × B" := (dirprod_rxgraph A%rxgraph_spec B%rxgraph_spec) : rxgraph_spec.
+Notation "A '×!' B" := (dirprod_rxgraph' A%rxgraph_spec B%rxgraph_spec)
+                         (at level 75, right associativity) : rxgraph_spec.
+(* type in Emacs using agda-input with \times *)
+
+Notation "A ⨿ B" := (coprod_rxgraph A%rxgraph_spec B%rxgraph_spec) : rxgraph_spec.
+Notation "A '⨿!' B" := (coprod_rxgraph' A%rxgraph_spec B%rxgraph_spec) (at level 75, right associativity) : rxgraph_spec.
+(* type in Emacs with C-X 8 RET AMALGAMATION OR COPRODUCT
+   or using agda-input with \union (on the second page). *)
+
+Notation "B '/' E" := (family_image_rxgraph B%rxgraph_spec E%rxgraph_spec) : rxgraph_spec.
+
+Notation "A '^op'" := (opp_rxgraph A%rxgraph_spec) (at level 1, format "A ^op") : rxgraph_spec.
+Notation "A '^op!'" := (opp_rxgraph' A%rxgraph_spec) (at level 1, format "A ^op!") : rxgraph_spec.
+
+Notation "E ⟦ x ⟧" := (disp_rxgraph_at E%rxgraph_spec x) (at level 49) : rxgraph_spec.
+Notation "E ⟦ x '⟧!'" := (disp_rxgraph_at' E%rxgraph_spec x) (at level 49) : rxgraph_spec.
+(* type in Emacs using agda-input with \[[ \]] *)
+
+Notation "'{'  x '∣' P  '}'" := (sub_rxgraph _ (λ (x : _%rxgraph_spec), P)) (x binder) : rxgraph_spec.
+Notation "'{'  x '∣![' H  ']' P  '}'" := (sub_rxgraph_pred' _ (λ (x : _%rxgraph_spec), P) (λ x, H)) (x binder) : rxgraph_spec.
+Notation "'{'  x '∣!' P  '}'" := (sub_rxgraph' _ (λ x, P)) (x binder) : rxgraph_spec.
+(* type in Emacs using agda-input with \mid *)

--- a/UniMath/IdentitySystems/Fibred.v
+++ b/UniMath/IdentitySystems/Fibred.v
@@ -1,0 +1,510 @@
+(********************************************************************************
+
+ Fibred Reflexive Graphs
+
+ The work here is based on Jon Sterling, 2026, "Reflexive graph lenses in
+ Univalent Foundations" (doi:10.1017/S0960129526100565, arXiv:2404.07854).
+
+ Contents:
+ 1. Definitions
+ 2. Relationship with lenses
+ 2.1. Pushforwards and pullbacks
+ 2.2. Straightening of edges
+ 2.3. Lenses from fibrations
+ 2.4. Equivalence between fibrations and lenses
+
+ Author: B. Szilvasy
+ September 2026
+
+ ********************************************************************************)
+
+Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.All.
+
+Require Import UniMath.IdentitySystems.RXGraph.
+Require Import UniMath.IdentitySystems.Examples.
+Require Import UniMath.IdentitySystems.Lenses.
+Require Import UniMath.IdentitySystems.RXGraphOfRXGraphs.
+
+Local Open Scope rxgraph.
+Local Bind Scope rxgraph_spec with rxgraph.
+
+(** ** Definitions *)
+
+(** Covariant fibrations *)
+
+Definition is_covy_fibration
+  {B : rxgraph} (E : disp_rxgraph B)
+  := ∏ (x y : B) (e : x ≈ y) (a : E x),
+    ∃! (b : E y), a ≈[e] b.
+Definition covy_fibration (B : rxgraph) : UU :=
+  ∑ (E : disp_rxgraph B), is_covy_fibration E.
+
+Lemma isaprop_is_covy_fibration
+  {B : rxgraph} (E : disp_rxgraph B)
+  : isaprop (is_covy_fibration E).
+Proof.
+  do 4 (apply impred; intro).
+  apply isapropiscontr.
+Qed.
+
+Lemma is_univalent_covy_fibration {B : rxgraph}
+  (E : disp_rxgraph B) (H : is_covy_fibration E)
+  : is_disp_univalent E.
+Proof.
+  intro x; apply is_univalent_from_iscontr_edges_from.
+  exact (H x x (refl x)).
+Defined.
+
+Coercion covy_fibration_to_disp_rxgraph {B : rxgraph} (E : covy_fibration B)
+  : univalent_disp_rxgraph B
+  := make_univalent_disp_rxgraph (pr1 E)
+       (is_univalent_covy_fibration (pr1 E) (pr2 E)).
+Coercion covy_fibration_property {B : rxgraph} (E : covy_fibration B)
+  : is_covy_fibration E := pr2 E.
+
+Definition covy_fibration_lift
+  {B : rxgraph} {E : disp_rxgraph B}
+  (ℓ : is_covy_fibration E)
+  : ∏ {x y : B} (e : x ≈ y) (a : E x),
+    ∃! (b : E y), a ≈[e] b
+  := ℓ.
+
+(** Contravariant fibrations *)
+
+Definition is_contra_fibration
+  {B : rxgraph} (E : disp_rxgraph B)
+  := ∏ (x y : B) (e : x ≈ y) (b : E y),
+    ∃! (a : E x), a ≈[e] b.
+Definition contra_fibration (B : rxgraph) : UU :=
+  ∑ (E : disp_rxgraph B), is_contra_fibration E.
+
+Lemma isaprop_is_contra_fibration
+  {B : rxgraph} (E : disp_rxgraph B)
+  : isaprop (is_contra_fibration E).
+Proof.
+  do 4 (apply impred; intro).
+  apply isapropiscontr.
+Qed.
+
+Lemma is_univalent_contra_fibration {B : rxgraph}
+  (E : disp_rxgraph B) (H : is_contra_fibration E)
+  : is_disp_univalent E.
+Proof.
+  intro x; apply is_univalent_from_iscontr_edges_to.
+  exact (H x x (refl x)).
+Defined.
+
+Coercion contra_fibration_to_disp_rxgraph {B : rxgraph} (E : contra_fibration B)
+  : univalent_disp_rxgraph B
+  := make_univalent_disp_rxgraph (pr1 E)
+       (is_univalent_contra_fibration (pr1 E) (pr2 E)).
+Coercion contra_fibration_property {B : rxgraph} (E : contra_fibration B)
+  : is_contra_fibration E := pr2 E.
+
+Definition contra_fibration_lift
+  {B : rxgraph} {E : disp_rxgraph B}
+  (ℓ : is_contra_fibration E)
+  : ∏ {x y : B} (e : x ≈ y) (b : E y),
+    ∃! (a : E x), a ≈[e] b
+  := ℓ.
+
+(** ** Relationship with lenses *)
+
+(** *** Pushforwards and pullbacks *)
+
+(** Pushforwards *)
+
+Definition pushforwards_are_universal {B : rxgraph} (E : covy_lens B) : UU
+  := ∏ (x y : B) (e : x ≈ y) (a : E x),
+    isaprop (edges_from (E y) (lens_push E e a)).
+
+Lemma is_covy_fibration_covy_lens {B : rxgraph} (E : covy_lens B)
+  (H : pushforwards_are_universal E)
+  : is_covy_fibration (covy_lens_disp_rxgraph E).
+Proof.
+  intros x y e a.
+  apply (iscontraprop1 (H x y e a)).
+  apply edges_from_refl.
+Defined.
+
+Lemma covy_lens_pushfowards_are_universal_from_univalent
+  {B : rxgraph} (E : covy_lens B)
+  (HE : ∏ x, is_univalent (E x))
+  : pushforwards_are_universal E.
+Proof.
+  intros x y e a.
+  apply is_univalent_to_isaprop_edges_from, HE.
+Qed.
+
+Lemma covy_lens_univalent_from_pushforwards_are_universal
+  {B : rxgraph} (E : covy_lens B)
+  (H : pushforwards_are_universal E)
+  : ∏ x, is_univalent (E x).
+Proof.
+  intro x; apply is_univalent_from_isaprop_edges_from; intro a.
+  apply (isofhlevelweqf 1 (X:=edges_from _ (lens_push E (refl x) a))).
+  - apply weqfibtototal; intro b.
+    refine (transportb (λ c, c ≈ b ≃ a ≈ b) _ (idweq _)).
+    refine (base_paths (edges_from_refl _) (a,, lens_push_refl E x a) _).
+    apply proofirrelevance, H.
+  - apply H.
+Qed.
+
+Definition covy_fibration_from_univalent_covy_lens {B : rxgraph}
+  (E : univalent_covy_lens B)
+  : covy_fibration B.
+Proof.
+  exists (covy_lens_disp_rxgraph E).
+  apply is_covy_fibration_covy_lens, covy_lens_pushfowards_are_universal_from_univalent.
+  intro x.
+  apply rxgraph_univalence.
+Defined.
+
+(** Pullbacks *)
+
+Definition pullbacks_are_universal {B : rxgraph} (E : contra_lens B) : UU
+  := ∏ (x y : B) (e : x ≈ y) (a : E y),
+    isaprop (edges_to (E x) (lens_pull E e a)).
+
+Lemma is_contra_fibration_contra_lens {B : rxgraph} (E : contra_lens B)
+  (H : pullbacks_are_universal E)
+  : is_contra_fibration (contra_lens_disp_rxgraph E).
+Proof.
+  intros x y e a.
+  apply (iscontraprop1 (H x y e a)).
+  apply edges_to_refl.
+Defined.
+
+Lemma contra_lens_pullfowards_are_universal_from_univalent
+  {B : rxgraph} (E : contra_lens B)
+  (HE : ∏ x, is_univalent (E x))
+  : pullbacks_are_universal E.
+Proof.
+  intros x y e a.
+  apply is_univalent_to_isaprop_edges_to, HE.
+Qed.
+
+Lemma contra_lens_univalent_from_pullbacks_are_universal
+  {B : rxgraph} (E : contra_lens B)
+  (H : pullbacks_are_universal E)
+  : ∏ x, is_univalent (E x).
+Proof.
+  intro x; apply is_univalent_from_isaprop_edges_to; intro b.
+  apply (isofhlevelweqf 1 (X:=edges_to _ (lens_pull E (refl x) b))).
+  - apply weqfibtototal; intro a.
+    refine (transportb (λ c, a ≈ c ≃ a ≈ b) _ (idweq _)).
+    refine (base_paths (edges_to_refl _) (b,, lens_pull_refl E x b) _).
+    apply proofirrelevance, H.
+  - apply H.
+Qed.
+
+Definition contra_fibration_from_univalent_contra_lens {B : rxgraph}
+  (E : univalent_contra_lens B)
+  : contra_fibration B.
+Proof.
+  exists (contra_lens_disp_rxgraph E).
+  apply is_contra_fibration_contra_lens, contra_lens_pullfowards_are_universal_from_univalent.
+  intro x.
+  apply rxgraph_univalence.
+Defined.
+
+(** *** Straightening of edges *)
+
+Section covy_straightening.
+  Context {B : rxgraph} (E : covy_fibration B)
+    {x y : B} (e : x ≈ y) {a : E x}.
+
+  Let p := iscontrpr1 (covy_fibration_lift E e a).
+  Notation "'p*a'" := (pr1 p).
+  Notation "'p†a'" := (pr2 p).
+
+  Definition covy_edge_str₀
+    {b : E y} (e' : a ≈[e] b)
+    (H : p = b,, e')
+    : p*a ≈{E⟦y⟧} b.
+  Proof.
+    refine (transportb (λ c, pr1 c ≈{E⟦y⟧} pr1 (b,, e')) H _).
+    apply refl.
+  Defined.
+
+  Definition covy_edge_str
+    {b : E y} (e' : a ≈[e] b)
+    : p*a ≈{E⟦y⟧} b.
+  Proof.
+    apply (covy_edge_str₀ e').
+    apply pathsinv0, iscontr_uniqueness.
+  Defined.
+
+  Definition covy_edge_unstr₀
+    {b : E y} (e' : p*a ≈{E⟦y⟧} b)
+    (I : edges_from_refl (G:=E⟦y⟧) p*a = b,, e')
+    : a ≈[e] b.
+  Proof.
+    refine (transportf (λ c, a ≈[e] pr1 c) I _).
+    exact p†a.
+  Defined.
+
+  Definition covy_edge_unstr
+    {b : E y} (e' : p*a ≈{E⟦y⟧} b)
+    : a ≈[e] b.
+  Proof.
+    apply (covy_edge_unstr₀ e').
+    apply proofirrelevance, (is_univalent_to_isaprop_edges_from (E⟦y⟧)).
+    apply is_univalent_covy_fibration, E.
+  Defined.
+
+  Definition covy_edge_str₀_after_unstr₀
+    {b : E y} (e' : p*a ≈{E⟦y⟧} b)
+    (I : edges_from_refl (G:=E⟦y⟧) p*a = b,, e')
+    (H : p = b,, covy_edge_unstr₀ e' I)
+    : covy_edge_str₀ (covy_edge_unstr₀ e' I) H = e'.
+  Proof.
+    pose (be' := b,, e' : ∑ b, p*a ≈{E⟦y⟧} b).
+    fold be' in I; fold (pr1 be') (pr2 be') in H |- *.
+    induction I; clear b e'.
+    cbn in H |- *.
+    assert (H' : idpath p = H).
+    { apply proofirrelevancecontr.
+      refine ((_ : isaprop _) _ _).
+      apply isapropifcontr, covy_fibration_lift, E. }
+    induction H'.
+    reflexivity.
+  Qed.
+
+  Definition covy_edge_unstr₀_after_str₀
+    {b : E y} (e' : a ≈[e] b)
+    (H : p = b,, e')
+    (I : edges_from_refl (G:=E⟦y⟧) p*a = b,, covy_edge_str₀ e' H)
+    : covy_edge_unstr₀ (covy_edge_str₀ e' H) I = e'.
+  Proof.
+    pose (be' := b,, e' : ∑ b, a ≈[e] b).
+    fold be' in H; fold (pr1 be') (pr2 be') in I |- *.
+    induction H; clear b e'.
+    cbn in I |- *.
+    assert (I' : idpath _ = I).
+    { apply proofirrelevancecontr.
+      refine ((_ : isaprop _) _ _).
+      apply isapropifcontr, covy_fibration_lift, E. }
+    induction I'.
+    reflexivity.
+  Qed.
+
+  Corollary isweq_covy_edge_str (b : E y)
+    : isweq (λ (e' : a ≈[e] b), covy_edge_str e').
+  Proof.
+    use isweq_iso.
+    - exact covy_edge_unstr.
+    - intro e'; apply covy_edge_unstr₀_after_str₀.
+    - intro e'; apply covy_edge_str₀_after_unstr₀.
+  Defined.
+
+  Definition weq_covy_edge_str (b : E y)
+    : a ≈[ e ] b ≃ p*a ≈{E⟦y⟧} b
+    := make_weq _ (isweq_covy_edge_str b).
+
+  Definition weq_covy_edge_unstr (b : E y)
+    : p*a ≈{E⟦y⟧} b ≃ a ≈[ e ] b
+    := invweq (weq_covy_edge_str b).
+
+End covy_straightening.
+Arguments weq_covy_edge_str {B} E {x y} e a b.
+Arguments weq_covy_edge_unstr {B} E {x y} e a b.
+
+Section contra_straightening.
+  Context {B : rxgraph} (E : contra_fibration B)
+    {x y : B} (e : x ≈ y) {b : E y}.
+
+  Let p := iscontrpr1 (contra_fibration_lift E e b).
+  Notation "'p*b'" := (pr1 p).
+  Notation "'p†b'" := (pr2 p).
+
+  Definition contra_edge_str₀
+    {a : E x} (e' : a ≈[e] b)
+    (H : p = a,, e')
+    : a ≈{E⟦x⟧} p*b.
+  Proof.
+    refine (transportb (λ c, pr1 (a,, e' : ∑ a, a ≈[e] b) ≈{E⟦x⟧} pr1 c) H _).
+    apply refl.
+  Defined.
+
+  Definition contra_edge_str
+    {a : E x} (e' : a ≈[e] b)
+    : a ≈{E⟦x⟧} p*b.
+  Proof.
+    apply (contra_edge_str₀ e').
+    apply pathsinv0, iscontr_uniqueness.
+  Defined.
+
+  Definition contra_edge_unstr₀
+    {a : E x} (e' : a ≈{E⟦x⟧} p*b)
+    (I : edges_to_refl (G:=E⟦x⟧) p*b = a,, e')
+    : a ≈[e] b.
+  Proof.
+    refine (transportf (λ c, pr1 c ≈[e] b) I _).
+    exact p†b.
+  Defined.
+
+  Definition contra_edge_unstr
+    {a : E x} (e' : a ≈{E⟦x⟧} p*b)
+    : a ≈[e] b.
+  Proof.
+    apply (contra_edge_unstr₀ e').
+    apply proofirrelevance, (is_univalent_to_isaprop_edges_to (E⟦x⟧)).
+    apply is_univalent_contra_fibration, E.
+  Defined.
+
+  Definition contra_edge_str₀_after_unstr₀
+    {a : E x} (e' : a ≈{E⟦x⟧} p*b)
+    (I : edges_to_refl (G:=E⟦x⟧) p*b = a,, e')
+    (H : p = a,, contra_edge_unstr₀ e' I)
+    : contra_edge_str₀ (contra_edge_unstr₀ e' I) H = e'.
+  Proof.
+    pose (ae' := a,, e' : ∑ a, a ≈{E⟦x⟧} p*b).
+    fold ae' in I; fold (pr1 ae') (pr2 ae') in H |- *.
+    induction I; clear a e'.
+    cbn in H |- *.
+    assert (H' : idpath p = H).
+    { apply proofirrelevancecontr.
+      refine ((_ : isaprop _) _ _).
+      apply isapropifcontr, contra_fibration_lift, E. }
+    induction H'.
+    reflexivity.
+  Qed.
+
+  Definition contra_edge_unstr₀_after_str₀
+    {a : E x} (e' : a ≈[e] b)
+    (H : p = a,, e')
+    (I : edges_to_refl (G:=E⟦x⟧) p*b = a,, contra_edge_str₀ e' H)
+    : contra_edge_unstr₀ (contra_edge_str₀ e' H) I = e'.
+  Proof.
+    pose (ae' := a,, e' : ∑ a, a ≈[e] b).
+    fold ae' in H; fold (pr1 ae') (pr2 ae') in I |- *.
+    induction H; clear a e'.
+    cbn in I |- *.
+    assert (I' : idpath _ = I).
+    { apply proofirrelevancecontr.
+      refine ((_ : isaprop _) _ _).
+      apply isapropifcontr, contra_fibration_lift, E. }
+    induction I'.
+    reflexivity.
+  Qed.
+
+  Corollary isweq_contra_edge_str (a : E x)
+    : isweq (λ (e' : a ≈[e] b), contra_edge_str e').
+  Proof.
+    use isweq_iso.
+    - exact contra_edge_unstr.
+    - intro e'; apply contra_edge_unstr₀_after_str₀.
+    - intro e'; apply contra_edge_str₀_after_unstr₀.
+  Defined.
+
+  Definition weq_contra_edge_str (a : E x)
+    : a ≈[ e ] b ≃ a ≈{E⟦x⟧} p*b
+    := make_weq _ (isweq_contra_edge_str a).
+
+  Definition weq_contra_edge_unstr (a : E x)
+    : a ≈{E⟦x⟧} p*b ≃ a ≈[ e ] b
+    := invweq (weq_contra_edge_str a).
+
+End contra_straightening.
+Arguments weq_contra_edge_str {B} E {x y} e b a.
+Arguments weq_contra_edge_unstr {B} E {x y} e b a.
+
+(** *** Lenses from fibrations *)
+
+Definition univalent_covy_lens_from_fibration {B : rxgraph}
+  (E : covy_fibration B)
+  : univalent_covy_lens B.
+Proof.
+  use make_univalent_covy_lens.
+  - intro x; exists (E⟦x⟧)%rxgraph_spec.
+    apply is_univalent_covy_fibration, E.
+  - intros x y e a.
+    exact (pr1 (iscontrpr1 (covy_fibration_lift E e a))).
+  - intros x a.
+    refine (weq_covy_edge_str E (refl x) a a _).
+    exact (disp_refl x a).
+Defined.
+
+Definition univalent_contra_lens_from_fibration {B : rxgraph}
+  (E : contra_fibration B)
+  : univalent_contra_lens B.
+Proof.
+  use make_univalent_contra_lens.
+  - intro x; exists (E⟦x⟧)%rxgraph_spec.
+    apply is_univalent_contra_fibration, E.
+  - intros x y e a.
+    exact (pr1 (iscontrpr1 (contra_fibration_lift E e a))).
+  - intros x a.
+    refine (weq_contra_edge_str E (refl x) a a _).
+    exact (disp_refl x a).
+Defined.
+
+(** *** Equivalence between fibrations and lenses
+
+ We do not yet show that the round-trip below
+ preserves the lens structure itself.
+ *)
+
+Definition disp_rxgraph_from_covy_lens_from_fibration_iso
+  {B : rxgraph} (E : covy_fibration B)
+  : disp_rxgraph_iso E
+      (covy_lens_disp_rxgraph (univalent_covy_lens_from_fibration E)).
+Proof.
+  use make_disp_rxgraph_iso.
+  - intros x; exact (idweq (E x)).
+  - intros x y e a b; cbn in a, b |- *.
+    exact (weq_covy_edge_str E e a b).
+  - easy.
+Defined.
+
+Definition covy_lens_from_fibration_from_covy_lens_iso
+  {B : rxgraph} (E : univalent_covy_lens B)
+  : ∏ (x : B),
+    rxgraph_iso
+      (E x)
+      (univalent_covy_lens_from_fibration
+         (covy_fibration_from_univalent_covy_lens E)
+         x).
+Proof.
+  intro x.
+  use make_rxgraph_iso.
+  - exact (idweq (E x)).
+  - intros a b; cbn in a, b |- *.
+    eexists.
+    apply (isweq_edge_comp_left (E x) (lens_push_refl E x a)).
+  - intros a; cbn in a |- *.
+    apply edge_comp_refl_right.
+Defined.
+
+Definition disp_rxgraph_from_contra_lens_from_fibration_iso
+  {B : rxgraph} (E : contra_fibration B)
+  : disp_rxgraph_iso E
+      (contra_lens_disp_rxgraph (univalent_contra_lens_from_fibration E)).
+Proof.
+  use make_disp_rxgraph_iso.
+  - intros x; exact (idweq (E x)).
+  - intros x y e a b; cbn in a, b |- *.
+    exact (weq_contra_edge_str E e b a).
+  - easy.
+Defined.
+
+Definition contra_lens_from_fibration_from_contra_lens_iso
+  {B : rxgraph} (E : univalent_contra_lens B)
+  : ∏ (x : B),
+    rxgraph_iso
+      (E x)
+      (univalent_contra_lens_from_fibration
+         (contra_fibration_from_univalent_contra_lens E)
+         x).
+Proof.
+  intro x.
+  use make_rxgraph_iso.
+  - exact (idweq (E x)).
+  - intros a b; cbn in a, b |- *.
+    eexists.
+    apply (isweq_edge_comp_right (E x) (lens_pull_refl E x b)).
+  - intros a; cbn in a |- *.
+    apply edge_comp_refl_left.
+Defined.

--- a/UniMath/IdentitySystems/Lenses.v
+++ b/UniMath/IdentitySystems/Lenses.v
@@ -1,0 +1,541 @@
+(********************************************************************************
+
+ Reflexive Graph Lenses
+
+ Reflexive graph lenses characterize transport over the edges of a base
+ reflexive graph, to construct a new displayed reflexive graph out of a family
+ of reflexive graphs.  The work here is based on Jon Sterling, 2026, "Reflexive
+ graph lenses in Univalent Foundations" (doi:10.1017/S0960129526100565,
+ arXiv:2404.07854).
+
+ Contents:
+ 1. Definitions
+ 1.1. Oplax covariant lenses
+ 1.2. Lax contravariant lenses
+ 1.3. Unbiased dependent lenses
+ 2. Definitional Replacement
+
+ Author: B. Szilvasy
+ September 2026
+
+ ********************************************************************************)
+
+Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.All.
+
+Require Import UniMath.IdentitySystems.RXGraph.
+Require Import UniMath.IdentitySystems.Examples.
+
+Local Open Scope rxgraph.
+Local Bind Scope rxgraph_spec with rxgraph.
+
+(** ** Definitions *)
+
+(** *** Oplax covariant lenses
+
+    ("covariant" because of the direction of [lens_push],
+    "oplax" because of the direction of [lens_push_refl])
+ *)
+
+Definition covy_lens_structure {B : rxgraph} (E : B -> rxgraph) : UU
+  := ∑ (push : ∏ (x y : B) (e : x ≈ y), E x -> E y),
+    ∏ (x : B) (a : E x), push x x (refl x) a ≈ a.
+Definition covy_lens (B : rxgraph) : UU
+  := ∑ (E : B -> rxgraph), covy_lens_structure E.
+
+Definition covy_lens_rxgraph {B : rxgraph} (E : covy_lens B) := pr1 E.
+Coercion covy_lens_rxgraph : covy_lens >-> Funclass.
+Coercion covy_lens_to_structure {B : rxgraph} (E : covy_lens B)
+  : covy_lens_structure E := pr2 E.
+
+Definition univalent_covy_lens (B : rxgraph) : UU
+  := ∑ (E : B -> univalent_rxgraph), covy_lens_structure E.
+Definition univalent_covy_lens_rxgraph {B : rxgraph} (E : univalent_covy_lens B) := pr1 E.
+Coercion univalent_covy_lens_rxgraph : univalent_covy_lens >-> Funclass.
+(* Ambiguous *) Coercion univalent_covy_lens_to_covy_lens {B : rxgraph}
+  (E : univalent_covy_lens B) : covy_lens B
+  := (univalent_rxgraph_to_rxgraph ∘ pr1 E),, pr2 E.
+
+Definition lens_push {B : rxgraph} {E : B -> rxgraph} (ℓ : covy_lens_structure E)
+  : ∏ {x y : B} (e : x ≈ y), E x -> E y := pr1 ℓ.
+Definition lens_push_refl {B : rxgraph} {E : B -> rxgraph} (ℓ : covy_lens_structure E)
+  : ∏ (x : B) (a : E x), lens_push ℓ (refl x) a ≈ a := pr2 ℓ.
+
+Definition make_covy_lens_structure (B : rxgraph) (E : B -> rxgraph)
+  (push : ∏ (x y : B) (e : x ≈ y), E x -> E y)
+  (push_refl : ∏ (x : B) (a : E x), push x x (refl x) a ≈ a)
+  : covy_lens_structure E
+  := push,, push_refl.
+
+Definition make_covy_lens (B : rxgraph) (E : B -> rxgraph)
+  (push : ∏ (x y : B) (e : x ≈ y), E x -> E y)
+  (push_refl : ∏ (x : B) (a : E x), push x x (refl x) a ≈ a)
+  : covy_lens B
+  := E,, push,, push_refl.
+
+Definition make_univalent_covy_lens (B : rxgraph) (E : B -> univalent_rxgraph)
+  (push : ∏ (x y : B) (e : x ≈ y), E x -> E y)
+  (push_refl : ∏ (x : B) (a : E x), push x x (refl x) a ≈ a)
+  : univalent_covy_lens B
+  := E,, push,, push_refl.
+
+Definition make_univalent_covy_lens' (B : rxgraph)
+  (E : covy_lens B)
+  (H : ∏ x, is_univalent (E x))
+  : univalent_covy_lens B
+  := make_univalent_covy_lens B
+       (λ x, make_univalent_rxgraph (E x) (H x))
+       (@lens_push _ _ E)
+       (@lens_push_refl _ _ E).
+
+Definition covy_lens_disp_rxgraph {B : rxgraph}
+  (E : covy_lens B) : disp_rxgraph B.
+Proof.
+  use make_disp_rxgraph.
+  - intro x; exact (E x).
+  - intros x y e a b.
+    exact (lens_push E e a ≈ b).
+  - intros x a.
+    exact (lens_push_refl E x a).
+Defined.
+
+Lemma is_univalent_covy_lens_disp_rxgraph
+  {B : rxgraph} (E : covy_lens B)
+  (HE : ∏ x, is_univalent (E x))
+  : is_disp_univalent (covy_lens_disp_rxgraph E).
+Proof.
+  intros x.
+  apply is_univalent_from_isaprop_edges_from; intro a.
+  apply (is_univalent_to_isaprop_edges_from _ (HE x)).
+Defined.
+
+Lemma weq_sec_over_contr_total2
+  {A : UU} {B : A -> UU}
+  (H : iscontr (∑ a, B a))
+  (c := iscontrpr1 H)
+  (C : ∏ a, B a -> UU)
+  : (∏ (a : A) (b : B a), C a b) ≃ C (pr1 c) (pr2 c).
+Proof.
+  intermediate_weq (∏ (ab : ∑ a, B a), C (pr1 ab) (pr2 ab)).
+  - apply invweq, weqsecovertotal2.
+  - exact (weqsecovercontr _ H).
+Defined.
+
+Lemma iscontr_covy_lens_structure_over_univalent
+  {B : rxgraph} (E : B -> rxgraph)
+  (HB : is_univalent B)
+  (HE : ∏ x, is_univalent (E x))
+  : iscontr (covy_lens_structure E).
+Proof.
+  eapply (isofhlevelweqf 0).
+  { exact (sec_total2_distributivity
+             (λ x push, ∏ (a : E x), push x (refl x) a ≈ a)). }
+  apply impred; intro x.
+  apply (isofhlevelweqb 0 (Y:=∑ (ϕ : E x -> E x), ∏ a, ϕ a ≈ a)). {
+    use weqbandf; [apply (weq_sec_over_contr_total2 (is_univalent_to_iscontr_edges_from _ HB x))|].
+    intro; exact (idweq _).
+  }
+  change (iscontr (edges_to (∏ _, E x) (idfun _))).
+  apply is_univalent_to_iscontr_edges_to.
+  apply is_univalent_product_rxgraph; intro.
+  apply HE.
+Qed.
+
+(** *** Lax contravariant lenses
+
+    ("contravariant" because of the direction of [lens_pull],
+    "lax" because of the direction of [lens_pull_refl])
+ *)
+
+Definition contra_lens_structure {B : rxgraph} (E : B -> rxgraph)
+  := ∑ (pull : ∏ (x y : B) (e : x ≈ y), E y -> E x),
+    ∏ (x : B) (a : E x), a ≈ pull x x (refl x) a.
+Definition contra_lens (B : rxgraph) : UU
+  := ∑ (E : B -> rxgraph), contra_lens_structure E.
+
+Definition contra_lens_rxgraph {B : rxgraph} (E : contra_lens B) := pr1 E.
+Coercion contra_lens_rxgraph : contra_lens >-> Funclass.
+Coercion contra_lens_to_structure {B : rxgraph} (E : contra_lens B)
+  : contra_lens_structure E := pr2 E.
+
+Definition univalent_contra_lens (B : rxgraph) : UU
+  := ∑ (E : B -> univalent_rxgraph), contra_lens_structure E.
+Definition univalent_contra_lens_rxgraph {B : rxgraph} (E : univalent_contra_lens B) := pr1 E.
+Coercion univalent_contra_lens_rxgraph : univalent_contra_lens >-> Funclass.
+(* Ambiguous *) Coercion univalent_contra_lens_to_contra_lens {B : rxgraph}
+  (E : univalent_contra_lens B) : contra_lens B
+  := (univalent_rxgraph_to_rxgraph ∘ pr1 E),, pr2 E.
+
+Definition lens_pull {B : rxgraph} {E : B -> rxgraph} (ℓ : contra_lens_structure E)
+  : ∏ {x y : B} (e : x ≈ y), E y -> E x := pr1 ℓ.
+Definition lens_pull_refl {B : rxgraph} {E : B -> rxgraph} (ℓ : contra_lens_structure E)
+  : ∏ (x : B) (a : E x), a ≈ lens_pull ℓ (refl x) a := pr2 ℓ.
+
+Definition make_contra_lens_structure (B : rxgraph) (E : B -> rxgraph)
+  (pull : ∏ (x y : B) (e : x ≈ y), E y -> E x)
+  (pull_refl : ∏ (x : B) (a : E x), a ≈ pull x x (refl x) a)
+  : contra_lens_structure E
+  := pull,, pull_refl.
+
+Definition make_contra_lens (B : rxgraph) (E : B -> rxgraph)
+  (pull : ∏ (x y : B) (e : x ≈ y), E y -> E x)
+  (pull_refl : ∏ (x : B) (a : E x), a ≈ pull x x (refl x) a)
+  : contra_lens B
+  := E,, pull,, pull_refl.
+
+Definition make_univalent_contra_lens (B : rxgraph) (E : B -> univalent_rxgraph)
+  (pull : ∏ (x y : B) (e : x ≈ y), E y -> E x)
+  (pull_refl : ∏ (x : B) (a : E x), a ≈ pull x x (refl x) a)
+  : univalent_contra_lens B
+  := E,, pull,, pull_refl.
+
+Definition make_univalent_contra_lens' (B : rxgraph)
+  (E : contra_lens B)
+  (H : ∏ x, is_univalent (E x))
+  : univalent_contra_lens B
+  := make_univalent_contra_lens B
+       (λ x, make_univalent_rxgraph (E x) (H x))
+       (@lens_pull _ _ E)
+       (@lens_pull_refl _ _ E).
+
+Definition contra_lens_disp_rxgraph {B : rxgraph}
+  (E : contra_lens B) : disp_rxgraph B.
+Proof.
+  use make_disp_rxgraph.
+  - intro x; exact (E x).
+  - intros x y e a b.
+    exact (a ≈ lens_pull E e b).
+  - intros x a.
+    exact (lens_pull_refl E x a).
+Defined.
+
+Lemma is_univalent_contra_lens_disp_rxgraph
+  {B : rxgraph} (E : contra_lens B)
+  (HE : ∏ x, is_univalent (E x))
+  : is_disp_univalent (contra_lens_disp_rxgraph E).
+Proof.
+  intros x.
+  apply is_univalent_from_isaprop_edges_to; intro a.
+  apply (is_univalent_to_isaprop_edges_to _ (HE x)).
+Defined.
+
+Lemma iscontr_contra_lens_structure_over_univalent
+  {B : rxgraph} (E : B -> rxgraph)
+  (HB : is_univalent B)
+  (HE : ∏ x, is_univalent (E x))
+  : iscontr (contra_lens_structure E).
+Proof.
+  eapply (isofhlevelweqf 0).
+  { exact (sec_total2_distributivity
+             (λ x pull, ∏ (a : E x), a ≈ pull x (refl x) a)). }
+  apply impred; intro x.
+  apply (isofhlevelweqb 0 (Y:=∑ (ϕ : E x -> E x), ∏ a, a ≈ ϕ a)). {
+    use weqbandf; [apply (weq_sec_over_contr_total2 (is_univalent_to_iscontr_edges_from _ HB x))|].
+    intro; exact (idweq _).
+  }
+  change (iscontr (edges_from (∏ _ : E x, E x) (λ a, a))).
+  apply is_univalent_to_iscontr_edges_from.
+  apply is_univalent_product_rxgraph; intro.
+  apply HE.
+Qed.
+
+(** Involution *)
+
+Definition covy_to_contra_lens {B : rxgraph}
+  (E : covy_lens B) : contra_lens B^op.
+Proof.
+  use make_contra_lens.
+  - intro x; exact (E x)^op%rxgraph_spec.
+  - intros x y e; exact (lens_push E e).
+  - intros x a; exact (lens_push_refl E x a).
+Defined.
+
+Definition contra_to_covy_lens {B : rxgraph}
+  (E : contra_lens B) : covy_lens B^op.
+Proof.
+  use make_covy_lens.
+  - intro x; exact (E x)^op%rxgraph_spec.
+  - intros x y e; exact (lens_pull E e).
+  - intros x a; exact (lens_pull_refl E x a).
+Defined.
+
+Definition contra_to_covy_lens_involution_compute {B : rxgraph} (E : covy_lens B)
+  : contra_to_covy_lens (covy_to_contra_lens E) = E.
+Proof. reflexivity. Defined.
+
+Definition covy_to_contra_lens_involution_compute {B : rxgraph} (E : contra_lens B)
+  : covy_to_contra_lens (contra_to_covy_lens E) = E.
+Proof. reflexivity. Defined.
+
+Definition covy_to_contra_lens_disp_rxgraph_compute {B : rxgraph} (E : covy_lens B)
+  : contra_lens_disp_rxgraph (covy_to_contra_lens E)
+    = total_opp_disp_rxgraph (covy_lens_disp_rxgraph E).
+Proof. reflexivity. Defined.
+
+Definition contra_to_covy_lens_disp_rxgraph_compute {B : rxgraph} (E : contra_lens B)
+  : covy_lens_disp_rxgraph (contra_to_covy_lens E)
+    = total_opp_disp_rxgraph (contra_lens_disp_rxgraph E).
+Proof. reflexivity. Defined.
+
+(** *** Unbiased dependent lenses *)
+
+Definition unbiased_lens_structure {B : rxgraph}
+  (E : ∏ {a b : B}, a ≈ b -> rxgraph) : UU
+  := ∑ (lext : ∏ {x y : B} (e : x ≈ y) (a : E (refl x)), E e)
+       (rext : ∏ {x y : B} (e : x ≈ y) (a : E (refl y)), E e),
+    (∏ (x : B) (a : E (refl x)), lext (refl x) a ≈ rext (refl x) a) ×
+    (∏ (x : B) (a : E (refl x)), a ≈ rext (refl x) a).
+
+Definition unbiased_lens (B : rxgraph) : UU
+  := ∑ (E : ∏ {a b : B}, a ≈ b -> rxgraph),
+    unbiased_lens_structure (@E).
+
+Definition make_unbiased_lens_structure {B : rxgraph}
+  (E : ∏ {a b : B}, a ≈ b -> rxgraph)
+  (lext : ∏ {x y : B} (e : x ≈ y) (a : E (refl x)), E e)
+  (rext : ∏ {x y : B} (e : x ≈ y) (a : E (refl y)), E e)
+  (ext_refl : ∏ (x : B) (a : E (refl x)), lext (refl x) a ≈ rext (refl x) a)
+  (rext_refl : ∏ (x : B) (a : E (refl x)), a ≈ rext (refl x) a)
+  : unbiased_lens_structure (@E)
+  := @lext,, @rext,, @ext_refl,, @rext_refl.
+
+Definition make_unbiased_lens {B : rxgraph}
+  (E : ∏ {a b : B}, a ≈ b -> rxgraph)
+  (lext : ∏ {x y : B} (e : x ≈ y) (a : E (refl x)), E e)
+  (rext : ∏ {x y : B} (e : x ≈ y) (a : E (refl y)), E e)
+  (ext_refl : ∏ (x : B) (a : E (refl x)), lext (refl x) a ≈ rext (refl x) a)
+  (rext_refl : ∏ (x : B) (a : E (refl x)), a ≈ rext (refl x) a)
+  : unbiased_lens B
+  := @E,, @lext,, @rext,, @ext_refl,, @rext_refl.
+
+Definition unbiased_lens_family {B : rxgraph} (E : unbiased_lens B)
+  : ∏ {a b : B}, a ≈ b -> rxgraph := pr1 E.
+Coercion unbiased_lens_family : unbiased_lens >-> Funclass.
+Coercion unbiased_lens_to_structure {B : rxgraph} (E : unbiased_lens B)
+  : unbiased_lens_structure E := pr2 E.
+
+Definition lens_lext {B : rxgraph}
+  {E : ∏ {a b : B}, a ≈ b -> rxgraph} (ℓ : unbiased_lens_structure (@E))
+  : ∏ {x y : B} (e : x ≈ y) (a : E (refl x)), E e := pr1 ℓ.
+Definition lens_rext {B : rxgraph}
+  {E : ∏ {a b : B}, a ≈ b -> rxgraph} (ℓ : unbiased_lens_structure (@E))
+  : ∏ {x y : B} (e : x ≈ y) (a : E (refl y)), E e := pr12 ℓ.
+Definition lens_ext_refl {B : rxgraph}
+  {E : ∏ {a b : B}, a ≈ b -> rxgraph} (ℓ : unbiased_lens_structure (@E))
+  : ∏ (x : B) (a : E (refl x)), lens_lext ℓ (refl x) a ≈ lens_rext ℓ (refl x) a := pr122 ℓ.
+Definition lens_rext_refl {B : rxgraph}
+  {E : ∏ {a b : B}, a ≈ b -> rxgraph} (ℓ : unbiased_lens_structure (@E))
+  : ∏ (x : B) (a : E (refl x)), a ≈ lens_rext ℓ (refl x) a := pr222 ℓ.
+
+Definition unbiased_lens_disp_rxgraph {B : rxgraph}
+  (E : unbiased_lens B) : disp_rxgraph B.
+Proof.
+  use make_disp_rxgraph.
+  - intro x; exact (E _ _ (refl x)).
+  - intros x y e a b.
+    exact (lens_lext E e a ≈ lens_rext E e b).
+  - intros x a.
+    exact (lens_ext_refl E x a).
+Defined.
+
+Lemma is_univalent_unbiased_lens_disp_rxgraph
+  {B : rxgraph} (E : unbiased_lens B)
+  (HE : ∏ (x y : B) (e : x ≈ y), is_univalent (E _ _ e))
+  : is_disp_univalent (unbiased_lens_disp_rxgraph E).
+Proof.
+  intro x.
+  apply is_univalent_from_isaprop_edges_from; intro a.
+  use (isofhlevelweqb 1 (Y:=edges_from (E _ _ (refl x)) (lens_lext E (refl x) a))).
+  - apply weqfibtototal; intro b; cbn.
+    elim (lens_rext_refl E x b) using rxgraph_edge_rect_left.
+    + apply HE.
+    + exact (idweq _).
+  - apply is_univalent_to_isaprop_edges_from, HE.
+Qed.
+
+Lemma iscontr_unbiased_lens_structure_over_univalent
+  {B : rxgraph} (E : ∏ {x y : B}, x ≈ y -> rxgraph)
+  (HB : is_univalent B)
+  (HE : ∏ (x y : B) (e : x ≈ y), is_univalent (E e))
+  : iscontr (unbiased_lens_structure (@E)).
+Proof.
+  unfold unbiased_lens_structure.
+  eapply (isofhlevelweqf 0
+            (X:=(∏ x, ∑ (lext : ∏ (y : B) (e : x ≈ y), E x x (refl x) → E x y e)
+                        (rext : ∏ (y : B) (e : x ≈ y), E y y (refl y) → E x y e),
+                  (∏ (a : E x x (refl x)), lext x (refl x) a ≈ rext x (refl x) a)
+                    × (∏ (a : E x x (refl x)), a ≈ rext x (refl x) a)))).
+  { use weq_iso.
+    - intros f.
+      exact ((λ x, pr1 (f x)),, (λ x, pr12 (f x)),,
+               (λ x, pr122 (f x)),, (λ x, pr222 (f x))).
+    - intros [lext [rext [eq eqr]]] x.
+      exact (lext x,, rext x,, eq x,, eqr x).
+    - easy.
+    - easy. }
+  apply impred; intro x.
+  eapply (isofhlevelweqb 0
+            (Y:=∑ (lext rext : E _ _ (refl x) -> E _ _ (refl x)),
+               (lext ≈{∏_,_} rext) × (idfun _ ≈{∏_,_} rext))). {
+    use weqbandf; [apply (weq_sec_over_contr_total2 (is_univalent_to_iscontr_edges_from _ HB x))|].
+    intro lext; cbn.
+    use weqbandf; [apply (weq_sec_over_contr_total2 (is_univalent_to_iscontr_edges_from _ HB x))|].
+    intro rext; cbn.
+    exact (idweq _).
+  }
+  eapply (isofhlevelweqb 0 (Y:=edges_to (product_rxgraph _) (idfun (E _ _ (refl x))))).
+  { apply weqfibtototal; intro lext.
+    intermediate_weq (∑ (rext : edges_from (product_rxgraph _) (idfun (E _ _ (refl x)))),
+                       lext ≈{∏_,_} pr1 rext).
+    { use weq_iso.
+      - intros [r [p q]]; exact ((r,,q),,p).
+      - intros [[r q] p]; exact (r,, p,, q).
+      - easy.
+      - easy. }
+    refine (weqcomp _ (weqtotal2overunit (λ _, _))).
+    apply invweq.
+    use weqbandf. {
+      apply wequnittocontr, is_univalent_to_iscontr_edges_from.
+      apply is_univalent_product_rxgraph; intro; apply HE.
+    }
+    intro; exact (idweq _).
+  }
+  apply is_univalent_to_iscontr_edges_to.
+  apply is_univalent_product_rxgraph; intro; apply HE.
+Qed.
+
+(** Unbiased lenses from biased ones *)
+
+Definition unbiased_lens_from_covy {B : rxgraph}
+  (E : covy_lens B) : unbiased_lens B.
+Proof.
+  use make_unbiased_lens.
+  - intros x y e; exact (E y).
+  - intros x y e; exact (lens_push E e).
+  - intros x y e; exact (idfun (E y)).
+  - intros x a; exact (lens_push_refl E x a).
+  - intros x a; exact (refl a).
+Defined.
+
+Lemma unbiased_lens_from_covy_disp_compute
+  {B : rxgraph} (E : covy_lens B)
+  : unbiased_lens_disp_rxgraph (unbiased_lens_from_covy E)
+    = covy_lens_disp_rxgraph E.
+Proof. reflexivity. Defined.
+
+Definition unbiased_lens_from_contra {B : rxgraph}
+  (E : contra_lens B) : unbiased_lens B.
+Proof.
+  use make_unbiased_lens.
+  - intros x y e; exact (E x).
+  - intros x y e; exact (idfun (E x)).
+  - intros x y e; exact (lens_pull E e).
+  - intros x a; exact (lens_pull_refl E x a).
+  - intros x a; exact (lens_pull_refl E x a).
+Defined.
+
+Lemma unbiased_lens_from_contra_disp_compute
+  {B : rxgraph} (E : contra_lens B)
+  : unbiased_lens_disp_rxgraph (unbiased_lens_from_contra E)
+    = contra_lens_disp_rxgraph E.
+Proof. reflexivity. Defined.
+
+(** Definitional replacement *)
+
+Definition discrete_covy_lens {B : UU} (E : B -> rxgraph)
+  : @covy_lens_structure (Δ B) E.
+Proof.
+  use make_covy_lens_structure.
+  - intros x y e; exact (transportf E e).
+  - intros x a; exact (refl a).
+Defined.
+
+Definition make_discrete_covy_lens {B : UU} (E : B -> rxgraph) : covy_lens (Δ B)
+  := E,, discrete_covy_lens E.
+
+Definition discrete_contra_lens {B : UU} (E : B -> rxgraph)
+  : @contra_lens_structure (Δ B) E.
+Proof.
+  use make_contra_lens_structure.
+  - intros x y e; exact (transportb E e).
+  - intros x a; exact (refl a).
+Defined.
+
+Definition make_discrete_contra_lens {B : UU} (E : B -> rxgraph) : contra_lens (Δ B)
+  := E,, discrete_contra_lens E.
+
+Definition flatten_covy_lens {B : rxgraph}
+  (E : covy_lens B) : rxgraph.
+Proof.
+  use make_rxgraph.
+  - exact B.
+  - intros x y.
+    exact (∑ (e : x ≈ y) (e' : E x -> E y),
+            ∏ (a : E x), lens_push E e a ≈ e' a).
+  - intro x; cbn.
+    exists (refl x), (idfun (E x)).
+    exact (lens_push_refl E x).
+Defined.
+
+Lemma is_univalent_flatten_covy_lens
+  {B : rxgraph} (E : covy_lens B)
+  (HB : is_univalent B)
+  (HE : ∏ x, is_univalent (E x))
+  : is_univalent (flatten_covy_lens E).
+Proof.
+  apply is_univalent_from_weq.
+  cbn; intros x y.
+  apply (weqcomp (weq_id_to_edge HB x y)).
+  apply invweq, weqpr1; intro e.
+  refine (is_univalent_to_iscontr_edges_from (∏ _, E y) _ (lens_push E e)).
+  apply is_univalent_product_rxgraph; intro a.
+  apply HE.
+Qed.
+
+Definition flatten_covy_lens_structure
+  {B : rxgraph} (E : covy_lens B)
+  : @covy_lens_structure (flatten_covy_lens E) E.
+Proof.
+  use make_covy_lens_structure.
+  - intros x y [e [e' f]].
+    exact e'.
+  - intros x a; exact (refl a).
+Defined.
+
+Definition flatten_contra_lens {B : rxgraph}
+  (E : contra_lens B) : rxgraph.
+Proof.
+  use make_rxgraph.
+  - exact B.
+  - intros x y.
+    exact (∑ (e : x ≈ y) (e' : E y -> E x),
+            ∏ (a : E y), e' a ≈ lens_pull E e a).
+  - intro x; cbn.
+    exists (refl x), (idfun (E x)).
+    exact (lens_pull_refl E x).
+Defined.
+
+Lemma is_univalent_flatten_contra_lens
+  {B : rxgraph} (E : contra_lens B)
+  (HB : is_univalent B)
+  (HE : ∏ x, is_univalent (E x))
+  : is_univalent (flatten_contra_lens E).
+Proof.
+  apply is_univalent_from_weq.
+  cbn; intros x y.
+  apply (weqcomp (weq_id_to_edge HB x y)).
+  apply invweq, weqpr1; intro e.
+  refine (is_univalent_to_iscontr_edges_to (∏ _, E x) _ (lens_pull E e)).
+  apply is_univalent_product_rxgraph; intro a.
+  apply HE.
+Qed.
+
+Definition flatten_contra_lens_structure
+  {B : rxgraph} (E : contra_lens B)
+  : @contra_lens_structure (flatten_contra_lens E) E.
+Proof.
+  use make_contra_lens_structure.
+  - intros x y [e [e' f]].
+    exact e'.
+  - intros x a; exact (refl a).
+Defined.

--- a/UniMath/IdentitySystems/RXGraph.v
+++ b/UniMath/IdentitySystems/RXGraph.v
@@ -1,0 +1,610 @@
+(********************************************************************************
+
+ Reflexive Graphs
+
+ We define reflexive graphs for the purpose of characterizing identity types.
+
+ A reflexive graph consists of:
+ - a type [A type] called vertices,
+ - a family of types [a, b : A ⊢ a ≈ b type] called edges,
+ - and a reflexivity datum [a : A ⊢ refl a : a ≈ a].
+ A reflexive graph is univalent if edges are equivalent to identifications.
+
+ Reflexive graphs can be combined using the combinators in [Examples.v]
+ to characterize the identifications of many types.
+
+ Contents:
+ 1. Reflexive graphs
+ 1.1. Univalence
+ 1.2. Fundamental Theorem of Identity Types
+ 2. Path operations for univalent reflexive graphs
+ 2.1. Induction schemes
+ 2.2. Edge algebra
+ 3. Displayed reflexive graphs
+ 3.1. Univalence
+
+ Author: B. Szilvasy
+ February—September 2026
+
+ ********************************************************************************)
+
+Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.All.
+
+Declare Scope rxgraph.
+Delimit Scope rxgraph with rxgraph.
+Local Open Scope rxgraph.
+
+Declare Scope rxgraph_spec.
+Delimit Scope rxgraph_spec with rxgraph_spec.
+
+(** ** Definition of reflexive graphs *)
+
+Definition rxgraph := ∑ (A : UU) (edge : A -> A -> UU), ∏ a, edge a a.
+
+Coercion rxgraph_vertex (G : rxgraph) : UU := pr1 G.
+
+Definition edge (G : rxgraph) : G -> G -> UU := pr12 G.
+Notation "a '≈{' G  '}' b" := (edge G%rxgraph_spec a b) (at level 70) : rxgraph.
+Notation "a '≈' b" := (edge _ a b) (at level 70) : rxgraph.
+
+Definition refl {G : rxgraph} : ∏ (a : G), a ≈ a := pr22 G.
+
+Definition make_rxgraph
+  (A : UU)
+  (edge : A -> A -> UU)
+  (refl : ∏ a, edge a a)
+  : rxgraph
+  := A,, edge,, refl.
+
+Section univalence.
+
+  (** *** Univalence *)
+
+  Definition id_to_edge {G : rxgraph} {a b : G} : a = b -> a ≈ b.
+  Proof. intro p; induction p; apply refl. Defined.
+
+  Definition is_univalent (G : rxgraph)
+    := ∏ (a b : G), isweq (λ (p : a = b), id_to_edge p).
+
+  Lemma isaprop_is_univalent (G : rxgraph)
+    : isaprop (is_univalent G).
+  Proof.
+    do 2 (apply impred; intro).
+    apply isapropisweq.
+  Qed.
+
+  Definition univalent_rxgraph := ∑ (G : rxgraph), is_univalent G.
+  Coercion univalent_rxgraph_to_rxgraph (G : univalent_rxgraph) := pr1 G.
+  Coercion rxgraph_univalence (G : univalent_rxgraph)
+    : is_univalent G := pr2 G.
+
+  Definition make_univalent_rxgraph (G : rxgraph)
+    (H : is_univalent G)
+    : univalent_rxgraph
+    := G,, H.
+
+  Definition weq_id_to_edge {G : rxgraph}
+    (H : is_univalent G)
+    (a b : G) : a = b ≃ a ≈ b
+    := make_weq _ (H a b).
+
+  Definition weq_edge_to_id {G : rxgraph}
+    (H : is_univalent G)
+    (a b : G) : a ≈ b ≃ a = b
+    := invweq (weq_id_to_edge H a b).
+
+  Definition edge_to_id {G : rxgraph}
+    (H : is_univalent G)
+    {a b : G} : a ≈ b -> a = b
+    := invmap (weq_id_to_edge H a b).
+
+  Definition edges_from (G : rxgraph) (a : G) : UU := ∑ (b : G), a ≈ b.
+  Definition edges_to   (G : rxgraph) (a : G) : UU := ∑ (b : G), b ≈ a.
+
+  Definition make_edges_from {G : rxgraph} {a b : G} (e : a ≈ b) : edges_from G a := b,, e.
+  Definition make_edges_to {G : rxgraph} {a b : G} (e : a ≈ b) : edges_to G b := a,, e.
+  Coercion make_edges_from : edge >-> edges_from.
+  Coercion make_edges_to : edge >-> edges_to.
+
+  Definition edges_from_refl {G : rxgraph} (a : G) : edges_from G a := refl a.
+  Definition edges_to_refl {G : rxgraph} (a : G) : edges_to G a := refl a.
+
+  (** *** Fundamental Theorem of Identity Types
+
+This is a variant of that from Egbert Rijke's "Introduction to Homotopy Type
+Theory", (DOI:10.1017/9781108933568, arXiv:2212.11082).
+
+Let [G] be a reflexive graph. The following are equivalent.
+1. [G] is univalent.
+2. Every [edges_from a] (or [edges_to a]) for [a : G] is a proposition.
+3. Every [edges_from a] (or [edges_to a]) for [a : G] is
+   contractible with centre [edges_*_refl a].
+
+   *)
+
+  (** 3 -> 1 *)
+  Lemma is_univalent_from_iscontr_edges_from (G : rxgraph)
+    (H : ∏ (a : G), iscontr (edges_from G a))
+    : is_univalent G.
+  Proof.
+    intros a b.
+    apply isweqtotaltofib; clear b.
+    apply isweqcontrcontr.
+    - apply iscontr_paths_from.
+    - apply H.
+  Defined.
+
+  (** 2 -> 1 *)
+  Lemma is_univalent_from_isaprop_edges_from (G : rxgraph)
+    (H : ∏ (a : G), isaprop (edges_from G a))
+    : is_univalent G.
+  Proof.
+    apply is_univalent_from_iscontr_edges_from.
+    intro a.
+    apply iscontraprop1; [|apply edges_from_refl].
+    apply H.
+  Defined.
+
+  (** 1 -> 2 *)
+  Lemma is_univalent_to_isaprop_edges_from (G : rxgraph)
+    (H : is_univalent G)
+    : ∏ (a : G), isaprop (edges_from G a).
+  Proof.
+    intro a.
+    apply (isofhlevelweqb 1 (Y:=paths_from a)).
+    - refine (make_weq _ (isweqfibtototal _ _ _)).
+      intro b.
+      apply weq_edge_to_id, H.
+    - apply isapropifcontr, iscontr_paths_from.
+  Qed. (* [isaprop] should not be used transparently *)
+
+  (** 1 -> 3 *)
+  Lemma is_univalent_to_iscontr_edges_from (G : rxgraph)
+    (H : is_univalent G)
+    : ∏ (a : G), iscontr (edges_from G a).
+  Proof.
+    intro a.
+    apply iscontraprop1; [|apply edges_from_refl].
+    apply is_univalent_to_isaprop_edges_from, H.
+  Defined.
+
+  (** 3 ([edges_to]) -> 3 ([edges_from]) *)
+  Lemma isaprop_edges_to_implies_isaprop_edges_from (G : rxgraph)
+    (H : ∏ (a : G), isaprop (edges_to G a))
+    : ∏ (a : G), isaprop (edges_from G a).
+  Proof.
+    intro a; apply invproofirrelevance.
+    intros [b₁ e₁] [b₂ e₂].
+    assert (p : edges_to_refl _ = a,,e₁); [apply H|].
+    apply total2_paths_equiv in p.
+    induction p as [p q]; cbn in *.
+    induction p; cbn in q.
+    induction q.
+    assert (p : edges_to_refl _ = b₁,,e₂); [apply H|].
+    apply total2_paths_equiv in p.
+    induction p as [p q]; cbn in *.
+    induction p; cbn in q.
+    induction q.
+    reflexivity.
+  Qed.
+
+  (** 3 ([edges_from]) -> 3 ([edges_to]) *)
+  Lemma isaprop_edges_from_implies_isaprop_edges_to (G : rxgraph)
+    (H : ∏ (a : G), isaprop (edges_from G a))
+    : ∏ (a : G), isaprop (edges_to G a).
+  Proof.
+    intro a; apply invproofirrelevance.
+    intros [b₁ e₁] [b₂ e₂].
+    assert (p : edges_from_refl _ = a,,e₁); [apply H|].
+    apply total2_paths_equiv in p.
+    induction p as [p q]; cbn in *.
+    induction p; cbn in q.
+    induction q.
+    assert (p : edges_from_refl _ = b₁,,e₂); [apply H|].
+    apply total2_paths_equiv in p.
+    induction p as [p q]; cbn in *.
+    induction p; cbn in q.
+    induction q.
+    reflexivity.
+  Qed.
+
+  (** 2 -> 1 *)
+  Lemma is_univalent_from_isaprop_edges_to (G : rxgraph)
+    (H : ∏ (a : G), isaprop (edges_to G a))
+    : is_univalent G.
+  Proof.
+    use is_univalent_from_isaprop_edges_from.
+    exact (isaprop_edges_to_implies_isaprop_edges_from _ H).
+  Defined.
+
+  (** 3 -> 1 *)
+  Lemma is_univalent_from_iscontr_edges_to (G : rxgraph)
+    (H : ∏ (a : G), iscontr (edges_to G a))
+    : is_univalent G.
+  Proof.
+    use is_univalent_from_isaprop_edges_to.
+    intro a; apply isapropifcontr, H.
+  Defined.
+
+  (** 1 -> 2 *)
+  Lemma is_univalent_to_isaprop_edges_to (G : rxgraph)
+    (H : is_univalent G)
+    : ∏ (a : G), isaprop (edges_to G a).
+  Proof.
+    use isaprop_edges_from_implies_isaprop_edges_to.
+    use is_univalent_to_isaprop_edges_from.
+    exact H.
+  Qed.
+
+  (** 1 -> 3 *)
+  Lemma is_univalent_to_iscontr_edges_to (G : rxgraph)
+    (H : is_univalent G)
+    : ∏ (a : G), iscontr (edges_to G a).
+  Proof.
+    intro a; apply iscontraprop1.
+    - apply is_univalent_to_isaprop_edges_to, H.
+    - apply edges_to_refl.
+  Defined.
+
+  (** A consequence is that it suffices to give an arbitrary equivalence, rather
+      than needing to prove that [id_to_edge] specifically is an equivalence. *)
+  Theorem is_univalent_from_weq (G : rxgraph)
+    (w : ∏ (a b : G), a = b ≃ a ≈ b)
+    : is_univalent G.
+  Proof.
+    apply is_univalent_from_iscontr_edges_from.
+    intro a.
+    apply (iscontrweqf (X:=paths_from a)).
+    - apply weqfibtototal, w.
+    - apply iscontr_paths_from.
+  Qed.
+
+End univalence.
+
+(** ** Path operations for univalent reflexive graphs *)
+
+Section induction.
+  (** *** Induction schemes *)
+
+  (** Unbased induction *)
+
+  Definition rxgraph_edge_rect (G : rxgraph)
+    (H : is_univalent G)
+    (P : ∏ (a b : G), a ≈ b -> UU)
+    (base : ∏ (a : G), P a a (refl a))
+    : ∏ (a b : G) (e : a ≈ b), P a b e.
+  Proof.
+    intros a b e.
+    refine (transportb (λ (c : edges_from G a), P a (pr1 c) (pr2 c))
+              (_ : b,, e = edges_from_refl a)
+              (base a)).
+    exact (pr2 (is_univalent_to_iscontr_edges_from G H a) _).
+  Defined.
+
+  Definition rxgraph_edge_rect' (G : univalent_rxgraph)
+    (P : ∏ (a b : G), a ≈ b -> UU)
+    (base : ∏ (a : G), P a a (refl a))
+    : ∏ (a b : G) (e : a ≈ b), P a b e
+    := rxgraph_edge_rect G G P base.
+
+  Definition rxgraph_edge_rect_eq (G : rxgraph)
+    (H : is_univalent G)
+    (P : ∏ (a b : G), a ≈ b -> UU)
+    (base : ∏ (a : G), P a a (refl a))
+    (a : G)
+    : rxgraph_edge_rect G H P base a a (refl a) = base a.
+  Proof.
+    refine (maponpaths (λ p, transportb _ p (base a)) (_ : _ = idpath _)).
+    apply proofirrelevancecontr, (is_univalent_to_isaprop_edges_from G H).
+  Defined.
+
+  (** Based induction *)
+
+  Definition rxgraph_edge_rect_left (G : rxgraph)
+    (H : is_univalent G)
+    (a : G)
+    (P : ∏ (b : G), a ≈ b -> UU)
+    (base : P a (refl a))
+    : ∏ (b : G) (e : a ≈ b), P b e.
+  Proof.
+    intros b e.
+    refine (transportb (λ (c : edges_from G a), P (pr1 c) (pr2 c))
+              (_ : b,, e = edges_from_refl a)
+              base).
+    exact (pr2 (is_univalent_to_iscontr_edges_from G H a) _).
+  Defined.
+
+  Definition rxgraph_edge_rect_left' (G : univalent_rxgraph)
+    (a : G)
+    (P : ∏ (b : G), a ≈ b -> UU)
+    (base : P a (refl a))
+    : ∏ (b : G) (e : a ≈ b), P b e
+    := rxgraph_edge_rect_left G G a P base.
+
+  Definition rxgraph_edge_rect_left_eq (G : rxgraph)
+    (H : is_univalent G)
+    (a : G)
+    (P : ∏ (b : G), a ≈ b -> UU)
+    (base : P a (refl a))
+    : rxgraph_edge_rect_left G H a P base a (refl a) = base.
+  Proof.
+    refine (maponpaths (λ p, transportb _ p base) (_ : _ = idpath _)).
+    apply proofirrelevancecontr, (is_univalent_to_isaprop_edges_from G H).
+  Defined.
+
+  Definition rxgraph_edge_rect_right (G : rxgraph)
+    (H : is_univalent G)
+    (b : G)
+    (P : ∏ (a : G), a ≈ b -> UU)
+    (base : P b (refl b))
+    : ∏ (a : G) (e : a ≈ b), P a e.
+  Proof.
+    intros a e.
+    refine (transportb (λ (c : edges_to G b), P (pr1 c) (pr2 c))
+              (_ : a,, e = edges_to_refl b)
+              base).
+    exact (pr2 (is_univalent_to_iscontr_edges_to G H b) _).
+  Defined.
+
+  Definition rxgraph_edge_rect_right' (G : univalent_rxgraph)
+    (b : G)
+    (P : ∏ (a : G), a ≈ b -> UU)
+    (base : P b (refl b))
+    : ∏ (a : G) (e : a ≈ b), P a e
+    := rxgraph_edge_rect_right G G b P base.
+
+  Definition rxgraph_edge_rect_right_eq (G : rxgraph)
+    (H : is_univalent G)
+    (b : G)
+    (P : ∏ (a : G), a ≈ b -> UU)
+    (base : P b (refl b))
+    : rxgraph_edge_rect_right G H b P base b (refl b) = base.
+  Proof.
+    refine (maponpaths (λ p, transportb _ p base) (_ : _ = idpath _)).
+    apply proofirrelevancecontr, (is_univalent_to_isaprop_edges_to G H).
+  Defined.
+
+  (** Examples using the induction schemes with the [elim] and [induction]
+      tactics. *)
+
+  Goal ∏ (G : univalent_rxgraph) (Q : UU) (a b : G) (f : G -> Q) (e : a ≈ b), f a = f b.
+    intros.
+    Succeed elim e using rxgraph_edge_rect_left'; exact (idpath (f a)).
+    Succeed revert b e; apply rxgraph_edge_rect_left'.
+    Succeed induction a, e using (rxgraph_edge_rect_right' G b); exact (idpath (f b)).
+    Succeed revert a b e; apply rxgraph_edge_rect'; intro a.
+    induction e using rxgraph_edge_rect'.
+    easy.
+  Qed.
+
+End induction.
+
+Section algebra.
+  (** *** Edge algebra *)
+
+  Definition edge_inv {G : rxgraph} (H : is_univalent G)
+    {a b : G} (e : a ≈ b) : b ≈ a.
+  Proof.
+    exact (rxgraph_edge_rect _ H
+             (λ (a b : G) _, b ≈ a) refl a b e).
+  Defined.
+
+  Definition edge_inv_refl {G : rxgraph} (H : is_univalent G)
+    (a : G) : edge_inv H (refl a) = refl a.
+  Proof.
+    exact (rxgraph_edge_rect_eq _ H
+             (λ (a b : G) _, b ≈ a) refl a).
+  Defined.
+
+  Lemma edge_inv_edge_inv {G : rxgraph} (H : is_univalent G)
+    {a b : G} (e : a ≈ b)
+    : edge_inv H (edge_inv H e) = e.
+  Proof.
+    elim e using (rxgraph_edge_rect _ H).
+    clear a b e; intro a.
+    etrans; [apply maponpaths, edge_inv_refl|].
+    apply edge_inv_refl.
+  Defined.
+
+  Lemma isweq_edge_inv {G : rxgraph} (H : is_univalent G)
+    : ∏ (a b : G), isweq (λ (e : a ≈ b), edge_inv H e).
+  Proof.
+    intros a b; use isweq_iso.
+    - exact (edge_inv H).
+    - apply edge_inv_edge_inv.
+    - apply edge_inv_edge_inv.
+  Defined.
+
+  Definition edge_comp {G : rxgraph} (H : is_univalent G)
+    {a b c : G} (e : a ≈ b) : b ≈ c -> a ≈ c.
+  Proof.
+    exact (rxgraph_edge_rect _ H
+             (λ (a b : G) _, b ≈ c -> a ≈ c)
+             (λ (a : G), idfun (a ≈ c))
+             a b e).
+  Defined.
+
+  Definition edge_comp_refl_left {G : rxgraph} (H : is_univalent G)
+    {b c : G} (e : b ≈ c)
+    : edge_comp H (refl b) e = e.
+  Proof.
+    exact (eqtohomot
+             (rxgraph_edge_rect_eq _ H
+                (λ (a b : G) _, b ≈ c -> a ≈ c)
+                (λ (a : G), idfun (a ≈ c))
+                b)
+             e).
+  Defined.
+
+  Definition edge_comp_refl_right {G : rxgraph} (H : is_univalent G)
+    {a b : G} (e : a ≈ b)
+    : edge_comp H e (refl b) = e.
+  Proof.
+    refine (rxgraph_edge_rect _ H
+              (λ (a b : G) (e : a ≈ b),
+                edge_comp H e (refl b) = e)
+              _ a b e).
+    clear a b e; intro a.
+    apply edge_comp_refl_left.
+  Defined.
+
+  Lemma isweq_edge_comp_left {G : rxgraph} (H : is_univalent G)
+    {a b : G} (e : a ≈ b)
+    : ∏ c, isweq (λ (e' : b ≈ c), edge_comp H e e').
+  Proof.
+    intro c.
+    elim e using (rxgraph_edge_rect _ H).
+    clear a b e; intro a.
+    use isweqhomot.
+    - exact (idfun _).
+    - intro e.
+      apply pathsinv0.
+      apply edge_comp_refl_left.
+    - apply idisweq.
+  Qed.
+
+  Lemma isweq_edge_comp_right {G : rxgraph} (H : is_univalent G)
+    {b c : G} (e : b ≈ c)
+    : ∏ a, isweq (λ (e' : a ≈ b), edge_comp H e' e).
+  Proof.
+    intro a.
+    elim e using (rxgraph_edge_rect _ H).
+    clear b c e; intro b.
+    use isweqhomot.
+    - exact (idfun _).
+    - intro e.
+      apply pathsinv0.
+      apply edge_comp_refl_right.
+    - apply idisweq.
+  Qed.
+
+End algebra.
+
+(** ** Displayed reflexive graphs *)
+
+Definition disp_rxgraph (B : rxgraph) :=
+  ∑ (E : B -> UU)
+    (disp_edge : ∏ (x y : B) (e : x ≈ y), E x -> E y -> UU),
+    ∏ (x : B) (a : E x), disp_edge x x (refl x) a a.
+
+Definition disp_rxgraph_vertex {B : rxgraph} (E : disp_rxgraph B)
+  : B -> UU := pr1 E.
+Coercion disp_rxgraph_vertex : disp_rxgraph >-> Funclass.
+
+Definition disp_edge {B : rxgraph} (E : disp_rxgraph B)
+  : ∏ {x y : B} (e : x ≈ y), E x -> E y -> UU := pr12 E.
+Notation "a '≈{' E  '}[' e  ']' b" := (disp_edge E%rxgraph_spec e a b) (at level 70) : rxgraph.
+Notation "a '≈[' e  ']' b" := (disp_edge _ e a b) (at level 70) : rxgraph.
+
+Definition disp_refl {B : rxgraph} {E : disp_rxgraph B}
+  : ∏ (x : B) (a : E x), a ≈[ refl x ] a := pr22 E.
+
+Definition make_disp_rxgraph
+  (B : rxgraph)
+  (E : B -> UU)
+  (disp_edge : ∏ (x y : B) (e : x ≈ y), E x -> E y -> UU)
+  (disp_refl : ∏ (x : B) (a : E x), disp_edge x x (refl x) a a)
+  : disp_rxgraph B
+  := E,, disp_edge,, disp_refl.
+
+Section univalence.
+  Context {B : rxgraph}.
+
+  (** *** Univalence
+
+The component of a displayed reflexive graph [x : B ⊢ E[x]] over [x : B] is the
+reflexive graph obtained by fixing it at [x].  A displayed reflexive graph is
+(by definition) univalent if all its components are. *)
+
+  Definition disp_rxgraph_at (E : disp_rxgraph B)
+    (x : B) : rxgraph.
+  Proof.
+    use make_rxgraph.
+    - exact (E x).
+    - intros aa bb.
+      exact (aa ≈[ refl x ] bb).
+    - intro aa.
+      exact (disp_refl x aa).
+  Defined.
+
+  Definition is_disp_univalent (E : disp_rxgraph B) : UU
+    := ∏ (x : B), is_univalent (disp_rxgraph_at E x).
+
+  Lemma isaprop_is_disp_univalent (E : disp_rxgraph B)
+    : isaprop (is_disp_univalent E).
+  Proof.
+    apply impred; intro.
+    apply isaprop_is_univalent.
+  Qed.
+
+  (** Another way to characterize displayed univalence is via [PathOver]. *)
+
+  Definition PathOver_to_disp_edge (E : disp_rxgraph B)
+    {x y : B} (e : x = y) (a : E x) (b : E y)
+    : PathOver e a b -> a ≈[ id_to_edge e ] b.
+  Proof.
+    intro p.
+    induction e; induction p.
+    apply disp_refl.
+  Defined.
+
+  Definition is_disp_univalent_alt (E : disp_rxgraph B) : UU
+    := ∏ (x y : B) (e : x = y) (a : E x) (b : E y),
+      isweq (PathOver_to_disp_edge E e a b).
+
+  Lemma isaprop_is_disp_univalent_alt (E : disp_rxgraph B)
+    : isaprop (is_disp_univalent_alt E).
+  Proof.
+    do 5 (apply impred; intro).
+    apply isapropisweq.
+  Qed.
+
+  Lemma weq_is_disp_univalent_alt (E : disp_rxgraph B)
+    : is_disp_univalent E ≃ is_disp_univalent_alt E.
+  Proof.
+    use weqimplimpl.
+    - intros H x y e.
+      induction e; exact (H x).
+    - intros H x.
+      exact (H x x (idpath x)).
+    - apply isaprop_is_disp_univalent.
+    - apply isaprop_is_disp_univalent_alt.
+  Qed.
+
+  Definition weq_PathOver_to_disp_edge {E : disp_rxgraph B}
+    (HE : is_disp_univalent E)
+    {x y : B} (e : x = y) (a : E x) (b : E y)
+    : PathOver e a b ≃ a ≈[ id_to_edge e ] b.
+  Proof.
+    apply (make_weq (PathOver_to_disp_edge E e a b)).
+    apply (weq_is_disp_univalent_alt E HE).
+  Defined.
+
+  Definition weq_PathOver_to_disp_edge' {E : disp_rxgraph B}
+    (HB : is_univalent B) (HE : is_disp_univalent E)
+    {x y : B} (e : x ≈ y) (a : E x) (b : E y)
+    : PathOver (edge_to_id HB e) a b ≃ a ≈[ e ] b.
+  Proof.
+    intermediate_weq (a ≈[ id_to_edge (edge_to_id HB e) ] b).
+    { apply (weq_PathOver_to_disp_edge HE). }
+    refine (transportf (λ e', a ≈[e'] b ≃ a ≈[e] b) _ (idweq _)).
+    exact (homotinvweqweq0 (weq_edge_to_id HB x y) _).
+  Defined.
+
+End univalence.
+
+Definition univalent_disp_rxgraph (B : rxgraph)
+  := ∑ (E : disp_rxgraph B), is_disp_univalent E.
+Coercion univalent_disp_rxgraph_to_disp_rxgraph
+  {B : rxgraph} (E : univalent_disp_rxgraph B)
+  : disp_rxgraph B := pr1 E.
+Coercion disp_rxgraph_univalence
+  {B : rxgraph} (E : univalent_disp_rxgraph B)
+  : is_disp_univalent E := pr2 E.
+
+Definition make_univalent_disp_rxgraph
+  {B : rxgraph} (E : disp_rxgraph B)
+  (H : is_disp_univalent E)
+  : univalent_disp_rxgraph B
+  := E,, H.

--- a/UniMath/IdentitySystems/RXGraphOfRXGraphs.v
+++ b/UniMath/IdentitySystems/RXGraphOfRXGraphs.v
@@ -1,0 +1,341 @@
+(********************************************************************************
+
+ The Reflexive Graph of Reflexive Graphs
+
+ We classify the identifications of (small) reflexive graphs and displayed
+ reflexive graphs using (large) reflexive graphs.  The work here is based on Jon
+ Sterling, 2026, "Reflexive graph lenses in Univalent Foundations"
+ (doi:10.1017/S0960129526100565, arXiv:2404.07854).
+
+ Users of this library should note the size issues: vertices of
+ [rxgraph_rxgraph] should be considered *small* reflexive graphs, while
+ [rxgraph_rxgraph] itself is a *large* reflexive graph.  In particular,
+ [rxgraph_rxgraph] should not be considered as an element of itself, but as an
+ element of a larger [rxgraph_rxgraph].  We annotate definitions in this file
+ which use multiple universes with an imaginary level parameter [ℓ] (\ell) to
+ clarify.
+
+ Contents:
+ 1. Reflexive graph of graphs
+ 2. Reflexive graph of [rxgraph]s
+ 3. Reflexive graph of displayed graphs
+ 4. Reflexive graph of [disp_rxgraph]s
+ 5. Displayed reflexive graph of [disp_rxgraph]s
+
+ Author: B. Szilvasy
+ September 2026
+
+ ********************************************************************************)
+
+Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.All.
+
+Require Import UniMath.IdentitySystems.RXGraph.
+Require Import UniMath.IdentitySystems.Examples.
+Require Import UniMath.IdentitySystems.Lenses.
+
+Local Open Scope rxgraph.
+Local Bind Scope rxgraph_spec with rxgraph.
+Local Bind Scope rxgraph_spec with univalent_rxgraph.
+
+(** ** Reflexive graph of graphs *)
+
+Definition graph_on_rxgraph (* ℓ *)
+  : contra_lens (* ℓ+1 *) (UU_rxgraph (* ℓ *)).
+Proof.
+  use make_contra_lens.
+  - intros A; exact (∏ (_ _ : A), UU_rxgraph (* ℓ *))%rxgraph_spec.
+  - intros x y w e; cbn in w, e.
+    exact (λ x' y', e (w x') (w y')).
+  - intros A edge; exact (refl edge).
+Defined.
+
+Lemma is_univalent_graph_on_rxgraph (* ℓ *) (A : UU (* ℓ *))
+  : is_univalent (* ℓ+1 *) (graph_on_rxgraph (* ℓ *) A).
+Proof. exact (∏! _ _, UU_rxgraph')%rxgraph_spec. Qed.
+
+Definition graph_rxgraph (* ℓ *) : rxgraph (* ℓ+1 *)
+  := total_rxgraph (* ℓ+1 *)
+       (contra_lens_disp_rxgraph (* ℓ+1 *) (graph_on_rxgraph (* ℓ *))).
+
+Lemma is_univalent_graph_rxgraph (* ℓ *)
+  : is_univalent (* ℓ+1 *) (graph_rxgraph (* ℓ *)).
+Proof.
+  apply is_univalent_total_rxgraph.
+  - exact UU_rxgraph'.
+  - apply is_univalent_contra_lens_disp_rxgraph; intro A.
+    apply is_univalent_graph_on_rxgraph.
+Qed.
+
+Definition graph_rxgraph' (* ℓ *) : univalent_rxgraph (* ℓ+1 *)
+  := make_univalent_rxgraph (* ℓ+1 *) _ is_univalent_graph_rxgraph.
+
+Definition graph_iso (* ℓ *) (C D : graph_rxgraph (* ℓ *)) : UU (* ℓ *) := C ≈ D.
+Identity Coercion Id_graph_iso : graph_iso >-> edge.
+
+Coercion graph_iso_on_vertex {C D : graph_rxgraph}
+  (w : graph_iso C D) : pr1 C ≃ pr1 D := pr1 w.
+Definition graph_iso_on_edge {C D : graph_rxgraph}
+  (w : graph_iso C D)
+  : ∏ {a b : pr1 C}, pr2 C a b ≃ pr2 D (w a) (w b)
+  := pr2 w.
+
+Definition make_graph_iso (C D : graph_rxgraph)
+  (v : pr1 C ≃ pr1 D)
+  (e : ∏ (a b : pr1 C), pr2 C a b ≃ pr2 D (v a) (v b))
+  : graph_iso C D
+  := v,, e.
+
+(** ** Reflexive graph of [rxgraph]s *)
+
+Definition has_refl_rxgraph (* ℓ *)
+  : unbiased_lens (* ℓ+1 *) (graph_rxgraph (* ℓ *)).
+Proof.
+  use make_unbiased_lens.
+  - intros C D f.
+    change (graph_iso C D) in f.
+    exact (∏ (a : pr1 C), Δ pr2 D (f a) (f a))%rxgraph_spec.
+  - intros C D f refl a.
+    change (graph_iso C D) in f.
+    cbn in refl.
+    exact (graph_iso_on_edge f (refl a)).
+  - intros C D f refl a.
+    change (graph_iso C D) in f.
+    cbn in refl.
+    exact (refl (f a)).
+  - intros C refl'; exact (refl refl').
+  - intros C refl'; exact (refl refl').
+Defined.
+
+Lemma is_univalent_has_refl_rxgraph (* ℓ *)
+  {C D : graph_rxgraph (* ℓ *)} (w : graph_iso (* ℓ *) C D)
+  : is_univalent (* ℓ+1 *) (has_refl_rxgraph (* ℓ *) C D w).
+Proof. exact (∏! _, Δ _)%rxgraph_spec. Qed.
+
+(* We defined [rxgraph] associated to the right, which means the [total_rxgraph]
+   of [has_refl_rxgraph] is the wrong thing.  We can use [sigma_disp_rxgraph] to
+   associate to the right as needed. *)
+Definition rxgraph_rxgraph (* ℓ *) : rxgraph (* ℓ+1 *)
+  := total_rxgraph (* ℓ+1 *)
+       (sigma_disp_rxgraph (* ℓ+1 *) _
+          (unbiased_lens_disp_rxgraph (* ℓ+1 *)
+             (has_refl_rxgraph (* ℓ *)))).
+
+Example rxgraph_vertex_rxgraph_rxgraph_compute (* ℓ *)
+  : rxgraph_vertex (* ℓ+1 *) (rxgraph_rxgraph (* ℓ *))
+    = rxgraph (* ℓ *).
+Proof. reflexivity. Defined.
+
+Lemma is_univalent_rxgraph_rxgraph (* ℓ *)
+  : is_univalent (* ℓ+1 *) (rxgraph_rxgraph (* ℓ *)).
+Proof.
+  use is_univalent_total_rxgraph.
+  - exact UU_rxgraph'.
+  - apply is_univalent_sigma_disp_rxgraph.
+    + apply is_univalent_contra_lens_disp_rxgraph; intro A.
+      apply is_univalent_graph_on_rxgraph.
+    + apply is_univalent_unbiased_lens_disp_rxgraph.
+      intros C D w.
+      apply is_univalent_has_refl_rxgraph.
+Qed.
+
+Definition rxgraph_rxgraph' (* ℓ *) : univalent_rxgraph (* ℓ+1 *)
+  := make_univalent_rxgraph _ is_univalent_rxgraph_rxgraph.
+
+Definition rxgraph_iso (C D : rxgraph) : UU := C ≈{rxgraph_rxgraph} D.
+Identity Coercion Id_rxgraph_iso : graph_iso >-> edge.
+
+Coercion rxgraph_iso_on_vertex {C D : rxgraph}
+  (w : rxgraph_iso C D) : C ≃ D := pr1 w.
+Definition rxgraph_iso_on_edge {C D : rxgraph}
+  (w : rxgraph_iso C D)
+  : ∏ {a b : C}, a ≈ b ≃ w a ≈ w b
+  := pr12 w.
+Definition rxgraph_iso_on_refl {C D : rxgraph}
+  (w : rxgraph_iso C D)
+  : ∏ (a : C), rxgraph_iso_on_edge w (refl a) = refl (w a)
+  := pr22 w.
+
+Definition make_rxgraph_iso (C D : rxgraph)
+  (verts : C ≃ D)
+  (edges : ∏ {a b : C}, a ≈ b ≃ verts a ≈ verts b)
+  (refls : ∏ (a : C), edges (refl a) = refl (verts a))
+  : rxgraph_iso C D
+  := verts,, @edges,, refls.
+
+Definition is_univalent_rxgraph_iso_f
+  (C D : rxgraph) (F : rxgraph_iso C D)
+  (H : is_univalent C) : is_univalent D.
+Proof.
+  apply is_univalent_from_isaprop_edges_from; intro a.
+  apply (isofhlevelweqb 1 (Y:=(edges_from C (invmap F a)))).
+  - apply (weqbandf (invweq F)); intro b.
+    intermediate_weq (F (invmap F a) ≈ F (invmap F b)).
+    { rewrite !(homotweqinvweq F).
+      exact (idweq (a ≈ b)). }
+    apply invweq, (rxgraph_iso_on_edge F).
+  - apply is_univalent_to_isaprop_edges_from, H.
+Qed.
+
+Definition is_univalent_rxgraph_iso_b
+  (C D : rxgraph) (F : rxgraph_iso C D)
+  (H : is_univalent D) : is_univalent C.
+Proof.
+  apply is_univalent_from_isaprop_edges_from; intro a.
+  apply (isofhlevelweqb 1 (Y:=(edges_from D (F a)))).
+  - apply (weqbandf F); intro b.
+    exact (rxgraph_iso_on_edge F).
+  - apply is_univalent_to_isaprop_edges_from, H.
+Qed.
+
+(** ** Reflexive graph of displayed graphs *)
+
+Definition disp_graph_on_rxgraph (* ℓ *) (B : rxgraph (* ℓ *))
+  : contra_lens (* ℓ+1 *) (∏ (_ : B), UU_rxgraph (* ℓ *)).
+Proof.
+  use make_contra_lens.
+  - intro E.
+    exact (∏ (x y : B) (e : x ≈ y) (_ : E x) (_ : E y),
+            UU_rxgraph (* ℓ *))%rxgraph_spec.
+  - cbn; intros E₁ E₂ w edge x y e a b.
+    exact (edge x y e (w x a) (w y b)).
+  - intros E disp_edge; exact (refl disp_edge).
+Defined.
+
+Lemma is_univalent_disp_graph_on_rxgraph (* ℓ *)
+  (B : rxgraph (* ℓ *)) (E : B -> UU (* ℓ *))
+  : is_univalent (* ℓ+1 *) (disp_graph_on_rxgraph (* ℓ *) B E).
+Proof.
+  do 5 (apply is_univalent_product_rxgraph; intro).
+  exact UU_rxgraph'.
+Qed.
+
+Definition disp_graph_rxgraph (* ℓ *) (B : rxgraph (* ℓ *))
+  : rxgraph (* ℓ+1 *)
+  := total_rxgraph (* ℓ+1 *)
+       (contra_lens_disp_rxgraph (* ℓ+1 *)
+          (disp_graph_on_rxgraph (* ℓ *) B)).
+
+Lemma is_univalent_disp_graph_rxgraph (* ℓ *) (B : rxgraph (* ℓ *))
+  : is_univalent (* ℓ+1 *) (disp_graph_rxgraph (* ℓ *) B).
+Proof.
+  apply is_univalent_total_rxgraph.
+  - exact (∏! _, UU_rxgraph')%rxgraph_spec.
+  - apply is_univalent_contra_lens_disp_rxgraph; intro.
+    apply is_univalent_disp_graph_on_rxgraph.
+Qed.
+
+(** ** Reflexive graph of [disp_rxgraph]s *)
+
+Definition has_disp_refl_rxgraph (* ℓ *) (B : rxgraph (* ℓ *))
+  : unbiased_lens (* ℓ+1 *) (disp_graph_rxgraph (* ℓ *) B).
+Proof.
+  use make_unbiased_lens.
+  - intros C D f.
+    cbn in f.
+    exact (∏ (x : B) (a : pr1 C x),
+            Δ pr2 D x x (refl x) (pr1 f x a) (pr1 f x a))%rxgraph_spec.
+  - intros C D f disp_refl x a.
+    cbn in f, disp_refl.
+    exact (pr2 f _ _ (refl x) _ _ (disp_refl x a)).
+  - intros C D f disp_refl x a.
+    cbn in f, disp_refl.
+    exact (disp_refl x (pr1 f x a)).
+  - intros C disp_refl; exact (refl disp_refl).
+  - intros C disp_refl; exact (refl disp_refl).
+Defined.
+
+Lemma is_univalent_has_disp_refl_rxgraph (* ℓ *) (B : rxgraph (* ℓ *))
+  {E₁ E₂ : disp_graph_rxgraph (* ℓ *) B} (f : E₁ ≈ E₂)
+  : is_univalent (* ℓ+1 *) (has_disp_refl_rxgraph (* ℓ *) B _ _ f).
+Proof.
+  exact (∏! _ _, Δ _)%rxgraph_spec.
+Qed.
+
+Definition disp_rxgraph_rxgraph (* ℓ *) (B : rxgraph (* ℓ *))
+  : rxgraph (* ℓ+1 *)
+  := total_rxgraph (* ℓ+1 *)
+       (sigma_disp_rxgraph (* ℓ+1 *) _
+          (unbiased_lens_disp_rxgraph (* ℓ+1 *)
+             (has_disp_refl_rxgraph (* ℓ *) B))).
+
+Example rxgraph_vertex_disp_rxgraph_rxgraph_compute (* ℓ *)
+  (B : rxgraph (* ℓ *))
+  : rxgraph_vertex (* ℓ+1 *) (disp_rxgraph_rxgraph (* ℓ *) B)
+    = disp_rxgraph (* ℓ *) B.
+Proof. reflexivity. Qed.
+
+Lemma is_univalent_disp_rxgraph_rxgraph (* ℓ *) (B : rxgraph (* ℓ *))
+  : is_univalent (* ℓ+1 *) (disp_rxgraph_rxgraph (* ℓ *) B).
+Proof.
+  apply is_univalent_total_rxgraph.
+  - exact (∏! _, UU_rxgraph')%rxgraph_spec.
+  - apply is_univalent_sigma_disp_rxgraph.
+    + apply is_univalent_contra_lens_disp_rxgraph; intro.
+      apply is_univalent_disp_graph_on_rxgraph.
+    + apply is_univalent_unbiased_lens_disp_rxgraph; intros x y e.
+      apply is_univalent_has_disp_refl_rxgraph.
+Qed.
+
+Definition disp_rxgraph_rxgraph' (* ℓ *) (B : rxgraph (* ℓ *))
+  : univalent_rxgraph (* ℓ+1 *)
+  := make_univalent_rxgraph (* ℓ+1 *) _
+       (is_univalent_disp_rxgraph_rxgraph (* ℓ *) B).
+
+Definition disp_rxgraph_iso {B : rxgraph} (E₁ E₂ : disp_rxgraph B) : UU
+  := E₁ ≈{disp_rxgraph_rxgraph B} E₂.
+
+Definition make_disp_rxgraph_iso
+  {B : rxgraph} (E₁ E₂ : disp_rxgraph B)
+  (verts : ∏ {x}, E₁ x ≃ E₂ x)
+  (edges : ∏ {x y : B} (e : x ≈ y) {a : E₁ x} {b : E₁ y},
+      a ≈[e] b ≃ verts a ≈[e] verts b)
+  (refls : ∏ (x : B) (a : E₁ x),
+      edges (refl x) (disp_refl x a) = disp_refl x (verts a))
+  : disp_rxgraph_iso E₁ E₂
+  := @verts,, @edges,, refls.
+
+(** ** Displayed reflexive graph of [disp_rxgraph]s *)
+
+Definition transportb_disp_rxgraph
+  {B₁ B₂ : rxgraph} (i : rxgraph_iso B₁ B₂)
+  (E : disp_rxgraph B₂)
+  : disp_rxgraph B₁.
+Proof.
+  use make_disp_rxgraph.
+  - intros x'.
+    exact (E (i x')).
+  - cbn; intros x y e a b.
+    exact (a ≈[rxgraph_iso_on_edge i e] b).
+  - cbn; intros x a.
+    refine (transportb (λ e, a ≈[e] a) _ (disp_refl (i x) a)).
+    exact (rxgraph_iso_on_refl i x).
+Defined.
+
+Definition disp_rxgraph_lens_structure (* ℓ *)
+  : contra_lens_structure (* ℓ+1 *)
+      (B:=rxgraph_rxgraph (* ℓ *))
+      (disp_rxgraph_rxgraph (* ℓ *)).
+Proof.
+  use make_contra_lens_structure.
+  - intros C D i E.
+    exact (transportb_disp_rxgraph i E).
+  - intros B E; exact (refl E).
+Defined.
+
+Definition disp_rxgraph_disp_rxgraph (* ℓ *)
+  : disp_rxgraph (* ℓ+1 *) (rxgraph_rxgraph (* ℓ *))
+  := contra_lens_disp_rxgraph (* ℓ+1 *)
+       (disp_rxgraph_rxgraph (* ℓ *),, disp_rxgraph_lens_structure (* ℓ *)
+         : contra_lens (* ℓ+1 *) (rxgraph_rxgraph (* ℓ *))).
+
+Lemma is_univalent_disp_rxgraph_disp_rxgraph
+  : is_disp_univalent disp_rxgraph_disp_rxgraph.
+Proof.
+  apply is_univalent_contra_lens_disp_rxgraph; intro.
+  apply is_univalent_disp_rxgraph_rxgraph.
+Qed.
+
+Definition disp_rxgraph_disp_rxgraph' (* ℓ *)
+  : univalent_disp_rxgraph (* ℓ+1 *) (rxgraph_rxgraph (* ℓ *))
+  := make_univalent_disp_rxgraph _ is_univalent_disp_rxgraph_disp_rxgraph.


### PR DESCRIPTION
This PR adds a new library for reflexive graphs, in a package called `IdentitySystems`.[^1] The literature has similar constructs under the name "identity system" (e.g. [the HoTT book](https://homotopytypetheory.org/book), Egbert Rijke's [Introduction to Homotopy Type Theory](https://www.doi.org/10.1017/9781108933568)). Importantly, reflexive graphs have displayed versions, for building up reflexive graphs in towers, similarly to how one might with displayed categories and bicategories. Reflexive graphs can be considered a much more lightweight and general way to characterise identifications than univalent (bi)categories, involving considerably less data, while still providing a more robust organising framework than manually writing out all the intermediate types and proving the equivalences by hand.

Features include:
- Reflexive graphs and displayed reflexive graphs (`RXGraph.v`).
- The "fundamental theorem of identity types". As a corollary, it is possible to prove that the canonical `id_to_XYZ : a = b -> a ≈ b` is an equivalence by providing any(!) equivalence `a = b ≃ a ≈ b`.
- Many simple examples of reflexive graphs corresponding to type constructors (`Examples.v`).
- Reflexive graph lenses, for making displayed reflexive graphs easily (`Lenses.v`).

This was originally written for use in my work on duploids in UniMath that I have yet to ready for upstreaming.[^2] Much of the work here, particularly the lenses, is based on Jon Sterling's (@jonsterling) paper "Reflexive graph lenses in Univalent Foundations" ([doi:10.1017/S0960129526100565](https://doi.org/10.1017/S0960129526100565), [arXiv:2404.07854](https://arxiv.org/abs/2404.07854)). This PR includes two examples of how to use the library: the first is with the reflexive graphs of (displayed) reflexive graphs themselves, and the second is a characterization of identifications of categories.

[^1]: The rationale for the package name is that it should be generic in case anyone wants to add something similar here that isn't exactly reflexive graphs.
[^2]: On that branch, they currently live in the `Combinatorics` package, which is a horrible place for them.